### PR TITLE
The Battle Tower, a readable GDScript analyser, and an output-path guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,13 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > Silver: every Johto badge with the errand behind it, then Kanto, all sixteen
 > badges, the Hall of Fame with Prof Oak's rating, and the credits.
 >
-> Missing: link play and Mystery Gift, the Battle Tower, and a
-> handful of pixel-level divergences still being chased in the opening movies
-> and title screen against a real cartridge.
+> The Battle Tower is a full seven-trainer challenge: the room list, the party
+> rules, the sampled opponents with their own lines, the save between battles and
+> the prize at the end.
+>
+> Missing: link play and Mystery Gift, and a handful of pixel-level divergences
+> still being chased in the opening movies and title screen against a real
+> cartridge.
 
 ## Getting started
 

--- a/addons/warning_scan/plugin.cfg
+++ b/addons/warning_scan/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Warning Scan"
+description="Reads the GDScript analyser's warnings without a person at the editor."
+author="pokerecomp"
+version="1.0"
+script="plugin.gd"

--- a/addons/warning_scan/plugin.gd
+++ b/addons/warning_scan/plugin.gd
@@ -1,0 +1,74 @@
+@tool
+extends EditorPlugin
+
+## Reads the GDScript analyser without a person driving editor menus.
+##
+##   Godot --headless --editor --path . -- --warning-scan [path ...]
+##
+## Prints one line per warning as `file:line CODE message`, a tally per code and
+## how many scripts it analysed, then quits: 0 when there were none, 1 when there
+## were. The paths may be files or directories, `res://` or `user://`, and
+## default to [constant DEFAULT_PATHS].
+##
+## Silence is an answer only because the paths are explicit and the count of
+## analysed scripts is printed beside the warnings. That is the difference
+## between "nothing is wrong" and "nothing was read", which is what made the
+## editor's panel unusable as a check.
+##
+## It reports the first warning in each script and no more; see
+## [Gen2EditorWarnings] for why, and re-run after a fix to see the next.
+##
+## Without the flag the plugin does nothing at all, so an ordinary editor session
+## is untouched by it.
+##
+## It costs what opening every script in the editor costs: this project's 566
+## take a few minutes and about three gigabytes, because `edit_script` adds a tab
+## per script and the editor exposes no way to close one. Name a directory rather
+## than sweeping everything when only part of the tree moved.
+
+const FLAG: String = "--warning-scan"
+## The project's own script trees. `mods` is the shipped examples; a player's
+## installed mods live under `user://mods` and are named on the command line.
+const DEFAULT_PATHS: Array[String] = [
+	"res://game", "res://tools", "res://tests", "res://autoload", "res://mods",
+	"res://addons/warning_scan",
+]
+## Frames spent letting the editor finish opening before the scan starts. The
+## filesystem scan is awaited properly below; these are for the docks.
+const SETTLE_FRAMES: int = 4
+
+
+func _enter_tree() -> void:
+	if not OS.get_cmdline_user_args().has(FLAG):
+		return
+	_scan.call_deferred()
+
+
+func _scan() -> void:
+	for _pass: int in SETTLE_FRAMES:
+		await get_tree().process_frame
+	var filesystem: EditorFileSystem = EditorInterface.get_resource_filesystem()
+	while filesystem.is_scanning():
+		await get_tree().process_frame
+
+	var analysed := PackedStringArray()
+	var rows: Array[Dictionary] = await Gen2EditorWarnings.analyse(
+		_requested_paths(), get_tree(), analysed
+	)
+	for row: Dictionary in rows:
+		print("%s:%d %s %s" % [row["file"], row["line"], row["code"], row["message"]])
+	var codes: Dictionary = Gen2EditorWarnings.tally(rows)
+	for code: Variant in codes:
+		print("  %s %d" % [code, int(codes[code])])
+	print("%d warnings in %d analysed scripts" % [rows.size(), analysed.size()])
+	get_tree().quit(1 if not rows.is_empty() else 0)
+
+
+func _requested_paths() -> PackedStringArray:
+	var out := PackedStringArray()
+	for argument: String in OS.get_cmdline_user_args():
+		if argument != FLAG and not argument.begins_with("--"):
+			out.append(argument)
+	if out.is_empty():
+		out.append_array(DEFAULT_PATHS)
+	return out

--- a/addons/warning_scan/plugin.gd.uid
+++ b/addons/warning_scan/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://daw86hha3oeub

--- a/addons/warning_scan/warnings.gd
+++ b/addons/warning_scan/warnings.gd
@@ -1,0 +1,148 @@
+@tool
+class_name Gen2EditorWarnings
+extends RefCounted
+
+## The GDScript analyser's warnings for a named script, read without a person
+## driving editor menus.
+##
+## The analyser runs inside the editor and reports nowhere else: no CLI mode
+## prints its warnings, `--check-only` suppresses them, and a running game prints
+## none. Opening a script in the editor's own script editor analyses it on the
+## spot, and the panel beside it is the answer. That is the only way to ask about
+## a named file and get an answer about that file, which is what makes silence
+## mean "clean" rather than "never read".
+##
+## It reports [b]the first warning in each script and no more[/b]. The panel
+## holds one entry however many the script has, which is the engine's behaviour
+## and not a limit here; a fix loop still converges, because the next warning
+## appears once the first is gone.
+##
+## `tools/dump_editor_errors.gd` is the other half and is not this: it writes out
+## the Debugger panel's whole list for a session, engine errors included, which
+## is how a running game's `user://` scripts have always been seen.
+
+## `ScriptTextEditor._update_warnings`' own row: an `[Ignore]` link, then
+## `Line N (CODE):` and the message.
+const PANEL_LINE: String = "Line "
+## Frames spent per script before its panel is read. The editor validates on
+## idle, so the panel is a frame or two behind `edit_script`.
+const PANEL_SETTLE_FRAMES: int = 4
+
+
+## Opens each of [param paths] in the script editor and answers what the panel
+## says about it, as `{ file, line, code, message }`.
+##
+## A directory is walked for the `.gd` files under it. `user://` is reached the
+## same way `res://` is, which matters because a mod's scripts live there and are
+## the ones no editor scan ever sees.
+##
+## [param analysed] is filled with the files actually opened, so a caller can say
+## what its silence covers: a script the analyser never read is silent for the
+## same reason a clean one is, and that is what made the panel unusable as a
+## check.
+static func analyse(
+	paths: PackedStringArray, tree: SceneTree, analysed: PackedStringArray
+) -> Array[Dictionary]:
+	var rows: Array[Dictionary] = []
+	var seen: Dictionary = {}
+	for path: String in paths:
+		for script_path: String in scripts_under(path):
+			if seen.has(script_path):
+				continue
+			seen[script_path] = true
+			analysed.append(script_path)
+			var row: Dictionary = await _analyse_one(script_path, tree)
+			if not row.is_empty():
+				rows.append(row)
+	return rows
+
+
+static func _analyse_one(path: String, tree: SceneTree) -> Dictionary:
+	## Plain `load`, not `CACHE_MODE_IGNORE`: the analysis comes from opening the
+	## script in the editor, and re-parsing under the cache reloads this very
+	## file when the sweep reaches it, which corrupts the running frame.
+	var script: Resource = load(path)
+	if not script is Script:
+		return {}
+	EditorInterface.edit_script(script as Script)
+	for _pass: int in PANEL_SETTLE_FRAMES:
+		await tree.process_frame
+	## The panel has to be the open tab's own. `edit_script` adds a tab and every
+	## tab keeps its own warnings panel, so searching the whole editor finds the
+	## first script that had any and reports its warning against every clean
+	## script opened after it.
+	var editor: ScriptEditorBase = EditorInterface.get_script_editor().get_current_editor()
+	if editor == null:
+		return {}
+	var text: String = _panel_text(editor)
+	if text.is_empty():
+		return {}
+	var row: Dictionary = _parse_panel(text)
+	if row.is_empty():
+		return {}
+	row["file"] = path
+	return row
+
+
+## `Line 6 (UNUSED_VARIABLE):The local variable "lid" is ...`, which is what the
+## panel writes once the `[Ignore]` link in front of it is stripped.
+static func _parse_panel(text: String) -> Dictionary:
+	var at: int = text.find(PANEL_LINE)
+	var open: int = text.find(" (", at)
+	var close: int = text.find("):", open)
+	if at < 0 or open < 0 or close < 0:
+		return {}
+	return {
+		"line": int(text.substr(at + PANEL_LINE.length(), open - at - PANEL_LINE.length())),
+		"code": text.substr(open + 2, close - open - 2),
+		"message": text.substr(close + 2).strip_edges(),
+	}
+
+
+## The open tab's warnings panel, which is the one [RichTextLabel] under it whose
+## text is a `Line N (CODE):` row.
+static func _panel_text(node: Node) -> String:
+	if node is RichTextLabel:
+		var text: String = (node as RichTextLabel).get_parsed_text()
+		if text.contains(PANEL_LINE) and text.contains("):"):
+			return text
+	for child: Node in node.get_children(true):
+		var found: String = _panel_text(child)
+		if not found.is_empty():
+			return found
+	return ""
+
+
+## Every `.gd` file at or under [param path], which may be a file or a
+## directory, `res://` or `user://`.
+static func scripts_under(path: String) -> PackedStringArray:
+	var out := PackedStringArray()
+	if path.get_extension() == "gd":
+		if FileAccess.file_exists(path):
+			out.append(path)
+		return out
+	var directory: DirAccess = DirAccess.open(path)
+	if directory == null:
+		return out
+	directory.list_dir_begin()
+	var entry: String = directory.get_next()
+	while entry != "":
+		var child: String = path.path_join(entry)
+		if directory.current_is_dir():
+			if not entry.begins_with("."):
+				out.append_array(scripts_under(child))
+		elif entry.get_extension() == "gd":
+			out.append(child)
+		entry = directory.get_next()
+	directory.list_dir_end()
+	out.sort()
+	return out
+
+
+## How many of each warning code, which is the number a session is green on.
+static func tally(rows: Array[Dictionary]) -> Dictionary:
+	var codes: Dictionary = {}
+	for row: Dictionary in rows:
+		var code: String = String(row.get("code", ""))
+		codes[code] = int(codes.get(code, 0)) + 1
+	return codes

--- a/addons/warning_scan/warnings.gd.uid
+++ b/addons/warning_scan/warnings.gd.uid
@@ -1,0 +1,1 @@
+uid://c1ml5smncsqgj

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -123,10 +123,35 @@ it cannot hold sixty anywhere.
 
 The GDScript analyzer runs only inside the editor: no CLI mode prints its
 warnings, `--check-only` suppresses them, and file logging records the running
-game rather than the editor. Read them with `tools/dump_editor_errors.gd` from
-Editor > File > Run, which writes `user://editor_errors.txt` and tallies the
-warning codes; the panel holds what the session has analysed, so reload the
-project first for a full sweep. The tree stays at zero entries.
+game rather than the editor. There are two ways to read it and they answer
+different questions. The tree stays at zero entries either way.
+
+```bash
+Godot --headless --editor --path . -- --warning-scan [path ...]
+```
+
+`addons/warning_scan` opens each named script in the editor's own script editor
+and prints what the analyser says, as `file:line CODE message`, then a tally and
+how many scripts it analysed; it exits 1 when there were any. Paths may be files
+or directories, `res://` or `user://`, and default to the project's script trees.
+Because the paths are explicit and the count is printed, silence means clean
+rather than unread, which is what the panel alone could never say. It reports the
+first warning per script: fix it, run again, and the next one appears. Without
+the flag the plugin does nothing, so an ordinary editor session is untouched.
+
+`tools/dump_editor_errors.gd` is the other half, run from Editor > File > Run:
+it writes the Debugger panel's whole list to `user://editor_errors.txt`, engine
+errors included, and is where a running game's warnings arrive, which is how a
+mod's `user://` scripts are seen. The panel holds what the session has analysed,
+so reload the project first for a full sweep.
+
+A tool that takes an output path guards it with `Gen2ToolPath.refuses()` before
+doing any work. A tool runs with `--path <this project>`, so a relative path
+resolves against the checkout rather than the directory the command was run in: a
+bare `out.png` is written into the project and the editor makes an `.import` file
+beside it. The test is where the path resolves, not how it is spelt, since
+`res://out.png` is absolute to `is_absolute_path()` and lands in the project all
+the same. `user://` is allowed.
 
 `integer_division` is the one warning turned off in `project.godot`: this is
 8-bit hardware arithmetic throughout, where `a / b` on two integers is the

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -168,6 +168,12 @@ Mail is on the record rather than in a slot of its own: `Gen2SaveMon.mail` is
 behind `sMailboxCount`. Both default rather than versioning, so a slot written
 before mail existed reads as a party holding none and an empty mailbox.
 
+`SECTION "SRAM Battle Tower"` rides in the world snapshot rather than in the
+save proper, which is where the cartridge keeps it too: a challenge can be saved
+and left between battles, so `Gen2WorldState.battle_tower()` carries the state,
+the streak of trainers already met, the chosen room, the save-file flags and the
+prize drawn for the run. It defaults rather than versioning the way mail does.
+
 Original SRAM also contains player, map, checksum, PC box, Hall of Fame and
 Crystal-specific regions. The first model imports only party data; the optional
 project world snapshot is a separate canonical runtime shape and does not claim

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -258,7 +258,6 @@ func _pic_layer(
 	vbank1: PackedByteArray = PackedByteArray(), animated: bool = false
 ) -> PackedByteArray:
 	var out: PackedByteArray = _new_buffer()
-	var box: int = side * TILE
 	var strip: int = pic_stride(pixels, side)
 	if strip <= 0:
 		return out

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -126,6 +126,7 @@ var _world_spawns: Dictionary = {}
 var _world_audio: Dictionary = {}
 var _battle_anims_section: Dictionary = {}
 var _pic_anims_section: Dictionary = {}
+var _battle_tower_section: Dictionary = {}
 ## Which of the sections above have been read. A section that is genuinely empty
 ## is indistinguishable from one that has not been read yet, so the answer is
 ## recorded rather than inferred from the value.
@@ -2719,6 +2720,33 @@ func pic_animation(number: int, unown_form: int = 0) -> Dictionary:
 	}
 
 
+## The whole Battle Tower block, empty on a cartridge that has no tower:
+## { trainers, mons, class_genders, class_sprites, texts, level_rows, menu_rows,
+## menu_text }. See [Gen2BattleTower], which is the only reader.
+func battle_tower() -> Dictionary:
+	if _claim_section("battle_tower"):
+		_battle_tower_section = _read_section(RomCache.battle_tower_path(directory), false)
+	return _battle_tower_section
+
+
+## Whether this cartridge ships a Battle Tower at all. Gold and Silver do not.
+func has_battle_tower() -> bool:
+	return not battle_tower().is_empty()
+
+
+## One `BattleTowerMons` row as the party-mon struct plus nickname it is:
+## [param group] is `wBTChoiceOfLvlGroup - 1` and [param index] the row inside
+## it. Empty when either is outside the table.
+func battle_tower_mon(group: int, index: int) -> PackedByteArray:
+	var groups: Variant = battle_tower().get("mons", [])
+	if not groups is Array or group < 0 or group >= (groups as Array).size():
+		return PackedByteArray()
+	var rows: Variant = (groups as Array)[group]
+	if not rows is Array or index < 0 or index >= (rows as Array).size():
+		return PackedByteArray()
+	return _payload_bytes((rows as Array)[index], _blob("battle_tower"))
+
+
 func _pic_anims() -> Dictionary:
 	if _claim_section("pic_anims"):
 		_pic_anims_section = _read_section(RomCache.pic_anims_path(directory), false)
@@ -2790,6 +2818,8 @@ func _section_json_path(section: String) -> String:
 			return RomCache.battle_anims_path(directory)
 		"pic_anims":
 			return RomCache.pic_anims_path(directory)
+		"battle_tower":
+			return RomCache.battle_tower_path(directory)
 		"overworld_effects":
 			return RomCache.overworld_effects_path(directory)
 	return ""

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -165,8 +165,8 @@ static func open_directory(path: String) -> GameData:
 	data._card_palettes = manifest.get("card_palettes", {})
 	var mail_palettes: Variant = manifest.get("mail_palettes", [])
 	data._mail_palettes = mail_palettes if mail_palettes is Array else []
-	var mail_items: Variant = manifest.get("mail_items", [])
-	data._mail_items = mail_items if mail_items is Array else []
+	var raw_mail_items: Variant = manifest.get("mail_items", [])
+	data._mail_items = raw_mail_items if raw_mail_items is Array else []
 	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
 	data._pack = manifest.get("pack", {})
 	var raw_pc_palette: Variant = manifest.get("pc_palette", [])

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -65,6 +65,7 @@ const WORLD_FRUIT_TREES: String = "world_fruit_trees.json"
 const WORLD_SPAWNS: String = "world_spawns.json"
 const BATTLE_ANIMS: String = "battle_anims.json"
 const PIC_ANIMS: String = "pic_anims.json"
+const BATTLE_TOWER: String = "battle_tower.json"
 const BATTLE_ANIM_GFX_DIR: String = "battle_anim_gfx"
 
 ## The key a payload span is stored under, and how many numbers it holds. A
@@ -81,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 86
+const FORMAT_VERSION: int = 87
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a
@@ -264,6 +265,13 @@ static func battle_anims_path(directory: String) -> String:
 ## JSON for the reason every other tile strip is: it is pixels, not records.
 static func battle_anim_gfx_path(directory: String, number: int) -> String:
 	return "%s/%s/%02d.idx" % [directory, BATTLE_ANIM_GFX_DIR, number]
+
+
+## The Battle Tower's trainers, its ten level groups of party-mon structs, the
+## two per-class tables and every string its menus print. Absent for Gold and
+## Silver, which ship no tower at all.
+static func battle_tower_path(directory: String) -> String:
+	return "%s/%s" % [directory, BATTLE_TOWER]
 
 
 ## `AnimateFrontpic`'s scripts, bitmasks and frames, one record per species and

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -298,6 +298,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not mail["ok"]:
 		return mail
 
+	var battle_tower: Dictionary = verify_battle_tower(rom, layout)
+	if not battle_tower["ok"]:
+		return battle_tower
+
 	var intro_text: Dictionary = verify_intro_text(rom, layout)
 	if not intro_text["ok"]:
 		return intro_text
@@ -2481,6 +2485,226 @@ static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"ok": true, "message": "Mail tables, graphics and palettes verified."}
 
 
+## `BattleTowerTrainers`' two ends, which is what says the run is the run.
+## `data/battle_tower/classes.asm` opens on HANSON and closes on WONG.
+const BATTLETOWER_PINNED_NAMES: Dictionary = {0: "HANSON", 69: "WONG"}
+## `MON_LEVEL`'s own offset inside a party-mon struct.
+const BATTLETOWER_MON_LEVEL: int = 31
+## `Strings_L10ToL100`'s eleventh row and `MenuData_ChallengeExplanationCancel`'s
+## three, decoded.
+const BATTLETOWER_LEVEL_CANCEL: String = "CANCEL"
+const BATTLETOWER_CHALLENGE_MENU_ROWS: Array = ["Challenge", "Explanation", "Cancel"]
+
+
+## `MenuData_ChallengeExplanationCancel`'s three rows.
+static func read_challenge_menu_rows(rom: RomFile, layout: Dictionary) -> PackedStringArray:
+	if not RomLayout.has_battle_tower(layout):
+		return PackedStringArray()
+	var at: int = int(RomLayout.battle_tower(layout)["challenge_menu"]) + 2
+	return Gen2Text.decode_sequence(
+		rom.slice(at, RomLayout.OAK_TEXT_MAX_BYTES), 0,
+		RomLayout.BATTLETOWER_CHALLENGE_MENU_ROWS, RomLayout.OAK_TEXT_MAX_BYTES
+	)
+
+
+## The whole Battle Tower block: the 70 trainers, the ten level groups of 21
+## Pokemon as the party-mon structs they are, the two per-class tables, the 120
+## trainer lines, the level menu's own rows and the challenge menu's three.
+##
+## Empty on Gold and Silver, which is what [GameData] answers "no tower" from.
+func _import_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if not RomLayout.has_battle_tower(layout):
+		return {}
+	var entry: Dictionary = RomLayout.battle_tower(layout)
+	var trainers: Array = []
+	for index: int in RomLayout.BATTLETOWER_NUM_UNIQUE_TRAINERS:
+		var row: int = int(entry["trainers"]) + index * RomLayout.BATTLETOWER_TRAINER_ROW_BYTES
+		trainers.append({
+			"name": Gen2Text.decode_fixed(
+				rom.slice(row, RomLayout.BATTLETOWER_TRAINER_NAME_BYTES), 0,
+				RomLayout.BATTLETOWER_TRAINER_NAME_BYTES
+			),
+			"class": rom.u8(row + RomLayout.BATTLETOWER_TRAINER_NAME_BYTES),
+		})
+	var groups: Array = []
+	for group: int in RomLayout.BATTLETOWER_LEVEL_GROUPS:
+		var rows: Array = []
+		for index: int in RomLayout.BATTLETOWER_NUM_UNIQUE_MON:
+			rows.append({RomCache.BYTES_KEY: Array(rom.slice(
+				RomLayout.battle_tower_mon_offset(layout, group, index),
+				RomLayout.BATTLETOWER_MON_BYTES
+			))})
+		groups.append(rows)
+	var texts: Dictionary = {}
+	for kind: int in RomLayout.BATTLETOWER_TEXT_KINDS.size():
+		var male: Array = []
+		var female: Array = []
+		for trainer: int in RomLayout.BATTLETOWER_MALE_TEXTS:
+			male.append(read_oak_text(
+				rom, layout, RomLayout.battle_tower_text_offset(layout, false, trainer, kind)
+			))
+		for trainer: int in RomLayout.BATTLETOWER_FEMALE_TEXTS:
+			female.append(read_oak_text(
+				rom, layout, RomLayout.battle_tower_text_offset(layout, true, trainer, kind)
+			))
+		texts[RomLayout.BATTLETOWER_TEXT_KINDS[kind]] = {"male": male, "female": female}
+	var levels: Array = []
+	for index: int in RomLayout.BATTLETOWER_LEVEL_ROWS:
+		levels.append(Gen2Text.decode_fixed(
+			rom.slice(
+				int(entry["level_strings"]) + index * RomLayout.BATTLETOWER_LEVEL_ROW_BYTES,
+				RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
+			), 0, RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
+		).strip_edges())
+	var menu_text: Dictionary = {}
+	for name: String in RomLayout.BATTLETOWER_MENU_TEXT_ORDER:
+		var at: int = int((entry["text"] as Dictionary)[name])
+		var decoded: Dictionary = Gen2WorldScript.decode_text(
+			rom.slice(at, RomLayout.OAK_TEXT_MAX_BYTES)
+		)
+		menu_text[name] = String(decoded["text"]) if bool(decoded.get("ok", false)) else ""
+	var genders: Array = []
+	var sprites: Array = []
+	for index: int in RomLayout.trainer_class_count(layout) - 1:
+		genders.append(rom.u8(int(entry["class_genders"]) + index))
+		sprites.append(rom.u8(int(entry["class_sprites"]) + index))
+	return {
+		"trainers": trainers,
+		"mons": groups,
+		"class_genders": genders,
+		"class_sprites": sprites,
+		"texts": texts,
+		"level_rows": levels,
+		"menu_rows": Array(read_challenge_menu_rows(rom, layout)),
+		"menu_text": menu_text,
+	}
+
+
+## The Battle Tower's seven pins, each against something only the right offset
+## carries: the first and last of `BattleTowerTrainers`' 70 names with every
+## class byte in range, `BattleTowerMons`' first row and every row's level
+## agreeing with the level group it sits in, the two per-class tables' own
+## widths and values, all 120 `text_far` stubs, `Strings_L10ToL100`'s CANCEL row
+## and `MenuData_ChallengeExplanationCancel`'s three rows.
+##
+## A cartridge with no tower answers ok: Gold and Silver ship no map, routine or
+## table for it, so an absent block is the truth about them.
+static func verify_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if not RomLayout.has_battle_tower(layout):
+		return {"ok": true, "message": "The cartridge has no Battle Tower."}
+	var entry: Dictionary = RomLayout.battle_tower(layout)
+	var classes: int = RomLayout.trainer_class_count(layout)
+
+	var trainers: int = int(entry["trainers"])
+	var trainer_bytes: int = RomLayout.BATTLETOWER_NUM_UNIQUE_TRAINERS \
+		* RomLayout.BATTLETOWER_TRAINER_ROW_BYTES
+	if not rom.in_bounds(trainers, trainer_bytes):
+		return {"ok": false, "message": "BattleTowerTrainers is outside the cartridge."}
+	for index: int in RomLayout.BATTLETOWER_NUM_UNIQUE_TRAINERS:
+		var row: int = trainers + index * RomLayout.BATTLETOWER_TRAINER_ROW_BYTES
+		var trainer_class: int = rom.u8(row + RomLayout.BATTLETOWER_TRAINER_NAME_BYTES)
+		if trainer_class < 1 or trainer_class > classes:
+			return {
+				"ok": false,
+				"message": "BattleTowerTrainers row %d has class %d, outside 1..%d." % [
+					index, trainer_class, classes,
+				],
+			}
+	for index: int in BATTLETOWER_PINNED_NAMES:
+		var name: String = Gen2Text.decode_fixed(
+			rom.slice(
+				trainers + int(index) * RomLayout.BATTLETOWER_TRAINER_ROW_BYTES,
+				RomLayout.BATTLETOWER_TRAINER_NAME_BYTES
+			), 0, RomLayout.BATTLETOWER_TRAINER_NAME_BYTES
+		)
+		if name != String(BATTLETOWER_PINNED_NAMES[index]):
+			return {
+				"ok": false,
+				"message": "BattleTowerTrainers row %d is \"%s\", expected \"%s\"." % [
+					index, name, BATTLETOWER_PINNED_NAMES[index],
+				],
+			}
+
+	var mon_bytes: int = RomLayout.BATTLETOWER_LEVEL_GROUPS \
+		* RomLayout.BATTLETOWER_NUM_UNIQUE_MON * RomLayout.BATTLETOWER_MON_BYTES
+	if not rom.in_bounds(int(entry["mons"]), mon_bytes):
+		return {"ok": false, "message": "BattleTowerMons runs past the cartridge."}
+	for group: int in RomLayout.BATTLETOWER_LEVEL_GROUPS:
+		# `LoadRandomBattleTowerMon` indexes the group by `wBTChoiceOfLvlGroup`
+		# alone, so a group whose rows are not all its own level is the offset
+		# being wrong rather than the data being odd.
+		var level: int = (group + 1) * 10
+		for index: int in RomLayout.BATTLETOWER_NUM_UNIQUE_MON:
+			var at: int = RomLayout.battle_tower_mon_offset(layout, group, index)
+			var species: int = rom.u8(at)
+			if species < 1 or species > RomLayout.SPECIES_COUNT:
+				return {
+					"ok": false,
+					"message": "BattleTowerMons %d/%d is species %d." % [group, index, species],
+				}
+			if rom.u8(at + BATTLETOWER_MON_LEVEL) != level:
+				return {
+					"ok": false,
+					"message": "BattleTowerMons %d/%d is level %d, expected %d." % [
+						group, index, rom.u8(at + BATTLETOWER_MON_LEVEL), level,
+					],
+				}
+
+	for key: String in ["class_genders", "class_sprites"]:
+		if not rom.in_bounds(int(entry[key]), classes - 1):
+			return {"ok": false, "message": "The Battle Tower %s table is outside the cartridge." % key}
+	for index: int in classes - 1:
+		if rom.u8(int(entry["class_genders"]) + index) > 1:
+			return {
+				"ok": false,
+				"message": "BTTrainerClassGenders entry %d is not MALE or FEMALE." % index,
+			}
+		if rom.u8(int(entry["class_sprites"]) + index) == 0:
+			return {"ok": false, "message": "BTTrainerClassSprites entry %d is zero." % index}
+
+	var stubs: int = (RomLayout.BATTLETOWER_MALE_TEXTS + RomLayout.BATTLETOWER_FEMALE_TEXTS) \
+		* RomLayout.BATTLETOWER_TEXT_KINDS.size()
+	if not rom.in_bounds(int(entry["trainer_text"]), stubs * RomLayout.TEXT_FAR_STUB_BYTES):
+		return {"ok": false, "message": "The Battle Tower text stubs run past the cartridge."}
+	for index: int in stubs:
+		var stub: int = int(entry["trainer_text"]) + index * RomLayout.TEXT_FAR_STUB_BYTES
+		if rom.u8(stub) != Gen2TextStream.TX_FAR \
+			or rom.u8(stub + RomLayout.TEXT_FAR_STUB_BYTES - 1) != Gen2TextStream.TX_END:
+			return {"ok": false, "message": "Battle Tower text stub %d is not a text_far." % index}
+
+	var levels: int = int(entry["level_strings"])
+	var level_bytes: int = RomLayout.BATTLETOWER_LEVEL_ROWS * RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
+	if not rom.in_bounds(levels, level_bytes):
+		return {"ok": false, "message": "Strings_L10ToL100 is outside the cartridge."}
+	var cancel: String = Gen2Text.decode_fixed(
+		rom.slice(
+			levels + RomLayout.BATTLETOWER_LEVEL_GROUPS * RomLayout.BATTLETOWER_LEVEL_ROW_BYTES,
+			RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
+		), 0, RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
+	)
+	if cancel != BATTLETOWER_LEVEL_CANCEL:
+		return {
+			"ok": false,
+			"message": "Strings_L10ToL100 ends on \"%s\", expected \"%s\"." % [
+				cancel, BATTLETOWER_LEVEL_CANCEL,
+			],
+		}
+
+	var menu: int = int(entry["challenge_menu"])
+	if not rom.in_bounds(menu, 2) \
+		or rom.u8(menu + 1) != RomLayout.BATTLETOWER_CHALLENGE_MENU_ROWS:
+		return {"ok": false, "message": "The challenge menu does not have three rows."}
+	var rows: Array = Array(read_challenge_menu_rows(rom, layout))
+	if rows != BATTLETOWER_CHALLENGE_MENU_ROWS:
+		return {
+			"ok": false,
+			"message": "The challenge menu reads %s, expected %s." % [
+				rows, BATTLETOWER_CHALLENGE_MENU_ROWS,
+			],
+		}
+	return {"ok": true, "message": "Battle Tower tables, texts and menus verified."}
+
+
 static func verify_name_input_chars(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var at: int = int(layout.get("name_input_chars", -1))
 	if not rom.in_bounds(at, RomLayout.NAME_INPUT_BLOCK_BYTES):
@@ -4311,6 +4535,13 @@ func import_rom(
 		RomCache.blob_path(RomCache.pic_anims_path(directory)), pic_anims
 	):
 		result["message"] = "Could not write pic animation data."
+		return result
+	var battle_tower: Dictionary = _import_battle_tower(rom, layout)
+	if not battle_tower.is_empty() and not RomCache.write_section(
+		RomCache.battle_tower_path(directory),
+		RomCache.blob_path(RomCache.battle_tower_path(directory)), battle_tower
+	):
+		result["message"] = "Could not write Battle Tower data."
 		return result
 	if not RomCache.write_json(RomCache.moves_path(directory), moves):
 		result["message"] = "Could not write move data."

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1501,6 +1501,21 @@ const SPECIAL_TEXT_RUNS: Dictionary = {
 			"more_care", "more_confident", "much_strength", "mighty", "impressed",
 		]],
 	],
+	## `engine/events/battle_tower/rules.asm`'s eight, which are three runs
+	## because `BattleTower_PleaseReturnWhenReady`'s own three instructions sit
+	## between the first two and `_CheckForBattleTowerRules` between the second
+	## and the third. The last run is the mobile challenge's two rules ahead of
+	## the local one's four, which is the file's order rather than either
+	## routine's table.
+	"battle_tower": [
+		["battle_tower_excuse_text", ["excuse_me"]],
+		["battle_tower_ready_text", ["return_when_ready"]],
+		["battle_tower_rule_text", [
+			"need_at_least_three", "egg_does_not_qualify",
+			"only_three_may_be_entered", "must_all_be_different_kinds",
+			"must_not_hold_the_same_items", "you_cant_take_an_egg",
+		]],
+	],
 	## `BuenaPrize`'s six, in its own file order.
 	"buena_prize": [["buena_prize_text", [
 		"ask_which_prize", "is_that_right", "here_you_go", "not_enough_points",
@@ -1960,6 +1975,43 @@ const MAIL_GFX_TILES: int = MAIL_GFX_BYTES / TILE_BYTES_1BPP
 ## icon over the entry.
 const MAIL_ICON_TILES: int = 8
 
+## constants/battle_tower_constants.asm. A challenge is seven trainers deep and
+## three Pokemon wide, and both tables the cartridge samples from are 21 rows of
+## a level group. `BATTLETOWER_NUM_UNIQUE_TRAINERS` is 70, and only Crystal 1.1
+## can reach past the first 21: `LoadOpponentTrainerAndPokemon`'s Crystal 1.0
+## branch masks with `BATTLETOWER_NUM_UNIQUE_MON` instead.
+const BATTLETOWER_PARTY_LENGTH: int = 3
+const BATTLETOWER_STREAK_LENGTH: int = 7
+const BATTLETOWER_NUM_UNIQUE_MON: int = 21
+const BATTLETOWER_NUM_UNIQUE_TRAINERS: int = 70
+const BATTLETOWER_LEVEL_GROUPS: int = 10
+## `bt_trainer` is `dname` plus the class byte, so a row is `NAME_LENGTH - 1`
+## characters and one more.
+const BATTLETOWER_TRAINER_NAME_BYTES: int = 10
+const BATTLETOWER_TRAINER_ROW_BYTES: int = BATTLETOWER_TRAINER_NAME_BYTES + 1
+## `NICKNAMED_MON_STRUCT_LENGTH`, the party-mon struct with its nickname behind
+## it, which is exactly what `LoadRandomBattleTowerMon` copies per slot.
+const BATTLETOWER_MON_BYTES: int = 48 + 11
+## `BattleTowerText`'s two arrays. A male class draws from 25 texts and a female
+## from 15, and each trainer owns a greeting, a loss line and a win line, laid
+## out in the file in that order per trainer. One pin walks all 120 stubs.
+const BATTLETOWER_MALE_TEXTS: int = 25
+const BATTLETOWER_FEMALE_TEXTS: int = 15
+const BATTLETOWER_TEXT_KINDS: Array[String] = ["greeting", "loss", "win"]
+## `Strings_L10ToL100`: ten level rows and CANCEL, each eight bytes with two
+## terminators. `Strings_Ll0ToL40` is the same run's first four rows plus its own
+## CANCEL, so the short menu is a slice rather than a second pin.
+const BATTLETOWER_LEVEL_ROW_BYTES: int = 8
+const BATTLETOWER_LEVEL_ROWS: int = BATTLETOWER_LEVEL_GROUPS + 1
+## `MenuData_ChallengeExplanationCancel`: the flags byte, the row count and three
+## terminated strings.
+const BATTLETOWER_CHALLENGE_MENU_ROWS: int = 3
+## The four boxes `_BattleTowerRoomMenu` prints, which are plain texts in the
+## mobile bank rather than `text_far` stubs.
+const BATTLETOWER_MENU_TEXT_ORDER: Array[String] = [
+	"what_level", "party_mon_tops_this_level", "uber_restriction", "cancel_challenge",
+]
+
 ## constants/item_constants.asm. TM01 is $bf and HM01 $f3, but the run is not
 ## contiguous: ITEM_C3 and ITEM_DC are dummy items inside it, which is why
 ## GetTMHMNumber skips them rather than subtracting.
@@ -2190,6 +2242,8 @@ const GOLD_SILVER: Dictionary = {
 	# belong to are Crystal bg events, where pokegold's cells carry the puzzle
 	# sign, and neither `DisplayUnownWords` nor the words are in the dump.
 	"unown_walls": -1,
+	## Gold and Silver have no Battle Tower map, routine or table at all.
+	"battle_tower": {},
 	# The credits. `gfx` was located by converting the pinned gfx/credits PNGs
 	# and matching the bytes: the border and the four mon sheets are one
 	# contiguous run in `credits.asm`'s own INCBIN order and `CreditsScript`
@@ -2454,6 +2508,11 @@ const GOLD_SILVER: Dictionary = {
 	"poke_seer_text": 0,
 	"seer_advice_text": 0,
 	"buena_prize_text": 0,
+	## The Battle Tower's three stub runs, which Gold and Silver ship no routine
+	## to reach; see the `battle_tower` block in the Crystal layout.
+	"battle_tower_excuse_text": 0,
+	"battle_tower_ready_text": 0,
+	"battle_tower_rule_text": 0,
 	"fruit_trees": 0x44091,
 	## `SpawnPoints` and `Flypoints`, each located by the byte column that is the
 	## same on all three dumps: the spawn coordinates at a stride of four, and
@@ -2873,6 +2932,33 @@ const CRYSTAL: Dictionary = {
 		"palettes": 0x8D05,
 		"icon": 0x11EF4,
 	},
+	# The Battle Tower, which Gold and Silver have no map, routine or table for.
+	# `trainers` is `BattleTowerTrainers`' 70 rows, `mons` the ten level groups
+	# of 21 nicknamed party-mon structs, `class_genders` and `class_sprites` the
+	# two per-class tables `BattleTowerText` and
+	# `LoadOpponentTrainerAndPokemonWithOTSprite` index, `trainer_text` the 120
+	# `text_far` stubs behind `BTMaleTrainerTexts`, `level_strings`
+	# `Strings_L10ToL100` and `challenge_menu`
+	# `MenuData_ChallengeExplanationCancel`. Each hits once.
+	#
+	# `BattleTowerTrainerData` is deliberately not here: its 36 bytes per trainer
+	# are the mobile greeting's easy-chat word pairs, which `Function17042c`
+	# alone walks, and nothing on the local challenge reads them.
+	"battle_tower": {
+		"trainers": 0x1F814E,
+		"mons": 0x1F8450,
+		"class_genders": 0x11F2F0,
+		"class_sprites": 0x170B90,
+		"trainer_text": 0x11F42E,
+		"level_strings": 0x119D0C,
+		"challenge_menu": 0x17D297,
+		"text": {
+			"what_level": 0x11ABA5,
+			"party_mon_tops_this_level": 0x11AAF0,
+			"uber_restriction": 0x11AB0F,
+			"cancel_challenge": 0x11AB4A,
+		},
+	},
 	# Battle animations; see the Gold and Silver block above for how these were
 	# located. All five tables sit in the same two banks in every dump and only
 	# the addresses within them move.
@@ -2960,6 +3046,10 @@ const CRYSTAL: Dictionary = {
 	"poke_seer_text": 0x4F28C,
 	"seer_advice_text": 0x4F2E8,
 	"buena_prize_text": 0x8B072,
+	## `engine/events/battle_tower/rules.asm`'s three stub runs; Crystal only.
+	"battle_tower_excuse_text": 0x8B22C,
+	"battle_tower_ready_text": 0x8B238,
+	"battle_tower_rule_text": 0x8B23D,
 	"fruit_trees": 0x44097,
 	"spawn_points": 0x152AB,
 	"flypoints": 0x91C5E,
@@ -3179,6 +3269,31 @@ static func name_input_table_offset(layout: Dictionary, table: int) -> int:
 static func mail_input_table_offset(layout: Dictionary, table: int) -> int:
 	return int((layout["mail"] as Dictionary)["input_chars"]) \
 		+ table * MAIL_INPUT_TABLE_ROWS * MAIL_INPUT_ROW_BYTES
+
+
+## The Battle Tower's own block, empty on a cartridge that has no tower.
+static func battle_tower(layout: Dictionary) -> Dictionary:
+	return layout.get("battle_tower", {}) as Dictionary
+
+
+static func has_battle_tower(layout: Dictionary) -> bool:
+	return not battle_tower(layout).is_empty()
+
+
+## `BattleTowerMons` row [param index] of level group [param group], which is
+## `AddNTimes` twice: once over a whole group and once over the row.
+static func battle_tower_mon_offset(layout: Dictionary, group: int, index: int) -> int:
+	return int(battle_tower(layout)["mons"]) \
+		+ (group * BATTLETOWER_NUM_UNIQUE_MON + index) * BATTLETOWER_MON_BYTES
+
+
+## One of the 120 `text_far` stubs, addressed the way `BattleTowerText` reaches
+## it: the male array first, then the female one, and within a trainer the
+## greeting, the loss line and the win line.
+static func battle_tower_text_offset(layout: Dictionary, female: bool, trainer: int, kind: int) -> int:
+	var base: int = int(battle_tower(layout)["trainer_text"])
+	var row: int = (BATTLETOWER_MALE_TEXTS if female else 0) + trainer
+	return base + (row * BATTLETOWER_TEXT_KINDS.size() + kind) * TEXT_FAR_STUB_BYTES
 
 
 ## `data/text_buffers.asm`'s StringBufferPointers, in `text_buffer` argument

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -319,10 +319,10 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 		var index: int = int(sprite["set"])
 		if index < 0 or index >= OAM_SETS.size():
 			continue
-		var set: Dictionary = OAM_SETS[index]
+		var ordering: Dictionary = OAM_SETS[index]
 		var at: Vector2i = sprite["at"]
 		var flip_x: bool = bool(sprite["flip_x"])
-		for part: Array in set["parts"]:
+		for part: Array in ordering["parts"]:
 			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
 			if out.size() >= SHADOW_OAM_SPRITES:
 				return out
@@ -337,7 +337,7 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 				# offset past the screen wraps rather than clamping.
 				"y": (at.y + int(part[0])) & 0xFF,
 				"x": (at.x + dx) & 0xFF,
-				"tile": (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF,
+				"tile": (int(sprite["vtile"]) + int(ordering["vtile"]) + int(part[2])) & 0xFF,
 				"palette": 1 if attrs & ATTR_PALETTE else 0,
 				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
 				"flip_y": bool(attrs & ATTR_YFLIP),

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -269,11 +269,11 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 		var index: int = int(sprite["set"])
 		if index < 0 or index >= OAM_SETS.size():
 			continue
-		var set: Dictionary = OAM_SETS[index]
+		var ordering: Dictionary = OAM_SETS[index]
 		var at: Vector2i = sprite["at"]
 		var flip_x: bool = bool(sprite["flip_x"])
 		var flip_y: bool = bool(sprite["flip_y"])
-		for part: Array in set["parts"]:
+		for part: Array in ordering["parts"]:
 			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
 			if out.size() >= SHADOW_OAM_SPRITES:
 				return out
@@ -291,7 +291,7 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 				# offset past the screen wraps rather than clamping.
 				"y": (at.y + dy) & 0xFF,
 				"x": (at.x + dx) & 0xFF,
-				"tile": (int(sprite["vtile"]) + int(set["vtile"]) + int(part[2])) & 0xFF,
+				"tile": (int(sprite["vtile"]) + int(ordering["vtile"]) + int(part[2])) & 0xFF,
 				"palette": attrs & ATTR_PALETTE,
 				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
 				"flip_y": bool(attrs & ATTR_YFLIP) != flip_y,
@@ -475,7 +475,7 @@ func _blit_sprite_tile(
 			pixels[at_pixel] = table[pixel]
 
 
-func _sheet(movie: Gen2IntroMovie, name: String) -> PackedByteArray:
+func _sheet(_movie: Gen2IntroMovie, name: String) -> PackedByteArray:
 	if name.is_empty() or _data == null:
 		return PackedByteArray()
 	if _sheets.has(name):

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -241,7 +241,7 @@ func deposit_selected_party() -> bool:
 		_prompt = PROMPT_CHOOSE
 		_refresh()
 		return false
-	var name: String = _display_name(_save.party[_selected_party_index] as Gen2SaveMon)
+	var mon_name: String = _display_name(_save.party[_selected_party_index] as Gen2SaveMon)
 	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(
 		_save, _data, _selected_party_index, _box_index, -1, _persist
 	)
@@ -249,7 +249,7 @@ func deposit_selected_party() -> bool:
 		_prompt = _refusal(result, PROMPT_BOX_FULL)
 		_refresh()
 		return false
-	_prompt = PROMPT_STORED % name
+	_prompt = PROMPT_STORED % mon_name
 	_selected_party_index = -1
 	_clamp_cursor()
 	_refresh()
@@ -263,7 +263,7 @@ func withdraw_selected_box() -> bool:
 		_refresh()
 		return false
 	var box: Gen2SaveBox = _save.boxes[_box_index] if _box_index < _save.boxes.size() else null
-	var name: String = _display_name(
+	var mon_name: String = _display_name(
 		box.slots[_selected_box_slot] as Gen2SaveMon if box != null else null
 	)
 	var result: Dictionary = Gen2SaveStorage.withdraw_box_to_party(
@@ -273,7 +273,7 @@ func withdraw_selected_box() -> bool:
 		_prompt = _refusal(result, PROMPT_PARTY_FULL)
 		_refresh()
 		return false
-	_prompt = PROMPT_GOT % name
+	_prompt = PROMPT_GOT % mon_name
 	_selected_box_slot = -1
 	_clamp_cursor()
 	_refresh()
@@ -286,7 +286,7 @@ func release_selected() -> bool:
 	if _save == null:
 		return false
 	var mon: Gen2SaveMon = _selected_mon()
-	var name: String = _display_name(mon)
+	var mon_name: String = _display_name(mon)
 	var result: Dictionary = Gen2SaveStorage.release_party_member(
 		_save, _data, _selected_party_index, _persist
 	) if _loaded == LOADED_PARTY else Gen2SaveStorage.release_box_slot(
@@ -296,7 +296,7 @@ func release_selected() -> bool:
 		_prompt = _refusal(result, PROMPT_LAST_MON)
 		_refresh()
 		return false
-	_prompt = PROMPT_BYE % name
+	_prompt = PROMPT_BYE % mon_name
 	_selected_party_index = -1
 	_selected_box_slot = -1
 	_clamp_cursor()
@@ -412,11 +412,11 @@ func _open_submenu() -> void:
 	_refresh()
 
 
-func _close_submenu(draw: bool = true) -> void:
+func _close_submenu(redraw: bool = true) -> void:
 	_submenu_open = false
 	_release_open = false
 	_prompt = PROMPT_CHOOSE
-	if draw:
+	if redraw:
 		_refresh()
 
 

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -353,7 +353,7 @@ static func _read_save(
 		var species: int = int(raw[species_start + index])
 		if species <= 0 or species == 0xFF:
 			return null
-		var mon: Gen2SaveMon = _read_mon(raw, mons_start + index * PARTYMON_SIZE)
+		var mon: Gen2SaveMon = read_party_mon(raw, mons_start + index * PARTYMON_SIZE)
 		if mon == null or mon.species != species:
 			return null
 		mon.original_trainer = Gen2Text.decode_fixed(raw, ot_start + index * NAME_LENGTH, NAME_LENGTH)
@@ -364,7 +364,9 @@ static func _read_save(
 	return save
 
 
-static func _read_mon(raw: PackedByteArray, start: int) -> Gen2SaveMon:
+## One party-mon struct, which is the same 48 bytes wherever it is stored: a
+## save file's party, a box's, and `BattleTowerMons`' own rows.
+static func read_party_mon(raw: PackedByteArray, start: int) -> Gen2SaveMon:
 	if start < 0 or start + PARTYMON_SIZE > raw.size():
 		return null
 	var mon := Gen2SaveMon.new()

--- a/game/world/battle_tower.gd
+++ b/game/world/battle_tower.gd
@@ -1,0 +1,509 @@
+class_name Gen2BattleTower
+extends RefCounted
+
+## `SECTION "SRAM Battle Tower"` and the routines that read it: the challenge's
+## own state, the seven trainers it has already sampled, and the levels, rules
+## and rewards `engine/events/battle_tower/` decides from them.
+##
+## Scene free. The world screen owns the two menus and the battle; this record
+## owns the SRAM section and every answer `BattleTowerAction`, `LoadOpponentTrainerAndPokemon`
+## and `_CheckForBattleTowerRules` give from it.
+
+## constants/battle_tower_constants.asm's `sBattleTowerChallengeState` values.
+const NO_CHALLENGE: int = 0
+const SAVED_AND_LEFT: int = 1
+const CHALLENGE_IN_PROGRESS: int = 2
+const WON_CHALLENGE: int = 3
+const RECEIVED_REWARD: int = 4
+
+const PARTY_LENGTH: int = RomLayout.BATTLETOWER_PARTY_LENGTH
+const STREAK_LENGTH: int = RomLayout.BATTLETOWER_STREAK_LENGTH
+const NUM_UNIQUE_MON: int = RomLayout.BATTLETOWER_NUM_UNIQUE_MON
+const NUM_UNIQUE_TRAINERS: int = RomLayout.BATTLETOWER_NUM_UNIQUE_TRAINERS
+const LEVEL_GROUPS: int = RomLayout.BATTLETOWER_LEVEL_GROUPS
+## `sBTTrainers` is filled with `$ff` by `ResetBattleTowerTrainersSRAM`, which is
+## also what makes "no trainer sampled yet" a value no trainer index can be.
+const NO_TRAINER: int = 0xFF
+
+## `BattleTowerAction`'s own jumptable indices, in the order
+## constants/battle_tower_constants.asm declares them. Only the rows a script
+## the player can reach uses are named; the rest are the mobile adapter's and
+## answer [method action]'s default.
+const ACTION_CHECK_EXPLANATION_READ: int = 0
+const ACTION_SET_EXPLANATION_READ: int = 1
+const ACTION_GET_CHALLENGE_STATE: int = 2
+const ACTION_SAVE_AND_QUIT: int = 3
+const ACTION_CHALLENGE_CANCELED: int = 4
+const ACTION_MOBILE_RECORD_CLEAR: int = 6
+const ACTION_SAVE_LEVEL_GROUP: int = 7
+const ACTION_LOAD_LEVEL_GROUP: int = 8
+const ACTION_CHECK_SAVE_FILE_IS_YOURS: int = 9
+const ACTION_MAX_VOLUME: int = 10
+const ACTION_MOBILE_CLEAR_ROOM_FLAG: int = 17
+const ACTION_LEVEL_CHECK: int = 24
+const ACTION_UBERS_CHECK: int = 25
+const ACTION_RESET_DATA: int = 26
+const ACTION_GIVE_REWARD: int = 27
+const ACTION_SET_WON_CHALLENGE: int = 28
+const ACTION_SET_RECEIVED_REWARD: int = 29
+const ACTION_CHOOSE_REWARD: int = 30
+const ACTION_SAVE_OPTIONS: int = 31
+
+## `sBattleTowerSaveFileFlags`. Bit 1 is the explanation the receptionist only
+## offers once; bit 0 is the mobile half's own and nothing local reads it.
+const FLAG_MOBILE_READ: int = 1
+const FLAG_EXPLANATION_READ: int = 2
+
+## `BATTLETOWER_MIN_REWARD` and `BATTLETOWER_MAX_REWARD`, the stat boosters
+## `BattleTower_RandomlyChooseReward` rolls between, and the LUCKY_PUNCH sitting
+## inside the run that it rerolls. `BattleTower_GiveReward` answers POTION when
+## the pack cannot hold five more of the roll, which the script prints its
+## "stuffed full" line from.
+const MIN_REWARD: int = 26
+const MAX_REWARD: int = 31
+const LUCKY_PUNCH: int = 30
+const REWARD_QUANTITY: int = 5
+const REWARD_FULL_PACK: int = 18
+
+## `BattleTower_UbersCheck`: MEWTWO, MEW and everything from LUGIA up may only
+## enter a room of Lv.70 or higher, and the check is skipped outright once the
+## chosen group is that high.
+const UBER_MEWTWO: int = 150
+const UBER_MEW: int = 151
+const UBER_FIRST_LEGENDARY: int = 249
+const UBER_MIN_LEVEL: int = 70
+
+## `BattleTowerRoomMenu_PlacePickLevelMenu`: four rows before the Hall of Fame
+## and all ten after it, CANCEL behind either.
+const PRE_HALL_OF_FAME_GROUPS: int = 4
+
+## How many times a `.resample` loop is drawn before the guard below answers.
+## The cartridge's own loops are unbounded and cannot hang; see
+## [method _first_unsampled_trainer].
+const RESAMPLE_LIMIT: int = 256
+
+## `BattleTowerText`'s two arrays and the three lines each trainer owns.
+const TEXT_GREETING: int = 0
+const TEXT_LOSS: int = 1
+const TEXT_WIN: int = 2
+
+## `sBattleTowerChallengeState`
+var challenge_state: int = NO_CHALLENGE
+## `sNrOfBeatenBattleTowerTrainers`, which is also where in `sBTTrainers` the
+## next sampled trainer is written.
+var beaten: int = 0
+## `sBTChoiceOfLevelGroup`, 1 to 10. Zero until a challenge has chosen one.
+var level_group: int = 0
+## `wBTChoiceOfLvlGroup`, the WRAM byte the room menu writes and the hallway,
+## the sampler and `SaveBattleTowerLevelGroup` read. Its own field because the
+## two are written at different moments: the menu picks a room, and only the
+## save at the end of a session copies that pick into SRAM.
+var chosen_group: int = 0
+## `sBTTrainers`, seven trainer indices or [constant NO_TRAINER].
+var trainers: Array = []
+var save_file_flags: int = 0
+## `sBattleTowerReward`, chosen once per challenge by
+## `BattleTower_RandomlyChooseReward` and handed over only at the end of it.
+var reward: int = 0
+## `sBTMonPrevTrainer1`-`3` and `sBTMonPrevPrevTrainer1`-`3`, the species of the
+## last two teams: the sampler refuses a species either of them used.
+var previous_mons: Array = []
+var earlier_mons: Array = []
+
+
+func _init() -> void:
+	trainers = _filled(STREAK_LENGTH, NO_TRAINER)
+	previous_mons = _filled(PARTY_LENGTH, 0)
+	earlier_mons = _filled(PARTY_LENGTH, 0)
+
+
+static func _filled(size: int, value: int) -> Array:
+	var out: Array = []
+	for _index: int in size:
+		out.append(value)
+	return out
+
+
+func to_dict() -> Dictionary:
+	return {
+		"challenge_state": challenge_state,
+		"beaten": beaten,
+		"level_group": level_group,
+		"chosen_group": chosen_group,
+		"trainers": trainers.duplicate(),
+		"save_file_flags": save_file_flags,
+		"reward": reward,
+		"previous_mons": previous_mons.duplicate(),
+		"earlier_mons": earlier_mons.duplicate(),
+	}
+
+
+## The stored shape, defaulting rather than versioning: a slot written before the
+## tower existed reads as a save with no challenge in it, which is the truth
+## about it.
+static func from_dict(raw: Variant) -> Gen2BattleTower:
+	var out := Gen2BattleTower.new()
+	if not raw is Dictionary:
+		return out
+	var source: Dictionary = raw as Dictionary
+	out.challenge_state = clampi(int(source.get("challenge_state", NO_CHALLENGE)), 0, RECEIVED_REWARD)
+	out.beaten = clampi(int(source.get("beaten", 0)), 0, STREAK_LENGTH)
+	out.level_group = clampi(int(source.get("level_group", 0)), 0, LEVEL_GROUPS)
+	out.chosen_group = clampi(int(source.get("chosen_group", 0)), 0, LEVEL_GROUPS)
+	out.save_file_flags = int(source.get("save_file_flags", 0)) & 0xFF
+	out.reward = int(source.get("reward", 0)) & 0xFF
+	out.trainers = _bytes_field(source.get("trainers", []), STREAK_LENGTH, NO_TRAINER)
+	out.previous_mons = _bytes_field(source.get("previous_mons", []), PARTY_LENGTH, 0)
+	out.earlier_mons = _bytes_field(source.get("earlier_mons", []), PARTY_LENGTH, 0)
+	return out
+
+
+static func _bytes_field(raw: Variant, size: int, fill: int) -> Array:
+	var out: Array = _filled(size, fill)
+	if not raw is Array:
+		return out
+	var source: Array = raw as Array
+	for index: int in mini(size, source.size()):
+		out[index] = int(source[index]) & 0xFF
+	return out
+
+
+func duplicate_tower() -> Gen2BattleTower:
+	return from_dict(to_dict())
+
+
+## `ResetBattleTowerTrainersSRAM`: every sampled trainer forgotten and the count
+## back to zero. The level group, the reward and the save-file flags are not
+## touched, which is why a cancelled challenge still remembers the explanation.
+func reset_trainers() -> void:
+	trainers = _filled(STREAK_LENGTH, NO_TRAINER)
+	beaten = 0
+
+
+## The highest level a party member may be for [param group], `wcd4f * 10` in
+## `BattleTower_LevelCheck`.
+static func group_level(group: int) -> int:
+	return group * 10
+
+
+## `BattleTower_LevelCheck`, which fails on the first party member above the
+## chosen group's level. -1 when the party is inside it.
+##
+## [param party] is the read-only party mirror the script runner carries:
+## `species`, `levels`, `held_items` and `eggs`, one entry per slot.
+static func level_check(party: Dictionary, group: int) -> int:
+	var levels: Array = party.get("levels", []) as Array
+	var cap: int = group_level(group)
+	for index: int in levels.size():
+		if int(levels[index]) > cap:
+			return index
+	return -1
+
+
+## `BattleTower_UbersCheck`. Answers the offending party index, or -1. The whole
+## check is skipped once the chosen group is Lv.70 or higher, which is what its
+## own `cp 70 / 10` in front of the loop does.
+static func ubers_check(party: Dictionary, group: int) -> int:
+	if group_level(group) >= UBER_MIN_LEVEL:
+		return -1
+	var species: Array = party.get("species", []) as Array
+	var levels: Array = party.get("levels", []) as Array
+	for index: int in species.size():
+		var number: int = int(species[index])
+		var uber: bool = number == UBER_MEWTWO or number == UBER_MEW \
+			or (number >= UBER_FIRST_LEGENDARY and number <= RomLayout.SPECIES_COUNT)
+		if uber and index < levels.size() and int(levels[index]) < UBER_MIN_LEVEL:
+			return index
+	return -1
+
+
+## `_CheckForBattleTowerRules`' four checks in its own order, each named by the
+## box it prints. An empty Array is a party that may enter.
+##
+## `BattleTower_ExecuteJumptable` runs every check rather than stopping at the
+## first, so a party can fail more than one and the receptionist says so once
+## per failure.
+static func rule_failures(party: Dictionary) -> Array:
+	var species: Array = party.get("species", []) as Array
+	var eggs: Array = party.get("eggs", []) as Array
+	var out: Array = []
+	if species.size() != PARTY_LENGTH:
+		out.append("only_three_may_be_entered")
+	if not _values_are_unique(species, eggs):
+		out.append("must_all_be_different_kinds")
+	if not _values_are_unique(party.get("held_items", []) as Array, eggs):
+		out.append("must_not_hold_the_same_items")
+	for index: int in eggs.size():
+		if bool(eggs[index]):
+			out.append("you_cant_take_an_egg")
+			break
+	return out
+
+
+## `CheckPartyValueIsUnique`, which skips an egg on either side of the
+## comparison and a zero on the left: three members holding nothing are not
+## three members holding the same item.
+static func _values_are_unique(values: Array, eggs: Array) -> bool:
+	for first: int in values.size():
+		if first < eggs.size() and bool(eggs[first]):
+			continue
+		var value: int = int(values[first])
+		if value == 0:
+			continue
+		for second: int in range(first + 1, values.size()):
+			if second < eggs.size() and bool(eggs[second]):
+				continue
+			if int(values[second]) == value:
+				return false
+	return true
+
+
+## `LoadOpponentTrainerAndPokemon`: a trainer this streak has not sampled, and
+## three Pokemon of the chosen level group that share no species or held item
+## with each other or with either of the last two teams.
+##
+## The sampled trainer is written into `sBTTrainers[beaten]` and the two
+## previous-team lists shift, so calling this twice in a row gives two different
+## opponents the way the cartridge's own streak does. Answers
+## { trainer, name, class, mons }, `mons` being three [Gen2SaveMon], or an empty
+## Dictionary when the cartridge has no tower.
+func load_opponent(data: GameData, random: RandomNumberGenerator) -> Dictionary:
+	if data == null or not data.has_battle_tower():
+		return {}
+	var rows: Array = data.battle_tower().get("trainers", []) as Array
+	if rows.is_empty():
+		return {}
+	var trainer: int = _sample_trainer(random)
+	if beaten >= 0 and beaten < trainers.size():
+		trainers[beaten] = trainer
+	var record: Dictionary = rows[trainer % rows.size()] as Dictionary
+	var mons: Array = _sample_mons(data, random)
+	var sampled: Array = []
+	for mon: Gen2SaveMon in mons:
+		sampled.append(mon.species)
+	earlier_mons = previous_mons.duplicate()
+	previous_mons = sampled
+	return {
+		"trainer": trainer,
+		"name": String(record.get("name", "")),
+		"class": int(record.get("class", 0)),
+		"mons": mons,
+	}
+
+
+## The `.resample` loop: `maskbits BATTLETOWER_NUM_UNIQUE_TRAINERS` is seven
+## bits, so the roll is 0 to 127 and anything past the table is drawn again, as
+## is any index already in `sBTTrainers`.
+##
+## Crystal 1.0 masks with `BATTLETOWER_NUM_UNIQUE_MON` instead and can only ever
+## reach the first 21; the pinned dumps are 1.1, so this is the 1.1 branch.
+func _sample_trainer(random: RandomNumberGenerator) -> int:
+	for _attempt: int in RESAMPLE_LIMIT:
+		var roll: int = random.randi() & 0x7F
+		if roll >= NUM_UNIQUE_TRAINERS or trainers.has(roll):
+			continue
+		return roll
+	return _first_unsampled_trainer()
+
+
+## What a resample loop that will not terminate answers. The cartridge's own
+## loop cannot hang: seven sampled trainers out of seventy always leave one, and
+## the roll is uniform. A generator that is not costs a frozen game rather than
+## a rare opponent, so the guard picks the lowest index the streak has not used.
+func _first_unsampled_trainer() -> int:
+	for index: int in NUM_UNIQUE_TRAINERS:
+		if not trainers.has(index):
+			return index
+	return 0
+
+
+## `LoadRandomBattleTowerMon`'s `.FindARandomBattleTowerMon`: three rows of the
+## chosen level group, refusing a species or an item already on this team and a
+## species either of the last two teams used.
+func _sample_mons(data: GameData, random: RandomNumberGenerator) -> Array:
+	var out: Array = []
+	var group: int = clampi(chosen_group, 1, LEVEL_GROUPS) - 1
+	for _slot: int in PARTY_LENGTH:
+		var chosen: Gen2SaveMon = null
+		for _attempt: int in RESAMPLE_LIMIT:
+			var roll: int = random.randi() & 0x1F
+			if roll >= NUM_UNIQUE_MON:
+				continue
+			var candidate: Gen2SaveMon = _read_mon(data, group, roll)
+			if candidate == null or not _mon_is_free(candidate, out):
+				continue
+			chosen = candidate
+			break
+		if chosen == null:
+			chosen = _first_free_mon(data, group, out)
+		if chosen != null:
+			out.append(chosen)
+	return out
+
+
+func _mon_is_free(candidate: Gen2SaveMon, team: Array) -> bool:
+	for mon: Gen2SaveMon in team:
+		if mon.species == candidate.species or mon.item == candidate.item:
+			return false
+	return not previous_mons.has(candidate.species) \
+		and not earlier_mons.has(candidate.species)
+
+
+func _first_free_mon(data: GameData, group: int, team: Array) -> Gen2SaveMon:
+	for index: int in NUM_UNIQUE_MON:
+		var candidate: Gen2SaveMon = _read_mon(data, group, index)
+		if candidate != null and _mon_is_free(candidate, team):
+			return candidate
+	return null
+
+
+## One `BattleTowerMons` row. The bytes are a party-mon struct with its nickname
+## behind it, which is the same struct a save file's party is written in, so
+## [Gen2SramAdapter] reads it rather than a second parser.
+static func _read_mon(data: GameData, group: int, index: int) -> Gen2SaveMon:
+	var bytes: PackedByteArray = data.battle_tower_mon(group, index)
+	if bytes.size() < RomLayout.BATTLETOWER_MON_BYTES:
+		return null
+	var mon: Gen2SaveMon = Gen2SramAdapter.read_party_mon(bytes, 0)
+	if mon == null:
+		return null
+	mon.nickname = Gen2Text.decode_fixed(
+		bytes, RomLayout.BATTLETOWER_MON_BYTES - Gen2SramAdapter.MON_NAME_LENGTH,
+		Gen2SramAdapter.MON_NAME_LENGTH
+	)
+	return mon
+
+
+## `BattleTowerText`: a male class draws from 25 lines and a female from 15, and
+## the greeting's roll is remembered so the same trainer's win and loss lines
+## come from the same personality. Answers { index, text }.
+func trainer_line(
+	data: GameData, trainer_class: int, kind: int, random: RandomNumberGenerator,
+	remembered: int = -1
+) -> Dictionary:
+	var texts: Dictionary = data.battle_tower().get("texts", {}) as Dictionary
+	var female: bool = is_class_female(data, trainer_class)
+	var lines: Array = ((texts.get(
+		RomLayout.BATTLETOWER_TEXT_KINDS[kind], {}
+	) as Dictionary).get("female" if female else "male", []) as Array)
+	if lines.is_empty():
+		return {"index": 0, "text": ""}
+	var index: int = remembered
+	if kind == TEXT_GREETING or index < 0 or index >= lines.size():
+		# The `dec c / jr nz, .restore` in the source: only the greeting rolls,
+		# and the two lines behind it read `wBT_TrainerTextIndex` back.
+		index = _roll_line(random, lines.size())
+	return {"index": index, "text": String(lines[index])}
+
+
+## `and $1f / cp 25 / sub 25` for a male and `and $f / cp 15 / sub 15` for a
+## female: one mask and one subtraction rather than a resample, so the low
+## indices are twice as likely as the high ones and that is the distribution.
+static func _roll_line(random: RandomNumberGenerator, count: int) -> int:
+	var mask: int = 0x1F if count > 16 else 0x0F
+	var roll: int = random.randi() & mask
+	return roll if roll < count else roll - count
+
+
+## `BTTrainerClassGenders`, which the table indexes with the class minus one.
+static func is_class_female(data: GameData, trainer_class: int) -> bool:
+	var genders: Array = data.battle_tower().get("class_genders", []) as Array
+	var index: int = trainer_class - 1
+	if index < 0 or index >= genders.size():
+		return false
+	return int(genders[index]) != 0
+
+
+## `BTTrainerClassSprites`, the overworld sprite
+## `LoadOpponentTrainerAndPokemonWithOTSprite` gives the battle room's opponent
+## object. Zero when the class is outside the table.
+static func class_sprite(data: GameData, trainer_class: int) -> int:
+	var sprites: Array = data.battle_tower().get("class_sprites", []) as Array
+	var index: int = trainer_class - 1
+	if index < 0 or index >= sprites.size():
+		return 0
+	return int(sprites[index])
+
+
+## `BattleTower_RandomlyChooseReward`: one of the six stat boosters, LUCKY_PUNCH
+## rerolled because it sits inside the run without being a reward. Stored rather
+## than handed over, so the item the player gets after seven wins was decided
+## before the first.
+func choose_reward(random: RandomNumberGenerator) -> int:
+	var span: int = MAX_REWARD - MIN_REWARD + 1
+	for _attempt: int in RESAMPLE_LIMIT:
+		var roll: int = random.randi() & 0x07
+		if roll >= span:
+			roll -= span
+		var item: int = MIN_REWARD + roll
+		if item == LUCKY_PUNCH:
+			continue
+		reward = item
+		return item
+	reward = MIN_REWARD
+	return reward
+
+
+## `BattleTower_GiveReward`: the stored item, or POTION when the pack has no room
+## for five more of it. [param pack] is the item pocket as
+## [code]{ item: quantity }[/code].
+##
+## The source's own shape, which is not "is there room": a pack under `MAX_ITEMS`
+## always has room for a new row, and a full one only does when it already
+## carries the reward with fewer than `MAX_ITEM_STACK - 5 + 1` of it.
+func reward_for(pack: Dictionary) -> int:
+	if pack.size() < Gen2WorldPack.MAX_ITEMS:
+		return reward
+	if pack.has(reward) \
+		and int(pack[reward]) < Gen2WorldPack.MAX_ITEM_STACK - REWARD_QUANTITY + 1:
+		return reward
+	return REWARD_FULL_PACK
+
+
+## `BattleTowerAction`'s jumptable, as the value it leaves in `wScriptVar`.
+## An action that writes nothing there answers -1, which the runner leaves the
+## variable alone for.
+##
+## The mobile rows are no-ops with a reason: each writes a byte in SRAM bank 5
+## that only the mobile adapter's own routines read, and none of them reaches a
+## script the player can talk to.
+func action(index: int, context: Dictionary = {}) -> int:
+	match index:
+		ACTION_CHECK_EXPLANATION_READ:
+			if not bool(context.get("save_is_yours", true)):
+				return 0
+			return save_file_flags & FLAG_EXPLANATION_READ
+		ACTION_SET_EXPLANATION_READ:
+			save_file_flags |= FLAG_EXPLANATION_READ
+		ACTION_GET_CHALLENGE_STATE:
+			return challenge_state
+		ACTION_SAVE_AND_QUIT:
+			challenge_state = SAVED_AND_LEFT
+		ACTION_CHALLENGE_CANCELED:
+			challenge_state = NO_CHALLENGE
+		ACTION_SAVE_LEVEL_GROUP:
+			level_group = chosen_group
+		ACTION_LOAD_LEVEL_GROUP:
+			chosen_group = level_group
+			return chosen_group
+		ACTION_CHECK_SAVE_FILE_IS_YOURS:
+			return 1 if bool(context.get("save_is_yours", true)) else 0
+		ACTION_LEVEL_CHECK:
+			var over: int = level_check(context.get("party", {}) as Dictionary, chosen_group)
+			return 0 if over < 0 else group_level(chosen_group)
+		ACTION_UBERS_CHECK:
+			var uber: int = ubers_check(context.get("party", {}) as Dictionary, chosen_group)
+			return 0 if uber < 0 else group_level(chosen_group)
+		ACTION_RESET_DATA:
+			reset_trainers()
+		ACTION_CHOOSE_REWARD:
+			var random: Variant = context.get("random", null)
+			if random is RandomNumberGenerator:
+				choose_reward(random as RandomNumberGenerator)
+		ACTION_GIVE_REWARD:
+			return reward_for(context.get("pack", {}) as Dictionary)
+		ACTION_SET_WON_CHALLENGE:
+			challenge_state = WON_CHALLENGE
+		ACTION_SET_RECEIVED_REWARD:
+			challenge_state = RECEIVED_REWARD
+	return -1

--- a/game/world/battle_tower.gd.uid
+++ b/game/world/battle_tower.gd.uid
@@ -1,0 +1,1 @@
+uid://b8usx52fs86ab

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -450,10 +450,10 @@ func _resume_after_name() -> void:
 	_enter_next_beat()
 
 
-func _hide_speech(hidden: bool) -> void:
+func _hide_speech(was_hidden: bool) -> void:
 	for node: CanvasItem in [_background, _pic, _text_box]:
 		if node != null:
-			node.visible = not hidden
+			node.visible = not was_hidden
 
 
 ## `Intro_PrepTrainerPic` and `PrepMonFrontpic` both fill a seven-tile box at
@@ -580,8 +580,8 @@ func _start_audio() -> void:
 func _show_shrink_pic(which: int) -> void:
 	if _pic == null or _data == null:
 		return
-	var name: String = RomLayout.SHRINK_PIC_NAMES[which]
-	var indices: PackedByteArray = _data.tile_indices(name)
+	var pic_name: String = RomLayout.SHRINK_PIC_NAMES[which]
+	var indices: PackedByteArray = _data.tile_indices(pic_name)
 	var side: int = RomLayout.SHRINK_PIC_COLUMNS * TILE
 	if indices.size() < side * side:
 		return

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -657,12 +657,12 @@ func _scroll_list_to_cursor() -> void:
 	if _menu == null:
 		_list_scroll = 0
 		return
-	var visible: int = Gen2StartMenuPage.visible_rows(
+	var shown: int = Gen2StartMenuPage.visible_rows(
 		_world != null and _world.bug_contest_active()
 	)
 	_list_scroll = clampi(
-		clampi(_list_scroll, _menu.cursor - visible + 1, _menu.cursor),
-		0, maxi(_menu.size() - visible, 0)
+		clampi(_list_scroll, _menu.cursor - shown + 1, _menu.cursor),
+		0, maxi(_menu.size() - shown, 0)
 	)
 
 
@@ -2134,7 +2134,7 @@ func _hardware_image() -> Image:
 			if _menu == null:
 				return null
 			var contest: bool = _world != null and _world.bug_contest_active()
-			var visible: int = Gen2StartMenuPage.visible_rows(contest)
+			var shown: int = Gen2StartMenuPage.visible_rows(contest)
 			var labels: Array = []
 			for entry: Variant in _menu.items():
 				labels.append(String((entry as Dictionary).get("label", "")))
@@ -2143,7 +2143,7 @@ func _hardware_image() -> Image:
 			var description: String = _menu.selected_description() \
 				if Gen2OptionsStore.current().menu_account else ""
 			return _page.render_list(
-				labels.slice(_list_scroll, _list_scroll + visible),
+				labels.slice(_list_scroll, _list_scroll + shown),
 				_menu.cursor - _list_scroll, description, contest
 			)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -6597,6 +6597,23 @@ func _day_care_species(sprite_number: int) -> int:
 ## it, so a save that has not met Sudowoodo really does stand two copies of the
 ## player's sprite on that route. An object that should not be there at all is
 ## masked by [method load_object_masks], not by this fallback.
+## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail: it writes a sprite number
+## straight into `wMapObjects` and calls `GetUsedSprite`, because the Battle
+## Tower's opponent is drawn at random and its object event carries a placeholder
+## instead. The overworld sprite is replaced in place; nothing else about the
+## object moves.
+func set_object_sprite(index: int, sprite_number: int) -> Dictionary:
+	if index < 0 or index >= objects.size() or sprite_number <= 0:
+		return {"ok": false, "reason": &"invalid_object_sprite", "object": index}
+	var object: Gen2WorldObject = objects[index] as Gen2WorldObject
+	object.sprite_number = sprite_number
+	var icon_number: int = _mon_icon_for_sprite(sprite_number)
+	object.sprite = data.overworld_icon(icon_number) if icon_number > 0 \
+		else data.overworld_sprite(sprite_number)
+	set_object_time(object_hour, object_time_of_day)
+	return {"ok": true, "object": index, "sprite": sprite_number}
+
+
 func _object_from_event(index: int, value: Dictionary) -> Gen2WorldObject:
 	var sprite_number: int = _resolved_sprite(int(value.get("sprite", 0)))
 	var sprite: Gen2WorldSprite = null

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -63,6 +63,19 @@ static func prepare(
 				return _failure(&"invalid_trainer", {
 					"trainer_class": trainer_class, "trainer_index": trainer_index,
 				})
+		&"battle_tower":
+			## `ReadBTTrainerParty` copies a whole `wOTPartyMon` block out of the
+			## sampled record rather than building one from a trainer table, so
+			## the party arrives with the request and nothing is rolled here.
+			trainer_class = int(values.get("trainer_class", 0))
+			var members: Array = []
+			for raw_mon: Variant in values.get("enemy_party", []) as Array:
+				var saved: Gen2SaveMon = Gen2SaveMon.from_dict(raw_mon)
+				var member: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, saved)
+				if member == null:
+					return _failure(&"invalid_battle_tower_mon", {"mon": raw_mon})
+				members.append(member)
+			enemy_party = Gen2Party.create(members)
 		_:
 			return _failure(&"unsupported_battle_kind", {"kind": kind})
 
@@ -70,8 +83,8 @@ static func prepare(
 		return _failure(&"missing_enemy_party")
 	var generator := random if random != null else RandomNumberGenerator.new()
 	var battle: Gen2Battle = Gen2Battle.create_parties(
-		data, player_party, enemy_party, generator, kind == &"trainer", player_badges,
-		battle_rules
+		data, player_party, enemy_party, generator,
+		kind == &"trainer" or kind == &"battle_tower", player_badges, battle_rules
 	)
 	if battle == null:
 		return _failure(&"battle_setup_failed")

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -73,15 +73,15 @@ static func host_seconds() -> float:
 ## a host clock that has been put back: neither is a reason to run the world's
 ## own clock backwards.
 static func catch_up(
-	day_value: int, hour: int, minute: int, stamp: float, now: float = -1.0
+	day_value: int, hour_value: int, minute_value: int, stamp: float, now: float = -1.0
 ) -> Dictionary:
 	var here: float = now if now >= 0.0 else host_seconds()
 	var elapsed: float = here - stamp
 	if stamp <= 0.0 or elapsed <= 0.0:
-		return {"day": day_value, "hour": hour, "minute": minute}
+		return {"day": day_value, "hour": hour_value, "minute": minute_value}
 	@warning_ignore("integer_division")
 	var minutes: int = int(elapsed / SECONDS_PER_MINUTE) \
-		+ minute + hour * MINUTES_PER_HOUR \
+		+ minute_value + hour_value * MINUTES_PER_HOUR \
 		+ day_value * MINUTES_PER_HOUR * HOURS_PER_DAY
 	var day_minutes: int = MINUTES_PER_HOUR * HOURS_PER_DAY
 	@warning_ignore("integer_division")

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -6239,6 +6239,23 @@ func _show_script_results(results: Array) -> void:
 				open_hall_of_fame()
 			elif result_event.get("type", &"") == &"credits_requested":
 				open_credits()
+			elif result_event.get("type", &"") == &"soft_reset_requested":
+				## `special Reset` restarts the console, which is how a saved and
+				## left Battle Tower challenge leaves the battle room. The save
+				## has already been written by the action in front of it.
+				persist_world_snapshot()
+				get_tree().change_scene_to_file.call_deferred(
+					"res://game/world/intro_screen.tscn"
+				)
+				return
+			elif result_event.get("type", &"") == &"battle_tower_opponent_loaded":
+				## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail, which
+				## writes the sampled class's sprite into `wMapObjects` and loads
+				## it: the opponent is chosen at random and has to appear as
+				## whoever was drawn.
+				_world.set_object_sprite(
+					int(result_event.get("object", 0)), int(result_event.get("sprite", 0))
+				)
 			elif result_event.get("type", &"") == &"field_move_confirmed":
 				## `iftrue Script_Cut` and its four counterparts. The move is the
 				## host's, and it is the same staged request and acknowledge the
@@ -6357,6 +6374,16 @@ func _show_script_results(results: Array) -> void:
 					})
 					_script_prompt = _bug_contest_placings_text(judged)
 					_show_script_results(judged_results)
+					return
+				if StringName(request.get("kind", &"")) == &"quick_save_requested":
+					## `TryQuickSave` writes the save where it stands and answers
+					## TRUE; a write that fails answers FALSE, which is the same
+					## "no" the source gives a player who declines.
+					var written: Dictionary = persist_world_snapshot()
+					_show_script_results(_world.complete_runtime_request({
+						"ok": true,
+						"script_value": 1 if bool(written.get("ok", false)) else 0,
+					}))
 					return
 				if StringName(request.get("kind", &"")) == &"party_selection_requested":
 					if _open_party_selection():
@@ -7256,6 +7283,7 @@ func _refresh_party_summary() -> void:
 	var happiness: Array = []
 	var own_ot: Array = []
 	var held_items: Array = []
+	var levels: Array = []
 	var id_numbers: Array = []
 	for member: Variant in save.party:
 		if member is Gen2SaveMon:
@@ -7265,6 +7293,7 @@ func _refresh_party_summary() -> void:
 			happiness.append(int(mon.happiness))
 			own_ot.append(_is_own_mon(save, mon))
 			held_items.append(int(mon.item))
+			levels.append(int(mon.level))
 			id_numbers.append(int(mon.ot_id))
 			species.append(int(mon.species))
 			# CheckPartyMove walks every slot's four move slots; zeroes are empty
@@ -7303,6 +7332,10 @@ func _refresh_party_summary() -> void:
 			## `OmanyteChamber` walks MON_ITEM backwards for a WATER STONE, which
 			## is the one routine that reads a held item off the mirror.
 			"held_items": held_items,
+			## `BattleTower_LevelCheck` walks MON_LEVEL against the level group
+			## the player chose, and `BattleTower_UbersCheck` walks it beside
+			## the species list.
+			"levels": levels,
 			## `CheckForLuckyNumberWinners` compares the show's number against
 			## every ID in the party and then against every one in storage, so
 			## the boxes come over as one list the way its three passes add up.

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -781,6 +781,9 @@ static func command_at(
 					command["map_group"] = int(data[offset + 2])
 					command["map_number"] = int(data[offset + 3])
 					return command
+				0xA4: # battletowertext, a BATTLETOWERTEXT_* index
+					command["value"] = int(data[offset + 1])
+					return command
 				0xA8: # wait, in units of six frames
 					command["value"] = int(data[offset + 1])
 					return command

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -47,6 +47,11 @@ var _staged_lucky_number_day: int = 0
 var _staged_caught_species: Dictionary = {}
 var _staged_best_magikarp: Dictionary = {}
 var _staged_blue_card_balance: int = -1
+## `wBT_OTTrainer`, which `LoadOpponentTrainerAndPokemon` fills and both
+## `BattleTowerBattle` and `battletowertext` read back.
+var _battle_tower_opponent: Dictionary = {}
+## `wBT_TrainerTextIndex`, the personality the greeting rolled. -1 until one has.
+var _battle_tower_text_index: int = -1
 var _staged_mom_savings_flags: int = -1
 ## `SFX_TRANSACTION` and the `WaitSFX` behind it, which stand between the
 ## transfer and the box that reports it.
@@ -197,6 +202,42 @@ const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
 ## tables disagree on, so `special_index()` leaves it alone. `MoveDeletion` owns
 ## the same shape `NameRater` does, one house further on, so it is one host
 ## request as well.
+## The Battle Tower's own six specials, Crystal's alone. `BattleTowerAction` is
+## one routine reached with a `setval` in front of it, `BattleTowerRoomMenu` and
+## `Menu_ChallengeExplanationCancel` are the two menus the receptionist opens,
+## `LoadOpponentTrainerAndPokemon...` samples the next opponent and
+## `BattleTowerBattle` fights it. `CheckForBattleTowerRules` is the party check
+## in front of the whole challenge.
+const SPECIAL_BATTLE_TOWER_ROOM_MENU: int = 116
+const SPECIAL_BATTLE_TOWER_BATTLE: int = 119
+const SPECIAL_LOAD_BATTLE_TOWER_OPPONENT: int = 122
+const SPECIAL_CHECK_BATTLE_TOWER_RULES: int = 124
+const SPECIAL_BATTLE_TOWER_ACTION: int = 134
+const SPECIAL_CHALLENGE_MENU: int = 136
+## `TryQuickSave`, which the challenge asks for before it starts, and `Reset`,
+## `home/init.asm`'s own soft reset of the console. Both are in the link block of
+## `SpecialsPointers` and neither is link play: the tower is the only thing in
+## either corpus that reaches them.
+const SPECIAL_TRY_QUICK_SAVE: int = 4
+const SPECIAL_RESET: int = 126
+## `Menu_ChallengeExplanationCancel`'s own answers: the three rows are 1 to 3 and
+## B is 4, which is why `Script_Menu_ChallengeExplanationCancel` tests only 1 and
+## 2 and treats everything else as leaving.
+const CHALLENGE_MENU_CHALLENGE: int = 1
+const CHALLENGE_MENU_EXPLANATION: int = 2
+const CHALLENGE_MENU_CANCEL: int = 4
+## What `special BattleTowerRoomMenu` leaves in wScriptVar: zero for a chosen
+## room, `$a` for a cancelled menu. `Script_ChooseChallenge` branches on both and
+## treats anything else as the mobile error it cannot reach here.
+const ROOM_MENU_CHOSEN: int = 0
+const ROOM_MENU_CANCELLED: int = 0x0A
+## `wcd49`, which `BattleTower_UbersCheck` copies the offending member's name
+## into and `Text_UberRestriction` prints as `text_ram`.
+const BATTLE_TOWER_NAME_BUFFER: int = 0xCD49
+## `wNrOfBeatenBattleTowerTrainers`, the WRAM copy the room script `readmem`s
+## after each win.
+const BEATEN_TRAINERS_ADDRESS: int = 0xCF64
+
 const SPECIAL_MOVE_DELETION: int = 33
 ## MoveTutor, 131, Crystal's alone: pokegold's SpecialsPointers has no row for
 ## it and no Gold or Silver script reaches one. `MoveTutor` owns the party list
@@ -669,6 +710,19 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 				"source": _request.duplicate(true),
 			}
 			return _waiting_result()
+		if pending_type == &"menu" and _pending_tag() == &"battle_tower_challenge_menu":
+			## `Function17d246`: a row answers its own one-based number and B
+			## answers the same 4 the routine writes before it opens the menu.
+			_pending = {}
+			_script_value = CHALLENGE_MENU_CANCEL if choice < 0 else choice + 1
+			return advance()
+		if pending_type == &"menu" and _pending_tag() == &"battle_tower_room_menu":
+			return _resolve_room_menu(choice)
+		## The two refusals the room menu prints put its jumptable back at zero
+		## rather than leaving the routine, so the menu opens again behind them.
+		if pending_type == &"text" and _pending_tag() == &"battle_tower_room_refusal":
+			_pending = {}
+			return _stage_room_menu()
 		if pending_type == &"menu" and _pending_tag() == &"buenas_password":
 			## `STATICMENU_DISABLE_B`: B does not close the list, so the only way
 			## out is a row. The answer is whether it is the row the byte's own
@@ -1245,6 +1299,9 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## `_Diploma`, `_PrintDiploma` and `_UnownPrinter` write nothing either:
 		## the page stands until a button and the script runs on behind it.
 		&"diploma_requested", &"unown_printer_requested",
+		## `TryQuickSave` answers TRUE for a save that was written and FALSE for
+		## one that was not, which is the branch both of its sites read.
+		&"quick_save_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -1314,8 +1371,28 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 	if String(outcome).is_empty():
 		return _fail(&"invalid_battle_outcome", result)
 	var battle_values: Dictionary = request.get("values", {})
+	if outcome == Gen2WorldBattleAdapter.OUTCOME_LOST \
+		and StringName(battle_values.get("kind", &"")) == &"battle_tower":
+		## The tower's own loss: `RunBattleTowerTrainer` heals the party and
+		## returns, and the room script warps the player out. There is no
+		## `reloadmapafterbattle` anywhere in it, so nothing blacks out.
+		_battle_tower_opponent = {}
+		_script_value = BATTLE_RESULT_LOSE
+		_events.append({
+			"type": &"battle_lost",
+			"outcome": outcome,
+			"battle_tower": true,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
+		return advance()
 	if outcome == Gen2WorldBattleAdapter.OUTCOME_LOST and bool(battle_values.get("can_lose", false)):
-		_script_value = 0
+		## `Script_startbattle` writes `wBattleResult & ~BATTLERESULT_BITMASK`
+		## whatever the battle type was, so a lost CANLOSE battle answers LOSE.
+		## Cherrygrove's three sites are the only ones in either corpus and their
+		## two branches print the same text, which is what hid a zero here.
+		_script_value = BATTLE_RESULT_LOSE
 		_events.append({
 			"type": &"battle_lost",
 			"outcome": outcome,
@@ -1371,6 +1448,28 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 	if outcome != Gen2WorldBattleAdapter.OUTCOME_WON:
 		return _fail(StringName("battle_%s" % outcome), result)
 
+	if StringName(battle_values.get("kind", &"")) == &"battle_tower":
+		## `RunBattleTowerTrainer`'s win branch: the SRAM count is read back into
+		## `wNrOfBeatenBattleTowerTrainers`, which the room script's `readmem`
+		## then compares against the streak length, and the same number plus
+		## `'1'` goes into wStringBuffer3 for "Next up, opponent no. N".
+		var beaten: int = _battle_tower().beaten
+		var counted: Dictionary = _stage_script_memory(BEATEN_TRAINERS_ADDRESS, beaten)
+		if not bool(counted.get("ok", true)):
+			return counted
+		_set_text_buffer(
+			RomLayout.STRING_BUFFER_3, str(beaten + 1), &"battle_tower_opponent"
+		)
+		_battle_tower_opponent = {}
+		_script_value = BATTLE_RESULT_WIN
+		_events.append({
+			"type": &"battle_completed",
+			"outcome": outcome,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
+		return advance()
 	_stage_just_battled(true)
 	## Script_startbattle leaves `wBattleResult & ~BATTLERESULT_BITMASK` in
 	## wScriptVar, and WIN is zero there, so the eight corpus scripts that put
@@ -2339,6 +2438,10 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 			_events.append({"type": &"credits_requested"})
 		0xA1:
 			return _stage_warp_facing_request(command)
+		0xA2:
+			## Crystal's own `battletowertext`, raw $a4. Gold and Silver's
+			## command table stops at $a1, so nothing of theirs reaches here.
+			return _stage_battle_tower_text(int(command.get("value", 1)))
 	## The commands whose case above falls out of the match rather than returning
 	## a result of its own. The four that now wait (`showemote`, `earthquake`,
 	## `pause` and `deactivatefacing`) return from inside it and are not here.
@@ -2982,6 +3085,38 @@ func _execute_special(special: int) -> Dictionary:
 				"special": special,
 				"mode": &"pokemon_center",
 			})
+		SPECIAL_BATTLE_TOWER_ACTION:
+			## `jumptable .dw, wScriptVar`: the `setval` in front of the special
+			## names the row, and the row's own answer replaces it.
+			var answered: int = _battle_tower().action(_script_value, {
+				"party": _battle_tower_party(),
+				"pack": _pack_items(),
+				"save_is_yours": true,
+				"random": _battle_tower_random(0),
+			})
+			if answered >= 0:
+				_script_value = answered
+			return {"ok": true}
+		SPECIAL_CHECK_BATTLE_TOWER_RULES:
+			return _check_battle_tower_rules()
+		SPECIAL_TRY_QUICK_SAVE:
+			return _stage_runtime_request(&"quick_save_requested", {"special": special})
+		SPECIAL_RESET:
+			## The console restarting, which is how a saved-and-left challenge
+			## leaves the battle room. Nothing follows it in any script.
+			_events.append({"type": &"soft_reset_requested"})
+			_pending = {}
+			_active = false
+			_completed = true
+			return {"ok": true}
+		SPECIAL_CHALLENGE_MENU:
+			return _stage_challenge_menu()
+		SPECIAL_BATTLE_TOWER_ROOM_MENU:
+			return _stage_room_menu()
+		SPECIAL_LOAD_BATTLE_TOWER_OPPONENT:
+			return _load_battle_tower_opponent()
+		SPECIAL_BATTLE_TOWER_BATTLE:
+			return _stage_battle_tower_battle()
 		SPECIAL_SET_DAY_OF_WEEK:
 			_stage_day_of_week_menu()
 			return {"ok": true}
@@ -3927,6 +4062,271 @@ func _mom_result(staged: Dictionary) -> Dictionary:
 ## claims the box and the cartridge's index wherever nothing does. Read as a
 ## name, so an index is simply not one: comparing the two is an engine error
 ## rather than a false answer.
+## `BattleTowerRoomMenu_UpdatePickLevelMenu`'s `.a_button` and `.b_button`: the
+## CANCEL row and B both leave with `$a` in wScriptVar, and a level row is
+## refused by either check before it is stored.
+func _resolve_room_menu(choice: int) -> Dictionary:
+	var groups: int = int(_pending.get("groups", RomLayout.BATTLETOWER_LEVEL_GROUPS))
+	_pending = {}
+	if choice < 0 or choice >= groups:
+		_script_value = ROOM_MENU_CANCELLED
+		return advance()
+	var tower: Gen2BattleTower = _battle_tower()
+	tower.chosen_group = choice + 1
+	var party: Dictionary = _battle_tower_party()
+	if Gen2BattleTower.level_check(party, tower.chosen_group) >= 0:
+		return _stage_room_menu_refusal("party_mon_tops_this_level")
+	var uber: int = Gen2BattleTower.ubers_check(party, tower.chosen_group)
+	if uber >= 0:
+		var names: Array = (_request.get("party", {}) as Dictionary).get("names", [])
+		return _stage_room_menu_refusal(
+			"uber_restriction", String(names[uber]) if uber < names.size() else ""
+		)
+	_script_value = ROOM_MENU_CHOSEN
+	return advance()
+
+
+## The Battle Tower's own SRAM section, which the runner writes in place: every
+## byte of it is one the cartridge writes through `OpenSRAM` straight away, with
+## no transaction between the receptionist and the section.
+func _battle_tower() -> Gen2BattleTower:
+	return state.battle_tower() if state != null else Gen2BattleTower.new()
+
+
+## The tower's own generator. `Random` is the cartridge's one RNG and this
+## runner is scene free, so the seed comes in with the request and each draw
+## takes its own offset: the opponent, its three lines and the reward are four
+## separate rolls in the source and must not repeat here.
+func _battle_tower_random(offset: int) -> RandomNumberGenerator:
+	var random := RandomNumberGenerator.new()
+	random.seed = int(_request.get("battle_tower_seed", randi())) + offset
+	return random
+
+
+## The item pocket as `BattleTower_GiveReward` walks it, staged rows over the
+## saved ones. A row staged to zero is one the script has just spent and is not
+## in the pack any more.
+func _pack_items() -> Dictionary:
+	var pack: Dictionary = state.items() if state != null else {}
+	for item: Variant in _staged_items:
+		var quantity: int = int(_staged_items[item])
+		if quantity > 0:
+			pack[item] = quantity
+		else:
+			pack.erase(item)
+	return pack
+
+
+## The cartridge's own Battle Tower block, empty when there is no cache behind
+## the runner at all, which is what the specials probe runs with.
+func _battle_tower_data() -> Dictionary:
+	return data.battle_tower() if data != null else {}
+
+
+## The party facts the tower's own checks read, off the read-only mirror.
+func _battle_tower_party() -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	return {
+		"species": party.get("species", []),
+		"levels": party.get("levels", []),
+		"held_items": party.get("held_items", []),
+		"eggs": party.get("eggs", []),
+	}
+
+
+## `_CheckForBattleTowerRules`: every rule is run rather than stopping at the
+## first failure, so a party can fail more than one and the receptionist says so
+## once per failure. `BattleTower_PleaseReturnWhenReady` closes the run.
+##
+## wScriptVar is TRUE when something failed, which is what
+## `ifnotequal FALSE, Script_WaitButton` refuses the challenge on.
+func _check_battle_tower_rules() -> Dictionary:
+	var failures: Array = Gen2BattleTower.rule_failures(_battle_tower_party())
+	if failures.is_empty():
+		_script_value = 0
+		return {"ok": true}
+	_script_value = 1
+	## `ld [hl], '3'` at the top of the routine: the box that names how many may
+	## be entered prints the number out of `wStringBuffer2` rather than spelling
+	## it, so a party of the wrong size is told the rule and not just refused.
+	_set_text_buffer(
+		RomLayout.STRING_BUFFER_2, str(Gen2BattleTower.PARTY_LENGTH), &"battle_tower_rules"
+	)
+	var boxes: Array = [_special_box("battle_tower", "excuse_me")]
+	for failure: String in failures:
+		boxes.append(_special_box("battle_tower", failure))
+	boxes.append(_special_box("battle_tower", "return_when_ready"))
+	for box: String in boxes:
+		if box.is_empty():
+			return _fail(
+				&"missing_special_text", {"special": SPECIAL_CHECK_BATTLE_TOWER_RULES}
+			)
+	var head: String = String(boxes.pop_front())
+	return _stage_internal_text(head, false, {
+		"special": &"battle_tower_rules", "next_internal_texts": boxes,
+	})
+
+
+## `Menu_ChallengeExplanationCancel`, a three-row `VerticalMenu` whose rows are
+## the cartridge's own strings. A row answers its own one-based number and B
+## answers 4, which is why the script tests only Challenge and Explanation.
+func _stage_challenge_menu() -> Dictionary:
+	var rows: Array = (_battle_tower_data().get("menu_rows", []) as Array).duplicate()
+	if rows.size() != RomLayout.BATTLETOWER_CHALLENGE_MENU_ROWS:
+		return _fail(&"missing_battle_tower_menu", {"special": SPECIAL_CHALLENGE_MENU})
+	_pending = {
+		"type": &"menu",
+		"command": &"challenge_menu",
+		"options": rows,
+		## `MenuHeader_ChallengeExplanationCancel`: `menu_coords 0, 0, 14, 7`,
+		## `db 1` for the row the cursor opens on, and its own two menu flags.
+		"header": {
+			"default": 1,
+			"data_flags": Gen2MenuBox.STATICMENU_CURSOR | Gen2WorldMenu.STATICMENU_WRAP,
+			"left": 0, "top": 0, "right": 14, "bottom": 7,
+		},
+		## `Script_Menu_ChallengeExplanationCancel` writes its question and then
+		## opens the menu over it, so the box already on screen is the prompt.
+		"text": _standing_text,
+		"special": &"battle_tower_challenge_menu",
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+## `BattleTowerRoomMenu_PlacePickLevelMenu`: four rooms before the Hall of Fame
+## and all ten after it, CANCEL behind either.
+func _stage_room_menu() -> Dictionary:
+	var rows: Array = (_battle_tower_data().get("level_rows", []) as Array).duplicate()
+	if rows.size() != RomLayout.BATTLETOWER_LEVEL_ROWS:
+		return _fail(&"missing_battle_tower_menu", {"special": SPECIAL_BATTLE_TOWER_ROOM_MENU})
+	var groups: int = RomLayout.BATTLETOWER_LEVEL_GROUPS if _hall_of_fame_entered() \
+		else Gen2BattleTower.PRE_HALL_OF_FAME_GROUPS
+	var options: Array = rows.slice(0, groups)
+	options.append(rows[RomLayout.BATTLETOWER_LEVEL_GROUPS])
+	_pending = {
+		"type": &"menu",
+		"command": &"battle_tower_room",
+		"options": options,
+		## `MenuHeader_119cf7`'s own `menu_coords 12, 7, SCREEN_WIDTH - 1,
+		## TEXTBOX_Y - 1`, the window `BattleTowerRoomMenu_PlacePickLevelMenu`
+		## opens beside the message it prints.
+		"header": {
+			"default": 1,
+			"data_flags": Gen2MenuBox.STATICMENU_CURSOR | Gen2WorldMenu.STATICMENU_WRAP,
+			"left": 12, "top": 7, "right": 19, "bottom": 11,
+		},
+		"text": String((_battle_tower_data().get("menu_text", {}) as Dictionary).get(
+			"what_level", ""
+		)),
+		"special": &"battle_tower_room_menu",
+		"groups": groups,
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+func _hall_of_fame_entered() -> bool:
+	return state != null and state.hall_of_fame()
+
+
+## One of the room menu's two refusals, printed and then followed by the menu
+## again: `BattleTowerRoomMenu_DelayRestartMenu` puts the jumptable back at zero
+## rather than leaving the routine.
+func _stage_room_menu_refusal(name: String, buffer_name: String = "") -> Dictionary:
+	var text: String = String(
+		(_battle_tower_data().get("menu_text", {}) as Dictionary).get(name, "")
+	)
+	if text.is_empty():
+		return _fail(
+			&"missing_special_text", {"special": SPECIAL_BATTLE_TOWER_ROOM_MENU}
+		)
+	if not buffer_name.is_empty():
+		## `Text_UberRestriction` is `text_ram wcd49`, which
+		## `BattleTower_UbersCheck` fills with the offending member's name.
+		text = Gen2TextStream.fill_all_markers(
+			text, "%s%04X>" % [Gen2TextStream.RAM_MARKER, BATTLE_TOWER_NAME_BUFFER],
+			buffer_name
+		)
+	return _stage_internal_text(text, false, {
+		"special": &"battle_tower_room_refusal",
+	})
+
+
+## `LoadOpponentTrainerAndPokemonWithOTSprite`. The sampled trainer and team go
+## into the runner's own `wBT_OTTrainer`, and the sprite the class carries is
+## given to the map object `wScriptVar` names, which the battle room's own
+## `setval BATTLETOWERBATTLEROOM_YOUNGSTER` chose.
+func _load_battle_tower_opponent() -> Dictionary:
+	var opponent: Dictionary = _battle_tower().load_opponent(data, _battle_tower_random(1))
+	if opponent.is_empty():
+		return _fail(
+			&"missing_battle_tower_data", {"special": SPECIAL_LOAD_BATTLE_TOWER_OPPONENT}
+		)
+	var mons: Array = []
+	for mon: Gen2SaveMon in opponent["mons"] as Array:
+		mons.append(mon.to_dict())
+	_battle_tower_opponent = {
+		"trainer": int(opponent["trainer"]),
+		"name": String(opponent["name"]),
+		"class": int(opponent["class"]),
+		"mons": mons,
+	}
+	_events.append({
+		"type": &"battle_tower_opponent_loaded",
+		"object": _script_value,
+		"sprite": Gen2BattleTower.class_sprite(data, int(opponent["class"])),
+		"trainer": int(opponent["trainer"]),
+		"trainer_class": int(opponent["class"]),
+		"name": String(opponent["name"]),
+	})
+	return {"ok": true}
+
+
+## `BattleTowerBattle`, which is `RunBattleTowerTrainer` around one
+## `predef StartBattle`: the party is healed on the way in and on the way out,
+## SET MODE is forced for the fight, and `wBattleResult` is what the room script
+## reads afterwards.
+func _stage_battle_tower_battle() -> Dictionary:
+	if _battle_tower_opponent.is_empty():
+		return _fail(
+			&"missing_battle_tower_opponent", {"special": SPECIAL_BATTLE_TOWER_BATTLE}
+		)
+	## `CopyBTTrainer_FromBT_OT_TowBT_OTTemp` runs in front of the battle, so the
+	## challenge is in progress and the trainer counted before a blow is struck.
+	var tower: Gen2BattleTower = _battle_tower()
+	tower.challenge_state = Gen2BattleTower.CHALLENGE_IN_PROGRESS
+	tower.beaten = mini(tower.beaten + 1, Gen2BattleTower.STREAK_LENGTH)
+	return _stage_runtime_request(&"battle_requested", {
+		"kind": &"battle_tower",
+		"special": SPECIAL_BATTLE_TOWER_BATTLE,
+		## `set BATTLE_SHIFT, [hl]` for the length of the fight and
+		## `farcall HealParty` on both sides of it.
+		"force_switch_mode": true,
+		"heal_party": true,
+		"trainer_class": int(_battle_tower_opponent["class"]),
+		"trainer_name": String(_battle_tower_opponent["name"]),
+		"enemy_party": (_battle_tower_opponent["mons"] as Array).duplicate(true),
+	})
+
+
+## `battletowertext`, which is `BattleTowerText` for the opponent's own class:
+## the greeting rolls a personality and the win and loss lines read the same one
+## back, so all three come from one trainer rather than three.
+func _stage_battle_tower_text(kind: int) -> Dictionary:
+	if _battle_tower_opponent.is_empty():
+		return _fail(&"missing_battle_tower_opponent", {"kind": kind})
+	var line: Dictionary = _battle_tower().trainer_line(
+		data, int(_battle_tower_opponent["class"]), clampi(kind - 1, 0, 2),
+		_battle_tower_random(1 + kind), _battle_tower_text_index
+	)
+	_battle_tower_text_index = int(line["index"])
+	var text: String = String(line["text"])
+	if text.is_empty():
+		return _fail(&"missing_battle_tower_text", {"kind": kind})
+	return _stage_internal_text(text, false)
+
+
 func _pending_tag() -> StringName:
 	var tag: Variant = _pending.get("special", &"")
 	return tag if tag is StringName else &""

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -574,8 +574,8 @@ func _advance_mart_text() -> void:
 ## because `ScrollingMenu_InitFlags` adds it to the row count and `.d_down`
 ## stops scrolling at `size - height`.
 func _mart_row_count() -> int:
-	var size: int = _mart_list().size()
-	return size + 1 if size < Gen2MartPage.LIST_HEIGHT else Gen2MartPage.LIST_HEIGHT
+	var rows: int = _mart_list().size()
+	return rows + 1 if rows < Gen2MartPage.LIST_HEIGHT else Gen2MartPage.LIST_HEIGHT
 
 
 ## Whichever of the shop's stock and the player's pack the stage is showing.
@@ -1653,13 +1653,13 @@ func _open_box_naming() -> void:
 ## `.Name`'s tail: whatever `NamingScreen_StoreEntry` left is written straight
 ## back over the box's name, and an empty entry is the default name again rather
 ## than a blank label.
-func _on_box_named(name: String) -> void:
+func _on_box_named(entered: String) -> void:
 	if _naming != null:
 		Gen2Screen.drop(_naming)
 		_naming = null
 	_set_overlay_open(false)
 	if _save != null:
-		_save.set_box_name(_box_submenu_index, name)
+		_save.set_box_name(_box_submenu_index, entered)
 	_open_box_list()
 
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -293,6 +293,11 @@ var _buenas_password: int = 0
 ## own `ifequal` in front of the award, not a rule the byte enforces.
 var _blue_card_balance: int = 0
 
+## `SECTION "SRAM Battle Tower"`, which the cartridge keeps beside the save
+## rather than inside it because a challenge can be saved and left between
+## battles. Never null; see [Gen2BattleTower].
+var _battle_tower: Gen2BattleTower = Gen2BattleTower.new()
+
 
 func _init(
 	initial_event_flags: Dictionary = {}, initial_map_scenes: Dictionary = {},
@@ -420,6 +425,7 @@ func to_dict() -> Dictionary:
 		"mom_savings_flags": _mom_savings_flags,
 		"blue_card_balance": _blue_card_balance,
 		"buenas_password": _buenas_password,
+		"battle_tower": _battle_tower.to_dict(),
 	}
 
 
@@ -532,6 +538,9 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored._mom_savings_flags = int(source.get("mom_savings_flags", 0)) & 0xFF
 	restored._blue_card_balance = int(source.get("blue_card_balance", 0)) & 0xFF
 	restored._buenas_password = int(source.get("buenas_password", 0)) & 0xFF
+	## Defaults rather than versioning: a slot written before the tower existed
+	## reads as one with no challenge in it, which is the truth about it.
+	restored._battle_tower = Gen2BattleTower.from_dict(source.get("battle_tower", {}))
 	return restored
 
 
@@ -598,7 +607,15 @@ func restore_from_dict(raw: Variant) -> void:
 	_mom_savings_flags = restored._mom_savings_flags
 	_blue_card_balance = restored._blue_card_balance
 	_buenas_password = restored._buenas_password
+	_battle_tower = restored._battle_tower
 	changed.emit()
+
+
+## The live Battle Tower record, which callers edit in place: every write to it
+## is a write to SRAM the cartridge would have made straight away, and there is
+## no transaction between the receptionist and the section.
+func battle_tower() -> Gen2BattleTower:
+	return _battle_tower
 
 
 func maptile_decoration(category: StringName) -> int:

--- a/project.godot
+++ b/project.godot
@@ -36,7 +36,7 @@ window/handheld/orientation=6
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/gut/plugin.cfg")
+enabled=PackedStringArray("res://addons/gut/plugin.cfg", "res://addons/warning_scan/plugin.cfg")
 
 [input_devices]
 

--- a/tests/integration/test_battle_move_forget.gd
+++ b/tests/integration/test_battle_move_forget.gd
@@ -105,9 +105,9 @@ func _drain_box() -> void:
 			return
 
 
-func _press(button: int) -> void:
+func _step(button: int) -> void:
 	_settle_bars()
-	await _drain_box()
+	_drain_box()
 	_screen._answer_forget(button)
 	await get_tree().process_frame
 
@@ -138,13 +138,13 @@ func test_choosing_a_slot_forgets_that_move_and_learns_the_offered_one() -> void
 	var battle: Gen2Battle = _screen.get("_battle")
 	await _advance_to_offer()
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "list")
 	assert_eq((_screen.get("_forget_moves") as Array).size(), 4)
 
 	## Slot 1 is Ember, an ordinary move.
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "", "the offer is answered")
 	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
 	assert_eq(battle.player.moves[1], BattleFixture.SLASH)
@@ -157,13 +157,13 @@ func test_an_hm_row_is_refused_and_the_list_stays_open() -> void:
 	await _open_with_full_moveset(MOVE_SURF)
 	var battle: Gen2Battle = _screen.get("_battle")
 	await _advance_to_offer()
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "list")
 
 	## Slot 2 is SURF.
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
 
 	assert_eq(_stage(), "list", "the list stays open")
 	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
@@ -182,11 +182,11 @@ func test_refusing_reaches_stop_learning_and_declines_the_move() -> void:
 	await _advance_to_offer()
 	var before: Array = battle.player.moves.duplicate()
 
-	await _press(Gen2Button.RIGHT)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.RIGHT)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "stop")
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "")
 	assert_false(battle.must_learn_move(Gen2Battle.PLAYER))
 	assert_eq(battle.player.moves, before, "nothing was forgotten")
@@ -198,12 +198,12 @@ func test_declining_to_stop_returns_to_the_ask() -> void:
 	var battle: Gen2Battle = _screen.get("_battle")
 	await _advance_to_offer()
 
-	await _press(Gen2Button.RIGHT)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.RIGHT)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "stop")
 
-	await _press(Gen2Button.RIGHT)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.RIGHT)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "ask")
 	assert_true(battle.must_learn_move(Gen2Battle.PLAYER))
 	assert_eq(_screen.get("_forget_confirm_cursor"), 0, "YesNoBox reopens on YES")
@@ -227,8 +227,8 @@ func test_a_confirm_pages_the_prompt_before_answering_it() -> void:
 func test_backing_out_of_the_list_reaches_stop_learning() -> void:
 	await _open_with_full_moveset()
 	await _advance_to_offer()
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "list")
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "stop")

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -110,7 +110,7 @@ func _read_question() -> void:
 	await get_tree().process_frame
 
 
-func _press(button: int) -> void:
+func _step(button: int) -> void:
 	_settle_bars()
 	# A press cannot finish a printing page, so the page is read first, which is
 	# what a player waits through.
@@ -146,9 +146,9 @@ func test_no_sends_the_trainer_out_and_leaves_the_player_standing() -> void:
 	await _advance_to("offer")
 	await _read_question()
 
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(_cursor(), 1)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 
 	assert_eq(_stage(), "", "the question is answered")
 	assert_eq(battle.awaiting_switch_offer(), -1)
@@ -164,7 +164,7 @@ func test_b_is_the_same_answer_as_no() -> void:
 	await _advance_to("offer")
 	await _read_question()
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "")
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0)
 
@@ -177,15 +177,15 @@ func test_yes_opens_the_party_list_and_the_chosen_row_switches() -> void:
 	await _advance_to("offer")
 	await _read_question()
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
 	assert_true(_layer().visible)
 	assert_eq(_layer().position, Vector2.ZERO, "the list is the whole screen")
 	assert_false((_screen.get("_box") as Gen2TextBox).visible, "and the battle's box is not")
 
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(_cursor(), 1)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 
 	assert_eq(_stage(), "")
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the player switched too")
@@ -200,9 +200,9 @@ func test_the_one_already_out_is_refused_and_the_list_comes_back() -> void:
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
 	await _advance_to("offer")
 	await _read_question()
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "refused")
 	assert_true(
 		String(_screen.battle_snapshot()["message"]).contains("is already out"),
@@ -212,7 +212,7 @@ func test_the_one_already_out_is_refused_and_the_list_comes_back() -> void:
 
 	## One press, which is the one `StdBattleTextbox` was waiting for: the line is
 	## read first and a press cannot shorten the reading.
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick", "the list is redrawn")
 	assert_true(_layer().visible)
 
@@ -223,9 +223,9 @@ func test_cancelling_the_list_is_the_same_answer_as_no() -> void:
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.switch_to(1)])
 	await _advance_to("offer")
 	await _read_question()
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "")
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0)
 	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
@@ -264,19 +264,19 @@ func test_baton_pass_opens_a_list_that_cannot_be_backed_out_of() -> void:
 	assert_true(bool(_screen.battle_snapshot()["switch_forced"]))
 	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "pick", "B is swallowed")
 	assert_eq(battle.awaiting_baton_pass(), Gen2Battle.PLAYER)
 
 	## Two rows and CANCEL, so two presses down reach it.
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(_cursor(), 2)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick", "and so is the CANCEL row")
 
-	await _press(Gen2Button.UP)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.UP)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "")
 	assert_eq(battle.awaiting_baton_pass(), -1)
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the pass landed on the row chosen")
@@ -341,7 +341,7 @@ func test_a_wild_faint_asks_whether_to_use_the_next_pokemon() -> void:
 	assert_true(_layer().visible)
 	assert_eq(_cursor(), 0, "YesNoMenuHeader opens on YES")
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick", "ForcePlayerMonChoice, with no press in between")
 	assert_eq(String(_screen.battle_snapshot()["switch_reason"]), "replace")
 	assert_true(bool(_screen.battle_snapshot()["switch_forced"]))
@@ -355,7 +355,7 @@ func test_no_runs_from_the_wild_battle_instead_of_replacing() -> void:
 	await _advance_to("use_next")
 	await _read_question()
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "")
 	assert_true(battle.has_fled())
 	assert_true(bool(_screen.battle_snapshot()["battle_over"]))
@@ -369,18 +369,18 @@ func test_a_trainer_faint_opens_a_replacement_list_with_no_way_out() -> void:
 	await _advance_to("pick")
 
 	assert_eq(String(_screen.battle_snapshot()["switch_reason"]), "replace")
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "pick", "B is swallowed")
 
 	## Two rows and CANCEL, so two presses down reach a row that refuses too.
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(_cursor(), 2)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
 
-	await _press(Gen2Button.UP)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.UP)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "")
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1)
 	assert_false(battle.awaiting_replacement())
@@ -393,7 +393,7 @@ func test_the_fainted_row_is_refused_and_the_list_comes_back() -> void:
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
 	await _advance_to("pick")
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "refused")
 	assert_true(
 		String(_screen.battle_snapshot()["message"]).contains("no will to battle"),
@@ -401,7 +401,7 @@ func test_the_fainted_row_is_refused_and_the_list_comes_back() -> void:
 	)
 	assert_true(battle.must_replace(Gen2Battle.PLAYER), "and nothing was answered")
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick", "the list is redrawn")
 	assert_true(bool(_screen.battle_snapshot()["switch_forced"]), "still with no way out")
 
@@ -418,8 +418,8 @@ func test_shift_offers_a_switch_when_the_trainer_replaces_its_own_faint() -> voi
 	assert_eq(battle.party(Gen2Battle.ENEMY).active, 0, "nobody is out yet")
 
 	await _read_question()
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "")
 	assert_eq(battle.party(Gen2Battle.ENEMY).active, 1)
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 0, "and the player stayed")
@@ -480,15 +480,15 @@ func test_the_battle_menu_walks_its_two_by_two_and_does_not_wrap() -> void:
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
 	await _advance_to_menu()
 
-	await _press(Gen2Button.LEFT)
+	await _step(Gen2Button.LEFT)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.FIGHT)
-	await _press(Gen2Button.RIGHT)
+	await _step(Gen2Button.RIGHT)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PKMN)
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.RUN)
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.RUN)
-	await _press(Gen2Button.LEFT)
+	await _step(Gen2Button.LEFT)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PACK)
 
 
@@ -499,16 +499,16 @@ func test_fight_opens_the_move_list_and_the_chosen_row_is_the_move_used() -> voi
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
 	await _advance_to_menu()
 
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_menu_stage(), "move")
 	var rows: Array = _screen.battle_snapshot()["move_rows"]
 	assert_eq(rows.size(), 2, "two moves, two rows")
 	assert_eq(int((rows[0] as Dictionary)["move"]), BattleFixture.TACKLE)
 
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(int(_screen.battle_snapshot()["move_cursor"]), 1)
 	var before: int = battle.mon(Gen2Battle.PLAYER).pp_left(1)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 
 	assert_eq(_menu_stage(), "", "the list is gone once the turn is taken")
 	assert_eq(battle.mon(Gen2Battle.PLAYER).pp_left(1), before - 1, "GROWL was used")
@@ -519,14 +519,14 @@ func test_the_move_cursor_wraps_and_b_goes_back_to_the_menu() -> void:
 	var battle: Gen2Battle = _menu_battle()
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
 	await _advance_to_menu()
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 
-	await _press(Gen2Button.UP)
+	await _step(Gen2Button.UP)
 	assert_eq(int(_screen.battle_snapshot()["move_cursor"]), 1, "wrapped to the last row")
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(int(_screen.battle_snapshot()["move_cursor"]), 0)
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_menu_stage(), "main", "B leaves the list for the menu behind it")
 
 
@@ -538,8 +538,8 @@ func test_a_move_with_no_pp_is_refused_and_the_list_comes_back() -> void:
 	await _advance_to_menu()
 	battle.mon(Gen2Battle.PLAYER).pp[0] = 0
 
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_menu_stage(), "refused")
 	assert_true(
 		String(_screen.battle_snapshot()["message"]).contains("no PP left"),
@@ -551,7 +551,7 @@ func test_a_move_with_no_pp_is_refused_and_the_list_comes_back() -> void:
 		box.finish()
 		if box.has_pages_left():
 			box.advance()
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_menu_stage(), "move", "and the list is back")
 
 
@@ -561,10 +561,10 @@ func test_run_leaves_the_wild_battle() -> void:
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
 	await _advance_to_menu()
 
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.RIGHT)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.RIGHT)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.RUN)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_menu_stage(), "")
 	assert_false(_screen.get("_pending").is_empty(), "the run is a turn's worth of events")
 
@@ -576,19 +576,19 @@ func test_pkmn_opens_a_party_list_that_can_be_cancelled_back_to_the_menu() -> vo
 	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
 	await _advance_to_menu()
 
-	await _press(Gen2Button.RIGHT)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.RIGHT)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
 	assert_eq(String(_screen.battle_snapshot()["switch_reason"]), "player")
 	assert_false(bool(_screen.battle_snapshot()["switch_forced"]), "and it can be left")
 
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "")
 	assert_eq(_menu_stage(), "main", "cancelling is a jp BattleMenu")
 
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
 	assert_eq(battle.party(Gen2Battle.PLAYER).active, 1, "the bench member came in")
 
 
@@ -601,7 +601,7 @@ func test_a_renderer_is_not_offered_input_while_a_menu_is_up() -> void:
 	await _advance_to("offer")
 	assert_false(_screen._renderer_input_free())
 	await _read_question()
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_true(_screen._renderer_input_free())
 
 
@@ -622,17 +622,17 @@ func test_the_pack_uses_an_item_on_the_chosen_member_and_spends_the_turn() -> vo
 	var bench: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
 	bench.hp = 1
 
-	await _press(Gen2Button.DOWN)
+	await _step(Gen2Button.DOWN)
 	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PACK)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_true(bool(_screen.get("_pack_selecting")), "the pack list is up")
 	assert_eq(_screen.selected_pack_item(), BattleFixture.POTION)
 
 	# The party list `UseItem_SelectMon` opens, and the bench member on it.
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
 
 	assert_eq(bench.hp, 21, "the potion landed on the bench member")
 	assert_eq(spent, [[BattleFixture.POTION, 1]], "and the world was told to spend it")
@@ -649,16 +649,16 @@ func test_the_item_target_list_takes_the_one_out_and_backs_out_to_the_pack() -> 
 	_screen.set_battle_pack([BattleFixture.POTION], {BattleFixture.POTION: 1})
 	battle.mon(Gen2Battle.PLAYER).hp = 1
 
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.B)
 	assert_eq(_stage(), "", "the list is gone")
 	assert_true(bool(_screen.get("_pack_selecting")), "and the pack is back")
 
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	## Healed to 21 and then hit, because the item spends the turn and the enemy
 	## still moves in it.
 	assert_gt(battle.mon(Gen2Battle.PLAYER).hp, 1, "used on the one that is out")
@@ -673,13 +673,13 @@ func test_an_x_item_needs_no_target_and_b_closes_the_pack() -> void:
 	await _advance_to_menu()
 	_screen.set_battle_pack([BattleFixture.X_ATTACK], {BattleFixture.X_ATTACK: 1})
 
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.B)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.B)
 	assert_eq(_menu_stage(), "main", "B is a jp BattleMenu")
 
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(battle.mon(Gen2Battle.PLAYER).stage("attack"), 1)
 	assert_eq(_stage(), "", "no target list for an item used on the one that is out")
 
@@ -695,14 +695,14 @@ func test_an_ether_asks_which_move_and_fills_that_slot() -> void:
 	user.pp[0] = 0
 	user.pp[1] = 0
 
-	await _press(Gen2Button.DOWN)
-	await _press(Gen2Button.A)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_true(bool(_screen.get("_pack_move_selecting")), "the move list is up")
 
-	await _press(Gen2Button.RIGHT)
-	await _press(Gen2Button.A)
+	await _step(Gen2Button.RIGHT)
+	await _step(Gen2Button.A)
 	assert_eq(user.pp_left(0), 0, "the slot it was not used on")
 	assert_gt(user.pp_left(1), 0, "and the one it was")

--- a/tests/integration/test_controls_settings.gd
+++ b/tests/integration/test_controls_settings.gd
@@ -47,7 +47,7 @@ func _open(button: int) -> Gen2BindingSheet:
 
 func _key(code: int, pressed: bool = true) -> InputEventKey:
 	var event := InputEventKey.new()
-	event.physical_keycode = code
+	event.physical_keycode = code as Key
 	event.pressed = pressed
 	return event
 
@@ -176,7 +176,7 @@ func test_a_stick_binds_when_it_returns_to_centre() -> void:
 
 func _motion(axis: int, value: float) -> InputEventJoypadMotion:
 	var event := InputEventJoypadMotion.new()
-	event.axis = axis
+	event.axis = axis as JoyAxis
 	event.axis_value = value
 	return event
 
@@ -287,16 +287,16 @@ func test_arrows_stay_inside_an_open_sheet() -> void:
 	inside[0].grab_focus()
 	for step: int in 12:
 		guard.move_focus(Vector2.DOWN)
-		var owner: Control = _host.get_viewport().gui_get_focus_owner()
+		var focused: Control = _host.get_viewport().gui_get_focus_owner()
 		assert_true(
-			owner == sheet or sheet.is_ancestor_of(owner),
+			focused == sheet or sheet.is_ancestor_of(focused),
 			"down %d stayed in the sheet" % step
 		)
 	for step: int in 12:
 		guard.move_focus(Vector2.UP)
-		var owner: Control = _host.get_viewport().gui_get_focus_owner()
+		var focused: Control = _host.get_viewport().gui_get_focus_owner()
 		assert_true(
-			owner == sheet or sheet.is_ancestor_of(owner), "up %d" % step
+			focused == sheet or sheet.is_ancestor_of(focused), "up %d" % step
 		)
 	sheet.close()
 	await get_tree().process_frame

--- a/tests/integration/test_intro_screen.gd
+++ b/tests/integration/test_intro_screen.gd
@@ -67,7 +67,7 @@ func _settle_splash(limit: int = 800) -> void:
 ## fades, pic moves and `DelayFrames` are real frame counts, so a test drives
 ## them rather than skipping them; there is no clock in a GUT run.
 func _settle(limit: int = 40) -> void:
-	for _pass: int in limit:
+	for _step: int in limit:
 		var owed: int = _screen.animation_frames_left()
 		if owed == 0:
 			return

--- a/tests/integration/test_oak_speech.gd
+++ b/tests/integration/test_oak_speech.gd
@@ -29,7 +29,7 @@ func after_each() -> void:
 ## beats and the two pic moves are real frame counts, so a test drives them
 ## rather than skipping them; there is no clock in a GUT run.
 func _settle(limit: int = 40) -> void:
-	for _pass: int in limit:
+	for _step: int in limit:
 		if _screen.animation_frames_left() == 0:
 			return
 		_screen.advance_frames(_screen.animation_frames_left())
@@ -244,7 +244,7 @@ func test_a_female_intro_takes_the_female_default() -> void:
 	add_child_autofree(female)
 	female.open(_data, Gen2SaveData.GENDER_FEMALE)
 	for _step: int in 200:
-		for _pass: int in 40:
+		for _frame: int in 40:
 			if female.animation_frames_left() == 0:
 				break
 			female.advance_frames(female.animation_frames_left())
@@ -253,7 +253,7 @@ func test_a_female_intro_takes_the_female_default() -> void:
 		female.handle_button(Gen2Button.A)
 	female.handle_button(Gen2Button.START)
 	female.handle_button(Gen2Button.A)
-	for _pass: int in 40:
+	for _step: int in 40:
 		female.advance_frames(female.animation_frames_left())
 	assert_eq(female.player_name(), Gen2OakSpeech.DEFAULT_FEMALE)
 

--- a/tests/integration/test_world_mon_specials.gd
+++ b/tests/integration/test_world_mon_specials.gd
@@ -154,7 +154,7 @@ func test_the_ending_text_waits_on_the_scripts_own_waitbutton() -> void:
 
 func test_the_party_list_is_select_mon_from_party() -> void:
 	await _open_world()
-	await _reach_party()
+	_reach_party()
 	var party: Gen2PartyScreen = _host().party_screen()
 	assert_not_null(party)
 	assert_eq(party._prompt(), Gen2PartyScreen.PROMPT_CHOOSE)
@@ -167,7 +167,7 @@ func test_the_party_list_is_select_mon_from_party() -> void:
 ## `PartyMenuSelect`'s carry: B over the list is the same `.cancel` a NO is.
 func test_cancelling_the_party_list_ends_on_come_again() -> void:
 	await _open_world()
-	await _reach_party()
+	_reach_party()
 	_host().party_screen().handle_button(Gen2Button.B)
 	assert_null(_host())
 	assert_eq(
@@ -181,7 +181,7 @@ func test_cancelling_the_party_list_ends_on_come_again() -> void:
 func test_a_traded_member_ends_on_perfect_name_with_its_nickname_filled() -> void:
 	await _open_world()
 	_world_screen.active_save().party[0].ot_id += 1
-	await _reach_party()
+	_reach_party()
 	_host().party_screen().handle_button(Gen2Button.A)
 	assert_null(_host())
 	var shown: String = " ".join(_world_screen._text_box.text_lines())
@@ -194,7 +194,7 @@ func test_a_traded_member_ends_on_perfect_name_with_its_nickname_filled() -> voi
 func test_an_egg_ends_on_the_egg_text() -> void:
 	await _open_world()
 	_world_screen.active_save().party[0].is_egg = true
-	await _reach_party()
+	_reach_party()
 	_host().party_screen().handle_button(Gen2Button.A)
 	assert_null(_host())
 	assert_eq(
@@ -206,7 +206,7 @@ func test_an_egg_ends_on_the_egg_text() -> void:
 ## The whole line through, ending in the `CopyBytes` into the party row.
 func test_a_new_name_is_written_to_the_party_row() -> void:
 	await _open_world()
-	await _reach_party()
+	_reach_party()
 	_host().party_screen().handle_button(Gen2Button.A)
 	_settle()
 	assert_eq(_host().phase(), Gen2NameRaterScreen.Phase.BETTER_ASK)
@@ -232,7 +232,7 @@ func test_a_new_name_is_written_to_the_party_row() -> void:
 ## row keeps the name it had.
 func test_an_empty_entry_leaves_the_row_alone() -> void:
 	await _open_world()
-	await _reach_party()
+	_reach_party()
 	_host().party_screen().handle_button(Gen2Button.A)
 	_settle()
 	_world_screen.press_button(Gen2Button.A)
@@ -318,7 +318,7 @@ func test_a_member_with_one_move_is_refused_before_the_list() -> void:
 ## the list neither cycles between members nor holds a move.
 func test_the_move_list_neither_cycles_nor_swaps() -> void:
 	await _open_deleter_world()
-	await _reach_move_list()
+	_reach_move_list()
 	var moves: Gen2MoveScreen = _deleter().move_screen()
 	assert_not_null(moves)
 	assert_false(moves.handle_button(Gen2Button.RIGHT))
@@ -330,7 +330,7 @@ func test_the_move_list_neither_cycles_nor_swaps() -> void:
 ## text is the script's.
 func test_a_deleted_move_takes_its_pp_with_it() -> void:
 	await _open_deleter_world()
-	await _reach_move_list()
+	_reach_move_list()
 	_deleter().move_screen().handle_button(Gen2Button.DOWN)
 	_deleter().move_screen().handle_button(Gen2Button.A)
 	assert_eq(_deleter().phase(), Gen2MoveDeleterScreen.Phase.DELETE_ASK)
@@ -349,7 +349,7 @@ func test_a_deleted_move_takes_its_pp_with_it() -> void:
 ## NO on the second question is `.declined`, and nothing is written.
 func test_no_on_the_confirmation_leaves_the_moves_alone() -> void:
 	await _open_deleter_world()
-	await _reach_move_list()
+	_reach_move_list()
 	_deleter().move_screen().handle_button(Gen2Button.A)
 	_settle_deleter()
 	_world_screen.press_button(Gen2Button.B)

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -871,10 +871,10 @@ func test_tmhm_use_reports_an_incompatible_species() -> void:
 ## Fills the first party member's four move slots so LearnMove's scan finds no
 ## zero and reaches ForgetMove. Slot 1 is SURF, HM03, the row .hmmove refuses.
 func _fill_moveset(with_hm: bool = true) -> Gen2SaveMon:
-	var mon: Gen2SaveMon = _world_screen._injected_save.party[0]
-	mon.moves = [1, 0x39 if with_hm else 2, 3, 4]
-	mon.pp = [10, 10, 10, 10]
-	return mon
+	var _mon: Gen2SaveMon = _world_screen._injected_save.party[0]
+	_mon.moves = [1, 0x39 if with_hm else 2, 3, 4]
+	_mon.pp = [10, 10, 10, 10]
+	return _mon
 
 
 ## Walks the pack to the TEACH prompt and answers yes, which reaches the party
@@ -896,7 +896,7 @@ func _reach_forget_ask() -> Gen2StartMenuScreen:
 func test_a_full_moveset_opens_forget_move_and_a_choice_replaces_that_slot() -> void:
 	_write_tmhm_item()
 	await _open_world()
-	var mon: Gen2SaveMon = _fill_moveset()
+	var _mon: Gen2SaveMon = _fill_moveset()
 	var host: Gen2StartMenuScreen = await _reach_forget_ask()
 
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_FORGET_ASK)
@@ -1131,9 +1131,9 @@ func _select(host: Gen2StartMenuScreen, kind: StringName) -> void:
 func _open_pack_with_a_hurt_party() -> Gen2StartMenuScreen:
 	await _open_world()
 	var save: Gen2SaveData = _world_screen.get("_injected_save")
-	var mon: Gen2SaveMon = save.party[0]
-	mon.hp = maxi(mon.hp - 15, 1)
-	mon.nickname = "TESTMON"
+	var _mon: Gen2SaveMon = save.party[0]
+	_mon.hp = maxi(_mon.hp - 15, 1)
+	_mon.nickname = "TESTMON"
 	_world_screen._open_start_menu()
 	await get_tree().process_frame
 	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
@@ -1832,10 +1832,10 @@ func test_a_registered_item_is_used_by_the_select_button() -> void:
 ## What the party list shows for the first member: `GetCurNickname`, which falls
 ## back to the species name the fixture gave it.
 func _first_member_name(save: Gen2SaveData) -> String:
-	var mon: Gen2SaveMon = save.party[0]
-	if not mon.nickname.is_empty():
-		return mon.nickname
-	return String(_data.species(mon.species).get("name", ""))
+	var _mon: Gen2SaveMon = save.party[0]
+	if not _mon.nickname.is_empty():
+		return _mon.nickname
+	return String(_data.species(_mon.species).get("name", ""))
 
 
 ## A registered start-menu row that names a host action rather than a handler:
@@ -2013,10 +2013,10 @@ func test_giving_mail_writes_a_message_before_it_leaves_the_bag() -> void:
 
 	assert_null(host.get("_naming"))
 	var save: Gen2SaveData = _world_screen._injected_save
-	var mon: Gen2SaveMon = save.party[0]
-	assert_eq(mon.item, mail_item)
-	assert_not_null(mon.mail)
-	assert_eq(mon.mail.item, mail_item)
-	assert_eq(mon.mail.author, save.player_name)
-	assert_eq(mon.mail.species, mon.species)
+	var _mon: Gen2SaveMon = save.party[0]
+	assert_eq(_mon.item, mail_item)
+	assert_not_null(_mon.mail)
+	assert_eq(_mon.mail.item, mail_item)
+	assert_eq(_mon.mail.author, save.player_name)
+	assert_eq(_mon.mail.species, _mon.species)
 	assert_eq(_world_screen._world.state.item_quantity(mail_item), 0)

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -89,8 +89,8 @@ func _trigger_trainer() -> void:
 		_world_screen.advance_frame()
 		if _battle_child() != null:
 			break
-		var pending: Dictionary = _world_screen._world.pending_script_input()
-		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+		var waiting: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(waiting.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
 	await get_tree().process_frame
 	## Only that the overlay opened: the entrance is left where each test wants
@@ -266,8 +266,8 @@ func test_trainer_approach_step_interpolates_the_objects_position() -> void:
 			lowest_magnitude = mini(lowest_magnitude, magnitude)
 		else:
 			was_stepping = false
-		var pending: Dictionary = _world_screen._world.pending_script_input()
-		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+		var waiting: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(waiting.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
 	await get_tree().process_frame
 	assert_not_null(_battle_host())
@@ -408,9 +408,9 @@ func test_a_battle_is_spent_and_steered_by_the_world_that_opened_it() -> void:
 	## the funnel is what makes a recorded log complete.
 	_world_screen.record_input()
 	assert_true(_world_screen.press_button(Gen2Button.A))
-	var log: Array = _world_screen.input_recording()
-	assert_eq(log.size(), 1, "the world recorded the battle's own press")
-	assert_eq(int(log[0]["button"]), Gen2Button.A)
+	var recorded: Array = _world_screen.input_recording()
+	assert_eq(recorded.size(), 1, "the world recorded the battle's own press")
+	assert_eq(int(recorded[0]["button"]), Gen2Button.A)
 
 
 ## Two runs of the same fight from the same seed decide the same things, which is
@@ -1251,8 +1251,8 @@ func test_the_battle_track_is_chosen_before_the_transition_on_one_driver() -> vo
 		_world_screen.advance_frame()
 		if _world_screen.battle_transition_running():
 			break
-		var pending: Dictionary = _world_screen._world.pending_script_input()
-		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+		var waiting: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(waiting.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
 	assert_true(_world_screen.battle_transition_running())
 	var chosen: int = Gen2WorldBattleAdapter.music_for(
@@ -1289,8 +1289,8 @@ func test_a_battle_runs_its_transition_before_the_overlay_exists() -> void:
 		_world_screen.advance_frame()
 		if _world_screen.battle_transition_running():
 			break
-		var pending: Dictionary = _world_screen._world.pending_script_input()
-		if StringName(pending.get("type", &"")) in [&"text", &"button"]:
+		var waiting: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(waiting.get("type", &"")) in [&"text", &"button"]:
 			_world_screen._advance_script_input()
 	assert_true(
 		_world_screen.battle_transition_running(),
@@ -1776,7 +1776,7 @@ func test_a_registered_policy_pays_a_capture_between_gotcha_and_the_nickname() -
 	var caught: String = "Gotcha! %s was caught!" % _wild_name()
 	var messages: Array = []
 	## The award moves the EXP bar, and nothing behind a moving bar is shown, so
-	## this spends the screen's own frames the way a player waiting does.
+	## this spends the screen's own frames the way a player pending does.
 	for _frame: int in 900:
 		var line: String = String(host.battle_snapshot()["message"])
 		if messages.is_empty() or messages.back() != line:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -97,19 +97,19 @@ static func directory(game_id: StringName = GAME_ID) -> String:
 
 
 static func build(game_id: StringName = GAME_ID) -> GameData:
-	var directory: String = directory(game_id)
-	var base: GameData = BattleFixture.build(directory)
+	var cache_directory: String = directory(game_id)
+	var base: GameData = BattleFixture.build(cache_directory)
 	assert(base != null)
 
-	var manifest: Dictionary = RomCache.read_manifest(directory)
+	var manifest: Dictionary = RomCache.read_manifest(cache_directory)
 	# GameData.id, and therefore Gen2WorldScriptRunner's command profile, comes
 	# straight from this field, so the trainer script bytes below must match it.
 	var crystal_commands: bool = game_id != &"gold" and game_id != &"silver"
-	_write_trainers(directory)
-	_write_world(directory, crystal_commands)
-	_write_overworld_graphics(directory)
-	_write_battle_graphics(directory, manifest)
-	_write_splash_graphics(directory, manifest, game_id == RomRegistry.CRYSTAL)
+	_write_trainers(cache_directory)
+	_write_world(cache_directory, crystal_commands)
+	_write_overworld_graphics(cache_directory)
+	_write_battle_graphics(cache_directory, manifest)
+	_write_splash_graphics(cache_directory, manifest, game_id == RomRegistry.CRYSTAL)
 	_write_menu_text(manifest)
 	_write_name_rater_text(manifest)
 	_write_move_deleter_text(manifest)
@@ -117,23 +117,23 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_pokecenter_pc(manifest)
 	_write_decorations(manifest)
 	_write_unown_words(manifest)
-	_write_unown_puzzle(directory, manifest)
-	_write_slots(directory, manifest)
-	_write_card_flip(directory, manifest)
-	_write_credits(directory, manifest, crystal_commands)
-	_write_name_input_chars(directory)
-	_write_intro_text(directory, crystal_commands)
+	_write_unown_puzzle(cache_directory, manifest)
+	_write_slots(cache_directory, manifest)
+	_write_card_flip(cache_directory, manifest)
+	_write_credits(cache_directory, manifest, crystal_commands)
+	_write_name_input_chars(cache_directory)
+	_write_intro_text(cache_directory, crystal_commands)
 	manifest["game_id"] = String(game_id)
 	manifest["sha1"] = SHA1
 	manifest["complete"] = true
-	RomCache.write_json(RomCache.manifest_path(directory), manifest)
-	return GameData.open_directory(directory)
+	RomCache.write_json(RomCache.manifest_path(cache_directory), manifest)
+	return GameData.open_directory(cache_directory)
 
 
 ## The four naming keyboards with the real block's shape and command rows, the
 ## letters generated. What is under a letter key decides nothing in
 ## `naming_screen.asm`; the command row and the row counts decide everything.
-static func _write_name_input_chars(directory: String) -> void:
+static func _write_name_input_chars(cache_directory: String) -> void:
 	var tables: Array = []
 	for table: int in RomLayout.NAME_INPUT_TABLE_ROWS.size():
 		var first: int = RomLayout.NAME_INPUT_LOWER_A if table < 2 else RomLayout.NAME_INPUT_UPPER_A
@@ -173,14 +173,14 @@ static func _write_name_input_chars(directory: String) -> void:
 					codes.append(Gen2Text.SPACE)
 			rows.append(codes)
 		tables.append(rows)
-	RomCache.write_json(RomCache.name_input_chars_path(directory), tables)
+	RomCache.write_json(RomCache.name_input_chars_path(cache_directory), tables)
 
 
 ## The intro's own texts, synthetic. Every rule that reads them cares only that
 ## a text is there and how many pages it wraps to, so the words are stand-ins.
 ## The gender text is Crystal only, the way `init_gender.asm` is: a Gold or
 ## Silver fixture leaves the key out and the gender screen refuses to open.
-static func _write_intro_text(directory: String, crystal: bool) -> void:
+static func _write_intro_text(cache_directory: String, crystal: bool) -> void:
 	var text: Dictionary = {
 		"oak_1": "Oak one.\n\nOak one page two.",
 		"oak_2": "Oak two.",
@@ -191,11 +191,11 @@ static func _write_intro_text(directory: String, crystal: bool) -> void:
 	}
 	if crystal:
 		text["gender"] = "Are you a boy?\nOr are you a girl?"
-	RomCache.write_json(RomCache.intro_text_path(directory), text)
+	RomCache.write_json(RomCache.intro_text_path(cache_directory), text)
 
 
-static func _write_trainers(directory: String) -> void:
-	RomCache.write_json(RomCache.trainers_path(directory), [{
+static func _write_trainers(cache_directory: String) -> void:
+	RomCache.write_json(RomCache.trainers_path(cache_directory), [{
 		"number": 1,
 		"name": "LEADER",
 		"palette": [0x1234, 0x5678],
@@ -220,7 +220,7 @@ static func _write_trainers(directory: String) -> void:
 	}])
 
 
-static func _write_world(directory: String, crystal_commands: bool = true) -> void:
+static func _write_world(cache_directory: String, crystal_commands: bool = true) -> void:
 	var blocks: Array = []
 	blocks.resize(MAP_WIDTH_BLOCKS * MAP_HEIGHT_BLOCKS)
 	blocks.fill(0)
@@ -305,7 +305,7 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 		"x": HOME_WARP_CELL.x, "y": HOME_WARP_CELL.y, "destination": 1,
 		"map_group": MAP_GROUP, "map_number": MAP_NUMBER,
 	}]}
-	RomCache.write_json(RomCache.world_maps_path(directory), [map, home_map])
+	RomCache.write_json(RomCache.world_maps_path(cache_directory), [map, home_map])
 	var grass_slots: Array = []
 	for _slot: int in RomLayout.WILD_GRASS_SLOT_COUNT:
 		grass_slots.append({"level": 5, "species": TRAINER_SPECIES})
@@ -313,7 +313,7 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 	var home_key: String = "%d:%d" % [
 		Gen2WorldSpawn.NEW_BARK_GROUP, Gen2WorldSpawn.PLAYERS_HOUSE_2F,
 	]
-	RomCache.write_json(RomCache.world_encounters_path(directory), {
+	RomCache.write_json(RomCache.world_encounters_path(cache_directory), {
 		"grass": {"1:1": {
 			"map": "1:1", "region": "johto", "rates": [255, 255, 255], "slots": grass_times,
 		}},
@@ -355,17 +355,17 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 		raw.call(0x60), 3, # catchtutorial
 		raw.call(0x90), # end
 	]
-	RomCache.write_json(RomCache.world_scripts_path(directory), {
+	RomCache.write_json(RomCache.world_scripts_path(cache_directory), {
 		Gen2WorldScript.pointer_key(BANK, TRAINER_SCRIPT): script,
 		Gen2WorldScript.pointer_key(BANK, TUTORIAL_SCRIPT): tutorial_script,
 	})
-	RomCache.write_json(RomCache.world_text_path(directory), {
+	RomCache.write_json(RomCache.world_text_path(cache_directory), {
 		Gen2WorldScript.pointer_key(BANK, SEEN_TEXT): _text("RIVAL noticed you."),
 		Gen2WorldScript.pointer_key(BANK, WIN_TEXT): _text("YOU WON."),
 		Gen2WorldScript.pointer_key(BANK, LOSS_TEXT): _text("YOU LOST."),
 	})
-	RomCache.write_json(RomCache.world_standard_scripts_path(directory), {})
-	RomCache.write_json(RomCache.world_movements_path(directory), {})
+	RomCache.write_json(RomCache.world_standard_scripts_path(cache_directory), {})
+	RomCache.write_json(RomCache.world_movements_path(cache_directory), {})
 
 	var meta: Array = []
 	for tile: int in RomLayout.MAP_BLOCK_TILE_WIDTH * RomLayout.MAP_BLOCK_TILE_WIDTH:
@@ -373,7 +373,7 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 	var palette_map: Array = []
 	palette_map.resize((RomLayout.TILESET_TILE_COUNT + 1) / 2)
 	palette_map.fill(0)
-	RomCache.write_json(RomCache.world_tilesets_path(directory), [{
+	RomCache.write_json(RomCache.world_tilesets_path(cache_directory), [{
 		"number": 0,
 		"block_count": 1,
 		"tile_count": RomLayout.TILESET_TILE_COUNT,
@@ -385,12 +385,12 @@ static func _write_world(directory: String, crystal_commands: bool = true) -> vo
 	var palettes: Array = []
 	for _group: int in 42:
 		palettes.append([0x7FFF, 0x421F, 0x2108, 0])
-	RomCache.write_json(RomCache.world_palettes_path(directory), palettes)
-	RomCache.write_json(RomCache.world_animation_assets_path(directory), {})
+	RomCache.write_json(RomCache.world_palettes_path(cache_directory), palettes)
+	RomCache.write_json(RomCache.world_animation_assets_path(cache_directory), {})
 
 
-static func _write_overworld_graphics(directory: String) -> void:
-	RomCache.write_json(RomCache.overworld_sprites_path(directory), [{
+static func _write_overworld_graphics(cache_directory: String) -> void:
+	RomCache.write_json(RomCache.overworld_sprites_path(cache_directory), [{
 		"number": TRAINER_SPRITE,
 		"address": 0x4000,
 		"bank": BANK,
@@ -402,28 +402,28 @@ static func _write_overworld_graphics(directory: String) -> void:
 	var palettes: Array = []
 	for _group: int in RomLayout.OVERWORLD_SPRITE_PALETTE_GROUP_COUNT:
 		palettes.append([0x7FFF, 0x421F, 0x2108, 0])
-	RomCache.write_json(RomCache.overworld_sprite_palettes_path(directory), palettes)
+	RomCache.write_json(RomCache.overworld_sprite_palettes_path(cache_directory), palettes)
 
 	var tiles: PackedByteArray = PackedByteArray()
 	tiles.resize(RomLayout.TILESET_TILE_COUNT * Gen2Tiles.TILE_PIXELS)
 	tiles.fill(1)
-	RomCache.write_indices(RomCache.world_tile_path(directory, 0), tiles)
+	RomCache.write_indices(RomCache.world_tile_path(cache_directory, 0), tiles)
 
 	var sprite: PackedByteArray = PackedByteArray()
 	sprite.resize(4 * Gen2Tiles.TILE_PIXELS)
 	sprite.fill(1)
-	RomCache.write_indices(RomCache.overworld_sprite_path(directory, TRAINER_SPRITE), sprite)
+	RomCache.write_indices(RomCache.overworld_sprite_path(cache_directory, TRAINER_SPRITE), sprite)
 
 	## `MonMenuIcons`, one row per species: every one of them icon 1, which is
 	## all anything drawing a party icon or a visible encounter needs here.
 	var menu_icons: PackedByteArray = PackedByteArray()
 	menu_icons.resize(RomLayout.SPECIES_COUNT)
 	menu_icons.fill(1)
-	RomCache.write_indices(RomCache.mon_menu_icons_path(directory), menu_icons)
+	RomCache.write_indices(RomCache.mon_menu_icons_path(cache_directory), menu_icons)
 	var icon: PackedByteArray = PackedByteArray()
 	icon.resize(8 * Gen2Tiles.TILE_PIXELS)
 	icon.fill(1)
-	RomCache.write_indices(RomCache.overworld_icon_path(directory, 1), icon)
+	RomCache.write_indices(RomCache.overworld_icon_path(cache_directory, 1), icon)
 
 
 ## `engine/events/name_rater.asm`'s ten boxes, shortened but keeping the two
@@ -574,7 +574,7 @@ static func _write_unown_words(manifest: Dictionary) -> void:
 ## right length per name, since the doubling and the borders are arithmetic over
 ## whatever is in them. Each strip is filled with a different index so a tile
 ## drawn from the wrong one is visible rather than merely different.
-static func _write_unown_puzzle(directory: String, manifest: Dictionary) -> void:
+static func _write_unown_puzzle(cache_directory: String, manifest: Dictionary) -> void:
 	var sheets: Dictionary = manifest.get("tiles", {})
 	var rows: Array = [["tile_borders", RomLayout.UNOWN_PUZZLE_BORDER_TILES]]
 	rows.append(["cursor", 4])
@@ -590,7 +590,7 @@ static func _write_unown_puzzle(directory: String, manifest: Dictionary) -> void
 		indices.resize(tile_count * Gen2Tiles.TILE_PIXELS)
 		indices.fill(fill % 4)
 		fill += 1
-		RomCache.write_indices(RomCache.tile_path(directory, key), indices)
+		RomCache.write_indices(RomCache.tile_path(cache_directory, key), indices)
 		sheets[key] = {
 			"width": tile_count * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
@@ -608,7 +608,7 @@ static func _write_unown_puzzle(directory: String, manifest: Dictionary) -> void
 ## from the cache is a run of the right length per name, since every symbol is
 ## addressed by tile number. The reels *are* the cartridge's, because the rules
 ## read them.
-static func _write_slots(directory: String, manifest: Dictionary) -> void:
+static func _write_slots(cache_directory: String, manifest: Dictionary) -> void:
 	var sheets: Dictionary = manifest.get("tiles", {})
 	var fill: int = 1
 	for row: Array in RomLayout.SLOTS_SECTION:
@@ -620,7 +620,7 @@ static func _write_slots(directory: String, manifest: Dictionary) -> void:
 		indices.resize(tile_count * Gen2Tiles.TILE_PIXELS)
 		indices.fill(fill % 4)
 		fill += 1
-		RomCache.write_indices(RomCache.tile_path(directory, name), indices)
+		RomCache.write_indices(RomCache.tile_path(cache_directory, name), indices)
 		sheets[name] = {
 			"width": tile_count * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
@@ -651,7 +651,7 @@ static func _write_slots(directory: String, manifest: Dictionary) -> void:
 ## the slot machine's are: the strips are runs of the right length rather than
 ## the cartridge's picture, and the board is the cartridge's own tilemap shape,
 ## since the lamp column is what the screen writes into.
-static func _write_card_flip(directory: String, manifest: Dictionary) -> void:
+static func _write_card_flip(cache_directory: String, manifest: Dictionary) -> void:
 	var sheets: Dictionary = manifest.get("tiles", {})
 	var fill: int = 1
 	for row: Array in RomLayout.CARD_FLIP_SECTION:
@@ -661,7 +661,7 @@ static func _write_card_flip(directory: String, manifest: Dictionary) -> void:
 		indices.resize(tile_count * Gen2Tiles.TILE_PIXELS)
 		indices.fill(fill % 4)
 		fill += 1
-		RomCache.write_indices(RomCache.tile_path(directory, name), indices)
+		RomCache.write_indices(RomCache.tile_path(cache_directory, name), indices)
 		sheets[name] = {
 			"width": tile_count * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
@@ -767,7 +767,7 @@ static func _write_pokecenter_pc(manifest: Dictionary) -> void:
 ## way the cartridges do: Crystal gives a scene three palettes and sixteen banner
 ## blocks, Gold and Silver one palette and thirteen.
 static func _write_credits(
-	directory: String, manifest: Dictionary, crystal: bool
+	cache_directory: String, manifest: Dictionary, crystal: bool
 ) -> void:
 	var frames: Array = []
 	if crystal:
@@ -842,7 +842,7 @@ static func _write_credits(
 				var y: int = pixel / Gen2Tiles.TILE_WIDTH
 				indices[y * count * Gen2Tiles.TILE_WIDTH
 					+ tile * Gen2Tiles.TILE_WIDTH + pixel % Gen2Tiles.TILE_WIDTH] = index
-		RomCache.write_indices(RomCache.tile_path(directory, String(entry[0])), indices)
+		RomCache.write_indices(RomCache.tile_path(cache_directory, String(entry[0])), indices)
 		sheets[String(entry[0])] = {
 			"width": count * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
@@ -858,7 +858,7 @@ static func _write_credits(
 ## The words below name the strip's own first tiles, so the ink index matters and
 ## the picture does not.
 static func _write_splash_graphics(
-	directory: String, manifest: Dictionary, crystal: bool
+	cache_directory: String, manifest: Dictionary, crystal: bool
 ) -> void:
 	var sheets: Dictionary = manifest.get("tiles", {})
 	## The 1bpp logo carries `Gen2Tiles.INK`, since that is the only index a 1bpp
@@ -881,7 +881,7 @@ static func _write_splash_graphics(
 		var indices: PackedByteArray = PackedByteArray()
 		indices.resize(tile_count * Gen2Tiles.TILE_PIXELS)
 		indices.fill(int(counts[name][1]))
-		RomCache.write_indices(RomCache.tile_path(directory, name), indices)
+		RomCache.write_indices(RomCache.tile_path(cache_directory, name), indices)
 		sheets[name] = {
 			"width": tile_count * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
@@ -902,7 +902,7 @@ static func _write_splash_graphics(
 	manifest["presents_palettes"] = palettes
 
 
-static func _write_battle_graphics(directory: String, manifest: Dictionary) -> void:
+static func _write_battle_graphics(cache_directory: String, manifest: Dictionary) -> void:
 	var sheets: Dictionary = {}
 	var sheet_tiles: Dictionary = {
 		"exp_bar": [RomLayout.EXP_BAR_TILES, 2],
@@ -975,7 +975,7 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 		var indices: PackedByteArray = PackedByteArray()
 		indices.resize(tile_count * Gen2Tiles.TILE_PIXELS)
 		indices.fill(int(sheet_tiles[name][1]))
-		RomCache.write_indices(RomCache.tile_path(directory, name), indices)
+		RomCache.write_indices(RomCache.tile_path(cache_directory, name), indices)
 		sheets[name] = {
 			"width": tile_count * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
@@ -1036,7 +1036,7 @@ static func _write_battle_graphics(directory: String, manifest: Dictionary) -> v
 	atlas_indices.fill(1)
 	var atlases: Dictionary = manifest.get("atlases", {})
 	for name: String in ["front", "back"]:
-		RomCache.write_indices(RomCache.pic_path(directory, name), atlas_indices)
+		RomCache.write_indices(RomCache.pic_path(cache_directory, name), atlas_indices)
 		atlases[name] = {
 			"width": atlas_width,
 			"height": rows * cell,

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -36,8 +36,8 @@ func test_types_discourages_a_move_the_defender_is_immune_to() -> void:
 	# every time, tie-break or no.
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.THUNDERBOLT, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_TYPES, _rng
 		)
@@ -47,8 +47,8 @@ func test_types_discourages_a_move_the_defender_is_immune_to() -> void:
 func test_offensive_discourages_a_move_with_no_power() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.HAZE, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_OFFENSIVE, _rng
 		)
@@ -60,8 +60,8 @@ func test_status_dismisses_a_status_move_the_defender_is_immune_to() -> void:
 	# every Electric move in this fixture's chart, paralysis included.
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.THUNDER_WAVE, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_STATUS, _rng
 		)
@@ -72,8 +72,8 @@ func test_basic_discourages_confuse_against_an_already_confused_target() -> void
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SUPERSONIC, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.substatus = Gen2Substatus.CONFUSED
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -84,8 +84,8 @@ func test_basic_discourages_a_status_move_against_an_already_statused_target() -
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.THUNDER_WAVE, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.status = Gen2Status.POISON
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -99,8 +99,8 @@ func test_smart_toxic_is_discouraged_against_a_target_already_hurt() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TOXIC, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.hp = 1
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
 		)
@@ -111,8 +111,8 @@ func test_smart_belly_drum_is_discouraged_once_attack_is_already_maxed_out() -> 
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.BELLY_DRUM, Fixture.TACKLE])
 	pikachu.stages["attack"] = 3
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
 		)
@@ -122,8 +122,8 @@ func test_smart_belly_drum_is_discouraged_once_attack_is_already_maxed_out() -> 
 func test_smart_skull_bash_is_discouraged_above_a_quarter_hp() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SKULL_BASH, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
 		)
@@ -143,8 +143,8 @@ func test_aggressive_prefers_whichever_move_deals_more_damage() -> void:
 	assert_ne(ember_damage, slash_damage, "the scenario needs the two moves to actually differ")
 	var stronger_slot: int = 0 if ember_damage > slash_damage else 1
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			charmander, bulbasaur, _data, RomLayout.AI_AGGRESSIVE, _rng
 		)
@@ -165,8 +165,8 @@ func test_risky_encourages_whichever_move_would_actually_ko() -> void:
 
 	# Set HP strictly between the two: Ember KOs, Slash does not.
 	bulbasaur.hp = slash_damage + 1
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			charmander, bulbasaur, _data, RomLayout.AI_RISKY, _rng
 		)
@@ -190,8 +190,8 @@ func test_setup_only_ever_encourages_a_stat_up_move_on_the_first_turn() -> void:
 
 	var encouraged: bool = false
 	var left_alone: bool = false
-	for seed: int in 100:
-		_rng.seed = seed
+	for seed_value: int in 100:
+		_rng.seed = seed_value
 		var scores: Array = [20, 20, 20, 20]
 		Gen2BattleAI._apply_setup(scores, pikachu, geodude, _data, _rng, 0, 5, Gen2Weather.NONE)
 		if scores[0] < 20:
@@ -204,8 +204,8 @@ func test_setup_only_ever_encourages_a_stat_up_move_on_the_first_turn() -> void:
 	# Past the first turn, the same move should never be encouraged, only ever
 	# discouraged or left alone.
 	var discouraged_late: bool = false
-	for seed: int in 100:
-		_rng.seed = seed
+	for seed_value: int in 100:
+		_rng.seed = seed_value
 		var scores: Array = [20, 20, 20, 20]
 		Gen2BattleAI._apply_setup(scores, pikachu, geodude, _data, _rng, 3, 5, Gen2Weather.NONE)
 		assert_true(scores[0] >= 20, "a stat-up move past turn one is never encouraged")
@@ -240,8 +240,8 @@ func test_basic_discourages_disable_against_an_already_disabled_target() -> void
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.DISABLE_MOVE, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.disabled_slot = 0
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -252,8 +252,8 @@ func test_basic_discourages_encore_against_an_already_encored_target() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.ENCORE_MOVE, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.encored_slot = 0
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -270,8 +270,8 @@ func test_basic_discourages_attract_between_the_same_gender() -> void:
 	var defender: Gen2BattleMon = Gen2BattleMon.create(
 		_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE], Gen2Stats.pack_dvs(0, 0, 0, 0)
 	)
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(attacker, defender, _data, RomLayout.AI_BASIC, _rng)
 		assert_eq(slot, 1, "the same gender can never fall for Attract")
 
@@ -282,8 +282,8 @@ func test_basic_discourages_attract_against_a_genderless_target() -> void:
 	)
 	# Species 6 is not named in the fixture, so it reads genderless.
 	var defender: Gen2BattleMon = Gen2BattleMon.create(_data, 6, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(attacker, defender, _data, RomLayout.AI_BASIC, _rng)
 		assert_eq(slot, 1, "a genderless target can never fall for Attract")
 
@@ -292,8 +292,8 @@ func test_basic_discourages_mist_and_focus_energy_used_a_second_time() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MIST_MOVE, Fixture.TACKLE])
 	pikachu.substatus |= Gen2Substatus.MIST
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -301,8 +301,8 @@ func test_basic_discourages_mist_and_focus_energy_used_a_second_time() -> void:
 
 	var pikachu2: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.FOCUS_ENERGY_MOVE, Fixture.TACKLE])
 	pikachu2.substatus |= Gen2Substatus.FOCUS_ENERGY
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu2, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -319,8 +319,8 @@ func test_basic_discourages_setting_weather_that_is_already_up() -> void:
 	]:
 		var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [int(pair[0]), Fixture.TACKLE])
 		var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
-		for seed: int in 5:
-			_rng.seed = seed
+		for seed_value: int in 5:
+			_rng.seed = seed_value
 			var slot: int = Gen2BattleAI.choose_slot(
 				pikachu, charmander, _data, RomLayout.AI_BASIC, _rng, 0, 0, int(pair[1])
 			)
@@ -333,8 +333,8 @@ func test_basic_discourages_a_second_mean_look_from_the_same_pokemon() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MEAN_LOOK, Fixture.TACKLE])
 	var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
 	pikachu.substatus |= Gen2Substatus.CANT_RUN
-	for seed: int in 5:
-		_rng.seed = seed
+	for seed_value: int in 5:
+		_rng.seed = seed_value
 		assert_eq(
 			Gen2BattleAI.choose_slot(pikachu, charmander, _data, RomLayout.AI_BASIC, _rng), 1
 		)
@@ -384,12 +384,12 @@ func test_smart_reads_the_weather_for_solarbeam() -> void:
 
 	var sunny: Array = []
 	var rainy: Array = []
-	for seed: int in 40:
-		_rng.seed = seed
+	for seed_value: int in 40:
+		_rng.seed = seed_value
 		sunny.append(Gen2BattleAI.choose_slot(
 			pikachu, charmander, _data, RomLayout.AI_SMART, _rng, 0, 0, Gen2Weather.SUN
 		))
-		_rng.seed = seed
+		_rng.seed = seed_value
 		rainy.append(Gen2BattleAI.choose_slot(
 			pikachu, charmander, _data, RomLayout.AI_SMART, _rng, 0, 0, Gen2Weather.RAIN
 		))
@@ -406,8 +406,8 @@ func test_smart_discourages_thunder_in_sun_only() -> void:
 	var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
 
 	var discouraged: int = 0
-	for seed: int in 40:
-		_rng.seed = seed
+	for seed_value: int in 40:
+		_rng.seed = seed_value
 		if Gen2BattleAI.choose_slot(
 			pikachu, charmander, _data, RomLayout.AI_SMART, _rng, 0, 0, Gen2Weather.SUN
 		) == 1:
@@ -415,8 +415,8 @@ func test_smart_discourages_thunder_in_sun_only() -> void:
 
 	assert_gt(discouraged, 20, "sun has to push Thunder aside most of the time")
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var scores: Array = [Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE]
 		Gen2BattleAI._apply_smart(
 			scores, pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.RAIN
@@ -429,8 +429,8 @@ func test_smart_discourages_thunder_in_sun_only() -> void:
 func test_smart_will_not_raise_a_sandstorm_against_a_rock_type() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SANDSTORM, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var scores: Array = [Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE]
 		Gen2BattleAI._apply_smart(scores, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE)
 		assert_eq(int(scores[0]), Gen2BattleAI.DEFAULT_SCORE + 2)
@@ -479,8 +479,8 @@ func test_smart_will_not_bind_a_target_twice() -> void:
 	charmander.trapped_turns = 3
 
 	var raised: int = 0
-	for seed: int in 40:
-		_rng.seed = seed
+	for seed_value: int in 40:
+		_rng.seed = seed_value
 		var scores: Array = [Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE]
 		Gen2BattleAI._apply_smart(scores, pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE)
 		assert_gte(int(scores[0]), Gen2BattleAI.DEFAULT_SCORE, "a bound target is never encouraged")
@@ -495,8 +495,8 @@ func test_smart_binds_a_fresh_target_but_not_on_its_last_legs() -> void:
 
 	var healthy: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.WRAP, Fixture.TACKLE])
 	var lowered: int = 0
-	for seed: int in 40:
-		_rng.seed = seed
+	for seed_value: int in 40:
+		_rng.seed = seed_value
 		var scores: Array = [Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE]
 		Gen2BattleAI._apply_smart(scores, healthy, charmander, _data, _rng, 0, 0, Gen2Weather.NONE)
 		if int(scores[0]) < Gen2BattleAI.DEFAULT_SCORE:
@@ -506,8 +506,8 @@ func test_smart_binds_a_fresh_target_but_not_on_its_last_legs() -> void:
 	# `AICheckEnemyQuarterHP` gates the encouragement on the user's own health.
 	var spent: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.WRAP, Fixture.TACKLE])
 	spent.hp = 1
-	for seed: int in 20:
-		_rng.seed = seed
+	for seed_value: int in 20:
+		_rng.seed = seed_value
 		var scores: Array = [Gen2BattleAI.DEFAULT_SCORE, Gen2BattleAI.DEFAULT_SCORE]
 		Gen2BattleAI._apply_smart(scores, spent, charmander, _data, _rng, 0, 0, Gen2Weather.NONE)
 		assert_eq(int(scores[0]), Gen2BattleAI.DEFAULT_SCORE, "nothing to hold it there with")
@@ -518,8 +518,8 @@ func test_smart_binds_a_fresh_target_but_not_on_its_last_legs() -> void:
 func test_smart_heal_is_discouraged_while_the_ai_is_healthy() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.RECOVER, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
 		)
@@ -532,8 +532,8 @@ func test_smart_heal_is_encouraged_once_the_ai_is_nearly_out() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MORNING_SUN, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	var chose_heal: int = 0
-	for seed: int in 20:
-		_rng.seed = seed
+	for seed_value: int in 20:
+		_rng.seed = seed_value
 		pikachu.hp = 1
 		if Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_SMART, _rng) == 0:
 			chose_heal += 1
@@ -547,8 +547,8 @@ func test_basic_treats_a_second_perish_song_as_redundant() -> void:
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.substatus |= Gen2Substatus.PERISH
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_BASIC, _rng
 		)
@@ -561,8 +561,8 @@ func test_smart_discourages_perish_song_with_nobody_on_the_bench() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		var slot: int = Gen2BattleAI.choose_slot(
 			pikachu, geodude, _data, RomLayout.AI_SMART, _rng
 		)
@@ -578,8 +578,8 @@ func test_smart_encourages_perish_song_against_a_player_that_cannot_run() -> voi
 
 	var encouraged: bool = false
 	var left_alone: bool = false
-	for seed: int in 100:
-		_rng.seed = seed
+	for seed_value: int in 100:
+		_rng.seed = seed_value
 		var scores: Array = [20, 20, 20, 20]
 		Gen2BattleAI._apply_smart(
 			scores, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE,
@@ -600,8 +600,8 @@ func test_smart_discourages_perish_song_only_while_the_matchup_holds() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.PERISH_SONG])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 
-	for seed: int in 100:
-		_rng.seed = seed
+	for seed_value: int in 100:
+		_rng.seed = seed_value
 		var losing: Array = [20, 20, 20, 20]
 		Gen2BattleAI._apply_smart(
 			losing, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE,
@@ -611,8 +611,8 @@ func test_smart_discourages_perish_song_only_while_the_matchup_holds() -> void:
 
 	var discouraged: bool = false
 	var left_alone: bool = false
-	for seed: int in 100:
-		_rng.seed = seed
+	for seed_value: int in 100:
+		_rng.seed = seed_value
 		var scores: Array = [20, 20, 20, 20]
 		Gen2BattleAI._apply_smart(
 			scores, pikachu, geodude, _data, _rng, 0, 0, Gen2Weather.NONE,
@@ -633,8 +633,8 @@ func test_basic_treats_a_second_substitute_as_redundant() -> void:
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	pikachu.substatus |= Gen2Substatus.SUBSTITUTE
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		assert_eq(
 			Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_BASIC, _rng), 1
 		)
@@ -646,8 +646,8 @@ func test_basic_treats_a_second_leech_seed_as_redundant() -> void:
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	geodude.substatus |= Gen2Substatus.LEECH_SEED
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		assert_eq(
 			Gen2BattleAI.choose_slot(pikachu, geodude, _data, RomLayout.AI_BASIC, _rng), 1
 		)
@@ -658,8 +658,8 @@ func test_basic_treats_a_second_spikes_as_redundant() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.SPIKES, Fixture.TACKLE])
 	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		assert_eq(
 			Gen2BattleAI.choose_slot(
 				pikachu, geodude, _data, RomLayout.AI_BASIC, _rng, 0, 0,
@@ -677,8 +677,8 @@ func test_basic_reproduces_the_nightmare_redundancy_bug() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.NIGHTMARE, Fixture.TACKLE])
 	var awake: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		assert_eq(
 			Gen2BattleAI.choose_slot(pikachu, awake, _data, RomLayout.AI_BASIC, _rng), 1,
 			"an unstatused target really is the redundant case"
@@ -687,8 +687,8 @@ func test_basic_reproduces_the_nightmare_redundancy_bug() -> void:
 	var burned: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	burned.status = Gen2Status.BURN
 	var kept: int = 0
-	for seed: int in 20:
-		_rng.seed = seed
+	for seed_value: int in 20:
+		_rng.seed = seed_value
 		if Gen2BattleAI.choose_slot(pikachu, burned, _data, RomLayout.AI_BASIC, _rng) == 0:
 			kept += 1
 	assert_gt(kept, 0, "a burn is not sleep, and the AI is not discouraged anyway")
@@ -696,8 +696,8 @@ func test_basic_reproduces_the_nightmare_redundancy_bug() -> void:
 	var dreaming: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 	dreaming.status = Gen2Status.BURN
 	dreaming.substatus |= Gen2Substatus.NIGHTMARE
-	for seed: int in 10:
-		_rng.seed = seed
+	for seed_value: int in 10:
+		_rng.seed = seed_value
 		assert_eq(
 			Gen2BattleAI.choose_slot(pikachu, dreaming, _data, RomLayout.AI_BASIC, _rng), 1,
 			"a target already dreaming is redundant on the second clause"
@@ -825,7 +825,7 @@ func test_smart_leaves_endure_alone_under_a_quarter_with_no_reversal() -> void:
 	geodude.hp = geodude.max_hp() / 8
 
 	var spread: Array = _smart_spread(geodude, pikachu)
-	assert_eq(int(spread[2]), 100, "untouched on every seed")
+	assert_eq(int(spread[2]), 100, "untouched on every seed_value")
 
 
 ## `AIHasMoveEffect` for `EFFECT_REVERSAL`: three points on, which is the
@@ -1243,15 +1243,15 @@ func test_the_cautious_bug_abandons_the_slots_after_a_missed_roll() -> void:
 	# Every one of the four is residual, so the fix discourages all four whenever
 	# no roll misses and never leaves a gap; with the bug a miss stops the walk.
 	var abandoned: bool = false
-	for seed: int in 60:
+	for seed_value: int in 60:
 		Gen2Rules.install(null)
-		_rng.seed = seed
+		_rng.seed = seed_value
 		var fixed: Array = Gen2BattleAI.score_slots(
 			pikachu, geodude, _data, RomLayout.AI_CAUTIOUS, _rng, 1
 		)
 		rules.set_flag(&"cautious_ai_abandons_remaining_moves", true)
 		Gen2Rules.install(rules)
-		_rng.seed = seed
+		_rng.seed = seed_value
 		var hardware: Array = Gen2BattleAI.score_slots(
 			pikachu, geodude, _data, RomLayout.AI_CAUTIOUS, _rng, 1
 		)

--- a/tests/unit/test_ai_items.gd
+++ b/tests/unit/test_ai_items.gd
@@ -42,8 +42,8 @@ func _use_rate(
 	item: int, mon: Gen2BattleMon, flags: int, turns_taken: int, seeds: int = 64
 ) -> int:
 	var used: int = 0
-	for seed: int in seeds:
-		_rng.seed = seed
+	for seed_value: int in seeds:
+		_rng.seed = seed_value
 		if Gen2AIItems.choose(mon, [item], flags, turns_taken, _rng) == item:
 			used += 1
 	return used

--- a/tests/unit/test_ai_switch.gd
+++ b/tests/unit/test_ai_switch.gd
@@ -151,8 +151,8 @@ func test_the_bench_pokemon_immune_to_the_last_move_is_the_one_chosen() -> void:
 func test_a_class_with_no_switch_bit_never_leaves() -> void:
 	var battle: Gen2Battle = _wants_out()
 
-	for seed: int in 32:
-		_rng.seed = seed
+	for seed_value: int in 32:
+		_rng.seed = seed_value
 		assert_false(bool(Gen2AISwitch.decide(battle, 0, _rng)["switch"]))
 
 
@@ -163,8 +163,8 @@ func test_the_three_frequencies_act_at_their_own_rates() -> void:
 	var rates: Dictionary = {}
 	for frequency: int in [OFTEN, SOMETIMES, RARELY]:
 		var switched: int = 0
-		for seed: int in 128:
-			_rng.seed = seed
+		for seed_value: int in 128:
+			_rng.seed = seed_value
 			if bool(Gen2AISwitch.decide(battle, frequency, _rng)["switch"]):
 				switched += 1
 		rates[frequency] = switched
@@ -184,8 +184,8 @@ func test_the_last_pokemon_standing_cannot_leave() -> void:
 	battle.party(Gen2Battle.ENEMY).at(2).hp = 0
 
 	assert_eq(int(Gen2AISwitch.evaluate(battle)["tier"]), 0, "nobody to switch to")
-	for seed: int in 32:
-		_rng.seed = seed
+	for seed_value: int in 32:
+		_rng.seed = seed_value
 		assert_false(bool(Gen2AISwitch.decide(battle, OFTEN, _rng)["switch"]))
 
 
@@ -199,8 +199,8 @@ func test_a_trapped_or_mean_looked_enemy_does_not_switch() -> void:
 		else:
 			battle.player.substatus |= Gen2Substatus.CANT_RUN
 
-		for seed: int in 16:
-			_rng.seed = seed
+		for seed_value: int in 16:
+			_rng.seed = seed_value
 			var action: Dictionary = Gen2BattleAI.choose_action(battle, OFTEN, 0, _rng)
 			assert_ne(
 				StringName(action["type"]), Gen2Battle.ACTION_SWITCH, String(setup)
@@ -220,8 +220,8 @@ func test_a_locked_in_enemy_neither_switches_nor_uses_an_item() -> void:
 		battle.enemy_items = [Gen2AIItems.X_ATTACK]
 		battle.enemy.substatus |= flag
 
-		for seed: int in 16:
-			_rng.seed = seed
+		for seed_value: int in 16:
+			_rng.seed = seed_value
 			var action: Dictionary = Gen2BattleAI.choose_action(battle, OFTEN, 0, _rng)
 			assert_eq(
 				StringName(action["type"]), Gen2Battle.ACTION_MOVE,

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -120,15 +120,15 @@ func test_the_queue_is_kept_to_its_latency_target_not_to_the_brim() -> void:
 	assert_true(_player.play_record(_record(99), &"map_music")["ok"])
 	_player._service_timeline()
 	var capacity: int = _player._capacity
-	var pending: int = capacity - _player._playback.get_frames_available()
+	var waiting: int = capacity - _player._playback.get_frames_available()
 	assert_gt(capacity, 0, "the depth was learned from the stream")
 	assert_gt(_player._timeline_updates, 0, "the service filled the queue at all")
 	assert_almost_eq(
-		float(pending),
+		float(waiting),
 		float(Gen2AudioPlayer.TARGET_FRAMES_MIN * Gen2Apu.SAMPLES_PER_FRAME),
 		float(Gen2Apu.SAMPLES_PER_FRAME),
 	)
-	assert_lt(pending, capacity, "the rest of the depth is left as headroom")
+	assert_lt(waiting, capacity, "the rest of the depth is left as headroom")
 
 	# A second service does not fill to the brim: the target is a level, not a
 	# rate, so the queue comes back to the same depth rather than growing. The

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -2528,12 +2528,12 @@ func test_struggling_counts_as_a_turn_even_though_it_spends_no_pp() -> void:
 ## settled.
 func test_a_quick_claw_can_beat_a_faster_pokemon_to_the_punch() -> void:
 	var claimed: int = 0
-	for seed: int in 200:
+	for seed_value: int in 200:
 		var battle: Gen2Battle = _battle(
 			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
 			_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
 		)
-		battle.rng.seed = seed
+		battle.rng.seed = seed_value
 		battle.mon(Gen2Battle.PLAYER).item = Fixture.QUICK_CLAW
 
 		if battle.order({Gen2Battle.PLAYER: Fixture.TACKLE, Gen2Battle.ENEMY: Fixture.TACKLE})[0] \
@@ -2550,8 +2550,8 @@ func test_a_quick_claw_never_overrides_priority() -> void:
 		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
 	)
 	battle.mon(Gen2Battle.PLAYER).item = Fixture.QUICK_CLAW
-	for seed: int in 50:
-		battle.rng.seed = seed
+	for seed_value: int in 50:
+		battle.rng.seed = seed_value
 		# Counter is priority 0 against Tackle's 1, so the player is last however
 		# the claw rolls.
 		var acting: Array = battle.order({
@@ -2565,12 +2565,12 @@ func test_a_quick_claw_never_overrides_priority() -> void:
 func test_two_quick_claws_roll_the_enemys_first() -> void:
 	var enemy_first: int = 0
 	var player_first: int = 0
-	for seed: int in 300:
+	for seed_value: int in 300:
 		var battle: Gen2Battle = _battle(
 			_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
 			_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
 		)
-		battle.rng.seed = seed
+		battle.rng.seed = seed_value
 		battle.mon(Gen2Battle.PLAYER).item = Fixture.QUICK_CLAW
 		battle.mon(Gen2Battle.ENEMY).item = Fixture.QUICK_CLAW
 
@@ -2593,8 +2593,8 @@ func test_no_quick_claw_leaves_the_order_to_speed() -> void:
 		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE]),
 		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
 	)
-	for seed: int in 30:
-		battle.rng.seed = seed
+	for seed_value: int in 30:
+		battle.rng.seed = seed_value
 		assert_eq(
 			battle.order({
 				Gen2Battle.PLAYER: Fixture.TACKLE, Gen2Battle.ENEMY: Fixture.TACKLE,
@@ -3143,8 +3143,8 @@ func test_an_x_accuracy_makes_the_enemys_moves_stop_missing() -> void:
 	Gen2AIItems.apply(battle.enemy, Gen2AIItems.X_ACCURACY)
 
 	var landed: int = 0
-	for seed: int in 32:
-		battle.rng.seed = seed
+	for seed_value: int in 32:
+		battle.rng.seed = seed_value
 		battle.player.substatus = Gen2Substatus.NONE
 		battle.player.confusion_turns = 0
 		# Both back to full, or Geodude faints partway through; and its PP back,

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -32,18 +32,18 @@ func _write_cache(with_sheets: bool = true) -> void:
 			"font": [RomLayout.FONT_TILES, 3],
 			"frames": [RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES, 3],
 		}
-		for name: String in written:
-			var tiles: int = written[name][0]
-			var value: int = written[name][1]
+		for row_name: String in written:
+			var tiles: int = written[row_name][0]
+			var value: int = written[row_name][1]
 			var indices: PackedByteArray = PackedByteArray()
 			indices.resize(tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
 			indices.fill(value)
-			RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
-			sheets[name] = {
+			RomCache.write_indices(RomCache.tile_path(_directory, row_name), indices)
+			sheets[row_name] = {
 				"width": tiles * Gen2Tiles.TILE_WIDTH,
 				"height": Gen2Tiles.TILE_HEIGHT,
 				"tiles": tiles,
-				"first_code": RomLayout.FONT_FIRST_CODE if name == "font" else 0,
+				"first_code": RomLayout.FONT_FIRST_CODE if row_name == "font" else 0,
 				"bits": 1,
 			}
 
@@ -157,7 +157,7 @@ func test_the_hud_draws_its_panels_where_the_hardware_puts_them() -> void:
 	hud.draw_enemy(screen, Gen2Screen.WIDTH, "PIDGEY", 5)
 	hud.draw_player(screen, Gen2Screen.WIDTH, "CYNDAQUIL", 5, 18, 18)
 
-	assert_ne(_ink_in_row(screen, Gen2BattleHud.ENEMY_NAME.y), 0, "the enemy's name row")
+	assert_ne(_ink_in_row(screen, Gen2BattleHud.ENEMY_NAME.y), 0, "the enemy's row_name row")
 	assert_ne(_ink_in_row(screen, Gen2BattleHud.PLAYER_BAR.y), 0, "the player's bar row")
 	assert_eq(_ink_in_row(screen, Gen2TextBox.STANDARD_TOP), 0, "nothing in the text box")
 	assert_eq(_ink_in_row(screen, 5), 0, "nothing between the two panels")

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -424,11 +424,11 @@ func test_the_scope_lens_makes_criticals_more_common() -> void:
 	var rng := RandomNumberGenerator.new()
 	var plain: int = 0
 	var lensed: int = 0
-	for seed: int in 2000:
-		rng.seed = seed
+	for seed_value: int in 2000:
+		rng.seed = seed_value
 		if Gen2Damage.roll_critical(_data.move(Fixture.TACKLE), rng):
 			plain += 1
-		rng.seed = seed
+		rng.seed = seed_value
 		if Gen2Damage.roll_critical(_data.move(Fixture.TACKLE), rng, false, true):
 			lensed += 1
 	assert_gt(lensed, plain * 3 / 2, "level 1 is 32 in 256 against level 0's 17")

--- a/tests/unit/test_diagnostics.gd
+++ b/tests/unit/test_diagnostics.gd
@@ -15,8 +15,8 @@ func _diagnostics() -> Gen2Diagnostics:
 
 func after_each() -> void:
 	if DirAccess.dir_exists_absolute(SCRATCH):
-		for name: String in DirAccess.get_files_at(SCRATCH):
-			DirAccess.remove_absolute("%s/%s" % [SCRATCH, name])
+		for row_name: String in DirAccess.get_files_at(SCRATCH):
+			DirAccess.remove_absolute("%s/%s" % [SCRATCH, row_name])
 		DirAccess.remove_absolute(SCRATCH)
 
 
@@ -109,9 +109,9 @@ func test_the_bundle_holds_the_report_and_the_log_files() -> void:
 	assert_true(names.has("report.txt"))
 	assert_string_contains(reader.read_file("report.txt").get_string_from_utf8(), "pokerecomp")
 	var logs: int = 0
-	for name: String in names:
+	for row_name: String in names:
 		# The reader lists the folder itself as an entry too.
-		if name.begins_with("logs/") and not name.ends_with("/"):
+		if row_name.begins_with("logs/") and not row_name.ends_with("/"):
 			logs += 1
 	assert_eq(logs, expected, "every kept log file is packed")
 	reader.close()
@@ -176,13 +176,13 @@ func test_files_written_in_the_same_second_still_order_newest_first() -> void:
 		ProjectSettings.get_setting("debug/file_logging/log_path", "")
 	).get_file()
 	var stem: String = live.get_basename()
-	for name: String in [
+	for row_name: String in [
 		"%s2026-08-01T00.00.03.log" % stem,
 		"%s2026-08-01T00.00.01.log" % stem,
 		live,
 		"%s2026-08-01T00.00.02.log" % stem,
 	]:
-		var file: FileAccess = FileAccess.open("%s/%s" % [SCRATCH, name], FileAccess.WRITE)
+		var file: FileAccess = FileAccess.open("%s/%s" % [SCRATCH, row_name], FileAccess.WRITE)
 		file.store_string("x")
 		file = null
 	var order: PackedStringArray = _diagnostics().log_files(SCRATCH)
@@ -198,3 +198,33 @@ func test_the_marker_reads_a_crash_and_nothing_else() -> void:
 	assert_false(Gen2Diagnostics.unclean_marker('{"clean": true}'))
 	assert_false(Gen2Diagnostics.unclean_marker(""), "a first launch is not a crash")
 	assert_false(Gen2Diagnostics.unclean_marker("{ half writ"), "nor is a torn file")
+
+
+## `Gen2ToolPath`: a tool runs with `--path <this project>`, so a relative output
+## path lands in the checkout rather than where the command was run. The test is
+## where a path resolves, not how it is spelt, which is what a guard written on
+## prefixes gets wrong: `res://out.png` is absolute to `is_absolute_path()` and
+## lands in the project all the same.
+func test_an_output_path_inside_the_project_is_refused() -> void:
+	for path: String in [
+		"", "out.png", "./out.png", "sub/out.png", "res://out.png",
+		"res://tools/out.png",
+		ProjectSettings.globalize_path("res://").path_join("out.png"),
+	]:
+		assert_ne(
+			Gen2ToolPath.refusal(path), "", "%s is inside the project" % path
+		)
+
+
+## The paths a tool is supposed to be given. A sibling directory whose name
+## merely starts the same way is not inside the project, which is what the
+## separator in the comparison is for.
+func test_an_output_path_outside_the_project_is_allowed() -> void:
+	var project: String = ProjectSettings.globalize_path("res://").simplify_path()
+	for path: String in [
+		"/tmp/out.png", "user://out.png", "user://logs/out.txt",
+		"%s-notes/out.png" % project, project.get_base_dir().path_join("out.png"),
+	]:
+		assert_eq(
+			Gen2ToolPath.refusal(path), "", "%s is outside the project" % path
+		)

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -179,10 +179,10 @@ func _matchup(
 	}
 
 
-func _species(number: int, name: String, normal: int, shiny: int) -> Dictionary:
+func _species(number: int, row_name: String, normal: int, shiny: int) -> Dictionary:
 	return {
 		"number": number,
-		"name": name,
+		"name": row_name,
 		"stats": {"hp": 45, "attack": 49},
 		"types": [0, 3],
 		"front_tiles": [1, 1],

--- a/tests/unit/test_gold_silver_intro.gd
+++ b/tests/unit/test_gold_silver_intro.gd
@@ -63,19 +63,19 @@ func test_the_silhouette_and_flash_registers_flood_one_colour() -> void:
 ## callback `PlaySpriteAnimations` answers, and every frameset entry names an
 ## OAM set the page holds.
 func test_every_object_resolves_to_a_frameset_and_an_oam_set() -> void:
-	for name: StringName in Gen2GoldSilverIntro.OBJECTS:
-		var row: Dictionary = Gen2GoldSilverIntro.OBJECTS[name]
+	for row_name: StringName in Gen2GoldSilverIntro.OBJECTS:
+		var row: Dictionary = Gen2GoldSilverIntro.OBJECTS[row_name]
 		assert_true(
-			Gen2GoldSilverIntro.FRAMESETS.has(StringName(row["frameset"])), String(name)
+			Gen2GoldSilverIntro.FRAMESETS.has(StringName(row["frameset"])), String(row_name)
 		)
-	for name: StringName in Gen2GoldSilverIntro.FRAMESETS:
-		var frameset: Dictionary = Gen2GoldSilverIntro.FRAMESETS[name]
-		assert_false((frameset["frames"] as Array).is_empty(), String(name))
+	for row_name: StringName in Gen2GoldSilverIntro.FRAMESETS:
+		var frameset: Dictionary = Gen2GoldSilverIntro.FRAMESETS[row_name]
+		assert_false((frameset["frames"] as Array).is_empty(), String(row_name))
 		for entry: Array in frameset["frames"]:
 			assert_between(
-				int(entry[0]), 0, Gen2GoldSilverIntroPage.OAM_SETS.size() - 1, String(name)
+				int(entry[0]), 0, Gen2GoldSilverIntroPage.OAM_SETS.size() - 1, String(row_name)
 			)
-			assert_gt(int(entry[1]), 0, "%s lasts n + 1 frames" % name)
+			assert_gt(int(entry[1]), 0, "%s lasts n + 1 frames" % row_name)
 
 
 ## The three `Intro_GetMonFrontpic` calls and the vtile each is decompressed to,
@@ -83,8 +83,8 @@ func test_every_object_resolves_to_a_frameset_and_an_oam_set() -> void:
 func test_the_starters_are_the_three_johto_ones_at_their_own_vtiles() -> void:
 	var species: Array[int] = []
 	var vtiles: Array[int] = []
-	for name: StringName in Gen2GoldSilverIntro.STARTERS:
-		var row: Dictionary = Gen2GoldSilverIntro.STARTERS[name]
+	for row_name: StringName in Gen2GoldSilverIntro.STARTERS:
+		var row: Dictionary = Gen2GoldSilverIntro.STARTERS[row_name]
 		species.append(int(row["species"]))
 		vtiles.append(int(row["vtile"]))
 	assert_eq(species, [152, 155, 158] as Array[int], "Chikorita, Cyndaquil, Totodile")

--- a/tests/unit/test_input_actions.gd
+++ b/tests/unit/test_input_actions.gd
@@ -12,7 +12,7 @@ func after_each() -> void:
 
 func _key(code: int) -> InputEventKey:
 	var event := InputEventKey.new()
-	event.physical_keycode = code
+	event.physical_keycode = code as Key
 	event.pressed = true
 	return event
 

--- a/tests/unit/test_intro_movie.gd
+++ b/tests/unit/test_intro_movie.gd
@@ -144,7 +144,7 @@ func test_the_perspective_band_is_reported_a_pass_ahead() -> void:
 	while movie.waiting():
 		movie.advance_frame()
 	var band: Array[int] = []
-	for _pass: int in 4:
+	for _step: int in 4:
 		band.append(movie.scroll_x_at(96))
 		movie.advance_frame()
 	# The scene's own first pass has not run on the frame its delay ends; every

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -147,11 +147,11 @@ func _scripts_under(root: String) -> Array[String]:
 	var queue: Array[String] = [root]
 	while not queue.is_empty():
 		var directory: String = queue.pop_front()
-		for name: String in DirAccess.get_directories_at(directory):
-			queue.append("%s/%s" % [directory, name])
-		for name: String in DirAccess.get_files_at(directory):
-			if name.ends_with(".gd"):
-				found.append("%s/%s" % [directory, name])
+		for row_name: String in DirAccess.get_directories_at(directory):
+			queue.append("%s/%s" % [directory, row_name])
+		for row_name: String in DirAccess.get_files_at(directory):
+			if row_name.ends_with(".gd"):
+				found.append("%s/%s" % [directory, row_name])
 	return found
 
 
@@ -227,7 +227,7 @@ func test_a_mod_icon_keeps_its_square_whether_or_not_the_mod_has_a_picture() -> 
 	for square: Control in [blank, drawn]:
 		assert_eq(
 			square.custom_minimum_size, Vector2(side, side),
-			"a name starts at the same place with or without an icon"
+			"a row_name starts at the same place with or without an icon"
 		)
 	assert_eq(
 		(drawn as TextureRect).stretch_mode, TextureRect.STRETCH_KEEP_ASPECT_CENTERED,

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -33,8 +33,8 @@ func _note(turn: Gen2Turn) -> void:
 	_ran.append(turn.move_number)
 
 
-func _watch(event: Dictionary) -> void:
-	_seen.append(event)
+func _watch(queued_event: Dictionary) -> void:
+	_seen.append(queued_event)
 
 
 func test_a_registered_command_runs_inside_a_real_move_sequence() -> void:
@@ -125,13 +125,13 @@ func test_two_mods_claiming_one_effect_is_refused() -> void:
 func test_a_subscriber_sees_published_events_and_cannot_write_through_them() -> void:
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	assert_true(bool(host.subscribe(Gen2ModHost.CHANNEL_BATTLE, MOD, _watch).get("ok", false)))
-	var event: Dictionary = {"type": Gen2Battle.HIT, "damage": 12}
-	Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)
+	var queued_event: Dictionary = {"type": Gen2Battle.HIT, "damage": 12}
+	Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, queued_event)
 	assert_eq(_seen.size(), 1)
 	assert_eq(int(_seen[0]["damage"]), 12)
 	# The subscriber holds a copy, so writing to it reaches nothing.
 	(_seen[0] as Dictionary)["damage"] = 999
-	assert_eq(int(event["damage"]), 12)
+	assert_eq(int(queued_event["damage"]), 12)
 	# And the other channel is a different conversation.
 	Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, {"status": &"waiting"})
 	assert_eq(_seen.size(), 1)
@@ -144,9 +144,9 @@ func test_an_event_mutator_rewrites_presentation_and_not_the_routing_key() -> vo
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	assert_true(bool(host.register_event_mutator(
 		Gen2ModHost.CHANNEL_BATTLE, MOD,
-		func(event: Dictionary) -> Dictionary:
-			event["damage"] = 1
-			return event
+		func(queued_event: Dictionary) -> Dictionary:
+			queued_event["damage"] = 1
+			return queued_event
 	).get("ok", false)))
 	assert_true(bool(host.subscribe(Gen2ModHost.CHANNEL_BATTLE, MOD, _watch).get("ok", false)))
 
@@ -169,13 +169,13 @@ func test_a_mutator_that_changes_the_key_or_answers_with_nothing_is_ignored() ->
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	host.register_event_mutator(
 		Gen2ModHost.CHANNEL_BATTLE, MOD,
-		func(event: Dictionary) -> Dictionary:
-			event["type"] = Gen2Battle.ANIMATION
-			return event
+		func(mutated: Dictionary) -> Dictionary:
+			mutated["type"] = Gen2Battle.ANIMATION
+			return mutated
 	)
-	var event: Dictionary = {"type": Gen2Battle.HIT, "damage": 12}
+	var queued_event: Dictionary = {"type": Gen2Battle.HIT, "damage": 12}
 	assert_eq(
-		StringName(Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, event)["type"]),
+		StringName(Gen2ModHost.publish(Gen2ModHost.CHANNEL_BATTLE, queued_event)["type"]),
 		StringName(Gen2Battle.HIT),
 		"a rewrite cannot turn one screen operation into another"
 	)
@@ -187,7 +187,7 @@ func test_a_mutator_that_changes_the_key_or_answers_with_nothing_is_ignored() ->
 	assert_eq(
 		Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, {"status": &"waiting"}),
 		{"status": &"waiting"},
-		"and a mutator answering with nothing leaves the event alone"
+		"and a mutator answering with nothing leaves the queued_event alone"
 	)
 
 

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -33,8 +33,8 @@ func _clear(path: String = ROOT) -> void:
 	var directory: DirAccess = DirAccess.open(path)
 	if directory == null:
 		return
-	for name: String in directory.get_directories():
-		_clear("%s/%s" % [path, name])
+	for row_name: String in directory.get_directories():
+		_clear("%s/%s" % [path, row_name])
 	for file: String in directory.get_files():
 		DirAccess.remove_absolute("%s/%s" % [path, file])
 	DirAccess.remove_absolute(path)
@@ -817,9 +817,9 @@ func test_a_declared_pack_that_is_absent_is_refused_by_name() -> void:
 ## not a resource pack at all, is refused before a mount is attempted.
 func test_a_pack_that_points_outside_the_mod_is_refused() -> void:
 	for pack: String in ["../other.pck", "/tmp/other.pck", "nested/other.pck", "res://x.pck"]:
-		var source: Dictionary = _valid_manifest()
-		source["pack"] = pack
-		_write_manifest(source)
+		var escaping: Dictionary = _valid_manifest()
+		escaping["pack"] = pack
+		_write_manifest(escaping)
 		assert_eq(
 			Gen2ModManifest.read(_directory)["reason"], &"pack_escapes_mod",
 			"pack %s must be refused" % pack
@@ -1492,7 +1492,9 @@ func test_two_sources_listing_one_mod_leave_it_under_the_first() -> void:
 ## what those measure without appearing anywhere in their output, so they
 ## discover mods and run none.
 func test_a_tool_run_lists_the_mods_it_finds_and_runs_none_of_them() -> void:
-	assert_false(GameRuntime.mods_are_allowed(), "this run is headless and script-driven")
+	assert_false(
+		Gen2GameRuntime.mods_are_allowed(), "this run is headless and script-driven"
+	)
 	_write_dependency_mod("%s/quiet" % Gen2ModHost.ROOT, "quiet", "1.0.0")
 	assert_eq(GameRuntime.load_mods(), [], "nothing was run")
 	assert_true(

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -921,7 +921,7 @@ func test_multi_hit_lands_between_two_and_five_times() -> void:
 		_rng.seed = seed_value
 		var turn: Gen2Turn = _run_move(_battle(), Fixture.MULTI_HIT_MOVE)
 		var hits: int = _of_type(turn.events, Gen2Battle.HIT).size()
-		assert_between(hits, 2, 5, "seed %d" % seed_value)
+		assert_between(hits, 2, 5, "seed_value %d" % seed_value)
 		assert_eq(int(_first(turn.events, Gen2Battle.HIT_TIMES)["times"]), hits)
 
 
@@ -1070,7 +1070,7 @@ func test_psywave_stays_inside_its_own_range() -> void:
 		_rng.seed = seed_value
 		Gen2EffectCommands.run(Gen2EffectCommands.FIXED_DAMAGE, turn)
 		Gen2EffectCommands.run(Gen2EffectCommands.RESET_TYPE_MATCHUP, turn)
-		assert_between(turn.damage, 1, upper - 1, "seed %d" % seed_value)
+		assert_between(turn.damage, 1, upper - 1, "seed_value %d" % seed_value)
 
 
 func test_ohko_rolls_its_own_accuracy_and_leaves_the_damage_to_applydamage() -> void:
@@ -1625,8 +1625,8 @@ func test_brightpowder_takes_its_parameter_off_the_accuracy() -> void:
 	battle.enemy.item = Fixture.BRIGHTPOWDER
 
 	var missed: int = 0
-	for seed: int in 200:
-		battle.rng.seed = seed
+	for seed_value: int in 200:
+		battle.rng.seed = seed_value
 		var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
 		Gen2EffectCommands.run(Gen2EffectCommands.CHECK_HIT, turn)
 		if turn.missed:
@@ -1636,8 +1636,8 @@ func test_brightpowder_takes_its_parameter_off_the_accuracy() -> void:
 	assert_lt(missed, 40, "twenty in 255, not more")
 
 	battle.enemy.item = 0
-	for seed: int in 50:
-		battle.rng.seed = seed
+	for seed_value: int in 50:
+		battle.rng.seed = seed_value
 		var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
 		Gen2EffectCommands.run(Gen2EffectCommands.CHECK_HIT, turn)
 		assert_false(turn.missed, "and without it the same move never misses")
@@ -1650,8 +1650,8 @@ func test_kings_rock_flinches_out_of_its_own_parameter() -> void:
 	battle.player.item = Fixture.KINGS_ROCK
 
 	var flinched: int = 0
-	for seed: int in 256:
-		battle.rng.seed = seed
+	for seed_value: int in 256:
+		battle.rng.seed = seed_value
 		battle.enemy.substatus = Gen2Substatus.NONE
 		var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
 		Gen2EffectCommands.run(Gen2EffectCommands.KINGS_ROCK, turn)
@@ -1705,9 +1705,9 @@ func test_only_the_lists_the_cartridge_gives_kings_rock_have_it() -> void:
 ## which is what leaves the Pokémon on one hit point rather than none.
 func test_a_focus_band_can_hold_a_pokemon_on_one_hit_point() -> void:
 	var survived: int = 0
-	for seed: int in 200:
+	for seed_value: int in 200:
 		var battle: Gen2Battle = _battle()
-		battle.rng.seed = seed
+		battle.rng.seed = seed_value
 		battle.enemy.item = Fixture.FOCUS_BAND
 		battle.enemy.hp = 1
 		var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
@@ -1728,8 +1728,8 @@ func test_a_focus_band_changes_nothing_about_a_hit_that_was_not_lethal() -> void
 	battle.enemy.item = Fixture.FOCUS_BAND
 	var before: int = battle.enemy.hp
 
-	for seed: int in 50:
-		battle.rng.seed = seed
+	for seed_value: int in 50:
+		battle.rng.seed = seed_value
 		battle.enemy.hp = before
 		var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
 		turn.damage = 5
@@ -2260,7 +2260,7 @@ func test_triple_kick_lands_one_two_or_three_times() -> void:
 		battle.enemy.hp = 30000
 		var turn: Gen2Turn = _run_move(battle, Fixture.TRIPLE_KICK, false, {"accuracy": 255})
 		var kicks: int = _of_type(turn.events, Gen2Battle.HIT).size()
-		assert_between(kicks, 1, 3, "seed %d" % seed_value)
+		assert_between(kicks, 1, 3, "seed_value %d" % seed_value)
 		assert_eq(int(_first(turn.events, Gen2Battle.HIT_TIMES)["times"]), kicks)
 		seen[kicks] = true
 	assert_gt(seen.size(), 1, "forty seeds should not all give the same count")
@@ -2314,7 +2314,7 @@ func test_a_rampage_rolls_its_length_once_and_not_again_each_turn() -> void:
 func test_false_swipe_leaves_the_target_standing_on_one() -> void:
 	var battle: Gen2Battle = _battle()
 	battle.enemy.hp = 3
-	var turn: Gen2Turn = _run_move(battle, Fixture.FALSE_SWIPE)
+	_run_move(battle, Fixture.FALSE_SWIPE)
 	assert_eq(battle.enemy.hp, 1)
 	assert_false(battle.enemy.is_fainted())
 
@@ -2322,7 +2322,7 @@ func test_false_swipe_leaves_the_target_standing_on_one() -> void:
 func test_false_swipe_leaves_a_hit_it_could_not_have_killed_alone() -> void:
 	var battle: Gen2Battle = _battle()
 	var full: int = battle.enemy.max_hp()
-	var turn: Gen2Turn = _run_move(battle, Fixture.FALSE_SWIPE)
+	_run_move(battle, Fixture.FALSE_SWIPE)
 	assert_lt(battle.enemy.hp, full, "it still hurts")
 	assert_gt(battle.enemy.hp, 1, "and was not cut down to one")
 
@@ -2848,9 +2848,9 @@ func test_a_doll_refuses_a_stat_drop_and_a_kings_rock() -> void:
 ## spends. "Hung on" is printed over a Pokémon that was never in danger.
 func test_a_focus_band_still_fires_in_front_of_a_doll() -> void:
 	var fired: int = 0
-	for seed: int in 200:
+	for seed_value: int in 200:
 		var battle: Gen2Battle = _battle()
-		battle.rng.seed = seed
+		battle.rng.seed = seed_value
 		_raise_enemy_substitute(battle)
 		battle.enemy.substitute_hp = 200
 		battle.enemy.item = Fixture.FOCUS_BAND
@@ -3172,7 +3172,7 @@ func test_the_first_protect_of_a_chain_always_lands() -> void:
 		var turn: Gen2Turn = _run_move(battle, Fixture.PROTECT)
 		assert_true(
 			Gen2Substatus.has(battle.player.substatus, Gen2Substatus.PROTECT),
-			"seed %d" % seed_value
+			"seed_value %d" % seed_value
 		)
 		assert_eq(_of_type(turn.events, Gen2Battle.PROTECTED_ITSELF).size(), 1)
 		assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 0)
@@ -3782,7 +3782,7 @@ func test_a_locked_on_move_cannot_miss() -> void:
 		# Evasion at the ceiling, which would otherwise cut a 90% move to a third.
 		battle.enemy.stages["evasion"] = 6
 		var turn: Gen2Turn = _run_move(battle, Fixture.SCREECH)
-		assert_false(turn.missed, "seed %d" % seed_value)
+		assert_false(turn.missed, "seed_value %d" % seed_value)
 
 
 ## `.LockOn` names three moves that still cannot reach a target above them, and
@@ -3793,10 +3793,9 @@ func test_a_locked_on_move_cannot_miss() -> void:
 ## to; the test below owns that half.
 func test_a_locked_on_flying_target_is_still_missed_by_the_ground_moves() -> void:
 	for move: int in [Fixture.EARTHQUAKE, Fixture.MAGNITUDE]:
-		var battle: Gen2Battle = _battle()
-		battle.enemy.substatus |= Gen2Substatus.LOCK_ON | Gen2Substatus.FLYING
-		var turn: Gen2Turn = _run_move(battle, move)
-		assert_true(turn.missed, "move %d" % move)
+		var grounded: Gen2Battle = _battle()
+		grounded.enemy.substatus |= Gen2Substatus.LOCK_ON | Gen2Substatus.FLYING
+		assert_true(_run_move(grounded, move).missed, "move %d" % move)
 
 	# The same target is reached by anything else, since the lock-on is read in
 	# front of the hidden check.
@@ -3841,7 +3840,7 @@ func test_spite_takes_two_to_five_pp_off_the_targets_last_move() -> void:
 
 		var event: Dictionary = _first(turn.events, Gen2Battle.PP_REDUCED)
 		var amount: int = int(event["amount"])
-		assert_between(amount, 2, 5, "seed %d" % seed_value)
+		assert_between(amount, 2, 5, "seed_value %d" % seed_value)
 		assert_eq(int(event["slot"]), 0)
 		assert_eq(int(event["move"]), Fixture.TACKLE)
 		assert_eq(battle.enemy.pp_left(0), 35 - amount)
@@ -4061,7 +4060,7 @@ func test_a_wild_pokemon_always_teleports_and_still_draws_the_roll() -> void:
 		var before: int = battle.rng.state
 		var turn: Gen2Turn = _run_enemy_move(battle, Fixture.TELEPORT)
 
-		assert_true(battle.is_over(), "seed %d" % seed_value)
+		assert_true(battle.is_over(), "seed_value %d" % seed_value)
 		assert_eq(battle.forced_out_side(), Gen2Battle.ENEMY)
 		assert_eq(_of_type(turn.events, Gen2Battle.FLED_FROM_BATTLE).size(), 1)
 		assert_ne(battle.rng.state, before, "the roll is drawn and thrown away")

--- a/tests/unit/test_pack_page.gd
+++ b/tests/unit/test_pack_page.gd
@@ -75,7 +75,7 @@ func test_a_row_is_a_name_a_count_and_the_cursor() -> void:
 	var name_codes: PackedByteArray = Gen2Text.encode("AB")
 	assert_eq(
 		map[2 * Gen2PackPage.COLUMNS + Gen2PackPage.NAME_COLUMN], int(name_codes[0]),
-		"the name starts in column 8 of row 2"
+		"the row_name starts in column 8 of row 2"
 	)
 	assert_eq(
 		map[3 * Gen2PackPage.COLUMNS + 17], Gen2PackPage.TIMES_CODE,
@@ -169,15 +169,15 @@ func _name_piece(pocket: int) -> PackedByteArray:
 
 func _write_cache() -> void:
 	var sheets: Dictionary = {}
-	for name: String in ["font", "frames"]:
-		var tiles: int = RomLayout.FONT_TILES if name == "font" \
+	for row_name: String in ["font", "frames"]:
+		var tiles: int = RomLayout.FONT_TILES if row_name == "font" \
 			else RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES
 		var indices := PackedByteArray()
 		indices.resize(tiles * Gen2Tiles.TILE_PIXELS)
 		indices.fill(3)
-		RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
-		sheets[name] = _sheet_entry(tiles, RomLayout.FONT_FIRST_CODE \
-			if name == "font" else RomLayout.FRAME_FIRST_CODE)
+		RomCache.write_indices(RomCache.tile_path(_directory, row_name), indices)
+		sheets[row_name] = _sheet_entry(tiles, RomLayout.FONT_FIRST_CODE \
+			if row_name == "font" else RomLayout.FRAME_FIRST_CODE)
 
 	var menu := PackedByteArray()
 	menu.resize(RomLayout.PACK_MENU_TILES * Gen2Tiles.TILE_PIXELS)
@@ -187,18 +187,18 @@ func _write_cache() -> void:
 
 	# Piece p is filled with index p, and the female sheet with the piece after
 	# it, so which sheet and which piece reached the screen are both readable.
-	for name: String in ["pack_pockets", "pack_pockets_female"]:
+	for row_name: String in ["pack_pockets", "pack_pockets_female"]:
 		var strip := PackedByteArray()
 		var width: int = RomLayout.PACK_TILES * Gen2Tiles.TILE_WIDTH
 		strip.resize(width * Gen2Tiles.TILE_HEIGHT)
-		var shift: int = 1 if name.ends_with("female") else 0
+		var shift: int = 1 if row_name.ends_with("female") else 0
 		for row: int in Gen2Tiles.TILE_HEIGHT:
 			for column: int in width:
 				@warning_ignore("integer_division")
 				var piece: int = column / (RomLayout.PACK_POCKET_TILES * Gen2Tiles.TILE_WIDTH)
 				strip[row * width + column] = (piece + shift) % RomLayout.PACK_POCKETS
-		RomCache.write_indices(RomCache.tile_path(_directory, name), strip)
-		sheets[name] = _sheet_entry(RomLayout.PACK_TILES, 0)
+		RomCache.write_indices(RomCache.tile_path(_directory, row_name), strip)
+		sheets[row_name] = _sheet_entry(RomLayout.PACK_TILES, 0)
 
 	var names: Array = []
 	for pocket: int in RomLayout.PACK_POCKETS:

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -55,17 +55,17 @@ func _write_cache() -> void:
 	var first_codes: Dictionary = {
 		"font": RomLayout.FONT_FIRST_CODE, "frames": RomLayout.FRAME_FIRST_CODE,
 	}
-	for name: String in written:
-		var tiles: int = written[name]
+	for row_name: String in written:
+		var tiles: int = written[row_name]
 		var indices: PackedByteArray = PackedByteArray()
 		indices.resize(tiles * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT)
-		indices.fill(2 if name == "battle_font" else 3)
-		RomCache.write_indices(RomCache.tile_path(_directory, name), indices)
-		sheets[name] = {
+		indices.fill(2 if row_name == "battle_font" else 3)
+		RomCache.write_indices(RomCache.tile_path(_directory, row_name), indices)
+		sheets[row_name] = {
 			"width": tiles * Gen2Tiles.TILE_WIDTH,
 			"height": Gen2Tiles.TILE_HEIGHT,
 			"tiles": tiles,
-			"first_code": int(first_codes.get(name, 0)),
+			"first_code": int(first_codes.get(row_name, 0)),
 			"bits": 1,
 		}
 
@@ -133,7 +133,7 @@ func _rows(count: int = 2) -> Array:
 func _animated(rows: Array, cursor: int, passes: int) -> Image:
 	var page: Gen2PartyMenuPage = _page()
 	page.reset(rows)
-	for _pass: int in passes:
+	for _step: int in passes:
 		page.advance(rows, cursor)
 	return page.render(rows, cursor, Gen2BattleSwitchMenu.prompt_text())
 
@@ -468,7 +468,7 @@ func test_every_page_indicator_is_a_two_by_two_block() -> void:
 ## 6, so nothing on the upper half moves and five pages is the ceiling.
 func test_a_fourth_page_grows_the_indicator_run_leftward_and_moves_the_arrow() -> void:
 	assert_true(bool(Gen2ModHost.instance().register_stats_page(
-		&"testmod", {"build": func(_page: Dictionary) -> Array: return []}
+		&"testmod", {"build": func(_built: Dictionary) -> Array: return []}
 	)["ok"]))
 	assert_eq(
 		Gen2StatsScreenPage.page_indicators(4),

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -219,14 +219,14 @@ func _write_class_names(data: PackedByteArray, at: int) -> void:
 	var count: int = RomLayout.trainer_class_count(_layout)
 	var cursor: int = at
 	for trainer_class: int in range(1, count + 1):
-		var name: String = "LASS"
+		var row_name: String = "LASS"
 		if trainer_class == 1:
-			name = RomImporter.TRAINER_FIRST_CLASS
+			row_name = RomImporter.TRAINER_FIRST_CLASS
 		elif trainer_class == RomImporter.TRAINER_MIDDLE_CLASS:
-			name = RomImporter.TRAINER_MIDDLE_CLASS_NAME
+			row_name = RomImporter.TRAINER_MIDDLE_CLASS_NAME
 		elif trainer_class == count:
-			name = String(_layout["trainer_last_class"])
-		var encoded: PackedByteArray = Gen2Text.encode(name)
+			row_name = String(_layout["trainer_last_class"])
+		var encoded: PackedByteArray = Gen2Text.encode(row_name)
 		encoded.append(Gen2Text.TERMINATOR)
 		_write(data, cursor, encoded)
 		cursor += encoded.size()
@@ -1454,8 +1454,8 @@ func test_the_pokegear_cards_decode_as_tile_then_length() -> void:
 	_write(data, int((_layout["town_map"] as Dictionary)["cards"]), _cards())
 	var cards: Dictionary = RomImporter.read_pokegear_cards(_rom(data), _layout)
 	assert_eq(cards.size(), RomLayout.POKEGEAR_CARD_ORDER.size())
-	for name: String in RomLayout.POKEGEAR_CARD_ORDER:
-		var cells: PackedByteArray = cards[name]
+	for row_name: String in RomLayout.POKEGEAR_CARD_ORDER:
+		var cells: PackedByteArray = cards[row_name]
 		assert_eq(cells.size(), RomLayout.POKEGEAR_CARD_CELLS)
 		assert_eq(cells[0], Gen2TownMapPage.CARD_BLANK_TILE)
 

--- a/tests/unit/test_rom_verifier.gd
+++ b/tests/unit/test_rom_verifier.gd
@@ -20,8 +20,8 @@ func after_each() -> void:
 		DirAccess.remove_absolute(path)
 
 
-func _write_file(name: String, size: int, fill: int = 0) -> String:
-	var path: String = "%s/%s" % [SCRATCH_DIR, name]
+func _write_file(row_name: String, size: int, fill: int = 0) -> String:
+	var path: String = "%s/%s" % [SCRATCH_DIR, row_name]
 	var file: FileAccess = FileAccess.open(path, FileAccess.WRITE)
 	var buffer: PackedByteArray = []
 	buffer.resize(size)

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -162,9 +162,9 @@ func test_starting_a_new_game_stages_the_slot_and_writes_nothing() -> void:
 		"no slot on disk until the intro finishes"
 	)
 	assert_eq(GameRuntime.selected_game_id, _data.id)
-	var pending: Dictionary = GameRuntime.take_pending_new_game()
-	assert_eq(int(pending["slot"]), 0)
-	assert_eq(String(pending["label"]), "Run one")
+	var waiting: Dictionary = GameRuntime.take_pending_new_game()
+	assert_eq(int(waiting["slot"]), 0)
+	assert_eq(String(waiting["label"]), "Run one")
 
 
 ## The only name the launcher takes is the save's own. The field is the slot

--- a/tests/unit/test_slot_machine.gd
+++ b/tests/unit/test_slot_machine.gd
@@ -39,9 +39,9 @@ func _strips() -> Array[PackedByteArray]:
 	return out
 
 
-func _machine(coins: int = 200, lucky: bool = false, seed: int = 1) -> Gen2SlotMachine:
+func _machine(coins: int = 200, lucky: bool = false, seed_value: int = 1) -> Gen2SlotMachine:
 	var rng := RandomNumberGenerator.new()
-	rng.seed = seed
+	rng.seed = seed_value
 	return Gen2SlotMachine.create(_strips(), coins, lucky, rng)
 
 
@@ -115,9 +115,9 @@ func test_cancelling_the_menu_leaves_the_game() -> void:
 ## for, and `SLOTS_NO_BIAS` matches nothing: an unbiased spin cannot pay.
 func test_an_unbiased_spin_never_lines_anything_up() -> void:
 	var unbiased: int = 0
-	for seed: int in 24:
-		var machine: Gen2SlotMachine = _machine(200, false, seed)
-		assert_true(_spin(machine, 3), "spin %d must reach its payout" % seed)
+	for seed_value: int in 24:
+		var machine: Gen2SlotMachine = _machine(200, false, seed_value)
+		assert_true(_spin(machine, 3), "spin %d must reach its payout" % seed_value)
 		if machine.bias() != Gen2SlotMachine.SLOTS_NO_BIAS:
 			continue
 		unbiased += 1
@@ -131,8 +131,8 @@ func test_an_unbiased_spin_never_lines_anything_up() -> void:
 ## `Slots_GetPayout.PayoutTable` against `wCoins`, over whichever seeds pay.
 func test_a_match_pays_its_own_table_row() -> void:
 	var paid: int = 0
-	for seed: int in 64:
-		var machine: Gen2SlotMachine = _machine(200, true, seed)
+	for seed_value: int in 64:
+		var machine: Gen2SlotMachine = _machine(200, true, seed_value)
 		assert_true(_spin(machine, 3))
 		var matched: int = machine.matched()
 		if matched == Gen2SlotMachine.SLOTS_NO_MATCH:

--- a/tests/unit/test_smoke.gd
+++ b/tests/unit/test_smoke.gd
@@ -12,14 +12,14 @@ func _files(dir_path: String, extension: String, out: PackedStringArray) -> void
 	if dir == null:
 		return
 	dir.list_dir_begin()
-	var name: String = dir.get_next()
-	while name != "":
-		var full: String = "%s/%s" % [dir_path, name]
+	var row_name: String = dir.get_next()
+	while row_name != "":
+		var full: String = "%s/%s" % [dir_path, row_name]
 		if dir.current_is_dir():
 			_files(full, extension, out)
-		elif name.ends_with(extension):
+		elif row_name.ends_with(extension):
 			out.append(full)
-		name = dir.get_next()
+		row_name = dir.get_next()
 	dir.list_dir_end()
 
 

--- a/tests/unit/test_title_scene.gd
+++ b/tests/unit/test_title_scene.gd
@@ -296,9 +296,9 @@ func test_golds_trail_alternates_its_two_pictures_and_silvers_does_not() -> void
 		for sprite: Dictionary in gold.sprites():
 			if StringName(sprite["kind"]) != Gen2TitleScene.SPRITE_TRAIL:
 				continue
-			var set: int = int(sprite["tile"])
-			if sets.is_empty() or sets[sets.size() - 1] != set:
-				sets.append(set)
+			var ordering: int = int(sprite["tile"])
+			if sets.is_empty() or sets[sets.size() - 1] != ordering:
+				sets.append(ordering)
 			break
 	# Every trail on screen is on the same phase, since they are spawned on a
 	# four-frame cadence and the frameset's cycle is four frames long.

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -8422,3 +8422,83 @@ func _special_world(state: Gen2WorldState = null) -> Gen2WorldAPI:
 
 func _run_special(world: Gen2WorldAPI) -> Array:
 	return _run_script(world, world.dispatch_script_events())
+
+
+## `BattleTowerAction` is one special reached with a `setval` in front of it, and
+## its jumptable both reads and writes wScriptVar. The three rows the tower's own
+## scripts open with: the state is set, read back, and the streak reset.
+func test_the_battle_tower_action_reads_and_writes_the_sram_section() -> void:
+	_write_special_script([
+		Gen2WorldScript.SETVAL, Gen2BattleTower.ACTION_SET_WON_CHALLENGE,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_ACTION, 0,
+		Gen2WorldScript.SETVAL, Gen2BattleTower.ACTION_GET_CHALLENGE_STATE,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_ACTION, 0,
+		Gen2WorldScript.WRITEMEM, 0xA0, 0xD1,
+		Gen2WorldScript.END,
+	])
+	var state := Gen2WorldState.new()
+	state.battle_tower().beaten = 5
+	state.battle_tower().trainers[0] = 12
+	var world: Gen2WorldAPI = _special_world(state)
+	assert_eq(_final_status(_run_special(world)), &"complete")
+	assert_eq(state.battle_tower().challenge_state, Gen2BattleTower.WON_CHALLENGE)
+	assert_eq(
+		state.script_memory(0xD1A0), Gen2BattleTower.WON_CHALLENGE,
+		"the read leaves the state in wScriptVar"
+	)
+
+	_write_special_script([
+		Gen2WorldScript.SETVAL, Gen2BattleTower.ACTION_RESET_DATA,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_ACTION, 0,
+		Gen2WorldScript.END,
+	])
+	var reset: Gen2WorldAPI = _special_world(state)
+	assert_eq(_final_status(_run_special(reset)), &"complete")
+	assert_eq(state.battle_tower().beaten, 0)
+	assert_eq(state.battle_tower().trainers[0], Gen2BattleTower.NO_TRAINER)
+
+
+## `SaveBattleTowerLevelGroup` and `LoadBattleTowerLevelGroup` are the two halves
+## of one byte: the room menu writes WRAM, only the save at the end of a session
+## copies it into SRAM, and a resumed challenge reads it back.
+func test_the_chosen_room_only_reaches_sram_when_the_session_is_saved() -> void:
+	_write_special_script([
+		Gen2WorldScript.SETVAL, Gen2BattleTower.ACTION_SAVE_LEVEL_GROUP,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_ACTION, 0,
+		Gen2WorldScript.END,
+	])
+	var state := Gen2WorldState.new()
+	state.battle_tower().chosen_group = 6
+	assert_eq(state.battle_tower().level_group, 0, "nothing has been saved yet")
+	assert_eq(_final_status(_run_special(_special_world(state))), &"complete")
+	assert_eq(state.battle_tower().level_group, 6)
+
+	_write_special_script([
+		Gen2WorldScript.SETVAL, Gen2BattleTower.ACTION_LOAD_LEVEL_GROUP,
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_ACTION, 0,
+		Gen2WorldScript.WRITEMEM, 0xA0, 0xD1,
+		Gen2WorldScript.END,
+	])
+	state.battle_tower().chosen_group = 0
+	assert_eq(_final_status(_run_special(_special_world(state))), &"complete")
+	assert_eq(state.battle_tower().chosen_group, 6)
+	assert_eq(state.script_memory(0xD1A0), 6)
+
+
+## `Reset` is `home/init.asm`'s own soft reset, and nothing follows it in any
+## script: the room's save-and-quit branch ends there.
+func test_the_battle_tower_reset_ends_the_script_and_asks_for_a_restart() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_RESET, 0,
+		Gen2WorldScript.SETEVENT, 0x12, 0x00,
+		Gen2WorldScript.END,
+	])
+	var world: Gen2WorldAPI = _special_world()
+	var results: Array = _run_special(world)
+	var asked: bool = false
+	for result: Dictionary in results:
+		for event: Dictionary in result.get("events", []):
+			if event.get("type", &"") == &"soft_reset_requested":
+				asked = true
+	assert_true(asked, "the console restarts")
+	assert_false(world.event_flag_active(0x12), "nothing behind it runs")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4721,9 +4721,9 @@ func test_a_writetext_says_whether_its_text_owes_a_press() -> void:
 		data.world_map(1, 1).events["coord_events"][0]["script"] = int(expected["script"])
 		var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
 		assert_eq(world.dispatch_script_events(Vector2i(7, 6))[0]["status"], &"waiting")
-		var pending: Dictionary = world.pending_script_input()
-		assert_eq(StringName(pending.get("type", &"")), &"text")
-		assert_eq(bool(pending.get("prompt", true)), bool(expected["prompt"]),
+		var waiting: Dictionary = world.pending_script_input()
+		assert_eq(StringName(waiting.get("type", &"")), &"text")
+		assert_eq(bool(waiting.get("prompt", true)), bool(expected["prompt"]),
 			"script %04X" % int(expected["script"]))
 
 
@@ -6478,7 +6478,7 @@ func test_a_warp_clears_the_turning_direction() -> void:
 
 
 func _finish_step(world: Gen2WorldAPI) -> void:
-	for _pass: int in 64:
+	for _step: int in 64:
 		if not world.player_step_in_progress():
 			return
 		world.advance_player_step_pass()
@@ -7578,7 +7578,7 @@ func test_a_catalogued_site_hands_over_what_a_mod_patched() -> void:
 	assert_eq(int(request["values"]["level"]), 3)
 
 	## The battle is answered and the give runs behind it, into its own
-	## acknowledge text, which is where the script is left waiting.
+	## acknowledge text, which is where the script is left pending.
 	var after: Array = world.complete_runtime_request({
 		"ok": true, "outcome": Gen2WorldBattleAdapter.OUTCOME_WON,
 	})

--- a/tests/unit/test_world_bag_host.gd
+++ b/tests/unit/test_world_bag_host.gd
@@ -217,7 +217,7 @@ func test_an_induction_records_the_party_newest_first() -> void:
 	assert_eq(Gen2HallOfFame.win_count(records), 2)
 
 	## `sHallOfFame` holds thirty and the oldest falls off the end.
-	for _pass: int in Gen2HallOfFame.MAX_RECORDS:
+	for _step: int in Gen2HallOfFame.MAX_RECORDS:
 		records = Gen2HallOfFame.inducted(records, _save)
 	assert_eq(records.size(), Gen2HallOfFame.MAX_RECORDS)
 	assert_eq(Gen2HallOfFame.win_count(records), 2 + Gen2HallOfFame.MAX_RECORDS)

--- a/tests/unit/test_world_day_care.gd
+++ b/tests/unit/test_world_day_care.gd
@@ -338,13 +338,13 @@ func test_the_counter_runs_down_a_step_at_a_time_and_offers_an_egg() -> void:
 	Gen2WorldDayCare.init_breeding(state, _data, "RED", 1, _seeded(9))
 	var random: RandomNumberGenerator = _seeded(4)
 	var steps: int = state.steps_to_egg()
-	for _pass: int in steps - 1:
+	for _step: int in steps - 1:
 		assert_false(Gen2WorldDayCare.step(state, _data, random))
 	assert_eq(state.steps_to_egg(), 1)
 	# The pass that empties the counter re-rolls it and rolls for the egg; it may
 	# refuse, so the walk runs until one is offered rather than asserting on one.
 	var offered: bool = false
-	for _pass: int in 4000:
+	for _step: int in 4000:
 		if Gen2WorldDayCare.step(state, _data, random):
 			offered = true
 			break

--- a/tests/unit/test_world_encounters.gd
+++ b/tests/unit/test_world_encounters.gd
@@ -150,9 +150,9 @@ func test_roaming_selection_uses_the_land_roll_before_normal_slots() -> void:
 		"slots": slots,
 	}
 	var found: Dictionary = {}
-	for seed: int in range(1, 512):
+	for seed_value: int in range(1, 512):
 		var random := RandomNumberGenerator.new()
-		random.seed = seed
+		random.seed = seed_value
 		found = Gen2WorldEncounter.resolve(
 			record, Gen2WorldEncounter.METHOD_GRASS, Gen2WorldPalette.TIME_DAY,
 			random, true, {

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -98,9 +98,9 @@ func test_name_rater_treats_an_empty_or_unchanged_entry_as_unchanged() -> void:
 		var settled: Dictionary = Gen2NameRater.ending_for_entry(entered, "SPARKY")
 		assert_eq(settled["ending"], Gen2NameRater.ENDING_SAME_NAME, entered)
 		assert_eq(settled["nickname"], "SPARKY", entered)
-	var renamed: Dictionary = Gen2NameRater.ending_for_entry("BOLT", "SPARKY")
-	assert_eq(renamed["ending"], Gen2NameRater.ENDING_FINISHED)
-	assert_eq(renamed["nickname"], "BOLT")
+	var was_renamed: Dictionary = Gen2NameRater.ending_for_entry("BOLT", "SPARKY")
+	assert_eq(was_renamed["ending"], Gen2NameRater.ENDING_FINISHED)
+	assert_eq(was_renamed["nickname"], "BOLT")
 
 
 ## `GetNicknamenameLength` stops at MON_NAME_LENGTH - 1, so two entries that
@@ -675,7 +675,7 @@ func test_a_stone_will_not_evolve_an_everstone_holder_from_the_pack() -> void:
 ## than one, since the branch behind the gate is a roll: before the city, no
 ## draw converts anything.
 func test_a_shuckle_holding_a_berry_makes_juice_only_past_goldenrod() -> void:
-	var flag: int = _world.state.engine_flag(
+	var flag: int = Gen2WorldState.engine_flag(
 		Gen2WorldState.ENGINE_REACHED_GOLDENROD, true
 	)
 	assert_false(_world.state.is_engine_flag_active(flag), "the fixture starts short of it")
@@ -708,7 +708,7 @@ func _juice_run(seed_value: int) -> bool:
 ## spread, and nothing is infected de novo while one is standing, so the strain
 ## every seed can produce is the carrier's own rather than a fresh roll.
 func test_a_carrier_spreads_its_own_strain_and_blocks_a_new_infection() -> void:
-	_world.state.set_engine_flag(_world.state.engine_flag(
+	_world.state.set_engine_flag(Gen2WorldState.engine_flag(
 		Gen2WorldState.ENGINE_REACHED_GOLDENROD, true
 	), true)
 	var spread: int = 0

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -70,6 +70,17 @@ func test_crystal_trainer_and_tutorial_commands_use_the_pinned_layout() -> void:
 	assert_eq(tutorial["name"], &"catchtutorial")
 	assert_eq(tutorial["value"], 3)
 
+	## `battletowertext`, raw $a4, whose operand is a BATTLETOWERTEXT_* index.
+	## Gold and Silver's command table stops at $a1, so their $a4 is nothing.
+	var tower_text: Dictionary = Gen2WorldScript.command_at(
+		PackedByteArray([0xA4, 2]), 0, true
+	)
+	assert_true(tower_text["ok"])
+	assert_eq(tower_text["name"], &"battletowertext")
+	assert_eq(tower_text["width"], 2)
+	assert_eq(tower_text["value"], 2)
+	assert_false(Gen2WorldScript.command_at(PackedByteArray([0xA4, 2]), 0, false)["ok"])
+
 
 func test_raw_opcode_shifts_only_at_and_above_the_farjumptext_insertion() -> void:
 	# Below the shift boundary both profiles agree on the raw byte.

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -436,8 +436,8 @@ func test_name_rater_special_stages_a_request_carrying_all_ten_boxes() -> void:
 	assert_true(resolved["ok"], JSON.stringify(resolved))
 	var lines: Dictionary = resolved["data"]["name_rater_text"]
 	assert_eq(lines.size(), RomLayout.NAME_RATER_TEXT_ORDER.size())
-	for name: String in RomLayout.NAME_RATER_TEXT_ORDER:
-		assert_false(String(lines[name]).is_empty(), name)
+	for row_name: String in RomLayout.NAME_RATER_TEXT_ORDER:
+		assert_false(String(lines[row_name]).is_empty(), row_name)
 
 
 ## A cache imported before format 76 carries none of the boxes, and inventing
@@ -500,8 +500,8 @@ func test_move_deleter_special_stages_a_request_carrying_all_eight_boxes() -> vo
 	assert_true(resolved["ok"], JSON.stringify(resolved))
 	var lines: Dictionary = resolved["data"]["move_deleter_text"]
 	assert_eq(lines.size(), RomLayout.MOVE_DELETER_TEXT_ORDER.size())
-	for name: String in RomLayout.MOVE_DELETER_TEXT_ORDER:
-		assert_false(String(lines[name]).is_empty(), name)
+	for row_name: String in RomLayout.MOVE_DELETER_TEXT_ORDER:
+		assert_false(String(lines[row_name]).is_empty(), row_name)
 
 
 func test_move_deleter_refuses_a_cache_without_his_boxes() -> void:

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -638,3 +638,92 @@ func test_the_deferred_routines_state_survives_a_round_trip() -> void:
 	assert_eq(restored.buenas_password(), 0x32)
 	assert_eq(restored.kenji_break_timer(), 5)
 	assert_true(restored.battle_caught_celebi())
+
+
+## `SECTION "SRAM Battle Tower"`: a challenge saved between two battles has to
+## come back with the room it chose, the trainers it has already met and the
+## reward it drew, or the streak restarts against the same opponents.
+func test_a_battle_tower_challenge_survives_a_round_trip() -> void:
+	var state := Gen2WorldState.new()
+	var tower: Gen2BattleTower = state.battle_tower()
+	tower.challenge_state = Gen2BattleTower.CHALLENGE_IN_PROGRESS
+	tower.beaten = 3
+	tower.chosen_group = 7
+	tower.level_group = 7
+	tower.trainers = [12, 40, 3, 0xFF, 0xFF, 0xFF, 0xFF]
+	tower.save_file_flags = Gen2BattleTower.FLAG_EXPLANATION_READ
+	tower.reward = Gen2BattleTower.MIN_REWARD
+	tower.previous_mons = [135, 197, 6]
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	var back: Gen2BattleTower = restored.battle_tower()
+	assert_eq(back.challenge_state, Gen2BattleTower.CHALLENGE_IN_PROGRESS)
+	assert_eq(back.beaten, 3)
+	assert_eq(back.chosen_group, 7)
+	assert_eq(back.level_group, 7)
+	assert_eq(back.trainers, [12, 40, 3, 0xFF, 0xFF, 0xFF, 0xFF])
+	assert_eq(back.save_file_flags, Gen2BattleTower.FLAG_EXPLANATION_READ)
+	assert_eq(back.reward, Gen2BattleTower.MIN_REWARD)
+	assert_eq(back.previous_mons, [135, 197, 6])
+
+
+## A slot written before the tower existed reads as one with no challenge in it,
+## which is the truth about it: nothing versions for this, the way `box_names`
+## and the Hall of Fame do not.
+func test_a_slot_with_no_battle_tower_record_reads_as_no_challenge() -> void:
+	var raw: Dictionary = Gen2WorldState.new().to_dict()
+	raw.erase("battle_tower")
+	var tower: Gen2BattleTower = Gen2WorldState.from_dict(raw).battle_tower()
+	assert_eq(tower.challenge_state, Gen2BattleTower.NO_CHALLENGE)
+	assert_eq(tower.beaten, 0)
+	assert_eq(tower.trainers.size(), Gen2BattleTower.STREAK_LENGTH)
+	assert_eq(tower.trainers[0], Gen2BattleTower.NO_TRAINER)
+
+
+## `ResetBattleTowerTrainersSRAM` clears the streak and its count and nothing
+## else: `Script_ChooseChallenge` runs it every time the counter is approached,
+## and a cleared explanation flag would make the receptionist explain the tower
+## again on every visit.
+func test_resetting_the_streak_keeps_the_explanation_and_the_room() -> void:
+	var tower := Gen2BattleTower.new()
+	tower.beaten = 4
+	tower.trainers[0] = 12
+	tower.level_group = 5
+	tower.save_file_flags = Gen2BattleTower.FLAG_EXPLANATION_READ
+	tower.reset_trainers()
+	assert_eq(tower.beaten, 0)
+	assert_eq(tower.trainers[0], Gen2BattleTower.NO_TRAINER)
+	assert_eq(tower.level_group, 5)
+	assert_eq(tower.save_file_flags, Gen2BattleTower.FLAG_EXPLANATION_READ)
+
+
+## `BattleTower_GiveReward`'s own shape, which is not "is there room": a pack
+## under `MAX_ITEMS` always has room for a new row, and a full one only when it
+## already carries the reward with fewer than 95 of it.
+func test_a_full_pack_turns_the_reward_into_a_potion() -> void:
+	var tower := Gen2BattleTower.new()
+	tower.reward = Gen2BattleTower.MIN_REWARD
+	assert_eq(tower.reward_for({1: 1}), Gen2BattleTower.MIN_REWARD)
+	var full: Dictionary = {}
+	for item: int in Gen2WorldPack.MAX_ITEMS:
+		full[item + 1] = 1
+	assert_eq(tower.reward_for(full), Gen2BattleTower.REWARD_FULL_PACK)
+	full.erase(1)
+	full[Gen2BattleTower.MIN_REWARD] = 94
+	assert_eq(tower.reward_for(full), Gen2BattleTower.MIN_REWARD)
+	full[Gen2BattleTower.MIN_REWARD] = 95
+	assert_eq(tower.reward_for(full), Gen2BattleTower.REWARD_FULL_PACK)
+
+
+## LUCKY_PUNCH sits inside `BATTLETOWER_MIN_REWARD`..`BATTLETOWER_MAX_REWARD`
+## without being a reward, so the roll that lands on it is drawn again.
+func test_the_reward_is_a_stat_booster_and_never_the_lucky_punch() -> void:
+	var tower := Gen2BattleTower.new()
+	var seen: Dictionary = {}
+	for seed_value: int in 200:
+		var random := RandomNumberGenerator.new()
+		random.seed = seed_value
+		var item: int = tower.choose_reward(random)
+		assert_between(item, Gen2BattleTower.MIN_REWARD, Gen2BattleTower.MAX_REWARD)
+		assert_ne(item, Gen2BattleTower.LUCKY_PUNCH)
+		seen[item] = true
+	assert_eq(seen.size(), Gen2BattleTower.MAX_REWARD - Gen2BattleTower.MIN_REWARD)

--- a/tools/checks/battle_tower.gd
+++ b/tools/checks/battle_tower.gd
@@ -1,0 +1,424 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the Battle Tower against freshly imported real caches, on all three
+## games.
+##
+## Expected values come from the pinned pokecrystal source: the 70 rows of
+## data/battle_tower/classes.asm, the ten level groups of
+## data/battle_tower/parties.asm, data/trainers/genders.asm,
+## data/trainers/sprites.asm and mobile/mobile_46.asm's own menu strings. The
+## pins here are counted off the asm rather than read from [Gen2BattleTower]'s
+## own tables, so a mistranscribed row is a failure instead of an agreement.
+##
+## Gold and Silver ship no tower at all, which is checked as an absence rather
+## than as an empty table: the cartridge has no map, no routine and no data for
+## one, and a cache that claims otherwise is a wrong pin.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- battle_tower
+
+## `BattleTowerTrainers`' four corners: the run's own ends and the two rows
+## either side of `assert_table_length BATTLETOWER_NUM_UNIQUE_MON`, which is
+## where Crystal 1.0's sampler stops.
+## The `; nn` comments in constants/trainer_constants.asm are hexadecimal:
+## FISHER is $25, CAMPER $36, GENTLEMAN $20 and FIREBREATHER $30.
+const EXPECTED_TRAINERS: Dictionary = {
+	0: ["HANSON", 0x25], 20: ["McMAHILL", 0x36], 21: ["OBRIEN", 0x20], 69: ["WONG", 0x30],
+}
+
+## `BattleTowerMons`' first row of each level group: species, held item and the
+## four moves, counted off data/battle_tower/parties.asm.
+const EXPECTED_FIRST_MONS: Array = [
+	# JOLTEON/MIRACLEBERRY: THUNDERBOLT, HYPER_BEAM, SHADOW_BALL, ROAR
+	[135, 109, [85, 63, 247, 46]],
+	# UMBREON/LEFTOVERS: PROTECT, TOXIC, MUD_SLAP, ATTRACT
+	[197, 146, [182, 92, 189, 213]],
+	# JOLTEON/MIRACLEBERRY: THUNDERBOLT, THUNDER_WAVE, ROAR, MUD_SLAP
+	[135, 109, [85, 86, 46, 189]],
+	# TAUROS/GOLD_BERRY: RETURN, HYPER_BEAM, EARTHQUAKE, IRON_TAIL
+	[128, 174, [216, 63, 89, 231]],
+	# KINGDRA/GOLD_BERRY: SURF, HYPER_BEAM, BLIZZARD, DRAGONBREATH
+	[230, 174, [57, 63, 59, 225]],
+	# KINGDRA/LEFTOVERS: DRAGONBREATH, SURF, HYPER_BEAM, BLIZZARD
+	[230, 146, [225, 57, 63, 59]],
+	# JOLTEON/MIRACLEBERRY: THUNDERBOLT, HYPER_BEAM, SHADOW_BALL, ROAR
+	[135, 109, [85, 63, 247, 46]],
+	# JOLTEON/MIRACLEBERRY: THUNDER_WAVE, THUNDERBOLT, IRON_TAIL, ROAR
+	[135, 109, [86, 85, 231, 46]],
+	# UMBREON/KINGS_ROCK: FAINT_ATTACK, MUD_SLAP, MOONLIGHT, CONFUSE_RAY
+	[197, 82, [185, 189, 236, 109]],
+	# HOUNDOOM/MINT_BERRY: CRUNCH, FLAMETHROWER, ROAR, REST
+	[229, 84, [242, 53, 46, 156]],
+]
+
+## `Strings_L10ToL100` and `MenuData_ChallengeExplanationCancel`, decoded.
+const EXPECTED_LEVEL_ROWS: Array[String] = [
+	"L:10", "L:20", "L:30", "L:40", "L:50", "L:60", "L:70", "L:80", "L:90",
+	"L:100", "CANCEL",
+]
+const EXPECTED_MENU_ROWS: Array[String] = ["Challenge", "Explanation", "Cancel"]
+
+## `BATTLE_TOWER_BATTLE_ROOM`, its warp-in cell, and how many script steps the
+## room's scene is driven for before the first fight has to be up.
+const BATTLE_ROOM_GROUP: int = 22
+const BATTLE_ROOM_MAP: int = 12
+const BATTLE_ROOM_CELL: Vector2i = Vector2i(3, 7)
+const BATTLE_ROOM_FRAME_CAP: int = 512
+
+## `BTTrainerClassGenders`' own ends: FALKNER is MALE and GRUNTF is FEMALE.
+const EXPECTED_GENDERS: Dictionary = {0: 0, 65: 1}
+## `BTTrainerClassSprites`' own ends: SPRITE_FALKNER ($12) and SPRITE_ROCKET_GIRL
+## ($36), the constants file's comments being hexadecimal here as well.
+const EXPECTED_SPRITES: Dictionary = {0: 0x12, 65: 0x36}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		if _r.data.id != &"crystal":
+			_r.check(
+				not _r.data.has_battle_tower(),
+				"%s has a Battle Tower block, which its cartridge ships nothing for" % _r.data.id
+			)
+			return
+		_verify_trainers()
+		_verify_mons()
+		_verify_strings()
+		_verify_class_tables()
+		_verify_sampler()
+		_verify_rules()
+		_verify_battle_room()
+	)
+
+
+func _verify_trainers() -> void:
+	var rows: Array = _r.data.battle_tower().get("trainers", []) as Array
+	if not _r.check(
+		rows.size() == Gen2BattleTower.NUM_UNIQUE_TRAINERS,
+		"BattleTowerTrainers has %d rows, not %d." % [
+			rows.size(), Gen2BattleTower.NUM_UNIQUE_TRAINERS,
+		]
+	):
+		return
+	for index: Variant in EXPECTED_TRAINERS:
+		var row: Dictionary = rows[int(index)] as Dictionary
+		var expected: Array = EXPECTED_TRAINERS[index] as Array
+		_r.check(
+			String(row.get("name", "")) == String(expected[0]),
+			"BattleTowerTrainers row %d is \"%s\", not \"%s\"." % [
+				index, row.get("name", ""), expected[0],
+			]
+		)
+		_r.check(
+			int(row.get("class", 0)) == int(expected[1]),
+			"BattleTowerTrainers row %d is class %d, not %d." % [
+				index, int(row.get("class", 0)), int(expected[1]),
+			]
+		)
+
+
+## Every one of the 210 rows, on its own group's level, with a species and four
+## move slots the cache can name: a group read at the wrong stride lands on the
+## previous group's levels long before it lands outside the table.
+func _verify_mons() -> void:
+	for group: int in Gen2BattleTower.LEVEL_GROUPS:
+		var level: int = (group + 1) * 10
+		for index: int in Gen2BattleTower.NUM_UNIQUE_MON:
+			var bytes: PackedByteArray = _r.data.battle_tower_mon(group, index)
+			if not _r.check(
+				bytes.size() == RomLayout.BATTLETOWER_MON_BYTES,
+				"BattleTowerMons %d/%d is %d bytes." % [group, index, bytes.size()]
+			):
+				return
+			var mon: Gen2SaveMon = Gen2SramAdapter.read_party_mon(bytes, 0)
+			_r.check(
+				mon != null and mon.level == level,
+				"BattleTowerMons %d/%d is level %d, not %d." % [
+					group, index, mon.level if mon != null else -1, level,
+				]
+			)
+			_r.check(
+				mon != null and not _r.data.species(mon.species).is_empty(),
+				"BattleTowerMons %d/%d names species %d." % [
+					group, index, mon.species if mon != null else -1,
+				]
+			)
+			for move: int in mon.moves:
+				_r.check(
+					move == 0 or not _r.data.move(move).is_empty(),
+					"BattleTowerMons %d/%d knows move %d." % [group, index, move]
+				)
+		var first: Array = EXPECTED_FIRST_MONS[group] as Array
+		var head: Gen2SaveMon = Gen2SramAdapter.read_party_mon(
+			_r.data.battle_tower_mon(group, 0), 0
+		)
+		_r.check(
+			head != null and head.species == int(first[0]) and head.item == int(first[1])
+			and head.moves == (first[2] as Array),
+			"BattleTowerMons group %d opens on %s, not %s." % [
+				group,
+				[head.species, head.item, head.moves] if head != null else [],
+				first,
+			]
+		)
+
+
+func _verify_strings() -> void:
+	_r.check(
+		Array(_r.data.battle_tower().get("level_rows", [])) == Array(EXPECTED_LEVEL_ROWS),
+		"Strings_L10ToL100 reads %s." % [_r.data.battle_tower().get("level_rows", [])]
+	)
+	_r.check(
+		Array(_r.data.battle_tower().get("menu_rows", [])) == Array(EXPECTED_MENU_ROWS),
+		"The challenge menu reads %s." % [_r.data.battle_tower().get("menu_rows", [])]
+	)
+	for name: String in RomLayout.BATTLETOWER_MENU_TEXT_ORDER:
+		_r.check(
+			not String((_r.data.battle_tower().get("menu_text", {}) as Dictionary).get(
+				name, ""
+			)).is_empty(),
+			"The room menu's %s box decoded to nothing." % name
+		)
+	## All 120 trainer lines, both arrays and all three kinds. A pin one stub out
+	## reads the neighbouring line rather than nothing, so the count is what says
+	## the run is the run and the emptiness is what says every entry is a text.
+	var texts: Dictionary = _r.data.battle_tower().get("texts", {}) as Dictionary
+	for kind: String in RomLayout.BATTLETOWER_TEXT_KINDS:
+		var arrays: Dictionary = texts.get(kind, {}) as Dictionary
+		for array: String in ["male", "female"]:
+			var lines: Array = arrays.get(array, []) as Array
+			var expected: int = RomLayout.BATTLETOWER_MALE_TEXTS if array == "male" \
+				else RomLayout.BATTLETOWER_FEMALE_TEXTS
+			if not _r.check(
+				lines.size() == expected,
+				"The %s %s lines number %d, not %d." % [array, kind, lines.size(), expected]
+			):
+				continue
+			for index: int in lines.size():
+				_r.check(
+					not String(lines[index]).is_empty(),
+					"The %s %s line %d decoded to nothing." % [array, kind, index]
+				)
+
+
+func _verify_class_tables() -> void:
+	var genders: Array = _r.data.battle_tower().get("class_genders", []) as Array
+	var sprites: Array = _r.data.battle_tower().get("class_sprites", []) as Array
+	var expected: int = _r.data.trainer_count() - 1
+	_r.check(
+		genders.size() == expected and sprites.size() == expected,
+		"The per-class tables are %d and %d rows, not %d." % [
+			genders.size(), sprites.size(), expected,
+		]
+	)
+	for index: Variant in EXPECTED_GENDERS:
+		_r.check(
+			int(genders[int(index)]) == int(EXPECTED_GENDERS[index]),
+			"BTTrainerClassGenders %d is %d." % [index, int(genders[int(index)])]
+		)
+	for index: Variant in EXPECTED_SPRITES:
+		_r.check(
+			int(sprites[int(index)]) == int(EXPECTED_SPRITES[index]),
+			"BTTrainerClassSprites %d is %d." % [index, int(sprites[int(index)])]
+		)
+	## Every class the 70 trainers actually name has to reach both tables, which
+	## is what a class byte read one row out fails on.
+	for row: Dictionary in _r.data.battle_tower().get("trainers", []) as Array:
+		var trainer_class: int = int(row.get("class", 0))
+		_r.check(
+			trainer_class >= 1 and trainer_class <= expected,
+			"%s is class %d, outside the two per-class tables." % [
+				row.get("name", ""), trainer_class,
+			]
+		)
+		_r.check(
+			Gen2BattleTower.class_sprite(_r.data, trainer_class) > 0,
+			"%s's class has no overworld sprite." % row.get("name", "")
+		)
+
+
+## A whole streak sampled on every level group: seven opponents, none of them
+## the same trainer, each of three Pokemon that share no species or held item,
+## and none repeating a species either of the two teams before it used.
+func _verify_sampler() -> void:
+	for group: int in Gen2BattleTower.LEVEL_GROUPS:
+		var tower := Gen2BattleTower.new()
+		tower.chosen_group = group + 1
+		var random := RandomNumberGenerator.new()
+		random.seed = group + 1
+		var teams: Array = []
+		var drawn: Array = []
+		for battle: int in Gen2BattleTower.STREAK_LENGTH:
+			var opponent: Dictionary = tower.load_opponent(_r.data, random)
+			if not _r.check(
+				not opponent.is_empty(),
+				"group %d battle %d sampled no opponent" % [group, battle]
+			):
+				return
+			_r.check(
+				not drawn.has(int(opponent["trainer"])),
+				"group %d met trainer %d twice in one streak" % [group, opponent["trainer"]]
+			)
+			drawn.append(int(opponent["trainer"]))
+			## `CopyBTTrainer_FromBT_OT_TowBT_OTTemp` counts the trainer before
+			## the fight, and `sBTTrainers[sNrOfBeaten]` is where the next sample
+			## is written: without the count the streak keeps one slot.
+			tower.beaten += 1
+			var species: Array = []
+			var items: Array = []
+			for mon: Gen2SaveMon in opponent["mons"] as Array:
+				_r.check(
+					mon.level == (group + 1) * 10,
+					"group %d drew a level %d opponent" % [group, mon.level]
+				)
+				species.append(mon.species)
+				items.append(mon.item)
+			_r.check(
+				species.size() == Gen2BattleTower.PARTY_LENGTH,
+				"group %d battle %d has %d Pokemon" % [group, battle, species.size()]
+			)
+			for index: int in species.size():
+				_r.check(
+					species.count(species[index]) == 1,
+					"group %d battle %d doubled species %d" % [group, battle, species[index]]
+				)
+				_r.check(
+					items.count(items[index]) == 1,
+					"group %d battle %d doubled item %d" % [group, battle, items[index]]
+				)
+			for earlier: Array in teams.slice(maxi(0, teams.size() - 2)):
+				for number: int in species:
+					_r.check(
+						not earlier.has(number),
+						"group %d battle %d reused species %d" % [group, battle, number]
+					)
+			teams.append(species)
+
+
+## `BattleTowerBattleRoom`'s own scene, driven on the real map: the opponent is
+## sampled, its class gives the room's object a sprite, `battletowertext` prints
+## that trainer's greeting, and the fight staged is the sampled team rather than
+## a trainer-table party.
+func _verify_battle_room() -> void:
+	var state := Gen2WorldState.new()
+	state.battle_tower().chosen_group = 3
+	var world: Gen2WorldAPI = _r.open_world(
+		BATTLE_ROOM_GROUP, BATTLE_ROOM_MAP, BATTLE_ROOM_CELL, state
+	)
+	if world == null:
+		return
+	world.set_party_summary(3, false, [1, 4, 7] as Array[int], [[], [], []],
+		["A", "B", "C"], [false, false, false], {"levels": [30, 30, 30]})
+	## `MapSetupScript_Warp` reaches `MAPCALLBACK_NEWMAP` and then the scene, so
+	## the room's own `SCENE_BATTLETOWERBATTLEROOM_ENTER` runs on map entry
+	## rather than off a coordinate the player steps on.
+	var results: Array = world.dispatch_map_entry()
+	for _frame: int in BATTLE_ROOM_FRAME_CAP:
+		var staged: Dictionary = world.pending_runtime_request()
+		if StringName(staged.get("kind", &"")) == &"battle_requested":
+			break
+		if not staged.is_empty():
+			## Everything the room asks for on the way in: the warp sound, the
+			## opponent's own music and the movements between them. Each is
+			## answered the way the screen answers it, so the walk to the fight
+			## is the real one.
+			results.append_array(world.complete_runtime_request({"ok": true}))
+			continue
+		if not world.pending_script_wait().is_empty():
+			results.append_array(world.advance_script_presentation_frame())
+			continue
+		if not world.script_busy():
+			break
+		results.append_array(world.run_event_queue(true, 0))
+	var request: Dictionary = world.pending_runtime_request()
+	if not _r.check(
+		StringName(request.get("kind", &"")) == &"battle_requested",
+		"the battle room staged %s rather than a fight" % [request.get("kind", &"none")]
+	):
+		return
+	var values: Dictionary = request.get("values", {}) as Dictionary
+	_r.check(
+		StringName(values.get("kind", &"")) == &"battle_tower",
+		"the fight is a %s battle" % [values.get("kind", &"")]
+	)
+	_r.check(
+		(values.get("enemy_party", []) as Array).size() == Gen2BattleTower.PARTY_LENGTH,
+		"the opponent brought %d Pokemon" % (values.get("enemy_party", []) as Array).size()
+	)
+	_r.check(
+		int(values.get("trainer_class", 0)) >= 1,
+		"the opponent has no trainer class"
+	)
+	_r.check(
+		not String(values.get("trainer_name", "")).is_empty(),
+		"the opponent has no name"
+	)
+	## `CopyBTTrainer_FromBT_OT_TowBT_OTTemp` runs in front of the fight.
+	_r.check(
+		state.battle_tower().challenge_state == Gen2BattleTower.CHALLENGE_IN_PROGRESS,
+		"the challenge is not in progress by the time the first fight starts"
+	)
+	_r.check(state.battle_tower().beaten == 1, "the first trainer was not counted")
+	var greeted: bool = false
+	var sprited: bool = false
+	for result: Dictionary in results:
+		for event: Dictionary in result.get("events", []) as Array:
+			if event.get("type", &"") == &"battle_tower_opponent_loaded":
+				sprited = int(event.get("sprite", 0)) > 0
+		var text: Dictionary = result.get("event", {}) as Dictionary
+		if StringName(text.get("type", &"")) == &"text" \
+			and not String(text.get("text", "")).is_empty():
+			greeted = true
+	_r.check(sprited, "the sampled opponent was given no overworld sprite")
+	_r.check(greeted, "the opponent said nothing before the fight")
+
+
+## The four party rules and the two room-menu refusals, each on a party that
+## fails exactly it.
+func _verify_rules() -> void:
+	var legal: Dictionary = {
+		"species": [1, 4, 7], "levels": [10, 10, 10],
+		"held_items": [0, 0, 0], "eggs": [false, false, false],
+	}
+	_r.check(
+		Gen2BattleTower.rule_failures(legal).is_empty(),
+		"a legal party was refused: %s" % [Gen2BattleTower.rule_failures(legal)]
+	)
+	var cases: Array = [
+		[{"species": [1, 4], "levels": [10, 10], "held_items": [0, 0],
+			"eggs": [false, false]}, "only_three_may_be_entered"],
+		[{"species": [1, 1, 7], "levels": [10, 10, 10], "held_items": [0, 0, 0],
+			"eggs": [false, false, false]}, "must_all_be_different_kinds"],
+		[{"species": [1, 4, 7], "levels": [10, 10, 10], "held_items": [1, 1, 0],
+			"eggs": [false, false, false]}, "must_not_hold_the_same_items"],
+		[{"species": [1, 4, 7], "levels": [10, 10, 10], "held_items": [0, 0, 0],
+			"eggs": [false, false, true]}, "you_cant_take_an_egg"],
+	]
+	for case: Array in cases:
+		_r.check(
+			Gen2BattleTower.rule_failures(case[0] as Dictionary) == [String(case[1])],
+			"%s was not the only failure of %s" % [case[1], case[0]]
+		)
+	## `BattleTower_LevelCheck` and `BattleTower_UbersCheck`: a member over the
+	## room's own level, and a legendary under Lv.70 in a room below it.
+	_r.check(
+		Gen2BattleTower.level_check({"levels": [10, 11, 10]}, 1) == 1,
+		"the level check missed a member over the room's level"
+	)
+	_r.check(
+		Gen2BattleTower.level_check({"levels": [10, 10, 10]}, 1) == -1,
+		"the level check refused a legal party"
+	)
+	_r.check(
+		Gen2BattleTower.ubers_check(
+			{"species": [1, 150, 7], "levels": [60, 60, 60]}, 6
+		) == 1,
+		"the ubers check let MEWTWO into a Lv.60 room"
+	)
+	_r.check(
+		Gen2BattleTower.ubers_check(
+			{"species": [1, 150, 7], "levels": [70, 70, 70]}, 7
+		) == -1,
+		"the ubers check refused a Lv.70 room, which it never reads"
+	)

--- a/tools/checks/battle_tower.gd.uid
+++ b/tools/checks/battle_tower.gd.uid
@@ -1,0 +1,1 @@
+uid://2tqedapcg2o6

--- a/tools/checks/card_flip.gd
+++ b/tools/checks/card_flip.gd
@@ -215,9 +215,9 @@ func _walked(path: PackedInt32Array) -> Vector2i:
 
 
 ## A table driven to `.PlaceYourBet`, which is where the cursor exists at all.
-func _bet_ready(seed: int) -> Gen2CardFlip:
+func _bet_ready(seed_value: int) -> Gen2CardFlip:
 	var rng := RandomNumberGenerator.new()
-	rng.seed = seed
+	rng.seed = seed_value
 	var board := PackedByteArray()
 	board.resize(RomLayout.CARD_FLIP_TILEMAP_BYTES)
 	var game: Gen2CardFlip = Gen2CardFlip.create(board, 100, rng)
@@ -324,9 +324,9 @@ func _verify_cards(game_id: StringName, data: GameData) -> void:
 ## running off the end of `wDeck`.
 func _verify_games(game_id: StringName, data: GameData) -> void:
 	var deals: int = 0
-	for run: int in GAMES:
+	for game_run: int in GAMES:
 		var rng := RandomNumberGenerator.new()
-		rng.seed = run + 1
+		rng.seed = game_run + 1
 		var page: Gen2CardFlipPage = Gen2CardFlipPage.from_data(data)
 		if page == null:
 			return
@@ -338,7 +338,7 @@ func _verify_games(game_id: StringName, data: GameData) -> void:
 		## driver that presses A the instant the prompt appears always takes the
 		## top one. Holding a different number of frames per run is what reaches
 		## `wCardFlipWhichCard` 1 at all.
-		var hold: int = run % (Gen2CardFlip.TOGGLE_FRAMES * 2)
+		var hold: int = game_run % (Gen2CardFlip.TOGGLE_FRAMES * 2)
 		var held: int = 0
 		for _frame: int in GAME_FRAME_CAP:
 			if game.finished():
@@ -371,7 +371,7 @@ func _verify_games(game_id: StringName, data: GameData) -> void:
 			if game.deck() != deck:
 				deck = game.deck()
 				seen = {}
-			if not _verify_deal(game_id, run, game, seen):
+			if not _verify_deal(game_id, game_run, game, seen):
 				return
 	_r.note("%s: %d games, %d cards dealt, every deck a permutation." % [
 		game_id, GAMES, deals
@@ -380,7 +380,7 @@ func _verify_games(game_id: StringName, data: GameData) -> void:
 
 ## One deal: the shuffle behind it and the card it turned over.
 func _verify_deal(
-	game_id: StringName, run: int, game: Gen2CardFlip, seen: Dictionary
+	game_id: StringName, game_run: int, game: Gen2CardFlip, seen: Dictionary
 ) -> bool:
 	var deck: PackedByteArray = game.deck()
 	var present: Dictionary = {}
@@ -389,18 +389,18 @@ func _verify_deal(
 	if not _r.check(
 		present.size() == Gen2CardFlip.DECK_SIZE,
 		"%s: game %d shuffled a deck of %d distinct cards." % [
-			game_id, run, present.size()
+			game_id, game_run, present.size()
 		]
 	):
 		return false
 	var card: int = game.face_up_card()
 	if not _r.check(
 		not seen.has(card),
-		"%s: game %d dealt card %d twice before a shuffle." % [game_id, run, card]
+		"%s: game %d dealt card %d twice before a shuffle." % [game_id, game_run, card]
 	):
 		return false
 	seen[card] = true
 	return _r.check(
 		game.discarded()[card] != 0,
-		"%s: game %d turned card %d over without discarding it." % [game_id, run, card]
+		"%s: game %d turned card %d over without discarding it." % [game_id, game_run, card]
 	)

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -62,17 +62,17 @@ const EXPECTED_PRIZE_PRICES: Dictionary = {
 func run(r: RefCounted) -> void:
 	_r = r
 	_r.each_game(func() -> void:
-		var catalog: Gen2WorldCatalog = _r.data.catalog()
-		_verify_census(catalog)
-		_verify_starters(catalog)
-		_verify_statics(catalog)
-		_verify_prizes(catalog)
-		_verify_badges(catalog)
-		_verify_ids(catalog)
-		_verify_patching(catalog)
-		_verify_links(catalog)
-		_verify_progression(catalog)
-		_verify_sidecar(catalog)
+		var _catalog: Gen2WorldCatalog = _r.data.catalog()
+		_verify_census(_catalog)
+		_verify_starters(_catalog)
+		_verify_statics(_catalog)
+		_verify_prizes(_catalog)
+		_verify_badges(_catalog)
+		_verify_ids(_catalog)
+		_verify_patching(_catalog)
+		_verify_links(_catalog)
+		_verify_progression(_catalog)
+		_verify_sidecar(_catalog)
 	)
 
 
@@ -81,14 +81,14 @@ func run(r: RefCounted) -> void:
 ## [method GameData.catalog] handed back. So this asks the other question, that
 ## a restored catalog and a freshly scanned one are the same catalog, every row,
 ## every link and every kind's order.
-func _verify_sidecar(catalog: Gen2WorldCatalog) -> void:
+func _verify_sidecar(_catalog: Gen2WorldCatalog) -> void:
 	var written: Variant = RomCache.read_json(
 		RomCache.world_catalog_path(_r.data.directory)
 	)
-	if not _r.check(written is Dictionary, "the import wrote no catalog sidecar."):
+	if not _r.check(written is Dictionary, "the import wrote no _catalog sidecar."):
 		return
 	var restored: Gen2WorldCatalog = Gen2WorldCatalog.from_dict(_r.data, written)
-	if not _r.check(restored != null, "the catalog sidecar does not restore."):
+	if not _r.check(restored != null, "the _catalog sidecar does not restore."):
 		return
 	var scanned: Gen2WorldCatalog = Gen2WorldCatalog.build(_r.data)
 	_r.check(
@@ -108,12 +108,12 @@ func _verify_sidecar(catalog: Gen2WorldCatalog) -> void:
 				return
 
 
-func _verify_census(catalog: Gen2WorldCatalog) -> void:
-	var found: Array = [catalog.size()]
+func _verify_census(_catalog: Gen2WorldCatalog) -> void:
+	var found: Array = [_catalog.size()]
 	for kind: StringName in Gen2WorldCatalog.KINDS:
-		found.append(catalog.ids(kind).size())
+		found.append(_catalog.ids(kind).size())
 	var expected: Array = EXPECTED_CENSUS[_r.game_id]
-	_r.note("catalog %d rows: %s." % [catalog.size(), str(found.slice(1))])
+	_r.note("catalog %d rows: %s." % [_catalog.size(), str(found.slice(1))])
 	_r.check(
 		found == expected,
 		"census is %s, not the pinned %s." % [str(found), str(expected)]
@@ -123,23 +123,23 @@ func _verify_census(catalog: Gen2WorldCatalog) -> void:
 ## The one shape only Elm's three balls take: a `pokepic` of the species a
 ## `givepoke` in the same script hands over. If that stops being unique, this is
 ## where it shows.
-func _verify_starters(catalog: Gen2WorldCatalog) -> void:
-	var found: Array[int] = catalog.possible_starters()
+func _verify_starters(_catalog: Gen2WorldCatalog) -> void:
+	var found: Array[int] = _catalog.possible_starters()
 	found.sort()
 	var wanted: Array[int] = [CHIKORITA, CYNDAQUIL, TOTODILE]
 	_r.check(
 		found == wanted, "starters are %s, not the three Elm offers." % str(found)
 	)
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_STARTER):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_STARTER):
 		_r.check(
 			int(row["level"]) == 5,
 			"a starter is offered at level %d rather than 5." % int(row["level"])
 		)
 
 
-func _verify_statics(catalog: Gen2WorldCatalog) -> void:
+func _verify_statics(_catalog: Gen2WorldCatalog) -> void:
 	var levels: Dictionary = {}
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_STATIC):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_STATIC):
 		var species: int = int(row["species"])
 		var list: Array = levels.get(species, [])
 		list.append(int(row["level"]))
@@ -160,9 +160,9 @@ func _verify_statics(catalog: Gen2WorldCatalog) -> void:
 
 ## A prize is a give site with a `takecoins` behind it, and the price has to be
 ## the one for THAT branch rather than the first one in the vendor's script.
-func _verify_prizes(catalog: Gen2WorldCatalog) -> void:
+func _verify_prizes(_catalog: Gen2WorldCatalog) -> void:
 	var prices: Array = []
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_PRIZE):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_PRIZE):
 		prices.append(int(row["price"]))
 	_r.check(
 		prices == EXPECTED_PRIZE_PRICES[_r.game_id],
@@ -175,12 +175,12 @@ func _verify_prizes(catalog: Gen2WorldCatalog) -> void:
 ## Sixteen badges exist and each is granted somewhere. Gold and Silver set two of
 ## them from a second script as well, which is why the row count is not the badge
 ## count and why the test is over the SET rather than the list.
-func _verify_badges(catalog: Gen2WorldCatalog) -> void:
+func _verify_badges(_catalog: Gen2WorldCatalog) -> void:
 	var seen: Dictionary = {}
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_BADGE):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_BADGE):
 		seen[int(row["badge"])] = true
 		_r.check(
-			catalog.is_progression(row), "badge %d is not progression." % int(row["badge"])
+			_catalog.is_progression(row), "badge %d is not progression." % int(row["badge"])
 		)
 	var badges: Array = seen.keys()
 	badges.sort()
@@ -194,9 +194,9 @@ func _verify_badges(catalog: Gen2WorldCatalog) -> void:
 
 ## An id has to name one site and be recomputable from the site's own address,
 ## since that is what a runtime reader does. Both directions, over every row.
-func _verify_ids(catalog: Gen2WorldCatalog) -> void:
+func _verify_ids(_catalog: Gen2WorldCatalog) -> void:
 	var seen: Dictionary = {}
-	for row: Dictionary in catalog.rows():
+	for row: Dictionary in _catalog.rows():
 		var id: int = int(row["id"])
 		if seen.has(id):
 			_r.check(false, "id %d names two sites." % id)
@@ -216,15 +216,15 @@ func _verify_ids(catalog: Gen2WorldCatalog) -> void:
 ## The four fields whose effect is not at the command the site is: a starter's
 ## picture, and a prize's two coin commands. A patch that reached the `givepoke`
 ## alone would show one Pokemon and hand over another.
-func _verify_links(catalog: Gen2WorldCatalog) -> void:
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_STARTER):
+func _verify_links(_catalog: Gen2WorldCatalog) -> void:
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_STARTER):
 		_r.check(
 			row.has("picture_address"),
 			"a starter has no linked pokepic, so its ball would show the old one."
 		)
 		if not row.has("picture_address"):
 			return
-		var linked: Dictionary = catalog.link_at(
+		var linked: Dictionary = _catalog.link_at(
 			int(row["bank"]), int(row["picture_address"])
 		)
 		_r.check(
@@ -232,18 +232,18 @@ func _verify_links(catalog: Gen2WorldCatalog) -> void:
 				and StringName(linked.get("role", &"")) == &"picture",
 			"a starter's pokepic does not link back to it."
 		)
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_PRIZE):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_PRIZE):
 		for key: String in ["check_address", "take_address"]:
 			_r.check(row.has(key), "a prize has no linked %s." % key)
 			if not row.has(key):
 				return
-			var linked: Dictionary = catalog.link_at(int(row["bank"]), int(row[key]))
+			var linked: Dictionary = _catalog.link_at(int(row["bank"]), int(row[key]))
 			_r.check(
 				int(linked.get("id", -1)) == int(row["id"])
 					and StringName(linked.get("role", &"")) == &"price",
 				"a prize's %s does not link back to it." % key
 			)
-	var shops: Array = catalog.rows(Gen2WorldCatalog.KIND_SHOP)
+	var shops: Array = _catalog.rows(Gen2WorldCatalog.KIND_SHOP)
 	var stocked: int = 0
 	for row: Dictionary in shops:
 		if not (row.get("items", []) as Array).is_empty():
@@ -254,7 +254,7 @@ func _verify_links(catalog: Gen2WorldCatalog) -> void:
 
 ## The cartridge's own placement finishes, and one that hides Surf behind Surf
 ## does not. The second is the whole reason the validator exists.
-func _verify_progression(catalog: Gen2WorldCatalog) -> void:
+func _verify_progression(_catalog: Gen2WorldCatalog) -> void:
 	var data: GameData = GameData.open(_r.game_id)
 	if data == null:
 		return
@@ -268,13 +268,13 @@ func _verify_progression(catalog: Gen2WorldCatalog) -> void:
 	])
 
 	var surf_item: int = 0
-	for item: int in catalog.field_hm_items():
-		if catalog.move_for_hm_item(item) == Gen2WorldFieldMove.MOVE_SURF:
+	for item: int in _catalog.field_hm_items():
+		if _catalog.move_for_hm_item(item) == Gen2WorldFieldMove.MOVE_SURF:
 			surf_item = item
 	var walk: Gen2WorldReachability = Gen2WorldReachability.build(data)
 	var dry: Dictionary = walk.reachable(Gen2WorldProgression.START_MAP, {})
 	var behind: int = -1
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_ITEM):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_ITEM):
 		if not row.has("map"):
 			continue
 		var key: int = Gen2WorldReachability.map_key(
@@ -288,7 +288,7 @@ func _verify_progression(catalog: Gen2WorldCatalog) -> void:
 		return
 	## Surf on a shore only Surf reaches, and nowhere else.
 	var patches: Dictionary = {behind: {"item": surf_item}}
-	for row: Dictionary in catalog.rows(Gen2WorldCatalog.KIND_ITEM):
+	for row: Dictionary in _catalog.rows(Gen2WorldCatalog.KIND_ITEM):
 		if int(row["item"]) == surf_item and int(row["id"]) != behind:
 			patches[int(row["id"])] = {"item": RomLayout.ITEM_TM01}
 	var locked: Dictionary = Gen2WorldProgression.validate(data, patches)
@@ -310,7 +310,7 @@ func _verify_progression(catalog: Gen2WorldCatalog) -> void:
 
 ## The whole point of the catalog: a patch has to reach the row a runtime reader
 ## gets. Done on an overlay of this check's own, so the shared one is untouched.
-func _verify_patching(catalog: Gen2WorldCatalog) -> void:
+func _verify_patching(_catalog: Gen2WorldCatalog) -> void:
 	var overlay := Gen2ContentOverlay.new()
 	var data: GameData = GameData.open(_r.game_id)
 	if data == null:

--- a/tools/checks/day_care.gd
+++ b/tools/checks/day_care.gd
@@ -51,8 +51,8 @@ func run(r: RefCounted) -> void:
 ## say the pin is that run and not its neighbour.
 func _verify_texts(game_id: StringName, data: GameData) -> void:
 	var found: int = 0
-	for run: Array in RomLayout.DAY_CARE_TEXT_RUNS:
-		for raw_name: Variant in run[1] as Array:
+	for subject: Array in RomLayout.DAY_CARE_TEXT_RUNS:
+		for raw_name: Variant in subject[1] as Array:
 			var name: String = String(raw_name)
 			var text: String = data.day_care_text(name)
 			if _r.check(

--- a/tools/checks/fuchsia.gd
+++ b/tools/checks/fuchsia.gd
@@ -155,7 +155,8 @@ func _verify_chain(data: GameData, game_id: StringName, crystal: bool) -> void:
 			]
 		)
 		print("%s %s: %d cells, %d sight lines, %s owed." % [
-			game_id, label, region.size(), lines.size(), owed if not owed.is_empty() else "none",
+			game_id, label, region.size(), lines.size(),
+			str(owed) if not owed.is_empty() else "none",
 		])
 
 

--- a/tools/checks/intro_movie.gd
+++ b/tools/checks/intro_movie.gd
@@ -197,7 +197,7 @@ func _run(game_id: StringName, data: GameData) -> void:
 			sampled = false
 	_r.check(
 		movie.finished(),
-		"%s: the intro movie never set its exit bit." % game_id
+		"%s: the intro movie never ordering its exit bit." % game_id
 	)
 	_r.check(
 		movie.frame() == EXPECTED_FRAMES,
@@ -227,6 +227,6 @@ func _run(game_id: StringName, data: GameData) -> void:
 func _sprite_count(movie: Gen2IntroMovie) -> int:
 	var total: int = 0
 	for sprite: Dictionary in movie.sprites():
-		var set: Dictionary = Gen2IntroMoviePage.OAM_SETS[int(sprite["set"])]
-		total += (set["parts"] as Array).size()
+		var ordering: Dictionary = Gen2IntroMoviePage.OAM_SETS[int(sprite["set"])]
+		total += (ordering["parts"] as Array).size()
 	return total

--- a/tools/checks/naming.gd
+++ b/tools/checks/naming.gd
@@ -153,7 +153,7 @@ func _flatten(data: GameData) -> PackedByteArray:
 ## The block offset is profile split but the bytes are not, in any of the three
 ## dumps, so a decode that differs anywhere means one offset is wrong.
 func _verify_identical() -> void:
-	var reference: StringName = &""
+	var expected: StringName = &""
 	for game_id: StringName in _blocks:
 		var block: PackedByteArray = _blocks[game_id]
 		_r.check(
@@ -162,12 +162,12 @@ func _verify_identical() -> void:
 				game_id, block.size(), RomLayout.NAME_INPUT_BLOCK_BYTES,
 			]
 		)
-		if reference == &"":
-			reference = game_id
+		if expected == &"":
+			expected = game_id
 			continue
 		_r.check(
-			block == PackedByteArray(_blocks[reference]),
-			"%s: block differs from %s, which ships it byte identical." % [game_id, reference]
+			block == PackedByteArray(_blocks[expected]),
+			"%s: block differs from %s, which ships it byte identical." % [game_id, expected]
 		)
 	if not _blocks.is_empty():
 		print("Name input block: %d bytes, identical in %d games." % [

--- a/tools/checks/pic_anim.gd
+++ b/tools/checks/pic_anim.gd
@@ -86,7 +86,7 @@ func _check_record(record: Dictionary, species: int, form: int) -> int:
 		return 0
 
 	# The run the cartridge loads: the padded box, then `w * h` tiles behind it.
-	var run: int = BOX_TILES + height * height
+	var subject: int = BOX_TILES + height * height
 	var list: Array = record["frames"] as Array
 	for index: int in list.size():
 		var frame: PackedByteArray = list[index]
@@ -104,8 +104,8 @@ func _check_record(record: Dictionary, species: int, form: int) -> int:
 		var reaches: bool = false
 		for at: int in range(mask_bytes, frame.size()):
 			var tile: int = RomLayout.pic_anim_box_tile(int(frame[at]), height)
-			_r.check(tile < run, "%s frame %d names tile %d, past the %d loaded." % [
-				where, index, tile, run
+			_r.check(tile < subject, "%s frame %d names tile %d, past the %d loaded." % [
+				where, index, tile, subject
 			])
 			# `PokeAnim_SetVBank1`'s reason: the block's own 49 is `AppearUser`'s
 			# `$31` for the player's back pic, so an animated square has to be
@@ -116,7 +116,7 @@ func _check_record(record: Dictionary, species: int, form: int) -> int:
 
 	for mirrored: bool in [false, true]:
 		for kind: int in Gen2PicAnimation.SCENES:
-			_run_scene(record, kind, mirrored, run, where)
+			_run_scene(record, kind, mirrored, subject, where)
 	return list.size()
 
 
@@ -124,7 +124,7 @@ func _check_record(record: Dictionary, species: int, form: int) -> int:
 ## box the animation leaves has to be drawable, which is the only thing the
 ## renderer asks of it.
 func _run_scene(
-	record: Dictionary, kind: int, mirrored: bool, run: int, where: String
+	record: Dictionary, kind: int, mirrored: bool, subject: int, where: String
 ) -> void:
 	var animation := Gen2PicAnimation.new(record, kind, mirrored)
 	var spent: int = 0
@@ -132,9 +132,9 @@ func _run_scene(
 		animation.advance()
 		spent += 1
 		for tile: int in animation.box:
-			if tile >= run:
+			if tile >= subject:
 				_r.check(false, "%s scene %d draws tile %d, past the %d loaded." % [
-					where, kind, tile, run
+					where, kind, tile, subject
 				])
 				return
 	_r.check(animation.finished(), "%s scene %d did not end within %d frames." % [

--- a/tools/checks/radio.gd
+++ b/tools/checks/radio.gd
@@ -90,21 +90,21 @@ const SHOW_SEEDS: int = 20
 func run(r: RefCounted) -> void:
 	_r = r
 	for game_id: StringName in _r.GAME_IDS:
-		var data: GameData = GameData.open(game_id)
-		if data == null:
+		var _data: GameData = GameData.open(game_id)
+		if _data == null:
 			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
 			continue
-		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
-		_verify_stations(data, game_id, crystal)
-		_verify_music_records(data, game_id, crystal)
-		_verify_shows(data, game_id, crystal)
-		_verify_big_object_census(data, game_id)
-		_verify_snorlax(data, game_id, crystal)
-		_verify_route_2(data, game_id, crystal)
+		var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
+		_verify_stations(_data, game_id, crystal)
+		_verify_music_records(_data, game_id, crystal)
+		_verify_shows(_data, game_id, crystal)
+		_verify_big_object_census(_data, game_id)
+		_verify_snorlax(_data, game_id, crystal)
+		_verify_route_2(_data, game_id, crystal)
 
 
 ## RadioChannels, its three profile splits and the music each station commits.
-func _verify_stations(data: GameData, game_id: StringName, crystal: bool) -> void:
+func _verify_stations(_data: GameData, game_id: StringName, crystal: bool) -> void:
 	var vermilion: int = LANDMARK_VERMILION_CITY if crystal else LANDMARK_VERMILION_CITY - 1
 	var new_bark: int = LANDMARK_NEW_BARK_TOWN
 	var kanto: Dictionary = {"landmark": vermilion, "crystal": crystal, "expn_card": true}
@@ -155,9 +155,9 @@ func _verify_stations(data: GameData, game_id: StringName, crystal: bool) -> voi
 ## can catch that a unit test cannot: a line whose `text_ram` buffer the cache
 ## does not fill, so it prints an empty name, and a segment that never leaves
 ## the box it wrote.
-func _verify_shows(data: GameData, game_id: StringName, crystal: bool) -> void:
+func _verify_shows(_data: GameData, game_id: StringName, crystal: bool) -> void:
 	var caught: Array = []
-	for species: int in range(1, data.species_count() + 1):
+	for species: int in range(1, _data.species_count() + 1):
 		caught.append(species)
 	var visited: Dictionary = {}
 	var lines_seen: int = 0
@@ -170,7 +170,7 @@ func _verify_shows(data: GameData, game_id: StringName, crystal: bool) -> void:
 			random.seed = seed_index
 			# Both sides of NITE_HOUR, so Buena's off-air arm is walked too.
 			var hour: int = 20 if seed_index % 2 == 0 else 9
-			var show: Gen2RadioShow = Gen2RadioShow.start(data, channel, {
+			var show: Gen2RadioShow = Gen2RadioShow.start(_data, channel, {
 				"crystal": crystal, "weekday": seed_index % 7, "hour": hour,
 				"caught": caught, "hall_of_fame": seed_index % 3 == 0,
 				"kanto_badges": 0xFF if seed_index % 3 == 0 else 0,
@@ -222,13 +222,13 @@ func _verify_shows(data: GameData, game_id: StringName, crystal: bool) -> void:
 
 ## Every station's track has to be a real imported music record, or tuning to it
 ## would leave the overworld silent.
-func _verify_music_records(data: GameData, game_id: StringName, crystal: bool) -> void:
+func _verify_music_records(_data: GameData, game_id: StringName, crystal: bool) -> void:
 	for channel: int in Gen2WorldRadio.CHANNEL_SONGS.size():
 		if channel == Gen2WorldRadio.BUENAS_PASSWORD and not crystal:
 			continue
 		var song: int = Gen2WorldRadio.CHANNEL_SONGS[channel]
 		_r.check(
-			not data.world_audio(&"music", song).is_empty(),
+			not _data.world_audio(&"music", song).is_empty(),
 			"%s: channel %d wants music record %d, which this cache lacks." % [
 				game_id, channel, song,
 			]
@@ -237,9 +237,9 @@ func _verify_music_records(data: GameData, game_id: StringName, crystal: bool) -
 
 ## data/sprites/map_objects.asm gives BIG_OBJECT to three SpriteMovementData
 ## rows, and exactly two objects in either game use one.
-func _verify_big_object_census(data: GameData, game_id: StringName) -> void:
+func _verify_big_object_census(_data: GameData, game_id: StringName) -> void:
 	var found: Array = []
-	for map: Gen2WorldMap in data.world_maps():
+	for map: Gen2WorldMap in _data.world_maps():
 		for row: Variant in map.events.get("objects", []):
 			if not row is Dictionary:
 				continue
@@ -263,8 +263,8 @@ func _verify_big_object_census(data: GameData, game_id: StringName) -> void:
 
 ## The Snorlax itself: what it fills, what it seals, and the whole radio chain
 ## driven against the real cache.
-func _verify_snorlax(data: GameData, game_id: StringName, crystal: bool) -> void:
-	var sealed: Gen2WorldAPI = _open(data, VERMILION_GROUP, VERMILION_CITY, PORT_LANDING)
+func _verify_snorlax(_data: GameData, game_id: StringName, crystal: bool) -> void:
+	var sealed: Gen2WorldAPI = _open(_data, VERMILION_GROUP, VERMILION_CITY, PORT_LANDING)
 	if sealed == null:
 		return
 	_r.check(
@@ -315,16 +315,16 @@ func _verify_snorlax(data: GameData, game_id: StringName, crystal: bool) -> void
 			]
 		)
 
-	_verify_wake(data, game_id, crystal)
+	_verify_wake(_data, game_id, crystal)
 
 
 ## The chain end to end: tune 20.0 next to it, talk to it, win, and watch the
 ## cave mouth open.
-func _verify_wake(data: GameData, game_id: StringName, crystal: bool) -> void:
+func _verify_wake(_data: GameData, game_id: StringName, crystal: bool) -> void:
 	var state := Gen2WorldState.new()
 	state.set_engine_flag(Gen2WorldState.ENGINE_RADIO_CARD, true)
 	state.set_engine_flag(Gen2WorldState.ENGINE_EXPN_CARD, true)
-	var world: Gen2WorldAPI = _open(data, VERMILION_GROUP, VERMILION_CITY, TALK_FROM, state)
+	var world: Gen2WorldAPI = _open(_data, VERMILION_GROUP, VERMILION_CITY, TALK_FROM, state)
 	if world == null:
 		return
 	_r.check(
@@ -334,7 +334,7 @@ func _verify_wake(data: GameData, game_id: StringName, crystal: bool) -> void:
 
 	# Talking to it before the radio is tuned takes SnorlaxAwake's false branch.
 	world.player_facing = Gen2WorldSprite.FACING_UP
-	var asleep: Dictionary = _drain(world, world.interact(), data)
+	var asleep: Dictionary = _drain(world, world.interact(), _data)
 	_r.check(
 		not world.event_flag_active(EVENT_FOUGHT_SNORLAX)
 			and int(asleep.get("battles", 0)) == 0,
@@ -354,7 +354,7 @@ func _verify_wake(data: GameData, game_id: StringName, crystal: bool) -> void:
 	)
 
 	world.player_facing = Gen2WorldSprite.FACING_UP
-	var awake: Dictionary = _drain(world, world.interact(), data)
+	var awake: Dictionary = _drain(world, world.interact(), _data)
 	_r.check(
 		int(awake.get("battles", 0)) == 1
 			and int(awake.get("species", 0)) == SPECIES_SNORLAX
@@ -398,8 +398,8 @@ func _verify_wake(data: GameData, game_id: StringName, crystal: bool) -> void:
 ## of Route 2 closed by two cut trees, and cutting the northern one reaches both
 ## the Pewter and the Viridian crossing. Everything west of Kanto hangs off this,
 ## so it is checked here rather than left as an assertion in prose.
-func _verify_route_2(data: GameData, game_id: StringName, crystal: bool) -> void:
-	var world: Gen2WorldAPI = _open(data, ROUTE_2_GROUP, ROUTE_2, CAVE_LANDING)
+func _verify_route_2(_data: GameData, game_id: StringName, crystal: bool) -> void:
+	var world: Gen2WorldAPI = _open(_data, ROUTE_2_GROUP, ROUTE_2, CAVE_LANDING)
 	if world == null:
 		return
 	var cave: int = DIGLETTS_CAVE if crystal else DIGLETTS_CAVE_GOLD_SILVER
@@ -442,7 +442,7 @@ func _verify_route_2(data: GameData, game_id: StringName, crystal: bool) -> void
 	cutter.set_engine_flag(
 		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_HIVE, crystal), true
 	)
-	var opened: Gen2WorldAPI = _open(data, ROUTE_2_GROUP, ROUTE_2, CAVE_LANDING, cutter)
+	var opened: Gen2WorldAPI = _open(_data, ROUTE_2_GROUP, ROUTE_2, CAVE_LANDING, cutter)
 	if opened == null:
 		return
 	opened.player_cell = ROUTE_2_OPENING_APPROACH
@@ -487,7 +487,7 @@ func _reaches_edge(world: Gen2WorldAPI, region: Dictionary, axis: Vector2i) -> b
 
 
 ## Runs a script to its end, answering the one battle it can reach with a win.
-func _drain(world: Gen2WorldAPI, results: Array, data: GameData) -> Dictionary:
+func _drain(world: Gen2WorldAPI, results: Array, _data: GameData) -> Dictionary:
 	var out: Dictionary = {"battles": 0, "species": 0, "level": 0, "battle_type": -1}
 	var guard: int = 0
 	while guard < 64:
@@ -518,10 +518,10 @@ func _drain(world: Gen2WorldAPI, results: Array, data: GameData) -> Dictionary:
 
 
 func _open(
-	data: GameData, group: int, number: int, cell: Vector2i, state: Gen2WorldState = null
+	_data: GameData, group: int, number: int, cell: Vector2i, state: Gen2WorldState = null
 ) -> Gen2WorldAPI:
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(
-		data, group, number, cell, state if state != null else Gen2WorldState.new()
+		_data, group, number, cell, state if state != null else Gen2WorldState.new()
 	)
 	if world == null:
 		_r.fail("map %d/%d is missing." % [group, number])

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -86,7 +86,7 @@ const SPECIALS_POINTERS_SIZE: int = 169
 var _r: RefCounted = null
 ## Which indices the runner answers, derived from the runner rather than kept
 ## beside it: a second copy of the match would go stale the first time one is
-## built, which is the whole failure this topic exists to catch.
+## built, which is the whole failure this run exists to catch.
 var _handled: Dictionary = {}
 
 
@@ -209,19 +209,19 @@ func _verify_special_text(data: GameData) -> void:
 		if address >= 0:
 			fillable[address] = true
 	for raw_run: Variant in RomLayout.SPECIAL_TEXT_RUNS:
-		var run: String = String(raw_run)
-		if run in CRYSTAL_ONLY_TEXT_RUNS and data.id != &"crystal":
+		var subject: String = String(raw_run)
+		if subject in CRYSTAL_ONLY_TEXT_RUNS and data.id != &"crystal":
 			_r.check(
-				not data.has_special_text(run),
-				"%s is on a cartridge whose scripts cannot reach it" % run
+				not data.has_special_text(subject),
+				"%s is on a cartridge whose scripts cannot reach it" % subject
 			)
 			continue
-		if not _r.check(data.has_special_text(run), "the %s run is missing" % run):
+		if not _r.check(data.has_special_text(subject), "the %s subject is missing" % subject):
 			continue
-		for box: String in RomLayout.special_text_names(run):
-			var text: String = data.special_text(run, box)
+		for box: String in RomLayout.special_text_names(subject):
+			var text: String = data.special_text(subject, box)
 			if not _r.check(
-				not text.is_empty(), "%s/%s decoded to nothing" % [run, box]
+				not text.is_empty(), "%s/%s decoded to nothing" % [subject, box]
 			):
 				continue
 			var at: int = text.find(Gen2TextStream.RAM_MARKER)
@@ -233,7 +233,7 @@ func _verify_special_text(data: GameData) -> void:
 				)).hex_to_int() if end > at else -1
 				_r.check(
 					fillable.has(address),
-					"%s/%s names $%04X, which nothing can fill" % [run, box, address]
+					"%s/%s names $%04X, which nothing can fill" % [subject, box, address]
 				)
 				at = text.find(Gen2TextStream.RAM_MARKER, at + 1)
 

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -23,28 +23,21 @@ extends RefCounted
 ## in both directions: an index here that the runner now handles fails, so the
 ## row is deleted with the work rather than left behind.
 const EXPECTED_DEFERRED: Dictionary = {
-	## HANDOFF's "Deliberately deferred": link play, the Mobile Adapter GB,
-	## Mystery Gift and the Battle Tower. None of the four has a path to a
-	## modern platform or a save section this project reads.
+	## HANDOFF's "Deliberately deferred": link play, the Mobile Adapter GB and
+	## Mystery Gift. None of the three has a peer to talk to on a modern
+	## platform. The Battle Tower's own seven rows have left this list.
 	1: "SetBitsForLinkTradeRequest", 2: "WaitForLinkedFriend",
-	3: "CheckLinkTimeout_Receptionist", 4: "TryQuickSave",
+	3: "CheckLinkTimeout_Receptionist",
 	5: "CheckBothSelectedSameRoom", 6: "FailedLinkToPast", 7: "CloseLink",
 	8: "WaitForOtherPlayerToExit", 9: "SetBitsForBattleRequest",
 	10: "SetBitsForTimeCapsuleRequest", 11: "CheckTimeCapsuleCompatibility",
 	12: "EnterTimeCapsule", 13: "TradeCenter", 14: "Colosseum", 15: "TimeCapsule",
 	16: "CableClubCheckWhichChris", 17: "CheckMysteryGift",
 	18: "GetMysteryGiftItem", 19: "UnlockMysteryGift", 88: "DisplayLinkRecord",
-	116: "BattleTowerRoomMenu", 119: "BattleTowerBattle",
-	122: "LoadOpponentTrainerAndPokemonWithOTSprite",
-	124: "CheckForBattleTowerRules", 125: "GiveOddEgg",
+	125: "GiveOddEgg",
 	127: "Function1011f1", 128: "Function101220", 129: "Function101225",
-	130: "Function101231", 134: "BattleTowerAction",
-	136: "Menu_ChallengeExplanationCancel", 139: "BattleTowerMobileError",
+	130: "Function101231", 139: "BattleTowerMobileError",
 	140: "AskMobileOrCable", 154: "Mobile_SelectThreeMons",
-	## `home/init.asm`'s `Reset`, a soft reset of the console. Its one script
-	## site is BattleTowerBattleRoom.asm, so it belongs to row 2 of the last four
-	## features rather than to a screen of its own.
-	126: "Reset",
 	155: "Function1037eb", 156: "Function10383c", 159: "Function1037c2",
 	160: "CheckMobileAdapterStatusSpecial", 161: "Function103780",
 	162: "Function10387b", 163: "AskRememberPassword",
@@ -79,7 +72,7 @@ const EXPECTED_FADE_FRAMES: Dictionary = {46: 8, 47: 28, 48: 8, 49: 8, 50: 8}
 ## `data/events/special_pointers.asm`'s own length, the same in both pins.
 ## The three runs Crystal alone ships. `poke_seer`, `seer_advice` and
 ## `buena_prize` sit past the end of Gold and Silver's `SpecialsPointers`.
-const CRYSTAL_ONLY_TEXT_RUNS: Array[String] = ["poke_seer", "buena_prize"]
+const CRYSTAL_ONLY_TEXT_RUNS: Array[String] = ["poke_seer", "buena_prize", "battle_tower"]
 
 ## The `special_text_ram` names a box may fill beyond the string buffers, which
 ## is what `Gen2WorldScriptRunner._set_text_ram` writes through.

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -66,19 +66,19 @@ const SHADOW_OAM_SPRITES: int = 40
 func run(r: RefCounted) -> void:
 	_r = r
 	for game_id: StringName in _r.GAME_IDS:
-		var data: GameData = GameData.open(game_id)
-		if data == null:
+		var _data: GameData = GameData.open(game_id)
+		if _data == null:
 			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
 			continue
-		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
-		_verify_landmarks(game_id, data, crystal)
-		_verify_regions(game_id, data)
-		_verify_palettes(game_id, data, crystal)
-		_verify_cursor_walk(game_id, data, crystal)
-		_verify_page(game_id, data, crystal)
-		_verify_nests(game_id, data, crystal)
-		_verify_flypoints(game_id, data)
-		_verify_cards(game_id, data)
+		var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
+		_verify_landmarks(game_id, _data, crystal)
+		_verify_regions(game_id, _data)
+		_verify_palettes(game_id, _data, crystal)
+		_verify_cursor_walk(game_id, _data, crystal)
+		_verify_page(game_id, _data, crystal)
+		_verify_nests(game_id, _data, crystal)
+		_verify_flypoints(game_id, _data)
+		_verify_cards(game_id, _data)
 
 
 ## `Flypoints` and `SpawnPoints` against the cache they were imported beside:
@@ -92,10 +92,10 @@ func run(r: RefCounted) -> void:
 ## per row reaches each of the region's twelve and comes back to where it
 ## started, and every cursor lands on a landmark the region map draws an icon
 ## for.
-func _verify_fly_walk(game_id: StringName, data: GameData) -> void:
-	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+func _verify_fly_walk(game_id: StringName, _data: GameData) -> void:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
 	var visited: Array[int] = []
-	for index: int in data.flypoint_count():
+	for index: int in _data.flypoint_count():
 		visited.append(index)
 	for in_kanto: bool in [false, true]:
 		var map: Gen2TownMap = Gen2TownMap.fly(
@@ -105,8 +105,8 @@ func _verify_fly_walk(game_id: StringName, data: GameData) -> void:
 		var seen: Dictionary = {}
 		for _press: int in RomLayout.KANTO_FLYPOINT:
 			seen[map.cursor] = true
-			var landmark: int = int(data.flypoint(map.cursor).get("landmark", -1))
-			var point: Dictionary = data.landmark(landmark)
+			var landmark: int = int(_data.flypoint(map.cursor).get("landmark", -1))
+			var point: Dictionary = _data.landmark(landmark)
 			_r.check(
 				not point.is_empty(),
 				"%s: flypoint %d names landmark %d, which the map cannot draw." % [
@@ -129,29 +129,29 @@ func _verify_fly_walk(game_id: StringName, data: GameData) -> void:
 		)
 
 
-func _verify_flypoints(game_id: StringName, data: GameData) -> void:
+func _verify_flypoints(game_id: StringName, _data: GameData) -> void:
 	if not _r.check(
-		data.flypoint_count() == RomLayout.FLYPOINT_COUNT,
+		_data.flypoint_count() == RomLayout.FLYPOINT_COUNT,
 		"%s: %d flypoints, not %d." % [
-			game_id, data.flypoint_count(), RomLayout.FLYPOINT_COUNT,
+			game_id, _data.flypoint_count(), RomLayout.FLYPOINT_COUNT,
 		]
 	):
 		return
 	if not _r.check(
-		data.spawn_point_count() == RomLayout.SPAWN_COUNT,
+		_data.spawn_point_count() == RomLayout.SPAWN_COUNT,
 		"%s: %d spawn points, not %d." % [
-			game_id, data.spawn_point_count(), RomLayout.SPAWN_COUNT,
+			game_id, _data.spawn_point_count(), RomLayout.SPAWN_COUNT,
 		]
 	):
 		return
 
 	var seen: Dictionary = {}
-	for index: int in data.flypoint_count():
-		var row: Dictionary = data.flypoint(index)
+	for index: int in _data.flypoint_count():
+		var row: Dictionary = _data.flypoint(index)
 		var landmark: int = int(row["landmark"])
 		var spawn: int = int(row["spawn"])
 		_r.check(
-			landmark > 0 and landmark < data.landmark_count(),
+			landmark > 0 and landmark < _data.landmark_count(),
 			"%s: flypoint %d names landmark %d, which this cartridge does not ship." % [
 				game_id, index, landmark,
 			]
@@ -161,9 +161,9 @@ func _verify_flypoints(game_id: StringName, data: GameData) -> void:
 			"%s: flypoint %d repeats landmark %d." % [game_id, index, landmark]
 		)
 		seen[landmark] = true
-		var point: Dictionary = data.spawn_point(spawn)
+		var point: Dictionary = _data.spawn_point(spawn)
 		_r.check(
-			not point.is_empty() and data.world_map(
+			not point.is_empty() and _data.world_map(
 				int(point["map_group"]), int(point["map_number"])
 			) != null,
 			"%s: flypoint %d lands on spawn %d, which names no map." % [
@@ -173,88 +173,88 @@ func _verify_flypoints(game_id: StringName, data: GameData) -> void:
 		# Johto first, Kanto behind it: `FlyMap` picks a region's cursor range
 		# off that split alone.
 		_r.check(
-			(landmark < Gen2WorldRadio.kanto_landmark(Gen2WorldState.is_crystal_profile(data)))
+			(landmark < Gen2WorldRadio.kanto_landmark(Gen2WorldState.is_crystal_profile(_data)))
 				== (index < RomLayout.KANTO_FLYPOINT),
 			"%s: flypoint %d is on the wrong side of the region split." % [game_id, index]
 		)
-	for index: int in data.spawn_point_count():
-		var point: Dictionary = data.spawn_point(index)
+	for index: int in _data.spawn_point_count():
+		var point: Dictionary = _data.spawn_point(index)
 		_r.check(
-			data.world_map(int(point["map_group"]), int(point["map_number"])) != null,
+			_data.world_map(int(point["map_group"]), int(point["map_number"])) != null,
 			"%s: spawn %d names map %d.%d, which this cartridge does not ship." % [
 				game_id, index, int(point["map_group"]), int(point["map_number"]),
 			]
 		)
-	_verify_fly_walk(game_id, data)
+	_verify_fly_walk(game_id, _data)
 	print("%s: %d flypoints over %d spawn points, %d of them Johto." % [
-		game_id, data.flypoint_count(), data.spawn_point_count(), RomLayout.KANTO_FLYPOINT,
+		game_id, _data.flypoint_count(), _data.spawn_point_count(), RomLayout.KANTO_FLYPOINT,
 	])
 
 
-func _verify_landmarks(game_id: StringName, data: GameData, crystal: bool) -> void:
+func _verify_landmarks(game_id: StringName, _data: GameData, crystal: bool) -> void:
 	var wanted: int = RomLayout.LANDMARK_COUNT if crystal \
 		else RomLayout.LANDMARK_COUNT_GOLD_SILVER
 	if not _r.check(
-		data.landmark_count() == wanted,
-		"%s: %d landmarks, expected %d." % [game_id, data.landmark_count(), wanted]
+		_data.landmark_count() == wanted,
+		"%s: %d landmarks, expected %d." % [game_id, _data.landmark_count(), wanted]
 	):
 		return
 	_r.check(
-		data.landmark_name(LANDMARK_SPECIAL) == "SPECIAL",
-		"%s: landmark 0 is %s, not SPECIAL." % [game_id, data.landmark_name(LANDMARK_SPECIAL)]
+		_data.landmark_name(LANDMARK_SPECIAL) == "SPECIAL",
+		"%s: landmark 0 is %s, not SPECIAL." % [game_id, _data.landmark_name(LANDMARK_SPECIAL)]
 	)
 	# The whole profile split, as one row: Crystal inserts BATTLE TOWER after the
 	# Lighthouse and everything past it is one higher.
 	_r.check(
-		data.landmark_name(BATTLE_TOWER - 1) == LIGHTHOUSE_NAME,
+		_data.landmark_name(BATTLE_TOWER - 1) == LIGHTHOUSE_NAME,
 		"%s: landmark %d is %s, not %s." % [
-			game_id, BATTLE_TOWER - 1, data.landmark_name(BATTLE_TOWER - 1), LIGHTHOUSE_NAME,
+			game_id, BATTLE_TOWER - 1, _data.landmark_name(BATTLE_TOWER - 1), LIGHTHOUSE_NAME,
 		]
 	)
 	var after: String = BATTLE_TOWER_NAME if crystal else ROUTE_40_NAME
 	_r.check(
-		data.landmark_name(BATTLE_TOWER) == after,
+		_data.landmark_name(BATTLE_TOWER) == after,
 		"%s: landmark %d is %s, not %s." % [
-			game_id, BATTLE_TOWER, data.landmark_name(BATTLE_TOWER), after,
+			game_id, BATTLE_TOWER, _data.landmark_name(BATTLE_TOWER), after,
 		]
 	)
 	_r.check(
-		data.landmark_name(data.landmark_count() - 1) == "FAST SHIP",
+		_data.landmark_name(_data.landmark_count() - 1) == "FAST SHIP",
 		"%s: the last landmark is %s, not FAST SHIP." % [
-			game_id, data.landmark_name(data.landmark_count() - 1),
+			game_id, _data.landmark_name(_data.landmark_count() - 1),
 		]
 	)
 	_r.check(
-		_breaks(data, BROKEN_NAME),
+		_breaks(_data, BROKEN_NAME),
 		"%s: landmark %d carries no line break." % [game_id, BROKEN_NAME]
 	)
 	_r.check(
-		not _breaks(data, UNBROKEN_NAME),
+		not _breaks(_data, UNBROKEN_NAME),
 		"%s: landmark %d carries a line break it should not." % [game_id, UNBROKEN_NAME]
 	)
-	for index: int in range(1, data.landmark_count()):
-		var entry: Dictionary = data.landmark(index)
+	for index: int in range(1, _data.landmark_count()):
+		var entry: Dictionary = _data.landmark(index)
 		var x: int = int(entry.get("x", -1))
 		var y: int = int(entry.get("y", -1))
 		if not _r.check(
 			x >= ICON_ORIGIN and x + ICON_ORIGIN <= Gen2Screen.WIDTH \
 				and y >= ICON_ORIGIN and y + ICON_ORIGIN <= Gen2Screen.HEIGHT,
 			"%s: landmark %d (%s) is at (%d,%d); its icon hangs off the screen." % [
-				game_id, index, data.landmark_name(index), x, y,
+				game_id, index, _data.landmark_name(index), x, y,
 			]
 		):
 			return
 
 
 ## Whether a landmark's name carries the `<BSP>` the region map breaks on.
-func _breaks(data: GameData, landmark: int) -> bool:
-	var codes: PackedByteArray = data.landmark(landmark).get("codes", PackedByteArray())
+func _breaks(_data: GameData, landmark: int) -> bool:
+	var codes: PackedByteArray = _data.landmark(landmark).get("codes", PackedByteArray())
 	return Gen2TownMapPage.NAME_BREAK_CODES[0] in codes
 
 
-func _verify_regions(game_id: StringName, data: GameData) -> void:
+func _verify_regions(game_id: StringName, _data: GameData) -> void:
 	for region: String in ["johto", "kanto"]:
-		var cells: PackedByteArray = data.town_map_region(region)
+		var cells: PackedByteArray = _data.town_map_region(region)
 		if not _r.check(
 			cells.size() == RomLayout.TOWN_MAP_REGION_CELLS,
 			"%s: the %s map is %d cells, expected %d." % [
@@ -270,9 +270,9 @@ func _verify_regions(game_id: StringName, data: GameData) -> void:
 				break
 
 
-func _verify_palettes(game_id: StringName, data: GameData, crystal: bool) -> void:
+func _verify_palettes(game_id: StringName, _data: GameData, crystal: bool) -> void:
 	for slot: int in RomLayout.TOWN_MAP_PALETTES:
-		var colors: PackedColorArray = data.town_map_palette(slot)
+		var colors: PackedColorArray = _data.town_map_palette(slot)
 		if not _r.check(
 			colors.size() == RomLayout.TOWN_MAP_PALETTE_COLORS,
 			"%s: region palette %d has %d colours." % [game_id, slot, colors.size()]
@@ -284,13 +284,13 @@ func _verify_palettes(game_id: StringName, data: GameData, crystal: bool) -> voi
 		)
 	# `TownMapPals`' table stops at $60; the font above it takes palette 0.
 	_r.check(
-		data.town_map_palette_of(RomLayout.TOWN_MAP_PALETTE_MAP_LIMIT) == 0,
+		_data.town_map_palette_of(RomLayout.TOWN_MAP_PALETTE_MAP_LIMIT) == 0,
 		"%s: a tile past the palette map is not on palette 0." % game_id
 	)
 	# `FemalePokegearPals` differs from the male run in its city palette alone,
 	# and only Crystal ships one.
-	var male: PackedColorArray = data.town_map_palette(Gen2TownMapPage.CITY_PALETTE)
-	var female: PackedColorArray = data.town_map_palette(Gen2TownMapPage.CITY_PALETTE, true)
+	var male: PackedColorArray = _data.town_map_palette(Gen2TownMapPage.CITY_PALETTE)
+	var female: PackedColorArray = _data.town_map_palette(Gen2TownMapPage.CITY_PALETTE, true)
 	_r.check(
 		(male != female) == crystal,
 		"%s: the female city palette %s the male one." % [
@@ -301,7 +301,7 @@ func _verify_palettes(game_id: StringName, data: GameData, crystal: bool) -> voi
 
 ## `.pressed_up` and `.pressed_down` walk the whole window and wrap at both ends,
 ## so a full lap visits every landmark in it exactly once and comes home.
-func _verify_cursor_walk(game_id: StringName, data: GameData, crystal: bool) -> void:
+func _verify_cursor_walk(game_id: StringName, _data: GameData, crystal: bool) -> void:
 	for opened: bool in [false, true]:
 		for landmark: int in [Gen2TownMap.JOHTO_LANDMARK, Gen2WorldRadio.kanto_landmark(crystal)]:
 			var map := Gen2TownMap.create(landmark, crystal, opened)
@@ -340,8 +340,8 @@ func _verify_cursor_walk(game_id: StringName, data: GameData, crystal: bool) -> 
 
 ## The page against the real art: every tile a region map or a frame names has to
 ## resolve out of the two sheets, and both screens have to compose.
-func _verify_page(game_id: StringName, data: GameData, crystal: bool) -> void:
-	var page: Gen2TownMapPage = Gen2TownMapPage.from_data(data)
+func _verify_page(game_id: StringName, _data: GameData, crystal: bool) -> void:
+	var page: Gen2TownMapPage = Gen2TownMapPage.from_data(_data)
 	if not _r.check(page != null and page.ready(), "%s: the region map art is missing." % game_id):
 		return
 	# The two objects the screen draws come off strips of their own.
@@ -350,7 +350,7 @@ func _verify_page(game_id: StringName, data: GameData, crystal: bool) -> void:
 		["fast_ship", RomLayout.FAST_SHIP_TILES],
 	]:
 		_r.check(
-			data.tile_indices(String(sheet[0])).size()
+			_data.tile_indices(String(sheet[0])).size()
 				== int(sheet[1]) * Gen2Tiles.TILE_PIXELS,
 			"%s: the %s strip is not %d tiles." % [game_id, sheet[0], int(sheet[1])]
 		)
@@ -362,12 +362,12 @@ func _verify_page(game_id: StringName, data: GameData, crystal: bool) -> void:
 			var landmark: int = BROKEN_NAME if region == "johto" \
 				else Gen2WorldRadio.kanto_landmark(crystal)
 			var map: PackedInt32Array = page.tilemap(
-				data.town_map_region(region),
-				data.landmark(landmark).get("codes", PackedByteArray()),
+				_data.town_map_region(region),
+				_data.landmark(landmark).get("codes", PackedByteArray()),
 				screen,
 				[&"map", &"phone", &"radio"] as Array,
 			)
-			var image: Image = page.image(data, map)
+			var image: Image = page.image(_data, map)
 			_r.check(
 				image.get_width() == Gen2Screen.WIDTH \
 					and image.get_height() == Gen2Screen.HEIGHT,
@@ -378,19 +378,19 @@ func _verify_page(game_id: StringName, data: GameData, crystal: bool) -> void:
 ## `FindNest` over the whole species range, which is the only sweep that can say
 ## the merged encounter tables kept their regions: a Johto walk that reached a
 ## Kanto row would put a nest on the wrong map.
-func _verify_nests(game_id: StringName, data: GameData, crystal: bool) -> void:
+func _verify_nests(game_id: StringName, _data: GameData, crystal: bool) -> void:
 	_r.check(
-		data.tile_indices("dex_nest_icon").size()
+		_data.tile_indices("dex_nest_icon").size()
 			== RomLayout.DEX_NEST_ICON_TILES * Gen2Tiles.TILE_PIXELS,
 		"%s: the dex nest icon is not one tile." % game_id
 	)
 	var kanto_first: int = Gen2WorldRadio.kanto_landmark(crystal)
-	var roaming: Array = data.world_roaming_mons()
+	var roaming: Array = _data.world_roaming_mons()
 	var deepest: int = 0
 	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
 		for region: int in Gen2TownMap.REGION_NAMES.size():
 			var list: Array = Gen2WorldEncounter.nests(
-				data, species, Gen2TownMap.region_name(region), roaming
+				_data, species, Gen2TownMap.region_name(region), roaming
 			)
 			deepest = maxi(deepest, list.size())
 			var seen: Dictionary = {}
@@ -419,17 +419,17 @@ func _verify_nests(game_id: StringName, data: GameData, crystal: bool) -> void:
 	for index: int in roaming.size():
 		var mon: Dictionary = roaming[index]
 		var species: int = int(mon["species"])
-		var map: Gen2WorldMap = data.world_map(int(mon["map_group"]), int(mon["map_number"]))
+		var map: Gen2WorldMap = _data.world_map(int(mon["map_group"]), int(mon["map_number"]))
 		var wanted: Array = [] if index >= Gen2WorldEncounter.ROAM_NEST_MONS \
 			else [map.location]
 		_r.check(
-			Gen2WorldEncounter.nests(data, species, "johto", roaming) == wanted,
+			Gen2WorldEncounter.nests(_data, species, "johto", roaming) == wanted,
 			"%s: roamer %d (species %d) does not nest on %s." % [
 				game_id, index, species, str(wanted),
 			]
 		)
 		_r.check(
-			Gen2WorldEncounter.nests(data, species, "kanto", roaming).is_empty(),
+			Gen2WorldEncounter.nests(_data, species, "kanto", roaming).is_empty(),
 			"%s: roamer %d (species %d) nests in Kanto." % [game_id, index, species]
 		)
 
@@ -438,15 +438,15 @@ func _verify_nests(game_id: StringName, data: GameData, crystal: bool) -> void:
 ## a whole screen out of the two sheets, both Pokegear texts as the source's own
 ## words, and the page drawing all three. The tilemaps and the texts are byte
 ## identical on the three cartridges, so the pins below are the same everywhere.
-func _verify_cards(game_id: StringName, data: GameData) -> void:
-	var page: Gen2TownMapPage = Gen2TownMapPage.from_data(data)
+func _verify_cards(game_id: StringName, _data: GameData) -> void:
+	var page: Gen2TownMapPage = Gen2TownMapPage.from_data(_data)
 	if not _r.check(
 		page != null and page.cards_ready(),
 		"%s: the cache holds no Pokegear card tilemaps." % game_id
 	):
 		return
 	for card: String in RomLayout.POKEGEAR_CARD_ORDER:
-		var cells: PackedByteArray = data.pokegear_card(StringName(card))
+		var cells: PackedByteArray = _data.pokegear_card(StringName(card))
 		if not _r.check(
 			cells.size() == RomLayout.POKEGEAR_CARD_CELLS,
 			"%s: the %s card is %d cells, wanted %d." % [
@@ -462,7 +462,7 @@ func _verify_cards(game_id: StringName, data: GameData) -> void:
 			):
 				break
 	for pin: Array in CARD_PINS:
-		var cells: PackedByteArray = data.pokegear_card(StringName(pin[0]))
+		var cells: PackedByteArray = _data.pokegear_card(StringName(pin[0]))
 		var at: Vector2i = pin[1]
 		var cell: int = int(cells[at.y * Gen2TownMapPage.COLUMNS + at.x])
 		_r.check(
@@ -473,9 +473,9 @@ func _verify_cards(game_id: StringName, data: GameData) -> void:
 		)
 	for name: String in CARD_TEXTS:
 		_r.check(
-			data.pokegear_text(name) == String(CARD_TEXTS[name]),
+			_data.pokegear_text(name) == String(CARD_TEXTS[name]),
 			"%s: Pokegear text %s reads \"%s\"." % [
-				game_id, name, data.pokegear_text(name).replace("\n", "|"),
+				game_id, name, _data.pokegear_text(name).replace("\n", "|"),
 			]
 		)
 	## `PrintHoursMins` and `_GearTodayText` on the card the cartridge draws

--- a/tools/dump_editor_errors.gd
+++ b/tools/dump_editor_errors.gd
@@ -10,7 +10,12 @@ extends EditorScript
 ## panel is the only way to read them outside it.
 ##
 ## The panel holds what this editor session has analysed, so a full sweep is
-## Project > Reload Current Project first, then this.
+## Project > Reload Current Project first, then this. It is also where a running
+## game's warnings arrive, which is how a mod's `user://` scripts are seen.
+##
+## For the analyser alone, with no editor to drive, see
+## `addons/warning_scan/plugin.gd`: it opens named scripts headlessly and prints
+## what the analyser says about each.
 
 const OUTPUT_PATH: String = "user://editor_errors.txt"
 

--- a/tools/lib/tool_path.gd
+++ b/tools/lib/tool_path.gd
@@ -1,0 +1,49 @@
+class_name Gen2ToolPath
+extends RefCounted
+
+## Refuses an output path that would be written inside this project.
+##
+## A tool runs with `--path <this project>`, so the project is what a path
+## resolves against rather than the directory the command was run from. A bare
+## `out.png` lands in the checkout and the editor then makes an `.import` file
+## beside it. That is a hazard this project owns, since it is what `--path`
+## points at, and it belongs to anything run against it: the mod repository's own
+## twenty-five tools hit it too, which is why this is a `class_name` rather than
+## a copy per tool.
+##
+## The test is where the path ends up, not how it is spelt. `res://out.png` is
+## absolute to `is_absolute_path()` and lands in the project just as a bare name
+## does, so a guard written on prefixes lets through the one thing it exists to
+## stop. Globalizing answers the question directly and also catches an absolute
+## path that happens to point into the checkout.
+##
+## `user://` is allowed: it is the userdata directory, which is where a tool's
+## own scratch belongs and is not the project.
+
+
+## True when [param path] is refused, having printed why. A tool quits on true.
+static func refuses(path: String) -> bool:
+	var reason: String = refusal(path)
+	if reason.is_empty():
+		return false
+	print(reason)
+	return true
+
+
+## Why [param path] is refused, or "" when it is not. Separate from
+## [method refuses] so a test can read the answer instead of the console.
+static func refusal(path: String) -> String:
+	if path.is_empty():
+		return "no output path given"
+	var project: String = ProjectSettings.globalize_path("res://").simplify_path()
+	var full: String = ProjectSettings.globalize_path(path).simplify_path()
+	## A relative path globalizes unchanged and Godot resolves it against the
+	## project, so that is where it has to be measured. The separator is what
+	## keeps a sibling directory whose name merely starts the same way out of it.
+	if not full.is_absolute_path():
+		full = project.path_join(full)
+	if full != project and not full.begins_with(project.path_join("")):
+		return ""
+	return "refusing %s: it would be written to %s, inside the project. %s" % [
+		path, full, "Give a path outside it, or a user:// one.",
+	]

--- a/tools/lib/tool_path.gd.uid
+++ b/tools/lib/tool_path.gd.uid
@@ -1,0 +1,1 @@
+uid://di13s63kdf00b

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -67,6 +67,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	_move = int(args[2])
 	_side_is_enemy = int(args[3]) != 0
 	if args[4].contains("-"):

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -75,6 +75,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	_stage = args[2] if args.size() > 2 else "offer"
 	if args.size() > 3:
 		_presses = args[3].split(",", false)

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -25,6 +25,9 @@ func _initialize() -> void:
 		push_error("Usage: -s tools/preview_collision.gd -- <game> <group> <number> <output.png>")
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[3]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])

--- a/tools/preview_controls.gd
+++ b/tools/preview_controls.gd
@@ -33,6 +33,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[0]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	_with_mod_buttons = args.size() > 1 and args[1] == "mod"
 
 

--- a/tools/preview_credits.gd
+++ b/tools/preview_credits.gd
@@ -47,6 +47,9 @@ func _initialize() -> void:
 	frames.sort()
 
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	if args.size() > 3 and args[3] == "live":
 		_spent = int(frames[frames.size() - 1])
 		_open_world(data)

--- a/tools/preview_fishing.gd
+++ b/tools/preview_fishing.gd
@@ -28,6 +28,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[0]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	if args.size() >= 4:
 		_data = GameData.open(StringName(args[1]))
 		if _data == null:

--- a/tools/preview_gs_intro.gd
+++ b/tools/preview_gs_intro.gd
@@ -22,6 +22,9 @@ func _initialize() -> void:
 		push_error("Usage: preview_gs_intro.gd -- <game> [output.png] [frame;frame;...]")
 		quit(1)
 		return
+	if args.size() > 1 and Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_hall_of_fame.gd
+++ b/tools/preview_hall_of_fame.gd
@@ -27,6 +27,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	_advance = int(args[2]) if args.size() > 2 else 0
 
 	var data: GameData = GameData.open(StringName(args[0]))

--- a/tools/preview_intro.gd
+++ b/tools/preview_intro.gd
@@ -56,6 +56,9 @@ func _initialize() -> void:
 		return
 	var game: StringName = StringName(args[0])
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	if args.size() > 2:
 		_what = args[2]
 	if args.size() > 4:

--- a/tools/preview_intro_movie.gd
+++ b/tools/preview_intro_movie.gd
@@ -22,6 +22,9 @@ func _initialize() -> void:
 		push_error("Usage: preview_intro_movie.gd -- <game> [output.png] [frame;frame;...]")
 		quit(1)
 		return
+	if args.size() > 1 and Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -48,11 +48,6 @@ var _mod: String = ""
 var _scroll: int = 0
 var _focus: int = -1
 var _fade: int = 0
-## Forced frames seen during an import, and which one is photographed: late
-## enough that the bar has something on it, early enough to be inside the job.
-var _forced: int = 0
-var _captured: bool = false
-const FORCED_FRAME_WANTED: int = 34
 
 
 func _initialize() -> void:
@@ -62,6 +57,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output = args[0]
+	if Gen2ToolPath.refuses(_output):
+		quit(2)
+		return
 	var mode: String = args[1] if args.size() > 1 else "light"
 	var width: int = int(args[2]) if args.size() > 2 else 1280
 	var height: int = int(args[3]) if args.size() > 3 else 800

--- a/tools/preview_mail.gd
+++ b/tools/preview_mail.gd
@@ -30,6 +30,9 @@ func _initialize() -> void:
 		push_error("Usage: preview_mail.gd -- <game> <output.png> [type|all]")
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -63,6 +63,9 @@ func _initialize() -> void:
 	_game = game
 	if args.size() > 1:
 		_output_path = args[1]
+		if Gen2ToolPath.refuses(_output_path):
+			quit(2)
+			return
 	if args.size() > 2:
 		_capture_frame = maxi(1, int(args[2]))
 

--- a/tools/preview_naming_screen.gd
+++ b/tools/preview_naming_screen.gd
@@ -39,6 +39,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_oak_speech.gd
+++ b/tools/preview_oak_speech.gd
@@ -25,6 +25,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_overworld_sprites.gd
+++ b/tools/preview_overworld_sprites.gd
@@ -33,6 +33,9 @@ func _initialize() -> void:
 		push_error("Usage: -s tools/preview_overworld_sprites.gd -- <game> <output.png>")
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -65,6 +65,9 @@ func _capture() -> void:
 		)
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -56,6 +56,9 @@ func _initialize() -> void:
 		return
 	var game: StringName = StringName(args[0])
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	if args.size() > 2:
 		_what = args[2]
 	if args.size() > 3:

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -42,6 +42,9 @@ func _initialize() -> void:
 
 	var game: StringName = StringName(positional[0])
 	var out_path: String = positional[1]
+	if Gen2ToolPath.refuses(out_path):
+		quit(2)
+		return
 	var atlas_name: String = positional[2] if positional.size() > 2 else "front"
 
 	var directory: String = _find_cache(game)
@@ -50,15 +53,15 @@ func _initialize() -> void:
 		quit(1)
 		return
 
-	var manifest: Dictionary = RomCache.read_manifest(directory)
-	var atlases: Dictionary = manifest.get("atlases", {})
-	var sheets: Dictionary = manifest.get("tiles", {})
+	var _manifest: Dictionary = RomCache.read_manifest(directory)
+	var atlases: Dictionary = _manifest.get("atlases", {})
+	var sheets: Dictionary = _manifest.get("tiles", {})
 
 	var image: Image = null
 	if sheets.has(atlas_name):
 		image = _render_sheet(directory, sheets[atlas_name], atlas_name)
 	elif atlases.has(atlas_name):
-		image = _render(directory, manifest, atlases[atlas_name], atlas_name, shiny)
+		image = _render(directory, _manifest, atlases[atlas_name], atlas_name, shiny)
 	else:
 		push_error("Nothing named %s in this cache." % atlas_name)
 		quit(1)
@@ -126,7 +129,7 @@ func _render_sheet(directory: String, sheet: Dictionary, name: String) -> Image:
 
 
 func _render(
-	directory: String, manifest: Dictionary, atlas: Dictionary, name: String, shiny: bool
+	directory: String, _manifest: Dictionary, atlas: Dictionary, name: String, shiny: bool
 ) -> Image:
 	var indices: PackedByteArray = RomCache.read_indices(RomCache.pic_path(directory, name))
 	var width: int = int(atlas["width"])

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -47,6 +47,9 @@ func _initialize() -> void:
 		)
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])

--- a/tools/preview_saves.gd
+++ b/tools/preview_saves.gd
@@ -11,6 +11,9 @@ var _frames: int = 0
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	_output = args[0]
+	if Gen2ToolPath.refuses(_output):
+		quit(2)
+		return
 	var mode: String = args[1] if args.size() > 1 else "light"
 	var options: Gen2Options = Gen2OptionsStore.current()
 	options.ui_theme = StringName(mode)

--- a/tools/preview_title.gd
+++ b/tools/preview_title.gd
@@ -20,6 +20,9 @@ func _initialize() -> void:
 		push_error("Usage: preview_title.gd -- <game> <output.png> [frame;frame;...]")
 		quit(1)
 		return
+	if args.size() > 1 and Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -46,6 +46,9 @@ func _initialize() -> void:
 		)
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -239,6 +239,10 @@ func _initialize() -> void:
 		quit(1)
 		return
 
+	if Gen2ToolPath.refuses(args[3]):
+		quit(2)
+		return
+
 	var data: GameData = GameData.open(StringName(args[0]))
 	if args.size() >= 5 and args[4] == "live":
 		if data == null:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -67,6 +67,11 @@ extends SceneTree
 ## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
 ## map's edge onto its neighbour: `crystal 24 4 ... map_name_sign 1 8` crosses
 ## New Bark Town into Route 29),
+## `battle_tower` (`BattleTower1FReceptionistScript`, talked to from the cell
+## below her: the first number is how many A presses to spend and the second how
+## many DOWN presses, so `crystal 22 11 ... battle_tower@7,7 5 0` is the
+## Challenge / Explanation / Cancel menu and `... battle_tower@7,7 6 2` the level
+## list standing on its third room),
 ## `yes_no` (`Script_yesorno`'s box, over the map's first script run to the
 ## choice it ends on: `crystal 26 3 ... yes_no 31 6` is Cherrygrove's guide),
 ## `name_rater` and `move_deleter` (`special NameRater` and `special
@@ -206,6 +211,9 @@ const SCREEN_DRIVER: String = "preview_%s"
 ## welcome the buy screen opens on. One more reaches the list, two the quantity
 ## dial and three the yes/no.
 const MART_PRESSES: int = 1
+## Frames spent between two presses of a driven menu, so the box a press opened
+## owes nothing before the next one lands: nothing shortens a printing text.
+const TEXT_SETTLE_FRAMES: int = 20
 
 const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_CUT: int = 12
@@ -331,6 +339,22 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 
 ## Spends whatever one of the two routines' boxes still owes, plus the frame
 ## `advance_frame` reads it on: `PrintText` returning is what opens a `YesNoBox`.
+## Three legal entrants at the level the room list opens on, so the driven
+## receptionist reaches the level menu rather than the rules refusal.
+func _stage_battle_tower_party() -> void:
+	var save: Gen2SaveData = _screen.active_save()
+	if save == null:
+		save = Gen2SaveStore.create_development_save(_screen._data, 0)
+		_screen.set_save(save)
+	save.party = []
+	for slot: int in Gen2BattleTower.PARTY_LENGTH:
+		var mon: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(
+			Gen2BattleMon.create(_screen._data, 155 + slot * 3, 10, [33])
+		)
+		save.party.append(mon)
+	_screen._refresh_party_summary()
+
+
 func _settle_mon_special(host_property: String) -> void:
 	for _frame: int in MON_SPECIAL_FRAME_CAP:
 		var routine: Control = _screen.get(host_property)
@@ -522,6 +546,30 @@ func _process(_delta: float) -> bool:
 					break
 				_screen.press_button(Gen2Button.A)
 				_settle_mon_special(host_property)
+		elif _kind == &"battle_tower":
+			## `BattleTower1FReceptionistScript` from the cell below her, which
+			## is where `Script_WalkToBattleTowerElevator` puts the player back.
+			## The first number is how many A presses to spend, which walks the
+			## welcome box, the explanation question and the Challenge /
+			## Explanation / Cancel menu; the second is how many DOWN presses to
+			## spend on whichever menu is up, so `battle_tower 6 2` stands on the
+			## third room of the level list.
+			## `_CheckForBattleTowerRules` refuses anything but three different
+			## species holding three different items, and the development save's
+			## party is not one, so the challenge would never open a room.
+			_stage_battle_tower_party()
+			_screen.press_button(Gen2Button.UP)
+			_screen.interact()
+			for _frame: int in TEXT_SETTLE_FRAMES:
+				_screen.advance_frame()
+			for _press: int in maxi(_cell.x, 0):
+				_screen.press_button(Gen2Button.A)
+				for _frame: int in TEXT_SETTLE_FRAMES:
+					_screen.advance_frame()
+			for _press: int in maxi(_cell.y, 0):
+				_screen.press_button(Gen2Button.DOWN)
+				for _frame: int in TEXT_SETTLE_FRAMES:
+					_screen.advance_frame()
 		elif _kind == &"yes_no":
 			## `Script_yesorno`'s own box: the NPC beside the player is talked
 			## to and each page answered until the choice the script ends on is

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -52,6 +52,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_output_path = args[0]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	if args.size() > 1:
 		_kind = StringName(args[1])
 	if args.size() > 2:

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -3056,13 +3056,13 @@ func _glacier_badge_path(
 			"reason": "Route 38 back to Ecruteak failed: %s" % to_ecruteak.get("reason", ""),
 		}
 
-	var to_route_42: Dictionary = _gate_leg(
+	var route_42_path: Dictionary = _gate_leg(
 		world, save, random, data, Vector2i(35, 26), 2, 5
 	)
-	if not bool(to_route_42.get("ok", false)):
+	if not bool(route_42_path.get("ok", false)):
 		return {
 			"ok": false, "path": path,
-			"reason": "Ecruteak to Route 42 failed: %s" % to_route_42.get("reason", ""),
+			"reason": "Ecruteak to Route 42 failed: %s" % route_42_path.get("reason", ""),
 		}
 	# Route 42's halves do not join on foot. Its west side ends at x=13 and its
 	# only other land exit is Mt Mortar's door at (10,5), which opens into a cave
@@ -4004,16 +4004,16 @@ func _goldenrod_crossing(
 ) -> Dictionary:
 	var westbound: bool = heading == "west"
 	if westbound:
-		var to_route_42: Dictionary = _walk_connection_resolving(
+		var mahogany_leg: Dictionary = _walk_connection_resolving(
 			world, "west", 2, 5, save, random, data
 		)
 		var _r42_entry: Dictionary = _drain_story(
 			world, world.dispatch_map_entry(), save, random, data
 		)
-		if not bool(to_route_42.get("ok", false)):
+		if not bool(mahogany_leg.get("ok", false)):
 			return {
 				"ok": false, "path": path,
-				"reason": "Mahogany to Route 42 failed: %s" % to_route_42.get("reason", ""),
+				"reason": "Mahogany to Route 42 failed: %s" % mahogany_leg.get("reason", ""),
 			}
 		# The same two lakes _glacier_badge_path() crossed eastward, taken from
 		# the far shore each time.
@@ -4119,13 +4119,13 @@ func _goldenrod_crossing(
 					leg[0], leg[1], leg[2], walked.get("reason", ""),
 				],
 			}
-	var to_route_42: Dictionary = _gate_leg(
+	var route_42_path: Dictionary = _gate_leg(
 		world, save, random, data, Vector2i(35, 26), 2, 5
 	)
-	if not bool(to_route_42.get("ok", false)):
+	if not bool(route_42_path.get("ok", false)):
 		return {
 			"ok": false, "path": path,
-			"reason": "Ecruteak to Route 42 failed: %s" % to_route_42.get("reason", ""),
+			"reason": "Ecruteak to Route 42 failed: %s" % route_42_path.get("reason", ""),
 		}
 	var west_lake: Dictionary = _lake_crossing(
 		world, save, random, data,

--- a/tools/profile.gd
+++ b/tools/profile.gd
@@ -230,15 +230,15 @@ func _open_overworld(fill: bool = true) -> Dictionary:
 	## Walked rather than stood still: a standing player redraws nothing, and
 	## what a map costs is the camera moving over it. The turn every two seconds
 	## keeps the walk on the spawn map.
-	var log: Array = []
+	var log_lines: Array = []
 	for frame: int in WARMUP_FRAMES + BATTLE_FRAMES:
 		@warning_ignore("integer_division")
 		var leg: int = (frame / 120) % 4
-		log.append({
+		log_lines.append({
 			"frame": frame, "kind": "hold",
 			"button": [Gen2Button.DOWN, Gen2Button.RIGHT, Gen2Button.UP, Gen2Button.LEFT][leg],
 		})
-	screen.replay_input(log)
+	screen.replay_input(log_lines)
 	return {"node": screen, "step": func() -> void: screen.advance_frame()}
 
 

--- a/tools/render_audio.gd
+++ b/tools/render_audio.gd
@@ -25,6 +25,9 @@ func _initialize() -> void:
 	var kind: StringName = StringName(arguments[1])
 	var frames: int = int(arguments[3])
 	var prefix: String = arguments[4]
+	if Gen2ToolPath.refuses(prefix):
+		quit(2)
+		return
 	var stereo: bool = arguments.size() > 5 and arguments[5] == "1"
 
 	var data: GameData = GameData.open(game)
@@ -40,11 +43,11 @@ func _initialize() -> void:
 	if arguments[2] == "all":
 		var index: int = 1 if kind == &"mon_cry" else 0
 		while true:
-			var record: Dictionary = _record(data, kind, index)
-			if record.is_empty():
+			var swept: Dictionary = _record(data, kind, index)
+			if swept.is_empty():
 				break
-			_report(kind, index, record)
-			if not _render(record, kind, assets, frames, stereo, "%s_%d" % [prefix, index]):
+			_report(kind, index, swept)
+			if not _render(swept, kind, assets, frames, stereo, "%s_%d" % [prefix, index]):
 				quit(1)
 				return
 			index += 1
@@ -52,13 +55,13 @@ func _initialize() -> void:
 		quit(0)
 		return
 
-	var record: Dictionary = _record(data, kind, int(arguments[2]))
-	if record.is_empty():
-		printerr("No %s record %s in the %s cache." % [kind, arguments[2], game])
+	var entry: Dictionary = _record(data, kind, int(arguments[2]))
+	if entry.is_empty():
+		printerr("No %s entry %s in the %s cache." % [kind, arguments[2], game])
 		quit(1)
 		return
-	_report(kind, int(arguments[2]), record)
-	if not _render(record, kind, assets, frames, stereo, prefix):
+	_report(kind, int(arguments[2]), entry)
+	if not _render(entry, kind, assets, frames, stereo, prefix):
 		quit(1)
 		return
 	print("%s.wav: %d frames" % [prefix, frames])
@@ -73,20 +76,20 @@ func _record(data: GameData, kind: StringName, index: int) -> Dictionary:
 
 ## `mon_cry` resolves through `PokemonCries`, so the parameters it picked are
 ## worth printing: a parity run has to hand the same two to the other side.
-func _report(kind: StringName, index: int, record: Dictionary) -> void:
+func _report(kind: StringName, index: int, entry: Dictionary) -> void:
 	if kind != &"mon_cry":
 		return
 	print("species %d: cry index %d pitch %d length %d" % [
-		index, int(record.get("index", -1)),
-		int(record.get("cry_pitch", 0)), int(record.get("cry_length", 0)),
+		index, int(entry.get("index", -1)),
+		int(entry.get("cry_pitch", 0)), int(entry.get("cry_length", 0)),
 	])
 
 
 func _render(
-	record: Dictionary, kind: StringName, assets: Dictionary, frames: int,
+	entry: Dictionary, kind: StringName, assets: Dictionary, frames: int,
 	stereo: bool, prefix: String
 ) -> bool:
-	var result: Dictionary = Gen2AudioRender.render(record, kind, assets, frames, stereo, true)
+	var result: Dictionary = Gen2AudioRender.render(entry, kind, assets, frames, stereo, true)
 	if not bool(result.get("ok", false)):
 		printerr("Render failed: %s" % result.get("reason", "unknown"))
 		return false

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -209,7 +209,7 @@ func _check_route(data: GameData, route: Dictionary, requested_frames: int) -> i
 	if not bool(recorded.get("ok", false)):
 		_report(data, route, "open", String(recorded.get("reason", "unavailable")))
 		return 1
-	var log: Array = recorded["log"]
+	var log_lines: Array = recorded["log"]
 	var expected: String = recorded["state"]
 	## A route the input never moved would pass every comparison below on a world
 	## that did nothing, which is the same trap `_drain_story`'s require_events
@@ -243,7 +243,7 @@ func _check_route(data: GameData, route: Dictionary, requested_frames: int) -> i
 			host_fps = 30.0
 		elif label == "144fps":
 			host_fps = 144.0
-		var run: Dictionary = await _run(data, route, seed_value, frames, log, false, host_fps)
+		var run: Dictionary = await _run(data, route, seed_value, frames, log_lines, false, host_fps)
 		if not bool(run.get("ok", false)):
 			_report(data, route, label, String(run.get("reason", "unavailable")))
 			failures += 1
@@ -252,12 +252,12 @@ func _check_route(data: GameData, route: Dictionary, requested_frames: int) -> i
 			_report(data, route, label, _first_difference(expected, String(run["state"])))
 			failures += 1
 			continue
-		if label == "replay" and JSON.stringify(run["log"]) != JSON.stringify(log):
+		if label == "replay" and JSON.stringify(run["log"]) != JSON.stringify(log_lines):
 			_report(data, route, label, "the replay consumed a different log")
 			failures += 1
 			continue
 		print("%-8s %-16s %-7s %d frames, %d input entries%s" % [
-			data.id, route["name"], label, frames, log.size(),
+			data.id, route["name"], label, frames, log_lines.size(),
 			", %d battles" % int(run["battles"]) if int(run["battles"]) > 0 else "",
 		])
 	return failures
@@ -271,7 +271,7 @@ func _run(
 	route: Dictionary,
 	seed_value: int,
 	frames: int,
-	log: Array,
+	log_lines: Array,
 	recording: bool,
 	host_fps: float = 0.0,
 	adaptive: bool = false,
@@ -314,7 +314,7 @@ func _run(
 	var initial: String = JSON.stringify(screen._world.snapshot().to_dict(), "\t")
 	var initial_money: int = screen._world.state.money()
 
-	screen.replay_input(log)
+	screen.replay_input(log_lines)
 	if recording:
 		screen.record_input()
 	var battles: int = 0
@@ -350,7 +350,7 @@ func _run(
 		"outcome": outcome,
 		"money": money,
 		"world": world,
-		"log": log if not recording else consumed,
+		"log": log_lines if not recording else consumed,
 	}
 
 
@@ -444,20 +444,20 @@ func _program(seed_value: int, frames: int, errand: bool = false) -> Array:
 		return _errand_program(frames)
 	var random := RandomNumberGenerator.new()
 	random.seed = seed_value
-	var log: Array = []
+	var log_lines: Array = []
 	var frame: int = 1
 	while frame <= frames:
 		if random.randi_range(0, 9) == 0:
-			log.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
+			log_lines.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
 			frame += random.randi_range(2, 8)
 			continue
 		var direction: int = DIRECTIONS[random.randi_range(0, DIRECTIONS.size() - 1)]
 		for _held: int in random.randi_range(4, 40):
 			if frame > frames:
 				break
-			log.append({"frame": frame, "kind": "hold", "button": direction})
+			log_lines.append({"frame": frame, "kind": "hold", "button": direction})
 			frame += 1
-	return log
+	return log_lines
 
 
 ## One walk step in the hardware frames this tool spends, which is the pass
@@ -476,24 +476,24 @@ func _walk_frames() -> int:
 ## the walk rate is, and the turn into the counter is a press the wall refuses to
 ## move on.
 func _errand_program(frames: int) -> Array:
-	var log: Array = []
+	var log_lines: Array = []
 	var walk: int = mini(frames, (MART_DOOR.y - MART_COUNTER.y) * _walk_frames())
 	for frame: int in range(1, walk + 1):
-		log.append({"frame": frame, "kind": "hold", "button": Gen2Button.UP})
+		log_lines.append({"frame": frame, "kind": "hold", "button": Gen2Button.UP})
 	## Clear of the walk rather than up against it: `move_player` refuses a press
 	## while the last step is still in flight, and a turn that is refused leaves
 	## the player facing the wall behind the counter instead of the clerk.
 	if walk + _walk_frames() * 3 <= frames:
-		log.append({
+		log_lines.append({
 			"frame": walk + _walk_frames() * 3,
 			"kind": "press",
 			"button": Gen2Button.LEFT,
 		})
 	var frame: int = walk + _walk_frames() * 5
 	while frame <= frames:
-		log.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
+		log_lines.append({"frame": frame, "kind": "press", "button": Gen2Button.A})
 		frame += 8
-	return log
+	return log_lines
 
 
 ## `String.hash()` moves by one between two names that differ in their last

--- a/tools/screenshot.gd
+++ b/tools/screenshot.gd
@@ -34,6 +34,9 @@ func _initialize() -> void:
 
 	var scene_path: String = args[0]
 	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
 	if args.size() >= 3:
 		_frames_to_wait = maxi(1, int(args[2]))
 

--- a/tools/trace_battle_commands.gd
+++ b/tools/trace_battle_commands.gd
@@ -38,6 +38,9 @@ func _initialize() -> void:
 		)
 		quit(1)
 		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -63,6 +63,9 @@ func _initialize() -> void:
 		quit(1)
 		return
 	if args.size() > 2:
+		if Gen2ToolPath.refuses(args[2]):
+			quit(2)
+			return
 		_shot_prefix = args[2].get_basename()
 	if args.size() > 3:
 		for value: String in args[3].split(","):

--- a/tools/trace_world_script.gd
+++ b/tools/trace_world_script.gd
@@ -50,6 +50,9 @@ func _run() -> void:
 		push_error("usage: <game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>")
 		quit(2)
 		return
+	if Gen2ToolPath.refuses(args[7]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("no imported cache for %s" % args[0])

--- a/tools/trace_world_tiles.gd
+++ b/tools/trace_world_tiles.gd
@@ -23,6 +23,9 @@ func _run() -> void:
 		push_error("usage: <game> <group> <map> <frames> <out.txt> [time_of_day]")
 		quit(2)
 		return
+	if Gen2ToolPath.refuses(args[4]):
+		quit(2)
+		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
 		push_error("no imported cache for %s" % args[0])

--- a/tools/trace_world_walk.gd
+++ b/tools/trace_world_walk.gd
@@ -64,10 +64,10 @@ func _run() -> void:
 
 	## Held from the eleventh frame on, which is where the cartridge trace
 	## presses, and released once the run has spent its frames.
-	var log: Array = []
+	var log_lines: Array = []
 	for frame: int in range(STANDING_FRAMES, frames):
-		log.append({"frame": frame, "kind": "hold", "button": direction})
-	screen.replay_input(log)
+		log_lines.append({"frame": frame, "kind": "hold", "button": direction})
+	screen.replay_input(log_lines)
 
 	var lines: PackedStringArray = PackedStringArray([
 		"# frame cam_x cam_y x y screen_x screen_y facing walk_frame"
@@ -76,6 +76,9 @@ func _run() -> void:
 		screen.advance_frame()
 		lines.append(_sample(screen._world, frame))
 	var out: String = args[7]
+	if Gen2ToolPath.refuses(out):
+		quit(2)
+		return
 	FileAccess.open(out, FileAccess.WRITE).store_string("\n".join(lines) + "\n")
 	print("wrote %d frames to %s" % [frames, out])
 	root.remove_child(screen)

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,6 +44,7 @@ const GROUPS: Dictionary = {
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
 		&"card_flip", &"move_effects", &"phone", &"decorations", &"mail",
+		&"battle_tower",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 }


### PR DESCRIPTION
## The Battle Tower

The receptionist's whole flow runs now. The welcome, the explanation a save file is only offered once, the Challenge / Explanation / Cancel menu, the four party rules, the save before the room, the level list, the walk to the elevator, and seven opponents in the battle room with the prize behind them.

Seven Crystal addresses, each hitting once:

| Table | What it is |
|---|---|
| `BattleTowerTrainers` | 70 names and classes |
| `BattleTowerMons` | 10 level groups of 21 nicknamed party-mon structs |
| `BTTrainerClassGenders`, `BTTrainerClassSprites` | one row per trainer class |
| `BattleTowerText` | 120 `text_far` stubs, three lines per trainer |
| `Strings_L10ToL100` | the level list's own rows |
| `MenuData_ChallengeExplanationCancel` | the three menu rows |

`RomImporter.verify_battle_tower` checks each against something only the right offset carries. `tools/checks/battle_tower.gd` sweeps all 210 Pokemon on all three cartridges, samples a full seven-trainer streak on every level group, and drives the battle room's own scene on the real map to its first fight. Gold and Silver ship no tower, which the topic checks as an absence rather than as an empty table.

A `BattleTowerMons` row is the same 48-byte party-mon struct a save file's party is written in, so `Gen2SramAdapter.read_party_mon` reads both. `SECTION "SRAM Battle Tower"` rides in the world snapshot, which is where the cartridge keeps it too, and defaults rather than versioning, so there is no save-format bump.

`LoadOpponentTrainerAndPokemon` is transcribed rather than approximated: a trainer no slot of `sBTTrainers` holds, then three Pokemon of the chosen group sharing no species or held item with each other or with either of the last two teams. `battletowertext` is a command rather than a special, and the greeting rolls the personality the win and loss lines read back.

`TryQuickSave` and `Reset` came with it. Both sit in the link block of `SpecialsPointers` without being link play, and the tower is the only thing in either corpus that reaches them.

## Reading the GDScript analyser without a person at the editor

```bash
Godot --headless --editor --path . -- --warning-scan [path ...]
```

`addons/warning_scan` opens each named script in the editor's own script editor, which analyses it on the spot, and reads the warnings panel beside it. It prints `file:line CODE message`, a tally and how many scripts it analysed, and exits 1 when there were any. Paths may be files or directories, `res://` or `user://`, so a mod's scripts are reachable too. Without the flag the plugin does nothing, so an ordinary editor session is untouched.

Silence is an answer only because the paths are explicit and the count is printed. A script the analyser never read was silent for the same reason a clean one is, which is what made the panel unusable as a check.

That found **59 warnings in 566 scripts**, where the panel had never shown more than 16. All are fixed at the declaration, and the scan exits 0.

| Code | Count |
|---|---|
| `SHADOWED_VARIABLE_BASE_CLASS` | 28 |
| `SHADOWED_GLOBAL_IDENTIFIER` | 12 |
| `SHADOWED_VARIABLE` | 6 |
| `UNUSED_PARAMETER` | 4 |
| `CONFUSABLE_LOCAL_DECLARATION` | 3 |
| `INT_AS_ENUM_WITHOUT_CAST` | 2 |
| four others | 1 each |

## The output-path guard

`Gen2ToolPath.refuses()`. A tool runs with `--path <here>`, so a relative output path resolves against this checkout and a bare `out.png` is written into the tree with an `.import` file beside it. The test is where a path resolves rather than how it is spelt, since `res://out.png` is absolute to `is_absolute_path()` and lands in the project all the same. `user://` is allowed. All 32 tools that take an output path check it before doing any work.

## Also fixed

A lost CANLOSE battle left WIN in `wScriptVar`. `Script_startbattle` writes `wBattleResult & ~BATTLERESULT_BITMASK` whatever the battle type was. Cherrygrove's three sites are the only ones in either corpus and both their branches print the same text, which is what hid it.

## Proof

Full test tier green (3,728 tests, 69,053 asserts), 72 check topics pass, the warning scan reports 0 in 566 scripts, the three-profile story walk and `replay_world.gd` are unchanged, and `tools/preview_world.gd -- crystal 22 11 <png> live battle_tower@7,7 <A> <DOWN>` photographs the receptionist's menus.