### PR TITLE
Every wild rolls its own DVs, and a shiny is drawn shiny

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 16 for [the shiny seam](#how-many-times-a-wilds-dvs-are-rolled), [an item gift](#asking-the-host-to-hand-an-item-over) and [reading the bag](#reading-the-bag), 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -1411,6 +1411,76 @@ entry, the host runs it.
   world can spend it rather than dropped.
 
 Which cell to name is the mod's own business.
+
+## Asking the host to hand an item over
+
+`Gen2ModHost.request_item_gift(item, quantity)` is `request_hidden_item`'s twin
+for an item **no map gives** (`api_version` 16). The mod names an item and reads
+nothing back; on the next world frame nothing else owns, the host runs
+`verbosegiveitem`'s own transaction: the bag write, the fanfare, the received
+line, the pocket line and the pack-full branch.
+
+Everything on that list is world state a mod must not write, and the box, the
+sound and the pacing are a screen it cannot see. The queue behaves exactly as a
+hidden item's does, and for the same reasons: one spent per frame, an ask made
+inside a battle, a text box, a warp or an overlay spent when the world can spend
+it rather than dropped, and the rest waiting in order. An item number the
+cartridge does not know does nothing.
+
+Use it where the mod can **see** the moment but the script has no give site in
+it: `special Diploma` reaches the world channel as a `diploma_requested` runtime
+request, and the designer's script is `writetext`, `special Diploma`, `setevent`
+with nothing to patch. `patch_check` changes the number an existing site hands
+out; this is for when there is no site.
+
+## Reading the bag
+
+`Gen2ModHost.inventory()` answers the live world's own `{item: quantity}`, the
+same copy a Repel provider is handed, and `{}` when no world is open
+(`api_version` 16). Read only, and a copy.
+
+One narrow accessor rather than a handle on `Gen2WorldAPI`, because a
+non-renderer mod is deliberately given no world: "do I hold this key item" is a
+question every gameplay mod has and the whole world is not the answer to it.
+
+## How many times a wild's DVs are rolled
+
+Every wild the game builds rolls its own DVs, off the battle's own generator, the
+way `LoadEnemyMon` does: shininess, a bad stat and which Hidden Power it answers
+are all facts about those four numbers. `register_shiny_rolls(id, provider)` says
+how many words one wild is drawn with, which is the later games' charm
+(`api_version` 16):
+
+```gdscript
+class Held:
+	func shiny_rolls(context: Dictionary) -> int:
+		return 3 if int(Gen2ModHost.instance().inventory().get(SHINY_CHARM, 0)) > 0 else 1
+```
+
+The host draws up to that many, keeps the first that `Gen2Stats.is_shiny`
+accepts and otherwise keeps the last, and clamps to
+`Gen2ModHost.MAX_SHINY_ROLLS`. 0 and 1 both mean the cartridge's own single
+roll, which is also what an unregistered host does.
+
+| `context` key | Meaning |
+|---|---|
+| `species` | What is about to be built |
+| `level` | Its level, already chosen |
+| `method` | The encounter method, empty for a wild with no method behind it |
+| `map_group`, `map_number` | Where, or -1 apiece |
+
+It carries no bag: `inventory()` is the live one, and a snapshot per wild would
+be a staler answer than the mod can get for itself.
+
+Three wilds keep an answer of their own and no provider is asked: one whose
+request already carries `dvs`, which is the Pokemon a visible encounter's player
+walked up to; `BATTLETYPE_FORCESHINY`, which is the red Gyarados and is written
+rather than rolled; and a roaming Pokemon, which keeps its stored word. A wild
+UNOWN rerolls until its letter is one the Ruins of Alph puzzle has unlocked.
+
+**Two providers compose by the largest answer**, rather than by registration
+order: two charms have an obvious join, and refusing the second by name would
+make installing both an error over a number.
 
 ## An alternate field-move source
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1313,6 +1313,11 @@ func send_out(
 		"species": current.active_mon().species, "level": current.active_mon().level,
 		"hp": current.active_mon().hp, "max_hp": current.active_mon().max_hp(),
 		"unown_form": unown_form_of(current.active_mon()),
+		## `BattleCheckPlayerShininess`/`BattleCheckEnemyShininess` again, which
+		## is what `CGB_BattleColors` picks the pic's palette with: the same
+		## reading [method entrance_events] takes the sparkle from, so the gold
+		## sweep and the colours under it can never disagree.
+		"shiny": Gen2Stats.is_shiny(current.active_mon().dvs),
 		"line": send_out_line(side),
 	})
 	(_participants[side] as Dictionary)[index] = true

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -162,8 +162,9 @@ func _draw_pics() -> void:
 	var map_key: PackedByteArray = map.duplicate()
 
 	var enemy: int = int(_view.get("enemy_species", 0))
+	var enemy_shiny: bool = bool(_view.get("enemy_shiny", false))
 	var enemy_palette: PackedColorArray = _battler_palette(
-		enemy, Gen2BattleAnimBackground.PAL_BG_ENEMY
+		enemy, Gen2BattleAnimBackground.PAL_BG_ENEMY, enemy_shiny
 	)
 	# `GetFrontpicPalettePointer` reads `wTrainerClass` rather than a species
 	# when the square is holding a trainer, which it is until that trainer has
@@ -189,8 +190,9 @@ func _draw_pics() -> void:
 			enemy_palette
 		)
 	var player: int = int(_view.get("player_species", 0))
+	var player_shiny: bool = bool(_view.get("player_shiny", false))
 	var player_palette: PackedColorArray = _battler_palette(
-		player, Gen2BattleAnimBackground.PAL_BG_PLAYER
+		player, Gen2BattleAnimBackground.PAL_BG_PLAYER, player_shiny
 	)
 	# `GetPlayerOrMonPalettePointer`'s `and a / jp nz`: a zero species is the
 	# player standing there, and the palette is the player's own.
@@ -499,11 +501,15 @@ static func _append_animation(
 
 ## A battler pic's own palette, permuted by whatever DMG byte the animation's
 ## last `BattleAnimRequestPals` left on that palette slot.
-func _battler_palette(species: int, slot: int) -> PackedColorArray:
+##
+## `CGB_BattleColors` reads `CheckShininess` on both sides, so the shiny palette
+## is the picture's for the whole fight and not just the gold sweep the entrance
+## plays over it.
+func _battler_palette(species: int, slot: int, shiny: bool) -> PackedColorArray:
 	var grayscale: PackedColorArray = _grayscale()
 	if not grayscale.is_empty():
 		return grayscale
-	return _remap(_data.palette(species), _palette_map("bg_palette_maps", slot))
+	return _remap(_data.palette(species, shiny), _palette_map("bg_palette_maps", slot))
 
 
 ## `_CGB_BattleGrayscale`'s palette while the view says the battle is still in

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -382,6 +382,8 @@ var _player: int = 1
 ## Drawn values like the two above: they follow the events rather than the party.
 var _enemy_unown_form: int = 0
 var _player_unown_form: int = 0
+var _enemy_shiny: bool = false
+var _player_shiny: bool = false
 var _enemy_level: int = 5
 var _player_level: int = 5
 var _enemy_hp: int = 0
@@ -947,8 +949,17 @@ func start_world_battle(
 		badge_mask = save.world.world_state.badge_mask(crystal)
 	if badge_mask < 0:
 		badge_mask = 0
+	## `wUnlockedUnowns`, which `CheckUnownLetter` gates a rolled wild Unown's
+	## letter on. Stamped here because the adapter is scene-free and this is the
+	## one path that has the save; a request without it takes whatever it rolled.
+	var stamped: Dictionary = request.duplicate(true)
+	if save != null and save.world != null and save.world.world_state != null:
+		var stamped_values: Variant = stamped.get("values", stamped)
+		if stamped_values is Dictionary:
+			(stamped_values as Dictionary)["unlocked_unowns"] = \
+				save.world.world_state.unlocked_unowns(crystal)
 	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
-		_data, request, player_party, _rng, badge_mask, _injected_rules
+		_data, stamped, player_party, _rng, badge_mask, _injected_rules
 	)
 	if not bool(prepared.get("ok", false)):
 		_emit_world_battle_failure(
@@ -1158,6 +1169,8 @@ func _init_battle_display() -> void:
 	## the same way the species above do; every later change is a send-out.
 	_enemy_unown_form = Gen2Battle.unown_form_of(_battle.enemy)
 	_player_unown_form = Gen2Battle.unown_form_of(_battle.player)
+	_enemy_shiny = Gen2Stats.is_shiny(_battle.enemy.dvs)
+	_player_shiny = Gen2Stats.is_shiny(_battle.player.dvs)
 	_close_switch()
 	_clear_level_up_box()
 	_reseed_bg_map()
@@ -4166,11 +4179,13 @@ func _apply_event_state(event: Dictionary) -> void:
 				enemy_seen.emit(int(event["species"]))
 				_enemy = int(event["species"])
 				_enemy_unown_form = int(event.get("unown_form", 0))
+				_enemy_shiny = bool(event.get("shiny", false))
 				_enemy_level = int(event["level"])
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				_player = int(event["species"])
 				_player_unown_form = int(event.get("unown_form", 0))
+				_player_shiny = bool(event.get("shiny", false))
 				_player_level = int(event["level"])
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
 			# A send-out draws a picture through `GetBattleMonBackpic` or
@@ -4944,6 +4959,8 @@ func _push_view() -> void:
 		"enemy_species": _enemy, "player_species": _player,
 		"enemy_unown_form": _enemy_unown_form,
 		"player_unown_form": _player_unown_form,
+		"enemy_shiny": _enemy_shiny,
+		"player_shiny": _player_shiny,
 		## Whose picture is the substitute's doll rather than the Pokémon's own.
 		"enemy_substitute": bool(_substitute_pic[Gen2Battle.ENEMY]),
 		"player_substitute": bool(_substitute_pic[Gen2Battle.PLAYER]),

--- a/game/battle/stats.gd
+++ b/game/battle/stats.gd
@@ -49,6 +49,11 @@ const DV_SPECIAL_SHIFT: int = 0
 ## [method is_shiny].
 const SHINY_ATK_MASK: int = 0b0010
 const SHINY_DV: int = 10
+## `ATKDEFDV_SHINY` and `SPDSPCDV_SHINY` as one word: 14/10/10/10, which is
+## what `BATTLETYPE_FORCESHINY` writes instead of rolling, and is the red
+## Gyarados. Any Attack DV [constant SHINY_ATK_MASK] accepts would do; this is
+## the pair the source picked.
+const SHINY_DVS: int = 0xEAAA
 
 
 ## The cartridge's square root: the first entry of a table of squares not

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -157,6 +157,13 @@ const FIELD_MOVE_SOURCE_METHODS: Array[String] = ["allows_field_move"]
 const REPEL_PROVIDER_METHODS: Array[String] = ["repel_to_use"]
 const CATCH_EXPERIENCE_METHODS: Array[String] = ["awards_catch_experience"]
 const BATTLE_INFO_METHODS: Array[String] = ["annotate_battle"]
+const SHINY_ROLLS_METHODS: Array[String] = ["shiny_rolls"]
+
+## The most DV words the host will draw for one wild, whatever a provider asks
+## for. A roll is cheap, but the count is a mod's number and the ceiling is the
+## host's: the odds are 1 in 8192 a word, so this is already a shiny about one
+## wild in eight.
+const MAX_SHINY_ROLLS: int = 1024
 
 ## Pocket type numbers 1 to 4 are the cartridge's ITEM, KEY_ITEM, BALL and TM_HM,
 ## so a registered pocket has to claim a number above them, the same reservation
@@ -215,6 +222,13 @@ var _world_actors: Dictionary = {}
 ## Cells a mod asked the host to pick a hidden item up from. See
 ## [method request_hidden_item].
 var _hidden_item_requests: Array[Vector2i] = []
+## `{item, quantity}` a mod asked the host to hand over. See
+## [method request_item_gift].
+var _item_gift_requests: Array[Dictionary] = []
+## What [method inventory] reads the live bag through, set by the world screen
+## while a world is open. A Callable rather than a handle on [Gen2WorldAPI]: a
+## mod is given the copy and never the world.
+var _inventory_source: Callable = Callable()
 ## Mod id to the visible-encounter provider it registered, held the way an actor
 ## is. See [method register_visible_encounters].
 var _visible_encounters: Dictionary = {}
@@ -224,6 +238,7 @@ var _field_move_sources: Dictionary = {}
 var _repel_renewals: Dictionary = {}
 var _catch_experience: Dictionary = {}
 var _battle_info: Dictionary = {}
+var _shiny_rolls: Dictionary = {}
 var _battle_renderers: Dictionary = {}
 ## The one id the player's view is chosen by, read from [Gen2ModState] when the
 ## host is built and written back whenever it changes. It is a bare id and may
@@ -363,6 +378,60 @@ func requeue_hidden_items(cells: Array[Vector2i]) -> void:
 	_hidden_item_requests = cells + _hidden_item_requests
 
 
+## Asks the world screen to hand [param item] over, [param quantity] of it,
+## through `verbosegiveitem`'s own transaction: the bag write, the fanfare, the
+## received line, the pocket line and the pack-full branch. A REQUEST and never
+## the act, for the reason [method request_hidden_item] is one, and answering
+## nothing for the same reason: a mod names an item and the host runs the screen.
+##
+## Queued the way a hidden item's ask is, so one made inside a battle, a text
+## box, a warp or an overlay is spent on the first world frame nothing else owns
+## rather than dropped. An item number the cartridge does not know is refused
+## when the queue is spent, not here.
+##
+## Unlike a hidden item there is no cell, no event flag and no map: this is the
+## give a script would have made, from a mod that has no script.
+func request_item_gift(item: int, quantity: int = 1) -> void:
+	if item <= 0 or quantity <= 0:
+		return
+	_item_gift_requests.append({"item": item, "quantity": quantity})
+
+
+## Drained by [Gen2WorldScreen], once, on the frame it spends them.
+func take_item_gift_requests() -> Array[Dictionary]:
+	var out: Array[Dictionary] = _item_gift_requests
+	_item_gift_requests = []
+	return out
+
+
+## What a drain could not spend this frame, put back in front of anything asked
+## for since. See [method requeue_hidden_items].
+func requeue_item_gifts(gifts: Array[Dictionary]) -> void:
+	if gifts.is_empty():
+		return
+	_item_gift_requests = gifts + _item_gift_requests
+
+
+## Where [method inventory] reads from while a world is open, set by
+## [Gen2WorldScreen] and cleared when it closes. An empty Callable is the honest
+## default: the launcher and every screen that is not the world have no bag.
+func set_inventory_source(source: Callable) -> void:
+	_inventory_source = source
+
+
+## The live world's own `{item: quantity}`, the copy a
+## [method register_repel_renewal] provider is handed, and empty when no world is
+## open. Read only, and a copy: writing the bag is the host's.
+##
+## One narrow accessor rather than a handle on [Gen2WorldAPI], because a
+## non-renderer mod is deliberately given no world at all.
+func inventory() -> Dictionary:
+	if not _inventory_source.is_valid():
+		return {}
+	var bag: Variant = _inventory_source.call()
+	return (bag as Dictionary).duplicate(true) if bag is Dictionary else {}
+
+
 func world_actor_ids() -> Array:
 	return _world_actors.keys()
 
@@ -482,14 +551,55 @@ func repel_renewal_ids() -> Array:
 	return _repel_renewals.keys()
 
 
-## The item the first provider to answer would spend, or 0. [param inventory] is
-## copied per provider, so answering cannot change what the next one is asked.
-func repel_renewal_item(inventory: Dictionary) -> int:
+## The item the first provider to answer would spend, or 0. [param bag] is copied
+## per provider, so answering cannot change what the next one is asked. Named for
+## what it holds rather than for [method inventory], which is a mod's own read of
+## the same thing and would shadow this parameter.
+func repel_renewal_item(bag: Dictionary) -> int:
 	for provider: Object in _repel_renewals.values():
-		var item: int = int(provider.call("repel_to_use", inventory.duplicate(true)))
+		var item: int = int(provider.call("repel_to_use", bag.duplicate(true)))
 		if item > 0:
 			return item
 	return 0
+
+
+## Registers a SHINY ROLLS provider under [param id]: how many DV words the host
+## draws for one wild before it settles, which is the later games' charm.
+##
+## [param provider] answers [constant SHINY_ROLLS_METHODS]' `shiny_rolls(context)`
+## with a whole number. The host draws up to that many words off the battle's own
+## generator, keeps the first [method Gen2Stats.is_shiny] accepts and otherwise
+## keeps the last, and clamps to [constant MAX_SHINY_ROLLS]. 0 and 1 both mean
+## the cartridge's own single roll, which is also what an unregistered host does.
+##
+## [param context] carries `species`, `level`, `method`, `map_group` and
+## `map_number`, so an answer may vary by encounter. It does not carry the bag:
+## [method inventory] is what a mod asks the bag with, and asking it here would
+## give a provider one snapshot per wild rather than the live one.
+##
+## Two providers COMPOSE BY THE LARGEST ANSWER rather than by registration order,
+## which is what [method shiny_roll_count] takes. Refusing the second by name
+## would make two charms an install error over a number that has an obvious
+## join; a mod that wants fewer rolls than another mod asked for is asking for
+## something the host cannot honestly give both of.
+func register_shiny_rolls(id: StringName, provider: Object) -> Dictionary:
+	return _register_provider(_shiny_rolls, SHINY_ROLLS_METHODS, id, provider)
+
+
+func shiny_rolls_ids() -> Array:
+	return _shiny_rolls.keys()
+
+
+## The largest count any provider asks for, clamped, or 1 when none does. Static
+## and null-safe the way [method allows_item_field_move] is: it is read where a
+## wild is built, which runs with no host in a test and in every tool.
+static func shiny_roll_count(context: Dictionary) -> int:
+	if _instance == null:
+		return 1
+	var rolls: int = 1
+	for provider: Object in _instance._shiny_rolls.values():
+		rolls = maxi(rolls, int(provider.call("shiny_rolls", context.duplicate(true))))
+	return clampi(rolls, 1, MAX_SHINY_ROLLS)
 
 
 ## Registers a CATCH EXPERIENCE policy for [param manifest]'s own run: whether a

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -58,7 +58,15 @@ const FILENAME: String = "mod.json"
 ## is the same shape in the other direction: a mod may send one to a host that
 ## drops it and the Pokemon simply does not glow, which is why `api_version` 15
 ## is only needed by a mod that requires the mark to appear.
-const API_VERSION: int = 15
+##
+## 16 is the shiny seam, three registrations a mod that changes what comes out of
+## the grass needs: [method Gen2ModHost.register_shiny_rolls], the count of DV
+## words one wild is drawn with; [method Gen2ModHost.request_item_gift], which is
+## [method Gen2ModHost.request_hidden_item]'s twin for an item no map gives; and
+## [method Gen2ModHost.inventory], the live bag a non-renderer mod otherwise has
+## no way to read. Only the first two are contract: a mod may feature-detect the
+## bag but not a roll it never sees taken.
+const API_VERSION: int = 16
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2234,6 +2234,13 @@ func encounter_request(
 			"lead_level": lead_level,
 			"map_music": state.map_music(),
 			"cleanse_tag": cleanse_tag,
+			## `ChooseWildEncounter`'s own `ld a, [wUnlockedUnowns] / and a`, and
+			## the guard that keeps `CheckUnownLetter`'s reroll answerable: on a
+			## save that has solved no Ruins of Alph puzzle there is no letter to
+			## give an Unown, so the step finds nothing rather than a Pokemon.
+			"unlocked_unowns": state.unlocked_unowns(
+				Gen2WorldState.is_crystal_profile(data)
+			),
 		}
 	)
 	if resolved.is_empty():
@@ -4016,12 +4023,13 @@ func _script_address_for_event(event: Dictionary) -> int:
 
 
 func _enqueue_script(request: Dictionary) -> void:
-	## A field-move prompt is the one queued request with no address of its own:
-	## the source reaches its Ask*Script through CallScript on a link-time
-	## address the pins do not resolve, so the runner synthesizes the body from
-	## the request kind the way it does for an item ball.
+	## The two queued requests with no address of their own, both of which the
+	## runner synthesizes a body for the way it does for an item ball: a
+	## field-move prompt, whose Ask*Script the source reaches through CallScript
+	## on a link-time address the pins do not resolve, and a mod's item gift,
+	## which no script anywhere makes.
 	if int(request.get("script", 0)) <= 0 \
-		and StringName(request.get("kind", &"")) != &"field_move_prompt":
+		and StringName(request.get("kind", &"")) not in [&"field_move_prompt", &"item_gift"]:
 		return
 	if not request.has("collision"):
 		var cell_value: Variant = request.get("cell", player_cell)
@@ -6287,6 +6295,32 @@ func take_hidden_item(cell: Vector2i) -> Array:
 		_enqueue_script(request)
 		return run_event_queue(false)
 	return []
+
+
+## `verbosegiveitem`'s own transaction for [param item], queued and run through
+## the ordinary script path, so the bag write, the save, the received line, the
+## fanfare and the pack-full branch are all the host's exactly as they are for a
+## give the map makes. Answers the script results [method take_hidden_item] does,
+## and an empty array when the item is not one the cartridge knows or when a
+## script is already running.
+##
+## There is no cell, no event flag and no map behind it: this is the give a mod
+## asked for through [method Gen2ModHost.request_item_gift], and the mod named
+## the item and nothing else.
+func give_item_gift(item: int, quantity: int = 1) -> Array:
+	if current_map == null or _active_script != null or not _script_queue.is_empty():
+		return []
+	if item <= 0 or data == null or data.item_name(item).is_empty():
+		return []
+	_enqueue_script({
+		"kind": &"item_gift",
+		"map_group": current_map.group,
+		"map_number": current_map.number,
+		"bank": int(current_map.events.get("bank", 0)),
+		"item": item,
+		"quantity": maxi(1, quantity),
+	})
+	return run_event_queue(false)
 
 
 func hidden_item_nearby() -> bool:

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -31,6 +31,15 @@ static func prepare(
 	var enemy_party: Gen2Party = null
 	var trainer_class: int = 0
 	var trainer_index: int = 0
+	# wBattleType, which a `loadvar VAR_BATTLETYPE` before `startbattle` sets.
+	# Read before the party is built, since `LoadEnemyMon` branches a wild's DVs
+	# on it. Running is the only other thing that reads it so far, and four of
+	# its values are what make Celebi, Suicune and the Rocket trap battles
+	# inescapable.
+	var battle_type: int = int(values.get("battle_type", Gen2Battle.BATTLETYPE_NORMAL))
+	# `BattleRandom`, so a wild's DVs come out of the run's own sequence and a
+	# replay of the same seed meets the same Pokemon.
+	var generator := random if random != null else RandomNumberGenerator.new()
 
 	match kind:
 		&"wild":
@@ -40,12 +49,9 @@ static func prepare(
 				return _failure(&"invalid_wild_species", {"species": species})
 			if level < 1 or level > Gen2Experience.MAX_LEVEL:
 				return _failure(&"invalid_wild_level", {"level": level})
-			# `LoadEnemyMon` rolls `wEnemyMonDVs` unless the caller already has
-			# them; a visible encounter chose its own before the player met it,
-			# and shininess is a fact about those four numbers alone.
 			var wild_mon: Gen2BattleMon = Gen2BattleMon.create(
 				data, species, level, data.moves_at_level(species, level),
-				int(values.get("dvs", Gen2BattleMon.PERFECT_DVS))
+				wild_dvs(values, battle_type, species, generator)
 			)
 			# LoadEnemyMon's .TreeMon branch: a headbutt encounter whose species
 			# is in CheckSleepingTreeMon's list for the current time of day
@@ -84,17 +90,13 @@ static func prepare(
 
 	if enemy_party == null or enemy_party.is_wiped():
 		return _failure(&"missing_enemy_party")
-	var generator := random if random != null else RandomNumberGenerator.new()
 	var battle: Gen2Battle = Gen2Battle.create_parties(
 		data, player_party, enemy_party, generator,
 		kind in [&"trainer", &"battle_tower", &"link_battle"], player_badges, battle_rules
 	)
 	if battle == null:
 		return _failure(&"battle_setup_failed")
-	# wBattleType, which a `loadvar VAR_BATTLETYPE` before `startbattle` sets.
-	# Running is the only thing that reads it so far, and four of its values are
-	# what make Celebi, Suicune and the Rocket trap battles inescapable.
-	battle.battle_type = int(values.get("battle_type", Gen2Battle.BATTLETYPE_NORMAL))
+	battle.battle_type = battle_type
 
 	return {
 		"ok": true,
@@ -106,6 +108,79 @@ static func prepare(
 		"trainer_index": trainer_index,
 		"trainer_battle": kind == &"trainer",
 	}
+
+
+## `LoadEnemyMon`'s `.InitDVs` for a wild, which is the whole of what decides
+## whether the Pokemon in the grass is shiny, has a bad stat or answers a
+## different Hidden Power. Every wild reached this with 15/15/15/15 before,
+## because only the visible-encounter provider ever put `dvs` in the request and
+## the other eight sources (grass, surf, fishing, Headbutt, Rock Smash, the Bug
+## Contest, a static `loadwildmon`, a roamer) carried none.
+##
+## Rolled here rather than in each of those callers: this is the one place a
+## wild is built, and [param generator] is the battle's own, so an encounter
+## stays inside the run's reproducible sequence.
+##
+## Three cases keep an answer of their own, in the source's order:
+##
+## - a request already carrying `dvs` keeps it, which is what leaves the
+##   Pokemon a player walked up to the one they saw, and is also `.Roaming`'s
+##   stored word once the roamer's struct has been initialised;
+## - [constant Gen2Battle.BATTLETYPE_FORCESHINY] writes
+##   [constant Gen2Stats.SHINY_DVS] rather than rolling. This is the red
+##   Gyarados, which nothing read the type for until now;
+## - a wild UNOWN rerolls until its letter is one the Ruins of Alph puzzle has
+##   unlocked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`. The source
+##   notes the loop never ends if a forced shiny is also an Unown, so the shiny
+##   branch stays in front of it here the way it is there.
+static func wild_dvs(
+	values: Dictionary, battle_type: int, species: int, generator: RandomNumberGenerator
+) -> int:
+	if values.has("dvs"):
+		return int(values["dvs"])
+	if battle_type == Gen2Battle.BATTLETYPE_FORCESHINY:
+		return Gen2Stats.SHINY_DVS
+	var rolls: int = Gen2ModHost.shiny_roll_count({
+		"species": species,
+		"level": int(values.get("level", 0)),
+		"method": StringName(values.get("method", &"")),
+		"map_group": int(values.get("map_group", -1)),
+		"map_number": int(values.get("map_number", -1)),
+	})
+	## -1 is what an unstamped request means, and is every caller that is not the
+	## world screen: no gate, which is how a preview tool or a test keeps the
+	## letter it rolled.
+	var unlocked: int = int(values.get("unlocked_unowns", -1))
+	var word: int = _roll_dvs(generator, species, unlocked)
+	## The charm's extra rolls sit past the source, which takes one: the first
+	## shiny is kept and otherwise the last stands, so 0 and 1 are both vanilla.
+	for _extra: int in maxi(0, rolls - 1):
+		if Gen2Stats.is_shiny(word):
+			break
+		word = _roll_dvs(generator, species, unlocked)
+	return word
+
+
+## Two `BattleRandom` bytes, high byte first, rerolled while the letter they give
+## a wild Unown is locked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`.
+##
+## Unbounded the way the source's is, and safe for the same reason: the mask is
+## narrowed to the four real sets first, and every one of them holds letters, so
+## any mask left standing is one a roll reaches. A mask of nothing is the save
+## that has solved no puzzle, and there the gate is dropped rather than looped
+## on: `ChooseWildEncounter` refuses a wild Unown outright on that save, so a
+## caller reaching here with one has already left the cartridge's own path.
+static func _roll_dvs(
+	generator: RandomNumberGenerator, species: int, unlocked_unowns: int
+) -> int:
+	var gated: bool = species == RomLayout.UNOWN_SPECIES and unlocked_unowns > 0
+	var mask: int = unlocked_unowns & ((1 << Gen2WorldState.UNOWN_LETTER_SETS.size()) - 1)
+	while true:
+		var word: int = (generator.randi_range(0, 255) << 8) | generator.randi_range(0, 255)
+		if not gated or mask == 0 \
+			or Gen2WorldState.unown_letter_unlocked(Gen2Stats.unown_letter(word), mask):
+			return word
+	return 0
 
 
 ## `PlayBattleMusic`'s track, off the request alone.

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -86,6 +86,12 @@ static func resolve(
 	var level: int = int((selected as Dictionary).get("level", 0))
 	if species < 1 or species > RomLayout.SPECIES_COUNT or level < 1 or level > RomLayout.MAX_LEVEL:
 		return {}
+	## `ChooseWildEncounter`'s last test, after `ValidateTempWildMonSpecies` and
+	## on the drawn slot rather than the table: a wild UNOWN is refused outright
+	## while `wUnlockedUnowns` is zero, which is every save before the first
+	## Ruins of Alph puzzle. The step finds nothing; it does not draw again.
+	if species == RomLayout.UNOWN_SPECIES and int(options.get("unlocked_unowns", -1)) == 0:
+		return {}
 
 	var level_roll: int = -1
 	if method == METHOD_SURF:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -500,6 +500,10 @@ func _build_world() -> void:
 	## time of day resolves to.
 	_encounters = Gen2WorldEncounters.new()
 	_encounters.set_providers(Gen2ModHost.instance().visible_encounter_providers())
+	## What [method Gen2ModHost.inventory] reads while this world is open. Bound
+	## here rather than handed the world, so a mod is given the copy and never a
+	## way to write the bag.
+	Gen2ModHost.instance().set_inventory_source(_mod_inventory)
 	_encounters.set_world(_world, anim_data)
 	_actors.set_encounters(_encounters)
 	var rods: Array[StringName] = _world.available_fishing_rods()
@@ -855,6 +859,7 @@ func advance_frame() -> void:
 		_renderer.refresh()
 	_spend_actor_requests()
 	_spend_hidden_item_requests()
+	_spend_item_gift_requests()
 	if map_pass and _objects_may_move() \
 		and _world.advance_object_steps_pass(_object_random) \
 		and _renderer != null:
@@ -7283,6 +7288,33 @@ func _spend_actor_requests() -> void:
 	for request: Dictionary in _actors.take_requests():
 		if StringName(request["kind"]) == Gen2WorldActors.REQUEST_CRY:
 			_play_species_cry(int(request["species"]))
+
+
+func _mod_inventory() -> Dictionary:
+	return _world.state.items() if _world != null else {}
+
+
+## A mod's item-gift asks, spent the way its hidden-item asks are and on the same
+## gate: `verbosegiveitem`'s own transaction through the ordinary script path, so
+## the fanfare, the box and the pacing are the world screen's exactly as they are
+## for a give the map itself makes.
+##
+## One per frame, since the first one's box owns the world until it is pressed
+## past, and the rest wait in the host's queue.
+func _spend_item_gift_requests() -> void:
+	if _world == null or not _world_idle_for_mod_request():
+		return
+	var gifts: Array[Dictionary] = Gen2ModHost.instance().take_item_gift_requests()
+	for index: int in gifts.size():
+		var results: Array = _world.give_item_gift(
+			int(gifts[index].get("item", 0)), int(gifts[index].get("quantity", 1))
+		)
+		if results.is_empty():
+			continue
+		_zero_map_name_sign_timer()
+		_show_script_results(results)
+		Gen2ModHost.instance().requeue_item_gifts(gifts.slice(index + 1))
+		return
 
 
 ## A mod's hidden-item asks, spent on the first world frame nothing else owns.

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -452,6 +452,9 @@ const HEADBUTT_ASK_TEXT: String = \
 ## `end` frame still has to sit in the CPU's switchable window for _push_frame,
 ## so it is put at its base; nothing ever reads the address back.
 const FIELD_MOVE_PROMPT_FRAME: int = RomFile.BANK_SIZE
+## A mod's item gift has no source address either, and for a stronger reason: no
+## script anywhere gives that item. Shares the base for the reason above.
+const ITEM_GIFT_FRAME: int = RomFile.BANK_SIZE
 ## data/text/common_2.asm's _FoundItemText, less its <PLAYER>; see
 ## _stage_item_ball(). The source line break sits before the item name.
 const FOUND_ITEM_TEXT: String = "Found\n%s!"
@@ -681,6 +684,16 @@ static func begin(
 		)
 		if started:
 			runner._stage_field_move_prompt()
+	elif StringName(request.get("kind", &"")) == &"item_gift":
+		## A mod's ask through [method Gen2ModHost.request_item_gift]. There is
+		## no script behind it at all, not even two bytes of data, so the frame
+		## is the same bare `end` an item ball's is and the staging call is
+		## `verbosegiveitem` with nothing in front of it.
+		started = runner._push_frame(bank, ITEM_GIFT_FRAME, PackedByteArray([
+			Gen2WorldScript.raw_opcode(Gen2WorldScript.GOLD_END, runner._crystal_commands())
+		]))
+		if started:
+			runner._stage_item_gift()
 	elif StringName(request.get("kind", &"")) in [&"item_ball", &"hidden_item"]:
 		## Neither pointer is code, so the frame that stands in for it is a bare
 		## `end` and the staging call replays FindItemInBallScript or
@@ -5491,6 +5504,25 @@ func _stage_pocket_is_full(item: int, finish_after: bool) -> Dictionary:
 	return _stage_internal_text(
 		POCKET_FULL_TEXT % Gen2WorldPack.source_pocket_name(data, item), finish_after
 	)
+
+
+## `Script_verbosegiveitem` with no script around it, which is what a mod's ask
+## through [method Gen2ModHost.request_item_gift] is: the same STRING_BUFFER_4
+## fill, the same bag write and the same GiveItemScript tail the 0x9D command
+## runs, finishing after the last box rather than resuming a caller, since there
+## is no caller.
+func _stage_item_gift() -> Dictionary:
+	var item: int = int(_request.get("item", 0))
+	var item_name: String = data.item_name(item) if data != null else ""
+	if item <= 0 or item_name.is_empty():
+		return _fail(&"invalid_item_gift", {"item": item})
+	_set_text_buffer(
+		RomLayout.STRING_BUFFER_4, item_name, &"item_name", {"item": item}
+	)
+	var given: Dictionary = _stage_item_delta(item, maxi(1, int(_request.get("quantity", 1))))
+	if not bool(given.get("ok", true)):
+		return given
+	return _stage_give_item_script(item, item_name)
 
 
 ## `GiveItemScript`, which is the whole of `verbosegiveitem` past the receive:

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -49,6 +49,18 @@ const ENGINE_UNOWN_DEX: int = 12
 ## The one entry pokegold does not ship, and so the index every profile split in
 ## this table is measured from. See engine_flag().
 const ENGINE_MOBILE_SYSTEM: int = 16
+## `wUnlockedUnowns`, one engine flag per puzzle: the four `UnlockedUnownLetterSets`
+## in source order, A-K first. `CheckUnownLetter` refuses a letter no unlocked set
+## holds, and `ChooseWildEncounter` refuses a wild UNOWN outright while none is
+## set. Crystal indices; engine_flag() moves them for Gold and Silver.
+const ENGINE_UNLOCKED_UNOWNS_FIRST: int = 43
+## The letters each set holds, 1 being A, in the order the table names them.
+const UNOWN_LETTER_SETS: Array = [
+	[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+	[12, 13, 14, 15, 16, 17, 18],
+	[19, 20, 21, 22, 23],
+	[24, 25, 26],
+]
 ## The three wPokegearFlags/wStatusFlags bits the radio card reads
 ## (data/events/engine_flags.asm). Only the last is profile split, since it sits
 ## in the wStatusFlags2 run after Crystal's extra entry.
@@ -730,6 +742,32 @@ func hall_of_fame() -> bool:
 
 func set_hall_of_fame(active: bool = true) -> void:
 	set_engine_flag(ENGINE_HALL_OF_FAME, active)
+
+
+## The `wUnlockedUnowns` byte this save holds, one bit per set, as
+## `CheckUnownLetter` and `ChooseWildEncounter` read it.
+func unlocked_unowns(crystal: bool = true) -> int:
+	var mask: int = 0
+	for set_index: int in UNOWN_LETTER_SETS.size():
+		if is_engine_flag_active(
+			engine_flag(ENGINE_UNLOCKED_UNOWNS_FIRST + set_index, crystal)
+		):
+			mask |= 1 << set_index
+	return mask
+
+
+## `CheckUnownLetter`: whether [param letter] (1 being A) is in any set
+## [param unlocked] has the bit for. A negative mask is no gate at all, which is
+## what a caller with no save behind it passes.
+static func unown_letter_unlocked(letter: int, unlocked: int) -> bool:
+	if unlocked < 0:
+		return true
+	for set_index: int in UNOWN_LETTER_SETS.size():
+		if (unlocked & (1 << set_index)) == 0:
+			continue
+		if letter in (UNOWN_LETTER_SETS[set_index] as Array):
+			return true
+	return false
 
 
 ## `crystal` selects which game's engine flag table this state's raw flag

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -474,6 +474,10 @@ func _play_differently(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
 	## The step an active Repel runs out on. The mod picks the weakest item it
 	## owns; the prompt, the bag and the encounter ordering are the host's.
 	host.register_repel_renewal(manifest.id, RepelRenewal.new())
+	## How many DV words one wild is drawn with, which is the later games' charm.
+	## The count is the mod's; the roll, the generator and the ceiling are the
+	## host's, so an encounter stays inside the run's reproducible sequence.
+	host.register_shiny_rolls(manifest.id, ShinyRolls.new())
 	## Experience for a successful capture. Save bound, so the manifest
 	## `register` was handed is the capability rather than the id.
 	host.register_catch_experience(manifest, CatchExperience.new())
@@ -514,6 +518,19 @@ class RepelRenewal:
 			if int(inventory.get(item, 0)) > 0:
 				return item
 		return 0
+
+
+## How many words a wild's DVs are drawn from. 1 is the cartridge's own roll.
+class ShinyRolls:
+	extends RefCounted
+
+	## The charm's own item number, read from the LIVE bag rather than from a
+	## snapshot the context could carry: a mod that was handed the bag per wild
+	## would answer for a bag one encounter out of date.
+	const SHINY_CHARM: int = 0x19
+
+	func shiny_rolls(_context: Dictionary) -> int:
+		return 3 if int(Gen2ModHost.instance().inventory().get(SHINY_CHARM, 0)) > 0 else 1
 
 
 ## Read on every throw rather than once, so a switch the player turns off

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 15,
+	"api_version": 16,
 	"entry": "mod.gd",
-	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the five read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, battle annotations and a start-menu row that opens the host's own storage."
+	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 15,
+	"api_version": 16,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -393,6 +393,30 @@ func test_the_shipped_example_mod_registers_everything_it_documents() -> void:
 	assert_true(Gen2ModHost.allows_item_field_move(Gen2WorldFieldMove.MOVE_FLY))
 	assert_true(Gen2ModHost.awards_catch_experience())
 	assert_eq(host.repel_renewal_item({0x2B: 1}), 0x2B, "the only one owned")
+	## 16: how many DV words one wild is drawn with, and the bag the provider
+	## reads the charm out of. No world is open here, so the bag is empty and the
+	## example answers the cartridge's own single roll.
+	assert_eq(host.shiny_rolls_ids().size(), 1)
+	assert_eq(host.inventory(), {}, "no world open")
+	assert_eq(Gen2ModHost.shiny_roll_count({"species": 25}), 1, "the charm is not held")
+	host.set_inventory_source(Callable(self, "_charmed_bag"))
+	assert_eq(host.inventory(), {0x19: 1})
+	assert_eq(Gen2ModHost.shiny_roll_count({"species": 25}), 3, "held")
+	host.set_inventory_source(Callable())
+	## 16: an item gift, queued rather than answered the way a hidden item's ask
+	## is, and drained in order.
+	host.request_item_gift(0x19, 2)
+	host.request_item_gift(0x14)
+	host.request_item_gift(0, 1)
+	var gifts: Array[Dictionary] = host.take_item_gift_requests()
+	assert_eq(gifts, [{"item": 0x19, "quantity": 2}, {"item": 0x14, "quantity": 1}])
+	assert_eq(host.take_item_gift_requests(), [], "the drain empties the queue")
+	host.request_item_gift(0x2B)
+	host.requeue_item_gifts(gifts)
+	var order: Array = []
+	for gift: Dictionary in host.take_item_gift_requests():
+		order.append(int(gift["item"]))
+	assert_eq(order, [0x19, 0x14, 0x2B], "what could not be spent goes back in front")
 	## A start-menu row naming a host action, gated on the host's own party test
 	## after the mod's predicate.
 	assert_eq(host.start_menu_entries({"party_count": 0}).size(), 0)
@@ -513,3 +537,9 @@ func test_the_last_rows_effects_stay_replaceable() -> void:
 		assert_true(bool(Gen2ModHost.instance().register_move_effect(
 			MOD, effect, [Gen2EffectCommands.END_MOVE]
 		)["ok"]), "effect %d" % effect)
+
+
+## The bag [method Gen2ModHost.inventory] reads while the test stands in for an
+## open world: the example mod's charm, and nothing else.
+func _charmed_bag() -> Dictionary:
+	return {0x19: 1}

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6603,6 +6603,39 @@ func test_a_hidden_item_is_dispatched_from_its_three_data_bytes() -> void:
 	assert_true(world.event_flag_active(20))
 
 
+## A mod's ask through `Gen2ModHost.request_item_gift`, which has no cell, no
+## event flag and no script at all behind it: `verbosegiveitem`'s own
+## transaction and nothing else, so the received line, the sound and the pocket
+## line are the host's exactly as they are for a give a map makes.
+func test_an_item_gift_runs_verbosegiveitem_with_no_script_behind_it() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+
+	var results: Array = world.give_item_gift(3, 2)
+	assert_eq(results.size(), 1, JSON.stringify(results))
+	assert_eq(results[0]["source"]["kind"], &"item_gift")
+	assert_eq(results[0]["status"], &"waiting", JSON.stringify(results[0]))
+	## GiveItemScript's own `_ReceivedItemText`, whose STRING_BUFFER_4 the
+	## staging filled: without the fill the name never resolves.
+	assert_eq(results[0]["event"]["text"], "Received\n%s." % _item_name(3))
+
+	_receipt_sound(world, &"special_sound")
+	var finished: Array = _receipt_notify(world, 3)
+	assert_eq(finished[0]["status"], &"complete", JSON.stringify(finished[0]))
+	assert_eq(world.state.items().get(3, 0), 2)
+
+
+## An item number the cartridge does not know is refused where the ask is spent
+## rather than running a give of nothing, which is the one validation the host
+## does on a mod's behalf.
+func test_an_item_gift_of_an_unknown_item_does_nothing() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 7))
+	assert_eq(world.give_item_gift(0, 1), [])
+	assert_eq(world.give_item_gift(0xFFFF, 1), [])
+	assert_true(world.state.items().is_empty())
+
+
 func test_a_full_item_pocket_leaves_a_hidden_item_flag_clear() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:61A0"] = [20, 0, 3, Gen2WorldScript.END]

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -166,8 +166,8 @@ func test_invalid_battle_identifiers_are_structured_failures() -> void:
 
 
 ## A visible encounter chose its DVs before the player met it, so the battle is
-## built with those four numbers rather than a fresh roll. Nothing else names
-## `dvs`, and what does not gets the perfect word it always got.
+## built with those four numbers rather than a fresh roll. This is also
+## `.Roaming`'s stored word: the caller that has one puts it in the request.
 func test_a_wild_request_carries_its_own_dvs_into_the_battle() -> void:
 	var shiny: int = Gen2Stats.pack_dvs(2, 10, 10, 10)
 	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
@@ -178,13 +178,118 @@ func test_a_wild_request_carries_its_own_dvs_into_the_battle() -> void:
 	assert_eq((prepared["battle"] as Gen2Battle).enemy.dvs, shiny)
 	assert_true(Gen2Stats.is_shiny((prepared["battle"] as Gen2Battle).enemy.dvs))
 
-	var rolled: Dictionary = Gen2WorldBattleAdapter.prepare(
-		_data, {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5}},
-		_player_party()
+
+## `LoadEnemyMon`'s `.GenerateDVs`: a wild that carries none is rolled two bytes
+## off the BATTLE's own generator rather than handed 15/15/15/15, which is what
+## every encounter source but the visible-encounter provider used to get. Off
+## that generator and no other, so the same seed meets the same Pokemon.
+func test_a_wild_with_no_dvs_is_rolled_off_the_battles_own_generator() -> void:
+	var words: Array[int] = []
+	for _attempt: int in 2:
+		var generator := RandomNumberGenerator.new()
+		generator.seed = 20260825
+		var run: Array[int] = []
+		for _wild: int in 8:
+			var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+				_data, {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5}},
+				_player_party(), generator
+			)
+			assert_true(bool(prepared["ok"]), String(prepared.get("reason", "")))
+			run.append((prepared["battle"] as Gen2Battle).enemy.dvs)
+		if words.is_empty():
+			words = run
+		else:
+			assert_eq(run, words, "the same seed draws the same eight words")
+	## Not the perfect word, and not one word eight times: the point of the roll.
+	assert_false(words.all(func(word: int) -> bool:
+		return word == Gen2BattleMon.PERFECT_DVS
+	), "no wild is perfect any more")
+	assert_gt(words.reduce(func(seen: Dictionary, word: int) -> Dictionary:
+		seen[word] = true
+		return seen
+	, {}).size(), 1, "eight rolls are not one number")
+
+
+## `.NotRoaming`'s forced-shiny branch, which writes `ATKDEFDV_SHINY` and
+## `SPDSPCDV_SHINY` rather than rolling. This is the red Gyarados, and nothing
+## read the battle type for its DVs before.
+func test_a_forced_shiny_wild_is_shiny() -> void:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 7
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {
+			"kind": &"wild", "pokemon": SPECIES_TWO, "level": 30,
+			"battle_type": Gen2Battle.BATTLETYPE_FORCESHINY,
+		}}, _player_party(), generator
 	)
-	assert_eq(
-		(rolled["battle"] as Gen2Battle).enemy.dvs, Gen2BattleMon.PERFECT_DVS
-	)
+	assert_true(bool(prepared["ok"]), String(prepared.get("reason", "")))
+	assert_eq((prepared["battle"] as Gen2Battle).enemy.dvs, Gen2Stats.SHINY_DVS)
+	assert_true(Gen2Stats.is_shiny((prepared["battle"] as Gen2Battle).enemy.dvs))
+
+
+## `register_shiny_rolls`: the host draws up to the count the provider asks for
+## and keeps the first shiny word, so a charmed run meets one far sooner than
+## 1 in 8192. Measured rather than asserted on one wild, since a single roll
+## proves nothing about a count.
+func test_a_shiny_rolls_provider_draws_more_words_per_wild() -> void:
+	var vanilla: int = _shiny_wilds(64)
+	Gen2ModHost.instance().register_shiny_rolls(&"test_charm", ShinyRollsStub.new())
+	var charmed: int = _shiny_wilds(64)
+	Gen2ModHost.reset()
+	## The stub asks for more than MAX_SHINY_ROLLS, so the host draws its own
+	## ceiling of 1024: one wild in eight, and about eight shinies over 64. One
+	## roll a wild is one in 8192, so vanilla's 64 find none in almost every run.
+	assert_eq(vanilla, 0, "one roll a wild finds no shiny in 64")
+	assert_gt(charmed, 0, "1024 rolls a wild does")
+
+
+## A wild UNOWN rerolls while its letter is locked, which is `CheckUnownLetter`'s
+## `jr c, .GenerateDVs`. The mask is the save's `wUnlockedUnowns` and reaches
+## here on the request, since the adapter has no save.
+func test_a_wild_unown_only_takes_an_unlocked_letter() -> void:
+	## The roll rather than a whole battle: this cartridge-free suite has no
+	## UNOWN to build a party member out of, and the gate is in the word.
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 99
+	for _wild: int in 32:
+		## X-Z alone, the last set and the smallest.
+		var word: int = Gen2WorldBattleAdapter.wild_dvs(
+			{"unlocked_unowns": 0b1000}, Gen2Battle.BATTLETYPE_NORMAL,
+			RomLayout.UNOWN_SPECIES, generator
+		)
+		var letter: int = Gen2Stats.unown_letter(word)
+		assert_true(letter in [24, 25, 26], "letter %d is not in X-Z" % letter)
+	## No mask stamped is no gate, which is every caller that is not the world
+	## screen: the letters it draws are not all in one set.
+	var ungated: Dictionary = {}
+	for _wild: int in 32:
+		ungated[Gen2Stats.unown_letter(Gen2WorldBattleAdapter.wild_dvs(
+			{}, Gen2Battle.BATTLETYPE_NORMAL, RomLayout.UNOWN_SPECIES, generator
+		))] = true
+	assert_gt(ungated.size(), 3, "an ungated roll reaches past one set")
+
+
+## How many of [param count] rolled wilds came out shiny, off one seeded
+## generator so the two halves of the test above draw the same sequence.
+func _shiny_wilds(count: int) -> int:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 4242
+	var shinies: int = 0
+	for _wild: int in count:
+		var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+			_data, {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5}},
+			_player_party(), generator
+		)
+		if Gen2Stats.is_shiny((prepared["battle"] as Gen2Battle).enemy.dvs):
+			shinies += 1
+	return shinies
+
+
+class ShinyRollsStub:
+	extends RefCounted
+
+	func shiny_rolls(_context: Dictionary) -> int:
+		return 4096
 
 
 ## `PlayBattleMusic` runs in front of `DoBattleTransition`, so the track has to

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -106,6 +106,43 @@ func test_badge_mask_follows_source_order_on_both_profiles() -> void:
 	assert_eq(gold.badge_mask(false), (1 << 0) | (1 << 15))
 
 
+## `wUnlockedUnowns` sits directly after `wKantoBadges` in the engine-flag
+## table, so it carries the badges' own one-index profile shift, and it is what
+## `CheckUnownLetter` refuses a rolled wild Unown's letter against.
+func test_the_unlocked_unown_sets_follow_the_badges_onto_both_profiles() -> void:
+	var crystal := Gen2WorldState.new()
+	assert_eq(crystal.unlocked_unowns(), 0)
+	crystal.set_engine_flag(Gen2WorldState.ENGINE_UNLOCKED_UNOWNS_FIRST)
+	crystal.set_engine_flag(Gen2WorldState.ENGINE_UNLOCKED_UNOWNS_FIRST + 3)
+	assert_eq(crystal.unlocked_unowns(), (1 << 0) | (1 << 3))
+
+	var gold := Gen2WorldState.new()
+	gold.set_engine_flag(Gen2WorldState.ENGINE_UNLOCKED_UNOWNS_FIRST - 1)
+	assert_eq(gold.unlocked_unowns(false), 1 << 0)
+	## The Crystal index on a Gold table would land one row late, on L-R.
+	assert_eq(gold.unlocked_unowns(), 0)
+
+
+## `CheckUnownLetter` walks only the sets whose bit is set, so a letter is
+## unlocked when ANY unlocked set holds it. A save with nothing solved holds no
+## letter at all, and a negative mask is the no-gate a caller with no save passes.
+func test_an_unown_letter_is_unlocked_by_any_set_that_holds_it() -> void:
+	assert_true(Gen2WorldState.unown_letter_unlocked(1, 0b0001), "A in A-K")
+	assert_false(Gen2WorldState.unown_letter_unlocked(12, 0b0001), "L is not")
+	assert_true(Gen2WorldState.unown_letter_unlocked(12, 0b0011), "L once L-R is up")
+	assert_true(Gen2WorldState.unown_letter_unlocked(26, 0b1000), "Z in X-Z")
+	for letter: int in range(1, 27):
+		assert_false(Gen2WorldState.unown_letter_unlocked(letter, 0), "nothing solved")
+		assert_true(Gen2WorldState.unown_letter_unlocked(letter, -1), "no gate")
+	## The four sets are the whole alphabet with no letter in two of them.
+	var seen: Dictionary = {}
+	for one_set: Array in Gen2WorldState.UNOWN_LETTER_SETS:
+		for letter: int in one_set:
+			assert_false(seen.has(letter), "letter %d is in two sets" % letter)
+			seen[letter] = true
+	assert_eq(seen.size(), RomLayout.UNOWN_FORMS)
+
+
 ## BIKEFLAGS_STRENGTH_ACTIVE_F sits three flags ahead of ENGINE_ZEPHYRBADGE, so
 ## it carries the same one-index profile shift the badges do, and it must not be
 ## confused with a badge in either direction.

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -51,7 +51,119 @@ func run(r: RefCounted) -> void:
 		_verify_gate_errand()
 		_census()
 		_verify_wild_patch_indices()
+		_verify_rolled_dvs()
 	)
+
+
+## How many wilds the DV sweep builds per cartridge. Big enough for the shiny
+## count to be a measurement rather than a coincidence: 1 in 8192 a wild, so a
+## sweep this size finds one about half the time and the check below is on the
+## spread rather than on a shiny turning up.
+const DV_SWEEP_WILDS: int = 4096
+## Species and level the sweep builds, chosen for being in all three caches and
+## for not being UNOWN, whose letter gate is swept separately below.
+const DV_SWEEP_SPECIES: int = 19
+const DV_SWEEP_LEVEL: int = 5
+
+
+## `LoadEnemyMon`'s `.InitDVs` against the real caches: every wild the game
+## builds now rolls its own DVs, where before only a visible encounter carried
+## any and all eight other sources entered at 15/15/15/15. The sweep is the
+## point, the way the census above is: one wild proves nothing about a roll.
+##
+## Four claims, in the source's own order of precedence:
+##
+## - a request carrying `dvs` keeps them, which is the visible encounter and the
+##   roamer's stored word;
+## - `BATTLETYPE_FORCESHINY` writes `ATKDEFDV_SHINY`/`SPDSPCDV_SHINY`, which is
+##   the red Gyarados and is a shiny;
+## - an ordinary wild spreads over the whole 16-bit word rather than sitting on
+##   one number, and every nibble reaches both ends of 0 to 15;
+## - a wild UNOWN takes only a letter the puzzle has unlocked, per set.
+func _verify_rolled_dvs() -> void:
+	var party: Gen2Party = Gen2WorldBattleAdapter.fallback_party(_r.data)
+	if not _r.check(party != null, "no party could be built for the DV sweep."):
+		return
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 20260825
+
+	var carried: int = Gen2Stats.pack_dvs(2, 10, 10, 10)
+	_r.check(
+		_dv_word(party, generator, {"dvs": carried}) == carried,
+		"a wild carrying its own DVs was rolled over."
+	)
+	_r.check(
+		_dv_word(party, generator, {
+			"battle_type": Gen2Battle.BATTLETYPE_FORCESHINY,
+		}) == Gen2Stats.SHINY_DVS,
+		"a forced-shiny wild did not get the shiny word."
+	)
+
+	var words: Dictionary = {}
+	var lowest: Array[int] = [15, 15, 15, 15]
+	var highest: Array[int] = [0, 0, 0, 0]
+	var shinies: int = 0
+	for _wild: int in DV_SWEEP_WILDS:
+		var word: int = _dv_word(party, generator, {})
+		words[word] = true
+		if Gen2Stats.is_shiny(word):
+			shinies += 1
+		var nibbles: Array[int] = [
+			Gen2Stats.attack_dv(word), Gen2Stats.defense_dv(word),
+			Gen2Stats.speed_dv(word), Gen2Stats.special_dv(word),
+		]
+		for index: int in nibbles.size():
+			lowest[index] = mini(lowest[index], nibbles[index])
+			highest[index] = maxi(highest[index], nibbles[index])
+	_r.check(
+		words.size() > DV_SWEEP_WILDS / 2,
+		"%d wilds drew only %d distinct DV words." % [DV_SWEEP_WILDS, words.size()]
+	)
+	_r.check(
+		lowest == [0, 0, 0, 0] and highest == [15, 15, 15, 15],
+		"a DV nibble never reached both ends: %s to %s." % [lowest, highest]
+	)
+	_r.note(
+		"wild DVs: %d words over %d rolls, %d shiny" % [words.size(), DV_SWEEP_WILDS, shinies]
+	)
+
+	## `CheckUnownLetter`, one set at a time. A save with nothing solved meets no
+	## wild UNOWN at all, so no mask of zero is swept here.
+	for set_index: int in Gen2WorldState.UNOWN_LETTER_SETS.size():
+		var allowed: Array = Gen2WorldState.UNOWN_LETTER_SETS[set_index]
+		var seen: Dictionary = {}
+		for _wild: int in 256:
+			seen[Gen2Stats.unown_letter(Gen2WorldBattleAdapter.wild_dvs(
+				{"unlocked_unowns": 1 << set_index}, Gen2Battle.BATTLETYPE_NORMAL,
+				RomLayout.UNOWN_SPECIES, generator
+			))] = true
+		for letter: int in seen:
+			_r.check(
+				letter in allowed,
+				"set %d let UNOWN letter %d through." % [set_index, letter]
+			)
+		_r.check(
+			seen.size() == allowed.size(),
+			"set %d reached %d of its %d letters." % [set_index, seen.size(), allowed.size()]
+		)
+
+
+## One wild built through the whole adapter, so the sweep measures the path a
+## battle takes rather than the roll on its own.
+func _dv_word(
+	party: Gen2Party, generator: RandomNumberGenerator, extra: Dictionary
+) -> int:
+	var values: Dictionary = {
+		"kind": &"wild", "pokemon": DV_SWEEP_SPECIES, "level": DV_SWEEP_LEVEL,
+	}
+	values.merge(extra, true)
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_r.data, {"values": values}, party, generator
+	)
+	if not bool(prepared.get("ok", false)):
+		_r.fail("a wild could not be prepared: %s" % prepared.get("reason", ""))
+		return -1
+	return (prepared["battle"] as Gen2Battle).enemy.dvs
 
 
 ## The National Park gate, where a contest is entered. Same ids on both

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -14,8 +14,10 @@ extends SceneTree
 ## `info_pkmn` (the same battle state, with the modal that covers the
 ## annotations open and no provider of this tool's own registered, so a mod
 ## under test is the only thing answering), `contest`, `pack`,
-## `pick`, `use_next`, `replace` and `level_up`, which is the stats box
-## `.skip_exp_bar_animation` draws beside its grew-to-level line;
+## `pick`, `use_next`, `replace`, `level_up`, which is the stats box
+## `.skip_exp_bar_animation` draws beside its grew-to-level line, and `shiny`
+## and `normal`, the same wild entered through the world's own path with and
+## without the shiny DV word, which is the pair `CGB_BattleColors` is read from;
 ## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
 ## cursor row or a refusal can be photographed; [passes] is how many sprite
 ## passes the party page's icons are given, which is what moves the chosen row's
@@ -53,6 +55,16 @@ const LEAD_MOVES: Array[int] = [33, 45, 39, 44]
 ## against Pidgey's NORMAL/FLYING: THUNDERSHOCK is super effective, TACKLE
 ## neutral, VINE WHIP resisted and EARTHQUAKE has no effect at all.
 const INFO_MOVES: Array[int] = [84, 33, 22, 89]
+
+## The `shiny` and `normal` stages' wild: GYARADOS, whose ordinary blue and whose
+## shiny red are the furthest apart of any pair the cartridge draws, and the one
+## the game itself forces (`BATTLETYPE_FORCESHINY` at the Lake of Rage).
+const SHINY_SPECIES: int = 130
+const SHINY_LEVEL: int = 30
+## The two stages that go through `start_world_battle` rather than a staged
+## `_battle`, because the palette is chosen in `_init_battle_display` and only
+## the world path runs it.
+const WORLD_STAGES: Array[String] = ["shiny", "normal"]
 
 ## The stages `BattleMenu`'s own first opening leads into with nothing staged
 ## behind it, rather than a question a turn has to reach.
@@ -201,6 +213,41 @@ func _open() -> void:
 	var data: GameData = _screen.get("_data")
 	var rng := RandomNumberGenerator.new()
 	rng.seed = 3
+
+	## The wild the world starts, entered the way a step into the grass does:
+	## `BATTLETYPE_FORCESHINY` is what writes the shiny word, so the picture is
+	## the cartridge's own forced shiny rather than a number typed in here.
+	if _stage in WORLD_STAGES:
+		var values: Dictionary = {
+			"kind": &"wild", "pokemon": SHINY_SPECIES, "level": SHINY_LEVEL,
+		}
+		if _stage == "shiny":
+			values["battle_type"] = Gen2Battle.BATTLETYPE_FORCESHINY
+		else:
+			## Named rather than rolled, so the two pictures differ in the four
+			## numbers alone: an unnamed wild would roll and could be anything.
+			values["dvs"] = Gen2BattleMon.PERFECT_DVS
+		_screen.start_world_battle({"values": values})
+		## Both sides in one picture: `CGB_BattleColors` reads `CheckShininess`
+		## for the back pic as well, and the player's own party is the only place
+		## a shiny back pic can come from. Written after the battle is built and
+		## the display re-read, since the palette is chosen there.
+		var started: Gen2Battle = _screen.get("_battle")
+		if started != null:
+			started.player.dvs = Gen2Stats.SHINY_DVS if _stage == "shiny" \
+				else Gen2BattleMon.PERFECT_DVS
+			_screen._init_battle_display()
+		_drain_to_menu()
+		## The second `_init_battle_display` leaves a shorter event queue behind
+		## it, so the drain can land a press further in than it does without one.
+		## Backed out rather than counted, so both stages photograph the same
+		## screen and the two pictures differ in the palettes alone.
+		for _press: int in 4:
+			if String(_screen.battle_snapshot()["menu_stage"]) == "main":
+				break
+			_screen._handle_button(Gen2Button.B)
+			_settle()
+		return
 
 	var members: Array = []
 	for species: int in PLAYER_SPECIES:


### PR DESCRIPTION
No wild Pokemon in the game had ever had rolled DVs. The battle adapter defaulted a wild's DV word to the perfect one, and the only producer that ever supplied a word was the visible-encounter path a mod drives. So every other wild entered at 15/15/15/15: grass, surf, fishing, Headbutt, Rock Smash, the Bug Contest, a static `loadwildmon`, a roamer. No wild could be shiny. None could have a bad stat. Hidden Power was the same type every time.

`BATTLETYPE_FORCESHINY` existed and nothing read it. The red Gyarados at the Lake of Rage was not shiny.

And nothing drawn was ever drawn shiny. The battle renderer asked for a species palette with no shiny flag, so a shiny wore its ordinary colours for the whole fight, underneath the cartridge's own gold sparkle sweeping across it correctly.

Both were found by the mods repository, which wrote a shiny-charm mod against five host seams that did not exist.

## What this does

`LoadEnemyMon`'s `.InitDVs` is where a wild is built now, off the battle's own generator so a run stays reproducible. Three cases keep their own answer, in the source's order: a request already carrying a word keeps it, which is the Pokemon a visible encounter's player walked up to and a roamer's stored word; a forced shiny is written rather than rolled; and a wild Unown rerolls while its letter is locked.

That last one is `CheckUnownLetter`, and it needed `ChooseWildEncounter`'s own refusal of a wild Unown on a save that has solved no puzzle, or the reroll would have nothing to land on. Both are built. The four `wUnlockedUnowns` engine flags join the world state; they sit directly after `wKantoBadges` and carry the badges' profile shift.

Both battlers take the shiny flag now, off the live DVs the way `CGB_BattleColors` reads them, so a Transform that copied the target's DVs is drawn as what it copied.

Three registrations follow, for a mod that changes what comes out of the grass:

| Seam | What it is |
|---|---|
| `register_shiny_rolls(id, provider)` | How many DV words one wild is drawn with. The first shiny is kept, otherwise the last. Two mods compose by the largest answer. |
| `request_item_gift(item, quantity)` | `request_hidden_item`'s twin, for an item no map gives. Spends `verbosegiveitem`'s own transaction on the first idle world frame. |
| `inventory()` | The live bag. A non-renderer mod had no way to read it. |

`API_VERSION` is 16.

## The picture

The two new `preview_battle_switch.gd` stages, the same wild with and without the shiny word:

| `shiny` | `normal` |
|---|---|
| Red Gyarados, magenta Cyndaquil flame | Blue Gyarados, red flame |

## Measured

| Check | Result |
|---|---|
| GUT, all tiers | 3754 pass over 162 scripts |
| `validate.gd -- all` | 73 topics pass, three cartridges |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| GDScript analyser | 0 warnings over the 19 scripts touched |
| Boot smoke, with and without mods | exit 0 |

`wild_encounters` sweeps 4096 built wilds per cartridge and reports the distinct word count and the shiny count, and sweeps the Unown letter gate one set at a time.
