### PR TITLE
Draw the launcher in points, and keep it clear of the screen's own furniture

### DIFF
--- a/game/input/touch_pad.gd
+++ b/game/input/touch_pad.gd
@@ -93,8 +93,18 @@ func is_editing() -> bool:
 	return _edit_mode
 
 
+## The rectangle the buttons are laid out in: the pad's own, less whatever the
+## screen keeps for itself. A phone counts its notch, its home indicator and its
+## rounded corners as display, so a face button anchored hard against the edge is
+## drawn under glass that no finger reaches through. Every rect, every hit test
+## and every drag is measured from here, so insetting it moves all three.
 func area() -> Rect2:
-	return Rect2(Vector2.ZERO, size)
+	var insets: Dictionary = Gen2LauncherUI.safe_area_insets(get_window())
+	var corner := Vector2(float(insets["left"]), float(insets["top"]))
+	var taken := corner + Vector2(float(insets["right"]), float(insets["bottom"]))
+	if taken.x >= size.x or taken.y >= size.y:
+		return Rect2(Vector2.ZERO, size)
+	return Rect2(corner, size - taken)
 
 
 ## Which button a point in the pad's own coordinates would press. Public so a
@@ -234,10 +244,14 @@ func _edit_pointer(index: int, point: Vector2, pressed: bool) -> void:
 
 
 func _edit_moved(index: int, point: Vector2) -> void:
-	if _dragging == &"" or index != _drag_index or size.x <= 0.0 or size.y <= 0.0:
+	var rect: Rect2 = area()
+	if _dragging == &"" or index != _drag_index or rect.size.x <= 0.0 or rect.size.y <= 0.0:
 		return
 	_layout.set_anchor(
-		Gen2TouchLayout.orientation_of(size), _dragging, (point - _drag_offset) / size, size
+		Gen2TouchLayout.orientation_of(rect.size),
+		_dragging,
+		(point - _drag_offset - rect.position) / rect.size,
+		rect.size,
 	)
 	queue_redraw()
 

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -11,11 +11,16 @@ extends Control
 
 signal page_selected(id: StringName)
 
-## Width below which the launcher writes smaller and pads tighter.
+## Width below which the launcher writes smaller and pads tighter. Measured in
+## launcher units, which are points rather than pixels, so a phone held upright
+## is below it whatever its screen is made of.
 const COMPACT_WIDTH: float = 820.0
 ## Room kept for a message and its detail line above the page.
 const TOAST_HEIGHT: float = 84.0
 const DOCK_OVERLAY_HEIGHT: float = Gen2LauncherUI.DOCK_SAFE_BOTTOM + 22.0
+## The widest a dock disc is allowed to grow into a narrow row. Past this the
+## row reads as four buttons rather than as a dock.
+const DOCK_SIDE_MAX: float = 84.0
 
 var theme_palette: Gen2LauncherTheme = null
 var compact: bool = false
@@ -35,6 +40,7 @@ var _battery: Gen2LauncherBattery = null
 var _top_right: HBoxContainer = null
 var _pages: MarginContainer = null
 var _dock_host: Control = null
+var _dock_centre: CenterContainer = null
 var _dock: HBoxContainer = null
 var _toast: Gen2LauncherToast = null
 var _flash: ColorRect = null
@@ -149,6 +155,17 @@ func _build() -> void:
 	_focus = Gen2FocusGuard.attach(self)
 
 
+## Every launcher screen is drawn in points, and only a launcher screen is: the
+## world upscales a 160x144 screen by a whole number of real pixels, and a
+## window drawn in points would make that number wrong.
+func _enter_tree() -> void:
+	Gen2LauncherUI.apply_display_density(get_window(), true)
+
+
+func _exit_tree() -> void:
+	Gen2LauncherUI.apply_display_density(get_window(), false)
+
+
 ## The wall clock, on the twenty-four hour dial the rest of the project uses.
 func _now() -> String:
 	var clock: Dictionary = Time.get_time_dict_from_system()
@@ -176,13 +193,13 @@ func _build_dock() -> Control:
 	fade.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	_dock_host.add_child(fade)
 
-	var centre := CenterContainer.new()
-	centre.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	centre.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	centre.offset_top = 26.0
+	_dock_centre = CenterContainer.new()
+	_dock_centre.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_dock_centre.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_dock_centre.offset_top = 26.0
 	_dock = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
-	centre.add_child(_dock)
-	_dock_host.add_child(centre)
+	_dock_centre.add_child(_dock)
+	_dock_host.add_child(_dock_centre)
 	return _dock_host
 
 
@@ -199,6 +216,10 @@ func add_page(id: StringName, label: String, glyph: StringName, page: Control) -
 	page.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_page_nodes[id] = page
 	_pages.add_child(page)
+	# The layout is settled before the first page exists, so a page is told the
+	# shape it is being added into rather than waiting for the next change of it.
+	if page.has_method("set_compact"):
+		page.call("set_compact", compact)
 	_rebuild_dock()
 	if _current.is_empty():
 		select(id)
@@ -353,6 +374,7 @@ func _rebuild_dock() -> void:
 		button.gui_input.connect(_on_dock_input.bind(id))
 		_dock.add_child(button)
 		_buttons[id] = button
+	_apply_layout()
 	if not _current.is_empty():
 		select(_current)
 
@@ -389,18 +411,18 @@ func _on_dock_input(event: InputEvent, id: StringName) -> void:
 
 
 func _apply_layout() -> void:
+	var insets: Dictionary = Gen2LauncherUI.safe_area_insets(get_window())
 	var wide: bool = size.x >= COMPACT_WIDTH
 	var margin: int = 30 if wide else 16
-	_host.add_theme_constant_override("margin_left", margin)
-	_host.add_theme_constant_override("margin_right", margin)
-	_host.add_theme_constant_override("margin_top", 20 if wide else 14)
+	# The clock and the charge sit on the top row, which a notch or a rounded
+	# corner would otherwise take a bite out of.
+	_host.add_theme_constant_override("margin_left", margin + int(insets["left"]))
+	_host.add_theme_constant_override("margin_right", margin + int(insets["right"]))
+	_host.add_theme_constant_override("margin_top", (20 if wide else 14) + int(insets["top"]))
 	# Pages reach the bezel; each scrolling page owns a safe tail that can move
 	# its final control above the floating dock.
 	_host.add_theme_constant_override("margin_bottom", 0)
-	for key: StringName in _buttons:
-		(_buttons[key] as Gen2LauncherButton).set_side(
-			Gen2LauncherButton.DOCK_SIDE if wide else 68.0
-		)
+	_layout_dock(wide, insets)
 	if compact == not wide and not _entries.is_empty():
 		return
 	compact = not wide
@@ -410,13 +432,37 @@ func _apply_layout() -> void:
 			page.call("set_compact", compact)
 
 
+## The discs take the row they are given rather than a fixed size, so a narrow
+## screen gets the largest disc four of them fit on instead of the smallest one
+## a desktop looked right with. Never below what a finger can hit, which is what
+## the row is for.
+func _layout_dock(wide: bool, insets: Dictionary) -> void:
+	var count: int = maxi(_entries.size(), 1)
+	var gap: float = float(Gen2LauncherUI.GAP_MD)
+	var margin: float = float(30 if wide else 16)
+	var room: float = size.x - float(insets["left"]) - float(insets["right"]) - margin * 2.0
+	var fits: float = (room - gap * float(count - 1)) / float(count)
+	var side: float = (
+		Gen2LauncherButton.DOCK_SIDE
+		if wide
+		else clampf(fits, Gen2LauncherUI.TOUCH_TARGET, DOCK_SIDE_MAX)
+	)
+	for key: StringName in _buttons:
+		(_buttons[key] as Gen2LauncherButton).set_side(side)
+	# The fade and the row above it both stand off the home indicator, so the
+	# bottom disc is reachable rather than half under it.
+	var bottom: float = float(insets["bottom"])
+	_dock_host.offset_top = -(DOCK_OVERLAY_HEIGHT + bottom)
+	_dock_centre.offset_bottom = -bottom
+
+
 ## Just above the page, so the message clears the dock and whatever the page puts
 ## along its own bottom edge. Measured rather than fixed: a short window has far
 ## less room under the page than a tall one.
 func _place_toast() -> void:
 	if _toast == null or _pages == null:
 		return
-	_toast.offset_bottom = -(Gen2LauncherUI.DOCK_SAFE_BOTTOM + 10.0)
+	_toast.offset_bottom = -(Gen2LauncherUI.dock_reserve(get_window()) + 10.0)
 	_toast.offset_top = _toast.offset_bottom - TOAST_HEIGHT
 
 

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -15,6 +15,93 @@ const MOD_ICON_SIDE: float = 64.0
 ## Empty scroll tail that lets the final control rise clear of the floating dock.
 const DOCK_SAFE_BOTTOM: float = 132.0
 
+## The smallest square a finger can be asked to hit, in launcher units. Apple
+## and Google both name 44 and 48 device-independent points; the larger is used
+## because a dock disc is aimed at while walking.
+const TOUCH_TARGET: float = 48.0
+
+
+## How many window pixels one launcher unit is drawn at, so that a unit is a
+## device-independent point rather than a pixel.
+##
+## Every size the launcher is written in is a desktop pixel, which is a comfortable
+## reading size only because a desktop screen is about 100 pixels to the inch. A
+## phone is three to four times that, so the same numbers arrive at a third of the
+## size and the window measures wide enough to be taken for a desktop. The screen's
+## own backing scale is exactly that ratio, and iOS and Android both report it.
+static func display_density() -> float:
+	if preview_density > 0.0:
+		return preview_density
+	if not OS.has_feature("mobile"):
+		return 1.0
+	var scale: float = DisplayServer.screen_get_scale()
+	if scale > 1.0:
+		return scale
+	# Android reports 1.0 here and puts the ratio in the dots per inch instead,
+	# against the 160 that defines the density-independent pixel.
+	var dpi: int = DisplayServer.screen_get_dpi()
+	return clampf(float(dpi) / 160.0, 1.0, 4.0)
+
+
+## Draws [param window] in launcher units. Set while a launcher screen is on and
+## unset when it leaves, because the game is drawn in cartridge pixels and an
+## integer upscale of a 160x144 screen must be computed against the real ones.
+static func apply_display_density(window: Window, on: bool) -> void:
+	if window == null:
+		return
+	var density: float = display_density() if on else 1.0
+	# A desktop draws in points already, and so does a headless run, whose window
+	# has no size to divide by.
+	var base: Vector2 = Vector2(window.content_scale_size)
+	var pixels: Vector2 = Vector2(window.size)
+	if is_equal_approx(density, 1.0) or base.x <= 0.0 or base.y <= 0.0 or pixels.x <= 0.0:
+		window.content_scale_factor = 1.0
+		return
+	# The project already stretches the window onto its base viewport, and the
+	# factor multiplies that rather than replacing it, so the stretch has to be
+	# divided back out for a unit to land on a point.
+	var stretch: float = minf(pixels.x / base.x, pixels.y / base.y)
+	window.content_scale_factor = clampf(density / maxf(stretch, 0.01), 0.25, 8.0)
+
+
+## What the screen's own furniture takes out of [param window], in launcher
+## units: the notch and the clock above, the home indicator below, and the
+## rounded corners the display server counts into both. Zero everywhere the
+## platform has nothing to say.
+static func safe_area_insets(window: Window) -> Dictionary:
+	var none: Dictionary = {"left": 0.0, "top": 0.0, "right": 0.0, "bottom": 0.0}
+	if not preview_insets.is_empty():
+		return preview_insets
+	if window == null or not OS.has_feature("mobile"):
+		return none
+	var safe: Rect2i = DisplayServer.get_display_safe_area()
+	var screen: Vector2i = DisplayServer.screen_get_size()
+	if safe.size.x <= 0 or safe.size.y <= 0 or screen.x <= 0 or screen.y <= 0:
+		return none
+	# The safe area is given in screen pixels; a launcher unit is what the window
+	# draws one at.
+	var unit: float = maxf(float(window.size.x) / maxf(window.get_visible_rect().size.x, 1.0), 0.01)
+	return {
+		"left": maxf(float(safe.position.x), 0.0) / unit,
+		"top": maxf(float(safe.position.y), 0.0) / unit,
+		"right": maxf(float(screen.x - safe.end.x), 0.0) / unit,
+		"bottom": maxf(float(screen.y - safe.end.y), 0.0) / unit,
+	}
+
+
+## Preview seams for `tools/preview_launcher.gd`, which runs on a desktop and so
+## is told about a phone rather than asking one. Zero and empty mean ask the
+## display server, which is every real run.
+static var preview_density: float = 0.0
+static var preview_insets: Dictionary = {}
+
+
+## How much a scrolling page keeps clear along its bottom edge: the dock's own
+## room plus whatever the screen takes under it for a home indicator.
+static func dock_reserve(window: Window) -> float:
+	return DOCK_SAFE_BOTTOM + float(safe_area_insets(window)["bottom"])
+
+
 
 static func title(theme: Gen2LauncherTheme, text: String, size: int = Gen2LauncherTheme.FONT_TITLE) -> Label:
 	return _label(text, size, theme.text)
@@ -83,6 +170,10 @@ static func dock_safe_space() -> Control:
 	var gap := Control.new()
 	gap.custom_minimum_size.y = DOCK_SAFE_BOTTOM
 	gap.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# The home indicator's height is only knowable once there is a window to ask.
+	gap.tree_entered.connect(
+		func() -> void: gap.custom_minimum_size.y = dock_reserve(gap.get_window())
+	)
 	return gap
 
 
@@ -268,15 +359,22 @@ static func slider(
 	return line
 
 
-## The one file picker every launcher dialog is built from.
+## The one file picker every launcher dialog is built from. Any new file-picking
+## UI goes through here rather than building its own [FileDialog].
 ##
 ## `use_native_dialog` is asked for unconditionally rather than gated on
 ## `FEATURE_NATIVE_DIALOG_FILE`: [FileDialog] already makes that exact test
 ## before it goes native and falls back to its own window when the platform says
 ## no, so a second gate here can only refuse a picker the platform would have
-## given us. That is what left iOS on the built-in browser, which lists paths
-## `FileAccess.open()` then refuses on every sandboxed platform. Any new
-## file-picking UI goes through here rather than building its own [FileDialog].
+## given us. Android answers it and hands over the system picker, which grants
+## the one file chosen and is why the app declares no storage permission.
+##
+## iOS answers no: `DisplayServerIOS` implements no `file_dialog_show` at the
+## engine pin, so there is no system picker to open and the built-in browser is
+## what appears. Browsing the whole filesystem there lists paths
+## `FileAccess.open()` then refuses, so the browser is rooted at the app's own
+## Documents instead, which is the one place a sandboxed app may read and which
+## `UIFileSharingEnabled` lets the Files app put a cartridge into.
 static func file_picker(
 	theme: Gen2LauncherTheme,
 	title_text: String,
@@ -285,9 +383,18 @@ static func file_picker(
 ) -> FileDialog:
 	var dialog := FileDialog.new()
 	dialog.file_mode = mode
-	dialog.access = FileDialog.ACCESS_FILESYSTEM
+	var native: bool = DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE)
+	dialog.access = (
+		FileDialog.ACCESS_FILESYSTEM
+		if native or not OS.has_feature("mobile")
+		else FileDialog.ACCESS_USERDATA
+	)
 	dialog.filters = filters
 	dialog.title = title_text
+	if dialog.access == FileDialog.ACCESS_USERDATA:
+		# The browser gives no room to explain itself, and a player looking at an
+		# empty folder needs to be told which folder it is.
+		dialog.title = "%s (this app's Documents folder)" % title_text
 	dialog.use_native_dialog = true
 	dialog.theme = theme.control_theme()
 	return dialog

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -28,6 +28,9 @@ const MAX_DOWNLOAD_BYTES: int = 96 * 1024 * 1024
 
 var _theme: Gen2LauncherTheme = null
 var _host: Control = null
+## Whether the page is drawn for a narrow screen, where a row's controls go under
+## its name instead of beside it.
+var _compact: bool = false
 var _views: Control = null
 var _list_view: VBoxContainer = null
 var _list: VBoxContainer = null
@@ -188,25 +191,38 @@ func _empty_state() -> Control:
 ## on the mod's own page, which the row itself opens.
 func _card(row: Dictionary) -> Control:
 	var panel: Gen2LauncherCard = Gen2LauncherCard.create(_theme, Gen2LauncherTheme.RADIUS_MD, 18)
+	# A phone is narrower than the icon, the name, the switch and three buttons
+	# laid end to end, so the controls drop under the name rather than off the
+	# card. Everything is the same node either way round; only the box differs.
+	var stack: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
+	panel.add_child(stack)
 	var line: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
-	panel.add_child(line)
+	stack.add_child(line)
 	line.add_child(_icon_square(row))
 
 	var text: VBoxContainer = Gen2LauncherUI.column(1)
 	text.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	text.alignment = BoxContainer.ALIGNMENT_CENTER
 	line.add_child(text)
-	text.add_child(Gen2LauncherUI.body(_theme, String(row["name"])))
-	text.add_child(Gen2LauncherUI.muted(_theme, _version_line(row)))
+	# An id is one long word and will not wrap, so it is trimmed rather than
+	# allowed to set the width of every row on the page.
+	text.add_child(_clipped(Gen2LauncherUI.body(_theme, String(row["name"]))))
+	text.add_child(_clipped(Gen2LauncherUI.muted(_theme, _version_line(row))))
+
+	var controls: HBoxContainer = line
+	if _compact:
+		controls = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
+		controls.alignment = BoxContainer.ALIGNMENT_END
+		stack.add_child(controls)
 
 	if bool(row["installed"]):
 		var switch: Gen2LauncherToggle = Gen2LauncherToggle.create(_theme, bool(row["enabled"]))
 		switch.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 		switch.toggled.connect(func(on: bool) -> void: set_enabled(row, on))
-		line.add_child(switch)
+		controls.add_child(switch)
 
 	for button: Control in _action_buttons(row):
-		line.add_child(button)
+		controls.add_child(button)
 
 	var open: Gen2LauncherButton = Gen2LauncherButton.icon_only(
 		_theme, &"chevron", Gen2LauncherButton.Variant.QUIET, 40.0
@@ -221,6 +237,25 @@ func _card(row: Dictionary) -> Control:
 			open_mod(StringName(row["id"]))
 	)
 	return panel
+
+
+## Redrawn for the width the page is being given. Rebuilding is how every
+## launcher pane changes shape, since each is built in code from its state.
+func set_compact(on: bool) -> void:
+	if on == _compact:
+		return
+	_compact = on
+	refresh()
+
+
+## A label that gives up its width rather than pushing the row wider than the
+## card. Its own minimum is what makes a [HBoxContainer] overflow.
+static func _clipped(label: Label) -> Label:
+	label.autowrap_mode = TextServer.AUTOWRAP_OFF
+	label.clip_text = true
+	label.text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS
+	label.custom_minimum_size.x = 0.0
+	return label
 
 
 ## What a row can do: download a mod that is not installed, update one a source

--- a/game/launcher/touch_layout_sheet.gd
+++ b/game/launcher/touch_layout_sheet.gd
@@ -60,9 +60,12 @@ func _build() -> void:
 func _toolbar() -> Control:
 	var host := MarginContainer.new()
 	host.set_anchors_and_offsets_preset(Control.PRESET_TOP_WIDE)
-	host.add_theme_constant_override("margin_left", 24)
-	host.add_theme_constant_override("margin_right", 24)
-	host.add_theme_constant_override("margin_top", 20)
+	# The sheet opens against the top edge, which is where a phone keeps its
+	# notch and its clock.
+	var insets: Dictionary = Gen2LauncherUI.safe_area_insets(get_window())
+	host.add_theme_constant_override("margin_left", 24 + int(insets["left"]))
+	host.add_theme_constant_override("margin_right", 24 + int(insets["right"]))
+	host.add_theme_constant_override("margin_top", 20 + int(insets["top"]))
 	var card: Gen2LauncherCard = Gen2LauncherCard.floating(
 		_theme, Gen2LauncherTheme.RADIUS_LG, 18, 30
 	)

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -587,6 +587,69 @@ func test_the_about_page_offers_both_ways_to_report_a_bug() -> void:
 	assert_has(opened, Gen2AppVersion.REPOSITORY, "and the project itself on the page")
 
 
+func test_a_narrow_shell_gives_its_dock_discs_a_finger_to_hit() -> void:
+	# The dock is the one row that has to be pressed while walking, so what it
+	# gets from a phone's width is asserted rather than the width itself.
+	var shell: Gen2LauncherShell = Gen2LauncherShell.create(_light)
+	add_child_autofree(shell)
+	# The shell fills whatever it is put in, so the test gives it a rect of its
+	# own rather than a window to fill.
+	shell.set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
+	for id: StringName in [&"a", &"b", &"c", &"d"]:
+		shell.add_page(id, String(id), &"shelf", Control.new())
+	shell.size = Vector2(390, 844)
+	await get_tree().process_frame
+	assert_true(shell.compact, "a phone held upright is not a desktop")
+	for button: Gen2LauncherButton in _buttons_under(shell):
+		assert_gte(
+			button.custom_minimum_size.x,
+			Gen2LauncherUI.TOUCH_TARGET,
+			"every disc is at least a finger wide",
+		)
+	shell.size = Vector2(1280, 800)
+	await get_tree().process_frame
+	assert_false(shell.compact, "and a desktop is not a phone")
+
+
+func test_the_screen_furniture_is_taken_out_of_the_room_a_page_is_given() -> void:
+	# The insets are what a notch and a home indicator cost; the preview seam
+	# stands in for a phone, because the machine running this has neither.
+	Gen2LauncherUI.preview_insets = {"left": 0.0, "top": 59.0, "right": 0.0, "bottom": 34.0}
+	var window: Window = get_tree().root
+	assert_eq(Gen2LauncherUI.safe_area_insets(window)["top"], 59.0)
+	assert_eq(
+		Gen2LauncherUI.dock_reserve(window),
+		Gen2LauncherUI.DOCK_SAFE_BOTTOM + 34.0,
+		"a page's tail clears the dock and the home indicator together",
+	)
+	Gen2LauncherUI.preview_insets = {}
+	assert_eq(Gen2LauncherUI.safe_area_insets(window)["bottom"], 0.0, "and a desktop has neither")
+
+
+func test_a_mod_row_fits_a_phone_rather_than_running_off_its_card() -> void:
+	var page: Gen2ModsPage = Gen2ModsPage.create(_light, null)
+	add_child_autofree(page)
+	page.set_compact(true)
+	await get_tree().process_frame
+	var width: float = 390.0 - 32.0
+	for card: Node in _cards_under(page):
+		assert_lte(
+			(card as Control).get_combined_minimum_size().x,
+			width,
+			"a row asks for no more than a phone has",
+		)
+
+
+## Every card in [param root]'s subtree.
+func _cards_under(root: Node) -> Array[Gen2LauncherCard]:
+	var found: Array[Gen2LauncherCard] = []
+	if root is Gen2LauncherCard:
+		found.append(root)
+	for child: Node in root.get_children():
+		found.append_array(_cards_under(child))
+	return found
+
+
 ## Every button in [param root]'s subtree, which is how a page built in code is
 ## inspected without naming the containers it happens to nest them in.
 func _buttons_under(root: Node) -> Array[Gen2LauncherButton]:

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -5,7 +5,7 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_launcher.gd -- \
 ##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] \
-##       [scroll] [focus index] [fade step]
+##       [scroll] [focus index] [fade step] [insets]
 ##
 ## `view` opens a sheet (`manage`, `touch`, `binding`, `bugs`, `report`,
 ## `delete_mod`) or
@@ -14,6 +14,11 @@ extends SceneTree
 ## to 4 for one of `FadeOutToWhite`'s own rows: the launcher's leave-the-screen
 ## sheet is stepped rather than tweened, so a still is the only way to see that
 ## it is discrete. See [method Gen2LauncherShell.flash].
+##
+## `insets` is the screen furniture a phone would take, as `left,top,right,bottom`
+## in launcher units, so the notch and home indicator cases can be photographed on
+## a desktop. Give the window a phone's size in points and one of these to see
+## what the phone shows. See [method Gen2LauncherUI.safe_area_insets].
 ##
 ## `scroll` is how far down the page's own scroll to photograph, in pixels, for a
 ## card that does not fit the window. `focus` puts the keyboard on the nth
@@ -60,6 +65,15 @@ func _initialize() -> void:
 	_scroll = int(args[8]) if args.size() > 8 else 0
 	_focus = int(args[9]) if args.size() > 9 else -1
 	_fade = int(args[10]) if args.size() > 10 else 0
+	if args.size() > 11 and not args[11].is_empty():
+		var edges: PackedStringArray = args[11].split(",")
+		if edges.size() == 4:
+			Gen2LauncherUI.preview_insets = {
+				"left": float(edges[0]),
+				"top": float(edges[1]),
+				"right": float(edges[2]),
+				"bottom": float(edges[3]),
+			}
 
 	# Both, because the window already exists by the time a tool script runs and
 	# only the display server moves it.


### PR DESCRIPTION
A phone reports its pixels, not its points. On a 390 point wide screen the
launcher measured itself at 1170, so every size arrived at a third of itself and
the window was wide enough to be classed as a desktop. The type was unreadable,
the dock discs were about 3 mm across, and the clock and the charge sat in the
rounded corners.

The screen's own backing scale is exactly that ratio and both handheld platforms
report it. A launcher screen is now drawn through it, so a launcher unit is a
point. The world is not drawn through it: it upscales a 160x144 screen by a
whole number of real pixels, and that number has to count the real ones.

What else is in here:

- The safe area is taken out of the room a page, the arrange-the-buttons sheet
  and the touch pad are given. A face button anchored against an edge is no
  longer under glass a finger cannot reach through.
- The dock takes the row it is given rather than a fixed size, and never goes
  below the width of a finger.
- A mod row folds its switch and its buttons under its name where the card is
  too narrow for them, and trims a long id rather than letting one word set the
  width of every row on the page.
- The file picker is rooted at the app's own Documents where the platform offers
  no system picker. That is iOS: `DisplayServerIOS` implements no
  `file_dialog_show`, so `FileDialog` was falling back to browsing a filesystem
  the app is then refused every read of.

A page added to the shell is now told the shape it is being added into. It used
to be told only on the next change of shape, which on a phone never came.

Tested: 3575 tests pass, `validate.gd -- all` exits 0, and the launcher is
photographed at 390x844 with a notch and a home indicator through the new
`insets` argument to `tools/preview_launcher.gd`.