### PR TITLE
Say what the Print row does, and spell the frame row as the cartridge does

### DIFF
--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -239,9 +239,15 @@ static func number(
 	return box
 
 
+## [param format] spells the readout, for a row the cartridge shows as something
+## other than the byte it stores: OPTION's own frame row is `UpdateFrame`'s
+## `add '1'`, so a stored 0 reads TYPE 1. Omitted, the readout is the number.
 static func slider(
-	theme: Gen2LauncherTheme, value: int, minimum: int, maximum: int, handler: Callable
+	theme: Gen2LauncherTheme, value: int, minimum: int, maximum: int, handler: Callable,
+	format: Callable = Callable()
 ) -> Control:
+	var spell: Callable = format if format.is_valid() \
+		else func(number: int) -> String: return str(number)
 	var line: HBoxContainer = row(GAP_MD)
 	var bar := HSlider.new()
 	bar.min_value = minimum
@@ -250,11 +256,11 @@ static func slider(
 	bar.value = value
 	bar.custom_minimum_size = Vector2(170, 22)
 	bar.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-	var readout: Label = muted(theme, str(value))
-	readout.custom_minimum_size = Vector2(30, 0)
+	var readout: Label = muted(theme, spell.call(value))
+	readout.custom_minimum_size = Vector2(52, 0)
 	readout.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	bar.value_changed.connect(func(changed: float) -> void:
-		readout.text = str(int(changed))
+		readout.text = spell.call(int(changed))
 		handler.call(int(changed))
 	)
 	line.add_child(bar)

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -190,7 +190,8 @@ func _build() -> void:
 		_theme, _options.textbox_frame, 0, Gen2Options.FRAME_COUNT - 1,
 		func(value: int) -> void:
 			_options.textbox_frame = value
-			_persist()
+			_persist(),
+		func(value: int) -> String: return "Type %d" % (value + 1)
 	)))
 	game.add_child(Gen2LauncherUI.field(_theme, "Menu account", _toggle(
 		_options.menu_account, func(on: bool) -> void:
@@ -203,6 +204,15 @@ func _build() -> void:
 			_options.printer_brightness = index
 			_persist()
 	)))
+	## The one row here that changes nothing you can see. It is the cartridge's
+	## own PRINT byte and is kept because the block is kept whole; the Game Boy
+	## Printer is a real peripheral with no path to a modern device, so the
+	## Pokedex's own PRINT does nothing, exactly as `.Print` does without one.
+	game.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"Print sets the Game Boy Printer's darkness. Nothing here can print, so "
+		+ "this only keeps the byte the cartridge stored."
+	))
 	column.add_child(Gen2LauncherUI.dock_safe_space())
 
 


### PR DESCRIPTION
An audit of every launcher setting, asking of each one whether anything reads
it. All of them do, except two rows that told the player less than they could.

**Print** is the one row in the page that changes nothing you can see. It is
the cartridge's own PRINT byte and is kept because the OPTION block is kept
whole, but the Game Boy Printer is a peripheral with no path to a modern
device, so the Pokedex's own PRINT does nothing, exactly as `.Print` does
without one. It now says so, beside the Screen and Bugs rows that already
explain themselves.

**Text frame** read as the stored 0 to 7 where the in-game OPTION menu reads
TYPE 1 to TYPE 8, which is `UpdateFrame`'s own `add '1'`. `Gen2LauncherUI.slider`
takes an optional way to spell its readout, so one value has one name in both
places.

Nothing else moved. Every other field of `Gen2Options` has a live reader:
`ui_theme`, both volumes, `video_mode` and `max_fps` through
`Gen2GameRuntime.apply_display_options`, `screen_fill` and `zoom_step` through
`Gen2Screen`, `game_speed` through `Gen2WorldAnimation.FrameClock`, the rules
flags and difficulty, and the whole OPTION block through
`Gen2WorldOptionsMenu` and the screens that draw it.

GUT 3,572 tests over 161 scripts, green.