### PR TITLE
A shiny is drawn shiny on all five screens, not one

### DIFF
--- a/game/battle/evolution.gd
+++ b/game/battle/evolution.gd
@@ -185,6 +185,10 @@ static func after_battle(
 			# `.check_statused`'s `CheckFaintedFrzSlp`, which costs the cry and the
 			# closing `AnimateFrontpic` both.
 			"statused": is_statused(mon),
+			# `SCGB_EVOLUTION` reaches `GetMonNormalOrShinyPalettePointer`, and
+			# an evolution changes the species rather than the DV word, so both
+			# pictures the sequence draws are the same answer.
+			"shiny": Gen2Stats.is_shiny(mon.dvs),
 			# `.pressed_b` reads `wForceEvolution`: a level evolution is not
 			# forced, so B cancels it, and an item's is and B does nothing.
 			"can_cancel": true,

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -773,7 +773,11 @@ func _refresh_pic(mon: Gen2SaveMon) -> void:
 		return
 	var image: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(mon.species)
+		## `_CGB_BillsPC` reaches `GetMonNormalOrShinyPalettePointer`, so the
+		## selected Pokemon is drawn shiny here the way it is on its own stats
+		## page. The headless page beside this one already asked; the live node
+		## did not, which is the same screen answering two ways.
+		_data.palette(mon.species, Gen2Stats.is_shiny(mon.dvs))
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())

--- a/game/world/egg_hatch_screen.gd
+++ b/game/world/egg_hatch_screen.gd
@@ -112,6 +112,13 @@ func remaining() -> int:
 	return maxi(_hatches.size() - _index, 0)
 
 
+## `SCGB_EVOLUTION`, which `HatchEggs` asks for: what hatched is drawn in its own
+## colours. Read off the record rather than the party, the way the species is:
+## the screen deliberately lags the transaction that wrote it.
+func _hatch_shiny() -> bool:
+	return bool(current_hatch().get("shiny", false))
+
+
 func current_hatch() -> Dictionary:
 	if _index < 0 or _index >= _hatches.size():
 		return {}
@@ -470,7 +477,7 @@ func _draw_species(species: int) -> void:
 	if pic.is_empty():
 		_pic.texture = null
 		return
-	_blit(pic, _data.palette(species), HATCHLING_AT)
+	_blit(pic, _data.palette(species, _hatch_shiny()), HATCHLING_AT)
 
 
 func _blit(pic: Dictionary, colours: PackedColorArray, at: Vector2i) -> void:
@@ -515,7 +522,8 @@ func _draw_animation_box() -> void:
 				for x: int in TILE:
 					indices[to + x] = _animation_pixels[from + x]
 	var image: Image = Gen2PicImage.from_indices(
-		indices, side, side, _data.palette(int(current_hatch().get("species", 0)))
+		indices, side, side,
+		_data.palette(int(current_hatch().get("species", 0)), _hatch_shiny())
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())

--- a/game/world/evolution_screen.gd
+++ b/game/world/evolution_screen.gd
@@ -106,6 +106,12 @@ func remaining() -> int:
 	return maxi(_plans.size() - _index, 0)
 
 
+## `SCGB_EVOLUTION`, which the sequence asks for: both pictures are the one DV
+## word, since an evolution changes the species and not the four numbers.
+func _plan_shiny() -> bool:
+	return bool(current_plan().get("shiny", false))
+
+
 func current_plan() -> Dictionary:
 	if _index < 0 or _index >= _plans.size():
 		return {}
@@ -412,7 +418,7 @@ func _draw_species(species: int) -> void:
 		return
 	var image: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(species)
+		_data.palette(species, _plan_shiny())
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
@@ -457,7 +463,7 @@ func _draw_animation_box() -> void:
 					indices[to + x] = _animation_pixels[from + x]
 	var image: Image = Gen2PicImage.from_indices(
 		indices, side, side,
-		_data.palette(int(current_plan().get("new_species", 0)))
+		_data.palette(int(current_plan().get("new_species", 0)), _plan_shiny())
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -101,6 +101,10 @@ static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
 		## `wUnownLetter`: an Unown in the Hall of Fame is its own letter, not A.
 		"unown_form": Gen2Stats.unown_letter(mon.dvs) \
 			if mon.species == RomLayout.UNOWN_SPECIES else 0,
+		## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS`, which is the layout the Hall of
+		## Fame asks for and which reaches `GetMonNormalOrShinyPalettePointer`.
+		## The other fact about the DV word the pic needs, so it rides beside it.
+		"shiny": Gen2Stats.is_shiny(mon.dvs),
 	}
 
 
@@ -167,6 +171,7 @@ static func record_pages(data: GameData, record: Dictionary) -> Array:
 			"gender": Gen2BattleMon.gender_for(data, species, dvs),
 			"unown_form": Gen2Stats.unown_letter(dvs) \
 				if species == RomLayout.UNOWN_SPECIES else 0,
+			"shiny": Gen2Stats.is_shiny(dvs),
 			## `.print_num_hof`'s "-Time Famer", which is the one line the viewer
 			## draws that an induction does not.
 			"win_count": int(record.get("win_count", 0)),

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -150,7 +150,7 @@ func _refresh_pic(page: Dictionary) -> void:
 		return
 	var image: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(species)
+		_data.palette(species, bool(page.get("shiny", false)))
 	)
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1656,6 +1656,9 @@ func _use_selected_item(party_index: int, move_slot: int = -1) -> void:
 			"new_species": int(result.get("new_species", 0)),
 			"evolving_name": String(result.get("evolving_name", "")),
 			"statused": Gen2Evolution.is_statused(_pack_save.party[party_index]),
+			## The stone does not touch the DV word either, so the plan carries
+			## the same answer the level path's does. See `Gen2Evolution.plans`.
+			"shiny": Gen2Stats.is_shiny(_pack_save.party[party_index].dvs),
 			"can_cancel": false,
 		}, _offer_next_evolution_move)
 		return

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -2091,6 +2091,10 @@ static func hatch_egg(
 	return {
 		"kind": &"hatch", "party_index": index, "species": mon.species,
 		"level": mon.level, "nickname": mon.nickname,
+		## `HatchEggs` asks for `SCGB_EVOLUTION`, which reaches
+		## `GetMonNormalOrShinyPalettePointer`: what comes out of the egg is
+		## drawn in its own colours, and a bred shiny is first seen here.
+		"shiny": Gen2Stats.is_shiny(mon.dvs),
 	}
 
 

--- a/tests/unit/test_evolution.gd
+++ b/tests/unit/test_evolution.gd
@@ -133,6 +133,22 @@ func test_a_statused_party_member_is_planned_without_its_cry() -> void:
 	)[0]["statused"]))
 
 
+## `SCGB_EVOLUTION` reaches `GetMonNormalOrShinyPalettePointer`, so both pictures
+## the sequence draws are the shiny ones. An evolution changes the species and
+## not the DV word, so the plan carries one answer for both.
+func test_an_evolution_plan_says_whether_the_pictures_are_shiny() -> void:
+	var save: Gen2SaveData = _save_with([Fixture.BULBASAUR], 16)
+	save.party[0].dvs = Gen2Stats.SHINY_DVS
+	assert_true(bool(Gen2Evolution.after_battle(
+		_data, save, [0], Gen2WorldPalette.TIME_DAY
+	)[0]["shiny"]))
+
+	save.party[0].dvs = Gen2BattleMon.PERFECT_DVS
+	assert_false(bool(Gen2Evolution.after_battle(
+		_data, save, [0], Gen2WorldPalette.TIME_DAY
+	)[0]["shiny"]), "the perfect word is not a shiny one")
+
+
 ## An EGG keeps its party slot without being a combatant, so the flag the battle
 ## set for battle slot 0 belongs to party slot 1 when an egg is in front of it.
 func test_an_egg_shifts_the_flag_off_the_battle_party_indices() -> void:

--- a/tests/unit/test_hall_of_fame.gd
+++ b/tests/unit/test_hall_of_fame.gd
@@ -38,6 +38,21 @@ func test_pages_follow_the_party_and_end_with_the_player() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4]))
 	assert_eq(pages.size(), 2 + RATING_PAGES)
 	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_MON)
+	## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS`, which the Hall of Fame asks for and
+	## which reaches `GetMonNormalOrShinyPalettePointer`: a shiny is inducted in
+	## its own colours, the same DV word the letter beside it comes from.
+	assert_false(bool(pages[0]["shiny"]), "the fixture's party is not shiny")
+
+	var shiny_save: Gen2SaveData = _save([1, 4])
+	shiny_save.party[0].dvs = Gen2Stats.SHINY_DVS
+	var shiny_pages: Array = Gen2HallOfFame.pages(_data, shiny_save)
+	assert_true(bool(shiny_pages[0]["shiny"]))
+	assert_false(bool(shiny_pages[1]["shiny"]), "and only the one that is")
+	## The stored records take the same road: an induction is written and read
+	## back, so a shiny in the viewer is drawn shiny however long ago it won.
+	var stored: Array = Gen2HallOfFame.inducted([], shiny_save)
+	var replayed: Array = Gen2HallOfFame.record_pages(_data, stored[0])
+	assert_true(bool(replayed[0]["shiny"]), "the stored record kept it")
 	assert_eq(int(pages[0]["species"]), 1)
 	assert_eq(int(pages[0]["dex_number"]), 1)
 	assert_eq(int(pages[1]["species"]), 4)

--- a/tests/unit/test_world_day_care.gd
+++ b/tests/unit/test_world_day_care.gd
@@ -332,6 +332,48 @@ func test_the_egg_takes_the_parents_defence_dv() -> void:
 	)
 
 
+## The Gen 2 shiny-breeding chain, which falls out of `.GotDVs` rather than being
+## a rule of its own: the egg inherits the Defense DV and the Special DV's low
+## three bits from the chosen parent, so a shiny parent hands over Defense 10 and
+## the two bits that make Special 10 or 2. What is left to roll is the Attack
+## DV's shiny bit, the Speed DV and the Special DV's top bit, which is about one
+## egg in sixty-four. Measured rather than asserted on one egg.
+func test_a_shiny_parent_breeds_shiny_at_the_source_rate() -> void:
+	var shinies: int = 0
+	var eggs: int = 512
+	var random: RandomNumberGenerator = _seeded(11)
+	var shiny_parent: Gen2SaveMon = _mon(CUBONE, Gen2Stats.SHINY_DVS)
+	var plain_parent: Gen2SaveMon = _mon(CUBONE, MALE_DVS)
+	var from_shiny: int = 0
+	for _egg: int in eggs:
+		var word: int = Gen2WorldDayCare.inherited_dvs(
+			_data, CUBONE, Gen2BattleMon.random_dvs(random),
+			shiny_parent, plain_parent
+		)
+		## The half of the inheritance the parent is chosen for, whichever parent
+		## the gender check picked: this is what makes the rate a real one.
+		if Gen2Stats.defense_dv(word) == Gen2Stats.defense_dv(Gen2Stats.SHINY_DVS):
+			from_shiny += 1
+		if Gen2Stats.is_shiny(word):
+			shinies += 1
+	assert_gt(from_shiny, 0, "the shiny parent is chosen sometimes")
+	## One in 8192 without the inheritance, so 512 eggs finding any at all is the
+	## chain working; the band is wide because 512 draws of a 1-in-64 event is a
+	## count around eight and this is a seeded measurement, not a probability.
+	assert_gt(shinies, 0, "%d of %d eggs came out shiny" % [shinies, eggs])
+	assert_lt(shinies, eggs / 4, "and it is not every egg")
+
+	## Two plain parents and the chain is not there: the Defense DV they hand
+	## over is not the shiny one, so no roll of the rest can produce it.
+	var plain: int = 0
+	for _egg: int in eggs:
+		if Gen2Stats.is_shiny(Gen2WorldDayCare.inherited_dvs(
+			_data, CUBONE, Gen2BattleMon.random_dvs(random), plain_parent, plain_parent
+		)):
+			plain += 1
+	assert_eq(plain, 0, "two plain parents cannot pass on a Defense DV of 10")
+
+
 func test_the_counter_runs_down_a_step_at_a_time_and_offers_an_egg() -> void:
 	var state: Gen2WorldState = _state()
 	_breeding_pair(state)

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1367,6 +1367,10 @@ func test_hatching_writes_the_row_the_source_writes() -> void:
 	assert_eq(mon.caught_level, Gen2WorldPartyHost.CAUGHT_EGG_LEVEL)
 	assert_eq(mon.caught_location, _world.landmark())
 	assert_true(_world.state.has_caught_species(1), "SetSeenAndCaughtMon runs here")
+	## `HatchEggs` asks for `SCGB_EVOLUTION`, which is a shiny-reading layout, so
+	## the row the screen draws from says which colours the hatchling wears. A
+	## bred shiny is first seen here and nowhere earlier.
+	assert_eq(bool(summary.get("shiny", false)), Gen2Stats.is_shiny(mon.dvs))
 	assert_true(Gen2WorldPartyHost.hatch_egg(_world, _save, 0).is_empty(),
 		"a hatched row is not an egg any more")
 

--- a/tools/checks/screen_palettes.gd
+++ b/tools/checks/screen_palettes.gd
@@ -20,6 +20,21 @@ var _r: RefCounted = null
 ##
 ##   Godot --headless --path . -s res://tools/validate.gd -- screen_palettes
 
+## Every screen the source draws a Pokemon's SHINY colours on, by the layout it
+## asks for: `_CGB_BattleColors`, `_CGB_StatsScreenHPPals`, `_CGB_BillsPC`,
+## `_CGB_Evolution` (which breeding's hatch asks for too) and
+## `_CGB_PlayerOrMonFrontpicPals` (the Hall of Fame and the trade animation).
+## Every one of them reaches `GetMonNormalOrShinyPalettePointer`.
+##
+## Named here because the list is the point: `_CGB_Pokedex` and `_CGB_PartyMenu`
+## are NOT on it, so the dex and the party menu's icons are drawn in ordinary
+## colours on the cartridge and must not be "fixed" here.
+const SHINY_LAYOUTS: Array[String] = [
+	"battle", "stats screen", "Bill's PC", "evolution and hatch",
+	"Hall of Fame and trade",
+]
+
+
 ## `data/pokemon/base_stats/`'s own range.
 const FIRST_SPECIES: int = 1
 const LAST_SPECIES: int = 251
@@ -48,12 +63,46 @@ const SOURCE_MOVE_BOXES: Array = [[11, 1, 9, 2, 1]]
 const HP_FRACTIONS: Array[float] = [1.0, 0.3, 0.05]
 
 
+## `PokemonPalettes` is two four-colour entries per species, normal then shiny,
+## and `GetMonNormalOrShinyPalettePointer` picks the second by stepping four
+## bytes on. Every screen in [constant SHINY_LAYOUTS] asks for one or the other,
+## so a species whose shiny entry never reached the cache would draw its ordinary
+## colours on all five however carefully each one asked.
+##
+## Swept rather than sampled: the pair is per species and the importer reads them
+## from one table, so one missing entry is the whole failure mode.
+func _verify_shiny_palettes() -> void:
+	var flat: int = 0
+	var missing: int = 0
+	for species: int in range(FIRST_SPECIES, LAST_SPECIES + 1):
+		var normal: PackedColorArray = _r.data.palette(species, false)
+		var shiny: PackedColorArray = _r.data.palette(species, true)
+		if normal.size() != Gen2Palette.COLORS_PER_PIC \
+			or shiny.size() != Gen2Palette.COLORS_PER_PIC:
+			missing += 1
+			continue
+		## The two middle colours are the Pokemon; 0 and 3 are white and black on
+		## every entry, which is why a pair differing only there would be a
+		## palette that is not really a shiny one.
+		if normal[1] == shiny[1] and normal[2] == shiny[2]:
+			flat += 1
+	_r.check(missing == 0, "%d species have no four-colour palette pair." % missing)
+	_r.check(
+		flat == 0,
+		"%d species draw the same two colours shiny as normal." % flat
+	)
+	_r.note("shiny palettes: %d species, %d layouts read them" % [
+		LAST_SPECIES - FIRST_SPECIES + 1, SHINY_LAYOUTS.size(),
+	])
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	_r.each_game(_check_game)
 
 
 func _check_game() -> void:
+	_verify_shiny_palettes()
 	var page: Gen2StatsScreenPage = Gen2StatsScreenPage.from_data(_r.data)
 	if not _r.check(page != null, "the stats screen page will not build."):
 		return

--- a/tools/preview_hall_of_fame.gd
+++ b/tools/preview_hall_of_fame.gd
@@ -6,6 +6,9 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_hall_of_fame.gd -- crystal /tmp/hof.png [page]
 ##
+## A fourth argument of `shiny` makes the lead shiny, which is the one thing
+## about the panel a check cannot read off the buffer.
+##
 ## [page] is how many times to advance before the capture, so 0 is the first
 ## party member and the last pages are the player's own panel with each box
 ## `ProfOaksPCRating` prints into it.
@@ -17,6 +20,7 @@ const SETTLE_FRAMES: int = 18
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
 var _advance: int = 0
+var _shiny: bool = false
 var _frames: int = 0
 
 
@@ -31,6 +35,7 @@ func _initialize() -> void:
 		quit(2)
 		return
 	_advance = int(args[2]) if args.size() > 2 else 0
+	_shiny = args.size() > 3 and args[3] == "shiny"
 
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
@@ -53,6 +58,12 @@ func _initialize() -> void:
 	_screen.map_number = spawn.map_id.y
 	_screen.start_cell = spawn.player_cell
 	save.world = spawn
+	## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS` reaches
+	## `GetMonNormalOrShinyPalettePointer`, so the panel is one of the five
+	## screens a shiny is drawn shiny on. The lead is made shiny and the rest are
+	## left alone, which is what makes one capture the comparison.
+	if _shiny and not save.party.is_empty():
+		save.party[0].dvs = Gen2Stats.SHINY_DVS
 	_screen.set_data(data)
 	_screen.set_save(save)
 	root.add_child(_screen)

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -3,7 +3,11 @@ extends SceneTree
 ## Captures the window-resolution save overlays against a real cache: the party,
 ## the PC boxes and the start menu's pack.
 ##
-##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> [party|box|pack|select|stats] [presses]
+##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> [party|box|pack|select|stats] [presses] [shiny]
+##
+## A final `shiny` makes the lead shiny. The PC's pic and the stats page draw it;
+## the party menu's icons deliberately do not, which is the cartridge's own
+## answer and is what the three captures together say.
 ##
 ## `presses` is a comma-separated button list driven into the overlay before the
 ## shot, the way `preview_world_services.gd` photographs a second page: `d` is
@@ -36,6 +40,7 @@ const BUTTONS: Dictionary = {
 
 var _output_path: String = ""
 var _what: String = "party"
+var _shiny: bool = false
 var _programs: Array[String] = [""]
 var _at: int = 0
 var _screen: Control = null
@@ -61,10 +66,11 @@ func _initialize() -> void:
 		return
 	if args.size() > 2:
 		_what = args[2]
-	if args.size() > 3:
+	if args.size() > 3 and args[3] != "shiny":
 		_programs = []
 		for program: String in args[3].split(";"):
 			_programs.append(program)
+	_shiny = args.has("shiny")
 
 	var directory: String = _find_cache(game)
 	if directory.is_empty():
@@ -103,6 +109,13 @@ func _build(data: GameData) -> Control:
 	if save == null:
 		push_error("Could not build a development save for %s." % data.id)
 		return null
+	## `_CGB_BillsPC` and `_CGB_StatsScreenHPPals` both reach
+	## `GetMonNormalOrShinyPalettePointer`, and the party menu's own layout
+	## deliberately does not: one lead made shiny photographs all three answers
+	## at once, which is the only way to see that the middle screen is right and
+	## the icons beside it are right to stay as they are.
+	if _shiny and not save.party.is_empty():
+		save.party[0].dvs = Gen2Stats.SHINY_DVS
 	if _what == "box":
 		var boxes := Gen2BoxScreen.new()
 		boxes.set_context(data, save, false, true)


### PR DESCRIPTION
The battle was the case that got reported, and it is fixed. But it was never the only screen.

Reading `GetMonNormalOrShinyPalettePointer`'s callers gives five layouts, not one:

| Layout | Screen | Before |
|---|---|---|
| `_CGB_BattleColors` | Battle | fixed last time |
| `_CGB_StatsScreenHPPals` | Stats screen | already right |
| `_CGB_BillsPC` | Bill's PC | **wrong** |
| `_CGB_Evolution` | Evolution, and egg hatch | **wrong** |
| `_CGB_PlayerOrMonFrontpicPals` | Hall of Fame | **wrong** |

Bill's PC answered two ways about the same Pokemon. The headless page passed the flag and the live node did not, so the pic beside the box list was never shiny while the stats page one keypress away always was.

The evolution sequence, the egg hatch and the Hall of Fame each dropped it. Each carries the flag on the record its screen reads now, beside the `unown_form` or `statused` already riding there, because both are facts about the one DV word the pic needs. An evolution changes the species and not that word, so a plan carries one answer for both of its pictures, and a hatch is where a bred shiny is first seen.

## What is deliberately not changed

`_CGB_Pokedex` and `_CGB_PartyMenu` are not on that list. The dex draws a species rather than an individual, and the party menu's icons are the cartridge's fixed per-icon palettes. `tools/checks/screen_palettes.gd` names both, so the next reader does not "fix" them.

## The DV side

Checked rather than assumed, and it needed nothing:

| Source | DVs |
|---|---|
| Wild, all eight methods | rolled (previous PR) |
| Forced shiny (red Gyarados) | written |
| Gift, starter | already rolled in `_new_mon` |
| Egg from breeding | already inherited in `inherited_dvs` |
| In-game trade | the `npc_trades` table's fixed word |
| Capture | keeps `persistent_dvs()` |

So the Gen 2 shiny-breeding chain falls out of `.GotDVs` on its own, and is now measured: 512 eggs off a shiny parent produce some, 512 off two plain ones produce none, because a plain parent cannot pass on a Defense DV of 10.

## Measured

| Check | Result |
|---|---|
| GUT, all tiers | 3756 pass over 162 scripts |
| `validate.gd -- all` | 73 topics, three cartridges |
| Shiny palette sweep | 251 species x 3 cartridges, every pair distinct |
| GDScript analyser | 0 warnings over the 15 scripts touched |

`preview_hall_of_fame.gd` and `preview_party.gd` take a `shiny` argument now, which is how the three captures above were taken.
