### PR TITLE
Step a visible population on overworld frames and keep its snapshot current

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -33,7 +33,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version. Strict `major.minor.patch` |
-| `api_version` | The contract this mod is written against. Current: `Gen2ModManifest.API_VERSION`, 18. A host accepts 1 to 18 |
+| `api_version` | The contract this mod is written against. Current: `Gen2ModManifest.API_VERSION`, 19. A host accepts 1 to 19 |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -1084,8 +1084,8 @@ registration:
 
 | Method | Called when |
 |---|---|
-| `set_context(context: Dictionary)` | The map changed, and whenever the player's pose moves |
-| `advance_frame()` | Once per hardware frame |
+| `set_context(context: Dictionary)` | The map changed, and whenever the player's pose, the occupancy or the tables move |
+| `advance_frame()` | Once per hardware frame the overworld is running. Not while a battle, a menu, an overlay, a text box, a map fade or a trainer's approach owns the world, which is when the map's own objects stand still too. A provider counting its own calls is counting the time the player spent walking around |
 | `encounters() -> Array` | The population now. Asked once a frame |
 | `battle_finished(id: StringName, result: Dictionary)` | A battle this provider's entry started ended |
 
@@ -1094,9 +1094,9 @@ The context is a snapshot, never a live handle:
 | Key | Meaning |
 |---|---|
 | `map` | `Vector2i(group, number)` |
-| `eligible` | `{grass, surf}` to `PackedVector2Array` of cells a wild may stand on. `CanEncounterWildMon` per cell |
+| `eligible` | `{grass, surf}` to `PackedVector2Array` of cells a wild may stand on. `CanEncounterWildMon` per cell. Taken again, and pushed, if a script runs `wildoff` or `wildon` while the map is up |
 | `occupied` | The walk cells the map's own objects hold this frame: NPCs, item balls, all four cells of a big object, and both cells of one mid-step. Refreshed with `player`, not with `map`. An entry outside `eligible` is dropped, so the two are deliberately separate. Refusing an occupied cell is the provider's choice. The player's cell is not in it |
-| `tables` | `{grass, surf}` to `{source, slots}`, the table a roll would read now, with swarm and Bug Contest substitutions and the time of day already applied. A slot is `{species, min_level, max_level}` |
+| `tables` | `{grass, surf}` to `{source, slots}`, the table a roll would read now, with swarm and Bug Contest substitutions and the time of day already applied. A slot is `{species, min_level, max_level}`. Refreshed while the map is up, whenever the hour, a swarm or the Bug Contest moves what a roll would read |
 | `player` | `{cell, facing}` |
 | `run_seed` | The run's seed, so a population is reproducible |
 | `generation` | Bumped on every map change; an older one means the context is stale |
@@ -1134,6 +1134,11 @@ What the host does with a valid population:
 - Starts the normal wild battle when the player steps onto an entry, with that
   entry's exact species, level and DVs, then calls `battle_finished`. Whether the
   entry survives is the provider's rule to document.
+- Keeps an entry it already admitted while it keeps standing on the same cell's
+  method with the same species and level, even after the tables move under it. A
+  route entered in daylight therefore turns over to its night species as each
+  wild is replaced, rather than emptying at six. A new entry is checked against
+  the tables in force now, so `generation` never moves for an hour boundary.
 - Discards the population, its sprites and any running pulse on a map change.
 - Plays `ANIM_SEND_OUT_MON` with the shiny param over a pulsing shiny entry, sound
   included. A request inside `Gen2WorldEncounters.PULSE_FRAMES` of the last one is

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -16,7 +16,7 @@ const FILENAME: String = "mod.json"
 ## What each version added is in the commit history; `docs/MODS.md` documents the
 ## current contract only. An optional field a mod may send and an older host may
 ## drop is deliberately not a bump.
-const API_VERSION: int = 18
+const API_VERSION: int = 19
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2140,6 +2140,26 @@ func visible_encounter_cells() -> Dictionary:
 	return out
 
 
+## `wildoff`. The only thing that empties [method visible_encounter_cells] while
+## one map is up, and a script may run it at any point in a walk.
+func wild_encounters_off() -> bool:
+	return state.wild_encounters_off()
+
+
+## What [method active_encounter_tables] resolves against, and nothing else: the
+## hour the objects are drawn at, the Bug Contest and a swarm on this map. Three
+## reads rather than two table builds, so a caller may ask on every frame whether
+## the tables have moved without building one to find out.
+func encounter_tables_key() -> Array:
+	if current_map == null or data == null:
+		return []
+	return [
+		object_time_of_day,
+		bug_contest_active(),
+		state.swarm_active_on(current_map.group, current_map.number),
+	]
+
+
 ## The wild table each method would resolve against right now, with the Bug
 ## Contest's and the swarm's substitutions already made and the time of day
 ## already picked. `slots` is the flat list of `{species, min_level, max_level}`
@@ -2521,7 +2541,7 @@ func count_step() -> bool:
 func do_bike_step() -> bool:
 	if state == null or current_map == null:
 		return false
-	var flag: int = state.engine_flag(
+	var flag: int = Gen2WorldState.engine_flag(
 		Gen2WorldState.ENGINE_BIKE_SHOP_CALL, Gen2WorldState.is_crystal_profile(data)
 	)
 	var armed: bool = movement_mode == MOVEMENT_BIKE and state.is_engine_flag_active(flag)

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -74,6 +74,17 @@ var _entries: Array = []
 ## one after the entry itself is gone.
 var _owners: Dictionary = {}
 var _frame: int = 0
+## What the context's `tables` were resolved against, so the frame that moves
+## them can be told from the ones that do not.
+## See [method Gen2WorldAPI.encounter_tables_key].
+var _tables_key: Array = []
+## Whether `wildoff` was on when the eligible sweep in the context was taken. A
+## script may run it in the middle of a walk, and it empties the sweep.
+var _encounters_off: bool = false
+## Entry id to the `[method, species, level]` it was admitted under, rebuilt from
+## the population every frame. What keeps a wild standing when the tables move
+## out from under it.
+var _admitted: Dictionary = {}
 ## Entry id to the frame its last pulse started on.
 var _pulsed: Dictionary = {}
 var _pulse: Gen2BattleAnimPlayer = null
@@ -118,7 +129,7 @@ func advance_frame() -> bool:
 		return false
 	_frame += 1
 	_frame_commands = []
-	_push_player_pose()
+	_push_context_changes()
 	for provider: Object in _providers:
 		provider.call("advance_frame")
 	var before: Array = _entries
@@ -236,10 +247,13 @@ func battle_finished(id: StringName, result: Variant) -> void:
 func _reset() -> void:
 	_entries = []
 	_owners = {}
+	_admitted = {}
 	_pulsed = {}
 	_pulse = null
 	_pulse_id = &""
 	_frame_commands = []
+	_tables_key = _world.encounter_tables_key() if _world != null else []
+	_encounters_off = _world.wild_encounters_off() if _world != null else false
 	_context = _build_context()
 	for provider: Object in _providers:
 		provider.call("set_context", _context.duplicate(true))
@@ -293,21 +307,49 @@ func _occupied_cells() -> PackedVector2Array:
 	return out
 
 
-## The pose moves and the map does not, so the sweep and the tables are not taken
-## again: a provider is handed the same context with `player` and `occupied`
-## refreshed, and only when one of the two has actually changed. An object walks
-## while the player stands still, so the occupancy is on this pass rather than on
-## the map change.
-func _push_player_pose() -> void:
+## What moves while one map is up: the player's pose, the cells the map's own
+## objects hold, the tables, and `wildoff`. An object walks while the player
+## stands still, so the occupancy is on this pass rather than on the map change.
+##
+## The eligible sweep is the whole map and is taken only when `wildoff` is
+## toggled, which is the one thing that moves it: `CanEncounterWildMon`'s answer
+## for a cell is the terrain's and stands as long as the map does. A script may
+## run `wildoff` at any point in a walk, and an entry standing on a cell it just
+## emptied is dropped by [method _validate] rather than grandfathered: a wild is
+## admitted against a table, never against a map that has switched wilds off.
+##
+## The tables move without the map: six o'clock, a swarm arriving, and the Bug
+## Contest starting or ending each change what a roll would read. A provider that
+## mints an entry LATER than the map change plans it against whatever it was
+## handed, so a stale snapshot would spawn a day species at night and
+## [method _table_offers] would agree with it. `generation` is deliberately not
+## bumped: that means "the map changed, discard everything", and an hour boundary
+## is not a map change.
+##
+## Pushed once, so a frame that moves two of the three costs one call.
+func _push_context_changes() -> void:
 	if _world == null or _context.is_empty():
 		return
+	var changed: bool = false
 	var pose: Dictionary = {"cell": _world.player_cell, "facing": _world.player_facing}
 	var occupied: PackedVector2Array = _occupied_cells()
-	if _context.get("player", {}) == pose \
-	and _context.get("occupied", PackedVector2Array()) == occupied:
+	if _context.get("player", {}) != pose \
+	or _context.get("occupied", PackedVector2Array()) != occupied:
+		_context["player"] = pose
+		_context["occupied"] = occupied
+		changed = true
+	var off: bool = _world.wild_encounters_off()
+	if off != _encounters_off:
+		_encounters_off = off
+		_context["eligible"] = _world.visible_encounter_cells()
+		changed = true
+	var key: Array = _world.encounter_tables_key()
+	if key != _tables_key:
+		_tables_key = key
+		_context["tables"] = _world.active_encounter_tables()
+		changed = true
+	if not changed:
 		return
-	_context["player"] = pose
-	_context["occupied"] = occupied
 	for provider: Object in _providers:
 		provider.call("set_context", _context.duplicate(true))
 
@@ -315,7 +357,11 @@ func _push_player_pose() -> void:
 func _collect() -> void:
 	_entries = []
 	if _world == null or _world.data == null:
+		_admitted = {}
 		return
+	## Rebuilt rather than added to, so an entry a provider stopped sending is
+	## checked against the tables again if it ever comes back.
+	var admitted: Dictionary = {}
 	var seen: Dictionary = {}
 	for provider: Object in _providers:
 		var answer: Variant = provider.call("encounters")
@@ -323,15 +369,20 @@ func _collect() -> void:
 			continue
 		for raw: Variant in answer as Array:
 			if _entries.size() >= MAX_ENTRIES:
-				return
+				break
 			var entry: Dictionary = _validate(raw)
 			if entry.is_empty() or seen.has(entry["id"]):
 				continue
 			seen[entry["id"]] = true
+			admitted[entry["id"]] = entry["admission"]
+			entry.erase("admission")
 			_owners[entry["id"]] = provider
 			_entries.append(entry)
 			if bool(entry["pulse"]):
 				_start_pulse(entry)
+		if _entries.size() >= MAX_ENTRIES:
+			break
+	_admitted = admitted
 
 
 ## One entry against the context it was given. An id, a cell inside the eligible
@@ -353,7 +404,13 @@ func _validate(raw: Variant) -> Dictionary:
 		return {}
 	var species: int = int(row.get("species", 0))
 	var level: int = int(row.get("level", 0))
-	if not _table_offers(method, species, level):
+	## A wild admitted legally stays admitted while it keeps standing where it
+	## was. The tables move under a standing population at six o'clock and on a
+	## swarm, and revalidating against the new ones would empty the route on the
+	## hour instead of letting it turn over as each Pokemon leaves.
+	var admission: Array = [method, species, level]
+	if _admitted.get(id, null) != admission \
+		and not _table_offers(method, species, level):
 		return {}
 	var dvs: int = int(row.get("dvs", 0))
 	if dvs < 0 or dvs > 0xFFFF:
@@ -367,6 +424,8 @@ func _validate(raw: Variant) -> Dictionary:
 		"dvs": dvs,
 		"shiny": Gen2Stats.is_shiny(dvs),
 		"pulse": bool(row.get("pulse", false)),
+		## Read and dropped by [method _collect]; never reaches a caller.
+		"admission": admission,
 	}
 	var glow: Dictionary = _glow(row.get("glow", null))
 	if not glow.is_empty():

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -861,10 +861,21 @@ func advance_frame() -> void:
 	## `player_step_offset_cells()` sees this frame rather than the last one's.
 	## Before the actors, which draw its population: a wild that moved this frame
 	## has to be in the sprite list the actor layer collects after it.
-	if _encounters != null and _encounters.advance_frame():
+	##
+	## Gated on the same predicate the map's own objects step behind, so a
+	## provider's frame count is the time the player spent on the overworld: a
+	## population stands still behind a battle, a menu, a text box and a fade,
+	## which is what the map does with its objects. Not the pass's: a wild is
+	## drawn between cells like an object mid-step, and the source moves those on
+	## every frame.
+	if _encounters != null and _objects_may_move() and _encounters.advance_frame():
 		_play_encounter_sounds()
 		if _renderer != null:
 			_renderer.refresh()
+	## Deliberately not gated with it: an actor owns no state the host validates
+	## and is drawn only on the frames the map is, so an animation running behind
+	## an overlay costs a mod nothing and freezing one would strand a walk cycle
+	## mid-step.
 	if _actors != null and _actors.advance_frame() and _renderer != null:
 		_renderer.refresh()
 	_spend_actor_requests()

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 18,
+	"api_version": 19,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 18,
+	"api_version": 19,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -514,6 +514,15 @@ func test_a_visible_encounter_provider_is_driven_validated_drawn_and_fought() ->
 	## reported back to the provider when the fight ends.
 	assert_eq(_world_screen._battle_encounter_id, &"a")
 
+	## R54's whole point: the pump that spends a provider's frames is the world
+	## screen's, and it spends the battle's frames too. A provider is stepped on
+	## the frames the map's own objects step on and no others, so a despawn
+	## countdown measures the time the player spent walking rather than the
+	## thirty seconds a fight took.
+	var fighting: int = int(provider.get("frames"))
+	_world_screen.advance_frames(8)
+	assert_eq(int(provider.get("frames")), fighting, "the fight spends no wild's frame")
+
 	_world_screen._on_battle_finished({"outcome": Gen2WorldBattleAdapter.OUTCOME_RAN})
 	var reported: Array = provider.get("results")
 	assert_eq(reported.size(), 1)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -7497,6 +7497,119 @@ func test_a_visible_encounter_glow_is_quantized_and_walks_its_own_colours() -> v
 	assert_eq(rungs.size(), Gen2WorldEncounters.GLOW_RUNGS + 1)
 
 
+## The tables move while one map is up, and a provider that mints an entry after
+## the map change plans against whatever it was last handed. So they are pushed
+## when they move, without a new generation, and a population already admitted is
+## not deleted by the move.
+func test_a_populations_tables_are_refreshed_without_discarding_it() -> void:
+	var world := _world()
+	var driver := Gen2WorldEncounters.new()
+	var provider: Object = _table_provider()
+	driver.set_providers([provider])
+	driver.set_world(world)
+	driver.advance_frame()
+	assert_eq(driver.entries().size(), 1, "the map's own day species stands")
+	var generation: int = int((provider.get("context") as Dictionary)["generation"])
+	assert_eq(
+		int((provider.get("context")["tables"][Gen2WorldEncounter.METHOD_GRASS]
+			as Dictionary)["slots"][0]["species"]),
+		16
+	)
+
+	## A swarm is one of the three movers, and it changes what a roll would read
+	## without changing the map.
+	world.set_swarm_map(Vector2i(1, 1))
+	driver.advance_frame()
+	var swarmed: Dictionary = provider.get("context")["tables"][
+		Gen2WorldEncounter.METHOD_GRASS
+	]
+	assert_eq(StringName(swarmed["source"]), Gen2WorldEncounter.SOURCE_SWARM)
+	assert_eq(int((swarmed["slots"] as Array)[0]["species"]), 19)
+	assert_eq(
+		int((provider.get("context") as Dictionary)["generation"]), generation,
+		"an hour or a swarm is not a map change"
+	)
+
+	## The one the mod already placed keeps standing: revalidating it against the
+	## table that just moved would empty the route in a single frame.
+	assert_eq(driver.entries().size(), 1)
+	assert_eq(int(driver.entries()[0]["species"]), 16)
+
+	## A NEW entry is checked against the table in force now, which is what stops
+	## a day species being spawned at night with nothing reporting a fault.
+	provider.set("rows", [
+		{"id": &"one", "cell": Vector2i(5, 10), "species": 16, "level": 5, "dvs": 0},
+		{"id": &"two", "cell": Vector2i(5, 10), "species": 16, "level": 5, "dvs": 0},
+		{"id": &"three", "cell": Vector2i(5, 10), "species": 19, "level": 5, "dvs": 0},
+	])
+	driver.advance_frame()
+	var ids: Array = []
+	for entry: Dictionary in driver.entries():
+		ids.append(StringName(entry["id"]))
+	assert_eq(ids, [&"one", &"three"], "the standing one and the swarm's own")
+
+	## And an id the provider stopped sending is checked again if it comes back,
+	## rather than carrying its admission forever.
+	provider.set("rows", [
+		{"id": &"three", "cell": Vector2i(5, 10), "species": 19, "level": 5, "dvs": 0},
+	])
+	driver.advance_frame()
+	provider.set("rows", [
+		{"id": &"one", "cell": Vector2i(5, 10), "species": 16, "level": 5, "dvs": 0},
+	])
+	driver.advance_frame()
+	assert_eq(driver.entries().size(), 0, "off the table it left")
+
+	## `wildoff` moves the other half of the snapshot, and a script may run it in
+	## the middle of a walk. The sweep is taken again and the population standing
+	## on it goes: an admission is against a table, not against a map that has
+	## switched wild encounters off.
+	world.set_swarm_map(Vector2i(1, 1), false)
+	provider.set("rows", [
+		{"id": &"one", "cell": Vector2i(5, 10), "species": 16, "level": 5, "dvs": 0},
+	])
+	driver.advance_frame()
+	assert_eq(driver.entries().size(), 1, "the day species is back on the map's table")
+	world.state.set_wild_encounters_off(true)
+	driver.advance_frame()
+	assert_eq(
+		((provider.get("context")["eligible"] as Dictionary)[
+			Gen2WorldEncounter.METHOD_GRASS
+		] as PackedVector2Array).size(),
+		0, "the sweep is empty while wilds are off"
+	)
+	assert_eq(driver.entries().size(), 0, "and nothing stands on it")
+	world.state.set_wild_encounters_off(false)
+	driver.advance_frame()
+	assert_eq(driver.entries().size(), 1, "`wildon` puts the map back")
+
+
+## A provider whose population and recorded context the caller owns.
+func _table_provider() -> Object:
+	var script := GDScript.new()
+	script.source_code = """extends RefCounted
+
+var context: Dictionary = {}
+var rows: Array = [{
+	"id": &"one", "cell": Vector2i(5, 10), "species": 16, "level": 5, "dvs": 0,
+}]
+
+func set_context(value: Dictionary) -> void:
+	context = value
+
+func advance_frame() -> void:
+	pass
+
+func encounters() -> Array:
+	return rows
+
+func battle_finished(_id, _result) -> void:
+	pass
+"""
+	script.reload()
+	return script.new()
+
+
 ## `_changed` is what decides whether a view repaints, so a glow that moves while
 ## the Pokemon stands still has to be in it.
 func test_a_moving_glow_repaints_a_standing_pokemon() -> void:


### PR DESCRIPTION
Two seams a mod asked for, plus the third case the second one turned out to serve.

## The provider step is an overworld frame

`Gen2WorldScreen.advance_frame()` is the single pump for the whole game: the
battle host, the menus, the text box and both map fades are spent from it. A
visible-encounter provider was stepped from it unconditionally, so a
thirty-second fight spent thirty seconds of a provider's frames with the
overworld standing still behind it.

The step is now behind `_objects_may_move()`, which is the predicate the map's
own objects step behind two lines below. Wilds stop roaming while a text box is
up, which is what the cartridge does with its objects.

The actor layer next to it is deliberately not gated. An actor owns no state
the host validates and is drawn only on the frames the map is, so freezing one
would strand a walk cycle mid-step and buy nothing.

## The snapshot stays current

`tables` was resolved once, on the map change. It moves without the map at
06:00, 10:00 and 18:00, on a swarm arriving, and at either end of the Bug
Contest. That was invisible while a population was minted once from the same
snapshot the host validates it against: both sides stale together, so they
agree. A provider that mints an entry later would draw a day species from a
stale table at 18:05 and the validator would accept it, with nothing anywhere
reporting a fault.

`eligible` has the same shape of hole, one step over. A script running
`wildoff` empties the sweep, and the corpus does that ten times. Both are
refreshed and pushed when they move.

Two rules keep the refresh from being worse than the bug:

- `generation` does not move. It means "the map changed, discard everything",
  and an hour boundary is not a map change.
- An entry already admitted keeps its cell's method, species and level, so
  revalidating against a table that just moved does not empty the route in a
  single frame. A route entered in daylight turns over to its night species as
  each wild is replaced, rather than snapping at six.

An entry standing on a cell `wildoff` just emptied is dropped rather than
grandfathered: an admission is against a table, never against a map that has
switched wild encounters off.

`API_VERSION` 19.

## Measured

| Check | Result |
|---|---|
| Unit tier | 3278 tests, 62399 asserts, green |
| Scene tier | 3800 tests, 71598 asserts, green |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| Boot, with and without mods | no script error |
| Analyser over the changed scripts | 0 warnings in 5 |

Also fixes an analyser warning it turned up on the way: `state.engine_flag` in
`do_bike_step` is a static function called from an instance.