### PR TITLE
Mark a menu row that is cut, and name the built-in view to fit

### DIFF
--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -254,9 +254,9 @@ func _pack_bundle(directory: String) -> Dictionary:
 	var written: int = 0
 	if _pack(packer, "report.txt", report().to_utf8_buffer()):
 		written += 1
-	for name: String in log_files():
-		var bytes: PackedByteArray = FileAccess.get_file_as_bytes("%s/%s" % [DIRECTORY, name])
-		if not bytes.is_empty() and _pack(packer, "logs/%s" % name, bytes):
+	for file: String in log_files():
+		var bytes: PackedByteArray = FileAccess.get_file_as_bytes("%s/%s" % [DIRECTORY, file])
+		if not bytes.is_empty() and _pack(packer, "logs/%s" % file, bytes):
 			written += 1
 	packer.close()
 	return {"ok": true, "message": "", "path": path, "files": written}
@@ -277,9 +277,9 @@ func log_files(directory: String = DIRECTORY) -> PackedStringArray:
 		ProjectSettings.get_setting("debug/file_logging/log_path", "")
 	).get_file()
 	var found: Array[String] = []
-	for name: String in DirAccess.get_files_at(directory):
-		if name.get_extension().to_lower() == "log":
-			found.append(name)
+	for file: String in DirAccess.get_files_at(directory):
+		if file.get_extension().to_lower() == "log":
+			found.append(file)
 	found.sort_custom(func(a: String, b: String) -> bool:
 		if (a == live) != (b == live):
 			return a == live
@@ -462,8 +462,8 @@ func _bundle_directory() -> String:
 	return ProjectSettings.globalize_path("user://")
 
 
-func _pack(packer: ZIPPacker, name: String, bytes: PackedByteArray) -> bool:
-	if packer.start_file(name) != OK:
+func _pack(packer: ZIPPacker, entry: String, bytes: PackedByteArray) -> bool:
+	if packer.start_file(entry) != OK:
 		return false
 	var ok: bool = packer.write_file(bytes) == OK
 	packer.close_file()

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -824,7 +824,7 @@ keeps the built-in renderer on the other, and `gen2` selects both.
 | Method | Value |
 |---|---|
 | `view_ids() -> Array[StringName]` | Every id that registered a renderer of either kind, `gen2` first and the rest in load order |
-| `view_label(id) -> String` | The label the registration gave |
+| `view_label(id) -> String` | The label the registration gave, drawn in eight cells (see "What a name is drawn in") |
 | `view_surfaces(id) -> Dictionary` | `{world, battle}`, which of the two that id draws |
 | `selected_view() -> StringName` | The chosen id, whether or not its mod is loaded |
 | `select_view(id) -> Dictionary` | Chooses it, and persists the choice |
@@ -842,6 +842,23 @@ the change on `view_changed`, and the world and battle screens rebuild what they
 are drawing with on it, so the launcher's mod page, the start menu's own VIEW
 row and `V` are one path. A mod neither needs nor should hold a screen; it may
 connect to the signal to hear about a switch.
+
+### What a name is drawn in
+
+The start menu is the hardware's twenty-cell screen, so a name a mod registers
+is drawn into a fixed budget and a longer one ends in the charmap's own "…":
+
+| Row | Cells | What is drawn there |
+|---|---|---|
+| A mod's name in the MODS list | 17 | The manifest's `name` |
+| A setting's `label`, and the VIEW row's own | 17 | `register_option`'s `label` |
+| A setting's value, and a view's label | 8 | The chosen rung's label, a button's `press_label`, or `view_label` |
+
+The built-in view is labelled "GBC 2D" for that reason. A name that has to read
+whole in the start menu is written to those budgets; a longer one still works
+and is shown cut, rather than drawn through the panel's border as it was before.
+The numbers are `Gen2StartMenuPage.OPTIONS_LABEL_CELLS` and
+`OPTIONS_VALUE_CELLS`. The launcher draws the full name either way.
 
 **Players reach the view from three places.** The mod's page in the launcher,
 where they already change what a mod does; the VIEW row at the top of the start

--- a/game/launcher/launcher_file_picker.gd
+++ b/game/launcher/launcher_file_picker.gd
@@ -26,20 +26,21 @@ var _native: Object = null
 
 
 static func create(
-	theme: Gen2LauncherTheme,
+	palette: Gen2LauncherTheme,
 	title_text: String,
-	mode: FileDialog.FileMode,
-	filters: PackedStringArray,
+	picker_mode: FileDialog.FileMode,
+	patterns: PackedStringArray,
 ) -> Gen2LauncherFilePicker:
 	var dialog := Gen2LauncherFilePicker.new()
-	dialog.file_mode = mode
-	dialog.filters = filters
+	dialog.file_mode = picker_mode
+	dialog.filters = patterns
 	dialog.title = title_text
 	dialog.use_native_dialog = true
-	dialog.theme = theme.control_theme()
+	dialog.theme = palette.control_theme()
 	# The plugin opens files; naming one that does not exist yet is a different
 	# controller and a different flow, so a save keeps the engine's own path.
-	if mode == FileDialog.FILE_MODE_OPEN_FILE and Engine.has_singleton(NATIVE_SINGLETON):
+	if picker_mode == FileDialog.FILE_MODE_OPEN_FILE \
+		and Engine.has_singleton(NATIVE_SINGLETON):
 		dialog._native = Engine.get_singleton(NATIVE_SINGLETON)
 	dialog.access = (
 		FileDialog.ACCESS_FILESYSTEM if dialog._can_browse_freely() else FileDialog.ACCESS_USERDATA

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -338,7 +338,7 @@ static func slider(
 	format: Callable = Callable()
 ) -> Control:
 	var spell: Callable = format if format.is_valid() \
-		else func(number: int) -> String: return str(number)
+		else func(amount: int) -> String: return str(amount)
 	var line: HBoxContainer = row(GAP_MD)
 	var bar := HSlider.new()
 	bar.min_value = minimum

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -233,11 +233,14 @@ var _failures: Array = []
 static func instance() -> Gen2ModHost:
 	if _instance == null:
 		_instance = Gen2ModHost.new()
+		## Short because the start menu's VIEW row draws a label in
+		## `Gen2StartMenuPage.OPTIONS_VALUE_CELLS` cells: a longer one is cut
+		## there and a player picking a view reads the cut, not the name.
 		_instance.register_world_renderer(
-			BUILT_IN_RENDERER, Gen2WorldRenderer, "Game Boy Color 2D"
+			BUILT_IN_RENDERER, Gen2WorldRenderer, "GBC 2D"
 		)
 		_instance.register_battle_renderer(
-			BUILT_IN_RENDERER, Gen2BattleRenderer, "Game Boy Color 2D"
+			BUILT_IN_RENDERER, Gen2BattleRenderer, "GBC 2D"
 		)
 		## Read before any mod has registered anything, which is the only order
 		## available: the id is resolved every time a renderer is asked for, so a

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -215,9 +215,9 @@ func game_titles() -> Array[String]:
 static func titles_for(ids: Array) -> Array[String]:
 	var out: Array[String] = []
 	for game: Variant in ids:
-		var id := StringName(game)
-		var title: String = RomRegistry.title_for(id)
-		out.append(title if not title.is_empty() else String(id))
+		var game_id := StringName(game)
+		var title: String = RomRegistry.title_for(game_id)
+		out.append(title if not title.is_empty() else String(game_id))
 	return out
 
 

--- a/game/render/card_flip_page.gd
+++ b/game/render/card_flip_page.gd
@@ -317,16 +317,16 @@ static func from_data(data: GameData) -> Gen2CardFlipPage:
 	var one: PackedByteArray = data.card_flip_indices("card_flip_1")
 	var two: PackedByteArray = data.card_flip_indices("card_flip_2")
 	var three: PackedByteArray = data.card_flip_indices("card_flip_3")
-	var board: PackedByteArray = data.card_flip_tilemap()
+	var tilemap: PackedByteArray = data.card_flip_tilemap()
 	if glyphs == null or one.is_empty() or two.is_empty() or three.is_empty() \
-		or board.size() < RomLayout.CARD_FLIP_TILEMAP_BYTES:
+		or tilemap.size() < RomLayout.CARD_FLIP_TILEMAP_BYTES:
 		return null
 
 	var page := Gen2CardFlipPage.new()
 	page.font = glyphs
 	page.frame_style = Gen2OptionsStore.current().textbox_frame
 	page.digits_lifted = data.id == RomRegistry.CRYSTAL
-	page._board = board
+	page._board = tilemap
 	page._background_tiles = _bank(
 		[[SHEET_1_FIRST_TILE, one], [SHEET_2_FIRST_TILE, two]], BACKGROUND_TILES
 	)

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -139,17 +139,39 @@ func draw_code(
 ## [param max_tiles] stops the run short. `PlaceString` has no such bound and
 ## needs none: every cartridge string is written to fit the box it is placed in.
 ## A label a mod supplies is not, so a caller drawing into a fixed width passes
-## the room it has and the rest of the string is dropped rather than written
-## over whatever is beside the box. Negative means no bound.
+## the room it has. Negative means no bound.
+##
+## A bounded run that does not fit ends in the charmap's own "…" rather than
+## stopping mid-word, so a cut value is never read as a whole one: two views
+## labelled "Game Boy Color 2D" and "Game Boy Advance" would otherwise draw the
+## same eight characters. The battle-extra strip has no ellipsis tile under $75,
+## so under that font the run is cut without one.
 func draw_text(
 	text: String, into: PackedByteArray, into_width: int, at_x: int, at_y: int,
 	font: StringName = Gen2Text.FONT_MAIN, max_tiles: int = -1
 ) -> int:
-	var codes: PackedByteArray = Gen2Text.encode(text, font)
-	var drawn: int = codes.size() if max_tiles < 0 else mini(codes.size(), max_tiles)
-	for i: int in drawn:
+	var codes: PackedByteArray = fit(text, max_tiles, font)
+	for i: int in codes.size():
 		draw_code(codes[i], into, into_width, at_x + i * TILE, at_y, font)
-	return drawn
+	return codes.size()
+
+
+## [param text] encoded and cut to [param max_tiles] cells, marked with an
+## ellipsis where anything was dropped. Negative is no bound. Exposed so a
+## caller that measures before it draws asks the same question once.
+static func fit(
+	text: String, max_tiles: int, font: StringName = Gen2Text.FONT_MAIN
+) -> PackedByteArray:
+	var codes: PackedByteArray = Gen2Text.encode(text, font)
+	if max_tiles < 0 or codes.size() <= max_tiles:
+		return codes
+	if max_tiles <= 0:
+		return PackedByteArray()
+	if font == Gen2Text.FONT_BATTLE_EXTRA:
+		return codes.slice(0, max_tiles)
+	var out: PackedByteArray = codes.slice(0, max_tiles - 1)
+	out.append(Gen2Text.ELLIPSIS_CODE)
+	return out
 
 
 ## Draws one tile of one text box border. [param code] is a box-drawing code

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -452,10 +452,10 @@ func _max_zoom_step() -> int:
 ## The buffer a scale of [param scale] needs to cover [param area], rounded up
 ## to a whole block on each axis past the hardware's own screen so the 160x144
 ## interface rectangle lands on a whole tile.
-static func buffer_for(area: Vector2, scale: float) -> Vector2i:
+static func buffer_for(area: Vector2, at_scale: float) -> Vector2i:
 	var wanted := Vector2i(
-		maxi(ceili(area.x / maxf(scale, MIN_SCALE)), WIDTH),
-		maxi(ceili(area.y / maxf(scale, MIN_SCALE)), HEIGHT),
+		maxi(ceili(area.x / maxf(at_scale, MIN_SCALE)), WIDTH),
+		maxi(ceili(area.y / maxf(at_scale, MIN_SCALE)), HEIGHT),
 	)
 	return Vector2i(
 		WIDTH + ceili(float(wanted.x - WIDTH) / float(BUFFER_STEP)) * BUFFER_STEP,

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -60,6 +60,11 @@ const ROW_STEP: int = 2
 ## `ScrollingMenu_CallFunctions1and2` steps `wMenuData_ScrollingMenuWidth` from
 ## the name before it calls function 2.
 const PRICE_COLUMN: int = NAME_AT.x + 8
+## The cells a shelf row's name is drawn in, up to the column the arrows stand
+## in. Every cartridge item name fits; a shelf line a mod registers is any
+## length, so it is bounded and a long one ends in an ellipsis rather than being
+## drawn over the border.
+const NAME_CELLS: int = LIST_RIGHT - NAME_AT.x
 
 ## `UpdateItemDescription`: `hlcoord 0, 12` with `lb bc, 4, SCREEN_WIDTH - 2`,
 ## so a six-row frame across the screen, and the description at `decoord 1, 14`.
@@ -216,7 +221,7 @@ func _draw_list(indices: PackedByteArray, width: int, state: Dictionary) -> void
 		if bool(row.get("cancel", false)):
 			_text(indices, width, CANCEL, at)
 			continue
-		_text(indices, width, String(row.get("name", "")), at)
+		_text(indices, width, String(row.get("name", "")), at, NAME_CELLS)
 		_text(
 			indices, width, money_string(int(row.get("price", 0))),
 			Vector2i(PRICE_COLUMN, at.y + 1)
@@ -259,8 +264,12 @@ func _draw_quantity(
 	_text(indices, width, money_string(subtotal), SUBTOTAL_AT)
 
 
-func _text(indices: PackedByteArray, width: int, text: String, at: Vector2i) -> void:
-	font.draw_text(text, indices, width, at.x * TILE, at.y * TILE)
+func _text(
+	indices: PackedByteArray, width: int, text: String, at: Vector2i, cells: int = -1
+) -> void:
+	font.draw_text(
+		text, indices, width, at.x * TILE, at.y * TILE, Gen2Text.FONT_MAIN, cells
+	)
 
 
 func _code(indices: PackedByteArray, width: int, code: int, at: Vector2i) -> void:

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -52,6 +52,14 @@ const OPTIONS_CURSOR_COLUMN: int = 1
 const OPTIONS_VISIBLE_ROWS: int = 8
 const OPTIONS_VISIBLE_VALUE_ROWS: int = 7
 
+## The cells a row's own words are drawn in, from its column to the last one
+## before the right-hand border. Every cartridge option is written to fit; a
+## mod's name and a view's label are not, so both are drawn bounded and a cut
+## one ends in an ellipsis. Documented in `docs/MODS.md` as the budget a mod
+## names itself to.
+const OPTIONS_LABEL_CELLS: int = COLUMNS - 1 - OPTIONS_LABEL_COLUMN
+const OPTIONS_VALUE_CELLS: int = COLUMNS - 1 - OPTIONS_VALUE_COLUMN
+
 ## `DisplaySaveInfoOnSave`'s `lb de, 4, 0` through `_OffsetMenuHeader`, which
 ## keeps `menu_coords 0, 0, 15, 9`'s span and moves its left edge to column 4.
 const SAVE_INFO_LEFT: int = 4
@@ -255,12 +263,17 @@ func render_options(rows: Array, cursor: int) -> Image:
 	for index: int in rows.size():
 		var row: Dictionary = rows[index]
 		var label_row: int = OPTIONS_FIRST_ROW + 2 * index
-		_text(indices, String(row.get("label", "")), OPTIONS_LABEL_COLUMN, label_row)
+		_text(
+			indices, String(row.get("label", "")), OPTIONS_LABEL_COLUMN, label_row,
+			OPTIONS_LABEL_CELLS
+		)
 		var value: String = String(row.get("value", ""))
 		if value.is_empty():
 			continue
 		_text(indices, ":", OPTIONS_COLON_COLUMN, label_row + 1)
-		_text(indices, value, OPTIONS_VALUE_COLUMN, label_row + 1)
+		_text(
+			indices, value, OPTIONS_VALUE_COLUMN, label_row + 1, OPTIONS_VALUE_CELLS
+		)
 	if cursor >= 0 and cursor < rows.size():
 		font.draw_code(
 			Gen2MenuPage.CURSOR_CODE, indices, Gen2Screen.WIDTH,
@@ -286,8 +299,13 @@ func _render_account(description: String) -> Image:
 	)
 
 
-func _text(indices: PackedByteArray, text: String, column: int, row: int) -> void:
-	font.draw_text(text, indices, Gen2Screen.WIDTH, column * TILE, row * TILE)
+func _text(
+	indices: PackedByteArray, text: String, column: int, row: int, cells: int = -1
+) -> void:
+	font.draw_text(
+		text, indices, Gen2Screen.WIDTH, column * TILE, row * TILE,
+		Gen2Text.FONT_MAIN, cells
+	)
 
 
 ## `PAL_BG_TEXT`, which is what every one of these boxes is drawn with.

--- a/game/world/boot_cinema.gd
+++ b/game/world/boot_cinema.gd
@@ -90,10 +90,10 @@ func start(
 	_emit(&"hide_image", {"id": &"boot"})
 
 
-## Whether [param phase] is one this run draws. A phase the host named, or any
+## Whether [param name] is one this run draws. A phase the host named, or any
 ## phase when it named none.
-func is_available(phase: StringName) -> bool:
-	return _available.is_empty() or phase in _available
+func is_available(name: StringName) -> bool:
+	return _available.is_empty() or name in _available
 
 
 func phase() -> StringName:
@@ -308,11 +308,11 @@ func _intro_finished() -> bool:
 	return _gs_movie.finished() if _gs_movie != null else true
 
 
-## Enters the first phase after [param phase] the host can draw, with that
+## Enters the first phase after [param name] the host can draw, with that
 ## phase's own opening events, or finishes when none is left. The events a phase
 ## leaves behind belong to the phase leaving, so a caller emits those first.
-func _enter_after(phase: StringName) -> void:
-	var at: int = PHASE_ORDER.find(phase)
+func _enter_after(name: StringName) -> void:
+	var at: int = PHASE_ORDER.find(name)
 	for index: int in range(at + 1, PHASE_ORDER.size()):
 		var next: StringName = PHASE_ORDER[index]
 		if not is_available(next):

--- a/game/world/card_flip.gd
+++ b/game/world/card_flip.gd
@@ -227,15 +227,15 @@ var _payout_left: int = 0
 var _events: Array = []
 
 
-## [param coins] is `wCoins` and [param rng] the generator every `Random` is
-## drawn from.
+## [param start_coins] is `wCoins` and [param rng] the generator every `Random`
+## is drawn from.
 static func create(
-	board: PackedByteArray, coins: int, rng: RandomNumberGenerator
+	board: PackedByteArray, start_coins: int, rng: RandomNumberGenerator
 ) -> Gen2CardFlip:
 	var game := Gen2CardFlip.new()
 	game._rng = rng
 	game._board = board
-	game._coins = clampi(coins, 0, MAX_COINS)
+	game._coins = clampi(start_coins, 0, MAX_COINS)
 	game._deck.resize(DECK_SIZE)
 	game._discarded.resize(DECK_SIZE)
 	game._tilemap.resize(SCREEN_COLUMNS * SCREEN_ROWS)

--- a/game/world/game_freak_presents.gd
+++ b/game/world/game_freak_presents.gd
@@ -149,8 +149,8 @@ var _logo_palette: int = OBJECT_PALETTE_ORDER
 ## motion is read out of. Without one the sprites sit still and the frame counts
 ## are unchanged, so a caller with no animation layer still spends the right
 ## frames.
-func start(profile: StringName, sine: Gen2BattleAnimData = null) -> void:
-	_profile = profile
+func start(id: StringName, sine: Gen2BattleAnimData = null) -> void:
+	_profile = id
 	_sine = sine
 	_scene = 0
 	_timer = 0

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -828,9 +828,9 @@ func _update_tilemap_and_bg_map() -> void:
 func _animate_ocean_waves() -> void:
 	if _counter2 & 0x03 == 0x03:
 		return
-	var set: int = (_counter2 & 0x30) >> 4
+	var group: int = (_counter2 & 0x30) >> 4
 	for column: int in MAP_COLUMNS:
-		_bg_map[WAVE_ROW * MAP_COLUMNS + column] = 0x70 + set * 4 + (column & 0x03)
+		_bg_map[WAVE_ROW * MAP_COLUMNS + column] = 0x70 + group * 4 + (column & 0x03)
 
 
 ## `Intro_InitSineLYOverrides`: `BattleAnim_Sine_e` at amplitude 4, one entry per
@@ -917,13 +917,13 @@ func _meta_tiles() -> PackedByteArray:
 
 ## `DrawIntroCharizardGraphic`: eight rows blanked, then a run of ascending tile
 ## numbers laid out at the frame's own width, height and corner.
-func _draw_charizard(frame: int) -> void:
+func _draw_charizard(index: int) -> void:
 	for row: int in CHARIZARD_CLEAR_ROWS:
 		for column: int in COLUMNS:
 			var cell: int = (CHARIZARD_CLEAR_ROW + row) * MAP_COLUMNS + column
 			if cell < _bg_map.size():
 				_bg_map[cell] = 0
-	var entry: Array = CHARIZARD_FRAMES[frame]
+	var entry: Array = CHARIZARD_FRAMES[index]
 	var tile: int = int(entry[0])
 	for row: int in int(entry[2]):
 		for column: int in int(entry[1]):

--- a/game/world/slot_machine.gd
+++ b/game/world/slot_machine.gd
@@ -250,14 +250,15 @@ static func _percent(value: int) -> int:
 	return value * 0xFF / 100
 
 
-## [param coins] is `wCoins`, [param lucky] the `wScriptVar` the map set, and
-## [param rng] the generator every `Random` here is drawn from.
+## [param start_coins] is `wCoins`, [param lucky] the `wScriptVar` the map set,
+## and [param rng] the generator every `Random` here is drawn from.
 static func create(
-	strips: Array[PackedByteArray], coins: int, lucky: bool, rng: RandomNumberGenerator
+	strips: Array[PackedByteArray], start_coins: int, lucky: bool,
+	rng: RandomNumberGenerator
 ) -> Gen2SlotMachine:
 	var machine := Gen2SlotMachine.new()
 	machine._rng = rng
-	machine._coins = clampi(coins, 0, MAX_COINS)
+	machine._coins = clampi(start_coins, 0, MAX_COINS)
 	machine._lucky = lucky
 	for reel: int in REELS:
 		var state := Reel.new()

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -127,10 +127,10 @@ func configure_tileset(
 ## water moving across a route boundary rather than restarting it.
 func reload_tileset(world: Gen2WorldAPI, time_of_day: int = Gen2WorldPalette.TIME_MORNING) -> void:
 	var at_command: int = _command_index
-	var timer: int = _timer
+	var at_timer: int = _timer
 	configure(world, time_of_day)
 	_command_index = at_command
-	_timer = timer
+	_timer = at_timer
 
 
 ## Runs one hardware frame's command and reports whether the tile strip or a

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -584,8 +584,8 @@ static func _last_healthy(save: Gen2SaveData, party_index: int) -> bool:
 
 ## `.day_care_lady`'s three `inc [hl]`: one point of experience, with the high
 ## byte held at `MAX_DAY_CARE_EXP`'s own on the pass a carry reaches it.
-static func _day_care_exp_after(exp: int) -> int:
-	var raised: int = (exp + 1) & 0xFFFFFF
+static func _day_care_exp_after(points: int) -> int:
+	var raised: int = (points + 1) & 0xFFFFFF
 	if raised & 0xFFFF == 0 and raised >> 16 >= MAX_DAY_CARE_EXP >> 16:
 		return MAX_DAY_CARE_EXP
 	return raised

--- a/tests/unit/test_font.gd
+++ b/tests/unit/test_font.gd
@@ -235,3 +235,34 @@ func test_a_cache_without_the_battle_strip_refuses_that_run_rather_than_guessing
 	# And the letters it does have still draw.
 	font.draw_code(RomLayout.FONT_FIRST_CODE, into, Gen2Font.TILE, 0, 0)
 	assert_eq(into[0], Gen2Tiles.INK)
+
+
+func test_a_bounded_run_that_fits_is_untouched() -> void:
+	var codes: PackedByteArray = Gen2Font.fit("AB", 4)
+	assert_eq(codes, Gen2Text.encode("AB"))
+
+
+func test_a_bounded_run_that_does_not_fit_ends_in_an_ellipsis() -> void:
+	# The whole point: two labels sharing a prefix must not draw the same cells.
+	var codes: PackedByteArray = Gen2Font.fit("ABABAB", 3)
+	assert_eq(codes.size(), 3)
+	assert_eq(codes[2], Gen2Text.ELLIPSIS_CODE)
+	assert_eq(codes.slice(0, 2), Gen2Text.encode("AB"))
+
+
+func test_one_cell_of_room_is_all_ellipsis_and_none_is_nothing() -> void:
+	assert_eq(Gen2Font.fit("ABAB", 1), PackedByteArray([Gen2Text.ELLIPSIS_CODE]))
+	assert_eq(Gen2Font.fit("ABAB", 0), PackedByteArray())
+
+
+func test_the_battle_strip_cuts_without_an_ellipsis() -> void:
+	# $75 is part of an HP bar with that strip loaded, so there is no glyph to
+	# mark the cut with.
+	var codes: PackedByteArray = Gen2Font.fit("ABAB", 2, Gen2Text.FONT_BATTLE_EXTRA)
+	assert_eq(codes, Gen2Text.encode("AB", Gen2Text.FONT_BATTLE_EXTRA))
+
+
+func test_drawing_stops_at_the_bound_and_marks_it() -> void:
+	var into: PackedByteArray = _canvas(4)
+	assert_eq(_font.draw_text("AAAA", into, 4 * Gen2Font.TILE, 0, 0, Gen2Text.FONT_MAIN, 2), 2)
+	assert_eq(into[Gen2Font.TILE * 2], 0, "nothing past the bound")

--- a/tests/unit/test_menu_page.gd
+++ b/tests/unit/test_menu_page.gd
@@ -179,6 +179,9 @@ func test_the_pokepic_box_refuses_a_species_the_cache_does_not_hold() -> void:
 ## written to fit the box it is placed in. A label a mod registers is not, and
 ## unbounded it was drawn straight through the right-hand border and over
 ## whatever the box sits on, which is what the in-game MODS row could do.
+## The cut itself, and that it is marked, are [Gen2Font]'s and tested there. Here
+## the row is only bounded: the ellipsis lands in the last interior column, which
+## this cache has no tile for, so the column before it is the last glyph.
 func test_a_row_too_wide_for_its_box_is_cut_at_the_border() -> void:
 	var box: Gen2MenuBox = _box()
 	var indices: PackedByteArray = _blank()
@@ -186,7 +189,10 @@ func test_a_row_too_wide_for_its_box_is_cut_at_the_border() -> void:
 
 	# The last interior column, one short of the right-hand border at box.right.
 	var last: int = box.left + box.interior().x
-	assert_true(_ink_in_tile(indices, Vector2i(last, box.item_position(0).y)), "fills the row")
+	assert_true(
+		_ink_in_tile(indices, Vector2i(last - 1, box.item_position(0).y)),
+		"fills the row up to the cut"
+	)
 	for column: int in range(box.right + 1, Gen2Screen.WIDTH / TILE):
 		assert_false(
 			_ink_in_tile(indices, Vector2i(column, box.item_position(0).y)),

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1615,6 +1615,19 @@ func test_the_view_list_names_each_id_once_with_the_built_in_first() -> void:
 	assert_eq(host.view_surfaces(&"arena"), {"world": false, "battle": true})
 
 
+## The start menu's VIEW row is the one place a shipped build picks a view, and
+## it draws a label in eight cells. The built-in one is the host's own, so a
+## rename that no longer reads whole there fails here rather than in a photo.
+func test_the_built_in_view_label_fits_the_row_it_is_read_in() -> void:
+	var label: String = Gen2ModHost.instance().view_label(Gen2ModHost.BUILT_IN_RENDERER)
+	assert_false(label.is_empty())
+	assert_eq(
+		Gen2Font.fit(label, Gen2StartMenuPage.OPTIONS_VALUE_CELLS),
+		Gen2Text.encode(label),
+		"%s is drawn cut in the VIEW row" % label
+	)
+
+
 ## The choice is the installation's, so it outlives the host a mod list change
 ## throws away. A stored id whose mod is no longer registered draws with the
 ## built-in renderer and is not refused: the mod may be reinstalled.


### PR DESCRIPTION
The start menu draws a mod's name and a view's label into the hardware's twenty
cells. It cut them without saying so. The VIEW row read "Game Boy" for the
built-in "Game Boy Color 2D", so two views could read the same on a screen that
is the only place a shipped build picks one, and a mod's name ran straight
through the panel border mid-word.

The bound is `Gen2Font.draw_text`'s and it was a plain cut. It ends in
`charmap.asm`'s own ellipsis now, so every label drawn anywhere goes through one
rule: the options page, every menu box, and a mart shelf line a mod registers.
The battle-extra strip has no tile under $75, so under that font the run is cut
without one.

Three more things came with it:

- The options page bounded neither column. It bounds both now, from its own
  constants, so a long value is cut inside the frame instead of over it.
- A mart shelf line a mod registers was drawn unbounded. Same fault, same fix.
- The built-in view is labelled `GBC 2D`, which is read whole in eight cells.
  `test_mods` fails if a later rename does not fit, so it is caught here and not
  in a screenshot.

`docs/MODS.md` gains the two budgets, 17 cells for a name and 8 for a value, so
a mod can name itself to fit.

Full GUT tier green, 3113 tests. `validate.gd -- all` passes, `replay_world.gd`
is 33 routes and 0 failures, and the story walk runs clean on all three
cartridges.