### PR TITLE
Change the view from inside the game, and cover the switch

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -103,7 +103,7 @@ Two example mods are in `mods/examples/`, to copy into `user://mods/`:
 
 | Mod | Shows |
 |---|---|
-| `voxel_preview/` | A world renderer. Switch it on from its page in the launcher, or press `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it, on the native layer with a translucent text box and one registered setting |
+| `voxel_preview/` | A world renderer. Switch it on from its page in the launcher, from the start menu's MODS entry, or with `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it, on the native layer with a translucent text box and one registered setting |
 | `new_content/` | Every non-renderer surface in one file: a type and two matchups, a species with its own art, a move, a move effect, an item with its pocket and mart shelf, a named control axis, a visible-encounter population that reads the run's rules, two rebalancing patches, both event channels and the world channel's presentation mutator |
 
 The repository examples are development material and are excluded from every
@@ -251,7 +251,8 @@ belongs to the first one followed, so it is on screen once.
 ## Adding content
 
 `mods/examples/new_content/` is every non-renderer surface of the contract in one
-file, `api_version` 9: it registers a type and two chart exceptions, a species
+file: it declares the current `api_version` and its newest surface is 9's, and
+it registers a type and two chart exceptions, a species
 with its own decoded art, a move and its effect, an item with a pack pocket, a
 mart shelf and an evolution it causes, a named control axis, a world actor that
 walks behind the player, a fourth page on the stats screen and a visible-encounter population that reads the
@@ -827,15 +828,37 @@ keeps the built-in renderer on the other, and `gen2` selects both.
 | `view_surfaces(id) -> Dictionary` | `{world, battle}`, which of the two that id draws |
 | `selected_view() -> StringName` | The chosen id, whether or not its mod is loaded |
 | `select_view(id) -> Dictionary` | Chooses it, and persists the choice |
+| `view_changed(id)` | Signal, emitted whenever the chosen id actually changes |
 
 The choice is stored per installation in `user://mods_disabled.json` beside the
 disabled list, so it survives a restart the way a mod's own options do, and it is
 resolved every time a surface builds a renderer rather than once at load: a
 stored id whose mod is uninstalled or switched off draws with the built-in
 renderer and is not refused, and starts drawing again the moment the mod
-registers. Players reach it from the mod's own page in the launcher, which is
-where they already change what a mod does; `V` stays as the live switch where
-[Gen2DebugKeys] is enabled.
+registers.
+
+**Every way of choosing reaches the same live screen.** `select_view` announces
+the change on `view_changed`, and the world and battle screens rebuild what they
+are drawing with on it, so the launcher's mod page, the start menu's own VIEW
+row and `V` are one path. A mod neither needs nor should hold a screen; it may
+connect to the signal to hear about a switch.
+
+**Players reach the view from three places.** The mod's page in the launcher,
+where they already change what a mod does; the VIEW row at the top of the start
+menu's MODS entry, which is the host's own row and appears as soon as more than
+one view is registered, whether or not any mod registered a setting; and `V`
+where [Gen2DebugKeys] is enabled. A mod must not register a view button of its
+own: the host holds the one selection, and a mod's copy of it would be a second
+answer to the same question.
+
+**The switch is covered.** Building a renderer is a stall -- meshing a map can
+land whole on one frame -- and nothing on one thread can animate over its own
+freeze. `Gen2Screen.play_view_cover` closes with
+`StartTrainerBattle_SpeckleToBlack`'s own scatter on the renderer that is still
+running, builds the new one on the frame the screen is fully black, and opens
+with the same frames backwards. It is around the switch rather than at a caller,
+so every one of the three gets it, and renderers need nothing new: the outgoing
+one is asked for no frame it would not have drawn anyway.
 
 ## Replacing the battle renderer
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -568,6 +568,7 @@ func _ready() -> void:
 	_build_renderer()
 	if not _renderer_ready:
 		return
+	Gen2ModHost.instance().view_changed.connect(_on_view_changed)
 
 	## The cartridge has one APU. A screen that opened this one hands its own
 	## driver over so a cry here takes the channels the map music is holding
@@ -4507,9 +4508,14 @@ func select_view(id: StringName) -> Dictionary:
 	if not bool(result.get("ok", false)):
 		show_message("Renderer unavailable: %s" % String(result.get("reason", "unknown")))
 		return result
-	_build_renderer()
 	show_message("Renderer: %s" % Gen2ModHost.instance().view_label(id))
 	return result
+
+
+## The same one switch the overworld takes: see
+## [method Gen2WorldScreen._on_view_changed].
+func _on_view_changed(_id: StringName) -> void:
+	_screen.play_view_cover(_build_renderer)
 
 
 ## Selects the view after the current one, wrapping.

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -199,6 +199,19 @@ static func create(
 	return out
 
 
+## The scatter outro on its own, for a cover that is not a battle: no ball, no
+## flash and no BG map of squares, because nothing is being transitioned to.
+## `StartTrainerBattle_SetUpForRandomScatterOutro` and `..._SpeckleToBlack` are
+## the whole of it, which is what a view switch is dressed in.
+static func create_outro(rng: RandomNumberGenerator = null) -> Gen2BattleTransition:
+	var out := Gen2BattleTransition.new()
+	out._scene = [&"scatter_setup", &"scatter"]
+	out._rng = rng if rng != null else RandomNumberGenerator.new()
+	out._cells = PackedByteArray()
+	out._cells.resize(COLUMNS * ROWS)
+	return out
+
+
 ## Which scene of the jumptable is running, for a test or a trace: `ball`,
 ## `bgmap`, `flash`, `next`, one of the four setups or one of the four outros.
 func scene() -> StringName:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -167,6 +167,11 @@ signal option_changed(id: StringName, key: StringName, value: Variant)
 ## Emitted when one of a mod's own registered actions is pressed or released,
 ## whichever device produced it. See [method register_action].
 signal action_changed(id: StringName, key: StringName, pressed: bool)
+## Emitted whenever [method select_view] changes the view, whichever surface
+## chose it. A live screen rebuilds what it is drawing with on this, which is
+## what makes one switch of one host state reach the world, the battle and the
+## key that cycles them; nothing a mod registered changes.
+signal view_changed(id: StringName)
 
 static var _instance: Gen2ModHost = null
 ## Which mod packs this process has mounted. Static because a resource pack
@@ -466,15 +471,19 @@ func selected_view() -> StringName:
 ## ever selects either.
 ##
 ## Persisted per installation, so the choice survives a restart the way a mod's
-## own options do. The caller rebuilds whatever it is showing; nothing here
-## touches a live screen.
+## own options do. A live screen rebuilds on [signal view_changed], so the
+## launcher's page, the start menu's row and the key that cycles views are one
+## path rather than three, and a caller that holds no screen needs nothing.
 func select_view(id: StringName) -> Dictionary:
 	if id != BUILT_IN_RENDERER and not _world_renderers.has(id) \
 		and not _battle_renderers.has(id):
 		return {"ok": false, "reason": &"unknown_renderer", "detail": String(id)}
+	var changed: bool = _selected_view != id
 	_selected_view = id
 	if not Gen2ModState.set_selected_view(id):
 		return {"ok": false, "reason": &"view_not_written", "detail": String(id)}
+	if changed:
+		view_changed.emit(id)
 	return {"ok": true, "id": id}
 
 

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -40,7 +40,7 @@ const FILENAME: String = "mod.json"
 ## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
 ## host that has never heard of either ignores the field, so a mod that ships
 ## art still installs on an older launcher and simply has no face there.
-const API_VERSION: int = 11
+const API_VERSION: int = 12
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -103,6 +103,18 @@ var _draw_scale: float = 1.0
 var _interface: Control = null
 ## Drawn between the content and the interface: see [member interface_masked].
 var _mask: Control = null
+## The cover a view switch is hidden behind, above both layers rather than
+## inside either: see [method play_view_cover].
+var _cover: Control = null
+var _cover_cells: PackedByteArray = PackedByteArray()
+## Each frame of the close, kept so the open is the same picture backwards.
+var _cover_frames: Array[PackedByteArray] = []
+var _cover_index: int = 0
+var _cover_opening: bool = false
+## What the black middle runs. Cleared as it is called, so a cover interrupted
+## after that point cannot run it twice.
+var _cover_rebuild: Callable = Callable()
+var _cover_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 func _ready() -> void:
@@ -124,6 +136,17 @@ func _ready() -> void:
 	# does, so the rectangle it was clipped against does it instead.
 	_interface.clip_contents = true
 	_viewport.add_child(_interface)
+	## Outside the viewport, because it covers a native renderer as well: the
+	## viewport is composited over the native layer and a cover inside it would
+	## leave a 3D view showing through.
+	_cover = Control.new()
+	_cover.name = "Cover"
+	_cover.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_cover.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_cover.visible = false
+	_cover.draw.connect(_draw_cover)
+	add_child(_cover)
+	set_process(false)
 	_fit()
 
 
@@ -254,6 +277,148 @@ func viewport() -> SubViewport:
 ## interface sits, which is above whatever [method display_content] drew.
 func interface_layer() -> Control:
 	return _interface
+
+
+## Hides a view switch behind the cartridge's own way of going black.
+##
+## Building a renderer is a stall: a 3D view meshes a whole map on the frame it
+## is turned on, and nothing on one thread can animate over its own freeze. Only
+## the middle is frozen, though, and the middle is a still picture, so the close
+## is spent on the renderer that is still running, [param rebuild] is called on
+## the frame the screen is fully black, and the open is spent on the one it
+## built. The player sees a wipe with a long middle instead of a jump.
+##
+## `StartTrainerBattle_SpeckleToBlack` is the pattern
+## ([method Gen2BattleTransition.create_outro]), so the switch reads as the
+## game's own and costs no art. The open is the close's frames backwards, which
+## is the same picture rather than a second animation.
+##
+## This is around the switch rather than at one caller: every way of choosing a
+## view reaches [signal Gen2ModHost.view_changed], and every screen listening to
+## it comes through here. A screen that cannot animate -- a headless check, a
+## screenshot driver, a screen not in the tree -- rebuilds at once, because a
+## cover measured by nobody is only a delay.
+func play_view_cover(rebuild: Callable) -> void:
+	if not _can_animate_cover():
+		if rebuild.is_valid():
+			rebuild.call()
+		return
+	## A second switch before the first has finished: the first one's rebuild is
+	## owed either way, and a cover restarted from black has nothing to hide.
+	_run_cover_rebuild()
+	_cover_rebuild = rebuild
+	_cover_frames = _cover_close_frames()
+	_cover_index = 0
+	_cover_opening = false
+	_cover_clock.reset()
+	_cover_cells = _cover_frames[0]
+	_cover.visible = true
+	_cover.queue_redraw()
+	set_process(true)
+
+
+## Whether a view switch is still being covered.
+func view_cover_active() -> bool:
+	return _cover != null and _cover.visible
+
+
+## Spends the whole cover now, for a caller that wants the switch done rather
+## than shown: a tool taking a photograph, or a test.
+func settle_view_cover() -> void:
+	_run_cover_rebuild()
+	_cover_frames = []
+	_cover_cells = PackedByteArray()
+	_cover_index = 0
+	_cover_opening = false
+	if _cover != null:
+		_cover.visible = false
+	set_process(false)
+
+
+## Spends [param frames] hardware frames of a running cover, for a tool
+## photographing the wipe itself rather than what it uncovers. The clock stops
+## with it: a driver that steps the cover by hand owns its pace, or the frames
+## it spends taking the picture would finish the wipe underneath it.
+func step_view_cover(frames: int) -> void:
+	set_process(false)
+	for _frame: int in frames:
+		if not view_cover_active():
+			return
+		_advance_cover()
+
+
+func _process(delta: float) -> void:
+	if not view_cover_active():
+		set_process(false)
+		return
+	for _frame: int in _cover_clock.tick(delta):
+		_advance_cover()
+		if not view_cover_active():
+			return
+
+
+## One hardware frame of the cover: down the close, the rebuild on the black
+## frame, then back up the same frames.
+func _advance_cover() -> void:
+	if not _cover_opening:
+		_cover_index += 1
+		if _cover_index >= _cover_frames.size():
+			_run_cover_rebuild()
+			_cover_opening = true
+			_cover_index = _cover_frames.size() - 1
+	else:
+		_cover_index -= 1
+		if _cover_index < 0:
+			settle_view_cover()
+			return
+	_cover_cells = _cover_frames[_cover_index]
+	_cover.queue_redraw()
+
+
+func _run_cover_rebuild() -> void:
+	if not _cover_rebuild.is_valid():
+		return
+	var rebuild: Callable = _cover_rebuild
+	_cover_rebuild = Callable()
+	rebuild.call()
+
+
+## The close, frame by frame, ending on the screen fully black.
+func _cover_close_frames() -> Array[PackedByteArray]:
+	var out: Array[PackedByteArray] = []
+	var outro: Gen2BattleTransition = Gen2BattleTransition.create_outro()
+	out.append(outro.cells().duplicate())
+	while outro.advance_frame():
+		out.append(outro.cells().duplicate())
+	return out
+
+
+func _can_animate_cover() -> bool:
+	return is_inside_tree() and not Engine.is_editor_hint() 		and DisplayServer.get_name() != "headless"
+
+
+## The transition's twenty by eighteen cells over the whole control, letterbox
+## included: what it covers is the switch, not the hardware screen, and a
+## renderer drawing at window resolution has no 160x144 rectangle to stop at.
+func _draw_cover() -> void:
+	if _cover_cells.is_empty():
+		return
+	var cell := Vector2(
+		size.x / float(Gen2BattleTransition.COLUMNS),
+		size.y / float(Gen2BattleTransition.ROWS),
+	)
+	for row: int in Gen2BattleTransition.ROWS:
+		for column: int in Gen2BattleTransition.COLUMNS:
+			if _cover_cells[row * Gen2BattleTransition.COLUMNS + column] 				== Gen2BattleTransition.CELL_NONE:
+				continue
+			_cover.draw_rect(
+				Rect2(
+					Vector2(float(column) * cell.x, float(row) * cell.y),
+					## Rounded up, so two cells meet rather than leave a seam.
+					Vector2(ceilf(cell.x), ceilf(cell.y))
+				),
+				Color.BLACK, true
+			)
 
 
 ## The letterbox, drawn rather than left empty: four rectangles around the

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -198,9 +198,14 @@ var _save_result: Dictionary = {}
 
 var _options_menu: Gen2WorldOptionsMenu = null
 
+## The two kinds of row the MODS entry holds: see [method _mod_rows].
+const MOD_ROW_VIEW: StringName = &"view"
+const MOD_ROW_MOD: StringName = &"mod"
+
 ## The MODS entry: which mod is being configured and where each cursor sits.
 ## The rows themselves are the host's registrations, read fresh on every render
-## so a value changed from the launcher is never shown stale.
+## so a value changed from the launcher is never shown stale. The VIEW row in
+## front of them is the host's own and belongs to no mod: see [method _mod_rows].
 var _mod_ids: Array[StringName] = []
 var _mod_cursor: int = 0
 var _mod_id: StringName = &""
@@ -208,8 +213,8 @@ var _mod_option_cursor: int = 0
 
 ## The cartridge's own screens, drawn into whichever [Gen2Screen] the host
 ## handed over. `StartMenu`'s box sits over the map, so it goes into the world's
-## own screen rather than one of this node's; without one, the panel below
-## stands in, which is what a test or the launcher gets.
+## own screen rather than one of this node's; without one, nothing is drawn at
+## all, which is what a test or the launcher gets.
 var _screen: Gen2Screen = null
 var _view: TextureRect = null
 var _page: Gen2StartMenuPage = null
@@ -218,8 +223,6 @@ var _page: Gen2StartMenuPage = null
 var _target_page: Gen2PartyMenuPage = null
 ## The target list's icon clock.
 var _target_clock := Gen2WorldAnimation.FrameClock.new()
-## The panel's own two roots, hidden whenever a cartridge screen is up.
-
 
 
 func _ready() -> void:
@@ -416,9 +419,14 @@ func _move(direction: Vector2i) -> void:
 				_persist_options()
 				_render_options_menu()
 		Mode.MODS:
-			if direction.y != 0 and not _mod_ids.is_empty():
-				_mod_cursor = wrapi(_mod_cursor + signi(direction.y), 0, _mod_ids.size())
+			var mod_rows: Array = _mod_rows()
+			if mod_rows.is_empty():
+				return
+			if direction.y != 0:
+				_mod_cursor = wrapi(_mod_cursor + signi(direction.y), 0, mod_rows.size())
 				_render_mods()
+			elif direction.x != 0 and _mod_view_row(mod_rows):
+				_cycle_view(signi(direction.x))
 		Mode.MOD_OPTIONS:
 			var rows: Array = _mod_options()
 			if rows.is_empty():
@@ -491,9 +499,12 @@ func _confirm() -> void:
 		Mode.OPTIONS:
 			if _options_menu.is_cancel():
 				_open_list_mode()
+		## The VIEW row is read with left and right, the way a value row is, so
+		## A does nothing on it.
 		Mode.MODS:
-			if _mod_cursor >= 0 and _mod_cursor < _mod_ids.size():
-				_open_mod_options_mode(_mod_ids[_mod_cursor])
+			var chosen: Dictionary = _mod_row()
+			if StringName(chosen.get("kind", &"")) == MOD_ROW_MOD:
+				_open_mod_options_mode(StringName(chosen["id"]))
 		## A ladder row is read with left and right, so A does nothing on one, the
 		## way it does on the cartridge's own value rows. A button row is the
 		## exception: pressing it is the whole setting.
@@ -610,7 +621,52 @@ func _render_options_menu() -> void:
 func _open_mods_mode() -> void:
 	_mode = Mode.MODS
 	_mod_ids = Gen2ModHost.instance().option_mod_ids()
-	_mod_cursor = clampi(_mod_cursor, 0, maxi(_mod_ids.size() - 1, 0))
+	_mod_cursor = clampi(_mod_cursor, 0, maxi(_mod_rows().size() - 1, 0))
+	_render_mods()
+
+
+## The rows the MODS entry shows: the host's own VIEW row where the player has
+## more than one view to choose from, then one row per mod that registered a
+## setting.
+##
+## The view is the host's and not any mod's: `Gen2ModHost` holds one selection
+## for both surfaces, persists it and draws it on the launcher's mod page, and a
+## mod registering a VIEW button of its own would be a private copy of that
+## state, six of them for six mods. This is the same list on the surface a
+## player is already changing what a mod does from, which is the only place a
+## shipped build has: `V` is behind [method Gen2DebugKeys.enabled].
+func _mod_rows() -> Array:
+	var rows: Array = []
+	if Gen2ModHost.instance().view_ids().size() > 1:
+		rows.append({"kind": MOD_ROW_VIEW, "id": &""})
+	for id: StringName in _mod_ids:
+		rows.append({"kind": MOD_ROW_MOD, "id": id})
+	return rows
+
+
+## The row the cursor is on, empty where there is none.
+func _mod_row() -> Dictionary:
+	var rows: Array = _mod_rows()
+	if _mod_cursor < 0 or _mod_cursor >= rows.size():
+		return {}
+	return rows[_mod_cursor]
+
+
+func _mod_view_row(rows: Array) -> bool:
+	return _mod_cursor >= 0 and _mod_cursor < rows.size() \
+		and StringName(rows[_mod_cursor].get("kind", &"")) == MOD_ROW_VIEW
+
+
+## One step along the host's view list, wrapping. The switch is the host's, so
+## the live screens rebuild on [signal Gen2ModHost.view_changed] and this row
+## neither knows nor cares which of them is up.
+func _cycle_view(step: int) -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var ids: Array[StringName] = host.view_ids()
+	if ids.size() < 2:
+		return
+	var at: int = maxi(ids.find(host.selected_view()), 0)
+	host.select_view(ids[posmod(at + step, ids.size())])
 	_render_mods()
 
 
@@ -1935,8 +1991,14 @@ func _hardware_image() -> Image:
 			)
 		Mode.MODS:
 			var rows: Array = []
-			for id: StringName in _mod_ids:
-				rows.append({"label": _mod_name(id), "value": ""})
+			for row: Dictionary in _mod_rows():
+				if StringName(row["kind"]) == MOD_ROW_VIEW:
+					var host: Gen2ModHost = Gen2ModHost.instance()
+					rows.append({
+						"label": "VIEW", "value": host.view_label(host.selected_view()),
+					})
+					continue
+				rows.append({"label": _mod_name(StringName(row["id"])), "value": ""})
 			var window: Dictionary = _option_window(rows, _mod_cursor)
 			return _page.render_options(window["rows"], window["cursor"])
 		Mode.MOD_OPTIONS:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -33,6 +33,10 @@ const MOVEMENT_BIKE: StringName = &"bike"
 ## constants/sprite_constants.asm's first real id, and what GetMonSprite answers
 ## for a variable sprite no script has assigned yet.
 const SPRITE_CHRIS: int = 1
+## `GetMonSprite`'s two `.BreedMon` bytes, which are the species in the day
+## care's own slots rather than an entry in any sprite table.
+const SPRITE_DAY_CARE_MON_1: int = 0xE0
+const SPRITE_DAY_CARE_MON_2: int = 0xE1
 const TRAINER_SHOCK_EMOTE: int = 0
 ## `SeenByTrainerScript`'s `showemote EMOTE_SHOCK, LAST_TALKED, 30`
 ## (engine/events/trainer_scripts.asm), read the way every other `showemote` is:
@@ -6346,6 +6350,45 @@ func _on_world_state_changed() -> void:
 	set_object_time(object_hour, object_time_of_day)
 
 
+## `GetMonSprite` itself: a variable slot resolves through the table and is
+## re-read, because a script may assign one a Pokemon sprite, and an unassigned
+## slot answers `WALKING_SPRITE`. A day care byte keeps its own id here and is
+## read for its species by [method _mon_icon_for_sprite]; an empty slot is
+## `.NoBreedmon`, which is the same 1.
+func _resolved_sprite(sprite_number: int) -> int:
+	var resolved: int = sprite_number
+	## The table is a byte per slot and a slot may name another one, so the walk
+	## is bounded rather than trusted to end.
+	for _pass: int in 4:
+		if resolved == SPRITE_DAY_CARE_MON_1 or resolved == SPRITE_DAY_CARE_MON_2:
+			return resolved if _day_care_species(resolved) > 0 else SPRITE_CHRIS
+		if resolved < Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE:
+			return resolved
+		var assigned: int = int(_variable_sprites.get(resolved, 0))
+		if assigned == 0:
+			return SPRITE_CHRIS
+		resolved = assigned
+	return SPRITE_CHRIS
+
+
+## `SpriteMons` for the thirty-five reusable shapes, and `ReadMonMenuIcon` on
+## the species itself for the two day care bytes, which is what
+## `LoadOverworldMonIcon` does with `wBreedMon1Species` and `wBreedMon2Species`.
+func _mon_icon_for_sprite(sprite_number: int) -> int:
+	if sprite_number == SPRITE_DAY_CARE_MON_1 or sprite_number == SPRITE_DAY_CARE_MON_2:
+		return data.mon_menu_icon(_day_care_species(sprite_number)) if data != null else 0
+	return Gen2WorldSprite.mon_icon_for_sprite(sprite_number)
+
+
+func _day_care_species(sprite_number: int) -> int:
+	if state == null:
+		return 0
+	var mon: Gen2SaveMon = state.day_care_mon(
+		0 if sprite_number == SPRITE_DAY_CARE_MON_1 else 1
+	)
+	return 0 if mon == null else mon.species
+
+
 ## One row of a map's object events as a live object.
 ##
 ## `GetMonSprite`'s `.Variable` branch reads wVariableSprites and falls through
@@ -6355,17 +6398,15 @@ func _on_world_state_changed() -> void:
 ## script has assigned yet is drawn, occupies its cell and is talkable.
 ## Copycat's House 2F is where it matters: SPRITE_COPYCAT is $fb and only the
 ## Copycat's own script assigns it, so without this she could not be reached to
-## run it. An object that should not be there at all is masked by
-## [method load_object_masks], not by this fallback.
+## run it. Route 37's twins are the same rule seen from the other end: their
+## SPRITE_WEIRD_TREE is Sudowoodo's slot and only Route 36's own script assigns
+## it, so a save that has not met Sudowoodo really does stand two copies of the
+## player's sprite on that route. An object that should not be there at all is
+## masked by [method load_object_masks], not by this fallback.
 func _object_from_event(index: int, value: Dictionary) -> Gen2WorldObject:
-	var source_sprite_number: int = int(value.get("sprite", 0))
-	var sprite_number: int = int(_variable_sprites.get(
-		source_sprite_number, source_sprite_number
-	))
-	if sprite_number >= Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE:
-		sprite_number = SPRITE_CHRIS
+	var sprite_number: int = _resolved_sprite(int(value.get("sprite", 0)))
 	var sprite: Gen2WorldSprite = null
-	var icon_number: int = Gen2WorldSprite.mon_icon_for_sprite(sprite_number)
+	var icon_number: int = _mon_icon_for_sprite(sprite_number)
 	if icon_number > 0:
 		sprite = data.overworld_icon(icon_number)
 	else:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -14,6 +14,10 @@ const SERVICE_SCENE: PackedScene = preload("res://game/world/world_service_scree
 const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_screen.tscn")
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
+## How far into a view switch's close [method preview_view_cover] photographs:
+## part way down the scatter, where the wipe is readable and the screen is not
+## yet black.
+const PREVIEW_COVER_FRAMES: int = 10
 ## constants/sfx_constants.asm's SFX_JUMP_OVER_LEDGE (comments there are hex,
 ## confirmed against neighbouring $0a/$0f/$1a), played by .TryJump as the hop
 ## starts. Played directly rather than through _handle_audio_request(), which
@@ -411,6 +415,7 @@ func _build_world() -> void:
 	_animation.configure(_world, _render_time_of_day())
 	_apply_screen_fill()
 	_build_renderer()
+	Gen2ModHost.instance().view_changed.connect(_on_view_changed)
 	_screen.view_size_changed.connect(_on_view_size_changed)
 	_screen_base_position = _screen.position
 	_audio_player = AUDIO_PLAYER_SCRIPT.new()
@@ -613,10 +618,22 @@ func select_view(id: StringName) -> Dictionary:
 		_script_prompt = "Renderer unavailable: %s" % String(result.get("reason", "unknown"))
 		_refresh_labels()
 		return result
-	_build_renderer()
 	_script_prompt = "Renderer: %s" % Gen2ModHost.instance().view_label(id)
 	_refresh_labels()
 	return result
+
+
+## Spends the whole of a view switch's cover now, for a caller that wants the
+## renderer swapped rather than the swap shown: a tool taking a photograph.
+func settle_view_cover() -> void:
+	_screen.settle_view_cover()
+
+
+## The switch itself, wherever it was made: this screen, the launcher's mod page
+## or the start menu's own row. The renderer is built inside the cover rather
+## than here, because building one is a stall of its own.
+func _on_view_changed(_id: StringName) -> void:
+	_screen.play_view_cover(_build_renderer)
 
 
 ## Selects the view after the current one, wrapping. One key can then cycle every
@@ -3249,6 +3266,33 @@ func preview_start_menu() -> void:
 		_open_start_menu()
 		return
 	_start_menu_host.handle_button(Gen2Button.DOWN)
+
+
+## Public screenshot driver for the cover a view switch is hidden behind: the
+## switch itself, photographed part way down its close. See
+## [method Gen2Screen.play_view_cover].
+func preview_view_cover() -> void:
+	## A `view=` argument has already chosen one and left its cover running; on
+	## its own the driver switches to the next view itself.
+	if not _screen.view_cover_active() and not cycle_view().get("ok", false):
+		return
+	_screen.step_view_cover(PREVIEW_COVER_FRAMES)
+
+
+## Public screenshot driver for the MODS entry, which is where a player changes
+## the view on a shipped build: one call opens the menu and walks to the row,
+## and the picture is the host's own VIEW row at the top of it.
+func preview_mod_views() -> void:
+	if _world == null or _data == null:
+		return
+	if _start_menu_host == null:
+		_injected_save = _embedded_party_save()
+		_open_start_menu()
+	if _start_menu_host == null:
+		return
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_MODS):
+		return
+	_start_menu_host.handle_button(Gen2Button.A)
 
 
 ## Public screenshot driver for `_Option`, which is what the start menu's own

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -98,7 +98,11 @@ static func build(
 		if not String(gate).is_empty() and not bool(passes.get(gate, false)):
 			continue
 		if entry["kind"] == ITEM_EXIT:
-			if not Gen2ModHost.instance().option_mod_ids().is_empty():
+			## The entry carries the host's own VIEW row as well as the mods'
+			## settings, so a player with a view to switch to reaches it with no
+			## mod having registered anything.
+			if not Gen2ModHost.instance().option_mod_ids().is_empty() \
+				or Gen2ModHost.instance().view_ids().size() > 1:
 				rows.append(_entry(ITEM_MODS, "MODS", true))
 			rows.append_array(Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_START))
 		var label: String = String(entry["label"])

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 11,
+	"api_version": 12,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 11,
+	"api_version": 12,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -14,6 +14,22 @@ const ITEMFINDER: int = 0x37
 const CARD_KEY: int = 0x7F
 const OLD_ROD: int = Gen2WorldInventory.ITEM_OLD_ROD
 
+## The least a registered world renderer can be, for the VIEW row's own case.
+const RENDERER_SOURCE: String = """extends Node2D
+
+func set_world(_world, _animation = null) -> void:
+	pass
+
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+
+func refresh() -> void:
+	pass
+
+func refresh_animation() -> void:
+	pass
+"""
+
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
 
@@ -151,6 +167,41 @@ func test_mod_settings_use_the_hardware_option_screen() -> void:
 	assert_true((host.get("_view") as TextureRect).visible)
 
 	Gen2ModHost.reset()
+
+
+## R36: `V` is behind `Gen2DebugKeys.enabled`, so a shipped build had exactly
+## one place to change the view and it was the launcher. The row is the host's
+## own, it is in front of the mods' settings, and the entry is reachable with no
+## mod having registered a setting at all.
+func test_the_view_row_is_reachable_and_switches_the_live_screen() -> void:
+	var script := GDScript.new()
+	script.source_code = RENDERER_SOURCE
+	script.reload()
+	assert_true(Gen2ModHost.instance().register_world_renderer(&"voxel", script)["ok"])
+	await _open_world()
+	var built_in: Node = _world_screen._renderer
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_MODS)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.MODS)
+	assert_eq(host.get("_mod_cursor"), 0)
+
+	host.handle_button(Gen2Button.RIGHT)
+
+	assert_eq(Gen2ModHost.instance().selected_view(), &"voxel")
+	assert_ne(_world_screen._renderer, built_in, "the live screen kept its renderer")
+	## A on a value row does nothing, the way it does on the cartridge's own.
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.MODS)
+
+	host.handle_button(Gen2Button.LEFT)
+	assert_eq(Gen2ModHost.instance().selected_view(), Gen2ModHost.BUILT_IN_RENDERER)
+
+	Gen2ModHost.reset()
+	DirAccess.remove_absolute(Gen2ModState.PATH)
+	Gen2ModState.reload()
 
 
 func test_long_mod_list_scrolls_the_hardware_option_screen() -> void:

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -221,6 +221,28 @@ func _count(cells: PackedByteArray, value: int) -> int:
 	return out
 
 
+## The view switch's cover is this animation with nothing in front of it: no
+## ball, no flash, no BG map of squares, because nothing is being transitioned
+## to. It has to end black, since the frame it ends on is the one the new
+## renderer is built behind ([method Gen2Screen.play_view_cover]).
+func test_the_outro_alone_is_a_cover_that_ends_black() -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 7
+	var outro: Gen2BattleTransition = Gen2BattleTransition.create_outro(rng)
+	var frames: int = 0
+	var squares: int = 0
+	while outro.advance_frame() and frames < 4000:
+		frames += 1
+		squares = maxi(squares, _count(outro.cells(), Gen2BattleTransition.CELL_SQUARE))
+
+	assert_eq(
+		_count(outro.cells(), Gen2BattleTransition.CELL_BLACK),
+		Gen2BattleTransition.COLUMNS * Gen2BattleTransition.ROWS
+	)
+	assert_eq(squares, 0, "a cover has no Poke Ball and no BG map behind it")
+	assert_between(frames, 10, 40, "the scatter alone, not a whole transition")
+
+
 func test_every_transition_ends_with_the_screen_black() -> void:
 	for stronger: bool in [false, true]:
 		for cave: bool in [false, true]:

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1581,6 +1581,24 @@ func test_a_view_no_mod_registered_is_refused_and_leaves_the_choice_alone() -> v
 	assert_eq(host.selected_view(), Gen2ModHost.BUILT_IN_RENDERER)
 
 
+## R36b: `select_view` sets host state and nothing else, so the launcher, the
+## start menu's VIEW row and the key that cycles views all needed a rebuild of
+## their own. One signal is what makes them one path, and a choice that did not
+## change anything is not a switch to hide or rebuild for.
+func test_choosing_a_view_announces_the_change_once() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.register_world_renderer(&"voxel3d", _world_renderer_script(), "Voxel")
+	var seen: Array[StringName] = []
+	host.view_changed.connect(func(id: StringName) -> void: seen.append(id))
+
+	assert_true(host.select_view(&"voxel3d")["ok"])
+	assert_true(host.select_view(&"voxel3d")["ok"])
+	assert_false(host.select_view(&"nothing_registered_this")["ok"])
+	assert_true(host.select_view(Gen2ModHost.BUILT_IN_RENDERER)["ok"])
+
+	assert_eq(seen, [&"voxel3d", Gen2ModHost.BUILT_IN_RENDERER] as Array[StringName])
+
+
 ## One entry per view rather than one per surface, built-in first so a player
 ## cycling from it reaches the mods in the order they loaded.
 func test_the_view_list_names_each_id_once_with_the_built_in_first() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5011,6 +5011,37 @@ func test_an_unassigned_variable_sprite_still_occupies_and_is_talkable() -> void
 	assert_false(world.can_walk_to(Vector2i(7, 5)), "it did not occupy its cell")
 
 
+## `GetMonSprite`'s two `.BreedMon` branches read wBreedMon1Species and
+## wBreedMon2Species and hand the species to `LoadOverworldMonIcon`, so Route
+## 34's two day care objects are drawn as whatever is boarding there. An empty
+## slot is `.NoBreedmon`, which is the same `ld a, WALKING_SPRITE` the
+## unassigned variable sprite above answers with.
+func test_a_day_care_object_is_drawn_as_the_mon_boarding_there() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var objects: Array = world.current_map.events["objects"]
+	objects[0]["sprite"] = Gen2WorldAPI.SPRITE_DAY_CARE_MON_1
+	objects[0]["x"] = 7
+	objects[0]["y"] = 5
+
+	world.reload_current_map()
+	var empty: Gen2WorldObject = world.object_at(Vector2i(7, 5))
+	assert_not_null(empty, "an empty day care slot left the cell empty")
+	assert_eq(empty.sprite_number, Gen2WorldAPI.SPRITE_CHRIS, "and it drew nothing")
+
+	var boarder := Gen2SaveMon.new()
+	boarder.species = 1
+	world.state.set_day_care_mon(0, boarder)
+	world.reload_current_map()
+
+	var standing: Gen2WorldObject = world.object_at(Vector2i(7, 5))
+	assert_not_null(standing)
+	assert_eq(
+		standing.sprite_number, Gen2WorldAPI.SPRITE_DAY_CARE_MON_1,
+		"a boarding mon was still drawn as the player"
+	)
+
+
 ## `ReadObjectEvents` builds wMapObjects from map data and `LoadSpriteGFX` fills
 ## VRAM afterwards, so an object exists before its graphics do and none of
 ## IsNPCAtCoord, CheckFacingObject or CanObjectMoveInDirection asks what loaded.

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -172,8 +172,35 @@ func test_a_registered_entry_without_a_handler_is_unavailable() -> void:
 	Gen2ModHost.reset()
 
 
-## MODS is not the cartridge's, so it appears only when a mod registered a
-## setting, and it sits ahead of both the registered entries and EXIT.
+## The entry also carries the host's own VIEW row, so a mod that registered a
+## renderer and no setting still has to be reachable: without this, a player on
+## a shipped build could only change the view from the launcher.
+func test_mods_appears_for_a_registered_view_with_no_setting() -> void:
+	Gen2ModHost.reset()
+	var script := GDScript.new()
+	script.source_code = """extends Node2D
+func set_world(_world, _animation = null) -> void:
+	pass
+func set_time_of_day(_time_of_day: int) -> void:
+	pass
+func refresh() -> void:
+	pass
+func refresh_animation() -> void:
+	pass
+"""
+	script.reload()
+	assert_true(bool(
+		Gen2ModHost.instance().register_world_renderer(&"voxel", script).get("ok", false)
+	))
+
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
+
+	assert_true(_kinds(menu).has(Gen2WorldStartMenu.ITEM_MODS))
+	Gen2ModHost.reset()
+
+
+## MODS is not the cartridge's, so it appears only when there is something in it
+## to change, and it sits ahead of both the registered entries and EXIT.
 func test_mods_appears_only_for_a_mod_that_registered_a_setting() -> void:
 	Gen2ModHost.reset()
 	var without: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -580,7 +580,7 @@ func _process(_delta: float) -> bool:
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
 			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
-			&"ice_slide", &"whiteout",
+			&"ice_slide", &"whiteout", &"view_cover",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.
@@ -610,10 +610,17 @@ func _process(_delta: float) -> bool:
 ## the autoloads are in the tree, so nothing is registered while the screen is
 ## being built and the choice has to wait for the first frame.
 func _choose_view() -> void:
+	## Remembered whether or not this run chooses one: the `view_cover` driver
+	## switches views itself, and the choice is persisted wherever it is made.
+	_restore_view = Gen2ModHost.instance().selected_view()
 	if _view.is_empty():
 		return
-	_restore_view = Gen2ModHost.instance().selected_view()
 	var chosen: Dictionary = _screen.select_view(_view)
+	## A live switch is covered by a wipe whose middle is the build; a
+	## photograph wants the picture behind it rather than the wipe, unless the
+	## wipe is what is being photographed.
+	if _kind != &"view_cover":
+		_screen.settle_view_cover()
 	if not bool(chosen.get("ok", false)):
 		push_error("View %s unavailable: %s. Did you pass --mods?" % [
 			_view, chosen.get("reason", "unknown")
@@ -623,7 +630,7 @@ func _choose_view() -> void:
 ## A view is chosen per installation and persisted, so a capture that chose one
 ## puts the player's own back rather than leaving them on a mod's renderer.
 func _restore_selected_view() -> void:
-	if _view.is_empty() or _restore_view.is_empty():
+	if _restore_view.is_empty():
 		return
 	Gen2ModHost.instance().select_view(_restore_view)
 


### PR DESCRIPTION
Three requests from the mods repository, R35 to R37.

## R36: there was no way to change the view from a shipped build

`V` is behind `Gen2DebugKeys.enabled()`, which is `OS.is_debug_build()`. A
player on a release had one place to turn a mod's 3D view on and off: that
mod's page in the launcher, before or between runs.

The start menu's MODS entry now carries a VIEW row at the top of it. The row is
the host's, not a mod's: `Gen2ModHost` already holds one view selection for
both surfaces, persists it and draws it on the launcher's page, and a mod
registering its own VIEW button would be a second copy of that state. The entry
appears as soon as more than one view is registered, whether or not any mod
registered a setting.

`select_view` set host state, persisted it, and said in its own comment that
nothing there touched a live screen, so each caller rebuilt for itself and a mod
could not switch at all. It emits `Gen2ModHost.view_changed(id)` now, and the
world and battle screens rebuild on it. The launcher, the menu row and the key
are one path.

## R37: the switch is a stall, and a mod cannot hide its own

Building a renderer lands whole on one frame and everything is on one thread, so
a transition a mod animated would freeze on the frames it exists to hide. Only
the middle is frozen and the middle is a still picture.

`Gen2Screen.play_view_cover` closes on the renderer that is still running,
builds the new one on the frame the screen is fully black, and opens on the
frames of the close backwards. The pattern is the cartridge's own
`StartTrainerBattle_SpeckleToBlack` (`Gen2BattleTransition.create_outro`), so it
costs no art. It sits around the switch rather than at any caller, so all three
ways of choosing get it, and it is drawn outside the hardware viewport so it
covers a native-layer renderer as well as a hardware one. Renderers need nothing
new.

## R35: the two player sprites on Route 37 are the cartridge's

Not a defect. `SPRITE_WEIRD_TREE` is Sudowoodo's `wVariableSprites` slot, and
only Route 36's own script assigns it (`variablesprite SPRITE_WEIRD_TREE,
SPRITE_TWIN`, on both branches of the Sudowoodo encounter). `GetMonSprite`'s
unassigned slot falls into `.NoBreedmon`, whose `ld a, WALKING_SPRITE` is 1,
which is `SPRITE_CHRIS`. So a save that has not met Sudowoodo really does stand
Twins Ann and Anne there wearing the player's sprite, and no view is at fault.

Reading it did find the branch beside it. `SPRITE_DAY_CARE_MON_1` and `_2` are
`wBreedMon1Species` and `wBreedMon2Species` handed to `LoadOverworldMonIcon`,
and this port had neither, so Route 34's two boarding Pokemon resolved to no
sprite at all and were drawn as nothing. `Gen2WorldAPI._resolved_sprite` is
`GetMonSprite` whole now, including the re-read a slot assigned a Pokemon sprite
takes, and the fix is in the one place both the loaded map and the connected
maps build their objects from.

Mod `api_version` is 12.

## Checks

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3581 passing, 0 failing |
| `tools/validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | complete, no refusals |
| Photographs | the MODS entry's VIEW row, and the cover's close and open around a real switch to the voxel3d mod |