### PR TITLE
Mail is a real item again, all ten designs and both menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > Silver: every Johto badge with the errand behind it, then Kanto, all sixteen
 > badges, the Hall of Fame with Prof Oak's rating, and the credits.
 >
-> Missing: link play, item mail and Mystery Gift, the Battle Tower, and a
+> Missing: link play and Mystery Gift, the Battle Tower, and a
 > handful of pixel-level divergences still being chased in the opening movies
 > and title screen against a real cartridge.
 
@@ -266,7 +266,7 @@ The rest are previews and dumps, each driving a real screen or table:
 |---|---|
 | `dump_tables.gd <game> <table>` | Prints a decoded table: `species`, `moves`, `items`, `types`, `matchups`, `trainers`, `learnsets`, `egg_moves`, `evolutions`, `growth` or `all` |
 | `preview_pics.gd <game> <png> [kind]` | Contact sheet of `front`, `trainers`, `font` or `frames` |
-| `preview_*.gd` | One per screen: the intro, title, credits, Hall of Fame, region map, party, marts, fishing, battle switch and animations, overworld sprites and collision |
+| `preview_*.gd` | One per screen: the intro, title, credits, Hall of Fame, region map, party, marts, mail, fishing, battle switch and animations, overworld sprites and collision |
 | `preview_world_story.gd` | Map entry callbacks, event-flag visibility, facing interactions and the whole story route |
 | `replay_world.gd [game ...] [frames]` | Records `(frame, button)` from a real run and replays it into a fresh world; the same seed and log must reach the same snapshot, party and battle outcome byte for byte, at 30 fps and at 144. One route fights: a wild battle is spent from the world's own pump and steered through its own funnel |
 | `render_audio.gd <game> <kind> <id> <frames> <prefix>` | One record or a whole table through the driver and APU: a WAV plus a per-frame register trace to diff |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -145,7 +145,11 @@ the whole corpus, and settle every disagreement against pret.
   during a call can corrupt the VM. Use
   `godot --headless --check-only --script res://path.gd`.
 - New scripts need an editor scan before they resolve; edits to existing ones do
-  not: `godot --headless --editor --path . --quit`.
+  not: `godot --headless --editor --path . --quit`. The class index lives in
+  `.godot/`, which is a build cache and not committed, so the gap is visible to
+  anything else resolving against this checkout: a mod repository parsing its
+  own scripts with `--check-only --path <this>` fails on the file that names the
+  new class, not on its own. Run the scan in the commit that adds the class.
 - Defer `_ready()` scene changes with `change_scene_to_file.call_deferred(path)`.
 - A bare `PanelContainer` is transparent; give modals a
   `theme_override_styles/panel` `StyleBoxFlat`.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -163,7 +163,12 @@ item, four moves, OT ID, three-byte experience, five stat-experience words, DVs,
 PP, happiness, Pokerus, caught data and level. `party_struct` adds status,
 current/max HP and five derived stats.
 
-Original SRAM also contains player, map, checksum, PC box, mail, Hall of Fame and
+Mail is on the record rather than in a slot of its own: `Gen2SaveMon.mail` is
+`sPartyMail`'s entry for that member and `Gen2SaveData.mailbox` is `sMailboxes`
+behind `sMailboxCount`. Both default rather than versioning, so a slot written
+before mail existed reads as a party holding none and an empty mailbox.
+
+Original SRAM also contains player, map, checksum, PC box, Hall of Fame and
 Crystal-specific regions. The first model imports only party data; the optional
 project world snapshot is a separate canonical runtime shape and does not claim
 to reproduce unsupported SRAM bytes.

--- a/game/battle/held_item.gd
+++ b/game/battle/held_item.gd
@@ -98,8 +98,11 @@ const PIKACHU: int = 25
 const METAL_POWDER_ITEM: int = 35
 const DITTO: int = 132
 
-## `MailItems` (data/items/mail_items.asm), pinned rather than imported for want
-## of a locator. `BattleCommand_Thief` is the only reader.
+## `MailItems` (data/items/mail_items.asm). Pinned rather than read from
+## [GameData] because the battle engine takes no cache; the table is imported
+## beside it and `tools/checks/mail.gd` holds the two together on all three
+## cartridges, so a wrong pin here is a red check rather than a silent
+## disagreement.
 const MAIL_ITEMS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]
 
 ## Metal Powder's half again, floored the way `srl a; add c` floors it.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -58,6 +58,8 @@ var _stats_screen_palettes: Dictionary = {}
 var _player_palettes: Dictionary = {}
 var _transition_palettes: Dictionary = {}
 var _card_palettes: Dictionary = {}
+var _mail_palettes: Array = []
+var _mail_items: Array = []
 var _pokedex_palettes: Dictionary = {}
 var _pack: Dictionary = {}
 var _pc_palette: Array = []
@@ -160,6 +162,10 @@ static func open_directory(path: String) -> GameData:
 	data._player_palettes = manifest.get("player_palettes", {})
 	data._transition_palettes = manifest.get("transition_palettes", {})
 	data._card_palettes = manifest.get("card_palettes", {})
+	var mail_palettes: Variant = manifest.get("mail_palettes", [])
+	data._mail_palettes = mail_palettes if mail_palettes is Array else []
+	var mail_items: Variant = manifest.get("mail_items", [])
+	data._mail_items = mail_items if mail_items is Array else []
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	data._pack = manifest.get("pack", {})
 	var raw_pc_palette: Variant = manifest.get("pc_palette", [])
@@ -1347,6 +1353,29 @@ func name_input_chars(table: int) -> Array:
 		for code: Variant in row:
 			codes.append(int(code))
 		out.append(codes)
+	return out
+
+
+## `MailItems`, the ten item numbers `ItemIsMail` answers for. Empty on a cache
+## written before mail was imported, which is what [method Gen2HeldItem.is_mail]
+## falls back to its own pin for.
+func mail_items() -> Array:
+	var out: Array = []
+	for number: Variant in _mail_items:
+		out.append(int(number))
+	return out
+
+
+## One of `LoadMailPalettes.MailPals`' ten, in `MailGFXPointers` order and whole:
+## the read-mail screen draws every one of its four colours, unlike the pairs
+## `LoadPalette_White_Col1_Col2_Black` expands.
+func mail_palette(index: int) -> PackedColorArray:
+	if index < 0 or index >= _mail_palettes.size():
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	var stored: Array = _mail_palettes[index]
+	var out := PackedColorArray()
+	for word: Variant in stored:
+		out.append(Gen2Palette.from_packed(int(word)))
 	return out
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -81,7 +81,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 85
+const FORMAT_VERSION: int = 86
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -294,6 +294,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not name_input["ok"]:
 		return name_input
 
+	var mail: Dictionary = verify_mail(rom, layout)
+	if not mail["ok"]:
+		return mail
+
 	var intro_text: Dictionary = verify_intro_text(rom, layout)
 	if not intro_text["ok"]:
 		return intro_text
@@ -2373,6 +2377,110 @@ static func verify_string_buffer_pointers(rom: RomFile, layout: Dictionary) -> D
 	return {"ok": true, "pointers": pointers}
 
 
+## `MailItems` (data/items/mail_items.asm), pinned here rather than read off the
+## cartridge so the check disagrees with a wrong offset instead of agreeing with
+## it. FLOWER_MAIL is the odd one out; the other nine are consecutive.
+const MAIL_ITEM_NUMBERS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]
+## `gfx/mail/morph_mail_divider.1bpp`, the eight bytes `gfx/mail.asm` opens on,
+## and the eight `gfx/mail/portraitmail_border.1bpp` ends on. Both are one flat
+## tile, which is what makes the ends of a 1,360-byte run checkable at all.
+const MAIL_GFX_FIRST_TILE: Array[int] = [0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00]
+const MAIL_GFX_LAST_TILE: Array[int] = [0x27, 0x27, 0x27, 0x27, 0x27, 0x27, 0x27, 0x27]
+## `gfx/mail/mail.pal`'s first colour per row, encoded. The fourth colour of
+## every row is black, which is checked as a run rather than pinned per row.
+const MAIL_PALETTE_FIRST: Array[int] = [
+	0x2FF4, 0x7E8F, 0x7E38, 0x473F, 0x7F53, 0x727F, 0x5E33, 0x7F47, 0x57F5, 0x7F47,
+]
+
+
+## The five mail pins, each against something only the right offset carries:
+## `MailItems`' own eleven bytes, the two mail keyboards at both ends the way
+## the name keyboards are checked, the flat tiles `gfx/mail.asm` begins and ends
+## on, and `mail.pal`'s first colour per row with black behind every one.
+##
+## The icon is checked for bounds alone: eight 2bpp tiles of a picture with no
+## structure a wrong offset would fail, and `tools/checks/mail.gd` is what looks
+## at it.
+static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("mail", {})
+	if entry.is_empty():
+		return {"ok": false, "message": "The cartridge has no mail block."}
+
+	var items: int = int(entry.get("items", -1))
+	if not rom.in_bounds(items, RomLayout.MAIL_ITEM_COUNT + 1):
+		return {"ok": false, "message": "MailItems is outside the cartridge."}
+	for index: int in RomLayout.MAIL_ITEM_COUNT:
+		if rom.u8(items + index) != MAIL_ITEM_NUMBERS[index]:
+			return {
+				"ok": false,
+				"message": "MailItems entry %d is $%02X, expected $%02X." % [
+					index, rom.u8(items + index), MAIL_ITEM_NUMBERS[index],
+				],
+			}
+	if rom.u8(items + RomLayout.MAIL_ITEM_COUNT) != RomLayout.MAIL_ITEM_END:
+		return {"ok": false, "message": "MailItems does not end in -1."}
+
+	var chars: int = int(entry.get("input_chars", -1))
+	var block: int = RomLayout.MAIL_INPUT_TABLES * RomLayout.MAIL_INPUT_TABLE_ROWS \
+		* RomLayout.MAIL_INPUT_ROW_BYTES
+	if not rom.in_bounds(chars, block):
+		return {"ok": false, "message": "Mail input tables are outside the cartridge."}
+	for table: int in RomLayout.MAIL_INPUT_TABLES:
+		var start: int = RomLayout.mail_input_table_offset(layout, table)
+		var first: int = RomLayout.MAIL_INPUT_UPPER_A if table == 0 else RomLayout.MAIL_INPUT_LOWER_A
+		for column: int in RomLayout.MAIL_INPUT_COLUMNS:
+			var expected: int = first + column
+			var stored: int = rom.u8(start + column * RomLayout.NAME_INPUT_COLUMN_STRIDE)
+			if stored != expected:
+				return {
+					"ok": false,
+					"message": "Mail input table %d letter %d is $%02X, expected $%02X." % [
+						table, column, stored, expected,
+					],
+				}
+		var command: int = start + (RomLayout.MAIL_INPUT_TABLE_ROWS - 1) \
+			* RomLayout.MAIL_INPUT_ROW_BYTES
+		var expected_row: Array[int] = (
+			RomLayout.MAIL_INPUT_COMMAND_UPPER if table == 0
+			else RomLayout.MAIL_INPUT_COMMAND_LOWER
+		)
+		if Array(rom.slice(command, RomLayout.MAIL_INPUT_ROW_BYTES)) != Array(expected_row):
+			return {"ok": false, "message": "Mail input table %d has no command row." % table}
+
+	var gfx: int = int(entry.get("gfx", -1))
+	if not rom.in_bounds(gfx, RomLayout.MAIL_GFX_BYTES):
+		return {"ok": false, "message": "Mail graphics run past the cartridge."}
+	var ends: Dictionary = {
+		gfx: MAIL_GFX_FIRST_TILE,
+		gfx + RomLayout.MAIL_GFX_BYTES - RomLayout.TILE_BYTES_1BPP: MAIL_GFX_LAST_TILE,
+	}
+	for at: int in ends:
+		if Array(rom.slice(at, RomLayout.TILE_BYTES_1BPP)) != Array(ends[at] as Array):
+			return {"ok": false, "message": "Mail graphics tile at $%X is not its own." % at}
+
+	var palettes: int = int(entry.get("palettes", -1))
+	var palette_bytes: int = RomLayout.MAIL_PALETTE_COUNT * RomLayout.MAIL_PALETTE_COLOURS * 2
+	if not rom.in_bounds(palettes, palette_bytes):
+		return {"ok": false, "message": "Mail palettes are outside the cartridge."}
+	for index: int in RomLayout.MAIL_PALETTE_COUNT:
+		var at_row: int = palettes + index * RomLayout.MAIL_PALETTE_COLOURS * 2
+		if rom.u16le(at_row) != MAIL_PALETTE_FIRST[index]:
+			return {
+				"ok": false,
+				"message": "Mail palette %d opens on $%04X, expected $%04X." % [
+					index, rom.u16le(at_row), MAIL_PALETTE_FIRST[index],
+				],
+			}
+		if rom.u16le(at_row + (RomLayout.MAIL_PALETTE_COLOURS - 1) * 2) != 0:
+			return {"ok": false, "message": "Mail palette %d does not end in black." % index}
+
+	if not rom.in_bounds(
+		int(entry.get("icon", -1)), RomLayout.MAIL_ICON_TILES * RomLayout.TILE_BYTES_2BPP
+	):
+		return {"ok": false, "message": "The mail icon is outside the cartridge."}
+	return {"ok": true, "message": "Mail tables, graphics and palettes verified."}
+
+
 static func verify_name_input_chars(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var at: int = int(layout.get("name_input_chars", -1))
 	if not rom.in_bounds(at, RomLayout.NAME_INPUT_BLOCK_BYTES):
@@ -4300,6 +4408,8 @@ func import_rom(
 		"move_screen_palette": _import_move_screen_palette(rom, layout),
 		"stats_screen_palettes": _import_stats_screen_palettes(rom, layout),
 		"card_palettes": _import_card_palettes(rom, layout),
+		"mail_palettes": _import_mail_palettes(rom, layout),
+		"mail_items": _import_mail_items(rom, layout),
 		"pokedex_palettes": _import_pokedex_palettes(rom, layout),
 		"pc_palette": _import_pc_palette(rom, layout),
 		"gender_screen_palette": _import_gender_screen_palette(rom, layout),
@@ -4609,6 +4719,40 @@ func _import_name_input_chars(rom: RomFile, layout: Dictionary) -> Array:
 			var at: int = start + row * RomLayout.NAME_INPUT_ROW_BYTES
 			rows.append(Array(rom.slice(at, RomLayout.NAME_INPUT_ROW_BYTES)))
 		out.append(rows)
+	## data/text/mail_input_chars.asm's two, appended so one cache file carries
+	## every keyboard the naming screen can be on. A mail row is 19 bytes and a
+	## name row 17, which is the only difference in how they are read.
+	for table: int in RomLayout.MAIL_INPUT_TABLES:
+		var mail_start: int = RomLayout.mail_input_table_offset(layout, table)
+		var mail_rows: Array = []
+		for row: int in RomLayout.MAIL_INPUT_TABLE_ROWS:
+			var at: int = mail_start + row * RomLayout.MAIL_INPUT_ROW_BYTES
+			mail_rows.append(Array(rom.slice(at, RomLayout.MAIL_INPUT_ROW_BYTES)))
+		out.append(mail_rows)
+	return out
+
+
+## `MailItems`, the ten numbers in front of its -1. `ItemIsMail` is the only
+## reader and [method Gen2HeldItem.is_mail] is its pin; `tools/checks/mail.gd`
+## is what holds the two to each other on every cartridge.
+func _import_mail_items(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int((layout["mail"] as Dictionary)["items"])
+	return Array(rom.slice(at, RomLayout.MAIL_ITEM_COUNT))
+
+
+## `LoadMailPalettes.MailPals`, four packed words per mail type in
+## `MailGFXPointers` order. Stored packed the way the other palette tables are,
+## so the colour a page draws with is the cartridge's own word.
+func _import_mail_palettes(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int((layout["mail"] as Dictionary)["palettes"])
+	var out: Array = []
+	for index: int in RomLayout.MAIL_PALETTE_COUNT:
+		var colours: Array = []
+		for colour: int in RomLayout.MAIL_PALETTE_COLOURS:
+			colours.append(
+				rom.u16le(at + (index * RomLayout.MAIL_PALETTE_COLOURS + colour) * 2)
+			)
+		out.append(colours)
 	return out
 
 
@@ -6276,6 +6420,20 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 		"naming_cursor": {
 			"offset": RomLayout.naming_cursor_offset(layout),
 			"tiles": RomLayout.NAMING_CURSOR_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		## `gfx/mail.asm`, one flat 1bpp run the ten `Load*MailGFX` routines
+		## index by byte, and `_ComposeMailMessage.MailIcon`'s eight 2bpp tiles.
+		"mail_gfx": {
+			"offset": int((layout["mail"] as Dictionary)["gfx"]),
+			"tiles": RomLayout.MAIL_GFX_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"mail_icon": {
+			"offset": int((layout["mail"] as Dictionary)["icon"]),
+			"tiles": RomLayout.MAIL_ICON_TILES,
 			"first_code": 0,
 			"bits": 2,
 		},

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -161,8 +161,9 @@ const ICON_EGG: int = 28
 
 ## `HeldItemIcons` is `gfx/stats/mail.2bpp` and `gfx/stats/item.2bpp`, the two
 ## tiles `GetIconGFX` loads behind every icon's eight. `ItemIsMail` is
-## [method Gen2HeldItem.is_mail]; the mail icon is still drawn by no party menu
-## here, and `SPRITE_ANIM_FRAMESET_PARTY_MON_WITH_MAIL` is unreachable.
+## [method Gen2HeldItem.is_mail], and `.SpawnItemIcon` is what picks between
+## the two: `SPRITE_ANIM_FRAMESET_PARTY_MON_WITH_MAIL` for a held mail and
+## `..._WITH_ITEM` for anything else.
 const HELD_ITEM_ICON_TILES: int = 2
 const HELD_ITEM_ICON_MAIL: int = 0
 const HELD_ITEM_ICON_ITEM: int = 1
@@ -1906,6 +1907,59 @@ const NAME_INPUT_COMMAND_UPPER: Array[int] = [
 	0x8B, 0x7F, 0x7F, 0x7F, 0x84, 0x8D, 0x83, 0x7F,
 ]
 
+## data/text/mail_input_chars.asm's two keyboards, stored the same way and
+## behind their own pin: `_ComposeMailMessage`'s code sits between them and the
+## four above, so the block is not walked from `name_input_chars`. A mail row is
+## 19 bytes rather than 17 and every table is 6 rows, `.PlaceMailCharset`'s own
+## `ld b, 6` over `ld c, SCREEN_WIDTH - 1`.
+const MAIL_INPUT_ROW_BYTES: int = 19
+const MAIL_INPUT_TABLE_ROWS: int = 6
+const MAIL_INPUT_TABLES: int = 2
+## `ComposeMail_AnimateCursor.LetterEntries` has ten entries and steps $10, so a
+## mail column is every second byte the way a name column is.
+const MAIL_INPUT_COLUMNS: int = 10
+## The first row of each keyboard, which is what pins the block: "A B C ..." and
+## "a b c ...", encoded.
+const MAIL_INPUT_UPPER_A: int = 0x80
+const MAIL_INPUT_LOWER_A: int = 0xA0
+## The command row of each mail keyboard, which is what the other end of the
+## block is pinned on. Table 0 is uppercase and its switch says "lower".
+const MAIL_INPUT_COMMAND_UPPER: Array[int] = [
+	0xAB, 0xAE, 0xB6, 0xA4, 0xB1, 0x7F, 0x7F, 0x83, 0x84, 0x8B,
+	0x7F, 0x7F, 0x7F, 0x84, 0x8D, 0x83, 0x7F, 0x7F, 0x7F,
+]
+const MAIL_INPUT_COMMAND_LOWER: Array[int] = [
+	0x94, 0x8F, 0x8F, 0x84, 0x91, 0x7F, 0x7F, 0x83, 0x84, 0x8B,
+	0x7F, 0x7F, 0x7F, 0x84, 0x8D, 0x83, 0x7F, 0x7F, 0x7F,
+]
+
+## constants/item_data_constants.asm's mail block. `MAIL_STRUCT_LENGTH` is $2f:
+## two lines, the `<NEXT>` between them, the author, a nationality word, the
+## author's ID, the species and the mail type.
+const MAIL_LINE_LENGTH: int = 0x10
+const MAIL_MSG_LENGTH: int = 2 * MAIL_LINE_LENGTH
+const MAILBOX_CAPACITY: int = 10
+const MAIL_STRUCT_LENGTH: int = 0x2F
+## `PLAYER_NAME_LENGTH`, the field's own width. Both writers copy
+## `NAME_LENGTH - 1` bytes into it, so the two bytes of `Nationality` behind it
+## carry the tail of the name and no nationality; see [Gen2SaveMail].
+const MAIL_AUTHOR_FIELD: int = 8
+const MAIL_AUTHOR_LENGTH: int = 10
+
+## `MailItems`, ten numbers and the -1 behind them.
+const MAIL_ITEM_COUNT: int = 10
+const MAIL_ITEM_END: int = 0xFF
+## `MailGFXPointers` order, which is also `LoadMailPalettes.MailPals`': the
+## *MAIL_INDEX constants at the head of engine/pokemon/mail_2.asm.
+const MAIL_PALETTE_COUNT: int = 10
+const MAIL_PALETTE_COLOURS: int = 4
+## `gfx/mail.asm`, one uncompressed 1bpp run the load routines index by byte.
+const MAIL_GFX_BYTES: int = 1360
+const MAIL_GFX_TILES: int = MAIL_GFX_BYTES / TILE_BYTES_1BPP
+## `_ComposeMailMessage.MailIcon`, the eight tiles the screen spawns as a party
+## icon over the entry.
+const MAIL_ICON_TILES: int = 8
+
 ## constants/item_constants.asm. TM01 is $bf and HM01 $f3, but the run is not
 ## contiguous: ITEM_C3 and ITEM_DC are dummy items inside it, which is why
 ## GetTMHMNumber skips them rather than subtracting.
@@ -2298,6 +2352,17 @@ const GOLD_SILVER: Dictionary = {
 		"select_gfx": 0xE3BF8,
 		"mail_gfx": 0xE3C18,
 		"orange_palette": 0x95CD,
+	},
+	# Mail. `items` is `MailItems`' own eleven bytes, `input_chars` the two
+	# `MailEntry_*` keyboards assembled whole, `gfx` the 1,360 bytes
+	# `gfx/mail.asm` INCBINs in one run, `palettes` `gfx/mail/mail.pal` encoded
+	# and `icon` `gfx/naming_screen/mail.2bpp`. Each hits once per dump.
+	"mail": {
+		"items": 0xBBAF7,
+		"input_chars": 0x125B6,
+		"gfx": 0xBB59D,
+		"palettes": 0x92C1,
+		"icon": 0x122C1,
 	},
 	# Battle animations. `BattleAnimations` was located by matching
 	# `BattleAnim_Pound` whole (d1 01 e0 01 31 d0 08 88 38 00 06 d0 01 88 38 00
@@ -2800,6 +2865,14 @@ const CRYSTAL: Dictionary = {
 		"mail_gfx": 0xE349D,
 		"orange_palette": 0x9036,
 	},
+	# Mail; see the Gold and Silver block above for how these were located.
+	"mail": {
+		"items": 0xB9E80,
+		"input_chars": 0x121DD,
+		"gfx": 0xB9926,
+		"palettes": 0x8D05,
+		"icon": 0x11EF4,
+	},
 	# Battle animations; see the Gold and Silver block above for how these were
 	# located. All five tables sit in the same two banks in every dump and only
 	# the addresses within them move.
@@ -3098,6 +3171,14 @@ static func name_input_table_offset(layout: Dictionary, table: int) -> int:
 	for before: int in table:
 		at += NAME_INPUT_TABLE_ROWS[before] * NAME_INPUT_ROW_BYTES
 	return at
+
+
+## Where [param table] of the two mail keyboards starts. The pair is stored back
+## to back the way the four name keyboards are, and every mail table is the same
+## six rows.
+static func mail_input_table_offset(layout: Dictionary, table: int) -> int:
+	return int((layout["mail"] as Dictionary)["input_chars"]) \
+		+ table * MAIL_INPUT_TABLE_ROWS * MAIL_INPUT_ROW_BYTES
 
 
 ## `data/text_buffers.asm`'s StringBufferPointers, in `text_buffer` argument

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -16,6 +16,9 @@ extends RefCounted
 
 const TERMINATOR: int = 0x50
 const SPACE: int = 0x7F
+## `'<NEXT>'`, the line break `_ComposeMailMessage` writes into the middle of a
+## mail buffer and `PlaceString` drops two rows on.
+const NEXT_LINE: int = 0x4E
 
 ## `_LoadStandardFont`'s strip, and `_LoadFontsBattleExtra`'s, which
 ## `engine/events/halloffame.asm` calls before it prints a panel.
@@ -331,7 +334,7 @@ static func _characters() -> Dictionary:
 	table[0x22] = "\n"
 	table[0x4B] = "\n"
 	table[0x4C] = "\n"
-	table[0x4E] = "\n"
+	table[NEXT_LINE] = "\n"
 	table[0x4F] = "\n"
 	table[0x51] = "\n\n"
 	table[0x55] = "\n"

--- a/game/render/mail_page.gd
+++ b/game/render/mail_page.gd
@@ -1,0 +1,646 @@
+class_name Gen2MailPage
+extends RefCounted
+
+## `ReadAnyMail` and the ten `Load*MailGFX` routines behind it
+## (`engine/pokemon/mail_2.asm`) on the hardware tile grid.
+##
+## Each mail type builds its own VRAM window out of one flat 1bpp run and then
+## writes a tilemap over it, so the page is two transcribed programs per type
+## rather than a picture: [constant LOADS] is the routine's `LoadMailGFX_Color*`
+## calls and [constant PLACES] its `hlcoord` writes. Keeping them as data is what
+## makes ten near-identical routines readable and what lets
+## `tools/checks/mail.gd` sweep every one on every cartridge.
+##
+## The 1bpp run has one ink level; `LoadMailGFX_Color1`, `_Color2` and `_Color3`
+## are the same bytes written into plane 0, plane 1 or both, so a lit pixel comes
+## out as palette index 1, 2 or 3 and an unlit one as 0. That is the whole reason
+## one sheet draws in three shades.
+##
+## Node-free like the other pages: it writes indices into a buffer.
+## PORTRAITMAIL's `PrepMonFrontpic` is in that buffer too rather than being a
+## layer over it: `PlaceGraphic` writes the picture into the tilemap, under the
+## frame the routine then draws, so a host laying it on top would cover the mail
+## with the Pokemon or the Pokemon with the mail.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+
+## `ClearTilemap`'s own fill, which every cell the routine does not write keeps.
+const BLANK_TILE: int = Gen2Text.SPACE
+## `ld hl, vTiles2 tile $31`, where every routine starts loading, and the second
+## destination four of them switch to.
+const FIRST_TILE: int = 0x31
+const SECOND_TILE: int = 0x3D
+
+## `MailGFXPointers` order, which `MailGFX_PlaceMessage` and `LoadMailPalettes`
+## both index: the *MAIL_INDEX constants at the head of `mail_2.asm`.
+const FLOWER: int = 0
+const SURF: int = 1
+const LITEBLUE: int = 2
+const PORTRAIT: int = 3
+const LOVELY: int = 4
+const EON: int = 5
+const MORPH: int = 6
+const BLUESKY: int = 7
+const MUSIC: int = 8
+const MIRAGE: int = 9
+
+## The item number each index is reached by, which is `MailGFXPointers`' own
+## first column and `MailItems`' order.
+const ITEM_NUMBERS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]
+
+## Byte offsets into the `gfx/mail.asm` run, one per INCBIN label. The run is
+## uncompressed and contiguous, so a label is an offset and a `+ n * TILE_1BPP_
+## SIZE` in the source is `+ n * 8` here.
+const G_MORPH_DIVIDER: int = 0
+const G_GRASS: int = 8
+const G_SMALL_POKEBALL: int = 16
+const G_MORPH_BORDER: int = 24
+const G_SMALL_NOTE: int = 32
+const G_WAVE: int = 40
+const G_PORTRAIT_UNDERLINE: int = 56
+const G_LOVELY_UNDERLINE: int = 64
+const G_SMALL_HEART: int = 72
+const G_SMALL_SHAPES: int = 80
+const G_EON_BORDER_1: int = 88
+const G_EON_BORDER_2: int = 104
+const G_NATU: int = 112
+const G_DRATINI: int = 160
+const G_POLIWAG: int = 208
+const G_LAPRAS: int = 256
+const G_EEVEE: int = 304
+const G_DITTO: int = 352
+const G_MEW: int = 400
+const G_DRAGONITE_SENTRET: int = 544
+const G_LARGE_POKEBALL: int = 728
+const G_ODDISH: int = 760
+const G_LARGE_SHAPES: int = 792
+const G_LARGE_HEART: int = 824
+const G_MORPH_CORNER: int = 856
+const G_LARGE_CIRCLE: int = 888
+const G_FLOWER: int = 920
+const G_LARGE_NOTE: int = 984
+const G_CLOUD: int = 1008
+const G_SURF_BORDER: int = 1056
+const G_FLOWER_BORDER: int = 1120
+const G_LITEBLUE_BORDER: int = 1184
+const G_MUSIC_BORDER: int = 1248
+const G_LOVELY_BORDER: int = 1280
+const G_PORTRAIT_BORDER: int = 1320
+
+## A `gfx` op whose source is -1 continues where the last one stopped, which is
+## `de` never being reloaded between two `LoadMailGFX_Color*` calls.
+const CONTINUE: int = -1
+
+## Per type, the routine's own loads. `["at", tile]` is `ld hl, vTiles2 tile n`,
+## `["gfx", source, bytes, colour]` one `LoadMailGFX_Color*` and
+## `["fill", bytes, index]` a `ByteFill` or `MailGFX_GenerateMonochromeTiles
+## Color2`, both of which write a constant rather than a picture.
+const LOADS: Array = [
+	# FLOWER_MAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_FLOWER_BORDER, 64, 1],
+		["gfx", G_ODDISH, 32, 3],
+		["gfx", G_FLOWER_BORDER + 48, 8, 2],
+		["gfx", G_FLOWER, 32, 1],
+		["gfx", CONTINUE, 32, 2],
+	],
+	# SURF_MAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_SURF_BORDER, 64, 2],
+		["gfx", G_LAPRAS, 48, 3],
+		["gfx", G_WAVE, 8, 2],
+		["gfx", G_SMALL_SHAPES, 16, 2],
+		["gfx", CONTINUE, 16, 1],
+		["gfx", G_LARGE_SHAPES, 64, 1],
+		["gfx", CONTINUE, 64, 2],
+	],
+	# LITEBLUEMAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_LITEBLUE_BORDER, 64, 2],
+		["gfx", G_DRATINI, 48, 3],
+		["gfx", G_PORTRAIT_UNDERLINE, 8, 2],
+		["gfx", G_SMALL_SHAPES, 16, 2],
+		["gfx", CONTINUE, 16, 1],
+		["gfx", G_LARGE_SHAPES, 64, 1],
+		["gfx", CONTINUE, 64, 2],
+	],
+	# PORTRAITMAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_PORTRAIT_BORDER, 40, 2],
+		["gfx", G_PORTRAIT_UNDERLINE, 8, 2],
+		["at", SECOND_TILE],
+		["gfx", G_LARGE_POKEBALL, 32, 1],
+		["gfx", G_SMALL_POKEBALL, 8, 2],
+	],
+	# LOVELY_MAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_LOVELY_BORDER, 40, 2],
+		["gfx", G_POLIWAG, 48, 3],
+		["gfx", G_LOVELY_UNDERLINE, 8, 2],
+		["gfx", G_LARGE_HEART, 32, 2],
+		["gfx", G_SMALL_HEART, 8, 1],
+	],
+	# EON_MAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_EON_BORDER_1, 8, 2],
+		["gfx", G_EON_BORDER_2, 8, 1],
+		["gfx", G_EON_BORDER_2, 8, 1],
+		["gfx", G_EON_BORDER_1, 8, 2],
+		["gfx", G_SURF_BORDER + 48, 8, 2],
+		["gfx", G_EEVEE, 48, 3],
+		["at", SECOND_TILE],
+		["gfx", G_LARGE_CIRCLE, 32, 1],
+		["gfx", G_EON_BORDER_2, 8, 2],
+	],
+	# MORPH_MAIL
+	[
+		["at", FIRST_TILE],
+		["fill", 40, 2],
+		["gfx", G_MORPH_CORNER + 24, 8, 2],
+		["gfx", G_MORPH_CORNER, 8, 2],
+		["gfx", G_MORPH_BORDER, 8, 2],
+		["gfx", G_EON_BORDER_1, 8, 1],
+		["gfx", G_MORPH_DIVIDER, 8, 2],
+		["gfx", G_DITTO, 48, 3],
+	],
+	# BLUESKY_MAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_EON_BORDER_1, 8, 2],
+		["fill", 8, 3],
+		["gfx", G_GRASS, 8, 3],
+		["gfx", G_DRAGONITE_SENTRET, 184, 3],
+		["gfx", G_CLOUD, 48, 1],
+		["gfx", G_FLOWER_BORDER + 48, 8, 1],
+		["gfx", G_CLOUD, 8, 1],
+		["gfx", G_CLOUD + 16, 16, 1],
+		["gfx", G_CLOUD + 40, 8, 1],
+	],
+	# MUSIC_MAIL
+	[
+		["at", FIRST_TILE],
+		["gfx", G_MUSIC_BORDER, 32, 2],
+		["gfx", G_MORPH_BORDER, 16, 2],
+		["gfx", G_NATU, 48, 3],
+		["fill", 8, 0],
+		["gfx", G_LARGE_NOTE, 24, 1],
+		["gfx", G_SMALL_NOTE, 8, 1],
+	],
+	# MIRAGE_MAIL
+	[
+		["at", FIRST_TILE],
+		["fill", 40, 2],
+		["gfx", G_GRASS, 8, 2],
+		["gfx", G_MEW, 144, 2],
+		["gfx", G_LITEBLUE_BORDER + 8, 8, 1],
+		["gfx", G_LITEBLUE_BORDER + 48, 8, 1],
+	],
+]
+
+## `LovelyEonMail_PlaceIcons`, which four routines share.
+const ICON_PLACES: Array = [
+	["g2", 2, 2, 0x3D], ["g2", 16, 2, 0x3D], ["g2", 9, 4, 0x3D],
+	["g2", 2, 11, 0x3D], ["g2", 6, 12, 0x3D], ["g2", 12, 11, 0x3D],
+	["put", 5, 4, 0x41], ["put", 6, 2, 0x41], ["put", 12, 4, 0x41],
+	["put", 14, 2, 0x41], ["put", 3, 13, 0x41], ["put", 9, 11, 0x41],
+	["put", 16, 12, 0x41],
+]
+
+## `DrawMailBorder` and `DrawMailBorder2`, the two frames the routines share.
+## Each is the same eight writes with different corners: the first gives every
+## corner its own tile, the second reuses $31 for all four.
+const BORDER: Array = [
+	["put", 0, 0, 0x31], ["row", 1, 0, 0x32, 18], ["put", 19, 0, 0x33],
+	["col", 0, 1, 0x34, 16], ["put", 0, 17, 0x36], ["row", 1, 17, 0x37, 18],
+	["col", 19, 1, 0x35, 16], ["put", 19, 17, 0x38],
+]
+const BORDER2: Array = [
+	["put", 0, 0, 0x31], ["row", 1, 0, 0x32, 18], ["put", 19, 0, 0x31],
+	["col", 0, 1, 0x33, 16], ["put", 0, 17, 0x31], ["row", 1, 17, 0x34, 18],
+	["col", 19, 1, 0x35, 16], ["put", 19, 17, 0x31],
+]
+
+## Per type, the routine's own tilemap writes. `row`/`col` are
+## `Mail_DrawRowLoop` and `Mail_DrawLeftRightBorder`, `altrow`/`altcol` are
+## `Mail_PlaceAlternatingRow`/`Column` and take the number of pairs the source
+## counts (`ld b, 18 / 2`), `seq` is `Mail_Place6TileRow`, `g2` and `g3` are the
+## two `Mail_Draw*Graphic` blocks, and `pic` is `PrepMonFrontpic`.
+const PLACES: Array = [
+	# FLOWER_MAIL
+	[
+		["border"], ["row", 2, 15, 0x3D, 16],
+		["g2", 16, 13, 0x39], ["g2", 2, 13, 0x39],
+		["g2", 2, 2, 0x3E], ["g2", 5, 3, 0x3E], ["g2", 10, 2, 0x3E],
+		["g2", 16, 3, 0x3E], ["g2", 5, 11, 0x3E], ["g2", 16, 10, 0x3E],
+		["g2", 3, 4, 0x42], ["g2", 12, 3, 0x42], ["g2", 14, 2, 0x42],
+		["g2", 2, 10, 0x42], ["g2", 14, 11, 0x42],
+	],
+	# SURF_MAIL
+	[
+		["border"], ["row", 2, 15, 0x3F, 16], ["g3", 15, 14, 0x39],
+		["g2", 2, 2, 0x44], ["g2", 15, 11, 0x44],
+		["g2", 3, 12, 0x4C], ["g2", 15, 2, 0x4C], ["g2", 6, 3, 0x50],
+		["put", 13, 2, 0x40], ["put", 6, 14, 0x40],
+		["put", 4, 5, 0x41], ["put", 17, 5, 0x41], ["put", 13, 12, 0x41],
+		["put", 9, 2, 0x42], ["put", 14, 5, 0x42], ["put", 3, 10, 0x42],
+		["put", 6, 11, 0x43],
+	],
+	# LITEBLUEMAIL: `FinishLoadingSurfLiteBlueMailGFX` is one routine, so the
+	# two types differ in their sheets and in nothing they draw.
+	[
+		["border"], ["row", 2, 15, 0x3F, 16], ["g3", 15, 14, 0x39],
+		["g2", 2, 2, 0x44], ["g2", 15, 11, 0x44],
+		["g2", 3, 12, 0x4C], ["g2", 15, 2, 0x4C], ["g2", 6, 3, 0x50],
+		["put", 13, 2, 0x40], ["put", 6, 14, 0x40],
+		["put", 4, 5, 0x41], ["put", 17, 5, 0x41], ["put", 13, 12, 0x41],
+		["put", 9, 2, 0x42], ["put", 14, 5, 0x42], ["put", 3, 10, 0x42],
+		["put", 6, 11, 0x43],
+	],
+	# PORTRAITMAIL
+	[
+		["border2"], ["row", 8, 15, 0x36, 10], ["icons"], ["pic", 1, 10],
+	],
+	# LOVELY_MAIL
+	[
+		["border2"], ["row", 2, 15, 0x3C, 16], ["g3", 15, 14, 0x36], ["icons"],
+	],
+	# EON_MAIL
+	[
+		["altrow", 0, 0, 0x31, 9], ["altrow", 1, 17, 0x31, 9],
+		["altcol", 0, 1, 0x33, 8], ["altcol", 19, 0, 0x33, 8],
+		["row", 2, 15, 0x35, 16], ["g3", 15, 14, 0x36], ["icons"],
+	],
+	# MORPH_MAIL
+	[
+		["border2"],
+		["g2", 1, 1, 0x31], ["g2", 17, 15, 0x31],
+		["put", 1, 3, 0x31], ["put", 3, 1, 0x31],
+		["put", 16, 16, 0x31], ["put", 18, 14, 0x31],
+		["put", 1, 4, 0x36], ["put", 2, 3, 0x36],
+		["put", 3, 2, 0x36], ["put", 4, 1, 0x36],
+		["put", 15, 16, 0x37], ["put", 16, 15, 0x37],
+		["put", 17, 14, 0x37], ["put", 18, 13, 0x37],
+		["row", 2, 15, 0x38, 14],
+		["row", 2, 11, 0x39, 16], ["row", 2, 5, 0x39, 16],
+		["row", 6, 1, 0x3A, 13], ["row", 1, 16, 0x3A, 13],
+		["g3", 3, 13, 0x3B],
+	],
+	# BLUESKY_MAIL
+	[
+		["row", 0, 0, 0x31, 20], ["col", 0, 1, 0x31, 16], ["col", 19, 1, 0x31, 16],
+		["row", 0, 17, 0x32, 20], ["row", 0, 16, 0x33, 20],
+		# Three `Mail_Place6TileRow`s in a row without reloading `a`, so each
+		# starts where the last stopped: $34, then $3a, then $40.
+		["seq", 2, 2, 0x34, 6], ["seq", 3, 3, 0x3A, 6], ["seq", 4, 4, 0x40, 6],
+		# `dec hl / ld [hl], $7f`: the last tile of the third row is blanked.
+		["put", 9, 4, BLANK_TILE],
+		["g2", 15, 14, 0x45],
+		["put", 15, 16, 0x49], ["put", 16, 16, 0x4A],
+		["g3", 12, 1, 0x4B], ["g3", 15, 4, 0x4B],
+		["row", 2, 11, 0x51, 16], ["g2", 10, 3, 0x52],
+	],
+	# MUSIC_MAIL
+	[
+		["altrow", 0, 0, 0x31, 9], ["altrow", 1, 17, 0x31, 9],
+		["altcol", 0, 1, 0x33, 8], ["altcol", 19, 0, 0x33, 8],
+		["altrow", 2, 15, 0x35, 7], ["g3", 15, 14, 0x37], ["icons"],
+	],
+	# MIRAGE_MAIL
+	[
+		["border2"], ["row", 1, 16, 0x36, 18], ["g3", 15, 14, 0x37],
+		["put", 15, 16, 0x38], ["put", 16, 16, 0x39],
+		["altrow", 1, 1, 0x3F, 9],
+		["altcol", 0, 2, 0x41, 7], ["altcol", 19, 2, 0x43, 7],
+		["put", 0, 1, 0x45], ["put", 19, 1, 0x46],
+		["put", 0, 16, 0x47], ["put", 19, 16, 0x48],
+		["row", 2, 5, 0x49, 16], ["row", 2, 11, 0x4A, 16],
+	],
+]
+
+## `MailGFX_PlaceMessage`'s `hlcoord 2, 7` for the message and its three author
+## columns, which are the type's own: PORTRAITMAIL prints at 8, MORPH_MAIL at 6
+## and everything else at 5.
+const MESSAGE_AT: Vector2i = Vector2i(2, 7)
+const AUTHOR_ROW: int = 14
+const AUTHOR_COLUMN: int = 5
+const AUTHOR_COLUMN_PORTRAIT: int = 8
+const AUTHOR_COLUMN_MORPH: int = 6
+
+## `PrepMonFrontpic`'s `hlcoord 1, 10` and its seven-tile cell. `wBoxAlignment`
+## is 1 there, so the picture is mirrored and `PlaceGraphic.right` lays its
+## columns from the other side; the two compose into a plain horizontal flip
+## (see [method Gen2PicImage.x_flipped_indices]).
+const PIC_AT: Vector2i = Vector2i(1, 10)
+const PIC_TILES: int = 7
+
+var font: Gen2Font = null
+
+## PORTRAITMAIL alone needs the cache at draw time, for the picture the routine
+## puts under its frame.
+var _data: GameData = null
+
+## The `gfx/mail.asm` run as one index strip, `RomLayout.MAIL_GFX_TILES` wide.
+var _strip: PackedByteArray = PackedByteArray()
+## The VRAM window the last [method draw] built, tile number to 64 indices,
+## and the tilemap it wrote over it. Both are kept so `tools/checks/mail.gd` can
+## ask what a type loaded and what it placed without re-running the program.
+var _vram: Dictionary = {}
+var _map: PackedInt32Array = PackedInt32Array()
+var _cursor_tile: int = FIRST_TILE
+var _cursor_row: int = 0
+var _source: int = 0
+
+
+static func from_data(data: GameData) -> Gen2MailPage:
+	var glyphs: Gen2Font = Gen2Font.from_data(data)
+	if glyphs == null or data == null:
+		return null
+	var out := Gen2MailPage.new()
+	out.font = glyphs
+	out._data = data
+	out._strip = data.tile_indices("mail_gfx")
+	return out
+
+
+func ready() -> bool:
+	return font != null \
+		and _strip.size() == RomLayout.MAIL_GFX_TILES * TILE * TILE
+
+
+## Which `MailGFXPointers` row [param item] reaches. The source walks the table
+## and falls through to the first entry when nothing matches; every item that
+## reaches this screen is in the table, so the fallback is the same answer
+## without reproducing the out-of-range palette index the walk leaves behind.
+static func index_for_item(item: int) -> int:
+	var found: int = ITEM_NUMBERS.find(item)
+	return found if found >= 0 else FLOWER
+
+
+## Whether this type draws a Pokemon into the page, which is PORTRAITMAIL alone.
+static func has_pic(index: int) -> bool:
+	return index == PORTRAIT
+
+
+## The whole 160x144 page as palette indices, for [param mail] as it stands.
+func draw(mail: Gen2SaveMail) -> PackedByteArray:
+	var index: int = index_for_item(mail.item if mail != null else 0)
+	_build_vram(index)
+
+	var map: PackedInt32Array = PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	map.fill(BLANK_TILE)
+	_place(map, PLACES[index])
+	_message(map, mail, index)
+	_map = map
+	var indices: PackedByteArray = _compose(map)
+	if has_pic(index):
+		_blend_pic(indices, mail)
+	return indices
+
+
+## The tile numbers the last [method draw] loaded, in order.
+func loaded_tiles() -> Array:
+	var out: Array = _vram.keys()
+	out.sort()
+	return out
+
+
+## The distinct tile numbers the last [method draw] placed on the tilemap.
+func placed_tiles() -> Array:
+	var seen: Dictionary = {}
+	for tile: int in _map:
+		seen[tile] = true
+	var out: Array = seen.keys()
+	out.sort()
+	return out
+
+
+## One cell of the last [method draw]'s tilemap, for a check reading back what
+## the message and the author printed.
+func map_tile(at: Vector2i) -> int:
+	if at.x < 0 or at.x >= COLUMNS or at.y < 0 or at.y >= ROWS:
+		return -1
+	return _map[at.y * COLUMNS + at.x]
+
+
+## `MailGFXPointers`' own walk, so a host knows which
+## `LoadMailPalettes.MailPals` row to draw the page with.
+static func palette_index(mail: Gen2SaveMail) -> int:
+	return index_for_item(mail.item if mail != null else 0)
+
+
+## `MailGFX_PlaceMessage`: the buffer through one `PlaceString` at
+## `hlcoord 2, 7`, whose `<NEXT>` drops two rows, then the author on row 14.
+func _message(map: PackedInt32Array, mail: Gen2SaveMail, index: int) -> void:
+	if mail == null:
+		return
+	var at: Vector2i = MESSAGE_AT
+	var column: int = 0
+	for code: int in mail.message:
+		if code == Gen2Text.TERMINATOR:
+			break
+		if code == Gen2SaveMail.LINE_BREAK:
+			at.y += 2
+			column = 0
+			continue
+		_put(map, Vector2i(at.x + column, at.y), code)
+		column += 1
+	if mail.author.is_empty():
+		return
+	var author_x: int = AUTHOR_COLUMN
+	if index == PORTRAIT:
+		author_x = AUTHOR_COLUMN_PORTRAIT
+	elif index == MORPH:
+		author_x = AUTHOR_COLUMN_MORPH
+	var codes: PackedByteArray = Gen2Text.encode(mail.author)
+	for offset: int in codes.size():
+		_put(map, Vector2i(author_x + offset, AUTHOR_ROW), codes[offset])
+
+
+## One type's `LoadMailGFX_Color*` run into a fresh VRAM window.
+func _build_vram(index: int) -> void:
+	_vram = {}
+	_cursor_tile = FIRST_TILE
+	_cursor_row = 0
+	_source = 0
+	for raw_op: Variant in LOADS[index]:
+		var op: Array = raw_op
+		match String(op[0]):
+			"at":
+				_cursor_tile = int(op[1])
+				_cursor_row = 0
+			"gfx":
+				if int(op[1]) != CONTINUE:
+					_source = int(op[1])
+				for _row: int in int(op[2]):
+					_write_row(_source_row(_source), int(op[3]))
+					_source += 1
+			"fill":
+				for _row: int in int(op[1]):
+					_write_row(PackedByteArray(), int(op[2]), true)
+
+
+## One 1bpp byte out of the run, as the eight pixels it lights. The strip is
+## already decoded, so a lit pixel is [constant Gen2Tiles.INK] and the row is
+## read off it rather than out of the byte.
+func _source_row(byte_offset: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(TILE)
+	@warning_ignore("integer_division")
+	var tile: int = byte_offset / TILE
+	var row: int = byte_offset % TILE
+	var width: int = RomLayout.MAIL_GFX_TILES * TILE
+	if tile < 0 or tile >= RomLayout.MAIL_GFX_TILES:
+		return out
+	for column: int in TILE:
+		out[column] = _strip[row * width + tile * TILE + column]
+	return out
+
+
+## One row of the write cursor's tile, advancing it and stepping to the next
+## tile every eight rows. [param constant_fill] writes [param colour] over the
+## whole row, which is what a `ByteFill` and the monochrome generator do.
+func _write_row(source: PackedByteArray, colour: int, constant_fill: bool = false) -> void:
+	if not _vram.has(_cursor_tile):
+		var blank := PackedByteArray()
+		blank.resize(TILE * TILE)
+		_vram[_cursor_tile] = blank
+	var cell: PackedByteArray = _vram[_cursor_tile]
+	for column: int in TILE:
+		if constant_fill:
+			cell[_cursor_row * TILE + column] = colour
+		elif column < source.size() and source[column] == Gen2Tiles.INK:
+			cell[_cursor_row * TILE + column] = colour
+	_vram[_cursor_tile] = cell
+	_cursor_row += 1
+	if _cursor_row >= TILE:
+		_cursor_row = 0
+		_cursor_tile += 1
+
+
+func _place(map: PackedInt32Array, program: Array) -> void:
+	for raw_op: Variant in program:
+		var op: Array = raw_op
+		match String(op[0]):
+			"border":
+				_place(map, BORDER)
+			"border2":
+				_place(map, BORDER2)
+			"icons":
+				_place(map, ICON_PLACES)
+			"put":
+				_put(map, Vector2i(int(op[1]), int(op[2])), int(op[3]))
+			"row":
+				for step: int in int(op[4]):
+					_put(map, Vector2i(int(op[1]) + step, int(op[2])), int(op[3]))
+			"col":
+				for step: int in int(op[4]):
+					_put(map, Vector2i(int(op[1]), int(op[2]) + step), int(op[3]))
+			"seq":
+				for step: int in int(op[4]):
+					_put(map, Vector2i(int(op[1]) + step, int(op[2])), int(op[3]) + step)
+			"altrow":
+				_alternating(map, op, true)
+			"altcol":
+				_alternating(map, op, false)
+			"g2":
+				_block(map, op, 2)
+			"g3":
+				_block(map, op, 3)
+			"pic":
+				## `PrepMonFrontpic` writes tiles the page has no picture for:
+				## the pic is its host's own layer over [method pic_position].
+				pass
+
+
+## `Mail_PlaceAlternatingRow` and `..._Column`: `b` pairs of the tile and the
+## one after it, then one more of the tile itself, so a run is `2 * b + 1` long.
+func _alternating(map: PackedInt32Array, op: Array, horizontal: bool) -> void:
+	var at := Vector2i(int(op[1]), int(op[2]))
+	var tile: int = int(op[3])
+	var step := Vector2i(1, 0) if horizontal else Vector2i(0, 1)
+	for pair: int in int(op[4]):
+		_put(map, at, tile)
+		_put(map, at + step, tile + 1)
+		at += step * 2
+	_put(map, at, tile)
+
+
+## `Mail_Draw2x2Graphic` and `Mail_Draw3x2Graphic`, both of which lay their
+## tiles left to right and then top to bottom from the tile they are given.
+func _block(map: PackedInt32Array, op: Array, width: int) -> void:
+	var at := Vector2i(int(op[1]), int(op[2]))
+	var tile: int = int(op[3])
+	for row: int in 2:
+		for column: int in width:
+			_put(map, at + Vector2i(column, row), tile)
+			tile += 1
+
+
+## `_PrepMonFrontpic` into the page's own indices: the picture is mirrored, and
+## a pic smaller than the seven-tile cell is padded the way
+## `LoadOrientedFrontpic` pads one, from the right rather than the left because
+## the alignment is set. Its own palette is not: `LoadMailPalettes` has already
+## loaded the mail's, so the Pokemon is drawn in the mail's four colours.
+func _blend_pic(indices: PackedByteArray, mail: Gen2SaveMail) -> void:
+	if _data == null or mail == null:
+		return
+	var pic: Dictionary = _data.species_pic(mail.species)
+	if pic.is_empty():
+		return
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic
+	)
+	if cell.is_empty():
+		return
+	var width: int = int(cell["width"])
+	var height: int = int(cell["height"])
+	var pixels: PackedByteArray = Gen2PicImage.x_flipped_indices(cell["indices"], width)
+	@warning_ignore("integer_division")
+	var pad: int = Gen2PicImage.frontpic_pad_columns(width / TILE, true)
+	var origin := Vector2i(
+		(PIC_AT.x + pad) * TILE, PIC_AT.y * TILE + PIC_TILES * TILE - height
+	)
+	var page_width: int = COLUMNS * TILE
+	for y: int in height:
+		for x: int in width:
+			var to_x: int = origin.x + x
+			var to_y: int = origin.y + y
+			if to_x < 0 or to_x >= page_width or to_y < 0 or to_y >= ROWS * TILE:
+				continue
+			indices[to_y * page_width + to_x] = pixels[y * width + x]
+
+
+func _put(map: PackedInt32Array, at: Vector2i, tile: int) -> void:
+	if at.x < 0 or at.x >= COLUMNS or at.y < 0 or at.y >= ROWS:
+		return
+	map[at.y * COLUMNS + at.x] = tile
+
+
+## Resolves every tile number to pixels: the window this type just built, and
+## the font for everything the message and the author printed.
+func _compose(map: PackedInt32Array) -> PackedByteArray:
+	var width: int = COLUMNS * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * ROWS * TILE)
+	if font == null:
+		return indices
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			var tile: int = map[row * COLUMNS + column]
+			if _vram.has(tile):
+				var cell: PackedByteArray = _vram[tile]
+				for y: int in TILE:
+					for x: int in TILE:
+						indices[(row * TILE + y) * width + column * TILE + x] = cell[y * TILE + x]
+			else:
+				font.draw_code(tile, indices, width, column * TILE, row * TILE)
+	return indices

--- a/game/render/mail_page.gd.uid
+++ b/game/render/mail_page.gd.uid
@@ -1,0 +1,1 @@
+uid://g1gs6f6u2yi7

--- a/game/render/naming_screen_page.gd
+++ b/game/render/naming_screen_page.gd
@@ -11,7 +11,9 @@ extends RefCounted
 ## Positions are `NamingScreen_InitText` and `NamingScreen_ApplyTextInputMode`'s
 ## own. The layout is the same shape on both keyboards and differs only in where
 ## the two `ClearBox` calls land and how many rows are printed, which is the
-## whole of `NamingScreen_IsTargetBox` here.
+## whole of `NamingScreen_IsTargetBox` here. `_ComposeMailMessage.InitCharset`
+## is the third layout: the same tiles and the same cursor over a wider
+## keyboard, a two-line entry and an icon instead of a prompt.
 ##
 ## Node-free: it writes indices into a buffer, so a page can be drawn and read
 ## back headless.
@@ -40,9 +42,21 @@ const PROMPT_AT: Vector2i = Vector2i(5, 2)
 const ENTRY_AT_NAME: Vector2i = Vector2i(5, 6)
 const ENTRY_AT_BOX: Vector2i = Vector2i(5, 4)
 ## `hlcoord 2, 8` and `hlcoord 2, 6`: where the live keyboard's first row prints.
+## `.PlaceMailCharset`'s own is `hlcoord 1, 7`.
 const KEYBOARD_LEFT: int = 2
 const KEYBOARD_TOP_NAME: int = 8
 const KEYBOARD_TOP_BOX: int = 6
+const KEYBOARD_LEFT_MAIL: int = 1
+const KEYBOARD_TOP_MAIL: int = 7
+## `.Update`'s `hlcoord 2, 2`, the one `PlaceString` the whole buffer goes
+## through: `<NEXT>` drops two rows at the string's own starting column, so the
+## second line lands at (2, 4) without the routine naming it.
+const ENTRY_AT_MAIL: Vector2i = Vector2i(2, 2)
+## `.InitBlankMail`'s `depixel 3, 2` for the mail icon, which is a party-icon
+## struct: the coordinate less shadow OAM's own origin is the top-left tile.
+const MAIL_ICON_AT: Vector2i = Vector2i(1, 1)
+## The first `.Frameset_PartyMon` entry, four tiles of the eight loaded.
+const MAIL_ICON_TILES: int = 4
 ## The cursor steps two tiles per column and two per row, so a keyboard cell is
 ## two tiles wide even where its character is one.
 const CELL: int = 2
@@ -67,6 +81,10 @@ const COMMAND_CURSOR_STEP: int = 6
 ## bottom row, cleared separately because the run above it stops short of it.
 const CLEARED_NAME: Array = [[1, 1, 6, 18], [1, 8, 7, 18], [1, 16, 1, 18]]
 const CLEARED_BOX: Array = [[1, 1, 4, 18], [1, 6, 9, 18], [1, 16, 1, 18]]
+## `.InitCharset`: the border runs over rows 0 to 5 alone, everything below it
+## is blanked outright, and one `ClearBox` opens the entry inside the border.
+const MAIL_BORDER_ROWS: int = 6
+const CLEARED_MAIL: Array = [[1, 1, 4, 18]]
 
 const BLANK_TILE: int = -1
 
@@ -74,6 +92,8 @@ var font: Gen2Font = null
 
 var _tiles: Dictionary = {}
 var _cursor_tiles: Dictionary = {}
+## `_ComposeMailMessage.MailIcon`, drawn only by the mail screen.
+var _icon_tiles: Dictionary = {}
 
 
 static func from_data(data: GameData) -> Gen2NamingScreenPage:
@@ -92,10 +112,13 @@ static func from_data(data: GameData) -> Gen2NamingScreenPage:
 	out._load_sheet(
 		data, "naming_cursor", out._cursor_tiles, CURSOR_CORNER_TILE, RomLayout.NAMING_CURSOR_TILES
 	)
+	out._load_sheet(data, "mail_icon", out._icon_tiles, 0, MAIL_ICON_TILES)
 	return out
 
 
 ## Whether the cache carried every sheet this page needs.
+## The mail icon is not in this list: it is one sprite over the compose screen
+## and no keyboard needs it, so a cache without it draws every screen here.
 func ready() -> bool:
 	return font != null and _tiles.size() == 3 and _cursor_tiles.size() == 2
 
@@ -106,51 +129,103 @@ func draw(screen: Gen2NamingScreen, prompt: String) -> PackedByteArray:
 	var map: PackedInt32Array = PackedInt32Array()
 	map.resize(COLUMNS * ROWS)
 	map.fill(BORDER_TILE)
-	for box: Array in (CLEARED_BOX if screen.is_box else CLEARED_NAME):
+	if screen.is_mail:
+		_clear(map, 0, MAIL_BORDER_ROWS, ROWS - MAIL_BORDER_ROWS, COLUMNS)
+	for box: Array in _cleared(screen):
 		_clear(map, int(box[0]), int(box[1]), int(box[2]), int(box[3]))
 
-	_string(map, prompt, PROMPT_AT)
+	## `_ComposeMailMessage` prints no prompt of its own: the icon over the
+	## entry is what says whose mail is being written.
+	if not screen.is_mail:
+		_string(map, prompt, PROMPT_AT)
 	_entry(map, screen)
 	_keyboard(map, screen)
 
 	var indices: PackedByteArray = _compose(map)
+	if screen.is_mail:
+		_mail_icon(indices)
 	_cursor(indices, screen)
 	return indices
+
+
+func _cleared(screen: Gen2NamingScreen) -> Array:
+	if screen.is_mail:
+		return CLEARED_MAIL
+	return CLEARED_BOX if screen.is_box else CLEARED_NAME
+
+
+## The party-icon struct `.InitBlankMail` spawns, at its first frameset entry.
+## It is an object, so index 0 stays see-through the way the cursor does.
+func _mail_icon(indices: PackedByteArray) -> void:
+	for quadrant: int in MAIL_ICON_TILES:
+		_blit(
+			indices, _icon_tiles, quadrant, MAIL_ICON_AT, false, false, true,
+			Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
+		)
 
 
 ## The name being typed, printed as the raw buffer rather than as text: the two
 ## markers are tiles, not characters, and `.UpdateStringEntry` prints the whole
 ## buffer every frame rather than only what has been entered.
 func _entry(map: PackedInt32Array, screen: Gen2NamingScreen) -> void:
+	if screen.is_mail:
+		_mail_entry(map, screen)
+		return
 	var at: Vector2i = ENTRY_AT_BOX if screen.is_box else ENTRY_AT_NAME
 	for index: int in screen.max_length:
 		_put(map, at + Vector2i(index, 0), screen.buffer[index])
 
 
+## `.Update`'s one `PlaceString` over the whole mail buffer. The break is a
+## `<NEXT>`, which drops two rows and returns to the string's own column, so it
+## occupies a buffer position and no tile.
+func _mail_entry(map: PackedInt32Array, screen: Gen2NamingScreen) -> void:
+	var at: Vector2i = ENTRY_AT_MAIL
+	var column: int = 0
+	for index: int in screen.max_length:
+		var code: int = screen.buffer[index]
+		if code == Gen2SaveMail.LINE_BREAK:
+			at.y += 2
+			column = 0
+			continue
+		_put(map, Vector2i(at.x + column, at.y), code)
+		column += 1
+
+
 ## The live keyboard, 17 tiles a row two rows apart, which is what
 ## `NamingScreen_ApplyTextInputMode`'s `ld de, 2 * SCREEN_WIDTH - $11` steps.
 func _keyboard(map: PackedInt32Array, screen: Gen2NamingScreen) -> void:
-	var top: int = KEYBOARD_TOP_BOX if screen.is_box else KEYBOARD_TOP_NAME
+	var top: int = _keyboard_top(screen)
+	var left: int = _keyboard_left(screen)
 	var rows: Array = screen.rows()
 	for row: int in rows.size():
 		var codes: Array = rows[row]
 		for column: int in codes.size():
-			_put(map, Vector2i(KEYBOARD_LEFT + column, top + row * CELL), int(codes[column]))
+			_put(map, Vector2i(left + column, top + row * CELL), int(codes[column]))
+
+
+func _keyboard_top(screen: Gen2NamingScreen) -> int:
+	if screen.is_mail:
+		return KEYBOARD_TOP_MAIL
+	return KEYBOARD_TOP_BOX if screen.is_box else KEYBOARD_TOP_NAME
+
+
+func _keyboard_left(screen: Gen2NamingScreen) -> int:
+	return KEYBOARD_LEFT_MAIL if screen.is_mail else KEYBOARD_LEFT
 
 
 ## The bracket over whatever the cursor is on. A letter takes the plain
 ## frameset, the command row the big one, and `NamingScreen_AnimateCursor` snaps
 ## the big one to its command group rather than leaving it on the raw column.
 func _cursor(indices: PackedByteArray, screen: Gen2NamingScreen) -> void:
-	var top: int = KEYBOARD_TOP_BOX if screen.is_box else KEYBOARD_TOP_NAME
-	var at := Vector2i(
-		KEYBOARD_LEFT + screen.column * CELL, top + screen.row * CELL
-	)
+	var top: int = _keyboard_top(screen)
+	var left: int = _keyboard_left(screen)
+	var at := Vector2i(left + screen.column * CELL, top + screen.row * CELL)
 	var width: int = CELL
 	var command: int = screen.cursor_command()
 	if command != Gen2NamingScreen.COMMAND_NONE:
 		width = COMMAND_CURSOR_WIDTH
-		at.x = KEYBOARD_LEFT + (command - 1) * COMMAND_CURSOR_STEP
+		at.x = left + (command - 1) * COMMAND_CURSOR_STEP
 	_bracket(indices, at, width)
 
 

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -83,10 +83,11 @@ const ICON_FRAME_TILES: int = 4
 const ICON_SPEEDS: Array[int] = [0x00, 0x40, 0x80]
 const ICON_BOBS: Array[int] = [-2, -1, 0]
 
-## `.SpawnItemIcon`'s marker, `HeldItemIcons`' second tile, over the icon's own
-## bottom-left one. Its mail sibling is unreachable here (see
-## [constant RomLayout.HELD_ITEM_ICON_MAIL]).
+## `.SpawnItemIcon`'s marker over the icon's own bottom-left one, which is
+## `HeldItemIcons`' first tile for a held mail ($08 in
+## `.OAMData_PartyMonWithMail1`) and its second for anything else ($09).
 const ICON_ITEM_TILE: int = RomLayout.HELD_ITEM_ICON_ITEM
+const ICON_MAIL_TILE: int = RomLayout.HELD_ITEM_ICON_MAIL
 const ICON_ITEM_QUADRANT: int = 2
 
 ## `PlaceStatusString`'s three-letter strings, in the order
@@ -200,6 +201,7 @@ func reset(rows: Array) -> void:
 				int(member.get("species", 0)), bool(member.get("egg", false))
 			) if data != null else PackedByteArray(),
 			"item": int(member.get("item", 0)) != 0,
+			"mail": Gen2HeldItem.is_mail(int(member.get("item", 0))),
 			"speed": speed,
 			"frame": -1,
 			"duration": 0,
@@ -274,7 +276,7 @@ func _blend_icons(pixels: PackedInt32Array, count: int) -> void:
 			var tile: int = first + quadrant
 			if quadrant == ICON_ITEM_QUADRANT and bool(icon["item"]) and not held.is_empty():
 				source = held
-				tile = ICON_ITEM_TILE
+				tile = ICON_MAIL_TILE if bool(icon["mail"]) else ICON_ITEM_TILE
 			blend_tile(
 				pixels, source, tile, colors,
 				at + Vector2i((quadrant & 1) * ICON_TILE, (quadrant >> 1) * ICON_TILE)

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -60,6 +60,12 @@ const OPTION_MOVE: StringName = &"move"
 ## `GiveTakeItemMenuData`'s own two rows, which ITEM opens rather than answers.
 const OPTION_GIVE: StringName = &"give"
 const OPTION_TAKE: StringName = &"take"
+## `MONMENUITEM_MAIL`, which `GetMonSubmenuItems` puts where ITEM would be when
+## `ItemIsMail` answers for the held item, and `MonMailAction`'s own three rows.
+const OPTION_MAIL: StringName = &"mail"
+const OPTION_MAIL_READ: StringName = &"mail_read"
+const OPTION_MAIL_TAKE: StringName = &"mail_take"
+const OPTION_MAIL_QUIT: StringName = &"mail_quit"
 ## engine/pokemon/mon_submenu.asm's NUM_MONMENU_ITEMS: a list already this long
 ## drops CANCEL rather than growing.
 const MAX_SUBMENU_ITEMS: int = 8
@@ -104,6 +110,9 @@ const SUBMENU_BOTTOM: int = 17
 ## `GiveTakeItemMenuData`'s `menu_coords 12, 12, SCREEN_WIDTH - 1,
 ## SCREEN_HEIGHT - 1`, which is a fixed box rather than a grown one.
 const ITEM_MENU_BOX: Rect2i = Rect2i(12, 12, 7, 5)
+## `MonMailAction.MenuHeader`'s `menu_coords 12, 10, SCREEN_WIDTH - 1,
+## SCREEN_HEIGHT - 1`, one row taller than GIVE/TAKE's.
+const MAIL_MENU_BOX: Rect2i = Rect2i(12, 10, 7, 7)
 
 var _data: GameData = null
 var _data_override: GameData = null
@@ -126,6 +135,9 @@ var _submenu_open: bool = false
 ## Whether the rows on screen are ITEM's GIVE/TAKE box rather than the mon's own
 ## submenu, which is what B goes back to.
 var _item_menu_open: bool = false
+## Which fixed box that submenu is drawn in: GIVE/TAKE's or `MonMailAction`'s,
+## which is one row taller and two rows higher.
+var _fixed_menu_box: Rect2i = ITEM_MENU_BOX
 ## `.SelectMilkDrinkRecipient`: which party member is giving its health away, and
 ## which of the two moves asked. -1 and 0 when no recipient list is open.
 var _heal_user: int = -1
@@ -239,9 +251,6 @@ func party_snapshot() -> Dictionary:
 ## acted on: the screens STATS and MOVE open are built, so a row that cannot be
 ## chosen no longer exists here.
 ##
-## The MAIL branch is not reproduced: ItemIsMail tests the held item against
-## data/items/mail_items.asm, and this project has no mail, so ITEM is always
-## the entry in that position.
 ## [param slot] is one-based and [param in_battle] is whether the list belongs to
 ## a turn: both only decide which mod rows are offered, and neither changes a
 ## cartridge row.
@@ -273,7 +282,12 @@ static func submenu_items_for(
 	## out, so the row is offered whatever the party holds.
 	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
 	items.append(_option_entry(OPTION_MOVE, "MOVE"))
-	items.append(_option_entry(OPTION_ITEM, "ITEM"))
+	## `GetMonSubmenuItems`: `ItemIsMail` decides between the two rows, so a
+	## member holding mail has no ITEM row at all.
+	if Gen2HeldItem.is_mail(mon.item):
+		items.append(_option_entry(OPTION_MAIL, "MAIL"))
+	else:
+		items.append(_option_entry(OPTION_ITEM, "ITEM"))
 	## After every cartridge action and before CANCEL, which is the source's own
 	## last row and the way out of the box. A mod cannot displace one: the list
 	## still stops at `NUM_MONMENU_ITEMS`, so rows past it are simply not offered.
@@ -300,6 +314,16 @@ static func item_menu_items() -> Array:
 	return [
 		{"kind": &"mon_item", "option": OPTION_GIVE, "label": "GIVE"},
 		{"kind": &"mon_item", "option": OPTION_TAKE, "label": "TAKE"},
+	]
+
+
+## `MonMailAction.MenuData`'s three rows. READ opens `ReadPartyMonMail` and
+## TAKE is `SendMailToPC` or the bag, both of which need the live world.
+static func mail_menu_items() -> Array:
+	return [
+		{"kind": &"mon_mail", "option": OPTION_MAIL_READ, "label": "READ"},
+		{"kind": &"mon_mail", "option": OPTION_MAIL_TAKE, "label": "TAKE"},
+		{"kind": &"mon_mail", "option": OPTION_MAIL_QUIT, "label": "QUIT"},
 	]
 
 
@@ -423,6 +447,17 @@ func _confirm() -> void:
 				"slot": _member_cursor,
 				"name": _display_name(_save.party[_member_cursor]),
 			})
+		&"mon_mail":
+			## `.done` answers 3, which `.choosemenu` takes back to the list.
+			if StringName(entry.get("option", &"")) == OPTION_MAIL_QUIT:
+				_open_submenu()
+				return
+			action_chosen.emit({
+				"kind": &"mon_mail",
+				"option": StringName(entry.get("option", &"")),
+				"slot": _member_cursor,
+				"name": _display_name(_save.party[_member_cursor]),
+			})
 		&"mod_party_action":
 			## The handler is the mod's, and the slot is the only thing it is
 			## told: the menu closes behind it the way a field move's does.
@@ -438,6 +473,8 @@ func _confirm() -> void:
 			match StringName(entry.get("option", &"")):
 				OPTION_ITEM:
 					_open_item_menu()
+				OPTION_MAIL:
+					_open_mail_menu()
 				OPTION_SWITCH:
 					_begin_switch()
 				OPTION_STATS:
@@ -612,6 +649,15 @@ func _open_item_menu() -> void:
 	_submenu_items = item_menu_items()
 	_submenu_cursor = 0
 	_item_menu_open = true
+	_fixed_menu_box = ITEM_MENU_BOX
+	_refresh()
+
+
+func _open_mail_menu() -> void:
+	_submenu_items = mail_menu_items()
+	_submenu_cursor = 0
+	_item_menu_open = true
+	_fixed_menu_box = MAIL_MENU_BOX
 	_refresh()
 
 
@@ -847,13 +893,13 @@ func _blend_stats_pic(image: Image, snapshot: Dictionary) -> void:
 	image.blit_rect(art, Rect2i(Vector2i.ZERO, art.get_size()), origin)
 
 
-## `.GetTopCoord` for the mon's own submenu, and `GiveTakeItemMenuData`'s fixed
-## box for the GIVE/TAKE it opens.
+## `.GetTopCoord` for the mon's own submenu, and the fixed box whichever of
+## `GiveTakeItemMenuData` and `MonMailAction.MenuHeader` is open over it.
 func _submenu_box() -> Gen2MenuBox:
 	if _item_menu_open:
 		return Gen2MenuBox.from_coords(
-			ITEM_MENU_BOX.position.x, ITEM_MENU_BOX.position.y,
-			ITEM_MENU_BOX.end.x, ITEM_MENU_BOX.end.y, Gen2MenuBox.STATICMENU_CURSOR
+			_fixed_menu_box.position.x, _fixed_menu_box.position.y,
+			_fixed_menu_box.end.x, _fixed_menu_box.end.y, Gen2MenuBox.STATICMENU_CURSOR
 		)
 	return mon_menu_box(_submenu_items.size())
 
@@ -954,6 +1000,14 @@ func _build_ui() -> void:
 	_status.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_status.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
 	footer.add_child(_status)
+
+
+## A caller's own refusal in this list's box, for a selection the list itself
+## cannot judge. `_PlayerMailBoxMenu`'s `.AttachMail` is the shape: it prints
+## `.MailEggText` or `.MailAlreadyHoldingItemText` and jumps back to
+## `.try_again`, which is this list still open behind the box.
+func say(message: String) -> void:
+	_say(message)
 
 
 ## A refusal, in whichever box this view has: the menu's own bottom one when it

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -80,12 +80,25 @@ var hall_of_fame: Array = []
 ## one and `SetDefaultBoxNames` fills them all at a new game. Empty is that
 ## default, which [method box_name] spells rather than storing.
 var box_names: Array = []
+## `sMailboxCount` and `sMailboxes`: the messages the player has sent to the PC,
+## newest last, at most [constant Gen2SaveMail.CAPACITY]. Like `box_names` this
+## defaults rather than versioning; an empty list is the truth about a slot
+## written before mail existed.
+var mailbox: Array = []
 
 
 func _init() -> void:
 	game_time = Gen2GameTime.new()
 	for _box_index: int in BOX_COUNT:
 		boxes.append(Gen2SaveBox.new())
+
+
+func _mailbox_dicts() -> Array:
+	var out: Array = []
+	for mail: Gen2SaveMail in mailbox:
+		if mail != null:
+			out.append(mail.to_dict())
+	return out
 
 
 func to_dict() -> Dictionary:
@@ -110,6 +123,7 @@ func to_dict() -> Dictionary:
 		"current_box": current_box,
 		"hall_of_fame": hall_of_fame.duplicate(true),
 		"box_names": box_names.duplicate(),
+		"mailbox": _mailbox_dicts(),
 		"world": world.to_dict() if world != null else {},
 		"mods": mods.duplicate(true),
 		"run": {
@@ -148,6 +162,12 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 			out.box_names.append(
 				String((raw_box_names as Array)[index]).substr(0, MAX_BOX_NAME)
 			)
+	var raw_mailbox: Variant = source.get("mailbox", [])
+	if raw_mailbox is Array:
+		for raw_mail: Variant in (raw_mailbox as Array).slice(0, Gen2SaveMail.CAPACITY):
+			var mail: Gen2SaveMail = Gen2SaveMail.from_dict(raw_mail)
+			if mail != null:
+				out.mailbox.append(mail)
 	var raw_party: Variant = source.get("party", [])
 	if raw_party is Array:
 		for raw_mon: Variant in raw_party as Array:
@@ -318,6 +338,9 @@ func copy_from(source: Gen2SaveData) -> bool:
 	party = copied.party
 	boxes = copied.boxes
 	current_box = copied.current_box
+	hall_of_fame = copied.hall_of_fame.duplicate(true)
+	box_names = copied.box_names.duplicate()
+	mailbox = copied.mailbox.duplicate()
 	world = copied.world
 	mods = copied.mods.duplicate(true)
 	run_seed = copied.run_seed

--- a/game/save/save_mail.gd
+++ b/game/save/save_mail.gd
@@ -1,0 +1,182 @@
+class_name Gen2SaveMail
+extends RefCounted
+
+## One `mailmsg` struct (`macros/ram.asm`) and the four routines in
+## `engine/pokemon/mail.asm` that move one between a party member and the PC.
+##
+## The cartridge keeps party mail in `sPartyMail`, a sixth of SRAM indexed by
+## party slot, and the mailbox in `sMailboxes` behind its own count. The mailbox
+## is kept the same way here, on [member Gen2SaveData.mailbox]; a party member's
+## mail is kept on the member instead of on its slot, because everything that
+## moves a slot moves its mail with it (`SwitchPartyMons` swaps both) and
+## nothing can put a mailed Pokemon anywhere else: `BillsPC_CheckMail_Prevent
+## Blackout` and `Gen2WorldDayCare`'s own refusal are the two gates, and the
+## day care's is already built.
+##
+## Scene-free and cache-free, like the rest of `game/save/`.
+
+## `MAIL_LINE_LENGTH`, `MAIL_MSG_LENGTH` and `MAILBOX_CAPACITY`.
+const LINE_LENGTH: int = RomLayout.MAIL_LINE_LENGTH
+const MESSAGE_LENGTH: int = RomLayout.MAIL_MSG_LENGTH
+const CAPACITY: int = RomLayout.MAILBOX_CAPACITY
+## The `<NEXT>` byte between the two lines, which `_ComposeMailMessage` writes
+## once and neither the entry nor the delete may overwrite.
+const LINE_BREAK: int = Gen2Text.NEXT_LINE
+const TERMINATOR: int = Gen2Text.TERMINATOR
+## The whole buffer the screen types into: two lines and the break between them.
+const BUFFER_LENGTH: int = MESSAGE_LENGTH + 1
+## `PLAYER_NAME_LENGTH` is 8 and both writers copy `NAME_LENGTH - 1`, so the
+## author runs two bytes into the `Nationality` word behind it and no cartridge
+## in this project's allowlist ever writes a nationality. Ten is what is stored
+## and ten is what `MailboxPC_GetMailAuthor` reads back.
+const AUTHOR_LENGTH: int = RomLayout.MAIL_AUTHOR_LENGTH
+
+## The typed message, `BUFFER_LENGTH` raw codes with `'@'` behind what was
+## entered. Raw rather than a String because the break is a code and the two
+## lines are fixed-width fields, which is how every reader addresses them.
+var message: PackedByteArray = PackedByteArray()
+var author: String = ""
+## `wPlayerID`, the author's own trainer number.
+var author_id: int = 0
+## `wCurPartySpecies` at the moment the mail was written, which is what
+## PORTRAITMAIL draws.
+var species: int = 0
+## The mail item's own number, which is what `MailGFXPointers` is walked with.
+var item: int = 0
+
+
+func _init() -> void:
+	message = blank_message()
+
+
+## `NamingScreen_InitNameEntry` followed by `_ComposeMailMessage.InitBlankMail`'s
+## `ld [hl], '<NEXT>'`: a terminated buffer with the break already in place.
+static func blank_message() -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(BUFFER_LENGTH)
+	out.fill(TERMINATOR)
+	out[LINE_LENGTH] = LINE_BREAK
+	return out
+
+
+## `ComposeMailMessage` (`engine/pokemon/mon_menu.asm`): the entry the naming
+## screen stored, then the player's name, id, the species holding it and the
+## item itself.
+static func compose(
+	entry: PackedByteArray, player_name: String, player_id: int, held_by: int, mail_item: int
+) -> Gen2SaveMail:
+	var out := Gen2SaveMail.new()
+	var buffer: PackedByteArray = blank_message()
+	for index: int in mini(entry.size(), BUFFER_LENGTH):
+		buffer[index] = entry[index]
+	buffer[LINE_LENGTH] = LINE_BREAK
+	out.message = buffer
+	out.author = player_name.substr(0, AUTHOR_LENGTH)
+	out.author_id = player_id & 0xFFFF
+	out.species = held_by
+	out.item = mail_item
+	return out
+
+
+## One of the two lines as text, decoded up to its terminator. `MailGFX_Place
+## Message` prints the whole buffer with one `PlaceString`, and `<NEXT>` is what
+## splits it; this is that split for a caller that wants the halves.
+func line(index: int) -> String:
+	var at: int = index * (LINE_LENGTH + 1)
+	var codes := PackedByteArray()
+	for offset: int in LINE_LENGTH:
+		var code: int = message[at + offset] if at + offset < message.size() else TERMINATOR
+		if code == TERMINATOR or code == LINE_BREAK:
+			break
+		codes.append(code)
+	return Gen2Text.decode(codes, 0, codes.size())
+
+
+func to_dict() -> Dictionary:
+	return {
+		"message": Array(message),
+		"author": author,
+		"author_id": author_id,
+		"species": species,
+		"item": item,
+	}
+
+
+static func from_dict(raw: Variant) -> Gen2SaveMail:
+	if not raw is Dictionary:
+		return null
+	var source: Dictionary = raw
+	var out := Gen2SaveMail.new()
+	var buffer: PackedByteArray = blank_message()
+	var stored: Variant = source.get("message", [])
+	if stored is Array:
+		var codes: Array = stored
+		for index: int in mini(codes.size(), BUFFER_LENGTH):
+			buffer[index] = int(codes[index]) & 0xFF
+	out.message = buffer
+	out.author = String(source.get("author", "")).substr(0, AUTHOR_LENGTH)
+	out.author_id = int(source.get("author_id", 0)) & 0xFFFF
+	out.species = int(source.get("species", 0))
+	out.item = int(source.get("item", 0))
+	return out
+
+
+## `GetMailboxCount`, which reads `sMailboxCount` and nothing else.
+static func mailbox_count(save: Gen2SaveData) -> int:
+	return save.mailbox.size() if save != null else 0
+
+
+## `IsAnyMonHoldingMail`, the guard `SaveGameData` runs before a link and the
+## day care runs before a deposit.
+static func any_mon_holding_mail(save: Gen2SaveData) -> bool:
+	if save == null:
+		return false
+	for mon: Gen2SaveMon in save.party:
+		if mon != null and mon.mail != null:
+			return true
+	return false
+
+
+## `SendMailToPC`. The mail leaves the party member, its item goes with it and
+## `sMailboxCount` is incremented; a full mailbox or a member holding no mail is
+## the routine's own `scf`.
+static func send_to_pc(save: Gen2SaveData, slot: int) -> bool:
+	if save == null or slot < 0 or slot >= save.party.size():
+		return false
+	var mon: Gen2SaveMon = save.party[slot]
+	if mon == null or mon.mail == null:
+		return false
+	if save.mailbox.size() >= CAPACITY:
+		return false
+	save.mailbox.append(mon.mail)
+	mon.mail = null
+	mon.item = 0
+	return true
+
+
+## `DeleteMailFromPC`, which shifts every message behind the deleted one down
+## and clears the last slot.
+static func delete_from_pc(save: Gen2SaveData, index: int) -> bool:
+	if save == null or index < 0 or index >= save.mailbox.size():
+		return false
+	save.mailbox.remove_at(index)
+	return true
+
+
+## `MoveMailFromPCToParty`: the message is copied onto the party member, its own
+## `Type` byte becomes the member's held item, and the mailbox entry is deleted
+## behind it. The caller has already refused an egg and a member holding
+## anything, which is `.AttachMail`'s own two branches.
+static func move_from_pc_to_party(save: Gen2SaveData, index: int, slot: int) -> bool:
+	if save == null or index < 0 or index >= save.mailbox.size():
+		return false
+	if slot < 0 or slot >= save.party.size():
+		return false
+	var mon: Gen2SaveMon = save.party[slot]
+	if mon == null:
+		return false
+	var mail: Gen2SaveMail = save.mailbox[index]
+	mon.mail = mail
+	mon.item = mail.item
+	save.mailbox.remove_at(index)
+	return true

--- a/game/save/save_mail.gd.uid
+++ b/game/save/save_mail.gd.uid
@@ -1,0 +1,1 @@
+uid://ccjew3xy7nvyu

--- a/game/save/save_mon.gd
+++ b/game/save/save_mon.gd
@@ -39,6 +39,9 @@ var status: int = Gen2Status.NONE
 var nickname: String = ""
 var original_trainer: String = ""
 var is_egg: bool = false
+## `sPartyMail`'s own entry for this member, or null when the held item is not
+## mail. Kept on the record rather than on the party slot; see [Gen2SaveMail].
+var mail: Gen2SaveMail = null
 
 
 func to_dict() -> Dictionary:
@@ -66,6 +69,7 @@ func to_dict() -> Dictionary:
 		"nickname": nickname,
 		"original_trainer": original_trainer,
 		"is_egg": is_egg,
+		"mail": mail.to_dict() if mail != null else {},
 	}
 
 
@@ -99,6 +103,11 @@ static func from_dict(raw: Variant) -> Gen2SaveMon:
 	out.nickname = String(source.get("nickname", ""))
 	out.original_trainer = String(source.get("original_trainer", ""))
 	out.is_egg = bool(source.get("is_egg", false))
+	## An empty object is a record written before mail existed and one written
+	## for a member holding none: both mean no mail, which needs no version.
+	var stored_mail: Variant = source.get("mail", {})
+	if stored_mail is Dictionary and not (stored_mail as Dictionary).is_empty():
+		out.mail = Gen2SaveMail.from_dict(stored_mail)
 	return out
 
 

--- a/game/world/mail_screen.gd
+++ b/game/world/mail_screen.gd
@@ -1,0 +1,77 @@
+class_name Gen2MailScreen
+extends Control
+
+## `ReadAnyMail` (`engine/pokemon/mail_2.asm`), embedded the way the Hall of
+## Fame viewer is.
+##
+## The routine loads the type's own graphics, prints the message and the author
+## over them, and then does nothing but wait: `.loop` reads A, B and START and
+## returns on any of the first two. [Gen2MailPage] owns the picture; this is the
+## node between it and the buttons.
+##
+## START is `PrintMailAndExit`, the Game Boy Printer, which this project has no
+## transport for. It is answered as a press that does nothing rather than left
+## to fall through to whatever is behind the screen.
+
+signal closed()
+
+## The screen has no field of its own: `ClearBGPalettes` and `DisableLCD` run
+## before the type's graphics are loaded, so the surround is the mail's own
+## background colour once `LoadMailPalettes` has run.
+var _data: GameData = null
+var _mail: Gen2SaveMail = null
+var _page: Gen2MailPage = null
+var _background: TextureRect = null
+
+
+func set_context(data: GameData, mail: Gen2SaveMail) -> void:
+	_data = data
+	_mail = mail
+	_page = Gen2MailPage.from_data(data)
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _page == null or not _page.ready() or _mail == null:
+		closed.emit()
+		return
+	_build()
+	_refresh()
+
+
+## `.loop`: A and B leave, START reaches the printer and comes back. Nothing
+## else is read, so the d-pad does not close the screen.
+func handle_button(button: int) -> bool:
+	if button == Gen2Button.A or button == Gen2Button.B:
+		closed.emit()
+		return true
+	return button == Gen2Button.START
+
+
+func _build() -> void:
+	var colours: PackedColorArray = _colours()
+	add_child(Gen2Screen.Field.create(
+		colours[0] if colours.size() > 0 else Color.WHITE
+	))
+
+	_background = TextureRect.new()
+	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_background)
+
+
+func _refresh() -> void:
+	var indices: PackedByteArray = _page.draw(_mail)
+	Gen2PicImage.show(_background, Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _colours()
+	))
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## `LoadMailPalettes`, whole: this is the one screen in the project drawn
+## through four cartridge colours rather than a white-to-black pair.
+func _colours() -> PackedColorArray:
+	if _data == null or _mail == null:
+		return Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return _data.mail_palette(Gen2MailPage.palette_index(_mail))

--- a/game/world/mail_screen.gd.uid
+++ b/game/world/mail_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dv0rgsjgi3su1

--- a/game/world/naming_screen.gd
+++ b/game/world/naming_screen.gd
@@ -11,12 +11,15 @@ extends RefCounted
 ## NAMINGSCREEN_UNDERLINE and NAMINGSCREEN_MIDDLELINE rather than a String,
 ## because every routine here reads and writes those two markers.
 
-## The four keyboards in block order, which is the order they are imported in.
+## The six keyboards in block order, which is the order they are imported in:
+## `data/text/name_input_chars.asm`'s four and `mail_input_chars.asm`'s two.
 enum Keyboard {
 	NAME_LOWER,
 	BOX_LOWER,
 	NAME_UPPER,
 	BOX_UPPER,
+	MAIL_UPPER,
+	MAIL_LOWER,
 }
 
 ## `naming_screen.asm`'s own three: the cursor under the entry, the dashes it
@@ -49,18 +52,32 @@ const BOX_MAX_LENGTH: int = 8
 ## `MON_NAME_LENGTH - 1`, which `.StoreMonIconParams` writes. A nickname uses
 ## the player's keyboard and entry row and differs only in how long it may be.
 const MON_MAX_LENGTH: int = 10
+## `.initwNamingScreenMaxNameLength`'s `MAIL_MSG_LENGTH + 1`: two lines and the
+## `<NEXT>` between them, which is a buffer position the cursor steps over
+## rather than a character anything can type.
+const MAIL_MAX_LENGTH: int = Gen2SaveMail.BUFFER_LENGTH
+const MAIL_LINE_LENGTH: int = Gen2SaveMail.LINE_LENGTH
+const MAIL_LINE_BREAK: int = Gen2SaveMail.LINE_BREAK
 
 ## The cursor's own columns, which is every second byte of a row.
 const COLUMNS: int = RomLayout.NAME_INPUT_COLUMNS
 const COLUMN_STRIDE: int = RomLayout.NAME_INPUT_COLUMN_STRIDE
-## `.LetterEntries` has nine entries, so the last column is 8.
+## `.LetterEntries` has nine entries, so the last column is 8. Mail's own
+## `ComposeMail_AnimateCursor.LetterEntries` has ten.
 const LAST_COLUMN: int = COLUMNS - 1
-## `.CaseDelEnd` snaps the cursor to three groups three columns apart.
+const MAIL_COLUMNS: int = RomLayout.MAIL_INPUT_COLUMNS
+const MAIL_LAST_COLUMN: int = MAIL_COLUMNS - 1
+## `.CaseDelEnd` snaps the cursor to three groups three columns apart, on both
+## screens: mail's own table repeats $00, $30 and $60 the same way.
 const COMMAND_GROUP: int = 3
 
 ## `NamingScreen_IsTargetBox`: a box keyboard is six rows and a name keyboard
 ## five, so the command row is row 5 or row 4.
 var is_box: bool = false
+## `_ComposeMailMessage` rather than `NamingScreen`: a six-row, ten-column
+## keyboard of its own, a two-line entry with a fixed break in the middle, and
+## no prompt. Everything else on the screen is the same walk.
+var is_mail: bool = false
 ## wNamingScreenLetterCase. 0 is upper, which is what NamingScreen_InitText
 ## loads before anything has been pressed.
 var upper_case: bool = true
@@ -91,6 +108,20 @@ static func for_mon(data: GameData) -> Gen2NamingScreen:
 	return _build(data, false, MON_MAX_LENGTH)
 
 
+## `_ComposeMailMessage`, whose destination buffer is a mail message rather than
+## a name.
+static func for_mail(data: GameData) -> Gen2NamingScreen:
+	var screen := Gen2NamingScreen.new()
+	screen.is_mail = true
+	screen.max_length = MAIL_MAX_LENGTH
+	if data != null:
+		for table: int in Keyboard.size():
+			screen._tables.append(data.name_input_chars(table))
+	screen.init_name_entry()
+	screen.init_cursor()
+	return screen
+
+
 static func _build(data: GameData, box: bool, limit: int) -> Gen2NamingScreen:
 	var screen := Gen2NamingScreen.new()
 	screen.is_box = box
@@ -119,11 +150,17 @@ func init_name_entry() -> void:
 	buffer[0] = UNDERLINE
 	buffer[max_length] = TERMINATOR
 	length = 0
+	## `.InitBlankMail`'s own last two instructions, after the shared entry: the
+	## break is written once and every later pass puts it back.
+	if is_mail:
+		buffer[MAIL_LINE_LENGTH] = MAIL_LINE_BREAK
 
 
 ## `NamingScreen_ApplyTextInputMode`'s table selection: the case picks the pair
 ## and NamingScreen_IsTargetBox picks which of the pair.
 func keyboard() -> int:
+	if is_mail:
+		return Keyboard.MAIL_UPPER if upper_case else Keyboard.MAIL_LOWER
 	var table: int = Keyboard.NAME_UPPER if upper_case else Keyboard.NAME_LOWER
 	return table + 1 if is_box else table
 
@@ -137,7 +174,7 @@ func rows() -> Array:
 
 ## `ld b, $5` / `ld b, $6`: the number of rows the live keyboard has.
 func row_count() -> int:
-	return 6 if is_box else 5
+	return 6 if is_box or is_mail else 5
 
 
 ## Which row the case switch, DEL and END sit on.
@@ -167,6 +204,11 @@ func last_character() -> int:
 	var codes: Array = table[row]
 	var at: int = column * COLUMN_STRIDE
 	return int(codes[at]) if at >= 0 and at < codes.size() else 0
+
+
+## The rightmost column of the live keyboard, which is what both wraps run to.
+func last_column() -> int:
+	return MAIL_LAST_COLUMN if is_mail else LAST_COLUMN
 
 
 ## `NamingScreen_AnimateCursor`'s `.GetDPad`. Horizontal movement on the command
@@ -201,6 +243,7 @@ func press_a() -> StringName:
 		# TryAddCharacter's carry falls straight into `.start`, so filling the
 		# last slot puts the cursor on END rather than leaving it on a letter.
 		press_start()
+	_step_over_line_break(true)
 	return RESULT_LETTER
 
 
@@ -212,12 +255,26 @@ func press_b() -> void:
 	buffer[length] = UNDERLINE
 	if length + 1 < buffer.size() and buffer[length + 1] == UNDERLINE:
 		buffer[length + 1] = MIDDLELINE
+	_step_over_line_break(false)
+
+
+## `_ComposeMailMessage`'s `.a` and `.b` tails: the `<NEXT>` at
+## `MAIL_LINE_LENGTH` is a buffer position rather than a character, so an entry
+## that lands on it steps past it in whichever direction it arrived from and
+## writes the break back. Both tails run only when the length is exactly the
+## line length, so nothing else on either screen is touched.
+func _step_over_line_break(forwards: bool) -> void:
+	if not is_mail or length != MAIL_LINE_LENGTH:
+		return
+	length += 1 if forwards else -1
+	buffer[length] = UNDERLINE
+	buffer[MAIL_LINE_LENGTH] = MAIL_LINE_BREAK
 
 
 ## `.start`: the cursor jumps to END, which is the last column of the command
 ## row.
 func press_start() -> void:
-	column = LAST_COLUMN
+	column = last_column()
 	row = command_row()
 
 
@@ -229,6 +286,18 @@ func press_select() -> void:
 
 ## `NamingScreen_StoreEntry`: every marker still in the buffer becomes a
 ## terminator, so the name is what was typed and nothing behind it.
+## `NamingScreen_StoreEntry` whole: the buffer at its own length with every
+## marker turned into a terminator and everything else left where it is. Mail
+## needs the whole buffer rather than the run in front of the first marker,
+## because its `<NEXT>` sits inside it and its second line sits behind that.
+func stored_entry() -> PackedByteArray:
+	var out := PackedByteArray()
+	for index: int in max_length:
+		var code: int = buffer[index]
+		out.append(TERMINATOR if code == MIDDLELINE or code == UNDERLINE else code)
+	return out
+
+
 func stored_codes() -> PackedByteArray:
 	var out := PackedByteArray()
 	for index: int in max_length:
@@ -267,7 +336,7 @@ func _right() -> void:
 		var next: int = 0 if command == COMMAND_END else command
 		column = next * COMMAND_GROUP
 		return
-	column = 0 if column >= LAST_COLUMN else column + 1
+	column = 0 if column >= last_column() else column + 1
 
 
 func _left() -> void:
@@ -277,7 +346,7 @@ func _left() -> void:
 		var next: int = 4 if command == COMMAND_CASE else command
 		column = (next - 2) * COMMAND_GROUP
 		return
-	column = LAST_COLUMN if column <= 0 else column - 1
+	column = last_column() if column <= 0 else column - 1
 
 
 func _down() -> void:

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -18,6 +18,11 @@ signal closed(name: String)
 const KIND_PLAYER: StringName = &"player"
 const KIND_MON: StringName = &"mon"
 const KIND_BOX: StringName = &"box"
+## `_ComposeMailMessage`, which is not a `wNamingScreenType` at all: its own
+## routine with its own keyboard. A caller that opens this one reads the raw
+## buffer off [method model] rather than the `closed` argument, since a mail
+## message is two fixed-width lines and a break rather than a name.
+const KIND_MAIL: StringName = &"mail"
 
 var _screen: Gen2NamingScreen = null
 var _page: Gen2NamingScreenPage = null
@@ -56,6 +61,8 @@ static func _model(data: GameData, kind: StringName) -> Gen2NamingScreen:
 		return Gen2NamingScreen.for_mon(data)
 	if kind == KIND_BOX:
 		return Gen2NamingScreen.for_box(data)
+	if kind == KIND_MAIL:
+		return Gen2NamingScreen.for_mail(data)
 	return Gen2NamingScreen.for_player(data)
 
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -235,6 +235,13 @@ var _mod_option_cursor: int = 0
 ## own screen rather than one of this node's; without one, nothing is drawn at
 ## all, which is what a test or the launcher gets.
 var _screen: Gen2Screen = null
+## `ComposeMailMessage`: the keyboard GIVE opens for a mail item, and what it
+## wrote, held until [method _give_selected_item] runs the transaction with it.
+var _naming: Gen2NamingScreenScreen = null
+var _pending_mail: Gen2SaveMail = null
+var _mail_item: int = 0
+var _mail_target: int = -1
+var _mail_swap: bool = false
 var _view: TextureRect = null
 var _page: Gen2StartMenuPage = null
 ## `LoadPartyMenuGFX`: the target list is the party menu, so it is drawn by the
@@ -354,6 +361,10 @@ func _select_pack_item(item: int) -> bool:
 
 
 func handle_button(button: int) -> bool:
+	## The mail keyboard owns all 160x144 while it is up, the way BILL'S PC's
+	## own does over the box screen.
+	if _naming != null:
+		return _naming.handle_button(button)
 	## `BuySellToss_InterpretJoypad` reads the joypad itself and answers with a
 	## carry, so the dial takes the whole button rather than a direction and an
 	## A/B split, the way [Gen2WorldApricorn] feeds it.
@@ -1138,9 +1149,16 @@ func _give_selected_item(party_index: int, swap: bool = false) -> void:
 	if not Gen2WorldPack.can_hold(_data, number):
 		_show_pack_result(Gen2WorldPack.cant_hold_text(), false)
 		return
+	## `GivePartyItem` writes the item and then runs `ComposeMailMessage`; here
+	## the message is written first, because the transaction is what commits and
+	## a cancelled entry has to leave the bag alone.
+	if Gen2HeldItem.is_mail(number) and _pending_mail == null:
+		_open_mail_composer(number, party_index, swap)
+		return
 	var result: Dictionary = Gen2WorldBagHost.give_to_party(
-		_world, _pack_save, number, party_index, swap, _pack_persist
+		_world, _pack_save, number, party_index, swap, _pack_persist, _pending_mail
 	)
+	_pending_mail = null
 	if bool(result.get("ok", false)):
 		var target_name: String = _target_name(party_index)
 		var held_name: String = String(result.get("held_name", ""))
@@ -1160,8 +1178,50 @@ func _give_selected_item(party_index: int, swap: bool = false) -> void:
 	_show_pack_result(_give_refusal(reason, party_index), false)
 
 
+## `_ComposeMailMessage` over the party menu's own screen. The entry is the
+## caller's, so it is written here and handed to the transaction; B on the
+## keyboard is not a way out of the screen, so an empty message is a message.
+func _open_mail_composer(item: int, party_index: int, swap: bool) -> void:
+	if _naming != null or _screen == null:
+		return
+	var host := Gen2NamingScreenScreen.new()
+	if not host.open(_data, "", Gen2NamingScreenScreen.KIND_MAIL):
+		host.free()
+		_show_pack_result("The mail keyboard is not in this cache.", false)
+		return
+	_naming = host
+	_mail_item = item
+	_mail_target = party_index
+	_mail_swap = swap
+	host.z_index = 5
+	host.closed.connect(_on_mail_composed)
+	_screen.display(host)
+
+
+## `ComposeMailMessage`'s tail: the stored entry, the player's own name and ID,
+## the species that is about to hold it and the item itself.
+func _on_mail_composed(_name: String) -> void:
+	var entry: PackedByteArray = _naming.model().stored_entry() if _naming != null 		else Gen2SaveMail.blank_message()
+	if _naming != null:
+		Gen2Screen.drop(_naming)
+		_naming = null
+	var species: int = 0
+	if _pack_save != null and _mail_target >= 0 and _mail_target < _pack_save.party.size():
+		species = (_pack_save.party[_mail_target] as Gen2SaveMon).species
+	_pending_mail = Gen2SaveMail.compose(
+		entry,
+		_pack_save.player_name if _pack_save != null else "",
+		_pack_save.player_id if _pack_save != null else 0,
+		species, _mail_item
+	)
+	_give_selected_item(_mail_target, _mail_swap)
+
+
 func _give_refusal(reason: StringName, party_index: int) -> String:
 	match reason:
+		&"holding_mail":
+			## `.please_remove_mail`, the one refusal a swap is not offered for.
+			return "Please remove the\nMAIL first."
 		&"cannot_hold_egg":
 			return Gen2WorldPack.egg_cant_hold_text()
 		&"item_cannot_be_held":
@@ -2011,6 +2071,9 @@ func _exit_tree() -> void:
 	if _view != null:
 		Gen2Screen.drop(_view)
 		_view = null
+	if _naming != null:
+		Gen2Screen.drop(_naming)
+		_naming = null
 
 
 ## Whichever of the cartridge's screens this mode is. `_hardware_image()` answers

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -60,16 +60,20 @@ static func toss(
 ## a Pokemon already holding something is refused with nothing written, which is
 ## where the source stops to ask.
 ##
-## `ItemIsMail` is [method Gen2HeldItem.is_mail], but nothing here composes a
-## message, so `.please_remove_mail` and `ComposeMailMessage` are unreachable and
-## no item is refused for being mail.
+## `ItemIsMail` is [method Gen2HeldItem.is_mail] and it is read twice here.
+## `.please_remove_mail` refuses in front of the swap, because a message cannot
+## be taken off with the item that carries it; and `GivePartyItem` runs
+## `ComposeMailMessage` when the item being given is mail, which is a screen
+## rather than a transaction, so the caller writes it and hands the finished
+## [param mail] in.
 static func give_to_party(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
 	item: int,
 	party_index: int,
 	swap: bool = false,
-	persist: bool = true
+	persist: bool = true,
+	mail: Gen2SaveMail = null
 ) -> Dictionary:
 	if world == null or world.data == null or world.state == null:
 		return Gen2WorldTransaction.failure(&"missing_world", {})
@@ -91,11 +95,19 @@ static func give_to_party(
 	if mon.is_egg:
 		return Gen2WorldTransaction.failure(&"cannot_hold_egg", {"party_index": party_index})
 	var held: int = mon.item
+	## `.please_remove_mail`, which is asked before `.already_holding_item`: a
+	## held mail is not offered as a swap at all.
+	if Gen2HeldItem.is_mail(held):
+		return Gen2WorldTransaction.failure(&"holding_mail", {"party_index": party_index})
 	if held > 0 and not swap:
 		return Gen2WorldTransaction.failure(&"already_holding", {
 			"party_index": party_index, "held": held,
 			"held_name": world.data.item_name(held),
 		})
+	## `GivePartyItem`'s own tail: a mail item with no message behind it would
+	## be a held item the MAIL row could not read.
+	if Gen2HeldItem.is_mail(item) and mail == null:
+		return Gen2WorldTransaction.failure(&"mail_not_written", {"item": item})
 	var changes: Dictionary = {item: owned - 1}
 	if held > 0:
 		## `GiveItemToPokemon` runs before `ReceiveItemFromPokemon`, so the entry
@@ -109,6 +121,7 @@ static func give_to_party(
 			return Gen2WorldTransaction.failure(&"bag_full", room)
 		changes[held] = int(remaining.get(held, 0)) + 1
 	mon.item = item
+	mon.mail = mail
 	var before: Gen2WorldSnapshot = world.snapshot()
 	var applied: Dictionary = world.state.apply_changes({}, {}, {"items": changes})
 	if not bool(applied.get("ok", false)):
@@ -149,6 +162,11 @@ static func take_from_party(
 	if not bool(room.get("ok", false)):
 		return Gen2WorldTransaction.failure(&"bag_full", room)
 	mon.item = 0
+	## `TakePartyItem` asks `ItemIsMail` and does nothing with the answer: the
+	## message goes into the bag with the item and is gone. Here the message is
+	## on the record rather than in a slot of SRAM, so it is cleared rather than
+	## left behind as mail nothing holds.
+	mon.mail = null
 	var before: Gen2WorldSnapshot = world.snapshot()
 	var applied: Dictionary = world.state.apply_changes({}, {}, {
 		"items": {held: world.state.item_quantity(held) + 1},

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -11,12 +11,10 @@ extends RefCounted
 ## boundary is [Gen2WorldTransaction], the same one the mart, Kurt and the bag
 ## go through.
 ##
-## One of the source's rows is absent from the lists this returns rather than
-## offered and refused, because it has nothing behind it: MAIL BOX is
-## `_PlayerMailBoxMenu`'s over `wMailbox`, which the save model does not keep.
-## DECORATION is [Gen2WorldDecoration]'s and HALL OF FAME is
-## [Gen2HallOfFame]'s viewer over [member Gen2SaveData.hall_of_fame]; both are
-## offered.
+## Every row of both lists is built. MAIL BOX is `_PlayerMailBoxMenu` over
+## [member Gen2SaveData.mailbox] and its own submenu below, DECORATION is
+## [Gen2WorldDecoration]'s and HALL OF FAME is [Gen2HallOfFame]'s viewer over
+## [member Gen2SaveData.hall_of_fame].
 
 ## `PokemonCenterPC.Jumptable` indexes.
 const PCPCITEM_PLAYERS_PC: int = 0
@@ -54,7 +52,7 @@ const PLAYER_MARKER: String = "<PLAYER>"
 ## The rows above with nothing behind them, dropped from every list rather than
 ## offered and refused. See the class comment for what each needs first.
 const UNBUILT_TOP_MENU_ROWS: Array[int] = []
-const UNBUILT_PLAYERS_PC_ROWS: Array[int] = [PLAYERSPCITEM_MAIL_BOX]
+const UNBUILT_PLAYERS_PC_ROWS: Array[int] = []
 
 
 ## `_BillsPC.MenuData`'s five rows, in its `.Jumptable`'s own order. Inline menu
@@ -73,6 +71,25 @@ const BILLS_PC_ROWS: Array[String] = [
 ## that no script reaches either.
 const BILLS_PC_WHAT: String = "What?"
 const BILLS_PC_NEEDS_POKEMON: String = "You gotta have\n#MON to call!"
+
+## `MailboxPC.SubMenuData`'s four rows, inline menu strings the way BILL'S PC's
+## own five are, and the five `text_far` stubs `.PutInPack` and `.AttachMail`
+## print through. Kept here rather than imported for the same reason: nothing
+## points at them, so there is no table to walk.
+const MAILBOXITEM_READ: int = 0
+const MAILBOXITEM_PUT_IN_PACK: int = 1
+const MAILBOXITEM_ATTACH: int = 2
+const MAILBOXITEM_CANCEL: int = 3
+const MAILBOX_ROWS: Array[String] = [
+	"READ MAIL", "PUT IN PACK", "ATTACH MAIL", "CANCEL",
+]
+const MAILBOX_EMPTY: String = "There's no MAIL\nhere."
+const MAILBOX_MESSAGE_LOST: String = "The MAIL's message\nwill be lost. OK?"
+const MAILBOX_PACK_FULL: String = "The PACK is full."
+const MAILBOX_CLEARED: String = "The cleared MAIL\nwas put away."
+const MAILBOX_ALREADY_HOLDING: String = "It's already hold-\ning an item."
+const MAILBOX_EGG: String = "An EGG can't hold\nany MAIL."
+const MAILBOX_MOVED: String = "The MAIL was moved\nfrom the MAILBOX."
 
 ## Every row of the machine's own menu is built: MOVE PKMN W/O MAIL is
 ## [Gen2BoxScreen]'s `MODE_MOVE`, which is `_MovePKMNWithoutMail`'s own two
@@ -290,6 +307,122 @@ static func _transfer(
 		"bag": changes["items"][item],
 		"pc": changes["pc_items"][item],
 	})
+
+
+## `MailboxPC`'s own rows: one per stored message, printed by
+## `MailboxPC_PrintMailAuthor`, which is the author and nothing else.
+static func mailbox_entries(save: Gen2SaveData) -> Array:
+	var out: Array = []
+	if save == null:
+		return out
+	for index: int in save.mailbox.size():
+		var mail: Gen2SaveMail = save.mailbox[index]
+		out.append({"row": index, "name": mail.author if mail != null else ""})
+	return out
+
+
+## `MonMailAction`'s TAKE and its `SendMailToPC`. The mail leaves the party
+## member with its item; nothing in the bag or the world moves, so the only
+## change is to the save.
+static func mailbox_send(
+	world: Gen2WorldAPI, save: Gen2SaveData, slot: int, persist: bool = true
+) -> Dictionary:
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return opened
+	var candidate: Gen2SaveData = opened["candidate"]
+	if not Gen2SaveMail.send_to_pc(candidate, slot):
+		## `.MailboxFull` is the one refusal the routine has; a member holding
+		## no mail cannot reach the row that calls it.
+		return Gen2WorldTransaction.failure(&"mailbox_full", {"slot": slot})
+	return _committed(world, save, candidate, persist, {"slot": slot})
+
+
+## `.PutInPack`: the message is lost, its `Type` byte becomes an ordinary item
+## in the bag, and the mailbox entry is deleted behind it. `ReceiveItem` is
+## asked first, so a full pack leaves the message where it is.
+static func mailbox_to_pack(
+	world: Gen2WorldAPI, save: Gen2SaveData, index: int, persist: bool = true
+) -> Dictionary:
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return opened
+	var candidate: Gen2SaveData = opened["candidate"]
+	if index < 0 or index >= candidate.mailbox.size():
+		return Gen2WorldTransaction.failure(&"unknown_mail", {"index": index})
+	var item: int = (candidate.mailbox[index] as Gen2SaveMail).item
+	var room: Dictionary = Gen2WorldPack.receive_check(
+		world.data, world.state.items(), item, 1
+	)
+	if not bool(room.get("ok", false)):
+		return Gen2WorldTransaction.failure(
+			StringName(room.get("reason", &"pack_full")), {"item": item}
+		)
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {item: world.state.item_quantity(item) + 1},
+	})
+	if not bool(applied.get("ok", false)):
+		return Gen2WorldTransaction.failure(&"pc_state_failed", applied)
+	Gen2SaveMail.delete_from_pc(candidate, index)
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {
+		"ok": true, "item": item,
+		"name": String(world.data.item(item).get("name", "UNKNOWN")),
+	}
+
+
+## `.AttachMail`, once `PartyMenuSelect` has picked a member. The two refusals
+## in front of it are the caller's, because both print and go back to the same
+## list: an egg cannot hold mail and a member already holding an item is not
+## asked to swap.
+static func mailbox_attach(
+	world: Gen2WorldAPI, save: Gen2SaveData, index: int, slot: int,
+	persist: bool = true
+) -> Dictionary:
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return opened
+	var candidate: Gen2SaveData = opened["candidate"]
+	var refusal: StringName = attach_refusal(candidate, slot)
+	if refusal != &"":
+		return Gen2WorldTransaction.failure(refusal, {"slot": slot})
+	if not Gen2SaveMail.move_from_pc_to_party(candidate, index, slot):
+		return Gen2WorldTransaction.failure(&"unknown_mail", {"index": index})
+	return _committed(world, save, candidate, persist, {"slot": slot, "index": index})
+
+
+## `.AttachMail`'s own two branches: `cp EGG` and the held-item test.
+static func attach_refusal(save: Gen2SaveData, slot: int) -> StringName:
+	if save == null or slot < 0 or slot >= save.party.size():
+		return &"unknown_member"
+	var mon: Gen2SaveMon = save.party[slot]
+	if mon == null:
+		return &"unknown_member"
+	if mon.is_egg:
+		return &"egg"
+	return &"already_holding" if mon.item != 0 else &""
+
+
+## A candidate the caller has already changed, written through the same
+## boundary the item transactions use. The world is unchanged, so the snapshot
+## a refusal would restore is the live one.
+static func _committed(
+	world: Gen2WorldAPI, save: Gen2SaveData, candidate: Gen2SaveData,
+	persist: bool, answer: Dictionary
+) -> Dictionary:
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, world.snapshot(), persist
+	)
+	if not bool(committed.get("ok", false)):
+		return committed
+	var out: Dictionary = answer.duplicate()
+	out["ok"] = true
+	return out
 
 
 static func _commit(

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -196,6 +196,28 @@ var _field_move_text: bool = false
 ## The item the standing renewal question would spend, 0 while none is up. See
 ## [method _offer_repel_renewal].
 var _repel_renewal_item: int = 0
+## `MonMailAction`'s own two questions and the member whose mail they are about.
+## `.take` asks `.MailAskSendToPCText` and, when that is refused, `.RemoveMail
+## ToBag` asks `.MailLoseMessageText`: two `YesNoBox`es in a row, so which one is
+## open has to be remembered as well as who it is about.
+const MAIL_TAKE_NONE: int = 0
+const MAIL_TAKE_ASK_PC: int = 1
+const MAIL_TAKE_ASK_BAG: int = 2
+var _mail_take_slot: int = -1
+var _mail_take_stage: int = MAIL_TAKE_NONE
+var _mail_take_name: String = ""
+## `ReadPartyMonMail`'s screen, which the MAIL submenu opens over the party list.
+var _mail_host: Gen2MailScreen = null
+
+## `MonMailAction`'s six `text_far` stubs, in `data/text/common_2.asm`. Kept
+## here rather than imported for the same reason BILL'S PC's own two are: no
+## script points at them, so there is no table to walk.
+const MAIL_ASK_SEND_TO_PC_TEXT: String = "Send the removed\nMAIL to your PC?"
+const MAIL_SENT_TO_PC_TEXT: String = "The MAIL was sent\nto your PC."
+const MAILBOX_FULL_TEXT: String = "Your PC's MAILBOX\nis full."
+const MAIL_LOSE_MESSAGE_TEXT: String = "The MAIL will lose\nits message. OK?"
+const MAIL_NO_SPACE_TEXT: String = "There's no space\nfor removing MAIL."
+const MAIL_DETACHED_TEXT: String = "MAIL detached from\n%s."
 ## `PlayerEventScriptPointers`: an engine script the overworld runs on its own
 ## rather than out of a map. Each entry is one `writetext`/`waitbutton` pair and
 ## [member _player_event_after] is whatever the script does past its last one,
@@ -640,7 +662,7 @@ func _apply_interface_mask() -> void:
 		or _move_tutor_host != null or _day_care_host != null
 		or _unown_puzzle_host != null or _slot_machine_host != null
 		or _card_flip_host != null or _diploma_host != null
-		or _unown_printer_host != null
+		or _unown_printer_host != null or _mail_host != null
 	)
 	_screen.interface_masked = _screen.expanded and owned \
 		and Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
@@ -1064,7 +1086,8 @@ func _overlay_open() -> bool:
 		or _move_tutor_host != null \
 		or _day_care_host != null or _unown_puzzle_host != null \
 		or _slot_machine_host != null or _card_flip_host != null \
-		or _diploma_host != null or _unown_printer_host != null
+		or _diploma_host != null or _unown_printer_host != null \
+		or _mail_host != null
 
 
 ## Wandering objects keep to themselves while anything else owns the world: a
@@ -1227,6 +1250,11 @@ func _handle_button(button: int) -> bool:
 		return true
 	if _credits_host != null:
 		_credits_host.handle_button(button)
+		return true
+	## `ReadPartyMonMail`, which `MonMailAction` opens over the party list and
+	## comes back to: it owns the screen while it is up.
+	if _mail_host != null:
+		_mail_host.handle_button(button)
 		return true
 	if _party_host != null:
 		_party_host.handle_button(button)
@@ -5510,6 +5538,9 @@ func _run_party_action(action: Dictionary) -> void:
 	if StringName(action.get("kind", &"")) == &"mon_item":
 		_run_mon_item_action(action)
 		return
+	if StringName(action.get("kind", &"")) == &"mon_mail":
+		_run_mon_mail_action(action)
+		return
 	if StringName(action.get("kind", &"")) == &"heal_transfer":
 		_run_heal_transfer(action)
 		return
@@ -5737,6 +5768,88 @@ func _run_mon_item_action(action: Dictionary) -> void:
 					action_name, String(result.get("reason", "")),
 				]
 			)
+
+
+## `MonMailAction`'s READ and TAKE, once the party submenu has chosen. READ is
+## `ReadPartyMonMail` over the list; TAKE is `.MailAskSendToPCText` and, if that
+## is refused, `.MailLoseMessageText` and the bag.
+func _run_mon_mail_action(action: Dictionary) -> void:
+	var slot: int = int(action.get("slot", -1))
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or slot < 0 or slot >= save.party.size():
+		return
+	var mon: Gen2SaveMon = save.party[slot]
+	if mon == null or mon.mail == null:
+		return
+	if StringName(action.get("option", &"")) == Gen2PartyScreen.OPTION_MAIL_READ:
+		_open_mail_reader(mon.mail)
+		return
+	_mail_take_slot = slot
+	_mail_take_name = String(action.get("name", ""))
+	_mail_take_stage = MAIL_TAKE_ASK_PC
+	if not _open_host_prompt(MAIL_ASK_SEND_TO_PC_TEXT):
+		_mail_take_slot = -1
+
+
+func _open_mail_reader(mail: Gen2SaveMail) -> void:
+	if _mail_host != null:
+		return
+	var host := Gen2MailScreen.new()
+	host.set_context(_data, mail)
+	_mail_host = host
+	host.z_index = 20
+	host.closed.connect(_on_mail_reader_closed)
+	_screen.display(host)
+	_apply_interface_mask()
+	_refresh_labels()
+
+
+## `.read` answers 0, which `.choosemenu` takes back to the party list. Here the
+## list has already closed, because [method _on_party_action] drops it before it
+## dispatches: every party action in this project is answered over the map, and
+## this one is not the place to make an exception.
+func _on_mail_reader_closed() -> void:
+	if _mail_host != null:
+		Gen2Screen.drop(_mail_host)
+		_mail_host = null
+	_apply_interface_mask()
+	_refresh_labels()
+
+
+## The answer to whichever of `MonMailAction`'s two questions is open.
+func _answer_mail_take(accepted: bool) -> void:
+	var slot: int = _mail_take_slot
+	var stage: int = _mail_take_stage
+	_mail_take_slot = -1
+	_mail_take_stage = MAIL_TAKE_NONE
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or slot < 0:
+		return
+	if stage == MAIL_TAKE_ASK_PC:
+		if not accepted:
+			## `.RemoveMailToBag`, which is the second question rather than a
+			## way out.
+			_mail_take_slot = slot
+			_mail_take_stage = MAIL_TAKE_ASK_BAG
+			if not _open_host_prompt(MAIL_LOSE_MESSAGE_TEXT):
+				_mail_take_slot = -1
+			return
+		var sent: Dictionary = Gen2WorldPC.mailbox_send(
+			_world, save, slot, _injected_save == null
+		)
+		_show_field_move_text(
+			MAIL_SENT_TO_PC_TEXT if bool(sent.get("ok", false)) else MAILBOX_FULL_TEXT
+		)
+		return
+	if not accepted:
+		return
+	var taken: Dictionary = Gen2WorldBagHost.take_from_party(
+		_world, save, slot, _injected_save == null
+	)
+	if not bool(taken.get("ok", false)):
+		_show_field_move_text(MAIL_NO_SPACE_TEXT)
+		return
+	_show_field_move_text(MAIL_DETACHED_TEXT % _mail_take_name)
 
 
 ## `Softboiled_MilkDrinkFunction`'s two halves, once the party menu has picked
@@ -6040,9 +6153,14 @@ func _apply_host_choice(results: Array) -> bool:
 	for result: Dictionary in results:
 		if StringName(result.get("kind", &"")) != &"host_choice":
 			continue
+		var accepted: bool = int(result.get("choice", 1)) == 0
+		if _mail_take_slot >= 0:
+			_answer_mail_take(accepted)
+			_refresh_labels()
+			return true
 		var item: int = _repel_renewal_item
 		_repel_renewal_item = 0
-		if int(result.get("choice", 1)) == 0 and item > 0:
+		if accepted and item > 0:
 			_renew_repel(item)
 		_refresh_labels()
 		return true

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -31,12 +31,16 @@ enum MODE {
 	PC_BOXES, PC_BOX_LIST,
 	PC_DECO, PC_DECO_LIST, PC_DECO_SIDE,
 	PC_BOX_SUBMENU,
+	PC_MAILBOX, PC_MAIL_SUBMENU, PC_MAIL_CONFIRM,
 }
 
 ## `PokemonCenterPC`'s own box storage, which is the one row that opens a screen
 ## rather than a list. It is added as a child the way the MAP card adds the
 ## region map, so the top menu is still there when the box screen closes.
 const BOX_SCENE := preload("res://game/save/box_screen.tscn")
+## `.AttachMail`'s own `PartyMenuSelect`, which is the same list the day care
+## and the move tutor open.
+const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 
 ## engine/pokegear/pokegear.asm's card order. Each is behind its own
 ## wPokegearFlags bit, named here by the engine flag that carries it, since that
@@ -191,6 +195,11 @@ var _hof: Gen2HallOfFameScreen = null
 var _box_submenu_index: int = 0
 var _naming: Gen2NamingScreenScreen = null
 var _hof_index: int = 0
+## `MailboxPC`: `wCurMessageIndex`, the message a submenu is acting on, the
+## reader `.ReadMail` opens and the party list `.AttachMail` opens.
+var _mail_index: int = 0
+var _mail_reader: Gen2MailScreen = null
+var _mail_party: Gen2PartyScreen = null
 ## `_ChangeBox_MenuHeader`'s `db 4, 0`: four rows of a scrolling list, and where
 ## the window into the fourteen boxes stands.
 const BOX_LIST_ROWS: int = 4
@@ -242,6 +251,9 @@ func _exit_tree() -> void:
 	if _hof != null:
 		Gen2Screen.drop(_hof)
 		_hof = null
+	if _mail_reader != null:
+		Gen2Screen.drop(_mail_reader)
+		_mail_reader = null
 	if _naming != null:
 		Gen2Screen.drop(_naming)
 		_naming = null
@@ -381,6 +393,10 @@ func handle_button(button: int) -> bool:
 		return _hof.handle_button(button)
 	if _boxes != null:
 		return _boxes.handle_button(button)
+	if _mail_reader != null:
+		return _mail_reader.handle_button(button)
+	if _mail_party != null:
+		return _mail_party.handle_button(button)
 	if Gen2Button.is_direction(button):
 		_move_direction(Gen2Button.vector(button))
 		return true
@@ -1303,6 +1319,15 @@ func _confirm_pc_row() -> void:
 		else:
 			_apply_decoration(_deco_pending, side)
 		return
+	if _mode == MODE.PC_MAILBOX:
+		_open_mail_submenu(row)
+		return
+	if _mode == MODE.PC_MAIL_SUBMENU:
+		_confirm_mail_submenu(row)
+		return
+	if _mode == MODE.PC_MAIL_CONFIRM:
+		_confirm_mail_to_pack(row == 0)
+		return
 	if _mode == MODE.PC:
 		match row:
 			Gen2WorldPC.PCPCITEM_BILLS_PC:
@@ -1324,6 +1349,8 @@ func _confirm_pc_row() -> void:
 		Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM, \
 		Gen2WorldPC.PLAYERSPCITEM_TOSS_ITEM:
 			_open_pc_item_list(row)
+		Gen2WorldPC.PLAYERSPCITEM_MAIL_BOX:
+			_open_mailbox()
 		Gen2WorldPC.PLAYERSPCITEM_DECORATION:
 			_open_decorations()
 		Gen2WorldPC.PLAYERSPCITEM_LOG_OFF:
@@ -1668,6 +1695,141 @@ func _refresh_box_counts() -> void:
 
 ## BILL'S PC's own two lists. The panel steps aside for the box screen the way it
 ## does for the region map, so the menu is still there when the boxes close.
+## `_PlayerMailBoxMenu`: `InitMail` answers zero when `sMailboxCount` is, and
+## the routine prints `.EmptyMailboxText` instead of opening the list.
+func _open_mailbox() -> void:
+	_pc_rows = Gen2WorldPC.mailbox_entries(_save)
+	if _pc_rows.is_empty():
+		_status = Gen2WorldPC.MAILBOX_EMPTY
+		_mode = MODE.PC_ITEMS
+		_pc_rows = Gen2WorldPC.players_pc_menu(_data, _pc_house)
+		_render_rows()
+		return
+	_mode = MODE.PC_MAILBOX
+	## `MailboxPC` keeps `wCurMessageIndex` across the submenu, so the list
+	## reopens on the message that was just acted on rather than at the top.
+	_cursor = clampi(_mail_index, 0, _pc_rows.size() - 1)
+	_title = _data.pokecenter_pc_row("mail_box", true)
+	_summary = ""
+	_status = ""
+	_render_rows()
+
+
+func _open_mail_submenu(index: int) -> void:
+	_mail_index = clampi(index, 0, maxi(0, _save.mailbox.size() - 1))
+	_mode = MODE.PC_MAIL_SUBMENU
+	_cursor = 0
+	_pc_rows = []
+	for row: int in Gen2WorldPC.MAILBOX_ROWS.size():
+		_pc_rows.append({"row": row, "name": Gen2WorldPC.MAILBOX_ROWS[row]})
+	_status = ""
+	_render_rows()
+
+
+func _confirm_mail_submenu(row: int) -> void:
+	match row:
+		Gen2WorldPC.MAILBOXITEM_READ:
+			_open_mail_reader()
+		Gen2WorldPC.MAILBOXITEM_PUT_IN_PACK:
+			_open_mail_confirm()
+		Gen2WorldPC.MAILBOXITEM_ATTACH:
+			_open_mail_attach()
+		_:
+			_open_mailbox()
+
+
+## `.PutInPack`'s `.MailMessageLostText` and the `YesNoBox` under it.
+func _open_mail_confirm() -> void:
+	_mode = MODE.PC_MAIL_CONFIRM
+	_cursor = 0
+	_pc_rows = [{"row": 0, "name": "YES"}, {"row": 1, "name": "NO"}]
+	_summary = Gen2WorldPC.MAILBOX_MESSAGE_LOST
+	_status = ""
+	_render_rows()
+
+
+func _confirm_mail_to_pack(accepted: bool) -> void:
+	_summary = ""
+	if not accepted:
+		_open_mailbox()
+		return
+	var applied: Dictionary = Gen2WorldPC.mailbox_to_pack(
+		_world, _save, _mail_index, _persist
+	)
+	_open_mailbox()
+	if not bool(applied.get("ok", false)):
+		## `ReceiveItem`'s own failure, which is `.MailPackFullText`.
+		_status = Gen2WorldPC.MAILBOX_PACK_FULL
+		return
+	_status = Gen2WorldPC.MAILBOX_CLEARED
+
+
+func _open_mail_reader() -> void:
+	var mail: Gen2SaveMail = _save.mailbox[_mail_index] 		if _mail_index >= 0 and _mail_index < _save.mailbox.size() else null
+	var host := Gen2MailScreen.new()
+	host.set_context(_data, mail)
+	_mail_reader = host
+	_set_overlay_open(true)
+	host.z_index = 5
+	host.closed.connect(_on_mail_reader_closed)
+	_service_hardware.display(host)
+
+
+func _on_mail_reader_closed() -> void:
+	if _mail_reader != null:
+		Gen2Screen.drop(_mail_reader)
+		_mail_reader = null
+	_set_overlay_open(false)
+	## `.ReadMail` ends in `CloseSubmenu`, which is back into `MailboxPC.loop`.
+	_open_mailbox()
+
+
+func _open_mail_attach() -> void:
+	var host: Gen2PartyScreen = PARTY_SCENE.instantiate() as Gen2PartyScreen
+	if host == null or _save == null:
+		_status = "Attaching mail needs a validated save."
+		return
+	_mail_party = host
+	_set_overlay_open(true)
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.mouse_filter = Control.MOUSE_FILTER_STOP
+	host.z_index = 5
+	host.set_screen(_service_hardware)
+	add_child(host)
+	host.set_context(_data, _save, true)
+	host.selection_made.connect(_on_mail_attach_selected)
+	host.open_selection()
+
+
+## `.try_again`: the egg and held-item refusals print and reopen the same list,
+## so only a member that can take the mail leaves it.
+func _on_mail_attach_selected(party_index: int) -> void:
+	if party_index >= 0:
+		var refusal: StringName = Gen2WorldPC.attach_refusal(_save, party_index)
+		if refusal != &"":
+			_mail_party.say(
+				Gen2WorldPC.MAILBOX_EGG if refusal == &"egg"
+				else Gen2WorldPC.MAILBOX_ALREADY_HOLDING
+			)
+			return
+	_close_mail_attach()
+	if party_index < 0:
+		_open_mailbox()
+		return
+	var applied: Dictionary = Gen2WorldPC.mailbox_attach(
+		_world, _save, _mail_index, party_index, _persist
+	)
+	_open_mailbox()
+	_status = Gen2WorldPC.MAILBOX_MOVED if bool(applied.get("ok", false)) 		else "Refused: %s" % String(applied.get("reason", ""))
+
+
+func _close_mail_attach() -> void:
+	if _mail_party != null:
+		Gen2Screen.drop(_mail_party)
+		_mail_party = null
+	_set_overlay_open(false)
+
+
 func _open_boxes(mode: int) -> void:
 	var host: Gen2BoxScreen = BOX_SCENE.instantiate() as Gen2BoxScreen
 	if host == null or _save == null:
@@ -2035,6 +2197,7 @@ func _confirm() -> void:
 	if _mode in [
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
 		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
+		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
 	]:
 		_confirm_pc_row()
 		return
@@ -2073,6 +2236,15 @@ func _cancel() -> void:
 			_open_pc(&"pokemon_center")
 	elif _mode == MODE.PC_ITEM_LIST:
 		_open_pc_items()
+	elif _mode == MODE.PC_MAILBOX:
+		## `ScrollingMenu`'s PAD_B, which is `.exit` and the way back to the
+		## menu `_PlayerMailBoxMenu` was called from.
+		_open_pc_items()
+	elif _mode == MODE.PC_MAIL_SUBMENU:
+		## `VerticalMenu`'s carry, which `.subexit` takes back to `.loop`.
+		_open_mailbox()
+	elif _mode == MODE.PC_MAIL_CONFIRM:
+		_confirm_mail_to_pack(false)
 	elif _mode == MODE.PC_DECO:
 		_leave_decorations()
 	elif _mode == MODE.PC_DECO_LIST:
@@ -2147,6 +2319,7 @@ func _render_rows(override: Array = []) -> void:
 			MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES,
 			MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
 			MODE.PC_BOX_SUBMENU,
+			MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
 		] \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else ["Continue"]
@@ -2231,6 +2404,15 @@ func _service_box() -> Gen2MenuBox:
 			return _menu.box()
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_DECO_LIST:
 			return _pc_top_box()
+		MODE.PC_MAILBOX:
+			## `.TopMenuHeader`'s `menu_coords 8, 1, SCREEN_WIDTH - 2, 10`.
+			return Gen2MenuBox.from_coords(8, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
+		MODE.PC_MAIL_SUBMENU:
+			## `.SubMenuHeader`'s `menu_coords 0, 0, 13, 9`.
+			return Gen2MenuBox.from_coords(0, 0, 13, 9, Gen2MenuBox.STATICMENU_CURSOR)
+		MODE.PC_MAIL_CONFIRM:
+			## `YesNoBox`'s own box, which `.PutInPack` opens over its question.
+			return Gen2MenuBox.yes_no()
 		MODE.PC_DECO:
 			return _deco_category_box()
 		MODE.PC_DECO_SIDE:
@@ -2307,6 +2489,7 @@ func _option_count() -> int:
 	if _mode in [
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
 		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
+		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
 	]:
 		return _pc_rows.size()
 	if _mode == MODE.PC_ITEM_LIST:

--- a/game/world/world_transaction.gd
+++ b/game/world/world_transaction.gd
@@ -95,6 +95,10 @@ static func copy_into(target: Gen2SaveData, source: Gen2SaveData) -> void:
 	target.label = source.label
 	target.party = source.party.duplicate(true)
 	target.boxes = source.boxes
+	target.current_box = source.current_box
+	target.hall_of_fame = source.hall_of_fame.duplicate(true)
+	target.box_names = source.box_names.duplicate()
+	target.mailbox = source.mailbox.duplicate()
 	target.world = source.world
 	target.mods = source.mods.duplicate(true)
 	target.run_seed = source.run_seed

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -103,6 +103,7 @@ func test_players_house_pc_opens_the_item_pc_and_resumes_the_waiting_script() ->
 		Gen2WorldPC.PLAYERSPCITEM_WITHDRAW_ITEM,
 		Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM,
 		Gen2WorldPC.PLAYERSPCITEM_TOSS_ITEM,
+		Gen2WorldPC.PLAYERSPCITEM_MAIL_BOX,
 		Gen2WorldPC.PLAYERSPCITEM_DECORATION,
 		Gen2WorldPC.PLAYERSPCITEM_TURN_OFF,
 	])
@@ -891,8 +892,8 @@ func test_the_decoration_row_sets_a_decoration_up_and_closes_the_machine() -> vo
 	assert_not_null(host)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_ITEMS)
 
-	## WITHDRAW, DEPOSIT, TOSS, then DECORATION.
-	for _step: int in 3:
+	## WITHDRAW, DEPOSIT, TOSS, MAIL BOX, then DECORATION.
+	for _step: int in 4:
 		host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_DECO)
@@ -916,3 +917,83 @@ func test_the_decoration_row_sets_a_decoration_up_and_closes_the_machine() -> vo
 	await get_tree().process_frame
 	assert_null(_world_screen._service_host, "a changed room closes the machine")
 	assert_false(_world_screen._world.script_input_waiting())
+
+
+## `_PlayerMailBoxMenu`: `InitMail` answers zero when the mailbox is empty, so
+## the row prints `.EmptyMailboxText` instead of opening a list.
+func test_an_empty_mailbox_prints_its_own_line_and_opens_no_list() -> void:
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	for _step: int in 3:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_ITEMS)
+	assert_eq(host._status, Gen2WorldPC.MAILBOX_EMPTY)
+
+
+## `MailboxPC`: the list prints one author a message, the submenu is
+## `.SubMenuData`'s four rows, and READ MAIL opens `ReadAnyMail` over it.
+func test_the_mailbox_lists_its_authors_and_reads_one() -> void:
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	var save: Gen2SaveData = _world_screen._embedded_party_save()
+	save.mailbox.append(Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, 1, Gen2MailPage.ITEM_NUMBERS[0]
+	))
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	for _step: int in 3:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_MAILBOX)
+	assert_eq(host._pc_rows.size(), 1)
+	assert_eq(String(host._pc_rows[0]["name"]), "GOLD")
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_MAIL_SUBMENU)
+	assert_eq(host._pc_rows.size(), Gen2WorldPC.MAILBOX_ROWS.size())
+
+	host.handle_button(Gen2Button.A)
+	assert_not_null(host._mail_reader)
+	## `.loop` returns on A or B and on nothing else.
+	assert_false(host.handle_button(Gen2Button.DOWN))
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_null(host._mail_reader)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_MAILBOX)
+
+
+## `.PutInPack`: the question first, then `ReceiveItem`, then the entry is
+## deleted and `.MailClearedPutAwayText` printed.
+func test_putting_a_message_in_the_pack_empties_the_mailbox() -> void:
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	var save: Gen2SaveData = _world_screen._embedded_party_save()
+	var item: int = Gen2MailPage.ITEM_NUMBERS[0]
+	save.mailbox.append(Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, 1, item
+	))
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	for _step: int in 3:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_MAIL_CONFIRM)
+	assert_eq(host._summary, Gen2WorldPC.MAILBOX_MESSAGE_LOST)
+
+	host.handle_button(Gen2Button.A)
+	assert_eq(save.mailbox.size(), 0)
+	assert_eq(_world_screen._world.state.item_quantity(item), 1)
+	assert_eq(host._status, Gen2WorldPC.MAILBOX_CLEARED)

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -7,6 +7,7 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
 ## `ITEM_REPEL`, whose effect `UseItem` keys on the item number for.
 const REPEL: int = 0x14
+const FLOWER_MAIL: int = 158
 ## ITEMMENU_CLOSE rows at their real numbers: two `.Field` runs here and one it
 ## does not, which is what says the pack quits on the effect rather than on the
 ## menu nibble.
@@ -92,6 +93,14 @@ func _write_pack_item() -> void:
 				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
 				raw["permissions"] = Gen2WorldPack.CANT_TOSS
 				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+			FLOWER_MAIL:
+				## `MailItems`' first entry at its real number, with FLOWER
+				## MAIL's own row: `ItemIsMail` checks the number, so a stand-in
+				## would not be mail at all.
+				raw["name"] = "FLOWER MAIL"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_NOUSE
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 
 
@@ -1975,3 +1984,39 @@ func test_a_list_longer_than_the_screen_is_scrolled_rather_than_drawn_past_it() 
 	assert_eq(host._menu.cursor, rows - 1)
 	assert_eq(host._list_scroll, rows - visible)
 	Gen2ModHost.reset()
+
+
+## `GivePartyItem`: a mail item opens `_ComposeMailMessage` before anything is
+## written, and the finished entry goes onto the record with the item.
+func test_giving_mail_writes_a_message_before_it_leaves_the_bag() -> void:
+	await _open_world()
+	var mail_item: int = FLOWER_MAIL
+	_world_screen._world.state.apply_changes({}, {}, {"items": {7: 0, mail_item: 1}})
+	var host: Gen2StartMenuScreen = await _open_pack()
+	_choose_action(host, Gen2WorldPack.ACTION_GIVE)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+
+	host.handle_button(Gen2Button.A)
+	## Nothing has moved yet: the keyboard is what stands between the choice and
+	## the transaction.
+	var naming: Gen2NamingScreenScreen = host.get("_naming")
+	assert_not_null(naming)
+	assert_true(naming.model().is_mail)
+	assert_eq(_world_screen._world.state.item_quantity(mail_item), 1)
+
+	## One letter, then END, which is the last column of the command row.
+	naming.model().column = 0
+	naming.model().row = 0
+	host.handle_button(Gen2Button.A)
+	naming.model().press_start()
+	host.handle_button(Gen2Button.A)
+
+	assert_null(host.get("_naming"))
+	var save: Gen2SaveData = _world_screen._injected_save
+	var mon: Gen2SaveMon = save.party[0]
+	assert_eq(mon.item, mail_item)
+	assert_not_null(mon.mail)
+	assert_eq(mon.mail.item, mail_item)
+	assert_eq(mon.mail.author, save.player_name)
+	assert_eq(mon.mail.species, mon.species)
+	assert_eq(_world_screen._world.state.item_quantity(mail_item), 0)

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -153,6 +153,26 @@ static func _write_name_input_chars(directory: String) -> void:
 					codes.append(Gen2Text.SPACE)
 			rows.append(codes)
 		tables.append(rows)
+	## `mail_input_chars.asm`'s two, appended the way the importer appends them:
+	## ten columns two bytes apart, six rows, and the command row last.
+	for table: int in RomLayout.MAIL_INPUT_TABLES:
+		var first: int = RomLayout.MAIL_INPUT_UPPER_A if table == 0 \
+			else RomLayout.MAIL_INPUT_LOWER_A
+		var rows: Array = []
+		for row: int in RomLayout.MAIL_INPUT_TABLE_ROWS:
+			if row == RomLayout.MAIL_INPUT_TABLE_ROWS - 1:
+				rows.append(Array(
+					RomLayout.MAIL_INPUT_COMMAND_UPPER if table == 0
+					else RomLayout.MAIL_INPUT_COMMAND_LOWER
+				))
+				continue
+			var codes: Array[int] = []
+			for column: int in RomLayout.MAIL_INPUT_COLUMNS:
+				codes.append(first + row * RomLayout.MAIL_INPUT_COLUMNS + column)
+				if column < RomLayout.MAIL_INPUT_COLUMNS - 1:
+					codes.append(Gen2Text.SPACE)
+			rows.append(codes)
+		tables.append(rows)
 	RomCache.write_json(RomCache.name_input_chars_path(directory), tables)
 
 
@@ -934,6 +954,11 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 		"pokedex_slowpoke": [RomLayout.POKEDEX_SLOWPOKE_TILES, 2],
 		"unown_font": [RomLayout.UNOWN_FONT_TILES, 3],
 		"footprints": [RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES, 1],
+		## `gfx/mail.asm`'s one run and `_ComposeMailMessage.MailIcon`. The run
+		## is at its real length so every `Load*MailGFX` program can address it;
+		## a flat fill of ink is what makes each type's own tiles visible.
+		"mail_gfx": [RomLayout.MAIL_GFX_TILES, Gen2Tiles.INK],
+		"mail_icon": [RomLayout.MAIL_ICON_TILES, 2],
 	}
 	## The font and the frames are the two sheets addressed by character code
 	## rather than by slot, so both need their real first code. A frames sheet
@@ -966,6 +991,14 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 		],
 		"badge": [0x7FFF, 0x5ABA, 0x49EF, 0x0000],
 	}
+	## `MailItems` and `LoadMailPalettes.MailPals`, at their real numbers: the
+	## item number is what `MailGFXPointers` is walked with, so a stand-in there
+	## would reach the wrong type.
+	manifest["mail_items"] = Gen2MailPage.ITEM_NUMBERS.duplicate()
+	var mail_palettes: Array = []
+	for index: int in RomLayout.MAIL_PALETTE_COUNT:
+		mail_palettes.append([0x7FFF, 0x2A9F + index, 0x195A, 0x0000])
+	manifest["mail_palettes"] = mail_palettes
 	## `_CGB_Pokedex`'s three: PREDEFPAL_POKEDEX and the two the screen loads
 	## beside it (gfx/pokedex/question_mark.pal and cursor.pal).
 	manifest["pokedex_palettes"] = {

--- a/tests/unit/test_naming_screen.gd
+++ b/tests/unit/test_naming_screen.gd
@@ -47,6 +47,25 @@ func _write_cache() -> void:
 				codes.append(first + row * RomLayout.NAME_INPUT_COLUMNS + column)
 			rows.append(_spread(codes))
 		tables.append(rows)
+	## `mail_input_chars.asm`'s two behind them, ten columns rather than nine.
+	for table: int in RomLayout.MAIL_INPUT_TABLES:
+		var first: int = RomLayout.MAIL_INPUT_UPPER_A if table == 0 \
+			else RomLayout.MAIL_INPUT_LOWER_A
+		var rows: Array = []
+		for row: int in RomLayout.MAIL_INPUT_TABLE_ROWS:
+			if row == RomLayout.MAIL_INPUT_TABLE_ROWS - 1:
+				rows.append(Array(
+					RomLayout.MAIL_INPUT_COMMAND_UPPER if table == 0
+					else RomLayout.MAIL_INPUT_COMMAND_LOWER
+				))
+				continue
+			var codes: Array[int] = []
+			for column: int in RomLayout.MAIL_INPUT_COLUMNS:
+				codes.append(first + row * RomLayout.MAIL_INPUT_COLUMNS + column)
+				if column < RomLayout.MAIL_INPUT_COLUMNS - 1:
+					codes.append(SPACE)
+			rows.append(codes)
+		tables.append(rows)
 	RomCache.write_json(RomCache.name_input_chars_path(_directory), tables)
 	for path: String in [
 		RomCache.species_path(_directory), RomCache.moves_path(_directory),
@@ -349,3 +368,65 @@ func test_a_screen_without_keyboards_reads_no_character() -> void:
 	assert_eq(screen.last_character(), 0)
 	assert_eq(screen.press_a(), Gen2NamingScreen.RESULT_LETTER)
 	assert_eq(screen.length, 0, "nothing is added when there is nothing to read")
+
+
+## `_ComposeMailMessage`'s own keyboard: six rows, ten columns and the command
+## row at row 5, against `NamingScreen`'s five and nine.
+func test_the_mail_keyboard_is_six_rows_of_ten() -> void:
+	var mail: Gen2NamingScreen = Gen2NamingScreen.for_mail(_data)
+	assert_true(mail.is_mail)
+	assert_eq(mail.row_count(), RomLayout.MAIL_INPUT_TABLE_ROWS)
+	assert_eq(mail.command_row(), RomLayout.MAIL_INPUT_TABLE_ROWS - 1)
+	assert_eq(mail.last_column(), Gen2NamingScreen.MAIL_LAST_COLUMN)
+	assert_eq(mail.rows().size(), RomLayout.MAIL_INPUT_TABLE_ROWS)
+	assert_eq(mail.keyboard(), Gen2NamingScreen.Keyboard.MAIL_UPPER)
+	mail.press_select()
+	assert_eq(mail.keyboard(), Gen2NamingScreen.Keyboard.MAIL_LOWER)
+	## `.start` sets VAR1 to $9 and VAR2 to $5, which is the tenth column.
+	mail.press_start()
+	assert_eq(mail.column, Gen2NamingScreen.MAIL_LAST_COLUMN)
+	assert_eq(mail.row, RomLayout.MAIL_INPUT_TABLE_ROWS - 1)
+
+
+## `.InitBlankMail`'s `ld [hl], '<NEXT>'`, and the `wNamingScreenMaxNameLength`
+## of MAIL_MSG_LENGTH + 1 behind it.
+func test_a_mail_buffer_opens_with_the_break_already_in_it() -> void:
+	var mail: Gen2NamingScreen = Gen2NamingScreen.for_mail(_data)
+	assert_eq(mail.max_length, Gen2SaveMail.BUFFER_LENGTH)
+	assert_eq(mail.buffer.size(), Gen2SaveMail.BUFFER_LENGTH + 1)
+	assert_eq(mail.buffer[Gen2SaveMail.LINE_LENGTH], Gen2SaveMail.LINE_BREAK)
+	assert_eq(mail.buffer[Gen2SaveMail.BUFFER_LENGTH], Gen2NamingScreen.TERMINATOR)
+	assert_eq(mail.buffer[0], Gen2NamingScreen.UNDERLINE)
+
+
+## `.a`'s and `.b`'s tails: an entry that lands on the line break steps over it
+## in whichever direction it arrived from, and the break is written back.
+func test_the_line_break_is_stepped_over_in_both_directions() -> void:
+	var mail: Gen2NamingScreen = Gen2NamingScreen.for_mail(_data)
+	for _index: int in Gen2SaveMail.LINE_LENGTH:
+		mail.column = 0
+		mail.row = 0
+		mail.press_a()
+	assert_eq(mail.length, Gen2SaveMail.LINE_LENGTH + 1, "the break took its own slot")
+	assert_eq(mail.buffer[Gen2SaveMail.LINE_LENGTH], Gen2SaveMail.LINE_BREAK)
+	assert_eq(mail.buffer[Gen2SaveMail.LINE_LENGTH + 1], Gen2NamingScreen.UNDERLINE)
+
+	mail.press_b()
+	assert_eq(mail.length, Gen2SaveMail.LINE_LENGTH - 1)
+	assert_eq(mail.buffer[Gen2SaveMail.LINE_LENGTH], Gen2SaveMail.LINE_BREAK)
+	assert_eq(mail.buffer[Gen2SaveMail.LINE_LENGTH - 1], Gen2NamingScreen.UNDERLINE)
+
+
+## `NamingScreen_StoreEntry` over a mail buffer: every marker becomes a
+## terminator and the break stays where it is, which is what makes the second
+## line reachable by `PlaceString` at all.
+func test_a_stored_mail_entry_keeps_its_break_and_terminates_the_rest() -> void:
+	var mail: Gen2NamingScreen = Gen2NamingScreen.for_mail(_data)
+	mail.column = 0
+	mail.row = 0
+	mail.press_a()
+	var stored: PackedByteArray = mail.stored_entry()
+	assert_eq(stored.size(), Gen2SaveMail.BUFFER_LENGTH)
+	assert_eq(stored[0], RomLayout.MAIL_INPUT_UPPER_A)
+	assert_eq(stored[1], Gen2NamingScreen.TERMINATOR)
+	assert_eq(int(stored[Gen2SaveMail.LINE_LENGTH]), Gen2SaveMail.LINE_BREAK)

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -921,3 +921,61 @@ func test_export_updates_both_copies_and_preserves_trailing_bytes() -> void:
 	assert_true(backup_import["ok"], backup_import["message"])
 	assert_eq(backup_import["copy"], "backup")
 	assert_eq((backup_import["save"] as Gen2SaveData).player_name, "BLUE")
+
+
+## `sPartyMail` and `sMailboxes`, both of which default rather than versioning:
+## a slot written before mail existed reads as a party holding none and an empty
+## mailbox, which is exactly what it was.
+func test_mail_round_trips_on_a_member_and_in_the_mailbox() -> void:
+	var save := Gen2SaveData.new()
+	save.game_id = &"savetest"
+	var mon := Gen2SaveMon.new()
+	mon.species = Fixture.CUBONE
+	mon.item = Fixture.FLOWER_MAIL
+	var entry: PackedByteArray = Gen2SaveMail.blank_message()
+	var text: PackedByteArray = Gen2Text.encode("HELLO")
+	for index: int in text.size():
+		entry[index] = text[index]
+	mon.mail = Gen2SaveMail.compose(entry, "GOLD", 0x1234, mon.species, mon.item)
+	save.party = [mon]
+	save.mailbox = [Gen2SaveMail.compose(entry, "KRIS", 0x4321, 1, Fixture.FLOWER_MAIL)]
+
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	assert_not_null(restored)
+	var carried: Gen2SaveMail = (restored.party[0] as Gen2SaveMon).mail
+	assert_not_null(carried)
+	assert_eq(carried.author, "GOLD")
+	assert_eq(carried.author_id, 0x1234)
+	assert_eq(carried.item, Fixture.FLOWER_MAIL)
+	assert_eq(carried.line(0), "HELLO")
+	assert_eq(carried.line(1), "")
+	assert_eq(restored.mailbox.size(), 1)
+	assert_eq((restored.mailbox[0] as Gen2SaveMail).author, "KRIS")
+
+	## A record with no mail keeps none rather than an empty message.
+	mon.mail = null
+	assert_null((Gen2SaveData.from_dict(save.to_dict()).party[0] as Gen2SaveMon).mail)
+
+
+## `copy_from` replaces the shared runtime save in place, and every field it
+## forgets is one a transaction silently throws away: the mailbox, the Hall of
+## Fame, the box names and the current box all live only in memory between two
+## writes.
+func test_copying_a_save_in_place_keeps_every_field() -> void:
+	var save := Gen2SaveData.new()
+	save.game_id = &"savetest"
+	var source := Gen2SaveData.new()
+	source.game_id = &"savetest"
+	source.current_box = 3
+	source.box_names = ["ALPHA"]
+	source.hall_of_fame = [{"win_count": 1, "mons": []}]
+	source.mailbox = [Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, 1, Fixture.FLOWER_MAIL
+	)]
+
+	assert_true(save.copy_from(source))
+	assert_eq(save.current_box, 3)
+	assert_eq(save.box_names, ["ALPHA"])
+	assert_eq(save.hall_of_fame.size(), 1)
+	assert_eq(save.mailbox.size(), 1)
+	assert_eq((save.mailbox[0] as Gen2SaveMail).author, "GOLD")

--- a/tests/unit/test_world_bag_host.gd
+++ b/tests/unit/test_world_bag_host.gd
@@ -10,6 +10,9 @@ const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 
 const POTION: int = 7
 const KEY_ITEM: int = 8
+## `MailItems`' first entry, at its real number: `ItemIsMail` checks the number,
+## so a stand-in would not be mail at all.
+const FLOWER_MAIL: int = 158
 
 var _data: GameData = null
 var _world: Gen2WorldAPI = null
@@ -20,7 +23,7 @@ func before_each() -> void:
 	_data = Fixture.build()
 	_write_items()
 	_data = GameData.open_directory(Fixture.directory())
-	var state := Gen2WorldState.new({}, {}, {POTION: 5, KEY_ITEM: 1}, {0: 500})
+	var state := Gen2WorldState.new({}, {}, {POTION: 5, KEY_ITEM: 1, FLOWER_MAIL: 1}, {0: 500})
 	_world = Gen2WorldAPI.open(
 		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6), state
 	)
@@ -43,6 +46,11 @@ func _write_items() -> void:
 				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
 				raw["permissions"] = Gen2WorldPack.CANT_SELECT
 				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
+			FLOWER_MAIL:
+				raw["name"] = "FLOWER MAIL"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_NOUSE
 			KEY_ITEM:
 				raw["name"] = "BICYCLE"
 				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
@@ -428,3 +436,121 @@ func _put_away_row(slot: StringName) -> int:
 			and Gen2WorldDecoration.is_put_away(_data, deco):
 			return deco
 	return -1
+
+
+## `GivePartyItem`'s tail: a mail item is only handed over with the message
+## `ComposeMailMessage` wrote, and the message travels on the record.
+func test_mail_is_only_given_with_a_message_behind_it() -> void:
+	var refused: Dictionary = Gen2WorldBagHost.give_to_party(
+		_world, _save, FLOWER_MAIL, 0, false, false
+	)
+	assert_false(bool(refused["ok"]))
+	assert_eq(refused["reason"], &"mail_not_written")
+	assert_eq(_world.state.item_quantity(FLOWER_MAIL), 1)
+
+	var mail: Gen2SaveMail = Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, 1, FLOWER_MAIL
+	)
+	var given: Dictionary = Gen2WorldBagHost.give_to_party(
+		_world, _save, FLOWER_MAIL, 0, false, false, mail
+	)
+	assert_true(bool(given["ok"]), str(given))
+	assert_eq(_world.state.item_quantity(FLOWER_MAIL), 0)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, FLOWER_MAIL)
+	assert_eq((_save.party[0] as Gen2SaveMon).mail.author, "GOLD")
+
+
+## `.please_remove_mail`, which is asked in front of `PokemonAskSwapItemText`:
+## a held mail is not offered as a swap at all.
+func test_a_member_holding_mail_is_refused_rather_than_asked_to_swap() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.item = FLOWER_MAIL
+	mon.mail = Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, mon.species, FLOWER_MAIL
+	)
+	for swap: bool in [false, true]:
+		var result: Dictionary = Gen2WorldBagHost.give_to_party(
+			_world, _save, POTION, 0, swap, false
+		)
+		assert_false(bool(result["ok"]))
+		assert_eq(result["reason"], &"holding_mail")
+	assert_eq(_world.state.item_quantity(POTION), 5)
+
+
+## `TakePartyItem` puts the item in the bag and says nothing about the message,
+## so the message goes with it: a record left holding mail with no item is one
+## the MAIL row could still read.
+func test_taking_a_mail_item_takes_its_message_with_it() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.item = FLOWER_MAIL
+	mon.mail = Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, mon.species, FLOWER_MAIL
+	)
+	var result: Dictionary = Gen2WorldBagHost.take_from_party(_world, _save, 0, false)
+	assert_true(bool(result["ok"]), str(result))
+	assert_eq((_save.party[0] as Gen2SaveMon).item, 0)
+	assert_null((_save.party[0] as Gen2SaveMon).mail)
+	assert_eq(_world.state.item_quantity(FLOWER_MAIL), 2)
+
+
+## `SendMailToPC`, `DeleteMailFromPC` and `MoveMailFromPCToParty`, which is the
+## whole of what MAIL BOX moves.
+func test_mail_moves_between_a_member_and_the_mailbox() -> void:
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.item = FLOWER_MAIL
+	mon.mail = Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, mon.species, FLOWER_MAIL
+	)
+	assert_true(Gen2SaveMail.any_mon_holding_mail(_save))
+	var sent: Dictionary = Gen2WorldPC.mailbox_send(_world, _save, 0, false)
+	assert_true(bool(sent["ok"]), str(sent))
+	assert_eq(_save.mailbox.size(), 1)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, 0)
+	assert_null((_save.party[0] as Gen2SaveMon).mail)
+	assert_false(Gen2SaveMail.any_mon_holding_mail(_save))
+
+	## `.AttachMail` refuses a member already holding an item without moving
+	## anything, which is `.MailAlreadyHoldingItemText`.
+	(_save.party[0] as Gen2SaveMon).item = POTION
+	var refused: Dictionary = Gen2WorldPC.mailbox_attach(_world, _save, 0, 0, false)
+	assert_false(bool(refused["ok"]))
+	assert_eq(refused["reason"], &"already_holding")
+	assert_eq(_save.mailbox.size(), 1)
+
+	(_save.party[0] as Gen2SaveMon).item = 0
+	var attached: Dictionary = Gen2WorldPC.mailbox_attach(_world, _save, 0, 0, false)
+	assert_true(bool(attached["ok"]), str(attached))
+	assert_eq(_save.mailbox.size(), 0)
+	assert_eq((_save.party[0] as Gen2SaveMon).item, FLOWER_MAIL)
+	assert_eq((_save.party[0] as Gen2SaveMon).mail.author, "GOLD")
+
+
+## `.PutInPack`: `ReceiveItem` first, so a full pack leaves the message where it
+## is, and the mailbox entry is only deleted once the item has arrived.
+func test_putting_mail_in_the_pack_deletes_it_and_keeps_the_item() -> void:
+	_save.mailbox.append(Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, 1, FLOWER_MAIL
+	))
+	var result: Dictionary = Gen2WorldPC.mailbox_to_pack(_world, _save, 0, false)
+	assert_true(bool(result["ok"]), str(result))
+	assert_eq(result["item"], FLOWER_MAIL)
+	assert_eq(_save.mailbox.size(), 0)
+	assert_eq(_world.state.item_quantity(FLOWER_MAIL), 2)
+
+
+## `GetMailboxCount` against `MAILBOX_CAPACITY`, which is `SendMailToPC`'s only
+## refusal.
+func test_a_full_mailbox_refuses_the_next_message() -> void:
+	for _index: int in Gen2SaveMail.CAPACITY:
+		_save.mailbox.append(Gen2SaveMail.compose(
+			Gen2SaveMail.blank_message(), "GOLD", 0x1234, 1, FLOWER_MAIL
+		))
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.item = FLOWER_MAIL
+	mon.mail = Gen2SaveMail.compose(
+		Gen2SaveMail.blank_message(), "GOLD", 0x1234, mon.species, FLOWER_MAIL
+	)
+	var sent: Dictionary = Gen2WorldPC.mailbox_send(_world, _save, 0, false)
+	assert_false(bool(sent["ok"]))
+	assert_eq(sent["reason"], &"mailbox_full")
+	assert_eq((_save.party[0] as Gen2SaveMon).item, FLOWER_MAIL)

--- a/tools/checks/mail.gd
+++ b/tools/checks/mail.gd
@@ -1,0 +1,295 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies mail against freshly imported real caches, in all three games.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## data/items/mail_items.asm's MailItems, data/text/mail_input_chars.asm's two
+## keyboards, gfx/mail/mail.pal, and the ten Load*MailGFX routines in
+## engine/pokemon/mail_2.asm.
+##
+## The pins here are counted off the asm rather than read from
+## [Gen2MailPage]'s own tables, so a mistranscribed byte count or tile number is
+## a failure instead of an agreement: LOADED_RANGES is what each routine's
+## `ld c, n * TILE_1BPP_SIZE` calls add up to, and every tile a routine places
+## has to fall inside its own range.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- mail
+
+## `MailItems`, which is also [constant Gen2HeldItem.MAIL_ITEMS]' pin.
+const EXPECTED_ITEMS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]
+
+## The two mail keyboards' symbol rows by cursor column, which is the part of
+## the block a plausible neighbouring run of text would not reproduce.
+## Uppercase row 4 is PK MN PO KE é ♂ ♀ ¥ … ×; lowercase row 2 ends . - / and
+## row 4 opens on the two quotation marks.
+const EXPECTED_SYMBOL_ROWS: Array = [
+	# MailEntry_Uppercase row 2: U to Z, a blank, then , ? !
+	[0, 2, [0x94, 0x95, 0x96, 0x97, 0x98, 0x99, 0x7F, 0xF4, 0xE6, 0xE7]],
+	# row 4: PK MN PO KE é ♂ ♀ ¥ … ×
+	[0, 4, [0xE1, 0xE2, 0x70, 0x71, 0xEA, 0xEF, 0xF5, 0xF0, 0x75, 0xF1]],
+	# MailEntry_Lowercase row 2: u to z, a blank, then . - /
+	[1, 2, [0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0x7F, 0xE8, 0xE3, 0xF3]],
+	# row 4: the two quotation marks, [ ] ' : ; and three blanks
+	[1, 4, [0x72, 0x73, 0x9E, 0x9F, 0xE0, 0x9C, 0x9D, 0x7F, 0x7F, 0x7F]],
+]
+
+## `gfx/mail/mail.pal`'s first colour per row, encoded, and the black every row
+## ends on.
+const EXPECTED_PALETTE_FIRST: Array[int] = [
+	0x2FF4, 0x7E8F, 0x7E38, 0x473F, 0x7F53, 0x727F, 0x5E33, 0x7F47, 0x57F5, 0x7F47,
+]
+
+## Per mail type, the VRAM runs its routine fills, counted off its own
+## `LoadMailGFX_Color*` byte counts: eight bytes is one tile, and a routine that
+## reloads `hl` opens a second run. `[first, last]` inclusive.
+const LOADED_RANGES: Array = [
+	[[0x31, 0x45]],              # FLOWER_MAIL: 8 + 4 + 1 + 4 + 4 tiles
+	[[0x31, 0x53]],              # SURF_MAIL: 8 + 6 + 1 + 2 + 2 + 8 + 8
+	[[0x31, 0x53]],              # LITEBLUEMAIL: the same tail, its own head
+	[[0x31, 0x36], [0x3D, 0x41]],# PORTRAITMAIL: 5 + 1, then 4 + 1 at $3d
+	[[0x31, 0x41]],              # LOVELY_MAIL: 5 + 6 + 1 + 4 + 1
+	[[0x31, 0x3B], [0x3D, 0x41]],# EON_MAIL: 5 + 6, then 4 + 1 at $3d
+	[[0x31, 0x40]],              # MORPH_MAIL: 5 generated + 5 + 6
+	[[0x31, 0x55]],              # BLUESKY_MAIL: 1 + 1 + 1 + 23 + 6 + 1 + 1 + 2 + 1
+	[[0x31, 0x41]],              # MUSIC_MAIL: 4 + 2 + 6 + 1 + 3 + 1
+	[[0x31, 0x4A]],              # MIRAGE_MAIL: 5 generated + 1 + 18 + 1 + 1
+]
+
+## A message that fills the first line exactly, so the page has to put the break
+## in the right place for the second line to start where it should. No "PK" or
+## "MN" in it: `Gen2Text.encode` folds either into one code, and a sixteen-letter
+## line that encodes to fifteen bytes would not reach the break at all.
+const SAMPLE_LINE_1: String = "AAAABBBBCCCCDDDD"
+const SAMPLE_LINE_2: String = "QRSTUV"
+const SAMPLE_AUTHOR: String = "GOLD"
+
+var _blocks: Dictionary = {}
+var _palettes: Dictionary = {}
+var _items: Dictionary = {}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		_verify_items()
+		_verify_keyboards()
+		_verify_palettes()
+		_verify_pages()
+	)
+	_verify_identical()
+
+
+## `MailItems` against the number list `ItemIsMail`'s only caller here reads.
+func _verify_items() -> void:
+	var items: Array = _r.data.mail_items()
+	if not _r.check(
+		items.size() == EXPECTED_ITEMS.size(),
+		"MailItems has %d entries, not the pinned %d." % [items.size(), EXPECTED_ITEMS.size()]
+	):
+		return
+	for index: int in items.size():
+		_r.check(
+			int(items[index]) == EXPECTED_ITEMS[index],
+			"MailItems entry %d is %d, not %d." % [index, int(items[index]), EXPECTED_ITEMS[index]]
+		)
+		_r.check(
+			Gen2HeldItem.is_mail(int(items[index])),
+			"item %d is in MailItems and Gen2HeldItem.is_mail refuses it." % int(items[index])
+		)
+	_r.check(
+		not Gen2HeldItem.is_mail(0),
+		"Gen2HeldItem.is_mail answers yes for no item at all."
+	)
+	_items[_r.game_id] = items.duplicate()
+
+
+## The two keyboards' shape, letters, symbol rows and command rows.
+func _verify_keyboards() -> void:
+	var flat: Array = []
+	for table: int in RomLayout.MAIL_INPUT_TABLES:
+		var rows: Array = _r.data.name_input_chars(
+			Gen2NamingScreen.Keyboard.MAIL_UPPER + table
+		)
+		if not _r.check(
+			rows.size() == RomLayout.MAIL_INPUT_TABLE_ROWS,
+			"mail table %d has %d rows, not %d." % [
+				table, rows.size(), RomLayout.MAIL_INPUT_TABLE_ROWS,
+			]
+		):
+			continue
+		for row: Array in rows:
+			_r.check(
+				row.size() == RomLayout.MAIL_INPUT_ROW_BYTES,
+				"mail table %d has a %d-byte row, not %d." % [
+					table, row.size(), RomLayout.MAIL_INPUT_ROW_BYTES,
+				]
+			)
+			flat.append_array(row)
+		# Rows 0 and 1 spell the first twenty letters ten at a time.
+		var first: int = RomLayout.MAIL_INPUT_UPPER_A if table == 0 \
+			else RomLayout.MAIL_INPUT_LOWER_A
+		for row: int in 2:
+			for column: int in RomLayout.MAIL_INPUT_COLUMNS:
+				var expected: int = first + row * RomLayout.MAIL_INPUT_COLUMNS + column
+				var stored: int = _cell(rows, row, column)
+				_r.check(
+					stored == expected,
+					"mail table %d cell (%d,%d) is $%02X, not $%02X." % [
+						table, row, column, stored, expected,
+					]
+				)
+		var command: Array[int] = RomLayout.MAIL_INPUT_COMMAND_UPPER if table == 0 \
+			else RomLayout.MAIL_INPUT_COMMAND_LOWER
+		_r.check(
+			Array(rows[RomLayout.MAIL_INPUT_TABLE_ROWS - 1]) == Array(command),
+			"mail table %d has no command row." % table
+		)
+	for entry: Array in EXPECTED_SYMBOL_ROWS:
+		var rows: Array = _r.data.name_input_chars(
+			Gen2NamingScreen.Keyboard.MAIL_UPPER + int(entry[0])
+		)
+		if rows.size() != RomLayout.MAIL_INPUT_TABLE_ROWS:
+			continue
+		var codes: Array = entry[2]
+		for column: int in codes.size():
+			var stored: int = _cell(rows, int(entry[1]), column)
+			_r.check(
+				stored == int(codes[column]),
+				"mail table %d cell (%d,%d) is $%02X, not $%02X." % [
+					int(entry[0]), int(entry[1]), column, stored, int(codes[column]),
+				]
+			)
+	_r.check(
+		_r.data.name_input_chars(Gen2NamingScreen.Keyboard.size()).is_empty(),
+		"a seventh keyboard was read out of a six-table block."
+	)
+	_blocks[_r.game_id] = flat
+
+
+func _cell(rows: Array, row: int, column: int) -> int:
+	var codes: Array = rows[row]
+	var at: int = column * RomLayout.NAME_INPUT_COLUMN_STRIDE
+	return int(codes[at]) if at < codes.size() else -1
+
+
+## `LoadMailPalettes.MailPals`: four colours a row, the first pinned and the
+## last black.
+func _verify_palettes() -> void:
+	var stored: Array = []
+	for index: int in RomLayout.MAIL_PALETTE_COUNT:
+		var colours: PackedColorArray = _r.data.mail_palette(index)
+		if not _r.check(
+			colours.size() == RomLayout.MAIL_PALETTE_COLOURS,
+			"mail palette %d has %d colours, not %d." % [
+				index, colours.size(), RomLayout.MAIL_PALETTE_COLOURS,
+			]
+		):
+			continue
+		var expected: Color = Gen2Palette.from_packed(EXPECTED_PALETTE_FIRST[index])
+		_r.check(
+			colours[0].is_equal_approx(expected),
+			"mail palette %d opens on %s, not %s." % [index, colours[0], expected]
+		)
+		_r.check(
+			colours[RomLayout.MAIL_PALETTE_COLOURS - 1].is_equal_approx(Color.BLACK),
+			"mail palette %d does not end in black." % index
+		)
+		for colour: Color in colours:
+			stored.append(colour)
+	_palettes[_r.game_id] = stored
+
+
+## Every type's page: the run its routine loads, that nothing is placed outside
+## it, and that the message and the author land where `MailGFX_PlaceMessage`
+## puts them.
+func _verify_pages() -> void:
+	var page: Gen2MailPage = Gen2MailPage.from_data(_r.data)
+	if not _r.check(page != null and page.ready(), "the mail graphics sheet is missing."):
+		return
+	for index: int in EXPECTED_ITEMS.size():
+		var mail: Gen2SaveMail = _sample(EXPECTED_ITEMS[index])
+		var pixels: PackedByteArray = page.draw(mail)
+		_r.check(
+			pixels.size() == Gen2Screen.WIDTH * Gen2Screen.HEIGHT,
+			"mail %d drew %d pixels, not a whole screen." % [index, pixels.size()]
+		)
+		_r.check(
+			Gen2MailPage.index_for_item(EXPECTED_ITEMS[index]) == index,
+			"item %d does not reach mail type %d." % [EXPECTED_ITEMS[index], index]
+		)
+
+		var wanted: Array = []
+		for span: Variant in LOADED_RANGES[index]:
+			for tile: int in range(int((span as Array)[0]), int((span as Array)[1]) + 1):
+				wanted.append(tile)
+		_r.check(
+			page.loaded_tiles() == wanted,
+			"mail %d loaded %s, not the pinned run %s." % [
+				index, _span(page.loaded_tiles()), _span(wanted),
+			]
+		)
+		for tile: int in page.placed_tiles():
+			# Only the mail window is the routine's; below it and from the blank
+			# up is the font, which the message and the author print through.
+			if tile < Gen2MailPage.FIRST_TILE or tile >= Gen2Text.SPACE:
+				continue
+			_r.check(
+				wanted.has(tile),
+				"mail %d places tile $%02X, which its routine never loads." % [index, tile]
+			)
+
+		var at: Vector2i = Gen2MailPage.MESSAGE_AT
+		_r.check(
+			page.map_tile(at) == Gen2Text.encode(SAMPLE_LINE_1)[0],
+			"mail %d does not print the message at %s." % [index, at]
+		)
+		## `<NEXT>` drops two rows at the string's own starting column, so the
+		## second line opens under the first rather than beside it.
+		_r.check(
+			page.map_tile(at + Vector2i(0, 2)) == Gen2Text.encode(SAMPLE_LINE_2)[0],
+			"mail %d does not break its message onto row %d." % [index, at.y + 2]
+		)
+		var author_x: int = Gen2MailPage.AUTHOR_COLUMN
+		if index == Gen2MailPage.PORTRAIT:
+			author_x = Gen2MailPage.AUTHOR_COLUMN_PORTRAIT
+		elif index == Gen2MailPage.MORPH:
+			author_x = Gen2MailPage.AUTHOR_COLUMN_MORPH
+		_r.check(
+			page.map_tile(Vector2i(author_x, Gen2MailPage.AUTHOR_ROW))
+				== Gen2Text.encode(SAMPLE_AUTHOR)[0],
+			"mail %d does not print its author at column %d." % [index, author_x]
+		)
+	_r.note("ten mail types drawn, %d tiles of graphics." % RomLayout.MAIL_GFX_TILES)
+
+
+## One composed message on both lines, which is what `_ComposeMailMessage`
+## leaves behind once the entry has filled the first.
+func _sample(item: int) -> Gen2SaveMail:
+	var entry: PackedByteArray = Gen2SaveMail.blank_message()
+	var first: PackedByteArray = Gen2Text.encode(SAMPLE_LINE_1)
+	for index: int in first.size():
+		entry[index] = first[index]
+	var second: PackedByteArray = Gen2Text.encode(SAMPLE_LINE_2)
+	for index: int in second.size():
+		entry[Gen2SaveMail.LINE_LENGTH + 1 + index] = second[index]
+	return Gen2SaveMail.compose(entry, SAMPLE_AUTHOR, 0x1234, 1, item)
+
+
+## Every cartridge ships the same tables and the same palettes; only the offsets
+## move, so a disagreement is a wrong pin rather than a cartridge difference.
+func _verify_identical() -> void:
+	for table: Dictionary in [_blocks, _palettes, _items]:
+		var ids: Array = table.keys()
+		for index: int in range(1, ids.size()):
+			_r.check(
+				table[ids[index]] == table[ids[0]],
+				"%s and %s disagree about the mail tables." % [ids[0], ids[index]]
+			)
+
+
+func _span(tiles: Array) -> String:
+	if tiles.is_empty():
+		return "nothing"
+	return "$%02X..$%02X (%d)" % [int(tiles[0]), int(tiles[-1]), tiles.size()]

--- a/tools/checks/mail.gd.uid
+++ b/tools/checks/mail.gd.uid
@@ -1,0 +1,1 @@
+uid://tgra53tycojw

--- a/tools/checks/naming.gd
+++ b/tools/checks/naming.gd
@@ -77,9 +77,14 @@ func _verify_shape(game_id: StringName, data: GameData) -> void:
 					game_id, table, row.size(), RomLayout.NAME_INPUT_ROW_BYTES,
 				]
 			)
+	## The two mail keyboards follow in the same cache file and are 19 bytes a
+	## row rather than 17, so a name block read one table too long shows up as a
+	## fifth table of the wrong width. `tools/checks/mail.gd` owns the pair.
+	var mail: Array = data.name_input_chars(EXPECTED_ROWS.size())
 	_r.check(
-		data.name_input_chars(EXPECTED_ROWS.size()).is_empty(),
-		"%s: a fifth keyboard was read out of a four-table block." % game_id
+		mail.size() == RomLayout.MAIL_INPUT_TABLE_ROWS
+			and (mail[0] as Array).size() == RomLayout.MAIL_INPUT_ROW_BYTES,
+		"%s: the table after the four keyboards is not a mail keyboard." % game_id
 	)
 
 

--- a/tools/preview_mail.gd
+++ b/tools/preview_mail.gd
@@ -1,0 +1,85 @@
+extends SceneTree
+
+## Captures `ReadAnyMail` against a real imported cache. The ten mail types are
+## the one screen in this project drawn through four cartridge colours rather
+## than a white-to-black pair, and every one of them is a different VRAM window
+## over the same 1bpp run, so the picture is what says a transcription is right.
+##
+##   Godot --headless --path . -s res://tools/preview_mail.gd -- crystal /tmp/mail.png [type]
+##
+## [type] is a `MailGFXPointers` index, 0 to 9, or `all` for a contact sheet of
+## every one. PORTRAITMAIL draws a Pokemon, which is `wCurPartySpecies` at the
+## moment the message was written.
+##
+## The page is composed into an [Image] rather than through a window, so this
+## runs headless and needs no settling frames.
+
+const COLUMNS: int = 5
+const SAMPLE_SPECIES: int = 1
+
+## Two lines that fill the first exactly, so the break is where the picture
+## shows it rather than where a short message would leave it.
+const SAMPLE_LINE_1: String = "HAVE A GOOD DAY!"
+const SAMPLE_LINE_2: String = "SEE YOU SOON"
+const SAMPLE_AUTHOR: String = "GOLD"
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_mail.gd -- <game> <output.png> [type|all]")
+		quit(1)
+		return
+
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+	var page: Gen2MailPage = Gen2MailPage.from_data(data)
+	if page == null or not page.ready():
+		push_error("The %s cache carries no mail graphics." % args[0])
+		quit(1)
+		return
+
+	var wanted: String = args[2] if args.size() > 2 else "all"
+	var types: Array = range(RomLayout.MAIL_PALETTE_COUNT) if wanted == "all" \
+		else [clampi(int(wanted), 0, RomLayout.MAIL_PALETTE_COUNT - 1)]
+	var columns: int = mini(COLUMNS, types.size())
+	@warning_ignore("integer_division")
+	var rows: int = (types.size() + columns - 1) / columns
+	var sheet: Image = Image.create_empty(
+		columns * Gen2Screen.WIDTH, rows * Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	for index: int in types.size():
+		var type: int = int(types[index])
+		var indices: PackedByteArray = page.draw(_sample(type))
+		var tile: Image = Gen2PicImage.from_indices(
+			indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, data.mail_palette(type)
+		)
+		@warning_ignore("integer_division")
+		sheet.blit_rect(tile, Rect2i(Vector2i.ZERO, tile.get_size()), Vector2i(
+			(index % columns) * Gen2Screen.WIDTH, (index / columns) * Gen2Screen.HEIGHT
+		))
+	if sheet.save_png(args[1]) != OK:
+		push_error("Could not write %s" % args[1])
+		quit(1)
+		return
+	print("Wrote %s (%dx%d), %d mail types." % [
+		args[1], sheet.get_width(), sheet.get_height(), types.size(),
+	])
+	quit(0)
+
+
+## `ComposeMailMessage`'s own result for [param index]'s item.
+func _sample(index: int) -> Gen2SaveMail:
+	var entry: PackedByteArray = Gen2SaveMail.blank_message()
+	var first: PackedByteArray = Gen2Text.encode(SAMPLE_LINE_1)
+	for at: int in first.size():
+		entry[at] = first[at]
+	var second: PackedByteArray = Gen2Text.encode(SAMPLE_LINE_2)
+	for at: int in second.size():
+		entry[Gen2SaveMail.LINE_LENGTH + 1 + at] = second[at]
+	return Gen2SaveMail.compose(
+		entry, SAMPLE_AUTHOR, 0x1234, SAMPLE_SPECIES, Gen2MailPage.ITEM_NUMBERS[index]
+	)

--- a/tools/preview_mail.gd.uid
+++ b/tools/preview_mail.gd.uid
@@ -1,0 +1,1 @@
+uid://dl68ipvjdgwwd

--- a/tools/preview_naming_screen.gd
+++ b/tools/preview_naming_screen.gd
@@ -6,6 +6,9 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_naming_screen.gd -- crystal /tmp/name.png [presses]
 ##
+## A `mail` argument after the presses opens `_ComposeMailMessage` instead: the
+## same screen class over its own six-row keyboard and two-line entry.
+##
 ## [presses] is a button script driving the screen before the capture: `r`, `l`,
 ## `u`, `d` for the d-pad, `a`, `b`, `s` for START and `c` for SELECT. So
 ## `aaardc` types three letters, steps right and down and flips the case.
@@ -45,8 +48,12 @@ func _initialize() -> void:
 
 	root.set_content_scale_size(WINDOW_SIZE)
 	root.size = WINDOW_SIZE
+	var mail: bool = args.has("mail")
 	_screen = Gen2NamingScreenScreen.new()
-	if not _screen.open(data, "YOUR NAME?"):
+	if not _screen.open(
+		data, "" if mail else "YOUR NAME?",
+		Gen2NamingScreenScreen.KIND_MAIL if mail else Gen2NamingScreenScreen.KIND_PLAYER
+	):
 		push_error("The %s cache carries no naming screen data." % args[0])
 		quit(1)
 		return
@@ -54,7 +61,7 @@ func _initialize() -> void:
 	root.add_child(_screen)
 	current_scene = _screen
 
-	var presses: String = args[2] if args.size() > 2 else ""
+	var presses: String = args[2] if args.size() > 2 and args[2] != "mail" else ""
 	for key: String in presses:
 		if BUTTONS.has(key):
 			_screen.handle_button(int(BUTTONS[key]))

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -43,7 +43,7 @@ const GROUPS: Dictionary = {
 		&"tmhm", &"naming", &"world_scripts", &"opening_lane", &"pokecenter_pc",
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
-		&"card_flip", &"move_effects", &"phone", &"decorations",
+		&"card_flip", &"move_effects", &"phone", &"decorations", &"mail",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
Mail was the first row of the last rung of open work. It is built.

## What is imported

Five addresses per cartridge, each located by content and each hitting once:

| Pin | What it is |
|---|---|
| `mail.items` | `MailItems`' own eleven bytes |
| `mail.input_chars` | `MailEntry_Uppercase` and `MailEntry_Lowercase`, assembled whole |
| `mail.gfx` | `gfx/mail.asm`'s 1,360-byte 1bpp run |
| `mail.palettes` | `gfx/mail/mail.pal`, ten palettes |
| `mail.icon` | `gfx/naming_screen/mail.2bpp` |

`RomImporter.verify_mail` checks each against something only the right offset
carries. `tools/checks/mail.gd` sweeps all ten mail types on all three
cartridges: the tile run each routine loads, that nothing is placed outside it,
and where the message and the author land. Its expectations are counted off the
asm rather than read from the code it checks, so a mistranscribed byte count is
a failure and not an agreement.

## What is built

- Giving a mail item opens `_ComposeMailMessage`. It is a third mode of the
  naming screen rather than a screen of its own: six rows of ten against a name
  keyboard's five of nine, a two-line entry, and a `<NEXT>` fixed in the middle
  that the cursor steps over in both directions.
- The message travels on the Pokemon's record. The party submenu offers MAIL
  where ITEM would be, the party icon takes `HeldItemIcons`' mail tile, and a
  member already holding mail is refused rather than asked to swap.
- MAIL's own READ, TAKE and QUIT. TAKE asks about the PC first and the bag
  second, which is two questions in a row the way the source asks them.
- `ReadAnyMail` draws all ten designs. Each is two transcribed programs: the
  routine's tile loads and its tilemap writes. One 1bpp run draws in three
  shades because the three load routines write plane 0, plane 1 or both.
  PORTRAITMAIL's front pic is in the page's own buffer, mirrored.
- The PC's MAIL BOX row is `_PlayerMailBoxMenu` over a ten-message mailbox,
  with READ MAIL, PUT IN PACK and ATTACH MAIL behind it.

No save-format bump. The mailbox and a member's message default the way the box
names and the Hall of Fame do, so a slot written before this reads as a party
holding no mail.

## One bug found on the way

`Gen2WorldTransaction.copy_into` and `Gen2SaveData.copy_from` were dropping
`current_box`, `hall_of_fame` and `box_names`. The candidate written to disk
carried them, so the loss was invisible until a slot was reopened: every world
transaction reset the live save's current box to 0 and emptied its Hall of Fame
for the rest of the session. Both now copy every field, with a test.

## Proof

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3718/3718, up from 3702 |
| `tools/validate.gd -- all` | 71 topics pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failures |
| Boot smoke, with and without mods | clean |
| Three cartridges re-imported | `layout: Layout verified.` on each |

Cache format 86.