### PR TITLE
The last four facilities with no routine

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -75,6 +75,8 @@ var _unown_walls: PackedStringArray = PackedStringArray()
 var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _unown_puzzle: Dictionary = {}
+var _diploma: Dictionary = {}
+var _printer_strings: Dictionary = {}
 var _slots: Dictionary = {}
 var _slots_text: Dictionary = {}
 var _card_flip: Dictionary = {}
@@ -194,6 +196,10 @@ static func open_directory(path: String) -> GameData:
 	data._intro_movie = intro_movie if intro_movie is Dictionary else {}
 	var unown_puzzle: Variant = manifest.get("unown_puzzle", {})
 	data._unown_puzzle = unown_puzzle if unown_puzzle is Dictionary else {}
+	var diploma: Variant = manifest.get("diploma", {})
+	data._diploma = diploma if diploma is Dictionary else {}
+	var printer_strings: Variant = manifest.get("printer_strings", {})
+	data._printer_strings = printer_strings if printer_strings is Dictionary else {}
 	var slots: Variant = manifest.get("slots", {})
 	data._slots = slots if slots is Dictionary else {}
 	var raw_slots_text: Variant = manifest.get("slots_text", {})
@@ -1889,6 +1895,40 @@ func unown_puzzle_palette() -> PackedColorArray:
 	for packed: Variant in _unown_puzzle.get("palette", []) as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
+
+
+## `DiplomaGFX`'s own strip, and one of `PlaceDiplomaOnScreen`'s two tilemaps by
+## its page number. A cache imported before format 84 carries neither, which is
+## what `has_diploma` answers for.
+func has_diploma() -> bool:
+	return not (_diploma.get("page1", []) as Array).is_empty()
+
+
+func diploma_indices() -> PackedByteArray:
+	return tile_indices("diploma")
+
+
+func diploma_tilemap(page: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	for code: Variant in _diploma.get("page%d" % page, []) as Array:
+		out.append(int(code))
+	return out
+
+
+## PREDEFPAL_DIPLOMA, the one palette SCGB_DIPLOMA's own layout gives every cell
+## of the page.
+func diploma_palette() -> PackedColorArray:
+	var colors := PackedColorArray()
+	for packed: Variant in _diploma.get("palette", []) as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## One `GBPrinterStrings` entry by the status it names, or the empty string,
+## which is what a status of zero prints and what a cache too old to carry the
+## run answers for every name.
+func printer_status_string(name: String) -> String:
+	return String(_printer_strings.get(name, ""))
 
 
 ## Whether the cache carries `_SlotMachine`'s art, which is the whole of what

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -81,7 +81,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 83
+const FORMAT_VERSION: int = 84
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -362,6 +362,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not slots["ok"]:
 		return slots
 
+	var printer: Dictionary = verify_printer(rom, layout)
+	if not printer["ok"]:
+		return printer
+
 	var card_flip: Dictionary = verify_card_flip(rom, layout)
 	if not card_flip["ok"]:
 		return card_flip
@@ -1625,6 +1629,31 @@ static func verify_unown_puzzle(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if RomLayout.predef_palette_offset(layout, RomLayout.PREDEFPAL_UNOWN_PUZZLE) < 0:
 		return {"ok": false, "message": "No PredefPals pin for the Unown puzzle palette."}
 	return {"ok": true, "message": "Unown puzzle verified."}
+
+## The diploma's art and the printer's own two runs. The section walks are most
+## of the check: a tilemap indexing past `DiplomaGFX` and a status run whose
+## first entry is not the empty string both refuse there. What is left is the
+## line the second status prints, which is what says the table is in its own
+## order rather than some other run of eight strings.
+static func verify_printer(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if int(layout.get("diploma", -1)) < 0:
+		return {"ok": true, "message": "No diploma on this cartridge."}
+	if read_diploma_section(rom, layout).is_empty():
+		return {"ok": false, "message": "The diploma's art and tilemaps do not walk."}
+	var strings: Dictionary = read_printer_strings(rom, layout)
+	if strings.is_empty():
+		return {"ok": false, "message": "The printer's status strings do not walk."}
+	if not String(strings.get("checking_link", "")).contains("CHECKING LINK"):
+		return {
+			"ok": false,
+			"message": "The printer's status run opens on \"%s\"." % strings.get(
+				"checking_link", ""
+			),
+		}
+	if int(layout.get("unown_printer_glyphs", -1)) < 0:
+		return {"ok": false, "message": "No pin for the Unown printer's own glyphs."}
+	return {"ok": true, "message": "The diploma and the printer verified."}
+
 
 ## `_SlotMachine`. The section walk is most of the check; what is left is the
 ## three reel strips, which repeat their own first three symbols, and the seven
@@ -4260,6 +4289,8 @@ func import_rom(
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
 		"unown_puzzle": _import_unown_puzzle(rom, layout),
+		"diploma": _import_diploma(rom, layout),
+		"printer_strings": _import_printer_strings(rom, layout),
 		"slots": _import_slots(rom, layout),
 		"slots_text": _import_slots_text(rom, layout),
 		"card_flip": _import_card_flip(rom, layout),
@@ -5901,6 +5932,99 @@ func _import_card_flip_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return read_card_flip_texts(rom, layout)
 
 
+## `PlaceDiplomaOnScreen`'s art: `DiplomaGFX` decompressed, and the two whole
+## screens of tile numbers laid out behind its stream. The art itself is what
+## says the address is right, since each tilemap has to index inside it.
+##
+## Returns {tiles, page1, page2}, or an empty Dictionary if any part does not
+## land on its own size.
+static func read_diploma_section(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("diploma", -1))
+	if at < 0:
+		return {}
+	var lz := Gen2Lz.new()
+	var raw: PackedByteArray = lz.decompress(rom.bytes(), at)
+	if lz.failed or raw.size() != RomLayout.DIPLOMA_TILES * Gen2Tiles.TILE_BYTES:
+		return {}
+	var maps_at: int = at + lz.consumed
+	var bytes: int = RomLayout.DIPLOMA_TILEMAP_BYTES
+	if not rom.in_bounds(maps_at, bytes * 2):
+		return {}
+	var out: Dictionary = {"tiles": raw}
+	for page: int in 2:
+		var map: PackedByteArray = rom.slice(maps_at + page * bytes, bytes)
+		for code: int in map:
+			if code >= RomLayout.DIPLOMA_TILES:
+				return {}
+		out["page%d" % (page + 1)] = map
+	return out
+
+
+## The eight `GBPrinterStrings`, walked from the empty one a status of zero
+## names. `PlaceFarString` prints them with the same `next` line breaks a box
+## carries, so they are decoded rather than kept as bytes.
+static func read_printer_strings(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("printer_strings", -1))
+	if at < 0:
+		return {}
+	var out: Dictionary = {}
+	for name: String in RomLayout.PRINTER_STATUS_STRINGS:
+		var length: int = 0
+		while rom.in_bounds(at + length) and rom.u8(at + length) != Gen2Text.TERMINATOR:
+			length += 1
+			if length > RomLayout.OAK_TEXT_MAX_BYTES:
+				return {}
+		out[name] = Gen2Text.decode(rom.bytes(), at, length)
+		at += length + 1
+	## `GBPrinterString_Null` is the one that prints nothing, and a run pinned
+	## one byte out would put a whole line there.
+	if not String(out.get("null", "?")).is_empty():
+		return {}
+	return out
+
+
+func _import_diploma(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_diploma_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var palette: Array = _import_predef_palette(
+		rom, layout, RomLayout.PREDEFPAL_DIPLOMA
+	)
+	if palette.is_empty():
+		return {}
+	return {
+		"page1": Array(section["page1"] as PackedByteArray),
+		"page2": Array(section["page2"] as PackedByteArray),
+		"palette": palette,
+	}
+
+
+func _import_printer_strings(rom: RomFile, layout: Dictionary) -> Dictionary:
+	return read_printer_strings(rom, layout)
+
+
+## `DiplomaGFX`'s own strip, written the way the splash's Ditto is.
+func _import_diploma_sheet(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_diploma_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	if not RomCache.write_indices(
+		RomCache.tile_path(directory, "diploma"),
+		Gen2Tiles.decode_2bpp_strip(section["tiles"], 0, RomLayout.DIPLOMA_TILES)
+	):
+		return {}
+	return {
+		"diploma": {
+			"width": RomLayout.DIPLOMA_TILES * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": RomLayout.DIPLOMA_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+	}
+
+
 ## `GameFreakDittoGFX`, the one LZ run in the splash. `GameFreakPresentsInit`
 ## splits it over `vTiles0` and `vTiles1` as 128 tiles each, and the OAM sets
 ## index the result with a stride of $10, so it is kept as one strip of 256 and
@@ -6218,6 +6342,16 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 			"bits": 2,
 		}
 
+	## `UnownDexATile` and `UnownDexBTile`, the two 1bpp glyphs `_UnownPrinter`
+	## requests into `♂` and `♀` before it prints its own menu.
+	if int(layout.get("unown_printer_glyphs", -1)) >= 0:
+		sheets["unown_printer_glyphs"] = {
+			"offset": int(layout["unown_printer_glyphs"]),
+			"tiles": RomLayout.UNOWN_PRINTER_GLYPH_TILES,
+			"first_code": 0,
+			"bits": 1,
+		}
+
 	## `PokedexNestIconGFX`, the AREA screen's own object tile.
 	if RomLayout.dex_nest_icon_offset(layout) >= 0:
 		sheets["dex_nest_icon"] = {
@@ -6272,6 +6406,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_unown_puzzle_sheets(rom, layout), true)
 	written.merge(_import_slots_sheets(rom, layout), true)
 	written.merge(_import_card_flip_sheets(rom, layout), true)
+	written.merge(_import_diploma_sheet(rom, layout), true)
 	var done: int = 0
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1182,6 +1182,31 @@ const UNOWN_PUZZLE_BORDER_TILES: int = 8
 const PREDEFPAL_UNOWN_PUZZLE: int = 0x4C
 
 
+## `PlaceDiplomaOnScreen`'s art (`engine/events/diploma.asm`): `DiplomaGFX` is
+## one LZ strip and the two tilemaps behind it are whole screens of tile
+## numbers, uncompressed and laid out in the file's own order. Identical on all
+## three cartridges.
+const DIPLOMA_TILES: int = 112
+const DIPLOMA_TILEMAP_BYTES: int = 360
+
+## `PalPacket_Diploma`'s first entry, and the only one the page is drawn in:
+## `_CGB_Unused0D` is SCGB_DIPLOMA's own layout and its `WipeAttrmap` puts every
+## cell on palette 0.
+const PREDEFPAL_DIPLOMA: int = 0x1B
+
+## `PrinterStatusStringPointers`' eight strings in table order, by the status
+## each names. `null` is the empty string a status of zero prints, which is what
+## `PlacePrinterStatusString` returns early on rather than drawing.
+const PRINTER_STATUS_STRINGS: Array[String] = [
+	"null", "checking_link", "transmitting", "printing",
+	"error_1", "error_2", "error_3", "error_4",
+]
+
+## `_UnownPrinter`'s two `Request1bpp` glyphs, which the menu prints as `♂` and
+## `♀`: a bold A for PRINT and a bold B for CANCEL.
+const UNOWN_PRINTER_GLYPH_TILES: int = 2
+
+
 ## `_SlotMachine`'s own data run (engine/games/slot_machine.asm), as
 ## (cache name, kind, size). `strip` is a raw byte run of that many bytes and
 ## `lz` a compressed one of that many tiles. `Reel1Tilemap` pins the lot: the
@@ -2163,6 +2188,13 @@ const GOLD_SILVER: Dictionary = {
 	# `_UnownPuzzle`'s art, the same two pins as Crystal's at Gold and Silver's
 	# own addresses. Both cartridges carry it at the same offsets.
 	"unown_puzzle": {"tile_borders": 0xE1F30, "section": 0xE1FD2},
+	# `DiplomaGFX` and the two tilemaps behind it, at Gold and Silver's own
+	# address; located the way Crystal's is.
+	"diploma": 0xE0105,
+	# `UnownDexATile` behind `UnownDexVacantString`, and `GBPrinterStrings`
+	# behind `PrinterStatusStringPointers`' first entry.
+	"unown_printer_glyphs": 0x16FCC,
+	"printer_strings": 0x1C00C5,
 	# `_SlotMachine`'s run at Gold and Silver's own addresses, which are the same
 	# on both. The bet text sits at the end of bank $65 and the four behind it at
 	# the top of $66, which a byte walk crosses without noticing.
@@ -2655,6 +2687,17 @@ const CRYSTAL: Dictionary = {
 	# `UnownPuzzleCursorGFX` are the two pinned addresses; the walk in
 	# `UNOWN_PUZZLE_SECTION` reaches the five behind the cursor.
 	"unown_puzzle": {"tile_borders": 0xE1723, "section": 0xE17C5},
+	# `DiplomaGFX`, which `PlaceDiplomaOnScreen` decompresses and whose two
+	# `SCREEN_AREA` tilemaps are laid out behind it with nothing between them.
+	# Located off `.GameFreak`, the last of `PrintDiplomaPage2`'s own two
+	# strings: `db "GAME FREAK@"` is eleven bytes and the INCBIN follows it.
+	"diploma": 0x1DD805,
+	# `UnownDexATile`, the two 1bpp tiles `_UnownPrinter` requests into the
+	# menu's own A and B glyphs, seven bytes behind `UnownDexVacantString`.
+	"unown_printer_glyphs": 0x16D9C,
+	# `GBPrinterStrings`, which is `GBPrinterString_Null`'s own `"@"` with the
+	# other seven terminated strings behind it in table order.
+	"printer_strings": 0x1DC275,
 	# `_SlotMachine`'s data run and the sixteen palettes `_CGB_SlotMachine`
 	# copies. `section` is `Reel1Tilemap`, which walks the whole run; the three
 	# text pins are the stub blocks at the end of `Slots_AskBet`,

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -255,6 +255,8 @@ static func _characters() -> Dictionary:
 	table[0xE8] = "."
 	table[0xE9] = "&"
 	table[0xEA] = "é"
+	## `charmap "←", $df`, which `UnownDexMenuString` prints beside PREVIOUS.
+	table[0xDF] = "←"
 	table[0xEB] = "→"
 	table[UP_ARROW_CODE] = "▲"
 	table[0xEC] = "▷"

--- a/game/render/diploma_page.gd
+++ b/game/render/diploma_page.gd
@@ -94,9 +94,9 @@ func _draw_status(indices: PackedByteArray, status: String) -> void:
 	## blanked rather than showing through: the certificate's own lines sit in
 	## the same rows this box covers.
 	for row: int in STATUS_BOX_SIZE.y * TILE:
-		var line: int = (STATUS_BOX_AT.y * TILE + row) * WIDTH + STATUS_BOX_AT.x * TILE
+		var start: int = (STATUS_BOX_AT.y * TILE + row) * WIDTH + STATUS_BOX_AT.x * TILE
 		for column: int in STATUS_BOX_SIZE.x * TILE:
-			indices[line + column] = 0
+			indices[start + column] = 0
 	font.draw_box(
 		Gen2OptionsStore.current().textbox_frame, indices, WIDTH,
 		STATUS_BOX_AT.x * TILE, STATUS_BOX_AT.y * TILE,

--- a/game/render/diploma_page.gd
+++ b/game/render/diploma_page.gd
@@ -1,0 +1,148 @@
+class_name Gen2DiplomaPage
+extends RefCounted
+
+## `PlaceDiplomaOnScreen` and `PrintDiplomaPage2` (`engine/events/diploma.asm`),
+## the two whole screens the diploma is. Each is a stored tilemap with a few
+## strings written into it, so this owns the tilemap walk and the strings and
+## nothing else; node-free, so a check can read it back headless.
+##
+## A cell under `FONT_FIRST_CODE` names a tile of `DiplomaGFX` and a cell at or
+## above it names a font glyph, which is the hardware's own split: the art is
+## loaded into `vTiles2` and the font is already at the codes it prints under.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+const WIDTH: int = COLUMNS * TILE
+const HEIGHT: int = ROWS * TILE
+
+## `_Diploma`'s own three `PlaceString`s. `.EmptyString` at `hlcoord 15, 5` is
+## the `"@"` that prints nothing, so only the two that draw are here.
+const PLAYER_LABEL_AT: Vector2i = Vector2i(2, 5)
+const PLAYER_NAME_AT: Vector2i = Vector2i(9, 5)
+const CERTIFICATION_AT: Vector2i = Vector2i(2, 8)
+const CERTIFICATION: Array[String] = [
+	"This certifies", "that you have", "completed the",
+	"new #DEX.", "Congratulations!",
+]
+
+## `PrintDiplomaPage2`'s own three, and the colon `ld [hl], $67` writes between
+## the two halves of the play time.
+const GAME_FREAK_AT: Vector2i = Vector2i(8, 0)
+const PLAY_TIME_AT: Vector2i = Vector2i(3, 15)
+const PLAY_TIME_VALUE_AT: Vector2i = Vector2i(12, 15)
+const PLAY_TIME_HOUR_CELLS: int = 4
+## `ld [hl], $67`: a tile of `DiplomaGFX`, not a character code.
+const COLON_CODE: int = 0x67
+
+var font: Gen2Font = null
+var palette: PackedColorArray = PackedColorArray()
+
+var _tiles: PackedByteArray = PackedByteArray()
+var _maps: Array[PackedByteArray] = []
+
+
+static func from_data(data: GameData) -> Gen2DiplomaPage:
+	if data == null or not data.has_diploma():
+		return null
+	var page := Gen2DiplomaPage.new()
+	page.font = Gen2Font.from_data(data)
+	page.palette = data.diploma_palette()
+	page._tiles = data.diploma_indices()
+	page._maps = [data.diploma_tilemap(1), data.diploma_tilemap(2)]
+	if page.font == null or page.palette.is_empty() or page._tiles.is_empty():
+		return null
+	for map: PackedByteArray in page._maps:
+		if map.size() != RomLayout.DIPLOMA_TILEMAP_BYTES:
+			return null
+	return page
+
+
+## `PlacePrinterStatusString`: `Textbox` at `hlcoord 0, 5` with `lb bc, 10, 18`,
+## the status at `hlcoord 1, 7` and the cancel line at `hlcoord 2, 15`. It is
+## written into the page's own tilemap rather than laid over it, which is what
+## keeps the box the page's own colours.
+const STATUS_BOX_AT: Vector2i = Vector2i(0, 5)
+const STATUS_BOX_SIZE: Vector2i = Vector2i(20, 12)
+const STATUS_TEXT_AT: Vector2i = Vector2i(1, 7)
+const CANCEL_AT: Vector2i = Vector2i(2, 15)
+const CANCEL_STRING: String = "Press B to Cancel"
+
+
+## [param page] is 1 or 2. [param play_time] is `{hours, minutes}`, which page 2
+## prints and page 1 has no use for. [param status] is the printer's own status
+## line, empty for a page nothing is printing.
+func render(
+	page: int, player: String, play_time: Dictionary = {}, status: String = ""
+) -> Image:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	var map: PackedByteArray = _maps[clampi(page, 1, 2) - 1]
+	for cell: int in map.size():
+		_blit(indices, int(map[cell]), Vector2i(cell % COLUMNS, cell / COLUMNS))
+	if page == 2:
+		_draw_page_2(indices, play_time)
+	else:
+		_draw_page_1(indices, player)
+	if not status.is_empty():
+		_draw_status(indices, status)
+	return Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+
+
+func _draw_status(indices: PackedByteArray, status: String) -> void:
+	## `Textbox` is `ClearBox` and then the border, so the page under it is
+	## blanked rather than showing through: the certificate's own lines sit in
+	## the same rows this box covers.
+	for row: int in STATUS_BOX_SIZE.y * TILE:
+		var line: int = (STATUS_BOX_AT.y * TILE + row) * WIDTH + STATUS_BOX_AT.x * TILE
+		for column: int in STATUS_BOX_SIZE.x * TILE:
+			indices[line + column] = 0
+	font.draw_box(
+		Gen2OptionsStore.current().textbox_frame, indices, WIDTH,
+		STATUS_BOX_AT.x * TILE, STATUS_BOX_AT.y * TILE,
+		STATUS_BOX_SIZE.x, STATUS_BOX_SIZE.y
+	)
+	var line: int = 0
+	for row: String in status.split("\n"):
+		_text(indices, row, STATUS_TEXT_AT + Vector2i(0, line))
+		line += 1
+	_text(indices, CANCEL_STRING, CANCEL_AT)
+
+
+func _draw_page_1(indices: PackedByteArray, player: String) -> void:
+	_text(indices, "PLAYER", PLAYER_LABEL_AT)
+	_text(indices, player, PLAYER_NAME_AT)
+	for line: int in CERTIFICATION.size():
+		_text(indices, CERTIFICATION[line], CERTIFICATION_AT + Vector2i(0, line))
+
+
+## `PrintNum` twice: the hours in four cells with leading blanks, then the
+## colon, then the minutes in two with leading zeros.
+func _draw_page_2(indices: PackedByteArray, play_time: Dictionary) -> void:
+	_text(indices, "GAME FREAK", GAME_FREAK_AT)
+	_text(indices, "PLAY TIME", PLAY_TIME_AT)
+	var hours: String = String.num_int64(maxi(int(play_time.get("hours", 0)), 0))
+	_text(indices, hours.lpad(PLAY_TIME_HOUR_CELLS), PLAY_TIME_VALUE_AT)
+	var at: Vector2i = PLAY_TIME_VALUE_AT + Vector2i(PLAY_TIME_HOUR_CELLS, 0)
+	## `ld [hl], $67` writes a tile number rather than a character: the colon is
+	## `DiplomaGFX`'s own, since the art is what `vTiles2` holds while the page
+	## is up.
+	_blit(indices, COLON_CODE, at)
+	_text(
+		indices,
+		String.num_int64(maxi(int(play_time.get("minutes", 0)), 0)).lpad(2, "0"),
+		at + Vector2i(1, 0)
+	)
+
+
+func _text(indices: PackedByteArray, text: String, at: Vector2i) -> void:
+	font.draw_text(text, indices, WIDTH, at.x * TILE, at.y * TILE)
+
+
+func _blit(into: PackedByteArray, code: int, at: Vector2i) -> void:
+	if code >= RomLayout.FONT_FIRST_CODE:
+		font.draw_code(code, into, WIDTH, at.x * TILE, at.y * TILE)
+		return
+	Gen2Font.blit_slot(
+		_tiles, RomLayout.DIPLOMA_TILES * TILE, code, into, WIDTH, at.x * TILE, at.y * TILE
+	)

--- a/game/render/diploma_page.gd.uid
+++ b/game/render/diploma_page.gd.uid
@@ -1,0 +1,1 @@
+uid://bhdqjdofcsko8

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -48,6 +48,17 @@ const BALANCES_MONEY_AT: Vector2i = Vector2i(12, 1)
 const BALANCES_COIN_LABEL_AT: Vector2i = Vector2i(6, 3)
 const BALANCES_COIN_AT: Vector2i = Vector2i(15, 3)
 
+## `Mom_ContinueMenuSetup`'s own box and the three rows it prints in.
+## `hlcoord 13, 6` plus `wMomBankDigitCursorPosition` is the digit the cursor
+## blanks, which is the amount's first digit column.
+const BANK_AT: Vector2i = Vector2i(0, 0)
+const BANK_SIZE: Vector2i = Vector2i(20, 8)
+const BANK_LABEL_COLUMN: int = 1
+const BANK_VALUE_COLUMN: int = 12
+const BANK_DIGIT_COLUMN: int = 13
+const BANK_DIGITS: int = 6
+const BANK_ROWS: Array[int] = [2, 4, 6]
+
 ## `MenuHeader_Buy`: `menu_coords 1, 3, SCREEN_WIDTH - 1, TEXTBOX_Y - 1`, four
 ## rows of eight columns. `ScrollingMenu_InitFlags` puts the cursor on the left
 ## border coordinate itself and steps `$20`, which is two rows.
@@ -196,6 +207,53 @@ static func balance_window(
 	return {
 		"image": image.get_region(Rect2i(at * TILE, box * TILE)),
 		"at": at,
+	}
+
+
+## `Mom_ContinueMenuSetup`'s box (`engine/events/mom.asm`), drawn here for the
+## reason the three balance windows are: it is a money box, and `PrintNum` with
+## PRINTNUM_MONEY is what fills all four of them.
+##
+## `Textbox` at `hlcoord 0, 0` with `lb bc, 6, 18`, so eight rows and the whole
+## screen's width; SAVED against her balance, HELD against the player's and the
+## transaction's own word against the amount being typed.
+## `Mom_WithdrawDepositMenuJoypad` blanks the digit the cursor stands on for
+## sixteen frames in every thirty-two, which is `hVBlankCounter`'s bit 4, so an
+## off half of the blink is a missing digit rather than a mark beside one.
+static func bank_window(
+	data: GameData, word: String, saved: int, held: int, amount: String,
+	cursor: int, cursor_up: bool
+) -> Dictionary:
+	var page: Gen2MartPage = Gen2MartPage.from_data(data)
+	if page == null:
+		return {}
+	var width: int = Gen2Screen.WIDTH
+	var indices := PackedByteArray()
+	indices.resize(width * Gen2Screen.HEIGHT)
+	page.font.draw_box(
+		page.frame_style, indices, width,
+		BANK_AT.x * TILE, BANK_AT.y * TILE, BANK_SIZE.x, BANK_SIZE.y
+	)
+	var rows: Array = [
+		["SAVED", money_string(saved)], ["HELD", money_string(held)], [word, amount],
+	]
+	for index: int in rows.size():
+		var row: Array = rows[index]
+		var line: int = BANK_ROWS[index]
+		page._text(indices, width, String(row[0]), Vector2i(BANK_LABEL_COLUMN, line))
+		page._text(indices, width, String(row[1]), Vector2i(BANK_VALUE_COLUMN, line))
+	if not cursor_up:
+		page._text(
+			indices, width, " ",
+			Vector2i(BANK_DIGIT_COLUMN + clampi(cursor, 0, BANK_DIGITS - 1), BANK_ROWS[2])
+		)
+	var image: Image = Gen2PicImage.from_indices(
+		indices, width, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	return {
+		"image": image.get_region(Rect2i(BANK_AT * TILE, BANK_SIZE * TILE)),
+		"at": BANK_AT,
 	}
 
 

--- a/game/render/unown_printer_page.gd
+++ b/game/render/unown_printer_page.gd
@@ -1,0 +1,181 @@
+class_name Gen2UnownPrinterPage
+extends RefCounted
+
+## `_UnownPrinter` (`engine/events/print_unown.asm`), the ALPH RUINS STAMP
+## browser, and the page `PrintUnownStamp` builds out of it.
+##
+## Three `Textbox`es, three strings and one Unown frontpic; the menu's PRINT and
+## CANCEL rows are printed as `♂` and `♀` because `Request1bpp` has just
+## overwritten those two font tiles with a bold A and a bold B, so the two codes
+## are drawn from `UnownDexATile` rather than from the font.
+##
+## Node-free: the image is the whole product, so a check reads it back headless.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+const WIDTH: int = COLUMNS * TILE
+const HEIGHT: int = ROWS * TILE
+
+## The routine's own three boxes, as `Textbox` takes them: the top coordinate
+## and the interior's rows and columns, which frame two more of each.
+const BOXES: Array[Array] = [
+	[Vector2i(0, 0), Vector2i(18, 3)],
+	[Vector2i(0, 5), Vector2i(7, 7)],
+	[Vector2i(0, 14), Vector2i(18, 2)],
+]
+const TITLE_AT: Vector2i = Vector2i(1, 2)
+const TITLE: String = " ALPH RUINS STAMP"
+const PROMPT_AT: Vector2i = Vector2i(1, 16)
+const PROMPT: String = "Do what?"
+const MENU_AT: Vector2i = Vector2i(10, 6)
+const MENU: Array[String] = ["♂ PRINT", "♀ CANCEL", "← PREVIOUS", "→ NEXT"]
+## `hlcoord 1, 6` with `lb bc, 7, 7`, and `UnownDexVacantString` in the middle of
+## the same block when the browser is on the empty slot.
+const PIC_AT: Vector2i = Vector2i(1, 6)
+const VACANT_AT: Vector2i = Vector2i(1, 9)
+const VACANT: String = "VACANT"
+## `PlaceUnownPrinterFrontpic`: the whole screen blanked and the rotated stamp
+## at `hlcoord 7, 11`.
+const STAMP_AT: Vector2i = Vector2i(7, 11)
+## `NUM_UNOWN`, and the slot past the last letter, which is the vacant one.
+const LETTERS: int = 26
+const SLOTS: int = LETTERS + 1
+
+## `UNOWNSTAMP_BOLD_A` and `UNOWNSTAMP_BOLD_B`, the two codes the glyphs are
+## requested into.
+const BOLD_CODES: Array[int] = [0xEF, 0xF5]
+
+var font: Gen2Font = null
+var palette: PackedColorArray = PackedColorArray()
+
+var _data: GameData = null
+var _glyphs: PackedByteArray = PackedByteArray()
+
+
+static func from_data(data: GameData) -> Gen2UnownPrinterPage:
+	if data == null:
+		return null
+	var page := Gen2UnownPrinterPage.new()
+	page.font = Gen2Font.from_data(data)
+	page.palette = data.palette(RomLayout.UNOWN_SPECIES, false)
+	page._data = data
+	page._glyphs = data.tile_indices("unown_printer_glyphs")
+	if page.font == null or page.palette.size() < 4 or page._glyphs.is_empty():
+		return null
+	return page
+
+
+## The browser on [param slot], which is a letter under [constant LETTERS] and
+## the vacant page at it.
+func render(slot: int) -> Image:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	for box: Array in BOXES:
+		_box(indices, box[0], box[1])
+	_text(indices, TITLE, TITLE_AT)
+	_text(indices, PROMPT, PROMPT_AT)
+	for row: int in MENU.size():
+		_text(indices, MENU[row], MENU_AT + Vector2i(0, row * 2))
+	if slot >= LETTERS:
+		_text(indices, VACANT, VACANT_AT)
+		return Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+	var image: Image = Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+	_blend_pic(image, slot, PIC_AT, false)
+	return image
+
+
+## `PlaceUnownPrinterFrontpic`, which is what the printer is sent: the screen
+## blanked and the stamp rotated a quarter turn clockwise. `RotateUnownFrontpic`
+## does that twice over, once per tile with `.Rotate`'s bit walk and once over
+## the 7x7 block with `UnownPrinter_GBPrinterRectangle`, which together are one
+## rotation of the whole picture.
+func render_stamp(slot: int) -> Image:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	var image: Image = Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+	if slot < LETTERS:
+		_blend_pic(image, slot, STAMP_AT, true)
+	return image
+
+
+## `PlacePrinterStatusString`, the same box the diploma's printing loop stands
+## under, drawn over whatever page is up.
+func draw_status(image: Image, status: String) -> void:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	_box(
+		indices, Gen2DiplomaPage.STATUS_BOX_AT,
+		Gen2DiplomaPage.STATUS_BOX_SIZE - Vector2i(2, 2)
+	)
+	var line: int = 0
+	for row: String in status.split("\n"):
+		_text(indices, row, Gen2DiplomaPage.STATUS_TEXT_AT + Vector2i(0, line))
+		line += 1
+	_text(indices, Gen2DiplomaPage.CANCEL_STRING, Gen2DiplomaPage.CANCEL_AT)
+	var box: Image = Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+	var region := Rect2i(
+		Gen2DiplomaPage.STATUS_BOX_AT * TILE, Gen2DiplomaPage.STATUS_BOX_SIZE * TILE
+	)
+	image.blit_rect(
+		box.get_region(region), Rect2i(Vector2i.ZERO, region.size), region.position
+	)
+
+
+func _blend_pic(image: Image, slot: int, at: Vector2i, rotated: bool) -> void:
+	var pic: Dictionary = _data.unown_pic(slot)
+	if pic.is_empty():
+		return
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic
+	)
+	if cell.is_empty():
+		return
+	var width: int = int(cell["width"])
+	var height: int = int(cell["height"])
+	var pixels: PackedByteArray = cell["indices"]
+	if rotated:
+		pixels = _rotated(pixels, width, height)
+		var swapped: int = width
+		width = height
+		height = swapped
+	image.blend_rect(
+		Gen2PicImage.from_indices(pixels, width, height, palette),
+		Rect2i(Vector2i.ZERO, Vector2i(width, height)), at * TILE
+	)
+
+
+## A quarter turn clockwise: `dest(row, column) = source(height - 1 - column, row)`,
+## which is what `.Rotate`'s own bit walk does inside a tile and what the
+## rectangle table does to the tiles.
+static func _rotated(pixels: PackedByteArray, width: int, height: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(width * height)
+	for row: int in width:
+		for column: int in height:
+			out[row * height + column] = pixels[(height - 1 - column) * width + row]
+	return out
+
+
+## `Textbox`: the frame is two cells wider and taller than the interior it is
+## given, and the interior is cleared before it is drawn.
+func _box(indices: PackedByteArray, at: Vector2i, interior: Vector2i) -> void:
+	font.draw_box(
+		Gen2OptionsStore.current().textbox_frame, indices, WIDTH,
+		at.x * TILE, at.y * TILE, interior.x + 2, interior.y + 2
+	)
+
+
+func _text(indices: PackedByteArray, text: String, at: Vector2i) -> void:
+	var x: int = at.x * TILE
+	for code: int in Gen2Text.encode(text):
+		if code == Gen2Text.TERMINATOR:
+			break
+		if BOLD_CODES.has(code):
+			Gen2Font.blit_slot(
+				_glyphs, RomLayout.UNOWN_PRINTER_GLYPH_TILES * TILE,
+				BOLD_CODES.find(code), indices, WIDTH, x, at.y * TILE
+			)
+		else:
+			font.draw_code(code, indices, WIDTH, x, at.y * TILE)
+		x += TILE

--- a/game/render/unown_printer_page.gd.uid
+++ b/game/render/unown_printer_page.gd.uid
@@ -1,0 +1,1 @@
+uid://dvv3421mcmxj5

--- a/game/world/diploma_screen.gd
+++ b/game/world/diploma_screen.gd
@@ -1,0 +1,111 @@
+class_name Gen2DiplomaScreen
+extends Control
+
+## `_Diploma` and `_PrintDiploma` (`engine/events/diploma.asm`,
+## `engine/printer/printer.asm`), which are the same page under two loops.
+##
+## `_Diploma` is `PlaceDiplomaOnScreen` and `WaitPressAorB_BlinkCursor`, so
+## either button closes it. `_PrintDiploma` draws the same page and then holds
+## in `SendScreenToPrinter`, which prints whatever `CheckPrinterStatus` last
+## found; with nothing on the link `wPrinterHandshake` and `wPrinterStatusFlags`
+## both stay -1, which is PRINTER_ERROR_2, and B is the way out. That is not a
+## refusal invented here: it is the branch a Game Boy with no printer plugged in
+## takes, and there is no printer to plug in.
+##
+## Page 2 is therefore never drawn by the printing loop, because `.cancel` skips
+## it. [method preview_page] is what photographs it.
+
+signal closed()
+signal music_requested(index: int)
+
+## `MUSIC_PRINTER`, which `Printer_PlayMusic` starts before the send.
+const MUSIC_PRINTER: int = 0x5B
+
+## `CheckPrinterStatus`'s `.error_2`, the connection error a link with nothing
+## on it reaches.
+const STATUS_CONNECTION_ERROR: String = "error_2"
+
+var _page: Gen2DiplomaPage = null
+var _view: TextureRect = null
+var _player: String = ""
+var _play_time: Dictionary = {}
+var _status: String = ""
+var _printing: bool = false
+var _shown_page: int = 1
+var _open: bool = false
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## [param printing] is `_PrintDiploma` rather than `_Diploma`. Answers false on
+## a cache with no diploma art, which is what the caller refuses the special on
+## rather than opening an empty page.
+func open(
+	data: GameData, player: String, play_time: Dictionary, printing: bool = false
+) -> bool:
+	_page = Gen2DiplomaPage.from_data(data)
+	if _page == null:
+		visible = false
+		return false
+	_player = player
+	_play_time = play_time.duplicate()
+	_printing = printing
+	_status = data.printer_status_string(STATUS_CONNECTION_ERROR) if printing else ""
+	_open = true
+	visible = true
+	if printing:
+		music_requested.emit(MUSIC_PRINTER)
+	_refresh()
+	return true
+
+
+func page() -> Gen2DiplomaPage:
+	return _page
+
+
+## Which of the two pages is on screen, for a check that would otherwise read
+## pixels back.
+func shown_page() -> int:
+	return _shown_page
+
+
+func handle_button(button: int) -> bool:
+	if not _open:
+		return false
+	## `CheckCancelPrint` reads B alone; `WaitPressAorB_BlinkCursor` reads both.
+	if button == Gen2Button.B or (not _printing and button == Gen2Button.A):
+		close()
+	return true
+
+
+## The screenshot driver's own second page, which no loop here reaches: with a
+## printer on the link `SendScreenToPrinter` would return without carry and
+## `PrintDiplomaPage2` would draw it.
+func preview_page(page_number: int) -> void:
+	_shown_page = clampi(page_number, 1, 2)
+	_refresh()
+
+
+func close() -> void:
+	if not _open:
+		return
+	_open = false
+	visible = false
+	closed.emit()
+
+
+func _refresh() -> void:
+	if _page == null:
+		return
+	if _view == null:
+		_view = TextureRect.new()
+		_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		add_child(_view)
+	Gen2PicImage.show(_view, _page.render(
+		_shown_page, _player, _play_time,
+		_status if _shown_page == 1 else ""
+	))

--- a/game/world/diploma_screen.gd.uid
+++ b/game/world/diploma_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://qhcttxcwyb7

--- a/game/world/unown_printer_screen.gd
+++ b/game/world/unown_printer_screen.gd
@@ -1,0 +1,111 @@
+class_name Gen2UnownPrinterScreen
+extends Control
+
+## `_UnownPrinter`'s `.joy_loop` (`engine/events/print_unown.asm`): left and
+## right walk the twenty-six letters and the vacant slot behind them, wrapping
+## either way, B leaves and A sends the stamp to the printer.
+##
+## A therefore reaches `SendScreenToPrinter`, which prints whatever
+## `CheckPrinterStatus` last found. With nothing on the link `wPrinterHandshake`
+## and `wPrinterStatusFlags` stay -1, which is PRINTER_ERROR_2, and B is the way
+## back; the page under that box is `PlaceUnownPrinterFrontpic`'s, the stamp the
+## printer would have taken. There is no printer to plug in, so that is the
+## whole of what A can do here rather than a refusal invented for it.
+
+signal closed()
+signal music_requested(index: int)
+
+const MUSIC_PRINTER: int = Gen2DiplomaScreen.MUSIC_PRINTER
+const STATUS_CONNECTION_ERROR: String = Gen2DiplomaScreen.STATUS_CONNECTION_ERROR
+
+var _page: Gen2UnownPrinterPage = null
+var _view: TextureRect = null
+## `wJumptableIndex`, which this routine uses as the browser's own cursor.
+var _slot: int = 0
+var _status: String = ""
+var _printing: bool = false
+var _open: bool = false
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## Answers false on a cache with no printer glyphs, and on `ld a, [wUnownDex] /
+## and a / ret z`: with no Unown caught the routine returns before it draws
+## anything.
+func open(data: GameData, caught: int) -> bool:
+	_page = Gen2UnownPrinterPage.from_data(data)
+	if _page == null or caught <= 0:
+		visible = false
+		return false
+	_status = data.printer_status_string(STATUS_CONNECTION_ERROR)
+	_slot = 0
+	_printing = false
+	_open = true
+	visible = true
+	_refresh()
+	return true
+
+
+func slot() -> int:
+	return _slot
+
+
+func printing() -> bool:
+	return _printing
+
+
+func page() -> Gen2UnownPrinterPage:
+	return _page
+
+
+func handle_button(button: int) -> bool:
+	if not _open:
+		return false
+	if _printing:
+		## `CheckCancelPrint` reads B alone, and the send never ends on its own.
+		if button == Gen2Button.B:
+			_printing = false
+			music_requested.emit(0)
+			_refresh()
+		return true
+	match button:
+		Gen2Button.B:
+			close()
+		Gen2Button.A:
+			_printing = true
+			music_requested.emit(MUSIC_PRINTER)
+			_refresh()
+		Gen2Button.LEFT:
+			## `.press_left`: zero becomes `NUM_UNOWN + 1` before the decrement,
+			## so the vacant slot is what the first letter wraps back to.
+			_slot = Gen2UnownPrinterPage.SLOTS - 1 if _slot == 0 else _slot - 1
+			_refresh()
+		Gen2Button.RIGHT:
+			_slot = 0 if _slot >= Gen2UnownPrinterPage.SLOTS - 1 else _slot + 1
+			_refresh()
+	return true
+
+
+func close() -> void:
+	if not _open:
+		return
+	_open = false
+	visible = false
+	closed.emit()
+
+
+func _refresh() -> void:
+	if _page == null:
+		return
+	if _view == null:
+		_view = TextureRect.new()
+		_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		add_child(_view)
+	var image: Image = _page.render_stamp(_slot) if _printing else _page.render(_slot)
+	if _printing:
+		_page.draw_status(image, _status)
+	Gen2PicImage.show(_view, image)

--- a/game/world/unown_printer_screen.gd.uid
+++ b/game/world/unown_printer_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://ctu43ug2hcd8v

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1043,30 +1043,30 @@ const FIELD_MOVE_SOURCE_ITEM: StringName = &"item"
 ## request tests its own `CheckBadge` in the source's own order, so a player
 ## carrying HM01 without the Hive Badge is told about the badge, exactly as one
 ## whose Pokemon knows CUT is.
-func field_move_source(move: int) -> Dictionary:
-	var slot: int = party_slot_with_move(move)
+func field_move_source(move_id: int) -> Dictionary:
+	var slot: int = party_slot_with_move(move_id)
 	if slot >= 0:
 		return {
-			"kind": FIELD_MOVE_SOURCE_PARTY, "move": move, "slot": slot, "item": 0,
+			"kind": FIELD_MOVE_SOURCE_PARTY, "move": move_id, "slot": slot, "item": 0,
 		}
-	var item: int = item_field_move_source(move)
+	var item: int = item_field_move_source(move_id)
 	if item <= 0:
 		return {}
-	return {"kind": FIELD_MOVE_SOURCE_ITEM, "move": move, "slot": -1, "item": item}
+	return {"kind": FIELD_MOVE_SOURCE_ITEM, "move": move_id, "slot": -1, "item": item}
 
 
 ## The HM in the bag that teaches [param move] while a registered provider
 ## allows that move, or 0. Which item teaches which move is `GetTMHMItemMove`'s
 ## answer rather than a second table, so a cartridge whose HMs differ needs
 ## nothing here.
-func item_field_move_source(move: int) -> int:
+func item_field_move_source(move_id: int) -> int:
 	if data == null or state == null \
-		or not Gen2WorldFieldMove.is_hm_field_move(move) \
-		or not Gen2ModHost.allows_item_field_move(move):
+		or not Gen2WorldFieldMove.is_hm_field_move(move_id) \
+		or not Gen2ModHost.allows_item_field_move(move_id):
 		return 0
 	for raw_item: Variant in state.items():
 		var item: int = int(raw_item)
-		if Gen2WorldTMHM.is_hm(item) and Gen2WorldTMHM.move_for_item(data, item) == move:
+		if Gen2WorldTMHM.is_hm(item) and Gen2WorldTMHM.move_for_item(data, item) == move_id:
 			return item
 	return 0
 
@@ -1083,16 +1083,16 @@ func item_field_move_offers() -> Array:
 	if data == null or state == null:
 		return out
 	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
-	for move: int in Gen2WorldFieldMove.HM_FIELD_MOVES:
-		var source: Dictionary = field_move_source(move)
+	for move_id: int in Gen2WorldFieldMove.HM_FIELD_MOVES:
+		var source: Dictionary = field_move_source(move_id)
 		if StringName(source.get("kind", &"")) != FIELD_MOVE_SOURCE_ITEM:
 			continue
-		var badge: int = Gen2WorldFieldMove.badge_for_move(move)
+		var badge: int = Gen2WorldFieldMove.badge_for_move(move_id)
 		if badge >= 0 and not state.is_engine_flag_active(
 			Gen2WorldState.badge_flag(badge, crystal)
 		):
 			continue
-		out.append({"move": move, "item": int(source["item"]), "badge": badge})
+		out.append({"move": move_id, "item": int(source["item"]), "badge": badge})
 	return out
 
 
@@ -4049,10 +4049,10 @@ func _enqueue_script(request: Dictionary) -> void:
 		## resolved here and handed over the way collision and the clock are.
 		## Absent when nothing supplies one, which is every unmodded game.
 		var alternates: Dictionary = {}
-		for move: int in Gen2WorldFieldMove.HM_FIELD_MOVES:
-			var item: int = item_field_move_source(move)
+		for move_id: int in Gen2WorldFieldMove.HM_FIELD_MOVES:
+			var item: int = item_field_move_source(move_id)
 			if item > 0:
-				alternates[move] = item
+				alternates[move_id] = item
 		if not alternates.is_empty():
 			request["field_move_items"] = alternates
 	if not request.has("player_name") and not _player_name.is_empty():

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -73,7 +73,10 @@ static func complete_runtime_request(
 		}
 	if kind in [&"battle_requested", &"swarm_requested"]:
 		return {"ok": true, "handled": true, "results": world.complete_runtime_request(result)}
-	if kind == &"town_map_requested":
+	## Neither reads cartridge data of its own: the region map's landmark and the
+	## bank dial's amount are the whole answer, and the runner owns what is done
+	## with it.
+	if kind in [&"town_map_requested", &"mom_bank_dial_requested"]:
 		return {
 			"ok": true,
 			"handled": true,

--- a/game/world/world_money_dial.gd
+++ b/game/world/world_money_dial.gd
@@ -1,0 +1,83 @@
+class_name Gen2WorldMoneyDial
+extends RefCounted
+
+## `Mom_WithdrawDepositMenuJoypad` (`engine/events/mom.asm`), the six-digit money
+## dial her bank is the only caller of. It owns `wStringBuffer2`, the amount
+## being typed, and `wMomBankDigitCursorPosition`, which digit the cursor stands
+## on; the caller owns the box the three balances are drawn in.
+##
+## Not [Gen2WorldQuantityPrompt], which is `BuySellToss_InterpretJoypad`: that
+## dial steps one value against a ceiling and this one adds and subtracts a
+## power of ten per digit, so up on the hundreds column moves the amount by a
+## hundred rather than moving a digit.
+
+## `.DigitQuantities`, `10**x` for x from five down to nought. The table is
+## written out three times in the source and only the first sixth is indexed:
+## `.getdigitquantity` adds the cursor position three times, which is one
+## `bigdt` row.
+const DIGITS: int = 6
+## `MAX_MONEY`, which `GiveMoney` clamps the typed amount to.
+const MAXIMUM: int = Gen2WorldInventory.MAX_MONEY
+
+## `Mom_DepositString` and `Mon_WithdrawString`, the word over the amount and
+## the whole difference between the two headers.
+const MODE_DEPOSIT: StringName = &"deposit"
+const MODE_WITHDRAW: StringName = &"withdraw"
+const WORD_OF: Dictionary = {MODE_DEPOSIT: "DEPOSIT", MODE_WITHDRAW: "WITHDRAW"}
+
+const PENDING: StringName = &"pending"
+const CONFIRMED: StringName = &"confirmed"
+const CANCELLED: StringName = &"cancelled"
+
+## `Mom_SetUpDepositMenu` and `Mom_SetUpWithdrawMenu`, which differ only in the
+## word over the amount.
+var mode: StringName = MODE_DEPOSIT
+## `wMomsMoney` and `wMoney` as the box drew them, which is a picture rather
+## than a balance: the transaction is settled by the runner once A is pressed.
+var saved: int = 0
+var held: int = 0
+## `wStringBuffer2`, zeroed by `.StoreMoney` before the box opens.
+var value: int = 0
+## `wMomBankDigitCursorPosition`, `ld a, 5` on entry: the ones column.
+var cursor: int = DIGITS - 1
+
+
+static func open(mode_name: StringName, saved_balance: int, held_balance: int) -> Gen2WorldMoneyDial:
+	var dial := Gen2WorldMoneyDial.new()
+	dial.mode = mode_name
+	dial.saved = maxi(saved_balance, 0)
+	dial.held = maxi(held_balance, 0)
+	return dial
+
+
+func press(button: int) -> StringName:
+	match button:
+		Gen2Button.A:
+			return CONFIRMED
+		Gen2Button.B:
+			return CANCELLED
+		Gen2Button.UP:
+			## `.incrementdigit` is `GiveMoney`, so the whole amount is clamped
+			## at the ceiling rather than the digit wrapping.
+			value = mini(value + _step(), MAXIMUM)
+		Gen2Button.DOWN:
+			## `.decrementdigit` is `TakeMoney`, which leaves zero rather than
+			## borrowing past it.
+			value = maxi(value - _step(), 0)
+		Gen2Button.LEFT:
+			## `.movecursorleft` and `.movecursorright` both `ret` at the edge:
+			## the cursor stops rather than wrapping.
+			cursor = maxi(cursor - 1, 0)
+		Gen2Button.RIGHT:
+			cursor = mini(cursor + 1, DIGITS - 1)
+	return PENDING
+
+
+## What `PrintNum` draws with PRINTNUM_MONEY and PRINTNUM_LEADINGZEROS: six
+## digits behind the currency mark, with no blanks in front of them.
+func amount_string() -> String:
+	return "¥%s" % String.num_int64(value).lpad(DIGITS, "0")
+
+
+func _step() -> int:
+	return int(pow(10, DIGITS - 1 - cursor))

--- a/game/world/world_money_dial.gd.uid
+++ b/game/world/world_money_dial.gd.uid
@@ -1,0 +1,1 @@
+uid://dye0mqukgabep

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -2147,7 +2147,7 @@ static func _lucky_number_score(wanted: String, mon_id: int) -> int:
 static func _apply_give_shuckle(
 	world: Gen2WorldAPI,
 	candidate: Gen2SaveData,
-	request: Dictionary,
+	_request: Dictionary,
 	random: RandomNumberGenerator
 ) -> Dictionary:
 	if candidate.party.size() >= Gen2SaveData.MAX_PARTY:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3145,6 +3145,28 @@ func preview_name_rater() -> void:
 	_open_name_rater()
 
 
+## Public screenshot driver for `Mom_WithdrawDepositMenuJoypad`, whose box no
+## fixture cell reaches: her house is not one of the preview maps and the dial
+## stands three questions into her own routine.
+func preview_mom_bank(mode: StringName, saved: int, held: int) -> void:
+	if _world == null or _data == null or _service_host != null:
+		return
+	var host: Gen2WorldServiceScreen = SERVICE_SCENE.instantiate() as Gen2WorldServiceScreen
+	if host == null:
+		return
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	host.set_screen(_screen)
+	add_child(host)
+	if not host.open_mom_bank(_world, _data, mode, saved, held):
+		Gen2Screen.drop(host)
+		return
+	host.completed.connect(_on_service_completed)
+	host.sfx_requested.connect(_play_sfx)
+	_service_host = host
+	_refresh_labels()
+
+
 ## Public screenshot driver for the Day-Care's five specials, which no cell of
 ## the fixture maps reaches either. [param role] picks the routine; the two signs
 ## and the man outside need state behind them, so a slot is filled and the egg
@@ -6081,6 +6103,7 @@ func _show_script_results(results: Array) -> void:
 					&"mart_requested", &"phone_call_requested",
 					&"special_phone_call_requested", &"town_map_requested",
 					&"apricorn_selection_requested", &"pc_requested",
+					&"mom_bank_dial_requested",
 				]:
 					_open_service_host()
 					break

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2418,8 +2418,8 @@ func _offer_repel_renewal() -> bool:
 		return false
 	if _service_host != null or _overlay_open() or _field_move_text:
 		return false
-	var name: String = _data.item_name(item)
-	if not _open_host_prompt(REPEL_RENEWAL_TEXT % (name if not name.is_empty() else "REPEL")):
+	var repel: String = _data.item_name(item)
+	if not _open_host_prompt(REPEL_RENEWAL_TEXT % (repel if not repel.is_empty() else "REPEL")):
 		return false
 	_world.clear_repel_expired()
 	_repel_renewal_item = item

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -177,6 +177,8 @@ var _move_tutor_script_value: int = Gen2MoveTutor.SCRIPT_VALUE_CANCELLED
 ## do, so the save it was handed is kept beside it only to write nothing else.
 var _day_care_host: Gen2DayCareScreen = null
 var _unown_puzzle_host: Gen2UnownPuzzleScreen = null
+var _diploma_host: Gen2DiplomaScreen = null
+var _unown_printer_host: Gen2UnownPrinterScreen = null
 var _slot_machine_host: Gen2SlotMachineScreen = null
 var _card_flip_host: Gen2CardFlipScreen = null
 ## What `DayCareManOutside` left in wScriptVar, held between the screen finishing
@@ -632,7 +634,8 @@ func _apply_interface_mask() -> void:
 		or _name_rater_host != null or _move_deleter_host != null
 		or _move_tutor_host != null or _day_care_host != null
 		or _unown_puzzle_host != null or _slot_machine_host != null
-		or _card_flip_host != null
+		or _card_flip_host != null or _diploma_host != null
+		or _unown_printer_host != null
 	)
 	_screen.interface_masked = _screen.expanded and owned \
 		and Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
@@ -1055,7 +1058,8 @@ func _overlay_open() -> bool:
 		or _name_rater_host != null or _move_deleter_host != null \
 		or _move_tutor_host != null \
 		or _day_care_host != null or _unown_puzzle_host != null \
-		or _slot_machine_host != null or _card_flip_host != null
+		or _slot_machine_host != null or _card_flip_host != null \
+		or _diploma_host != null or _unown_printer_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world: a
@@ -1185,6 +1189,15 @@ func _handle_button(button: int) -> bool:
 	## The Day-Care's five, one screen with the same shape again.
 	if _day_care_host != null:
 		_day_care_host.handle_button(button)
+		return true
+	## `special UnownPrinter`, which owns the whole screen until B off its list.
+	if _unown_printer_host != null:
+		_unown_printer_host.handle_button(button)
+		return true
+	## `special Diploma`, which owns the whole screen until a button, and
+	## `special PrintDiploma`, which owns it until B.
+	if _diploma_host != null:
+		_diploma_host.handle_button(button)
 		return true
 	## `special UnownPuzzle`, which owns the whole screen until START or the
 	## last piece.
@@ -1909,6 +1922,86 @@ func _on_name_rater_closed() -> void:
 ## `special UnownPuzzle`. `FadeToMenu` in front of it and `ExitAllMenus` behind
 ## it are what the host's own overlay already is: the board covers the map and
 ## the map is redrawn when it closes.
+## `_Diploma`'s page, or `_PrintDiploma`'s with the printer's own status box
+## over it. The screen owns both loops; this only hands it the two things the
+## page prints that the cache does not carry.
+func _open_diploma(request: Dictionary) -> bool:
+	if _diploma_host != null or _world == null or _data == null:
+		return false
+	var host := Gen2DiplomaScreen.new()
+	host.z_index = 30
+	## Displayed before it draws: `Gen2PicImage.show` hands the picture to the
+	## screen the node stands in, and a node not in one yet tells it nothing, so
+	## the surround would keep the map behind a page that fills the hardware.
+	_screen.display(host)
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	var clock: Gen2GameTime = save.game_time if save != null else null
+	if not host.open(
+		_data, _player_display_name(),
+		{
+			"hours": clock.hours if clock != null else 0,
+			"minutes": clock.minutes if clock != null else 0,
+		},
+		bool((request.get("values", {}) as Dictionary).get("printing", false))
+	):
+		Gen2Screen.drop(host)
+		_script_prompt = "Diploma unavailable: diploma_art_unavailable"
+		return false
+	host.closed.connect(_on_diploma_closed)
+	host.music_requested.connect(_play_music_track)
+	_diploma_host = host
+	## Here as well as on the next frame: a screen opened by a driver that spends
+	## no frame would otherwise stand with the map around it.
+	_apply_interface_mask()
+	_script_prompt = "Diploma"
+	_refresh_labels()
+	return true
+
+
+func _on_diploma_closed() -> void:
+	var host: Gen2DiplomaScreen = _diploma_host
+	_diploma_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	## `Printer_RestartMapMusic`, and `ExitAllMenus` behind both specials.
+	_play_current_map_music()
+	_show_script_results(_world.complete_runtime_request({"ok": true}))
+
+
+## `_UnownPrinter`'s browser. The dex count comes from the request rather than
+## from here, so the runner and the screen answer the same `ret z`.
+func _open_unown_printer(request: Dictionary) -> bool:
+	if _unown_printer_host != null or _world == null or _data == null:
+		return false
+	var host := Gen2UnownPrinterScreen.new()
+	host.z_index = 30
+	_screen.display(host)
+	if not host.open(
+		_data, int((request.get("values", {}) as Dictionary).get("caught", 0))
+	):
+		Gen2Screen.drop(host)
+		_script_prompt = "Unown printer unavailable: no Unown caught"
+		return false
+	host.closed.connect(_on_unown_printer_closed)
+	host.music_requested.connect(_play_music_track)
+	_unown_printer_host = host
+	_apply_interface_mask()
+	_script_prompt = "Unown printer"
+	_refresh_labels()
+	return true
+
+
+func _on_unown_printer_closed() -> void:
+	var host: Gen2UnownPrinterScreen = _unown_printer_host
+	_unown_printer_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	## `RestartMapMusic` behind `.pressed_b`, and `ReturnToMapFromSubmenu`.
+	_play_current_map_music()
+	_show_script_results(_world.complete_runtime_request({"ok": true}))
+
+
 func _open_unown_puzzle(request: Dictionary) -> bool:
 	if _unown_puzzle_host != null or _world == null or _data == null:
 		return false
@@ -3143,6 +3236,31 @@ func preview_name_rater() -> void:
 	_injected_save = save
 	_world.set_player_id(save.player_id)
 	_open_name_rater()
+
+
+## Public screenshot driver for `_UnownPrinter`, which no fixture cell reaches
+## and which a world with no caught Unown never opens: [param slot] is the
+## browser's own cursor and [param printing] the page A sends.
+func preview_unown_printer(slot: int = 0, printing: bool = false) -> void:
+	if not _open_unown_printer({"values": {"caught": 1}}):
+		return
+	if _unown_printer_host == null:
+		return
+	for _step: int in maxi(slot, 0):
+		_unown_printer_host.handle_button(Gen2Button.RIGHT)
+	if printing:
+		_unown_printer_host.handle_button(Gen2Button.A)
+
+
+## Public screenshot driver for `_Diploma` and `_PrintDiploma`, which no fixture
+## cell reaches: the diploma is one flag deep into the Hall of Fame's own script.
+## [param page] is 1 or 2, and 2 is the page only a printer that answered would
+## have reached.
+func preview_diploma(printing: bool = false, page: int = 1) -> void:
+	if not _open_diploma({"values": {"printing": printing}}):
+		return
+	if _diploma_host != null and page != 1:
+		_diploma_host.preview_page(page)
 
 
 ## Public screenshot driver for `Mom_WithdrawDepositMenuJoypad`, whose box no
@@ -6066,6 +6184,20 @@ func _show_script_results(results: Array) -> void:
 						)),
 					}))
 					return
+				if StringName(request.get("kind", &"")) == &"unown_printer_requested":
+					if _open_unown_printer(request):
+						break
+					## `ret z` on an empty dex, and the same answer for a cache
+					## with no glyphs: the script runs straight on.
+					_show_script_results(_world.complete_runtime_request({"ok": true}))
+					return
+				if StringName(request.get("kind", &"")) == &"diploma_requested":
+					if _open_diploma(request):
+						break
+					## A cache with no diploma art answers the script the way a
+					## page that has been read does: it writes nothing either.
+					_show_script_results(_world.complete_runtime_request({"ok": true}))
+					return
 				if StringName(request.get("kind", &"")) == &"unown_puzzle_requested":
 					if _open_unown_puzzle(request):
 						break
@@ -6714,6 +6846,18 @@ func _fade_to_map_music() -> void:
 ## the track a tuned radio station left there survives until the player leaves
 ## the map. Restarting a piece that is already playing is a presentation
 ## difference from the source, which compares before it restarts.
+## One music track by its own index, for a screen that starts its own: the
+## printer's is the first, and `_play_current_map_music` is what puts the map's
+## back.
+func _play_music_track(index: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	var record: Dictionary = _data.world_audio(&"music", index)
+	if record.is_empty():
+		return
+	_audio_player.play_record(record, &"map_music", _audio_assets())
+
+
 func _play_current_map_music() -> void:
 	if _audio_player == null or _data == null or _world == null or _world.current_map == null:
 		return

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -449,6 +449,7 @@ const ITEM_WATER_STONE: int = 24
 const SPECIAL_CHECK_MAGIKARP_LENGTH: int = 25
 const SPECIAL_MAGIKARP_HOUSE_SIGN: int = 26
 const SPECIAL_BANK_OF_MOM: int = 34
+const SPECIAL_UNOWN_PRINTER: int = 39
 const SPECIAL_MAP_RADIO: int = 40
 ## `constants/script_constants.asm`'s MOMS_MONEY, the account her bank holds.
 const ACCOUNT_MOMS_MONEY: int = 1
@@ -490,6 +491,8 @@ const SPECIAL_RESET_LUCKY_NUMBER_SHOW_FLAG: int = 84
 const SPECIAL_PRINT_TODAYS_LUCKY_NUMBER: int = 85
 const SPECIAL_TRAINER_HOUSE: int = 103
 const SPECIAL_PHOTO_STUDIO: int = 104
+const SPECIAL_DIPLOMA: int = 107
+const SPECIAL_PRINT_DIPLOMA: int = 108
 const SPECIAL_OMANYTE_CHAMBER: int = 132
 const SPECIAL_HO_OH_CHAMBER: int = 141
 const SPECIAL_CELEBI_SHRINE_EVENT: int = 143
@@ -1245,6 +1248,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## `GiveDratini` rewrites four move slots and answers nothing: every one
 		## of its scripts runs straight on.
 		&"dratini_moveset_requested",
+		## `_Diploma`, `_PrintDiploma` and `_UnownPrinter` write nothing either:
+		## the page stands until a button and the script runs on behind it.
+		&"diploma_requested", &"unown_printer_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -3498,6 +3504,23 @@ func _execute_special(special: int) -> Dictionary:
 			return _stage_internal_text(sign_box, false, {"special": special})
 		SPECIAL_BANK_OF_MOM:
 			return _bank_of_mom(MOM_CHECK_INITIALIZED)
+		SPECIAL_UNOWN_PRINTER:
+			## `ld a, [wUnownDex] / and a / ret z`: with no Unown caught the
+			## routine draws nothing at all, which the host answers for since it
+			## is the one that holds the dex.
+			return _stage_runtime_request(&"unown_printer_requested", {
+				"special": special,
+				"caught": state.unown_caught_count() if state != null else 0,
+			})
+		SPECIAL_DIPLOMA, SPECIAL_PRINT_DIPLOMA:
+			## `_Diploma` draws `PlaceDiplomaOnScreen`'s page and waits for a
+			## button; `_PrintDiploma` draws the same page and then holds in
+			## `SendScreenToPrinter`. Neither writes anything a script reads, so
+			## the request carries only which of the two loops is standing.
+			return _stage_runtime_request(&"diploma_requested", {
+				"special": special,
+				"printing": special == SPECIAL_PRINT_DIPLOMA,
+			})
 		SPECIAL_BUENA_PRIZE:
 			## The counter is one loop: the prize list, a yes/no on the row, and
 			## whichever of the four boxes the answer reaches. B on the list is

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -47,6 +47,11 @@ var _staged_lucky_number_day: int = 0
 var _staged_caught_species: Dictionary = {}
 var _staged_best_magikarp: Dictionary = {}
 var _staged_blue_card_balance: int = -1
+var _staged_mom_savings_flags: int = -1
+## `SFX_TRANSACTION` and the `WaitSFX` behind it, which stand between the
+## transfer and the box that reports it.
+var _bank_of_mom_after_sound: int = -1
+var _mom_receipt_box: String = ""
 var _reset_phone_receive_timer: bool = false
 var _events: Array = []
 var _pending: Dictionary = {}
@@ -445,6 +450,37 @@ const SPECIAL_CHECK_MAGIKARP_LENGTH: int = 25
 const SPECIAL_MAGIKARP_HOUSE_SIGN: int = 26
 const SPECIAL_BANK_OF_MOM: int = 34
 const SPECIAL_MAP_RADIO: int = 40
+## `constants/script_constants.asm`'s MOMS_MONEY, the account her bank holds.
+const ACCOUNT_MOMS_MONEY: int = 1
+## `ram_constants.asm`'s wMomSavingMoney. Bit 7 is whether the bank has ever
+## been opened; the low three are how much of a battle prize she keeps, and only
+## MOM_SAVING_SOME_MONEY is ever written, since that is the one tier her menu
+## offers. Nothing spends the tier here: prize money is a deliberate divergence.
+const MOM_ACTIVE: int = 1 << 7
+const MOM_SAVING_SOME_MONEY: int = 1 << 0
+## `BankOfMom.dw`, the jumptable this routine walks. `wJumptableIndex` is the
+## whole of its state, so each index below is one staged box, menu or dial and
+## the loop around `.RunJumptable` is the chain of them.
+const MOM_CHECK_INITIALIZED: int = 0
+const MOM_INITIALIZE: int = 1
+const MOM_IS_THIS_ABOUT_YOUR_MONEY: int = 2
+const MOM_ACCESS_BANK: int = 3
+const MOM_STORE_MONEY: int = 4
+const MOM_TAKE_MONEY: int = 5
+const MOM_STOP_OR_START_SAVING: int = 6
+const MOM_JUST_DO_WHAT_YOU_CAN: int = 7
+## `.AskDST`, which sets JUMPTABLE_EXIT_F and asks nothing: `DSTChecks` is
+## reached from `.IsThisAboutYourMoney` instead.
+const MOM_EXIT: int = 8
+## `BankOfMom_MenuHeader.MenuData`'s four rows and the index each reaches.
+const MOM_MENU_ROWS: Array[String] = ["GET", "SAVE", "CHANGE", "CANCEL"]
+const MOM_MENU_TARGETS: Array[int] = [
+	MOM_TAKE_MONEY, MOM_STORE_MONEY, MOM_STOP_OR_START_SAVING, MOM_JUST_DO_WHAT_YOU_CAN,
+]
+## Which way `Mom_WithdrawDepositMenuJoypad`'s dial moves the money, named by
+## the model that draws it rather than a second time here.
+const MOM_DIAL_DEPOSIT: StringName = Gen2WorldMoneyDial.MODE_DEPOSIT
+const MOM_DIAL_WITHDRAW: StringName = Gen2WorldMoneyDial.MODE_WITHDRAW
 const SPECIAL_GAME_CORNER_PRIZE_MON_CHECK_DEX: int = 57
 const SPECIAL_GIVE_SHUCKLE: int = 75
 const SPECIAL_RETURN_SHUCKIE: int = 76
@@ -621,7 +657,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		if not acknowledge:
 			return _waiting_result()
 		var pending_type: StringName = StringName(_pending.get("type", &""))
-		if pending_type == &"menu" and _pending.get("special", &"") == &"set_day_of_week":
+		if pending_type == &"menu" and _pending_tag() == &"set_day_of_week":
 			if choice < 0:
 				return _waiting_result()
 			var selected_day: int = posmod(choice, WEEKDAY_NAMES.size())
@@ -636,7 +672,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"source": _request.duplicate(true),
 			}
 			return _waiting_result()
-		if pending_type == &"menu" and _pending.get("special", &"") == &"buenas_password":
+		if pending_type == &"menu" and _pending_tag() == &"buenas_password":
 			## `STATICMENU_DISABLE_B`: B does not close the list, so the only way
 			## out is a row. The answer is whether it is the row the byte's own
 			## low nibble names, which `maskbits NUM_PASSWORDS_PER_CATEGORY`
@@ -647,13 +683,11 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			_pending = {}
 			_script_value = 1 if choice == (password & 0x3) else 0
 			return advance()
-		if pending_type == &"text" and _pending.get("special", &"") == &"set_day_of_week_confirmation":
+		if pending_type == &"text" and _pending_tag() == &"set_day_of_week_confirmation":
 			var confirmation_day: int = int(_pending.get("day", 0))
 			_stage_day_of_week_confirmation(confirmation_day)
 			return _waiting_result()
-		if pending_type == &"choice" and _pending.get("special", &"") == &"set_day_of_week_confirmation":
-			if choice < 0:
-				return _waiting_result()
+		if pending_type == &"choice" and _pending_tag() == &"set_day_of_week_confirmation":
 			var confirmed_day: int = int(_pending.get("day", 0))
 			_pending = {}
 			if choice == 0:
@@ -664,7 +698,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			return _waiting_result()
 		## AskStrengthScript's `.AskStrength`: opentext, writetext, yesorno. The
 		## text pause is acknowledged first, then the choice is offered.
-		if pending_type == &"text" and _pending.get("special", &"") == &"strength_ask":
+		if pending_type == &"text" and _pending_tag() == &"strength_ask":
 			_pending = {
 				"type": &"choice",
 				"command": &"yesorno",
@@ -675,9 +709,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"source": _request.duplicate(true),
 			}
 			return _waiting_result()
-		if pending_type == &"choice" and _pending.get("special", &"") == &"strength_ask":
-			if choice < 0:
-				return _waiting_result()
+		if pending_type == &"choice" and _pending_tag() == &"strength_ask":
 			var chosen_slot: int = int(_pending.get("slot", -1))
 			_pending = {}
 			## `iftrue Script_UsedStrength`, and a no falls to closetext/end.
@@ -687,7 +719,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			_stage_strength_used(chosen_slot)
 			return _waiting_result()
 		## FruitTreeScript's promptbutton, behind which its two callasms sit.
-		if pending_type == &"text" and _pending.get("special", &"") == &"fruit_tree":
+		if pending_type == &"text" and _pending_tag() == &"fruit_tree":
 			var fruit_tree: int = int(_pending.get("tree_id", 0))
 			var fruit_item: int = int(_pending.get("item", 0))
 			_pending = {}
@@ -698,7 +730,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			return _waiting_result()
 		## The tail every item receipt shares behind its own line: the sound, and
 		## then `itemnotify`'s box once the host has played it.
-		if pending_type == &"text" and _pending.get("special", &"") == &"item_received":
+		if pending_type == &"text" and _pending_tag() == &"item_received":
 			var receipt_item: int = int(_pending.get("item", 0))
 			var receipt_sfx: int = int(_pending.get("sfx", 0))
 			var receipt_finish: bool = bool(_pending.get("finish", false))
@@ -707,7 +739,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			_stage_receipt_tail(receipt_item, receipt_sfx, receipt_finish)
 			return _waiting_result()
 		## `GiveItemScript.Full`, whose `promptbutton` is the acknowledge above.
-		if pending_type == &"text" and _pending.get("special", &"") == &"pocket_is_full":
+		if pending_type == &"text" and _pending_tag() == &"pocket_is_full":
 			var full_item: int = int(_pending.get("item", 0))
 			var full_finish: bool = bool(_pending.get("finish", false))
 			_pending = {}
@@ -715,7 +747,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			_stage_pocket_is_full(full_item, full_finish)
 			return _waiting_result()
 		## Script_UsedStrength's second writetext, _MoveBoulderText.
-		if pending_type == &"text" and _pending.get("special", &"") == &"strength_used":
+		if pending_type == &"text" and _pending_tag() == &"strength_used":
 			var used_name: String = String(_pending.get("name", "#MON"))
 			_stage_internal_text("%s can\nmove boulders." % used_name, true)
 			return _waiting_result()
@@ -733,7 +765,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"next_internal_texts": chained,
 			})
 			return _waiting_result()
-		if pending_type == &"menu" and _pending.get("special", &"") == &"buena_prize":
+		if pending_type == &"menu" and _pending_tag() == &"buena_prize":
 			var prize_special: int = int(_pending.get("prize_special", 0))
 			if choice < 0:
 				## `Buena_PrizeMenu`'s `.cancel`: B leaves the counter, and both
@@ -761,15 +793,71 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"source": _request.duplicate(true),
 			}
 			return _waiting_result()
-		if pending_type == &"choice" and _pending.get("special", &"") == &"buena_prize_confirm":
-			if choice < 0:
-				return _waiting_result()
+		if pending_type == &"choice" and _pending_tag() == &"buena_prize_confirm":
 			var confirm_row: int = int(_pending.get("prize", 0))
 			var confirm_special: int = int(_pending.get("prize_special", 0))
 			_pending = {}
 			if choice != 0:
 				return _stage_buena_prize_menu(confirm_special)
 			return _buy_buena_prize(confirm_special, confirm_row)
+		if pending_type == &"menu" and _pending_tag() == &"bank_of_mom_menu":
+			_pending = {}
+			if choice < 0:
+				return _mom_result(_bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN))
+			return _mom_result(_bank_of_mom(
+				MOM_MENU_TARGETS[clampi(choice, 0, MOM_MENU_TARGETS.size() - 1)]
+			))
+		if pending_type == &"choice" and _pending_tag() == &"bank_of_mom_choice":
+			var mom_state: int = int(_pending.get("mom_state", MOM_EXIT))
+			var mom_yes: bool = choice == 0
+			_pending = {}
+			match mom_state:
+				MOM_INITIALIZE:
+					## `MomLeavingText3` is printed either way; YES adds the tier
+					## she keeps and NO leaves the account open and saving
+					## nothing.
+					_staged_mom_savings_flags = MOM_ACTIVE \
+						| (MOM_SAVING_SOME_MONEY if mom_yes else 0)
+					if not mom_yes:
+						return _mom_result(_mom_box("leaving_3", MOM_EXIT))
+					var second: String = _special_box("bank_of_mom", "leaving_2")
+					var third: String = _special_box("bank_of_mom", "leaving_3")
+					if second.is_empty() or third.is_empty():
+						return _fail(
+							&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM}
+						)
+					return _mom_result(_stage_internal_text(second, false, {
+						"special": SPECIAL_BANK_OF_MOM, "next_internal_texts": [third],
+					}))
+				MOM_IS_THIS_ABOUT_YOUR_MONEY:
+					return _mom_result(_bank_of_mom(
+						MOM_ACCESS_BANK if mom_yes else MOM_JUST_DO_WHAT_YOU_CAN
+					))
+				MOM_STOP_OR_START_SAVING:
+					_staged_mom_savings_flags = MOM_ACTIVE \
+						| (MOM_SAVING_SOME_MONEY if mom_yes else 0)
+					if not mom_yes:
+						return _mom_result(_bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN))
+					return _mom_result(_mom_box("start_saving_money", MOM_EXIT))
+			return _fail(&"invalid_bank_of_mom_state", {"state": mom_state})
+		## Her own boxes, each with the jumptable index that follows it.
+		if pending_type == &"text" and _pending.has("bank_of_mom_after_text"):
+			var mom_next: int = int(_pending["bank_of_mom_after_text"])
+			_pending = {}
+			_finish_after_pending = false
+			return _mom_result(_bank_of_mom(mom_next))
+		## `Mom_SetUpDepositMenu` stands behind the question rather than over it.
+		if pending_type == &"text" and _pending.has("bank_of_mom_dial"):
+			var mom_mode: StringName = StringName(_pending["bank_of_mom_dial"])
+			_pending = {}
+			_finish_after_pending = false
+			_stage_runtime_request(&"mom_bank_dial_requested", {
+				"special": SPECIAL_BANK_OF_MOM,
+				"mode": mom_mode,
+				"saved": _money_balance(ACCOUNT_MOMS_MONEY),
+				"held": _money_balance(ACCOUNT_YOUR_MONEY),
+			})
+			return _waiting_result()
 		## A box the prize counter printed, which goes back to her list rather
 		## than ending: `.print` falls into `.loop`.
 		if pending_type == &"text" and _pending.has("buena_prize_after_text"):
@@ -802,7 +890,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			return _waiting_result() if _pending else advance()
 		## The five Ask*Scripts TryTileCollisionEvent reaches, all one shape:
 		## opentext, writetext, yesorno, iftrue <the move>, closetext, end.
-		if pending_type == &"text" and _pending.get("special", &"") == &"field_move_ask":
+		if pending_type == &"text" and _pending_tag() == &"field_move_ask":
 			_pending = {
 				"type": &"choice",
 				"command": &"yesorno",
@@ -814,9 +902,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"source": _request.duplicate(true),
 			}
 			return _waiting_result()
-		if pending_type == &"choice" and _pending.get("special", &"") == &"field_move_ask":
-			if choice < 0:
-				return _waiting_result()
+		if pending_type == &"choice" and _pending_tag() == &"field_move_ask":
 			var asked_move: int = int(_pending.get("move", 0))
 			var asked_slot: int = int(_pending.get("slot", -1))
 			_pending = {}
@@ -830,7 +916,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				})
 			return _complete()
 		## AskRockSmashScript, the same opentext/writetext/yesorno shape.
-		if pending_type == &"text" and _pending.get("special", &"") == &"rock_smash_ask":
+		if pending_type == &"text" and _pending_tag() == &"rock_smash_ask":
 			_pending = {
 				"type": &"choice",
 				"command": &"yesorno",
@@ -841,9 +927,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"source": _request.duplicate(true),
 			}
 			return _waiting_result()
-		if pending_type == &"choice" and _pending.get("special", &"") == &"rock_smash_ask":
-			if choice < 0:
-				return _waiting_result()
+		if pending_type == &"choice" and _pending_tag() == &"rock_smash_ask":
 			var smash_slot: int = int(_pending.get("slot", -1))
 			_pending = {}
 			## `iftrue RockSmashScript`, and a no falls to closetext/end.
@@ -855,7 +939,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		## RockSmashScript's `closetext`, `special WaitSFX` and
 		## `playsound SFX_STRENGTH`. The rest of the script waits on the sound
 		## the way a trainer's approach waits on its encounter music.
-		if pending_type == &"text" and _pending.get("special", &"") == &"rock_smash_used":
+		if pending_type == &"text" and _pending_tag() == &"rock_smash_used":
 			_pending = {}
 			_rock_smash_after_sound = true
 			_stage_audio_request(&"sound", {"address": SFX_STRENGTH})
@@ -1031,6 +1115,25 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		):
 			return _fail(&"phone_script_missing", phone_script)
 		return advance()
+	if kind == &"mom_bank_dial_requested":
+		if not bool(result.get("ok", false)):
+			return _fail(
+				StringName(result.get("reason", &"mom_bank_dial_failed")), result
+			)
+		var dial_mode: StringName = StringName(
+			(request.get("values", {}) as Dictionary).get("mode", MOM_DIAL_DEPOSIT)
+		)
+		## A cancelled box answers -1, which is `.CancelDeposit`'s own zero
+		## amount one step earlier.
+		var dial_amount: int = int(result.get("amount", -1))
+		_events.append({
+			"type": &"runtime_request_completed",
+			"kind": kind,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
+		return _mom_result(_finish_mom_bank_dial(dial_mode, maxi(dial_amount, 0)))
 	if kind == &"party_selection_requested":
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -1162,7 +1265,14 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 			== &"sound" and _rock_smash_after_sound
 		var notify_after_sound: Dictionary = _item_notify_after_sound \
 			if kind == &"audio_requested" else {}
+		var mom_after_sound: int = _bank_of_mom_after_sound \
+			if kind == &"audio_requested" else -1
 		_pending = {}
+		if mom_after_sound >= 0:
+			_bank_of_mom_after_sound = -1
+			var receipt: String = _mom_receipt_box
+			_mom_receipt_box = ""
+			return _mom_result(_mom_box(receipt, mom_after_sound))
 		if approach_after_audio:
 			_trainer_intro_approach_pending = false
 			_stage_trainer_approach()
@@ -1321,6 +1431,16 @@ func complete_wait() -> Dictionary:
 
 ## Cancels a pending menu or choice without inventing a cartridge option. The
 ## script receives zero, matching the false branch used by yes/no commands.
+## The pendings a built-in routine owns the B of. Everything else staged as a
+## `choice` or a `menu` is the cartridge's own command, whose B is the false
+## answer `cancel_input` writes.
+const CANCEL_OWNED_PENDINGS: Array[StringName] = [
+	&"buena_prize", &"buena_prize_confirm", &"bank_of_mom_menu", &"bank_of_mom_choice",
+	&"strength_ask", &"field_move_ask", &"rock_smash_ask",
+	&"set_day_of_week_confirmation",
+]
+
+
 func cancel_input() -> Dictionary:
 	if _pending.is_empty() or StringName(_pending.get("type", &"")) not in [&"choice", &"menu"]:
 		return {
@@ -1329,6 +1449,13 @@ func cancel_input() -> Dictionary:
 			"reason": &"script_input_not_cancellable",
 		}
 	var pending_type: StringName = StringName(_pending.get("type", &""))
+	## A box one of the built-in routines put up answers its own B rather than
+	## resuming: Buena's counter prints her parting line, Mom falls to
+	## `.JustDoWhatYouCan`, and every `YesNoBox` among them reads it as its NO,
+	## which is the carry the routine returns. A `Script_yesorno` or a
+	## `Script_verticalmenu` the cartridge staged is the false answer below.
+	if _pending_tag() in CANCEL_OWNED_PENDINGS:
+		return advance(true, -1)
 	if pending_type == &"choice" and _pending.has("contact"):
 		_emit_runtime_event(&"phone_number_result", {
 			"contact": int(_pending.get("contact", -1)), "accepted": false,
@@ -2357,19 +2484,20 @@ func _stage_item_delta(item: int, delta: int) -> Dictionary:
 	return {"ok": true}
 
 
+## `GiveMoney` and `TakeMoney` (`engine/events/money.asm`). Neither refuses and
+## neither leaves the account alone: a gift past `MAX_MONEY` writes the ceiling
+## and a payment past the balance writes zero, both returning the carry that
+## only `BankOfMom` reads. `Script_givemoney` and `Script_takemoney` write no
+## wScriptVar of their own, so what they answer is the balance rather than a
+## rejection.
 func _stage_money_delta(account: int, amount: int, give: bool) -> Dictionary:
 	if account < 0 or amount < 0:
 		return {"ok": false, "reason": &"invalid_money_command"}
 	var current: int = _money_balance(account)
-	var next: int = current + amount if give else current - amount
-	if next < 0:
-		_script_value = 0
-		_emit_runtime_event(&"money_change_rejected", {
-			"account": account, "amount": amount, "available": current,
-		})
-		return {"ok": true}
+	var next: int = clampi(
+		current + amount if give else current - amount, 0, Gen2WorldInventory.MAX_MONEY
+	)
 	_staged_money[account] = next
-	_script_value = 1
 	_emit_runtime_event(&"money_changed", {
 		"account": account, "amount": amount, "balance": next,
 		"direction": &"give" if give else &"take",
@@ -2377,19 +2505,15 @@ func _stage_money_delta(account: int, amount: int, give: bool) -> Dictionary:
 	return {"ok": true}
 
 
+## `GiveCoins` and `TakeCoins`, the same pair of ceilings one account over.
 func _stage_coins_delta(amount: int, give: bool) -> Dictionary:
 	if amount < 0:
 		return {"ok": false, "reason": &"invalid_coins_command"}
 	var current: int = _coins_value()
-	var next: int = current + amount if give else current - amount
-	if next < 0:
-		_script_value = 0
-		_emit_runtime_event(&"coins_change_rejected", {
-			"amount": amount, "available": current,
-		})
-		return {"ok": true}
+	var next: int = clampi(
+		current + amount if give else current - amount, 0, Gen2WorldInventory.MAX_COINS
+	)
 	_staged_coins = next
-	_script_value = 1
 	_emit_runtime_event(&"coins_changed", {
 		"amount": amount, "balance": next,
 		"direction": &"give" if give else &"take",
@@ -3372,6 +3496,8 @@ func _execute_special(special: int) -> Dictionary:
 			if sign_box.is_empty():
 				return {"ok": false, "reason": &"missing_special_text", "special": special}
 			return _stage_internal_text(sign_box, false, {"special": special})
+		SPECIAL_BANK_OF_MOM:
+			return _bank_of_mom(MOM_CHECK_INITIALIZED)
 		SPECIAL_BUENA_PRIZE:
 			## The counter is one loop: the prize list, a yes/no on the row, and
 			## whichever of the four boxes the answer reaches. B on the list is
@@ -3609,6 +3735,167 @@ func _buena_prize_box(special: int, name: String, closing: bool) -> Dictionary:
 	return _stage_internal_text(box, closing, {"special": special} if closing else {
 		"special": special, "buena_prize_after_text": special,
 	})
+
+
+## `BankOfMom`'s jumptable, one index at a time (`engine/events/mom.asm`). Every
+## state either prints a box, opens her menu or opens the dial, so the source's
+## `.loop` is the chain of pendings each of them leaves behind.
+##
+## `DSTChecks` is the one branch not built: its own six boxes sit above her
+## sixteen in the file and are the clock question the two DST specials already
+## ask. `.nope` runs it and then falls to `.JustDoWhatYouCan`, which is what a
+## clock nowhere near a boundary does, so that is the branch taken here.
+func _bank_of_mom(index: int) -> Dictionary:
+	match index:
+		MOM_CHECK_INITIALIZED:
+			var flags: int = _mom_savings_flags()
+			if flags & MOM_ACTIVE != 0:
+				return _bank_of_mom(MOM_IS_THIS_ABOUT_YOUR_MONEY)
+			## `.CheckIfBankInitialized` sets the bit before the question, so a
+			## player who says NO has still opened the account.
+			_staged_mom_savings_flags = flags | MOM_ACTIVE
+			return _bank_of_mom(MOM_INITIALIZE)
+		MOM_INITIALIZE:
+			return _mom_yes_no("leaving_1", index)
+		MOM_IS_THIS_ABOUT_YOUR_MONEY:
+			return _mom_yes_no("is_this_about_your_money", index)
+		MOM_ACCESS_BANK:
+			return _stage_mom_menu()
+		MOM_STORE_MONEY:
+			return _mom_dial_box("store_money", MOM_DIAL_DEPOSIT)
+		MOM_TAKE_MONEY:
+			return _mom_dial_box("take_money", MOM_DIAL_WITHDRAW)
+		MOM_STOP_OR_START_SAVING:
+			return _mom_yes_no("save_money", index)
+		MOM_JUST_DO_WHAT_YOU_CAN:
+			return _mom_box("just_do_what_you_can", MOM_EXIT)
+	return _fail(&"invalid_bank_of_mom_state", {"state": index})
+
+
+## `.AccessBankOfMom`: the question, and `VerticalMenu` over the box it left.
+func _stage_mom_menu() -> Dictionary:
+	var asked: String = _special_box("bank_of_mom", "what_do_you_want_to_do")
+	if asked.is_empty():
+		return _fail(&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM})
+	_pending = {
+		"type": &"menu",
+		"command": &"bank_of_mom",
+		"options": MOM_MENU_ROWS.duplicate(),
+		## `db 1`, and STATICMENU_CURSOR without STATICMENU_DISABLE_B: B leaves,
+		## which is `.cancel`.
+		"header": {"default": 1, "data_flags": 0},
+		"text": asked,
+		"special": &"bank_of_mom_menu",
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+## One of her boxes, with the jumptable index the routine is on once it has been
+## read. Every box but the two the dial stands behind takes this path.
+func _mom_box(name: String, next_state: int) -> Dictionary:
+	var box: String = _special_box("bank_of_mom", name)
+	if box.is_empty():
+		return _fail(&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM})
+	if next_state == MOM_EXIT:
+		return _stage_internal_text(box, false, {"special": SPECIAL_BANK_OF_MOM})
+	return _stage_internal_text(box, false, {"bank_of_mom_after_text": next_state})
+
+
+## `.StoreMoney` and `.TakeMoney` print their question and then open the dial,
+## so the box carries which way the transaction goes rather than an index.
+func _mom_dial_box(name: String, mode: StringName) -> Dictionary:
+	var box: String = _special_box("bank_of_mom", name)
+	if box.is_empty():
+		return _fail(&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM})
+	return _stage_internal_text(box, false, {"bank_of_mom_dial": mode})
+
+
+## One of the three `YesNoBox` questions, over the box the state just printed.
+func _mom_yes_no(name: String, state_index: int) -> Dictionary:
+	var box: String = _special_box("bank_of_mom", name)
+	if box.is_empty():
+		return _fail(&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM})
+	_pending = {
+		"type": &"choice",
+		"command": &"bank_of_mom",
+		"choices": [&"yes", &"no"],
+		"text": box,
+		"special": &"bank_of_mom_choice",
+		"mom_state": state_index,
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+## `.StoreMoney`'s tail and `.TakeMoney`'s, which differ only in which account is
+## which. Three things the source does that a rewrite loses:
+##
+## - `GiveMoney` here adds into `wStringBuffer2` rather than into an account, so
+##   the ceiling is tested against the balance the transaction would leave and
+##   nothing is written when it fails.
+## - Both refusals `ret` with `wJumptableIndex` unchanged, so her question is
+##   asked again and the dial reopens rather than the routine ending.
+## - A dial left at zero is `.CancelDeposit`, the same branch B takes.
+func _finish_mom_bank_dial(mode: StringName, amount: int) -> Dictionary:
+	var deposit: bool = mode == MOM_DIAL_DEPOSIT
+	var state_index: int = MOM_STORE_MONEY if deposit else MOM_TAKE_MONEY
+	if amount <= 0:
+		return _bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN)
+	var from_account: int = ACCOUNT_YOUR_MONEY if deposit else ACCOUNT_MOMS_MONEY
+	var to_account: int = ACCOUNT_MOMS_MONEY if deposit else ACCOUNT_YOUR_MONEY
+	if _money_balance(from_account) < amount:
+		return _mom_box(
+			"insufficient_funds_in_wallet" if deposit else "havent_saved_that_much",
+			state_index
+		)
+	if _money_balance(to_account) + amount > Gen2WorldInventory.MAX_MONEY:
+		return _mom_box(
+			"not_enough_room_in_bank" if deposit else "not_enough_room_in_wallet",
+			state_index
+		)
+	_move_mom_money(from_account, to_account, amount)
+	_bank_of_mom_after_sound = MOM_EXIT
+	_mom_receipt_box = "stored_money" if deposit else "taken_money"
+	return _stage_audio_request(&"sound", {"address": SFX_TRANSACTION})
+
+
+## The `TakeMoney`/`GiveMoney` pair the transaction is, without the wScriptVar
+## neither of them writes.
+func _move_mom_money(from_account: int, to_account: int, amount: int) -> void:
+	for row: Array in [[from_account, -amount], [to_account, amount]]:
+		var account: int = int(row[0])
+		var next: int = _money_balance(account) + int(row[1])
+		_staged_money[account] = next
+		_emit_runtime_event(&"money_changed", {
+			"account": account, "amount": amount, "balance": next,
+			"direction": &"give" if int(row[1]) > 0 else &"take",
+		})
+
+
+## `advance` has to answer with a result, where the command loop is what turns a
+## staged pending into one, so every step the routine takes from inside a pending
+## handler is answered through here.
+func _mom_result(staged: Dictionary) -> Dictionary:
+	if staged.has("status") or not bool(staged.get("ok", false)):
+		return staged
+	return advance()
+
+
+## `_pending`'s own `special`, which is a routine's name wherever a handler
+## claims the box and the cartridge's index wherever nothing does. Read as a
+## name, so an index is simply not one: comparing the two is an engine error
+## rather than a false answer.
+func _pending_tag() -> StringName:
+	var tag: Variant = _pending.get("special", &"")
+	return tag if tag is StringName else &""
+
+
+## `wMomSavingMoney` as the routine reads it: staged first, then the save.
+func _mom_savings_flags() -> int:
+	if _staged_mom_savings_flags >= 0:
+		return _staged_mom_savings_flags
+	return state.mom_savings_flags() if state != null else 0
 
 
 ## `RestartLuckyNumberCountdown.GetDaysUntilNextFriday`, which answers seven on
@@ -4923,6 +5210,8 @@ func _complete() -> Dictionary:
 		runtime_changes["best_magikarp"] = _staged_best_magikarp.duplicate()
 	if _staged_blue_card_balance >= 0:
 		runtime_changes["blue_card_balance"] = _staged_blue_card_balance
+	if _staged_mom_savings_flags >= 0:
+		runtime_changes["mom_savings_flags"] = _staged_mom_savings_flags
 	if not _staged_engine_flags.is_empty():
 		runtime_changes["engine_flags"] = _staged_engine_flags.duplicate()
 	if _reset_phone_receive_timer:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -3764,10 +3764,11 @@ func _buena_prize_box(special: int, name: String, closing: bool) -> Dictionary:
 ## state either prints a box, opens her menu or opens the dial, so the source's
 ## `.loop` is the chain of pendings each of them leaves behind.
 ##
-## `DSTChecks` is the one branch not built: its own six boxes sit above her
-## sixteen in the file and are the clock question the two DST specials already
-## ask. `.nope` runs it and then falls to `.JustDoWhatYouCan`, which is what a
-## clock nowhere near a boundary does, so that is the branch taken here.
+## `DSTChecks` is the one branch not built, and it is a save-format bump: `.nope`
+## asks whether to move the clock an hour, which needs a saved `wDST` bit and the
+## `wStartHour`/`wStartDay` shift behind it, and nothing here carries either. The
+## branch taken instead is `.JustDoWhatYouCan`, which is what a clock nowhere
+## near a boundary reaches.
 func _bank_of_mom(index: int) -> Dictionary:
 	match index:
 		MOM_CHECK_INITIALIZED:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -23,7 +23,7 @@ signal sfx_requested(index: int, waited: bool)
 
 enum MODE {
 	MENU, MART, PHONE, TOWN_MAP, CARD,
-	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT,
+	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT, MOM_BANK,
 }
 
 ## `PokemonCenterPC`'s own box storage, which is the one row that opens a screen
@@ -101,6 +101,10 @@ var _mart_pages: Array = []
 var _mart_after: StringName = MART_LIST
 var _mart_confirm: int = 0
 var _apricorns: Gen2WorldApricorn = null
+var _mom_dial: Gen2WorldMoneyDial = null
+## The same counted blink [Gen2TextBox]'s arrow is, since it is the same
+## `hVBlankCounter` bit: sixteen frames with the digit and sixteen without.
+var _mom_blink: float = 0.0
 var _pokegear_cards: Array = []
 var _town_map: Gen2TownMapScreen = null
 ## The clock, phone or radio card while one is open, which is a hardware-
@@ -202,6 +206,9 @@ func open_pending(
 	if StringName(request.get("kind", &"")) == &"town_map_requested":
 		_open_town_map(true)
 		return true
+	if StringName(request.get("kind", &"")) == &"mom_bank_dial_requested":
+		_open_mom_bank(request.get("values", {}))
+		return true
 	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world, request)
 	if not bool(resolved.get("ok", false)):
 		_show_error("Service unavailable: %s" % String(resolved.get("reason", "unknown")))
@@ -287,6 +294,9 @@ func handle_button(button: int) -> bool:
 		return true
 	if _mode == MODE.MART:
 		_press_mart(button)
+		return true
+	if _mode == MODE.MOM_BANK:
+		_press_mom_bank(button)
 		return true
 	if _mode == MODE.CARD and _pokegear != null:
 		return _pokegear.handle_button(button)
@@ -732,6 +742,101 @@ func _finish_apricorns() -> void:
 	var answer: Dictionary = _apricorns.result()
 	_apricorns = null
 	_finish_runtime({"ok": true, "item": answer["item"], "quantity": answer["quantity"]})
+
+
+## `Mom_SetUpDepositMenu` and `Mom_SetUpWithdrawMenu` over
+## `Mom_WithdrawDepositMenuJoypad`. The model owns the amount and the cursor;
+## this owns the box and the blink.
+##
+## `Mom_Wait10Frames` stands between the box and the joypad so a press that
+## opened it cannot be read as a press on it. The world screen spends the press
+## that reaches here, so those ten frames are not held: what they are for is
+## already true.
+func _open_mom_bank(values: Dictionary) -> void:
+	_mode = MODE.MOM_BANK
+	_mom_dial = Gen2WorldMoneyDial.open(
+		StringName(values.get("mode", Gen2WorldMoneyDial.MODE_DEPOSIT)),
+		int(values.get("saved", 0)), int(values.get("held", 0))
+	)
+	_mom_blink = 0.0
+	_title = "MOM"
+	_summary = ""
+	_status = ""
+	set_process(true)
+	_render_rows()
+
+
+func _press_mom_bank(button: int) -> void:
+	if _mom_dial == null:
+		_finish_mom_bank(-1)
+		return
+	match _mom_dial.press(button):
+		Gen2WorldMoneyDial.CONFIRMED:
+			_finish_mom_bank(_mom_dial.value)
+		Gen2WorldMoneyDial.CANCELLED:
+			_finish_mom_bank(-1)
+		_:
+			_render_rows()
+
+
+func _finish_mom_bank(amount: int) -> void:
+	_mom_dial = null
+	set_process(false)
+	_finish_runtime({"ok": true, "amount": amount})
+
+
+## The digit under the cursor is drawn for sixteen frames in every thirty-two,
+## so only a crossing of the half period is redrawn.
+func _process(_delta: float) -> void:
+	if _mode != MODE.MOM_BANK or _mom_dial == null:
+		return
+	var was_up: bool = _mom_cursor_up()
+	_mom_blink = fmod(
+		_mom_blink + Gen2TextBox.FRAME_SECONDS,
+		Gen2TextBox.FRAME_SECONDS * float(Gen2TextBox.CURSOR_BLINK_FRAMES) * 2.0
+	)
+	if _mom_cursor_up() != was_up:
+		_render_rows()
+
+
+func _mom_cursor_up() -> bool:
+	return _mom_blink < Gen2TextBox.FRAME_SECONDS * float(Gen2TextBox.CURSOR_BLINK_FRAMES)
+
+
+func _mom_bank_image() -> Image:
+	if _mom_dial == null:
+		return null
+	var drawn: Dictionary = Gen2MartPage.bank_window(
+		_data, Gen2WorldMoneyDial.WORD_OF[_mom_dial.mode],
+		_mom_dial.saved, _mom_dial.held, _mom_dial.amount_string(),
+		_mom_dial.cursor, _mom_cursor_up()
+	)
+	if drawn.is_empty():
+		return null
+	var image := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	var part: Image = drawn["image"]
+	image.blit_rect(
+		part, Rect2i(Vector2i.ZERO, part.get_size()),
+		(drawn["at"] as Vector2i) * Gen2Font.TILE
+	)
+	return image
+
+
+## The dial with no script behind it, for the screenshot driver: the routine's
+## boxes are the runner's and reach it through `open_pending`, and this is the
+## one picture that has to be looked at.
+func open_mom_bank(
+	world: Gen2WorldAPI, data: GameData, mode: StringName, saved: int, held: int
+) -> bool:
+	_world = world
+	_data = data
+	if _world == null or _data == null:
+		_show_error("Mom's bank has no world or cartridge cache.")
+		return false
+	_open_mom_bank({"mode": mode, "saved": saved, "held": held})
+	return true
 
 
 ## BILL'S PC on its own, without the machine's top menu in front of it: the
@@ -1407,7 +1512,8 @@ func _render_service_page(values: Array) -> void:
 			labels.append(label)
 		else:
 			labels.append(String(value))
-	var image: Image = _dial_image() if _is_dial() else _service_page.render(
+	var image: Image = _mom_bank_image() if _mode == MODE.MOM_BANK \
+		else _dial_image() if _is_dial() else _service_page.render(
 		_title, _summary, labels, _cursor, _status, _service_box()
 	)
 	if image != null:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -8231,6 +8231,47 @@ func _mom_state(
 	return state
 
 
+## `Diploma` and `PrintDiploma` are the same page under two loops, and neither
+## writes anything a script reads: what the request carries is which loop.
+func test_the_two_diploma_specials_differ_only_in_the_loop_they_open() -> void:
+	for row: Array in [
+		[Gen2WorldScriptRunner.SPECIAL_DIPLOMA, false],
+		[Gen2WorldScriptRunner.SPECIAL_PRINT_DIPLOMA, true],
+	]:
+		_write_special_script([
+			Gen2WorldScript.SPECIAL, int(row[0]), 0,
+			Gen2WorldScript.SETEVENT, 0x12, 0x00,
+			Gen2WorldScript.END,
+		])
+		var world: Gen2WorldAPI = _special_world()
+		var opened: Array = _run_special(world)
+		var request: Dictionary = opened[0]["event"]["request"]
+		assert_eq(request["kind"], &"diploma_requested")
+		assert_eq(bool(request["values"]["printing"]), bool(row[1]))
+		var resumed: Array = world.complete_runtime_request({"ok": true})
+		assert_eq(resumed[0]["status"], &"complete")
+		assert_true(world.event_flag_active(0x12), "the script runs on behind the page")
+
+
+## `_UnownPrinter`'s own `ld a, [wUnownDex] / and a / ret z`: the count is the
+## whole of what the request carries, so the host and the runner refuse on the
+## same byte.
+func test_the_unown_printer_carries_the_dex_count_it_refuses_on() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_UNOWN_PRINTER, 0,
+		Gen2WorldScript.END,
+	])
+	for caught: int in [0, 3]:
+		var state := Gen2WorldState.new()
+		for form: int in range(1, caught + 1):
+			state.update_unown_dex(form)
+		var world: Gen2WorldAPI = _special_world(state)
+		var request: Dictionary = _run_special(world)[0]["event"]["request"]
+		assert_eq(request["kind"], &"unown_printer_requested")
+		assert_eq(int(request["values"]["caught"]), caught)
+		assert_eq(world.complete_runtime_request({"ok": true})[0]["status"], &"complete")
+
+
 ## One script at a fixed address, reached by the map's own coordinate event, so
 ## every special test above drives the same path a real script does.
 func _write_special_script(bytes: Array, extra: Dictionary = {}) -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -353,6 +353,20 @@ func _write_cache(game_id: String = "testworld") -> void:
 				"much_strength": "Much strength.", "mighty": "Mighty.",
 				"impressed": "Impressed.",
 			},
+			"bank_of_mom": {
+				"leaving_1": "Shall I save money?", "leaving_2": "I will save some.",
+				"leaving_3": "Take care!", "is_this_about_your_money": "Your money?",
+				"what_do_you_want_to_do": "What shall I do?",
+				"store_money": "How much to save?", "take_money": "How much to get?",
+				"save_money": "Shall I keep saving?",
+				"havent_saved_that_much": "You have not saved that much.",
+				"not_enough_room_in_wallet": "Your wallet is full.",
+				"insufficient_funds_in_wallet": "You do not have that much.",
+				"not_enough_room_in_bank": "I cannot hold that much.",
+				"start_saving_money": "I will keep saving.",
+				"stored_money": "Saved it.", "taken_money": "Here it is.",
+				"just_do_what_you_can": "Do what you can.",
+			},
 			"buena_prize": {
 				"ask_which_prize": "Which prize?", "is_that_right": "<RAM_CF6B>?",
 				"here_you_go": "Here you go!", "not_enough_points": "Not enough.",
@@ -7987,6 +8001,234 @@ func test_the_lucky_number_show_names_the_matching_row() -> void:
 	assert_true(results[0]["status"] in [&"complete", &"waiting"], JSON.stringify(results))
 	assert_between(world.state.lucky_id_number(), 0, 0xFFFF)
 	assert_ne(world.state.lucky_number_day(), 0, "the draw stamps the day it was made")
+
+
+## `BankOfMom`'s first visit: `.CheckIfBankInitialized` sets MOM_ACTIVE before
+## the question, so the account is open whichever way it is answered, and
+## `MomLeavingText3` is printed on both branches.
+func test_moms_bank_opens_the_account_whichever_way_the_first_question_goes() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BANK_OF_MOM, 0,
+		Gen2WorldScript.END,
+	])
+	var saving: Gen2WorldAPI = _special_world()
+	var opened: Array = _run_special(saving)
+	assert_eq(opened[0]["event"]["type"], &"choice")
+	assert_eq(opened[0]["event"]["text"], "Shall I save money?")
+	assert_eq(saving.choose_script_input(0)[0]["event"]["text"], "I will save some.")
+	assert_eq(saving.run_event_queue(true)[0]["event"]["text"], "Take care!")
+	assert_eq(saving.run_event_queue(true)[0]["status"], &"complete")
+	assert_eq(
+		saving.state.mom_savings_flags(),
+		Gen2WorldScriptRunner.MOM_ACTIVE | Gen2WorldScriptRunner.MOM_SAVING_SOME_MONEY
+	)
+
+	var refused: Gen2WorldAPI = _special_world()
+	_run_special(refused)
+	## B is the same NO the second row is, which is `YesNoBox`' own carry.
+	assert_eq(refused.cancel_script_input()[0]["event"]["text"], "Take care!")
+	assert_eq(refused.run_event_queue(true)[0]["status"], &"complete")
+	assert_eq(
+		refused.state.mom_savings_flags(), Gen2WorldScriptRunner.MOM_ACTIVE,
+		"the account is open and keeping nothing"
+	)
+
+
+## `.IsThisAboutYourMoney` and `.AccessBankOfMom`: an account already open goes
+## straight to her four-row menu, and CANCEL and B both reach
+## `.JustDoWhatYouCan` rather than ending the routine where they stand.
+func test_a_second_visit_opens_her_menu_and_both_ways_out_print_her_line() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BANK_OF_MOM, 0,
+		Gen2WorldScript.END,
+	])
+	for way_out: int in [3, -1]:
+		var world: Gen2WorldAPI = _special_world(_mom_state())
+		assert_eq(_run_special(world)[0]["event"]["text"], "Your money?")
+		var menu: Dictionary = world.choose_script_input(0)[0]["event"]
+		assert_eq(menu["type"], &"menu")
+		assert_eq(menu["text"], "What shall I do?")
+		assert_eq(menu["options"], Gen2WorldScriptRunner.MOM_MENU_ROWS)
+		var left: Array = world.choose_script_input(way_out) if way_out >= 0 \
+			else world.cancel_script_input()
+		assert_eq(left[0]["event"]["text"], "Do what you can.", "way out %d" % way_out)
+		assert_eq(world.run_event_queue(true)[0]["status"], &"complete")
+
+
+## `.StoreMoney`'s tail, which is `CompareMoney`, `GiveMoney` into the buffer,
+## `TakeMoney` out of the wallet and only then the copy into `wMomsMoney`.
+func test_a_deposit_moves_the_money_and_reports_it_behind_the_sound() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BANK_OF_MOM, 0,
+		Gen2WorldScript.END,
+	])
+	var world: Gen2WorldAPI = _special_world(_mom_state(5000, 300))
+	_run_special(world)
+	world.choose_script_input(0)
+	assert_eq(world.choose_script_input(1)[0]["event"]["text"], "How much to save?")
+	var dial: Dictionary = world.run_event_queue(true)[0]["event"]["request"]
+	assert_eq(dial["kind"], &"mom_bank_dial_requested")
+	assert_eq(dial["values"]["mode"], Gen2WorldMoneyDial.MODE_DEPOSIT)
+	assert_eq(dial["values"]["held"], 5000)
+	assert_eq(dial["values"]["saved"], 300)
+	var sound: Dictionary = world.complete_runtime_request({
+		"ok": true, "amount": 1200,
+	})[0]["event"]["request"]
+	assert_eq(sound["kind"], &"audio_requested")
+	assert_eq(int(sound["values"]["address"]), Gen2WorldScriptRunner.SFX_TRANSACTION)
+	assert_eq(
+		world.complete_runtime_request({"ok": true})[0]["event"]["text"], "Saved it."
+	)
+	assert_eq(world.run_event_queue(true)[0]["status"], &"complete")
+	assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY), 3800)
+	assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY), 1500)
+
+
+## `.TakeMoney` is the same routine with the accounts the other way round.
+func test_a_withdrawal_moves_the_money_the_other_way() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BANK_OF_MOM, 0,
+		Gen2WorldScript.END,
+	])
+	var world: Gen2WorldAPI = _special_world(_mom_state(100, 4000))
+	_run_special(world)
+	world.choose_script_input(0)
+	assert_eq(world.choose_script_input(0)[0]["event"]["text"], "How much to get?")
+	var dial: Dictionary = world.run_event_queue(true)[0]["event"]["request"]
+	assert_eq(dial["values"]["mode"], Gen2WorldMoneyDial.MODE_WITHDRAW)
+	world.complete_runtime_request({"ok": true, "amount": 2500})
+	assert_eq(
+		world.complete_runtime_request({"ok": true})[0]["event"]["text"], "Here it is."
+	)
+	world.run_event_queue(true)
+	assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY), 2600)
+	assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY), 1500)
+
+
+## Her four refusals. Each `ret`s with `wJumptableIndex` untouched, so the
+## question is asked again and the dial reopens rather than the routine ending,
+## and a dial left at zero is the same `.CancelDeposit` B is.
+func test_every_refusal_asks_the_same_question_again_and_moves_nothing() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BANK_OF_MOM, 0,
+		Gen2WorldScript.END,
+	])
+	var ceiling: int = Gen2WorldInventory.MAX_MONEY
+	for row: Array in [
+		[1, 500, 0, 900, "You do not have that much.", "How much to save?"],
+		[1, 500, ceiling - 100, 200, "I cannot hold that much.", "How much to save?"],
+		[0, 0, 500, 900, "You have not saved that much.", "How much to get?"],
+		[0, ceiling - 100, 500, 200, "Your wallet is full.", "How much to get?"],
+	]:
+		var world: Gen2WorldAPI = _special_world(_mom_state(int(row[1]), int(row[2])))
+		_run_special(world)
+		world.choose_script_input(0)
+		world.choose_script_input(int(row[0]))
+		world.run_event_queue(true)
+		var refused: Array = world.complete_runtime_request({
+			"ok": true, "amount": int(row[3]),
+		})
+		assert_eq(refused[0]["event"]["text"], String(row[4]))
+		assert_eq(
+			world.run_event_queue(true)[0]["event"]["text"], String(row[5]),
+			"the refusal falls back into the same question"
+		)
+		world.run_event_queue(true)
+		var cancelled: Array = world.complete_runtime_request({"ok": true, "amount": 0})
+		assert_eq(cancelled[0]["event"]["text"], "Do what you can.")
+		assert_eq(world.run_event_queue(true)[0]["status"], &"complete")
+		assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY), int(row[1]))
+		assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY), int(row[2]))
+
+
+## `.StopOrStartSavingMoney`, the CHANGE row: YES writes the one tier her menu
+## offers and NO leaves the account open and keeping nothing.
+func test_the_change_row_turns_her_saving_on_and_off() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BANK_OF_MOM, 0,
+		Gen2WorldScript.END,
+	])
+	var saving: Gen2WorldAPI = _special_world(_mom_state())
+	_run_special(saving)
+	saving.choose_script_input(0)
+	assert_eq(saving.choose_script_input(2)[0]["event"]["text"], "Shall I keep saving?")
+	assert_eq(saving.choose_script_input(0)[0]["event"]["text"], "I will keep saving.")
+	assert_eq(saving.run_event_queue(true)[0]["status"], &"complete")
+	assert_eq(
+		saving.state.mom_savings_flags(),
+		Gen2WorldScriptRunner.MOM_ACTIVE | Gen2WorldScriptRunner.MOM_SAVING_SOME_MONEY
+	)
+
+	var stopped: Gen2WorldAPI = _special_world(
+		_mom_state(0, 0, Gen2WorldScriptRunner.MOM_ACTIVE | Gen2WorldScriptRunner.MOM_SAVING_SOME_MONEY)
+	)
+	_run_special(stopped)
+	stopped.choose_script_input(0)
+	stopped.choose_script_input(2)
+	assert_eq(stopped.choose_script_input(1)[0]["event"]["text"], "Do what you can.")
+	assert_eq(stopped.run_event_queue(true)[0]["status"], &"complete")
+	assert_eq(stopped.state.mom_savings_flags(), Gen2WorldScriptRunner.MOM_ACTIVE)
+
+
+## `Mom_WithdrawDepositMenuJoypad`'s dial: up and down are `GiveMoney` and
+## `TakeMoney` on the whole amount, so a digit column moves it by its own power
+## of ten and clamps rather than wrapping, and the cursor stops at either end.
+func test_her_dial_steps_by_the_column_it_stands_on_and_clamps() -> void:
+	var dial := Gen2WorldMoneyDial.open(Gen2WorldMoneyDial.MODE_DEPOSIT, 0, 0)
+	assert_eq(dial.cursor, Gen2WorldMoneyDial.DIGITS - 1, "it opens on the ones column")
+	assert_eq(dial.press(Gen2Button.UP), Gen2WorldMoneyDial.PENDING)
+	assert_eq(dial.value, 1)
+	assert_eq(dial.amount_string(), "¥000001")
+	for _step: int in 5:
+		dial.press(Gen2Button.LEFT)
+	assert_eq(dial.cursor, 0)
+	dial.press(Gen2Button.LEFT)
+	assert_eq(dial.cursor, 0, "the cursor stops at the edge rather than wrapping")
+	dial.press(Gen2Button.UP)
+	assert_eq(dial.value, 100001)
+	for _step: int in 9:
+		dial.press(Gen2Button.UP)
+	assert_eq(dial.value, Gen2WorldInventory.MAX_MONEY, "GiveMoney clamps at the ceiling")
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	dial.press(Gen2Button.DOWN)
+	assert_eq(dial.value, 0, "TakeMoney leaves zero rather than borrowing past it")
+	assert_eq(dial.press(Gen2Button.A), Gen2WorldMoneyDial.CONFIRMED)
+	assert_eq(dial.press(Gen2Button.B), Gen2WorldMoneyDial.CANCELLED)
+
+
+## `GiveMoney` writes `MAX_MONEY` and `TakeMoney` writes zero rather than either
+## of them refusing, which is what a script command answers with.
+func test_a_script_cannot_push_an_account_past_either_of_its_ends() -> void:
+	_write_special_script([
+		Gen2WorldScript.GIVEMONEY, 0, 0x99, 0x99, 0x99,
+		Gen2WorldScript.GIVEMONEY, 0, 0x00, 0x50, 0x00,
+		Gen2WorldScript.TAKEMONEY, 0, 0x99, 0x99, 0x99,
+		Gen2WorldScript.TAKEMONEY, 0, 0x00, 0x50, 0x00,
+		Gen2WorldScript.END,
+	])
+	var world: Gen2WorldAPI = _special_world()
+	assert_eq(_run_special(world)[0]["status"], &"complete")
+	assert_eq(world.state.money(Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY), 0)
+
+
+## The wallet and the flags a visit to her starts from.
+func _mom_state(
+	money: int = 0, saved: int = 0, flags: int = Gen2WorldScriptRunner.MOM_ACTIVE
+) -> Gen2WorldState:
+	var state := Gen2WorldState.new({}, {}, {}, {
+		Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY: money,
+		Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY: saved,
+	})
+	state.set_mom_savings_flags(flags)
+	return state
 
 
 ## One script at a fixed address, reached by the map's own coordinate event, so

--- a/tools/checks/printer.gd
+++ b/tools/checks/printer.gd
@@ -1,0 +1,189 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the diploma's art, the printer's status run and the Unown printer's
+## own browser against freshly imported real caches on all three cartridges.
+##
+## `DiplomaGFX` and its two tilemaps are one pinned run: the LZ stream has to
+## decompress to exactly its own tile count and both tilemaps have to index
+## inside it, so an address one byte out fails rather than drawing rubbish. The
+## strings are the other half of the pin: `GBPrinterStrings` opens on the empty
+## string a status of zero prints, and a run pinned wrong would put a line there.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- printer
+
+## `PlaceDiplomaOnScreen`'s tilemaps are whole screens, and page 1's own corner
+## is the certificate's top-left border tile.
+const SCREEN_CELLS: int = 360
+
+## What each `GBPrinterStrings` entry has to contain, by the status it names.
+## The four errors differ only in their digit, which is what tells a run in the
+## table's own order from one read backwards.
+const STATUS_CONTAINS: Dictionary = {
+	"null": "", "checking_link": "CHECKING LINK", "transmitting": "TRANSMITTING",
+	"printing": "PRINTING", "error_1": "Printer Error 1", "error_2": "Printer Error 2",
+	"error_3": "Printer Error 3", "error_4": "Printer Error 4",
+}
+
+## `.Certification`'s own last line, which the page draws under the player's
+## name and no tilemap carries.
+const CERTIFICATION_LAST: String = "Congratulations!"
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	var pages: Array = []
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		if not _r.check(data.has_diploma(), "%s: no diploma art in the cache." % game_id):
+			continue
+		_verify_tilemaps(game_id, data)
+		_verify_strings(game_id, data)
+		pages.append(_verify_page(game_id, data))
+		_verify_unown_printer(game_id, data)
+	_r.game_id = &""
+	_verify_pages_agree(pages)
+
+
+## Both tilemaps index inside `DiplomaGFX` and neither is short: a cell past the
+## art is a wrong pin and a short map is a wrong length.
+func _verify_tilemaps(game_id: StringName, data: GameData) -> void:
+	var tiles: int = data.diploma_indices().size() / (
+		Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT
+	)
+	_r.check(
+		tiles == RomLayout.DIPLOMA_TILES,
+		"%s: the diploma's strip is %d tiles, not %d." % [
+			game_id, tiles, RomLayout.DIPLOMA_TILES,
+		]
+	)
+	for page: int in [1, 2]:
+		var map: PackedByteArray = data.diploma_tilemap(page)
+		if not _r.check(
+			map.size() == SCREEN_CELLS,
+			"%s: diploma page %d is %d cells, not %d." % [
+				game_id, page, map.size(), SCREEN_CELLS,
+			]
+		):
+			continue
+		var highest: int = 0
+		for code: int in map:
+			highest = maxi(highest, code)
+		_r.check(
+			highest < RomLayout.DIPLOMA_TILES,
+			"%s: diploma page %d indexes tile %d, past its own art." % [
+				game_id, page, highest,
+			]
+		)
+	_r.check(
+		data.diploma_palette().size() == RomLayout.PREDEF_PALETTE_COLORS,
+		"%s: the diploma's palette is not four colours." % game_id
+	)
+
+
+func _verify_strings(game_id: StringName, data: GameData) -> void:
+	for name: Variant in STATUS_CONTAINS:
+		var wanted: String = String(STATUS_CONTAINS[name])
+		var line: String = data.printer_status_string(String(name))
+		if wanted.is_empty():
+			_r.check(
+				line.is_empty(),
+				"%s: the printer's %s status prints \"%s\", not nothing." % [
+					game_id, name, line,
+				]
+			)
+			continue
+		_r.check(
+			line.contains(wanted),
+			"%s: the printer's %s status is \"%s\"." % [game_id, name, line]
+		)
+
+
+## The page as it is drawn, which is the half a tilemap check cannot reach: the
+## strings `PlaceString` writes over the art, and the play time `PrintNum` puts
+## between them.
+func _verify_page(game_id: StringName, data: GameData) -> Array:
+	var page: Gen2DiplomaPage = Gen2DiplomaPage.from_data(data)
+	if not _r.check(page != null, "%s: the diploma page did not build." % game_id):
+		return []
+	var out: Array = []
+	for number: int in [1, 2]:
+		var image: Image = page.render(
+			number, "RED", {"hours": 41, "minutes": 7}
+		)
+		if not _r.check(
+			image != null and image.get_width() == Gen2DiplomaPage.WIDTH \
+				and image.get_height() == Gen2DiplomaPage.HEIGHT,
+			"%s: diploma page %d did not render at screen size." % [game_id, number]
+		):
+			return []
+		out.append(image.get_data())
+	## The two pages are different pictures, which is what says page 2 is drawn
+	## from its own tilemap rather than page 1 twice.
+	_r.check(
+		out[0] != out[1],
+		"%s: both diploma pages drew the same picture." % game_id
+	)
+	return out
+
+
+## The art is byte identical between the three cartridges, so the drawn pages
+## are too: a difference would be a wrong pin on one of them.
+func _verify_pages_agree(pages: Array) -> void:
+	var complete: Array = []
+	for entry: Variant in pages:
+		if not (entry as Array).is_empty():
+			complete.append(entry)
+	if complete.size() < 2:
+		return
+	for index: int in range(1, complete.size()):
+		_r.check(
+			complete[index] == complete[0],
+			"the diploma is drawn differently on cartridge %d." % index
+		)
+
+
+## `_UnownPrinter`'s browser, over every slot the cursor reaches: each of the
+## twenty-six letters is its own picture, the vacant slot past them is not one of
+## them, and the page A sends carries the stamp rather than nothing.
+func _verify_unown_printer(game_id: StringName, data: GameData) -> void:
+	var page: Gen2UnownPrinterPage = Gen2UnownPrinterPage.from_data(data)
+	if not _r.check(page != null, "%s: the Unown printer page did not build." % game_id):
+		return
+	var seen: Dictionary = {}
+	for slot: int in Gen2UnownPrinterPage.SLOTS:
+		var image: Image = page.render(slot)
+		if not _r.check(
+			image != null and image.get_width() == Gen2UnownPrinterPage.WIDTH,
+			"%s: Unown printer slot %d did not render." % [game_id, slot]
+		):
+			return
+		var key: String = image.get_data().hex_encode()
+		_r.check(
+			not seen.has(key),
+			"%s: Unown printer slot %d draws the same page as %d." % [
+				game_id, slot, int(seen.get(key, -1)),
+			]
+		)
+		seen[key] = slot
+	## `PlaceUnownPrinterFrontpic` blanks the screen and puts the rotated stamp
+	## on it, so a letter's stamp page is not an empty one.
+	var blank: PackedByteArray = page.render_stamp(Gen2UnownPrinterPage.LETTERS).get_data()
+	for slot: int in Gen2UnownPrinterPage.LETTERS:
+		if not _r.check(
+			page.render_stamp(slot).get_data() != blank,
+			"%s: the stamp for Unown slot %d is a blank page." % [game_id, slot]
+		):
+			return
+	## A quarter turn, twice, is a half turn: the rotation is its own inverse
+	## after four, which is what says it is a rotation rather than a transpose.
+	var square := PackedByteArray([0, 1, 2, 3])
+	_r.check(
+		Gen2UnownPrinterPage._rotated(square, 2, 2) == PackedByteArray([2, 0, 3, 1]),
+		"%s: the stamp rotation is not a quarter turn clockwise." % game_id
+	)

--- a/tools/checks/printer.gd.uid
+++ b/tools/checks/printer.gd.uid
@@ -1,0 +1,1 @@
+uid://ddf05e4u1qlri

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -56,8 +56,7 @@ const EXPECTED_DEFERRED: Dictionary = {
 	## The three printer rows need art no cache carries: `DiplomaGFX` and its two
 	## tilemaps, and `_UnownPrinter`'s own frontpic page. Both are a cache-format
 	## bump away rather than a routine away.
-	34: "BankOfMom", 39: "UnownPrinter",
-	107: "Diploma", 108: "PrintDiploma",
+	39: "UnownPrinter", 107: "Diploma", 108: "PrintDiploma",
 
 	## Reached by one script row each and by nothing the player can talk to.
 	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table.

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -53,10 +53,6 @@ const EXPECTED_DEFERRED: Dictionary = {
 	## work, not a dispatch entry: it opens a screen, spends a transaction, or
 	## reads a save field nothing writes.
 	##
-	## The three printer rows need art no cache carries: `DiplomaGFX` and its two
-	## tilemaps, and `_UnownPrinter`'s own frontpic page. Both are a cache-format
-	## bump away rather than a routine away.
-	39: "UnownPrinter", 107: "Diploma", 108: "PrintDiploma",
 
 	## Reached by one script row each and by nothing the player can talk to.
 	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -76,6 +76,9 @@ extends SceneTree
 ## into the prompt to photograph, 1 its question with the YES/NO up and 2 the
 ## `WasSentToBillsPCText` behind NO, and the second the species, plus 1000 for
 ## the box branch that prints that line),
+## `mom_bank` (`Mom_WithdrawDepositMenuJoypad`'s dial, which no fixture cell
+## reaches: the first number is the wallet in hundreds and the second her own
+## balance in hundreds, plus 1000 for the WITHDRAW header),
 ## `move_tutor` (`special MoveTutor`, driven the same way, except that it opens
 ## on `ChooseMonToLearnTMHM` rather than on a box: 0 is that list),
 ## `day_care` (the Day-Care's five specials, driven the same way: the first
@@ -591,6 +594,15 @@ func _process(_delta: float) -> bool:
 					break
 		elif _kind == &"pokepic":
 			_screen.preview_pokepic(POKEPIC_SPECIES)
+		elif _kind == &"mom_bank":
+			## `Mom_SetUpDepositMenu` and its withdraw twin, which no fixture
+			## cell reaches: her house is not a preview map and the dial stands
+			## three questions into `BankOfMom`.
+			_screen.preview_mom_bank(
+				Gen2WorldMoneyDial.MODE_WITHDRAW if _cell.y >= 1000 \
+					else Gen2WorldMoneyDial.MODE_DEPOSIT,
+				(maxi(_cell.y, 0) % 1000) * 100, maxi(_cell.x, 0) * 100
+			)
 		elif FIELD_ITEMS.has(_kind):
 			if _kind in FACE_UP_FIRST:
 				_screen.move_up()
@@ -609,7 +621,7 @@ func _process(_delta: float) -> bool:
 			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
-			&"catch_nickname",
+			&"catch_nickname", &"mom_bank",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -76,6 +76,12 @@ extends SceneTree
 ## into the prompt to photograph, 1 its question with the YES/NO up and 2 the
 ## `WasSentToBillsPCText` behind NO, and the second the species, plus 1000 for
 ## the box branch that prints that line),
+## `unown_printer` (`_UnownPrinter`'s ALPH RUINS STAMP browser, which no fixture
+## cell reaches: the first number is the slot, 26 being the vacant one, and the
+## second is 1 for the page A sends to a printer that is not there),
+## `diploma` (`_Diploma`'s page: the first number is 1 for `_PrintDiploma`'s
+## loop, which stands the printer's own connection error over it, and the second
+## is the page, where 2 is the one only a printer that answered reaches),
 ## `mom_bank` (`Mom_WithdrawDepositMenuJoypad`'s dial, which no fixture cell
 ## reaches: the first number is the wallet in hundreds and the second her own
 ## balance in hundreds, plus 1000 for the WITHDRAW header),
@@ -594,6 +600,15 @@ func _process(_delta: float) -> bool:
 					break
 		elif _kind == &"pokepic":
 			_screen.preview_pokepic(POKEPIC_SPECIES)
+		elif _kind == &"unown_printer":
+			## `_UnownPrinter`'s browser: the first number is the slot, where 26
+			## is the vacant one, and the second is 1 for the page A sends.
+			_screen.preview_unown_printer(maxi(_cell.x, 0), _cell.y >= 1)
+		elif _kind == &"diploma":
+			## `_Diploma`'s page, `_PrintDiploma`'s with the printer's own status
+			## box over it, and page 2 behind a printer that answered: the first
+			## number is 1 for the printing loop and the second the page.
+			_screen.preview_diploma(_cell.x >= 1, maxi(_cell.y, 1))
 		elif _kind == &"mom_bank":
 			## `Mom_SetUpDepositMenu` and its withdraw twin, which no fixture
 			## cell reaches: her house is not a preview map and the dial stands


### PR DESCRIPTION
Four rows left the deferred-specials list: Mom's bank, the diploma, its
printing loop and the Alph Ruins stamp browser. Each needed a page rather than
a routine, so cache format 84 carries the art the last three wanted.

**Mom's bank.** `BankOfMom`'s jumptable is a chain of staged pendings, one per
index. Her dial is its own model, not the mart's: a column there steps one
value against a ceiling, where a column here adds or subtracts a power of ten
through `GiveMoney` and `TakeMoney`, so the amount clamps at either end and no
digit wraps.

**The diploma and the stamp browser.** `DiplomaGFX` with its two screen
tilemaps, `GBPrinterStrings`' eight status lines and the two glyphs the stamp
menu prints as A and B. Each pin is found off a plain string in its own file
and then checks itself: the compressed art has to land on its own tile count,
both tilemaps have to index inside it, and the status run has to open on the
empty string. `tools/checks/printer.gd` sweeps all three cartridges.

What A does in either printing loop is what a Game Boy with nothing plugged
into the link port does. The handshake never answers, so the printer reports
error 2 and B is the way out. There is no printer to plug in, so that is the
whole of the send rather than a refusal invented for it.

**Defects found on the way, all fixed here.**

- B on a box one of the built-in routines put up resumed the script instead of
  answering the box. Buena's prize list never printed her parting line, and the
  yes/no questions behind Strength, Rock Smash and the five field moves waited
  for ever rather than reading B as their NO.
- `givemoney` and `givecoins` had no ceiling, and `takemoney` and `takecoins`
  refused instead of emptying the account. The source does neither: it writes
  the maximum, or zero.
- Both also wrote the script variable, which neither command does, so a script
  branching after one read an answer the cartridge never gave it.
- A pending box's tag is a routine name in some places and a number in others,
  and comparing the two is an engine error. It is read as a name now, once.
- The left-arrow character had no entry in the text codec, so the one string
  that prints it decoded to a marker.
- A node hands its picture to the screen it stands in, so a screen that drew
  before it was displayed told it nothing and stood with the map around it.
- Six editor warnings the command line cannot see, four of them older than this
  branch.

**Checks.** GUT 3174 tests green, `validate.gd -- all` 70 topics green on all
three cartridges, the replay's 33 routes with no failures, and the three-profile
story walk clean. All three cartridges re-imported on format 84 with the layout
verified.
