### PR TITLE
Sell to a mart, decorate the room, give a PC back its last three rows, and let a wild glow

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -1326,15 +1326,28 @@ Each entry of `encounters()`:
 | `species`, `level` | Must be offered by that table |
 | `dvs` | The packed DV word, carried into the battle unchanged |
 | `pulse` | Optional. Ask for the shiny sparkle over this entry |
+| `glow` | Optional `{color: Color, amount: float}`. Walks the Pokemon's own colours toward `color` by `amount`, leaving colour 0 alone: it is the icon's cut-out. Presentation only, and it changes no DV, no battle and no roll |
 
 Anything else is dropped rather than drawn, including an entry that names
-`shiny`: shininess is `CheckShininess` over the DVs and is the host's answer.
+`shiny`: shininess is `CheckShininess` over the DVs and is the host's answer. A
+malformed `glow` costs the glow rather than the entry.
 At most `Gen2WorldEncounters.MAX_ENTRIES` entries are drawn in a frame.
+
+`amount` is rounded onto `Gen2WorldEncounters.GLOW_RUNGS` steps by the host, so
+nine values between nothing and the full walk are all a mod can reach. That is
+not a nicety: both world renderers cache one sprite texture per distinct set of
+four colours and **neither evicts**, so a smoothly interpolated glow would leave
+a texture behind on every frame the map was up. Send whatever cycle you like;
+what reaches the palette is the nearest rung, and an amount that rounds to
+nothing is no glow at all. Eighths rather than quarters so that a mark meant to
+be subtle still has a cycle after the rounding: a peak under half the walk keeps
+four steps on eighths and one on quarters.
 
 What the host does with a valid population:
 
 - Draws it through the actor layer, with the SPECIES' own four colours, shiny or
-  not, so a renderer reading `set_actors` gets it for free.
+  not and glowing or not, so a renderer reading `set_actors` gets it for free:
+  the palette arrives in the same per-entry `colors` override a shiny's does.
 - Turns the ordinary post-step roll off while any provider is registered.
   Scripted, fishing, Headbutt, Rock Smash, Sweet Scent and Bug Contest
   encounters keep their own paths.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -52,8 +52,11 @@ preallocated, up to `Gen2SaveStore.MAX_SLOTS`; a slot number is still its file
 name, so slots written before this stay where they were. Each save carries its
 own `label`, the player's name for the slot, so an exported file names itself;
 an empty label means fall back to the player name. `current_box` is `wCurBox`,
-which CHANGE BOX writes and both of BILL'S PC's lists read. Box names and
-cartridge SRAM box placement are intentionally outside this model.
+which CHANGE BOX's SWITCH writes and both of BILL'S PC's lists read, and
+`box_names` is `sBoxNames`, which its NAME row writes; an empty name is
+`SetDefaultBoxNames`' own "BOX1" spelling rather than a stored string.
+`hall_of_fame` is `sHallOfFame`, the thirty induction records newest first.
+Cartridge SRAM box placement is intentionally outside this model.
 
 `player_id` is the cartridge's own `wPlayerID`, rolled once when a game starts,
 read from SRAM on import and written back on export. `GetTreeScore` is what reads
@@ -114,10 +117,11 @@ House PC as an embedded overworld overlay, presents one numbered box at a time
 with twenty fixed slots and a party selection column. Depositing uses the
 current box's first free slot, withdrawal requires party capacity, and both go
 through `Gen2SaveStorage` to validate and write a candidate save before the
-shared runtime object changes. The last party member cannot be boxed. The
-current box is transient UI state; box names and SRAM placement stay outside the
-model. Closing the embedded overlay resumes the paused source script with no
-decoration change. Selected runtime saves persist transfers; injected scene-test
+shared runtime object changes. The last party member cannot be boxed. MOVE PKMN W/O MAIL is
+the same screen in `Gen2BoxScreen.MODE_MOVE`, where left and right load the
+party or any box and a chosen Pokemon is inserted at a second cursor. SRAM
+placement stays outside the model. Closing the embedded overlay resumes the
+paused source script, which is where a changed decoration reloads the room. Selected runtime saves persist transfers; injected scene-test
 and development saves use the validated in-memory candidate without writing a
 slot.
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -70,6 +70,7 @@ var _title: Dictionary = {}
 var _town_map: Dictionary = {}
 var _oak_ratings: Dictionary = {}
 var _pokecenter_pc: Dictionary = {}
+var _decorations: Dictionary = {}
 var _unown_words: PackedStringArray = PackedStringArray()
 var _unown_walls: PackedStringArray = PackedStringArray()
 var _credits: Dictionary = {}
@@ -182,6 +183,8 @@ static func open_directory(path: String) -> GameData:
 	data._oak_ratings = raw_oak_ratings if raw_oak_ratings is Dictionary else {}
 	var pokecenter_pc: Variant = manifest.get("pokecenter_pc", {})
 	data._pokecenter_pc = pokecenter_pc if pokecenter_pc is Dictionary else {}
+	var decorations: Variant = manifest.get("decorations", {})
+	data._decorations = decorations if decorations is Dictionary else {}
 	var unown_words: Variant = manifest.get("unown_words", [])
 	if unown_words is Array:
 		for word: Variant in unown_words as Array:
@@ -1768,6 +1771,37 @@ func pokecenter_pc_lists(players: bool = false) -> Array:
 func pokecenter_pc_text(name: String) -> String:
 	var texts: Variant = _pokecenter_pc.get("texts", {})
 	return String((texts as Dictionary).get(name, "")) if texts is Dictionary else ""
+
+
+## One `DecorationAttributes` row by its own `DECO_*` id, as
+## [code]{ type, name, action, flag, sprite }[/code]. Empty for an id outside the
+## table and on a cache imported without it.
+func decoration(deco: int) -> Dictionary:
+	var rows: Variant = _decorations.get("attributes", [])
+	if not rows is Array or deco < 0 or deco >= (rows as Array).size():
+		return {}
+	var row: Variant = (rows as Array)[deco]
+	if not row is Dictionary:
+		return {}
+	var out: Dictionary = {}
+	for key: Variant in row as Dictionary:
+		out[String(key)] = int((row as Dictionary)[key])
+	return out
+
+
+func decoration_count() -> int:
+	var rows: Variant = _decorations.get("attributes", [])
+	return (rows as Array).size() if rows is Array else 0
+
+
+## One `DecorationNames` part by its own index, which is what a row's `name`
+## field carries for every type but the poster, doll and big doll: those name a
+## species instead.
+func decoration_name_part(index: int) -> String:
+	var names: Variant = _decorations.get("names", [])
+	if not names is Array or index < 0 or index >= (names as Array).size():
+		return ""
+	return String((names as Array)[index])
 
 
 ## The word `PrintUnownWord` puts under Unown form [param form], A being 1.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -81,7 +81,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 84
+const FORMAT_VERSION: int = 85
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -338,6 +338,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not pokecenter_pc["ok"]:
 		return pokecenter_pc
 
+	var decorations: Dictionary = verify_decorations(rom, layout)
+	if not decorations["ok"]:
+		return decorations
+
 	var unown_words: Dictionary = verify_unown_words(rom, layout)
 	if not unown_words["ok"]:
 		return unown_words
@@ -1144,6 +1148,34 @@ static func verify_pokecenter_pc(rom: RomFile, layout: Dictionary) -> Dictionary
 				"message": "The Pokemon Center PC's %s text did not decode." % name,
 			}
 	return {"ok": true, "message": "The Pokemon Center PC verified."}
+
+
+## `DecorationAttributes` and the `DecorationNames` run behind it, identified by
+## structure: every row's type has to be one of the six, the table's own last
+## row is the silver trophy, and all twenty-six names have to decode.
+static func verify_decorations(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var rows: Array = read_decoration_attributes(rom, layout)
+	if rows.size() != RomLayout.DECORATION_COUNT:
+		return {"ok": false, "message": "The decoration attributes are outside the cartridge."}
+	for row: Dictionary in rows:
+		var type: int = int(row.get("type", 0))
+		if type < 1 or type > Gen2WorldDecoration.TYPE_BIG_DOLL:
+			return {
+				"ok": false,
+				"message": "A decoration row carries type %d." % type,
+			}
+	var names: PackedStringArray = read_decoration_names(rom, layout)
+	if names.size() != RomLayout.DECORATION_NAME_COUNT:
+		return {"ok": false, "message": "The decoration names are outside the cartridge."}
+	for name: String in names:
+		if name.strip_edges().is_empty():
+			return {"ok": false, "message": "A decoration name did not decode."}
+	if names[0] != "CANCEL" or names[1] != "PUT IT AWAY":
+		return {
+			"ok": false,
+			"message": "The decoration names open \"%s\", not CANCEL." % names[0],
+		}
+	return {"ok": true, "message": "Decorations verified."}
 
 
 ## `engine/items/mart.asm`'s own `text_far` stubs, identified by content: all
@@ -4288,6 +4320,7 @@ func import_rom(
 		"gs_intro": _import_gs_intro(rom, layout),
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
+		"decorations": _import_decorations(rom, layout),
 		"unown_puzzle": _import_unown_puzzle(rom, layout),
 		"diploma": _import_diploma(rom, layout),
 		"printer_strings": _import_printer_strings(rom, layout),
@@ -5535,6 +5568,50 @@ func _import_pokecenter_pc(rom: RomFile, layout: Dictionary) -> Dictionary:
 		)
 	out["texts"] = texts
 	return out
+
+
+## `DecorationAttributes`, one row per `DECO_*` id. The event flag is the row's
+## own little-endian word; the sprite byte is a block for the four map-tile
+## categories and a `SPRITE_*` for the three object ones.
+static func read_decoration_attributes(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout.get("decorations", -1))
+	var size: int = RomLayout.DECORATION_ATTRIBUTE_SIZE
+	if at < 0 or not rom.in_bounds(at, RomLayout.DECORATION_COUNT * size):
+		return []
+	var out: Array = []
+	for index: int in RomLayout.DECORATION_COUNT:
+		var row: int = at + index * size
+		out.append({
+			"type": rom.u8(row),
+			"name": rom.u8(row + 1),
+			"action": rom.u8(row + 2),
+			"flag": rom.u8(row + 3) | (rom.u8(row + 4) << 8),
+			"sprite": rom.u8(row + 5),
+		})
+	return out
+
+
+## `DecorationNames`, the parts `GetDecoName` joins into a decoration's own name.
+static func read_decoration_names(rom: RomFile, layout: Dictionary) -> PackedStringArray:
+	var at: int = int(layout.get("decorations", -1))
+	if at < 0:
+		return PackedStringArray()
+	at += RomLayout.DECORATION_NAMES_AT
+	if not rom.in_bounds(
+		at, RomLayout.DECORATION_NAME_COUNT * RomLayout.DECORATION_NAME_MAX_BYTES
+	):
+		return PackedStringArray()
+	return Gen2Text.decode_sequence(
+		rom.bytes(), at, RomLayout.DECORATION_NAME_COUNT,
+		RomLayout.DECORATION_NAME_MAX_BYTES
+	)
+
+
+func _import_decorations(rom: RomFile, layout: Dictionary) -> Dictionary:
+	return {
+		"attributes": read_decoration_attributes(rom, layout),
+		"names": Array(read_decoration_names(rom, layout)),
+	}
 
 
 ## `Pokegear_LoadGFX`'s three LZ runs, each as one strip of tiles.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1383,6 +1383,19 @@ const POKECENTER_PC_TEXT_AT: Dictionary = {
 	"closed": 0x446,
 }
 
+## `DecorationAttributes`: one six-byte row per decoration, indexed by the
+## `DECO_*` constant itself, so row 0 is the CANCEL entry and each category's
+## own id is its PUT IT AWAY row. `DecorationNames` follows the table at
+## `DECORATION_NAMES_AT` on all three cartridges; the attribute table is byte
+## identical between the two pins and the name run is not, since Gold and Silver
+## spell the third console "NINTENDO64".
+const DECORATION_COUNT: int = 53
+const DECORATION_ATTRIBUTE_SIZE: int = 6
+const DECORATION_NAMES_AT: int = 0x13E
+const DECORATION_NAME_COUNT: int = 26
+## `list_start TEXTBOX_INNERW - 1`: seventeen characters and the terminator.
+const DECORATION_NAME_MAX_BYTES: int = 18
+
 ## Every `text_far` stub `engine/items/mart.asm` prints through, as its distance
 ## from `MartHowManyText`. `GetMartDialogGroup.MartTextFunctionPointers` is what
 ## groups them: the rooftop sale reads the standard group, the bargain shop asks
@@ -1413,12 +1426,19 @@ const MART_TEXT_AT: Dictionary = {
 	"pharmacy_pack_full": 0x096,
 	"pharmacy_no_money": 0x09B,
 	"pharmacy_come_again": 0x0A0,
+	## `SellMenu`'s own four, which sit between the shop groups above and
+	## `MartWelcomeText`: `UnusedDummyString`'s six bytes are the gap between
+	## `sell_price` and `welcome`.
+	"sell_how_many": 0x165,
+	"sell_price": 0x16A,
 	"welcome": 0x175,
 	"thanks": 0x192,
 	"no_money": 0x197,
 	"pack_full": 0x19C,
+	"cant_buy": 0x1A1,
 	"come_again": 0x1A6,
 	"ask_more": 0x1AB,
+	"bought": 0x1B0,
 }
 
 ## A `text_far` stub is `TX_FAR`, a two-byte address, a bank byte and a
@@ -2104,6 +2124,10 @@ const GOLD_SILVER: Dictionary = {
 	# both were located by matching the row run's own bytes, which are unique in
 	# a dump.
 	"pokecenter_pc": 0x158D1,
+	# `DecorationAttributes`, located by assembling the whole 53-row table from
+	# the source's own constants and matching it, which hits once per dump.
+	# `DecorationNames` is `DECORATION_NAMES_AT` behind it.
+	"decorations": 0x26C2B,
 	# `UnownWords`, located by encoding the twenty-six words in the Unown font's
 	# own codes and matching the whole run, which hits once per dump; the table
 	# is the fifty-four bytes in front of it.
@@ -2616,6 +2640,7 @@ const CRYSTAL: Dictionary = {
 	# See the Gold and Silver block above; the run is byte identical and only its
 	# address moves.
 	"pokecenter_pc": 0x155FA,
+	"decorations": 0x26A4F,
 	# See the Gold and Silver block above; the words are byte identical and only
 	# their address moves.
 	"unown_words": 0xFBA5A,

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -44,10 +44,21 @@ const FILENAME: String = "mod.json"
 ## [method Gen2ModHost.register_battle_info], and a start-menu entry's own
 ## [constant Gen2ModHost.START_ACTIONS] plus its `visible` predicate.
 ##
+## 15 added a visible encounter's own `glow`, the optional
+## `{color, amount}` on an `encounters()` entry that walks the Pokemon's four
+## colours toward a light. It is presentation and changes no DV, no battle and
+## no roll; the host rounds the amount onto
+## [constant Gen2WorldEncounters.GLOW_RUNGS] itself, because both renderers cache
+## a sprite texture per set of four colours and neither evicts. Nine amounts, so
+## a subtle glow still has a cycle after the rounding.
+##
 ## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
 ## host that has never heard of either ignores the field, so a mod that ships
-## art still installs on an older launcher and simply has no face there.
-const API_VERSION: int = 14
+## art still installs on an older launcher and simply has no face there. A glow
+## is the same shape in the other direction: a mod may send one to a host that
+## drops it and the Pokemon simply does not glow, which is why `api_version` 15
+## is only needed by a mod that requires the mark to appear.
+const API_VERSION: int = 15
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -25,6 +25,14 @@ const MON_TOP_BOX: Rect2i = Rect2i(0, 0, 20, 5)
 const MON_BOTTOM_BOX: Rect2i = Rect2i(0, 12, 20, 6)
 const CAPTION: Vector2i = Vector2i(1, 2)
 const CAPTION_TEXT: String = "New Hall of Famer!"
+## `_HallOfFamePC.DisplayMonAndStrings` draws this caption instead: `.TimeFamer`
+## at `hlcoord 1, 2` and then `PrintNum` `lb bc, 1, 3` over `hlcoord 2, 2`, so
+## the count is right-aligned in three columns and the words start at column 5.
+## `.HOFMaster` is its unreachable sibling: `cp HOF_MASTER_COUNT + 1` needs 201
+## and `wHallOfFameCount` stops at 200 (`docs/bugs_and_glitches.md`).
+const FAMER_TEXT: String = "-Time Famer"
+const FAMER_COUNT: Vector2i = Vector2i(2, 2)
+const FAMER_DIGITS: int = 3
 
 ## `hlcoord 6, 5`, and the pic is seven tiles square.
 const PIC_AT: Vector2i = Vector2i(6, 5)
@@ -117,7 +125,12 @@ func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:
 	var width: int = COLUMNS * TILE
 	_box(indices, width, MON_TOP_BOX)
 	_box(indices, width, MON_BOTTOM_BOX)
-	_text(indices, width, CAPTION_TEXT, CAPTION)
+	if page.has("win_count"):
+		_text(indices, width, "%*d%s" % [
+			FAMER_DIGITS, int(page["win_count"]), FAMER_TEXT,
+		], FAMER_COUNT)
+	else:
+		_text(indices, width, CAPTION_TEXT, CAPTION)
 
 	_code(indices, width, CODE_NUMERO, DEX_LABEL)
 	_code(indices, width, CODE_DOT, DEX_LABEL + Vector2i(1, 0))

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -48,9 +48,23 @@ const PARTY_NAME: String = "PARTY PKMN"
 ## `wBillsPC_LoadedBox`: zero is the party and the boxes follow it.
 const LOADED_PARTY: int = 0
 
-## Which of `_BillsPC.Jumptable`'s two list rows opened this screen.
+## Which of `_BillsPC.Jumptable`'s three list rows opened this screen.
 const MODE_DEPOSIT: int = 0
 const MODE_WITHDRAW: int = 1
+## `_MovePKMNWithoutMail`, which is neither list: left and right load any of the
+## party and the fourteen boxes, and A twice moves a Pokemon from one place in
+## one of them to another place in another.
+const MODE_MOVE: int = 2
+## Its two `.Joypad` passes: choosing the Pokemon and choosing where it goes.
+const MOVE_PHASE_CHOOSE: int = 0
+const MOVE_PHASE_INSERT: int = 1
+## `PCString_MoveToWhere` and `PCString_TheresNoRoom`.
+const PROMPT_MOVE_WHERE: String = "Move to where?"
+const PROMPT_NO_ROOM: String = "There's no room."
+## `.MenuData`'s own three rows, which drop the RELEASE the other two lists have.
+const SUBMENU_ROWS_MOVE: Array[String] = ["MOVE", "STATS", "CANCEL"]
+const SUBMENU_MOVE_STATS: int = 1
+const SUBMENU_MOVE_CANCEL: int = 2
 
 ## `BillsPCDepositMenuHeader` and `BillsPC_Withdraw.MenuHeader`, the same
 ## `menu_coords 9, 4, SCREEN_WIDTH - 1, 13` over the listing, and the yes/no
@@ -95,6 +109,12 @@ var _prompt: String = PROMPT_CHOOSE
 ## `_DepositPKMN` or `_WithdrawPKMN`, and the submenu, the release yes/no and
 ## the stats screen either of them can put over the listing.
 var _mode: int = MODE_DEPOSIT
+## `wJumptableIndex`'s two joypad passes and the backup `.Move` takes of where
+## the Pokemon came from, which `.b_button_2` puts back.
+var _move_phase: int = MOVE_PHASE_CHOOSE
+var _move_from_loaded: int = LOADED_PARTY
+var _move_from_index: int = -1
+var _move_backup: Array = []
 var _submenu_open: bool = false
 var _submenu_cursor: int = 0
 var _release_open: bool = false
@@ -137,11 +157,15 @@ func set_context(
 	_embedded = embedded
 	_data = data
 	_save = save
-	_mode = MODE_WITHDRAW if mode == MODE_WITHDRAW else MODE_DEPOSIT
+	_mode = mode if mode in [MODE_DEPOSIT, MODE_WITHDRAW, MODE_MOVE] else MODE_DEPOSIT
 	_box_index = clampi(box_index, 0, Gen2SaveData.BOX_COUNT - 1)
 	## `.Init` writes `wBillsPC_LoadedBox` itself, so which list is up is the
-	## mode's rather than anything the last screen left behind.
+	## mode's rather than anything the last screen left behind. MOVE PKMN W/O
+	## MAIL opens on `wCurBox`, which is the box the machine is already on.
 	_loaded = LOADED_PARTY if _mode == MODE_DEPOSIT else _box_index + 1
+	_move_phase = MOVE_PHASE_CHOOSE
+	_move_from_index = -1
+	_move_backup = []
 	_cursor = 0
 	_scroll = 0
 	_prompt = PROMPT_CHOOSE
@@ -309,6 +333,13 @@ func handle_button(button: int) -> bool:
 			_press_up()
 		Gen2Button.DOWN:
 			_press_down()
+		Gen2Button.LEFT, Gen2Button.RIGHT:
+			## `MoveMonWithoutMail_DPad`'s carry: left and right load the list
+			## before or after this one, and the cursor starts again at its top.
+			## They belong to MOVE PKMN W/O MAIL alone and do nothing elsewhere.
+			if _mode != MODE_MOVE:
+				return false
+			_load_neighbour(-1 if button == Gen2Button.LEFT else 1)
 		Gen2Button.A:
 			_confirm()
 		Gen2Button.B:
@@ -367,6 +398,8 @@ func _handle_release_button(button: int) -> bool:
 
 ## The submenu's own four rows, whose first is named for the list that is loaded.
 func _submenu_labels() -> Array:
+	if _mode == MODE_MOVE:
+		return SUBMENU_ROWS_MOVE
 	return SUBMENU_ROWS_WITHDRAW if _loaded != LOADED_PARTY else SUBMENU_ROWS
 
 
@@ -388,6 +421,24 @@ func _close_submenu(draw: bool = true) -> void:
 
 
 func _confirm_submenu() -> void:
+	if _mode == MODE_MOVE:
+		match _submenu_cursor:
+			SUBMENU_TRANSFER:
+				## `.Move`: `BillsPC_CheckMail_PreventBlackout` first, and then
+				## the second joypad pass over whichever list is loaded then.
+				var refusal: String = _blackout_refusal()
+				if not refusal.is_empty():
+					_close_submenu(false)
+					_prompt = refusal
+					_refresh()
+					return
+				_close_submenu(false)
+				_begin_move()
+			SUBMENU_MOVE_STATS:
+				_open_stats()
+			_:
+				_close_submenu()
+		return
 	match _submenu_cursor:
 		SUBMENU_TRANSFER:
 			var refusal: String = _blackout_refusal()
@@ -779,7 +830,7 @@ func _cursor_image(
 func _box_name() -> String:
 	if _loaded == LOADED_PARTY:
 		return PARTY_NAME
-	return "BOX %d" % (_box_index + 1)
+	return _save.box_name(_box_index) if _save != null else ""
 
 
 func _mon_snapshot(box: int, slot: int, mon: Gen2SaveMon) -> Dictionary:
@@ -828,6 +879,9 @@ func _press_down() -> void:
 ## A on the CANCEL row leaves, the way `.a_button`'s `cp -1` does; on any other
 ## row it opens the submenu.
 func _confirm() -> void:
+	if _mode == MODE_MOVE and _move_phase == MOVE_PHASE_INSERT:
+		_insert_moved_mon()
+		return
 	var all_rows: Array = rows()
 	var at: int = _cursor + _scroll
 	if at < 0 or at >= all_rows.size() or bool((all_rows[at] as Dictionary)["cancel"]):
@@ -835,6 +889,66 @@ func _confirm() -> void:
 		return
 	_sync_selection()
 	_open_submenu()
+
+
+## `MoveMonWithoutMail_DPad`: the party is `wBillsPC_LoadedBox` zero and the
+## fourteen boxes follow it, wrapping either way.
+func _load_neighbour(step: int) -> void:
+	_loaded = wrapi(_loaded + step, 0, Gen2SaveData.BOX_COUNT + 1)
+	if _loaded != LOADED_PARTY:
+		_box_index = _loaded - 1
+	_cursor = 0
+	_scroll = 0
+	_selected_box_slot = -1
+	_selected_party_index = -1
+	_refresh()
+
+
+## `.Move`: the list and the row the Pokemon came from are backed up, and the
+## second pass begins wherever the first one left off.
+func _begin_move() -> void:
+	_move_from_loaded = _loaded
+	_move_from_index = _cursor + _scroll
+	_move_backup = [_loaded, _cursor, _scroll]
+	_move_phase = MOVE_PHASE_INSERT
+	_prompt = PROMPT_MOVE_WHERE
+	_refresh()
+
+
+## `.a_button_2`: `BillsPC_CheckSpaceInDestination` and then
+## `MovePKMNWithoutMail_InsertMon`, which puts the Pokemon where the cursor
+## stands and shifts everything behind it down.
+func _insert_moved_mon() -> void:
+	var result: Dictionary = Gen2SaveStorage.move_mon(
+		_save, _data, _move_from_loaded, _move_from_index, _loaded,
+		_cursor + _scroll, _persist
+	)
+	if not bool(result.get("ok", false)):
+		## `.no_space` steps the jumptable back one, which leaves the insert
+		## cursor where it was with the box's own refusal printed under it.
+		_prompt = PROMPT_NO_ROOM if StringName(
+			result.get("reason", &"")
+		) == &"no_room_in_destination" else _refusal(result, PROMPT_NO_ROOM)
+		_refresh()
+		return
+	_end_move()
+
+
+## `.Cancel` and `.b_button_2` alike: the first pass again, on the list the
+## Pokemon was chosen from.
+func _end_move() -> void:
+	if _move_backup.size() == 3:
+		_loaded = int(_move_backup[0])
+		_cursor = int(_move_backup[1])
+		_scroll = int(_move_backup[2])
+		if _loaded != LOADED_PARTY:
+			_box_index = _loaded - 1
+	_move_phase = MOVE_PHASE_CHOOSE
+	_move_from_index = -1
+	_move_backup = []
+	_prompt = PROMPT_CHOOSE
+	_clamp_cursor()
+	_refresh()
 
 
 ## After a transfer the list is one row shorter, so the cursor comes back inside
@@ -851,6 +965,9 @@ func _clamp_cursor() -> void:
 
 
 func _back() -> void:
+	if _mode == MODE_MOVE and _move_phase == MOVE_PHASE_INSERT:
+		_end_move()
+		return
 	if _embedded:
 		close_embedded()
 		return

--- a/game/save/save_box.gd
+++ b/game/save/save_box.gd
@@ -3,9 +3,10 @@ extends RefCounted
 
 ## One persistent Generation 2 PC box.
 ##
-## A box is deliberately only a fixed ordered set of save Pokémon. Box names,
-## current-box UI state and cartridge SRAM placement remain outside this
-## project model until they have a canonical owner.
+## A box is only a fixed ordered set of save Pokémon. Its name and which box is
+## current are [Gen2SaveData]'s, the way `sBoxNames` and `wCurBox` are their own
+## bytes on the cartridge rather than part of a box; SRAM placement remains
+## outside this project model.
 
 const CAPACITY: int = 20
 

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -16,6 +16,8 @@ const MAX_PLAYER_NAME: int = 10
 ## [member player_name], so a slot always has something to show.
 const MAX_LABEL: int = 24
 const BOX_COUNT: int = 14
+## `BOX_NAME_LENGTH - 1`, the same cap the naming screen writes one under.
+const MAX_BOX_NAME: int = 8
 const BOX_CAPACITY: int = Gen2SaveBox.CAPACITY
 
 ## `constants/wram_constants.asm`: `PLAYERGENDER_FEMALE_F` is bit 0 of
@@ -66,6 +68,18 @@ var boxes_shape_valid: bool = true
 ## opens on. Like the `run` block it defaults rather than versioning: a slot
 ## written before it existed is one whose current box is the first.
 var current_box: int = 0
+## `sHallOfFame`, newest first: `AddHallOfFameEntry` shifts every record down and
+## writes the new team at the front, and the thirtieth falls off. A record is
+## `{ win_count, mons }`, and a mon is what `hof_mon` keeps: species, OT id, DVs,
+## level and nickname. Like `current_box` and the `run` block this defaults
+## rather than versioning; an empty list is the truth about a slot written
+## before it existed.
+var hall_of_fame: Array = []
+## `sBoxNames`, which is its own array in SRAM rather than part of a box: one
+## eight-character name per box, `BillsPC_ChangeBoxSubmenu`'s NAME row writes
+## one and `SetDefaultBoxNames` fills them all at a new game. Empty is that
+## default, which [method box_name] spells rather than storing.
+var box_names: Array = []
 
 
 func _init() -> void:
@@ -94,6 +108,8 @@ func to_dict() -> Dictionary:
 		"party": saved_party,
 		"boxes": saved_boxes,
 		"current_box": current_box,
+		"hall_of_fame": hall_of_fame.duplicate(true),
+		"box_names": box_names.duplicate(),
 		"world": world.to_dict() if world != null else {},
 		"mods": mods.duplicate(true),
 		"run": {
@@ -125,6 +141,13 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	out.game_time = Gen2GameTime.parse(source.get("game_time", {}))
 	out.label = String(source.get("label", ""))
 	out.current_box = clampi(int(source.get("current_box", 0)), 0, BOX_COUNT - 1)
+	out.hall_of_fame = Gen2HallOfFame.parse_records(source.get("hall_of_fame", []))
+	var raw_box_names: Variant = source.get("box_names", [])
+	if raw_box_names is Array:
+		for index: int in mini((raw_box_names as Array).size(), BOX_COUNT):
+			out.box_names.append(
+				String((raw_box_names as Array)[index]).substr(0, MAX_BOX_NAME)
+			)
 	var raw_party: Variant = source.get("party", [])
 	if raw_party is Array:
 		for raw_mon: Variant in raw_party as Array:
@@ -327,3 +350,23 @@ static func _valid_mod_id(id: String) -> bool:
 	var regex := RegEx.new()
 	regex.compile("^[a-z0-9][a-z0-9_-]*$")
 	return regex.search(id) != null
+
+
+## `GetBoxName`, with `SetDefaultBoxNames`' own spelling behind it: the default
+## is "BOX" and the number with no space between them.
+func box_name(index: int) -> String:
+	if index < 0 or index >= BOX_COUNT:
+		return ""
+	var stored: String = String(box_names[index]) if index < box_names.size() else ""
+	return stored if not stored.is_empty() else "BOX%d" % (index + 1)
+
+
+## `BillsPC_ChangeBoxSubmenu.Name`, which writes `wBoxNameBuffer` back over the
+## box's own name. An empty name is the default again rather than a blank label.
+func set_box_name(index: int, name: String) -> bool:
+	if index < 0 or index >= BOX_COUNT:
+		return false
+	while box_names.size() < BOX_COUNT:
+		box_names.append("")
+	box_names[index] = name.substr(0, MAX_BOX_NAME)
+	return true

--- a/game/save/save_storage.gd
+++ b/game/save/save_storage.gd
@@ -122,6 +122,87 @@ static func release_box_slot(
 	}, persist)
 
 
+## `MovePKMNWithoutMail_InsertMon`'s four branches in one: the mon leaves
+## [param from_index] of one list and is inserted at [param to_index] of the
+## other, everything behind it shifting down. A list is the party when it is
+## `Gen2BoxScreen.LOADED_PARTY` and the box before it otherwise, which is
+## `wBillsPC_LoadedBox`'s own numbering.
+##
+## `BillsPC_CheckSpaceInDestination` is the one refusal, and only for a move
+## between two lists: a reorder inside one cannot overflow it.
+static func move_mon(
+	save: Gen2SaveData,
+	data: GameData,
+	from_loaded: int,
+	from_index: int,
+	to_loaded: int,
+	to_index: int,
+	persist: bool = true,
+) -> Dictionary:
+	var candidate_result: Dictionary = _candidate(save, data)
+	if not bool(candidate_result.get("ok", false)):
+		return candidate_result
+	var candidate: Gen2SaveData = candidate_result["save"]
+	var source: Array = _loaded_list(candidate, from_loaded)
+	if source.is_empty() and from_index != 0:
+		return _failure(&"invalid_loaded_list")
+	if from_index < 0 or from_index >= source.size():
+		return _failure(&"invalid_source_slot")
+	var mon: Gen2SaveMon = source[from_index]
+	if mon == null:
+		return _failure(&"missing_pokemon")
+	if from_loaded == to_loaded:
+		var reordered: Array = source.duplicate()
+		reordered.remove_at(from_index)
+		reordered.insert(clampi(to_index, 0, reordered.size()), mon)
+		_write_loaded_list(candidate, from_loaded, reordered)
+	else:
+		var destination: Array = _loaded_list(candidate, to_loaded)
+		var capacity: int = Gen2SaveData.MAX_PARTY 			if to_loaded == Gen2BoxScreen.LOADED_PARTY else Gen2SaveBox.CAPACITY
+		if destination.size() >= capacity:
+			return _failure(&"no_room_in_destination")
+		if from_loaded == Gen2BoxScreen.LOADED_PARTY and source.size() <= 1:
+			return _failure(&"last_party_member")
+		var without: Array = source.duplicate()
+		without.remove_at(from_index)
+		destination = destination.duplicate()
+		destination.insert(clampi(to_index, 0, destination.size()), mon)
+		_write_loaded_list(candidate, from_loaded, without)
+		_write_loaded_list(candidate, to_loaded, destination)
+	return _commit(save, data, candidate, {
+		"kind": &"move_mon",
+		"from_loaded": from_loaded, "from_index": from_index,
+		"to_loaded": to_loaded, "to_index": to_index,
+	}, persist)
+
+
+## One `wBillsPC_LoadedBox` list as the packed array the source treats it as:
+## the party is already one and a box's own occupied slots are read in order.
+static func _loaded_list(save: Gen2SaveData, loaded: int) -> Array:
+	if loaded == Gen2BoxScreen.LOADED_PARTY:
+		return save.party
+	var box: Gen2SaveBox = save.boxes[loaded - 1] 		if loaded - 1 >= 0 and loaded - 1 < save.boxes.size() else null
+	if box == null:
+		return []
+	var out: Array = []
+	for slot: int in Gen2SaveBox.CAPACITY:
+		if slot < box.slots.size() and box.slots[slot] != null:
+			out.append(box.slots[slot])
+	return out
+
+
+static func _write_loaded_list(save: Gen2SaveData, loaded: int, members: Array) -> void:
+	if loaded == Gen2BoxScreen.LOADED_PARTY:
+		save.party = members.duplicate()
+		return
+	var box: Gen2SaveBox = save.boxes[loaded - 1] 		if loaded - 1 >= 0 and loaded - 1 < save.boxes.size() else null
+	if box == null:
+		return
+	box.slots.fill(null)
+	for slot: int in mini(members.size(), Gen2SaveBox.CAPACITY):
+		box.slots[slot] = members[slot]
+
+
 static func _candidate(save: Gen2SaveData, data: GameData) -> Dictionary:
 	if save == null or data == null:
 		return _failure(&"missing_save_context")

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -22,6 +22,13 @@ const MAX_MONS: int = 6
 const PAGE_MON: StringName = &"mon"
 const PAGE_PLAYER: StringName = &"player"
 
+## `sHallOfFame`'s own thirty records and `HOF_MASTER_COUNT`, which is where
+## `wHallOfFameCount` stops rather than wrapping.
+const MAX_RECORDS: int = 30
+const MASTER_COUNT: int = 200
+## `hof_mon`'s nickname field, which is `MON_NAME_LENGTH - 1`.
+const MAX_NICKNAME: int = 10
+
 
 ## The pages, in AnimateHallOfFame's order: every non-egg party member, then the
 ## player. An empty or egg-only party still answers the player's page, matching
@@ -95,3 +102,104 @@ static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
 		"unown_form": Gen2Stats.unown_letter(mon.dvs) \
 			if mon.species == RomLayout.UNOWN_SPECIES else 0,
 	}
+
+
+## `GetHallOfFameParty` and `AddHallOfFameEntry`: the party as a stored record,
+## eggs skipped, in front of whatever was already kept, with the thirtieth
+## falling off the end. The win count is `wHallOfFameCount` after its own
+## increment, which stops at `HOF_MASTER_COUNT` rather than wrapping.
+static func inducted(records: Array, save: Gen2SaveData) -> Array:
+	if save == null:
+		return records.duplicate(true)
+	var mons: Array = []
+	for mon: Gen2SaveMon in save.party:
+		if mons.size() >= MAX_MONS:
+			break
+		if mon == null or mon.is_egg:
+			continue
+		mons.append({
+			"species": mon.species,
+			"ot_id": mon.ot_id,
+			"dvs": mon.dvs,
+			"level": mon.level,
+			"nickname": mon.nickname.substr(0, MAX_NICKNAME),
+		})
+	var out: Array = records.duplicate(true)
+	out.push_front({"win_count": mini(win_count(records) + 1, MASTER_COUNT), "mons": mons})
+	out.resize(mini(out.size(), MAX_RECORDS))
+	return out
+
+
+## `wHallOfFameCount`, which the newest record carries: every induction stores
+## the count it was made at.
+static func win_count(records: Array) -> int:
+	if records.is_empty() or not records[0] is Dictionary:
+		return 0
+	return int((records[0] as Dictionary).get("win_count", 0))
+
+
+## One stored record as the panels `_HallOfFamePC.DisplayTeam` walks. Unlike an
+## induction there is no player panel behind them: the viewer's `.b_button` is
+## the only way out.
+static func record_pages(data: GameData, record: Dictionary) -> Array:
+	var out: Array = []
+	if data == null:
+		return out
+	var raw_mons: Variant = record.get("mons", [])
+	if not raw_mons is Array:
+		return out
+	for raw: Variant in raw_mons as Array:
+		if not raw is Dictionary:
+			continue
+		var mon: Dictionary = raw
+		var species: int = int(mon.get("species", 0))
+		var species_name: String = String(data.species(species).get("name", ""))
+		var nickname: String = String(mon.get("nickname", ""))
+		var dvs: int = int(mon.get("dvs", 0))
+		out.append({
+			"kind": PAGE_MON,
+			"species": species,
+			"dex_number": species,
+			"species_name": species_name,
+			"nickname": nickname if not nickname.is_empty() else species_name,
+			"level": int(mon.get("level", 0)),
+			"ot_id": int(mon.get("ot_id", 0)),
+			"gender": Gen2BattleMon.gender_for(data, species, dvs),
+			"unown_form": Gen2Stats.unown_letter(dvs) \
+				if species == RomLayout.UNOWN_SPECIES else 0,
+			## `.print_num_hof`'s "-Time Famer", which is the one line the viewer
+			## draws that an induction does not.
+			"win_count": int(record.get("win_count", 0)),
+		})
+	return out
+
+
+## The stored shape, checked rather than trusted: JSON numbers come back as
+## floats and a hand-edited save can carry anything.
+static func parse_records(raw: Variant) -> Array:
+	var out: Array = []
+	if not raw is Array:
+		return out
+	for raw_record: Variant in raw as Array:
+		if not raw_record is Dictionary or out.size() >= MAX_RECORDS:
+			continue
+		var record: Dictionary = raw_record
+		var mons: Array = []
+		var raw_mons: Variant = record.get("mons", [])
+		if raw_mons is Array:
+			for raw_mon: Variant in raw_mons as Array:
+				if not raw_mon is Dictionary or mons.size() >= MAX_MONS:
+					continue
+				var mon: Dictionary = raw_mon
+				mons.append({
+					"species": int(mon.get("species", 0)) & 0xFF,
+					"ot_id": int(mon.get("ot_id", 0)) & 0xFFFF,
+					"dvs": int(mon.get("dvs", 0)) & 0xFFFF,
+					"level": clampi(int(mon.get("level", 0)), 0, Gen2Experience.MAX_LEVEL),
+					"nickname": String(mon.get("nickname", "")).substr(0, MAX_NICKNAME),
+				})
+		out.append({
+			"win_count": clampi(int(record.get("win_count", 0)), 0, MASTER_COUNT),
+			"mons": mons,
+		})
+	return out

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -8,8 +8,10 @@ extends Control
 ## at a time and then shows the player's own with `ProfOaksPCRating` printed into
 ## it, and finally runs the credits. What is here is that walk, advanced by A.
 ## The credits, the backpic and frontpic slides and the palette rotations are
-## not, and neither is the persisted Hall of Fame record, which has no save field
-## to go in.
+## not.
+##
+## `_HallOfFamePC` reuses the same walk over a stored record ([member viewer]);
+## the record itself is [member Gen2SaveData.hall_of_fame].
 ##
 ## The source pauses 60 frames per panel and moves on by itself. This waits for
 ## a key instead: there is no animation to watch yet, so a timer would only be a
@@ -23,6 +25,13 @@ signal closed()
 signal rating_reached(sfx: int)
 
 const BACKDROP: Color = Color.WHITE
+
+## Whether this is `_HallOfFamePC`'s viewer rather than `AnimateHallOfFame`'s
+## induction: only the viewer answers B and START.
+var viewer: bool = false
+## Whether B closed it, which is `.b_button`'s carry and the way out of the
+## machine's own loop.
+var cancelled: bool = false
 
 var _data: GameData = null
 var _pages: Array = []
@@ -65,11 +74,25 @@ func current_page() -> Dictionary:
 
 ## A moves on, matching every other text pause in the overworld. There is no way
 ## back: the cartridge's panels do not rewind either.
+##
+## `_HallOfFamePC.DisplayTeam` adds two: B leaves the viewer, which is what
+## [member cancelled] says afterwards, and START skips the rest of this team.
+## `AnimateHallOfFame` reads neither, so an induction ignores them.
 func handle_button(button: int) -> bool:
-	if button != Gen2Button.A:
+	if button == Gen2Button.A:
+		advance()
+		return true
+	if not viewer:
 		return false
-	advance()
-	return true
+	if button == Gen2Button.B:
+		cancelled = true
+		closed.emit()
+		return true
+	if button == Gen2Button.START:
+		_index = _pages.size()
+		closed.emit()
+		return true
+	return false
 
 
 func advance() -> void:

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -12,10 +12,12 @@ extends Control
 ## nothing else, so a caller that never sees this signal has no name to take.
 signal closed(name: String)
 
-## `wNamingScreenType`'s two that a screen here opens. Both are the player's
-## keyboard; NAME_MON differs only in `MON_NAME_LENGTH - 1` behind it.
+## `wNamingScreenType`'s three that a screen here opens. All three are the
+## player's keyboard; NAME_MON and NAME_BOX differ only in the length cap behind
+## them.
 const KIND_PLAYER: StringName = &"player"
 const KIND_MON: StringName = &"mon"
+const KIND_BOX: StringName = &"box"
 
 var _screen: Gen2NamingScreen = null
 var _page: Gen2NamingScreenPage = null
@@ -52,6 +54,8 @@ func open(data: GameData, prompt: String, kind: StringName = KIND_PLAYER) -> boo
 static func _model(data: GameData, kind: StringName) -> Gen2NamingScreen:
 	if kind == KIND_MON:
 		return Gen2NamingScreen.for_mon(data)
+	if kind == KIND_BOX:
+		return Gen2NamingScreen.for_box(data)
 	return Gen2NamingScreen.for_player(data)
 
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -37,7 +37,7 @@ signal field_move_chosen(action: Dictionary)
 
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
-	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING,
+	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING, PACK_PP_MOVE,
 	PACK_TOSS_QUANTITY, PACK_TOSS_CONFIRM, PACK_GIVE_SWAP,
 	PACK_RESULT, SAVE_ASK, SAVE_OVERWRITE, SAVE_SAVING, SAVE_SAVED,
 	SAVE_FAILED, OPTIONS, MODS, MOD_OPTIONS, FIELD_MOVES,
@@ -60,6 +60,15 @@ const SAVE_SAVING_LINES: Array[String] = [
 	"SAVING… DON'T TURN", "OFF THE POWER.",
 ]
 ## `_SavedTheGameText`, whose `<PLAYER>` is filled from the save.
+## `RestoreThePPOfWhichMoveText`, `PPRestoredText` and the refusal the pack owes
+## PP UP, whose ceiling the save model does not carry. The first two are
+## `text_far` stubs in `data/text/common_2.asm` that no script reaches, so they
+## are this screen's the way the save boxes below are; the third is this port's
+## own words, because the cartridge has no such refusal.
+const RESTORE_PP_WHICH_MOVE: String = "Restore the PP of\nwhich move?"
+const PP_RESTORED: String = "PP was restored."
+const PP_UP_UNSUPPORTED: String = "PP UP has no effect\nin this port yet."
+
 const SAVE_SAVED_LINES: Array[String] = [
 	"%s saved", "the game.",
 ]
@@ -178,6 +187,10 @@ var _pending_entry: Callable = Callable()
 ## because the second teach_tm_hm() call has to name the same Pokémon the first
 ## one refused.
 var _forget_moves: Array = []
+## `RestorePPEffect`'s own `MoveSelectionScreen`: which item asked and which
+## party member it is being used on, held while the move list is up.
+var _pp_item: int = 0
+var _pp_party_index: int = -1
 ## `MoveCantForgetHMText` while the list it was refused on is still open.
 var _forget_refusal: String = ""
 var _forget_cursor: int = 0
@@ -389,7 +402,7 @@ func _move(direction: Vector2i) -> void:
 			if direction.y != 0 or direction.x != 0:
 				_forget_confirm_cursor = 1 - _forget_confirm_cursor
 				_render_forget_ask()
-		Mode.PACK_FORGET:
+		Mode.PACK_FORGET, Mode.PACK_PP_MOVE:
 			## w2DMenuNumCols is 1, so only vertical input moves the move list.
 			if direction.y != 0 and not _forget_moves.is_empty():
 				_forget_cursor = wrapi(
@@ -482,6 +495,8 @@ func _confirm() -> void:
 			_confirm_forget_ask()
 		Mode.PACK_FORGET:
 			_confirm_forget()
+		Mode.PACK_PP_MOVE:
+			_confirm_pp_move()
 		Mode.PACK_STOP_LEARNING:
 			_confirm_stop_learning()
 		Mode.PACK_TOSS_CONFIRM:
@@ -559,6 +574,9 @@ func _cancel() -> void:
 		## No to "Stop learning?" is `jp .loop`, back to ForgetMove's ask.
 		Mode.PACK_STOP_LEARNING:
 			_open_forget_ask()
+		## B in `MoveSelectionScreen` is `jr nz, .loop`, back to the party list.
+		Mode.PACK_PP_MOVE:
+			_open_target_mode()
 		Mode.PACK_TARGET:
 			_open_item_mode()
 		## B at the yes/no is `YesNoBox`'s no, which is the carry `TossMenu`
@@ -1540,7 +1558,7 @@ func _render_targets() -> void:
 	_render_hardware()
 
 
-func _use_selected_item(party_index: int) -> void:
+func _use_selected_item(party_index: int, move_slot: int = -1) -> void:
 	var item: Dictionary = _selected_item()
 	if item.is_empty():
 		return
@@ -1549,10 +1567,21 @@ func _use_selected_item(party_index: int) -> void:
 		return
 	var number: int = int(item.get("item", 0))
 	var result: Dictionary = Gen2WorldPartyHost.use_item(
-		_world, _pack_save, number, party_index, _pack_persist
+		_world, _pack_save, number, party_index, _pack_persist, move_slot
 	)
 	if not bool(result.get("ok", false)):
+		if StringName(result.get("reason", &"")) == &"move_slot_required":
+			_open_pp_move_list(number, party_index)
+			return
 		_show_pack_result(_use_refusal(StringName(result.get("reason", &"")), number), false)
+		return
+	if StringName(result.get("effect", &"")) == &"rare_candy":
+		## `RareCandyEffect` prints its level-up box and then runs
+		## `LearnLevelMoves`, whose full-moveset case is the same `ForgetMove` the
+		## TM path opens.
+		_forget_party_index = party_index
+		_evolution_offers.assign(result.get("move_offers", []))
+		_show_pack_result(_use_summary(item, result), true, _offer_next_evolution_move)
 		return
 	if StringName(result.get("effect", &"")) == &"evolution":
 		_forget_party_index = party_index
@@ -1609,6 +1638,12 @@ func _use_summary(item: Dictionary, result: Dictionary) -> String:
 		return "%s will repel weak Pokemon for %d steps." % [
 			item_name, int(result.get("repel_steps", 0)),
 		]
+	if int(result.get("level", 0)) > 0:
+		return "%s grew to level %d!" % [
+			_target_name(_forget_party_index), int(result.get("level", 0)),
+		]
+	if int(result.get("restored", 0)) > 0:
+		return PP_RESTORED
 	var healed: int = int(result.get("healed", 0))
 	if healed > 0:
 		return "%s restored %d HP." % [item_name, healed]
@@ -1632,7 +1667,35 @@ func _use_refusal(reason: StringName, item: int) -> String:
 			return "It won't have any effect."
 		&"insufficient_item_quantity":
 			return "You have none of those."
+		&"pp_up_unsupported":
+			return PP_UP_UNSUPPORTED
 	return "Can't use that here: %s" % String(reason)
+
+
+## `RestoreThePPOfWhichMoveText` and `MoveSelectionScreen` behind it. The list is
+## the target's own moves; the item is spent when one is chosen.
+func _open_pp_move_list(item: int, party_index: int) -> void:
+	var mon: Gen2SaveMon = _pack_save.party[party_index] \
+		if _pack_save != null and party_index >= 0 \
+		and party_index < _pack_save.party.size() else null
+	_forget_moves = Gen2MoveForget.options(_data, mon.moves) if mon != null else []
+	if _forget_moves.is_empty():
+		_show_pack_result(_use_refusal(&"item_has_no_effect", item), false)
+		return
+	_mode = Mode.PACK_PP_MOVE
+	_pp_item = item
+	_pp_party_index = party_index
+	_forget_cursor = 0
+	_forget_refusal = ""
+	_render_hardware()
+
+
+func _confirm_pp_move() -> void:
+	if _forget_cursor < 0 or _forget_cursor >= _forget_moves.size():
+		return
+	_use_selected_item(
+		_pp_party_index, int(_forget_moves[_forget_cursor].get("slot", -1))
+	)
 
 
 ## `TossMenu`: the ask, then `SelectQuantityToToss`, which is the same dial the
@@ -1989,6 +2052,8 @@ func box_text() -> String:
 		Mode.PACK_FORGET:
 			return _forget_refusal if not _forget_refusal.is_empty() \
 				else Gen2MoveForget.which_text()
+		Mode.PACK_PP_MOVE:
+			return RESTORE_PP_WHICH_MOVE
 		Mode.PACK_RESULT:
 			return _pack_result_text()
 	return ""
@@ -2055,7 +2120,7 @@ func _hardware_image() -> Image:
 					_toss_prompt.value if _toss_prompt != null else 1
 				)
 			)
-		Mode.PACK_FORGET:
+		Mode.PACK_FORGET, Mode.PACK_PP_MOVE:
 			var moves: Array = []
 			for entry: Dictionary in _forget_moves:
 				moves.append(String(entry.get("name", "")))

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -1,0 +1,345 @@
+class_name Gen2WorldDecoration
+extends RefCounted
+
+## `engine/overworld/decorations.asm`: which decorations the player owns, the
+## seven category menus `_PlayerDecorationMenu` opens over them, and the
+## `DecoAction_*` that move one between a `wDeco*` slot and the room.
+##
+## Scene-free like the other world hosts. Ownership is an event flag, which the
+## state already carries, and a placed decoration is a `wDeco*` slot, which is
+## [method Gen2WorldState.maptile_decoration]; nothing here is new save state.
+## The imported `DecorationAttributes` row is the only source of a decoration's
+## type, name parts, action, flag and block or sprite, so a mod repointing one
+## takes all five with it.
+
+## `constants/deco_constants.asm`' decoration types, which decide how
+## `GetDecoName` spells a row rather than which category it is in.
+const TYPE_PLANT: int = 1
+const TYPE_BED: int = 2
+const TYPE_CARPET: int = 3
+const TYPE_POSTER: int = 4
+const TYPE_DOLL: int = 5
+const TYPE_BIG_DOLL: int = 6
+
+## `DecorationNames` indices the name assembly reaches for by itself. Everything
+## else a row names is either another entry of that list or a species.
+const NAME_CANCEL: int = 0
+const NAME_PUT_IT_AWAY: int = 1
+const NAME_BED: int = 13
+const NAME_CARPET: int = 14
+const NAME_POSTER: int = 15
+const NAME_DOLL: int = 16
+const NAME_BIG: int = 17
+
+## `DoDecorationAction2.DecoActions` indices. Zero is `DecoAction_nothing`, the
+## CANCEL row's; every other action is a set-up/put-away pair over one slot.
+const ACTION_NOTHING: int = 0
+
+## The `wDeco*` slot each action pair owns. The ornament pair owns two, because
+## `DecoAction_setupornament` asks which side of the room first.
+const SLOT_BED: StringName = &"bed"
+const SLOT_CARPET: StringName = &"carpet"
+const SLOT_PLANT: StringName = &"plant"
+const SLOT_POSTER: StringName = &"poster"
+const SLOT_CONSOLE: StringName = &"console"
+const SLOT_BIG_DOLL: StringName = &"big_doll"
+const SLOT_LEFT_ORNAMENT: StringName = &"left_ornament"
+const SLOT_RIGHT_ORNAMENT: StringName = &"right_ornament"
+
+## `.DecoActions` as `{ action: [slot, sets up] }`. Read from the imported row
+## rather than from the id, so the table decides which category a row is in.
+const ACTIONS: Dictionary = {
+	1: [SLOT_BED, true], 2: [SLOT_BED, false],
+	3: [SLOT_CARPET, true], 4: [SLOT_CARPET, false],
+	5: [SLOT_PLANT, true], 6: [SLOT_PLANT, false],
+	7: [SLOT_POSTER, true], 8: [SLOT_POSTER, false],
+	9: [SLOT_CONSOLE, true], 10: [SLOT_CONSOLE, false],
+	11: [SLOT_BIG_DOLL, true], 12: [SLOT_BIG_DOLL, false],
+	13: [SLOT_LEFT_ORNAMENT, true], 14: [SLOT_LEFT_ORNAMENT, false],
+}
+
+## `_PlayerDecorationMenu.category_pointers`' own order and its own strings,
+## which are inline in the routine and reached by no script, so nothing imports
+## them and they are this host's the way [Gen2WorldPC]'s BILL'S PC rows are.
+## ORNAMENT is in front of BIG DOLL here and behind it in the id order.
+const CATEGORIES: Array[Dictionary] = [
+	{"slot": SLOT_BED, "name": "BED"},
+	{"slot": SLOT_CARPET, "name": "CARPET"},
+	{"slot": SLOT_PLANT, "name": "PLANT"},
+	{"slot": SLOT_POSTER, "name": "POSTER"},
+	{"slot": SLOT_CONSOLE, "name": "GAME CONSOLE"},
+	{"slot": SLOT_LEFT_ORNAMENT, "name": "ORNAMENT"},
+	{"slot": SLOT_BIG_DOLL, "name": "BIG DOLL"},
+]
+const CATEGORY_EXIT: String = "EXIT"
+
+## `DecoAction_AskWhichSide`'s own three rows, and which slot each answers.
+const SIDE_RIGHT: StringName = SLOT_RIGHT_ORNAMENT
+const SIDE_LEFT: StringName = SLOT_LEFT_ORNAMENT
+const SIDE_ROWS: Array[Dictionary] = [
+	{"side": SIDE_RIGHT, "name": "RIGHT SIDE"},
+	{"side": SIDE_LEFT, "name": "LEFT SIDE"},
+	{"side": &"", "name": "CANCEL"},
+]
+
+## `PopulateDecoCategoryMenu`: eight rows fit the non-scrolling menu, and a
+## ninth turns it into `ScrollingMenu` and costs the list its CANCEL row.
+const CATEGORY_MENU_HEIGHT: int = 8
+
+## `ToggleMaptileDecorations`' four `changeblock` coordinates. The carpet is
+## four blocks rather than one, and its own three are the sprite byte plus one,
+## two and one again.
+const MAPTILE_AT: Dictionary = {
+	SLOT_BED: Vector2i(0, 4),
+	SLOT_PLANT: Vector2i(7, 4),
+	SLOT_POSTER: Vector2i(6, 0),
+}
+const CARPET_AT: Array[Vector2i] = [
+	Vector2i(0, 0), Vector2i(0, 2), Vector2i(2, 2), Vector2i(4, 2),
+]
+const CARPET_BLOCK_STEP: Array[int] = [0, 1, 2, 1]
+
+## `ToggleDecorationsVisibility`: which object event flag each of the four object
+## slots masks, and the `wVariableSprites` slot it fills when one is out.
+## `EVENT_PLAYERS_HOUSE_2F_*` and `SPRITE_CONSOLE` and up are the same numbers on
+## all three cartridges.
+const OBJECT_SLOTS: Array[Dictionary] = [
+	{"slot": SLOT_CONSOLE, "flag": 1857, "variable_sprite": 0xF0},
+	{"slot": SLOT_LEFT_ORNAMENT, "flag": 1858, "variable_sprite": 0xF1},
+	{"slot": SLOT_RIGHT_ORNAMENT, "flag": 1859, "variable_sprite": 0xF2},
+	{"slot": SLOT_BIG_DOLL, "flag": 1860, "variable_sprite": 0xF3},
+]
+
+## The wording of the boxes `_PlayerDecorationMenu` prints, which are
+## `text_far` stubs in `data/text/common_1.asm` that no script reaches, so they
+## are this host's the way [Gen2WorldPack]'s hold and swap boxes are.
+const TEXT_NOTHING_TO_CHOOSE: String = "There's nothing to\nchoose."
+const TEXT_ALREADY_SET_UP: String = "That's already set\nup."
+const TEXT_NOTHING_TO_PUT_AWAY: String = "There's nothing to\nput away."
+const TEXT_WHICH_SIDE_PUT_ON: String = "Which side do you\nwant to put it on?"
+const TEXT_WHICH_SIDE_PUT_AWAY: String = "Which side do you\nwant to put away?"
+
+
+static func set_up_text(name: String) -> String:
+	return "Set up the\n%s." % name
+
+
+static func put_away_text(name: String) -> String:
+	return "Put away the\n%s." % name
+
+
+## `PutAwayAndSetUpText`, whose second half is a `para` rather than a line.
+static func put_away_and_set_up_text(put_away: String, set_up: String) -> String:
+	return "Put away the\n%s\n\nand set up the\n%s." % [put_away, set_up]
+
+
+## `GetDecoName`: a row's type decides which parts its name is spelled from, and
+## the poster, doll and big doll name a species where the others name a
+## `DecorationNames` entry. Empty for a row outside the table.
+static func decoration_name(data: GameData, deco: int) -> String:
+	if data == null:
+		return ""
+	var row: Dictionary = data.decoration(deco)
+	if row.is_empty():
+		return ""
+	var part: int = int(row.get("name", 0))
+	match int(row.get("type", 0)):
+		TYPE_PLANT:
+			return data.decoration_name_part(part)
+		TYPE_BED:
+			return data.decoration_name_part(part) + data.decoration_name_part(NAME_BED)
+		TYPE_CARPET:
+			return data.decoration_name_part(part) + data.decoration_name_part(NAME_CARPET)
+		TYPE_POSTER:
+			return _species_name(data, part) + data.decoration_name_part(NAME_POSTER)
+		TYPE_DOLL:
+			return _species_name(data, part) + data.decoration_name_part(NAME_DOLL)
+		TYPE_BIG_DOLL:
+			return data.decoration_name_part(NAME_BIG) + _species_name(data, part)
+	return ""
+
+
+static func _species_name(data: GameData, species: int) -> String:
+	return String(data.species(species).get("name", ""))
+
+
+## The `wDeco*` slot a row's action belongs to, or an empty name for the CANCEL
+## row and for an action no `DecoAction_*` answers.
+static func slot_of(data: GameData, deco: int) -> StringName:
+	var action: int = int(data.decoration(deco).get("action", ACTION_NOTHING)) \
+		if data != null else ACTION_NOTHING
+	var pair: Variant = ACTIONS.get(action, null)
+	return StringName((pair as Array)[0]) if pair is Array else &""
+
+
+## Whether a row is its category's PUT IT AWAY header rather than a decoration.
+static func is_put_away(data: GameData, deco: int) -> bool:
+	var action: int = int(data.decoration(deco).get("action", ACTION_NOTHING)) \
+		if data != null else ACTION_NOTHING
+	var pair: Variant = ACTIONS.get(action, null)
+	return pair is Array and not bool((pair as Array)[1])
+
+
+## `DecorationFlagAction CHECK_FLAG`: the row's own `DECOATTR_EVENT_FLAG`. The
+## header rows all name `EVENT_TEMPORARY_UNTIL_MAP_RELOAD_1`, so ownership is
+## only ever asked of a set-up row.
+static func owns(data: GameData, state: Gen2WorldState, deco: int) -> bool:
+	if data == null or state == null:
+		return false
+	var row: Dictionary = data.decoration(deco)
+	if row.is_empty():
+		return false
+	return state.is_event_flag_active(int(row.get("flag", -1)))
+
+
+## `SetSpecificDecorationFlag`, which is what a doll Mom buys and a trophy the
+## Bug Contest awards go through.
+static func set_owned(
+	data: GameData, state: Gen2WorldState, deco: int, owned: bool = true
+) -> bool:
+	if data == null or state == null:
+		return false
+	var row: Dictionary = data.decoration(deco)
+	if row.is_empty() or is_put_away(data, deco):
+		return false
+	state.set_event_flag(int(row.get("flag", -1)), owned)
+	return true
+
+
+## `.FindCategoriesWithOwnedDecos`: only a category the player owns something in
+## is on the top menu, and EXIT is always its last row.
+static func categories(data: GameData, state: Gen2WorldState) -> Array:
+	var out: Array = []
+	for category: Dictionary in CATEGORIES:
+		var slot: StringName = StringName(category["slot"])
+		if _owned_in(data, state, slot).is_empty():
+			continue
+		out.append({"slot": slot, "name": String(category["name"])})
+	out.append({"slot": &"", "name": CATEGORY_EXIT})
+	return out
+
+
+## `FindOwnedDecosInCategory`: the owned rows in id order, then the category's
+## own PUT IT AWAY, then CANCEL. `PopulateDecoCategoryMenu.beyond_eight` drops
+## that last row once the list is longer than the menu, which is what the
+## ornament category reaches.
+static func category_rows(
+	data: GameData, state: Gen2WorldState, slot: StringName
+) -> Array:
+	var owned: Array = _owned_in(data, state, slot)
+	if owned.is_empty():
+		return []
+	var out: Array = []
+	for deco: int in owned:
+		out.append({"deco": deco, "name": decoration_name(data, deco)})
+	var header: int = _header_of(data, slot)
+	if header >= 0:
+		out.append({"deco": header, "name": decoration_name(data, header)})
+	if out.size() < CATEGORY_MENU_HEIGHT:
+		out.append({"deco": 0, "name": decoration_name(data, 0)})
+	return out
+
+
+static func _owned_in(
+	data: GameData, state: Gen2WorldState, slot: StringName
+) -> Array:
+	var out: Array = []
+	if data == null or state == null or slot.is_empty():
+		return out
+	## The two ornament slots are one category, and `FindOwnedOrnaments` is the
+	## left one's action either way.
+	var wanted: StringName = SLOT_LEFT_ORNAMENT if slot == SLOT_RIGHT_ORNAMENT else slot
+	for deco: int in data.decoration_count():
+		if slot_of(data, deco) != wanted or is_put_away(data, deco):
+			continue
+		if owns(data, state, deco):
+			out.append(deco)
+	return out
+
+
+static func _header_of(data: GameData, slot: StringName) -> int:
+	if data == null:
+		return -1
+	var wanted: StringName = SLOT_LEFT_ORNAMENT if slot == SLOT_RIGHT_ORNAMENT else slot
+	for deco: int in data.decoration_count():
+		if slot_of(data, deco) == wanted and is_put_away(data, deco):
+			return deco
+	return -1
+
+
+## Whether the chosen row needs `DecoAction_AskWhichSide` in front of it, which
+## is the ornament category and nothing else.
+static func asks_side(data: GameData, deco: int) -> bool:
+	return slot_of(data, deco) == SLOT_LEFT_ORNAMENT
+
+
+## `DoDecorationAction2`: set the chosen decoration up in its slot, or put away
+## whatever stands there. [param side] is the ornament slot
+## `DecoAction_AskWhichSide` answered with and is ignored by every other
+## category. The answer carries the box the source prints and whether the room
+## changed, which is `wChangedDecorations` and what makes the map reload.
+static func apply(
+	world: Gen2WorldAPI, save: Gen2SaveData, deco: int, side: StringName = &"",
+	persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return Gen2WorldTransaction.failure(&"missing_world", {})
+	var data: GameData = world.data
+	var row: Dictionary = data.decoration(deco)
+	if row.is_empty():
+		return Gen2WorldTransaction.failure(&"unknown_decoration", {"decoration": deco})
+	var slot: StringName = slot_of(data, deco)
+	if slot.is_empty():
+		return {"ok": true, "changed": false, "text": ""}
+	if slot == SLOT_LEFT_ORNAMENT:
+		if side != SLOT_LEFT_ORNAMENT and side != SLOT_RIGHT_ORNAMENT:
+			return Gen2WorldTransaction.failure(&"decoration_side_required", {
+				"decoration": deco,
+			})
+		slot = side
+	var standing: int = world.state.maptile_decoration(slot)
+	var text: String = ""
+	var next: int = standing
+	if is_put_away(data, deco):
+		## `DecoAction_TryPutItAway` clears the slot before it looks at what was
+		## in it, so an empty slot is still cleared and the box is the refusal.
+		if standing == 0:
+			return {"ok": true, "changed": false, "text": TEXT_NOTHING_TO_PUT_AWAY}
+		next = 0
+		text = put_away_text(decoration_name(data, standing))
+	else:
+		if not owns(data, world.state, deco):
+			return Gen2WorldTransaction.failure(&"decoration_not_owned", {
+				"decoration": deco,
+			})
+		if standing == deco:
+			## `DecoAction_SetItUp.alreadythere` is the one refusal that leaves
+			## the slot alone.
+			return {"ok": true, "changed": false, "text": TEXT_ALREADY_SET_UP}
+		next = deco
+		text = set_up_text(decoration_name(data, deco)) if standing == 0 \
+			else put_away_and_set_up_text(
+				decoration_name(data, standing), decoration_name(data, deco)
+			)
+	var writes: Dictionary = {slot: next}
+	## `DecoAction_SetItUp_Ornament.getwhichside`: a doll set up on one side is
+	## taken off the other, so the room never holds two of the same ornament.
+	if next != 0 and (slot == SLOT_LEFT_ORNAMENT or slot == SLOT_RIGHT_ORNAMENT):
+		var other: StringName = SLOT_RIGHT_ORNAMENT if slot == SLOT_LEFT_ORNAMENT \
+			else SLOT_LEFT_ORNAMENT
+		if world.state.maptile_decoration(other) == next:
+			writes[other] = 0
+	var before: Gen2WorldSnapshot = world.snapshot()
+	for written: StringName in writes:
+		if world.state.set_maptile_decoration(written, int(writes[written])):
+			continue
+		Gen2WorldTransaction.restore(world, before)
+		return Gen2WorldTransaction.failure(&"decoration_state_failed", {
+			"decoration": deco, "slot": written,
+		})
+	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {
+		"ok": true, "changed": true, "text": text, "slot": slot, "decoration": next,
+	}

--- a/game/world/world_decoration.gd.uid
+++ b/game/world/world_decoration.gd.uid
@@ -1,0 +1,1 @@
+uid://dwnxu5aa03nmn

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -40,6 +40,27 @@ const PULSE_FRAMES: int = 600
 ## The four `Gen2WorldSprite` facings.
 const MAX_FACING: int = Gen2WorldSprite.FACING_RIGHT
 
+## How many steps an entry's `glow` amount is rounded onto, and the palette
+## colour it leaves alone.
+##
+## The rung count is the host's rather than the mod's on purpose. Both world
+## renderers cache one sprite texture per distinct set of four colours and
+## neither evicts (`world_renderer.gd:_actor_texture` keys on `hash(colors)`), so
+## a glow interpolated freely would leave a texture behind on every frame the map
+## is up. Nine amounts is nine palettes per species, and the key carries a facing
+## and a frame beside them: eight of those, so seventy-two textures for a species
+## that glows and none for one that does not.
+##
+## Eight rather than four because a mark meant to be subtle has to keep a cycle
+## after the rounding. A glow whose peak is under half the walk, which is what
+## reads as a breath rather than a recolour, has four steps left on eighths and
+## one on quarters.
+##
+## Colour 0 is the icon's cut-out ([method Gen2PicImage.lookup] gives it alpha
+## zero), so walking it would change the cache key and no pixel.
+const GLOW_RUNGS: int = 8
+const GLOW_CUTOUT_COLOR: int = 0
+
 var _providers: Array = []
 var _world: Gen2WorldAPI = null
 var _anim_data: Gen2BattleAnimData = null
@@ -107,8 +128,8 @@ func advance_frame() -> bool:
 
 
 ## The validated population, each entry `{id, cell, facing, species, level, dvs,
-## shiny}`. `shiny` is the host's own answer from the DVs; a provider that sends
-## one is refused.
+## shiny, pulse}` and an optional `glow`. `shiny` is the host's own answer from
+## the DVs; a provider that sends one is refused.
 func entries() -> Array:
 	return _entries
 
@@ -128,8 +149,12 @@ func actor_entries() -> Array:
 			"facing": int(entry["facing"]),
 			"position_cells": Vector2(entry["cell"]),
 			# `GetMonNormalOrShinyPalettePointer`: the species' own four colours,
-			# which is what makes a shiny one visible before the battle starts.
-			"colors": _world.data.palette(int(entry["species"]), bool(entry["shiny"])),
+			# which is what makes a shiny one visible before the battle starts,
+			# walked toward an entry's own light when it asked for one.
+			"colors": glow_palette(
+				_world.data.palette(int(entry["species"]), bool(entry["shiny"])),
+				entry.get("glow", {})
+			),
 		})
 	return out
 
@@ -333,7 +358,7 @@ func _validate(raw: Variant) -> Dictionary:
 	var dvs: int = int(row.get("dvs", 0))
 	if dvs < 0 or dvs > 0xFFFF:
 		return {}
-	return {
+	var entry: Dictionary = {
 		"id": id,
 		"cell": cell,
 		"facing": clampi(int(row.get("facing", Gen2WorldSprite.FACING_DOWN)), 0, MAX_FACING),
@@ -343,6 +368,48 @@ func _validate(raw: Variant) -> Dictionary:
 		"shiny": Gen2Stats.is_shiny(dvs),
 		"pulse": bool(row.get("pulse", false)),
 	}
+	var glow: Dictionary = _glow(row.get("glow", null))
+	if not glow.is_empty():
+		entry["glow"] = glow
+	return entry
+
+
+## An entry's optional `{color, amount}`, with the amount rounded onto
+## [constant GLOW_RUNGS]. A malformed one costs the glow and not the entry: it is
+## presentation, and a wild without one is still a wild the host can vouch for.
+## An amount that rounds to nothing answers empty, so an entry not glowing this
+## frame carries no key and asks for no second texture.
+static func _glow(raw: Variant) -> Dictionary:
+	if not raw is Dictionary:
+		return {}
+	var row: Dictionary = raw
+	if not row.get("color", null) is Color:
+		return {}
+	var amount: float = float(row.get("amount", 0.0))
+	if not is_finite(amount):
+		return {}
+	var rung: int = roundi(clampf(amount, 0.0, 1.0) * GLOW_RUNGS)
+	if rung <= 0:
+		return {}
+	return {"color": row["color"] as Color, "amount": float(rung) / float(GLOW_RUNGS)}
+
+
+## One entry's palette with its glow applied: every colour but the cut-out walked
+## toward the light by the quantized amount. Public because a renderer drawing
+## the population itself resolves the same palette.
+static func glow_palette(
+	colors: PackedColorArray, glow: Dictionary
+) -> PackedColorArray:
+	if glow.is_empty():
+		return colors
+	var light: Color = glow["color"]
+	var amount: float = float(glow["amount"])
+	var out: PackedColorArray = colors.duplicate()
+	for index: int in out.size():
+		if index == GLOW_CUTOUT_COLOR:
+			continue
+		out[index] = out[index].lerp(light, amount)
+	return out
 
 
 ## Which method's eligible list [param cell] is in, empty when neither.
@@ -414,6 +481,18 @@ func _changed(before: Array, after: Array) -> bool:
 		var now: Dictionary = after[index]
 		if was["cell"] != now["cell"] or int(was["facing"]) != int(now["facing"]) \
 			or int(was["species"]) != int(now["species"]) \
-			or bool(was["shiny"]) != bool(now["shiny"]):
+			or bool(was["shiny"]) != bool(now["shiny"]) \
+			or _glow_changed(was.get("glow", {}), now.get("glow", {})):
 			return true
 	return false
+
+
+## A glow that moves while nothing else does still has to repaint, or the
+## Pokemon stands at whichever rung it was on when it last stepped.
+static func _glow_changed(was: Dictionary, now: Dictionary) -> bool:
+	if was.is_empty() != now.is_empty():
+		return true
+	if was.is_empty():
+		return false
+	return not is_equal_approx(float(was["amount"]), float(now["amount"])) \
+		or Color(was["color"]) != Color(now["color"])

--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -3,7 +3,7 @@ extends RefCounted
 
 ## Scene-free mart transactions over imported lists and mutable world state.
 ## The UI owns selection; this class owns validation, money, inventory and save
-## writeback for one purchase.
+## writeback for one purchase off `BuyMenu` or one sale off `SellMenu`.
 
 const MONEY_ACCOUNT: int = 0
 const MAX_ITEM_STACK: int = 99
@@ -171,6 +171,76 @@ static func purchase(
 		"total": total,
 		"balance": balance - total,
 		"owned": next_quantity,
+	}
+
+
+## `SellMenu.TryToSellItem`: `CheckItemMenu`'s nibble decides first, and the
+## three `.cant_buy` rows are the ones no cartridge item carries; what actually
+## refuses a key item is `_CheckTossableItem` behind them.
+static func can_sell(data: GameData, item: int) -> bool:
+	if data == null:
+		return false
+	var definition: Dictionary = data.item(item)
+	if definition.is_empty():
+		return false
+	var menu: int = int(definition.get("field_menu", 0))
+	if menu >= 1 and menu < Gen2WorldPack.ITEMMENU_CURRENT:
+		return false
+	return Gen2WorldPack.can_toss(data, item)
+
+
+## `DisplaySellingPrice`: the whole stack is multiplied and then halved, so the
+## shift is on the total rather than on each unit's price.
+static func sell_price(data: GameData, item: int, quantity: int = 1) -> int:
+	if data == null or quantity <= 0:
+		return 0
+	return (int(data.item(item).get("price", 0)) * quantity) >> 1
+
+
+## `SellMenu.okay_to_sell`: the stack leaves the pack through `TossItem` and
+## `GiveMoney` puts the halved price in, clamped to `MAX_MONEY` the way every
+## other gift is.
+static func sell(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	item: int,
+	quantity: int = 1,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return _failure(&"missing_world", {})
+	var definition: Dictionary = world.data.item(item)
+	if definition.is_empty():
+		return _failure(&"unknown_item", {"item": item})
+	if not can_sell(world.data, item):
+		return _failure(&"item_cannot_be_sold", {"item": item})
+	var owned: int = world.state.item_quantity(item)
+	if quantity < 1 or quantity > owned:
+		return _failure(&"invalid_sell_quantity", {
+			"item": item, "quantity": quantity, "owned": owned,
+		})
+	var balance: int = world.state.money(MONEY_ACCOUNT)
+	var total: int = sell_price(world.data, item, quantity)
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {item: owned - quantity},
+		"money": {
+			MONEY_ACCOUNT: mini(balance + total, Gen2WorldInventory.MAX_MONEY),
+		},
+	})
+	if not bool(applied.get("ok", false)):
+		return _failure(&"sale_state_failed", applied)
+	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {
+		"ok": true,
+		"item": item,
+		"name": String(definition.get("name", "UNKNOWN")),
+		"quantity": quantity,
+		"total": total,
+		"balance": world.state.money(MONEY_ACCOUNT),
+		"owned": owned - quantity,
 	}
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -92,6 +92,24 @@ const HAPPINESS_PROBABILITIES: Dictionary = {
 const STRING_BUFFER_1: Dictionary = {true: 0xD073, false: 0xCF6B}
 const HAPPINESS_TABLE_OVERRUN_OPCODE: int = 0x21
 
+## `RareCandyEffect` and `RestorePPEffect`'s own five. PP UP is the sixth and
+## has no branch: `ApplyPPUp` raises a ceiling the save model does not carry, so
+## the pack refuses it and says why (see `use_item`).
+const ITEM_RARE_CANDY: int = 0x20
+const ITEM_PP_UP: int = 0x3E
+const ITEM_ETHER: int = 0x3F
+const ITEM_MAX_ETHER: int = 0x40
+const ITEM_ELIXER: int = 0x41
+const ITEM_MAX_ELIXER: int = 0x15
+## `RestorePP.restore_some`'s own `ld c, 10`, and `.restore_all`, which the two
+## MAX rows take.
+const PP_RESTORE_STEP: int = 10
+const PP_RESTORE_ITEMS: Dictionary = {
+	ITEM_ETHER: false, ITEM_MAX_ETHER: false,
+	ITEM_ELIXER: true, ITEM_MAX_ELIXER: true,
+}
+const PP_RESTORE_MAX_ITEMS: Array[int] = [ITEM_MAX_ETHER, ITEM_MAX_ELIXER]
+
 const ITEM_BERRY: int = 0xAD
 const ITEM_BERRY_JUICE: int = 0x8B
 const SHUCKLE: int = 0xD5
@@ -381,12 +399,16 @@ static func _party_member(save: Gen2SaveData, index: int) -> Gen2SaveMon:
 ## Applies a field item to a save and the live world as one candidate transaction.
 ## The current slice covers source party item effects, including EvoStoneEffect's
 ## candidate evolution and the HP delta applied by EvolvePokemon.
+## [param move_slot] is `MoveSelectionScreen`'s answer, which only ETHER and MAX
+## ETHER ask for: those two refuse with `move_slot_required` until the caller has
+## one, the way [method teach_tm_hm] refuses with `moveset_full`.
 static func use_item(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
 	item: int,
 	party_index: int = -1,
-	persist: bool = true
+	persist: bool = true,
+	move_slot: int = -1
 ) -> Dictionary:
 	if world == null or save == null or world.data == null:
 		return _failure(&"missing_save", {})
@@ -396,7 +418,9 @@ static func use_item(
 	if not bool(opened.get("ok", false)):
 		return _failure(StringName(opened["reason"]), opened.get("details", {}))
 	var candidate: Gen2SaveData = opened["candidate"]
-	var effect: Dictionary = _apply_item_effect(world.data, candidate, item, party_index)
+	var effect: Dictionary = _apply_item_effect(
+		world.data, candidate, item, party_index, move_slot, world.map_time_of_day()
+	)
 	if not bool(effect.get("ok", false)):
 		return _failure(StringName(effect.get("reason", &"item_has_no_effect")), effect)
 	var before: Gen2WorldSnapshot = world.snapshot()
@@ -430,6 +454,8 @@ static func use_item(
 		"move_offers": effect.get("move_offers", []).duplicate(),
 		"bitter": bool(effect.get("bitter", false)),
 		"stat": String(effect.get("stat", "")),
+		"level": int(effect.get("level", 0)),
+		"restored": int(effect.get("restored", 0)),
 	}
 
 
@@ -1430,7 +1456,8 @@ static func _trade_gender_matches(
 
 
 static func _apply_item_effect(
-	data: GameData, save: Gen2SaveData, item: int, party_index: int
+	data: GameData, save: Gen2SaveData, item: int, party_index: int,
+	move_slot: int = -1, time_of_day: int = -1
 ) -> Dictionary:
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
@@ -1447,6 +1474,16 @@ static func _apply_item_effect(
 	var mon: Gen2SaveMon = save.party[party_index]
 	if mon == null or mon.is_egg:
 		return {"ok": false, "reason": &"invalid_party_member"}
+	if item == ITEM_RARE_CANDY:
+		return _apply_rare_candy(data, mon, time_of_day)
+	if PP_RESTORE_ITEMS.has(item):
+		return _apply_pp_restore(data, mon, item, move_slot)
+	if item == ITEM_PP_UP:
+		## `ApplyPPUp` raises `PP_UP_MASK`, the top two bits of a move's own PP
+		## byte, which [Gen2SaveMon] does not keep: its `pp` is the current value
+		## alone and every `max_pp` in the game is the move's base. Building this
+		## is a save-format addition.
+		return {"ok": false, "reason": &"pp_up_unsupported", "item": item}
 	var evolution: Dictionary = _apply_item_evolution(data, mon, item)
 	if not evolution.is_empty():
 		return evolution
@@ -1482,6 +1519,95 @@ static func _apply_item_effect(
 		"ok": true, "effect": &"party_item", "healed": healed,
 		"status_cleared": cleared,
 	})
+
+
+## `RareCandyEffect`: one level, `CalcExpAtLevel` back onto the experience,
+## `UpdateStatsAfterItem`'s max-HP delta added to the current HP,
+## `LevelUpHappinessMod`, `LearnLevelMoves` and then `EvolvePokemon` with
+## `wForceEvolution` clear. `MAX_LEVEL` is `NoEffectMessage` rather than a clamp.
+##
+## The happiness row is `HAPPINESS_GAINLEVEL` flat: `LevelUpHappinessMod`'s
+## at-home row compares the caught landmark against the *battle's* landmark, and
+## a field item is not in one.
+static func _apply_rare_candy(
+	data: GameData, mon: Gen2SaveMon, time_of_day: int
+) -> Dictionary:
+	if mon.level >= Gen2Experience.MAX_LEVEL:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	var before_max_hp: int = _max_hp(data, mon)
+	mon.level += 1
+	mon.exp = Gen2Experience.total_exp_at(
+		int(data.species(mon.species).get(
+			"growth_rate", Gen2Experience.GROWTH_MEDIUM_FAST
+		)), mon.level
+	)
+	mon.hp += maxi(0, _max_hp(data, mon) - before_max_hp)
+	mon.happiness = change_happiness(
+		data, mon.happiness, Gen2Battle.HAPPINESS_GAINLEVEL
+	)
+	## `LearnLevelMoves`: an empty slot takes the move unasked and a full moveset
+	## is what the caller has to open `ForgetMove` for.
+	var move_offers: Array[int] = []
+	for move: int in data.moves_learned_at(mon.species, mon.level):
+		if mon.moves.has(move):
+			continue
+		var empty: int = mon.moves.find(0)
+		if empty < 0:
+			move_offers.append(move)
+			continue
+		mon.moves[empty] = move
+		mon.pp[empty] = int(data.move(move).get("pp", 0))
+	var levelled: Dictionary = {
+		"ok": true, "effect": &"rare_candy", "level": mon.level,
+		"move_offers": move_offers,
+	}
+	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, mon)
+	if battle_mon == null or time_of_day < 0:
+		return levelled
+	var row: Dictionary = Gen2Evolution.level_evolution(data, battle_mon, time_of_day)
+	if row.is_empty():
+		return levelled
+	var evolved: Dictionary = apply_evolution(data, mon, row)
+	if evolved.is_empty():
+		return levelled
+	## `EvolvePokemon` runs behind the level-up box, so the caller owes both: the
+	## moves the level taught are already written and the evolution's own offers
+	## follow them.
+	var offers: Array = move_offers.duplicate()
+	offers.append_array(evolved.get("move_offers", []))
+	evolved["move_offers"] = offers
+	evolved["level"] = mon.level
+	return evolved
+
+
+## `RestorePPEffect`: MAX ETHER and MAX ELIXER fill a move, ETHER and ELIXER add
+## ten, and the two ELIXERs walk all four slots where the two ETHERs need the
+## slot `MoveSelectionScreen` chose. A move already at its ceiling is
+## `.dont_restore`, and nothing restored at all is `WontHaveAnyEffectMessage`.
+static func _apply_pp_restore(
+	data: GameData, mon: Gen2SaveMon, item: int, move_slot: int
+) -> Dictionary:
+	var all_moves: bool = bool(PP_RESTORE_ITEMS[item])
+	if not all_moves and (move_slot < 0 or move_slot >= Gen2SaveMon.MAX_MOVES):
+		return {"ok": false, "reason": &"move_slot_required", "item": item}
+	var full: bool = item in PP_RESTORE_MAX_ITEMS
+	var restored: int = 0
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		if not all_moves and slot != move_slot:
+			continue
+		var move: int = int(mon.moves[slot])
+		if move <= 0:
+			continue
+		var maximum: int = int(data.move(move).get("pp", 0))
+		var current: int = int(mon.pp[slot])
+		if current >= maximum:
+			continue
+		var next: int = maximum if full else mini(maximum, current + PP_RESTORE_STEP)
+		restored += next - current
+		mon.pp[slot] = next
+	if restored <= 0:
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	return {"ok": true, "effect": &"restore_pp", "restored": restored}
 
 
 ## `VitaminEffect`. The cap is a refusal rather than a clamp.

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -11,12 +11,12 @@ extends RefCounted
 ## boundary is [Gen2WorldTransaction], the same one the mart, Kurt and the bag
 ## go through.
 ##
-## Two of the source's rows are absent from the lists this returns rather than
-## offered and refused, because neither has anything behind it: HALL OF FAME is
-## `_HallOfFamePC`'s viewer over saved induction records and MAIL BOX is
-## `_PlayerMailBoxMenu`'s over `wMailbox`, and the save model keeps neither.
-## DECORATION is the third: `_PlayerDecorationMenu` browses the owned-decoration
-## flags, and [Gen2WorldState] holds only the four decorations already placed.
+## One of the source's rows is absent from the lists this returns rather than
+## offered and refused, because it has nothing behind it: MAIL BOX is
+## `_PlayerMailBoxMenu`'s over `wMailbox`, which the save model does not keep.
+## DECORATION is [Gen2WorldDecoration]'s and HALL OF FAME is
+## [Gen2HallOfFame]'s viewer over [member Gen2SaveData.hall_of_fame]; both are
+## offered.
 
 ## `PokemonCenterPC.Jumptable` indexes.
 const PCPCITEM_PLAYERS_PC: int = 0
@@ -53,10 +53,8 @@ const PLAYER_MARKER: String = "<PLAYER>"
 
 ## The rows above with nothing behind them, dropped from every list rather than
 ## offered and refused. See the class comment for what each needs first.
-const UNBUILT_TOP_MENU_ROWS: Array[int] = [PCPCITEM_HALL_OF_FAME]
-const UNBUILT_PLAYERS_PC_ROWS: Array[int] = [
-	PLAYERSPCITEM_MAIL_BOX, PLAYERSPCITEM_DECORATION,
-]
+const UNBUILT_TOP_MENU_ROWS: Array[int] = []
+const UNBUILT_PLAYERS_PC_ROWS: Array[int] = [PLAYERSPCITEM_MAIL_BOX]
 
 
 ## `_BillsPC.MenuData`'s five rows, in its `.Jumptable`'s own order. Inline menu
@@ -76,11 +74,10 @@ const BILLS_PC_ROWS: Array[String] = [
 const BILLS_PC_WHAT: String = "What?"
 const BILLS_PC_NEEDS_POKEMON: String = "You gotta have\n#MON to call!"
 
-## MOVE PKMN W/O MAIL is `_MovePKMNWithoutMail`, a screen of its own with its own
-## joypad (`MoveMonWithoutMail_DPad`) and its own save-before-you-start step; the
-## row is dropped rather than offered and refused, the way the three rows above
-## are.
-const UNBUILT_BILLS_PC_ROWS: Array[int] = [BILLSPCITEM_MOVE_WITHOUT_MAIL]
+## Every row of the machine's own menu is built: MOVE PKMN W/O MAIL is
+## [Gen2BoxScreen]'s `MODE_MOVE`, which is `_MovePKMNWithoutMail`'s own two
+## joypad passes over the same listing.
+const UNBUILT_BILLS_PC_ROWS: Array[int] = []
 
 
 ## The top menu behind BILL'S PC, as `{row, name}` in the source's own order.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2875,9 +2875,20 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 ## the player, asking for its pulse. The provider is the synthetic one below;
 ## everything else is the host's own path.
 func preview_visible_encounter() -> void:
+	_preview_visible_encounter(false)
+
+
+## The same population wearing an entry's own `glow` instead: ordinary DVs, so
+## the mark is the one a mod puts on a Pokemon worth stopping for rather than
+## the shiny's palette and sparkle.
+func preview_visible_encounter_glow() -> void:
+	_preview_visible_encounter(true)
+
+
+func _preview_visible_encounter(glow: bool) -> void:
 	if _world == null or _encounters == null or _renderer == null:
 		return
-	_encounters.set_providers([PreviewEncounters.new(_world)])
+	_encounters.set_providers([PreviewEncounters.new(_world, glow)])
 	advance_frames(2)
 	_script_prompt = "Debug visible encounter preview"
 	_renderer.refresh()
@@ -2888,10 +2899,14 @@ func preview_visible_encounter() -> void:
 class PreviewEncounters extends RefCounted:
 	## `CheckShininess`: the attack mask and three tens.
 	const SHINY_DVS: int = (2 << 12) | (10 << 8) | (10 << 4) | 10
+	## The light and the walk a glowing entry asks for, at the top rung so the
+	## picture is the mark at its strongest rather than a frame of a breath.
+	const GLOW_COLOR := Color(1.0, 0.87, 0.35)
+	const GLOW_AMOUNT: float = 0.5
 
 	var _entries: Array = []
 
-	func _init(world: Gen2WorldAPI) -> void:
+	func _init(world: Gen2WorldAPI, glow: bool = false) -> void:
 		var cells: Dictionary = world.visible_encounter_cells()
 		var tables: Dictionary = world.active_encounter_tables()
 		for method: Variant in cells:
@@ -2903,14 +2918,17 @@ class PreviewEncounters extends RefCounted:
 					nearest = cell
 			if nearest.x < 0 or slots.is_empty():
 				continue
-			_entries.append({
+			var entry: Dictionary = {
 				"id": StringName("preview_%s" % method),
 				"cell": Vector2i(nearest),
 				"species": int(slots[0]["species"]),
 				"level": int(slots[0]["min_level"]),
-				"dvs": SHINY_DVS,
-				"pulse": true,
-			})
+				"dvs": 0 if glow else SHINY_DVS,
+				"pulse": not glow,
+			}
+			if glow:
+				entry["glow"] = {"color": GLOW_COLOR, "amount": GLOW_AMOUNT}
+			_entries.append(entry)
 
 	func set_context(_context: Dictionary) -> void:
 		pass

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3283,6 +3283,56 @@ func preview_bills_pc() -> void:
 	_open_bills_pc()
 
 
+## Public screenshot drivers for the two PCs, whose cells no preview map has:
+## the Pokemon Center's machine and the bedroom's own item PC, which is the one
+## that carries DECORATION.
+## The machine's own list grows with the story, and its last row is postgame:
+## `.ChooseWhichPCListToUse` asks for the Pokedex and then the induction. Neither
+## has happened on a preview save, so this drives `halloffame`'s own two writes
+## first rather than photographing a list that is missing two of its rows.
+func preview_pokemon_center_pc() -> void:
+	var save: Gen2SaveData = _embedded_party_save()
+	if _world != null and save != null and save.hall_of_fame.is_empty():
+		_world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+		_world.state.set_hall_of_fame(true)
+		save.hall_of_fame = Gen2HallOfFame.inducted(save.hall_of_fame, save)
+	## `_embedded_party_save` builds a development save when nothing is injected,
+	## so the seeded one has to be the save the host is then handed.
+	_injected_save = save
+	_preview_pc(&"pokemon_center")
+
+
+func preview_players_pc() -> void:
+	_preview_pc(&"players_house")
+
+
+func _preview_pc(mode: StringName) -> void:
+	if _world == null or _data == null or _service_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "The PC preview needs a party"
+		_refresh_labels()
+		return
+	_injected_save = save
+	var host: Gen2WorldServiceScreen = SERVICE_SCENE.instantiate() as Gen2WorldServiceScreen
+	if host == null:
+		return
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	host.set_screen(_screen)
+	add_child(host)
+	if not host.open_pc_machine(_world, _data, save, false, mode):
+		Gen2Screen.drop(host)
+		return
+	host.completed.connect(_on_service_completed)
+	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
+	_service_host = host
+	_script_prompt = "PC open"
+	_refresh_labels()
+
+
 ## Public screenshot driver for `Mom_WithdrawDepositMenuJoypad`, whose box no
 ## fixture cell reaches: her house is not one of the preview maps and the dial
 ## stands three questions into her own routine.
@@ -4907,6 +4957,10 @@ func open_hall_of_fame() -> void:
 		_refresh_labels()
 		return
 	var pages: Array = Gen2HallOfFame.pages(_data, save, _world.state)
+	## `AddHallOfFameEntry` runs behind `SaveGameData` and in front of the
+	## animation, so the team is stored whether or not the player watches it;
+	## the snapshot itself is written when the sequence ends.
+	save.hall_of_fame = Gen2HallOfFame.inducted(save.hall_of_fame, save)
 	## No anchor preset: this is a child of the 160x144 Gen2Screen and sizes
 	## itself in native pixels, the way the story picture does.
 	var host := Gen2HallOfFameScreen.new()

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -541,12 +541,6 @@ const SEER_ADVICE: Array = [
 const CELEBI_SHRINE_PASSES: int = 160
 const CELEBI_SHRINE_FRAMES_PER_PASS: int = 2
 const VARIABLE_SPRITE_BASE: int = 0xF0
-const DECORATION_BLOCKS: Dictionary = {
-	&"bed": {0x02: 0x1B, 0x03: 0x1C, 0x04: 0x1D, 0x05: 0x1E},
-	&"carpet": {0x07: 0x08, 0x08: 0x0B, 0x09: 0x0E, 0x0A: 0x11},
-	&"plant": {0x0C: 0x20, 0x0D: 0x21, 0x0E: 0x22},
-	&"poster": {0x10: 0x1F, 0x11: 0x23, 0x12: 0x24, 0x13: 0x25},
-}
 
 
 static func begin(
@@ -2670,15 +2664,23 @@ const DECO_TOWN_MAP: int = 0x10
 const DECO_PIKACHU_POSTER: int = 0x11
 const DECO_CLEFAIRY_POSTER: int = 0x12
 const DECO_JIGGLYPUFF_POSTER: int = 0x13
+## Which `wDeco*` slot each of the three name-a-decoration descriptions reads.
+const DECODESC_SLOTS: Dictionary = {
+	DECODESC_LEFT_DOLL: Gen2WorldDecoration.SLOT_LEFT_ORNAMENT,
+	DECODESC_RIGHT_DOLL: Gen2WorldDecoration.SLOT_RIGHT_ORNAMENT,
+	DECODESC_CONSOLE: Gen2WorldDecoration.SLOT_CONSOLE,
+}
 
 
 func _stage_decoration_description(description: int) -> Dictionary:
 	match description:
 		DECODESC_POSTER:
-			var poster: int = state.maptile_decoration(&"poster") if state != null else 0
+			var poster: int = state.maptile_decoration(
+				Gen2WorldDecoration.SLOT_POSTER
+			) if state != null else 0
 			match poster:
 				DECO_TOWN_MAP:
-					_stage_internal_text("It's a town map.", false)
+					_stage_internal_text("It's the TOWN MAP.", false)
 					_pending["special_after_text"] = SPECIAL_OVERWORLD_TOWN_MAP
 					return {"ok": true}
 				DECO_PIKACHU_POSTER:
@@ -2688,11 +2690,16 @@ func _stage_decoration_description(description: int) -> Dictionary:
 				DECO_JIGGLYPUFF_POSTER:
 					return _stage_internal_text("It's a poster of a\ncute JIGGLYPUFF.", false)
 				_:
+					## `DecorationDesc_NullPoster` is an `end` and prints nothing.
 					return {"ok": true}
 		DECODESC_BIG_DOLL:
 			return _stage_internal_text("A giant doll! It's\nfluffy and cuddly.", false)
 		DECODESC_LEFT_DOLL, DECODESC_RIGHT_DOLL, DECODESC_CONSOLE:
-			return _stage_internal_text("It's an adorable decoration.", false)
+			## `DecorationDesc_OrnamentOrConsole` names whatever stands in that
+			## slot; the box is one text with the name written into it.
+			return _stage_internal_text("It's an adorable\n%s." % Gen2WorldDecoration.decoration_name(
+				data, state.maptile_decoration(DECODESC_SLOTS[description]) if state != null else 0
+			), false)
 	return _fail(&"invalid_decoration_description", {"description": description})
 
 
@@ -3312,19 +3319,28 @@ func _execute_special(special: int) -> Dictionary:
 				"decorations": state.maptile_decorations() if state != null else {},
 			})
 		SPECIAL_TOGGLE_DECORATIONS_VISIBILITY:
-			## With the default zero decoration selections, ToggleDecorationVisibility
-			## sets each object event flag and the renderer removes those objects.
-			for flag: int in [
-				EVENT_PLAYERS_HOUSE_2F_CONSOLE,
-				EVENT_PLAYERS_HOUSE_2F_DOLL_1,
-				EVENT_PLAYERS_HOUSE_2F_DOLL_2,
-				EVENT_PLAYERS_HOUSE_2F_BIG_DOLL,
-			]:
-				_staged_flags[flag] = true
+			## `ToggleDecorationVisibility` per slot: an empty slot sets the
+			## object's event flag and the renderer removes it, and a filled one
+			## clears the flag and writes the decoration's own variable sprite.
+			var shown: Dictionary = {}
+			for row: Dictionary in Gen2WorldDecoration.OBJECT_SLOTS:
+				var deco: int = state.maptile_decoration(
+					StringName(row["slot"])
+				) if state != null else 0
+				var sprite: int = int(data.decoration(deco).get("sprite", 0)) \
+					if data != null and deco > 0 else 0
+				_staged_flags[int(row["flag"])] = sprite <= 0
+				if sprite <= 0:
+					continue
+				shown[int(row["variable_sprite"])] = sprite
+				_emit_runtime_event(&"variable_sprite_changed", {
+					"variable_sprite": int(row["variable_sprite"]),
+					"sprite": sprite,
+				})
 			_emit_runtime_event(&"decoration_callback_applied", {
 				"special": special,
 				"kind": &"toggle_decorations_visibility",
-				"defaults": true,
+				"sprites": shown,
 			})
 		SPECIAL_SLOT_MACHINE:
 			return _stage_runtime_request(&"slot_machine_requested", {
@@ -3648,31 +3664,32 @@ func _execute_special(special: int) -> Dictionary:
 ## (engine/overworld/decorations.asm). Coordinates are changeblock coordinates;
 ## Gen2WorldAPI applies their padded-buffer conversion.
 func _apply_maptile_decorations() -> void:
-	var decorations: Dictionary = state.maptile_decorations() if state != null else {}
-	var bed_block: int = _decoration_block(&"bed", int(decorations.get(&"bed", 0)))
-	var plant_block: int = _decoration_block(&"plant", int(decorations.get(&"plant", 0)))
-	var poster_block: int = _decoration_block(&"poster", int(decorations.get(&"poster", 0)))
-	var carpet_block: int = _decoration_block(&"carpet", int(decorations.get(&"carpet", 0)))
-	if bed_block > 0:
-		_emit_runtime_event(&"map_block_changed", {"x": 0, "y": 4, "block": bed_block})
-	if plant_block > 0:
-		_emit_runtime_event(&"map_block_changed", {"x": 7, "y": 4, "block": plant_block})
-	if poster_block > 0:
-		_emit_runtime_event(&"map_block_changed", {"x": 6, "y": 0, "block": poster_block})
+	for slot: StringName in Gen2WorldDecoration.MAPTILE_AT:
+		var block: int = _decoration_block(slot)
+		if block <= 0:
+			continue
+		var at: Vector2i = Gen2WorldDecoration.MAPTILE_AT[slot]
+		_emit_runtime_event(&"map_block_changed", {"x": at.x, "y": at.y, "block": block})
+	var carpet_block: int = _decoration_block(Gen2WorldDecoration.SLOT_CARPET)
 	if carpet_block > 0:
-		for row: Dictionary in [
-			{"x": 0, "y": 0, "block": carpet_block},
-			{"x": 0, "y": 2, "block": carpet_block + 1},
-			{"x": 2, "y": 2, "block": carpet_block + 2},
-			{"x": 4, "y": 2, "block": carpet_block + 1},
-		]:
-			_emit_runtime_event(&"map_block_changed", row)
-	_staged_flags[EVENT_PLAYERS_ROOM_POSTER] = poster_block > 0
+		for row: int in Gen2WorldDecoration.CARPET_AT.size():
+			var at: Vector2i = Gen2WorldDecoration.CARPET_AT[row]
+			_emit_runtime_event(&"map_block_changed", {
+				"x": at.x, "y": at.y,
+				"block": carpet_block + Gen2WorldDecoration.CARPET_BLOCK_STEP[row],
+			})
+	## `SetPosterVisibility` is the one slot that also masks a bg event.
+	_staged_flags[EVENT_PLAYERS_ROOM_POSTER] = \
+		_decoration_block(Gen2WorldDecoration.SLOT_POSTER) > 0
 
 
-func _decoration_block(category: StringName, decoration: int) -> int:
-	var category_blocks: Dictionary = DECORATION_BLOCKS.get(category, {})
-	return int(category_blocks.get(decoration, 0))
+## `_GetDecorationSprite`: the block a slot's own decoration stamps, which is the
+## imported row's `DECOATTR_SPRITE`. Zero when the slot is empty.
+func _decoration_block(slot: StringName) -> int:
+	if state == null or data == null:
+		return 0
+	var deco: int = state.maptile_decoration(slot)
+	return int(data.decoration(deco).get("sprite", 0)) if deco > 0 else 0
 
 
 ## One `RomLayout.SPECIAL_TEXT_RUNS` box, with the buffers this runner has

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -29,6 +29,8 @@ enum MODE {
 	MENU, MART, PHONE, TOWN_MAP, CARD,
 	APRICORN, PC, PC_ITEMS, PC_ITEM_LIST, PC_TEXT, MOM_BANK,
 	PC_BOXES, PC_BOX_LIST,
+	PC_DECO, PC_DECO_LIST, PC_DECO_SIDE,
+	PC_BOX_SUBMENU,
 }
 
 ## `PokemonCenterPC`'s own box storage, which is the one row that opens a screen
@@ -62,6 +64,23 @@ const MART_LIST: StringName = &"list"
 const MART_QUANTITY: StringName = &"quantity"
 const MART_CONFIRM: StringName = &"confirm"
 const MART_MESSAGE: StringName = &"message"
+## `StandardMart`'s own jumptable, which only `MartDialog` runs: the BUY/SELL/QUIT
+## menu and the three states `SellMenu` adds behind its SELL row. The other four
+## shop types open `BuyMenu` and nothing else.
+const MART_TOP: StringName = &"top"
+const MART_SELL: StringName = &"sell"
+const MART_SELL_QUANTITY: StringName = &"sell_quantity"
+const MART_SELL_CONFIRM: StringName = &"sell_confirm"
+const MART_SELL_STAGES: Array[StringName] = [
+	MART_SELL, MART_SELL_QUANTITY, MART_SELL_CONFIRM,
+]
+## `MenuHeader_BuySell`'s three rows, inline in `engine/items/mart.asm` and
+## reached by no script, so they are this screen's the way [Gen2WorldPC]'s
+## BILL'S PC rows are.
+const MART_TOP_ROWS: Array[String] = ["BUY", "SELL", "QUIT"]
+const MART_TOP_BUY: int = 0
+const MART_TOP_SELL: int = 1
+const MART_TOP_QUIT: int = 2
 ## Which of `GetMartDialogGroup.MartTextFunctionPointers`' groups a variant
 ## reads. The rooftop sale takes the standard group, which is why it has no
 ## prefix of its own; the bargain shop's `MARTTEXT_HOW_MANY` slot is
@@ -72,6 +91,21 @@ const MART_TEXT_PREFIX: Dictionary = {
 }
 ## `PlayTransactionSound`, once the money has been taken.
 const SFX_TRANSACTION: int = 0x22
+## `BillsPC_PlaceEmptyBoxString_SFX`'s own `SFX_WRONG`.
+const SFX_WRONG: int = 0x19
+
+## `BillsPC_ChangeBoxSubmenu.MenuData`'s four rows, inline in `bills_pc.asm` and
+## reached by no script, so they are this screen's the way the machine's own top
+## menu is.
+const BOX_SUBMENU_SWITCH: int = 0
+const BOX_SUBMENU_NAME: int = 1
+const BOX_SUBMENU_PRINT: int = 2
+const BOX_SUBMENU_QUIT: int = 3
+const BOX_SUBMENU_ROWS: Array[String] = ["SWITCH", "NAME", "PRINT", "QUIT"]
+## `.NoMonString`, and `PrintPCBox` behind PRINT: with nothing on the link
+## `CheckPrinterStatus` leaves `wPrinterHandshake` at -1, which is the same
+## PRINTER_ERROR_2 the diploma and the Unown printer answer with.
+const BOX_EMPTY_TEXT: String = "There's no #MON."
 ## `Textbox`'s interior, which is what a mart box's words are wrapped to.
 const MART_TEXT_COLUMNS: int = 18
 const MART_TEXT_ROWS: int = 2
@@ -105,6 +139,9 @@ var _mart_scroll: int = 0
 var _mart_pages: Array = []
 var _mart_after: StringName = MART_LIST
 var _mart_confirm: int = 0
+## `SellMenu`'s own list, which is the pack rather than the shop's stock.
+var _mart_sell_entries: Array = []
+var _mart_top: int = MART_TOP_BUY
 var _apricorns: Gen2WorldApricorn = null
 var _mom_dial: Gen2WorldMoneyDial = null
 ## The same counted blink [Gen2TextBox]'s arrow is, since it is the same
@@ -135,7 +172,25 @@ var _pc_pages: Array = []
 var _pc_sfx: int = -1
 var _pc_after: StringName = &"top"
 var _pc_label: String = ""
+## `_PlayerDecorationMenu`: which category is open, the row waiting on
+## `DecoAction_AskWhichSide`, and `wChangedDecorations`, which is what makes the
+## machine close so the room can redraw.
+var _deco_slot: StringName = &""
+var _deco_pending: int = -1
+var _deco_changed: bool = false
+## Events this screen produced outside the request it is answering, which the
+## map's own callbacks are: they belong at the end of the same result list.
+var _extra_results: Array = []
 var _boxes: Gen2BoxScreen = null
+## `_HallOfFamePC`: the records the machine is walking and which one is up.
+## `LoadHOFTeam`'s carry is what a record with nothing in it answers, so an
+## empty team ends the walk rather than drawing a blank panel.
+var _hof: Gen2HallOfFameScreen = null
+## `BillsPC_ChangeBoxSubmenu`'s `wMenuSelection`, which is the box the list's
+## cursor was on rather than `wCurBox`, and the keyboard its NAME row opens.
+var _box_submenu_index: int = 0
+var _naming: Gen2NamingScreenScreen = null
+var _hof_index: int = 0
 ## `_ChangeBox_MenuHeader`'s `db 4, 0`: four rows of a scrolling list, and where
 ## the window into the fourteen boxes stands.
 const BOX_LIST_ROWS: int = 4
@@ -184,6 +239,12 @@ func set_screen(screen: Gen2Screen) -> void:
 
 ## Both views live in a screen this node may not own, so they go by hand.
 func _exit_tree() -> void:
+	if _hof != null:
+		Gen2Screen.drop(_hof)
+		_hof = null
+	if _naming != null:
+		Gen2Screen.drop(_naming)
+		_naming = null
 	for view: TextureRect in [_service_view, _mart_view]:
 		if view != null:
 			Gen2Screen.drop(view)
@@ -314,6 +375,10 @@ func handle_button(button: int) -> bool:
 		return _pokegear.handle_button(button)
 	## The box screen owns all 160x144 while BILL'S PC is open, the way the
 	## region map does, so the buttons are its own.
+	if _naming != null:
+		return _naming.handle_button(button)
+	if _hof != null:
+		return _hof.handle_button(button)
 	if _boxes != null:
 		return _boxes.handle_button(button)
 	if Gen2Button.is_direction(button):
@@ -407,7 +472,17 @@ func _open_mart(mart: Dictionary) -> void:
 		## Gen2Screen.display]'s z-order: the shop owns all 160x144 while it is
 		## up and the menu behind it is hidden anyway.
 		_service_hardware.display(_mart_view)
-	_show_mart_text(_mart_text("intro"), MART_LIST)
+	_mart_top = MART_TOP_BUY
+	_refresh_mart_sell_entries()
+	## `.HowMayIHelpYou` prints `MartWelcomeText` and hands the loop to
+	## `.TopMenu`; every other shop type prints its own intro over `BuyMenu`.
+	_show_mart_text(_mart_text("intro"), MART_TOP if _mart_standard() else MART_LIST)
+
+
+## Whether this shop is `MartDialog`'s, which is the one that runs
+## `StandardMart`'s BUY/SELL/QUIT loop rather than opening `BuyMenu` alone.
+func _mart_standard() -> bool:
+	return StringName(_mart_source().get("variant", &"")) == &"standard"
 
 
 ## One of the shop's own boxes, by the slot name its group gives it.
@@ -468,8 +543,11 @@ func _advance_mart_text() -> void:
 	if not _mart_pages.is_empty():
 		_render_mart()
 		return
-	if _mart_after == MART_LIST:
-		_mart_stage = MART_LIST
+	if _mart_after == MART_LIST or _mart_after == MART_TOP or _mart_after == MART_SELL:
+		_mart_stage = _mart_after
+		_cursor = 0
+		if _mart_after == MART_TOP:
+			_cursor = _mart_top
 		_render_mart()
 		return
 	_close_mart()
@@ -480,23 +558,28 @@ func _advance_mart_text() -> void:
 ## because `ScrollingMenu_InitFlags` adds it to the row count and `.d_down`
 ## stops scrolling at `size - height`.
 func _mart_row_count() -> int:
-	return _mart_entries.size() + 1 if _mart_entries.size() < Gen2MartPage.LIST_HEIGHT \
-		else Gen2MartPage.LIST_HEIGHT
+	var size: int = _mart_list().size()
+	return size + 1 if size < Gen2MartPage.LIST_HEIGHT else Gen2MartPage.LIST_HEIGHT
+
+
+## Whichever of the shop's stock and the player's pack the stage is showing.
+func _mart_list() -> Array:
+	return _mart_sell_entries if _mart_stage in MART_SELL_STAGES else _mart_entries
 
 
 func _mart_rows() -> Array:
+	var entries: Array = _mart_list()
 	var out: Array = []
 	for row: int in _mart_row_count():
 		var index: int = _mart_scroll + row
-		out.append(
-			{"cancel": true} if index >= _mart_entries.size() else _mart_entries[index]
-		)
+		out.append({"cancel": true} if index >= entries.size() else entries[index])
 	return out
 
 
 func _mart_selection() -> Dictionary:
+	var entries: Array = _mart_list()
 	var index: int = _mart_scroll + _cursor
-	return {} if index >= _mart_entries.size() else _mart_entries[index]
+	return {} if index >= entries.size() else entries[index]
 
 
 func _press_mart(button: int) -> void:
@@ -504,12 +587,20 @@ func _press_mart(button: int) -> void:
 		MART_MESSAGE:
 			if button in [Gen2Button.A, Gen2Button.B]:
 				_advance_mart_text()
+		MART_TOP:
+			_press_mart_top(button)
 		MART_LIST:
 			_press_mart_list(button)
 		MART_QUANTITY:
 			_press_mart_quantity(button)
 		MART_CONFIRM:
 			_press_mart_confirm(button)
+		MART_SELL:
+			_press_mart_sell_list(button)
+		MART_SELL_QUANTITY:
+			_press_mart_sell_quantity(button)
+		MART_SELL_CONFIRM:
+			_press_mart_sell_confirm(button)
 
 
 func _press_mart_list(button: int) -> void:
@@ -550,7 +641,7 @@ func _move_mart_cursor(delta: int) -> void:
 		if _mart_scroll > 0:
 			_mart_scroll -= 1
 	elif next >= rows:
-		if _mart_entries.size() >= _mart_scroll + Gen2MartPage.LIST_HEIGHT:
+		if _mart_list().size() >= _mart_scroll + Gen2MartPage.LIST_HEIGHT:
 			_mart_scroll += 1
 	else:
 		_cursor = next
@@ -639,8 +730,174 @@ func _buy_mart_selection() -> void:
 	}), MART_LIST)
 
 
+## B off the buy or sell list. `.Buy` and `.Sell` both fall into
+## `.AnythingElse`, so a standard shop asks again rather than saying goodbye;
+## only `.Quit` and the four single-list shop types print the come-again box.
 func _leave_mart() -> void:
+	if _mart_standard():
+		_show_mart_text(_mart_text("ask_more"), MART_TOP)
+		return
+	_quit_mart()
+
+
+func _quit_mart() -> void:
 	_show_mart_text(_mart_text("come_again"), &"exit")
+
+
+## `.TopMenu`'s three rows. `VerticalMenu` answers carry on B, which `.quit`
+## takes, so B is QUIT rather than a way back out of the shop.
+func _press_mart_top(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			_cursor = wrapi(_cursor - 1, 0, MART_TOP_ROWS.size())
+		Gen2Button.DOWN:
+			_cursor = wrapi(_cursor + 1, 0, MART_TOP_ROWS.size())
+		Gen2Button.B:
+			_quit_mart()
+			return
+		Gen2Button.A:
+			_mart_top = _cursor
+			match _cursor:
+				MART_TOP_BUY:
+					_mart_stage = MART_LIST
+					_cursor = 0
+					_mart_scroll = 0
+				MART_TOP_SELL:
+					_open_mart_sell()
+					return
+				_:
+					_quit_mart()
+					return
+	_render_mart()
+
+
+## `.Sell`: `DepositSellPack` over the whole pack. A pack with nothing sellable
+## in it answers `wPackUsedItem` zero at once, which is `SellMenu.quit`, so the
+## shop asks again rather than opening an empty list.
+func _open_mart_sell() -> void:
+	_refresh_mart_sell_entries()
+	if _mart_sell_entries.is_empty():
+		_show_mart_text(_mart_text("ask_more"), MART_TOP)
+		return
+	_mart_stage = MART_SELL
+	_cursor = 0
+	_mart_scroll = 0
+	_mart_quantity = 1
+	_render_mart()
+
+
+## The pack as rows this list can draw, at `GetMartPrice`'s halved price per
+## unit. `SellMenu.TryToSellItem` refuses a key item after it is chosen, so the
+## row is on offer and the refusal is `MartCantBuyText`.
+func _refresh_mart_sell_entries() -> void:
+	_mart_sell_entries = []
+	for pocket: Dictionary in Gen2WorldPack.build(_data, _world.state):
+		for row: Dictionary in pocket.get("items", []):
+			var item: int = int(row.get("item", 0))
+			_mart_sell_entries.append({
+				"item": item,
+				"name": String(row.get("name", "")),
+				"price": Gen2WorldMartHost.sell_price(_data, item),
+				"quantity": int(row.get("quantity", 0)),
+			})
+
+
+func _press_mart_sell_list(button: int) -> void:
+	match button:
+		Gen2Button.UP:
+			_move_mart_cursor(-1)
+		Gen2Button.DOWN:
+			_move_mart_cursor(1)
+		Gen2Button.B:
+			_leave_mart()
+		Gen2Button.A:
+			var entry: Dictionary = _mart_selection()
+			if entry.is_empty():
+				_leave_mart()
+				return
+			if not Gen2WorldMartHost.can_sell(_data, int(entry.get("item", 0))):
+				## `.try_sell`'s `_CheckTossableItem` refusal, which leaves the
+				## list up rather than ending the sale.
+				_show_mart_text(_mart_text("cant_buy"), MART_SELL)
+				return
+			_mart_quantity = 1
+			_mart_pages = Gen2TextLayout.lay_out(
+				_mart_text("sell_how_many"), MART_TEXT_COLUMNS, MART_TEXT_ROWS
+			)
+			_mart_stage = MART_SELL_QUANTITY
+			_render_mart()
+
+
+## `Toss_Sell_Loop` is the same dial the purchase uses, bounded by the stack the
+## player owns rather than by ninety-nine.
+func _press_mart_sell_quantity(button: int) -> void:
+	var maximum: int = maxi(1, int(_mart_selection().get("quantity", 1)))
+	match button:
+		Gen2Button.UP:
+			_mart_quantity = 1 if _mart_quantity >= maximum else _mart_quantity + 1
+		Gen2Button.DOWN:
+			_mart_quantity = maximum if _mart_quantity <= 1 else _mart_quantity - 1
+		Gen2Button.RIGHT:
+			_mart_quantity = mini(_mart_quantity + 10, maximum)
+		Gen2Button.LEFT:
+			_mart_quantity = maxi(_mart_quantity - 10, 1)
+		Gen2Button.B:
+			_mart_stage = MART_SELL
+		Gen2Button.A:
+			_mart_confirm = 0
+			_mart_stage = MART_SELL_CONFIRM
+			_mart_pages = Gen2TextLayout.lay_out(
+				_mart_text("sell_price", {
+					"total": Gen2WorldMartHost.sell_price(
+						_data, int(_mart_selection().get("item", 0)), _mart_quantity
+					),
+					"quantity": _mart_quantity,
+				}),
+				MART_TEXT_COLUMNS, MART_TEXT_ROWS
+			)
+	_render_mart()
+
+
+func _press_mart_sell_confirm(button: int) -> void:
+	match button:
+		Gen2Button.UP, Gen2Button.DOWN:
+			_mart_confirm = 1 - _mart_confirm
+		Gen2Button.B:
+			_mart_stage = MART_SELL
+		Gen2Button.A:
+			if _mart_confirm == 0:
+				_sell_mart_selection()
+				return
+			_mart_stage = MART_SELL
+	_render_mart()
+
+
+## The sale itself, and `MartBoughtText` behind it.
+func _sell_mart_selection() -> void:
+	var entry: Dictionary = _mart_selection()
+	var sold: Dictionary = Gen2WorldMartHost.sell(
+		_world, _save, int(entry.get("item", 0)), _mart_quantity, _persist
+	)
+	if not bool(sold.get("ok", false)):
+		var reason: StringName = StringName(sold.get("reason", &""))
+		if reason == &"item_cannot_be_sold":
+			_show_mart_text(_mart_text("cant_buy"), MART_SELL)
+			return
+		_status = "Sale failed: %s" % String(reason)
+		_mart_stage = MART_SELL
+		_render_mart()
+		return
+	sfx_requested.emit(SFX_TRANSACTION, true)
+	_refresh_mart_sell_entries()
+	_mart_scroll = mini(_mart_scroll, maxi(0, _mart_sell_entries.size() - 1))
+	_cursor = mini(_cursor, maxi(0, _mart_sell_entries.size() - _mart_scroll - 1))
+	_show_mart_text(
+		_mart_text("bought", {
+			"name": sold.get("name", ""), "quantity": _mart_quantity,
+			"total": int(sold.get("total", 0)),
+		}),
+		MART_SELL if not _mart_sell_entries.is_empty() else MART_TOP
+	)
 
 
 func _close_mart() -> void:
@@ -659,33 +916,51 @@ func _render_mart() -> void:
 		return
 	var page: PackedStringArray = _mart_pages[0] if not _mart_pages.is_empty() \
 		else PackedStringArray()
+	var selling: bool = _mart_stage in MART_SELL_STAGES
+	var listing: bool = _mart_stage == MART_LIST or _mart_stage == MART_SELL
 	var image: Image = _mart_page.render({
 		"money": _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
 		"rows": _mart_rows(),
-		"cursor": _cursor if _mart_stage == MART_LIST else -1,
+		"cursor": _cursor if listing else -1,
 		"scrolled": _mart_scroll > 0,
-		"text": "\n".join(page) if _mart_stage != MART_LIST else _mart_description(),
+		"text": "\n".join(page) if not listing else _mart_description(),
 		## `StandardMartAskPurchaseQuantity` closes the dial with `ExitMenu`
 		## before `MartConfirmPurchase` prints, so the box is the quantity
 		## stage's alone.
-		"quantity": _mart_quantity if _mart_stage == MART_QUANTITY else -1,
-		"subtotal": int(_mart_selection().get("price", 0)) * _mart_quantity,
+		"quantity": _mart_quantity \
+			if _mart_stage == MART_QUANTITY or _mart_stage == MART_SELL_QUANTITY else -1,
+		## `DisplaySellingPrice` halves the multiplied total, not each unit's
+		## price, so the two subtotals are not the same arithmetic.
+		"subtotal": Gen2WorldMartHost.sell_price(
+			_data, int(_mart_selection().get("item", 0)), _mart_quantity
+		) if selling else int(_mart_selection().get("price", 0)) * _mart_quantity,
 	})
 	if image == null:
 		return
-	if _mart_stage == MART_CONFIRM:
-		if _mart_menu_page == null:
-			_mart_menu_page = Gen2MenuPage.from_data(_data)
-		if _mart_menu_page != null:
-			var box: Gen2MenuBox = Gen2MenuBox.yes_no()
-			var menu: Image = _mart_menu_page.render(
-				box, ["YES", "NO"], _mart_confirm
-			)
-			image.blend_rect(
-				menu, Rect2i(Vector2i.ZERO, menu.get_size()),
-				box.border_position() * Gen2Font.TILE
-			)
+	if _mart_stage == MART_CONFIRM or _mart_stage == MART_SELL_CONFIRM:
+		_blend_mart_menu(image, Gen2MenuBox.yes_no(), ["YES", "NO"], _mart_confirm)
+	elif _mart_stage == MART_TOP:
+		## `MenuHeader_BuySell`'s `menu_coords 0, 0, 7, 8`.
+		_blend_mart_menu(
+			image,
+			Gen2MenuBox.from_coords(0, 0, 7, 8, Gen2MenuBox.STATICMENU_CURSOR),
+			MART_TOP_ROWS, _cursor
+		)
 	Gen2PicImage.show(_mart_view, image)
+
+
+func _blend_mart_menu(
+	image: Image, box: Gen2MenuBox, rows: Array, cursor: int
+) -> void:
+	if _mart_menu_page == null:
+		_mart_menu_page = Gen2MenuPage.from_data(_data)
+	if _mart_menu_page == null:
+		return
+	var menu: Image = _mart_menu_page.render(box, rows, cursor)
+	image.blend_rect(
+		menu, Rect2i(Vector2i.ZERO, menu.get_size()),
+		box.border_position() * Gen2Font.TILE
+	)
 
 
 ## `UpdateItemDescription`, which prints nothing for the CANCEL row.
@@ -875,6 +1150,29 @@ func open_bills_pc(
 	return true
 
 
+## `special PokemonCenterPC` and `special PlayersHousePC` without a script in
+## front of them, for the screenshot drivers: no preview map carries either cell.
+func open_pc_machine(
+	world: Gen2WorldAPI,
+	data: GameData,
+	save: Gen2SaveData,
+	persist: bool,
+	mode: StringName
+) -> bool:
+	_world = world
+	_data = data
+	_save = save
+	_persist = persist
+	if _world == null or _data == null:
+		_show_error("The PC has no world or cartridge cache.")
+		return false
+	if not Gen2WorldPC.can_open(_save):
+		_show_error("The PC needs a party.")
+		return false
+	_open_pc(mode)
+	return true
+
+
 ## `BillsPC_SeeYa`, and the `.LogOut` behind it: back to the machine's own top
 ## menu, or out of the host when nothing opened this but a start-menu action.
 func _leave_bills_pc() -> void:
@@ -913,6 +1211,7 @@ func _open_pc_items() -> void:
 	_mode = MODE.PC_ITEMS
 	_cursor = 0
 	_pc_action = -1
+	_deco_changed = false
 	_pc_rows = Gen2WorldPC.players_pc_menu(_data, _pc_house)
 	_title = _data.pokecenter_pc_row("players_pc").replace(
 		Gen2WorldPC.PLAYER_MARKER,
@@ -969,13 +1268,10 @@ func _confirm_pc_row() -> void:
 		return
 	var row: int = int(_pc_rows[_cursor].get("row", -1))
 	if _mode == MODE.PC_BOX_LIST:
-		## `BillsPC_ChangeBoxSubmenu`'s SWITCH, which is `wCurBox` and nothing
-		## else. The list stays up, the way `.loop` leaves it.
-		_box_index = clampi(row, 0, Gen2SaveData.BOX_COUNT - 1)
-		if _save != null:
-			_save.current_box = _box_index
-		_refresh_box_counts()
-		_render_rows()
+		_open_box_submenu(clampi(row, 0, Gen2SaveData.BOX_COUNT - 1))
+		return
+	if _mode == MODE.PC_BOX_SUBMENU:
+		_confirm_box_submenu(row)
 		return
 	if _mode == MODE.PC_BOXES:
 		match row:
@@ -985,8 +1281,27 @@ func _confirm_pc_row() -> void:
 				_open_boxes(Gen2BoxScreen.MODE_DEPOSIT)
 			Gen2WorldPC.BILLSPCITEM_CHANGE_BOX:
 				_open_box_list()
+			Gen2WorldPC.BILLSPCITEM_MOVE_WITHOUT_MAIL:
+				_open_boxes(Gen2BoxScreen.MODE_MOVE)
 			Gen2WorldPC.BILLSPCITEM_SEE_YA:
 				_leave_bills_pc()
+		return
+	if _mode == MODE.PC_DECO:
+		var slot: StringName = StringName(_pc_rows[_cursor].get("slot", &""))
+		if slot.is_empty():
+			_leave_decorations()
+		else:
+			_open_decoration_category(slot)
+		return
+	if _mode == MODE.PC_DECO_LIST:
+		_choose_decoration(int(_pc_rows[_cursor].get("deco", 0)))
+		return
+	if _mode == MODE.PC_DECO_SIDE:
+		var side: StringName = StringName(_pc_rows[_cursor].get("side", &""))
+		if side.is_empty():
+			_open_decoration_category(_deco_slot)
+		else:
+			_apply_decoration(_deco_pending, side)
 		return
 	if _mode == MODE.PC:
 		match row:
@@ -996,6 +1311,8 @@ func _confirm_pc_row() -> void:
 				_open_pc_items()
 			Gen2WorldPC.PCPCITEM_OAKS_PC:
 				_open_pc_oak()
+			Gen2WorldPC.PCPCITEM_HALL_OF_FAME:
+				_open_hall_of_fame(0)
 			Gen2WorldPC.PCPCITEM_TURN_OFF:
 				## `TurnOffPC` prints before `.shutdown` runs.
 				_open_pc_text(
@@ -1007,6 +1324,8 @@ func _confirm_pc_row() -> void:
 		Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM, \
 		Gen2WorldPC.PLAYERSPCITEM_TOSS_ITEM:
 			_open_pc_item_list(row)
+		Gen2WorldPC.PLAYERSPCITEM_DECORATION:
+			_open_decorations()
 		Gen2WorldPC.PLAYERSPCITEM_LOG_OFF:
 			_open_pc(&"pokemon_center")
 		Gen2WorldPC.PLAYERSPCITEM_TURN_OFF:
@@ -1084,6 +1403,96 @@ func _open_pc_oak() -> void:
 	_open_pc_text(boot["pages"], &"top", "PROF.OAK'S PC")
 
 
+## `_PlayerDecorationMenu`'s top menu: only a category the player owns something
+## in, and EXIT.
+func _open_decorations() -> void:
+	_mode = MODE.PC_DECO
+	_cursor = 0
+	_deco_slot = &""
+	_deco_pending = -1
+	_pc_rows = Gen2WorldDecoration.categories(_data, _world.state)
+	_title = _data.pokecenter_pc_row("decoration", true)
+	_summary = ""
+	_status = ""
+	_render_rows()
+
+
+## `PopulateDecoCategoryMenu`: the owned rows, the category's own PUT IT AWAY and
+## CANCEL, which the ornament list is too long to keep.
+func _open_decoration_category(slot: StringName) -> void:
+	var rows: Array = Gen2WorldDecoration.category_rows(_data, _world.state, slot)
+	if rows.is_empty():
+		## `.empty`'s own box. `categories()` drops a category with nothing in
+		## it, so this is only reached by a mod's list emptying under the menu.
+		_open_pc_text(
+			[Gen2WorldDecoration.TEXT_NOTHING_TO_CHOOSE], &"decoration", _title
+		)
+		return
+	_mode = MODE.PC_DECO_LIST
+	_cursor = 0
+	_deco_slot = slot
+	_pc_rows = rows
+	_summary = ""
+	_status = ""
+	_render_rows()
+
+
+## `DecoAction_AskWhichSide` stands between the ornament category and its action;
+## every other category runs straight into `DoDecorationAction2`.
+func _choose_decoration(deco: int) -> void:
+	if deco <= 0:
+		_open_decorations()
+		return
+	if not Gen2WorldDecoration.asks_side(_data, deco):
+		_apply_decoration(deco, &"")
+		return
+	_mode = MODE.PC_DECO_SIDE
+	_cursor = 0
+	_deco_pending = deco
+	_pc_rows = Gen2WorldDecoration.SIDE_ROWS.duplicate()
+	_summary = Gen2WorldDecoration.TEXT_WHICH_SIDE_PUT_AWAY \
+		if Gen2WorldDecoration.is_put_away(_data, deco) \
+		else Gen2WorldDecoration.TEXT_WHICH_SIDE_PUT_ON
+	_status = ""
+	_render_rows()
+
+
+func _apply_decoration(deco: int, side: StringName) -> void:
+	var applied: Dictionary = Gen2WorldDecoration.apply(
+		_world, _save, deco, side, _persist
+	)
+	if not bool(applied.get("ok", false)):
+		_status = "Refused: %s" % String(applied.get("reason", &""))
+		_render_rows()
+		return
+	_deco_changed = _deco_changed or bool(applied.get("changed", false))
+	## `PopulateDecoCategoryMenu` returns to `.top_loop` after one action, so a
+	## category list is opened once per visit rather than looped in.
+	var text: String = String(applied.get("text", ""))
+	if text.is_empty():
+		_open_decorations()
+		return
+	var pages: Array = []
+	for page: PackedStringArray in Gen2TextLayout.lay_out(
+		text, MART_TEXT_COLUMNS, MART_TEXT_ROWS
+	):
+		pages.append("\n".join(page))
+	_open_pc_text(pages, &"decoration", _title)
+
+
+## The way out of the decoration menu, which is the way out of the machine once
+## anything moved: `ToggleMaptileDecorations` and `ToggleDecorationsVisibility`
+## are map callbacks, so the room is only right after they have run again.
+func _leave_decorations() -> void:
+	if not _deco_changed:
+		_open_pc_items()
+		return
+	_deco_changed = false
+	_extra_results = _world.dispatch_callbacks(-1)
+	_world.load_object_masks()
+	_finish_runtime({"ok": true, "script_value": 0})
+
+
 ## A run of the PC's own boxes, acknowledged one at a time.
 func _open_pc_text(pages: Array, after: StringName, label: String) -> void:
 	_mode = MODE.PC_TEXT
@@ -1115,6 +1524,9 @@ func _advance_pc_text() -> void:
 	if _pc_after == &"close":
 		_finish_runtime({"ok": true, "script_value": 0})
 		return
+	if _pc_after == &"decoration":
+		_open_decorations()
+		return
 	_open_pc(&"pokemon_center")
 
 
@@ -1141,19 +1553,101 @@ func _open_bills_pc_menu() -> void:
 
 ## `_ChangeBox`'s scrolling list: every box by name, with what
 ## `BillsPC_PrintBoxCountAndCapacity` prints beside the one the cursor is on.
-## Its own submenu is SWITCH, NAME, PRINT and QUIT; NAME needs box names, which
-## the save model does not carry ([Gen2SaveBox]), and PRINT is `PrintPCBox`
-## behind them, so a row here is the SWITCH the source's default option is.
+## Choosing one opens `BillsPC_ChangeBoxSubmenu`.
 func _open_box_list() -> void:
 	_mode = MODE.PC_BOX_LIST
 	_cursor = _box_index
 	_pc_scroll = clampi(_box_index - BOX_LIST_ROWS + 1, 0, Gen2SaveData.BOX_COUNT - BOX_LIST_ROWS)
 	_pc_rows = []
 	for index: int in Gen2SaveData.BOX_COUNT:
-		_pc_rows.append({"row": index, "name": "BOX %d" % (index + 1)})
+		_pc_rows.append({
+			"row": index,
+			"name": _save.box_name(index) if _save != null else "BOX%d" % (index + 1),
+		})
 	_title = "CHANGE BOX"
 	_summary = "Choose a BOX."
 	_refresh_box_counts()
+	_render_rows()
+
+
+## `BillsPC_ChangeBoxSubmenu`: the four rows over whichever box the list's own
+## cursor was standing on, which is `wMenuSelection`.
+func _open_box_submenu(index: int) -> void:
+	_mode = MODE.PC_BOX_SUBMENU
+	_box_submenu_index = index
+	_cursor = BOX_SUBMENU_SWITCH
+	_pc_rows = []
+	for row: int in BOX_SUBMENU_ROWS.size():
+		_pc_rows.append({"row": row, "name": BOX_SUBMENU_ROWS[row]})
+	_summary = Gen2WorldPC.BILLS_PC_WHAT
+	_status = ""
+	_render_rows()
+
+
+func _confirm_box_submenu(row: int) -> void:
+	match row:
+		BOX_SUBMENU_SWITCH:
+			## `.Switch`: `wCurBox` and nothing else, and the box it is already
+			## on is a `ret z` rather than a second save.
+			if _box_submenu_index != _box_index:
+				_box_index = _box_submenu_index
+				if _save != null:
+					_save.current_box = _box_index
+			_open_box_list()
+		BOX_SUBMENU_NAME:
+			_open_box_naming()
+		BOX_SUBMENU_PRINT:
+			_print_box()
+		_:
+			_open_box_list()
+
+
+## `.Name`: `NamingScreen` with `NAME_BOX`, whose answer is written back over the
+## box's own name. The keyboard is the one the player's name and a nickname use.
+func _open_box_naming() -> void:
+	if _naming != null or _data == null or _save == null:
+		return
+	var host := Gen2NamingScreenScreen.new()
+	if not host.open(
+		_data, _save.box_name(_box_submenu_index),
+		Gen2NamingScreenScreen.KIND_BOX
+	):
+		host.free()
+		_status = "The naming keyboard is not in this cache."
+		_render_rows()
+		return
+	_naming = host
+	_set_overlay_open(true)
+	host.z_index = 5
+	host.closed.connect(_on_box_named)
+	_service_hardware.display(host)
+
+
+## `.Name`'s tail: whatever `NamingScreen_StoreEntry` left is written straight
+## back over the box's name, and an empty entry is the default name again rather
+## than a blank label.
+func _on_box_named(name: String) -> void:
+	if _naming != null:
+		Gen2Screen.drop(_naming)
+		_naming = null
+	_set_overlay_open(false)
+	if _save != null:
+		_save.set_box_name(_box_submenu_index, name)
+	_open_box_list()
+
+
+## `.Print`: `GetBoxCount` first, and then `PrintPCBox` over the box's own mons.
+## There is no printer on the link, so the send answers the same PRINTER_ERROR_2
+## the diploma and the Unown printer do.
+func _print_box() -> void:
+	var box: Gen2SaveBox = _save.boxes[_box_submenu_index] if _save != null \
+		and _box_submenu_index < _save.boxes.size() else null
+	if box == null or box.occupied_count() <= 0:
+		sfx_requested.emit(SFX_WRONG, true)
+		_status = BOX_EMPTY_TEXT
+		_render_rows()
+		return
+	_status = _data.printer_status_string(Gen2DiplomaScreen.STATUS_CONNECTION_ERROR)
 	_render_rows()
 
 
@@ -1199,6 +1693,42 @@ func _on_boxes_cry(species: int) -> void:
 
 ## `Gen2BoxScreen.closed` carries the result its own host would have resumed a
 ## script with; nothing is waiting here, because the PC's request is still open.
+## `_HallOfFamePC.MasterLoop`: one stored team at a time, newest first, until
+## `LoadHOFTeam` runs out of records or B leaves. The panels are the induction's
+## own, which is why this opens the same screen the sequence does.
+func _open_hall_of_fame(index: int) -> void:
+	var records: Array = _save.hall_of_fame if _save != null else []
+	var pages: Array = Gen2HallOfFame.record_pages(
+		_data, records[index]
+	) if index >= 0 and index < records.size() else []
+	if pages.is_empty():
+		## `.absent` and `.invalid` both answer carry, which `.MasterLoop` takes
+		## straight back to the machine's own menu.
+		_open_pc(&"pokemon_center")
+		return
+	var host := Gen2HallOfFameScreen.new()
+	host.viewer = true
+	host.set_context(_data, pages)
+	_hof = host
+	_hof_index = index
+	_set_overlay_open(true)
+	host.z_index = 5
+	host.closed.connect(_on_hall_of_fame_closed)
+	_service_hardware.display(host)
+
+
+func _on_hall_of_fame_closed() -> void:
+	var cancelled: bool = _hof != null and _hof.cancelled
+	if _hof != null:
+		Gen2Screen.drop(_hof)
+		_hof = null
+	_set_overlay_open(false)
+	if cancelled:
+		_open_pc(&"pokemon_center")
+		return
+	_open_hall_of_fame(_hof_index + 1)
+
+
 func _on_boxes_closed(_result: Dictionary) -> void:
 	if _boxes != null:
 		Gen2Screen.drop(_boxes)
@@ -1502,7 +2032,10 @@ func _move_direction(direction: Vector2i) -> void:
 
 
 func _confirm() -> void:
-	if _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST]:
+	if _mode in [
+		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
+		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
+	]:
 		_confirm_pc_row()
 		return
 	if _mode == MODE.PC_ITEM_LIST:
@@ -1527,6 +2060,9 @@ func _cancel() -> void:
 		_leave_bills_pc()
 	elif _mode == MODE.PC_BOX_LIST:
 		_open_bills_pc_menu()
+	elif _mode == MODE.PC_BOX_SUBMENU:
+		## `VerticalMenu`'s carry, which `.ret c` takes back to `.loop`.
+		_open_box_list()
 	elif _mode == MODE.PC:
 		## `.shutdown`: B off the top menu is the same shut-down TURN OFF is.
 		_finish_runtime({"ok": true, "script_value": 0})
@@ -1537,6 +2073,12 @@ func _cancel() -> void:
 			_open_pc(&"pokemon_center")
 	elif _mode == MODE.PC_ITEM_LIST:
 		_open_pc_items()
+	elif _mode == MODE.PC_DECO:
+		_leave_decorations()
+	elif _mode == MODE.PC_DECO_LIST:
+		_open_decorations()
+	elif _mode == MODE.PC_DECO_SIDE:
+		_open_decoration_category(_deco_slot)
 	elif _mode == MODE.PC_TEXT:
 		## Both `PromptButton` answers advance the box; neither leaves early.
 		_advance_pc_text()
@@ -1578,6 +2120,9 @@ func _finish_runtime(result: Dictionary) -> void:
 
 
 func _finish(results: Array) -> void:
+	if not _extra_results.is_empty():
+		results.append_array(_extra_results)
+		_extra_results = []
 	_mode = -1
 	_close_mart()
 	completed.emit(results)
@@ -1598,7 +2143,11 @@ func _render_rows(override: Array = []) -> void:
 		return
 	var values: Array = override if not override.is_empty() else (
 		_choices if _mode == MODE.MENU \
-		else _pc_rows if _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES] \
+		else _pc_rows if _mode in [
+			MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES,
+			MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
+			MODE.PC_BOX_SUBMENU,
+		] \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else ["Continue"]
 	)
@@ -1680,10 +2229,20 @@ func _service_box() -> Gen2MenuBox:
 			if _menu == null or _menu.kind == &"spinner":
 				return null
 			return _menu.box()
-		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES:
+		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_DECO_LIST:
 			return _pc_top_box()
+		MODE.PC_DECO:
+			return _deco_category_box()
+		MODE.PC_DECO_SIDE:
+			return _deco_side_box()
 		MODE.PC_BOX_LIST:
 			return _pc_box_list_box()
+		MODE.PC_BOX_SUBMENU:
+			## `.MenuHeader`'s `menu_coords 11, 4, SCREEN_WIDTH - 1, 13`, raised
+			## two rows: the change-box screen it is drawn over on the cartridge
+			## has its own words at rows 14 to 17, and this panel's box is at 11,
+			## which the source's corner would put QUIT behind.
+			return Gen2MenuBox.from_coords(11, 2, 19, 11, Gen2MenuBox.STATICMENU_CURSOR)
 		MODE.PC_ITEM_LIST:
 			return _pc_item_list_box()
 		MODE.APRICORN:
@@ -1712,6 +2271,19 @@ func _pc_box_list_box() -> Gen2MenuBox:
 	return box
 
 
+## `_PlayerDecorationMenu.MenuHeader`'s `menu_coords 5, 0, SCREEN_WIDTH - 1,
+## SCREEN_HEIGHT - 1`.
+func _deco_category_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		5, 0, 19, 17, Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
+	)
+
+
+## `DecoSideMenuHeader`'s `menu_coords 0, 0, 13, 7`.
+func _deco_side_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(0, 0, 13, 7, Gen2MenuBox.STATICMENU_CURSOR)
+
+
 ## `PCItemsMenuData`'s `menu_coords 4, 1, 18, 10`.
 func _pc_item_list_box() -> Gen2MenuBox:
 	return Gen2MenuBox.from_coords(4, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
@@ -1732,7 +2304,10 @@ func _apricorn_quantity_box() -> Gen2MenuBox:
 func _option_count() -> int:
 	if _mode == MODE.MENU:
 		return _menu.options.size() if _menu != null else _choices.size()
-	if _mode in [MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST]:
+	if _mode in [
+		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
+		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
+	]:
 		return _pc_rows.size()
 	if _mode == MODE.PC_ITEM_LIST:
 		return maxi(1, _pc_entries.size())

--- a/game/world/world_spawn.gd
+++ b/game/world/world_spawn.gd
@@ -12,6 +12,10 @@ const START_MONEY: int = 3000
 ## InitDecorations (engine/overworld/decorations.asm): DECO_FEATHERY_BED and
 ## DECO_TOWN_MAP. The other two maptile slots remain zero.
 const INITIAL_MAPTILE_DECORATIONS: Dictionary = {&"bed": 0x02, &"poster": 0x10}
+## `InitializeEventsScript` owns the two flags that say the player *has* those
+## two, which is what puts them on `_PlayerDecorationMenu`'s own lists:
+## `EVENT_DECO_BED_1` and `EVENT_DECO_POSTER_1`.
+const INITIAL_DECORATION_FLAGS: Array[int] = [676, 687]
 
 
 static func new_game_snapshot(data: GameData) -> Gen2WorldSnapshot:
@@ -45,3 +49,5 @@ static func apply_initial_decorations(state: Gen2WorldState) -> void:
 		state.set_maptile_decoration(
 			category, int(INITIAL_MAPTILE_DECORATIONS[category])
 		)
+	for flag: int in INITIAL_DECORATION_FLAGS:
+		state.set_event_flag(flag, true)

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -235,8 +235,14 @@ var _radio_channel: int = -1
 ## and `wRadioTuningKnob` rather than in the Pokedex's own cleared block: the
 ## dex takes its mode from here on opening and writes the mode back on exit.
 var _last_dex_mode: int = RomLayout.DEXMODE_NEW
-## wDecoBed, wDecoCarpet, wDecoPlant and wDecoPoster. Values are decoration
-## ids from data/decorations/decorations.asm, not the blocks they stamp.
+## The eight `wDeco*` slots, four of which stamp a block into the bedroom and
+## four of which fill a variable sprite. Values are decoration ids from
+## data/decorations/decorations.asm, not the blocks or sprites they stamp.
+## [Gen2WorldDecoration] owns what each one means.
+const MAPTILE_DECORATION_SLOTS: Array[StringName] = [
+	&"bed", &"carpet", &"plant", &"poster",
+	&"console", &"big_doll", &"left_ornament", &"right_ornament",
+]
 var _maptile_decorations: Dictionary = {}
 ## `wKurtApricornQuantity`. Saved player data, not scratch: `SelectApricornForKurt`
 ## writes it and `VAR_KURT_APRICORNS` is read a day later, by a different script
@@ -348,7 +354,7 @@ func _init(
 		var value: int = int(initial_script_memory[raw_address]) & 0xFF
 		if address > 0 and value != 0 and _script_memory.size() < SCRIPT_MEMORY_CAPACITY:
 			_script_memory[address] = value
-	for category: StringName in [&"bed", &"carpet", &"plant", &"poster"]:
+	for category: StringName in MAPTILE_DECORATION_SLOTS:
 		var decoration: int = int(initial_maptile_decorations.get(category, 0))
 		if decoration > 0 and decoration <= 0xFF:
 			_maptile_decorations[category] = decoration
@@ -604,7 +610,7 @@ func maptile_decorations() -> Dictionary:
 
 
 func set_maptile_decoration(category: StringName, decoration: int) -> bool:
-	if category not in [&"bed", &"carpet", &"plant", &"poster"] \
+	if category not in MAPTILE_DECORATION_SLOTS \
 		or decoration < 0 or decoration > 0xFF:
 		return false
 	if maptile_decoration(category) == decoration:

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -373,9 +373,18 @@ class Population:
 	## is allowed on at all.
 	const POPULATION: int = 3
 
+	## The light an entry's own colours are walked toward, and how far, on the
+	## breath below. `api_version` 15: the host rounds the amount onto
+	## `Gen2WorldEncounters.GLOW_RUNGS` and applies it where it already resolves
+	## the species' palette, so nothing here draws a pixel and both views get it.
+	const GLOW_COLOR := Color(1.0, 0.87, 0.35)
+	const GLOW_PEAK: float = 0.5
+	const GLOW_PERIOD_FRAMES: int = 48
+
 	var _context: Dictionary = {}
 	var _entries: Array = []
 	var _generation: int = -1
+	var _frame: int = 0
 
 	func set_context(context: Dictionary) -> void:
 		_context = context
@@ -386,8 +395,17 @@ class Population:
 		_generation = int(context.get("generation", -1))
 		_repopulate()
 
+	## A raised cosine over `GLOW_PERIOD_FRAMES`, so a wanderer breathes gold
+	## rather than wearing a badge. Send whatever curve you like: what reaches
+	## the palette is the nearest of the host's own rungs, and an amount that
+	## rounds to nothing carries no glow at all.
 	func advance_frame() -> void:
-		pass
+		_frame += 1
+		var phase: float = TAU * float(_frame % GLOW_PERIOD_FRAMES) \
+			/ float(GLOW_PERIOD_FRAMES)
+		var amount: float = 0.5 * (1.0 - cos(phase)) * GLOW_PEAK
+		for entry: Dictionary in _entries:
+			entry["glow"] = {"color": GLOW_COLOR, "amount": amount}
 
 	func encounters() -> Array:
 		return _entries

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 14,
+	"api_version": 15,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the five read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, battle annotations and a start-menu row that opens the host's own storage."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 14,
+	"api_version": 15,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -54,6 +54,25 @@ func _queue_service() -> void:
 	await get_tree().process_frame
 
 
+## `StandardMart` opens on `.TopMenu`, so every buy in this file starts by
+## taking its BUY row. `.Quit` and B are the way out of the shop now; B off the
+## buy list is `.AnythingElse`.
+func _enter_mart_buy(host: Gen2WorldServiceScreen) -> void:
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
+
+
+## B until the shop is shut. The synthetic cache carries none of the mart's own
+## words, so `.AnythingElse`'s box and `MartComeAgainText` each advance without a
+## press and only the two B's are spent.
+func _quit_mart(host: Gen2WorldServiceScreen) -> void:
+	if host._mart_stage != Gen2WorldServiceScreen.MART_TOP:
+		assert_true(host.handle_button(Gen2Button.B))
+		assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_true(host.handle_button(Gen2Button.B))
+
+
 func _write_pc_request() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
 	scripts["48:6190"] = [Gen2WorldScript.SPECIAL, 29, 0, Gen2WorldScript.END]
@@ -84,6 +103,7 @@ func test_players_house_pc_opens_the_item_pc_and_resumes_the_waiting_script() ->
 		Gen2WorldPC.PLAYERSPCITEM_WITHDRAW_ITEM,
 		Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM,
 		Gen2WorldPC.PLAYERSPCITEM_TOSS_ITEM,
+		Gen2WorldPC.PLAYERSPCITEM_DECORATION,
 		Gen2WorldPC.PLAYERSPCITEM_TURN_OFF,
 	])
 
@@ -102,9 +122,98 @@ func test_players_house_pc_opens_the_item_pc_and_resumes_the_waiting_script() ->
 	assert_false(_world_screen._world.script_input_waiting())
 
 
+## `BillsPC_ChangeBoxSubmenu`: SWITCH writes `wCurBox`, NAME opens the keyboard
+## over `sBoxNames`, and PRINT answers `GetBoxCount` before it reaches the
+## printer that is not there.
+func test_change_box_switches_names_and_prints_a_box() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
+	for _step: int in 2:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
+
+	## The second box, then SWITCH.
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_SUBMENU)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
+	assert_eq(host._box_index, 1)
+	assert_eq(host._save.current_box, 1)
+
+	## PRINT over an empty box is `.EmptyBox` rather than a send.
+	host.handle_button(Gen2Button.A)
+	for _step: int in 2:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._status, Gen2WorldServiceScreen.BOX_EMPTY_TEXT)
+
+	## NAME opens the keyboard, and what it stores is what the list draws. The
+	## submenu is still up with its cursor on PRINT, so one row back reaches it.
+	host.handle_button(Gen2Button.UP)
+	host.handle_button(Gen2Button.A)
+	assert_not_null(host._naming, host._status)
+	host._on_box_named("KANTO")
+	await get_tree().process_frame
+	assert_null(host._naming)
+	assert_eq(host._save.box_name(1), "KANTO")
+	assert_eq(String(host._pc_rows[1]["name"]), "KANTO")
+
+
+## `_HallOfFamePC.MasterLoop`: one stored team at a time, and B is the way out.
+func test_the_hall_of_fame_row_walks_the_stored_records() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	host._save.hall_of_fame = Gen2HallOfFame.inducted([], host._save)
+	host._world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+	host._world.state.set_hall_of_fame(true)
+	host._open_pc(&"pokemon_center")
+	var rows: Array = []
+	for row: Dictionary in host._pc_rows:
+		rows.append(int(row["row"]))
+	assert_true(Gen2WorldPC.PCPCITEM_HALL_OF_FAME in rows)
+
+	host._cursor = rows.find(Gen2WorldPC.PCPCITEM_HALL_OF_FAME)
+	host.handle_button(Gen2Button.A)
+	assert_not_null(host._hof)
+	assert_eq(host._hof.remaining(), host._save.hall_of_fame[0]["mons"].size())
+	assert_eq(
+		int(host._hof.current_page()["win_count"]),
+		Gen2HallOfFame.win_count(host._save.hall_of_fame)
+	)
+
+	## B leaves the machine's own loop rather than the record.
+	host.handle_button(Gen2Button.B)
+	await get_tree().process_frame
+	assert_null(host._hof)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
+
+
 ## `PokemonCenterPC`'s top menu, whose BILL'S PC row is the box screen the
 ## bedroom's PC used to open.
 func test_pokemon_center_pc_opens_the_top_menu_and_bills_pc_behind_it() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
+	assert_eq(int(host._pc_rows[0]["row"]), Gen2WorldPC.PCPCITEM_BILLS_PC)
+
+	## `_BillsPC`'s own top menu stands between the machine and the lists, and
+	## its DEPOSIT row is what opens the party one.
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
+	assert_eq(int(host._pc_rows[0]["row"]), Gen2WorldPC.BILLSPCITEM_WITHDRAW)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	await _finish_pokemon_center_pc(host)
+
+
+## `special PokemonCenterPC` from a coord event, which is how every test above
+## reaches the machine.
+func _open_pokemon_center_pc() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
 	scripts["48:6195"] = [
 		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_POKEMON_CENTER_PC, 0,
@@ -121,18 +230,10 @@ func test_pokemon_center_pc_opens_the_top_menu_and_bills_pc_behind_it() -> void:
 	_world_screen._show_script_results(waiting)
 	await get_tree().process_frame
 
-	var host: Gen2WorldServiceScreen = _world_screen._service_host
-	assert_not_null(host)
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
-	assert_eq(int(host._pc_rows[0]["row"]), Gen2WorldPC.PCPCITEM_BILLS_PC)
 
-	## `_BillsPC`'s own top menu stands between the machine and the lists, and
-	## its DEPOSIT row is what opens the party one.
-	host.handle_button(Gen2Button.A)
-	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
-	assert_eq(int(host._pc_rows[0]["row"]), Gen2WorldPC.BILLSPCITEM_WITHDRAW)
-	host.handle_button(Gen2Button.DOWN)
-	host.handle_button(Gen2Button.A)
+## The DEPOSIT list `_BillsPC` opened, closed, and then B twice: off the
+## machine's own menu that is SEE YA!, and off the top one it shuts the PC down.
+func _finish_pokemon_center_pc(host: Gen2WorldServiceScreen) -> void:
 	var boxes: Gen2BoxScreen = host._boxes
 	assert_not_null(boxes)
 	assert_eq(int(boxes.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
@@ -142,7 +243,6 @@ func test_pokemon_center_pc_opens_the_top_menu_and_bills_pc_behind_it() -> void:
 	assert_null(host._boxes)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
 
-	## B off the top menu is SEE YA!, and B off the machine's own shuts it down.
 	host.handle_button(Gen2Button.B)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
 	host.handle_button(Gen2Button.B)
@@ -160,7 +260,7 @@ func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 	## `BuyMenu` owns the whole screen, so this host's own layer steps aside.
 	assert_false(host._service_view.visible)
 	assert_not_null(host._mart_view)
-	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
+	_enter_mart_buy(host)
 	## One item and CANCEL, which is the row `ScrollingMenu` draws past the
 	## list's own terminator.
 	assert_eq(host._mart_rows().size(), 2)
@@ -175,7 +275,7 @@ func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 	assert_eq(_world_screen._world.state.item_quantity(7), 2)
 	assert_true(host.is_active())
 
-	assert_true(host.handle_button(Gen2Button.B))
+	_quit_mart(host)
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_false(_world_screen._world.script_input_waiting())
@@ -192,6 +292,7 @@ func test_a_registered_mart_row_is_bought_through_the_regular_transaction() -> v
 	assert_eq(host._mart_entries.size(), 2)
 	assert_eq(int(host._mart_entries[1]["item"]), 8)
 	assert_eq(int(host._mart_entries[1]["price"]), 25)
+	_enter_mart_buy(host)
 	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	host.handle_button(Gen2Button.A)
@@ -206,6 +307,7 @@ func test_mart_overlay_purchases_the_selected_quantity() -> void:
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
 	assert_not_null(host)
+	_enter_mart_buy(host)
 	assert_true(host.handle_button(Gen2Button.A))
 	## `BuySellToss_InterpretJoypad`: ten on right, one on down, and down off one
 	## wraps to `wItemQuantity` rather than stopping.
@@ -225,7 +327,7 @@ func test_mart_overlay_purchases_the_selected_quantity() -> void:
 	assert_eq(_world_screen._world.state.item_quantity(7), 3)
 	assert_true(host.is_active())
 
-	assert_true(host.handle_button(Gen2Button.B))
+	_quit_mart(host)
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 	assert_false(_world_screen._world.script_input_waiting())
@@ -244,6 +346,7 @@ func test_a_purchase_plays_its_sound_through_the_world_driver() -> void:
 	host.sfx_requested.connect(
 		func(index: int, _waited: bool) -> void: played.append(index)
 	)
+	_enter_mart_buy(host)
 	assert_true(host.handle_button(Gen2Button.A))
 	assert_true(host.handle_button(Gen2Button.A))
 	assert_true(host.handle_button(Gen2Button.A))
@@ -261,6 +364,7 @@ func test_mart_overlay_refuses_without_taking_money() -> void:
 	await _queue_service()
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	_enter_mart_buy(host)
 	assert_true(host.handle_button(Gen2Button.A))
 	assert_true(host.handle_button(Gen2Button.B))
 	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
@@ -275,16 +379,56 @@ func test_mart_overlay_refuses_without_taking_money() -> void:
 	assert_eq(_world_screen._world.state.item_quantity(7), 1)
 
 
-## The CANCEL row leaves the same way B does.
-func test_mart_overlay_cancel_row_leaves_the_shop() -> void:
+## The CANCEL row leaves the buy list the same way B does, which on a standard
+## shop is `.AnythingElse` rather than the door.
+func test_mart_overlay_cancel_row_leaves_the_buy_list() -> void:
 	await _open_world()
 	await _queue_service()
 
 	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	_enter_mart_buy(host)
 	assert_true(host.handle_button(Gen2Button.DOWN))
 	assert_eq(host.selected_index(), 1)
 	assert_true(host._mart_selection().is_empty())
 	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_true(host.handle_button(Gen2Button.B))
+	await get_tree().process_frame
+	assert_null(_world_screen._service_host)
+
+
+## `StandardMart`'s SELL row: `DepositSellPack` over the pack, the halved price
+## and `MartBoughtText`.
+func test_mart_overlay_sells_a_stack_at_half_price() -> void:
+	await _open_world({7: 2})
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_true(host.handle_button(Gen2Button.DOWN))
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_SELL)
+	assert_eq(host._mart_sell_entries.size(), 1, JSON.stringify(host._mart_sell_entries))
+	assert_eq(int(host._mart_sell_entries[0]["price"]), 60)
+
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_SELL_QUANTITY)
+	## The dial is bounded by the stack, so up off the last one wraps to one.
+	assert_true(host.handle_button(Gen2Button.UP))
+	assert_eq(host._mart_quantity, 2)
+	assert_true(host.handle_button(Gen2Button.UP))
+	assert_eq(host._mart_quantity, 1)
+	assert_true(host.handle_button(Gen2Button.UP))
+
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_SELL_CONFIRM)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(_world_screen._world.state.item_quantity(7), 0)
+	assert_eq(_world_screen._world.state.money(), 620)
+
+	## An empty pack has nothing left to sell, so the box lands on the top menu.
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_true(host.handle_button(Gen2Button.B))
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host)
 
@@ -596,6 +740,9 @@ func _write_service_cache() -> void:
 		if int(raw.get("number", 0)) == 7:
 			raw["name"] = "ITEM7"
 			raw["price"] = 120
+			## `SellMenu` reads the pack rather than the shop's stock, and
+			## `Gen2WorldPack.build` groups by the item's own type byte.
+			raw["pocket"] = Gen2WorldPack.TYPE_ITEM
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 	RomCache.write_json(RomCache.world_marts_path(Fixture.directory()), {
 		"marts": [{"index": 0, "bank": Fixture.BANK, "address": 0x4000, "items": [7]}],
@@ -728,3 +875,44 @@ func _write_request_script(script: Array, address: int) -> void:
 		events["coord_events"] = [{"x": 7, "y": 6, "script": address}]
 		raw["events"] = events
 	RomCache.write_json(RomCache.world_maps_path(Fixture.directory()), maps)
+
+
+## `_PlayerDecorationMenu` behind the bedroom PC's DECORATION row: the category
+## menu, one category's list, the action, and the machine closing on
+## `wChangedDecorations` so the room's own callbacks run again.
+func test_the_decoration_row_sets_a_decoration_up_and_closes_the_machine() -> void:
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	_world_screen._world.state.set_event_flag(676, true)
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_ITEMS)
+
+	## WITHDRAW, DEPOSIT, TOSS, then DECORATION.
+	for _step: int in 3:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_DECO)
+	assert_eq(host._pc_rows.size(), 2, JSON.stringify(host._pc_rows))
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_DECO_LIST)
+	assert_eq(int(host._pc_rows[0]["deco"]), Fixture.DECO_FEATHERY_BED)
+
+	## The bed, its box, and then EXIT off the category menu.
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_TEXT)
+	assert_eq(
+		_world_screen._world.state.maptile_decoration(Gen2WorldDecoration.SLOT_BED),
+		Fixture.DECO_FEATHERY_BED
+	)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_DECO)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_null(_world_screen._service_host, "a changed room closes the machine")
+	assert_false(_world_screen._world.script_input_waiting())

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -69,6 +69,25 @@ const CREDITS_BLOCK_INDEXES: int = 4
 const TRAINER_CLASS: int = 1
 const TRAINER_SPECIES: int = 16
 const TRAINER_SPRITE: int = 1
+## The decoration table's own length here, which is one past the second ornament
+## rather than the cartridge's fifty-three.
+const DECORATION_ROWS: int = 32
+## [id, action, event flag, block or sprite] per row the fixture fills. The ids
+## and the actions are the source's; the flags are `EVENT_DECO_*` and the last
+## column is a block for the first four categories and a sprite for the rest.
+const DECORATION_FIXTURE: Array[Array] = [
+	[1, 2, 0, 0], [2, 1, 676, 0x1B],
+	[6, 4, 0, 0], [7, 3, 680, 0x08],
+	[11, 6, 0, 0], [12, 5, 684, 0x20],
+	[15, 8, 0, 0], [16, 7, 687, 0x1F],
+	[20, 10, 0, 0], [21, 9, 691, 0x5C],
+	[25, 12, 0, 0], [26, 11, 719, 0x33],
+	[29, 14, 0, 0], [30, 13, 695, 0x8E], [31, 13, 696, 0x34],
+]
+## The two the fixture's own tests reach for by name.
+const DECO_FEATHERY_BED: int = 2
+const DECO_PIKACHU_DOLL: int = 30
+const DECO_SURF_PIKACHU_DOLL: int = 31
 
 
 ## Every caller but the Gold/Silver profile tests uses the default id, so the
@@ -96,6 +115,7 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_move_deleter_text(manifest)
 	_write_day_care_text(manifest)
 	_write_pokecenter_pc(manifest)
+	_write_decorations(manifest)
 	_write_unown_words(manifest)
 	_write_unown_puzzle(directory, manifest)
 	_write_slots(directory, manifest)
@@ -667,6 +687,25 @@ const SLOT_REELS: Array = [
 		0x04, 0x08, 0x10, 0x14, 0x0C, 0x00, 0x0C, 0x08,
 	],
 ]
+
+
+## `DecorationAttributes` in the shape a real cache carries: the seven category
+## headers at the ids the source gives them, one decoration behind each, and the
+## ornament category's second member, since two on one category is what
+## `DecoAction_AskWhichSide` and the CANCEL row's own cut-off need. The names are
+## the fixture's own.
+static func _write_decorations(manifest: Dictionary) -> void:
+	var attributes: Array = []
+	var names: Array = []
+	for deco: int in DECORATION_ROWS:
+		attributes.append({"type": 1, "name": deco, "action": 0, "flag": 0, "sprite": 0})
+		names.append("DECO%d" % deco)
+	for row: Array in DECORATION_FIXTURE:
+		attributes[int(row[0])] = {
+			"type": 1, "name": int(row[0]), "action": int(row[1]),
+			"flag": int(row[2]), "sprite": int(row[3]),
+		}
+	manifest["decorations"] = {"attributes": attributes, "names": names}
 
 
 static func _write_pokecenter_pc(manifest: Dictionary) -> void:

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -370,8 +370,21 @@ func test_the_shipped_example_mod_registers_everything_it_documents() -> void:
 	# 3: a named axis, whose two halves both registered rather than colliding
 	# with the cartridge's eight.
 	assert_eq(host.actions().size(), 2)
-	# 2: a visible-encounter population.
+	# 2: a visible-encounter population, and 15: its own glow, which is a field
+	# on the entry rather than anything the mod draws.
 	assert_eq(host.visible_encounter_ids().size(), 1)
+	var population: Object = host.visible_encounter_providers()[0]
+	population.call("set_context", {
+		"generation": 1, "run_seed": 1,
+		"eligible": {"grass": PackedVector2Array([Vector2(4, 4)])},
+		"tables": {"grass": {"slots": [
+			{"species": 25, "min_level": 3, "max_level": 3},
+		]}},
+	})
+	population.call("advance_frame")
+	var wanderers: Array = population.call("encounters")
+	assert_eq(wanderers.size(), 1)
+	assert_gt(float((wanderers[0] as Dictionary)["glow"]["amount"]), 0.0)
 	# 13: the five read-only policies that change how the game is played.
 	assert_eq(host.field_move_source_ids().size(), 1)
 	assert_eq(host.repel_renewal_ids().size(), 1)

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -279,6 +279,67 @@ func test_a_row_opens_the_submenu_and_its_first_row_is_the_transfer() -> void:
 	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
 
 
+## `_MovePKMNWithoutMail`: left and right load another list, the submenu drops
+## RELEASE, and the second A puts the Pokemon where the insert cursor stands.
+func test_move_without_mail_reorders_a_list_and_moves_between_two() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	var third: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.GEODUDE, 12, [Fixture.GROWL]
+	)
+	save.party.append(Gen2SaveBattleAdapter.from_battle_mon(third))
+	(save.party[2] as Gen2SaveMon).nickname = "THIRD"
+	await _open_box_screen(save, Gen2BoxScreen.MODE_MOVE)
+	## `.Init` loads `wCurBox`, so the screen opens on the box rather than on the
+	## party; left is what walks back to it.
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), 1)
+	assert_true(_box_screen.handle_button(Gen2Button.LEFT))
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
+
+	## The third member to the front of the party.
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(_box_screen.box_snapshot()["submenu"], Gen2BoxScreen.SUBMENU_ROWS_MOVE)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(
+		String(_box_screen.box_snapshot()["prompt"]), Gen2BoxScreen.PROMPT_MOVE_WHERE
+	)
+	_box_screen.handle_button(Gen2Button.UP)
+	_box_screen.handle_button(Gen2Button.UP)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(String((save.party[0] as Gen2SaveMon).nickname), "THIRD")
+	assert_eq(save.party.size(), 3)
+
+	## Left and right load another list, which only this mode answers.
+	assert_true(_box_screen.handle_button(Gen2Button.RIGHT))
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), 1)
+	assert_true(_box_screen.handle_button(Gen2Button.LEFT))
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
+
+	## The same Pokemon into the first box, which is a different list.
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.RIGHT)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(save.party.size(), 2)
+	assert_not_null(save.boxes[0].slots[0])
+	assert_eq(String((save.boxes[0].slots[0] as Gen2SaveMon).nickname), "THIRD")
+
+
+## `BillsPC_ChangeBoxSubmenu.Name` writes `sBoxNames`, and `SetDefaultBoxNames`
+## spells the default with no space in it.
+func test_a_box_keeps_the_name_it_was_given_and_defaults_without_one() -> void:
+	var save: Gen2SaveData = _save()
+	assert_eq(save.box_name(0), "BOX1")
+	assert_eq(save.box_name(Gen2SaveData.BOX_COUNT - 1), "BOX14")
+	assert_true(save.set_box_name(0, "KANTO"))
+	assert_eq(save.box_name(0), "KANTO")
+	assert_eq(Gen2SaveData.from_dict(save.to_dict()).box_name(0), "KANTO")
+	## An empty entry is the default again rather than a blank label.
+	assert_true(save.set_box_name(0, ""))
+	assert_eq(save.box_name(0), "BOX1")
+
+
 ## `_WithdrawPKMN` opens on `wCurBox` and its submenu says WITHDRAW.
 func test_the_withdraw_list_opens_on_the_current_box() -> void:
 	var save: Gen2SaveData = _save_with_two()

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5,6 +5,10 @@ extends GutTest
 
 var _directory: String = ""
 
+## The species the visible-encounter tests stand a wild on, which is the one the
+## fixture's own grass table offers.
+const VISIBLE_ENCOUNTER_SPECIES: int = 16
+
 
 func before_each() -> void:
 	_directory = RomCache.directory_for(&"testworld", "0123456789abcdef")
@@ -7356,6 +7360,97 @@ func test_a_visible_encounter_entry_is_validated_against_the_snapshot() -> void:
 	provider.set("overrides", {})
 	driver.advance_frame()
 	assert_eq(driver.entries().size(), 1)
+
+
+## The optional `glow`: quantized by the host, applied to every colour but the
+## cut-out, and in `_changed` so a view repaints when only the rung moves.
+func test_a_visible_encounter_glow_is_quantized_and_walks_its_own_colours() -> void:
+	var world := _drawable_world()
+	var driver := Gen2WorldEncounters.new()
+	var provider: Object = _pulse_provider()
+	provider.set("dvs", 0)
+	driver.set_providers([provider])
+	driver.set_world(world)
+
+	## Nothing asked for, nothing carried: an entry without a glow costs no
+	## second texture.
+	driver.advance_frame()
+	assert_eq(driver.actor_entries().size(), 1, "the species has an icon to draw")
+	assert_false(driver.entries()[0].has("glow"))
+	var plain: PackedColorArray = driver.actor_entries()[0]["colors"]
+
+	## An amount between two rungs lands on the nearer one, and the walk reaches
+	## colours 1 up rather than the icon's cut-out.
+	provider.set("overrides", {"glow": {"color": Color.GOLD, "amount": 0.6}})
+	driver.advance_frame()
+	assert_almost_eq(float(driver.entries()[0]["glow"]["amount"]), 0.625, 0.0001)
+	var lit: PackedColorArray = driver.actor_entries()[0]["colors"]
+	assert_eq(lit[0], plain[0], "colour 0 is the cut-out and is left alone")
+	for index: int in range(1, plain.size()):
+		assert_eq(lit[index], plain[index].lerp(Color.GOLD, 0.625), "colour %d" % index)
+
+	## A malformed glow costs the glow and not the entry, and an amount that
+	## rounds to nothing is no glow at all.
+	for bad: Variant in [
+		{"color": "gold", "amount": 1.0}, {"amount": 1.0}, "gold",
+		{"color": Color.GOLD, "amount": 0.05},
+		{"color": Color.GOLD, "amount": -4.0},
+	]:
+		provider.set("overrides", {"glow": bad})
+		driver.advance_frame()
+		assert_eq(driver.entries().size(), 1, str(bad))
+		assert_false(driver.entries()[0].has("glow"), str(bad))
+
+	## `GLOW_RUNGS` is the whole of what a mod can reach, however smooth the ramp
+	## it sends: both renderers cache a texture per palette and never evict.
+	var rungs: Dictionary = {}
+	for step: int in 101:
+		provider.set("overrides", {
+			"glow": {"color": Color.GOLD, "amount": float(step) / 100.0},
+		})
+		driver.advance_frame()
+		var glow: Dictionary = driver.entries()[0].get("glow", {})
+		rungs[float(glow.get("amount", 0.0))] = true
+	assert_eq(rungs.size(), Gen2WorldEncounters.GLOW_RUNGS + 1)
+
+
+## `_changed` is what decides whether a view repaints, so a glow that moves while
+## the Pokemon stands still has to be in it.
+func test_a_moving_glow_repaints_a_standing_pokemon() -> void:
+	var world := _world()
+	var driver := Gen2WorldEncounters.new()
+	var provider: Object = _pulse_provider()
+	provider.set("dvs", 0)
+	provider.set("overrides", {"glow": {"color": Color.GOLD, "amount": 1.0}})
+	driver.set_providers([provider])
+	driver.set_world(world)
+	driver.advance_frame()
+
+	assert_false(driver.advance_frame(), "nothing moved")
+	provider.set("overrides", {"glow": {"color": Color.GOLD, "amount": 0.5}})
+	assert_true(driver.advance_frame(), "the rung moved")
+	provider.set("overrides", {"glow": {"color": Color.RED, "amount": 0.5}})
+	assert_true(driver.advance_frame(), "the light moved")
+	provider.set("overrides", {})
+	assert_true(driver.advance_frame(), "the glow went out")
+
+
+## The fixture's own species list carries no rows, so `actor_entries()` finds no
+## icon and draws nothing. This gives the one species the visible-encounter tests
+## stand on an icon and a palette, which is what those two answers are read from.
+func _drawable_world() -> Gen2WorldAPI:
+	## The table is read by position, so the rows in front of the one that
+	## matters have to be there.
+	var species: Array = []
+	for number: int in VISIBLE_ENCOUNTER_SPECIES:
+		species.append({
+			"number": number + 1, "name": "MON%d" % (number + 1), "icon": 1,
+			## `GetMonNormalOrShinyPalettePointer`'s two packed middle colours,
+			## one pair for each of the two answers.
+			"palette": {"normal": [0x1CE7, 0x0C63], "shiny": [0x7FFF, 0x001F]},
+		})
+	RomCache.write_json(RomCache.species_path(_directory), species)
+	return _world()
 
 
 func _pulse_provider() -> Object:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -17,6 +17,35 @@ func after_each() -> void:
 	RomCache.clear(_directory)
 
 
+## Seven `PUT IT AWAY` headers and one decoration each, at the ids the source
+## gives them, so `Gen2WorldDecoration` reads the same shape it reads from a
+## cartridge. Names are the fixture's own.
+func _decoration_fixture() -> Dictionary:
+	var attributes: Array = []
+	for deco: int in 31:
+		attributes.append({
+			"type": 1, "name": 0, "action": 0, "flag": 0, "sprite": 0,
+		})
+	## [id, action, event flag, block or sprite] for the header and the member.
+	for row: Array in [
+		[1, 2, 0, 0], [2, 1, 676, 0x1B],
+		[6, 4, 0, 0], [7, 3, 680, 0x08],
+		[11, 6, 0, 0], [12, 5, 684, 0x20],
+		[15, 8, 0, 0], [16, 7, 687, 0x1F],
+		[20, 10, 0, 0], [21, 9, 691, 0x5C],
+		[25, 12, 0, 0], [26, 11, 719, 0x33],
+		[29, 14, 0, 0], [30, 13, 695, 0x8E],
+	]:
+		attributes[row[0]] = {
+			"type": 1, "name": row[0], "action": row[1], "flag": row[2],
+			"sprite": row[3],
+		}
+	var names: Array = []
+	for part: int in 31:
+		names.append("DECO%d" % part)
+	return {"attributes": attributes, "names": names}
+
+
 func _write_cache(game_id: String = "testworld") -> void:
 	RomCache.write_json(RomCache.species_path(_directory), [])
 	RomCache.write_json(RomCache.moves_path(_directory), [])
@@ -325,6 +354,10 @@ func _write_cache(game_id: String = "testworld") -> void:
 		## `UnownWalls`' four, since the special that draws one names them by
 		## index and a wrong index has to be told from a right one.
 		"unown_walls": ["WALLA", "WALLB", "WALLC", "WALLD"],
+		## `DecorationAttributes` in the shape a real cache carries: one row per
+		## category header and one decoration behind it, so a slot's own block or
+		## sprite is read from the table rather than guessed.
+		"decorations": _decoration_fixture(),
 		## The `RomLayout.SPECIAL_TEXT_RUNS` boxes the deferred routines print,
 		## with the `text_ram` markers a real cache carries so a filled buffer is
 		## told from an unfilled one.
@@ -3240,7 +3273,7 @@ func test_describedecoration_runs_locally_and_opens_only_the_town_map_host() -> 
 	var text_pause: Dictionary = runner.advance()
 	assert_eq(text_pause["status"], &"waiting", JSON.stringify(text_pause))
 	assert_eq(text_pause["event"]["type"], &"text", JSON.stringify(text_pause))
-	assert_eq(text_pause["event"]["text"], "It's a town map.")
+	assert_eq(text_pause["event"]["text"], "It's the TOWN MAP.")
 	var map_pause: Dictionary = runner.advance(true)
 	assert_eq(map_pause["status"], &"waiting", JSON.stringify(map_pause))
 	assert_eq(map_pause["event"]["type"], &"runtime_request", JSON.stringify(map_pause))

--- a/tests/unit/test_world_bag_host.gd
+++ b/tests/unit/test_world_bag_host.gd
@@ -163,8 +163,8 @@ func test_the_pc_tosses_its_own_stack() -> void:
 	assert_eq(_world.state.item_quantity(POTION), 2, "the bag is not touched")
 
 
-## `.ChooseWhichPCListToUse`, and the HALL OF FAME row this project drops for
-## want of saved induction records.
+## `.ChooseWhichPCListToUse`: the Pokedex adds PROF.OAK'S PC and the induction
+## adds HALL OF FAME.
 func test_the_top_menu_grows_with_the_dex_and_the_hall_of_fame() -> void:
 	var rows: Callable = func() -> Array:
 		var out: Array = []
@@ -186,10 +186,47 @@ func test_the_top_menu_grows_with_the_dex_and_the_hall_of_fame() -> void:
 
 	_world.state.set_hall_of_fame(true)
 	assert_eq(Gen2WorldPC.top_menu_list(_world.state), Gen2WorldPC.PCPC_POSTGAME)
-	assert_false(
-		Gen2WorldPC.PCPCITEM_HALL_OF_FAME in rows.call(),
-		"the induction viewer has no records to read"
+	assert_true(Gen2WorldPC.PCPCITEM_HALL_OF_FAME in rows.call())
+
+
+## `GetHallOfFameParty` and `AddHallOfFameEntry`: eggs are skipped, the newest
+## team is at the front, and `wHallOfFameCount` counts the inductions rather
+## than the records.
+func test_an_induction_records_the_party_newest_first() -> void:
+	(_save.party[0] as Gen2SaveMon).nickname = "FIRST"
+	var records: Array = Gen2HallOfFame.inducted([], _save)
+	assert_eq(records.size(), 1)
+	assert_eq(int(records[0]["win_count"]), 1)
+	assert_eq(int(records[0]["mons"].size()), _save.party.size())
+	assert_eq(String(records[0]["mons"][0]["nickname"]), "FIRST")
+
+	(_save.party[0] as Gen2SaveMon).nickname = "SECOND"
+	records = Gen2HallOfFame.inducted(records, _save)
+	assert_eq(records.size(), 2)
+	assert_eq(int(records[0]["win_count"]), 2)
+	assert_eq(String(records[0]["mons"][0]["nickname"]), "SECOND")
+	assert_eq(String(records[1]["mons"][0]["nickname"]), "FIRST")
+	assert_eq(Gen2HallOfFame.win_count(records), 2)
+
+	## `sHallOfFame` holds thirty and the oldest falls off the end.
+	for _pass: int in Gen2HallOfFame.MAX_RECORDS:
+		records = Gen2HallOfFame.inducted(records, _save)
+	assert_eq(records.size(), Gen2HallOfFame.MAX_RECORDS)
+	assert_eq(Gen2HallOfFame.win_count(records), 2 + Gen2HallOfFame.MAX_RECORDS)
+
+	## `_HallOfFamePC.DisplayMonAndStrings` draws the count on every panel of the
+	## record it belongs to, which is the one line an induction has no room for.
+	var pages: Array = Gen2HallOfFame.record_pages(_data, records[0])
+	assert_eq(pages.size(), records[0]["mons"].size())
+	assert_eq(int(pages[0]["win_count"]), Gen2HallOfFame.win_count(records))
+	assert_eq(
+		Gen2SaveData.from_dict(_save.to_dict()).hall_of_fame.size(), 0,
+		"nothing is stored until an induction writes it"
 	)
+	_save.hall_of_fame = records
+	var reopened: Gen2SaveData = Gen2SaveData.from_dict(_save.to_dict())
+	assert_eq(reopened.hall_of_fame.size(), Gen2HallOfFame.MAX_RECORDS)
+	assert_eq(String(reopened.hall_of_fame[0]["mons"][0]["nickname"]), "SECOND")
 
 
 ## `PlayersPCMenuData.WhichPC`: the bedroom's list ends in TURN OFF, a Pokemon
@@ -280,3 +317,114 @@ func test_a_registration_lasts_while_the_item_is_owned() -> void:
 	_world.state.apply_changes({}, {}, {"items": {KEY_ITEM: 0}})
 	assert_eq(Gen2WorldBagHost.registered_item(_world), 0)
 	assert_eq(_world.state.registered_item(), 0, "the check clears it where it looks")
+
+
+## `.FindCategoriesWithOwnedDecos`: only a category with an owned decoration is
+## on the top menu, and EXIT is its last row whether or not anything is.
+func test_the_decoration_menu_offers_only_categories_with_something_in_them() -> void:
+	var categories: Array = Gen2WorldDecoration.categories(_data, _world.state)
+	assert_eq(categories.size(), 1, JSON.stringify(categories))
+	assert_eq(String(categories[0]["name"]), Gen2WorldDecoration.CATEGORY_EXIT)
+
+	Gen2WorldDecoration.set_owned(_data, _world.state, Fixture.DECO_FEATHERY_BED)
+	categories = Gen2WorldDecoration.categories(_data, _world.state)
+	assert_eq(categories.size(), 2, JSON.stringify(categories))
+	assert_eq(StringName(categories[0]["slot"]), Gen2WorldDecoration.SLOT_BED)
+
+
+## `FindOwnedDecosInCategory` appends the category's PUT IT AWAY and then
+## CANCEL, so an owned row is never the whole list.
+func test_a_category_list_ends_in_put_it_away_and_cancel() -> void:
+	Gen2WorldDecoration.set_owned(_data, _world.state, Fixture.DECO_FEATHERY_BED)
+	var rows: Array = Gen2WorldDecoration.category_rows(
+		_data, _world.state, Gen2WorldDecoration.SLOT_BED
+	)
+	assert_eq(rows.size(), 3, JSON.stringify(rows))
+	assert_eq(int(rows[0]["deco"]), Fixture.DECO_FEATHERY_BED)
+	assert_true(Gen2WorldDecoration.is_put_away(_data, int(rows[1]["deco"])))
+	assert_eq(int(rows[2]["deco"]), 0)
+
+
+## `DecoAction_TrySetItUp` and `DecoAction_TryPutItAway` over one slot, and the
+## `.alreadythere` refusal that leaves it where it is.
+func test_setting_a_decoration_up_and_putting_it_away_move_one_slot() -> void:
+	Gen2WorldDecoration.set_owned(_data, _world.state, Fixture.DECO_FEATHERY_BED)
+	var refused: Dictionary = Gen2WorldDecoration.apply(
+		_world, _save, Fixture.DECO_SURF_PIKACHU_DOLL,
+		Gen2WorldDecoration.SLOT_LEFT_ORNAMENT, false
+	)
+	assert_eq(
+		StringName(refused.get("reason", &"")), &"decoration_not_owned",
+		"an unowned row cannot be set up"
+	)
+
+	var set_up: Dictionary = Gen2WorldDecoration.apply(
+		_world, _save, Fixture.DECO_FEATHERY_BED, &"", false
+	)
+	assert_true(bool(set_up["ok"]), str(set_up))
+	assert_true(bool(set_up["changed"]))
+	assert_eq(
+		_world.state.maptile_decoration(Gen2WorldDecoration.SLOT_BED),
+		Fixture.DECO_FEATHERY_BED
+	)
+
+	var again: Dictionary = Gen2WorldDecoration.apply(
+		_world, _save, Fixture.DECO_FEATHERY_BED, &"", false
+	)
+	assert_false(bool(again["changed"]))
+	assert_eq(String(again["text"]), Gen2WorldDecoration.TEXT_ALREADY_SET_UP)
+
+	var put_away: Dictionary = Gen2WorldDecoration.apply(
+		_world, _save, _put_away_row(Gen2WorldDecoration.SLOT_BED), &"", false
+	)
+	assert_true(bool(put_away["changed"]))
+	assert_eq(_world.state.maptile_decoration(Gen2WorldDecoration.SLOT_BED), 0)
+	assert_eq(
+		String(
+			Gen2WorldDecoration.apply(
+				_world, _save, _put_away_row(Gen2WorldDecoration.SLOT_BED), &"", false
+			)["text"]
+		),
+		Gen2WorldDecoration.TEXT_NOTHING_TO_PUT_AWAY
+	)
+
+
+## `DecoAction_setupornament` asks which side, and
+## `DecoAction_SetItUp_Ornament.getwhichside` takes the same doll off the other
+## one rather than standing two of it.
+func test_an_ornament_takes_a_side_and_leaves_the_other() -> void:
+	Gen2WorldDecoration.set_owned(_data, _world.state, Fixture.DECO_PIKACHU_DOLL)
+	assert_true(Gen2WorldDecoration.asks_side(_data, Fixture.DECO_PIKACHU_DOLL))
+	assert_eq(
+		StringName(
+			Gen2WorldDecoration.apply(
+				_world, _save, Fixture.DECO_PIKACHU_DOLL, &"", false
+			)["reason"]
+		),
+		&"decoration_side_required"
+	)
+
+	assert_true(bool(Gen2WorldDecoration.apply(
+		_world, _save, Fixture.DECO_PIKACHU_DOLL,
+		Gen2WorldDecoration.SLOT_LEFT_ORNAMENT, false
+	)["ok"]))
+	assert_true(bool(Gen2WorldDecoration.apply(
+		_world, _save, Fixture.DECO_PIKACHU_DOLL,
+		Gen2WorldDecoration.SLOT_RIGHT_ORNAMENT, false
+	)["ok"]))
+	assert_eq(
+		_world.state.maptile_decoration(Gen2WorldDecoration.SLOT_LEFT_ORNAMENT), 0,
+		"the doll left the side it was on"
+	)
+	assert_eq(
+		_world.state.maptile_decoration(Gen2WorldDecoration.SLOT_RIGHT_ORNAMENT),
+		Fixture.DECO_PIKACHU_DOLL
+	)
+
+
+func _put_away_row(slot: StringName) -> int:
+	for deco: int in _data.decoration_count():
+		if Gen2WorldDecoration.slot_of(_data, deco) == slot \
+			and Gen2WorldDecoration.is_put_away(_data, deco):
+			return deco
+	return -1

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -385,6 +385,111 @@ func test_sacred_ash_is_refused_and_kept_while_nothing_has_fainted() -> void:
 	assert_eq(_world.state.item_quantity(0x9C), 1)
 
 
+## `RareCandyEffect`: one level, `CalcExpAtLevel` back onto the experience, and
+## the max-HP delta added to the current HP rather than a heal.
+func test_a_rare_candy_adds_one_level_and_the_maximum_it_brought_with_it() -> void:
+	_world.state.apply_changes({}, {}, {"items": {Gen2WorldPartyHost.ITEM_RARE_CANDY: 1}})
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.hp = 1
+	var level: int = mon.level
+	var before_max: int = Gen2SaveBattleAdapter.to_battle_mon(_data, mon).max_hp()
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_RARE_CANDY, 0, false
+	)
+
+	assert_true(bool(result["ok"]), JSON.stringify(result))
+	assert_eq(_save.party[0].level, level + 1)
+	assert_eq(int(result["level"]), level + 1)
+	var after_max: int = Gen2SaveBattleAdapter.to_battle_mon(_data, _save.party[0]).max_hp()
+	assert_eq(_save.party[0].hp, 1 + (after_max - before_max))
+	assert_eq(
+		_save.party[0].exp,
+		Gen2Experience.total_exp_at(
+			int(_data.species(_save.party[0].species).get(
+				"growth_rate", Gen2Experience.GROWTH_MEDIUM_FAST
+			)),
+			level + 1
+		)
+	)
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_RARE_CANDY), 0)
+
+
+## `cp MAX_LEVEL / jp nc, NoEffectMessage`: a refusal, so the candy is kept.
+func test_a_rare_candy_is_refused_at_the_level_cap() -> void:
+	_world.state.apply_changes({}, {}, {"items": {Gen2WorldPartyHost.ITEM_RARE_CANDY: 1}})
+	_save.party[0].level = Gen2Experience.MAX_LEVEL
+	_save.party[0].exp = Gen2Experience.total_exp_at(
+		int(_data.species(_save.party[0].species).get(
+			"growth_rate", Gen2Experience.GROWTH_MEDIUM_FAST
+		)),
+		Gen2Experience.MAX_LEVEL
+	)
+	var result: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_RARE_CANDY, 0, false
+	)
+	assert_false(bool(result["ok"]))
+	assert_eq(StringName(result["reason"]), &"item_has_no_effect")
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_RARE_CANDY), 1)
+
+
+## `RestorePP`: ten for an ETHER and the whole ceiling for a MAX, the ETHERs on
+## the slot `MoveSelectionScreen` chose and the ELIXERs on all four. A move
+## already full is `.dont_restore`, and nothing restored at all is a refusal.
+func test_the_pp_restorers_fill_one_move_or_all_four() -> void:
+	_world.state.apply_changes({}, {}, {"items": {
+		Gen2WorldPartyHost.ITEM_ETHER: 1, Gen2WorldPartyHost.ITEM_MAX_ETHER: 1,
+		Gen2WorldPartyHost.ITEM_ELIXER: 1,
+	}})
+	var mon: Gen2SaveMon = _save.party[0]
+	## The fixture's species carry no learnset, so the development save's party
+	## knows nothing: the moves are written here rather than assumed.
+	mon.moves = [1, 0, 0, 0]
+	var maximum: int = int(_data.move(1).get("pp", 0))
+	assert_gt(maximum, 0, "the fixture's first move has PP")
+
+	## An ETHER with no slot chosen is the caller's cue to open the move list.
+	mon.pp = [0, 0, 0, 0]
+	var asked: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_ETHER, 0, false
+	)
+	assert_eq(StringName(asked["reason"]), &"move_slot_required")
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_ETHER), 1)
+
+	var ether: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_ETHER, 0, false, 0
+	)
+	assert_true(bool(ether["ok"]), JSON.stringify(ether))
+	assert_eq(_save.party[0].pp[0], mini(maximum, Gen2WorldPartyHost.PP_RESTORE_STEP))
+
+	var maxed: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_MAX_ETHER, 0, false, 0
+	)
+	assert_true(bool(maxed["ok"]), JSON.stringify(maxed))
+	assert_eq(_save.party[0].pp[0], maximum)
+
+	## Every move already full is `WontHaveAnyEffectMessage`, and the ELIXER
+	## stays in the pack.
+	var refused: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_ELIXER, 0, false
+	)
+	assert_false(bool(refused["ok"]))
+	assert_eq(StringName(refused["reason"]), &"item_has_no_effect")
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_ELIXER), 1)
+
+
+## PP UP raises `PP_UP_MASK`, which [Gen2SaveMon] does not carry: the pack says
+## so rather than pretending the item did nothing.
+func test_pp_up_names_the_save_field_it_needs() -> void:
+	_world.state.apply_changes({}, {}, {"items": {Gen2WorldPartyHost.ITEM_PP_UP: 1}})
+	var result: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_PP_UP, 0, false
+	)
+	assert_false(bool(result["ok"]))
+	assert_eq(StringName(result["reason"]), &"pp_up_unsupported")
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_PP_UP), 1)
+
+
 ## `VitaminEffect`: ten added to the high byte of one stat experience word,
 ## which is 2,560 flat, and HAPPINESS_USEDITEM. `UpdateStatsAfterItem` writes
 ## MON_MAXHP and the stats, never MON_HP, so the maximum rises and the member is

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -75,6 +75,37 @@ func test_mart_purchase_refuses_insufficient_money_without_mutation() -> void:
 	assert_eq(_save.world.world_state.money(), 500)
 
 
+## `SellMenu.okay_to_sell`: the stack leaves the pack and `GiveMoney` puts
+## `Sell_HalvePrice`'s answer in, which halves the multiplied total rather than
+## each unit's price.
+func test_mart_sale_pays_half_the_multiplied_price_and_empties_the_stack() -> void:
+	_world.state.apply_changes({}, {}, {"items": {7: 3}})
+	assert_eq(Gen2WorldMartHost.sell_price(_data, 7, 1), 60)
+	assert_eq(Gen2WorldMartHost.sell_price(_data, 7, 3), 180)
+
+	var sold: Dictionary = Gen2WorldMartHost.sell(_world, _save, 7, 3, false)
+	assert_true(bool(sold["ok"]), str(sold))
+	assert_eq(int(sold["total"]), 180)
+	assert_eq(_world.state.item_quantity(7), 0)
+	assert_eq(_world.state.money(), 680)
+	assert_eq(_save.world.world_state.money(), 680)
+
+
+## `.try_sell`'s `_CheckTossableItem` refusal, and the quantity guard in front
+## of it, neither of which touches the world.
+func test_mart_sale_refuses_an_untossable_item_and_an_impossible_quantity() -> void:
+	var before: Dictionary = _world.snapshot().to_dict()
+	var too_many: Dictionary = Gen2WorldMartHost.sell(_world, _save, 7, 9, false)
+	assert_eq(StringName(too_many["reason"]), &"invalid_sell_quantity")
+
+	_world.state.apply_changes({}, {}, {"items": {8: 1}})
+	assert_false(Gen2WorldMartHost.can_sell(_data, 8))
+	var refused: Dictionary = Gen2WorldMartHost.sell(_world, _save, 8, 1, false)
+	assert_eq(StringName(refused["reason"]), &"item_cannot_be_sold")
+	_world.state.apply_changes({}, {}, {"items": {8: 0}})
+	assert_eq(_world.snapshot().to_dict(), before)
+
+
 func test_mart_dialog_resolves_all_imported_shop_variants() -> void:
 	var standard: Dictionary = Gen2WorldMartHost.resolve_mart(
 		_data, Gen2WorldMartHost.MARTTYPE_STANDARD, 0
@@ -494,6 +525,10 @@ func _write_services_at(directory: String) -> void:
 		if int(raw.get("number", 0)) == 7:
 			raw["name"] = "ITEM7"
 			raw["price"] = 120
+		## `ITEMATTR_PERMISSIONS`' can't-toss bit, which is what `SellMenu`'s
+		## `_CheckTossableItem` refuses a key item with.
+		if int(raw.get("number", 0)) == 8:
+			raw["permissions"] = RomLayout.ITEM_ATTRIBUTE_CANT_TOSS
 	RomCache.write_json(RomCache.items_path(directory), items)
 	RomCache.write_json(RomCache.world_marts_path(directory), {
 		"marts": [{"index": 0, "bank": Fixture.BANK, "address": 0x4000, "items": [7, 8]}],

--- a/tools/checks/decorations.gd
+++ b/tools/checks/decorations.gd
@@ -1,0 +1,174 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies `DecorationAttributes` and the `DecorationNames` run behind it
+## against freshly imported real caches, in all three games, and the name
+## [Gen2WorldDecoration] spells from each row.
+##
+## Expected values are the pinned pokecrystal and pokegold sources'
+## `data/decorations/attributes.asm`, `data/decorations/names.asm` and
+## `GetDecoName`. One pinned address per cartridge finds the lot, so what says
+## the address is right is the content: fifty-three rows whose types, actions,
+## event flags and block or sprite bytes are all the source's, and the names they
+## are spelled from.
+##
+## The two pins are byte identical bar one name: Gold and Silver spell the third
+## console "NINTENDO64" where Crystal spells it "NINTENDO 64". That is checked
+## here rather than assumed, and it is why the whole run is not compared between
+## cartridges the way the Pokemon Center PC's is.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- decorations
+
+## Every row, as [name, type, action, event flag, block or sprite]. The name is
+## what `GetDecoName` assembles, not the `DecorationNames` entry the row points
+## at: a poster, doll and big doll each name a species instead.
+const EXPECTED: Array[Array] = [
+	["CANCEL", 1, 0, 0, 0x00],
+	["PUT IT AWAY", 1, 2, 0, 0x00],
+	["FEATHERY BED", 2, 1, 676, 0x1B],
+	["PINK BED", 2, 1, 677, 0x1C],
+	["POLKADOT BED", 2, 1, 678, 0x1D],
+	["PIKACHU BED", 2, 1, 679, 0x1E],
+	["PUT IT AWAY", 1, 4, 0, 0x00],
+	["RED CARPET", 3, 3, 680, 0x08],
+	["BLUE CARPET", 3, 3, 681, 0x0B],
+	["YELLOW CARPET", 3, 3, 682, 0x0E],
+	["GREEN CARPET", 3, 3, 683, 0x11],
+	["PUT IT AWAY", 1, 6, 0, 0x00],
+	["MAGNAPLANT", 1, 5, 684, 0x20],
+	["TROPICPLANT", 1, 5, 685, 0x21],
+	["JUMBOPLANT", 1, 5, 686, 0x22],
+	["PUT IT AWAY", 1, 8, 0, 0x00],
+	["TOWN MAP", 1, 7, 687, 0x1F],
+	["PIKACHU POSTER", 4, 7, 688, 0x23],
+	["CLEFAIRY POSTER", 4, 7, 689, 0x24],
+	["JIGGLYPUFF POSTER", 4, 7, 690, 0x25],
+	["PUT IT AWAY", 1, 10, 0, 0x00],
+	["NES", 1, 9, 691, 0x5C],
+	["SUPER NES", 1, 9, 692, 0x5B],
+	["NINTENDO 64", 1, 9, 693, 0x51],
+	["VIRTUAL BOY", 1, 9, 694, 0x57],
+	["PUT IT AWAY", 1, 12, 0, 0x00],
+	["BIG SNORLAX", 6, 11, 719, 0x33],
+	["BIG ONIX", 6, 11, 720, 0x50],
+	["BIG LAPRAS", 6, 11, 721, 0x47],
+	["PUT IT AWAY", 1, 14, 0, 0x00],
+	["PIKACHU DOLL", 5, 13, 695, 0x8E],
+	["SURF PIKACHU DOLL", 1, 13, 696, 0x34],
+	["CLEFAIRY DOLL", 5, 13, 697, 0x8F],
+	["JIGGLYPUFF DOLL", 5, 13, 698, 0x94],
+	["BULBASAUR DOLL", 5, 13, 699, 0x93],
+	["CHARMANDER DOLL", 5, 13, 700, 0x90],
+	["SQUIRTLE DOLL", 5, 13, 701, 0x89],
+	["POLIWAG DOLL", 5, 13, 702, 0x8D],
+	["DIGLETT DOLL", 5, 13, 703, 0x8C],
+	["STARYU DOLL", 5, 13, 704, 0x92],
+	["MAGIKARP DOLL", 5, 13, 705, 0x88],
+	["ODDISH DOLL", 5, 13, 706, 0x85],
+	["GENGAR DOLL", 5, 13, 707, 0x86],
+	["SHELLDER DOLL", 5, 13, 708, 0x84],
+	["GRIMER DOLL", 5, 13, 709, 0x95],
+	["VOLTORB DOLL", 5, 13, 710, 0x9B],
+	["WEEDLE DOLL", 5, 13, 711, 0x83],
+	["UNOWN DOLL", 5, 13, 712, 0x80],
+	["GEODUDE DOLL", 5, 13, 713, 0x81],
+	["MACHOP DOLL", 5, 13, 714, 0x9A],
+	["TENTACOOL DOLL", 5, 13, 715, 0x98],
+	["GOLD TROPHY", 1, 13, 717, 0x5E],
+	["SILVER TROPHY", 1, 13, 718, 0x5F],
+]
+## `data/decorations/names.asm`'s one difference between the pins.
+const NINTENDO_64: int = 23
+const NINTENDO_64_GOLD_SILVER: String = "NINTENDO64"
+const FIELDS: Array[String] = ["type", "action", "flag", "sprite"]
+
+## `_PlayerDecorationMenu.category_pointers`' seven categories and the ids each
+## `FindOwned*` list holds, which is what a category menu offers once the flags
+## are set. Pinned from the source's own lists rather than read off the table,
+## so the two have to agree.
+const EXPECTED_CATEGORIES: Dictionary = {
+	&"bed": [2, 3, 4, 5],
+	&"carpet": [7, 8, 9, 10],
+	&"plant": [12, 13, 14],
+	&"poster": [16, 17, 18, 19],
+	&"console": [21, 22, 23, 24],
+	&"big_doll": [26, 27, 28],
+	&"left_ornament": [
+		30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+		48, 49, 50, 51, 52,
+	],
+}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(_verify_game)
+
+
+func _verify_game() -> void:
+	var data: GameData = _r.data
+	if not _r.check(
+		data.decoration_count() == EXPECTED.size(),
+		"the table holds %d rows, not %d" % [data.decoration_count(), EXPECTED.size()]
+	):
+		return
+	for deco: int in EXPECTED.size():
+		_verify_row(data, deco)
+	_verify_categories(data)
+	_r.note("%d decoration rows in %d categories" % [
+		EXPECTED.size(), EXPECTED_CATEGORIES.size(),
+	])
+
+
+func _verify_row(data: GameData, deco: int) -> void:
+	var expected: Array = EXPECTED[deco]
+	var name: String = String(expected[0])
+	if deco == NINTENDO_64 and not _r.crystal:
+		name = NINTENDO_64_GOLD_SILVER
+	var spelled: String = Gen2WorldDecoration.decoration_name(data, deco)
+	_r.check(
+		spelled == name,
+		"row %d is named \"%s\", not \"%s\"" % [deco, spelled, name]
+	)
+	var row: Dictionary = data.decoration(deco)
+	for index: int in FIELDS.size():
+		var field: String = FIELDS[index]
+		_r.check(
+			int(row.get(field, -1)) == int(expected[index + 1]),
+			"row %d's %s is %d, not %d" % [
+				deco, field, int(row.get(field, -1)), int(expected[index + 1]),
+			]
+		)
+
+
+## The category a row's action puts it in, and the PUT IT AWAY header each
+## category has exactly one of.
+func _verify_categories(data: GameData) -> void:
+	var found: Dictionary = {}
+	var headers: Dictionary = {}
+	for deco: int in EXPECTED.size():
+		var slot: StringName = Gen2WorldDecoration.slot_of(data, deco)
+		if slot.is_empty():
+			_r.check(deco == 0, "row %d belongs to no category" % deco)
+			continue
+		if Gen2WorldDecoration.is_put_away(data, deco):
+			headers[slot] = int(headers.get(slot, 0)) + 1
+			continue
+		var members: Array = found.get(slot, [])
+		members.append(deco)
+		found[slot] = members
+	for slot: StringName in EXPECTED_CATEGORIES:
+		_r.check(
+			found.get(slot, []) == EXPECTED_CATEGORIES[slot],
+			"category %s holds %s, not %s" % [
+				slot, JSON.stringify(found.get(slot, [])),
+				JSON.stringify(EXPECTED_CATEGORIES[slot]),
+			]
+		)
+		_r.check(
+			int(headers.get(slot, 0)) == 1,
+			"category %s has %d PUT IT AWAY rows, not one" % [
+				slot, int(headers.get(slot, 0)),
+			]
+		)

--- a/tools/checks/decorations.gd.uid
+++ b/tools/checks/decorations.gd.uid
@@ -1,0 +1,1 @@
+uid://bypk65x1uiosv

--- a/tools/checks/mart.gd
+++ b/tools/checks/mart.gd
@@ -35,6 +35,11 @@ const EXPECTED_TEXT_OPENINGS: Dictionary = {
 	"bargain_thanks": "Thanks.",
 	"pharmacy_intro": "What's up? Need",
 	"pharmacy_come_again": "All right.",
+	## `SellMenu`'s own four, which the standard shop's SELL row reaches.
+	"sell_how_many": "How many?",
+	"sell_price": "I can pay you",
+	"cant_buy": "Sorry, I can't buy",
+	"bought": "Got ",
 }
 
 ## The three values a mart box leaves a marker for. `hMoneyTemp` is HRAM and
@@ -48,6 +53,10 @@ const EXPECTED_MARKERS: Dictionary = {
 	"bitter_final_price": {"name": 1, "quantity": 1, "total": 1},
 	"pharmacy_final_price": {"name": 1, "quantity": 1, "total": 1},
 	"bargain_final_price": {"name": 1, "quantity": 0, "total": 1},
+	## `MartSellPriceText` names the money alone, since the item is still on the
+	## list the sale was chosen from; `MartBoughtText` names both.
+	"sell_price": {"name": 0, "quantity": 0, "total": 1},
+	"bought": {"name": 1, "quantity": 0, "total": 1},
 }
 
 ## The screen's own width. A name prints from column 2 and its price from

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -41,7 +41,9 @@ extends SceneTree
 ## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
 ## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `mart`
 ## (`BuyMenu`, talked open from the cell in front of a shop's counter, as
-## `crystal 1 8 ... mart 3 3`), `pokepic`
+## `crystal 1 8 ... mart 3 3`), `mart_sell` (the same shop's SELL row, which is
+## `DepositSellPack` on the cartridge and this port's own list of the pack),
+## `pokepic`
 ## (`Script_pokepic`'s box over the map, holding Chikorita),
 ## `pet_actor` (a mod's world actor one cell in front of the player, pressed with
 ## A so it wears the heart `showemote` puts over a map object),
@@ -86,6 +88,10 @@ extends SceneTree
 ## cell reaches: the first number is how many rows down the menu to stand and the
 ## second how many A presses to spend, so `crystal 24 6 ... bills_pc 1 2` is the
 ## DEPOSIT list with its submenu up),
+## `players_pc` and `pokemon_center_pc` (the bedroom's item PC and the Pokemon
+## Center's machine, driven the same way: `crystal 24 6 ... players_pc 3 1` is
+## the decoration menu and `crystal 24 6 ... pokemon_center_pc 3 1` the Hall of
+## Fame viewer on a save that has been inducted),
 ## `mom_bank` (`Mom_WithdrawDepositMenuJoypad`'s dial, which no fixture cell
 ## reaches: the first number is the wallet in hundreds and the second her own
 ## balance in hundreds, plus 1000 for the WITHDRAW header),
@@ -527,7 +533,7 @@ func _process(_delta: float) -> bool:
 				_screen.press_button(Gen2Button.A)
 				for _frame: int in 20:
 					_screen.advance_frame()
-		elif _kind == &"mart":
+		elif _kind == &"mart" or _kind == &"mart_sell":
 			## The clerk behind the counter, talked to from the cell in front of
 			## him: his `pokemart` is what opens `BuyMenu`, so the shop is
 			## reached the way a player reaches it. The presses are the dialog's
@@ -536,6 +542,11 @@ func _process(_delta: float) -> bool:
 			_screen.interact()
 			for _press: int in MART_PRESSES:
 				_screen.press_button(Gen2Button.A)
+			## `StandardMart`'s BUY/SELL/QUIT loop is what the welcome box hands
+			## the shop to. `mart` takes its BUY row, `mart_sell` the one below.
+			if _kind == &"mart_sell":
+				_screen.press_button(Gen2Button.DOWN)
+			_screen.press_button(Gen2Button.A)
 		elif _kind == &"warp":
 			## `MapSetupScript_Door` at its whitest: the step onto the warp tile
 			## and then `FadeOutToWhite`'s last order, which is the frame the map
@@ -629,12 +640,12 @@ func _process(_delta: float) -> bool:
 			for _down: int in maxi(_cell.x, 0):
 				_screen.press_button(Gen2Button.DOWN)
 				_screen.advance_frame()
-		elif _kind == &"bills_pc":
+		elif _kind in [&"bills_pc", &"players_pc", &"pokemon_center_pc"]:
 			## `_BillsPC`, which no preview cell reaches: the first number is how
 			## many rows down the top menu to stand and the second how many A
 			## presses to spend from there, so `1 1` is the DEPOSIT list and
 			## `1 2` its submenu on the first party member.
-			_screen.preview_bills_pc()
+			_screen.call(SCREEN_DRIVER % _kind)
 			for _down: int in maxi(_cell.x, 0):
 				_screen.press_button(Gen2Button.DOWN)
 				_screen.advance_frame()
@@ -668,7 +679,8 @@ func _process(_delta: float) -> bool:
 			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
-			&"catch_nickname", &"mom_bank", &"bills_pc", &"start_menu",
+			&"catch_nickname", &"mom_bank", &"bills_pc", &"players_pc",
+			&"pokemon_center_pc", &"start_menu",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -118,6 +118,9 @@ extends SceneTree
 ## `visible_encounter` (a shiny of the map's own table standing on the eligible
 ## cell nearest the player, with the cartridge's sparkle over it: try
 ## `crystal 24 3 ... visible_encounter 4 9`),
+## `visible_encounter_glow` (the same population with ordinary DVs wearing an
+## entry's own `glow` instead, which is the mark a mod puts on a Pokemon worth
+## stopping for: `crystal 24 3 ... visible_encounter_glow 4 9`),
 ## `field_moves_menu` (the start menu's MOVES row, and the list of HM moves the
 ## bag can supply behind it, both of which need a registered field-move source
 ## before they exist: driven twice, since each call is one step),

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -10,6 +10,8 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/oak.png oak_pc
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc a,down,a
+##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/deco.png decoration
+##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/hof.png hall_of_fame
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/unown.png unown_dex
 ##
 ## `presses` drives the overlay with its own buttons before the shot, which is
@@ -23,6 +25,10 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 ## The forms the Unown dex preview has caught, in catching order rather than
 ## alphabetically, since that is the whole of what the screen lists.
 const UNOWN_CAUGHT: Array[int] = [6, 21, 1, 14, 26]
+
+## `EVENT_DECO_CHARMANDER_DOLL`, the first doll `data/items/mom_phone.asm` lets
+## Mom's savings buy.
+const DECO_FLAG_CHARMANDER_DOLL: int = 700
 
 const APRICORNS: Dictionary = {
 	0x55: "RED APRICORN", 0x59: "BLU APRICORN", 0x5C: "YLW APRICORN",
@@ -72,6 +78,14 @@ func _initialize() -> void:
 	if _kind == &"pokegear":
 		state.set_engine_flag(Gen2WorldState.ENGINE_PHONE_CARD, true)
 		state.set_engine_flag(Gen2WorldState.ENGINE_RADIO_CARD, true)
+	if _kind == &"decoration":
+		## `InitializeEventsScript`'s two owned decorations plus the doll Mom's
+		## savings buy first, so the category menu has more than one row.
+		Gen2WorldSpawn.apply_initial_decorations(state)
+		state.set_event_flag(DECO_FLAG_CHARMANDER_DOLL, true)
+	if _kind == &"hall_of_fame":
+		state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+		state.set_hall_of_fame(true)
 	if _kind == &"unown_dex":
 		state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
 		## What the Ruins of Alph research centre leaves behind: the upgraded
@@ -84,6 +98,8 @@ func _initialize() -> void:
 	)
 	var save := Gen2SaveStore.create_development_save(_data, 0)
 	save.world = world.snapshot()
+	if _kind == &"hall_of_fame":
+		save.hall_of_fame = Gen2HallOfFame.inducted([], save)
 	_screen.set_data(_data)
 	_screen.set_save(save)
 	root.add_child(_screen)
@@ -160,6 +176,9 @@ func _write_service_cache() -> void:
 		if number == 7:
 			raw["name"] = "ITEM7"
 			raw["price"] = 120
+			## `SellMenu` reads the pack, which groups by the item's own type
+			## byte: an unclassified row is in no pocket and cannot be sold.
+			raw["pocket"] = Gen2WorldPack.TYPE_ITEM
 		elif APRICORNS.has(number):
 			raw["name"] = String(APRICORNS[number])
 	RomCache.write_json(RomCache.items_path(_fixture_directory), items)
@@ -178,7 +197,7 @@ func _write_service_cache() -> void:
 		Gen2WorldScript.SPECIAL,
 		Gen2WorldScriptRunner.SPECIAL_POKEMON_CENTER_PC, 0x00,
 		Gen2WorldScript.END,
-	] if _kind == &"pc" else [
+	] if _kind in [&"pc", &"decoration", &"hall_of_fame"] else [
 		0x94, 0, 0x00, 0x40, 0x91,
 	]
 	RomCache.write_json(RomCache.world_scripts_path(_fixture_directory), scripts)

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -43,7 +43,7 @@ const GROUPS: Dictionary = {
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
-		&"card_flip", &"move_effects", &"phone",
+		&"card_flip", &"move_effects", &"phone", &"decorations",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
Five screens this port had simplified are built, and the mod repository's open
engine request is answered.

## A mart can be sold to

`StandardMart`'s BUY/SELL/QUIT loop runs over the buy screen that was already
there, with `.AnythingElse` between one sale and the next. A sale is `TossItem`
plus `GiveMoney` at `Sell_HalvePrice`'s halved *total*, which is not the same
arithmetic as a halved unit price. Four more `SellMenu` text stubs join
`MART_TEXT_AT`; `tools/checks/mart.gd` pins them on all three cartridges.

The list a sale is chosen from is the shop's own, not `DepositSellPack`'s pack
screen. That is a decision and it is in the divergence table with its reason.

## RARE CANDY and the four PP restorers work in the field

Rare candy is one level, `CalcExpAtLevel` back onto the experience, the max-HP
delta added to the current HP rather than a heal, `LearnLevelMoves` and then
`EvolvePokemon`. `MAX_LEVEL` is a refusal, not a clamp. ETHER and MAX ETHER ask
`MoveSelectionScreen` for a slot; ELIXER and MAX ELIXER walk all four.

PP UP is refused by name rather than doing nothing: `ApplyPPUp` raises the top
two bits of a move's own PP byte, and the save model keeps the current value
alone.

## Decorations

`DecorationAttributes` and `DecorationNames` are imported, one pinned address per
dump. `tools/checks/decorations.gd` sweeps all fifty-three rows on all three
cartridges: every type, action, event flag and block-or-sprite byte, plus the
name the port spells from them. The two pins differ in one string and the check
pins that too.

The bedroom PC's DECORATION row is the seven categories and the `DecoAction_*`
over them. Ownership is the `EVENT_DECO_*` flags the world state already carried
and the four extra `wDeco*` slots are four more keys in the dictionary
`maptile_decoration` already was, so no format version moved for either.
`ToggleDecorationsVisibility` fills the four variable sprites now instead of
hiding all four objects, and `describedecoration` names what stands in the slot.

## HALL OF FAME, MOVE PKMN W/O MAIL, and CHANGE BOX's NAME and PRINT

`Gen2SaveData` grew `hall_of_fame` and `box_names`. Both default rather than
versioning, the way `current_box` does: an older slot's empty list is the truth
about it. A machine's HALL OF FAME row walks the stored inductions through the
induction's own panels, so there is one implementation of them.

`Gen2BoxScreen.MODE_MOVE` is `_MovePKMNWithoutMail`: left and right load the
party or any box, the submenu drops RELEASE, and the second A inserts the
Pokemon where the cursor stands. CHANGE BOX opens SWITCH, NAME and PRINT.

## A visible encounter may ask for a glow (`api_version` 15)

The mod repository's open request. `overworld_encounters` wants to mark a wild
whose DVs total 50 or more so a player can tell one worth stopping for from
across a route, and it cannot: `actor_entries()` resolves the four colours itself
and `_validate` builds a fresh row from the keys it knows, so a provider has no
way to reach the palette its own Pokemon is drawn in. That division is right;
what was missing is the ask.

An entry may now carry an optional `{color, amount}`, applied where the host
already resolves that palette. Colour 0 is left alone: it is the icon's cut-out,
so walking it would change the texture cache key and no pixel. The glow is in
`_changed()`, or a Pokemon standing still would hold whichever rung it was on
when it last moved.

The amount is rounded onto `Gen2WorldEncounters.GLOW_RUNGS` by the host rather
than by the mod. Both world renderers cache one sprite texture per distinct set
of four colours and **neither evicts**, so a smoothly interpolated glow would
leave a texture behind on every frame the map was up. Eight rungs rather than
four: a mark meant to be subtle needs a cycle left after the rounding, and a peak
under half the walk keeps four steps on eighths and one on quarters.

Presentation only. No DV, no battle and no roll changes, and both views get it
through the same per-entry `colors` override a shiny's palette already takes.

## Proof

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3702 tests, 3702 passing |
| `tools/validate.gd -- all` | 70 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no refusals |
| Import, three cartridges | `layout: Layout verified.` on each |

Cache format 85, `api_version` 15. The decorations check goes red on a broken
name index, which is how it was proved to be checking something.