### PR TITLE
Draw each map group's own roof, and keep Crystal's two swarms apart

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -101,6 +101,7 @@ var _world_command_queues: Dictionary = {}
 var _world_tilesets: Dictionary = {}
 var _world_encounters: Dictionary = {}
 var _world_palettes: Array = []
+var _world_roofs: Dictionary = {}
 var _decoded_palettes: Dictionary = {}
 var _world_animation_assets: Dictionary = {}
 var _overworld_sprites: Array = []
@@ -999,6 +1000,88 @@ func world_palette(number: int) -> PackedColorArray:
 		out.append(Gen2Palette.from_packed(int(packed)))
 	_decoded_palettes[number] = out
 	return out
+
+
+## `MapGroupRoofs`: which of the five roof runs a map group draws, or -1 for a
+## group whose maps have no roof tiles of their own.
+func map_group_roof(map_group: int) -> int:
+	var groups: Variant = _roofs().get("groups", [])
+	if not groups is Array or map_group < 0 or map_group >= (groups as Array).size():
+		return -1
+	var value: int = int((groups as Array)[map_group])
+	return -1 if value == 0xFF else value
+
+
+## One roof run as an eight-row index strip, the shape a tileset's own tiles come
+## in, so [constant RomLayout.ROOF_TILES] tiles can be written straight over
+## `vTiles2 tile $0a`.
+func roof_tile_indices(roof: int) -> PackedByteArray:
+	var tiles: Variant = _roofs().get("tiles", [])
+	if not tiles is Array or roof < 0 or roof >= (tiles as Array).size():
+		return PackedByteArray()
+	var raw: Variant = (tiles as Array)[roof]
+	if not raw is Array:
+		return PackedByteArray()
+	var out := PackedByteArray()
+	out.resize((raw as Array).size())
+	for index: int in out.size():
+		out[index] = int((raw as Array)[index]) & 0xFF
+	return out
+
+
+## A map group's two roof colours, which stand in for colours 1 and 2 of
+## `PAL_BG_ROOF`. `_LoadMapPals` walks four bytes forward for NITE and DARKNESS,
+## so [param night] is the second pair rather than a third row.
+func roof_palette(map_group: int, night: bool) -> PackedColorArray:
+	var palettes: Variant = _roofs().get("palettes", [])
+	var out := PackedColorArray()
+	if not palettes is Array or map_group < 0 or map_group >= (palettes as Array).size():
+		return out
+	var raw: Variant = (palettes as Array)[map_group]
+	if not raw is Array or (raw as Array).size() < 4:
+		return out
+	var at: int = 2 if night else 0
+	for index: int in 2:
+		out.append(Gen2Palette.from_packed(int((raw as Array)[at + index])))
+	return out
+
+
+## `LoadMapGroupRoof`, which runs on every map load whatever the environment is:
+## a map group's nine roof tiles are copied over `vTiles2 tile $0a`, so they
+## replace whatever the tileset's own strip holds there. A group with no roof
+## (`cp -1 / ret z`) is handed its strip back unchanged.
+##
+## [param roof] is [method map_group_roof]'s answer, passed in rather than a map,
+## because the overworld's animated strip goes through here on every pass that
+## rotates a tile and the group is already resolved by then.
+func roofed_tile_indices(
+	indices: PackedByteArray, roof: int, tile_count: int
+) -> PackedByteArray:
+	if roof < 0:
+		return indices
+	var tiles: PackedByteArray = roof_tile_indices(roof)
+	var roof_width: int = RomLayout.ROOF_TILES * Gen2Tiles.TILE_WIDTH
+	var width: int = tile_count * Gen2Tiles.TILE_WIDTH
+	var left: int = RomLayout.ROOF_VRAM_TILE * Gen2Tiles.TILE_WIDTH
+	if tiles.size() < roof_width * Gen2Tiles.TILE_HEIGHT \
+		or indices.size() < width * Gen2Tiles.TILE_HEIGHT or left + roof_width > width:
+		return indices
+	var out: PackedByteArray = indices.duplicate()
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in roof_width:
+			out[y * width + left + x] = tiles[y * roof_width + x]
+	return out
+
+
+## The strip a map is actually drawn from: its tileset's own tiles with its map
+## group's roof over them. Every static reader of a map's tiles goes through
+## this so none of them can forget the roof.
+func map_tile_indices(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> PackedByteArray:
+	if map == null or tileset == null:
+		return PackedByteArray()
+	return roofed_tile_indices(
+		world_tileset_indices(tileset.number), map_group_roof(map.group), tileset.tile_count
+	)
 
 
 ## Raw 2bpp frames embedded in the cartridge's animation routines.
@@ -2618,6 +2701,12 @@ func _palettes() -> Array:
 	if _claim_section("palettes"):
 		_world_palettes = _read_section(RomCache.world_palettes_path(directory), true)
 	return _world_palettes
+
+
+func _roofs() -> Dictionary:
+	if _claim_section("roofs"):
+		_world_roofs = _read_section(RomCache.world_roofs_path(directory), false)
+	return _world_roofs
 
 
 func _animation_assets() -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -44,6 +44,7 @@ const WORLD_COMMAND_QUEUES: String = "world_command_queues.json"
 const WORLD_TILESETS: String = "world_tilesets.json"
 const WORLD_ENCOUNTERS: String = "world_encounters.json"
 const WORLD_PALETTES: String = "world_palettes.json"
+const WORLD_ROOFS: String = "world_roofs.json"
 const WORLD_ANIMATION_ASSETS: String = "world_animation_assets.json"
 const WORLD_TILES_DIR: String = "world_tiles"
 const OVERWORLD_EFFECTS: String = "overworld_effects.json"
@@ -80,7 +81,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 81
+const FORMAT_VERSION: int = 82
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a
@@ -207,6 +208,10 @@ static func world_encounters_path(directory: String) -> String:
 
 static func world_palettes_path(directory: String) -> String:
 	return "%s/%s" % [directory, WORLD_PALETTES]
+
+
+static func world_roofs_path(directory: String) -> String:
+	return "%s/%s" % [directory, WORLD_ROOFS]
 
 
 static func world_animation_assets_path(directory: String) -> String:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -278,6 +278,18 @@ const WORLD_PALETTE_GROUP_COUNT: int = 42
 const WORLD_PALETTE_GROUP_BYTES: int = 8
 const WORLD_PALETTE_BYTES: int = WORLD_PALETTE_GROUP_COUNT * WORLD_PALETTE_GROUP_BYTES
 const WORLD_PALETTE_MAP_BYTES: int = 0x70
+
+## `LoadMapGroupRoof` and `RoofPals`. A map group names one of five nine-tile
+## roof runs, copied over `vTiles2 tile $0a` on every map load, and `_LoadMapPals`
+## replaces colours 1 and 2 of `PAL_BG_ROOF` with that group's own pair on a TOWN
+## or ROUTE map. `MapGroupRoofs` is NUM_MAP_GROUPS + 1 bytes and `RoofPals` is
+## two colours for morn/day and two for nite per group.
+const MAP_GROUP_ROOF_COUNT: int = 27
+const ROOF_COUNT: int = 5
+const ROOF_TILES: int = 9
+const ROOF_TILE_BYTES: int = ROOF_TILES * 16
+const ROOF_PALETTE_BYTES: int = 8
+const ROOF_VRAM_TILE: int = 0x0A
 const WORLD_ANIMATION_BANK: int = 0x3F
 const WORLD_ANIMATION_COMMAND_BYTES: int = 4
 const WORLD_ANIMATION_MAX_COMMANDS: int = 64
@@ -2217,6 +2229,9 @@ const GOLD_SILVER: Dictionary = {
 	"tileset_block_counts": [128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 40],
 	"tileset_palette_bank": 0x02,
 	"world_palette_offset": 0xB75E,
+	"roof_palettes": 0xB9AE,
+	"map_group_roofs": 0x1C021,
+	"roof_tiles": 0x1C03C,
 	"overworld_sprites": 0x147DE,
 	"overworld_sprite_count": 95,
 	"overworld_sprite_palettes": 0xB8AE,
@@ -2682,6 +2697,9 @@ const CRYSTAL: Dictionary = {
 	"tileset_block_counts": [128, 128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 40, 64, 64, 64, 64, 64],
 	"tileset_palette_bank": 0x13,
 	"world_palette_offset": 0xB319,
+	"roof_palettes": 0xB569,
+	"map_group_roofs": 0x1C021,
+	"roof_tiles": 0x1C03C,
 	"overworld_sprites": 0x14736,
 	## NUM_OVERWORLD_SPRITES (constants/sprite_constants.asm), which is the last
 	## constant's own value: SPRITE_STANDING_YOUNGSTER is $66. Crystal's four rows

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -69,6 +69,8 @@ static func import_to_cache(
 		return {"ok": false, "message": "Could not write overworld tileset data."}
 	if not RomCache.write_json(RomCache.world_palettes_path(directory), result["palettes"]):
 		return {"ok": false, "message": "Could not write overworld palette data."}
+	if not RomCache.write_json(RomCache.world_roofs_path(directory), result["roofs"]):
+		return {"ok": false, "message": "Could not write overworld roof data."}
 	if not RomCache.write_json(
 		RomCache.world_animation_assets_path(directory), result["animation_assets"]
 	):
@@ -173,6 +175,9 @@ static func read_world(
 	var animation_assets: Dictionary = _read_world_animation_assets(rom, layout)
 	if not bool(animation_assets.get("ok", false)):
 		return animation_assets
+	var roofs: Dictionary = _read_world_roofs(rom, layout)
+	if not bool(roofs.get("ok", false)):
+		return roofs
 
 	var tilesets: Array = []
 	var graphics: Dictionary = {}
@@ -235,6 +240,7 @@ static func read_world(
 		"tilesets": tilesets,
 		"graphics": graphics,
 		"palettes": palettes["groups"],
+		"roofs": roofs["roofs"],
 		"animation_assets": animation_assets["assets"],
 		"sprites": sprites["sprites"],
 		"sprite_palettes": sprites["palettes"],
@@ -831,6 +837,44 @@ static func _read_world_palettes(rom: RomFile, layout: Dictionary) -> Dictionary
 			colors.append(int(bytes[at]) | (int(bytes[at + 1]) << 8))
 		groups.append(colors)
 	return {"ok": true, "groups": groups}
+
+
+## `LoadMapGroupRoof` and `_LoadMapPals`' own roof branch, as one record.
+##
+## The tiles are a plain 2bpp run of [constant RomLayout.ROOF_COUNT] nine-tile
+## roofs, and the palette pair is read whole rather than split: `RoofPals`' row
+## is morn/day's two colours then nite's two, and which half a map takes is the
+## renderer's question rather than the importer's.
+static func _read_world_roofs(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var groups: PackedByteArray = rom.slice(
+		int(layout["map_group_roofs"]), RomLayout.MAP_GROUP_ROOF_COUNT
+	)
+	if groups.size() != RomLayout.MAP_GROUP_ROOF_COUNT:
+		return _error("The map group roof table is outside the cartridge.")
+	var tile_bytes: int = RomLayout.ROOF_COUNT * RomLayout.ROOF_TILE_BYTES
+	var raw: PackedByteArray = rom.slice(int(layout["roof_tiles"]), tile_bytes)
+	if raw.size() != tile_bytes:
+		return _error("The roof tiles are outside the cartridge.")
+	var palette_bytes: int = RomLayout.MAP_GROUP_ROOF_COUNT * RomLayout.ROOF_PALETTE_BYTES
+	var packed: PackedByteArray = rom.slice(int(layout["roof_palettes"]), palette_bytes)
+	if packed.size() != palette_bytes:
+		return _error("The roof palettes are outside the cartridge.")
+
+	var palettes: Array = []
+	for group: int in RomLayout.MAP_GROUP_ROOF_COUNT:
+		var colors: Array = []
+		for color: int in 4:
+			var at: int = group * RomLayout.ROOF_PALETTE_BYTES + color * 2
+			colors.append(int(packed[at]) | (int(packed[at + 1]) << 8))
+		palettes.append(colors)
+	var tiles: Array = []
+	for roof: int in RomLayout.ROOF_COUNT:
+		tiles.append(Array(Gen2Tiles.decode_2bpp_strip(
+			raw, roof * RomLayout.ROOF_TILE_BYTES, RomLayout.ROOF_TILES
+		)))
+	return {"ok": true, "roofs": {
+		"groups": Array(groups), "tiles": tiles, "palettes": palettes,
+	}}
 
 
 static func _read_world_animation_assets(rom: RomFile, layout: Dictionary) -> Dictionary:

--- a/game/render/unown_wall_page.gd
+++ b/game/render/unown_wall_page.gd
@@ -25,7 +25,7 @@ static func render(
 	var blocks: Array = Gen2UnownWall.blocks(word)
 	if blocks.is_empty():
 		return null
-	var indices: PackedByteArray = data.world_tileset_indices(tileset.number)
+	var indices: PackedByteArray = data.map_tile_indices(map, tileset)
 	if indices.size() < RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS:
 		return null
 	var menu: Gen2MenuPage = Gen2MenuPage.from_data(data)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2132,8 +2132,11 @@ func repel_steps() -> int:
 	return state.repel_steps()
 
 
-func set_swarm_map(map_key: Vector2i, active: bool = true, fishing_species: int = 0) -> void:
-	state.set_swarm_map(map_key, active, fishing_species)
+func set_swarm_map(
+	map_key: Vector2i, active: bool = true, fishing_species: int = 0,
+	kind: int = Gen2WorldState.SWARM_DUNSPARCE,
+) -> void:
+	state.set_swarm_map(map_key, active, fishing_species, kind)
 
 
 func roaming_mons() -> Array:
@@ -2155,6 +2158,7 @@ func advance_schedule(random: RandomNumberGenerator = null) -> Dictionary:
 			"reason": &"missing_schedule_random",
 			"roaming": [],
 			"swarm_map": state.swarm_map(),
+			"yanma_swarm_map": state.swarm_map(Gen2WorldState.SWARM_YANMA),
 			"fishing_swarm_species": state.fishing_swarm_species(),
 		}
 	var moved: Array = advance_roaming(random)
@@ -2163,6 +2167,7 @@ func advance_schedule(random: RandomNumberGenerator = null) -> Dictionary:
 		"kind": &"world_schedule_updated",
 		"roaming": moved,
 		"swarm_map": state.swarm_map(),
+		"yanma_swarm_map": state.swarm_map(Gen2WorldState.SWARM_YANMA),
 		"fishing_swarm_species": state.fishing_swarm_species(),
 	}
 

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -143,10 +143,34 @@ static func fade_palette(palette: PackedColorArray, order: int) -> PackedColorAr
 	return out
 
 
+## `PAL_BG_ROOF`, the one background slot whose colours are not the row's own.
+const PAL_BG_ROOF: int = 6
+
+
 static func palette_slots(environment: int, time_of_day: int) -> Array:
 	var environment_index: int = clampi(environment, 0, PALETTE_ROWS.size() - 1)
 	var time_index: int = clampi(time_of_day, 0, 3)
 	return (PALETTE_ROWS[environment_index] as Array)[time_index]
+
+
+## The two colours a map group lends `PAL_BG_ROOF`, or nothing when the map is
+## not one `_LoadMapPals` reaches the roof branch for.
+##
+## `cp NITE_F / jr c, .morn_day` is the whole test, so DARKNESS takes the nite
+## pair as well: the four rows are two, not four.
+static func roof_colors(
+	data: GameData, environment: int, time_of_day: int, map_group: int
+) -> PackedColorArray:
+	if data == null or map_group < 0:
+		return PackedColorArray()
+	if environment != ENVIRONMENT_TOWN and environment != ENVIRONMENT_ROUTE:
+		return PackedColorArray()
+	return data.roof_palette(map_group, time_of_day >= TIME_NIGHT)
+
+
+## `wEnvironment`'s TOWN and ROUTE, the two `_LoadMapPals` tests by hand.
+const ENVIRONMENT_TOWN: int = 1
+const ENVIRONMENT_ROUTE: int = 2
 
 
 ## One palette per tile of [param tileset], in tile order.
@@ -176,6 +200,16 @@ static func tile_palettes(
 		elif slot == 4 and cave_color >= 0 and base.size() >= 2:
 			palette[0] = base[clampi(cave_color, 0, 1)]
 		resolved.append(palette)
+	# `_LoadMapPals`' own tail: colours 1 and 2 of `PAL_BG_ROOF` come from the
+	# map group rather than from the time-of-day row, and only a TOWN or ROUTE
+	# map reaches the branch at all.
+	var roof: PackedColorArray = roof_colors(data, map.environment, time_of_day, map.group)
+	if roof.size() == 2 and resolved.size() > PAL_BG_ROOF:
+		var slot_palette: PackedColorArray = resolved[PAL_BG_ROOF]
+		if slot_palette.size() >= 3:
+			slot_palette[1] = roof[0]
+			slot_palette[2] = roof[1]
+			resolved[PAL_BG_ROOF] = slot_palette
 	# `FillWhiteBGColor`, which only the fade out of the map runs: every
 	# background palette takes palette 0's own colour 0, so the order that
 	# flattens a palette onto it flattens the screen onto one white.

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -163,17 +163,26 @@ func refresh_animation() -> void:
 	var changed: PackedInt32Array = _animation.changed_tiles()
 	if changed.is_empty():
 		return
-	var indices: PackedByteArray = _animation.current_indices()
+	var animated: PackedByteArray = _animation.current_indices()
 	for entry: Dictionary in _atlases.values():
 		if not bool(entry["animated"]):
 			continue
+		# The roof stands over `vTiles2 tile $0a` for as long as the map is
+		# loaded, so an animation pass rebuilds the strip under it rather than
+		# replacing it.
+		var indices: PackedByteArray = _world.data.roofed_tile_indices(
+			animated, int(entry["roof"]), int(entry["tile_count"])
+		)
 		var image: Image = entry["image"]
 		var palettes: Array = entry["palettes"]
 		for tile: int in changed:
 			_paint_tile(image, indices, palettes, tile)
 		(entry["texture"] as ImageTexture).update(image)
 		entry["indices"] = indices
-	_priority_indices = indices
+	# The priority strip is the map being walked on, not whichever cached strip
+	# the loop ended on: a connected map in another group has its own roof.
+	var current: Dictionary = _atlas_for(_world.current_map, _world.current_tileset)
+	_priority_indices = current["indices"] if not current.is_empty() else animated
 	_priority_atlas = null
 	queue_redraw()
 
@@ -208,7 +217,7 @@ func _rebuild_atlas() -> void:
 func _atlas_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Dictionary:
 	if map == null or tileset == null or _world == null or _world.data == null:
 		return {}
-	var key: String = "%d:%d" % [tileset.number, map.environment]
+	var key: String = "%d:%d:%d" % [tileset.number, map.environment, map.group]
 	if _atlases.has(key):
 		return _atlases[key]
 	var indices: PackedByteArray = _world.data.world_tileset_indices(tileset.number)
@@ -219,6 +228,8 @@ func _atlas_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Dictionary:
 		indices = _animation.current_indices()
 	if indices.size() < tileset.tile_count * Gen2Tiles.TILE_PIXELS:
 		return {}
+	var roof: int = _world.data.map_group_roof(map.group)
+	indices = _world.data.roofed_tile_indices(indices, roof, tileset.tile_count)
 	var palettes: Array = _tile_palettes_for(map, tileset)
 	var image := Image.create(
 		tileset.tile_count * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT,
@@ -232,6 +243,8 @@ func _atlas_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Dictionary:
 		"palettes": palettes,
 		"indices": indices,
 		"animated": animated,
+		"roof": roof,
+		"tile_count": tileset.tile_count,
 	}
 	_atlases[key] = entry
 	return entry

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2224,6 +2224,9 @@ func world_snapshot() -> Dictionary:
 		"just_battled": _world.state.just_battled() if _world != null else false,
 		"fishing_state": _world.fishing_state() if _world != null else Gen2WorldFishing.STATE_IDLE,
 		"swarm_map": _world.state.swarm_map() if _world != null else Vector2i(-1, -1),
+		"yanma_swarm_map": _world.state.swarm_map(
+			Gen2WorldState.SWARM_YANMA
+		) if _world != null else Vector2i(-1, -1),
 		"roaming_count": _world.state.roaming_mons().size() if _world != null else 0,
 		"owned_rods": _world.available_fishing_rods() if _world != null else [],
 		"owned_balls": Gen2WorldPartyHost.owned_capture_balls(_world) if _world != null else [],

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -811,12 +811,18 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		var map_group: int = int(result.get("map_group", values.get("map_group", -1)))
 		var map_number: int = int(result.get("map_number", values.get("map_number", -1)))
 		var fishing_species: int = int(result.get("fishing_species", 0))
+		var swarm_kind: int = int(
+			result.get("kind", values.get("kind", Gen2WorldState.SWARM_DUNSPARCE))
+		)
 		if active and (map_group < 0 or map_number < 0):
 			return _fail(&"invalid_swarm_map", result)
 		if fishing_species not in [0, 0xD3, 0xDF]:
 			return _fail(&"invalid_fishing_swarm_species", result)
+		if swarm_kind not in [Gen2WorldState.SWARM_DUNSPARCE, Gen2WorldState.SWARM_YANMA]:
+			return _fail(&"invalid_swarm_kind", result)
 		_staged_swarm = {
 			"active": active,
+			"kind": swarm_kind,
 			"map_group": map_group,
 			"map_number": map_number,
 			"fishing_species": fishing_species,
@@ -824,6 +830,7 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		_has_staged_swarm = true
 		_events.append({
 			"type": &"swarm_changed",
+			"kind": swarm_kind,
 			"map_group": map_group,
 			"map_number": map_number,
 			"active": active,
@@ -2003,7 +2010,11 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 				return given
 			return _stage_give_item_script(verbose_item, verbose_name)
 		0x9E:
+			## Crystal's `swarm` carries which of the two swarms it is setting
+			## and pokegold's does not, because `StoreSwarmMapIndices` there
+			## writes one pair whatever `c` holds.
 			return _stage_runtime_request(&"swarm_requested", {
+				"kind": int(command.get("flag", Gen2WorldState.SWARM_DUNSPARCE)),
 				"map_group": int(command.get("map_group", 0)),
 				"map_number": int(command.get("map_number", 0)),
 			})

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -23,6 +23,9 @@ const SCRIPT_MEMORY_CAPACITY: int = 64
 ## from the `StepHappiness` pass at zero.
 const EGG_STEP_PHASE: int = 0x80
 const PHONE_RECEIVE_DELAYS: Array[int] = [20, 10, 5, 3]
+## `StoreSwarmMapIndices`' own two arguments, `constants/script_constants.asm`.
+const SWARM_DUNSPARCE: int = 0
+const SWARM_YANMA: int = 1
 const TEMPORARY_MAP_RELOAD_FLAGS: Array[int] = [0, 1, 2, 3, 4, 5, 6, 7]
 ## Crystal maps STATUSFLAGS_HALL_OF_FAME_F through the source engine flag
 ## table to ENGINE_CREDITS_SKIP, and the Goldenrod bargain merchant uses the
@@ -180,7 +183,13 @@ var _contest_mon: Dictionary = {}
 ## `wBugContestSecondPartySpecies`: the byte `ContestDropOffMons` moves out of
 ## the way so the party is one Pokemon long, and `ContestReturnMons` puts back.
 var _contest_second_party_species: int = 0
-var _swarm_map: Vector2i = Vector2i(-1, -1)
+## `wDunsparceMapGroup`/`wDunsparceMapNumber` and `wYanmaMapGroup`/
+## `wYanmaMapNumber`: Crystal's two swarms are independent, each with its own
+## `wSwarmFlags` bit, and `_SwarmWildmonCheck` tries Dunsparce before Yanma.
+## Gold and Silver hold one `wSwarmMapGroup` and their own
+## `StoreSwarmMapIndices` takes no kind, so only [constant SWARM_DUNSPARCE] is
+## ever written on those two.
+var _swarm_maps: Array[Vector2i] = [Vector2i(-1, -1), Vector2i(-1, -1)]
 var _fishing_swarm_species: int = 0
 var _roaming_mons: Array = []
 var _seen_species: Dictionary = {}
@@ -271,7 +280,7 @@ func _init(
 		if bool(initial_phone_contacts[raw_contact]) and _phone_contacts.size() < PHONE_CONTACT_CAPACITY:
 			_phone_contacts[int(raw_contact)] = true
 	_repel_steps = maxi(0, initial_repel_steps)
-	_swarm_map = initial_swarm_map
+	_swarm_maps[SWARM_DUNSPARCE] = initial_swarm_map
 	_fishing_swarm_species = initial_fishing_swarm_species if initial_fishing_swarm_species in [0, 0xD3, 0xDF] else 0
 	_roaming_mons = _copy_roaming_mons(initial_roaming_mons)
 	for raw_species: Variant in initial_seen_species:
@@ -321,7 +330,8 @@ func to_dict() -> Dictionary:
 		"bug_contest_started": _bug_contest_started.duplicate(),
 		"contest_mon": _contest_mon.duplicate(),
 		"contest_second_party_species": _contest_second_party_species,
-		"swarm_map": [_swarm_map.x, _swarm_map.y],
+		"swarm_map": [_swarm_maps[SWARM_DUNSPARCE].x, _swarm_maps[SWARM_DUNSPARCE].y],
+		"yanma_swarm_map": [_swarm_maps[SWARM_YANMA].x, _swarm_maps[SWARM_YANMA].y],
 		"fishing_swarm_species": _fishing_swarm_species,
 		"roaming_mons": _copy_roaming_mons(_roaming_mons),
 		"seen_species": _seen_species.duplicate(),
@@ -385,6 +395,12 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 			if pc_item > 0 and pc_quantity > 0 \
 				and restored._pc_items.size() < Gen2WorldPack.MAX_PC_ITEMS:
 				restored._pc_items[pc_item] = pc_quantity
+	## Absent in a state written while there was one swarm slot. Crystal's Yanma
+	## swarm reads as inactive then, which is what a save taken before the news
+	## announced one would hold anyway.
+	restored._swarm_maps[SWARM_YANMA] = _vector_from_value(
+		source.get("yanma_swarm_map", [-1, -1])
+	)
 	restored._map_music = maxi(0, int(source.get("map_music", MUSIC_NONE)))
 	restored.set_radio_knob(int(source.get("radio_knob", Gen2WorldRadio.KNOB_MIN)))
 	restored._radio_channel = int(source.get("radio_channel", -1))
@@ -464,7 +480,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_bug_contest_started = restored._bug_contest_started.duplicate()
 	_contest_mon = restored._contest_mon.duplicate()
 	_contest_second_party_species = restored._contest_second_party_species
-	_swarm_map = restored._swarm_map
+	_swarm_maps = restored._swarm_maps.duplicate()
 	_fishing_swarm_species = restored._fishing_swarm_species
 	_roaming_mons = _copy_roaming_mons(restored._roaming_mons)
 	_seen_species = restored._seen_species.duplicate()
@@ -1248,22 +1264,28 @@ static func _mon_from_value(raw: Variant) -> Gen2SaveMon:
 	return Gen2SaveMon.from_dict(raw)
 
 
-func swarm_map() -> Vector2i:
-	return _swarm_map
+func swarm_map(kind: int = SWARM_DUNSPARCE) -> Vector2i:
+	return _swarm_maps[clampi(kind, SWARM_DUNSPARCE, SWARM_YANMA)]
 
 
-func set_swarm_map(map_id: Vector2i, active: bool = true, fishing_species: int = 0) -> void:
+func set_swarm_map(
+	map_id: Vector2i, active: bool = true, fishing_species: int = 0,
+	kind: int = SWARM_DUNSPARCE,
+) -> void:
+	var slot: int = clampi(kind, SWARM_DUNSPARCE, SWARM_YANMA)
 	var next_map: Vector2i = map_id if active else Vector2i(-1, -1)
 	var next_species: int = fishing_species if fishing_species in [0, 0xD3, 0xDF] else 0
-	if _swarm_map == next_map and _fishing_swarm_species == next_species:
+	if _swarm_maps[slot] == next_map and _fishing_swarm_species == next_species:
 		return
-	_swarm_map = next_map
+	_swarm_maps[slot] = next_map
 	_fishing_swarm_species = next_species
 	changed.emit()
 
 
+## `_SwarmWildmonCheck` tries Dunsparce and then Yanma, so two swarms stand at
+## once and whichever names this map answers.
 func swarm_active_on(map_group: int, map_number: int) -> bool:
-	return _swarm_map == Vector2i(map_group, map_number)
+	return _swarm_maps.has(Vector2i(map_group, map_number))
 
 
 func fishing_swarm_species() -> int:
@@ -1532,7 +1554,7 @@ func apply_changes(
 	var swarm_change: Variant = runtime_changes.get("swarm", null)
 	if swarm_change != null and not swarm_change is Dictionary:
 		return {"ok": false, "reason": &"invalid_swarm"}
-	var next_swarm_map: Vector2i = _swarm_map
+	var next_swarm_maps: Array[Vector2i] = _swarm_maps.duplicate()
 	var next_fishing_swarm_species: int = _fishing_swarm_species
 	if swarm_change is Dictionary:
 		var swarm: Dictionary = swarm_change
@@ -1544,7 +1566,12 @@ func apply_changes(
 		var swarm_species: int = int(swarm.get("fishing_species", 0))
 		if swarm_species not in [0, 0xD3, 0xDF]:
 			return {"ok": false, "reason": &"invalid_fishing_swarm_species"}
-		next_swarm_map = Vector2i(swarm_group, swarm_number) if swarm_active else Vector2i(-1, -1)
+		var swarm_kind: int = int(swarm.get("kind", SWARM_DUNSPARCE))
+		if swarm_kind != SWARM_DUNSPARCE and swarm_kind != SWARM_YANMA:
+			return {"ok": false, "reason": &"invalid_swarm_kind"}
+		next_swarm_maps[swarm_kind] = (
+			Vector2i(swarm_group, swarm_number) if swarm_active else Vector2i(-1, -1)
+		)
 		next_fishing_swarm_species = swarm_species
 	var next_repel_steps: int = int(runtime_changes.get("repel_steps", _repel_steps))
 	if next_repel_steps < 0:
@@ -1675,7 +1702,7 @@ func apply_changes(
 		or next_contacts != _phone_contacts or next_just_battled != _just_battled \
 		or next_seen_species != _seen_species \
 		or next_caught_species != _caught_species \
-		or next_repel_steps != _repel_steps or next_swarm_map != _swarm_map \
+		or next_repel_steps != _repel_steps or next_swarm_maps != _swarm_maps \
 		or next_fishing_swarm_species != _fishing_swarm_species \
 		or next_receive_cycle != _phone_receive_cycle \
 		or next_receive_minutes != _phone_receive_minutes \
@@ -1695,7 +1722,7 @@ func apply_changes(
 	_phone_contacts = next_contacts
 	_just_battled = next_just_battled
 	_repel_steps = next_repel_steps
-	_swarm_map = next_swarm_map
+	_swarm_maps = next_swarm_maps
 	_fishing_swarm_species = next_fishing_swarm_species
 	_phone_receive_cycle = next_receive_cycle
 	_phone_receive_minutes = next_receive_minutes

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -192,6 +192,24 @@ func _write_cache() -> void:
 	RomCache.write_json(
 		RomCache.world_animation_assets_path(_directory), {"water": water, "forest": forest}
 	)
+	# Two roofs of nine tiles each, every pixel carrying its own roof number, and
+	# a group table naming one, the other and none.
+	var roof_tiles: Array = []
+	for roof: int in 2:
+		var run: Array = []
+		run.resize(RomLayout.ROOF_TILES * Gen2Tiles.TILE_PIXELS)
+		for index: int in run.size():
+			run[index] = roof + 1
+		roof_tiles.append(run)
+	var roof_groups: Array = [0, 1, 0xFF]
+	var roof_palettes: Array = []
+	for group: int in roof_groups.size():
+		roof_palettes.append([
+			0x0001 + group, 0x0002 + group, 0x0003 + group, 0x0004 + group,
+		])
+	RomCache.write_json(RomCache.world_roofs_path(_directory), {
+		"groups": roof_groups, "tiles": roof_tiles, "palettes": roof_palettes,
+	})
 	RomCache.write_json(RomCache.manifest_path(_directory), {
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": "testanimation",
@@ -404,3 +422,62 @@ func _lit_row(animation: Gen2WorldAnimation, tile: int) -> int:
 		if animation.current_indices()[y * width + tile * Gen2Tiles.TILE_WIDTH] != 0:
 			return y
 	return -1
+
+
+## `LoadMapGroupRoof` copies nine tiles over `vTiles2 tile $0a` and touches
+## nothing else, and a group whose entry is -1 leaves the strip alone.
+func test_a_map_group_roof_replaces_nine_tiles_of_the_strip() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var tileset: Gen2WorldTileset = data.world_tileset(0)
+	var base: PackedByteArray = data.world_tileset_indices(0)
+	var width: int = tileset.tile_count * Gen2Tiles.TILE_WIDTH
+	var left: int = RomLayout.ROOF_VRAM_TILE * Gen2Tiles.TILE_WIDTH
+	var span: int = RomLayout.ROOF_TILES * Gen2Tiles.TILE_WIDTH
+
+	assert_eq(data.map_group_roof(0), 0)
+	assert_eq(data.map_group_roof(1), 1)
+	assert_eq(data.map_group_roof(2), -1)
+
+	for group: int in 2:
+		var map := Gen2WorldMap.from_cache({"group": group, "tileset": 0})
+		var drawn: PackedByteArray = data.map_tile_indices(map, tileset)
+		assert_eq(drawn.size(), base.size())
+		for y: int in Gen2Tiles.TILE_HEIGHT:
+			for x: int in width:
+				var inside: bool = x >= left and x < left + span
+				assert_eq(
+					drawn[y * width + x], group + 1 if inside else base[y * width + x],
+					"group %d pixel %d,%d" % [group, x, y],
+				)
+
+	var plain := Gen2WorldMap.from_cache({"group": 2, "tileset": 0})
+	assert_eq(data.map_tile_indices(plain, tileset), base)
+
+
+## `_LoadMapPals`' tail: colours 1 and 2 of `PAL_BG_ROOF` come from the map
+## group, on a TOWN or ROUTE map alone, and `cp NITE_F` puts DARKNESS on the
+## nite pair rather than a third one.
+func test_roof_colours_replace_two_slots_on_outdoor_maps_only() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var morning: PackedColorArray = Gen2WorldPalette.roof_colors(
+		data, Gen2WorldPalette.ENVIRONMENT_TOWN, Gen2WorldPalette.TIME_MORNING, 1
+	)
+	assert_eq(morning.size(), 2)
+	assert_eq(morning[0], Gen2Palette.from_packed(0x0002))
+	assert_eq(morning[1], Gen2Palette.from_packed(0x0003))
+	for time: int in [Gen2WorldPalette.TIME_NIGHT, Gen2WorldPalette.TIME_DARK]:
+		var night: PackedColorArray = Gen2WorldPalette.roof_colors(
+			data, Gen2WorldPalette.ENVIRONMENT_ROUTE, time, 1
+		)
+		assert_eq(night[0], Gen2Palette.from_packed(0x0004))
+		assert_eq(night[1], Gen2Palette.from_packed(0x0005))
+	for environment: int in [0, 3, 4, 6, 7]:
+		assert_eq(Gen2WorldPalette.roof_colors(
+			data, environment, Gen2WorldPalette.TIME_DAY, 1
+		).size(), 0, "environment %d has no roof branch" % environment)
+	# `_LoadMapPals` reads `RoofPals` off `wMapGroup` alone and never consults
+	# `MapGroupRoofs`, so a group with no roof tiles still tints the slot.
+	assert_eq(data.map_group_roof(2), -1)
+	assert_eq(Gen2WorldPalette.roof_colors(
+		data, Gen2WorldPalette.ENVIRONMENT_TOWN, Gen2WorldPalette.TIME_DAY, 2
+	)[0], Gen2Palette.from_packed(0x0003))

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4698,6 +4698,49 @@ func test_swarm_runtime_request_commits_its_map_indices_as_one_transaction() -> 
 	assert_eq(state.fishing_swarm_species(), 0xD3)
 
 
+## Crystal's two swarms are two WRAM pairs with a `wSwarmFlags` bit each, and
+## `_SwarmWildmonCheck` tries Dunsparce before Yanma, so setting one leaves the
+## other standing. pokegold has one pair and its `StoreSwarmMapIndices` takes no
+## kind at all.
+func test_the_two_crystal_swarms_stand_at_once() -> void:
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:60B0": [0xA0, Gen2WorldState.SWARM_DUNSPARCE, 1, 2, 0x91],
+		"48:60C0": [0xA0, Gen2WorldState.SWARM_YANMA, 3, 4, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	var state := Gen2WorldState.new()
+	for entry: Array in [
+		[0x60B0, Gen2WorldState.SWARM_DUNSPARCE, 1, 2],
+		[0x60C0, Gen2WorldState.SWARM_YANMA, 3, 4],
+	]:
+		var runner := Gen2WorldScriptRunner.begin(data, state, {
+			"kind": &"test", "bank": 48, "script": int(entry[0]),
+		})
+		var waiting: Dictionary = runner.advance()
+		assert_eq(waiting["event"]["request"]["values"]["kind"], int(entry[1]))
+		var done: Dictionary = runner.complete_runtime_request({
+			"ok": true, "active": true,
+			"map_group": int(entry[2]), "map_number": int(entry[3]),
+		})
+		assert_eq(done["status"], &"complete")
+
+	assert_eq(state.swarm_map(Gen2WorldState.SWARM_DUNSPARCE), Vector2i(1, 2))
+	assert_eq(state.swarm_map(Gen2WorldState.SWARM_YANMA), Vector2i(3, 4))
+	assert_true(state.swarm_active_on(1, 2))
+	assert_true(state.swarm_active_on(3, 4))
+	assert_false(state.swarm_active_on(1, 4))
+
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(restored.swarm_map(Gen2WorldState.SWARM_YANMA), Vector2i(3, 4))
+	# A state written before the second slot existed restores with Yanma clear.
+	var old_state: Dictionary = state.to_dict()
+	old_state.erase("yanma_swarm_map")
+	assert_eq(
+		Gen2WorldState.from_dict(old_state).swarm_map(Gen2WorldState.SWARM_YANMA),
+		Vector2i(-1, -1),
+	)
+
+
 func test_crystal_engine_flags_and_hall_of_fame_commit_at_script_end() -> void:
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
 		"48:60C0": [

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -30,6 +30,12 @@ const BG_PALETTES: Array[String] = [
 	"GRAY", "RED", "GREEN", "WATER", "YELLOW", "BROWN", "ROOF", "TEXT",
 ]
 
+## `data/maps/roofs.asm`'s five `INCBIN`s in order, so the row index is the
+## `ROOF_*` value.
+const ROOF_FILES: Array[String] = [
+	"new_bark", "violet", "azalea", "olivine", "goldenrod",
+]
+
 ## `constants/hardware.inc`: `OAM_BANK1 equ 1 << B_OAM_BANK1`.
 const OAM_BANK1: int = 1 << 3
 
@@ -53,6 +59,7 @@ func _check_game() -> void:
 		return
 	_check_blocks(pin)
 	_check_tilesets(pin)
+	_check_roofs(pin)
 
 
 # --- Map block arrays -------------------------------------------------------
@@ -202,6 +209,193 @@ func _check_palette_reach(number: int, tileset: Gen2WorldTileset) -> void:
 		_report("tileset %d names tile %d, past its %d-byte palette map." % [
 			number, highest, tileset.palette_map.size()
 		])
+
+
+# --- Roofs ------------------------------------------------------------------
+
+
+## `MapGroupRoofs`, `RoofPals` and the strip `LoadMapGroupRoof` writes over.
+##
+## The two tables are compared against the pin's own text, and the strip is
+## checked from the other side: a group that names a roof must change tiles
+## $0A..$12 of every tileset it draws with, since a copy that lands somewhere
+## else or reads the wrong run is silent until someone looks at a town.
+func _check_roofs(pin: String) -> void:
+	var groups: PackedByteArray = _roof_groups(pin)
+	var palettes: Array = _roof_palettes(pin)
+	if groups.is_empty() or palettes.is_empty():
+		_report("the pin carries no roof tables.")
+		return
+	_r.check(
+		groups.size() == RomLayout.MAP_GROUP_ROOF_COUNT
+			and palettes.size() == RomLayout.MAP_GROUP_ROOF_COUNT,
+		"the pin lists %d roof groups and %d palettes, %d expected." % [
+			groups.size(), palettes.size(), RomLayout.MAP_GROUP_ROOF_COUNT,
+		],
+	)
+	var roofed: int = 0
+	for group: int in mini(groups.size(), RomLayout.MAP_GROUP_ROOF_COUNT):
+		var ours: int = _r.data.map_group_roof(group)
+		var pinned: int = -1 if groups[group] == 0xFF else int(groups[group])
+		if ours != pinned:
+			_report("map group %d draws roof %d, the pin says %d." % [group, ours, pinned])
+			continue
+		if pinned < 0:
+			continue
+		roofed += 1
+		_r.check(
+			pinned < RomLayout.ROOF_COUNT,
+			"map group %d names roof %d, past the %d the cartridge holds." % [
+				group, pinned, RomLayout.ROOF_COUNT,
+			],
+		)
+		for night: bool in [false, true]:
+			var colors: PackedColorArray = _r.data.roof_palette(group, night)
+			var expected: Array = palettes[group]
+			var at: int = 2 if night else 0
+			if colors.size() != 2:
+				_report("map group %d has %d roof colours, 2 expected." % [
+					group, colors.size(),
+				])
+				continue
+			for index: int in 2:
+				var pinned_color: Color = Gen2Palette.from_packed(int(expected[at + index]))
+				if not colors[index].is_equal_approx(pinned_color):
+					_report("map group %d colour %d (%s) is %s, the pin says %s." % [
+						group, index, "nite" if night else "morn/day",
+						colors[index], pinned_color,
+					])
+	_r.note("roof groups %d, of which %d carry one." % [groups.size(), roofed])
+	_check_roof_strips(pin)
+
+
+## Every (map group, tileset) pair the corpus really draws: the strip a map is
+## given must hold that group's own roof at tiles $0A..$12 and its tileset's own
+## tiles everywhere else.
+##
+## The roof itself is compared against the pin's `gfx/tilesets/roofs/*.png`
+## rather than against the cache, so a wrong offset or a wrong run is caught by
+## the source and not by a second reading of the same bytes. rgbgfx maps the
+## shade rather than its rank, so `$FF` is index 0 and `$00` is index 3.
+func _check_roof_strips(pin: String) -> void:
+	var seen: Dictionary = {}
+	var pairs: int = 0
+	for group: int in RomLayout.MAP_GROUP_ROOF_COUNT:
+		for number: int in RomLayout.MAP_GROUP_ROOF_COUNT * 16:
+			var map: Gen2WorldMap = _r.data.world_map(group, number)
+			if map == null:
+				continue
+			var key: String = "%d:%d" % [group, map.tileset]
+			if seen.has(key):
+				continue
+			seen[key] = true
+			var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+			if tileset == null:
+				continue
+			pairs += 1
+			_compare_roof_strip(pin, group, map, tileset)
+	_r.note("map group and tileset pairs walked: %d." % pairs)
+
+
+func _compare_roof_strip(
+	pin: String, group: int, map: Gen2WorldMap, tileset: Gen2WorldTileset
+) -> void:
+	var base: PackedByteArray = _r.data.world_tileset_indices(tileset.number)
+	var drawn: PackedByteArray = _r.data.map_tile_indices(map, tileset)
+	if drawn.size() != base.size():
+		_report("map group %d tileset %d: the drawn strip is %d bytes, %d expected." % [
+			group, tileset.number, drawn.size(), base.size(),
+		])
+		return
+	var roof: int = _r.data.map_group_roof(group)
+	var pinned: PackedByteArray = _roof_pixels(pin, roof)
+	var width: int = tileset.tile_count * Gen2Tiles.TILE_WIDTH
+	var left: int = RomLayout.ROOF_VRAM_TILE * Gen2Tiles.TILE_WIDTH
+	var roof_width: int = RomLayout.ROOF_TILES * Gen2Tiles.TILE_WIDTH
+	if roof >= 0 and pinned.size() != roof_width * Gen2Tiles.TILE_HEIGHT:
+		_report("roof %d is not in the pin, so nothing was compared." % roof)
+		return
+	for y: int in Gen2Tiles.TILE_HEIGHT:
+		for x: int in width:
+			var inside: bool = roof >= 0 and x >= left and x < left + roof_width
+			var expected: int = (
+				pinned[y * roof_width + x - left] if inside else base[y * width + x]
+			)
+			if drawn[y * width + x] == expected:
+				continue
+			_report("map group %d tileset %d: pixel %d,%d is %d, %d expected." % [
+				group, tileset.number, x, y, drawn[y * width + x], expected,
+			])
+			return
+
+
+## One roof run out of the pin's own PNG, as index values in the strip shape the
+## cache uses.
+func _roof_pixels(pin: String, roof: int) -> PackedByteArray:
+	if roof < 0 or roof >= ROOF_FILES.size():
+		return PackedByteArray()
+	return _parsed(pin, StringName("roof_%d" % roof), func() -> PackedByteArray:
+		var path: String = pin.path_join("gfx/tilesets/roofs/%s.png" % ROOF_FILES[roof])
+		var image := Image.new()
+		if image.load(path) != OK:
+			return PackedByteArray()
+		var out: PackedByteArray = PackedByteArray()
+		var width: int = RomLayout.ROOF_TILES * Gen2Tiles.TILE_WIDTH
+		out.resize(width * Gen2Tiles.TILE_HEIGHT)
+		# The sheet is a 3x3 block of tiles walked the way rgbgfx walks one, left
+		# to right and then down; the strip is one row of nine.
+		var columns: int = image.get_width() / Gen2Tiles.TILE_WIDTH
+		for tile: int in RomLayout.ROOF_TILES:
+			var at := Vector2i(tile % columns, tile / columns) * Gen2Tiles.TILE_WIDTH
+			for y: int in Gen2Tiles.TILE_HEIGHT:
+				for x: int in Gen2Tiles.TILE_WIDTH:
+					var shade: float = image.get_pixel(at.x + x, at.y + y).r
+					out[y * width + tile * Gen2Tiles.TILE_WIDTH + x] = 3 - roundi(shade * 3.0)
+		return out
+	)
+
+
+## `data/maps/roofs.asm`'s `MapGroupRoofs` table, `-1` kept as $FF.
+func _roof_groups(pin: String) -> PackedByteArray:
+	return _parsed(pin, &"roof_groups", func() -> PackedByteArray:
+		var order: Dictionary = {}
+		var out: PackedByteArray = PackedByteArray()
+		var open: bool = false
+		for line: String in _lines(pin.path_join("data/maps/roofs.asm")):
+			if line.begins_with("const ROOF_"):
+				order[line.substr("const ".length()).strip_edges()] = order.size()
+			elif line.begins_with("MapGroupRoofs:"):
+				open = true
+			elif open and line.begins_with("assert_table_length"):
+				break
+			elif open and line.begins_with("db "):
+				var value: String = line.substr("db ".length()).strip_edges()
+				out.append(0xFF if value == "-1" else int(order.get(value, 0xFF)))
+		return out
+	)
+
+
+## `gfx/tilesets/roofs.pal`, four packed colours a group. The two pins format the
+## same list differently, one `RGB` a line against two colours a line, so the
+## numbers are collected in order rather than by line.
+func _roof_palettes(pin: String) -> Array:
+	return _parsed(pin, &"roof_palettes", func() -> Array:
+		var packed: Array = []
+		for line: String in _lines(pin.path_join("gfx/tilesets/roofs.pal")):
+			if not line.begins_with("RGB "):
+				continue
+			var fields: PackedStringArray = _fields(line)
+			for index: int in range(0, fields.size() - 2, 3):
+				packed.append(
+					_number(fields[index])
+					| (_number(fields[index + 1]) << 5)
+					| (_number(fields[index + 2]) << 10)
+				)
+		var out: Array = []
+		for group: int in packed.size() / 4:
+			out.append(packed.slice(group * 4, group * 4 + 4))
+		return out
+	)
 
 
 # --- Comparison -------------------------------------------------------------

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -40,7 +40,7 @@ func _initialize() -> void:
 
 	var map: Gen2WorldMap = world.current_map
 	var tileset: Gen2WorldTileset = world.current_tileset
-	var indices: PackedByteArray = data.world_tileset_indices(tileset.number)
+	var indices: PackedByteArray = data.map_tile_indices(map, tileset)
 	var palettes: Array = Gen2WorldPalette.tile_palettes(
 		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1
 	)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -601,7 +601,7 @@ func _render(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Im
 	var width: int = map.width_blocks * RomLayout.MAP_BLOCK_TILE_WIDTH * Gen2Tiles.TILE_WIDTH
 	var height: int = map.height_blocks * RomLayout.MAP_BLOCK_TILE_WIDTH * Gen2Tiles.TILE_HEIGHT
 	var image := Image.create(width, height, false, Image.FORMAT_RGBA8)
-	var pixels: PackedByteArray = data.world_tileset_indices(tileset.number)
+	var pixels: PackedByteArray = data.map_tile_indices(map, tileset)
 	var atlas_width: int = tileset.tile_count * Gen2Tiles.TILE_WIDTH
 	var palettes: Array = Gen2WorldPalette.tile_palettes(data, map, tileset)
 


### PR DESCRIPTION
Two gaps found by reading the coverage sweep's `engine/` rows against the pins.

## Roofs

`LoadMapGroupRoof` was not built. A map group names one of five nine-tile roof runs. The cartridge copies that run over `vTiles2 tile $0a` on every map load, so tiles $0A..$12 of an outdoor tileset are placeholder art until it runs. `_LoadMapPals` then replaces colours 1 and 2 of `PAL_BG_ROOF` with the group's own pair.

The result: every town and route in the game drew the wrong roof, in the wrong colour. Ecruteak's orange roofs, Violet's purple, New Bark's green and Cherrygrove's pink were all the same generic cyan.

Two things a reading of the source gets wrong, both now stated where they are enforced:

- `_LoadMapPals` reads `RoofPals` off `wMapGroup` alone and never consults `MapGroupRoofs`. A group with no roof tiles still tints the slot.
- `cp NITE_F` puts DARKNESS on the nite pair rather than a third one. There are two rows, not four.

`GameData.map_tile_indices` is the one seam every static reader of a map's tiles goes through, so no caller can forget the roof, and the overworld's animated strip is roofed on every pass rather than once.

## Swarms

`StoreSwarmMapIndices` writes `wDunsparceMapGroup` or `wYanmaMapGroup` off its first argument. `_SwarmWildmonCheck` tries Dunsparce and then Yanma, and each has its own `wSwarmFlags` bit, so both swarms stand at once.

The `swarm` command here decoded its kind byte and then dropped it, into one slot. Arnie's call (`swarm SWARM_YANMA, ROUTE_35`) erased Anthony's Dark Cave swarm, and the other way round.

pokegold really does have one pair, and its own `StoreSwarmMapIndices` takes no kind. That is why the slot stays `SWARM_DUNSPARCE` on those two cartridges.

## Proving it

Cache format 82 carries the three roof tables. All three cartridges re-imported, each reporting `layout: Layout verified.`

`tools/checks/map_data.gd` gains the roof layers. It walks every map group and tileset pair the corpus draws, on all three cartridges, and compares the five runs against pret's own `gfx/tilesets/roofs/*.png` and the palettes against its own `roofs.pal` rather than against a second reading of the cache. 167 pairs on Crystal, 157 on Gold and Silver. Reverting the splice turns it red on 199 layers.

| Run | Result |
|---|---|
| `validate.gd -- all` | 66 topics, all pass |
| GUT, full tier | 3,529 tests over 160 scripts, green |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failure |
| Boot smoke test | clean |