### PR TITLE
Keep screen fill out of a view that declined the hardware buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ cursor -- stays inside the 160x144 rectangle in the middle of it, exactly where
 the cartridge put it. Only the surround grows.
 
 While walking, `+` and `-` zoom, `0` returns to the fitting scale, and the mouse
-wheel does the same. Zooming out past one screen pixel per map pixel is a survey
+wheel does the same. Those keys count screen pixels per Game Boy pixel, so a mod
+drawing the world in 3D keeps them for its own camera and the game leaves them
+alone. Zooming out past one screen pixel per map pixel is a survey
 of the region: the connection graph places the maps around this one and the map
 header's own border block fills what no map covers. The maps around you are a
 picture. Their people stand where their map puts them and nothing else about

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -556,7 +556,7 @@ A registered renderer is a `Node` providing:
 Registration is refused, by name, if any of these is missing or the script is
 not a `Node`, rather than failing on the first drawn frame.
 
-Two methods are optional, on either renderer kind:
+Six methods are optional, on either renderer kind:
 
 | Method | Effect |
 |---|---|
@@ -564,6 +564,8 @@ Two methods are optional, on either renderer kind:
 | `set_native_size(size: Vector2i)` | The native layer's size in window pixels, on creation and on every window change |
 | `interface_opacity() -> float` | How opaque the screen draws the field of its own text box, 0 to 1 |
 | `set_text_box_rect(rect: Rect2i)` | Where that box is, in hardware pixels, on every change and empty when none is on screen |
+| `set_interface_masked(masked: bool)` | A screen laid out in 160x144 has taken the picture, or given it back. See [A screen that fills the window](#a-screen-that-fills-the-window) |
+| `set_screen_rect(rect: Rect2i)` | Where the hardware's 160x144 screen sits inside the native layer, beside every `set_native_size` |
 
 A view built out of geometry cannot be drawn into a 160x144 buffer and then
 magnified, so the second layer is what makes a 3D or HD renderer possible at
@@ -669,6 +671,45 @@ of every cache over its whole padded rectangle and refuses a disagreement.
 
 Live `changeblock` edits are the loaded world's own and are not visible to the
 static form, which is correct for a map nobody is standing on.
+`Gen2WorldAPI.block_revision` counts them, and a map load, so a view caching the
+block buffer knows when to read it again rather than rebuilding per frame.
+
+### The maps past this one's edge
+
+`ChangeMap` copies a map into the middle of `wOverworldMapBlocks`, three blocks
+wider than the map on every side. That margin is `BUFFER_BLOCKS`, it is what a
+connection strip fills, and it is everything the cartridge holds: past it there
+is nothing at all, which is why a 20x18 screen never needed more.
+
+A view wider than that does. The connection graph is walked instead, and the
+whole neighbouring maps are placed in this map's own block coordinates.
+
+| Call | Value |
+|---|---|
+| `map_placements() -> Dictionary` | `"group:number"` to `{map, origin}` for every map the graph reaches from the loaded one, nearest first. The loaded map is not in it: it is the origin |
+| `placements_around(data, map, hops) -> Dictionary` | The same for a map nobody is standing on |
+| `connection_origin_blocks(source, target, connection) -> Vector2i` | Where one connection puts one map, which is the arithmetic the two above and the strip share |
+| `expanded_block_at(x, y) -> int` | `drawn_block_at` inside the buffer, byte for byte; past it, whichever placed map covers the coordinate, and the border block where none does |
+| `in_hardware_buffer(map, x, y) -> bool` | Which of those two answers a coordinate takes |
+
+`PLACEMENT_HOPS` and `PLACEMENT_LIMIT` bound the walk at three hops and 24 maps,
+which is as much as the furthest zoom shows.
+
+`expanded_block_at` is the whole answer for a renderer with one tileset atlas
+only if it never leaves this map's tileset. It does: a placed map is numbered in
+its OWN tileset, so a block read across a tileset boundary is a different
+picture with the same number. Read `map_placements()` and check
+`Gen2WorldMap.tileset` against the loaded one where that matters;
+`GameData.world_tileset(number)` resolves the rest, and `Gen2WorldMap.blocks` and
+`border_block` are public.
+
+`connected_map_objects() -> Array` is the people standing on those maps, as
+`{object, offset}` with the offset in walk cells. They are read-only copies and
+deliberately not part of `Gen2WorldAPI.objects`: `ReadObjectEvents` fills
+`wMapObjects` from the loaded map alone, so on the cartridge a connected map's
+people do not exist until its own map load builds them. They take the event-flag
+and visible-hours tests and nothing else. No step, no script, no sight, no
+collision, no encounter, and they cannot be talked to.
 
 ## Framing the view
 
@@ -679,6 +720,13 @@ static form, which is correct for a map nobody is standing on.
 | `player_position_cells() -> Vector2` | The committed cell plus any in-flight step, in walk cells |
 | `visible_origin_cells() -> Vector2` | The framed view's top-left in fractional walk cells, centred on that position and clamped to the map |
 | `visible_origin_cell() -> Vector2i` | The hardware page origin, which follows the committed cell |
+| `view_pixels: Vector2i` | The drawn surface in hardware pixels, `VIEW_PIXELS` (160x144) unless a screen asked for more |
+| `view_origin_pixels() -> Vector2` | That surface's top-left in world pixels, which is `visible_origin_cells()` scaled when the surface is the hardware's own |
+| `player_view_pixel() -> Vector2i` | The player's pixel inside it, which is `player_pixel_position()` plus half of whatever surround a wider surface added |
+
+The extra a wider surface adds is spread evenly around the screen the cartridge
+would have drawn, so the player keeps the place `PLAYER_VIEW_CELL` puts him in
+and only the surround grows. A renderer framing its own view can ignore all six.
 
 `player_cell` commits at the start of a step, so the hardware page origin moves a
 whole cell the instant one begins. That is what the 160x144 tile page wants and
@@ -693,6 +741,68 @@ runs. `Gen2WorldScreen.select_view()` is that switch, and `cycle_view()` is what
 `V` is bound to: the map, the player and any running script are untouched,
 because a renderer reads world state and must not write it. Two views of one
 world have to agree.
+
+## A screen that fills the window
+
+A window is not the Game Boy's 10:9. **SCREEN FILL** (`Gen2Options.screen_fill`,
+on by default, Settings > Application > Screen) grows the drawn surface to the
+whole control instead of framing 160x144 inside it, and the overworld fills it
+with more map: see [The maps past this one's edge](#the-maps-past-this-ones-edge).
+
+**Everything the cartridge laid out stays put.** Text boxes, menus and the start
+menu go inside a 160x144 rectangle centred in the surface and clipped to it, so
+a mod reading `set_text_box_rect` reads the same numbers it always did.
+
+| Read | Value |
+|---|---|
+| `Gen2Screen.expanded` | Whether this screen grew to its control |
+| `Gen2Screen.view_size() -> Vector2i` | The drawn surface in hardware pixels |
+| `Gen2Screen.view_size_changed(size)` | Emitted when it changes |
+| `Gen2Screen.interface_layer() -> Control` | The 160x144 rectangle, positioned in surface pixels |
+| `Gen2Screen.interface_masked` | Whether the screen is painting its own letterbox |
+| `Gen2Screen.screen_rect() -> Rect2i` | The 160x144 screen in native-layer pixels, which is what `set_screen_rect` pushes |
+
+**`set_native_size` may now be the whole control.** It was always "the screen's
+rectangle at window resolution"; framed, that rectangle was a whole multiple of
+160x144, and expanded it is not. A renderer that sized itself to what it was
+handed needed no edit for this.
+
+**`set_screen_rect` is where the Game Boy screen is inside it**, pushed beside
+every `set_native_size`. That is what turns a hardware-pixel number into a place
+on the surface, `set_text_box_rect`'s rectangle first: framed, the mapping was
+the surface itself, and filled it is not. A hardware pixel `p` lands at
+`rect.position + p * rect.size / Vector2i(160, 144)`.
+
+**A native-layer renderer keeps the zoom keys.** `+`, `-`, `0` and the wheel step
+`Gen2Screen.zoom_step`, and that ladder counts screen pixels per HARDWARE pixel.
+A view that answered `uses_hardware_viewport()` false has no hardware pixel, so
+the screen does not claim those events and they reach `handle_world_input` and a
+mod's own registered actions as usual. Its zoom is its camera's.
+
+**The letterbox is not painted over the native layer.** When a screen laid out in
+160x144 takes the picture -- the pack, the party, the PC, the dex, the trainer
+card, an evolution, a hatch, the day-care, the slot machine, card flip, a battle,
+and `DoBattleTransition` -- the surround becomes bars rather than the world
+behind it. That mask is drawn inside the hardware viewport, which composites over
+the native layer, so raising it would crop a view that had already filled the
+whole surface. It is not raised there. `set_interface_masked(masked)` is how such
+a renderer closes its own surround instead, and the transition is the case it
+exists for: twenty by eighteen cells cannot be widened, so a wedge reaching the
+edge of a filled window is a shape only the view drawing that window can draw. A
+renderer that does not take it keeps drawing what it was drawing.
+`mods/examples/voxel_preview` draws the four bands around `set_screen_rect`'s
+rectangle, which is the same shape the screen paints for a hardware-pixel view.
+
+**A battle fills the window when its renderer draws the place.** `_BattleScene`
+is a 160x144 picture with nothing to put in a wider surface, so the built-in
+arena keeps the bars. A battle renderer on the native layer, staged on the map
+the encounter fired on, has the same world the overworld was filling the window
+with a frame earlier, and takes the setting with it. The HUD does not move either
+way: the panels, the bars and the boxes are hardware pixels in that same centred
+rectangle.
+
+`Gen2Options.zoom_step` is the ladder's position, persisted because it is a view
+preference rather than part of a run.
 
 ## Choosing the view
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -4430,6 +4430,9 @@ func _build_renderer() -> void:
 		_renderer.get_parent().remove_child(_renderer)
 		Gen2Screen.drop(_renderer)
 	_renderer = Gen2ModHost.instance().create_battle_renderer()
+	## Before the layer is chosen, because the surface's size is what
+	## `set_native_size` is about to be told.
+	_apply_screen_fill()
 	if Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
 		_screen.display_content(_renderer)
 	else:
@@ -4440,6 +4443,25 @@ func _build_renderer() -> void:
 	_push_world_context()
 	_push_view()
 	_apply_renderer_interface_style()
+
+
+## SCREEN FILL, which a fight takes only when its renderer draws the place
+## rather than a picture.
+##
+## The built-in arena is `_BattleScene`'s own 160x144 and has nothing to put in a
+## wider buffer, exactly like the pack or the PC, so it keeps the bars the
+## setting gives every other laid-out screen. A renderer on the native layer,
+## staged on the map the encounter fired on, has the same world the overworld was
+## filling the window with a frame earlier, and shrinking it to 10:9 for the
+## length of the battle and back is the surface being decided with the view left
+## out of the question.
+##
+## The interface does not move either way: the panels, the bars and the boxes are
+## hardware pixels laid out in 160x144 and stay in the rectangle
+## [Gen2Screen] centres in the buffer.
+func _apply_screen_fill() -> void:
+	_screen.expanded = Gen2OptionsStore.current().screen_fill \
+		and not Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
 
 
 ## The text box over a native-layer renderer, the same seam
@@ -4473,6 +4495,7 @@ func _push_world_context() -> void:
 func _on_native_size_changed(size_pixels: Vector2i) -> void:
 	if _renderer != null and _renderer.has_method(Gen2ModHost.RENDERER_RESIZE_METHOD):
 		_renderer.call(Gen2ModHost.RENDERER_RESIZE_METHOD, size_pixels)
+	Gen2ModHost.renderer_set_screen_rect(_renderer, _screen.screen_rect())
 
 
 ## Switches the live view without disturbing the battle behind it. The same one

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -103,6 +103,27 @@ const RENDERER_INTERFACE_OPACITY_METHOD: String = "interface_opacity"
 ## when no box is on screen. A renderer composing around the box reads this
 ## instead of assuming the standard twenty by six at row twelve.
 const RENDERER_TEXT_BOX_METHOD: String = "set_text_box_rect"
+## Optional, both renderer kinds. Called when a screen laid out in 160x144 takes
+## the picture over the view, and again when it gives it back.
+##
+## A renderer drawing in hardware pixels needs nothing: the screen paints its own
+## letterbox around the rectangle and that mask is inside the hardware viewport.
+## A native-layer renderer is not covered by it, deliberately, since the mask
+## would crop a view that already filled the whole surface. This is how such a
+## renderer closes its own surround instead, and `DoBattleTransition` is the case
+## it exists for: twenty by eighteen cells cannot be widened, so the wedge
+## closing over a filled window is a shape only the view drawing that window can
+## draw. A renderer that does not take it keeps drawing what it was drawing.
+const RENDERER_INTERFACE_MASK_METHOD: String = "set_interface_masked"
+## Optional, both renderer kinds, and only meaningful on the native layer. Called
+## beside [constant RENDERER_RESIZE_METHOD] with the cartridge's own 160x144
+## screen expressed in that layer's pixels.
+##
+## Every hardware-pixel number a renderer is handed -- the text box's rectangle,
+## first -- has to land somewhere inside the surface it draws on. Framed, that
+## mapping was the surface itself, because it was a whole multiple of 160x144.
+## A surface filling the window is not, so this is where the screen is.
+const RENDERER_SCREEN_RECT_METHOD: String = "set_screen_rect"
 ## The id of the built-in 2D renderer, which is always registered for both
 ## renderer kinds.
 const BUILT_IN_RENDERER: StringName = &"gen2"
@@ -1377,6 +1398,25 @@ static func renderer_set_text_box_rect(renderer: Node, rect: Rect2i) -> void:
 	if renderer == null or not renderer.has_method(RENDERER_TEXT_BOX_METHOD):
 		return
 	renderer.call(RENDERER_TEXT_BOX_METHOD, rect)
+
+
+## Tells [param renderer] that a screen laid out in the hardware's own 160x144
+## has taken the picture, or given it back. See
+## [constant RENDERER_INTERFACE_MASK_METHOD]; a renderer that does not ask is not
+## called.
+static func renderer_set_interface_masked(renderer: Node, masked: bool) -> void:
+	if renderer == null or not renderer.has_method(RENDERER_INTERFACE_MASK_METHOD):
+		return
+	renderer.call(RENDERER_INTERFACE_MASK_METHOD, masked)
+
+
+## Tells [param renderer] where the hardware's 160x144 screen sits inside the
+## layer it draws on. See [constant RENDERER_SCREEN_RECT_METHOD]; a renderer that
+## does not ask is not called.
+static func renderer_set_screen_rect(renderer: Node, rect: Rect2i) -> void:
+	if renderer == null or not renderer.has_method(RENDERER_SCREEN_RECT_METHOD):
+		return
+	renderer.call(RENDERER_SCREEN_RECT_METHOD, rect)
 
 
 static func _renderer_takes_input(renderer: Node, method: String, event: InputEvent) -> bool:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -26,11 +26,21 @@ const FILENAME: String = "mod.json"
 ## [method Gen2WorldAPI.hidden_items].
 ## 8 added [method Gen2ModHost.register_stats_page], a page of a Pokémon's stats
 ## screen past the cartridge's own three.
+## 9 added the evolution an item causes, on the item record itself.
+## 10 is the screen that fills the window: the connection graph past the
+## cartridge's three-block margin ([method Gen2WorldAPI.map_placements],
+## [method Gen2WorldAPI.expanded_block_at],
+## [method Gen2WorldAPI.connected_map_objects]), the wider drawn surface
+## ([member Gen2WorldAPI.view_pixels]) and
+## [constant Gen2ModHost.RENDERER_INTERFACE_MASK_METHOD] beside
+## [constant Gen2ModHost.RENDERER_SCREEN_RECT_METHOD]. A view on the native
+## layer needs it: whether the host claims the zoom keys and paints its letterbox
+## over that layer is a behaviour no mod can feature-detect.
 ##
 ## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
 ## host that has never heard of either ignores the field, so a mod that ships
 ## art still installs on an older launcher and simply has no face there.
-const API_VERSION: int = 9
+const API_VERSION: int = 10
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -162,6 +162,20 @@ func view_size() -> Vector2i:
 	return _view_size
 
 
+## The cartridge's own 160x144 screen, in the native layer's own pixels.
+##
+## A view on that layer is handed a rectangle and told nothing else, and every
+## hardware-pixel number it is given -- the text box's, first -- has to land
+## somewhere inside it. Framed, that mapping was the layer itself, since the
+## rectangle was a whole multiple of 160x144. Expanded it is not, so the screen
+## says where.
+func screen_rect() -> Rect2i:
+	var drawn: Vector2 = Vector2(WIDTH, HEIGHT) * _draw_scale
+	var at: Vector2 = (_interface.position if _interface != null else Vector2.ZERO) \
+		* _draw_scale
+	return Rect2i(Vector2i(at.round()), Vector2i(drawn.round()))
+
+
 ## The largest whole number of window pixels per hardware pixel that fits.
 ## Public because [Gen2GameFrame] sizes the on-screen controller off it.
 static func fit_factor(area: Vector2) -> int:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -236,6 +236,11 @@ var _spending_frame: bool = false
 var _sound_schedule: Array = []
 var _sound_schedule_frame: int = 0
 var _screen_base_position: Vector2 = Vector2.ZERO
+## Whether a screen laid out in 160x144 owns the picture, as last told to the
+## renderer, and whether it has been told at all: [method _apply_interface_mask]
+## runs every frame, and a renderer swapped in mid-scene has heard nothing.
+var _interface_owned: bool = false
+var _interface_owned_pushed: bool = false
 
 @onready var _screen: Gen2Screen = %Screen
 @onready var _caption: Label = %Caption
@@ -449,6 +454,8 @@ func _apply_renderer_interface_style() -> void:
 	# A renderer swapped in mid-scene has no rectangle, so this one is not deduped.
 	_text_box_rect_pushed = false
 	_push_text_box_rect()
+	_interface_owned_pushed = false
+	_apply_interface_mask()
 
 
 ## Pushed only when the rectangle actually changes, and never while a page turn
@@ -506,8 +513,17 @@ func _apply_screen_fill() -> void:
 ## nothing wider, so a wedge pattern in a filled window would stop where the
 ## cartridge's screen ended. It closes the surround for the battle that follows
 ## it, which is masked for the same reason.
+##
+## The mask is drawn inside the hardware viewport and the viewport is composited
+## over the native layer, so raising it would crop a renderer that is not drawing
+## in the buffer it describes: one of those has already filled the whole surface,
+## and a letterbox around a rectangle it never used has nothing to say about it.
+## Such a renderer is told instead
+## ([constant Gen2ModHost.RENDERER_INTERFACE_MASK_METHOD]) and closes its own
+## surround in its own units, which is the only way a transition's wedge reaches
+## the edge of a filled window.
 func _apply_interface_mask() -> void:
-	_screen.interface_masked = _screen.expanded and (
+	var owned: bool = (
 		_battle_transition != null
 		or _battle_host != null or _service_host != null or _party_host != null
 		or _hall_of_fame_host != null or _trainer_card_host != null
@@ -518,6 +534,13 @@ func _apply_interface_mask() -> void:
 		or _unown_puzzle_host != null or _slot_machine_host != null
 		or _card_flip_host != null
 	)
+	_screen.interface_masked = _screen.expanded and owned \
+		and Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
+	if _interface_owned_pushed and owned == _interface_owned:
+		return
+	_interface_owned = owned
+	_interface_owned_pushed = true
+	Gen2ModHost.renderer_set_interface_masked(_renderer, owned)
 
 
 func _on_view_size_changed(size_pixels: Vector2i) -> void:
@@ -534,6 +557,7 @@ func _on_native_size_changed(size_pixels: Vector2i) -> void:
 	if _renderer != null \
 		and _renderer.has_method(Gen2ModHost.RENDERER_RESIZE_METHOD):
 		_renderer.call(Gen2ModHost.RENDERER_RESIZE_METHOD, size_pixels)
+	Gen2ModHost.renderer_set_screen_rect(_renderer, _screen.screen_rect())
 
 
 ## Switches the live view without disturbing the world behind it. The choice is
@@ -1192,9 +1216,16 @@ func _complete_unattended_request() -> Array:
 ## laid out against the 160x144 rectangle and moving the surface under one is
 ## the player losing their place. A framed screen refuses the step, since there
 ## is no more world to show and it would only shrink the picture
-## ([method Gen2Screen.step_zoom]).
+## ([method Gen2Screen.step_zoom]), and so does a view on the native layer, which
+## has no hardware pixel for the ladder to count.
 func _handle_zoom(event: InputEvent) -> bool:
 	if not _renderer_input_free() or not _screen.expanded:
+		return false
+	## A view that declined the hardware buffer has no hardware pixel to scale:
+	## the ladder's unit is screen pixels per one of those, and what a step moves
+	## is a buffer that renderer never draws into. Its zoom is its camera's own
+	## registered action, and leaving the event alone is what reaches it.
+	if not Gen2ModHost.renderer_uses_hardware_viewport(_renderer):
 		return false
 	var delta: int = 0
 	var key := event as InputEventKey

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 9,
+	"api_version": 10,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 9,
+	"api_version": 10,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -7,9 +7,12 @@ extends SubViewportContainer
 ## permission, the block grid, the tileset's palettes, the player's cell) and
 ## extrudes a solid per cell with a camera on the player.
 ##
-## It answers [code]uses_hardware_viewport[/code] false, so it gets the Game Boy
-## screen's rectangle at window resolution rather than a 160x144 buffer. Text
-## boxes and menus stay hardware pixels over the top.
+## It answers [code]uses_hardware_viewport[/code] false, so it gets the screen's
+## own rectangle at window resolution rather than a 160x144 buffer, which under
+## SCREEN FILL is the whole window. Text boxes and menus stay hardware pixels
+## over the top, inside the rectangle [method set_screen_rect] names, and the
+## letterbox around them is this view's own to draw ([method
+## set_interface_masked]) because the screen's cannot reach this layer.
 ##
 ## It reads the world and never writes it, so the two renderers can be swapped
 ## mid-step and neither can tell the other what changed.
@@ -52,6 +55,12 @@ var _objects: Node3D = null
 var _time_of_day: int = 0
 var _camera_pitch: float = CAMERA_PITCH_DEGREES
 var _text_box_rect := Rect2i()
+## Where the cartridge's own screen sits inside this view, and whether a screen
+## laid out in it currently owns the picture. See [method set_screen_rect] and
+## [method set_interface_masked].
+var _screen_rect := Rect2i()
+var _interface_masked: bool = false
+var _surround: Control = null
 
 
 func _init() -> void:
@@ -96,6 +105,14 @@ func _init() -> void:
 	_player.material_override = _material(Color("#d34a5a"))
 	_viewport.add_child(_player)
 
+	# Over the viewport rather than in it: this is the letterbox the screen draws
+	# for a hardware-pixel renderer and cannot draw for this one.
+	_surround = Control.new()
+	_surround.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_surround.visible = false
+	_surround.draw.connect(_draw_surround)
+	add_child(_surround)
+
 	# The setting mod.gd registered, read once here and again whenever it
 	# changes, so a value picked in the start menu or the launcher reaches the
 	# camera without this view polling for it. Null means the entry script did
@@ -134,6 +151,58 @@ func text_box_rect() -> Rect2i:
 	return _text_box_rect
 
 
+## Where the hardware's 160x144 screen is inside this view, which is what turns
+## a hardware-pixel number such as [method text_box_rect] into a place on it. It
+## is the whole view when the screen is framed and a rectangle in the middle when
+## it fills the window. See Gen2ModHost.RENDERER_SCREEN_RECT_METHOD.
+func set_screen_rect(rect: Rect2i) -> void:
+	_screen_rect = rect
+	_place_surround()
+
+
+func screen_rect() -> Rect2i:
+	return _screen_rect
+
+
+## A screen laid out in 160x144 has taken the picture. The host's own letterbox
+## is drawn inside the hardware viewport and cannot reach this layer, so a view
+## that filled the window closes its own surround, around the rectangle
+## [method set_screen_rect] named. A view drawing `DoBattleTransition`'s own
+## wedge across the whole window would draw that here instead. See
+## Gen2ModHost.RENDERER_INTERFACE_MASK_METHOD.
+func set_interface_masked(masked: bool) -> void:
+	_interface_masked = masked
+	_place_surround()
+
+
+func interface_masked() -> bool:
+	return _interface_masked
+
+
+func _place_surround() -> void:
+	if _surround == null:
+		return
+	_surround.visible = _interface_masked and _screen_rect.size.x > 0
+	_surround.size = size
+	_surround.queue_redraw()
+
+
+## The four bands around the hardware screen, which is the same shape
+## [Gen2Screen] paints for a renderer drawing in hardware pixels. Dimmed rather
+## than filled, because there is a diorama under it worth still seeing.
+func _draw_surround() -> void:
+	var inside := Rect2(_screen_rect)
+	var shade := Color(0.0, 0.0, 0.0, 0.72)
+	for band: Rect2 in [
+		Rect2(0.0, 0.0, size.x, inside.position.y),
+		Rect2(0.0, inside.end.y, size.x, size.y - inside.end.y),
+		Rect2(0.0, inside.position.y, inside.position.x, inside.size.y),
+		Rect2(inside.end.x, inside.position.y, size.x - inside.end.x, inside.size.y),
+	]:
+		if band.size.x > 0.0 and band.size.y > 0.0:
+			_surround.draw_rect(band, shade, true)
+
+
 func _on_option_changed(id: StringName, key: StringName, value: Variant) -> void:
 	if id != MOD_ID:
 		return
@@ -156,9 +225,12 @@ func _on_action_changed(id: StringName, key: StringName, pressed: bool) -> void:
 
 
 ## The container's own size is all that is set here: a stretching
-## SubViewportContainer owns its viewport's size and refuses a manual one.
+## SubViewportContainer owns its viewport's size and refuses a manual one. It may
+## be the whole window rather than a whole multiple of 160x144, which is what
+## SCREEN FILL means for this layer.
 func set_native_size(size_pixels: Vector2i) -> void:
 	size = Vector2(size_pixels)
+	_place_surround()
 
 
 func set_world(world: Gen2WorldAPI, _animation: Gen2WorldAnimation = null) -> void:

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -1,9 +1,11 @@
 extends GutTest
 
 ## The interface seam a native-layer renderer gets: how opaque the screen draws
-## its own text box, and where that box is, plus the seam a mod's world actor
-## gets, which is the same shape one layer down. Both screens are the production
-## paths; only the renderer and the actor are synthetic.
+## its own text box, where that box is, when a screen laid out in 160x144 takes
+## the picture over it, and whether the surface it is handed fills the window.
+## Plus the seam a mod's world actor gets, which is the same shape one layer
+## down. Both screens are the production paths; only the renderer and the actor
+## are synthetic.
 ##
 ## The contract is that the box stays the screen's. A renderer asks and is told;
 ## it never draws or moves the box, and the frame and the glyphs are opaque
@@ -14,6 +16,8 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 const NATIVE_SOURCE: String = """extends Node2D
 
 var rects: Array = []
+var masks: Array = []
+var screens: Array = []
 
 func set_world(_world, _animation = null) -> void:
 	pass
@@ -41,6 +45,12 @@ func interface_opacity() -> float:
 
 func set_text_box_rect(rect: Rect2i) -> void:
 	rects.append(rect)
+
+func set_interface_masked(masked: bool) -> void:
+	masks.append(masked)
+
+func set_screen_rect(rect: Rect2i) -> void:
+	screens.append(rect)
 """
 
 ## The same request from a renderer drawing in hardware pixels, which cannot be
@@ -70,6 +80,10 @@ var _battle_screen: Gen2BattleScreen = null
 
 
 func before_each() -> void:
+	# SCREEN FILL is what half of this file measures, and the persisting a zoom
+	# step does must not reach the developer's own options file.
+	Gen2OptionsStore.use_test_path()
+	Gen2OptionsStore.current().screen_fill = true
 	_forget_view()
 	Fixture.build()
 	_data = GameData.open_directory(Fixture.directory())
@@ -757,4 +771,104 @@ func test_a_consumed_press_redraws_on_the_frame_it_was_pressed() -> void:
 	## the emote is already on screen, so the icon's flip is all that is left.
 	assert_eq(
 		int(_world_screen._actors.sprites()[0]["emote"]), Gen2WorldActors.EMOTE_HEART
+	)
+
+
+## SCREEN FILL's letterbox is drawn inside the hardware viewport, and the
+## viewport is composited over the native layer, so raising it would crop a view
+## that had already filled the whole surface.
+func test_the_interface_mask_does_not_reach_the_native_layer() -> void:
+	var renderer: Node = await _open_world(NATIVE_SOURCE)
+	assert_true(_world_screen._screen.expanded, "the overworld fills the window")
+	assert_eq((renderer.get("masks") as Array), [false], "told once, before anything opened")
+
+	_world_screen.preview_battle_transition(0)
+	assert_false(
+		_world_screen._screen.interface_masked,
+		"the screen leaves the layer behind it alone",
+	)
+	assert_eq(
+		(renderer.get("masks") as Array).back(), true,
+		"and tells the view to close its own surround",
+	)
+
+
+## A renderer drawing in the hardware buffer is masked by the screen, which is
+## what the letterbox describes.
+func test_a_hardware_viewport_renderer_keeps_the_screens_own_mask() -> void:
+	await _open_world(HARDWARE_SOURCE)
+	assert_false(_world_screen._screen.interface_masked)
+	_world_screen.preview_battle_transition(0)
+	assert_true(_world_screen._screen.interface_masked)
+
+
+## Zoom counts screen pixels per HARDWARE pixel. A view that declined the
+## hardware buffer has none, so the keys are left where its own camera can read
+## them rather than spent stepping a buffer nothing draws into.
+func test_zoom_is_left_alone_for_a_view_with_no_hardware_pixel() -> void:
+	await _open_world(NATIVE_SOURCE)
+	var before: int = _world_screen._screen.zoom_step
+	assert_false(_world_screen._handle_zoom(_key(KEY_MINUS)))
+	assert_eq(_world_screen._screen.zoom_step, before, "and nothing moved")
+
+
+func test_zoom_steps_the_buffer_a_hardware_renderer_draws_into() -> void:
+	await _open_world(HARDWARE_SOURCE)
+	var before: int = _world_screen._screen.zoom_step
+	assert_true(_world_screen._handle_zoom(_key(KEY_MINUS)))
+	assert_eq(_world_screen._screen.zoom_step, before - 1)
+
+
+func _key(code: Key) -> InputEventKey:
+	var event := InputEventKey.new()
+	event.keycode = code
+	event.pressed = true
+	return event
+
+
+## A fight staged on the map in 3D has as much to fill a window with as the
+## overworld it started from; the built-in arena is a 160x144 scene and has not.
+func test_a_native_layer_battle_fills_the_window_and_the_built_in_one_does_not() -> void:
+	await _open_battle()
+	assert_true(_battle_screen._screen.expanded)
+
+	_battle_screen.free()
+	_battle_screen = null
+	assert_true(Gen2ModHost.instance().select_view(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	_battle_screen = packed.instantiate() as Gen2BattleScreen
+	_battle_screen.set_data(_data)
+	add_child(_battle_screen)
+	await get_tree().process_frame
+	assert_false(_battle_screen._screen.expanded)
+
+
+## A hardware-pixel number means nothing on the native layer without the
+## rectangle the hardware screen occupies there. Framed it was the whole surface,
+## and filled it is not, so the screen says where.
+func test_the_native_layer_is_told_where_the_hardware_screen_is() -> void:
+	var renderer: Node = await _open_world(NATIVE_SOURCE)
+	var screen: Gen2Screen = _world_screen._screen
+	assert_true(screen.expanded)
+	var rect: Rect2i = (renderer.get("screens") as Array).back()
+	assert_eq(rect, screen.screen_rect())
+	assert_gt(rect.position.x, 0, "centred in a surface wider than the hardware's")
+	assert_eq(
+		float(rect.size.x) / float(rect.size.y),
+		float(Gen2Screen.WIDTH) / float(Gen2Screen.HEIGHT),
+		"and still ten by nine",
+	)
+	assert_lt(rect.size.x, screen.native_size().x, "with the view around it")
+
+
+## Framed, the rectangle is the whole surface, which is the mapping every
+## renderer written before this assumed.
+func test_a_framed_screen_hands_back_its_whole_surface() -> void:
+	Gen2OptionsStore.current().screen_fill = false
+	var renderer: Node = await _open_world(NATIVE_SOURCE)
+	var screen: Gen2Screen = _world_screen._screen
+	assert_false(screen.expanded)
+	assert_eq(
+		(renderer.get("screens") as Array).back(),
+		Rect2i(Vector2i.ZERO, screen.native_size()),
 	)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -26,7 +26,16 @@ extends SceneTree
 ##
 ##   ... live effects 4 4 1920x1080 zoom=-3
 ##
+## `view=<mod id>` photographs a registered renderer instead of the built-in one,
+## which needs `--mods` in front of the `--` so the mods are actually loaded:
+##
+##   Godot --path . -s res://tools/preview_world.gd --mods -- crystal 26 2 \
+##     /tmp/out.png live effects 4 4 1920x1080 view=voxel3d
+##
 ## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
+## `battle` (the wild fight `preview_battle_request` starts, settled past its
+## transition into the fight itself, which is the picture a battle renderer
+## staged on the map draws),
 ## `unown_wall` (`DisplayUnownWords`' box, read off a Ruins of Alph chamber's
 ## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
 ## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
@@ -104,6 +113,10 @@ const ICE_SLIDE_BUTTONS: Array[int] = [
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## What the live mode actually opens in, which a phone-shaped argument replaces.
 var _window: Vector2i = WINDOW_SIZE
+## The renderer to photograph, empty for whichever one the installation last
+## chose. Restored after the capture so a preview never changes that choice.
+var _view: StringName = &""
+var _restore_view: StringName = &""
 ## Longer than a step onto a warp tile and the fade behind it, for the `warp`
 ## kind, which drives to a frame rather than spending a count.
 const WARP_FRAME_CAP: int = 120
@@ -206,6 +219,8 @@ func _initialize() -> void:
 				Gen2OptionsStore.current().screen_fill = false
 			elif extra.begins_with("zoom="):
 				Gen2OptionsStore.current().zoom_step = int(extra.trim_prefix("zoom="))
+			elif extra.begins_with("view="):
+				_view = StringName(extra.trim_prefix("view="))
 		_build_live(
 			data, int(args[1]), int(args[2]),
 			Vector2i(int(args[6]), int(args[7])) if args.size() >= 8 else Vector2i(-1, -1),
@@ -294,6 +309,8 @@ func _process(_delta: float) -> bool:
 	## call in [method _build_live] alone leaves the screen spending frames of
 	## its own beside the ones staged below.
 	_screen.set_process(false)
+	if _frames == 1:
+		_choose_view()
 	if _frames == 2:
 		if _kind == &"unown_wall":
 			## The chamber's own `bg_event ..., BGEVENT_UP`: face the wall from
@@ -305,6 +322,12 @@ func _process(_delta: float) -> bool:
 			## is what runs `special DisplayUnownWords` and puts the box up.
 			_screen.press_button(Gen2Button.A)
 			_screen.press_button(Gen2Button.A)
+		elif _kind == &"battle":
+			## Past the transition and into the fight it opens, which is the one
+			## picture a battle renderer staged on the map draws.
+			_screen.preview_battle_request()
+			_screen.settle_battle_transition()
+			_screen.advance_frames(STAGED_FRAMES)
 		elif _kind == &"battle_transition":
 			## `DoBattleTransition` over the map it runs on. The first of the two
 			## numbers is how many frames into it to photograph rather than a
@@ -529,8 +552,9 @@ func _process(_delta: float) -> bool:
 			_screen.preview_effect_sprites(_kind)
 		if _kind not in [
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
-			&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
-			&"move_deleter", &"move_tutor", &"day_care", &"ice_slide",
+			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
+			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
+			&"ice_slide",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.
@@ -546,8 +570,31 @@ func _process(_delta: float) -> bool:
 		quit(1)
 		return true
 	print("Wrote %s (%dx%d)" % [_output_path, image.get_width(), image.get_height()])
+	_restore_selected_view()
 	quit(0)
 	return true
+
+
+## The mod's own renderer, once there is one to choose: `_initialize` runs before
+## the autoloads are in the tree, so nothing is registered while the screen is
+## being built and the choice has to wait for the first frame.
+func _choose_view() -> void:
+	if _view.is_empty():
+		return
+	_restore_view = Gen2ModHost.instance().selected_view()
+	var chosen: Dictionary = _screen.select_view(_view)
+	if not bool(chosen.get("ok", false)):
+		push_error("View %s unavailable: %s. Did you pass --mods?" % [
+			_view, chosen.get("reason", "unknown")
+		])
+
+
+## A view is chosen per installation and persisted, so a capture that chose one
+## puts the player's own back rather than leaving them on a mod's renderer.
+func _restore_selected_view() -> void:
+	if _view.is_empty() or _restore_view.is_empty():
+		return
+	Gen2ModHost.instance().select_view(_restore_view)
 
 
 func _render(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Image:


### PR DESCRIPTION
Answers R33 from the mods repo. Screen fill was written for the buffer the cartridge drew into, then applied to a surface that is not one. Everything below is the same sentence four times, for a renderer answering `uses_hardware_viewport()` false.

## R33a: the zoom keys

The ladder counts screen pixels per HARDWARE pixel. A view on the native layer has none, so `+`, `-`, `0`, the keypad pair and both wheel notches were being spent stepping a buffer nothing draws into, and were claimed before the mod-action dispatch a 3D camera's own dolly arrives through. The screen no longer claims them there.

## R33b: the letterbox

The mask is painted inside the hardware viewport, and the viewport composites over the native layer, so raising it cropped a view that had already filled the whole surface. Seventeen hosts and `DoBattleTransition` each snapped the world behind them into a 160x144 box and back. It is not raised there.

`set_interface_masked(masked)` tells such a renderer instead, feature-detected beside `set_text_box_rect`. That is the only way a transition's wedge reaches the edge of a filled window: twenty by eighteen cells cannot be widened, so the shape can only be drawn by the view drawing that window.

## R33c: a battle

`_BattleScene` is a 160x144 picture with nothing to put in a wider surface and keeps the bars, like the pack or the PC. A battle renderer on the native layer, staged on the map the encounter fired on, has the world the overworld was filling the window with a frame earlier, and takes the setting with it. The host's HUD does not move either way.

## The gap under all of it

Writing the example renderer found what R33 did not name: a hardware-pixel number has nowhere to land on the native layer any more. Framed, the mapping was the surface itself, because it was a whole multiple of 160x144. Filled it is not, and `set_text_box_rect`'s rectangle had quietly stopped meaning anything there.

`set_screen_rect(rect)` is pushed beside every `set_native_size` with the Game Boy screen's place inside the layer. Framed it is the whole surface, which is what every renderer written before this assumed, so nothing changes for one. `mods/examples/voxel_preview` draws its own letterbox around it and dims rather than fills, because there is a view under it worth still seeing.

## R33d: the contract

`docs/MODS.md` had none of PR #344. It now has the drawn surface (`view_pixels`, `view_origin_pixels()`, `player_view_pixel()`), the maps past this one's edge (`map_placements()`, `placements_around()`, `connection_origin_blocks()`, `expanded_block_at()`, `in_hardware_buffer()`, `connected_map_objects()`, `block_revision`, and the four constants), a section on the filling screen, and the two new renderer methods. The cross-tileset trap is written down: a placed map is numbered in its OWN tileset, so a block read across that boundary is a different picture with the same number.

`api_version` 10 is what a mod declares for the lot. Whether the host claims those keys and paints over that layer is behaviour no mod can feature-detect, so there has to be a number for it.

## Proof

| Check | Result |
|---|---|
| GUT (unit + scene) | 3,527 / 3,527, 7 new cases |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| voxel3d 0.4.0 on a 1600x900 window | overworld, mart and a battle photographed uncropped |

`tools/preview_world.gd` grows `view=<mod id>` (with `--mods`) and a `battle` kind, which is how those were photographed. It puts the installation's own chosen view back afterwards.