### PR TITLE
Cut the documentation down to what a reader needs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,5 @@ Write "not source-derived" for tooling, docs, launcher or export work.
 
 - [ ] No ROM-derived, generated, cache or local-only file is staged
 - [ ] `git diff --cached --check` is clean
-- [ ] `HANDOFF.md` updated if deliberate behavior, scaffolding or known breaks changed
-- [ ] Defects met along the way are fixed here or recorded in `HANDOFF.md` open work
+- [ ] Defects met along the way are fixed here
 - [ ] Docs updated if a contract in `docs/` changed

--- a/README.md
+++ b/README.md
@@ -33,42 +33,30 @@ Inspired by [gen1recomp](https://github.com/bryanthaboi/gen1recomp).
 >   blackout recovery, object lifecycle, followers, block edits, emotes, surf,
 >   ledge hops, grass, fishing, roaming, repel and wild encounters, plus the
 >   service overlay (marts, Kurt's errand, phone dispatch, music and cries).
->   Everything the overworld times is a hardware frame count spent by one clock,
->   so a seed, an input log and a frame number reproduce a walk exactly.
-> - **A screen that fills the window.** The map is drawn past the Game Boy's
->   160x144 to whatever shape the window is, with the connected maps around it
->   drawn seamlessly and no black bars. Zoom out far enough and a region is on
->   screen at once. See [Screen fill](#screen-fill).
+>   Everything is counted in hardware frames spent by one clock, so a seed, an
+>   input log and a frame number reproduce a walk exactly.
+> - **A screen that fills the window.** The map is drawn past 160x144 to whatever
+>   shape the window is, with the connected maps around it and no black bars.
+>   See [Screen fill](#screen-fill).
 > - **Saves.** Three slots, `.sav` import, and a 14-box PC with 20 slots a box.
 >   Every party transaction commits through a validated candidate save.
 > - **Mods.** A mod under `user://mods/` can add or rebalance content, register
 >   move effects, watch the world and battle event channels, add menu entries and
->   controls, and replace the world or battle renderer, which is what a 3D or HD
->   view needs.
+>   controls, and replace the world or battle renderer.
+> - **The story.** All three cartridges walk from Elm's lab to Red on Mt. Silver:
+>   every Johto badge and its errand, then Kanto, all sixteen badges, the Hall of
+>   Fame with Prof Oak's rating, and the credits.
+> - **The Battle Tower.** A full seven-trainer challenge: the room list, the
+>   party rules, the sampled opponents, the save between battles and the prize.
+> - **The Cable Club and Mystery Gift.** There is no cable on a modern machine,
+>   so the second player is your own other save file. The three receptionists,
+>   the Trade Center, the Colosseum's link battle, the link record, and Mystery
+>   Gift's five gifts a day all work between two of your saves. With one save
+>   file you are told your friend is not ready, which is what one Game Boy has
+>   always been told.
 >
-> The story preview walks all three cartridges from Elm's lab to Red on Mt.
-> Silver: every Johto badge with the errand behind it, then Kanto, all sixteen
-> badges, the Hall of Fame with Prof Oak's rating, and the credits.
->
-> The Battle Tower is a full seven-trainer challenge: the room list, the party
-> rules, the sampled opponents with their own lines, the save between battles and
-> the prize at the end.
->
-> The Cable Club is open. There is no cable on a modern machine, so the second
-> player is your own other save file: the three receptionists, the Trade Center's
-> two-list trade screen with the swap and the trade evolution behind it, the
-> Colosseum's link battle, and the link record on the sign between them. With one
-> save file the receptionist says your friend is not ready, which is what a
-> single Game Boy has always been told.
->
-> Mystery Gift works the same way. Carrie in GOLDENROD DEPT. STORE 5F unlocks
-> it, the row then appears beside a save slot, and the infrared partner is your
-> other save file: five gifts a day, one per person, and the officer on the
-> POKEMON CENTER's second floor hands over whatever arrived. With one save file
-> the exchange times out, which is what one Game Boy has always seen.
->
-> Missing: the trade animation, and a handful of pixel-level divergences still
-> being chased in the opening movies and title screen against a real cartridge.
+> Missing: the trade animation, and some pixel-level divergences in the opening
+> movies and title screen.
 
 ## Getting started
 
@@ -136,34 +124,33 @@ godot --headless --path . --quit-after 30
 
 The launcher is a shelf of three cartridges. An unimported bay is drawn in the
 cartridge's own outline: drop a dump on it, or click to browse. Mods, settings
-and about are in the dock underneath. It has a light and a dark appearance and
-the same layout works on a phone.
+and about are in the dock underneath. Light and dark, and the same layout works
+on a phone.
 
 Play opens the save screen: validated slots, naming, export and import, `.sav`
 import, party inspection, and a save editor that cannot produce a save the game
 will not load. A new game opens on the cartridge's own splash, GameFreak
 animation, intro movie and title screen, then the gender question and Oak's
-speech. Continue enters the overworld, where the start menu's SAVE writes its
-map, inventory, event and clock snapshot. See [docs/SAVES.md](docs/SAVES.md).
+speech. Continue enters the overworld. See [docs/SAVES.md](docs/SAVES.md).
 
-The start menu wires every source entry: Pokedex, Pokemon, Pack, Pokegear,
-Player, Save, Options and Exit. Options is the cartridge's own seven-row OPTION
-screen over the same values the launcher's settings edit, so the two cannot
-disagree. Pokedex has the three source orderings, type search and the
-`<MON>'S NEST` area map. Pokegear draws all four of its cards on the hardware
-tile grid, clock, map, phone and radio, each with its own dial, list and mode
-arrow, and a tuned station keeps playing after it closes, which is how the Poke
-Flute channel wakes Vermilion's Snorlax. Pack opens each item's own submenu: USE,
-GIVE, TOSS and SEL, which registers an item to the SELECT button and uses it
-from the map. The party submenu offers all eight field moves to a Pokemon that
-knows one, and ITEM gives or takes what it holds.
+The start menu wires every source entry:
+
+| Entry | What is there |
+|---|---|
+| Pokedex | The three source orderings, type search and the `<MON>'S NEST` area map |
+| Pokemon | The party, its submenu, all eight field moves, and ITEM to give or take |
+| Pack | Each item's own submenu: USE, GIVE, TOSS and SEL, which binds an item to SELECT |
+| Pokegear | Clock, map, phone and radio on the hardware tile grid. A tuned station keeps playing after it closes, which is how the Poke Flute channel wakes Vermilion's Snorlax |
+| Player, Save, Exit | The trainer card, the map/inventory/event/clock snapshot, and the way out |
+| Options | The cartridge's seven-row OPTION screen over the same values the launcher's settings edit |
 
 Facing something and pressing A is the other way to every field move: a cut
 tree, a whirlpool, a waterfall, a headbutt tree and open water each offer their
 move in the cartridge's own order and words. Fruit trees bear once a day, Poke
-Balls and hidden items are picked up by facing them, and the imported Players
-House PC opens the item PC, while a Pokemon Center's opens BILL'S PC beside it. Walking into a new area raises Crystal's own map name
-sign for sixty frames, which Gold and Silver never had.
+Balls and hidden items are picked up by facing them, and the Players House PC
+opens the item PC while a Pokemon Center's opens BILL'S PC. Walking into a new
+area raises Crystal's map name sign for sixty frames, which Gold and Silver
+never had.
 
 Icons come from [Lucide](https://lucide.dev). See
 [docs/THIRD_PARTY.md](docs/THIRD_PARTY.md).
@@ -197,28 +184,26 @@ orientation.
 ### Screen fill
 
 A window is not the Game Boy's 10:9, and the black bars around a framed screen
-are room the overworld can draw into. Settings > Application > Screen offers
-two answers:
+are room the overworld can draw into. Settings > Application > Screen:
 
 | Screen | What it draws |
 |---|---|
 | Fill (default) | The map covers the whole window at any shape, and the maps connected to this one are drawn around it |
 | Framed | The 160x144 screen at a whole scale, centred, with black bars, as the hardware had |
 
-Everything laid out on the screen -- text boxes, menus, the start menu, the
-cursor -- stays inside the 160x144 rectangle in the middle of it, exactly where
-the cartridge put it. Only the surround grows.
+Everything laid out on the screen (text boxes, menus, the start menu, the
+cursor) stays inside the 160x144 rectangle in the middle of it, where the
+cartridge put it. Only the surround grows.
 
 While walking, `+` and `-` zoom, `0` returns to the fitting scale, and the mouse
-wheel does the same. Those keys count screen pixels per Game Boy pixel, so a mod
-drawing the world in 3D keeps them for its own camera and the game leaves them
-alone. Zooming out past one screen pixel per map pixel is a survey
-of the region: the connection graph places the maps around this one and the map
-header's own border block fills what no map covers. The maps around you are a
-picture. Their people stand where their map puts them and nothing else about
-them runs: no scripts, no walking, no wild encounters, no collision. Only the map
-you are on is live, exactly as on the cartridge, where a connected map is three
-blocks of scenery copied into the buffer and nothing more.
+wheel does the same. They count screen pixels per Game Boy pixel, so a mod
+drawing the world in 3D keeps them for its own camera.
+
+Zoom out far enough and a region is on screen at once: the connection graph
+places the maps around this one and the border block fills what no map covers.
+Those maps are a picture. Their people stand where their map puts them and
+nothing else runs: no scripts, no walking, no wild encounters, no collision.
+Only the map you are on is live, exactly as on the cartridge.
 
 ### Game speed, window and frame rate
 
@@ -230,16 +215,14 @@ Settings > Application carries three more that reach the engine:
 | Window | Windowed, fullscreen or borderless |
 | Frame rate | 30, 60, 120, 144 or uncapped |
 
-**Sound is deliberately outside game speed.** The driver is fed by the audio
+Sound is deliberately outside game speed. The driver is fed by the audio
 output's own demand rather than by a game frame, so music, effects and cries keep
-the cartridge's tempo and pitch at every setting; only how often the game asks
-for one changes.
+the cartridge's tempo and pitch at every setting.
 
 Development shortcuts are debug-build only, along with the map and cell readout.
-That readout carries the frame rate beside the cell: `fps` is host frames drawn,
-`hw` the hardware frames the pump actually spent, which is 59.7 a second on a
-machine keeping up, and `worst` the longest single frame of the last second,
-which is where a stutter shows and an average hides it.
+That readout carries `fps` (host frames drawn), `hw` (hardware frames the pump
+spent, 59.7 a second when keeping up) and `worst` (the longest single frame of
+the last second, where a stutter shows and an average hides it).
 
 | Scene | Keys |
 |---|---|
@@ -347,31 +330,26 @@ not compiled extensions. The project is therefore GDScript-first. See
 
 ## Reporting a bug
 
-The launcher's About page has a **Report a bug** button with both routes on it.
-Either works:
+The launcher's About page has a **Report a bug** button. Either route works:
 
-- [Open an issue](https://github.com/Decryptu/pokerecomp/issues/new), if you use
-  an issue tracker.
-- [Ask on Discord](https://discord.gg/twkrHkHprk), if you would rather not.
+- [Open an issue](https://github.com/Decryptu/pokerecomp/issues/new)
+- [Ask on Discord](https://discord.gg/twkrHkHprk)
 
 Say which cartridge, where you were and what you did. A screenshot settles most
 of it.
 
-The sheet behind that button also has **Save a report file**, which writes one
-`.zip` to your downloads folder and opens the folder on it. It holds the build,
-your machine, your settings, the mods you have installed and the last few
-session logs, and nothing else: no save data and no other file from your
-computer. **Copy the details** puts the same thing without the logs on the
-clipboard, which is the version that fits in a chat message. Attach the file if
-the game crashed or looked wrong; it is the difference between a report someone
-can act on and one nobody can reproduce.
+The same sheet has **Save a report file**, which writes one `.zip` to your
+downloads folder. It holds the build, your machine, your settings, your installed
+mods and the last few session logs, and nothing else: no save data, no other file
+from your computer. **Copy the details** is the same thing without the logs, for
+a chat message. Attach the file if the game crashed or looked wrong.
 
-The launcher says so at the next launch when a session did not shut down
-cleanly. Logs live under `logs/` in the same directory as your saves:
+The launcher tells you at the next launch when a session did not shut down
+cleanly. Logs live under `logs/` beside your saves:
 `%APPDATA%\Godot\app_userdata\pokerecomp` on Windows,
 `~/Library/Application Support/Godot/app_userdata/pokerecomp` on macOS,
 `~/.local/share/godot/app_userdata/pokerecomp` on Linux. Old ones are deleted as
-new ones arrive, so they never grow without bound.
+new ones arrive.
 
 ## Contributing
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 Read [the README](../README.md) first. This file holds the rules and the traps.
 It does not describe the architecture: every source finding, constant and
-contract lives next to the code that enforces it, and a second copy here would
-only go stale.
+contract lives next to the code that enforces it.
 
 ## Keep cartridge data out
 
@@ -34,7 +33,7 @@ tools still read it with `FileAccess`. Do not delete it.
 | `audio/` | The cartridge's own driver over an emulated APU |
 | `autoload/diagnostics.gd` | The log sink, the crash marker and the report bundle |
 
-Four boundaries are load-bearing and not obvious from one file:
+Five boundaries are load-bearing and not obvious from one file:
 
 - **Raw byte runs never go into JSON.** A decimal array costs ~4 bytes on disk
   and ~26 resident per cartridge byte. Use `RomCache.write_payload_map()` or
@@ -46,12 +45,10 @@ Four boundaries are load-bearing and not obvious from one file:
   takes `handle_button(button)`, so a test presses a button, not a key.
 - **Anything printed is already in the bug report.** `Gen2Diagnostics` installs
   a [Logger] with `OS.add_logger`, so every `print`, `push_warning`,
-  `push_error` and runtime error, in the game, a tool or a mod, reaches the
-  session log and the report a player attaches to an issue. Never add a second
-  reporting path beside a message; add the message. `Gen2Diagnostics.note()` is
-  the same print with a topic on it, for a fact a reader of the log needs, and
-  `trace()` is the one for a breadcrumb, which is kept out of a check or a tool
-  run so its output stays readable.
+  `push_error` and runtime error reaches the session log and the report a player
+  attaches to an issue. Never add a second reporting path beside a message; add
+  the message. `Gen2Diagnostics.note()` is the same print with a topic on it;
+  `trace()` is for a breadcrumb and is kept out of check and tool runs.
 - **Reach an autoload by its static accessor**, `Gen2InputRuntime.instance()` or
   `Gen2GameRuntime.instance()`, never the `InputRuntime`/`GameRuntime` global. A
   script handed to `-s` compiles before the tree exists, so naming one by
@@ -108,10 +105,10 @@ An optional `<method> <times> [int arg]` drives a scene before capture. Keep
 state changes as callable methods, not only input branches, so screens stay
 inspectable without a key press.
 
-`tools/record_clip.gd` is the moving picture the screenshot is a still of: one
-overworld clip to a video, mods and all, for a trailer rather than for a check.
-Godot's Movie Maker pins the frame delta, so the world spends exactly one
-hardware frame per recorded frame and the same arguments give the same clip:
+`tools/record_clip.gd` records one overworld clip to video, mods and all, for a
+trailer rather than for a check. Godot's Movie Maker pins the frame delta, so the
+world spends exactly one hardware frame per recorded frame and the same arguments
+give the same clip:
 
 ```bash
 godot --path . --mods --write-movie /tmp/clip.avi --fixed-fps 60 \
@@ -123,8 +120,8 @@ and its `probe=` modes answer where a walk may go and what a seed puts on the
 map before a clip is shot. The header has the options and the ffmpeg line.
 
 `tools/profile.gd` answers what a drawn frame costs, per screen, in
-milliseconds. It needs a window too, and it turns the frame cap and the vertical
-sync off so the number is the work rather than the monitor:
+milliseconds. It needs a window, and turns the frame cap and vsync off so the
+number is the work rather than the monitor:
 
 ```bash
 godot --path . -s res://tools/profile.gd -- all crystal 600
@@ -132,49 +129,42 @@ godot --path . -s res://tools/profile.gd -- all crystal 600
 
 Each subject is driven by counted hardware frames with the screen's own
 `_process` off, so a row is comparable between two runs on one machine. Between
-machines only the ratio carries; a subject over 16.7 ms on the machine measuring
-it cannot hold sixty anywhere.
+machines only the ratio carries.
 
 The GDScript analyzer runs only inside the editor: no CLI mode prints its
-warnings, `--check-only` suppresses them, and file logging records the running
-game rather than the editor. There are two ways to read it and they answer
-different questions. The tree stays at zero entries either way.
+warnings and `--check-only` suppresses them. Two ways to read it, both required
+to stay at zero.
 
 ```bash
 Godot --headless --editor --path . -- --warning-scan [path ...]
 ```
 
-`addons/warning_scan` opens each named script in the editor's own script editor
-and prints what the analyser says, as `file:line CODE message`, then a tally and
-how many scripts it analysed; it exits 1 when there were any. Paths may be files
-or directories, `res://` or `user://`, and default to the project's script trees.
-Because the paths are explicit and the count is printed, silence means clean
-rather than unread, which is what the panel alone could never say. It reports the
-first warning per script: fix it, run again, and the next one appears. Without
-the flag the plugin does nothing, so an ordinary editor session is untouched.
+`addons/warning_scan` opens each named script in the editor's script editor and
+prints `file:line CODE message`, then a tally and how many scripts it analysed;
+it exits 1 when there were any. Paths may be files or directories, `res://` or
+`user://`, and default to the project's script trees. It reports the first
+warning per script: fix it, run again, and the next appears. Without the flag the
+plugin does nothing.
 
-`tools/dump_editor_errors.gd` is the other half, run from Editor > File > Run:
-it writes the Debugger panel's whole list to `user://editor_errors.txt`, engine
-errors included, and is where a running game's warnings arrive, which is how a
-mod's `user://` scripts are seen. The panel holds what the session has analysed,
-so reload the project first for a full sweep.
+`tools/dump_editor_errors.gd` is the other half, run from Editor > File > Run.
+It writes the Debugger panel's whole list to `user://editor_errors.txt`, engine
+errors included, which is how a mod's `user://` scripts are seen. The panel holds
+what the session has analysed, so reload the project first for a full sweep.
 
 A tool that takes an output path guards it with `Gen2ToolPath.refuses()` before
-doing any work. A tool runs with `--path <this project>`, so a relative path
-resolves against the checkout rather than the directory the command was run in: a
-bare `out.png` is written into the project and the editor makes an `.import` file
-beside it. The test is where the path resolves, not how it is spelt, since
-`res://out.png` is absolute to `is_absolute_path()` and lands in the project all
-the same. `user://` is allowed.
+doing any work. A tool runs with `--path <this project>`, so a bare `out.png`
+lands in the checkout and the editor makes an `.import` beside it. The test is
+where the path resolves, not how it is spelt: `res://out.png` is absolute to
+`is_absolute_path()` and lands in the project all the same. `user://` is allowed.
 
 `integer_division` is the one warning turned off in `project.godot`: this is
 8-bit hardware arithmetic throughout, where `a / b` on two integers is the
 intended operation, and a float result is written with an explicit `float()`.
 
-Before rewriting or finishing a subsystem, read the verification method: port
-the state machine rather than approximating its output, find a second executable
-implementation to diff against, pick an artefact that compares exactly, sweep
-the whole corpus, and settle every disagreement against pret.
+Before rewriting or finishing a subsystem: port the state machine rather than
+approximating its output, find a second executable implementation to diff
+against, pick an artefact that compares exactly, sweep the whole corpus, and
+settle every disagreement against pret.
 
 ## Pitfalls
 
@@ -184,11 +174,9 @@ the whole corpus, and settle every disagreement against pret.
   during a call can corrupt the VM. Use
   `godot --headless --check-only --script res://path.gd`.
 - New scripts need an editor scan before they resolve; edits to existing ones do
-  not: `godot --headless --editor --path . --quit`. The class index lives in
-  `.godot/`, which is a build cache and not committed, so the gap is visible to
-  anything else resolving against this checkout: a mod repository parsing its
-  own scripts with `--check-only --path <this>` fails on the file that names the
-  new class, not on its own. Run the scan in the commit that adds the class.
+  not: `godot --headless --editor --path . --quit`. The class index lives in the
+  uncommitted `.godot/`, so anything else resolving against this checkout sees
+  the gap. Run the scan in the commit that adds the class.
 - Defer `_ready()` scene changes with `change_scene_to_file.call_deferred(path)`.
 - A bare `PanelContainer` is transparent; give modals a
   `theme_override_styles/panel` `StyleBoxFlat`.
@@ -214,8 +202,7 @@ the whole corpus, and settle every disagreement against pret.
 
 ## Writing and file budget
 
-The repository is kept small on purpose. A reader's time and a machine's are
-both finite, and both were being spent on restatement.
+The repository is kept small on purpose.
 
 **Extend, do not add.** A new feature belongs in the file that already owns its
 subject. Before creating any file, name the existing one it cannot go in.
@@ -228,14 +215,11 @@ subject. Before creating any file, name the existing one it cannot go in.
   at a second layer buys nothing and costs the suite. Keep slow work
   (real caches, whole-movie runs, frame sweeps) out of the default suite.
 - **Docs.** State each fact once, where it is enforced, and link instead of
-  repeating. Source findings and constants go next to the code, contracts in
-  `docs/`, status in `HANDOFF.md`.
+  repeating. Source findings and constants go next to the code; contracts go in
+  `docs/`.
 - **Comments.** A source symbol plus a one-line reason. Comment non-obvious
   constraints and quirks; never restate the line below. No section banners, no
-  doc comment on a self-evident function. Net new comment lines should stay a
-  small fraction of net new code lines. `rom_layout.gd` is the one exemption and
-  says why in its own header: a comment recording how an offset was located is
-  the evidence for that number, not an explanation of the code.
+  doc comment on a self-evident function. `rom_layout.gd` is the one exemption:
+  a comment recording how an offset was located is the evidence for that number.
 
-When something changes, replace the old text. Never append a correction, and
-never let a file grow just because work happened.
+When something changes, replace the old text. Never append a correction.

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1,25 +1,20 @@
 # Mods
 
-A mod is interpreted GDScript in a directory under `user://mods/`. iOS forbids
-JIT and loading native code at runtime, so a distributed mod cannot be a
-compiled extension.
+A mod is interpreted GDScript in a directory under `user://mods/`. It is
+interpreted because iOS forbids JIT and native code at runtime.
 
-Mods never touch scene nodes or engine internals. A mod is handed
-`Gen2ModHost`, registers what it provides, and returns. Everything it can reach
-is cartridge content through `GameData` or live world state through
-`Gen2WorldAPI`, both of which are scene-free.
+A mod never touches scene nodes or engine internals. It is handed a
+`Gen2ModHost`, registers what it provides, and returns. It reads cartridge
+content through `GameData` and live world state through `Gen2WorldAPI`. Both are
+scene-free.
 
-`GameRuntime` discovers and loads every installed mod before the first screen
-exists, creating `user://mods/` when it is absent. The launcher lists what
-loaded and names anything it refused.
+`GameRuntime` loads every installed mod before the first screen exists. The
+launcher lists what loaded and names what it refused. A mod that fails to load is
+reported through `Gen2ModHost.failures()` and skipped; the others still run.
 
 A mod can be switched off without uninstalling it. `Gen2ModState` keeps the
-disabled ids in `user://mods_disabled.json`, and only `load_discovered()`
-consults them: a disabled mod is still discovered and still listed, it just
-does not run, and that is not a refusal. Disabled ids are stored rather than
-enabled ones, so a newly installed mod runs without an entry being written for
-it and a damaged file means everything runs rather than nothing. Uninstalling
-drops the id, so reinstalling later does not find it silently off.
+disabled ids in `user://mods_disabled.json`. A disabled mod is still discovered
+and still listed, it just does not run.
 
 ## Layout
 
@@ -35,46 +30,36 @@ user://mods/<id>/
 
 | Field | Meaning |
 |---|---|
-| `id` | Lowercase `[a-z0-9][a-z0-9_-]*`; addresses the directory and registry keys |
+| `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
-| `version` | The mod's own version, not the host's |
-| `api_version` | Between `Gen2ModManifest.MIN_API_VERSION` and `API_VERSION`. Declare the oldest host you need: 18 for [a hidden-item ask that collapses](#hidden-items-a-mod-can-see-and-ask-for) and [a refused annotation being reported](#annotating-the-battle), 17 for [the battlers block](#the-battlers), 16 for [the shiny seam](#how-many-times-a-wilds-dvs-are-rolled), [an item gift](#asking-the-host-to-hand-an-item-over) and [reading the bag](#reading-the-bag), 15 for [a visible encounter's glow](#visible-wild-encounters), 14 for [an annotation's own interface field](#annotating-the-battle), 13 for [an alternate field-move source](#an-alternate-field-move-source), [Repel renewal](#renewing-a-repel), [experience for a capture](#experience-for-a-capture), [battle annotations](#annotating-the-battle) and a start-menu entry's action and visibility, 12 for `Gen2ModHost.view_changed`, 11 for the battle view's other resolved fields, 10 for [a screen that fills the window](#a-screen-that-fills-the-window) and the maps past this one's edge, 9 for an item that names an evolution method, 8 for a stats-screen page, 7 for an actor's `interact`, `emote` and outbox and for hidden-item requests, 6 for `occupied` in the visible-encounter context, 5 for the run's rules, 4 for types, matchups, mod art and event mutators, 3 for mart rows and named axes, 2 for visible encounters, 1 for everything else |
+| `version` | The mod's own version. Strict `major.minor.patch` |
+| `api_version` | The contract this mod is written against. Current: `Gen2ModManifest.API_VERSION`, 18. A host accepts 1 to 18 |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
-| `icon` | Optional path to the icon, when it is not one of the conventional names |
-| `thumbnail` | Optional path to the thumbnail, same |
-| `dependencies` | Optional object from required mod ids to SemVer ranges |
-| `games` | Optional list of cartridge ids the mod is for |
+| `icon`, `thumbnail` | Optional paths, when the art is not at a conventional name |
+| `dependencies` | Optional map of required mod ids to SemVer ranges |
+| `games` | Optional list of cartridge ids: `gold`, `silver`, `crystal` |
 
-Neither art field is an `api_version` change: a host that has never heard of
-one ignores it, so a mod shipping art still installs on an older launcher and
-simply has no face there.
+Dependency ranges accept an exact version, `*`, wildcards (`1.x`, `1.4.*`),
+comparison chains (`>=1.2.0 <2.0.0`), and caret or tilde ranges. Dependencies
+load first. A missing, disabled, incompatible or failed dependency is refused by
+name, and so is every member of a dependency cycle.
 
-`version` is a strict `major.minor.patch` number. Dependency ranges accept an
-exact version, `*`, component wildcards such as `1.x` or `1.4.*`, comparison
-chains such as `>=1.2.0 <2.0.0`, and caret or tilde ranges such as `^1.2.3` and
-`~1.2.3`. Dependencies load first. A missing, disabled, incompatible or failed
-dependency, and every member of a dependency cycle, is refused by name before
-the dependent entry script runs.
-
-`games` is `RomRegistry` ids: `["gold", "silver", "crystal"]`. Absent or empty
-means every cartridge the host knows, which is what a manifest written before
-this existed says. A cartridge the mod does not name refuses the mod at load, by
-name, and the launcher's card prints what a mod is for before Play is pressed.
-Ids the host has never heard of are not refused when the manifest is read: a mod
-that also names a cartridge a later launcher will ship has to install today, and
-naming only such an id simply means it never runs here. There is no generation
-shorthand, because a generation is not a fact the registry holds about a dump,
-and a list of ids stays right when the launcher gains one.
+`games` absent or empty means every cartridge. A cartridge the mod does not name
+refuses the mod at load, and the launcher's card shows the list before Play. An
+id this host has never heard of is not refused when the manifest is read, so a
+mod naming a future cartridge still installs.
 
 An entry that is absolute, contains `..` or is not GDScript is refused before
-anything runs. Manifests are read without executing mod code, so a launcher can
+anything runs. Manifests are read without executing mod code, so the launcher can
 list what is installed and say why something was rejected.
+
+### Packs
 
 A mod may ship its scripts and resources in a resource pack instead of loose
 files. `pack` names a `.pck` or `.zip` beside `mod.json`, exported from
-`res://mods/<id>/`, and `entry` is then a path inside that root:
+`res://mods/<id>/`. `entry` is then a path inside that root:
 
 ```
 user://mods/voxel/
@@ -82,12 +67,13 @@ user://mods/voxel/
   content.zip   mods/voxel/mod.gd, mods/voxel/renderer.gd, ...
 ```
 
-`mod.json` itself stays a plain file, so the launcher lists a packed mod and can
-refuse it without mounting anything. The pack is mounted only when the mod
-actually loads, with `replace_files` false, so it can add paths and never land on
-one the game itself ships. A pack that names a path rather than a file beside the
-manifest, or that is neither `.pck` nor `.zip`, is refused when the manifest is
-read.
+`mod.json` stays a plain file, so the launcher can list and refuse a packed mod
+without mounting it. The pack is mounted only when the mod loads, with
+`replace_files` false, so it can add paths but never override the game's own. A
+`pack` that is not a `.pck` or `.zip` file beside the manifest is refused when the
+manifest is read.
+
+### The entry script
 
 ```gdscript
 extends RefCounted
@@ -96,25 +82,23 @@ func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
 	host.register_world_renderer(manifest.id, load("%s/renderer.gd" % manifest.directory), "Voxel")
 ```
 
-A mod that fails to load is reported through `Gen2ModHost.failures()` and
-skipped. One broken mod does not stop the others and does not stop the game.
+### Examples
 
-Two example mods are in `mods/examples/`, to copy into `user://mods/`:
+Two example mods are in `mods/examples/`. Copy either into `user://mods/`.
 
 | Mod | Shows |
 |---|---|
-| `voxel_preview/` | A world renderer. Switch it on from its page in the launcher, from the start menu's MODS entry, or with `V` in the overworld; it reads the same collision, block and palette data the 2D view reads and extrudes geometry from it, on the native layer with a translucent text box and one registered setting |
-| `new_content/` | Every non-renderer surface in one file: a type and two matchups, a species with its own art, a move, a move effect, an item with its pocket and mart shelf, a named control axis, a visible-encounter population that reads the run's rules, two rebalancing patches, both event channels and the world channel's presentation mutator |
+| `voxel_preview/` | A world renderer. Switch it on from its launcher page, from the start menu's MODS entry, or with `V` in the overworld. It extrudes geometry from the same collision, block and palette data the 2D view reads, on the native layer, with a translucent text box and one registered setting |
+| `new_content/` | Every non-renderer surface in one file: a type and two matchups, a species with its own art, a move, a move effect, an item with its pocket and mart shelf, a named control axis, a visible-encounter population, two rebalancing patches, both event channels and a presentation mutator |
 
-The repository examples are development material and are excluded from every
-export preset. A distributed build contains the loader but no preinstalled mod;
-players install their own copies under `user://mods/`.
+The examples are excluded from every export preset. A distributed build ships the
+loader and no mod.
 
 ## Installing
 
 The launcher takes a `.zip` on every platform, through **Install** on its mods
-page or by dropping the archive on the window where the OS offers that. The archive holds
-one mod, at its root or in a single folder:
+page or by dropping the archive on the window. The archive holds one mod, at its
+root or in a single folder:
 
 ```
 voxel_preview.zip
@@ -124,77 +108,66 @@ voxel_preview.zip
 ```
 
 An archive is refused whole if it has no `mod.json`, holds more than one mod
-folder, declares another `api_version`, or names a path that would write outside
-its own folder. Nothing is written until all of that passes, so a refusal leaves
-what is already installed untouched. Reimporting a mod that is present asks
-first, and replacing one removes files the new version dropped rather than
-leaving them behind.
+folder, declares an `api_version` this host does not answer, or names a path that
+would write outside its own folder. Nothing is written until all of that passes,
+so a refusal leaves what is installed untouched. Reimporting a mod that is present
+asks first, and replacing one removes files the new version dropped.
 
-Mods do not load in a headless run or one driving a `-s` tool script: a check, a
-test tier or a screenshot would otherwise be measuring a renderer or a shuffled
-table without saying so. Such a run still discovers mods, so a listing is right,
-and `--mods` on the command line puts them back for a run that is about a mod:
+An installed mod loads immediately, without a restart. So does a change to the
+list: switching one on or off, deleting one, or choosing a different cartridge
+reloads every mod against a fresh host. Mods load the same way in an exported
+build as in the editor.
+
+`user://mods/` is `app_userdata/pokerecomp/mods` on desktop, the app's
+`Documents/mods` on iOS (visible in the Files app), and internal app storage on
+Android.
+
+### Headless runs
+
+A headless run and a `-s` tool run load no mods, so a check, a test or a
+screenshot measures the game rather than whatever is installed. Such a run still
+discovers mods. Pass `--mods` for a run that is about a mod:
 
 ```bash
 godot --headless --path . --quit-after 30 --mods
 ```
 
 `--clock=HH:MM` pins the world clock for the run, over the export defaults and
-over a save's own, and holds it there: every world opened believes it is that
-time, so a renderer can be photographed at a chosen hour through the production
-path. `--clock=HH:MM:D` names the day of the week with it. A renderer reads world
-state and must not write it, which is why this is a switch rather than a call.
+over a save's own. `--clock=HH:MM:D` adds the day of the week. Use it to
+photograph a renderer at a chosen hour through the production path.
 
 ```bash
 godot --path . -s res://tools/preview_world.gd --clock=06:00 -- crystal 24 3 \
   /tmp/dawn.png live effects 20 8
 ```
 
-Mods load the same way in an exported build as in the editor: the entry script
-is plain GDScript read at runtime, even though the game's own scripts ship as
-binary tokens. An installed mod loads immediately, without a restart, and so
-does a change to the list: switching one on or off, deleting one, or choosing a
-different cartridge reloads every mod against a fresh host.
+## Icon and thumbnail
 
-`user://mods/` is the platform's `app_userdata/pokerecomp/mods` on desktop, the
-app's `Documents/mods` on iOS (reachable in the Files app, since the export sets
-`UIFileSharingEnabled`), and internal app storage on Android, where the system
-file picker is how an archive gets in.
-
-## An icon and a thumbnail
-
-Both are optional, and a mod that wants either declares nothing: dropping the
-file at the mod root is the whole of it.
+Both are optional. Dropping the file at the mod root is the whole of it.
 
 | | File tried, in order | Size | Drawn by |
 |---|---|---|---|
 | Icon | `icon.png`, `icon.webp`, `icon.jpg` | 32x32, square | The launcher's list row and mod page |
 | Thumbnail | `thumbnail.webp`, `thumb.webp`, `thumbnail.png`, `thumb.png` | 1280x720 | Nothing in the game; a listing site |
 
-A manifest may name another path with `icon` or `thumbnail`, which is what a mod
-keeping its art in a subdirectory needs. The path stays inside the mod folder on
-the same rule as `entry`, and one that climbs out is refused as
-`art_escapes_mod`.
+The manifest may name another path with `icon` or `thumbnail`, for art kept in a
+subdirectory. The path must stay inside the mod folder; one that climbs out is
+refused as `art_escapes_mod`.
 
-32x32 is the party-icon grid the cartridge itself draws on, and the launcher
-draws an icon at a whole multiple of it with nearest filtering, so the pixels
-stay square. Anything up to `Gen2ModArt.MAX_ICON_SIDE` on a side is accepted and
-never stretched to fill its box; past that, or past a megabyte, or not a PNG,
-WebP or JPEG by its own magic, it is ignored and the row keeps the generic
-glyph. A mod's art comes out of a stranger's archive, so every one of those is
-an ordinary answer rather than an error.
+An icon is drawn at a whole multiple of 32x32 with nearest filtering, so the
+pixels stay square. Anything up to `Gen2ModArt.MAX_ICON_SIDE` is accepted and
+never stretched. Past that, past a megabyte, or not a PNG, WebP or JPEG by its own
+magic, it is ignored and the row keeps the generic glyph.
 
-An index row may carry `icon` and `thumbnail` as https URLs. That is how a mod
-has a face while it is still only listed: the launcher fetches each one once, on
-its own request so an icon never delays a download or a feed, and keeps it under
-`user://mod_icon_cache/` so a listing browsed offline still has faces. An
-installed copy's own file always wins over the URL.
+An index row may carry `icon` and `thumbnail` as https URLs, so a mod has a face
+before it is installed. The launcher fetches each once and caches it under
+`user://mod_icon_cache/`. An installed copy's own file always wins.
 
 ## Publishing a source
 
-A source is a JSON feed listing mods that stay in their authors' own
-repositories. Anyone can publish one, and the game follows none until a player
-adds it, because following a source is trusting whoever publishes it.
+A source is a JSON feed listing mods that stay in their authors' repositories.
+Anyone can publish one. The game follows none until a player adds it, because
+following a source means trusting whoever publishes it.
 
 ```json
 {
@@ -215,74 +188,50 @@ adds it, because following a source is trusting whoever publishes it.
 }
 ```
 
-`schema_version` must be exactly the version the build reads, because a later
-format may reuse a field name for something else. Feeds and downloads are https
-only: over plain http anyone on the path could rewrite where a download points.
-A row with no `id`, no usable `download`, or an id that is not a legal mod id is
-dropped, and the rest of the listing still works. `icon` and `thumbnail` are
-optional and held to the same https rule; one that is not is dropped on its own
-rather than costing the row.
-
-`games` repeats the manifest's own list of cartridge ids, so a listing says what
-a mod is for before anyone downloads it: the launcher prints it on the mod's page
-and a site can filter on it. It is optional, and a row without one means every
-cartridge, as an empty list in a manifest does. Only the shape is checked, a
-malformed id being dropped on its own; the manifest inside the archive is still
-what decides where the mod runs.
+- `schema_version` must be exactly the version the build reads.
+- Feeds and downloads are https only.
+- A row with no `id`, no usable `download`, or an illegal id is dropped; the rest
+  of the listing still works. A bad `icon` or `thumbnail` costs only itself.
+- `games` repeats the manifest's list so a listing says what a mod is for. Only
+  the shape is checked. The manifest inside the archive still decides.
 
 Pasting `owner/repo`, the repository page, a site root or the feed file all
-resolve to the same feed, `https://<owner>.github.io/<repo>/index.json` for a
+resolve to the same feed: `https://<owner>.github.io/<repo>/index.json` for a
 GitHub slug.
 
 A listed mod installs through the same path an imported `.zip` does, and its
-manifest id must match the one the feed advertised, so a listing grants a mod
-nothing that picking the same file by hand would not.
+manifest id must match the one the feed advertised.
 
-A row whose `version` is newer than the installed copy's says so and offers
-**Update** rather than **Reinstall**, and the status line counts how many the
-listing offers. Both sides have to be strict `major.minor.patch` numbers to be
-compared: a version a feed made up is reported as uncomparable rather than
-guessed at, and a listing older than the installed copy is neither an update nor
-an error.
+A row whose `version` is newer than the installed copy offers **Update** rather
+than **Reinstall**. Both sides must be strict `major.minor.patch` numbers to
+compare; anything else is reported as uncomparable.
 
-Each feed's last listing that parsed is kept under `user://mod_index_cache/`. It
-is what the mod list is built from, so the list opens instantly and offline and
-the network is only ever asked when the player asks for it, on **Sources**. A
-fetch that fails leaves the copy on disk up with its age said on the status
-line. Unfollowing a source drops its cached copy with it.
+Each feed's last listing that parsed is cached under `user://mod_index_cache/`.
+The mod list is built from the cache, so it opens instantly and offline; the
+network is asked only on **Sources**. Unfollowing a source drops its cache.
 
-The launcher's mod list is grouped by where each mod came from: a source that
-lists a mod's id owns it, and a mod no source lists came from a file. That is
-the whole rule and nothing records it, which is what makes removal mean two
-different things. Removing a mod a source lists uninstalls it and leaves the row
-behind offering the download again; removing one that came from a file deletes
-the only copy there was, and is confirmed first. A mod listed by two sources
-belongs to the first one followed, so it is on screen once.
+The launcher groups the mod list by origin: a source that lists a mod's id owns
+it, and a mod no source lists came from a file. Removing a source's mod
+uninstalls it and leaves the row offering the download again. Removing a file's
+mod deletes the only copy, and is confirmed first. A mod listed by two sources
+belongs to the first source followed.
 
 ## Adding content
 
-`mods/examples/new_content/` is every non-renderer surface of the contract in one
-file: it declares the current `api_version` and its newest surface is 9's, and
-it registers a type and two chart exceptions, a species
-with its own decoded art, a move and its effect, an item with a pack pocket, a
-mart shelf and an evolution it causes, a named control axis, a world actor that
-walks behind the player, a fourth page on the stats screen and a visible-encounter population that reads the
-run's rules and refuses a cell something is standing on, patches two cartridge
-rows, watches both event channels and rewrites the world channel's presentation.
-Copy it and read it beside this section.
+`mods/examples/new_content/` is every non-renderer surface in one file. Copy it
+and read it beside this section.
 
-A content number is per kind and starts at `Gen2ContentOverlay.FIRST_MOD_NUMBER`,
-which is 256. Every cartridge number fits in a byte, so a number that does not is
-unambiguously not the cartridge's, and a mod's own numbers mean the same thing on
-Gold, Silver and Crystal. Five kinds are numbered this way: `KIND_SPECIES`,
-`KIND_MOVE`, `KIND_ITEM`, `KIND_TRAINER` and `KIND_TYPE`.
+A content number is per kind and starts at `Gen2ContentOverlay.FIRST_MOD_NUMBER`
+(256). Every cartridge number fits in a byte, so a larger number is
+unambiguously a mod's and means the same thing on all three cartridges. Five
+kinds are numbered this way: `KIND_SPECIES`, `KIND_MOVE`, `KIND_ITEM`,
+`KIND_TRAINER` and `KIND_TYPE`.
 
-A type is the one kind numbered from zero, the cartridge's own chart being
-zero-based, so `patch_content(KIND_TYPE, id, 0, ...)` renames NORMAL and a defined
-type sits past 256 like the rest. It carries a `name` and `physical`, which is
-which stat pair it uses: Generation II splits by type number rather than per move,
-and a number past the chart has nothing to compare against, so a defined type has
-to say. Special is the default.
+Types are the exception: the cartridge chart is zero-based, so
+`patch_content(KIND_TYPE, id, 0, ...)` renames NORMAL, and a defined type still
+sits past 256. A defined type must carry `name` and `physical`, because Gen II
+splits physical and special by type number and a number past the chart has
+nothing to compare against. Special is the default.
 
 ```gdscript
 host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
@@ -292,18 +241,22 @@ host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
 })
 ```
 
-A definition is partial. Whatever it leaves out comes from the kind's defaults,
-which exist because readers index these rows directly: `palette.normal` and
-`front_tiles` are read without asking whether they are there, so a definition
-that omitted either would crash the reader rather than draw wrong.
+A definition is partial; whatever it leaves out comes from the kind's defaults.
+Everything a species carries is a field on the one row, so its learnset,
+evolution, egg moves and TM compatibility are part of the definition rather than
+four more registrations. Every content read goes through `GameData._content()`,
+so the engine reads a mod species exactly as it reads Pikachu.
 
-Everything a species carries is a field on the one row, so a learnset, an
-evolution, its egg moves and TM compatibility are part of the definition rather
-than four more registrations. The engine then reads them the way it reads Pikachu's, because
-every content read in the game goes through one place, `GameData._content()`.
+Two mods claiming one number is refused and named rather than decided by load
+order. `Gen2ContentOverlay.owner_of()` says which mod holds a number.
 
-An item may name the evolution using it causes (`api_version` 9), which is the
-one effect a definition can give a field item:
+`species_count()`, `move_count()` and `trainer_count()` are the cartridge's own
+runs. Mod numbers are listed with `Gen2ContentOverlay.defined_numbers(kind)`.
+
+### Items that evolve
+
+An item may name the evolution it causes, which is the one effect a definition
+can give a field item:
 
 ```gdscript
 host.register_content(Gen2ContentOverlay.KIND_ITEM, manifest.id, 256, {
@@ -313,20 +266,18 @@ host.register_content(Gen2ContentOverlay.KIND_ITEM, manifest.id, 256, {
 })
 ```
 
-A fact rather than a callback: the host runs that method's own predicate over the
-chosen Pokemon and then the whole of `EvolveAfterBattle`'s tail, so the adapter,
-the HP delta, a consumed held item and the moves the new species offers stay in
-one place instead of a copy per mod. `EVOLVE_TRADE` and `EVOLVE_ITEM` are the two
-methods a field item can name; an optional `"parameter"` beside the method is the
-stone `EVOLVE_ITEM` looks for, defaulting to the item's own number. An item that
-names no `evolution` behaves exactly as it did, cartridge stones included.
+The host runs that method's own predicate and then the whole of
+`EvolveAfterBattle`'s tail, so the adapter, the HP delta, a consumed held item and
+the new moves stay in one place. `EVOLVE_TRADE` and `EVOLVE_ITEM` are the two
+methods available; an optional `"parameter"` is the stone `EVOLVE_ITEM` looks for,
+defaulting to the item's own number. An item with no `evolution` behaves as before.
 
 ### Art
 
-The pic atlases hold exactly the cartridge's own slots, so a defined species or
-trainer class has no cell to point at and supplies decoded indices instead: two
-bits a pixel, row-major, in the same 0-3 index space the cache stores, and exactly
-`tiles * tiles * 64` of them.
+The pic atlases hold exactly the cartridge's slots, so a defined species or
+trainer class supplies decoded indices instead: two bits a pixel, row-major, in
+the same 0-3 index space the cache stores, and exactly `tiles * tiles * 64` of
+them.
 
 ```gdscript
 host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
@@ -337,28 +288,39 @@ host.register_content(Gen2ContentOverlay.KIND_SPECIES, manifest.id, 256, {
 })
 ```
 
-A species drawing its own `pics` stands still when it is sent out: the wobble is
-`AnimateFrontpic`, whose frames are the tiles the cartridge packs behind the
-picture, and a supplied one has none. The cry still plays, which is the source's
-own `.cry_no_anim` branch.
+A species drawing its own `pics` stands still when sent out: the wobble is
+`AnimateFrontpic`, whose frames the cartridge packs behind the picture. The cry
+still plays.
 
 A trainer class names one `pic` rather than two. An `icon` is the party menu's
-own strip, the eight tiles of its two 2x2 frames, or one of the cartridge's icon
-numbers to borrow a picture that already exists. Art left out is not an error: a
-species with no `pics` draws whatever its atlas slot holds, which for a number
-past 251 is nothing, and `GameData.species_pic()` answers both kinds in one shape
-so no screen has to know which it got.
+strip, the eight tiles of its two 2x2 frames, or a cartridge icon number. Art left
+out is not an error; `GameData.species_pic()` answers both kinds in one shape.
 
-`patch_content()` changes a row the cartridge does have. Only the fields named
-change, and a Dictionary field merges, so patching one stat leaves the other five
+A mod species gets no Pokedex entry unless it replaces a cartridge one: both dex
+order tables are cartridge data of exactly 251 entries. Mod content also cannot
+leave the project's own save, because the hardware stores a species, item or move
+in one byte; `Gen2SramAdapter` refuses to export a save carrying any of it.
+
+### Patching cartridge rows
+
+`patch_content()` changes a row the cartridge does have. Only the named fields
+change, and a Dictionary field merges, so patching one stat leaves the others
 alone. A patch of a number this cartridge lacks changes nothing rather than
-inventing a row, which is what keeps a mod that patches Crystal's MYSTICALMAN
-from conjuring one on Gold.
+inventing a row.
 
-`KIND_ENCOUNTER` and `KIND_FISHING` are the cartridge's wild tables. They are
-patched and never defined, since a mod can add neither a map nor a map header,
-and their numbers are table coordinates rather than content numbers. Patch them
-through the two helpers rather than counting the coordinate out yourself:
+A type matchup is patched by its pair and is patch-only, since the cartridge chart
+is a sparse table of exceptions and an absent pair is already neutral.
+`multiplier` is in tenths, the way the damage formula divides.
+
+```gdscript
+host.patch_type_matchup(manifest.id, 256, RomLayout.TYPE_NORMAL, {
+	"multiplier": RomLayout.MATCHUP_SUPER_EFFECTIVE,
+})
+```
+
+`KIND_ENCOUNTER` and `KIND_FISHING` are the wild tables. They are patch-only,
+since a mod can add neither a map nor a map header. Use the helpers rather than
+counting table coordinates:
 
 ```gdscript
 host.patch_encounter(manifest.id, &"grass", 3, 2, {
@@ -368,49 +330,30 @@ host.patch_encounter(manifest.id, &"grass", 3, 2, {
 host.patch_fishing_group(manifest.id, 1, {"rods": [...]})
 ```
 
-A type matchup is patched by its pair rather than by a number, and is patch-only:
-the cartridge chart is a sparse table of exceptions, so an absent pair is already
-neutral and there is no row to define. `multiplier` is in tenths, the way the
-damage formula divides, and `negated_by_foresight` is the Ghost immunities' own
-rule.
+The method is one of `grass`, `surf`, `swarm_grass` and `swarm_water`. `slots`
+and `rates` replace whole. The patched row is what every reader gets, including
+the region walk `FindNest` uses.
 
-```gdscript
-host.patch_type_matchup(manifest.id, 256, RomLayout.TYPE_NORMAL, {
-	"multiplier": RomLayout.MATCHUP_SUPER_EFFECTIVE,
-})
-```
+The four wild sources beside the map tables are patched by index:
 
-An encounter row is what `GameData.world_encounter(method, group, number)`
-answers, and the patched row is what every reader gets, including the region
-walk `FindNest` uses. The method is one of `grass`, `surf`, `swarm_grass` and
-`swarm_water`. `slots` and `rates` are arrays and replace whole; patching a map
-this cartridge lacks changes nothing, exactly as a species patch does.
+| Helper | Row |
+|---|---|
+| `patch_treemon_set(id, set, fields)` | `GameData.treemon_set(set)`, shared by Headbutt and Rock Smash |
+| `patch_bug_contest_mon(id, index, fields)` | One `ContestMons` row |
+| `patch_roaming_mon(id, index, fields)` | One roaming Pokemon |
+| `patch_fishing_time_group(id, index, fields)` | One day/night fishing substitution |
 
-The four wild sources beside the map tables are patched the same way, each by its
-own index in the cartridge's own table:
-
-| Helper | Row | Index |
-|---|---|---|
-| `patch_treemon_set(id, set, fields)` | `GameData.treemon_set(set)`, which Headbutt and Rock Smash share | The set number `treemon_set_for_map` answers |
-| `patch_bug_contest_mon(id, index, fields)` | One `ContestMons` row | Its position in the list |
-| `patch_roaming_mon(id, index, fields)` | One roaming Pokemon | Its position in the list |
-| `patch_fishing_time_group(id, index, fields)` | One day/night fishing substitution | Its position in the list |
-
-Name only what changes. A contest row's `percent` is both the choice roll's
-weight and part of what the judging reads, a rod entry's `threshold` is the bite,
-and a roaming mon's `map_group`/`map_number` are where it currently is, which the
-roamer's own movement writes; a patch naming `species` and `level` leaves all
-three exactly as the cartridge has them. Every runtime reader goes through
-`GameData`, so a patched row reaches the encounter roll, the treemon draw, the
-Pokedex nest search and a visible encounter's context alike.
+Name only what changes. A contest row's `percent` is both the choice weight and
+part of the judging. A rod entry's `threshold` is the bite. A roaming mon's
+`map_group`/`map_number` are where it is now, written by the roamer's own
+movement, so a patch naming `species` and `level` leaves them alone.
 
 ## The gameplay catalog
 
-Everything else a cartridge hands out is a SITE in a script or a map event, not a
+Everything else a cartridge hands out is a site in a script or a map event, not a
 table: a starter, a gift, a static battle, a trade, a Game Corner prize, an item
-on the ground, a badge and a shop. `GameData.catalog()` decodes them once and
-gives each a stable id, so a mod places rewards without holding a single script
-address of its own.
+on the ground, a badge, a shop. `GameData.catalog()` decodes them once and gives
+each a stable id, so a mod places rewards without holding a script address.
 
 ```gdscript
 var catalog := data.catalog()
@@ -420,37 +363,38 @@ for row in catalog.rows(Gen2WorldCatalog.KIND_STATIC):
 
 | Kind | A row carries | Decoded from |
 |---|---|---|
-| `KIND_STARTER` | `species`, `level`, `item` | A `givepoke` whose script also shows the same species with `pokepic`, which only Elm's three balls do |
+| `KIND_STARTER` | `species`, `level`, `item` | A `givepoke` whose script also shows the species with `pokepic`, which only Elm's three balls do |
 | `KIND_GIFT` | `species`, `level`, `item` | Any other `givepoke` or `giveegg` |
-| `KIND_PRIZE` | `species`, `level`, `price` | A give site in a script that spends `takecoins`, priced by the branch's own take |
+| `KIND_PRIZE` | `species`, `level`, `price` | A give site that spends `takecoins`, priced by the branch's own take |
 | `KIND_STATIC` | `species`, `level` | A `loadwildmon` with the `startbattle` that makes it one |
 | `KIND_TRADE` | `trade`, `species`, `requested_species` | A `trade` command and the record it names |
-| `KIND_ITEM` | `item`, `quantity`, `hidden` | `giveitem`, `verbosegiveitem`, an `itemball` object and a `hiddenitem` bg event |
+| `KIND_ITEM` | `item`, `quantity`, `hidden` | `giveitem`, `verbosegiveitem`, an `itemball` object, a `hiddenitem` bg event |
 | `KIND_BADGE` | `badge`, `engine_flag` | A `setflag` of a badge's engine flag |
-| `KIND_SHOP` | `mart`, `dialog`, `items` | A `pokemart` command. `items` is the resolved shelf, `{item, price}` per row, so a mod can move one row of one shop without inventing a mart |
+| `KIND_SHOP` | `mart`, `dialog`, `items` | A `pokemart` command. `items` is the resolved shelf, `{item, price}` per row |
 
-Every row also carries `id`, `kind`, its `bank` and `address` (or its `map` and
-`event_index`), the `map` it stands on where the host could attribute one, and
+Every row also carries `id`, `kind`, its `bank` and `address` (or `map` and
+`event_index`), the `map` it stands on where one could be attributed, and
 `requires`: the events, engine flags and items the script tested before reaching
-the site, read from the site's own branch rather than the whole blob.
+the site.
 
 `patch_check(id, fields)` changes a field of a row. It cannot replace the script:
-the site still sets its own completion flag, prints its own dialogue, takes its
-own money and runs its own battle, and only the number it hands over is the
-mod's. Two mods patching one id is refused by the overlay's own ownership rule,
-not by load order.
+the site still sets its own flag, prints its own dialogue, takes its own money and
+runs its own battle. Two mods patching one id is refused.
 
-A field is effective at its whole TRANSACTION, not at one command of it. The
-host links the commands a site's numbers also reach:
+A field is effective at its whole transaction, not at one command:
 
 | Patch | Also drives |
 |---|---|
-| a starter's `species` | the `pokepic` its ball shows, so the picture and the Pokemon cannot disagree |
-| a prize's `price` | its `checkcoins` affordability branch and its `takecoins` deduction, as one transaction |
-| a trade's `species` / `requested_species` | both halves of the trade, carried beside the cartridge record rather than written into it, so a second site naming that record is unaffected |
-| a shop's `items` | the shelf the counter sells, as `{item, price}` rows |
+| a starter's `species` | the `pokepic` its ball shows |
+| a prize's `price` | its `checkcoins` branch and its `takecoins` deduction |
+| a trade's `species` / `requested_species` | both halves of the trade, carried beside the cartridge record so another site naming that record is unaffected |
+| a shop's `items` | the shelf the counter sells |
 
-## Proving a placement finishes
+The catalog is derived, not imported, so it needs no cache bump and no re-import.
+`tools/checks/catalog.gd` pins both the census and the semantics on all three
+cartridges.
+
+### Proving a placement finishes
 
 A shuffle of badges and key items can write a seed nobody can beat.
 `host.validate_placement(data, patches)` answers before anything is installed:
@@ -461,53 +405,30 @@ if not result["ok"]:
 	print(result["missing"])   # {check, kind, requirement}
 ```
 
-`patches` is the same `{check_id: fields}` shape `patch_check` takes one row at a
-time. The answer is `{ok, reached, critical, missing}`, deterministic, and it
-installs nothing: a failed seed leaves the game exactly as it was, so a generator
-retries against `missing` rather than guessing.
+`patches` is the same `{check_id: fields}` shape `patch_check` takes. The answer
+is `{ok, reached, critical, missing}`, deterministic, and it installs nothing, so
+a generator retries against `missing`.
 
-`missing.requirement` is one of `{map}`, `{item}` or `{badge}`, which is the
-first thing that never became satisfiable. Behind it:
+`missing.requirement` is `{map}`, `{item}` or `{badge}`: the first thing that
+never became satisfiable. Behind it:
 
-- `Gen2WorldReachability` floods each map's own collision grid from the cells a
-  player arrives on, so an exit only Surf reaches is a Surf exit, and asks the
-  same tile questions the overworld does.
-- An HM is only a way past anything once its badge is in hand; the badge each
-  field move needs is `Gen2WorldFieldMove.badge_for_move`.
+- `Gen2WorldReachability` floods each map's collision grid from the cells a player
+  arrives on, asking the same tile questions the overworld does.
+- An HM is a way past something only once its badge is in hand
+  (`Gen2WorldFieldMove.badge_for_move`).
 - `catalog.possible_starters()`, `catalog.field_hm_items()` and
-  `catalog.is_progression(row)` are the same facts for a mod doing its own
-  planning.
+  `catalog.is_progression(row)` are the same facts for a mod planning its own.
 
-What it does NOT model, stated so a mod does not read more into a pass than is
-there: it is MAP-granular rather than cell-exact, and story `checkevent` guards
-are treated as satisfiable because a placement does not move the scripts that
-set them. Both are deliberate and both err toward passing a seed rather than
-rejecting a good one. A site the catalog could not attribute to a map is taken
-as standing where the player already is.
-
-The catalog is DERIVED, not imported, so it needs no cache-format bump and no
-re-import. It is also a decode of a corpus: `tools/checks/catalog.gd` pins both
-the census and the semantics on all three cartridges, because a decode that
-drifts into something still plausible is what a count alone cannot see.
-
-Counts: `species_count()`, `move_count()` and `trainer_count()` are the
-cartridge's own runs. Mod numbers are not part of them and are enumerated with
-`Gen2ContentOverlay.defined_numbers(kind)`.
-
-Two mods claiming one number is refused and named, rather than decided by load
-order. `Gen2ContentOverlay.owner_of()` says which mod won a number.
-
-What content does not get: a pic. The atlases are decoded from the cartridge and
-hold its own 251 slots, so a defined species draws nothing until a renderer draws
-it. `Gen2SramAdapter` cannot export a mod species to a real `.sav` either, since
-the cartridge stores a species in one byte; the project's own save is JSON and
-carries them fine.
+It does not model everything. It is map-granular rather than cell-exact, and story
+`checkevent` guards are treated as satisfiable because a placement does not move
+the scripts that set them. Both err toward passing a seed. A site with no
+attributed map is taken as standing where the player already is.
 
 ## Adding a move effect
 
-A move's effect byte is a number until something answers for it.
-`Gen2MoveEffect` holds the cartridge's lists and `Gen2EffectCommands` the steps
-one is built from; a registration is a list of those steps.
+A move's effect byte is a number until something answers for it. `Gen2MoveEffect`
+holds the cartridge's lists and `Gen2EffectCommands` the steps one is built from.
+A registration is a list of steps.
 
 ```gdscript
 host.register_move_effect(manifest.id, 0xF0, [
@@ -522,47 +443,39 @@ host.register_move_effect(manifest.id, 0xF0, [
 ])
 ```
 
-A list naming a step nobody wrote is refused at registration, where the mod's id
-is still in hand, rather than pushing an error in the middle of a turn.
-`register_effect_command()` adds a step of your own, as a Callable taking the
-`Gen2Turn`; it cannot take a name the engine already uses, so a registration can
-never quietly change what every move in the game does.
+A list naming an unknown step is refused at registration rather than mid-turn.
+`register_effect_command()` adds a step of your own, a Callable taking the
+`Gen2Turn`. It cannot take a name the engine already uses.
 
-A registered effect replaces the cartridge's list for that byte, which is how a
-mod rewrites Sleep rather than only adding to the table.
-`Gen2MoveEffect.RESERVED_EFFECTS` is the exception: the multi-hit, fixed-damage,
-Rollout, Selfdestruct, time-based heal and the two screen bytes are read back off
-the turn by their own commands, so replacing one would leave that command
-answering for a list it is no longer in.
+A registered effect replaces the cartridge's list for that byte, so a mod can
+rewrite Sleep. `Gen2MoveEffect.RESERVED_EFFECTS` is the exception: the multi-hit,
+fixed-damage, Rollout, Selfdestruct, time-based heal and two screen bytes are read
+back off the turn by their own commands.
 
 ## Watching what happens
 
 `subscribe(channel, id, handler)` on `Gen2ModHost.CHANNEL_WORLD` or
-`CHANNEL_BATTLE` calls `handler` with each event dictionary as the screen showing
-it reads it, so a subscriber sees what the player sees, in that order.
+`CHANNEL_BATTLE` calls `handler` with each event dictionary as the screen reads
+it, so a subscriber sees what the player sees, in order.
 
-A subscriber reads only: the handler is given a copy and nothing reads its return
-value, so watching cannot make two mods fight over the same state. Events are
-published from the screens, so a headless tool or a test driving the engine
-directly fires none.
+A subscriber only reads: the handler gets a copy and its return value is ignored.
+Events are published from the screens, so a headless tool or a test driving the
+engine directly fires none.
 
 `register_event_mutator(channel, id, handler)` is the other half. The turn or the
-script has already committed its state by the time these events reach the screen,
-so the handler may rewrite what is SHOWN - text, animation, display values - and
-is handed the whole event to return a changed copy of. Two things it cannot do:
-change the routing key (`type` on the battle channel, `status` on the world one),
-which would turn one screen operation into another, and share the channel. One
-mutator per channel, because composing two rewrites in load order would make the
-picture depend on which mod loaded first. A handler that returns anything else
-leaves the event alone, and subscribers see the mutated event, not the original.
+script has already committed its state by then, so the handler may rewrite what is
+*shown* (text, animation, display values) and returns a changed copy of the whole
+event. Two limits: it cannot change the routing key (`type` on the battle channel,
+`status` on the world one), and there is one mutator per channel, so the picture
+never depends on load order. A handler returning anything else leaves the event
+alone. Subscribers see the mutated event.
 
 ## Replacing the world renderer
 
-Nothing about the world requires that the drawing be 2D: maps are node-free
-`RefCounted` records, each tileset is one addressable atlas, animated tiles
-replace atlas slots rather than map rectangles, and collision is a raw
-permission byte per 2x2 walk cell. A renderer that extrudes geometry from that
-same data is a registration, not a fork.
+Nothing about the world requires 2D drawing. Maps are node-free `RefCounted`
+records, each tileset is one addressable atlas, animated tiles replace atlas slots
+rather than map rectangles, and collision is a permission byte per 2x2 walk cell.
+A renderer that extrudes geometry from that data is a registration, not a fork.
 
 A registered renderer is a `Node` providing:
 
@@ -573,167 +486,144 @@ A registered renderer is a `Node` providing:
 | `refresh()` | The player, an object or an event changed something |
 | `refresh_animation()` | A tileset animation command changed tile data |
 
-Registration is refused, by name, if any of these is missing or the script is
-not a `Node`, rather than failing on the first drawn frame.
+Registration is refused by name if any is missing or the script is not a `Node`.
 
 Six methods are optional, on either renderer kind:
 
 | Method | Effect |
 |---|---|
-| `uses_hardware_viewport() -> bool` | Answering false moves the renderer off the 160x144 hardware viewport onto the screen's own rectangle at window resolution |
+| `uses_hardware_viewport() -> bool` | False moves the renderer off the 160x144 hardware viewport onto the screen's own rectangle at window resolution |
 | `set_native_size(size: Vector2i)` | The native layer's size in window pixels, on creation and on every window change |
-| `interface_opacity() -> float` | How opaque the screen draws the field of its own text box, 0 to 1 |
-| `set_text_box_rect(rect: Rect2i)` | Where that box is, in hardware pixels, on every change and empty when none is on screen |
-| `set_interface_masked(masked: bool)` | A screen laid out in 160x144 has taken the picture, or given it back. See [A screen that fills the window](#a-screen-that-fills-the-window) |
-| `set_screen_rect(rect: Rect2i)` | Where the hardware's 160x144 screen sits inside the native layer, beside every `set_native_size` |
+| `interface_opacity() -> float` | How opaque the screen draws the field of its text box, 0 to 1 |
+| `set_text_box_rect(rect: Rect2i)` | Where that box is, in hardware pixels. Pushed on every change, empty when none is up |
+| `set_interface_masked(masked: bool)` | A screen laid out in 160x144 has taken the picture, or given it back |
+| `set_screen_rect(rect: Rect2i)` | Where the 160x144 screen sits inside the native layer. Pushed beside every `set_native_size` |
 
-A view built out of geometry cannot be drawn into a 160x144 buffer and then
-magnified, so the second layer is what makes a 3D or HD renderer possible at
-all. Text boxes and menus stay hardware pixels over the top: the world gains
-resolution, the interface stays a Game Boy.
+A view built out of geometry cannot be drawn into a 160x144 buffer and magnified,
+so the native layer is what makes a 3D or HD renderer possible. Text boxes and
+menus stay hardware pixels over the top: the world gains resolution, the interface
+stays a Game Boy.
 
-The box is drawn opaque, as the cartridge draws it. `interface_opacity()` asks
-for the field behind it to be drawn through, and only the field: the frame and
-the glyphs stay ink, so nothing a renderer asks for makes text harder to read.
-Around 0.75 reads well over a map. It is honoured only for a renderer that
-answered `uses_hardware_viewport()` false, since one drawing in hardware pixels
-paints the background itself and a hole would show the window behind the screen.
+The box is drawn opaque. `interface_opacity()` asks for the field behind it to be
+drawn through, and only the field: the frame and glyphs stay ink. Around 0.75
+reads well over a map. It is honoured only for a renderer that answered
+`uses_hardware_viewport()` false.
 
-`set_text_box_rect` is the same box measured rather than styled, pushed on every
-change including the empty rectangle when it goes away. The standard box is
-twenty by six at row twelve, but a box can be any size and is not always up.
-
-The world's own menus are not this box: the start menu, party and PC are
-window-resolution panels with their own scrim, so a renderer neither sees nor
-styles them. The pack's listing inside that panel is the cartridge's own screen,
-drawn by `Gen2PackPage`, and is not this box either. `Gen2MenuPage` is the cartridge box path, used by the naming and
+The world's own menus are not this box. The start menu, party and PC are
+window-resolution panels with their own scrim, which a renderer neither sees nor
+styles. The pack listing inside that panel is drawn by `Gen2PackPage` and is not
+this box either. `Gen2MenuPage` is the cartridge box path, used by the naming and
 gender screens, neither of which is ever over a renderer.
 
-A world renderer has a third:
+A world renderer has one more:
 
 | Method | Effect |
 |---|---|
-| `handle_world_input(event: InputEvent) -> bool` | Every input event the world screen did not use. Answering true consumes it |
+| `handle_world_input(event: InputEvent) -> bool` | Every input event the world screen did not use. True consumes it |
 
-The screen claims what it needs and offers the rest, so camera pitch, first
-person and free-roam are all reachable while a movement or interaction key never
-arrives: a renderer reads world state and must not write it, and moving the
-player is writing it. Free-roam movement is the pose layer below, not this. An
-open overlay, a running script, a battle or a trainer approach takes the event
-first, exactly as it does for the screen's own keys.
+The screen claims what it needs and offers the rest, so camera pitch, first person
+and free-roam are reachable while a movement or interaction key never arrives: a
+renderer reads world state and must not write it, and moving the player is writing
+it. An open overlay, a running script, a battle or a trainer approach takes the
+event first.
 
-Implement this rather than Godot's `_input` or `_unhandled_input`. A node in the
-tree is offered events before the screen decides what it needs, so a renderer
-reading them directly races the gameplay keys instead of taking what is left of
-them.
+Implement this rather than Godot's `_input` or `_unhandled_input`, which would
+race the gameplay keys instead of taking what is left of them.
 
 ### The tileset atlas
 
-`GameData.world_tileset_indices(number)` is one tileset's graphics as a single
-indexed strip, `Gen2WorldTileset.tile_count` tiles wide and eight tall, one byte
-of colour index per pixel. Every number a block can name indexes it directly:
-`Gen2WorldTileset.tile_index(block, tile)` is the strip slot, and
-`Gen2WorldPalette.tile_palettes()` answers one palette per slot in the same
-order.
+`GameData.world_tileset_indices(number)` is one tileset's graphics as an indexed
+strip, `Gen2WorldTileset.tile_count` tiles wide and eight tall, one byte of colour
+index per pixel. Every number a block can name indexes it directly:
+`Gen2WorldTileset.tile_index(block, tile)` is the slot, and
+`Gen2WorldPalette.tile_palettes()` answers one palette per slot in the same order.
 
-The cartridge loads a tileset's graphics as two blocks of 96 tiles into separate
-VRAM banks, and a metatile byte with the high bit set names the second. The strip
-carries both, at the cartridge's own numbering: block 0 at 0 to 95, block 1 at
-128 to 223, and the 32 tiles between them are the font's, always blank here. A
-tileset that ships only one block leaves 128 to 223 blank. Nothing needs to know
-which block a tile came from; the number is enough.
+The cartridge loads a tileset as two blocks of 96 tiles into separate VRAM banks,
+and a metatile byte with the high bit set names the second. The strip carries both
+at the cartridge's numbering: block 0 at 0-95, block 1 at 128-223, and the 32 tiles
+between are the font's, always blank here. A tileset shipping one block leaves
+128-223 blank.
 
-`Gen2WorldAnimation` rewrites slots in this strip, so a renderer texturing from
-it follows water and flowers without knowing an animation ran. That is also why
-geometry cut from the strip is cut from one arbitrary frame:
-`tile_frames(tile)` answers every frame a tile is ever drawn as, in play order,
-each entry that tile's sixty-four palette indices row by row, with the tileset's
-own tile first and an empty array for a tile no command touches. It does not
-advance the live sequence, since the running game shares the object. Ask it once
-per animated tile when a map resolves, and let a mesh span the union.
+`Gen2WorldAnimation` rewrites slots in this strip, so a renderer texturing from it
+follows water and flowers for free. Geometry cut from the strip is cut from one
+arbitrary frame, so `tile_frames(tile)` answers every frame a tile is ever drawn
+as, in play order, each entry that tile's 64 palette indices row by row, with the
+tileset's own tile first and an empty array for a tile no command touches. It does
+not advance the live sequence. Ask it once per animated tile when a map resolves
+and let a mesh span the union.
 
 ### Asking what a cell is
 
 `Gen2WorldAPI.collision_code_at(cell)` is the raw cartridge byte, and
 `Gen2WorldCollision` answers what the source asks of it. Read a predicate rather
 than a tile number: a pin by drawing is per tile id and per tileset, and the
-cartridge's own answer is per cell.
+cartridge's answer is per cell.
 
 | Call | Source |
 |---|---|
 | `permission_for(code)`, `is_walkable(code)` | `CollisionPermissionTable` |
 | `talks(code)` | The same table's `TALK` bit |
-| `grass_kind(code)`, `is_grass(code)`, `is_long_grass(code)` | `SetTallGrassFlags`, which is `CheckSuperTallGrassTile` then `CheckGrassTile` |
+| `grass_kind(code)`, `is_grass(code)`, `is_long_grass(code)` | `SetTallGrassFlags` |
 | `allows_hop(code, direction)` | `.TryJump` |
 | `is_warp_tile(code)`, `is_pit_tile(code)` | `CheckWarpCollision`, `CheckPitTile` |
 | `side_wall_face_mask(code)` | `GetMovementPermissions` |
 
-`grass_kind` returns `GRASS_NONE`, `GRASS_TALL` or `GRASS_LONG`, because the
-cartridge keeps the two apart: the long grass is its own pair of codes and the
-Bug Contest doubles its encounter rate. It is `IN_GRASS_F`, not the encounter
-gate; `CheckGrassCollision` is that one and it includes water, since one routine
-gates a surf roll too.
+`grass_kind` returns `GRASS_NONE`, `GRASS_TALL` or `GRASS_LONG`: long grass is its
+own pair of codes and the Bug Contest doubles its encounter rate. It is
+`IN_GRASS_F`, not the encounter gate; `CheckGrassCollision` is that one and it
+includes water.
 
-### The drawn block of a map that is not open
+### Blocks past the loaded map
 
-`Gen2WorldAPI.drawn_block_at(x, y)` is the block a coordinate is drawn from
-rather than the block that is stored there: `LoadMetatiles` substitutes the
-map's border block for a `$00` byte, and `FillMapConnections` fills three blocks
-of padding around the map with a neighbour's art where a connection reaches.
+`Gen2WorldAPI.drawn_block_at(x, y)` is the block a coordinate is *drawn* from
+rather than the block stored there: `LoadMetatiles` substitutes the border block
+for a `$00` byte, and `FillMapConnections` fills three blocks of padding around
+the map with a neighbour's art.
 
 A caller with no world reads the same fold through
 `Gen2WorldAPI.drawn_block_for(data, map, x, y)`. That is what a battle has: a
-`Gen2BattleWorldContext` names the map and hands over no world, deliberately, so
-an arena built from `GameData` records asks the static. The instance method calls
-through to it, so the strip geometry and the north/south/west/east order at an
-overlapping corner exist once. `tools/checks/drawn_blocks.gd` sweeps every map
-of every cache over its whole padded rectangle and refuses a disagreement.
+`Gen2BattleWorldContext` names the map and hands over no world.
+`tools/checks/drawn_blocks.gd` sweeps every map of every cache over its padded
+rectangle and refuses a disagreement.
 
-Live `changeblock` edits are the loaded world's own and are not visible to the
-static form, which is correct for a map nobody is standing on.
-`Gen2WorldAPI.block_revision` counts them, and a map load, so a view caching the
-block buffer knows when to read it again rather than rebuilding per frame.
-
-### The maps past this one's edge
+Live `changeblock` edits belong to the loaded world and are not visible to the
+static form. `Gen2WorldAPI.block_revision` counts them, and a map load, so a view
+caching the block buffer knows when to read it again.
 
 `ChangeMap` copies a map into the middle of `wOverworldMapBlocks`, three blocks
-wider than the map on every side. That margin is `BUFFER_BLOCKS`, it is what a
-connection strip fills, and it is everything the cartridge holds: past it there
-is nothing at all, which is why a 20x18 screen never needed more.
-
-A view wider than that does. The connection graph is walked instead, and the
-whole neighbouring maps are placed in this map's own block coordinates.
+wider on every side (`BUFFER_BLOCKS`). Past that margin the cartridge holds
+nothing, which is why a 20x18 screen never needed more. A wider view walks the
+connection graph instead, placing whole neighbouring maps in this map's block
+coordinates.
 
 | Call | Value |
 |---|---|
-| `map_placements() -> Dictionary` | `"group:number"` to `{map, origin}` for every map the graph reaches from the loaded one, nearest first. The loaded map is not in it: it is the origin |
+| `map_placements() -> Dictionary` | `"group:number"` to `{map, origin}` for every map the graph reaches, nearest first. The loaded map is the origin and is not in it |
 | `placements_around(data, map, hops) -> Dictionary` | The same for a map nobody is standing on |
-| `connection_origin_blocks(source, target, connection) -> Vector2i` | Where one connection puts one map, which is the arithmetic the two above and the strip share |
-| `expanded_block_at(x, y) -> int` | `drawn_block_at` inside the buffer, byte for byte; past it, whichever placed map covers the coordinate, and the border block where none does |
-| `in_hardware_buffer(map, x, y) -> bool` | Which of those two answers a coordinate takes |
+| `connection_origin_blocks(source, target, connection) -> Vector2i` | Where one connection puts one map |
+| `expanded_block_at(x, y) -> int` | `drawn_block_at` inside the buffer; past it, whichever placed map covers the coordinate, and the border block where none does |
+| `in_hardware_buffer(map, x, y) -> bool` | Which of those two a coordinate takes |
 
-`PLACEMENT_HOPS` and `PLACEMENT_LIMIT` bound the walk at three hops and 24 maps,
-which is as much as the furthest zoom shows.
+`PLACEMENT_HOPS` and `PLACEMENT_LIMIT` bound the walk at three hops and 24 maps.
 
-`expanded_block_at` is the whole answer for a renderer with one tileset atlas
-only if it never leaves this map's tileset. It does: a placed map is numbered in
-its OWN tileset, so a block read across a tileset boundary is a different
-picture with the same number. Read `map_placements()` and check
-`Gen2WorldMap.tileset` against the loaded one where that matters;
+`expanded_block_at` is enough for a renderer with one tileset atlas only while it
+stays in this map's tileset. A placed map is numbered in its *own* tileset, so a
+block read across a boundary is a different picture with the same number. Read
+`map_placements()` and compare `Gen2WorldMap.tileset` where that matters;
 `GameData.world_tileset(number)` resolves the rest, and `Gen2WorldMap.blocks` and
 `border_block` are public.
 
 `connected_map_objects() -> Array` is the people standing on those maps, as
 `{object, offset}` with the offset in walk cells. They are read-only copies and
-deliberately not part of `Gen2WorldAPI.objects`: `ReadObjectEvents` fills
-`wMapObjects` from the loaded map alone, so on the cartridge a connected map's
+deliberately not part of `Gen2WorldAPI.objects`: on the cartridge a connected map's
 people do not exist until its own map load builds them. They take the event-flag
 and visible-hours tests and nothing else. No step, no script, no sight, no
 collision, no encounter, and they cannot be talked to.
 
 ## Framing the view
 
-`Gen2WorldAPI` offers a camera; it does not impose one.
+`Gen2WorldAPI` offers a camera; it does not impose one. A renderer framing its own
+view can ignore all six calls.
 
 | Method | Value |
 |---|---|
@@ -741,255 +631,190 @@ collision, no encounter, and they cannot be talked to.
 | `visible_origin_cells() -> Vector2` | The framed view's top-left in fractional walk cells, centred on that position and clamped to the map |
 | `visible_origin_cell() -> Vector2i` | The hardware page origin, which follows the committed cell |
 | `view_pixels: Vector2i` | The drawn surface in hardware pixels, `VIEW_PIXELS` (160x144) unless a screen asked for more |
-| `view_origin_pixels() -> Vector2` | That surface's top-left in world pixels, which is `visible_origin_cells()` scaled when the surface is the hardware's own |
-| `player_view_pixel() -> Vector2i` | The player's pixel inside it, which is `player_pixel_position()` plus half of whatever surround a wider surface added |
+| `view_origin_pixels() -> Vector2` | That surface's top-left in world pixels |
+| `player_view_pixel() -> Vector2i` | The player's pixel inside it |
 
 The extra a wider surface adds is spread evenly around the screen the cartridge
-would have drawn, so the player keeps the place `PLAYER_VIEW_CELL` puts him in
-and only the surround grows. A renderer framing its own view can ignore all six.
+would have drawn, so the player keeps the place `PLAYER_VIEW_CELL` puts him in.
 
 `player_cell` commits at the start of a step, so the hardware page origin moves a
-whole cell the instant one begins. That is what the 160x144 tile page wants and
-what a camera does not: following it pans a step early.
-`visible_origin_cells()` frames the interpolated position instead, and the two
-agree whenever no step is in flight. A renderer that frames its own view, which
-is what a free camera is, can ignore all three and read
-`player_position_cells()` and `map_size_cells()` directly.
+whole cell the instant one begins. A camera following it pans a step early;
+`visible_origin_cells()` frames the interpolated position instead. The two agree
+whenever no step is in flight.
 
 The host constructs a renderer per world, so the view can change while the game
-runs. `Gen2WorldScreen.select_view()` is that switch, and `cycle_view()` is what
-`V` is bound to: the map, the player and any running script are untouched,
-because a renderer reads world state and must not write it. Two views of one
-world have to agree.
+runs. `Gen2WorldScreen.select_view()` is that switch and `cycle_view()` is what
+`V` is bound to. The map, the player and any running script are untouched.
 
 ## A screen that fills the window
 
 A window is not the Game Boy's 10:9. **SCREEN FILL** (`Gen2Options.screen_fill`,
 on by default, Settings > Application > Screen) grows the drawn surface to the
 whole control instead of framing 160x144 inside it. Every screen takes it; what
-differs is who fills it. The overworld fills it with more map: see
-[The maps past this one's edge](#the-maps-past-this-ones-edge). A screen laid out
-in 160x144 has nothing of its own out there, so the screen fills the surround
-with that screen's own field, taken from the picture it drew.
+differs is who fills it. The overworld fills it with more map. A screen laid out
+in 160x144 has nothing out there, so the screen fills the surround with that
+screen's own field, taken from the picture it drew.
 
-**Everything the cartridge laid out stays put.** Text boxes, menus and the start
-menu go inside a 160x144 rectangle centred in the surface and clipped to it, so
-a mod reading `set_text_box_rect` reads the same numbers it always did.
+Everything the cartridge laid out stays put. Text boxes, menus and the start menu
+go inside a 160x144 rectangle centred in the surface and clipped to it, so a mod
+reading `set_text_box_rect` reads the numbers it always did.
 
 | Read | Value |
 |---|---|
 | `Gen2Screen.expanded` | Whether this screen grew to its control |
 | `Gen2Screen.view_size() -> Vector2i` | The drawn surface in hardware pixels |
 | `Gen2Screen.view_size_changed(size)` | Emitted when it changes |
-| `Gen2Screen.interface_layer() -> Control` | The 160x144 rectangle, positioned in surface pixels |
+| `Gen2Screen.interface_layer() -> Control` | The 160x144 rectangle, in surface pixels |
 | `Gen2Screen.interface_masked` | Whether the screen is painting the surround itself |
-| `Gen2Screen.screen_rect() -> Rect2i` | The 160x144 screen in native-layer pixels, which is what `set_screen_rect` pushes |
+| `Gen2Screen.screen_rect() -> Rect2i` | The 160x144 screen in native-layer pixels |
 
-**`set_native_size` may now be the whole control.** It was always "the screen's
-rectangle at window resolution"; framed, that rectangle was a whole multiple of
-160x144, and expanded it is not. A renderer that sized itself to what it was
-handed needed no edit for this.
+`set_native_size` may be the whole control, which is not a whole multiple of
+160x144. A renderer that sized itself to what it was handed needs no change.
 
-**`set_screen_rect` is where the Game Boy screen is inside it**, pushed beside
-every `set_native_size`. That is what turns a hardware-pixel number into a place
-on the surface, `set_text_box_rect`'s rectangle first: framed, the mapping was
-the surface itself, and filled it is not. A hardware pixel `p` lands at
-`rect.position + p * rect.size / Vector2i(160, 144)`.
+`set_screen_rect` turns a hardware-pixel number into a place on the surface. A
+hardware pixel `p` lands at `rect.position + p * rect.size / Vector2i(160, 144)`.
 
-**A native-layer renderer keeps the zoom keys.** `+`, `-`, `0` and the wheel step
-`Gen2Screen.zoom_step`, and that ladder counts screen pixels per HARDWARE pixel.
-A view that answered `uses_hardware_viewport()` false has no hardware pixel, so
-the screen does not claim those events and they reach `handle_world_input` and a
-mod's own registered actions as usual. Its zoom is its camera's.
+A native-layer renderer keeps the zoom keys. `+`, `-`, `0` and the wheel step
+`Gen2Screen.zoom_step`, which counts screen pixels per *hardware* pixel. A view
+that answered `uses_hardware_viewport()` false has no hardware pixel, so those
+events reach `handle_world_input` and a mod's registered actions instead.
+`Gen2Options.zoom_step` persists the ladder position.
 
-**The surround is not painted over the native layer.** When a screen laid out in
-160x144 takes the picture -- the pack, the party, the PC, the dex, the trainer
-card, an evolution, a hatch, the day-care, the slot machine, card flip, a battle,
-and `DoBattleTransition` -- the surround becomes that screen's own field rather
-than the world behind it. It is drawn inside the hardware viewport, which
-composites over the native layer, so raising it would crop a view that had
-already filled the whole surface. It is not raised there.
-`set_interface_masked(masked)` is how such a renderer closes its own surround
-instead, and the transition is the case it exists for: twenty by eighteen cells cannot be widened, so a wedge reaching the
-edge of a filled window is a shape only the view drawing that window can draw. A
-renderer that does not take it keeps drawing what it was drawing.
-`mods/examples/voxel_preview` draws the four bands around `set_screen_rect`'s
-rectangle, which is the same shape the screen paints for a hardware-pixel view.
+The surround is not painted over the native layer. When a screen laid out in
+160x144 takes the picture (the pack, party, PC, dex, trainer card, an evolution, a
+hatch, the day-care, the slot machine, card flip, a battle, `DoBattleTransition`)
+the surround becomes that screen's field. It is drawn inside the hardware
+viewport, which composites over the native layer, so raising it would crop a view
+that had filled the surface. `set_interface_masked(masked)` is how a renderer
+closes its own surround instead. `mods/examples/voxel_preview` draws the four bands
+around `set_screen_rect`'s rectangle.
 
-**A battle fills the window either way; who fills it differs.** `_BattleScene`
-is a 160x144 picture with nothing to put in a wider surface, so the screen fills
-the surround with the arena's own field. A battle renderer on the native layer,
-staged on the map the encounter fired on, has the same world the overworld was
-filling the window with a frame earlier and fills the surface itself, so the
-screen leaves it alone. The HUD does not move either way: the panels, the bars and the boxes are hardware pixels in that same centred
-rectangle.
-
-`Gen2Options.zoom_step` is the ladder's position, persisted because it is a view
-preference rather than part of a run.
+A battle fills the window either way. `_BattleScene` is a 160x144 picture, so the
+screen fills the surround with the arena's own field. A battle renderer on the
+native layer already has the world the overworld was filling the window with, so
+it fills the surface itself and the screen leaves it alone. The HUD does not move
+either way.
 
 ## Choosing the view
 
-**Choosing a view is one choice.** `Gen2ModHost.select_view(id)` takes a mod id,
-not a surface, and applies to whichever of the two renderer kinds that id
-registered. Registering a world renderer and a battle renderer under one id is
-how a mod says the two are one view of one world; a mod registering only one
-keeps the built-in renderer on the other, and `gen2` selects both.
+Choosing a view is one choice. `Gen2ModHost.select_view(id)` takes a mod id, not a
+surface, and applies to whichever renderer kinds that id registered. Registering a
+world renderer and a battle renderer under one id says the two are one view of one
+world. A mod registering only one keeps the built-in renderer on the other.
+`gen2` selects both.
 
 | Method | Value |
 |---|---|
-| `view_ids() -> Array[StringName]` | Every id that registered a renderer of either kind, `gen2` first and the rest in load order |
-| `view_label(id) -> String` | The label the registration gave, drawn in eight cells (see "What a name is drawn in") |
+| `view_ids() -> Array[StringName]` | Every id that registered a renderer of either kind, `gen2` first, then load order |
+| `view_label(id) -> String` | The label the registration gave |
 | `view_surfaces(id) -> Dictionary` | `{world, battle}`, which of the two that id draws |
 | `selected_view() -> StringName` | The chosen id, whether or not its mod is loaded |
 | `select_view(id) -> Dictionary` | Chooses it, and persists the choice |
-| `view_changed(id)` | Signal, emitted whenever the chosen id actually changes |
+| `view_changed(id)` | Signal, emitted whenever the chosen id changes |
 
-The choice is stored per installation in `user://mods_disabled.json` beside the
-disabled list, so it survives a restart the way a mod's own options do, and it is
-resolved every time a surface builds a renderer rather than once at load: a
-stored id whose mod is uninstalled or switched off draws with the built-in
-renderer and is not refused, and starts drawing again the moment the mod
-registers.
+The choice is stored per installation in `user://mods_disabled.json` and resolved
+every time a surface builds a renderer. A stored id whose mod is uninstalled or
+switched off draws with the built-in renderer, is not refused, and starts drawing
+again the moment the mod registers.
 
-**Every way of choosing reaches the same live screen.** `select_view` announces
-the change on `view_changed`, and the world and battle screens rebuild what they
-are drawing with on it, so the launcher's mod page, the start menu's own VIEW
-row and `V` are one path. A mod neither needs nor should hold a screen; it may
-connect to the signal to hear about a switch.
+Every way of choosing reaches the same live screen: `select_view` announces the
+change on `view_changed` and both screens rebuild on it, so the launcher's mod
+page, the start menu's VIEW row and `V` are one path. A mod neither needs nor
+should hold a screen; it may connect to the signal.
 
-### What a name is drawn in
+Players reach the view from three places: the mod's launcher page, the VIEW row at
+the top of the start menu's MODS entry (present as soon as more than one view is
+registered), and `V` where `Gen2DebugKeys` is enabled. A mod must not register a
+view button of its own.
 
-The start menu is the hardware's twenty-cell screen, so a name a mod registers
-is drawn into a fixed budget and a longer one ends in the charmap's own "…":
+The switch is covered. Building a renderer can stall a whole frame, and nothing on
+one thread can animate over its own freeze. `Gen2Screen.play_view_cover` closes
+with `StartTrainerBattle_SpeckleToBlack`'s scatter on the renderer still running,
+builds the new one while the screen is black, and opens with the same frames
+backwards.
 
-| Row | Cells | What is drawn there |
+### Name lengths
+
+The start menu is the hardware's twenty-cell screen, so a registered name is drawn
+into a fixed budget and a longer one ends in the charmap's "…":
+
+| Row | Cells | What is drawn |
 |---|---|---|
 | A mod's name in the MODS list | 17 | The manifest's `name` |
-| A setting's `label`, and the VIEW row's own | 17 | `register_option`'s `label` |
+| A setting's `label`, and the VIEW row's | 17 | `register_option`'s `label` |
 | A setting's value, and a view's label | 8 | The chosen rung's label, a button's `press_label`, or `view_label` |
 
-The built-in view is labelled "GBC 2D" for that reason. A name that has to read
-whole in the start menu is written to those budgets; a longer one still works
-and is shown cut, rather than drawn through the panel's border as it was before.
 The numbers are `Gen2StartMenuPage.OPTIONS_LABEL_CELLS` and
-`OPTIONS_VALUE_CELLS`. The launcher draws the full name either way.
-
-**Players reach the view from three places.** The mod's page in the launcher,
-where they already change what a mod does; the VIEW row at the top of the start
-menu's MODS entry, which is the host's own row and appears as soon as more than
-one view is registered, whether or not any mod registered a setting; and `V`
-where [Gen2DebugKeys] is enabled. A mod must not register a view button of its
-own: the host holds the one selection, and a mod's copy of it would be a second
-answer to the same question.
-
-**The switch is covered.** Building a renderer is a stall -- meshing a map can
-land whole on one frame -- and nothing on one thread can animate over its own
-freeze. `Gen2Screen.play_view_cover` closes with
-`StartTrainerBattle_SpeckleToBlack`'s own scatter on the renderer that is still
-running, builds the new one on the frame the screen is fully black, and opens
-with the same frames backwards. It is around the switch rather than at a caller,
-so every one of the three gets it, and renderers need nothing new: the outgoing
-one is asked for no frame it would not have drawn anyway.
+`OPTIONS_VALUE_CELLS`. The built-in view is labelled "GBC 2D" to fit. The launcher
+draws the full name either way.
 
 ## Replacing the battle renderer
 
-The same boundary covers battle presentation. `Gen2BattleScreen` owns the
-battle, the events and the text box; it decides nothing about how a Pokémon,
-a panel or a bar is drawn. A registered battle renderer is a `Node` providing:
+`Gen2BattleScreen` owns the battle, the events and the text box. It decides
+nothing about how a Pokemon, a panel or a bar is drawn. A registered battle
+renderer is a `Node` providing:
 
 | Method | Called when |
 |---|---|
-| `set_battle_data(data) -> bool` | The screen is ready, before the first view; a false return leaves the screen not ready |
-| `set_view(view: Dictionary)` | The screen has new plain display values to show |
+| `set_battle_data(data) -> bool` | The screen is ready, before the first view. False leaves the screen not ready |
+| `set_view(view: Dictionary)` | The screen has new display values to show |
 | `refresh()` | The renderer should redraw its current view |
 
-`view` carries `enemy_species`, `player_species`, `enemy_unown_form`,
-`player_unown_form`, `enemy_substitute`, `player_substitute`, `enemy_name`,
-`player_name`, `enemy_level`, `player_level`, `battle_kind`, `trainer_class`,
-`trainer_index`, `trainer_name`, `enemy_hp`, `enemy_max_hp`, `player_hp`,
-`player_max_hp`, `enemy_shiny`, `player_shiny`, `exp_pixels`, `raster_scx`,
-`raster_scy`, `battlers`,
-`intro_sprites`, `grayscale`, `enemy_trainer_pic`, `player_backpic`,
-`player_backpic_palette`, `enemy_hud_visible`, `player_hud_visible`,
-`trainer_hud_balls`, `trainer_hud_border`, `bg_map`, `bg_vbank1`,
-`bg_palette_maps`, `ob_palette_maps`, `anim_sprites`, `anim_tiles` and
-`hud_visible`: plain values read out of a resolved battle event, never the
-battle engine itself, the same rule `Gen2BattleScreen`'s own setters already
-followed.
+Registration uses the same refusal rules as a world renderer, and shares both
+optional methods (`uses_hardware_viewport()`, `set_native_size()`), the view
+selection above, and the `V` cycle.
 
-`battle_kind` is `wild` or `trainer` and the three fields after it say who the
-fight is against, which the species and levels do not. A wild battle carries
-class 0, index 0 and an empty name, the way `wOtherTrainerClass` is zero there.
-A class number is what `GameData.trainer_pic()` and `trainer_name()` take, so a
-renderer standing the opponent behind their Pokémon draws the cartridge's own
-picture of them; `trainer_name` is the trainer's own name from the party record,
-not the class name. `exp_pixels` is a
-count out of 64, which is `PlaceExpBar`'s own unit; the exp bar is never a
-ratio, because `CalcExpBar` has already done the division and rounded it the
-cartridge's way.
+`view` carries plain values read out of a resolved battle event, never the battle
+engine itself:
 
-`enemy_shiny` and `player_shiny` say the individual on that square is shiny, so
-its picture is drawn in the shiny palette rather than the species one:
-`GameData.palette(number, shiny)` is the accessor both take, the same call
-`_CGB_BattleColors` makes through `GetMonNormalOrShinyPalettePointer`. They are
-about the individual and not the species, so they cannot be derived from
-`enemy_species` and `player_species`; a renderer that ignores them draws every
-shiny in normal colours. Both are `api_version` 11, pushed with the rest of the
-resolved battle fields.
+| Group | Fields |
+|---|---|
+| Who is standing | `enemy_species`, `player_species`, `enemy_name`, `player_name`, `enemy_level`, `player_level`, `enemy_shiny`, `player_shiny`, `enemy_unown_form`, `player_unown_form`, `enemy_substitute`, `player_substitute` |
+| The fight | `battle_kind` (`wild` or `trainer`), `trainer_class`, `trainer_index`, `trainer_name` |
+| Bars | `enemy_hp`, `enemy_max_hp`, `player_hp`, `player_max_hp`, `exp_pixels` |
+| HUD | `hud_visible`, `enemy_hud_visible`, `player_hud_visible`, `trainer_hud_balls`, `trainer_hud_border` |
+| Entrance | `battlers`, `intro_sprites`, `grayscale`, `enemy_trainer_pic`, `player_backpic`, `player_backpic_palette` |
+| Hardware | `raster_scx`, `raster_scy`, `bg_map`, `bg_vbank1`, `bg_palette_maps`, `ob_palette_maps`, `anim_sprites`, `anim_tiles` |
 
-`raster_scx` is the background's own horizontal scroll, one value per scanline
-in the order the hardware draws them, and empty whenever the background is
-sitting still, which is every frame outside the opening slide. An offset is a
-distance to look *right* into a background map 256 pixels wide against the
-screen's 160, so a larger one puts the drawn content further left and the map's
-blank columns wrap in behind it. `Gen2Raster.scroll(image, offsets, 256)` is
-that operation and is what the built-in renderer applies to each of its layers;
-a renderer that ignores the field simply draws no slide. `raster_scy`
-is the same thing vertically, which only a battle animation ever asks for;
-`Gen2Raster.scroll_rows(image, offsets, 256)` is that operation.
+Notes on the less obvious ones:
 
-The last six fields are the battle animation layer. `bg_map` is `wTilemap`, a
-20 by 18 grid of tile ids naming which tile of which battler's picture sits in
-each cell: `$00` up is the enemy's front pic and `$31` up the player's back pic,
-each `base + column * side + row`, and everything else is blank. A renderer
-draws the two pictures out of that map rather than at a fixed corner, because
-the map is what a battle animation edits, and `Gen2BattleScreenMap` is where the
-constants and the plain seeding live. `bg_palette_maps` and `ob_palette_maps`
-are eight DMG palette bytes each: colour `i` of palette `n` is drawn as colour
-`(byte >> i * 2) & 3` of whatever the battle loaded, which is `CopyPals`. A
-renderer that ignores all of it draws a battle with no animation in it.
+- A wild battle carries class 0, index 0 and an empty name. `trainer_class` is
+  what `GameData.trainer_pic()` and `trainer_name()` take; `trainer_name` is the
+  trainer's own name from the party record, not the class name.
+- `exp_pixels` is a count out of 64, `PlaceExpBar`'s own unit, never a ratio.
+- `enemy_unown_form` and `player_unown_form` are one-based letters for Unown and 0
+  otherwise. Non-zero means `GameData.unown_pic(form - 1, back)` in place of
+  `species_pic(number, back)`.
+- The two HP values and `exp_pixels` are the *drawn* values, not the committed
+  ones: a hit drains the bar over roughly a second and `set_view` is called on
+  every step. A renderer wanting a moving bar needs no work; one wanting the final
+  number should wait for the animation to end.
+- `anim_sprites` is `wShadowOAM` as the animation left it, up to forty
+  `{y, x, tile, attributes}` entries with the hardware's byte values: OAM
+  subtracts sixteen and eight, so a `y` or `x` of zero is off screen.
+- `anim_tiles` says where each tile of the animation window came from, as
+  `{gfx, tile}` counted from `Gen2BattleAnimObject.BASE_TILE`. An OAM tile id below
+  that base is not an animation tile.
+- `hud_visible` is false for the length of a move animation
+  (`BattleAnimClearHud` / `BattleAnimRestoreHuds`).
+- `grayscale` is true for the entrance slide, since `GetSGBLayout
+  SCGB_BATTLE_COLORS` runs only once `BattleIntroSlidingPics` returns.
+- `intro_sprites` is the eighteen `{tile, x, y}` of the player's head and
+  shoulders during the slide, empty outside it.
 
-`anim_sprites` is `wShadowOAM` as the animation left it, up to forty
-`{ y, x, tile, attributes }` entries with the hardware's own byte values: OAM
-subtracts sixteen and eight, so a `y` or `x` of zero is off screen, and the
-attributes carry the x and y flips and the object palette slot. `anim_tiles`
-says where each tile of the animation window came from, as
-`{ gfx, tile }` counted from `Gen2BattleAnimObject.BASE_TILE`, so an OAM tile id
-below that base is not an animation tile at all. `hud_visible` is false for the
-length of a move animation, which is `BattleAnimClearHud` taking the panels and
-both bars off the map and `BattleAnimRestoreHuds` putting them back.
+A renderer that ignores the hardware group draws a battle with no animation in it.
 
 ### The battlers
 
-A fight does not open with two Pokémon standing on the field. Two *trainers*
-slide in from opposite sides, the opponent sends out first, the player's back
-pic walks off, and a ball puts a Pokémon where each trainer was standing. Every
-field so far says that in the terms the hardware draws it in: the slide is a
-scanline scroll (`raster_scx`), the walk off is columns going blank in `bg_map`,
-and the player mid-slide is eighteen OAM entries (`intro_sprites`).
+A fight does not open with two Pokemon standing on the field. Two trainers slide
+in from opposite sides, the opponent sends out first, the player's back pic walks
+off, and a ball puts a Pokemon where each trainer stood. Everything that happens
+to a battler after that (a faint sinking the picture, a Fly or Dig user blanked
+for a turn, a recall, a send-out, and every deformation from Tackle to Vibrate) is
+a background-plane effect on the cartridge.
 
-Nothing that happens to a battler *after* the entrance is any different. A faint
-sinks the picture a tile row at a time inside `bg_map`; a Fly, Dig, Bounce,
-Teleport or Whirlwind user is blanked out of it for a turn; a recall and a
-send-out restamp it out of progressively smaller subsamplings of itself; and
-every per-battler deformation, Tackle, Withdraw, Psychic, DoubleTeam, AcidArmor,
-Wobble, Flail, WaveDeformMon, BounceDown and Vibrate, is a scanline window over
-that side's own rows.
-
-A renderer with no background plane has none of that, and reconstructing it by
-scanning a 20 by 18 grid every frame is both duplicated work and lossy: a resize
-script's arrangement and a faint sink read the same at the tile level. So
-`battlers` is all of it said plainly, one entry per side, on every frame:
+A renderer with no background plane has none of that, so `battlers` states it
+plainly, one entry per side, on every frame:
 
 ```gdscript
 view["battlers"] = {
@@ -1000,131 +825,66 @@ view["battlers"] = {
         "species": 0,                    # 0 unless kind is mon
         "visible": true,                 # false while the picture is off the square
         "offset_pixels": Vector2(142.0, 0.0),
-        "scale": Vector2.ONE,            # the resize script's own steps otherwise
+        "scale": Vector2.ONE,            # the resize script's steps otherwise
     },
     "enemy": { ... the same seven, with trainer_class carrying the class },
 }
 ```
 
-`kind` is what the square holds, and it is the whole of what a view drawing
-`player_species` from the first frame is missing: `&"trainer"` a person,
-`&"mon"` a Pokémon, and `&"none"` the stretch between the trainer walking off
-and the ball arriving. `backpic` is what `GameData.player_backpic(kind)` and
-`player_palette(kind)` take, `trainer_class` what `GameData.trainer_pic(number)`
-and `trainer_palette(number)` take, and `species` what `species_pic()` takes, so
-whichever one is set names a picture the renderer can resolve. A wild opponent
-is never a trainer and slides in as its own front pic.
+- `kind` is what the square holds. `&"none"` is the stretch between the trainer
+  walking off and the ball arriving. `backpic` feeds
+  `GameData.player_backpic(kind)` and `player_palette(kind)`, `trainer_class`
+  feeds `trainer_pic()` and `trainer_palette()`, `species` feeds `species_pic()`.
+  A wild opponent is never a trainer and slides in as its own front pic.
+- `visible` is whether the picture is on the square at all
+  (`BattleBGEffect_HideMon`, `..._RemoveMon`). Not the same question as `kind`:
+  `&"none"` is a square nobody stands on, `visible` false a picture taken away
+  from one somebody does.
+- `offset_pixels` is how far the picture stands from its resting square. Zero is
+  standing still. The player comes in from the right and leaves left, the opponent
+  the other way, and a faint is positive downwards. The whole-screen scroll is not
+  in it; `raster_scx` and `raster_scy` already carry that. For WaveDeformMon and
+  Psychic, which stretch rather than move, it is the mean of the window.
+- `scale` is the side of the square `BattleBGEffect_RunPicResizeScript` last placed
+  over the side of the whole picture, so a recall's shrink and a send-out's grow
+  are one number. `Vector2.ONE` is every frame outside a resize. The cartridge
+  subsamples rather than scales, so a renderer drawing a real scaled picture draws
+  it better than the hardware did.
 
-`visible` is whether the picture is on the square at all.
-`BattleBGEffect_HideMon` is what takes it off for a vanished turn and
-`..._RemoveMon` for a recall, and it stays off until a send-out puts a whole
-picture back. It is not the same question as `kind`: `&"none"` is a square
-nobody is standing on, `visible` false a picture that has been taken away from
-one somebody is.
+A renderer reading only `kind`, the three picture fields and `offset_pixels` draws
+a correct battle.
 
-`offset_pixels` is how far that picture stands from its resting square, and one
-number covers every movement because they are all the same thing: the slide
-brings a picture in, `SlideBattlePicOut` takes it off, `MonFaintedAnimation`
-sinks it, `RemoveMon` pushes it aside, and the window effects lunge, shake and
-sink it. Zero is standing still. The player comes in from the right and leaves to
-the left and the opponent the other way, so the sign is the direction, and a
-faint is positive downwards. The whole-screen scroll is not in it: `raster_scx`
-and `raster_scy` already carry that, and this is what is left after it. Two
-effects stretch the picture rather than move it, WaveDeformMon and Psychic, and
-for those the number is the mean of the window rather than an exact answer.
-
-`scale` is the side of the square `BattleBGEffect_RunPicResizeScript` last placed
-over the side of the whole picture, so the ball shrink of a recall and the grow
-of a send-out are one number. `Vector2.ONE` is the whole picture, which is every
-frame outside a resize. The cartridge subsamples rather than scales, dropping
-rows and columns, so a renderer drawing a real scaled picture is drawing it
-better than the hardware did rather than differently.
-
-A renderer that reads only `kind`, the three picture fields and `offset_pixels`
-draws exactly what it drew before this block existed.
-
-`intro_sprites` is the eighteen `{ tile, x, y }` of the player's own head and
-shoulders during the slide, drawn as OAM because those three tile rows fall in
-the band the opponent scrolls; it is empty outside the slide. `grayscale` is
-true for the same stretch, since `GetSGBLayout SCGB_BATTLE_COLORS` runs only
-once `BattleIntroSlidingPics` has returned. `enemy_trainer_pic` and
-`player_backpic` are which picture is on each square, zero and empty once a
-Pokémon has taken it, and `player_backpic_palette` is the `chris`, `kris` or
-`dude` whose colours the back pic is drawn in. `enemy_hud_visible` and
-`player_hud_visible` are the two panels one at a time, against `hud_visible`'s
-summary of both; `trainer_hud_balls` and `trainer_hud_border` are
-`BattleStart_TrainerHuds`' party balls and the frame they hang in, both empty
-once the fight has started. `enemy_substitute` and `player_substitute` say the
-doll is on the square rather than the Pokémon, which is the overworld
-substitute sprite rather than any species pic; `enemy_unown_form` and
-`player_unown_form` are one-based letters for Unown and nothing for every other
-species, and a non-zero one means `GameData.unown_pic(form - 1, back)` in place
-of `species_pic(number, back)`. `bg_vbank1` is `wAttrmap` bit
-3 over the screen, the VRAM bank each cell's tile number is read from, which
-only the enemy's own pic animation ever sets.
-
-`battlers` is `api_version` 17 and replaces `entrance`, which carried the first
-five fields alone and is gone: the two describe the same thing at different
-moments in one fight, and a renderer reading one for the opening and the other
-for the rest would have had to hold both. The twelve fields named in this section
-are `api_version` 11.
-Before it they were pushed and undeclared, and one more was declared and never
-true: `player_pic_visible` was a literal `true` in every view, because the
-premise behind it is wrong. `CopyBackpic` puts the player's back pic on the
-tilemap before `InitBattleDisplay` reaches the slide, so it is on the map
-throughout. The field is gone; `battlers` is what answers the question it was
-asked for.
-
-The two HP values and `exp_pixels` are the *drawn* ones, not the committed ones:
-a hit drains the bar over roughly a second the way the cartridge does, an award
-fills the exp bar over one, and `set_view` is called again on every step of
-either. A renderer that wants a bar to move needs no work; one that wants the
-final number should wait for the animation to end rather than reading the view,
-since mid-animation it is deliberately not the real value.
-
-Registration uses the same refusal rules as a world renderer, and shares both
-optional methods (`uses_hardware_viewport()`, `set_native_size()`), the one view
-selection above, and the `V` cycle, bound in `Gen2BattleScreen` the way
-`Gen2WorldScreen` binds it.
+### Where the battle is
 
 A battle renderer has two optional methods of its own:
 
 | Method | Effect |
 |---|---|
-| `set_world_context(context: Gen2BattleWorldContext)` | Where the battle is being fought, once per battle, after `set_battle_data` and before the first view |
-| `handle_battle_input(event: InputEvent) -> bool` | Every input event the battle screen did not use. Answering true consumes it |
+| `set_world_context(context: Gen2BattleWorldContext)` | Where the battle is fought. Once per battle, after `set_battle_data` and before the first view |
+| `handle_battle_input(event: InputEvent) -> bool` | Every input event the battle screen did not use. True consumes it |
 
-`handle_battle_input` is `handle_world_input`'s twin and follows the same rule:
-the screen claims what it needs and offers the rest, so a renderer can steer a
-camera and can never take a gameplay press. A `Gen2Button` is routed to whatever
-owns the screen before this is reached, on both sides, so the text box, the
-forget-move list, the pack's own rows and ball selection each take their press
-first and what arrives here is pointer and stick motion. Those three also
-withhold everything else while they are up, because a press there means
-something by itself. A draining bar, the opening slide and a move animation do
-not: none of them reads input, and a camera that stalls whenever a bar drains is
-not a camera.
+`handle_battle_input` follows `handle_world_input`'s rule: the screen claims what
+it needs and offers the rest. A `Gen2Button` is routed to whatever owns the screen
+first, so the text box, the forget-move list, the pack rows and ball selection each
+take their press and what arrives here is pointer and stick motion. Those three
+also withhold everything else while up. A draining bar, the opening slide and a
+move animation do not, since none reads input.
 
-`view` says what is on the field and nothing about the place, which is right for
-the cartridge's white field and leaves a renderer staging the fight on the map
-with nowhere to stage it. `Gen2BattleWorldContext` is that place, and it carries
-`map_id` (group and number), `tileset`, `player_cell`, `player_facing` and
-`time_of_day`, the last being the row the world was *drawn* with rather than the
-clock's, so a battle entered from an unlit cave is staged in the dark.
+`view` says what is on the field and nothing about the place.
+`Gen2BattleWorldContext` is the place: `map_id` (group and number), `tileset`,
+`player_cell`, `player_facing` and `time_of_day`, the last being the row the world
+was *drawn* with, so a battle entered from an unlit cave is staged in the dark.
 
-It is a copy taken when the battle starts, not a handle on the world: a renderer
-cannot reach live world state through it, and the two screens stay independent.
-The map and tileset are numbers, which is what `GameData.world_map()` and
-`world_tileset()` take, so a renderer resolves whatever records it wants through
-the `GameData` it already has. A battle started outside the world, which is
-every development driver, supplies none and the method is not called.
+It is a copy taken when the battle starts, not a handle: a renderer cannot reach
+live world state through it. The map and tileset are numbers for
+`GameData.world_map()` and `world_tileset()`. A battle started outside the world,
+which is every development driver, supplies none and the method is not called.
 
 ## Experience for a capture
 
 `register_catch_experience(manifest, provider)` makes a successful wild capture
-award the caught Pokemon's experience. `PokeBallEffect` awards none, so this is
-an addition rather than a correction, and it is off until a provider says
-otherwise:
+award the caught Pokemon's experience. `PokeBallEffect` awards none, so this adds
+rather than corrects, and it is off until a provider says otherwise:
 
 ```gdscript
 class Policy:
@@ -1132,28 +892,23 @@ class Policy:
 		return enabled
 ```
 
-Registered with the manifest `register()` was handed, the way
-[a save lifecycle](#holding-a-run-rather-than-an-installation) is: the run is
-what the policy belongs to. It is read on every throw, so switching a setting off
-mid-run is off from the next one.
+Registered with the manifest `register()` was handed, because the run is what the
+policy belongs to. It is read on every throw, so switching a setting off mid-run
+takes effect from the next one.
 
-The award is the engine's own `_give_experience_for`, the pass a faint takes, so
-participants, held Exp. Share splitting, stat experience, level ups, move offers,
+The award is the engine's own `_give_experience_for`, the same pass a faint takes,
+so participants, Exp. Share splitting, stat experience, level ups, move offers,
 happiness, evolution eligibility and the EXP-bar events are one implementation.
-The opponent is not pretended to have fainted. Everything it produces is spent
-between the Gotcha line and the nickname prompt, so nothing is filed with a level
-up still owed, and the party the experience landed on reaches the save before the
-world files the catch.
+The opponent is not pretended to have fainted. Everything is spent between the
+Gotcha line and the nickname prompt.
 
-The catching tutorial and a Bug Contest catch are excluded: neither is an
-ordinary capture.
+The catching tutorial and a Bug Contest catch are excluded.
 
 ## Annotating the battle
 
 `register_battle_info(id, provider)` draws read-only annotations on the hardware
-interface, over whichever battle renderer is selected. A provider receives a
-fresh plain snapshot and answers placements on the cartridge's own 20x18 tile
-grid:
+interface, over whichever battle renderer is selected. A provider receives a plain
+snapshot and answers placements on the cartridge's 20x18 tile grid:
 
 ```gdscript
 class Info:
@@ -1174,173 +929,150 @@ class Info:
 		return out
 ```
 
-A placement the grid cannot hold is refused rather than clipped, and the refusal
-reaches `Gen2ModHost.failures()` with the mod's id and why (`api_version` 18). A column that grows
-by a row per active stat stage runs off the bottom only when several are up at
-once, so what a player would otherwise see is a row quietly missing. It is
-recorded once per distinct refusal, not once a frame.
-
 A placement is `{"at": Vector2i}` plus one of:
 
 | Key | What it is |
 |---|---|
-| `text` | written with the interface's own font, cut at the right edge |
-| `tile` | one 8x8 cell: eight bytes of 1bpp, or sixty-four palette indices |
+| `text` | Written with the interface's own font, cut at the right edge |
+| `tile` | One 8x8 cell: eight bytes of 1bpp, or sixty-four palette indices |
 
 and one optional flag:
 
 | Key | What it is |
 |---|---|
-| `field` | `true` asks for the cartridge's interface field behind exactly the cells this placement occupies (`api_version` 14) |
+| `field` | `true` asks for the cartridge's interface field behind exactly the cells this placement occupies |
 
-so a mod can supply a symbol the cartridge has no glyph for without a Node, a
-renderer or any art of its own. A placement outside the grid, or one whose text
-does not fit, is refused rather than clipped.
+A placement outside the grid, or whose text does not fit, is refused rather than
+clipped, and the refusal reaches `Gen2ModHost.failures()` with the mod's id and
+why. It is recorded once per distinct refusal, not once a frame. Two providers
+claiming one cell is refused rather than resolved by load order.
 
-The interface font is the cartridge's, which is what a `tile` is for: there is no
-`+` in the charmap at all, and its `▲` is a code `_LoadFontsExtra2` parks in a run
-the main font does not carry. `-` is the only sign a string can print, so a stage
-summary reads `ATK2`/`SPD-1`, and a mark for super effective, resisted or immune
-is supplied as a tile. The example mod's three are a circle with a centre dot, a
-triangle and an X.
+The interface font is the cartridge's, which is what `tile` is for: there is no
+`+` in the charmap and `-` is the only sign a string can print, so a stage summary
+reads `ATK2`/`SPD-1` and a super-effective, resisted or immune mark is supplied as
+a tile. The example mod's three are a circle with a centre dot, a triangle and an
+X.
+
+Use `field` where ink would sit on bare battle scenery: a stage figure at the top
+of the screen or a weather glyph beside the enemy. A mark on the move list or over
+the command panel already has a field and should not set it. The host draws the
+field just below the annotations, at the opacity the selected renderer asks its
+interface to be drawn at.
 
 The snapshot carries what a subscriber of past events cannot know:
 
 | Key | |
 |---|---|
 | `player_stages`, `enemy_stages` | `Gen2BattleMon.stages`, live |
-| `player_species`, `enemy_species`, `player_level`, `enemy_level` | who is standing |
-| `enemy_types`, `enemy_identified` | the defender, and whether Foresight named it |
-| `enemy_seen_before` | whether this save had seen the opponent before this battle |
-| `weather`, `weather_turns` | what is on and how much is left |
-| `hud_visible`, `enemy_hud_visible`, `player_hud_visible`, `menu_stage`, `menu_position`, `move_cursor` | what is on screen |
-| `move_rows` | the move list, each row with its exact `effectiveness` |
-| `move_rows_at`, `move_rows_step`, `move_rows_right` | where `MoveSelectionScreen` puts its rows, so a provider annotating them never writes the menu's coordinates down |
-| `neutral` | what `effectiveness` compares against |
+| `player_species`, `enemy_species`, `player_level`, `enemy_level` | Who is standing |
+| `enemy_types`, `enemy_identified` | The defender, and whether Foresight named it |
+| `enemy_seen_before` | Whether this save had seen the opponent before this battle |
+| `weather`, `weather_turns` | What is on and how much is left |
+| `hud_visible`, `enemy_hud_visible`, `player_hud_visible`, `menu_stage`, `menu_position`, `move_cursor` | What is on screen |
+| `move_rows` | The move list, each row with its exact `effectiveness` |
+| `move_rows_at`, `move_rows_step`, `move_rows_right` | Where `MoveSelectionScreen` puts its rows |
+| `neutral` | What `effectiveness` compares against |
 
-`effectiveness` is `GameData.type_effectiveness` over the defender's own types
-with Foresight applied, so a mod never copies the type chart, never resolves a
-dual type itself and never rebuilds state from the event stream.
+`effectiveness` is `GameData.type_effectiveness` over the defender's types with
+Foresight applied, so a mod never copies the type chart.
 
-`field` exists because ink alone is only readable where something already put a
-field under it. A mark on the move list or a summary over the command panel has
-one; a stage figure at the top of the screen or a weather glyph beside the enemy
-sits on bare battle scenery, which is white in the built-in arena and arbitrary
-map geometry under a native-layer renderer. The host draws the field in a layer
-of its own immediately below the annotations, at the opacity the selected
-renderer asks its interface to be drawn at, and hides and restores it with the
-ink. A placement without the flag is unchanged, so do not set it where the
-interface already supplies a field.
+The layer is refreshed after every event, view push and menu change, and hidden
+from the frame a modal takes the interface: the party page, the pack and its
+sub-lists, ball selection, the forget offer, the naming prompt and the entrance.
 
-The layer is refreshed after every event, every view push and every menu change,
-and hidden from the frame a modal takes the interface: the party page, the pack
-and its sub-lists, ball selection, the forget offer, the naming prompt and the
-entrance. Ownership is answered where the host's own state changes, so a subflow
-added later hides the annotations without a provider being told anything. Two providers claiming one cell is refused rather than
-resolved by load order, so which mod loaded first cannot decide what a player
-sees.
-
-## Logical world state and optional mod pose
+## World state and mod pose
 
 The game stays logically grid-based. The player and NPCs occupy walk cells,
-movement commits one cell at a time in the four cardinal directions, and
-interactions use the current logical cell plus one cardinal facing. Animating a
-sprite between cells does not change that model.
+movement commits one cell at a time in four cardinal directions, and interactions
+use the current logical cell plus one cardinal facing. Animating a sprite between
+cells does not change that.
 
-A movement mod may add a more precise pose for smooth, analog, first-person or
-3D movement, with a sub-cell position and an arbitrary facing angle. It is an
-extra layer, not a replacement: the core world stays responsible for collision,
-cell transitions, map triggers, warps and script or NPC interactions, and a mod
-must not overwrite the authoritative cell or bypass those boundaries.
+A movement mod may add a more precise pose for smooth, analog, first-person or 3D
+movement, with a sub-cell position and an arbitrary facing angle. It is an extra
+layer, not a replacement. The core world stays responsible for collision, cell
+transitions, map triggers, warps and interactions, and a mod must not overwrite the
+authoritative cell or bypass those boundaries.
 
-When a mod requests an interaction it projects its pose back onto the normal
-rules: resolve a deterministic logical cell, quantize the facing angle to one of
-the four source directions using the source tie-breaking, and pass both to the
-existing interaction path. Smooth movement then leaves an NPC in the
-neighbouring cell interacting exactly as it would on the cartridge.
+When a mod requests an interaction it projects its pose back onto the normal rules:
+resolve a deterministic logical cell, quantize the facing angle to one of the four
+source directions using the source tie-breaking, and pass both to the existing
+interaction path.
 
 ## Putting one sprite in the world
 
 A mod that wants a follower, a pet, a marker over an object or a ghost of a
-previous run does not need a renderer: it registers a world **actor** and the
-built-in view draws it with the map's own objects.
+previous run registers a world **actor**, and the built-in view draws it with the
+map's own objects.
 
 ```gdscript
 func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
     host.register_world_actor(manifest.id, Follower.new())
 ```
 
-The actor is a `RefCounted` and never a `Node`, because it is a pose and not a
-view. Three methods, refused by name at registration the way a renderer's are:
+An actor is a `RefCounted` and never a `Node`, because it is a pose and not a view.
+Three methods, refused by name at registration:
 
 | Method | Called when |
 |---|---|
 | `set_world(world: Gen2WorldAPI)` | The map changed, or the view was created |
 | `advance_frame()` | Once per world frame, after the player's step advanced |
-| `sprites() -> Array` | What to draw now. A read: it is asked once a frame however many times the screen redraws |
+| `sprites() -> Array` | What to draw now. Asked once a frame however many times the screen redraws |
 
-Two more are **optional** (`api_version` 7) and offered only to an actor that
-defines them, so every actor already written keeps working:
+Two more are optional and offered only to an actor that defines them:
 
 | Method | Called when |
 |---|---|
-| `interact(cell: Vector2i, facing: int) -> bool` | A press of A that no cartridge object, background event or tile branch answered. `cell` is the player's faced cell and `facing` the player's own; the first actor answering true consumes the press |
+| `interact(cell: Vector2i, facing: int) -> bool` | A press of A that no cartridge object, background event or tile branch answered. The first actor answering true consumes the press |
 | `take_requests() -> Array` | The actor's one-shot outbox, drained once a world frame and emptied by the drain |
 
-`interact` is offered **only** after `Gen2WorldAPI.interact()` answered nothing at
-all, so a mod can never shadow a cartridge interaction. Only the actor's own pose
-changes, so no player event is spent, and a pose the press changed is on screen
-on the frame it was pressed.
+`interact` is offered only after `Gen2WorldAPI.interact()` answered nothing, so a
+mod can never shadow a cartridge interaction. Only the actor's pose changes, so no
+player event is spent.
 
-`take_requests` is where an **edge** goes; `sprites()` is where a **pose** goes.
-The one kind so far is `{"kind": &"cry", "species": n}`, played through the same
-player a script's `cry` command and the Pokedex CRY button use. A mod may not
-play a sound, so it asks and the host spends it, which is the bargain the shiny
-pulse already has; no dedup window is needed, since the mod asks once. Anything
-else in the outbox is dropped.
+`take_requests` is where an edge goes; `sprites()` is where a pose goes. The one
+request kind is `{"kind": &"cry", "species": n}`, played through the same player a
+script's `cry` command uses. A mod may not play a sound, so it asks and the host
+spends it. Anything else in the outbox is dropped.
 
-Each entry of `sprites()` is a dictionary naming cartridge art and nothing else:
+Each entry of `sprites()` names cartridge art and nothing else:
 
 | Key | Meaning |
 |---|---|
 | `icon` | An `IconPointers` row, as `GameData.mon_menu_icon(species)` answers it |
-| `sprite` | An `OverworldSprites` row instead, for an NPC or an object picture |
-| `facing` | `Gen2WorldSprite.FACING_*`. Right is the left picture mirrored, as on the cartridge |
-| `position_cells` | Where to draw it, in fractional walk cells, the unit `player_position_cells()` is in |
-| `colors` | Optional. Four colours to draw the sprite in instead of the map's own sprite palette. What a visible encounter wears, so a shiny one is a shiny one before the battle starts |
-| `emote` | Optional (`api_version` 7). `Gen2WorldActors.EMOTE_SHOCK` through `EMOTE_GRASS_RUSTLE`, drawn two rows above the sprite exactly as `SpawnEmote` puts one over a map object. State rather than an edge: it is up for as long as the entry keeps asking, so the mod owns the duration and the host owns the pixels, and a renderer reading `set_actors` gets it for free. An index outside the twelve is no emote rather than a wrong sheet |
+| `sprite` | An `OverworldSprites` row instead, for an NPC or object picture |
+| `facing` | `Gen2WorldSprite.FACING_*`. Right is the left picture mirrored |
+| `position_cells` | Where to draw it, in fractional walk cells |
+| `colors` | Optional. Four colours instead of the map's sprite palette. What a visible encounter wears, so a shiny one is shiny before the battle starts |
+| `emote` | Optional. `Gen2WorldActors.EMOTE_SHOCK` through `EMOTE_GRASS_RUSTLE`, drawn two rows above the sprite as `SpawnEmote` puts one over a map object. It is state, not an edge: up for as long as the entry keeps asking. An index outside the twelve is no emote |
 
-The host resolves the strip, the palette, the time of day and the icon's own
-two-frame animation (`.Frameset_PartyMon`'s rate), so a mod never composes
-pixels. An entry naming art the cache does not carry is dropped rather than
-drawn as a placeholder.
+The host resolves the strip, the palette, the time of day and the icon's two-frame
+animation, so a mod never composes pixels. An entry naming art the cache does not
+carry is dropped.
 
-An actor's sprite is **presentation**: it occupies no cell, blocks nothing,
-nobody talks to it, no trainer sees it and it is in no snapshot. That is what
-lets it exist at all, since world state is the one thing a mod must not write.
-Actors are sorted into the object pass by the row they stand on, so a follower
-one cell below an NPC is drawn over it.
+An actor's sprite is presentation. It occupies no cell, blocks nothing, nobody
+talks to it, no trainer sees it and it is in no snapshot. Actors are sorted into
+the object pass by the row they stand on, so a follower one cell below an NPC is
+drawn over it.
 
-A registered world renderer that wants to draw them takes them through the
-optional `set_actors(actors: Gen2WorldActors)`, which is handed the same
-resolved list the built-in view draws.
+A world renderer that wants to draw them takes the optional
+`set_actors(actors: Gen2WorldActors)`, handed the same resolved list.
 
 ### The map fades
 
-A warp spends `MapSetupScript_Door`'s two fades, sixteen frames in which no
-input is read. A renderer is offered each step of them through the optional
+A warp spends `MapSetupScript_Door`'s two fades, sixteen frames in which no input
+is read. A renderer is offered each step through the optional
 `set_fade(order: int, white_fill: bool)`: `order` is the palette order
 `DmgToCgbTimePals` applies to every palette on screen, and `white_fill` is
-`FillWhiteBGColor`, which the way out runs and the way in does not. The identity
-order (`Gen2WorldPalette.FADE_IDENTITY`) is every other frame of the game. A
-renderer that does not define it cuts to the new map on the frame the cartridge
-is at its whitest; the host spends the frames either way.
+`FillWhiteBGColor`, which only the way out runs. The identity order
+(`Gen2WorldPalette.FADE_IDENTITY`) is every other frame of the game. A renderer
+that does not define it cuts to the new map on the whitest frame; the host spends
+the frames either way.
 
 ## Visible wild encounters
 
-A mod that wants wild Pokemon standing on the map instead of a roll on every
-step registers a **provider** (`api_version` 2). It owns the population and
-nothing else; every rule a cartridge owns stays in `Gen2WorldAPI`.
+A mod that wants wild Pokemon standing on the map instead of a roll on every step
+registers a provider. It owns the population and nothing else; every rule a
+cartridge owns stays in `Gen2WorldAPI`.
 
 ```gdscript
 func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
@@ -1352,9 +1084,9 @@ registration:
 
 | Method | Called when |
 |---|---|
-| `set_context(context: Dictionary)` | The map changed, and again whenever the player's pose moves |
+| `set_context(context: Dictionary)` | The map changed, and whenever the player's pose moves |
 | `advance_frame()` | Once per hardware frame |
-| `encounters() -> Array` | The population now. A read, asked once a frame |
+| `encounters() -> Array` | The population now. Asked once a frame |
 | `battle_finished(id: StringName, result: Dictionary)` | A battle this provider's entry started ended |
 
 The context is a snapshot, never a live handle:
@@ -1362,152 +1094,120 @@ The context is a snapshot, never a live handle:
 | Key | Meaning |
 |---|---|
 | `map` | `Vector2i(group, number)` |
-| `eligible` | `{grass, surf}` to `PackedVector2Array` of cells a wild may stand on. `CanEncounterWildMon` per cell: the grass test, the cave and dungeon branch that skips it, and the ice refusal |
-| `occupied` | `PackedVector2Array` of the walk cells the map's own objects hold this frame: NPCs, item balls and every other map object, all four cells of a big one, and both cells an object mid-step is drawn across. Refreshed with `player`, not with `map`. Deliberately apart from `eligible`, which is a cartridge rule and never moves: an entry outside `eligible` is dropped, so folding the two together would delete a wild an NPC walks over. Refusing an occupied cell is the provider's own choice. The player's cell is not in it; `player` is where that is |
-| `tables` | `{grass, surf}` to `{source, slots}`, the table a roll would read right now, with the swarm's and the Bug Contest's substitutions already made and the time of day already picked. A slot is `{species, min_level, max_level}` |
+| `eligible` | `{grass, surf}` to `PackedVector2Array` of cells a wild may stand on. `CanEncounterWildMon` per cell |
+| `occupied` | The walk cells the map's own objects hold this frame: NPCs, item balls, all four cells of a big object, and both cells of one mid-step. Refreshed with `player`, not with `map`. An entry outside `eligible` is dropped, so the two are deliberately separate. Refusing an occupied cell is the provider's choice. The player's cell is not in it |
+| `tables` | `{grass, surf}` to `{source, slots}`, the table a roll would read now, with swarm and Bug Contest substitutions and the time of day already applied. A slot is `{species, min_level, max_level}` |
 | `player` | `{cell, facing}` |
-| `run_seed` | The run's own seed, so a population is reproducible |
-| `generation` | Bumped on every map change: a context with an older one is stale |
+| `run_seed` | The run's seed, so a population is reproducible |
+| `generation` | Bumped on every map change; an older one means the context is stale |
 
 Each entry of `encounters()`:
 
 | Key | Meaning |
 |---|---|
-| `id` | Stable across frames. It is what a battle result is reported back under |
-| `cell` | Must be in `eligible`; which method it is in decides which table it is checked against |
+| `id` | Stable across frames. What a battle result is reported under |
+| `cell` | Must be in `eligible`. Which method it is in decides which table it is checked against |
 | `facing` | `Gen2WorldSprite.FACING_*` |
 | `species`, `level` | Must be offered by that table |
 | `dvs` | The packed DV word, carried into the battle unchanged |
 | `pulse` | Optional. Ask for the shiny sparkle over this entry |
-| `glow` | Optional `{color: Color, amount: float}`. Walks the Pokemon's own colours toward `color` by `amount`, leaving colour 0 alone: it is the icon's cut-out. Presentation only, and it changes no DV, no battle and no roll |
+| `glow` | Optional `{color: Color, amount: float}`. Walks the Pokemon's colours toward `color` by `amount`, leaving colour 0 alone. Presentation only |
 
-Anything else is dropped rather than drawn, including an entry that names
-`shiny`: shininess is `CheckShininess` over the DVs and is the host's answer. A
-malformed `glow` costs the glow rather than the entry.
-At most `Gen2WorldEncounters.MAX_ENTRIES` entries are drawn in a frame.
+Anything else is dropped, including an entry naming `shiny`: shininess is
+`CheckShininess` over the DVs and is the host's answer. A malformed `glow` costs
+the glow rather than the entry. At most `Gen2WorldEncounters.MAX_ENTRIES` entries
+are drawn in a frame.
 
-`amount` is rounded onto `Gen2WorldEncounters.GLOW_RUNGS` steps by the host, so
-nine values between nothing and the full walk are all a mod can reach. That is
-not a nicety: both world renderers cache one sprite texture per distinct set of
-four colours and **neither evicts**, so a smoothly interpolated glow would leave
-a texture behind on every frame the map was up. Send whatever cycle you like;
-what reaches the palette is the nearest rung, and an amount that rounds to
-nothing is no glow at all. Eighths rather than quarters so that a mark meant to
-be subtle still has a cycle after the rounding: a peak under half the walk keeps
-four steps on eighths and one on quarters.
+`amount` is rounded onto `Gen2WorldEncounters.GLOW_RUNGS` steps, so nine values
+are all a mod can reach. Both world renderers cache one sprite texture per distinct
+set of four colours and neither evicts, so a smoothly interpolated glow would leak
+a texture every frame. Send whatever cycle you like; the nearest rung is what
+reaches the palette.
 
 What the host does with a valid population:
 
-- Draws it through the actor layer, with the SPECIES' own four colours, shiny or
-  not and glowing or not, so a renderer reading `set_actors` gets it for free:
-  the palette arrives in the same per-entry `colors` override a shiny's does.
+- Draws it through the actor layer with the species' own four colours, shiny or
+  not and glowing or not, so a renderer reading `set_actors` gets it for free.
 - Turns the ordinary post-step roll off while any provider is registered.
-  Scripted, fishing, Headbutt, Rock Smash, Sweet Scent and Bug Contest
-  encounters keep their own paths.
+  Scripted, fishing, Headbutt, Rock Smash, Sweet Scent and Bug Contest encounters
+  keep their own paths.
 - Starts the normal wild battle when the player steps onto an entry, with that
-  entry's exact species, level and DVs, then calls `battle_finished`. Whether
-  the entry survives that is the provider's one rule to document.
-- Discards the population, its sprites and any running pulse on a map change,
-  before the new map is drawn.
-- Plays `ANIM_SEND_OUT_MON` with the shiny param over a pulsing shiny entry,
-  anchored to it and with no battle field behind it, sound included. The host
-  deduplicates: a request inside `Gen2WorldEncounters.PULSE_FRAMES` of the last
-  one is dropped, so a provider may ask on spawn and every ten seconds without
-  touching a node or the audio service. A pulse on an ordinary Pokemon draws
-  nothing.
+  entry's exact species, level and DVs, then calls `battle_finished`. Whether the
+  entry survives is the provider's rule to document.
+- Discards the population, its sprites and any running pulse on a map change.
+- Plays `ANIM_SEND_OUT_MON` with the shiny param over a pulsing shiny entry, sound
+  included. A request inside `Gen2WorldEncounters.PULSE_FRAMES` of the last one is
+  dropped, so a provider may ask on spawn and every ten seconds. A pulse on an
+  ordinary Pokemon draws nothing.
 
 A world renderer that wants to draw the sparkle itself takes the optional
-`set_encounters(encounters: Gen2WorldEncounters)`; the population itself already
-arrives through `set_actors`.
+`set_encounters(encounters: Gen2WorldEncounters)`.
 
 ### The earthquake
 
 `Gen2WorldEffects.offset()` is `StepFunction_ScreenShake`, in hardware pixels and
-positive downward. It reaches hSCY on the cartridge and hSCY alone, so it is the
-**background's** offset and moves no sprite: the built-in view adds it to the
-camera the map quads are placed at and to nothing else. A renderer taking
-`set_effects` applies it the same way, or ignores it and does not shake.
+positive downward. It reaches hSCY alone, so it is the *background's* offset and
+moves no sprite. A renderer taking `set_effects` applies it to the camera the map
+is placed at, or ignores it and does not shake.
 
-## Hidden items a mod can see, and ask for
+## Hidden items
 
-A mod that wants something of its own to pick a hidden item up, a follower
-walking over one or a detector drawing them, reads them and **asks** for one
-(`api_version` 7). It never takes one: taking one writes the bag, the event flag
-and the save, and runs `hiddenitem`'s own `verbosegiveitem` with its FOUND text,
-its fanfare and its pack-full branch, all of which is world state a mod must not
-write.
+A mod that wants a follower or a detector to pick up a hidden item reads them and
+**asks** for one. It never takes one: taking one writes the bag, the event flag and
+the save, and runs `hiddenitem`'s own `verbosegiveitem` with its FOUND text,
+fanfare and pack-full branch.
 
 `Gen2WorldAPI.hidden_items()` is the read: one entry per `BGEVENT_ITEM` on the
-current map, taken or not. Scene-free, like `visible_encounter_cells()` beside
-it, so a probe can walk a map and print them with no game running.
+current map, taken or not. Scene-free, so a probe can walk a map with no game
+running.
 
 | Key | Meaning |
 |---|---|
 | `cell` | Where the record sits |
-| `item` | The item it gives, with the gameplay catalog's patch already applied |
-| `flag` | Its own event flag, which is the site's completion |
+| `item` | The item it gives, with the catalog's patch applied |
+| `flag` | Its event flag, which is the site's completion |
 | `taken` | `event_flag_active(flag)`. The Itemfinder's own test |
 
-`Gen2ModHost.request_hidden_item(cell)` is the ask. The mod names a cell and
-reads nothing back: the host validates it against that same list and, on the
-next world frame nothing else owns, runs the map's **own** script through the
-ordinary path, so the text box, the fanfare and the pacing are the world
-screen's exactly as they are for a player walking onto the cell. It is the same
-bargain a visible-encounter provider has with a wild battle: the mod names the
-entry, the host runs it.
+`Gen2ModHost.request_hidden_item(cell)` is the ask. The mod names a cell and reads
+nothing back. The host validates it against that list and, on the next free world
+frame, runs the map's own script through the ordinary path, so the text box, the
+fanfare and the pacing are the world screen's.
 
-- An ask for a cell with no record, or one whose flag is already set, does
-  nothing. `CheckBGEventFlag` is the host's test, not the mod's, and a set flag
-  now drops the ask when it is made rather than when it is spent.
-- An ask for a cell already in the queue is dropped too (`api_version` 18), so a
-  provider may read `hidden_items()` every frame and name what it stands on
-  without keeping its own set of what it has already asked for. The pack-full branch leaves the flag
-  clear and prints its box, and asking again after it is free and correct.
-- One is spent per frame, since the first one's script owns the world until its
-  box is pressed past; the rest wait in the queue in order.
+- An ask for a cell with no record, or whose flag is set, does nothing.
+- An ask for a cell already queued is dropped, so a provider may read
+  `hidden_items()` every frame and name what it stands on without tracking its own
+  asks. The pack-full branch leaves the flag clear, so asking again later works.
+- One is spent per frame; the rest wait in order.
 - An ask made inside a battle, a text box, a warp or an overlay is spent when the
   world can spend it rather than dropped.
 
-Which cell to name is the mod's own business.
+## Asking the host for an item
 
-## Asking the host to hand an item over
+`Gen2ModHost.request_item_gift(item, quantity)` is the twin for an item no map
+gives. The mod names an item and reads nothing back; on the next free world frame
+the host runs `verbosegiveitem`'s transaction: the bag write, the fanfare, the
+received line, the pocket line and the pack-full branch. The queue behaves exactly
+as a hidden item's. An unknown item number does nothing.
 
-`Gen2ModHost.request_item_gift(item, quantity)` is `request_hidden_item`'s twin
-for an item **no map gives** (`api_version` 16). The mod names an item and reads
-nothing back; on the next world frame nothing else owns, the host runs
-`verbosegiveitem`'s own transaction: the bag write, the fanfare, the received
-line, the pocket line and the pack-full branch.
-
-Everything on that list is world state a mod must not write, and the box, the
-sound and the pacing are a screen it cannot see. The queue behaves exactly as a
-hidden item's does, and for the same reasons: one spent per frame, an ask made
-inside a battle, a text box, a warp or an overlay spent when the world can spend
-it rather than dropped, and the rest waiting in order. An item number the
-cartridge does not know does nothing.
-
-Use it where the mod can **see** the moment but the script has no give site in
-it: `special Diploma` reaches the world channel as a `diploma_requested` runtime
-request, and the designer's script is `writetext`, `special Diploma`, `setevent`
-with nothing to patch. `patch_check` changes the number an existing site hands
-out; this is for when there is no site.
+Use it where the mod can see the moment but the script has no give site:
+`special Diploma` reaches the world channel as a `diploma_requested` runtime
+request, and the script is `writetext`, `special Diploma`, `setevent` with nothing
+to patch. `patch_check` changes the number an existing site hands out; this is for
+when there is no site.
 
 ## Reading the bag
 
-`Gen2ModHost.inventory()` answers the live world's own `{item: quantity}`, the
-same copy a Repel provider is handed, and `{}` when no world is open
-(`api_version` 16). Read only, and a copy.
+`Gen2ModHost.inventory()` answers the live world's `{item: quantity}`, and `{}`
+when no world is open. Read only, and a copy.
 
-One narrow accessor rather than a handle on `Gen2WorldAPI`, because a
-non-renderer mod is deliberately given no world: "do I hold this key item" is a
-question every gameplay mod has and the whole world is not the answer to it.
+It is one narrow accessor rather than a handle on `Gen2WorldAPI`, because a
+non-renderer mod is deliberately given no world.
 
-## How many times a wild's DVs are rolled
+## Shiny rolls
 
-Every wild the game builds rolls its own DVs, off the battle's own generator, the
-way `LoadEnemyMon` does: shininess, a bad stat and which Hidden Power it answers
-are all facts about those four numbers. `register_shiny_rolls(id, provider)` says
-how many words one wild is drawn with, which is the later games' charm
-(`api_version` 16):
+Every wild the game builds rolls its own DVs off the battle's generator, the way
+`LoadEnemyMon` does. `register_shiny_rolls(id, provider)` says how many words one
+wild is drawn with, which is the later games' charm:
 
 ```gdscript
 class Held:
@@ -1515,36 +1215,31 @@ class Held:
 		return 3 if int(Gen2ModHost.instance().inventory().get(SHINY_CHARM, 0)) > 0 else 1
 ```
 
-The host draws up to that many, keeps the first that `Gen2Stats.is_shiny`
-accepts and otherwise keeps the last, and clamps to
-`Gen2ModHost.MAX_SHINY_ROLLS`. 0 and 1 both mean the cartridge's own single
-roll, which is also what an unregistered host does.
+The host draws up to that many, keeps the first that `Gen2Stats.is_shiny` accepts
+and otherwise the last, and clamps to `Gen2ModHost.MAX_SHINY_ROLLS`. 0 and 1 both
+mean the cartridge's single roll.
 
 | `context` key | Meaning |
 |---|---|
 | `species` | What is about to be built |
 | `level` | Its level, already chosen |
-| `method` | The encounter method, empty for a wild with no method behind it |
+| `method` | The encounter method, empty where there is none |
 | `map_group`, `map_number` | Where, or -1 apiece |
 
-It carries no bag: `inventory()` is the live one, and a snapshot per wild would
-be a staler answer than the mod can get for itself.
+It carries no bag; `inventory()` is the live one.
 
-Three wilds keep an answer of their own and no provider is asked: one whose
-request already carries `dvs`, which is the Pokemon a visible encounter's player
-walked up to; `BATTLETYPE_FORCESHINY`, which is the red Gyarados and is written
-rather than rolled; and a roaming Pokemon, which keeps its stored word. A wild
-UNOWN rerolls until its letter is one the Ruins of Alph puzzle has unlocked.
+Three wilds keep their own answer and no provider is asked: one whose request
+already carries `dvs` (the Pokemon a visible encounter's player walked up to),
+`BATTLETYPE_FORCESHINY` (the red Gyarados), and a roaming Pokemon, which keeps its
+stored word. A wild UNOWN rerolls until its letter is one the Ruins of Alph puzzle
+has unlocked.
 
-**Two providers compose by the largest answer**, rather than by registration
-order: two charms have an obvious join, and refusing the second by name would
-make installing both an error over a number.
+Two providers compose by the largest answer rather than by registration order.
 
 ## An alternate field-move source
 
-`register_field_move_source(id, provider)` says that an HM's field move may be
-used without a party member who knows it. The provider is read only and answers
-one question:
+`register_field_move_source(id, provider)` says an HM's field move may be used
+without a party member who knows it. The provider is read only:
 
 ```gdscript
 class Anywhere:
@@ -1552,36 +1247,35 @@ class Anywhere:
 		return true
 ```
 
-That is the whole of what a mod decides. The host owns everything else:
+The host owns everything else:
 
 | Question | Where the host answers it |
 |---|---|
-| Which item teaches which move | `GetTMHMItemMove`, so a mod writes no HM table |
-| Whether it is in the bag | the live world's own items |
-| Whether the badge is in hand | each `Try*OW`'s own `CheckBadge`, in source order |
-| Whether the tile allows it | the staged request the party submenu already reaches |
-| What the move then does | the same commit, animation and script |
+| Which item teaches which move | `GetTMHMItemMove` |
+| Whether it is in the bag | The live world's items |
+| Whether the badge is in hand | Each `Try*OW`'s own `CheckBadge` |
+| Whether the tile allows it | The staged request the party submenu reaches |
+| What the move then does | The same commit, animation and script |
 
-The party is always asked first, so a game with no provider resolves every field
-move exactly as it always has, and a Pokemon that knows the move keeps its own
-submenu row. Only the seven HM moves have an alternate source: CUT, FLY, SURF,
-STRENGTH, FLASH, WHIRLPOOL and WATERFALL. Rock Smash is a TM.
+The party is asked first, so a game with no provider resolves every field move
+exactly as before, and a Pokemon that knows the move keeps its submenu row. Only
+the seven HM moves have an alternate source: CUT, FLY, SURF, STRENGTH, FLASH,
+WHIRLPOOL and WATERFALL. Rock Smash is a TM.
 
-The source is carried through every entrance rather than one: the party submenu,
-`Gen2WorldAPI`'s staged request and complete pairs, the A-button prompts at a
-tree, water, a whirlpool and a waterfall, the Strength boulder script, Flash, and
-Fly's region map. A move with no Pokemon behind it prints the host's own
-`<PLAYER> used CUT!` and surfs on the ordinary sprite.
+The source is carried through every entrance: the party submenu, `Gen2WorldAPI`'s
+staged request and complete pairs, the A-button prompts at a tree, water, a
+whirlpool and a waterfall, the Strength boulder script, Flash, and Fly's region
+map. A move with no Pokemon behind it prints `<PLAYER> used CUT!` and surfs on the
+ordinary sprite.
 
-FLY and FLASH are chosen from no tile and no party member, so the start menu
-grows a **MOVES** row for them: one entry per HM move the bag can supply, the
-party does not know and the badge allows. It is absent whenever that list is
-empty, which is every game with no provider registered.
+FLY and FLASH are chosen from no tile and no party member, so the start menu grows
+a **MOVES** row: one entry per HM move the bag can supply, the party does not know
+and the badge allows. It is absent when that list is empty.
 
 ## Renewing a Repel
 
-`register_repel_renewal(id, provider)` is offered the step an active Repel runs
-out on, before the encounter roll:
+`register_repel_renewal(id, provider)` is offered the step an active Repel runs out
+on, before the encounter roll:
 
 ```gdscript
 class Weakest:
@@ -1592,86 +1286,75 @@ class Weakest:
 		return 0
 ```
 
-`inventory` is a copy of the bag as `{item: quantity}`. Answering an item number
-puts the cartridge's own YES/NO box over the map; YES runs the pack's own field
-item transaction, so exactly one item is spent and its own step count applied,
-and NO changes nothing. Answering 0 changes nothing at all, which is what an
-empty bag and an unregistered host both do.
+`inventory` is a copy of the bag. Answering an item number puts the cartridge's
+YES/NO box over the map; YES runs the pack's own field item transaction, so exactly
+one item is spent and its step count applied. Answering 0 changes nothing.
 
-The question is the step's own player event, so no wild is rolled underneath it.
-An offer landing on a step a script, a warp, an overlay or a battle already owns
-waits for a step that can spend it rather than being lost.
+The question is the step's own player event, so no wild is rolled underneath it. An
+offer landing on a step a script, warp, overlay or battle owns waits for a step
+that can spend it.
 
-## Measured against the voxel mod
+## What a renderer mod needs
 
-[DramaticShapeVoxelMod](https://github.com/DramaticShape/DramaticShapeVoxelMod)
-is the reference for what a renderer mod has to be able to do: a voxel diorama
-with selectable camera pitch, first and third person, VR, reflections and a day
-cycle, shipping no cartridge art. Everything it needs is in the contract above.
-Geometry comes from collision permissions, the block grid and the tileset atlas;
-the view runs at window resolution; animated tiles follow because
-`Gen2WorldAnimation` replaces atlas slots rather than map rectangles.
+[DramaticShapeVoxelMod](https://github.com/DramaticShape/DramaticShapeVoxelMod) is
+the reference for what a renderer mod has to be able to do: a voxel diorama with
+selectable camera pitch, first and third person, VR, reflections and a day cycle,
+shipping no cartridge art. Everything it needs is in the contract above.
 
-Movement is the one part worth naming. `Gen2WorldAPI.player_step_offset_cells()`
-and `Gen2WorldObject.step_offset_cells()` return an in-flight step as a
-fractional cell, from one cell behind the committed cell down to zero. The
-logical cell commits at the start of the step; the fraction is presentation only
-and never reaches collision, events or the snapshot. `applymovement` applies its
-whole stream at once, so a scripted path commits together and the offset trails
-by as many cells as are left to draw; `advance_scripted_steps_pass()` drains
-that trail, 16 overworld passes a step for the slow commands, 8 for plain, 4 for
-bike speed. A pass is two hardware frames
-(`Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS`, `MaxOverworldDelay`), so a plain step
-covers its cell in sixteen of them. `Gen2WorldObject.frame` is the cartridge's
-`Facings` index, 0 to 3, changing every four passes the way
-`SetFacingStepAction` does.
-`mods/examples/voxel_preview/` reads all of it.
+Movement is the part worth naming. `Gen2WorldAPI.player_step_offset_cells()` and
+`Gen2WorldObject.step_offset_cells()` return an in-flight step as a fractional
+cell, from one cell behind the committed cell down to zero. The logical cell
+commits at the start of the step; the fraction is presentation only and never
+reaches collision, events or the snapshot.
+
+`applymovement` applies its whole stream at once, so a scripted path commits
+together and the offset trails by as many cells as are left to draw;
+`advance_scripted_steps_pass()` drains that trail, 16 overworld passes a step for
+the slow commands, 8 for plain, 4 for bike speed. A pass is two hardware frames
+(`Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS`, `MaxOverworldDelay`).
+`Gen2WorldObject.frame` is the cartridge's `Facings` index, 0 to 3, changing every
+four passes.
 
 A hop is the one step with a second axis.
 `Gen2WorldAPI.player_height_offset_pixels()` and
-`Gen2WorldObject.height_offset_pixels()` return how far above the ground the
-sprite is drawn, in world pixels and positive upward, which is
-`UpdateJumpPosition`'s own `.y_offsets` table over the step's frames. It is zero
-at rest, zero on every ordinary step, and zero again on the frame the hop
-completes; only a ledge hop and the three `jump_step` movement commands raise it,
-and each of those covers two cells over twice its command's frames. Presentation
-only, like the horizontal offset beside it: the cell, the collision, the triggers
-and the snapshot are at the landing cell for the whole arc.
+`Gen2WorldObject.height_offset_pixels()` return how far above the ground the sprite
+is drawn, in world pixels and positive upward, which is `UpdateJumpPosition`'s
+`.y_offsets` table over the step's frames. It is zero at rest, on every ordinary
+step, and on the frame the hop completes. Only a ledge hop and the three
+`jump_step` commands raise it, each covering two cells. Presentation only: the
+cell, the collision, the triggers and the snapshot are at the landing cell for the
+whole arc.
 
 Not covered: the teleport, skyfall and dig step types. `teleport_from`,
 `teleport_to`, `skyfall` and `step_dig` reach the caller as a
 `movement_command_requested` event and change nothing. None moves a cell on the
-cartridge either, each being a spin, a rise or a fall over a fixed frame count
-(`StepFunction_TeleportFrom` and its neighbours), so each is a pose a renderer
-has to be told about rather than an offset it can read.
+cartridge either, so each is a pose a renderer has to be told about rather than an
+offset it can read.
 
-**Per-block height is deliberately not a host boundary.** A renderer resolves
-shape from the collision permissions, the block grid and the tileset, all
-already public, and keeps whatever table it needs beside its own resolver. A
-host-side one would be a second place for the same facts.
+Per-block height is deliberately not a host boundary. A renderer resolves shape
+from the collision permissions, the block grid and the tileset, all already public.
 
 ## Adding a menu entry
 
 `register_menu_entry(menu, id, entry)` appends to a menu the game builds. The
-cartridge's own entries are never registered, so a mod can add but not reorder
-or remove them.
+cartridge's own entries are never registered, so a mod can add but not reorder or
+remove them.
 
 | Menu | Where the entry lands | `entry` keys |
 |---|---|---|
-| `Gen2ModHost.MENU_START` | the start menu, immediately before EXIT | `label`, optional `handler: Callable` |
-| `Gen2ModHost.MENU_PACK_POCKET` | after the pack's four source pockets | `label`, `pocket` |
-| `Gen2ModHost.MENU_MART` | after a mart's cartridge shelf | `label`, `item`, optional `price`, optional `available(mart)` |
+| `Gen2ModHost.MENU_START` | The start menu, immediately before EXIT | `label`, optional `handler: Callable` |
+| `Gen2ModHost.MENU_PACK_POCKET` | After the pack's four source pockets | `label`, `pocket` |
+| `Gen2ModHost.MENU_MART` | After a mart's cartridge shelf | `label`, `item`, optional `price`, optional `available(mart)` |
 
 ```gdscript
-func register(host: Gen2ModHost, manifest: Gen2ModManifest) -> void:
-	host.register_menu_entry(Gen2ModHost.MENU_START, manifest.id, {
-		"label": "Atlas",
-		"handler": func() -> void: print("opened"),
-	})
+host.register_menu_entry(Gen2ModHost.MENU_START, manifest.id, {
+	"label": "Atlas",
+	"handler": func() -> void: print("opened"),
+})
 ```
 
-A start-menu entry may name a host **action** instead of a handler, for a row
-whose work is opening a screen a mod never receives:
+A start-menu entry may name a host **action** instead of a handler, for a row whose
+work is opening a screen a mod never receives:
 
 ```gdscript
 host.register_menu_entry(Gen2ModHost.MENU_START, manifest.id, {
@@ -1681,41 +1364,35 @@ host.register_menu_entry(Gen2ModHost.MENU_START, manifest.id, {
 })
 ```
 
-`Gen2ModHost.START_ACTIONS` is the allow list; `OPEN_BILLS_PC` opens BILL'S PC
-at the same top menu the Pokemon Center's machine reaches, and its SEE YA! or B
-returns through the ordinary start-menu flow. An optional `visible(context)`
-predicate is asked with a copy of `{party_count, pokedex, pokegear}` and leaves
-the row ABSENT rather than present and refused, which is what the cartridge's own
-gated rows do. The host applies its own gate after the predicate, so a row cannot
-be shown where the game would refuse it: `OPEN_BILLS_PC` needs a party, which is
-`PC_CheckPartyForPokemon`.
+`Gen2ModHost.START_ACTIONS` is the allow list. `OPEN_BILLS_PC` opens BILL'S PC at
+the same top menu the Pokemon Center's machine reaches. An optional
+`visible(context)` predicate is asked with a copy of
+`{party_count, pokedex, pokegear}` and leaves the row *absent* rather than present
+and refused. The host applies its own gate after the predicate, so a row cannot be
+shown where the game would refuse it: `OPEN_BILLS_PC` needs a party.
 
-**The start menu shows eight rows at once and scrolls past that.** A fully
-unlocked save already fills those eight (POKEDEX, POKEMON, PACK, POKEGEAR, the
-player's name, SAVE, OPTION, EXIT), so the MODS row and every registered row are
-reached by scrolling: the box stays the height of the screen, the window follows
-the cursor, and the cursor still wraps at both ends, so any row is reachable in
-either direction and EXIT is one press up from the top one. The Bug Contest's own
-list starts two rows lower and shows seven. A mod may register any number of
-rows; only how many are on screen at once is fixed.
+The start menu shows eight rows at once and scrolls past that. A fully unlocked
+save already fills those eight, so the MODS row and every registered row are
+reached by scrolling: the window follows the cursor, and the cursor wraps at both
+ends. The Bug Contest's list starts two rows lower and shows seven. A mod may
+register any number of rows.
 
 A start-menu entry with neither an action nor a handler still appears, marked
-unavailable. A pocket's number has to be at or
-above `Gen2ModHost.FIRST_MOD_POCKET`: 1 to 4 are the cartridge's ITEM, KEY_ITEM,
-BALL and TM_HM, and an item joins the pocket its own definition names. Two mods
-claiming the same entry id is refused with `duplicate_menu_entry` rather than one
-silently winning.
+unavailable. A pocket's number must be at or above `Gen2ModHost.FIRST_MOD_POCKET`;
+1 to 4 are the cartridge's ITEM, KEY_ITEM, BALL and TM_HM, and an item joins the
+pocket its own definition names. Two mods claiming one entry id is refused with
+`duplicate_menu_entry`.
 
 A mart filter receives the resolved mart dictionary, including `mart_id`,
-`dialog_id` and `variant`. Its row is omitted when the filter answers false or
-the source shelf already sells that item. Selection still goes through the
-ordinary mart transaction, including money, stack limits and save validation.
+`dialog_id` and `variant`. Its row is omitted when the filter answers false or the
+source shelf already sells that item. Selection goes through the ordinary mart
+transaction, including money, stack limits and save validation.
 
 ## Adding a row to a party member's menu
 
-`register_party_member_menu(id, entry)` appends to the box a party slot opens.
-Both halves are Callables taking the ONE-based slot, because a row here is about
-a member rather than about the menu:
+`register_party_member_menu(id, entry)` appends to the box a party slot opens. Both
+halves are Callables taking the one-based slot, because a row here is about a
+member rather than about the menu:
 
 ```gdscript
 host.register_party_member_menu(manifest.id, {
@@ -1726,22 +1403,19 @@ host.register_party_member_menu(manifest.id, {
 })
 ```
 
-Rows land after every cartridge action and before CANCEL, which is the way out
-of the box; a mod cannot displace or reorder a cartridge row, and the list still
-stops at the source's own `NUM_MONMENU_ITEMS`. A label answering an empty string
-drops its own row, which is how a row is shown conditionally. Choosing one calls
-the handler and closes the menu, the way a field move does.
+Rows land after every cartridge action and before CANCEL. The list still stops at
+the source's `NUM_MONMENU_ITEMS`. A label answering an empty string drops its own
+row, which is how a row is shown conditionally. Choosing one calls the handler and
+closes the menu.
 
-Not offered for an egg, and not offered inside a battle: a battle's party list is
-a switch, and a row running a mod's action in the middle of a turn would be world
-state changing while the turn owns it.
+Not offered for an egg, and not inside a battle, where the party list is a switch.
 
 ## Adding a page to the stats screen
 
 `register_stats_page(id, {"build": Callable})` adds a page after the cartridge's
-pink, green and blue. `build` takes the screen's snapshot and answers placements
-on its own 20x18 tile grid; the host writes them with the screen's font, so the
-page needs no node, no renderer and no art:
+pink, green and blue. `build` takes the screen's snapshot and answers placements on
+its own 20x18 tile grid; the host writes them with the screen's font, so the page
+needs no node, renderer or art:
 
 ```gdscript
 host.register_stats_page(manifest.id, {
@@ -1756,70 +1430,64 @@ host.register_stats_page(manifest.id, {
 
 | Placement | Draws |
 |---|---|
-| `{"text": String, "at": Vector2i}` | the string at that tile |
-| `{"divider": int}` | the pink and blue pages' own vertical divider down that column |
+| `{"text": String, "at": Vector2i}` | The string at that tile |
+| `{"divider": int}` | The pink and blue pages' vertical divider down that column |
 
-The lower half is rows 8 to 17 and a placement outside it is dropped, which is
-what keeps a page off the upper half's name, level and front pic. The snapshot is
-`Gen2MonStatsScreen.snapshot`, which carries `dvs` (the packed word,
-`Gen2Stats.attack_dv` and friends read it) and `stat_exp` (keyed `hp`, `attack`,
-`defense`, `speed`, `special`) beside everything the cartridge pages print.
+The lower half is rows 8 to 17 and a placement outside it is dropped, which keeps a
+page off the upper half's name, level and front pic. The snapshot is
+`Gen2MonStatsScreen.snapshot`, which carries `dvs` (the packed word, read with
+`Gen2Stats.attack_dv` and friends) and `stat_exp` (keyed `hp`, `attack`, `defense`,
+`speed`, `special`) beside everything the cartridge pages print.
 
-Pages turn with LEFT and RIGHT and wrap, A on the last page leaves the screen,
-and the 2x2 page indicators are centred against the right arrow with the left
-arrow moving to meet them. Five pages is the ceiling
-(`Gen2StatsScreenPage.MAX_PAGES`): a sixth block reaches the front pic. Past it
-registration is refused with `stats_pages_full`, and a second mod claiming one id
-with `duplicate_stats_page`. An egg has no pages at all, so a registered one is
-not reached for it, the way the cartridge's own are not.
+Pages turn with LEFT and RIGHT and wrap, A on the last page leaves the screen, and
+the 2x2 page indicators are centred against the right arrow. Five pages is the
+ceiling (`Gen2StatsScreenPage.MAX_PAGES`); past it registration is refused with
+`stats_pages_full`, and a second mod claiming one id with `duplicate_stats_page`.
+An egg has no pages at all.
 
 ## Holding a run rather than an installation
 
 A mod whose settings decide what a whole playthrough looks like has a problem
-`read_save_data` alone does not solve: an installation option changed mid-run
-would silently rewrite the save being played, and opening another save could not
-restore the settings that made it. `register_save_lifecycle(manifest, provider)`
-is the seam for that.
+`read_save_data` alone does not solve: an installation option changed mid-run would
+silently rewrite the save being played, and opening another save could not restore
+the settings that made it. `register_save_lifecycle(manifest, provider)` is the
+seam for that.
 
-The `manifest` is the object `register()` was handed, and it IS the capability:
+The `manifest` is the object `register()` was handed, and it *is* the capability:
 the host keeps it beside the provider, so a callback reaches
 `read_save_data`/`write_save_data` for its own namespace and no other mod's. A
 manifest this host never discovered registers nothing.
 
 | Method | Called when |
 |---|---|
-| `save_created(save)` | A save has just been made, before it is written. Snapshot whatever the run is built from into your namespace here |
-| `save_activated(save)` | That save is about to be played. `save` is `null` for a DEVELOPMENT run, one started with no selected slot |
+| `save_created(save)` | A save has just been made, before it is written. Snapshot whatever the run is built from |
+| `save_activated(save)` | That save is about to be played. `save` is `null` for a development run |
 | `save_deactivated()` | The save was closed |
 
-Ordering, which is the part that matters:
+Ordering:
 
 1. The host drops every lifecycle mod's overlay contributions, in one pass.
 2. `save_activated` runs, in registration order.
 
-So a provider always starts from the cartridge, two slots cannot leak patches
-into one another, and a provider that fails leaves nothing installed rather than
-the previous run's shuffle. `save_deactivated` clears afterwards, so nothing
-stays patched by a run nobody is playing.
+So a provider always starts from the cartridge, two slots cannot leak patches into
+one another, and a provider that fails leaves nothing installed.
 
-Save the compact INPUTS plus an algorithm version, not the generated plan: a plan
+Save the compact *inputs* plus an algorithm version, not the generated plan: a plan
 can exceed the 64 KiB namespace and duplicates cartridge rows anyway. A save
-carrying no snapshot has no run and should stay vanilla rather than adopt today's
-options.
+carrying no snapshot has no run and should stay vanilla.
 
 Registered settings need none of that. The host snapshots them onto the save
-itself (`Gen2SaveData.run_options`) when it is created, binds that snapshot while
-the slot is played, and puts a change made mid-run into the save rather than into
-the installation. So `host.option()` answers with what THIS run is played with,
-the launcher edits the installation with no slot open, and a slot written before
-the snapshot existed adopts the installation once, when it is first activated.
+(`Gen2SaveData.run_options`) when it is created, binds that snapshot while the slot
+is played, and puts a mid-run change into the save rather than the installation. So
+`host.option()` answers with what *this* run is played with, the launcher edits the
+installation with no slot open, and a slot written before the snapshot existed
+adopts the installation once, on first activation.
 
 ## Reading the run's rules
 
 `world.rules` is a `Gen2Rules`: which of the cartridge's own bugs this run
 reproduces, and its trainer-AI difficulty. Read it, do not write it. A rule that
-changed mid-run would make the save it produced unreproducible, which is the
-whole reason the rules belong to the run rather than to the installation.
+changed mid-run would make the save it produced unreproducible.
 
 ```gdscript
 if world.rules.reproduces(&"metal_powder_overflow"):
@@ -1828,22 +1496,21 @@ if world.rules.difficulty == Gen2Rules.DIFFICULTY_HARD:
 	...
 ```
 
-`Gen2Rules.FLAGS` is every flag this build names, mapped to what it does by
-default. Each is named for the HARDWARE's behaviour, so a flag that is on means
-the cartridge's bug is reproduced and off means this project's corrected answer is
-used. An unknown flag answers false rather than failing, so a mod written against
-a later build still runs.
+`Gen2Rules.FLAGS` is every flag this build names, mapped to its default. Each is
+named for the *hardware's* behaviour, so a flag that is on means the cartridge's
+bug is reproduced and off means this project's corrected answer is used. An unknown
+flag answers false rather than failing, so a mod written against a later build
+still runs.
 
 The same object is on a battle (`battle.rules`), and exactly one set is installed
-at a time (`Gen2Rules.active()`) because the damage formula and the experience
+at a time (`Gen2Rules.active()`), because the damage formula and the experience
 curves are statics with no engine object to read it off.
 
 ## Adding a setting
 
-`register_option(id, option)` describes one setting: a ladder of values, a
-number in a range, or a button. The
-game and the launcher each build a surface from that one registration, so a mod
-writes no settings screen and the two can never disagree.
+`register_option(id, option)` describes one setting: a ladder of values, a number
+in a range, or a button. The game and the launcher each build a surface from that
+one registration, so a mod writes no settings screen.
 
 ```gdscript
 host.register_option(manifest.id, {
@@ -1857,65 +1524,56 @@ host.register_option(manifest.id, {
 |---|---|
 | `key` | Addresses the setting within the mod |
 | `label` | Shown to the player |
-| `kind` | Optional; `Gen2ModHost.OPTION_LADDER` (the default), `OPTION_NUMBER` or `OPTION_BUTTON` |
+| `kind` | Optional. `Gen2ModHost.OPTION_LADDER` (default), `OPTION_NUMBER` or `OPTION_BUTTON` |
 | `values` | The rungs, at least one. A toggle is a two-rung ladder. Ladder only |
-| `labels` | Optional; what each rung is shown as, defaulting to the values |
+| `labels` | Optional. What each rung is shown as, defaulting to the values |
 | `minimum`, `maximum` | The range, inclusive. Number only |
-| `step` | Optional; what one press moves the value by, defaulting to 1. Number only |
-| `default` | Optional; the rung or the number used until the player picks one, defaulting to the first rung or the minimum |
-| `press_label` | Optional; what a button setting's control reads, defaulting to `Go`. Button only |
+| `step` | Optional. What one press moves the value by, default 1. Number only |
+| `default` | Optional. The rung or number used until the player picks one |
+| `press_label` | Optional. What a button's control reads, default `Go`. Button only |
 
-A **number** setting is one whole value in a range rather than a ladder with
-every rung written out: a randomizer's seed is one field with ten thousand
-values, and dialling it as four one-digit ladders spends four menu rows on one
-value. Set it with `set_option(id, key, value)`, clamped into the range as
-registered now, or step it with `adjust_option(id, key, delta)`, which is what
-both surfaces call and which steps a ladder just as well. The launcher draws it
-as a field that can be typed into; the start menu steps it left and right.
+A **number** setting is one whole value in a range: a randomizer's seed is one
+field with ten thousand values, and dialling it as four one-digit ladders would
+spend four menu rows. Set it with `set_option(id, key, value)`, clamped into the
+range, or step it with `adjust_option(id, key, delta)`, which both surfaces call
+and which steps a ladder just as well. The launcher draws it as a typed field; the
+start menu steps it left and right.
 
 A **button** setting is a press rather than a ladder, for something with no value
-to keep: "recentre the camera now" is an action, not a rung. It stores nothing,
-`press_option(id, key)` is what both surfaces call, and `option_changed` carries
-a null value to say the press is the whole setting.
+to keep. It stores nothing, `press_option(id, key)` is what both surfaces call, and
+`option_changed` carries a null value.
 
-Read it back with `host.option(id, key)`, or `option_index(id, key)` for the
-rung, which is -1 for anything that is not a ladder.
-A mod that has to rebuild something on a change connects to `option_changed(id,
-key, value)` rather than polling. The host keeps the entry object `register` was
-called on for as long as the mod is loaded, so connecting a signal to it is safe
-and a mod does not have to hold itself in a static variable: `mods/examples/voxel_preview/` registers a
-camera setting in `mod.gd` and its renderer reads it once and then listens.
+Read it back with `host.option(id, key)`, or `option_index(id, key)` for the rung,
+which is -1 for anything that is not a ladder. Connect to
+`option_changed(id, key, value)` rather than polling. The host keeps the entry
+object `register` was called on for as long as the mod is loaded, so connecting a
+signal to it is safe and a mod does not have to hold itself in a static variable.
 
-The two surfaces are a **MODS** entry in the start menu, beside the pack and the
-save, and rows on that mod's card in the launcher's mods page. The entry appears
-only when at least one loaded mod registered a setting, so a player with no mods
-sees the cartridge's menu exactly.
+The two surfaces are a **MODS** entry in the start menu and rows on that mod's card
+in the launcher. The entry appears only when at least one loaded mod registered a
+setting.
 
-A change is committed the moment it is made, the way the cartridge's own OPTION
-menu writes each press to `wOptions`. With no slot open it lands in
-`user://mod_options.json`, keyed by mod id: that file is the installation's own
-values and the template a new run is created from. While a slot is played the
-change belongs to the slot instead (`run_options`, see "Holding a run rather than
-an installation"), because a draw distance that moved under a loaded save would
-make that save's own recorded walk unreproducible. Only values are stored, never
-what a setting means, so a mod that drops a rung in a later version finds its
-stored value refused and its default used instead, and uninstalling a mod drops
-what it stored.
+A change is committed the moment it is made. With no slot open it lands in
+`user://mod_options.json`, keyed by mod id: that file is the installation's values
+and the template a new run is created from. While a slot is played the change
+belongs to the slot (`run_options`). Only values are stored, never what a setting
+means, so a mod that drops a rung in a later version finds its stored value refused
+and its default used. Uninstalling a mod drops what it stored.
 
-Per-slot state belongs in the save instead. A discovered manifest can use
+Per-slot state belongs in the save. A discovered manifest uses
 `host.read_save_data(manifest, save)` and
-`host.write_save_data(manifest, save, value)` to access only its own namespace.
-Both sides deep-copy dictionaries, and writes larger than 64 KiB of UTF-8 JSON
-are refused. The manifest object itself is the capability: constructing another
-manifest with the same id does not grant access to that mod's state.
+`host.write_save_data(manifest, save, value)` for its own namespace. Both sides
+deep-copy dictionaries, and writes larger than 64 KiB of UTF-8 JSON are refused.
+The manifest object is the capability: constructing another manifest with the same
+id grants nothing.
 
 ## Adding a control
 
-`register_action(id, action)` declares a control of the mod's own. A mod cannot
-see the cartridge's eight, and the screen claims every one of them before a
-renderer is offered anything, so reading raw keycodes out of
-`handle_world_input` produces controls that cannot be rebound, collide silently
-with the d-pad, and do not exist on a touchscreen at all.
+`register_action(id, action)` declares a control of the mod's own. A mod cannot see
+the cartridge's eight, and the screen claims every one of them before a renderer is
+offered anything, so reading raw keycodes out of `handle_world_input` produces
+controls that cannot be rebound, collide silently with the d-pad, and do not exist
+on a touchscreen.
 
 ```gdscript
 host.register_action(manifest.id, {
@@ -1928,10 +1586,9 @@ host.register_action(manifest.id, {
 |---|---|
 | `key` | Addresses the control within the mod |
 | `label` | Shown wherever the control is listed or drawn |
-| `default` | Optional; bindings in `Gen2InputActions`' own shape |
+| `default` | Optional. Bindings in `Gen2InputActions`' own shape |
 
-`default` takes the same three kinds the eight take, so a mod's control binds to
-a key by physical position, a pad button, or a stick axis past the same deadzone:
+`default` takes the same three kinds the cartridge's eight take:
 
 ```gdscript
 {"kind": "key",        "code": <physical keycode>}
@@ -1939,13 +1596,12 @@ a key by physical position, a pad button, or a stick axis past the same deadzone
 {"kind": "pad_axis",   "code": <JoyAxis>, "sign": -1 or 1}
 ```
 
-A default already bound to one of the eight is **dropped and reported**, because
-such a binding would never once fire: the screen takes those first. The action
-still registers, unbound on that slot, and the refusal reaches
-`Gen2ModHost.failures()` and the launcher. `W`, `A`, `S` and `D` are the d-pad's
-own default keys.
+A default already bound to one of the eight is dropped and reported, because it
+would never fire. The action still registers, unbound on that slot, and the refusal
+reaches `Gen2ModHost.failures()` and the launcher. `W`, `A`, `S` and `D` are the
+d-pad's default keys.
 
-Three ways to read one, none of them an `InputEvent`:
+Read one without an `InputEvent`:
 
 | Call | For |
 |---|---|
@@ -1955,30 +1611,18 @@ Three ways to read one, none of them an `InputEvent`:
 | `action_axis(id, negative, positive) -> float` | Two named actions as one signed axis |
 | `action_vector(id, left, right, up, down) -> Vector2` | Two named axes, limited to unit length |
 
-`action_strength` is what makes an analogue control analogue: a stick bound to an
-action answers its travel past the deadzone, so a camera on the right stick moves
-at the rate the player is pushing it, while a key answers 0 or 1. Cameras can
-compose four such actions through `action_vector`; a two-finger drag remains a
-raw `handle_world_input` or `handle_battle_input` leftover.
+`action_strength` is what makes an analogue control analogue: a stick answers its
+travel past the deadzone while a key answers 0 or 1. A two-finger drag remains a raw
+`handle_world_input` or `handle_battle_input` leftover.
 
 Everything a registered control reaches is reachable without a keyboard:
 
-- the launcher's **controls** card lists a loaded mod's actions in their own
-  group under the eight, and rebinds them through the same sheet;
-- the on-screen controller can carry them. Off by default, because a mod must
-  not cover the screen of a player who never asked for one; switched on from the
+- The launcher's **controls** card lists a loaded mod's actions in their own group
+  under the eight, and rebinds them through the same sheet.
+- The on-screen controller can carry them. Off by default; switched on from the
   same card, each is a pill the player drags where they like, per orientation,
   beside A and B.
 
-An event reaches a mod's action only where the screen would have offered a
-renderer one, so an open menu, a running script, a battle or a trainer approach
-takes the press first.
-
-## Not built yet
-
-A mod species does not appear in the Pokedex: both dex order tables are cartridge
-data of exactly 251 entries, and nothing splices `defined_numbers()` into them,
-though a mod species that replaces a cartridge one does carry its own dex entry.
-Mod content cannot leave the project's own save either: every species, item and
-move on the hardware is one byte, so `Gen2SramAdapter` refuses to export a save
-carrying any of it rather than truncating a number into a different Pokemon.
+An event reaches a mod's action only where the screen would have offered a renderer
+one, so an open menu, a running script, a battle or a trainer approach takes the
+press first.

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -1,10 +1,10 @@
 # External source references
 
-This project uses the pret disassemblies as authoritative references when
-matching original game behavior. Ports and other recompilations are secondary:
-read them for approach, settle behavior against pret. All of them are
-comparison sources, not project content. Do not copy ROMs, extracted cartridge data, or a complete external
-checkout into the project history.
+The pret disassemblies are the authoritative reference for original game
+behaviour. Ports and other recompilations are secondary: read them for approach,
+settle behaviour against pret. All are comparison sources, never project
+content. Never copy a ROM, extracted cartridge data or a whole external checkout
+into the project history.
 
 ## Pinned repositories
 
@@ -18,10 +18,8 @@ checkouts the fetch and status scripts manage.
 | Gold and Silver | [pret/pokegold](https://github.com/pret/pokegold) | `a0dad0957ac8a9ffa67e950ee3ab6715a212ded5` | Maps, scripts, events, data, battle behavior |
 | Crystal, C port | [DanZC/suiCune](https://github.com/DanZC/suiCune) | `201d70028249b3297c441be195489e579bbf231a` | Secondary reference only: a C99 rewrite of pokecrystal, useful for how a routine reads once the GameBoy hardware assumptions are removed. Behavior is settled against pret, never against this port. |
 
-The lock file is the machine-readable source of truth; revisions are pinned so
-source comparisons stay reproducible. The branch name recorded there is the
-upstream branch used when each revision was pinned, never a substitute for the
-commit hash.
+The lock file is the source of truth. The branch name recorded there is the
+upstream branch the revision was pinned from, never a substitute for the hash.
 
 ## Local checkout workflow
 
@@ -34,11 +32,11 @@ bash tools/reference_status.sh --remote
 ```
 
 The fetch script clones a missing repository, fetches the locked revision and
-checks it out detached. An existing checkout must have the expected origin and
-no local edits: the script refuses to replace local work or silently move to
-another revision. The status script reports each checkout as missing, dirty, at
-the wrong revision or ready; `--remote` also reports when the recorded upstream
-branch has moved past the pin.
+checks it out detached. An existing checkout must have the expected origin and no
+local edits; the script refuses to replace local work or move to another
+revision. The status script reports each checkout as missing, dirty, at the wrong
+revision or ready. `--remote` also reports when the recorded upstream branch has
+moved past the pin.
 
 The default checkout root is `.references/`, ignored by the project and safe to
 remove and recreate. Set `GEN2_REFERENCE_ROOT`, or pass a first argument to
@@ -49,8 +47,8 @@ GEN2_REFERENCE_ROOT=/path/to/reference-cache bash tools/fetch_reference_sources.
 bash tools/reference_status.sh /path/to/reference-cache
 ```
 
-Updating a pin is deliberate maintenance: inspect the source changes, update
-`references.lock`, and record why.
+Updating a pin is deliberate: inspect the changes, update `references.lock`, and
+record why.
 
 ## Source lookup guide
 
@@ -68,7 +66,7 @@ The two repositories use closely related paths. Check the matching path in
 | Wild encounters | `data/wild/*.asm`, `data/wild/fish.asm` |
 | Trainer parties and data | `data/trainers/parties.asm`, the matching trainer data files |
 
-When a source fact changes runtime behavior, record the file and symbol next to
+When a source fact changes runtime behaviour, record the file and symbol next to
 the implementation, plus the pinned commit if the fact is revision-specific.
-Source-derived data stays outside tracked files unless it is a small, verified
+Source-derived data stays out of tracked files unless it is a small, verified
 runtime table or test fixture the project requires.

--- a/docs/SAVES.md
+++ b/docs/SAVES.md
@@ -17,11 +17,11 @@ Save format version 6 stores:
 - an optional validated world snapshot: map ID, player cell, facing, movement
   mode, event flags, map scenes, inventory quantities, money, coins, phone
   contacts, seen species, repel steps, swarm state, roaming positions, source
-  engine flags, the script memory bytes `readmem`/`loadmem` address, the current
+  engine flags, the script memory bytes `readmem`/`loadmem` address, the
   day/hour/minute clock, the host second that clock was written at and the
-  daylight-saving flag. The stamp is what makes the clock a real-time one across
-  sessions: a world opens at the saved time plus the seconds that have passed
-  since, because the cartridge's RTC keeps running while the machine is off
+  daylight-saving flag. The stamp makes the clock real-time across sessions: a
+  world opens at the saved time plus the seconds that have passed since, because
+  the cartridge's RTC keeps running while the machine is off
   (`Gen2WorldClock.catch_up`);
 - imported-save and party-transaction identity fields: OT ID, nickname, OT,
   happiness, Pokerus and caught data;
@@ -34,48 +34,37 @@ Save format version 6 stores:
   reopened, and the gameplay rules it is played under (`run_rules`: which of the
   cartridge's own bugs are reproduced, and the trainer-AI difficulty);
 - `is_egg` for received eggs. An egg keeps its party slot and is skipped when
-  the battle party is built, matching the cartridge refusing it as a combatant
-  rather than removing it; the writeback puts it back in the same slot. Its
-  `happiness` byte is its hatch counter, which is what `GiveEgg` writes and what
-  `DoEggStep` drains: the walk takes one cycle off every egg in the party every
-  256 steps, and the first to reach zero hatches where it stands. A script's
-  `giveegg` and the Day-Care both hand one out.
+  the battle party is built, the way the cartridge refuses it as a combatant
+  rather than removing it. Its `happiness` byte is its hatch counter, written by
+  `GiveEgg` and drained by `DoEggStep`: one cycle off every egg in the party
+  every 256 steps, and the first to reach zero hatches where it stands.
 
-Derived battle stats are recalculated on load. Volatile state, including stages,
-confusion, recharge, Disable, Encore, trapping, Fly, Dig, Rollout and rampage,
-is never saved, and neither is the battle's own weather or its screens. A held
-item is not
-volatile: a berry eaten in a battle is gone from the party afterwards.
-The validator checks the selected `GameData`. Slots live under
-`user://save_slots` per game revision and are created on demand rather than
-preallocated, up to `Gen2SaveStore.MAX_SLOTS`; a slot number is still its file
-name, so slots written before this stay where they were. Each save carries its
-own `label`, the player's name for the slot, so an exported file names itself;
-an empty label means fall back to the player name. `current_box` is `wCurBox`,
-which CHANGE BOX's SWITCH writes and both of BILL'S PC's lists read, and
-`box_names` is `sBoxNames`, which its NAME row writes; an empty name is
-`SetDefaultBoxNames`' own "BOX1" spelling rather than a stored string.
-`hall_of_fame` is `sHallOfFame`, the thirty induction records newest first.
+Derived battle stats are recalculated on load. Volatile state is never saved:
+stages, confusion, recharge, Disable, Encore, trapping, Fly, Dig, Rollout,
+rampage, weather and screens. A held item is not volatile, so a berry eaten in a
+battle is gone from the party afterwards.
+
+Slots live under `user://save_slots` per game revision, created on demand up to
+`Gen2SaveStore.MAX_SLOTS`. A slot number is its file name. Each save carries a
+`label`, the player's name for the slot, so an exported file names itself; an
+empty label falls back to the player name.
+
+| Field | Source |
+|---|---|
+| `player_id` | `wPlayerID`, rolled once when a game starts, read from SRAM on import and written back on export. `GetTreeScore` reads it: half of a headbutt tree's encounter tier comes from the trainer ID |
+| `gender` | Crystal's `wPlayerGender`. Always male on Gold and Silver, which ship neither the byte nor Kris |
+| `current_box` | `wCurBox`, written by CHANGE BOX's SWITCH and read by both of BILL'S PC's lists |
+| `box_names` | `sBoxNames`, written by its NAME row. An empty name means `SetDefaultBoxNames`' own "BOX1" spelling rather than a stored string |
+| `hall_of_fame` | `sHallOfFame`, the thirty induction records newest first |
+
 Cartridge SRAM box placement is intentionally outside this model.
 
-`player_id` is the cartridge's own `wPlayerID`, rolled once when a game starts,
-read from SRAM on import and written back on export. `GetTreeScore` is what reads
-it: half of a headbutt tree's encounter tier comes from the trainer ID. `gender`
-is Crystal's `wPlayerGender` and is always male on Gold and Silver, which ship
-neither the byte nor Kris.
-
-Older project saves migrate in memory one version step at a time: version 1
-gains fourteen empty boxes, version 2 gains an empty label, version 3 gains a
-zero `player_id`, version 4 gains a male gender and a 0:00 timer, version 5 gains
-an empty mod namespace. Migration preserves a missing world snapshot as missing;
-it does not invent a map, player position or event state, and it does not roll an
-ID, since that would change an existing save's headbutt encounters. The `run`
-block joined version 6 after it shipped and is not a version of its own, and so
-did `current_box` and the world snapshot's clock stamp: each defaults rather than
-versioning, to no seed, mod list, settings snapshot or rules, to the first box,
-and to a clock that resumes where it stopped, which is the truth about a slot
-written before they existed; such a slot adopts the installation's
-rules once, when it is first activated. The next successful save writes version 6.
+Older project saves migrate in memory one version step at a time up to 6, and
+the next successful save writes 6. Migration invents nothing: a missing world
+snapshot stays missing, and no trainer ID is rolled, since that would change an
+existing save's headbutt encounters. Fields added inside version 6 default
+rather than versioning, and a slot written before the run block adopts the
+installation's rules once, on first activation.
 
 ## Player flow
 
@@ -85,15 +74,11 @@ the lowest free number, and rejects failed `.sav` imports before calling
 `Gen2SaveStore.save`, so partial data cannot replace a slot. A game with no
 saves lists none and has nothing selected.
 
-New games accept up to ten encoded characters and start with an empty party,
-matching Crystal's new-game initialization. When the source home map exists,
-they start at map group 24, map 7, cell 3,3 with 3000 money, from Crystal's
-`SPAWN_HOME` and `START_MONEY`. The imported Elm's Lab scripts offer Chikorita,
-Cyndaquil or Totodile at level 5 holding Berry; the party host creates the first
-save Pokémon only after the player confirms the source choice. The party screen
-shows all six positions, current and maximum HP and persistent status, and
-starts the development battle only once `GameRuntime` holds the same validated
-slot.
+New games accept up to ten encoded characters and start with an empty party.
+When the source home map exists they start at map group 24, map 7, cell 3,3 with
+3000 money, from Crystal's `SPAWN_HOME` and `START_MONEY`. The imported Elm's Lab
+scripts offer Chikorita, Cyndaquil or Totodile at level 5 holding Berry; the
+party host creates the first save Pokemon only after the player confirms.
 
 After battle messages finish, `Gen2SaveBattleAdapter` writes player name,
 Pokémon identity, held item, happiness, Pokerus, caught data, nickname, OT, HP,
@@ -103,27 +88,26 @@ discarded.
 Overworld writeback is transactional. A confirmed win saves after result
 messages finish; a loss never overwrites the slot, and the host validates and
 reconstructs the source save party before returning blackout recovery. Continue
-enters the overworld only with a validated snapshot; the start menu's SAVE
-writes map, player, items, currency, events, source engine flags and schedule
-state through
-`Gen2SaveStore`, with item and currency references checked against the selected
-cache. Daily engine flags reset when the saved world day changes while story
-flags such as Hall of Fame persist. Saves without a snapshot keep the configured
-development entry, since migration invents no world position, and
-`Gen2WorldAPI.open_snapshot()` restores a saved position without clamping it.
+enters the overworld only with a validated snapshot. The start menu's SAVE writes
+map, player, items, currency, events, source engine flags and schedule state
+through `Gen2SaveStore`, with item and currency references checked against the
+selected cache. Daily engine flags reset when the saved world day changes; story
+flags such as Hall of Fame persist. `Gen2WorldAPI.open_snapshot()` restores a
+saved position without clamping it.
 
-`box_screen.tscn`, opened from the party screen or from the imported Players
-House PC as an embedded overworld overlay, presents one numbered box at a time
-with twenty fixed slots and a party selection column. Depositing uses the
-current box's first free slot, withdrawal requires party capacity, and both go
-through `Gen2SaveStorage` to validate and write a candidate save before the
-shared runtime object changes. The last party member cannot be boxed. MOVE PKMN W/O MAIL is
-the same screen in `Gen2BoxScreen.MODE_MOVE`, where left and right load the
-party or any box and a chosen Pokemon is inserted at a second cursor. SRAM
-placement stays outside the model. Closing the embedded overlay resumes the
-paused source script, which is where a changed decoration reloads the room. Selected runtime saves persist transfers; injected scene-test
-and development saves use the validated in-memory candidate without writing a
-slot.
+`box_screen.tscn`, opened from the party screen or from the Players House PC as
+an embedded overworld overlay, presents one numbered box at a time with twenty
+fixed slots and a party selection column. Depositing uses the current box's first
+free slot, withdrawal requires party capacity, and both go through
+`Gen2SaveStorage` to validate and write a candidate save before the shared
+runtime object changes. The last party member cannot be boxed.
+
+MOVE PKMN W/O MAIL is the same screen in `Gen2BoxScreen.MODE_MOVE`, where left
+and right load the party or any box and a chosen Pokemon is inserted at a second
+cursor. Closing the overlay resumes the paused source script, which is where a
+changed decoration reloads the room. Selected runtime saves persist transfers;
+scene-test and development saves use the validated in-memory candidate without
+writing a slot.
 
 Party-owned overworld transactions modify a candidate `Gen2SaveData` and the
 live world snapshot first. Gifts, eggs, NPC trades, source `HealParty` recovery,
@@ -168,16 +152,16 @@ Mail is on the record rather than in a slot of its own: `Gen2SaveMon.mail` is
 behind `sMailboxCount`. Both default rather than versioning, so a slot written
 before mail existed reads as a party holding none and an empty mailbox.
 
-`SECTION "SRAM Battle Tower"` rides in the world snapshot rather than in the
-save proper, which is where the cartridge keeps it too: a challenge can be saved
-and left between battles, so `Gen2WorldState.battle_tower()` carries the state,
-the streak of trainers already met, the chosen room, the save-file flags and the
-prize drawn for the run. It defaults rather than versioning the way mail does.
+`SECTION "SRAM Battle Tower"` rides in the world snapshot rather than the save
+proper, which is where the cartridge keeps it too, since a challenge can be saved
+and left between battles. `Gen2WorldState.battle_tower()` carries the state, the
+streak of trainers already met, the chosen room, the save-file flags and the
+prize drawn for the run.
 
 Original SRAM also contains player, map, checksum, PC box, Hall of Fame and
-Crystal-specific regions. The first model imports only party data; the optional
-project world snapshot is a separate canonical runtime shape and does not claim
-to reproduce unsupported SRAM bytes.
+Crystal-specific regions. This model imports only party data; the world snapshot
+is a separate runtime shape and does not claim to reproduce unsupported SRAM
+bytes.
 
 ## Cartridge SRAM boundary
 
@@ -190,14 +174,13 @@ rewritten with little-endian 16-bit checksums.
 
 It maps player name and six-party fields: species, item, moves, OT ID,
 experience, stat experience, DVs, PP, happiness, Pokerus, caught data, level,
-status, current HP, nickname and OT. Derived stats are rebuilt from selected
+status, current HP, nickname and OT. Derived stats are rebuilt from the selected
 `GameData`; other bytes remain untouched. Export requires an existing valid SRAM
-image and does not invent unsupported map or event state. It also refuses a save
-carrying mod content: every species, item and move on the hardware is one byte,
-and `Gen2ContentOverlay.FIRST_MOD_NUMBER` sits past that, so truncating one would
-write a different Pokemon into a real cartridge. Crystal's player gender rides
-along in `sCrystalData`, its own section outside both save copies, of which only
-bit 0 is written.
+image and invents no map or event state. It refuses a save carrying mod content:
+every species, item and move on the hardware is one byte and
+`Gen2ContentOverlay.FIRST_MOD_NUMBER` sits past that, so truncating one would
+write a different Pokemon into a real cartridge. Crystal's player gender rides in
+`sCrystalData`, outside both save copies; only bit 0 is written.
 
 | Profile | Primary data | Checksum | Party | Backup |
 |---|---|---|---|---|

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -290,7 +290,7 @@ func effect_playing() -> bool:
 ## count across two frames instead of trusting that answer, and stops waiting when
 ## it has not moved. `AudioStreamPlayer.playing` is not that test: the dummy audio
 ## driver reports true and consumes nothing. See `Gen2BattleScreen`'s
-## `ANIM_WAIT_SFX` and `HANDOFF.md`'s `WaitSFX` row.
+## `ANIM_WAIT_SFX`.
 func timeline_updates() -> int:
 	return _timeline_updates
 

--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -241,8 +241,6 @@ func registered_bank_count() -> int:
 	return _banks.size()
 
 
-# ---------------------------------------------------------------- entry points
-
 
 ## `_InitSound`.
 func init_sound() -> void:
@@ -453,8 +451,6 @@ func any_channel_active() -> bool:
 	return music_channels_active() or sfx_active()
 
 
-# ------------------------------------------------------------------ per frame
-
 
 ## `_UpdateSound`.
 func update_sound() -> void:
@@ -657,8 +653,6 @@ func _fade_music() -> void:
 		level -= 1
 	volume = (level << 4) | level
 
-
-# ------------------------------------------------------------- note machinery
 
 
 func _load_note() -> void:

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -312,8 +312,6 @@ static func run(
 	return true
 
 
-# ---------------------------------------------------------------- helpers ----
-
 ## `BattleBGEffects_IncAnonJumptableIndex`.
 static func _inc(effect: Gen2BattleAnimBgEffect) -> void:
 	effect.jumptable_index = (effect.jumptable_index + 1) & 0xFF
@@ -466,8 +464,6 @@ static func _wavy_screen_fx(background: Gen2BattleAnimBackground) -> void:
 	background.ly_overrides_backup[at] = first
 
 
-# -------------------------------------------------------- palette effects ----
-
 ## `BattleBGEffect_FlashContinue`: the turn byte is how long a flash lasts and
 ## the parameter how many are left.
 static func _flash(
@@ -579,8 +575,6 @@ static func _fade_mons_to_black_repeating(
 			background.load_enemy_pals(Gen2BattleAnimBackground.PALETTE_IDENTITY)
 			effect.end()
 
-
-# -------------------------------------------------------- tilemap effects ----
 
 ## `BattleBGEffect_HideMon`: the battler's own box blanked, then four frames of
 ## nothing while the tilemap reaches VRAM.
@@ -801,8 +795,6 @@ static func _remove_mon(
 				return
 			effect.jumptable_index = 0x1
 
-
-# ------------------------------------------------------- scanline effects ----
 
 ## `BattleBGEffect_Surf`, which opens no window of its own: it rides the one
 ## `start_water` set, and does nothing until it exists.

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -172,8 +172,6 @@ static func run(
 	return true
 
 
-# ---------------------------------------------------------------- helpers ----
-
 ## `BattleAnim_IncAnonJumptableIndex`.
 static func _inc(object: Gen2BattleAnimObject) -> void:
 	object.jumptable_index = (object.jumptable_index + 1) & 0xFF
@@ -270,8 +268,6 @@ static func _ball_palette(player: Gen2BattleAnimPlayer, object: Gen2BattleAnimOb
 			return
 	object.palette = BALL_COLOR_DEFAULT
 
-
-# -------------------------------------------------------------- callbacks ----
 
 ## `BattleAnimFunc_Null`, which is not a no-op: its second state deletes the
 ## object, and that is how `anim_incobj` retires the sixty-two rows that use it.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1625,8 +1625,6 @@ func advance_bars() -> bool:
 	return moved
 
 
-# ------------------------------------------------- battle animations ----
-
 ## `_PlayBattleAnim`'s own framing, as steps the screen walks a frame at a time.
 ## Each is a dictionary carrying its own `kind`; the delays are
 ## `BattleAnimDelayFrame` counts and `script` is `RunBattleAnimScript`.
@@ -5131,37 +5129,15 @@ func _push_view() -> void:
 	_refresh_annotations()
 
 
-## What is standing on one side's square, whether it is on it, how far it is from
-## resting there and how big it is drawn, for a renderer that stages the fight
-## somewhere other than a 20x18 tile page.
+## What is standing on one side's square, whether it is on it, how far it is
+## from resting there and how big it is drawn. `docs/MODS.md` documents the
+## block; this is where it is filled.
 ##
-## Every other field describing a battler says it in the terms the hardware draws
-## it in: the opening slide is a scanline scroll, the walk off is columns going
-## blank in `bg_map`, the player mid-slide is eighteen OAM entries, a faint sinks
-## the picture a tile row at a time inside the map, a resize script restamps it
-## out of smaller subsamplings, and every per-battler deformation is a scanline
-## window over that side's own rows. A view with no background plane has none of
-## those and would have to rebuild host state to read any of them, which is lossy
-## as well as duplicated: a resize script's arrangement and a faint sink read the
-## same at the tile level. These four values are that state said plainly.
-##
-## [code]kind[/code] is what the square holds: [code]&"trainer"[/code] a person,
-## [code]&"mon"[/code] a Pokemon, and [code]&"none"[/code] the stretch between
-## the trainer walking off and the ball putting a Pokemon there.
-## [code]visible[/code] is whether the picture is on the square at all, which
-## `BattleBGEffect_HideMon` and `..._RemoveMon` are what take it off.
-## [code]offset_pixels[/code] is how far that picture is from its resting square,
-## and one number covers every movement because they are all the same thing: the
-## opening slide brings a picture in, `SlideBattlePicOut` takes it off,
-## `MonFaintedAnimation` sinks it, `RemoveMon` pushes it aside and the window
-## effects lunge, shake and sink it. Zero is standing still.
-## [code]scale[/code] is the side of the square `BattleBGEffect_RunPicResizeScript`
-## last placed over the side of the whole picture, so the ball shrink of a recall
-## and the grow of a send-out are one number; 1 is the whole picture.
-##
-## Every value is read out of state the screen already runs rather than simulated
-## again: `faint_step`, `slide_step`, the resize scripts and the scanline window
-## are what drive the map, and this reports what they drove it with.
+## Every other battler field says it in the terms the hardware draws it in, so a
+## renderer with no background plane would have to rebuild host state to read a
+## faint, a recall or a deformation. These four say it plainly instead, read out
+## of the state the screen already runs (`faint_step`, `slide_step`, the resize
+## scripts and the scanline window) rather than simulated again.
 func battler_side(side: int) -> Dictionary:
 	var player_side: bool = side == Gen2Battle.PLAYER
 	var backpic: String = _player_backpic if player_side else ""

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -13,67 +13,9 @@ extends RefCounted
 
 const FILENAME: String = "mod.json"
 ## Bumped when the host contract changes in a way an existing mod would notice.
-## 2 added [method Gen2ModHost.register_visible_encounters].
-## 3 added mart rows and named action axes.
-## 4 added types, type matchups and mod-supplied art as content, and
-## [method Gen2ModHost.register_event_mutator].
-## 5 added [member Gen2WorldAPI.rules], the run's own divergence flags.
-## 6 added `occupied` to the visible-encounter context, which is the only way a
-## provider can tell that a cell has an NPC or an item ball standing on it.
-## 7 gave a world actor an optional `interact` and an optional `take_requests`
-## outbox, an optional `emote` on a `sprites()` entry, and the host
-## [method Gen2ModHost.request_hidden_item] over
-## [method Gen2WorldAPI.hidden_items].
-## 8 added [method Gen2ModHost.register_stats_page], a page of a Pokémon's stats
-## screen past the cartridge's own three.
-## 9 added the evolution an item causes, on the item record itself.
-## 10 is the screen that fills the window: the connection graph past the
-## cartridge's three-block margin ([method Gen2WorldAPI.map_placements],
-## [method Gen2WorldAPI.expanded_block_at],
-## [method Gen2WorldAPI.connected_map_objects]), the wider drawn surface
-## ([member Gen2WorldAPI.view_pixels]) and
-## [constant Gen2ModHost.RENDERER_INTERFACE_MASK_METHOD] beside
-## [constant Gen2ModHost.RENDERER_SCREEN_RECT_METHOD]. A view on the native
-## layer needs it: whether the host claims the zoom keys and paints its letterbox
-## over that layer is a behaviour no mod can feature-detect.
-##
-## 13 is the five registrations that let a mod change how the game is played
-## without reaching a screen: [method Gen2ModHost.register_field_move_source],
-## [method Gen2ModHost.register_repel_renewal],
-## [method Gen2ModHost.register_catch_experience],
-## [method Gen2ModHost.register_battle_info], and a start-menu entry's own
-## [constant Gen2ModHost.START_ACTIONS] plus its `visible` predicate.
-##
-## 15 added a visible encounter's own `glow`, the optional
-## `{color, amount}` on an `encounters()` entry that walks the Pokemon's four
-## colours toward a light. It is presentation and changes no DV, no battle and
-## no roll; the host rounds the amount onto
-## [constant Gen2WorldEncounters.GLOW_RUNGS] itself, because both renderers cache
-## a sprite texture per set of four colours and neither evicts. Nine amounts, so
-## a subtle glow still has a cycle after the rounding.
-##
-## An optional `icon` or `thumbnail` is deliberately NOT a contract change: a
-## host that has never heard of either ignores the field, so a mod that ships
-## art still installs on an older launcher and simply has no face there. A glow
-## is the same shape in the other direction: a mod may send one to a host that
-## drops it and the Pokemon simply does not glow, which is why `api_version` 15
-## is only needed by a mod that requires the mark to appear.
-##
-## 16 is the shiny seam, three registrations a mod that changes what comes out of
-## the grass needs: [method Gen2ModHost.register_shiny_rolls], the count of DV
-## words one wild is drawn with; [method Gen2ModHost.request_item_gift], which is
-## [method Gen2ModHost.request_hidden_item]'s twin for an item no map gives; and
-## [method Gen2ModHost.inventory], the live bag a non-renderer mod otherwise has
-## no way to read. Only the first two are contract: a mod may feature-detect the
-## bag but not a roll it never sees taken.
-##
-## 17 is the one break in the list. `view["entrance"]` is gone and
-## `view["battlers"]` stands in its place, carrying the same five fields plus
-## `visible` and `scale`: everything that happens to a battler after the entrance
-## used to be readable only as `bg_map` edits, and the two blocks describe the
-## same thing at different moments. Carrying both would have meant a renderer
-## reading one for the opening and the other for the fight, so the fold is the
-## contract. See [method Gen2BattleScreen.battler_side].
+## What each version added is in the commit history; `docs/MODS.md` documents the
+## current contract only. An optional field a mod may send and an older host may
+## drop is deliberately not a bump.
 const API_VERSION: int = 18
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1

--- a/game/options/rules.gd
+++ b/game/options/rules.gd
@@ -6,9 +6,9 @@ extends RefCounted
 ##
 ## Separate from [Gen2Options], which is the installation's own settings: a rule
 ## changes what the engine DOES, so it belongs to the run that produced a save
-## rather than to whichever machine is playing it. `HANDOFF.md`'s divergence table
-## is what becomes named flags here, one at a time, each with a live branch on
-## both sides and a test on each.
+## rather than to whichever machine is playing it. A divergence becomes a named
+## flag here one at a time, each with a live branch on both sides and a test on
+## each.
 ##
 ## Every flag is named for the cartridge's behaviour and answers "reproduce the
 ## hardware", so a flag that is off is this project's own corrected answer. That
@@ -71,7 +71,7 @@ const FLAG_TEXT: Dictionary = {
 	},
 }
 
-## `HANDOFF.md`'s mutual recoil faint row is deliberately NOT here: the award pass
+## The mutual recoil faint is deliberately NOT a flag: the award pass
 ## already refuses a fainted recipient, so clearing the participant as
 ## `UpdateFaintedPlayerMon` does changes no outcome that can be observed. It
 ## becomes a flag when turn-event ordering makes the difference visible, and a

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -282,7 +282,7 @@ func results_window_map(rows: Array, cursor: int) -> PackedInt32Array:
 	# `DrawPokedexSearchResultsWindow` draws a second frame over rows 11 to 17,
 	# which at `hWX` $4a would cut `.BottomWindowText` in the background box in
 	# half. Only the listing's own frame is drawn until the oracle says what the
-	# hardware puts there; see HANDOFF.md.
+	# hardware puts there.
 	for frame: Array in [[0, 10]]:
 		var top: int = int(frame[0])
 		var bottom: int = int(frame[1])

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -749,7 +749,7 @@ func _mon_state(mon: Gen2SaveMon) -> Dictionary:
 		"species_name": String(_data.species(mon.species).get("name", "")),
 		"item": mon.item,
 		## `ItemIsMail` reads a list no importer reads, so no item is mail here
-		## and the mail marker is unreachable; see HANDOFF.md.
+		## and the mail marker is unreachable.
 		"mail": false,
 	}
 

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -95,8 +95,8 @@ const SFX_SWITCH_POKEMON: int = 0x20
 
 ## `_PokemonNotEnoughHPText` and `_ItemCantUseOnMonText`, the two refusals the
 ## heal transfer prints. Both are a `MenuTextbox` over the menu on the cartridge
-## and stand in the menu's own bottom box here, which is the divergence
-## `HANDOFF.md` records; the A or B they wait for is the same.
+## and stand in the menu's own bottom box here. The A or B they wait for is the
+## same.
 const MESSAGE_NOT_ENOUGH_HP: String = "Not enough HP…"
 const MESSAGE_NO_EFFECT: String = "It won't have any effect."
 

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -365,7 +365,8 @@ func _print_text() -> void:
 
 
 ## `OakText2`'s `text_asm` plays the cry once the words are up. The source's
-## `WaitSFX` after it is not modelled; see `HANDOFF.md`.
+## `WaitSFX` after it is not modelled: nothing here holds the script until the
+## four effect channels are free.
 func _play_cry_if_due() -> void:
 	if _cry_played or _index >= _beats.size() or _text_box == null:
 		return

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -336,7 +336,7 @@ var breed_random: RandomNumberGenerator = null
 var _radio_show: Gen2RadioShow = null
 ## `wBuenasPassword` and `DAILYFLAGS2_BUENAS_PASSWORD_F`, and `wLuckyIDNumber`.
 ## None of the three is in the save model, so each is rolled once per world and
-## kept here; see HANDOFF.md's divergence row.
+## kept here rather than persisted.
 var _buenas_password: int = -1
 var _buenas_password_today: bool = false
 var _lucky_number: int = -1

--- a/game/world/world_apricorn.gd
+++ b/game/world/world_apricorn.gd
@@ -75,7 +75,7 @@ static func find_in_bag(data: GameData, state: Gen2WorldState) -> Array:
 
 ## `Kurt_GetQuantityOfApricorn`. The source walks every stack of the item and
 ## clamps the total; the flat item model holds one stack, so only the clamp is
-## left. See HANDOFF's item-stack divergence.
+## left.
 static func quantity_of(state: Gen2WorldState, item: int) -> int:
 	if state == null:
 		return 0

--- a/game/world/world_apricorn_host.gd
+++ b/game/world/world_apricorn_host.gd
@@ -8,7 +8,7 @@ extends RefCounted
 ## The source routine collects every bag stack of the item, sorts them and
 ## empties them in turn ("Compatible with multiple stacks"). The flat item model
 ## holds one stack per item, so the walk collapses to a single `Kurt_GetRidOfItem`.
-## HANDOFF's item-stack divergence covers it.
+## Nothing observable differs until the save model can hold two stacks of one item.
 
 static func complete_runtime_request(
 	world: Gen2WorldAPI,

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -8,7 +8,7 @@ extends RefCounted
 ## The source routine walks `_TossItem`'s pocket jumptable to find which packed
 ## array the item lives in and calls `RemoveItemFromPocket` on it. The flat item
 ## model has one stack per item and no pocket arrays, so the whole walk is a
-## subtraction; HANDOFF's item-stack divergence covers the difference.
+## subtraction. Nothing observable differs until a save can hold two stacks.
 ##
 ## The commit boundary is [Gen2WorldTransaction], the same one the mart, Kurt
 ## and the party hosts go through.

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -17,8 +17,7 @@ signal completed(results: Array)
 ## [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent in front of the sound
 ## by hand: the cartridge holds there until the four effect channels are free,
 ## so the request can never be the one `PlaySFX`'s own priority gate refuses.
-## The wait itself is not spent (see `HANDOFF.md`'s `WaitSFX` row); what it
-## carries is that the sound is heard.
+## The wait itself is not spent; what it carries is that the sound is heard.
 signal sfx_requested(index: int, waited: bool)
 ## `PlayMonCry2` from a screen this one opens, the box screen's stats page today.
 ## Passed on for the same reason [signal sfx_requested] is: the world screen owns

--- a/roms/README.md
+++ b/roms/README.md
@@ -11,6 +11,6 @@ godot --headless --path . -s res://tools/verify_rom.gd -- roms
 ```
 
 Names do not matter: every file is matched by SHA-1 against the supported
-cartridges listed in [the README](../README.md#supported-cartridges). Unknown
+cartridges listed in [the README](../README.md#getting-started). Unknown
 hashes are refused rather than imported with an uncharacterised bank layout that
 could produce corrupt assets.

--- a/tests/unit/test_battle_anim_bg_effects.gd
+++ b/tests/unit/test_battle_anim_bg_effects.gd
@@ -65,8 +65,6 @@ func _background() -> Gen2BattleAnimBackground:
 	return _player.background()
 
 
-# --------------------------------------------------------- the profile split ----
-
 ## pokegold ships no `BATTLE_BG_EFFECT_BODY_SLAM`, so its list is one shorter and
 ## every id from $25 on names a different effect. Nothing normalises between the
 ## two, which is why both tables are held whole.
@@ -127,8 +125,6 @@ func test_only_crystal_rewinds_the_tilemap_push() -> void:
 	assert_eq(_background().bg_map_third, 2)
 
 
-# ------------------------------------------------------------------ the pool ----
-
 ## `QueueBGEffect` takes the first free slot and a sixth effect simply is not
 ## queued, the way an eleventh object is not spawned.
 func test_five_effects_run_at_once_and_a_sixth_is_refused() -> void:
@@ -164,8 +160,6 @@ func test_incbgeffect_finds_a_live_effect_by_its_id() -> void:
 	player.advance_frame()
 	assert_eq(effect.jumptable_index, before + 1)
 
-
-# ---------------------------------------------------------------- the screen ----
 
 ## `BGEffect_FillLYOverridesBackup` writes one value across the window and
 ## nothing outside it.
@@ -242,8 +236,6 @@ func test_rollout_moves_the_first_object_against_the_screen() -> void:
 	assert_eq(_background().scy, 0x04)
 
 
-# --------------------------------------------------------------- the palettes ----
-
 ## The hue walks end when their list does, and `alternate_hues` is the one that
 ## takes an object palette with it.
 func test_a_hue_walk_ends_on_its_own_list() -> void:
@@ -310,8 +302,6 @@ func test_a_fade_reaches_one_side_of_the_field() -> void:
 	)
 
 
-# ---------------------------------------------------------------- the tilemap ----
-
 ## `BattleBGEffect_HideMon` blanks the battler's own box and then spends four
 ## frames doing nothing while the tilemap reaches VRAM.
 func test_hiding_a_mon_blanks_its_box_and_then_waits() -> void:
@@ -366,8 +356,6 @@ func test_a_mon_entering_is_stamped_at_three_sizes() -> void:
 	assert_eq(background.tile_at(12, 0), 0x00, "then the whole seven-by-seven")
 	assert_eq(background.tile_at(18, 6), 0x30)
 
-
-# ------------------------------------------------------------------- helpers ----
 
 ## A player whose script is [param body], so the queueing commands can be driven
 ## through the interpreter rather than called directly.

--- a/tests/unit/test_battle_anim_functions.gd
+++ b/tests/unit/test_battle_anim_functions.gd
@@ -50,8 +50,6 @@ func _run(object: Gen2BattleAnimObject) -> void:
 	assert_true(Gen2BattleAnimFunctions.run(_player, object))
 
 
-# ---------------------------------------------------------------- helpers ----
-
 ## `BattleAnim_Sine` at the quarter turn is the whole amplitude, because
 ## `BattleAnimSineWave`'s sixteenth entry is $0100 and not $00ff. An eight-bit
 ## re-derivation of the table is short by one here and everywhere it is scaled.
@@ -110,8 +108,6 @@ func test_a_coordinate_wraps_rather_than_clamping() -> void:
 	_run(object)
 	assert_eq(object.x, 0x08)
 
-
-# -------------------------------------------------------------- callbacks ----
 
 ## `BattleAnimFunc_Null` is not a no-op: its second state deletes the object,
 ## which is how `anim_incobj` retires the sixty-two rows that use it.

--- a/tools/checks/pokepic.gd
+++ b/tools/checks/pokepic.gd
@@ -19,9 +19,8 @@ var _r: RefCounted = null
 const FIRST_SPECIES: int = 1
 const LAST_SPECIES: int = 251
 
-## New Bark Town, whose group is untouched by the Gold and Silver map-id shifts
-## (`HANDOFF.md`, "What a Gold/Silver leg costs"). Any map would do: what the
-## box reads off one is its eight background palettes.
+## New Bark Town, whose group is untouched by the Gold and Silver map-id shifts.
+## Any map would do: what the box reads off one is its eight background palettes.
 const MAP_GROUP: int = 24
 const MAP_NUMBER: int = 4
 

--- a/tools/checks/side_walls.gd
+++ b/tools/checks/side_walls.gd
@@ -10,8 +10,8 @@ var _r: RefCounted = null
 ##
 ## The real-cartridge counterpart to the side-wall cases in
 ## tests/unit/test_world_collision.gd and tests/unit/test_world_api.gd, which
-## use synthetic caches. It also pins the map census HANDOFF.md's open-work
-## entry measured against these caches, so a future cache change is loud.
+## use synthetic caches. It also pins the map census, so a future cache change
+## is loud.
 ##
 ##   Godot --headless --path . -s res://tools/validate.gd -- side_walls
 
@@ -91,8 +91,8 @@ func _verify_codes(game_id: StringName) -> void:
 	)
 
 
-## Pins HANDOFF.md's map census so a future cache change is loud rather than
-## silently changing which cells this feature affects.
+## Pins the map census so a future cache change is loud rather than silently
+## changing which cells this feature affects.
 func _verify_census(game_id: StringName, data: GameData) -> void:
 	var expected: Dictionary = EXPECTED_CENSUS[game_id]
 	var counts: Dictionary = {}

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -272,8 +272,7 @@ const FACING_STEPS: Array[Vector2i] = [
 
 ## Every object on the map faced and talked to, answering with the first one
 ## whose script says anything. The officer's cell is not pinned: the two gates
-## differ between the profiles in nothing else, and a hand-named cell is what
-## `HANDOFF.md`'s route habits warn about.
+## differ in nothing else, and a hand-named cell breaks on the other profile.
 func _talk_to_officer(world: Gen2WorldAPI) -> Array:
 	for index: int in world.objects.size():
 		var object: Gen2WorldObject = world.objects[index]

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -4,145 +4,76 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/preview_world.gd -- gold 1 1 /tmp/world.png
 ##
-## A fifth `live` argument photographs the real screen on that map instead, with
-## the sprites the engine draws over an object staged on it: an emote over the
-## first visible object, the boulder dust, the grass rustle and the headbutt
-## tree. That mode drives the screen's own path and needs a display, so it runs
-## without `--headless`:
+## A fifth `live` argument photographs the real screen on that map instead. It
+## drives the screen's own path and needs a display, so it runs without
+## `--headless`:
 ##
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y] [WxH] [touch]
 ##
-## `kind` may carry the player's own cell as `<kind>@x,y`, which is what a kind
-## reading the two numbers as something else needs: `battle_transition@5,7`.
+## The two numbers after `kind` are that kind's own arguments; where a kind reads
+## them as something else, the player's cell is written on the kind itself as
+## `<kind>@x,y`, for example `battle_transition@5,7`.
 ##
-## `WxH` is the window to photograph in, for the two shapes a phone has, and
-## `touch` draws the on-screen controller with it, which is the only way to see
-## how [Gen2GameFrame] splits a portrait screen:
+## Extra flags, in any order after the kind:
+##
+## | Flag | Effect |
+## | `WxH` | The window to photograph in, for a phone's two shapes |
+## | `touch` | Draw the on-screen controller, the only way to see how [Gen2GameFrame] splits a portrait screen |
+## | `framed` | The 160x144 letterbox the hardware had, instead of SCREEN FILL |
+## | `zoom=<n>` | The zoom ladder; `zoom=-3` is the whole-region survey |
+## | `view=<mod id>` | A registered renderer instead of the built-in one. Needs `--mods` in front of the `--` |
 ##
 ##   ... live effects 4 4 430x932 touch
-##
-## `zoom=<n>` and `framed` are the SCREEN FILL controls: `framed` photographs the
-## 160x144 letterbox the hardware had, and `zoom=-3` the whole-region survey:
-##
-##   ... live effects 4 4 1920x1080 zoom=-3
-##
-## `view=<mod id>` photographs a registered renderer instead of the built-in one,
-## which needs `--mods` in front of the `--` so the mods are actually loaded:
-##
 ##   Godot --path . -s res://tools/preview_world.gd --mods -- crystal 26 2 \
-##     /tmp/out.png live effects 4 4 1920x1080 view=voxel3d
+##     /tmp/out.png live effects 4 4 1920x1080 zoom=-3 view=voxel3d
 ##
-## `kind` is `effects` (the emote, the dust, the rustle and the headbutt tree),
-## `battle` (the wild fight `preview_battle_request` starts, settled past its
-## transition into the fight itself, which is the picture a battle renderer
-## staged on the map draws),
-## `unown_wall` (`DisplayUnownWords`' box, read off a Ruins of Alph chamber's
-## own wall pattern from the cell below it: maps 23 to 26 of group 3 say HO-OH,
-## ESCAPE, WATER and LIGHT, as `crystal 3 24 ... unown_wall 3 1`),
-## `cut` (`OWCutAnimation`'s two halves and the jump shadow), `mart`
-## (`BuyMenu`, talked open from the cell in front of a shop's counter, as
-## `crystal 1 8 ... mart 3 3`), `mart_sell` (the same shop's SELL row, which is
-## `DepositSellPack` on the cartridge and this port's own list of the pack),
-## `pokepic`
-## (`Script_pokepic`'s box over the map, holding Chikorita),
-## `pet_actor` (a mod's world actor one cell in front of the player, pressed with
-## A so it wears the heart `showemote` puts over a map object),
-## `warp` (`MapSetupScript_Door` at its whitest: the player is walked up onto the
-## warp tile named by the two numbers below it, and the picture is
-## `FadeOutToWhite`'s last order, which is the frame the new map is loaded on:
-## `crystal 24 7 ... warp 7 1` is the bedroom staircase),
-## `script_fade` (one of the five fade specials over the map, as
-## `crystal 24 4 ... script_fade 46 6`: the first number is the special and the
-## second how many of its frames to spend before the picture),
-## `door` (`.CheckWarp`'s carpet: the player is walked down onto an interior
-## door's mat and photographed standing on it, which the step itself no longer
-## warps: `crystal 24 6 ... door 6 5` is the front door of the player's house),
-## `ice_slide` (`DoPlayerMovement.CheckForced`'s run: the player is walked in
-## one direction until the step lands on ice and the frames after that are the
-## slide's own, with nothing held, as `crystal 3 61 ... ice_slide@16,8 2 40`,
-## whose first number is the direction in down, up, left, right order and whose
-## second is how many of the slide's frames to spend),
-## `ledge` (the ledge hop at the top of its arc, walking south from the cell the
-## two numbers name until one allows the hop: `crystal 24 4 ... ledge 5 4`),
-## `map_name_sign` (`InitMapNameSign`'s window, raised by walking west off the
-## map's edge onto its neighbour: `crystal 24 4 ... map_name_sign 1 8` crosses
-## New Bark Town into Route 29),
-## `battle_tower` (`BattleTower1FReceptionistScript`, talked to from the cell
-## below her: the first number is how many A presses to spend and the second how
-## many DOWN presses, so `crystal 22 11 ... battle_tower@7,7 5 0` is the
-## Challenge / Explanation / Cancel menu and `... battle_tower@7,7 6 2` the level
-## list standing on its third room),
-## `yes_no` (`Script_yesorno`'s box, over the map's first script run to the
-## choice it ends on: `crystal 26 3 ... yes_no 31 6` is Cherrygrove's guide),
-## `name_rater` and `move_deleter` (`special NameRater` and `special
-## MoveDeletion`, which no fixture cell reaches: the first number is how many
-## presses into the routine to photograph, so 0 is the introduction, 2 its last
-## page with the YES/NO up, and 4 the party list),
-## `gift_nickname` (`GiveANickname_YesNo`, which no fixture cell reaches because
-## a `givepoke` is somebody's map script: the first number is how many presses
-## into the prompt to photograph, 1 its question with the YES/NO up and 2 the
-## `WasSentToBillsPCText` behind NO, and the second the species, plus 1000 for
-## the box branch that prints that line),
-## `unown_printer` (`_UnownPrinter`'s ALPH RUINS STAMP browser, which no fixture
-## cell reaches: the first number is the slot, 26 being the vacant one, and the
-## second is 1 for the page A sends to a printer that is not there),
-## `diploma` (`_Diploma`'s page: the first number is 1 for `_PrintDiploma`'s
-## loop, which stands the printer's own connection error over it, and the second
-## is the page, where 2 is the one only a printer that answered reaches),
-## `bills_pc` (`_BillsPC`'s top menu and the lists behind it, which no preview
-## cell reaches: the first number is how many rows down the menu to stand and the
-## second how many A presses to spend, so `crystal 24 6 ... bills_pc 1 2` is the
-## DEPOSIT list with its submenu up),
-## `players_pc` and `pokemon_center_pc` (the bedroom's item PC and the Pokemon
-## Center's machine, driven the same way: `crystal 24 6 ... players_pc 3 1` is
-## the decoration menu and `crystal 24 6 ... pokemon_center_pc 3 1` the Hall of
-## Fame viewer on a save that has been inducted),
-## `mom_bank` (`Mom_WithdrawDepositMenuJoypad`'s dial, which no fixture cell
-## reaches: the first number is the wallet in hundreds and the second her own
-## balance in hundreds, plus 1000 for the WITHDRAW header),
-## `move_tutor` (`special MoveTutor`, driven the same way, except that it opens
-## on `ChooseMonToLearnTMHM` rather than on a box: 0 is that list),
-## `day_care` (the Day-Care's five specials, driven the same way: the first
-## number is how many presses in and the second which routine, 0 the man,
-## 1 the lady, 2 the man outside, 3 and 4 the two signs),
-## `slot_machine` (`special SlotMachine`, which no fixture cell reaches: the
-## first number is how many frames into the game to photograph and the second
-## the bet, 1 to 3, plus 4 for the lucky machine),
-## `tile_anim` (the map after the first number's worth of `AnimateTileset`
-## frames, which is how the water, the flowers, the lava and the cave scroll are
-## photographed at a chosen point in their cycle: `crystal 3 37 ... tile_anim 60`
-## is Union Cave a second in),
-## `card_flip` (`special CardFlip`, which no fixture cell reaches: the first
-## number is how many frames into the game to photograph and the second the
-## balance in hundreds of coins),
-## `unown_puzzle` (`special UnownPuzzle`'s board, which no fixture cell reaches:
-## the first number is how many frames in to photograph and the second which
-## picture, 0 Kabuto, 1 Omanyte, 2 Aerodactyl and 3 Ho-Oh, or 4 to 7 for the
-## same four solved; the empty cursor blinks off `hVBlankCounter`, so a frame
-## with bit 4 clear has none on it),
-## `visible_encounter` (a shiny of the map's own table standing on the eligible
-## cell nearest the player, with the cartridge's sparkle over it: try
-## `crystal 24 3 ... visible_encounter 4 9`),
-## `visible_encounter_glow` (the same population with ordinary DVs wearing an
-## entry's own `glow` instead, which is the mark a mod puts on a Pokemon worth
-## stopping for: `crystal 24 3 ... visible_encounter_glow 4 9`),
-## `field_moves_menu` (the start menu's MOVES row, and the list of HM moves the
-## bag can supply behind it, both of which need a registered field-move source
-## before they exist: driven twice, since each call is one step),
-## `repel_renewal` (the question a Repel running out asks, which needs a
-## registered renewal provider), the name of any
-## `preview_*` driver on the world screen without that prefix (`field_move` is
-## `PartyMenu` with a taught CUT on it, `start_menu`, `capture`,
-## `catch_nickname` (`PokeBallEffect`'s own question, over the battle the throw
-## was made in), `move_forget`
-## and the rest; a `*_use` name is driven twice, since each call is one step of
-## its own sequence), or one of
-## [constant FIELD_ITEMS]' own names, which is the pack's USE on that item: the
-## Itemfinder closes the pack over the world's answer, the Coin Case prints
+## Kinds, with what their two numbers mean. A kind saying "no fixture cell" is
+## driven directly because no map cell reaches it.
+##
+## | Kind | Numbers | Draws |
+## | `effects` | cell | The emote, boulder dust, grass rustle and headbutt tree over the first visible object |
+## | `battle` | cell | The wild fight `preview_battle_request` starts, settled past its transition |
+## | `cut` | cell | `OWCutAnimation`'s two halves and the jump shadow |
+## | `tile_anim` | frames | The map that many `AnimateTileset` frames in: water, flowers, lava, cave scroll |
+## | `unown_wall` | cell | `DisplayUnownWords`' box, read off the chamber wall above the cell. Group 3 maps 23 to 26 say HO-OH, ESCAPE, WATER, LIGHT |
+## | `mart`, `mart_sell` | cell in front of the counter | `BuyMenu`, and the SELL row (`DepositSellPack`) |
+## | `pokepic` | cell | `Script_pokepic`'s box over the map, holding Chikorita |
+## | `pet_actor` | cell | A mod's world actor one cell ahead, pressed with A so it wears a `showemote` heart |
+## | `warp` | warp tile | `MapSetupScript_Door` at its whitest, which is the frame the new map loads on |
+## | `script_fade` | special, frames | One of the five fade specials over the map |
+## | `door` | door mat | `.CheckWarp`'s carpet, standing on an interior door's mat |
+## | `ice_slide` | direction, frames | `DoPlayerMovement.CheckForced`'s run. Direction is down, up, left, right |
+## | `ledge` | start cell | The ledge hop at the top of its arc, walking south until one allows it |
+## | `map_name_sign` | cell | `InitMapNameSign`'s window, raised by walking west onto the neighbouring map |
+## | `yes_no` | script, presses | `Script_yesorno`'s box over the map's script |
+## | `battle_tower` | A presses, DOWN presses | `BattleTower1FReceptionistScript`, talked to from the cell below her |
+## | `name_rater`, `move_deleter` | presses | `special NameRater` / `special MoveDeletion`. 0 is the introduction, 2 the last page with YES/NO, 4 the party list |
+## | `gift_nickname` | presses, species | `GiveANickname_YesNo`. 1 is the question, 2 the `WasSentToBillsPCText` behind NO. Add 1000 to the species for the box branch |
+## | `unown_printer` | slot, page | `_UnownPrinter`'s ALPH RUINS STAMP browser. Slot 26 is the vacant one; page 1 is what A sends to a printer that is not there |
+## | `diploma` | loop, page | `_Diploma`'s page. 1 stands `_PrintDiploma`'s connection error over it; page 2 needs a printer that answered |
+## | `bills_pc` | rows down, A presses | `_BillsPC`'s top menu and the lists behind it |
+## | `players_pc`, `pokemon_center_pc` | rows down, A presses | The bedroom's item PC and the Pokemon Center's machine |
+## | `mom_bank` | wallet, balance, both in hundreds | `Mom_WithdrawDepositMenuJoypad`'s dial. Add 1000 for the WITHDRAW header |
+## | `move_tutor` | presses | `special MoveTutor`. 0 is `ChooseMonToLearnTMHM`'s list, not a box |
+## | `day_care` | presses, routine | 0 the man, 1 the lady, 2 the man outside, 3 and 4 the two signs |
+## | `slot_machine` | frames, bet | `special SlotMachine`. Bet is 1 to 3, plus 4 for the lucky machine |
+## | `card_flip` | frames, coins in hundreds | `special CardFlip` |
+## | `unown_puzzle` | frames, picture | `special UnownPuzzle`. 0 Kabuto, 1 Omanyte, 2 Aerodactyl, 3 Ho-Oh, or 4 to 7 solved. The cursor blinks off `hVBlankCounter`, so a frame with bit 4 clear has none |
+## | `visible_encounter` | cell | A shiny of the map's own table on the eligible cell nearest the player, with the sparkle over it |
+## | `visible_encounter_glow` | cell | The same population with ordinary DVs wearing an entry's `glow` |
+## | `field_moves_menu` | cell | The start menu's MOVES row and the HM list behind it. Needs a registered field-move source, and is driven twice |
+## | `repel_renewal` | cell | The question a Repel running out asks. Needs a registered renewal provider |
+##
+## A kind may also be the name of any `preview_*` driver on the world screen
+## without that prefix: `field_move` (`PartyMenu` with a taught CUT),
+## `start_menu`, `capture`, `catch_nickname` (`PokeBallEffect`'s question over
+## the battle the throw was made in), `move_forget` and the rest. A `*_use` name
+## is driven twice, since each call is one step of its own sequence.
+##
+## Or one of [constant FIELD_ITEMS]' names, which is the pack's USE on that item:
+## the Itemfinder closes the pack over the world's answer, the Coin Case prints
 ## inside the pack, and the three in [constant FACE_UP_FIRST] each need their own
-## map and the cell below their target. The two numbers are the cell
-## the player stands on, which is how the grass a standing object is drawn behind
-## is photographed.
+## map and the cell below their target.
 
 ## `.forced_dpad`'s own order, which the first number indexes.
 const ICE_SLIDE_BUTTONS: Array[int] = [


### PR DESCRIPTION
docs/MODS.md documented every past api_version alongside the current one, so a mod author had to read the history to find the contract. It now states the current contract only.

README, CONTRIBUTING, SAVES and REFERENCES lose the rationale paragraphs that restated a fact after stating it, and the save-format migration archaeology becomes one sentence. Long prose runs become tables where the content was already a table.

Also: delete the section banner comments the style rules forbid, turn preview_world.gd's 143-line header into a table of its kinds, and fix a pull-request template and a roms README pointing at things that are not in the repository.