### PR TITLE
Keep the variable sprite table with the save, where the cartridge keeps it

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 16 for [the shiny seam](#how-many-times-a-wilds-dvs-are-rolled), [an item gift](#asking-the-host-to-hand-an-item-over) and [reading the bag](#reading-the-bag), 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for [the battle entrance](#the-entrance) and the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 17 for [the battlers block](#the-battlers), 16 for [the shiny seam](#how-many-times-a-wilds-dvs-are-rolled), [an item gift](#asking-the-host-to-hand-an-item-over) and [reading the bag](#reading-the-bag), 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -907,7 +907,8 @@ a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
 `player_unown_form`, `enemy_substitute`, `player_substitute`, `enemy_name`,
 `player_name`, `enemy_level`, `player_level`, `battle_kind`, `trainer_class`,
 `trainer_index`, `trainer_name`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
-`player_max_hp`, `exp_pixels`, `raster_scx`, `raster_scy`, `entrance`,
+`player_max_hp`, `enemy_shiny`, `player_shiny`, `exp_pixels`, `raster_scx`,
+`raster_scy`, `battlers`,
 `intro_sprites`, `grayscale`, `enemy_trainer_pic`, `player_backpic`,
 `player_backpic_palette`, `enemy_hud_visible`, `player_hud_visible`,
 `trainer_hud_balls`, `trainer_hud_border`, `bg_map`, `bg_vbank1`,
@@ -926,6 +927,15 @@ not the class name. `exp_pixels` is a
 count out of 64, which is `PlaceExpBar`'s own unit; the exp bar is never a
 ratio, because `CalcExpBar` has already done the division and rounded it the
 cartridge's way.
+
+`enemy_shiny` and `player_shiny` say the individual on that square is shiny, so
+its picture is drawn in the shiny palette rather than the species one:
+`GameData.palette(number, shiny)` is the accessor both take, the same call
+`_CGB_BattleColors` makes through `GetMonNormalOrShinyPalettePointer`. They are
+about the individual and not the species, so they cannot be derived from
+`enemy_species` and `player_species`; a renderer that ignores them draws every
+shiny in normal colours. Both are `api_version` 11, pushed with the rest of the
+resolved battle fields.
 
 `raster_scx` is the background's own horizontal scroll, one value per scanline
 in the order the hardware draws them, and empty whenever the background is
@@ -959,27 +969,40 @@ below that base is not an animation tile at all. `hud_visible` is false for the
 length of a move animation, which is `BattleAnimClearHud` taking the panels and
 both bars off the map and `BattleAnimRestoreHuds` putting them back.
 
-### The entrance
+### The battlers
 
 A fight does not open with two Pokémon standing on the field. Two *trainers*
 slide in from opposite sides, the opponent sends out first, the player's back
 pic walks off, and a ball puts a Pokémon where each trainer was standing. Every
 field so far says that in the terms the hardware draws it in: the slide is a
 scanline scroll (`raster_scx`), the walk off is columns going blank in `bg_map`,
-and the player mid-slide is eighteen OAM entries (`intro_sprites`). A renderer
-with no background plane has none of those three, so `entrance` is the same
-state said plainly, one entry per side:
+and the player mid-slide is eighteen OAM entries (`intro_sprites`).
+
+Nothing that happens to a battler *after* the entrance is any different. A faint
+sinks the picture a tile row at a time inside `bg_map`; a Fly, Dig, Bounce,
+Teleport or Whirlwind user is blanked out of it for a turn; a recall and a
+send-out restamp it out of progressively smaller subsamplings of itself; and
+every per-battler deformation, Tackle, Withdraw, Psychic, DoubleTeam, AcidArmor,
+Wobble, Flail, WaveDeformMon, BounceDown and Vibrate, is a scanline window over
+that side's own rows.
+
+A renderer with no background plane has none of that, and reconstructing it by
+scanning a 20 by 18 grid every frame is both duplicated work and lossy: a resize
+script's arrangement and a faint sink read the same at the tile level. So
+`battlers` is all of it said plainly, one entry per side, on every frame:
 
 ```gdscript
-view["entrance"] = {
+view["battlers"] = {
     "player": {
         "kind": &"trainer",              # or &"mon", or &"none"
         "backpic": "kris",               # "" unless kind is trainer
         "trainer_class": 0,              # always 0 on the player's side
         "species": 0,                    # 0 unless kind is mon
+        "visible": true,                 # false while the picture is off the square
         "offset_pixels": Vector2(142.0, 0.0),
+        "scale": Vector2.ONE,            # the resize script's own steps otherwise
     },
-    "enemy": { ... the same five, with trainer_class carrying the class },
+    "enemy": { ... the same seven, with trainer_class carrying the class },
 }
 ```
 
@@ -992,13 +1015,33 @@ and `trainer_palette(number)` take, and `species` what `species_pic()` takes, so
 whichever one is set names a picture the renderer can resolve. A wild opponent
 is never a trainer and slides in as its own front pic.
 
-`offset_pixels` is how far that picture stands from its resting square, and it
-covers both movements with one number because both are one thing: the slide
-brings a picture in from off the field and `SlideBattlePicOut` takes it off
-again. Zero is standing still, which is every frame outside an entrance. The
-player comes in from the right and leaves to the left and the opponent the other
-way, so the sign is the direction. A renderer that ignores the block draws
-exactly what it draws today.
+`visible` is whether the picture is on the square at all.
+`BattleBGEffect_HideMon` is what takes it off for a vanished turn and
+`..._RemoveMon` for a recall, and it stays off until a send-out puts a whole
+picture back. It is not the same question as `kind`: `&"none"` is a square
+nobody is standing on, `visible` false a picture that has been taken away from
+one somebody is.
+
+`offset_pixels` is how far that picture stands from its resting square, and one
+number covers every movement because they are all the same thing: the slide
+brings a picture in, `SlideBattlePicOut` takes it off, `MonFaintedAnimation`
+sinks it, `RemoveMon` pushes it aside, and the window effects lunge, shake and
+sink it. Zero is standing still. The player comes in from the right and leaves to
+the left and the opponent the other way, so the sign is the direction, and a
+faint is positive downwards. The whole-screen scroll is not in it: `raster_scx`
+and `raster_scy` already carry that, and this is what is left after it. Two
+effects stretch the picture rather than move it, WaveDeformMon and Psychic, and
+for those the number is the mean of the window rather than an exact answer.
+
+`scale` is the side of the square `BattleBGEffect_RunPicResizeScript` last placed
+over the side of the whole picture, so the ball shrink of a recall and the grow
+of a send-out are one number. `Vector2.ONE` is the whole picture, which is every
+frame outside a resize. The cartridge subsamples rather than scales, dropping
+rows and columns, so a renderer drawing a real scaled picture is drawing it
+better than the hardware did rather than differently.
+
+A renderer that reads only `kind`, the three picture fields and `offset_pixels`
+draws exactly what it drew before this block existed.
 
 `intro_sprites` is the eighteen `{ tile, x, y }` of the player's own head and
 shoulders during the slide, drawn as OAM because those three tile rows fall in
@@ -1020,12 +1063,16 @@ of `species_pic(number, back)`. `bg_vbank1` is `wAttrmap` bit
 3 over the screen, the VRAM bank each cell's tile number is read from, which
 only the enemy's own pic animation ever sets.
 
-`entrance` and the twelve fields named in this section are `api_version` 11.
+`battlers` is `api_version` 17 and replaces `entrance`, which carried the first
+five fields alone and is gone: the two describe the same thing at different
+moments in one fight, and a renderer reading one for the opening and the other
+for the rest would have had to hold both. The twelve fields named in this section
+are `api_version` 11.
 Before it they were pushed and undeclared, and one more was declared and never
 true: `player_pic_visible` was a literal `true` in every view, because the
 premise behind it is wrong. `CopyBackpic` puts the player's back pic on the
 tilemap before `InitBattleDisplay` reaches the slide, so it is on the map
-throughout. The field is gone; `entrance` is what answers the question it was
+throughout. The field is gone; `battlers` is what answers the question it was
 asked for.
 
 The two HP values and `exp_pixels` are the *drawn* ones, not the committed ones:

--- a/game/battle/battle_anim_background.gd
+++ b/game/battle/battle_anim_background.gd
@@ -100,6 +100,91 @@ var bg_map_third: int = 0
 ## `wSurfWaveBGEffect`.
 var surf_wave: PackedByteArray = PackedByteArray()
 
+## What the tilemap effects did to each battler's picture, said plainly beside
+## the map they said it in. Keyed by `player_side`, the same bool the effects
+## already carry.
+##
+## `BattleBGEffect_HideMon`, `..._RemoveMon` and `..._RunPicResizeScript` are the
+## three that move or take away a whole picture, and all three say it by editing
+## `wTilemap`: a renderer with no background plane cannot read a shrink or a
+## removal back out of a 20x18 grid of tile ids, because a resize script's
+## arrangement and a faint sink look the same there. These three are that state
+## said plainly, and [method Gen2BattleScreen.battler_side] is what composes them
+## with the entrance, the faint and the scanline window into one block per side.
+##
+## `visible` is whether a picture is on the square at all, `shift` how far
+## `RemoveMon` has pushed it off in pixels, and `scale` the side of the square
+## the resize script last placed over the side of the whole picture.
+var battler_visible: Dictionary = {true: true, false: true}
+var battler_shift: Dictionary = {true: Vector2.ZERO, false: Vector2.ZERO}
+var battler_scale: Dictionary = {true: 1.0, false: 1.0}
+
+## `.BGSquares`' seven and six: the whole picture on each side, which every other
+## square of the resize scripts is a subsampling of.
+const BATTLER_SQUARE: Dictionary = {true: 6, false: 7}
+
+
+## `BGEffect_DisplaceLYOverridesBackup`'s own `$90`, a scanline scrolled to a row
+## the picture is not on. Those lines carry no displacement to average.
+const LY_OFF_SCREEN: int = 0x90
+## `SetLCDStatCustoms` opens the player's window at `$2d` or `$2f` and the
+## opponent's at `$00`, so where a window starts is what says whose it is.
+const PLAYER_WINDOW_TOP: int = 0x2D
+
+
+## How far the open scanline window has moved one side's picture, in pixels.
+##
+## Every per-battler deformation is one window over that side's own rows:
+## Tackle, Withdraw, Dig, Psychic, DoubleTeam, AcidArmor, Wobble, Flail,
+## WaveDeformMon, BounceDown and Vibrate all move a battler by writing scroll
+## values into it. The mean of the window on the axis `hLCDCPointer` names is
+## what this reports, with the whole-screen scroll taken off because `raster_scx`
+## and `raster_scy` already carry that. A scroll of n draws the content n pixels
+## further left or up, so the picture's own offset is its negation, and a row
+## pushed off with `$90` is not part of the mean: the rows that are left carry
+## the displacement, which is what makes a Withdraw read as a sink.
+##
+## WaveDeformMon and Psychic stretch the picture rather than move it, and there
+## the mean is the honest summary of one rather than an exact answer.
+func battler_window_offset(player_side: bool) -> Vector2:
+	if lcdc_pointer != LCDC_SCX and lcdc_pointer != LCDC_SCY:
+		return Vector2.ZERO
+	var first: int = ly_override_start & 0xFF
+	var count: int = (ly_override_end - ly_override_start) & 0xFF
+	var mine: bool = first >= PLAYER_WINDOW_TOP if player_side \
+		else first < PLAYER_WINDOW_TOP
+	if count == 0 or not mine:
+		return Vector2.ZERO
+	var base: int = scx if lcdc_pointer == LCDC_SCX else scy
+	var total: float = 0.0
+	var lines: int = 0
+	for step: int in count:
+		var line: int = (first + step) & (LY_PAGE - 1)
+		if line >= SCREEN_LINES:
+			continue
+		var value: int = int(ly_overrides[line])
+		if value == LY_OFF_SCREEN:
+			continue
+		total += float(value - 256 if value > 127 else value) - float(base)
+		lines += 1
+	if lines == 0:
+		return Vector2.ZERO
+	var offset: float = -total / float(lines)
+	return Vector2(offset, 0.0) if lcdc_pointer == LCDC_SCX \
+		else Vector2(0.0, offset)
+
+
+## One tilemap effect's report. [param player_side] is the effect's own side.
+func report_battler(
+	player_side: bool, visible: bool, scale: float = -1.0,
+	shift: Vector2 = Vector2.INF
+) -> void:
+	battler_visible[player_side] = visible
+	if scale >= 0.0:
+		battler_scale[player_side] = scale
+	if shift != Vector2.INF:
+		battler_shift[player_side] = shift
+
 
 func _init() -> void:
 	ly_overrides.resize(LY_PAGE)

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -591,10 +591,12 @@ static func _hide_mon(
 	match effect.jumptable_index:
 		0:
 			_inc(effect)
-			if _player_side(player, effect):
+			var hidden_side: bool = _player_side(player, effect)
+			if hidden_side:
 				background.clear_box(2, 6, 6, 6)
 			else:
 				background.clear_box(12, 0, 7, 7)
+			background.report_battler(hidden_side, false)
 			# Crystal alone rewinds the push; pokegold leaves whichever third
 			# was in flight.
 			if player.profile() == &"crystal":
@@ -660,9 +662,18 @@ static func _run_pic_resize_script(
 					return
 				if square == -2:
 					_resize_clear_box(background, int(row[1]), int(row[2]))
+					## The scripts alternate a placement with the clear that
+					## takes it away again, so whichever ran last is what is on
+					## the square: `RESIZE_RETURN_*` ends on a clear and the
+					## picture is gone, `RESIZE_ENTER_*` on a placement.
+					background.report_battler(_player_side(player, effect), false)
 					continue
 				if square != -3:
 					_resize_place_graphic(background, square, int(row[1]), int(row[2]))
+					var side: bool = _player_side(player, effect)
+					background.report_battler(side, true, float(
+						RESIZE_SIZES[square]
+					) / float(int(Gen2BattleAnimBackground.BATTLER_SQUARE[side])))
 				_inc(effect)
 				background.bg_map_mode = 1
 				return
@@ -771,6 +782,16 @@ static func _remove_mon(
 			background.bg_map_mode = 1
 			_inc(effect)
 			effect.param = (effect.param - 1) & 0xFF
+			## The enemy's picture leaves to the right and the player's to the
+			## left, one tile column per step, which is the same sign the
+			## entrance's own walk off carries.
+			var removed_side: bool = effect.battle_turn != 0
+			var step: float = -float(Gen2Tiles.TILE_WIDTH) if removed_side \
+				else float(Gen2Tiles.TILE_WIDTH)
+			background.report_battler(
+				removed_side, effect.param != 0, -1.0,
+				(background.battler_shift[removed_side] as Vector2) + Vector2(step, 0.0)
+			)
 		2, 3:
 			_inc(effect)
 		4:

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -111,7 +111,8 @@ var enemy_off_field: bool = false
 ## animation. [param param] is `wBattleAnimParam` and [param enemy_turn] is
 ## `hBattleTurn`, the two inputs set before `PlayBattleAnim`.
 static func create(
-	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool = false, param: int = 0
+	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool = false,
+	param: int = 0, wobbles: Array[int] = []
 ) -> Gen2BattleAnimPlayer:
 	if anim_data == null:
 		return null
@@ -134,7 +135,7 @@ static func create(
 		player._bg_effects[slot] = Gen2BattleAnimBgEffect.new()
 	player._background = Gen2BattleAnimBackground.new()
 	player._script = Gen2BattleAnimScript.create(
-		region["data"], int(region["address"]), address, param
+		region["data"], int(region["address"]), address, param, wobbles
 	)
 	return player
 

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -113,6 +113,13 @@ const IF_PARAM_EQUAL: StringName = &"if_param_equal"
 const IF_VAR_EQUAL: StringName = &"if_var_equal"
 const SET_VAR: StringName = &"set_var"
 const INC_VAR: StringName = &"inc_var"
+const CHECK_POKEBALL: StringName = &"check_pokeball"
+
+## `GetPokeBallWobble`'s three answers, which `BattleAnim_ThrowPokeBall.Loop`
+## branches on: keep wobbling, click shut, or break free.
+const WOBBLE_NEXT: int = 0
+const WOBBLE_CAUGHT: int = 1
+const WOBBLE_ESCAPED: int = 2
 
 ## How many commands one frame may run before the script is abandoned.
 ##
@@ -138,6 +145,12 @@ var _loops: int = 0
 var _delay: int = 0
 var _var: int = 0
 var _param: int = 0
+## `GetPokeBallWobble`'s answers in the order it will give them, which the caller
+## has already decided: the throw is resolved before it is drawn, the way
+## `PokeBallEffect` sets `wWildMon` and `wThrownBallWobbleCount` in front of
+## `PlayBattleAnim`. An empty queue is `.finished` with `wWildMon` zero, which is
+## a break free.
+var _wobbles: Array[int] = []
 var _stopped: bool = false
 var _failed: bool = false
 
@@ -148,13 +161,15 @@ var _failed: bool = false
 ## [param param] is `wBattleAnimParam`, which the caller sets before playing;
 ## `wBattleAnimVar` starts at zero because `ClearBattleAnims` clears it.
 static func create(
-	region: PackedByteArray, base_address: int, start_address: int, param: int = 0
+	region: PackedByteArray, base_address: int, start_address: int, param: int = 0,
+	wobbles: Array[int] = []
 ) -> Gen2BattleAnimScript:
 	var script := Gen2BattleAnimScript.new()
 	script._region = region
 	script._base_address = base_address
 	script._address = start_address
 	script._param = param & 0xFF
+	script._wobbles = wobbles.duplicate()
 	script._stopped = not script._holds(start_address)
 	script._failed = script._stopped
 	return script
@@ -296,6 +311,11 @@ func _execute(command: Dictionary) -> bool:
 			_var = int(operands[0])
 		INC_VAR:
 			_var = (_var + 1) & 0xFF
+		CHECK_POKEBALL:
+			## `BattleAnimCmd_CheckPokeball`, which is `GetPokeBallWobble` into
+			## `wBattleAnimVar`. The roll itself is not taken here: the catch is
+			## already decided, and this is the sequence it decided.
+			_var = _wobbles.pop_front() if not _wobbles.is_empty() else WOBBLE_ESCAPED
 	return false
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -215,8 +215,18 @@ var _slides: Array[Dictionary] = []
 ## way the walk goes: the player leaves to the left and the opponent to the
 ## right. Kept after the walk ends rather than dropped with the slide's entry,
 ## because the picture stays off the square until the ball puts a Pokemon there;
-## that stretch is the `none` [method _entrance_side] reports.
+## that stretch is the `none` [method battler_side] reports.
 var _slid_pixels: Dictionary = {Gen2Battle.PLAYER: 0.0, Gen2Battle.ENEMY: 0.0}
+## What the tilemap effects last did to each battler's picture, carried past the
+## animation that did it: `BattleBGEffect_HideMon` leaves a Fly or Dig user off
+## the field for a turn, and `..._RemoveMon` leaves a recalled Pokemon off the
+## square until the next send-out. The anim background reports both while it runs
+## and this is where they outlive it; see [method battler_side].
+var _battler_visible: Dictionary = {Gen2Battle.PLAYER: true, Gen2Battle.ENEMY: true}
+var _battler_scale: Dictionary = {Gen2Battle.PLAYER: 1.0, Gen2Battle.ENEMY: 1.0}
+var _battler_shift: Dictionary = {
+	Gen2Battle.PLAYER: Vector2.ZERO, Gen2Battle.ENEMY: Vector2.ZERO,
+}
 ## `AnimateFrontpic` over the enemy's square, or null when none is running.
 var _frontpic: Gen2PicAnimation = null
 ## `wAttrmap` bit 3, which `PokeAnim_SetVBank1` sets over that square while the
@@ -1234,7 +1244,7 @@ func advance_intro() -> bool:
 		# then `hGraphicStartTile = $31` / `hlcoord 2, 6` / `PlaceGraphic`, which
 		# puts back the two tile rows its `ClearBox` took off before the slide.
 		_intro = null
-		Gen2BattleScreenMap.stamp(_bg_map, true)
+		_restamp_battler(true)
 		_push_view()
 		_build_entrance()
 		_advance_entrance()
@@ -1645,6 +1655,9 @@ var _substitute_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: f
 ## `wFXAnimID` is a word: an id past this is not a move and skips the whole
 ## battle-scene, hud and after-anim half of `BattleAnimRunScript`.
 const ANIM_MOVE_LIMIT: int = 0x100
+## `ANIM_THROW_POKE_BALL`, the first entry past the moves
+## (constants/move_constants.asm).
+const ANIM_THROW_POKE_BALL: int = 0x100
 
 ## `SendOutMonText`'s four texts, in [constant Gen2Battle.SEND_OUT_GO]'s order.
 const SEND_OUT_LINES: Array[String] = [
@@ -1852,7 +1865,7 @@ func _run_next_anim_step() -> void:
 				_set_substitute_pic(
 					Gen2Battle.ENEMY if enemy_turn else Gen2Battle.PLAYER, false
 				)
-				Gen2BattleScreenMap.stamp(_bg_map, not enemy_turn)
+				_restamp_battler(not enemy_turn)
 				_push_view()
 	_anim = null
 	_anim_event = {}
@@ -1868,9 +1881,11 @@ func _run_next_anim_step() -> void:
 func _start_script(index: int) -> bool:
 	if _anim_data == null:
 		return false
+	var wobbles: Array[int] = []
+	wobbles.assign(_anim_event.get("wobbles", []))
 	_anim = Gen2BattleAnimPlayer.create(
 		_anim_data, index, bool(_anim_event.get("enemy_turn", false)),
-		int(_anim_event.get("param", 0))
+		int(_anim_event.get("param", 0)), wobbles
 	)
 	if _anim == null:
 		return false
@@ -1897,7 +1912,31 @@ func _after_anim_frame() -> void:
 						else Gen2Battle.PLAYER,
 					StringName(command["name"]) == Gen2BattleAnimScript.RAISE_SUB
 				)
+	_carry_battler_reports()
 	_push_view()
+
+
+## The anim background's own report, lifted onto the screen so it outlives the
+## animation the way the tilemap it was written beside does.
+func _carry_battler_reports() -> void:
+	if _anim == null:
+		return
+	var background: Gen2BattleAnimBackground = _anim.background()
+	for player_side: bool in [true, false]:
+		var side: int = Gen2Battle.PLAYER if player_side else Gen2Battle.ENEMY
+		_battler_visible[side] = bool(background.battler_visible[player_side])
+		_battler_scale[side] = float(background.battler_scale[player_side])
+		_battler_shift[side] = background.battler_shift[player_side] as Vector2
+
+
+## `PlaceGraphic` putting a whole picture back on a square, which is the one
+## thing that undoes every report above.
+func _restamp_battler(player_side: bool) -> void:
+	Gen2BattleScreenMap.stamp(_bg_map, player_side)
+	var side: int = Gen2Battle.PLAYER if player_side else Gen2Battle.ENEMY
+	_battler_visible[side] = true
+	_battler_scale[side] = 1.0
+	_battler_shift[side] = Vector2.ZERO
 
 
 func _end_script() -> void:
@@ -2625,14 +2664,50 @@ func complete_capture(result: Dictionary) -> Dictionary:
 			_capture_ball_index = mini(_capture_ball_index, maxi(_capture_balls.size() - 1, 0))
 
 	var wobbles: int = clampi(int(result.get("wobbles", 0)), 0, 3)
+	var caught: bool = bool(result.get("caught", false))
 	for _wobble: int in wobbles:
 		_capture_messages.append("The ball shook!")
-	if bool(result.get("caught", false)):
+	if caught:
 		_capture_messages.append("Gotcha! %s was caught!" % _name_of(_enemy))
 		_capture_terminal = true
 	else:
 		_capture_messages.append("%s broke free!" % _name_of(_enemy))
+	_begin_capture_animation(result_ball, wobbles, caught)
 	return result
+
+
+## `PokeBallEffect`'s own `PlayBattleAnim` on `ANIM_THROW_POKE_BALL`, which is
+## the throw, the poof, the opponent going into the ball, the wobbles and the
+## click or the break free: one script, not five.
+##
+## The catch is already resolved when this runs, the way the source resolves it
+## in front of the animation and hands the drawing `wWildMon` and
+## `wThrownBallWobbleCount` rather than a roll. `anim_checkpokeball` is what
+## reads them, so the queue is `GetPokeBallWobble`'s answers in order.
+##
+## The opponent leaving the field and coming back are `BATTLE_BG_EFFECT_RETURN_MON`
+## and `..._ENTER_MON` inside the script, which is why nothing here touches the
+## picture: both report through [method battler_side] like every other resize.
+func _begin_capture_animation(ball: int, wobbles: int, caught: bool) -> void:
+	if ball <= 0:
+		return
+	var answers: Array[int] = []
+	for _wobble: int in wobbles:
+		answers.append(Gen2BattleAnimScript.WOBBLE_NEXT)
+	answers.append(
+		Gen2BattleAnimScript.WOBBLE_CAUGHT if caught \
+			else Gen2BattleAnimScript.WOBBLE_ESCAPED
+	)
+	_begin_animation({
+		## `.not_kurt_ball`: every ball Kurt makes is drawn as a POKE BALL,
+		## which is what the `cp POKE_BALL + 1` in front of it decides.
+		"param": mini(ball, Gen2WorldPartyHost.ITEM_POKE_BALL),
+		"index": ANIM_THROW_POKE_BALL,
+		## `xor a / ldh [hBattleTurn]`: the throw is the player's, so the
+		## script's `BG_EFFECT_TARGET` is the opponent.
+		"enemy_turn": false,
+		"wobbles": answers,
+	})
 
 
 func _show_capture_selection() -> void:
@@ -5010,8 +5085,13 @@ func _push_view() -> void:
 		## `BattleStart_TrainerHuds`' party balls and the frame they hang in.
 		"trainer_hud_balls": _hud_balls,
 		"trainer_hud_border": _hud_border,
-		## `wTilemap` and the video state an animation writes over it.
-		"bg_map": _bg_map,
+		## `wTilemap` and the video state an animation writes over it. The
+		## running animation's own copy is the live one: `RunBattleAnimScript`
+		## hands the tilemap in and takes it back out, and every effect that
+		## blanks, sinks or resizes a picture edits it a frame at a time, so a
+		## view given the screen's copy meanwhile watched an animation happen to
+		## a picture that never moved.
+		"bg_map": _anim.background().bg_map if _anim != null else _bg_map,
 		"bg_vbank1": _bg_vbank1,
 		"bg_palette_maps": _background_maps(&"bg"),
 		"ob_palette_maps": _background_maps(&"ob"),
@@ -5020,11 +5100,12 @@ func _push_view() -> void:
 		## Whether both panels are on the map, which is the summary of the two
 		## keys above rather than a third state.
 		"hud_visible": _hud_visible(),
-		## Who is standing on each square and how far off it they are, resolved:
-		## see [method _entrance_side].
-		"entrance": {
-			"player": _entrance_side(Gen2Battle.PLAYER),
-			"enemy": _entrance_side(Gen2Battle.ENEMY),
+		## Who is standing on each square, whether the picture is on it, how far
+		## it is from resting there and how big it is drawn: see
+		## [method battler_side].
+		"battlers": {
+			"player": battler_side(Gen2Battle.PLAYER),
+			"enemy": battler_side(Gen2Battle.ENEMY),
 		},
 	})
 	if _box != null:
@@ -5035,24 +5116,38 @@ func _push_view() -> void:
 	_refresh_annotations()
 
 
-## What is standing on one side's square and how far it is from standing on it,
-## for a renderer that stages the fight somewhere other than a 20x18 tile page.
+## What is standing on one side's square, whether it is on it, how far it is from
+## resting there and how big it is drawn, for a renderer that stages the fight
+## somewhere other than a 20x18 tile page.
 ##
-## Every other field describing the entrance says it in the terms the hardware
-## draws it in: the slide in is a scanline scroll, the walk off is columns going
-## blank in `bg_map`, and the player mid-slide is eighteen OAM entries. A view
-## with no background plane has none of those three and would have to rebuild
-## host state to read either movement. These three values are that state said
-## plainly.
+## Every other field describing a battler says it in the terms the hardware draws
+## it in: the opening slide is a scanline scroll, the walk off is columns going
+## blank in `bg_map`, the player mid-slide is eighteen OAM entries, a faint sinks
+## the picture a tile row at a time inside the map, a resize script restamps it
+## out of smaller subsamplings, and every per-battler deformation is a scanline
+## window over that side's own rows. A view with no background plane has none of
+## those and would have to rebuild host state to read any of them, which is lossy
+## as well as duplicated: a resize script's arrangement and a faint sink read the
+## same at the tile level. These four values are that state said plainly.
 ##
 ## [code]kind[/code] is what the square holds: [code]&"trainer"[/code] a person,
 ## [code]&"mon"[/code] a Pokemon, and [code]&"none"[/code] the stretch between
 ## the trainer walking off and the ball putting a Pokemon there.
-## [code]offset_pixels[/code] is how far that picture is from its resting square
-## and covers both movements with one number, because both are one thing: the
-## opening slide brings a picture in and `SlideBattlePicOut` takes it off again.
-## Zero is standing still, which is every frame outside an entrance.
-func _entrance_side(side: int) -> Dictionary:
+## [code]visible[/code] is whether the picture is on the square at all, which
+## `BattleBGEffect_HideMon` and `..._RemoveMon` are what take it off.
+## [code]offset_pixels[/code] is how far that picture is from its resting square,
+## and one number covers every movement because they are all the same thing: the
+## opening slide brings a picture in, `SlideBattlePicOut` takes it off,
+## `MonFaintedAnimation` sinks it, `RemoveMon` pushes it aside and the window
+## effects lunge, shake and sink it. Zero is standing still.
+## [code]scale[/code] is the side of the square `BattleBGEffect_RunPicResizeScript`
+## last placed over the side of the whole picture, so the ball shrink of a recall
+## and the grow of a send-out are one number; 1 is the whole picture.
+##
+## Every value is read out of state the screen already runs rather than simulated
+## again: `faint_step`, `slide_step`, the resize scripts and the scanline window
+## are what drive the map, and this reports what they drove it with.
+func battler_side(side: int) -> Dictionary:
 	var player_side: bool = side == Gen2Battle.PLAYER
 	var backpic: String = _player_backpic if player_side else ""
 	var trainer_class: int = 0 if player_side else _enemy_trainer_pic
@@ -5079,8 +5174,31 @@ func _entrance_side(side: int) -> Dictionary:
 		"backpic": backpic if kind == &"trainer" else "",
 		"trainer_class": trainer_class if kind == &"trainer" else 0,
 		"species": species if kind == &"mon" else 0,
-		"offset_pixels": Vector2(offset, 0.0),
+		"visible": bool(_battler_visible[side]),
+		"offset_pixels": Vector2(offset, 0.0) + Vector2(_battler_shift[side]) \
+			+ _faint_offset(side) + _window_offset(player_side),
+		"scale": Vector2.ONE * float(_battler_scale[side]),
 	}
+
+
+## `MonFaintedAnimation`'s outer loop, which takes the block's rows from the row
+## above: seven steps of one tile row each, so the picture sinks a tile a step.
+func _faint_offset(side: int) -> Vector2:
+	for faint: Dictionary in _faints:
+		var player_side: bool = side == Gen2Battle.PLAYER
+		if bool(faint["player_side"]) != player_side:
+			continue
+		return Vector2(0.0, float(int(faint["step"]) * Gen2Tiles.TILE_HEIGHT))
+	return Vector2.ZERO
+
+
+## The scanline window over one side's own rows, which is how every per-battler
+## deformation moves a picture; [method Gen2BattleAnimBackground.battler_window_offset]
+## owns the reading and this is the frame it is asked on.
+func _window_offset(player_side: bool) -> Vector2:
+	if _anim == null:
+		return Vector2.ZERO
+	return _anim.background().battler_window_offset(player_side)
 
 
 ## The background scroll for the whole screen: the intro's own bands, or an

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -66,7 +66,15 @@ const FILENAME: String = "mod.json"
 ## [method Gen2ModHost.inventory], the live bag a non-renderer mod otherwise has
 ## no way to read. Only the first two are contract: a mod may feature-detect the
 ## bag but not a roll it never sees taken.
-const API_VERSION: int = 16
+##
+## 17 is the one break in the list. `view["entrance"]` is gone and
+## `view["battlers"]` stands in its place, carrying the same five fields plus
+## `visible` and `scale`: everything that happens to a battler after the entrance
+## used to be readable only as `bg_map` edits, and the two blocks describe the
+## same thing at different moments. Carrying both would have meant a renderer
+## reading one for the opening and the other for the fight, so the fold is the
+## contract. See [method Gen2BattleScreen.battler_side].
+const API_VERSION: int = 17
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -231,7 +231,6 @@ var _transient_object_visibility_overrides: Dictionary = {}
 var _object_position_overrides: Dictionary = {}
 var _object_facing_overrides: Dictionary = {}
 var _object_followers: Dictionary = {}
-var _variable_sprites: Dictionary = {}
 ## `LoadMapObjects` runs `MAPCALLBACK_OBJECTS` and then `LoadObjectMasks`, so a
 ## map load owes its masks once the callbacks it queued have run and not before:
 ## the flag one of them writes is read by the other. Raised by every map load and
@@ -4246,7 +4245,10 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 				or sprite <= 0:
 				generated.append({"type": &"variable_sprite_change_failed"})
 				continue
-			_variable_sprites[variable_sprite] = sprite
+			state.set_variable_sprite(variable_sprite, sprite)
+			## The table is `wPlayerData`, not the loaded map, so the people
+			## SCREEN FILL draws on the maps next door resolve through it too.
+			_connected_objects = []
 			reload_objects = true
 			generated.append({
 				"type": &"variable_sprite_changed",
@@ -6592,7 +6594,7 @@ func _resolved_sprite(sprite_number: int) -> int:
 			return resolved if _day_care_species(resolved) > 0 else SPRITE_CHRIS
 		if resolved < Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE:
 			return resolved
-		var assigned: int = int(_variable_sprites.get(resolved, 0))
+		var assigned: int = state.variable_sprite(resolved) if state != null else 0
 		if assigned == 0:
 			return SPRITE_CHRIS
 		resolved = assigned
@@ -6622,15 +6624,13 @@ func _day_care_species(sprite_number: int) -> int:
 ## `GetMonSprite`'s `.Variable` branch reads wVariableSprites and falls through
 ## to `.NoBreedmon` on a zero slot, whose `ld a, WALKING_SPRITE` is 1 and so
 ## `SPRITE_CHRIS` by coincidence of two constant lists
-## (engine/overworld/overworld.asm). So an object whose variable sprite no
-## script has assigned yet is drawn, occupies its cell and is talkable.
-## Copycat's House 2F is where it matters: SPRITE_COPYCAT is $fb and only the
-## Copycat's own script assigns it, so without this she could not be reached to
-## run it. Route 37's twins are the same rule seen from the other end: their
-## SPRITE_WEIRD_TREE is Sudowoodo's slot and only Route 36's own script assigns
-## it, so a save that has not met Sudowoodo really does stand two copies of the
-## player's sprite on that route. An object that should not be there at all is
-## masked by [method load_object_masks], not by this fallback.
+## (engine/overworld/overworld.asm). Reaching that fallback is the exception and
+## not the rule: `Gen2WorldState.INITIAL_VARIABLE_SPRITES` is what
+## `InitializeEventsScript` leaves in nine of the slots and
+## `ToggleDecorationsVisibility` fills the other four, so every slot any map
+## stands an object on has a row. An object drawn as the player means the table
+## lost one. An object that should not be there at all is masked by [method
+## load_object_masks], not by this fallback.
 ## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail: it writes a sprite number
 ## straight into `wMapObjects` and calls `GetUsedSprite`, because the Battle
 ## Tower's opponent is drawn at random and its object event carries a placeholder

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -305,6 +305,37 @@ var _buenas_password: int = 0
 ## own `ifequal` in front of the award, not a rule the byte enforces.
 var _blue_card_balance: int = 0
 
+## `wVariableSprites`, the sixteen `SPRITE_VARS` slots `GetMonSprite` resolves a
+## variable sprite through. It sits inside `wPlayerData`, which `SaveData` copies
+## whole into `sPlayerData`, so the table is saved and restored: an assignment
+## made in one session is still there in the next. Keeping it on the world
+## instead cost the port every one of them on reload, which drew the nine
+## `InitializeEventsScript` rows as `SPRITE_CHRIS` (see [constant
+## INITIAL_VARIABLE_SPRITES]).
+var _variable_sprites: Dictionary = {}
+
+## `InitializeEventsScript` (engine/events/std_scripts.asm), which the player's
+## bedroom runs once at new game behind `EVENT_INITIALIZED_EVENTS`. A fresh state
+## starts with these for the same reason [method Gen2WorldSpawn.apply_initial_decorations]
+## exists: every state the game can be in has run it, and a slot with no row is
+## `.NoBreedmon`'s `WALKING_SPRITE`, which is the player.
+##
+## The four `SPRITE_CONSOLE`..`SPRITE_BIG_DOLL` slots are deliberately absent:
+## `ToggleDecorationsVisibility` fills those on every entry to the bedroom, so
+## they are the one group that needs no default. The numbers are the same on all
+## three cartridges (constants/sprite_constants.asm).
+const INITIAL_VARIABLE_SPRITES: Dictionary = {
+	0xF4: 0x52,  # SPRITE_WEIRD_TREE      -> SPRITE_SUDOWOODO
+	0xF5: 0x04,  # SPRITE_OLIVINE_RIVAL   -> SPRITE_RIVAL
+	0xF6: 0x35,  # SPRITE_AZALEA_ROCKET   -> SPRITE_ROCKET
+	0xF7: 0x0A,  # SPRITE_FUCHSIA_GYM_1   -> SPRITE_JANINE
+	0xF8: 0x0A,  # SPRITE_FUCHSIA_GYM_2   -> SPRITE_JANINE
+	0xF9: 0x0A,  # SPRITE_FUCHSIA_GYM_3   -> SPRITE_JANINE
+	0xFA: 0x0A,  # SPRITE_FUCHSIA_GYM_4   -> SPRITE_JANINE
+	0xFB: 0x28,  # SPRITE_COPYCAT         -> SPRITE_LASS
+	0xFC: 0x28,  # SPRITE_JANINE_IMPERSONATOR -> SPRITE_LASS
+}
+
 ## `SECTION "SRAM Battle Tower"`, which the cartridge keeps beside the save
 ## rather than inside it because a challenge can be saved and left between
 ## battles. Never null; see [Gen2BattleTower].
@@ -393,6 +424,7 @@ func _init(
 		var decoration: int = int(initial_maptile_decorations.get(category, 0))
 		if decoration > 0 and decoration <= 0xFF:
 			_maptile_decorations[category] = decoration
+	_variable_sprites = INITIAL_VARIABLE_SPRITES.duplicate()
 
 
 ## JSON-safe representation of the mutable overworld state. Cartridge records
@@ -455,6 +487,7 @@ func to_dict() -> Dictionary:
 		"mom_savings_flags": _mom_savings_flags,
 		"blue_card_balance": _blue_card_balance,
 		"buenas_password": _buenas_password,
+		"variable_sprites": _variable_sprites.duplicate(),
 		"battle_tower": _battle_tower.to_dict(),
 	}
 
@@ -571,6 +604,16 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	## Defaults rather than versioning: a slot written before the tower existed
 	## reads as one with no challenge in it, which is the truth about it.
 	restored._battle_tower = Gen2BattleTower.from_dict(source.get("battle_tower", {}))
+	## Absent in a state written before the table was saved. Those slots are
+	## whatever `InitializeEventsScript` left, which is what the constructor
+	## already seeded, so an old save needs no migration.
+	var stored_sprites: Variant = source.get("variable_sprites", {})
+	if stored_sprites is Dictionary:
+		for raw_slot: Variant in stored_sprites as Dictionary:
+			restored.set_variable_sprite(
+				int(raw_slot), int((stored_sprites as Dictionary)[raw_slot])
+			)
+
 	return restored
 
 
@@ -637,6 +680,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_mom_savings_flags = restored._mom_savings_flags
 	_blue_card_balance = restored._blue_card_balance
 	_buenas_password = restored._buenas_password
+	_variable_sprites = restored._variable_sprites.duplicate()
 	_battle_tower = restored._battle_tower
 	changed.emit()
 
@@ -673,6 +717,29 @@ func set_mystery_gift(section: Dictionary) -> void:
 ## receptionist's "your friend is not ready" answers.
 func set_link_transport(transport: Gen2LinkTransport) -> void:
 	_link_transport = transport if transport != null else Gen2LinkTransport.new()
+
+
+## `GetMonSprite`'s `.Variable` read. Zero is `.NoBreedmon`, whose
+## `ld a, WALKING_SPRITE` the caller resolves.
+func variable_sprite(slot: int) -> int:
+	return int(_variable_sprites.get(slot, 0))
+
+
+func variable_sprites() -> Dictionary:
+	return _variable_sprites.duplicate()
+
+
+## `Script_variablesprite`: one byte written into the table. A zero is refused
+## rather than stored, because the table's own zero means "unassigned".
+func set_variable_sprite(slot: int, sprite: int) -> bool:
+	if slot < Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE or slot > 0xFF \
+		or sprite <= 0 or sprite > 0xFF:
+		return false
+	if variable_sprite(slot) == sprite:
+		return true
+	_variable_sprites[slot] = sprite
+	changed.emit()
+	return true
 
 
 func maptile_decoration(category: StringName) -> int:

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 16,
+	"api_version": 17,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 16,
+	"api_version": 17,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -540,7 +540,7 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 	## the opponent comes in from the left. Both are drawn without colour:
 	## `SCGB_BATTLE_GRAYSCALE` is set where the battle is entered and
 	## `SCGB_BATTLE_COLORS` only after the slide returns.
-	var entering: Dictionary = view["entrance"]
+	var entering: Dictionary = view["battlers"]
 	assert_gt(
 		(entering["player"] as Dictionary)["offset_pixels"].x, 0.0,
 		"the back pic slides in too, from the right"
@@ -570,7 +570,7 @@ func test_a_battle_opens_on_the_slide_and_says_nothing_until_it_is_done() -> voi
 		"the start message waited for the slide"
 	)
 	var settled: Dictionary = _battle_screen._renderer._view
-	var standing: Dictionary = settled["entrance"]
+	var standing: Dictionary = settled["battlers"]
 	assert_eq(
 		(standing["player"] as Dictionary)["offset_pixels"], Vector2.ZERO,
 		"both are on their squares once the slide has returned"
@@ -660,7 +660,7 @@ func test_the_doll_is_what_a_substituted_side_draws() -> void:
 	assert_eq(renderer._player_pixels, own)
 
 
-## The whole entrance as `view["entrance"]` reports it, one side at a time: who
+## The whole entrance as `view["battlers"]` reports it, one side at a time: who
 ## is standing on each square, and how far off it they are.
 ##
 ## This is the field a renderer with no background plane has instead of the
@@ -689,7 +689,7 @@ func test_the_entrance_says_who_is_on_each_square_and_how_far_off_it() -> void:
 		guard -= 1
 		for who: String in kinds:
 			var side: Dictionary = (
-				_battle_screen._renderer._view["entrance"] as Dictionary
+				_battle_screen._renderer._view["battlers"] as Dictionary
 			)[who]
 			var kind: StringName = StringName(side["kind"])
 			if (kinds[who] as Array).is_empty() or (kinds[who] as Array).back() != kind:
@@ -729,7 +729,7 @@ func test_the_entrance_says_who_is_on_each_square_and_how_far_off_it() -> void:
 
 	# Nothing is moving once the fight has started, and both squares name the
 	# Pokemon standing on them rather than the people who brought them.
-	var fighting: Dictionary = _battle_screen._renderer._view["entrance"]
+	var fighting: Dictionary = _battle_screen._renderer._view["battlers"]
 	for who: String in ["player", "enemy"]:
 		var side: Dictionary = fighting[who]
 		assert_eq(side["offset_pixels"], Vector2.ZERO, who)
@@ -746,14 +746,14 @@ func test_a_wild_opponent_is_its_own_picture_from_the_first_frame() -> void:
 	_battle_screen.show_matchup(16, 155, 7, 9)
 
 	var enemy: Dictionary = (
-		_battle_screen._renderer._view["entrance"] as Dictionary
+		_battle_screen._renderer._view["battlers"] as Dictionary
 	)["enemy"]
 	assert_eq(StringName(enemy["kind"]), &"mon")
 	assert_eq(int(enemy["species"]), 16)
 	assert_lt((enemy["offset_pixels"] as Vector2).x, 0.0, "and it is still sliding in")
 	assert_eq(
 		StringName((
-			(_battle_screen._renderer._view["entrance"] as Dictionary)["player"]
+			(_battle_screen._renderer._view["battlers"] as Dictionary)["player"]
 			as Dictionary
 		)["kind"]),
 		&"trainer",
@@ -793,3 +793,110 @@ func test_a_battler_object_tile_is_read_over_the_pics_own_strip() -> void:
 				int(pixels[((side - 1) * Gen2Font.TILE + line) * strip + column]),
 				"pixel %d,%d of the feet" % [column, line]
 			)
+
+
+## `MonFaintedAnimation` sinks a picture a tile row at a time inside `bg_map`,
+## which a renderer with no background plane cannot read: seven of those steps
+## and a slide off the square are the same columns and rows moving. The block
+## says it as one number.
+func test_a_faint_sinks_the_battlers_own_offset() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+
+	var before: Vector2 = (
+		(_battle_screen._renderer._view["battlers"] as Dictionary)["enemy"]
+		as Dictionary
+	)["offset_pixels"]
+	assert_eq(before, Vector2.ZERO, "the opponent is standing on its square")
+
+	_battle_screen._begin_faint(Gen2Battle.ENEMY)
+	var steps: int = 0
+	var deepest: float = 0.0
+	var guard: int = 200
+	while _battle_screen.fainting() and guard > 0:
+		_battle_screen.advance_faint()
+		guard -= 1
+		steps += 1
+		deepest = maxf(deepest, float((
+			(_battle_screen._renderer._view["battlers"] as Dictionary)["enemy"]
+			as Dictionary
+		)["offset_pixels"].y))
+
+	assert_gt(steps, 0, "the faint ran")
+	assert_eq(
+		deepest,
+		float((Gen2BattleScreenMap.FAINT_STEPS - 1) * Gen2Tiles.TILE_HEIGHT),
+		"the picture sank a tile row a step and never rose",
+	)
+	assert_eq(
+		(
+			(_battle_screen._renderer._view["battlers"] as Dictionary)["player"]
+			as Dictionary
+		)["offset_pixels"],
+		Vector2.ZERO,
+		"and the other side did not move",
+	)
+
+
+## `BattleBGEffect_HideMon` blanks a battler's own box and `..._RunPicResizeScript`
+## restamps it out of smaller subsamplings of itself. Both are `bg_map` edits and
+## nothing else, so `visible` and `scale` are the only way a card on a 3D stage
+## can know a Fly user is gone or a recall is shrinking.
+func test_hiding_and_resizing_a_battler_are_reported_plainly() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+	var standing: Dictionary = (
+		_battle_screen._renderer._view["battlers"] as Dictionary
+	)["enemy"]
+	assert_true(bool(standing["visible"]))
+	assert_eq(standing["scale"], Vector2.ONE)
+
+	var background := Gen2BattleAnimBackground.new()
+	background.report_battler(false, false)
+	assert_false(bool(background.battler_visible[false]))
+	# `RESIZE_RETURN_ENEMY`'s smallest square is BGSQUARE_THREE against a whole
+	# picture of seven, which is the last thing on the square before the clear
+	# that ends the script.
+	background.report_battler(false, true, 3.0 / 7.0)
+	assert_true(bool(background.battler_visible[false]))
+	assert_almost_eq(float(background.battler_scale[false]), 3.0 / 7.0, 0.001)
+	assert_eq(
+		float(background.battler_visible.size()), 2.0,
+		"the report is one entry a side and no more",
+	)
+
+
+## Every per-battler deformation moves its picture through one scanline window
+## over that side's own rows, which is `SetLCDStatCustoms`' `$2f`..`$5e` for the
+## player and `$00`..`$36` for the opponent. A renderer with no background plane
+## reads the window's mean instead, and the two sides must not read each other's.
+func test_the_scanline_window_reports_the_side_it_is_open_over() -> void:
+	var background := Gen2BattleAnimBackground.new()
+	background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCX
+	background.ly_override_start = 0x2F
+	background.ly_override_end = 0x5E
+	# `Tackle_MoveForward`'s own eight pixels, as the signed byte the window
+	# holds: the player lunges right, so the scroll is negative.
+	background.fill_ly_backup(0xF8)
+	background.push_ly_overrides()
+
+	assert_eq(background.battler_window_offset(true), Vector2(8.0, 0.0))
+	assert_eq(
+		background.battler_window_offset(false), Vector2.ZERO,
+		"the opponent is not in the player's window",
+	)
+
+	# `BattleBGEffect_Withdraw` pushes the top of the window off with `$90` and
+	# holds the rest at the negated displacement, which reads as a sink.
+	var sinking := Gen2BattleAnimBackground.new()
+	sinking.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCY
+	sinking.ly_override_start = 0x00
+	sinking.ly_override_end = 0x36
+	sinking.displace_ly_backup(4)
+	sinking.push_ly_overrides()
+
+	var sunk: Vector2 = sinking.battler_window_offset(false)
+	assert_eq(sunk.x, 0.0, "a vertical window moves nothing sideways")
+	assert_eq(sunk.y, 5.0, "the rows still on screen carry the whole push")

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -145,6 +145,16 @@ func _battle_host() -> Gen2BattleScreen:
 
 ## The same overlay with the slide spent and nothing else, which is where the
 ## line `BattleStartMessage` prints is still on screen.
+## The frames a screen owes, spent the way the screen's own `_process` spends
+## them. A capture owes some now: `PokeBallEffect` draws the throw between the
+## text that says it was thrown and the text that says what happened.
+func _settle_frames(host: Gen2BattleScreen) -> void:
+	var guard: int = 4000
+	while host.frames_running() and guard > 0:
+		host.advance_frame()
+		guard -= 1
+
+
 func _battle_opening() -> Gen2BattleScreen:
 	var host: Gen2BattleScreen = _battle_child()
 	if host == null:
@@ -559,6 +569,7 @@ func test_master_ball_capture_runs_through_the_real_battle_overlay() -> void:
 	assert_true(host.begin_capture()["ok"])
 	assert_true(host.select_capture_ball(1)["ok"])
 	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
 	assert_eq(
 		host.battle_snapshot()["message"],
 		"You threw a %s!" % _data.item_name(Gen2WorldPartyHost.ITEM_MASTER_BALL)
@@ -593,6 +604,7 @@ func test_failed_capture_shows_break_free_and_returns_to_battle() -> void:
 	assert_not_null(host)
 	assert_true(host.begin_capture()["ok"])
 	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
 	assert_eq(
 		host.battle_snapshot()["message"],
 		"You threw a %s!" % _data.item_name(Gen2WorldPartyHost.ITEM_POKE_BALL)
@@ -945,6 +957,7 @@ func test_a_capture_keeps_the_damage_taken_and_the_pp_spent() -> void:
 	assert_true(host.begin_capture()["ok"])
 	assert_true(host.select_capture_ball(1)["ok"])
 	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
 	var guard: int = 12
 	while _battle_child() != null and guard > 0:
 		host.finish()
@@ -1067,6 +1080,7 @@ func _catch_the_wild() -> Gen2BattleScreen:
 		host.available_capture_balls().find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
 	)["ok"])
 	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
 	for _message: int in 10:
 		if host.get("_capture_nickname_host") != null:
 			break
@@ -1772,6 +1786,7 @@ func test_a_registered_policy_pays_a_capture_between_gotcha_and_the_nickname() -
 	assert_true(host.begin_capture()["ok"])
 	assert_true(host.select_capture_ball(1)["ok"])
 	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
 
 	var caught: String = "Gotcha! %s was caught!" % _wild_name()
 	var messages: Array = []
@@ -1822,6 +1837,7 @@ func test_a_capture_pays_nothing_with_no_policy_registered() -> void:
 	assert_true(host.begin_capture()["ok"])
 	assert_true(host.select_capture_ball(1)["ok"])
 	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
 	for _frame: int in 900:
 		assert_false(
 			String(host.battle_snapshot()["message"]).contains("EXP. Points!"),
@@ -1835,3 +1851,50 @@ func test_a_capture_pays_nothing_with_no_policy_registered() -> void:
 		host.finish()
 		host.advance()
 	assert_false(bool(host.get("_capture_experience_spent")))
+
+
+## `PokeBallEffect` plays `ANIM_THROW_POKE_BALL` between the throw text and the
+## result text, and that one script is the whole capture: the ball, the poof, the
+## opponent going into it through `BATTLE_BG_EFFECT_RETURN_MON`, the wobbles that
+## `anim_checkpokeball` counts out, and the click or the break free. Nothing
+## played it here, so no renderer could draw a capture and the built-in one drew
+## nothing either.
+##
+## This fixture ships no animation layer, so what it can say is that the screen
+## asks for the animation and spends its frames. What the script then draws is
+## swept against real caches by `tools/checks/battle_anims.gd`.
+func test_a_thrown_ball_asks_for_the_throw_animation() -> void:
+	await _open_world()
+	_data.species(Fixture.TRAINER_SPECIES)["catch_rate"] = 1
+	_world_screen._encounter_random.seed = 1
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+
+	assert_true(host.animation_running(), "the throw is drawn, not only printed")
+	assert_eq(int(host._anim_event["index"]), Gen2BattleScreen.ANIM_THROW_POKE_BALL)
+	assert_eq(
+		int(host._anim_event["param"]), Gen2WorldPartyHost.ITEM_POKE_BALL,
+		"`.not_kurt_ball`: the ball the script is told to draw",
+	)
+	assert_false(
+		bool(host._anim_event["enemy_turn"]),
+		"`xor a / ldh [hBattleTurn]`: the throw is the player's",
+	)
+	# `GetPokeBallWobble` answers `next` for each shake and then `escaped`, which
+	# is what `.Loop` branches on. The catch is decided before it is drawn.
+	var answers: Array = host._anim_event["wobbles"]
+	assert_eq(
+		answers.back(), Gen2BattleAnimScript.WOBBLE_ESCAPED,
+		"a Pokemon that got out is drawn getting out",
+	)
+	for step: int in answers.size() - 1:
+		assert_eq(int(answers[step]), Gen2BattleAnimScript.WOBBLE_NEXT)
+
+	_settle_frames(host)
+	assert_false(host.animation_running(), "and its frames are spent")

--- a/tests/unit/test_battle_anim_script.gd
+++ b/tests/unit/test_battle_anim_script.gd
@@ -250,3 +250,34 @@ func test_decode_command_reports_operands_and_branch_targets() -> void:
 	assert_false(
 		bool(Gen2BattleAnimScript.decode_command(region, BASE, BASE - 1).get("ok", false))
 	)
+
+
+## `BattleAnimCmd_CheckPokeball` is `GetPokeBallWobble` into `wBattleAnimVar`,
+## which `BattleAnim_ThrowPokeBall.Loop` branches on: 0 keeps wobbling, 1 clicks
+## shut, 2 breaks free. `PokeBallEffect` has already decided which, and writes
+## `wWildMon` and `wThrownBallWobbleCount` before it plays the animation, so the
+## queue is the answers rather than a roll taken here.
+func test_check_pokeball_answers_the_queue_and_then_a_break_free() -> void:
+	var answers: Array[int] = [
+		Gen2BattleAnimScript.WOBBLE_NEXT, Gen2BattleAnimScript.WOBBLE_CAUGHT,
+	]
+	# check_pokeball, wait 1, check_pokeball, wait 1, check_pokeball, ret
+	var bytes: Array = [0xDB, 0x01, 0xDB, 0x01, 0xDB, 0xFF]
+	var script: Gen2BattleAnimScript = Gen2BattleAnimScript.create(
+		_region(bytes), BASE, BASE, 0, answers
+	)
+
+	script.advance_frame()
+	assert_eq(script.variable(), Gen2BattleAnimScript.WOBBLE_NEXT)
+	# `anim_wait 1` costs the frame it is read on and the frame it counts down,
+	# so each check lands two frames after the last.
+	script.advance_frame()
+	script.advance_frame()
+	assert_eq(script.variable(), Gen2BattleAnimScript.WOBBLE_CAUGHT)
+	script.advance_frame()
+	script.advance_frame()
+	assert_eq(
+		script.variable(), Gen2BattleAnimScript.WOBBLE_ESCAPED,
+		"`.finished` with `wWildMon` zero, which is the escape",
+	)
+	assert_eq(answers.size(), 2, "the caller's own array is not spent")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -5135,14 +5135,14 @@ func test_magnet_train_special_reports_its_direction_and_writes_nothing() -> voi
 
 ## GetMonSprite's `.Variable` branch reads wVariableSprites and falls through to
 ## `.NoBreedmon` when the slot is still zero, which answers SPRITE_CHRIS rather
-## than nothing (engine/overworld/overworld.asm). Copycat's House 2F is where it
-## matters: SPRITE_COPYCAT is $fb and only her own script assigns it, so without
-## the fallback she could not be reached to run it.
+## than nothing (engine/overworld/overworld.asm). Slot $fd carries no row in
+## either corpus, so it is the one that still reaches the fallback: every slot a
+## map stands an object on is seeded or filled, which is the test below.
 func test_an_unassigned_variable_sprite_still_occupies_and_is_talkable() -> void:
 	var data: GameData = GameData.open_directory(_directory)
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
 	var objects: Array = world.current_map.events["objects"]
-	objects[0]["sprite"] = Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE + 0x0B
+	objects[0]["sprite"] = Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE + 0x0D
 	objects[0]["x"] = 7
 	objects[0]["y"] = 5
 	world.reload_current_map()
@@ -5150,7 +5150,41 @@ func test_an_unassigned_variable_sprite_still_occupies_and_is_talkable() -> void
 	var standing: Gen2WorldObject = world.object_at(Vector2i(7, 5))
 
 	assert_not_null(standing, "an unassigned variable sprite left the cell empty")
+	assert_eq(standing.sprite_number, Gen2WorldAPI.SPRITE_CHRIS)
 	assert_false(world.can_walk_to(Vector2i(7, 5)), "it did not occupy its cell")
+
+
+## `wVariableSprites` is inside `wPlayerData`, which `SaveData` copies whole into
+## `sPlayerData` (ram/wram.asm, engine/menus/save.asm), so a row assigned in one
+## session opens the next one still assigned. Keeping the table on the loaded
+## world instead drew Route 40's swimmers, Azalea's Rockets and the Copycat as
+## the player on every reload.
+func test_a_variablesprite_assignment_survives_a_save() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var objects: Array = world.current_map.events["objects"]
+	objects[0]["sprite"] = Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE + 0x05
+	objects[0]["x"] = 7
+	objects[0]["y"] = 5
+	world.reload_current_map()
+
+	# InitializeEventsScript's own row for SPRITE_OLIVINE_RIVAL.
+	assert_eq(world.object_at(Vector2i(7, 5)).sprite_number, 0x04)
+
+	world.state.set_variable_sprite(
+		Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE + 0x05, 0x31
+	)
+	var reopened: Gen2WorldState = Gen2WorldState.from_dict(world.state.to_dict())
+	var next_session: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, 1, 1, Vector2i(7, 6), reopened
+	)
+	next_session.current_map.events["objects"][0]["sprite"] = \
+		Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE + 0x05
+	next_session.current_map.events["objects"][0]["x"] = 7
+	next_session.current_map.events["objects"][0]["y"] = 5
+	next_session.reload_current_map()
+
+	assert_eq(next_session.object_at(Vector2i(7, 5)).sprite_number, 0x31)
 
 
 ## `GetMonSprite`'s two `.BreedMon` branches read wBreedMon1Species and

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -118,6 +118,7 @@ func run(r: RefCounted) -> void:
 		_play_every_animation(game_id, data)
 		_verify_tackle_frames(game_id, data)
 		_verify_the_entrance(game_id, data)
+		_verify_the_thrown_ball(game_id, data)
 		_verify_the_transition(game_id, data)
 
 
@@ -126,6 +127,11 @@ func run(r: RefCounted) -> void:
 ## `.Shiny` is the inverted flash and the palette cycle. The beta body the fan
 ## falls through to runs `BATTLE_BG_EFFECT_BETA_SEND_OUT_MON2` ($2b), which is
 ## how a parameter that never reached the interpreter shows up here.
+## `ANIM_THROW_POKE_BALL` (constants/move_constants.asm), and the POKE BALL
+## `.not_kurt_ball` draws every ball Kurt makes as.
+const THROW_BALL_INDEX: int = 0x100
+const THROW_BALL_PARAM: int = 0x05
+
 const SEND_OUT_EFFECTS: Dictionary = {0: [0x0B], 1: [0x01, 0x06]}
 ## And how long each takes: the two `anim_wait`s of `.Normal` and the ten of
 ## `.Shiny`, plus the frame each batch of commands between them spends.
@@ -197,6 +203,67 @@ func _verify_tackle_frames(game_id: StringName, data: GameData) -> void:
 		)
 		print("%s: TACKLE draws %s over %d frames on the %s side." % [
 			game_id, runs, frames, "enemy" if enemy_turn else "player",
+		])
+
+
+## `ANIM_THROW_POKE_BALL`, which is the whole of a capture: the ball, the poof,
+## `BATTLE_BG_EFFECT_RETURN_MON` taking the opponent off the field, the wobble
+## loop, and either `.Click` or `.BreakFree`'s `..._ENTER_MON` putting it back.
+##
+## Only `anim_checkpokeball` decides which way the loop leaves, so the two
+## endings are two runs of the same script with two answers, and the sweep above
+## reaches neither: with no answers queued the loop takes the escape on its
+## first turn and the click body is never decoded.
+##
+## What is checked is what a renderer with no background plane reads, which is
+## the resize scripts reporting through the battler block rather than the
+## tilemap: the opponent is on its square, goes off it, and comes back only when
+## it got out.
+func _verify_the_thrown_ball(game_id: StringName, data: GameData) -> void:
+	var anims: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(data)
+	if not _r.check(anims != null, "%s: no battle animation data in the cache." % game_id):
+		return
+	for caught: bool in [true, false]:
+		var answers: Array[int] = [
+			Gen2BattleAnimScript.WOBBLE_NEXT, Gen2BattleAnimScript.WOBBLE_NEXT,
+			Gen2BattleAnimScript.WOBBLE_CAUGHT if caught \
+				else Gen2BattleAnimScript.WOBBLE_ESCAPED,
+		]
+		var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create(
+			anims, THROW_BALL_INDEX, false, THROW_BALL_PARAM, answers
+		)
+		if not _r.check(
+			player != null, "%s: the thrown ball would not start." % game_id
+		):
+			continue
+		var background: Gen2BattleAnimBackground = player.background()
+		background.set_bg_map(Gen2BattleScreenMap.seeded())
+		var frames: int = 0
+		var vanished: bool = false
+		var smallest: float = 1.0
+		while player.advance_frame() and frames < MAX_FRAMES:
+			frames += 1
+			if not bool(background.battler_visible[false]):
+				vanished = true
+			smallest = minf(smallest, float(background.battler_scale[false]))
+		_r.check(
+			vanished,
+			"%s: the thrown ball never took the opponent off its square." % game_id
+		)
+		_r.check(
+			smallest < 1.0,
+			"%s: the opponent never shrank into the ball; the resize script"
+			% game_id + " reported %f as its smallest square." % smallest
+		)
+		_r.check(
+			bool(background.battler_visible[false]) != caught,
+			"%s: a %s Pokemon is %s on its square when the script ends." % [
+				game_id, "caught" if caught else "freed",
+				"still" if caught else "not",
+			]
+		)
+		print("%s: the thrown ball runs %d frames and the opponent %s." % [
+			game_id, frames, "stays in the ball" if caught else "comes back out",
 		])
 
 

--- a/tools/checks/magnet_train.gd
+++ b/tools/checks/magnet_train.gd
@@ -13,9 +13,9 @@ var _r: RefCounted = null
 ## maps/GoldenrodMagnetTrainStation.asm.
 ##
 ## Three findings carry the leg. The Copycat is a variable sprite, SPRITE_COPYCAT
-## ($fb), that only her own script ever assigns, so she is on the map before
-## anything has given her a sprite; GetMonSprite answers SPRITE_CHRIS for an
-## unassigned variable sprite, which is what puts her in her cell at all. Each
+## ($fb), whose row is InitializeEventsScript's SPRITE_LASS until her own script
+## overwrites it; GetMonSprite answers SPRITE_CHRIS for a slot with no row at
+## all, which is what a lost table looks like. Each
 ## station is two regions with no walkable seam: row 9 is solid, so the lobby
 ## never reaches the platform and the only way onto a train is the officer's own
 ## `applymovement`, which is a forced step. And the errand is a three-legged
@@ -171,8 +171,9 @@ func _verify_copycat(data: GameData, game_id: StringName) -> void:
 		standing == 1,
 		"%s: %d Copycats stand on %s, not one." % [game_id, standing, COPYCAT_CELL]
 	)
-	# She is there with no variablesprite having run yet, which is the whole
-	# reason an unassigned variable sprite has to resolve to something.
+	# She is there before her own script assigns her sprite, wearing
+	# InitializeEventsScript's SPRITE_LASS default; without a row she would be
+	# the player, which is what an unassigned slot resolves to.
 	_r.check(
 		world.object_at(COPYCAT_CELL) != null,
 		"%s: nothing occupies the Copycat's cell %s before her script assigns her sprite." % [

--- a/tools/checks/variable_sprites.gd
+++ b/tools/checks/variable_sprites.gd
@@ -1,0 +1,221 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies `wVariableSprites` against freshly imported real caches for both
+## command profiles: every object either wears a row the source wrote or is
+## drawn as the player, and the table survives a save the way `wPlayerData` does.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## engine/overworld/overworld.asm's `GetMonSprite`, engine/events/std_scripts.asm's
+## `InitializeEventsScript`, engine/overworld/decorations.asm's
+## `ToggleDecorationsVisibility`, ram/wram.asm and engine/menus/save.asm.
+##
+## Two findings carry the topic. `wVariableSprites` sits inside `wPlayerData`,
+## which `SaveData` copies whole into `sPlayerData`, so a row assigned in one
+## session is still there in the next; keeping the table on the loaded world
+## instead drew nine slots' worth of people as the player on every reload, which
+## is what Route 40's swimmers reported. And a slot with no row at all is
+## `.NoBreedmon`'s `WALKING_SPRITE`, which is `SPRITE_CHRIS` by coincidence of
+## two constant lists, so the fallback is a symptom rather than a feature: the
+## nineteen slot-carrying objects in either corpus all have a row.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- variable_sprites
+
+## constants/sprite_constants.asm, the same numbers on all three cartridges.
+const SPRITE_CHRIS: int = 0x01
+const SPRITE_RIVAL: int = 0x04
+const SPRITE_JANINE: int = 0x0A
+const SPRITE_TWIN: int = 0x26
+const SPRITE_LASS: int = 0x28
+const SPRITE_SWIMMER_GUY: int = 0x31
+const SPRITE_ROCKET: int = 0x35
+const SPRITE_SUDOWOODO: int = 0x52
+const SPRITE_VARS: int = 0xF0
+
+## Every object event in either corpus that names a variable sprite, as
+## [group, number, object index, slot]. Crystal's second Copycat is her female
+## row and Gold and Silver ship no `KrisStateSprites` and no second object, which
+## is the one place the two corpora differ; [constant CRYSTAL_ONLY] names it.
+const SLOT_OBJECTS: Array = [
+	[1, 14, 3, 0xF5], [8, 7, 0, 0xF6], [8, 7, 9, 0xF6], [8, 7, 10, 0xF6],
+	[10, 3, 2, 0xF4], [10, 4, 0, 0xF4], [10, 4, 1, 0xF4],
+	[17, 8, 1, 0xF7], [17, 8, 2, 0xF8], [17, 8, 3, 0xF9], [17, 8, 4, 0xFA],
+	[17, 10, 3, 0xFC],
+	[22, 1, 0, 0xF5], [22, 1, 1, 0xF5],
+	[22, 2, 0, 0xF5], [22, 2, 1, 0xF5], [22, 2, 2, 0xF5], [22, 2, 3, 0xF5],
+	[22, 2, 4, 0xF5],
+	[24, 7, 0, 0xF0], [24, 7, 1, 0xF1], [24, 7, 2, 0xF2], [24, 7, 3, 0xF3],
+	[25, 12, 0, 0xFB], [25, 12, 5, 0xFB],
+]
+const CRYSTAL_ONLY: Array = [[25, 12, 5, 0xFB]]
+
+## The four `ToggleDecorationsVisibility` slots, which are filled on every entry
+## to the player's bedroom rather than once at new game, and so are deliberately
+## NOT in `Gen2WorldState.INITIAL_VARIABLE_SPRITES`. A reader adding them there
+## would be filling a room the player has not decorated yet.
+const DECORATION_SLOTS: Array[int] = [0xF0, 0xF1, 0xF2, 0xF3]
+
+## `Gen2WorldState.INITIAL_VARIABLE_SPRITES` read back off the source, so the
+## constant and this file cannot drift together.
+const INITIALIZE_EVENTS: Dictionary = {
+	0xF4: SPRITE_SUDOWOODO, 0xF5: SPRITE_RIVAL, 0xF6: SPRITE_ROCKET,
+	0xF7: SPRITE_JANINE, 0xF8: SPRITE_JANINE, 0xF9: SPRITE_JANINE,
+	0xFA: SPRITE_JANINE, 0xFB: SPRITE_LASS, 0xFC: SPRITE_LASS,
+}
+
+## Route 40, whose two male swimmers are the reported case: `SPRITE_OLIVINE_RIVAL`
+## is the rival until OlivineCity's own scene retires him into a swimmer.
+const ROUTE_40_GROUP: int = 22
+const ROUTE_40: int = 1
+const ROUTE_40_SWIMMER: Vector2i = Vector2i(14, 15)
+const ROUTE_40_ENTRY: Vector2i = Vector2i(14, 17)
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in [&"crystal", &"gold", &"silver"]:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_defaults(game_id)
+		_verify_corpus(game_id, data)
+		_verify_route_40(game_id, data)
+		_verify_save_round_trip(game_id)
+
+
+## The nine rows are the source's, and the four decoration slots are not among
+## them: `ToggleDecorationsVisibility` owns those and runs every map load.
+func _verify_defaults(game_id: StringName) -> void:
+	var initial: Dictionary = Gen2WorldState.INITIAL_VARIABLE_SPRITES
+	_r.check(
+		initial.size() == INITIALIZE_EVENTS.size(),
+		"%s: InitializeEventsScript writes %d slots, the state seeds %d." % [
+			game_id, INITIALIZE_EVENTS.size(), initial.size(),
+		]
+	)
+	for slot: int in INITIALIZE_EVENTS:
+		_r.check(
+			int(initial.get(slot, 0)) == int(INITIALIZE_EVENTS[slot]),
+			"%s: slot $%02X seeds $%02X, not InitializeEventsScript's $%02X." % [
+				game_id, slot, int(initial.get(slot, 0)), int(INITIALIZE_EVENTS[slot]),
+			]
+		)
+	for slot: int in DECORATION_SLOTS:
+		_r.check(
+			not initial.has(slot),
+			"%s: decoration slot $%02X is seeded; ToggleDecorationsVisibility owns it." % [
+				game_id, slot,
+			]
+		)
+
+
+## Every object in the corpus that names a slot, and nothing else naming one.
+## The pair is what says a new slot cannot appear without a row for it.
+func _verify_corpus(game_id: StringName, data: GameData) -> void:
+	var expected: Dictionary = {}
+	for row: Array in SLOT_OBJECTS:
+		if game_id != &"crystal" and row in CRYSTAL_ONLY:
+			continue
+		expected["%d:%d:%d" % [row[0], row[1], row[2]]] = int(row[3])
+	var found: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		var rows: Array = map.events.get("objects", [])
+		for index: int in rows.size():
+			var sprite: int = int((rows[index] as Dictionary).get("sprite", 0))
+			if sprite >= SPRITE_VARS:
+				found["%d:%d:%d" % [map.group, map.number, index]] = sprite
+	_r.check(
+		found.size() == expected.size(),
+		"%s: %d objects name a variable sprite, not %d." % [
+			game_id, found.size(), expected.size(),
+		]
+	)
+	for key: String in expected:
+		_r.check(
+			int(found.get(key, 0)) == int(expected[key]),
+			"%s: object %s names $%02X, not $%02X." % [
+				game_id, key, int(found.get(key, 0)), int(expected[key]),
+			]
+		)
+	## The whole point of the table: every slot an object stands on is either
+	## seeded or filled by the bedroom's own callback, so none of them resolves
+	## to the player.
+	var state := Gen2WorldState.new()
+	for key: String in found:
+		var slot: int = int(found[key])
+		var resolved: int = state.variable_sprite(slot)
+		if slot in DECORATION_SLOTS:
+			_r.check(
+				resolved == 0,
+				"%s: decoration slot $%02X is filled before the bedroom fills it." % [
+					game_id, slot,
+				]
+			)
+			continue
+		_r.check(
+			resolved > 0 and resolved != SPRITE_CHRIS,
+			"%s: object %s on slot $%02X resolves to $%02X, which draws the player." % [
+				game_id, key, slot, resolved,
+			]
+		)
+
+
+## The reported case, end to end on the real map: Route 40's swimmer is the rival
+## before Olivine's scene and the swimmer guy after it, and never the player.
+func _verify_route_40(game_id: StringName, data: GameData) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ROUTE_40_GROUP, ROUTE_40, ROUTE_40_ENTRY, Gen2WorldState.new()
+	)
+	if not _r.check(world != null, "%s: Route 40 map 22/1 is missing." % game_id):
+		return
+	var swimmer: Gen2WorldObject = world.object_at(ROUTE_40_SWIMMER)
+	if not _r.check(
+		swimmer != null,
+		"%s: nothing stands on Route 40's %s." % [game_id, ROUTE_40_SWIMMER]
+	):
+		return
+	_r.check(
+		swimmer.sprite_number == SPRITE_RIVAL,
+		"%s: Route 40's swimmer is sprite $%02X, not InitializeEventsScript's $%02X." % [
+			game_id, swimmer.sprite_number, SPRITE_RIVAL,
+		]
+	)
+	# OlivineCity's rival scene ends on `variablesprite SPRITE_OLIVINE_RIVAL,
+	# SPRITE_SWIMMER_GUY`, and the objects it reaches are on a map two maps away.
+	world.state.set_variable_sprite(0xF5, SPRITE_SWIMMER_GUY)
+	var reloaded: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, ROUTE_40_GROUP, ROUTE_40, ROUTE_40_ENTRY, world.state
+	)
+	var after: Gen2WorldObject = reloaded.object_at(ROUTE_40_SWIMMER) if reloaded != null else null
+	_r.check(
+		after != null and after.sprite_number == SPRITE_SWIMMER_GUY,
+		"%s: Route 40's swimmer is not the swimmer guy once the slot is assigned." % game_id
+	)
+
+
+## `SaveData` copies `wPlayerData` whole, and `wVariableSprites` is inside it, so
+## a row assigned in one session opens the next one still assigned.
+func _verify_save_round_trip(game_id: StringName) -> void:
+	var state := Gen2WorldState.new()
+	state.set_variable_sprite(0xF5, SPRITE_SWIMMER_GUY)
+	state.set_variable_sprite(0xF4, SPRITE_TWIN)
+	var reopened: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	_r.check(
+		reopened.variable_sprite(0xF5) == SPRITE_SWIMMER_GUY \
+			and reopened.variable_sprite(0xF4) == SPRITE_TWIN,
+		"%s: an assigned variable sprite does not survive a save." % game_id
+	)
+	## A state written before the table was saved carries no rows, and the slots
+	## it lost are the ones InitializeEventsScript wrote.
+	var older: Dictionary = state.to_dict()
+	older.erase("variable_sprites")
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(older)
+	for slot: int in INITIALIZE_EVENTS:
+		_r.check(
+			restored.variable_sprite(slot) == int(INITIALIZE_EVENTS[slot]),
+			"%s: a save with no table reads slot $%02X as $%02X, not $%02X." % [
+				game_id, slot, restored.variable_sprite(slot), int(INITIALIZE_EVENTS[slot]),
+			]
+		)

--- a/tools/checks/variable_sprites.gd.uid
+++ b/tools/checks/variable_sprites.gd.uid
@@ -1,0 +1,1 @@
+uid://byvjfk5wx2cja

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -12,6 +12,11 @@ extends SceneTree
 ## can be photographed; `<side>` is 0 for the player's own and 1 for the
 ## enemy's; `<frames>` is how many frames into the animation to stop.
 ##
+## `<move> catch` throws a ball instead of taking a turn, which is
+## `ANIM_THROW_POKE_BALL` and the whole of a capture: the ball, the poof, the
+## opponent going into it, three wobbles and then the click or the break free.
+## `<side>` picks the ending, 0 caught and 1 broken free.
+##
 ## `<move> 0` photographs the entrance instead, which is `BattleStartMessage` and
 ## the opening of `DoBattle` rather than a turn: a wild one, or a trainer's with
 ## `<side>` at 1, and `<frames>` counted from the frame the pics stop sliding.
@@ -41,6 +46,9 @@ const MAX_STEPS: int = 4096
 ## it. A person is what the cartridge waits for; a fixed count is what makes two
 ## runs of this tool the same run.
 const PRESS_AFTER: int = 40
+## `<move> catch` throws a ball instead of taking a turn. It is not a move
+## number, so it cannot collide with one.
+const CATCH_MOVE: int = -1
 
 var _screen: Gen2BattleScreen = null
 var _output_path: String = ""
@@ -70,7 +78,7 @@ func _initialize() -> void:
 	if Gen2ToolPath.refuses(_output_path):
 		quit(2)
 		return
-	_move = int(args[2])
+	_move = CATCH_MOVE if args[2] == "catch" else int(args[2])
 	_side_is_enemy = int(args[3]) != 0
 	if args[4].contains("-"):
 		var span: PackedStringArray = args[4].split("-", false)
@@ -270,11 +278,34 @@ func _settle_entrance() -> void:
 		_screen.advance()
 
 
+## `PokeBallEffect`'s own throw, which is not a turn: `ANIM_THROW_POKE_BALL` is
+## played by the item rather than by a move, and `<side>` decides whether the
+## Pokemon is caught or gets out, since only `anim_checkpokeball` tells the two
+## endings apart.
+func _drive_capture() -> bool:
+	_screen.show_matchup(16, 155, 20, 20)
+	while _screen.intro_running():
+		_screen.advance_frame()
+	_settle_entrance()
+	## The ball selector belongs to a wild battle a world screen opened, and this
+	## driver has no world. What is being photographed is the animation the
+	## resolved throw plays, so it is asked for the way `complete_capture` asks
+	## for it: a POKE BALL, three wobbles, and the ending `<side>` names.
+	_screen._begin_capture_animation(
+		Gen2WorldPartyHost.ITEM_POKE_BALL, 3, not _side_is_enemy
+	)
+	for _frame: int in _frames_in:
+		_screen.advance_frame()
+	return true
+
+
 ## Settles the intro, teaches both Pokemon the move, takes the turn and walks the
 ## event queue to the first animation on the requested side.
 func _drive() -> bool:
 	if _move == 0:
 		return _drive_entrance()
+	if _move == CATCH_MOVE:
+		return _drive_capture()
 	_screen.show_matchup(16, 155, 20, 20)
 	while _screen.intro_running():
 		_screen.advance_frame()

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -411,8 +411,8 @@ const SAFFRON_COPYCAT_HOUSE_DOOR: Vector2i = Vector2i(9, 11)
 const COPYCAT_HOUSE_STAIRS_UP: Vector2i = Vector2i(2, 0)
 const COPYCAT_HOUSE_STAIRS_DOWN: Vector2i = Vector2i(3, 0)
 const COPYCAT_HOUSE_EXIT: Vector2i = Vector2i(2, 7)
-## She is a variable sprite only her own script assigns, so she stands here with
-## no sprite of her own until the first talk runs `variablesprite`.
+## She is a variable sprite wearing InitializeEventsScript's SPRITE_LASS until
+## the first talk runs her own `variablesprite`.
 const COPYCAT_FACE: Vector2i = Vector2i(5, 3)
 const SAFFRON_ROUTE_6_GATE_DOOR: Vector2i = Vector2i(16, 33)
 const ROUTE_6_GATE_SOUTH_DOOR: Vector2i = Vector2i(4, 7)

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,7 +44,7 @@ const GROUPS: Dictionary = {
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
 		&"card_flip", &"move_effects", &"phone", &"decorations", &"mail",
-		&"mystery_gift",
+		&"mystery_gift", &"variable_sprites",
 		&"battle_tower",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],


### PR DESCRIPTION
A player sprite was standing in the water on Route 40 while a promo clip was
being recorded. It was Swimmer SIMON, and the seam was not Route 40.

`wVariableSprites` is inside `wPlayerData`, which `SaveData` copies whole into
`sPlayerData`, so a row assigned in one session is still there in the next. This
port kept the table on the loaded world and dropped it on every load.

Nine of the sixteen slots are written once at new game, by
`InitializeEventsScript` behind `EVENT_INITIALIZED_EVENTS`, and no callback ever
writes them again. With the table gone, `GetMonSprite` falls to `.NoBreedmon`,
whose `WALKING_SPRITE` is `SPRITE_CHRIS`. So every object standing on one of
those slots was drawn as the player:

| Map | Objects | Slot |
|---|---|---|
| Route 40, Route 41 | 7 swimmers | `SPRITE_OLIVINE_RIVAL` |
| Olivine City | the rival | `SPRITE_OLIVINE_RIVAL` |
| Azalea Town | 3 Rockets | `SPRITE_AZALEA_ROCKET` |
| Route 36, Route 37 | Sudowoodo and the two twins | `SPRITE_WEIRD_TREE` |
| Fuchsia Gym | 4 trainers | `SPRITE_FUCHSIA_GYM_1` to `_4` |
| Fuchsia Pokecenter | the Janine impersonator | `SPRITE_JANINE_IMPERSONATOR` |
| Copycat's House 2F | the Copycat | `SPRITE_COPYCAT` |

The table lives on `Gen2WorldState` now and travels in the snapshot, seeded with
`InitializeEventsScript`'s own rows. A saved state that carries no table reads as
the rows that script wrote, so there is no save-format bump.

The four decoration slots are deliberately not seeded.
`ToggleDecorationsVisibility` fills those on every entry to the bedroom, so
seeding them would decorate a room the player has not decorated yet.

`tools/checks/variable_sprites.gd` sweeps every object in either corpus that
stands on a slot, twenty on Crystal and nineteen on Gold and Silver, checks that
none of them resolves to the player, and names both groups so neither is moved
into the other. A `variablesprite` also drops the connected-map object cache now,
since the people SCREEN FILL draws on the maps next door resolve through the same
table.

Two comments said an unassigned slot was the normal case for the Copycat and for
Route 37's twins. It never was; both are corrected.

Measured: GUT 3258 pass over 130 scripts, `validate.gd -- all` 75 topics pass on
all three cartridges, `replay_world.gd` 33 routes 0 failures, and the
three-profile story walk has no failed step.

---

## Also in this PR: the three engine requests from the mods repository

**R47, the battler block.** `view["battlers"]` replaces `view["entrance"]`, which
is `api_version` 17 and the one break in the list. Everything that happens to a
battler after the entrance was readable only as `bg_map` edits: the faint sink,
the blanking a Fly or Dig user costs, the resize scripts a recall and a send-out
restamp through, and the eleven per-battler deformations. The block carries
`visible` and `scale` beside the entrance's own five fields, and `offset_pixels`
covers the faint, `RemoveMon` and the scanline window as well as the slide.

Every deformation is one window over that side's own rows, which is what makes
them one number rather than eleven: `SetLCDStatCustoms` gives the player `$2d` or
`$2f` to `$5e` and the opponent `$00` to `$36`, and `battler_window_offset` is
the mean of it on the axis `hLCDCPointer` names, less the whole-screen scroll
`raster_scx` already carries. `HideMon`, `RemoveMon` and the resize scripts
report beside the map they edit instead.

**R48, the shiny fields.** `enemy_shiny` and `player_shiny` are in the field list
in `docs/MODS.md` now, with `GameData.palette(number, shiny)` beside them and the
version they arrived in.

**R49, the thrown ball.** `anim_checkpokeball` was the one command standing
between this port and `ANIM_THROW_POKE_BALL`, which is the whole of a capture in
one script: the throw, the poof, `RETURN_MON` taking the opponent off, the wobble
loop and either the click or `.BreakFree`'s `ENTER_MON`. It answers
`GetPokeBallWobble`'s three values off a queue the caller has already decided,
the way `PokeBallEffect` writes `wWildMon` and `wThrownBallWobbleCount` in front
of `PlayBattleAnim`. Both endings are swept on all three cartridges;
`tools/preview_battle_anim.gd -- <game> <out.png> catch <0 caught|1 freed>
<frames>` is the picture.

**Two defects came out of answering them.** An animation's tilemap edits never
reached the view until the script ended, because `RunBattleAnimScript` hands the
map in and takes it back out and the screen pushed its own stale copy meanwhile,
so every renderer watched an animation happen to a picture that never moved. And
the two shiny fields above had been pushed since `api_version` 11 with nothing in
the document naming them.

Measured after all of it: GUT 3774 pass over 162 scripts, `validate.gd -- all` 75
topics pass on all three cartridges, `replay_world.gd` 33 routes 0 failures.
