### PR TITLE
Slide the player across ice the way DoPlayerMovement does

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -168,6 +168,16 @@ var world_hour: int = 6
 var world_minute: int = 0
 var dst_enabled: bool = false
 var movement_mode: StringName = MOVEMENT_WALK
+## `DOWN`, `UP`, `LEFT`, `RIGHT`: the direction constants' own order, which is
+## both `.FinishFacing`'s row order and `.GetAction`'s test order.
+const TURNING_DIRECTION_ORDER: Array[Vector2i] = [
+	Vector2i.DOWN, Vector2i.UP, Vector2i.LEFT, Vector2i.RIGHT,
+]
+## `wPlayerTurningDirection`: 0 while standing, `$80 | direction` once
+## `DoPlayerMovement.DoStep` has committed a step or a turn. Only the input path
+## writes it, which is why a scripted `applymovement` leaves it where it stands.
+## `CheckStandingOnIce`'s `cp $f0` is dead in both pins: nothing writes $F0.
+var _player_turning_direction: int = 0
 ## wPlayerState resolved through ChrisStateSprites, which is the only part of
 ## that state a renderer reads. movement_mode carries the rest; the two surfing
 ## states differ from each other here and nowhere else.
@@ -789,7 +799,7 @@ func _queue_player_step(
 
 func _face_player_toward(direction: Vector2i) -> void:
 	if direction != Vector2i.ZERO:
-		player_facing = _facing_for_direction(direction)
+		player_facing = facing_for_direction(direction)
 
 
 ## The player's half of [method Gen2WorldObject._start_next_queued_step].
@@ -4015,14 +4025,14 @@ func _apply_object_movement(event: Dictionary) -> Array:
 			## the walk ends. `queue_step` drains an entry of no frames itself.
 			var turn: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			object.queue_step(Vector2i.ZERO, 0, false, turn)
-			final_facing = _facing_for_direction(turn)
+			final_facing = facing_for_direction(turn)
 			continue
 		if SCRIPTED_STEP_PASSES.has(kind):
 			var direction: Vector2i = _movement_direction(int(command.get("direction", 0)))
 			var jumping: bool = kind in JUMP_STEP_KINDS
 			var cells: int = 2 if jumping else 1
 			var destination: Vector2i = object.cell + direction * cells
-			final_facing = _facing_for_direction(direction)
+			final_facing = facing_for_direction(direction)
 			if _cell_in_bounds(destination):
 				var vacated: Vector2i = object.cell
 				object.cell = destination
@@ -4335,7 +4345,7 @@ func edge_warp_ready(direction: Vector2i) -> bool:
 		return false
 	## `ld a, [wPlayerDirection] / rrca / rrca` against wWalkingDirection: the
 	## facing has to agree with the press, which a turn from the same cell buys.
-	if _facing_for_direction(direction) != player_facing:
+	if facing_for_direction(direction) != player_facing:
 		return false
 	return not warp_at(player_cell).is_empty()
 
@@ -4519,7 +4529,8 @@ func try_connection(direction: Vector2i) -> Dictionary:
 	## other step does. `_apply_map` clears the step it inherits, so the step is
 	## begun after it; the cell it is drawn walking out of is the new map's own
 	## connection strip, which is the same picture the old map's edge was.
-	player_facing = _facing_for_direction(direction)
+	player_facing = facing_for_direction(direction)
+	_do_step(direction)
 	_start_player_step(direction, _step_frames_for_movement())
 	return {
 		"ok": true,
@@ -4917,7 +4928,7 @@ func _step_follower(follower_index: int, target_cell: Vector2i, exact: bool) -> 
 	# the leader's own command bytes.
 	if follower == null:
 		player_cell = destination
-		player_facing = _facing_for_direction(direction)
+		player_facing = facing_for_direction(direction)
 		_queue_player_step(direction, STEP_PASSES_WALK)
 		return
 	follower.cell = destination
@@ -4954,10 +4965,15 @@ func player_input_move(direction: Vector2i) -> Dictionary:
 	## `.CheckTile` overwrites the pressed direction, so a forced walk is not a
 	## turn however the facing sits; move_result owns that branch.
 	var forced: StringName = StringName(forced_movement().get("kind", &"none"))
-	if forced == &"none":
-		var pressed_facing: int = _facing_for_direction(direction)
+	## `.CheckTurning`'s own first test is `wPlayerTurningDirection`, so a turn is
+	## only ever taken from a standstill. On ice that byte stays set between
+	## steps, which is what makes a slide change direction without spending a
+	## turn on it.
+	if forced == &"none" and _player_turning_direction == 0:
+		var pressed_facing: int = facing_for_direction(direction)
 		if pressed_facing != player_facing:
 			player_facing = pressed_facing
+			_do_step(direction)
 			_start_player_step(Vector2i.ZERO, STEP_PASSES_TURN)
 			return {
 				"ok": true, "kind": &"turn", "facing": player_facing, "cell": player_cell,
@@ -4970,6 +4986,8 @@ func player_input_move(direction: Vector2i) -> Dictionary:
 	## it always is: the cell past a door carpet is the map's own wall or edge.
 	## `.StandInPlace` spends no step, so the warp is taken on the press.
 	if forced == &"none" and edge_warp_ready(direction):
+		## `.CheckWarp` calls `.StandInPlace` before it returns the warp.
+		_stand_in_place()
 		return {
 			"ok": true,
 			"kind": &"edge_warp",
@@ -4983,6 +5001,9 @@ func player_input_move(direction: Vector2i) -> Dictionary:
 
 func move_result(direction: Vector2i) -> Dictionary:
 	if phone_ring_active():
+		## `StopPlayerForEvent`, which is what an event interrupting a walk runs:
+		## it clears the turning direction, so a slide does not resume after it.
+		_stand_in_place()
 		return {"ok": false, "kind": &"move", "reason": &"phone_ring_active"}
 	if abs(direction.x) + abs(direction.y) != 1:
 		return {"ok": false, "kind": &"move", "reason": &"invalid_direction"}
@@ -5008,6 +5029,8 @@ func move_result(direction: Vector2i) -> Dictionary:
 			## `CountStep`, so the step that leaves a map costs no repel step;
 			## try_connection() owns the facing and the step's own frames.
 			return transition
+		## `.NotMoving`, which reaches `._WalkInPlace`.
+		_stand_in_place()
 		return {"ok": false, "kind": &"move", "reason": &"map_edge"}
 	if forced_walk:
 		return _forced_step(direction, destination)
@@ -5023,6 +5046,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 			return hop
 		if not pushed.is_empty():
 			return pushed
+		_stand_in_place()
 		return {"ok": false, "kind": &"move", "reason": &"blocked"}
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
@@ -5039,9 +5063,10 @@ func move_result(direction: Vector2i) -> Dictionary:
 	elif movement_mode == MOVEMENT_SURF:
 		kind = &"water_move"
 	player_cell = destination
-	player_facing = _facing_for_direction(direction)
+	player_facing = facing_for_direction(direction)
 	state.count_step()
 	_advance_followers(-1, from_cell)
+	_do_step(direction)
 	_start_player_step(direction, _step_frames_for_movement())
 	return {
 		"ok": true,
@@ -5051,6 +5076,49 @@ func move_result(direction: Vector2i) -> Dictionary:
 		"to_map": from_map,
 		"to_cell": player_cell,
 	}
+
+
+## `.DoStep`'s own tail: the walking direction is stored as `$80 | direction`
+## for `.CheckForced` to read back next poll. Every branch of `DoPlayerMovement`
+## that commits a step or a turn passes through here; nothing else does.
+func _do_step(direction: Vector2i) -> void:
+	_player_turning_direction = 0x80 | TURNING_DIRECTION_ORDER.find(direction)
+
+
+## `.StandInPlace` and `._WalkInPlace`, which differ only in the movement byte
+## they queue and both clear the turning direction. Reached by every poll that
+## commits nothing, so on any tile but ice the byte is zero between steps.
+func _stand_in_place() -> void:
+	_player_turning_direction = 0
+
+
+## A poll of `DoPlayerMovement` that committed nothing: `.Standing` reaches
+## `.StandInPlace`. The screen's own frame pump is where a poll with nothing
+## held happens, since a press is what reaches [method player_input_move].
+func note_standing_still() -> void:
+	_stand_in_place()
+
+
+## `CheckStandingOnIce`. `PLAYER_SKATE` is deliberately absent: no script in
+## either pin sets it, so the collision code is the whole test.
+func standing_on_ice() -> bool:
+	if _player_turning_direction == 0 or current_map == null:
+		return false
+	return Gen2WorldCollision.is_ice(collision_code_at(player_cell))
+
+
+## `.CheckForced`, then `.GetAction`. The forced bit is OR'd into `wCurInput`
+## rather than replacing it, so a held direction and the slide's own can both be
+## set and `.GetAction`'s own test order decides between them: down, up, left,
+## right. [param held] is Vector2i.ZERO when nothing is held.
+func effective_input_direction(held: Vector2i) -> Vector2i:
+	if not standing_on_ice():
+		return held
+	var forced: Vector2i = TURNING_DIRECTION_ORDER[_player_turning_direction & 3]
+	for candidate: Vector2i in TURNING_DIRECTION_ORDER:
+		if candidate == held or candidate == forced:
+			return candidate
+	return held
 
 
 ## .CheckTile for the cell the player stands on: whether the tile overrides input,
@@ -5081,7 +5149,7 @@ func advance_forced_movement() -> Dictionary:
 ## player who surfs onto a whirlpool therefore cannot walk off it, which is the
 ## cartridge's own behavior and not a gap here.
 func _forced_turn() -> Dictionary:
-	player_facing = _facing_for_direction(-_direction_for_facing(player_facing))
+	player_facing = facing_for_direction(-_direction_for_facing(player_facing))
 	return {
 		"ok": true,
 		"kind": &"forced_turn",
@@ -5099,9 +5167,10 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
 	player_cell = destination
-	player_facing = _facing_for_direction(direction)
+	player_facing = facing_for_direction(direction)
 	state.count_step()
 	_advance_followers(-1, from_cell)
+	_do_step(direction)
 	_start_player_step(direction, STEP_PASSES_WALK)
 	return {
 		"ok": true,
@@ -5207,9 +5276,10 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
 	player_cell = landing
-	player_facing = _facing_for_direction(direction)
+	player_facing = facing_for_direction(direction)
 	state.count_step()
 	_advance_followers(-1, from_cell)
+	_do_step(direction)
 	_start_player_step(direction * 2, STEP_PASSES_HOP, true)
 	return {
 		"ok": true,
@@ -5260,7 +5330,7 @@ func _direction_for_facing(facing: int) -> Vector2i:
 	return Vector2i.DOWN
 
 
-func _facing_for_direction(direction: Vector2i) -> int:
+func facing_for_direction(direction: Vector2i) -> int:
 	match direction:
 		Vector2i.UP:
 			return Gen2WorldSprite.FACING_UP
@@ -5327,6 +5397,9 @@ func _apply_map(
 	from_warp: int = 0,
 ) -> void:
 	_record_escape_points(target_map, from_warp)
+	## `RefreshPlayerSprite` clears `wPlayerTurningDirection`, and every warp and
+	## connection reaches it, so a slide never survives a map change.
+	_stand_in_place()
 	_block_overrides.clear()
 	_pending_cut.clear()
 	_pending_surf.clear()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -826,8 +826,19 @@ func _advance_held_direction() -> void:
 	if not _objects_may_move() or _world.script_input_waiting() \
 		or _world.player_step_in_progress():
 		return
-	if direction != Gen2Button.NONE:
-		move_player(Gen2Button.vector(direction))
+	## `.CheckForced` sits in front of `.GetAction` in all three of
+	## `.TranslateIntoMovement`'s branches, so a player standing on ice keeps
+	## walking with nothing held at all and a held direction is only obeyed when
+	## `.GetAction` tests it before the slide's own.
+	var held: Vector2i = Vector2i.ZERO if direction == Gen2Button.NONE \
+		else Gen2Button.vector(direction)
+	var walking: Vector2i = _world.effective_input_direction(held)
+	if walking != Vector2i.ZERO:
+		move_player(walking)
+		return
+	## A poll that commits nothing reaches `.StandInPlace`, which is what stops a
+	## slide from resuming after the player has stepped off the ice.
+	_world.note_standing_still()
 
 
 ## Whether any embedded screen is up. Every overlay is named here and nowhere
@@ -1023,6 +1034,17 @@ func _handle_button(button: int) -> bool:
 		if button == Gen2Button.A:
 			_advance_script_pause()
 		return true
+	## The d-pad first, because `DoPlayerMovement` runs in front of
+	## `CheckStandingOnIce` in `OWPlayerInput` and has already decided what a
+	## direction means while a slide is running.
+	if Gen2Button.is_direction(button):
+		move_player(_world.effective_input_direction(Gen2Button.vector(button)))
+		return true
+	## `OWPlayerInput`'s own comment: "Can't perform button actions while sliding
+	## on ice." `CheckStandingOnIce` stands in front of `CheckAPressOW` and
+	## `CheckMenuOW`, so A, START and SELECT are all refused until the run ends.
+	if _world.standing_on_ice():
+		return true
 	match button:
 		Gen2Button.A:
 			return interact()
@@ -1032,9 +1054,6 @@ func _handle_button(button: int) -> bool:
 		Gen2Button.SELECT:
 			open_select_menu()
 			return true
-	if Gen2Button.is_direction(button):
-		move_player(Gen2Button.vector(button))
-		return true
 	return false
 
 
@@ -2040,6 +2059,12 @@ func move_up() -> void:
 
 func move_down() -> void:
 	move_player(Vector2i.DOWN)
+
+
+## Whether the player is mid-slide, for `preview_world.gd`'s `ice_slide` kind,
+## which drives until the run has started rather than spending a count.
+func standing_on_ice() -> bool:
+	return _world != null and _world.standing_on_ice()
 
 
 ## The hop's own arc, for `preview_world.gd`'s `ledge` kind, which drives to the
@@ -3224,21 +3249,10 @@ func _position_for_fishing_preview() -> void:
 				if _world.collision_permission_at(cell + direction) != Gen2WorldCollision.WATER_TILE:
 					continue
 				_world.player_cell = cell
-				_world.player_facing = _facing_for_direction(direction)
+				_world.player_facing = _world.facing_for_direction(direction)
 				if _renderer != null:
 					_renderer.refresh()
 				return
-
-
-func _facing_for_direction(direction: Vector2i) -> int:
-	match direction:
-		Vector2i.UP:
-			return Gen2WorldSprite.FACING_UP
-		Vector2i.LEFT:
-			return Gen2WorldSprite.FACING_LEFT
-		Vector2i.RIGHT:
-			return Gen2WorldSprite.FACING_RIGHT
-	return Gen2WorldSprite.FACING_DOWN
 
 
 func select_fishing_rod(index: int) -> Dictionary:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -138,6 +138,13 @@ func _write_cache(game_id: String = "testworld") -> void:
 	# environment including the cave branch that skips the grass test.
 	collision[10 * 16 + 6] = 0x23  # COLL_ICE
 
+	# An ice run on row 1 for DoPlayerMovement.CheckForced: (2,1) to (5,1) are
+	# ice with a wall at (6,1), so a step east from (1,1) slides the whole run
+	# and bumps the wall. Everything else on the row stays LAND_TILE.
+	for column: int in range(2, 6):
+		collision[1 * 16 + column] = 0x23  # COLL_ICE
+	collision[1 * 16 + 6] = 0x07           # wall the slide ends against
+
 	var source_events: Dictionary = {
 		"bank": 48,
 		"warps": [
@@ -6072,6 +6079,101 @@ func test_advance_forced_movement_moves_without_a_pressed_direction() -> void:
 	assert_true(bool(forced.get("ok", false)), JSON.stringify(forced))
 	assert_eq(world.player_cell, Vector2i(1, 6))
 	assert_true(world.advance_forced_movement().is_empty())
+
+
+## engine/overworld/player_movement.asm's DoPlayerMovement.CheckForced and
+## CheckStandingOnIce. A step onto ice leaves wPlayerTurningDirection set, and
+## the next poll ORs that direction back into wCurInput, so the walk carries on
+## with nothing held.
+func test_a_step_onto_ice_keeps_going_with_nothing_held() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 1))
+	world.player_facing = world.facing_for_direction(Vector2i.RIGHT)
+	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	assert_eq(world.player_cell, Vector2i(2, 1))
+	assert_true(world.standing_on_ice())
+	assert_eq(world.effective_input_direction(Vector2i.ZERO), Vector2i.RIGHT)
+
+	# The run to the wall, one poll a cell, all of it with nothing held.
+	for expected: int in [3, 4, 5]:
+		_finish_step(world)
+		var forced: Vector2i = world.effective_input_direction(Vector2i.ZERO)
+		assert_true(bool(world.player_input_move(forced).get("ok", false)))
+		assert_eq(world.player_cell, Vector2i(expected, 1))
+
+	# `.NotMoving` reaches `._WalkInPlace`, which clears the byte, so the wall
+	# ends the slide rather than the player being stuck against it.
+	_finish_step(world)
+	assert_false(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	assert_eq(world.player_cell, Vector2i(5, 1))
+	assert_false(world.standing_on_ice())
+	assert_eq(world.effective_input_direction(Vector2i.ZERO), Vector2i.ZERO)
+
+
+## Standing on ice is not enough: CheckStandingOnIce tests the turning direction
+## first, so a player who walked onto the ice and then stopped may press again.
+func test_ice_forces_nothing_once_the_player_has_stood_still() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 1))
+	world.player_facing = world.facing_for_direction(Vector2i.RIGHT)
+	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	_finish_step(world)
+	world.note_standing_still()
+	assert_false(world.standing_on_ice())
+	assert_eq(world.effective_input_direction(Vector2i.ZERO), Vector2i.ZERO)
+	assert_eq(world.effective_input_direction(Vector2i.LEFT), Vector2i.LEFT)
+
+
+## `.CheckForced` ORs its bit into wCurInput rather than replacing it, so both
+## directions are set and `.GetAction`'s own test order decides: down, up, left,
+## right. A held DOWN therefore beats a slide running right, and a held UP does
+## not beat a slide running down.
+func test_a_held_direction_beats_the_slide_only_in_getactions_order() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 1))
+	world.player_facing = world.facing_for_direction(Vector2i.RIGHT)
+	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	_finish_step(world)
+	assert_eq(world.effective_input_direction(Vector2i.DOWN), Vector2i.DOWN)
+	assert_eq(world.effective_input_direction(Vector2i.UP), Vector2i.UP)
+	assert_eq(world.effective_input_direction(Vector2i.LEFT), Vector2i.LEFT)
+	# Right against right is still right, and nothing held is the slide's own.
+	assert_eq(world.effective_input_direction(Vector2i.RIGHT), Vector2i.RIGHT)
+	assert_eq(world.effective_input_direction(Vector2i.ZERO), Vector2i.RIGHT)
+
+
+## `.CheckTurning`'s first test is wPlayerTurningDirection, so the tap-to-turn
+## only happens from a standstill. The poll right after a step still has the
+## byte set, which is what keeps a walk around a corner from spending a turn.
+func test_a_direction_pressed_straight_after_a_step_steps_rather_than_turns() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
+	assert_eq(world.player_input_move(Vector2i.LEFT)["kind"], &"turn")
+	_finish_step(world)
+	assert_eq(world.player_input_move(Vector2i.LEFT)["kind"], &"move")
+	_finish_step(world)
+	# Still walking: the byte is set, so UP is a step and not a turn.
+	assert_eq(world.player_input_move(Vector2i.UP)["kind"], &"move")
+	_finish_step(world)
+	# A poll that commits nothing is `.StandInPlace`, and the tap turns again.
+	world.note_standing_still()
+	assert_eq(world.player_input_move(Vector2i.RIGHT)["kind"], &"turn")
+
+
+## `RefreshPlayerSprite` clears the byte, and every warp and connection reaches
+## it, so no walk carries its turning direction into the map it arrives on.
+func test_a_warp_clears_the_turning_direction() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(5, 6))
+	world.player_facing = world.facing_for_direction(Vector2i.RIGHT)
+	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	assert_eq(world.player_cell, Vector2i(6, 6))
+	_finish_step(world)
+	assert_true(bool(world.try_warp().get("ok", false)))
+	# The byte is zero on the far side, so a tap turns rather than steps.
+	assert_eq(world.player_input_move(Vector2i.LEFT)["kind"], &"turn")
+
+
+func _finish_step(world: Gen2WorldAPI) -> void:
+	for _pass: int in 64:
+		if not world.player_step_in_progress():
+			return
+		world.advance_player_step_pass()
 
 
 ## ObjectEventTypeArray's `.itemball` copies `db item, quantity` into

--- a/tools/checks/ice_slides.gd
+++ b/tools/checks/ice_slides.gd
@@ -1,0 +1,123 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Sweeps every ice cell on every map of all three cartridges through the slide
+## `DoPlayerMovement.CheckForced` and `CheckStandingOnIce` produce, rather than
+## sampling the Ice Path. The expected shapes come from the pinned
+## engine/overworld/player_movement.asm, identical in pokecrystal and pokegold:
+## a step onto ice leaves `wPlayerTurningDirection` set, the next poll ORs that
+## direction back into `wCurInput`, and the run ends at the first refused step,
+## whose `._WalkInPlace` clears the byte.
+##
+## Two invariants are what a broken slide trips. It has to terminate, which it
+## only does because a refusal clears the byte; and with nothing held it has to
+## keep the one direction, since a slide that could turn on its own would carry
+## the player off a run the map laid out.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- ice_slides
+
+## A slide can be no longer than the map, so anything past this is a loop.
+const RUN_CEILING: int = 512
+## Passes to spend draining one step, above any STEP_PASSES_* this can reach.
+const PASS_CEILING: int = 64
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in [&"crystal", &"gold", &"silver"]:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_sweep(game_id, data)
+
+
+func _sweep(game_id: StringName, data: GameData) -> void:
+	var maps_with_ice: int = 0
+	var cells: int = 0
+	var slides: int = 0
+	for map: Gen2WorldMap in data.world_maps():
+		var ice_cells: Array[Vector2i] = _ice_cells(map)
+		if ice_cells.is_empty():
+			continue
+		maps_with_ice += 1
+		cells += ice_cells.size()
+		for cell: Vector2i in ice_cells:
+			for direction: Vector2i in [
+				Vector2i.DOWN, Vector2i.UP, Vector2i.LEFT, Vector2i.RIGHT
+			]:
+				if _run_one(game_id, data, map, cell, direction):
+					slides += 1
+	_r.check(
+		maps_with_ice > 0,
+		"%s: no map carries COLL_ICE, so nothing was swept." % game_id
+	)
+	_r.note("%s: %d ice cells over %d maps, %d slides run." % [
+		game_id, cells, maps_with_ice, slides
+	])
+
+
+func _ice_cells(map: Gen2WorldMap) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	for y: int in map.collision_height:
+		for x: int in map.collision_width:
+			if Gen2WorldCollision.is_ice(map.collision_at(x, y)):
+				out.append(Vector2i(x, y))
+	return out
+
+
+## One slide, started from [param cell] walking [param direction]. Returns
+## whether a slide actually ran, so a start that bumps at once is not counted.
+func _run_one(
+	game_id: StringName,
+	data: GameData,
+	map: Gen2WorldMap,
+	cell: Vector2i,
+	direction: Vector2i,
+) -> bool:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, map.group, map.number, cell, Gen2WorldState.new()
+	)
+	if world == null:
+		return false
+	## `.CheckTurning` would spend the first press on the turn, which is the
+	## cartridge's own behaviour and not what this is measuring.
+	world.player_facing = world.facing_for_direction(direction)
+	var where: String = "%s: map %d/%d %s from %s" % [
+		game_id, map.group, map.number, str(direction), str(cell)
+	]
+	if not bool(world.player_input_move(direction).get("ok", false)):
+		return false
+	var steps: int = 0
+	while world.standing_on_ice():
+		if not _drain_step(world, where):
+			return false
+		## `.CheckForced` with nothing held at all, which is the whole point of
+		## the routine: the slide supplies its own direction.
+		var forced: Vector2i = world.effective_input_direction(Vector2i.ZERO)
+		if not _r.check(forced == direction, "%s: the slide turned to %s." % [
+			where, str(forced)
+		]):
+			return false
+		steps += 1
+		if not _r.check(steps < RUN_CEILING, "%s: the slide never ended." % where):
+			return false
+		if not bool(world.player_input_move(forced).get("ok", false)):
+			## `._WalkInPlace` cleared the byte, so the player is standing on the
+			## ice rather than sliding on it and a press is theirs again.
+			return _r.check(
+				not world.standing_on_ice(),
+				"%s: a refused step left the slide running." % where
+			)
+	return true
+
+
+func _drain_step(world: Gen2WorldAPI, where: String) -> bool:
+	var passes: int = 0
+	while world.player_step_in_progress():
+		world.advance_player_step_pass()
+		passes += 1
+		if not _r.check(passes < PASS_CEILING, "%s: a step never finished." % where):
+			return false
+	return true

--- a/tools/checks/ice_slides.gd.uid
+++ b/tools/checks/ice_slides.gd.uid
@@ -1,0 +1,1 @@
+uid://d1ddt7vpwfqub

--- a/tools/checks/ledge_hops.gd
+++ b/tools/checks/ledge_hops.gd
@@ -224,7 +224,7 @@ func _verify_warp_carpets(game_id: StringName, data: GameData) -> void:
 				world != null, "%s: map %d/%d did not open." % [game_id, map.group, map.number]
 			):
 				continue
-			world.player_facing = world._facing_for_direction(direction)
+			world.player_facing = world.facing_for_direction(direction)
 			_r.check(
 				not world.warp_pending(cell),
 				"%s: map %d/%d %s warps on the step that lands on it." % [

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -41,6 +41,11 @@ extends SceneTree
 ## `door` (`.CheckWarp`'s carpet: the player is walked down onto an interior
 ## door's mat and photographed standing on it, which the step itself no longer
 ## warps: `crystal 24 6 ... door 6 5` is the front door of the player's house),
+## `ice_slide` (`DoPlayerMovement.CheckForced`'s run: the player is walked in
+## one direction until the step lands on ice and the frames after that are the
+## slide's own, with nothing held, as `crystal 3 61 ... ice_slide@16,8 2 40`,
+## whose first number is the direction in down, up, left, right order and whose
+## second is how many of the slide's frames to spend),
 ## `ledge` (the ledge hop at the top of its arc, walking south from the cell the
 ## two numbers name until one allows the hop: `crystal 24 4 ... ledge 5 4`),
 ## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
@@ -85,6 +90,11 @@ extends SceneTree
 ## map and the cell below their target. The two numbers are the cell
 ## the player stands on, which is how the grass a standing object is drawn behind
 ## is photographed.
+
+## `.forced_dpad`'s own order, which the first number indexes.
+const ICE_SLIDE_BUTTONS: Array[int] = [
+	Gen2Button.DOWN, Gen2Button.UP, Gen2Button.LEFT, Gen2Button.RIGHT,
+]
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## What the live mode actually opens in, which a phone-shaped argument replaces.
@@ -232,7 +242,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	elif cell.x >= 0 and _kind not in [
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
 		&"move_deleter", &"move_tutor", &"day_care", &"unown_puzzle", &"slot_machine",
-		&"card_flip", &"tile_anim",
+		&"card_flip", &"tile_anim", &"ice_slide",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -465,6 +475,21 @@ func _process(_delta: float) -> bool:
 				_screen.advance_frame()
 				if _screen.player_height_offset_pixels() >= LEDGE_ARC_TOP:
 					break
+		elif _kind == &"ice_slide":
+			## `DoPlayerMovement.CheckForced`: one press starts the run and the
+			## frames after it are the slide's own, since nothing is held. The
+			## first number is the direction in `.forced_dpad` order, down, up,
+			## left, right, and the second how many frames to spend after the
+			## press; the cell goes in `ice_slide@x,y`
+			## (`crystal 3 61 ... ice_slide@11,29 3 40`).
+			var slide_button: int = ICE_SLIDE_BUTTONS[posmod(maxi(_cell.x, 0), 4)]
+			for _press: int in WARP_FRAME_CAP:
+				if _screen.standing_on_ice():
+					break
+				_screen.press_button(slide_button)
+				_screen.advance_frame()
+			for _spent: int in maxi(_cell.y, 0):
+				_screen.advance_frame()
 		elif _kind == &"map_name_sign":
 			## `MapSetupScript_Connection`'s `InitMapNameSign`: walked west off
 			## New Bark Town's edge onto Route 29, photographed while the sign
@@ -495,7 +520,7 @@ func _process(_delta: float) -> bool:
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
 			&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-			&"move_deleter", &"move_tutor", &"day_care",
+			&"move_deleter", &"move_tutor", &"day_care", &"ice_slide",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -23,7 +23,8 @@ const GROUPS: Dictionary = {
 		&"field_move_prompts",
 	],
 	&"terrain": [
-		&"ledge_hops", &"side_walls", &"drawn_blocks", &"story_map_ids", &"map_data",
+		&"ledge_hops", &"ice_slides", &"side_walls", &"drawn_blocks", &"story_map_ids",
+		&"map_data",
 	],
 	&"johto": [
 		&"radio_tower", &"rising_badge", &"command_queues", &"item_balls",


### PR DESCRIPTION
The player never slid on ice. The Ice Path and Mahogany Gym were walkable a cell at a time.

`wPlayerTurningDirection` is what the routine hangs on, and its name is what makes it hard to read. `.DoStep` writes `$80 | direction` on every commit, a walk, a jump and a turn alike. Only `.StandInPlace`, `._WalkInPlace`, `StopPlayerForEvent` and `RefreshPlayerSprite` clear it. Three rules read the byte, and none of them was modelled here.

`CheckStandingOnIce` refuses when the byte is zero. So standing on ice is not enough: a step has to have been taken. `.CheckForced` then ORs that direction back into `wCurInput`, and the walk carries on with nothing held until a refused step clears the byte.

The OR is not a replacement. Both bits can be set, and `.GetAction`'s own test order decides: down, up, left, right. A slide running right obeys a held DOWN. A slide running down does not obey a held UP.

`.CheckTurning`'s first test is the same byte, so the tap-to-turn only happens from a standstill. A walk around a corner used to spend a turn here. It no longer does.

`OWPlayerInput` puts `CheckStandingOnIce` in front of `CheckAPressOW` and `CheckMenuOW`, so A, START and SELECT are refused while a slide runs. The d-pad is not, because `DoPlayerMovement` has already read it.

`cp $f0` is dead in both pins, and so is `PLAYER_SKATE`: nothing writes either. The ice collision codes are the whole test.

## What it is checked against

| Artefact | Result |
|---|---|
| `tools/checks/ice_slides.gd`, whole corpus, three cartridges | 779 ice cells over 5 maps on Crystal, 775 over 5 on Gold and Silver; 8,041 slides, each ending against a wall or off the ice |
| GUT, unit tier | 3,048 passing |
| GUT, scene tier | 3,509 passing |
| `tools/validate.gd -- all` | 66 topics passing |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| story walk, three profiles | 130 steps, all ok |

`tools/preview_world.gd` gains an `ice_slide` kind, so any frame of a run can be photographed:

    crystal 3 61 out.png live ice_slide@16,8 2 40

Also here: the world screen kept a second copy of `facing_for_direction`. It uses the world's now.