### PR TITLE
Fill the window with the map instead of framing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   service overlay (marts, Kurt's errand, phone dispatch, music and cries).
 >   Everything the overworld times is a hardware frame count spent by one clock,
 >   so a seed, an input log and a frame number reproduce a walk exactly.
+> - **A screen that fills the window.** The map is drawn past the Game Boy's
+>   160x144 to whatever shape the window is, with the connected maps around it
+>   drawn seamlessly and no black bars. Zoom out far enough and a region is on
+>   screen at once. See [Screen fill](#screen-fill).
 > - **Saves.** Three slots, `.sav` import, and a 14-box PC with 20 slots a box.
 >   Every party transaction commits through a validated candidate save.
 > - **Mods.** A mod under `user://mods/` can add or rebalance content, register
@@ -174,6 +178,30 @@ arrange them separately for upright and sideways. Three quick taps brings them
 back. The screen fills whatever window or device it is given, in either
 orientation.
 
+### Screen fill
+
+A window is not the Game Boy's 10:9, and the black bars around a framed screen
+are room the overworld can draw into. Settings > Application > Screen offers
+two answers:
+
+| Screen | What it draws |
+|---|---|
+| Fill (default) | The map covers the whole window at any shape, and the maps connected to this one are drawn around it |
+| Framed | The 160x144 screen at a whole scale, centred, with black bars, as the hardware had |
+
+Everything laid out on the screen -- text boxes, menus, the start menu, the
+cursor -- stays inside the 160x144 rectangle in the middle of it, exactly where
+the cartridge put it. Only the surround grows.
+
+While walking, `+` and `-` zoom, `0` returns to the fitting scale, and the mouse
+wheel does the same. Zooming out past one screen pixel per map pixel is a survey
+of the region: the connection graph places the maps around this one and the map
+header's own border block fills what no map covers. The maps around you are a
+picture. Their people stand where their map puts them and nothing else about
+them runs: no scripts, no walking, no wild encounters, no collision. Only the map
+you are on is live, exactly as on the cartridge, where a connected map is three
+blocks of scenery copied into the buffer and nothing more.
+
 Development shortcuts are debug-build only, along with the map and cell readout:
 
 | Scene | Keys |
@@ -182,6 +210,9 @@ Development shortcuts are debug-build only, along with the map and cell readout:
 | `game/render/text_viewer.tscn` | Space advances, `F` cycles borders, `C` shows every glyph |
 | `game/battle/battle_screen.tscn` | `T` turn, A advances, `Y` switch, `R` run, `[`/`]` matchup, `G`/`H` damage; in wild battles B opens the ball selector |
 | `game/world/world_screen.tscn` | `F` fishes with an owned rod, `1`/`2`/`3` pick a rod, `P` opens the phone, `V` cycles views, F5 writes a snapshot |
+
+Zoom is not one of these: `+`, `-` and `0` are player controls and work in a
+release export.
 
 A release export offers the eight buttons and nothing else. The method behind
 each shortcut stays public, which is how `tools/preview_*.gd` drives them.

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -89,6 +89,18 @@ func _build() -> void:
 			_options.video_mode = Gen2Options.VIDEO_MODES[index]
 			_persist()
 	)))
+	app.add_child(Gen2LauncherUI.field(_theme, "Screen", Gen2LauncherUI.segmented(
+		_theme, ["Framed", "Fill"], 1 if _options.screen_fill else 0,
+		func(index: int) -> void:
+			_options.screen_fill = index == 1
+			_persist()
+	)))
+	app.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"Fill gives the overworld the whole window instead of black bars, drawing "
+		+ "the connected maps around this one. Menus and boxes stay where the "
+		+ "hardware put them. Zoom with + and - while walking."
+	))
 	app.add_child(Gen2LauncherUI.field(_theme, "Game speed", Gen2LauncherUI.segmented(
 		_theme, _titles(Gen2Options.GAME_SPEEDS),
 		maxi(Gen2Options.GAME_SPEEDS.find(_options.game_speed), 0),

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -76,6 +76,14 @@ var fast_text_delay: bool = true
 var music_volume: int = 7
 var sfx_volume: int = 7
 var video_mode: StringName = &"windowed"
+## SCREEN FILL. The window is not the Game Boy's 10:9 and the black bars around
+## a framed screen are room the overworld can draw map into, so the buffer grows
+## to the window instead ([member Gen2Screen.expanded]). Interface stays inside
+## the 160x144 rectangle centred in it, so nothing the cartridge laid out moves.
+var screen_fill: bool = true
+## Whole steps of zoom away from the fitting scale, kept between sessions
+## because it is a view preference rather than part of a run.
+var zoom_step: int = 0
 var max_fps: int = 60
 var game_speed: StringName = &"normal"
 var ui_theme: StringName = &"light"
@@ -182,6 +190,8 @@ func to_dict() -> Dictionary:
 		"music_volume": music_volume,
 		"sfx_volume": sfx_volume,
 		"video_mode": String(video_mode),
+		"screen_fill": screen_fill,
+		"zoom_step": zoom_step,
 		"max_fps": max_fps,
 		"game_speed": String(game_speed),
 		"ui_theme": String(ui_theme),
@@ -215,6 +225,8 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.music_volume = clampi(int(row.get("music_volume", 7)), 0, MAX_VOLUME)
 	options.sfx_volume = clampi(int(row.get("sfx_volume", 7)), 0, MAX_VOLUME)
 	options.video_mode = _one_of(row.get("video_mode", ""), VIDEO_MODES)
+	options.screen_fill = bool(row.get("screen_fill", true))
+	options.zoom_step = clampi(int(row.get("zoom_step", 0)), -32, 32)
 	options.game_speed = _one_of(row.get("game_speed", ""), GAME_SPEEDS)
 	options.ui_theme = _one_of(row.get("ui_theme", ""), UI_THEMES)
 	var fps: int = int(row.get("max_fps", 60))

--- a/game/render/game_frame.gd
+++ b/game/render/game_frame.gd
@@ -36,16 +36,30 @@ func _ready() -> void:
 			_pad = child
 	resized.connect(_relayout)
 	Gen2InputRuntime.instance().touch_controls_changed.connect(_on_touch_controls_changed)
+	if _screen != null:
+		# An expanded screen takes the whole portrait share rather than the 10:9
+		# rectangle in it, so the split has to be redone when it is switched on.
+		_screen.expanded_changed.connect(_on_screen_expanded_changed)
 	_relayout()
 
 
 ## The rectangle the hardware screen occupies, and the one left for the
 ## controller. Split out so a test can check both without a viewport.
-static func split(area: Vector2, controls_shown: bool) -> Dictionary:
+##
+## [param expanded] is a screen that fills whatever it is given
+## ([member Gen2Screen.expanded]): it is handed the whole share rather than the
+## 10:9 rectangle inside it, since the leftover would be void it could have
+## drawn map into.
+static func split(area: Vector2, controls_shown: bool, expanded: bool = false) -> Dictionary:
 	var landscape: bool = area.x >= area.y
 	if landscape or not controls_shown:
 		return {"screen": Rect2(Vector2.ZERO, area), "controls": Rect2(Vector2.ZERO, area)}
-	var offered := Vector2(area.x, area.y * (1.0 - PORTRAIT_CONTROL_SHARE))
+	var offered := Vector2(area.x, floorf(area.y * (1.0 - PORTRAIT_CONTROL_SHARE)))
+	if expanded:
+		return {
+			"screen": Rect2(Vector2.ZERO, offered),
+			"controls": Rect2(Vector2(0.0, offered.y), Vector2(area.x, area.y - offered.y)),
+		}
 	var drawn: Vector2 = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) \
 		* float(Gen2Screen.fit_factor(offered))
 	return {
@@ -59,7 +73,11 @@ static func split(area: Vector2, controls_shown: bool) -> Dictionary:
 func _relayout() -> void:
 	if size.x <= 0.0 or size.y <= 0.0:
 		return
-	var rects: Dictionary = split(size, Gen2InputRuntime.instance().touch_controls_shown())
+	var rects: Dictionary = split(
+		size,
+		Gen2InputRuntime.instance().touch_controls_shown(),
+		_screen != null and _screen.expanded,
+	)
 	if _screen != null:
 		var screen_rect: Rect2 = rects["screen"]
 		_screen.position = screen_rect.position
@@ -71,6 +89,10 @@ func _relayout() -> void:
 
 
 func _on_touch_controls_changed(_shown: bool) -> void:
+	_relayout()
+
+
+func _on_screen_expanded_changed(_expanded: bool) -> void:
 	_relayout()
 
 

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -11,26 +11,119 @@ extends Control
 ## [method display_native] is a second layer behind it, covering the same
 ## rectangle at window resolution, for a view that cannot be drawn into a 160x144
 ## buffer and magnified but still has to line up with the boxes above it.
+##
+## [member expanded] widens the buffer instead of framing it. The window is not
+## 10:9 and never was; the black bars are the shape of a screen this project can
+## draw past, so a view that asks for it is given a surface the size of the whole
+## control and fills it with more world. Interface is unmoved: [method display]
+## puts a screen inside a 160x144 rectangle centred in that surface, so every
+## box, menu and cursor is laid out exactly where the cartridge laid it out and
+## only the surround grows. [member zoom_step] is how many whole pixels a
+## hardware pixel is drawn as, counted from the largest that fits.
 
 const WIDTH: int = 160
 const HEIGHT: int = 144
+## Below one screen pixel per hardware pixel the picture is halved rather than
+## stepped, which is what puts a whole region in a window.
+const MIN_SCALE: float = 0.25
+## An expanded buffer grows by whole map blocks, so half the difference from the
+## hardware screen is always a whole tile and the interface rectangle inside it
+## lands on the grid every screen is laid out against.
+const BUFFER_STEP: int = 32
+## How far past the fitting scale a player may zoom out. Three steps reaches
+## MIN_SCALE from a 1x window, and the same three from any other.
+const ZOOM_OUT_STEPS: int = 3
 
 ## After a resize changes the factor. Nothing in the game should care.
 signal scale_changed(factor: int)
 ## After the native layer's rectangle changes; a view drawn there sizes to this.
 signal native_size_changed(size: Vector2i)
+## After the drawn buffer changes size, in hardware pixels. A view that fills it
+## reads this rather than assuming 160x144.
+signal view_size_changed(size: Vector2i)
+## After [member expanded] is switched, so the frame around the screen can hand
+## it a different rectangle.
+signal expanded_changed(expanded: bool)
 
 var scale_factor: int = 1
+## Whether the buffer grows to the control instead of being framed inside it.
+var expanded: bool = false:
+	set(value):
+		if expanded == value:
+			return
+		expanded = value
+		clip_contents = value
+		expanded_changed.emit(value)
+		_fit()
+## Whole steps away from the fitting scale, positive towards the player.
+var zoom_step: int = 0:
+	get:
+		return _zoom_step
+	set(value):
+		var stepped: int = clampi(value, _min_zoom_step(), _max_zoom_step())
+		if _zoom_step == stepped:
+			return
+		_zoom_step = stepped
+		_fit()
+
+var _zoom_step: int = 0
+
+## Whether everything outside the 160x144 rectangle is blacked out.
+##
+## A screen that owns the whole picture -- a battle, the pack, the PC -- is laid
+## out in 160x144 and has nothing to fill a wider buffer with. The surround
+## becomes the letterbox a framed screen has, rather than the map that screen is
+## standing in front of.
+var interface_masked: bool = false:
+	set(value):
+		if interface_masked == value:
+			return
+		interface_masked = value
+		if _mask != null:
+			_mask.visible = value
+
+## What [member interface_masked] paints with. The screen does not know what is
+## behind it, and a mask in a different colour from the bars a framed screen
+## leaves would read as a border rather than as the same letterbox; the scene
+## that owns the screen says which colour its own background is.
+var letterbox_color: Color = Color.BLACK:
+	set(value):
+		letterbox_color = value
+		if _mask != null:
+			_mask.queue_redraw()
+
+var _view_size: Vector2i = Vector2i(WIDTH, HEIGHT)
+var _draw_scale: float = 1.0
 
 @onready var _container: SubViewportContainer = %Container
 @onready var _viewport: SubViewport = %Viewport
 @onready var _native: Control = %Native
+## The 160x144 rectangle interface is laid out in, moved to the middle of a
+## wider buffer rather than the buffer's corner.
+var _interface: Control = null
+## Drawn between the content and the interface: see [member interface_masked].
+var _mask: Control = null
 
 
 func _ready() -> void:
 	# The viewport's size is the container's divided by the shrink factor, and
 	# writing it directly is refused at runtime.
 	resized.connect(_fit)
+	_mask = Control.new()
+	_mask.name = "Mask"
+	_mask.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_mask.visible = interface_masked
+	_mask.draw.connect(_draw_mask)
+	_viewport.add_child(_mask)
+	_interface = Control.new()
+	_interface.name = "Interface"
+	_interface.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_interface.size = Vector2(WIDTH, HEIGHT)
+	# The viewport used to be exactly the Game Boy screen and clipped anything
+	# drawn past it, which is a slide-in's own edge. An expanded buffer no longer
+	# does, so the rectangle it was clipped against does it instead.
+	_interface.clip_contents = true
+	_viewport.add_child(_interface)
 	_fit()
 
 
@@ -39,12 +132,15 @@ func _ready() -> void:
 ## Everything placed this way is interface, and sits above whatever
 ## [method display_content] put there, in the order it was placed.
 func display(node: Node) -> void:
-	_viewport.add_child(node)
+	_interface.add_child(node)
 
 
 ## Renderer content, in hardware pixels, kept below every node [method display]
 ## placed. A renderer rebuilt mid-screen would otherwise be appended after a live
 ## text box and paint over it.
+##
+## Its origin is the buffer's own, not the interface rectangle's, so a view that
+## fills an expanded screen draws over all of it.
 func display_content(node: Node) -> void:
 	_viewport.add_child(node)
 	_viewport.move_child(node, 0)
@@ -58,13 +154,52 @@ func display_native(node: Node) -> void:
 
 ## The native layer's rectangle in window pixels.
 func native_size() -> Vector2i:
-	return Vector2i(WIDTH * scale_factor, HEIGHT * scale_factor)
+	return Vector2i((Vector2(_view_size) * _draw_scale).round())
+
+
+## The drawn buffer in hardware pixels: 160x144 unless [member expanded].
+func view_size() -> Vector2i:
+	return _view_size
+
+
+## The largest whole number of window pixels per hardware pixel that fits.
+## Public because [Gen2GameFrame] sizes the on-screen controller off it.
+static func fit_factor(area: Vector2) -> int:
+	return maxi(1, mini(int(area.x) / WIDTH, int(area.y) / HEIGHT))
+
+
+## Screen pixels per hardware pixel at [param step] away from a fitting scale of
+## [param fit]. Whole numbers on the way in; on the way out the last three steps
+## halve instead, since one screen pixel per hardware pixel is as far as whole
+## numbers go and a survey of a region needs to be further out than that.
+static func scale_at(fit: int, step: int) -> float:
+	var raw: int = maxi(fit, 1) + step
+	if raw >= 1:
+		return float(raw)
+	return maxf(pow(0.5, float(1 - raw)), MIN_SCALE)
+
+
+## One step of zoom, reported as the scale it settled on. Refused unless the
+## screen is expanded: framed at 160x144 there is no more world to show and a
+## step would only shrink the picture.
+func step_zoom(delta: int) -> float:
+	if not expanded:
+		return _draw_scale
+	zoom_step = zoom_step + delta
+	return _draw_scale
+
+
+func reset_zoom() -> void:
+	zoom_step = 0
 
 
 ## Frees everything on screen, on both layers.
 func clear() -> void:
-	for parent: Node in [_viewport, _native]:
+	for parent: Node in [_interface, _native]:
 		for child: Node in parent.get_children():
+			drop(child)
+	for child: Node in _viewport.get_children():
+		if child != _interface:
 			drop(child)
 
 
@@ -100,23 +235,99 @@ func viewport() -> SubViewport:
 	return _viewport
 
 
-## The largest whole number of window pixels per hardware pixel that fits.
-## Public because [Gen2GameFrame] sizes the on-screen controller off it.
-static func fit_factor(area: Vector2) -> int:
-	return maxi(1, mini(int(area.x) / WIDTH, int(area.y) / HEIGHT))
+## The layer [method display] puts a screen on: the 160x144 rectangle, centred
+## in the buffer. For a caller that has to know where in the viewport the
+## interface sits, which is above whatever [method display_content] drew.
+func interface_layer() -> Control:
+	return _interface
+
+
+## The letterbox, drawn rather than left empty: four rectangles around the
+## 160x144 the interface is laid out in. Not a filled surface, because the
+## middle is not always the interface's -- a battle transition is the renderer's
+## own screen and has to stay visible inside it.
+func _draw_mask() -> void:
+	var inside := Rect2(_interface.position, Vector2(WIDTH, HEIGHT))
+	var whole := Vector2(_view_size)
+	for band: Rect2 in [
+		Rect2(Vector2.ZERO, Vector2(whole.x, inside.position.y)),
+		Rect2(Vector2(0.0, inside.end.y), Vector2(whole.x, whole.y - inside.end.y)),
+		Rect2(Vector2(0.0, inside.position.y), Vector2(inside.position.x, inside.size.y)),
+		Rect2(
+			Vector2(inside.end.x, inside.position.y),
+			Vector2(whole.x - inside.end.x, inside.size.y),
+		),
+	]:
+		if band.size.x > 0.0 and band.size.y > 0.0:
+			_mask.draw_rect(band, letterbox_color, true)
+
+
+func _min_zoom_step() -> int:
+	return 1 - fit_factor(size) - ZOOM_OUT_STEPS
+
+
+func _max_zoom_step() -> int:
+	return fit_factor(size)
+
+
+## The buffer a scale of [param scale] needs to cover [param area], rounded up
+## to a whole block on each axis past the hardware's own screen so the 160x144
+## interface rectangle lands on a whole tile.
+static func buffer_for(area: Vector2, scale: float) -> Vector2i:
+	var wanted := Vector2i(
+		maxi(ceili(area.x / maxf(scale, MIN_SCALE)), WIDTH),
+		maxi(ceili(area.y / maxf(scale, MIN_SCALE)), HEIGHT),
+	)
+	return Vector2i(
+		WIDTH + ceili(float(wanted.x - WIDTH) / float(BUFFER_STEP)) * BUFFER_STEP,
+		HEIGHT + ceili(float(wanted.y - HEIGHT) / float(BUFFER_STEP)) * BUFFER_STEP,
+	)
 
 
 func _fit() -> void:
 	var factor: int = fit_factor(size)
-	var drawn := Vector2(WIDTH * factor, HEIGHT * factor)
+	# A resize moves the fitting scale, so a step chosen against the old one can
+	# fall outside the ladder. Clamped on the field rather than through the
+	# property, which would come straight back into this.
+	_zoom_step = clampi(_zoom_step, _min_zoom_step(), _max_zoom_step())
+	var scale_now: float = scale_at(factor, _zoom_step) if expanded else float(factor)
+	var view: Vector2i = buffer_for(size, scale_now) if expanded \
+		else Vector2i(WIDTH, HEIGHT)
+	var drawn: Vector2 = Vector2(view) * scale_now
 
-	_container.stretch_shrink = factor
-	_container.size = drawn
+	# A whole-number scale keeps the proven shrink path, where the container is
+	# the drawn size and the viewport is that divided by the factor. Below one
+	# the shrink cannot express the ratio, so the container is the buffer and the
+	# texture is scaled down instead.
+	if scale_now >= 1.0 and is_equal_approx(scale_now, roundf(scale_now)):
+		_container.stretch_shrink = int(roundf(scale_now))
+		_container.scale = Vector2.ONE
+		_container.size = drawn
+	else:
+		_container.stretch_shrink = 1
+		_container.size = Vector2(view)
+		_container.scale = Vector2(scale_now, scale_now)
+	# Nearest is what keeps a hardware pixel a square block of screen pixels, and
+	# it is the wrong answer in the one place the picture is made smaller rather
+	# than larger: dropping three pixels in four turns a tree wall into moire.
+	_container.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST if scale_now >= 1.0 \
+		else CanvasItem.TEXTURE_FILTER_LINEAR
 	# Centred rather than anchored: an uneven margin is visible.
 	_container.position = ((size - drawn) * 0.5).floor()
 	_native.size = drawn
 	_native.position = _container.position
+	if _mask != null:
+		_mask.size = Vector2(view)
+		_mask.queue_redraw()
+	if _interface != null:
+		_interface.position = ((Vector2(view - Vector2i(WIDTH, HEIGHT)) * 0.5)
+			/ float(Gen2Tiles.TILE_WIDTH)).floor() * float(Gen2Tiles.TILE_WIDTH)
+		_interface.size = Vector2(WIDTH, HEIGHT)
 
+	_draw_scale = scale_now
+	if view != _view_size:
+		_view_size = view
+		view_size_changed.emit(view)
 	if factor != scale_factor:
 		scale_factor = factor
 		scale_changed.emit(factor)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -10,6 +10,19 @@ extends RefCounted
 const VIEW_CELLS: Vector2i = Vector2i(10, 9)
 const VIEW_TILES: Vector2i = VIEW_CELLS * RomLayout.MAP_BLOCK_CELL_WIDTH
 const CELL_PIXELS: int = Gen2Tiles.TILE_WIDTH * RomLayout.MAP_BLOCK_CELL_WIDTH
+## The screen the cartridge draws, in pixels: 160x144.
+const VIEW_PIXELS: Vector2i = VIEW_CELLS * CELL_PIXELS
+## `ChangeMap` copies a map into the middle of `wOverworldMapBlocks`, which is
+## three blocks wider than the map on every side (`home/map.asm`). That margin
+## is what a connection strip fills and what a 20x18 screen can reach at a map
+## edge; nothing past it exists on the cartridge at all.
+const BUFFER_BLOCKS: int = 3
+## How far [method map_placements] walks the connection graph, and how many maps
+## it may place. Three hops reaches the towns either side of the routes next to
+## this map, which is as much as the furthest zoom shows; the cap is what stops
+## a walk of the whole region on a map that has many ways out.
+const PLACEMENT_HOPS: int = 3
+const PLACEMENT_LIMIT: int = 24
 ## The overworld object coordinate used by the player sprite. The 20x18 screen
 ## is not symmetrically centred around a 16x16 object: the source loads four
 ## walk cells before the player on each axis (`_LoadOverworldTilemap`).
@@ -216,6 +229,19 @@ var _object_facing_overrides: Dictionary = {}
 var _object_followers: Dictionary = {}
 var _variable_sprites: Dictionary = {}
 var _block_overrides: Dictionary = {}
+## [method map_placements], built on first use and dropped with the map it is
+## measured from.
+var _map_placements: Dictionary = {}
+## [method connected_map_objects], built and dropped beside the placements.
+var _connected_objects: Array = []
+## Bumped whenever a `changeblock` or a map load moves a block byte, so a view
+## that caches the block buffer knows when to read it again.
+var block_revision: int = 0
+## The drawn surface in hardware pixels, which is [constant VIEW_PIXELS] unless
+## a view has asked for more. The extra is spread evenly around the screen the
+## cartridge would have drawn, so the player keeps the place
+## [constant PLAYER_VIEW_CELL] puts him in and only the surround grows.
+var view_pixels: Vector2i = VIEW_PIXELS
 ## A resolved but uncommitted Cut, held between cut_request() and complete_cut()
 ## the way Script_Cut holds wCutWhirlpool* across its writetext. Cleared with the
 ## block overrides, since the block it names belongs to the loaded map.
@@ -425,6 +451,9 @@ func _init(
 	inventory = Gen2WorldInventory.new(data, state)
 	state.ensure_roaming_mons(data.world_roaming_mons())
 	current_map = map
+	_map_placements = {}
+	_connected_objects = []
+	block_revision += 1
 	current_tileset = tileset
 	player_cell = _clamp_cell(start_cell)
 	# Opening a world is `StartMap`, which falls into `EnterMap`: the five-step
@@ -679,6 +708,13 @@ func visible_origin_cells() -> Vector2:
 	return player_position_cells() - _camera_lag_cells - Vector2(PLAYER_VIEW_CELL)
 
 
+## The drawn surface's top-left in world pixels, which is
+## [method visible_origin_cells] for a hardware-sized view.
+func view_origin_pixels() -> Vector2:
+	return visible_origin_cells() * float(CELL_PIXELS) \
+		- Vector2(view_pixels - VIEW_PIXELS) * 0.5
+
+
 ## The player's screen pixel, which is PLAYER_VIEW_CELL plus whatever hSCX/hSCY
 ## have not caught up with: `ScrollScreen` sits after `NextOverworldFrame` in
 ## `HandleMapBackground`, so the scroll a pass computed is written two frames
@@ -688,6 +724,13 @@ func player_pixel_position() -> Vector2i:
 	return Vector2i(
 		(player_position_cells() - visible_origin_cells()) * float(CELL_PIXELS)
 	)
+
+
+## The player's pixel inside the drawn surface, which is
+## [method player_pixel_position] plus half of whatever surround a view wider
+## than the hardware's added. The two are the same value on a 160x144 view.
+func player_view_pixel() -> Vector2i:
+	return player_pixel_position() + (view_pixels - VIEW_PIXELS) / 2
 
 
 func player_step_in_progress() -> bool:
@@ -2578,6 +2621,12 @@ func set_object_time(hour: int, time_of_day: int) -> void:
 			object.active = bool(_object_visibility_overrides[key])
 		if object.deleted:
 			object.active = false
+	## `CheckObjectTime` runs from the clock callback for whatever is on the
+	## screen, and these are on it.
+	for entry: Dictionary in _connected_objects:
+		var neighbour: Gen2WorldObject = entry["object"]
+		neighbour.active = neighbour.visible_at(object_hour, object_time_of_day) \
+			and not neighbour.flag_hidden
 
 
 func set_event_flag(flag: int, active: bool = true) -> void:
@@ -2652,6 +2701,7 @@ func change_block(block_x: int, block_y: int, block: int) -> Dictionary:
 		_block_overrides.erase(key)
 	else:
 		_block_overrides[key] = block
+	block_revision += 1
 	return {
 		"ok": true,
 		"kind": &"block_change",
@@ -2817,6 +2867,117 @@ func drawn_block_at(block_x: int, block_y: int) -> int:
 	return drawn_block_for(data, current_map, block_x, block_y, _block_overrides)
 
 
+## [method drawn_block_at] for a view wider than the hardware's own.
+##
+## Inside `wOverworldMapBlocks` this is [method drawn_block_at] byte for byte,
+## so nothing a 20x18 screen can reach changes. Past it the cartridge holds
+## nothing at all, and a view that reaches further would show border block to
+## the horizon; the connection graph places whole neighbouring maps there
+## instead ([method map_placements]), and the border block still fills what no
+## map covers.
+func expanded_block_at(block_x: int, block_y: int) -> int:
+	if current_map == null:
+		return 0
+	if in_hardware_buffer(current_map, block_x, block_y):
+		return drawn_block_at(block_x, block_y)
+	for placement: Dictionary in map_placements().values():
+		var map: Gen2WorldMap = placement["map"]
+		var origin: Vector2i = placement["origin"]
+		var local := Vector2i(block_x - origin.x, block_y - origin.y)
+		if local.x < 0 or local.y < 0 \
+			or local.x >= map.width_blocks or local.y >= map.height_blocks:
+			continue
+		var block: int = _overridden_block_at(map, local.x, local.y, _block_overrides)
+		return map.border_block if block == 0 else block
+	return current_map.border_block
+
+
+## Whether a block coordinate is one `ChangeMap` writes: the map's own blocks
+## plus the three-block margin around them.
+static func in_hardware_buffer(map: Gen2WorldMap, block_x: int, block_y: int) -> bool:
+	if map == null:
+		return false
+	return block_x >= -BUFFER_BLOCKS and block_y >= -BUFFER_BLOCKS \
+		and block_x < map.width_blocks + BUFFER_BLOCKS \
+		and block_y < map.height_blocks + BUFFER_BLOCKS
+
+
+## Every map the connection graph reaches from the current one, keyed
+## `"group:number"`, each with its origin in the current map's block
+## coordinates. The current map is not in it: it is the origin.
+##
+## Built once per map load and kept, since the graph is header data and nothing
+## a run does moves a map. Ordered nearest first, so a caller that draws them in
+## order draws the far ones under the near ones.
+func map_placements() -> Dictionary:
+	if _map_placements.is_empty() and current_map != null:
+		_map_placements = placements_around(data, current_map)
+	return _map_placements
+
+
+## [method map_placements] for a map that is not the loaded one, which is what a
+## test and the importer's own checks have.
+static func placements_around(
+	data_source: GameData, map: Gen2WorldMap, hops: int = PLACEMENT_HOPS
+) -> Dictionary:
+	var out: Dictionary = {}
+	if data_source == null or map == null:
+		return out
+	var root: String = "%d:%d" % [map.group, map.number]
+	var placed: Dictionary = {root: Vector2i.ZERO}
+	var queue: Array = [{"map": map, "origin": Vector2i.ZERO, "hops": 0}]
+	var at: int = 0
+	while at < queue.size() and out.size() < PLACEMENT_LIMIT:
+		var entry: Dictionary = queue[at]
+		at += 1
+		var source: Gen2WorldMap = entry["map"]
+		if int(entry["hops"]) >= hops:
+			continue
+		for connection: Dictionary in source.connections:
+			var target: Gen2WorldMap = data_source.world_map(
+				int(connection.get("map_group", -1)),
+				int(connection.get("map_number", -1)),
+			)
+			if target == null:
+				continue
+			var key: String = "%d:%d" % [target.group, target.number]
+			if placed.has(key):
+				continue
+			var origin: Vector2i = (entry["origin"] as Vector2i) + connection_origin_blocks(
+				source, target, connection
+			)
+			placed[key] = origin
+			out[key] = {"map": target, "origin": origin}
+			queue.append({"map": target, "origin": origin, "hops": int(entry["hops"]) + 1})
+	return out
+
+
+## Where [param target] sits, in [param source]'s block coordinates, for a
+## connection running [param direction] out of [param source].
+##
+## The four cases are `_connected_drawn_block_at`'s own arithmetic read the
+## other way round: it takes a padding block to a cell of the target, and this
+## takes the target's own origin to a block of the source. Both come from
+## `FillMapConnections`' pointer sums, and having them in one place is what
+## keeps a strip and the map behind it from disagreeing by a block.
+static func connection_origin_blocks(
+	source: Gen2WorldMap, target: Gen2WorldMap, connection: Dictionary
+) -> Vector2i:
+	## The macro stores the offset in cells, and every strip lookup halves it.
+	var along_x: int = -floori(float(int(connection.get("x_offset", 0))) / 2.0)
+	var along_y: int = -floori(float(int(connection.get("y_offset", 0))) / 2.0)
+	match String(connection.get("direction", "")):
+		"north":
+			return Vector2i(along_x, -target.height_blocks)
+		"south":
+			return Vector2i(along_x, source.height_blocks)
+		"west":
+			return Vector2i(-target.width_blocks, along_y)
+		"east":
+			return Vector2i(source.width_blocks, along_y)
+	return Vector2i.ZERO
+
+
 ## The same fold for a map that is not the loaded one, which is what a battle
 ## staged on a map has: [Gen2BattleWorldContext] names the map and hands over no
 ## world, deliberately, so there is no `current_map` to read.
@@ -2869,22 +3030,11 @@ static func _connected_drawn_block_at(
 		)
 		if target == null:
 			continue
-		var target_cell := Vector2i(block_x, block_y)
-		match direction:
-			"north":
-				target_cell.x += floori(float(int(connection.get("x_offset", 0))) / 2.0)
-				target_cell.y += target.height_blocks
-			"south":
-				target_cell.x += floori(float(int(connection.get("x_offset", 0))) / 2.0)
-				target_cell.y -= map.height_blocks
-			"west":
-				target_cell.x += target.width_blocks
-				target_cell.y += floori(float(int(connection.get("y_offset", 0))) / 2.0)
-			"east":
-				target_cell.x -= map.width_blocks
-				target_cell.y += floori(float(int(connection.get("y_offset", 0))) / 2.0)
-			_:
-				continue
+		## The strip's own arithmetic is [method connection_origin_blocks] read
+		## the other way round: that places the target's origin in this map's
+		## blocks, and this takes a padding block to a cell of the target.
+		var target_cell: Vector2i = Vector2i(block_x, block_y) \
+			- connection_origin_blocks(map, target, connection)
 		if target_cell.x < 0 or target_cell.y < 0 \
 			or target_cell.x >= target.width_blocks or target_cell.y >= target.height_blocks:
 			continue
@@ -5401,6 +5551,7 @@ func _apply_map(
 	## connection reaches it, so a slide never survives a map change.
 	_stand_in_place()
 	_block_overrides.clear()
+	block_revision += 1
 	_pending_cut.clear()
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
@@ -5431,6 +5582,9 @@ func _apply_map(
 	# or a town puts the light out, and a cave to cave doorway does not.
 	state.clear_flash_if_outdoors(target_map.environment)
 	current_map = target_map
+	_map_placements = {}
+	_connected_objects = []
+	block_revision += 1
 	current_tileset = target_tileset
 	player_cell = _clamp_cell(target_cell)
 	# RefreshPlayerSprite calls CheckWarpFacingDown, then applies a scripted
@@ -6066,6 +6220,7 @@ func reload_current_map() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return {"ok": false, "reason": &"missing_map"}
 	_block_overrides.clear()
+	block_revision += 1
 	_pending_cut.clear()
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
@@ -6088,6 +6243,68 @@ func _on_world_state_changed() -> void:
 	set_object_time(object_hour, object_time_of_day)
 
 
+## One row of a map's object events as a live object.
+##
+## `GetMonSprite`'s `.Variable` branch reads wVariableSprites and falls through
+## to `.NoBreedmon` on a zero slot, whose `ld a, WALKING_SPRITE` is 1 and so
+## `SPRITE_CHRIS` by coincidence of two constant lists
+## (engine/overworld/overworld.asm). So an object whose variable sprite no
+## script has assigned yet is drawn, occupies its cell and is talkable.
+## Copycat's House 2F is where it matters: SPRITE_COPYCAT is $fb and only the
+## Copycat's own script assigns it, so without this she could not be reached to
+## run it. An object that should not be there at all is masked by
+## [method load_object_masks], not by this fallback.
+func _object_from_event(index: int, value: Dictionary) -> Gen2WorldObject:
+	var source_sprite_number: int = int(value.get("sprite", 0))
+	var sprite_number: int = int(_variable_sprites.get(
+		source_sprite_number, source_sprite_number
+	))
+	if sprite_number >= Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE:
+		sprite_number = SPRITE_CHRIS
+	var sprite: Gen2WorldSprite = null
+	var icon_number: int = Gen2WorldSprite.mon_icon_for_sprite(sprite_number)
+	if icon_number > 0:
+		sprite = data.overworld_icon(icon_number)
+	else:
+		sprite = data.overworld_sprite(sprite_number)
+	var object_event: Dictionary = value.duplicate(true)
+	object_event["sprite"] = sprite_number
+	return Gen2WorldObject.from_event(index, object_event, sprite)
+
+
+## The people standing on the maps [method map_placements] puts around this one,
+## for a view wide enough to see them.
+##
+## Deliberately not part of [member objects]: `ReadObjectEvents` fills
+## `wMapObjects` from the loaded map alone, so on the cartridge a connected
+## map's people do not exist until its own map load builds them. These take no
+## step, run no script, answer no collision and are not talked to. They stand
+## where their map's event data puts them, which is what a town seen from the
+## route next to it looks like.
+##
+## Each entry is `{"object": Gen2WorldObject, "offset": Vector2i}`, the offset
+## being the map's own origin in walk cells.
+func connected_map_objects() -> Array:
+	if not _connected_objects.is_empty() or current_map == null or data == null:
+		return _connected_objects
+	for placement: Dictionary in map_placements().values():
+		var map: Gen2WorldMap = placement["map"]
+		var offset: Vector2i = (placement["origin"] as Vector2i) \
+			* RomLayout.MAP_BLOCK_CELL_WIDTH
+		var rows: Array = map.events.get("objects", [])
+		for index: int in rows.size():
+			var object: Gen2WorldObject = _object_from_event(index, rows[index])
+			if object.sprite == null:
+				continue
+			object.flag_hidden = object.event_flag_active(state)
+			object.active = object.visible_at(object_hour, object_time_of_day) \
+				and not object.flag_hidden
+			if not object.active:
+				continue
+			_connected_objects.append({"object": object, "offset": offset})
+	return _connected_objects
+
+
 ## [param carry_presentation] keeps the live emote and movement trail of the
 ## records being replaced, for the reloads that happen inside one visit to a map
 ## rather than on the way into it. See Gen2WorldObject.carry_presentation_from().
@@ -6098,31 +6315,7 @@ func _load_objects(carry_presentation: bool = false) -> void:
 		return
 	var rows: Array = current_map.events.get("objects", [])
 	for index: int in rows.size():
-		var value: Dictionary = rows[index]
-		var source_sprite_number: int = int(value.get("sprite", 0))
-		var sprite_number: int = int(_variable_sprites.get(
-			source_sprite_number, source_sprite_number
-		))
-		## `GetMonSprite`'s `.Variable` branch reads wVariableSprites and falls
-		## through to `.NoBreedmon` on a zero slot, whose `ld a, WALKING_SPRITE`
-		## is 1 and so `SPRITE_CHRIS` by coincidence of two constant lists
-		## (engine/overworld/overworld.asm). So an object whose variable sprite
-		## no script has assigned yet is drawn, occupies its cell and is
-		## talkable. Copycat's House 2F is where it matters: SPRITE_COPYCAT is
-		## $fb and only the Copycat's own script assigns it, so without this she
-		## could not be reached to run it. An object that should not be there at
-		## all is masked by [method load_object_masks], not by this fallback.
-		if sprite_number >= Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE:
-			sprite_number = SPRITE_CHRIS
-		var sprite: Gen2WorldSprite = null
-		var icon_number: int = Gen2WorldSprite.mon_icon_for_sprite(sprite_number)
-		if icon_number > 0:
-			sprite = data.overworld_icon(icon_number)
-		else:
-			sprite = data.overworld_sprite(sprite_number)
-		var object_event: Dictionary = value.duplicate(true)
-		object_event["sprite"] = sprite_number
-		var object: Gen2WorldObject = Gen2WorldObject.from_event(index, object_event, sprite)
+		var object: Gen2WorldObject = _object_from_event(index, rows[index])
 		var key: String = _object_key(current_map.group, current_map.number, index)
 		if _object_position_overrides.has(key):
 			object.cell = _object_position_overrides[key]

--- a/game/world/world_map_layer.gd
+++ b/game/world/world_map_layer.gd
@@ -1,0 +1,138 @@
+class_name Gen2WorldMapLayer
+extends Node2D
+
+## One map's blocks, drawn as a single quad.
+##
+## `LoadMetatiles` resolves a block byte to sixteen graphics tiles every time it
+## refreshes the screen, and the renderer used to do the same on the CPU: one
+## draw per 8x8 tile, 380 of them for a hardware screen. A view that fills the
+## window at one pixel per world pixel wants tens of thousands, and a view that
+## takes in a whole region wants hundreds of thousands, which no per-tile loop
+## reaches at sixty frames a second.
+##
+## So the fold moves to the GPU. The block buffer, the tileset's metatile table
+## and the coloured tile strip go across as three byte textures and the fragment
+## shader does exactly what [method Gen2WorldAPI.drawn_block_at] does: block
+## byte, `$00` to the map's border block, metatile slot, tile, pixel. Nothing is
+## baked, so the strip the animation and the map fades already repaint is the
+## one this samples and neither needs a second path.
+##
+## Drawn behind its parent, so the renderer's own sprites stay above the map.
+
+## The three lookups a tile costs, in one pass. `map_blocks` of zero is the void
+## fill: every block is the border block, which is what surrounds a map on the
+## cartridge and what fills the window past the last connected map here.
+const MAP_SHADER: String = """
+shader_type canvas_item;
+render_mode unshaded;
+
+uniform sampler2D atlas : filter_nearest, repeat_disable;
+uniform sampler2D blocks : filter_nearest, repeat_disable;
+uniform sampler2D block_tiles : filter_nearest, repeat_disable;
+uniform highp vec2 map_blocks = vec2(0.0, 0.0);
+uniform highp vec2 view_origin = vec2(0.0, 0.0);
+uniform highp float border_block = 0.0;
+uniform highp float block_count = 1.0;
+uniform highp float tile_count = 1.0;
+uniform bool fill_border = false;
+
+varying highp vec2 local_pos;
+
+void vertex() {
+	local_pos = VERTEX;
+}
+
+void fragment() {
+	highp vec2 world = floor(local_pos + view_origin);
+	highp vec2 at = floor(world / 32.0);
+	highp float block = border_block;
+	if (at.x >= 0.0 && at.y >= 0.0 && at.x < map_blocks.x && at.y < map_blocks.y) {
+		block = floor(texture(blocks, (at + 0.5) / max(map_blocks, vec2(1.0))).r * 255.0 + 0.5);
+		if (block < 0.5) {
+			block = border_block;
+		}
+	} else if (!fill_border) {
+		discard;
+	}
+	highp vec2 inside = world - at * 32.0;
+	highp vec2 cell = floor(inside / 8.0);
+	highp float slot = cell.y * 4.0 + cell.x;
+	highp float tile = floor(texture(block_tiles,
+		vec2((slot + 0.5) / 16.0, (block + 0.5) / max(block_count, 1.0))).r * 255.0 + 0.5);
+	highp vec2 pixel = inside - cell * 8.0;
+	COLOR = texture(atlas, vec2((tile * 8.0 + pixel.x + 0.5) / max(tile_count * 8.0, 1.0),
+		(pixel.y + 0.5) / 8.0));
+}
+"""
+
+## One compiled program for every layer: the uniforms differ per map, the code
+## never does.
+static var _shader: Shader = null
+
+var _material := ShaderMaterial.new()
+var _quad := Rect2()
+
+
+func _init() -> void:
+	show_behind_parent = true
+	if _shader == null:
+		_shader = Shader.new()
+		_shader.code = MAP_SHADER
+	_material.shader = _shader
+	material = _material
+
+
+## [param blocks] is one byte per block in row-major order, [param block_tiles]
+## the tileset's own sixteen-bytes-a-block metatile table, and [param atlas] the
+## coloured tile strip the renderer already keeps.
+func configure(
+	atlas: Texture2D,
+	blocks: Texture2D,
+	block_tiles: Texture2D,
+	map_blocks: Vector2i,
+	border_block: int,
+	block_count: int,
+	tile_count: int,
+	fill_border: bool,
+) -> void:
+	_material.set_shader_parameter(&"atlas", atlas)
+	_material.set_shader_parameter(&"blocks", blocks)
+	_material.set_shader_parameter(&"block_tiles", block_tiles)
+	_material.set_shader_parameter(&"map_blocks", Vector2(map_blocks))
+	_material.set_shader_parameter(&"border_block", float(border_block))
+	_material.set_shader_parameter(&"block_count", float(maxi(block_count, 1)))
+	_material.set_shader_parameter(&"tile_count", float(maxi(tile_count, 1)))
+	_material.set_shader_parameter(&"fill_border", fill_border)
+
+
+## Where the quad goes on screen and which world pixel its own origin is.
+## [param origin] is zero for a map, whose quad starts at its own first block,
+## and the camera's own 32-pixel phase for the void fill, which is one quad over
+## the whole view rather than a map.
+func place(at: Vector2, size: Vector2, origin: Vector2 = Vector2.ZERO) -> void:
+	position = at
+	_material.set_shader_parameter(&"view_origin", origin)
+	if _quad.size != size:
+		_quad = Rect2(Vector2.ZERO, size)
+		queue_redraw()
+
+
+func _draw() -> void:
+	if _quad.size.x <= 0.0 or _quad.size.y <= 0.0:
+		return
+	draw_rect(_quad, Color.WHITE, true)
+
+
+## The block buffer as a byte texture. [param bytes] is one block per byte in
+## row-major order and is padded rather than refused: a short cache row draws as
+## the map's border block, which is what the missing blocks would be.
+static func block_texture(bytes: PackedByteArray, size: Vector2i) -> ImageTexture:
+	if size.x <= 0 or size.y <= 0:
+		return null
+	var padded: PackedByteArray = bytes
+	if padded.size() != size.x * size.y:
+		padded = bytes.duplicate()
+		padded.resize(size.x * size.y)
+	return ImageTexture.create_from_image(
+		Image.create_from_data(size.x, size.y, false, Image.FORMAT_R8, padded)
+	)

--- a/game/world/world_map_layer.gd.uid
+++ b/game/world/world_map_layer.gd.uid
@@ -1,0 +1,1 @@
+uid://lbd1tiff6oj1

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -4,6 +4,12 @@ extends Node2D
 ## Draws the visible map page and the development player marker in hardware
 ## pixels. It does not own map state; call [method set_world] when the API
 ## changes or [method refresh] after a movement.
+##
+## The surface is the cartridge's 160x144 unless the world has been given a
+## larger [member Gen2WorldAPI.view_pixels], in which case the map fills all of
+## it: the connected maps the graph places around this one are drawn as well, on
+## [Gen2WorldMapLayer] quads under the sprites, and the border block fills
+## whatever no map covers.
 
 const PLAYER_COLOR: Color = Color("#d34a5a")
 const FALLBACK_BACKGROUND: Color = Color("#f5f1d8")
@@ -27,6 +33,20 @@ var _encounters: Gen2WorldEncounters = null
 var _anim_textures: Dictionary = {}
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var _atlas: ImageTexture = null
+## The coloured tile strips in use this frame, keyed by the pair that chooses
+## their colours: see [method _atlas_for]. The current map's is [member _atlas].
+var _atlases: Dictionary = {}
+## The map quads, in draw order: the void fill, each connected map, then this
+## map's own block buffer. Pooled rather than rebuilt, since the camera moves
+## every frame and nothing about a quad but its position does.
+var _map_layers: Array[Gen2WorldMapLayer] = []
+var _block_textures: Dictionary = {}
+var _tiles_textures: Dictionary = {}
+## `wOverworldMapBlocks` itself: the map plus the three-block margin
+## `ChangeMap` leaves, resolved through [method Gen2WorldAPI.drawn_block_at] so
+## the connection strips in it are the cartridge's own.
+var _buffer_texture: ImageTexture = null
+var _buffer_revision: int = -1
 ## Kept beside the texture so an animation frame can repaint the one or two
 ## tiles it rewrote instead of recolouring the whole strip.
 var _atlas_image: Image = null
@@ -47,8 +67,11 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 	_animation = animation
 	_actor_textures.clear()
 	_effect_textures.clear()
+	_block_textures.clear()
+	_buffer_texture = null
+	_buffer_revision = -1
 	_rebuild_atlas()
-	queue_redraw()
+	refresh()
 
 
 ## `DoBattleTransition`'s own screen: the cells it has written, the two tiles it
@@ -141,40 +164,77 @@ func refresh_animation() -> void:
 	if changed.is_empty():
 		return
 	var indices: PackedByteArray = _animation.current_indices()
-	var palettes: Array = _tile_palettes()
-	for tile: int in changed:
-		_paint_tile(_atlas_image, indices, palettes, tile)
-	_atlas.update(_atlas_image)
+	for entry: Dictionary in _atlases.values():
+		if not bool(entry["animated"]):
+			continue
+		var image: Image = entry["image"]
+		var palettes: Array = entry["palettes"]
+		for tile: int in changed:
+			_paint_tile(image, indices, palettes, tile)
+		(entry["texture"] as ImageTexture).update(image)
+		entry["indices"] = indices
 	_priority_indices = indices
 	_priority_atlas = null
 	queue_redraw()
 
 
 func _rebuild_atlas() -> void:
+	_atlases.clear()
 	_atlas = null
 	_atlas_image = null
+	_background_color = FALLBACK_BACKGROUND
 	if _world == null or _world.data == null or _world.current_tileset == null:
 		return
-	var indices: PackedByteArray = _world.data.world_tileset_indices(_world.current_tileset.number)
-	if _animation != null and not _animation.current_indices().is_empty():
-		indices = _animation.current_indices()
-	var palettes: Array = _tile_palettes()
+	var entry: Dictionary = _atlas_for(_world.current_map, _world.current_tileset)
+	if entry.is_empty():
+		return
+	var palettes: Array = entry["palettes"]
 	if not palettes.is_empty() and (palettes[0] as PackedColorArray).size() >= 1:
 		_background_color = (palettes[0] as PackedColorArray)[0]
-	else:
-		_background_color = FALLBACK_BACKGROUND
-	var tile_count: int = _world.current_tileset.tile_count
-	if indices.size() < tile_count * Gen2Tiles.TILE_PIXELS:
-		return
-	_atlas_image = Image.create(
-		tile_count * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT, false, Image.FORMAT_RGBA8
-	)
-	for tile: int in tile_count:
-		_paint_tile(_atlas_image, indices, palettes, tile)
-	_atlas = ImageTexture.create_from_image(_atlas_image)
+	_atlas = entry["texture"]
+	_atlas_image = entry["image"]
 	# Built on demand: only an object standing in grass reads it.
-	_priority_indices = indices
+	_priority_indices = entry["indices"]
 	_priority_atlas = null
+	# The quads hold the strip they were configured with, and this is a new one.
+	_sync_map_layers()
+
+
+## The coloured tile strip a map draws with, cached on the two things that
+## choose its colours: the tileset the tiles come from and the environment
+## `GetMapPalette` reads the eight background slots out of. A connected map
+## sharing both shares the strip rather than colouring a second copy of it, and
+## the animation repaints every cached strip that came from its own tileset.
+func _atlas_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Dictionary:
+	if map == null or tileset == null or _world == null or _world.data == null:
+		return {}
+	var key: String = "%d:%d" % [tileset.number, map.environment]
+	if _atlases.has(key):
+		return _atlases[key]
+	var indices: PackedByteArray = _world.data.world_tileset_indices(tileset.number)
+	var animated: bool = _animation != null and _world.current_tileset != null \
+		and tileset.number == _world.current_tileset.number \
+		and not _animation.current_indices().is_empty()
+	if animated:
+		indices = _animation.current_indices()
+	if indices.size() < tileset.tile_count * Gen2Tiles.TILE_PIXELS:
+		return {}
+	var palettes: Array = _tile_palettes_for(map, tileset)
+	var image := Image.create(
+		tileset.tile_count * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT,
+		false, Image.FORMAT_RGBA8,
+	)
+	for tile: int in tileset.tile_count:
+		_paint_tile(image, indices, palettes, tile)
+	var entry: Dictionary = {
+		"texture": ImageTexture.create_from_image(image),
+		"image": image,
+		"palettes": palettes,
+		"indices": indices,
+		"animated": animated,
+	}
+	_atlases[key] = entry
+	return entry
 
 
 ## The one palette `.pal_loop` puts every background tile on, through whatever
@@ -189,19 +249,30 @@ func flood_palette() -> PackedColorArray:
 
 
 func _tile_palettes() -> Array:
+	return _tile_palettes_for(_world.current_map, _world.current_tileset)
+
+
+## The palettes the current map's tile strip was coloured with, which
+## [method _atlas_for] already resolved and kept.
+func _current_palettes() -> Array:
+	var entry: Dictionary = _atlas_for(_world.current_map, _world.current_tileset)
+	return entry["palettes"] if not entry.is_empty() else []
+
+
+func _tile_palettes_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
 	## `StartTrainerBattle_LoadPokeBallGraphics.pal_loop` puts every background
 	## tile on `PAL_BG_TEXT` and fills that one palette, which is why a trainer
 	## transition draws the whole map in four colours.
 	if not _transition_palette.is_empty():
 		var flooded: Array = []
 		var flood: PackedColorArray = flood_palette()
-		for _tile: int in _world.current_tileset.tile_count:
+		for _tile: int in tileset.tile_count:
 			flooded.append(flood)
 		return flooded
 	var rows: Array = Gen2WorldPalette.tile_palettes(
 		_world.data,
-		_world.current_map,
-		_world.current_tileset,
+		map,
+		tileset,
 		_time_of_day,
 		_animation.water_palette_color() if _animation != null else -1,
 		_animation.cave_palette_color() if _animation != null else -1,
@@ -297,22 +368,33 @@ func clear_transition() -> void:
 ## OAM_PRIO pass a sprite standing in grass wants: colour 0 loses that test, so
 ## it is left transparent there and drawn like any other colour here.
 func _draw_transition(
-	page: PackedInt32Array, palettes: Array, window: Vector2i,
-	clip: Rect2 = Rect2(), priority: bool = false
+	camera_pixels: Vector2, clip: Rect2 = Rect2(), priority: bool = false
 ) -> void:
 	var black: int = Gen2BattleTransition.CELL_BLACK
 	var flood: PackedColorArray = flood_palette()
+	## The strip's own palettes, not a fresh resolve: this runs again over the
+	## lower half of every sprite standing in grass, and building one palette
+	## table per sprite was most of such a frame.
+	var palettes: Array = [] if not flood.is_empty() else _current_palettes()
+	## The screen's own top-left corner, which is the surface's until a view
+	## larger than the hardware's puts the twenty by eighteen cells in the middle
+	## of something wider.
+	var origin: Vector2 = screen_offset()
+	var screen_tile := Vector2i(
+		floori((camera_pixels.x + origin.x) / float(Gen2Tiles.TILE_WIDTH)),
+		floori((camera_pixels.y + origin.y) / float(Gen2Tiles.TILE_HEIGHT)),
+	)
 	## The whole screen, or the few cells a sprite's own lower half falls in.
 	var first := Vector2i.ZERO
 	var last := Vector2i(Gen2BattleTransition.COLUMNS - 1, Gen2BattleTransition.ROWS - 1)
 	if priority:
 		first = Vector2i(
-			floori(clip.position.x / Gen2Tiles.TILE_WIDTH),
-			floori(clip.position.y / Gen2Tiles.TILE_HEIGHT),
+			floori((clip.position.x - origin.x) / Gen2Tiles.TILE_WIDTH),
+			floori((clip.position.y - origin.y) / Gen2Tiles.TILE_HEIGHT),
 		)
 		last = Vector2i(
-			mini(ceili(clip.end.x / Gen2Tiles.TILE_WIDTH), last.x),
-			mini(ceili(clip.end.y / Gen2Tiles.TILE_HEIGHT), last.y),
+			mini(ceili((clip.end.x - origin.x) / Gen2Tiles.TILE_WIDTH), last.x),
+			mini(ceili((clip.end.y - origin.y) / Gen2Tiles.TILE_HEIGHT), last.y),
 		)
 	for y: int in range(maxi(first.y, 0), last.y + 1):
 		for x: int in range(maxi(first.x, 0), last.x + 1):
@@ -320,7 +402,7 @@ func _draw_transition(
 			if cell == Gen2BattleTransition.CELL_NONE:
 				continue
 			var at := Rect2(
-				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT),
+				origin + Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT),
 				Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT)
 			)
 			var covered: Rect2 = at if not priority else at.intersection(clip)
@@ -328,7 +410,7 @@ func _draw_transition(
 				continue
 			var palette: PackedColorArray = flood
 			if palette.is_empty():
-				var tile: int = page[y * window.x + x] if y * window.x + x < page.size() else 0
+				var tile: int = _drawn_tile_at(screen_tile.x + x, screen_tile.y + y)
 				palette = palettes[tile] if tile >= 0 and tile < palettes.size() \
 					else PackedColorArray()
 			if cell == black or _transition_tiles.is_empty():
@@ -370,49 +452,208 @@ func _transition_texture(
 
 
 func refresh() -> void:
+	_sync_map_layers()
 	queue_redraw()
 
 
-func _draw() -> void:
-	draw_rect(
-		Rect2(Vector2.ZERO, Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)),
-		_background_color,
-		true,
+## Lays the map quads out under this frame's camera.
+##
+## The order is the order the cartridge's own buffer would be read in if it had
+## one this wide: the border block under everything, then each connected map
+## furthest first, then `wOverworldMapBlocks` itself over the top. That last one
+## is what keeps the three-block margin byte for byte the cartridge's -- a
+## connection strip stops at the `length` the macro stored, and a neighbour map
+## drawn whole does not -- so nothing a 20x18 screen can reach changes.
+func _sync_map_layers() -> void:
+	if _world == null or _world.current_map == null or _world.current_tileset == null \
+		or _atlas == null:
+		_show_map_layers(0)
+		return
+	var map: Gen2WorldMap = _world.current_map
+	var tileset: Gen2WorldTileset = _world.current_tileset
+	var camera: Vector2 = _world.view_origin_pixels().floor()
+	var view := Vector2(view_pixels())
+	var block_pixels: int = RomLayout.MAP_BLOCK_CELL_WIDTH * Gen2WorldAPI.CELL_PIXELS
+	var used: int = 0
+
+	var fill: Gen2WorldMapLayer = _map_layer(used)
+	used += 1
+	fill.configure(
+		_atlas, _one_block_texture(), _tiles_texture(tileset), Vector2i.ZERO,
+		map.border_block, tileset.block_count, tileset.tile_count, true,
 	)
-	if _world == null:
+	fill.place(Vector2.ZERO, view, camera)
+
+	if view.x > Gen2WorldAPI.VIEW_PIXELS.x or view.y > Gen2WorldAPI.VIEW_PIXELS.y:
+		var placements: Array = _world.map_placements().values()
+		placements.reverse()
+		for placement: Dictionary in placements:
+			var near: Gen2WorldMap = placement["map"]
+			var near_tileset: Gen2WorldTileset = _world.data.world_tileset(near.tileset)
+			if near_tileset == null:
+				continue
+			var at: Vector2 = Vector2(placement["origin"] as Vector2i) * float(block_pixels) \
+				- camera
+			var size := Vector2(near.width_blocks, near.height_blocks) * float(block_pixels)
+			if not Rect2(at, size).intersects(Rect2(Vector2.ZERO, view)):
+				continue
+			var blocks: ImageTexture = _blocks_texture(near)
+			var strip: Dictionary = _atlas_for(near, near_tileset)
+			if blocks == null or strip.is_empty():
+				continue
+			var layer: Gen2WorldMapLayer = _map_layer(used)
+			used += 1
+			layer.configure(
+				strip["texture"], blocks, _tiles_texture(near_tileset),
+				Vector2i(near.width_blocks, near.height_blocks), near.border_block,
+				near_tileset.block_count, near_tileset.tile_count, false,
+			)
+			layer.place(at.floor(), size)
+
+	var buffer: ImageTexture = _map_buffer_texture()
+	if buffer != null:
+		var span := Vector2i(
+			map.width_blocks + 2 * Gen2WorldAPI.BUFFER_BLOCKS,
+			map.height_blocks + 2 * Gen2WorldAPI.BUFFER_BLOCKS,
+		)
+		var layer: Gen2WorldMapLayer = _map_layer(used)
+		used += 1
+		layer.configure(
+			_atlas, buffer, _tiles_texture(tileset), span, map.border_block,
+			tileset.block_count, tileset.tile_count, false,
+		)
+		layer.place(
+			(Vector2.ONE * float(-Gen2WorldAPI.BUFFER_BLOCKS * block_pixels) - camera).floor(),
+			Vector2(span) * float(block_pixels),
+		)
+	_show_map_layers(used)
+
+
+func _map_layer(index: int) -> Gen2WorldMapLayer:
+	while _map_layers.size() <= index:
+		var layer := Gen2WorldMapLayer.new()
+		_map_layers.append(layer)
+		add_child(layer)
+	return _map_layers[index]
+
+
+func _show_map_layers(count: int) -> void:
+	for index: int in _map_layers.size():
+		_map_layers[index].visible = index < count
+
+
+## `wOverworldMapBlocks`: the map's own blocks with the three-block margin
+## around them, every byte through [method Gen2WorldAPI.drawn_block_at], so the
+## connection strips and the border fill in it are the cartridge's own.
+func _map_buffer_texture() -> ImageTexture:
+	if _world == null or _world.current_map == null:
+		return null
+	if _buffer_texture != null and _buffer_revision == _world.block_revision:
+		return _buffer_texture
+	var map: Gen2WorldMap = _world.current_map
+	var span := Vector2i(
+		map.width_blocks + 2 * Gen2WorldAPI.BUFFER_BLOCKS,
+		map.height_blocks + 2 * Gen2WorldAPI.BUFFER_BLOCKS,
+	)
+	if span.x <= 0 or span.y <= 0:
+		return null
+	var bytes := PackedByteArray()
+	bytes.resize(span.x * span.y)
+	for y: int in span.y:
+		var row: int = y * span.x
+		for x: int in span.x:
+			bytes[row + x] = _world.drawn_block_at(
+				x - Gen2WorldAPI.BUFFER_BLOCKS, y - Gen2WorldAPI.BUFFER_BLOCKS
+			) & 0xFF
+	_buffer_texture = Gen2WorldMapLayer.block_texture(bytes, span)
+	_buffer_revision = _world.block_revision
+	return _buffer_texture
+
+
+## A connected map's own block list, which nothing a run does edits: only the
+## loaded map takes `changeblock`.
+func _blocks_texture(map: Gen2WorldMap) -> ImageTexture:
+	var key: String = "%d:%d" % [map.group, map.number]
+	if _block_textures.has(key):
+		return _block_textures[key]
+	var texture: ImageTexture = Gen2WorldMapLayer.block_texture(
+		map.blocks, Vector2i(map.width_blocks, map.height_blocks)
+	)
+	_block_textures[key] = texture
+	return texture
+
+
+## The tileset's metatile table as sixteen bytes a block, with anything past the
+## tile strip folded to zero the way [method Gen2WorldTileset.tile_index] does.
+func _tiles_texture(tileset: Gen2WorldTileset) -> ImageTexture:
+	if _tiles_textures.has(tileset.number):
+		return _tiles_textures[tileset.number]
+	var slots: int = RomLayout.MAP_BLOCK_TILE_WIDTH * RomLayout.MAP_BLOCK_TILE_WIDTH
+	var bytes := PackedByteArray()
+	bytes.resize(slots * maxi(tileset.block_count, 1))
+	for at: int in bytes.size():
+		var index: int = tileset.meta[at] if at < tileset.meta.size() else 0
+		bytes[at] = index if index < tileset.tile_count else 0
+	var texture: ImageTexture = Gen2WorldMapLayer.block_texture(
+		bytes, Vector2i(slots, maxi(tileset.block_count, 1))
+	)
+	_tiles_textures[tileset.number] = texture
+	return texture
+
+
+## A one-block stand-in for the void fill's block sampler, which its own quad
+## never reads: every pixel of that quad is outside the map it declares.
+func _one_block_texture() -> ImageTexture:
+	if not _block_textures.has("void"):
+		_block_textures["void"] = Gen2WorldMapLayer.block_texture(
+			PackedByteArray([0]), Vector2i.ONE
+		)
+	return _block_textures["void"]
+
+
+## The drawn surface in hardware pixels, which is the cartridge's own until a
+## screen asks the world for more.
+func view_pixels() -> Vector2i:
+	return _world.view_pixels if _world != null else Gen2WorldAPI.VIEW_PIXELS
+
+
+## Where the cartridge's own 160x144 screen sits inside the drawn surface. Zero
+## unless the view is larger, and always a whole tile, since everything the
+## hardware laid out on the screen -- the transition's twenty by eighteen cells
+## first -- is laid out in tiles.
+func screen_offset() -> Vector2:
+	return ((Vector2(view_pixels() - Gen2WorldAPI.VIEW_PIXELS) * 0.5)
+		/ float(Gen2Tiles.TILE_WIDTH)).floor() * float(Gen2Tiles.TILE_WIDTH)
+
+
+func _draw() -> void:
+	if _world == null or _atlas == null:
+		draw_rect(Rect2(Vector2.ZERO, Vector2(view_pixels())), _background_color, true)
 		return
 
-	var camera_pixels: Vector2 = _world.visible_origin_cells() * Gen2WorldAPI.CELL_PIXELS
-	var tile_origin := Vector2i(
-		floori(camera_pixels.x / float(Gen2Tiles.TILE_WIDTH)),
-		floori(camera_pixels.y / float(Gen2Tiles.TILE_HEIGHT)),
-	)
-	var tile_offset: Vector2 = camera_pixels - Vector2(
-		tile_origin.x * Gen2Tiles.TILE_WIDTH,
-		tile_origin.y * Gen2Tiles.TILE_HEIGHT,
-	)
-	var window_size: Vector2i = Gen2WorldAPI.VIEW_TILES + Vector2i.ONE
-	var page: PackedInt32Array = _world.tile_indices_in_window(tile_origin, window_size)
-	var hidden_tiles: Dictionary = _hidden_tree_tiles()
-	for y: int in window_size.y:
-		for x: int in window_size.x:
-			var tile: int = page[y * window_size.x + x]
-			if hidden_tiles.has(tile_origin + Vector2i(x, y)):
-				tile = Gen2WorldEffects.HEADBUTT_TREE_HIDDEN_TILE
-			if _atlas == null or tile < 0 or tile >= _world.current_tileset.tile_count:
-				continue
-			draw_texture_rect_region(
-				_atlas,
-				Rect2(
-					Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT) - tile_offset,
-					Vector2(8, 8),
-				),
-				Rect2(Vector2(tile * Gen2Tiles.TILE_WIDTH, 0), Vector2(8, 8)),
-			)
-
-	var palettes: Array = _tile_palettes()
+	var camera_pixels: Vector2 = _world.view_origin_pixels()
+	## `Cut_Headbutt_GetPixelFacing`'s tree goes away while its own sprite
+	## animation plays, which the map quad knows nothing about: the four tiles of
+	## the cell are painted over with the tileset's own blank one.
+	for cell: Vector2i in (_effects.hidden_tree_cells() if _effects != null else []):
+		var at: Vector2 = Vector2(cell * Gen2WorldAPI.CELL_PIXELS) - camera_pixels
+		for row: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
+			for column: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
+				draw_texture_rect_region(
+					_atlas,
+					Rect2(
+						at + Vector2(column * Gen2Tiles.TILE_WIDTH, row * Gen2Tiles.TILE_HEIGHT),
+						Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT),
+					),
+					Rect2(
+						Vector2(
+							Gen2WorldEffects.HEADBUTT_TREE_HIDDEN_TILE * Gen2Tiles.TILE_WIDTH, 0
+						),
+						Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT),
+					),
+				)
 	if not _transition_cells.is_empty():
-		_draw_transition(page, palettes, window_size)
+		_draw_transition(camera_pixels)
 	if _transition_sprites == Gen2BattleTransition.SPRITES_NONE:
 		return
 
@@ -436,16 +677,29 @@ func _draw() -> void:
 	if _actors != null and not battlers_only:
 		for sprite: Dictionary in _actors.sprites():
 			drawn.append({"actor": sprite, "row": (sprite["position_cells"] as Vector2).y})
+	## The people on the maps around this one, sorted into the same rows: a view
+	## wide enough to see the next town is wide enough to see somebody standing
+	## in it. They are the world API's read-only copies and take no part in
+	## anything: see [method Gen2WorldAPI.connected_map_objects].
+	if not battlers_only and view_pixels() != Gen2WorldAPI.VIEW_PIXELS:
+		for entry: Dictionary in _world.connected_map_objects():
+			var neighbour: Gen2WorldObject = entry["object"]
+			if not neighbour.active or neighbour.sprite == null:
+				continue
+			var offset: Vector2i = entry["offset"]
+			drawn.append({
+				"object": neighbour,
+				"offset": offset,
+				"row": float(offset.y + neighbour.cell.y),
+			})
 	drawn.sort_custom(_sort_drawn)
 	for entry: Dictionary in drawn:
 		if entry.has("actor"):
-			_draw_actor(
-				entry["actor"], camera_pixels, page, palettes, tile_origin, tile_offset,
-				window_size
-			)
+			_draw_actor(entry["actor"], camera_pixels)
 			continue
 		var object: Gen2WorldObject = entry["object"]
-		var pixel: Vector2 = Vector2(object.cell * Gen2WorldAPI.CELL_PIXELS) \
+		var offset: Vector2i = entry.get("offset", Vector2i.ZERO)
+		var pixel: Vector2 = Vector2((object.cell + offset) * Gen2WorldAPI.CELL_PIXELS) \
 			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS)) - camera_pixels \
 			+ SPRITE_LIFT
 		var texture: Texture2D = _actor_texture(
@@ -456,14 +710,16 @@ func _draw() -> void:
 		var object_jump := Vector2(0, -object.height_offset_pixels())
 		if texture != null:
 			draw_texture(texture, pixel + object_jump)
+		if offset != Vector2i.ZERO:
+			continue
 		if _in_grass(object.cell):
-			_draw_grass_over(pixel, page, palettes, tile_origin, tile_offset, window_size)
+			_draw_grass_over(pixel, camera_pixels)
 		if object.emote_visible:
 			_draw_emote(object.emote_id, pixel)
 		if not battlers_only:
 			_draw_effect_sprites(object.index, pixel)
 
-	var player: Vector2 = Vector2(_world.player_pixel_position()) + SPRITE_LIFT
+	var player: Vector2 = Vector2(_world.player_view_pixel()) + SPRITE_LIFT
 	## The jump arc is a sprite offset, not a position: the shadow and the grass
 	## the hop leaves behind stay on the ground.
 	var jump: Vector2 = Vector2(0, _world.player_jump_offset())
@@ -474,7 +730,7 @@ func _draw() -> void:
 	if player_texture != null:
 		draw_texture(player_texture, player + jump)
 		if _in_grass(_world.player_cell):
-			_draw_grass_over(player + jump, page, palettes, tile_origin, tile_offset, window_size)
+			_draw_grass_over(player + jump, camera_pixels)
 		if _world.fishing_busy():
 			_draw_fishing_rod(player + jump)
 	else:
@@ -555,10 +811,7 @@ func _actor_texture(
 ## One mod actor, drawn from the [Gen2WorldSprite] the actor layer resolved for
 ## it. Its position is in walk cells, the unit `player_position_cells()` is in,
 ## so a follower halfway through a step is drawn halfway.
-func _draw_actor(
-	sprite: Dictionary, camera_pixels: Vector2, page: PackedInt32Array, palettes: Array,
-	tile_origin: Vector2i, tile_offset: Vector2, window_size: Vector2i
-) -> void:
+func _draw_actor(sprite: Dictionary, camera_pixels: Vector2) -> void:
 	var cell_position: Vector2 = sprite["position_cells"]
 	var pixel: Vector2 = cell_position * float(Gen2WorldAPI.CELL_PIXELS) - camera_pixels \
 		+ SPRITE_LIFT
@@ -570,7 +823,7 @@ func _draw_actor(
 		return
 	draw_texture(texture, pixel)
 	if _in_grass(Vector2i(roundi(cell_position.x), roundi(cell_position.y))):
-		_draw_grass_over(pixel, page, palettes, tile_origin, tile_offset, window_size)
+		_draw_grass_over(pixel, camera_pixels)
 	## The same bubble a map object's `showemote` puts up, over an actor that
 	## asked for one. Drawn after the grass, as an object's is: `SpawnEmote` is
 	## its own OAM and stands over the tuft rather than behind it.
@@ -624,14 +877,7 @@ func _in_grass(cell: Vector2i) -> bool:
 
 ## Redraws the map over the bottom half of a sprite drawn at [param pixel], with
 ## the transparent index left out, which is what OAM_PRIO amounts to here.
-func _draw_grass_over(
-	pixel: Vector2,
-	page: PackedInt32Array,
-	palettes: Array,
-	_tile_origin: Vector2i,
-	tile_offset: Vector2,
-	window_size: Vector2i,
-) -> void:
+func _draw_grass_over(pixel: Vector2, camera_pixels: Vector2) -> void:
 	if _priority_atlas == null:
 		_build_priority_atlas()
 	if _priority_atlas == null:
@@ -640,16 +886,27 @@ func _draw_grass_over(
 		pixel + Vector2(0, Gen2Tiles.TILE_HEIGHT),
 		Vector2(Gen2WorldAPI.CELL_PIXELS, Gen2Tiles.TILE_HEIGHT),
 	)
-	for y: int in window_size.y:
-		for x: int in window_size.x:
+	## The tuft is sixteen by eight pixels, so it covers at most three tiles by
+	## two. Walking the whole page for it cost the view's every tile once per
+	## sprite standing in grass, which a window-filling view cannot afford.
+	var first := Vector2i(
+		floori((over.position.x + camera_pixels.x) / float(Gen2Tiles.TILE_WIDTH)),
+		floori((over.position.y + camera_pixels.y) / float(Gen2Tiles.TILE_HEIGHT)),
+	)
+	var last := Vector2i(
+		ceili((over.end.x + camera_pixels.x) / float(Gen2Tiles.TILE_WIDTH)),
+		ceili((over.end.y + camera_pixels.y) / float(Gen2Tiles.TILE_HEIGHT)),
+	)
+	for y: int in range(first.y, last.y + 1):
+		for x: int in range(first.x, last.x + 1):
 			var at := Rect2(
-				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT) - tile_offset,
+				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT) - camera_pixels,
 				Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT),
 			)
 			var covered: Rect2 = at.intersection(over)
 			if covered.size.x <= 0.0 or covered.size.y <= 0.0:
 				continue
-			var tile: int = page[y * window_size.x + x]
+			var tile: int = _drawn_tile_at(x, y)
 			if tile < 0 or tile >= _world.current_tileset.tile_count:
 				continue
 			for piece: Rect2 in _priority_pieces(covered):
@@ -665,7 +922,21 @@ func _draw_grass_over(
 	## wins the priority test where it wrote is its own tile rather than the
 	## grass. The pieces above left those cells to it.
 	if not _transition_cells.is_empty():
-		_draw_transition(page, palettes, window_size, over, true)
+		_draw_transition(camera_pixels, over, true)
+
+
+## The graphics tile drawn at a map-space tile coordinate, through the same
+## block fold the map quad's shader runs.
+func _drawn_tile_at(tile_x: int, tile_y: int) -> int:
+	if _world == null or _world.current_tileset == null:
+		return -1
+	var width: int = RomLayout.MAP_BLOCK_TILE_WIDTH
+	var block: int = _world.expanded_block_at(
+		floori(float(tile_x) / float(width)), floori(float(tile_y) / float(width))
+	)
+	return _world.current_tileset.tile_index(
+		block, posmod(tile_y, width) * width + posmod(tile_x, width)
+	)
 
 
 ## The parts of [param rect] the map still owns, split on the screen's own
@@ -691,8 +962,9 @@ func _priority_pieces(rect: Rect2) -> Array[Rect2]:
 
 ## Whether the transition has taken the screen cell [param at] falls in.
 func _transition_wrote(at: Vector2) -> bool:
-	var x: int = floori(at.x / Gen2Tiles.TILE_WIDTH)
-	var y: int = floori(at.y / Gen2Tiles.TILE_HEIGHT)
+	var screen: Vector2 = at - screen_offset()
+	var x: int = floori(screen.x / Gen2Tiles.TILE_WIDTH)
+	var y: int = floori(screen.y / Gen2Tiles.TILE_HEIGHT)
 	if x < 0 or x >= Gen2BattleTransition.COLUMNS \
 		or y < 0 or y >= Gen2BattleTransition.ROWS:
 		return false
@@ -819,20 +1091,6 @@ func _pulse_texture(
 
 func _effect_sprites() -> Array:
 	return _effects.sprites() if _effects != null else []
-
-
-## The tiles a live effect takes from the map, as a set of absolute tile
-## coordinates. See Gen2WorldEffects.hidden_tree_cells().
-func _hidden_tree_tiles() -> Dictionary:
-	var out: Dictionary = {}
-	if _effects == null:
-		return out
-	for cell: Vector2i in _effects.hidden_tree_cells():
-		var origin: Vector2i = cell * RomLayout.MAP_BLOCK_CELL_WIDTH
-		for y: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
-			for x: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
-				out[origin + Vector2i(x, y)] = true
-	return out
 
 
 ## Whatever [param object_index] is carrying this frame, drawn over it: the dust

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -361,7 +361,9 @@ func _build_world() -> void:
 	if not rods.is_empty() and not rods.has(_selected_rod):
 		_selected_rod = rods[0]
 	_animation.configure(_world, _render_time_of_day())
+	_apply_screen_fill()
 	_build_renderer()
+	_screen.view_size_changed.connect(_on_view_size_changed)
 	_screen_base_position = _screen.position
 	_audio_player = AUDIO_PLAYER_SCRIPT.new()
 	_audio_player.name = "AudioPlayer"
@@ -474,6 +476,60 @@ func _render_time_of_day() -> int:
 	return _world.map_time_of_day()
 
 
+## SCREEN FILL: the overworld is the one screen with more to show than the
+## hardware framed, so it is the one screen that grows into the window. Every
+## menu, box and cursor over it stays inside the 160x144 rectangle
+## [Gen2Screen] centres in the buffer.
+func _apply_screen_fill() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	## The bars a framed screen leaves are this scene's own background, so a mask
+	## that stands in for them is painted in the same colour.
+	var background := get_node_or_null(^"Background") as Panel
+	var style := background.get_theme_stylebox(&"panel") as StyleBoxFlat \
+		if background != null else null
+	if style != null:
+		_screen.letterbox_color = style.bg_color
+	_screen.expanded = options.screen_fill
+	if _screen.expanded:
+		_screen.zoom_step = options.zoom_step
+	_on_view_size_changed(_screen.view_size())
+	_apply_interface_mask()
+
+
+## A screen that hides the map takes the whole picture with it: it is laid out
+## in 160x144 and has nothing to put in a wider buffer, so the surround becomes
+## the letterbox rather than the map behind it. The start menu is not one of
+## these -- it is a box the map is still visible around, as on the cartridge --
+## and neither is a map fade, which fades the whole picture.
+##
+## `DoBattleTransition` is: it writes twenty by eighteen screen cells and
+## nothing wider, so a wedge pattern in a filled window would stop where the
+## cartridge's screen ended. It closes the surround for the battle that follows
+## it, which is masked for the same reason.
+func _apply_interface_mask() -> void:
+	_screen.interface_masked = _screen.expanded and (
+		_battle_transition != null
+		or _battle_host != null or _service_host != null or _party_host != null
+		or _hall_of_fame_host != null or _trainer_card_host != null
+		or _pokedex_host != null or _credits_host != null
+		or _evolution_host != null or _hatch_host != null
+		or _name_rater_host != null or _move_deleter_host != null
+		or _move_tutor_host != null or _day_care_host != null
+		or _unown_puzzle_host != null or _slot_machine_host != null
+		or _card_flip_host != null
+	)
+
+
+func _on_view_size_changed(size_pixels: Vector2i) -> void:
+	if _world == null:
+		return
+	if _world.view_pixels == size_pixels:
+		return
+	_world.view_pixels = size_pixels
+	if _renderer != null and _renderer.has_method(&"refresh"):
+		_renderer.refresh()
+
+
 func _on_native_size_changed(size_pixels: Vector2i) -> void:
 	if _renderer != null \
 		and _renderer.has_method(Gen2ModHost.RENDERER_RESIZE_METHOD):
@@ -522,6 +578,10 @@ func _process(delta: float) -> void:
 		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
 		advance_frame()
 	_advance_day_cycle(delta)
+	## Every drawn frame rather than every hardware frame: above sixty a drawn
+	## frame can carry no hardware one, and a screen opened by the press that
+	## drawn frame served would show the map around it until the next.
+	_apply_interface_mask()
 
 
 ## Spends [param count] hardware frames. Public beside [method advance_frame] so
@@ -567,6 +627,9 @@ func advance_frame() -> void:
 	## `DoBattleTransition`'s own `.loop`, which owns every frame between the
 	## encounter and the battle screen.
 	_advance_battle_transition()
+	## Here as well as in [method _process]: a driver that spends frames without
+	## a clock -- a test, a preview, a replay -- never reaches the other one.
+	_apply_interface_mask()
 	## `RefreshMapSprites` runs inside the setup script and `PlaceMapNameSign`
 	## with the rest of the map's background, so a sign raised by the load this
 	## frame carried is spent from the next one.
@@ -899,6 +962,9 @@ func _unhandled_input(event: InputEvent) -> void:
 		_credits_host.release_button(released)
 		accept_event()
 		return
+	if _handle_zoom(event):
+		accept_event()
+		return
 	if event.is_pressed() and _handle_debug_key(event):
 		accept_event()
 		return
@@ -1118,6 +1184,49 @@ func _complete_unattended_request() -> Array:
 		_script_prompt = "Host unavailable: %s" % String(settled.get("reason", "unknown"))
 		return []
 	return settled.get("results", [])
+
+
+## Zoom, on the keys every map program uses for it and on the wheel.
+##
+## Only while the map itself has the screen: a text box, a menu or a script is
+## laid out against the 160x144 rectangle and moving the surface under one is
+## the player losing their place. A framed screen refuses the step, since there
+## is no more world to show and it would only shrink the picture
+## ([method Gen2Screen.step_zoom]).
+func _handle_zoom(event: InputEvent) -> bool:
+	if not _renderer_input_free() or not _screen.expanded:
+		return false
+	var delta: int = 0
+	var key := event as InputEventKey
+	if key != null and key.pressed and not key.echo:
+		match key.keycode:
+			KEY_EQUAL, KEY_PLUS, KEY_KP_ADD:
+				delta = 1
+			KEY_MINUS, KEY_KP_SUBTRACT:
+				delta = -1
+			KEY_0, KEY_KP_0:
+				_screen.reset_zoom()
+				_persist_zoom()
+				return true
+	var wheel := event as InputEventMouseButton
+	if wheel != null and wheel.pressed:
+		if wheel.button_index == MOUSE_BUTTON_WHEEL_UP:
+			delta = 1
+		elif wheel.button_index == MOUSE_BUTTON_WHEEL_DOWN:
+			delta = -1
+	if delta == 0:
+		return false
+	_screen.step_zoom(delta)
+	_persist_zoom()
+	return true
+
+
+func _persist_zoom() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	if options.zoom_step == _screen.zoom_step:
+		return
+	options.zoom_step = _screen.zoom_step
+	Gen2OptionsStore.save(options)
 
 
 ## Scaffolding that reaches parts of the world no cartridge control does: the
@@ -3361,6 +3470,7 @@ func preview_battle_transition(frames: int, trainer: bool = false) -> void:
 		false, false, trainer, false, _encounter_random,
 		_data.battle_anim_sine() if _data != null else PackedByteArray()
 	)
+	_apply_interface_mask()
 	_apply_battle_transition()
 	for _frame: int in maxi(frames, 0):
 		if _battle_transition == null:

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -193,10 +193,12 @@ func test_a_renderer_rebuilt_mid_scene_stays_below_the_live_text_box() -> void:
 	assert_true(Gen2ModHost.instance().select_view(&"gen2")["ok"])
 	_world_screen._build_renderer()
 	var viewport: SubViewport = _world_screen._screen.viewport()
+	var interface: Control = _world_screen._screen.interface_layer()
 	assert_eq(_world_screen._renderer.get_parent(), viewport, "still in the viewport")
+	assert_eq(box.get_parent(), interface, "the box is on the interface layer")
 	assert_true(
 		viewport.get_children().find(_world_screen._renderer)
-			< viewport.get_children().find(box),
+			< viewport.get_children().find(interface),
 		"and below the box rather than over it"
 	)
 	assert_eq(_world_screen._text_box, box, "the same live box node")
@@ -215,8 +217,10 @@ func test_a_battle_renderer_rebuilt_mid_scene_stays_below_the_interface() -> voi
 	_battle_screen._build_renderer()
 	var viewport: SubViewport = _battle_screen._screen.viewport()
 	var children: Array = viewport.get_children()
+	var interface: Control = _battle_screen._screen.interface_layer()
 	assert_eq(children.find(_battle_screen._renderer), 0, "the renderer is the floor")
-	assert_true(children.find(_battle_screen._box) > 0)
+	assert_eq(_battle_screen._box.get_parent(), interface)
+	assert_true(children.find(interface) > 0)
 	assert_eq(_dropped_on(viewport), 0, "the old view is off the screen, not under the new")
 
 

--- a/tests/unit/test_game_frame.gd
+++ b/tests/unit/test_game_frame.gd
@@ -71,3 +71,62 @@ func test_a_handheld_may_turn_into_the_portrait_layout() -> void:
 		int(ProjectSettings.get_setting("display/window/handheld/orientation")),
 		DisplayServer.SCREEN_SENSOR,
 	)
+
+
+## SCREEN FILL: an expanded screen is given the whole portrait share instead of
+## the 10:9 rectangle inside it, since the leftover is void it can draw map into.
+func test_an_expanded_portrait_screen_takes_the_whole_share() -> void:
+	var area := Vector2(480, 960)
+	var framed: Rect2 = Gen2GameFrame.split(area, true)["screen"]
+	var filled: Rect2 = Gen2GameFrame.split(area, true, true)["screen"]
+	assert_eq(filled.position, Vector2.ZERO)
+	assert_eq(filled.size.x, area.x)
+	assert_gt(filled.size.y, framed.size.y)
+	assert_eq(
+		Gen2GameFrame.split(area, true, true)["controls"].position.y,
+		filled.end.y,
+		"the controller still starts where the screen ends",
+	)
+
+
+## Landscape and a screen with no controller are unchanged either way: the
+## screen already had the whole frame and fills it itself.
+func test_expanding_changes_nothing_where_the_screen_had_the_frame() -> void:
+	for area: Vector2 in [Vector2(1152, 648), Vector2(480, 960)]:
+		assert_eq(
+			Gen2GameFrame.split(area, false, true)["screen"],
+			Gen2GameFrame.split(area, false)["screen"],
+		)
+
+
+## The zoom ladder: whole pixels per hardware pixel on the way in, halves on the
+## way out once one pixel each is reached, and never past the survey floor.
+func test_the_zoom_ladder_steps_whole_pixels_then_halves() -> void:
+	assert_eq(Gen2Screen.scale_at(4, 0), 4.0, "no step is the fitting scale")
+	assert_eq(Gen2Screen.scale_at(4, 2), 6.0)
+	assert_eq(Gen2Screen.scale_at(4, -3), 1.0, "one pixel each is the last whole step")
+	assert_eq(Gen2Screen.scale_at(4, -4), 0.5)
+	assert_eq(Gen2Screen.scale_at(4, -5), 0.25)
+	assert_eq(Gen2Screen.scale_at(4, -9), Gen2Screen.MIN_SCALE, "the survey floor")
+
+
+## The expanded buffer covers the window and grows by whole map blocks, so half
+## the difference from the hardware screen is a whole tile and the interface
+## rectangle inside it lands on the grid every screen is laid out against.
+func test_the_expanded_buffer_covers_the_window_on_a_block_grid() -> void:
+	for area: Vector2 in [Vector2(1152, 648), Vector2(1920, 1080), Vector2(430, 932)]:
+		for scale: float in [1.0, 2.0, 4.0, 0.5]:
+			var view: Vector2i = Gen2Screen.buffer_for(area, scale)
+			assert_gte(float(view.x) * scale, area.x, "%s at %sx covers the width" % [area, scale])
+			assert_gte(float(view.y) * scale, area.y, "%s at %sx covers the height" % [area, scale])
+			assert_eq((view.x - Gen2Screen.WIDTH) % Gen2Screen.BUFFER_STEP, 0)
+			assert_eq((view.y - Gen2Screen.HEIGHT) % Gen2Screen.BUFFER_STEP, 0)
+
+
+## A window smaller than the hardware screen still gets the hardware screen:
+## there is nothing to fill and a smaller buffer would crop the game.
+func test_the_expanded_buffer_never_shrinks_below_the_hardware_screen() -> void:
+	assert_eq(
+		Gen2Screen.buffer_for(Vector2(100, 100), 4.0),
+		Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT),
+	)

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -146,6 +146,24 @@ func test_out_of_range_values_are_clamped_rather_than_refused() -> void:
 	assert_eq(options.max_fps, 60, "an unlisted frame cap falls back to 60")
 
 
+## SCREEN FILL and its zoom step are view preferences rather than part of a run,
+## so they live in the options file and survive a session.
+func test_the_screen_fill_rows_round_trip_and_default_on() -> void:
+	assert_true(Gen2Options.new().screen_fill, "the window is not 10:9 by default")
+	assert_eq(Gen2Options.new().zoom_step, 0)
+
+	var options := Gen2Options.new()
+	options.screen_fill = false
+	options.zoom_step = -3
+	var restored: Gen2Options = Gen2Options.parse(options.to_dict())
+	assert_false(restored.screen_fill)
+	assert_eq(restored.zoom_step, -3)
+	assert_eq(
+		Gen2Options.parse({"zoom_step": 900}).zoom_step, 32,
+		"an out of range step is clamped rather than refused",
+	)
+
+
 ## The gameplay rules live in the options file but are their own block: the
 ## settings screen edits them there, and a new run takes a copy.
 func test_the_rules_block_travels_with_the_options_file() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -7492,3 +7492,98 @@ func test_take_hidden_item_refuses_while_a_script_is_running() -> void:
 	assert_eq(world.interact().size(), 1, "The faced record is waiting on its box.")
 	assert_true(world.take_hidden_item(Vector2i(2, 5)).is_empty())
 	assert_false(world.event_flag_active(35))
+
+
+## SCREEN FILL: the connection graph places whole maps around this one, in the
+## same block coordinates `FillMapConnections` writes its strip in.
+func test_the_connection_graph_places_the_neighbour_at_its_own_edge() -> void:
+	var world: Gen2WorldAPI = _world()
+	var placements: Dictionary = world.map_placements()
+	assert_eq(placements.size(), 1)
+	assert_true(placements.has("1:2"))
+	assert_eq(
+		placements["1:2"]["origin"],
+		Vector2i(world.current_map.width_blocks, 0),
+		"an east connection starts where this map ends",
+	)
+	assert_eq((placements["1:2"]["map"] as Gen2WorldMap).number, 2)
+
+
+## Inside `wOverworldMapBlocks` the expansion is the cartridge's own fold, so a
+## 20x18 screen sees exactly what it always saw.
+func test_expanded_blocks_are_the_hardware_buffer_inside_it() -> void:
+	var world: Gen2WorldAPI = _world()
+	var map: Gen2WorldMap = world.current_map
+	for block_y: int in range(-Gen2WorldAPI.BUFFER_BLOCKS, map.height_blocks + Gen2WorldAPI.BUFFER_BLOCKS):
+		for block_x: int in range(-Gen2WorldAPI.BUFFER_BLOCKS, map.width_blocks + Gen2WorldAPI.BUFFER_BLOCKS):
+			assert_eq(
+				world.expanded_block_at(block_x, block_y),
+				world.drawn_block_at(block_x, block_y),
+				"(%d,%d)" % [block_x, block_y],
+			)
+
+
+## Past it, the neighbour answers with its own blocks rather than the border
+## block the cartridge's buffer holds there.
+func test_expanded_blocks_read_the_placed_neighbour_past_the_buffer() -> void:
+	var world: Gen2WorldAPI = _world()
+	var map: Gen2WorldMap = world.current_map
+	var neighbour: Gen2WorldMap = world.data.world_map(1, 2)
+	var past: int = map.width_blocks + Gen2WorldAPI.BUFFER_BLOCKS
+	assert_lt(past, map.width_blocks + neighbour.width_blocks, "the strip stops short of the map")
+	for block_x: int in range(past, map.width_blocks + neighbour.width_blocks):
+		assert_eq(
+			world.expanded_block_at(block_x, 2),
+			Gen2WorldAPI.drawn_block_for(world.data, neighbour, block_x - map.width_blocks, 2),
+			"block %d" % block_x,
+		)
+	assert_eq(
+		world.expanded_block_at(map.width_blocks + neighbour.width_blocks + 4, 2),
+		map.border_block,
+		"past every placed map the border block fills the void",
+	)
+
+
+## A wider view is the same screen with more around it: the player keeps the
+## place PLAYER_VIEW_CELL puts him in and only the surround grows.
+func test_a_wider_view_keeps_the_player_where_the_hardware_put_him() -> void:
+	var world: Gen2WorldAPI = _world()
+	var framed: Vector2 = world.view_origin_pixels()
+	assert_eq(framed, world.visible_origin_cells() * float(Gen2WorldAPI.CELL_PIXELS))
+	world.view_pixels = Gen2WorldAPI.VIEW_PIXELS + Vector2i(320, 64)
+	assert_eq(world.view_origin_pixels(), framed - Vector2(160, 32))
+	assert_eq(
+		Vector2(world.player_position_cells()) * float(Gen2WorldAPI.CELL_PIXELS)
+			- world.view_origin_pixels(),
+		Vector2(world.player_pixel_position()) + Vector2(160, 32),
+		"the player moved by exactly half the extra surround",
+	)
+	assert_eq(
+		world.player_view_pixel(), world.player_pixel_position() + Vector2i(160, 32),
+		"and the sprite is drawn there",
+	)
+
+
+## The people on a connected map are drawn and nothing else: they are not in the
+## object table, so no collision, script or interaction can reach them.
+func test_connected_map_objects_are_drawn_but_not_in_the_object_table() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 2).events["objects"] = [{
+		"sprite": Gen2WorldAPI.SPRITE_CHRIS, "x": 5, "y": 4, "movement": 0,
+		"x_radius": 0, "y_radius": 0, "hour_1": -1, "hour_2": -1, "palette": 0,
+		"object_type": 0, "sight_range": 0, "script": 0, "event_flag": 0,
+	}]
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
+	var neighbours: Array = world.connected_map_objects()
+	assert_eq(neighbours.size(), 1)
+	var entry: Dictionary = neighbours[0]
+	var object: Gen2WorldObject = entry["object"]
+	assert_eq(
+		entry["offset"],
+		Vector2i(world.current_map.width_blocks * RomLayout.MAP_BLOCK_CELL_WIDTH, 0),
+	)
+	assert_false(world.objects.has(object), "not one of this map's own")
+	assert_null(
+		world.object_at(object.cell + (entry["offset"] as Vector2i)),
+		"and standing on nothing this map can walk into",
+	)

--- a/tools/checks/drawn_blocks.gd
+++ b/tools/checks/drawn_blocks.gd
@@ -14,11 +14,25 @@ var _r: RefCounted = null
 ## The count of padded blocks that came from a neighbour rather than from the
 ## border block is reported per game, because two implementations that both
 ## answer the border block everywhere would agree and prove nothing.
+##
+## SCREEN FILL adds a second question to the same sweep, since it is the same
+## fold one step further out. `expanded_block_at` places whole connected maps
+## past the padding, and the two things that has to be true of it are checked
+## here rather than photographed:
+##
+## - inside `wOverworldMapBlocks` it is `drawn_block_at`, byte for byte, so
+##   nothing a 20x18 screen can reach moved;
+## - where the padding took a block off a neighbour, the placed map answers the
+##   same block, which is the seam being continuous rather than merely adjacent.
 
 ## `FillMapConnections` writes three blocks of padding on each side.
 const PADDING: int = 3
 
 var _failures: int = 0
+## How many blocks each half of the expansion question was asked of, so a run
+## that quietly stopped asking is visible.
+var _buffer_agreed: int = 0
+var _seam_agreed: int = 0
 
 
 func run(r: RefCounted) -> void:
@@ -31,6 +45,10 @@ func run(r: RefCounted) -> void:
 		_check_game(data)
 	if _failures > 0:
 		_r.fail("%d blocks disagreed with the fold from a map record alone." % _failures)
+	if _buffer_agreed == 0 or _seam_agreed == 0:
+		_r.fail("the expansion was never exercised: %d buffer blocks, %d seam blocks." % [
+			_buffer_agreed, _seam_agreed
+		])
 
 
 func _check_game(data: GameData) -> void:
@@ -58,12 +76,56 @@ func _check_game(data: GameData) -> void:
 					or block_x >= map.width_blocks or block_y >= map.height_blocks
 				if outside and recorded != map.border_block:
 					neighbours += 1
+				## Inside the buffer the expansion is the fold itself.
+				if world.expanded_block_at(block_x, block_y) != loaded:
+					_failures += 1
+					printerr("%-8s map %d/%d block (%d,%d): expanded %d, drawn %d" % [
+						data.id, map.group, map.number, block_x, block_y,
+						world.expanded_block_at(block_x, block_y), loaded,
+					])
+					return
+				_buffer_agreed += 1
 		from_neighbour += neighbours
+		_check_seams(data, map, world)
 		if neighbours > 0:
 			connected_maps += 1
-	print("%-8s %d maps, %d blocks, %d padded blocks off a neighbour on %d maps" % [
-		data.id, maps.size(), blocks, from_neighbour, connected_maps
+	print("%-8s %d maps, %d blocks, %d padded blocks off a neighbour on %d maps, %d seam blocks" % [
+		data.id, maps.size(), blocks, from_neighbour, connected_maps, _seam_agreed
 	])
 	if from_neighbour == 0:
 		_failures += 1
 		printerr("%-8s no padded block came off a neighbour, so the fold proved nothing" % data.id)
+
+
+## Every padding block the connection strips filled, against the whole map the
+## placement graph puts there. `FillMapConnections` writes the strip from a
+## pointer sum and [method Gen2WorldAPI.connection_origin_blocks] places the map
+## from the same one, so a disagreement is a seam a filled screen would show as
+## a step in the ground.
+func _check_seams(data: GameData, map: Gen2WorldMap, world: Gen2WorldAPI) -> void:
+	var placements: Dictionary = Gen2WorldAPI.placements_around(data, map, 1)
+	for block_y: int in range(-PADDING, map.height_blocks + PADDING):
+		for block_x: int in range(-PADDING, map.width_blocks + PADDING):
+			if block_x >= 0 and block_y >= 0 \
+				and block_x < map.width_blocks and block_y < map.height_blocks:
+				continue
+			var strip: int = world.drawn_block_at(block_x, block_y)
+			if strip == map.border_block:
+				continue
+			for placement: Dictionary in placements.values():
+				var near: Gen2WorldMap = placement["map"]
+				var origin: Vector2i = placement["origin"]
+				var local := Vector2i(block_x - origin.x, block_y - origin.y)
+				if local.x < 0 or local.y < 0 \
+					or local.x >= near.width_blocks or local.y >= near.height_blocks:
+					continue
+				var placed: int = Gen2WorldAPI.drawn_block_for(data, near, local.x, local.y)
+				if placed != strip:
+					_failures += 1
+					printerr("%-8s map %d/%d block (%d,%d): strip %d, %d/%d says %d" % [
+						data.id, map.group, map.number, block_x, block_y, strip,
+						near.group, near.number, placed,
+					])
+					return
+				_seam_agreed += 1
+				break

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -21,6 +21,11 @@ extends SceneTree
 ##
 ##   ... live effects 4 4 430x932 touch
 ##
+## `zoom=<n>` and `framed` are the SCREEN FILL controls: `framed` photographs the
+## 160x144 letterbox the hardware had, and `zoom=-3` the whole-region survey:
+##
+##   ... live effects 4 4 1920x1080 zoom=-3
+##
 ## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
 ## `unown_wall` (`DisplayUnownWords`' box, read off a Ruins of Alph chamber's
 ## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
@@ -192,10 +197,15 @@ func _initialize() -> void:
 			var shape: PackedStringArray = args[8].split("x")
 			if shape.size() == 2:
 				_window = Vector2i(int(shape[0]), int(shape[1]))
-		if args.size() >= 10 and args[9] == "touch":
-			var options: Gen2Options = Gen2OptionsStore.current()
-			options.touch_mode = Gen2Options.TOUCH_ALWAYS
-			Gen2InputRuntime.instance().apply_options(options)
+		for extra: String in args.slice(9):
+			if extra == "touch":
+				var options: Gen2Options = Gen2OptionsStore.current()
+				options.touch_mode = Gen2Options.TOUCH_ALWAYS
+				Gen2InputRuntime.instance().apply_options(options)
+			elif extra == "framed":
+				Gen2OptionsStore.current().screen_fill = false
+			elif extra.begins_with("zoom="):
+				Gen2OptionsStore.current().zoom_step = int(extra.trim_prefix("zoom="))
 		_build_live(
 			data, int(args[1]), int(args[2]),
 			Vector2i(int(args[6]), int(args[7])) if args.size() >= 8 else Vector2i(-1, -1),


### PR DESCRIPTION
A window is not the Game Boy's 10:9, and the black bars around a framed screen are room the overworld can draw into. SCREEN FILL, on by default, grows the drawn buffer to the whole control and fills it with more world: the maps the connection graph places around this one, with the map header's border block filling whatever no map covers.

While walking, `+` and `-` zoom, `0` returns to the fitting scale, and the mouse wheel does the same. Three steps past one screen pixel per map pixel is a survey of the region. Settings > Application > Screen switches back to Framed.

## Nothing the cartridge laid out moves

Interface goes inside a 160x144 rectangle centred in the buffer, clipped to it the way the viewport used to clip. A screen that owns the whole picture paints the surround in the same colour a framed screen leaves there, so those screens are pixel for pixel what they were: a battle, the pack, the PC, and `DoBattleTransition`, whose twenty by eighteen cells stop where the hardware screen did. The mart screen and a mid-transition frame are both byte-identical PNGs filled and framed.

The block fold is unchanged inside `wOverworldMapBlocks`. The buffer is drawn over the neighbours and every byte of it is `drawn_block_at`, so a connection strip still stops at the `length` the macro stored. `expanded_block_at` only answers past the margin, where the cartridge holds nothing at all.

## What proves it

`tools/checks/drawn_blocks.gd` sweeps both halves on all three cartridges.

| Cartridge | Buffer blocks agreeing with `drawn_block_at` | Padding blocks off a neighbour matching the map placed behind them |
|---|---|---|
| Gold | 87,942 | 3,403 |
| Silver | 87,942 | 3,403 |
| Crystal | 91,259 | 3,407 |

GUT 3,520/3,520 (11 new cases), `validate.gd -- all` green, `replay_world.gd` 33 routes and 0 failures, and the three-profile story walk unchanged.

## The map fold moves to the GPU

`LoadMetatiles` resolves a block byte to sixteen tiles per screen refresh and this drew one quad per tile to match. A window-filling view wants tens of thousands of them and a survey wants hundreds of thousands. `Gen2WorldMapLayer` hands the block buffer, the metatile table and the coloured tile strip across as three byte textures, and one quad per map does the fold. Nothing is baked, so the strip the tile animation and the map fades already repaint is the one it samples.

## The maps around you are a picture

Their people stand where their map's event data puts them and take the flag and visible-hours tests. Nothing else about them runs: no scripts, no walking, no wild encounters, no collision, no talking. `ReadObjectEvents` fills `wMapObjects` from the loaded map alone, so on the cartridge a connected map's people do not exist until it is loaded.

## Three defects on the way

- The grass tuft over a sprite walked the whole visible page for each sprite standing in grass, to draw at most six tiles.
- A battle transition redrawn over that tuft resolved a fresh palette table per sprite; the strip's own is already resolved and kept.
- The player sprite was drawn against the hardware screen's origin rather than the drawn surface's, which put it in the wrong place in a wider view.