### PR TITLE
Keep the five saved bytes the cartridge keeps

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -10,7 +10,7 @@ signal item_used(item: int, target: int)
 ## enemy sent out sets it, a trainer's party as much as a wild, so this is the
 ## event rather than the battle result. The host owns the flag, since the battle
 ## engine is scene-free and holds no world state.
-signal enemy_seen(species: int)
+signal enemy_seen(species: int, unown_form: int)
 
 ## Owns the battle, the events and the text box; decides nothing about how they
 ## are drawn. A [Gen2Battle] resolves the turn and answers with events; this
@@ -3384,8 +3384,22 @@ func _finish_world_battle() -> void:
 		result["evolvable"] = _battle.evolvable_indices()
 	if outcome == Gen2WorldBattleAdapter.OUTCOME_LOST:
 		result["recovery"] = _world_battle_recovery.duplicate(true)
+	result["enemy"] = _enemy_battler_record()
 	_world_battle_completion_sent = true
 	battle_finished.emit(result)
+
+
+## What `BattleEnd_HandleRoamMons` reads out of `wEnemyMon` on the way out of a
+## wild battle: the species it was, the HP it is leaving on and the DVs it was
+## built with. Empty when there is no enemy to read, which is every path that
+## ends before one exists.
+func _enemy_battler_record() -> Dictionary:
+	if _battle == null:
+		return {}
+	var enemy: Gen2BattleMon = _battle.party(Gen2Battle.ENEMY).active_mon()
+	if enemy == null:
+		return {}
+	return {"species": enemy.species, "hp": enemy.hp, "dvs": enemy.dvs}
 
 
 func _finish_world_capture(capture: Dictionary) -> void:
@@ -3397,6 +3411,7 @@ func _finish_world_capture(capture: Dictionary) -> void:
 		"outcome": Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
 		"request": _world_battle_request.duplicate(true),
 		"capture": capture.duplicate(true),
+		"enemy": _enemy_battler_record(),
 	})
 
 
@@ -4251,7 +4266,7 @@ func _apply_event_state(event: Dictionary) -> void:
 			# here does. The level is part of that: a trainer's own party is not
 			# all one level the way the invented one used to be.
 			if int(event["side"]) == Gen2Battle.ENEMY:
-				enemy_seen.emit(int(event["species"]))
+				enemy_seen.emit(int(event["species"]), int(event.get("unown_form", 0)))
 				_enemy = int(event["species"])
 				_enemy_unown_form = int(event.get("unown_form", 0))
 				_enemy_shiny = bool(event.get("shiny", false))

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -286,6 +286,12 @@ func unown_unlocked() -> bool:
 
 ## `Pokedex_DrawUnownModeBG`'s own walk: the forms caught, in catching order.
 ## `wDexUnownCount` is its length.
+## `wFirstUnownSeen`, the letter `Pokedex_LoadSelectedMonTiles` draws an UNOWN
+## row with.
+func first_unown_seen() -> int:
+	return _state.first_unown_seen() if _state != null else 0
+
+
 func unown_forms() -> Array[int]:
 	return _state.unown_dex() if _state != null else [] as Array[int]
 

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -560,6 +560,11 @@ func _selected_pic() -> Image:
 	# selected row.
 	if species <= 0 or not _dex.can_open_entry():
 		return _page.unseen_pic()
+	# `ld a, [wFirstUnownSeen] / ld [wUnownLetter], a` in front of `GetMonFrontpic`:
+	# every UNOWN row in the listing and its entry are drawn as the first Unown
+	# this save met, not as form A.
+	if species == RomLayout.UNOWN_SPECIES and _dex.first_unown_seen() > 0:
+		return _pic_image(_data.unown_pic(_dex.first_unown_seen() - 1), species)
 	return _pic_image(_data.species_pic(species), species)
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -208,6 +208,9 @@ var last_spawn_map: Vector2i = Vector2i(-1, -1)
 ## the player last came into a cave through, which is where Dig and an Escape
 ## Rope put them back. Empty until one is walked.
 var dig_warp: Dictionary = {}
+## `wSpawnAfterChampion`, which the induction and Red's credits write and the
+## next CONTINUE spends; see [member Gen2WorldSnapshot.spawn_after_champion].
+var spawn_after_champion: int = Gen2WorldSnapshot.SPAWN_AFTER_NONE
 ## `wPrevLandmark`, which is not saved on the cartridge either: `NewGame` writes
 ## New Bark Town into it and `FinishContinueFunction` sets SHOWN_MAP_NAME_SIGN so
 ## the map a loaded game opens on raises no sign. Opening a world is both of
@@ -432,6 +435,15 @@ static func open_snapshot(
 	out.frame_number = world_snapshot.frame_number
 	out.last_spawn_map = world_snapshot.last_spawn_map
 	out.dig_warp = world_snapshot.dig_warp.duplicate()
+	## `.SpawnAfterE4` and `.AfterRed`, which stand between `ClockContinue` and
+	## `FinishContinueFunction`: the map the slot was written on is loaded and
+	## then left, so everything a map load owes has already run when the spawn
+	## warp happens. `PostCreditsSpawn` clears the byte behind itself.
+	out.spawn_after_champion = world_snapshot.spawn_after_champion
+	var spawn: int = world_snapshot.continue_spawn_index()
+	if spawn >= 0:
+		out.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_NONE
+		out.warp_to_spawn(spawn)
 	return out
 
 
@@ -2468,6 +2480,24 @@ func count_step() -> bool:
 	if state == null or special_phone_call_ready():
 		return false
 	return state.count_step()
+
+
+## `DoBikeStep`, which `CountStep` reaches behind the poison branch: the three
+## gates in front of the counter, and the flag the queued call is paid for with.
+## Answers whether the bike shop owner's call was queued.
+func do_bike_step() -> bool:
+	if state == null or current_map == null:
+		return false
+	var flag: int = state.engine_flag(
+		Gen2WorldState.ENGINE_BIKE_SHOP_CALL, Gen2WorldState.is_crystal_profile(data)
+	)
+	var armed: bool = movement_mode == MOVEMENT_BIKE and state.is_engine_flag_active(flag)
+	if not state.do_bike_step(
+		armed, Gen2WorldPhoneHost.map_has_phone_service(current_map)
+	):
+		return false
+	state.set_engine_flag(flag, false)
+	return true
 
 
 ## Checks the pending special call before ordinary step effects, matching the

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -60,6 +60,13 @@ static func prepare(
 			# Gold and Silver never say true, having neither routine nor data.
 			if wild_mon != null and bool(values.get("asleep", false)):
 				wild_mon.status = Gen2WorldTreemon.SLEEP_TURNS
+			## `LoadEnemyMon`'s second `BATTLETYPE_ROAMING` branch: a roamer whose
+			## struct has been initialised comes back on the stored HP rather than
+			## on a full bar, which is what makes chipping one down between
+			## encounters worth doing. The uninitialised case carries no `hp` and
+			## keeps the stats it was just built with.
+			if wild_mon != null and int(values.get("hp", 0)) > 0:
+				wild_mon.hp = clampi(int(values["hp"]), 1, wild_mon.max_hp())
 			enemy_party = Gen2Party.of(wild_mon)
 		&"trainer":
 			trainer_class = int(values.get("trainer_group", 0))

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -70,10 +70,21 @@ static func resolve(
 			var roaming_level: int = int(roaming["level"])
 			if _blocked_by_repel(roaming_level, options):
 				return {}
-			return _wild_result(
+			var roamer: Dictionary = _wild_result(
 				method, SOURCE_ROAMING, -1, int(roaming["species"]), roaming_level,
 				rate, encounter_roll, -1, force_encounter, roaming_roll, roaming_index
 			)
+			## `CheckEncounterRoamMon`'s own `ld a, BATTLETYPE_ROAMING`, and the
+			## two struct fields `LoadEnemyMon` branches on it for: a roamer whose
+			## HP byte is still zero rolls its DVs on this encounter and keeps
+			## them, and one that has been fought before comes back on the HP the
+			## last fight left it at.
+			var values: Dictionary = roamer["values"]
+			values["battle_type"] = Gen2Battle.BATTLETYPE_ROAMING
+			if int(roaming.get("hp", 0)) > 0:
+				values["hp"] = int(roaming["hp"])
+				values["dvs"] = int(roaming.get("dvs", 0))
+			return roamer
 
 	var slots: Array = _slots(record, method, time_of_day)
 	var slot: int = _choose_slot(generator, method)
@@ -358,12 +369,20 @@ static func _resolve_roaming(
 	var mon: Variant = (mons as Array)[selected_index]
 	if not mon is Dictionary:
 		return result
+	## `CheckEncounterRoamMon` compares the map bytes alone, and a roamer that has
+	## been caught or defeated carries `GROUP_N_A` in them, so the compare is what
+	## keeps the emptied slot out of an encounter. The species test is this port's
+	## own: a record the cache seeded with no species is not a Pokemon either.
+	if int((mon as Dictionary).get("species", 0)) <= 0:
+		return result
 	if int((mon as Dictionary).get("map_group", -1)) != map_group \
 		or int((mon as Dictionary).get("map_number", -1)) != map_number:
 		return result
 	result["index"] = selected_index
 	result["species"] = int((mon as Dictionary).get("species", 0))
 	result["level"] = int((mon as Dictionary).get("level", 0))
+	result["hp"] = int((mon as Dictionary).get("hp", 0))
+	result["dvs"] = int((mon as Dictionary).get("dvs", 0))
 	return result
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2419,6 +2419,9 @@ func _after_map_settled() -> bool:
 		return true
 	if _spend_poison_steps():
 		return true
+	## `CountStep`'s last line, which the poison branch above jumps over when it
+	## reaches a script of its own.
+	_world.do_bike_step()
 	var phone_attempt: Dictionary = _world.try_receive_phone_call(_encounter_random)
 	var phone_results: Array = phone_attempt.get("results", [])
 	if bool(phone_attempt.get("attempted", false)) and not phone_results.is_empty():
@@ -4551,11 +4554,16 @@ func _open_battle_host(request: Dictionary) -> void:
 	_refresh_labels()
 
 
-## `LoadEnemyMon`'s dex write. The flag lands on live world state, so the next
-## snapshot carries it exactly as the cartridge's next save does.
-func _on_enemy_seen(species: int) -> void:
-	if _world != null and _world.state != null:
-		_world.state.set_species_seen(species)
+## `LoadEnemyMon`'s dex write, and the `wFirstUnownSeen` write beside it: the
+## letter of the first Unown the save meets is stored whether it is caught or
+## only seen. Both land on live world state, so the next snapshot carries them
+## exactly as the cartridge's next save does.
+func _on_enemy_seen(species: int, unown_form: int) -> void:
+	if _world == null or _world.state == null:
+		return
+	_world.state.set_species_seen(species)
+	if species == RomLayout.UNOWN_SPECIES:
+		_world.state.note_first_unown_seen(unown_form)
 
 
 func _on_capture_requested(ball: int) -> void:
@@ -4632,6 +4640,7 @@ func _on_battle_finished(result: Dictionary) -> void:
 	if _world == null:
 		return
 	_last_battle_outcome = StringName(result.get("outcome", &""))
+	_record_roam_battle(result)
 	if not _link_battle_peer.is_empty():
 		_record_link_battle(result)
 	var pay_day_money: int = int(result.get("pay_day_money", 0))
@@ -4651,6 +4660,35 @@ func _on_battle_finished(result: Dictionary) -> void:
 		)
 		return
 	_finish_battle_exit(result, fought_save)
+
+
+## `BattleEnd_HandleRoamMons`, which `ExitBattle` reaches on the way out of any
+## battle and which does nothing unless `wBattleType` is `BATTLETYPE_ROAMING`.
+## A caught or defeated roamer empties its struct; anything else stores the HP
+## and the DVs the fight leaves behind, so the next encounter is the same
+## Pokemon on the bar the player left it on.
+func _record_roam_battle(result: Dictionary) -> void:
+	if _world == null or _world.state == null:
+		return
+	## `prepare()` answers the values dictionary itself under `request`, which is
+	## the same shape `win_text` and `loss_text` are read out of.
+	var values: Variant = result.get("request", {})
+	if not values is Dictionary:
+		return
+	if int((values as Dictionary).get("battle_type", 0)) != Gen2Battle.BATTLETYPE_ROAMING:
+		return
+	var enemy: Variant = result.get("enemy", {})
+	if not enemy is Dictionary or (enemy as Dictionary).is_empty():
+		return
+	var outcome: StringName = StringName(result.get("outcome", &""))
+	var won: bool = outcome in [
+		Gen2WorldBattleAdapter.OUTCOME_WON, Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
+	]
+	_world.state.note_roam_battle_end(
+		int((enemy as Dictionary).get("species", 0)), won,
+		int((enemy as Dictionary).get("hp", 0)),
+		int((enemy as Dictionary).get("dvs", 0)),
+	)
 
 
 ## `AddLastLinkBattleToLinkRecord`, which runs on the way out of a Colosseum
@@ -5066,6 +5104,9 @@ func open_hall_of_fame() -> void:
 		_script_prompt = "Hall of Fame needs a save"
 		_refresh_labels()
 		return
+	## `HallOfFame`'s own second instruction, in front of everything the sequence
+	## draws: the next CONTINUE spawns at New Bark Town rather than in the Hall.
+	_world.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_LANCE
 	var pages: Array = Gen2HallOfFame.pages(_data, save, _world.state)
 	## `AddHallOfFameEntry` runs behind `SaveGameData` and in front of the
 	## animation, so the team is stored whether or not the player watches it;
@@ -6410,6 +6451,10 @@ func _show_script_results(results: Array) -> void:
 				## so nothing is waiting to be resumed when this opens.
 				open_hall_of_fame()
 			elif result_event.get("type", &"") == &"credits_requested":
+				## `Script_credits` farcalls `RedCredits`, whose own
+				## `ld a, SPAWN_RED` puts the next CONTINUE on Mount Silver.
+				if _world != null:
+					_world.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_RED
 				open_credits()
 			elif result_event.get("type", &"") == &"soft_reset_requested":
 				## `special Reset` restarts the console, which is how a saved and

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -5,6 +5,13 @@ extends RefCounted
 ## Cartridge content is looked up from GameData when this snapshot is opened.
 
 const FORMAT_VERSION: int = 1
+## `constants/ram_constants.asm`'s two `wSpawnAfterChampion` values, and the
+## `SpawnPoints` indices `PostCreditsSpawn` and `SpawnAfterRed` send each to.
+const SPAWN_AFTER_NONE: int = 0
+const SPAWN_AFTER_LANCE: int = 1
+const SPAWN_AFTER_RED: int = 2
+const SPAWN_NEW_BARK: int = 14
+const SPAWN_MT_SILVER: int = 26
 
 var format_version: int = FORMAT_VERSION
 var map_id: Vector2i = Vector2i(-1, -1)
@@ -37,6 +44,12 @@ var frame_number: int = 0
 ## which reads as a game that has entered no Pokemon Center and no cave.
 var last_spawn_map: Vector2i = Vector2i(-1, -1)
 var dig_warp: Dictionary = {}
+## `wSpawnAfterChampion`, saved player data on both pins: `HallOfFame` writes
+## `SPAWN_LANCE` and `RedCredits` writes `SPAWN_RED`, and the CONTINUE that opens
+## the slot next puts the player at New Bark Town or Mount Silver instead of
+## where the credits caught them, then clears the byte. Zero in a snapshot
+## written before it existed, which reads as a save no credits have rolled on.
+var spawn_after_champion: int = SPAWN_AFTER_NONE
 var world_state: Gen2WorldState = Gen2WorldState.new()
 
 
@@ -58,6 +71,7 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.frame_number = world.frame_number
 	out.last_spawn_map = world.last_spawn_map
 	out.dig_warp = world.dig_warp.duplicate()
+	out.spawn_after_champion = world.spawn_after_champion
 	out.world_state = Gen2WorldState.from_dict(world.state.to_dict())
 	return out
 
@@ -77,6 +91,7 @@ func to_dict() -> Dictionary:
 		"frame_number": frame_number,
 		"last_spawn_map": [last_spawn_map.x, last_spawn_map.y],
 		"dig_warp": dig_warp.duplicate(),
+		"spawn_after_champion": spawn_after_champion,
 		"world_state": world_state.to_dict() if world_state != null else {},
 	}
 
@@ -116,6 +131,10 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 			"map_group": int((raw_dig as Dictionary).get("map_group", 0)),
 			"map_number": int((raw_dig as Dictionary).get("map_number", 0)),
 		}
+	out.spawn_after_champion = clampi(
+		int(source.get("spawn_after_champion", SPAWN_AFTER_NONE)),
+		SPAWN_AFTER_NONE, SPAWN_AFTER_RED
+	)
 	out.world_state = Gen2WorldState.from_dict(source.get("world_state", {}))
 	return out
 
@@ -130,3 +149,14 @@ static func _vector_from_value(value: Variant) -> Vector2i:
 	if value is Dictionary:
 		return Vector2i(int((value as Dictionary).get("x", -1)), int((value as Dictionary).get("y", -1)))
 	return Vector2i(-1, -1)
+
+
+## `.SpawnAfterE4` and `.AfterRed`: the spawn a CONTINUE puts the player at
+## instead of the map the slot was written on, or -1 when the byte is clear.
+func continue_spawn_index() -> int:
+	match spawn_after_champion:
+		SPAWN_AFTER_LANCE:
+			return SPAWN_NEW_BARK
+		SPAWN_AFTER_RED:
+			return SPAWN_MT_SILVER
+	return -1

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -26,6 +26,21 @@ const EGG_STEP_PHASE: int = 0x80
 ## `DoPoisonStep`, counted in steps rather than in frames.
 const POISON_STEP_PHASE: int = 4
 const PHONE_RECEIVE_DELAYS: Array[int] = [20, 10, 5, 3]
+## `SPECIALCALL_BIKESHOP` (`constants/phone_constants.asm`), the same index on
+## both pins.
+const SPECIALCALL_BIKESHOP: int = 6
+## `DoBikeStep`'s own `cp HIGH(1024)` on the high byte, and the `$ffff` its two
+## `cp 255` tests saturate the counter at.
+const BIKE_SHOP_CALL_STEPS: int = 1024
+const MAX_BIKE_STEP: int = 0xFFFF
+## `wStatusFlags2`' `STATUSFLAGS2_BIKE_SHOP_CALL_F`, which the bike shop owner
+## sets when he takes the player's number and which `DoBikeStep` clears behind
+## the call it queues. Crystal index; see the badge comment for the split.
+const ENGINE_BIKE_SHOP_CALL: int = 20
+const ENGINE_BIKE_SHOP_CALL_GOLD_SILVER: int = 19
+## `GROUP_N_A`/`MAP_N_A`, which `BattleEnd_HandleRoamMons` writes over a
+## roamer's map bytes once it has been caught or defeated.
+const ROAM_MAP_N_A: int = -1
 ## `StoreSwarmMapIndices`' own two arguments, `constants/script_constants.asm`.
 const SWARM_DUNSPARCE: int = 0
 const SWARM_YANMA: int = 1
@@ -226,6 +241,12 @@ var _caught_species: Dictionary = {}
 ## where an empty one is a zero; here the list is as long as it is full, so its
 ## size is `.count_unown`'s own answer.
 var _unown_dex: Array[int] = []
+## `wFirstUnownSeen`, the letter every Pokedex entry for UNOWN is drawn with:
+## `Pokedex_LoadSelectedMonTiles` copies it into `wUnownLetter` before it asks
+## for the front picture. Written once, by whichever of the first sighting and
+## the first party addition comes first, and saved with the rest of
+## `wPokemonData`. Zero is a save that has met no Unown.
+var _first_unown_seen: int = 0
 var _phone_receive_cycle: int = 0
 var _phone_receive_minutes: int = PHONE_RECEIVE_DELAYS[0]
 var _pending_special_phone_call: int = 0
@@ -235,10 +256,16 @@ var _script_memory: Dictionary = {}
 ## and compares against it, and because a tuned radio station overwrites it and
 ## survives the Pokegear closing. `SnorlaxAwake` reads exactly that byte.
 ## `wStatusFlags`' `STATUSFLAGS_FLASH_F`. Its own byte on the cartridge rather
-## than an engine flag, and it does not survive walking out into the open:
+## than an engine flag, saved with the rest of `wPlayerData` the way its
+## byte-neighbours here are, and it does not survive walking out into the open:
 ## `ResetFlashIfOutOfCave` clears it on entering a ROUTE or a TOWN, so a lit cave
 ## goes dark again the moment the player leaves and comes back.
 var _used_flash: bool = false
+
+## `wBikeStep`, the two bytes `DoBikeStep` counts a bike ride in. Saved player
+## data on the cartridge, and the whole of how far off the bike shop owner's
+## call still is.
+var _bike_step: int = 0
 
 var _map_music: int = MUSIC_NONE
 var _radio_knob: int = Gen2WorldRadio.KNOB_MIN
@@ -457,10 +484,13 @@ func to_dict() -> Dictionary:
 		"seen_species": _seen_species.duplicate(),
 		"caught_species": _caught_species.duplicate(),
 		"unown_dex": _unown_dex.duplicate(),
+		"first_unown_seen": _first_unown_seen,
 		"phone_receive_cycle": _phone_receive_cycle,
 		"phone_receive_minutes": _phone_receive_minutes,
 		"pending_special_phone_call": _pending_special_phone_call,
 		"script_memory": _script_memory.duplicate(),
+		"used_flash": _used_flash,
+		"bike_step": _bike_step,
 		"map_music": _map_music,
 		"radio_knob": _radio_knob,
 		"radio_channel": _radio_channel,
@@ -536,6 +566,14 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored._swarm_maps[SWARM_YANMA] = _vector_from_value(
 		source.get("yanma_swarm_map", [-1, -1])
 	)
+	## Absent in a state written before the byte was saved, which reads as a cave
+	## that has not been lit. `ResetFlashIfOutOfCave` clears it on the next ROUTE
+	## or TOWN either way, so an old save loses at most one cave's light.
+	restored._used_flash = bool(source.get("used_flash", false))
+	## Absent in a state written before the counter was kept, which reads as a
+	## ride that has not started: zero is what a new game holds and the only
+	## reader is the 1024-step threshold below it.
+	restored._bike_step = clampi(int(source.get("bike_step", 0)), 0, MAX_BIKE_STEP)
 	restored._map_music = maxi(0, int(source.get("map_music", MUSIC_NONE)))
 	restored.set_radio_knob(int(source.get("radio_knob", Gen2WorldRadio.KNOB_MIN)))
 	restored._radio_channel = int(source.get("radio_channel", -1))
@@ -550,6 +588,11 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	## one: the flag that unlocks the mode is an engine flag and survives on its
 	## own, so an old save shows the mode with nothing listed under it, which is
 	## what a player who has caught none would see anyway.
+	## Read before the forms below, because [method update_unown_dex] writes this
+	## byte too: a state that carries one keeps it, and one written before the
+	## byte was kept falls back to the first form caught, which is the same
+	## answer for every save whose first Unown was caught rather than only met.
+	restored.note_first_unown_seen(int(source.get("first_unown_seen", 0)))
 	var stored_unown: Variant = source.get("unown_dex", [])
 	if stored_unown is Array:
 		for raw_form: Variant in stored_unown as Array:
@@ -634,6 +677,8 @@ func restore_from_dict(raw: Variant) -> void:
 	_phone_contacts = restored._phone_contacts.duplicate()
 	_just_battled = restored._just_battled
 	_repel_steps = restored._repel_steps
+	_used_flash = restored._used_flash
+	_bike_step = restored._bike_step
 	_wild_encounter_cooldown = restored._wild_encounter_cooldown
 	_step_count = restored._step_count
 	_poison_step_count = restored._poison_step_count
@@ -651,6 +696,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_seen_species = restored._seen_species.duplicate()
 	_caught_species = restored._caught_species.duplicate()
 	_unown_dex = restored._unown_dex.duplicate()
+	_first_unown_seen = restored._first_unown_seen
 	_phone_receive_cycle = restored._phone_receive_cycle
 	_phone_receive_minutes = restored._phone_receive_minutes
 	_pending_special_phone_call = restored._pending_special_phone_call
@@ -1585,6 +1631,36 @@ func count_step() -> bool:
 	return true
 
 
+## `DoBikeStep`, which `CountStep` reaches behind the poison branch. The caller
+## answers the three gates in front of the counter, since only it knows the map
+## and the player's state: [param armed] is `STATUSFLAGS2_BIKE_SHOP_CALL_F` and
+## the bike, and [param in_service] is `GetMapPhoneService`.
+##
+## The counter saturates at `$ffff` rather than wrapping, which is what the two
+## `cp 255` tests do, and the call is queued the first counted step past 1024
+## that finds no other special call already waiting. Answers whether the call was
+## queued.
+func do_bike_step(armed: bool, in_service: bool) -> bool:
+	if not armed or not in_service:
+		return false
+	if _bike_step < MAX_BIKE_STEP:
+		_bike_step += 1
+		changed.emit()
+	if _bike_step < BIKE_SHOP_CALL_STEPS:
+		return false
+	## `.NoCall`: a call already queued is not overwritten, and the flag stays
+	## set so the next step tries again.
+	if _pending_special_phone_call != 0:
+		return false
+	_pending_special_phone_call = SPECIALCALL_BIKESHOP
+	changed.emit()
+	return true
+
+
+func bike_step() -> int:
+	return _bike_step
+
+
 func step_count() -> int:
 	return _step_count
 
@@ -1771,6 +1847,8 @@ func roaming_mons_on(map_group: int, map_number: int) -> Array:
 	var out: Array = []
 	for index: int in _roaming_mons.size():
 		var mon: Dictionary = _roaming_mons[index]
+		if int(mon.get("species", 0)) <= 0:
+			continue
 		if int(mon.get("map_group", -1)) != map_group or int(mon.get("map_number", -1)) != map_number:
 			continue
 		var value: Dictionary = mon.duplicate(true)
@@ -1819,9 +1897,26 @@ func set_species_caught(species: int, caught: bool = true) -> void:
 func update_unown_dex(form: int) -> void:
 	if form < 1 or form > RomLayout.UNOWN_FORMS:
 		return
+	## `.registerunowndex`'s own tail: the `wFirstUnownSeen` write sits behind the
+	## `UpdateUnownDex` call and runs whether or not the form was new.
+	note_first_unown_seen(form)
 	if form in _unown_dex or _unown_dex.size() >= RomLayout.UNOWN_FORMS:
 		return
 	_unown_dex.append(form)
+
+
+## The three `wFirstUnownSeen` writes, which are one test: a letter is stored
+## only while the byte is still zero, so the first Unown the save meets is the
+## one every dex entry is drawn as.
+func note_first_unown_seen(form: int) -> void:
+	if _first_unown_seen != 0 or form < 1 or form > RomLayout.UNOWN_FORMS:
+		return
+	_first_unown_seen = form
+	changed.emit()
+
+
+func first_unown_seen() -> int:
+	return _first_unown_seen
 
 
 ## The forms caught, in catching order. `Pokedex_DrawUnownModeBG` walks exactly
@@ -1872,6 +1967,11 @@ func advance_roaming(map_rows: Array, random: RandomNumberGenerator = null) -> A
 	for index: int in _roaming_mons.size():
 		var mon: Dictionary = _roaming_mons[index]
 		var current := Vector2i(int(mon.get("map_group", -1)), int(mon.get("map_number", -1)))
+		## `UpdateRoamMons`' own `cp GROUP_N_A / jr z`: a roamer that has been
+		## caught or defeated is skipped rather than walked, and skipping it
+		## spends none of `.Update`'s draws either.
+		if current.x == ROAM_MAP_N_A:
+			continue
 		var target: Vector2i = _roaming_target(map_rows, current, generator)
 		if target == Vector2i(-1, -1):
 			continue
@@ -1913,11 +2013,42 @@ func _copy_roaming_mons(source: Array) -> Array:
 	for raw: Variant in source:
 		if raw is Dictionary:
 			var mon: Dictionary = (raw as Dictionary).duplicate(true)
-			for field: String in ["species", "level", "map_group", "map_number"]:
+			for field: String in ["species", "level", "map_group", "map_number", "hp", "dvs"]:
 				if mon.has(field):
 					mon[field] = int(mon[field])
 			out.append(mon)
 	return out
+
+
+## `BattleEnd_HandleRoamMons`, which every roaming battle ends through. A win,
+## which is the source's word for caught or defeated alike, empties the struct:
+## `GetRoamMonHP` writes 0, the two map bytes become `GROUP_N_A`/`MAP_N_A` and
+## the species byte becomes 0, so `CheckEncounterRoamMon` can never select that
+## slot again. Any other ending stores the HP the fight left the roamer on.
+##
+## [param dvs] is the word `LoadEnemyMon`'s `.Roaming` rolled on the first
+## encounter and read back on every later one; it is stored beside the HP so a
+## roamer keeps the Pokemon it was, shininess included. Answers whether the
+## record moved.
+func note_roam_battle_end(species: int, won: bool, hp: int, dvs: int) -> bool:
+	for index: int in _roaming_mons.size():
+		var mon: Dictionary = _roaming_mons[index]
+		if int(mon.get("species", 0)) != species:
+			continue
+		if won:
+			mon["species"] = 0
+			mon["hp"] = 0
+			mon["map_group"] = ROAM_MAP_N_A
+			mon["map_number"] = ROAM_MAP_N_A
+		else:
+			## The struct's HP is one byte, and `GetRoamMonHP` stores
+			## `wEnemyMonHP + 1` alone: a roamer above 255 HP would wrap, and at
+			## level 40 none of the three can reach it.
+			mon["hp"] = clampi(hp, 0, 0xFF)
+			mon["dvs"] = dvs & 0xFFFF
+		changed.emit()
+		return true
+	return false
 
 
 func _roaming_target(

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -510,6 +510,35 @@ func test_resolved_wild_encounter_reaches_the_real_battle_overlay() -> void:
 	assert_eq(host.battle_snapshot()["message"], "Wild %s\nappeared!" % _wild_name())
 
 
+## `BattleEnd_HandleRoamMons` reached through the screen that owns it: the shape
+## the battle overlay reports a finished fight in is what the write-back reads,
+## so a roamer run from keeps its HP and one defeated empties its struct.
+func test_a_finished_roaming_battle_writes_the_struct_back() -> void:
+	await _open_world()
+	var state: Gen2WorldState = _world_screen._world.state
+	state.ensure_roaming_mons(
+		[{"species": Fixture.TRAINER_SPECIES, "level": 40, "map_group": 1, "map_number": 1}]
+	)
+	var finished: Dictionary = {
+		"ok": true,
+		"outcome": Gen2WorldBattleAdapter.OUTCOME_RAN,
+		"request": {
+			"kind": &"wild", "pokemon": Fixture.TRAINER_SPECIES, "level": 40,
+			"battle_type": Gen2Battle.BATTLETYPE_ROAMING,
+		},
+		"enemy": {"species": Fixture.TRAINER_SPECIES, "hp": 12, "dvs": 0x1234},
+	}
+	_world_screen._on_battle_finished(finished)
+	assert_eq(int(state.roaming_mons()[0]["hp"]), 12)
+	assert_eq(int(state.roaming_mons()[0]["dvs"]), 0x1234)
+
+	finished["outcome"] = Gen2WorldBattleAdapter.OUTCOME_WON
+	finished["enemy"] = {"species": Fixture.TRAINER_SPECIES, "hp": 0, "dvs": 0x1234}
+	_world_screen._on_battle_finished(finished)
+	assert_eq(int(state.roaming_mons()[0]["species"]), 0)
+	assert_eq(state.roaming_mons_on(1, 1).size(), 0)
+
+
 func test_catch_tutorial_uses_the_real_battle_overlay_without_persistent_capture() -> void:
 	await _open_world()
 	var balls_before: int = _world_screen._world.state.item_quantity(

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6166,6 +6166,22 @@ func test_world_snapshot_round_trips_the_surfing_player_sprite() -> void:
 	)
 
 
+## `wSpawnAfterChampion` is saved with the snapshot, and `continue_spawn_index`
+## is the `.SpawnAfterE4`/`.AfterRed` pair. The warp it drives is covered where
+## the spawn table is, in `test_world_field_move.gd`.
+func test_the_post_champion_spawn_byte_round_trips() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6))
+	world.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_RED
+	var decoded := Gen2WorldSnapshot.from_dict(world.snapshot().to_dict())
+	assert_eq(decoded.spawn_after_champion, Gen2WorldSnapshot.SPAWN_AFTER_RED)
+	assert_eq(decoded.continue_spawn_index(), Gen2WorldSnapshot.SPAWN_MT_SILVER)
+	decoded.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_LANCE
+	assert_eq(decoded.continue_spawn_index(), Gen2WorldSnapshot.SPAWN_NEW_BARK)
+	decoded.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_NONE
+	assert_eq(decoded.continue_spawn_index(), -1)
+
+
 func test_explicit_fishing_uses_the_current_map_fish_group() -> void:
 	var world := _world(Vector2i(8, 6))
 	var encounter: Dictionary = world.encounter_request(

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -179,6 +179,35 @@ func test_a_wild_request_carries_its_own_dvs_into_the_battle() -> void:
 	assert_true(Gen2Stats.is_shiny((prepared["battle"] as Gen2Battle).enemy.dvs))
 
 
+## `LoadEnemyMon`'s second BATTLETYPE_ROAMING branch: a roamer whose struct has
+## been initialised comes back on the HP the last fight left it on rather than on
+## a full bar, and a full-bar request is left alone.
+func test_a_roamer_returns_on_the_hp_its_struct_carries() -> void:
+	var chipped: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {
+			"kind": &"wild", "pokemon": SPECIES_TWO, "level": 40,
+			"battle_type": Gen2Battle.BATTLETYPE_ROAMING, "hp": 7, "dvs": 0xABCD,
+		}},
+		_player_party()
+	)
+	assert_true(bool(chipped["ok"]), String(chipped.get("reason", "")))
+	var enemy: Gen2BattleMon = (chipped["battle"] as Gen2Battle).enemy
+	assert_eq(enemy.hp, 7)
+	assert_eq(enemy.dvs, 0xABCD)
+	assert_gt(enemy.max_hp(), 7, "only the current HP is stored")
+
+	var fresh: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {
+			"kind": &"wild", "pokemon": SPECIES_TWO, "level": 40,
+			"battle_type": Gen2Battle.BATTLETYPE_ROAMING,
+		}},
+		_player_party()
+	)
+	assert_true(bool(fresh["ok"]), String(fresh.get("reason", "")))
+	var full: Gen2BattleMon = (fresh["battle"] as Gen2Battle).enemy
+	assert_eq(full.hp, full.max_hp())
+
+
 ## `LoadEnemyMon`'s `.GenerateDVs`: a wild that carries none is rolled two bytes
 ## off the BATTLE's own generator rather than handed 15/15/15/15, which is what
 ## every encounter source but the visible-encounter provider used to get. Off

--- a/tests/unit/test_world_encounters.gd
+++ b/tests/unit/test_world_encounters.gd
@@ -168,6 +168,61 @@ func test_roaming_selection_uses_the_land_roll_before_normal_slots() -> void:
 	assert_eq(found["level"], 40)
 
 
+## `CheckEncounterRoamMon` reads the struct rather than a species list: a roamer
+## whose HP byte is still zero rolls fresh DVs, one that has been fought before
+## comes back on its stored HP and DVs, and one that has been caught or defeated
+## carries no species and is never selected.
+func test_a_roaming_encounter_carries_the_struct_the_last_fight_left() -> void:
+	var slots: Array = []
+	for _time_of_day: int in RomLayout.WILD_TIME_COUNT:
+		var day_slots: Array = []
+		for _slot: int in RomLayout.WILD_GRASS_SLOT_COUNT:
+			day_slots.append({"level": 5, "species": 16})
+		slots.append(day_slots)
+	var record: Dictionary = {"rates": [255, 255, 255], "slots": slots}
+
+	var fresh: Dictionary = _first_roaming_encounter(
+		record, [{"species": 0xF3, "level": 40, "map_group": 1, "map_number": 1}]
+	)
+	assert_eq(fresh["source"], Gen2WorldEncounter.SOURCE_ROAMING)
+	assert_eq(
+		int(fresh["values"]["battle_type"]), Gen2Battle.BATTLETYPE_ROAMING
+	)
+	assert_false(
+		(fresh["values"] as Dictionary).has("dvs"),
+		"an uninitialised struct rolls its DVs in the battle"
+	)
+
+	var fought: Dictionary = _first_roaming_encounter(record, [{
+		"species": 0xF3, "level": 40, "map_group": 1, "map_number": 1,
+		"hp": 37, "dvs": 0xABCD,
+	}])
+	assert_eq(int(fought["values"]["hp"]), 37)
+	assert_eq(int(fought["values"]["dvs"]), 0xABCD)
+
+	assert_true(_first_roaming_encounter(record, [{
+		"species": 0, "level": 40,
+		"map_group": Gen2WorldState.ROAM_MAP_N_A,
+		"map_number": Gen2WorldState.ROAM_MAP_N_A,
+	}]).is_empty(), "an emptied struct is never selected")
+
+
+## The first roaming encounter the seeds 1..511 produce, or empty when none of
+## them selects the roamer.
+func _first_roaming_encounter(record: Dictionary, mons: Array) -> Dictionary:
+	for seed_value: int in range(1, 512):
+		var random := RandomNumberGenerator.new()
+		random.seed = seed_value
+		var found: Dictionary = Gen2WorldEncounter.resolve(
+			record, Gen2WorldEncounter.METHOD_GRASS, Gen2WorldPalette.TIME_DAY,
+			random, true,
+			{"map_group": 1, "map_number": 1, "roaming_mons": mons}
+		)
+		if found.get("source", &"") == Gen2WorldEncounter.SOURCE_ROAMING:
+			return found
+	return {}
+
+
 func test_layout_exposes_swarm_fishing_and_roaming_tables() -> void:
 	var gold: Dictionary = RomLayout.for_id(RomRegistry.GOLD)
 	var crystal: Dictionary = RomLayout.for_id(RomRegistry.CRYSTAL)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -137,12 +137,22 @@ func _write_cache() -> void:
 		_map(ESCAPE_CAVE, TILESET_NO_ENTRY, 0, ENVIRONMENT_CAVE),
 		_map(ESCAPE_POKECENTER, TILESET_POKECENTER, 0, ENVIRONMENT_INDOOR),
 	])
-	# `SpawnPoints`, with the town as the one spawn this cache carries.
+	# `SpawnPoints`, with the town as the one spawn this cache carries and the
+	# Pokemon Center standing in for SPAWN_NEW_BARK, which is the row a
+	# post-champion CONTINUE reads. The rows between them name a map no cache
+	# holds, so nothing but those two resolves.
+	var spawns: Array = [{
+		"map_group": 1, "map_number": ESCAPE_TOWN,
+		"x": SPAWN_CELL.x, "y": SPAWN_CELL.y,
+	}]
+	while spawns.size() < Gen2WorldSnapshot.SPAWN_NEW_BARK:
+		spawns.append({"map_group": 99, "map_number": 99, "x": 0, "y": 0})
+	spawns.append({
+		"map_group": 1, "map_number": ESCAPE_POKECENTER,
+		"x": SPAWN_CELL.x, "y": SPAWN_CELL.y,
+	})
 	RomCache.write_json(RomCache.world_spawns_path(_directory), {
-		"spawns": [{
-			"map_group": 1, "map_number": ESCAPE_TOWN,
-			"x": SPAWN_CELL.x, "y": SPAWN_CELL.y,
-		}],
+		"spawns": spawns,
 		"flypoints": [],
 	})
 
@@ -1850,3 +1860,28 @@ func test_the_menu_offers_only_moves_the_badge_allows() -> void:
 	assert_eq(
 		int((offers[0] as Dictionary)["item"]), _hm_item(Gen2WorldFieldMove.MOVE_CUT)
 	)
+
+
+## `.SpawnAfterE4`: a slot whose `wSpawnAfterChampion` is SPAWN_LANCE opens at
+## New Bark Town rather than where the credits caught the player, and
+## `PostCreditsSpawn` clears the byte so the next CONTINUE is ordinary.
+func test_a_post_champion_slot_continues_at_new_bark() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_LANCE
+	var encoded: Dictionary = world.snapshot().to_dict()
+	var data: GameData = GameData.open_directory(_directory)
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
+		data, Gen2WorldSnapshot.from_dict(encoded)
+	)
+	assert_not_null(restored)
+	assert_eq(restored.map_id(), Vector2i(1, ESCAPE_POKECENTER))
+	assert_eq(restored.player_cell, SPAWN_CELL)
+	assert_eq(restored.spawn_after_champion, Gen2WorldSnapshot.SPAWN_AFTER_NONE)
+
+	## The byte a snapshot written before it existed does not carry, which opens
+	## on the map the slot was written on.
+	encoded.erase("spawn_after_champion")
+	var legacy: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
+		data, Gen2WorldSnapshot.from_dict(encoded)
+	)
+	assert_eq(legacy.map_id(), world.map_id())

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -764,3 +764,97 @@ func test_the_reward_is_a_stat_booster_and_never_the_lucky_punch() -> void:
 		assert_ne(item, Gen2BattleTower.LUCKY_PUNCH)
 		seen[item] = true
 	assert_eq(seen.size(), Gen2BattleTower.MAX_REWARD - Gen2BattleTower.MIN_REWARD)
+
+
+## `BattleEnd_HandleRoamMons`: a roamer that was run from keeps the HP and the
+## DVs the fight left it on, and one that was caught or defeated is emptied so
+## `CheckEncounterRoamMon` can never select the slot again.
+func test_a_roamer_keeps_its_hp_and_dvs_between_encounters() -> void:
+	var state := Gen2WorldState.new()
+	state.ensure_roaming_mons(
+		[{"species": 243, "level": 40, "map_group": 1, "map_number": 1}]
+	)
+	assert_true(state.note_roam_battle_end(243, false, 37, 0xABCD))
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	var kept: Dictionary = restored.roaming_mons()[0]
+	assert_eq(int(kept["hp"]), 37)
+	assert_eq(int(kept["dvs"]), 0xABCD)
+
+	assert_true(restored.note_roam_battle_end(243, true, 0, 0xABCD))
+	var emptied: Dictionary = restored.roaming_mons()[0]
+	assert_eq(int(emptied["species"]), 0)
+	assert_eq(int(emptied["hp"]), 0)
+	assert_eq(int(emptied["map_group"]), Gen2WorldState.ROAM_MAP_N_A)
+	assert_eq(
+		restored.roaming_mons_on(1, 1).size(), 0,
+		"an emptied slot is on no map"
+	)
+
+
+## `UpdateRoamMons` skips a struct whose map group is GROUP_N_A, so a beaten
+## roamer is never walked back onto the map.
+func test_a_beaten_roamer_is_not_walked() -> void:
+	var state := Gen2WorldState.new()
+	state.ensure_roaming_mons(
+		[{"species": 243, "level": 40, "map_group": 1, "map_number": 1}]
+	)
+	state.note_roam_battle_end(243, true, 0, 0)
+	var rows: Array = [{
+		"map_group": 1, "map_number": 1,
+		"connections": [{"map_group": 1, "map_number": 2}],
+	}]
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 7
+	assert_eq(state.advance_roaming(rows, generator), [])
+	assert_eq(int(state.roaming_mons()[0]["map_group"]), Gen2WorldState.ROAM_MAP_N_A)
+
+
+## `wStatusFlags`' flash bit is saved player data, so a cave lit before a save is
+## still lit when the slot is opened again.
+func test_flash_survives_a_snapshot() -> void:
+	var state := Gen2WorldState.new()
+	state.set_used_flash(true)
+	assert_true(Gen2WorldState.from_dict(state.to_dict()).used_flash())
+	var without: Dictionary = state.to_dict()
+	without.erase("used_flash")
+	assert_false(Gen2WorldState.from_dict(without).used_flash())
+
+
+## `DoBikeStep`: the counter is saved, the call is queued the first counted step
+## past 1024, and the counter saturates rather than wrapping.
+func test_the_bike_shop_call_is_queued_after_1024_saved_steps() -> void:
+	var state := Gen2WorldState.new()
+	for _step: int in Gen2WorldState.BIKE_SHOP_CALL_STEPS - 1:
+		assert_false(state.do_bike_step(true, true))
+	assert_eq(state.bike_step(), Gen2WorldState.BIKE_SHOP_CALL_STEPS - 1)
+
+	var reopened: Gen2WorldState = Gen2WorldState.from_dict(state.to_dict())
+	assert_eq(reopened.bike_step(), Gen2WorldState.BIKE_SHOP_CALL_STEPS - 1)
+	assert_false(
+		reopened.do_bike_step(false, true), "a step off the bike counts nothing"
+	)
+	assert_false(
+		reopened.do_bike_step(true, false), "a map with no service counts nothing"
+	)
+	assert_true(reopened.do_bike_step(true, true))
+	assert_eq(reopened.pending_special_phone_call(), Gen2WorldState.SPECIALCALL_BIKESHOP)
+	assert_false(
+		reopened.do_bike_step(true, true), "a queued call is not overwritten"
+	)
+
+
+## The first Unown a save meets is what every Pokedex entry for UNOWN is drawn
+## as, whether it was caught or only seen, and it is written once.
+func test_the_first_unown_seen_is_kept_and_written_once() -> void:
+	var state := Gen2WorldState.new()
+	state.note_first_unown_seen(9)
+	state.update_unown_dex(3)
+	assert_eq(state.first_unown_seen(), 9)
+	assert_eq(state.unown_dex(), [3] as Array[int])
+	assert_eq(Gen2WorldState.from_dict(state.to_dict()).first_unown_seen(), 9)
+
+	## A state written before the byte was kept falls back to the first form
+	## caught rather than to form A.
+	var without: Dictionary = state.to_dict()
+	without.erase("first_unown_seen")
+	assert_eq(Gen2WorldState.from_dict(without).first_unown_seen(), 3)


### PR DESCRIPTION
`wPlayerData` and `wPokemonData` were swept symbol by symbol against this tree,
along with the non-mobile `ram/sram.asm` sections. Most of what is in them is
already built, or is an engine flag, or is one of the script-memory bytes.
Five were not: they lived on the runtime object and died with the world.

Each of the five is in the snapshot now. None of them moves the save format:
every one defaults to what a slot written before it existed truthfully says.

**A roamer had no struct, only a species and a level.** `roam_struct` carries an
HP byte and a DV word, and `BattleEnd_HandleRoamMons` was absent outright. So
Raikou and Entei rolled fresh DVs on every encounter, came back on a full bar
however far they had been chipped, and were never removed from the table when
caught or defeated, which meant one could be caught again forever.
`UpdateRoamMons`' own `cp GROUP_N_A` guard now keeps an emptied slot off the map
rather than letting the 1-in-32 jump branch walk it back on.

**`wStatusFlags`' flash bit was dropped on every load**, so a cave lit before a
save was dark when the slot was opened again. Its byte-neighbours here were
already saved; this was the one that was not.

**`wBikeStep` and `DoBikeStep` did not exist**, so the bike shop owner's call
could never arrive. The counter is two saved bytes and the routine is
`CountStep`'s last line, behind the poison branch and skipped when that branch
takes a script of its own.

**`wFirstUnownSeen` did not exist**, so every Pokedex entry for UNOWN was drawn
as form A rather than as the letter the save first met. It is written once, by
whichever of the first sighting and the first party addition comes first, which
is the one test all three source writes share.

**`wSpawnAfterChampion` did not exist.** `HallOfFame` writes `SPAWN_LANCE` and
`RedCredits` writes `SPAWN_RED`, and the CONTINUE that opens the slot next
spawns at New Bark Town or Mount Silver and clears the byte. Both pins do this
and both name the same spawn indices.

| Check | Result |
|---|---|
| GUT, unit tier | 3267/3267 |
| GUT, all tiers | 3785/3785 |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failures |