### PR TITLE
Mystery Gift

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 > save file the receptionist says your friend is not ready, which is what a
 > single Game Boy has always been told.
 >
-> Missing: Mystery Gift, the trade animation, and a handful of pixel-level
-> divergences still being chased in the opening movies and title screen against a
-> real cartridge.
+> Mystery Gift works the same way. Carrie in GOLDENROD DEPT. STORE 5F unlocks
+> it, the row then appears beside a save slot, and the infrared partner is your
+> other save file: five gifts a day, one per person, and the officer on the
+> POKEMON CENTER's second floor hands over whatever arrived. With one save file
+> the exchange times out, which is what one Game Boy has always seen.
+>
+> Missing: the trade animation, and a handful of pixel-level divergences still
+> being chased in the opening movies and title screen against a real cartridge.
 
 ## Getting started
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -79,6 +79,7 @@ var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _unown_puzzle: Dictionary = {}
 var _diploma: Dictionary = {}
+var _mystery_gift: Dictionary = {}
 var _link_border: Dictionary = {}
 var _other_player_link_mode: int = -1
 var _printer_strings: Dictionary = {}
@@ -210,6 +211,8 @@ static func open_directory(path: String) -> GameData:
 	data._unown_puzzle = unown_puzzle if unown_puzzle is Dictionary else {}
 	var diploma: Variant = manifest.get("diploma", {})
 	data._diploma = diploma if diploma is Dictionary else {}
+	var mystery_gift: Variant = manifest.get("mystery_gift", {})
+	data._mystery_gift = mystery_gift if mystery_gift is Dictionary else {}
 	var link_border: Variant = manifest.get("link_border", {})
 	data._link_border = link_border if link_border is Dictionary else {}
 	data._other_player_link_mode = int(manifest.get("other_player_link_mode", -1))
@@ -1991,6 +1994,37 @@ func diploma_palette() -> PackedColorArray:
 	for packed: Variant in _diploma.get("palette", []) as Array:
 		colors.append(Gen2Palette.from_packed(int(packed)))
 	return colors
+
+
+## `InitMysteryGiftLayout`'s art and the two gift tables beside it. A cache
+## imported before format 89 carries none of it, which is what
+## [method has_mystery_gift] answers for.
+func has_mystery_gift() -> bool:
+	return not (_mystery_gift.get("items", []) as Array).is_empty()
+
+
+func mystery_gift_indices() -> PackedByteArray:
+	return tile_indices("mystery_gift")
+
+
+## `_CGB_MysteryGift`'s own copy into `wBGPals1`: two palettes on Crystal and
+## one on Gold and Silver.
+func mystery_gift_palette() -> PackedColorArray:
+	var colors := PackedColorArray()
+	for packed: Variant in _mystery_gift.get("palette", []) as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## `.String_PressAToLink_BToCancel`, the box the screen opens on.
+func mystery_gift_prompt() -> String:
+	return String(_mystery_gift.get("prompt", ""))
+
+
+## `MysteryGiftItems` or `MysteryGiftDecos`, whichever
+## `wMysteryGiftPartnerSentDeco` names.
+func mystery_gift_table(decorations: bool) -> Array:
+	return (_mystery_gift.get("decos" if decorations else "items", []) as Array).duplicate()
 
 
 ## `LinkCommsBorderGFX`'s own strip and, on Crystal alone, the three tilemaps

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 88
+const FORMAT_VERSION: int = 89
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -298,6 +298,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not mail["ok"]:
 		return mail
 
+	var mystery_gift: Dictionary = verify_mystery_gift(rom, layout)
+	if not mystery_gift["ok"]:
+		return mystery_gift
+
 	var battle_tower: Dictionary = verify_battle_tower(rom, layout)
 	if not battle_tower["ok"]:
 		return battle_tower
@@ -1286,6 +1290,7 @@ const SPECIAL_TEXT_FIRST_BOX: Dictionary = {
 	"bank_of_mom": ["leaving_1", "Wow, that's a cute"],
 	"poke_seer": ["see_all", "I see all."],
 	"buena_prize": ["ask_which_prize", "Which prize would"],
+	"mystery_gift": ["canceled", "The link has been"],
 }
 
 
@@ -2444,6 +2449,24 @@ const MAIL_PALETTE_FIRST: Array[int] = [
 ## The icon is checked for bounds alone: eight 2bpp tiles of a picture with no
 ## structure a wrong offset would fail, and `tools/checks/mail.gd` is what looks
 ## at it.
+## `data/items/mystery_gift_items.asm` and
+## `data/decorations/mystery_gift_decos.asm`, resolved through their own
+## constant blocks rather than read back out of a dump: these are what say the
+## two pins are the tables and not some other pair of adjacent runs. Identical
+## in both disassemblies.
+const MYSTERY_GIFT_ITEM_NUMBERS: Array[int] = [
+	0xAD, 0x4E, 0x54, 0x50, 0x4F, 0x4A, 0x29, 0x33, 0x31, 0x53, 0x2C, 0x35,
+	0x21, 0xB9, 0xBA, 0xBC, 0x6D, 0xAE, 0x27, 0x04, 0x2A, 0x2B, 0x41, 0x3F,
+	0x18, 0x16, 0x22, 0x17, 0x40, 0x15, 0x28, 0x8C, 0x1A, 0x3E, 0x20, 0xBB,
+	0xBD,
+]
+const MYSTERY_GIFT_DECO_NUMBERS: Array[int] = [
+	0x16, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20, 0x21, 0x22, 0x0D, 0x0E,
+	0x10, 0x23, 0x25, 0x26, 0x08, 0x09, 0x0F, 0x11, 0x17, 0x19, 0x01, 0x02,
+	0x04, 0x05, 0x06, 0x07, 0x0A, 0x12, 0x29, 0x0C, 0x2A, 0x14, 0x03, 0x24,
+	0x27,
+]
+
 static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("mail", {})
 	if entry.is_empty():
@@ -4704,6 +4727,7 @@ func import_rom(
 		"decorations": _import_decorations(rom, layout),
 		"unown_puzzle": _import_unown_puzzle(rom, layout),
 		"diploma": _import_diploma(rom, layout),
+		"mystery_gift": _import_mystery_gift(rom, layout),
 		"link_border": _import_link_border(rom, layout),
 		"printer_strings": _import_printer_strings(rom, layout),
 		"slots": _import_slots(rom, layout),
@@ -6421,6 +6445,153 @@ static func read_card_flip_texts(rom: RomFile, layout: Dictionary) -> Dictionary
 	return out
 
 
+## `InitMysteryGiftLayout`'s art, the two gift tables beside it and the prompt
+## the screen opens on. Each is checked against something only the right offset
+## carries: the tables against their own constant blocks, the art against the
+## highest tile the routine indexes, and the prompt against its first line.
+static func verify_mystery_gift(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("mystery_gift", {})
+	if entry.is_empty():
+		return {"ok": false, "message": "The cartridge has no Mystery Gift block."}
+
+	for table: Array in [
+		["items", MYSTERY_GIFT_ITEM_NUMBERS], ["decos", MYSTERY_GIFT_DECO_NUMBERS],
+	]:
+		var at: int = int(entry.get(String(table[0]), -1))
+		var expected: Array[int] = table[1]
+		if not rom.in_bounds(at, RomLayout.MYSTERY_GIFT_TABLE_ROWS):
+			return {
+				"ok": false,
+				"message": "MysteryGift %s is outside the cartridge." % table[0],
+			}
+		for index: int in RomLayout.MYSTERY_GIFT_TABLE_ROWS:
+			if rom.u8(at + index) != expected[index]:
+				return {
+					"ok": false,
+					"message": "MysteryGift %s row %d is $%02X, expected $%02X." % [
+						table[0], index, rom.u8(at + index), expected[index],
+					],
+				}
+
+	var gfx: int = int(entry.get("gfx", -1))
+	var bytes: int = int(entry.get("tiles", 0)) * Gen2Tiles.TILE_BYTES
+	if bytes <= 0 or not rom.in_bounds(gfx, bytes):
+		return {"ok": false, "message": "MysteryGiftGFX runs past the cartridge."}
+	for name: String in ["background", "gfx2"]:
+		var at: int = int(entry.get(name, -1))
+		if at < 0:
+			continue
+		var run: int = (
+			RomLayout.MYSTERY_GIFT_BACKGROUND_BYTES if name == "background"
+			else RomLayout.MYSTERY_GIFT_GFX2_TILES * Gen2Tiles.TILE_BYTES
+		)
+		if not rom.in_bounds(at, run):
+			return {
+				"ok": false,
+				"message": "MysteryGift %s runs past the cartridge." % name,
+			}
+
+	var palette: int = int(entry.get("palette", -1))
+	var colors: int = int(entry.get("palettes", 0)) \
+		* RomLayout.MYSTERY_GIFT_PALETTE_COLORS
+	if colors <= 0 or not rom.in_bounds(palette, colors * 2):
+		return {"ok": false, "message": "The Mystery Gift palette is out of bounds."}
+	## Every `.pal` include opens on white, and a run pinned one word out does
+	## not.
+	if rom.u16le(palette) != 0x7FFF:
+		return {
+			"ok": false,
+			"message": "The Mystery Gift palette opens on $%04X, not white." % \
+				rom.u16le(palette),
+		}
+
+	var prompt: String = read_mystery_gift_prompt(rom, layout)
+	if not prompt.begins_with("Press A to"):
+		return {
+			"ok": false,
+			"message": "The Mystery Gift prompt reads \"%s\"." % prompt,
+		}
+	return {"ok": true, "message": "The Mystery Gift block verified."}
+
+
+## `.String_PressAToLink_BToCancel`, an inline `db` string rather than a
+## `text_far` stub, so it is walked to its own terminator.
+static func read_mystery_gift_prompt(rom: RomFile, layout: Dictionary) -> String:
+	var at: int = int((layout.get("mystery_gift", {}) as Dictionary).get("prompt", -1))
+	if at < 0:
+		return ""
+	var length: int = 0
+	while rom.in_bounds(at + length) and rom.u8(at + length) != Gen2Text.TERMINATOR:
+		length += 1
+		if length > RomLayout.OAK_TEXT_MAX_BYTES:
+			return ""
+	return Gen2Text.decode(rom.bytes(), at, length)
+
+
+## The Mystery Gift screen's whole cache section: the two gift tables, the
+## prompt, the palette `_CGB_MysteryGift` copies, and every tile
+## `InitMysteryGiftLayout` puts on screen. Gold and Silver's three art runs are
+## flattened into one strip here, in the order the routine loads them into
+## vTiles2, so the page indexes one block on all three cartridges.
+static func read_mystery_gift_section(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var entry: Dictionary = layout.get("mystery_gift", {})
+	if entry.is_empty():
+		return {}
+	var tiles: PackedByteArray = rom.slice(
+		int(entry.get("gfx", 0)), int(entry.get("tiles", 0)) * Gen2Tiles.TILE_BYTES
+	)
+	var background: int = int(entry.get("background", -1))
+	if background >= 0:
+		## `FarCopyBytesDouble` writes each 1bpp byte into both planes and the
+		## loop behind it then fills plane 1 with $ff, so the tile that lands in
+		## vTiles2 is the source byte and $ff alternating.
+		var raw: PackedByteArray = rom.slice(
+			background, RomLayout.MYSTERY_GIFT_BACKGROUND_BYTES
+		)
+		for byte: int in raw:
+			tiles.append(byte)
+			tiles.append(0xFF)
+	var gfx2: int = int(entry.get("gfx2", -1))
+	if gfx2 >= 0:
+		tiles.append_array(rom.slice(
+			gfx2, RomLayout.MYSTERY_GIFT_GFX2_TILES * Gen2Tiles.TILE_BYTES
+		))
+		## `ld hl, vTiles2 tile $3d / ld a, $ff / ByteFill`: the solid tile the
+		## screen is filled with sits one past the last run Gold and Silver
+		## load, so it is appended here rather than left for the page to invent.
+		for _byte: int in Gen2Tiles.TILE_BYTES:
+			tiles.append(0xFF)
+	var colors: Array = []
+	for index: int in int(entry.get("palettes", 0)) \
+			* RomLayout.MYSTERY_GIFT_PALETTE_COLORS:
+		colors.append(rom.u16le(int(entry.get("palette", 0)) + index * 2))
+	return {
+		"tiles": tiles,
+		"palette": colors,
+		"prompt": read_mystery_gift_prompt(rom, layout),
+		"items": Array(rom.slice(
+			int(entry.get("items", 0)), RomLayout.MYSTERY_GIFT_TABLE_ROWS
+		)),
+		"decos": Array(rom.slice(
+			int(entry.get("decos", 0)), RomLayout.MYSTERY_GIFT_TABLE_ROWS
+		)),
+	}
+
+
+func _import_mystery_gift(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_mystery_gift_section(rom, layout)
+	if section.is_empty():
+		return {}
+	return {
+		"tiles": Array(section["tiles"] as PackedByteArray),
+		"palette": (section["palette"] as Array).duplicate(),
+		"prompt": String(section["prompt"]),
+		"items": (section["items"] as Array).duplicate(),
+		"decos": (section["decos"] as Array).duplicate(),
+	}
+
+
+
 func _import_card_flip_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return read_card_flip_texts(rom, layout)
 
@@ -6583,6 +6754,30 @@ func _import_diploma_sheet(rom: RomFile, layout: Dictionary) -> Dictionary:
 		},
 	}
 
+
+## The Mystery Gift screen's own strip, written the way the diploma's is.
+## Crystal's is one run and Gold and Silver's is three, so the count is what
+## the section actually assembled rather than a constant.
+func _import_mystery_gift_sheet(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_mystery_gift_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var tiles: int = (section["tiles"] as PackedByteArray).size() / Gen2Tiles.TILE_BYTES
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	if not RomCache.write_indices(
+		RomCache.tile_path(directory, "mystery_gift"),
+		Gen2Tiles.decode_2bpp_strip(section["tiles"], 0, tiles)
+	):
+		return {}
+	return {
+		"mystery_gift": {
+			"width": tiles * Gen2Tiles.TILE_WIDTH,
+			"height": Gen2Tiles.TILE_HEIGHT,
+			"tiles": tiles,
+			"first_code": 0,
+			"bits": 2,
+		},
+	}
 
 ## `GameFreakDittoGFX`, the one LZ run in the splash. `GameFreakPresentsInit`
 ## splits it over `vTiles0` and `vTiles1` as 128 tiles each, and the OAM sets
@@ -6981,6 +7176,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_card_flip_sheets(rom, layout), true)
 	written.merge(_import_diploma_sheet(rom, layout), true)
 	written.merge(_import_link_border_sheet(rom, layout), true)
+	written.merge(_import_mystery_gift_sheet(rom, layout), true)
 	var done: int = 0
 	for name: String in sheets:
 		var sheet: Dictionary = sheets[name]

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1187,6 +1187,20 @@ const PREDEFPAL_UNOWN_PUZZLE: int = 0x4C
 ## one LZ strip and the two tilemaps behind it are whole screens of tile
 ## numbers, uncompressed and laid out in the file's own order. Identical on all
 ## three cartridges.
+## `MysteryGiftItems` and `MysteryGiftDecos`, which are the same length and sit
+## next to each other in both pins: thirty-seven rows each, and an index past
+## either end is `MysteryGiftFallbackItem`.
+const MYSTERY_GIFT_TABLE_ROWS: int = 37
+## `LoadMysteryGiftBackgroundGFX`'s `ld bc, wBGMapBufferEnd - wBGMapBuffer`: 120
+## 1bpp bytes, which `FarCopyBytesDouble` turns into fifteen tiles whose second
+## plane is then filled with $ff. Gold and Silver only.
+const MYSTERY_GIFT_BACKGROUND_BYTES: int = 0x78
+## `LoadMysteryGiftGFX2`'s own `ld bc, 14 tiles`. Gold and Silver only.
+const MYSTERY_GIFT_GFX2_TILES: int = 14
+## The four colours of a `.pal` include, which is what `_CGB_MysteryGift` copies
+## straight into `wBGPals1`.
+const MYSTERY_GIFT_PALETTE_COLORS: int = 4
+
 const DIPLOMA_TILES: int = 112
 const DIPLOMA_TILEMAP_BYTES: int = 360
 
@@ -1545,6 +1559,14 @@ const SPECIAL_TEXT_RUNS: Dictionary = {
 		["link_abnormal_mon_text", ["abnormal_mon"]],
 		["link_ask_trade_text", ["ask_trade"]],
 	],
+	## `DoMysteryGift`'s eight, one contiguous run behind
+	## `.String_PressAToLink_BToCancel`. Every box the routine can end on is
+	## here: the two refusals in front of the gift, the two daily limits, the
+	## two the exchange itself fails with, and the two the gift arrives in.
+	"mystery_gift": [["mystery_gift_text", [
+		"canceled", "comm_error", "retrieve", "friend_not_ready",
+		"five_a_day", "one_a_day", "sent", "sent_home",
+	]]],
 	## `BuenaPrize`'s six, in its own file order.
 	"buena_prize": [["buena_prize_text", [
 		"ask_which_prize", "is_that_right", "here_you_go", "not_enough_points",
@@ -2357,6 +2379,17 @@ const GOLD_SILVER: Dictionary = {
 	# `LinkTextboxAtHL` instead. The same address on Gold and on Silver.
 	"link_border": 0x29D5B,
 	"link_trade_tilemaps": -1,
+	# `InitMysteryGiftLayout` at Gold and Silver's own addresses, which is three
+	# art runs rather than Crystal's one: thirty-two tiles of `MysteryGiftGFX`,
+	# `MysteryGiftBackgroundGFX`'s 1bpp question mark and border doubled into
+	# fifteen, and `MysteryGiftGFX2`'s fourteen. The single palette is
+	# `_CGB_MysteryGift`'s own, against Crystal's two.
+	"mystery_gift": {
+		"gfx": 0xFD0C9, "tiles": 0x20,
+		"background": 0x17079, "gfx2": 0x170F1,
+		"prompt": 0x29F01, "palette": 0x9AAA, "palettes": 1,
+		"items": 0x2C530, "decos": 0x2C555,
+	},
 	# `UnownDexATile` behind `UnownDexVacantString`, and `GBPrinterStrings`
 	# behind `PrinterStatusStringPointers`' first entry.
 	"unown_printer_glyphs": 0x16FCC,
@@ -2538,6 +2571,12 @@ const GOLD_SILVER: Dictionary = {
 		## `wBufferTrademonNickname`, which `_LinkAskTradeForText` names with a
 		## `text_ram` whose address is in the text data itself.
 		"trademon_nickname": 0xCEEF,
+		## The two names `_MysteryGiftSentText` and `_MysteryGiftSentHomeText`
+		## spell: the partner who sent the gift and the player it came home to.
+		## Gold and Silver's Mystery Gift block sits a page below Crystal's, the
+		## way their link block does.
+		"mystery_gift_partner_name": 0xC803,
+		"mystery_gift_player_name": 0xC853,
 	},
 	## Gold and Silver's own WRAM address for the same byte; their link block sits
 	## a page lower than Crystal's.
@@ -2546,6 +2585,7 @@ const GOLD_SILVER: Dictionary = {
 	"link_cant_battle_text": 0x289A8,
 	"link_abnormal_mon_text": 0x289BD,
 	"link_ask_trade_text": 0x28D51,
+	"mystery_gift_text": 0x29F31,
 	"magikarp_measure_text": 0xFBCAD,
 	"magikarp_record_text": 0xFBDEC,
 	"lucky_number_text": 0xC7BA3,
@@ -2893,6 +2933,18 @@ const CRYSTAL: Dictionary = {
 	# `gfx/trade/border_tiles.png`; the tilemaps are pinned separately because
 	# `__LoadTradeScreenBorderGFX`, `LoadMobileTradeBorderTilemap` and
 	# `TestMobileTradeBorderTilemap` sit between the two.
+	# `InitMysteryGiftLayout`'s own `ld bc, $43 tiles`, uncompressed and
+	# straight into vTiles2, so the pin is a bounds check against the run the
+	# routine indexes rather than a decompression. `_CGB_MysteryGift` copies two
+	# palettes where Gold and Silver copy one. Located off
+	# `.String_PressAToLink_BToCancel`, the inline `db` string a page in front of
+	# the eight `text_far` stubs, which is the only plain text in the routine.
+	"mystery_gift": {
+		"gfx": 0x105258, "tiles": 0x43,
+		"background": -1, "gfx2": -1,
+		"prompt": 0x1049CD, "palette": 0x95E0, "palettes": 2,
+		"items": 0x2C725, "decos": 0x2C74A,
+	},
 	"link_border": 0x16CFC1,
 	"link_trade_tilemaps": 0x16D465,
 	# `UnownDexATile`, the two 1bpp tiles `_UnownPrinter` requests into the
@@ -3092,6 +3144,8 @@ const CRYSTAL: Dictionary = {
 		"seer_ot": 0xD02A,
 		"seer_caught_level": 0xD036,
 		"trademon_nickname": 0xD004,
+		"mystery_gift_partner_name": 0xC903,
+		"mystery_gift_player_name": 0xC953,
 	},
 	## `wOtherPlayerLinkMode`, the byte all three receptionist scripts `readmem`
 	## after `CheckLinkTimeout_Receptionist`. Located off those three `readmem`s
@@ -3100,6 +3154,7 @@ const CRYSTAL: Dictionary = {
 	"link_cant_battle_text": 0x28AAF,
 	"link_abnormal_mon_text": 0x28AC4,
 	"link_ask_trade_text": 0x28EB8,
+	"mystery_gift_text": 0x1049FD,
 	"magikarp_measure_text": 0xFBBA9,
 	"magikarp_record_text": 0xFBCE8,
 	"lucky_number_text": 0x4D9C9,

--- a/game/render/mystery_gift_page.gd
+++ b/game/render/mystery_gift_page.gd
@@ -1,0 +1,263 @@
+class_name Gen2MysteryGiftPage
+extends RefCounted
+
+## `InitMysteryGiftLayout` and the boxes `DoMysteryGift` prints over it.
+##
+## Two screens under one name: Crystal builds its frame out of one sixty-seven
+## tile run and colours it with two palettes, and Gold and Silver build theirs
+## out of three runs and one palette. Neither has a stored tilemap, so the
+## screen is the routine's own `hlcoord` writes transcribed rather than a map
+## read out of the dump; [constant CRYSTAL_LAYOUT] and [constant GS_LAYOUT] are
+## those writes in the order the routine makes them, and drawing is a walk over
+## them.
+##
+## Node-free, so a check can read the tilemap back headless.
+
+const TILE: int = Gen2Font.TILE
+const COLUMNS: int = 20
+const ROWS: int = 18
+const WIDTH: int = COLUMNS * TILE
+const HEIGHT: int = ROWS * TILE
+
+## `ClearBox`'s own fill, which is the blank the font already draws.
+const BLANK_CODE: int = 0x7F
+
+## The three shapes a `.Load*` helper writes. `gfx` steps the tile number and
+## the other two repeat it, which is the difference between a run of art and a
+## run of one border tile.
+const RUN_GFX: StringName = &"gfx"
+const RUN_ROW: StringName = &"row"
+const RUN_COLUMN: StringName = &"column"
+
+## `DoMysteryGift`'s own `hlcoord 3, 8`, a `PlaceString` straight into the box
+## `InitMysteryGiftLayout` cleared in the middle.
+const PROMPT_AT: Vector2i = Vector2i(3, 8)
+
+## Every box the routine ends on goes through `PrintText`, which is
+## `SpeechTextbox` over whatever is on screen and then `PrintTextboxTextAt` at
+## its inner corner. `hlcoord 2, 8` a line above the jump is dead: `.LinkCanceled`
+## and its seven neighbours load `hl` again before `PrintText` reads it.
+const MESSAGE_BOX_AT: Vector2i = Vector2i(0, 12)
+const MESSAGE_BOX_SIZE: Vector2i = Vector2i(20, 6)
+const MESSAGE_AT: Vector2i = Vector2i(1, 14)
+## `TEXTBOX_INNERW` and the two lines under `TEXTBOX_INNERY`, which is what a
+## box shows before it waits to be advanced.
+const MESSAGE_COLUMNS: int = 18
+const MESSAGE_ROWS: int = 2
+
+## `InitMysteryGiftLayout`, Crystal's: the screen fill, the box it clears in the
+## middle, and then every write in the routine's order. A later row overwrites
+## an earlier one, which is what the routine does too.
+const CRYSTAL_LAYOUT: Dictionary = {
+	"fill": 0x42,
+	"clear": [Vector2i(3, 7), Vector2i(15, 9)],
+	"runs": [
+		[Vector2i(0, 0), 0x00, RUN_GFX, 2],
+		[Vector2i(0, 1), 0x02, RUN_GFX, 2],
+		[Vector2i(7, 1), 0x12, RUN_GFX, 5],
+		[Vector2i(2, 2), 0x17, RUN_GFX, 16],
+		[Vector2i(2, 3), 0x27, RUN_GFX, 16],
+		[Vector2i(9, 4), 0x37, RUN_GFX, 2],
+		[Vector2i(1, 2), 0x04, RUN_ROW, 1],
+		[Vector2i(1, 3), 0x05, RUN_COLUMN, 14],
+		[Vector2i(18, 5), 0x09, RUN_COLUMN, 11],
+		[Vector2i(2, 5), 0x0B, RUN_ROW, 16],
+		[Vector2i(2, 16), 0x07, RUN_ROW, 16],
+		[Vector2i(2, 5), 0x0D, RUN_GFX, 5],
+		[Vector2i(7, 5), 0x0C, RUN_ROW, 1],
+		[Vector2i(18, 5), 0x0A, RUN_ROW, 1],
+		[Vector2i(18, 16), 0x08, RUN_ROW, 1],
+		[Vector2i(1, 16), 0x06, RUN_ROW, 1],
+		[Vector2i(2, 6), 0x3A, RUN_ROW, 16],
+		[Vector2i(2, 15), 0x40, RUN_ROW, 16],
+		[Vector2i(2, 6), 0x3C, RUN_COLUMN, 9],
+		[Vector2i(17, 6), 0x3E, RUN_COLUMN, 9],
+		[Vector2i(2, 6), 0x39, RUN_ROW, 1],
+		[Vector2i(17, 6), 0x3B, RUN_ROW, 1],
+		[Vector2i(2, 15), 0x3F, RUN_ROW, 1],
+		[Vector2i(17, 15), 0x41, RUN_ROW, 1],
+	],
+	## `_CGB_MysteryGift`'s own `FillBoxCGB` calls over a wiped attrmap: every
+	## cell is palette 0 and these five boxes are palette 1.
+	"attributes": [
+		[Vector2i(3, 7), Vector2i(14, 8)],
+		[Vector2i(1, 5), Vector2i(18, 1)],
+		[Vector2i(1, 16), Vector2i(18, 1)],
+		[Vector2i(0, 0), Vector2i(2, 17)],
+		[Vector2i(18, 5), Vector2i(1, 12)],
+	],
+}
+
+## The same routine at Gold and Silver's own tile numbers. Their art is three
+## runs loaded into vTiles2 at $00, $20 and $2f, plus the solid tile the
+## routine byte-fills at $3d, which the importer lays out as one strip in that
+## order so a code here indexes it directly.
+const GS_LAYOUT: Dictionary = {
+	"fill": 0x3D,
+	"clear": [Vector2i(3, 7), Vector2i(15, 9)],
+	"runs": [
+		[Vector2i(0, 0), 0x1E, RUN_GFX, 2],
+		[Vector2i(0, 1), 0x33, RUN_GFX, 2],
+		[Vector2i(3, 1), 0x00, RUN_GFX, 15],
+		[Vector2i(3, 2), 0x0F, RUN_GFX, 15],
+		[Vector2i(8, 0), 0x20, RUN_GFX, 4],
+		[Vector2i(9, 3), 0x24, RUN_GFX, 3],
+		[Vector2i(9, 4), 0x27, RUN_ROW, 1],
+		[Vector2i(1, 2), 0x2E, RUN_COLUMN, 15],
+		[Vector2i(18, 5), 0x2A, RUN_COLUMN, 11],
+		[Vector2i(2, 5), 0x28, RUN_ROW, 16],
+		[Vector2i(2, 16), 0x2C, RUN_ROW, 16],
+		[Vector2i(2, 5), 0x35, RUN_GFX, 4],
+		[Vector2i(18, 5), 0x29, RUN_ROW, 1],
+		[Vector2i(18, 16), 0x2B, RUN_ROW, 1],
+		[Vector2i(1, 16), 0x2D, RUN_ROW, 1],
+		[Vector2i(2, 6), 0x39, RUN_ROW, 16],
+		[Vector2i(2, 15), 0x3B, RUN_ROW, 16],
+		[Vector2i(2, 6), 0x3C, RUN_COLUMN, 9],
+		[Vector2i(17, 6), 0x3A, RUN_COLUMN, 9],
+		[Vector2i(2, 6), 0x2F, RUN_ROW, 1],
+		[Vector2i(17, 6), 0x30, RUN_ROW, 1],
+		[Vector2i(2, 15), 0x32, RUN_ROW, 1],
+		[Vector2i(17, 15), 0x31, RUN_ROW, 1],
+	],
+	## `GS_CGB_MysteryGift` copies one palette and wipes the attrmap, so every
+	## cell is palette 0.
+	"attributes": [],
+}
+
+var font: Gen2Font = null
+var palette: PackedColorArray = PackedColorArray()
+var prompt: String = ""
+
+var _tiles: PackedByteArray = PackedByteArray()
+var _tile_count: int = 0
+var _layout: Dictionary = {}
+
+
+static func from_data(data: GameData) -> Gen2MysteryGiftPage:
+	if data == null or not data.has_mystery_gift():
+		return null
+	var page := Gen2MysteryGiftPage.new()
+	page.font = Gen2Font.from_data(data)
+	page.palette = data.mystery_gift_palette()
+	page.prompt = data.mystery_gift_prompt()
+	page._tiles = data.mystery_gift_indices()
+	if page.font == null or page.palette.is_empty() or page._tiles.is_empty():
+		return null
+	page._tile_count = page._tiles.size() / (TILE * TILE)
+	## Two palettes is Crystal's `_CGB_MysteryGift`; one is Gold and Silver's.
+	page._layout = CRYSTAL_LAYOUT if page.palette.size() > 4 else GS_LAYOUT
+	return page
+
+
+## The tilemap the routine leaves behind, as one row-major array of codes.
+func tilemap() -> PackedByteArray:
+	var map := PackedByteArray()
+	map.resize(COLUMNS * ROWS)
+	map.fill(int(_layout["fill"]))
+	var clear: Array = _layout["clear"] as Array
+	_fill(map, clear[0], clear[1], BLANK_CODE)
+	for run: Array in _layout["runs"] as Array:
+		var at: Vector2i = run[0]
+		var code: int = int(run[1])
+		var count: int = int(run[3])
+		for step: int in count:
+			var cell: Vector2i = (
+				at + Vector2i(0, step) if run[2] == RUN_COLUMN
+				else at + Vector2i(step, 0)
+			)
+			if cell.x < 0 or cell.x >= COLUMNS or cell.y < 0 or cell.y >= ROWS:
+				continue
+			map[cell.y * COLUMNS + cell.x] = (
+				(code + step) & 0xFF if run[2] == RUN_GFX else code
+			)
+	return map
+
+
+## Which palette each cell takes, which is what `FillBoxCGB` writes into the
+## attrmap. All zero on Gold and Silver, whose layout copies one palette.
+func attributes() -> PackedByteArray:
+	var attrs := PackedByteArray()
+	attrs.resize(COLUMNS * ROWS)
+	attrs.fill(0)
+	for box: Array in _layout["attributes"] as Array:
+		_fill(attrs, box[0], box[1], 1)
+	return attrs
+
+
+## The screen with [param text] in the box `DoMysteryGift` prints into. Empty
+## text is the prompt the screen opens on, which is the routine's own
+## `.String_PressAToLink_BToCancel` and is drawn one column further in.
+func render(text: String = "") -> Image:
+	var indices := PackedByteArray()
+	indices.resize(WIDTH * HEIGHT)
+	var map: PackedByteArray = tilemap()
+	for cell: int in map.size():
+		_blit(indices, int(map[cell]), Vector2i(cell % COLUMNS, cell / COLUMNS))
+	if text.is_empty():
+		var line: int = 0
+		for row: String in prompt.split("\n"):
+			font.draw_text(
+				row, indices, WIDTH, PROMPT_AT.x * TILE, (PROMPT_AT.y + line) * TILE
+			)
+			line += 1
+	else:
+		_draw_message(indices, text)
+	return _compose(indices)
+
+
+## `PrintText`: `SpeechTextbox` is `Textbox`, which clears its own interior
+## before drawing the border, so the frame under it does not show through.
+func _draw_message(indices: PackedByteArray, text: String) -> void:
+	for row: int in MESSAGE_BOX_SIZE.y * TILE:
+		var start: int = (MESSAGE_BOX_AT.y * TILE + row) * WIDTH \
+			+ MESSAGE_BOX_AT.x * TILE
+		for column: int in MESSAGE_BOX_SIZE.x * TILE:
+			indices[start + column] = 0
+	font.draw_box(
+		Gen2OptionsStore.current().textbox_frame, indices, WIDTH,
+		MESSAGE_BOX_AT.x * TILE, MESSAGE_BOX_AT.y * TILE,
+		MESSAGE_BOX_SIZE.x, MESSAGE_BOX_SIZE.y
+	)
+	var line: int = 0
+	for row: String in text.split("\n"):
+		font.draw_text(
+			row, indices, WIDTH, MESSAGE_AT.x * TILE, (MESSAGE_AT.y + line) * TILE
+		)
+		line += 1
+
+
+## The two palettes over one index buffer. A cell's attribute picks which four
+## colours its pixels are read through, which is what the CGB does with the
+## attrmap and what one call to [method Gen2PicImage.from_indices] cannot do.
+func _compose(indices: PackedByteArray) -> Image:
+	if palette.size() <= 4:
+		return Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, palette)
+	var attrs: PackedByteArray = attributes()
+	var image: Image = Image.create_empty(WIDTH, HEIGHT, false, Image.FORMAT_RGBA8)
+	for y: int in HEIGHT:
+		var row: int = (y / TILE) * COLUMNS
+		for x: int in WIDTH:
+			var bank: int = int(attrs[row + x / TILE]) * 4
+			image.set_pixel(x, y, palette[bank + (indices[y * WIDTH + x] & 3)])
+	return image
+
+
+static func _fill(
+	into: PackedByteArray, at: Vector2i, size: Vector2i, value: int
+) -> void:
+	for row: int in size.y:
+		for column: int in size.x:
+			var cell: Vector2i = at + Vector2i(column, row)
+			if cell.x < 0 or cell.x >= COLUMNS or cell.y < 0 or cell.y >= ROWS:
+				continue
+			into[cell.y * COLUMNS + cell.x] = value
+
+
+func _blit(into: PackedByteArray, code: int, at: Vector2i) -> void:
+	if code >= RomLayout.FONT_FIRST_CODE or code >= _tile_count:
+		font.draw_code(code, into, WIDTH, at.x * TILE, at.y * TILE)
+		return
+	Gen2Font.blit_slot(
+		_tiles, _tile_count * TILE, code, into, WIDTH, at.x * TILE, at.y * TILE
+	)

--- a/game/render/mystery_gift_page.gd.uid
+++ b/game/render/mystery_gift_page.gd.uid
@@ -1,0 +1,1 @@
+uid://dpgof8pxodrc4

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -91,6 +91,12 @@ var mailbox: Array = []
 ## this defaults rather than versioning; a slot written before link play reads
 ## as one that has never linked, which is the truth about it.
 var link_record: Dictionary = Gen2LinkSession.normalize_record({})
+## `sMysteryGiftData`: the waiting gift, the day's partners, the decorations
+## already received and the name the Trainer House reads. It sits outside the
+## checksummed save on the cartridge, which is why the exchange can happen from
+## the menu with no file loaded, and it defaults here the way `mailbox` and
+## `box_names` do rather than versioning.
+var mystery_gift: Dictionary = Gen2MysteryGift.default_section()
 
 
 func _init() -> void:
@@ -129,6 +135,7 @@ func to_dict() -> Dictionary:
 		"current_box": current_box,
 		"hall_of_fame": hall_of_fame.duplicate(true),
 		"link_record": link_record.duplicate(true),
+		"mystery_gift": mystery_gift.duplicate(true),
 		"box_names": box_names.duplicate(),
 		"mailbox": _mailbox_dicts(),
 		"world": world.to_dict() if world != null else {},
@@ -164,6 +171,7 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	out.current_box = clampi(int(source.get("current_box", 0)), 0, BOX_COUNT - 1)
 	out.hall_of_fame = Gen2HallOfFame.parse_records(source.get("hall_of_fame", []))
 	out.link_record = Gen2LinkSession.normalize_record(source.get("link_record", {}))
+	out.mystery_gift = Gen2MysteryGift.normalize(source.get("mystery_gift", {}))
 	var raw_box_names: Variant = source.get("box_names", [])
 	if raw_box_names is Array:
 		for index: int in mini((raw_box_names as Array).size(), BOX_COUNT):
@@ -348,6 +356,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	current_box = copied.current_box
 	hall_of_fame = copied.hall_of_fame.duplicate(true)
 	link_record = copied.link_record.duplicate(true)
+	mystery_gift = copied.mystery_gift.duplicate(true)
 	box_names = copied.box_names.duplicate()
 	mailbox = copied.mailbox.duplicate()
 	world = copied.world

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -29,6 +29,13 @@ var _name_input: LineEdit = null
 var _export_dialog: Gen2LauncherFilePicker = null
 var _slot_import_dialog: Gen2LauncherFilePicker = null
 var _file_dialog: Gen2LauncherFilePicker = null
+## `MysteryGift`'s own screen, which is a main-menu row on the cartridge and
+## belongs here for the same reason its SRAM block sits outside the checksummed
+## save: the exchange happens with no file loaded, and the two slots this
+## screen already lists are the only two Mystery Gift blocks on one machine.
+var _mystery_gift: Gen2MysteryGiftScreen = null
+var _mystery_gift_hardware: Gen2Screen = null
+var _mystery_gift_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 func _ready() -> void:
@@ -358,6 +365,15 @@ func _refresh_details() -> void:
 		body.add_child(save_actions)
 		save_actions.add_child(_action("Continue", Gen2LauncherButton.Variant.PRIMARY, &"play", _continue_selected))
 		save_actions.add_child(_action("Party", Gen2LauncherButton.Variant.NEUTRAL, &"", _open_party))
+		## `MainMenu_GetWhichMenu`: the row is on the menu once
+		## `sNumDailyMysteryGiftPartnerIDs` is no longer -1, which is the byte a
+		## save wrote rather than the one Carrie cleared, so it appears on the
+		## session after the explanation rather than during it.
+		if Gen2MysteryGift.menu_row_unlocked(save.mystery_gift):
+			save_actions.add_child(_action(
+				"Mystery Gift", Gen2LauncherButton.Variant.NEUTRAL, &"",
+				_open_mystery_gift
+			))
 		save_actions.add_child(_action("Import .sav", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_import))
 		save_actions.add_child(_action("Replace", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_new_game))
 		_add_party_summary(body, save)
@@ -602,6 +618,92 @@ func _continue_selected() -> void:
 	Gen2LauncherAudio.play(&"power")
 	await _shell.flash(false)
 	get_tree().change_scene_to_file.call_deferred("res://game/world/world_screen.tscn")
+
+
+## `MainMenu_MysteryGift`: `UpdateTime`, the day countdown, and then the
+## screen. The partner is the first other occupied slot of the same cartridge,
+## which is `IR_SENDER`'s Game Boy here; no other slot is nobody in the window,
+## and the exchange times out the way the routine does with one console.
+func _open_mystery_gift() -> void:
+	var save: Gen2SaveData = _load_selected_save()
+	if _data == null or save == null or _mystery_gift != null:
+		return
+	var random := RandomNumberGenerator.new()
+	var host := Gen2MysteryGiftScreen.new()
+	host.set_context(
+		_data, save, _mystery_gift_transport(save, random),
+		_mystery_gift_dex_caught(save), _mystery_gift_day(save), random
+	)
+	host.closed.connect(_close_mystery_gift.bind(save))
+	_mystery_gift = host
+	_mystery_gift_hardware = Gen2Screen.host_for(self, _mystery_gift_hardware)
+	_mystery_gift_hardware.display(host)
+	set_process(true)
+
+
+## The other slot's own block, staged the moment the window opens: the roll is
+## that save's rather than this one's, which is what makes the item it offers
+## its own.
+func _mystery_gift_transport(
+	save: Gen2SaveData, random: RandomNumberGenerator
+) -> Gen2MysteryGiftTransport:
+	for slot: int in Gen2SaveStore.occupied_slots(_data.id, _data.sha1):
+		if slot == save.slot:
+			continue
+		var loaded: Dictionary = Gen2SaveStore.load_result(
+			_data.id, _data.sha1, slot, _data
+		)
+		if not bool(loaded.get("ok", false)):
+			continue
+		var peer: Gen2SaveData = loaded["save"] as Gen2SaveData
+		return Gen2MysteryGiftTransport.to_save(
+			peer, _mystery_gift_dex_caught(peer), random
+		)
+	return Gen2MysteryGiftTransport.new()
+
+
+## Which day the countdown behind the daily limit is measured in. A slot carries
+## the world day it was saved on; one with no world yet is day zero, which is
+## where a new game starts.
+func _mystery_gift_day(save: Gen2SaveData) -> int:
+	return save.world.world_day if save.world != null else 0
+
+
+## `CountSetBits` over `wPokedexCaught`, which is what a partner's block carries
+## and nothing here reads back. A slot with no world has caught nothing.
+func _mystery_gift_dex_caught(save: Gen2SaveData) -> int:
+	if save.world == null or save.world.world_state == null:
+		return 0
+	return save.world.world_state.caught_count()
+
+
+func _close_mystery_gift(save: Gen2SaveData) -> void:
+	var host: Gen2MysteryGiftScreen = _mystery_gift
+	_mystery_gift = null
+	if host != null:
+		Gen2Screen.drop(host)
+	set_process(false)
+	## The section is the file's, so a gift that arrived is written back before
+	## the screen is forgotten.
+	Gen2SaveStore.save(save, _data)
+	_refresh()
+
+
+func _process(delta: float) -> void:
+	if _mystery_gift == null:
+		return
+	for _frame: int in _mystery_gift_clock.tick(delta):
+		_mystery_gift.advance_frame()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if _mystery_gift == null:
+		return
+	var button: int = Gen2Button.pressed_in(event)
+	if button == Gen2Button.NONE:
+		return
+	get_viewport().set_input_as_handled()
+	_mystery_gift.handle_button(button)
 
 
 func _open_party() -> void:

--- a/game/world/mystery_gift.gd
+++ b/game/world/mystery_gift.gd
@@ -1,0 +1,405 @@
+class_name Gen2MysteryGift
+extends RefCounted
+
+## `engine/link/mystery_gift.asm` and `mystery_gift_2.asm`: the SRAM block, the
+## staged block the two Game Boys swap over IR, and `DoMysteryGift`'s own chain
+## of refusals between the exchange and the gift.
+##
+## Mystery Gift is not the cable link play [Gen2LinkSession] runs. It never
+## touches `wLinkMode`, it has its own `sMysteryGiftData` section outside the
+## checksummed save, and its peer is an infrared window rather than a wire, so
+## the transport is its own too ([Gen2MysteryGiftTransport]).
+##
+## Everything here is the section and the decision. The pixels are
+## [Gen2MysteryGiftPage] and the host is [Gen2MysteryGiftScreen]; the three
+## specials that reach the section from a script are
+## [Gen2WorldScriptRunner]'s.
+
+## `constants/serial_constants.asm`. Five gifts in a day, and one per person.
+const MAX_PARTNERS: int = 5
+
+## `constants/deco_constants.asm`. The two trophy dolls sit past it, so a
+## received decoration can never be one.
+const NUM_NON_TROPHY_DECOS: int = 43
+
+## `MysteryGiftFallbackItem`, which both tables share: `DECOFLAG_RED_CARPET` and
+## `GREAT_BALL` are the same byte, and which one it means is which table the
+## index missed.
+const FALLBACK_GIFT: int = 4
+
+## `hMGStatusFlags`. `MG_OKAY` is every error bit clear, which is what
+## `ExchangeMysteryGiftData` returns on a finished exchange.
+const MG_OKAY: int = 0
+const MG_WRONG_CHECKSUM: int = 1 << 0
+const MG_TIMED_OUT: int = 1 << 1
+const MG_CANCELED: int = 1 << 4
+const MG_WRONG_PREFIX: int = 1 << 7
+
+## `constants/misc_constants.asm`. Mystery Gift sends `GS_VERSION + 1`, so a
+## Game Boy game is 1 or 2; the two above it are the Pokemon Pikachu 2 and the
+## version reserved beside it, and both skip parts of the chain.
+const GAME_VERSION_GS: int = 1
+const POKEMON_PIKACHU_2_VERSION: int = 3
+const RESERVED_GAME_VERSION: int = 4
+
+## `NAME_LENGTH`, which is what `.SaveMysteryGiftTrainerName` copies.
+const NAME_LENGTH: int = 11
+
+## Which box `DoMysteryGift` ends on. Each names one of the eight `text_far`
+## stubs behind the routine, in the run's own order, so the key is the string
+## the importer reads rather than a message written here.
+const OUTCOME_CANCELED: StringName = &"canceled"
+const OUTCOME_COMM_ERROR: StringName = &"comm_error"
+const OUTCOME_RETRIEVE: StringName = &"retrieve"
+const OUTCOME_FRIEND_NOT_READY: StringName = &"friend_not_ready"
+const OUTCOME_FIVE_A_DAY: StringName = &"five_a_day"
+const OUTCOME_ONE_A_DAY: StringName = &"one_a_day"
+const OUTCOME_SENT: StringName = &"sent"
+const OUTCOME_SENT_HOME: StringName = &"sent_home"
+
+## The stub run's own order, which is the order `SPECIAL_TEXT_RUNS` reads it in.
+const OUTCOME_ORDER: Array[StringName] = [
+	OUTCOME_CANCELED, OUTCOME_COMM_ERROR, OUTCOME_RETRIEVE,
+	OUTCOME_FRIEND_NOT_READY, OUTCOME_FIVE_A_DAY, OUTCOME_ONE_A_DAY,
+	OUTCOME_SENT, OUTCOME_SENT_HOME,
+]
+
+## `sMysteryGiftUnlocked` and `sNumDailyMysteryGiftPartnerIDs` before Carrie has
+## explained the machine. `UnlockMysteryGift` is the only thing that clears it,
+## and the main menu reads the second byte rather than the first.
+const LOCKED: int = 0xFF
+
+
+## The section a slot that has never seen a Mystery Gift carries.
+##
+## `sMysteryGiftData` is two pairs rather than one block, and the pairing is
+## what `BackupMysteryGift` and `RestoreMysteryGift` copy between: `item` and
+## `unlocked` are the working bytes the exchange writes, `backup_item` and
+## `daily_partners` are the pair a save writes and a load reads back. The
+## second byte of the backup pair is also the day's partner counter, which is
+## why the main menu's row does not appear until the game after Carrie.
+static func default_section() -> Dictionary:
+	return {
+		"item": 0,
+		"unlocked": LOCKED,
+		"backup_item": 0,
+		"daily_partners": LOCKED,
+		"partner_ids": [],
+		"decorations_received": [],
+		"timer": 0,
+		"trainer_house_flag": 0,
+		"partner_name": "",
+		"trainer": {},
+	}
+
+
+## Reads a stored section back, clamping every byte to what SRAM could hold.
+## A slot written before Mystery Gift existed has no key at all, and every one
+## of them then defaults, which is the truth about it.
+static func normalize(source: Variant) -> Dictionary:
+	var out: Dictionary = default_section()
+	if source is not Dictionary:
+		return out
+	var raw: Dictionary = source as Dictionary
+	for key: String in ["item", "unlocked", "backup_item", "daily_partners",
+			"trainer_house_flag"]:
+		out[key] = int(raw.get(key, out[key])) & 0xFF
+	out["timer"] = int(raw.get("timer", 0)) & 0xFFFF
+	out["partner_name"] = String(raw.get("partner_name", "")).substr(0, NAME_LENGTH)
+	var ids: Variant = raw.get("partner_ids", [])
+	if ids is Array:
+		for id: Variant in (ids as Array).slice(0, MAX_PARTNERS):
+			(out["partner_ids"] as Array).append(int(id) & 0xFFFF)
+	var received: Variant = raw.get("decorations_received", [])
+	if received is Array:
+		for deco: Variant in received as Array:
+			var index: int = int(deco)
+			if index >= 0 and index < NUM_NON_TROPHY_DECOS \
+					and index not in out["decorations_received"]:
+				(out["decorations_received"] as Array).append(index)
+	var trainer: Variant = raw.get("trainer", {})
+	if trainer is Dictionary:
+		out["trainer"] = (trainer as Dictionary).duplicate(true)
+	return out
+
+
+## `UnlockMysteryGift`, Carrie's own special. `sMysteryGiftUnlocked` of -1 is
+## the locked state, and clearing it clears `sMysteryGiftItem` with it; a byte
+## that is anything else is left alone, so talking to her twice is not a way to
+## throw a waiting gift away.
+static func unlock(section: Dictionary) -> bool:
+	if int(section.get("unlocked", LOCKED)) != LOCKED:
+		return false
+	section["unlocked"] = 0
+	section["item"] = 0
+	return true
+
+
+## `CheckMysteryGift`'s own answer into `wScriptVar`: zero when no gift is
+## waiting, and the item plus one when one is. POKECENTER_2F's scene script
+## branches on the zero and nothing reads the value it puts there otherwise.
+static func check_value(section: Dictionary) -> int:
+	var item: int = int(section.get("item", 0)) & 0xFF
+	return 0 if item == 0 else (item + 1) & 0xFF
+
+
+## `GetMysteryGiftItem`'s SRAM half. The bag is the caller's, so this answers
+## which item is waiting and clears the byte only once the caller says it went
+## in: `.no_room` closes SRAM without clearing, so a full bag keeps the gift.
+static func take_item(section: Dictionary) -> int:
+	return int(section.get("item", 0)) & 0xFF
+
+
+static func clear_item(section: Dictionary) -> void:
+	section["item"] = 0
+
+
+## `ResetDailyMysteryGiftLimitIfUnlocked`, which `DoMysteryGiftIfDayHasPassed`
+## calls once a day has passed. A locked file keeps its -1: clearing the
+## counter there would unlock the main menu's row on the first midnight.
+static func reset_daily_limit_if_unlocked(section: Dictionary) -> bool:
+	if int(section.get("daily_partners", LOCKED)) == LOCKED:
+		return false
+	section["daily_partners"] = 0
+	(section["partner_ids"] as Array).clear()
+	return true
+
+
+## `BackupMysteryGift`, which every save runs: the working pair goes to the
+## backup pair.
+static func backup(section: Dictionary) -> void:
+	section["backup_item"] = int(section.get("item", 0)) & 0xFF
+	section["daily_partners"] = int(section.get("unlocked", LOCKED)) & 0xFF
+
+
+## `RestoreMysteryGift`, which `TryLoadSaveFile` runs: the backup pair comes
+## back into the working pair. The exchange happens outside a loaded game, so
+## this is what carries a gift received at the menu into the file.
+static func restore(section: Dictionary) -> void:
+	section["item"] = int(section.get("backup_item", 0)) & 0xFF
+	section["unlocked"] = int(section.get("daily_partners", LOCKED)) & 0xFF
+
+
+## `MainMenu_GetWhichMenu`'s own test: the row is on the menu when
+## `sNumDailyMysteryGiftPartnerIDs` is not -1, which is the byte a save wrote
+## rather than the one Carrie cleared.
+static func menu_row_unlocked(section: Dictionary) -> bool:
+	return int(section.get("daily_partners", LOCKED)) != LOCKED
+
+
+## `CheckAndSetMysteryGiftDecorationAlreadyReceived`. Answers whether the
+## decoration is new, and records it when it is; the flag array is
+## `sMysteryGiftDecorationsReceived` and it is what
+## `CopyMysteryGiftReceivedDecorationsToPC` walks on the next Continue.
+static func receive_decoration(section: Dictionary, deco: int) -> bool:
+	var received: Array = section["decorations_received"] as Array
+	if deco in received:
+		return false
+	received.append(deco)
+	return true
+
+
+## `CopyMysteryGiftReceivedDecorationsToPC`, run once per Continue: every flag
+## the array carries becomes the decoration's own event flag, which is where
+## ownership lives ([Gen2WorldDecoration]). The array is not cleared, so the
+## walk is idempotent and a decoration received while a different slot was
+## loaded still arrives.
+static func copy_decorations_to_pc(
+	section: Dictionary, data: GameData, state: Gen2WorldState
+) -> int:
+	var given: int = 0
+	for deco: int in section.get("decorations_received", []) as Array:
+		if Gen2WorldDecoration.set_owned(data, state, deco):
+			given += 1
+	return given
+
+
+## `MysteryGiftGetItem` and `MysteryGiftGetDecoration`, which share
+## `MysteryGiftFallbackItem`: an index past either table's end is a RED CARPET
+## as a decoration and a GREAT BALL as an item, the same byte read two ways.
+##
+## [param table] is the imported `MysteryGiftItems` or `MysteryGiftDecos`.
+static func gift_at(table: Array, index: int) -> int:
+	if index < 0 or index >= table.size():
+		return FALLBACK_GIFT
+	return int(table[index]) & 0xFF
+
+
+## `StageDataForMysteryGift`: the twenty bytes this Game Boy holds out to the
+## other one. Every field is read at the moment the window opens, so the item
+## and the decoration a partner offers are rolled here rather than by whoever
+## receives them.
+static func stage_player_data(
+	save: Gen2SaveData, section: Dictionary, dex_caught: int,
+	random: RandomNumberGenerator
+) -> Dictionary:
+	var id: int = (save.player_id if save != null else 0) & 0xFFFF
+	var id_high: int = (id >> 8) & 0xFF
+	var id_low: int = id & 0xFF
+	return {
+		"game_version": GAME_VERSION_GS,
+		"id": id,
+		"name": save.player_name if save != null else "",
+		"dex_caught": dex_caught & 0xFF,
+		## `Random / and 1`: which of the two tables this side is offering from.
+		"sent_deco": random.randi() & 1,
+		"which_item": _random_sample(id_high, id_low, random),
+		## The second call swaps b and c, so the two rolls read the ID's two
+		## bytes the other way round.
+		"which_deco": _random_sample(id_low, id_high, random),
+		"backup_item": int(section.get("backup_item", 0)) & 0xFF,
+		"daily_partners": int(section.get("daily_partners", LOCKED)) & 0xFF,
+	}
+
+
+## `StageDataForMysteryGift.RandomSample`, which is four weighted bands rather
+## than an index: about 90% of the time a row of the table's first sixteen,
+## then eight, then eight, then one of the last two. The player's own ID picks
+## the odd row inside a band, so two players sitting down together do not offer
+## the same thing.
+static func _random_sample(
+	high: int, low: int, random: RandomNumberGenerator
+) -> int:
+	if (random.randi() & 0xFF) >= 25:
+		var pick: int = random.randi() & 0x7
+		return (pick << 1) + (1 if _rotated_bit(pick) & low else 0)
+	if (random.randi() & 0xFF) >= 50:
+		var pick: int = random.randi() & 0x3
+		return 0x10 + (pick << 1) + (1 if _rotated_bit(pick) & high else 0)
+	if (random.randi() & 0xFF) >= 50:
+		## `swap a / and $7`: the ID byte's high nibble, three bits of it.
+		return 0x18 + ((high >> 4) & 0x7)
+	return 0x21 if high & 0x80 else 0x20
+
+
+## The `rlc e` loop the sample tests its ID byte with: `e` starts at $80 and is
+## rotated once per count, so a count of zero rotates 256 times and lands back
+## where it started rather than not rotating at all.
+static func _rotated_bit(count: int) -> int:
+	return 1 << ((7 + (count if count > 0 else 256)) % 8)
+
+
+## `DoMysteryGift` from the exchange down: every refusal in the routine's own
+## order, and the gift behind the last of them.
+##
+## The section is written in place, which is what the cartridge does to SRAM
+## between one box and the next: the partner ID is added and the trainer name
+## saved before the gift is chosen, so a partner who offers a decoration this
+## side already owns still counts against both daily limits.
+##
+## Answers `{ outcome, name, item, deco, retry }`. `outcome` names one of the
+## eight `text_far` stubs, `name` is what the box's `<PLAYER>`-style buffer
+## holds, and `retry` is `.CommunicationError`'s own `jp DoMysteryGift`: the
+## routine goes back to the prompt rather than leaving the screen.
+static func exchange(
+	section: Dictionary, transport: Gen2MysteryGiftTransport,
+	player: Dictionary, tables: Dictionary, data: GameData = null
+) -> Dictionary:
+	var status: int = transport.status()
+	var partner: Dictionary = transport.exchange(player) if status == MG_OKAY else {}
+	if status == MG_CANCELED:
+		return _outcome(OUTCOME_CANCELED)
+	if status != MG_OKAY or partner.is_empty():
+		return _outcome(OUTCOME_COMM_ERROR, "", true)
+
+	var version: int = int(partner.get("game_version", GAME_VERSION_GS))
+	if version != POKEMON_PIKACHU_2_VERSION:
+		if int(section.get("daily_partners", 0)) >= MAX_PARTNERS:
+			return _outcome(OUTCOME_FIVE_A_DAY)
+		var seen: Array = section.get("partner_ids", []) as Array
+		if int(partner.get("id", 0)) in seen:
+			return _outcome(OUTCOME_ONE_A_DAY)
+	## `wMysteryGiftPlayerBackupItem` is this side's own waiting gift, so a
+	## player who has not been to the counter cannot take a second one.
+	if int(section.get("backup_item", 0)) != 0:
+		return _outcome(OUTCOME_RETRIEVE)
+	if int(partner.get("backup_item", 0)) != 0:
+		return _outcome(OUTCOME_FRIEND_NOT_READY)
+
+	if version != POKEMON_PIKACHU_2_VERSION:
+		_add_partner_id(section, int(partner.get("id", 0)))
+		if version != RESERVED_GAME_VERSION:
+			_save_partner_trainer(section, partner)
+
+	if int(partner.get("sent_deco", 0)) != 0:
+		var deco: int = gift_at(
+			tables.get("decos", []) as Array, int(partner.get("which_deco", 0))
+		)
+		if receive_decoration(section, deco):
+			return _outcome(
+				OUTCOME_SENT_HOME, Gen2WorldDecoration.decoration_name(data, deco)
+			)
+	var item: int = gift_at(
+		tables.get("items", []) as Array, int(partner.get("which_item", 0))
+	)
+	## The gift lands in the backup pair, which is where the counter reads it
+	## from once `RestoreMysteryGift` has carried it into the loaded file.
+	section["backup_item"] = item
+	return _outcome(OUTCOME_SENT, _item_name(data, item))
+
+
+static func _outcome(
+	outcome: StringName, name: String = "", retry: bool = false
+) -> Dictionary:
+	return {"outcome": outcome, "name": name, "retry": retry}
+
+
+## `.AddMysteryGiftPartnerID`, which counts the partner whether or not the gift
+## behind it is one this side keeps.
+static func _add_partner_id(section: Dictionary, id: int) -> void:
+	var ids: Array = section["partner_ids"] as Array
+	if ids.size() < MAX_PARTNERS:
+		ids.append(id & 0xFFFF)
+	section["daily_partners"] = mini(
+		int(section.get("daily_partners", 0)) + 1, 0xFF
+	)
+
+
+## `.SaveMysteryGiftTrainerName`, which is what the Trainer House reads: the
+## partner's name and the flag that says somebody has linked.
+##
+## The party beside them is deliberately empty, because a real cartridge's is:
+## `StagePartyDataForMysteryGift` sits behind a `vc_patch` and is unreferenced
+## in the retail build, so `ClearMysteryGiftTrainer` zeroes `wMysteryGiftTrainer`
+## and nothing ever fills it. `GetTrainerName` still reads the name, which is
+## the half that works.
+static func _save_partner_trainer(section: Dictionary, partner: Dictionary) -> void:
+	section["trainer_house_flag"] = 1
+	section["partner_name"] = String(partner.get("name", "")).substr(0, NAME_LENGTH)
+	section["trainer"] = {"name": section["partner_name"], "party": []}
+
+
+static func _item_name(data: GameData, item: int) -> String:
+	if data == null:
+		return ""
+	return String((data.item(item) as Dictionary).get("name", ""))
+
+
+## `DoMysteryGiftIfDayHasPassed`, which is the only thing that resets the day's
+## partner list and runs when the menu row is chosen rather than at midnight.
+##
+## `sMysteryGiftTimer` is `InitOneDayCountdown`'s own two bytes: the days still
+## to run, and the day the countdown started on. `CheckDayDependentEventHL`
+## takes the days since that start off the first byte and reports the borrow,
+## so the limit lifts on the first opening a day or more later.
+static func day_has_passed(section: Dictionary, day: int) -> bool:
+	var timer: int = int(section.get("timer", 0)) & 0xFFFF
+	var remaining: int = (timer >> 8) & 0xFF
+	var started: int = timer & 0xFF
+	var elapsed: int = posmod(day - started, Gen2WorldClock.DAYS_PER_WEEK)
+	return elapsed >= remaining
+
+
+## `InitOneDayCountdown`: one day to run, from today.
+static func start_countdown(section: Dictionary, day: int) -> void:
+	section["timer"] = (1 << 8) | (day & 0xFF)
+
+
+## `MysteryGift`'s own two calls in front of the screen: the countdown is read,
+## the day's partners are cleared if it has run out, and it is restarted.
+static func begin_session(section: Dictionary, day: int) -> bool:
+	var lifted: bool = false
+	if day_has_passed(section, day):
+		lifted = reset_daily_limit_if_unlocked(section)
+		start_countdown(section, day)
+	return lifted

--- a/game/world/mystery_gift.gd.uid
+++ b/game/world/mystery_gift.gd.uid
@@ -1,0 +1,1 @@
+uid://cilcip6p1tg2k

--- a/game/world/mystery_gift_screen.gd
+++ b/game/world/mystery_gift_screen.gd
@@ -1,0 +1,204 @@
+class_name Gen2MysteryGiftScreen
+extends Control
+
+## `DoMysteryGift` (`engine/link/mystery_gift.asm`), from the prompt the screen
+## opens on to the box it ends on.
+##
+## The routine is three steps and no menu: the layout with
+## `.String_PressAToLink_BToCancel` under it, A to hold the infrared window open
+## and B to leave it, and then one box. Everything the box could say is
+## [method Gen2MysteryGift.exchange]'s answer, so this screen owns the wait, the
+## two buttons and the picture; the decision is not here and neither is the
+## section.
+##
+## It is the main menu's row rather than an overworld one, so its host is the
+## save screen: the section lives outside the checksummed save on the cartridge
+## precisely so the exchange can happen with no file loaded, and the two slots
+## the save screen already has in front of it are the only two Mystery Gift
+## blocks that exist on one machine.
+
+signal closed()
+
+## What is on screen, in the order the routine reaches them.
+enum STEP { PROMPT, EXCHANGING, MESSAGE }
+
+## `ExchangeMysteryGiftData`'s own four-second timeout, in hardware frames. The
+## screen spends it whether or not a partner is in the window, because that is
+## what the routine spends looking.
+const EXCHANGE_FRAMES: int = 60 * 4
+
+var _page: Gen2MysteryGiftPage = null
+var _data: GameData = null
+var _save: Gen2SaveData = null
+var _transport: Gen2MysteryGiftTransport = null
+var _random: RandomNumberGenerator = null
+var _dex_caught: int = 0
+var _day: int = 0
+
+var _step: STEP = STEP.PROMPT
+var _frames: int = 0
+var _result: Dictionary = {}
+var _pages: Array = []
+var _page_index: int = 0
+var _background: TextureRect = null
+
+
+## [param transport] is the infrared window; one with nobody in it is a real
+## path rather than a stub. [param day] is the world day the countdown behind
+## the daily limit is measured in.
+func set_context(
+	data: GameData, save: Gen2SaveData, transport: Gen2MysteryGiftTransport,
+	dex_caught: int, day: int, random: RandomNumberGenerator
+) -> void:
+	_data = data
+	_save = save
+	_transport = transport if transport != null else Gen2MysteryGiftTransport.new()
+	_dex_caught = dex_caught
+	_day = day
+	_random = random if random != null else RandomNumberGenerator.new()
+	_page = Gen2MysteryGiftPage.from_data(data)
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _page == null or _save == null:
+		closed.emit()
+		return
+	_background = TextureRect.new()
+	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_background)
+	## `MysteryGift`'s own two calls in front of the screen: `UpdateTime` and
+	## `DoMysteryGiftIfDayHasPassed`, which is what lifts yesterday's limit.
+	Gen2MysteryGift.begin_session(_section(), _day)
+	_refresh()
+
+
+func step() -> STEP:
+	return _step
+
+
+## What the last exchange answered, empty before one has run.
+func result() -> Dictionary:
+	return _result.duplicate()
+
+
+func handle_button(button: int) -> bool:
+	if _page == null:
+		return false
+	match _step:
+		STEP.PROMPT:
+			if button == Gen2Button.A:
+				_step = STEP.EXCHANGING
+				_frames = EXCHANGE_FRAMES
+				_refresh()
+			elif button == Gen2Button.B:
+				closed.emit()
+		STEP.MESSAGE:
+			if button in [Gen2Button.A, Gen2Button.B]:
+				if _page_index + 1 < _pages.size():
+					_page_index += 1
+					_refresh()
+				elif bool(_result.get("retry", false)):
+					## `.CommunicationError` is the one box that does not leave:
+					## `jp DoMysteryGift` puts the prompt back up.
+					_step = STEP.PROMPT
+					_refresh()
+				else:
+					closed.emit()
+	return true
+
+
+func advance_frame() -> void:
+	if _frames <= 0:
+		return
+	_frames -= 1
+	if _frames == 0 and _step == STEP.EXCHANGING:
+		_exchange()
+
+
+func settle(limit: int = EXCHANGE_FRAMES + 8) -> void:
+	var guard: int = limit
+	while _frames > 0 and guard > 0:
+		advance_frame()
+		guard -= 1
+
+
+## The whole of the routine past `ExchangeMysteryGiftData`, and the write-back
+## behind it: the section this screen edited is the save's, so a gift lands in
+## the slot that was chosen rather than in the one being played.
+func _exchange() -> void:
+	var section: Dictionary = _section()
+	var player: Dictionary = Gen2MysteryGift.stage_player_data(
+		_save, section, _dex_caught, _random
+	)
+	_result = Gen2MysteryGift.exchange(section, _transport, player, {
+		"items": _data.mystery_gift_table(false),
+		"decos": _data.mystery_gift_table(true),
+	}, _data)
+	_save.mystery_gift = section
+	_pages = Gen2TextLayout.lay_out(box_text(
+		_data, StringName(_result.get("outcome", &"")),
+		String(_transport.peer.get("name", "")),
+		_save.player_name, String(_result.get("name", ""))
+	), Gen2MysteryGiftPage.MESSAGE_COLUMNS, Gen2MysteryGiftPage.MESSAGE_ROWS)
+	_page_index = 0
+	_step = STEP.MESSAGE
+	_refresh()
+
+
+func _section() -> Dictionary:
+	if _save.mystery_gift.is_empty():
+		_save.mystery_gift = Gen2MysteryGift.default_section()
+	return _save.mystery_gift
+
+
+## One of `DoMysteryGift`'s eight boxes with its `text_ram` markers filled in.
+## The two the gift arrives in name the partner, the player and the gift; the
+## other six name nobody, and filling a marker they do not carry costs nothing.
+static func box_text(
+	data: GameData, outcome: StringName, partner: String, player: String,
+	gift: String
+) -> String:
+	if data == null or outcome.is_empty():
+		return ""
+	var text: String = data.special_text("mystery_gift", String(outcome))
+	if text.is_empty():
+		return ""
+	var buffers: Dictionary = {
+		"mystery_gift_partner_name": partner,
+		"mystery_gift_player_name": player,
+	}
+	for name: String in buffers:
+		var address: int = data.special_text_ram(name)
+		if address >= 0:
+			text = Gen2TextStream.fill_all_markers(
+				text, "%s%04X>" % [Gen2TextStream.RAM_MARKER, address],
+				String(buffers[name])
+			)
+	var buffer_1: Array[int] = data.string_buffer_addresses()
+	if buffer_1.size() > RomLayout.STRING_BUFFER_1:
+		text = Gen2TextStream.fill_all_markers(
+			text,
+			"%s%04X>" % [
+				Gen2TextStream.RAM_MARKER, buffer_1[RomLayout.STRING_BUFFER_1],
+			],
+			gift
+		)
+	return text
+
+
+## What is in the box right now: empty while the prompt is up, and one page of
+## the outcome once it has been printed.
+func visible_text() -> String:
+	if _step != STEP.MESSAGE or _page_index >= _pages.size():
+		return ""
+	return "\n".join(_pages[_page_index] as PackedStringArray)
+
+
+func _refresh() -> void:
+	if _background == null or _page == null:
+		return
+	Gen2PicImage.show(_background, _page.render(visible_text()))
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)

--- a/game/world/mystery_gift_screen.gd.uid
+++ b/game/world/mystery_gift_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://wfft3qw5blnb

--- a/game/world/mystery_gift_transport.gd
+++ b/game/world/mystery_gift_transport.gd
@@ -1,0 +1,92 @@
+class_name Gen2MysteryGiftTransport
+extends RefCounted
+
+## The infrared window, as the only thing above it needs it to be.
+##
+## `ExchangeMysteryGiftData` reaches the other Game Boy through rRP rather than
+## through the cable, and what it does with it comes down to three things:
+## whether a partner is in the window at all, which of the two ends is the
+## sender, and one twenty-byte block swapped both ways. There is no infrared
+## port on a modern platform, so this project chooses the transport, and this
+## class is that choice.
+##
+## Scene free and injected, the way [Gen2LinkTransport] is. A window with
+## nobody in it is the honest default and a real game path rather than a stub:
+## the exchange times out, `hMGStatusFlags` comes back `MG_TIMED_OUT` and
+## `DoMysteryGift` prints its own communication-error box.
+##
+## The one partner that exists today is another of this player's own save
+## slots, which [method peer_from_save] builds. A network transport subclasses
+## this and overrides [method peer_block]; nothing above changes.
+
+## `hMGRole`. The side that holds the window open first is the receiver, which
+## is what `InitializeIRCommunicationRoles` settles between two real Game Boys.
+const IR_RECEIVER: int = 1
+const IR_SENDER: int = 2
+
+## The partner's own side of the window, or empty for nobody in it. The keys
+## are `StageDataForMysteryGift`'s own twenty bytes plus the slot it came from.
+var peer: Dictionary = {}
+
+## `hMGRole`. Whoever opened this screen is the one waiting, so they receive
+## first and send back, which is `ReceiverExchangeMysteryGiftDataPayloads`.
+var role: int = IR_RECEIVER
+
+
+## Whether anybody is in the window at all. Everything else asks this first.
+func connected() -> bool:
+	return not peer.is_empty()
+
+
+## `ExchangeMysteryGiftData`'s own return in `hMGStatusFlags`. A window with
+## nobody in it spends its four seconds and comes back timed out, which
+## `DoMysteryGift` reads as its communication error and loops back to the
+## prompt.
+func status() -> int:
+	return Gen2MysteryGift.MG_OKAY if connected() else Gen2MysteryGift.MG_TIMED_OUT
+
+
+## `SendMysteryGiftDataPayload` and `ReceiveMysteryGiftDataPayload` as the one
+## operation they are together: this side's staged block goes out and the
+## partner's comes back. Empty means the window closed, which every caller
+## treats the same way as nobody being in it.
+func exchange(payload: Dictionary) -> Dictionary:
+	if not connected():
+		return {}
+	return peer_block(payload)
+
+
+## The partner's own block. The base transport answers out of [member peer],
+## which is a save slot that is not being played, so its roll was made when the
+## window opened and it does not change while this side thinks about it.
+func peer_block(_payload: Dictionary) -> Dictionary:
+	return peer.duplicate(true)
+
+
+## A partner built from a save slot: the player's other file, which is the only
+## second Mystery Gift block that exists on one machine.
+##
+## [param dex_caught] and [param random] are what `StageDataForMysteryGift`
+## reads and rolls on that side, so the roll is the slot's rather than this
+## one's.
+static func peer_from_save(
+	save: Gen2SaveData, dex_caught: int, random: RandomNumberGenerator
+) -> Dictionary:
+	if save == null:
+		return {}
+	var section: Dictionary = Gen2MysteryGift.normalize(save.mystery_gift)
+	var block: Dictionary = Gen2MysteryGift.stage_player_data(
+		save, section, dex_caught, random
+	)
+	block["slot"] = save.slot
+	return block
+
+
+## The transport a save slot makes, or one with nobody in the window when there
+## is no other slot to hold one open.
+static func to_save(
+	save: Gen2SaveData, dex_caught: int, random: RandomNumberGenerator
+) -> Gen2MysteryGiftTransport:
+	var transport := Gen2MysteryGiftTransport.new()
+	transport.peer = peer_from_save(save, dex_caught, random)
+	return transport

--- a/game/world/mystery_gift_transport.gd.uid
+++ b/game/world/mystery_gift_transport.gd.uid
@@ -1,0 +1,1 @@
+uid://c148ox4i8j6ci

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -437,6 +437,15 @@ func _build_world() -> void:
 		initial_day = int(saved_clock.get("day", initial_day))
 		initial_hour = int(saved_clock.get("hour", initial_hour))
 		initial_minute = int(saved_clock.get("minute", initial_minute))
+		## `TryLoadSaveFile`'s own `RestoreMysteryGift`, and `Continue`'s
+		## `CopyMysteryGiftReceivedDecorationsToPC` behind it: a gift received
+		## at the menu with no file open reaches the file here, and a
+		## decoration that came with one reaches the PC.
+		_world.state.set_mystery_gift(selected_save.mystery_gift)
+		Gen2MysteryGift.restore(_world.state.mystery_gift())
+		Gen2MysteryGift.copy_decorations_to_pc(
+			_world.state.mystery_gift(), _data, _world.state
+		)
 	elif selected_save != null:
 		var saveless_state := Gen2WorldState.new()
 		Gen2WorldSpawn.apply_initial_decorations(saveless_state)
@@ -2786,6 +2795,11 @@ func persist_world_snapshot() -> Dictionary:
 	if save == null:
 		return {"ok": false, "reason": &"missing_save"}
 	save.world = _world.snapshot()
+	## `BackupMysteryGift`, which every one of `SaveGameData`'s three entrances
+	## runs: the working pair goes to the backup pair, and the backup pair is
+	## what the file carries.
+	Gen2MysteryGift.backup(_world.state.mystery_gift())
+	save.mystery_gift = _world.state.mystery_gift().duplicate(true)
 	if _injected_save != null:
 		return {"ok": true, "kind": &"world_snapshot_saved", "save": save}
 	return Gen2SaveStore.save(save, _data)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -136,6 +136,12 @@ var _money_window: StringName = &""
 const PHONE_CONTACT_GOT: int = 0
 const PHONE_CONTACTS_FULL: int = 1
 const PHONE_CONTACT_REFUSED: int = 2
+## Mystery Gift's whole script surface (`engine/link/mystery_gift.asm`). The
+## exchange itself is not a special: it happens at the main menu with no file
+## loaded, and what a script can reach is the gift it left behind.
+const SPECIAL_CHECK_MYSTERY_GIFT: int = 17
+const SPECIAL_GET_MYSTERY_GIFT_ITEM: int = 18
+const SPECIAL_UNLOCK_MYSTERY_GIFT: int = 19
 ## The Bug Catching Contest's own six, all below the index where Gold and
 ## Silver's table diverges except the contestant draw, which special_index()
 ## normalizes (engine/events/special_pointers.asm).
@@ -2606,6 +2612,39 @@ func _execute_object_command(source_opcode: int, command: Dictionary) -> Diction
 	return {"ok": true}
 
 
+## The live `sMysteryGiftData`, which [Gen2WorldState] mirrors out of the save
+## so a scene script reaching `CheckMysteryGift` on a map-load frame has an
+## answer rather than a request to wait on.
+func _mystery_gift_section() -> Dictionary:
+	if state == null:
+		return Gen2MysteryGift.default_section()
+	return state.mystery_gift()
+
+
+## `GetMysteryGiftItem`: the waiting item into the bag, its own received box,
+## and `wScriptVar` for the officer's `iffalse`. `.no_room` closes SRAM without
+## clearing the byte, so a full pack leaves the gift where it is and the player
+## can come back for it.
+func _stage_mystery_gift_item(special: int) -> Dictionary:
+	var section: Dictionary = _mystery_gift_section()
+	var item: int = Gen2MysteryGift.take_item(section)
+	if item <= 0:
+		_script_value = 0
+		return {"ok": true}
+	var given: Dictionary = _stage_item_delta(item, 1)
+	if not bool(given.get("ok", true)):
+		return given
+	if _script_value == 0:
+		return {"ok": true}
+	Gen2MysteryGift.clear_item(section)
+	var item_name: String = data.item_name(item) if data != null else ""
+	_set_text_buffer(
+		RomLayout.STRING_BUFFER_4, item_name, &"item_name", {"item": item}
+	)
+	return _stage_internal_text(RECEIVED_ITEM_TEXT % item_name, false, {
+		"special": special, "item": item,
+	})
+
 func _stage_item_delta(item: int, delta: int) -> Dictionary:
 	if item > 0:
 		_last_item = item
@@ -3654,11 +3693,22 @@ func _execute_special(special: int) -> Dictionary:
 			_staged_kenji_break_timer = Gen2WorldState.kenji_break_countdown(_random)
 			_has_staged_kenji_break_timer = true
 		SPECIAL_TRAINER_HOUSE:
-			## `sMysteryGiftTrainerHouseFlag` straight into wScriptVar. Only a
-			## received Mystery Gift ever sets it and nothing here can receive
-			## one, so the byte is zero and the Trainer House turns the player
-			## away, which is what a cartridge that has never linked does.
-			_script_value = 0
+			## `sMysteryGiftTrainerHouseFlag` straight into wScriptVar: a
+			## player who has never received a Mystery Gift is turned away, and
+			## one who has fights CAL under the partner's name.
+			_script_value = int(_mystery_gift_section().get("trainer_house_flag", 0))
+		SPECIAL_CHECK_MYSTERY_GIFT:
+			## Zero when nothing is waiting and the item plus one when something
+			## is. POKECENTER_2F's scene script branches on the zero, and the
+			## officer it puts on the floor is what hands the gift over.
+			_script_value = Gen2MysteryGift.check_value(_mystery_gift_section())
+		SPECIAL_UNLOCK_MYSTERY_GIFT:
+			## Carrie's own row on GOLDENROD DEPT. STORE 5F, behind a
+			## `GameboyCheck` this project always passes: there is no Game Boy
+			## here that is not a colour one.
+			Gen2MysteryGift.unlock(_mystery_gift_section())
+		SPECIAL_GET_MYSTERY_GIFT_ITEM:
+			return _stage_mystery_gift_item(special)
 		SPECIAL_HO_OH_CHAMBER:
 			## `wPartySpecies`' first byte and nothing else: the wall opens for a
 			## party led by Ho-Oh. `GetMapAttributesPointer` in front of it is

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -319,6 +319,15 @@ var _battle_tower: Gen2BattleTower = Gen2BattleTower.new()
 var _link_session: Gen2LinkSession = Gen2LinkSession.new()
 var _link_transport: Gen2LinkTransport = Gen2LinkTransport.new()
 
+## `sMysteryGiftData`, mirrored here so the three specials can read and write it
+## the way `OpenSRAM` does rather than through a runtime request: a scene script
+## reaches `CheckMysteryGift` on the frame the map loads and has nothing to wait
+## on. It is deliberately outside [method to_dict], because the section is not
+## part of the checksummed save on the cartridge either: [Gen2SaveData] owns it
+## and `RestoreMysteryGift` and `BackupMysteryGift` are what move it in and out
+## ([method Gen2MysteryGift.restore], [method Gen2MysteryGift.backup]).
+var _mystery_gift: Dictionary = Gen2MysteryGift.default_section()
+
 
 func _init(
 	initial_event_flags: Dictionary = {}, initial_map_scenes: Dictionary = {},
@@ -648,6 +657,16 @@ func link_session() -> Gen2LinkSession:
 
 func link_transport() -> Gen2LinkTransport:
 	return _link_transport
+
+
+## The live Mystery Gift section, edited in place the way the tower's record is.
+func mystery_gift() -> Dictionary:
+	return _mystery_gift
+
+
+## `RestoreMysteryGift`'s destination: the section a save slot carried.
+func set_mystery_gift(section: Dictionary) -> void:
+	_mystery_gift = Gen2MysteryGift.normalize(section)
 
 
 ## Injects the cable. A null transport is no cable at all, which is what the

--- a/game/world/world_transaction.gd
+++ b/game/world/world_transaction.gd
@@ -100,6 +100,7 @@ static func copy_into(target: Gen2SaveData, source: Gen2SaveData) -> void:
 	target.link_record = source.link_record.duplicate(true)
 	target.box_names = source.box_names.duplicate()
 	target.mailbox = source.mailbox.duplicate()
+	target.mystery_gift = source.mystery_gift.duplicate(true)
 	target.world = source.world
 	target.mods = source.mods.duplicate(true)
 	target.run_seed = source.run_seed

--- a/tests/unit/test_link.gd
+++ b/tests/unit/test_link.gd
@@ -313,3 +313,127 @@ func _save() -> Gen2SaveData:
 	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_data, 0)
 	save.world = _live_world.snapshot()
 	return save
+
+
+## Mystery Gift is a second peer rather than the cable: `mystery_gift.asm`
+## never touches `wLinkMode` and keeps its own SRAM block, so what follows is
+## that block and the decision over it. The real-cartridge counterpart is
+## `tools/checks/mystery_gift.gd`, which sweeps both gift tables and every box
+## on all three dumps.
+
+
+## `UnlockMysteryGift` is the one thing that clears the locked byte, and the
+## main menu reads the backup pair rather than the working one: the row appears
+## on the session after Carrie, because only a save copies one into the other.
+func test_the_mystery_gift_row_appears_only_after_a_save() -> void:
+	var section: Dictionary = Gen2MysteryGift.default_section()
+	assert_false(Gen2MysteryGift.menu_row_unlocked(section))
+	assert_true(Gen2MysteryGift.unlock(section))
+	assert_false(
+		Gen2MysteryGift.menu_row_unlocked(section),
+		"Carrie clears sMysteryGiftUnlocked, not sNumDailyMysteryGiftPartnerIDs"
+	)
+	Gen2MysteryGift.backup(section)
+	assert_true(Gen2MysteryGift.menu_row_unlocked(section))
+
+
+## The gift lands in the backup pair, which is where a save wrote it from, so
+## `RestoreMysteryGift` is what carries a gift received at the menu into the
+## file the counter reads.
+func test_a_gift_reaches_the_loaded_file_through_the_backup_pair() -> void:
+	var section: Dictionary = Gen2MysteryGift.default_section()
+	Gen2MysteryGift.unlock(section)
+	section["backup_item"] = 0xAD
+	assert_eq(Gen2MysteryGift.check_value(section), 0, "nothing is waiting yet")
+	Gen2MysteryGift.restore(section)
+	assert_eq(
+		Gen2MysteryGift.check_value(section), 0xAE,
+		"CheckMysteryGift answers the item plus one"
+	)
+	Gen2MysteryGift.clear_item(section)
+	assert_eq(Gen2MysteryGift.check_value(section), 0)
+
+
+## `DoMysteryGiftIfDayHasPassed`: the limit lifts when the day the countdown
+## started on is behind us, and not before. A locked file keeps its -1, or the
+## first midnight would put the menu row up on its own.
+func test_the_daily_limit_lifts_only_once_a_day_has_passed() -> void:
+	var section: Dictionary = Gen2MysteryGift.default_section()
+	Gen2MysteryGift.unlock(section)
+	Gen2MysteryGift.backup(section)
+	section["daily_partners"] = Gen2MysteryGift.MAX_PARTNERS
+	Gen2MysteryGift.start_countdown(section, 3)
+	assert_false(Gen2MysteryGift.begin_session(section, 3))
+	assert_eq(int(section["daily_partners"]), Gen2MysteryGift.MAX_PARTNERS)
+	assert_true(Gen2MysteryGift.begin_session(section, 4))
+	assert_eq(int(section["daily_partners"]), 0)
+
+	var locked: Dictionary = Gen2MysteryGift.default_section()
+	Gen2MysteryGift.start_countdown(locked, 3)
+	assert_false(Gen2MysteryGift.begin_session(locked, 5))
+	assert_false(
+		Gen2MysteryGift.menu_row_unlocked(locked),
+		"a midnight does not unlock a file Carrie has never spoken to"
+	)
+
+
+## A window with nobody in it is a real path rather than a stub: the exchange
+## times out and `.CommunicationError` puts the prompt back up rather than
+## leaving the screen.
+func test_an_empty_infrared_window_times_out_into_the_retry_box() -> void:
+	var transport := Gen2MysteryGiftTransport.new()
+	assert_false(transport.connected())
+	assert_eq(transport.status(), Gen2MysteryGift.MG_TIMED_OUT)
+	var result: Dictionary = Gen2MysteryGift.exchange(
+		Gen2MysteryGift.default_section(), transport, {}, {}
+	)
+	assert_eq(result["outcome"], Gen2MysteryGift.OUTCOME_COMM_ERROR)
+	assert_true(result["retry"], "the routine loops back to its own prompt")
+
+
+## `.AddMysteryGiftPartnerID` runs in front of the gift rather than behind it,
+## so a partner whose decoration this side already owns still counts against
+## both daily limits.
+func test_a_partner_counts_even_when_the_decoration_was_already_received() -> void:
+	var section: Dictionary = Gen2MysteryGift.default_section()
+	Gen2MysteryGift.unlock(section)
+	section["daily_partners"] = 0
+	section["decorations_received"] = [7]
+	var transport := Gen2MysteryGiftTransport.new()
+	transport.peer = {
+		"game_version": 1, "id": 0x0BAD, "name": "KRIS", "sent_deco": 1,
+		"which_item": 0, "which_deco": 0, "backup_item": 0,
+	}
+	var result: Dictionary = Gen2MysteryGift.exchange(
+		section, transport, {}, {"items": [0xAD], "decos": [7]}
+	)
+	assert_eq(result["outcome"], Gen2MysteryGift.OUTCOME_SENT)
+	assert_eq(int(section["backup_item"]), 0xAD)
+	assert_eq(int(section["daily_partners"]), 1)
+	assert_eq(section["partner_ids"], [0x0BAD])
+	assert_eq(
+		int(section["trainer_house_flag"]), 1,
+		"a linked file is what opens the Trainer House"
+	)
+
+
+## A rolled sample is always a row of the table it names, whichever of the four
+## weighted bands it lands in: the last band answers 32 or 33 and no band can
+## reach past the thirty-seven rows.
+func test_every_staged_roll_names_a_row_of_its_own_table() -> void:
+	var random := RandomNumberGenerator.new()
+	random.seed = 7
+	var section: Dictionary = Gen2MysteryGift.default_section()
+	var save := Gen2SaveData.new()
+	save.player_id = 0xBEEF
+	var bands: Dictionary = {}
+	for _roll: int in 512:
+		var staged: Dictionary = Gen2MysteryGift.stage_player_data(
+			save, section, 30, random
+		)
+		for key: String in ["which_item", "which_deco"]:
+			var index: int = int(staged[key])
+			assert_between(index, 0, RomLayout.MYSTERY_GIFT_TABLE_ROWS - 1)
+			bands[index / 8] = true
+	assert_true(bands.has(0), "the common band is reached")
+	assert_true(bands.has(4), "the rarest band is reached")

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -316,6 +316,11 @@ func test_the_transaction_write_back_carries_every_field_but_the_live_clock() ->
 	var rules := Gen2Rules.new()
 	rules.difficulty = Gen2Rules.DIFFICULTY_HARD
 	candidate.run_rules = rules
+	## `mystery_gift` is the newest field in the list this test guards, and the
+	## list is named field by field rather than delegated, so it has to differ
+	## or a dropped copy would still compare equal.
+	candidate.mystery_gift = Gen2MysteryGift.default_section()
+	candidate.mystery_gift["backup_item"] = 0xAD
 	live.game_time.frames = 12
 
 	Gen2WorldTransaction.copy_into(live, candidate)
@@ -979,3 +984,31 @@ func test_copying_a_save_in_place_keeps_every_field() -> void:
 	assert_eq(save.hall_of_fame.size(), 1)
 	assert_eq(save.mailbox.size(), 1)
 	assert_eq((save.mailbox[0] as Gen2SaveMail).author, "GOLD")
+
+
+## `sMysteryGiftData` defaults rather than versioning, the way `mailbox` and
+## `box_names` do: a slot written before Mystery Gift existed reads as one that
+## has never linked, which is the truth about it.
+func test_a_save_without_a_mystery_gift_block_reads_as_locked() -> void:
+	var raw: Dictionary = _save().to_dict()
+	raw.erase("mystery_gift")
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(raw)
+	assert_not_null(restored)
+	assert_eq(int(restored.mystery_gift["item"]), 0)
+	assert_false(Gen2MysteryGift.menu_row_unlocked(restored.mystery_gift))
+
+
+## The block round-trips through the file, which is what carries a gift
+## received at the menu into the game that collects it.
+func test_a_mystery_gift_block_round_trips_through_the_file() -> void:
+	var save: Gen2SaveData = _save()
+	Gen2MysteryGift.unlock(save.mystery_gift)
+	save.mystery_gift["item"] = 0xAD
+	save.mystery_gift["partner_ids"] = [0x1234]
+	save.mystery_gift["decorations_received"] = [7]
+	save.mystery_gift["partner_name"] = "KRIS"
+	Gen2MysteryGift.backup(save.mystery_gift)
+	assert_eq(int(save.mystery_gift["backup_item"]), 0xAD)
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	assert_not_null(restored)
+	assert_eq(restored.mystery_gift, save.mystery_gift)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -8535,3 +8535,96 @@ func test_the_battle_tower_reset_ends_the_script_and_asks_for_a_restart() -> voi
 				asked = true
 	assert_true(asked, "the console restarts")
 	assert_false(world.event_flag_active(0x12), "nothing behind it runs")
+
+
+## `CheckMysteryGift` is a scene script, so it has to answer on the frame the
+## map loads rather than wait on a host: an empty section is zero and a waiting
+## gift is the item plus one, which is the byte POKECENTER_2F branches on.
+func test_check_mystery_gift_answers_the_waiting_item_plus_one() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_CHECK_MYSTERY_GIFT, 0,
+		Gen2WorldScript.IFEQUAL, 0, 0x50, 0x62,
+		Gen2WorldScript.SETEVENT, 31, 0,
+		Gen2WorldScript.END,
+	], {"48:6250": [Gen2WorldScript.END]})
+	for waiting: int in [0, 0xAD]:
+		var state := Gen2WorldState.new()
+		state.mystery_gift()["item"] = waiting
+		var world: Gen2WorldAPI = _special_world(state)
+		_run_special(world)
+		assert_eq(
+			world.state.is_event_flag_active(31), waiting != 0,
+			"a waiting item is the branch the officer appears on"
+		)
+
+
+## `GetMysteryGiftItem`: the gift into the bag and its own received box, and
+## `.no_room`'s refusal leaves the byte where it is so the player can come back
+## for it. Both branches are the same script row with a different pack.
+func test_get_mystery_gift_item_keeps_the_gift_when_the_pack_is_full() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_GET_MYSTERY_GIFT_ITEM, 0,
+		Gen2WorldScript.END,
+	])
+	var state := Gen2WorldState.new()
+	state.mystery_gift()["item"] = Gen2WorldPartyHost.ITEM_POKE_BALL
+	var world: Gen2WorldAPI = _special_world(state)
+	_run_special(world)
+	## The received box is `GetMysteryGiftItem`'s own `PrintText`, so the script
+	## is waiting on it and the bag is not written until it is acknowledged.
+	world.run_event_queue(true)
+	assert_eq(int(world.state.mystery_gift()["item"]), 0, "a received gift is cleared")
+	assert_true(
+		world.state.item_quantity(Gen2WorldPartyHost.ITEM_POKE_BALL) > 0,
+		"the gift reached the bag"
+	)
+
+	var full := Gen2WorldState.new({}, {}, {
+		Gen2WorldPartyHost.ITEM_POKE_BALL: Gen2WorldPack.MAX_ITEM_STACK,
+	})
+	full.mystery_gift()["item"] = Gen2WorldPartyHost.ITEM_POKE_BALL
+	var refused: Gen2WorldAPI = _special_world(full)
+	_run_special(refused)
+	refused.run_event_queue(true)
+	assert_eq(
+		int(refused.state.mystery_gift()["item"]), Gen2WorldPartyHost.ITEM_POKE_BALL,
+		"a full pack leaves the gift at the counter"
+	)
+
+
+## `UnlockMysteryGift` clears the locked byte once and never touches a section
+## that already has a gift in it, which is what stops Carrie throwing one away.
+func test_unlock_mystery_gift_clears_the_locked_byte_once() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_UNLOCK_MYSTERY_GIFT, 0,
+		Gen2WorldScript.END,
+	])
+	var state := Gen2WorldState.new()
+	var world: Gen2WorldAPI = _special_world(state)
+	_run_special(world)
+	assert_eq(int(world.state.mystery_gift()["unlocked"]), 0)
+
+	world.state.mystery_gift()["item"] = 0xAD
+	_run_special(_special_world(world.state))
+	assert_eq(
+		int(world.state.mystery_gift()["item"]), 0xAD,
+		"an unlocked section keeps whatever is waiting in it"
+	)
+
+
+## `GetTrainerName`'s CAL branch reads `sMysteryGiftTrainerHouseFlag`, and the
+## Trainer House's own special hands the same byte to its script: a player who
+## has never received a gift is turned away.
+func test_the_trainer_house_reads_the_mystery_gift_flag() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_TRAINER_HOUSE, 0,
+		Gen2WorldScript.IFEQUAL, 0, 0x50, 0x62,
+		Gen2WorldScript.SETEVENT, 31, 0,
+		Gen2WorldScript.END,
+	], {"48:6250": [Gen2WorldScript.END]})
+	for linked: int in [0, 1]:
+		var state := Gen2WorldState.new()
+		state.mystery_gift()["trainer_house_flag"] = linked
+		var world: Gen2WorldAPI = _special_world(state)
+		_run_special(world)
+		assert_eq(world.state.is_event_flag_active(31), linked == 1)

--- a/tools/checks/mystery_gift.gd
+++ b/tools/checks/mystery_gift.gd
@@ -1,0 +1,325 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Sweeps Mystery Gift against freshly imported real caches on all three
+## cartridges: both gift tables end to end, every box `DoMysteryGift` can end
+## on, the screen each cartridge draws, and the whole decision chain the
+## routine runs between the exchange and the gift.
+##
+## The class this exists to stop is a chain that answers the wrong box: every
+## refusal in `DoMysteryGift` is one `jp` away from the next, and a test that
+## drives only the happy path never sees the other seven. So the chain is
+## driven once per outcome, with the section built to reach exactly that jump.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- mystery_gift
+
+## `MysteryGiftItems` and `MysteryGiftDecos`. The first and last row of each is
+## what tells a table read forwards from one read backwards, and the pair of
+## fourth rows is `MysteryGiftFallbackItem`'s own shared byte.
+const FIRST_ITEM: int = 0xAD
+const LAST_ITEM: int = 0xBD
+const FIRST_DECO: int = 0x16
+const LAST_DECO: int = 0x27
+
+## Crystal's `_CGB_MysteryGift` copies two palettes and Gold and Silver's copies
+## one, which is the one thing about the screen that is not the same on all
+## three.
+const PALETTES: Dictionary = {&"crystal": 2, &"gold": 1, &"silver": 1}
+
+## `.String_PressAToLink_BToCancel`'s own four lines.
+const PROMPT_LINES: int = 4
+
+## A partner block that reaches the gift, which every outcome case then breaks
+## in exactly one way.
+const PARTNER: Dictionary = {
+	"game_version": 1, "id": 0x1234, "name": "KRIS", "dex_caught": 30,
+	"sent_deco": 0, "which_item": 0, "which_deco": 0, "backup_item": 0,
+	"daily_partners": 0,
+}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	var screens: Dictionary = {}
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		if not _r.check(
+			data.has_mystery_gift(), "%s: no Mystery Gift block in the cache." % game_id
+		):
+			continue
+		_verify_tables(game_id, data)
+		_verify_boxes(game_id, data)
+		screens[game_id] = _verify_screen(game_id, data)
+		_verify_chain(game_id, data)
+		_verify_live_screen(game_id, data)
+	_r.game_id = &""
+	_verify_screens_agree(screens)
+
+
+## Both tables are their own length, open and close on their own rows, and
+## every row of `MysteryGiftDecos` names a decoration that is not a trophy: the
+## two trophy dolls sit past `NUM_NON_TROPHY_DECOS` and the received-decoration
+## flag array has no room for one.
+func _verify_tables(game_id: StringName, data: GameData) -> void:
+	for decorations: bool in [false, true]:
+		var table: Array = data.mystery_gift_table(decorations)
+		var label: String = "MysteryGiftDecos" if decorations else "MysteryGiftItems"
+		if not _r.check(
+			table.size() == RomLayout.MYSTERY_GIFT_TABLE_ROWS,
+			"%s: %s is %d rows, not %d." % [
+				game_id, label, table.size(), RomLayout.MYSTERY_GIFT_TABLE_ROWS,
+			]
+		):
+			continue
+		var first: int = FIRST_DECO if decorations else FIRST_ITEM
+		var last: int = LAST_DECO if decorations else LAST_ITEM
+		_r.check(
+			int(table[0]) == first and int(table[-1]) == last,
+			"%s: %s runs $%02X..$%02X, not $%02X..$%02X." % [
+				game_id, label, int(table[0]), int(table[-1]), first, last,
+			]
+		)
+		if not decorations:
+			continue
+		var highest: int = 0
+		for row: Variant in table:
+			highest = maxi(highest, int(row))
+		_r.check(
+			highest < Gen2MysteryGift.NUM_NON_TROPHY_DECOS,
+			"%s: %s offers decoration %d, which is a trophy." % [
+				game_id, label, highest,
+			]
+		)
+	## `MysteryGiftFallbackItem` is one byte read two ways, so an index past
+	## either end has to answer it and nothing else.
+	for decorations: bool in [false, true]:
+		_r.check(
+			Gen2MysteryGift.gift_at(
+				data.mystery_gift_table(decorations),
+				RomLayout.MYSTERY_GIFT_TABLE_ROWS
+			) == Gen2MysteryGift.FALLBACK_GIFT,
+			"%s: an index past the table's end is not the fallback." % game_id
+		)
+
+
+## All eight `text_far` stubs decode, and each says what only it says. A run
+## pinned one stub out would still decode eight boxes, so the content is what
+## the check is on.
+func _verify_boxes(game_id: StringName, data: GameData) -> void:
+	var contains: Dictionary = {
+		Gen2MysteryGift.OUTCOME_CANCELED: "cancelled",
+		Gen2MysteryGift.OUTCOME_COMM_ERROR: "Communication",
+		Gen2MysteryGift.OUTCOME_RETRIEVE: "retrieve",
+		Gen2MysteryGift.OUTCOME_FRIEND_NOT_READY: "friend",
+		Gen2MysteryGift.OUTCOME_FIVE_A_DAY: "five",
+		Gen2MysteryGift.OUTCOME_ONE_A_DAY: "per person",
+		Gen2MysteryGift.OUTCOME_SENT: "sent",
+		Gen2MysteryGift.OUTCOME_SENT_HOME: "home",
+	}
+	for outcome: Variant in contains:
+		var text: String = Gen2MysteryGiftScreen.box_text(
+			data, StringName(outcome), "KRIS", "GOLD", "BERRY"
+		)
+		_r.check(
+			text.contains(String(contains[outcome])),
+			"%s: the %s box reads \"%s\"." % [game_id, outcome, text]
+		)
+	## The two boxes the gift arrives in are the only two that name anybody, and
+	## both have to spell the partner rather than leaving a marker behind.
+	for outcome: StringName in [
+		Gen2MysteryGift.OUTCOME_SENT, Gen2MysteryGift.OUTCOME_SENT_HOME,
+	]:
+		var text: String = Gen2MysteryGiftScreen.box_text(
+			data, outcome, "KRIS", "GOLD", "BERRY"
+		)
+		_r.check(
+			text.contains("KRIS") and text.contains("BERRY") \
+				and not text.contains(Gen2TextStream.RAM_MARKER),
+			"%s: the %s box did not fill its buffers: \"%s\"." % [
+				game_id, outcome, text,
+			]
+		)
+
+
+## The screen each cartridge draws: the tilemap indexes its own art, the prompt
+## is the routine's own four lines, and the picture comes out at screen size.
+func _verify_screen(game_id: StringName, data: GameData) -> PackedByteArray:
+	var page: Gen2MysteryGiftPage = Gen2MysteryGiftPage.from_data(data)
+	if not _r.check(page != null, "%s: the Mystery Gift page did not build." % game_id):
+		return PackedByteArray()
+	_r.check(
+		page.palette.size() == int(PALETTES[game_id]) * RomLayout.PREDEF_PALETTE_COLORS,
+		"%s: the screen carries %d colours, not %d palettes' worth." % [
+			game_id, page.palette.size(), int(PALETTES[game_id]),
+		]
+	)
+	_r.check(
+		page.prompt.split("\n").size() == PROMPT_LINES,
+		"%s: the prompt is %d lines, not %d." % [
+			game_id, page.prompt.split("\n").size(), PROMPT_LINES,
+		]
+	)
+	var tiles: int = data.mystery_gift_indices().size() / (
+		Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT
+	)
+	var highest: int = 0
+	for code: int in page.tilemap():
+		## `ClearBox`'s own blank is a font glyph rather than a tile of the
+		## screen's art, which is what the cartridge blanks a box with too.
+		if code < RomLayout.FONT_FIRST_CODE \
+				and code != Gen2MysteryGiftPage.BLANK_CODE:
+			highest = maxi(highest, code)
+	_r.check(
+		highest < tiles,
+		"%s: the screen indexes tile %d of %d." % [game_id, highest, tiles]
+	)
+	## Every cell of the attrmap names a palette the layout copied, which is
+	## what says Crystal's second one is reached and Gold's single one is not
+	## overrun.
+	var banks: int = int(PALETTES[game_id])
+	var worst: int = 0
+	for attribute: int in page.attributes():
+		worst = maxi(worst, attribute)
+	_r.check(
+		worst < banks,
+		"%s: the attrmap names palette %d of %d." % [game_id, worst, banks]
+	)
+	var image: Image = page.render("")
+	if not _r.check(
+		image != null and image.get_width() == Gen2MysteryGiftPage.WIDTH \
+			and image.get_height() == Gen2MysteryGiftPage.HEIGHT,
+		"%s: the Mystery Gift screen did not render at screen size." % game_id
+	):
+		return PackedByteArray()
+	return image.get_data()
+
+
+## `DoMysteryGift` from the exchange down, once per box it can end on. Each case
+## is the same partner with exactly one thing changed, so a chain that tests in
+## the wrong order answers the wrong box and fails here.
+func _verify_chain(game_id: StringName, data: GameData) -> void:
+	var tables: Dictionary = {
+		"items": data.mystery_gift_table(false),
+		"decos": data.mystery_gift_table(true),
+	}
+	for case: Array in [
+		[Gen2MysteryGift.OUTCOME_SENT, {}, {}],
+		## Five partners already today, which is tested before anything else.
+		[Gen2MysteryGift.OUTCOME_FIVE_A_DAY,
+			{"daily_partners": Gen2MysteryGift.MAX_PARTNERS}, {}],
+		## The same person twice, which is the second test.
+		[Gen2MysteryGift.OUTCOME_ONE_A_DAY,
+			{"partner_ids": [0x1234], "daily_partners": 1}, {}],
+		## A gift already waiting at the counter, and then the partner's own.
+		[Gen2MysteryGift.OUTCOME_RETRIEVE, {"backup_item": 1}, {}],
+		[Gen2MysteryGift.OUTCOME_FRIEND_NOT_READY, {}, {"backup_item": 1}],
+		## A decoration nobody has received yet goes home; the same decoration a
+		## second time falls through to the item, which is the one branch in the
+		## chain that does not end where it started.
+		[Gen2MysteryGift.OUTCOME_SENT_HOME, {}, {"sent_deco": 1}],
+		[Gen2MysteryGift.OUTCOME_SENT,
+			{"decorations_received": [int(tables["decos"][0])]}, {"sent_deco": 1}],
+	]:
+		var section: Dictionary = Gen2MysteryGift.default_section()
+		section["unlocked"] = 0
+		section["daily_partners"] = 0
+		for key: Variant in case[1] as Dictionary:
+			section[key] = (case[1] as Dictionary)[key]
+		var partner: Dictionary = PARTNER.duplicate()
+		for key: Variant in case[2] as Dictionary:
+			partner[key] = (case[2] as Dictionary)[key]
+		var transport := Gen2MysteryGiftTransport.new()
+		transport.peer = partner
+		var result: Dictionary = Gen2MysteryGift.exchange(
+			section, transport, PARTNER.duplicate(), tables, data
+		)
+		_r.check(
+			StringName(result.get("outcome", &"")) == StringName(case[0]),
+			"%s: the chain answered %s where %s was due." % [
+				game_id, result.get("outcome", &""), case[0],
+			]
+		)
+	## A window with nobody in it is a real path: `ExchangeMysteryGiftData`
+	## times out and the routine loops back to its own prompt.
+	var empty: Dictionary = Gen2MysteryGift.default_section()
+	var timed_out: Dictionary = Gen2MysteryGift.exchange(
+		empty, Gen2MysteryGiftTransport.new(), PARTNER.duplicate(), tables, data
+	)
+	_r.check(
+		StringName(timed_out.get("outcome", &"")) == Gen2MysteryGift.OUTCOME_COMM_ERROR \
+			and bool(timed_out.get("retry", false)),
+		"%s: an empty window did not time out into the retry box." % game_id
+	)
+
+
+## The art differs between Crystal and the other two on purpose, and Gold and
+## Silver's is the same run at the same address, so their two screens are one
+## picture. A difference there would be a wrong pin on one of them.
+func _verify_screens_agree(screens: Dictionary) -> void:
+	if screens.size() < 3:
+		return
+	_r.check(
+		screens[&"gold"] == screens[&"silver"] \
+			and not (screens[&"gold"] as PackedByteArray).is_empty(),
+		"Gold and Silver drew different Mystery Gift screens."
+	)
+	_r.check(
+		screens[&"crystal"] != screens[&"gold"],
+		"Crystal drew Gold's Mystery Gift screen, which is a wrong pin."
+	)
+
+
+## The live path, which an offline chain cannot reach: the screen is built,
+## displayed, and driven with the two buttons the routine has. What it settles
+## is that the section the screen edits is the save's, so a gift received here
+## is in the file the counter reads and not in a copy of it.
+func _verify_live_screen(game_id: StringName, data: GameData) -> void:
+	var tree: SceneTree = Engine.get_main_loop() as SceneTree
+	if tree == null:
+		_r.fail("%s: no scene tree for the Mystery Gift screen." % game_id)
+		return
+	var save := Gen2SaveData.new()
+	save.player_name = "GOLD"
+	Gen2MysteryGift.unlock(save.mystery_gift)
+	Gen2MysteryGift.backup(save.mystery_gift)
+	var transport := Gen2MysteryGiftTransport.new()
+	transport.peer = PARTNER.duplicate()
+	var random := RandomNumberGenerator.new()
+	random.seed = 11
+	var host := Gen2MysteryGiftScreen.new()
+	host.set_context(data, save, transport, 30, 0, random)
+	tree.root.add_child(host)
+	## The screen counts its own frames off the clock in `_process`; this check
+	## spends them by hand, the way `tools/preview_*.gd` do.
+	host.set_process(false)
+	_r.check(
+		host.step() == Gen2MysteryGiftScreen.STEP.PROMPT \
+			and host.visible_text().is_empty(),
+		"%s: the screen did not open on its prompt." % game_id
+	)
+	host.handle_button(Gen2Button.A)
+	host.settle()
+	_r.check(
+		host.step() == Gen2MysteryGiftScreen.STEP.MESSAGE,
+		"%s: the exchange did not finish inside its own timeout." % game_id
+	)
+	_r.check(
+		StringName(host.result().get("outcome", &"")) == Gen2MysteryGift.OUTCOME_SENT,
+		"%s: the live exchange answered %s." % [
+			game_id, host.result().get("outcome", &""),
+		]
+	)
+	_r.check(
+		int(save.mystery_gift["backup_item"]) != 0,
+		"%s: the gift did not reach the save the screen was handed." % game_id
+	)
+	_r.check(
+		host.visible_text().contains("KRIS"),
+		"%s: the box on screen does not name the partner." % game_id
+	)
+	host.queue_free()

--- a/tools/checks/mystery_gift.gd.uid
+++ b/tools/checks/mystery_gift.gd.uid
@@ -1,0 +1,1 @@
+uid://dqaho76gpwb6c

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -23,12 +23,10 @@ extends RefCounted
 ## in both directions: an index here that the runner now handles fails, so the
 ## row is deleted with the work rather than left behind.
 const EXPECTED_DEFERRED: Dictionary = {
-	## The Mobile Adapter GB and Mystery Gift, neither of which has a peer to
-	## talk to on a modern platform. The cable club's own sixteen rows have left
-	## this list with the Battle Tower's seven, and so has `DisplayLinkRecord`,
-	## which sat in the link block without being link play.
-	17: "CheckMysteryGift",
-	18: "GetMysteryGiftItem", 19: "UnlockMysteryGift",
+	## The Mobile Adapter GB, which is a real Game Boy peripheral with no path
+	## to a modern platform. The cable club's own sixteen rows have left this
+	## list with the Battle Tower's seven, `DisplayLinkRecord`, which sat in the
+	## link block without being link play, and Mystery Gift's three.
 	125: "GiveOddEgg",
 	127: "Function1011f1", 128: "Function101220", 129: "Function101225",
 	130: "Function101231", 139: "BattleTowerMobileError",
@@ -76,6 +74,9 @@ const SPECIAL_TEXT_RAM_NAMES: Array[String] = [
 	"seer_time_of_day", "seer_ot", "seer_caught_level",
 	## `wBufferTrademonNickname`, which `_LinkAskTradeForText` names.
 	"trademon_nickname",
+	## `wMysteryGiftPartnerName` and `wMysteryGiftPlayerName`, the two names
+	## `_MysteryGiftSentText` and `_MysteryGiftSentHomeText` spell.
+	"mystery_gift_partner_name", "mystery_gift_player_name",
 ]
 
 const SPECIALS_POINTERS_SIZE: int = 169

--- a/tools/preview_mystery_gift.gd
+++ b/tools/preview_mystery_gift.gd
@@ -1,0 +1,88 @@
+extends SceneTree
+
+## Captures the Mystery Gift screen against a real imported cache.
+##
+##   Godot --headless --path . -s res://tools/preview_mystery_gift.gd -- <game> <out.png> [box]
+##
+## [box] is `prompt` or one of `DoMysteryGift`'s eight outcome names
+## (`canceled`, `comm_error`, `retrieve`, `friend_not_ready`, `five_a_day`,
+## `one_a_day`, `sent`, `sent_home`), or `all` for a contact sheet of every one.
+## `all` is the default.
+##
+## The frame is the one picture that differs between the two cartridges for a
+## reason: Crystal builds it out of one run and two palettes, Gold and Silver
+## out of three runs and one, so the same call on the three caches is the whole
+## comparison.
+##
+## Composed into an [Image] rather than through a window, so this runs headless.
+
+const COLUMNS: int = 3
+const PARTNER: String = "KRIS"
+const PLAYER: String = "GOLD"
+const GIFT: String = "BERRY"
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error("Usage: preview_mystery_gift.gd -- <game> <output.png> [box|all]")
+		quit(1)
+		return
+	if Gen2ToolPath.refuses(args[1]):
+		quit(2)
+		return
+	var data: GameData = GameData.open(StringName(args[0]))
+	if data == null:
+		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		quit(1)
+		return
+	var page: Gen2MysteryGiftPage = Gen2MysteryGiftPage.from_data(data)
+	if page == null:
+		push_error("The %s cache carries no Mystery Gift screen." % args[0])
+		quit(1)
+		return
+
+	var boxes: Array[String] = ["prompt"]
+	for outcome: StringName in Gen2MysteryGift.OUTCOME_ORDER:
+		boxes.append(String(outcome))
+	var wanted: String = args[2] if args.size() > 2 else "all"
+	if wanted != "all":
+		if wanted not in boxes:
+			push_error("Unknown box %s." % wanted)
+			quit(1)
+			return
+		boxes = [wanted] as Array[String]
+
+	var columns: int = mini(COLUMNS, boxes.size())
+	@warning_ignore("integer_division")
+	var rows: int = (boxes.size() + columns - 1) / columns
+	var sheet: Image = Image.create_empty(
+		columns * Gen2Screen.WIDTH, rows * Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	for index: int in boxes.size():
+		var tile: Image = page.render(_text(data, boxes[index]))
+		@warning_ignore("integer_division")
+		sheet.blit_rect(tile, Rect2i(Vector2i.ZERO, tile.get_size()), Vector2i(
+			(index % columns) * Gen2Screen.WIDTH, (index / columns) * Gen2Screen.HEIGHT
+		))
+	if sheet.save_png(args[1]) != OK:
+		push_error("Could not write %s" % args[1])
+		quit(1)
+		return
+	print("Wrote %s (%dx%d), %d boxes, %d palettes." % [
+		args[1], sheet.get_width(), sheet.get_height(), boxes.size(),
+		page.palette.size() / 4,
+	])
+	quit(0)
+
+
+## The prompt is the page's own; every other box is one of the eight imported
+## stubs with the two names and the gift filled in.
+func _text(data: GameData, box: String) -> String:
+	if box == "prompt":
+		return ""
+	var pages: Array = Gen2TextLayout.lay_out(
+		Gen2MysteryGiftScreen.box_text(data, StringName(box), PARTNER, PLAYER, GIFT),
+		Gen2MysteryGiftPage.MESSAGE_COLUMNS, Gen2MysteryGiftPage.MESSAGE_ROWS
+	)
+	return "\n".join(pages[0] as PackedStringArray) if not pages.is_empty() else ""

--- a/tools/preview_mystery_gift.gd.uid
+++ b/tools/preview_mystery_gift.gd.uid
@@ -1,0 +1,1 @@
+uid://ckvfx75i0p3vn

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,6 +44,7 @@ const GROUPS: Dictionary = {
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
 		&"card_flip", &"move_effects", &"phone", &"decorations", &"mail",
+		&"mystery_gift",
 		&"battle_tower",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],


### PR DESCRIPTION
Mystery Gift is built. It was the last row of the last rung, so the open-work ladder is empty of features.

The cartridge receives a gift over infrared, not over the cable. `engine/link/mystery_gift.asm` never touches `wLinkMode`, keeps `sMysteryGiftData` outside the checksummed save, and reaches the other Game Boy through rRP. So the transport is its own: `Gen2MysteryGiftTransport` is the window and nothing about infrared. The partner that exists today is the player's own other save slot. With one save file the exchange times out and the routine prints its communication error, which is what one Game Boy has always shown.

**The SRAM block is two pairs, not one, and the pairing is the whole behaviour.** `sMysteryGiftItem`/`sMysteryGiftUnlocked` are the working bytes; `sBackupMysteryGiftItem`/`sNumDailyMysteryGiftPartnerIDs` are the pair a save writes and a load reads back. The gift lands in the backup byte because the exchange happens with no file open, and `RestoreMysteryGift` carries it into the game that collects it. The second byte of the backup pair is also the day's partner counter, so the menu row appears the session after Carrie: only a save copies one byte into the other.

No save-format bump. `Gen2SaveData.mystery_gift` defaults the way `mailbox` and `box_names` do, so an older slot reads as one that has never linked.

**Where the row went.** The main menu is the launcher and the save screen in this port. The save screen already has both slots in front of the player, and those two slots are the only two Mystery Gift blocks on one machine, so the row is there.

**What the specials do now.** `CheckMysteryGift`, `GetMysteryGiftItem` and `UnlockMysteryGift` leave the deferred list. `SPECIAL_TRAINER_HOUSE` reads the real flag instead of a hardcoded zero, so a player who has linked is let in and CAL wears the partner's name.

**Two things a reading settled.**

- `.RandomSample` is four weighted bands, not an index, and the player's own ID picks the odd row inside a band. Its `rlc e` loop rotates 256 times on a count of zero and lands back where it started.
- `hlcoord 2, 8` in `DoMysteryGift` is dead. All eight endings load `hl` again before `PrintText` reads it, so every box is the ordinary speech textbox at the bottom of the screen.

Cache format 89 carries the screen, which is two screens: Crystal builds its frame from one sixty-seven tile run coloured with two palettes, Gold and Silver from three runs and one plus the solid tile the routine byte-fills. Neither has a stored tilemap, so `InitMysteryGiftLayout`'s own writes are transcribed.

One deliberate divergence, recorded with its reason: the Trainer House party. `ReadTrainerParty` copies it out of `sMysteryGiftTrainer`, which is zeroes on a real cartridge because `StagePartyDataForMysteryGift` sits behind a `vc_patch`. Reproducing that exactly means a fight against six level-0 blanks, so CAL2's own table party is kept and only the half the cartridge really fills is taken.

Measured:

| Check | Result |
|---|---|
| GUT, all tiers | 3768 pass over 162 scripts |
| `validate.gd -- all` | 74 topics pass on all three cartridges |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| Boot smoke | clean |

`tools/checks/mystery_gift.gd` sweeps both gift tables end to end, all eight boxes, every branch of the chain once each, and drives the live screen with its two buttons. `tools/preview_mystery_gift.gd -- <game> <out.png> [box|all]` is the picture.