### PR TITLE
Bide locks a trainer in, the way the other three substatus bits do

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -147,11 +147,13 @@ static func _can_leave(battle: Gen2Battle) -> bool:
 	return battle.mon(Gen2Battle.ENEMY).trapped_turns <= 0
 
 
-## `CheckEnemyLockedIn`. Bide is not implemented and so is not among these.
+## `CheckEnemyLockedIn`: the four substatus bits its three tests read, BIDE
+## among them (`wEnemySubStatus3`'s `1 << SUBSTATUS_BIDE`). A trainer storing
+## Bide picks no move and does not switch.
 static func _locked_in(mon: Gen2BattleMon) -> bool:
 	for flag: int in [
 		Gen2Substatus.RECHARGING, Gen2Substatus.CHARGING,
-		Gen2Substatus.RAMPAGING, Gen2Substatus.ROLLOUT,
+		Gen2Substatus.RAMPAGING, Gen2Substatus.ROLLOUT, Gen2Substatus.BIDE,
 	]:
 		if Gen2Substatus.has(mon.substatus, flag):
 			return true

--- a/tests/unit/test_ai_switch.gd
+++ b/tests/unit/test_ai_switch.gd
@@ -210,14 +210,23 @@ func test_a_trapped_or_mean_looked_enemy_does_not_switch() -> void:
 ## `CheckEnemyLockedIn` returns out of the whole routine, so a charging Pokémon
 ## neither switches nor is handed an item.
 func test_a_locked_in_enemy_neither_switches_nor_uses_an_item() -> void:
-	var battle: Gen2Battle = _wants_out()
-	battle.enemy_items = [Gen2AIItems.X_ATTACK]
-	battle.enemy.substatus |= Gen2Substatus.CHARGING
+	## All four bits the routine's three tests read, Bide's among them: it is
+	## `wEnemySubStatus3`'s own `1 << SUBSTATUS_BIDE`, beside CHARGED and RAMPAGE.
+	for flag: int in [
+		Gen2Substatus.CHARGING, Gen2Substatus.RECHARGING,
+		Gen2Substatus.RAMPAGING, Gen2Substatus.ROLLOUT, Gen2Substatus.BIDE,
+	]:
+		var battle: Gen2Battle = _wants_out()
+		battle.enemy_items = [Gen2AIItems.X_ATTACK]
+		battle.enemy.substatus |= flag
 
-	for seed: int in 16:
-		_rng.seed = seed
-		var action: Dictionary = Gen2BattleAI.choose_action(battle, OFTEN, 0, _rng)
-		assert_eq(StringName(action["type"]), Gen2Battle.ACTION_MOVE)
+		for seed: int in 16:
+			_rng.seed = seed
+			var action: Dictionary = Gen2BattleAI.choose_action(battle, OFTEN, 0, _rng)
+			assert_eq(
+				StringName(action["type"]), Gen2Battle.ACTION_MOVE,
+				"substatus bit %d" % flag
+			)
 
 
 ## A wild battle has no trainer behind it, so neither half of the routine runs.


### PR DESCRIPTION
Found while sweeping for features the port had quietly simplified.

`CheckEnemyLockedIn` tests four substatus bits: RECHARGE, CHARGED, RAMPAGE and
ROLLOUT, and BIDE is in the middle of them (`wEnemySubStatus3`'s
`1 << SUBSTATUS_BIDE`). This port's list had the other four and not that one, so
an enemy storing Bide chose a fresh move each turn and could be handed an item,
where the cartridge returns out of the whole routine.

Bide is implemented here, so the comment claiming it was not goes with the bug.
The existing test now walks all five bits rather than the one it happened to
pick.

Unit tier: 3180 tests, all passing.