### PR TITLE
Count a step the way CountStep does, guards and all

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2347,6 +2347,32 @@ func request_incoming_phone_call(
 	return _start_phone_ring(request)
 
 
+## `Script_SpecialBillCall`: `LoadCallerScript PHONE_BILL` and then
+## `Script_ReceivePhoneCall`, which is the same two rings an incoming call
+## spends. Nothing gates it, so the only caller is the event that owes it.
+func request_caller_phone_call(contact_id: int) -> Array:
+	if phone_ring_active():
+		return [{"ok": true, "status": &"phone_ring", "event": pending_phone_ring()}]
+	if current_map == null:
+		return [{"ok": false, "status": &"phone_unavailable", "reason": &"missing_map"}]
+	var resolved: Dictionary = Gen2WorldPhoneHost.resolve_caller(data, contact_id)
+	if not bool(resolved.get("ok", false)):
+		return [{
+			"ok": false, "status": &"phone_unavailable",
+			"reason": resolved.get("reason", &"phone_unavailable"),
+		}]
+	return _start_phone_ring({
+		"kind": &"phone_incoming",
+		"map_group": current_map.group,
+		"map_number": current_map.number,
+		"bank": int(resolved["script"]["bank"]),
+		"script": int(resolved["script"]["address"]),
+		"phone": resolved["phone"],
+		"contact": resolved["contact"],
+		"reset_receive_timer": true,
+	})
+
+
 ## Queues a source-style special call. The pending call remains in world state
 ## until the imported phone script clears VAR_SPECIALPHONECALL.
 func request_special_phone_call(call_id: int) -> Array:
@@ -2372,6 +2398,29 @@ func request_special_phone_call(call_id: int) -> Array:
 		"reset_receive_timer": true,
 	}
 	return _start_phone_ring(request, 30)
+
+
+## `CheckSpecialPhoneCall`'s own carry, without starting the call: a pending
+## call whose condition holds ends the step at `CountStep`'s first test, so
+## [method count_step] charges nothing on the step the phone rings.
+func special_phone_call_ready() -> bool:
+	if state == null or current_map == null:
+		return false
+	var call_id: int = state.pending_special_phone_call()
+	if call_id <= 0:
+		return false
+	return bool(Gen2WorldPhoneHost.resolve_special(
+		data, current_map, call_id, world_hour
+	).get("ok", false))
+
+
+## `CountStep` whole: the two guards in front of the counters, which every step
+## taken here goes through. A special call about to ring and a Repel that has
+## just worn off each reach `.doscript`, and neither step is counted.
+func count_step() -> bool:
+	if state == null or special_phone_call_ready():
+		return false
+	return state.count_step()
 
 
 ## Checks the pending special call before ordinary step effects, matching the
@@ -5411,7 +5460,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 		kind = &"water_move"
 	player_cell = destination
 	player_facing = facing_for_direction(direction)
-	state.count_step()
+	count_step()
 	_advance_followers(-1, from_cell)
 	_do_step(direction)
 	_start_player_step(direction, _step_frames_for_movement())
@@ -5515,7 +5564,7 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	var from_cell: Vector2i = player_cell
 	player_cell = destination
 	player_facing = facing_for_direction(direction)
-	state.count_step()
+	count_step()
 	_advance_followers(-1, from_cell)
 	_do_step(direction)
 	_start_player_step(direction, STEP_PASSES_WALK)
@@ -5624,7 +5673,7 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	var from_cell: Vector2i = player_cell
 	player_cell = landing
 	player_facing = facing_for_direction(direction)
-	state.count_step()
+	count_step()
 	_advance_followers(-1, from_cell)
 	_do_step(direction)
 	_start_player_step(direction * 2, STEP_PASSES_HOP, true)
@@ -6438,6 +6487,11 @@ func reload_current_map() -> Dictionary:
 	# EnterMap and takes its five-step cooldown with it: that is what stops a
 	# second wild the step after the first.
 	state.set_wild_encounter_cooldown(Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS)
+	# `EnterMap`'s one entry-method branch: `hMapEntryMethod` is
+	# MAPSETUP_RELOADMAP here and nowhere else, and that method alone zeroes
+	# `wPoisonStepCount`. So a battle, a `reloadmap` and the catch tutorial each
+	# start the four-step poison phase again, and a warp or a door does not.
+	state.clear_poison_step_count()
 	_load_objects()
 	return {"ok": true, "kind": &"reload_map", "map": map_id(), "cell": player_cell}
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -917,6 +917,7 @@ static func capture_wild(
 	var outcome: Dictionary = _capture_outcome(world.data, wild, ball, generator)
 	var candidate: Gen2SaveData = opened["candidate"]
 	var destination: Dictionary = {}
+	var box_full: bool = false
 	if bool(outcome.get("caught", false)):
 		var captured: Gen2SaveMon = _captured_mon(world.data, save, wild, generator)
 		if captured == null:
@@ -934,6 +935,7 @@ static func capture_wild(
 			return _failure(StringName(destination.get("reason", &"storage_full")), {
 				"ball": ball, "outcome": outcome,
 			})
+		box_full = _fills_its_box(candidate, destination)
 	var before: Gen2WorldSnapshot = world.snapshot()
 	## After the snapshot the rollback below restores, so a refused candidate
 	## save takes the dex flag back with the ball.
@@ -951,6 +953,11 @@ static func capture_wild(
 	)
 	if not bool(committed.get("ok", false)):
 		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	## `.SendToPC`'s own `cp MONS_PER_BOX`: the catch that fills a box raises
+	## BATTLERESULT_BOX_FULL, which `Script_reloadmapafterbattle` answers with
+	## `Script_SpecialBillCall` once the battle is over. Behind the commit, so a
+	## catch that was rolled back owes no phone call.
+	world.state.set_battle_box_full(box_full)
 	return {
 		"ok": true,
 		"handled": true,
@@ -961,7 +968,20 @@ static func capture_wild(
 		"wobbles": int(outcome.get("wobbles", 0)),
 		"species": wild.species,
 		"destination": destination.duplicate(true),
+		"box_full": box_full,
 	}
+
+
+## `.SendToPC`'s `ld a, [sBoxCount] / cp MONS_PER_BOX`, read after the deposit:
+## the box the catch landed in has no room left. The save model keeps no
+## current-box pointer, so the box asked about is the one the deposit picked,
+## which is what [method Gen2SaveData.box_free_space] already answers scripts
+## with.
+static func _fills_its_box(save: Gen2SaveData, destination: Dictionary) -> bool:
+	if save == null or StringName(destination.get("destination", &"")) != &"box":
+		return false
+	var box: Gen2SaveBox = save.boxes[int(destination.get("box", -1))] as Gen2SaveBox
+	return box != null and box.occupied_count() >= Gen2SaveBox.CAPACITY
 
 
 ## `CheckPartyFullAfterContest`, which is what takes home whatever the Bug

--- a/game/world/world_phone_host.gd
+++ b/game/world/world_phone_host.gd
@@ -187,6 +187,38 @@ static func registered_contact_summaries(data: GameData, state: Gen2WorldState) 
 	return summaries
 
 
+## `PHONE_BILL`, the one contact an event rather than the player or the timer
+## can put on the line. Third in `PhoneContacts` on all three cartridges.
+const CONTACT_BILL: int = 3
+
+
+## `LoadCallerScript`: the contact's own *caller* script, which is
+## `PHONE_CONTACT_SCRIPT2` and the one `Script_ReceivePhoneCall`'s `memcall`
+## runs. No entrance, timer, roll, registration or time test stands in front of
+## it: the event that asks for the call has already decided there is one.
+static func resolve_caller(data: GameData, contact_id: int) -> Dictionary:
+	if data == null:
+		return _phone_unavailable(&"phone_data_unavailable")
+	var contact: Dictionary = data.world_phone_contact(contact_id)
+	if contact.is_empty():
+		return _phone_unavailable(&"phone_contact_missing")
+	var script: Dictionary = contact.get("caller_script", {})
+	if script.is_empty():
+		return _phone_unavailable(&"phone_caller_script_missing")
+	return {
+		"ok": true,
+		"contact": contact.duplicate(true),
+		"contact_id": contact_id,
+		"role": &"caller",
+		"script": script.duplicate(true),
+		"phone": {
+			"contact_id": contact_id,
+			"caller_id": contact_id,
+			"role": &"caller",
+		},
+	}
+
+
 static func resolve_special(
 	data: GameData, map: Gen2WorldMap, call_id: int, _hour: int
 ) -> Dictionary:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2248,13 +2248,18 @@ func _after_map_settled() -> bool:
 	## `CountStep`, and only then `RandomEncounter`. A poison pass that reaches a
 	## script answers with carry, so the step it runs on rolls no wild, and
 	## `CheckTimeEvents` below is a caller further on.
-	if _spend_poison_steps():
-		return true
+	##
+	## `CheckSpecialPhoneCall` is `CountStep`'s first test and stands in front of
+	## the counters, so the step a special call rings on is charged nothing:
+	## [method Gen2WorldAPI.count_step] already refused it, and the poison pass
+	## below reads the counter that refusal left standing.
 	var special_attempt: Dictionary = _world.try_special_phone_call()
 	var special_results: Array = special_attempt.get("results", [])
 	if bool(special_attempt.get("attempted", false)) and not special_results.is_empty():
 		_zero_map_name_sign_timer()
 		_show_script_results(special_results)
+		return true
+	if _spend_poison_steps():
 		return true
 	var phone_attempt: Dictionary = _world.try_receive_phone_call(_encounter_random)
 	var phone_results: Array = phone_attempt.get("results", [])
@@ -4416,7 +4421,23 @@ func _finish_battle_exit(result: Dictionary, fought_save: Gen2SaveData) -> void:
 	## a battle leaves through a map reload, and that reload is what puts the
 	## map's own track back over the one `PlayBattleMusic` started.
 	_play_current_map_music()
+	_start_box_full_call()
 	_refresh_labels()
+
+
+## `Script_reloadmapafterbattle`'s `.was_wild` branch: a catch that filled its
+## box staged `Script_SpecialBillCall` with `LoadMemScript`, so Bill rings once
+## the map is back. The flag is spent whether or not the call could be placed,
+## which is what clearing `wBattleResult` on the way out of the script does.
+func _start_box_full_call() -> void:
+	if _world == null or not _world.state.battle_box_full():
+		return
+	_world.state.set_battle_box_full(false)
+	var results: Array = _world.request_caller_phone_call(
+		Gen2WorldPhoneHost.CONTACT_BILL
+	)
+	if not results.is_empty() and bool(results[0].get("ok", false)):
+		_show_script_results(results)
 
 
 ## `EvoStoneEffect`'s evolution, which the pack has already applied: only the
@@ -5830,6 +5851,9 @@ func _show_script_results(results: Array) -> void:
 	var waiting: bool = false
 	var failed: bool = false
 	var map_changed: bool = false
+	## `Script_reloadmap`'s own entry method, which a warp does not share: only
+	## this one re-enters the map the player is already standing on.
+	var map_reloaded: bool = false
 	var clock_changed: bool = false
 	var blacked_out: bool = false
 	for source_result: Dictionary in results:
@@ -5896,6 +5920,7 @@ func _show_script_results(results: Array) -> void:
 				clock_changed = true
 			elif result_event.get("type", &"") == &"battle_map_reload_requested":
 				map_changed = true
+				map_reloaded = true
 			elif result_event.get("type", &"") == &"blackout":
 				## `Script_reloadmapafterbattle`'s LOSE branch, which is
 				## `ScriptJump Script_BattleWhiteout` and ends the script: the
@@ -6080,7 +6105,11 @@ func _show_script_results(results: Array) -> void:
 			## A warp redraws the whole tilemap, so a balance window a script
 			## left standing goes with it the way `closetext`'s redraw takes it.
 			_hide_money_window()
-			_world.reload_current_map()
+			## A warp has already run `_apply_map`, which is `EnterMap` whole;
+			## re-entering it here would take MAPSETUP_RELOADMAP's own poison
+			## reset on a step that never asked for one.
+			if map_reloaded:
+				_world.reload_current_map()
 			_animation.configure(_world, _render_time_of_day())
 			_set_renderer_world()
 			_renderer.set_time_of_day(_render_time_of_day())

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -139,6 +139,8 @@ var _repel_steps: int = 0
 ## Set by the step that took `_repel_steps` from one to zero and cleared by
 ## whoever spends it. See [method take_repel_expired].
 var _repel_expired: bool = false
+## `wBattleResult`'s BATTLERESULT_BOX_FULL bit. See [method battle_box_full].
+var _battle_box_full: bool = false
 ## `wWildEncounterCooldown`, which `EnterMap` sets to five and every step
 ## decrements. Scratch on the cartridge rather than saved data, kept here
 ## because this is where the world's own per-step counters live; a state written
@@ -149,8 +151,8 @@ var _wild_encounter_cooldown: int = 0
 ## counters that wrap. `wStepCount` wrapping to zero is what `jr nz` reads to
 ## reach `StepHappiness`, and `wHappinessStepCount`'s `and 1` makes that act on
 ## every second visit, so the party gains a point every 512 steps.
-## `wPoisonStepCount` has no reader here yet: field poison is not built, and the
-## byte is counted anyway so the reader that arrives needs no migration.
+## `wPoisonStepCount` is what `CountStep`'s own `cp 4` reads before it calls
+## `DoPoisonStep`, and `EnterMap` zeroes it on MAPSETUP_RELOADMAP alone.
 var _step_count: int = 0
 var _poison_step_count: int = 0
 var _happiness_step_count: int = 0
@@ -850,6 +852,22 @@ func just_battled() -> bool:
 	return _just_battled
 
 
+## `wBattleResult`'s BATTLERESULT_BOX_FULL bit, raised by `.SendToPC` when the
+## caught Pokemon was the one that filled its box and read by
+## `Script_reloadmapafterbattle`, which answers it with Bill on the phone.
+## Runtime only, like the byte it models: `wBattleResult` is scratch, so a save
+## reloaded after such a catch owes no call.
+func battle_box_full() -> bool:
+	return _battle_box_full
+
+
+func set_battle_box_full(full: bool) -> void:
+	if full == _battle_box_full:
+		return
+	_battle_box_full = full
+	changed.emit()
+
+
 ## `wMapMusic`: the track that is playing, not the track the current map asks
 ## for. The two differ whenever a radio station is tuned.
 func used_flash() -> bool:
@@ -1130,7 +1148,22 @@ func picked_fruit_trees() -> Dictionary:
 ## `CountStep`: the two step counters, the Repel countdown, and `StepHappiness`
 ## on the pass `wStepCount` wraps. One call per step the player finishes, from
 ## wherever the step was taken.
-func count_step() -> void:
+##
+## `DoRepelStep` stands in front of the counters, and the step a Repel runs out
+## on reaches `.doscript` with carry: nothing below that test is charged, so
+## that step counts for neither poison, happiness, an egg nor the Day-Care.
+## Answers whether the step was counted.
+func count_step() -> bool:
+	if _repel_steps > 0:
+		_repel_steps -= 1
+		if _repel_steps == 0:
+			## Where a renewal offer belongs: every way of taking a step reaches
+			## CountStep, so this is the only place the edge exists. Runtime
+			## only, and never saved: a save reloaded on the step a Repel ended
+			## has no offer owed.
+			_repel_expired = true
+			changed.emit()
+			return false
 	_poison_step_count = (_poison_step_count + 1) & 0xFF
 	_step_count = (_step_count + 1) & 0xFF
 	if _step_count == 0:
@@ -1143,14 +1176,8 @@ func count_step() -> void:
 	## step; a step that hatches jumps over it, which the spender settles because
 	## only it knows whether an egg came out.
 	_pending_day_care_steps += 1
-	if _repel_steps > 0:
-		_repel_steps -= 1
-		## The one step a Repel runs out on, which is where a renewal offer
-		## belongs: every way of taking a step reaches CountStep, so this is the
-		## only place the edge exists. Runtime only, and never saved: a save
-		## reloaded on the step a Repel ended has no offer owed.
-		_repel_expired = _repel_steps == 0
 	changed.emit()
+	return true
 
 
 func step_count() -> int:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -452,6 +452,42 @@ func test_world_host_resolves_imported_mart_audio_and_phone_records() -> void:
 	assert_eq(special_world.state.pending_special_phone_call(), 1)
 
 
+## `Script_SpecialBillCall`: `LoadCallerScript` takes the contact's *caller*
+## script, which is `PHONE_CONTACT_SCRIPT2` and not the one an incoming call
+## runs, and nothing gates the ring in front of it.
+func test_an_event_call_rings_the_contact_caller_script() -> void:
+	_write_service_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var contact: Dictionary = data.world_phone_contact(0)
+	var resolved: Dictionary = Gen2WorldPhoneHost.resolve_caller(data, 0)
+	assert_true(bool(resolved["ok"]), JSON.stringify(resolved))
+	assert_eq(resolved["script"], contact["caller_script"])
+	assert_ne(resolved["script"], contact["callee_script"])
+
+	var started: Array = world.request_caller_phone_call(0)
+	assert_true(bool(started[0]["ok"]), JSON.stringify(started))
+	assert_true(world.phone_ring_active())
+	assert_eq(world.pending_phone_ring()["phone"]["role"], &"caller")
+	assert_false(Gen2WorldPhoneHost.resolve_caller(data, 999)["ok"])
+
+
+## `CheckSpecialPhoneCall` is `CountStep`'s first test and answers with carry,
+## which reaches `.doscript`: the step the phone is about to ring on is counted
+## for nothing, poison phase included.
+func test_a_pending_special_call_stops_the_step_being_counted() -> void:
+	_write_service_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	assert_true(world.state.set_pending_special_phone_call(1))
+	assert_true(world.special_phone_call_ready())
+	assert_false(world.count_step(), "the step the call rings on is not counted")
+	assert_eq(world.state.poison_step_count(), 0)
+	world.state.set_pending_special_phone_call(0)
+	assert_true(world.count_step())
+	assert_eq(world.state.poison_step_count(), 1)
+
+
 ## Spends [param frames] hardware frames of the two-ring sequence and returns
 ## whatever finishing it produced.
 func _spend_phone_ring(world: Gen2WorldAPI, frames: int) -> Array:
@@ -5738,6 +5774,18 @@ func test_reloading_the_current_map_rebuilds_live_objects_without_moving_player(
 	assert_eq(reloaded["kind"], &"reload_map")
 	assert_eq(world.player_cell, before)
 	assert_eq(world.objects.size(), 1)
+
+
+## `EnterMap`'s one entry-method branch: MAPSETUP_RELOADMAP zeroes
+## `wPoisonStepCount`, so the four-step poison phase starts again after every
+## battle, `reloadmap` and the catch tutorial.
+func test_reloading_the_current_map_starts_the_poison_phase_again() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(5, 6))
+	for _step: int in Gen2WorldState.POISON_STEP_PHASE - 1:
+		world.count_step()
+	assert_eq(world.state.poison_step_count(), Gen2WorldState.POISON_STEP_PHASE - 1)
+	assert_true(world.reload_current_map()["ok"])
+	assert_eq(world.state.poison_step_count(), 0)
 
 
 func test_world_battle_requires_an_explicit_outcome() -> void:

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -953,6 +953,33 @@ func test_a_full_party_capture_uses_the_first_pc_box_slot() -> void:
 	assert_eq(result["destination"]["destination"], &"box")
 
 
+## `.SendToPC`'s own `cp MONS_PER_BOX`, which raises BATTLERESULT_BOX_FULL for
+## `Script_reloadmapafterbattle` to answer with Bill on the phone. Only the
+## catch that fills the box raises it; the one before it does not, and a catch
+## that reached the party never does.
+func test_the_catch_that_fills_a_box_raises_the_box_full_result() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	var box: Gen2SaveBox = _save.boxes[0]
+	for slot: int in Gen2SaveBox.CAPACITY - 2:
+		box.slots[slot] = Gen2SaveMon.from_dict(_save.party[0].to_dict())
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	_world.state.apply_changes({}, {}, {"items": {0x01: 2}})
+	var first: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)
+	assert_true(bool(first["caught"]))
+	assert_false(bool(first["box_full"]), "one slot is still free")
+	assert_false(_world.state.battle_box_full())
+	var second: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)
+	assert_true(bool(second["box_full"]), JSON.stringify(second))
+	assert_true(_world.state.battle_box_full())
+
+
 ## `GeneratePartyMonStats`' `.registerunowndex`: the letter comes off the DVs
 ## that were caught, and it is entered once however many of that form are caught.
 func test_catching_an_unown_into_the_party_enters_its_letter_in_the_unown_dex() -> void:

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -543,6 +543,21 @@ func test_the_step_that_runs_a_repel_out_is_an_edge_the_reader_holds() -> void:
 	assert_false(walking.repel_expired())
 
 
+## `DoRepelStep` stands in front of the counters and its wear-off answers with
+## carry, so `CountStep` reaches `.doscript` and charges the step to nothing:
+## not the poison phase, not the step count, not the Day-Care.
+func test_the_step_a_repel_runs_out_on_is_counted_for_nothing() -> void:
+	var state := Gen2WorldState.new({}, {}, {}, {}, 0, {}, 2)
+	assert_true(state.count_step(), "a step with the Repel still on is counted")
+	assert_eq(state.poison_step_count(), 1)
+	assert_false(state.count_step(), "the step it wears off on is not")
+	assert_eq(state.poison_step_count(), 1)
+	assert_eq(state.step_count(), 1)
+	assert_eq(state.take_pending_day_care_steps(), 1)
+	assert_true(state.count_step(), "the step after it is counted again")
+	assert_eq(state.poison_step_count(), 2)
+
+
 ## The three counters are saved beside the Repel countdown. A state written
 ## before they existed carries none of the keys and restores as a fresh walk.
 func test_step_counters_round_trip_and_default_to_a_fresh_walk() -> void:

--- a/tools/checks/phone.gd
+++ b/tools/checks/phone.gd
@@ -1,0 +1,82 @@
+extends RefCounted
+
+## Sweeps every imported phone contact and special call on all three cartridges.
+##
+## `PhoneContacts` is a fixed-width table of two scripts per row and
+## `SpecialPhoneCallList` a table of a condition and a third, and every one of
+## them is reached by a routine rather than by a script the catalog walks: an
+## incoming call takes `PHONE_CONTACT_SCRIPT1`, `Script_SpecialBillCall` takes
+## `PHONE_CONTACT_SCRIPT2` for `PHONE_BILL` alone, and `CheckSpecialPhoneCall`
+## takes the list's own. So a row the importer read short reaches no test and no
+## story walk; it reaches a silent phone.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- phone
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_contacts(game_id, data)
+		_special_calls(game_id, data)
+
+
+## Every row carries both scripts, and `PHONE_BILL` resolves through the seam
+## `Script_SpecialBillCall` reaches it by.
+func _contacts(game_id: StringName, data: GameData) -> void:
+	var count: int = data.world_phone_contact_count()
+	if not _r.check(
+		count > Gen2WorldPhoneHost.CONTACT_BILL,
+		"%s: %d phone contacts, too few for PHONE_BILL." % [game_id, count]
+	):
+		return
+	for index: int in count:
+		var contact: Dictionary = data.world_phone_contact(index)
+		if not _r.check(not contact.is_empty(), "%s: phone contact %d is absent." % [
+			game_id, index,
+		]):
+			continue
+		for role: String in ["callee_script", "caller_script"]:
+			var script: Dictionary = contact.get(role, {})
+			_r.check(
+				not script.is_empty() and int(script.get("bank", 0)) > 0,
+				"%s: phone contact %d has no %s." % [game_id, index, role]
+			)
+	var bill: Dictionary = Gen2WorldPhoneHost.resolve_caller(
+		data, Gen2WorldPhoneHost.CONTACT_BILL
+	)
+	_r.check(
+		bool(bill.get("ok", false)),
+		"%s: PHONE_BILL's caller script does not resolve: %s." % [
+			game_id, String(bill.get("reason", &"unknown")),
+		]
+	)
+
+
+## `CheckSpecialPhoneCall` walks this list by index, so every row must name a
+## contact this cache has and a condition the host answers.
+func _special_calls(game_id: StringName, data: GameData) -> void:
+	var index: int = 0
+	while true:
+		var call_row: Dictionary = data.world_special_phone_call(index)
+		if call_row.is_empty():
+			break
+		index += 1
+		var contact: int = int(call_row.get("contact", -1))
+		_r.check(
+			contact >= 0 and not data.world_phone_contact(contact).is_empty(),
+			"%s: special call %d names contact %d, which this cache has no row for." % [
+				game_id, index, contact,
+			]
+		)
+		var script: Dictionary = call_row.get("script", {})
+		_r.check(
+			not script.is_empty() and int(script.get("bank", 0)) > 0,
+			"%s: special call %d has no script." % [game_id, index]
+		)
+	_r.check(index > 0, "%s: no special phone calls were imported." % game_id)

--- a/tools/checks/phone.gd.uid
+++ b/tools/checks/phone.gd.uid
@@ -1,0 +1,1 @@
+uid://eladdkbmrnsr

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -43,7 +43,7 @@ const GROUPS: Dictionary = {
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
-		&"card_flip", &"move_effects",
+		&"card_flip", &"move_effects", &"phone",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
Four defects from reading `engine/overworld/events.asm` against this port.

**The step a Repel wears off on was counted.** `DoRepelStep` answers with carry and `CountStep` then reaches `.doscript`. Nothing below that test is charged: not the poison phase, not the step count, not the egg pass, not the Day-Care. `Gen2WorldState.count_step` answers whether it counted, and every way of taking a step already went through it.

**`CheckSpecialPhoneCall` is the same routine's first test.** It stands in front of the counters, not behind them, so the step a special call rings on is charged nothing at all. `Gen2WorldAPI.count_step` holds both guards now, and the step pump asks about the call before the poison pass.

**`wPoisonStepCount` was never reset.** `EnterMap` zeroes it on `MAPSETUP_RELOADMAP` and on no other entry method, so the four-step phase starts again after every battle, every `reloadmap` and the catch tutorial. `reload_current_map` is that entry method and now nothing else: a script warp was reaching it too, on top of the map entry it had already run.

**A catch that filled its box never phoned Bill.** `.SendToPC`'s `cp MONS_PER_BOX` raises `BATTLERESULT_BOX_FULL`, and `Script_reloadmapafterbattle` answers it with `Script_SpecialBillCall`: `LoadCallerScript PHONE_BILL` and then the two rings an incoming call spends. The script it runs is the caller one, `PHONE_CONTACT_SCRIPT2`, not the callee script an incoming call takes.

`tools/checks/phone.gd` is the corpus half. Every phone contact on all three cartridges carries both scripts, `PHONE_BILL` resolves through the seam the Bill call reaches it by, and every special call names a contact this cache has and a script.

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3,646 tests, 67,731 asserts, all green |
| `validate.gd -- all` | pass, `phone` included |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |