### PR TITLE
Stop the camera jolting two pixels at each end of a step

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -139,6 +139,17 @@ and `--mods` on the command line puts them back for a run that is about a mod:
 godot --headless --path . --quit-after 30 --mods
 ```
 
+`--clock=HH:MM` pins the world clock for the run, over the export defaults and
+over a save's own, and holds it there: every world opened believes it is that
+time, so a renderer can be photographed at a chosen hour through the production
+path. `--clock=HH:MM:D` names the day of the week with it. A renderer reads world
+state and must not write it, which is why this is a switch rather than a call.
+
+```bash
+godot --path . -s res://tools/preview_world.gd --clock=06:00 -- crystal 24 3 \
+  /tmp/dawn.png live effects 20 8
+```
+
 Mods load the same way in an exported build as in the editor: the entry script
 is plain GDScript read at runtime, even though the game's own scripts ship as
 binary tokens. An installed mod loads immediately, without a restart, and so
@@ -1224,6 +1235,14 @@ What the host does with a valid population:
 A world renderer that wants to draw the sparkle itself takes the optional
 `set_encounters(encounters: Gen2WorldEncounters)`; the population itself already
 arrives through `set_actors`.
+
+### The earthquake
+
+`Gen2WorldEffects.offset()` is `StepFunction_ScreenShake`, in hardware pixels and
+positive downward. It reaches hSCY on the cartridge and hSCY alone, so it is the
+**background's** offset and moves no sprite: the built-in view adds it to the
+camera the map quads are placed at and to nothing else. A renderer taking
+`set_effects` applies it the same way, or ignores it and does not shake.
 
 ## Hidden items a mod can see, and ask for
 

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -45,8 +45,9 @@ const RENDERER_SURFACE_METHOD: String = "uses_hardware_viewport"
 const RENDERER_RESIZE_METHOD: String = "set_native_size"
 ## Optional, world renderers only. Called with the screen's [Gen2WorldEffects]
 ## when the renderer is built. It holds the sprites the engine draws over the
-## map rather than as objects, all of them presentation with no world state
-## behind them, so a renderer that draws its own effects can ignore it.
+## map rather than as objects, and `offset()`, the earthquake's own scroll, which
+## is the background's and moves no sprite. All of it is presentation with no
+## world state behind it, so a renderer that draws its own effects can ignore it.
 const RENDERER_EFFECTS_METHOD: String = "set_effects"
 ## Optional, world renderers only. Called with the screen's [Gen2WorldActors]
 ## when the renderer is built. It holds the sprites registered mods put in the

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -359,10 +359,6 @@ var _player_queued_steps: Array = []
 var _player_scripted_steps: bool = false
 ## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
 var _player_step_frame: int = 0
-## How far the player has moved that hSCX/hSCY have not been given yet: one
-## pass's step vector, since `ScrollScreen` runs after `NextOverworldFrame`.
-## See visible_origin_cells().
-var _camera_lag_cells: Vector2 = Vector2.ZERO
 ## Frames left of the counted wait a script is standing in, -1 while it is not
 ## standing in one or has not started counting.
 var _script_wait_frames: int = -1
@@ -714,21 +710,32 @@ func player_position_cells() -> Vector2:
 func visible_origin_cells() -> Vector2:
 	if current_map == null:
 		return Vector2.ZERO
-	return player_position_cells() - _camera_lag_cells - Vector2(PLAYER_VIEW_CELL)
+	return player_position_cells() - Vector2(PLAYER_VIEW_CELL)
+
+
+## Half of whatever surround a view wider than the hardware's added, in whole
+## pixels. The camera and the player's own pixel are both measured from this, so
+## a surround with an odd side cannot round the two apart.
+func view_surround_offset() -> Vector2i:
+	return Vector2i(
+		floori((view_pixels.x - VIEW_PIXELS.x) * 0.5),
+		floori((view_pixels.y - VIEW_PIXELS.y) * 0.5),
+	)
 
 
 ## The drawn surface's top-left in world pixels, which is
-## [method visible_origin_cells] for a hardware-sized view.
+## [method visible_origin_cells] for a hardware-sized view. Whole pixels: the map
+## quads and every sprite standing on them are placed from this one number.
 func view_origin_pixels() -> Vector2:
 	return visible_origin_cells() * float(CELL_PIXELS) \
-		- Vector2(view_pixels - VIEW_PIXELS) * 0.5
+		- Vector2(view_surround_offset())
 
 
-## The player's screen pixel, which is PLAYER_VIEW_CELL plus whatever hSCX/hSCY
-## have not caught up with: `ScrollScreen` sits after `NextOverworldFrame` in
-## `HandleMapBackground`, so the scroll a pass computed is written two frames
-## after the sprite moved and a walking player is drawn two pixels ahead of its
-## resting cell for the whole walk.
+## The player's screen pixel, which is PLAYER_VIEW_CELL for as long as the
+## player is the thing the view is framed on. `_UpdateSprites` and `ScrollScreen`
+## are one after the other at the end of `HandleMapBackground`, so the shadow OAM
+## a pass wrote and the scroll it computed are latched by the same VBlank and the
+## drawn player never leaves its resting pixel. Only a height offset moves it.
 func player_pixel_position() -> Vector2i:
 	return Vector2i(
 		(player_position_cells() - visible_origin_cells()) * float(CELL_PIXELS)
@@ -736,10 +743,10 @@ func player_pixel_position() -> Vector2i:
 
 
 ## The player's pixel inside the drawn surface, which is
-## [method player_pixel_position] plus half of whatever surround a view wider
-## than the hardware's added. The two are the same value on a 160x144 view.
+## [method player_pixel_position] plus [method view_surround_offset]. The two are
+## the same value on a 160x144 view.
 func player_view_pixel() -> Vector2i:
-	return player_pixel_position() + (view_pixels - VIEW_PIXELS) / 2
+	return player_pixel_position() + view_surround_offset()
 
 
 func player_step_in_progress() -> bool:
@@ -882,7 +889,6 @@ func _begin_player_step(
 
 
 func _clear_player_step() -> void:
-	_camera_lag_cells = Vector2.ZERO
 	_player_step_began = false
 	_player_jumping = false
 	_player_step_direction = Vector2i.ZERO
@@ -900,16 +906,11 @@ func _clear_player_step() -> void:
 ## never starts a step sees no difference.
 func advance_player_step_pass() -> bool:
 	if _player_step_passes_remaining <= 0:
-		_camera_lag_cells = Vector2.ZERO
 		return false
-	var before: Vector2 = player_position_cells()
 	_player_step_frame = (_player_step_frame + 1) & 0x0F
 	_player_step_passes_remaining -= 1
 	if _player_step_passes_remaining <= 0:
 		_start_next_player_step()
-	## What `ScrollScreen` will add to hSCX/hSCY, which it does not do until
-	## after this pass's own two frames have been spent.
-	_camera_lag_cells = player_position_cells() - before
 	return true
 
 

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -26,10 +26,19 @@ const MORN_START: int = 4
 const DAY_START: int = 10
 const NITE_START: int = 18
 
+## `--clock=HH:MM`, and `--clock=HH:MM:D` to name the day of the week as well.
+## The prefix, so the switch is written once.
+const PIN_ARGUMENT: String = "--clock="
+
 var day: int = 0
 var hour: int = 0
 var minute: int = 0
+## Whether this clock is held where it was opened. See [method pin].
+var pinned: bool = false
 var _elapsed_seconds: float = 0.0
+
+static var _pin: Dictionary = {}
+static var _pin_read: bool = false
 
 
 func _init(start_hour: int = 0, start_minute: int = 0, start_day: int = 0) -> void:
@@ -48,8 +57,46 @@ func time_of_day() -> int:
 	return Gen2WorldPalette.TIME_NIGHT
 
 
+## `--clock=HH:MM` on the command line: the time every world opened this run
+## starts at and is held at, over the export defaults and over a save's own.
+##
+## An hour reaches the screen through the palettes and the light, and a renderer
+## reads world state and must not write it, so a shot tool or a mod's own
+## instrument cannot otherwise photograph what it draws at any hour but the one
+## the run happens to be in. Empty unless the switch was passed, and read once:
+## a run's clock cannot change under it.
+static func pin() -> Dictionary:
+	if not _pin_read:
+		_pin_read = true
+		_pin = parse_pin(OS.get_cmdline_args() + OS.get_cmdline_user_args())
+	return _pin
+
+
+## The pin [param args] names, empty if none of them is one. Public so a test
+## reaches the parsing without a command line.
+static func parse_pin(args: PackedStringArray) -> Dictionary:
+	for argument: String in args:
+		if not argument.begins_with(PIN_ARGUMENT):
+			continue
+		var parts: PackedStringArray = argument.trim_prefix(PIN_ARGUMENT).split(":")
+		if parts.size() < 2 or not parts[0].is_valid_int() or not parts[1].is_valid_int():
+			push_warning("%s wants HH:MM, or HH:MM:D for the day: %s" % [
+				PIN_ARGUMENT, argument
+			])
+			continue
+		var named_day: int = 0
+		if parts.size() > 2 and parts[2].is_valid_int():
+			named_day = int(parts[2])
+		return {
+			"hour": posmod(int(parts[0]), HOURS_PER_DAY),
+			"minute": posmod(int(parts[1]), MINUTES_PER_HOUR),
+			"day": posmod(named_day, DAYS_PER_WEEK),
+		}
+	return {}
+
+
 func advance(seconds: float, world: Gen2WorldAPI = null) -> Array:
-	if seconds <= 0.0:
+	if seconds <= 0.0 or pinned:
 		return []
 	_elapsed_seconds += seconds
 	var ticks: Array = []

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -320,15 +320,19 @@ func sprites_active() -> bool:
 	return not _sprites.is_empty()
 
 
+## `StepFunction_ScreenShake.Run` reaches hSCY and nothing else: the whole shake
+## is one vertical scroll offset whose sign `.GetSign` flips on what is left of
+## the duration, and the pass that runs it out deletes the object with the offset
+## undone. In hardware pixels, and the background's alone, since a scroll moves
+## no sprite.
 func offset() -> Vector2:
 	if not active():
 		return Vector2.ZERO
-	var magnitude: float = float(_amplitude)
-	match _frame & 3:
-		0: return Vector2(-magnitude, 0.0)
-		1: return Vector2(magnitude, 0.0)
-		2: return Vector2(0.0, -magnitude)
-		_: return Vector2(0.0, magnitude)
+	## `dec [hl]` before the sign, so the first pass already reads one less.
+	var remaining: int = _duration - 1 - _frame
+	if remaining <= 0:
+		return Vector2.ZERO
+	return Vector2(0.0, float(_amplitude if remaining % 2 == 0 else -_amplitude))
 
 
 ## What a renderer draws this frame: one record per live sprite, each carrying

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -543,6 +543,14 @@ func refresh() -> void:
 	queue_redraw()
 
 
+## The scroll the map is drawn at. `StepFunction_ScreenShake` reaches hSCY and
+## nothing else, so an earthquake moves the background under the sprites standing
+## on it rather than moving the picture.
+func _background_camera() -> Vector2:
+	var camera: Vector2 = _world.view_origin_pixels()
+	return camera if _effects == null else camera + _effects.offset()
+
+
 ## Lays the map quads out under this frame's camera.
 ##
 ## The order is the order the cartridge's own buffer would be read in if it had
@@ -558,7 +566,7 @@ func _sync_map_layers() -> void:
 		return
 	var map: Gen2WorldMap = _world.current_map
 	var tileset: Gen2WorldTileset = _world.current_tileset
-	var camera: Vector2 = _world.view_origin_pixels().floor()
+	var camera: Vector2 = _background_camera()
 	var view := Vector2(view_pixels())
 	var block_pixels: int = RomLayout.MAP_BLOCK_CELL_WIDTH * Gen2WorldAPI.CELL_PIXELS
 	var used: int = 0
@@ -595,7 +603,7 @@ func _sync_map_layers() -> void:
 				Vector2i(near.width_blocks, near.height_blocks), near.border_block,
 				near_tileset.block_count, near_tileset.tile_count, false,
 			)
-			layer.place(at.floor(), size)
+			layer.place(at, size)
 
 	var buffer: ImageTexture = _map_buffer_texture()
 	if buffer != null:
@@ -610,7 +618,7 @@ func _sync_map_layers() -> void:
 			tileset.block_count, tileset.tile_count, false,
 		)
 		layer.place(
-			(Vector2.ONE * float(-Gen2WorldAPI.BUFFER_BLOCKS * block_pixels) - camera).floor(),
+			Vector2.ONE * float(-Gen2WorldAPI.BUFFER_BLOCKS * block_pixels) - camera,
 			Vector2(span) * float(block_pixels),
 		)
 	_show_map_layers(used)
@@ -719,11 +727,12 @@ func _draw() -> void:
 		return
 
 	var camera_pixels: Vector2 = _world.view_origin_pixels()
+	var background: Vector2 = _background_camera()
 	## `Cut_Headbutt_GetPixelFacing`'s tree goes away while its own sprite
 	## animation plays, which the map quad knows nothing about: the four tiles of
 	## the cell are painted over with the tileset's own blank one.
 	for cell: Vector2i in (_effects.hidden_tree_cells() if _effects != null else []):
-		var at: Vector2 = Vector2(cell * Gen2WorldAPI.CELL_PIXELS) - camera_pixels
+		var at: Vector2 = Vector2(cell * Gen2WorldAPI.CELL_PIXELS) - background
 		for row: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
 			for column: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
 				draw_texture_rect_region(
@@ -740,7 +749,7 @@ func _draw() -> void:
 					),
 				)
 	if not _transition_cells.is_empty():
-		_draw_transition(camera_pixels)
+		_draw_transition(background)
 	if _transition_sprites == Gen2BattleTransition.SPRITES_NONE:
 		return
 
@@ -800,7 +809,7 @@ func _draw() -> void:
 		if offset != Vector2i.ZERO:
 			continue
 		if _in_grass(object.cell):
-			_draw_grass_over(pixel, camera_pixels)
+			_draw_grass_over(pixel, background)
 		if object.emote_visible:
 			_draw_emote(object.emote_id, pixel)
 		if not battlers_only:
@@ -817,7 +826,7 @@ func _draw() -> void:
 	if player_texture != null:
 		draw_texture(player_texture, player + jump)
 		if _in_grass(_world.player_cell):
-			_draw_grass_over(player + jump, camera_pixels)
+			_draw_grass_over(player + jump, background)
 		if _world.fishing_busy():
 			_draw_fishing_rod(player + jump)
 	else:
@@ -913,7 +922,7 @@ func _draw_actor(sprite: Dictionary, camera_pixels: Vector2) -> void:
 		return
 	draw_texture(texture, pixel)
 	if _in_grass(Vector2i(roundi(cell_position.x), roundi(cell_position.y))):
-		_draw_grass_over(pixel, camera_pixels)
+		_draw_grass_over(pixel, _background_camera())
 	## The same bubble a map object's `showemote` puts up, over an actor that
 	## asked for one. Drawn after the grass, as an object's is: `SpawnEmote` is
 	## its own OAM and stands over the tuft rather than behind it.
@@ -967,7 +976,7 @@ func _in_grass(cell: Vector2i) -> bool:
 
 ## Redraws the map over the bottom half of a sprite drawn at [param pixel], with
 ## the transparent index left out, which is what OAM_PRIO amounts to here.
-func _draw_grass_over(pixel: Vector2, camera_pixels: Vector2) -> void:
+func _draw_grass_over(pixel: Vector2, background: Vector2) -> void:
 	if _priority_atlas == null:
 		_build_priority_atlas()
 	if _priority_atlas == null:
@@ -980,17 +989,17 @@ func _draw_grass_over(pixel: Vector2, camera_pixels: Vector2) -> void:
 	## two. Walking the whole page for it cost the view's every tile once per
 	## sprite standing in grass, which a window-filling view cannot afford.
 	var first := Vector2i(
-		floori((over.position.x + camera_pixels.x) / float(Gen2Tiles.TILE_WIDTH)),
-		floori((over.position.y + camera_pixels.y) / float(Gen2Tiles.TILE_HEIGHT)),
+		floori((over.position.x + background.x) / float(Gen2Tiles.TILE_WIDTH)),
+		floori((over.position.y + background.y) / float(Gen2Tiles.TILE_HEIGHT)),
 	)
 	var last := Vector2i(
-		ceili((over.end.x + camera_pixels.x) / float(Gen2Tiles.TILE_WIDTH)),
-		ceili((over.end.y + camera_pixels.y) / float(Gen2Tiles.TILE_HEIGHT)),
+		ceili((over.end.x + background.x) / float(Gen2Tiles.TILE_WIDTH)),
+		ceili((over.end.y + background.y) / float(Gen2Tiles.TILE_HEIGHT)),
 	)
 	for y: int in range(first.y, last.y + 1):
 		for x: int in range(first.x, last.x + 1):
 			var at := Rect2(
-				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT) - camera_pixels,
+				Vector2(x * Gen2Tiles.TILE_WIDTH, y * Gen2Tiles.TILE_HEIGHT) - background,
 				Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT),
 			)
 			var covered: Rect2 = at.intersection(over)
@@ -1012,7 +1021,7 @@ func _draw_grass_over(pixel: Vector2, camera_pixels: Vector2) -> void:
 	## wins the priority test where it wrote is its own tile rather than the
 	## grass. The pieces above left those cells to it.
 	if not _transition_cells.is_empty():
-		_draw_transition(camera_pixels, over, true)
+		_draw_transition(background, over, true)
 
 
 ## The graphics tile drawn at a map-space tile coordinate, through the same

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -254,7 +254,6 @@ var _spending_frame: bool = false
 ## that started one is waiting on it.
 var _sound_schedule: Array = []
 var _sound_schedule_frame: int = 0
-var _screen_base_position: Vector2 = Vector2.ZERO
 ## Whether a screen laid out in 160x144 owns the picture, as last told to the
 ## renderer, and whether it has been told at all: [method _apply_interface_mask]
 ## runs every frame, and a renderer swapped in mid-scene has heard nothing.
@@ -398,7 +397,15 @@ func _build_world() -> void:
 	_world.script_random = _encounter_random
 	_world.object_random = _object_random
 	_world.breed_random = _breed_random
+	## `--clock=HH:MM` beats both the export defaults and the save's own, and
+	## holds the clock there for the run: see [method Gen2WorldClock.pin].
+	var pinned_clock: Dictionary = Gen2WorldClock.pin()
+	if not pinned_clock.is_empty():
+		initial_day = int(pinned_clock["day"])
+		initial_hour = int(pinned_clock["hour"])
+		initial_minute = int(pinned_clock["minute"])
 	_clock = Gen2WorldClock.new(initial_hour, initial_minute, initial_day)
+	_clock.pinned = not pinned_clock.is_empty()
 	time_of_day = _clock.time_of_day()
 	_animation = Gen2WorldAnimation.new()
 	_effects = Gen2WorldEffects.new()
@@ -424,7 +431,6 @@ func _build_world() -> void:
 	_build_renderer()
 	Gen2ModHost.instance().view_changed.connect(_on_view_changed)
 	_screen.view_size_changed.connect(_on_view_size_changed)
-	_screen_base_position = _screen.position
 	_audio_player = AUDIO_PLAYER_SCRIPT.new()
 	_audio_player.name = "AudioPlayer"
 	add_child(_audio_player)
@@ -730,7 +736,6 @@ func advance_frame() -> void:
 			effects_moved = _effects.advance_pass() or effects_moved
 		if effects_moved and _renderer != null:
 			_renderer.refresh()
-		_apply_world_effect_offset()
 	## `AnimateTileset` is VBlank's, not the pass's, so the water and the flowers
 	## animate on every frame while the objects standing on them move on passes.
 	if _animation != null and _animation.advance_frame() and _renderer != null:
@@ -5618,7 +5623,8 @@ func _show_script_results(results: Array) -> void:
 						&"screen_shake",
 						result_event,
 					)
-				_apply_world_effect_offset()
+				if _renderer != null:
+					_renderer.refresh()
 			elif result_event.get("type", &"") == &"tree_shake_requested":
 				## The object animates itself for the frames the stream sleeps;
 				## there is nothing for a host to start.
@@ -5861,13 +5867,6 @@ func _spawn_grass_rustles() -> void:
 		)
 	if _renderer != null and _effects.sprites_active():
 		_renderer.refresh()
-
-
-func _apply_world_effect_offset() -> void:
-	if _screen == null:
-		return
-	var effect_offset: Vector2 = _effects.offset() if _effects != null else Vector2.ZERO
-	_screen.position = _screen_base_position + effect_offset
 
 
 ## The yes half of an Ask*Script. Each move's own request is what decides

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2180,7 +2180,15 @@ func test_player_walk_step_starts_a_cell_behind_and_never_moves_the_committed_ce
 	assert_eq(world.player_pixel_position(), Gen2WorldAPI.PLAYER_VIEW_CELL * 16)
 
 
-func test_the_camera_origin_follows_the_player_one_pass_behind() -> void:
+## `_UpdateSprites` and `ScrollScreen` are one after the other at the end of
+## `HandleMapBackground`, so a pass's shadow OAM and its scroll are latched by
+## the same VBlank: the drawn player never leaves PLAYER_VIEW_CELL and the camera
+## moves the whole step, every pass of it, by the same two pixels. Measured on a
+## real cartridge as OAM slot 0 against rSCX, which is what the PPU read; the
+## `sprite_x - scx` of 62 the WRAM fields report is one pass of lead
+## `HandleMapObjects` writes before `NextOverworldFrame` spends its two frames
+## and nothing draws from.
+func test_the_camera_and_the_drawn_player_move_on_the_same_pass() -> void:
 	var world: Gen2WorldAPI = _world()
 	# Standing still, the hardware page origin and the camera agree.
 	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
@@ -2194,22 +2202,26 @@ func test_the_camera_origin_follows_the_player_one_pass_behind() -> void:
 	assert_eq(world.player_position_cells(), Vector2(8.0, 6.0))
 	assert_eq(world.visible_origin_cells(), Vector2(4.0, 2.0))
 
-	# `ScrollScreen` runs after `NextOverworldFrame`, so the scroll a pass
-	# computed is written two frames after the sprite moved: the camera stands
-	# still on the pass the walk starts and the player is drawn two pixels ahead
-	# of it, which is `sprite_x - scx` of 62 on the cartridge.
-	assert_true(world.advance_player_step_pass())
-	assert_eq(world.player_position_cells(), Vector2(7.875, 6.0))
-	assert_eq(world.visible_origin_cells(), Vector2(4.0, 2.0))
-	assert_eq(world.player_pixel_position(), Vector2i(62, 64))
+	var last: Vector2 = world.view_origin_pixels()
+	for pass_index: int in Gen2WorldAPI.STEP_PASSES_WALK:
+		assert_true(world.advance_player_step_pass())
+		assert_eq(
+			world.player_pixel_position(), Gen2WorldAPI.PLAYER_VIEW_CELL * 16,
+			"pass %d draws the player where he rests" % pass_index,
+		)
+		assert_eq(
+			world.view_origin_pixels(), last + Vector2(-2.0, 0.0),
+			"pass %d scrolls the camera by the step vector" % pass_index,
+		)
+		last = world.view_origin_pixels()
 
-	# The step lands on the committed cell with the camera still one pass behind,
-	# and the pass after it, which moves nothing, is where the two agree again.
-	_finish_player_step(world)
+	# The step ends on the committed cell with nothing left for a later pass to
+	# catch up on: the pass after it moves the camera no further.
 	assert_false(world.player_step_in_progress())
 	assert_eq(world.player_position_cells(), Vector2(7.0, 6.0))
-	assert_eq(world.visible_origin_cells(), Vector2(3.125, 2.0))
+	assert_eq(world.visible_origin_cells(), Vector2(3.0, 2.0))
 	assert_false(world.advance_player_step_pass())
+	assert_eq(world.view_origin_pixels(), last)
 	assert_eq(world.visible_origin_cells(), Vector2(world.visible_screen_origin_cell()))
 	assert_eq(world.player_pixel_position(), Gen2WorldAPI.PLAYER_VIEW_CELL * 16)
 
@@ -7715,6 +7727,18 @@ func test_a_wider_view_keeps_the_player_where_the_hardware_put_him() -> void:
 	assert_eq(
 		world.player_view_pixel(), world.player_pixel_position() + Vector2i(160, 32),
 		"and the sprite is drawn there",
+	)
+	# An odd surround has one whole-pixel answer, not a floor on one side and a
+	# ceiling on the other: the map quads and the player are placed from it.
+	world.view_pixels = Gen2WorldAPI.VIEW_PIXELS + Vector2i(321, 65)
+	assert_eq(world.view_surround_offset(), Vector2i(160, 32))
+	assert_eq(world.view_origin_pixels(), framed - Vector2(160, 32))
+	assert_eq(world.player_view_pixel(), world.player_pixel_position() + Vector2i(160, 32))
+	assert_eq(
+		Vector2(world.player_view_pixel()),
+		Vector2(world.player_cell) * float(Gen2WorldAPI.CELL_PIXELS)
+			- world.view_origin_pixels(),
+		"the player stands where an object on his own cell would be drawn",
 	)
 
 

--- a/tests/unit/test_world_clock.gd
+++ b/tests/unit/test_world_clock.gd
@@ -24,3 +24,30 @@ func test_clock_uses_source_time_of_day_boundaries_and_wraps_the_week() -> void:
 	clock.advance(6.0 * 60.0 * 60.0)
 	assert_eq(clock.hour, 0)
 	assert_eq(clock.day, 0)
+
+
+## `--clock=HH:MM`, which is how an hour is photographed through the production
+## path: a renderer reads world state and must not write it, so nothing inside
+## the game can move the clock to look at what it draws at another hour.
+func test_the_clock_pin_is_parsed_off_the_command_line_and_holds_the_run() -> void:
+	assert_eq(Gen2WorldClock.parse_pin(PackedStringArray(["--headless"])), {})
+	assert_eq(
+		Gen2WorldClock.parse_pin(PackedStringArray(["--clock=06:30"])),
+		{"hour": 6, "minute": 30, "day": 0},
+	)
+	assert_eq(
+		Gen2WorldClock.parse_pin(PackedStringArray(["-s", "x.gd", "--clock=22:05:3"])),
+		{"hour": 22, "minute": 5, "day": 3},
+	)
+	# Out of range wraps rather than refusing, the way the constructor's does.
+	assert_eq(
+		Gen2WorldClock.parse_pin(PackedStringArray(["--clock=25:61:9"])),
+		{"hour": 1, "minute": 1, "day": 2},
+	)
+
+	var clock := Gen2WorldClock.new(6, 30)
+	clock.pinned = true
+	assert_eq(clock.advance(60.0 * 60.0 * 12.0), [])
+	assert_eq(clock.hour, 6)
+	assert_eq(clock.minute, 30)
+	assert_eq(clock.time_of_day(), Gen2WorldPalette.TIME_MORNING)

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -7,11 +7,21 @@ func test_source_packed_screen_shake_uses_duration_and_amplitude_bits() -> void:
 	assert_true(started["active"])
 	assert_eq(started["duration"], 20)
 	assert_eq(started["amplitude"], 2)
-	assert_eq(started["offset"], Vector2(-2, 0))
+	# hSCY and nothing else, the sign flipping on what is left of the duration
+	# after `.Run`'s own `dec [hl]`: 19 on the first pass, so the scroll goes down
+	# before it goes up.
+	assert_eq(started["offset"], Vector2(0, -2))
 
+	var seen: Array[Vector2] = []
 	for _frame: int in 19:
+		seen.append(effects.offset())
 		assert_true(effects.advance_pass())
+	assert_eq(seen[1], Vector2(0, 2), "and back on the next pass")
+	assert_eq(seen[18], Vector2(0, -2), "still shaking on the last shaking pass")
+	for entry: Vector2 in seen:
+		assert_eq(entry.x, 0.0, "no horizontal half")
 	assert_true(effects.active())
+	assert_eq(effects.offset(), Vector2.ZERO, "the pass that runs it out undoes it")
 	assert_true(effects.advance_pass())
 	assert_false(effects.active())
 	assert_false(effects.advance_pass(), "a spent effect costs no more frames")

--- a/tools/trace_world_walk.gd
+++ b/tools/trace_world_walk.gd
@@ -10,10 +10,13 @@ extends SceneTree
 ## same artefact off a real cartridge. The line is
 ## `frame cam_x cam_y x y screen_x screen_y facing walk_frame`, where `cam_x`
 ## and `cam_y` are hSCX/hSCY in map pixels rather than modulo the BG map and
-## `screen_x`/`screen_y` are `sprite_x - scx` on that side: the camera lags the
-## player by one pass (`ScrollScreen` runs after `NextOverworldFrame`), so a
-## walking player is drawn two pixels ahead of its resting cell and the pair is
-## what says so.
+## `screen_x`/`screen_y` are the player's own drawn pixel.
+##
+## Diff `screen_x` against the cartridge's OAM slot 0 minus rSCX, not against its
+## `wPlayerSpriteX - hSCX`: `HandleMapObjects` writes the object field before
+## `NextOverworldFrame` spends its two frames and `_UpdateSprites` does not copy
+## it into shadow OAM until after them, so that pair reads two pixels of lead the
+## screen never shows.
 ##
 ## Ten standing frames come first, the way the cartridge trace opens, so a diff
 ## aligns on the frame the direction starts being held rather than on the file.


### PR DESCRIPTION
Movement stuttered. Every step popped two pixels one way when it started and two back when it ended, and because the camera is the one number the map, the NPCs, the effect sprites and any registered renderer are all placed from, the whole picture jolted against the player at once.

## What was wrong

The camera had been given a pass of lag. The reason was a walk trace that read `wPlayerSpriteX` against `hSCX`: that pair really does say 62 while walking and 64 standing, so it looks like the scroll trails the sprite by two pixels.

Neither field is what the frame is drawn from. `HandleMapObjects` writes the object field before `NextOverworldFrame` spends the pass's two frames. `_UpdateSprites` copies it into shadow OAM after them, one instruction before `ScrollScreen` writes `hSCX`. Both are therefore latched by the same VBlank.

Sampling what the hardware actually drew, OAM against rSCX on a real cartridge:

| Measure, Route 29 walking west | Cartridge | Before | After |
|---|---|---|---|
| Drawn player pixel while walking | 64 on all 82 frames | 62 | 64 on all 82 frames |
| Drawn player pixel standing | 64 | 64 | 64 |
| Camera moves of anything but 0 or 2 px | none | none | none |
| Steps ending with the camera still owing 2 px | none | every one | none |

The player is nailed to the screen and the background is the only thing that moves.

## Two more in the same class

`view_origin_pixels()` is whole pixels now, through a new `view_surround_offset()` that the player's own pixel is measured from as well. A surround with an odd side used to floor on one side and round up on the other, leaving the map quads half a pixel off the sprites standing on them.

The earthquake was applied to the screen control's position, in window pixels: a quarter of a hardware pixel at 4x, and it took the interface with it. `StepFunction_ScreenShake.Run` reaches hSCY and nothing else, so it is the background camera's now, in hardware pixels, with the routine's own vertical sign flip rather than an invented four-phase one. It moves no sprite. A renderer taking `set_effects` applies it the same way.

## Also in here

`--clock=HH:MM` pins the world clock for a run, over the export defaults and over a save's own, and holds it there. An hour reaches the screen through the palettes and the light, and a renderer reads world state and must not write it, so nothing could otherwise photograph what it draws at any hour but the one the machine happened to be in.

## Checks

- 3601 tests, 67437 asserts, all passing
- `validate.gd -- all`: 67 topics PASS, exit 0
- `replay_world.gd`: 33 routes, 0 failures
- Story walk on all three cartridges: no failures
- A standing frame of Route 29 renders byte for byte identical to before