### PR TITLE
Ask for a nickname when a Pokemon is caught

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -263,6 +263,15 @@ var _capture_waiting: bool = false
 var _capture_messages: Array[String] = []
 var _capture_terminal: bool = false
 var _capture_result: Dictionary = {}
+## `PokeBallEffect`'s own `AskGiveNicknameText`, which stands over the battle
+## because the whole routine runs inside it. Null while nothing is being named.
+var _capture_nickname_host: Gen2NicknamePromptScreen = null
+## `wStringBuffer1` after `InitName`: the species name until the player answers
+## the naming screen with something else.
+var _capture_nickname: String = ""
+## Whether the prompt for the catch now on screen has already been answered, so
+## the pump finishes the capture instead of asking twice.
+var _capture_nickname_asked: bool = false
 
 ## Where a level-up's move offer has got to, following LearnMove and ForgetMove
 ## (engine/pokemon/learn.asm): [code]&"ask"[/code] is AskForgetMoveText's yes/no,
@@ -706,6 +715,11 @@ func advance_hardware_frame() -> bool:
 	## complete the page forever and never acknowledge it.
 	if _box != null:
 		_box.advance_frame()
+	## The prompt draws its own box, and its `YesNoBox` does not appear until
+	## that box owes nothing, so it is spent a frame at a time like this one.
+	if _capture_nickname_host != null:
+		_capture_nickname_host.advance_frame()
+		return true
 	if _switch_stage in [&"pick", &"refused"]:
 		moved = advance_party_icons()
 		_refresh_menu_layer()
@@ -2418,12 +2432,72 @@ func _capture_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "reason": reason}
 
 
+## `AskGiveNicknameText`, `YesNoBox` and `NamingScreen`, which `PokeBallEffect`
+## runs for a caught Pokemon whether it went to the party or to the box, and
+## which `.catch_bug_contest_mon` and `.FinishTutorial` both jump past.
+##
+## True while the prompt stands, so the pump that called this waits for it.
+func _open_capture_nickname() -> bool:
+	if _capture_nickname_host != null:
+		return true
+	if _capture_nickname_asked or _data == null or _screen == null:
+		return false
+	if not bool(_capture_result.get("caught", false)) \
+		or bool(_capture_result.get("contest", false)):
+		return false
+	var species_name: String = _name_of(_enemy)
+	if species_name.is_empty():
+		return false
+	_capture_nickname_asked = true
+	_capture_nickname = species_name
+	var host := Gen2NicknamePromptScreen.new()
+	## `.SendToPC` prints `BallSentToPCText` behind the naming and the party
+	## branch prints nothing, which is the one difference between the two.
+	var destination: Dictionary = _capture_result.get("destination", {})
+	host.set_context(
+		_data, species_name,
+		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT \
+			if StringName(destination.get("destination", &"")) == &"box" else "",
+		Gen2WorldPartyHost.capture_nickname_question(species_name)
+	)
+	host.named.connect(_on_capture_named)
+	host.closed.connect(_on_capture_nickname_closed)
+	host.z_index = 30
+	_capture_nickname_host = host
+	_screen.display(host)
+	if _capture_nickname_host == null:
+		return false
+	## The battle's own box is what the prompt stands over, and it is left where
+	## `Text_GotchaMonWasCaught` put it: `ClearSprites` takes the sprites down,
+	## not the box.
+	return true
+
+
+func _on_capture_named(nickname: String) -> void:
+	_capture_nickname = nickname
+
+
+func _on_capture_nickname_closed() -> void:
+	_close_capture_nickname()
+	_continue_after_messages()
+
+
+func _close_capture_nickname() -> void:
+	var host: Gen2NicknamePromptScreen = _capture_nickname_host
+	_capture_nickname_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+
+
 func _clear_capture_action() -> void:
 	_capture_selecting = false
 	_capture_waiting = false
 	_capture_messages.clear()
 	_capture_terminal = false
 	_capture_result.clear()
+	_close_capture_nickname()
+	_capture_nickname = ""
+	_capture_nickname_asked = false
 
 
 func _reset_capture_state() -> void:
@@ -2773,6 +2847,10 @@ func advance() -> void:
 func _continue_after_messages() -> void:
 	if _box == null:
 		return
+	## `PokeBallEffect` does not return until the naming is over, so nothing
+	## behind it runs while the prompt is up.
+	if _capture_nickname_host != null:
+		return
 	## The same waits [method _resume_after_frames] respects: a box still up, a
 	## line held behind a bar, or frames nobody has spent yet.
 	if _intro != null or bars_animating() or fainting() or animation_running():
@@ -2814,7 +2892,13 @@ func _continue_after_messages() -> void:
 		if bool(_capture_result.get("replace_offer", false)) and _switch_stage == &"":
 			_open_yes_no(&"contest_replace", CONTEST_REPLACE_TEXT)
 			return
+		## `.skip_pokedex` reaches `.catch_bug_contest_mon` before either
+		## `AskGiveNicknameText`, so a contest catch is never named.
+		if _open_capture_nickname():
+			return
 		var capture: Dictionary = _capture_result.duplicate(true)
+		if not _capture_nickname.is_empty():
+			capture["nickname"] = _capture_nickname
 		_clear_capture_action()
 		_finish_world_capture(capture)
 		return
@@ -4321,6 +4405,9 @@ func _renderer_input_free() -> bool:
 
 
 func _handle_button(button: int) -> bool:
+	if _capture_nickname_host != null:
+		return _capture_nickname_host.handle_button(button)
+
 	if _forget_stage != &"":
 		_answer_forget(button)
 		return true

--- a/game/world/nickname_prompt_screen.gd
+++ b/game/world/nickname_prompt_screen.gd
@@ -27,8 +27,13 @@ enum Phase {
 var _data: GameData = null
 ## `wStringBuffer1`, which is the species name until the player replaces it.
 var _species_name: String = ""
-## `_WasSentToBillsPCText` when the gift landed in the box, empty otherwise.
-var _after_text: String = ""
+## `_WasSentToBillsPCText`/`_BallSentToPCText` when the Pokemon landed in the
+## box, empty otherwise. A format, because both read the name buffer the naming
+## screen has just written rather than the species name the question asked with.
+var _after_text_format: String = ""
+## `_CaughtAskNicknameText` unless the caller names `PokeBallEffect`'s own
+## `_AskGiveNicknameText` instead.
+var _question: String = ""
 var _phase: int = Phase.DONE
 var _yes: bool = true
 var _answer: String = ""
@@ -39,10 +44,17 @@ var _menu: TextureRect = null
 var _naming: Gen2NamingScreenScreen = null
 
 
-func set_context(data: GameData, species_name: String, after_text: String = "") -> void:
+func set_context(
+	data: GameData,
+	species_name: String,
+	after_text_format: String = "",
+	question: String = ""
+) -> void:
 	_data = data
 	_species_name = species_name
-	_after_text = after_text
+	_after_text_format = after_text_format
+	_question = question if not question.is_empty() \
+		else Gen2WorldPartyHost.caught_nickname_question(species_name)
 
 
 func _ready() -> void:
@@ -58,7 +70,7 @@ func _ready() -> void:
 	_text_box.visible = true
 	## `_CaughtAskNicknameText` ends in `done`, so the last page draws no arrow:
 	## what waits is the `YesNoBox` behind it.
-	_text_box.show_text(Gen2WorldPartyHost.caught_nickname_question(_species_name), false)
+	_text_box.show_text(_question, false)
 
 
 func phase() -> int:
@@ -208,12 +220,12 @@ func _on_named(entered: String) -> void:
 
 
 func _after_question() -> void:
-	if _after_text.is_empty():
+	if _after_text_format.is_empty():
 		_finish()
 		return
 	_phase = Phase.AFTER_TEXT
 	_text_box.visible = true
-	_text_box.show_text(_after_text)
+	_text_box.show_text(_after_text_format % _answer)
 
 
 func _finish() -> void:

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -17,8 +17,11 @@ extends RefCounted
 ## screen that can draw one intercepts the request in front of this list
 ## (`Gen2WorldScreen._open_gift_nickname`) and a driver that cannot settles it
 ## here with the species name, which is what NO answers.
+## `contest_mon_requested` is `CheckPartyFullAfterContest`, which reaches the
+## same routine one caller further on and is intercepted the same way.
 const UNATTENDED_REQUESTS: Array[StringName] = [
 	&"party_heal_requested", &"pokemon_requested", &"trade_requested",
+	&"contest_mon_requested",
 ]
 
 
@@ -35,7 +38,7 @@ static func complete_runtime_request(
 	if request.is_empty():
 		return _unavailable(&"runtime_request_not_pending", {})
 	var kind: StringName = StringName(request.get("kind", &""))
-	if kind in [&"pokemon_requested", &"trade_requested"]:
+	if kind in [&"pokemon_requested", &"trade_requested", &"contest_mon_requested"]:
 		return Gen2WorldPartyHost.complete_runtime_request(
 			world, result, save, persist, random
 		)

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -15,6 +15,14 @@ const CAUGHT_EGG_LEVEL: int = 1
 const HATCHED_HAPPINESS: int = 0x78
 ## `LANDMARK_GIFT`, the landmark `SetGiftMonCaughtData` writes instead of a map.
 const LANDMARK_GIFT: int = 0x7E
+## `LANDMARK_NATIONAL_PARK`, which `CheckPartyFullAfterContest` writes over
+## whatever `SetCaughtData` read off the map the results are collected on.
+const LANDMARK_NATIONAL_PARK: int = 13
+
+## `CheckPartyFullAfterContest`'s own three answers.
+const BUGCONTEST_CAUGHT_MON: int = 0
+const BUGCONTEST_BOXED_MON: int = 1
+const BUGCONTEST_NO_CATCH: int = 2
 ## `HatchEggs`' own `cp TOGEPI`, the one species whose hatch sets an event flag.
 const SPECIES_TOGEPI: int = 0xAF
 const EVENT_TOGEPI_HATCHED: int = 84
@@ -136,7 +144,7 @@ static func complete_runtime_request(
 	if request.is_empty():
 		return _failure(&"runtime_request_not_pending", {})
 	var kind: StringName = StringName(request.get("kind", &""))
-	if kind not in [&"pokemon_requested", &"trade_requested"]:
+	if kind not in [&"pokemon_requested", &"trade_requested", &"contest_mon_requested"]:
 		return _failure(&"party_request_not_pending", request)
 	if save == null or world.data == null:
 		return _failure(&"missing_save", request)
@@ -188,6 +196,9 @@ static func complete_runtime_request(
 		"ok": true,
 		"handled": true,
 		"request": request,
+		## What the script read out of wScriptVar, which for
+		## `CheckPartyFullAfterContest` is the branch its caller takes.
+		"script_value": int(transaction.get("script_value", 0)),
 		"transaction": transaction.get("summary", {}).duplicate(true),
 		"results": resumed,
 	}
@@ -689,10 +700,23 @@ static func caught_nickname_question(species_name: String) -> String:
 	]
 
 
-## `_WasSentToBillsPCText`, printed behind the nickname whenever a `givepoke`
-## landed in the box.
+## `_AskGiveNicknameText`, which is `PokeBallEffect`'s own question and not
+## `GiveANickname_YesNo`'s: a caught Pokemon is asked about by name alone, where
+## a received one is [method caught_nickname_question]'s longer line.
+static func capture_nickname_question(species_name: String) -> String:
+	return "Give a nickname to\n%s?" % species_name
+
+
+## `_WasSentToBillsPCText` and `_BallSentToPCText`, which are the same words in
+## the same shape: the gift path reads `wStringBuffer1` and the capture path
+## `wMonOrItemNameBuffer`, and both hold the name the row ended up with rather
+## than the species. Kept as a format so the screen that owns the naming can
+## fill it in with its own answer.
+const SENT_TO_BOX_FORMAT: String = "%s was\nsent to BILL's PC."
+
+
 static func sent_to_box_text(species_name: String) -> String:
-	return "%s was\nsent to BILL's PC." % species_name
+	return SENT_TO_BOX_FORMAT % species_name
 
 
 ## Where `GivePoke` would put one more Pokemon: `TryAddMonToParty` first, then
@@ -940,6 +964,135 @@ static func capture_wild(
 	}
 
 
+## `CheckPartyFullAfterContest`, which is what takes home whatever the Bug
+## Catching Contest caught. `wContestMon` is a party struct already, so the party
+## branch is a copy and the box branch an `InsertPokemonIntoBox`; each stands
+## behind its own `GiveANickname_YesNo`, and `SetCaughtData` is then overwritten
+## with LANDMARK_NATIONAL_PARK, the gender bit kept.
+##
+## Three things a reading gets wrong. `.BoxFull` writes nothing and still answers
+## BUGCONTEST_BOXED_MON, so a full party over a full box loses the catch; the box
+## branch prints no "sent to BILL's PC" line, because the script's own
+## `ContestResults_PartyFullText` is what BUGCONTEST_BOXED_MON reaches; and
+## `wContestMon` is cleared on every branch but that last one.
+static func _apply_contest_mon(
+	world: Gen2WorldAPI,
+	candidate: Gen2SaveData,
+	result: Dictionary,
+	random: RandomNumberGenerator
+) -> Dictionary:
+	var caught: Dictionary = world.state.contest_mon() if world.state != null else {}
+	var species: int = int(caught.get("species", 0))
+	if species <= 0 or world.data.species(species).is_empty():
+		return {
+			"ok": true, "accepted": false, "script_value": BUGCONTEST_NO_CATCH,
+			"reason": &"no_contest_catch",
+			"summary": {"kind": &"contest_mon", "accepted": false},
+		}
+	var boxed: bool = candidate.party.size() >= Gen2SaveData.MAX_PARTY
+	if boxed and not bool(candidate.first_empty_box_slot().get("ok", false)):
+		## `.BoxFull`: nothing is written and the catch is gone, which is the
+		## cartridge's own answer rather than a refusal of this port's.
+		world.state.set_contest_mon({})
+		return {
+			"ok": true, "accepted": false, "script_value": BUGCONTEST_BOXED_MON,
+			"reason": &"storage_full",
+			"summary": {"kind": &"contest_mon", "accepted": false, "species": species},
+		}
+	var mon: Gen2SaveMon = _new_mon(
+		world.data, candidate, species, int(caught.get("level", 1)),
+		int(caught.get("item", 0)), random, false, int(caught.get("dvs", -1))
+	)
+	if mon == null:
+		return {"ok": false, "reason": &"could_not_create_pokemon"}
+	## The health it was standing there with, which is what `ContestScore` read
+	## and what the struct kept.
+	mon.hp = clampi(int(caught.get("hp", mon.hp)), 0, mon.hp)
+	if result.has("nickname"):
+		var chosen: String = String(result["nickname"]).strip_edges()
+		if not chosen.is_empty():
+			mon.nickname = chosen
+	set_caught_data(
+		mon, int(caught.get("level", 1)), world.object_time_of_day,
+		world.player_female(), LANDMARK_NATIONAL_PARK
+	)
+	var placed: Dictionary = candidate.add_party_or_box(mon)
+	if not bool(placed.get("ok", false)):
+		return {"ok": false, "reason": StringName(placed.get("reason", &"storage_full"))}
+	world.state.set_contest_mon({})
+	return {
+		"ok": true,
+		"accepted": true,
+		"script_value": BUGCONTEST_BOXED_MON if boxed else BUGCONTEST_CAUGHT_MON,
+		"register_caught": species,
+		"register_unown": _unown_form(species, mon.dvs, placed),
+		"summary": {
+			"kind": &"contest_mon", "accepted": true, "species": species,
+			"level": int(caught.get("level", 1)),
+			"destination": placed.get("destination", &"party"),
+			"nickname": mon.nickname,
+		},
+	}
+
+
+## `InitNickname`, which `PokeBallEffect` runs once the row is already in the
+## party or the box: `NamingScreen` writes into `wPartyMonNicknames` or
+## `sBoxMonNicknames` rather than into the struct the catch built, so the rename
+## is its own write and not part of [method capture_wild]'s transaction.
+##
+## [param destination] is that method's own answer. Nothing is written when the
+## player kept the species name, which is what NO and an empty entry both leave
+## in `wStringBuffer1`.
+static func name_captured_mon(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	destination: Dictionary,
+	nickname: String,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or save == null or nickname.strip_edges().is_empty():
+		return _failure(&"missing_nickname_context", {})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	var candidate: Gen2SaveData = opened["candidate"]
+	var mon: Gen2SaveMon = _captured_row(candidate, destination)
+	if mon == null:
+		return _failure(&"captured_row_not_found", destination.duplicate(true))
+	if mon.nickname == nickname:
+		return {"ok": true, "handled": true, "renamed": false}
+	mon.nickname = nickname
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	return {"ok": true, "handled": true, "renamed": true, "nickname": nickname}
+
+
+## The row [method capture_wild] just wrote, on either side of
+## `TryAddMonToParty`/`SendMonIntoBox`.
+static func _captured_row(save: Gen2SaveData, destination: Dictionary) -> Gen2SaveMon:
+	if save == null or destination.is_empty():
+		return null
+	match StringName(destination.get("destination", &"")):
+		&"party":
+			var index: int = int(destination.get("party_index", -1))
+			return save.party[index] as Gen2SaveMon \
+				if index >= 0 and index < save.party.size() else null
+		&"box":
+			var box_index: int = int(destination.get("box", -1))
+			if box_index < 0 or box_index >= save.boxes.size():
+				return null
+			var box: Gen2SaveBox = save.boxes[box_index] as Gen2SaveBox
+			var slot: int = int(destination.get("slot", -1))
+			if box == null or slot < 0 or slot >= box.slots.size():
+				return null
+			return box.slots[slot] as Gen2SaveMon
+	return null
+
+
 static func _apply_party_request(
 	world: Gen2WorldAPI,
 	candidate: Gen2SaveData,
@@ -948,6 +1101,8 @@ static func _apply_party_request(
 	random: RandomNumberGenerator
 ) -> Dictionary:
 	var kind: StringName = StringName(request.get("kind", &""))
+	if kind == &"contest_mon_requested":
+		return _apply_contest_mon(world, candidate, result, random)
 	if kind == &"pokemon_requested":
 		var values: Dictionary = request.get("values", {})
 		var is_egg: bool = not values.has("pokemon")

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1715,8 +1715,43 @@ func _open_gift_nickname(request: Dictionary) -> bool:
 	var host := Gen2NicknamePromptScreen.new()
 	host.set_context(
 		_data, species_name,
-		Gen2WorldPartyHost.sent_to_box_text(species_name) if destination == &"box" else ""
+		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT if destination == &"box" else ""
 	)
+	_nickname_answer = species_name
+	host.named.connect(_on_gift_named)
+	host.closed.connect(_on_gift_nickname_closed)
+	host.z_index = 30
+	_nickname_host = host
+	_screen.display(host)
+	if _nickname_host == null:
+		return false
+	_script_prompt = "Nickname"
+	_refresh_labels()
+	return true
+
+
+## `CheckPartyFullAfterContest`'s own `GiveANickname_YesNo`, which is the same
+## question the gift path asks and reaches no "sent to BILL's PC" line: the box
+## branch prints nothing and the script's `ContestResults_PartyFullText` is what
+## BUGCONTEST_BOXED_MON reaches instead.
+##
+## False when the routine reaches no prompt: nothing was caught, and `.BoxFull`,
+## which writes nothing and answers BUGCONTEST_BOXED_MON where it stands.
+func _open_contest_nickname() -> bool:
+	if _nickname_host != null or _world == null or _data == null or _world.state == null:
+		return false
+	var caught: Dictionary = _world.state.contest_mon()
+	var species_name: String = String(
+		_data.species(int(caught.get("species", 0))).get("name", "")
+	)
+	if species_name.is_empty():
+		return false
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	if Gen2WorldPartyHost.gift_destination(save) == &"full":
+		return false
+	var host := Gen2NicknamePromptScreen.new()
+	host.set_context(_data, species_name)
 	_nickname_answer = species_name
 	host.named.connect(_on_gift_named)
 	host.closed.connect(_on_gift_nickname_closed)
@@ -3271,7 +3306,7 @@ func preview_gift_nickname(species: int = 0, boxed: bool = false) -> void:
 	var host := Gen2NicknamePromptScreen.new()
 	host.set_context(
 		_data, species_name,
-		Gen2WorldPartyHost.sent_to_box_text(species_name) if boxed else ""
+		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT if boxed else ""
 	)
 	_nickname_answer = species_name
 	_nickname_preview = true
@@ -3627,19 +3662,71 @@ func preview_capture() -> void:
 	call_deferred("_preview_capture_throw")
 
 
+## Retried on the next idle frame rather than inside this one: a `call_deferred`
+## made while the queue is flushing is appended to the flush that is running, so
+## a self-deferring retry never lets a frame pass and fills the queue instead.
 func _preview_capture_throw() -> void:
-	if _battle_host == null or _battle_host.capture_target() == null:
-		call_deferred("_preview_capture_throw")
+	if _preview_throw_master_ball():
 		return
+	if _battle_host != null:
+		get_tree().process_frame.connect(
+			_preview_capture_throw, CONNECT_ONE_SHOT | CONNECT_DEFERRED
+		)
+
+
+## True once the throw has been made. False while the battle has no live wild
+## target yet, which is the caller's cue to spend a frame and ask again.
+func _preview_throw_master_ball() -> bool:
+	if _battle_host == null or _battle_host.capture_target() == null:
+		return false
 	var balls: Array[int] = _battle_host.available_capture_balls()
 	var master_index: int = balls.find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
 	if master_index < 0:
-		return
+		return true
 	if not bool(_battle_host.begin_capture().get("ok", false)):
-		return
+		return true
 	_battle_host.select_capture_ball(master_index)
 	_battle_host.throw_capture_ball()
 	_battle_host.finish()
+	return true
+
+
+## Public screenshot driver for `PokeBallEffect`'s own `AskGiveNicknameText`,
+## which stands over the battle rather than over the map: [method
+## preview_capture]'s throw, driven past `Text_GotchaMonWasCaught` to the
+## question. Answers whether the prompt is up.
+func preview_catch_nickname() -> bool:
+	preview_capture()
+	## `DoBattleTransition` stands between the request and the fight, and the
+	## throw needs the fight: the `battle` preview settles it the same way.
+	settle_battle_transition()
+	for _frame: int in CATCH_NICKNAME_FRAMES:
+		if _battle_host == null:
+			return false
+		if _preview_throw_master_ball():
+			break
+		_battle_host.advance_hardware_frame()
+	## `BattleIntroSlidingPics`, the throw line and up to four shakes, each of
+	## them a box that owes frames before the press that clears it.
+	for _frame: int in CATCH_NICKNAME_FRAMES:
+		if _battle_host == null:
+			return false
+		var prompt: Gen2NicknamePromptScreen = _battle_host.get("_capture_nickname_host")
+		if prompt != null:
+			if prompt.question_ready():
+				_script_prompt = "Nickname"
+				_refresh_labels()
+				return true
+		else:
+			_battle_host.finish()
+			_battle_host.advance()
+		_battle_host.advance_hardware_frame()
+	return false
+
+
+## Enough for the battle's own opening, the throw and the shakes, each of which
+## is a box printing at the OPTION screen's own speed.
+const CATCH_NICKNAME_FRAMES: int = 1200
 
 
 ## Public screenshot driver for a resolved imported wild encounter. It uses the
@@ -4028,6 +4115,23 @@ func _on_capture_requested(ball: int) -> void:
 
 ## `UseDisposableItem` inside a battle: the effect has already landed on the
 ## party the battle owns, so all the world does is take the row down by one.
+## `InitNickname` behind `PokeBallEffect`'s own `YesNoBox`. The battle screen
+## owns the question and the keyboard, because the routine runs inside the
+## fight; the row it names is on the save this screen handed the catch.
+func _apply_capture_nickname(capture: Dictionary) -> void:
+	var nickname: String = String(capture.get("nickname", ""))
+	if nickname.is_empty() or _world == null:
+		return
+	var save: Gen2SaveData = _active_battle_save
+	if save == null:
+		return
+	var named: Dictionary = Gen2WorldPartyHost.name_captured_mon(
+		_world, save, capture.get("destination", {}), nickname, _active_battle_persist
+	)
+	if not bool(named.get("ok", false)):
+		_script_prompt = "Nickname refused: %s" % String(named.get("reason", "unknown"))
+
+
 func _on_battle_item_used(item: int, _target: int) -> void:
 	if _world == null or _world.inventory == null:
 		return
@@ -4117,6 +4221,7 @@ func _finish_battle_exit(result: Dictionary, fought_save: Gen2SaveData) -> void:
 					_world.state.park_balls(),
 				]
 			else:
+				_apply_capture_nickname(capture)
 				var species: Dictionary = _data.species(int(capture.get("species", 0)))
 				_script_prompt = "Caught %s" % String(species.get("name", "UNKNOWN"))
 		else:
@@ -5671,6 +5776,9 @@ func _show_script_results(results: Array) -> void:
 					return
 				if StringName(request.get("kind", &"")) == &"pokemon_requested" \
 					and _open_gift_nickname(request):
+					break
+				if StringName(request.get("kind", &"")) == &"contest_mon_requested" \
+					and _open_contest_nickname():
 					break
 				if StringName(request.get("kind", &"")) in \
 					Gen2WorldHost.UNATTENDED_REQUESTS:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -965,6 +965,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## `UnownPuzzle` answers `wSolvedUnownPuzzle`, which is zero for a board
 		## left on START and one for a solved one.
 		&"unown_puzzle_requested",
+		## `CheckPartyFullAfterContest`'s own three answers, which
+		## `BugContestResults_DidNotLeaveMons` branches on twice.
+		&"contest_mon_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -2937,12 +2940,13 @@ func _execute_special(special: int) -> Dictionary:
 		SPECIAL_CONTEST_RETURN_MONS:
 			_emit_runtime_event(&"contest_mons_returned", {"special": special})
 		SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST:
-			## `CheckPartyFullAfterContest` answers whether the Pokemon caught in
-			## the contest can be taken home, which is a party slot or a box slot.
-			var after_party: Dictionary = _request.get("party", {})
-			if after_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			_script_value = 1 if bool(after_party.get("storage_full", false)) else 0
+			## `CheckPartyFullAfterContest` does not only answer where the
+			## Pokemon caught in the contest would go: it takes it home, asks
+			## `GiveANickname_YesNo` about it and clears `wContestMon`. The
+			## answer is the party host's, since a nickname is a screen.
+			return _stage_runtime_request(&"contest_mon_requested", {
+				"special": special,
+			})
 		SPECIAL_BUG_CONTEST_JUDGING:
 			## The judging prints three placings and leaves the player's own in
 			## wScriptVar, which the results script branches on.

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -571,6 +571,7 @@ func test_master_ball_capture_runs_through_the_real_battle_overlay() -> void:
 	assert_eq(host.battle_snapshot()["message"], caught)
 	host.finish()
 	host.advance()
+	_refuse_capture_nickname(host)
 	await get_tree().process_frame
 	assert_null(_battle_host())
 	assert_eq(_world_screen._world.state.item_quantity(Gen2WorldPartyHost.ITEM_MASTER_BALL), 0)
@@ -945,6 +946,8 @@ func test_a_capture_keeps_the_damage_taken_and_the_pp_spent() -> void:
 	while _battle_child() != null and guard > 0:
 		host.finish()
 		host.advance()
+		if host.get("_capture_nickname_host") != null:
+			_refuse_capture_nickname(host)
 		guard -= 1
 	await get_tree().process_frame
 	assert_null(_battle_child())
@@ -953,6 +956,151 @@ func test_a_capture_keeps_the_damage_taken_and_the_pp_spent() -> void:
 	var after: Gen2SaveMon = save.party[0] as Gen2SaveMon
 	assert_eq(after.hp, starting_hp - 3, "the caught save must carry the damage taken")
 	assert_eq(after.pp[0], starting_pp - 1, "the caught save must carry the PP spent")
+
+
+## `PokeBallEffect`'s own `AskGiveNicknameText`, which is not
+## `GiveANickname_YesNo`'s `_CaughtAskNicknameText`: a caught Pokemon is asked
+## about by name alone. YES reaches `NamingScreen` and `InitName` writes what it
+## stored into the row `TryAddMonToParty` already added.
+func test_a_caught_pokemon_is_named_over_the_battle() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var before: int = save.party.size()
+	assert_true(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	)["ok"])
+	var host: Gen2BattleScreen = await _catch_the_wild()
+	var prompt: Gen2NicknamePromptScreen = host.get("_capture_nickname_host")
+	assert_not_null(prompt, "the prompt stands over the battle, not over the map")
+	_settle_capture_nickname_text(host, prompt)
+	assert_eq(prompt.text_lines(), PackedStringArray([
+		"Give a nickname to", "%s?" % _wild_name(),
+	]))
+	assert_eq(prompt.nickname_cursor(), 0, "YesNoBox opens on YES")
+
+	host.press_button(Gen2Button.A)
+	assert_eq(prompt.phase(), Gen2NicknamePromptScreen.Phase.NAMING)
+	var model: Gen2NamingScreen = prompt.naming_screen().model()
+	assert_eq(model.max_length, Gen2NamingScreen.MON_MAX_LENGTH)
+	model.press_a()
+	model.column = Gen2NamingScreen.LAST_COLUMN
+	model.row = model.command_row()
+	host.press_button(Gen2Button.A)
+	await get_tree().process_frame
+
+	assert_null(_battle_host(), "and the fight ends behind it")
+	assert_eq(save.party.size(), before + 1)
+	assert_eq(
+		(save.party[before] as Gen2SaveMon).nickname.length(), 1,
+		"the one letter that was entered"
+	)
+	await get_tree().process_frame
+
+
+## `.skip_nickname` keeps the species name `GetPokemonName` left in
+## `wStringBuffer1`, and B is `YesNoBox`'s own NO.
+func test_no_keeps_the_caught_species_name() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	var before: int = save.party.size()
+	assert_true(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	)["ok"])
+	var host: Gen2BattleScreen = await _catch_the_wild()
+	_refuse_capture_nickname(host)
+	await get_tree().process_frame
+	assert_null(_battle_host())
+	assert_eq(save.party.size(), before + 1)
+	assert_eq((save.party[before] as Gen2SaveMon).nickname, _wild_name())
+	await get_tree().process_frame
+
+
+## `.SendToPC` prints `BallSentToPCText` behind the naming, and it reads
+## `wMonOrItemNameBuffer`, which `.SkipBoxMonNickname`'s own copy has just filled
+## from `sBoxMonNicknames`: the line names the row, not the species.
+func test_a_boxed_catch_prints_bills_pc_with_the_name_the_keyboard_stored() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	while save.party.size() < Gen2SaveData.MAX_PARTY:
+		save.party.append(Gen2SaveMon.from_dict((save.party[0] as Gen2SaveMon).to_dict()))
+	assert_true(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	)["ok"])
+	var host: Gen2BattleScreen = await _catch_the_wild()
+	var prompt: Gen2NicknamePromptScreen = host.get("_capture_nickname_host")
+	_settle_capture_nickname_text(host, prompt)
+	host.press_button(Gen2Button.A)
+	var model: Gen2NamingScreen = prompt.naming_screen().model()
+	model.press_a()
+	model.column = Gen2NamingScreen.LAST_COLUMN
+	model.row = model.command_row()
+	host.press_button(Gen2Button.A)
+	assert_eq(prompt.phase(), Gen2NicknamePromptScreen.Phase.AFTER_TEXT)
+	_settle_capture_nickname_text(host, prompt)
+	var entered: String = " ".join(prompt.text_lines()).split(" was")[0]
+	assert_eq(entered.length(), 1, "the one letter that was entered, not the species")
+	assert_eq(
+		" ".join(prompt.text_lines()),
+		Gen2WorldPartyHost.sent_to_box_text(entered).replace("\n", " ")
+	)
+	host.press_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_null(_battle_host())
+	assert_eq(save.party.size(), Gen2SaveData.MAX_PARTY)
+	assert_eq((save.boxes[0].slots[0] as Gen2SaveMon).nickname, entered)
+	await get_tree().process_frame
+
+
+## A wild encounter, a Master Ball and the "Gotcha!" line pressed past, which is
+## where `AskGiveNicknameText` stands.
+func _catch_the_wild() -> Gen2BattleScreen:
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.select_capture_ball(
+		host.available_capture_balls().find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
+	)["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	for _message: int in 10:
+		if host.get("_capture_nickname_host") != null:
+			break
+		host.finish()
+		host.advance()
+	return host
+
+
+## `PrintText` owing the box frames, and the `YesNoBox` behind it not appearing
+## until it owes none: each page the text ends on is a press.
+func _settle_capture_nickname_text(
+	host: Gen2BattleScreen, prompt: Gen2NicknamePromptScreen
+) -> void:
+	for _frame: int in 600:
+		if prompt.phase() == Gen2NicknamePromptScreen.Phase.ASK:
+			if prompt.question_ready():
+				return
+		elif not prompt._text_box.is_revealing() and not prompt._text_box.has_pages_left():
+			return
+		if not prompt._text_box.is_revealing() and prompt._text_box.has_pages_left():
+			host.press_button(Gen2Button.A)
+		host.advance_hardware_frame()
+
+
+## `AskGiveNicknameText` behind the "Gotcha!" line, which `PokeBallEffect` prints
+## whether the catch went to the party or to the box. Spends what the box owes,
+## presses past each page it ends on, and answers NO, which is `.skip_nickname`.
+func _refuse_capture_nickname(host: Gen2BattleScreen) -> void:
+	var prompt: Gen2NicknamePromptScreen = host.get("_capture_nickname_host")
+	assert_not_null(prompt, "`AskGiveNicknameText` is drawn over the battle")
+	for _frame: int in 600:
+		if prompt.question_ready():
+			break
+		if not prompt._text_box.is_revealing() and prompt._text_box.has_pages_left():
+			host.press_button(Gen2Button.A)
+		host.advance_hardware_frame()
+	host.press_button(Gen2Button.B)
 
 
 func _event_value(events: Array, event_type: StringName, key: String) -> Variant:
@@ -1468,6 +1616,40 @@ func test_a_boxed_gift_prints_bills_pc_and_keeps_the_species_name() -> void:
 	assert_null(_world_screen.get("_nickname_host"))
 	assert_eq(save.party.size(), Gen2SaveData.MAX_PARTY)
 	assert_eq(save.boxes[0].slots[0].nickname, species_name)
+	await get_tree().process_frame
+
+
+## `.skip_nickname`'s tail runs `PrintText` before its own `CopyBytes`, so
+## `_WasSentToBillsPCText` reads the `wStringBuffer1` `InitName` just filled with
+## the typed name while the row it names is overwritten with the species. The
+## line and the row disagree on the cartridge, and they disagree here.
+func test_a_boxed_gift_names_the_typed_nickname_and_stores_the_species() -> void:
+	_write_givepoke_script()
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	while save.party.size() < Gen2SaveData.MAX_PARTY:
+		save.party.append(Gen2SaveMon.from_dict(save.party[0].to_dict()))
+	var host: Gen2NicknamePromptScreen = _run_givepoke()
+	_settle_nickname_text()
+	_world_screen.press_button(Gen2Button.A)
+	var model: Gen2NamingScreen = host.naming_screen().model()
+	model.press_a()
+	model.column = Gen2NamingScreen.LAST_COLUMN
+	model.row = model.command_row()
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(host.phase(), Gen2NicknamePromptScreen.Phase.AFTER_TEXT)
+	_settle_nickname_text()
+	var named: String = " ".join(host.text_lines()).split(" was")[0]
+	assert_eq(named.length(), 1, "the line names what the keyboard stored")
+	_world_screen.press_button(Gen2Button.A)
+	assert_null(_world_screen.get("_nickname_host"))
+	var species_name: String = String(
+		_data.species(Fixture.TRAINER_SPECIES).get("name", "")
+	)
+	assert_eq(
+		save.boxes[0].slots[0].nickname, species_name,
+		"and the row behind it keeps the species, which is the cartridge's own bug"
+	)
 	await get_tree().process_frame
 
 

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -170,6 +170,67 @@ func test_a_gift_takes_the_nickname_the_prompt_answered() -> void:
 	assert_eq(_save.party[2].nickname, "SPARKY")
 
 
+## `CheckPartyFullAfterContest` is not a question: it copies `wContestMon` into
+## the party, names it, writes LANDMARK_NATIONAL_PARK over the caught location
+## and clears the stash. BUGCONTEST_CAUGHT_MON is the answer with a party slot.
+func test_the_contest_catch_comes_home_and_is_named() -> void:
+	_world.state.set_contest_mon({"species": 25, "level": 9, "hp": 4, "dvs": 0x9888})
+	_set_script(0x6230)
+	var waiting: Array = _world.dispatch_script_events(Vector2i(2, 2))
+	assert_eq(waiting[0]["status"], &"waiting")
+	assert_eq(_world.pending_runtime_request()["kind"], &"contest_mon_requested")
+
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"nickname": "BUZZ"}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(result["script_value"], Gen2WorldPartyHost.BUGCONTEST_CAUGHT_MON)
+	assert_eq(_save.party.size(), 3)
+	var caught: Gen2SaveMon = _save.party[2]
+	assert_eq(caught.species, 25)
+	assert_eq(caught.level, 9)
+	assert_eq(caught.nickname, "BUZZ")
+	assert_eq(caught.hp, 4, "the health it was standing there with")
+	assert_eq(
+		caught.caught_location, Gen2WorldPartyHost.LANDMARK_NATIONAL_PARK,
+		"the map the results are collected on is overwritten"
+	)
+	assert_true(_world.state.contest_mon().is_empty(), "wContestMon is cleared")
+
+
+## `.TryAddToBox` with room: the answer is BUGCONTEST_BOXED_MON, which is what
+## makes the script print `ContestResults_PartyFullText`. The port used to answer
+## BUGCONTEST_CAUGHT_MON here, because it read a full party and a full box.
+func test_a_full_party_boxes_the_contest_catch_and_says_so() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	_world.state.set_contest_mon({"species": 25, "level": 9, "hp": 4, "dvs": 0x9888})
+	_set_script(0x6230)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(result["script_value"], Gen2WorldPartyHost.BUGCONTEST_BOXED_MON)
+	assert_eq(_save.party.size(), Gen2SaveData.MAX_PARTY)
+	assert_eq(_save.boxes[0].slots[0].species, 25)
+	assert_true(_world.state.contest_mon().is_empty())
+
+
+## `.DidntCatchAnything`: no `wContestMonSpecies`, BUGCONTEST_NO_CATCH, and
+## nothing written.
+func test_no_contest_catch_answers_no_catch_and_writes_nothing() -> void:
+	_set_script(0x6230)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	var before: int = _save.party.size()
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(result["script_value"], Gen2WorldPartyHost.BUGCONTEST_NO_CATCH)
+	assert_eq(_save.party.size(), before)
+
+
 ## `.skip_nickname` copies `wMonOrItemNameBuffer` over `sBoxMonNicknames` behind
 ## `InitNickname`, so a boxed gift always ends up with the species name.
 func test_a_boxed_gift_keeps_the_species_name_over_the_answer() -> void:
@@ -974,6 +1035,11 @@ func _add_party_scripts() -> void:
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6200)] = [0x2D, 25, 5, 0, 0, 0x91]
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6210)] = [0x2E, 25, 5, 0x91]
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6220)] = [0x96, 0, 0x91]
+	## `special CheckPartyFullAfterContest`, which is
+	## `BugContestResults_DidNotLeaveMons`' own first command.
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6230)] = [
+		Gen2WorldScript.SPECIAL, 21, 0, 0x91,
+	]
 	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
 
 

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -100,7 +100,9 @@ extends SceneTree
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`), the name of any
 ## `preview_*` driver on the world screen without that prefix (`field_move` is
-## `PartyMenu` with a taught CUT on it, `start_menu`, `capture`, `move_forget`
+## `PartyMenu` with a taught CUT on it, `start_menu`, `capture`,
+## `catch_nickname` (`PokeBallEffect`'s own question, over the battle the throw
+## was made in), `move_forget`
 ## and the rest; a `*_use` name is driven twice, since each call is one step of
 ## its own sequence), or one of
 ## [constant FIELD_ITEMS]' own names, which is the pack's USE on that item: the
@@ -602,6 +604,7 @@ func _process(_delta: float) -> bool:
 			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
+			&"catch_nickname",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.


### PR DESCRIPTION
`PokeBallEffect` runs inside the fight, so its `AskGiveNicknameText` stands over the battle rather than over the map. The battle screen opens the prompt on its own screen where the pump reached `Text_GotchaMonWasCaught`, and nothing behind it runs while it is up.

The question is not `GiveANickname_YesNo`'s. `_AskGiveNicknameText` names the species alone; `_CaughtAskNicknameText` is the longer "you received" line. A contest catch and the catching tutorial both jump past the prompt and neither is asked.

`InitNickname` writes into the row `TryAddMonToParty` or `SendMonIntoBox` has already added, so the rename is its own transaction behind the catch's.

## The contest catch

`CheckPartyFullAfterContest` is the same routine one caller further on, and it is not the question this port read it as. It copies `wContestMon` into the party or inserts it into a box, asks about it, writes `LANDMARK_NATIONAL_PARK` over the caught location, and clears the stash. The special answered `wScriptVar` and wrote nothing, so a contest win handed the player no Pokemon at all.

Three things the reading cost:

- `.BoxFull` writes nothing and still answers `BUGCONTEST_BOXED_MON`, so a full party over a full box loses the catch.
- The box branch prints no "sent to BILL's PC" line. `ContestResults_PartyFullText` is what that answer reaches.
- The old answer tested party and box together, so a full party with box room answered `BUGCONTEST_CAUGHT_MON` and the PARTY FULL line was never said.

## Two more on the way

The box line named the species rather than the row. `_BallSentToPCText` reads `wMonOrItemNameBuffer` and `_WasSentToBillsPCText` reads `wStringBuffer1`, and `InitName` has filled both with what the keyboard stored by the time either is printed. The gift path said "PIDGEY was sent to BILL's PC" over a row the player had just named. The stored box row still keeps the species on that path, because `.skip_nickname`'s `CopyBytes` runs behind `PrintText`: the line and the row disagree on the cartridge and they disagree here.

The capture preview driver could fill the message queue. It re-deferred itself while the battle had no live target, and a `call_deferred` made during a flush is appended to the flush that is running, so the retry never let a frame pass. It waits on `process_frame` now.

## Checks

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3600/3600, up from 3596 |
| `validate.gd -- all` | 67 PASS, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failing step |
| Editor error panel | no new script errors |