### PR TITLE
Resolve the battle entrance for a renderer with no background plane

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -841,11 +841,15 @@ a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
 | `set_view(view: Dictionary)` | The screen has new plain display values to show |
 | `refresh()` | The renderer should redraw its current view |
 
-`view` carries `enemy_species`, `player_species`, `enemy_name`, `player_name`,
-`enemy_level`, `player_level`, `battle_kind`, `trainer_class`, `trainer_index`,
-`trainer_name`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
-`player_max_hp`, `exp_pixels`, `raster_scx`, `raster_scy`, `player_pic_visible`,
-`bg_map`, `bg_palette_maps`, `ob_palette_maps`, `anim_sprites`, `anim_tiles` and
+`view` carries `enemy_species`, `player_species`, `enemy_unown_form`,
+`player_unown_form`, `enemy_substitute`, `player_substitute`, `enemy_name`,
+`player_name`, `enemy_level`, `player_level`, `battle_kind`, `trainer_class`,
+`trainer_index`, `trainer_name`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
+`player_max_hp`, `exp_pixels`, `raster_scx`, `raster_scy`, `entrance`,
+`intro_sprites`, `grayscale`, `enemy_trainer_pic`, `player_backpic`,
+`player_backpic_palette`, `enemy_hud_visible`, `player_hud_visible`,
+`trainer_hud_balls`, `trainer_hud_border`, `bg_map`, `bg_vbank1`,
+`bg_palette_maps`, `ob_palette_maps`, `anim_sprites`, `anim_tiles` and
 `hud_visible`: plain values read out of a resolved battle event, never the
 battle engine itself, the same rule `Gen2BattleScreen`'s own setters already
 followed.
@@ -868,10 +872,7 @@ distance to look *right* into a background map 256 pixels wide against the
 screen's 160, so a larger one puts the drawn content further left and the map's
 blank columns wrap in behind it. `Gen2Raster.scroll(image, offsets, 256)` is
 that operation and is what the built-in renderer applies to each of its layers;
-a renderer that ignores the field simply draws no slide. `player_pic_visible`
-is false for exactly that stretch, because `InitBattleDisplay` places the
-player's back pic with `PlaceGraphic` only after `BattleIntroSlidingPics` has
-returned, so during the slide it is not on the map to be scrolled. `raster_scy`
+a renderer that ignores the field simply draws no slide. `raster_scy`
 is the same thing vertically, which only a battle animation ever asks for;
 `Gen2Raster.scroll_rows(image, offsets, 256)` is that operation.
 
@@ -895,6 +896,75 @@ says where each tile of the animation window came from, as
 below that base is not an animation tile at all. `hud_visible` is false for the
 length of a move animation, which is `BattleAnimClearHud` taking the panels and
 both bars off the map and `BattleAnimRestoreHuds` putting them back.
+
+### The entrance
+
+A fight does not open with two Pokémon standing on the field. Two *trainers*
+slide in from opposite sides, the opponent sends out first, the player's back
+pic walks off, and a ball puts a Pokémon where each trainer was standing. Every
+field so far says that in the terms the hardware draws it in: the slide is a
+scanline scroll (`raster_scx`), the walk off is columns going blank in `bg_map`,
+and the player mid-slide is eighteen OAM entries (`intro_sprites`). A renderer
+with no background plane has none of those three, so `entrance` is the same
+state said plainly, one entry per side:
+
+```gdscript
+view["entrance"] = {
+    "player": {
+        "kind": &"trainer",              # or &"mon", or &"none"
+        "backpic": "kris",               # "" unless kind is trainer
+        "trainer_class": 0,              # always 0 on the player's side
+        "species": 0,                    # 0 unless kind is mon
+        "offset_pixels": Vector2(142.0, 0.0),
+    },
+    "enemy": { ... the same five, with trainer_class carrying the class },
+}
+```
+
+`kind` is what the square holds, and it is the whole of what a view drawing
+`player_species` from the first frame is missing: `&"trainer"` a person,
+`&"mon"` a Pokémon, and `&"none"` the stretch between the trainer walking off
+and the ball arriving. `backpic` is what `GameData.player_backpic(kind)` and
+`player_palette(kind)` take, `trainer_class` what `GameData.trainer_pic(number)`
+and `trainer_palette(number)` take, and `species` what `species_pic()` takes, so
+whichever one is set names a picture the renderer can resolve. A wild opponent
+is never a trainer and slides in as its own front pic.
+
+`offset_pixels` is how far that picture stands from its resting square, and it
+covers both movements with one number because both are one thing: the slide
+brings a picture in from off the field and `SlideBattlePicOut` takes it off
+again. Zero is standing still, which is every frame outside an entrance. The
+player comes in from the right and leaves to the left and the opponent the other
+way, so the sign is the direction. A renderer that ignores the block draws
+exactly what it draws today.
+
+`intro_sprites` is the eighteen `{ tile, x, y }` of the player's own head and
+shoulders during the slide, drawn as OAM because those three tile rows fall in
+the band the opponent scrolls; it is empty outside the slide. `grayscale` is
+true for the same stretch, since `GetSGBLayout SCGB_BATTLE_COLORS` runs only
+once `BattleIntroSlidingPics` has returned. `enemy_trainer_pic` and
+`player_backpic` are which picture is on each square, zero and empty once a
+Pokémon has taken it, and `player_backpic_palette` is the `chris`, `kris` or
+`dude` whose colours the back pic is drawn in. `enemy_hud_visible` and
+`player_hud_visible` are the two panels one at a time, against `hud_visible`'s
+summary of both; `trainer_hud_balls` and `trainer_hud_border` are
+`BattleStart_TrainerHuds`' party balls and the frame they hang in, both empty
+once the fight has started. `enemy_substitute` and `player_substitute` say the
+doll is on the square rather than the Pokémon, which is the overworld
+substitute sprite rather than any species pic; `enemy_unown_form` and
+`player_unown_form` are one-based letters for Unown and nothing for every other
+species, and a non-zero one means `GameData.unown_pic(form - 1, back)` in place
+of `species_pic(number, back)`. `bg_vbank1` is `wAttrmap` bit
+3 over the screen, the VRAM bank each cell's tile number is read from, which
+only the enemy's own pic animation ever sets.
+
+`entrance` and the twelve fields named in this section are `api_version` 11.
+Before it they were pushed and undeclared, and one more was declared and never
+true: `player_pic_visible` was a literal `true` in every view, because the
+premise behind it is wrong. `CopyBackpic` puts the player's back pic on the
+tilemap before `InitBattleDisplay` reaches the slide, so it is on the map
+throughout. The field is gone; `entrance` is what answers the question it was
+asked for.
 
 The two HP values and `exp_pixels` are the *drawn* ones, not the committed ones:
 a hit drains the bar over roughly a second the way the cartridge does, an award

--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -151,6 +151,29 @@ func offsets() -> PackedInt32Array:
 	return out
 
 
+## How far the picture standing in each band is from its resting square, along
+## x and in pixels, for a renderer with no background plane to read a scroll off.
+## Zero once the slide has returned.
+##
+## Taken from the band's own arithmetic rather than from the byte [method
+## offsets] reports, because a scroll register cannot say which way a picture is
+## travelling: the two bands come in from opposite sides, and Crystal's middle
+## runs two pixels past its square and back, so the same `$02` reads as +254 or
+## -2 depending only on when in the slide it was sampled. The unwrapped step
+## count has no such ambiguity.
+##
+## The top band carries the opponent, which is in from the left, so its
+## displacement is negative and climbs to zero. The middle carries the player,
+## in from the right, so its own falls to zero and then to the -2 Crystal
+## overshoots by before `InitBattleDisplay`'s `xor a` settles it.
+func enemy_offset() -> float:
+	return 0.0 if finished() else float(-_top_scx())
+
+
+func player_offset() -> float:
+	return 0.0 if finished() else float(MAP_WIDTH - _middle_scx())
+
+
 func _is_gold_lead() -> bool:
 	return not _crystal and _frame < GOLD_LEAD_FRAMES
 
@@ -159,17 +182,27 @@ func _is_gold_lead() -> bool:
 ## `hSCX`, which VBlank copies to `rSCX` a frame late, so their top band trails
 ## the middle by one. Crystal's two bands share a table and lag together.
 func _top_offset() -> int:
-	if _crystal:
-		return posmod(CRYSTAL_TOP_START - STEP * _frame, MAP_WIDTH)
-	var stepped: int = maxi(_frame - GOLD_LEAD_FRAMES, 0)
-	return posmod(GOLD_TOP_START - STEP * maxi(stepped - 1, 0), MAP_WIDTH)
+	return posmod(_top_scx(), MAP_WIDTH)
 
 
 ## `$72` and `$70` up by two each frame. Crystal's runs past the end of a byte
 ## and wraps, which is why it lands on 2.
 func _middle_offset() -> int:
+	return posmod(_middle_scx(), MAP_WIDTH)
+
+
+## The two bands before the hardware's own wrap, which is what [method
+## enemy_offset] and [method player_offset] need and what the byte above hides.
+func _top_scx() -> int:
 	if _crystal:
-		return posmod(CRYSTAL_MIDDLE_START + STEP * _frame, MAP_WIDTH)
+		return CRYSTAL_TOP_START - STEP * _frame
+	var stepped: int = maxi(_frame - GOLD_LEAD_FRAMES, 0)
+	return GOLD_TOP_START - STEP * maxi(stepped - 1, 0)
+
+
+func _middle_scx() -> int:
+	if _crystal:
+		return CRYSTAL_MIDDLE_START + STEP * _frame
 	if _is_gold_lead():
 		return GOLD_TOP_START
-	return posmod(GOLD_MIDDLE_START + STEP * (_frame - GOLD_LEAD_FRAMES), MAP_WIDTH)
+	return GOLD_MIDDLE_START + STEP * (_frame - GOLD_LEAD_FRAMES)

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -191,39 +191,32 @@ func _draw_pics() -> void:
 			),
 			enemy_palette
 		)
-	# `InitBattleDisplay` places the player's back pic with `PlaceGraphic` only
-	# after `BattleIntroSlidingPics` has returned, so it is not on the map to be
-	# scrolled and is simply not there yet.
-	if bool(_view.get("player_pic_visible", true)):
-		var player: int = int(_view.get("player_species", 0))
-		var player_palette: PackedColorArray = _battler_palette(
-			player, Gen2BattleAnimBackground.PAL_BG_PLAYER
+	var player: int = int(_view.get("player_species", 0))
+	var player_palette: PackedColorArray = _battler_palette(
+		player, Gen2BattleAnimBackground.PAL_BG_PLAYER
+	)
+	# `GetPlayerOrMonPalettePointer`'s `and a / jp nz`: a zero species is the
+	# player standing there, and the palette is the player's own.
+	var backpic: String = String(_view.get("player_backpic", ""))
+	if not backpic.is_empty() and not bool(_view.get("grayscale", false)):
+		player_palette = _remap(
+			_data.player_palette(String(_view.get("player_backpic_palette", "chris"))),
+			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_PLAYER)
 		)
-		# `GetPlayerOrMonPalettePointer`'s `and a / jp nz`: a zero species is the
-		# player standing there, and the palette is the player's own.
-		var backpic: String = String(_view.get("player_backpic", ""))
-		if not backpic.is_empty() and not bool(_view.get("grayscale", false)):
-			player_palette = _remap(
-				_data.player_palette(String(_view.get("player_backpic_palette", "chris"))),
-				_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_PLAYER)
-			)
-		var player_key: Array = [
-			map_key, player, _player_pixels_key, player_palette, raster,
-			vbank1.duplicate(), gray,
-		]
-		if player_key != _player_pic_key:
-			_player_pic_key = player_key
-			_show_layer(
-				_player_pic,
-				_pic_layer(
-					map, Gen2BattleScreenMap.PLAYER_BASE_TILE,
-					Gen2BattleScreenMap.PLAYER_SIDE, _player_pixels, vbank1
-				),
-				player_palette
-			)
-	else:
-		_player_pic.texture = null
-		_player_pic_key = []
+	var player_key: Array = [
+		map_key, player, _player_pixels_key, player_palette, raster,
+		vbank1.duplicate(), gray,
+	]
+	if player_key != _player_pic_key:
+		_player_pic_key = player_key
+		_show_layer(
+			_player_pic,
+			_pic_layer(
+				map, Gen2BattleScreenMap.PLAYER_BASE_TILE,
+				Gen2BattleScreenMap.PLAYER_SIDE, _player_pixels, vbank1
+			),
+			player_palette
+		)
 
 
 ## `wAttrmap` bit 3 over the screen, which is the VRAM bank each cell's tile

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -205,6 +205,12 @@ var _hud_balls: Array = []
 var _hud_border: Array = []
 ## `SlideBattlePicOut`, one entry per square still sliding off.
 var _slides: Array[Dictionary] = []
+## How far each square's picture has walked off it, in pixels along x, signed the
+## way the walk goes: the player leaves to the left and the opponent to the
+## right. Kept after the walk ends rather than dropped with the slide's entry,
+## because the picture stays off the square until the ball puts a Pokemon there;
+## that stretch is the `none` [method _entrance_side] reports.
+var _slid_pixels: Dictionary = {Gen2Battle.PLAYER: 0.0, Gen2Battle.ENEMY: 0.0}
 ## `AnimateFrontpic` over the enemy's square, or null when none is running.
 var _frontpic: Gen2PicAnimation = null
 ## `wAttrmap` bit 3, which `PokeAnim_SetVBank1` sets over that square while the
@@ -490,6 +496,10 @@ func advance_slide() -> bool:
 	slide["step"] = int(slide["step"]) + 1
 	var player_side: bool = bool(slide["player_side"])
 	Gen2BattleScreenMap.slide_step(_bg_map, player_side)
+	var side: int = Gen2Battle.PLAYER if player_side else Gen2Battle.ENEMY
+	_slid_pixels[side] = float(_slid_pixels[side]) + (
+		-float(Gen2Tiles.TILE_WIDTH) if player_side else float(Gen2Tiles.TILE_WIDTH)
+	)
 	if int(slide["step"]) >= int(Gen2BattleScreenMap.SLIDE_STEPS[player_side]):
 		_slides.remove_at(0)
 	_push_view()
@@ -1089,6 +1099,7 @@ func _init_battle_display() -> void:
 	_intro_message = ""
 	_entrance_stages = []
 	_slides = []
+	_slid_pixels = {Gen2Battle.PLAYER: 0.0, Gen2Battle.ENEMY: 0.0}
 	_frontpic = null
 	_bg_vbank1 = PackedByteArray()
 	_hud_balls = []
@@ -1353,8 +1364,10 @@ func _apply_entrance_step(what: StringName) -> void:
 			# before the ball is thrown, and the square itself is empty until
 			# `BATTLE_BG_EFFECT_ENTER_MON` stamps the map back.
 			_enemy_trainer_pic = 0
+			_slid_pixels[Gen2Battle.ENEMY] = 0.0
 		ENTRANCE_PLAYER_PIC:
 			_player_backpic = ""
+			_slid_pixels[Gen2Battle.PLAYER] = 0.0
 	_push_view()
 
 
@@ -4575,10 +4588,9 @@ func _push_view() -> void:
 		## `CopyBackpic` puts the player's back pic on the tilemap before
 		## `InitBattleDisplay` ever reaches the slide, so it is there through it
 		## and comes in with the middle band. Its top three tile rows fall in the
-		## band the enemy scrolls, which is what the eighteen sprites below are
+		## band the enemy scrolls, which is what the eighteen sprites here are
 		## for; `PlaceGraphic` afterwards is what settles the two pixels between
 		## them.
-		"player_pic_visible": true,
 		"intro_sprites": _intro.sprites() if _intro != null else [],
 		## `GetSGBLayout SCGB_BATTLE_GRAYSCALE` is called where the battle is
 		## entered and `SCGB_BATTLE_COLORS` only after `BattleIntroSlidingPics`,
@@ -4608,9 +4620,63 @@ func _push_view() -> void:
 		## Whether both panels are on the map, which is the summary of the two
 		## keys above rather than a third state.
 		"hud_visible": _hud_visible(),
+		## Who is standing on each square and how far off it they are, resolved:
+		## see [method _entrance_side].
+		"entrance": {
+			"player": _entrance_side(Gen2Battle.PLAYER),
+			"enemy": _entrance_side(Gen2Battle.ENEMY),
+		},
 	})
 	if _box != null:
 		_box.raster_scx = _box_raster_offsets()
+
+
+## What is standing on one side's square and how far it is from standing on it,
+## for a renderer that stages the fight somewhere other than a 20x18 tile page.
+##
+## Every other field describing the entrance says it in the terms the hardware
+## draws it in: the slide in is a scanline scroll, the walk off is columns going
+## blank in `bg_map`, and the player mid-slide is eighteen OAM entries. A view
+## with no background plane has none of those three and would have to rebuild
+## host state to read either movement. These three values are that state said
+## plainly.
+##
+## [code]kind[/code] is what the square holds: [code]&"trainer"[/code] a person,
+## [code]&"mon"[/code] a Pokemon, and [code]&"none"[/code] the stretch between
+## the trainer walking off and the ball putting a Pokemon there.
+## [code]offset_pixels[/code] is how far that picture is from its resting square
+## and covers both movements with one number, because both are one thing: the
+## opening slide brings a picture in and `SlideBattlePicOut` takes it off again.
+## Zero is standing still, which is every frame outside an entrance.
+func _entrance_side(side: int) -> Dictionary:
+	var player_side: bool = side == Gen2Battle.PLAYER
+	var backpic: String = _player_backpic if player_side else ""
+	var trainer_class: int = 0 if player_side else _enemy_trainer_pic
+	var species: int = _player if player_side else _enemy
+	var person: bool = not backpic.is_empty() if player_side else trainer_class > 0
+	var offset: float = 0.0
+	var kind: StringName = &"mon"
+	if _intro != null:
+		# Both squares are sliding in. A wild opponent is its own front pic
+		# rather than a trainer, and slides in exactly the same way.
+		offset = _intro.player_offset() if player_side else _intro.enemy_offset()
+		kind = &"trainer" if person else &"mon"
+	elif person:
+		offset = float(_slid_pixels[side])
+		var walked: float = float(
+			int(Gen2BattleScreenMap.SLIDE_STEPS[player_side]) * Gen2Tiles.TILE_WIDTH
+		)
+		kind = &"none" if absf(offset) >= walked else &"trainer"
+	return {
+		"kind": kind,
+		## Empty and zero on the side and in the state they do not describe: the
+		## player is named by a back pic and the opponent by a class number, and
+		## neither is on the square once a Pokemon has taken it.
+		"backpic": backpic if kind == &"trainer" else "",
+		"trainer_class": trainer_class if kind == &"trainer" else 0,
+		"species": species if kind == &"mon" else 0,
+		"offset_pixels": Vector2(offset, 0.0),
+	}
 
 
 ## The background scroll for the whole screen: the intro's own bands, or an

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -40,7 +40,7 @@ const FILENAME: String = "mod.json"
 ## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
 ## host that has never heard of either ignores the field, so a mod that ships
 ## art still installs on an older launcher and simply has no face there.
-const API_VERSION: int = 10
+const API_VERSION: int = 11
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 10,
+	"api_version": 11,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 10,
+	"api_version": 11,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -540,7 +540,15 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 	## the opponent comes in from the left. Both are drawn without colour:
 	## `SCGB_BATTLE_GRAYSCALE` is set where the battle is entered and
 	## `SCGB_BATTLE_COLORS` only after the slide returns.
-	assert_true(bool(view["player_pic_visible"]), "the back pic slides in too")
+	var entering: Dictionary = view["entrance"]
+	assert_gt(
+		(entering["player"] as Dictionary)["offset_pixels"].x, 0.0,
+		"the back pic slides in too, from the right"
+	)
+	assert_lt(
+		(entering["enemy"] as Dictionary)["offset_pixels"].x, 0.0,
+		"and the opponent from the left"
+	)
 	assert_true(bool(view["grayscale"]), "and the battle has no colour yet")
 	assert_eq(
 		(view["intro_sprites"] as Array).size(),
@@ -562,7 +570,12 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 		"the start message waited for the slide"
 	)
 	var settled: Dictionary = _battle_screen._renderer._view
-	assert_true(bool(settled["player_pic_visible"]))
+	var standing: Dictionary = settled["entrance"]
+	assert_eq(
+		(standing["player"] as Dictionary)["offset_pixels"], Vector2.ZERO,
+		"both are on their squares once the slide has returned"
+	)
+	assert_eq((standing["enemy"] as Dictionary)["offset_pixels"], Vector2.ZERO)
 	assert_false(bool(settled["grayscale"]), "`SCGB_BATTLE_COLORS` runs after the slide")
 	assert_true((settled["intro_sprites"] as Array).is_empty(), "`HideSprites`")
 	assert_true(PackedInt32Array(settled["raster_scx"]).is_empty(), "and nothing is scrolled")
@@ -645,3 +658,104 @@ func test_the_doll_is_what_a_substituted_side_draws() -> void:
 		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": false,
 	})
 	assert_eq(renderer._player_pixels, own)
+
+
+## The whole entrance as `view["entrance"]` reports it, one side at a time: who
+## is standing on each square, and how far off it they are.
+##
+## This is the field a renderer with no background plane has instead of the
+## scanline scroll and the blanking `bg_map` columns, so it is asserted as the
+## sequence a fight actually opens with rather than at one sampled frame: two
+## trainers slide in, each walks off its own square, and a Pokemon takes it.
+##
+## The two sides do not pass through the same states, and the reason is one line
+## of the source. `ShowBattleTextEnemySentOut` waits on a press, so the
+## opponent's square stands empty for as long as the player takes to read it;
+## `SendOutMonText` "ends in `done`" and prints with the ball already in the air,
+## so the player's square is never empty at the end of a frame. That also costs
+## the player's walk its last step at a frame boundary: the ninth column shifts
+## and the Pokemon is stamped in the same frame, so what a renderer is handed is
+## the eighth, which is what every other field says at that frame too.
+func test_the_entrance_says_who_is_on_each_square_and_how_far_off_it() -> void:
+	await _open_battle()
+	_battle_screen.show_trainer(Fixture.TRAINER_CLASS, 0)
+
+	var kinds: Dictionary = {"player": [], "enemy": []}
+	var lows: Dictionary = {"player": 0.0, "enemy": 0.0}
+	var highs: Dictionary = {"player": 0.0, "enemy": 0.0}
+	var guard: int = 8000
+	while (_battle_screen.frames_running() or _battle_screen.entrance_running()) \
+		and guard > 0:
+		guard -= 1
+		for who: String in kinds:
+			var side: Dictionary = (
+				_battle_screen._renderer._view["entrance"] as Dictionary
+			)[who]
+			var kind: StringName = StringName(side["kind"])
+			if (kinds[who] as Array).is_empty() or (kinds[who] as Array).back() != kind:
+				(kinds[who] as Array).append(kind)
+			var at: float = (side["offset_pixels"] as Vector2).x
+			lows[who] = minf(float(lows[who]), at)
+			highs[who] = maxf(float(highs[who]), at)
+		_battle_screen.advance_frame()
+		if _battle_screen.frames_running() or not _battle_screen.entrance_running():
+			continue
+		_battle_screen.finish()
+		_battle_screen.advance()
+	assert_gt(guard, 0, "the entrance finished")
+
+	assert_eq(
+		kinds["enemy"], [&"trainer", &"none", &"mon"],
+		"a person, then the square they left, then a Pokemon"
+	)
+	assert_eq(
+		kinds["player"], [&"trainer", &"mon"],
+		"the player's own empty square has no frame of its own"
+	)
+	# `SlideBattlePicOut` walks the player's square nine tiles to the left and
+	# the opponent's eight to the right, and the opening slide brings each in
+	# from the side it later leaves towards.
+	var step: int = Gen2Tiles.TILE_WIDTH
+	assert_eq(
+		lows["player"], -float((int(Gen2BattleScreenMap.SLIDE_STEPS[true]) - 1) * step),
+		"the player walks off to the left, all but the step it is replaced on"
+	)
+	assert_gt(float(highs["player"]), 0.0, "and slid in from the right")
+	assert_eq(
+		highs["enemy"], float(int(Gen2BattleScreenMap.SLIDE_STEPS[false]) * step),
+		"the opponent walks the whole way off, to the right"
+	)
+	assert_lt(float(lows["enemy"]), 0.0, "and slid in from the left")
+
+	# Nothing is moving once the fight has started, and both squares name the
+	# Pokemon standing on them rather than the people who brought them.
+	var fighting: Dictionary = _battle_screen._renderer._view["entrance"]
+	for who: String in ["player", "enemy"]:
+		var side: Dictionary = fighting[who]
+		assert_eq(side["offset_pixels"], Vector2.ZERO, who)
+		assert_eq(String(side["backpic"]), "", who)
+		assert_eq(int(side["trainer_class"]), 0, who)
+		assert_gt(int(side["species"]), 0, "%s: and it is a species" % who)
+
+
+## A wild opponent is never a trainer: it slides in as its own front pic and
+## stands on its square for the whole fight, while the player still arrives
+## behind a back pic that walks off.
+func test_a_wild_opponent_is_its_own_picture_from_the_first_frame() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+
+	var enemy: Dictionary = (
+		_battle_screen._renderer._view["entrance"] as Dictionary
+	)["enemy"]
+	assert_eq(StringName(enemy["kind"]), &"mon")
+	assert_eq(int(enemy["species"]), 16)
+	assert_lt((enemy["offset_pixels"] as Vector2).x, 0.0, "and it is still sliding in")
+	assert_eq(
+		StringName((
+			(_battle_screen._renderer._view["entrance"] as Dictionary)["player"]
+			as Dictionary
+		)["kind"]),
+		&"trainer",
+		"the player is a person at the same moment",
+	)


### PR DESCRIPTION
Answers R34 from the mods repository, all three parts.

## R34a: the view had a secret

Fourteen fields were pushed to every battle renderer and declared in none of
them: `intro_sprites`, `grayscale`, `enemy_trainer_pic`, `player_backpic`,
`player_backpic_palette`, `enemy_hud_visible`, `player_hud_visible`,
`trainer_hud_balls`, `trainer_hud_border`, `enemy_substitute`,
`player_substitute`, `enemy_unown_form`, `player_unown_form` and `bg_vbank1`.
A mod reading an undeclared key takes on debt it cannot see, so all fourteen
are now in `docs/MODS.md`, along with the `GameData` calls that turn each into
a picture: `player_backpic(kind)`, `player_palette(kind)`, `trainer_pic(number)`,
`trainer_palette(number)`, `species_pic(number, back)` and
`unown_pic(form - 1, back)`.

`player_pic_visible` is deleted rather than made real. Its premise is wrong.
`CopyBackpic` puts the player's back pic on the tilemap before
`InitBattleDisplay` reaches the slide, so the pic is on the map throughout and
the field was a literal `true` in every view ever pushed. The paragraph in
`docs/MODS.md` explaining why it went false is wrong for the same reason and is
gone with it. The built-in renderer's branch on it is gone; it drew the same
thing either way.

## R34b: `view["entrance"]`

```gdscript
view["entrance"] = {
    "player": {
        "kind": &"trainer",              # or &"mon", or &"none"
        "backpic": "kris",               # "" unless kind is trainer
        "trainer_class": 0,              # always 0 on the player's side
        "species": 0,                    # 0 unless kind is mon
        "offset_pixels": Vector2(142.0, 0.0),
    },
    "enemy": { ... the same five, with trainer_class carrying the class },
}
```

`offset_pixels` covers the slide in and `SlideBattlePicOut` with one number.
Zero is standing still, which is every frame outside an entrance. The player
comes in from the right and leaves to the left, the opponent the other way, so
the sign is the direction. A renderer that ignores the block draws exactly what
it drew before, so nothing lands on the built-in view.

Two things a reading of it cost, both now in the code beside what they explain:

**A scroll register cannot say which way a picture is travelling.** The two
bands come in from opposite sides, and Crystal's middle runs two pixels past its
square before `InitBattleDisplay`'s `xor a` settles it, so the same `$02` reads
as +254 or -2 depending only on when in the slide it was sampled. The
displacement is taken from the band's own unwrapped step count instead
(`Gen2BattleIntro.enemy_offset` / `player_offset`), which has no such ambiguity.
The wrapped byte `offsets()` reports is unchanged.

**The two sides do not pass through the same states.**
`ShowBattleTextEnemySentOut` waits on a press, so the opponent's square stands
empty for as long as the player takes to read it and `&"none"` is a state a
renderer sees. `SendOutMonText` ends in `done` and prints with the ball already
in the air, so on the player's side the ninth slide column and the Pokemon being
stamped land in the same frame: the player's square is never empty at the end of
a frame, and the walk a renderer is handed stops at the eighth column. That is
what `bg_map` says at that frame too, so the block agrees with every other
field rather than inventing a state of its own. Both facts are asserted.

## R34c: the opponent's exit

Same field. `entrance.enemy.offset_pixels` runs to +64 as the class picture
walks off to the right, then `kind` goes `&"none"` and then `&"mon"`. Standing
the opponent behind their Pokemon for the rest of the fight stays a staging
choice; the entrance is the stretch where the cartridge's own answer wins.

## `api_version` 11

`entrance` and the fourteen documented fields are version 11. Both shipped
examples declare it. Nothing older breaks: the fourteen were already being
pushed, and the one removal was a constant `true` that every reader defaults to.

## Checks

| Check | Result |
|---|---|
| `gut` unit tier | 3069/3069 |
| `gut` full tier | 3543/3543 |
| `validate.gd -- all` | 67 topics, all PASS |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 0 failures each |
| Boot smoke test | exit 0 |
| `preview_battle_anim.gd` entrance frames | unchanged against the built-in renderer |

Three new test cases in `test_battle_renderer.gd`: the entrance's whole sequence
for a trainer battle, a wild opponent being its own picture from the first
frame, and the opening slide's two directions.