### PR TITLE
Annotation ownership, an annotation's own field, and a switch that stops printing under a menu

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -1134,6 +1134,12 @@ A placement is `{"at": Vector2i}` plus one of:
 | `text` | written with the interface's own font, cut at the right edge |
 | `tile` | one 8x8 cell: eight bytes of 1bpp, or sixty-four palette indices |
 
+and one optional flag:
+
+| Key | What it is |
+|---|---|
+| `field` | `true` asks for the cartridge's interface field behind exactly the cells this placement occupies (`api_version` 14) |
+
 so a mod can supply a symbol the cartridge has no glyph for without a Node, a
 renderer or any art of its own. A placement outside the grid, or one whose text
 does not fit, is refused rather than clipped.
@@ -1163,10 +1169,21 @@ The snapshot carries what a subscriber of past events cannot know:
 with Foresight applied, so a mod never copies the type chart, never resolves a
 dual type itself and never rebuilds state from the event stream.
 
+`field` exists because ink alone is only readable where something already put a
+field under it. A mark on the move list or a summary over the command panel has
+one; a stage figure at the top of the screen or a weather glyph beside the enemy
+sits on bare battle scenery, which is white in the built-in arena and arbitrary
+map geometry under a native-layer renderer. The host draws the field in a layer
+of its own immediately below the annotations, at the opacity the selected
+renderer asks its interface to be drawn at, and hides and restores it with the
+ink. A placement without the flag is unchanged, so do not set it where the
+interface already supplies a field.
+
 The layer is refreshed after every event, every view push and every menu change,
-and hidden wherever one of the host's own full-screen subflows owns the same
-cells: the party page, the pack and its sub-lists, the forget offer, the naming
-prompt and the entrance. Two providers claiming one cell is refused rather than
+and hidden from the frame a modal takes the interface: the party page, the pack
+and its sub-lists, ball selection, the forget offer, the naming prompt and the
+entrance. Ownership is answered where the host's own state changes, so a subflow
+added later hides the annotations without a provider being told anything. Two providers claiming one cell is refused rather than
 resolved by load order, so which mod loaded first cannot decide what a player
 sees.
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -144,7 +144,10 @@ var _injected_data: GameData = null
 ## only has to satisfy Gen2ModHost.BATTLE_RENDERER_METHODS, not extend the
 ## built-in one.
 var _renderer: Node = null
-var _renderer_ready: bool = false
+var _renderer_ready: bool = false:
+	set(value):
+		_renderer_ready = value
+		_gate_annotations()
 
 ## The battle behind the screen, and the two Pokémon in it. The display state
 ## below is what is currently drawn, which is not always where the battle has
@@ -179,7 +182,10 @@ var _faints: Array[Dictionary] = []
 ## The running [Gen2ExpBarAnimation], or null when the exp bar is not filling.
 var _exp_bar: Gen2ExpBarAnimation = null
 ## The running [Gen2BattleIntro], or null once the pics have slid into place.
-var _intro: Gen2BattleIntro = null
+var _intro: Gen2BattleIntro = null:
+	set(value):
+		_intro = value
+		_gate_annotations()
 ## What `BattleStartMessage` will say. It is held for the whole slide, because
 ## `InitBattleDisplay` returns before it is called and the box drawn before the
 ## slide is an empty one.
@@ -246,19 +252,28 @@ var _world_context: Gen2BattleWorldContext = null
 var _pack_rows: Array[int] = []
 var _pack_quantities: Dictionary = {}
 var _pack_index: int = 0
-var _pack_selecting: bool = false
+var _pack_selecting: bool = false:
+	set(value):
+		_pack_selecting = value
+		_gate_annotations()
 var _pack_item: int = 0
 ## `RestorePPEffect`'s own `.loop`, which asks which move before it restores
 ## anything. Only the three items that fill one slot ever open it.
 var _pack_move_slots: Array = []
 var _pack_move_index: int = 0
 var _pack_move_target: int = -1
-var _pack_move_selecting: bool = false
+var _pack_move_selecting: bool = false:
+	set(value):
+		_pack_move_selecting = value
+		_gate_annotations()
 
 var _capture_balls: Array[int] = []
 var _capture_quantities: Dictionary = {}
 var _capture_ball_index: int = 0
-var _capture_selecting: bool = false
+var _capture_selecting: bool = false:
+	set(value):
+		_capture_selecting = value
+		_gate_annotations()
 var _capture_waiting: bool = false
 var _capture_messages: Array[String] = []
 var _capture_terminal: bool = false
@@ -268,7 +283,14 @@ var _capture_experience_spent: bool = false
 ## The layer registered battle-information providers draw on, and the page that
 ## writes their placements. See [method info_snapshot].
 var _annotation_layer: TextureRect = null
+## The interface field the flagged placements asked for, drawn under the ink.
+## See [method _refresh_annotations].
+var _annotation_field_layer: TextureRect = null
 var _annotations: Gen2BattleAnnotations = null
+## What [method _annotations_visible] last answered when the layer was built, so
+## a modal that opens or closes is noticed by [method _gate_annotations] rather
+## than by whichever caller happened to remember to refresh.
+var _annotations_ungated: bool = false
 ## What the layer is currently holding, so it is rebuilt only when a provider
 ## would answer something different. Same shape as [member _menu_drawn].
 var _annotations_drawn: String = ""
@@ -278,7 +300,10 @@ var _enemy_seen_before: bool = false
 var _capture_result: Dictionary = {}
 ## `PokeBallEffect`'s own `AskGiveNicknameText`, which stands over the battle
 ## because the whole routine runs inside it. Null while nothing is being named.
-var _capture_nickname_host: Gen2NicknamePromptScreen = null
+var _capture_nickname_host: Gen2NicknamePromptScreen = null:
+	set(value):
+		_capture_nickname_host = value
+		_gate_annotations()
 ## `wStringBuffer1` after `InitName`: the species name until the player answers
 ## the naming screen with something else.
 var _capture_nickname: String = ""
@@ -290,7 +315,10 @@ var _capture_nickname_asked: bool = false
 ## (engine/pokemon/learn.asm): [code]&"ask"[/code] is AskForgetMoveText's yes/no,
 ## [code]&"list"[/code] ForgetMove's own .loop, [code]&"stop"[/code]
 ## LearnMove.cancel's StopLearningMoveText. Empty when nothing is pending.
-var _forget_stage: StringName = &""
+var _forget_stage: StringName = &"":
+	set(value):
+		_forget_stage = value
+		_gate_annotations()
 var _forget_moves: Array = []
 var _forget_cursor: int = 0
 var _forget_confirm_cursor: int = 0
@@ -300,7 +328,10 @@ var _forget_confirm_cursor: int = 0
 ## same place, and [code]&"pick"[/code] the party menu `SetUpBattlePartyMenu`
 ## puts up behind either, which Baton Pass and a replacement open straight into.
 ## Empty when none of them is on screen.
-var _switch_stage: StringName = &""
+var _switch_stage: StringName = &"":
+	set(value):
+		_switch_stage = value
+		_gate_annotations()
 ## Which question the list is answering: [code]&"offer"[/code] is `OfferSwitch`'s
 ## YES, [code]&"baton_pass"[/code] the target `ForcePickSwitchMonInBattle` asks
 ## for inside the move, and [code]&"replace"[/code] `ForcePlayerMonChoice` after
@@ -313,7 +344,10 @@ var _switch_offer: Gen2WorldMenu = null
 ## `BattleMenu`'s own loop: [code]&"main"[/code] is FIGHT/PKMN/PACK/RUN,
 ## [code]&"move"[/code] `MoveSelectionScreen`'s list and [code]&"refused"[/code]
 ## the line it prints over that list before reopening it.
-var _menu_stage: StringName = &""
+var _menu_stage: StringName = &"":
+	set(value):
+		_menu_stage = value
+		_gate_annotations()
 ## `wBattleMenuCursorPosition`, which is written back after every visit and so
 ## opens on whatever was chosen last.
 var _menu_position: int = Gen2BattleMenu.FIGHT
@@ -644,6 +678,14 @@ func _ready() -> void:
 	## Last, so a registered provider's annotations sit over every box and menu
 	## the interface draws, whichever renderer is under all of it.
 	_annotations = Gen2BattleAnnotations.from_data(_data)
+	## Immediately below the ink, so a placement that asked for a field gets the
+	## cartridge's own interface behind exactly its cells and nothing else. The
+	## built-in arena already has a white background and so is unchanged by it;
+	## a native-layer renderer has the map there, and its own interface opacity.
+	_annotation_field_layer = TextureRect.new()
+	_annotation_field_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_annotation_field_layer.visible = false
+	_screen.display(_annotation_field_layer)
 	_annotation_layer = TextureRect.new()
 	_annotation_layer.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_annotation_layer.visible = false
@@ -2205,12 +2247,27 @@ func info_snapshot() -> Dictionary:
 
 ## Whether the annotation layer may draw at all. Hidden wherever one of the
 ## host's own full-screen subflows owns the same cells: the party page, the pack
-## and its two sub-lists, the forget offer, the naming prompt and the entrance,
-## each of which is the whole interface rather than a box in it.
+## and its two sub-lists, ball selection, the forget offer, the naming prompt and
+## the entrance, each of which is the whole interface rather than a box in it.
 func _annotations_visible() -> bool:
 	return _renderer_ready and _annotations != null and _intro == null \
 		and _capture_nickname_host == null and _switch_stage == &"" \
-		and not _pack_selecting and not _pack_move_selecting and _forget_stage == &""
+		and not _pack_selecting and not _pack_move_selecting \
+		and not _capture_selecting and _forget_stage == &""
+
+
+## Rebuilds the layer the frame a modal takes the interface or gives it back.
+##
+## Every state [method _annotations_visible] reads writes through a setter that
+## reaches here, so ownership is answered where it changes rather than at each
+## caller that opens a subflow: a modal built next year hides the annotations by
+## being made of the same flags, and nothing has to remember to refresh.
+func _gate_annotations() -> void:
+	if _annotation_layer == null:
+		return
+	if _annotations_visible() == _annotations_ungated:
+		return
+	_refresh_annotations()
 
 
 ## Rebuilds the annotation layer when what a provider would answer has changed.
@@ -2219,18 +2276,22 @@ func _annotations_visible() -> bool:
 func _refresh_annotations() -> void:
 	if _annotation_layer == null:
 		return
-	if not _annotations_visible() or Gen2ModHost.instance().battle_info_ids().is_empty():
-		_annotation_layer.visible = false
-		_annotations_drawn = ""
+	_annotations_ungated = _annotations_visible()
+	if not _annotations_ungated or Gen2ModHost.instance().battle_info_ids().is_empty():
+		_hide_annotations()
 		return
 	var placements: Array = Gen2ModHost.instance().battle_info_placements(info_snapshot())
 	var signature: String = str(placements)
 	if signature == _annotations_drawn:
-		_annotation_layer.visible = not placements.is_empty()
+		var shown: bool = not placements.is_empty()
+		_annotation_layer.visible = shown
+		if _annotation_field_layer != null:
+			_annotation_field_layer.visible = shown \
+				and Gen2BattleAnnotations.any_field(placements)
 		return
 	_annotations_drawn = signature
 	if placements.is_empty():
-		_annotation_layer.visible = false
+		_hide_annotations()
 		return
 	var indices := PackedByteArray()
 	indices.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
@@ -2244,6 +2305,42 @@ func _refresh_annotations() -> void:
 		),
 		Vector2i.ZERO
 	)
+	_refresh_annotation_field(placements)
+
+
+## The field layer under the ink: the cells the flagged placements own, painted
+## in the same white the cartridge's own boxes are and at the opacity the
+## selected renderer asks its interface to be drawn at, which is 1.0 for the
+## built-in arena and for anything on the hardware viewport.
+func _refresh_annotation_field(placements: Array) -> void:
+	if _annotation_field_layer == null:
+		return
+	if not Gen2BattleAnnotations.any_field(placements):
+		_annotation_field_layer.visible = false
+		return
+	var indices := PackedByteArray()
+	indices.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	_annotations.draw_field(placements, indices, Gen2Screen.WIDTH)
+	var opacity: float = Gen2ModHost.renderer_interface_opacity(_renderer)
+	var field := Color(Color.WHITE, opacity)
+	_show_layer_image(
+		_annotation_field_layer,
+		Gen2PicImage.from_indices(
+			indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+			PackedColorArray([field, field, field, field]),
+			true
+		),
+		Vector2i.ZERO
+	)
+
+
+## Both annotation layers away together: the field exists only to sit under ink
+## that is being drawn, so it never outlives it by a frame.
+func _hide_annotations() -> void:
+	_annotation_layer.visible = false
+	if _annotation_field_layer != null:
+		_annotation_field_layer.visible = false
+	_annotations_drawn = ""
 
 
 ## Supplies the battle with the overworld's own clock reading, which Morning Sun,
@@ -4735,6 +4832,10 @@ func _apply_renderer_interface_style() -> void:
 		return
 	_box.field_opacity = Gen2ModHost.renderer_interface_opacity(_renderer)
 	_push_text_box_rect()
+	## The annotation field is the same interface over the same renderer, so it
+	## is repainted with the box rather than left at the last renderer's opacity.
+	_annotations_drawn = ""
+	_refresh_annotations()
 
 
 func _push_text_box_rect() -> void:
@@ -4765,10 +4866,34 @@ func _on_native_size_changed(size_pixels: Vector2i) -> void:
 func select_view(id: StringName) -> Dictionary:
 	var result: Dictionary = Gen2ModHost.instance().select_view(id)
 	if not bool(result.get("ok", false)):
-		show_message("Renderer unavailable: %s" % String(result.get("reason", "unknown")))
+		_report_view("Renderer unavailable: %s" % String(result.get("reason", "unknown")))
 		return result
-	show_message("Renderer: %s" % Gen2ModHost.instance().view_label(id))
+	_report_view("Renderer: %s" % Gen2ModHost.instance().view_label(id))
 	return result
+
+
+## Says what a view switch did, unless a menu is holding the interface.
+##
+## The acknowledgement is battle text, and the menu layer above it covers the
+## box's right-hand half rather than the whole panel, so a line printed under an
+## open menu leaks its first glyphs out beside the list. The cartridge's own
+## transition cover already says the switch happened; the words are development
+## chrome and are worth less than the menu underneath them staying intact. Said
+## through the same log the refusals use, so nothing is silently dropped.
+func _report_view(message: String) -> void:
+	if _menu_owns_interface():
+		print_verbose(message)
+		return
+	show_message(message)
+
+
+## Whether one of the interface's own menus is on screen and holding the lower
+## panel. Not the same question as [method _annotations_visible], which is about
+## the cells a full-screen subflow takes: the main and move menus own the panel
+## a battle message would print into while leaving the annotations correct.
+func _menu_owns_interface() -> bool:
+	return _menu_stage != &"" or _switch_stage != &"" or _forget_stage != &"" \
+		or _pack_selecting or _pack_move_selecting or _capture_selecting
 
 
 ## The same one switch the overworld takes: see
@@ -4782,7 +4907,7 @@ func cycle_view() -> Dictionary:
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	var ids: Array[StringName] = host.view_ids()
 	if ids.size() < 2:
-		show_message("No other renderer is registered")
+		_report_view("No other renderer is registered")
 		return {"ok": false, "reason": &"single_renderer"}
 	var at: int = ids.find(host.selected_view())
 	return select_view(ids[posmod(at + 1, ids.size())])

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -47,7 +47,7 @@ const FILENAME: String = "mod.json"
 ## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
 ## host that has never heard of either ignores the field, so a mod that ships
 ## art still installs on an older launcher and simply has no face there.
-const API_VERSION: int = 13
+const API_VERSION: int = 14
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/render/battle_annotations.gd
+++ b/game/render/battle_annotations.gd
@@ -49,6 +49,12 @@ static func from_data(data: GameData) -> Gen2BattleAnnotations:
 
 ## [param placement] as the host will keep it, or `{}` when it cannot be drawn.
 ##
+## `field` is the one optional key: with it set the host draws the cartridge's
+## own interface field behind exactly the cells [method cells] answers, so ink a
+## provider puts on bare battle scenery is readable over a native renderer. It
+## is kept only when it was asked for, so a placement without it is exactly the
+## dictionary an API 13 provider already got back.
+##
 ## Refused rather than clipped: a symbol half off the screen, or a stage summary
 ## running through the border, is worse than one the player never sees, and a
 ## provider that is told nothing about the refusal would keep sending it.
@@ -59,18 +65,25 @@ static func validate(placement: Dictionary) -> Dictionary:
 	var at: Vector2i = at_value
 	if at.x < 0 or at.y < 0 or at.x >= COLUMNS or at.y >= ROWS:
 		return {}
+	var field: bool = bool(placement.get("field", false))
+	var out: Dictionary = {"at": at}
 	if placement.has("tile"):
 		var tile: PackedByteArray = _tile_bytes(placement["tile"])
 		if tile.is_empty():
 			return {}
-		return {"at": at, "tile": tile}
-	var text: String = String(placement.get("text", ""))
-	if text.is_empty():
-		return {}
-	var codes: PackedByteArray = Gen2Font.fit(text, COLUMNS - at.x, FONT)
-	if codes.is_empty():
-		return {}
-	return {"at": at, "text": text, "width": codes.size()}
+		out["tile"] = tile
+	else:
+		var text: String = String(placement.get("text", ""))
+		if text.is_empty():
+			return {}
+		var codes: PackedByteArray = Gen2Font.fit(text, COLUMNS - at.x, FONT)
+		if codes.is_empty():
+			return {}
+		out["text"] = text
+		out["width"] = codes.size()
+	if field:
+		out["field"] = true
+	return out
 
 
 ## Which cells [param placement] occupies, for the ownership check. A validated
@@ -97,6 +110,32 @@ func draw(placements: Array, indices: PackedByteArray, width: int) -> void:
 			String(placement.get("text", "")), indices, width,
 			at.x * TILE, at.y * TILE, FONT, COLUMNS - at.x
 		)
+
+
+## Draws the interface field of the flagged placements in [param placements]
+## into [param indices], the layer that sits immediately below the ink. A cell
+## is filled with [constant INK_INDEX] because the field layer's own palette
+## paints that index in the field colour; an unflagged placement fills nothing.
+func draw_field(placements: Array, indices: PackedByteArray, width: int) -> void:
+	for placement: Dictionary in placements:
+		if not bool(placement.get("field", false)):
+			continue
+		for cell: Vector2i in cells(placement):
+			for row: int in TILE:
+				var start: int = (cell.y * TILE + row) * width + cell.x * TILE
+				if start < 0 or start + TILE > indices.size():
+					continue
+				for column: int in TILE:
+					indices[start + column] = INK_INDEX
+
+
+## Whether any of [param placements] asked for a field, so the host skips
+## building a layer nothing would draw into.
+static func any_field(placements: Array) -> bool:
+	for placement: Dictionary in placements:
+		if bool(placement.get("field", false)):
+			return true
+	return false
 
 
 func _draw_tile(tile: PackedByteArray, indices: PackedByteArray, width: int, at: Vector2i) -> void:

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -580,6 +580,12 @@ class BattleInfo:
 				out.append({
 					"text": "%s%d" % [STAGE_LABELS.get(key, key.to_upper()), stage],
 					"at": at,
+					## Bare battle scenery under it: white in the built-in arena
+					## and whatever a native renderer staged in the others, so
+					## the host is asked for the interface field behind these
+					## cells. The move-row marks above ask for none, because
+					## `MoveSelectionScreen`'s own box is already under them.
+					"field": true,
 				})
 				at += Vector2i(0, 1)
 		return out
@@ -593,7 +599,7 @@ class BattleInfo:
 	func _weather(snapshot: Dictionary) -> Array:
 		if not Gen2Weather.is_active(int(snapshot.get("weather", 0))):
 			return []
-		return [{"tile": SUN_ROWS, "at": WEATHER_AT}]
+		return [{"tile": SUN_ROWS, "at": WEATHER_AT, "field": true}]
 
 
 ## Changing what the cartridge shipped, rather than adding to it. A patch names

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 13,
+	"api_version": 14,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the five read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, battle annotations and a start-menu row that opens the host's own storage."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 13,
+	"api_version": 14,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -1013,6 +1013,26 @@ func test_battle_annotations_are_validated_and_owned_per_cell() -> void:
 			continue
 		assert_true(answer.is_empty(), str(refused))
 
+	## `field` is the one optional key: kept only when it was asked for, so an
+	## API 13 placement comes back exactly as it always did, and it never widens
+	## the cells the ownership check reads.
+	var plain: Dictionary = Gen2BattleAnnotations.validate({"text": "ABC", "at": Vector2i(2, 3)})
+	assert_false(plain.has("field"), "an unflagged placement carries nothing extra")
+	assert_eq(plain, {"at": Vector2i(2, 3), "text": "ABC", "width": 3})
+	var flagged: Dictionary = Gen2BattleAnnotations.validate({
+		"text": "ABC", "at": Vector2i(2, 3), "field": true,
+	})
+	assert_true(bool(flagged["field"]))
+	assert_eq(Gen2BattleAnnotations.cells(flagged), Gen2BattleAnnotations.cells(plain))
+	assert_eq(int(flagged["width"]), 3, "the flag is not a cell of its own")
+	assert_true(Gen2BattleAnnotations.any_field([plain, flagged]))
+	assert_false(Gen2BattleAnnotations.any_field([plain]))
+	var tile: Dictionary = Gen2BattleAnnotations.validate({
+		"tile": PackedByteArray([1, 2, 3, 4, 5, 6, 7, 8]), "at": Vector2i(0, 0), "field": 1,
+	})
+	assert_true(bool(tile["field"]), "a truthy value is one flag, not a second shape")
+	assert_eq(Gen2BattleAnnotations.cells(tile).size(), 1)
+
 	var first: Object = _script(BATTLE_INFO_SOURCE).new()
 	var second: Object = _script(BATTLE_INFO_SOURCE).new()
 	first.set("placements", [{"text": "AB", "at": Vector2i(4, 4)}])
@@ -1028,6 +1048,140 @@ func test_battle_annotations_are_validated_and_owned_per_cell() -> void:
 	assert_eq(
 		StringName((host.failures().back() as Dictionary)["reason"]), &"battle_info_cells_taken"
 	)
+
+
+## A modal that takes the interface takes it from the annotations too, on the
+## frame it opens rather than on whatever refresh happens next. Every state the
+## visibility predicate reads writes through a setter, so this walks the four
+## the pack reproduction goes through plus the two the party page opens.
+func test_annotations_are_hidden_the_frame_a_modal_takes_the_interface() -> void:
+	var provider: Object = _script(BATTLE_INFO_SOURCE).new()
+	assert_true(
+		bool(Gen2ModHost.instance().register_battle_info(&"qol", provider).get("ok", false))
+	)
+	provider.set("placements", [{"text": "ATK+2", "at": Vector2i(0, 0)}])
+	await _open_battle()
+	_finish_entrance()
+	var layer: TextureRect = _battle_screen._annotation_layer
+	assert_true(layer.visible, "the battle itself leaves them up")
+
+	## The reproduction: main menu, PACK, and the item refusal that reopens the
+	## list under `It won't have any effect.`.
+	_battle_screen._open_battle_menu()
+	assert_true(layer.visible, "the main menu is a box, not a modal")
+	_battle_screen._pack_selecting = true
+	assert_false(layer.visible, "pack selection, the frame it opens")
+	_battle_screen._pack_selecting = false
+	assert_true(layer.visible, "and back when B closes it")
+
+	for opened: Callable in [
+		func() -> void: _battle_screen._pack_move_selecting = true,
+		func() -> void: _battle_screen._capture_selecting = true,
+		func() -> void: _battle_screen._switch_stage = &"pick",
+		func() -> void: _battle_screen._forget_stage = &"ask",
+	]:
+		opened.call()
+		assert_false(layer.visible, "a modal owns the interface")
+		_battle_screen._pack_move_selecting = false
+		_battle_screen._capture_selecting = false
+		_battle_screen._switch_stage = &""
+		_battle_screen._forget_stage = &""
+		assert_true(layer.visible, "and gives it back")
+
+	## The move list keeps its marks: the useful ordering the layer exists for.
+	_battle_screen._open_move_menu()
+	assert_true(layer.visible, "move-row marks stay over the list")
+
+
+## `field` puts the cartridge's own interface under exactly the cells that asked
+## for it, in a layer of its own below the ink and at the renderer's opacity.
+func test_an_annotation_can_ask_for_the_interface_field_behind_it() -> void:
+	var provider: Object = _script(BATTLE_INFO_SOURCE).new()
+	assert_true(
+		bool(Gen2ModHost.instance().register_battle_info(&"qol", provider).get("ok", false))
+	)
+	provider.set("placements", [
+		{"text": "DEF-1", "at": Vector2i(13, 0), "field": true},
+		{"text": "AB", "at": Vector2i(0, 10)},
+	])
+	await _open_battle()
+	_finish_entrance()
+	var ink: TextureRect = _battle_screen._annotation_layer
+	var field: TextureRect = _battle_screen._annotation_field_layer
+	assert_true(field.visible, "a flagged placement asked for one")
+
+	var interface: Control = _battle_screen._screen.interface_layer()
+	var children: Array = interface.get_children()
+	assert_eq(children.back(), ink, "the ink is still last")
+	assert_eq(children[children.size() - 2], field, "and the field immediately under it")
+
+	var image: Image = field.texture.get_image()
+	assert_eq(image.get_size(), Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT))
+	var painted: Color = image.get_pixel(13 * 8 + 1, 1)
+	assert_almost_eq(painted.a, 0.75, 0.01, "the renderer's own interface opacity")
+	assert_eq(Color(painted.r, painted.g, painted.b), Color.WHITE)
+	assert_eq(image.get_pixel(13 * 8 - 1, 1).a, 0.0, "nothing to the left of it")
+	assert_eq(image.get_pixel(18 * 8, 1).a, 0.0, "and it stops where the five cells do")
+	assert_eq(image.get_pixel(4, 10 * 8 + 4).a, 0.0, "an unflagged placement gets none")
+
+	## Hidden and restored with the ink, R1's gate included.
+	_battle_screen._pack_selecting = true
+	assert_false(field.visible, "the field goes with the ink")
+	_battle_screen._pack_selecting = false
+	assert_true(field.visible)
+
+	provider.set("placements", [{"text": "DEF-1", "at": Vector2i(13, 0)}])
+	_battle_screen._refresh_annotations()
+	assert_false(field.visible, "and nothing is drawn for an unflagged answer")
+	assert_true(ink.visible)
+
+
+## The switch acknowledgement is battle text and the menu layer covers only half
+## the panel, so the words are kept off the screen while a menu is open. The
+## menu, its cursor and the annotations over it are untouched either way.
+func test_a_view_switch_does_not_print_behind_an_open_menu() -> void:
+	var provider: Object = _script(BATTLE_INFO_SOURCE).new()
+	assert_true(
+		bool(Gen2ModHost.instance().register_battle_info(&"qol", provider).get("ok", false))
+	)
+	provider.set("placements", [{"text": "ATK+2", "at": Vector2i(0, 0)}])
+	await _open_battle()
+	_finish_entrance()
+	assert_true(
+		Gen2ModHost.instance().register_battle_renderer(&"second", _script(NATIVE_SOURCE))["ok"]
+	)
+
+	## The default matchup is two species and no moveset, and `MoveSelectionScreen`
+	## does not open a list for a Pokemon with nothing to pick.
+	var mon: Gen2BattleMon = _battle_screen._battle.mon(Gen2Battle.PLAYER)
+	mon.moves = [1, 0, 0, 0]
+	mon.pp = [35, 0, 0, 0]
+
+	for stage: StringName in [&"main", &"move"]:
+		if stage == &"main":
+			_battle_screen._open_battle_menu()
+		else:
+			_battle_screen._open_move_menu()
+		assert_eq(_battle_screen._menu_stage, stage, "the %s menu opened" % stage)
+		var cursor: int = _battle_screen._menu_position
+		for id: StringName in [&"second", &"native"]:
+			assert_true(bool(_battle_screen.select_view(id).get("ok", false)))
+			_battle_screen._screen.settle_view_cover()
+			assert_false(
+				"".join(_battle_screen._box.text_lines()).contains("Renderer"),
+				"no renderer name is left in the battle text under the %s menu" % stage
+			)
+		assert_eq(_battle_screen._menu_stage, stage, "the menu is where it was")
+		assert_eq(_battle_screen._menu_position, cursor, "and so is its cursor")
+		assert_true(_battle_screen._annotation_layer.visible, "and the marks with it")
+
+	## With no menu open the acknowledgement still prints, so ordinary message
+	## progression is not stalled by the guard.
+	_battle_screen._close_battle_menu()
+	_battle_screen._menu_stage = &""
+	assert_true(bool(_battle_screen.select_view(&"second").get("ok", false)))
+	_battle_screen._screen.settle_view_cover()
+	assert_string_contains("".join(_battle_screen._box.text_lines()), "Renderer")
 
 
 ## Nothing at all without a provider: the layer never appears and the snapshot is

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -10,7 +10,10 @@ extends SceneTree
 ## [stage] is one of `offer` (the default), `menu`, `move`, `info` (the move
 ## list with a registered battle-information provider's annotations over it:
 ## a mark per row for the effectiveness against the defender, the non-zero stat
-## stages, and a tile of the provider's own for the weather), `contest`, `pack`,
+## stages, and a tile of the provider's own for the weather), `info_pack` and
+## `info_pkmn` (the same battle state, with the modal that covers the
+## annotations open and no provider of this tool's own registered, so a mod
+## under test is the only thing answering), `contest`, `pack`,
 ## `pick`, `use_next`, `replace` and `level_up`, which is the stats box
 ## `.skip_exp_bar_animation` draws beside its grew-to-level line;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
@@ -46,10 +49,16 @@ const PLAYER_LEVEL: int = 30
 ## Four moves on the lead, so `MoveSelectionScreen`'s list is a full one:
 ## TACKLE, GROWL, TAIL_WHIP and BITE (constants/move_constants.asm).
 const LEAD_MOVES: Array[int] = [33, 45, 39, 44]
-## The `info` stage's own four, one per effectiveness the annotation can mark
+## The `info` stages' own four, one per effectiveness the annotation can mark
 ## against Pidgey's NORMAL/FLYING: THUNDERSHOCK is super effective, TACKLE
 ## neutral, VINE WHIP resisted and EARTHQUAKE has no effect at all.
 const INFO_MOVES: Array[int] = [84, 33, 22, 89]
+
+## The stages `BattleMenu`'s own first opening leads into with nothing staged
+## behind it, rather than a question a turn has to reach.
+const MENU_STAGES: Array[String] = [
+	"menu", "move", "info", "info_pack", "info_pkmn", "contest", "pack",
+]
 
 var _screen: Gen2BattleScreen = null
 var _output_path: String = ""
@@ -178,6 +187,13 @@ class Annotations extends RefCounted:
 ## about, or the player's own going down, which is what `AskUseNextPokemon` and
 ## `ForcePlayerMonChoice` follow. SHIFT is forced on rather than read out of the
 ## options file, since the question is the thing being photographed.
+## Whether this stage stands the battle up in the state an information provider
+## has something to say about. Registering a provider is a separate question:
+## see [constant MENU_STAGES].
+func _informing() -> bool:
+	return _stage.begins_with("info")
+
+
 func _open() -> void:
 	var data: GameData = _screen.get("_data")
 	var rng := RandomNumberGenerator.new()
@@ -185,7 +201,7 @@ func _open() -> void:
 
 	var members: Array = []
 	for species: int in PLAYER_SPECIES:
-		var lead: Array[int] = INFO_MOVES if _stage == "info" else LEAD_MOVES
+		var lead: Array[int] = INFO_MOVES if _informing() else LEAD_MOVES
 		members.append(Gen2BattleMon.create(
 			data, species, PLAYER_LEVEL,
 			lead.duplicate() if members.is_empty() else [33]
@@ -226,7 +242,7 @@ func _open() -> void:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.use_move(0)
 		))
-	elif _stage not in ["menu", "move", "info", "contest", "pack"]:
+	elif _stage not in MENU_STAGES:
 		_screen.set("_pending", battle.take_actions(
 			Gen2Battle.use_move(0), Gen2Battle.switch_to(1)
 		))
@@ -250,12 +266,13 @@ func _open() -> void:
 
 	## Both menu stages are what the intro leads into with nothing else staged,
 	## which is `BattleMenu`'s own first opening.
-	if _stage in ["menu", "move", "info", "contest", "pack"]:
-		## The annotations are a mod's, over the move list they describe: the
-		## provider is synthetic and everything it is handed, and everything drawn
-		## from what it answers, is the host's.
-		if _stage == "info":
-			Gen2ModHost.instance().register_battle_info(&"preview", Annotations.new())
+	if _stage in MENU_STAGES:
+		## The state an information provider reads, which is the stage rather
+		## than the provider: a seen opponent, weather on, and two stages moved.
+		## Only `info` registers this tool's own, so a capture of a mod's
+		## annotations has exactly one provider answering and cannot attribute
+		## one mod's placements to the other.
+		if _informing():
 			## What `SetSeenMon` would have left behind, since a first sighting is
 			## not something the Pokedex could have told the player about.
 			_screen.set("_enemy_seen_before", true)
@@ -263,14 +280,24 @@ func _open() -> void:
 			battle.weather_turns = 3
 			battle.player.stages["attack"] = 2
 			battle.player.stages["speed"] = -1
+		## The annotations are a mod's, over the move list they describe: the
+		## provider is synthetic and everything it is handed, and everything drawn
+		## from what it answers, is the host's.
+		if _stage == "info":
+			Gen2ModHost.instance().register_battle_info(&"preview", Annotations.new())
 		_drain_to_menu()
 		if _stage in ["move", "info"]:
 			_screen._handle_button(Gen2Button.A)
 		## `BattlePack`'s own list, over the bag the world hands the battle. The
 		## rows are a real cache's items, so the picture reads as the pack.
-		if _stage == "pack":
+		if _stage in ["pack", "info_pack"]:
 			_screen.set_battle_pack(PACK_ITEMS, PACK_QUANTITIES)
 			_screen._handle_button(Gen2Button.DOWN)
+			_screen._handle_button(Gen2Button.A)
+		## `BattleMenu_PKMN`'s party page, the other modal that covers the same
+		## cells: RIGHT from FIGHT is PKMN.
+		if _stage == "info_pkmn":
+			_screen._handle_button(Gen2Button.RIGHT)
 			_screen._handle_button(Gen2Button.A)
 		for press: String in _presses:
 			_screen._handle_button(_button(press))


### PR DESCRIPTION
Three things the mod repository asked for.

**The annotation layer follows a modal now.** It was hidden by a predicate and refreshed by whichever caller remembered to call the refresh. Any subflow that set a flag without also pushing a view left the last annotation texture standing over its own text. The pack was the reported one: `open_battle_pack()` sets its flag and draws its list without a refresh, so stage text and a weather glyph sat over `Use ITEM...`. Ball selection and the item refusal had the same hole, and so would anything added later.

The fix is not a refresh call per subflow. Every state the visibility predicate reads is a property with a setter, and one gate rebuilds the layer the frame ownership changes. A modal built next year hides the annotations by being made of the same flags. Ball selection joins the predicate, which it was never in.

**A placement can ask for the field behind it.** Ink is readable where something already put a field under it. The move list and the command panel do; bare battle scenery does not, and under a renderer that draws the map there a stage figure is black on dark trees. `{"field": true}` gives that placement the cartridge's own interface behind exactly the cells it occupies, in a layer under the ink, at the opacity the selected renderer asks its interface to be drawn at. A placement without the flag is unchanged. `api_version` 14, and the example mod flags the two placements that need it.

**The view switch stops printing under a menu.** `select_view()` said "Renderer: ..." into battle text while the menu layer above covered only the box's right-hand half, so the first glyphs came out beside the move list. It goes to the verbose log while a menu owns the interface, which is how the map's own switch has always reported it. The transition cover already says the switch happened.

| Check | |
|---|---|
| GUT, unit and scene | 3665 tests, 67923 asserts, all passing |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three cartridges | no failure in any leg |
| Boot smoke, with and without mods | clean |

`preview_battle_switch.gd` grows `info_pack` and `info_pkmn`: the battle state an information provider has something to say about, with the modal that covers it open and no provider of the tool's own registered, so a capture of a mod's annotations has exactly one provider answering.