### PR TITLE
BILL's PC's own menu, the feet a hit scrambled, and a clock that keeps time

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Facing something and pressing A is the other way to every field move: a cut
 tree, a whirlpool, a waterfall, a headbutt tree and open water each offer their
 move in the cartridge's own order and words. Fruit trees bear once a day, Poke
 Balls and hidden items are picked up by facing them, and the imported Players
-House PC opens box storage. Walking into a new area raises Crystal's own map name
+House PC opens the item PC, while a Pokemon Center's opens BILL'S PC beside it. Walking into a new area raises Crystal's own map name
 sign for sixty frames, which Gold and Silver never had.
 
 Icons come from [Lucide](https://lucide.dev). See

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1540,14 +1540,23 @@ host.register_menu_entry(Gen2ModHost.MENU_START, manifest.id, {
 })
 ```
 
-`Gen2ModHost.START_ACTIONS` is the allow list; `OPEN_BILLS_PC` opens Bill's
-storage through the same box screen the Pokemon Center's machine does, and its B
+`Gen2ModHost.START_ACTIONS` is the allow list; `OPEN_BILLS_PC` opens BILL'S PC
+at the same top menu the Pokemon Center's machine reaches, and its SEE YA! or B
 returns through the ordinary start-menu flow. An optional `visible(context)`
 predicate is asked with a copy of `{party_count, pokedex, pokegear}` and leaves
 the row ABSENT rather than present and refused, which is what the cartridge's own
 gated rows do. The host applies its own gate after the predicate, so a row cannot
 be shown where the game would refuse it: `OPEN_BILLS_PC` needs a party, which is
 `PC_CheckPartyForPokemon`.
+
+**The start menu shows eight rows at once and scrolls past that.** A fully
+unlocked save already fills those eight (POKEDEX, POKEMON, PACK, POKEGEAR, the
+player's name, SAVE, OPTION, EXIT), so the MODS row and every registered row are
+reached by scrolling: the box stays the height of the screen, the window follows
+the cursor, and the cursor still wraps at both ends, so any row is reachable in
+either direction and EXIT is one press up from the top one. The Bug Contest's own
+list starts two rows lower and shows seven. A mod may register any number of
+rows; only how many are on screen at once is fixed.
 
 A start-menu entry with neither an action nor a handler still appears, marked
 unavailable. A pocket's number has to be at or

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -18,7 +18,11 @@ Save format version 6 stores:
   mode, event flags, map scenes, inventory quantities, money, coins, phone
   contacts, seen species, repel steps, swarm state, roaming positions, source
   engine flags, the script memory bytes `readmem`/`loadmem` address, the current
-  day/hour/minute clock and the daylight-saving flag;
+  day/hour/minute clock, the host second that clock was written at and the
+  daylight-saving flag. The stamp is what makes the clock a real-time one across
+  sessions: a world opens at the saved time plus the seconds that have passed
+  since, because the cartridge's RTC keeps running while the machine is off
+  (`Gen2WorldClock.catch_up`);
 - imported-save and party-transaction identity fields: OT ID, nickname, OT,
   happiness, Pokerus and caught data;
 - the trainer card's own fields: `player_id`, the player's `gender` and the play
@@ -47,8 +51,9 @@ The validator checks the selected `GameData`. Slots live under
 preallocated, up to `Gen2SaveStore.MAX_SLOTS`; a slot number is still its file
 name, so slots written before this stay where they were. Each save carries its
 own `label`, the player's name for the slot, so an exported file names itself;
-an empty label means fall back to the player name. Box names, current-box UI
-state and cartridge SRAM box placement are intentionally outside this model.
+an empty label means fall back to the player name. `current_box` is `wCurBox`,
+which CHANGE BOX writes and both of BILL'S PC's lists read. Box names and
+cartridge SRAM box placement are intentionally outside this model.
 
 `player_id` is the cartridge's own `wPlayerID`, rolled once when a game starts,
 read from SRAM on import and written back on export. `GetTreeScore` is what reads
@@ -62,9 +67,11 @@ zero `player_id`, version 4 gains a male gender and a 0:00 timer, version 5 gain
 an empty mod namespace. Migration preserves a missing world snapshot as missing;
 it does not invent a map, player position or event state, and it does not roll an
 ID, since that would change an existing save's headbutt encounters. The `run`
-block joined version 6 after it shipped and is not a version of its own: it
-defaults to no seed, mod list, settings snapshot or rules, which is the truth
-about a slot written before it existed; such a slot adopts the installation's
+block joined version 6 after it shipped and is not a version of its own, and so
+did `current_box` and the world snapshot's clock stamp: each defaults rather than
+versioning, to no seed, mod list, settings snapshot or rules, to the first box,
+and to a clock that resumes where it stopped, which is the truth about a slot
+written before they existed; such a slot adopts the installation's
 rules once, when it is first activated. The next successful save writes version 6.
 
 ## Player flow

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -259,13 +259,9 @@ func _pic_layer(
 ) -> PackedByteArray:
 	var out: PackedByteArray = _new_buffer()
 	var box: int = side * TILE
-	if pixels.size() < box * box:
+	var strip: int = pic_stride(pixels, side)
+	if strip <= 0:
 		return out
-	# The strip is `side` tiles tall and as wide as it has tiles, so a pic
-	# carrying `AnimateFrontpic`'s frames behind its own box is the same buffer
-	# with more columns and the same `column * side + row` addressing.
-	@warning_ignore("integer_division")
-	var strip: int = pixels.size() / box
 	@warning_ignore("integer_division")
 	var banked: int = (strip / TILE) * side
 	var square: int = side * side
@@ -390,6 +386,19 @@ static func substitute_pixels(strip: PackedByteArray, player_side: bool) -> Pack
 			for column: int in TILE:
 				out[to + column] = strip[from + column]
 	return out
+
+
+## The row stride of a buffer [method padded_pic] produced. The box is square
+## and `AnimateFrontpic`'s frames sit behind it in the same rows, so a pic that
+## carries them is wider than its own box and every row of it is that wide.
+## Zero when the buffer is not one, which is a caller with nothing to draw.
+static func pic_stride(pixels: PackedByteArray, side: int) -> int:
+	var box: int = side * TILE
+	if box <= 0 or pixels.size() < box * box:
+		return 0
+	@warning_ignore("integer_division")
+	var strip: int = pixels.size() / box
+	return strip
 
 
 ## [param front] is whether `PadFrontpic` runs over this one: a back pic fills
@@ -766,10 +775,17 @@ func _battler_tile(vram: int) -> PackedByteArray:
 		else Gen2BattleScreenMap.PLAYER_SIDE
 	var base: int = Gen2BattleScreenMap.ENEMY_BASE_TILE if enemy \
 		else Gen2BattleScreenMap.PLAYER_BASE_TILE
-	var pixels: PackedByteArray = _enemy_pixels if enemy else _player_pixels
-	var index: int = vram - base
-	var box: int = side * TILE
-	if index < 0 or index >= side * side or pixels.size() < box * box:
+	return pic_tile(_enemy_pixels if enemy else _player_pixels, side, vram - base)
+
+
+## One tile of a buffer [method padded_pic] produced, numbered `column * side +
+## row` the way `PlaceGraphic` numbers a picture's own box. Static because the
+## same read is what `tools/checks/pokepic.gd` sweeps a corpus with: it is the
+## one place a battler moved as objects and the same battler drawn as tilemap
+## can disagree.
+static func pic_tile(pixels: PackedByteArray, side: int, index: int) -> PackedByteArray:
+	var strip: int = pic_stride(pixels, side)
+	if index < 0 or index >= side * side or strip <= 0:
 		return PackedByteArray()
 
 	@warning_ignore("integer_division")
@@ -778,7 +794,7 @@ func _battler_tile(vram: int) -> PackedByteArray:
 	var out: PackedByteArray = PackedByteArray()
 	out.resize(TILE * TILE)
 	for row: int in TILE:
-		var from: int = (top + row) * box + left
+		var from: int = (top + row) * strip + left
 		for column: int in TILE:
 			out[row * TILE + column] = pixels[from + column]
 	return out

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -119,12 +119,23 @@ static func from_data(data: GameData) -> Gen2StartMenuPage:
 	return out
 
 
+## How many rows the box can show at once: it grows two rows an entry plus its
+## own border, and the screen is where it stops. The cartridge never needs this,
+## because `SetUpMenuItems` can append at most the eight rows that fit exactly;
+## a mod's `MENU_START` entry is what asks for a ninth (`docs/MODS.md`).
+static func visible_rows(contest: bool = false) -> int:
+	@warning_ignore("integer_division")
+	return (ROWS - (LIST_CONTEST_TOP if contest else LIST_TOP) - 1) / 2
+
+
 ## `AutomaticGetMenuBottomCoord`: the box grows downward by two rows an entry
-## plus its own border, so the header's bottom coordinate is never read.
+## plus its own border, so the header's bottom coordinate is never read. A list
+## longer than the screen stops at the screen and is scrolled through instead.
 static func list_box(count: int, contest: bool = false) -> Gen2MenuBox:
 	var top: int = LIST_CONTEST_TOP if contest else LIST_TOP
+	var rows: int = mini(maxi(count, 0), visible_rows(contest))
 	return Gen2MenuBox.from_coords(
-		LIST_LEFT, top, LIST_RIGHT, top + 2 * maxi(count, 0) + 1, LIST_FLAGS
+		LIST_LEFT, top, LIST_RIGHT, top + 2 * rows + 1, LIST_FLAGS
 	)
 
 

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -1,36 +1,80 @@
 class_name Gen2BoxScreen
 extends Control
 
-## Bill's PC, on the hardware's own grid.
+## Bill's PC's two lists, on the hardware's own grid.
 ##
-## [Gen2PCBoxPage] is the picture and `engine/pokemon/bills_pc.asm` is the model:
-## `wBillsPC_LoadedBox` picks the party or one box, `CopyBoxmonSpecies` builds
-## the list it walks with a CANCEL row on the end, and
-## `BillsPC_PressUp`/`Down`/`Left`/`Right` are the cursor, the scroll and the box
-## the D-pad changes.
+## [Gen2PCBoxPage] is the picture and `engine/pokemon/bills_pc.asm` is the model.
+## `_DepositPKMN` and `_WithdrawPKMN` are this one screen with a different list
+## loaded: `wBillsPC_LoadedBox` is the party for one and the current box for the
+## other, `CopyBoxmonSpecies` builds the list with a CANCEL row on the end, and
+## `Withdraw_UpDown` walks it. `_BillsPC`'s own top menu is the panel's
+## ([Gen2WorldServiceScreen]), which is what opens this in either mode.
 ##
-## What the source splits between DEPOSIT, WITHDRAW and MOVE WITHOUT MAIL is one
-## screen here: A on a party row deposits and A on a box row withdraws, through
-## [Gen2SaveStorage]'s atomic transfers. The submenus behind those rows (STATS,
-## RELEASE, MOVE) are not built; nothing calls them and the storage boundary is
-## what the PC exists for.
+## A on a row opens the submenu both jumptables reach: the transfer, STATS,
+## RELEASE and CANCEL. Left and right do nothing, because the only routine that
+## reads them is `MoveMonWithoutMail_DPad`, and MOVE PKMN W/O MAIL is a screen of
+## its own that is not built.
 
 signal closed(result: Dictionary)
+## `PlayMonCry2` from the stats screen this one can open, played by whoever owns
+## the audio player: nothing here reaches [Gen2AudioPlayer].
+signal cry_requested(species: int)
 
 ## The PC is drawn in hardware pixels and the panel it is opened from is ordinary
 ## UI at window resolution, so the screen carries a [Gen2Screen] of its own, the
 ## way [Gen2TownMapScreen] does.
 
-## `PCString_ChooseaPKMN` and `.PartyPKMN`. Both are engine strings inside
+## `PCString_*` and `.PartyPKMN`. All of them are engine strings inside
 ## `bills_pc.asm` that no script points at, so nothing imports them and they are
 ## the host's, like the contest judging lines. "PKMN" is the two tiles `<PK>` and
 ## `<MN>`, which is what [method Gen2Text.encode] makes of it; "#" is the POKé
 ## ligature and has no tile in either font.
 const PROMPT_CHOOSE: String = "Choose a PKMN."
+const PROMPT_WHATS_UP: String = "What's up?"
+const PROMPT_RELEASE: String = "Release PKMN?"
+const PROMPT_LAST_MON: String = "It's your last PKMN!"
+const PROMPT_NO_USABLE: String = "No more usable PKMN!"
+const PROMPT_BOX_FULL: String = "The BOX is full."
+const PROMPT_PARTY_FULL: String = "The party's full!"
+const PROMPT_NO_EGGS: String = "No releasing EGGS!"
+const PROMPT_STORED: String = "Stored %s!"
+const PROMPT_GOT: String = "Got %s!"
+## `ReleasePKMN_ByePKMN` prints `PCString_ReleasedPKMN` for eighty frames and
+## then this one for fifty. Nothing here spends frames, so the line left on the
+## page is the one the source leaves on it.
+const PROMPT_BYE: String = "Bye, %s!"
 const PARTY_NAME: String = "PARTY PKMN"
 
 ## `wBillsPC_LoadedBox`: zero is the party and the boxes follow it.
 const LOADED_PARTY: int = 0
+
+## Which of `_BillsPC.Jumptable`'s two list rows opened this screen.
+const MODE_DEPOSIT: int = 0
+const MODE_WITHDRAW: int = 1
+
+## `BillsPCDepositMenuHeader` and `BillsPC_Withdraw.MenuHeader`, the same
+## `menu_coords 9, 4, SCREEN_WIDTH - 1, 13` over the listing, and the yes/no
+## `lb bc, 14, 11` puts under it. `_YesNoBox` adds five and four to the corner it
+## is handed.
+const SUBMENU_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR
+const SUBMENU_AT: Rect2i = Rect2i(9, 4, 10, 9)
+const RELEASE_AT: Vector2i = Vector2i(14, 11)
+const RELEASE_SPAN: Vector2i = Vector2i(5, 4)
+const RELEASE_OPTIONS: Array[String] = ["YES", "NO"]
+
+## `BillsPCDepositJumptable` and `BillsPC_Withdraw.dw`: the same four rows, whose
+## first is the transfer the loaded list implies.
+const SUBMENU_TRANSFER: int = 0
+const SUBMENU_STATS: int = 1
+const SUBMENU_RELEASE: int = 2
+const SUBMENU_CANCEL: int = 3
+const SUBMENU_ROWS: Array[String] = ["DEPOSIT", "STATS", "RELEASE", "CANCEL"]
+const SUBMENU_ROWS_WITHDRAW: Array[String] = ["WITHDRAW", "STATS", "RELEASE", "CANCEL"]
+
+## `BillsPC_CheckMail_PreventBlackout`'s own `cp $3` against
+## `wBillsPC_NumMonsInBox`, which `CopyBoxmonSpecies` leaves one over the party
+## count because the CANCEL row is in it.
+const BLACKOUT_ROWS: int = 3
 
 var _data: GameData = null
 var _data_override: GameData = null
@@ -48,6 +92,16 @@ var _scroll: int = 0
 ## The line the bottom box carries, which is `PCString_ChooseaPKMN` until a
 ## transfer answers.
 var _prompt: String = PROMPT_CHOOSE
+## `_DepositPKMN` or `_WithdrawPKMN`, and the submenu, the release yes/no and
+## the stats screen either of them can put over the listing.
+var _mode: int = MODE_DEPOSIT
+var _submenu_open: bool = false
+var _submenu_cursor: int = 0
+var _release_open: bool = false
+var _release_cursor: int = 0
+var _stats: Gen2MonStatsScreen = null
+var _stats_page: Gen2StatsScreenPage = null
+var _menu_page: Gen2MenuPage = null
 var _page: Gen2PCBoxPage = null
 ## The screen this is drawn in, and the 160x144 layer inside it.
 var _screen: Gen2Screen = null
@@ -74,7 +128,8 @@ func _ready() -> void:
 ## Supplies the cache/save context. Embedded overworld use can keep the same
 ## atomic storage operations in memory while a selected runtime save persists.
 func set_context(
-	data: GameData, save: Gen2SaveData, persist: bool = true, embedded: bool = false
+	data: GameData, save: Gen2SaveData, persist: bool = true, embedded: bool = false,
+	mode: int = MODE_DEPOSIT, box_index: int = 0
 ) -> void:
 	_data_override = data
 	_save_override = save
@@ -82,6 +137,14 @@ func set_context(
 	_embedded = embedded
 	_data = data
 	_save = save
+	_mode = MODE_WITHDRAW if mode == MODE_WITHDRAW else MODE_DEPOSIT
+	_box_index = clampi(box_index, 0, Gen2SaveData.BOX_COUNT - 1)
+	## `.Init` writes `wBillsPC_LoadedBox` itself, so which list is up is the
+	## mode's rather than anything the last screen left behind.
+	_loaded = LOADED_PARTY if _mode == MODE_DEPOSIT else _box_index + 1
+	_cursor = 0
+	_scroll = 0
+	_prompt = PROMPT_CHOOSE
 	if is_inside_tree():
 		if _page == null:
 			_page = Gen2PCBoxPage.from_data(_data)
@@ -106,6 +169,11 @@ func box_snapshot() -> Dictionary:
 		"cursor": _cursor,
 		"scroll": _scroll,
 		"prompt": _prompt,
+		"mode": _mode,
+		"submenu": _submenu_labels() if _submenu_open else [],
+		"submenu_cursor": _submenu_cursor if _submenu_open else -1,
+		"release": _release_cursor if _release_open else -1,
+		"stats": _stats != null,
 		"boxes": boxes,
 	}
 
@@ -115,7 +183,7 @@ func select_box(box_index: int) -> bool:
 		return false
 	_box_index = box_index
 	_selected_box_slot = -1
-	if _loaded != LOADED_PARTY:
+	if _mode == MODE_WITHDRAW:
 		_loaded = box_index + 1
 	_cursor = 0
 	_scroll = 0
@@ -141,56 +209,106 @@ func select_party_member(index: int) -> bool:
 	return true
 
 
+## `DepositPokemon`. A transaction reason never reaches the page: the source
+## prints one of its own strings for each refusal it has, and one it has none for
+## is one the joypad cannot ask for.
 func deposit_selected_party() -> bool:
 	if _save == null or _selected_party_index < 0:
-		_prompt = "Choose a party PKMN."
+		_prompt = PROMPT_CHOOSE
 		_refresh()
 		return false
+	var name: String = _display_name(_save.party[_selected_party_index] as Gen2SaveMon)
 	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(
 		_save, _data, _selected_party_index, _box_index, -1, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_prompt = String(result.get("message", result.get("reason", "Deposit refused.")))
+		_prompt = _refusal(result, PROMPT_BOX_FULL)
 		_refresh()
 		return false
-	_prompt = "Stored in BOX %d." % (int(result["box"]) + 1)
+	_prompt = PROMPT_STORED % name
 	_selected_party_index = -1
 	_clamp_cursor()
 	_refresh()
 	return true
 
 
+## `TryWithdrawPokemon`, whose one refusal is `PCString_PartyFull`.
 func withdraw_selected_box() -> bool:
 	if _save == null or _selected_box_slot < 0:
-		_prompt = "Choose a stored PKMN."
+		_prompt = PROMPT_CHOOSE
 		_refresh()
 		return false
+	var box: Gen2SaveBox = _save.boxes[_box_index] if _box_index < _save.boxes.size() else null
+	var name: String = _display_name(
+		box.slots[_selected_box_slot] as Gen2SaveMon if box != null else null
+	)
 	var result: Dictionary = Gen2SaveStorage.withdraw_box_to_party(
 		_save, _data, _box_index, _selected_box_slot, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_prompt = String(result.get("message", result.get("reason", "Withdrawal refused.")))
+		_prompt = _refusal(result, PROMPT_PARTY_FULL)
 		_refresh()
 		return false
-	_prompt = "Taken out of BOX %d." % (_box_index + 1)
+	_prompt = PROMPT_GOT % name
 	_selected_box_slot = -1
 	_clamp_cursor()
 	_refresh()
 	return true
 
 
-## `_StatsScreenDPad` and its siblings: up and down walk the list, left and right
-## change the loaded box, A takes the row the cursor stands on and B leaves.
+## `.release`, behind the yes/no both submenus put up. The party's own blackout
+## check has already run: the source asks it before the question, not after.
+func release_selected() -> bool:
+	if _save == null:
+		return false
+	var mon: Gen2SaveMon = _selected_mon()
+	var name: String = _display_name(mon)
+	var result: Dictionary = Gen2SaveStorage.release_party_member(
+		_save, _data, _selected_party_index, _persist
+	) if _loaded == LOADED_PARTY else Gen2SaveStorage.release_box_slot(
+		_save, _data, _box_index, _selected_box_slot, _persist
+	)
+	if not bool(result.get("ok", false)):
+		_prompt = _refusal(result, PROMPT_LAST_MON)
+		_refresh()
+		return false
+	_prompt = PROMPT_BYE % name
+	_selected_party_index = -1
+	_selected_box_slot = -1
+	_clamp_cursor()
+	_refresh()
+	return true
+
+
+## The line a refused transaction prints. Every reason the joypad can produce has
+## a string of its own; anything else is a damaged save reaching a screen that
+## cannot say so, and takes the caller's own line rather than a symbol name.
+func _refusal(result: Dictionary, fallback: String) -> String:
+	match StringName(result.get("reason", &"")):
+		&"box_full", &"box_slot_occupied":
+			return PROMPT_BOX_FULL
+		&"party_full":
+			return PROMPT_PARTY_FULL
+		&"last_party_member":
+			return PROMPT_LAST_MON
+	return fallback
+
+
+## `Withdraw_UpDown` and the two jumptables around it: up and down walk the list,
+## A takes the row the cursor stands on and B leaves. Left and right belong to
+## MOVE PKMN W/O MAIL alone and do nothing here.
 func handle_button(button: int) -> bool:
+	if _stats != null:
+		return _stats.handle_button(button)
+	if _release_open:
+		return _handle_release_button(button)
+	if _submenu_open:
+		return _handle_submenu_button(button)
 	match button:
 		Gen2Button.UP:
 			_press_up()
 		Gen2Button.DOWN:
 			_press_down()
-		Gen2Button.LEFT:
-			_press_left()
-		Gen2Button.RIGHT:
-			_press_right()
 		Gen2Button.A:
 			_confirm()
 		Gen2Button.B:
@@ -198,6 +316,156 @@ func handle_button(button: int) -> bool:
 		_:
 			return false
 	return true
+
+
+## `VerticalMenu` over the listing. Its B is the CANCEL row, which is
+## `BillsPCDepositFuncCancel`: back to the list, nothing done.
+func _handle_submenu_button(button: int) -> bool:
+	match button:
+		Gen2Button.UP:
+			_submenu_cursor = wrapi(_submenu_cursor - 1, 0, _submenu_labels().size())
+		Gen2Button.DOWN:
+			_submenu_cursor = wrapi(_submenu_cursor + 1, 0, _submenu_labels().size())
+		Gen2Button.A:
+			_confirm_submenu()
+			return true
+		Gen2Button.B:
+			_close_submenu()
+			return true
+		_:
+			return false
+	_refresh()
+	return true
+
+
+## `PlaceYesNoBox`, whose B is its NO.
+func _handle_release_button(button: int) -> bool:
+	match button:
+		Gen2Button.UP:
+			_release_cursor = wrapi(_release_cursor - 1, 0, RELEASE_OPTIONS.size())
+		Gen2Button.DOWN:
+			_release_cursor = wrapi(_release_cursor + 1, 0, RELEASE_OPTIONS.size())
+		Gen2Button.A:
+			_release_open = false
+			if _release_cursor == 0:
+				_close_submenu(false)
+				release_selected()
+			else:
+				_prompt = PROMPT_WHATS_UP
+				_refresh()
+			return true
+		Gen2Button.B:
+			_release_open = false
+			_prompt = PROMPT_WHATS_UP
+			_refresh()
+			return true
+		_:
+			return false
+	_refresh()
+	return true
+
+
+## The submenu's own four rows, whose first is named for the list that is loaded.
+func _submenu_labels() -> Array:
+	return SUBMENU_ROWS_WITHDRAW if _loaded != LOADED_PARTY else SUBMENU_ROWS
+
+
+## `.WhatsUp`/`.PrepSubmenu`: the string changes and the cursor opens on the
+## transfer row, which is `ld a, $1 / ld [wMenuCursorY], a`.
+func _open_submenu() -> void:
+	_submenu_open = true
+	_submenu_cursor = 0
+	_prompt = PROMPT_WHATS_UP
+	_refresh()
+
+
+func _close_submenu(draw: bool = true) -> void:
+	_submenu_open = false
+	_release_open = false
+	_prompt = PROMPT_CHOOSE
+	if draw:
+		_refresh()
+
+
+func _confirm_submenu() -> void:
+	match _submenu_cursor:
+		SUBMENU_TRANSFER:
+			var refusal: String = _blackout_refusal()
+			if not refusal.is_empty():
+				_close_submenu(false)
+				_prompt = refusal
+				_refresh()
+				return
+			_close_submenu(false)
+			if _loaded == LOADED_PARTY:
+				deposit_selected_party()
+			else:
+				withdraw_selected_box()
+		SUBMENU_STATS:
+			_open_stats()
+		SUBMENU_RELEASE:
+			var blocked: String = _blackout_refusal()
+			if blocked.is_empty() and _selected_mon() != null \
+					and (_selected_mon() as Gen2SaveMon).is_egg:
+				## `BillsPC_IsMonAnEgg`, which the box side checks on its own and
+				## the party side reaches behind the blackout check.
+				blocked = PROMPT_NO_EGGS
+			if not blocked.is_empty():
+				_close_submenu(false)
+				_prompt = blocked
+				_refresh()
+				return
+			_release_open = true
+			_release_cursor = 0
+			_prompt = PROMPT_RELEASE
+			_refresh()
+		_:
+			_close_submenu()
+
+
+## `BillsPC_CheckMail_PreventBlackout`, which guards the party list's transfer
+## and its release alike. Its mail branch is unreachable here: no item is mail
+## until `ItemIsMail`'s list is imported (see [method _mon_state]).
+func _blackout_refusal() -> String:
+	if _loaded != LOADED_PARTY or _save == null:
+		return ""
+	if rows().size() < BLACKOUT_ROWS:
+		return PROMPT_LAST_MON
+	if _all_others_fainted():
+		return PROMPT_NO_USABLE
+	return ""
+
+
+## `CheckCurPartyMonFainted`: whether every party member but the chosen one has
+## no HP left.
+func _all_others_fainted() -> bool:
+	for index: int in _save.party.size():
+		if index == _selected_party_index:
+			continue
+		var mon: Gen2SaveMon = _save.party[index]
+		if mon != null and mon.hp > 0:
+			return false
+	return true
+
+
+## `BillsPC_StatsScreen`, which is `StatsScreenInit` over this screen and hands
+## control back on the way out.
+func _open_stats() -> void:
+	var mon: Gen2SaveMon = _selected_mon()
+	if mon == null or _data == null:
+		return
+	_stats = Gen2MonStatsScreen.create(_data, [mon])
+	_stats.closed.connect(_close_stats)
+	_stats.cry_requested.connect(func(species: int) -> void: cry_requested.emit(species))
+	_stats.announce()
+	_refresh()
+
+
+## The submenu is still up behind it, which is where `.stats` returns.
+func _close_stats() -> void:
+	_stats = null
+	_prompt = PROMPT_WHATS_UP
+	_refresh()
 
 
 ## The list `CopyBoxmonSpecies` builds: every occupied slot of the loaded list,
@@ -276,6 +544,9 @@ func _refresh() -> void:
 	var mon: Gen2SaveMon = _selected_mon()
 	if _page == null or _background == null:
 		return
+	if _stats != null:
+		_refresh_stats()
+		return
 	var visible_rows: Array = []
 	var all_rows: Array = rows()
 	for index: int in Gen2PCBoxPage.LIST_HEIGHT:
@@ -288,6 +559,7 @@ func _refresh() -> void:
 		"prompt": _prompt,
 		"mon": _mon_state(mon),
 	})
+	_draw_menus(indices)
 	var palette: PackedColorArray = _interface_palette()
 	if _backdrop != null:
 		_backdrop.color = palette[0]
@@ -296,7 +568,86 @@ func _refresh() -> void:
 	))
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_refresh_pic(mon)
-	_refresh_cursor(all_rows.size())
+	## `.WhatsUp` and `.PrepSubmenu` both open with `ClearSprites`, and the
+	## picture is tilemap rather than OAM, so only the ring goes.
+	_refresh_cursor(0 if _submenu_open else all_rows.size())
+
+
+## The submenu, and the release yes/no under it, into the page's own buffer:
+## `VerticalMenu` and `PlaceYesNoBox` draw over the tilemap that is already up.
+func _draw_menus(indices: PackedByteArray) -> void:
+	if not _submenu_open:
+		return
+	if _menu_page == null:
+		_menu_page = Gen2MenuPage.from_data(_data)
+	if _menu_page == null:
+		return
+	var width: int = Gen2Screen.WIDTH
+	_menu_page.draw(
+		Gen2MenuBox.from_coords(
+			SUBMENU_AT.position.x, SUBMENU_AT.position.y,
+			SUBMENU_AT.position.x + SUBMENU_AT.size.x,
+			SUBMENU_AT.position.y + SUBMENU_AT.size.y, SUBMENU_FLAGS
+		),
+		_submenu_labels(), _submenu_cursor, indices, width
+	)
+	if not _release_open:
+		return
+	_menu_page.draw(
+		Gen2MenuBox.from_coords(
+			RELEASE_AT.x, RELEASE_AT.y,
+			RELEASE_AT.x + RELEASE_SPAN.x, RELEASE_AT.y + RELEASE_SPAN.y,
+			SUBMENU_FLAGS | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+		),
+		RELEASE_OPTIONS, _release_cursor, indices, width
+	)
+
+
+## `StatsScreenInit` over this screen, drawn the way the party menu draws it: the
+## front pic has a palette of its own and is composed on top of the page.
+func _refresh_stats() -> void:
+	if _stats_page == null:
+		_stats_page = Gen2StatsScreenPage.from_data(_data)
+	if _stats_page == null:
+		return
+	var snapshot: Dictionary = _stats.snapshot()
+	var image: Image = _stats_page.render(snapshot, _data)
+	if image == null:
+		return
+	Gen2PicImage.show(_background, image)
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _backdrop != null:
+		_backdrop.color = Color.WHITE
+	_refresh_stats_pic(snapshot)
+	_refresh_cursor(0)
+
+
+## `PrepMonFrontpic`'s cell, the same one [method _refresh_pic] places a listing
+## picture in, at the stats screen's own corner.
+func _refresh_stats_pic(snapshot: Dictionary) -> void:
+	if _pic == null:
+		return
+	_pic.texture = null
+	var species: int = int(snapshot.get("species", 0))
+	if species <= 0 or _data == null:
+		return
+	var egg: bool = bool(snapshot.get("egg", false))
+	var pic: Dictionary = _data.egg_pic() if egg else _data.species_pic(species)
+	if pic.is_empty():
+		return
+	var art: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
+		_data.egg_palette() if egg \
+			else _data.palette(species, bool(snapshot.get("shiny", false)))
+	)
+	if art == null:
+		return
+	Gen2PicImage.show(_pic, art)
+	_pic.size = Vector2(art.get_size())
+	var cell: int = Gen2StatsScreenPage.pic_size()
+	_pic.position = Vector2(Gen2StatsScreenPage.pic_position()) + Vector2(
+		float(cell - art.get_width()) * 0.5, float(cell - art.get_height())
+	)
 
 
 ## `_CGB_BillsPC`'s background palette, PREDEFPAL_POKEDEX, which the Pokedex
@@ -474,30 +825,8 @@ func _press_down() -> void:
 	_refresh()
 
 
-## `BillsPC_PressLeft`/`Right`, which wrap the party and every box round.
-func _press_left() -> void:
-	_load(_loaded - 1 if _loaded > LOADED_PARTY else Gen2SaveData.BOX_COUNT)
-
-
-func _press_right() -> void:
-	_load(_loaded + 1 if _loaded < Gen2SaveData.BOX_COUNT else LOADED_PARTY)
-
-
-func _load(loaded: int) -> void:
-	_loaded = loaded
-	if _loaded != LOADED_PARTY:
-		_box_index = _loaded - 1
-	_cursor = 0
-	_scroll = 0
-	_selected_box_slot = -1
-	_selected_party_index = -1
-	_prompt = PROMPT_CHOOSE
-	_sync_selection()
-	_refresh()
-
-
-## A on the CANCEL row leaves, the way `.Cancel` does; on any other row it is the
-## transfer the loaded list implies.
+## A on the CANCEL row leaves, the way `.a_button`'s `cp -1` does; on any other
+## row it opens the submenu.
 func _confirm() -> void:
 	var all_rows: Array = rows()
 	var at: int = _cursor + _scroll
@@ -505,10 +834,7 @@ func _confirm() -> void:
 		_back()
 		return
 	_sync_selection()
-	if _loaded == LOADED_PARTY:
-		deposit_selected_party()
-		return
-	withdraw_selected_box()
+	_open_submenu()
 
 
 ## After a transfer the list is one row shorter, so the cursor comes back inside

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -62,6 +62,10 @@ var run_options: Dictionary = {}
 ## adopts the installation's once.
 var run_rules: Gen2Rules = null
 var boxes_shape_valid: bool = true
+## `wCurBox`, which is where a deposit lands and which box BILL'S PC's WITHDRAW
+## opens on. Like the `run` block it defaults rather than versioning: a slot
+## written before it existed is one whose current box is the first.
+var current_box: int = 0
 
 
 func _init() -> void:
@@ -89,6 +93,7 @@ func to_dict() -> Dictionary:
 		"label": label,
 		"party": saved_party,
 		"boxes": saved_boxes,
+		"current_box": current_box,
 		"world": world.to_dict() if world != null else {},
 		"mods": mods.duplicate(true),
 		"run": {
@@ -119,6 +124,7 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	out.gender = GENDER_FEMALE if int(source.get("gender", GENDER_MALE)) & 1 else GENDER_MALE
 	out.game_time = Gen2GameTime.parse(source.get("game_time", {}))
 	out.label = String(source.get("label", ""))
+	out.current_box = clampi(int(source.get("current_box", 0)), 0, BOX_COUNT - 1)
 	var raw_party: Variant = source.get("party", [])
 	if raw_party is Array:
 		for raw_mon: Variant in raw_party as Array:
@@ -288,6 +294,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	label = copied.label
 	party = copied.party
 	boxes = copied.boxes
+	current_box = copied.current_box
 	world = copied.world
 	mods = copied.mods.duplicate(true)
 	run_seed = copied.run_seed

--- a/game/save/save_storage.gd
+++ b/game/save/save_storage.gd
@@ -77,6 +77,51 @@ static func withdraw_box_to_party(
 	}, persist)
 
 
+## `RemoveMonFromPartyOrBox` behind `BillsPCDepositFuncRelease` and Bill's PC's
+## own `.release`: the same atomic write the two transfers make, with nothing on
+## the other end of it. Both of the source's refusals are the caller's, since
+## both are boxes it prints before the yes/no: `BillsPC_IsMonAnEgg` and, for the
+## party alone, `BillsPC_CheckMail_PreventBlackout`.
+static func release_party_member(
+	save: Gen2SaveData, data: GameData, party_index: int, persist: bool = true
+) -> Dictionary:
+	var candidate_result: Dictionary = _candidate(save, data)
+	if not bool(candidate_result.get("ok", false)):
+		return candidate_result
+	var candidate: Gen2SaveData = candidate_result["save"]
+	if party_index < 0 or party_index >= candidate.party.size():
+		return _failure(&"invalid_party_index")
+	if candidate.party.size() <= 1:
+		return _failure(&"last_party_member")
+	candidate.party.remove_at(party_index)
+	return _commit(save, data, candidate, {
+		"kind": &"release_party", "party_index": party_index,
+	}, persist)
+
+
+static func release_box_slot(
+	save: Gen2SaveData, data: GameData, box_index: int, box_slot: int,
+	persist: bool = true
+) -> Dictionary:
+	var candidate_result: Dictionary = _candidate(save, data)
+	if not bool(candidate_result.get("ok", false)):
+		return candidate_result
+	var candidate: Gen2SaveData = candidate_result["save"]
+	if box_index < 0 or box_index >= candidate.boxes.size():
+		return _failure(&"invalid_box_index")
+	if box_slot < 0 or box_slot >= Gen2SaveBox.CAPACITY:
+		return _failure(&"invalid_box_slot")
+	var box: Gen2SaveBox = candidate.boxes[box_index]
+	if box == null or box_slot >= box.slots.size():
+		return _failure(&"invalid_box_shape")
+	if box.slots[box_slot] == null:
+		return _failure(&"empty_box_slot")
+	box.slots[box_slot] = null
+	return _commit(save, data, candidate, {
+		"kind": &"release_box", "box": box_index, "slot": box_slot,
+	}, persist)
+
+
 static func _candidate(save: Gen2SaveData, data: GameData) -> Dictionary:
 	if save == null or data == null:
 		return _failure(&"missing_save_context")

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -75,6 +75,11 @@ static func save(save_data: Gen2SaveData, data: GameData) -> Dictionary:
 	if DirAccess.make_dir_recursive_absolute(directory) != OK:
 		return _failure("could not create the save directory")
 
+	## The cartridge's RTC keeps running while the machine is off, so the file
+	## records the host second it was written at and the world it reopens catches
+	## up to what has passed since (`Gen2WorldClock.catch_up`).
+	if save_data.world != null:
+		save_data.world.world_clock_stamp = Gen2WorldClock.host_seconds()
 	var document: String = _wrap(JSON.stringify(save_data.to_dict(), "\t"))
 	var primary: Dictionary = _write_file(path, document)
 	if not primary["ok"]:

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -292,6 +292,9 @@ func _on_speech_finished(player_name: String) -> void:
 		created.world.world_day = int(_clock["day"])
 		created.world.world_hour = int(_clock["hour"])
 		created.world.world_minute = int(_clock["minute"])
+		## `InitClock` is what sets the RTC, so the time the player just dialled
+		## in is the time as of now rather than as of the snapshot's own stamp.
+		created.world.world_clock_stamp = Gen2WorldClock.host_seconds()
 	## Before the write: a mod holding a run snapshots what built it into the
 	## save's own namespace, and that has to be in the bytes on disk.
 	GameRuntime.announce_new_save(created)

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -134,6 +134,9 @@ var _pack_result: String = ""
 ## `wItemsPocketScrollPosition` and its three siblings: which entry the visible
 ## five start at. Held per pocket, the way the source holds one variable each.
 var _pack_scroll: Array[int] = [0, 0, 0, 0]
+## Which row of the start menu's own list is at the top of the box. See
+## [method _scroll_list_to_cursor].
+var _list_scroll: int = 0
 var _pack_cursors: Array[int] = [0, 0, 0, 0]
 var _pack_page: Gen2PackPage = null
 var _pack_result_ok: bool = false
@@ -367,6 +370,7 @@ func _move(direction: Vector2i) -> void:
 			## The source's .MenuData omits STATICMENU_ENABLE_LEFT_RIGHT, so
 			## only vertical input moves the top-level list.
 			if direction.x == 0 and _menu != null and _menu.move(direction.y):
+				_scroll_list_to_cursor()
 				_render_list()
 		Mode.PACK:
 			if direction.x != 0:
@@ -609,7 +613,28 @@ func _confirm_list() -> void:
 
 func _open_list_mode() -> void:
 	_mode = Mode.LIST
+	## The row the menu reopens on is the one it was left on, which may be past
+	## the window a previous open left behind.
+	_scroll_list_to_cursor()
 	_render_list()
+
+
+## The window the list is drawn through. The box is the height of the screen and
+## the cartridge's own eight rows fill it exactly, so a `MENU_START` entry a mod
+## registers is a row past the bottom; `_move_pack_cursor` solves the same thing
+## for a pocket, and this is its twin. `STATICMENU_WRAP` still wraps the cursor,
+## and the window follows it round, so EXIT is one press up from the top row.
+func _scroll_list_to_cursor() -> void:
+	if _menu == null:
+		_list_scroll = 0
+		return
+	var visible: int = Gen2StartMenuPage.visible_rows(
+		_world != null and _world.bug_contest_active()
+	)
+	_list_scroll = clampi(
+		clampi(_list_scroll, _menu.cursor - visible + 1, _menu.cursor),
+		0, maxi(_menu.size() - visible, 0)
+	)
 
 
 func _render_list() -> void:
@@ -1980,6 +2005,8 @@ func _hardware_image() -> Image:
 		Mode.LIST:
 			if _menu == null:
 				return null
+			var contest: bool = _world != null and _world.bug_contest_active()
+			var visible: int = Gen2StartMenuPage.visible_rows(contest)
 			var labels: Array = []
 			for entry: Variant in _menu.items():
 				labels.append(String((entry as Dictionary).get("label", "")))
@@ -1988,8 +2015,8 @@ func _hardware_image() -> Image:
 			var description: String = _menu.selected_description() \
 				if Gen2OptionsStore.current().menu_account else ""
 			return _page.render_list(
-				labels, _menu.cursor, description,
-				_world != null and _world.bug_contest_active()
+				labels.slice(_list_scroll, _list_scroll + visible),
+				_menu.cursor - _list_scroll, description, contest
 			)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
 		Mode.SAVE_FAILED:

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -14,6 +14,12 @@ extends RefCounted
 ## rather than by waiting for them
 ## ([method Gen2WorldScreen.advance_world_time]).
 ##
+## The clock keeps its own time while the game is not running, which is what a
+## cartridge's RTC does: a snapshot records the host second its time was written
+## at, and [method catch_up] moves the saved time on by what has passed since.
+## Without that a save resumed at the hour it was written at, so a player who set
+## the clock in the morning never saw a night.
+##
 ## The clock does not move roaming Pokémon: the cartridge advances those during
 ## map setup, so [method Gen2WorldAPI.advance_schedule] is driven by a map change
 ## rather than elapsed time.
@@ -33,6 +39,11 @@ const NITE_START: int = 18
 ## The prefix, so the switch is written once.
 const PIN_ARGUMENT: String = "--clock="
 
+## `Time.get_unix_time_from_system()`, or the second a test names in its place.
+## A run's own clock cannot be asked to be somewhere else: this is set by a test
+## and by nothing that ships.
+static var host_seconds_override: float = -1.0
+
 var day: int = 0
 var hour: int = 0
 var minute: int = 0
@@ -48,6 +59,37 @@ func _init(start_hour: int = 0, start_minute: int = 0, start_day: int = 0) -> vo
 	day = posmod(start_day, DAYS_PER_WEEK)
 	hour = posmod(start_hour, HOURS_PER_DAY)
 	minute = posmod(start_minute, MINUTES_PER_HOUR)
+
+
+static func host_seconds() -> float:
+	return host_seconds_override if host_seconds_override >= 0.0 \
+		else Time.get_unix_time_from_system()
+
+
+## The clock [param day], [param hour] and [param minute] a snapshot carries,
+## moved on by the real seconds between the host second it was written at
+## ([param stamp]) and now. The same time back when there is no stamp, which is a
+## save written before one was kept, or when the stamp is ahead of now, which is
+## a host clock that has been put back: neither is a reason to run the world's
+## own clock backwards.
+static func catch_up(
+	day_value: int, hour: int, minute: int, stamp: float, now: float = -1.0
+) -> Dictionary:
+	var here: float = now if now >= 0.0 else host_seconds()
+	var elapsed: float = here - stamp
+	if stamp <= 0.0 or elapsed <= 0.0:
+		return {"day": day_value, "hour": hour, "minute": minute}
+	@warning_ignore("integer_division")
+	var minutes: int = int(elapsed / SECONDS_PER_MINUTE) \
+		+ minute + hour * MINUTES_PER_HOUR \
+		+ day_value * MINUTES_PER_HOUR * HOURS_PER_DAY
+	var day_minutes: int = MINUTES_PER_HOUR * HOURS_PER_DAY
+	@warning_ignore("integer_division")
+	return {
+		"day": (minutes / day_minutes) % DAYS_PER_WEEK,
+		"hour": (minutes % day_minutes) / MINUTES_PER_HOUR,
+		"minute": minutes % MINUTES_PER_HOUR,
+	}
 
 
 func time_of_day() -> int:

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -59,6 +59,40 @@ const UNBUILT_PLAYERS_PC_ROWS: Array[int] = [
 ]
 
 
+## `_BillsPC.MenuData`'s five rows, in its `.Jumptable`'s own order. Inline menu
+## strings inside `bills_pc_top.asm` that no script points at, so nothing imports
+## them and they are the host's, the way [Gen2BoxScreen]'s own two are.
+const BILLSPCITEM_WITHDRAW: int = 0
+const BILLSPCITEM_DEPOSIT: int = 1
+const BILLSPCITEM_CHANGE_BOX: int = 2
+const BILLSPCITEM_MOVE_WITHOUT_MAIL: int = 3
+const BILLSPCITEM_SEE_YA: int = 4
+const BILLS_PC_ROWS: Array[String] = [
+	"WITHDRAW PKMN", "DEPOSIT PKMN", "CHANGE BOX", "MOVE PKMN W/O MAIL", "SEE YA!",
+]
+## `_PCWhatText` and `_PCGottaHavePokemonText`, the two lines `.LogIn` and
+## `.CheckCanUsePC` print. Both are `text_far` stubs in `data/text/common_2.asm`
+## that no script reaches either.
+const BILLS_PC_WHAT: String = "What?"
+const BILLS_PC_NEEDS_POKEMON: String = "You gotta have\n#MON to call!"
+
+## MOVE PKMN W/O MAIL is `_MovePKMNWithoutMail`, a screen of its own with its own
+## joypad (`MoveMonWithoutMail_DPad`) and its own save-before-you-start step; the
+## row is dropped rather than offered and refused, the way the three rows above
+## are.
+const UNBUILT_BILLS_PC_ROWS: Array[int] = [BILLSPCITEM_MOVE_WITHOUT_MAIL]
+
+
+## The top menu behind BILL'S PC, as `{row, name}` in the source's own order.
+static func bills_pc_menu() -> Array:
+	var out: Array = []
+	for row: int in BILLS_PC_ROWS.size():
+		if row in UNBUILT_BILLS_PC_ROWS:
+			continue
+		out.append({"row": row, "name": BILLS_PC_ROWS[row]})
+	return out
+
+
 ## `.ChooseWhichPCListToUse`: the Pokedex first, then `wHallOfFameCount`, which
 ## is the induction flag here because the save model counts no records.
 static func top_menu_list(state: Gen2WorldState) -> int:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -397,7 +397,12 @@ func _build_world() -> void:
 				"The saved map or player position is not valid for this cache.",
 			)
 			return
-		var saved_clock: Dictionary = selected_save.world.world_clock()
+		## The RTC ran while the game was closed, so a save opens at the time it
+		## was written at plus the real seconds since (`Gen2WorldClock.catch_up`).
+		var saved_clock: Dictionary = Gen2WorldClock.catch_up(
+			selected_save.world.world_day, selected_save.world.world_hour,
+			selected_save.world.world_minute, selected_save.world.world_clock_stamp
+		)
 		initial_day = int(saved_clock.get("day", initial_day))
 		initial_hour = int(saved_clock.get("hour", initial_hour))
 		initial_minute = int(saved_clock.get("minute", initial_minute))
@@ -3263,6 +3268,21 @@ func preview_diploma(printing: bool = false, page: int = 1) -> void:
 		_diploma_host.preview_page(page)
 
 
+## Public screenshot driver for `_BillsPC`, whose top menu no preview cell
+## reaches: every PC on a preview map is a script's, and the machine wants a
+## party before it opens at all.
+func preview_bills_pc() -> void:
+	if _world == null or _data == null or _service_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "BILL'S PC preview needs a party"
+		_refresh_labels()
+		return
+	_injected_save = save
+	_open_bills_pc()
+
+
 ## Public screenshot driver for `Mom_WithdrawDepositMenuJoypad`, whose box no
 ## fixture cell reaches: her house is not one of the preview maps and the dial
 ## stands three questions into her own routine.
@@ -3281,6 +3301,7 @@ func preview_mom_bank(mode: StringName, saved: int, held: int) -> void:
 		return
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
 	_service_host = host
 	_refresh_labels()
 
@@ -3645,6 +3666,9 @@ func preview_start_menu() -> void:
 		return
 	if _start_menu_host == null:
 		_injected_save = _embedded_party_save()
+		## `SetUpMenuItems` reads the world's own party count for the #MON row,
+		## and the picture wants the full list rather than a saveless one.
+		_refresh_party_summary()
 		_open_start_menu()
 		return
 	_start_menu_host.handle_button(Gen2Button.DOWN)
@@ -4862,6 +4886,7 @@ func _open_service_host() -> void:
 		return
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
 	_service_host = host
 	_script_prompt = "Service host open"
 	_refresh_labels()
@@ -5864,6 +5889,7 @@ func _open_host_prompt(text: String) -> bool:
 		return false
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
 	_service_host = host
 	_script_prompt = "A: answer"
 	_refresh_labels()
@@ -5899,6 +5925,7 @@ func _open_service_overlay(kind: StringName) -> void:
 		return
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
 	_service_host = host
 	_script_prompt = "%s open" % label
 	_refresh_labels()
@@ -5928,6 +5955,7 @@ func _open_fly_map(request: Dictionary) -> void:
 		return
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
 	_service_host = host
 	_script_prompt = "Fly: choose a town"
 	_refresh_labels()

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -20,10 +20,15 @@ signal completed(results: Array)
 ## The wait itself is not spent (see `HANDOFF.md`'s `WaitSFX` row); what it
 ## carries is that the sound is heard.
 signal sfx_requested(index: int, waited: bool)
+## `PlayMonCry2` from a screen this one opens, the box screen's stats page today.
+## Passed on for the same reason [signal sfx_requested] is: the world screen owns
+## the one player.
+signal cry_requested(species: int)
 
 enum MODE {
 	MENU, MART, PHONE, TOWN_MAP, CARD,
 	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT, MOM_BANK,
+	PC_BOXES, PC_BOX_LIST,
 }
 
 ## `PokemonCenterPC`'s own box storage, which is the one row that opens a screen
@@ -131,6 +136,13 @@ var _pc_sfx: int = -1
 var _pc_after: StringName = &"top"
 var _pc_label: String = ""
 var _boxes: Gen2BoxScreen = null
+## `_ChangeBox_MenuHeader`'s `db 4, 0`: four rows of a scrolling list, and where
+## the window into the fourteen boxes stands.
+const BOX_LIST_ROWS: int = 4
+var _pc_scroll: int = 0
+## `wCurBox`, which CHANGE BOX writes and both lists read. It is the save's, so
+## the box a deposit lands in outlives the machine being switched off.
+var _box_index: int = 0
 ## Whether storage was opened without the Pokemon Center machine around it, so
 ## its B leaves the host rather than stepping back to a menu. See
 ## [method open_bills_pc].
@@ -858,10 +870,18 @@ func open_bills_pc(
 	if not Gen2WorldPC.can_open(_save):
 		_show_error("Storage needs a party.")
 		return false
-	_mode = MODE.PC
 	_bills_pc_only = true
-	_open_boxes()
-	return _boxes != null
+	_open_bills_pc_menu()
+	return true
+
+
+## `BillsPC_SeeYa`, and the `.LogOut` behind it: back to the machine's own top
+## menu, or out of the host when nothing opened this but a start-menu action.
+func _leave_bills_pc() -> void:
+	if _bills_pc_only:
+		_finish([])
+		return
+	_open_pc(&"pokemon_center")
 
 
 ## `PokemonCenterPC`'s top menu, or `_PlayersHousePC`'s item PC when the script
@@ -948,10 +968,30 @@ func _confirm_pc_row() -> void:
 	if _cursor < 0 or _cursor >= _pc_rows.size():
 		return
 	var row: int = int(_pc_rows[_cursor].get("row", -1))
+	if _mode == MODE.PC_BOX_LIST:
+		## `BillsPC_ChangeBoxSubmenu`'s SWITCH, which is `wCurBox` and nothing
+		## else. The list stays up, the way `.loop` leaves it.
+		_box_index = clampi(row, 0, Gen2SaveData.BOX_COUNT - 1)
+		if _save != null:
+			_save.current_box = _box_index
+		_refresh_box_counts()
+		_render_rows()
+		return
+	if _mode == MODE.PC_BOXES:
+		match row:
+			Gen2WorldPC.BILLSPCITEM_WITHDRAW:
+				_open_boxes(Gen2BoxScreen.MODE_WITHDRAW)
+			Gen2WorldPC.BILLSPCITEM_DEPOSIT:
+				_open_boxes(Gen2BoxScreen.MODE_DEPOSIT)
+			Gen2WorldPC.BILLSPCITEM_CHANGE_BOX:
+				_open_box_list()
+			Gen2WorldPC.BILLSPCITEM_SEE_YA:
+				_leave_bills_pc()
+		return
 	if _mode == MODE.PC:
 		match row:
 			Gen2WorldPC.PCPCITEM_BILLS_PC:
-				_open_boxes()
+				_open_bills_pc_menu()
 			Gen2WorldPC.PCPCITEM_PLAYERS_PC:
 				_open_pc_items()
 			Gen2WorldPC.PCPCITEM_OAKS_PC:
@@ -1078,9 +1118,63 @@ func _advance_pc_text() -> void:
 	_open_pc(&"pokemon_center")
 
 
-## BILL'S PC. The panel steps aside for the box screen the way it does for the
-## region map, so the top menu is still there when the boxes close.
-func _open_boxes() -> void:
+## `_BillsPC`, the top menu the two lists and the box picker sit behind.
+## `.CheckCanUsePC` is the one refusal it has, and it is the machine's own.
+func _open_bills_pc_menu() -> void:
+	if not Gen2WorldPC.can_open(_save):
+		## `.CheckCanUsePC` prints and returns to `PokemonCenterPC`'s own loop.
+		## The start-menu action never reaches this: [method open_bills_pc]
+		## refuses the same test before the host is opened at all.
+		_open_pc_text([Gen2WorldPC.BILLS_PC_NEEDS_POKEMON], &"top", "BILL's PC")
+		return
+	_mode = MODE.PC_BOXES
+	_cursor = 0
+	_box_index = clampi(
+		_save.current_box if _save != null else 0, 0, Gen2SaveData.BOX_COUNT - 1
+	)
+	_pc_rows = Gen2WorldPC.bills_pc_menu()
+	_title = _data.pokecenter_pc_row("bills_pc")
+	_summary = Gen2WorldPC.BILLS_PC_WHAT
+	_status = ""
+	_render_rows()
+
+
+## `_ChangeBox`'s scrolling list: every box by name, with what
+## `BillsPC_PrintBoxCountAndCapacity` prints beside the one the cursor is on.
+## Its own submenu is SWITCH, NAME, PRINT and QUIT; NAME needs box names, which
+## the save model does not carry ([Gen2SaveBox]), and PRINT is `PrintPCBox`
+## behind them, so a row here is the SWITCH the source's default option is.
+func _open_box_list() -> void:
+	_mode = MODE.PC_BOX_LIST
+	_cursor = _box_index
+	_pc_scroll = clampi(_box_index - BOX_LIST_ROWS + 1, 0, Gen2SaveData.BOX_COUNT - BOX_LIST_ROWS)
+	_pc_rows = []
+	for index: int in Gen2SaveData.BOX_COUNT:
+		_pc_rows.append({"row": index, "name": "BOX %d" % (index + 1)})
+	_title = "CHANGE BOX"
+	_summary = "Choose a BOX."
+	_refresh_box_counts()
+	_render_rows()
+
+
+## `GetBoxCount` for the row the cursor stands on, over MONS_PER_BOX.
+func _refresh_box_counts() -> void:
+	var index: int = clampi(_cursor, 0, Gen2SaveData.BOX_COUNT - 1)
+	var box: Gen2SaveBox = _save.boxes[index] if _save != null \
+		and index < _save.boxes.size() else null
+	var count: int = 0
+	if box != null:
+		for slot: int in Gen2SaveBox.CAPACITY:
+			if slot < box.slots.size() and box.slots[slot] != null:
+				count += 1
+	_status = "%d/%d PKMN, CURRENT BOX %d" % [
+		count, Gen2SaveBox.CAPACITY, _box_index + 1,
+	]
+
+
+## BILL'S PC's own two lists. The panel steps aside for the box screen the way it
+## does for the region map, so the menu is still there when the boxes close.
+func _open_boxes(mode: int) -> void:
 	var host: Gen2BoxScreen = BOX_SCENE.instantiate() as Gen2BoxScreen
 	if host == null or _save == null:
 		_status = "Box storage needs a validated save."
@@ -1091,8 +1185,16 @@ func _open_boxes() -> void:
 	host.z_index = 5
 	host.set_screen(_service_hardware)
 	add_child(host)
-	host.set_context(_data, _save, _persist, true)
+	host.set_context(_data, _save, _persist, true, mode, _box_index)
+	host.cry_requested.connect(_on_boxes_cry)
 	host.closed.connect(_on_boxes_closed)
+
+
+## The box screen's stats page plays a cry, and this screen owns no player: the
+## world screen is what turns [signal sfx_requested] into sound, and a cry is not
+## one, so it is passed on rather than dropped silently.
+func _on_boxes_cry(species: int) -> void:
+	cry_requested.emit(species)
 
 
 ## `Gen2BoxScreen.closed` carries the result its own host would have resumed a
@@ -1102,12 +1204,9 @@ func _on_boxes_closed(_result: Dictionary) -> void:
 		Gen2Screen.drop(_boxes)
 		_boxes = null
 	_set_overlay_open(false)
-	## Storage opened on its own has no machine behind it to step back to, so its
-	## B leaves the host entirely and the caller reopens whatever it came from.
-	if _bills_pc_only:
-		_finish([])
-		return
-	_open_pc(&"pokemon_center")
+	## `BillsPC_DepositMenu` and `BillsPC_WithdrawMenu` both `CloseWindow` back
+	## into `.UseBillsPC`'s own loop, which is the top menu.
+	_open_bills_pc_menu()
 
 
 func _open_phone(request: Dictionary, data: Dictionary) -> void:
@@ -1374,6 +1473,13 @@ func _move_cursor(delta: int) -> void:
 	_cursor = wrapi(_cursor + delta, 0, count)
 	if _mode == MODE.PC_ITEM_LIST:
 		_pc_quantity = 1
+	if _mode == MODE.PC_BOX_LIST:
+		## `ScrollingMenu` keeps the cursor inside its own window and moves the
+		## window under it, and `BillsPC_PrintBoxCountAndCapacity` runs per row
+		## rather than per choice.
+		_pc_scroll = clampi(_pc_scroll, _cursor - BOX_LIST_ROWS + 1, _cursor)
+		_pc_scroll = clampi(_pc_scroll, 0, maxi(0, count - BOX_LIST_ROWS))
+		_refresh_box_counts()
 	_render_rows()
 
 
@@ -1396,7 +1502,7 @@ func _move_direction(direction: Vector2i) -> void:
 
 
 func _confirm() -> void:
-	if _mode in [MODE.PC, MODE.PC_ITEMS]:
+	if _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST]:
 		_confirm_pc_row()
 		return
 	if _mode == MODE.PC_ITEM_LIST:
@@ -1416,7 +1522,12 @@ func _confirm() -> void:
 
 
 func _cancel() -> void:
-	if _mode == MODE.PC:
+	if _mode == MODE.PC_BOXES:
+		## `.cancel`: B off the top menu is the same way out SEE YA! is.
+		_leave_bills_pc()
+	elif _mode == MODE.PC_BOX_LIST:
+		_open_bills_pc_menu()
+	elif _mode == MODE.PC:
 		## `.shutdown`: B off the top menu is the same shut-down TURN OFF is.
 		_finish_runtime({"ok": true, "script_value": 0})
 	elif _mode == MODE.PC_ITEMS:
@@ -1479,9 +1590,15 @@ func _render_rows(override: Array = []) -> void:
 		## One value at a time, the way the dial itself shows it.
 		override = [_choices[clampi(_cursor, 0, _choices.size() - 1)]] if not _choices.is_empty() \
 			else []
+	if _mode == MODE.PC_BOX_LIST and override.is_empty():
+		## The window `ScrollingMenu` draws, and the cursor's place inside it.
+		_render_service_page(
+			_pc_rows.slice(_pc_scroll, _pc_scroll + BOX_LIST_ROWS), _cursor - _pc_scroll
+		)
+		return
 	var values: Array = override if not override.is_empty() else (
 		_choices if _mode == MODE.MENU \
-		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS] \
+		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES] \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else ["Continue"]
 	)
@@ -1490,7 +1607,7 @@ func _render_rows(override: Array = []) -> void:
 
 ## `PhoneCall`'s ringing box and `PC_DisplayText`'s plain `MenuTextbox` print
 ## neither one, so those two draw no rows at all here.
-func _render_service_page(values: Array) -> void:
+func _render_service_page(values: Array, cursor: int = -1) -> void:
 	if _service_view == null or _data == null:
 		_service_drawn = false
 		_apply_layer_visibility()
@@ -1514,7 +1631,8 @@ func _render_service_page(values: Array) -> void:
 			labels.append(String(value))
 	var image: Image = _mom_bank_image() if _mode == MODE.MOM_BANK \
 		else _dial_image() if _is_dial() else _service_page.render(
-		_title, _summary, labels, _cursor, _status, _service_box()
+		_title, _summary, labels, _cursor if cursor < 0 else cursor, _status,
+		_service_box()
 	)
 	if image != null:
 		Gen2PicImage.show(_service_view, image)
@@ -1562,8 +1680,10 @@ func _service_box() -> Gen2MenuBox:
 			if _menu == null or _menu.kind == &"spinner":
 				return null
 			return _menu.box()
-		MODE.PC, MODE.PC_ITEMS:
+		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES:
 			return _pc_top_box()
+		MODE.PC_BOX_LIST:
+			return _pc_box_list_box()
 		MODE.PC_ITEM_LIST:
 			return _pc_item_list_box()
 		MODE.APRICORN:
@@ -1578,6 +1698,18 @@ func _pc_top_box() -> Gen2MenuBox:
 	return Gen2MenuBox.from_coords(
 		0, 0, 15, 12, Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
 	)
+
+
+## `_ChangeBox_MenuHeader`'s `menu_coords 1, 5, 9, 12`, which is four rows of a
+## scrolling list rather than all fourteen at once.
+func _pc_box_list_box() -> Gen2MenuBox:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		1, 5, 9, 5 + BOX_LIST_ROWS + 2, Gen2MenuBox.STATICMENU_CURSOR
+	)
+	## `ScrollingMenu` writes its rows one apart, where `VerticalMenu` writes
+	## them two.
+	box.row_step = 1
+	return box
 
 
 ## `PCItemsMenuData`'s `menu_coords 4, 1, 18, 10`.
@@ -1600,7 +1732,7 @@ func _apricorn_quantity_box() -> Gen2MenuBox:
 func _option_count() -> int:
 	if _mode == MODE.MENU:
 		return _menu.options.size() if _menu != null else _choices.size()
-	if _mode in [MODE.PC, MODE.PC_ITEMS]:
+	if _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST]:
 		return _pc_rows.size()
 	if _mode == MODE.PC_ITEM_LIST:
 		return maxi(1, _pc_entries.size())

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -16,6 +16,14 @@ var world_day: int = 0
 var world_hour: int = 6
 var world_minute: int = 0
 var dst_enabled: bool = false
+## The host second this save was written at, stamped by [method Gen2SaveStore.save]
+## rather than taken here: a snapshot is compared frame for frame by
+## `tools/replay_world.gd`, and a wall clock inside one would make two identical
+## runs differ. It is what lets a world opened later catch up to the time that
+## passed while the game was closed (`Gen2WorldClock.catch_up`); zero in a save
+## written before it was kept, which reads as "resume where it stopped" rather
+## than as 1970.
+var world_clock_stamp: float = 0.0
 ## What a replay needs beside the state: the seed the world's generators were
 ## built from and how many hardware frames it has been pumped for. Both are zero
 ## in a snapshot written before either existed, which reads as "not reproducible"
@@ -64,6 +72,7 @@ func to_dict() -> Dictionary:
 		"player_sprite_number": player_sprite_number,
 		"clock": [world_day, world_hour, world_minute],
 		"dst_enabled": dst_enabled,
+		"world_clock_stamp": world_clock_stamp,
 		"random_seed": random_seed,
 		"frame_number": frame_number,
 		"last_spawn_map": [last_spawn_map.x, last_spawn_map.y],
@@ -96,6 +105,7 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 		out.world_hour = int(clock[1])
 		out.world_minute = int(clock[2])
 	out.dst_enabled = bool(source.get("dst_enabled", false))
+	out.world_clock_stamp = maxf(0.0, float(source.get("world_clock_stamp", 0.0)))
 	out.random_seed = int(source.get("random_seed", 0))
 	out.frame_number = maxi(0, int(source.get("frame_number", 0)))
 	out.last_spawn_map = _vector_from_value(source.get("last_spawn_map", [-1, -1]))

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -759,3 +759,37 @@ func test_a_wild_opponent_is_its_own_picture_from_the_first_frame() -> void:
 		&"trainer",
 		"the player is a person at the same moment",
 	)
+
+
+## `anim_battlergfx_*` stands an object in for the picture's bottom rows, and it
+## reads the same padded buffer the tilemap layer draws from. A Crystal front pic
+## carries `AnimateFrontpic`'s frames in those same rows, so the buffer is wider
+## than the box and the stride is its own: with the box's, every line of the
+## object came from further along the line above it and the picture's feet were
+## scrambled.
+func test_a_battler_object_tile_is_read_over_the_pics_own_strip() -> void:
+	await _open_battle()
+	var renderer: Gen2BattleRenderer = _battle_screen._renderer
+	var side: int = Gen2BattleScreenMap.ENEMY_SIDE
+	var box: int = side * Gen2Font.TILE
+	# Two animation columns behind the box, and every pixel says where it stands.
+	var strip: int = box + 2 * Gen2Font.TILE
+	var pixels: PackedByteArray = PackedByteArray()
+	pixels.resize(box * strip)
+	for y: int in box:
+		for x: int in strip:
+			pixels[y * strip + x] = (y * strip + x) & 0xFF
+	renderer._enemy_pixels = pixels
+
+	assert_eq(Gen2BattleRenderer.pic_stride(pixels, side), strip)
+	# The picture's own bottom row, which is `.LoadFeet`'s first enemy tile.
+	var tile: int = Gen2BattleScreenMap.ENEMY_BASE_TILE + side - 1
+	var read: PackedByteArray = renderer._battler_tile(tile)
+	assert_eq(read.size(), Gen2Font.TILE * Gen2Font.TILE)
+	for line: int in Gen2Font.TILE:
+		for column: int in Gen2Font.TILE:
+			assert_eq(
+				int(read[line * Gen2Font.TILE + column]),
+				int(pixels[((side - 1) * Gen2Font.TILE + line) * strip + column]),
+				"pixel %d,%d of the feet" % [column, line]
+			)

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -126,15 +126,25 @@ func test_pokemon_center_pc_opens_the_top_menu_and_bills_pc_behind_it() -> void:
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
 	assert_eq(int(host._pc_rows[0]["row"]), Gen2WorldPC.PCPCITEM_BILLS_PC)
 
+	## `_BillsPC`'s own top menu stands between the machine and the lists, and
+	## its DEPOSIT row is what opens the party one.
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
+	assert_eq(int(host._pc_rows[0]["row"]), Gen2WorldPC.BILLSPCITEM_WITHDRAW)
+	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	var boxes: Gen2BoxScreen = host._boxes
 	assert_not_null(boxes)
+	assert_eq(int(boxes.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
 	assert_eq(boxes.box_snapshot()["boxes"].size(), Gen2SaveData.BOX_COUNT)
 	boxes.close_embedded()
 	await get_tree().process_frame
 	assert_null(host._boxes)
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
 
+	## B off the top menu is SEE YA!, and B off the machine's own shuts it down.
+	host.handle_button(Gen2Button.B)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
 	host.handle_button(Gen2Button.B)
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1849,9 +1849,13 @@ func test_a_registered_pc_row_opens_storage_and_returns_to_the_menu() -> void:
 	assert_null(_world_screen._start_menu_host)
 	var service: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(service, "the row opened the host itself, not the mod")
-	assert_not_null(service.get("_boxes"), "straight into storage, with no machine in front")
+	assert_eq(
+		service.get("_mode"), Gen2WorldServiceScreen.MODE.PC_BOXES,
+		"straight into BILL'S PC, with no machine in front"
+	)
 
-	service.get("_boxes").emit_signal("closed", {})
+	## SEE YA! off a menu nothing opened but the row leaves the host entirely.
+	service.handle_button(Gen2Button.B)
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_not_null(_world_screen._start_menu_host, "closing returns through the normal flow")
@@ -1932,3 +1936,42 @@ func test_a_repel_running_out_asks_nothing_with_no_provider_registered() -> void
 	assert_false(_world_screen._offer_repel_renewal())
 	assert_null(_world_screen._service_host)
 	assert_eq(world.state.item_quantity(REPEL), 2)
+
+
+## `SetUpMenuItems` already fills the box: eight rows reach the last row of the
+## screen exactly, so the host's own MODS row and every `MENU_START` entry a mod
+## registers land past it. The list is a window over the rows now, the way the
+## pack's pocket is, and EXIT stays reachable at both ends of the wrap.
+func test_a_list_longer_than_the_screen_is_scrolled_rather_than_drawn_past_it() -> void:
+	Gen2ModHost.reset()
+	for index: int in 4:
+		assert_true(bool(Gen2ModHost.instance().register_menu_entry(
+			Gen2ModHost.MENU_START, StringName("extra%d" % index),
+			{"label": "EXTRA%d" % index}
+		).get("ok", false)))
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	var visible: int = Gen2StartMenuPage.visible_rows()
+	var rows: int = host._menu.size()
+	assert_gt(rows, visible, "the fixture's own list already overflows the box")
+	assert_eq(host._list_scroll, 0, "and it opens at the top of itself")
+
+	## Down to the last row, which is EXIT: the window follows the cursor.
+	for _press: int in rows - 1:
+		host.handle_button(Gen2Button.DOWN)
+	assert_eq(host._menu.selected_kind(), Gen2WorldStartMenu.ITEM_EXIT)
+	assert_eq(host._list_scroll, rows - visible)
+	assert_true(
+		host._menu.cursor - host._list_scroll < visible, "EXIT is inside the window"
+	)
+
+	## `STATICMENU_WRAP` in both directions, with the window going round with it.
+	host.handle_button(Gen2Button.DOWN)
+	assert_eq(host._menu.cursor, 0)
+	assert_eq(host._list_scroll, 0)
+	host.handle_button(Gen2Button.UP)
+	assert_eq(host._menu.cursor, rows - 1)
+	assert_eq(host._list_scroll, rows - visible)
+	Gen2ModHost.reset()

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -83,10 +83,10 @@ func _open_party_screen(save: Gen2SaveData) -> void:
 	await get_tree().process_frame
 
 
-func _open_box_screen(save: Gen2SaveData) -> void:
+func _open_box_screen(save: Gen2SaveData, mode: int = Gen2BoxScreen.MODE_DEPOSIT) -> void:
 	var packed: PackedScene = load("res://game/save/box_screen.tscn")
 	_box_screen = packed.instantiate()
-	_box_screen.set_context(_data, save)
+	_box_screen.set_context(_data, save, true, false, mode)
 	add_child(_box_screen)
 	await get_tree().process_frame
 
@@ -257,24 +257,76 @@ func test_box_screen_lists_the_party_with_a_cancel_row() -> void:
 	assert_eq(int(snapshot["cursor"]) + int(snapshot["scroll"]), rows.size() - 1)
 
 
-## `BillsPC_PressRight` walks the party and every box round, and the row the
-## cursor stands on is what a transfer takes.
-func test_box_screen_walks_boxes_and_deposits_the_row_under_the_cursor() -> void:
+## `.a_button` opens `.Submenu` rather than moving anything, and its first row is
+## the transfer the loaded list implies. Left and right are `MoveMonWithoutMail_
+## DPad`'s alone, so neither reaches this screen.
+func test_a_row_opens_the_submenu_and_its_first_row_is_the_transfer() -> void:
 	var save: Gen2SaveData = _save_with_two()
 	await _open_box_screen(save)
 	_box_screen.handle_button(Gen2Button.DOWN)
 	_box_screen.handle_button(Gen2Button.A)
+	var open: Dictionary = _box_screen.box_snapshot()
+	assert_eq(open["submenu"], Gen2BoxScreen.SUBMENU_ROWS)
+	assert_eq(String(open["prompt"]), Gen2BoxScreen.PROMPT_WHATS_UP)
+	assert_eq(save.party.size(), 2, "nothing moved on the way in")
+
+	_box_screen.handle_button(Gen2Button.A)
 	assert_eq(save.party.size(), 1)
 	assert_not_null(save.boxes[0].slots[0])
-	_box_screen.handle_button(Gen2Button.RIGHT)
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), "Stored GEODUDE!")
+
+	assert_false(_box_screen.handle_button(Gen2Button.RIGHT))
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
+
+
+## `_WithdrawPKMN` opens on `wCurBox` and its submenu says WITHDRAW.
+func test_the_withdraw_list_opens_on_the_current_box() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	assert_true(Gen2SaveStorage.deposit_party_to_box(save, _data, 1, 0, -1, false)["ok"])
+	await _open_box_screen(save, Gen2BoxScreen.MODE_WITHDRAW)
 	assert_eq(int(_box_screen.box_snapshot()["loaded"]), 1)
 	assert_eq(String(_box_screen.rows()[0]["name"]), "GEODUDE")
 	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(_box_screen.box_snapshot()["submenu"], Gen2BoxScreen.SUBMENU_ROWS_WITHDRAW)
+	_box_screen.handle_button(Gen2Button.A)
 	assert_eq(save.party.size(), 2)
 	assert_null(save.boxes[0].slots[0])
-	for _press: int in Gen2SaveData.BOX_COUNT:
-		_box_screen.handle_button(Gen2Button.RIGHT)
-	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), "Got GEODUDE!")
+
+
+## `BillsPC_CheckMail_PreventBlackout` is asked before the transfer, so the last
+## party member is refused with `PCString_ItsYourLastPKMN` and no reason symbol
+## ever reaches the page.
+func test_the_last_party_member_is_refused_with_the_sources_own_line() -> void:
+	var save: Gen2SaveData = _save()
+	await _open_box_screen(save)
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), Gen2BoxScreen.PROMPT_LAST_MON)
+	assert_eq(save.party.size(), 1)
+	assert_null(save.boxes[0].slots[0])
+
+
+## `.release` behind the submenu's third row, and the yes/no `PlaceYesNoBox`
+## puts under it: NO leaves the mon where it is, YES is `RemoveMonFromPartyOrBox`.
+func test_release_asks_before_it_removes_a_stored_pokemon() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	assert_true(Gen2SaveStorage.deposit_party_to_box(save, _data, 1, 0, -1, false)["ok"])
+	await _open_box_screen(save, Gen2BoxScreen.MODE_WITHDRAW)
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(int(_box_screen.box_snapshot()["release"]), 0)
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), Gen2BoxScreen.PROMPT_RELEASE)
+
+	_box_screen.handle_button(Gen2Button.B)
+	assert_not_null(save.boxes[0].slots[0], "NO leaves it where it is")
+
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_null(save.boxes[0].slots[0])
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), "Bye, GEODUDE!")
 
 
 func test_pc_storage_refuses_depositing_the_last_party_member() -> void:

--- a/tests/unit/test_world_clock.gd
+++ b/tests/unit/test_world_clock.gd
@@ -51,3 +51,51 @@ func test_the_clock_pin_is_parsed_off_the_command_line_and_holds_the_run() -> vo
 	assert_eq(clock.hour, 6)
 	assert_eq(clock.minute, 30)
 	assert_eq(clock.time_of_day(), Gen2WorldPalette.TIME_MORNING)
+
+
+## The cartridge's RTC keeps running while the machine is off, so a save opens at
+## the time it was written at plus the real seconds since. Without this a session
+## resumed at the hour the last one stopped at, and a player who set the clock to
+## the morning saw no other time of day, whatever the hour they played at.
+func test_a_saved_clock_catches_up_to_the_time_that_passed_while_it_was_closed() -> void:
+	var stamp: float = 1_000_000.0
+	assert_eq(
+		Gen2WorldClock.catch_up(0, 10, 15, stamp, stamp + 60.0 * 90.0),
+		{"day": 0, "hour": 11, "minute": 45},
+	)
+	# Two and a half days on, which carries the weekday with it.
+	assert_eq(
+		Gen2WorldClock.catch_up(5, 23, 30, stamp, stamp + 60.0 * 60.0 * 60.0),
+		{"day": 1, "hour": 11, "minute": 30},
+	)
+	# A snapshot written before the stamp was kept, and a host clock put back:
+	# neither runs the world's own clock backwards.
+	assert_eq(
+		Gen2WorldClock.catch_up(3, 8, 5, 0.0, stamp), {"day": 3, "hour": 8, "minute": 5}
+	)
+	assert_eq(
+		Gen2WorldClock.catch_up(3, 8, 5, stamp, stamp - 3600.0),
+		{"day": 3, "hour": 8, "minute": 5},
+	)
+
+
+## The stamp is the snapshot's, so what a save carries is the host second its own
+## clock was written at.
+func test_a_snapshot_stamps_the_host_second_its_clock_was_written_at() -> void:
+	Gen2WorldClock.host_seconds_override = 1_234_567.0
+	var snapshot := Gen2WorldSnapshot.new()
+	snapshot.world_day = 2
+	snapshot.world_hour = 9
+	snapshot.world_minute = 40
+	snapshot.world_clock_stamp = Gen2WorldClock.host_seconds()
+	var restored: Gen2WorldSnapshot = Gen2WorldSnapshot.from_dict(snapshot.to_dict())
+	assert_eq(restored.world_clock_stamp, 1_234_567.0)
+	Gen2WorldClock.host_seconds_override = 2_234_567.0
+	assert_eq(
+		Gen2WorldClock.catch_up(
+			restored.world_day, restored.world_hour, restored.world_minute,
+			restored.world_clock_stamp
+		),
+		{"day": 6, "hour": 23, "minute": 26},
+	)
+	Gen2WorldClock.host_seconds_override = -1.0

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -247,6 +247,17 @@ func test_the_box_grows_downward_by_two_rows_an_entry() -> void:
 	assert_eq(Gen2StartMenuPage.list_box(5, true).border_position(), Vector2i(10, 2))
 
 
+## Eight rows reach the last row of the screen exactly, which is what a fully
+## unlocked save already has, so a `MENU_START` entry a mod registers has to be
+## scrolled to rather than drawn at row 18. The box stops at the screen.
+func test_the_box_stops_at_the_screen_however_many_rows_the_list_has() -> void:
+	assert_eq(Gen2StartMenuPage.visible_rows(), 8)
+	assert_eq(Gen2StartMenuPage.visible_rows(true), 7)
+	assert_eq(Gen2StartMenuPage.list_box(12).border_size(), Vector2i(10, 18))
+	assert_eq(Gen2StartMenuPage.list_box(12).bottom, Gen2StartMenuPage.ROWS - 1)
+	assert_eq(Gen2StartMenuPage.list_box(12, true).bottom, Gen2StartMenuPage.ROWS - 1)
+
+
 func _save_state(pokedex: bool, cursor: int) -> Dictionary:
 	return {
 		"player_name": "GOLD", "badges": 3, "pokedex": pokedex, "caught": 42,

--- a/tools/checks/pokepic.gd
+++ b/tools/checks/pokepic.gd
@@ -40,6 +40,7 @@ func _check_game() -> void:
 	var size: Vector2i = box.border_size() * Gen2Font.TILE
 	var sizes: Dictionary = {}
 	var drawn: int = 0
+	var animated: int = 0
 	for species: int in range(FIRST_SPECIES, LAST_SPECIES + 1):
 		var image: Image = Gen2PokepicPage.render(_r.data, species, map)
 		if not _r.check(image != null, "species %d draws no box." % species):
@@ -57,8 +58,9 @@ func _check_game() -> void:
 		sizes[tiles] = int(sizes.get(tiles, 0)) + 1
 		_check_placement(image, species, tiles)
 		_check_battle_block(pic, species, tiles)
-	_r.note("pokepic %d of %d species, sizes %s" % [
-		drawn, LAST_SPECIES - FIRST_SPECIES + 1, sizes
+		animated += 1 if _check_battler_feet(pic, species) else 0
+	_r.note("pokepic %d of %d species, sizes %s, %d animated strips" % [
+		drawn, LAST_SPECIES - FIRST_SPECIES + 1, sizes, animated
 	])
 
 
@@ -149,6 +151,42 @@ func _check_battle_block(pic: Dictionary, species: int, tiles: Vector2i) -> void
 		not outside,
 		"species %d draws outside its own pic in the battle block." % species
 	)
+
+
+## `anim_battlergfx_2row` stands objects in for the picture's bottom two rows and
+## reads them out of the same buffer the tilemap draws from. A Crystal front pic
+## carries `AnimateFrontpic`'s frames behind its own box in those same rows, so
+## the buffer is wider than the box and its stride is its own: read at the box's,
+## every line of the feet comes from further along the line above it and the
+## picture's feet are scrambled. Returns whether this species has frames behind
+## it, which is the only case that can show it.
+func _check_battler_feet(pic: Dictionary, species: int) -> bool:
+	var side: int = Gen2BattleScreenMap.ENEMY_SIDE
+	var box: int = side * Gen2Font.TILE
+	var square: PackedByteArray = Gen2BattleRenderer.padded_pic(_r.data, pic, side, true)
+	var strip: PackedByteArray = Gen2BattleRenderer.padded_pic(
+		_r.data, pic, side, true, _r.data.species_pic_animation(species)
+	)
+	var stride: int = Gen2BattleRenderer.pic_stride(strip, side)
+	if not _r.check(
+		stride >= box and square.size() == box * box,
+		"species %d has no battle strip to move as objects." % species
+	):
+		return false
+	## `.LoadHead`'s own source: vTiles2 $05 and $06 of every column, which is the
+	## bottom two tiles of each. Read through the renderer's own tile addressing,
+	## against the same tile of a buffer that has no frames behind it.
+	for column: int in side:
+		for row: int in range(side - 2, side):
+			var index: int = column * side + row
+			if Gen2BattleRenderer.pic_tile(strip, side, index) \
+				== Gen2BattleRenderer.pic_tile(square, side, index):
+				continue
+			_r.fail(
+				"species %d reads tile %d of its feet off the strip." % [species, index]
+			)
+			return stride > box
+	return stride > box
 
 
 ## Whether [param area] of a battle block holds a pixel that is not colour 0.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -82,6 +82,10 @@ extends SceneTree
 ## `diploma` (`_Diploma`'s page: the first number is 1 for `_PrintDiploma`'s
 ## loop, which stands the printer's own connection error over it, and the second
 ## is the page, where 2 is the one only a printer that answered reaches),
+## `bills_pc` (`_BillsPC`'s top menu and the lists behind it, which no preview
+## cell reaches: the first number is how many rows down the menu to stand and the
+## second how many A presses to spend, so `crystal 24 6 ... bills_pc 1 2` is the
+## DEPOSIT list with its submenu up),
 ## `mom_bank` (`Mom_WithdrawDepositMenuJoypad`'s dial, which no fixture cell
 ## reaches: the first number is the wallet in hundreds and the second her own
 ## balance in hundreds, plus 1000 for the WITHDRAW header),
@@ -609,6 +613,34 @@ func _process(_delta: float) -> bool:
 			## box over it, and page 2 behind a printer that answered: the first
 			## number is 1 for the printing loop and the second the page.
 			_screen.preview_diploma(_cell.x >= 1, maxi(_cell.y, 1))
+		elif _kind == &"start_menu":
+			## `SetUpMenuItems`' own gates opened, because the list worth
+			## photographing is the eight rows a finished save carries: they fill
+			## the box exactly, so the host's MODS row and any a mod registered
+			## are what the window has to be scrolled to. The first number is how
+			## many rows down to walk before the picture.
+			_screen.get("_world").state.set_engine_flag(
+				Gen2WorldStartMenu.ENGINE_POKEDEX, true
+			)
+			_screen.get("_world").state.set_engine_flag(
+				Gen2WorldStartMenu.ENGINE_POKEGEAR, true
+			)
+			_screen.preview_start_menu()
+			for _down: int in maxi(_cell.x, 0):
+				_screen.press_button(Gen2Button.DOWN)
+				_screen.advance_frame()
+		elif _kind == &"bills_pc":
+			## `_BillsPC`, which no preview cell reaches: the first number is how
+			## many rows down the top menu to stand and the second how many A
+			## presses to spend from there, so `1 1` is the DEPOSIT list and
+			## `1 2` its submenu on the first party member.
+			_screen.preview_bills_pc()
+			for _down: int in maxi(_cell.x, 0):
+				_screen.press_button(Gen2Button.DOWN)
+				_screen.advance_frame()
+			for _press: int in maxi(_cell.y, 0):
+				_screen.press_button(Gen2Button.A)
+				_screen.advance_frame()
 		elif _kind == &"mom_bank":
 			## `Mom_SetUpDepositMenu` and its withdraw twin, which no fixture
 			## cell reaches: her house is not a preview map and the dial stands
@@ -636,7 +668,7 @@ func _process(_delta: float) -> bool:
 			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
-			&"catch_nickname", &"mom_bank",
+			&"catch_nickname", &"mom_bank", &"bills_pc", &"start_menu",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.


### PR DESCRIPTION
Four reported defects.

## BILL'S PC had no top menu

The machine's BILL'S PC row opened one merged list. A on a party row deposited,
A on a box row withdrew, and a refused transfer printed the transaction's own
reason symbol, which is where `last?party?member` came from.

`_BillsPC`'s top menu is in front of it now: WITHDRAW PKMN, DEPOSIT PKMN,
CHANGE BOX and SEE YA!. Each list is the one its own routine loads, and A on a
row opens the four-row submenu both jumptables reach: the transfer, STATS,
RELEASE and CANCEL. Every refusal is one of the source's own strings, and
`BillsPC_CheckMail_PreventBlackout` is asked before the transfer rather than
inferred from what the transaction said afterwards. CHANGE BOX picks the box
both lists read, which the save now carries as `current_box`.

MOVE PKMN W/O MAIL is dropped from the menu rather than offered and refused: it
is a screen of its own, and it is the only routine that reads left and right,
which is why neither does anything on the two lists.

## A hit scrambled the target's feet

`anim_battlergfx_*` lifts a battler's bottom rows off the tilemap and draws them
as objects out of the same padded buffer. Crystal's front pics carry their
animation frames behind the box, so the buffer is wider than the box, and
reading it at the box's stride took each line from further along the line above
it. Every physical move scrambled the target.

The stride has one definition and the tile read has one, and
`tools/checks/pokepic.gd` sweeps all 251 species on all three cartridges through
it. Put the old arithmetic back and the check fails on species 1.

## The clock stood still between sessions

A save resumed at the hour it was written at, so a player who set the clock in
the morning never saw a night. The file records the host second it was written
at, and a world opened later moves the saved time on by what has passed, which
is what the cartridge's clock does while the machine is off. The stamp is the
file's rather than the snapshot's, because a snapshot is compared frame for
frame by the replay tool and a wall clock inside one makes two identical runs
differ.

## The start menu could not hold a ninth row

The list box grew two rows an entry with nothing stopping it at the screen. A
fully unlocked save already fills eight, so the MODS row alone made nine and
EXIT was drawn past the bottom. The box stops at the screen now and the list is
a window over the rows, the way a pack pocket is; the cursor still wraps and the
window follows it round, so EXIT is one press up from the top row. What a mod
may count on is written down.

## Proving it

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3683 tests, all passing |
| `validate.gd -- all` | 69 topics pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three cartridges | exit 0 on each |
| Boot smoke, with and without mods | clean |

Screenshots of the new menu, its submenu, the box picker, the target during a
hit, and the scrolled start menu were taken from the production path on a real
Crystal cache.