### PR TITLE
Teach the three tutor moves the way MoveTutor does

### DIFF
--- a/game/world/move_tutor.gd
+++ b/game/world/move_tutor.gd
@@ -1,0 +1,41 @@
+class_name Gen2MoveTutor
+extends RefCounted
+
+## `MoveTutor` and `CheckCanLearnMoveTutorMove` (`engine/events/move_tutor.asm`),
+## the rules half. [Gen2MoveTutorScreen] is the routine and
+## [method Gen2WorldPartyHost.teach_tutor_move] owns the transaction.
+##
+## Crystal only: `TMHMMoves` ends at HM07 on both Gold and Silver, so
+## [method move_for_value] answers 0 there and no map script reaches the special
+## anyway.
+
+## constants/script_constants.asm's MOVETUTOR_* run, which the map's own
+## `verticalmenu` leaves in wScriptVar. Its fourth row is CANCEL, which the
+## script branches away from before the special.
+const VALUE_FLAMETHROWER: int = 1
+const VALUE_THUNDERBOLT: int = 2
+const VALUE_ICE_BEAM: int = 3
+
+## `.quit`'s own `xor a` and `.cancel`'s `ld a, -1`, as the byte wScriptVar
+## holds. The map script reads only `ifequal FALSE`, so a cancelled list and an
+## incompatible party both reach `.Incompatible`.
+const SCRIPT_VALUE_LEARNED: int = 0
+const SCRIPT_VALUE_CANCELLED: int = 0xFF
+
+## `constants/sfx_constants.asm`'s SFX_WRONG, which `.can_learn`'s else branch
+## plays in front of `TMHMNotCompatibleText`.
+const SFX_WRONG: int = 0x2E
+
+
+## `.GetMoveTutorMove`. MT01_MOVE through MT03_MOVE are TMHMMoves entries
+## `NUM_TMS + NUM_HMS + 1` and up, so the move comes off the imported table
+## rather than from a pinned move number, and a cartridge without the three rows
+## answers 0.
+static func move_for_value(data: GameData, value: int) -> int:
+	if data == null:
+		return 0
+	## `cp MOVETUTOR_FLAMETHROWER` and `cp MOVETUTOR_THUNDERBOLT`, and anything
+	## else falls through to ICE_BEAM.
+	var tutor: int = clampi(value, VALUE_FLAMETHROWER, VALUE_ICE_BEAM) \
+		if value in [VALUE_FLAMETHROWER, VALUE_THUNDERBOLT] else VALUE_ICE_BEAM
+	return data.tmhm_move(RomLayout.TMHM_TM_COUNT + RomLayout.TMHM_HM_COUNT + tutor)

--- a/game/world/move_tutor.gd.uid
+++ b/game/world/move_tutor.gd.uid
@@ -1,0 +1,1 @@
+uid://k2daufga8j81

--- a/game/world/move_tutor_screen.gd
+++ b/game/world/move_tutor_screen.gd
@@ -1,0 +1,411 @@
+class_name Gen2MoveTutorScreen
+extends Control
+
+## `MoveTutor` (`engine/events/move_tutor.asm`) on the overworld's own pump.
+##
+## The same shape as [Gen2MoveDeleterScreen]: the routine owns the party list
+## `ChooseMonToLearnTMHM` opens, its refusals and the `ForgetMove` menu behind
+## `LearnMove`, and the map script's own `waitbutton` presses the box it leaves
+## standing.
+##
+## The `.loop` is the whole of it. `.didnt_learn` returns carry clear and the
+## routine reopens the list, so every refusal comes back to the party list and
+## only a learned move or a backed-out list ends the special.
+
+signal finished(script_value: int, party_index: int, ending_text: String)
+signal closed()
+signal sfx_requested(index: int, waited: bool)
+
+const TILE: int = Gen2Font.TILE
+
+const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
+
+## `ForgetMove`'s own `hlcoord 5, 2 / ld b, NUM_MOVES * 2 / ld c, MOVE_NAME_LENGTH`
+## and the `w2DMenuCursorOffsets` of `$20` under it, which is [Gen2MenuBox]'s
+## default two-row step.
+const FORGET_BOX: Array[int] = [5, 2, 19, 11]
+
+enum Phase {
+	SELECT_MON,
+	REFUSAL,
+	FORGET_ASK,
+	FORGET_LIST,
+	STOP_ASK,
+	DONE,
+}
+
+var _data: GameData = null
+var _world: Gen2WorldAPI = null
+var _save: Gen2SaveData = null
+var _persist: bool = true
+var _move: int = 0
+var _move_name: String = ""
+
+var _phase: int = Phase.DONE
+var _yes: bool = true
+var _party_index: int = -1
+var _forget_moves: Array = []
+var _forget_cursor: int = 0
+var _forget_refusal: String = ""
+## The line the current `Phase.REFUSAL` box is standing on.
+var _refusal_text: String = ""
+
+var _text_box: Gen2TextBox = null
+var _menu_page: Gen2MenuPage = null
+var _menu: TextureRect = null
+var _party: Gen2PartyScreen = null
+
+
+func set_context(
+	data: GameData, world: Gen2WorldAPI, save: Gen2SaveData, move: int,
+	persist: bool = true
+) -> void:
+	_data = data
+	_world = world
+	_save = save
+	_move = move
+	_persist = persist
+	_move_name = String(data.move(move).get("name", "MOVE")) if data != null else ""
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _world == null or _save == null or _move <= 0:
+		_end(Gen2MoveTutor.SCRIPT_VALUE_CANCELLED, "")
+		return
+	_build()
+	_open_party()
+
+
+func phase() -> int:
+	return _phase
+
+
+func question_cursor() -> int:
+	return (0 if _yes else 1) if _phase in [Phase.FORGET_ASK, Phase.STOP_ASK] else -1
+
+
+func forget_cursor() -> int:
+	return _forget_cursor if _phase == Phase.FORGET_LIST else -1
+
+
+func forget_options() -> Array:
+	return _forget_moves.duplicate(true)
+
+
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+func party_screen() -> Gen2PartyScreen:
+	return _party
+
+
+## The words this phase's own box prints, so a headless caller can read the
+## routine without the pixels.
+func box_text() -> String:
+	match _phase:
+		Phase.REFUSAL:
+			return _refusal_text
+		Phase.FORGET_ASK:
+			return Gen2MoveForget.ask_text(_mon_name(), _move_name)
+		Phase.STOP_ASK:
+			return Gen2MoveForget.stop_text(_move_name)
+		Phase.FORGET_LIST:
+			return _forget_refusal if not _forget_refusal.is_empty() \
+				else Gen2MoveForget.which_text()
+	return ""
+
+
+func handle_button(button: int) -> bool:
+	if _phase == Phase.SELECT_MON and _party != null:
+		return _party.handle_button(button)
+	if _phase == Phase.FORGET_LIST:
+		return _handle_forget_list(button)
+	if _phase in [Phase.FORGET_ASK, Phase.STOP_ASK]:
+		match button:
+			Gen2Button.UP, Gen2Button.DOWN:
+				_yes = not _yes
+				_draw_yes_no()
+				return true
+			Gen2Button.A:
+				_answer(_yes)
+				return true
+			Gen2Button.B:
+				_answer(false)
+				return true
+		return false
+	if _phase != Phase.REFUSAL or button != Gen2Button.A or _text_box == null:
+		return false
+	if _text_box.is_revealing() or _text_box.has_pages_left():
+		_text_box.advance()
+		return true
+	## `.didnt_learn` is `and a / ret`, which `.loop` reads as "go round again".
+	_open_party()
+	return true
+
+
+func advance_frame() -> void:
+	if _text_box != null and _text_box.visible:
+		_text_box.advance_frame()
+
+
+func _handle_forget_list(button: int) -> bool:
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN:
+			if _forget_moves.is_empty():
+				return true
+			## No `STATICMENU_WRAP`: `w2DMenuFlags1` is `$20` and the list stops
+			## at either end.
+			_forget_cursor = clampi(
+				_forget_cursor + (1 if button == Gen2Button.DOWN else -1),
+				0, _forget_moves.size() - 1
+			)
+			_forget_refusal = ""
+			_draw_forget_list()
+			return true
+		Gen2Button.A:
+			_confirm_forget()
+			return true
+		Gen2Button.B:
+			## `.cancel` sets carry, which `LearnMove` reads as `.cancel`.
+			_open_stop_ask()
+			return true
+	return false
+
+
+func _build() -> void:
+	_menu = TextureRect.new()
+	_menu.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_menu.visible = false
+	add_child(_menu)
+
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+## `ChooseMonToLearnTMHM`, whose `PARTYMENUACTION_TEACH_TMHM` is the prompt the
+## list stands under.
+func _open_party() -> void:
+	if _party != null:
+		return
+	var host: Gen2PartyScreen = PARTY_SCENE.instantiate() as Gen2PartyScreen
+	if host == null:
+		_end(Gen2MoveTutor.SCRIPT_VALUE_CANCELLED, "")
+		return
+	host.set_context(_data, _save, true)
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	host.selection_made.connect(_on_member_selected)
+	add_child(host)
+	host.open_selection(Gen2PartyScreen.PROMPT_TEACH_WHICH)
+	_party = host
+	if _text_box != null:
+		_text_box.visible = false
+	if _menu != null:
+		_menu.visible = false
+	_phase = Phase.SELECT_MON
+
+
+func _on_member_selected(party_index: int) -> void:
+	Gen2Screen.drop(_party)
+	_party = null
+	## `jr c, .cancel`: B on the list is the one way out that is not a learned
+	## move.
+	if party_index < 0 or party_index >= _save.party.size():
+		_end(Gen2MoveTutor.SCRIPT_VALUE_CANCELLED, "")
+		return
+	_party_index = party_index
+	_teach(-1)
+
+
+## `CheckCanLearnMoveTutorMove`'s own order, run through the host so the write
+## and the happiness row land in one transaction.
+func _teach(forget_slot: int) -> void:
+	var result: Dictionary = Gen2WorldPartyHost.teach_tutor_move(
+		_world, _save, _party_index, _move, forget_slot, _persist
+	)
+	if bool(result.get("ok", false)):
+		var learned: String = Gen2MoveForget.learned_text(_mon_name(), _move_name)
+		if forget_slot >= 0:
+			learned = "%s %s" % [
+				Gen2MoveForget.forgot_text(_mon_name(), _forgotten_name(forget_slot)),
+				learned,
+			]
+		_end(Gen2MoveTutor.SCRIPT_VALUE_LEARNED, learned)
+		return
+	var reason: StringName = StringName(result.get("reason", &""))
+	## `LearnMove` is the last of the three, so a full moveset is the one
+	## refusal that opens a menu instead of printing a line.
+	if reason == &"moveset_full":
+		_forget_moves = Gen2MoveForget.options(
+			_data, (result.get("details", {}) as Dictionary).get("moves", [])
+		)
+		if not _forget_moves.is_empty():
+			_open_forget_ask()
+			return
+	_show_refusal(reason)
+
+
+## The two lines `CheckCanLearnMoveTutorMove` prints itself, and the SFX_WRONG
+## that stands in front of only the first.
+func _show_refusal(reason: StringName) -> void:
+	match reason:
+		&"not_compatible":
+			sfx_requested.emit(Gen2MoveTutor.SFX_WRONG, false)
+			_refusal_text = Gen2WorldTMHM.not_compatible_text(_mon_name(), _move_name)
+		&"already_knows_move":
+			_refusal_text = Gen2WorldTMHM.knows_move_text(_mon_name(), _move_name)
+		&"invalid_party_index":
+			## `ChooseMonToLearnTMHM` refuses an egg with SFX_WRONG and reopens
+			## the list without a box, which is what an empty text is here.
+			sfx_requested.emit(Gen2MoveTutor.SFX_WRONG, false)
+			_open_party()
+			return
+		_:
+			_refusal_text = Gen2MoveForget.did_not_learn_text(_mon_name(), _move_name)
+	_phase = Phase.REFUSAL
+	_show_text(_refusal_text)
+
+
+func _open_forget_ask() -> void:
+	_phase = Phase.FORGET_ASK
+	_yes = true
+	_show_text(box_text())
+	_draw_yes_no()
+
+
+func _answer(yes: bool) -> void:
+	if _phase == Phase.FORGET_ASK:
+		if yes:
+			_open_forget_list()
+		else:
+			_open_stop_ask()
+		return
+	## `.cancel`'s own `jp c, .loop`: no goes back to `ForgetMove`'s ask.
+	if yes:
+		_end_did_not_learn()
+	else:
+		_open_forget_ask()
+
+
+func _open_forget_list() -> void:
+	_phase = Phase.FORGET_LIST
+	_forget_cursor = 0
+	_forget_refusal = ""
+	_show_text(box_text())
+	_draw_forget_list()
+
+
+func _confirm_forget() -> void:
+	if _forget_cursor < 0 or _forget_cursor >= _forget_moves.size():
+		return
+	var entry: Dictionary = _forget_moves[_forget_cursor]
+	## `.hmmove` is `jr .loop`, not a cancel: the list stays open behind the box.
+	if not bool(entry.get("forgettable", false)):
+		_forget_refusal = Gen2MoveForget.cant_forget_hm_text()
+		_show_text(box_text())
+		_draw_forget_list()
+		return
+	_teach(int(entry.get("slot", -1)))
+
+
+func _open_stop_ask() -> void:
+	_phase = Phase.STOP_ASK
+	_yes = true
+	_show_text(box_text())
+	_draw_yes_no()
+
+
+## `LearnMove` returns `b = 0`, which `CheckCanLearnMoveTutorMove` reads as
+## `.didnt_learn`, so the routine loops back to the party list rather than
+## ending.
+func _end_did_not_learn() -> void:
+	_refusal_text = Gen2MoveForget.did_not_learn_text(_mon_name(), _move_name)
+	_phase = Phase.REFUSAL
+	_show_text(_refusal_text)
+
+
+func _forgotten_name(slot: int) -> String:
+	for entry: Dictionary in _forget_moves:
+		if int(entry.get("slot", -1)) == slot:
+			return String(entry.get("name", ""))
+	return ""
+
+
+func _mon_name() -> String:
+	if _save == null or _party_index < 0 or _party_index >= _save.party.size():
+		return "#MON"
+	var mon: Gen2SaveMon = _save.party[_party_index] as Gen2SaveMon
+	if mon == null:
+		return "#MON"
+	var nickname: String = String(mon.nickname)
+	if not nickname.is_empty():
+		return nickname
+	return String(_data.species(mon.species).get("name", "#MON")) if _data != null \
+		else "#MON"
+
+
+func _show_text(text: String, prompt: bool = false) -> void:
+	if _text_box == null:
+		return
+	if _menu != null:
+		_menu.visible = false
+	_text_box.visible = true
+	_text_box.show_text(text, prompt)
+
+
+func _end(script_value: int, ending_text: String) -> void:
+	_phase = Phase.DONE
+	if _party != null:
+		Gen2Screen.drop(_party)
+		_party = null
+	if _text_box != null:
+		_text_box.visible = false
+	if _menu != null:
+		_menu.visible = false
+	finished.emit(script_value, _party_index, ending_text)
+	closed.emit()
+
+
+func _page() -> Gen2MenuPage:
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	return _menu_page
+
+
+func _draw_yes_no() -> void:
+	if _page() == null or _menu == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
+	var image: Image = _page().render(box, ["YES", "NO"], 0 if _yes else 1)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true
+
+
+func _draw_forget_list() -> void:
+	if _page() == null or _menu == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		FORGET_BOX[0], FORGET_BOX[1], FORGET_BOX[2], FORGET_BOX[3],
+		Gen2MenuBox.STATICMENU_CURSOR
+	)
+	var names: Array = []
+	for entry: Dictionary in _forget_moves:
+		names.append(String(entry.get("name", "")))
+	var image: Image = _page().render(box, names, _forget_cursor)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true

--- a/game/world/move_tutor_screen.gd.uid
+++ b/game/world/move_tutor_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://cy6xtolkmtg2v

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1369,11 +1369,9 @@ func _teach_refusal(reason: StringName, party_index: int) -> String:
 	var target_name: String = _target_name(party_index)
 	match reason:
 		&"not_compatible":
-			return "%s is not compatible with %s. It can't learn %s." % [
-				move_name, target_name, move_name,
-			]
+			return Gen2WorldTMHM.not_compatible_text(target_name, move_name)
 		&"already_knows_move":
-			return "%s knows %s." % [target_name, move_name]
+			return Gen2WorldTMHM.knows_move_text(target_name, move_name)
 		&"cannot_forget_hm":
 			return Gen2MoveForget.cant_forget_hm_text()
 		&"invalid_forget_slot":

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -187,6 +187,8 @@ static func _reason_for(kind: StringName) -> StringName:
 			return &"name_rater_data_unavailable"
 		&"move_deleter_requested":
 			return &"move_deleter_data_unavailable"
+		&"move_tutor_requested":
+			return &"move_tutor_data_unavailable"
 		&"day_care_requested":
 			return &"day_care_data_unavailable"
 		&"pc_requested":
@@ -233,6 +235,16 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 			if boxes.is_empty():
 				return {"ok": false, "reason": &"move_deleter_text_unavailable"}
 			return {"ok": true, "data": {"move_deleter_text": boxes}}
+		&"move_tutor_requested":
+			## Every box `MoveTutor` prints is `LearnMove`'s or `TeachTMHM`'s,
+			## which [Gen2MoveForget] and [Gen2WorldTMHM] already own, so the
+			## request's own data is the move the script chose.
+			return {
+				"ok": true,
+				"data": {"move": int((request.get("values", {}) as Dictionary).get(
+					"move", 0
+				))},
+			}
 		&"day_care_requested":
 			var day_care: Dictionary = day_care_texts(world.data)
 			if day_care.is_empty():

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -482,15 +482,23 @@ static func teach_tm_hm(
 ## `LearnMove` on its own, without the TM/HM that usually reaches it: what an
 ## evolution offers a Pokemon whose four slots are full. The refusal order is
 ## `LearnMove`'s own, an empty slot always winning over a passed
-## [param forget_slot] the way `.loop` does, and nothing is consumed and no
-## happiness moves because no item was used.
+## [param forget_slot] the way `.loop` does, and by default nothing is consumed
+## and no happiness moves because no item was used.
+##
+## [param compatibility_checked] is `CheckCanLearnMoveTutorMove`'s own
+## `predef CanLearnTMHMMove`, which stands in front of `KnowsMove` there and
+## nowhere else, and [param happiness_kind] its `ld c, HAPPINESS_LEARNMOVE`,
+## charged inside the same transaction the move is written in. A level-up offer
+## passes neither, which is what makes it the plain `LearnMove` it is.
 static func learn_move(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
 	party_index: int,
 	move: int,
 	forget_slot: int = -1,
-	persist: bool = true
+	persist: bool = true,
+	compatibility_checked: bool = false,
+	happiness_kind: int = 0
 ) -> Dictionary:
 	if world == null or save == null or world.data == null:
 		return _failure(&"missing_save", {})
@@ -499,6 +507,9 @@ static func learn_move(
 	var mon: Gen2SaveMon = _party_member(save, party_index)
 	if mon == null or mon.is_egg:
 		return _failure(&"invalid_party_index", {"party_index": party_index})
+	if compatibility_checked \
+		and not Gen2WorldTMHM.can_learn(world.data, mon.species, move):
+		return _failure(&"not_compatible", {"species": mon.species, "move": move})
 	if Gen2WorldTMHM.knows_move(mon.moves, move):
 		return _failure(&"already_knows_move", {"move": move})
 	var slot: int = Gen2WorldTMHM.first_empty_slot(mon.moves)
@@ -521,6 +532,14 @@ static func learn_move(
 	var learner: Gen2SaveMon = candidate.party[party_index] as Gen2SaveMon
 	learner.moves[slot] = move
 	learner.pp[slot] = int(world.data.move(move).get("pp", 0))
+	## `.learned` is what `CheckCanLearnMoveTutorMove` tests before its
+	## `ChangeHappiness`, so a cancelled forget charges nothing: the refusals
+	## above have already answered by here.
+	var happiness_before: int = learner.happiness
+	if happiness_kind > 0:
+		learner.happiness = change_happiness(
+			world.data, learner.happiness, happiness_kind
+		)
 	var before: Gen2WorldSnapshot = world.snapshot()
 	var committed: Dictionary = Gen2WorldTransaction.commit(
 		world, save, candidate, before, persist
@@ -534,7 +553,27 @@ static func learn_move(
 		"slot": slot,
 		"forgot": forgot,
 		"pp": learner.pp[slot],
+		"happiness": learner.happiness,
+		"happiness_change": learner.happiness - happiness_before,
 	}
+
+
+## `CheckCanLearnMoveTutorMove` (`engine/events/move_tutor.asm`): the same
+## `LearnMove` a TM reaches, with `CanLearnTMHMMove` in front of it and
+## `HAPPINESS_LEARNMOVE` behind it, and no item either way. The tutor charges
+## coins in its map script rather than here.
+static func teach_tutor_move(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	party_index: int,
+	move: int,
+	forget_slot: int = -1,
+	persist: bool = true
+) -> Dictionary:
+	return learn_move(
+		world, save, party_index, move, forget_slot, persist,
+		true, RomLayout.HAPPINESS_LEARNMOVE
+	)
 
 
 ## `ChangeHappiness` over the imported table, taking the byte rather than the

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -154,6 +154,10 @@ var _name_rater_save: Gen2SaveData = null
 ## `special MoveDeletion`'s screen. It needs no save of its own beside it: the
 ## moves and their PP belong to the save it was handed and it writes them itself.
 var _move_deleter_host: Gen2MoveDeleterScreen = null
+var _move_tutor_host: Gen2MoveTutorScreen = null
+## `MoveTutor`'s answer, held between the screen's `finished` and its `closed`
+## the way the Day-Care's is.
+var _move_tutor_script_value: int = Gen2MoveTutor.SCRIPT_VALUE_CANCELLED
 ## The Day-Care's five routines, all one screen. It edits the save's party and
 ## the world state directly, which is what `DepositBreedmon` and `RetrieveBreedmon`
 ## do, so the save it was handed is kept beside it only to write nothing else.
@@ -686,6 +690,8 @@ func advance_frame() -> void:
 		_name_rater_host.advance_frame()
 	if _move_deleter_host != null:
 		_move_deleter_host.advance_frame()
+	if _move_tutor_host != null:
+		_move_tutor_host.advance_frame()
 	if _day_care_host != null:
 		_day_care_host.advance_frame()
 	if _unown_puzzle_host != null:
@@ -838,6 +844,7 @@ func _overlay_open() -> bool:
 		or _pokedex_host != null or _credits_host != null \
 		or _evolution_host != null or _hatch_host != null \
 		or _name_rater_host != null or _move_deleter_host != null \
+		or _move_tutor_host != null \
 		or _day_care_host != null or _unown_puzzle_host != null \
 		or _slot_machine_host != null or _card_flip_host != null
 
@@ -948,7 +955,10 @@ func _handle_button(button: int) -> bool:
 	if _name_rater_host != null:
 		_name_rater_host.handle_button(button)
 		return true
-	## `special MoveDeletion` is the same shape one house further on.
+	## `special MoveTutor` and `special MoveDeletion`, the same shape again.
+	if _move_tutor_host != null:
+		_move_tutor_host.handle_button(button)
+		return true
 	if _move_deleter_host != null:
 		_move_deleter_host.handle_button(button)
 		return true
@@ -1638,6 +1648,83 @@ func _on_move_deleter_closed() -> void:
 	if _world != null:
 		_show_script_results(_world.complete_runtime_request({"ok": true}))
 	_refresh_labels()
+
+
+## `special MoveTutor`, hosted exactly as `special MoveDeletion` is. The move
+## comes from the request, since `.GetMoveTutorMove` has already read the map's
+## own `setval`.
+func _open_move_tutor(request: Dictionary) -> bool:
+	if _move_tutor_host != null or _world == null or _data == null:
+		return false
+	var move: int = int((request.get("values", {}) as Dictionary).get("move", 0))
+	if move <= 0:
+		return false
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null:
+		_script_prompt = "The move tutor needs a validated save"
+		return false
+	var host := Gen2MoveTutorScreen.new()
+	host.set_context(_data, _world, save, move)
+	host.finished.connect(_on_move_tutor_finished)
+	host.closed.connect(_on_move_tutor_closed)
+	host.sfx_requested.connect(_play_sfx)
+	host.z_index = 30
+	_move_tutor_host = host
+	_move_tutor_script_value = Gen2MoveTutor.SCRIPT_VALUE_CANCELLED
+	_screen.display(host)
+	_script_prompt = "Move tutor"
+	_refresh_labels()
+	return true
+
+
+## The screen has already written the move, its PP and the happiness row. What
+## is left is `LearnedMoveText`, which the map script's own `promptbutton`
+## presses on the branch that reached it.
+func _on_move_tutor_finished(
+	script_value: int, _party_index: int, ending_text: String
+) -> void:
+	_move_tutor_script_value = script_value
+	if ending_text.is_empty() or _text_box == null or _text_box.font == null:
+		return
+	_apply_text_box_options()
+	_text_awaits_press = false
+	_text_box.show_text(ending_text, false)
+	_text_box.visible = true
+
+
+func _on_move_tutor_closed() -> void:
+	var host: Gen2MoveTutorScreen = _move_tutor_host
+	_move_tutor_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	if _world != null:
+		_show_script_results(_world.complete_runtime_request({
+			"ok": true, "script_value": _move_tutor_script_value,
+		}))
+	_refresh_labels()
+
+
+## Public screenshot driver for `special MoveTutor`, the same way
+## [method preview_move_deleter] is. The move is MT01, the first of the three
+## rows `add_mt` appends past HM07, so a cartridge without them draws nothing.
+func preview_move_tutor() -> void:
+	if _world == null or _data == null or _move_tutor_host != null:
+		return
+	var move: int = Gen2MoveTutor.move_for_value(_data, Gen2MoveTutor.VALUE_FLAMETHROWER)
+	if move <= 0:
+		_script_prompt = "This cartridge has no move tutor moves"
+		_refresh_labels()
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Move tutor preview needs a party"
+		_refresh_labels()
+		return
+	save.party[0].is_egg = false
+	_injected_save = save
+	_open_move_tutor({"values": {"move": move}})
 
 
 ## Public screenshot driver for `special MoveDeletion`, the same way
@@ -5023,6 +5110,10 @@ func _show_script_results(results: Array) -> void:
 					continue
 				if StringName(request.get("kind", &"")) == &"move_deleter_requested":
 					if _open_move_deleter():
+						break
+					continue
+				if StringName(request.get("kind", &"")) == &"move_tutor_requested":
+					if _open_move_tutor(request):
 						break
 					continue
 				if StringName(request.get("kind", &"")) == &"day_care_requested":

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -176,6 +176,11 @@ const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
 ## the same shape `NameRater` does, one house further on, so it is one host
 ## request as well.
 const SPECIAL_MOVE_DELETION: int = 33
+## MoveTutor, 131, Crystal's alone: pokegold's SpecialsPointers has no row for
+## it and no Gold or Silver script reaches one. `MoveTutor` owns the party list
+## `ChooseMonToLearnTMHM` opens and the `.loop` behind it, so the whole routine
+## is one host request; the map script reads wScriptVar afterwards.
+const SPECIAL_MOVE_TUTOR: int = 131
 ## The Day-Care's five, all below the first index the two tables disagree on, so
 ## `special_index()` leaves them alone. `DayCareMan` and `DayCareLady` are the
 ## deposit and withdrawal counters; `DayCareManOutside` is the man who brings the
@@ -947,6 +952,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## Neither routine writes anything a script reads: each returns and the
 		## map's own `waitbutton` presses the text it left standing.
 		&"name_rater_requested", &"move_deleter_requested",
+		## `MoveTutor` answers FALSE when the move was learned and -1 when the
+		## list was backed out of, which is the one branch its script reads.
+		&"move_tutor_requested",
 		## `UnownPuzzle` answers `wSolvedUnownPuzzle`, which is zero for a board
 		## left on START and one for a solved one.
 		&"unown_puzzle_requested",
@@ -2864,6 +2872,23 @@ func _execute_special(special: int) -> Dictionary:
 		SPECIAL_MOVE_DELETION:
 			return _stage_runtime_request(&"move_deleter_requested", {
 				"special": special,
+			})
+		SPECIAL_MOVE_TUTOR:
+			## `.GetMoveTutorMove` reads the value the map's own `setval` left,
+			## and a cartridge whose TMHMMoves stops at HM07 has no move to
+			## teach, which is the refusal rather than a guessed one.
+			var tutor_move: int = Gen2MoveTutor.move_for_value(data, _script_value)
+			if tutor_move <= 0:
+				return {
+					"ok": false,
+					"reason": &"unknown_move_tutor_move",
+					"special": special,
+					"value": _script_value,
+				}
+			return _stage_runtime_request(&"move_tutor_requested", {
+				"special": special,
+				"value": _script_value,
+				"move": tutor_move,
 			})
 		SPECIAL_SELECT_APRICORN_FOR_KURT:
 			## Both of the special's boxes are the host's; it answers with the

--- a/game/world/world_tmhm.gd
+++ b/game/world/world_tmhm.gd
@@ -99,3 +99,17 @@ static func teach_prompt(data: GameData, item: int) -> Dictionary:
 		"hm": is_hm(item),
 		"text": "%s It contained %s. Teach %s to a #MON?" % [booted, move_name, move_name],
 	}
+
+
+## `_TMHMNotCompatibleText` (data/text/common_2.asm), which `TeachTMHM` and
+## `CheckCanLearnMoveTutorMove` both print when `CanLearnTMHMMove` says no.
+static func not_compatible_text(mon_name: String, move_name: String) -> String:
+	return "%s is not compatible with %s. It can't learn %s." % [
+		move_name, mon_name, move_name,
+	]
+
+
+## `_KnowsMoveText` (data/text/common_3.asm), printed by `KnowsMove` itself, so
+## every caller that reaches it shows this line and no other.
+static func knows_move_text(mon_name: String, move_name: String) -> String:
+	return "%s knows %s." % [mon_name, move_name]

--- a/tests/integration/test_world_mon_specials.gd
+++ b/tests/integration/test_world_mon_specials.gd
@@ -361,6 +361,155 @@ func test_no_on_the_confirmation_leaves_the_moves_alone() -> void:
 	)
 
 
+## `MoveTutor` from here down, one special further on again. Its map script is
+## `setval` then `special`, since `.GetMoveTutorMove` reads the value the
+## `verticalmenu` in front of it left.
+const TUTOR_MOVE: int = 0x35
+
+
+func _write_tutor_script(value: int) -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		Gen2WorldScript.SETVAL, value,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_MOVE_TUTOR, 0x00,
+		Gen2WorldScript.WAITBUTTON,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+
+
+## The three `add_mt` rows past HM07 and one species that learns the first of
+## them, which is what `CanLearnTMHMMove` reads.
+func _write_tutor_tables(learnable: bool) -> void:
+	var directory: String = Fixture.directory()
+	var table: Array = []
+	for index: int in RomLayout.TMHM_TM_COUNT + RomLayout.TMHM_HM_COUNT:
+		table.append(0x60 + index)
+	table.append_array([TUTOR_MOVE, TUTOR_MOVE + 1, TUTOR_MOVE + 2])
+	RomCache.write_json(RomCache.tmhm_moves_path(directory), table)
+	var species: Array = RomCache.read_json(RomCache.species_path(directory))
+	for raw: Dictionary in species:
+		var flags: Array = []
+		flags.resize(RomLayout.TMHM_BYTES)
+		for index: int in flags.size():
+			flags[index] = 0
+		# TMNUM 58 is MT01, bit index 57 counted from the low bit of byte 7.
+		flags[7] = 0x02 if learnable else 0x00
+		raw["tmhm"] = flags
+	RomCache.write_json(RomCache.species_path(directory), species)
+
+
+func _open_tutor_world(
+	value: int = Gen2MoveTutor.VALUE_FLAMETHROWER, learnable: bool = true
+) -> void:
+	Fixture.build()
+	_write_tutor_script(value)
+	_write_tutor_tables(learnable)
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world()
+	var mon: Gen2SaveMon = _world_screen.active_save().party[0]
+	mon.moves = [1, 0, 0, 0]
+	mon.pp = [10, 0, 0, 0]
+	mon.happiness = 70
+
+
+func _tutor() -> Gen2MoveTutorScreen:
+	return _world_screen._move_tutor_host
+
+
+## `MoveTutor` opens on `ChooseMonToLearnTMHM` with no box of its own: every
+## line before the list belongs to the map script.
+func test_the_tutor_special_opens_the_party_list_first() -> void:
+	await _open_tutor_world()
+	_run_script()
+	assert_not_null(_tutor())
+	assert_eq(_tutor().phase(), Gen2MoveTutorScreen.Phase.SELECT_MON)
+	assert_not_null(_tutor().party_screen())
+	assert_false(_world_screen.move_player(Vector2i.RIGHT))
+
+
+## `.quit`'s `xor a`: a learned move answers FALSE, which is the branch the map
+## script takes to `takecoins`.
+func test_a_learned_move_answers_false_and_costs_happiness() -> void:
+	await _open_tutor_world()
+	_run_script()
+	_tutor().party_screen().handle_button(Gen2Button.A)
+	assert_null(_tutor())
+	var mon: Gen2SaveMon = _world_screen.active_save().party[0]
+	assert_eq(mon.moves, [1, TUTOR_MOVE, 0, 0])
+	assert_eq(mon.happiness, 71)
+	assert_eq(_world_screen._world._active_script._script_value, Gen2MoveTutor.SCRIPT_VALUE_LEARNED)
+
+
+## `.cancel`'s `ld a, -1`: B on the list is the one exit that is not a learned
+## move, and it writes nothing.
+func test_backing_out_of_the_list_answers_minus_one() -> void:
+	await _open_tutor_world()
+	_run_script()
+	_tutor().party_screen().handle_button(Gen2Button.B)
+	assert_null(_tutor())
+	assert_eq(_world_screen.active_save().party[0].moves, [1, 0, 0, 0])
+	assert_eq(_world_screen._world._active_script._script_value, Gen2MoveTutor.SCRIPT_VALUE_CANCELLED)
+
+
+## `.didnt_learn` is `and a / ret`, and `jr nc, .loop` reads that as another
+## pass: an incompatible member prints its line and comes back to the list
+## rather than ending the special.
+func test_an_incompatible_member_loops_back_to_the_list() -> void:
+	await _open_tutor_world(Gen2MoveTutor.VALUE_FLAMETHROWER, false)
+	_run_script()
+	_tutor().party_screen().handle_button(Gen2Button.A)
+	assert_eq(_tutor().phase(), Gen2MoveTutorScreen.Phase.REFUSAL)
+	assert_true(_tutor().box_text().contains("not compatible"))
+	## The line is three lines of text and the box pages, so the presses that
+	## dismiss it are the player's own; what matters is where they land.
+	var guard: int = 8
+	while guard > 0 and _tutor() != null \
+		and _tutor().phase() == Gen2MoveTutorScreen.Phase.REFUSAL:
+		_settle_tutor()
+		_world_screen.press_button(Gen2Button.A)
+		guard -= 1
+	assert_not_null(_tutor())
+	assert_eq(_tutor().phase(), Gen2MoveTutorScreen.Phase.SELECT_MON)
+	assert_eq(_world_screen.active_save().party[0].moves, [1, 0, 0, 0])
+
+
+## `LearnMove` reaches `ForgetMove` last of the three, so a full moveset asks
+## before anything is written, and `.hmmove` is `jr .loop` rather than a cancel.
+func test_a_full_moveset_asks_and_refuses_an_hm_without_closing_the_list() -> void:
+	await _open_tutor_world()
+	var mon: Gen2SaveMon = _world_screen.active_save().party[0]
+	mon.moves = [Gen2MoveForget.HM_MOVES[0], 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	_run_script()
+	_tutor().party_screen().handle_button(Gen2Button.A)
+	assert_eq(_tutor().phase(), Gen2MoveTutorScreen.Phase.FORGET_ASK)
+	_settle_tutor()
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(_tutor().phase(), Gen2MoveTutorScreen.Phase.FORGET_LIST)
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(_tutor().phase(), Gen2MoveTutorScreen.Phase.FORGET_LIST, "the list stays open")
+	assert_eq(_tutor().box_text(), Gen2MoveForget.cant_forget_hm_text())
+	_settle_tutor()
+	_world_screen.press_button(Gen2Button.DOWN)
+	_world_screen.press_button(Gen2Button.A)
+	assert_null(_tutor())
+	assert_eq(_world_screen.active_save().party[0].moves[1], TUTOR_MOVE)
+	assert_eq(_world_screen._world._active_script._script_value, Gen2MoveTutor.SCRIPT_VALUE_LEARNED)
+
+
+func _settle_tutor() -> void:
+	var guard: int = 600
+	while guard > 0:
+		var host: Gen2MoveTutorScreen = _tutor()
+		if host == null or host._text_box == null or not host._text_box.is_revealing():
+			break
+		_world_screen.advance_frame()
+		guard -= 1
+	_world_screen.advance_frame()
+
+
 ## `engine/events/haircut.asm`'s four routines are the same `SelectMonFromParty`
 ## with no boxes of their own: every line the player reads belongs to the map
 ## script, so the special owes a party list and an answer and nothing else.

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -564,6 +564,11 @@ const TM_ITEM: int = 0xBF
 const HM_ITEM: int = 0xF6
 const TM_MOVE: int = 0xDF
 const HM_MOVE: int = 0x46
+## The three rows `add_mt` appends past HM07, which only Crystal carries. The
+## first member learns MT01 and MT03 and the second neither.
+const MT01_MOVE: int = 0x35
+const MT02_MOVE: int = 0x55
+const MT03_MOVE: int = 0x3A
 
 
 func _add_tmhm_metadata() -> void:
@@ -572,6 +577,7 @@ func _add_tmhm_metadata() -> void:
 		table.append(0x60 + index)
 	table[0] = TM_MOVE
 	table[RomLayout.TMHM_TM_COUNT + 3] = HM_MOVE
+	table.append_array([MT01_MOVE, MT02_MOVE, MT03_MOVE])
 	RomCache.write_json(RomCache.tmhm_moves_path(Fixture.directory()), table)
 
 	var species: Array = RomCache.read_json(RomCache.species_path(Fixture.directory()))
@@ -584,12 +590,14 @@ func _add_tmhm_metadata() -> void:
 			# TMNUM 1 (TM01) and 54 (HM04), bit index TMNUM - 1 from the low bit.
 			flags[0] = 0x01
 			flags[6] = 0x20
+			# TMNUM 58 (MT01) and 60 (MT03), bit index TMNUM - 1 again.
+			flags[7] = 0x02 | 0x08
 		raw["tmhm"] = flags
 	RomCache.write_json(RomCache.species_path(Fixture.directory()), species)
 
 	var moves: Array = RomCache.read_json(RomCache.moves_path(Fixture.directory()))
 	for raw: Dictionary in moves:
-		if int(raw["number"]) in [TM_MOVE, HM_MOVE]:
+		if int(raw["number"]) in [TM_MOVE, HM_MOVE, MT01_MOVE, MT02_MOVE, MT03_MOVE]:
 			raw["pp"] = 15
 	RomCache.write_json(RomCache.moves_path(Fixture.directory()), moves)
 
@@ -1177,3 +1185,78 @@ func test_daisys_grooming_overruns_its_table_on_a_roll_of_255() -> void:
 	var groomed: Dictionary = Gen2WorldPartyHost.groom_outcome(&"grooming", 254, true)
 	assert_eq(int(groomed["script_value"]), 2)
 	assert_eq(int(groomed["happiness_kind"]), Gen2Battle.HAPPINESS_GROOMING)
+
+
+## `.GetMoveTutorMove` reads MT01_MOVE through MT03_MOVE, which are TMHMMoves
+## entries past HM07 rather than pinned move numbers, and anything outside the
+## three MOVETUTOR_* values falls through to ICE_BEAM the way its `cp` chain
+## does. A cartridge whose table stops at HM07 answers nothing.
+func test_the_tutor_reads_its_three_moves_off_the_imported_table() -> void:
+	_add_tmhm_metadata()
+	assert_eq(Gen2MoveTutor.move_for_value(_data, Gen2MoveTutor.VALUE_FLAMETHROWER), MT01_MOVE)
+	assert_eq(Gen2MoveTutor.move_for_value(_data, Gen2MoveTutor.VALUE_THUNDERBOLT), MT02_MOVE)
+	assert_eq(Gen2MoveTutor.move_for_value(_data, Gen2MoveTutor.VALUE_ICE_BEAM), MT03_MOVE)
+	assert_eq(Gen2MoveTutor.move_for_value(_data, 0), MT03_MOVE, "the fall-through branch")
+	assert_eq(Gen2MoveTutor.move_for_value(_data, 9), MT03_MOVE)
+	assert_eq(Gen2MoveTutor.move_for_value(null, 1), 0)
+
+
+## `CheckCanLearnMoveTutorMove` is `LearnMove` with `CanLearnTMHMMove` in front
+## and `ld c, HAPPINESS_LEARNMOVE` behind, and no item on either side: the coins
+## are the map script's `takecoins`.
+func test_the_tutor_teaches_at_full_pp_and_charges_happiness_but_no_item() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.happiness = 70
+	var result: Dictionary = Gen2WorldPartyHost.teach_tutor_move(
+		_world, _save, 0, MT01_MOVE, -1, false
+	)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(int(result["slot"]), 1)
+	assert_eq(int(result["pp"]), 15)
+	assert_eq(int(result["happiness_change"]), 1)
+	assert_eq(_save.party[0].moves[1], MT01_MOVE)
+	assert_eq(_save.party[0].pp[1], 15)
+	assert_eq(_save.party[0].happiness, 71)
+
+
+## The tutor's own `predef CanLearnTMHMMove`, which the plain `LearnMove` an
+## evolution offers does not run: the same species and move answer differently
+## through the two entry points.
+func test_the_tutor_checks_compatibility_where_a_level_up_offer_does_not() -> void:
+	_teachable_save()
+	var refused: Dictionary = Gen2WorldPartyHost.teach_tutor_move(
+		_world, _save, 0, MT02_MOVE, -1, false
+	)
+	assert_false(refused["ok"])
+	assert_eq(refused["reason"], &"not_compatible")
+	assert_eq(_save.party[0].moves[1], 0, "nothing was written")
+
+	var offered: Dictionary = Gen2WorldPartyHost.learn_move(
+		_world, _save, 0, MT02_MOVE, -1, false
+	)
+	assert_true(offered["ok"], JSON.stringify(offered))
+	assert_eq(int(offered["happiness_change"]), 0, "no item, no happiness row")
+
+
+## `LearnMove` is still the last of the three, so a full moveset asks rather
+## than replacing one, and the happiness row is only charged once the move is
+## actually written.
+func test_the_tutor_asks_before_replacing_a_full_moveset_and_charges_nothing() -> void:
+	var mon: Gen2SaveMon = _teachable_save()
+	mon.moves = [1, 2, 3, 4]
+	mon.pp = [10, 10, 10, 10]
+	mon.happiness = 70
+	var asked: Dictionary = Gen2WorldPartyHost.teach_tutor_move(
+		_world, _save, 0, MT03_MOVE, -1, false
+	)
+	assert_false(asked["ok"])
+	assert_eq(asked["reason"], &"moveset_full")
+	assert_eq(_save.party[0].happiness, 70, "the ask writes nothing")
+
+	var replaced: Dictionary = Gen2WorldPartyHost.teach_tutor_move(
+		_world, _save, 0, MT03_MOVE, 2, false
+	)
+	assert_true(replaced["ok"], JSON.stringify(replaced))
+	assert_eq(int(replaced["forgot"]), 3)
+	assert_eq(_save.party[0].moves, [1, 2, MT03_MOVE, 4])
+	assert_eq(_save.party[0].happiness, 71)

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -56,7 +56,7 @@ const EXPECTED_DEFERRED: Dictionary = {
 	83: "CheckLuckyNumberShowFlag", 84: "ResetLuckyNumberShowFlag",
 	85: "PrintTodaysLuckyNumber", 103: "TrainerHouse",
 	104: "PhotoStudio", 107: "Diploma", 108: "PrintDiploma",
-	126: "Reset", 131: "MoveTutor", 132: "OmanyteChamber",
+	126: "Reset", 132: "OmanyteChamber",
 	141: "HoOhChamber", 143: "CelebiShrineEvent", 144: "CheckCaughtCelebi",
 	145: "PokeSeer", 146: "BuenasPassword", 147: "BuenaPrize",
 	148: "GiveDratini", 149: "SampleKenjiBreakCountdown",

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -52,6 +52,8 @@ extends SceneTree
 ## MoveDeletion`, which no fixture cell reaches: the first number is how many
 ## presses into the routine to photograph, so 0 is the introduction, 2 its last
 ## page with the YES/NO up, and 4 the party list),
+## `move_tutor` (`special MoveTutor`, driven the same way, except that it opens
+## on `ChooseMonToLearnTMHM` rather than on a box: 0 is that list),
 ## `day_care` (the Day-Care's five specials, driven the same way: the first
 ## number is how many presses in and the second which routine, 0 the man,
 ## 1 the lady, 2 the man outside, 3 and 4 the two signs),
@@ -229,7 +231,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 		_screen.start_cell = _kind_cell
 	elif cell.x >= 0 and _kind not in [
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-		&"move_deleter", &"day_care", &"unown_puzzle", &"slot_machine",
+		&"move_deleter", &"move_tutor", &"day_care", &"unown_puzzle", &"slot_machine",
 		&"card_flip", &"tile_anim",
 	]:
 		_screen.start_cell = cell
@@ -251,9 +253,12 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 func _settle_mon_special(host_property: String) -> void:
 	for _frame: int in MON_SPECIAL_FRAME_CAP:
 		var routine: Control = _screen.get(host_property)
-		if routine == null:
-			return
-		var box: Gen2TextBox = routine.get("_text_box")
+		## The routine's last box is handed back to the map, which reveals it on
+		## its own clock, so a closed host still owes the frames its ending text
+		## is printing. Photographing on the frame the host went away shows an
+		## empty box.
+		var box: Gen2TextBox = routine.get("_text_box") if routine != null \
+			else _screen.get("_text_box") as Gen2TextBox
 		if box == null or not box.is_revealing():
 			break
 		_screen.advance_frame()
@@ -377,19 +382,21 @@ func _process(_delta: float) -> bool:
 					break
 				_screen.press_button(Gen2Button.A)
 				_settle_mon_special("_day_care_host")
-		elif _kind in [&"name_rater", &"move_deleter"]:
+		elif _kind in [&"name_rater", &"move_deleter", &"move_tutor"]:
 			## `special NameRater` and `special MoveDeletion`, neither of which
 			## any fixture cell reaches. The first number is how many presses
 			## into the routine to photograph: 2 is the introduction's last page
 			## with its YES/NO up, 4 the party list, and so on. Presses are spent
 			## only once the box owes no frames, since nothing shortens a
 			## printing text.
-			if _kind == &"name_rater":
-				_screen.preview_name_rater()
-			else:
-				_screen.preview_move_deleter()
-			var host_property: String = "_name_rater_host" \
-				if _kind == &"name_rater" else "_move_deleter_host"
+			match _kind:
+				&"name_rater":
+					_screen.preview_name_rater()
+				&"move_tutor":
+					_screen.preview_move_tutor()
+				_:
+					_screen.preview_move_deleter()
+			var host_property: String = "_%s_host" % _kind
 			_settle_mon_special(host_property)
 			for _press: int in maxi(_cell.x, 0):
 				if _screen.get(host_property) == null:
@@ -488,7 +495,7 @@ func _process(_delta: float) -> bool:
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
 			&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-			&"move_deleter", &"day_care",
+			&"move_deleter", &"move_tutor", &"day_care",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.


### PR DESCRIPTION
`special MoveTutor` was the one entry left in Crystal's specials table with no
routine behind it here, so every path into Goldenrod's tutor stopped where the
command stood.

`Gen2MoveTutor` is `.GetMoveTutorMove`. Its three moves come off TMHMMoves' own
`add_mt` rows rather than pinned move numbers, so Gold and Silver, whose table
stops at HM07, answer nothing.

`Gen2WorldPartyHost.teach_tutor_move` is `CheckCanLearnMoveTutorMove`: the same
`LearnMove` a TM reaches, with `CanLearnTMHMMove` in front of it and
`HAPPINESS_LEARNMOVE` behind it, both inside the one transaction that writes the
move. `learn_move` grew the two options rather than gaining a second copy, so a
level-up offer still runs neither.

`Gen2MoveTutorScreen` is the routine: `ChooseMonToLearnTMHM`'s party list, the
two lines it prints itself, and `ForgetMove`'s menu behind `LearnMove`. The
`.loop` is what makes it come back rather than end. An incompatible member, a
move already known and a cancelled forget all return to the list. Only a learned
move or a backed-out list answers the script, with `FALSE` and `-1`.

The two refusal lines were written out inside the pack. They belong to
`TeachTMHM` and `KnowsMove`, so both callers read them from `Gen2WorldTMHM` now.

Also here: the world screenshot driver photographed a routine's ending text on
the frame its host went away, which is an empty box. The map reveals that box on
its own clock, so the settle follows it there. That was true of the name rater
and the move deleter too.

| Check | Result |
|---|---|
| GUT, unit and scene | 3504/3504 |
| `validate.gd -- all` | 65/65 topics pass, `specials` included |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failures |

`tools/preview_world.gd -- crystal 24 6 <png> live move_tutor <presses> 0`
photographs it. Press 0 is the party list under "Teach which PKMN?"; press 1 is
"CYNDAQUIL learned FLAMETHROWER!", with FLAMETHROWER read out of the cartridge's
own MT01 row.