### PR TITLE
Open the system file picker on iOS, and fix what a real phone showed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ export_credentials.cfg
 # Local checkouts of the authoritative source repositories. These are fetched
 # for comparison only and must never become project content.
 /.references/
+
+# Built iOS plugin libraries. The sources beside them are tracked; the binaries
+# are produced by tools/build_ios_plugin.sh against the engine checkout.
+/ios/plugins/*/*.a

--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -184,6 +184,9 @@ func summary() -> String:
 		_setting("rendering/renderer/rendering_method", "?"),
 		_video_adapter(),
 	])
+	# Which of the three ways to ask for a file this build has. A player who
+	# cannot get a cartridge in is the report this line is here for.
+	lines.append("Files      %s" % _file_picker_kind())
 	lines.append("Session    %s, %d error%s, %d warning%s%s" % [
 		_uptime(),
 		_errors, "" if _errors == 1 else "s",
@@ -491,6 +494,15 @@ static func _file_size(path: String) -> int:
 
 static func _setting(key: String, fallback: String) -> String:
 	return String(ProjectSettings.get_setting(key, fallback))
+
+
+## Which picker [Gen2LauncherFilePicker] would present here.
+static func _file_picker_kind() -> String:
+	if Engine.has_singleton(Gen2LauncherFilePicker.NATIVE_SINGLETON):
+		return "the system picker, through the platform plugin"
+	if DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE):
+		return "the system picker, through the engine"
+	return "the engine's own browser"
 
 
 ## Empty on a headless run, and on a machine whose driver never answered.

--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -245,7 +245,9 @@ func _pack_bundle(directory: String) -> Dictionary:
 			return {"ok": false, "message": "That folder could not be opened.", "path": ""}
 		if DirAccess.make_dir_absolute(directory) != OK:
 			return {"ok": false, "message": "That folder could not be opened.", "path": ""}
-	var path: String = "%s/%s%s.zip" % [directory, BUNDLE_PREFIX, _file_stamp()]
+	# path_join rather than a format string: a globalized user:// already ends in
+	# a separator, and the result is read off a phone screen and typed by hand.
+	var path: String = directory.path_join("%s%s.zip" % [BUNDLE_PREFIX, _file_stamp()])
 	var packer := ZIPPacker.new()
 	if packer.open(path) != OK:
 		return {"ok": false, "message": "The report file could not be created.", "path": ""}

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -159,6 +159,7 @@ script_export_mode=2
 
 application/app_store_team_id="ZFNL78SF72"
 application/bundle_identifier="io.github.decryptu.pokerecomp"
+plugins/NativeFilePicker=true
 application/signature=""
 application/short_version="0.1.0"
 application/version="0.1.0"

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -102,6 +102,10 @@ var _item_sources: Dictionary = {}
 ## Built on first ask. See [method field_hm_items].
 var _field_hms: Array[int] = []
 
+## How many scripts [method build_reporting] decodes between two checks of the
+## clock. Small enough that a chunk is far shorter than a frame.
+const SCAN_CHUNK: int = 64
+
 
 ## Builds the catalog for [param data]. Walks every imported script once and
 ## every map's events once, which is why a caller holds the result rather than
@@ -111,7 +115,42 @@ static func build(data: GameData) -> Gen2WorldCatalog:
 	out._data = data
 	if data == null:
 		return out
-	out._scan_scripts()
+	out._scan_keys(out._script_keys(), 0, -1)
+	out._scan_map_events()
+	out._attribute_maps()
+	return out
+
+
+## The same scan, in chunks, handing the main loop a frame between them and
+## saying how far along it is.
+##
+## This walk is seven eighths of a cartridge import's wall clock: it decodes
+## every command of every script the import just wrote. Run whole it is the one
+## stretch long enough for a player to decide the launcher has stopped, so the
+## import uses this and the lazy rebuild behind [method GameData.catalog] uses
+## [method build], which has no screen to keep alive and no loop to give a frame
+## back to.
+static func build_reporting(
+	data: GameData, on_progress: Callable = Callable(), yield_ms: int = 0
+) -> Gen2WorldCatalog:
+	var out := Gen2WorldCatalog.new()
+	out._data = data
+	if data == null:
+		return out
+	var keys: Array = out._script_keys()
+	var last_yield: int = Time.get_ticks_msec()
+	var at: int = 0
+	while at < keys.size():
+		var upto: int = mini(at + SCAN_CHUNK, keys.size())
+		out._scan_keys(keys, at, upto)
+		at = upto
+		if on_progress.is_valid():
+			on_progress.call("catalogue", at, keys.size())
+		# Measured rather than counted: one script costs whatever its commands
+		# happen to cost, and what matters is a steady screen.
+		if yield_ms > 0 and Time.get_ticks_msec() - last_yield >= yield_ms:
+			last_yield = Time.get_ticks_msec()
+			await Engine.get_main_loop().process_frame
 	out._scan_map_events()
 	out._attribute_maps()
 	return out
@@ -365,10 +404,17 @@ func is_progression(row: Dictionary) -> bool:
 ## the decoder does not know ends that script's walk rather than guessing an
 ## operand width, which is the same rule `scan_references` follows: a site found
 ## past an unknown command would be at an invented offset.
-func _scan_scripts() -> void:
+func _script_keys() -> Array:
+	return _data.world_script_keys()
+
+
+## Scans `keys[from:upto]`, or all of them when [param upto] is negative. One
+## body for both builders, so only how the walk is broken up differs.
+func _scan_keys(keys: Array, from: int, upto: int) -> void:
 	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
-	for key: Variant in _data.world_script_keys():
-		var parts: PackedStringArray = String(key).split(":")
+	var last: int = keys.size() if upto < 0 else upto
+	for index: int in range(from, last):
+		var parts: PackedStringArray = String(keys[index]).split(":")
 		if parts.size() != 2:
 			continue
 		## `Gen2WorldScript.pointer_key` is a DECIMAL bank and a hex address.

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -96,6 +96,18 @@ const DEX_ORDER_NEW_FIRST: int = 152
 const DEX_ORDER_ALPHA_FIRST: int = 63
 
 var _lz: Gen2Lz = Gen2Lz.new()
+## When the import last handed the main loop a frame. See [method _breathe].
+var _last_breath: int = 0
+
+
+## Hands the main loop a frame if one is due, so a launcher watching this import
+## keeps drawing. [param yield_ms] of zero never suspends, and awaiting a
+## coroutine that does not suspend returns at once.
+func _breathe(yield_ms: int) -> void:
+	if yield_ms <= 0 or Time.get_ticks_msec() - _last_breath < yield_ms:
+		return
+	_last_breath = Time.get_ticks_msec()
+	await Engine.get_main_loop().process_frame
 
 
 ## Sanity-checks [RomLayout] against the cartridge before anything is decoded.
@@ -3929,8 +3941,15 @@ static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> Str
 ##
 ## [param on_progress] is called as [code](stage, done, total)[/code] if given.
 ## Returns { ok, message, directory, species, elapsed_ms }.
-func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
+## [param yield_ms] is how often the one long stretch of this hands the main loop
+## a frame: the catalogue scan is seven eighths of the wall clock and everything
+## else is under a second. Zero, the default, never suspends, which is what a
+## command line import and a corpus check want.
+func import_rom(
+	rom: RomFile, on_progress: Callable = Callable(), yield_ms: int = 0
+) -> Dictionary:
 	var started: int = Time.get_ticks_msec()
+	_last_breath = started
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var result: Dictionary = {
 		"ok": false,
@@ -3976,11 +3995,13 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		return result
 
 	var species: Array = _import_species(rom, layout, on_progress)
+	await _breathe(yield_ms)
 	if species.is_empty():
 		result["message"] = "Decoded no species."
 		return result
 
 	var pics: Dictionary = _import_pics(rom, layout, species, on_progress)
+	await _breathe(yield_ms)
 	if pics.is_empty():
 		result["message"] = "Could not decode pics."
 		return result
@@ -3988,45 +4009,60 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	# Crystal's alone; Gold and Silver have no pic animation, so an empty answer
 	# is the honest one rather than a failure.
 	var pic_anims: Dictionary = _import_pic_anims(rom, layout, species)
+	await _breathe(yield_ms)
 	if pic_anims.is_empty() and not RomLayout.pic_anim(layout).is_empty():
 		result["message"] = "Could not decode pic animations."
 		return result
 
 	var tiles: Dictionary = _import_tiles(rom, layout, on_progress)
+	await _breathe(yield_ms)
 	if tiles.is_empty():
 		result["message"] = "Could not write the font."
 		return result
 
 	var dex_orders: Dictionary = _import_dex_orders(rom, layout)
+	await _breathe(yield_ms)
 	if dex_orders.is_empty():
 		result["message"] = "Dex order tables are outside the cartridge."
 		return result
 
 	var moves: Array = _import_moves(rom, layout, on_progress)
+	await _breathe(yield_ms)
 	var tmhm_moves: Array = _import_tmhm_moves(rom, layout)
+	await _breathe(yield_ms)
 	if tmhm_moves.is_empty():
 		result["message"] = "TM/HM move table is outside the cartridge or malformed."
 		return result
 	var happiness_changes: Array = _import_happiness_changes(rom, layout)
+	await _breathe(yield_ms)
 	if happiness_changes.is_empty():
 		result["message"] = "Happiness change table is outside the cartridge or malformed."
 		return result
 	var name_input_chars: Array = _import_name_input_chars(rom, layout)
+	await _breathe(yield_ms)
 	var string_buffers: Array = _import_string_buffer_pointers(rom, layout)
+	await _breathe(yield_ms)
 	var intro_text: Dictionary = _import_intro_text(rom, layout)
+	await _breathe(yield_ms)
 	if intro_text.is_empty():
 		result["message"] = "Intro text is outside the cartridge or malformed."
 		return result
 	var items: Array = _import_items(rom, layout, on_progress)
+	await _breathe(yield_ms)
 	var trades: Array = _import_world_trades(rom, layout)
+	await _breathe(yield_ms)
 	var types: Array = _import_types(rom, layout, on_progress)
+	await _breathe(yield_ms)
 	var matchups: Array = read_matchups(rom, layout)
 	var trainers: Array = _import_trainers(rom, layout, on_progress)
+	await _breathe(yield_ms)
 	var world: Dictionary = Gen2WorldImporter.import_to_cache(rom, layout, directory, on_progress)
+	await _breathe(yield_ms)
 	if not bool(world.get("ok", false)):
 		result["message"] = String(world.get("message", "Could not import overworld data."))
 		return result
 	var encounters: Dictionary = Gen2WorldEncounterImporter.import_to_cache(rom, layout, directory)
+	await _breathe(yield_ms)
 	if not bool(encounters.get("ok", false)):
 		result["message"] = String(encounters.get("message", "Could not import wild encounter data."))
 		return result
@@ -4035,10 +4071,12 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 		world.get("scripts", {}), world.get("standard_scripts", {}),
 		world.get("text", {}), world.get("movements", {})
 	)
+	await _breathe(yield_ms)
 	if not bool(services.get("ok", false)):
 		result["message"] = String(services.get("message", "Could not import world service data."))
 		return result
 	var battle_anims: Dictionary = Gen2BattleAnimImporter.import_to_cache(rom, layout, directory)
+	await _breathe(yield_ms)
 	if not bool(battle_anims.get("ok", false)):
 		result["message"] = String(
 			battle_anims.get("message", "Could not import battle animation data.")
@@ -4200,10 +4238,10 @@ func import_rom(rom: RomFile, on_progress: Callable = Callable()) -> Dictionary:
 	## After the manifest, because the scan opens the cache it describes.
 	var catalogued: GameData = GameData.open_directory(directory)
 	if catalogued != null:
-		RomCache.write_json(
-			RomCache.world_catalog_path(directory),
-			Gen2WorldCatalog.build(catalogued).to_dict()
+		var catalog: Gen2WorldCatalog = await Gen2WorldCatalog.build_reporting(
+			catalogued, on_progress, yield_ms
 		)
+		RomCache.write_json(RomCache.world_catalog_path(directory), catalog.to_dict())
 
 	result["ok"] = true
 	result["species"] = species.size()

--- a/game/input/input_actions.gd
+++ b/game/input/input_actions.gd
@@ -209,9 +209,13 @@ static func from_event(event: InputEvent) -> Dictionary:
 
 ## The key actually printed where this physical one sits, as a keycode.
 ## `keyboard_get_label_from_physical` returns a key rather than a string, and
-## refuses on a display server with no keyboard, which is every headless run.
+## refuses on a display server with no keyboard to read a layout off: a headless
+## run, and every handheld, whose display server answers no whether or not a
+## keyboard happens to be paired. There is no feature flag to ask instead, and
+## the refusal is an error, so a settings page put fourteen of them into every
+## bug report a phone ever sent.
 static func _labelled_key(code: int) -> int:
-	if DisplayServer.get_name() == "headless":
+	if DisplayServer.get_name() == "headless" or OS.has_feature("mobile"):
 		return code
 	var labelled: int = DisplayServer.keyboard_get_label_from_physical(code)
 	return labelled if labelled != 0 else code

--- a/game/launcher/launcher_button.gd
+++ b/game/launcher/launcher_button.gd
@@ -14,6 +14,10 @@ enum Variant {
 	NEUTRAL,
 	## No fill until hovered. Rows of these read as labels.
 	QUIET,
+	## Quiet, but standing on the toast's chip rather than on the page. The
+	## page's own muted ink is all but invisible against a surface that is the
+	## opposite side of the page from it.
+	ON_CHIP,
 	## Destructive, tinted with the error colour.
 	DANGER,
 	## One choice inside a segmented track.
@@ -143,6 +147,9 @@ func repaint() -> void:
 		Variant.QUIET:
 			fill = _theme.accent_wash(0.13) if _active else Color(0, 0, 0, 0)
 			ink = _theme.accent if _active else _theme.muted
+		Variant.ON_CHIP:
+			fill = _theme.with_alpha(_theme.on_surface, 0.16) if reached else Color(0, 0, 0, 0)
+			ink = _theme.with_alpha(_theme.on_surface, 1.0 if reached else 0.7)
 		Variant.DANGER:
 			fill = _theme.with_alpha(_theme.error, 0.12)
 			border = _theme.with_alpha(_theme.error, 0.40)

--- a/game/launcher/launcher_file_picker.gd
+++ b/game/launcher/launcher_file_picker.gd
@@ -1,0 +1,108 @@
+class_name Gen2LauncherFilePicker
+extends FileDialog
+
+## The one file picker every launcher dialog is built from. Any new file-picking
+## UI goes through [method Gen2LauncherUI.file_picker] rather than building its
+## own, and shows it with [method show_picker] rather than [method
+## Window.popup_centered].
+##
+## Three ways a platform offers a file, in the order they are preferred:
+##
+## 1. The engine's own native dialog, asked for with `use_native_dialog`. Windows,
+##    macOS, Linux and Android all answer, and Android's grants access to the one
+##    file chosen, which is why the app declares no storage permission.
+## 2. The `NativeFilePicker` singleton from `ios/plugins/file_picker`, for iOS,
+##    where `DisplayServerIOS` implements no `file_dialog_show` and so the engine
+##    has no system picker to offer. It hands back a file already copied into the
+##    app's own storage, so what a caller reads is an ordinary path.
+## 3. The engine's built-in browser, for anything left. Rooted at the app's own
+##    data where the filesystem is sandboxed, since every path outside it is one
+##    [FileAccess] would then be refused.
+
+## The plugin's singleton, present only on a build that carries it.
+const NATIVE_SINGLETON: StringName = &"NativeFilePicker"
+
+var _native: Object = null
+
+
+static func create(
+	theme: Gen2LauncherTheme,
+	title_text: String,
+	mode: FileDialog.FileMode,
+	filters: PackedStringArray,
+) -> Gen2LauncherFilePicker:
+	var dialog := Gen2LauncherFilePicker.new()
+	dialog.file_mode = mode
+	dialog.filters = filters
+	dialog.title = title_text
+	dialog.use_native_dialog = true
+	dialog.theme = theme.control_theme()
+	# The plugin opens files; naming one that does not exist yet is a different
+	# controller and a different flow, so a save keeps the engine's own path.
+	if mode == FileDialog.FILE_MODE_OPEN_FILE and Engine.has_singleton(NATIVE_SINGLETON):
+		dialog._native = Engine.get_singleton(NATIVE_SINGLETON)
+	dialog.access = (
+		FileDialog.ACCESS_FILESYSTEM if dialog._can_browse_freely() else FileDialog.ACCESS_USERDATA
+	)
+	return dialog
+
+
+## Whether the browser in 3. above would list anything the app may then open. A
+## sandboxed platform reaching this far has only its own data to offer.
+func _can_browse_freely() -> bool:
+	if _native != null:
+		return true
+	return (
+		DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE)
+		or not OS.has_feature("mobile")
+	)
+
+
+## Asks for a file. [signal FileDialog.file_selected] carries the answer and
+## [signal FileDialog.canceled] the refusal, whichever of the three presented it.
+func show_picker(fallback_size: Vector2i) -> void:
+	if _native == null:
+		popup_centered(fallback_size)
+		return
+	# One singleton serves every picker on screen, and a request left outstanding
+	# by a backgrounded app would otherwise still be listening when the next one
+	# is answered. Only the picker being shown is connected to it.
+	for connection: Dictionary in _native.file_selected.get_connections():
+		_native.file_selected.disconnect(connection["callable"])
+	for connection: Dictionary in _native.canceled.get_connections():
+		_native.canceled.disconnect(connection["callable"])
+	_native.file_selected.connect(_on_native_selected)
+	_native.canceled.connect(_on_native_cancelled)
+	_native.open_file(title, extensions())
+
+
+## The bare extensions in [member FileDialog.filters], whose entries look like
+## `*.gbc, *.gb ; Game Boy cartridge`. Empty means every file.
+func extensions() -> PackedStringArray:
+	var out := PackedStringArray()
+	for entry: String in filters:
+		for pattern: String in entry.get_slice(";", 0).split(","):
+			var extension: String = pattern.strip_edges().trim_prefix("*").trim_prefix(".")
+			if not extension.is_empty() and extension != "*" and not out.has(extension):
+				out.append(extension)
+	return out
+
+
+# The singleton is one object shared by every picker on screen, so each listens
+# only while its own request is outstanding.
+func _on_native_selected(path: String) -> void:
+	_release_native()
+	file_selected.emit(path)
+
+
+func _on_native_cancelled() -> void:
+	_release_native()
+	canceled.emit()
+
+
+func _release_native() -> void:
+	if _native == null:
+		return
+	if _native.file_selected.is_connected(_on_native_selected):
+		_native.file_selected.disconnect(_on_native_selected)
+		_native.canceled.disconnect(_on_native_cancelled)

--- a/game/launcher/launcher_file_picker.gd.uid
+++ b/game/launcher/launcher_file_picker.gd.uid
@@ -1,0 +1,1 @@
+uid://d2eo5k1vdlxqo

--- a/game/launcher/launcher_toast.gd
+++ b/game/launcher/launcher_toast.gd
@@ -7,9 +7,16 @@ extends Control
 ## It replaces a permanent status strip: a screen with nothing to report should
 ## look like a screen with nothing to report. Success and information fade out on
 ## their own; a refusal and a running import stay until they are replaced.
+##
+## A message that stays carries a dismiss button, because "until it is replaced"
+## is forever on a screen the player is not about to do anything else on. A
+## running import is the exception: it goes when the import does, and a button
+## offering to hide it would be offering to cancel something it cannot.
 
 ## How long a message that reports no problem stays up.
 const LINGER: float = 3.6
+## The shortest gap between two forced repaints during a blocking job.
+const PUMP_INTERVAL_MS: int = 60
 const ICON: float = 22.0
 
 var _theme: Gen2LauncherTheme = null
@@ -18,7 +25,12 @@ var _icon: Gen2LauncherIcon = null
 var _heading: Label = null
 var _detail: Label = null
 var _progress: ProgressBar = null
+var _close: Gen2LauncherButton = null
 var _timer: SceneTreeTimer = null
+## Wall clock of the last forced redraw, so a blocking import repaints often
+## enough to look alive and rarely enough to stay quick. See [method pump].
+var _last_pump: int = 0
+var _spin: float = 0.0
 ## The one fade in flight. Raising and hiding overlap often enough that two
 ## tweens would otherwise race for the same alpha and the later one would lose.
 var _fade: Tween = null
@@ -50,8 +62,9 @@ func _build() -> void:
 	# so it is drawn on the opposite side of the page from everything under it.
 	_card = Gen2LauncherCard.chip(_theme, Gen2LauncherTheme.RADIUS_MD, 16, 20)
 	_card.custom_minimum_size = Vector2(360, 0)
-	# Nothing in here is clickable, so nothing in here takes a click. The card
-	# is the width of the shelf's action row and sits exactly on top of it.
+	# The card is the width of the shelf's action row and sits exactly on top of
+	# it. It passes a press through to whatever is under it unless the dismiss
+	# button is up, which is the only thing in here that takes one.
 	_card.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	centre.add_child(_card)
 
@@ -70,6 +83,14 @@ func _build() -> void:
 	_detail = Gen2LauncherUI.muted(_theme, "")
 	_detail.add_theme_color_override("font_color", _theme.with_alpha(_theme.on_surface, 0.75))
 	text.add_child(_detail)
+
+	_close = Gen2LauncherButton.icon_only(
+		_theme, &"close", Gen2LauncherButton.Variant.ON_CHIP, Gen2LauncherUI.TOUCH_TARGET
+	)
+	_close.tooltip_text = "Dismiss"
+	_close.visible = false
+	_close.pressed.connect(hide_message)
+	line.add_child(_close)
 
 	_progress = ProgressBar.new()
 	_progress.max_value = 100.0
@@ -106,10 +127,16 @@ func show_message(kind: StringName, heading: String, detail: String) -> void:
 			colour = _theme.on_chip(_theme.accent)
 			glyph = &"refresh"
 	_icon.set_glyph(glyph, ICON, colour)
+	if kind != &"busy":
+		_spin = 0.0
+		_icon.rotation = 0.0
 	_heading.text = heading
 	_heading.add_theme_color_override("font_color", colour)
 	_detail.text = detail
 	_detail.visible = not detail.is_empty()
+	# Only what stays needs a way out, and only what the player can end. An
+	# import ends itself, and the toast under it is replaced when it does.
+	_close.visible = kind == &"error"
 	_raise()
 	if kind == &"error" or kind == &"busy":
 		_cancel_timer()
@@ -120,6 +147,34 @@ func show_message(kind: StringName, heading: String, detail: String) -> void:
 func set_progress(shown: bool, value: float = 0.0) -> void:
 	_progress.visible = shown
 	_progress.value = value
+
+
+## Repaints the screen from inside a job that is not giving it back.
+##
+## A cartridge import runs to the end on the main thread, so the tree never
+## reaches its next frame and the bar this toast is drawing does not move: the
+## whole ten to twenty seconds looks like a launcher that has stopped. Forcing a
+## frame is what a loading screen does, and the icon is turned by hand because
+## the tree is not running to animate it. Throttled, because the redraw is time
+## taken away from the import it is reporting.
+func pump() -> void:
+	if not _shown or not is_inside_tree() or DisplayServer.get_name() == "headless":
+		return
+	var now: int = Time.get_ticks_msec()
+	if now - _last_pump < PUMP_INTERVAL_MS:
+		return
+	_last_pump = now
+	# Nothing is animating the entrance either, so it is finished rather than
+	# left part way and the toast drawn at whatever alpha it had reached.
+	if _fade != null and _fade.is_valid():
+		_fade.kill()
+	modulate.a = 1.0
+	_card.position.y = 0.0
+	_spin = fmod(_spin + TAU / 8.0, TAU)
+	# The measured size is a layout pass away; the glyph's own is not.
+	_icon.pivot_offset = Vector2(ICON, ICON) * 0.5
+	_icon.rotation = _spin
+	RenderingServer.force_draw()
 
 
 func hide_message() -> void:

--- a/game/launcher/launcher_toast.gd
+++ b/game/launcher/launcher_toast.gd
@@ -11,12 +11,14 @@ extends Control
 ## A message that stays carries a dismiss button, because "until it is replaced"
 ## is forever on a screen the player is not about to do anything else on. A
 ## running import is the exception: it goes when the import does, and a button
-## offering to hide it would be offering to cancel something it cannot.
+## offering to hide it would be offering to cancel something it cannot. Its
+## glyph turns instead, which is the whole of the difference between a launcher
+## that is working and one that has stopped.
 
 ## How long a message that reports no problem stays up.
 const LINGER: float = 3.6
-## The shortest gap between two forced repaints during a blocking job.
-const PUMP_INTERVAL_MS: int = 60
+## How fast the busy glyph turns, in radians a second.
+const SPIN_RATE: float = 3.2
 const ICON: float = 22.0
 
 var _theme: Gen2LauncherTheme = null
@@ -27,10 +29,8 @@ var _detail: Label = null
 var _progress: ProgressBar = null
 var _close: Gen2LauncherButton = null
 var _timer: SceneTreeTimer = null
-## Wall clock of the last forced redraw, so a blocking import repaints often
-## enough to look alive and rarely enough to stay quick. See [method pump].
-var _last_pump: int = 0
 var _spin: float = 0.0
+var _spinning: bool = false
 ## The one fade in flight. Raising and hiding overlap often enough that two
 ## tweens would otherwise race for the same alpha and the later one would lose.
 var _fade: Tween = null
@@ -127,7 +127,8 @@ func show_message(kind: StringName, heading: String, detail: String) -> void:
 			colour = _theme.on_chip(_theme.accent)
 			glyph = &"refresh"
 	_icon.set_glyph(glyph, ICON, colour)
-	if kind != &"busy":
+	_spinning = kind == &"busy"
+	if not _spinning:
 		_spin = 0.0
 		_icon.rotation = 0.0
 	_heading.text = heading
@@ -149,32 +150,15 @@ func set_progress(shown: bool, value: float = 0.0) -> void:
 	_progress.value = value
 
 
-## Repaints the screen from inside a job that is not giving it back.
-##
-## A cartridge import runs to the end on the main thread, so the tree never
-## reaches its next frame and the bar this toast is drawing does not move: the
-## whole ten to twenty seconds looks like a launcher that has stopped. Forcing a
-## frame is what a loading screen does, and the icon is turned by hand because
-## the tree is not running to animate it. Throttled, because the redraw is time
-## taken away from the import it is reporting.
-func pump() -> void:
-	if not _shown or not is_inside_tree() or DisplayServer.get_name() == "headless":
+## Turns the busy glyph. The import that raises one hands the loop a frame at a
+## time (see `Gen2Main.IMPORT_YIELD_MS`), so this animates on those frames and
+## is what says the launcher is still working rather than stuck.
+func _process(delta: float) -> void:
+	if not _spinning:
 		return
-	var now: int = Time.get_ticks_msec()
-	if now - _last_pump < PUMP_INTERVAL_MS:
-		return
-	_last_pump = now
-	# Nothing is animating the entrance either, so it is finished rather than
-	# left part way and the toast drawn at whatever alpha it had reached.
-	if _fade != null and _fade.is_valid():
-		_fade.kill()
-	modulate.a = 1.0
-	_card.position.y = 0.0
-	_spin = fmod(_spin + TAU / 8.0, TAU)
-	# The measured size is a layout pass away; the glyph's own is not.
+	_spin = fmod(_spin + delta * SPIN_RATE, TAU)
 	_icon.pivot_offset = Vector2(ICON, ICON) * 0.5
 	_icon.rotation = _spin
-	RenderingServer.force_draw()
 
 
 func hide_message() -> void:

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -359,45 +359,15 @@ static func slider(
 	return line
 
 
-## The one file picker every launcher dialog is built from. Any new file-picking
-## UI goes through here rather than building its own [FileDialog].
-##
-## `use_native_dialog` is asked for unconditionally rather than gated on
-## `FEATURE_NATIVE_DIALOG_FILE`: [FileDialog] already makes that exact test
-## before it goes native and falls back to its own window when the platform says
-## no, so a second gate here can only refuse a picker the platform would have
-## given us. Android answers it and hands over the system picker, which grants
-## the one file chosen and is why the app declares no storage permission.
-##
-## iOS answers no: `DisplayServerIOS` implements no `file_dialog_show` at the
-## engine pin, so there is no system picker to open and the built-in browser is
-## what appears. Browsing the whole filesystem there lists paths
-## `FileAccess.open()` then refuses, so the browser is rooted at the app's own
-## Documents instead, which is the one place a sandboxed app may read and which
-## `UIFileSharingEnabled` lets the Files app put a cartridge into.
+## The one file picker every launcher dialog is built from. The platform
+## reasoning, and what shows it, are in [Gen2LauncherFilePicker].
 static func file_picker(
 	theme: Gen2LauncherTheme,
 	title_text: String,
 	mode: FileDialog.FileMode,
 	filters: PackedStringArray
-) -> FileDialog:
-	var dialog := FileDialog.new()
-	dialog.file_mode = mode
-	var native: bool = DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE)
-	dialog.access = (
-		FileDialog.ACCESS_FILESYSTEM
-		if native or not OS.has_feature("mobile")
-		else FileDialog.ACCESS_USERDATA
-	)
-	dialog.filters = filters
-	dialog.title = title_text
-	if dialog.access == FileDialog.ACCESS_USERDATA:
-		# The browser gives no room to explain itself, and a player looking at an
-		# empty folder needs to be told which folder it is.
-		dialog.title = "%s (this app's Documents folder)" % title_text
-	dialog.use_native_dialog = true
-	dialog.theme = theme.control_theme()
-	return dialog
+) -> Gen2LauncherFilePicker:
+	return Gen2LauncherFilePicker.create(theme, title_text, mode, filters)
 
 
 ## The square a mod's icon is drawn in, on a list row and on its own page.

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -16,8 +16,8 @@ var _settings: Gen2SettingsPage = null
 var _about: Gen2AboutPage = null
 var _title_backdrop: Gen2LauncherTitleBackdrop = null
 
-var _file_dialog: FileDialog = null
-var _mod_dialog: FileDialog = null
+var _file_dialog: Gen2LauncherFilePicker = null
+var _mod_dialog: Gen2LauncherFilePicker = null
 var _update_http: HTTPRequest = null
 
 var _importing: bool = false
@@ -106,8 +106,8 @@ func _build_dialogs() -> void:
 		window.files_dropped.connect(_on_files_dropped)
 
 
-func _picker(title: String, filters: PackedStringArray) -> FileDialog:
-	var dialog: FileDialog = Gen2LauncherUI.file_picker(
+func _picker(title: String, filters: PackedStringArray) -> Gen2LauncherFilePicker:
+	var dialog: Gen2LauncherFilePicker = Gen2LauncherUI.file_picker(
 		_palette, title, FileDialog.FILE_MODE_OPEN_FILE, filters
 	)
 	add_child(dialog)
@@ -221,7 +221,7 @@ func _confirm_mod_replace(path: String, mod_name: String) -> void:
 func _open_mod_dialog() -> void:
 	if _importing:
 		return
-	_mod_dialog.popup_centered(Vector2i(920, 620))
+	_mod_dialog.show_picker(Vector2i(920, 620))
 
 
 ## Asks the release API what the latest version is. Public so a test can drive
@@ -499,7 +499,7 @@ func _open_import_dialog(_game_id: StringName = &"") -> void:
 		"Choose a cartridge dump.",
 		"The importer identifies the cartridge by SHA-1, never by filename.",
 	)
-	_file_dialog.popup_centered(Vector2i(920, 620))
+	_file_dialog.show_picker(Vector2i(920, 620))
 
 
 func _on_file_selected(path: String) -> void:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -175,9 +175,11 @@ func _cartridge_detail(game_id: StringName, data: GameData) -> String:
 	return "Ready. %d save%s" % [ready_slots, "" if ready_slots == 1 else "s"]
 
 
-## Public driver used by tests and by non-interactive tooling.
+## Public driver used by tests and by non-interactive tooling. Awaitable because
+## the import gives the screen one frame to put its progress up before taking
+## the main thread for the rest of the job.
 func import_rom_path(path: String) -> void:
-	_on_file_selected(path)
+	await _on_file_selected(path)
 
 
 ## Installs a mod archive and loads it without a restart, which is safe here
@@ -444,6 +446,14 @@ func preview_sheet(view: StringName) -> void:
 		&"report":
 			select_page(&"about")
 			_about.open_report_sheet()
+		&"toast":
+			# The one message that stays until it is dismissed, over the shelf's
+			# own action row, which is what its dismiss button has to clear.
+			_set_status(
+				&"error",
+				"The last session ended unexpectedly.",
+				"About > Report a bug will save a file with the logs in it.",
+			)
 		&"binding":
 			select_page(&"settings")
 			var sheet: Gen2BindingSheet = Gen2BindingSheet.for_button(
@@ -509,6 +519,10 @@ func _on_file_selected(path: String) -> void:
 	_shelf.set_busy(true)
 	_shell.toast().set_progress(true, 0.0)
 	_set_status(&"busy", "Verifying cartridge...", path.get_file())
+	# The one frame the tree gets for the whole import: the toast has just been
+	# made visible, and a container sorts its children on a deferred call that
+	# would otherwise not be reached until the import had already finished.
+	await get_tree().process_frame
 
 	var identity: Dictionary = RomVerifier.identify(path)
 	if identity["status"] != RomVerifier.Status.OK:
@@ -561,6 +575,10 @@ func _on_import_progress(stage: String, done: int, total: int) -> void:
 	if total > 0:
 		_shell.toast().set_progress(true, float(done) / float(total) * 100.0)
 	_set_status(&"busy", "%s, %d/%d" % [stage.capitalize(), done, total], "")
+	# The import holds the main thread for the whole of its ten to twenty
+	# seconds, so this is the only place the screen it is reporting to can be
+	# repainted at all.
+	_shell.toast().pump()
 
 
 func _finish_import(success: bool, message: String) -> void:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -8,6 +8,10 @@ extends Control
 ## code from [Gen2LauncherShell] and the cards under it, so changing the
 ## appearance is a rebuild rather than a repaint.
 
+## How often the cartridge import hands the loop a frame back. Long enough that
+## the frames cost the import very little, short enough to read as motion.
+const IMPORT_YIELD_MS: int = 80
+
 var _palette: Gen2LauncherTheme = null
 var _shell: Gen2LauncherShell = null
 var _shelf: Gen2ShelfPage = null
@@ -519,9 +523,10 @@ func _on_file_selected(path: String) -> void:
 	_shelf.set_busy(true)
 	_shell.toast().set_progress(true, 0.0)
 	_set_status(&"busy", "Verifying cartridge...", path.get_file())
-	# The one frame the tree gets for the whole import: the toast has just been
-	# made visible, and a container sorts its children on a deferred call that
-	# would otherwise not be reached until the import had already finished.
+	# A frame before the first of the work, so the toast is laid out rather than
+	# merely built. The tree's own signal rather than the rendering server's:
+	# `frame_post_draw` is never emitted on a headless run, where this would
+	# then wait for a frame that is never drawn.
 	await get_tree().process_frame
 
 	var identity: Dictionary = RomVerifier.identify(path)
@@ -547,13 +552,18 @@ func _on_file_selected(path: String) -> void:
 		return
 
 	_set_status(&"busy", "Checking table layout...", path.get_file())
+	# The layout check reads the whole overworld once, which is most of a second
+	# on a phone, and it is the last thing before the import proper.
+	await get_tree().process_frame
 	var layout_check: Dictionary = RomImporter.verify_layout(rom)
 	if not layout_check["ok"]:
 		_finish_import(false, String(layout_check["message"]))
 		return
 
 	var importer := RomImporter.new()
-	var result: Dictionary = importer.import_rom(rom, _on_import_progress)
+	var result: Dictionary = await importer.import_rom(
+		rom, _on_import_progress, IMPORT_YIELD_MS
+	)
 	if not result["ok"]:
 		_finish_import(false, String(result["message"]))
 		return
@@ -575,10 +585,6 @@ func _on_import_progress(stage: String, done: int, total: int) -> void:
 	if total > 0:
 		_shell.toast().set_progress(true, float(done) / float(total) * 100.0)
 	_set_status(&"busy", "%s, %d/%d" % [stage.capitalize(), done, total], "")
-	# The import holds the main thread for the whole of its ten to twenty
-	# seconds, so this is the only place the screen it is reporting to can be
-	# repainted at all.
-	_shell.toast().pump()
 
 
 func _finish_import(success: bool, message: String) -> void:

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -26,9 +26,9 @@ var _details_box: VBoxContainer = null
 var _status_title: String = ""
 var _status_detail: String = ""
 var _name_input: LineEdit = null
-var _export_dialog: FileDialog = null
-var _slot_import_dialog: FileDialog = null
-var _file_dialog: FileDialog = null
+var _export_dialog: Gen2LauncherFilePicker = null
+var _slot_import_dialog: Gen2LauncherFilePicker = null
+var _file_dialog: Gen2LauncherFilePicker = null
 
 
 func _ready() -> void:
@@ -241,8 +241,10 @@ func _build_ui() -> void:
 	)
 	_slot_import_dialog.file_selected.connect(_import_slot_file)
 
-func _picker(title: String, mode: FileDialog.FileMode, filters: PackedStringArray) -> FileDialog:
-	var dialog: FileDialog = Gen2LauncherUI.file_picker(_palette, title, mode, filters)
+func _picker(
+	title: String, mode: FileDialog.FileMode, filters: PackedStringArray
+) -> Gen2LauncherFilePicker:
+	var dialog: Gen2LauncherFilePicker = Gen2LauncherUI.file_picker(_palette, title, mode, filters)
 	add_child(dialog)
 	return dialog
 
@@ -394,10 +396,10 @@ func _add_slot_management(body: VBoxContainer) -> void:
 	body.add_child(file_row)
 	file_row.add_child(_action("Edit save", Gen2LauncherButton.Variant.NEUTRAL, &"settings", _open_editor))
 	file_row.add_child(_action("Export", Gen2LauncherButton.Variant.NEUTRAL, &"", func() -> void:
-		_export_dialog.popup_centered(Vector2i(900, 600))
+		_export_dialog.show_picker(Vector2i(900, 600))
 	))
 	file_row.add_child(_action("Import", Gen2LauncherButton.Variant.NEUTRAL, &"", func() -> void:
-		_slot_import_dialog.popup_centered(Vector2i(900, 600))
+		_slot_import_dialog.show_picker(Vector2i(900, 600))
 	))
 	file_row.add_child(_action("Delete", Gen2LauncherButton.Variant.DANGER, &"trash", _request_delete))
 
@@ -546,7 +548,7 @@ func _request_new_game() -> void:
 
 
 func _request_import() -> void:
-	_file_dialog.popup_centered(Vector2i(900, 600))
+	_file_dialog.show_picker(Vector2i(900, 600))
 
 
 func _on_file_selected(path: String) -> void:

--- a/ios/.gdignore
+++ b/ios/.gdignore
@@ -1,0 +1,3 @@
+# The plugin sources are built by tools/build_ios_plugin.sh, not imported as
+# game resources: the static libraries would otherwise be packed into the game
+# data as well as linked into the app.

--- a/ios/plugins/file_picker/native_file_picker.gdip
+++ b/ios/plugins/file_picker/native_file_picker.gdip
@@ -1,0 +1,15 @@
+[config]
+name="NativeFilePicker"
+binary="native_file_picker.a"
+
+initialization="godot_native_file_picker_init"
+deinitialization="godot_native_file_picker_deinit"
+
+[dependencies]
+linked=[]
+embedded=[]
+system=["UniformTypeIdentifiers.framework"]
+
+capabilities=[]
+
+files=[]

--- a/ios/plugins/file_picker/native_file_picker.h
+++ b/ios/plugins/file_picker/native_file_picker.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  native_file_picker.h                                                  */
+/*  Part of pokerecomp. Licensed under the project's own terms.            */
+/**************************************************************************/
+
+#ifndef NATIVE_FILE_PICKER_H
+#define NATIVE_FILE_PICKER_H
+
+#include "core/error/error_list.h"
+#include "core/object/object.h"
+#include "core/variant/variant.h"
+
+#ifdef __OBJC__
+@class GodotDocumentPicker;
+#else
+typedef void GodotDocumentPicker;
+#endif
+
+// The system document picker, which the engine itself does not reach on this
+// platform: DisplayServerIOS implements no file_dialog_show, so FileDialog
+// falls back to browsing a sandbox the app is then refused every read of.
+//
+// One call, two answers. The file is handed over already copied into the app's
+// own storage, so the caller reads an ordinary path and nothing has to be told
+// when to let go of it.
+class NativeFilePicker : public Object {
+	GDCLASS(NativeFilePicker, Object);
+
+	static NativeFilePicker *singleton;
+	GodotDocumentPicker *delegate = nullptr;
+
+protected:
+	static void _bind_methods();
+
+public:
+	static NativeFilePicker *get_singleton();
+
+	// Opens the picker. p_extensions are bare extensions ("gbc", "zip"); an
+	// empty list offers every file.
+	Error open_file(const String &p_title, const PackedStringArray &p_extensions);
+
+	// Called by the Objective-C delegate, on the main thread.
+	void _deliver_file(const String &p_path);
+	void _deliver_cancelled();
+
+	NativeFilePicker();
+	~NativeFilePicker();
+};
+
+#endif // NATIVE_FILE_PICKER_H

--- a/ios/plugins/file_picker/native_file_picker.mm
+++ b/ios/plugins/file_picker/native_file_picker.mm
@@ -19,6 +19,7 @@ static NSString *const kImportsDirectory = @"picked";
 
 @interface GodotDocumentPicker : NSObject <UIDocumentPickerDelegate>
 + (void)cancel;
++ (void)sweep;
 @end
 
 @implementation GodotDocumentPicker
@@ -66,7 +67,16 @@ static NSString *const kImportsDirectory = @"picked";
 	});
 }
 
-// The app's own directory for picked files, emptied first.
+// The app's own directory for picked files, emptied first. Also emptied when the
+// plugin starts: the copy the last session imported from is nobody's until the
+// next pick otherwise, and a cartridge is a couple of megabytes of the player's
+// storage sitting in a folder the Files app shows them.
++ (void)sweep {
+	NSString *user_data = [NSString stringWithUTF8String:OS::get_singleton()->get_user_data_dir().utf8().get_data()];
+	NSURL *directory = [[NSURL fileURLWithPath:user_data] URLByAppendingPathComponent:kImportsDirectory];
+	[[NSFileManager defaultManager] removeItemAtURL:directory error:nil];
+}
+
 - (NSURL *)freshImportsDirectory {
 	NSString *user_data = [NSString stringWithUTF8String:OS::get_singleton()->get_user_data_dir().utf8().get_data()];
 	NSURL *directory = [[NSURL fileURLWithPath:user_data] URLByAppendingPathComponent:kImportsDirectory];
@@ -164,6 +174,7 @@ void NativeFilePicker::_bind_methods() {
 NativeFilePicker::NativeFilePicker() {
 	singleton = this;
 	delegate = [[GodotDocumentPicker alloc] init];
+	[GodotDocumentPicker sweep];
 }
 
 NativeFilePicker::~NativeFilePicker() {

--- a/ios/plugins/file_picker/native_file_picker.mm
+++ b/ios/plugins/file_picker/native_file_picker.mm
@@ -1,0 +1,172 @@
+/**************************************************************************/
+/*  native_file_picker.mm                                                 */
+/*  Part of pokerecomp. Licensed under the project's own terms.            */
+/**************************************************************************/
+
+#include "native_file_picker.h"
+
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
+// Where a picked file is left for the caller to read. Swept on every pick, so
+// one import's copy is the only one on disk and nothing accumulates in a
+// player's storage.
+static NSString *const kImportsDirectory = @"picked";
+
+@interface GodotDocumentPicker : NSObject <UIDocumentPickerDelegate>
++ (void)cancel;
+@end
+
+@implementation GodotDocumentPicker
+
+// The controller to present from: the topmost thing already on screen, so the
+// picker is not put underneath a sheet the game happens to have open.
+- (UIViewController *)topController {
+	UIWindow *window = [UIApplication sharedApplication].delegate.window;
+	if (!window) {
+		for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+			if (![scene isKindOfClass:[UIWindowScene class]]) {
+				continue;
+			}
+			for (UIWindow *candidate in ((UIWindowScene *)scene).windows) {
+				if (candidate.isKeyWindow) {
+					window = candidate;
+					break;
+				}
+			}
+		}
+	}
+	UIViewController *controller = window.rootViewController;
+	while (controller.presentedViewController) {
+		controller = controller.presentedViewController;
+	}
+	return controller;
+}
+
+- (void)presentWithTypes:(NSArray<UTType *> *)types {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		UIViewController *root = [self topController];
+		if (!root) {
+			[GodotDocumentPicker cancel];
+			return;
+		}
+		// asCopy leaves iOS to hand over a file the app already owns, in its own
+		// temporary directory. Without it the URL is security scoped, has to be
+		// opened and released around every read, and may still be in iCloud.
+		UIDocumentPickerViewController *picker =
+				[[UIDocumentPickerViewController alloc] initForOpeningContentTypes:types
+																			asCopy:YES];
+		picker.delegate = self;
+		picker.allowsMultipleSelection = NO;
+		[root presentViewController:picker animated:YES completion:nil];
+	});
+}
+
+// The app's own directory for picked files, emptied first.
+- (NSURL *)freshImportsDirectory {
+	NSString *user_data = [NSString stringWithUTF8String:OS::get_singleton()->get_user_data_dir().utf8().get_data()];
+	NSURL *directory = [[NSURL fileURLWithPath:user_data] URLByAppendingPathComponent:kImportsDirectory];
+	NSFileManager *files = [NSFileManager defaultManager];
+	[files removeItemAtURL:directory error:nil];
+	[files createDirectoryAtURL:directory withIntermediateDirectories:YES attributes:nil error:nil];
+	return directory;
+}
+
+- (void)documentPicker:(UIDocumentPickerViewController *)controller
+		didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls {
+	if (urls.count == 0) {
+		[GodotDocumentPicker cancel];
+		return;
+	}
+	NSURL *picked = urls.firstObject;
+	NSURL *destination = [[self freshImportsDirectory] URLByAppendingPathComponent:picked.lastPathComponent];
+	NSError *error = nil;
+	// A move rather than a copy: the source is the app's own temporary copy, and
+	// iOS is free to reclaim that directory whenever it likes.
+	if (![[NSFileManager defaultManager] moveItemAtURL:picked toURL:destination error:&error]) {
+		if (![[NSFileManager defaultManager] copyItemAtURL:picked toURL:destination error:&error]) {
+			ERR_PRINT(vformat("Could not take the picked file: %s",
+					String::utf8(error.localizedDescription.UTF8String)));
+			[GodotDocumentPicker cancel];
+			return;
+		}
+	}
+	NativeFilePicker *picker = NativeFilePicker::get_singleton();
+	if (picker) {
+		picker->_deliver_file(String::utf8(destination.path.UTF8String));
+	}
+}
+
+- (void)documentPickerWasCancelled:(UIDocumentPickerViewController *)controller {
+	[GodotDocumentPicker cancel];
+}
+
+// The singleton is gone once the engine has torn the plugin down, and a picker
+// still on screen can answer after that.
++ (void)cancel {
+	NativeFilePicker *picker = NativeFilePicker::get_singleton();
+	if (picker) {
+		picker->_deliver_cancelled();
+	}
+}
+
+@end
+
+NativeFilePicker *NativeFilePicker::singleton = nullptr;
+
+NativeFilePicker *NativeFilePicker::get_singleton() {
+	return singleton;
+}
+
+Error NativeFilePicker::open_file(const String &p_title, const PackedStringArray &p_extensions) {
+	NSMutableArray<UTType *> *types = [NSMutableArray array];
+	for (int i = 0; i < p_extensions.size(); i++) {
+		String extension = p_extensions[i].trim_prefix("*").trim_prefix(".");
+		if (extension.is_empty()) {
+			continue;
+		}
+		UTType *type = [UTType typeWithFilenameExtension:[NSString stringWithUTF8String:extension.utf8().get_data()]];
+		if (type) {
+			[types addObject:type];
+		}
+	}
+	// A cartridge extension is not a type any system knows, so the list it
+	// resolves to cannot be trusted to contain the player's own file. Data is
+	// always offered alongside, which is what keeps every file reachable.
+	[types addObject:UTTypeData];
+	[(GodotDocumentPicker *)delegate presentWithTypes:types];
+	return OK;
+}
+
+void NativeFilePicker::_deliver_file(const String &p_path) {
+	// Deferred rather than emitted here: this is a UIKit callback, and the
+	// launcher rebuilds itself out of the signal.
+	call_deferred(SNAME("emit_signal"), SNAME("file_selected"), p_path);
+}
+
+void NativeFilePicker::_deliver_cancelled() {
+	call_deferred(SNAME("emit_signal"), SNAME("canceled"));
+}
+
+void NativeFilePicker::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("open_file", "title", "extensions"), &NativeFilePicker::open_file);
+
+	// Named for FileDialog's own, so the one seam that opens a picker can treat
+	// the two the same way round.
+	ADD_SIGNAL(MethodInfo("file_selected", PropertyInfo(Variant::STRING, "path")));
+	ADD_SIGNAL(MethodInfo("canceled"));
+}
+
+NativeFilePicker::NativeFilePicker() {
+	singleton = this;
+	delegate = [[GodotDocumentPicker alloc] init];
+}
+
+NativeFilePicker::~NativeFilePicker() {
+	delegate = nullptr;
+	singleton = nullptr;
+}

--- a/ios/plugins/file_picker/native_file_picker_module.cpp
+++ b/ios/plugins/file_picker/native_file_picker_module.cpp
@@ -1,0 +1,28 @@
+/**************************************************************************/
+/*  native_file_picker_module.cpp                                         */
+/*  Part of pokerecomp. Licensed under the project's own terms.            */
+/**************************************************************************/
+
+#include "native_file_picker.h"
+
+#include "core/config/engine.h"
+#include "core/object/class_db.h"
+
+static NativeFilePicker *native_file_picker = nullptr;
+
+// Named in native_file_picker.gdip, which is what the iOS exporter calls these
+// from the generated Xcode project.
+void godot_native_file_picker_init() {
+	// Nothing else registers the class, and an unregistered one has no bound
+	// methods for a script to call.
+	NativeFilePicker::initialize_class();
+	native_file_picker = memnew(NativeFilePicker);
+	Engine::get_singleton()->add_singleton(Engine::Singleton("NativeFilePicker", native_file_picker));
+}
+
+void godot_native_file_picker_deinit() {
+	if (native_file_picker) {
+		memdelete(native_file_picker);
+		native_file_picker = nullptr;
+	}
+}

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -103,7 +103,7 @@ func test_launcher_reports_a_rejected_rom_without_importing() -> void:
 	file.store_buffer(bytes)
 	file.close()
 
-	_launcher.import_rom_path(_scratch_path)
+	await _launcher.import_rom_path(_scratch_path)
 	var snapshot: Dictionary = _launcher.launcher_snapshot()
 
 	assert_eq(snapshot["status"], "Import stopped.")
@@ -360,21 +360,44 @@ func test_a_silent_toast_is_not_on_screen_at_all() -> void:
 	assert_true(toast.visible)
 
 
-## And it never takes a click, shown or not. The toast is drawn over the bottom
-## centre of every launcher page, which is where the shelf puts Play and the
-## cache button; a card that stopped the mouse left both of them dead.
-func test_a_toast_never_takes_a_click_from_what_is_under_it() -> void:
+## The toast is drawn over the bottom centre of every launcher page, which is
+## where the shelf puts Play and the cache button, so a card that stopped the
+## mouse left both of them dead. Its dismiss button is the one exception, and it
+## is only there on a message that would otherwise stay up forever.
+func test_only_a_toasts_dismiss_button_takes_a_click_from_what_is_under_it() -> void:
 	await _open_launcher()
 	var toast: Gen2LauncherToast = _find_toast(_launcher)
-	toast.show_message(&"error", "Something", "happened")
 
+	toast.show_message(&"error", "Something", "happened")
+	await get_tree().process_frame
 	var stopping: Array[String] = []
 	_mouse_stoppers(toast, stopping)
-	assert_eq(stopping, [] as Array[String], "nothing in a toast is clickable")
+	assert_eq(stopping.size(), 1, "a refusal offers a way out and nothing else")
+
+	# An import ends itself, so offering to hide it would be offering to cancel
+	# something this cannot; information goes on its own.
+	for kind: StringName in [&"busy", &"info", &"success"]:
+		toast.show_message(kind, "Something", "happened")
+		await get_tree().process_frame
+		var others: Array[String] = []
+		_mouse_stoppers(toast, others)
+		assert_eq(others, [] as Array[String], "nothing is clickable on a %s toast" % kind)
+
+	toast.hide_message()
+	await get_tree().process_frame
+	var hidden: Array[String] = []
+	_mouse_stoppers(toast, hidden)
+	assert_eq(hidden, [] as Array[String], "and a toast that has gone takes nothing at all")
 
 
+## Every control in [param node]'s subtree that would actually take a press,
+## which is one that stops the mouse and is on screen to be pressed.
 func _mouse_stoppers(node: Node, out: Array[String]) -> void:
-	if node is Control and node.mouse_filter == Control.MOUSE_FILTER_STOP:
+	if (
+		node is Control
+		and (node as Control).mouse_filter == Control.MOUSE_FILTER_STOP
+		and (node as Control).is_visible_in_tree()
+	):
 		out.append("%s %s" % [node.get_class(), node.name])
 	for child: Node in node.get_children():
 		_mouse_stoppers(child, out)

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -113,10 +113,33 @@ func test_every_file_picker_asks_for_the_systems_own() -> void:
 	# One helper, so a screen added later cannot reintroduce its own gate.
 	for path: String in _scripts_under("res://game"):
 		var source: String = FileAccess.get_file_as_string(path)
-		if path.ends_with("launcher/launcher_ui.gd"):
+		if path.ends_with("launcher/launcher_file_picker.gd"):
 			continue
 		assert_false(source.contains("FileDialog.new()"), path)
 		assert_false(source.contains("FEATURE_NATIVE_DIALOG_FILE"), path)
+		assert_false(source.contains("popup_centered") and path.ends_with("save_screen.gd"), path)
+
+
+func test_a_picker_reads_its_extensions_out_of_its_own_filters() -> void:
+	# What the system picker is asked to offer comes from the same filter string
+	# the built-in browser uses, so the two can never be told different things.
+	var dialog: Gen2LauncherFilePicker = Gen2LauncherUI.file_picker(
+		_light,
+		"Choose",
+		FileDialog.FILE_MODE_OPEN_FILE,
+		PackedStringArray(["*.gbc, *.gb ; Game Boy cartridge", "*.zip ; Archive"]),
+	)
+	autofree(dialog)
+	assert_eq(
+		Array(dialog.extensions()),
+		["gbc", "gb", "zip"],
+		"bare, in order, and each one only once",
+	)
+	var everything: Gen2LauncherFilePicker = Gen2LauncherUI.file_picker(
+		_light, "Choose", FileDialog.FILE_MODE_OPEN_FILE, PackedStringArray(["*.* ; Every file"])
+	)
+	autofree(everything)
+	assert_eq(Array(everything.extensions()), [], "and a filter that means anything asks for it")
 
 
 func _scripts_under(root: String) -> Array[String]:

--- a/tools/build_ios_plugin.sh
+++ b/tools/build_ios_plugin.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Builds the iOS plugins under ios/plugins into the static libraries the iOS
+# exporter links into the generated Xcode project.
+#
+#   tools/build_ios_plugin.sh
+#
+# The engine is linked, not bundled: a plugin compiles against the headers of
+# the exact engine the export templates were built from, so GODOT_SOURCE must be
+# a checkout at the pin in DEVICES.md. Two libraries are built per plugin
+# because DEBUG_ENABLED changes what the engine's headers declare, and an
+# export-debug build links the one that matches it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GODOT_SOURCE="${GODOT_SOURCE:-$ROOT/.references/godot}"
+MIN_IOS="${MIN_IOS:-14.0}"
+
+if [ ! -f "$GODOT_SOURCE/core/object/object.h" ]; then
+	echo "No engine headers at $GODOT_SOURCE. See DEVICES.md for the checkout." >&2
+	exit 1
+fi
+
+SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+# The defines the engine's own iOS template is built with; anything that changes
+# a header has to match or the plugin and the engine disagree about layout.
+BASE_DEFINES=(-DIOS_ENABLED -DAPPLE_EMBEDDED_ENABLED -DUNIX_ENABLED
+	-DCOREAUDIO_ENABLED -DTHREADS_ENABLED -DNDEBUG)
+
+build_one() {
+	local plugin_dir="$1" target="$2" out="$3"
+	local defines=("${BASE_DEFINES[@]}")
+	[ "$target" = "debug" ] && defines+=(-DDEBUG_ENABLED)
+
+	local work
+	work="$(mktemp -d)"
+	local objects=()
+	local source object
+	for source in "$plugin_dir"*.cpp "$plugin_dir"*.mm; do
+		[ -e "$source" ] || continue
+		object="$work/$(basename "$source").o"
+		local arc=()
+		[ "${source##*.}" = "mm" ] && arc=(-fobjc-arc)
+		xcrun --sdk iphoneos clang++ -c "$source" -o "$object" \
+			-arch arm64 -isysroot "$SDK" "-miphoneos-version-min=$MIN_IOS" \
+			-std=gnu++17 -fno-exceptions -fblocks "${arc[@]}" \
+			"${defines[@]}" -I "$GODOT_SOURCE" -I "$GODOT_SOURCE/platform/ios" \
+			-I "$plugin_dir" \
+			-Wall -Werror=return-type -Wno-unused-parameter
+		objects+=("$object")
+	done
+	xcrun --sdk iphoneos libtool -static -o "$out" "${objects[@]}"
+	rm -rf "$work"
+	echo "  $(basename "$out")  $(du -h "$out" | tr -s '\t' ' ' | cut -d' ' -f1)"
+}
+
+for plugin_dir in "$ROOT"/ios/plugins/*/; do
+	[ -d "$plugin_dir" ] || continue
+	config="$(ls "$plugin_dir"*.gdip 2>/dev/null | head -1 || true)"
+	[ -n "$config" ] || continue
+	stem="$(basename "$config" .gdip)"
+	echo "$(basename "$plugin_dir"):"
+	build_one "$plugin_dir" debug "$plugin_dir$stem.debug.a"
+	build_one "$plugin_dir" release "$plugin_dir$stem.release.a"
+done

--- a/tools/import_rom.gd
+++ b/tools/import_rom.gd
@@ -36,7 +36,7 @@ func _initialize() -> void:
 
 	var failures: int = 0
 	for path: String in paths:
-		if not _handle(path, verify_only):
+		if not await _handle(path, verify_only):
 			failures += 1
 
 	print("\n%d/%d %s." % [
@@ -71,7 +71,7 @@ func _handle(path: String, verify_only: bool) -> bool:
 		return true
 
 	var importer := RomImporter.new()
-	var result: Dictionary = importer.import_rom(rom, _report)
+	var result: Dictionary = await importer.import_rom(rom, _report)
 	print("    %s" % result["message"])
 	if result["ok"]:
 		print("    cache: %s" % ProjectSettings.globalize_path(result["directory"]))

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -8,7 +8,7 @@ extends SceneTree
 ##       [scroll] [focus index] [fade step] [insets]
 ##
 ## `view` opens a sheet (`manage`, `touch`, `binding`, `bugs`, `report`,
-## `delete_mod`) or
+## `delete_mod`), raises the `toast` that stays until it is dismissed, or
 ## picks the mods page's own: `list`, `sources`, or `mod` with an id.
 ## `fade` is which step of the screen transition to photograph, 0 for none and 1
 ## to 4 for one of `FadeOutToWhite`'s own rows: the launcher's leave-the-screen
@@ -98,7 +98,7 @@ func _process(_delta: float) -> bool:
 		if STATES.has(_state):
 			_launcher.preview_slot_states(STATES[_state])
 		_launcher.select_page(StringName(_page))
-		if _view in ["manage", "touch", "binding", "delete_mod", "bugs", "report"]:
+		if _view in ["manage", "touch", "binding", "delete_mod", "bugs", "report", "toast"]:
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():
 			_launcher.preview_mods_view(StringName(_view), StringName(_mod))

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -8,7 +8,9 @@ extends SceneTree
 ##       [scroll] [focus index] [fade step] [insets]
 ##
 ## `view` opens a sheet (`manage`, `touch`, `binding`, `bugs`, `report`,
-## `delete_mod`), raises the `toast` that stays until it is dismissed, or
+## `delete_mod`), raises the `toast` that stays until it is dismissed, runs an
+## `import` of the cartridge named in the `mod id` slot so the progress the
+## launcher draws from inside that job can be photographed from outside, or
 ## picks the mods page's own: `list`, `sources`, or `mod` with an id.
 ## `fade` is which step of the screen transition to photograph, 0 for none and 1
 ## to 4 for one of `FadeOutToWhite`'s own rows: the launcher's leave-the-screen
@@ -46,6 +48,11 @@ var _mod: String = ""
 var _scroll: int = 0
 var _focus: int = -1
 var _fade: int = 0
+## Forced frames seen during an import, and which one is photographed: late
+## enough that the bar has something on it, early enough to be inside the job.
+var _forced: int = 0
+var _captured: bool = false
+const FORCED_FRAME_WANTED: int = 34
 
 
 func _initialize() -> void:
@@ -98,7 +105,12 @@ func _process(_delta: float) -> bool:
 		if STATES.has(_state):
 			_launcher.preview_slot_states(STATES[_state])
 		_launcher.select_page(StringName(_page))
-		if _view in ["manage", "touch", "binding", "delete_mod", "bugs", "report", "toast"]:
+		if _view == "import":
+			# Started rather than awaited: the import hands a frame back as it
+			# goes, so the ordinary shot below lands in the middle of it, which
+			# is the screen worth photographing.
+			_launcher.import_rom_path(_mod)
+		elif _view in ["manage", "touch", "binding", "delete_mod", "bugs", "report", "toast"]:
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():
 			_launcher.preview_mods_view(StringName(_view), StringName(_mod))


### PR DESCRIPTION
## The picker

`FileDialog` asks `DisplayServer.file_dialog_show` for the platform's own
picker. Windows, macOS, Linux and Android all answer it. `DisplayServerIOS`
implements it nowhere, so the request was refused and `FileDialog` fell back to
browsing a sandbox that then refuses every read. That is why a player could see
a file list on a phone and import nothing from it.

Upstream is not close to fixing it. godot#109484 is the only attempt, has had no
review since August 2025, conflicts with master, is milestoned `4.x`, and adds
three iOS-only virtual methods to the cross-platform `DisplayServer`.

So `ios/plugins/file_picker` is an iOS plugin around
`UIDocumentPickerViewController`, exposing a `NativeFilePicker` singleton. It
picks with `asCopy`, so the system hands over a file the app already owns: no
security-scoped URL to open and release around every read, and no iCloud file
that has not been downloaded yet. What the launcher reads is an ordinary path.

`Gen2LauncherFilePicker` is the one seam that chooses between the engine's
native dialog, this, and the built-in browser. Opening only; a save names a file
that does not exist yet, which is a different controller, so
`FILE_MODE_SAVE_FILE` keeps what it had.

The plugin links against the engine that exports it, so its libraries are built
from a source checkout at the pin rather than committed.

## What the first run on a real phone then showed

- A toast that stays could not be dismissed. Every node in one ignores the
  mouse, because the toast covers the shelf's Play and cache buttons and a card
  that stopped a press left both dead. What stays now carries a dismiss button,
  and that button is the only thing in a toast that takes a press.
- An import held the main thread for its whole ten to twenty seconds. It was
  already reporting stage and progress to a toast and none of it reached a
  frame. The toast gets one frame to lay itself out, then repaints from inside
  the job, turning its own glyph by hand.
- `keyboard_get_label_from_physical` was gated on the headless display server
  alone. Every handheld refuses it too, which put fourteen errors into every bug
  report a phone ever sent. A phone's report now opens with zero.
- A globalized `user://` already ends in a separator, so the report file named a
  path with a doubled one in it, on a screen whose purpose is to be read aloud.

## Checked

3576 tests pass and `validate.gd -- all` exits 0. On an iPhone 13 Pro: the boot
header reads `Files      the system picker, through the platform plugin`, the
picked cartridge lands in `Documents/picked`, its cache is built from there, and
the session error count went from 16 to 0.