### PR TITLE
Finish Randy's Spearow errand and draw a scrolling menu's arrows

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -38,7 +38,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 17 for [the battlers block](#the-battlers), 16 for [the shiny seam](#how-many-times-a-wilds-dvs-are-rolled), [an item gift](#asking-the-host-to-hand-an-item-over) and [reading the bag](#reading-the-bag), 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 18 for [a hidden-item ask that collapses](#hidden-items-a-mod-can-see-and-ask-for) and [a refused annotation being reported](#annotating-the-battle), 17 for [the battlers block](#the-battlers), 16 for [the shiny seam](#how-many-times-a-wilds-dvs-are-rolled), [an item gift](#asking-the-host-to-hand-an-item-over) and [reading the bag](#reading-the-bag), 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -427,7 +427,7 @@ for row in catalog.rows(Gen2WorldCatalog.KIND_STATIC):
 | `KIND_TRADE` | `trade`, `species`, `requested_species` | A `trade` command and the record it names |
 | `KIND_ITEM` | `item`, `quantity`, `hidden` | `giveitem`, `verbosegiveitem`, an `itemball` object and a `hiddenitem` bg event |
 | `KIND_BADGE` | `badge`, `engine_flag` | A `setflag` of a badge's engine flag |
-| `KIND_SHOP` | `mart`, `dialog` | A `pokemart` command |
+| `KIND_SHOP` | `mart`, `dialog`, `items` | A `pokemart` command. `items` is the resolved shelf, `{item, price}` per row, so a mod can move one row of one shop without inventing a mart |
 
 Every row also carries `id`, `kind`, its `bank` and `address` (or its `map` and
 `event_index`), the `map` it stands on where the host could attribute one, and
@@ -1174,6 +1174,12 @@ class Info:
 		return out
 ```
 
+A placement the grid cannot hold is refused rather than clipped, and the refusal
+reaches `Gen2ModHost.failures()` with the mod's id and why (`api_version` 18). A column that grows
+by a row per active stat stage runs off the bottom only when several are up at
+once, so what a player would otherwise see is a row quietly missing. It is
+recorded once per distinct refusal, not once a frame.
+
 A placement is `{"at": Vector2i}` plus one of:
 
 | Key | What it is |
@@ -1451,7 +1457,12 @@ bargain a visible-encounter provider has with a wild battle: the mod names the
 entry, the host runs it.
 
 - An ask for a cell with no record, or one whose flag is already set, does
-  nothing. `CheckBGEventFlag` is the host's test, not the mod's.
+  nothing. `CheckBGEventFlag` is the host's test, not the mod's, and a set flag
+  now drops the ask when it is made rather than when it is spent.
+- An ask for a cell already in the queue is dropped too (`api_version` 18), so a
+  provider may read `hidden_items()` every frame and name what it stands on
+  without keeping its own set of what it has already asked for. The pack-full branch leaves the flag
+  clear and prints its box, and asking again after it is free and correct.
 - One is spent per frame, since the first one's script owns the world until its
   box is pressed past; the rest wait in the queue in order.
 - An ask made inside a battle, a text box, a warp or an overlay is spent when the

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -144,6 +144,22 @@ static func open(game_id: StringName) -> GameData:
 	return open_directory(RomCache.directory_for(game_id, rom_hash))
 
 
+## Opens whichever of the two [param argument] names: a directory
+## [method RomCache.is_usable] accepts is a cache path, and anything else is a
+## [RomRegistry] id. Null when neither resolves.
+##
+## For a tool whose command line carries one string and cannot say which form it
+## is. Which of the two an argument means is a fact about the cache layout and
+## the registry, so it is answered here rather than sniffed by every tool that
+## would otherwise copy it and go stale when the cache naming moves. [member id]
+## is filled off the manifest either way. Named for its argument rather than
+## `open_any`, which already means the first cartridge that has a cache at all.
+static func open_argument(argument: String) -> GameData:
+	if RomCache.is_usable(argument):
+		return open_directory(argument)
+	return open(StringName(argument))
+
+
 ## Opens a cache directory, or null if it is missing, incomplete, or was written
 ## by an importer whose format this build does not read.
 static func open_directory(path: String) -> GameData:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -229,6 +229,9 @@ var _item_gift_requests: Array[Dictionary] = []
 ## while a world is open. A Callable rather than a handle on [Gen2WorldAPI]: a
 ## mod is given the copy and never the world.
 var _inventory_source: Callable = Callable()
+## The open map's `{cell, item, flag, taken}` rows, for the ask that collapses.
+## See [method set_hidden_items_source].
+var _hidden_items_source: Callable = Callable()
 ## Mod id to the visible-encounter provider it registered, held the way an actor
 ## is. See [method register_visible_encounters].
 var _visible_encounters: Dictionary = {}
@@ -262,6 +265,10 @@ var _subscribers: Dictionary = {}
 ## mod happened to load first.
 var _event_mutators: Dictionary = {}
 var _failures: Array = []
+## Which battle-annotation refusals have already reached [member _failures].
+## `battle_info_placements` runs once a frame off a snapshot, so without this
+## one bad placement would append sixty entries a second.
+var _battle_info_reported: Dictionary = {}
 
 
 ## The shared host. Created with the built-in renderers already registered, so a
@@ -359,8 +366,33 @@ func register_world_actor(id: StringName, actor: Object) -> Dictionary:
 ## [method Gen2WorldAPI.hidden_items] and runs the map's own script on the next
 ## world frame it is idle for, so an ask inside a battle, a text box or a warp is
 ## spent when the world can spend it. Which cell to name is the mod's business.
+##
+## An ask for a cell already queued, or one whose `CheckBGEventFlag` is already
+## set, is dropped here rather than at spend time. A provider reading
+## [method Gen2WorldAPI.hidden_items] every frame and naming what it stands on
+## would otherwise queue sixty asks a second for one cell, and would have to keep
+## a private set of what it has already named: a copy of state the host holds. It
+## is dropped and not refused, because the pack-full branch leaves the flag clear
+## and the mod has no way to tell that cell from one it has never asked about, so
+## asking again has to stay free and correct.
 func request_hidden_item(cell: Vector2i) -> void:
+	if _hidden_item_requests.has(cell) or _hidden_item_taken(cell):
+		return
 	_hidden_item_requests.append(cell)
+
+
+## Whether [param cell]'s own event flag is already set on the open map. False
+## with no world open, which is the honest answer for a queue nothing can spend.
+func _hidden_item_taken(cell: Vector2i) -> bool:
+	if not _hidden_items_source.is_valid():
+		return false
+	for raw: Variant in _hidden_items_source.call() as Array:
+		if raw is not Dictionary:
+			continue
+		var record: Dictionary = raw
+		if Vector2i(record.get("cell", Vector2i.ZERO)) == cell:
+			return bool(record.get("taken", false))
+	return false
 
 
 ## Drained by [Gen2WorldScreen], once, on the frame it spends them.
@@ -375,7 +407,13 @@ func take_hidden_item_requests() -> Array[Vector2i]:
 func requeue_hidden_items(cells: Array[Vector2i]) -> void:
 	if cells.is_empty():
 		return
-	_hidden_item_requests = cells + _hidden_item_requests
+	var out: Array[Vector2i] = cells.duplicate()
+	## A mod may have asked again on the frame the drain emptied the queue, so
+	## the merge collapses the same way an ask does.
+	for cell: Vector2i in _hidden_item_requests:
+		if not out.has(cell):
+			out.append(cell)
+	_hidden_item_requests = out
 
 
 ## Asks the world screen to hand [param item] over, [param quantity] of it,
@@ -417,6 +455,13 @@ func requeue_item_gifts(gifts: Array[Dictionary]) -> void:
 ## default: the launcher and every screen that is not the world have no bag.
 func set_inventory_source(source: Callable) -> void:
 	_inventory_source = source
+
+
+## Where [method request_hidden_item] reads the open map's own
+## [method Gen2WorldAPI.hidden_items] from, set the same way and for the same
+## reason: the flag behind a cell is the world's and a mod is given the copy.
+func set_hidden_items_source(source: Callable) -> void:
+	_hidden_items_source = source
 
 
 ## The live world's own `{item: quantity}`, the copy a
@@ -657,6 +702,11 @@ func battle_info_ids() -> Array:
 ## overlapping ownership refused rather than resolved by load order: a cell a
 ## later provider claims after an earlier one is dropped and reported, so which
 ## mod loaded first cannot decide what a player sees.
+##
+## A placement the grid refuses is reported by name too. A provider is a pure
+## function of a snapshot and this runs once a frame, so each distinct refusal
+## is recorded once: repeating it sixty times a second would bury every other
+## failure the launcher lists.
 func battle_info_placements(snapshot: Dictionary) -> Array:
 	var out: Array = []
 	var claimed: Dictionary = {}
@@ -669,9 +719,16 @@ func battle_info_placements(snapshot: Dictionary) -> Array:
 		for raw: Variant in answered as Array:
 			if raw is not Dictionary:
 				continue
-			var placement: Dictionary = Gen2BattleAnnotations.validate(raw as Dictionary)
-			if placement.is_empty():
+			var checked: Dictionary = Gen2BattleAnnotations.validated(raw as Dictionary)
+			if not bool(checked["ok"]):
+				_report_battle_info_refusal(
+					id, &"battle_info_placement_refused",
+					"%s: %s at %s" % [
+						id, checked["reason"], raw.get("at", "no cell"),
+					]
+				)
 				continue
+			var placement: Dictionary = checked["placement"]
 			var cells: Array = Gen2BattleAnnotations.cells(placement)
 			var taken: StringName = &""
 			for cell: Vector2i in cells:
@@ -679,15 +736,24 @@ func battle_info_placements(snapshot: Dictionary) -> Array:
 					taken = StringName(claimed[cell])
 					break
 			if taken != &"":
-				_failures.append({
-					"ok": false, "reason": &"battle_info_cells_taken",
-					"detail": "%s: %s owns %s" % [id, taken, cells[0]], "id": id,
-				})
+				_report_battle_info_refusal(
+					id, &"battle_info_cells_taken",
+					"%s: %s owns %s" % [id, taken, cells[0]]
+				)
 				continue
 			for cell: Vector2i in cells:
 				claimed[cell] = id
 			out.append(placement)
 	return out
+
+
+## One entry per distinct refusal, however many frames it survives.
+func _report_battle_info_refusal(id: StringName, reason: StringName, detail: String) -> void:
+	var key: String = "%s|%s" % [reason, detail]
+	if _battle_info_reported.has(key):
+		return
+	_battle_info_reported[key] = true
+	_failures.append({"ok": false, "reason": reason, "detail": detail, "id": id})
 
 
 ## Registers a battle renderer under [param id]. See
@@ -1764,6 +1830,7 @@ static func _renderer_takes_input(renderer: Node, method: String, event: InputEv
 func discover(root: String = ROOT) -> Array:
 	_manifests = {}
 	_failures = []
+	_battle_info_reported = {}
 	var directory: DirAccess = DirAccess.open(root)
 	if directory == null:
 		return []

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -74,7 +74,7 @@ const FILENAME: String = "mod.json"
 ## same thing at different moments. Carrying both would have meant a renderer
 ## reading one for the opening and the other for the fight, so the fold is the
 ## contract. See [method Gen2BattleScreen.battler_side].
-const API_VERSION: int = 17
+const API_VERSION: int = 18
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -93,6 +93,7 @@ const WORDING: Dictionary = {
 	&"save_provider_missing_methods": "A save provider is missing methods it needs (%s).",
 	&"duplicate_save_provider": "%s registered two save providers.",
 	&"battle_info_cells_taken": "Two mods both annotate the same battle cells (%s).",
+	&"battle_info_placement_refused": "A battle annotation will not fit the screen (%s).",
 	&"invalid_party_menu_entry": "A mod registered a party member row with no id.",
 	&"party_menu_entry_missing_callable": "A party member row has nothing to call: %s.",
 	&"duplicate_party_menu_entry": "Two mods both registered the party member row \"%s\".",

--- a/game/render/battle_annotations.gd
+++ b/game/render/battle_annotations.gd
@@ -56,34 +56,49 @@ static func from_data(data: GameData) -> Gen2BattleAnnotations:
 ## dictionary an API 13 provider already got back.
 ##
 ## Refused rather than clipped: a symbol half off the screen, or a stage summary
-## running through the border, is worse than one the player never sees, and a
-## provider that is told nothing about the refusal would keep sending it.
+## running through the border, is worse than one the player never sees.
 static func validate(placement: Dictionary) -> Dictionary:
+	var checked: Dictionary = validated(placement)
+	return checked["placement"] if bool(checked["ok"]) else {}
+
+
+## The same check with the refusal named, for a caller that has somewhere to
+## report it: `{"ok": bool, "reason": StringName, "placement": Dictionary}`. A
+## provider told nothing about a refusal keeps sending it, and a column that
+## grows with the number of active stat stages runs off the bottom of the screen
+## only when several are up at once, so the news has to reach the mod.
+static func validated(placement: Dictionary) -> Dictionary:
 	var at_value: Variant = placement.get("at", null)
 	if at_value is not Vector2i:
-		return {}
+		return _refused(&"no_cell")
 	var at: Vector2i = at_value
 	if at.x < 0 or at.y < 0 or at.x >= COLUMNS or at.y >= ROWS:
-		return {}
+		return _refused(&"off_grid")
 	var field: bool = bool(placement.get("field", false))
 	var out: Dictionary = {"at": at}
 	if placement.has("tile"):
 		var tile: PackedByteArray = _tile_bytes(placement["tile"])
 		if tile.is_empty():
-			return {}
+			return _refused(&"bad_tile")
 		out["tile"] = tile
 	else:
 		var text: String = String(placement.get("text", ""))
 		if text.is_empty():
-			return {}
+			return _refused(&"empty_text")
 		var codes: PackedByteArray = Gen2Font.fit(text, COLUMNS - at.x, FONT)
 		if codes.is_empty():
-			return {}
+			## `Gen2Font.fit` answers nothing for a string that will not fit the
+			## columns left of the border, which is the running-through case.
+			return _refused(&"text_does_not_fit")
 		out["text"] = text
 		out["width"] = codes.size()
 	if field:
 		out["field"] = true
-	return out
+	return {"ok": true, "reason": &"", "placement": out}
+
+
+static func _refused(reason: StringName) -> Dictionary:
+	return {"ok": false, "reason": reason, "placement": {}}
 
 
 ## Which cells [param placement] occupies, for the ownership check. A validated

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -9,13 +9,18 @@ extends RefCounted
 
 const TILE: int = Gen2Font.TILE
 
-## `charmap.asm`: `"▶"` is $ed, which is what `Place2DMenuCursor` writes.
+## `charmap.asm`: `"▶"` is $ed, which is what `Place2DMenuCursor` writes, and
+## `"▼"` is $ee. `"▲"` is the one code no font strip carries: it sits in the run
+## the battle font owns, so it comes off its own imported tile.
 const CURSOR_CODE: int = 0xED
+const DOWN_ARROW_CODE: int = 0xEE
 
 ## `Textbox` draws with wTextboxFrame, so a menu wears the player's chosen frame.
 var frame_style: int = 0
 
 var font: Gen2Font = null
+## `FontsExtra2_UpArrowGFX`, the single tile `"▲"` is drawn from.
+var _up_arrow: PackedByteArray = PackedByteArray()
 
 
 static func from_data(data: GameData) -> Gen2MenuPage:
@@ -25,6 +30,7 @@ static func from_data(data: GameData) -> Gen2MenuPage:
 	var out := Gen2MenuPage.new()
 	out.font = glyphs
 	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	out._up_arrow = data.tile_indices("up_arrow")
 	return out
 
 
@@ -73,6 +79,26 @@ func draw(
 	if cursor >= 0 and cursor < options.size() and box.has_flag(Gen2MenuBox.STATICMENU_CURSOR):
 		var arrow: Vector2i = box.cursor_position(cursor)
 		font.draw_code(CURSOR_CODE, indices, width, arrow.x * TILE, arrow.y * TILE)
+
+	_scroll_arrows(box, indices, width)
+
+
+## `ScrollingMenu_UpdateDisplay`'s two `Coord2Tile` writes, both onto the box's
+## right-hand border. `▼` is written whenever the flag is set, whatever is left
+## below the window; `▲` waits for `wMenuScrollPosition` to leave zero.
+func _scroll_arrows(box: Gen2MenuBox, indices: PackedByteArray, width: int) -> void:
+	if not box.scrolling_arrows:
+		return
+	font.draw_code(
+		DOWN_ARROW_CODE, indices, width, box.right * TILE, box.bottom * TILE
+	)
+	## A cache imported without the tile leaves the corner empty rather than
+	## drawing a wrong one.
+	if box.scroll <= 0 or _up_arrow.size() < TILE * TILE:
+		return
+	Gen2Font.blit_slot(
+		_up_arrow, TILE, 0, indices, width, box.right * TILE, box.top * TILE
+	)
 
 
 ## The same menu as an image of its frame alone, for a screen that composes

--- a/game/save/save_mail.gd
+++ b/game/save/save_mail.gd
@@ -78,17 +78,45 @@ static func compose(
 	return out
 
 
+## `GivePokeMail`, which copies a script's own bytes into the mail struct and
+## blanks nothing first: the message is whatever the pointer holds, and the
+## author, ID and species are read off the party member rather than the player.
+static func from_script(
+	bytes: PackedByteArray, author_name: String, id: int, held_by: int, mail_item: int
+) -> Gen2SaveMail:
+	var out := Gen2SaveMail.new()
+	var buffer: PackedByteArray = blank_message()
+	for index: int in mini(bytes.size(), BUFFER_LENGTH):
+		buffer[index] = bytes[index]
+	out.message = buffer
+	out.author = author_name.substr(0, AUTHOR_LENGTH)
+	out.author_id = id & 0xFFFF
+	out.species = held_by
+	out.item = mail_item
+	return out
+
+
 ## One of the two lines as text, decoded up to its terminator. `MailGFX_Place
-## Message` prints the whole buffer with one `PlaceString`, and `<NEXT>` is what
-## splits it; this is that split for a caller that wants the halves.
+## Message` prints the whole buffer with one `PlaceString` and `<NEXT>` is what
+## splits it, so the break is found rather than assumed: a script's own mail
+## (`GiftSpearowMail`) writes it behind a fifteen-letter line, where the naming
+## screen's fixed fields put it at `LINE_LENGTH`.
 func line(index: int) -> String:
-	var at: int = index * (LINE_LENGTH + 1)
+	var at: int = 0
+	var wanted: int = index
+	while wanted > 0:
+		if at >= message.size() or message[at] == TERMINATOR:
+			return ""
+		if message[at] == LINE_BREAK:
+			wanted -= 1
+		at += 1
 	var codes := PackedByteArray()
-	for offset: int in LINE_LENGTH:
-		var code: int = message[at + offset] if at + offset < message.size() else TERMINATOR
+	while at < message.size():
+		var code: int = message[at]
 		if code == TERMINATOR or code == LINE_BREAK:
 			break
 		codes.append(code)
+		at += 1
 	return Gen2Text.decode(codes, 0, codes.size())
 
 

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -34,6 +34,14 @@ var column_spacing: int = 0
 ## `w2DMenuCursorOffsets`' high nybble, which is `ROW_STEP` for every menu built
 ## from a header and one for `MoveSelectionScreen`'s own hand-built list.
 var row_step: int = ROW_STEP
+## `SCROLLINGMENU_DISPLAY_ARROWS` and `wMenuScrollPosition`, which
+## `ScrollingMenu_UpdateDisplay` reads together: `▼` at the box's bottom-right
+## whenever the flag is set, and `▲` at its top-right only past the first row.
+## A field of its own rather than a bit in [member flags], because the source's
+## one flags byte is read as `STATICMENU_*` by `VerticalMenu` and as
+## `SCROLLINGMENU_*` by `ScrollingMenu`, and the two sets overlap.
+var scrolling_arrows: bool = false
+var scroll: int = 0
 
 
 

--- a/game/world/world_menu.gd
+++ b/game/world/world_menu.gd
@@ -47,6 +47,10 @@ var box_right: int = YES_NO_RIGHT
 var box_bottom: int = YES_NO_BOTTOM
 ## `Place2DMenuItemStrings`' own column spacing, a `2d` menu's `db spacing`.
 var _spacing: int = 0
+## `SCROLLINGMENU_DISPLAY_ARROWS`. No imported `verticalmenu` header carries it:
+## every `ScrollingMenu` in the game is opened by a routine rather than by a
+## script, and Buena's prize list is the one this runner stages itself.
+var scrolling_arrows: bool = false
 
 
 static func from_input(input: Dictionary) -> Gen2WorldMenu:
@@ -71,6 +75,7 @@ static func from_input(input: Dictionary) -> Gen2WorldMenu:
 	menu.box_top = int(header.get("top", YES_NO_TOP))
 	menu.box_right = int(header.get("right", YES_NO_RIGHT))
 	menu.box_bottom = int(header.get("bottom", YES_NO_BOTTOM))
+	menu.scrolling_arrows = bool(header.get("arrows", false))
 	return menu
 
 
@@ -80,6 +85,7 @@ static func from_input(input: Dictionary) -> Gen2WorldMenu:
 ## here is one column with no spacing.
 func box() -> Gen2MenuBox:
 	var out := Gen2MenuBox.from_coords(box_left, box_top, box_right, box_bottom, flags)
+	out.scrolling_arrows = scrolling_arrows
 	if kind == &"2d":
 		out.columns = maxi(1, columns)
 		out.column_spacing = _spacing

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -23,6 +23,13 @@ const LANDMARK_NATIONAL_PARK: int = 13
 const BUGCONTEST_CAUGHT_MON: int = 0
 const BUGCONTEST_BOXED_MON: int = 1
 const BUGCONTEST_NO_CATCH: int = 2
+## `CheckPokeMail`'s five answers (`constants/script_constants.asm`), which
+## Route 31's Randy branches on once each.
+const POKEMAIL_WRONG_MAIL: int = 0
+const POKEMAIL_CORRECT: int = 1
+const POKEMAIL_REFUSED: int = 2
+const POKEMAIL_NO_MAIL: int = 3
+const POKEMAIL_LAST_MON: int = 4
 ## `HatchEggs`' own `cp TOGEPI`, the one species whose hatch sets an event flag.
 const SPECIES_TOGEPI: int = 0xAF
 const EVENT_TOGEPI_HATCHED: int = 84

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -6491,6 +6491,8 @@ func _show_script_results(results: Array) -> void:
 				_apply_party_happiness(result_event)
 			elif result_event.get("type", &"") == &"party_member_removed":
 				_remove_party_member(result_event)
+			elif result_event.get("type", &"") == &"party_mail_given":
+				_give_party_mail(result_event)
 			elif result_event.get("type", &"") == &"screen_shake_requested":
 				if _effects != null:
 					_effects.start_screen_shake(
@@ -6914,6 +6916,29 @@ func money_window_open() -> bool:
 ## the row the player handed back. An event rather than a runtime request: the
 ## routine writes wScriptVar and runs straight on, and the removal is the same
 ## save write a happiness change is.
+## `GivePokeMail`: the item onto the member's own MON_ITEM and the script's
+## message into its `sPartyMail` row, whose author, ID and species are the
+## member's own. An event rather than a runtime request, for the same reason the
+## removal below is one: the routine answers nothing and runs straight on.
+func _give_party_mail(event: Dictionary) -> void:
+	var save: Gen2SaveData = _embedded_party_save()
+	var slot: int = int(event.get("slot", -1))
+	if save == null or slot < 0 or slot >= save.party.size():
+		return
+	var mon: Gen2SaveMon = save.party[slot] as Gen2SaveMon
+	if mon == null:
+		return
+	var item: int = int(event.get("item", 0))
+	mon.item = item
+	var message := PackedByteArray()
+	for code: Variant in (event.get("message", []) as Array):
+		message.append(int(code) & 0xFF)
+	mon.mail = Gen2SaveMail.from_script(
+		message, mon.original_trainer, int(mon.ot_id),
+		int(event.get("species", mon.species)), item
+	)
+
+
 func _remove_party_member(event: Dictionary) -> void:
 	var save: Gen2SaveData = _embedded_party_save()
 	var slot: int = int(event.get("slot", -1))
@@ -7035,6 +7060,12 @@ func _on_party_selection_made(party_index: int) -> void:
 		_refresh_labels()
 		return
 	var result: Dictionary = {"ok": true, "party_index": -1}
+	## `CheckCurPartyMonFainted` walks `wPartyMon1HP` for every slot but the
+	## chosen one, so the whole column travels with the row that was picked.
+	var party_fainted: Array = []
+	if save != null:
+		for member: Variant in save.party:
+			party_fainted.append(member is Gen2SaveMon and (member as Gen2SaveMon).hp <= 0)
 	if save != null and party_index >= 0 and party_index < save.party.size():
 		var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
 		if mon != null:
@@ -7054,6 +7085,10 @@ func _on_party_selection_made(party_index: int) -> void:
 				"original_trainer": mon.original_trainer,
 				"happiness": int(mon.happiness),
 				"fainted": mon.hp <= 0,
+				## MON_ITEM and the `sPartyMail` row behind it, which
+				## `CheckPokeMail` reads in that order.
+				"item": int(mon.item),
+				"mail_message": Array(mon.mail.message) if mon.mail != null else [],
 				## `ReadCaughtData`'s two bytes, unpacked the way the save keeps
 				## them, plus MON_LEVEL for `SeerAdvice`.
 				"level": int(mon.level),
@@ -7061,6 +7096,7 @@ func _on_party_selection_made(party_index: int) -> void:
 				"caught_time": int(mon.caught_time),
 				"caught_gender": int(mon.caught_gender),
 				"caught_location": int(mon.caught_location),
+				"party_fainted": party_fainted,
 			}
 	_show_script_results(_world.complete_runtime_request(result))
 	_refresh_labels()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -513,6 +513,7 @@ func _build_world() -> void:
 	## here rather than handed the world, so a mod is given the copy and never a
 	## way to write the bag.
 	Gen2ModHost.instance().set_inventory_source(_mod_inventory)
+	Gen2ModHost.instance().set_hidden_items_source(_mod_hidden_items)
 	_encounters.set_world(_world, anim_data)
 	_actors.set_encounters(_encounters)
 	var rods: Array[StringName] = _world.available_fishing_rods()
@@ -7387,6 +7388,12 @@ func _spend_actor_requests() -> void:
 
 func _mod_inventory() -> Dictionary:
 	return _world.state.items() if _world != null else {}
+
+
+## What [method Gen2ModHost.request_hidden_item] collapses an ask against: the
+## open map's own rows, with `taken` already answered off the event flag.
+func _mod_hidden_items() -> Array:
+	return _world.hidden_items() if _world != null else []
 
 
 ## A mod's item-gift asks, spent the way its hidden-item asks are and on the same

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -603,6 +603,7 @@ const PARTY_SELECTION_ROUTINE_OF: Dictionary = {
 const PARTY_SELECTION_REFUSAL_OF: Dictionary = {
 	&"magikarp_length": Gen2WorldPartyHost.MAGIKARPLENGTH_REFUSED,
 	&"return_shuckie": Gen2WorldPartyHost.SHUCKIE_REFUSED,
+	&"check_poke_mail": Gen2WorldPartyHost.POKEMAIL_REFUSED,
 }
 
 ## `CelebiShrineEvent`'s own loop: `ld a, 160` into wFrameCounter and
@@ -2040,8 +2041,10 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 			## routine runs, whether or not the party had room for it.
 			_cur_party_species = int(command.get("pokemon", 0))
 			return _stage_runtime_request(&"pokemon_requested", command)
-		Gen2WorldScript.GIVEPOKEMAIL, Gen2WorldScript.CHECKPOKEMAIL:
-			return _stage_runtime_request(&"mail_requested", command)
+		Gen2WorldScript.GIVEPOKEMAIL:
+			return _give_poke_mail(command)
+		Gen2WorldScript.CHECKPOKEMAIL:
+			return _check_poke_mail(command)
 		Gen2WorldScript.GOLD_FACEPLAYER, Gen2WorldScript.FACEPLAYER:
 			if Gen2WorldScript.is_faceplayer(opcode, _crystal_commands()):
 				pass
@@ -4096,9 +4099,16 @@ func _stage_buena_prize_menu(special: int) -> Dictionary:
 		"type": &"menu",
 		"command": &"buena_prize",
 		"options": rows,
-		## `db 1` for the row the cursor opens on, and `SCROLLINGMENU`'s own B,
-		## which is how the player leaves.
-		"header": {"default": 1, "data_flags": 0},
+		## `.MenuHeader`'s `menu_coords 1, 1, 16, 9` and its `db 4, 13`, then
+		## `db 1` for the row the cursor opens on. `ScrollingMenu` always draws
+		## its own cursor and this list is a row longer than its window, which
+		## is what the flags and the row count stand for here.
+		"header": {
+			"default": 1,
+			"data_flags": Gen2MenuBox.STATICMENU_CURSOR,
+			"left": 1, "top": 1, "right": 16, "bottom": 9,
+			"rows": 4, "arrows": true,
+		},
 		"text": asked,
 		"special": &"buena_prize",
 		"prize_special": special,
@@ -4927,9 +4937,12 @@ func _finish_party_selection(request: Dictionary, result: Dictionary) -> Diction
 		})
 		_pending = {}
 		return advance()
-	if routine in [&"magikarp_length", &"photo_studio", &"return_shuckie", &"poke_seer"]:
+	if routine in [
+		&"magikarp_length", &"photo_studio", &"return_shuckie", &"poke_seer",
+		&"check_poke_mail",
+	]:
 		_pending = {}
-		return _finish_deferred_party_selection(routine, special, result)
+		return _finish_deferred_party_selection(routine, special, result, values)
 	if species == SPECIES_EGG:
 		_script_value = 1
 		_pending = {}
@@ -4956,7 +4969,7 @@ func _finish_party_selection(request: Dictionary, result: Dictionary) -> Diction
 ## the row it answered with. Each writes wScriptVar, and two of them write
 ## something else besides.
 func _finish_deferred_party_selection(
-	routine: StringName, special: int, result: Dictionary
+	routine: StringName, special: int, result: Dictionary, values: Dictionary = {}
 ) -> Dictionary:
 	var species: int = int(result.get("species", 0))
 	match routine:
@@ -5010,6 +5023,8 @@ func _finish_deferred_party_selection(
 			return _stage_internal_text(measure_box, false, {"special": special})
 		&"poke_seer":
 			return _finish_poke_seer(special, result)
+		&"check_poke_mail":
+			return _finish_check_poke_mail(result, values)
 		&"return_shuckie":
 			## Three tests in order and each has its own answer: the species, then
 			## MANIA's ID, then MANIA's OT name. A row that fails any of them is
@@ -5035,6 +5050,114 @@ func _finish_deferred_party_selection(
 			})
 			return advance()
 	return advance()
+
+
+## `Script_givepokemail`, which copies the pointer's `db item` and the
+## `MAIL_MSG_LENGTH` bytes behind it into `wMonMailMessageBuffer`, and
+## `GivePokeMail`, which hangs both on the last party member. Nothing is asked
+## and nothing is answered: the routine writes no wScriptVar and cannot fail, so
+## the write is an event the way a happiness change is.
+##
+## The mail's author, ID and species are the member's own `wPartyMonOTs`,
+## `wPartyMon1ID` and `wCurPartySpecies`, so the screen reads the first two off
+## the row it is writing and the runner carries the third, which the `givepoke`
+## in front of this one left standing.
+func _give_poke_mail(command: Dictionary) -> Dictionary:
+	var bytes: PackedByteArray = _mail_bytes(int(command.get("address", 0)))
+	if bytes.size() < Gen2SaveMail.MESSAGE_LENGTH + 1:
+		return {"ok": false, "reason": &"missing_mail_data", "command": command}
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "command": command}
+	var count: int = int(party.get("count", 0))
+	if count <= 0:
+		return {"ok": false, "reason": &"empty_party", "command": command}
+	_emit_runtime_event(&"party_mail_given", {
+		"slot": count - 1,
+		"item": int(bytes[0]),
+		"message": Array(bytes.slice(1, Gen2SaveMail.MESSAGE_LENGTH + 1)),
+		"species": _cur_party_species,
+	})
+	return {"ok": true}
+
+
+## `Script_checkpokemail`, whose whole body is `CheckPokeMail`: the party list,
+## then the held item, then the message byte for byte. The list is the same
+## staged selection the Seer and the haircut open.
+func _check_poke_mail(command: Dictionary) -> Dictionary:
+	var bytes: PackedByteArray = _mail_bytes(int(command.get("address", 0)))
+	if bytes.is_empty():
+		return {"ok": false, "reason": &"missing_mail_data", "command": command}
+	return _stage_runtime_request(&"party_selection_requested", {
+		"routine": &"check_poke_mail",
+		"expected": Array(bytes),
+	})
+
+
+## The bytes a `givepokemail` or `checkpokemail` points at, in the running
+## script's own bank (`wScriptBank`). Both sit behind the script that names
+## them rather than at a pointer key of their own, which is what
+## [method GameData.world_script_at] reaches.
+func _mail_bytes(address: int) -> PackedByteArray:
+	if data == null:
+		return PackedByteArray()
+	return data.world_script_at(int(_request.get("bank", 0)), address)
+
+
+## `CheckPokeMail` past its `farcall SelectMonFromParty`: the four refusals in
+## the order the routine tests them, and the removal the fifth answer pays for.
+func _finish_check_poke_mail(result: Dictionary, values: Dictionary) -> Dictionary:
+	var slot: int = int(result.get("party_index", -1))
+	if not Gen2HeldItem.is_mail(int(result.get("item", 0))):
+		## `ItemIsMail` on MON_ITEM, which an egg and an empty hand both fail.
+		_script_value = Gen2WorldPartyHost.POKEMAIL_NO_MAIL
+		return advance()
+	var expected: PackedByteArray = _byte_array(values.get("expected", []))
+	var carried: PackedByteArray = _byte_array(result.get("mail_message", []))
+	if not _mail_message_matches(expected, carried):
+		_script_value = Gen2WorldPartyHost.POKEMAIL_WRONG_MAIL
+		return advance()
+	## `CheckCurPartyMonFainted`: carry when every other slot is fainted, so
+	## handing this one over would black the player out. An egg is HP 0 and
+	## counts as fainted here, which is the routine reading `wPartyMon1HP` and
+	## nothing else.
+	var fainted: Array = result.get("party_fainted", [])
+	var healthy_elsewhere: bool = false
+	for index: int in fainted.size():
+		if index != slot and not bool(fainted[index]):
+			healthy_elsewhere = true
+			break
+	if not healthy_elsewhere:
+		_script_value = Gen2WorldPartyHost.POKEMAIL_LAST_MON
+		return advance()
+	_script_value = Gen2WorldPartyHost.POKEMAIL_CORRECT
+	_emit_runtime_event(&"party_member_removed", {
+		"slot": slot,
+		"routine": &"check_poke_mail",
+	})
+	return advance()
+
+
+## The compare loop's own two exits: the expected message's `'@'` ends it as a
+## match, and any other difference inside `MAIL_MSG_LENGTH` bytes does not.
+func _mail_message_matches(expected: PackedByteArray, carried: PackedByteArray) -> bool:
+	for index: int in Gen2SaveMail.MESSAGE_LENGTH:
+		var wanted: int = expected[index] if index < expected.size() else Gen2Text.TERMINATOR
+		if wanted == Gen2Text.TERMINATOR:
+			return true
+		if index >= carried.size() or carried[index] != wanted:
+			return false
+	return true
+
+
+func _byte_array(raw: Variant) -> PackedByteArray:
+	var out := PackedByteArray()
+	if raw is PackedByteArray:
+		return raw as PackedByteArray
+	if raw is Array:
+		for value: Variant in raw as Array:
+			out.append(int(value) & 0xFF)
+	return out
 
 
 ## `ReadCaughtData` and `SeerAction`, which are one reading of the row and then

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -216,6 +216,18 @@ var _mail_party: Gen2PartyScreen = null
 ## `_ChangeBox_MenuHeader`'s `db 4, 0`: four rows of a scrolling list, and where
 ## the window into the fourteen boxes stands.
 const BOX_LIST_ROWS: int = 4
+## The `db rows` byte of every scrolling menu this screen hosts, which is how
+## many of its list a window shows at once. `wMenuScrollPosition` is one value
+## here, the way it is one address on the cartridge: only one of these lists is
+## ever open.
+const SCROLLING_ROWS: Dictionary = {
+	MODE.PC_BOX_LIST: BOX_LIST_ROWS,
+	## `MailboxPC.TopMenuData`, `.PCItemsMenuData` and
+	## `_PlayerDecorationMenu.ScrollingMenuData`.
+	MODE.PC_MAILBOX: 4,
+	MODE.PC_ITEM_LIST: 4,
+	MODE.PC_DECO_LIST: 8,
+}
 var _pc_scroll: int = 0
 ## `wCurBox`, which CHANGE BOX writes and both lists read. It is the save's, so
 ## the box a deposit lands in outlives the machine being switched off.
@@ -2256,14 +2268,29 @@ func _move_cursor(delta: int) -> void:
 	_cursor = wrapi(_cursor + delta, 0, count)
 	if _mode == MODE.PC_ITEM_LIST:
 		_pc_quantity = 1
+	## `ScrollingMenu` keeps the cursor inside its own window and moves the
+	## window under it.
+	var rows: int = _scrolling_rows()
+	if rows > 0:
+		_pc_scroll = clampi(_pc_scroll, _cursor - rows + 1, _cursor)
+		_pc_scroll = clampi(_pc_scroll, 0, maxi(0, count - rows))
 	if _mode == MODE.PC_BOX_LIST:
-		## `ScrollingMenu` keeps the cursor inside its own window and moves the
-		## window under it, and `BillsPC_PrintBoxCountAndCapacity` runs per row
-		## rather than per choice.
-		_pc_scroll = clampi(_pc_scroll, _cursor - BOX_LIST_ROWS + 1, _cursor)
-		_pc_scroll = clampi(_pc_scroll, 0, maxi(0, count - BOX_LIST_ROWS))
+		## `BillsPC_PrintBoxCountAndCapacity` runs per row rather than per
+		## choice.
 		_refresh_box_counts()
 	_render_rows()
+
+
+## How many rows this mode's list shows at once, or zero for a menu that is not
+## a `ScrollingMenu` and draws all of its options.
+func _scrolling_rows() -> int:
+	if _mode == MODE.MENU:
+		## A scripted `verticalmenu` declares as many rows as it has options, so
+		## only a list longer than its own window is one.
+		if _menu == null or _menu.rows >= _menu.options.size():
+			return 0
+		return _menu.rows
+	return int(SCROLLING_ROWS.get(_mode, 0))
 
 
 func _move_direction(direction: Vector2i) -> void:
@@ -2398,12 +2425,6 @@ func _render_rows(override: Array = []) -> void:
 		## One value at a time, the way the dial itself shows it.
 		override = [_choices[clampi(_cursor, 0, _choices.size() - 1)]] if not _choices.is_empty() \
 			else []
-	if _mode == MODE.PC_BOX_LIST and override.is_empty():
-		## The window `ScrollingMenu` draws, and the cursor's place inside it.
-		_render_service_page(
-			_pc_rows.slice(_pc_scroll, _pc_scroll + BOX_LIST_ROWS), _cursor - _pc_scroll
-		)
-		return
 	var values: Array = override if not override.is_empty() else (
 		_choices if _mode == MODE.MENU \
 		else _pc_rows if _mode in [
@@ -2415,6 +2436,15 @@ func _render_rows(override: Array = []) -> void:
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else ["Continue"]
 	)
+	var rows: int = _scrolling_rows()
+	if rows > 0 and override.is_empty():
+		## The window `ScrollingMenu` draws, and the cursor's place inside it.
+		## Clamped here rather than at each way in: a list reopened on a row it
+		## was left on (`wCurMessageIndex`, `wCurBox`) starts scrolled to it.
+		_pc_scroll = clampi(_pc_scroll, _cursor - rows + 1, _cursor)
+		_pc_scroll = clampi(_pc_scroll, 0, maxi(0, values.size() - rows))
+		_render_service_page(values.slice(_pc_scroll, _pc_scroll + rows), _cursor - _pc_scroll)
+		return
 	_render_service_page(values)
 
 
@@ -2442,9 +2472,14 @@ func _render_service_page(values: Array, cursor: int = -1) -> void:
 			labels.append(label)
 		else:
 			labels.append(String(value))
+	## `_PlayerDecorationMenu`'s list reaches row 16 and the routine prints no
+	## box under it, so the category's name is the list's own title row on the
+	## cartridge rather than a speech box the list would be drawn over.
+	var quiet: bool = _mode == MODE.PC_DECO_LIST
 	var image: Image = _mom_bank_image() if _mode == MODE.MOM_BANK \
 		else _dial_image() if _is_dial() else _service_page.render(
-		_title, _summary, labels, _cursor if cursor < 0 else cursor, _status,
+		"" if quiet else _title, "" if quiet else _summary, labels,
+		_cursor if cursor < 0 else cursor, "" if quiet else _status,
 		_service_box(), _service_note()
 	)
 	if image != null:
@@ -2505,9 +2540,13 @@ func _service_box() -> Gen2MenuBox:
 		MODE.MENU:
 			if _menu == null or _menu.kind == &"spinner":
 				return null
-			return _menu.box()
-		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_DECO_LIST:
+			var menu_box: Gen2MenuBox = _menu.box()
+			menu_box.scroll = _pc_scroll
+			return menu_box
+		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES:
 			return _pc_top_box()
+		MODE.PC_DECO_LIST:
+			return _deco_list_box()
 		MODE.ELEVATOR:
 			## `Elevator_MenuHeader`'s `menu_coords 12, 1, 18, 9`.
 			##
@@ -2517,13 +2556,18 @@ func _service_box() -> Gen2MenuBox:
 			## a second row before the first item. A scrolling menu therefore has
 			## no top spacing, and this box's fourth floor sits on its own border
 			## without it.
-			return Gen2MenuBox.from_coords(
+			var elevator_box: Gen2MenuBox = Gen2MenuBox.from_coords(
 				12, 1, 18, 9,
 				Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
 			)
+			elevator_box.scrolling_arrows = true
+			elevator_box.scroll = _elevator_scroll
+			return elevator_box
 		MODE.PC_MAILBOX:
 			## `.TopMenuHeader`'s `menu_coords 8, 1, SCREEN_WIDTH - 2, 10`.
-			return Gen2MenuBox.from_coords(8, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
+			return _scrolling_box(
+				Gen2MenuBox.from_coords(8, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
+			)
 		MODE.PC_MAIL_SUBMENU:
 			## `.SubMenuHeader`'s `menu_coords 0, 0, 13, 9`.
 			return Gen2MenuBox.from_coords(0, 0, 13, 9, Gen2MenuBox.STATICMENU_CURSOR)
@@ -2585,12 +2629,36 @@ func _deco_side_box() -> Gen2MenuBox:
 
 ## `PCItemsMenuData`'s `menu_coords 4, 1, 18, 10`.
 func _pc_item_list_box() -> Gen2MenuBox:
-	return Gen2MenuBox.from_coords(4, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
+	return _scrolling_box(
+		Gen2MenuBox.from_coords(4, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
+	)
+
+
+## `_PlayerDecorationMenu.ScrollingMenuHeader`'s `menu_coords 1, 1, SCREEN_WIDTH
+## - 2, SCREEN_HEIGHT - 2`. The category list above it is a `VerticalMenu` with
+## its own coords, and this list used to be drawn in the PC's top-menu box.
+func _deco_list_box() -> Gen2MenuBox:
+	return _scrolling_box(
+		Gen2MenuBox.from_coords(1, 1, 18, 16, Gen2MenuBox.STATICMENU_CURSOR)
+	)
+
+
+## `SCROLLINGMENU_DISPLAY_ARROWS` and the window this screen's one
+## `wMenuScrollPosition` stands at.
+func _scrolling_box(box: Gen2MenuBox) -> Gen2MenuBox:
+	box.scrolling_arrows = true
+	box.scroll = _pc_scroll
+	return box
 
 
 ## `Kurt_SelectApricorn.MenuHeader`'s `menu_coords 1, 1, 13, 10`.
 func _apricorn_select_box() -> Gen2MenuBox:
-	return Gen2MenuBox.from_coords(1, 1, 13, 10, Gen2MenuBox.STATICMENU_CURSOR)
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		1, 1, 13, 10, Gen2MenuBox.STATICMENU_CURSOR
+	)
+	box.scrolling_arrows = true
+	box.scroll = _apricorns.scroll if _apricorns != null else 0
+	return box
 
 
 ## `Kurt_SelectQuantity.MenuHeader`'s `menu_coords 6, 9, SCREEN_WIDTH - 1, 12`.

--- a/mods/examples/new_content/mod.gd
+++ b/mods/examples/new_content/mod.gd
@@ -347,6 +347,11 @@ class Pet:
 	## And the other half a follower wants: a hidden item under the cell it is
 	## standing on. The mod reads the map and names the cell; taking one is the
 	## HOST's, because it writes the bag, the flag and the save.
+	##
+	## Asked from the read every frame and not remembered: the host drops an ask
+	## for a cell already queued or already taken (`api_version` 18), so a mod
+	## keeping its own set of what it has named would be holding a copy of host
+	## state, and would never retry a cell the pack-full branch left clear.
 	func _pick_up_what_it_walked_over() -> void:
 		if _world == null:
 			return

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 17,
+	"api_version": 18,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 17,
+	"api_version": 18,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_world_mon_specials.gd
+++ b/tests/integration/test_world_mon_specials.gd
@@ -1,6 +1,6 @@
 extends GutTest
 
-## Scene integration for the two specials that open `SelectMonFromParty`:
+## Scene integration for the routines that open `SelectMonFromParty`:
 ## `NameRater` and `MoveDeletion`. Each is its own line through the overworld,
 ## two `YesNoBox`es, the party list, and an ending text.
 ##
@@ -603,3 +603,152 @@ func test_a_balance_window_stands_over_the_map_until_closetext() -> void:
 	assert_true(_world_screen.money_window_open())
 	_world_screen.press_button(Gen2Button.A)
 	assert_false(_world_screen.money_window_open())
+
+
+## `Route35GoldenrodGate`'s `givepokemail GiftSpearowMail` and Route 31's
+## `checkpokemail ReceivedSpearowMailText`, which are one site each in either
+## corpus and the whole of Randy's Spearow errand. Both point at bytes that sit
+## behind the script naming them rather than at a pointer of their own, so the
+## fixture lays them out the same way.
+const MAIL_ITEM: int = 158
+const MAIL_LINE_1: String = "DARK CAVE leads"
+const MAIL_LINE_2: String = "to another road"
+
+
+func _mail_message(first: String, second: String) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.append_array(Gen2Text.encode(first))
+	out.append(Gen2Text.NEXT_LINE)
+	out.append_array(Gen2Text.encode(second))
+	out.append(Gen2Text.TERMINATOR)
+	out.resize(Gen2SaveMail.MESSAGE_LENGTH)
+	return out
+
+
+## `[opcode, pointer, waitbutton, end]` and the operand bytes behind them, at an
+## address inside this script's own cached slice.
+func _write_mail_script(opcode: int, payload: PackedByteArray) -> void:
+	var address: int = Fixture.TUTORIAL_SCRIPT + 5
+	var bytes: Array = [
+		opcode, address & 0xFF, (address >> 8) & 0xFF,
+		Gen2WorldScript.WAITBUTTON,
+		Gen2WorldScript.END,
+	]
+	bytes.append_array(Array(payload))
+	var directory: String = Fixture.directory()
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(directory))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, Fixture.TUTORIAL_SCRIPT)] = bytes
+	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
+
+
+## Trims the development save's party down to its first member, so
+## `CheckCurPartyMonFainted` has nobody left to walk home with.
+func _leave_one_member() -> void:
+	var save: Gen2SaveData = _world_screen.active_save()
+	save.party.resize(1)
+	_world_screen._refresh_party_summary()
+
+
+func _carry_mail(mon: Gen2SaveMon, message: PackedByteArray) -> void:
+	mon.item = MAIL_ITEM
+	mon.mail = Gen2SaveMail.from_script(
+		message, mon.original_trainer, mon.ot_id, mon.species, MAIL_ITEM
+	)
+	_world_screen._refresh_party_summary()
+
+
+func _run_mail_script(opcode: int, payload: PackedByteArray) -> void:
+	_write_mail_script(opcode, payload)
+	await _open_world()
+	_run_script()
+
+
+## `GivePokeMail` hangs the item on the last party member and copies the
+## script's own bytes into its mail row. The author is the member's OT rather
+## than the player's name, which is what `wPartyMonOTs` is.
+func test_givepokemail_writes_the_item_and_the_message_onto_the_last_member() -> void:
+	var message: PackedByteArray = _mail_message(MAIL_LINE_1, MAIL_LINE_2)
+	var payload := PackedByteArray([MAIL_ITEM])
+	payload.append_array(message)
+	await _run_mail_script(Gen2WorldScript.GIVEPOKEMAIL, payload)
+	var save: Gen2SaveData = _world_screen.active_save()
+	var last: Gen2SaveMon = save.party[save.party.size() - 1]
+	assert_eq(last.item, MAIL_ITEM)
+	assert_not_null(last.mail)
+	assert_eq(last.mail.item, MAIL_ITEM)
+	assert_eq(last.mail.author, last.original_trainer)
+	assert_eq(last.mail.author_id, last.ot_id)
+	## The break sits behind a fifteen-letter line here, where the naming screen
+	## would put it at `LINE_LENGTH`: the split is found, not assumed.
+	assert_eq(last.mail.line(0), MAIL_LINE_1)
+	assert_eq(last.mail.line(1), MAIL_LINE_2)
+
+
+## The five `POKEMAIL_*` answers Route 31 branches on, in the order
+## `CheckPokeMail` tests them.
+func test_checkpokemail_answers_refused_when_the_list_is_backed_out_of() -> void:
+	await _run_mail_script(
+		Gen2WorldScript.CHECKPOKEMAIL, _mail_message(MAIL_LINE_1, MAIL_LINE_2)
+	)
+	assert_not_null(_selection_list())
+	_selection_list().handle_button(Gen2Button.B)
+	assert_eq(
+		_world_screen._world._active_script._script_value,
+		Gen2WorldPartyHost.POKEMAIL_REFUSED
+	)
+
+
+func test_checkpokemail_answers_no_mail_for_an_empty_hand() -> void:
+	await _run_mail_script(
+		Gen2WorldScript.CHECKPOKEMAIL, _mail_message(MAIL_LINE_1, MAIL_LINE_2)
+	)
+	_selection_list().handle_button(Gen2Button.A)
+	assert_eq(
+		_world_screen._world._active_script._script_value,
+		Gen2WorldPartyHost.POKEMAIL_NO_MAIL
+	)
+
+
+func test_checkpokemail_answers_wrong_mail_for_another_message() -> void:
+	await _run_mail_script(
+		Gen2WorldScript.CHECKPOKEMAIL, _mail_message(MAIL_LINE_1, MAIL_LINE_2)
+	)
+	_carry_mail(
+		_world_screen.active_save().party[0], _mail_message(MAIL_LINE_1, "somewhere else")
+	)
+	_selection_list().handle_button(Gen2Button.A)
+	assert_eq(
+		_world_screen._world._active_script._script_value,
+		Gen2WorldPartyHost.POKEMAIL_WRONG_MAIL
+	)
+	assert_eq(_world_screen.active_save().party.size(), 2, "nothing is handed over")
+
+
+## `CheckCurPartyMonFainted` is read past the compare, so the right mail on the
+## only member who can still walk is still refused.
+func test_checkpokemail_answers_last_mon_when_no_other_member_can_fight() -> void:
+	var message: PackedByteArray = _mail_message(MAIL_LINE_1, MAIL_LINE_2)
+	await _run_mail_script(Gen2WorldScript.CHECKPOKEMAIL, message)
+	_leave_one_member()
+	_carry_mail(_world_screen.active_save().party[0], message)
+	_selection_list().handle_button(Gen2Button.A)
+	assert_eq(
+		_world_screen._world._active_script._script_value,
+		Gen2WorldPartyHost.POKEMAIL_LAST_MON
+	)
+	assert_eq(_world_screen.active_save().party.size(), 1)
+
+
+func test_checkpokemail_hands_the_member_over_on_the_right_message() -> void:
+	var message: PackedByteArray = _mail_message(MAIL_LINE_1, MAIL_LINE_2)
+	await _run_mail_script(Gen2WorldScript.CHECKPOKEMAIL, message)
+	var save: Gen2SaveData = _world_screen.active_save()
+	var mate: Gen2SaveMon = save.party[1]
+	_carry_mail(save.party[0], message)
+	_selection_list().handle_button(Gen2Button.A)
+	assert_eq(
+		_world_screen._world._active_script._script_value,
+		Gen2WorldPartyHost.POKEMAIL_CORRECT
+	)
+	assert_eq(save.party.size(), 1, "RemoveMonFromPartyOrBox with REMOVE_PARTY")
+	assert_eq(save.party[0], mate, "the slot behind the errand moves up")

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -910,7 +910,10 @@ static func _write_battle_graphics(cache_directory: String, manifest: Dictionary
 		"enemy_hud": [RomLayout.ENEMY_HUD_TILES, 2],
 		"player_hud": [RomLayout.PLAYER_HUD_TILES, 3],
 		"font": [RomLayout.FONT_TILES, 3],
-		"frames": [RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES, 3],
+		## A different index from the font's, so a glyph written over the box's
+		## own border (`ScrollingMenu_UpdateDisplay`'s two arrows) is visible as
+		## something other than the frame it replaces.
+		"frames": [RomLayout.FRAME_COUNT * RomLayout.FRAME_TILES, 2],
 		## The trainer card's own sheets. Flat fills like the rest of these: the
 		## card's layout is what a test checks, and real artwork would say
 		## nothing about it.
@@ -945,7 +948,7 @@ static func _write_battle_graphics(cache_directory: String, manifest: Dictionary
 		"pokegear_sprites": [RomLayout.POKEGEAR_SPRITE_TILES, 3],
 		"dex_nest_icon": [RomLayout.DEX_NEST_ICON_TILES, 3],
 		## `'▲'`, the single tile a scrolling menu draws its own arrow from.
-		"up_arrow": [1, 2],
+		"up_arrow": [1, 3],
 		## `Pokedex_LoadGFX`'s two runs, `UnownFont` and the footprint grid, at
 		## their real lengths so the dex page can address every tile a layout
 		## names. Flat fills like the rest: what a test checks is where each

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -221,6 +221,21 @@ func test_a_missing_cache_does_not_open() -> void:
 	assert_null(GameData.open_directory("user://nothing_here"))
 
 
+## One opener for a tool whose command line carries one string and cannot say
+## which of the two forms it is: a probe handed a cache path used to have it
+## taken as a game id, which opened somebody else's cartridge and read as a
+## failed run rather than a wrong argument.
+func test_one_opener_takes_a_cache_path_or_a_registry_id() -> void:
+	_write_cache()
+	var by_path: GameData = GameData.open_argument(_directory)
+	assert_not_null(by_path)
+	assert_eq(by_path.species_count(), 2)
+	assert_eq(by_path.directory, _directory, "the path form is not re-resolved")
+	## Not a usable cache directory and not a registry id either.
+	assert_null(GameData.open_argument("user://nothing_here"))
+	assert_null(GameData.open_argument("no_such_cartridge"))
+
+
 ## A cache written by an older importer is discarded rather than migrated, which
 ## is what a format bump is for. Written against the version rather than a
 ## number so the next bump does not have to edit this.

--- a/tests/unit/test_menu_page.gd
+++ b/tests/unit/test_menu_page.gd
@@ -198,3 +198,49 @@ func test_a_row_too_wide_for_its_box_is_cut_at_the_border() -> void:
 			_ink_in_tile(indices, Vector2i(column, box.item_position(0).y)),
 			"nothing past the border at column %d" % column
 		)
+
+
+## `ScrollingMenu_UpdateDisplay`'s two arrows, both written over the box's
+## right-hand border: `▼` whenever `SCROLLINGMENU_DISPLAY_ARROWS` is set, and
+## `▲` only past the first row. The frame is already drawn in both corners, so
+## each is read as a corner that differs from the same box without arrows.
+func _arrow_box(scroll: int) -> Gen2MenuBox:
+	var box: Gen2MenuBox = _box()
+	box.scrolling_arrows = true
+	box.scroll = scroll
+	return box
+
+
+func _tile(indices: PackedByteArray, at: Vector2i) -> PackedByteArray:
+	var out := PackedByteArray()
+	for row: int in TILE:
+		var start: int = (at.y * TILE + row) * WIDTH + at.x * TILE
+		out.append_array(indices.slice(start, start + TILE))
+	return out
+
+
+## `[top-right, bottom-right]` for a box drawn with [param scroll], against the
+## same box with no arrows at all.
+func _arrow_corners(scroll: int) -> Array[bool]:
+	var plain: PackedByteArray = _blank()
+	_page.draw(_box(), OPTIONS, 0, plain, WIDTH)
+	var drawn: PackedByteArray = _blank()
+	var box: Gen2MenuBox = _arrow_box(scroll)
+	_page.draw(box, OPTIONS, 0, drawn, WIDTH)
+	return [
+		_tile(drawn, Vector2i(box.right, box.top)) != _tile(plain, Vector2i(box.right, box.top)),
+		_tile(drawn, Vector2i(box.right, box.bottom))
+			!= _tile(plain, Vector2i(box.right, box.bottom)),
+	]
+
+
+func test_the_down_arrow_is_drawn_whatever_the_scroll_is() -> void:
+	var corners: Array[bool] = _arrow_corners(0)
+	assert_true(corners[1], "the down arrow does not wait for rows below the window")
+	assert_false(corners[0], "wMenuScrollPosition is zero, so the up arrow waits")
+
+
+func test_the_up_arrow_waits_for_the_window_to_leave_the_top() -> void:
+	var corners: Array[bool] = _arrow_corners(1)
+	assert_true(corners[0])
+	assert_true(corners[1])

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -461,6 +461,7 @@ func test_every_refusal_reason_the_mod_layer_produces_has_player_wording() -> vo
 		&"duplicate_party_menu_entry", &"party_menu_entry_missing_callable",
 		&"invalid_party_menu_entry", &"duplicate_stats_page",
 		&"stats_page_missing_callable", &"stats_pages_full",
+		&"battle_info_cells_taken", &"battle_info_placement_refused",
 	]:
 		var text: String = Gen2ModRefusal.text({"reason": reason, "detail": "x/y.zip"})
 		assert_false(text.begins_with(String(reason)), "worded: %s" % reason)
@@ -543,3 +544,70 @@ func test_the_last_rows_effects_stay_replaceable() -> void:
 ## open world: the example mod's charm, and nothing else.
 func _charmed_bag() -> Dictionary:
 	return {0x19: 1}
+
+
+## `battle_info_placements` refuses a placement the 20x18 grid cannot hold, and
+## says so: a provider whose column grows by a row per active stat stage runs off
+## the bottom only when several are up at once, and a row quietly missing is what
+## a player sees. Once per distinct refusal, because this runs every frame off a
+## snapshot a provider is a pure function of.
+class _OffGrid:
+	extends RefCounted
+
+	var placements: Array = []
+
+	func annotate_battle(_snapshot: Dictionary) -> Array:
+		return placements
+
+
+func test_a_battle_annotation_the_grid_refuses_is_reported_once() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var provider := _OffGrid.new()
+	provider.placements = [
+		{"at": Vector2i(0, Gen2BattleAnnotations.ROWS), "text": "ATK2"},
+		{"at": Vector2i(0, 0), "text": "OK"},
+	]
+	assert_true(bool(host.register_battle_info(MOD, provider)["ok"]))
+	var before: int = host.failures().size()
+	var drawn: Array = host.battle_info_placements({})
+	assert_eq(drawn.size(), 1, "the placement that fits is still drawn")
+	var failures: Array = host.failures()
+	assert_eq(failures.size(), before + 1)
+	var refusal: Dictionary = failures.back()
+	assert_eq(StringName(refusal["reason"]), &"battle_info_placement_refused")
+	assert_eq(StringName(refusal["id"]), MOD)
+	assert_string_contains(String(refusal["detail"]), "off_grid")
+	## The next frame is the same snapshot and the same answer, and says nothing.
+	host.battle_info_placements({})
+	host.battle_info_placements({})
+	assert_eq(host.failures().size(), before + 1, "one entry, not one a frame")
+
+
+## `request_hidden_item` collapses an ask for a cell already queued and one whose
+## own event flag is already set, so a provider may ask from its own read of
+## `hidden_items()` every frame without keeping a private set of what it has
+## named. A cell left clear by the pack-full branch stays askable.
+func test_a_hidden_item_ask_collapses_on_the_queue_and_on_the_flag() -> void:
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.set_hidden_items_source(Callable(self, "_hidden_item_rows"))
+	for _frame: int in 60:
+		host.request_hidden_item(Vector2i(3, 4))
+		host.request_hidden_item(Vector2i(9, 9))
+	assert_eq(
+		host.take_hidden_item_requests(), [Vector2i(3, 4)] as Array[Vector2i],
+		"the taken cell is dropped and the other queued once"
+	)
+	## What a drain could not spend goes back without doubling a cell the mod
+	## asked for again on the frame the queue was empty.
+	host.request_hidden_item(Vector2i(3, 4))
+	host.requeue_hidden_items([Vector2i(3, 4)] as Array[Vector2i])
+	assert_eq(host.take_hidden_item_requests(), [Vector2i(3, 4)] as Array[Vector2i])
+
+
+## `(9, 9)` has been picked up; `(3, 4)` has not, which is also what the
+## pack-full branch leaves behind.
+func _hidden_item_rows() -> Array:
+	return [
+		{"cell": Vector2i(3, 4), "item": 1, "flag": 10, "taken": false},
+		{"cell": Vector2i(9, 9), "item": 2, "flag": 11, "taken": true},
+	]

--- a/tools/checks/mail.gd
+++ b/tools/checks/mail.gd
@@ -65,6 +65,16 @@ const SAMPLE_LINE_1: String = "AAAABBBBCCCCDDDD"
 const SAMPLE_LINE_2: String = "QRSTUV"
 const SAMPLE_AUTHOR: String = "GOLD"
 
+## Randy's Spearow errand, which is every `givepokemail` and `checkpokemail` in
+## either corpus: `Route35GoldenrodGate` hands KENYA over carrying
+## `GiftSpearowMail` and Route 31's own man reads `ReceivedSpearowMailText`
+## back. Both operands are `db` bytes behind the script that names them rather
+## than pointers of their own, and the errand only finishes if the two messages
+## are the same bytes.
+const ERRAND_ITEM: int = 158
+const ERRAND_BREAK: String = "<NEXT>"
+const ERRAND_MESSAGE: String = "DARK CAVE leads" + ERRAND_BREAK + "to another road"
+
 var _blocks: Dictionary = {}
 var _palettes: Dictionary = {}
 var _items: Dictionary = {}
@@ -77,8 +87,72 @@ func run(r: RefCounted) -> void:
 		_verify_keyboards()
 		_verify_palettes()
 		_verify_pages()
+		_verify_errand()
 	)
 	_verify_identical()
+
+
+## Every `givepokemail` and `checkpokemail` on this cartridge, decoded out of
+## the cached scripts and read the way [Gen2WorldScriptRunner] reads them.
+func _verify_errand() -> void:
+	var found: Dictionary = {}
+	for raw_key: Variant in _r.data.world_script_keys():
+		var parts: PackedStringArray = String(raw_key).split(":")
+		if parts.size() != 2:
+			continue
+		var bank: int = int(parts[0])
+		var bytes: PackedByteArray = _r.data.world_script(
+			bank, ("0x%s" % parts[1]).hex_to_int()
+		)
+		var offset: int = 0
+		while offset < bytes.size():
+			var command: Dictionary = Gen2WorldScript.command_at(bytes, offset, _r.crystal)
+			if not bool(command.get("ok", false)):
+				break
+			var opcode: int = int(command["opcode"])
+			if opcode == Gen2WorldScript.GIVEPOKEMAIL 				or opcode == Gen2WorldScript.CHECKPOKEMAIL:
+				var payload: PackedByteArray = _r.data.world_script_at(
+					bank, int(command["address"])
+				)
+				found[String(command["name"])] = _errand_message(payload, opcode)
+			if not Gen2WorldScript.continues_after(opcode, _r.crystal):
+				break
+			offset += int(command["width"])
+	for name: String in ["givepokemail", "checkpokemail"]:
+		_r.check(found.has(name), "no %s is reachable in either corpus." % name)
+	for name: Variant in found:
+		_r.check(
+			String(found[name]) == ERRAND_MESSAGE,
+			"%s carries \"%s\", not \"%s\"." % [name, found[name], ERRAND_MESSAGE]
+		)
+	_r.note("Randy's errand: %d mail pointers, %s." % [
+		found.size(), ERRAND_MESSAGE.replace(ERRAND_BREAK, " / ")
+	])
+
+
+## The message half of one operand, decoded with `<NEXT>` kept: `givepokemail`
+## opens on `db item` and `checkpokemail` on the message itself.
+func _errand_message(payload: PackedByteArray, opcode: int) -> String:
+	var at: int = 0
+	if opcode == Gen2WorldScript.GIVEPOKEMAIL:
+		if payload.is_empty():
+			return ""
+		_r.check(
+			int(payload[0]) == ERRAND_ITEM,
+			"givepokemail hands over item %d, not FLOWER_MAIL." % int(payload[0])
+		)
+		at = 1
+	var out: String = ""
+	for index: int in Gen2SaveMail.MESSAGE_LENGTH:
+		if at + index >= payload.size():
+			break
+		var code: int = payload[at + index]
+		if code == Gen2Text.TERMINATOR:
+			return out
+		out += ERRAND_BREAK if code == Gen2Text.NEXT_LINE \
+			else Gen2Text.decode(PackedByteArray([code]), 0, 1)
+	_r.check(false, "a mail operand runs past MAIL_MSG_LENGTH with no terminator.")
+	return out
 
 
 ## `MailItems` against the number list `ItemIsMail`'s only caller here reads.


### PR DESCRIPTION
`givepokemail` and `checkpokemail` staged a runtime request that nothing answered, so Randy's Spearow errand stopped on the world screen's acknowledge prompt and the script never resumed. There is one site of each in either corpus. Both operands are `db` bytes sitting behind the script that names them rather than pointers of their own, so `GameData.world_script_at` is what reaches them.

- `GivePokeMail` answers nothing and cannot fail, so the write is an event, beside the happiness change and `ReturnShuckie`'s removal. The mail's author, ID and species are `wPartyMonOTs`, `wPartyMon1ID` and `wCurPartySpecies`, so the member wears its own OT rather than the player's name.
- `CheckPokeMail` is `SelectMonFromParty` and four refusals before the fifth answer, so it is staged as a party selection the way the Seer and the haircut are. `CheckCurPartyMonFainted` walks every slot but the chosen one, and the whole column has to be read when the row is picked rather than when the script was dispatched, so the selection result carries it.
- A script's own mail puts `<NEXT>` behind a fifteen-letter line, where the naming screen's fixed fields put it at `MAIL_LINE_LENGTH`. `Gen2SaveMail.line` assumed the second and read the gift's second line off by one; it finds the break now, the way `MailGFX_PlaceMessage` does.

`tools/checks/mail.gd` grew an errand topic that decodes both commands out of the cached scripts on all three cartridges and checks the gift's `db FLOWER_MAIL` and that the two messages are the same bytes, which they have to be or the errand cannot be finished.

`SCROLLINGMENU_DISPLAY_ARROWS` drew nothing outside the mart. It draws in `Gen2MenuPage` now, once: `▼` on the box's bottom-right border whenever the flag is set, `▲` on the top-right once `wMenuScrollPosition` leaves zero. `Gen2MenuBox` carries both as fields of their own rather than as bits of `flags`, because the cartridge's one flags byte is read as `STATICMENU_*` by `VerticalMenu` and as `SCROLLINGMENU_*` by `ScrollingMenu` and the two sets overlap.

Wiring every header that carries the flag found three more defects:

- The mailbox, the PC's item list and the decoration list drew every row with no window at all, so a list longer than its box ran through the frame. One `wMenuScrollPosition` serves them the way one address does on the cartridge, and the change box, which has no arrows in the source, joined it.
- Buena's prize list is staged by the runner rather than imported and carried `data_flags: 0`, so five prizes were drawn in a four-row box with no cursor at all.
- The decoration list was drawn in the Pokemon Center PC's top-menu box. `_PlayerDecorationMenu.ScrollingMenuHeader` is `menu_coords 1, 1, SCREEN_WIDTH - 2, SCREEN_HEIGHT - 2` and prints no box under it, which is why the category name is not a speech box there.

Full GUT tier 3796 tests green, `validate.gd -- all` 76 topics green, `replay_world` 33 routes and 0 failures, the three-profile story walk with no refusal.

---

## The four seams the mods repository asked for

`api_version` is 18; the two shipped example mods declare it.

**One opener that takes either form.** `GameData.open(game_id)` and `open_directory(path)` are two openers for one question and nothing on a tool's command line says which it was handed, so a probe given a cache path opened somebody else's cartridge and read as a failed run rather than a wrong argument. `GameData.open_argument(argument)` sniffs it once, here, where the cache layout and the registry both live. It is **not** called `open_any`: that name is taken and means the first cartridge with a cache at all, which is a different question and one a tool also asks.

**A refused battle annotation says so.** `Gen2BattleAnnotations.validate` answered `{}` for five different reasons and told nobody, which is how a column growing a row per active stat stage lost rows off the bottom of the screen with no error on either side. `validated()` names the reason and `validate()` is a wrapper on it, so there is still one body; `battle_info_placements` reports the refusal through `failures()` with the mod's id, the reason and the cell. Once per distinct refusal, not once a frame: the overlap refusal standing beside it had the same bug and now shares the guard.

**`request_hidden_item` collapses** a cell already in the queue and one whose event flag is already set, at insert time. The flag is read through a `set_hidden_items_source` callable the world screen binds, the way the bag already is, so the host still hands a mod the copy and never the world. `requeue_hidden_items` merges rather than concatenates, for the ask a mod makes on the frame the drain emptied the queue. The shipped follower asks from its own read every frame and remembers nothing, which is the point: the pack-full branch leaves the flag clear and asking again has to stay free.

**`docs/MODS.md`'s `KIND_SHOP` row** now names `items`, the resolved `{item, price}` shelf.

Full GUT tier 3799 tests green, `validate.gd -- all` 76 topics green, boot with `--mods` clean.
