### PR TITLE
Let the stairs off a Pokemon Center's second floor lead somewhere

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2745,8 +2745,9 @@ const LANDMARK_VICTORY_ROAD: int = 0x58
 ## landmark above it, because `cp LANDMARK_VICTORY_ROAD / jr c, .kanto` only
 ## takes the Kanto branch below that row.
 ##
-## The `LANDMARK_SPECIAL` backup lookup in front of it is the six Cable Club
-## rooms and is deliberately not modelled; see [method Gen2WorldAPI.landmark].
+## The `LANDMARK_SPECIAL` backup lookup in front of it is
+## [method Gen2WorldAPI.landmark_backup], which every caller of this resolves
+## the landmark through.
 static func region_is_kanto(landmark_id: int, crystal: bool = true) -> bool:
 	if landmark_id == Gen2WorldRadio.fast_ship_landmark(crystal):
 		return false

--- a/game/battle/battle_world_context.gd
+++ b/game/battle/battle_world_context.gd
@@ -43,7 +43,7 @@ static func capture(
 	out.tileset = world.current_map.tileset
 	out.player_cell = world.player_cell
 	out.player_facing = world.player_facing
-	out.landmark = world.landmark()
+	out.landmark = world.landmark_backup()
 	out.time_of_day = clampi(
 		drawn_time_of_day if drawn_time_of_day >= 0 else world.map_time_of_day(), 0, 3
 	)

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -340,6 +340,35 @@ func world_script(bank: int, address: int) -> PackedByteArray:
 	)
 
 
+## The cached bytes from [param address] onward, whether or not a slice starts
+## there: a `elevfloor` list sits behind the script that names it and is inside
+## that script's own slice rather than at a key of its own. Empty when no cached
+## slice in [param bank] covers the address.
+func world_script_at(bank: int, address: int) -> PackedByteArray:
+	var exact: PackedByteArray = world_script(bank, address)
+	if not exact.is_empty():
+		return exact
+	## Slices overlap: every script is cached as a fixed span from its own start,
+	## so several can cover one address and the useful one is whichever reaches
+	## furthest past it.
+	var prefix: String = "%d:" % bank
+	var best: PackedByteArray = PackedByteArray()
+	for key: Variant in _scripts():
+		var name: String = String(key)
+		if not name.begins_with(prefix):
+			continue
+		var start: int = name.substr(prefix.length()).hex_to_int()
+		if address < start:
+			continue
+		var bytes: PackedByteArray = _payload_bytes(_scripts()[key], _blob("scripts"))
+		if address >= start + bytes.size():
+			continue
+		var reach: PackedByteArray = bytes.slice(address - start)
+		if reach.size() > best.size():
+			best = reach
+	return best
+
+
 ## One imported menu header referenced by an overworld script.
 func world_menu(bank: int, address: int) -> Dictionary:
 	var value: Variant = _menus().get(Gen2WorldScript.pointer_key(bank, address), {})

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 89
+const FORMAT_VERSION: int = 90
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1508,6 +1508,10 @@ const SPECIAL_TEXT_RUNS: Dictionary = {
 	## `CheckForLuckyNumberWinners`' two, which differ only in where the match
 	## was found.
 	"lucky_number": [["lucky_number_text", ["match_party", "match_pc"]]],
+	## `Elevator_AskWhichFloor`'s one. Not a `special` at all: the elevator is a
+	## script command, and the run is here because this table is where a routine
+	## reaches its own `text_far` stubs.
+	"elevator": [["elevator_text", ["which_floor"]]],
 	## `engine/events/print_photo.asm`'s five, in `PhotoStudio`'s own file order.
 	"photo_studio": [["photo_studio_text", [
 		"which_mon", "hold_still", "presto", "no_photo", "egg",
@@ -2589,6 +2593,7 @@ const GOLD_SILVER: Dictionary = {
 	"magikarp_measure_text": 0xFBCAD,
 	"magikarp_record_text": 0xFBDEC,
 	"lucky_number_text": 0xC7BA3,
+	"elevator_text": 0x138CF,
 	"photo_studio_text": 0x17034,
 	"mom_text": 0x168A8,
 	"poke_seer_text": 0,
@@ -3158,6 +3163,7 @@ const CRYSTAL: Dictionary = {
 	"magikarp_measure_text": 0xFBBA9,
 	"magikarp_record_text": 0xFBCE8,
 	"lucky_number_text": 0x4D9C9,
+	"elevator_text": 0x1350D,
 	"photo_studio_text": 0x16E04,
 	"mom_text": 0x16649,
 	"poke_seer_text": 0x4F28C,

--- a/game/render/world_service_page.gd
+++ b/game/render/world_service_page.gd
@@ -21,13 +21,33 @@ static func from_data(data: GameData) -> Gen2WorldServicePage:
 ## the map stays visible around it and nothing here fills the screen white.
 ## The caller supplies its own `menu_coords` box; an empty [param rows] draws
 ## no box at all, which is what a plain `MenuTextbox` print is.
+## [param note] is the small box a routine draws beside its list rather than
+## under it. `Elevator_GetCurrentFloorText` is the only one: `hlcoord 0, 0 /
+## ld b, 4 / ld c, 8 / call Textbox` with "Now on:" at (1, 2) and the floor's
+## own string at (4, 4).
 func render(title: String, prompt: String, rows: Array, cursor: int,
-		message: String = "", box: Gen2MenuBox = null) -> Image:
+		message: String = "", box: Gen2MenuBox = null,
+		note: PackedStringArray = PackedStringArray()) -> Image:
 	var image := Image.create_empty(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
 	if not rows.is_empty() and box != null:
 		_blit(image, menu.render(box, rows, cursor), box.border_position())
+	if note.size() >= 2:
+		## `Textbox` draws b + 2 rows by c + 2 columns, so `ld b, 4 / ld c, 8` is
+		## ten tiles by six and the menu beside it keeps the rest of the row.
+		var note_width: int = 10 * TILE
+		var note_indices := PackedByteArray()
+		note_indices.resize(note_width * 6 * TILE)
+		font.draw_box(Gen2OptionsStore.current().textbox_frame, note_indices,
+			note_width, 0, 0, 10, 6)
+		font.draw_text(note[0], note_indices, note_width, TILE, 2 * TILE)
+		font.draw_text(note[1], note_indices, note_width, 4 * TILE, 4 * TILE)
+		var note_part: Image = Gen2PicImage.from_indices(
+			note_indices, note_width, 6 * TILE,
+			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		)
+		image.blit_rect(note_part, Rect2i(Vector2i.ZERO, note_part.get_size()), Vector2i.ZERO)
 	var words: String = message if not message.is_empty() else prompt
 	if words.is_empty():
 		words = title

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -273,7 +273,7 @@ func _open_area() -> void:
 	host.z_index = 10
 	add_child(host)
 	if not host.open_dex_area(
-		_data, species, nests, _world.landmark(), _world.state.hall_of_fame(),
+		_data, species, nests, _world.landmark_backup(), _world.state.hall_of_fame(),
 		_world.player_female(), _world.map_time_of_day()
 	):
 		Gen2Screen.drop(host)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -151,6 +151,11 @@ static func passes_in_frames(passes: int) -> int:
 ## screen. The two National Park gates are `GROUP_ROUTE_35_NATIONAL_PARK_GATE`'s
 ## maps 15 and 17, which `.CheckNationalParkGate` names because their
 ## environment is not `GATE`.
+## A `warp_event`'s destination byte for `-1`, which names [member backup_warp]
+## rather than a warp on the map beside it. Six warp events across five maps
+## carry it: POKECENTER_2F's stairs, both dept store elevators' two doors and
+## FAST_SHIP_1F's cabin.
+const BACKUP_WARP_DESTINATION: int = 0xFF
 const MAP_NAME_SIGN_NO_LANDMARK: int = -1
 ## `wLandmarkSignTimer`, decremented once per `PlaceMapNameSign` and so once
 ## per overworld pass, which is two hardware frames.
@@ -208,6 +213,13 @@ var last_spawn_map: Vector2i = Vector2i(-1, -1)
 ## the player last came into a cave through, which is where Dig and an Escape
 ## Rope put them back. Empty until one is walked.
 var dig_warp: Dictionary = {}
+## `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`: where a warp
+## whose destination is -1 sends the player, and whose landmark a map with
+## `LANDMARK_SPECIAL` borrows. `GetWarpDestCoords`'s `.backup` writes it on
+## arriving at such a warp and `Script_warpmod` writes it outright; empty is a
+## game that has walked through none, which is what a slot written before this
+## existed truthfully says.
+var backup_warp: Dictionary = {}
 ## `wSpawnAfterChampion`, which the induction and Red's credits write and the
 ## next CONTINUE spends; see [member Gen2WorldSnapshot.spawn_after_champion].
 var spawn_after_champion: int = Gen2WorldSnapshot.SPAWN_AFTER_NONE
@@ -435,6 +447,7 @@ static func open_snapshot(
 	out.frame_number = world_snapshot.frame_number
 	out.last_spawn_map = world_snapshot.last_spawn_map
 	out.dig_warp = world_snapshot.dig_warp.duplicate()
+	out.backup_warp = world_snapshot.backup_warp.duplicate()
 	## `.SpawnAfterE4` and `.AfterRed`, which stand between `ClockContinue` and
 	## `FinishContinueFunction`: the map the slot was written on is loaded and
 	## then left, so everything a map load owes has already run when the spawn
@@ -484,12 +497,32 @@ func map_id() -> Vector2i:
 	return Vector2i(current_map.group, current_map.number) if current_map != null else Vector2i(-1, -1)
 
 
-## GetWorldMapLocation: the current map's own landmark. LANDMARK_SPECIAL means
-## the map borrows the landmark of the one the player warped in from, which only
-## the six Cable Club rooms do; none of them is implemented, so the fallback has
-## no caller and is deliberately not modelled.
+## GetWorldMapLocation: the current map's own landmark, with no fallback. Every
+## reader but `InitMapNameSign` wants [method landmark_backup] instead.
 func landmark() -> int:
 	return current_map.location if current_map != null else Gen2WorldRadio.LANDMARK_SPECIAL
+
+
+## The same lookup with the `LANDMARK_SPECIAL` fallback `RegionCheck`,
+## `IsInJohto`, `FlyMap`, `Pokedex_GetLandmark` and both `TownMap_*` routines
+## spell out: a map with no landmark of its own borrows [member backup_warp]'s.
+##
+## Six maps carry `LANDMARK_SPECIAL` and only one of them is ordinary: POKECENTER_2F
+## is every Pokemon Center's own upstairs, so the region a radio, a battle track,
+## the town map and the dex area screen answer with is the backup's on every visit
+## to one. The other five are the cable club's rooms.
+##
+## `SetCaughtData` tests POKECENTER_2F by name rather than the landmark, and the
+## two agree everywhere a caught mon can be made: nothing is caught in the five
+## cable club rooms, and a traded mon carries its own data.
+func landmark_backup() -> int:
+	var here: int = landmark()
+	if here != Gen2WorldRadio.LANDMARK_SPECIAL or backup_warp.is_empty() or data == null:
+		return here
+	var backup: Gen2WorldMap = data.world_map(
+		int(backup_warp["map_group"]), int(backup_warp["map_number"])
+	)
+	return backup.location if backup != null else here
 
 
 ## `InitMapNameSign`'s own `wCurLandmark`: a gate borrows nobody's name, so its
@@ -565,7 +598,7 @@ func radio_context() -> Dictionary:
 	var tower: int = Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER if crystal \
 		else Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER_GOLD_SILVER
 	return {
-		"landmark": landmark(),
+		"landmark": landmark_backup(),
 		"crystal": crystal,
 		"expn_card": state.is_engine_flag_active(Gen2WorldState.ENGINE_EXPN_CARD),
 		"rocket_signal": state.is_engine_flag_active(Gen2WorldState.ENGINE_ROCKET_SIGNAL),
@@ -661,7 +694,7 @@ func play_map_radio(station: int) -> Dictionary:
 	var channel: int = Gen2WorldRadio.map_radio_channel(
 		station,
 		Gen2WorldRadio.is_kanto_landmark(
-			landmark(), Gen2WorldState.is_crystal_profile(data)
+			landmark_backup(), Gen2WorldState.is_crystal_profile(data)
 		),
 		object_time_of_day
 	)
@@ -4693,6 +4726,14 @@ func _apply_result_events(result: Dictionary) -> Dictionary:
 			last_spawn_map = Vector2i(
 				int(event.get("map_group", 0)), int(event.get("map_number", 0))
 			)
+		## `Script_warpmod`'s own three writes, the same field a -1 warp's
+		## arrival records for itself.
+		if StringName(event.get("type", &"")) == &"backup_warp_changed":
+			backup_warp = {
+				"warp": int(event.get("warp", 0)),
+				"map_group": int(event.get("map_group", 0)),
+				"map_number": int(event.get("map_number", 0)),
+			}
 	return result
 
 
@@ -4802,7 +4843,32 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 			"from_cell": cell,
 		}
 
+	## `CopyWarpData`'s own `cp -1`: a warp whose destination byte is -1 names no
+	## warp and no map of its own, and the three bytes at `wBackupWarpNumber` are
+	## read contiguously in its place. The map named beside such a byte is a
+	## placeholder (POKECENTER_2F names itself), so it is replaced too.
 	var destination_index: int = int(source_warp.get("destination", 0)) - 1
+	if int(source_warp.get("destination", 0)) == BACKUP_WARP_DESTINATION:
+		if backup_warp.is_empty():
+			return {
+				"ok": false,
+				"kind": &"warp",
+				"reason": &"no_backup_warp",
+				"from_map": map_id(),
+				"from_cell": cell,
+			}
+		destination_index = int(backup_warp["warp"]) - 1
+		target_group = int(backup_warp["map_group"])
+		target_number = int(backup_warp["map_number"])
+		target_map = data.world_map(target_group, target_number) if data != null else null
+		if target_map == null:
+			return {
+				"ok": false,
+				"kind": &"warp",
+				"reason": &"missing_map",
+				"from_map": map_id(),
+				"from_cell": cell,
+			}
 	var target_warps: Array = target_map.events.get("warps", [])
 	if destination_index < 0 or destination_index >= target_warps.size():
 		return {
@@ -4826,6 +4892,16 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	var target_warp: Dictionary = (target_warps[destination_index] as Dictionary).duplicate(true)
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = cell
+	## `GetWarpDestCoords`'s `.backup`, which runs on arrival: a warp that is
+	## itself a -1 warp records the warp and the map the player came from, and
+	## that is what walking back out of it spends. Behind the read above, as in
+	## the source, so a -1 warp taken back out of a -1 warp reads the old value.
+	if int(target_warp.get("destination", 0)) == BACKUP_WARP_DESTINATION:
+		var walked: int = warp_index_at(cell)
+		if walked > 0:
+			backup_warp = {
+				"warp": walked, "map_group": from_map.x, "map_number": from_map.y,
+			}
 	# `wPrevWarp` is the warp walked through, which is what a Dig or an Escape
 	# Rope comes back out of.
 	_apply_map(
@@ -6058,7 +6134,7 @@ func fly_request() -> Dictionary:
 		"kind": &"fly_requested",
 		"move": Gen2WorldFieldMove.MOVE_FLY,
 		"in_kanto": Gen2WorldRadio.is_kanto_landmark(
-			landmark(), Gen2WorldState.is_crystal_profile(data)
+			landmark_backup(), Gen2WorldState.is_crystal_profile(data)
 		),
 		"visited": visited_flypoints(),
 	}

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -218,6 +218,8 @@ static func _reason_for(kind: StringName) -> StringName:
 			return &"day_care_data_unavailable"
 		&"pc_requested":
 			return &"pc_host_unavailable"
+		&"elevator_requested":
+			return &"elevator_host_unavailable"
 		&"map_radio_requested":
 			return &"radio_host_unavailable"
 		&"pokedex_entry_requested":
@@ -253,6 +255,34 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 			return {
 				"ok": true,
 				"data": {"mart": mart, "mart_id": mart_id, "dialog": dialog_id},
+			}
+		&"elevator_requested":
+			var floors: Dictionary = Gen2WorldScript.decode_elevator_floors(
+				world.data.world_script_at(
+					int(values.get("bank", 0)), int(values.get("address", 0))
+				)
+			)
+			if not bool(floors.get("ok", false)):
+				return {
+					"ok": false,
+					"reason": StringName(floors.get("reason", &"elevator_data_unavailable")),
+				}
+			## `.FindCurrentFloor` walks the list for the row whose map is the
+			## backup warp's, and quits the whole routine when none is: the car
+			## does not know where it is standing, so it does not move.
+			var rows: Array = floors["floors"]
+			var current: int = -1
+			for index: int in rows.size():
+				var row: Dictionary = rows[index]
+				if int(row["map_group"]) == int(world.backup_warp.get("map_group", -1)) \
+					and int(row["map_number"]) == int(world.backup_warp.get("map_number", -1)):
+					current = index
+					break
+			if current < 0:
+				return {"ok": false, "reason": &"elevator_floor_unknown"}
+			return {
+				"ok": true,
+				"data": {"elevator": {"floors": rows, "current": current}},
 			}
 		&"name_rater_requested":
 			var lines: Dictionary = name_rater_texts(world.data)

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1102,7 +1102,7 @@ static func capture_wild(
 		## passes 0 and takes the map's.
 		set_caught_data(
 			captured, wild.level, world.object_time_of_day, world.player_female(),
-			caught_location if caught_location > 0 else world.landmark()
+			caught_location if caught_location > 0 else world.landmark_backup()
 		)
 		destination = candidate.add_party_or_box(captured)
 		if not bool(destination.get("ok", false)):
@@ -1328,7 +1328,7 @@ static func _apply_party_request(
 		## `SetEggMonCaughtData` when it hatches; a plain `givepoke` takes
 		## `SetCaughtData`, the map the player is standing on.
 		set_caught_data(
-			mon, level, world.object_time_of_day, world.player_female(), world.landmark()
+			mon, level, world.object_time_of_day, world.player_female(), world.landmark_backup()
 		)
 		if is_egg:
 			## `GiveEgg` is `TryAddMonToParty` and nothing else, so a full party
@@ -2071,7 +2071,7 @@ static func hatch_egg(
 		return {}
 	set_caught_data(
 		mon, CAUGHT_EGG_LEVEL, world.object_time_of_day,
-		world.player_female(), world.landmark()
+		world.player_female(), world.landmark_backup()
 	)
 	mon.is_egg = false
 	# `ld [hl], $78`: the counter the walk drained becomes the hatchling's own

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4473,7 +4473,7 @@ func _apply_battle_transition() -> void:
 func _play_battle_music(request: Dictionary) -> void:
 	if _audio_player == null or _data == null:
 		return
-	var landmark: int = _world.landmark() if _world != null \
+	var landmark: int = _world.landmark_backup() if _world != null \
 		else Gen2WorldRadio.LANDMARK_SPECIAL
 	var track: int = Gen2WorldBattleAdapter.music_for(
 		request, landmark, time_of_day, Gen2WorldState.is_crystal_profile(_data)
@@ -6705,7 +6705,7 @@ func _show_script_results(results: Array) -> void:
 					&"mart_requested", &"phone_call_requested",
 					&"special_phone_call_requested", &"town_map_requested",
 					&"apricorn_selection_requested", &"pc_requested",
-					&"mom_bank_dial_requested",
+					&"mom_bank_dial_requested", &"elevator_requested",
 				]:
 					_open_service_host()
 					break

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -131,6 +131,11 @@ const MAX_TEXT_BYTES: int = 1024
 ## constants/script_constants.asm's cmdqueue block. An entry is
 ## `dbw type, address` plus two filler bytes; four fit in wCmdQueue.
 const CMDQUEUE_ENTRY_SIZE: int = 5
+## `elevfloor` (macros/scripts/maps.asm): `db floor, warp` then `map_id`'s
+## `db group, number`. The list opens with a floor count and ends on a `db -1`.
+const ELEVATOR_FLOOR_SIZE: int = 4
+const ELEVATOR_TERMINATOR: int = 0xFF
+const MAX_ELEVATOR_FLOORS: int = 16
 const CMDQUEUE_CAPACITY: int = 4
 const CMDQUEUE_NULL: int = 0
 const CMDQUEUE_STONETABLE: int = 2
@@ -910,6 +915,7 @@ static func scan_references(
 	var texts: Array = []
 	var movements: Array = []
 	var command_queues: Array = []
+	var elevators: Array = []
 	var at: int = 0
 	var command_count: int = 0
 	while at < data.size() and command_count < MAX_COMMANDS:
@@ -955,13 +961,18 @@ static func scan_references(
 				## writecmdqueue points at a cmdqueue entry, which is data rather
 				## than script, so it is collected as its own kind.
 				command_queues.append({"bank": bank, "address": int(command["address"])})
+			0x94:
+				## elevator points at an `elevfloor` list, which is data rather
+				## than script, and `Elevator.LoadPointer` reads it out of the
+				## map scripts bank the command itself sits in.
+				elevators.append({"bank": bank, "address": int(command["address"])})
 		at += int(command["width"])
 		command_count += 1
 		if not continues_after(opcode, crystal_commands):
 			break
 	return {
 		"scripts": scripts, "texts": texts, "movements": movements,
-		"command_queues": command_queues,
+		"command_queues": command_queues, "elevators": elevators,
 	}
 
 
@@ -1004,6 +1015,36 @@ static func decode_stone_table(data: PackedByteArray) -> Dictionary:
 		})
 		at += STONETABLE_ROW_SIZE
 	return {"ok": false, "reason": &"unterminated_stone_table", "rows": rows}
+
+
+## Decodes an `elevfloor` list: the floor count, then one row per floor until
+## the `db -1`. `Elevator.LoadFloors` reads the count and walks the rows at a
+## four-byte stride, and `Elevator_GoToFloor` copies a row's last three bytes
+## straight over `wBackupWarpNumber`, which is what the warp out of the car
+## then spends.
+static func decode_elevator_floors(data: PackedByteArray) -> Dictionary:
+	if data.is_empty():
+		return {"ok": false, "reason": &"short_elevator_list"}
+	var count: int = data[0]
+	if count <= 0 or count > MAX_ELEVATOR_FLOORS:
+		return {"ok": false, "reason": &"unsupported_elevator_count", "count": count}
+	var floors: Array = []
+	var at: int = 1
+	while floors.size() < count:
+		if at >= data.size() or data[at] == ELEVATOR_TERMINATOR:
+			return {"ok": false, "reason": &"short_elevator_list", "floors": floors}
+		if at + ELEVATOR_FLOOR_SIZE > data.size():
+			return {"ok": false, "reason": &"short_elevator_list", "floors": floors}
+		floors.append({
+			"floor": data[at],
+			"warp": data[at + 1],
+			"map_group": data[at + 2],
+			"map_number": data[at + 3],
+		})
+		at += ELEVATOR_FLOOR_SIZE
+	if at >= data.size() or data[at] != ELEVATOR_TERMINATOR:
+		return {"ok": false, "reason": &"unterminated_elevator_list", "floors": floors}
+	return {"ok": true, "floors": floors, "bytes": at + 1}
 
 
 ## A world text with nothing to substitute into it. Anything carrying a name,

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1274,6 +1274,32 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		})
 		_pending = {}
 		return advance()
+	if kind == &"elevator_requested":
+		## `Script_elevator` zeroes `wScriptVar` before the call and writes TRUE
+		## only past `ret c`, so a cancelled ride and a car with no floor to
+		## match both leave the script's own FALSE branch standing.
+		if not bool(result.get("ok", false)):
+			return _fail(StringName(result.get("reason", &"elevator_failed")), result)
+		var rode: bool = result.has("floor") and result["floor"] is Dictionary
+		if rode:
+			## `Elevator_GoToFloor` copies the chosen row's last three bytes
+			## straight over `wBackupWarpNumber`, and the -1 warp out of the car
+			## is what spends them.
+			var floor_row: Dictionary = result["floor"]
+			_emit_runtime_event(&"backup_warp_changed", {
+				"warp": int(floor_row.get("warp", 0)),
+				"map_group": int(floor_row.get("map_group", 0)),
+				"map_number": int(floor_row.get("map_number", 0)),
+			})
+		_script_value = 1 if rode else 0
+		_events.append({
+			"type": &"runtime_request_completed",
+			"kind": kind,
+			"request": request.duplicate(true),
+			"result": result.duplicate(true),
+		})
+		_pending = {}
+		return advance()
 	if kind == &"trainer_approach_requested":
 		if not bool(result.get("ok", false)):
 			return _fail(
@@ -1715,6 +1741,17 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 				return {"ok": true}
 			var jump_result: Dictionary = _replace_frame(pointer_bank, pointer_address)
 			return jump_result
+		Gen2WorldScript.WARPMOD:
+			## `Script_warpmod` writes `wBackupWarpNumber`, `wBackupMapGroup` and
+			## `wBackupMapNumber` outright, which is how a map whose only exit is
+			## a -1 warp is given one before the player can reach it: both dept
+			## store elevators and the Fast Ship's cabin are entered by a script
+			## that runs this first.
+			_emit_runtime_event(&"backup_warp_changed", {
+				"warp": int(command.get("warp_id", 0)),
+				"map_group": int(command.get("map_group", 0)),
+				"map_number": int(command.get("map_number", 0)),
+			})
 		Gen2WorldScript.BLACKOUTMOD:
 			## `Script_blackoutmod` writes `wLastSpawnMapGroup` and
 			## `wLastSpawnMapNumber`, which is the pair `GetWhiteoutSpawn` reads
@@ -2420,7 +2457,11 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 				mart["items"] = command["mart_items"]
 			return _stage_runtime_request(&"mart_requested", mart)
 		0x94:
+			## `Script_elevator` hands `Elevator` the pointer in `de` and the
+			## running script's own bank in `b`, which is where the `elevfloor`
+			## list lives.
 			return _stage_runtime_request(&"elevator_requested", {
+				"bank": bank,
 				"address": int(command.get("address", 0)),
 			})
 		0x95:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -32,7 +32,16 @@ enum MODE {
 	PC_DECO, PC_DECO_LIST, PC_DECO_SIDE,
 	PC_BOX_SUBMENU,
 	PC_MAILBOX, PC_MAIL_SUBMENU, PC_MAIL_CONFIRM,
+	ELEVATOR,
 }
+
+## `ElevatorFloorNames`, in `FLOOR_*` order (constants/script_constants.asm).
+const FLOOR_NAMES: Array[String] = [
+	"B4F", "B3F", "B2F", "B1F", "1F", "2F", "3F", "4F", "5F", "6F",
+	"7F", "8F", "9F", "10F", "11F", "ROOF",
+]
+## `Elevator_MenuData`'s `db 4, 0`: four rows of floors are shown at a time.
+const ELEVATOR_ROWS: int = 4
 
 ## `PokemonCenterPC`'s own box storage, which is the one row that opens a screen
 ## rather than a list. It is added as a child the way the MAP card adds the
@@ -146,6 +155,10 @@ var _mart_confirm: int = 0
 ## `SellMenu`'s own list, which is the pack rather than the shop's stock.
 var _mart_sell_entries: Array = []
 var _mart_top: int = MART_TOP_BUY
+## `wCurElevatorFloors` and `wElevatorOriginFloor`: the list the host resolved
+## and the row `.FindCurrentFloor` matched, plus this screen's own scroll.
+var _elevator: Dictionary = {}
+var _elevator_scroll: int = 0
 var _apricorns: Gen2WorldApricorn = null
 var _mom_dial: Gen2WorldMoneyDial = null
 ## The same counted blink [Gen2TextBox]'s arrow is, since it is the same
@@ -309,6 +322,9 @@ func open_pending(
 		&"apricorn_selection_requested":
 			_open_apricorns()
 			return true
+		&"elevator_requested":
+			_open_elevator(resolved.get("data", {}).get("elevator", {}))
+			return true
 		&"pc_requested":
 			_open_pc(StringName(resolved.get("data", {}).get("pc", {}).get("mode", &"")))
 			return true
@@ -376,6 +392,9 @@ func handle_button(button: int) -> bool:
 		return false
 	if _mode == MODE.APRICORN:
 		_press_apricorns(button)
+		return true
+	if _mode == MODE.ELEVATOR:
+		_press_elevator(button)
 		return true
 	if _mode == MODE.MART:
 		_press_mart(button)
@@ -448,6 +467,78 @@ func open_prompt(
 	_host_prompt = true
 	_open_menu({"text": text, "choices": Gen2WorldMenu.YES_NO_KEYS})
 	return true
+
+
+## `Elevator_AskWhichFloor`: the floor list in `Elevator_MenuHeader`'s box with
+## `Elevator_GetCurrentFloorText`'s own small box beside it. `.LoadPointer` and
+## `.FindCurrentFloor` already ran on the host side, so this is the menu alone.
+func _open_elevator(elevator: Dictionary) -> void:
+	_mode = MODE.ELEVATOR
+	_elevator = elevator.duplicate(true)
+	_elevator_scroll = 0
+	## `ld a, 1` is the header's default option, and `xor a / ld
+	## [wMenuScrollPosition], a` puts the window at the top whatever floor the
+	## car is on.
+	_cursor = 0
+	_title = ""
+	_status = ""
+	_summary = _elevator_prompt()
+	_render_elevator()
+
+
+## `_AskFloorElevatorText`, or this host's own wording on a cache imported
+## before the stub was read.
+func _elevator_prompt() -> String:
+	var line: String = String(_data.special_text("elevator", "which_floor")) \
+		if _data != null else ""
+	return line if not line.is_empty() else "Which floor?"
+
+
+func _elevator_floors() -> Array:
+	return _elevator.get("floors", [])
+
+
+static func _floor_name(index: int) -> String:
+	return FLOOR_NAMES[index] if index >= 0 and index < FLOOR_NAMES.size() else "?"
+
+
+func _render_elevator() -> void:
+	var rows: Array = []
+	var floors: Array = _elevator_floors()
+	for row: int in ELEVATOR_ROWS:
+		var index: int = _elevator_scroll + row
+		if index >= floors.size():
+			break
+		rows.append(_floor_name(int((floors[index] as Dictionary)["floor"])))
+	_render_service_page(rows, _cursor - _elevator_scroll)
+
+
+func _press_elevator(button: int) -> void:
+	var floors: Array = _elevator_floors()
+	if button == Gen2Button.B:
+		## `.cancel`'s `scf`, which `Script_elevator`'s `ret c` leaves as FALSE.
+		_finish_runtime({"ok": true})
+		return
+	if button == Gen2Button.A:
+		if _cursor < 0 or _cursor >= floors.size():
+			return
+		## `Elevator`'s own `cp [hl] / jr z, .quit`: choosing the floor the car
+		## is already on is a cancel, not a ride.
+		if _cursor == int(_elevator.get("current", -1)):
+			_finish_runtime({"ok": true})
+			return
+		_finish_runtime({"ok": true, "floor": (floors[_cursor] as Dictionary).duplicate()})
+		return
+	if button == Gen2Button.UP:
+		_cursor = maxi(0, _cursor - 1)
+	elif button == Gen2Button.DOWN:
+		_cursor = mini(floors.size() - 1, _cursor + 1)
+	else:
+		return
+	_elevator_scroll = clampi(
+		_elevator_scroll, maxi(0, _cursor - ELEVATOR_ROWS + 1), _cursor
+	)
+	_render_elevator()
 
 
 func _open_menu(input: Dictionary) -> void:
@@ -2096,7 +2187,7 @@ func open_fly_map(
 		visited.append(int(index))
 	var opened: bool = _town_map.open_fly(
 		_data,
-		_world.landmark(),
+		_world.landmark_backup(),
 		bool(request.get("in_kanto", false)),
 		visited,
 		_save != null and _save.gender == Gen2SaveData.GENDER_FEMALE,
@@ -2128,7 +2219,7 @@ func _open_town_map(from_request: bool) -> void:
 		else Gen2TownMap.SCREEN_POKEGEAR_CARD
 	var opened: bool = _town_map.open(
 		_data,
-		_world.landmark(),
+		_world.landmark_backup(),
 		_world.state.hall_of_fame(),
 		screen,
 		owned,
@@ -2354,12 +2445,25 @@ func _render_service_page(values: Array, cursor: int = -1) -> void:
 	var image: Image = _mom_bank_image() if _mode == MODE.MOM_BANK \
 		else _dial_image() if _is_dial() else _service_page.render(
 		_title, _summary, labels, _cursor if cursor < 0 else cursor, _status,
-		_service_box()
+		_service_box(), _service_note()
 	)
 	if image != null:
 		Gen2PicImage.show(_service_view, image)
 	_service_drawn = image != null
 	_apply_layer_visibility()
+
+
+## `Elevator_GetCurrentFloorText`'s own box, which no other mode draws.
+func _service_note() -> PackedStringArray:
+	if _mode != MODE.ELEVATOR:
+		return PackedStringArray()
+	var floors: Array = _elevator_floors()
+	var current: int = int(_elevator.get("current", -1))
+	if current < 0 or current >= floors.size():
+		return PackedStringArray()
+	return PackedStringArray([
+		"Now on:", _floor_name(int((floors[current] as Dictionary)["floor"])),
+	])
 
 
 ## An overlay owns all 160x144 while it is up: the mart, box storage, a Pokegear
@@ -2404,6 +2508,19 @@ func _service_box() -> Gen2MenuBox:
 			return _menu.box()
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_DECO_LIST:
 			return _pc_top_box()
+		MODE.ELEVATOR:
+			## `Elevator_MenuHeader`'s `menu_coords 12, 1, 18, 9`.
+			##
+			## `ScrollingMenu_UpdateDisplay` reaches its first row with
+			## `MenuBoxCoord2Tile / ld bc, SCREEN_WIDTH + 1`, which is one row
+			## down and one column right, where `_InitVerticalMenuCursor` spends
+			## a second row before the first item. A scrolling menu therefore has
+			## no top spacing, and this box's fourth floor sits on its own border
+			## without it.
+			return Gen2MenuBox.from_coords(
+				12, 1, 18, 9,
+				Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+			)
 		MODE.PC_MAILBOX:
 			## `.TopMenuHeader`'s `menu_coords 8, 1, SCREEN_WIDTH - 2, 10`.
 			return Gen2MenuBox.from_coords(8, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -44,6 +44,12 @@ var frame_number: int = 0
 ## which reads as a game that has entered no Pokemon Center and no cave.
 var last_spawn_map: Vector2i = Vector2i(-1, -1)
 var dig_warp: Dictionary = {}
+## `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`, which
+## `SavePlayerData` copies into `sCurMapData` alongside the dig warp: where the
+## stairs out of a Pokemon Center's second floor lead and whose landmark that
+## floor borrows. Empty in a snapshot written before it existed, which reads as
+## a game that has walked through no such warp.
+var backup_warp: Dictionary = {}
 ## `wSpawnAfterChampion`, saved player data on both pins: `HallOfFame` writes
 ## `SPAWN_LANCE` and `RedCredits` writes `SPAWN_RED`, and the CONTINUE that opens
 ## the slot next puts the player at New Bark Town or Mount Silver instead of
@@ -71,6 +77,7 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.frame_number = world.frame_number
 	out.last_spawn_map = world.last_spawn_map
 	out.dig_warp = world.dig_warp.duplicate()
+	out.backup_warp = world.backup_warp.duplicate()
 	out.spawn_after_champion = world.spawn_after_champion
 	out.world_state = Gen2WorldState.from_dict(world.state.to_dict())
 	return out
@@ -91,6 +98,7 @@ func to_dict() -> Dictionary:
 		"frame_number": frame_number,
 		"last_spawn_map": [last_spawn_map.x, last_spawn_map.y],
 		"dig_warp": dig_warp.duplicate(),
+		"backup_warp": backup_warp.duplicate(),
 		"spawn_after_champion": spawn_after_champion,
 		"world_state": world_state.to_dict() if world_state != null else {},
 	}
@@ -124,13 +132,8 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 	out.random_seed = int(source.get("random_seed", 0))
 	out.frame_number = maxi(0, int(source.get("frame_number", 0)))
 	out.last_spawn_map = _vector_from_value(source.get("last_spawn_map", [-1, -1]))
-	var raw_dig: Variant = source.get("dig_warp", {})
-	if raw_dig is Dictionary and not (raw_dig as Dictionary).is_empty():
-		out.dig_warp = {
-			"warp": int((raw_dig as Dictionary).get("warp", 0)),
-			"map_group": int((raw_dig as Dictionary).get("map_group", 0)),
-			"map_number": int((raw_dig as Dictionary).get("map_number", 0)),
-		}
+	out.dig_warp = _warp_from_value(source.get("dig_warp", {}))
+	out.backup_warp = _warp_from_value(source.get("backup_warp", {}))
 	out.spawn_after_champion = clampi(
 		int(source.get("spawn_after_champion", SPAWN_AFTER_NONE)),
 		SPAWN_AFTER_NONE, SPAWN_AFTER_RED
@@ -141,6 +144,18 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 
 func world_clock() -> Dictionary:
 	return {"day": world_day, "hour": world_hour, "minute": world_minute}
+
+
+## The three-byte warp-and-map triple `dig_warp` and `backup_warp` both keep.
+static func _warp_from_value(value: Variant) -> Dictionary:
+	if not value is Dictionary or (value as Dictionary).is_empty():
+		return {}
+	var source: Dictionary = value
+	return {
+		"warp": int(source.get("warp", 0)),
+		"map_group": int(source.get("map_group", 0)),
+		"map_number": int(source.get("map_number", 0)),
+	}
 
 
 static func _vector_from_value(value: Variant) -> Vector2i:

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -421,3 +421,43 @@ func test_conditional_enders_do_not_stop_a_linear_walk() -> void:
 			Gen2WorldScript.continues_after(opcode, false),
 			"gold %02X stops" % opcode
 		)
+
+
+## `elevfloor`'s `db floor, warp` then `map_id`'s `db group, number`, opened by a
+## count and closed by a `db -1`. Celadon's six floors are the shape.
+func test_elevator_floors_decode_until_the_terminator() -> void:
+	var decoded: Dictionary = Gen2WorldScript.decode_elevator_floors(PackedByteArray([
+		2, 4, 4, 21, 5, 5, 3, 21, 6, 0xFF,
+	]))
+	assert_true(decoded["ok"])
+	assert_eq(decoded["bytes"], 10)
+	assert_eq(decoded["floors"], [
+		{"floor": 4, "warp": 4, "map_group": 21, "map_number": 5},
+		{"floor": 5, "warp": 3, "map_group": 21, "map_number": 6},
+	])
+
+
+## A list whose count outruns its rows is refused rather than read past: the
+## bytes behind an `elevfloor` list are the next record, not another floor.
+func test_elevator_floors_refuse_a_short_or_unterminated_list() -> void:
+	assert_eq(
+		Gen2WorldScript.decode_elevator_floors(PackedByteArray([2, 4, 4, 21, 5, 0xFF]))["reason"],
+		&"short_elevator_list"
+	)
+	assert_eq(
+		Gen2WorldScript.decode_elevator_floors(PackedByteArray([1, 4, 4, 21, 5, 4]))["reason"],
+		&"unterminated_elevator_list"
+	)
+	assert_eq(
+		Gen2WorldScript.decode_elevator_floors(PackedByteArray([0]))["reason"],
+		&"unsupported_elevator_count"
+	)
+
+
+## `Script_elevator` hands `Elevator` the running script's own bank, so the
+## `elevfloor` list is collected out of that bank the way a cmdqueue entry is.
+func test_reference_scan_reports_elevator_pointers() -> void:
+	var references: Dictionary = Gen2WorldScript.scan_references(
+		PackedByteArray([0x95, 0x6F, 0x67, 0x90]), 21, 0x6728, true
+	)
+	assert_eq(references["elevators"], [{"bank": 21, "address": 0x676F}])

--- a/tools/checks/backup_warp.gd
+++ b/tools/checks/backup_warp.gd
@@ -1,0 +1,300 @@
+extends RefCounted
+
+## Verifies the backup warp against freshly imported real caches on all three
+## cartridges: `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`,
+## which `SavePlayerData` copies into `sCurMapData` and which two unrelated
+## routines both read.
+##
+## Expected values come from the pinned pokecrystal and pokegold sources:
+## home/map.asm's `CopyWarpData` and `GetWarpDestCoords`, home/region.asm's
+## `IsInJohto`, engine/overworld/landmarks.asm's `RegionCheck`,
+## engine/overworld/scripting.asm's `Script_warpmod`, ram/wram.asm and
+## engine/menus/save.asm.
+##
+## The finding the topic carries: a `warp_event` whose destination is -1 names
+## no warp and no map of its own, and this port read the placeholder beside it,
+## so the stairs out of every Pokemon Center's second floor led nowhere. The
+## same three bytes are the landmark a `LANDMARK_SPECIAL` map borrows, so the
+## radio, the battle track, the town map and the dex area screen all answered
+## with Johto's defaults up there whatever region the player was in.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- backup_warp
+
+## The six `warp_event`s in either corpus whose destination is -1, as
+## [group, number, warp index]. Crystal and Gold and Silver disagree only on the
+## Goldenrod dept store elevator's map number, which [constant ELEVATOR_CRYSTAL]
+## and [constant ELEVATOR_GOLD_SILVER] name.
+const ELEVATOR_CRYSTAL: Array = [[11, 17, 1], [11, 17, 2]]
+const ELEVATOR_GOLD_SILVER: Array = [[11, 18, 1], [11, 18, 2]]
+const SHARED_BACKUP_WARPS: Array = [
+	[15, 3, 1],  # FAST_SHIP_1F's cabin
+	[20, 1, 1],  # POKECENTER_2F's stairs
+	[21, 11, 1], [21, 11, 2],  # the Celadon dept store elevator
+]
+
+## POKECENTER_2F, the one `LANDMARK_SPECIAL` map that is not a cable club room.
+const POKECENTER_2F_GROUP: int = 20
+const POKECENTER_2F: int = 1
+const POKECENTER_2F_STAIRS: Vector2i = Vector2i(0, 7)
+
+## Cherrygrove City's Pokemon Center, its stairs cell and the landmark the map
+## carries. Warp 3 there is the one that leads up, on all three cartridges.
+const CENTER_GROUP: int = 2
+const CENTER_MAP: int = 3
+const CENTER_STAIRS: Vector2i = Vector2i(0, 7)
+const CENTER_STAIRS_WARP: int = 3
+
+## The two dept store elevators, whose `elevator` script command reads the same
+## three bytes through `.FindCurrentFloor` and writes them through
+## `Elevator_GoToFloor`. Crystal's Goldenrod car is map 11/17 and Gold and
+## Silver's 11/18; the Celadon one is 21/11 on all three.
+const CELADON_ELEVATOR: Array = [21, 11]
+const GOLDENROD_ELEVATOR_CRYSTAL: Array = [11, 17]
+const GOLDENROD_ELEVATOR_GOLD_SILVER: Array = [11, 18]
+
+## Vermilion City's, whose landmark is Kanto's: the region a
+## `LANDMARK_SPECIAL` map answers with is the backup's and not a constant.
+const KANTO_CENTER_GROUP: int = 17
+const KANTO_CENTER_MAP: int = 10
+const KANTO_CENTER_STAIRS: Vector2i = Vector2i(0, 7)
+
+
+func run(r: RefCounted) -> void:
+	for game_id: StringName in [&"crystal", &"gold", &"silver"]:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_corpus(r, game_id, data)
+		_verify_walk(r, game_id, data, CENTER_GROUP, CENTER_MAP, CENTER_STAIRS)
+		_verify_walk(
+			r, game_id, data, KANTO_CENTER_GROUP, KANTO_CENTER_MAP, KANTO_CENTER_STAIRS
+		)
+		_verify_save_round_trip(r, game_id, data)
+		_verify_elevators(r, game_id, data)
+
+
+## Which warp events carry the destination, whole corpus. The pair of counts is
+## what says a seventh cannot appear without a reading of it.
+func _verify_corpus(r: RefCounted, game_id: StringName, data: GameData) -> void:
+	var expected: Dictionary = {}
+	var elevator: Array = ELEVATOR_CRYSTAL if game_id == &"crystal" else ELEVATOR_GOLD_SILVER
+	for row: Array in SHARED_BACKUP_WARPS + elevator:
+		expected["%d:%d:%d" % [row[0], row[1], row[2]]] = true
+	var found: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		var warps: Array = map.events.get("warps", [])
+		for index: int in warps.size():
+			if int((warps[index] as Dictionary).get("destination", 0)) \
+					== Gen2WorldAPI.BACKUP_WARP_DESTINATION:
+				found["%d:%d:%d" % [map.group, map.number, index + 1]] = true
+	r.check(
+		found.size() == expected.size(),
+		"%s: %d warp events name the backup warp, not %d." % [
+			game_id, found.size(), expected.size(),
+		]
+	)
+	for key: String in expected:
+		r.check(found.has(key), "%s: warp %s does not name the backup warp." % [game_id, key])
+
+
+## The reported shape, end to end on the real maps: up the stairs of a Pokemon
+## Center, and back down into the same one. `GetWarpDestCoords`'s `.backup` is
+## what records the way back, and the landmark the floor borrows is the same
+## map's.
+func _verify_walk(
+	r: RefCounted, game_id: StringName, data: GameData,
+	group: int, number: int, stairs: Vector2i,
+) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, group, number, stairs, Gen2WorldState.new()
+	)
+	if not r.check(world != null, "%s: map %d/%d is missing." % [game_id, group, number]):
+		return
+	var ground: int = world.landmark()
+	var up: Dictionary = world.try_warp(stairs)
+	if not r.check(
+		bool(up.get("ok", false)) and world.map_id() == Vector2i(POKECENTER_2F_GROUP, POKECENTER_2F),
+		"%s: the stairs of %d/%d do not reach POKECENTER_2F (%s)." % [
+			game_id, group, number, up.get("reason", &"no_result"),
+		]
+	):
+		return
+	r.check(
+		world.backup_warp == {
+			"warp": CENTER_STAIRS_WARP, "map_group": group, "map_number": number,
+		},
+		"%s: arriving on POKECENTER_2F from %d/%d recorded %s." % [
+			game_id, group, number, world.backup_warp,
+		]
+	)
+	r.check(
+		world.landmark() == Gen2WorldRadio.LANDMARK_SPECIAL,
+		"%s: POKECENTER_2F's own landmark is %d, not LANDMARK_SPECIAL." % [
+			game_id, world.landmark(),
+		]
+	)
+	r.check(
+		world.landmark_backup() == ground,
+		"%s: POKECENTER_2F borrows landmark %d, not %d/%d's %d." % [
+			game_id, world.landmark_backup(), group, number, ground,
+		]
+	)
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	r.check(
+		Gen2WorldRadio.is_kanto_landmark(world.landmark_backup(), crystal) \
+			== Gen2WorldRadio.is_kanto_landmark(ground, crystal),
+		"%s: POKECENTER_2F over %d/%d answers the wrong region." % [game_id, group, number]
+	)
+	var down: Dictionary = world.try_warp(POKECENTER_2F_STAIRS)
+	r.check(
+		bool(down.get("ok", false)) and world.map_id() == Vector2i(group, number),
+		"%s: the stairs off POKECENTER_2F reach %s, not %d/%d (%s)." % [
+			game_id, world.map_id(), group, number, down.get("reason", &"no_result"),
+		]
+	)
+
+
+## The three bytes sit in `wCurMapData`, which `SavePlayerData` copies into
+## `sCurMapData`, so a player who saves upstairs comes back down the way they
+## went up. A snapshot written before the field existed carries none, which is
+## a game that has walked through no such warp.
+func _verify_save_round_trip(r: RefCounted, game_id: StringName, data: GameData) -> void:
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, CENTER_GROUP, CENTER_MAP, CENTER_STAIRS, Gen2WorldState.new()
+	)
+	if world == null or not bool(world.try_warp(CENTER_STAIRS).get("ok", false)):
+		r.fail("%s: the walk up the stairs failed before the save." % game_id)
+		return
+	var reopened: Gen2WorldSnapshot = Gen2WorldSnapshot.from_dict(world.snapshot().to_dict())
+	var restored: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(data, reopened)
+	if not r.check(restored != null, "%s: the saved snapshot does not reopen." % game_id):
+		return
+	r.check(
+		restored.backup_warp == world.backup_warp,
+		"%s: a save reopens with backup warp %s, not %s." % [
+			game_id, restored.backup_warp, world.backup_warp,
+		]
+	)
+	r.check(
+		bool(restored.try_warp(POKECENTER_2F_STAIRS).get("ok", false)) \
+			and restored.map_id() == Vector2i(CENTER_GROUP, CENTER_MAP),
+		"%s: a save written on POKECENTER_2F cannot walk back down." % game_id
+	)
+	var older: Dictionary = world.snapshot().to_dict()
+	older.erase("backup_warp")
+	var legacy: Gen2WorldSnapshot = Gen2WorldSnapshot.from_dict(older)
+	r.check(
+		legacy != null and legacy.backup_warp.is_empty(),
+		"%s: a snapshot written before the field reads a backup warp it never had." % game_id
+	)
+
+
+## Every `elevator` command in the corpus, its floor list decoded and its rows
+## checked against the maps they name. `.FindCurrentFloor` matches the backup
+## warp's map, so the list is only usable if every row names a real map, and
+## `Elevator_GoToFloor` copies the row's last three bytes over the backup warp,
+## so every row's warp has to exist on the map it names.
+func _verify_elevators(r: RefCounted, game_id: StringName, data: GameData) -> void:
+	var crystal: bool = game_id == &"crystal"
+	var expected: Array = [
+		CELADON_ELEVATOR,
+		GOLDENROD_ELEVATOR_CRYSTAL if crystal else GOLDENROD_ELEVATOR_GOLD_SILVER,
+	]
+	var found: int = 0
+	for pair: Array in expected:
+		var map: Gen2WorldMap = data.world_map(pair[0], pair[1])
+		if not r.check(map != null, "%s: elevator map %s is missing." % [game_id, pair]):
+			continue
+		var bank: int = int(map.events.get("bank", 0))
+		for row: Dictionary in _elevator_commands(data, map, crystal):
+			found += 1
+			var decoded: Dictionary = Gen2WorldScript.decode_elevator_floors(
+				data.world_script_at(bank, int(row["address"]))
+			)
+			if not r.check(
+				bool(decoded.get("ok", false)),
+				"%s: %s's floor list did not decode (%s)." % [
+					game_id, pair, decoded.get("reason", &"unknown"),
+				]
+			):
+				continue
+			for entry: Dictionary in decoded["floors"]:
+				var floor_map: Gen2WorldMap = data.world_map(
+					int(entry["map_group"]), int(entry["map_number"])
+				)
+				if not r.check(
+					floor_map != null,
+					"%s: %s names map %d/%d, which is not in the cache." % [
+						game_id, pair, int(entry["map_group"]), int(entry["map_number"]),
+					]
+				):
+					continue
+				r.check(
+					int(entry["warp"]) >= 1 \
+						and int(entry["warp"]) <= (floor_map.events.get("warps", []) as Array).size(),
+					"%s: %s names warp %d on map %d/%d, which has %d." % [
+						game_id, pair, int(entry["warp"]),
+						int(entry["map_group"]), int(entry["map_number"]),
+						(floor_map.events.get("warps", []) as Array).size(),
+					]
+				)
+			## The car's own door is a -1 warp, so riding to a floor and walking
+			## out has to land on that floor's own warp.
+			_verify_ride(r, game_id, data, pair, decoded["floors"])
+	r.check(
+		found == expected.size(),
+		"%s: %d elevator commands were reached, not %d." % [game_id, found, expected.size()]
+	)
+
+
+## `Elevator_GoToFloor` then the -1 warp: choosing a floor writes the backup warp
+## and the door spends it, on every floor the list names.
+func _verify_ride(
+	r: RefCounted, game_id: StringName, data: GameData, pair: Array, floors: Array
+) -> void:
+	for entry: Dictionary in floors:
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(
+			data, pair[0], pair[1], Vector2i(1, 3), Gen2WorldState.new()
+		)
+		if world == null:
+			r.fail("%s: elevator map %s does not open." % [game_id, pair])
+			return
+		world.backup_warp = {
+			"warp": int(entry["warp"]),
+			"map_group": int(entry["map_group"]),
+			"map_number": int(entry["map_number"]),
+		}
+		var out: Dictionary = world.try_warp(Vector2i(1, 3))
+		r.check(
+			bool(out.get("ok", false)) \
+				and world.map_id() == Vector2i(int(entry["map_group"]), int(entry["map_number"])),
+			"%s: %s riding to floor %d reaches %s, not %d/%d (%s)." % [
+				game_id, pair, int(entry["floor"]), world.map_id(),
+				int(entry["map_group"]), int(entry["map_number"]),
+				out.get("reason", &"no_result"),
+			]
+		)
+
+
+## Every `elevator` command the map's own event scripts reach, as
+## `{address}` rows.
+func _elevator_commands(data: GameData, map: Gen2WorldMap, crystal: bool) -> Array:
+	var out: Array = []
+	var bank: int = int(map.events.get("bank", 0))
+	for raw: Variant in (map.events.get("bg_events", []) as Array) \
+			+ (map.events.get("objects", []) as Array):
+		var bytes: PackedByteArray = data.world_script(
+			bank, int((raw as Dictionary).get("script", 0))
+		)
+		var at: int = 0
+		while at < bytes.size():
+			var command: Dictionary = Gen2WorldScript.command_at(bytes, at, crystal)
+			if not bool(command.get("ok", false)):
+				break
+			if Gen2WorldScript.command_name(int(command["opcode"]), crystal) == &"elevator":
+				out.append({"address": int(command.get("address", 0))})
+			at += int(command["width"])
+			if Gen2WorldScript.is_terminal(int(command["opcode"]), crystal):
+				break
+	return out

--- a/tools/checks/backup_warp.gd.uid
+++ b/tools/checks/backup_warp.gd.uid
@@ -1,0 +1,1 @@
+uid://b5xtekhtv7u4l

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -602,6 +602,27 @@ func _process(_delta: float) -> bool:
 			if _kind == &"mart_sell":
 				_screen.press_button(Gen2Button.DOWN)
 			_screen.press_button(Gen2Button.A)
+		elif _kind == &"elevator":
+			## The floor panel, read from the cell below it: `bg_event 3, 0`'s
+			## own `elevator` is what opens the floor list. The car has to know
+			## where it is standing first, which is what `warpmod` gives it, so
+			## the map's own script is left to run before the panel is read.
+			## The number is how many DOWN presses to spend on the list.
+			var car: Gen2WorldAPI = _screen.get("_world")
+			var door: Dictionary = (car.current_map.events.get("warps", []) as Array)[0]
+			## `.FindCurrentFloor` matches the backup warp's map, which walking
+			## into the car through its own -1 door is what writes. A preview
+			## opens the map instead of walking to it, so the floor the door
+			## names stands in for the one the player came from.
+			car.backup_warp = {
+				"warp": 1,
+				"map_group": int(door["map_group"]),
+				"map_number": int(door["map_number"]),
+			}
+			_screen.press_button(Gen2Button.UP)
+			_screen.interact()
+			for _press: int in maxi(_cell.x, 0):
+				_screen.press_button(Gen2Button.DOWN)
 		elif _kind == &"warp":
 			## `MapSetupScript_Door` at its whitest: the step onto the warp tile
 			## and then `FadeOutToWhite`'s last order, which is the frame the map

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -25,6 +25,7 @@ const GROUPS: Dictionary = {
 	&"terrain": [
 		&"ledge_hops", &"ice_slides", &"side_walls", &"drawn_blocks", &"story_map_ids",
 		&"map_data",
+		&"backup_warp",
 	],
 	&"johto": [
 		&"radio_tower", &"rising_badge", &"command_queues", &"item_balls",


### PR DESCRIPTION
`SavePlayerData` copies two runs into SRAM, `wPlayerData` and then `wCurMapData`. The three bytes at the centre of the second one were missing here.

## What was broken

A `warp_event` whose destination is `-1` names no warp and no map of its own. `CopyWarpData` reads `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber` contiguously in its place, and the map written beside such a byte is a placeholder: `POKECENTER_2F` names itself. This port read the placeholder, so all six of those warps in either corpus refused with `missing_destination`.

| Map | Warp |
|---|---|
| `POKECENTER_2F` | the stairs down, on every Pokemon Center |
| Goldenrod dept store elevator | both doors |
| Celadon dept store elevator | both doors |
| `FAST_SHIP_1F` | the cabin |

`GetWarpDestCoords`'s `.backup` writes the three bytes on arriving at such a warp, and `Script_warpmod` writes them outright. `warpmod` was decoded here and executed by nothing.

The same three bytes are the landmark a `LANDMARK_SPECIAL` map borrows. `POKECENTER_2F` carries that landmark, so the lookup `RegionCheck`, `IsInJohto`, `FlyMap`, `Pokedex_GetLandmark` and both `TownMap_` routines spell out is reached on every visit to a centre's upstairs, not on six unreachable rooms. It was documented here as unmodellable. The radio, the battle track, the town map, the fly map and the dex area screen all answered with Johto's rows up there whatever region the player was in.

The `elevator` script command staged a request nothing answered. It is not a `special`, so the derived deferred list never counted it.

## What changed

- `Gen2WorldAPI.backup_warp`, written by an arriving `-1` warp and by `warpmod`, read by a departing one. It is in the snapshot, so a slot saved upstairs comes back down the way it went up. No save-format bump: an empty value is what a slot written before it existed truthfully says.
- `Gen2WorldAPI.landmark_backup()`, the borrowed-landmark lookup. Every reader but `InitMapNameSign`, which has no such lookup, goes through it.
- The elevator. Its `elevfloor` list was already inside the cached slice of the script that names it; the routine shows the floor the backup warp names, and choosing another writes the three bytes the door out of the car spends. Cache format 90 carries the one thing it could not do without, `_AskFloorElevatorText`'s stub.

## Proof

`tools/checks/backup_warp.gd`, a new topic in the `terrain` group, sweeps the whole corpus on all three cartridges: which warps name the backup, a walk up and back down two Pokemon Centers, the region each answers, a save round trip, and a ride to every floor of both elevators. Without the fix it reports `missing_destination` on all three.

| Run | Result |
|---|---|
| `validate.gd -- all` | 76 topics, 0 failures |
| GUT, all tiers | 3,788 tests, 0 failures |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no refusals |
| Re-import, three cartridges | `Layout verified.` on each |