### PR TITLE
Hand over the Odd Egg and Buena's password box

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -75,6 +75,7 @@ var _pokecenter_pc: Dictionary = {}
 var _decorations: Dictionary = {}
 var _unown_words: PackedStringArray = PackedStringArray()
 var _unown_walls: PackedStringArray = PackedStringArray()
+var _odd_eggs: Array = []
 var _credits: Dictionary = {}
 var _intro_movie: Dictionary = {}
 var _unown_puzzle: Dictionary = {}
@@ -219,6 +220,8 @@ static func open_directory(path: String) -> GameData:
 	if unown_walls is Array:
 		for wall: Variant in unown_walls as Array:
 			data._unown_walls.append(String(wall))
+	var odd_eggs: Variant = manifest.get("odd_eggs", [])
+	data._odd_eggs = odd_eggs if odd_eggs is Array else []
 	var credits: Variant = manifest.get("credits", {})
 	data._credits = credits if credits is Dictionary else {}
 	var intro_movie: Variant = manifest.get("intro_movie", {})
@@ -1902,6 +1905,26 @@ func unown_wall_word(index: int) -> String:
 	if index < 0 or index >= _unown_walls.size():
 		return ""
 	return _unown_walls[index]
+
+
+## `OddEggProbabilities` and `OddEggs` as one table: the cumulative word the
+## roll is compared against, and the nicknamed-mon bytes the row hands over.
+## Empty on Gold and Silver, which ship no Odd Egg.
+func odd_eggs() -> Array:
+	return _odd_eggs
+
+
+## Row [param index] of that table as the Pokemon it is, or null outside it.
+func odd_egg_mon(index: int) -> Gen2SaveMon:
+	if index < 0 or index >= _odd_eggs.size():
+		return null
+	var row: Variant = _odd_eggs[index]
+	if not row is Dictionary:
+		return null
+	var bytes: Variant = (row as Dictionary).get("bytes", [])
+	if not bytes is Array:
+		return null
+	return Gen2SramAdapter.read_nicknamed_mon(PackedByteArray(bytes as Array), 0)
 
 
 ## `OakRatings`, as [code]{ threshold, sfx, text }[/code] rows in table order.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 90
+const FORMAT_VERSION: int = 91
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -362,6 +362,10 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	if not unown_walls["ok"]:
 		return unown_walls
 
+	var odd_eggs: Dictionary = verify_odd_eggs(rom, layout)
+	if not odd_eggs["ok"]:
+		return odd_eggs
+
 	var intro_movie: Dictionary = verify_intro_movie(rom, layout)
 	if not intro_movie["ok"]:
 		return intro_movie
@@ -1424,6 +1428,76 @@ static func verify_unown_walls(rom: RomFile, layout: Dictionary) -> Dictionary:
 			return {"ok": false, "message": "Two Unown walls read \"%s\"." % word}
 		seen[word] = true
 	return {"ok": true, "message": "Unown walls verified."}
+
+
+## `data/events/odd_eggs.asm`: fourteen cumulative probability words followed by
+## fourteen nicknamed-mon rows. Each row is stored as the bytes it is, because
+## [method Gen2SramAdapter.read_nicknamed_mon] is what reads one and a second
+## decoder here would be the copy that goes stale. Empty on a cartridge with no
+## Odd Egg.
+static func read_odd_eggs(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout.get("odd_eggs", -1))
+	var span: int = RomLayout.ODD_EGG_MONS_OFFSET \
+		+ RomLayout.ODD_EGG_COUNT * RomLayout.NICKNAMED_MON_BYTES
+	if at < 0 or not rom.in_bounds(at, span):
+		return []
+	var out: Array = []
+	for index: int in RomLayout.ODD_EGG_COUNT:
+		out.append({
+			## `.loop` compares the random word against this entry and takes the
+			## row when the word is no greater, so the words are cumulative and
+			## the last is $ffff.
+			"probability": rom.u16le(at + index * RomLayout.ODD_EGG_PROBABILITY_BYTES),
+			"bytes": Array(rom.slice(
+				at + RomLayout.ODD_EGG_MONS_OFFSET
+					+ index * RomLayout.NICKNAMED_MON_BYTES,
+				RomLayout.NICKNAMED_MON_BYTES
+			)),
+		})
+	return out
+
+
+## The table's own shape is the pin: the probabilities rise and close on $ffff,
+## and every row is a level 5 baby with the nickname EGG that `dname` writes.
+static func verify_odd_eggs(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if int(layout.get("odd_eggs", -1)) < 0:
+		return {"ok": true, "message": "No Odd Egg in this dump."}
+	var rows: Array = read_odd_eggs(rom, layout)
+	if rows.size() != RomLayout.ODD_EGG_COUNT:
+		return {"ok": false, "message": "The Odd Egg table is outside the ROM."}
+	var previous: int = 0
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		var probability: int = int(row["probability"])
+		if probability <= previous:
+			return {
+				"ok": false,
+				"message": "Odd Egg %d's probability %d does not rise." % [index, probability],
+			}
+		previous = probability
+		var mon: Gen2SaveMon = Gen2SramAdapter.read_nicknamed_mon(
+			PackedByteArray(row["bytes"]), 0
+		)
+		if mon == null or mon.species <= 0 or mon.species > RomLayout.SPECIES_COUNT:
+			return {"ok": false, "message": "Odd Egg %d names no species." % index}
+		if mon.level != RomLayout.ODD_EGG_LEVEL:
+			return {
+				"ok": false,
+				"message": "Odd Egg %d is level %d, not %d." % [
+					index, mon.level, RomLayout.ODD_EGG_LEVEL,
+				],
+			}
+		if mon.nickname != RomLayout.ODD_EGG_NICKNAME:
+			return {
+				"ok": false,
+				"message": "Odd Egg %d is nicknamed \"%s\"." % [index, mon.nickname],
+			}
+	if previous != RomLayout.ODD_EGG_PROBABILITY_TOTAL:
+		return {
+			"ok": false,
+			"message": "The Odd Egg probabilities close on %d, not $ffff." % previous,
+		}
+	return {"ok": true, "message": "Odd Eggs verified."}
 
 
 ## One of the two row runs, in the source's own order. Empty when the run is out
@@ -4736,6 +4810,7 @@ func import_rom(
 		"card_flip_text": _import_card_flip_text(rom, layout),
 		"unown_words": Array(read_unown_words(rom, layout)),
 		"unown_walls": Array(read_unown_walls(rom, layout)),
+		"odd_eggs": read_odd_eggs(rom, layout),
 		"credits": _import_credits(rom, layout),
 		"text_bg_palette": _import_text_bg_palette(rom, layout),
 		"battle_object_palettes": _import_battle_object_palettes(rom, layout),

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1611,6 +1611,29 @@ const DAY_CARE_COMPATIBILITY_TEXT_ORDER: Array[String] = [
 	"brimming_with_energy", "no_interest", "appears_to_care", "friendly",
 	"shows_interest",
 ]
+## `NICKNAMED_MON_STRUCT_LENGTH`: a whole Pokemon as a ROM table stores one,
+## the 48-byte party-mon struct with its nickname behind it.
+## [method Gen2SramAdapter.read_nicknamed_mon] is what reads a row of either
+## table that uses it.
+const NICKNAMED_MON_BYTES: int = 48 + 11
+
+## `data/events/odd_eggs.asm`, Crystal's alone: `OddEggProbabilities`' fourteen
+## cumulative words followed by `OddEggs`' fourteen nicknamed-mon rows. The two
+## are one run, so one address reaches both.
+const ODD_EGG_COUNT: int = 14
+const ODD_EGG_PROBABILITY_BYTES: int = 2
+const ODD_EGG_MONS_OFFSET: int = ODD_EGG_COUNT * ODD_EGG_PROBABILITY_BYTES
+## `.Odd`, the name `_GiveOddEgg` copies into `wTempOddEggNickname` and then
+## hands `AddMobileMonToParty` as the OT. The nickname is the row's own, which
+## every row spells EGG.
+const ODD_EGG_OT_NAME: String = "ODD"
+## Every row's own `dname`, and the level and hatch counter all fourteen share.
+const ODD_EGG_NICKNAME: String = "EGG"
+const ODD_EGG_LEVEL: int = 5
+## `odd_egg_prob`'s last cumulative word: the macro asserts the percentages sum
+## to 100, and 100 * $ffff / 100 is $ffff.
+const ODD_EGG_PROBABILITY_TOTAL: int = 0xFFFF
+
 ## Which pin each name is walked from, and at what index into it.
 const DAY_CARE_TEXT_RUNS: Array = [
 	["day_care_text", DAY_CARE_TEXT_ORDER],
@@ -2046,7 +2069,7 @@ const BATTLETOWER_TRAINER_NAME_BYTES: int = 10
 const BATTLETOWER_TRAINER_ROW_BYTES: int = BATTLETOWER_TRAINER_NAME_BYTES + 1
 ## `NICKNAMED_MON_STRUCT_LENGTH`, the party-mon struct with its nickname behind
 ## it, which is exactly what `LoadRandomBattleTowerMon` copies per slot.
-const BATTLETOWER_MON_BYTES: int = 48 + 11
+const BATTLETOWER_MON_BYTES: int = NICKNAMED_MON_BYTES
 ## `BattleTowerText`'s two arrays. A male class draws from 25 texts and a female
 ## from 15, and each trainer owns a greeting, a loss line and a win line, laid
 ## out in the file in that order per trainer. One pin walks all 120 stubs.
@@ -2297,6 +2320,9 @@ const GOLD_SILVER: Dictionary = {
 	# belong to are Crystal bg events, where pokegold's cells carry the puzzle
 	# sign, and neither `DisplayUnownWords` nor the words are in the dump.
 	"unown_walls": -1,
+	## `OddEggs` and its probabilities are Crystal's alone: Gold and Silver have
+	## no `GiveOddEgg` special and no Day-Care Man who offers one.
+	"odd_eggs": -1,
 	## Gold and Silver have no Battle Tower map, routine or table at all.
 	"battle_tower": {},
 	# The credits. `gfx` was located by converting the pinned gfx/credits PNGs
@@ -3169,6 +3195,7 @@ const CRYSTAL: Dictionary = {
 	"poke_seer_text": 0x4F28C,
 	"seer_advice_text": 0x4F2E8,
 	"buena_prize_text": 0x8B072,
+	"odd_eggs": 0x1FB552,
 	## `engine/events/battle_tower/rules.asm`'s three stub runs; Crystal only.
 	"battle_tower_excuse_text": 0x8B22C,
 	"battle_tower_ready_text": 0x8B238,

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -16,6 +16,8 @@ const PARTY_LENGTH: int = 6
 const PARTYMON_SIZE: int = 48
 const NAME_LENGTH: int = 11
 const MON_NAME_LENGTH: int = 11
+## `NICKNAMED_MON_STRUCT_LENGTH`, the struct plus the nickname behind it.
+const NICKNAMED_MON_SIZE: int = PARTYMON_SIZE + MON_NAME_LENGTH
 const PP_MASK: int = 0x3F
 const PP_UP_MASK: int = 0xC0
 
@@ -395,6 +397,19 @@ static func read_party_mon(raw: PackedByteArray, start: int) -> Gen2SaveMon:
 	mon.level = int(raw[start + 31])
 	mon.status = int(raw[start + 32])
 	mon.hp = _read_u16_be(raw, start + 34)
+	return mon
+
+
+## `NICKNAMED_MON_STRUCT_LENGTH`: the same 48 bytes with the nickname behind
+## them. That is how a ROM table stores a whole Pokemon no save file ever wrote,
+## which is `BattleTowerMons`' rows and `OddEggs`' fourteen.
+static func read_nicknamed_mon(raw: PackedByteArray, start: int) -> Gen2SaveMon:
+	if start < 0 or start + NICKNAMED_MON_SIZE > raw.size():
+		return null
+	var mon: Gen2SaveMon = read_party_mon(raw, start)
+	if mon == null:
+		return null
+	mon.nickname = Gen2Text.decode_fixed(raw, start + PARTYMON_SIZE, MON_NAME_LENGTH)
 	return mon
 
 

--- a/game/world/battle_tower.gd
+++ b/game/world/battle_tower.gd
@@ -357,21 +357,11 @@ func _first_free_mon(data: GameData, group: int, team: Array) -> Gen2SaveMon:
 	return null
 
 
-## One `BattleTowerMons` row. The bytes are a party-mon struct with its nickname
-## behind it, which is the same struct a save file's party is written in, so
-## [Gen2SramAdapter] reads it rather than a second parser.
+## One `BattleTowerMons` row, which is the nicknamed-mon struct
+## [method Gen2SramAdapter.read_nicknamed_mon] reads wherever a ROM table stores
+## a whole Pokemon.
 static func _read_mon(data: GameData, group: int, index: int) -> Gen2SaveMon:
-	var bytes: PackedByteArray = data.battle_tower_mon(group, index)
-	if bytes.size() < RomLayout.BATTLETOWER_MON_BYTES:
-		return null
-	var mon: Gen2SaveMon = Gen2SramAdapter.read_party_mon(bytes, 0)
-	if mon == null:
-		return null
-	mon.nickname = Gen2Text.decode_fixed(
-		bytes, RomLayout.BATTLETOWER_MON_BYTES - Gen2SramAdapter.MON_NAME_LENGTH,
-		Gen2SramAdapter.MON_NAME_LENGTH
-	)
-	return mon
+	return Gen2SramAdapter.read_nicknamed_mon(data.battle_tower_mon(group, index), 0)
 
 
 ## `BattleTowerText`: a male class draws from 25 lines and a female from 15, and

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -233,11 +233,14 @@ static func complete_runtime_request(
 	_register_unown(world, int(transaction.get("register_unown", 0)))
 	var completion_result: Dictionary = {
 		"ok": true,
-		"script_value": int(transaction.get("script_value", 0)),
 		"accepted": bool(transaction.get("accepted", false)),
 		"reason": transaction.get("reason", &""),
 		"transaction": transaction.get("summary", {}).duplicate(true),
 	}
+	## Only a routine with an `ld [wScriptVar], a` in it answers one, which is
+	## what [Gen2WorldScriptRunner] leaves the value alone for.
+	if transaction.has("script_value"):
+		completion_result["script_value"] = int(transaction["script_value"])
 	var resumed: Array = world.complete_runtime_request(completion_result)
 	if resumed.is_empty() or not bool(resumed[0].get("ok", false)):
 		return _failure(&"runtime_request_failed", {
@@ -1312,6 +1315,9 @@ static func _apply_party_request(
 	if kind == &"pokemon_requested" \
 		and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) == &"give_shuckle":
 		return _apply_give_shuckle(world, candidate, request, random)
+	if kind == &"pokemon_requested" \
+		and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) == &"give_odd_egg":
+		return _apply_give_odd_egg(world, candidate, request, random)
 	if kind == &"dratini_moveset_requested":
 		return _apply_dratini_moveset(world, candidate, request)
 	if kind == &"pokemon_requested":
@@ -1479,7 +1485,9 @@ static func _append_mon(
 		}
 	return {
 		"ok": true, "accepted": true, "script_value": script_value,
-		"register_caught": 0 if StringName(summary.get("kind", &"")) == &"egg" else mon.species,
+		## `AddPartyMon` registers what it added, and an egg registers nothing:
+		## `SetSeenAndCaughtMon` sits behind the species byte, which is EGG.
+		"register_caught": 0 if mon.is_egg else mon.species,
 		"register_unown": 0 if mon.is_egg else _unown_form(mon.species, mon.dvs, destination),
 		"summary": summary.merged({
 			"accepted": true, "destination": destination.duplicate(true),
@@ -2423,6 +2431,66 @@ static func _apply_give_shuckle(
 			"ok": true, "accepted": false, "script_value": 0, "reason": &"party_full",
 			"summary": {"kind": &"shuckie", "accepted": false, "species": SHUCKLE},
 		}
+	return appended
+
+
+## `_GiveOddEgg`. `.loop` walks `OddEggProbabilities` comparing the random word
+## against each cumulative entry high byte first, and takes the row the word is
+## no greater than; the table closes on $ffff, so a word always lands. The last
+## entry is only reached by a word equal to $ffff, which is what `.done`'s own
+## break on $ffff leaves.
+static func odd_egg_row(rolled: int, probabilities: Array) -> int:
+	for index: int in probabilities.size():
+		if rolled <= int(probabilities[index]):
+			return index
+	return maxi(0, probabilities.size() - 1)
+
+
+## The Day-Care Man's Odd Egg. `AddMobileMonToParty` appends the row as it
+## stands, with `wTempOddEggNickname` as the OT and the row's own `dname` as the
+## nickname, so nothing about it is rolled except which of the fourteen it is.
+##
+## The party-full refusal is the script's own `readvar VAR_PARTYCOUNT` ahead of
+## the special, so the routine is never entered with a full party and appending
+## cannot fail; it is answered here as well because a mod can call the special
+## directly.
+static func _apply_give_odd_egg(
+	world: Gen2WorldAPI,
+	candidate: Gen2SaveData,
+	_request: Dictionary,
+	random: RandomNumberGenerator
+) -> Dictionary:
+	var rows: Array = world.data.odd_eggs() if world.data != null else []
+	if rows.is_empty():
+		return {"ok": false, "reason": &"no_odd_eggs"}
+	var probabilities: Array = []
+	for row: Variant in rows:
+		probabilities.append(int((row as Dictionary).get("probability", 0)))
+	## `call Random` fills hRandomAdd and hRandomSub, and `.loop` reads the pair
+	## as one big-endian word: hRandomSub is the high byte.
+	var index: int = odd_egg_row(
+		(_random_byte(random) << 8) | _random_byte(random), probabilities
+	)
+	var mon: Gen2SaveMon = world.data.odd_egg_mon(index)
+	if mon == null:
+		return {"ok": false, "reason": &"could_not_create_pokemon"}
+	## The struct names PICHU or another baby; what makes the party slot an egg
+	## is `wMobileMonMiscSpecies`, which `_GiveOddEgg` sets to EGG and
+	## `AddMobileMonToParty` writes into `wPartySpecies` beside the struct.
+	mon.is_egg = true
+	mon.original_trainer = RomLayout.ODD_EGG_OT_NAME
+	if candidate.party.size() >= Gen2SaveData.MAX_PARTY:
+		return {
+			"ok": true, "accepted": false, "reason": &"party_full",
+			"summary": {"kind": &"odd_egg", "accepted": false, "species": mon.species},
+		}
+	var appended: Dictionary = _append_mon(candidate, mon, 0, {
+		"kind": &"odd_egg", "species": mon.species, "level": mon.level,
+		"row": index, "item": mon.item,
+	})
+	## The routine has no `ld [wScriptVar], a`, so the script keeps the value the
+	## `readvar VAR_PARTYCOUNT` in front of it left.
+	appended.erase("script_value")
 	return appended
 
 

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -49,11 +49,6 @@ const PLAYERSPC_HOUSE: int = 1
 ## keeps the cartridge's marker rather than a placeholder.
 const PLAYER_MARKER: String = "<PLAYER>"
 
-## The rows above with nothing behind them, dropped from every list rather than
-## offered and refused. See the class comment for what each needs first.
-const UNBUILT_TOP_MENU_ROWS: Array[int] = []
-const UNBUILT_PLAYERS_PC_ROWS: Array[int] = []
-
 
 ## `_BillsPC.MenuData`'s five rows, in its `.Jumptable`'s own order. Inline menu
 ## strings inside `bills_pc_top.asm` that no script points at, so nothing imports
@@ -91,18 +86,12 @@ const MAILBOX_ALREADY_HOLDING: String = "It's already hold-\ning an item."
 const MAILBOX_EGG: String = "An EGG can't hold\nany MAIL."
 const MAILBOX_MOVED: String = "The MAIL was moved\nfrom the MAILBOX."
 
-## Every row of the machine's own menu is built: MOVE PKMN W/O MAIL is
-## [Gen2BoxScreen]'s `MODE_MOVE`, which is `_MovePKMNWithoutMail`'s own two
-## joypad passes over the same listing.
-const UNBUILT_BILLS_PC_ROWS: Array[int] = []
-
-
 ## The top menu behind BILL'S PC, as `{row, name}` in the source's own order.
+## Every row of it is built: MOVE PKMN W/O MAIL is [Gen2BoxScreen]'s `MODE_MOVE`,
+## which is `_MovePKMNWithoutMail`'s own two joypad passes over the same listing.
 static func bills_pc_menu() -> Array:
 	var out: Array = []
 	for row: int in BILLS_PC_ROWS.size():
-		if row in UNBUILT_BILLS_PC_ROWS:
-			continue
 		out.append({"row": row, "name": BILLS_PC_ROWS[row]})
 	return out
 
@@ -121,18 +110,14 @@ static func top_menu_list(state: Gen2WorldState) -> int:
 static func top_menu(
 	data: GameData, state: Gen2WorldState, player_name: String = ""
 ) -> Array:
-	return _rows(
-		data, false, _list(data, false, top_menu_list(state)),
-		UNBUILT_TOP_MENU_ROWS, player_name
-	)
+	return _rows(data, false, _list(data, false, top_menu_list(state)), player_name)
 
 
 ## The item PC's own rows. [param house] picks `PLAYERSPC_HOUSE`, which is what
 ## `_PlayersHousePC` passes and the Pokemon Center's `PlayersPC` does not.
 static func players_pc_menu(data: GameData, house: bool) -> Array:
 	return _rows(
-		data, true, _list(data, true, PLAYERSPC_HOUSE if house else PLAYERSPC_NORMAL),
-		UNBUILT_PLAYERS_PC_ROWS, ""
+		data, true, _list(data, true, PLAYERSPC_HOUSE if house else PLAYERSPC_NORMAL), ""
 	)
 
 
@@ -150,15 +135,14 @@ static func _list(data: GameData, players: bool, index: int) -> Array:
 ## `PlaceNthMenuStrings`: each list entry names a jumptable row, and the row
 ## names its own string.
 static func _rows(
-	data: GameData, players: bool, list: Array, unbuilt: Array[int],
-	player_name: String
+	data: GameData, players: bool, list: Array, player_name: String
 ) -> Array:
 	var order: Array[String] = RomLayout.POKECENTER_PC_PLAYERS_ORDER if players \
 		else RomLayout.POKECENTER_PC_ROWS
 	var out: Array = []
 	for raw_row: Variant in list:
 		var row: int = int(raw_row)
-		if row < 0 or row >= order.size() or row in unbuilt:
+		if row < 0 or row >= order.size():
 			continue
 		var name: String = data.pokecenter_pc_row(String(order[row]), players)
 		if name.is_empty():

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -580,6 +580,27 @@ const SPECIAL_TRAINER_HOUSE: int = 103
 const SPECIAL_PHOTO_STUDIO: int = 104
 const SPECIAL_DIPLOMA: int = 107
 const SPECIAL_PRINT_DIPLOMA: int = 108
+## `_GiveOddEgg`. The special itself sits in the mobile bank, but nothing in it
+## is mobile: `DayCareManScript_Inside` calls it and the routine reads a ROM
+## table and appends a party member.
+const SPECIAL_GIVE_ODD_EGG: int = 125
+## `AskRememberPassword`. In the mobile bank beside `GiveOddEgg` and no more
+## mobile than it is: `Buena` in RadioTower2F calls it to ask whether the player
+## remembers today's password, and the routine is a yes/no box in a corner.
+const SPECIAL_ASK_REMEMBER_PASSWORD: int = 163
+## `.DoMenu`'s `lb bc, 14, 7` with `YesNoMenuHeader`'s own width and height
+## added, which puts the box in the bottom-right rather than the standard
+## `menu_coords 10, 5, 15, 9`.
+const ASK_REMEMBER_PASSWORD_BOX: Dictionary = {
+	"default": 1, "left": 14, "top": 7, "right": 19, "bottom": 11,
+}
+## `ld c, 15 / call DelayFrames` and `Buena_ExitMenu`'s own `DelayFrame`, spent
+## after the answer and before the script reads it.
+const ASK_REMEMBER_PASSWORD_CLOSE_FRAMES: int = 16
+## `EGG_TICKET`, which `_GiveOddEgg` tosses one of on its way past. The
+## international cartridges ship no way to hold one, so the toss is a no-op
+## every time a player reaches it.
+const ITEM_EGG_TICKET: int = 81
 const SPECIAL_OMANYTE_CHAMBER: int = 132
 const SPECIAL_HO_OH_CHAMBER: int = 141
 const SPECIAL_CELEBI_SHRINE_EVENT: int = 143
@@ -1023,6 +1044,11 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 					"move": asked_move, "slot": asked_slot,
 				})
 			return _complete()
+		if pending_type == &"choice" and _pending_tag() == &"ask_remember_password":
+			_pending = {}
+			_script_value = 1 if choice == 0 else 0
+			_stage_frame_wait(ASK_REMEMBER_PASSWORD_CLOSE_FRAMES)
+			return _waiting_result()
 		## AskRockSmashScript, the same opentext/writetext/yesorno shape.
 		if pending_type == &"text" and _pending_tag() == &"rock_smash_ask":
 			_pending = {
@@ -1622,6 +1648,7 @@ func complete_wait() -> Dictionary:
 ## answer `cancel_input` writes.
 const CANCEL_OWNED_PENDINGS: Array[StringName] = [
 	&"buena_prize", &"buena_prize_confirm", &"bank_of_mom_menu", &"bank_of_mom_choice",
+	&"ask_remember_password",
 	&"strength_ask", &"field_move_ask", &"rock_smash_ask",
 	&"set_day_of_week_confirmation",
 ]
@@ -3942,6 +3969,35 @@ func _execute_special(special: int) -> Dictionary:
 				"nickname": Gen2WorldPartyHost.SHUCKIE_NICKNAME,
 				"original_trainer": Gen2WorldPartyHost.MANIA_OT_NAME,
 				"ot_id": Gen2WorldPartyHost.MANIA_OT_ID,
+				"party_only": true,
+			})
+		SPECIAL_ASK_REMEMBER_PASSWORD:
+			## The box alone: the question is the `writetext` in front of it, and
+			## the answer is `yesorno`'s own, YES writing 1 and B writing 0.
+			_pending = {
+				"type": &"choice",
+				"command": &"yesorno",
+				"choices": [&"yes", &"no"],
+				"text": _standing_text,
+				"special": &"ask_remember_password",
+				"header": ASK_REMEMBER_PASSWORD_BOX.duplicate(),
+				"source": _request.duplicate(true),
+			}
+			return _waiting_result()
+		SPECIAL_GIVE_ODD_EGG:
+			## `AddMobileMonToParty` with one of `OddEggs`' fourteen rows, rolled
+			## against `OddEggProbabilities`. `TossKeyItem` runs first and
+			## removes nothing when the pack holds no ticket; it writes no
+			## wScriptVar either way, so the toss's own answer is put back.
+			if _item_quantity(ITEM_EGG_TICKET) > 0:
+				var kept: int = _script_value
+				var tossed: Dictionary = _stage_item_delta(ITEM_EGG_TICKET, -1)
+				_script_value = kept
+				if not bool(tossed.get("ok", true)):
+					return tossed
+			return _stage_runtime_request(&"pokemon_requested", {
+				"special": special,
+				"kind": &"give_odd_egg",
 				"party_only": true,
 			})
 		SPECIAL_GIVE_DRATINI:

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -117,6 +117,7 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	_write_pokecenter_pc(manifest)
 	_write_decorations(manifest)
 	_write_unown_words(manifest)
+	_write_odd_eggs(manifest, crystal_commands)
 	_write_unown_puzzle(cache_directory, manifest)
 	_write_slots(cache_directory, manifest)
 	_write_card_flip(cache_directory, manifest)
@@ -128,6 +129,37 @@ static func build(game_id: StringName = GAME_ID) -> GameData:
 	manifest["complete"] = true
 	RomCache.write_json(RomCache.manifest_path(cache_directory), manifest)
 	return GameData.open_directory(cache_directory)
+
+
+## Two `OddEggs` rows with the real table's shape: a cumulative probability
+## word, the 48-byte party-mon struct and the `dname` EGG behind it. Gold and
+## Silver ship none, which is what the empty list stands for.
+static func _write_odd_eggs(manifest: Dictionary, crystal: bool) -> void:
+	if not crystal:
+		manifest["odd_eggs"] = []
+		return
+	var rows: Array = []
+	var probabilities: Array[int] = [0x7FFF, RomLayout.ODD_EGG_PROBABILITY_TOTAL]
+	var species: Array[int] = [25, 133]
+	for index: int in probabilities.size():
+		var bytes: PackedByteArray = PackedByteArray()
+		bytes.resize(RomLayout.NICKNAMED_MON_BYTES)
+		bytes.fill(0)
+		bytes[0] = species[index]
+		bytes[31] = RomLayout.ODD_EGG_LEVEL
+		## The struct carries its own experience, and a row whose level and
+		## experience disagree is what `Gen2WorldTransaction` refuses.
+		var exp: int = RomLayout.ODD_EGG_LEVEL ** 3
+		bytes[8] = (exp >> 16) & 0xFF
+		bytes[9] = (exp >> 8) & 0xFF
+		bytes[10] = exp & 0xFF
+		## `dname` pads the whole name field with the terminator behind the word.
+		var nickname: PackedByteArray = Gen2Text.encode(RomLayout.ODD_EGG_NICKNAME)
+		for step: int in Gen2SramAdapter.MON_NAME_LENGTH:
+			bytes[Gen2SramAdapter.PARTYMON_SIZE + step] = nickname[step] \
+				if step < nickname.size() else Gen2Text.TERMINATOR
+		rows.append({"probability": probabilities[index], "bytes": Array(bytes)})
+	manifest["odd_eggs"] = rows
 
 
 ## The four naming keyboards with the real block's shape and command rows, the

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -8596,6 +8596,58 @@ func test_the_unown_printer_carries_the_dex_count_it_refuses_on() -> void:
 		assert_eq(world.complete_runtime_request({"ok": true})[0]["status"], &"complete")
 
 
+## `AskRememberPassword` is Buena's own yes/no box, not a mobile routine: the
+## question is the `writetext` in front of it, YES writes 1 into wScriptVar and
+## both NO and B write 0, and the box stands where `.DoMenu` puts it.
+func test_buenas_password_box_answers_yes_no_where_the_routine_puts_it() -> void:
+	for answer: int in [0, 1, -1]:
+		_write_special_script([
+			Gen2WorldScript.SPECIAL,
+			Gen2WorldScriptRunner.SPECIAL_ASK_REMEMBER_PASSWORD, 0,
+			Gen2WorldScript.WRITEMEM, 0xA0, 0xD1,
+			Gen2WorldScript.END,
+		])
+		var state := Gen2WorldState.new()
+		var world: Gen2WorldAPI = _special_world(state)
+		world.dispatch_script_events()
+		var pending: Dictionary = world.pending_script_input()
+		assert_eq(StringName(pending.get("type", &"")), &"choice")
+		var menu: Gen2WorldMenu = Gen2WorldMenu.from_input(pending)
+		assert_eq(menu.box_left, 14)
+		assert_eq(menu.box_top, 7)
+		assert_eq(menu.box_right, 19)
+		assert_eq(menu.box_bottom, 11)
+		var answered: Array = world.cancel_script_input() if answer < 0 \
+			else world.choose_script_input(answer)
+		assert_eq(
+			_final_status(_run_script(world, answered)), &"complete",
+			"the box closes and the script carries on"
+		)
+		assert_eq(
+			state.script_memory(0xD1A0), 1 if answer == 0 else 0,
+			"YES is the only answer that writes 1"
+		)
+
+
+## `ld c, 15 / call DelayFrames` and `Buena_ExitMenu`'s own `DelayFrame` are
+## spent between the answer and the branch the script takes on it.
+func test_buenas_password_box_spends_its_own_close_frames() -> void:
+	_write_special_script([
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_ASK_REMEMBER_PASSWORD, 0,
+		Gen2WorldScript.END,
+	])
+	var world: Gen2WorldAPI = _special_world()
+	world.dispatch_script_events()
+	world.choose_script_input(0)
+	var wait: Dictionary = world.pending_script_wait()
+	assert_eq(StringName(wait.get("wait", &"")), Gen2WorldScriptRunner.WAIT_FRAMES)
+	assert_eq(
+		int(wait.get("frames", 0)),
+		Gen2WorldScriptRunner.ASK_REMEMBER_PASSWORD_CLOSE_FRAMES
+	)
+
+
 ## One script at a fixed address, reached by the map's own coordinate event, so
 ## every special test above drives the same path a real script does.
 func _write_special_script(bytes: Array, extra: Dictionary = {}) -> void:

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -170,6 +170,60 @@ func test_a_gift_takes_the_nickname_the_prompt_answered() -> void:
 	assert_eq(_save.party[2].nickname, "SPARKY")
 
 
+## `_GiveOddEgg` and `AddMobileMonToParty`: the row it rolls is appended as it
+## stands, an egg under `.Odd`'s own OT, and the script carries on.
+func test_the_odd_egg_is_appended_as_the_row_it_rolled() -> void:
+	_set_script(0x6240)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	assert_eq(_world.pending_runtime_request()["kind"], &"pokemon_requested")
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(result["results"][0]["status"], &"complete")
+	assert_eq(_save.party.size(), 3)
+	var egg: Gen2SaveMon = _save.party[2]
+	assert_true(egg.is_egg)
+	assert_eq(egg.level, RomLayout.ODD_EGG_LEVEL)
+	assert_eq(egg.nickname, RomLayout.ODD_EGG_NICKNAME)
+	assert_eq(egg.original_trainer, RomLayout.ODD_EGG_OT_NAME)
+	assert_eq(result["transaction"]["kind"], &"odd_egg")
+
+
+## An egg registers nothing in the Pokedex: `AddPartyMon` reads the species byte,
+## which `AddMobileMonToParty` wrote EGG into.
+func test_the_odd_egg_registers_no_species_as_caught() -> void:
+	_set_script(0x6240)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	Gen2WorldHost.complete_runtime_request(_world, {}, _save, false, _random)
+	assert_false(_world.state.has_caught_species(_save.party[2].species))
+
+
+## `.loop` takes the first cumulative word the roll is no greater than, so the
+## edges of a band belong to it and the word above it belongs to the next.
+func test_the_odd_egg_roll_takes_the_first_word_it_does_not_exceed() -> void:
+	var probabilities: Array = [0x1000, 0x2000, 0xFFFF]
+	assert_eq(Gen2WorldPartyHost.odd_egg_row(0, probabilities), 0)
+	assert_eq(Gen2WorldPartyHost.odd_egg_row(0x1000, probabilities), 0)
+	assert_eq(Gen2WorldPartyHost.odd_egg_row(0x1001, probabilities), 1)
+	assert_eq(Gen2WorldPartyHost.odd_egg_row(0x2000, probabilities), 1)
+	assert_eq(Gen2WorldPartyHost.odd_egg_row(0xFFFF, probabilities), 2)
+
+
+## The script's own `readvar VAR_PARTYCOUNT` refuses ahead of the special, so a
+## full party is only reachable by calling it directly, and it gives nothing.
+func test_a_full_party_is_given_no_odd_egg() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	_set_script(0x6240)
+	_world.dispatch_script_events(Vector2i(2, 2))
+	var result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {}, _save, false, _random
+	)
+	assert_true(result["ok"])
+	assert_eq(_save.party.size(), Gen2SaveData.MAX_PARTY)
+
+
 ## `CheckPartyFullAfterContest` is not a question: it copies `wContestMon` into
 ## the party, names it, writes LANDMARK_NATIONAL_PARK over the caught location
 ## and clears the stash. BUGCONTEST_CAUGHT_MON is the answer with a party slot.
@@ -1171,6 +1225,10 @@ func _add_party_scripts() -> void:
 	## `BugContestResults_DidNotLeaveMons`' own first command.
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6230)] = [
 		Gen2WorldScript.SPECIAL, 21, 0, 0x91,
+	]
+	## `special GiveOddEgg`, `DayCareManScript_Inside`'s own.
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6240)] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_GIVE_ODD_EGG, 0, 0x91,
 	]
 	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
 

--- a/tools/checks/day_care.gd
+++ b/tools/checks/day_care.gd
@@ -44,7 +44,58 @@ func run(r: RefCounted) -> void:
 		_verify_compatibility(game_id, data)
 		_verify_egg_moves(game_id, data)
 		_verify_fill_moves(game_id, data)
+		_verify_odd_eggs(game_id, data)
 	_r.game_id = &""
+
+
+## The Day-Care Man's own gift, Crystal's alone. Every row decodes as the
+## nicknamed-mon struct it is, the probabilities rise to $ffff, and every share
+## of the roll lands on a row: rolling each entry's own word and the one below
+## it walks both edges of `.loop`'s comparison rather than sampling the middle.
+func _verify_odd_eggs(game_id: StringName, data: GameData) -> void:
+	var rows: Array = data.odd_eggs()
+	if game_id != &"crystal":
+		_r.check(rows.is_empty(), "%s: ships %d Odd Eggs." % [game_id, rows.size()])
+		return
+	if not _r.check(
+		rows.size() == RomLayout.ODD_EGG_COUNT,
+		"%s: %d Odd Eggs, not %d." % [game_id, rows.size(), RomLayout.ODD_EGG_COUNT]
+	):
+		return
+	var probabilities: Array = []
+	for row: Variant in rows:
+		probabilities.append(int((row as Dictionary).get("probability", 0)))
+	for index: int in rows.size():
+		var mon: Gen2SaveMon = data.odd_egg_mon(index)
+		if not _r.check(mon != null, "%s: Odd Egg %d does not decode." % [game_id, index]):
+			continue
+		_r.check(
+			not data.species(mon.species).is_empty(),
+			"%s: Odd Egg %d names species %d." % [game_id, index, mon.species]
+		)
+		_r.check(
+			mon.level == RomLayout.ODD_EGG_LEVEL,
+			"%s: Odd Egg %d is level %d." % [game_id, index, mon.level]
+		)
+		_r.check(
+			mon.nickname == RomLayout.ODD_EGG_NICKNAME,
+			"%s: Odd Egg %d is nicknamed \"%s\"." % [game_id, index, mon.nickname]
+		)
+		_r.check(
+			Gen2WorldPartyHost.odd_egg_row(probabilities[index], probabilities) == index,
+			"%s: the word %d does not land on Odd Egg %d." % [
+				game_id, probabilities[index], index,
+			]
+		)
+		var below: int = probabilities[index - 1] + 1 if index > 0 else 0
+		_r.check(
+			Gen2WorldPartyHost.odd_egg_row(below, probabilities) == index,
+			"%s: the word %d does not land on Odd Egg %d." % [game_id, below, index]
+		)
+	_r.check(
+		probabilities[-1] == RomLayout.ODD_EGG_PROBABILITY_TOTAL,
+		"%s: the Odd Egg probabilities close on %d." % [game_id, probabilities[-1]]
+	)
 
 
 ## Every stub of the four runs decodes, and one per run carries the words that

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -27,13 +27,15 @@ const EXPECTED_DEFERRED: Dictionary = {
 	## to a modern platform. The cable club's own sixteen rows have left this
 	## list with the Battle Tower's seven, `DisplayLinkRecord`, which sat in the
 	## link block without being link play, and Mystery Gift's three.
-	125: "GiveOddEgg",
+	##
+	## The bank a routine sits in decides nothing: `GiveOddEgg` and
+	## `AskRememberPassword` sat here for being mobile neighbours, and both are
+	## reached by an ordinary NPC. Read the call sites before adding a row.
 	127: "Function1011f1", 128: "Function101220", 129: "Function101225",
 	130: "Function101231", 139: "BattleTowerMobileError",
 	140: "AskMobileOrCable", 154: "Mobile_SelectThreeMons",
 	155: "Function1037eb", 156: "Function10383c", 159: "Function1037c2",
-	161: "Function103780",
-	162: "Function10387b", 163: "AskRememberPassword",
+	161: "Function103780", 162: "Function10387b",
 
 	## Screens and facilities with no routine here yet. Each is its own piece of
 	## work, not a dispatch entry: it opens a screen, spends a transaction, or


### PR DESCRIPTION
Two `special` indices sat in `EXPECTED_DEFERRED` under "the Mobile Adapter GB"
because their routines live in the mobile banks. Neither is mobile, and each
stopped a script the player can reach.

- `GiveOddEgg` is `DayCareManScript_Inside`'s first command, guarded only by
  `EVENT_GOT_ODD_EGG`.
- `AskRememberPassword` is the yes/no box `Buena` opens in RadioTower2F once the
  Blue Card is in the pack.

`OddEggProbabilities` and `OddEggs` are imported rather than transcribed. A row
is the nicknamed-mon struct `BattleTowerMons` already uses, so
`Gen2SramAdapter.read_nicknamed_mon` reads both tables and the Battle Tower's
own copy of that decode is gone. Cache format 91; all three cartridges
re-imported and each reports `layout: Layout verified.`

`_apply_party_request` no longer answers wScriptVar for a routine that writes
none, which is what the script runner already documented.

Also removed: three empty `UNBUILT_*` lists in `Gen2WorldPC` and the row
filtering behind them, which could no longer drop anything.

| Check | Before | After |
|---|---|---|
| `validate.gd -- all` | 76 topics pass | 76 topics pass |
| Crystal specials reached but unbuilt | 14 | 12 |
| GUT, whole tier | 3804 pass | 3806 pass |
| Story walk, three profiles | reaches Red | reaches Red |
| `replay_world.gd` | 33 routes, 0 failures | 33 routes, 0 failures |