### PR TITLE
Put the frame rate on the debug readout

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,11 @@ output's own demand rather than by a game frame, so music, effects and cries kee
 the cartridge's tempo and pitch at every setting; only how often the game asks
 for one changes.
 
-Development shortcuts are debug-build only, along with the map and cell readout:
+Development shortcuts are debug-build only, along with the map and cell readout.
+That readout carries the frame rate beside the cell: `fps` is host frames drawn,
+`hw` the hardware frames the pump actually spent, which is 59.7 a second on a
+machine keeping up, and `worst` the longest single frame of the last second,
+which is where a stutter shows and an average hides it.
 
 | Scene | Keys |
 |---|---|

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -30,7 +30,15 @@ const TIMER_WATER_PALETTE: Array = [0, 1, 2, 1]
 ## from the output's own demand rather than from a game frame, so music, effects
 ## and cries keep the cartridge's tempo and pitch at every setting.
 class FrameClock extends RefCounted:
+	## How long [method rate] averages over before it publishes a new reading.
+	const RATE_WINDOW_SECONDS: float = 1.0
+
 	var _elapsed: float = 0.0
+	var _window_seconds: float = 0.0
+	var _window_ticks: int = 0
+	var _window_frames: int = 0
+	var _window_worst: float = 0.0
+	var _rate: Dictionary = {}
 
 	## Hardware frames owed since the last call. The scale is read every call
 	## because the settings object is shared and edited in place.
@@ -41,12 +49,46 @@ class FrameClock extends RefCounted:
 		)
 		var frames: int = int(_elapsed / FRAME_SECONDS)
 		_elapsed -= float(frames) * FRAME_SECONDS
+		_measure(delta, frames)
 		return frames
 
 	## Drops the banked remainder, for a pump that was not running: a screen that
-	## comes back owes frames from now rather than from when it stopped.
+	## comes back owes frames from now rather than from when it stopped. The
+	## measurement window goes with it, since a reading across a gap is a lie.
 	func reset() -> void:
 		_elapsed = 0.0
+		_window_seconds = 0.0
+		_window_ticks = 0
+		_window_frames = 0
+		_window_worst = 0.0
+		_rate = {}
+
+	## The last completed second of this pump, as `fps` (host frames drawn),
+	## `hardware` (hardware frames spent, which is 59.7 on a machine keeping up
+	## and whatever GAME SPEED multiplies that by) and `worst_ms` (the longest
+	## single host frame in the window, which is the number a stutter shows in
+	## and an average hides). Empty until the first window closes, and empty again
+	## after a reset, so a pump driven by hand rather than by a clock reports
+	## nothing instead of reporting zero.
+	func rate() -> Dictionary:
+		return _rate
+
+	func _measure(delta: float, frames: int) -> void:
+		_window_seconds += delta
+		_window_ticks += 1
+		_window_frames += frames
+		_window_worst = maxf(_window_worst, delta)
+		if _window_seconds < RATE_WINDOW_SECONDS:
+			return
+		_rate = {
+			"fps": float(_window_ticks) / _window_seconds,
+			"hardware": float(_window_frames) / _window_seconds,
+			"worst_ms": _window_worst * 1000.0,
+		}
+		_window_seconds = 0.0
+		_window_ticks = 0
+		_window_frames = 0
+		_window_worst = 0.0
 
 
 var data: GameData = null

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -264,6 +264,13 @@ var _interface_owned_pushed: bool = false
 @onready var _caption: Label = %Caption
 @onready var _hint: Label = %Hint
 
+## The debug caption without its frame-rate tail, and that tail. The readout is
+## rebuilt on a map, a step or a script, and the rate once a second, so the two
+## are kept apart rather than rebuilding the whole line every drawn frame.
+var _caption_text: String = ""
+var _rate_text: String = ""
+var _rate_reading: Dictionary = {}
+
 
 func _ready() -> void:
 	# The map and cell readout and the shortcut legend are scaffolding, and they
@@ -282,10 +289,35 @@ func _ready() -> void:
 ## this left the player a black screen with no reason on it. Every caller
 ## returns straight after, so nothing overwrites it with the readout.
 func _show_load_failure(reason: String, detail: String) -> void:
-	_caption.text = reason
+	_set_caption(reason)
 	_hint.text = detail
 	_caption.visible = true
 	_hint.visible = true
+
+
+## The debug caption, with whatever frame-rate reading is current appended.
+func _set_caption(text: String) -> void:
+	_caption_text = text
+	_caption.text = _caption_text + _rate_text
+
+
+## `fps` is host frames drawn, `hw` the hardware frames the pump spent, which is
+## 59.7 on a machine keeping up and whatever GAME SPEED multiplies that by, and
+## `worst` the longest single frame of the second, which is where a stutter shows
+## and an average hides it. The reading changes once a second and the line is
+## rebuilt only then: this is drawn on the frame it is measuring.
+## See [method Gen2WorldAnimation.FrameClock.rate].
+func _refresh_frame_rate() -> void:
+	if _world == null or _caption == null or not _caption.visible:
+		return
+	var rate: Dictionary = _frame_clock.rate()
+	if rate.is_empty() or rate == _rate_reading:
+		return
+	_rate_reading = rate
+	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms" % [
+		float(rate["fps"]), float(rate["hardware"]), float(rate["worst_ms"]),
+	]
+	_caption.text = _caption_text + _rate_text
 
 
 ## The two scaffolding labels off, for a capture that is diffed against a
@@ -671,6 +703,7 @@ func cycle_view() -> Dictionary:
 func _process(delta: float) -> void:
 	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
+	_refresh_frame_rate()
 	_advance_day_cycle(delta)
 	## Every drawn frame rather than every hardware frame: above sixty a drawn
 	## frame can carry no hardware one, and a screen opened by the press that
@@ -2965,7 +2998,7 @@ func preview_party_transaction() -> void:
 		_script_prompt = "Party transaction failed: %s" % String(result.get("reason", "unknown"))
 	_refresh_labels()
 	if not preview_caption.is_empty():
-		_caption.text = preview_caption
+		_set_caption(preview_caption)
 
 
 ## Public screenshot driver for the pack's item use. It grants a Potion and hurts
@@ -6567,16 +6600,17 @@ func _refresh_labels() -> void:
 	if _world == null or _data == null:
 		return
 	_refresh_party_summary()
-	_caption.text = "%s   map %d/%d   cell %d,%d" % [
+	var caption: String = "%s   map %d/%d   cell %d,%d" % [
 		_data.title(), _world.current_map.group, _world.current_map.number,
 		_world.player_cell.x, _world.player_cell.y,
 	]
 	var ring: Dictionary = _world.pending_phone_ring()
 	if _world.phone_ring_active() and not ring.is_empty():
-		_caption.text += "   PHONE RING %d/%d: %s" % [
+		caption += "   PHONE RING %d/%d: %s" % [
 			int(ring.get("ring", 0)), int(ring.get("rings", 0)),
 			_phone_contact_label(ring.get("contact", {})),
 		]
+	_set_caption(caption)
 	var rods: Array[StringName] = _world.available_fishing_rods()
 	var rod_labels: Array[String] = []
 	for rod: StringName in rods:

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -514,3 +514,39 @@ func test_roof_colours_replace_two_slots_on_outdoor_maps_only() -> void:
 	assert_eq(Gen2WorldPalette.roof_colors(
 		data, Gen2WorldPalette.ENVIRONMENT_TOWN, Gen2WorldPalette.TIME_DAY, 2
 	)[0], Gen2Palette.from_packed(0x0003))
+
+
+## The debug readout's frame-rate line, which is what says whether a stutter was
+## a dropped drawn frame or a dropped hardware one.
+func test_the_frame_clock_reports_a_second_of_drawn_and_hardware_frames() -> void:
+	var clock := Gen2WorldAnimation.FrameClock.new()
+	assert_eq(clock.rate(), {}, "nothing is reported before a window closes")
+
+	# Sixty host frames at the hardware's own rate, which is 59.7275 Hz and not
+	# 60: one hardware frame each, and the sixtieth closes the window.
+	var hardware: int = 0
+	for _host: int in 60:
+		hardware += clock.tick(Gen2WorldAnimation.FRAME_SECONDS)
+	assert_eq(hardware, 60)
+	var rate: Dictionary = clock.rate()
+	assert_almost_eq(float(rate["fps"]), 59.7275, 0.1)
+	assert_almost_eq(float(rate["hardware"]), 59.7275, 0.1)
+	assert_almost_eq(
+		float(rate["worst_ms"]), Gen2WorldAnimation.FRAME_SECONDS * 1000.0, 0.1
+	)
+
+	# One host frame that took a fifth of a second is the whole point: the mean
+	# hides it and `worst_ms` does not. It also costs hardware frames, because
+	# MAX_CATCHUP_FRAMES refuses to spend more than four of them at once.
+	clock.tick(0.2)
+	for _host: int in 48:
+		clock.tick(Gen2WorldAnimation.FRAME_SECONDS)
+	var stalled: Dictionary = clock.rate()
+	assert_almost_eq(float(stalled["worst_ms"]), 200.0, 1.0)
+	assert_true(
+		float(stalled["hardware"]) < 59.0,
+		"a stall drops hardware frames rather than banking them: %f" % stalled["hardware"],
+	)
+
+	clock.reset()
+	assert_eq(clock.rate(), {}, "a reading across a gap is not reported")


### PR DESCRIPTION
Three numbers beside the map and cell, so a stutter can be seen while playing rather than only measured afterwards:

```
Gold   map 24/3   cell 4,4   120 fps   hw 60/s   worst 11.3 ms
```

- **`fps`** — host frames drawn in the last second.
- **`hw`** — hardware frames the overworld pump actually spent. 59.7 a second on a machine keeping up, and whatever GAME SPEED multiplies that by. If this drops while `fps` holds, the *game* slowed down rather than the display.
- **`worst`** — the longest single host frame of that second. This is the one that catches a hitch; a mean hides it.

The first second after a scene opens reads `95 fps   hw 55/s   worst 150.0 ms`, which is the scene build, and it settles to the line above.

## Where it lives

`Gen2WorldAnimation.FrameClock` is the one place real seconds become hardware frames, so both counts already pass through it and it is where the window belongs. Every pump gets it; the world screen is the only one that draws it.

The reading is published once a second and the caption line is rebuilt only then, because this is drawn on the frame it is measuring. `rate()` is empty until a window closes and empty again after a `reset()`, so a pump driven by hand rather than by a clock reports nothing instead of zeroes: every `preview_*.gd` shot is byte for byte what it was, checked on Route 29.

## Checks

- 3602 tests, 67445 asserts, all passing
- `validate.gd -- all`: 67 topics PASS, exit 0
- `replay_world.gd`: 33 routes, 0 failures
- A Route 29 preview frame is byte for byte identical to before