### PR TITLE
One screen a window, and the surround only where a screen owns one

### DIFF
--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -28,6 +28,10 @@ extends Control
 
 const WIDTH: int = 160
 const HEIGHT: int = 144
+## Loaded rather than preloaded: this script is the scene's own, and a preload
+## of it here is a cycle. [method host_for] is the only caller and the loader
+## caches after the first.
+const SCENE_PATH: String = "res://game/render/gen2_screen.tscn"
 ## Below one screen pixel per hardware pixel the picture is halved rather than
 ## stepped, which is what puts a whole region in a window.
 const MIN_SCALE: float = 0.25
@@ -95,13 +99,29 @@ var interface_masked: bool = true:
 ## a screen hands a redrawn picture to the node that shows it. A screen with more
 ## art than the hardware framed hands [method set_backdrop] the real thing
 ## instead, and this is what is left for one without.
+##
+## Meaningless until something has said what it is: see [method has_field].
 var surround_color: Color = Color.BLACK:
 	set(value):
-		if surround_color == value:
+		var told: bool = _field_told
+		_field_told = true
+		if surround_color == value and told:
 			return
 		surround_color = value
 		if _mask != null:
 			_mask.queue_redraw()
+
+## Whether anything has said what [member surround_color] is.
+##
+## "Not told yet" is not "told it is black", and the difference is a whole class
+## of bug: a screen laid out over another -- a menu box over the map, a question
+## over a picture -- has no field of its own, and painting the default over the
+## surround cuts whatever it is standing on back to 160x144 with bars around it.
+## An untold screen paints no surround at all.
+var _field_told: bool = false
+## Who told it, so the colour goes when that screen does and the next one starts
+## from untold rather than inheriting a field it never drew.
+var _field_source: Node = null
 
 var _view_size: Vector2i = Vector2i(WIDTH, HEIGHT)
 var _draw_scale: float = 1.0
@@ -270,6 +290,7 @@ func reset_zoom() -> void:
 ## Frees everything on screen, on both layers.
 func clear() -> void:
 	clear_backdrop()
+	clear_field()
 	for parent: Node in [_interface, _content, _native]:
 		for child: Node in parent.get_children():
 			drop(child)
@@ -331,11 +352,7 @@ func interface_origin() -> Vector2i:
 ## The walk rather than a stored reference: a screen is added to whichever host
 ## has one and freed by it, and neither end should have to hold the other.
 ##
-## The outermost one, not the nearest. Half a dozen screens build a screen of
-## their own and are then opened inside another -- the pack, the dex, the town
-## map, the party -- and the inner one is a full-rect [Control] in a 160x144
-## rectangle, so it has no surround at all. The one that does is the one at the
-## window.
+## The outermost one, not the nearest, for a node that is somehow inside two.
 static func owner_of(node: Node) -> Gen2Screen:
 	var at: Node = node
 	var found: Gen2Screen = null
@@ -344,6 +361,34 @@ static func owner_of(node: Node) -> Gen2Screen:
 			found = at
 		at = at.get_parent()
 	return found
+
+
+## The screen a host's own 160x144 view belongs in.
+##
+## [param handed] is the one the opener gave it, for a host mounted beside a
+## screen rather than inside it; failing that the one [param node] is already
+## standing in; failing both a new one over [param node], which is what a host
+## opened on its own -- the launcher's PC, a preview -- really does need.
+##
+## A second screen over a window that already has one is what made the surround
+## ambiguous. Two viewports each pick their own scale and their own place for the
+## hardware rectangle, so an overlay meant to sit on the map is drawn at a
+## different size beside it, and both of them paint a surround the other did not
+## ask for. One window, one screen.
+static func host_for(node: Control, handed: Gen2Screen = null) -> Gen2Screen:
+	if handed != null:
+		return handed
+	var found: Gen2Screen = owner_of(node)
+	if found != null:
+		return found
+	var scene: PackedScene = load(SCENE_PATH) as PackedScene
+	var built: Gen2Screen = scene.instantiate() as Gen2Screen if scene != null else null
+	if built == null:
+		return null
+	built.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	built.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	node.add_child(built)
+	return built
 
 
 ## Real art for the surround, the size of [method view_size], from [param source].
@@ -409,7 +454,7 @@ static func note_field(target: CanvasItem, field: Color) -> void:
 	var screen: Gen2Screen = owner_of(target)
 	if screen == null or not screen.expanded:
 		return
-	screen.surround_color = field
+	screen._take_field(target, field)
 
 
 ## Takes the surround's colour from a picture a screen has just drawn.
@@ -418,8 +463,7 @@ static func note_field(target: CanvasItem, field: Color) -> void:
 ## one place a redrawn picture reaches the node showing it, so the surround
 ## follows a palette fade and a screen swap without either knowing this exists.
 ## Only a picture the size of the hardware screen counts, and only one that is
-## opaque where it is sampled -- a layer drawn over another screen's field is
-## not that screen's field.
+## opaque everywhere it is sampled: see [method Gen2PicImage.field_color].
 ##
 ## Whether the surround is showing is deliberately not a condition. A screen
 ## draws its field on the frame it opens and the host raises the mask on that
@@ -436,7 +480,45 @@ static func note_picture(target: CanvasItem, image: Image) -> void:
 	var field: Color = Gen2PicImage.field_color(image)
 	if field.a <= 0.0:
 		return
-	screen.surround_color = field
+	screen._take_field(target, field)
+
+
+## Whether anything has said what [member surround_color] is. False leaves the
+## surround unpainted: see [member _field_told].
+func has_field() -> bool:
+	return _field_told
+
+
+## Records [param field] and who drew it. A field belongs to one screen at a
+## time, so the last opaque one wins and the colour is forgotten when the node
+## that drew it goes.
+func _take_field(source: Node, field: Color) -> void:
+	surround_color = field
+	if _field_source == source:
+		return
+	_field_source = source
+	if source == null:
+		return
+	var gone: Callable = _on_field_source_gone.bind(source)
+	if not source.tree_exited.is_connected(gone):
+		source.tree_exited.connect(gone, CONNECT_ONE_SHOT)
+
+
+func _on_field_source_gone(source: Node) -> void:
+	if _field_source != source:
+		return
+	clear_field()
+
+
+## Forgets what the surround is, so a screen taken off leaves the next one
+## untold rather than standing on its colour.
+func clear_field() -> void:
+	_field_source = null
+	if not _field_told:
+		return
+	_field_told = false
+	if _mask != null:
+		_mask.queue_redraw()
 
 
 ## Hides a view switch behind the cartridge's own way of going black.
@@ -594,6 +676,10 @@ func _draw_mask() -> void:
 	var whole := Vector2(_view_size)
 	var backdrop: bool = _backdrop != null \
 		and _backdrop.get_size() == Vector2(whole)
+	# Nothing rather than the default: an untold screen is one standing over
+	# another, and a band of black is what cut the map back to 160x144.
+	if not backdrop and not _field_told:
+		return
 	for band: Rect2 in [
 		Rect2(Vector2.ZERO, Vector2(whole.x, inside.position.y)),
 		Rect2(Vector2(0.0, inside.end.y), Vector2(whole.x, whole.y - inside.end.y)),

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -15,6 +15,8 @@ const CHANNELS: int = 4
 ## per 8x8 tile on each axis.
 const FIELD_STRIDE: int = 4
 const TRANSPARENT := Color(0.0, 0.0, 0.0, 0.0)
+## The alpha byte a picture the hardware could have drawn carries everywhere.
+const OPAQUE: int = 255
 
 ## `PadFrontpic`'s box: every front pic is placed as 7x7 tiles whatever its own
 ## size is.
@@ -408,8 +410,13 @@ static func show(target: TextureRect, image: Image) -> void:
 ## blocks of eight and a quarter of the pixels answers the same question as all
 ## of them for a sixteenth of the walk.
 ##
-## A picture that is transparent where it is sampled has no field: it is a layer
-## over some other screen's, and answering for that screen would be wrong.
+## A picture with any transparency in it has no field at all. The hardware has no
+## alpha, so a screen's own picture is opaque everywhere; one that is not is a
+## layer drawn over another screen -- a `MENU_BACKUP_TILES` box, a sprite pass
+## composed over a background -- and answering for the screen underneath is what
+## painted a black band over the map. Whether the clear pixels outnumber the
+## drawn ones is not the question: a `PokemonCenterPC` menu with a text box
+## under it covers half the screen and still owns none of it.
 static func field_color(image: Image, stride: int = FIELD_STRIDE) -> Color:
 	if image == null or image.is_empty() or image.get_format() != Image.FORMAT_RGBA8:
 		return TRANSPARENT
@@ -428,6 +435,8 @@ static func field_color(image: Image, stride: int = FIELD_STRIDE) -> Color:
 		var x: int = 0
 		while x < width:
 			var at: int = row + x * CHANNELS
+			if data[at + 3] < OPAQUE:
+				return TRANSPARENT
 			var key: int = (
 				data[at] << 24 | data[at + 1] << 16 | data[at + 2] << 8 | data[at + 3]
 			)

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -340,6 +340,14 @@ func _enter_of(index: int) -> StringName:
 	return StringName(_pages[index].get("enter", &"page"))
 
 
+## How many of the page at [param index]'s lines `TextScroll` carried up rather
+## than printed, and so how many of them are already on screen.
+func _carried_of(index: int) -> int:
+	if index < 0 or index >= _pages.size():
+		return 0
+	return int(_pages[index].get("carried", 0))
+
+
 ## Starts `TextScroll`'s two steps, with the lines that are on screen moving up
 ## through the interior and off the top of it.
 func _begin_scroll(next_page: int) -> void:
@@ -398,13 +406,21 @@ func _end_scroll() -> void:
 func _start_page() -> void:
 	_lines = []
 	_tiles_on_page = 0
+	## `TextScroll` copies tiles up and `_ContTextNoPause` resumes at
+	## `TEXTBOX_INNERY + 2`, so the lines the scroll carried are already printed
+	## and the reveal starts past them. Typing them again is a line the player
+	## has read appearing to be new.
+	var carried: int = _carried_of(_page)
+	var already: int = 0
 	if _page < _pages.size():
 		for line: String in _pages[_page]["lines"]:
 			var codes: PackedByteArray = Gen2Text.encode(line)
+			if _lines.size() < carried:
+				already += codes.size()
 			_lines.append(codes)
 			_tiles_on_page += codes.size()
 
-	_shown = 0.0
+	_shown = float(already)
 	_blink = 0.0
 	set_process(_tiles_on_page > 0 and not driven)
 	if reveal_speed <= 0.0:

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -91,12 +91,18 @@ static func lay_out(text: String, columns: int, rows: int) -> Array:
 ## for a press first; `&"scroll"` for `_ContText`, which waits and then runs
 ## `TextScroll` twice; and `&"scroll_nowait"` for `_ContTextNoPause`, which is
 ## the same two scrolls with nothing waited for. The first page is `&"start"`.
+##
+## `carried` is how many of the page's first lines the scroll moved up rather
+## than printed. `TextScroll` copies tiles and `_ContTextNoPause` then writes at
+## `TEXTBOX_INNERY + 2`, so a carried line is already on screen and is never
+## typed a second time.
 static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
 	var out: Array = []
 	if rows <= 0 or columns <= 0:
 		return out
 	var page: PackedStringArray = PackedStringArray()
 	var enter: StringName = &"start"
+	var carried: int = 0
 	var at: int = 0
 	while at <= text.length():
 		var page_at: int = text.find(Gen2TextStream.PAGE_BREAK, at)
@@ -110,25 +116,28 @@ static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
 		for line: String in wrap_lines(segment, columns):
 			page.append(line)
 			if page.size() == rows:
-				out.append({"lines": page, "enter": enter})
+				out.append({"lines": page, "enter": enter, "carried": carried})
 				page = PackedStringArray()
 				enter = &"page"
+				carried = 0
 		if stop < 0:
 			break
 		var scrolled: bool = stop == scroll_at or stop == nowait_at
 		if not page.is_empty():
-			out.append({"lines": page, "enter": enter})
+			out.append({"lines": page, "enter": enter, "carried": carried})
 			page = PackedStringArray()
 		enter = &"page"
+		carried = 0
 		if scrolled:
 			enter = &"scroll" if stop == scroll_at else &"scroll_nowait"
 			if not out.is_empty():
 				var previous: PackedStringArray = out[out.size() - 1]["lines"]
 				if not previous.is_empty():
 					page.append(previous[previous.size() - 1])
+					carried = 1
 		at = stop + 1
 	if not page.is_empty():
-		out.append({"lines": page, "enter": enter})
+		out.append({"lines": page, "enter": enter, "carried": carried})
 	return out
 
 

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -20,7 +20,6 @@ signal closed(result: Dictionary)
 ## The PC is drawn in hardware pixels and the panel it is opened from is ordinary
 ## UI at window resolution, so the screen carries a [Gen2Screen] of its own, the
 ## way [Gen2TownMapScreen] does.
-const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
 ## `PCString_ChooseaPKMN` and `.PartyPKMN`. Both are engine strings inside
 ## `bills_pc.asm` that no script points at, so nothing imports them and they are
@@ -50,6 +49,8 @@ var _scroll: int = 0
 ## transfer answers.
 var _prompt: String = PROMPT_CHOOSE
 var _page: Gen2PCBoxPage = null
+## The screen this is drawn in, and the 160x144 layer inside it.
+var _screen: Gen2Screen = null
 var _field: Control = null
 var _backdrop: Gen2Screen.Field = null
 var _background: TextureRect = null
@@ -238,10 +239,10 @@ func _resolve_save() -> Gen2SaveData:
 
 
 func _build() -> void:
-	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
-	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(screen)
+	var screen: Gen2Screen = Gen2Screen.host_for(self, _screen)
+	if screen == null:
+		return
+	_screen = screen
 	_field = Control.new()
 	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -534,3 +535,16 @@ func close_embedded() -> void:
 	if not _embedded:
 		return
 	closed.emit({"ok": true, "script_value": 0, "changed": false})
+
+
+## The screen the opener wants this drawn in, handed over before it is added to
+## the tree. Without one the field goes in whichever screen this ends up inside.
+func set_screen(screen: Gen2Screen) -> void:
+	_screen = screen
+
+
+## The field lives in a screen this node may not own, so it goes by hand.
+func _exit_tree() -> void:
+	if _field != null:
+		Gen2Screen.drop(_field)
+		_field = null

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -36,8 +36,6 @@ signal cry_requested(species: int)
 ## per-caller mode.
 signal selection_made(party_index: int)
 
-const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
-
 const BACKGROUND: Color = Color("#09111f")
 const PANEL: Color = Color("#14233a")
 const BORDER: Color = Color("#2d4566")
@@ -141,7 +139,9 @@ var _switch_from: int = -1
 var _selecting: bool = false
 var _select_prompt: String = PROMPT_CHOOSE
 
-## The embedded view's own hardware screen and the two pages drawn into it.
+## The hardware screen the embedded view is drawn in, and the two pages drawn
+## into it. Handed over by the opener or found around this node; never a second
+## one over a window that already has one.
 var _hardware: Gen2Screen = null
 var _view: TextureRect = null
 var _page: Gen2PartyMenuPage = null
@@ -673,18 +673,32 @@ func _resolve_save() -> Gen2SaveData:
 
 
 ## `StartMenu_Pokemon`'s screen: the party menu owns all 160x144 of it, so the
-## view goes in a [Gen2Screen] of its own rather than into whatever window-
-## resolution parent added this one.
+## view is laid out in hardware pixels rather than in the window ones of
+## whatever parent added this one. The screen it goes in is the one already at
+## the window ([method Gen2Screen.host_for]), so the list lands exactly on the
+## rectangle the map behind it is drawn in.
 func _build_hardware_ui() -> void:
-	_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
-	_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(_hardware)
+	_hardware = Gen2Screen.host_for(self, _hardware)
+	if _hardware == null:
+		return
 	_view = TextureRect.new()
 	_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_hardware.display(_view)
+
+
+## The screen the opener wants this drawn in, handed over before it is added to
+## the tree. Without one the view goes in whichever screen this ends up inside.
+func set_screen(screen: Gen2Screen) -> void:
+	_hardware = screen
+
+
+## The view lives in a screen this node may not own, so it goes by hand.
+func _exit_tree() -> void:
+	if _view != null:
+		Gen2Screen.drop(_view)
+		_view = null
 
 
 ## One hardware frame of `PlaySpriteAnimations` over the icons. `FreezeMonIcons`

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -34,7 +34,6 @@ enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA, UNOWN }
 ## The dex is drawn in hardware pixels and the start menu it opens over is
 ## ordinary UI at window resolution, so it carries a [Gen2Screen] of its own the
 ## way [Gen2TownMapScreen] does.
-const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
 ## `Pokedex_BlinkArrowCursor` counts its own frames and shows the arrow on the
 ## eight it is off `$8`, so the cursor is up for eight frames and down for eight.
@@ -73,6 +72,8 @@ var _area: Gen2TownMapScreen = null
 
 var _page: Gen2PokedexPage = null
 ## The 160x144 field inside the hardware screen, and the one layer drawn into it.
+## The screen this is drawn in, and the 160x144 layer inside it.
+var _screen: Gen2Screen = null
 var _field: Control = null
 var _background: TextureRect = null
 ## `Pokedex_DisplayChangingModesMessage` and `Pokedex_DisplayTypeNotFoundMessage`
@@ -580,10 +581,10 @@ func advance_frame() -> void:
 
 
 func _build_ui() -> void:
-	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
-	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(screen)
+	var screen: Gen2Screen = Gen2Screen.host_for(self, _screen)
+	if screen == null:
+		return
+	_screen = screen
 	_field = Control.new()
 	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -592,3 +593,16 @@ func _build_ui() -> void:
 	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_field.add_child(_background)
+
+
+## The screen the opener wants this drawn in, handed over before it is added to
+## the tree. Without one the field goes in whichever screen this ends up inside.
+func set_screen(screen: Gen2Screen) -> void:
+	_screen = screen
+
+
+## The field lives in a screen this node may not own, so it goes by hand.
+func _exit_tree() -> void:
+	if _field != null:
+		Gen2Screen.drop(_field)
+		_field = null

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -456,26 +456,26 @@ func _knob_image() -> Image:
 ## through the overworld's first palette the way every icon on these screens is.
 ## Colour zero is transparent, which is what lets one sit over the card.
 func _icon(first: int, columns: int, rows: int, repeat: bool = false) -> Image:
-	var size := Vector2i(columns, rows) * Gen2TownMapPage.TILE
-	var out: PackedInt32Array = Gen2PicImage.canvas(size.x, size.y)
+	var pixels := Vector2i(columns, rows) * Gen2TownMapPage.TILE
+	var out: PackedInt32Array = Gen2PicImage.canvas(pixels.x, pixels.y)
 	var tiles: PackedByteArray = _data.tile_indices("pokegear_sprites") if _data != null \
 		else PackedByteArray()
 	var palette: PackedColorArray = _data.overworld_sprite_palette(0, _time_of_day) \
 		if _data != null else PackedColorArray()
 	if tiles.is_empty() or palette.is_empty():
-		return Gen2PicImage.canvas_image(out, size.x, size.y)
+		return Gen2PicImage.canvas_image(out, pixels.x, pixels.y)
 	@warning_ignore("integer_division")
 	var strip_tiles: int = tiles.size() / Gen2Tiles.TILE_PIXELS
 	var table: PackedInt32Array = Gen2PicImage.lookup(palette)
 	for row: int in rows:
 		for column: int in columns:
 			Gen2PicImage.blit_tile(
-				out, size.x, size.y, tiles, strip_tiles,
+				out, pixels.x, pixels.y, tiles, strip_tiles,
 				first if repeat else first + row * columns + column,
 				column * Gen2TownMapPage.TILE, row * Gen2TownMapPage.TILE,
 				table, false, false, 0
 			)
-	return Gen2PicImage.canvas_image(out, size.x, size.y)
+	return Gen2PicImage.canvas_image(out, pixels.x, pixels.y)
 
 
 ## The screen the opener wants this drawn in, handed over before it is added to

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -24,7 +24,6 @@ signal called(contact: int)
 ## Its DELETE row, once the yes/no box has been answered.
 signal deleted(contact: int)
 
-const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
 const CARD_CLOCK: StringName = &"clock"
 const CARD_PHONE: StringName = &"phone"
@@ -91,6 +90,8 @@ var _submenu_cursor: int = 0
 var _asking_delete: bool = false
 var _yes_no_cursor: int = 0
 
+## The screen this is drawn in, and the 160x144 layer inside it.
+var _screen: Gen2Screen = null
 var _field: Control = null
 var _background: TextureRect = null
 var _arrow: TextureRect = null
@@ -348,10 +349,10 @@ func render() -> Image:
 
 
 func _build() -> void:
-	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
-	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(screen)
+	var screen: Gen2Screen = Gen2Screen.host_for(self, _screen)
+	if screen == null:
+		return
+	_screen = screen
 	_field = Control.new()
 	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -475,3 +476,16 @@ func _icon(first: int, columns: int, rows: int, repeat: bool = false) -> Image:
 				table, false, false, 0
 			)
 	return Gen2PicImage.canvas_image(out, size.x, size.y)
+
+
+## The screen the opener wants this drawn in, handed over before it is added to
+## the tree. Without one the field goes in whichever screen this ends up inside.
+func set_screen(screen: Gen2Screen) -> void:
+	_screen = screen
+
+
+## The field lives in a screen this node may not own, so it goes by hand.
+func _exit_tree() -> void:
+	if _field != null:
+		Gen2Screen.drop(_field)
+		_field = null

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -23,7 +23,6 @@ signal closed()
 ## The region map is drawn in hardware pixels, and the Pokegear's card list it is
 ## opened from is ordinary UI at window resolution, so the screen carries a
 ## [Gen2Screen] of its own rather than trusting whatever it was added to.
-const SCREEN_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
 
 const CURSOR_TILE: int = 0x04
 const ICON_SIZE: int = 16
@@ -77,6 +76,8 @@ var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var _frames: int = 0
 var _open: bool = false
 ## The 160x144 field inside the hardware screen, which everything is drawn into.
+## The screen this is drawn in, and the 160x144 layer inside it.
+var _screen: Gen2Screen = null
 var _field: Control = null
 var _background: TextureRect = null
 var _cursor_icon: TextureRect = null
@@ -379,10 +380,10 @@ func _process(delta: float) -> void:
 ## `_TownMap` spawns the player's struct first, which takes the lower shadow-OAM
 ## indices, and a lower index is the one that shows.
 func _build() -> void:
-	var screen: Gen2Screen = SCREEN_SCENE.instantiate() as Gen2Screen
-	screen.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	add_child(screen)
+	var screen: Gen2Screen = Gen2Screen.host_for(self, _screen)
+	if screen == null:
+		return
+	_screen = screen
 	_field = Control.new()
 	_field.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_field.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -615,3 +616,16 @@ func _icon_position(landmark: int) -> Vector2i:
 	var entry: Dictionary = _data.landmark(landmark)
 	return Vector2i(int(entry.get("x", 0)), int(entry.get("y", 0))) \
 		- Vector2i(ICON_ORIGIN, ICON_ORIGIN)
+
+
+## The screen the opener wants this drawn in, handed over before it is added to
+## the tree. Without one the field goes in whichever screen this ends up inside.
+func set_screen(screen: Gen2Screen) -> void:
+	_screen = screen
+
+
+## The field lives in a screen this node may not own, so it goes by hand.
+func _exit_tree() -> void:
+	if _field != null:
+		Gen2Screen.drop(_field)
+		_field = null

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -849,10 +849,14 @@ func _draw() -> void:
 			Vector2((sprite["cell"] as Vector2i) * Gen2WorldAPI.CELL_PIXELS) - camera_pixels,
 		)
 	## `HealMachineAnim` writes OAM at fixed screen pixels rather than over an
-	## object or a cell, so the camera does not move it.
+	## object or a cell, so the camera does not move it. [method screen_offset]
+	## and not the buffer's own corner: a hardware pixel is measured from the
+	## 160x144 rectangle, which SCREEN FILL puts in the middle of something
+	## wider, and the same offset is what `_draw_transition` reads its cells at.
+	var screen: Vector2 = screen_offset()
 	for sprite: Dictionary in _effect_sprites():
 		if bool(sprite.get("screen", false)):
-			_draw_effect_sprite(sprite, Vector2.ZERO)
+			_draw_effect_sprite(sprite, screen)
 	_draw_encounter_pulse(camera_pixels)
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4552,6 +4552,7 @@ func _open_service_host() -> void:
 		return
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 20
+	host.set_screen(_screen)
 	add_child(host)
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	var persist: bool = save != null and _injected_save == null
@@ -4797,6 +4798,7 @@ func _open_pokedex() -> void:
 		_refresh_labels()
 		return
 	host.z_index = 10
+	host.set_screen(_screen)
 	add_child(host)
 	host.closed.connect(_on_pokedex_closed)
 	host.cry_requested.connect(_on_pokedex_cry_requested)
@@ -5045,6 +5047,7 @@ func _open_embedded_party() -> void:
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 20
 	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	host.set_screen(_screen)
 	add_child(host)
 	host.closed.connect(_on_party_closed)
 	host.action_chosen.connect(_on_party_action)
@@ -5518,6 +5521,7 @@ func _open_service_overlay(kind: StringName) -> void:
 		return
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 20
+	host.set_screen(_screen)
 	add_child(host)
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	var persist: bool = save != null and _injected_save == null
@@ -5548,6 +5552,7 @@ func _open_fly_map(request: Dictionary) -> void:
 		return
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 20
+	host.set_screen(_screen)
 	add_child(host)
 	var save: Gen2SaveData = _injected_save if _injected_save != null \
 		else _selected_runtime_save()
@@ -6041,6 +6046,7 @@ func _open_party_selection() -> bool:
 	host.selection_made.connect(_on_party_selection_made)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_on_pokedex_cry_requested)
+	host.set_screen(_screen)
 	add_child(host)
 	host.open_selection()
 	_party_host = host

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -31,9 +31,6 @@ enum MODE {
 ## region map, so the top menu is still there when the box screen closes.
 const BOX_SCENE := preload("res://game/save/box_screen.tscn")
 
-## `BuyMenu`'s own 160x144, which a window-resolution panel cannot host.
-const HARDWARE_SCENE: PackedScene = preload("res://game/render/gen2_screen.tscn")
-
 ## engine/pokegear/pokegear.asm's card order. Each is behind its own
 ## wPokegearFlags bit, named here by the engine flag that carries it, since that
 ## is what the state holds. The clock card needs no flag.
@@ -92,10 +89,9 @@ var _mart: Dictionary = {}
 var _mart_entries: Array = []
 var _mart_quantity: int = 1
 var _mart_purchased: bool = false
-## `BuyMenu`'s screen, which owns all 160x144 the way the region map does: the
+## `BuyMenu`'s own layer, which owns all 160x144 the way the region map does: the
 ## scrolling list's own scroll and cursor, which of `BuyMenuLoop`'s four states
 ## it is in, and the boxes waiting on a press.
-var _mart_hardware: Gen2Screen = null
 var _mart_view: TextureRect = null
 var _mart_page: Gen2MartPage = null
 var _mart_menu_page: Gen2MenuPage = null
@@ -132,6 +128,8 @@ var _pc_after: StringName = &"top"
 var _pc_label: String = ""
 var _boxes: Gen2BoxScreen = null
 
+## The screen every layer here is drawn in: the one the opener handed over, so
+## the menu box stands on the map's own 160x144 rather than beside it.
 var _service_hardware: Gen2Screen = null
 ## Whether the hardware layer holds an image for the mode this host is in, and
 ## whether a screen of its own is standing over both layers. [method
@@ -152,6 +150,22 @@ func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_STOP
 	set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	_build_ui()
+
+
+## The screen this panel's layers are drawn in, handed over before it is added
+## to the tree: the world's own, so a `MenuTextbox` over the map is composited
+## with the map instead of standing in a screen of its own beside it.
+func set_screen(screen: Gen2Screen) -> void:
+	_service_hardware = screen
+
+
+## Both views live in a screen this node may not own, so they go by hand.
+func _exit_tree() -> void:
+	for view: TextureRect in [_service_view, _mart_view]:
+		if view != null:
+			Gen2Screen.drop(view)
+	_service_view = null
+	_mart_view = null
 
 
 ## Opens the host for whatever pending input the world currently exposes.
@@ -291,11 +305,9 @@ func selected_index() -> int:
 
 
 func _build_ui() -> void:
-	_service_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
-	_service_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	_service_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	_service_hardware.z_index = 4
-	add_child(_service_hardware)
+	_service_hardware = Gen2Screen.host_for(self, _service_hardware)
+	if _service_hardware == null:
+		return
 	_service_view = TextureRect.new()
 	_service_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_service_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
@@ -333,17 +345,15 @@ func _open_mart(mart: Dictionary) -> void:
 	_mart_scroll = 0
 	_cursor = 0
 	_set_overlay_open(true)
-	if _mart_hardware == null:
-		_mart_hardware = HARDWARE_SCENE.instantiate() as Gen2Screen
-		_mart_hardware.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-		_mart_hardware.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		_mart_hardware.z_index = 5
-		add_child(_mart_hardware)
+	if _mart_view == null and _service_hardware != null:
 		_mart_view = TextureRect.new()
 		_mart_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_mart_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 		_mart_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		_mart_hardware.display(_mart_view)
+		## Displayed after the panel's own view, which is [method
+		## Gen2Screen.display]'s z-order: the shop owns all 160x144 while it is
+		## up and the menu behind it is hidden anyway.
+		_service_hardware.display(_mart_view)
 	_show_mart_text(_mart_text("intro"), MART_LIST)
 
 
@@ -581,9 +591,8 @@ func _leave_mart() -> void:
 
 
 func _close_mart() -> void:
-	if _mart_hardware != null:
-		Gen2Screen.drop(_mart_hardware)
-		_mart_hardware = null
+	if _mart_view != null:
+		Gen2Screen.drop(_mart_view)
 		_mart_view = null
 	_set_overlay_open(false)
 
@@ -919,6 +928,7 @@ func _open_boxes() -> void:
 	_set_overlay_open(true)
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 5
+	host.set_screen(_service_hardware)
 	add_child(host)
 	host.set_context(_data, _save, _persist, true)
 	host.closed.connect(_on_boxes_closed)
@@ -967,6 +977,7 @@ func _open_card(card: StringName) -> void:
 	_set_overlay_open(true)
 	_pokegear = Gen2PokegearScreen.new()
 	_pokegear.z_index = 5
+	_pokegear.set_screen(_service_hardware)
 	add_child(_pokegear)
 	_pokegear.closed.connect(_on_card_closed)
 	_pokegear.switched.connect(_on_card_switched)
@@ -1120,6 +1131,7 @@ func open_fly_map(
 	_set_overlay_open(true)
 	_town_map = Gen2TownMapScreen.new()
 	_town_map.z_index = 5
+	_town_map.set_screen(_service_hardware)
 	add_child(_town_map)
 	_town_map.closed.connect(_on_town_map_closed)
 	var visited: Array[int] = []
@@ -1147,6 +1159,7 @@ func _open_town_map(from_request: bool) -> void:
 	_set_overlay_open(true)
 	_town_map = Gen2TownMapScreen.new()
 	_town_map.z_index = 5
+	_town_map.set_screen(_service_hardware)
 	add_child(_town_map)
 	_town_map.closed.connect(_on_town_map_closed)
 	# The Pokegear's own MAP card when the Pokegear opened it, `_TownMap`'s
@@ -1345,8 +1358,8 @@ func _set_overlay_open(open: bool) -> void:
 ## never before a service has opened. Setting it by hand at each entrance is what
 ## left it standing behind whatever the mode drew.
 func _apply_layer_visibility() -> void:
-	if _service_hardware != null:
-		_service_hardware.visible = _mode >= 0 and not _overlay_open and _service_drawn
+	if _service_view != null:
+		_service_view.visible = _mode >= 0 and not _overlay_open and _service_drawn
 
 
 func _is_dial() -> bool:

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -130,6 +130,20 @@ func _open_world(source: String) -> Node:
 	return _world_screen._renderer
 
 
+## The built-in [Gen2WorldRenderer], which is what the game draws with unless a
+## mod has been chosen.
+func _open_built_in_world() -> Gen2WorldRenderer:
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	return _world_screen._renderer as Gen2WorldRenderer
+
+
 func _open_battle() -> Node:
 	assert_true(
 		Gen2ModHost.instance().register_battle_renderer(&"native", _script(NATIVE_SOURCE))["ok"]
@@ -850,6 +864,18 @@ func test_a_native_layer_battle_fills_its_own_surround_and_the_built_in_one_is_f
 	await get_tree().process_frame
 	assert_true(_battle_screen._screen.expanded)
 	assert_true(_battle_screen._screen.interface_masked, "and the screen fills it")
+
+
+## `HealMachineAnim` writes OAM at fixed hardware-screen pixels, and so does
+## `DoBattleTransition`'s own twenty by eighteen grid. Both are drawn from the
+## renderer's own [method Gen2WorldRenderer.screen_offset], which has to be
+## where the screen puts the 160x144 rectangle: the buffer's corner is outside
+## it, and the machine's poke balls were drawn out over the wall.
+func test_a_fixed_screen_pixel_is_the_rectangle_the_interface_is_in() -> void:
+	var renderer: Gen2WorldRenderer = await _open_built_in_world()
+	var screen: Gen2Screen = _world_screen._screen
+	assert_gt(screen.interface_origin().x, 0, "the buffer is wider than the screen")
+	assert_eq(Vector2i(renderer.screen_offset()), screen.interface_origin())
 
 
 ## A hardware-pixel number means nothing on the native layer without the

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -148,8 +148,8 @@ func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
 	## `BuyMenu` owns the whole screen, so this host's own layer steps aside.
-	assert_false(host._service_hardware.visible)
-	assert_not_null(host._mart_hardware)
+	assert_false(host._service_view.visible)
+	assert_not_null(host._mart_view)
 	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
 	## One item and CANCEL, which is the row `ScrollingMenu` draws past the
 	## list's own terminator.
@@ -467,17 +467,47 @@ func test_only_one_service_layer_is_ever_on_screen() -> void:
 	await _queue_service()
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
-	assert_true(host._service_hardware.visible, "the hardware layer draws the mode")
+	assert_true(host._service_view.visible, "the hardware layer draws the mode")
 	## DEPOSIT ITEM's own list is still the one layer.
 	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_ITEM_LIST)
-	assert_true(host._service_hardware.visible)
+	assert_true(host._service_view.visible)
 	## A screen of its own owns all 160x144, so nothing is drawn under it.
 	host._open_town_map(false)
-	assert_false(host._service_hardware.visible)
+	assert_false(host._service_view.visible)
 	host._town_map.close()
 	await get_tree().process_frame
+
+
+## `MenuTextbox` carries `MENU_BACKUP_TILES`: the map stays visible around the
+## box, so the panel is drawn in the screen the map is already in rather than in
+## a second one over it. Two screens over one window each pick their own scale
+## and their own place for the hardware rectangle, and each paints a surround
+## the other did not ask for, which is what cut the map back to 160x144 with
+## black bars around it.
+func test_a_menu_over_the_map_is_drawn_in_the_maps_own_screen() -> void:
+	Gen2OptionsStore.use_test_path()
+	Gen2OptionsStore.current().screen_fill = true
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	await _queue_service()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_eq(host._service_hardware, _world_screen._screen, "the map's own screen")
+	assert_eq(
+		host.find_children("*", "Gen2Screen", true, false), [],
+		"and no second one of its own",
+	)
+	assert_eq(
+		Gen2Screen.owner_of(host._service_view), _world_screen._screen,
+		"so the panel is laid out on the same 160x144 the map is drawn in",
+	)
+	## Nothing has said what the world's screen stands on, because the panel is
+	## transparent everywhere but its own box. An untold screen paints no
+	## surround, so what is around the box is the map.
+	assert_false(_world_screen._screen.has_field())
 
 
 ## The other half of the same rule: the radio card is what writes

--- a/tests/unit/test_game_frame.gd
+++ b/tests/unit/test_game_frame.gd
@@ -203,6 +203,54 @@ func test_a_layer_over_a_screen_does_not_answer_for_it() -> void:
 	assert_eq(screen.surround_color, Color.WHITE, "the screen under it still owns it")
 
 
+## Until something says what the field is, there is no surround to paint.
+## "Not told yet" is not "told it is black": a screen laid out over another one
+## -- a menu box over the map -- has no field of its own, and a band of the
+## default cut the map back to 160x144 with bars around it.
+func test_a_screen_nothing_has_told_paints_no_surround() -> void:
+	var screen: Gen2Screen = _built()
+	assert_false(screen.has_field(), "nothing has said what it stands on")
+	var view := TextureRect.new()
+	screen.display(view)
+	Gen2PicImage.show(view, _picture(Color(0, 0, 0, 0), Color.BLACK))
+	assert_false(screen.has_field(), "and a transparent overlay says nothing")
+
+
+## And it forgets when the screen that told it goes, so the next one starts from
+## untold rather than standing on a colour it never drew.
+func test_the_field_goes_with_the_screen_that_drew_it() -> void:
+	var screen: Gen2Screen = _built()
+	var view := TextureRect.new()
+	screen.display(view)
+	Gen2PicImage.show(view, _picture(Color.WHITE, Color.BLACK))
+	assert_true(screen.has_field())
+	Gen2Screen.drop(view)
+	await wait_process_frames(2)
+	assert_false(screen.has_field())
+
+
+## One window, one screen. A host asks for the screen it is standing in rather
+## than building a second over it: two viewports each pick their own scale and
+## their own place for the hardware rectangle, so an overlay meant to sit on the
+## map is drawn at a different size beside it.
+func test_a_host_inside_a_screen_is_given_that_screen() -> void:
+	var screen: Gen2Screen = _built()
+	var host := Control.new()
+	screen.display(host)
+	assert_eq(Gen2Screen.host_for(host), screen)
+	assert_eq(Gen2Screen.host_for(host, screen), screen, "and a handover wins")
+
+
+## A host opened on its own -- the launcher's PC, a preview -- really does need
+## one, and gets it over itself.
+func test_a_host_outside_every_screen_gets_one_of_its_own() -> void:
+	var host := Control.new()
+	add_child_autofree(host)
+	var screen: Gen2Screen = Gen2Screen.host_for(host)
+	assert_not_null(screen)
+	assert_eq(screen.get_parent(), host)
+
+
 ## Half the screens here are drawn as a colour rather than as a picture, so the
 ## field they stand on is the same seam.
 func test_a_screen_drawn_as_a_colour_says_so_too() -> void:

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -98,9 +98,22 @@ func test_a_page_says_how_it_was_reached() -> void:
 	## not.
 	assert_eq(pages[1]["lines"], PackedStringArray(["b"]))
 	assert_eq(pages[2]["lines"], PackedStringArray(["b", "c"]))
+	## And says so, because a carried line was moved up as tiles rather than
+	## typed and must not be typed again.
+	assert_eq(int(pages[1]["carried"]), 0)
+	assert_eq(int(pages[2]["carried"]), 1)
 
 
 const FRAME: float = Gen2TextBox.FRAME_SECONDS
+
+
+## What a box printing [param text] as one page owes, for comparing a scrolled
+## page against a whole one.
+func _owed(text: String) -> int:
+	var box: Gen2TextBox = _box()
+	box.reveal_speed = 30.0
+	box.show_text(text)
+	return box.frames_left()
 
 
 func _box() -> Gen2TextBox:
@@ -174,6 +187,30 @@ func test_a_continuation_scrolls_for_ten_frames_after_its_press() -> void:
 	box._process(FRAME)
 	assert_false(box.is_revealing())
 	assert_false(box.has_pages_left(), "the second page is up")
+
+
+## `TextScroll` copies the interior up a row at a time and `_ContTextNoPause`
+## then writes at `TEXTBOX_INNERY + 2`, so the line that moved to the top is
+## already on screen and the reveal starts on the bottom row. Typing it again is
+## a line the player has read appearing to be new.
+func test_a_scrolled_line_is_not_typed_a_second_time() -> void:
+	var box: Gen2TextBox = _box()
+	box.reveal_speed = 30.0
+	box.show_text("above" + Gen2TextStream.SCROLL_BREAK + "below")
+	for _frame: int in box.frames_left():
+		box.advance_frame()
+	assert_false(box.is_revealing(), "the first page is printed")
+
+	assert_true(box.advance())
+	for _frame: int in Gen2TextBox.SCROLL_STEP_FRAMES * Gen2TextBox.SCROLL_STEPS:
+		box.advance_frame()
+	## Only the bottom row is left to type. A page that re-revealed the line it
+	## carried would owe both rows.
+	var fresh: Gen2TextBox = _box()
+	fresh.reveal_speed = 30.0
+	fresh.show_text("below")
+	assert_eq(box.frames_left(), fresh.frames_left())
+	assert_lt(box.frames_left(), _owed("above below"), "not both rows")
 
 
 ## `_ContTextNoPause` has no `PromptButton` in front of those two scrolls, so

--- a/tools/checks/item_balls.gd
+++ b/tools/checks/item_balls.gd
@@ -80,6 +80,30 @@ const HIDDEN_ITEMS: Array[Dictionary] = [
 ]
 
 
+## `data/items/fruit_trees.asm`'s whole `FruitTreeItems`, in `FRUITTREE_*` order
+## and byte identical between the two pins, named as `data/items/names.asm` names
+## them. `GetFruitTreeItem` indexes this at the `fruittree` operand less one.
+##
+## Pinned by name rather than by number because the question a player asks about
+## a tree is what the bag then says: `BERRY` really is what four Johto trees and
+## Route 11 bear, Oran and Sitrus being a Gen 3 renaming, and the table has no
+## terminator and no pointer, so nothing but its contents says it decoded at the
+## right offset.
+const FRUIT_TREE_ITEMS: Array[String] = [
+	"BERRY", "BERRY", "BERRY", "BERRY",
+	"PSNCUREBERRY", "PSNCUREBERRY",
+	"BITTER BERRY", "BITTER BERRY",
+	"PRZCUREBERRY", "PRZCUREBERRY",
+	"MYSTERYBERRY", "MYSTERYBERRY",
+	"ICE BERRY", "ICE BERRY",
+	"MINT BERRY", "BURNT BERRY",
+	"RED APRICORN", "BLU APRICORN", "BLK APRICORN", "WHT APRICORN",
+	"PNK APRICORN", "GRN APRICORN", "YLW APRICORN",
+	"BERRY", "PSNCUREBERRY", "BITTER BERRY", "PRZCUREBERRY",
+	"ICE BERRY", "MINT BERRY", "BURNT BERRY",
+]
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	for game_id: StringName in _r.GAME_IDS:
@@ -90,7 +114,23 @@ func run(r: RefCounted) -> void:
 		_verify_hm07(data, game_id)
 		_verify_route_44(data, game_id)
 		_verify_hidden_items(data, game_id)
+		_verify_fruit_trees(data, game_id)
 		_sweep_the_public_read(data, game_id)
+
+
+## Every tree, read the way the `fruittree` command reads one.
+func _verify_fruit_trees(data: GameData, game_id: StringName) -> void:
+	var names: Array[String] = []
+	for tree: int in range(1, FRUIT_TREE_ITEMS.size() + 1):
+		names.append(data.item_name(data.world_fruit_tree_item(tree)))
+	if not _r.check(
+		names == FRUIT_TREE_ITEMS,
+		"%s fruit trees bear %s." % [game_id, str(names)],
+	):
+		return
+	_r.note("%s: %d fruit trees, each the source's own item." % [
+		game_id, FRUIT_TREE_ITEMS.size(),
+	])
 
 
 ## The one that unblocks the route: picking HM07 up puts Waterfall in the bag,


### PR DESCRIPTION
Four reported defects. Three were code; the fourth was not a defect.

## A black band around the map

Talk to the Pokemon Center nurse and reach the yes/no, or use a PC, and the
map behind the box was cut back to Game Boy size with black bars around it.
So was an evolution's first box, the Day-Care's, and the Name Rater's.

Two causes.

A screen nothing had told what it stood on painted black. "Not told yet" and
"told it is black" are different states now, and an untold screen paints no
surround at all. A picture with any transparency in it tells it nothing: the
hardware has no alpha, so a picture that is not opaque everywhere is a layer
over another screen. That holds whether or not its clear pixels outnumber its
drawn ones, which matters: a PC menu with a text box under it covers half the
screen and owns none of it. A field belongs to whoever drew it and is
forgotten when that node goes, the way a backdrop already was.

And six hosts built a screen of their own over the one already at the window:
the service panel and the shop inside it, the Pokedex, the region map, the
Pokegear, the boxes, the party. Two viewports over one window each pick their
own scale and their own place for the 160x144 rectangle. So a Pokegear card
was drawn a whole step larger than the map behind it, beside the rectangle
the map's own boxes sit in, and each screen painted a surround the other had
not asked for. `Gen2Screen.host_for` answers with the screen handed over,
else the one the node already stands in, else a new one. Only a host opened
on its own, the launcher's PC or a preview, reaches that last case. The start
menu was already this shape and is now what all seven do.

## The heal machine drew in the corner

Every healing station, the Pokemon Center's and Prof. Elm's, put its poke
balls at the top left over the wall. `HealMachineAnim` writes OAM at fixed
hardware-screen pixels and the map renderer fills the whole buffer, so those
pixels landed in the buffer's corner instead of inside the 160x144 rectangle
the interface is centred in. Both fixed-screen draws the renderer has, that
one and `DoBattleTransition`'s cells, read `screen_offset` now. Measured: the
sprite moved exactly 80 by 32 hardware pixels in a 1600x900 window, which is
the interface origin, and nothing else about it moved.

## A scrolled line was typed again

Advancing a text box re-revealed the line that had just moved up, so a line
you had already read looked new. `TextScroll` copies the interior up a row at
a time and `_ContTextNoPause` then writes at `TEXTBOX_INNERY + 2`, so the
line that reaches the top row is already on screen and only the bottom row is
printed. The layout says how many lines a page carried and the box starts the
reveal past them.

## Berries

`BERRY` is the item's real name. `data/items/names.asm` lists it beside
`PSNCUREBERRY`, `PRZCUREBERRY`, `BITTER BERRY`, `ICE BERRY`, `MINT BERRY`,
`BURNT BERRY`, `MIRACLEBERRY`, `MYSTERYBERRY` and `GOLD BERRY`. Oran and
Sitrus are a Gen 3 renaming. No change, but all thirty rows of
`FruitTreeItems` are pinned in the `item_balls` check topic by the name the
bag prints, on all three cartridges, so this is checked rather than asserted.

## Proof

| Check | Result |
|---|---|
| Unit tier | 3,125 tests |
| Full tier | 3,616 tests, up 7 |
| `validate.gd -- all` | exit 0, 67 topics |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 16 badges each, paths 295 / 292 / 292 |
| Editor warnings | 0 in this tree |

The opening screens, the standalone party and the PC boxes are pixel
identical before and after. The mart, the party over the map and the Pokegear
differ, which is the fix: they are drawn at the map's own scale now.