### PR TITLE
Let a listing say which cartridges a mod is for

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -195,6 +195,7 @@ adds it, because following a source is trusting whoever publishes it.
       "name": "Voxel Preview",
       "version": "1.0.0",
       "description": "Draws the map as geometry.",
+      "games": ["gold", "silver", "crystal"],
       "download": "https://example.com/voxel_preview-1.0.0.zip",
       "icon": "https://example.com/voxel_preview/icon.png",
       "thumbnail": "https://example.com/voxel_preview/thumbnail.webp"
@@ -210,6 +211,13 @@ A row with no `id`, no usable `download`, or an id that is not a legal mod id is
 dropped, and the rest of the listing still works. `icon` and `thumbnail` are
 optional and held to the same https rule; one that is not is dropped on its own
 rather than costing the row.
+
+`games` repeats the manifest's own list of cartridge ids, so a listing says what
+a mod is for before anyone downloads it: the launcher prints it on the mod's page
+and a site can filter on it. It is optional, and a row without one means every
+cartridge, as an empty list in a manifest does. Only the shape is checked, a
+malformed id being dropped on its own; the manifest inside the archive is still
+what decides where the mod runs.
 
 Pasting `owner/repo`, the repository page, a site root or the feed file all
 resolve to the same feed, `https://<owner>.github.io/<repo>/index.json` for a

--- a/game/launcher/mod_detail_page.gd
+++ b/game/launcher/mod_detail_page.gd
@@ -132,10 +132,10 @@ func _summary(row: Dictionary) -> Control:
 	# the mod refused to load. A mod that declares nothing is for every cartridge
 	# and says nothing here.
 	var manifest: Gen2ModManifest = row["manifest"]
-	if manifest != null:
-		var titles: Array[String] = manifest.game_titles()
-		if not titles.is_empty():
-			column.add_child(Gen2LauncherUI.field(_theme, "For", _value(", ".join(titles))))
+	var titles: Array[String] = manifest.game_titles() if manifest != null \
+		else Gen2ModManifest.titles_for(row.get("listed_games", []))
+	if not titles.is_empty():
+		column.add_child(Gen2LauncherUI.field(_theme, "For", _value(", ".join(titles))))
 
 	var actions: HFlowContainer = Gen2LauncherUI.actions()
 	column.add_child(actions)

--- a/game/mods/mod_catalogue.gd
+++ b/game/mods/mod_catalogue.gd
@@ -78,6 +78,9 @@ static func _row(
 		# otherwise, so a mod has a face while it is still only being browsed.
 		"icon": Gen2ModArt.icon_path(manifest),
 		"icon_url": String(entry.get("icon", "")),
+		# What the listing says it is for. The installed manifest is the truth
+		# when there is one; this is what the card has before then.
+		"listed_games": entry.get("games", [] as Array[StringName]),
 		"feed": feed,
 		"source_label": label,
 		"installed": manifest != null,

--- a/game/mods/mod_index.gd
+++ b/game/mods/mod_index.gd
@@ -78,8 +78,8 @@ static func resolve_source(input: String) -> Dictionary:
 ## Reads a fetched feed into rows the launcher can list.
 ##
 ## Returns { ok, name, entries } where each entry has id, name, version,
-## description, download, and the optional icon and thumbnail URLs. An entry
-## missing an id or a usable download is dropped rather than failing the whole
+## description, download, games, and the optional icon and thumbnail URLs. An
+## entry missing an id or a usable download is dropped rather than failing the whole
 ## feed, because one bad row in someone else's file should not cost the player
 ## the rest of the list.
 static func parse_feed(text: String) -> Dictionary:
@@ -268,7 +268,28 @@ static func _entry_from(raw: Dictionary) -> Dictionary:
 		# rather than refused: a listing without a picture is still a listing.
 		"icon": _art_url(raw.get("icon", "")),
 		"thumbnail": _art_url(raw.get("thumbnail", "")),
+		# Which cartridges the listing claims, in the manifest's own shape, so a
+		# mod says what it is for before it is installed. Empty means every game,
+		# and a row that gives no list is one of those.
+		"games": _games(raw.get("games", []), regex),
 	}
+
+
+## The [RomRegistry] ids in a listing's `games`, deduplicated. Shape only, like
+## [method Gen2ModManifest.from_dictionary]: an id this build has never heard of
+## is kept, because a feed may list a mod for a cartridge a later launcher ships.
+## A malformed id is dropped on its own rather than costing the row, the way a
+## bad art URL is: the manifest inside the archive is what decides what runs.
+static func _games(raw: Variant, regex: RegEx) -> Array[StringName]:
+	var out: Array[StringName] = []
+	if not raw is Array:
+		return out
+	for entry: Variant in raw as Array:
+		var game: String = str(entry).strip_edges()
+		if regex.search(game) == null or out.has(StringName(game)):
+			continue
+		out.append(StringName(game))
+	return out
 
 
 static func _art_url(raw: Variant) -> String:

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -207,10 +207,17 @@ func supports_game(game_id: StringName) -> bool:
 ## registry does not know keeps its own name, so a mod for a later generation
 ## says so rather than disappearing from its own card.
 func game_titles() -> Array[String]:
+	return titles_for(games)
+
+
+## The same titles for a list of ids that has no manifest behind it, which is
+## what a feed row is before the mod is installed.
+static func titles_for(ids: Array) -> Array[String]:
 	var out: Array[String] = []
-	for game: StringName in games:
-		var title: String = RomRegistry.title_for(game)
-		out.append(title if not title.is_empty() else String(game))
+	for game: Variant in ids:
+		var id := StringName(game)
+		var title: String = RomRegistry.title_for(id)
+		out.append(title if not title.is_empty() else String(id))
 	return out
 
 

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1052,6 +1052,25 @@ func test_index_feed_parses_entries_and_keeps_the_listing_order() -> void:
 	assert_eq(entries[1]["name"], "second")
 
 
+## A listing's `games` is the manifest's own field one step earlier, so a site
+## can filter and the mod page can say what a mod is for before it is installed.
+func test_index_feed_carries_the_games_a_row_declares() -> void:
+	var parsed: Dictionary = Gen2ModIndex.parse_feed(_feed([
+		{"id": "voxel", "download": "https://example.com/voxel.zip",
+		 "games": ["gold", "silver", "gold", "Bad Id", 7, "red"]},
+		{"id": "plain", "download": "https://example.com/plain.zip"},
+		{"id": "wrong", "download": "https://example.com/wrong.zip", "games": "crystal"},
+	]))
+	var entries: Array = parsed["entries"]
+	# Deduplicated, malformed ids dropped on their own, and an id this build has
+	# never heard of kept, because a feed may list a mod for a later cartridge.
+	assert_eq(entries[0]["games"], [&"gold", &"silver", &"red"] as Array[StringName])
+	# No list at all, and a list that is not a list, are both "every cartridge".
+	assert_eq(entries[1]["games"], [] as Array[StringName])
+	assert_eq(entries[2]["games"], [] as Array[StringName])
+	assert_eq(Gen2ModManifest.titles_for(entries[0]["games"]), ["Gold", "Silver", "red"] as Array[String])
+
+
 func test_index_feed_of_an_unknown_schema_is_refused_outright() -> void:
 	# A later format may reuse a field name, so this is a gate and not a hint.
 	var parsed: Dictionary = Gen2ModIndex.parse_feed(


### PR DESCRIPTION
A feed row may now carry `games`, the same list of cartridge ids the manifest already declares.

- `Gen2ModIndex` parses it, deduplicating and dropping a malformed id on its own rather than losing the row. A row without one means every cartridge, as an empty manifest list does.
- The mod page prints "For" for a mod that is only listed, not just an installed one.
- `docs/MODS.md` documents the field; one test covers parsing and titles.

The manifest inside the archive still decides where a mod runs. This is metadata for the launcher and for a site that wants to filter.