### PR TITLE
Give the launcher backdrop the title music, and the volume sliders the game

### DIFF
--- a/game/audio/gen2_apu.gd
+++ b/game/audio/gen2_apu.gd
@@ -87,6 +87,12 @@ var _master_left: int = 0
 var _master_right: int = 0
 var _mix: PackedInt32Array = PackedInt32Array()
 
+## Output gain per hardware channel, applied where the channel joins the mix and
+## nowhere else: the driver's own state is untouched, so a gain is a listening
+## level rather than a change to what the cartridge plays. [Gen2SoundEngine]
+## sets it from whichever of its eight streams owns the channel this frame.
+var channel_gain: PackedFloat32Array = PackedFloat32Array([1.0, 1.0, 1.0, 1.0])
+
 ## Register-write log, off unless a parity tool turns it on.
 var tracing: bool = false
 var trace_frame: int = 0
@@ -328,8 +334,9 @@ func _render_square(mix: PackedInt32Array, channel: int) -> void:
 	var len_enabled: bool = _len_enabled[channel] != 0
 	var capacitor: float = _capacitor[channel]
 	var enabled: bool = true
-	var left: int = _on_left[channel] * _master_left
-	var right: int = _on_right[channel] * _master_right
+	var gain: float = channel_gain[channel]
+	var left: float = float(_on_left[channel] * _master_left) * gain
+	var right: float = float(_on_right[channel] * _master_right) * gain
 	for index: int in SAMPLES_PER_FRAME:
 		if len_enabled:
 			len_counter += len_inc
@@ -384,8 +391,8 @@ func _render_square(mix: PackedInt32Array, channel: int) -> void:
 		capacitor = raw - filtered * 0.996
 		sample = int(filtered * 32768.0)
 		var at: int = index * 2
-		mix[at] += sample * left
-		mix[at + 1] += sample * right
+		mix[at] += int(float(sample) * left)
+		mix[at + 1] += int(float(sample) * right)
 	_freq_counter[channel] = freq_counter
 	_duty_counter[channel] = duty_counter
 	_value[channel] = value
@@ -411,8 +418,9 @@ func _render_wave(mix: PackedInt32Array) -> void:
 	var len_enabled: bool = _len_enabled[2] != 0
 	var capacitor: float = _capacitor[2]
 	var enabled: bool = true
-	var left: int = _on_left[2] * _master_left
-	var right: int = _on_right[2] * _master_right
+	var gain: float = channel_gain[2]
+	var left: float = float(_on_left[2] * _master_left) * gain
+	var right: float = float(_on_right[2] * _master_right) * gain
 	var shift: int = maxi(0, volume - 1)
 	# The sixteen packed sample bytes, hoisted out of the per-sample read.
 	var wave: PackedByteArray = _registers.slice(
@@ -456,8 +464,8 @@ func _render_wave(mix: PackedInt32Array) -> void:
 		capacitor = raw - filtered * 0.996
 		sample = int(filtered * 32768.0)
 		var at: int = index * 2
-		mix[at] += sample * left
-		mix[at + 1] += sample * right
+		mix[at] += int(float(sample) * left)
+		mix[at + 1] += int(float(sample) * right)
 	_freq_counter[2] = freq_counter
 	_wave_position = position
 	_len_counter[2] = len_counter
@@ -488,8 +496,9 @@ func _render_noise(mix: PackedInt32Array) -> void:
 	var len_enabled: bool = _len_enabled[3] != 0
 	var capacitor: float = _capacitor[3]
 	var enabled: bool = true
-	var left: int = _on_left[3] * _master_left
-	var right: int = _on_right[3] * _master_right
+	var gain: float = channel_gain[3]
+	var left: float = float(_on_left[3] * _master_left) * gain
+	var right: float = float(_on_right[3] * _master_right) * gain
 	for index: int in SAMPLES_PER_FRAME:
 		if len_enabled:
 			len_counter += len_inc
@@ -532,8 +541,8 @@ func _render_noise(mix: PackedInt32Array) -> void:
 		capacitor = raw - filtered * 0.996
 		sample = int(filtered * 32768.0)
 		var at: int = index * 2
-		mix[at] += sample * left
-		mix[at + 1] += sample * right
+		mix[at] += int(float(sample) * left)
+		mix[at + 1] += int(float(sample) * right)
 	_freq_counter[3] = freq_counter
 	_value[3] = value
 	_lfsr = lfsr

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -215,6 +215,13 @@ func low_health_alarm() -> bool:
 	return (_engine.low_health_alarm & (1 << Gen2SoundEngine.DANGER_ON_BIT)) != 0
 
 
+## Whether any music channel is on, which is what a host that keeps a piece up
+## for as long as its screen is up checks each frame. Separate from
+## [method audio_status] because that builds a dictionary.
+func music_playing() -> bool:
+	return _engine.music_channels_active()
+
+
 ## `_CheckSFX`, which is what `waitsfx` and the battle screen wait on.
 func effect_playing() -> bool:
 	return _engine.sfx_active()
@@ -299,8 +306,18 @@ func _start_stream() -> void:
 ## clock, not the renderer's: a long game frame is caught up here rather than
 ## slowing the music down.
 func _service_timeline() -> void:
-	if _player == null or not _player.playing:
+	if _player == null:
 		return
+	if not _player.playing:
+		# A stopped output under a driver whose channels are still on is silence
+		# over live music, which is what a host that stopped its stream and then
+		# asked for the same piece again used to leave behind. The output
+		# follows the driver rather than the other way round.
+		if not _engine.any_channel_active():
+			return
+		_start_stream()
+		if not _player.playing:
+			return
 	if _playback == null:
 		_playback = _player.get_stream_playback() as AudioStreamGeneratorPlayback
 		if _playback == null:

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -24,6 +24,14 @@ var stereo: bool = false:
 		if _engine != null:
 			_engine.stereo = value
 
+## Attenuation this host asks for on top of the player's own settings, 1.0 being
+## the level the settings alone give. The launcher's backdrop is the caller that
+## wants one: its title loop plays under the interface rather than as the game.
+var volume_scale: float = 1.0:
+	set(value):
+		volume_scale = maxf(value, 0.0)
+		_apply_volume()
+
 var _player: AudioStreamPlayer = null
 var _generator: AudioStreamGenerator = null
 var _playback: AudioStreamGeneratorPlayback = null
@@ -47,12 +55,33 @@ func _init() -> void:
 
 func _ready() -> void:
 	stereo = Gen2OptionsStore.current().stereo
+	_apply_volume()
 	_start_stream()
 	set_process(true)
 
 
 func _process(_delta: float) -> void:
+	_apply_volume()
 	_service_timeline()
+
+
+## The app block's two volumes, pushed to the driver's mix rather than to the
+## stream player: music and effects share the four hardware channels, so one
+## level on the output could not tell them apart. Read every frame because the
+## settings object is shared and edited in place, and pushed only when a number
+## actually moves.
+func _apply_volume() -> void:
+	if _engine == null:
+		return
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var music: float = float(options.music_volume) / float(Gen2Options.MAX_VOLUME)
+	var sfx: float = float(options.sfx_volume) / float(Gen2Options.MAX_VOLUME)
+	music *= volume_scale
+	sfx *= volume_scale
+	if not is_equal_approx(music, _engine.music_gain):
+		_engine.music_gain = music
+	if not is_equal_approx(sfx, _engine.sfx_gain):
+		_engine.sfx_gain = sfx
 
 
 ## Plays one imported audio record. Music continues when the source asks for the
@@ -215,6 +244,8 @@ func audio_status() -> Dictionary:
 		"sfx_active": _engine.sfx_active(),
 		"music_active": _engine.music_channels_active(),
 		"volume": _engine.volume,
+		"music_gain": _engine.music_gain,
+		"sfx_gain": _engine.sfx_gain,
 		"sound_output": _engine.sound_output,
 		"registered_banks": _engine.registered_bank_count(),
 		# The bank and address of the piece the driver is on, which is the same

--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -158,6 +158,12 @@ var channels: Array[Channel] = []
 var music_playing: bool = false
 var stereo: bool = false
 
+## Listening levels, 1.0 being the cartridge's own output. Not part of the
+## driver: they leave every register write alone and only weight the mix, so a
+## parity check reads the same numbers whatever the player has these set to.
+var music_gain: float = 1.0
+var sfx_gain: float = 1.0
+
 var volume: int = 0
 var last_volume: int = 0
 var sound_output: int = 0
@@ -482,6 +488,21 @@ func update_sound() -> void:
 	_fade_music()
 	apu.write(RNR50, volume)
 	apu.write(RNR51, sound_output)
+	_apply_output_gain()
+
+
+## The two listening levels, pushed to the hardware channels each frame by which
+## stream owns each one. A hardware channel an sfx stream has taken carries the
+## effect level for as long as it holds it, which is the same rule
+## [method sfx_active] answers on, so nothing here needs a second notion of who
+## is playing what.
+func _apply_output_gain() -> void:
+	for hardware: int in NUM_MUSIC_CHANNELS:
+		apu.channel_gain[hardware] = (
+			sfx_gain
+			if channels[hardware + NUM_MUSIC_CHANNELS].channel_on
+			else music_gain
+		)
 
 
 func _update_channels() -> void:

--- a/game/launcher/title_backdrop.gd
+++ b/game/launcher/title_backdrop.gd
@@ -1,15 +1,24 @@
 class_name Gen2LauncherTitleBackdrop
 extends Node
 
-## A muted, non-interactive title-screen loop for the launcher backdrop.
+## A non-interactive title-screen loop, picture and music, for the launcher
+## backdrop.
 ##
 ## This deliberately hosts only [Gen2TitleScene] and [Gen2TitlePage]. The boot
-## cinema that advances into the intro and menu is never created, and neither is
-## an audio player. When the title timer expires, this node creates a fresh title
-## scene and starts the same title animation again.
+## cinema that advances into the intro and menu is never created. What it does
+## create is the cartridge sound driver, so the screen is heard as well as seen:
+## the same `MUSIC_TITLE` the title screen itself plays, at [constant
+## VOLUME_SCALE] of the player's settings, looping for as long as the backdrop
+## is up.
 
 const FRAME_TIME: float = 1.0 / 60.0
 const MAX_STEPS_PER_TICK: int = 4
+## The backdrop plays under an interface rather than as the game, so it takes
+## half of whatever the app block's music volume is.
+const VOLUME_SCALE: float = 0.5
+## How often the loop is checked. The title piece loops on the driver's own
+## `loopchannel`, so this only has to catch a cache whose piece ends.
+const LOOP_CHECK_FRAMES: int = 60
 
 var _data: GameData = null
 var _page: Gen2TitlePage = null
@@ -17,6 +26,8 @@ var _scene: Gen2TitleScene = null
 var _sine: Gen2BattleAnimData = null
 var _texture: ImageTexture = null
 var _elapsed: float = 0.0
+var _audio: Gen2AudioPlayer = null
+var _loop_countdown: int = LOOP_CHECK_FRAMES
 
 
 func _ready() -> void:
@@ -39,14 +50,17 @@ func show_game(data: GameData) -> Texture2D:
 		_restart()
 	if _page == null or _scene == null:
 		set_process(false)
+		_stop_music()
 		return null
 	set_process(true)
+	_start_music()
 	return _texture
 
 
 func hide_backdrop() -> void:
 	set_process(false)
 	_elapsed = 0.0
+	_stop_music()
 
 
 func _process(delta: float) -> void:
@@ -64,6 +78,7 @@ func _process(delta: float) -> void:
 	var frame: Image = _clean_frame(_page.draw(_scene))
 	if frame != null:
 		_texture.update(frame)
+	_hold_music()
 
 
 func _restart() -> void:
@@ -80,6 +95,54 @@ func _restart() -> void:
 		_texture = ImageTexture.create_from_image(frame)
 	else:
 		_texture.update(frame)
+
+
+## `PlayMusic MUSIC_TITLE`, which is what the title screen's own entrance ends
+## on. The player is built on the first backdrop rather than in `_ready` so a
+## headless launcher run, a test or a screenshot tool never wakes the driver.
+func _start_music() -> void:
+	if _data == null:
+		return
+	var record: Dictionary = _data.world_audio(&"music", Gen2BootCinema.MUSIC_TITLE)
+	if record.is_empty():
+		return
+	if _audio == null:
+		_audio = Gen2AudioPlayer.new()
+		_audio.volume_scale = VOLUME_SCALE
+		add_child(_audio)
+	_loop_countdown = LOOP_CHECK_FRAMES
+	# A second request for the piece already playing is continued rather than
+	# restarted, so returning to the shelf does not start the tune over.
+	_audio.play_record(record, &"music", _audio_assets())
+
+
+func _stop_music() -> void:
+	if _audio == null:
+		return
+	_audio.stop_all()
+
+
+## The loop. The piece carries its own `loopchannel 0`, so the driver repeats it
+## without help; this only covers the case of it running out, which is what a
+## cache holding a piece with no loop would do.
+func _hold_music() -> void:
+	if _audio == null:
+		return
+	_loop_countdown -= 1
+	if _loop_countdown > 0:
+		return
+	_loop_countdown = LOOP_CHECK_FRAMES
+	if not bool(_audio.audio_status().get("music_active", false)):
+		_start_music()
+
+
+## The two blobs [Gen2SoundEngine] reads outside a record, the same pair the
+## opening's own screen passes.
+func _audio_assets() -> Dictionary:
+	return {
+		"wave_samples": _data.world_audio_asset(&"wave_samples"),
+		"drumkits": _data.world_audio_asset(&"drumkits"),
+	}
 
 
 ## Removes only the title lettering from the launcher copy. The real title page

--- a/game/launcher/title_backdrop.gd
+++ b/game/launcher/title_backdrop.gd
@@ -16,9 +16,6 @@ const MAX_STEPS_PER_TICK: int = 4
 ## The backdrop plays under an interface rather than as the game, so it takes
 ## half of whatever the app block's music volume is.
 const VOLUME_SCALE: float = 0.5
-## How often the loop is checked. The title piece loops on the driver's own
-## `loopchannel`, so this only has to catch a cache whose piece ends.
-const LOOP_CHECK_FRAMES: int = 60
 
 var _data: GameData = null
 var _page: Gen2TitlePage = null
@@ -27,7 +24,6 @@ var _sine: Gen2BattleAnimData = null
 var _texture: ImageTexture = null
 var _elapsed: float = 0.0
 var _audio: Gen2AudioPlayer = null
-var _loop_countdown: int = LOOP_CHECK_FRAMES
 
 
 func _ready() -> void:
@@ -110,7 +106,6 @@ func _start_music() -> void:
 		_audio = Gen2AudioPlayer.new()
 		_audio.volume_scale = VOLUME_SCALE
 		add_child(_audio)
-	_loop_countdown = LOOP_CHECK_FRAMES
 	# A second request for the piece already playing is continued rather than
 	# restarted, so returning to the shelf does not start the tune over.
 	_audio.play_record(record, &"music", _audio_assets())
@@ -122,18 +117,15 @@ func _stop_music() -> void:
 	_audio.stop_all()
 
 
-## The loop. The piece carries its own `loopchannel 0`, so the driver repeats it
-## without help; this only covers the case of it running out, which is what a
-## cache holding a piece with no loop would do.
+## The music is a property of the backdrop being up, checked on the frames the
+## backdrop draws rather than started by whichever event happened to bring it
+## back. Nothing then depends on a page, a sheet or a selection emitting the
+## signal that reaches [method show_game]: while there is a picture there is a
+## piece playing, and a piece that ends is started again on the next frame.
 func _hold_music() -> void:
-	if _audio == null:
+	if _audio != null and _audio.music_playing():
 		return
-	_loop_countdown -= 1
-	if _loop_countdown > 0:
-		return
-	_loop_countdown = LOOP_CHECK_FRAMES
-	if not bool(_audio.audio_status().get("music_active", false)):
-		_start_music()
+	_start_music()
 
 
 ## The two blobs [Gen2SoundEngine] reads outside a record, the same pair the

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -52,6 +52,10 @@ func _build() -> void:
 	_shelf.play_requested.connect(_launch_game)
 	_shelf.manage_requested.connect(_open_manage_sheet)
 	_shelf.selection_changed.connect(_on_cartridge_selected)
+	# The backdrop follows the shelf being on screen rather than the dock being
+	# pressed, so a sheet, a restored page or anything else that reveals the
+	# shelf without a page signal brings the picture and its music back too.
+	_shelf.visibility_changed.connect(_refresh_backdrop)
 	_shell.add_page(&"shelf", "Play", &"shelf", _shelf)
 
 	_mods = Gen2ModsPage.create(_palette, self)
@@ -125,6 +129,8 @@ func _on_page_selected(_id: StringName) -> void:
 ## The selected cartridge's artwork, and only once that cartridge is imported: an
 ## empty bay would otherwise advertise a game the player cannot start.
 func _refresh_backdrop() -> void:
+	if not is_instance_valid(_shelf) or not is_instance_valid(_shell):
+		return
 	var game_id: StringName = _shelf.selected_id()
 	var seated: Gen2Cartridge = _shelf.cartridge(game_id)
 	var showing: bool = (

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -27,6 +27,29 @@ func _record(bank: int, index: int = 1) -> Dictionary:
 	}
 
 
+## The app block's two volumes are the game's, not only the launcher's: they are
+## pushed to the driver's mix, where music and effects can still be told apart,
+## and a host's own scale multiplies them.
+func test_the_app_volumes_and_a_host_scale_reach_the_drivers_mix() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var music: int = options.music_volume
+	var sfx: int = options.sfx_volume
+	options.music_volume = Gen2Options.MAX_VOLUME
+	options.sfx_volume = 0
+	# Edited in place while the player runs, which is what the settings slider
+	# does, so the level has to be read rather than taken once at startup.
+	_player._apply_volume()
+	var status: Dictionary = _player.audio_status()
+	assert_almost_eq(float(status["music_gain"]), 1.0, 0.001)
+	assert_almost_eq(float(status["sfx_gain"]), 0.0, 0.001)
+
+	_player.volume_scale = 0.5
+	assert_almost_eq(float(_player.audio_status()["music_gain"]), 0.5, 0.001)
+
+	options.music_volume = music
+	options.sfx_volume = sfx
+
+
 func test_music_already_playing_is_continued_rather_than_started_again() -> void:
 	var first: Dictionary = _player.play_record(_record(2), &"map_music")
 	assert_true(first["ok"])

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -50,6 +50,21 @@ func test_the_app_volumes_and_a_host_scale_reach_the_drivers_mix() -> void:
 	options.sfx_volume = sfx
 
 
+## A host that stops its own stream and then asks for music again gets sound,
+## not a live driver over a dead output.
+func test_a_stopped_output_under_live_channels_starts_itself_again() -> void:
+	assert_true(_player.play_record(_record(2), &"map_music")["played"])
+	_player._player.stop()
+	_player._service_timeline()
+	assert_true(_player._player.playing, "the output followed the driver")
+
+	# Stopping the driver as well leaves it stopped, which is what a screen
+	# closing means.
+	_player.stop_all()
+	_player._service_timeline()
+	assert_false(_player._player.playing)
+
+
 func test_music_already_playing_is_continued_rather_than_started_again() -> void:
 	var first: Dictionary = _player.play_record(_record(2), &"map_music")
 	assert_true(first["ok"])

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -175,6 +175,46 @@ func test_the_title_backdrop_plays_the_title_music_and_stops_with_the_picture() 
 	assert_false(bool(audio.audio_status()["music_active"]), "and it stops with it")
 
 
+## Leaving the shelf and coming back is the whole cycle: the picture and the
+## music both come back with the page, without the player touching the list.
+func test_the_backdrop_music_comes_back_with_the_shelf() -> void:
+	if GameData.open_any() == null:
+		pass_test("No imported cache on this machine.")
+		return
+	await _open_launcher()
+	var shell: Gen2LauncherShell = _launcher.get("_shell")
+	var backdrop: Gen2LauncherTitleBackdrop = _launcher.get("_title_backdrop")
+	if backdrop.get_child_count() == 0:
+		pass_test("No cartridge is seated on this machine.")
+		return
+	assert_true(_music_active(backdrop), "the shelf started it")
+
+	shell.select(&"settings")
+	await get_tree().process_frame
+	assert_false(_music_active(backdrop), "another page stops it")
+
+	shell.select(&"shelf")
+	await get_tree().process_frame
+	assert_true(_music_active(backdrop), "and coming back starts it again")
+
+	# The picture being up is the whole condition: a piece stopped underneath is
+	# started again on the next frame the backdrop draws, whatever stopped it.
+	for child: Node in backdrop.get_children():
+		if child is Gen2AudioPlayer:
+			(child as Gen2AudioPlayer).stop_all()
+	assert_false(_music_active(backdrop))
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_true(_music_active(backdrop), "the backdrop holds its own music")
+
+
+func _music_active(backdrop: Gen2LauncherTitleBackdrop) -> bool:
+	for child: Node in backdrop.get_children():
+		if child is Gen2AudioPlayer:
+			return bool((child as Gen2AudioPlayer).audio_status()["music_active"])
+	return false
+
+
 func _write_probe_mod_zip() -> void:
 	var packer := ZIPPacker.new()
 	assert_eq(packer.open(_mod_archive), OK)

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -148,6 +148,33 @@ func test_the_selected_save_is_one_shared_instance_until_the_selection_changes()
 	GameRuntime.reload_selected_save()
 
 
+## The backdrop is heard as well as seen, at half the app block's music volume,
+## and it stops with the picture rather than playing on behind another page.
+func test_the_title_backdrop_plays_the_title_music_and_stops_with_the_picture() -> void:
+	var data: GameData = GameData.open_any()
+	if data == null:
+		pass_test("No imported cache on this machine.")
+		return
+	var backdrop := Gen2LauncherTitleBackdrop.new()
+	add_child_autofree(backdrop)
+	if backdrop.show_game(data) == null:
+		pass_test("This cache carries no title-screen art.")
+		return
+
+	var audio: Gen2AudioPlayer = null
+	for child: Node in backdrop.get_children():
+		if child is Gen2AudioPlayer:
+			audio = child
+	assert_not_null(audio, "the backdrop built a driver")
+	if audio == null:
+		return
+	assert_almost_eq(audio.volume_scale, Gen2LauncherTitleBackdrop.VOLUME_SCALE, 0.001)
+	assert_true(bool(audio.audio_status()["music_active"]), "the title piece started")
+
+	backdrop.hide_backdrop()
+	assert_false(bool(audio.audio_status()["music_active"]), "and it stops with it")
+
+
 func _write_probe_mod_zip() -> void:
 	var packer := ZIPPacker.new()
 	assert_eq(packer.open(_mod_archive), OK)

--- a/tests/unit/test_sound_engine.gd
+++ b/tests/unit/test_sound_engine.gd
@@ -243,6 +243,30 @@ func test_an_effect_takes_the_music_channel_and_gives_it_back() -> void:
 	assert_true(engine.music_channels_active(), "the music never stopped")
 
 
+## The two listening levels weight the mix and nothing else: a hardware channel
+## carries the effect level exactly while an effect stream owns it, and goes
+## back to the music level with the channel.
+func test_the_output_gain_follows_whichever_stream_owns_each_channel() -> void:
+	var engine: Gen2SoundEngine = _engine()
+	engine.music_gain = 0.5
+	engine.sfx_gain = 0.25
+	assert_true(engine.play_music(_record([[0, [
+		0xD8, 0x10, 0xB1, 0xD4, 0x1F, 0xFC, 0x03, 0x40,
+	]]], 0x3B)))
+	engine.update_sound()
+	assert_almost_eq(engine.apu.channel_gain[0], 0.5, 0.001)
+
+	assert_true(engine.play_sfx(_record([[4, [
+		0xDF, 0xD8, 0x01, 0xB1, 0xD4, 0x10, 0xFF,
+	]]], 0x3C)))
+	var _stolen: Array = _writes(engine, 1)
+	assert_almost_eq(engine.apu.channel_gain[0], 0.25, 0.001)
+	assert_almost_eq(engine.apu.channel_gain[1], 0.5, 0.001, "the rest is music")
+
+	var _drain: Array = _writes(engine, 6)
+	assert_almost_eq(engine.apu.channel_gain[0], 0.5, 0.001)
+
+
 ## `PlaySFX`'s own gate. The table is ordered highest priority first, so the id
 ## still on the channels has to be less than or equal to the new one for it to
 ## be taken; the same id restarts, which is `cp e / jr c`.


### PR DESCRIPTION
The launcher shows the selected cartridge's title screen behind the shelf, in silence. It now plays that screen's own music too.

- The backdrop plays `MUSIC_TITLE` at half the player's music volume, and stops when the shelf does. The piece loops on its own `loopchannel`; the driver is still playing it after 3,600 frames on all three cartridges.
- The Application settings' two volume sliders did not reach the game. Music volume governed nothing at all, and sound volume only the launcher's own six interface clips. Both are now the sound driver's listening levels.
- The driver pushes a music level and an effect level per hardware channel, by whichever of its eight streams owns that channel on the frame. That is the only place music and effects can still be told apart, because they share four channels.
- The gain is applied where a channel joins the mix, so no register write changes and an audio parity check reads the same numbers whatever the sliders are set to.

Measured per cartridge over 3,600 driver frames: RMS 7,060 at full and 3,530 at half on Gold and Silver, 7,139 and 3,569 on Crystal, music channels still on at the end.

Tests: 3,073 pass. `validate.gd -- all` passes.