### PR TITLE
Measure a drawn frame, and stop redrawing one the slow way

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -108,6 +108,19 @@ An optional `<method> <times> [int arg]` drives a scene before capture. Keep
 state changes as callable methods, not only input branches, so screens stay
 inspectable without a key press.
 
+`tools/profile.gd` answers what a drawn frame costs, per screen, in
+milliseconds. It needs a window too, and it turns the frame cap and the vertical
+sync off so the number is the work rather than the monitor:
+
+```bash
+godot --path . -s res://tools/profile.gd -- all crystal 600
+```
+
+Each subject is driven by counted hardware frames with the screen's own
+`_process` off, so a row is comparable between two runs on one machine. Between
+machines only the ratio carries; a subject over 16.7 ms on the machine measuring
+it cannot hold sixty anywhere.
+
 The GDScript analyzer runs only inside the editor: no CLI mode prints its
 warnings, `--check-only` suppresses them, and file logging records the running
 game rather than the editor. Read them with `tools/dump_editor_errors.gd` from

--- a/game/audio/gen2_apu.gd
+++ b/game/audio/gen2_apu.gd
@@ -10,6 +10,17 @@ extends RefCounted
 ##
 ## One [method render_frame] call is one LCD frame: registers are sampled once
 ## and held for the whole block, exactly as a per-VBlank driver observes them.
+##
+## Two things are counted rather than walked, and both answer the same samples.
+## `update_freq`'s loop adds `freq_inc` to a counter that resets to zero on every
+## crossing of `FREQ_INC_REF`, so the crossings a sample makes are
+## `(counter + freq_inc - 1) / FREQ_INC_REF` and what is left is the remainder;
+## the duty counter and the wave position are advanced by that count in one step,
+## since only where they end up is read. And minigb_apu's sub-sample average,
+## `((pos - prev) / freq_inc) * val`, is integer division on `uint32_t` with
+## `pos - prev` always below `freq_inc`, so every term of it is zero and the
+## sample is the last value the walk left. The noise channel runs sixteen
+## crossings a sample at its fastest rate, which is what both of these cost.
 
 const SAMPLE_RATE: int = 32768
 ## AUDIO_SAMPLE_RATE / (DMG clock / 70,224 clocks per frame), truncated.
@@ -27,6 +38,11 @@ const MAX_CHAN_VOLUME: int = 15
 ## master level under the 16-bit ceiling.
 const VOL_STEP: int = 273
 const WAVE_STEP: int = 511
+## The DAC's own full scale. A power of two, so scaling by it and by its
+## reciprocal are both exact and the reciprocal costs a multiply rather than a
+## divide once per sample per channel.
+const FULL_SCALE: float = 32768.0
+const INV_FULL_SCALE: float = 1.0 / FULL_SCALE
 
 const DUTY_PATTERNS: Array = [0x10, 0x30, 0x3C, 0xCF]
 const NOISE_DIVISORS: Array = [8, 16, 32, 48, 64, 80, 96, 112]
@@ -249,8 +265,7 @@ func write(address: int, value: int) -> void:
 ## it past the next call must copy it.
 func render_frame(out: PackedVector2Array) -> void:
 	var mix: PackedInt32Array = _mix
-	for index: int in SAMPLES_PER_FRAME * 2:
-		mix[index] = 0
+	mix.fill(0)
 	_render_square(mix, 0)
 	_render_square(mix, 1)
 	_render_wave(mix)
@@ -268,8 +283,7 @@ func render_frame(out: PackedVector2Array) -> void:
 ## Only the offline render and trace tools use this.
 func render_frame_pcm() -> PackedInt32Array:
 	var mix: PackedInt32Array = _mix
-	for index: int in SAMPLES_PER_FRAME * 2:
-		mix[index] = 0
+	mix.fill(0)
 	_render_square(mix, 0)
 	_render_square(mix, 1)
 	_render_wave(mix)
@@ -346,14 +360,19 @@ func _render_square(mix: PackedInt32Array, channel: int) -> void:
 				len_counter = 0
 		if not enabled:
 			continue
-		env_counter += env_inc
-		while env_counter > FREQ_INC_REF:
-			if env_step != 0:
-				volume += 1 if env_up else -1
-				if volume == 0 or volume == MAX_CHAN_VOLUME:
-					env_inc = 0
-				volume = clampi(volume, 0, MAX_CHAN_VOLUME)
-			env_counter -= FREQ_INC_REF
+		## `env_inc` is zeroed once the envelope has run out of steps, and a
+		## note holds far longer than it takes; the drain below cannot fire with
+		## nothing being added, since it always leaves the counter under the
+		## reference.
+		if env_inc != 0:
+			env_counter += env_inc
+			while env_counter > FREQ_INC_REF:
+				if env_step != 0:
+					volume += 1 if env_up else -1
+					if volume == 0 or volume == MAX_CHAN_VOLUME:
+						env_inc = 0
+					volume = clampi(volume, 0, MAX_CHAN_VOLUME)
+				env_counter -= FREQ_INC_REF
 		if channel == 0 and _sweep_inc != 0:
 			_sweep_counter += _sweep_inc
 			while _sweep_counter > FREQ_INC_REF:
@@ -369,27 +388,21 @@ func _render_square(mix: PackedInt32Array, channel: int) -> void:
 					enabled = false
 					_enabled[0] = 0
 				_sweep_counter -= FREQ_INC_REF
-		var position: int = 0
-		var previous: int = 0
-		var sample: int = 0
-		while true:
-			var increment: int = freq_inc - position
-			freq_counter += increment
-			if freq_counter <= FREQ_INC_REF:
-				position = freq_inc
-				break
-			position = freq_inc - (freq_counter - FREQ_INC_REF)
-			freq_counter = 0
-			duty_counter = (duty_counter + 1) & 7
-			sample += ((position - previous) / freq_inc) * value
+		var total: int = freq_counter + freq_inc
+		if total > FREQ_INC_REF:
+			@warning_ignore("integer_division")
+			var steps: int = (total - 1) / FREQ_INC_REF
+			freq_counter = total - steps * FREQ_INC_REF
+			duty_counter = (duty_counter + steps) & 7
 			value = VOL_STEP if (duty & (1 << duty_counter)) != 0 else -VOL_STEP
-			previous = position
-		sample += value
+		else:
+			freq_counter = total
+		var sample: int = value
 		sample = (sample * volume) / 4
-		var raw: float = float(sample) / 32768.0
+		var raw: float = float(sample) * INV_FULL_SCALE
 		var filtered: float = raw - capacitor
 		capacitor = raw - filtered * 0.996
-		sample = int(filtered * 32768.0)
+		sample = int(filtered * FULL_SCALE)
 		var at: int = index * 2
 		mix[at] += int(float(sample) * left)
 		mix[at + 1] += int(float(sample) * right)
@@ -439,30 +452,24 @@ func _render_wave(mix: PackedInt32Array) -> void:
 			continue
 		var packed: int = wave[position >> 1]
 		var nibble: int = ((packed & 0x0F) if (position & 1) != 0 else (packed >> 4)) >> shift
-		var cursor: int = 0
-		var previous: int = 0
-		var sample: int = 0
-		while true:
-			var increment: int = freq_inc - cursor
-			freq_counter += increment
-			if freq_counter <= FREQ_INC_REF:
-				cursor = freq_inc
-				break
-			cursor = freq_inc - (freq_counter - FREQ_INC_REF)
-			freq_counter = 0
-			position = (position + 1) & 31
-			sample += ((cursor - previous) / freq_inc) * (nibble - 8) * WAVE_STEP
+		var total: int = freq_counter + freq_inc
+		if total > FREQ_INC_REF:
+			@warning_ignore("integer_division")
+			var steps: int = (total - 1) / FREQ_INC_REF
+			freq_counter = total - steps * FREQ_INC_REF
+			position = (position + steps) & 31
 			packed = wave[position >> 1]
 			nibble = ((packed & 0x0F) if (position & 1) != 0 else (packed >> 4)) >> shift
-			previous = cursor
-		sample += (nibble - 8) * WAVE_STEP
+		else:
+			freq_counter = total
+		var sample: int = (nibble - 8) * WAVE_STEP
 		if volume == 0:
 			continue
 		sample = sample / 4
-		var raw: float = float(sample) / 32768.0
+		var raw: float = float(sample) * INV_FULL_SCALE
 		var filtered: float = raw - capacitor
 		capacitor = raw - filtered * 0.996
-		sample = int(filtered * 32768.0)
+		sample = int(filtered * FULL_SCALE)
 		var at: int = index * 2
 		mix[at] += int(float(sample) * left)
 		mix[at + 1] += int(float(sample) * right)
@@ -499,6 +506,9 @@ func _render_noise(mix: PackedInt32Array) -> void:
 	var gain: float = channel_gain[3]
 	var left: float = float(_on_left[3] * _master_left) * gain
 	var right: float = float(_on_right[3] * _master_right) * gain
+	# `wide` cannot change inside a frame: NR43 is sampled once, above.
+	var tap_high: int = 14 if wide else 6
+	var tap_low: int = 13 if wide else 5
 	for index: int in SAMPLES_PER_FRAME:
 		if len_enabled:
 			len_counter += len_inc
@@ -508,38 +518,39 @@ func _render_noise(mix: PackedInt32Array) -> void:
 				len_counter = 0
 		if not enabled:
 			continue
-		env_counter += env_inc
-		while env_counter > FREQ_INC_REF:
-			if env_step != 0:
-				volume += 1 if env_up else -1
-				if volume == 0 or volume == MAX_CHAN_VOLUME:
-					env_inc = 0
-				volume = clampi(volume, 0, MAX_CHAN_VOLUME)
-			env_counter -= FREQ_INC_REF
-		var position: int = 0
-		var previous: int = 0
-		var sample: int = 0
-		while true:
-			var increment: int = freq_inc - position
-			freq_counter += increment
-			if freq_counter <= FREQ_INC_REF:
-				position = freq_inc
-				break
-			position = freq_inc - (freq_counter - FREQ_INC_REF)
-			freq_counter = 0
+		## `env_inc` is zeroed once the envelope has run out of steps, and a
+		## note holds far longer than it takes; the drain below cannot fire with
+		## nothing being added, since it always leaves the counter under the
+		## reference.
+		if env_inc != 0:
+			env_counter += env_inc
+			while env_counter > FREQ_INC_REF:
+				if env_step != 0:
+					volume += 1 if env_up else -1
+					if volume == 0 or volume == MAX_CHAN_VOLUME:
+						env_inc = 0
+					volume = clampi(volume, 0, MAX_CHAN_VOLUME)
+				env_counter -= FREQ_INC_REF
+		var total: int = freq_counter + freq_inc
+		var steps: int = 0
+		if total > FREQ_INC_REF:
+			@warning_ignore("integer_division")
+			steps = (total - 1) / FREQ_INC_REF
+			freq_counter = total - steps * FREQ_INC_REF
+		else:
+			freq_counter = total
+		## The register is a shift, so unlike the duty counter and the wave
+		## position it has to be walked one step at a time.
+		for _step: int in steps:
 			lfsr = ((lfsr << 1) | (1 if value >= VOL_STEP else 0)) & 0xFFFF
-			var tap_high: int = 14 if wide else 6
-			var tap_low: int = 13 if wide else 5
 			var feedback: int = ((lfsr >> tap_high) & 1) ^ ((lfsr >> tap_low) & 1)
 			value = -VOL_STEP if feedback != 0 else VOL_STEP
-			sample += ((position - previous) / freq_inc) * value
-			previous = position
-		sample += value
+		var sample: int = value
 		sample = (sample * volume) / 4
-		var raw: float = float(sample) / 32768.0
+		var raw: float = float(sample) * INV_FULL_SCALE
 		var filtered: float = raw - capacitor
 		capacitor = raw - filtered * 0.996
-		sample = int(filtered * 32768.0)
+		sample = int(filtered * FULL_SCALE)
 		var at: int = index * 2
 		mix[at] += int(float(sample) * left)
 		mix[at + 1] += int(float(sample) * right)

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -654,7 +654,7 @@ func _draw_hud_balls() -> void:
 		buffer, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
 		_object_palette(Gen2BattleAnimBackground.PAL_OB_YELLOW), true
 	)
-	_hud_balls.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_hud_balls, image)
 	_hud_balls.size = image.get_size()
 	_hud_balls.position = Vector2.ZERO
 
@@ -682,7 +682,7 @@ func _draw_sprites() -> void:
 	for entry: Variant in intro:
 		if entry is Dictionary:
 			_blit_sprite(image, entry as Dictionary, true)
-	_sprites.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_sprites, image)
 	_sprites.size = image.get_size()
 	_sprites.position = Vector2.ZERO
 
@@ -840,7 +840,7 @@ func _show_image(into: TextureRect, image: Image) -> void:
 	var offsets: PackedInt32Array = PackedInt32Array(_view.get("raster_scx", []))
 	if not offsets.is_empty():
 		image = Gen2Raster.scroll(image, offsets, MAP_WIDTH)
-	into.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(into, image)
 	into.size = image.get_size()
 	into.position = Vector2.ZERO
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3740,7 +3740,7 @@ func _show_menu_image(image: Image, at: Vector2i) -> void:
 func _show_layer_image(layer: TextureRect, image: Image, at: Vector2i) -> void:
 	if layer == null:
 		return
-	layer.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(layer, image)
 	layer.position = Vector2(at)
 	layer.size = Vector2(image.get_size())
 	layer.visible = true

--- a/game/render/credits_page.gd
+++ b/game/render/credits_page.gd
@@ -68,33 +68,35 @@ func image(data: GameData, state: Dictionary) -> Image:
 	var map: PackedInt32Array = state.get("map", PackedInt32Array())
 	var slots: PackedInt32Array = state.get("attributes", PackedInt32Array())
 	var indices: PackedByteArray = compose(map, int(state.get("block", -1)))
-	var out := Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
+	var out: PackedInt32Array = Gen2PicImage.canvas(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	if map.size() < COLUMNS * ROWS or slots.size() < COLUMNS * ROWS:
-		return out
+		return Gen2PicImage.canvas_image(out, Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	var scene: int = int(state.get("scene", 0))
-	var palettes: Array = []
+	var tables: Array[PackedInt32Array] = []
 	for slot: int in [
 		Gen2Credits.PALETTE_BANNER, Gen2Credits.PALETTE_BORDER, Gen2Credits.PALETTE_TEXT,
 	]:
-		palettes.append(palette(data, scene, slot))
+		var colors: PackedColorArray = palette(data, scene, slot)
+		tables.append(
+			PackedInt32Array() if colors.is_empty() else Gen2PicImage.lookup(colors)
+		)
 	var scroll: int = int(state.get("scroll", 0))
 	var scrolled: Array = state.get("scroll_rows", [])
 	for row: int in ROWS:
 		var shift: int = scroll if row in scrolled else 0
 		for column: int in COLUMNS:
-			var palette_colors: PackedColorArray = palettes[
-				clampi(slots[row * COLUMNS + column], 0, palettes.size() - 1)
+			var table: PackedInt32Array = tables[
+				clampi(slots[row * COLUMNS + column], 0, tables.size() - 1)
 			]
-			if palette_colors.is_empty():
+			if table.is_empty():
 				continue
 			for y: int in TILE:
+				var at_y: int = row * TILE + y
+				var line: int = at_y * WIDTH
 				for x: int in TILE:
 					var at_x: int = column * TILE + x
-					var at_y: int = row * TILE + y
-					out.set_pixel(at_x, at_y, palette_colors[
-						indices[at_y * WIDTH + (at_x + shift) % WIDTH]
-					])
-	return out
+					out[line + at_x] = table[indices[line + (at_x + shift) % WIDTH]]
+	return Gen2PicImage.canvas_image(out, Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 
 
 ## `GetCreditsPalette`, whose Gold and Silver branch copies one four-colour

--- a/game/render/game_freak_presents_page.gd
+++ b/game/render/game_freak_presents_page.gd
@@ -120,14 +120,16 @@ func draw(phase: Gen2GameFreakPresents) -> Image:
 	indices.fill(BLANK_INDEX)
 	if phase != null:
 		_draw_words(indices, width, phase)
-	var image: Image = Gen2PicImage.from_indices(indices, width, height, _background)
+	var pixels: PackedInt32Array = Gen2PicImage.canvas_from_indices(
+		indices, width, height, _background
+	)
 	# The lower OAM index wins a pixel, so a slot only paints where no earlier
 	# one did.
 	var taken := PackedByteArray()
 	taken.resize(width * height)
 	for entry: Dictionary in shadow_oam(phase):
-		_draw_sprite(image, phase, entry, taken)
-	return image
+		_draw_sprite(pixels, phase, entry, taken)
+	return Gen2PicImage.canvas_image(pixels, width, height)
 
 
 ## Every live struct expanded into the shadow OAM the hardware would hold, in
@@ -190,7 +192,7 @@ func _draw_words(
 ## One shadow-OAM entry, drawn through the object palette whose first colour is
 ## transparent.
 func _draw_sprite(
-	image: Image, phase: Gen2GameFreakPresents, entry: Dictionary,
+	pixels: PackedInt32Array, phase: Gen2GameFreakPresents, entry: Dictionary,
 	taken: PackedByteArray
 ) -> void:
 	# `dbsprite`'s attribute byte names the object palette. Only Gold's logo is
@@ -199,7 +201,7 @@ func _draw_sprite(
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
 	_blit_sprite_tile(
-		image, palette,
+		pixels, palette,
 		int(entry["tile"]) - _vram_base(),
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
 		bool(entry["flip_x"]), bool(entry["flip_y"]), taken
@@ -313,7 +315,7 @@ func _blit_tile(
 ## off an edge cannot wrap onto the opposite one.
 ## [param taken] marks the pixels an earlier slot has already claimed.
 func _blit_sprite_tile(
-	image: Image, palette: PackedColorArray, tile: int, at: Vector2i,
+	pixels: PackedInt32Array, palette: PackedColorArray, tile: int, at: Vector2i,
 	flip_x: bool, flip_y: bool, taken: PackedByteArray
 ) -> void:
 	var tiles: PackedByteArray = _sprite_tiles
@@ -330,13 +332,17 @@ func _blit_sprite_tile(
 			index = tile - RomLayout.PRESENTS_LOGO_TILES
 	if stride <= 0 or index < 0:
 		return
+	var width: int = COLUMNS * TILE
+	var height: int = ROWS * TILE
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for y: int in TILE:
 		var target_y: int = at.y + y
-		if target_y < 0 or target_y >= image.get_height():
+		if target_y < 0 or target_y >= height:
 			continue
+		var row: int = target_y * width
 		for x: int in TILE:
 			var target_x: int = at.x + x
-			if target_x < 0 or target_x >= image.get_width():
+			if target_x < 0 or target_x >= width:
 				continue
 			var source_x: int = TILE - 1 - x if flip_x else x
 			var source_y: int = TILE - 1 - y if flip_y else y
@@ -346,8 +352,8 @@ func _blit_sprite_tile(
 			var value: int = tiles[from]
 			if value == TRANSPARENT_INDEX or value >= palette.size():
 				continue
-			var at_pixel: int = target_y * image.get_width() + target_x
+			var at_pixel: int = row + target_x
 			if taken[at_pixel] != 0:
 				continue
 			taken[at_pixel] = 1
-			image.set_pixel(target_x, target_y, palette[value])
+			pixels[at_pixel] = table[value]

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -292,18 +292,18 @@ static func from_data(data: GameData) -> Gen2GoldSilverIntroPage:
 
 ## The whole 160x144 screen for one frame of [param movie].
 func draw(movie: Gen2GoldSilverIntro) -> Image:
-	var image := Image.create(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(WIDTH, HEIGHT)
 	if movie == null:
-		return image
-	var behind: PackedByteArray = _draw_background(image, movie)
+		return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
+	var behind: PackedByteArray = _draw_background(pixels, movie)
 	# The lower OAM index wins a pixel, so a slot only paints where no earlier
 	# one did: Charizard's small fireball sits behind the big one it is spawned
 	# after, and the note behind Pikachu.
 	var taken := PackedByteArray()
 	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):
-		_draw_sprite(image, movie, entry, behind, taken)
-	return image
+		_draw_sprite(pixels, movie, entry, behind, taken)
+	return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
 
 
 ## Every live struct expanded into the shadow OAM the hardware would hold, in
@@ -350,7 +350,9 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 ## bytes and the map is 256 pixels square, so the sampling wraps rather than
 ## clipping. Returns each pixel's own colour index, which is what an `OAM_PRIO`
 ## sprite is drawn against.
-func _draw_background(image: Image, movie: Gen2GoldSilverIntro) -> PackedByteArray:
+func _draw_background(
+	pixels: PackedInt32Array, movie: Gen2GoldSilverIntro
+) -> PackedByteArray:
 	var behind := PackedByteArray()
 	var map: PackedByteArray = movie.bg_map()
 	if map.size() < MAP_COLUMNS * MAP_ROWS:
@@ -359,41 +361,62 @@ func _draw_background(image: Image, movie: Gen2GoldSilverIntro) -> PackedByteArr
 	if palette.is_empty():
 		return behind
 	behind.resize(WIDTH * HEIGHT)
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	var sheets: Dictionary = CUTSCENE_SHEETS.get(movie.cutscene(), {})
 	var low: PackedByteArray = _sheet(String(sheets.get("bg", "")))
 	var high: PackedByteArray = _sheet(String(sheets.get("bg_high", "")))
+	@warning_ignore("integer_division")
+	var low_stride: int = low.size() / TILE
+	@warning_ignore("integer_division")
+	var high_stride: int = high.size() / TILE
 	var scx: int = movie.scroll().x
+	## `hSCX` is one value for the whole frame here, so a run of pixels inside
+	## one tile shares its map cell and its sheet row.
 	for y: int in HEIGHT:
 		var scy: int = movie.scroll_y_at(y)
 		var map_y: int = (y + scy) & 0xFF
+		@warning_ignore("integer_division")
 		var row: int = (map_y / TILE) % MAP_ROWS
 		var in_tile_y: int = map_y % TILE
-		for x: int in WIDTH:
+		var line: int = y * WIDTH
+		var x: int = 0
+		while x < WIDTH:
 			var map_x: int = (x + scx) & 0xFF
+			var in_tile_x: int = map_x % TILE
+			var run: int = mini(TILE - in_tile_x, WIDTH - x)
+			@warning_ignore("integer_division")
 			var column: int = (map_x / TILE) % MAP_COLUMNS
 			var tile: int = map[row * MAP_COLUMNS + column]
 			var strip: PackedByteArray = low
+			var stride: int = low_stride
 			var index: int = tile
 			if tile >= HIGH_TILE:
 				strip = high
+				stride = high_stride
 				index = tile - HIGH_TILE
-			var pixel: int = _pixel(strip, index, map_x % TILE, in_tile_y, false, false)
-			behind[y * WIDTH + x] = pixel
-			image.set_pixel(x, y, palette[pixel])
+			# What a tile the sheet does not reach draws as.
+			var from: int = -1
+			if index >= 0 and (index + 1) * TILE <= stride:
+				from = in_tile_y * stride + index * TILE
+			for step: int in run:
+				var pixel: int = 0 if from < 0 else strip[from + in_tile_x + step]
+				behind[line + x + step] = pixel
+				pixels[line + x + step] = table[pixel]
+			x += run
 	return behind
 
 
 ## One shadow-OAM entry, off the cutscene's own object sheet. The position is
 ## already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
 func _draw_sprite(
-	image: Image, movie: Gen2GoldSilverIntro, entry: Dictionary,
+	pixels: PackedInt32Array, movie: Gen2GoldSilverIntro, entry: Dictionary,
 	behind: PackedByteArray, taken: PackedByteArray
 ) -> void:
 	var palette: PackedColorArray = movie.object_palette(int(entry["palette"]))
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
 	_blit_sprite_tile(
-		image,
+		pixels,
 		_sheet(String((CUTSCENE_SHEETS.get(movie.cutscene(), {}) as Dictionary).get("obj", ""))),
 		palette, int(entry["tile"]),
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
@@ -411,11 +434,12 @@ func _draw_sprite(
 ## `OAM_PRIO` and empty otherwise. The claim comes first: a sprite that loses the
 ## pixel to the background still wins it against the sprites behind it.
 func _blit_sprite_tile(
-	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
-	at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,
+	pixels: PackedInt32Array, strip: PackedByteArray, palette: PackedColorArray,
+	tile: int, at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,
 	behind: PackedByteArray, starters: bool
 ) -> void:
 	var starter: Dictionary = _starter_for(tile) if starters else {}
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for row: int in TILE:
 		var y: int = at.y + row
 		if y < 0 or y >= HEIGHT:
@@ -435,7 +459,7 @@ func _blit_sprite_tile(
 			taken[at_pixel] = 1
 			if not behind.is_empty() and behind[at_pixel] != TRANSPARENT_INDEX:
 				continue
-			image.set_pixel(x, y, palette[pixel])
+			pixels[at_pixel] = table[pixel]
 
 
 ## Which of the three front pics a sprite tile lands in, if any.

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -236,11 +236,15 @@ static func from_data(data: GameData) -> Gen2IntroMoviePage:
 
 
 ## The whole 160x144 screen for one frame of [param movie].
+##
+## One [method Gen2PicImage.canvas] for the frame: the movie is redrawn sixty
+## times a second and a per-pixel [method Image.set_pixel] costs a binding call
+## and a [Color] for every one of the 23,040.
 func draw(movie: Gen2IntroMovie) -> Image:
-	var image := Image.create(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(WIDTH, HEIGHT)
 	if movie == null:
-		return image
-	var background: Array = _draw_background(image, movie)
+		return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
+	var background: Array = _draw_background(pixels, movie)
 	var behind: PackedByteArray = background[0]
 	var forced: PackedByteArray = background[1]
 	# The lower OAM index wins a pixel, so a slot only paints where no earlier
@@ -248,8 +252,8 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	var taken := PackedByteArray()
 	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):
-		_draw_sprite(image, movie, entry, behind, forced, taken)
-	return image
+		_draw_sprite(pixels, movie, entry, behind, forced, taken)
+	return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
 
 
 ## Every live struct expanded into the shadow OAM the hardware would hold, in
@@ -300,7 +304,7 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 ## The BG map, sampled through `hSCY` and the scanline's own `hSCX`. Both are
 ## bytes and the map is 256 pixels square, so the sampling wraps rather than
 ## clipping.
-func _draw_background(image: Image, movie: Gen2IntroMovie) -> Array:
+func _draw_background(pixels: PackedInt32Array, movie: Gen2IntroMovie) -> Array:
 	var behind := PackedByteArray()
 	# The same indices where the tile's own attribute carries the priority bit,
 	# which wins over every sprite rather than only over the ones marked
@@ -314,9 +318,12 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> Array:
 	behind.resize(WIDTH * HEIGHT)
 	forced.resize(WIDTH * HEIGHT)
 	var screen: PackedByteArray = movie.screen_tilemap()
-	var palettes: Array[PackedColorArray] = []
+	var tables: Array[PackedInt32Array] = []
 	for slot: int in Gen2IntroMovie.BG_PALETTES:
-		palettes.append(movie.palette(slot))
+		var palette: PackedColorArray = movie.palette(slot)
+		tables.append(
+			PackedInt32Array() if palette.is_empty() else Gen2PicImage.lookup(palette)
+		)
 	var low: PackedByteArray = _sheet(movie, movie.sheet("bg"))
 	var low_first: int = movie.sheet_first_tile("bg")
 	var high: PackedByteArray = _sheet(movie, movie.sheet("bg_high"))
@@ -330,13 +337,22 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> Array:
 	var overlay_first: int = int(overlay[0]) if overlay.size() == 3 else 0
 	var overlay_count: int = int(overlay[1]) if overlay.size() == 3 else 0
 	var scy: int = movie.scroll().y
+	## `hSCX` is constant across a scanline, so the map cell, its attribute and
+	## its sheet are resolved once per run of pixels inside one tile rather than
+	## once per pixel: twenty-one lookups a line instead of a hundred and sixty.
 	for y: int in HEIGHT:
 		var scx: int = movie.scroll_x_at(y)
 		var map_y: int = (y + scy) & 0xFF
+		@warning_ignore("integer_division")
 		var row: int = (map_y / TILE) % MAP_ROWS
 		var in_tile_y: int = map_y % TILE
-		for x: int in WIDTH:
+		var line: int = y * WIDTH
+		var x: int = 0
+		while x < WIDTH:
 			var map_x: int = (x + scx) & 0xFF
+			var in_tile_x: int = map_x % TILE
+			var run: int = mini(TILE - in_tile_x, WIDTH - x)
+			@warning_ignore("integer_division")
 			var column: int = (map_x / TILE) % MAP_COLUMNS
 			var cell: int = row * MAP_COLUMNS + column
 			var tile: int = map[cell]
@@ -355,24 +371,37 @@ func _draw_background(image: Image, movie: Gen2IntroMovie) -> Array:
 			elif tile >= HIGH_TILE:
 				strip = high
 				index = tile - HIGH_TILE + high_first
-			var palette: PackedColorArray = palettes[byte & ATTR_PALETTE]
-			if palette.is_empty():
+			var table: PackedInt32Array = tables[byte & ATTR_PALETTE]
+			if table.is_empty():
+				x += run
 				continue
-			var pixel: int = _pixel(
-				strip, index, map_x % TILE, in_tile_y,
-				bool(byte & ATTR_XFLIP), bool(byte & ATTR_YFLIP)
-			)
-			behind[y * WIDTH + x] = pixel
-			if byte & ATTR_PRIORITY != 0:
-				forced[y * WIDTH + x] = pixel
-			image.set_pixel(x, y, palette[pixel])
+			var flip_x: bool = bool(byte & ATTR_XFLIP)
+			@warning_ignore("integer_division")
+			var stride: int = strip.size() / TILE
+			# What `_pixel` answers for a tile the sheet does not reach.
+			var from: int = -1
+			if index >= 0 and (index + 1) * TILE <= stride:
+				from = ((TILE - 1 - in_tile_y) if bool(byte & ATTR_YFLIP) else in_tile_y) \
+					* stride + index * TILE
+			var priority: bool = (byte & ATTR_PRIORITY) != 0
+			for step: int in run:
+				var source_x: int = in_tile_x + step
+				var pixel: int = 0 if from < 0 else strip[
+					from + ((TILE - 1 - source_x) if flip_x else source_x)
+				]
+				var at_pixel: int = line + x + step
+				behind[at_pixel] = pixel
+				if priority:
+					forced[at_pixel] = pixel
+				pixels[at_pixel] = table[pixel]
+			x += run
 	return [behind, forced]
 
 
 ## One shadow-OAM entry, off the sheet its struct was loaded into. The position
 ## is already the OAM byte, so it is only moved off OAM's own (8, 16) origin.
 func _draw_sprite(
-	image: Image, movie: Gen2IntroMovie, entry: Dictionary,
+	pixels: PackedInt32Array, movie: Gen2IntroMovie, entry: Dictionary,
 	behind: PackedByteArray, forced: PackedByteArray, taken: PackedByteArray
 ) -> void:
 	var tile: int = int(entry["tile"])
@@ -400,7 +429,7 @@ func _draw_sprite(
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
 	_blit_sprite_tile(
-		image, strip, palette, tile,
+		pixels, strip, palette, tile,
 		Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y),
 		bool(entry["flip_x"]), bool(entry["flip_y"]), taken,
 		behind if bool(entry.get("priority", false)) else forced
@@ -413,42 +442,37 @@ func _draw_sprite(
 ## priority bit otherwise. The claim comes first: a sprite that loses the pixel
 ## to the background still wins it against the sprites behind it.
 func _blit_sprite_tile(
-	image: Image, strip: PackedByteArray, palette: PackedColorArray, tile: int,
-	at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,
+	pixels: PackedInt32Array, strip: PackedByteArray, palette: PackedColorArray,
+	tile: int, at: Vector2i, flip_x: bool, flip_y: bool, taken: PackedByteArray,
 	behind: PackedByteArray
 ) -> void:
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
+	@warning_ignore("integer_division")
+	var stride: int = strip.size() / TILE
 	for row: int in TILE:
 		var y: int = at.y + row
 		if y < 0 or y >= HEIGHT:
 			continue
+		var from: int = -1
+		if tile >= 0 and (tile + 1) * TILE <= stride:
+			from = ((TILE - 1 - row) if flip_y else row) * stride + tile * TILE
+		if from < 0:
+			continue
+		var line: int = y * WIDTH
 		for column: int in TILE:
 			var x: int = at.x + column
 			if x < 0 or x >= WIDTH:
 				continue
-			var pixel: int = _pixel(strip, tile, column, row, flip_x, flip_y)
+			var pixel: int = strip[from + ((TILE - 1 - column) if flip_x else column)]
 			if pixel == TRANSPARENT_INDEX:
 				continue
-			var at_pixel: int = y * WIDTH + x
+			var at_pixel: int = line + x
 			if taken[at_pixel] != 0:
 				continue
 			taken[at_pixel] = 1
 			if not behind.is_empty() and behind[at_pixel] != TRANSPARENT_INDEX:
 				continue
-			image.set_pixel(x, y, palette[pixel])
-
-
-## One pixel of a tile in a horizontal strip of tile indices.
-func _pixel(
-	strip: PackedByteArray, tile: int, x: int, y: int, flip_x: bool, flip_y: bool
-) -> int:
-	if strip.is_empty():
-		return 0
-	var width: int = strip.size() / TILE
-	var column: int = tile * TILE + ((TILE - 1 - x) if flip_x else x)
-	var row: int = (TILE - 1 - y) if flip_y else y
-	if column < 0 or column >= width:
-		return 0
-	return strip[row * width + column]
+			pixels[at_pixel] = table[pixel]
 
 
 func _sheet(movie: Gen2IntroMovie, name: String) -> PackedByteArray:

--- a/game/render/move_screen_page.gd
+++ b/game/render/move_screen_page.gd
@@ -135,20 +135,22 @@ func advance() -> void:
 ## The page as pixels with the icon composed on top: it is an object, so colour
 ## 0 is transparent and it is blended rather than written into the buffer.
 func render(page: Dictionary, data: GameData) -> Image:
-	var image: Image = _background(page, data)
+	var pixels: PackedInt32Array = _background(page, data)
+	var width: int = COLUMNS * TILE
+	var height: int = ROWS * TILE
 	if data == null or _frame < 0:
-		return image
+		return Gen2PicImage.canvas_image(pixels, width, height)
 	var colors: PackedColorArray = data.party_menu_icon_palette()
 	var strip: PackedByteArray = data.species_icon_indices(int(page.get("species", 0)))
 	if strip.is_empty() or colors.size() != Gen2Palette.COLORS_PER_PIC:
-		return image
+		return Gen2PicImage.canvas_image(pixels, width, height)
 	var first: int = _frame * ICON_FRAME_TILES
 	for quadrant: int in ICON_FRAME_TILES:
 		Gen2PartyMenuPage.blend_tile(
-			image, strip, first + quadrant, colors,
+			pixels, strip, first + quadrant, colors,
 			ICON_AT + Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
 		)
-	return image
+	return Gen2PicImage.canvas_image(pixels, width, height)
 
 
 ## `_CGB_MoveList`: `PREDEFPAL_GOLDENROD` over the whole screen, and one
@@ -162,10 +164,10 @@ static func attributes() -> PackedInt32Array:
 	return Gen2PicImage.attribute_boxes([HP_ATTRIBUTE], COLUMNS, ROWS)
 
 
-func _background(page: Dictionary, data: GameData) -> Image:
+func _background(page: Dictionary, data: GameData) -> PackedInt32Array:
 	var indices: PackedByteArray = draw(page)
 	if data == null:
-		return Gen2PicImage.from_indices(
+		return Gen2PicImage.canvas_from_indices(
 			indices, COLUMNS * TILE, ROWS * TILE,
 			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 		)
@@ -173,7 +175,7 @@ func _background(page: Dictionary, data: GameData) -> Image:
 		int(page.get("hp", 0)), int(page.get("max_hp", 0)),
 		Gen2BattleHud.HP_BAR_TILES * TILE
 	)
-	return Gen2PicImage.from_attributes(
+	return Gen2PicImage.canvas_from_attributes(
 		indices, COLUMNS * TILE, ROWS * TILE, attributes(), COLUMNS,
 		[data.move_screen_palette(), data.bar_palette(GameData.hp_bar_palette_name(lit))]
 	)

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -153,15 +153,15 @@ func render(
 	_draw_cursor(page, width, cursor)
 	_draw_prompt(page, width, prompt)
 
-	var image: Image = Gen2PicImage.from_indices(
+	var pixels: PackedInt32Array = Gen2PicImage.canvas_from_indices(
 		page, width, height, Gen2Palette.pic_palette(
 			PackedColorArray([Color.WHITE, Color.BLACK])
 		)
 	)
 	for index: int in rows.size():
-		_blend_bar(image, index, rows[index])
-	_blend_icons(image, rows.size())
-	return image
+		_blend_bar(pixels, index, rows[index])
+	_blend_icons(pixels, rows.size())
+	return Gen2PicImage.canvas_image(pixels, width, height)
 
 
 ## One pass of `PlaySpriteAnimations` over `InitPartyMenuGFX`'s structs: the
@@ -247,7 +247,7 @@ func _step_icon_frame(icon: Dictionary) -> void:
 ## The icons over the page, in the one palette `InitPartyMenuOBPals` gives them.
 ## They are objects rather than tiles, so colour 0 is transparent and they are
 ## blended on top rather than written into the index buffer.
-func _blend_icons(image: Image, count: int) -> void:
+func _blend_icons(pixels: PackedInt32Array, count: int) -> void:
 	if data == null or _icons.is_empty():
 		return
 	var colors: PackedColorArray = data.party_menu_icon_palette()
@@ -276,7 +276,7 @@ func _blend_icons(image: Image, count: int) -> void:
 				source = held
 				tile = ICON_ITEM_TILE
 			blend_tile(
-				image, source, tile, colors,
+				pixels, source, tile, colors,
 				at + Vector2i((quadrant & 1) * ICON_TILE, (quadrant >> 1) * ICON_TILE)
 			)
 
@@ -284,25 +284,15 @@ func _blend_icons(image: Image, count: int) -> void:
 ## One 8x8 tile of an index strip, clipped to the screen. Static and public
 ## because the move screen composes the same icon over its own page.
 static func blend_tile(
-	image: Image, strip: PackedByteArray, tile: int, colors: PackedColorArray, at: Vector2i
+	pixels: PackedInt32Array, strip: PackedByteArray, tile: int,
+	colors: PackedColorArray, at: Vector2i
 ) -> void:
 	@warning_ignore("integer_division")
-	var width: int = strip.size() / Gen2Tiles.TILE_HEIGHT
-	var left: int = tile * Gen2Tiles.TILE_WIDTH
-	if left + Gen2Tiles.TILE_WIDTH > width:
-		return
-	for row: int in Gen2Tiles.TILE_HEIGHT:
-		var y: int = at.y + row
-		if y < 0 or y >= Gen2Screen.HEIGHT:
-			continue
-		for column: int in Gen2Tiles.TILE_WIDTH:
-			var x: int = at.x + column
-			if x < 0 or x >= Gen2Screen.WIDTH:
-				continue
-			var index: int = strip[row * width + left + column]
-			if index == 0:
-				continue
-			image.set_pixel(x, y, colors[index])
+	var tiles: int = strip.size() / Gen2Tiles.TILE_PIXELS
+	Gen2PicImage.blit_tile(
+		pixels, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, strip, tiles, tile,
+		at.x, at.y, Gen2PicImage.lookup(colors), false, false, 0
+	)
 
 
 func _draw_member(page: PackedByteArray, width: int, index: int, row: Dictionary) -> void:
@@ -337,28 +327,37 @@ func _draw_member(page: PackedByteArray, width: int, index: int, row: Dictionary
 
 ## The fill of one bar, blended over the page in its own colour: the hardware
 ## gives every tile its own palette, and one index buffer carries one.
-func _blend_bar(image: Image, index: int, row: Dictionary) -> void:
+##
+## A bar is one tile row of the screen, so it is drawn into a strip that tall:
+## six party rows used to cost six 160x144 buffers and six whole images a frame
+## for six 48x8 rectangles.
+func _blend_bar(pixels: PackedInt32Array, index: int, row: Dictionary) -> void:
 	var width: int = Gen2Screen.WIDTH
 	if bool(row.get("egg", false)):
 		return
 	var buffer: PackedByteArray = PackedByteArray()
-	buffer.resize(width * Gen2Screen.HEIGHT)
+	buffer.resize(width * TILE)
 	var hp: int = int(row.get("hp", 0))
 	var max_hp: int = int(row.get("max_hp", 0))
 	var top: int = HP_BAR.y + index * ROW_STEP
-	hud.draw_hp_bar(buffer, width, Vector2i(HP_BAR.x, top), hp, max_hp)
+	hud.draw_hp_bar(buffer, width, Vector2i(HP_BAR.x, 0), hp, max_hp)
 
 	var lit: int = Gen2BattleHud.bar_pixels(
 		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE
 	)
-	var fill: Image = Gen2PicImage.from_indices(
-		buffer, width, Gen2Screen.HEIGHT,
+	var table: PackedInt32Array = Gen2PicImage.lookup(
 		data.bar_palette(GameData.hp_bar_palette_name(lit)), true
 	)
-	var at := Vector2i((HP_BAR.x + 2) * TILE, top * TILE)
-	image.blend_rect(
-		fill, Rect2i(at, Vector2i(Gen2BattleHud.HP_BAR_TILES * TILE, TILE)), at
-	)
+	var left: int = (HP_BAR.x + 2) * TILE
+	for y: int in TILE:
+		var from: int = y * width
+		var to: int = (top * TILE + y) * width
+		for x: int in range(left, left + Gen2BattleHud.HP_BAR_TILES * TILE):
+			var value: int = buffer[from + x]
+			# `blend_rect` over a transparent index 0 left the pixel alone.
+			if value == 0:
+				continue
+			pixels[to + x] = table[value]
 
 
 ## `PlaceStatusString`: FNT for no health left, otherwise the first flag on the

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -31,19 +31,14 @@ static func from_indices(
 	if width <= 0 or height <= 0 or indices.size() < width * height:
 		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
 
-	var lookup: PackedByteArray = _lookup(palette, transparent_background)
-	var pixels: PackedByteArray = PackedByteArray()
-	pixels.resize(width * height * CHANNELS)
+	var table: PackedInt32Array = lookup(palette, transparent_background)
+	var words := PackedInt32Array()
+	words.resize(width * height)
 
 	for i: int in width * height:
-		var at: int = int(indices[i]) * CHANNELS
-		var to: int = i * CHANNELS
-		pixels[to] = lookup[at]
-		pixels[to + 1] = lookup[at + 1]
-		pixels[to + 2] = lookup[at + 2]
-		pixels[to + 3] = lookup[at + 3]
+		words[i] = table[indices[i]]
 
-	return Image.create_from_data(width, height, false, Image.FORMAT_RGBA8, pixels)
+	return canvas_image(words, width, height)
 
 
 ## An image from a row-major index buffer plus `wAttrmap`: one palette index per
@@ -67,30 +62,26 @@ static func from_attributes(
 	if width <= 0 or height <= 0 or indices.size() < width * height:
 		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
 
-	var lookups: Array[PackedByteArray] = []
+	var lookups: Array[PackedInt32Array] = []
 	for palette: Variant in palettes:
-		lookups.append(_lookup(palette as PackedColorArray, false))
+		lookups.append(lookup(palette as PackedColorArray, false))
 
 	var tile: int = Gen2Font.TILE
-	var pixels: PackedByteArray = PackedByteArray()
-	pixels.resize(width * height * CHANNELS)
+	var words := PackedInt32Array()
+	words.resize(width * height)
 	for y: int in height:
 		@warning_ignore("integer_division")
 		var row: int = (y / tile) * columns
+		var line: int = y * width
 		for x: int in width:
 			@warning_ignore("integer_division")
 			var slot: int = row + x / tile
-			var lookup: PackedByteArray = lookups[
+			var table: PackedInt32Array = lookups[
 				clampi(slots[slot] if slot < slots.size() else 0, 0, lookups.size() - 1)
 			]
-			var at: int = int(indices[y * width + x]) * CHANNELS
-			var to: int = (y * width + x) * CHANNELS
-			pixels[to] = lookup[at]
-			pixels[to + 1] = lookup[at + 1]
-			pixels[to + 2] = lookup[at + 2]
-			pixels[to + 3] = lookup[at + 3]
+			words[line + x] = table[indices[line + x]]
 
-	return Image.create_from_data(width, height, false, Image.FORMAT_RGBA8, pixels)
+	return canvas_image(words, width, height)
 
 
 ## An attrmap from a list of `FillBoxCGB` boxes, each (x, y, width, height,
@@ -177,22 +168,35 @@ static func atlas_cell(
 	return {"indices": cropped, "width": width, "height": height}
 
 
-## Four bytes per index, so the inner loop copies rather than converting colours.
-static func _lookup(palette: PackedColorArray, transparent_background: bool) -> PackedByteArray:
-	var out: PackedByteArray = PackedByteArray()
-	out.resize(Gen2Palette.COLORS_PER_PIC * CHANNELS)
+## One packed RGBA8 word per colour index, so a blit is an array copy rather
+## than a [Color] conversion. Little-endian, which is the order
+## [method PackedInt32Array.to_byte_array] writes and `FORMAT_RGBA8` reads.
+##
+## Public because every per-tile blit in the project shares it: a page that
+## builds a [Color] per pixel pays a binding call and an allocation for a table
+## lookup, which is what [method blit_tile] exists to stop.
+static func lookup(
+	palette: PackedColorArray, transparent_background: bool = false
+) -> PackedInt32Array:
+	var out := PackedInt32Array()
+	var count: int = maxi(palette.size(), Gen2Palette.COLORS_PER_PIC)
+	out.resize(count)
 
-	for i: int in Gen2Palette.COLORS_PER_PIC:
+	for i: int in count:
 		var color: Color = palette[i] if i < palette.size() else Color.MAGENTA
-		var at: int = i * CHANNELS
-		out[at] = int(roundf(color.r * 255.0))
-		out[at + 1] = int(roundf(color.g * 255.0))
-		out[at + 2] = int(roundf(color.b * 255.0))
 		# The palette's own alpha, so a translucent colour needs no second
 		# flag. Every cartridge palette is opaque, Gen2Palette.decode_color
 		# building an opaque Color.
-		out[at + 3] = 0 if transparent_background and i == 0 \
-			else int(roundf(clampf(color.a, 0.0, 1.0) * 255.0))
+		var alpha: int = 0 if transparent_background and i == 0 \
+			else int(clampf(color.a, 0.0, 1.0) * 255.0)
+		## Truncated, not rounded: `Image.set_pixel` casts and a five-bit
+		## colour's own reference expansion floors, so a colour comes out the
+		## same byte whichever path drew it. Rounding put every caller of this
+		## table one unit off the rest of the game on nine of the 32 levels.
+		out[i] = int(clampf(color.r, 0.0, 1.0) * 255.0) \
+			| (int(clampf(color.g, 0.0, 1.0) * 255.0) << 8) \
+			| (int(clampf(color.b, 0.0, 1.0) * 255.0) << 16) \
+			| (alpha << 24)
 
 	return out
 
@@ -252,3 +256,110 @@ static func x_flipped_indices(indices: PackedByteArray, width: int) -> PackedByt
 		for x: int in width:
 			out[row + x] = indices[row + width - 1 - x]
 	return out
+
+
+## The palette as the eight-bit colours a blit actually writes.
+##
+## For a caller comparing a rendered pixel against a palette: a 15-bit colour is
+## kept as a float and read back through an eight-bit image, so the comparison
+## belongs where the picture is and the conversion has to be the drawing's own.
+static func quantized(
+	palette: PackedColorArray, transparent_background: bool = false
+) -> PackedColorArray:
+	var table: PackedInt32Array = lookup(palette, transparent_background)
+	var out := PackedColorArray()
+	for index: int in palette.size():
+		var word: int = table[index]
+		out.append(Color8(
+			word & 0xFF, (word >> 8) & 0xFF, (word >> 16) & 0xFF, (word >> 24) & 0xFF
+		))
+	return out
+
+
+## A blank canvas [param width] x [param height], one packed RGBA8 word per
+## pixel. Every word is zero, which is transparent black.
+##
+## A word rather than four bytes because the inner loop of every page in the
+## project is one store per pixel either way, and four of them cost four bounds
+## checks; the conversion to bytes at the end is one memcpy.
+static func canvas(width: int, height: int) -> PackedInt32Array:
+	var out := PackedInt32Array()
+	out.resize(maxi(width, 0) * maxi(height, 0))
+	return out
+
+
+## The [Image] a canvas has become. Paired with [method canvas] so a page builds
+## its screen in one buffer and pays one conversion.
+static func canvas_image(pixels: PackedInt32Array, width: int, height: int) -> Image:
+	if width <= 0 or height <= 0 or pixels.size() < width * height:
+		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
+	return Image.create_from_data(
+		width, height, false, Image.FORMAT_RGBA8, pixels.to_byte_array()
+	)
+
+
+## One 8x8 tile of [param strip] into a [method canvas] buffer.
+##
+## [param strip] is a horizontal run of [param strip_tiles] tiles, one byte of
+## colour index per pixel, which is the shape every sheet in the cache is stored
+## in; [param table] is [method lookup]'s. [param skip_index] is the colour the
+## blit leaves standing, -1 for none: an object palette never draws index 0 and
+## a background tile draws all four.
+##
+## Clipped rather than refused, so a caller places a sprite partly off screen
+## the way OAM does.
+static func blit_tile(
+	pixels: PackedInt32Array,
+	width: int,
+	height: int,
+	strip: PackedByteArray,
+	strip_tiles: int,
+	tile: int,
+	at_x: int,
+	at_y: int,
+	table: PackedInt32Array,
+	flip_x: bool = false,
+	flip_y: bool = false,
+	skip_index: int = -1,
+) -> void:
+	if strip_tiles <= 0 or tile < 0 or tile >= strip_tiles or table.is_empty():
+		return
+	var stride: int = strip_tiles * Gen2Tiles.TILE_WIDTH
+	var left: int = tile * Gen2Tiles.TILE_WIDTH
+	var colors: int = table.size()
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		var y: int = at_y + row
+		if y < 0 or y >= height:
+			continue
+		var from: int = (
+			(Gen2Tiles.TILE_HEIGHT - 1 - row) if flip_y else row
+		) * stride + left
+		if from < 0 or from + Gen2Tiles.TILE_WIDTH > strip.size():
+			continue
+		var to_row: int = y * width
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			var x: int = at_x + column
+			if x < 0 or x >= width:
+				continue
+			var index: int = strip[
+				from + ((Gen2Tiles.TILE_WIDTH - 1 - column) if flip_x else column)
+			]
+			if index == skip_index:
+				continue
+			pixels[to_row + x] = table[mini(index, colors - 1)]
+
+
+## The texture [param texture] becomes once it holds [param image].
+##
+## A screen redrawn every frame used to answer `ImageTexture.create_from_image`
+## each time, which allocates a texture and frees the last one on every frame it
+## draws; `update` writes into the one already on the GPU. The size and format
+## have to match for that, so a first frame and a resize still create.
+static func refreshed_texture(texture: ImageTexture, image: Image) -> ImageTexture:
+	if image == null:
+		return texture
+	if texture == null or Vector2i(texture.get_size()) != image.get_size() \
+		or texture.get_format() != image.get_format():
+		return ImageTexture.create_from_image(image)
+	texture.update(image)
+	return texture

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -31,14 +31,29 @@ static func from_indices(
 	if width <= 0 or height <= 0 or indices.size() < width * height:
 		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
 
-	var table: PackedInt32Array = lookup(palette, transparent_background)
-	var words := PackedInt32Array()
-	words.resize(width * height)
+	return canvas_image(
+		canvas_from_indices(indices, width, height, palette, transparent_background),
+		width, height
+	)
 
+
+## The same before the conversion, for a page that goes on to blit over it.
+static func canvas_from_indices(
+	indices: PackedByteArray,
+	width: int,
+	height: int,
+	palette: PackedColorArray,
+	transparent_background: bool = false
+) -> PackedInt32Array:
+	var words := PackedInt32Array()
+	if width <= 0 or height <= 0 or indices.size() < width * height:
+		words.resize(maxi(width, 1) * maxi(height, 1))
+		return words
+	var table: PackedInt32Array = lookup(palette, transparent_background)
+	words.resize(width * height)
 	for i: int in width * height:
 		words[i] = table[indices[i]]
-
-	return canvas_image(words, width, height)
+	return words
 
 
 ## An image from a row-major index buffer plus `wAttrmap`: one palette index per
@@ -62,12 +77,32 @@ static func from_attributes(
 	if width <= 0 or height <= 0 or indices.size() < width * height:
 		return Image.create_empty(maxi(width, 1), maxi(height, 1), false, Image.FORMAT_RGBA8)
 
+	return canvas_image(
+		canvas_from_attributes(indices, width, height, slots, columns, palettes),
+		width, height
+	)
+
+
+## The same before the conversion, for a page that goes on to blit over it.
+static func canvas_from_attributes(
+	indices: PackedByteArray,
+	width: int,
+	height: int,
+	slots: PackedInt32Array,
+	columns: int,
+	palettes: Array
+) -> PackedInt32Array:
+	var words := PackedInt32Array()
+	if palettes.is_empty() or width <= 0 or height <= 0 \
+		or indices.size() < width * height:
+		words.resize(maxi(width, 1) * maxi(height, 1))
+		return words
+
 	var lookups: Array[PackedInt32Array] = []
 	for palette: Variant in palettes:
 		lookups.append(lookup(palette as PackedColorArray, false))
 
 	var tile: int = Gen2Font.TILE
-	var words := PackedInt32Array()
 	words.resize(width * height)
 	for y: int in height:
 		@warning_ignore("integer_division")
@@ -80,8 +115,7 @@ static func from_attributes(
 				clampi(slots[slot] if slot < slots.size() else 0, 0, lookups.size() - 1)
 			]
 			words[line + x] = table[indices[line + x]]
-
-	return canvas_image(words, width, height)
+	return words
 
 
 ## An attrmap from a list of `FillBoxCGB` boxes, each (x, y, width, height,
@@ -349,17 +383,38 @@ static func blit_tile(
 			pixels[to_row + x] = table[mini(index, colors - 1)]
 
 
+## Puts [param image] on [param target].
+##
+## The one way a screen in this project hands a redrawn picture to the node that
+## shows it, so the reuse below happens everywhere rather than at whichever
+## screen was measured.
+static func show(target: TextureRect, image: Image) -> void:
+	if target == null:
+		return
+	target.texture = refreshed_texture(target.texture as ImageTexture, image)
+
+
 ## The texture [param texture] becomes once it holds [param image].
 ##
 ## A screen redrawn every frame used to answer `ImageTexture.create_from_image`
 ## each time, which allocates a texture and frees the last one on every frame it
 ## draws; `update` writes into the one already on the GPU. The size and format
 ## have to match for that, so a first frame and a resize still create.
+##
+## Not headless. There is no GPU there to save the upload to, and the dummy
+## driver hands `ImageTexture.get_image` back the picture the texture was
+## created with rather than the one it was last updated with, so a check or a
+## test that reads a screen back would read the frame before the one it asked
+## for.
 static func refreshed_texture(texture: ImageTexture, image: Image) -> ImageTexture:
 	if image == null:
 		return texture
-	if texture == null or Vector2i(texture.get_size()) != image.get_size() \
+	if texture == null or _drawing_nothing \
+		or Vector2i(texture.get_size()) != image.get_size() \
 		or texture.get_format() != image.get_format():
 		return ImageTexture.create_from_image(image)
 	texture.update(image)
 	return texture
+
+
+static var _drawing_nothing: bool = DisplayServer.get_name() == "headless"

--- a/game/render/pic_viewer.gd
+++ b/game/render/pic_viewer.gd
@@ -160,7 +160,7 @@ func _refresh_trainer() -> void:
 
 
 func _show(image: Image) -> void:
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = image.get_size()
 	_pic.position = (
 		Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT) - Vector2(image.get_size())

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -431,7 +431,7 @@ func _redraw() -> void:
 	)
 	if not raster_scx.is_empty():
 		image = Gen2Raster.scroll(image, raster_scx, Gen2BattleIntro.MAP_WIDTH)
-	texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(self, image)
 	size = Vector2(width, height)
 
 

--- a/game/render/text_viewer.gd
+++ b/game/render/text_viewer.gd
@@ -166,6 +166,6 @@ func _build_chart() -> void:
 		indices, width, height,
 		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 	)
-	_chart.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_chart, image)
 	_chart.size = Vector2(width, height)
 	_chart.position = Vector2(int((Gen2Screen.WIDTH - width) / 2), 8)

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -194,8 +194,15 @@ var _tilemap: PackedByteArray = PackedByteArray()
 var _drawn: PackedByteArray = PackedByteArray()
 ## Which pixels an object has already claimed this frame.
 var _taken: PackedByteArray = PackedByteArray()
-var _map: Image = null
+## The BG map this frame, one packed colour per pixel beside the colour indices
+## `OAM_PRIO` reads.
+var _map: PackedInt32Array = PackedInt32Array()
 var _map_indices: PackedByteArray = PackedByteArray()
+## The same map without whatever moves on it, built once: the logo, the version
+## line and Gold and Silver's whole tilemap never change, and rebuilding 140
+## tiles of them sixty times a second is the frame this screen used to spend.
+var _base: PackedInt32Array = PackedInt32Array()
+var _base_indices: PackedByteArray = PackedByteArray()
 
 
 ## Null on a cache with no title art, which is the caller's cue to skip the
@@ -242,36 +249,46 @@ static func from_data(data: GameData) -> Gen2TitlePage:
 func draw(scene: Gen2TitleScene) -> Image:
 	var width: int = COLUMNS * TILE
 	var height: int = ROWS * TILE
-	var image: Image = Image.create_empty(width, height, false, Image.FORMAT_RGBA8)
-	var blank: Color = _background[0][0] if not _background[0].is_empty() else Color.BLACK
-	image.fill(blank)
+	var blank: int = 0
+	if not _background.is_empty() and not _background[0].is_empty():
+		blank = Gen2PicImage.lookup(_background[0])[0]
+	if scene == null:
+		var empty: PackedInt32Array = Gen2PicImage.canvas(width, height)
+		empty.fill(blank)
+		return Gen2PicImage.canvas_image(empty, width, height)
+
+	_build_base(blank)
+	if _profile == RomRegistry.CRYSTAL:
+		# The strip `LoadSuicuneFrame` re-points is the one thing on the map that
+		# moves, so the frame starts from the still half rather than from blank.
+		_map = _base.duplicate()
+		_map_indices = _base_indices.duplicate()
+		_draw_crystal_suicune(scene)
+	else:
+		_map = _base
+		_map_indices = _base_indices
 	# What colour index each pixel of the background ended up as, which is the
 	# only thing `OAM_PRIO` reads: a sprite behind the background shows through
-	# colour 0 and nowhere else.
-	_drawn.resize(width * height)
-	_drawn.fill(0)
-	if scene == null:
-		return image
-
-	_map = Image.create_empty(MAP_WIDTH, MAP_HEIGHT, false, Image.FORMAT_RGBA8)
-	_map.fill(blank)
-	_map_indices.resize(MAP_WIDTH * MAP_HEIGHT)
-	_map_indices.fill(0)
-	if _profile == RomRegistry.CRYSTAL:
-		_draw_crystal_background(scene)
-	else:
-		_draw_gs_background()
-	_compose(image, scene)
-	_draw_copyright_window(image, scene)
+	# colour 0 and nowhere else. Collected only for a frame that has one, since
+	# it is a second store per pixel of the screen and Crystal never asks.
+	var behind: bool = false
+	var sprites: Array[Dictionary] = shadow_oam(scene)
+	for entry: Dictionary in sprites:
+		if bool(entry["behind"]):
+			behind = true
+			break
+	_drawn.resize(0)
+	var pixels: PackedInt32Array = _compose(scene, behind)
+	_draw_copyright_window(pixels, scene)
 
 	# The lower OAM index wins a pixel, so a slot only paints where no earlier
 	# one did: Gold's bird is copied into the last struct, so every trail spawned
 	# after it still takes a lower slot and covers it.
 	_taken.resize(width * height)
 	_taken.fill(0)
-	for entry: Dictionary in shadow_oam(scene):
-		_draw_sprite(image, entry)
-	return image
+	for entry: Dictionary in sprites:
+		_draw_sprite(pixels, entry)
+	return Gen2PicImage.canvas_image(pixels, width, height)
 
 
 ## Every object expanded into the shadow OAM the hardware would hold, in struct
@@ -308,52 +325,79 @@ func shadow_oam(scene: Gen2TitleScene) -> Array[Dictionary]:
 
 ## The BG map through `hSCX` and whatever `wLYOverrides` is writing over it, one
 ## scanline at a time.
-func _compose(image: Image, scene: Gen2TitleScene) -> void:
+func _compose(scene: Gen2TitleScene, collect_indices: bool) -> PackedInt32Array:
 	var offsets: PackedInt32Array = scene.line_offsets()
 	var base: int = scene.scroll_x()
 	var scy: int = scene.scroll_y()
-	for y: int in image.get_height():
+	var width: int = COLUMNS * TILE
+	var pixels := PackedInt32Array()
+	## Appended run by run rather than pixel by pixel: the map is wider than the
+	## screen, so a scanline is one span of it or two with the wrap between them,
+	## and a span is a copy the engine does in one call.
+	for y: int in ROWS * TILE:
 		# `LCD` fires on `STAT_MODE_0` and writes `wLYOverrides[rLY]` to rSCX,
 		# which the line after it is drawn with; `VBlank_Cutscene` writes entry
 		# zero, so the first two lines share it.
 		var line: int = maxi(y - 1, 0)
 		var shift: int = offsets[line] if line < offsets.size() else base
-		var row: int = posmod(y + scy, MAP_HEIGHT)
-		for x: int in image.get_width():
-			var from: int = posmod(x + shift, MAP_WIDTH)
-			image.set_pixel(x, y, _map.get_pixel(from, row))
-			_drawn[y * image.get_width() + x] = _map_indices[row * MAP_WIDTH + from]
+		var row: int = posmod(y + scy, MAP_HEIGHT) * MAP_WIDTH
+		var from: int = posmod(shift, MAP_WIDTH)
+		var first: int = mini(width, MAP_WIDTH - from)
+		pixels.append_array(_map.slice(row + from, row + from + first))
+		if collect_indices:
+			_drawn.append_array(_map_indices.slice(row + from, row + from + first))
+		if first < width:
+			pixels.append_array(_map.slice(row, row + width - first))
+			if collect_indices:
+				_drawn.append_array(_map_indices.slice(row, row + width - first))
+	return pixels
 
 
 ## The window layer, which on this screen is the copyright line and nothing
 ## else: one row of `vBGMap1` at `hWX` 7, so it starts at column 0 and covers
 ## whatever the background left under it.
-func _draw_copyright_window(image: Image, scene: Gen2TitleScene) -> void:
+func _draw_copyright_window(pixels: PackedInt32Array, scene: Gen2TitleScene) -> void:
 	var top: int = scene.window_y()
-	if top >= image.get_height():
+	if top >= ROWS * TILE:
 		return
 	var palette: PackedColorArray = _palette(_background, CRYSTAL_COPYRIGHT_PALETTE)
 	if palette.is_empty():
 		return
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for index: int in CRYSTAL_COPYRIGHT_TILES:
 		_blit_window_tile(
-			image, palette, CRYSTAL_COPYRIGHT_TILE + index,
+			pixels, table, CRYSTAL_COPYRIGHT_TILE + index,
 			Vector2i((CRYSTAL_COPYRIGHT_AT + index) * TILE, top)
 		)
 
 
 ## `DrawTitleGraphic` over the logo, then `LoadSuicuneFrame`'s own six rows of
 ## eight. `hSCX` is the entrance's own scroll and moves the whole background.
-func _draw_crystal_background(scene: Gen2TitleScene) -> void:
+func _build_base(blank: int) -> void:
+	if not _base.is_empty():
+		return
+	_map = Gen2PicImage.canvas(MAP_WIDTH, MAP_HEIGHT)
+	_map.fill(blank)
+	_map_indices.resize(MAP_WIDTH * MAP_HEIGHT)
+	_map_indices.fill(0)
+	if _profile == RomRegistry.CRYSTAL:
+		_draw_crystal_logo()
+	else:
+		_draw_gs_background()
+	_base = _map.duplicate()
+	_base_indices = _map_indices.duplicate()
+
+
+func _draw_crystal_logo() -> void:
 	for row: int in CRYSTAL_LOGO_ROWS:
-		var palette: PackedColorArray = _palette(
+		var table: PackedInt32Array = _table(
 			_background, CRYSTAL_LOGO_PALETTES[row]
 		)
 		for column: int in CRYSTAL_LOGO_COLUMNS:
 			_blit_background(
 				"title_logo", row * CRYSTAL_LOGO_COLUMNS + column,
 				Vector2i(CRYSTAL_LOGO_AT.x + column, CRYSTAL_LOGO_AT.y + row) * TILE,
-				palette
+				table
 			)
 	# The eleven tiles of "CRYSTAL VERSION" sit on the logo's last row and take a
 	# palette of their own.
@@ -363,12 +407,17 @@ func _draw_crystal_background(scene: Gen2TitleScene) -> void:
 			"title_logo",
 			(CRYSTAL_VERSION_ROW - CRYSTAL_LOGO_AT.y) * CRYSTAL_LOGO_COLUMNS + column,
 			Vector2i(column, CRYSTAL_VERSION_ROW) * TILE,
-			_palette(_background, CRYSTAL_VERSION_PALETTE)
+			_table(_background, CRYSTAL_VERSION_PALETTE)
 		)
+
+
+## `LoadSuicuneFrame` re-points the strip every eighth frame, which is the one
+## part of Crystal's map that is not the same on every frame.
+func _draw_crystal_suicune(scene: Gen2TitleScene) -> void:
+	var table: PackedInt32Array = _table(_background, CRYSTAL_SUICUNE_PALETTE)
 	for placed: Vector3i in scene.suicune_tiles():
 		_blit_background(
-			"title_suicune", placed.z, Vector2i(placed.x, placed.y) * TILE,
-			_palette(_background, CRYSTAL_SUICUNE_PALETTE)
+			"title_suicune", placed.z, Vector2i(placed.x, placed.y) * TILE, table
 		)
 
 
@@ -388,7 +437,7 @@ func _draw_gs_background() -> void:
 				tile = code - GS_TOP_FIRST_TILE
 			_blit_background(
 				name, tile, Vector2i(column, row) * TILE,
-				_palette(_background, _gs_palette(row, column))
+				_table(_background, _gs_palette(row, column))
 			)
 
 
@@ -406,15 +455,16 @@ func _gs_palette(row: int, column: int) -> int:
 ## One shadow-OAM entry, drawn through an object palette whose first colour is
 ## transparent. The screen is in 8x16 mode, so the entry's tile is the top half
 ## and the one after it the bottom.
-func _draw_sprite(image: Image, entry: Dictionary) -> void:
+func _draw_sprite(pixels: PackedInt32Array, entry: Dictionary) -> void:
 	var palette: PackedColorArray = _palette(_object, int(entry["palette"]))
 	if palette.size() <= TRANSPARENT_INDEX:
 		return
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	var to := Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y)
 	var sheet: String = String(entry["sheet"])
 	for half: int in OBJECT_HEIGHT:
 		_blit_sprite_tile(
-			image, palette, sheet, int(entry["tile"]) - _vram_base(sheet) + half,
+			pixels, table, sheet, int(entry["tile"]) - _vram_base(sheet) + half,
 			Vector2i(to.x, to.y + half * TILE), bool(entry["behind"])
 		)
 
@@ -465,6 +515,12 @@ func _oam_set(kind: StringName, frame: int) -> Array[Vector3i]:
 			return out
 
 
+## The same run through [method Gen2PicImage.lookup], which is what every blit
+## below writes.
+func _table(run: Array[PackedColorArray], index: int) -> PackedInt32Array:
+	return Gen2PicImage.lookup(_palette(run, index))
+
+
 func _palette(run: Array[PackedColorArray], index: int) -> PackedColorArray:
 	if index < 0 or index >= run.size():
 		return PackedColorArray()
@@ -474,16 +530,17 @@ func _palette(run: Array[PackedColorArray], index: int) -> PackedColorArray:
 ## One tile into the BG map, through the palette its attribute names. The map is
 ## what wraps and what the scroll is applied to; nothing here knows the screen.
 func _blit_background(
-	name: String, tile: int, at: Vector2i, palette: PackedColorArray
+	name: String, tile: int, at: Vector2i, table: PackedInt32Array
 ) -> void:
 	var tiles: PackedByteArray = _sheets.get(name, PackedByteArray())
 	var stride: int = int(_widths.get(name, 0))
-	if stride <= 0 or tile < 0 or palette.is_empty():
+	if stride <= 0 or tile < 0 or table.is_empty():
 		return
 	for y: int in TILE:
 		var target_y: int = at.y + y
-		if target_y < 0 or target_y >= _map.get_height():
+		if target_y < 0 or target_y >= MAP_HEIGHT:
 			continue
+		var row: int = target_y * MAP_WIDTH
 		for x: int in TILE:
 			var target_x: int = at.x + x
 			if target_x < 0 or target_x >= MAP_WIDTH:
@@ -492,65 +549,69 @@ func _blit_background(
 			if from < 0 or from >= tiles.size():
 				continue
 			var value: int = tiles[from]
-			if value >= palette.size():
+			if value >= table.size():
 				continue
-			_map.set_pixel(target_x, target_y, palette[value])
-			_map_indices[target_y * MAP_WIDTH + target_x] = value
+			_map[row + target_x] = table[value]
+			_map_indices[row + target_x] = value
 
 
 ## One window tile straight onto the screen. The window is drawn over the
 ## background and under nothing, so it needs neither the map's wrap nor a claim
 ## on [member _taken].
 func _blit_window_tile(
-	image: Image, palette: PackedColorArray, tile: int, at: Vector2i
+	pixels: PackedInt32Array, table: PackedInt32Array, tile: int, at: Vector2i
 ) -> void:
 	var tiles: PackedByteArray = _sheets.get("title_logo", PackedByteArray())
 	var stride: int = int(_widths.get("title_logo", 0))
 	if stride <= 0:
 		return
+	var width: int = COLUMNS * TILE
 	for y: int in TILE:
 		var target_y: int = at.y + y
-		if target_y < 0 or target_y >= image.get_height():
+		if target_y < 0 or target_y >= ROWS * TILE:
 			continue
+		var row: int = target_y * width
 		for x: int in TILE:
 			var target_x: int = at.x + x
-			if target_x < 0 or target_x >= image.get_width():
+			if target_x < 0 or target_x >= width:
 				continue
 			var from: int = y * stride + tile * TILE + x
 			if from < 0 or from >= tiles.size():
 				continue
 			var value: int = tiles[from]
-			if value >= palette.size():
+			if value >= table.size():
 				continue
-			image.set_pixel(target_x, target_y, palette[value])
+			pixels[row + target_x] = table[value]
 
 
 ## One object tile onto the drawn screen, clipped per axis so a sprite hanging
 ## off an edge cannot wrap onto the opposite one. [param behind] is `OAM_PRIO`,
 ## which lets the background's colours 1 to 3 cover the object.
 func _blit_sprite_tile(
-	image: Image, palette: PackedColorArray, name: String, tile: int, at: Vector2i,
-	behind: bool = false
+	pixels: PackedInt32Array, table: PackedInt32Array, name: String, tile: int,
+	at: Vector2i, behind: bool = false
 ) -> void:
 	var tiles: PackedByteArray = _sheets.get(name, PackedByteArray())
 	var stride: int = int(_widths.get(name, 0))
 	if stride <= 0 or tile < 0:
 		return
+	var width: int = COLUMNS * TILE
 	for y: int in TILE:
 		var target_y: int = at.y + y
-		if target_y < 0 or target_y >= image.get_height():
+		if target_y < 0 or target_y >= ROWS * TILE:
 			continue
+		var row: int = target_y * width
 		for x: int in TILE:
 			var target_x: int = at.x + x
-			if target_x < 0 or target_x >= image.get_width():
+			if target_x < 0 or target_x >= width:
 				continue
 			var from: int = y * stride + tile * TILE + x
 			if from < 0 or from >= tiles.size():
 				continue
 			var value: int = tiles[from]
-			if value == TRANSPARENT_INDEX or value >= palette.size():
+			if value == TRANSPARENT_INDEX or value >= table.size():
 				continue
-			var at_pixel: int = target_y * image.get_width() + target_x
+			var at_pixel: int = row + target_x
 			if _taken[at_pixel] != 0:
 				continue
 			# The claim comes first: an object that loses the pixel to the
@@ -558,4 +619,4 @@ func _blit_sprite_tile(
 			_taken[at_pixel] = 1
 			if behind and _drawn[at_pixel] != 0:
 				continue
-			image.set_pixel(target_x, target_y, palette[value])
+			pixels[at_pixel] = table[value]

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -477,25 +477,28 @@ func attributes(data: GameData, map: PackedInt32Array) -> PackedInt32Array:
 func image(data: GameData, map: PackedInt32Array, female: bool = false) -> Image:
 	var indices: PackedByteArray = compose(map)
 	var slots: PackedInt32Array = attributes(data, map)
-	var out := Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
-	var palettes: Array = []
+	var out: PackedInt32Array = Gen2PicImage.canvas(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	var tables: Array[PackedInt32Array] = []
+	var sizes := PackedInt32Array()
 	for slot: int in RomLayout.TOWN_MAP_PALETTES:
-		palettes.append(data.town_map_palette(slot, female))
+		var palette: PackedColorArray = data.town_map_palette(slot, female)
+		tables.append(
+			PackedInt32Array() if palette.is_empty() else Gen2PicImage.lookup(palette)
+		)
+		sizes.append(palette.size())
 	for row: int in ROWS:
 		for column: int in COLUMNS:
-			var palette: PackedColorArray = palettes[
-				clampi(slots[row * COLUMNS + column], 0, palettes.size() - 1)
-			]
-			if palette.is_empty():
+			var slot: int = clampi(slots[row * COLUMNS + column], 0, tables.size() - 1)
+			var table: PackedInt32Array = tables[slot]
+			if table.is_empty():
 				continue
+			var last: int = sizes[slot] - 1
 			for y: int in TILE:
+				var line: int = (row * TILE + y) * Gen2Screen.WIDTH
 				for x: int in TILE:
 					var at_x: int = column * TILE + x
-					var at_y: int = row * TILE + y
-					out.set_pixel(at_x, at_y, palette[
-						clampi(indices[at_y * Gen2Screen.WIDTH + at_x], 0, palette.size() - 1)
-					])
-	return out
+					out[line + at_x] = table[clampi(indices[line + at_x], 0, last)]
+	return Gen2PicImage.canvas_image(out, Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 
 
 ## Resolves every tile number to pixels: the two graphics sheets out of the VRAM

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -292,7 +292,7 @@ func _refresh() -> void:
 	var palette: PackedColorArray = _interface_palette()
 	if _backdrop != null:
 		_backdrop.color = palette[0]
-	_background.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
+	Gen2PicImage.show(_background, Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, palette, true
 	))
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
@@ -374,7 +374,7 @@ func _refresh_pic(mon: Gen2SaveMon) -> void:
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
 		_data.palette(mon.species)
 	)
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	## `_PrepMonFrontpic` places a pic smaller than the seven-tile cell at its
 	## bottom, which is what keeps every species standing on the same line.
@@ -398,7 +398,7 @@ func _refresh_cursor(row_count: int) -> void:
 			continue
 		var sprite: Dictionary = sprites[index]
 		node.position = Vector2(sprite["position"])
-		node.texture = ImageTexture.create_from_image(_cursor_image(
+		Gen2PicImage.show(node, _cursor_image(
 			sheet, palette, int(sprite["tile"]),
 			bool(sprite["flip_x"]), bool(sprite["flip_y"])
 		))

--- a/game/world/card_flip_screen.gd
+++ b/game/world/card_flip_screen.gd
@@ -208,6 +208,6 @@ func _refresh() -> void:
 		_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		add_child(_view)
-	_view.texture = ImageTexture.create_from_image(
+	Gen2PicImage.show(_view,
 		_page.render(_game, overlay_state())
 	)

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -311,7 +311,7 @@ func _render() -> void:
 		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])),
 		_presentation.bgp()
 	)
-	_view.texture = ImageTexture.create_from_image(_page.render(
+	Gen2PicImage.show(_view, _page.render(
 		value_text, "", _confirm_cursor if confirm else -1, kind, colors
 	))
 	if _text_box != null:

--- a/game/world/credits_screen.gd
+++ b/game/world/credits_screen.gd
@@ -125,4 +125,4 @@ func _process(delta: float) -> void:
 func _refresh() -> void:
 	if _view == null:
 		return
-	_view.texture = ImageTexture.create_from_image(render())
+	Gen2PicImage.show(_view, render())

--- a/game/world/day_care_screen.gd
+++ b/game/world/day_care_screen.gd
@@ -538,6 +538,6 @@ func _draw_yes_no() -> void:
 		return
 	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true

--- a/game/world/egg_hatch_screen.gd
+++ b/game/world/egg_hatch_screen.gd
@@ -453,7 +453,7 @@ func _draw_yes_no() -> void:
 		return
 	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _nickname_yes else 1)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true
 
@@ -480,7 +480,7 @@ func _blit(pic: Dictionary, colours: PackedColorArray, at: Vector2i) -> void:
 	var image: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, colours
 	)
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	_pic_origin = at
 	_place_pic()
@@ -520,7 +520,7 @@ func _draw_animation_box() -> void:
 	var image: Image = Gen2PicImage.from_indices(
 		indices, side, side, _data.palette(int(current_hatch().get("species", 0)))
 	)
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	_pic_origin = HATCHLING_AT
 	_place_pic()

--- a/game/world/evolution_screen.gd
+++ b/game/world/evolution_screen.gd
@@ -417,7 +417,7 @@ func _draw_species(species: int) -> void:
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
 		_data.palette(species)
 	)
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	## `PadFrontpic` bottom-aligns a pic shorter than the block one column in,
 	## which is where `PlaceGraphic`'s tile numbers put it.
@@ -462,6 +462,6 @@ func _draw_animation_box() -> void:
 		indices, side, side,
 		_data.palette(int(current_plan().get("new_species", 0)))
 	)
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	_pic.position = Vector2(PIC_AT.x * TILE, PIC_AT.y * TILE)

--- a/game/world/gender_screen.gd
+++ b/game/world/gender_screen.gd
@@ -94,7 +94,7 @@ func _refresh() -> void:
 	if _background == null or _page == null or _menu == null:
 		return
 	var indices: PackedByteArray = _page.draw(_question, _menu.selected_index())
-	_background.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
+	Gen2PicImage.show(_background, Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _palette()
 	))
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -112,7 +112,7 @@ func _refresh() -> void:
 		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])),
 		true
 	)
-	_background.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_background, image)
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_refresh_pic(page)
 
@@ -133,7 +133,7 @@ func _refresh_pic(page: Dictionary) -> void:
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
 		_data.palette(species)
 	)
-	_pic.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	## The source centres a seven-tile cell on (6,5); a pic smaller than that
 	## cell is drawn at its bottom, the way _PrepMonFrontpic places it.

--- a/game/world/move_deleter_screen.gd
+++ b/game/world/move_deleter_screen.gd
@@ -303,7 +303,7 @@ func _draw_move_list() -> void:
 	var image: Image = _move_page.render(_move_model.snapshot(), _data)
 	if image == null:
 		return
-	_move_view.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_move_view, image)
 	_move_view.visible = true
 
 
@@ -314,6 +314,6 @@ func _draw_yes_no() -> void:
 		return
 	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true

--- a/game/world/move_tutor_screen.gd
+++ b/game/world/move_tutor_screen.gd
@@ -390,7 +390,7 @@ func _draw_yes_no() -> void:
 		return
 	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 	var image: Image = _page().render(box, ["YES", "NO"], 0 if _yes else 1)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true
 
@@ -406,6 +406,6 @@ func _draw_forget_list() -> void:
 	for entry: Dictionary in _forget_moves:
 		names.append(String(entry.get("name", "")))
 	var image: Image = _page().render(box, names, _forget_cursor)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -324,6 +324,6 @@ func _draw_yes_no() -> void:
 		return
 	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -100,7 +100,7 @@ func _refresh() -> void:
 	if _background == null or _page == null or _screen == null:
 		return
 	var indices: PackedByteArray = _page.draw(_screen, _prompt)
-	_background.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
+	Gen2PicImage.show(_background, Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _colors()
 	))
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)

--- a/game/world/nickname_prompt_screen.gd
+++ b/game/world/nickname_prompt_screen.gd
@@ -184,7 +184,7 @@ func _draw_yes_no() -> void:
 		return
 	var box: Gen2MenuBox = Gen2MenuBox.yes_no()
 	var image: Image = _menu_page.render(box, ["YES", "NO"], 0 if _yes else 1)
-	_menu.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_menu, image)
 	_menu.position = Vector2(box.border_position() * TILE)
 	_menu.visible = true
 

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -511,7 +511,7 @@ func _show_pic(kind: int) -> void:
 func _redraw_pic(colors: PackedColorArray) -> void:
 	if _pic_cell.is_empty():
 		return
-	_pic.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
+	Gen2PicImage.show(_pic, Gen2PicImage.from_indices(
 		_pic_cell["indices"], int(_pic_cell["width"]), int(_pic_cell["height"]), colors
 	))
 
@@ -631,7 +631,7 @@ func _redraw_sprite(colors: PackedColorArray) -> void:
 	var image: Image = Gen2WorldSprite.image_for(
 		_sprite_source, _data.overworld_sprite_indices(_sprite_source.number), colors
 	)
-	_sprite.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_sprite, image)
 	_sprite.size = Vector2(image.get_size())
 
 

--- a/game/world/player_name_menu_screen.gd
+++ b/game/world/player_name_menu_screen.gd
@@ -81,7 +81,7 @@ func _refresh() -> void:
 	_page.draw(box, _options, _menu.selected_index(), indices, Gen2Screen.WIDTH, "NAME", 2)
 	# Index 0 stays transparent: `MENU_BACKUP_TILES` draws this over the left of
 	# a screen the player pic is still standing on the right of.
-	_background.texture = ImageTexture.create_from_image(Gen2PicImage.from_indices(
+	Gen2PicImage.show(_background, Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _colors(), true
 	))
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -455,7 +455,7 @@ func _open_search_results_mode() -> void:
 func _refresh() -> void:
 	if _background == null or _page == null or _dex == null:
 		return
-	_background.texture = ImageTexture.create_from_image(render())
+	Gen2PicImage.show(_background, render())
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 
 

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -374,14 +374,14 @@ func _sprite() -> TextureRect:
 func _refresh() -> void:
 	if not _open or _background == null or _page == null:
 		return
-	_background.texture = ImageTexture.create_from_image(_background_image())
+	Gen2PicImage.show(_background, _background_image())
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_arrow.position = Vector2(_arrow_position())
-	_arrow.texture = ImageTexture.create_from_image(_arrow_image())
+	Gen2PicImage.show(_arrow, _arrow_image())
 	_knob_icon.visible = _card == CARD_RADIO
 	if _knob_icon.visible:
 		_knob_icon.position = Vector2(_knob_position())
-		_knob_icon.texture = ImageTexture.create_from_image(_knob_image())
+		Gen2PicImage.show(_knob_icon, _knob_image())
 
 
 func _background_image() -> Image:
@@ -455,29 +455,23 @@ func _knob_image() -> Image:
 ## through the overworld's first palette the way every icon on these screens is.
 ## Colour zero is transparent, which is what lets one sit over the card.
 func _icon(first: int, columns: int, rows: int, repeat: bool = false) -> Image:
-	var pixels := Vector2i(columns, rows) * Gen2TownMapPage.TILE
-	var out := Image.create(pixels.x, pixels.y, false, Image.FORMAT_RGBA8)
-	out.fill(Color(0, 0, 0, 0))
+	var size := Vector2i(columns, rows) * Gen2TownMapPage.TILE
+	var out: PackedInt32Array = Gen2PicImage.canvas(size.x, size.y)
 	var tiles: PackedByteArray = _data.tile_indices("pokegear_sprites") if _data != null \
 		else PackedByteArray()
 	var palette: PackedColorArray = _data.overworld_sprite_palette(0, _time_of_day) \
 		if _data != null else PackedColorArray()
 	if tiles.is_empty() or palette.is_empty():
-		return out
-	var width: int = tiles.size() / Gen2TownMapPage.TILE
+		return Gen2PicImage.canvas_image(out, size.x, size.y)
+	@warning_ignore("integer_division")
+	var strip_tiles: int = tiles.size() / Gen2Tiles.TILE_PIXELS
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for row: int in rows:
 		for column: int in columns:
-			var tile: int = first if repeat else first + row * columns + column
-			for y: int in Gen2TownMapPage.TILE:
-				for x: int in Gen2TownMapPage.TILE:
-					var index: int = tiles[
-						y * width + tile * Gen2TownMapPage.TILE + x
-					]
-					if index == 0:
-						continue
-					out.set_pixel(
-						column * Gen2TownMapPage.TILE + x,
-						row * Gen2TownMapPage.TILE + y,
-						palette[clampi(index, 0, palette.size() - 1)]
-					)
-	return out
+			Gen2PicImage.blit_tile(
+				out, size.x, size.y, tiles, strip_tiles,
+				first if repeat else first + row * columns + column,
+				column * Gen2TownMapPage.TILE, row * Gen2TownMapPage.TILE,
+				table, false, false, 0
+			)
+	return Gen2PicImage.canvas_image(out, size.x, size.y)

--- a/game/world/slot_machine_screen.gd
+++ b/game/world/slot_machine_screen.gd
@@ -220,6 +220,6 @@ func _refresh() -> void:
 		_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		add_child(_view)
-	_view.texture = ImageTexture.create_from_image(
+	Gen2PicImage.show(_view,
 		_page.render(_machine, overlay_state())
 	)

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -34,6 +34,7 @@ var _title_page: Gen2TitlePage = null
 ## its two chords cannot be expressed as presses.
 var _held: Array[int] = []
 var _background: TextureRect = null
+var _texture: ImageTexture = null
 var _audio: Gen2AudioPlayer = null
 var _image: Image = null
 var _visible_id: StringName = &""
@@ -228,7 +229,11 @@ func _finish() -> void:
 func _refresh() -> void:
 	if _background == null:
 		return
-	_background.texture = ImageTexture.create_from_image(_frame_image())
+	## Updated rather than replaced: the opening redraws every frame, and a new
+	## texture a frame is an allocation and a fresh upload for a picture the same
+	## size as the last one.
+	_texture = Gen2PicImage.refreshed_texture(_texture, _frame_image())
+	_background.texture = _texture
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1879,7 +1879,7 @@ func _render_hardware() -> void:
 	_view.visible = image != null
 	if image == null:
 		return
-	_view.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_view, image)
 
 
 ## The words this mode's own box prints, which is what [method _hardware_image]

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -403,7 +403,7 @@ func _sprite() -> TextureRect:
 
 func _refresh() -> void:
 	if _background != null:
-		_background.texture = ImageTexture.create_from_image(_background_image())
+		Gen2PicImage.show(_background, _background_image())
 		_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_refresh_arrow()
 	if _map != null and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
@@ -423,7 +423,7 @@ func _refresh_objects() -> void:
 		and _has_landmark(_map.player_landmark)
 	if _player_icon.visible:
 		_player_icon.position = Vector2(_icon_position(_map.player_landmark))
-		_player_icon.texture = ImageTexture.create_from_image(_player_image())
+		Gen2PicImage.show(_player_icon, _player_image())
 	var landmarks: Array = current_nests() if _oam == OAM_NESTS else []
 	while _nest_icons.size() < landmarks.size():
 		_nest_icons.append(_sprite())
@@ -435,7 +435,7 @@ func _refresh_objects() -> void:
 		if not node.visible:
 			continue
 		node.position = Vector2(_nest_position(landmark))
-		node.texture = ImageTexture.create_from_image(icon)
+		Gen2PicImage.show(node, icon)
 
 
 ## Up only on the Pokegear's own card: `OverworldTownMap`, the fly map and the
@@ -453,7 +453,7 @@ func _refresh_arrow() -> void:
 			0
 		)
 	)
-	_arrow.texture = ImageTexture.create_from_image(_icon_from("pokegear_sprites", ARROW_TILE))
+	Gen2PicImage.show(_arrow, _icon_from("pokegear_sprites", ARROW_TILE))
 
 
 func _background_image() -> Image:
@@ -483,7 +483,7 @@ func _refresh_cursor() -> void:
 	if _cursor_icon == null or _map == null:
 		return
 	_place(_cursor_icon, cursor_landmark())
-	_cursor_icon.texture = ImageTexture.create_from_image(_cursor_image())
+	Gen2PicImage.show(_cursor_icon, _cursor_image())
 
 
 func _cursor_image() -> Image:
@@ -498,28 +498,21 @@ func _icon_from(sheet: String, first: int, flip: bool = false) -> Image:
 	var tiles: PackedByteArray = _data.tile_indices(sheet) if _data != null \
 		else PackedByteArray()
 	var palette: PackedColorArray = _object_palette()
-	var out := Image.create(ICON_SIZE, ICON_SIZE, false, Image.FORMAT_RGBA8)
-	out.fill(Color(0, 0, 0, 0))
+	var out: PackedInt32Array = Gen2PicImage.canvas(ICON_SIZE, ICON_SIZE)
 	if tiles.is_empty() or palette.is_empty():
-		return out
-	var width: int = tiles.size() / Gen2TownMapPage.TILE
+		return Gen2PicImage.canvas_image(out, ICON_SIZE, ICON_SIZE)
+	@warning_ignore("integer_division")
+	var strip_tiles: int = tiles.size() / Gen2Tiles.TILE_PIXELS
+	# Object colour zero is transparent under the hardware's own rules, which is
+	# what lets an icon sit over the map.
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for quadrant: int in 4:
-		var source_x: int = (first + quadrant) * Gen2TownMapPage.TILE
-		var to_x: int = (quadrant & 1) * Gen2TownMapPage.TILE
-		var to_y: int = (quadrant >> 1) * Gen2TownMapPage.TILE
-		for y: int in Gen2TownMapPage.TILE:
-			for x: int in Gen2TownMapPage.TILE:
-				var index: int = tiles[
-					y * width + source_x + (Gen2TownMapPage.TILE - 1 - x if flip else x)
-				]
-				# Object colour zero is transparent under the hardware's own
-				# rules, which is what lets an icon sit over the map.
-				if index == 0:
-					continue
-				out.set_pixel(
-					to_x + x, to_y + y, palette[clampi(index, 0, palette.size() - 1)]
-				)
-	return out
+		Gen2PicImage.blit_tile(
+			out, ICON_SIZE, ICON_SIZE, tiles, strip_tiles, first + quadrant,
+			(quadrant & 1) * Gen2TownMapPage.TILE,
+			(quadrant >> 1) * Gen2TownMapPage.TILE, table, flip, false, 0
+		)
+	return Gen2PicImage.canvas_image(out, ICON_SIZE, ICON_SIZE)
 
 
 ## `PokegearMap_InitPlayerIcon`: `GetPlayerIcon`'s standing and walking frames,
@@ -530,7 +523,7 @@ func _refresh_player_icon() -> void:
 	if _player_icon == null or _map == null:
 		return
 	_place(_player_icon, _map.player_landmark)
-	_player_icon.texture = ImageTexture.create_from_image(_player_image())
+	Gen2PicImage.show(_player_icon, _player_image())
 
 
 func _player_image() -> Image:
@@ -574,18 +567,16 @@ func _nest_image() -> Image:
 	var tiles: PackedByteArray = _data.tile_indices("dex_nest_icon") if _data != null \
 		else PackedByteArray()
 	var palette: PackedColorArray = _object_palette()
-	var out := Image.create(NEST_ICON_SIZE, NEST_ICON_SIZE, false, Image.FORMAT_RGBA8)
-	out.fill(Color(0, 0, 0, 0))
-	if tiles.size() < Gen2TownMapPage.TILE * Gen2TownMapPage.TILE or palette.is_empty():
-		return out
-	var width: int = tiles.size() / Gen2TownMapPage.TILE
-	for y: int in Gen2TownMapPage.TILE:
-		for x: int in Gen2TownMapPage.TILE:
-			var index: int = tiles[y * width + NEST_TILE * Gen2TownMapPage.TILE + x]
-			if index == 0:
-				continue
-			out.set_pixel(x, y, palette[clampi(index, 0, palette.size() - 1)])
-	return out
+	var out: PackedInt32Array = Gen2PicImage.canvas(NEST_ICON_SIZE, NEST_ICON_SIZE)
+	if tiles.size() < Gen2Tiles.TILE_PIXELS or palette.is_empty():
+		return Gen2PicImage.canvas_image(out, NEST_ICON_SIZE, NEST_ICON_SIZE)
+	@warning_ignore("integer_division")
+	Gen2PicImage.blit_tile(
+		out, NEST_ICON_SIZE, NEST_ICON_SIZE, tiles,
+		tiles.size() / Gen2Tiles.TILE_PIXELS, NEST_TILE, 0, 0,
+		Gen2PicImage.lookup(palette), false, false, 0
+	)
+	return Gen2PicImage.canvas_image(out, NEST_ICON_SIZE, NEST_ICON_SIZE)
 
 
 ## `.nestloop`'s `sub 4` on both coordinates, which centres one tile on the

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -142,7 +142,7 @@ func _refresh_page() -> void:
 	var separator: bool = int(_frames / SEPARATOR_FRAMES) % 2 == 0
 	var page: Dictionary = Gen2TrainerCard.page(_save, _world, _page, separator)
 	var indices: PackedByteArray = _page_renderer.draw(page)
-	_background.texture = ImageTexture.create_from_image(
+	Gen2PicImage.show(_background,
 		_image_from(indices, _page_renderer.attributes())
 	)
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
@@ -152,24 +152,13 @@ func _refresh_page() -> void:
 ## why this cannot go through [method Gen2PicImage.from_indices] whole: the card
 ## is eight palettes at once.
 func _image_from(indices: PackedByteArray, attributes: PackedInt32Array) -> Image:
-	var image := Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
-	var tile: int = Gen2TrainerCardPage.TILE
 	var palettes: Array = []
 	for slot: int in RomLayout.CARD_PALETTE_CLASSES.size():
 		palettes.append(_data.card_palette(slot))
-	for row: int in Gen2TrainerCardPage.ROWS:
-		for column: int in Gen2TrainerCardPage.COLUMNS:
-			var slot: int = attributes[row * Gen2TrainerCardPage.COLUMNS + column]
-			var palette: PackedColorArray = palettes[clampi(slot, 0, palettes.size() - 1)]
-			for y: int in tile:
-				for x: int in tile:
-					var at_x: int = column * tile + x
-					var at_y: int = row * tile + y
-					var index: int = indices[at_y * Gen2Screen.WIDTH + at_x]
-					image.set_pixel(
-						at_x, at_y, palette[clampi(index, 0, palette.size() - 1)]
-					)
-	return image
+	return Gen2PicImage.from_attributes(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, attributes,
+		Gen2TrainerCardPage.COLUMNS, palettes
+	)
 
 
 ## `TrainerCard_Page2_3_OAMUpdate`: one 2x2 object group per set badge, skipping
@@ -194,7 +183,7 @@ func _refresh_badges() -> void:
 		var sprite := TextureRect.new()
 		sprite.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		sprite.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		sprite.texture = ImageTexture.create_from_image(
+		Gen2PicImage.show(sprite,
 			_badge_image(int((badge["frames"] as Array)[frame]))
 		)
 		sprite.position = Vector2(
@@ -212,28 +201,24 @@ func _badge_image(frame_tile: int) -> Image:
 	var tiles: PackedByteArray = _data.tile_indices("card_badges")
 	var palette: PackedColorArray = _data.card_badge_palette()
 	var side: int = BADGE_TILE_SIZE * 2
-	var image := Image.create(side, side, false, Image.FORMAT_RGBA8)
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(side, side)
 	if tiles.is_empty():
-		return image
-	var strip_width: int = tiles.size() / BADGE_TILE_SIZE
-	var flip: bool = (frame_tile & BADGE_FLIP) != 0
+		return Gen2PicImage.canvas_image(pixels, side, side)
+	@warning_ignore("integer_division")
+	var strip_tiles: int = tiles.size() / Gen2Tiles.TILE_PIXELS
 	var first: int = frame_tile & ~BADGE_FLIP
+	## Object colour zero is transparent under the hardware's own rules, which
+	## is what lets a badge sit over the card.
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for quadrant: int in 4:
-		var tile: int = first + quadrant
-		var to_x: int = (quadrant % 2) * BADGE_TILE_SIZE
-		var to_y: int = int(quadrant / 2) * BADGE_TILE_SIZE
-		for y: int in BADGE_TILE_SIZE:
-			for x: int in BADGE_TILE_SIZE:
-				var from: int = y * strip_width + tile * BADGE_TILE_SIZE + x
-				if from >= tiles.size():
-					continue
-				var index: int = tiles[from]
-				## Object colour zero is transparent under the hardware's own
-				## rules, which is what lets a badge sit over the card.
-				if index == 0:
-					continue
-				var at_x: int = side - 1 - (to_x + x) if flip else to_x + x
-				image.set_pixel(
-					at_x, to_y + y, palette[clampi(index, 0, palette.size() - 1)]
-				)
+		@warning_ignore("integer_division")
+		var to_y: int = (quadrant / 2) * BADGE_TILE_SIZE
+		Gen2PicImage.blit_tile(
+			pixels, side, side, tiles, strip_tiles, first + quadrant,
+			(quadrant % 2) * BADGE_TILE_SIZE, to_y, table, false, false, 0
+		)
+	var image: Image = Gen2PicImage.canvas_image(pixels, side, side)
+	# `OAM_XFLIP` on the group mirrors the whole 16x16, quadrants included.
+	if (frame_tile & BADGE_FLIP) != 0:
+		image.flip_x()
 	return image

--- a/game/world/unown_puzzle_screen.gd
+++ b/game/world/unown_puzzle_screen.gd
@@ -142,4 +142,4 @@ func _refresh() -> void:
 		_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		add_child(_view)
-	_view.texture = ImageTexture.create_from_image(_page.render(_board, _frame))
+	Gen2PicImage.show(_view, _page.render(_board, _frame))

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -47,9 +47,6 @@ var _tiles_textures: Dictionary = {}
 ## the connection strips in it are the cartridge's own.
 var _buffer_texture: ImageTexture = null
 var _buffer_revision: int = -1
-## Kept beside the texture so an animation frame can repaint the one or two
-## tiles it rewrote instead of recolouring the whole strip.
-var _atlas_image: Image = null
 var _background_color: Color = FALLBACK_BACKGROUND
 var _actor_textures: Dictionary = {}
 var _priority_atlas: ImageTexture = null
@@ -151,46 +148,88 @@ func set_fade(order: int, white_fill: bool = false) -> void:
 ## Repaints the tiles the last animation frame rewrote.
 ##
 ## The sequence touches one or two of a tileset's tiles per frame, so recolouring
-## the whole strip was almost all of the frame's cost. A palette
-## command is the exception: it changes every tile drawn with that row, so it
-## still rebuilds.
+## the whole strip was almost all of the frame's cost. A palette command is the
+## exception and recolours every tile drawn with that row, but it is still a
+## repaint of the strips already cached rather than a rebuild of them: the
+## graphics, the roof and the quads are all unchanged, and only the colours a
+## tile is written through are not.
 func refresh_animation() -> void:
-	if _animation == null or _atlas == null or _atlas_image == null \
-		or _animation.palette_changed():
+	if _animation == null or _atlas == null:
 		_rebuild_atlas()
 		queue_redraw()
 		return
+	var recolour: bool = _animation.palette_changed()
 	var changed: PackedInt32Array = _animation.changed_tiles()
-	if changed.is_empty():
+	if not recolour and changed.is_empty():
 		return
 	var animated: PackedByteArray = _animation.current_indices()
 	for entry: Dictionary in _atlases.values():
-		if not bool(entry["animated"]):
-			continue
-		# The roof stands over `vTiles2 tile $0a` for as long as the map is
-		# loaded, so an animation pass rebuilds the strip under it rather than
-		# replacing it.
-		var indices: PackedByteArray = _world.data.roofed_tile_indices(
-			animated, int(entry["roof"]), int(entry["tile_count"])
-		)
-		var image: Image = entry["image"]
-		var palettes: Array = entry["palettes"]
-		for tile: int in changed:
-			_paint_tile(image, indices, palettes, tile)
-		(entry["texture"] as ImageTexture).update(image)
-		entry["indices"] = indices
+		_repaint_atlas(entry, animated, changed, recolour)
 	# The priority strip is the map being walked on, not whichever cached strip
 	# the loop ended on: a connected map in another group has its own roof.
 	var current: Dictionary = _atlas_for(_world.current_map, _world.current_tileset)
+	if recolour and not current.is_empty():
+		var palettes: Array = current["palettes"]
+		if not palettes.is_empty() and (palettes[0] as PackedColorArray).size() >= 1:
+			_background_color = (palettes[0] as PackedColorArray)[0]
 	_priority_indices = current["indices"] if not current.is_empty() else animated
 	_priority_atlas = null
 	queue_redraw()
 
 
+## One cached strip through this frame's graphics and, when [param recolour], its
+## own palette rows read again. Only the tiles whose colours or whose pixels
+## actually moved are written.
+func _repaint_atlas(
+	entry: Dictionary, animated: PackedByteArray, changed: PackedInt32Array,
+	recolour: bool
+) -> void:
+	var tiles: int = int(entry["tile_count"])
+	var indices: PackedByteArray = entry["indices"]
+	var repaint := PackedByteArray()
+	repaint.resize(tiles)
+	var any: bool = false
+	if bool(entry["animated"]):
+		# The roof stands over `vTiles2 tile $0a` for as long as the map is
+		# loaded, so an animation pass rebuilds the strip under it rather than
+		# replacing it.
+		indices = _world.data.roofed_tile_indices(
+			animated, int(entry["roof"]), tiles
+		)
+		entry["indices"] = indices
+		for tile: int in changed:
+			if tile >= 0 and tile < tiles:
+				repaint[tile] = 1
+				any = true
+	if recolour:
+		var palettes: Array = _tile_palettes_for(entry["map"], entry["tileset"])
+		var tables: Array = _palette_tables(palettes)
+		var was: Array = entry["tables"]
+		entry["palettes"] = palettes
+		entry["tables"] = tables
+		for tile: int in tiles:
+			if tile < was.size() and tables[tile] == was[tile]:
+				continue
+			repaint[tile] = 1
+			any = true
+	if not any:
+		return
+	var words: PackedInt32Array = entry["words"]
+	var background: int = Gen2PicImage.lookup(
+		PackedColorArray([_background_color])
+	)[0]
+	for tile: int in tiles:
+		if repaint[tile] != 0:
+			_paint_tile(words, tiles, indices, entry["tables"], background, tile)
+	entry["words"] = words
+	(entry["texture"] as ImageTexture).update(
+		Gen2PicImage.canvas_image(words, tiles * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT)
+	)
+
+
 func _rebuild_atlas() -> void:
 	_atlases.clear()
 	_atlas = null
-	_atlas_image = null
 	_background_color = FALLBACK_BACKGROUND
 	if _world == null or _world.data == null or _world.current_tileset == null:
 		return
@@ -201,7 +240,6 @@ func _rebuild_atlas() -> void:
 	if not palettes.is_empty() and (palettes[0] as PackedColorArray).size() >= 1:
 		_background_color = (palettes[0] as PackedColorArray)[0]
 	_atlas = entry["texture"]
-	_atlas_image = entry["image"]
 	# Built on demand: only an object standing in grass reads it.
 	_priority_indices = entry["indices"]
 	_priority_atlas = null
@@ -217,7 +255,9 @@ func _rebuild_atlas() -> void:
 func _atlas_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Dictionary:
 	if map == null or tileset == null or _world == null or _world.data == null:
 		return {}
-	var key: String = "%d:%d:%d" % [tileset.number, map.environment, map.group]
+	## Packed rather than formatted: `_sync_map_layers` asks for one of these per
+	## connected map on every frame the camera moves.
+	var key: int = tileset.number | (map.environment << 8) | (map.group << 16)
 	if _atlases.has(key):
 		return _atlases[key]
 	var indices: PackedByteArray = _world.data.world_tileset_indices(tileset.number)
@@ -231,16 +271,28 @@ func _atlas_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Dictionary:
 	var roof: int = _world.data.map_roof(map, tileset)
 	indices = _world.data.roofed_tile_indices(indices, roof, tileset.tile_count)
 	var palettes: Array = _tile_palettes_for(map, tileset)
-	var image := Image.create(
-		tileset.tile_count * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT,
-		false, Image.FORMAT_RGBA8,
+	var tables: Array = _palette_tables(palettes)
+	var background: int = Gen2PicImage.lookup(
+		PackedColorArray([_background_color])
+	)[0]
+	var words: PackedInt32Array = Gen2PicImage.canvas(
+		tileset.tile_count * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT
 	)
 	for tile: int in tileset.tile_count:
-		_paint_tile(image, indices, palettes, tile)
+		_paint_tile(words, tileset.tile_count, indices, tables, background, tile)
 	var entry: Dictionary = {
-		"texture": ImageTexture.create_from_image(image),
-		"image": image,
+		"texture": ImageTexture.create_from_image(Gen2PicImage.canvas_image(
+			words, tileset.tile_count * Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT
+		)),
+		## The strip before its conversion, so an animation frame repaints the
+		## one or two tiles it rewrote rather than recolouring the whole run.
+		"words": words,
 		"palettes": palettes,
+		"tables": tables,
+		## Kept so a palette step reads the rows this strip was coloured through
+		## again rather than rebuilding the cache to find out.
+		"map": map,
+		"tileset": tileset,
 		"indices": indices,
 		"animated": animated,
 		"roof": roof,
@@ -303,18 +355,40 @@ func _tile_palettes_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
 ## One tile of the strip, coloured. Index 0 is a colour here rather than a hole:
 ## the atlas is the background layer, and the cartridge's transparent index
 ## belongs to sprites.
-func _paint_tile(image: Image, indices: PackedByteArray, palettes: Array, tile: int) -> void:
-	var width: int = image.get_width()
-	var palette: PackedColorArray = palettes[tile] if tile < palettes.size() else PackedColorArray()
+func _paint_tile(
+	words: PackedInt32Array, tiles: int, indices: PackedByteArray, tables: Array,
+	background: int, tile: int
+) -> void:
+	var width: int = tiles * Gen2Tiles.TILE_WIDTH
+	var table: PackedInt32Array = tables[tile] if tile < tables.size() \
+		else PackedInt32Array()
+	var colors: int = table.size()
 	var left: int = tile * Gen2Tiles.TILE_WIDTH
 	for y: int in Gen2Tiles.TILE_HEIGHT:
 		var row: int = y * width + left
 		for x: int in Gen2Tiles.TILE_WIDTH:
 			var color_index: int = indices[row + x]
-			image.set_pixel(
-				left + x, y,
-				palette[color_index] if color_index < palette.size() else _background_color
-			)
+			words[row + x] = table[color_index] if color_index < colors else background
+
+
+## One [method Gen2PicImage.lookup] per tile, built once for a repaint rather
+## than once inside it. A tileset's couple of hundred tiles share the eight or
+## nine rows `GetMapPalette` resolved, so each row is converted once. Trimmed to
+## the row's own length, so a colour it does not hold still falls through to the
+## background the way it did before the table existed.
+func _palette_tables(palettes: Array) -> Array:
+	var seen: Dictionary = {}
+	var out: Array = []
+	for entry: Variant in palettes:
+		var palette: PackedColorArray = entry
+		if seen.has(palette):
+			out.append(seen[palette])
+			continue
+		var table: PackedInt32Array = Gen2PicImage.lookup(palette)
+		table.resize(palette.size())
+		seen[palette] = table
+		out.append(table)
+	return out
 
 
 ## `DoBattleTransition`, drawn over whatever the map was already showing.
@@ -795,10 +869,13 @@ func _actor_texture(
 	if sprite == null or _world == null or _world.data == null:
 		return null
 	var palette: int = palette_override if palette_override != 0 else sprite.default_palette
-	var key: String = "%d:%d:%d:%d:%d:%d:%d:%d" % [
-		sprite.sprite_type, sprite.number, palette, facing, frame, big_shape, _time_of_day,
-		hash(color_override),
-	]
+	## Packed rather than formatted: every sprite on screen asks for one of these
+	## on every drawn frame, and the override is empty for all but a visible
+	## encounter. Twelve bits for the sprite number leaves every field room for
+	## more than the cartridge has, and the hash sits above all of them.
+	var key: int = sprite.sprite_type | (sprite.number << 3) | (palette << 15) \
+		| (facing << 19) | (frame << 22) | (big_shape << 25) | (_time_of_day << 28) \
+		| (hash(color_override) << 30)
 	if _actor_textures.has(key):
 		return _actor_textures[key]
 	var indices: PackedByteArray = _world.data.overworld_icon_indices(sprite.icon_number) \
@@ -989,17 +1066,23 @@ func _transition_wrote(at: Vector2) -> bool:
 ## The same strip as the atlas with the cartridge's transparent index left out,
 ## for the tiles that are drawn over a sprite rather than under it.
 func _build_priority_atlas() -> void:
-	if _atlas_image == null:
+	if _atlas == null:
 		return
-	var image: Image = _atlas_image.duplicate()
-	var width: int = image.get_width()
+	var entry: Dictionary = _atlas_for(_world.current_map, _world.current_tileset)
+	if entry.is_empty():
+		return
+	var width: int = int(entry["tile_count"]) * Gen2Tiles.TILE_WIDTH
 	if _priority_indices.size() < width * Gen2Tiles.TILE_HEIGHT:
 		return
+	var words: PackedInt32Array = (entry["words"] as PackedInt32Array).duplicate()
 	for y: int in Gen2Tiles.TILE_HEIGHT:
+		var row: int = y * width
 		for x: int in width:
-			if int(_priority_indices[y * width + x]) == 0:
-				image.set_pixel(x, y, Color(0, 0, 0, 0))
-	_priority_atlas = ImageTexture.create_from_image(image)
+			if int(_priority_indices[row + x]) == 0:
+				words[row + x] = 0
+	_priority_atlas = ImageTexture.create_from_image(
+		Gen2PicImage.canvas_image(words, width, Gen2Tiles.TILE_HEIGHT)
+	)
 
 
 ## `FacingFishDown` and its three siblings: the standing player plus one tile of

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -5926,7 +5926,7 @@ func _show_money_window(event: Dictionary) -> void:
 	var image: Image = drawn["image"]
 	_money_window = TextureRect.new()
 	_money_window.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_money_window.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_money_window, image)
 	_money_window.size = image.get_size()
 	_money_window.position = Vector2(
 		(drawn["at"] as Vector2i) * Gen2Font.TILE
@@ -6064,7 +6064,7 @@ func _show_story_picture(species: int) -> void:
 	_hide_story_picture()
 	_story_picture = TextureRect.new()
 	_story_picture.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_story_picture.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_story_picture, image)
 	_story_picture.size = image.get_size()
 	_story_picture.position = Vector2(
 		Gen2PokepicPage.menu_box().border_position() * Gen2Font.TILE
@@ -6108,7 +6108,7 @@ func _raise_map_name_sign() -> void:
 		return
 	_map_name_sign = TextureRect.new()
 	_map_name_sign.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_map_name_sign.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_map_name_sign, image)
 	_map_name_sign.size = image.get_size()
 	_map_name_sign.position = Vector2(0, Gen2MapNameSignPage.TOP)
 	_map_name_sign.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -6182,7 +6182,7 @@ func _open_unown_wall(word: String) -> bool:
 	var box: Gen2MenuBox = Gen2UnownWall.menu_box(word)
 	_unown_wall_box = TextureRect.new()
 	_unown_wall_box.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	_unown_wall_box.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_unown_wall_box, image)
 	_unown_wall_box.size = image.get_size()
 	_unown_wall_box.position = Vector2(box.border_position() * Gen2Font.TILE)
 	_unown_wall_box.mouse_filter = Control.MOUSE_FILTER_IGNORE

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -623,7 +623,7 @@ func _render_mart() -> void:
 				menu, Rect2i(Vector2i.ZERO, menu.get_size()),
 				box.border_position() * Gen2Font.TILE
 			)
-	_mart_view.texture = ImageTexture.create_from_image(image)
+	Gen2PicImage.show(_mart_view, image)
 
 
 ## `UpdateItemDescription`, which prints nothing for the CANCEL row.
@@ -1329,7 +1329,7 @@ func _render_service_page(values: Array) -> void:
 		_title, _summary, labels, _cursor, _status, _service_box()
 	)
 	if image != null:
-		_service_view.texture = ImageTexture.create_from_image(image)
+		Gen2PicImage.show(_service_view, image)
 	_service_drawn = image != null
 	_apply_layer_visibility()
 

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -177,29 +177,23 @@ static func image_for(
 	facing: int = FACING_DOWN,
 	frame: int = 0,
 ) -> Image:
-	var image := Image.create(16, 16, false, Image.FORMAT_RGBA8)
-	image.fill(Color(0, 0, 0, 0))
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(16, 16)
 	if sprite == null or sprite.tiles < 4:
-		return image
+		return Gen2PicImage.canvas_image(pixels, 16, 16)
 	var width: int = sprite.tiles * Gen2Tiles.TILE_WIDTH
 	var source_tile: int = sprite.frame_tile_offset(facing, frame)
 	if source_tile < 0 or source_tile + 4 > sprite.tiles or indices.size() < width * 8:
-		return image
+		return Gen2PicImage.canvas_image(pixels, 16, 16)
 
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette, true)
 	for tile: int in 4:
-		var source_x: int = (source_tile + tile) * Gen2Tiles.TILE_WIDTH
-		var destination_x: int = (tile & 1) * Gen2Tiles.TILE_WIDTH
-		var destination_y: int = (tile >> 1) * Gen2Tiles.TILE_HEIGHT
-		for y: int in Gen2Tiles.TILE_HEIGHT:
-			for x: int in Gen2Tiles.TILE_WIDTH:
-				var color_index: int = int(indices[y * width + source_x + x])
-				var color := Color.MAGENTA
-				if color_index < palette.size():
-					color = palette[color_index]
-				if color_index == 0:
-					color.a = 0.0
-				image.set_pixel(destination_x + x, destination_y + y, color)
+		Gen2PicImage.blit_tile(
+			pixels, 16, 16, indices, sprite.tiles, source_tile + tile,
+			(tile & 1) * Gen2Tiles.TILE_WIDTH, (tile >> 1) * Gen2Tiles.TILE_HEIGHT,
+			table
+		)
 
+	var image: Image = Gen2PicImage.canvas_image(pixels, 16, 16)
 	if frame_is_mirrored(facing, frame):
 		image.flip_x()
 	return image
@@ -215,37 +209,19 @@ static func big_image_for(
 	palette: PackedColorArray,
 	shape: int,
 ) -> Image:
-	var image := Image.create(32, 32, false, Image.FORMAT_RGBA8)
-	image.fill(Color(0, 0, 0, 0))
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(32, 32)
 	if sprite == null or shape == BIG_SHAPE_NONE:
-		return image
+		return Gen2PicImage.canvas_image(pixels, 32, 32)
 	var tile_width: int = sprite.tiles
 	if tile_width <= 0 or indices.size() < tile_width * Gen2Tiles.TILE_PIXELS:
-		return image
-	var placements: Array = _big_placements(shape)
-	for placement: Array in placements:
-		var x: int = int(placement[0])
-		var y: int = int(placement[1])
-		var flip_x: bool = bool(placement[2])
-		var tile: int = int(placement[3])
-		if tile < 0 or tile >= sprite.tiles:
-			continue
-		for row: int in Gen2Tiles.TILE_HEIGHT:
-			for column: int in Gen2Tiles.TILE_WIDTH:
-				var source_x: int = column if not flip_x else 7 - column
-				var color_index: int = int(
-					indices[
-						row * tile_width * Gen2Tiles.TILE_WIDTH
-						+ tile * Gen2Tiles.TILE_WIDTH + source_x
-					]
-				)
-				var color := Color.MAGENTA
-				if color_index < palette.size():
-					color = palette[color_index]
-				if color_index == 0:
-					color.a = 0.0
-				image.set_pixel(x + column, y + row, color)
-	return image
+		return Gen2PicImage.canvas_image(pixels, 32, 32)
+	var table: PackedInt32Array = Gen2PicImage.lookup(palette, true)
+	for placement: Array in _big_placements(shape):
+		Gen2PicImage.blit_tile(
+			pixels, 32, 32, indices, tile_width, int(placement[3]),
+			int(placement[0]), int(placement[1]), table, bool(placement[2])
+		)
+	return Gen2PicImage.canvas_image(pixels, 32, 32)
 
 
 static func _big_placements(shape: int) -> Array:

--- a/tools/checks/map_name_sign.gd
+++ b/tools/checks/map_name_sign.gd
@@ -139,9 +139,11 @@ func _check_palette(landmark: int, blank: Color) -> void:
 	if not _r.check(wanted.size() >= 4, "the cache holds no PAL_BG_TEXT palette."):
 		return
 	## The rendered sign is an 8-bit image, so the comparison is made there
-	## rather than on the palette's own 5-bit-derived floats.
+	## rather than on the palette's own 5-bit-derived floats, and through the
+	## drawing's own conversion rather than `Color.to_rgba32`, which rounds where
+	## every blit in the game truncates.
 	_r.check(
-		blank.to_rgba32() == wanted[0].to_rgba32(),
+		blank == Gen2PicImage.quantized(wanted)[0],
 		"landmark %d's sign interior is %s, not PAL_BG_TEXT's own %s." % [
 			landmark, blank, wanted[0]
 		]

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -415,13 +415,7 @@ func _check_pack_palettes(
 		return
 	var palettes: Array = []
 	for slot: int in RomLayout.PACK_PALETTES:
-		var colours := PackedColorArray()
-		for colour: Color in data.pack_palette(slot):
-			colours.append(Color8(
-				int(roundf(colour.r * 255.0)), int(roundf(colour.g * 255.0)),
-				int(roundf(colour.b * 255.0)), int(roundf(colour.a * 255.0))
-			))
-		palettes.append(colours)
+		palettes.append(Gen2PicImage.quantized(data.pack_palette(slot)))
 	for row: int in Gen2PackPage.ROWS:
 		for column: int in columns:
 			var allowed: PackedColorArray = palettes[slots[row * columns + column]]

--- a/tools/checks/screen_palettes.gd
+++ b/tools/checks/screen_palettes.gd
@@ -121,7 +121,7 @@ func _check_page(
 	## The identity `LoadStatsScreenPals` writes: colour 0 of the HP palette, and
 	## so the background of every cell the attrmap left on slot 0.
 	if not _r.check(
-		image.get_pixel(0, (Gen2StatsScreenPage.MON_ROWS + 1) * TILE) == _quantised(
+		image.get_pixel(0, (Gen2StatsScreenPage.MON_ROWS + 1) * TILE) == Gen2PicImage.quantized(
 			PackedColorArray([tint]))[0],
 		"species %d page %d does not tint the lower half." % [species, number]
 	):
@@ -137,11 +137,11 @@ func _palettes(
 	var lit: int = Gen2BattleHud.bar_pixels(hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE)
 	var out: Array = [
 		_tinted(_r.data.bar_palette(GameData.hp_bar_palette_name(lit)), tint),
-		_quantised(_r.data.palette(species) if species > 0 else _r.data.egg_palette()),
+		Gen2PicImage.quantized(_r.data.palette(species) if species > 0 else _r.data.egg_palette()),
 		_tinted(_r.data.bar_palette(GameData.EXP_BAR_PALETTE), tint),
 	]
 	for index: int in pages:
-		out.append(_quantised(
+		out.append(Gen2PicImage.quantized(
 			_r.data.stats_page_palette(Gen2StatsScreenPage.PINK_PAGE + index)
 		))
 	return out
@@ -151,26 +151,13 @@ func _tinted(palette: PackedColorArray, colour: Color) -> PackedColorArray:
 	var out: PackedColorArray = palette.duplicate()
 	if not out.is_empty():
 		out[0] = colour
-	return _quantised(out)
+	return Gen2PicImage.quantized(out)
 
 
 ## The source's own boxes, flattened the way `WipeAttrmap` plus `FillBoxCGB`
 ## leaves them.
 func _source_slots() -> PackedInt32Array:
 	return Gen2PicImage.attribute_boxes(SOURCE_BOXES, COLUMNS, ROWS)
-
-
-## A 15-bit colour is stored as a float and read back through an eight-bit
-## image, so the comparison is made where the picture is: `Color8`'s own
-## rounding, which is what [method Gen2PicImage.from_attributes] wrote.
-func _quantised(palette: PackedColorArray) -> PackedColorArray:
-	var out := PackedColorArray()
-	for colour: Color in palette:
-		out.append(Color8(
-			int(roundf(colour.r * 255.0)), int(roundf(colour.g * 255.0)),
-			int(roundf(colour.b * 255.0)), int(roundf(colour.a * 255.0))
-		))
-	return out
 
 
 ## `EggStatsInit` jumps past `StatsScreen_LoadPage`, so an egg reaches
@@ -189,7 +176,7 @@ func _check_egg(page: Gen2StatsScreenPage) -> void:
 		"an egg's stats screen is tinted, and no cartridge tints one."
 	)
 	var slots: PackedInt32Array = _source_slots()
-	var egg: PackedColorArray = _quantised(_r.data.egg_palette())
+	var egg: PackedColorArray = Gen2PicImage.quantized(_r.data.egg_palette())
 	for row: int in Gen2StatsScreenPage.MON_ROWS:
 		for column: int in COLUMNS:
 			if slots[row * COLUMNS + column] != Gen2StatsScreenPage.MON_SLOT:
@@ -210,7 +197,7 @@ func _check_move_screen() -> void:
 	var page: Gen2MoveScreenPage = Gen2MoveScreenPage.from_data(_r.data)
 	if not _r.check(page != null, "the move screen page will not build."):
 		return
-	var goldenrod: PackedColorArray = _quantised(_r.data.move_screen_palette())
+	var goldenrod: PackedColorArray = Gen2PicImage.quantized(_r.data.move_screen_palette())
 	_r.check(
 		goldenrod.size() == RomLayout.PREDEF_PALETTE_COLORS,
 		"the move screen's palette is %d colours, not %d." % [
@@ -236,7 +223,7 @@ func _check_move_screen() -> void:
 	var slots: PackedInt32Array = Gen2PicImage.attribute_boxes(
 		SOURCE_MOVE_BOXES, COLUMNS, ROWS
 	)
-	var hp: PackedColorArray = _quantised(_r.data.bar_palette(
+	var hp: PackedColorArray = Gen2PicImage.quantized(_r.data.bar_palette(
 		GameData.hp_bar_palette_name(Gen2BattleHud.bar_pixels(
 			1, 100, Gen2BattleHud.HP_BAR_TILES * TILE
 		))

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -93,9 +93,10 @@ func _initialize() -> void:
 		quit(1)
 		return
 
-	var options: Gen2Options = Gen2OptionsStore.current()
-	options.battle_scene = not _scene_off
-	Gen2OptionsStore.save(options)
+	## The shared object rather than the file: `CheckBattleScene` reads what
+	## `current()` answers, and a capture has no business rewriting the option
+	## the owner of this machine chose.
+	Gen2OptionsStore.current().battle_scene = not _scene_off
 
 	root.set_content_scale_size(WINDOW_SIZE)
 	root.size = WINDOW_SIZE

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -79,6 +79,12 @@ func _initialize() -> void:
 		quit(1)
 		return
 	root.add_child(_screen)
+	## The party menu steps its icons off a real delta, so a run that took a
+	## millisecond longer photographed the next frame of the animation and the
+	## same shot came out two ways. The frames belong to this tool; it spends
+	## none, and the picture is the one the screen opened on.
+	if _screen is Gen2PartyScreen:
+		_screen.set_process(false)
 	# The party and box views are window-resolution panels, so they are given the
 	# whole window the way a scene root would be; the start menu is a hardware
 	# screen inside one and takes its own layer once both are in the tree.

--- a/tools/profile.gd
+++ b/tools/profile.gd
@@ -30,6 +30,8 @@ const BATTLE_FRAMES: int = 1200
 ## The hardware's own frame. A subject over this on this machine cannot hold
 ## sixty on any machine.
 const HARDWARE_FRAME_MS: float = 1000.0 / 60.0
+## Fixed, so two runs of a subject walk the same map and roll the same wilds.
+const PROFILE_SEED: int = 20260823
 
 ## Every subject, in the order `all` runs them. Each names the method that opens
 ## it; the method answers a node to add and a [Callable] that spends one hardware
@@ -55,6 +57,9 @@ func _initialize() -> void:
 	# under a 60 Hz sync measures the monitor.
 	Engine.max_fps = 0
 	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
+	# Every subject runs on the defaults rather than on whatever the owner of
+	# this machine last chose, so two runs on two machines are the same run.
+	Gen2OptionsStore.use_test_path()
 	_run.call_deferred()
 
 
@@ -200,10 +205,10 @@ func _open_title() -> Dictionary:
 
 func _open_overworld(fill: bool = true) -> Dictionary:
 	## SCREEN FILL is on by default, so the wide buffer is the ordinary case and
-	## the 160x144 one is what a player who turned it off gets.
-	var options: Gen2Options = Gen2OptionsStore.current()
-	options.screen_fill = fill
-	Gen2OptionsStore.save(options)
+	## the 160x144 one is what a player who turned it off gets. Set on the shared
+	## object rather than saved: the store is pointed at its own file below, and
+	## a measurement has no business rewriting what the player chose.
+	Gen2OptionsStore.current().screen_fill = fill
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
 	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
@@ -300,7 +305,3 @@ func _open_world_menu(button: int) -> Dictionary:
 	for _frame: int in 32:
 		screen.advance_frame()
 	return opened
-
-
-## Fixed, so two runs of a subject walk the same map and roll the same wilds.
-const PROFILE_SEED: int = 20260823

--- a/tools/profile.gd
+++ b/tools/profile.gd
@@ -1,0 +1,306 @@
+extends SceneTree
+
+## What a drawn frame costs, per screen, in milliseconds.
+##
+##   Godot --path . -s res://tools/profile.gd -- [subject ...] [game] [frames]
+##   Godot --path . -s res://tools/profile.gd -- all crystal 900
+##
+## Not a check and not a preview: `tools/checks/` runs headless under
+## `validate.gd` and answers right or wrong, and a `preview_*.gd` photographs one
+## frame. Neither can say what sixty of them cost, which is the only question
+## that decides whether a weaker machine holds its frame rate.
+##
+## A real window, vsync off and no frame cap, so the number is the whole frame:
+## the screen's own hardware pass, whatever it rebuilds, and the draw. Every
+## subject is driven by counted `advance_frame()` calls with the node's own
+## `_process` off, so one drawn frame is one hardware frame whatever the host
+## does, and two runs compare.
+##
+## The number is this machine's. What carries across machines is the ratio
+## between two runs of the same subject, which is what an optimisation is
+## measured by.
+
+const WINDOW_SIZE := Vector2i(1152, 648)
+## Frames spent before the first one is timed: a screen builds its textures on
+## the frame it is opened, and that is a load cost rather than a frame cost.
+const WARMUP_FRAMES: int = 60
+const DEFAULT_FRAMES: int = 600
+## A run that fights takes several battles' worth of frames to be worth reading.
+const BATTLE_FRAMES: int = 1200
+## The hardware's own frame. A subject over this on this machine cannot hold
+## sixty on any machine.
+const HARDWARE_FRAME_MS: float = 1000.0 / 60.0
+
+## Every subject, in the order `all` runs them. Each names the method that opens
+## it; the method answers a node to add and a [Callable] that spends one hardware
+## frame on it.
+const SUBJECTS: Array[StringName] = [
+	&"opening",
+	&"title",
+	&"overworld",
+	&"overworld_framed",
+	&"battle",
+	&"start_menu",
+	&"pack",
+]
+
+var _data: GameData = null
+var _rows: Array[Dictionary] = []
+
+
+func _initialize() -> void:
+	root.set_content_scale_size(WINDOW_SIZE)
+	root.size = WINDOW_SIZE
+	# The cap and the sync are what the number would otherwise be: a subject
+	# under a 60 Hz sync measures the monitor.
+	Engine.max_fps = 0
+	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
+	_run.call_deferred()
+
+
+func _run() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	var game: StringName = &"crystal"
+	var frames: int = DEFAULT_FRAMES
+	var wanted: Array[StringName] = []
+	for argument: String in args:
+		if argument.is_valid_int():
+			frames = maxi(1, int(argument))
+		elif argument == "all":
+			wanted.append_array(SUBJECTS)
+		elif SUBJECTS.has(StringName(argument)):
+			wanted.append(StringName(argument))
+		else:
+			game = StringName(argument)
+	if wanted.is_empty():
+		wanted = SUBJECTS.duplicate()
+
+	_data = GameData.open(game)
+	if _data == null:
+		printerr("No cache for %s. Import roms/%s.gbc first." % [game, game])
+		quit(1)
+		return
+
+	for subject: StringName in wanted:
+		await _measure(subject, frames)
+	_report(game)
+	quit(0)
+
+
+## One subject: open it, spend [constant WARMUP_FRAMES] untimed, then time each
+## of [param frames] drawn frames end to end.
+func _measure(subject: StringName, frames: int) -> void:
+	var opened: Dictionary = await call(&"_open_%s" % subject)
+	if opened.is_empty():
+		_rows.append({"subject": subject, "skipped": true})
+		return
+	var node: Node = opened["node"]
+	var step: Callable = opened["step"]
+	var count: int = int(opened.get("frames", frames))
+
+	# Re-asserted per subject: opening one goes through the game's own runtime,
+	# and a cap or a sync put back there would make every row the monitor's.
+	Engine.max_fps = 0
+	DisplayServer.window_set_vsync_mode(DisplayServer.VSYNC_DISABLED)
+	var samples := PackedFloat64Array()
+	for index: int in WARMUP_FRAMES + count:
+		var started: int = Time.get_ticks_usec()
+		step.call()
+		await process_frame
+		if index >= WARMUP_FRAMES:
+			samples.append(float(Time.get_ticks_usec() - started) / 1000.0)
+	_rows.append(_summary(subject, samples))
+
+	root.remove_child(node)
+	node.queue_free()
+	# The next subject starts from an empty tree rather than from whatever the
+	# last one left in flight.
+	await process_frame
+
+
+func _summary(subject: StringName, samples: PackedFloat64Array) -> Dictionary:
+	var sorted := PackedFloat64Array(samples)
+	sorted.sort()
+	var total: float = 0.0
+	var over: int = 0
+	for sample: float in samples:
+		total += sample
+		if sample > HARDWARE_FRAME_MS:
+			over += 1
+	var count: int = samples.size()
+	return {
+		"subject": subject,
+		"frames": count,
+		"mean": total / float(count),
+		"median": sorted[count / 2],
+		"p95": sorted[mini(int(float(count) * 0.95), count - 1)],
+		"max": sorted[count - 1],
+		"over": over,
+	}
+
+
+func _report(game: StringName) -> void:
+	print("%s, %s, vsync %d, cap %d" % [
+		game, OS.get_model_name(),
+		DisplayServer.window_get_vsync_mode(), Engine.max_fps,
+	])
+	print("%-20s %7s %8s %8s %8s %8s %7s" % [
+		"subject", "frames", "mean", "median", "p95", "max", "over"
+	])
+	for row: Dictionary in _rows:
+		if bool(row.get("skipped", false)):
+			print("%-20s %7s" % [row["subject"], "skipped"])
+			continue
+		print("%-20s %7d %8.3f %8.3f %8.3f %8.3f %7d" % [
+			row["subject"], row["frames"], row["mean"], row["median"],
+			row["p95"], row["max"], row["over"],
+		])
+
+
+## `SplashScreen` from its first frame: the copyright, the GameFreak logo and
+## whichever intro movie the cache carries. Restarted when it runs out, since the
+## movie is shorter than a long run and a finished screen costs nothing.
+func _open_opening() -> Dictionary:
+	var screen := Gen2SplashScreen.new()
+	if not screen.open(_data):
+		screen.free()
+		return {}
+	root.add_child(screen)
+	screen.set_process(false)
+	await process_frame
+	return {
+		"node": screen,
+		"step": func() -> void:
+			if screen.visible_image() == &"":
+				screen.open(_data)
+			screen.advance_frames(1),
+	}
+
+
+## The same screen held on `TitleScreenMain`, which is the one phase of the
+## opening a player can sit in.
+func _open_title() -> Dictionary:
+	var screen := Gen2SplashScreen.new()
+	if not screen.open(_data):
+		screen.free()
+		return {}
+	root.add_child(screen)
+	screen.set_process(false)
+	await process_frame
+	var guard: int = 0
+	while screen.visible_image() != &"title" and guard < 20000:
+		screen.advance_frames(1)
+		guard += 1
+	if screen.visible_image() != &"title":
+		root.remove_child(screen)
+		screen.free()
+		return {}
+	return {"node": screen, "step": func() -> void: screen.advance_frames(1)}
+
+
+func _open_overworld(fill: bool = true) -> Dictionary:
+	## SCREEN FILL is on by default, so the wide buffer is the ordinary case and
+	## the 160x144 one is what a player who turned it off gets.
+	var options: Gen2Options = Gen2OptionsStore.current()
+	options.screen_fill = fill
+	Gen2OptionsStore.save(options)
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	var screen: Gen2WorldScreen = packed.instantiate() as Gen2WorldScreen
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	if save == null:
+		screen.free()
+		return {}
+	save.run_seed = PROFILE_SEED
+	save.world = Gen2WorldSpawn.new_game_snapshot(_data)
+	screen.set_data(_data)
+	screen.set_save(save)
+	screen.process_mode = Node.PROCESS_MODE_DISABLED
+	root.add_child(screen)
+	await process_frame
+	if screen._world == null:
+		root.remove_child(screen)
+		screen.free()
+		return {}
+	screen.set_process(false)
+	## Walked rather than stood still: a standing player redraws nothing, and
+	## what a map costs is the camera moving over it. The turn every two seconds
+	## keeps the walk on the spawn map.
+	var log: Array = []
+	for frame: int in WARMUP_FRAMES + BATTLE_FRAMES:
+		@warning_ignore("integer_division")
+		var leg: int = (frame / 120) % 4
+		log.append({
+			"frame": frame, "kind": "hold",
+			"button": [Gen2Button.DOWN, Gen2Button.RIGHT, Gen2Button.UP, Gen2Button.LEFT][leg],
+		})
+	screen.replay_input(log)
+	return {"node": screen, "step": func() -> void: screen.advance_frame()}
+
+
+func _open_overworld_framed() -> Dictionary:
+	return await _open_overworld(false)
+
+
+## `DoBattle` from the menu on: the turn is retaken whenever the fight settles,
+## so the run measures animations, the HP bars and the boxes rather than a menu
+## sitting still.
+func _open_battle() -> Dictionary:
+	var packed: PackedScene = load("res://game/battle/battle_screen.tscn")
+	var screen: Gen2BattleScreen = packed.instantiate() as Gen2BattleScreen
+	screen.set_data(_data)
+	root.add_child(screen)
+	screen.set_process(false)
+	await process_frame
+	screen.show_matchup(16, 155, 20, 20)
+	return {
+		"node": screen,
+		"frames": BATTLE_FRAMES,
+		"step": func() -> void:
+			screen.set_process(false)
+			if screen._audio_player != null:
+				screen._audio_player.stop_all()
+			if screen.frames_running():
+				screen.advance_frame()
+				return
+			if screen.entrance_running() \
+				or bool(screen.battle_snapshot()["awaits_press"]):
+				screen.finish()
+				screen.advance()
+				return
+			screen.take_turn_with(0, 0),
+	}
+
+
+## `StartMenu` over the map, which is the menu a player opens most.
+func _open_start_menu() -> Dictionary:
+	return await _open_world_menu(Gen2Button.START)
+
+
+## The pack, which draws a list, an item's own picture and the map behind it.
+func _open_pack() -> Dictionary:
+	var opened: Dictionary = await _open_world_menu(Gen2Button.START)
+	if opened.is_empty():
+		return {}
+	var screen: Gen2WorldScreen = opened["node"]
+	## Down to PACK and A, on the pass the menu reads a press on.
+	for button: int in [Gen2Button.DOWN, Gen2Button.A]:
+		screen.press_button(button)
+		for _frame: int in 16:
+			screen.advance_frame()
+	return opened
+
+
+func _open_world_menu(button: int) -> Dictionary:
+	var opened: Dictionary = await _open_overworld()
+	if opened.is_empty():
+		return {}
+	var screen: Gen2WorldScreen = opened["node"]
+	screen.replay_input([])
+	screen.press_button(button)
+	for _frame: int in 32:
+		screen.advance_frame()
+	return opened
+
+
+## Fixed, so two runs of a subject walk the same map and roll the same wilds.
+const PROFILE_SEED: int = 20260823

--- a/tools/profile.gd.uid
+++ b/tools/profile.gd.uid
@@ -1,0 +1,1 @@
+uid://ce2sevtjdhyns


### PR DESCRIPTION
Nothing in the tree could say what a frame cost. `tools/checks/` answers
right or wrong, and a `preview_*.gd` draws one frame. So this starts with
`tools/profile.gd`: a real window with the frame cap and the vertical
sync off, each screen driven by counted hardware frames with its own
`_process` switched off, reporting mean, median, p95 and the worst frame
in milliseconds.

Three things had almost all of it.

**Pages were built one pixel at a time.** `Image.set_pixel` is a binding
call and a `Color` for a table lookup. The intro movie made 23,040 of
them a frame. The title screen made 46,080, over a background it rebuilt
out of its own tiles sixty times a second. `Gen2PicImage` already had the
right shape for a battle pic; eleven pages go through it now. A canvas is
one packed RGBA word per pixel, a palette becomes one lookup table, a
tile out of a sheet is one `blit_tile`, and the conversion happens once
at the end. The title's still half is built once, and its scanlines are
copied as runs, because the background map is wider than the screen and a
line is one span of it or two. `Gen2PicImage.show` is now the single way
a screen hands a redrawn picture to the node that shows it, and it writes
into the texture already on the GPU instead of allocating a new one every
frame.

**The overworld rebuilt its whole tile strip for a colour.** Water and
caves step their own colour every thirty-odd frames. Each step threw the
strip cache away and re-derived every cached map's tiles, roof and
texture. It repaints the strips already there now, and only the tiles
whose colours actually moved.

**The APU spent two thirds of its frame on a channel nobody can hear.**
An initialised noise channel sits at its fastest rate, sixteen shift-
register steps per sample, whenever nothing is playing. Each channel's
walk through its own period is counted rather than looped, and the duty
counter and the wave position advance by that count in one step. The
sub-sample average from the reference implementation is left out: it is
integer division on `uint32_t` there, so every term of it is zero.

| Subject | Mean before | Mean after | Worst before | Worst after |
|---|---|---|---|---|
| opening, Crystal | 7.44 ms | 2.40 ms | 12.9 ms | 8.2 ms |
| opening, Gold | 7.37 ms | 2.40 ms | 13.1 ms | 9.6 ms |
| title, Crystal | 5.57 ms | 2.19 ms | 11.2 ms | 7.5 ms |
| title, Gold | 8.66 ms | 1.28 ms | 14.6 ms | 5.8 ms |
| battle | 1.42 ms | 1.23 ms | 27.8 ms | 15.6 ms |
| overworld | 1.14 ms | 1.12 ms | 6.5 ms | 5.9 ms |
| the APU, per audio frame | 1.66 ms | 0.87 ms | | |

The audio number is per hardware frame either way, so it does not get
cheaper at a higher frame rate. It was a tenth of a 60 Hz budget on the
machine that measured it, and more than that on a phone.

## What was checked

Every frame of the Crystal movie, both Gold and Silver movies, all three
title screens, twenty tile-animation frames on two cartridges, and 66 of
the 69 screens in the preview sweep are byte for byte what they were.
So are the WAV files and register traces of all 2,152 music, sound-effect
and cry records on the three cartridges.

The other three screens are the pack. Its green moves one eight-bit unit,
from (58, 156, 58) to (57, 156, 57), because the lookup table truncates
where it used to round. That is what `Image.set_pixel` does and what a
five-bit colour's own reference expansion does, so a colour is now the
same byte whichever path drew it. Three checks compared a drawn pixel
against a rounded palette and read one unit high; all three go through
the drawing's own conversion now.

3,600 tests over 161 scripts green twice in a row, all 67 check topics
green on three freshly imported cartridges, 33 replay routes with no
failures, and the story walk clean on all three profiles.

Two tool defects met on the way and fixed here: the party preview
photographed a different frame of the icons run to run, and two preview
tools wrote the option they changed back to the player's own options
file.