### PR TITLE
Keep the sound out of game speed, and keep it alive across a session change

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,21 @@ them runs: no scripts, no walking, no wild encounters, no collision. Only the ma
 you are on is live, exactly as on the cartridge, where a connected map is three
 blocks of scenery copied into the buffer and nothing more.
 
+### Game speed, window and frame rate
+
+Settings > Application carries three more that reach the engine:
+
+| Setting | What it does |
+|---|---|
+| Game speed | Normal, double or half. Everything counted in hardware frames runs at that multiple: walking, animations, text, battle |
+| Window | Windowed, fullscreen or borderless |
+| Frame rate | 30, 60, 120, 144 or uncapped |
+
+**Sound is deliberately outside game speed.** The driver is fed by the audio
+output's own demand rather than by a game frame, so music, effects and cries keep
+the cartridge's tempo and pitch at every setting; only how often the game asks
+for one changes.
+
 Development shortcuts are debug-build only, along with the map and cell readout:
 
 | Scene | Keys |

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -86,7 +86,33 @@ var _loaded_mods: Array = []
 ## built would not be offered until the next map. It also means a broken mod is
 ## reported while there is still a launcher to report it in.
 func _ready() -> void:
+	apply_display_options(Gen2OptionsStore.current())
 	load_mods()
+
+
+## Puts the app block's window and frame-rate settings into the engine.
+##
+## The settings page calls this after every change, the way it calls
+## [method Gen2InputRuntime.apply_options] for the control scheme; nothing else
+## needs to. Refused on anything but a player's own launch: a headless check or a
+## `-s` tool would otherwise be capped at whatever frame rate the developer last
+## chose, and a screenshot driver would take the window with it. GAME SPEED is
+## not here: it reaches the game through [Gen2WorldAnimation.FrameClock], which
+## is what keeps it off the audio driver.
+static func apply_display_options(options: Gen2Options) -> void:
+	if options == null or not is_player_launch():
+		return
+	Engine.max_fps = maxi(options.max_fps, 0)
+	var mode: DisplayServer.WindowMode = DisplayServer.WINDOW_MODE_WINDOWED
+	var borderless: bool = false
+	match options.video_mode:
+		&"fullscreen":
+			mode = DisplayServer.WINDOW_MODE_FULLSCREEN
+		&"borderless":
+			mode = DisplayServer.WINDOW_MODE_FULLSCREEN
+			borderless = true
+	DisplayServer.window_set_mode(mode)
+	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_BORDERLESS, borderless)
 
 
 ## Discovers and runs every mod under [constant Gen2ModHost.ROOT], returning the
@@ -135,6 +161,14 @@ static func mods_are_allowed() -> bool:
 	var args: PackedStringArray = OS.get_cmdline_args()
 	if args.has("--mods") or OS.get_cmdline_user_args().has("--mods"):
 		return true
+	return is_player_launch()
+
+
+## Whether this process is a player running the game rather than a check, a test
+## tier, a screenshot driver or a replay. See [method mods_are_allowed] for what
+## rides on the distinction.
+static func is_player_launch() -> bool:
+	var args: PackedStringArray = OS.get_cmdline_args()
 	return not (
 		DisplayServer.get_name() == "headless"
 		or args.has("-s") or args.has("--script")

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -10,11 +10,32 @@ extends Node
 ## samples the APU produced from it.
 
 ## The generator's depth, which Godot rounds up to 4,096 output frames: seven
-## driver frames, 125 ms. This is latency, not headroom, because the buffer is
-## kept as full as it will go, so a button's effect is heard that long after the
-## press. Measured worst emptiness on a desktop run is a quarter of it; halving
-## it again would leave nothing for a long frame.
+## driver frames. This is capacity, not latency: [member _target_frames] is how
+## much of it is kept filled, and the rest is headroom a long frame is caught up
+## into. See [method _service_timeline].
 const BUFFER_SECONDS: float = 0.1
+
+## Driver frames kept queued ahead of the output, and so the press-to-sound delay
+## this player adds before the platform's own: three frames is 50 ms at
+## [constant Gen2Apu.SAMPLE_RATE].
+##
+## The buffer used to be kept as full as it would go, which spent its whole
+## 125 ms depth as latency. Measured worst emptiness on a desktop run was a
+## quarter of the depth, so about two driver frames are consumed between two
+## services there; three is that with a frame to spare, and a device that cannot
+## hold it says so by running the queue dry, which raises the target rather than
+## needing a build per target and an ear.
+const TARGET_FRAMES_MIN: int = 3
+## The ceiling the target grows to, which is the whole buffer: past it there is
+## nothing left to raise.
+const TARGET_FRAMES_MAX: int = 7
+
+## Real seconds the output may take nothing from the driver before it is treated
+## as dead. See [method _watch_for_a_dead_output].
+const STALL_SECONDS: float = 0.5
+## How much of that window a resume leaves: enough for a session that really did
+## come back to prove it, and no longer.
+const RESUME_GRACE_SECONDS: float = 0.1
 
 ## Whether `Music_StereoPanning` is honoured. Follows the SOUND option, which is
 ## what `wOptions`' STEREO bit means to the driver.
@@ -42,6 +63,20 @@ var _engine: Gen2SoundEngine = null
 var _apu: Gen2Apu = null
 var _music_key: String = ""
 var _buffer: PackedVector2Array = PackedVector2Array()
+## How much of the generator is kept filled, in driver frames. Raised by an
+## underrun and never lowered inside a run: a device that stuttered once will do
+## it again, and the frame of latency is cheaper than the gap.
+var _target_frames: int = TARGET_FRAMES_MIN
+## The generator's own depth in output frames, learned from the first service
+## rather than computed, since Godot rounds the length it was asked for.
+var _capacity: int = 0
+## Real seconds the output has consumed nothing while the driver had sound for
+## it. See [constant STALL_SECONDS].
+var _starved_seconds: float = 0.0
+## Underruns and dead-output rebuilds this player has seen, for [method
+## audio_status] and for a check that has to say a device held up.
+var _underruns: int = 0
+var _restarts: int = 0
 
 
 ## The driver exists before the node enters the tree: a host that plays its map
@@ -60,9 +95,28 @@ func _ready() -> void:
 	set_process(true)
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
 	_apply_volume()
-	_service_timeline()
+	_service_timeline(delta)
+
+
+## The audio session, on every platform that says anything about it.
+##
+## Android and iOS send the two APPLICATION notifications when a call, Siri, the
+## audio focus or a home press takes the session away, and desktop sends the two
+## FOCUS ones. Coming back is what needs handling: the driver kept running, the
+## stream player still reports `playing`, and pushing into a playback nothing
+## consumes is silence over live music until a screen change builds another one.
+## A resume does not rebuild outright, because an alt-tab is a FOCUS_IN too and
+## a live output would be cut for nothing; it shortens the watchdog's window
+## instead, so an output that is still there proves it on the next tick and one
+## that is not is replaced a tenth of a second later. Going away needs nothing:
+## `_process` stops with the main loop, and where it does not the generator fills
+## and the fill stops.
+func _notification(what: int) -> void:
+	match what:
+		NOTIFICATION_APPLICATION_RESUMED, NOTIFICATION_APPLICATION_FOCUS_IN:
+			_starved_seconds = maxf(_starved_seconds, STALL_SECONDS - RESUME_GRACE_SECONDS)
 
 
 ## The app block's two volumes, pushed to the driver's mix rather than to the
@@ -258,6 +312,11 @@ func audio_status() -> Dictionary:
 		# The bank and address of the piece the driver is on, which is the same
 		# key a second request for it is continued by. Empty when nothing is.
 		"music_key": _music_key,
+		# What the output cost: how far ahead of it the driver is kept, how often
+		# that was not enough, and how many dead sessions were rebuilt.
+		"target_frames": _target_frames,
+		"underruns": _underruns,
+		"output_restarts": _restarts,
 	}
 
 
@@ -302,10 +361,14 @@ func _start_stream() -> void:
 		_playback = _player.get_stream_playback() as AudioStreamGeneratorPlayback
 
 
-## Fills the generator a source frame at a time. Audio time is the driver's
-## clock, not the renderer's: a long game frame is caught up here rather than
-## slowing the music down.
-func _service_timeline() -> void:
+## Fills the generator up to [member _target_frames] ahead of the output.
+##
+## Audio time is the driver's clock, not the renderer's: a long game frame is
+## caught up here rather than slowing the music down, and GAME SPEED never
+## reaches it, because [param delta] is only ever the dead-output watchdog's.
+## Filling to a target rather than to the brim is what makes the rest of the
+## depth headroom instead of latency.
+func _service_timeline(delta: float = 0.0) -> void:
 	if _player == null:
 		return
 	if not _player.playing:
@@ -314,6 +377,7 @@ func _service_timeline() -> void:
 		# asked for the same piece again used to leave behind. The output
 		# follows the driver rather than the other way round.
 		if not _engine.any_channel_active():
+			_starved_seconds = 0.0
 			return
 		_start_stream()
 		if not _player.playing:
@@ -322,8 +386,67 @@ func _service_timeline() -> void:
 		_playback = _player.get_stream_playback() as AudioStreamGeneratorPlayback
 		if _playback == null:
 			return
-	while _playback.get_frames_available() >= Gen2Apu.SAMPLES_PER_FRAME:
+	var available: int = _playback.get_frames_available()
+	# The depth Godot actually gave, which is the length it was asked for rounded
+	# up to a power of two. Read rather than computed, and highest wins: the
+	# buffer is only this empty before the first fill.
+	var known: int = _capacity
+	_capacity = maxi(_capacity, available)
+	# A buffer that drained to empty was heard as a gap, so the target rises and
+	# the device tunes itself rather than needing a build and an ear per target.
+	# Only once a depth is known: a fresh stream is legitimately empty, and a
+	# rebuilt output has to learn the new device's depth before it can be short.
+	if known > 0 and available >= known and _timeline_updates > 0:
+		_underruns += 1
+		_target_frames = mini(_target_frames + 1, TARGET_FRAMES_MAX)
+	var target: int = mini(_target_frames * Gen2Apu.SAMPLES_PER_FRAME, _capacity)
+	var pushed: int = 0
+	while available >= Gen2Apu.SAMPLES_PER_FRAME and _capacity - available < target:
 		_timeline_updates += 1
 		_engine.update_sound()
 		_apu.render_frame(_buffer)
 		_playback.push_buffer(_buffer)
+		available = _playback.get_frames_available()
+		pushed += 1
+	_watch_for_a_dead_output(delta, pushed)
+
+
+## Rebuilds an output that has taken nothing from the driver for
+## [constant STALL_SECONDS] while the driver had sound for it.
+##
+## The platforms that announce an interruption are handled in
+## [method _notification]; this is the ones that do not, and it is also what
+## makes that handler cheap, since a resume only has to shorten this window
+## rather than rebuild a live output. `AudioStreamPlayer` reports `playing` over
+## a dead device, so what the queue does is the only honest evidence: a live one
+## consumes 59.7 driver frames a second and so takes a fill within a few ticks,
+## whatever the host's frame rate.
+func _watch_for_a_dead_output(delta: float, pushed: int) -> void:
+	if pushed > 0 or not _engine.any_channel_active():
+		_starved_seconds = 0.0
+		return
+	_starved_seconds += delta
+	if _starved_seconds >= STALL_SECONDS:
+		_restart_output()
+
+
+## Drops the stream player and builds another, which is the only way back from a
+## session that went away: the playback the audio server held belongs to the
+## device that is gone. The driver is untouched, so the piece the game is on
+## carries on from where it stands rather than restarting.
+func _restart_output() -> void:
+	_starved_seconds = 0.0
+	if _player == null:
+		return
+	_restarts += 1
+	_player.stop()
+	_player.stream = null
+	# Off the tree before it is freed, so the replacement can take its name back
+	# on this frame rather than being renamed against a child queued for deletion.
+	remove_child(_player)
+	_player.queue_free()
+	_player = null
+	_generator = null
+	_playback = null
+	_capacity = 0
+	_start_stream()

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -227,12 +227,12 @@ var _held_message: String = ""
 ## that the run of frames it just finished owes a press rather than the next
 ## command; see [method _resume_after_frames].
 var _message_awaits_press: bool = false
-## Leftover of a hardware frame the bars and the intro have not counted yet.
-var _frame_elapsed: float = 0.0
+## The bars' and the intro's clock: see [method _process].
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## The same, for the party page's icons. Kept apart because they animate while
 ## nothing else does, and [method frames_running] must stay false there: a
 ## caller draining frames to a terminal state would never reach one.
-var _icon_elapsed: float = 0.0
+var _icon_clock := Gen2WorldAnimation.FrameClock.new()
 ## What the overworld clock said when the battle started, for the three heals
 ## that read it. Only the world path supplies one; the development drivers below
 ## leave [Gen2Battle] at its own midday default.
@@ -392,16 +392,9 @@ func _process(delta: float) -> void:
 	## that answer would never stop.
 	var running: bool = frames_running()
 	if not running and (_box == null or not _box.visible):
-		_frame_elapsed = 0.0
+		_frame_clock.reset()
 		return
-	## Capped the way [method Gen2WorldScreen._process] caps it: a stall should
-	## drop animation frames, not run a second of them in one host frame.
-	_frame_elapsed = minf(
-		_frame_elapsed + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
-	)
-	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _frame_clock.tick(delta):
 		if frames_running():
 			advance_frame()
 		elif _box != null:
@@ -3250,7 +3243,7 @@ func _open_switch_pick(reason: StringName) -> void:
 	## list opens on the first frame of their animation rather than resuming.
 	if _party_page != null:
 		_party_page.reset(_switch_menu.rows)
-	_icon_elapsed = 0.0
+	_icon_clock.reset()
 	## The party menu is the whole screen rather than a box on it, so the battle's
 	## own box goes with the field it belongs to.
 	if _box != null:
@@ -3625,18 +3618,12 @@ func _draw_move_info(row: Dictionary) -> void:
 
 
 ## `PlaySpriteAnimations` over the party page's icons, on the hardware clock the
-## bars use. Capped the same way, so a stall drops passes rather than running a
-## second of them at once.
+## bars use.
 func _advance_party_icons(delta: float) -> void:
 	if _party_page == null or _switch_menu == null or _switch_stage not in [&"pick", &"refused"]:
-		_icon_elapsed = 0.0
+		_icon_clock.reset()
 		return
-	_icon_elapsed = minf(
-		_icon_elapsed + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
-	)
-	while _icon_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_icon_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _icon_clock.tick(delta):
 		advance_party_icons()
 
 

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -307,6 +307,7 @@ func _titles(values: Array[StringName]) -> Array[String]:
 
 
 func _persist() -> void:
+	Gen2GameRuntime.apply_display_options(_options)
 	var ok: bool = Gen2OptionsStore.save(_options)
 	_saved.text = (
 		"Saved." if ok else "The options file could not be written."

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -17,8 +17,8 @@ const TEXT_DELAY_FAST: int = 1
 const TEXT_DELAY_MED: int = 3
 const TEXT_DELAY_SLOW: int = 5
 const TEXT_DELAY_MASK: int = 0b111
-## The delays above are frame counts, so a rate needs the frame.
-const FRAME_SECONDS: float = 1.0 / 60.0
+## The delays above are frame counts of the hardware VBlank, so a rate needs it.
+const FRAME_SECONDS: float = Gen2WorldAnimation.FRAME_SECONDS
 const TEXT_DELAYS: Array[int] = [TEXT_DELAY_FAST, TEXT_DELAY_MED, TEXT_DELAY_SLOW]
 
 ## Both of these read backwards: `options_menu.asm` `Options_BattleScene`
@@ -52,6 +52,9 @@ const BIT_FAST_TEXT_DELAY: int = 0
 const MAX_VOLUME: int = 10
 const VIDEO_MODES: Array[StringName] = [&"windowed", &"fullscreen", &"borderless"]
 const GAME_SPEEDS: Array[StringName] = [&"normal", &"double", &"half"]
+## How much hardware time one real second buys, per row of [constant
+## GAME_SPEEDS]. See [method speed_scale].
+const GAME_SPEED_SCALES: Array[float] = [1.0, 2.0, 0.5]
 const FPS_CHOICES: Array[int] = [30, 60, 120, 144, 0]
 const UI_THEMES: Array[StringName] = [&"light", &"dark"]
 ## `auto` shows the on-screen controller while the player is using the
@@ -140,6 +143,17 @@ func text_delay_frames() -> int:
 ## needs: 60, 20 or 12 characters a second. See [member Gen2TextBox.reveal_speed].
 func text_reveal_speed() -> float:
 	return 1.0 / (FRAME_SECONDS * float(text_delay_frames()))
+
+
+## Hardware frames per real second, as a multiple of the cartridge's own rate.
+##
+## Applied by [Gen2WorldAnimation.FrameClock] and nowhere else, which is what
+## keeps it off the sound driver: [Gen2AudioPlayer] fills its generator from the
+## output's own demand, so music, effects and cries run at the cartridge's tempo
+## and pitch at every setting.
+func speed_scale() -> float:
+	var row: int = GAME_SPEEDS.find(game_speed)
+	return GAME_SPEED_SCALES[row] if row >= 0 else 1.0
 
 
 ## Reads a cartridge block back. A short block is refused rather than padded,

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -44,7 +44,7 @@ const CURSOR_COLUMN: int = 18
 ## the reason [member reveal_speed] is a rate: the period is the same either
 ## way and this does not assume 60 Hz.
 const CURSOR_BLINK_FRAMES: int = 16
-const FRAME_SECONDS: float = 1.0 / 60.0
+const FRAME_SECONDS: float = Gen2WorldAnimation.FRAME_SECONDS
 
 ## `TextScroll` shifts the whole interior up one tile row, blanks the row it
 ## leaves at the bottom and spends five frames. `_ContText` and
@@ -130,6 +130,8 @@ var _scroll_lines: Array = []
 var _scroll_rows: int = 0
 var _scroll_elapsed: float = 0.0
 var _scroll_page: int = -1
+## The clock an undriven box reveals on; see [method _process].
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 func _ready() -> void:
@@ -143,16 +145,23 @@ func _ready() -> void:
 ## screenshot driver, a replay. `PrintLetterDelay` is a frame count on the
 ## cartridge, so this is the same clock [method _process] converts real time into.
 func advance_frame() -> void:
-	_process(FRAME_SECONDS)
+	_advance()
 
 
+## An undriven box keeps its own clock, so GAME SPEED reaches a box nothing else
+## is spending frames for the way it reaches a driven one.
 func _process(delta: float) -> void:
+	for _frame: int in _frame_clock.tick(delta):
+		_advance()
+
+
+func _advance() -> void:
 	if _scroll_page >= 0:
-		_advance_scroll(delta)
+		advance_scroll_frames(1.0)
 		return
 	if _shown < float(_tiles_on_page):
 		var rate: float = maxf(reveal_speed, ACCELERATED_SPEED) if accelerated else reveal_speed
-		_shown = minf(_shown + delta * rate, float(_tiles_on_page))
+		_shown = minf(_shown + FRAME_SECONDS * rate, float(_tiles_on_page))
 		_redraw()
 		return
 	if _pages.is_empty():
@@ -165,7 +174,7 @@ func _process(delta: float) -> void:
 		return
 	# Waiting: only the arrow changes, and only when it crosses a half period.
 	var was_up: bool = _cursor_up()
-	_blink = fmod(_blink + delta, FRAME_SECONDS * float(CURSOR_BLINK_FRAMES) * 2.0)
+	_blink = fmod(_blink + FRAME_SECONDS, FRAME_SECONDS * float(CURSOR_BLINK_FRAMES) * 2.0)
 	if _cursor_up() != was_up:
 		_redraw()
 
@@ -343,10 +352,6 @@ func _begin_scroll(next_page: int) -> void:
 	_shown = 0.0
 	set_process(not driven)
 	_redraw()
-
-
-func _advance_scroll(delta: float) -> void:
-	advance_scroll_frames(delta / FRAME_SECONDS)
 
 
 ## [param frames] hardware frames of `TextScroll`. Counted in frames rather than

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -149,7 +149,8 @@ var _menu_page: Gen2MenuPage = null
 ## A refusal standing in the menu's own bottom box, which the next A or B
 ## clears. See [constant MESSAGE_NOT_ENOUGH_HP].
 var _message: String = ""
-var _elapsed: float = 0.0
+## This screen's hardware-frame clock.
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## `OpenPartyStats`' own screen, standing over the whole party menu while it is
 ## up, and the page that draws it.
 var _stats: Gen2MonStatsScreen = null
@@ -692,11 +693,7 @@ func _build_hardware_ui() -> void:
 func _process(delta: float) -> void:
 	if _view == null or _page == null:
 		return
-	_elapsed += delta
-	var frames: int = 0
-	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
-		frames += 1
+	var frames: int = _frame_clock.tick(delta)
 	if frames == 0 or _submenu_open or _item_menu_open or _stats != null:
 		return
 	if _moves != null:

--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -9,7 +9,6 @@ extends RefCounted
 ## engine/menus/intro_menu.asm (SplashScreen, IntroSceneJumper,
 ## TitleScreenScene, Copyright).
 
-const FRAME_RATE: float = 59.7275
 const COPYRIGHT_PRELUDE_FRAMES: int = 10
 const COPYRIGHT_HOLD_FRAMES: int = 100
 

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -49,7 +49,7 @@ var _view: TextureRect = null
 var _text_box: Gen2TextBox = null
 var _presentation := Gen2IntroPresentation.new()
 var _after: Callable = Callable()
-var _accumulator: float = 0.0
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 var _phase: int = Phase.WOKE_UP
 var _hour: int = 10
 var _minute: int = 0
@@ -94,10 +94,7 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	if _text_box != null:
 		_text_box.accelerated = Gen2Button.text_accelerating()
-	_accumulator += delta * Gen2IntroPresentation.FRAME_RATE
-	var frames: int = int(_accumulator)
-	_accumulator -= float(frames)
-	advance_frames(frames)
+	advance_frames(_frame_clock.tick(delta))
 
 
 ## Runs [param count] source frames of whatever the screen is standing in.
@@ -279,7 +276,7 @@ func _hold(frames: int) -> void:
 func _queue(after: Callable) -> void:
 	_after = after
 	_waiting = true
-	_accumulator = 0.0
+	_frame_clock.reset()
 	# The routine writes its first palette before the `DelayFrames` that holds
 	# it, so the frame this is queued on is already in that state.
 	_presentation.sync()

--- a/game/world/credits_screen.gd
+++ b/game/world/credits_screen.gd
@@ -23,8 +23,8 @@ var _credits: Gen2Credits = null
 var _page: Gen2CreditsPage = null
 var _view: TextureRect = null
 var _held: Array = []
-## Leftover of a hardware frame this screen has not counted yet.
-var _elapsed: float = 0.0
+## This screen's hardware-frame clock.
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 ## [param skippable] is `STATUSFLAGS_HALL_OF_FAME_F`. False leaves the credits
@@ -118,9 +118,7 @@ func render() -> Image:
 func _process(delta: float) -> void:
 	if _credits == null:
 		return
-	_elapsed += delta
-	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
 
 

--- a/game/world/intro_presentation.gd
+++ b/game/world/intro_presentation.gd
@@ -8,10 +8,8 @@ extends RefCounted
 ## A palette step is a DMG palette byte, not a rotation: `CopyPals` reads it two
 ## bits at a time and writes the loaded colour each pair names, so a fade is an
 ## index remap of the palette already loaded ([method apply_bgp]). Every count is
-## a `DelayFrames` operand, so a screen stepping this at [constant FRAME_RATE]
-## spends the frames the cartridge spends.
-
-const FRAME_RATE: float = 59.7275
+## a `DelayFrames` operand, so a screen stepping this on
+## [Gen2WorldAnimation.FrameClock] spends the frames the cartridge spends.
 
 ## A step that writes no palette byte, or that does not move the pic.
 const KEEP: int = -1

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -47,7 +47,7 @@ var _viewport: Gen2Screen = null
 ## the screen that hosts both is the one that can spend those frames.
 var _presentation := Gen2IntroPresentation.new()
 var _after: Callable = Callable()
-var _accumulator: float = 0.0
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 var _fading: bool = false
 
 
@@ -83,10 +83,7 @@ func _ready() -> void:
 ## Sub-screens that own frames of their own are driven from here, so the whole
 ## intro runs on one clock.
 func _process(delta: float) -> void:
-	_accumulator += delta * Gen2IntroPresentation.FRAME_RATE
-	var frames: int = int(_accumulator)
-	_accumulator -= float(frames)
-	advance_frames(frames)
+	advance_frames(_frame_clock.tick(delta))
 
 
 ## Spends [param count] source frames: the fade this screen is standing in, or
@@ -225,7 +222,7 @@ func _on_gender_chosen(chosen: int) -> void:
 	_presentation.push_delay(GENDER_TAIL_FRAMES + CLOCK_HEAD_FRAMES)
 	_presentation.push_rotate_four_left()
 	_fading = true
-	_accumulator = 0.0
+	_frame_clock.reset()
 	_after = _drop_gender_screen
 	_presentation.sync()
 	_apply_fade()

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -63,7 +63,7 @@ var _audio: Gen2AudioPlayer = null
 var _audio_started: bool = false
 var _cry_played: bool = false
 var _presentation := Gen2IntroPresentation.new()
-var _accumulator: float = 0.0
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## What to run when the queue empties, which is where the routine resumes.
 var _after: Callable = Callable()
 
@@ -123,10 +123,7 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	if _text_box != null:
 		_text_box.accelerated = Gen2Button.text_accelerating()
-	_accumulator += delta * Gen2IntroPresentation.FRAME_RATE
-	var frames: int = int(_accumulator)
-	_accumulator -= float(frames)
-	advance_frames(frames)
+	advance_frames(_frame_clock.tick(delta))
 
 
 ## Runs [param count] source frames of whatever the screen is standing in.
@@ -242,7 +239,7 @@ func _after_first_fade() -> void:
 func _queue(after: Callable) -> void:
 	_after = after
 	_phase = Phase.ANIMATING
-	_accumulator = 0.0
+	_frame_clock.reset()
 	_apply_frame()
 
 

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -82,7 +82,7 @@ var _message: String = ""
 ## `wDexArrowCursorBlinkCounter`, and the leftover of a hardware frame this
 ## screen has not counted yet.
 var _blink: int = 0
-var _elapsed: float = 0.0
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 ## Optional the way the trainer card is: without a world, its state or a cache
@@ -562,9 +562,7 @@ func _search_type_line() -> String:
 func _process(delta: float) -> void:
 	if _dex == null:
 		return
-	_elapsed += delta
-	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
 
 

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -23,8 +23,6 @@ extends Control
 ## Emitted once the last phase this host can draw has finished.
 signal closed()
 
-const FRAME_RATE: float = Gen2BootCinema.FRAME_RATE
-
 var _cinema: Gen2BootCinema = null
 var _data: GameData = null
 var _page: Gen2CopyrightPage = null
@@ -39,7 +37,7 @@ var _background: TextureRect = null
 var _audio: Gen2AudioPlayer = null
 var _image: Image = null
 var _visible_id: StringName = &""
-var _accumulator: float = 0.0
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 var _closed: bool = false
 ## The last `PlayMusic` handed to the driver, which is the only place the
 ## opening's own music can be observed from outside.
@@ -89,10 +87,7 @@ func _ready() -> void:
 
 
 func _process(delta: float) -> void:
-	_accumulator += delta * FRAME_RATE
-	var frames: int = int(_accumulator)
-	_accumulator -= float(frames)
-	advance_frames(frames)
+	advance_frames(_frame_clock.tick(delta))
 
 
 ## Runs [param count] source frames. Public so a test or a preview tool can

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -193,7 +193,7 @@ var _save_lines: Array = []
 var _save_line: int = 0
 var _save_cursor: int = -1
 var _save_frames: int = 0
-var _save_elapsed: float = 0.0
+var _save_clock := Gen2WorldAnimation.FrameClock.new()
 var _save_result: Dictionary = {}
 
 var _options_menu: Gen2WorldOptionsMenu = null
@@ -216,8 +216,8 @@ var _page: Gen2StartMenuPage = null
 ## `LoadPartyMenuGFX`: the target list is the party menu, so it is drawn by the
 ## page that draws the party menu everywhere else.
 var _target_page: Gen2PartyMenuPage = null
-## Leftover of a hardware frame the target list's icons have not counted yet.
-var _target_elapsed: float = 0.0
+## The target list's icon clock.
+var _target_clock := Gen2WorldAnimation.FrameClock.new()
 ## The panel's own two roots, hidden whenever a cartridge screen is up.
 
 
@@ -1388,7 +1388,7 @@ func _open_target_mode() -> void:
 	## is opened, which is what puts the icons on the page at all.
 	if _party_menu_page() != null:
 		_target_page.reset(_party_targets())
-	_target_elapsed = 0.0
+	_target_clock.reset()
 	_render_targets()
 	## `InitPartyMenuGFX` opens every struct on frame -1, so the icons are blank
 	## until `DoNextFrameForAllSprites` has run once; the list is drawn after
@@ -1731,22 +1731,14 @@ func advance_save_frames(count: int) -> void:
 
 func _process(delta: float) -> void:
 	if _mode == Mode.PACK_TARGET:
-		## Capped the way every other hardware-frame pump here caps it: a stall
-		## drops icon passes rather than running a second of them at once.
-		_target_elapsed = minf(
-			_target_elapsed + delta,
-			Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
-		)
-		while _target_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-			_target_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+		for _frame: int in _target_clock.tick(delta):
 			advance_target_icons()
 		return
-	_target_elapsed = 0.0
+	_target_clock.reset()
 	if _mode != Mode.SAVE_SAVING and _mode != Mode.SAVE_SAVED:
+		_save_clock.reset()
 		return
-	_save_elapsed += delta
-	while _save_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_save_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _save_clock.tick(delta):
 		advance_save_frame()
 
 

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -93,8 +93,8 @@ var _nests: Array = []
 var _oam: StringName = OAM_NESTS
 var _select_held: bool = false
 var _nest_icons: Array[TextureRect] = []
-## Leftover of a hardware frame this screen has not counted yet.
-var _elapsed: float = 0.0
+## This screen's hardware-frame clock.
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 func _ready() -> void:
@@ -369,10 +369,9 @@ func current_nests() -> Array:
 
 func _process(delta: float) -> void:
 	if not _open:
+		_frame_clock.reset()
 		return
-	_elapsed += delta
-	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
 
 

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -55,8 +55,8 @@ var _page: int = Gen2TrainerCard.PAGE_1
 var _frames: int = 0
 var _background: TextureRect = null
 var _badges: Array = []
-## Leftover of a hardware frame this screen has not counted yet.
-var _elapsed: float = 0.0
+## This screen's hardware-frame clock.
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 ## Optional the way the other overlays are: without a save there is no card, so
@@ -115,9 +115,7 @@ func advance_frame() -> void:
 
 
 func _process(delta: float) -> void:
-	_elapsed += delta
-	while _elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
 
 

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -8,17 +8,46 @@ extends RefCounted
 ## the indexed tile strip held by GameData.
 
 const TILE_BYTES: int = Gen2Tiles.TILE_BYTES
-## The hardware VBlank, and the project's one definition of it: every overworld
-## timer is counted in these, and [method Gen2WorldScreen.advance_frame] is the
-## single place real time is converted into them.
+## The hardware VBlank, and the project's one definition of it: every timer in
+## the game is counted in these, and [FrameClock] is the single place real time
+## is converted into them.
 const FRAME_SECONDS: float = 1.0 / 59.7275
 ## The most catch-up frames one host frame will run. A stall should drop frames,
 ## not spend the recovery frame walking thousands of commands.
 const MAX_CATCHUP_FRAMES: int = 4
+
 const TIMER_WATER_FRAMES: Array = [0, 1, 2, 3]
 const TIMER_FOUNTAIN_FRAMES: Array = [0, 1, 2, 3, 2, 3, 4, 0]
 const TIMER_TOWER_FRAMES: Array = [0, 1, 2, 3, 4, 3, 2, 1]
 const TIMER_WATER_PALETTE: Array = [0, 1, 2, 1]
+
+## Real seconds into hardware frames, for every screen that spends them.
+##
+## One instance per pump, and the whole conversion: the remainder is banked here
+## so nothing downstream keeps one, and the cap is applied here so no screen can
+## forget it. The app block's GAME SPEED is applied here and nowhere else, which
+## is what keeps it off the sound driver: [Gen2AudioPlayer] fills its generator
+## from the output's own demand rather than from a game frame, so music, effects
+## and cries keep the cartridge's tempo and pitch at every setting.
+class FrameClock extends RefCounted:
+	var _elapsed: float = 0.0
+
+	## Hardware frames owed since the last call. The scale is read every call
+	## because the settings object is shared and edited in place.
+	func tick(delta: float) -> int:
+		_elapsed = minf(
+			_elapsed + delta * Gen2OptionsStore.current().speed_scale(),
+			FRAME_SECONDS * float(MAX_CATCHUP_FRAMES),
+		)
+		var frames: int = int(_elapsed / FRAME_SECONDS)
+		_elapsed -= float(frames) * FRAME_SECONDS
+		return frames
+
+	## Drops the banked remainder, for a pump that was not running: a screen that
+	## comes back owes frames from now rather than from when it stopped.
+	func reset() -> void:
+		_elapsed = 0.0
+
 
 var data: GameData = null
 var map: Gen2WorldMap = null

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -220,9 +220,8 @@ var _object_random := RandomNumberGenerator.new()
 ## The Day-Care's rolls, from a stream of their own for the same reason.
 var _breed_random := RandomNumberGenerator.new()
 var _selected_rod: StringName = Gen2WorldEncounter.METHOD_OLD_ROD
-## Real time banked toward the next hardware frame. The overworld's one clock:
-## see [method _process].
-var _frame_elapsed: float = 0.0
+## The overworld's hardware-frame clock: see [method _process].
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## `(frame, button)` input, recorded from a run and played back into another.
 ## Both are opt-in and off in play. A replay applies a log's entries on the frame
 ## that recorded them, from inside the pump, so a host that owes two frames
@@ -634,16 +633,12 @@ func cycle_view() -> Dictionary:
 
 
 ## Real time becomes hardware frames here and nowhere else in the overworld.
-## Everything that counts frames is spent by [method advance_frame]; the day
-## cycle underneath it is the one deliberate reader of `delta`, because Gen II
-## keeps a real-time clock and a wall-clock reading is what the day cycle wants.
+## Everything that counts frames is spent by [method advance_frame], so GAME
+## SPEED reaches all of it through the clock; the day cycle underneath is the one
+## deliberate reader of `delta`, because Gen II keeps a real-time clock and a
+## wall-clock reading is what the day cycle wants at any speed.
 func _process(delta: float) -> void:
-	_frame_elapsed = minf(
-		_frame_elapsed + delta,
-		Gen2WorldAnimation.FRAME_SECONDS * float(Gen2WorldAnimation.MAX_CATCHUP_FRAMES),
-	)
-	while _frame_elapsed >= Gen2WorldAnimation.FRAME_SECONDS:
-		_frame_elapsed -= Gen2WorldAnimation.FRAME_SECONDS
+	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
 	_advance_day_cycle(delta)
 	## Every drawn frame rather than every hardware frame: above sixty a drawn

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -181,7 +181,7 @@ func _screen_at(start: Vector2i) -> Gen2WorldScreen:
 	add_child(screen)
 	await get_tree().process_frame
 	screen.set_process(false)
-	screen._frame_elapsed = 0.0
+	screen._frame_clock.reset()
 	return screen
 
 

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -49,7 +49,7 @@ func _open_world(seed_value: int = 4242) -> Gen2WorldScreen:
 	## tree ran above left a remainder banked, which is the state a case that
 	## counts frames has to start from zero.
 	screen.set_process(false)
-	screen._frame_elapsed = 0.0
+	screen._frame_clock.reset()
 	return screen
 
 
@@ -131,6 +131,44 @@ func test_the_same_seed_and_frame_count_reach_the_same_world_at_any_frame_rate()
 		screen.free()
 	assert_eq(snapshots[0], snapshots[1], "30 fps and 60 fps disagree")
 	assert_eq(snapshots[1], snapshots[2], "60 fps and 144 fps disagree")
+
+
+## GAME SPEED multiplies real time on its way into hardware frames, and the pump
+## is the only place it is applied, so every screen that counts frames gets it
+## and nothing that does not count them can.
+func test_game_speed_scales_real_time_into_hardware_frames() -> void:
+	_world_screen = await _open_world()
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var chosen: StringName = options.game_speed
+	for speed: StringName in [&"double", &"half", &"normal"]:
+		options.game_speed = speed
+		_world_screen._frame_clock.reset()
+		var before: int = _world_screen._world.frame_number
+		# Two hardware frames of real time, which is four, one and then two.
+		_world_screen._process(FRAME * 2.0)
+		assert_eq(
+			_world_screen._world.frame_number - before,
+			int(round(2.0 * options.speed_scale())),
+			"%s" % speed,
+		)
+	options.game_speed = chosen
+
+
+## The cap is the clock's, so a stall drops frames at every speed rather than
+## handing a screen a backlog four times the size at double.
+func test_the_catch_up_cap_holds_at_every_speed() -> void:
+	_world_screen = await _open_world()
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var chosen: StringName = options.game_speed
+	options.game_speed = &"double"
+	_world_screen._frame_clock.reset()
+	var before: int = _world_screen._world.frame_number
+	_world_screen._process(10.0)
+	assert_eq(
+		_world_screen._world.frame_number - before,
+		Gen2WorldAnimation.MAX_CATCHUP_FRAMES
+	)
+	options.game_speed = chosen
 
 
 ## `Gen2WorldClock` is deliberately not converted: Generation 2 keeps a

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -11,6 +11,9 @@ var _player: Gen2AudioPlayer = null
 func before_each() -> void:
 	_player = Player.new()
 	add_child_autofree(_player)
+	# Every case here services the timeline by hand and counts what it cost, so
+	# the node's own pump must not have spent a frame first.
+	_player.set_process(false)
 
 
 ## One looping channel stream, so a started track stays started.
@@ -111,14 +114,80 @@ func test_an_effect_is_playing_until_its_stream_ends() -> void:
 	assert_false(_player.effect_playing())
 
 
-func test_generator_refill_pushes_audio_within_its_output_capacity() -> void:
+## The queue is kept a fixed few frames ahead of the output rather than full, so
+## the rest of the generator's depth is headroom instead of press-to-sound delay.
+func test_the_queue_is_kept_to_its_latency_target_not_to_the_brim() -> void:
 	assert_true(_player.play_record(_record(99), &"map_music")["ok"])
 	_player._service_timeline()
-	var available: int = _player._playback.get_frames_available()
-	var capacity: int = ceili(float(_player._generator.mix_rate) * _player._generator.buffer_length)
-	assert_gt(available, 0)
-	assert_lt(available, capacity)
-	assert_lt(available, Gen2Apu.SAMPLES_PER_FRAME, "the buffer is filled a frame at a time")
+	var capacity: int = _player._capacity
+	var pending: int = capacity - _player._playback.get_frames_available()
+	assert_gt(capacity, 0, "the depth was learned from the stream")
+	assert_eq(
+		_player._timeline_updates, Gen2AudioPlayer.TARGET_FRAMES_MIN,
+		"one driver frame per queued frame and no more",
+	)
+	assert_almost_eq(
+		float(pending),
+		float(Gen2AudioPlayer.TARGET_FRAMES_MIN * Gen2Apu.SAMPLES_PER_FRAME),
+		float(Gen2Apu.SAMPLES_PER_FRAME),
+	)
+	assert_lt(pending, capacity, "the rest of the depth is left as headroom")
+
+	# A second service with nothing consumed adds nothing: the target is a level,
+	# not a rate.
+	_player._service_timeline()
+	assert_eq(_player._timeline_updates, Gen2AudioPlayer.TARGET_FRAMES_MIN)
+
+
+## A device that cannot hold the target says so by running the queue dry, and the
+## target rises for it rather than being chosen per platform by ear.
+func test_an_underrun_raises_the_target_instead_of_needing_a_build_per_target() -> void:
+	assert_true(_player.play_record(_record(99), &"map_music")["ok"])
+	_player._service_timeline()
+	var target: int = _player._target_frames
+	# An empty queue under a depth that is already known, which is what the audio
+	# server leaves behind when it consumed everything and asked for more.
+	_player._player.stop()
+	_player._player.play()
+	_player._playback = _player._player.get_stream_playback() as AudioStreamGeneratorPlayback
+	_player._service_timeline()
+	assert_eq(_player._target_frames, target + 1)
+	assert_eq(int(_player.audio_status()["underruns"]), 1)
+
+
+## An output that takes nothing while the driver has sound for it is a session
+## that went away, whatever `AudioStreamPlayer.playing` says. Every platform can
+## reach some version of it and only some announce one.
+func test_a_dead_output_is_rebuilt_rather_than_pushed_into_forever() -> void:
+	assert_true(_player.play_record(_record(99), &"map_music")["ok"])
+	_player._service_timeline()
+	var first: AudioStreamPlayer = _player._player
+	# The queue is at its target and nothing is consuming it, which is what a
+	# torn-down session looks like from here.
+	for _tick: int in 8:
+		_player._service_timeline(Gen2AudioPlayer.STALL_SECONDS * 0.25)
+	assert_eq(int(_player.audio_status()["output_restarts"]), 1)
+	assert_ne(_player._player, first, "the stream player is a new one")
+	assert_true(_player._player.playing)
+	assert_true(_player.audio_status()["music_active"], "the driver kept the piece")
+
+
+## A resume does not cut a live output: an alt-tab is a FOCUS_IN too. It shortens
+## the watchdog's window, so an output that is still there proves it at once.
+func test_a_resume_shortens_the_watchdog_rather_than_rebuilding_outright() -> void:
+	assert_true(_player.play_record(_record(99), &"map_music")["ok"])
+	_player._service_timeline()
+	_player._notification(Node.NOTIFICATION_APPLICATION_RESUMED)
+	assert_eq(int(_player.audio_status()["output_restarts"]), 0, "nothing was cut")
+	assert_almost_eq(
+		_player._starved_seconds,
+		Gen2AudioPlayer.STALL_SECONDS - Gen2AudioPlayer.RESUME_GRACE_SECONDS,
+		0.001,
+	)
+
+	# An output that is really gone is replaced a tenth of a second later.
+	_player._service_timeline(Gen2AudioPlayer.RESUME_GRACE_SECONDS)
+	assert_eq(int(_player.audio_status()["output_restarts"]), 1)
 
 
 func test_a_fade_walks_the_master_volume_down_and_then_stops() -> void:

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -68,7 +68,10 @@ func test_text_speed_is_a_per_character_frame_count() -> void:
 			0.001
 		)
 	options.text_speed = 2
-	assert_almost_eq(options.text_reveal_speed(), 12.0, 0.001, "slow is five frames")
+	assert_almost_eq(
+		options.text_reveal_speed(), 59.7275 / 5.0, 0.001,
+		"slow is five of the hardware's own VBlanks, not five sixtieths of a second",
+	)
 
 
 ## `.fast`: the branch taken when wTextboxFlags' FAST_TEXT_DELAY bit is clear
@@ -124,6 +127,22 @@ func test_every_cartridge_field_survives_a_byte_round_trip() -> void:
 	assert_false(restored.menu_account)
 	assert_eq(restored.textbox_frame, 6)
 	assert_false(restored.fast_text_delay)
+
+
+## Every row of GAME SPEED has a multiplier, and a damaged file's unlisted row
+## plays at the cartridge's own rate rather than stopping the game or racing it.
+func test_every_game_speed_has_a_multiplier_and_an_unknown_one_is_normal() -> void:
+	var options := Gen2Options.new()
+	assert_eq(Gen2Options.GAME_SPEED_SCALES.size(), Gen2Options.GAME_SPEEDS.size())
+	for index: int in Gen2Options.GAME_SPEEDS.size():
+		options.game_speed = Gen2Options.GAME_SPEEDS[index]
+		assert_almost_eq(
+			options.speed_scale(), Gen2Options.GAME_SPEED_SCALES[index], 0.001,
+			String(options.game_speed),
+		)
+	assert_almost_eq(Gen2Options.new().speed_scale(), 1.0, 0.001, "the default")
+	options.game_speed = &"warp"
+	assert_almost_eq(options.speed_scale(), 1.0, 0.001, "an unlisted row")
 
 
 func test_out_of_range_values_are_clamped_rather_than_refused() -> void:

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -100,7 +100,7 @@ func test_a_page_says_how_it_was_reached() -> void:
 	assert_eq(pages[2]["lines"], PackedStringArray(["b", "c"]))
 
 
-const FRAME: float = 1.0 / 60.0
+const FRAME: float = Gen2TextBox.FRAME_SECONDS
 
 
 func _box() -> Gen2TextBox:


### PR DESCRIPTION
Two owner-reported audio defects and the game-speed request, which turned out to be the same seam read from two ends.

## Game speed, with the sound left out of it

GAME SPEED governed nothing. Real seconds became hardware frames in fifteen hand-written accumulators; five spelled the frame rate themselves, and eleven had no catch-up cap, so a stall in the opening or on the town map ran the whole backlog.

They are one `Gen2WorldAnimation.FrameClock` now. The remainder is banked there, the cap is applied there, and the speed multiplies real time there and nowhere else.

That is what keeps the setting off the sound. The driver is filled from the audio output's own demand rather than from a game frame, so it cannot see a speed setting at all. Music, effects and cries keep the cartridge's tempo and pitch at half, normal and double; only how often the game asks for one changes.

## The audio session

Nothing handled a session being taken away. The driver kept running, the stream player kept reporting `playing`, and the fill went into a playback nothing consumed, so the music never came back until a screen change built another one.

`Gen2AudioPlayer` now rebuilds an output that has taken nothing from the driver for half a second while the driver had sound for it. That reads the queue rather than a platform's notification, so the targets that announce nothing (every desktop device change: headphones pulled, a default-output switch, a sleep and wake) are covered by the same code as the ones that do. `NOTIFICATION_APPLICATION_RESUMED` and `..._FOCUS_IN` shorten that window to a tenth of a second rather than cutting a live output, since an alt-tab is a FOCUS_IN too. A rebuild leaves the driver alone, so the piece carries on from where it stands.

## Output latency

The generator was kept as full as it would go, which spent its whole 125 ms depth as press-to-sound delay. It now fills to three driver frames, about 50 ms, and leaves the rest of the depth as headroom for a long frame. A device that cannot hold three says so by running the queue dry, and the target rises by one; so no build per target and no ear is needed to pick the number. `audio_status()` carries `target_frames`, `underruns` and `output_restarts`.

## Met on the way

- `video_mode` and `max_fps` were written to `options.json` and read by nothing. `Gen2GameRuntime.apply_display_options` is the applier, refused on anything but a player's own launch so a headless check is not capped at whatever frame rate the developer last chose.
- Three constants spelled the hardware VBlank and two more spelled 60 Hz. The two 60 Hz ones were a real 0.5% error in text speed: `Gen2WorldAnimation.FRAME_SECONDS` said it was the project's one definition and now is.

## Checked

| Run | Result |
|---|---|
| Unit tier | 3078 tests, green |
| Scene tier | 3554 tests over 160 scripts, green |
| `validate.gd -- all` | exit 0, 67 of 67 topics |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | exit 0, no errors |
| Boot smoke, with and without mods | exit 0 |

The per-target audio measurement is the owner's: the settled `target_frames` on each of macOS, Windows, Linux, Android and iOS, with the interruption to apply on each.