### PR TITLE
Stop the map only where the cartridge stops it

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3231,6 +3231,18 @@ func script_busy() -> bool:
 	return _active_script != null or not _script_queue.is_empty()
 
 
+## Whether the script holding the world is one that stops the map around it.
+##
+## `ScriptEvents` runs inside `HandleMap`, and `HandleMapObjects` runs on the
+## same iteration, so a script standing in `WaitScript` or `WaitScriptMovement`
+## leaves every object that is not frozen stepping: `FreezeAllOtherObjects` is
+## what stops them, per object, and `applymovement` is its only caller. What
+## does stop the whole map is a textbox, a menu or a host screen, each of which
+## is a loop of its own that never reaches `HandleMap`.
+func script_stops_the_map() -> bool:
+	return script_busy() and pending_script_wait().is_empty()
+
+
 func pending_runtime_request() -> Dictionary:
 	return _active_script.pending_runtime_request() if _active_script != null else {}
 
@@ -3457,7 +3469,7 @@ func run_event_queue(acknowledge: bool = false, choice: int = -1) -> Array:
 			results.append(_apply_result_events(result))
 			break
 		results.append(_finish_script_result(result))
-		_active_script = null
+		_clear_active_script()
 	return results
 
 
@@ -3494,7 +3506,7 @@ func complete_runtime_request(result: Dictionary) -> Array:
 		return results
 	if StringName(advanced.get("status", &"")) == &"recovered":
 		results.append(advanced)
-		_active_script = null
+		_clear_active_script()
 		_script_queue.clear()
 		return results
 	results.append_array(_resume_after(advanced))
@@ -3509,7 +3521,7 @@ func _resume_after(advanced: Dictionary) -> Array:
 	results.append(
 		_finish_script_result(advanced) if bool(advanced.get("ok", false)) else advanced
 	)
-	_active_script = null
+	_clear_active_script()
 	results.append_array(_drain_script_queue())
 	return results
 
@@ -3543,8 +3555,16 @@ func _drain_script_queue() -> Array:
 			results.append(_apply_result_events(next))
 			break
 		results.append(_finish_script_result(next) if bool(next.get("ok", false)) else next)
-		_active_script = null
+		_clear_active_script()
 	return results
+
+
+## `StopScript` leaves nothing frozen behind it: `ApplyMovement`'s freeze is
+## released by the wait it staged, and a script that ends or is abandoned before
+## that wait completes would otherwise leave the map standing still for good.
+func _clear_active_script() -> void:
+	_active_script = null
+	unfreeze_all_objects()
 
 
 func _active_events_at(cell: Vector2i) -> Array:
@@ -4177,6 +4197,9 @@ func _apply_object_movement(event: Dictionary) -> Array:
 		})
 		return generated
 	var object: Gen2WorldObject = objects[object_index]
+	## `ApplyMovement` freezes the map around the object it is about to walk,
+	## and the wait this command stages is what thaws it again.
+	freeze_all_other_objects(object_index)
 	## Where the stream leaves the object looking. The drawn facing trails the
 	## walk one step at a time, so the record the next map load restores is this
 	## rather than whichever step is on screen when the stream is applied.
@@ -4306,6 +4329,9 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			"type": &"movement_failed", "reason": decoded.get("reason", &"invalid_movement"),
 			"player": true,
 		}]
+	## The player is object struct 0, so `applymovement PLAYER` freezes every
+	## map object exactly as an NPC's own does.
+	freeze_all_other_objects(-1)
 	for command: Dictionary in decoded.get("commands", []):
 		var kind: StringName = StringName(command.get("kind", &""))
 		if kind in SCRIPTED_TURN_KINDS:
@@ -4903,6 +4929,11 @@ func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 		# the speed on every frame both drivers run.
 		if object.scripted_steps:
 			continue
+		# `HandleStepType` returns before every step function while FROZEN_F is
+		# set, so a frozen object spends no step frame, no wait frame and takes
+		# no decision. `applymovement` is what freezes the rest of the map.
+		if object.frozen:
+			continue
 		# A step in flight is drained whatever put it there, so a pushed
 		# boulder slides even though its template never decides anything.
 		# StepFunction_StrengthBoulder ends by standing the boulder back up
@@ -4940,6 +4971,47 @@ func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 ## when a scripted stream needs drawing. This decides nothing, rolls nothing and
 ## writes no cell: every cell the stream names committed when it was applied.
 ## Returns true when something a renderer draws moved.
+## `FreezeAllOtherObjects` (engine/overworld/map_objects.asm): `ApplyMovement`
+## freezes every object that has a sprite and then clears the bit on the one it
+## is about to move, so the map stands still around a scripted walk and nowhere
+## else. [param moving_index] is -1 for the player, who is object struct 0 on
+## the cartridge and not a member of `objects` here.
+##
+## `UnfreezeFollowerObject` behind it clears the follower's bit when the object
+## being moved is the leader it was told to follow, which is what keeps a
+## `follow` pair walking together through one `applymovement`.
+func freeze_all_other_objects(moving_index: int) -> void:
+	for slot: int in objects.size():
+		var object: Gen2WorldObject = objects[slot]
+		object.frozen = object.active and not object.deleted and slot != moving_index
+	_unfreeze_follower_of(moving_index)
+
+
+## `UnfreezeAllObjects`, which `WaitScript` and `WaitScriptMovement` both run the
+## frame their wait ends: the freeze lasts exactly as long as the wait an
+## `applymovement` staged.
+func unfreeze_all_objects() -> void:
+	for object: Gen2WorldObject in objects:
+		object.frozen = false
+
+
+## The follower of [param leader_index], which is the pair `_object_followers`
+## keys by the follower and names the leader in `target_index`.
+func _unfreeze_follower_of(leader_index: int) -> void:
+	if current_map == null:
+		return
+	for key: String in _object_followers:
+		var separator: PackedStringArray = key.split(":")
+		if separator.size() != 3 or int(separator[0]) != current_map.group \
+			or int(separator[1]) != current_map.number:
+			continue
+		if int((_object_followers[key] as Dictionary).get("target_index", -2)) != leader_index:
+			continue
+		var follower_index: int = int(separator[2])
+		if follower_index >= 0 and follower_index < objects.size():
+			objects[follower_index].frozen = false
+
+
 func advance_scripted_steps_pass() -> bool:
 	var changed: bool = false
 	for object: Gen2WorldObject in objects:
@@ -4988,6 +5060,9 @@ func scripted_movement_in_progress() -> bool:
 
 func _complete_script_wait() -> Array:
 	_script_wait_frames = -1
+	## `WaitScript` and `WaitScriptMovement` both run `UnfreezeAllObjects` the
+	## frame their wait ends, before they hand the script back to `SCRIPT_READ`.
+	unfreeze_all_objects()
 	if _active_script == null:
 		return []
 	var advanced: Dictionary = _active_script.complete_wait()

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -103,9 +103,14 @@ var weird_tree: bool = false
 var queued_steps: Array = []
 ## True while the trail above belongs to a script rather than to the movement
 ## templates, which is what tells the two drivers apart:
-## Gen2WorldAPI.advance_object_steps_pass() decides movement and is refused while a
-## script runs, advance_scripted_steps_pass() only draws and is not.
+## Gen2WorldAPI.advance_object_steps_pass() decides movement and skips a frozen
+## object, advance_scripted_steps_pass() only draws and is not gated at all.
 var scripted_steps: bool = false
+## OBJECT_FLAGS2 FROZEN_F. `HandleStepType` returns before every step function
+## for a frozen object, so it neither steps, nor spends its wait, nor decides;
+## `FreezeAllOtherObjects` is the only thing in the game that sets it and
+## `ApplyMovement` is its only caller.
+var frozen: bool = false
 ## Frames this object waits before its movement template decides again. The
 ## source keeps this in OBJECT_STEP_DURATION while the object sits in
 ## STEP_TYPE_SLEEP (engine/overworld/map_objects.asm, StepFunction_Sleep).

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -986,14 +986,17 @@ func _overlay_open() -> bool:
 		or _slot_machine_host != null or _card_flip_host != null
 
 
-## Wandering objects keep to themselves while anything else owns the world. A
-## script may be moving those same objects, a trainer approach paces its own
-## object by call count, and an overlay hides the map entirely.
+## Wandering objects keep to themselves while anything else owns the world: a
+## trainer approach paces its own object by call count, and an overlay hides the
+## map entirely. A script is not by itself one of those things, which is
+## `Gen2WorldAPI.script_stops_the_map()`: the frames it spends in a wait are
+## `HandleMap`'s own, so the map keeps walking around an `applymovement` except
+## for the objects that command froze.
 func _objects_may_move() -> bool:
 	return _world != null and not _overlay_open() \
 		and not _field_move_text and _oak_pc_pages.is_empty() \
 		and _trainer_approach.is_empty() \
-		and not _world.script_busy() \
+		and not _world.script_stops_the_map() \
 		and not _world.phone_ring_active() \
 		and not _world.fishing_busy()
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4399,9 +4399,9 @@ func _types_of(result: Dictionary) -> Array[StringName]:
 
 
 ## The two drivers own different objects. advance_object_steps_pass() decides
-## movement and a screen stops calling it while a script runs, which is exactly
-## when a scripted trail has to keep being drawn, so draining it there as well
-## would walk it at twice the speed.
+## movement and skips the object whose trail a script owns, which is exactly the
+## object advance_scripted_steps_pass() draws, so draining it in both would walk
+## it at twice the speed.
 func test_the_movement_driver_leaves_a_scripted_trail_to_its_own_driver() -> void:
 	RomCache.write_json(RomCache.world_movements_path(_directory), {
 		"48:6100": [0x0F, 0x47],
@@ -4427,6 +4427,53 @@ func test_the_movement_driver_leaves_a_scripted_trail_to_its_own_driver() -> voi
 	for _frame: int in half:
 		assert_true(world.advance_scripted_steps_pass())
 	assert_eq(object.step_offset_cells(), Vector2(-0.5, 0.0))
+
+
+## `ApplyMovement` freezes every other object for as long as the wait it staged
+## lasts, and `HandleStepType` returns in front of every step function while
+## FROZEN_F is set: a wanderer beside a scripted walk stands still, and starts
+## again the frame `UnfreezeAllObjects` runs.
+func test_an_applymovement_freezes_the_map_around_it_until_its_wait_ends() -> void:
+	RomCache.write_json(RomCache.world_movements_path(_directory), {
+		"48:6100": [0x0F, 0x47],
+	})
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x69, 2, 0x00, 0x61, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	data.world_map(1, 1).events["objects"].append({
+		"sprite": 1, "x": 9, "y": 6, "x_radius": 2, "y_radius": 2,
+		"movement": Gen2WorldObject.MOVEMENT_WANDER, "event_flag": 0xFFFF,
+	})
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var walker: Gen2WorldObject = world.objects[0]
+	var wanderer: Gen2WorldObject = world.objects[world.objects.size() - 1]
+	assert_eq(wanderer.movement, Gen2WorldObject.MOVEMENT_WANDER)
+
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+	assert_true(walker.scripted_steps, "the object the stream names walks")
+	assert_true(wanderer.frozen, "everything else is frozen")
+	assert_false(world.script_stops_the_map(), "a wait is HandleMap's own frame")
+
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	var resting: Vector2i = wanderer.cell
+	for _frame: int in 240:
+		world.advance_object_steps_pass(random)
+	assert_eq(wanderer.cell, resting, "a frozen object decides nothing")
+
+	while not world.pending_script_wait().is_empty():
+		world.advance_scripted_steps_pass()
+		world.advance_script_wait_frame()
+	assert_false(wanderer.frozen, "UnfreezeAllObjects runs when the wait ends")
+	var moved: bool = false
+	for _frame: int in 240:
+		world.advance_object_steps_pass(random)
+		if wanderer.cell != resting:
+			moved = true
+			break
+	assert_true(moved, "and it wanders again")
 
 
 ## The player's half of the same thing, plus the walk frame that goes with it.


### PR DESCRIPTION
Every wandering NPC in the game stood still for the whole of any script. The
screen refused the movement pass while a script ran, so talking to anyone, or
any scripted scene, froze the whole map until it finished.

The cartridge does not work that way. `ScriptEvents` runs inside `HandleMap`,
and `HandleMapObjects` runs on the same iteration, so a script standing in
`WaitScript` or `WaitScriptMovement` leaves the map walking around it.

What stops an object is `OBJECT_FLAGS2`'s FROZEN_F, one bit per object.
`FreezeAllOtherObjects` sets it on everything with a sprite except the one it is
about to move, `UnfreezeFollowerObject` clears the follower's again, and
`ApplyMovement` is the only caller in the game. `HandleStepType` returns in
front of every step function while the bit is set, so a frozen object spends no
step frame, no wait frame and takes no decision. Both waits run
`UnfreezeAllObjects` the frame they end.

So objects now keep to themselves for a textbox, a menu or a host screen, each
of which is a loop of its own that never reaches `HandleMap`, and they keep
walking through the frames a script merely spends.

Reach, from `validate.gd -- all`: 587 `applymovement` and 6
`applymovementlasttalked` sites on Crystal, 398 and 6 on Gold and Silver, plus
226 `pause` and 11 `wait` commands on Crystal.

Checked: GUT 3,572 tests over 161 scripts green, `validate.gd -- all` 67 topics
green on exit code, `replay_world.gd` 33 routes 0 failures, and the story walk
ok on all three profiles (295, 292, 292 steps). A new case in
`test_world_api.gd` asserts both halves: a wanderer beside a scripted walk
stands still, and wanders again the frame the wait ends.
