### PR TITLE
Ask for a nickname when a gift Pokemon is received

### DIFF
--- a/game/world/egg_hatch_screen.gd
+++ b/game/world/egg_hatch_screen.gd
@@ -153,6 +153,12 @@ func handle_button(button: int) -> bool:
 	if _phase == Phase.NAMING and _naming != null:
 		return _naming.handle_button(button)
 	if _phase == Phase.ASK_NICKNAME:
+		if _menu == null or not _menu.visible:
+			if button == Gen2Button.A and _text_box != null \
+				and (_text_box.is_revealing() or _text_box.has_pages_left()):
+				_text_box.advance()
+				return true
+			return false
 		match button:
 			Gen2Button.UP, Gen2Button.DOWN:
 				_nickname_yes = not _nickname_yes
@@ -235,7 +241,14 @@ func advance_frame() -> void:
 	if _text_box != null and _text_box.visible:
 		_text_box.advance_frame()
 		if _text_box.is_revealing() or _text_box.has_pages_left():
+			## `YesNoBox` opens behind `PrintText` returning, so the menu is not
+			## up while the question is still printing.
+			if _phase == Phase.ASK_NICKNAME and _menu != null:
+				_menu.visible = false
 			return
+	if _phase == Phase.ASK_NICKNAME and _menu != null and not _menu.visible:
+		_draw_yes_no()
+		return
 	match _phase:
 		Phase.HUH:
 			## Reached on the frame the empty `para` page has been pressed past,
@@ -381,7 +394,6 @@ func _open_nickname_question() -> void:
 	_show_text(
 		Gen2WorldPartyHost.nickname_question(String(current_hatch().get("nickname", "")))
 	)
-	_draw_yes_no()
 
 
 ## `.nonickname` keeps `wStringBuffer1`, which is the species name the row was

--- a/game/world/nickname_prompt_screen.gd
+++ b/game/world/nickname_prompt_screen.gd
@@ -1,0 +1,228 @@
+class_name Gen2NicknamePromptScreen
+extends Control
+
+## `GiveANickname_YesNo`, `InitNickname` and the `WasSentToBillsPCText` behind
+## them, for a Pokemon that was received rather than hatched: `GivePoke`'s
+## `.wildmon` branch and, through it, every `givepoke` that names no OT.
+##
+## Text only, because the routine draws nothing else: it stands over whatever
+## screen the caller left up, which on the overworld is the map with a textbox
+## on it. [Gen2EggHatchScreen] keeps its own copy of the same pair rather than
+## opening this one, since its question is `_BreedAskNicknameText` and its box
+## stands over its own animation backdrop.
+
+## The nickname the player settled on, emitted once, before [signal closed].
+signal named(nickname: String)
+signal closed()
+
+const TILE: int = Gen2Font.TILE
+
+enum Phase {
+	ASK,
+	NAMING,
+	AFTER_TEXT,
+	DONE,
+}
+
+var _data: GameData = null
+## `wStringBuffer1`, which is the species name until the player replaces it.
+var _species_name: String = ""
+## `_WasSentToBillsPCText` when the gift landed in the box, empty otherwise.
+var _after_text: String = ""
+var _phase: int = Phase.DONE
+var _yes: bool = true
+var _answer: String = ""
+
+var _text_box: Gen2TextBox = null
+var _menu_page: Gen2MenuPage = null
+var _menu: TextureRect = null
+var _naming: Gen2NamingScreenScreen = null
+
+
+func set_context(data: GameData, species_name: String, after_text: String = "") -> void:
+	_data = data
+	_species_name = species_name
+	_after_text = after_text
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _data == null or _species_name.is_empty():
+		closed.emit()
+		return
+	_build()
+	_answer = _species_name
+	_phase = Phase.ASK
+	_yes = true
+	_text_box.visible = true
+	## `_CaughtAskNicknameText` ends in `done`, so the last page draws no arrow:
+	## what waits is the `YesNoBox` behind it.
+	_text_box.show_text(Gen2WorldPartyHost.caught_nickname_question(_species_name), false)
+
+
+func phase() -> int:
+	return _phase
+
+
+func text_lines() -> PackedStringArray:
+	if _text_box == null or not _text_box.visible:
+		return PackedStringArray()
+	return _text_box.text_lines()
+
+
+## The YES/NO cursor, so a driver can read it without a redraw. -1 when the box
+## is not up, the same shape [Gen2EggHatchScreen] answers.
+func nickname_cursor() -> int:
+	return (0 if _yes else 1) if _phase == Phase.ASK else -1
+
+
+## Whether the `YesNoBox` is up, which is `PrintText` having returned. A driver
+## presses the text past its own `cont` while this is false.
+func question_ready() -> bool:
+	return _phase == Phase.ASK and _menu != null and _menu.visible
+
+
+func naming_screen() -> Gen2NamingScreenScreen:
+	return _naming
+
+
+func advance_frame() -> void:
+	if _phase in [Phase.DONE, Phase.NAMING]:
+		return
+	if _text_box != null and _text_box.visible:
+		_text_box.advance_frame()
+	_refresh_yes_no()
+
+
+## `GiveANickname_YesNo` is `PrintText` and then `YesNoBox`, so the box appears
+## only once the text it stands under owes nothing: `_CaughtAskNicknameText`'s
+## own `cont` is a press, and the menu is not up while the player is spending it.
+func _refresh_yes_no() -> void:
+	if _phase != Phase.ASK or _menu == null:
+		return
+	if _text_owes_frames():
+		_menu.visible = false
+		return
+	if not _menu.visible:
+		_draw_yes_no()
+
+
+func _text_owes_frames() -> bool:
+	return _text_box != null \
+		and (_text_box.is_revealing() or _text_box.has_pages_left())
+
+
+func handle_button(button: int) -> bool:
+	match _phase:
+		Phase.NAMING:
+			return _naming.handle_button(button) if _naming != null else false
+		Phase.ASK:
+			if _text_owes_frames():
+				if button == Gen2Button.A:
+					_text_box.advance()
+					_refresh_yes_no()
+					return true
+				return false
+			match button:
+				Gen2Button.UP, Gen2Button.DOWN:
+					_yes = not _yes
+					_draw_yes_no()
+					return true
+				Gen2Button.A:
+					_answer_question(_yes)
+					return true
+				Gen2Button.B:
+					## `YesNoBox` answers B as NO, which is `.skip_nickname`.
+					_answer_question(false)
+					return true
+		Phase.AFTER_TEXT:
+			if button != Gen2Button.A:
+				return false
+			if _text_box != null and (_text_box.is_revealing() or _text_box.has_pages_left()):
+				_text_box.advance()
+				return true
+			_finish()
+			return true
+	return false
+
+
+func _build() -> void:
+	_menu = TextureRect.new()
+	_menu.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_menu.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_menu.visible = false
+	add_child(_menu)
+
+	_text_box = Gen2TextBox.new()
+	_text_box.driven = true
+	_text_box.font = Gen2Font.from_data(_data)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	_text_box.set_frame_style(options.textbox_frame)
+	_text_box.reveal_speed = options.text_reveal_speed()
+	_text_box.place_at_bottom()
+	_text_box.visible = false
+	add_child(_text_box)
+
+
+func _draw_yes_no() -> void:
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
+	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
+	_menu.texture = ImageTexture.create_from_image(image)
+	_menu.position = Vector2(box.border_position() * TILE)
+	_menu.visible = true
+
+
+func _answer_question(yes: bool) -> void:
+	_menu.visible = false
+	if not yes:
+		_after_question()
+		return
+	_naming = Gen2NamingScreenScreen.new()
+	if not _naming.open(
+		_data,
+		Gen2WorldPartyHost.nickname_prompt(_species_name),
+		Gen2NamingScreenScreen.KIND_MON
+	):
+		_naming = null
+		_after_question()
+		return
+	_text_box.visible = false
+	_naming.closed.connect(_on_named)
+	add_child(_naming)
+	_phase = Phase.NAMING
+
+
+## `InitName`, which keeps the species name when the entry came back empty.
+func _on_named(entered: String) -> void:
+	var chosen: String = entered.strip_edges()
+	Gen2Screen.drop(_naming)
+	_naming = null
+	if not chosen.is_empty():
+		_answer = chosen
+	_after_question()
+
+
+func _after_question() -> void:
+	if _after_text.is_empty():
+		_finish()
+		return
+	_phase = Phase.AFTER_TEXT
+	_text_box.visible = true
+	_text_box.show_text(_after_text)
+
+
+func _finish() -> void:
+	if _phase == Phase.DONE:
+		return
+	_phase = Phase.DONE
+	if _text_box != null:
+		_text_box.visible = false
+	if _menu != null:
+		_menu.visible = false
+	named.emit(_answer)
+	closed.emit()

--- a/game/world/nickname_prompt_screen.gd.uid
+++ b/game/world/nickname_prompt_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://df8slduluf7rd

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -8,10 +8,15 @@ extends RefCounted
 ## if the subsystem had run.
 
 ## The requests the host settles out of the save alone. `special HealParty`,
-## `givepoke` and `giveegg` each run to completion inside the command that asked
-## for them and the script runs straight on, so a screen completes one where it
-## is staged rather than waiting for a press: the cartridge spends none, and a
-## request nothing draws for has nothing to acknowledge.
+## `giveegg` and a `givepoke` that names an OT each run to completion inside the
+## command that asked for them and the script runs straight on, so a screen
+## completes one where it is staged rather than waiting for a press.
+##
+## `pokemon_requested` is here for those and no further: `GivePoke`'s `.wildmon`
+## branch reaches `GiveANickname_YesNo`, which is a box and a naming screen, so a
+## screen that can draw one intercepts the request in front of this list
+## (`Gen2WorldScreen._open_gift_nickname`) and a driver that cannot settles it
+## here with the species name, which is what NO answers.
 const UNATTENDED_REQUESTS: Array[StringName] = [
 	&"party_heal_requested", &"pokemon_requested", &"trade_requested",
 ]

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -680,6 +680,34 @@ static func nickname_prompt(nickname: String) -> String:
 	return "%s'S\nNICKNAME?" % nickname
 
 
+## `_CaughtAskNicknameText`, the question `GiveANickname_YesNo` asks for anything
+## received rather than hatched. Distinct from [method nickname_question], which
+## is `_BreedAskNicknameText` and names the row on its own line.
+static func caught_nickname_question(species_name: String) -> String:
+	return "Give a nickname to\nthe %s you%sreceived?" % [
+		species_name, Gen2TextStream.SCROLL_BREAK,
+	]
+
+
+## `_WasSentToBillsPCText`, printed behind the nickname whenever a `givepoke`
+## landed in the box.
+static func sent_to_box_text(species_name: String) -> String:
+	return "%s was\nsent to BILL's PC." % species_name
+
+
+## Where `GivePoke` would put one more Pokemon: `TryAddMonToParty` first, then
+## `SendMonIntoBox`, and `.FailedToGiveMon` when neither has room. Answered
+## without writing anything, because `GiveANickname_YesNo` stands between the
+## two on the cartridge and the prompt it opens is drawn before this port's own
+## transaction runs.
+static func gift_destination(save: Gen2SaveData) -> StringName:
+	if save == null:
+		return &"full"
+	if save.party.size() < Gen2SaveData.MAX_PARTY:
+		return &"party"
+	return &"box" if bool(save.first_empty_box_slot().get("ok", false)) else &"full"
+
+
 ## `DoEggStep`, spent [param times] over. Each pass walks the party from the
 ## front taking one hatch cycle off every egg, and stops on the first egg whose
 ## counter reaches zero, so an egg behind that one keeps its cycle for that
@@ -943,27 +971,72 @@ static func _apply_party_request(
 		set_caught_data(
 			mon, level, world.object_time_of_day, world.player_female(), world.landmark()
 		)
-		if not is_egg:
-			var source: Dictionary = request.get("source", {})
-			var bank: int = int(source.get("bank", -1))
-			var nickname: String = _world_name(
-				world.data, bank, int(values.get("nickname_address", -1))
-			)
-			var ot_name: String = _world_name(
-				world.data, bank, int(values.get("ot_name_address", -1))
-			)
-			if not nickname.is_empty():
-				mon.nickname = nickname
-			if not ot_name.is_empty():
-				mon.original_trainer = ot_name
-				## `SetGiftPartyMonCaughtData`: a `givepoke` that names an OT is
-				## somebody's present, so its level byte is zero and its
-				## landmark is LANDMARK_GIFT rather than this map.
-				set_caught_data(mon, 0, -1, world.player_female(), LANDMARK_GIFT)
-		return _append_mon(candidate, mon, 2 if is_egg else 1, {
-			"kind": &"egg" if is_egg else &"gift",
-			"species": species, "level": level, "item": held_item,
+		if is_egg:
+			## `GiveEgg` is `TryAddMonToParty` and nothing else, so a full party
+			## boxes no egg and leaves `Script_giveegg`'s own `xor a` in
+			## wScriptVar; only the `ret nc` past it writes 2.
+			if candidate.party.size() >= Gen2SaveData.MAX_PARTY:
+				return {
+					"ok": true, "accepted": false, "script_value": 0,
+					"reason": &"party_full",
+					"summary": {
+						"kind": &"egg", "accepted": false,
+						"species": species, "level": level,
+					},
+				}
+			return _append_mon(candidate, mon, 2, {
+				"kind": &"egg", "species": species, "level": level, "item": held_item,
+			})
+		var source: Dictionary = request.get("source", {})
+		var bank: int = int(source.get("bank", -1))
+		var nickname: String = _world_name(
+			world.data, bank, int(values.get("nickname_address", -1))
+		)
+		var ot_name: String = _world_name(
+			world.data, bank, int(values.get("ot_name_address", -1))
+		)
+		if not nickname.is_empty():
+			mon.nickname = nickname
+		if not ot_name.is_empty():
+			mon.original_trainer = ot_name
+			## `SetGiftPartyMonCaughtData`: a `givepoke` that names an OT is
+			## somebody's present, so its level byte is zero and its
+			## landmark is LANDMARK_GIFT rather than this map.
+			set_caught_data(mon, 0, -1, world.player_female(), LANDMARK_GIFT)
+		elif result.has("nickname"):
+			## `GiveANickname_YesNo` and `InitNickname`: the `.wildmon` branch,
+			## which is the thirteen `givepoke` sites that name no OT. The screen
+			## drew the question and the naming keyboard, and NO answers with the
+			## species name `.done` already left in the row.
+			var chosen: String = String(result["nickname"]).strip_edges()
+			if not chosen.is_empty():
+				mon.nickname = chosen
+		var appended: Dictionary = _append_mon(candidate, mon, 0, {
+			"kind": &"gift", "species": species, "level": level, "item": held_item,
 		})
+		if not bool(appended.get("ok", false)):
+			## `.FailedToGiveMon`'s `ld b, $2`: neither the party nor the box had
+			## room, so nothing is written and the script reads 2 and runs on.
+			if StringName(appended.get("reason", &"")) == &"storage_full":
+				return {
+					"ok": true, "accepted": false, "script_value": 2,
+					"reason": &"storage_full",
+					"summary": {
+						"kind": &"gift", "accepted": false,
+						"species": species, "level": level,
+					},
+				}
+			return appended
+		var destination: StringName = StringName(
+			(appended["summary"]["destination"] as Dictionary).get("destination", &"party")
+		)
+		if destination == &"box":
+			## `.skip_nickname`'s tail copies `wMonOrItemNameBuffer` over
+			## `sBoxMonNicknames` after `InitNickname` has written the player's
+			## entry, so a boxed gift always ends up with the species name.
+			mon.nickname = String(world.data.species(species).get("name", ""))
+			appended["script_value"] = 1
+		return appended
 
 	if kind == &"trade_requested":
 		var values: Dictionary = request.get("values", {})

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -155,6 +155,13 @@ var _evolution_save: Gen2SaveData = null
 ## `OverworldHatchEgg`'s screen and the save whose party it has already written.
 var _hatch_host: Gen2EggHatchScreen = null
 var _hatch_save: Gen2SaveData = null
+## `GiveANickname_YesNo`'s screen, standing between `givepoke` staging the
+## request and the party host applying it.
+var _nickname_host: Gen2NicknamePromptScreen = null
+var _nickname_answer: String = ""
+## Raised by the screenshot driver alone, which opens the prompt with no
+## `givepoke` behind it and so has no request to complete when it closes.
+var _nickname_preview: bool = false
 ## `special NameRater`'s screen and the save whose party row it may rename.
 var _name_rater_host: Gen2NameRaterScreen = null
 var _name_rater_save: Gen2SaveData = null
@@ -577,6 +584,7 @@ func _apply_interface_mask() -> void:
 		or _hall_of_fame_host != null or _trainer_card_host != null
 		or _pokedex_host != null or _credits_host != null
 		or _evolution_host != null or _hatch_host != null
+		or _nickname_host != null
 		or _name_rater_host != null or _move_deleter_host != null
 		or _move_tutor_host != null or _day_care_host != null
 		or _unown_puzzle_host != null or _slot_machine_host != null
@@ -829,6 +837,8 @@ func advance_frame() -> void:
 		_evolution_host.advance_frame()
 	if _hatch_host != null:
 		_hatch_host.advance_frame()
+	if _nickname_host != null:
+		_nickname_host.advance_frame()
 	if _name_rater_host != null:
 		_name_rater_host.advance_frame()
 	if _move_deleter_host != null:
@@ -997,6 +1007,7 @@ func _overlay_open() -> bool:
 		or _hall_of_fame_host != null or _trainer_card_host != null \
 		or _pokedex_host != null or _credits_host != null \
 		or _evolution_host != null or _hatch_host != null \
+		or _nickname_host != null \
 		or _name_rater_host != null or _move_deleter_host != null \
 		or _move_tutor_host != null \
 		or _day_care_host != null or _unown_puzzle_host != null \
@@ -1109,6 +1120,11 @@ func _handle_button(button: int) -> bool:
 	## map loop suspended in exactly the same place.
 	if _hatch_host != null:
 		_hatch_host.handle_button(button)
+		return true
+	## `GivePoke` runs inside `givepoke`, with the map loop suspended behind the
+	## script the same way, and its own naming screen is reached through it.
+	if _nickname_host != null:
+		_nickname_host.handle_button(button)
 		return true
 	## `special NameRater` runs inside `opentext`, so the map loop is suspended
 	## behind it the same way and its own two screens are reached through it.
@@ -1671,6 +1687,74 @@ func _on_hatch_named(party_index: int, nickname: String) -> void:
 		return
 	mon.nickname = nickname
 	_script_prompt = "%s hatched" % nickname
+
+
+## `GivePoke`'s own prompt, for the `givepoke` sites that name no OT: thirteen
+## of the fourteen, every starter among them. `GiveANickname_YesNo` stands
+## between `TryAddMonToParty` and the row being named, so the request is left
+## pending while the screen is up and the party host applies it with the answer.
+##
+## False when the routine reaches no prompt and the request may be settled where
+## it was staged: an egg, a gift that names an OT, and the storage that has room
+## for neither, which is `.FailedToGiveMon`.
+func _open_gift_nickname(request: Dictionary) -> bool:
+	if _nickname_host != null or _world == null or _data == null:
+		return false
+	var values: Dictionary = request.get("values", {})
+	if not values.has("pokemon") or int(values.get("trainer", 0)) != 0:
+		return false
+	var species: int = int(values.get("pokemon", 0))
+	var species_name: String = String(_data.species(species).get("name", ""))
+	if species_name.is_empty():
+		return false
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	var destination: StringName = Gen2WorldPartyHost.gift_destination(save)
+	if destination == &"full":
+		return false
+	var host := Gen2NicknamePromptScreen.new()
+	host.set_context(
+		_data, species_name,
+		Gen2WorldPartyHost.sent_to_box_text(species_name) if destination == &"box" else ""
+	)
+	_nickname_answer = species_name
+	host.named.connect(_on_gift_named)
+	host.closed.connect(_on_gift_nickname_closed)
+	host.z_index = 30
+	_nickname_host = host
+	_screen.display(host)
+	if _nickname_host == null:
+		return false
+	_script_prompt = "Nickname"
+	_refresh_labels()
+	return true
+
+
+func _on_gift_named(nickname: String) -> void:
+	_nickname_answer = nickname
+
+
+## `InitNickname` has answered, so the row the party host is about to write
+## carries the player's entry rather than `wStringBuffer1`'s species name.
+func _on_gift_nickname_closed() -> void:
+	var host: Gen2NicknamePromptScreen = _nickname_host
+	_nickname_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	if _nickname_preview:
+		_nickname_preview = false
+		_refresh_labels()
+		return
+	var settled: Dictionary = _complete_pending_request({
+		"ok": true, "nickname": _nickname_answer,
+	})
+	if not bool(settled.get("ok", false)):
+		_script_prompt = "Host unavailable: %s" % String(settled.get("reason", "unknown"))
+		_refresh_labels()
+		return
+	_show_script_results(settled.get("results", []))
 
 
 func _on_hatch_closed() -> void:
@@ -3170,6 +3254,34 @@ func preview_egg_hatch(species: int = 0) -> void:
 	if summary.is_empty():
 		return
 	_open_hatch([summary], save)
+
+
+## Public screenshot driver for `GiveANickname_YesNo`, which no fixture cell
+## reaches: a `givepoke` is somebody's map script. The prompt is opened over the
+## map with no request behind it, so its close writes nothing.
+func preview_gift_nickname(species: int = 0, boxed: bool = false) -> void:
+	if _world == null or _data == null or _nickname_host != null:
+		return
+	var chosen: int = species if species > 0 else 1
+	var species_name: String = String(_data.species(chosen).get("name", ""))
+	if species_name.is_empty():
+		_script_prompt = "This cartridge has no species %d" % chosen
+		_refresh_labels()
+		return
+	var host := Gen2NicknamePromptScreen.new()
+	host.set_context(
+		_data, species_name,
+		Gen2WorldPartyHost.sent_to_box_text(species_name) if boxed else ""
+	)
+	_nickname_answer = species_name
+	_nickname_preview = true
+	host.named.connect(_on_gift_named)
+	host.closed.connect(_on_gift_nickname_closed)
+	host.z_index = 30
+	_nickname_host = host
+	_screen.display(host)
+	_script_prompt = "Nickname"
+	_refresh_labels()
 
 
 ## Public screenshot driver for the blackout. It poisons the whole party down to
@@ -5557,6 +5669,9 @@ func _show_script_results(results: Array) -> void:
 					})
 					_show_script_results(swarm_results)
 					return
+				if StringName(request.get("kind", &"")) == &"pokemon_requested" \
+					and _open_gift_nickname(request):
+					break
 				if StringName(request.get("kind", &"")) in \
 					Gen2WorldHost.UNATTENDED_REQUESTS:
 					var settled: Array = _complete_unattended_request()

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1332,6 +1332,12 @@ func test_yes_opens_the_naming_screen_and_its_entry_becomes_the_nickname() -> vo
 		if screen.awaiting_press():
 			_world_screen.press_button(Gen2Button.A)
 	assert_eq(screen.nickname_cursor(), 0, "YesNoBox opens on YES")
+	## `YesNoBox` stands behind `PrintText` returning, so the menu is not up
+	## while the question is still printing and A spends the text instead.
+	for _frame: int in 600:
+		if screen._menu.visible:
+			break
+		_world_screen.advance_frame()
 	_world_screen.press_button(Gen2Button.A)
 	assert_eq(screen.phase(), Gen2EggHatchScreen.Phase.NAMING)
 	var model: Gen2NamingScreen = screen.naming_screen().model()
@@ -1344,6 +1350,125 @@ func test_yes_opens_the_naming_screen_and_its_entry_becomes_the_nickname() -> vo
 	await _settle_hatch()
 	assert_null(_world_screen.get("_hatch_host"))
 	assert_eq(save.party[0].nickname.length(), 1, "the one letter that was entered")
+
+
+## `givepoke SPECIES, 5` on the cell the player spawns on, so the coord event
+## the fixture already carries runs `GivePoke` when the script is dispatched.
+func _write_givepoke_script() -> void:
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = [
+		Gen2WorldScript.GIVEPOKE, Fixture.TRAINER_SPECIES, 5, 0, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+	_data = GameData.open_directory(directory)
+
+
+func _run_givepoke() -> Gen2NicknamePromptScreen:
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(Vector2i(4, 5))
+	)
+	return _world_screen.get("_nickname_host")
+
+
+## Spends whatever the box still owes and presses past each page it ends on,
+## which is what `PrintText` returning costs: `_CaughtAskNicknameText`'s own
+## `cont` is a press, and `YesNoBox` opens only behind the last of them.
+func _settle_nickname_text() -> void:
+	for _frame: int in 600:
+		var host: Gen2NicknamePromptScreen = _world_screen.get("_nickname_host")
+		if host == null:
+			return
+		if not host._text_box.is_revealing():
+			if not host._text_box.has_pages_left():
+				break
+			_world_screen.press_button(Gen2Button.A)
+		_world_screen.advance_frame()
+	_world_screen.advance_frame()
+
+
+## `GivePoke`'s `.wildmon` branch, which is the thirteen `givepoke` sites that
+## name no OT: every starter among them. NO is `.skip_nickname`, which keeps the
+## species name `GetPokemonName` left in the row.
+func test_a_gift_asks_for_a_nickname_and_no_keeps_the_species_name() -> void:
+	_write_givepoke_script()
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var before: int = save.party.size()
+	var host: Gen2NicknamePromptScreen = _run_givepoke()
+	assert_not_null(host, "`GiveANickname_YesNo` is drawn")
+	assert_eq(save.party.size(), before, "and nothing is written while it stands")
+	var species_name: String = String(
+		_data.species(Fixture.TRAINER_SPECIES).get("name", "")
+	)
+	_settle_nickname_text()
+	## `cont` scrolls by one line rather than clearing the box, so the answer's
+	## page opens on the line above it rather than on an empty box.
+	assert_eq(host.text_lines(), PackedStringArray([
+		"Give a nickname to", "the %s you" % species_name,
+		"the %s you" % species_name, "received?",
+	]))
+	assert_eq(host.nickname_cursor(), 0, "YesNoBox opens on YES")
+	_world_screen.press_button(Gen2Button.B)
+	assert_null(_world_screen.get("_nickname_host"), "and B closes it as NO")
+	assert_eq(save.party.size(), before + 1, "the row is written behind the prompt")
+	assert_eq(save.party[before].nickname, species_name)
+	## `Gen2Screen.drop` is a `queue_free`, spent on a process frame this test
+	## otherwise never runs.
+	await get_tree().process_frame
+
+
+## YES reaches `NamingScreen` under NAME_MON, and `InitNickname` writes what it
+## stored into the row the request is about to make.
+func test_a_gift_takes_the_name_the_keyboard_stored() -> void:
+	_write_givepoke_script()
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var before: int = save.party.size()
+	var host: Gen2NicknamePromptScreen = _run_givepoke()
+	_settle_nickname_text()
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(host.phase(), Gen2NicknamePromptScreen.Phase.NAMING)
+	var model: Gen2NamingScreen = host.naming_screen().model()
+	assert_eq(model.max_length, Gen2NamingScreen.MON_MAX_LENGTH)
+	model.press_a()
+	model.column = Gen2NamingScreen.LAST_COLUMN
+	model.row = model.command_row()
+	_world_screen.press_button(Gen2Button.A)
+
+	assert_null(_world_screen.get("_nickname_host"))
+	assert_eq(save.party.size(), before + 1)
+	assert_eq(save.party[before].nickname.length(), 1, "the one letter that was entered")
+	await get_tree().process_frame
+
+
+## `.failed`'s box branch: `WasSentToBillsPCText` is printed behind the nickname,
+## and `.skip_nickname`'s own copy puts the species name back over whatever the
+## keyboard stored.
+func test_a_boxed_gift_prints_bills_pc_and_keeps_the_species_name() -> void:
+	_write_givepoke_script()
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	while save.party.size() < Gen2SaveData.MAX_PARTY:
+		save.party.append(Gen2SaveMon.from_dict(save.party[0].to_dict()))
+	var host: Gen2NicknamePromptScreen = _run_givepoke()
+	_settle_nickname_text()
+	_world_screen.press_button(Gen2Button.B)
+	assert_eq(host.phase(), Gen2NicknamePromptScreen.Phase.AFTER_TEXT)
+	_settle_nickname_text()
+	var species_name: String = String(
+		_data.species(Fixture.TRAINER_SPECIES).get("name", "")
+	)
+	assert_eq(
+		" ".join(host.text_lines()),
+		Gen2WorldPartyHost.sent_to_box_text(species_name).replace("\n", " ")
+	)
+	_world_screen.press_button(Gen2Button.A)
+	assert_null(_world_screen.get("_nickname_host"))
+	assert_eq(save.party.size(), Gen2SaveData.MAX_PARTY)
+	assert_eq(save.boxes[0].slots[0].nickname, species_name)
+	await get_tree().process_frame
 
 
 ## `CountStep`'s `cp 4` and the `DoPoisonStep` behind it. Three steps are below

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -158,6 +158,50 @@ func test_giveegg_records_an_egg_without_pretending_it_can_battle() -> void:
 	assert_eq(result["transaction"]["kind"], &"egg")
 
 
+## `GiveANickname_YesNo` answered YES, then `InitNickname`. The screen owns both
+## boxes; what the host owes is writing the answer into the row it just made.
+func test_a_gift_takes_the_nickname_the_prompt_answered() -> void:
+	_set_script(0x6200)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"nickname": "SPARKY"}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(_save.party[2].nickname, "SPARKY")
+
+
+## `.skip_nickname` copies `wMonOrItemNameBuffer` over `sBoxMonNicknames` behind
+## `InitNickname`, so a boxed gift always ends up with the species name.
+func test_a_boxed_gift_keeps_the_species_name_over_the_answer() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	_set_script(0x6200)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"nickname": "SPARKY"}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(_save.boxes[0].slots[0].nickname, String(_data.species(25)["name"]))
+	assert_eq(int(result["results"][0]["events"][0]["result"]["script_value"]), 1)
+
+
+## `GiveEgg` is `TryAddMonToParty` and nothing else, so a full party boxes no egg
+## and `Script_giveegg`'s own `xor a` is what the script reads.
+func test_a_full_party_boxes_no_egg_and_answers_zero() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	var before: Dictionary = _save.to_dict()
+	_set_script(0x6210)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_false(result["transaction"]["accepted"])
+	assert_eq(int(result["results"][0]["events"][0]["result"]["script_value"]), 0)
+	assert_eq(_save.to_dict(), before)
+
+
 func test_npc_trade_uses_the_imported_record_and_replaces_the_requested_slot() -> void:
 	_set_script(0x6220)
 	_world.dispatch_script_events(Vector2i(2, 2))
@@ -208,7 +252,9 @@ func test_full_party_stores_a_gift_in_the_first_pc_box_slot() -> void:
 	assert_eq(result["transaction"]["destination"]["destination"], &"box")
 
 
-func test_full_party_and_boxes_refuse_a_gift_without_mutation() -> void:
+## `.FailedToGiveMon`'s `ld b, $2`: nothing is written and the script reads 2
+## and runs on, which is not a refusal the host may stop the script for.
+func test_full_party_and_boxes_leave_a_gift_unwritten_and_answer_two() -> void:
 	while _save.party.size() < Gen2SaveData.MAX_PARTY:
 		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
 	for box: Gen2SaveBox in _save.boxes:
@@ -220,8 +266,9 @@ func test_full_party_and_boxes_refuse_a_gift_without_mutation() -> void:
 	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
 		_world, {}, _save, false, _random
 	)
-	assert_false(result["ok"])
-	assert_eq(result["reason"], &"storage_full")
+	assert_true(result["ok"])
+	assert_false(result["transaction"]["accepted"])
+	assert_eq(int(result["results"][0]["events"][0]["result"]["script_value"]), 2)
 	assert_eq(_save.to_dict(), before)
 
 

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -71,6 +71,11 @@ extends SceneTree
 ## MoveDeletion`, which no fixture cell reaches: the first number is how many
 ## presses into the routine to photograph, so 0 is the introduction, 2 its last
 ## page with the YES/NO up, and 4 the party list),
+## `gift_nickname` (`GiveANickname_YesNo`, which no fixture cell reaches because
+## a `givepoke` is somebody's map script: the first number is how many presses
+## into the prompt to photograph, 1 its question with the YES/NO up and 2 the
+## `WasSentToBillsPCText` behind NO, and the second the species, plus 1000 for
+## the box branch that prints that line),
 ## `move_tutor` (`special MoveTutor`, driven the same way, except that it opens
 ## on `ChooseMonToLearnTMHM` rather than on a box: 0 is that list),
 ## `day_care` (the Day-Care's five specials, driven the same way: the first
@@ -279,7 +284,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 	elif cell.x >= 0 and _kind not in [
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
 		&"move_deleter", &"move_tutor", &"day_care", &"unown_puzzle", &"slot_machine",
-		&"card_flip", &"tile_anim", &"ice_slide", &"whiteout",
+		&"card_flip", &"tile_anim", &"ice_slide", &"whiteout", &"gift_nickname",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -383,6 +388,22 @@ func _process(_delta: float) -> bool:
 					break
 				if hatching.awaiting_press():
 					_screen.press_button(Gen2Button.A)
+		elif _kind == &"gift_nickname":
+			## `GivePoke`'s own prompt. The presses are spent behind the frames
+			## the box owes, since nothing shortens a printing text; the second
+			## number's thousands digit is the box branch.
+			_screen.preview_gift_nickname(maxi(_cell.y, 0) % 1000, _cell.y >= 1000)
+			_settle_mon_special("_nickname_host")
+			for _press: int in maxi(_cell.x, 0):
+				var prompt: Gen2NicknamePromptScreen = _screen.get("_nickname_host")
+				if prompt == null:
+					break
+				## NO on the question, so the mode photographs the routine's own
+				## boxes; the keyboard behind YES has `preview_naming_screen.gd`.
+				_screen.press_button(
+					Gen2Button.B if prompt.question_ready() else Gen2Button.A
+				)
+				_settle_mon_special("_nickname_host")
 		elif _kind == &"whiteout":
 			## `Script_Whiteout`, which no fixture cell reaches: the party is
 			## poisoned down to its last point and the pass `CountStep` owes is
@@ -580,7 +601,7 @@ func _process(_delta: float) -> bool:
 			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
 			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
-			&"ice_slide", &"whiteout", &"view_cover",
+			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.


### PR DESCRIPTION
Thirteen of the fourteen `givepoke` sites in the game name no OT: every
starter, every Game Corner prize, Bill's Eevee, the Mt Mortar Tyrogue, the
Dragon Shrine Dratini. Those take `GivePoke`'s `.wildmon` branch, which is
`SetCaughtData` and then `GiveANickname_YesNo`. None of it was built, so
Elm's starter arrived with no question asked.

`Gen2NicknamePromptScreen` is that routine, `InitNickname` and the
`WasSentToBillsPCText` behind them. The request stays pending while the
prompt stands, because the cartridge names the row before the script runs on.
A driver that draws nothing still settles the request where it is staged,
which is what NO answers.

Four more defects came out of reading the routine around it.

- `Script_givepoke`'s answer was always 1. `GivePoke` returns 0 for the party,
  1 for the box and 2 for `.FailedToGiveMon`.
- A full party boxed the egg. `GiveEgg` is `TryAddMonToParty` and nothing
  else, so no egg has ever gone to a PC.
- Storage with room for neither stopped the script. The cartridge writes
  nothing, answers 2 and runs on.
- A boxed gift keeps the species name. `.skip_nickname`'s tail copies the
  name buffer over the box nickname behind `InitNickname`, so the typed name
  is thrown away. That is the cartridge's and is reproduced.

One class defect beside them: `YesNoBox` was drawn while its question was
still printing. `GiveANickname_YesNo` is `PrintText` and then `YesNoBox`, and
`Gen2TextBox.has_pages_left` already documented that a screen putting a menu
over the box waits for the printing to end. The egg hatch screen was the one
place that did not, so a press on its YES/NO answered a question the player
had not finished reading.

Photograph any of it with
`tools/preview_world.gd -- <game> <group> <map> <png> live gift_nickname
<presses> <species>`, plus 1000 on the species for the box branch.

Unit and scene tiers: 3587 tests, all passing. `validate.gd -- all` exits 0,
`replay_world.gd` is 33 routes and 0 failures, and the three-profile story
walk is byte identical before and after.