### PR TITLE
Give a bug report something to attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,22 @@ Either works:
 Say which cartridge, where you were and what you did. A screenshot settles most
 of it.
 
+The sheet behind that button also has **Save a report file**, which writes one
+`.zip` to your downloads folder and opens the folder on it. It holds the build,
+your machine, your settings, the mods you have installed and the last few
+session logs, and nothing else: no save data and no other file from your
+computer. **Copy the details** puts the same thing without the logs on the
+clipboard, which is the version that fits in a chat message. Attach the file if
+the game crashed or looked wrong; it is the difference between a report someone
+can act on and one nobody can reproduce.
+
+The launcher says so at the next launch when a session did not shut down
+cleanly. Logs live under `logs/` in the same directory as your saves:
+`%APPDATA%\Godot\app_userdata\pokerecomp` on Windows,
+`~/Library/Application Support/Godot/app_userdata/pokerecomp` on macOS,
+`~/.local/share/godot/app_userdata/pokerecomp` on Linux. Old ones are deleted as
+new ones arrive, so they never grow without bound.
+
 ## Contributing
 
 Read [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md). No cartridge-derived data may

--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -1,0 +1,532 @@
+class_name Gen2Diagnostics
+extends Node
+
+## What a player hands over when something goes wrong: one file holding this
+## build, this machine, the settings and mods in force, and the engine's own log
+## of the session that broke.
+##
+## It is a sink rather than a set of call sites. [Logger] is installed with
+## [method OS.add_logger], so every `print`, `push_warning`, `push_error`,
+## engine error and GDScript runtime error anywhere in the game, in a tool or in
+## a mod passes through here without that code knowing. Adding a message to a
+## screen therefore adds it to a bug report; nothing has to be routed twice.
+##
+## The file on disk is the engine's own, at [constant DIRECTORY]: the crash
+## handler writes its backtrace to stderr, which a script-side sink never sees
+## and the file logger does. What this class adds around it is the header the
+## file opens with, the pruning the engine does not do, and the bundle a player
+## can actually attach to an issue.
+
+## Where the engine's file logger writes, mirrored from `project.godot` so the
+## prune and the bundle read the directory the logs are actually in.
+const DIRECTORY: String = "user://logs"
+## Raised at boot and lowered on a clean exit, so the next launch can tell a
+## quit from a crash without parsing anything.
+const MARKER: String = "user://logs/session.json"
+
+## What the prune keeps. The engine's own rotation counts files and nothing
+## else, so a run that logged for a week is bounded here instead.
+const KEEP_FILES: int = 10
+const KEEP_DAYS: int = 30
+const KEEP_BYTES: int = 8 << 20
+
+## How much of the session the report itself quotes. The whole log is in the
+## bundle beside it; this is the part a reader sees without unzipping.
+const RECENT_LINES: int = 200
+## The longest single message kept in that tail, so one enormous dump cannot
+## push the rest of the session out of the report.
+const LINE_LIMIT: int = 1000
+
+const BUNDLE_PREFIX: String = "pokerecomp-report-"
+
+## The autoload, cached after the first lookup. Reached through this rather than
+## through the `Diagnostics` global for the reason
+## [method Gen2GameRuntime.instance] gives: a script handed to `-s` compiles
+## before the autoloads exist.
+static var _instance: Gen2Diagnostics = null
+
+var _sink: Gen2DiagnosticsSink = null
+## Guards the tail and the counters. A logger is called from whichever thread
+## raised the message, including the resource loader's.
+var _lock: Mutex = Mutex.new()
+var _tail: PackedStringArray = PackedStringArray()
+var _errors: int = 0
+var _warnings: int = 0
+var _started_unix: int = 0
+var _previous_unclean: bool = false
+## The scene last written to the log, so the breadcrumb is a change rather than
+## a line a frame.
+var _scene_path: String = ""
+
+
+static func instance() -> Gen2Diagnostics:
+	if _instance == null:
+		var loop: SceneTree = Engine.get_main_loop() as SceneTree
+		if loop != null:
+			_instance = loop.root.get_node_or_null(^"Diagnostics") as Gen2Diagnostics
+	return _instance
+
+
+## Records one line of context. Safe before the autoload exists and in a tool
+## run, so a caller never guards the call itself.
+##
+## Goes through `print`, which is what puts it in the engine's log file next to
+## the errors it explains; the sink below picks it up on the way past.
+static func note(topic: String, message: String) -> void:
+	print("[%s] %s" % [topic, message])
+
+
+## A breadcrumb rather than an event: the same line, kept out of a run that is
+## not a player's own. A corpus check or a story walk loads thousands of maps
+## and its output is read by a diff, so a trail written for a bug report would
+## drown it and would slow it down for no one's benefit.
+static func trace(topic: String, message: String) -> void:
+	if Gen2GameRuntime.is_player_launch():
+		note(topic, message)
+
+
+func _ready() -> void:
+	_started_unix = int(Time.get_unix_time_from_system())
+	prune()
+	_read_marker()
+	_install_sink()
+	# Deferred so the header names the mods that are running: this autoload is
+	# listed first, ahead of the one that loads them, because the sink has to be
+	# installed before anything else can raise a message it would miss.
+	_print_header.call_deferred()
+
+
+## Printed rather than written, so it is near the top of the engine's own log
+## file: a crash log is then self-describing whether or not the player ever
+## reaches the launcher again.
+##
+## A player's launch only, for the reason [method trace] gives: a check or a
+## tool is read for the answer it prints, and a header no one asked for is in
+## the way of it.
+func _print_header() -> void:
+	if Gen2GameRuntime.is_player_launch():
+		print(summary())
+
+
+func _exit_tree() -> void:
+	_clear_marker()
+	if _sink != null:
+		OS.remove_logger(_sink)
+		_sink = null
+
+
+## The breadcrumb every screen gets for free. `current_scene` has no signal of
+## its own, and one pointer comparison a frame is cheaper than a notification in
+## each of the screens that would otherwise have to report themselves.
+func _process(_delta: float) -> void:
+	var scene: Node = get_tree().current_scene
+	var path: String = scene.scene_file_path if scene != null else ""
+	if path == _scene_path:
+		return
+	_scene_path = path
+	if not path.is_empty():
+		trace("screen", path)
+
+
+## Whether the previous session ended without reaching [method _exit_tree]: a
+## crash, a kill, or a phone taking the process away. The launcher offers the
+## report on the strength of this.
+func previous_session_crashed() -> bool:
+	return _previous_unclean
+
+
+## Takes [param stored] as the previous session's marker. Public because the
+## notice it raises is otherwise reachable only by crashing the game, which no
+## test can do to itself.
+func adopt_marker(stored: String) -> void:
+	_previous_unclean = unclean_marker(stored)
+
+
+## Said once. The launcher is rebuilt whole on a palette change and replays what
+## it was saying, so a notice left standing would come back every time the
+## player switched appearance.
+func forget_previous_crash() -> void:
+	_previous_unclean = false
+
+
+func error_count() -> int:
+	return _errors
+
+
+func warning_count() -> int:
+	return _warnings
+
+
+## The last [constant RECENT_LINES] messages, oldest first.
+func tail() -> PackedStringArray:
+	_lock.lock()
+	var out: PackedStringArray = _tail.duplicate()
+	_lock.unlock()
+	return out
+
+
+## Everything but the log tail: the block a player can paste into a chat message
+## without it being a wall of text. [method report] is this plus the tail.
+func summary() -> String:
+	var lines: PackedStringArray = PackedStringArray()
+	lines.append("pokerecomp diagnostics")
+	lines.append("Generated  %s" % _stamp())
+	lines.append("Build      %s, Godot %s, %s" % [
+		Gen2AppVersion.display(),
+		Engine.get_version_info().get("string", "?"),
+		"debug" if OS.is_debug_build() else "release",
+	])
+	lines.append("Machine    %s %s, %s, %s" % [
+		OS.get_distribution_name(), OS.get_version(),
+		Engine.get_architecture_name(), OS.get_locale(),
+	])
+	lines.append("Video      %s, %s" % [
+		_setting("rendering/renderer/rendering_method", "?"),
+		_video_adapter(),
+	])
+	lines.append("Session    %s, %d error%s, %d warning%s%s" % [
+		_uptime(),
+		_errors, "" if _errors == 1 else "s",
+		_warnings, "" if _warnings == 1 else "s",
+		", the previous session ended unexpectedly" if _previous_unclean else "",
+	])
+	lines.append("")
+	lines.append_array(_cartridge_lines())
+	lines.append("")
+	lines.append_array(_mod_lines())
+	lines.append("")
+	lines.append_array(_settings_lines())
+	return "\n".join(lines)
+
+
+## The whole thing, header and log tail. What `report.txt` inside the bundle
+## holds, and what a player with no way to attach a file can still copy.
+func report() -> String:
+	var lines: PackedStringArray = PackedStringArray([summary(), "", "Recent log"])
+	var recent: PackedStringArray = tail()
+	if recent.is_empty():
+		lines.append("  nothing was logged this session")
+	for line: String in recent:
+		lines.append("  %s" % line)
+	return "\n".join(lines)
+
+
+## Writes the report and every kept log file into one `.zip` under
+## [param folder], and answers the path it wrote.
+##
+## A zip rather than the log itself because the useful thing is the whole set:
+## the session that crashed is usually the file *before* the one this launch is
+## writing. An empty [param folder] takes the platform's downloads directory,
+## and `user://` when there is none, which is what a phone answers.
+func write_bundle(folder: String = "") -> Dictionary:
+	var wanted: String = folder if not folder.is_empty() else _bundle_directory()
+	var fallback: String = ProjectSettings.globalize_path("user://")
+	# A downloads directory that exists is not a directory this process may
+	# write to: Android hands one back that needs a permission the game never
+	# asks for. The app's own directory always answers, so a refusal there is a
+	# real failure and a refusal above it is not.
+	var written: Dictionary = _pack_bundle(wanted)
+	if not bool(written["ok"]) and wanted != fallback:
+		written = _pack_bundle(fallback)
+	return written
+
+
+func _pack_bundle(directory: String) -> Dictionary:
+	# The parent is tested before the directory is created rather than letting
+	# the create fail: [method DirAccess.make_dir_absolute] raises an engine
+	# error on its way to returning one, and this refusal is an ordinary answer
+	# that the fallback above deals with. It would otherwise be the loudest line
+	# in the log of a player who reported nothing.
+	if not DirAccess.dir_exists_absolute(directory):
+		if not DirAccess.dir_exists_absolute(directory.get_base_dir()):
+			return {"ok": false, "message": "That folder could not be opened.", "path": ""}
+		if DirAccess.make_dir_absolute(directory) != OK:
+			return {"ok": false, "message": "That folder could not be opened.", "path": ""}
+	var path: String = "%s/%s%s.zip" % [directory, BUNDLE_PREFIX, _file_stamp()]
+	var packer := ZIPPacker.new()
+	if packer.open(path) != OK:
+		return {"ok": false, "message": "The report file could not be created.", "path": ""}
+	var written: int = 0
+	if _pack(packer, "report.txt", report().to_utf8_buffer()):
+		written += 1
+	for name: String in log_files():
+		var bytes: PackedByteArray = FileAccess.get_file_as_bytes("%s/%s" % [DIRECTORY, name])
+		if not bytes.is_empty() and _pack(packer, "logs/%s" % name, bytes):
+			written += 1
+	packer.close()
+	return {"ok": true, "message": "", "path": path, "files": written}
+
+
+## The kept log files, newest first, named relative to [param directory]. An
+## absolute path carries the player's own account name and this list is read
+## out into a file they are about to publish.
+##
+## The engine's live file sorts first whatever its timestamp says, and the
+## rotated ones fall back to their names. [method FileAccess.get_modified_time]
+## has one-second resolution and a rotation writes several files inside one
+## second, so mtime alone leaves the order arbitrary: the prune below would then
+## sometimes take the session it is being run to preserve. A rotated name is the
+## live one with an ISO stamp inserted, so name-descending IS newest-first.
+func log_files(directory: String = DIRECTORY) -> PackedStringArray:
+	var live: String = String(
+		ProjectSettings.get_setting("debug/file_logging/log_path", "")
+	).get_file()
+	var found: Array[String] = []
+	for name: String in DirAccess.get_files_at(directory):
+		if name.get_extension().to_lower() == "log":
+			found.append(name)
+	found.sort_custom(func(a: String, b: String) -> bool:
+		if (a == live) != (b == live):
+			return a == live
+		var left: int = FileAccess.get_modified_time("%s/%s" % [directory, a])
+		var right: int = FileAccess.get_modified_time("%s/%s" % [directory, b])
+		return a > b if left == right else left > right
+	)
+	return PackedStringArray(found)
+
+
+## Drops log files in [param directory] past the count, the age or the total
+## size this keeps, whichever bites first, oldest first.
+##
+## The engine's own rotation counts files at startup and nothing else, so a
+## single session that logged for a week, or a build that once wrote under
+## another name, would otherwise sit in the player's data directory for good.
+## Returns how many files it removed.
+func prune(directory: String = DIRECTORY) -> int:
+	if not DirAccess.dir_exists_absolute(directory):
+		return 0
+	var names: PackedStringArray = log_files(directory)
+	var oldest_kept: int = int(Time.get_unix_time_from_system()) - KEEP_DAYS * 86400
+	var budget: int = KEEP_BYTES
+	var removed: int = 0
+	for index: int in names.size():
+		var path: String = "%s/%s" % [directory, names[index]]
+		var size: int = _file_size(path)
+		budget -= size
+		var stale: bool = (
+			index >= KEEP_FILES
+			or budget < 0
+			or FileAccess.get_modified_time(path) < oldest_kept
+		)
+		# The newest file is the one being written right now, so it is kept
+		# whatever it costs: removing it would silently take the session the
+		# player is about to report with it.
+		if stale and index > 0 and DirAccess.remove_absolute(path) == OK:
+			removed += 1
+	return removed
+
+
+## Installs the sink. Kept as a field because [Logger] is a [RefCounted] and the
+## engine's list does not own it.
+func _install_sink() -> void:
+	_sink = Gen2DiagnosticsSink.new()
+	_sink.host = self
+	OS.add_logger(_sink)
+
+
+## Appends to the tail, from whichever thread raised the message.
+func record(level: String, message: String) -> void:
+	_lock.lock()
+	match level:
+		"error":
+			_errors += 1
+		"warning":
+			_warnings += 1
+	_tail.append("%s %-7s %s" % [
+		Time.get_time_string_from_system(), level, message.left(LINE_LIMIT)
+	])
+	while _tail.size() > RECENT_LINES:
+		_tail.remove_at(0)
+	_lock.unlock()
+
+
+## Reads the previous session's marker and raises this one's.
+##
+## Only a player's own launch writes it. A headless check or a `-s` tool that
+## the wall-clock cap kills never reaches [method _exit_tree], so letting those
+## write the marker would report a crash to the player at the next launch, and
+## letting them clear it would hide a real one.
+func _read_marker() -> void:
+	adopt_marker(FileAccess.get_file_as_string(MARKER))
+	if not Gen2GameRuntime.is_player_launch():
+		return
+	DirAccess.make_dir_recursive_absolute(DIRECTORY)
+	_write_marker(false)
+
+
+## Whether [param stored] is a marker left raised. A missing or unreadable one
+## answers false: an absent file is a first launch, and a half-written one is
+## not evidence of a crash worth telling the player about.
+static func unclean_marker(stored: String) -> bool:
+	if stored.is_empty():
+		return false
+	# Parsed through an instance rather than [method JSON.parse_string], which
+	# raises an engine error of its own: a torn marker is an ordinary answer
+	# here, not something to report in the log this class keeps.
+	var reader := JSON.new()
+	if reader.parse(stored) != OK:
+		return false
+	var raw: Variant = reader.data
+	return raw is Dictionary and not bool((raw as Dictionary).get("clean", true))
+
+
+func _clear_marker() -> void:
+	if Gen2GameRuntime.is_player_launch():
+		_write_marker(true)
+
+
+func _write_marker(clean: bool) -> void:
+	var file: FileAccess = FileAccess.open(MARKER, FileAccess.WRITE)
+	if file == null:
+		return
+	file.store_string(JSON.stringify({
+		"clean": clean, "version": Gen2AppVersion.VERSION, "started": _started_unix,
+	}))
+
+
+## Cache state per cartridge, and no save counts: a slot count would load every
+## save file to answer, which is real work at boot for a line a bug report
+## almost never turns on.
+func _cartridge_lines() -> PackedStringArray:
+	var lines: PackedStringArray = PackedStringArray(["Cartridges"])
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	var selected: StringName = runtime.selected_game_id if runtime != null else &""
+	for game_id: StringName in RomRegistry.ORDER:
+		var sha1: String = RomRegistry.sha1_for(game_id)
+		lines.append("  %-8s %-11s%s" % [
+			RomRegistry.title_for(game_id),
+			RomCache.state(RomCache.directory_for(game_id, sha1)),
+			"  (selected)" if game_id == selected else "",
+		])
+	return lines
+
+
+func _mod_lines() -> PackedStringArray:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var running: Array = host.loaded_mods()
+	var manifests: Array = host.manifests()
+	var lines: PackedStringArray = PackedStringArray(["Mods  %d installed, %d running" % [
+		manifests.size(), running.size(),
+	]])
+	for manifest: Gen2ModManifest in manifests:
+		lines.append("  %-24s %-10s api %-3d %s" % [
+			manifest.id, manifest.version, manifest.api_version,
+			"running" if running.has(manifest.id)
+			else ("on" if Gen2ModState.is_enabled(manifest.id) else "off"),
+		])
+	for failure: Dictionary in host.failures():
+		lines.append("  refused %s: %s (%s)" % [
+			failure.get("directory", failure.get("id", "?")),
+			failure.get("reason", "unknown"), failure.get("detail", ""),
+		])
+	return lines
+
+
+func _settings_lines() -> PackedStringArray:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var lines: PackedStringArray = PackedStringArray(["Settings"])
+	lines.append("  display    %s, %d fps, zoom %d, %s, %s" % [
+		options.video_mode, options.max_fps, options.zoom_step,
+		"screen fill" if options.screen_fill else "framed", options.ui_theme,
+	])
+	lines.append("  play       speed %s, text %d, %s, touch %s" % [
+		options.game_speed, options.text_speed,
+		"stereo" if options.stereo else "mono", options.touch_mode,
+	])
+	lines.append("  volume     music %d, effects %d" % [
+		options.music_volume, options.sfx_volume,
+	])
+	var rules: Gen2Rules = Gen2Rules.active()
+	var changed: PackedStringArray = PackedStringArray()
+	for flag: StringName in Gen2Rules.FLAGS:
+		if rules.reproduces(flag) != bool(Gen2Rules.FLAGS[flag]):
+			changed.append(String(flag))
+	lines.append("  rules      %s%s" % [
+		rules.mode_of(),
+		"" if changed.is_empty() else ", changed: %s" % ", ".join(changed),
+	])
+	return lines
+
+
+## The platform's downloads directory when it has one the player can reach, and
+## the app's own data directory otherwise, which is what a phone answers.
+func _bundle_directory() -> String:
+	var downloads: String = OS.get_system_dir(OS.SYSTEM_DIR_DOWNLOADS)
+	if not downloads.is_empty() and DirAccess.dir_exists_absolute(downloads):
+		return downloads
+	return ProjectSettings.globalize_path("user://")
+
+
+func _pack(packer: ZIPPacker, name: String, bytes: PackedByteArray) -> bool:
+	if packer.start_file(name) != OK:
+		return false
+	var ok: bool = packer.write_file(bytes) == OK
+	packer.close_file()
+	return ok
+
+
+func _uptime() -> String:
+	var seconds: int = maxi(int(Time.get_unix_time_from_system()) - _started_unix, 0)
+	return "up %dh %02dm" % [seconds / 3600, (seconds / 60) % 60]
+
+
+## Local time with the offset spelled out, because a report is read by someone
+## in another one and a bare local stamp cannot be lined up with anything.
+func _stamp() -> String:
+	var offset: int = int(Time.get_time_zone_from_system().get("bias", 0))
+	return "%s UTC%s%02d:%02d" % [
+		Time.get_datetime_string_from_system(false, true),
+		"-" if offset < 0 else "+", absi(offset) / 60, absi(offset) % 60,
+	]
+
+
+static func _file_stamp() -> String:
+	return Time.get_datetime_string_from_system().replace(":", "-")
+
+
+static func _file_size(path: String) -> int:
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	return 0 if file == null else int(file.get_length())
+
+
+static func _setting(key: String, fallback: String) -> String:
+	return String(ProjectSettings.get_setting(key, fallback))
+
+
+## Empty on a headless run, and on a machine whose driver never answered.
+static func _video_adapter() -> String:
+	var adapter: String = RenderingServer.get_video_adapter_name()
+	return adapter if not adapter.is_empty() else "no adapter"
+
+
+## The sink itself, kept beside the autoload rather than in a file of its own:
+## it is four lines and it has no other caller.
+##
+## Nothing here prints. A logger that raised a message of its own would be
+## handed it straight back.
+class Gen2DiagnosticsSink extends Logger:
+	var host: Gen2Diagnostics = null
+
+	func _log_message(message: String, error: bool) -> void:
+		if host != null and not error:
+			host.record("print", message.strip_edges())
+
+	func _log_error(
+		function: String,
+		file: String,
+		line: int,
+		code: String,
+		rationale: String,
+		_editor_notify: bool,
+		error_type: int,
+		script_backtraces: Array[ScriptBacktrace],
+	) -> void:
+		if host == null:
+			return
+		var level: String = "warning" if error_type == Logger.ERROR_TYPE_WARNING else "error"
+		var said: String = rationale if not rationale.is_empty() else code
+		var text: String = "%s  at %s (%s:%d)" % [said, function, file, line]
+		for backtrace: ScriptBacktrace in script_backtraces:
+			if not backtrace.is_empty():
+				text += "\n    %s" % backtrace.format(4).strip_edges()
+		host.record(level, text)

--- a/autoload/diagnostics.gd.uid
+++ b/autoload/diagnostics.gd.uid
@@ -1,0 +1,1 @@
+uid://c437q5dj6p5en

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -32,6 +32,7 @@ tools still read it with `FileAccess`. Do not delete it.
 | `game/render/` | Tile-grid pages; a `*_page.gd` draws, its model decides |
 | `game/mods/` | Manifest validation and the registry. See [MODS.md](MODS.md) |
 | `audio/` | The cartridge's own driver over an emulated APU |
+| `autoload/diagnostics.gd` | The log sink, the crash marker and the report bundle |
 
 Four boundaries are load-bearing and not obvious from one file:
 
@@ -43,6 +44,14 @@ Four boundaries are load-bearing and not obvious from one file:
   never read scripts, text or audio.
 - **Never match a keycode in a screen; match a `Gen2Button`.** An embedded host
   takes `handle_button(button)`, so a test presses a button, not a key.
+- **Anything printed is already in the bug report.** `Gen2Diagnostics` installs
+  a [Logger] with `OS.add_logger`, so every `print`, `push_warning`,
+  `push_error` and runtime error, in the game, a tool or a mod, reaches the
+  session log and the report a player attaches to an issue. Never add a second
+  reporting path beside a message; add the message. `Gen2Diagnostics.note()` is
+  the same print with a topic on it, for a fact a reader of the log needs, and
+  `trace()` is the one for a breadcrumb, which is kept out of a check or a tool
+  run so its output stays readable.
 - **Reach an autoload by its static accessor**, `Gen2InputRuntime.instance()` or
   `Gen2GameRuntime.instance()`, never the `InputRuntime`/`GameRuntime` global. A
   script handed to `-s` compiles before the tree exists, so naming one by

--- a/game/launcher/about_page.gd
+++ b/game/launcher/about_page.gd
@@ -13,6 +13,8 @@ signal update_check_requested
 
 var _theme: Gen2LauncherTheme = null
 var _result: Label = null
+## The report sheet's own answer line, rebuilt with the sheet.
+var _report_result: Label = null
 ## What a sheet opens over. The page itself is swapped out with the dock, so a
 ## sheet parented to it would vanish with the page behind it.
 var _host: Control = null
@@ -134,7 +136,71 @@ func open_report_sheet() -> void:
 	body.add_child(Gen2LauncherUI.muted(
 		_theme, "For everyone else. Ask in the chat and someone will write it up."
 	))
+
+	body.add_child(Gen2LauncherUI.caption(_theme, "Attach the details"))
+	body.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"A report file holds this build, your machine, your settings, the mods "
+		+ "you have installed and the last few session logs. No save data and "
+		+ "nothing else from your computer.",
+	))
+	var actions: HFlowContainer = Gen2LauncherUI.actions()
+	body.add_child(actions)
+	var save: Gen2LauncherButton = Gen2LauncherButton.create(
+		_theme, "Save a report file", Gen2LauncherButton.Variant.NEUTRAL, &"save"
+	)
+	save.pressed.connect(_save_report_file)
+	actions.add_child(save)
+	var copy: Gen2LauncherButton = Gen2LauncherButton.create(
+		_theme, "Copy the details", Gen2LauncherButton.Variant.NEUTRAL
+	)
+	copy.pressed.connect(_copy_report_summary)
+	actions.add_child(copy)
+	_report_result = Gen2LauncherUI.muted(_theme, "")
+	body.add_child(_report_result)
+	sheet.closed.connect(func() -> void: _report_result = null)
 	sheet.open(_host if _host != null else self)
+
+
+## Writes the bundle and shows the player where it went.
+##
+## The file manager is opened rather than the file: a zip handed to the desktop
+## would be unpacked or opened by whatever is registered for it, and what the
+## player needs is the file itself, selected, ready to drag into an issue or a
+## chat. A platform with no file manager answers nothing and the path in the
+## line below is what the player goes by.
+func _save_report_file() -> void:
+	var diagnostics: Gen2Diagnostics = Gen2Diagnostics.instance()
+	if diagnostics == null:
+		_set_report_result("Diagnostics are not running in this build.", _theme.error)
+		return
+	var written: Dictionary = diagnostics.write_bundle()
+	if not bool(written["ok"]):
+		_set_report_result(String(written["message"]), _theme.error)
+		return
+	var path: String = String(written["path"])
+	# The whole path, not the filename: a phone opens no file manager, so the
+	# line below is the only thing that says where the file went.
+	_set_report_result("Saved %s" % path, _theme.success)
+	OS.shell_show_in_file_manager(path, true)
+
+
+## The header without the log tail, which is what fits in a chat message. The
+## file above is the whole thing.
+func _copy_report_summary() -> void:
+	var diagnostics: Gen2Diagnostics = Gen2Diagnostics.instance()
+	if diagnostics == null:
+		_set_report_result("Diagnostics are not running in this build.", _theme.error)
+		return
+	DisplayServer.clipboard_set(diagnostics.summary())
+	_set_report_result("Copied. Paste it with your report.", _theme.success)
+
+
+func _set_report_result(message: String, colour: Color) -> void:
+	if _report_result == null or not is_instance_valid(_report_result):
+		return
+	_report_result.text = message
+	_report_result.add_theme_color_override("font_color", colour)
 
 
 ## A button that hands [param url] to the desktop's browser. [param sheet] is

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -25,7 +25,7 @@ var _selected_game_id: StringName = &""
 ## The game a re-import is replacing, so a cache is only overwritten by a dump
 ## of the cartridge it already holds.
 var _reimport_game_id: StringName = &""
-var _status: Dictionary = {"title": "", "detail": ""}
+var _status: Dictionary = {"kind": &"info", "title": "", "detail": ""}
 
 
 func _ready() -> void:
@@ -33,6 +33,7 @@ func _ready() -> void:
 	_build()
 	_print_allowlist()
 	_refresh_games()
+	_report_previous_crash()
 
 
 ## Rebuilt whole when the appearance changes, which is the only way a launcher
@@ -73,10 +74,13 @@ func _build() -> void:
 	_shell.page_selected.connect(_on_page_selected)
 	_build_dialogs()
 	_on_page_selected(_shell.current_page())
-	# A message survives a palette rebuild; a launcher with nothing to report
-	# shows nothing at all.
+	# A message survives a palette rebuild, in the kind it was raised as: an
+	# error replayed as information takes the warning glyph off it and gives it
+	# a dismissal timer the toast deliberately withholds from a failure.
 	if not String(_status["title"]).is_empty():
-		_set_status(&"info", String(_status["title"]), String(_status["detail"]))
+		_set_status(
+			StringName(_status["kind"]), String(_status["title"]), String(_status["detail"])
+		)
 
 
 func _build_dialogs() -> void:
@@ -378,6 +382,7 @@ func launcher_snapshot() -> Dictionary:
 		}
 	return {
 		"status": String(_status["title"]),
+		"kind": String(_status["kind"]),
 		"detail": String(_status["detail"]),
 		"importing": _importing,
 		"page": String(_shell.current_page()) if _shell != null else "",
@@ -572,9 +577,24 @@ func _finish_import(success: bool, message: String) -> void:
 
 
 func _set_status(kind: StringName, title: String, detail: String) -> void:
-	_status = {"title": title, "detail": detail}
+	_status = {"kind": kind, "title": title, "detail": detail}
 	if _shell != null:
 		_shell.toast().show_message(kind, title, detail)
+
+
+## Says so when the last session did not shut down, and says where the report
+## file is. The launcher is the one screen a player is certain to see after a
+## crash, so this is where the offer belongs; nothing is written or sent here.
+func _report_previous_crash() -> void:
+	var diagnostics: Gen2Diagnostics = Gen2Diagnostics.instance()
+	if diagnostics == null or not diagnostics.previous_session_crashed():
+		return
+	diagnostics.forget_previous_crash()
+	_set_status(
+		&"error",
+		"The last session ended unexpectedly.",
+		"About > Report a bug will save a file with the logs in it.",
+	)
 
 
 func _print_allowlist() -> void:

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -437,5 +437,9 @@ static func _valid_slot(slot: int) -> bool:
 	return slot >= 0 and slot < MAX_SLOTS
 
 
+## Every refusal in this file goes through here, which is why the diagnostics
+## note sits here rather than at each `return`: a save that would not write is
+## the one thing a bug report cannot reconstruct afterwards.
 static func _failure(message: String) -> Dictionary:
+	Gen2Diagnostics.note("save", "refused: %s" % message)
 	return {"ok": false, "message": message}

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5568,6 +5568,11 @@ func _apply_map(
 	custom_facing: bool = false,
 	from_warp: int = 0,
 ) -> void:
+	# The one breadcrumb a bug report cannot do without: every warp, connection
+	# and load reaches this, so a log always says which map the player was on.
+	Gen2Diagnostics.trace("map", "group %d map %d, tileset %d, cell %s" % [
+		target_map.group, target_map.number, target_map.tileset, target_cell,
+	])
 	_record_escape_points(target_map, from_warp)
 	## `RefreshPlayerSprite` clears `wPlayerTurningDirection`, and every warp and
 	## connection reaches it, so a slide never survives a map change.

--- a/project.godot
+++ b/project.godot
@@ -18,12 +18,14 @@ config/icon="res://app_icon.png"
 
 [autoload]
 
+Diagnostics="*res://autoload/diagnostics.gd"
 GameRuntime="*res://autoload/game_runtime.gd"
 InputRuntime="*res://autoload/input_runtime.gd"
 
 [debug]
 
 file_logging/enable_file_logging=true
+file_logging/max_log_files=10
 gdscript/warnings/integer_division=0
 
 [display]

--- a/tests/unit/test_diagnostics.gd
+++ b/tests/unit/test_diagnostics.gd
@@ -1,0 +1,200 @@
+extends GutTest
+
+## The log sink, the report and the prune. Nothing here writes into the real
+## log directory: the prune is driven over a scratch directory of its own, and
+## the bundle is written where the test can delete it.
+
+const SCRATCH: String = "user://diagnostics-test-bundle"
+
+
+func _diagnostics() -> Gen2Diagnostics:
+	var log_node: Gen2Diagnostics = Gen2Diagnostics.instance()
+	assert_not_null(log_node, "the Diagnostics autoload is registered")
+	return log_node
+
+
+func after_each() -> void:
+	if DirAccess.dir_exists_absolute(SCRATCH):
+		for name: String in DirAccess.get_files_at(SCRATCH):
+			DirAccess.remove_absolute("%s/%s" % [SCRATCH, name])
+		DirAccess.remove_absolute(SCRATCH)
+
+
+func test_the_engine_writes_a_log_file_this_can_read() -> void:
+	# The sink is a mirror; the file the bundle carries is the engine's own, so
+	# a build that turned file logging off would ship a report with no logs in
+	# it and nothing else would say so.
+	assert_true(
+		bool(ProjectSettings.get_setting("debug/file_logging/enable_file_logging", false)),
+		"file logging is on",
+	)
+	assert_eq(
+		String(ProjectSettings.get_setting("debug/file_logging/log_path", "")).get_base_dir(),
+		Gen2Diagnostics.DIRECTORY,
+	)
+
+
+func test_a_print_reaches_the_tail() -> void:
+	var log_node: Gen2Diagnostics = _diagnostics()
+	Gen2Diagnostics.note("test", "a line nothing else writes")
+	var tail: PackedStringArray = log_node.tail()
+	assert_gt(tail.size(), 0)
+	assert_string_contains(tail[tail.size() - 1], "[test] a line nothing else writes")
+
+
+func test_a_pushed_warning_is_counted_and_kept() -> void:
+	var log_node: Gen2Diagnostics = _diagnostics()
+	var warnings: int = log_node.warning_count()
+	var errors: int = log_node.error_count()
+	push_warning("diagnostics test warning")
+	assert_eq(log_node.warning_count(), warnings + 1)
+	assert_eq(log_node.error_count(), errors, "and a warning is not counted as one")
+	var tail: PackedStringArray = log_node.tail()
+	assert_string_contains(tail[tail.size() - 1], "diagnostics test warning")
+	assert_string_contains(tail[tail.size() - 1], "warning")
+
+
+func test_the_tail_is_bounded() -> void:
+	var log_node: Gen2Diagnostics = _diagnostics()
+	for index: int in Gen2Diagnostics.RECENT_LINES + 20:
+		Gen2Diagnostics.note("test", "line %d" % index)
+	assert_eq(log_node.tail().size(), Gen2Diagnostics.RECENT_LINES)
+
+
+func test_one_enormous_message_cannot_fill_the_report() -> void:
+	var log_node: Gen2Diagnostics = _diagnostics()
+	Gen2Diagnostics.note("test", "x".repeat(Gen2Diagnostics.LINE_LIMIT * 4))
+	var tail: PackedStringArray = log_node.tail()
+	assert_lt(tail[tail.size() - 1].length(), Gen2Diagnostics.LINE_LIMIT + 64)
+
+
+func test_the_summary_names_the_build_the_machine_and_every_mod() -> void:
+	var summary: String = _diagnostics().summary()
+	assert_string_contains(summary, Gen2AppVersion.VERSION)
+	assert_string_contains(summary, OS.get_distribution_name())
+	assert_string_contains(summary, "Cartridges")
+	assert_string_contains(summary, "Settings")
+	for game_id: StringName in RomRegistry.ORDER:
+		assert_string_contains(summary, RomRegistry.title_for(game_id))
+	for manifest: Gen2ModManifest in Gen2ModHost.instance().manifests():
+		assert_string_contains(summary, String(manifest.id))
+
+
+## What the player pastes into a chat is the summary, so it must not carry the
+## home directory their account is named after.
+func test_the_summary_carries_no_absolute_path() -> void:
+	var home: String = ProjectSettings.globalize_path("user://")
+	assert_false(_diagnostics().summary().contains(home))
+
+
+func test_the_report_quotes_the_log_tail() -> void:
+	Gen2Diagnostics.note("test", "a line the report should quote")
+	var report: String = _diagnostics().report()
+	assert_string_contains(report, "Recent log")
+	assert_string_contains(report, "a line the report should quote")
+
+
+func test_the_bundle_holds_the_report_and_the_log_files() -> void:
+	var expected: int = _diagnostics().log_files().size()
+	var written: Dictionary = _diagnostics().write_bundle(
+		ProjectSettings.globalize_path(SCRATCH)
+	)
+	assert_true(bool(written["ok"]), String(written["message"]))
+	var path: String = String(written["path"])
+	assert_true(FileAccess.file_exists(path))
+
+	var reader := ZIPReader.new()
+	assert_eq(reader.open(path), OK)
+	var names: PackedStringArray = reader.get_files()
+	assert_true(names.has("report.txt"))
+	assert_string_contains(reader.read_file("report.txt").get_string_from_utf8(), "pokerecomp")
+	var logs: int = 0
+	for name: String in names:
+		# The reader lists the folder itself as an entry too.
+		if name.begins_with("logs/") and not name.ends_with("/"):
+			logs += 1
+	assert_eq(logs, expected, "every kept log file is packed")
+	reader.close()
+
+
+## A downloads directory a phone hands back is not always one the game may
+## write to. Refusing there is not a failure the player should be shown.
+func test_a_folder_that_refuses_falls_back_to_the_app_directory() -> void:
+	# A directory under a file, which no platform will create.
+	var refused: String = "%s/inside-a-file" % ProjectSettings.globalize_path(
+		Gen2OptionsStore.path()
+	)
+	var written: Dictionary = _diagnostics().write_bundle(refused)
+	assert_true(bool(written["ok"]), String(written["message"]))
+	var path: String = String(written["path"])
+	assert_true(path.begins_with(ProjectSettings.globalize_path("user://")))
+	assert_true(FileAccess.file_exists(path))
+	DirAccess.remove_absolute(path)
+
+
+func test_the_prune_keeps_the_newest_files_and_drops_the_rest() -> void:
+	DirAccess.make_dir_recursive_absolute(SCRATCH)
+	var wanted: int = Gen2Diagnostics.KEEP_FILES + 6
+	for index: int in wanted:
+		var file: FileAccess = FileAccess.open(
+			"%s/godot%03d.log" % [SCRATCH, index], FileAccess.WRITE
+		)
+		file.store_string("line %d" % index)
+		file = null
+	# A file the prune must not touch, because a bundle only carries `.log`.
+	var marker: FileAccess = FileAccess.open("%s/keep.json" % SCRATCH, FileAccess.WRITE)
+	marker.store_string("{}")
+	marker = null
+
+	var removed: int = _diagnostics().prune(SCRATCH)
+	assert_eq(removed, wanted - Gen2Diagnostics.KEEP_FILES)
+	assert_eq(_diagnostics().log_files(SCRATCH).size(), Gen2Diagnostics.KEEP_FILES)
+	assert_true(FileAccess.file_exists("%s/keep.json" % SCRATCH))
+
+
+func test_the_prune_never_takes_the_file_being_written() -> void:
+	DirAccess.make_dir_recursive_absolute(SCRATCH)
+	var live: String = String(
+		ProjectSettings.get_setting("debug/file_logging/log_path", "")
+	).get_file()
+	var file: FileAccess = FileAccess.open("%s/%s" % [SCRATCH, live], FileAccess.WRITE)
+	# One file over every budget at once. It is still the newest, so it stays:
+	# taking it would drop the very session the player is about to report.
+	file.store_string("x".repeat(Gen2Diagnostics.KEEP_BYTES + 1))
+	file = null
+	assert_eq(_diagnostics().prune(SCRATCH), 0)
+	assert_eq(_diagnostics().log_files(SCRATCH).size(), 1)
+
+
+## The rotation writes several files inside one second, so the order has to
+## come from somewhere other than the modification time. A run that got this
+## wrong deleted whichever file the sort happened to put last, the live one
+## included.
+func test_files_written_in_the_same_second_still_order_newest_first() -> void:
+	DirAccess.make_dir_recursive_absolute(SCRATCH)
+	var live: String = String(
+		ProjectSettings.get_setting("debug/file_logging/log_path", "")
+	).get_file()
+	var stem: String = live.get_basename()
+	for name: String in [
+		"%s2026-08-01T00.00.03.log" % stem,
+		"%s2026-08-01T00.00.01.log" % stem,
+		live,
+		"%s2026-08-01T00.00.02.log" % stem,
+	]:
+		var file: FileAccess = FileAccess.open("%s/%s" % [SCRATCH, name], FileAccess.WRITE)
+		file.store_string("x")
+		file = null
+	var order: PackedStringArray = _diagnostics().log_files(SCRATCH)
+	assert_eq(order[0], live)
+	assert_string_contains(order[1], "00.00.03")
+	assert_string_contains(order[3], "00.00.01")
+
+
+## The marker is what tells a crash from a quit. A player never sees it, so it
+## is checked here rather than through the launcher's notice.
+func test_the_marker_reads_a_crash_and_nothing_else() -> void:
+	assert_true(Gen2Diagnostics.unclean_marker('{"clean": false}'))
+	assert_false(Gen2Diagnostics.unclean_marker('{"clean": true}'))
+	assert_false(Gen2Diagnostics.unclean_marker(""), "a first launch is not a crash")
+	assert_false(Gen2Diagnostics.unclean_marker("{ half writ"), "nor is a torn file")

--- a/tests/unit/test_diagnostics.gd.uid
+++ b/tests/unit/test_diagnostics.gd.uid
@@ -1,0 +1,1 @@
+uid://dxxo2q18q33o2

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -41,6 +41,12 @@ func _mods_page() -> Gen2ModsPage:
 
 
 func _open_launcher() -> void:
+	# The machine running the tests may itself have crashed last, and the notice
+	# that raises is a toast every other launcher test would then have to
+	# tolerate. Each test says for itself what the previous session did.
+	var diagnostics: Gen2Diagnostics = Gen2Diagnostics.instance()
+	if diagnostics != null:
+		diagnostics.adopt_marker("")
 	var packed: PackedScene = load("res://game/main/main.tscn")
 	_launcher = packed.instantiate()
 	add_child(_launcher)
@@ -512,3 +518,40 @@ func test_a_mod_with_no_renderer_has_no_view_switch() -> void:
 	detail.set_row(page._row_for(PROBE_MOD_ID))
 	assert_null(detail.find_child(String(Gen2ModDetailPage.VIEW_SWITCH_NAME), true, false))
 	Gen2ModHost.reset()
+
+
+## A palette change rebuilds the launcher whole and replays whatever it was
+## saying. Replayed as information, a failure lost its warning glyph and picked
+## up the dismissal timer the toast withholds from an error on purpose.
+func test_a_failure_survives_a_rebuild_as_a_failure() -> void:
+	await _open_launcher()
+	_launcher.import_mod_path("user://no-such-mod.zip")
+	assert_eq(_launcher.launcher_snapshot()["kind"], "error")
+
+	_launcher.preview_theme(&"dark")
+	await get_tree().process_frame
+	var snapshot: Dictionary = _launcher.launcher_snapshot()
+	assert_eq(snapshot["kind"], "error")
+	assert_eq(snapshot["status"], "That mod was not installed.")
+
+
+## A crash the player never saw a message about is a crash they cannot report.
+func test_a_crashed_session_is_reported_at_the_next_launch() -> void:
+	await _open_launcher()
+	Gen2Diagnostics.instance().adopt_marker('{"clean": false}')
+	await _open_launcher_keeping_the_marker()
+	var snapshot: Dictionary = _launcher.launcher_snapshot()
+	assert_eq(snapshot["kind"], "error")
+	assert_string_contains(String(snapshot["status"]), "ended unexpectedly")
+	assert_false(
+		Gen2Diagnostics.instance().previous_session_crashed(),
+		"and it is said once, not again on every rebuild",
+	)
+
+
+func _open_launcher_keeping_the_marker() -> void:
+	if is_instance_valid(_launcher):
+		_launcher.free()
+	_launcher = (load("res://game/main/main.tscn") as PackedScene).instantiate()
+	add_child(_launcher)
+	await get_tree().process_frame


### PR DESCRIPTION
## What this is for

A player who hits a bug has had two links in the launcher and nothing to put in them. Now the report sheet writes a file they can drag into an issue or a chat.

## What a player sees

About > Report a bug gains two buttons.

- **Save a report file** writes one `.zip` to the downloads folder and opens the folder on it. It holds the build, the machine, the settings, every installed mod and whether it is running, and the last few session logs. No save data, nothing else from the computer.
- **Copy the details** puts the same report without the log tail on the clipboard. That is the version that fits in a chat message.

If a session did not shut down cleanly, the launcher says so at the next launch and points at that sheet.

## How it works

The log is a sink, not a set of call sites. `Gen2Diagnostics` is an autoload listed ahead of the other two, and it installs a `Logger` with `OS.add_logger` before anything else can raise a message. Every `print`, `push_warning`, `push_error`, engine error and GDScript runtime error, in the game, in a tool or in a mod, is already in the report. Adding a message somewhere adds it to a bug report. There is no second path to keep in step.

The file on disk stays the engine's own, under `user://logs`. The crash handler writes its backtrace to stderr, which a script-side sink never sees and the file logger does.

What is added around it:

- The header the log opens with, so a crash log is self-describing even if the player never reaches the launcher again.
- A prune the engine does not do: ten files, thirty days, eight megabytes, whichever bites first, and never the file being written.
- The bundle, and the crash marker.

Breadcrumbs (the scene change and every map load) are written on a player's own launch only. A corpus check loads thousands of maps and its output is read by a diff.

## Two things a reading of it cost

**`FileAccess.get_modified_time` has one-second resolution and a rotation writes several files inside it.** Sorting the log directory by modification time alone leaves the order arbitrary, so a prune bounded on "newest first" would sometimes delete the live session, which is the one the player is about to report. The live file is named by `debug/file_logging/log_path`, and a rotated one is that name with an ISO stamp inserted, so name order is newest-first.

**A downloads directory that exists is not one the process may write to.** Android hands one back that needs a permission the game never asks for. The bundle falls back to the app's own directory, and the sheet names the whole path rather than the filename, because no phone opens a file manager either.

## Two defects fixed on the way

- The launcher replayed its message as information after a palette rebuild. That took the warning glyph off a failure and gave it the dismissal timer an error is meant to be spared. The kind is kept with the message now.
- Two notes said the mod contract was `api_version` 9 where `Gen2ModManifest.API_VERSION` is 11.

## Checks

| Check | Result |
|---|---|
| GUT, unit and integration | 3,571 tests, 0 failures |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 0 failures |
| Boot smoke, with and without `--mods` | clean |
| Crash marker | killed with `-9`, reported at the next launch; clean quit is not |

The report sheet and the crash notice were photographed. Fourteen new cases cover the sink, the counters, the bounded tail, the report, the bundle, the fallback folder, the prune and the sort order.