### PR TITLE
Open the Cable Club: trade, link battle and the record between them

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,16 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > rules, the sampled opponents with their own lines, the save between battles and
 > the prize at the end.
 >
-> Missing: link play and Mystery Gift, and a handful of pixel-level divergences
-> still being chased in the opening movies and title screen against a real
-> cartridge.
+> The Cable Club is open. There is no cable on a modern machine, so the second
+> player is your own other save file: the three receptionists, the Trade Center's
+> two-list trade screen with the swap and the trade evolution behind it, the
+> Colosseum's link battle, and the link record on the sign between them. With one
+> save file the receptionist says your friend is not ready, which is what a
+> single Game Boy has always been told.
+>
+> Missing: Mystery Gift, the trade animation, and a handful of pixel-level
+> divergences still being chased in the opening movies and title screen against a
+> real cartridge.
 
 ## Getting started
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1446,12 +1446,18 @@ func _apply_entrance_step(what: StringName) -> void:
 	_push_view()
 
 
-## `Battle_GetTrainerName`, which is the class and the trainer's own name. A wild
-## battle has neither, and the one line that names an opponent without a trainer
-## behind it is a link battle's, which this project does not open.
+## `Battle_GetTrainerName`, which is the class and the trainer's own name, and
+## `.linkbattle`, which is the other player's name with no class in front of it:
+## a link battle is the one opponent with a name and no trainer behind it. A wild
+## battle has neither.
 func _enemy_battler_label() -> String:
-	if _enemy_trainer_class <= 0 or _data == null:
+	if _data == null:
 		return "Enemy"
+	if _enemy_trainer_class <= 0:
+		## `wOTPlayerName`, which the request carries: a link opponent is not in
+		## any trainer table, so there is nothing to look the name up in.
+		var linked: String = String(_world_battle_request.get("trainer_name", ""))
+		return linked if not linked.is_empty() else "Enemy"
 	return "%s %s" % [
 		_data.trainer_name(_enemy_trainer_class), _enemy_trainer_name(),
 	]

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -79,6 +79,8 @@ var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _unown_puzzle: Dictionary = {}
 var _diploma: Dictionary = {}
+var _link_border: Dictionary = {}
+var _other_player_link_mode: int = -1
 var _printer_strings: Dictionary = {}
 var _slots: Dictionary = {}
 var _slots_text: Dictionary = {}
@@ -208,6 +210,9 @@ static func open_directory(path: String) -> GameData:
 	data._unown_puzzle = unown_puzzle if unown_puzzle is Dictionary else {}
 	var diploma: Variant = manifest.get("diploma", {})
 	data._diploma = diploma if diploma is Dictionary else {}
+	var link_border: Variant = manifest.get("link_border", {})
+	data._link_border = link_border if link_border is Dictionary else {}
+	data._other_player_link_mode = int(manifest.get("other_player_link_mode", -1))
 	var printer_strings: Variant = manifest.get("printer_strings", {})
 	data._printer_strings = printer_strings if printer_strings is Dictionary else {}
 	var slots: Variant = manifest.get("slots", {})
@@ -1986,6 +1991,36 @@ func diploma_palette() -> PackedColorArray:
 	for packed: Variant in _diploma.get("palette", []) as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
+
+
+## `LinkCommsBorderGFX`'s own strip and, on Crystal alone, the three tilemaps
+## the trade screen is laid out from. A cache imported before the border existed
+## carries neither, which is what [method has_link_border] answers for; a cache
+## that carries the strip but no screen is Gold or Silver, whose trade screen is
+## two `LinkTextboxAtHL` boxes rather than a tilemap.
+## `wOtherPlayerLinkMode`, whose address the two cartridges do not share: the
+## three receptionist scripts `readmem` it by their own profile's address, so a
+## runner writing Crystal's would leave Gold's read as zero and send every
+## player down the "can't link to the past" branch.
+func other_player_link_mode_address() -> int:
+	return _other_player_link_mode
+
+
+func has_link_border() -> bool:
+	return int(_link_border.get("tiles", 0)) > 0
+
+
+func link_border_indices() -> PackedByteArray:
+	return tile_indices("link_border")
+
+
+## `MobileTradeBorderTilemap`, `CableTradeBorderTopTilemap` and
+## `CableTradeBorderBottomTilemap` by name, empty on Gold and Silver.
+func link_border_tilemap(name: String) -> PackedByteArray:
+	var out := PackedByteArray()
+	for code: Variant in _link_border.get(name, []) as Array:
+		out.append(int(code))
+	return out
 
 
 ## One `GBPrinterStrings` entry by the status it names, or the empty string,

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 87
+const FORMAT_VERSION: int = 88
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -378,6 +378,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not printer["ok"]:
 		return printer
 
+	var link_border: Dictionary = verify_link_border(rom, layout)
+	if not link_border["ok"]:
+		return link_border
+
 	var card_flip: Dictionary = verify_card_flip(rom, layout)
 	if not card_flip["ok"]:
 		return card_flip
@@ -1693,6 +1697,41 @@ static func verify_printer(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if int(layout.get("unown_printer_glyphs", -1)) < 0:
 		return {"ok": false, "message": "No pin for the Unown printer's own glyphs."}
 	return {"ok": true, "message": "The diploma and the printer verified."}
+
+
+## `LinkCommsBorderGFX`. The walk in [method read_link_border] is most of it: a
+## tilemap that indexes past the block refuses there. What is left is the pair
+## of facts that say which cartridge's border this is, since the two are laid
+## out differently: Crystal's block carries `_LinkTextbox`'s own eight tiles at
+## `$30` and a whole screen behind it, and Gold and Silver's is nine tiles with
+## no tilemap at all.
+static func verify_link_border(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if int(layout.get("link_border", -1)) < 0:
+		return {"ok": false, "message": "No pin for the trade screen's border."}
+	var section: Dictionary = read_link_border(rom, layout)
+	if section.is_empty():
+		return {"ok": false, "message": "The trade screen's border does not walk."}
+	var crystal: bool = rom.id == &"crystal"
+	if section.has("screen") != crystal:
+		return {
+			"ok": false,
+			"message": "The trade border %s a screen tilemap." % [
+				"carries" if section.has("screen") else "carries no",
+			],
+		}
+	if not crystal:
+		return {"ok": true, "message": "The trade screen's border verified."}
+	## `_LinkTextbox`'s `.PlaceBorder` writes `$30` at the top left and `$37` at
+	## the bottom right, so those eight tiles are a box and not blank.
+	var box: PackedByteArray = (section["tiles"] as PackedByteArray).slice(
+		RomLayout.LINK_TEXTBOX_FIRST_TILE * Gen2Tiles.TILE_BYTES,
+		(RomLayout.LINK_TEXTBOX_FIRST_TILE + RomLayout.LINK_TEXTBOX_TILES) \
+			* Gen2Tiles.TILE_BYTES
+	)
+	for byte: int in box:
+		if byte != 0:
+			return {"ok": true, "message": "The trade screen's border verified."}
+	return {"ok": false, "message": "The trade border's own textbox tiles are blank."}
 
 
 ## `_SlotMachine`. The section walk is most of the check; what is left is the
@@ -4651,6 +4690,7 @@ func import_rom(
 		"day_care_text": _import_day_care_text(rom, layout),
 		"special_text": _import_special_text(rom, layout),
 		"special_text_ram": (layout.get("special_text_ram", {}) as Dictionary).duplicate(),
+		"other_player_link_mode": int(layout.get("other_player_link_mode", -1)),
 		"copyright_string": _import_copyright_string(rom, layout),
 		"copyright_palette": _import_copyright_palette(rom, layout),
 		"presents_palettes": _import_presents_palettes(rom, layout),
@@ -4664,6 +4704,7 @@ func import_rom(
 		"decorations": _import_decorations(rom, layout),
 		"unown_puzzle": _import_unown_puzzle(rom, layout),
 		"diploma": _import_diploma(rom, layout),
+		"link_border": _import_link_border(rom, layout),
 		"printer_strings": _import_printer_strings(rom, layout),
 		"slots": _import_slots(rom, layout),
 		"slots_text": _import_slots_text(rom, layout),
@@ -6451,6 +6492,72 @@ func _import_diploma(rom: RomFile, layout: Dictionary) -> Dictionary:
 	}
 
 
+## `LinkCommsBorderGFX` and, on Crystal alone, the three tilemaps behind it.
+## Uncompressed, so this is a bounds check and a walk: every code in the screen
+## tilemap has to name a tile the block actually carries, which is what says the
+## pin is the border rather than some other run of bytes.
+static func read_link_border(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("link_border", -1))
+	if at < 0:
+		return {}
+	var tiles: int = RomLayout.LINK_BORDER_TILES_CRYSTAL if rom.id == &"crystal" \
+		else RomLayout.LINK_BORDER_TILES_GOLD_SILVER
+	if not rom.in_bounds(at, tiles * Gen2Tiles.TILE_BYTES):
+		return {}
+	var out: Dictionary = {
+		"tiles": rom.slice(at, tiles * Gen2Tiles.TILE_BYTES), "count": tiles,
+	}
+	var maps_at: int = int(layout.get("link_trade_tilemaps", -1))
+	if maps_at < 0:
+		return out
+	var screen: int = RomLayout.LINK_TRADE_TILEMAP_BYTES
+	var strip: int = RomLayout.LINK_TRADE_CABLE_ROWS_BYTES
+	if not rom.in_bounds(maps_at, screen + strip * 2):
+		return {}
+	out["screen"] = rom.slice(maps_at, screen)
+	out["cable_top"] = rom.slice(maps_at + screen, strip)
+	out["cable_bottom"] = rom.slice(maps_at + screen + strip, strip)
+	for key: String in ["screen", "cable_top", "cable_bottom"]:
+		for code: int in out[key] as PackedByteArray:
+			if code >= tiles:
+				return {}
+	return out
+
+
+func _import_link_border(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_link_border(rom, layout)
+	if section.is_empty():
+		return {}
+	var out: Dictionary = {"tiles": int(section["count"])}
+	for key: String in ["screen", "cable_top", "cable_bottom"]:
+		if section.has(key):
+			out[key] = Array(section[key] as PackedByteArray)
+	return out
+
+
+## The border's own strip, written the way the diploma's is.
+func _import_link_border_sheet(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_link_border(rom, layout)
+	if section.is_empty():
+		return {}
+	var tiles: int = int(section["count"])
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	if not RomCache.write_indices(
+		RomCache.tile_path(directory, "link_border"),
+		Gen2Tiles.decode_2bpp_strip(section["tiles"], 0, tiles)
+	):
+		return {}
+	return {
+		"link_border": {
+			"width": tiles * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": tiles,
+			"first_code": 0,
+			"bits": 2,
+		},
+	}
+
+
 func _import_printer_strings(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return read_printer_strings(rom, layout)
 
@@ -6873,6 +6980,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_slots_sheets(rom, layout), true)
 	written.merge(_import_card_flip_sheets(rom, layout), true)
 	written.merge(_import_diploma_sheet(rom, layout), true)
+	written.merge(_import_link_border_sheet(rom, layout), true)
 	var done: int = 0
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1190,6 +1190,26 @@ const PREDEFPAL_UNOWN_PUZZLE: int = 0x4C
 const DIPLOMA_TILES: int = 112
 const DIPLOMA_TILEMAP_BYTES: int = 360
 
+
+## `LinkCommsBorderGFX`, the trade screen's own border, and the tilemaps behind
+## it. The two cartridges draw the same screen out of very different amounts of
+## data: Gold and Silver load nine tiles to `vTiles2 tile $76` and let
+## `PlaceTradeScreenTextbox` draw two ordinary boxes with them, while Crystal
+## loads seventy tiles to `vTiles2` and lays a whole screen of them down from
+## `MobileTradeBorderTilemap` with the two cable rows written over its top and
+## bottom. `_LinkTextbox`'s own eight corner and edge tiles are `$30` to `$37`
+## of Crystal's block, which is what `LinkComms_LoadPleaseWaitTextboxBorderGFX`
+## copies to `$76` when only the box is wanted.
+const LINK_BORDER_TILES_CRYSTAL: int = 70
+const LINK_BORDER_TILES_GOLD_SILVER: int = 9
+## `_LinkTextbox`'s `$30`, the first of the eight tiles it draws a box from.
+const LINK_TEXTBOX_FIRST_TILE: int = 0x30
+const LINK_TEXTBOX_TILES: int = 8
+## `MobileTradeBorderTilemap` is a whole screen; the two cable strips are two
+## rows each.
+const LINK_TRADE_TILEMAP_BYTES: int = 360
+const LINK_TRADE_CABLE_ROWS_BYTES: int = 40
+
 ## `PalPacket_Diploma`'s first entry, and the only one the page is drawn in:
 ## `_CGB_Unused0D` is SCGB_DIPLOMA's own layout and its `WipeAttrmap` puts every
 ## cell on palette 0.
@@ -1515,6 +1535,15 @@ const SPECIAL_TEXT_RUNS: Dictionary = {
 			"only_three_may_be_entered", "must_all_be_different_kinds",
 			"must_not_hold_the_same_items", "you_cant_take_an_egg",
 		]],
+	],
+	## The trade screen's own three, which is every box `LinkTrade` prints that
+	## is not an inline `db` string. Three runs of one rather than one of three:
+	## `.String_Stats_Trade`'s sixteen bytes sit between the first two stubs and
+	## the third is in `LinkTrade` itself, a page further down the file.
+	"link": [
+		["link_cant_battle_text", ["cant_battle"]],
+		["link_abnormal_mon_text", ["abnormal_mon"]],
+		["link_ask_trade_text", ["ask_trade"]],
 	],
 	## `BuenaPrize`'s six, in its own file order.
 	"buena_prize": [["buena_prize_text", [
@@ -2323,6 +2352,11 @@ const GOLD_SILVER: Dictionary = {
 	# `DiplomaGFX` and the two tilemaps behind it, at Gold and Silver's own
 	# address; located the way Crystal's is.
 	"diploma": 0xE0105,
+	# `LinkCommsBorderGFX`, which is nine tiles here and carries no tilemap:
+	# `PlaceTradeScreenTextbox` draws the trade screen's two boxes with
+	# `LinkTextboxAtHL` instead. The same address on Gold and on Silver.
+	"link_border": 0x29D5B,
+	"link_trade_tilemaps": -1,
 	# `UnownDexATile` behind `UnownDexVacantString`, and `GBPrinterStrings`
 	# behind `PrinterStatusStringPointers`' first entry.
 	"unown_printer_glyphs": 0x16FCC,
@@ -2499,7 +2533,19 @@ const GOLD_SILVER: Dictionary = {
 	## cartridge does not ship: the Poke Seer, Buena and her prize counter are
 	## Crystal's alone, and no Gold or Silver script reaches their specials.
 	## Gold and Silver's own, and only the one row they ship a routine for.
-	"special_text_ram": {"magikarp_record_holder": 0xDD35},
+	"special_text_ram": {
+		"magikarp_record_holder": 0xDD35,
+		## `wBufferTrademonNickname`, which `_LinkAskTradeForText` names with a
+		## `text_ram` whose address is in the text data itself.
+		"trademon_nickname": 0xCEEF,
+	},
+	## Gold and Silver's own WRAM address for the same byte; their link block sits
+	## a page lower than Crystal's.
+	"other_player_link_mode": 0xCE51,
+	## The same three stubs at Gold and Silver's own addresses, the same on both.
+	"link_cant_battle_text": 0x289A8,
+	"link_abnormal_mon_text": 0x289BD,
+	"link_ask_trade_text": 0x28D51,
 	"magikarp_measure_text": 0xFBCAD,
 	"magikarp_record_text": 0xFBDEC,
 	"lucky_number_text": 0xC7BA3,
@@ -2841,6 +2887,14 @@ const CRYSTAL: Dictionary = {
 	# Located off `.GameFreak`, the last of `PrintDiplomaPage2`'s own two
 	# strings: `db "GAME FREAK@"` is eleven bytes and the INCBIN follows it.
 	"diploma": 0x1DD805,
+	# `LinkCommsBorderGFX` and, sixty-eight bytes of code behind it,
+	# `MobileTradeBorderTilemap` with the two cable strips laid out after it.
+	# Located off the border tiles themselves, which are a byte-exact match for
+	# `gfx/trade/border_tiles.png`; the tilemaps are pinned separately because
+	# `__LoadTradeScreenBorderGFX`, `LoadMobileTradeBorderTilemap` and
+	# `TestMobileTradeBorderTilemap` sit between the two.
+	"link_border": 0x16CFC1,
+	"link_trade_tilemaps": 0x16D465,
 	# `UnownDexATile`, the two 1bpp tiles `_UnownPrinter` requests into the
 	# menu's own A and B glyphs, seven bytes behind `UnownDexVacantString`.
 	"unown_printer_glyphs": 0x16D9C,
@@ -3037,7 +3091,15 @@ const CRYSTAL: Dictionary = {
 		"seer_time_of_day": 0xD01F,
 		"seer_ot": 0xD02A,
 		"seer_caught_level": 0xD036,
+		"trademon_nickname": 0xD004,
 	},
+	## `wOtherPlayerLinkMode`, the byte all three receptionist scripts `readmem`
+	## after `CheckLinkTimeout_Receptionist`. Located off those three `readmem`s
+	## themselves, which are the only three in either corpus that name it.
+	"other_player_link_mode": 0xCF51,
+	"link_cant_battle_text": 0x28AAF,
+	"link_abnormal_mon_text": 0x28AC4,
+	"link_ask_trade_text": 0x28EB8,
 	"magikarp_measure_text": 0xFBBA9,
 	"magikarp_record_text": 0xFBCE8,
 	"lucky_number_text": 0x4D9C9,

--- a/game/render/link_page.gd
+++ b/game/render/link_page.gd
@@ -1,0 +1,380 @@
+class_name Gen2LinkPage
+extends RefCounted
+
+## The two screens the cable club draws: `InitTradeMenuDisplay`'s trade screen
+## (`engine/link/link.asm`) and `ReadAndPrintLinkBattleRecord`'s record page
+## (`engine/battle/core.asm`).
+##
+## Both are drawn with `LinkTextboxAtHL` rather than `Textbox`, which is a border
+## of its own out of `LinkCommsBorderGFX` and not the frame the OPTION menu
+## chooses. The two cartridges lay that border out differently and this is the
+## one place that difference shows: Crystal loads seventy tiles at `vTiles2` and
+## `LoadCableTradeBorderTilemap` puts a whole screen of them down, while Gold
+## and Silver load nine at `$76` and `PlaceTradeScreenTextbox` draws two ordinary
+## boxes with them.
+##
+## Node-free, the way [Gen2DiplomaPage] is: it writes palette indices into a
+## buffer so a check can read a screen back headless.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+const WIDTH: int = COLUMNS * TILE
+const HEIGHT: int = ROWS * TILE
+
+## `_LinkTextbox`'s eight tiles, in the order it places them: top left, top,
+## top right, left, right, bottom left, bottom, bottom right. Crystal's are
+## `$30` to `$37` in that order; Gold and Silver's `LinkTextboxAtHL` names
+## `$78`, `$79`, `$7a`, `$7b`, `$77`, `$7c`, `$76`, `$7d`, which are those
+## offsets from the nine-tile block it loads at `$76`.
+const CRYSTAL_BOX_TILES: Array[int] = [0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37]
+const GOLD_SILVER_BOX_TILES: Array[int] = [2, 3, 4, 5, 1, 6, 0, 7]
+
+## `PlaceTradePartnerNamesAndParty` (`engine/link/time_capsule.asm`): the two
+## names and the two species lists, and the `$14` tile it writes at the cell each
+## name ended on. That tile is `LinkCommsBorderGFX`'s own, so it is only a tile
+## on Crystal, where the whole block sits at `vTiles2` tile zero.
+const PLAYER_NAME_AT: Vector2i = Vector2i(4, 0)
+const PARTNER_NAME_AT: Vector2i = Vector2i(4, 8)
+const PLAYER_LIST_AT: Vector2i = Vector2i(7, 1)
+const PARTNER_LIST_AT: Vector2i = Vector2i(7, 9)
+const NAME_END_TILE: int = 0x14
+
+## `LinkTrade_PlayerPartyMenu` and `LinkTrade_OTPartyMenu`: `w2DMenuCursorInitX`
+## is 6 on both and `InitY` is 1 and 9. `.UpdateCursor` writes `$1f` there and
+## again `MON_NAME_LENGTH` columns to the right, so a selected row is marked at
+## both ends of its name.
+const CURSOR_COLUMN: int = 6
+const CURSOR_TILE: int = 0x1F
+const MON_NAME_LENGTH: int = 11
+
+## `LinkTradePlaceArrow`, which shows which Pokemon the other player offered.
+const PARTNER_ARROW: String = "▷"
+
+## `InitTradeSpeciesList`'s own `CANCEL`, and the `'▶'`
+## `LinkTradePartymonMenuCheckCancel` blinks in front of it.
+const CANCEL_AT: Vector2i = Vector2i(10, 17)
+const CANCEL_STRING: String = "CANCEL"
+const CANCEL_ARROW_AT: Vector2i = Vector2i(9, 17)
+const CANCEL_ARROW: String = "▶"
+const CANCEL_ARROW_SENT: String = "▷"
+
+## `LinkTrade_TradeStatsMenu`: a one-row box across the bottom and the two words
+## in it, with the cursor at column 1 or column 11.
+const FOOTER_BOX: Rect2i = Rect2i(0, 15, 18, 1)
+const FOOTER_AT: Vector2i = Vector2i(2, 16)
+const FOOTER_STRING: String = "STATS     TRADE"
+const FOOTER_CURSOR_ROW: int = 16
+const FOOTER_STATS_COLUMN: int = 1
+const FOOTER_TRADE_COLUMN: int = 11
+
+## `LinkTrade`'s question box and the TRADE/CANCEL menu it opens over it.
+const MESSAGE_BOX: Rect2i = Rect2i(0, 12, 18, 4)
+const MESSAGE_AT: Vector2i = Vector2i(1, 14)
+## `PrintTextboxTextAt` runs the ordinary text engine, whose lines are two rows
+## apart; `PlaceString` puts its own `next` on the very next row. Both print into
+## this box, so the caller says which it is.
+const MESSAGE_PRINTED_SPACING: int = 2
+const MESSAGE_PLACED_SPACING: int = 1
+const CONFIRM_BOX: Rect2i = Rect2i(10, 7, 7, 3)
+const CONFIRM_AT: Vector2i = Vector2i(12, 8)
+const CONFIRM_ROWS: Array[String] = ["TRADE", "CANCEL"]
+## `w2DMenuCursorOffsets` is `$20`, so the two rows are two apart.
+const CONFIRM_ROW_SPACING: int = 2
+const CONFIRM_CURSOR_COLUMN: int = 11
+
+## `PlaceWaitingTextAndSyncAndExchangeNybble.PlaceWaitingText`.
+const WAITING_BOX: Rect2i = Rect2i(4, 10, 10, 1)
+const WAITING_AT: Vector2i = Vector2i(5, 11)
+const WAITING_STRING: String = "WAITING..!"
+
+## `LinkCommunications`' own opening box, which stands while the two parties are
+## exchanged.
+const PLEASE_WAIT_BOX: Rect2i = Rect2i(3, 8, 12, 2)
+const PLEASE_WAIT_AT: Vector2i = Vector2i(4, 10)
+const PLEASE_WAIT_STRING: String = "Please wait!"
+
+## `String_TradeCompleted` and `String_TooBadTheTradeWasCanceled`, which are
+## inline `db` strings rather than `text_far` stubs.
+const TRADE_COMPLETED: String = "Trade completed!"
+const TRADE_CANCELED: String = "Too bad! The trade\nwas canceled!"
+
+## `ReadAndPrintLinkBattleRecord`'s own strings and columns. `PrintNum`'s
+## `lb bc, 2, 4` is two bytes printed in four cells, and the three counters are
+## five columns apart.
+const RECORD_TITLE_AT: Vector2i = Vector2i(1, 0)
+const RECORD_TITLE: String = "'s RECORD"
+const RECORD_TOTAL_AT: Vector2i = Vector2i(0, 2)
+const RECORD_TOTAL: String = "TOTAL  WIN LOSE DRAW"
+const RECORD_TOTALS_AT: Vector2i = Vector2i(6, 4)
+const RECORD_RESULT_AT: Vector2i = Vector2i(0, 6)
+const RECORD_RESULT: String = "RESULT WIN LOSE DRAW"
+const RECORD_ROWS_AT: Vector2i = Vector2i(0, 8)
+const RECORD_ROW_SPACING: int = 2
+const RECORD_COLUMN_STRIDE: int = 5
+const RECORD_DIGITS: int = 4
+## `.Format`, which is what an unused row prints.
+const RECORD_EMPTY_NAME: String = "  ---"
+const RECORD_EMPTY_COUNTS: String = "-"
+
+var font: Gen2Font = null
+var palette: PackedColorArray = PackedColorArray()
+
+var _tiles: PackedByteArray = PackedByteArray()
+var _tile_count: int = 0
+var _screen: PackedByteArray = PackedByteArray()
+var _cable_top: PackedByteArray = PackedByteArray()
+var _cable_bottom: PackedByteArray = PackedByteArray()
+var _box_tiles: Array[int] = CRYSTAL_BOX_TILES
+
+
+static func from_data(data: GameData) -> Gen2LinkPage:
+	if data == null or not data.has_link_border():
+		return null
+	var page := Gen2LinkPage.new()
+	page.font = Gen2Font.from_data(data)
+	if page.font == null:
+		return null
+	## `SetTradeRoomBGPals` is `GetSGBLayout SCGB_DIPLOMA`, the same two colours
+	## every 1bpp page here is drawn through.
+	page.palette = Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	page._tiles = data.link_border_indices()
+	page._screen = data.link_border_tilemap("screen")
+	page._cable_top = data.link_border_tilemap("cable_top")
+	page._cable_bottom = data.link_border_tilemap("cable_bottom")
+	page._tile_count = RomLayout.LINK_BORDER_TILES_CRYSTAL if not page._screen.is_empty() \
+		else RomLayout.LINK_BORDER_TILES_GOLD_SILVER
+	page._box_tiles = CRYSTAL_BOX_TILES if not page._screen.is_empty() \
+		else GOLD_SILVER_BOX_TILES
+	return page
+
+
+## Whether this cartridge lays the trade screen out from a tilemap, which is
+## Crystal alone.
+func has_screen_tilemap() -> bool:
+	return not _screen.is_empty()
+
+
+## `InitTradeMenuDisplay` and everything `LinkTradeMenu` draws over it.
+##
+## [param state] carries what is on screen rather than what the player may do:
+## `player`/`partner` are `{name, species}` with the species names already
+## resolved, `list` is 0 for the player's half and 1 for the partner's, `index`
+## the cursor row, `partner_choice` the row `LinkTradePlaceArrow` marks or -1,
+## `footer` -1 for no footer and 0 or 1 for STATS or TRADE, `cancel` whether the
+## cursor is on CANCEL, `message` the lines the bottom box prints, `confirm` the
+## TRADE/CANCEL row or -1, and `waiting` whether `WAITING..!` stands.
+func draw_trade(state: Dictionary) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	if font == null:
+		return indices
+	_draw_trade_background(indices)
+	var player: Dictionary = state.get("player", {})
+	var partner: Dictionary = state.get("partner", {})
+	_draw_party(indices, player, PLAYER_NAME_AT, PLAYER_LIST_AT)
+	_draw_party(indices, partner, PARTNER_NAME_AT, PARTNER_LIST_AT)
+	_text(indices, CANCEL_STRING, CANCEL_AT)
+
+	var partner_choice: int = int(state.get("partner_choice", -1))
+	if partner_choice >= 0:
+		_text(
+			indices, PARTNER_ARROW,
+			Vector2i(CURSOR_COLUMN, PARTNER_LIST_AT.y + partner_choice)
+		)
+	if bool(state.get("cancel", false)):
+		_text(
+			indices,
+			CANCEL_ARROW_SENT if bool(state.get("cancel_sent", false)) else CANCEL_ARROW,
+			CANCEL_ARROW_AT
+		)
+	else:
+		_draw_cursor(indices, state)
+
+	var footer: int = int(state.get("footer", -1))
+	if footer >= 0:
+		_box(indices, FOOTER_BOX)
+		_text(indices, FOOTER_STRING, FOOTER_AT)
+		_text(indices, CANCEL_ARROW, Vector2i(
+			FOOTER_TRADE_COLUMN if footer == 1 else FOOTER_STATS_COLUMN,
+			FOOTER_CURSOR_ROW
+		))
+
+	var message: Array = state.get("message", [])
+	if not message.is_empty():
+		_box(indices, MESSAGE_BOX)
+		var spacing: int = int(state.get("message_spacing", MESSAGE_PRINTED_SPACING))
+		for line: int in message.size():
+			_text(
+				indices, String(message[line]),
+				MESSAGE_AT + Vector2i(0, line * spacing)
+			)
+	var confirm: int = int(state.get("confirm", -1))
+	if confirm >= 0:
+		_box(indices, CONFIRM_BOX)
+		for row: int in CONFIRM_ROWS.size():
+			_text(
+				indices, CONFIRM_ROWS[row],
+				CONFIRM_AT + Vector2i(0, row * CONFIRM_ROW_SPACING)
+			)
+		_text(indices, CANCEL_ARROW, Vector2i(
+			CONFIRM_CURSOR_COLUMN, CONFIRM_AT.y + confirm * CONFIRM_ROW_SPACING
+		))
+	if bool(state.get("waiting", false)):
+		_box(indices, WAITING_BOX)
+		_text(indices, WAITING_STRING, WAITING_AT)
+	return indices
+
+
+## `LinkCommunications`' opening screen, which is the border with one box on it
+## and nothing else: the two parties have not been exchanged yet.
+func draw_please_wait() -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	if font == null:
+		return indices
+	_draw_trade_background(indices)
+	_box(indices, PLEASE_WAIT_BOX)
+	_text(indices, PLEASE_WAIT_STRING, PLEASE_WAIT_AT)
+	return indices
+
+
+## `ReadAndPrintLinkBattleRecord`. [param record] is
+## [member Gen2SaveData.link_record]; [param saved] is `wSavedAtLeastOnce`,
+## which is what makes a slot with no save behind it print zeros and dashes.
+func draw_record(record: Dictionary, player: String, saved: bool = true) -> PackedByteArray:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	if font == null:
+		return indices
+	var normalized: Dictionary = Gen2LinkSession.normalize_record(record)
+	_text(indices, player + RECORD_TITLE, RECORD_TITLE_AT)
+	_text(indices, RECORD_TOTAL, RECORD_TOTAL_AT)
+	_text(indices, RECORD_RESULT, RECORD_RESULT_AT)
+	for column: int in 3:
+		var key: String = ["wins", "losses", "draws"][column]
+		var value: String = str(int(normalized[key])) if saved else "0"
+		_text(indices, value.lpad(RECORD_DIGITS), RECORD_TOTALS_AT + Vector2i(
+			column * RECORD_COLUMN_STRIDE, 0
+		))
+	var rows: Array = normalized["records"]
+	for row: int in rows.size():
+		var entry: Dictionary = rows[row]
+		var at: Vector2i = RECORD_ROWS_AT + Vector2i(0, row * RECORD_ROW_SPACING)
+		if String(entry.get("name", "")).is_empty() or not saved:
+			_text(indices, RECORD_EMPTY_NAME, at)
+			for column: int in 3:
+				_text(indices, RECORD_EMPTY_COUNTS, at + Vector2i(
+					RECORD_TOTALS_AT.x + column * RECORD_COLUMN_STRIDE + 3, 1
+				))
+			continue
+		_text(indices, String(entry["name"]), at)
+		for column: int in 3:
+			var key: String = ["wins", "losses", "draws"][column]
+			_text(indices, str(int(entry[key])).lpad(RECORD_DIGITS), at + Vector2i(
+				RECORD_TOTALS_AT.x + column * RECORD_COLUMN_STRIDE, 1
+			))
+	return indices
+
+
+func image(indices: PackedByteArray) -> Image:
+	return Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+
+
+## `LoadCableTradeBorderTilemap`: the mobile screen laid down whole and the two
+## cable strips written over its first and last two rows. Gold and Silver have
+## no tilemap at all, so `PlaceTradeScreenTextbox`'s two boxes are the screen.
+func _draw_trade_background(indices: PackedByteArray) -> void:
+	if _screen.is_empty():
+		_box(indices, Rect2i(0, 0, 18, 6))
+		_box(indices, Rect2i(0, 8, 18, 6))
+		return
+	for cell: int in _screen.size():
+		_blit(indices, int(_screen[cell]), Vector2i(cell % COLUMNS, cell / COLUMNS))
+	_blit_strip(indices, _cable_top, 0)
+	_blit_strip(indices, _cable_bottom, ROWS - 2)
+
+
+func _blit_strip(indices: PackedByteArray, strip: PackedByteArray, top: int) -> void:
+	for cell: int in strip.size():
+		_blit(indices, int(strip[cell]), Vector2i(cell % COLUMNS, top + cell / COLUMNS))
+
+
+func _draw_party(
+	indices: PackedByteArray, side: Dictionary, name_at: Vector2i, list_at: Vector2i
+) -> void:
+	var name: String = String(side.get("name", ""))
+	_text(indices, name, name_at)
+	## `ld a, $14 / ld [bc], a` puts a tile of the border block at the cell the
+	## name ended on. Only Crystal's block is at `vTiles2` tile zero, so on Gold
+	## and Silver that cell is left as the screen found it.
+	if not _screen.is_empty():
+		_blit(indices, NAME_END_TILE, name_at + Vector2i(name.length(), 0))
+	var species: Array = side.get("species", [])
+	for row: int in species.size():
+		_text(indices, String(species[row]), list_at + Vector2i(0, row))
+
+
+## `.UpdateCursor`, which marks the row at the cursor column and again
+## `MON_NAME_LENGTH` columns along.
+func _draw_cursor(indices: PackedByteArray, state: Dictionary) -> void:
+	var list: int = int(state.get("list", 0))
+	var index: int = int(state.get("index", 0))
+	var side: Dictionary = state.get("partner", {}) if list == 1 \
+		else state.get("player", {})
+	if index < 0 or index >= (side.get("species", []) as Array).size():
+		return
+	var row: int = (PARTNER_LIST_AT.y if list == 1 else PLAYER_LIST_AT.y) + index
+	_blit(indices, CURSOR_TILE, Vector2i(CURSOR_COLUMN, row))
+	_blit(indices, CURSOR_TILE, Vector2i(CURSOR_COLUMN + MON_NAME_LENGTH, row))
+
+
+## `_LinkTextbox`, whose [param box] is the interior the source passes in `b`
+## and `c`: the border is drawn one cell outside it on every side.
+func _box(indices: PackedByteArray, box: Rect2i) -> void:
+	var left: int = box.position.x
+	var top: int = box.position.y
+	var right: int = left + box.size.x + 1
+	var bottom: int = top + box.size.y + 1
+	_blit(indices, _box_tiles[0], Vector2i(left, top))
+	_blit(indices, _box_tiles[2], Vector2i(right, top))
+	_blit(indices, _box_tiles[5], Vector2i(left, bottom))
+	_blit(indices, _box_tiles[7], Vector2i(right, bottom))
+	for column: int in range(left + 1, right):
+		_blit(indices, _box_tiles[1], Vector2i(column, top))
+		_blit(indices, _box_tiles[6], Vector2i(column, bottom))
+	for row: int in range(top + 1, bottom):
+		_blit(indices, _box_tiles[3], Vector2i(left, row))
+		_blit(indices, _box_tiles[4], Vector2i(right, row))
+		## `ld a, ' ' / call .PlaceRow` clears the interior, so a box opened over
+		## the border's own art hides it rather than letting it show through.
+		for column: int in range(left + 1, right):
+			_clear(indices, Vector2i(column, row))
+
+
+func _text(indices: PackedByteArray, text: String, at: Vector2i) -> void:
+	var line: int = 0
+	for row: String in text.split("\n"):
+		font.draw_text(row, indices, WIDTH, at.x * TILE, (at.y + line) * TILE)
+		line += 1
+
+
+func _clear(indices: PackedByteArray, at: Vector2i) -> void:
+	for row: int in TILE:
+		var start: int = (at.y * TILE + row) * WIDTH + at.x * TILE
+		for column: int in TILE:
+			indices[start + column] = 0
+
+
+## A cell of the border block by its tile number, which is what the tilemaps and
+## `_LinkTextbox` both name. A code at or above the font's own first code is a
+## glyph instead, the way [Gen2DiplomaPage] splits them.
+func _blit(into: PackedByteArray, code: int, at: Vector2i) -> void:
+	if code >= RomLayout.FONT_FIRST_CODE:
+		font.draw_code(code, into, WIDTH, at.x * TILE, at.y * TILE)
+		return
+	if code >= _tile_count:
+		return
+	Gen2Font.blit_slot(
+		_tiles, _tile_count * TILE, code, into, WIDTH, at.x * TILE, at.y * TILE
+	)

--- a/game/render/link_page.gd.uid
+++ b/game/render/link_page.gd.uid
@@ -1,0 +1,1 @@
+uid://o4py5hkbyser

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -85,6 +85,12 @@ var box_names: Array = []
 ## defaults rather than versioning; an empty list is the truth about a slot
 ## written before mail existed.
 var mailbox: Array = []
+## `sLinkBattleStats`: the three totals `_DisplayLinkRecord` prints across the
+## top and the five per-opponent rows under them, kept in the order
+## `AddLastLinkBattleToLinkRecord` sorts them. Like `mailbox` and `box_names`
+## this defaults rather than versioning; a slot written before link play reads
+## as one that has never linked, which is the truth about it.
+var link_record: Dictionary = Gen2LinkSession.normalize_record({})
 
 
 func _init() -> void:
@@ -122,6 +128,7 @@ func to_dict() -> Dictionary:
 		"boxes": saved_boxes,
 		"current_box": current_box,
 		"hall_of_fame": hall_of_fame.duplicate(true),
+		"link_record": link_record.duplicate(true),
 		"box_names": box_names.duplicate(),
 		"mailbox": _mailbox_dicts(),
 		"world": world.to_dict() if world != null else {},
@@ -156,6 +163,7 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	out.label = String(source.get("label", ""))
 	out.current_box = clampi(int(source.get("current_box", 0)), 0, BOX_COUNT - 1)
 	out.hall_of_fame = Gen2HallOfFame.parse_records(source.get("hall_of_fame", []))
+	out.link_record = Gen2LinkSession.normalize_record(source.get("link_record", {}))
 	var raw_box_names: Variant = source.get("box_names", [])
 	if raw_box_names is Array:
 		for index: int in mini((raw_box_names as Array).size(), BOX_COUNT):
@@ -339,6 +347,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	boxes = copied.boxes
 	current_box = copied.current_box
 	hall_of_fame = copied.hall_of_fame.duplicate(true)
+	link_record = copied.link_record.duplicate(true)
 	box_names = copied.box_names.duplicate()
 	mailbox = copied.mailbox.duplicate()
 	world = copied.world

--- a/game/world/link_screen.gd
+++ b/game/world/link_screen.gd
@@ -1,0 +1,493 @@
+class_name Gen2LinkScreen
+extends Control
+
+## `LinkCommunications` from the console the player used to the moment the room
+## lets them go: the trade screen's own two-list menu (`InitTradeMenuDisplay`
+## and `LinkTradeMenu`) and `_DisplayLinkRecord`'s one page.
+##
+## Embedded in the overworld the way the Hall of Fame viewer and BILL'S PC are.
+## The cable is [Gen2LinkTransport] and the commit is
+## [method Gen2WorldPartyHost.commit_link_trade]; this screen owns the cursor,
+## the boxes and the order they are shown in, and nothing else.
+##
+## The Colosseum is not here: `Colosseum` runs the same `LinkCommunications`
+## opening and then a battle, which the world screen already opens through its
+## own battle host.
+
+signal closed()
+## `LinkMonStatsScreen`, which the overworld opens over this the way the party
+## menu opens one. [param side] is 0 for the player's list and 1 for the
+## partner's.
+signal stats_requested(side: int, index: int)
+## One completed trade, as [method Gen2WorldPartyHost.commit_link_trade]
+## reported it.
+signal traded(result: Dictionary)
+
+const MODE_TRADE: int = 0
+const MODE_RECORD: int = 1
+
+## `LinkCommunications`' own `ld c, 80 / call DelayFrames` twice, spent behind
+## the "Please wait!" box while the two parties are exchanged.
+const PLEASE_WAIT_FRAMES: int = 160
+## `ld c, 100 / call DelayFrames` after both players have offered, and the fifty
+## `PlaceWaitingTextAndSyncAndExchangeNybble` ends on.
+const OFFER_FRAMES: int = 100
+const WAITING_FRAMES: int = 50
+
+## `LinkTradePartiesMenuMasterLoop`'s two lists.
+const LIST_PLAYER: int = 0
+const LIST_PARTNER: int = 1
+
+## `LinkTrade_TradeStatsMenu`'s two words.
+const FOOTER_STATS: int = 0
+const FOOTER_TRADE: int = 1
+
+## What the screen is showing, in the order `LinkTrade` reaches them.
+enum STEP {
+	PLEASE_WAIT, SELECT, FOOTER, OFFERING, CONFIRM, RESULT, LEAVING, DONE,
+}
+
+var mode: int = MODE_TRADE
+## Whether the trade is written to disk. A driver that only wants the screen
+## passes false, the way the box screen's own `persist` does.
+var persist: bool = true
+
+var _data: GameData = null
+var _world: Gen2WorldAPI = null
+var _save: Gen2SaveData = null
+var _transport: Gen2LinkTransport = null
+var _page: Gen2LinkPage = null
+var _background: TextureRect = null
+
+var _step: int = STEP.PLEASE_WAIT
+var _frames: int = 0
+var _list: int = LIST_PLAYER
+var _index: int = 0
+var _partner_index: int = 0
+var _on_cancel: bool = false
+var _cancel_sent: bool = false
+var _footer: int = FOOTER_TRADE
+var _confirm: int = 0
+var _message: Array = []
+var _message_spacing: int = Gen2LinkPage.MESSAGE_PRINTED_SPACING
+var _partner_choice: int = -1
+var _partner: Dictionary = {}
+
+
+func set_context(
+	data: GameData,
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	transport: Gen2LinkTransport,
+	screen_mode: int = MODE_TRADE,
+	persist_writes: bool = true
+) -> void:
+	_data = data
+	_world = world
+	_save = save
+	_transport = transport if transport != null else Gen2LinkTransport.new()
+	mode = screen_mode if screen_mode in [MODE_TRADE, MODE_RECORD] else MODE_TRADE
+	persist = persist_writes
+	_page = Gen2LinkPage.from_data(data)
+	_partner = _transport.peer.duplicate(true)
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _page == null:
+		closed.emit()
+		return
+	_background = TextureRect.new()
+	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_background)
+	if mode == MODE_RECORD:
+		_step = STEP.DONE
+	elif not _transport.connected():
+		## A room whose cable has nothing on the other end never gets past
+		## `LinkCommunications`' own opening box; `Link_CheckCommunicationError`
+		## is what ends it, and the player walks back out.
+		_step = STEP.PLEASE_WAIT
+		_frames = PLEASE_WAIT_FRAMES
+	else:
+		_step = STEP.PLEASE_WAIT
+		_frames = PLEASE_WAIT_FRAMES
+	_refresh()
+
+
+## Which step is on screen, for the checks and the screenshot tool.
+func step() -> int:
+	return _step
+
+
+func advance_frame() -> void:
+	if _frames <= 0:
+		return
+	_frames -= 1
+	if _frames > 0:
+		return
+	match _step:
+		STEP.PLEASE_WAIT:
+			if not _transport.connected():
+				_step = STEP.LEAVING
+				closed.emit()
+				return
+			_step = STEP.SELECT
+		STEP.OFFERING:
+			_step = STEP.CONFIRM
+		STEP.RESULT:
+			_step = STEP.SELECT
+			_message = []
+		STEP.LEAVING:
+			closed.emit()
+			return
+	_refresh()
+
+
+## Spends [param limit] frames of whatever wait is standing, for a driver that
+## wants the screen rather than the animation in front of it.
+func settle(limit: int = 600) -> void:
+	var guard: int = limit
+	while _frames > 0 and guard > 0:
+		advance_frame()
+		guard -= 1
+
+
+func handle_button(button: int) -> bool:
+	if _page == null:
+		return false
+	if mode == MODE_RECORD:
+		if button in [Gen2Button.A, Gen2Button.B]:
+			closed.emit()
+		return true
+	if _frames > 0:
+		return true
+	match _step:
+		STEP.SELECT:
+			return _press_select(button)
+		STEP.FOOTER:
+			return _press_footer(button)
+		STEP.CONFIRM:
+			return _press_confirm(button)
+	return true
+
+
+## `LinkTradePartymonMenuLoop` and `LinkTradeOTPartymonMenuLoop`, which are one
+## list each with the other one below it: DOWN off the bottom of the player's
+## list moves into the partner's, UP off the top of the partner's moves back,
+## and UP off the top of the player's reaches CANCEL.
+func _press_select(button: int) -> bool:
+	var rows: int = _rows(_list)
+	if _on_cancel:
+		match button:
+			Gen2Button.A:
+				_leave()
+			Gen2Button.UP:
+				_on_cancel = false
+				_list = LIST_PARTNER
+				_index = maxi(_rows(LIST_PARTNER) - 1, 0)
+			Gen2Button.DOWN:
+				_on_cancel = false
+				_list = LIST_PLAYER
+				_index = 0
+		_refresh()
+		return true
+	match button:
+		Gen2Button.A:
+			if _list == LIST_PARTNER:
+				## `.not_a_button`'s A branch opens `LinkMonStatsScreen` on the
+				## partner's row; the row the cursor is left on is the offer the
+				## transport answers with.
+				_partner_index = _index
+				stats_requested.emit(LIST_PARTNER, _index)
+			else:
+				_step = STEP.FOOTER
+				_footer = FOOTER_TRADE
+		Gen2Button.UP:
+			if _index > 0:
+				_index -= 1
+			elif _list == LIST_PARTNER:
+				_list = LIST_PLAYER
+				_index = maxi(_rows(LIST_PLAYER) - 1, 0)
+			else:
+				_on_cancel = true
+		Gen2Button.DOWN:
+			if _index + 1 < rows:
+				_index += 1
+			elif _list == LIST_PLAYER:
+				_list = LIST_PARTNER
+				_index = 0
+			else:
+				_on_cancel = true
+	_refresh()
+	return true
+
+
+## `LinkTrade_TradeStatsMenu`: RIGHT and LEFT move between the two words, B goes
+## back to the list, A on STATS opens the player's own stats page and A on TRADE
+## offers the row.
+func _press_footer(button: int) -> bool:
+	match button:
+		Gen2Button.RIGHT:
+			_footer = FOOTER_TRADE
+		Gen2Button.LEFT:
+			_footer = FOOTER_STATS
+		Gen2Button.B:
+			_step = STEP.SELECT
+		Gen2Button.A:
+			if _footer == FOOTER_STATS:
+				_step = STEP.SELECT
+				stats_requested.emit(LIST_PLAYER, _index)
+			else:
+				_offer()
+	_refresh()
+	return true
+
+
+## `.try_trade`: the row goes out as `wPlayerLinkAction`, the partner's comes
+## back as `wOtherPlayerLinkMode`, `LinkTradePlaceArrow` marks it and the two
+## validity tests run before the question is asked.
+func _offer() -> void:
+	_partner_choice = _transport_choice()
+	var incoming: Dictionary = _partner_mon(_partner_choice)
+	if incoming.is_empty() or not Gen2LinkSession.validate_ot_trademon(
+		incoming, int(incoming.get("species", 0)), bool(incoming.get("is_egg", false)),
+		_link_mode()
+	):
+		_refuse(_abnormal_message(incoming))
+		return
+	if not Gen2LinkSession.any_other_alive_mons_for_trade(
+		_player_rows(), _index, incoming
+	):
+		_refuse(_cant_battle_message())
+		return
+	_step = STEP.OFFERING
+	_frames = OFFER_FRAMES
+	_message = _ask_message(incoming)
+
+
+## `.abnormal` and the `CheckAnyOtherAliveMonsForTrade` branch beside it: both
+## print their box, then `String_TooBadTheTradeWasCanceled`, and go back to the
+## listing.
+func _refuse(lines: Array) -> void:
+	_partner_choice = -1
+	_step = STEP.RESULT
+	_frames = OFFER_FRAMES
+	_message = lines
+	_refresh()
+
+
+func _press_confirm(button: int) -> bool:
+	match button:
+		Gen2Button.UP:
+			_confirm = 0
+		Gen2Button.DOWN:
+			_confirm = 1
+		Gen2Button.B:
+			_cancel_trade()
+			return true
+		Gen2Button.A:
+			if _confirm == 0:
+				_commit()
+			else:
+				_cancel_trade()
+			return true
+	_refresh()
+	return true
+
+
+func _cancel_trade() -> void:
+	_confirm = 0
+	_partner_choice = -1
+	_step = STEP.RESULT
+	_frames = WAITING_FRAMES
+	_place_message(Gen2LinkPage.TRADE_CANCELED)
+	_refresh()
+
+
+## `.do_trade`, whose whole save-side effect is
+## [method Gen2WorldPartyHost.commit_link_trade]. `SaveAfterLinkTrade` is the
+## write that transaction already is.
+func _commit() -> void:
+	_confirm = 0
+	var result: Dictionary = Gen2WorldPartyHost.commit_link_trade(
+		_world, _save, _index, _partner_mon(_partner_choice),
+		{"name": String(_partner.get("name", "")), "link_mode": _link_mode()},
+		persist
+	)
+	_step = STEP.RESULT
+	_frames = WAITING_FRAMES
+	if not bool(result.get("ok", false)):
+		_place_message(Gen2LinkPage.TRADE_CANCELED)
+	else:
+		_place_message(Gen2LinkPage.TRADE_COMPLETED)
+		## The row the partner gave up is gone from its party for the rest of
+		## this visit, the way the cartridge's own copy of it is.
+		_take_partner_mon(_partner_choice)
+		_index = mini(_index, maxi(_rows(LIST_PLAYER) - 1, 0))
+		traded.emit(result)
+	_partner_choice = -1
+	_refresh()
+
+
+## `LinkTradePartymonMenuCheckCancel.a_button`, which sends `$f` and waits for
+## the same byte back before `ExitLinkCommunications` runs.
+func _leave() -> void:
+	_cancel_sent = true
+	_step = STEP.LEAVING
+	_frames = WAITING_FRAMES
+	_refresh()
+
+
+## One of the two inline `db` strings, which `PlaceString` puts on consecutive
+## rows rather than two apart.
+func _place_message(text: String) -> void:
+	_message = Array(text.split("\n"))
+	_message_spacing = Gen2LinkPage.MESSAGE_PLACED_SPACING
+
+
+func _link_mode() -> int:
+	if _world == null or _world.state == null:
+		return Gen2LinkSession.LINK_TRADECENTER
+	return _world.state.link_session().link_mode
+
+
+## `wOtherPlayerLinkMode` after `.try_trade`'s own exchange, which is the row the
+## partner offered. The transport is what answers it; see
+## [method Gen2LinkTransport.choose_trade_slot].
+func _transport_choice() -> int:
+	return _transport.choose_trade_slot({
+		"ot_cursor": _partner_index, "ot_count": _rows(LIST_PARTNER),
+	})
+
+
+func _rows(list: int) -> int:
+	if list == LIST_PARTNER:
+		return (_partner.get("party", []) as Array).size()
+	return _save.party.size() if _save != null else 0
+
+
+func _player_rows() -> Array:
+	var out: Array = []
+	if _save == null:
+		return out
+	for mon: Gen2SaveMon in _save.party:
+		out.append(mon.to_dict())
+	return out
+
+
+func _partner_mon(index: int) -> Dictionary:
+	var party: Array = _partner.get("party", [])
+	if index < 0 or index >= party.size():
+		return {}
+	return (party[index] as Dictionary).duplicate(true)
+
+
+func _take_partner_mon(index: int) -> void:
+	var party: Array = _partner.get("party", [])
+	if index >= 0 and index < party.size():
+		party.remove_at(index)
+	_partner["party"] = party
+	_partner_index = mini(_partner_index, maxi(party.size() - 1, 0))
+
+
+func _species_name(species: int) -> String:
+	return String(_data.species(species).get("name", "")) if _data != null else ""
+
+
+## `_LinkAskTradeForText`, whose two `text_ram` buffers are the two nicknames.
+func _ask_message(incoming: Dictionary) -> Array:
+	var mine: String = ""
+	if _save != null and _index < _save.party.size():
+		var mon: Gen2SaveMon = _save.party[_index]
+		mine = mon.nickname if not mon.nickname.is_empty() \
+			else _species_name(mon.species)
+	var theirs: String = String(incoming.get("nickname", ""))
+	if theirs.is_empty():
+		theirs = _species_name(int(incoming.get("species", 0)))
+	return _special_text("ask_trade", {"trademon_nickname": mine, 1: theirs})
+
+
+func _abnormal_message(incoming: Dictionary) -> Array:
+	return _special_text("abnormal_mon", {
+		1: _species_name(int(incoming.get("species", 0))),
+	})
+
+
+func _cant_battle_message() -> Array:
+	return _special_text("cant_battle", {})
+
+
+## One of the trade screen's three imported boxes, with its buffers filled and
+## its lines split the way the box would page them.
+func _special_text(name: String, buffers: Dictionary) -> Array:
+	if _data == null:
+		return []
+	var text: String = _data.special_text("link", name)
+	for name_or_address: Variant in buffers:
+		var address: int = _data.special_text_ram(String(name_or_address)) \
+			if name_or_address is String else int(name_or_address)
+		if address < 0:
+			continue
+		text = text.replace(
+			"%s%04X>" % [Gen2TextStream.RAM_MARKER, address],
+			String(buffers[name_or_address])
+		)
+	_message_spacing = Gen2LinkPage.MESSAGE_PRINTED_SPACING
+	var pages: Array = Gen2TextLayout.lay_out(
+		text, Gen2LinkPage.MESSAGE_BOX.size.x, 2
+	)
+	return Array(pages[0]) if not pages.is_empty() else []
+
+
+func _refresh() -> void:
+	if _background == null or _page == null:
+		return
+	var indices: PackedByteArray
+	if mode == MODE_RECORD:
+		indices = _page.draw_record(
+			_save.link_record if _save != null else {},
+			_save.player_name if _save != null else "",
+			_save != null
+		)
+	elif _step == STEP.PLEASE_WAIT:
+		indices = _page.draw_please_wait()
+	else:
+		indices = _page.draw_trade(trade_state())
+	Gen2PicImage.show(_background, _page.image(indices))
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+
+
+## What the page is asked to draw, exposed so a check can read a screen back
+## without a texture.
+func trade_state() -> Dictionary:
+	return {
+		"player": {
+			"name": _save.player_name if _save != null else "",
+			"species": _party_names(_player_rows()),
+		},
+		"partner": {
+			"name": String(_partner.get("name", "")),
+			"species": _party_names(_partner.get("party", [])),
+		},
+		"list": _list,
+		"index": _index,
+		"cancel": _on_cancel,
+		"cancel_sent": _cancel_sent,
+		"partner_choice": _partner_choice,
+		"footer": _footer if _step == STEP.FOOTER else -1,
+		"confirm": _confirm if _step == STEP.CONFIRM else -1,
+		"message": _message.duplicate(),
+		"message_spacing": _message_spacing,
+		"waiting": _step in [STEP.OFFERING, STEP.LEAVING],
+	}
+
+
+## `PlaceTradePartnerNamesAndParty` prints the species name and not the
+## nickname, which is the one place either list does.
+func _party_names(rows: Array) -> Array:
+	var out: Array = []
+	for row: Dictionary in rows:
+		out.append(_species_name(int(row.get("species", 0))))
+	return out

--- a/game/world/link_screen.gd.uid
+++ b/game/world/link_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://d33doddp6874r

--- a/game/world/link_session.gd
+++ b/game/world/link_session.gd
@@ -1,0 +1,349 @@
+class_name Gen2LinkSession
+extends RefCounted
+
+## `SECTION "Link Battle Data"` and every routine the cable club reaches through
+## it: `wLinkMode`, `wPlayerLinkAction`, `wChosenCableClubRoom` and
+## `wOtherPlayerLinkMode`, plus the answers `WaitForLinkedFriend`,
+## `CheckLinkTimeout_Receptionist`, `CheckBothSelectedSameRoom`,
+## `CheckTimeCapsuleCompatibility`, `ValidateOTTrademon` and
+## `CheckAnyOtherAliveMonsForTrade` give from them.
+##
+## Scene free, and WRAM rather than save data: the cartridge keeps none of this
+## across a reset, and neither does [Gen2WorldState], which holds one live and
+## leaves it out of its snapshot. The cable itself is [Gen2LinkTransport], which
+## is injected; nothing here knows what it is made of.
+
+const CONNECTION_NOT_ESTABLISHED: int = Gen2LinkTransport.CONNECTION_NOT_ESTABLISHED
+const USING_EXTERNAL_CLOCK: int = Gen2LinkTransport.USING_EXTERNAL_CLOCK
+const USING_INTERNAL_CLOCK: int = Gen2LinkTransport.USING_INTERNAL_CLOCK
+
+const LINK_NULL: int = Gen2LinkTransport.LINK_NULL
+const LINK_TIMECAPSULE: int = Gen2LinkTransport.LINK_TIMECAPSULE
+const LINK_TRADECENTER: int = Gen2LinkTransport.LINK_TRADECENTER
+const LINK_COLOSSEUM: int = Gen2LinkTransport.LINK_COLOSSEUM
+
+const CABLECLUBROOM_NULL: int = Gen2LinkTransport.CABLECLUBROOM_NULL
+const CABLECLUBROOM_TRADECENTER: int = Gen2LinkTransport.CABLECLUBROOM_TRADECENTER
+const CABLECLUBROOM_COLOSSEUM: int = Gen2LinkTransport.CABLECLUBROOM_COLOSSEUM
+
+## `CheckTimeCapsuleCompatibility`'s own four answers in wScriptVar.
+const TIME_CAPSULE_OK: int = 0
+const TIME_CAPSULE_MON_TOO_NEW: int = 1
+const TIME_CAPSULE_MOVE_TOO_NEW: int = 2
+const TIME_CAPSULE_MON_HAS_MAIL: int = 3
+
+## `JOHTO_POKEMON`, the first species a Gen 1 game has no room for, and
+## `STRUGGLE + 1`, the first move index past its own list.
+const JOHTO_POKEMON: int = 152
+const FIRST_GEN2_MOVE: int = 166
+
+## `MAX_LEVEL + 1`, which is what `ValidateOTTrademon` calls abnormal.
+const MAX_LEVEL: int = 100
+
+## MAGNEMITE and MAGNETON, the two species `ValidateOTTrademon` names rather
+## than type-checks: Electric became Electric/Steel between the generations.
+const TIME_CAPSULE_RETYPED_SPECIES: Array[int] = [81, 82]
+
+## `NUM_LINK_BATTLE_RECORDS` and `MAX_LINK_RECORD`.
+const NUM_LINK_BATTLE_RECORDS: int = 5
+const MAX_LINK_RECORD: int = 9999
+
+## The frames each routine spends, from its own `ld c` in front of `DelayFrames`.
+## None of them is free, and a receptionist that answers instantly is the same
+## class of defect the missing fades were.
+const WAIT_FOR_FRIEND_CONNECTED_FRAMES: int = 50
+const ENTER_TIME_CAPSULE_FRAMES: int = 50
+const WAIT_FOR_OTHER_PLAYER_FRAMES: int = 12
+const CLOSE_LINK_FRAMES: int = 6
+const FAILED_LINK_TO_PAST_FRAMES: int = 40
+const CHECK_LINK_TIMEOUT_FRAMES: int = 2
+
+## `wLinkMode`, which the room's own console special reads back and
+## `WaitForOtherPlayerToExit` clears.
+var link_mode: int = LINK_NULL
+## `wPlayerLinkAction`, the room at the receptionist and the menu choice inside
+## the trade screen.
+var player_link_action: int = CABLECLUBROOM_NULL
+## `wChosenCableClubRoom`, the door this player walked up to.
+var chosen_room: int = CABLECLUBROOM_NULL
+## `wOtherPlayerLinkMode`, which the receptionist scripts `readmem`: zero is a
+## Game Boy running a Gen 1 game and the only thing the Time Capsule accepts.
+var other_player_link_mode: int = 0
+## `hSerialConnectionStatus` as this side last saw it.
+var connection_status: int = CONNECTION_NOT_ESTABLISHED
+## The peer's own block from the last exchange: its name, id and party. Empty
+## until a room has been agreed.
+var peer: Dictionary = {}
+
+
+## `SetBitsForLinkTradeRequest` and `SetBitsForBattleRequest`, which are one
+## routine each: the room goes into both `wPlayerLinkAction` and
+## `wChosenCableClubRoom`.
+func request_room(room: int) -> void:
+	player_link_action = room
+	chosen_room = room
+
+
+## `SetBitsForTimeCapsuleRequest`, which asks for no room at all: it opens the
+## serial port and leaves both bytes at `CABLECLUBROOM_NULL`.
+func request_time_capsule() -> void:
+	request_room(CABLECLUBROOM_NULL)
+
+
+## `WaitForLinkedFriend`. TRUE once the other Game Boy has answered, FALSE when
+## its $2ff passes went by without one, which is what a single console always
+## gets. The frames the TRUE branch then spends are
+## [constant WAIT_FOR_FRIEND_CONNECTED_FRAMES].
+func wait_for_linked_friend(transport: Gen2LinkTransport) -> int:
+	connection_status = transport.status() if transport != null else CONNECTION_NOT_ESTABLISHED
+	if connection_status not in [USING_INTERNAL_CLOCK, USING_EXTERNAL_CLOCK]:
+		connection_status = CONNECTION_NOT_ESTABLISHED
+		return 0
+	return 1
+
+
+## `CheckLinkTimeout_Receptionist`, which sets `wPlayerLinkAction` to 1 and runs
+## `Link_CheckCommunicationError`: FALSE is a link that dropped while the two
+## players were saving, and the peer's own action lands in
+## `wOtherPlayerLinkMode` for the `readmem` that follows.
+##
+## A Gen 1 game has no `wPlayerLinkAction` to raise, so what comes back from one
+## is zero, which is the whole of the "can't link to the past" branch and the
+## whole of what makes the Time Capsule legal.
+func check_link_timeout(transport: Gen2LinkTransport) -> int:
+	player_link_action = 1
+	if transport == null or not transport.connected():
+		other_player_link_mode = 0
+		reset_serial_registers(transport)
+		return 0
+	other_player_link_mode = 0 if int(transport.peer.get(
+		"generation", Gen2LinkTransport.GENERATION_2
+	)) == Gen2LinkTransport.GENERATION_1 else 1
+	return 1
+
+
+## `CheckBothSelectedSameRoom`, which exchanges `wChosenCableClubRoom` and only
+## then commits `wLinkMode`. The mode is the room plus one, which is why
+## `CABLECLUBROOM_TRADECENTER` becomes `LINK_TRADECENTER`.
+func check_both_selected_same_room(transport: Gen2LinkTransport) -> int:
+	if transport == null:
+		return 0
+	if transport.peer_room(chosen_room) != chosen_room:
+		return 0
+	link_mode = chosen_room + 1
+	peer = transport.exchange({"room": chosen_room})
+	return 1
+
+
+## `EnterTimeCapsule`, which agrees a `$4` sync nybble and then sets
+## `LINK_TIMECAPSULE` by hand rather than off the chosen room, because the
+## Time Capsule's own room byte is `CABLECLUBROOM_NULL`.
+func enter_time_capsule(transport: Gen2LinkTransport) -> void:
+	if transport != null:
+		transport.exchange_nybble(4)
+		peer = transport.exchange({"room": CABLECLUBROOM_NULL})
+	link_mode = LINK_TIMECAPSULE
+
+
+## `TimeCapsule`, `TradeCenter` and `Colosseum`: each sets `wLinkMode` again on
+## the way into `LinkCommunications`, so the console the player used is what
+## decides what is exchanged rather than the receptionist that sent them there.
+func open_room(mode: int) -> void:
+	link_mode = mode
+
+
+## `CloseLink`, and `Link_ResetSerialRegistersAfterLinkClosure` behind it.
+func close_link(transport: Gen2LinkTransport) -> void:
+	link_mode = LINK_NULL
+	reset_serial_registers(transport)
+
+
+## `FailedLinkToPast`, which spends forty frames and agrees an `$e` nybble so
+## the Gen 1 game on the other end stops waiting too.
+func failed_link_to_past(transport: Gen2LinkTransport) -> void:
+	if transport != null:
+		transport.exchange_nybble(0xE)
+
+
+## `WaitForOtherPlayerToExit`, which walks the serial port through both clocks
+## and then puts everything back: the timeout counter, `hVBlank` and `wLinkMode`
+## all reach zero, which is what makes a cancelled visit leave no link behind.
+func wait_for_other_player_to_exit(transport: Gen2LinkTransport) -> void:
+	link_mode = LINK_NULL
+	peer = {}
+	reset_serial_registers(transport)
+
+
+## `Link_ResetSerialRegistersAfterLinkClosure`.
+func reset_serial_registers(transport: Gen2LinkTransport) -> void:
+	connection_status = CONNECTION_NOT_ESTABLISHED
+	if transport != null:
+		transport.close()
+
+
+## `CableClubCheckWhichChris`, which the three rooms' `MAPCALLBACK_OBJECTS` runs
+## to decide which of the two identical friends is standing there: TRUE for the
+## player holding the external clock, who is the one on the right.
+func which_chris(transport: Gen2LinkTransport) -> int:
+	var side: int = transport.status() if transport != null else connection_status
+	return 1 if side == USING_EXTERNAL_CLOCK else 0
+
+
+## `CheckTimeCapsuleCompatibility`, in the order the routine runs its three
+## tests: every species slot first, then mail, then moves. The answer is the
+## wScriptVar value and the party slot the box names, which is the slot the test
+## stopped on rather than the first slot of the party.
+##
+## [param party] is the world's own party mirror: the parallel `species`,
+## `held_items` and `moves` arrays [method Gen2WorldAPI.set_party_summary]
+## carries, which is where every other party-reading special gets its answer.
+static func time_capsule_compatibility(party: Dictionary) -> Dictionary:
+	var species: Array = party.get("species", [])
+	var held_items: Array = party.get("held_items", [])
+	var moves: Array = party.get("moves", [])
+	for slot: int in species.size():
+		if int(species[slot]) >= JOHTO_POKEMON:
+			return _incompatible(TIME_CAPSULE_MON_TOO_NEW, slot, int(species[slot]), 0)
+	for slot: int in held_items.size():
+		if Gen2HeldItem.is_mail(int(held_items[slot])):
+			return _incompatible(
+				TIME_CAPSULE_MON_HAS_MAIL, slot, _species_at(species, slot), 0
+			)
+	for slot: int in moves.size():
+		for move: Variant in moves[slot] as Array:
+			if int(move) >= FIRST_GEN2_MOVE:
+				return _incompatible(
+					TIME_CAPSULE_MOVE_TOO_NEW, slot, _species_at(species, slot),
+					int(move)
+				)
+	return _incompatible(TIME_CAPSULE_OK, -1, 0, 0)
+
+
+static func _species_at(species: Array, slot: int) -> int:
+	return int(species[slot]) if slot < species.size() else 0
+
+
+static func _incompatible(value: int, slot: int, species: int, move: int) -> Dictionary:
+	return {"value": value, "slot": slot, "species": species, "move": move}
+
+
+## `ValidateOTTrademon`: the offered Pokemon's own species must match the row the
+## party list names it by, unless that row says EGG, and its level must be one a
+## level can be. The Time Capsule adds a third test, and it is the only one that
+## needs the peer to say anything about itself: a Gen 1 game reports the typing
+## it holds for the species, and one whose typing this generation changed is
+## refused. Magnemite and Magneton are excused by name because theirs is that
+## change.
+##
+## [param mon] carries `types` only when the peer is a Gen 1 game, which is the
+## only sender `Link_ConvertPartyStruct1to2` fills `wLinkOTPartyMonTypes` from,
+## so a Gen 2 peer skips the test rather than failing an empty one.
+static func validate_ot_trademon(
+	mon: Dictionary, listed_species: int, listed_is_egg: bool, mode: int,
+	base_types: Array = []
+) -> bool:
+	if not listed_is_egg and listed_species != int(mon.get("species", 0)):
+		return false
+	if int(mon.get("level", 0)) > MAX_LEVEL:
+		return false
+	if mode != LINK_TIMECAPSULE:
+		return true
+	if int(mon.get("species", 0)) in TIME_CAPSULE_RETYPED_SPECIES:
+		return true
+	var reported: Array = mon.get("types", [])
+	if reported.size() < 2 or base_types.size() < 2:
+		return true
+	return int(reported[0]) == int(base_types[0]) \
+		and int(reported[1]) == int(base_types[1])
+
+
+## `CheckAnyOtherAliveMonsForTrade`. A trade that would leave this side with
+## nothing that can fight is refused, so the offered slot is skipped here and
+## the incoming Pokemon is what answers for it.
+##
+## Carry set is the refusal in the source, so this answers the opposite: TRUE
+## means the trade may go ahead.
+static func any_other_alive_mons_for_trade(
+	party: Array, offered_slot: int, incoming: Dictionary
+) -> bool:
+	for slot: int in party.size():
+		if slot == offered_slot:
+			continue
+		if int((party[slot] as Dictionary).get("hp", 0)) > 0:
+			return true
+	return int(incoming.get("hp", 0)) > 0
+
+
+## `AddLastLinkBattleToLinkRecord`. The totals rise first, then the opponent's
+## own row: an existing row for that ID and name is raised, and a new opponent
+## takes the last of the five, which `.FindOpponentAndAppendRecord`'s sort has
+## kept for the least successful one. Both counters stop at
+## [constant MAX_LINK_RECORD] rather than wrapping.
+##
+## [param result] is `wins`, `losses` or `draws`, which is `wBattleResult`'s own
+## WIN/LOSE/DRAW one name further on.
+static func add_battle_to_record(
+	record: Dictionary, opponent: Dictionary, result: StringName
+) -> Dictionary:
+	var updated: Dictionary = normalize_record(record)
+	var key: String = String(result)
+	updated[key] = _raise_count(int(updated.get(key, 0)))
+	var rows: Array = updated["records"]
+	var opponent_name: String = String(opponent.get("name", ""))
+	var id: int = int(opponent.get("id", 0)) & 0xFFFF
+	var found: int = -1
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		if String(row.get("name", "")) == opponent_name and int(row.get("id", 0)) == id:
+			found = index
+			break
+	if found < 0:
+		found = rows.size() - 1
+		rows[found] = {
+			"name": opponent_name, "id": id, "wins": 0, "losses": 0, "draws": 0,
+		}
+	rows[found][key] = _raise_count(int((rows[found] as Dictionary).get(key, 0)))
+	rows.sort_custom(_more_successful)
+	updated["records"] = rows
+	return updated
+
+
+## `.loop4`, which is a bubble sort of the five rows on the three counters in
+## the order they are stored.
+static func _more_successful(a: Dictionary, b: Dictionary) -> bool:
+	for key: String in ["wins", "losses", "draws"]:
+		if int(a.get(key, 0)) != int(b.get(key, 0)):
+			return int(a.get(key, 0)) > int(b.get(key, 0))
+	return false
+
+
+## `.CheckOverflow`, which stops a counter at the cap instead of carrying past
+## it.
+static func _raise_count(value: int) -> int:
+	return mini(value + 1, MAX_LINK_RECORD)
+
+
+## `sLinkBattleStats` as this project keeps it, with the five rows always
+## present: an empty row is one `_DisplayLinkRecord` prints its dashes for.
+static func normalize_record(raw: Variant) -> Dictionary:
+	var source: Dictionary = raw if raw is Dictionary else {}
+	var rows: Array = []
+	for entry: Variant in source.get("records", []):
+		if not entry is Dictionary or rows.size() >= NUM_LINK_BATTLE_RECORDS:
+			continue
+		var row: Dictionary = entry
+		rows.append({
+			"name": String(row.get("name", "")),
+			"id": int(row.get("id", 0)) & 0xFFFF,
+			"wins": clampi(int(row.get("wins", 0)), 0, MAX_LINK_RECORD),
+			"losses": clampi(int(row.get("losses", 0)), 0, MAX_LINK_RECORD),
+			"draws": clampi(int(row.get("draws", 0)), 0, MAX_LINK_RECORD),
+		})
+	while rows.size() < NUM_LINK_BATTLE_RECORDS:
+		rows.append({"name": "", "id": 0, "wins": 0, "losses": 0, "draws": 0})
+	return {
+		"wins": clampi(int(source.get("wins", 0)), 0, MAX_LINK_RECORD),
+		"losses": clampi(int(source.get("losses", 0)), 0, MAX_LINK_RECORD),
+		"draws": clampi(int(source.get("draws", 0)), 0, MAX_LINK_RECORD),
+		"records": rows,
+	}

--- a/game/world/link_session.gd.uid
+++ b/game/world/link_session.gd.uid
@@ -1,0 +1,1 @@
+uid://bf4ejy7hu8ll4

--- a/game/world/link_transport.gd
+++ b/game/world/link_transport.gd
@@ -1,0 +1,169 @@
+class_name Gen2LinkTransport
+extends RefCounted
+
+## The cable, as the only thing above it needs it to be.
+##
+## `home/serial.asm` and `engine/link/link.asm` reach the other Game Boy through
+## exactly three operations, and every routine the cable club runs is built from
+## them: read `hSerialConnectionStatus`, exchange one byte with `Link_EnsureSync`
+## or `Serial_PlaceWaitingTextAndSyncAndExchangeNybble`, and exchange a block
+## with `Serial_ExchangeBytes`. There is no cable on a modern platform, so this
+## project chooses the transport, and this class is that choice: the three
+## operations, and nothing about wires, timing or bit order.
+##
+## Scene free, and injected the way randomness is. A transport with no peer is
+## the honest default and a real game path rather than a stub: `WaitForLinkedFriend`
+## times out and the receptionist says the friend is not ready, which is what
+## the cartridge does with one Game Boy.
+##
+## The one peer that exists today is another of this player's own save slots,
+## which [method peer_from_save] builds. A network transport subclasses this and
+## overrides the three operations; nothing above changes.
+
+## constants/serial_constants.asm. `CONNECTION_NOT_ESTABLISHED` is what
+## `Link_ResetSerialRegistersAfterLinkClosure` writes back.
+const CONNECTION_NOT_ESTABLISHED: int = 0xFF
+const USING_EXTERNAL_CLOCK: int = 0x01
+const USING_INTERNAL_CLOCK: int = 0x02
+
+## `wLinkMode`.
+const LINK_NULL: int = 0
+const LINK_TIMECAPSULE: int = 1
+const LINK_TRADECENTER: int = 2
+const LINK_COLOSSEUM: int = 3
+const LINK_MOBILE: int = 4
+
+## `wChosenCableClubRoom` and `wPlayerLinkAction` at the receptionist.
+const CABLECLUBROOM_NULL: int = 0
+const CABLECLUBROOM_TRADECENTER: int = 1
+const CABLECLUBROOM_COLOSSEUM: int = 2
+
+## The peer's own side of the link, or empty for no cable. Keys:
+## `name`, `id`, `gender`, `party` (an array of [Gen2SaveMon] dictionaries),
+## `room` (its `wChosenCableClubRoom`) and `generation`.
+var peer: Dictionary = {}
+
+## Which side of the cable this player is. `CableClubCheckWhichChris` and the
+## trade animation both branch on it, and `WaitForLinkedFriend` only reports a
+## connection once it is one of the two clocks.
+var clock: int = CONNECTION_NOT_ESTABLISHED
+
+
+## Which generation the peer's game is. `readmem wOtherPlayerLinkMode` after
+## `CheckLinkTimeout_Receptionist` is zero for a Game Boy running a Gen 1 game
+## and non-zero for a Gen 2 one, which is the whole of the "can't link to the
+## past" test and the whole of what makes the Time Capsule legal.
+const GENERATION_1: int = 1
+const GENERATION_2: int = 2
+
+
+## Whether a peer is on the other end at all. Everything else asks this first.
+func connected() -> bool:
+	return not peer.is_empty()
+
+
+## `hSerialConnectionStatus`. The peer this project can build is another save
+## slot on this machine, and the player who opened the receptionist is the one
+## holding the cable's internal clock, so they are player 1.
+func status() -> int:
+	if not connected():
+		return CONNECTION_NOT_ESTABLISHED
+	if clock == CONNECTION_NOT_ESTABLISHED:
+		clock = USING_INTERNAL_CLOCK
+	return clock
+
+
+## `Link_EnsureSync`, which sends one nybble and returns the peer's. The source
+## spins until a byte with the `$d0` marker comes back; a transport with a peer
+## already has the answer, and one without has none.
+func exchange_nybble(value: int) -> int:
+	if not connected():
+		return -1
+	return peer_nybble(value & 0xF)
+
+
+## What the peer answers a sync nybble with. The base transport's peer is a save
+## file rather than a player, so it agrees with whatever this side proposed:
+## it entered the same room and it is ready. A network transport overrides this
+## with the byte that actually came back.
+func peer_nybble(value: int) -> int:
+	return value
+
+
+## `Serial_ExchangeBytes` at the block level: this side's payload goes out and
+## the peer's comes back. Empty means the cable dropped, which every caller
+## treats as a link that closed.
+func exchange(payload: Dictionary) -> Dictionary:
+	if not connected():
+		return {}
+	return peer_block(payload)
+
+
+## The peer's own block. The base transport answers out of [member peer], which
+## is a save slot that is not being played, so its party is whatever it was
+## saved with.
+func peer_block(_payload: Dictionary) -> Dictionary:
+	return {
+		"name": String(peer.get("name", "")),
+		"id": int(peer.get("id", 0)),
+		"gender": int(peer.get("gender", 0)),
+		"generation": int(peer.get("generation", GENERATION_2)),
+		"room": int(peer.get("room", CABLECLUBROOM_NULL)),
+		"party": (peer.get("party", []) as Array).duplicate(true),
+	}
+
+
+## `Link_ResetSerialRegistersAfterLinkClosure`. A closed link forgets which side
+## it was; the peer stays, because the player can walk back to the receptionist.
+func close() -> void:
+	clock = CONNECTION_NOT_ESTABLISHED
+
+
+## Which room the peer walked up to. A save slot cannot choose, so it agrees:
+## the two players who sat down together picked the same door, and the one case
+## that must still fail is a Gen 2 peer at the Time Capsule, which
+## [Gen2LinkSession] settles from `generation` rather than from here.
+func peer_room(chosen_room: int) -> int:
+	return int(peer.get("room", chosen_room))
+
+
+## Which row of its own party the peer offers in a trade. A save file has nobody
+## behind it to choose, so the base transport answers with the row the player
+## left the partner's list on, which is the list `LinkTrade_OTPartyMenu` already
+## lets them move a cursor through; a network transport answers with the row
+## that actually came back in `wOtherPlayerLinkMode`.
+##
+## [param context] carries `ot_cursor` and `ot_count`.
+func choose_trade_slot(context: Dictionary) -> int:
+	var rows: int = int(context.get("ot_count", 0))
+	if rows <= 0:
+		return -1
+	return clampi(int(context.get("ot_cursor", 0)), 0, rows - 1)
+
+
+## A peer built from a save slot: the player's other file, which is the only
+## second party that exists on one machine. [param room] is the door it is
+## treated as having walked up to.
+static func peer_from_save(save: Gen2SaveData, room: int = CABLECLUBROOM_NULL) -> Dictionary:
+	if save == null:
+		return {}
+	var party: Array = []
+	for mon: Gen2SaveMon in save.party:
+		party.append(mon.to_dict())
+	return {
+		"name": save.player_name,
+		"id": save.player_id,
+		"gender": save.gender,
+		"generation": GENERATION_2,
+		"room": room,
+		"party": party,
+		"slot": save.slot,
+	}
+
+
+## The transport a save slot makes, or one with no cable when there is no other
+## slot to link to.
+static func to_save(save: Gen2SaveData, room: int = CABLECLUBROOM_NULL) -> Gen2LinkTransport:
+	var transport := Gen2LinkTransport.new()
+	transport.peer = peer_from_save(save, room)
+	return transport

--- a/game/world/link_transport.gd.uid
+++ b/game/world/link_transport.gd.uid
@@ -1,0 +1,1 @@
+uid://n6mws5l13gqd

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -63,10 +63,13 @@ static func prepare(
 				return _failure(&"invalid_trainer", {
 					"trainer_class": trainer_class, "trainer_index": trainer_index,
 				})
-		&"battle_tower":
+		&"battle_tower", &"link_battle":
 			## `ReadBTTrainerParty` copies a whole `wOTPartyMon` block out of the
 			## sampled record rather than building one from a trainer table, so
 			## the party arrives with the request and nothing is rolled here.
+			## A link battle is the same shape one caller further out:
+			## `Link_PrepPartyData_Gen2` sends whole party structs and the other
+			## Game Boy's arrive the same way, with no trainer class behind them.
 			trainer_class = int(values.get("trainer_class", 0))
 			var members: Array = []
 			for raw_mon: Variant in values.get("enemy_party", []) as Array:
@@ -84,7 +87,7 @@ static func prepare(
 	var generator := random if random != null else RandomNumberGenerator.new()
 	var battle: Gen2Battle = Gen2Battle.create_parties(
 		data, player_party, enemy_party, generator,
-		kind == &"trainer" or kind == &"battle_tower", player_badges, battle_rules
+		kind in [&"trainer", &"battle_tower", &"link_battle"], player_badges, battle_rules
 	)
 	if battle == null:
 		return _failure(&"battle_setup_failed")

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -71,7 +71,13 @@ static func complete_runtime_request(
 			"request": request.duplicate(true),
 			"results": resumed,
 		}
-	if kind in [&"battle_requested", &"swarm_requested"]:
+	## `_DisplayLinkRecord` draws a page over a save field and writes nothing,
+	## and a room console with no cable on the other end has nothing to exchange:
+	## both run to completion where they are staged, the way the unattended
+	## requests above do. A screen that can draw either intercepts the request in
+	## front of this.
+	if kind in [&"battle_requested", &"swarm_requested",
+		&"link_record_requested", &"link_room_requested"]:
 		return {"ok": true, "handled": true, "results": world.complete_runtime_request(result)}
 	## Neither reads cartridge data of its own: the region map's landmark and the
 	## bank dial's amount are the whole answer, and the runner owns what is done

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -296,6 +296,119 @@ static func heal_party(
 
 
 
+## The link trade's own commit, which is `LinkTrade`'s `.do_trade` tail: the
+## offered slot leaves through `RemoveMonFromPartyOrBox` and the received
+## Pokemon is appended by `AddTempmonToParty`, so it lands at the END of the
+## party rather than in the slot that was emptied. That is the one place the
+## link trade differs from the in-game one, which writes into the vacated slot.
+##
+## `wForceEvolution` is set over the append, so a species that evolves by trade
+## evolves here and nowhere else. Mail travels with each Pokemon because it hangs
+## off the row: `sPartyMail` is shifted by the same removal.
+##
+## [param incoming] is the peer's [Gen2SaveMon] dictionary; [param peer] names
+## the trainer it came from, for the dex and for the box the caller prints.
+static func commit_link_trade(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	offered_slot: int,
+	incoming: Dictionary,
+	peer: Dictionary = {},
+	persist: bool = true
+) -> Dictionary:
+	if world == null or save == null or world.data == null:
+		return _failure(&"missing_save", {})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	var candidate: Gen2SaveData = opened["candidate"]
+	if offered_slot < 0 or offered_slot >= candidate.party.size():
+		return _failure(&"invalid_trade_slot", {"slot": offered_slot})
+	var received: Gen2SaveMon = Gen2SaveMon.from_dict(incoming)
+	if received == null or received.species <= 0:
+		return _failure(&"invalid_trade_partner_mon", {})
+	## `ValidateOTTrademon` and `CheckAnyOtherAliveMonsForTrade`, both of which
+	## the trade screen has already run: they are run again here because this is
+	## the boundary that writes, and a caller that skipped them must not.
+	if not Gen2LinkSession.validate_ot_trademon(
+		incoming, received.species, received.is_egg,
+		int(peer.get("link_mode", Gen2LinkSession.LINK_TRADECENTER))
+	):
+		return _failure(&"abnormal_trade_partner_mon", {})
+	var party_rows: Array = []
+	for mon: Gen2SaveMon in candidate.party:
+		party_rows.append(mon.to_dict())
+	if not Gen2LinkSession.any_other_alive_mons_for_trade(
+		party_rows, offered_slot, incoming
+	):
+		return _failure(&"trade_would_leave_no_battler", {"slot": offered_slot})
+
+	var given: Gen2SaveMon = candidate.party[offered_slot]
+	var given_species: int = given.species
+	candidate.party.remove_at(offered_slot)
+	candidate.party.append(received)
+	var evolution: Dictionary = {}
+	if not received.is_egg:
+		var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(
+			world.data, received
+		)
+		if battle_mon != null:
+			var row: Dictionary = Gen2Evolution.trade_evolution(world.data, battle_mon)
+			if not row.is_empty():
+				evolution = apply_evolution(world.data, received, row)
+
+	var before: Gen2WorldSnapshot = world.snapshot()
+	_register_caught(world, received.species)
+	_register_unown(world, _unown_form(
+		received.species, received.dvs, {"destination": &"party"}
+	))
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	return {
+		"ok": true,
+		"handled": true,
+		"given_species": given_species,
+		"given_slot": offered_slot,
+		"received_species": received.species,
+		"received_slot": save.party.size() - 1,
+		"partner": String(peer.get("name", "")),
+		"evolution": evolution.duplicate(true),
+	}
+
+
+## `AddLastLinkBattleToLinkRecord`, which runs after a Colosseum battle and is
+## the only writer of `sLinkBattleStats`. Its own transaction, because the record
+## is a save field and the battle that produced it is over.
+static func record_link_battle(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	opponent: Dictionary,
+	result: StringName,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or save == null or world.data == null:
+		return _failure(&"missing_save", {})
+	if result not in [&"wins", &"losses", &"draws"]:
+		return _failure(&"invalid_link_battle_result", {"result": result})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	var candidate: Gen2SaveData = opened["candidate"]
+	candidate.link_record = Gen2LinkSession.add_battle_to_record(
+		candidate.link_record, opponent, result
+	)
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	return {"ok": true, "handled": true, "record": save.link_record.duplicate(true)}
+
+
 ## `HealParty`'s own walk, without the transaction around it: full HP, no status
 ## and full PP for every party member that is not an egg. Answers how many rows
 ## it moved, or -1 for a row the battle adapter cannot read.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -142,6 +142,15 @@ var _service_host: Gen2WorldServiceScreen = null
 var _start_menu_host: Gen2StartMenuScreen = null
 var _party_host: Gen2PartyScreen = null
 var _hall_of_fame_host: Gen2HallOfFameScreen = null
+## `LinkCommunications`' own screen: the Trade Center's two-list menu and the
+## link record sign. The Colosseum runs through the battle host instead.
+var _link_host: Gen2LinkScreen = null
+## The peer a Colosseum battle is being fought against, for the record
+## `AddLastLinkBattleToLinkRecord` writes when it ends.
+var _link_battle_peer: Dictionary = {}
+## Which save slot the cable was last built for. The peer is another file on
+## disk, so it is read once per slot rather than on every party refresh.
+var _link_transport_slot: int = -2
 var _credits_host: Gen2CreditsScreen = null
 ## `EvolveAfterBattle`'s own screen, opened on the overworld after a battle that
 ## was won and by an evolution stone from the pack.
@@ -655,6 +664,7 @@ func _apply_interface_mask() -> void:
 		_battle_transition != null
 		or _battle_host != null or _service_host != null or _party_host != null
 		or _hall_of_fame_host != null or _trainer_card_host != null
+		or _link_host != null
 		or _pokedex_host != null or _credits_host != null
 		or _evolution_host != null or _hatch_host != null
 		or _nickname_host != null
@@ -909,6 +919,10 @@ func advance_frame() -> void:
 	## `DelayFrames` counts are spent from this pump.
 	if _evolution_host != null:
 		_evolution_host.advance_frame()
+	## `LinkCommunications` spends its own `DelayFrames` inside the map's loop
+	## too, which is what the trade screen's waits are counted from.
+	if _link_host != null:
+		_link_host.advance_frame()
 	if _hatch_host != null:
 		_hatch_host.advance_frame()
 	if _nickname_host != null:
@@ -1079,6 +1093,7 @@ func _overlay_open() -> bool:
 		or _battle_host != null or _service_host != null \
 		or _start_menu_host != null or _party_host != null \
 		or _hall_of_fame_host != null or _trainer_card_host != null \
+		or _link_host != null \
 		or _pokedex_host != null or _credits_host != null \
 		or _evolution_host != null or _hatch_host != null \
 		or _nickname_host != null \
@@ -1245,6 +1260,9 @@ func _handle_button(button: int) -> bool:
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
 	## to until it has finished, and it takes no cancel.
+	if _link_host != null:
+		_link_host.handle_button(button)
+		return true
 	if _hall_of_fame_host != null:
 		_hall_of_fame_host.handle_button(button)
 		return true
@@ -4321,6 +4339,10 @@ func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	var values: Dictionary = request.get("values", {})
 	if bool(values.get("tutorial", false)):
 		return null
+	## A link battle starts from `LinkCommunications`' own screen rather than
+	## from the map, so there is no map for `DoBattleTransition` to wipe away.
+	if bool(values.get("link", false)):
+		return null
 	var environment: int = _world.current_map.environment if _world.current_map != null else 0
 	## `cp CAVE / cp ENVIRONMENT_5 / cp DUNGEON`, the three the flash and the
 	## wavy outro belong to.
@@ -4591,6 +4613,8 @@ func _on_battle_finished(result: Dictionary) -> void:
 	if _world == null:
 		return
 	_last_battle_outcome = StringName(result.get("outcome", &""))
+	if not _link_battle_peer.is_empty():
+		_record_link_battle(result)
 	var pay_day_money: int = int(result.get("pay_day_money", 0))
 	if pay_day_money > 0 and StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON:
 		_world.state.apply_changes({}, {}, {"money": {
@@ -4608,6 +4632,27 @@ func _on_battle_finished(result: Dictionary) -> void:
 		)
 		return
 	_finish_battle_exit(result, fought_save)
+
+
+## `AddLastLinkBattleToLinkRecord`, which runs on the way out of a Colosseum
+## battle and nowhere else. A draw is what `wBattleResult` says when neither
+## side was wiped out.
+func _record_link_battle(result: Dictionary) -> void:
+	var peer: Dictionary = _link_battle_peer
+	_link_battle_peer = {}
+	var outcome: StringName = StringName(result.get("outcome", &""))
+	var key: StringName = &"draws"
+	if outcome == Gen2WorldBattleAdapter.OUTCOME_WON:
+		key = &"wins"
+	elif outcome == Gen2WorldBattleAdapter.OUTCOME_LOST:
+		key = &"losses"
+	var save: Gen2SaveData = _active_battle_save
+	if save == null:
+		return
+	Gen2WorldPartyHost.record_link_battle(
+		_world, save, {"name": peer.get("name", ""), "id": peer.get("id", 0)},
+		key, _active_battle_persist
+	)
 
 
 ## `EvolveAfterBattle`'s `wEvolvableFlags`, read only on a battle that was won.
@@ -5022,6 +5067,114 @@ func open_hall_of_fame() -> void:
 	_play_hall_of_fame_music()
 	_script_prompt = "Hall of Fame"
 	_refresh_labels()
+
+
+## `TradeCenter`, `Colosseum` and `TimeCapsule`, which are the same
+## `LinkCommunications` opening with a different exchange behind it: the two
+## trade rooms open this screen and the Colosseum opens a battle against the
+## peer's own party. Answers whether the request was taken over; a false leaves
+## it for the host, which settles a room with no cable on the other end.
+func _open_link_room(request: Dictionary) -> bool:
+	var values: Dictionary = request.get("values", {})
+	if int(values.get("link_mode", 0)) == Gen2LinkSession.LINK_COLOSSEUM:
+		return _start_link_battle(request)
+	return _open_link_screen(Gen2LinkScreen.MODE_TRADE)
+
+
+## `Colosseum`, which is `LinkCommunications` and then one battle against the
+## party that came back. The transport supplies the peer's choices, and the
+## record is written where `AddLastLinkBattleToLinkRecord` writes it.
+func _start_link_battle(request: Dictionary) -> bool:
+	var peer: Dictionary = _link_transport().peer
+	var party: Array = peer.get("party", [])
+	if party.is_empty():
+		return false
+	_link_battle_peer = peer.duplicate(true)
+	_start_battle_request({
+		"kind": &"link_room_requested",
+		"values": {
+			"kind": &"link_battle",
+			"special": int((request.get("values", {}) as Dictionary).get("special", 0)),
+			## `wLinkMode` is non-zero for the whole fight, which is what makes
+			## the switch menu the player's own rather than the AI's.
+			"link": true,
+			"trainer_name": String(peer.get("name", "")),
+			"enemy_party": party.duplicate(true),
+		},
+	})
+	return true
+
+
+func _open_link_screen(screen_mode: int) -> bool:
+	if _link_host != null or _world == null or _data == null:
+		return false
+	var host := Gen2LinkScreen.new()
+	host.set_context(
+		_data, _world, _selected_runtime_save() if _injected_save == null \
+			else _injected_save,
+		_link_transport(), screen_mode, _injected_save == null
+	)
+	host.closed.connect(_on_link_screen_closed)
+	_link_host = host
+	_screen.display(host)
+	if _link_host == null:
+		## A cartridge whose cache has no trade border closes on `_ready()`.
+		return false
+	_script_prompt = "Link record" if screen_mode == Gen2LinkScreen.MODE_RECORD \
+		else "Trade Center"
+	_refresh_labels()
+	return true
+
+
+func _on_link_screen_closed() -> void:
+	var host: Gen2LinkScreen = _link_host
+	_link_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	_show_script_results(_world.complete_runtime_request({"ok": true}))
+	if _renderer != null:
+		_renderer.refresh()
+	_refresh_labels()
+
+
+## The cable, on the same refresh the party mirror rides. There is no cable on
+## this platform and the only second party that exists on one machine is the
+## player's own other save file, so that is the peer: the first other occupied
+## slot of the same cartridge. No other slot is no cable, which is what the
+## receptionist's "your friend is not ready" answers.
+func _refresh_link_transport(save: Gen2SaveData) -> void:
+	if _world == null or _world.state == null or _data == null:
+		return
+	if _injected_save != null:
+		## A driver that brought its own save brought its own peer too, or none;
+		## a slot on disk is not this run's to reach for.
+		return
+	## Once per slot. This rides the party mirror's refresh, which runs whenever
+	## the party changes; reading another save file that often would put disk
+	## access in the middle of a battle, and the peer cannot change while this
+	## slot is the one being played.
+	if _link_transport_slot == save.slot:
+		return
+	_link_transport_slot = save.slot
+	for slot: int in Gen2SaveStore.occupied_slots(save.game_id, save.rom_sha1):
+		if slot == save.slot:
+			continue
+		var loaded: Dictionary = Gen2SaveStore.load_result(
+			save.game_id, save.rom_sha1, slot, _data
+		)
+		if not bool(loaded.get("ok", false)):
+			continue
+		_world.state.set_link_transport(
+			Gen2LinkTransport.to_save(loaded["save"] as Gen2SaveData)
+		)
+		return
+	_world.state.set_link_transport(null)
+
+
+func _link_transport() -> Gen2LinkTransport:
+	if _world == null or _world.state == null:
+		return Gen2LinkTransport.new()
+	return _world.state.link_transport()
 
 
 ## HallOfFame calls SaveGameData before the animation, so the record is written
@@ -6375,6 +6528,14 @@ func _show_script_results(results: Array) -> void:
 					_script_prompt = _bug_contest_placings_text(judged)
 					_show_script_results(judged_results)
 					return
+				if StringName(request.get("kind", &"")) == &"link_record_requested":
+					if _open_link_screen(Gen2LinkScreen.MODE_RECORD):
+						break
+					continue
+				if StringName(request.get("kind", &"")) == &"link_room_requested":
+					if _open_link_room(request):
+						break
+					continue
 				if StringName(request.get("kind", &"")) == &"quick_save_requested":
 					## `TryQuickSave` writes the save where it stands and answers
 					## TRUE; a write that fails answers FALSE, which is the same
@@ -7274,6 +7435,7 @@ func _refresh_party_summary() -> void:
 	_world.set_player_id(save.player_id)
 	_world.set_player_name(save.player_name)
 	_world.set_player_gender(save.gender == Gen2SaveData.GENDER_FEMALE)
+	_refresh_link_transport(save)
 	var has_pokerus: bool = false
 	var species: Array[int] = []
 	var moves: Array = []

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -220,6 +220,43 @@ const SPECIAL_CHALLENGE_MENU: int = 136
 ## either corpus that reaches them.
 const SPECIAL_TRY_QUICK_SAVE: int = 4
 const SPECIAL_RESET: int = 126
+
+## The cable club's own block of `SpecialsPointers`, in index order. Three
+## scripts reach it: the trade and battle receptionists on POKECENTER_2F, which
+## share one shape, and the Time Capsule's, which asks for no room at all. The
+## last three are the rooms themselves, reached from the console each one is
+## built around, and `CableClubCheckWhichChris` is the callback that decides
+## which of the two identical friends is standing in it.
+const SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST: int = 1
+const SPECIAL_WAIT_FOR_LINKED_FRIEND: int = 2
+const SPECIAL_CHECK_LINK_TIMEOUT_RECEPTIONIST: int = 3
+const SPECIAL_CHECK_BOTH_SELECTED_SAME_ROOM: int = 5
+const SPECIAL_FAILED_LINK_TO_PAST: int = 6
+const SPECIAL_CLOSE_LINK: int = 7
+const SPECIAL_WAIT_FOR_OTHER_PLAYER_TO_EXIT: int = 8
+const SPECIAL_SET_BITS_FOR_BATTLE_REQUEST: int = 9
+const SPECIAL_SET_BITS_FOR_TIME_CAPSULE_REQUEST: int = 10
+const SPECIAL_CHECK_TIME_CAPSULE_COMPATIBILITY: int = 11
+const SPECIAL_ENTER_TIME_CAPSULE: int = 12
+const SPECIAL_TRADE_CENTER: int = 13
+const SPECIAL_COLOSSEUM: int = 14
+const SPECIAL_TIME_CAPSULE: int = 15
+const SPECIAL_CABLE_CLUB_CHECK_WHICH_CHRIS: int = 16
+## `DisplayLinkRecord`, the sign beside the three receptionists. It is in the
+## same block and it is not link play: it reads `sLinkBattleStats` and draws it,
+## which is one page over a save field the link battle writes.
+const SPECIAL_DISPLAY_LINK_RECORD: int = 88
+## `CheckMobileAdapterStatusSpecial`, which both Crystal receptionists ask before
+## anything else. It is the Mobile Adapter's, and its FALSE is what reaches the
+## cable club: a script that cannot answer it stops in front of the whole room.
+const SPECIAL_CHECK_MOBILE_ADAPTER_STATUS: int = 160
+## Which `wLinkMode` each room's console writes on the way into
+## `LinkCommunications`.
+const LINK_ROOM_MODES: Dictionary = {
+	SPECIAL_TRADE_CENTER: Gen2LinkSession.LINK_TRADECENTER,
+	SPECIAL_COLOSSEUM: Gen2LinkSession.LINK_COLOSSEUM,
+	SPECIAL_TIME_CAPSULE: Gen2LinkSession.LINK_TIMECAPSULE,
+}
 ## `Menu_ChallengeExplanationCancel`'s own answers: the three rows are 1 to 3 and
 ## B is 4, which is why `Script_Menu_ChallengeExplanationCancel` tests only 1 and
 ## 2 and treats everything else as leaving.
@@ -1302,6 +1339,10 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		## `TryQuickSave` answers TRUE for a save that was written and FALSE for
 		## one that was not, which is the branch both of its sites read.
 		&"quick_save_requested",
+		## `_DisplayLinkRecord` draws one page and holds for a button, and the
+		## three link rooms' own consoles run their exchange and come back to a
+		## `newloadmap`. Neither writes anything the script reads.
+		&"link_record_requested", &"link_room_requested",
 	]:
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -3111,6 +3152,84 @@ func _execute_special(special: int) -> Dictionary:
 			return {"ok": true}
 		SPECIAL_CHALLENGE_MENU:
 			return _stage_challenge_menu()
+		SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST, SPECIAL_SET_BITS_FOR_BATTLE_REQUEST:
+			_link_session().request_room(
+				Gen2LinkSession.CABLECLUBROOM_TRADECENTER \
+					if special == SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST \
+					else Gen2LinkSession.CABLECLUBROOM_COLOSSEUM
+			)
+		SPECIAL_SET_BITS_FOR_TIME_CAPSULE_REQUEST:
+			## The Time Capsule asks for `CABLECLUBROOM_NULL`, which is why its
+			## own script never reaches `CheckBothSelectedSameRoom` on a branch
+			## that could pass.
+			_link_session().request_time_capsule()
+		SPECIAL_WAIT_FOR_LINKED_FRIEND:
+			_script_value = _link_session().wait_for_linked_friend(_link_transport())
+			if _script_value == 0:
+				return {"ok": true}
+			return _stage_frame_wait(
+				Gen2LinkSession.WAIT_FOR_FRIEND_CONNECTED_FRAMES,
+				{"special": special, "kind": &"link_wait"}
+			)
+		SPECIAL_CHECK_LINK_TIMEOUT_RECEPTIONIST:
+			var session: Gen2LinkSession = _link_session()
+			_script_value = session.check_link_timeout(_link_transport())
+			## The `readmem wOtherPlayerLinkMode` every one of the three scripts
+			## runs on the next line reads this byte and not wScriptVar.
+			var stored: Dictionary = _stage_script_memory(
+				data.other_player_link_mode_address() if data != null else -1,
+				session.other_player_link_mode
+			)
+			if not bool(stored.get("ok", true)):
+				return stored
+			return _stage_frame_wait(
+				Gen2LinkSession.CHECK_LINK_TIMEOUT_FRAMES,
+				{"special": special, "kind": &"link_wait"}
+			)
+		SPECIAL_CHECK_BOTH_SELECTED_SAME_ROOM:
+			_script_value = _link_session().check_both_selected_same_room(_link_transport())
+		SPECIAL_FAILED_LINK_TO_PAST:
+			_link_session().failed_link_to_past(_link_transport())
+			return _stage_frame_wait(
+				Gen2LinkSession.FAILED_LINK_TO_PAST_FRAMES,
+				{"special": special, "kind": &"link_wait"}
+			)
+		SPECIAL_CLOSE_LINK:
+			_link_session().close_link(_link_transport())
+			return _stage_frame_wait(
+				Gen2LinkSession.CLOSE_LINK_FRAMES,
+				{"special": special, "kind": &"link_wait"}
+			)
+		SPECIAL_WAIT_FOR_OTHER_PLAYER_TO_EXIT:
+			_link_session().wait_for_other_player_to_exit(_link_transport())
+			return _stage_frame_wait(
+				Gen2LinkSession.WAIT_FOR_OTHER_PLAYER_FRAMES,
+				{"special": special, "kind": &"link_wait"}
+			)
+		SPECIAL_CHECK_TIME_CAPSULE_COMPATIBILITY:
+			return _check_time_capsule_compatibility()
+		SPECIAL_ENTER_TIME_CAPSULE:
+			_link_session().enter_time_capsule(_link_transport())
+			return _stage_frame_wait(
+				Gen2LinkSession.ENTER_TIME_CAPSULE_FRAMES,
+				{"special": special, "kind": &"link_wait"}
+			)
+		SPECIAL_TRADE_CENTER, SPECIAL_COLOSSEUM, SPECIAL_TIME_CAPSULE:
+			return _stage_link_room(special)
+		SPECIAL_CHECK_MOBILE_ADAPTER_STATUS:
+			## `CheckMobileAdapterStatusSpecial` answers whether a Mobile Adapter
+			## GB is plugged in, and none is: there is no such peripheral on any
+			## platform this runs on. FALSE is what both Crystal receptionists
+			## branch on to reach `.NoMobile`, which is the cable club proper,
+			## so this is the answer that opens the room rather than the one that
+			## closes it.
+			_script_value = 0
+		SPECIAL_CABLE_CLUB_CHECK_WHICH_CHRIS:
+			_script_value = _link_session().which_chris(_link_transport())
+		SPECIAL_DISPLAY_LINK_RECORD:
+			## `_DisplayLinkRecord` draws `sLinkBattleStats` and holds for A or
+			## B. It writes nothing, so the script runs straight on behind it.
+			return _stage_runtime_request(&"link_record_requested", {"special": special})
 		SPECIAL_BATTLE_TOWER_ROOM_MENU:
 			return _stage_room_menu()
 		SPECIAL_LOAD_BATTLE_TOWER_OPPONENT:
@@ -4091,6 +4210,60 @@ func _resolve_room_menu(choice: int) -> Dictionary:
 ## no transaction between the receptionist and the section.
 func _battle_tower() -> Gen2BattleTower:
 	return state.battle_tower() if state != null else Gen2BattleTower.new()
+
+
+func _link_session() -> Gen2LinkSession:
+	return state.link_session() if state != null else Gen2LinkSession.new()
+
+
+func _link_transport() -> Gen2LinkTransport:
+	return state.link_transport() if state != null else Gen2LinkTransport.new()
+
+
+## `CheckTimeCapsuleCompatibility`. The three failures each name a party member
+## in wStringBuffer1 and the move failure names the move in front of it, which
+## is `GetMoveName` and `CopyName1` before `GetIncompatibleMonName`.
+func _check_time_capsule_compatibility() -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {
+			"ok": false, "reason": &"missing_party_summary",
+			"special": SPECIAL_CHECK_TIME_CAPSULE_COMPATIBILITY,
+		}
+	var verdict: Dictionary = Gen2LinkSession.time_capsule_compatibility(party)
+	_script_value = int(verdict["value"])
+	if _script_value == Gen2LinkSession.TIME_CAPSULE_OK:
+		return {"ok": true}
+	if _script_value == Gen2LinkSession.TIME_CAPSULE_MOVE_TOO_NEW and data != null:
+		_set_text_buffer(
+			RomLayout.STRING_BUFFER_1,
+			String(data.move(int(verdict["move"])).get("name", "")),
+			&"time_capsule_move", {"move": int(verdict["move"])}
+		)
+	var names: Array = party.get("names", [])
+	var slot: int = int(verdict["slot"])
+	if slot >= 0 and slot < names.size():
+		_set_text_buffer(
+			RomLayout.STRING_BUFFER_3, String(names[slot]), &"time_capsule_mon",
+			{"slot": slot, "species": int(verdict["species"])}
+		)
+	return {"ok": true}
+
+
+## `TradeCenter`, `Colosseum` and `TimeCapsule`, which are one routine each
+## around `LinkCommunications`: the room sets `wLinkMode` and then runs the
+## exchange the console in front of the player is for. The exchange itself is a
+## host request, because it is a party swap or a battle rather than anything the
+## script can settle.
+func _stage_link_room(special: int) -> Dictionary:
+	var session: Gen2LinkSession = _link_session()
+	session.open_room(LINK_ROOM_MODES[special])
+	return _stage_runtime_request(&"link_room_requested", {
+		"special": special,
+		"link_mode": session.link_mode,
+		"peer": session.peer.duplicate(true),
+		"connection": session.connection_status,
+	})
 
 
 ## The tower's own generator. `Random` is the cartridge's one RNG and this

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -298,6 +298,15 @@ var _blue_card_balance: int = 0
 ## battles. Never null; see [Gen2BattleTower].
 var _battle_tower: Gen2BattleTower = Gen2BattleTower.new()
 
+## `SECTION "Link Battle Data"`'s WRAM half and the cable behind it. Neither is
+## in [method to_dict]: the cartridge keeps none of `wLinkMode`,
+## `wChosenCableClubRoom` or the serial registers across a reset, and a transport
+## is injected by whoever owns the peer rather than saved with the world. A
+## slot loaded from disk therefore starts outside the cable club, which is the
+## truth about it.
+var _link_session: Gen2LinkSession = Gen2LinkSession.new()
+var _link_transport: Gen2LinkTransport = Gen2LinkTransport.new()
+
 
 func _init(
 	initial_event_flags: Dictionary = {}, initial_map_scenes: Dictionary = {},
@@ -616,6 +625,23 @@ func restore_from_dict(raw: Variant) -> void:
 ## no transaction between the receptionist and the section.
 func battle_tower() -> Gen2BattleTower:
 	return _battle_tower
+
+
+## The live link session, which callers edit in place the way they do the tower's
+## record: every write is one the cartridge would have made to WRAM straight
+## away.
+func link_session() -> Gen2LinkSession:
+	return _link_session
+
+
+func link_transport() -> Gen2LinkTransport:
+	return _link_transport
+
+
+## Injects the cable. A null transport is no cable at all, which is what the
+## receptionist's "your friend is not ready" answers.
+func set_link_transport(transport: Gen2LinkTransport) -> void:
+	_link_transport = transport if transport != null else Gen2LinkTransport.new()
 
 
 func maptile_decoration(category: StringName) -> int:

--- a/game/world/world_transaction.gd
+++ b/game/world/world_transaction.gd
@@ -97,6 +97,7 @@ static func copy_into(target: Gen2SaveData, source: Gen2SaveData) -> void:
 	target.boxes = source.boxes
 	target.current_box = source.current_box
 	target.hall_of_fame = source.hall_of_fame.duplicate(true)
+	target.link_record = source.link_record.duplicate(true)
 	target.box_names = source.box_names.duplicate()
 	target.mailbox = source.mailbox.duplicate()
 	target.world = source.world
@@ -109,6 +110,13 @@ static func copy_into(target: Gen2SaveData, source: Gen2SaveData) -> void:
 	## `game_time` is the one field the live save owns rather than the candidate:
 	## `Gen2WorldScreen._advance_game_time_frame` has been counting frames into it
 	## since the candidate was cloned, and copying the clone back loses them.
+	##
+	## This list is deliberately named field by field rather than delegated to
+	## [method Gen2SaveData.copy_from], which round-trips through `to_dict` and
+	## would rebuild every party member and renormalize the mod keys on every
+	## commit. `test_the_transaction_write_back_carries_every_field_but_the_live_clock`
+	## is what keeps the two lists in step: a field added to the save and
+	## forgotten here fails there.
 
 
 static func failure(reason: StringName, details: Dictionary) -> Dictionary:

--- a/tests/unit/test_link.gd
+++ b/tests/unit/test_link.gd
@@ -1,0 +1,315 @@
+extends GutTest
+
+## The cable club without a cartridge: the transport seam, the session's own
+## answers, and the trade transaction behind them.
+##
+## The real-cartridge counterpart is `tools/checks/link.gd`, which drives the
+## three receptionists on the real map. What is here is what a synthetic world
+## can settle: the rules, the record and the party swap.
+
+const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
+
+const SPECIES_ONE: int = BattleFixture.BULBASAUR
+const SPECIES_TWO: int = BattleFixture.CHARMANDER
+const TACKLE: int = BattleFixture.TACKLE
+
+var _data: GameData = null
+var _live_world: Gen2WorldAPI = null
+
+
+func before_each() -> void:
+	Gen2ModHost.reset()
+	Fixture.build()
+	_data = GameData.open_directory(Fixture.directory())
+	_live_world = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(2, 2), Gen2WorldState.new()
+	)
+
+
+func after_each() -> void:
+	Gen2ModHost.reset()
+	RomCache.clear(Fixture.directory())
+
+
+## A party member the save validator accepts: the development save's own row
+## with a species and an HP written over it, rather than a hand-built struct
+## with half its fields left at zero.
+func _mon(species: int, hp: int = 20, level: int = 5) -> Gen2SaveMon:
+	var mon: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(
+		Gen2BattleMon.create(_data, species, level, _data.moves_at_level(species, level))
+	)
+	mon.hp = hp
+	mon.original_trainer = "RED"
+	mon.ot_id = 1
+	return mon
+
+
+func _peer(room: int = Gen2LinkSession.CABLECLUBROOM_TRADECENTER) -> Gen2LinkTransport:
+	var transport := Gen2LinkTransport.new()
+	transport.peer = {
+		"name": "BLUE", "id": 4242, "gender": 0,
+		"generation": Gen2LinkTransport.GENERATION_2, "room": room,
+		"party": [_mon(SPECIES_TWO).to_dict()],
+	}
+	return transport
+
+
+## `WaitForLinkedFriend`'s `.done` branch, which is what one console always
+## reaches: no peer, no connection, and the receptionist's FALSE.
+func test_a_transport_with_no_peer_never_connects() -> void:
+	var session := Gen2LinkSession.new()
+	var transport := Gen2LinkTransport.new()
+	assert_false(transport.connected())
+	assert_eq(transport.status(), Gen2LinkTransport.CONNECTION_NOT_ESTABLISHED)
+	assert_eq(session.wait_for_linked_friend(transport), 0)
+	assert_eq(session.check_link_timeout(transport), 0)
+	assert_eq(session.link_mode, Gen2LinkSession.LINK_NULL)
+
+
+func test_a_peer_connects_as_the_internal_clock() -> void:
+	var session := Gen2LinkSession.new()
+	var transport: Gen2LinkTransport = _peer()
+	assert_eq(session.wait_for_linked_friend(transport), 1)
+	assert_eq(transport.status(), Gen2LinkTransport.USING_INTERNAL_CLOCK)
+	## `CableClubCheckWhichChris` answers TRUE for the external clock alone.
+	assert_eq(session.which_chris(transport), 0)
+
+
+## `CheckBothSelectedSameRoom`, whose `wLinkMode` is the room plus one.
+func test_agreeing_a_room_sets_the_link_mode_and_brings_the_peers_party_back() -> void:
+	var session := Gen2LinkSession.new()
+	var transport: Gen2LinkTransport = _peer()
+	session.request_room(Gen2LinkSession.CABLECLUBROOM_TRADECENTER)
+	assert_eq(session.check_both_selected_same_room(transport), 1)
+	assert_eq(session.link_mode, Gen2LinkSession.LINK_TRADECENTER)
+	assert_eq((session.peer.get("party", []) as Array).size(), 1)
+
+
+func test_a_peer_at_another_door_is_refused() -> void:
+	var session := Gen2LinkSession.new()
+	var transport: Gen2LinkTransport = _peer(Gen2LinkSession.CABLECLUBROOM_COLOSSEUM)
+	session.request_room(Gen2LinkSession.CABLECLUBROOM_TRADECENTER)
+	assert_eq(session.check_both_selected_same_room(transport), 0)
+	assert_eq(session.link_mode, Gen2LinkSession.LINK_NULL)
+
+
+## `readmem wOtherPlayerLinkMode` is zero for a Gen 1 game and nothing else,
+## which is both the "can't link to the past" branch and the Time Capsule's own
+## entry condition.
+func test_only_a_gen_1_peer_reads_as_the_past() -> void:
+	var session := Gen2LinkSession.new()
+	var modern: Gen2LinkTransport = _peer()
+	session.check_link_timeout(modern)
+	assert_ne(session.other_player_link_mode, 0)
+	var old: Gen2LinkTransport = _peer()
+	old.peer["generation"] = Gen2LinkTransport.GENERATION_1
+	session.check_link_timeout(old)
+	assert_eq(session.other_player_link_mode, 0)
+
+
+func test_leaving_the_receptionist_puts_the_serial_port_back() -> void:
+	var session := Gen2LinkSession.new()
+	var transport: Gen2LinkTransport = _peer()
+	session.request_room(Gen2LinkSession.CABLECLUBROOM_TRADECENTER)
+	session.wait_for_linked_friend(transport)
+	session.check_both_selected_same_room(transport)
+	session.wait_for_other_player_to_exit(transport)
+	assert_eq(session.link_mode, Gen2LinkSession.LINK_NULL)
+	assert_eq(session.connection_status, Gen2LinkSession.CONNECTION_NOT_ESTABLISHED)
+	assert_true(session.peer.is_empty())
+
+
+## `ValidateOTTrademon`: the party list's species has to match the struct's
+## unless the list says EGG, and no level may be above the cap.
+func test_an_offer_whose_species_disagrees_with_its_row_is_abnormal() -> void:
+	var mon: Dictionary = _mon(SPECIES_TWO).to_dict()
+	assert_true(Gen2LinkSession.validate_ot_trademon(
+		mon, SPECIES_TWO, false, Gen2LinkSession.LINK_TRADECENTER
+	))
+	assert_false(Gen2LinkSession.validate_ot_trademon(
+		mon, SPECIES_ONE, false, Gen2LinkSession.LINK_TRADECENTER
+	))
+	## An EGG row names no species, so the test is skipped rather than failed.
+	assert_true(Gen2LinkSession.validate_ot_trademon(
+		mon, SPECIES_ONE, true, Gen2LinkSession.LINK_TRADECENTER
+	))
+	var overlevelled: Dictionary = _mon(SPECIES_TWO, 20, 101).to_dict()
+	assert_false(Gen2LinkSession.validate_ot_trademon(
+		overlevelled, SPECIES_TWO, false, Gen2LinkSession.LINK_TRADECENTER
+	))
+
+
+## The Time Capsule's own type test, which only a Gen 1 peer supplies the
+## evidence for, and the two species it excuses by name.
+func test_the_time_capsule_refuses_a_species_this_generation_retyped() -> void:
+	var mon: Dictionary = _mon(SPECIES_TWO).to_dict()
+	mon["types"] = [0, 0]
+	assert_true(Gen2LinkSession.validate_ot_trademon(
+		mon, SPECIES_TWO, false, Gen2LinkSession.LINK_TIMECAPSULE, [0, 0]
+	))
+	assert_false(Gen2LinkSession.validate_ot_trademon(
+		mon, SPECIES_TWO, false, Gen2LinkSession.LINK_TIMECAPSULE, [0, 3]
+	))
+	var magnemite: Dictionary = _mon(Gen2LinkSession.TIME_CAPSULE_RETYPED_SPECIES[0]).to_dict()
+	magnemite["types"] = [0, 0]
+	assert_true(Gen2LinkSession.validate_ot_trademon(
+		magnemite, Gen2LinkSession.TIME_CAPSULE_RETYPED_SPECIES[0], false,
+		Gen2LinkSession.LINK_TIMECAPSULE, [0, 3]
+	))
+
+
+## `CheckAnyOtherAliveMonsForTrade`, which reads the incoming Pokemon as well as
+## the party left behind.
+func test_a_trade_that_would_leave_nothing_to_fight_with_is_refused() -> void:
+	var party: Array = [_mon(SPECIES_ONE).to_dict(), _mon(SPECIES_ONE, 0).to_dict()]
+	var healthy: Dictionary = _mon(SPECIES_TWO).to_dict()
+	var fainted: Dictionary = _mon(SPECIES_TWO, 0).to_dict()
+	assert_true(Gen2LinkSession.any_other_alive_mons_for_trade(party, 0, healthy))
+	assert_false(Gen2LinkSession.any_other_alive_mons_for_trade(party, 0, fainted))
+	## Trading the fainted slot leaves the healthy one behind.
+	assert_true(Gen2LinkSession.any_other_alive_mons_for_trade(party, 1, fainted))
+
+
+func test_the_time_capsule_runs_its_three_tests_in_the_routines_order() -> void:
+	var mail: int = Gen2HeldItem.MAIL_ITEMS[0]
+	assert_eq(
+		int(Gen2LinkSession.time_capsule_compatibility({
+			"species": [1, 4], "held_items": [0, 0], "moves": [[1], [1]],
+		})["value"]),
+		Gen2LinkSession.TIME_CAPSULE_OK
+	)
+	assert_eq(
+		int(Gen2LinkSession.time_capsule_compatibility({
+			"species": [1, 152], "held_items": [0, mail], "moves": [[1], [200]],
+		})["value"]),
+		Gen2LinkSession.TIME_CAPSULE_MON_TOO_NEW
+	)
+	assert_eq(
+		int(Gen2LinkSession.time_capsule_compatibility({
+			"species": [1, 4], "held_items": [0, mail], "moves": [[1], [200]],
+		})["value"]),
+		Gen2LinkSession.TIME_CAPSULE_MON_HAS_MAIL
+	)
+	assert_eq(
+		int(Gen2LinkSession.time_capsule_compatibility({
+			"species": [1, 4], "held_items": [0, 0], "moves": [[1], [200]],
+		})["value"]),
+		Gen2LinkSession.TIME_CAPSULE_MOVE_TOO_NEW
+	)
+
+
+## `AddLastLinkBattleToLinkRecord`, and `.CheckOverflow` behind it.
+func test_the_link_record_counts_totals_and_keeps_a_row_per_opponent() -> void:
+	var record: Dictionary = Gen2LinkSession.normalize_record({})
+	record = Gen2LinkSession.add_battle_to_record(record, {"name": "BLUE", "id": 1}, &"wins")
+	record = Gen2LinkSession.add_battle_to_record(record, {"name": "BLUE", "id": 1}, &"wins")
+	record = Gen2LinkSession.add_battle_to_record(record, {"name": "GREEN", "id": 2}, &"draws")
+	assert_eq(int(record["wins"]), 2)
+	assert_eq(int(record["draws"]), 1)
+	assert_eq(String((record["records"] as Array)[0].get("name", "")), "BLUE")
+	assert_eq(int((record["records"] as Array)[0].get("wins", 0)), 2)
+	var names: Array = []
+	for row: Dictionary in record["records"] as Array:
+		names.append(String(row.get("name", "")))
+	assert_true(names.has("GREEN"))
+
+
+func test_the_link_record_stops_at_its_cap() -> void:
+	var record: Dictionary = Gen2LinkSession.normalize_record({
+		"wins": Gen2LinkSession.MAX_LINK_RECORD,
+	})
+	record = Gen2LinkSession.add_battle_to_record(record, {"name": "BLUE", "id": 1}, &"wins")
+	assert_eq(int(record["wins"]), Gen2LinkSession.MAX_LINK_RECORD)
+
+
+## A slot written before link play reads as one that has never linked, the way
+## `mailbox` and `box_names` do.
+func test_a_save_without_a_link_record_reads_as_one_that_never_linked() -> void:
+	var save := Gen2SaveData.new()
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	assert_eq(int(restored.link_record["wins"]), 0)
+	assert_eq(
+		(restored.link_record["records"] as Array).size(),
+		Gen2LinkSession.NUM_LINK_BATTLE_RECORDS
+	)
+
+
+## `.do_trade`: `RemoveMonFromPartyOrBox` then `AddTempmonToParty`, so the
+## received Pokemon lands at the END of the party rather than in the slot the
+## given one left.
+func test_a_link_trade_appends_the_received_mon_and_removes_the_offered_one() -> void:
+	var world: Gen2WorldAPI = _world()
+	var save: Gen2SaveData = _save()
+	save.party = [_mon(SPECIES_ONE), _mon(SPECIES_ONE), _mon(SPECIES_ONE)]
+	save.party[1].nickname = "GIVEN"
+	var result: Dictionary = Gen2WorldPartyHost.commit_link_trade(
+		world, save, 1, _mon(SPECIES_TWO).to_dict(), {"name": "BLUE"}, false
+	)
+	assert_true(bool(result.get("ok", false)), String(result.get("reason", "")))
+	assert_eq(save.party.size(), 3)
+	assert_eq((save.party[2] as Gen2SaveMon).species, SPECIES_TWO)
+	for mon: Gen2SaveMon in save.party:
+		assert_ne(mon.nickname, "GIVEN")
+
+
+func test_a_link_trade_refuses_a_slot_that_is_not_in_the_party() -> void:
+	var world: Gen2WorldAPI = _world()
+	var save: Gen2SaveData = _save()
+	save.party = [_mon(SPECIES_ONE)]
+	var result: Dictionary = Gen2WorldPartyHost.commit_link_trade(
+		world, save, 3, _mon(SPECIES_TWO).to_dict(), {}, false
+	)
+	assert_false(bool(result.get("ok", false)))
+	assert_eq(StringName(result.get("reason", &"")), &"invalid_trade_slot")
+
+
+## The same refusal `CheckAnyOtherAliveMonsForTrade` makes, at the boundary that
+## writes: a caller that skipped the screen's own test must not get past it.
+func test_a_link_trade_refuses_to_leave_the_party_unable_to_fight() -> void:
+	var world: Gen2WorldAPI = _world()
+	var save: Gen2SaveData = _save()
+	save.party = [_mon(SPECIES_ONE)]
+	var result: Dictionary = Gen2WorldPartyHost.commit_link_trade(
+		world, save, 0, _mon(SPECIES_TWO, 0).to_dict(), {}, false
+	)
+	assert_false(bool(result.get("ok", false)))
+	assert_eq(StringName(result.get("reason", &"")), &"trade_would_leave_no_battler")
+
+
+func test_a_link_battle_writes_the_record_it_produced() -> void:
+	var world: Gen2WorldAPI = _world()
+	var save: Gen2SaveData = _save()
+	save.party = [_mon(SPECIES_ONE)]
+	var result: Dictionary = Gen2WorldPartyHost.record_link_battle(
+		world, save, {"name": "BLUE", "id": 7}, &"wins", false
+	)
+	assert_true(bool(result.get("ok", false)), String(result.get("reason", "")))
+	assert_eq(int(save.link_record["wins"]), 1)
+
+
+## A link battle is a whole-party exchange with no trainer class behind it,
+## which is `battle_tower`'s shape one caller further out.
+func test_a_link_battle_request_builds_the_peers_party() -> void:
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data,
+		{"kind": &"link_room_requested", "values": {
+			"kind": &"link_battle", "trainer_name": "BLUE",
+			"enemy_party": [_mon(SPECIES_TWO).to_dict()],
+		}},
+		Gen2WorldBattleAdapter.fallback_party(_data, SPECIES_ONE, 5, 1),
+		RandomNumberGenerator.new()
+	)
+	assert_true(bool(prepared.get("ok", false)), String(prepared.get("reason", "")))
+	assert_eq((prepared["enemy_party"] as Gen2Party).size(), 1)
+	assert_eq(int(prepared["trainer_class"]), 0)
+
+
+func _world() -> Gen2WorldAPI:
+	return _live_world
+
+
+func _save() -> Gen2SaveData:
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
+	save.world = _live_world.snapshot()
+	return save

--- a/tests/unit/test_link.gd.uid
+++ b/tests/unit/test_link.gd.uid
@@ -1,0 +1,1 @@
+uid://ty75n7b0tpg7

--- a/tools/checks/link.gd
+++ b/tools/checks/link.gd
@@ -1,0 +1,488 @@
+extends RefCounted
+
+## Sweeps link play against freshly imported real caches, all three cartridges.
+##
+## The class this exists to catch is a cable club that answers a question the
+## cartridge does not ask. Every one of the three receptionist scripts is the
+## same shape and none of them can be reached without a peer, so the two paths
+## that matter are the one a single console gets and the one a peer gets, and
+## both are driven here on the real map rather than asserted about the session.
+##
+## `LinkCommsBorderGFX` is checked as the two different things it is: seventy
+## tiles and a screen tilemap on Crystal, nine tiles and no tilemap on Gold and
+## Silver, which is the whole difference between the two trade screens.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- link
+
+## `newgroup CABLE_CLUB`, the same group and numbers in both pins.
+const CABLE_CLUB_GROUP: int = 20
+const POKECENTER_2F: int = 1
+const TRADE_CENTER: int = 2
+const COLOSSEUM: int = 3
+const TIME_CAPSULE: int = 4
+
+## `Pokecenter2F_MapEvents`' own object rows: the three receptionists stand one
+## cell above where the player talks to them.
+const TRADE_RECEPTIONIST_CELL: Vector2i = Vector2i(5, 3)
+const BATTLE_RECEPTIONIST_CELL: Vector2i = Vector2i(9, 3)
+const TIME_CAPSULE_RECEPTIONIST_CELL: Vector2i = Vector2i(13, 4)
+## `bg_event 7, 3, BGEVENT_READ, Pokecenter2FLinkRecordSign`.
+const LINK_RECORD_SIGN_CELL: Vector2i = Vector2i(7, 4)
+## `bg_event 4, 4, BGEVENT_RIGHT` in each room, which is read by facing right
+## from the cell to its left.
+const CONSOLE_CELL: Vector2i = Vector2i(3, 4)
+
+## `EVENT_GAVE_MYSTERY_EGG_TO_ELM`, which is what opens the trade and battle
+## rooms; the Time Capsule is gated on `EVENT_MET_BILL` being clear instead.
+const EVENT_GAVE_MYSTERY_EGG_TO_ELM: int = 31
+
+## How many script steps a receptionist path is given before it is called stuck.
+const STEP_CAP: int = 400
+
+## A party that passes every Time Capsule test: two Kanto species, no mail and
+## no move past `STRUGGLE`.
+const LEGAL_PARTY: Dictionary = {
+	"species": [1, 4], "held_items": [0, 0], "moves": [[1, 2], [3, 4]],
+	"names": ["ONE", "TWO"],
+}
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		_verify_border()
+		_verify_texts()
+		_verify_no_cable()
+		_verify_with_peer()
+		_verify_time_capsule_receptionist()
+		_verify_rooms()
+		_verify_record_sign()
+	)
+	_verify_compatibility()
+	_verify_record()
+
+
+## `LinkCommsBorderGFX` and the tilemaps behind it, which are the one part of
+## the trade screen the two cartridges do not share.
+func _verify_border() -> void:
+	var data: GameData = _r.data
+	if not _r.check(data.has_link_border(), "no trade screen border in the cache"):
+		return
+	var tiles: int = RomLayout.LINK_BORDER_TILES_CRYSTAL if _r.crystal \
+		else RomLayout.LINK_BORDER_TILES_GOLD_SILVER
+	_r.check(
+		data.link_border_indices().size() == tiles * Gen2Tiles.TILE_WIDTH \
+			* Gen2Tiles.TILE_HEIGHT,
+		"the border strip is not %d tiles" % tiles
+	)
+	var screen: PackedByteArray = data.link_border_tilemap("screen")
+	_r.check(
+		screen.is_empty() != _r.crystal,
+		"the cartridge %s a trade screen tilemap" % [
+			"carries" if not screen.is_empty() else "carries no",
+		]
+	)
+	if not _r.crystal:
+		return
+	_r.check(
+		screen.size() == RomLayout.LINK_TRADE_TILEMAP_BYTES,
+		"the screen tilemap is %d bytes" % screen.size()
+	)
+	for name: String in ["cable_top", "cable_bottom"]:
+		_r.check(
+			data.link_border_tilemap(name).size() == RomLayout.LINK_TRADE_CABLE_ROWS_BYTES,
+			"%s is %d bytes" % [name, data.link_border_tilemap(name).size()]
+		)
+	var page: Gen2LinkPage = Gen2LinkPage.from_data(data)
+	if not _r.check(page != null, "the trade page will not build"):
+		return
+	## The screen the player actually sees, drawn once: a page that draws nothing
+	## is a blank buffer, and the border alone fills more than a tenth of it.
+	var drawn: PackedByteArray = page.draw_trade({
+		"player": {"name": "RED", "species": ["ONE", "TWO"]},
+		"partner": {"name": "BLUE", "species": ["THREE"]},
+		"list": 0, "index": 0, "footer": -1, "confirm": -1,
+	})
+	var ink: int = 0
+	for value: int in drawn:
+		if value != 0:
+			ink += 1
+	_r.check(
+		ink > drawn.size() / 10,
+		"the trade screen drew %d of %d pixels" % [ink, drawn.size()]
+	)
+
+
+## The trade screen's three imported boxes, each by the words that identify it
+## and by the `text_ram` it names.
+func _verify_texts() -> void:
+	var data: GameData = _r.data
+	if not _r.check(data.has_special_text("link"), "no link text run in the cache"):
+		return
+	_r.check(
+		data.special_text("link", "cant_battle").contains("be able to battle"),
+		"cant_battle reads %s" % data.special_text("link", "cant_battle")
+	)
+	_r.check(
+		data.special_text("link", "abnormal_mon").contains("abnormal"),
+		"abnormal_mon reads %s" % data.special_text("link", "abnormal_mon")
+	)
+	var ask: String = data.special_text("link", "ask_trade")
+	_r.check(ask.begins_with("Trade "), "ask_trade reads %s" % ask)
+	var address: int = data.special_text_ram("trademon_nickname")
+	_r.check(
+		address > 0 and ask.contains("%s%04X>" % [Gen2TextStream.RAM_MARKER, address]),
+		"ask_trade does not name wBufferTrademonNickname (%04X)" % address
+	)
+
+
+## The path a single console gets, which is the only one a player without a
+## second save file can reach: `WaitForLinkedFriend` times out, the receptionist
+## says the friend is not ready, and the script ends where it stands.
+func _verify_no_cable() -> void:
+	var world: Gen2WorldAPI = _open_center(null)
+	if world == null:
+		return
+	var results: Array = _talk(world, TRADE_RECEPTIONIST_CELL)
+	## `yesorno` after `Text_TradeReceptionistIntro`.
+	if not _r.check(_offers_choice(results), "the trade receptionist asked nothing"):
+		return
+	results = world.choose_script_input(0)
+	results.append_array(_settle(world))
+	_r.check(
+		not world.script_busy(),
+		"the receptionist's script did not finish without a cable"
+	)
+	var session: Gen2LinkSession = world.state.link_session()
+	_r.check(
+		session.link_mode == Gen2LinkSession.LINK_NULL,
+		"a timed-out link left wLinkMode at %d" % session.link_mode
+	)
+	_r.check(
+		session.connection_status == Gen2LinkSession.CONNECTION_NOT_ESTABLISHED,
+		"a timed-out link left the serial port open"
+	)
+	## `Text_PleaseWait` is the box the timeout stands behind, and the one that
+	## follows it is `.FriendNotReady`'s, which the script prints and closes
+	## without a `waitbutton` of its own.
+	_r.check(
+		not _said(results, "Please wait").is_empty(),
+		"the receptionist did not print the waiting box"
+	)
+	_r.check(
+		world.pending_runtime_request().is_empty(),
+		"a timed-out link still opened %s" % [
+			world.pending_runtime_request().get("kind", &"none"),
+		]
+	)
+
+
+## The same path with a peer on the other end, which reaches the room: the save
+## prompt, the timeout check, the room agreement and the walk in.
+func _verify_with_peer() -> void:
+	var world: Gen2WorldAPI = _open_center(_peer(Gen2LinkSession.CABLECLUBROOM_TRADECENTER))
+	if world == null:
+		return
+	var results: Array = _talk(world, TRADE_RECEPTIONIST_CELL)
+	if not _r.check(_offers_choice(results), "the trade receptionist asked nothing"):
+		return
+	results = world.choose_script_input(0)
+	results.append_array(_settle(world))
+	## `Text_MustSaveGame`'s own yesorno.
+	if not _r.check(_offers_choice(results), "the receptionist did not offer to save"):
+		return
+	results = world.choose_script_input(0)
+	results.append_array(_settle(world))
+	var session: Gen2LinkSession = world.state.link_session()
+	_r.check(
+		session.chosen_room == Gen2LinkSession.CABLECLUBROOM_TRADECENTER,
+		"the trade receptionist chose room %d" % session.chosen_room
+	)
+	_r.check(
+		session.other_player_link_mode != 0,
+		"a Gen 2 peer was read as a Gen 1 game"
+	)
+	_r.check(
+		session.link_mode == Gen2LinkSession.LINK_TRADECENTER,
+		"the agreed room left wLinkMode at %d" % session.link_mode
+	)
+	_r.check(
+		not session.peer.is_empty(),
+		"the peer's own party never came back over the cable"
+	)
+	## The Colosseum's receptionist is the same script with the other room.
+	var battle_world: Gen2WorldAPI = _open_center(
+		_peer(Gen2LinkSession.CABLECLUBROOM_COLOSSEUM)
+	)
+	if battle_world == null:
+		return
+	var battle_results: Array = _talk(battle_world, BATTLE_RECEPTIONIST_CELL)
+	if not _r.check(
+		_offers_choice(battle_results), "the battle receptionist asked nothing"
+	):
+		return
+	battle_results = battle_world.choose_script_input(0)
+	battle_results.append_array(_settle(battle_world))
+	if _offers_choice(battle_results):
+		battle_results = battle_world.choose_script_input(0)
+		battle_results.append_array(_settle(battle_world))
+	_r.check(
+		battle_world.state.link_session().link_mode == Gen2LinkSession.LINK_COLOSSEUM,
+		"the battle receptionist agreed room %d" % \
+			battle_world.state.link_session().link_mode
+	)
+
+
+## The Time Capsule with a Gen 2 peer, which is the one room two of these
+## cartridges can never open: `SetBitsForTimeCapsuleRequest` asks for
+## `CABLECLUBROOM_NULL` and `readmem wOtherPlayerLinkMode` is non-zero for a
+## Gen 2 game, so the script takes `CheckBothSelectedSameRoom` and the
+## incompatible-rooms box.
+func _verify_time_capsule_receptionist() -> void:
+	var world: Gen2WorldAPI = _open_center(
+		_peer(Gen2LinkSession.CABLECLUBROOM_NULL)
+	)
+	if world == null:
+		return
+	var results: Array = _talk(world, TIME_CAPSULE_RECEPTIONIST_CELL)
+	if not _r.check(_offers_choice(results), "the Time Capsule receptionist asked nothing"):
+		return
+	results = world.choose_script_input(0)
+	results.append_array(_settle(world))
+	if _offers_choice(results):
+		results = world.choose_script_input(0)
+		results.append_array(_settle(world))
+	_r.check(
+		world.state.link_session().link_mode != Gen2LinkSession.LINK_TIMECAPSULE,
+		"a Gen 2 peer was let into the Time Capsule"
+	)
+
+
+## The three rooms: `CableClubCheckWhichChris` decides which friend is standing
+## there and the console runs the exchange the room is for.
+func _verify_rooms() -> void:
+	for room: Array in [
+		[TRADE_CENTER, Gen2LinkSession.LINK_TRADECENTER],
+		[COLOSSEUM, Gen2LinkSession.LINK_COLOSSEUM],
+		[TIME_CAPSULE, Gen2LinkSession.LINK_TIMECAPSULE],
+	]:
+		var state := Gen2WorldState.new()
+		state.set_link_transport(_peer(Gen2LinkSession.CABLECLUBROOM_TRADECENTER))
+		var world: Gen2WorldAPI = _r.open_world(
+			CABLE_CLUB_GROUP, int(room[0]), CONSOLE_CELL, state
+		)
+		if world == null:
+			continue
+		_settle_results(world, world.dispatch_map_entry())
+		## `MAPCALLBACK_OBJECTS` runs `CableClubCheckWhichChris`, which is the
+		## internal clock's side here: the player who opened the receptionist
+		## holds it, so the friend on the left is the one shown.
+		_r.check(
+			state.link_session().which_chris(state.link_transport()) == 0,
+			"room %d put the wrong friend on screen" % int(room[0])
+		)
+		world.player_facing = Gen2WorldSprite.FACING_RIGHT
+		var results: Array = world.interact()
+		results.append_array(_settle(world))
+		var request: Dictionary = world.pending_runtime_request()
+		if not _r.check(
+			StringName(request.get("kind", &"")) == &"link_room_requested",
+			"room %d's console staged %s" % [
+				int(room[0]), request.get("kind", &"none"),
+			]
+		):
+			continue
+		_r.check(
+			int((request.get("values", {}) as Dictionary).get("link_mode", 0)) == int(room[1]),
+			"room %d opened link mode %d" % [
+				int(room[0]),
+				int((request.get("values", {}) as Dictionary).get("link_mode", 0)),
+			]
+		)
+
+
+## `Pokecenter2FLinkRecordSign`, which is one `special DisplayLinkRecord` and
+## nothing else: it writes no state and the script runs on behind it.
+func _verify_record_sign() -> void:
+	var world: Gen2WorldAPI = _open_center(null)
+	if world == null:
+		return
+	world.player_cell = LINK_RECORD_SIGN_CELL
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	## Not settled: `DisplayLinkRecord` is the request itself, and answering it
+	## is what would take it off the pending slot before it could be read.
+	world.interact()
+	var request: Dictionary = world.pending_runtime_request()
+	_r.check(
+		StringName(request.get("kind", &"")) == &"link_record_requested",
+		"the link record sign staged %s" % request.get("kind", &"none")
+	)
+
+
+## `CheckTimeCapsuleCompatibility`'s four answers, each on a party that fails
+## exactly one of its three tests and in the order the routine runs them.
+func _verify_compatibility() -> void:
+	var cases: Array = [
+		[LEGAL_PARTY, Gen2LinkSession.TIME_CAPSULE_OK, -1],
+		[{
+			"species": [1, 152], "held_items": [0, 0], "moves": [[1], [1]],
+		}, Gen2LinkSession.TIME_CAPSULE_MON_TOO_NEW, 1],
+		[{
+			"species": [1, 4], "held_items": [0, Gen2HeldItem.MAIL_ITEMS[0]],
+			"moves": [[1], [1]],
+		}, Gen2LinkSession.TIME_CAPSULE_MON_HAS_MAIL, 1],
+		[{
+			"species": [1, 4], "held_items": [0, 0], "moves": [[1], [166]],
+		}, Gen2LinkSession.TIME_CAPSULE_MOVE_TOO_NEW, 1],
+	]
+	for row: Array in cases:
+		var verdict: Dictionary = Gen2LinkSession.time_capsule_compatibility(row[0])
+		_r.check(
+			int(verdict["value"]) == int(row[1]),
+			"a party expecting answer %d got %d" % [int(row[1]), int(verdict["value"])]
+		)
+		_r.check(
+			int(verdict["slot"]) == int(row[2]),
+			"answer %d named slot %d rather than %d" % [
+				int(row[1]), int(verdict["slot"]), int(row[2]),
+			]
+		)
+	## The species test runs before the mail test, so a party that fails both is
+	## refused for the species.
+	var both: Dictionary = Gen2LinkSession.time_capsule_compatibility({
+		"species": [152], "held_items": [Gen2HeldItem.MAIL_ITEMS[0]], "moves": [[1]],
+	})
+	_r.check(
+		int(both["value"]) == Gen2LinkSession.TIME_CAPSULE_MON_TOO_NEW,
+		"the three tests do not run in the routine's order"
+	)
+
+
+## `AddLastLinkBattleToLinkRecord`: the totals, an opponent's own row, and the
+## cap neither carries past.
+func _verify_record() -> void:
+	var record: Dictionary = Gen2LinkSession.normalize_record({})
+	_r.check(
+		(record["records"] as Array).size() == Gen2LinkSession.NUM_LINK_BATTLE_RECORDS,
+		"an empty record does not carry its five rows"
+	)
+	var opponent: Dictionary = {"name": "BLUE", "id": 1234}
+	for _win: int in 3:
+		record = Gen2LinkSession.add_battle_to_record(record, opponent, &"wins")
+	record = Gen2LinkSession.add_battle_to_record(record, opponent, &"losses")
+	_r.check(int(record["wins"]) == 3, "three wins counted as %d" % int(record["wins"]))
+	_r.check(int(record["losses"]) == 1, "one loss counted as %d" % int(record["losses"]))
+	var row: Dictionary = (record["records"] as Array)[0]
+	_r.check(
+		String(row.get("name", "")) == "BLUE" and int(row.get("wins", 0)) == 3,
+		"the opponent's own row reads %s" % [row]
+	)
+	## A second opponent takes a row of its own rather than the first one's.
+	record = Gen2LinkSession.add_battle_to_record(
+		record, {"name": "GREEN", "id": 9}, &"wins"
+	)
+	var names: Array = []
+	for entry: Dictionary in record["records"] as Array:
+		names.append(String(entry.get("name", "")))
+	_r.check(
+		names.has("BLUE") and names.has("GREEN"),
+		"two opponents did not both keep a row: %s" % [names]
+	)
+	## `.CheckOverflow`, which stops rather than wrapping.
+	var capped: Dictionary = Gen2LinkSession.normalize_record({
+		"wins": Gen2LinkSession.MAX_LINK_RECORD,
+	})
+	capped = Gen2LinkSession.add_battle_to_record(capped, opponent, &"wins")
+	_r.check(
+		int(capped["wins"]) == Gen2LinkSession.MAX_LINK_RECORD,
+		"the win counter passed its cap"
+	)
+
+
+func _peer(room: int) -> Gen2LinkTransport:
+	var transport := Gen2LinkTransport.new()
+	transport.peer = {
+		"name": "BLUE", "id": 4242, "gender": 0,
+		"generation": Gen2LinkTransport.GENERATION_2,
+		"room": room,
+		"party": [{"species": 1, "level": 5, "hp": 20, "moves": [1, 0, 0, 0]}],
+	}
+	return transport
+
+
+func _open_center(transport: Gen2LinkTransport) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	state.apply_changes({EVENT_GAVE_MYSTERY_EGG_TO_ELM: true}, {}, {})
+	state.set_link_transport(transport)
+	var world: Gen2WorldAPI = _r.open_world(
+		CABLE_CLUB_GROUP, POKECENTER_2F, TRADE_RECEPTIONIST_CELL, state
+	)
+	if world == null:
+		return null
+	world.set_party_summary(
+		2, false, [1, 4] as Array[int], LEGAL_PARTY["moves"], LEGAL_PARTY["names"],
+		[false, false], {"held_items": [0, 0], "levels": [5, 5]}
+	)
+	return world
+
+
+func _talk(world: Gen2WorldAPI, cell: Vector2i) -> Array:
+	world.player_cell = cell
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var results: Array = world.interact()
+	results.append_array(_settle(world))
+	return results
+
+
+## Answers everything the script asks for that is not a choice, the way the
+## screen answers it: the frames a link routine spends, the quick save it asks
+## to write, and the movements between the receptionist and the door.
+func _settle(world: Gen2WorldAPI) -> Array:
+	var out: Array = []
+	for _step: int in STEP_CAP:
+		if _offers_choice_pending(world):
+			return out
+		var request: Dictionary = world.pending_runtime_request()
+		if not request.is_empty():
+			if StringName(request.get("kind", &"")) == &"link_room_requested":
+				return out
+			out.append_array(world.complete_runtime_request({"ok": true}))
+			continue
+		if not world.pending_script_wait().is_empty():
+			out.append_array(world.advance_script_presentation_frame())
+			continue
+		if not world.script_busy():
+			return out
+		out.append_array(world.run_event_queue(true, -1))
+	_r.fail("a link script ran past %d steps" % STEP_CAP)
+	return out
+
+
+func _settle_results(world: Gen2WorldAPI, results: Array) -> Array:
+	results.append_array(_settle(world))
+	return results
+
+
+func _offers_choice_pending(world: Gen2WorldAPI) -> bool:
+	var pending: Dictionary = world.pending_script_input()
+	return StringName(pending.get("type", &"")) in [&"choice", &"menu"]
+
+
+func _offers_choice(results: Array) -> bool:
+	for result: Dictionary in results:
+		var event: Dictionary = result.get("event", {})
+		if StringName(event.get("type", &"")) in [&"choice", &"menu"]:
+			return true
+	return false
+
+
+## The first box in [param results] carrying [param words], or the empty string.
+func _said(results: Array, words: String) -> String:
+	for result: Dictionary in results:
+		var event: Dictionary = result.get("event", {})
+		var text: String = String(event.get("text", ""))
+		if text.contains(words):
+			return text
+	return ""

--- a/tools/checks/link.gd.uid
+++ b/tools/checks/link.gd.uid
@@ -1,0 +1,1 @@
+uid://ctw4ihg1lilw8

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -23,23 +23,18 @@ extends RefCounted
 ## in both directions: an index here that the runner now handles fails, so the
 ## row is deleted with the work rather than left behind.
 const EXPECTED_DEFERRED: Dictionary = {
-	## HANDOFF's "Deliberately deferred": link play, the Mobile Adapter GB and
-	## Mystery Gift. None of the three has a peer to talk to on a modern
-	## platform. The Battle Tower's own seven rows have left this list.
-	1: "SetBitsForLinkTradeRequest", 2: "WaitForLinkedFriend",
-	3: "CheckLinkTimeout_Receptionist",
-	5: "CheckBothSelectedSameRoom", 6: "FailedLinkToPast", 7: "CloseLink",
-	8: "WaitForOtherPlayerToExit", 9: "SetBitsForBattleRequest",
-	10: "SetBitsForTimeCapsuleRequest", 11: "CheckTimeCapsuleCompatibility",
-	12: "EnterTimeCapsule", 13: "TradeCenter", 14: "Colosseum", 15: "TimeCapsule",
-	16: "CableClubCheckWhichChris", 17: "CheckMysteryGift",
-	18: "GetMysteryGiftItem", 19: "UnlockMysteryGift", 88: "DisplayLinkRecord",
+	## The Mobile Adapter GB and Mystery Gift, neither of which has a peer to
+	## talk to on a modern platform. The cable club's own sixteen rows have left
+	## this list with the Battle Tower's seven, and so has `DisplayLinkRecord`,
+	## which sat in the link block without being link play.
+	17: "CheckMysteryGift",
+	18: "GetMysteryGiftItem", 19: "UnlockMysteryGift",
 	125: "GiveOddEgg",
 	127: "Function1011f1", 128: "Function101220", 129: "Function101225",
 	130: "Function101231", 139: "BattleTowerMobileError",
 	140: "AskMobileOrCable", 154: "Mobile_SelectThreeMons",
 	155: "Function1037eb", 156: "Function10383c", 159: "Function1037c2",
-	160: "CheckMobileAdapterStatusSpecial", 161: "Function103780",
+	161: "Function103780",
 	162: "Function10387b", 163: "AskRememberPassword",
 
 	## Screens and facilities with no routine here yet. Each is its own piece of
@@ -79,6 +74,8 @@ const CRYSTAL_ONLY_TEXT_RUNS: Array[String] = ["poke_seer", "buena_prize", "batt
 const SPECIAL_TEXT_RAM_NAMES: Array[String] = [
 	"magikarp_record_holder", "seer_nickname", "seer_caught_location",
 	"seer_time_of_day", "seer_ot", "seer_caught_level",
+	## `wBufferTrademonNickname`, which `_LinkAskTradeForText` names.
+	"trademon_nickname",
 ]
 
 const SPECIALS_POINTERS_SIZE: int = 169

--- a/tools/preview_link.gd
+++ b/tools/preview_link.gd
@@ -1,0 +1,123 @@
+extends SceneTree
+
+## Captures the cable club's two screens against a real imported cache.
+##
+##   Godot --headless --path . -s res://tools/preview_link.gd -- <game> <out.png> [screen]
+##
+## [screen] is `trade`, `wait`, `confirm`, `record` or `all` for a contact sheet
+## of every one. `all` is the default.
+##
+## The trade screen is the one page whose picture differs between the two
+## cartridges for a reason rather than by accident: Crystal lays it out from
+## `MobileTradeBorderTilemap` and Gold and Silver draw two `LinkTextboxAtHL`
+## boxes on an empty screen, so the same call on the three caches is the whole
+## comparison.
+##
+## Composed into an [Image] rather than through a window, so this runs headless
+## and needs no settling frames.
+
+const COLUMNS: int = 2
+const SCREENS: Array[String] = ["wait", "trade", "confirm", "record"]
+
+## A pair of parties long enough that both lists reach the cursor rows, with the
+## partner's one shorter so the two halves are told apart in the picture.
+const PLAYER_PARTY: Array[String] = [
+	"CHIKORITA", "TOTODILE", "CYNDAQUIL", "PIDGEY", "RATTATA", "SENTRET",
+]
+const PARTNER_PARTY: Array[String] = ["BULBASAUR", "SQUIRTLE", "CHARMANDER"]
+const PLAYER_NAME: String = "GOLD"
+const PARTNER_NAME: String = "KRIS"
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_link.gd -- <game> <output.png> [screen|all]")
+		quit(1)
+		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+	var page: Gen2LinkPage = Gen2LinkPage.from_data(data)
+	if page == null:
+		push_error("The %s cache carries no trade screen border." % args[0])
+		quit(1)
+		return
+
+	var wanted: String = args[2] if args.size() > 2 else "all"
+	var screens: Array[String] = SCREENS.duplicate() if wanted == "all" \
+		else ([wanted] as Array[String])
+	var columns: int = mini(COLUMNS, screens.size())
+	@warning_ignore("integer_division")
+	var rows: int = (screens.size() + columns - 1) / columns
+	var sheet: Image = Image.create_empty(
+		columns * Gen2Screen.WIDTH, rows * Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	for index: int in screens.size():
+		var tile: Image = page.image(_draw(page, screens[index]))
+		@warning_ignore("integer_division")
+		sheet.blit_rect(tile, Rect2i(Vector2i.ZERO, tile.get_size()), Vector2i(
+			(index % columns) * Gen2Screen.WIDTH, (index / columns) * Gen2Screen.HEIGHT
+		))
+	if sheet.save_png(args[1]) != OK:
+		push_error("Could not write %s" % args[1])
+		quit(1)
+		return
+	print("Wrote %s (%dx%d), %d screens, %s border." % [
+		args[1], sheet.get_width(), sheet.get_height(), screens.size(),
+		"tilemap" if page.has_screen_tilemap() else "textbox",
+	])
+	quit(0)
+
+
+func _draw(page: Gen2LinkPage, screen: String) -> PackedByteArray:
+	match screen:
+		"wait":
+			return page.draw_please_wait()
+		"record":
+			return page.draw_record(_record(), PLAYER_NAME)
+		"confirm":
+			return page.draw_trade(_trade_state({
+				"partner_choice": 1,
+				"confirm": 0,
+				"message": ["Trade CHIKORITA", "for SQUIRTLE?"],
+			}))
+		_:
+			return page.draw_trade(_trade_state({"footer": Gen2LinkScreen.FOOTER_TRADE}))
+
+
+func _trade_state(extra: Dictionary) -> Dictionary:
+	var state: Dictionary = {
+		"player": {"name": PLAYER_NAME, "species": PLAYER_PARTY.duplicate()},
+		"partner": {"name": PARTNER_NAME, "species": PARTNER_PARTY.duplicate()},
+		"list": Gen2LinkScreen.LIST_PLAYER,
+		"index": 0,
+		"cancel": false,
+		"partner_choice": -1,
+		"footer": -1,
+		"confirm": -1,
+		"message": [],
+		"waiting": false,
+	}
+	for key: Variant in extra:
+		state[key] = extra[key]
+	return state
+
+
+## A record with two opponents in it and three rows still empty, which is what
+## `_DisplayLinkRecord` prints its dashes for.
+func _record() -> Dictionary:
+	var record: Dictionary = Gen2LinkSession.normalize_record({})
+	for _win: int in 12:
+		record = Gen2LinkSession.add_battle_to_record(
+			record, {"name": PARTNER_NAME, "id": 4242}, &"wins"
+		)
+	record = Gen2LinkSession.add_battle_to_record(
+		record, {"name": "SILVER", "id": 7}, &"losses"
+	)
+	return record

--- a/tools/preview_link.gd.uid
+++ b/tools/preview_link.gd.uid
@@ -1,0 +1,1 @@
+uid://c0esuqd68h1la


### PR DESCRIPTION
There is no cable on a modern machine, so the transport is this project's own.
`Gen2LinkTransport` is the three operations `engine/link/link.asm` reaches the
other Game Boy through: the connection status, one exchanged nybble, and one
exchanged block. Nothing above it knows what it is made of.

A transport with no peer is the default, and it is a real game path rather than
a stub. The receptionist says your friend is not ready, which is what a single
Game Boy has always been told. The peer that exists today is the player's own
other save slot, read once per slot.

## What runs

- The three receptionists on POKECENTER_2F, end to end: the welcome, the save
  before the room, the timeout check, the room agreement and the walk in.
- The Trade Center's two-list trade screen, the STATS/TRADE footer, the confirm
  box, and the swap behind it. The received Pokemon lands at the end of the
  party, not in the slot the given one left, and `wForceEvolution` over that
  append is what makes a trade evolution happen.
- The Colosseum's link battle against the peer's own party, and
  `AddLastLinkBattleToLinkRecord` on the way out.
- `DisplayLinkRecord`, the sign between the three receptionists.

The Time Capsule needs a Gen 1 peer and correctly refuses a Gen 2 one:
`SetBitsForTimeCapsuleRequest` asks for `CABLECLUBROOM_NULL`, so its script
reaches the incompatible-rooms box. That is the cartridge's own answer.
`CheckTimeCapsuleCompatibility`'s three party tests are built and swept anyway,
since the receptionist runs them before the link is opened.

## What this cost to read

- `wOtherPlayerLinkMode` is `$cf51` on Crystal and `$ce51` on Gold and Silver.
  The three receptionist `readmem`s are what pin it. Writing Crystal's on Gold
  reads back zero, which is the "can't link to the past" branch, so every Gold
  player would have been told their friend was a Gen 1 game.
- `CheckMobileAdapterStatusSpecial` had to be answered rather than deferred.
  Both Crystal receptionists ask it before anything else, so a script that
  cannot answer it stops in front of the whole room. There is no adapter, and
  FALSE is the branch that opens the cable club.
- The two cartridges draw the trade screen from very different amounts of data.
  Crystal loads seventy tiles of `LinkCommsBorderGFX` and lays a whole screen
  down from `MobileTradeBorderTilemap`; Gold and Silver load nine at `$76` and
  draw two boxes. Cache format 88 carries both.

## Numbers

| Check | Before | After |
|---|---|---|
| Rows in `EXPECTED_DEFERRED` | 36 | 19 |
| `validate.gd -- all` topics | 72 | 73 |
| Unit tests | 3217 | 3235 |
| Scene tier | 3728 | 3746 |
| `replay_world.gd` routes | 33, 0 failures | 33, 0 failures |

`tools/checks/link.gd` drives both receptionist paths, the three rooms and the
record sign on all three cartridges. `tools/preview_link.gd` is the picture.

## One bug met on the way

`Gen2WorldTransaction.copy_into` names its fields one by one, and it dropped the
new save field silently: the trade wrote to disk and never to the live save.
`test_the_transaction_write_back_carries_every_field_but_the_live_clock` exists
for exactly that and caught it. The list is deliberately not delegated to
`copy_from`, which round-trips through `to_dict` on every commit; that test is
the seam instead.
