### PR TITLE
Close the last item effects, Mom's purchases and the far-text collection gap

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1880,6 +1880,15 @@ func decoration_count() -> int:
 	return (rows as Array).size() if rows is Array else 0
 
 
+## `DecorationIDs`: the decoration a `DECOFLAG_*` index names, or 0 for an index
+## outside the run. Zero is the CANCEL row, which owns nothing.
+func decoration_id_for_flag(index: int) -> int:
+	var ids: Variant = _decorations.get("ids", [])
+	if not ids is Array or index < 0 or index >= (ids as Array).size():
+		return 0
+	return int((ids as Array)[index])
+
+
 ## One `DecorationNames` part by its own index, which is what a row's `name`
 ## field carries for every type but the poster, doll and big doll: those name a
 ## species instead.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -73,6 +73,7 @@ var _town_map: Dictionary = {}
 var _oak_ratings: Dictionary = {}
 var _pokecenter_pc: Dictionary = {}
 var _decorations: Dictionary = {}
+var _mom_phone: Dictionary = {}
 var _unown_words: PackedStringArray = PackedStringArray()
 var _unown_walls: PackedStringArray = PackedStringArray()
 var _odd_eggs: Array = []
@@ -212,6 +213,8 @@ static func open_directory(path: String) -> GameData:
 	data._pokecenter_pc = pokecenter_pc if pokecenter_pc is Dictionary else {}
 	var decorations: Variant = manifest.get("decorations", {})
 	data._decorations = decorations if decorations is Dictionary else {}
+	var mom_phone: Variant = manifest.get("mom_phone", {})
+	data._mom_phone = mom_phone if mom_phone is Dictionary else {}
 	var unown_words: Variant = manifest.get("unown_words", [])
 	if unown_words is Array:
 		for word: Variant in unown_words as Array:
@@ -1878,6 +1881,29 @@ func decoration(deco: int) -> Dictionary:
 func decoration_count() -> int:
 	var rows: Variant = _decorations.get("attributes", [])
 	return (rows as Array).size() if rows is Array else 0
+
+
+## One `momitem` row as `{ trigger, cost, kind, item }`. [param set_number] is
+## `wWhichMomItemSet`: 0 is `MomItems_2`, the ladder, and anything else is
+## `MomItems_1`, the five she picks between. Empty for a row outside its list.
+func mom_item(set_number: int, index: int) -> Dictionary:
+	var rows: Variant = _mom_phone.get("items_2" if set_number == 0 else "items_1", [])
+	if not rows is Array or index < 0 or index >= (rows as Array).size():
+		return {}
+	var row: Variant = (rows as Array)[index]
+	return (row as Dictionary).duplicate() if row is Dictionary else {}
+
+
+func mom_item_count(set_number: int) -> int:
+	var rows: Variant = _mom_phone.get("items_2" if set_number == 0 else "items_1", [])
+	return (rows as Array).size() if rows is Array else 0
+
+
+## `Mom_GetScriptPointer`'s two answers, as the `{ bank, address }` every phone
+## script carries. [param doll] picks `.DollScript` over `.ItemScript`.
+func mom_phone_script(doll: bool) -> Dictionary:
+	var script: Variant = _mom_phone.get("doll_script" if doll else "item_script", {})
+	return (script as Dictionary).duplicate() if script is Dictionary else {}
 
 
 ## `DecorationIDs`: the decoration a `DECOFLAG_*` index names, or 0 for an index

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 91
+const FORMAT_VERSION: int = 92
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 92
+const FORMAT_VERSION: int = 93
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -353,6 +353,9 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 	var decorations: Dictionary = verify_decorations(rom, layout)
 	if not decorations["ok"]:
 		return decorations
+	var mom_phone: Dictionary = verify_mom_phone(rom, layout)
+	if not mom_phone["ok"]:
+		return mom_phone
 
 	var unown_words: Dictionary = verify_unown_words(rom, layout)
 	if not unown_words["ok"]:
@@ -1213,6 +1216,36 @@ static func verify_decorations(rom: RomFile, layout: Dictionary) -> Dictionary:
 				"message": "Decoration id %d is not a set-up row." % deco,
 			}
 	return {"ok": true, "message": "Decorations verified."}
+
+
+## `MomTriesToBuySomething`'s block, identified by content at both ends: the two
+## scripts have to be four `writetext`s and an `end`, and the ladder behind them
+## has to climb, since `CheckBalance_MomItem2` walks `MomItems_2` in order and a
+## row out of order would make her skip one forever.
+static func verify_mom_phone(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var block: Dictionary = read_mom_phone(rom, layout)
+	if block.is_empty():
+		return {"ok": false, "message": "Mom's phone block is outside the cartridge."}
+	var at: int = int(layout["mom_phone"])
+	for offset: int in [0, RomLayout.MOM_DOLL_SCRIPT_AT]:
+		for command: int in 4:
+			if rom.u8(at + offset + command * 3) != Gen2WorldScript.WRITETEXT:
+				return {
+					"ok": false,
+					"message": "Mom's script at +%d is not four writetexts." % offset,
+				}
+	var last: int = -1
+	for row: Dictionary in block["items_2"] as Array:
+		var trigger: int = int(row["trigger"])
+		if trigger <= last:
+			return {"ok": false, "message": "Mom's ladder does not climb."}
+		last = trigger
+	for key: String in ["items_1", "items_2"]:
+		for row: Dictionary in block[key] as Array:
+			var kind: int = int(row["kind"])
+			if kind < Gen2WorldMomPhone.KIND_ITEM or kind > Gen2WorldMomPhone.KIND_DOLL:
+				return {"ok": false, "message": "A momitem row carries kind %d." % kind}
+	return {"ok": true, "message": "Mom's phone block verified."}
 
 
 ## `engine/items/mart.asm`'s own `text_far` stubs, identified by content: all
@@ -4818,6 +4851,7 @@ func import_rom(
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
 		"decorations": _import_decorations(rom, layout),
+		"mom_phone": read_mom_phone(rom, layout),
 		"unown_puzzle": _import_unown_puzzle(rom, layout),
 		"diploma": _import_diploma(rom, layout),
 		"mystery_gift": _import_mystery_gift(rom, layout),
@@ -6154,6 +6188,44 @@ static func read_decoration_names(rom: RomFile, layout: Dictionary) -> PackedStr
 		rom.bytes(), at, RomLayout.DECORATION_NAME_COUNT,
 		RomLayout.DECORATION_NAME_MAX_BYTES
 	)
+
+
+## A dump offset as the `{ bank, address }` pair every other script pointer here
+## carries, so a script pinned by content reads the same as one read out of a
+## table. `RomFile.linear` is the inverse.
+static func _banked_pointer(offset: int) -> Dictionary:
+	var bank: int = offset / RomFile.BANK_SIZE
+	var address: int = offset % RomFile.BANK_SIZE
+	return {"bank": bank, "address": address if bank == 0 else address + RomFile.BANK_SIZE}
+
+
+## `MomItems_1` and `MomItems_2`, and the two scripts `Mom_GetScriptPointer`
+## answers with. A row is `momitem`: a three-byte big-endian trigger, a
+## three-byte cost, `MOMITEM_KIND` and either an item number or a `DECO_*` id.
+static func read_mom_phone(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("mom_phone", -1))
+	if at < 0:
+		return {}
+	var size: int = RomLayout.MOM_ITEM_SIZE
+	var rows: int = RomLayout.MOM_ITEMS_1_COUNT + RomLayout.MOM_ITEMS_2_COUNT
+	var table: int = at + RomLayout.MOM_ITEMS_AT
+	if not rom.in_bounds(table, rows * size):
+		return {}
+	var lists: Array = [[], []]
+	for index: int in rows:
+		var row: int = table + index * size
+		(lists[0 if index < RomLayout.MOM_ITEMS_1_COUNT else 1] as Array).append({
+			"trigger": (rom.u8(row) << 16) | (rom.u8(row + 1) << 8) | rom.u8(row + 2),
+			"cost": (rom.u8(row + 3) << 16) | (rom.u8(row + 4) << 8) | rom.u8(row + 5),
+			"kind": rom.u8(row + 6),
+			"item": rom.u8(row + 7),
+		})
+	return {
+		"items_1": lists[0],
+		"items_2": lists[1],
+		"item_script": _banked_pointer(at),
+		"doll_script": _banked_pointer(at + RomLayout.MOM_DOLL_SCRIPT_AT),
+	}
 
 
 func _import_decorations(rom: RomFile, layout: Dictionary) -> Dictionary:

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -1195,6 +1195,23 @@ static func verify_decorations(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"ok": false,
 			"message": "The decoration names open \"%s\", not CANCEL." % names[0],
 		}
+	## Every `DECOFLAG_*` has to name a set-up row of the table above it: a
+	## header or the CANCEL row would make `SetSpecificDecorationFlag` own a
+	## category instead of a decoration, and that is what a wrong offset gives.
+	var ids: Array = read_decoration_ids(rom, layout)
+	if ids.size() != RomLayout.DECORATION_ID_COUNT:
+		return {"ok": false, "message": "The decoration ids are outside the cartridge."}
+	for deco: int in ids:
+		if deco < 0 or deco >= rows.size():
+			return {"ok": false, "message": "A decoration id names row %d." % deco}
+		var pair: Variant = Gen2WorldDecoration.ACTIONS.get(
+			int((rows[deco] as Dictionary).get("action", 0)), null
+		)
+		if not (pair is Array and bool((pair as Array)[1])):
+			return {
+				"ok": false,
+				"message": "Decoration id %d is not a set-up row." % deco,
+			}
 	return {"ok": true, "message": "Decorations verified."}
 
 
@@ -2365,6 +2382,8 @@ const PACK_TEXT_OPENINGS: Dictionary = {
 	"sacred_ash": "<PLAYER>'s POKéMON",
 	"squirtbottle": "<PLAYER> sprinkled",
 	"coin_case": "Coins:",
+	"blue_card": "You now have",
+	"sent_trophy_home": "There was a trophy",
 }
 ## The first and last of `.PokedexDesc` through `.QuitDesc`, which is what says a
 ## nine-string run is that run and not another one in the same bank. As decoded
@@ -6106,6 +6125,21 @@ static func read_decoration_attributes(rom: RomFile, layout: Dictionary) -> Arra
 	return out
 
 
+## `DecorationIDs`, the decoration each `DECOFLAG_*` index names. Empty when the
+## run does not end in the source's own `-1`, which is what a wrong offset gives.
+static func read_decoration_ids(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout.get("decoration_ids", -1))
+	var count: int = RomLayout.DECORATION_ID_COUNT
+	if at < 0 or not rom.in_bounds(at, count + 1):
+		return []
+	if rom.u8(at + count) != 0xFF:
+		return []
+	var out: Array = []
+	for index: int in count:
+		out.append(rom.u8(at + index))
+	return out
+
+
 ## `DecorationNames`, the parts `GetDecoName` joins into a decoration's own name.
 static func read_decoration_names(rom: RomFile, layout: Dictionary) -> PackedStringArray:
 	var at: int = int(layout.get("decorations", -1))
@@ -6126,6 +6160,7 @@ func _import_decorations(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {
 		"attributes": read_decoration_attributes(rom, layout),
 		"names": Array(read_decoration_names(rom, layout)),
+		"ids": read_decoration_ids(rom, layout),
 	}
 
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1428,6 +1428,12 @@ const DECORATION_COUNT: int = 53
 const DECORATION_ATTRIBUTE_SIZE: int = 6
 const DECORATION_NAMES_AT: int = 0x13E
 const DECORATION_NAME_COUNT: int = 26
+## `DecorationIDs`, the `DECOFLAG_*` order `GetDecorationID` indexes: forty-five
+## decoration ids and the `-1` that ends the run. It is not the id order, because
+## the dolls come in front of the big dolls here and behind them there, so it is
+## a table rather than a rule. Its own address is pinned per cartridge, since the
+## name run in front of it is a different length on Gold and Silver.
+const DECORATION_ID_COUNT: int = 45
 ## `list_start TEXTBOX_INNERW - 1`: seventeen characters and the terminator.
 const DECORATION_NAME_MAX_BYTES: int = 18
 
@@ -2206,6 +2212,10 @@ const GOLD_SILVER: Dictionary = {
 		# the table: the arbitrary code execution pokegold's own comment names.
 		# There is no text to be faithful to, so it is not imported.
 		"coin_case": -1,
+		# `_BlueCardBalanceText` is Crystal's alone: Buena and her Blue Card are
+		# not in these two, so the item, the effect entry and the text are absent.
+		"blue_card": -1,
+		"sent_trophy_home": 0x19862A,
 	},
 	"intro_text": {
 		"oak_1": 0x195624,
@@ -2312,6 +2322,9 @@ const GOLD_SILVER: Dictionary = {
 	# the source's own constants and matching it, which hits once per dump.
 	# `DecorationNames` is `DECORATION_NAMES_AT` behind it.
 	"decorations": 0x26C2B,
+	# `DecorationIDs`, located by matching all forty-six ids and the terminator,
+	# which hits once per dump.
+	"decoration_ids": 0x270FE,
 	# `UnownWords`, located by encoding the twenty-six words in the Unown font's
 	# own codes and matching the whole run, which hits once per dump; the table
 	# is the fifty-four bytes in front of it.
@@ -2800,6 +2813,8 @@ const CRYSTAL: Dictionary = {
 		"sacred_ash": 0x1C0B65,
 		"squirtbottle": 0x1C0B3B,
 		"coin_case": 0x1C5C7B,
+		"blue_card": 0x1C5C5E,
+		"sent_trophy_home": 0x1C5D03,
 	},
 	"intro_text": {
 		"oak_1": 0x1C1D35,
@@ -2882,6 +2897,9 @@ const CRYSTAL: Dictionary = {
 	# address moves.
 	"pokecenter_pc": 0x155FA,
 	"decorations": 0x26A4F,
+	# See the Gold and Silver block above; the table is byte identical and only
+	# its address moves.
+	"decoration_ids": 0x26F2B,
 	# See the Gold and Silver block above; the words are byte identical and only
 	# their address moves.
 	"unown_words": 0xFBA5A,

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -1428,6 +1428,23 @@ const DECORATION_COUNT: int = 53
 const DECORATION_ATTRIBUTE_SIZE: int = 6
 const DECORATION_NAMES_AT: int = 0x13E
 const DECORATION_NAME_COUNT: int = 26
+## `engine/events/mom_phone.asm`'s own block, pinned at `Mom_GetScriptPointer`'s
+## two inline scripts: four `writetext`s and an `end` each, thirteen bytes apart,
+## with `MomItems_1` `MOM_ITEMS_AT` behind them and `MomItems_2` five rows past
+## that. One address finds all four, and the deltas are the same on all three
+## cartridges because the whole block is byte identical bar the item ids.
+const MOM_DOLL_SCRIPT_AT: int = 0x0D
+const MOM_ITEMS_AT: int = 0x39
+const MOM_ITEM_SIZE: int = 8
+## `MomItems_1` is what she picks from at random once the balance lands exactly
+## on a `MOM_MONEY` boundary; `MomItems_2` is the ladder she walks in order.
+const MOM_ITEMS_1_COUNT: int = 5
+const MOM_ITEMS_2_COUNT: int = 10
+## `constants/misc_constants.asm`' `MOM_MONEY`, the step the trigger balance
+## climbs by.
+const MOM_MONEY: int = 2300
+
+
 ## `DecorationIDs`, the `DECOFLAG_*` order `GetDecorationID` indexes: forty-five
 ## decoration ids and the `-1` that ends the run. It is not the id order, because
 ## the dolls come in front of the big dolls here and behind them there, so it is
@@ -2325,6 +2342,9 @@ const GOLD_SILVER: Dictionary = {
 	# `DecorationIDs`, located by matching all forty-six ids and the terminator,
 	# which hits once per dump.
 	"decoration_ids": 0x270FE,
+	# `Mom_GetScriptPointer.ItemScript`, located by its own five command bytes
+	# with `MomItems_1` at the pinned distance behind it, which hits once per dump.
+	"mom_phone": 0xFCE98,
 	# `UnownWords`, located by encoding the twenty-six words in the Unown font's
 	# own codes and matching the whole run, which hits once per dump; the table
 	# is the fifty-four bytes in front of it.
@@ -2900,6 +2920,9 @@ const CRYSTAL: Dictionary = {
 	# See the Gold and Silver block above; the table is byte identical and only
 	# its address moves.
 	"decoration_ids": 0x26F2B,
+	# See the Gold and Silver block above; only the address and the `end` opcode
+	# in the two scripts move.
+	"mom_phone": 0xFD0FD,
 	# See the Gold and Silver block above; the words are byte identical and only
 	# their address moves.
 	"unown_words": 0xFBA5A,

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -1463,11 +1463,36 @@ static func _collect_text(rom: RomFile, bank: int, address: int, text_data: Dict
 		if bytes[index] != Gen2WorldScript.TEXT_TERMINATOR \
 			and bytes[index] != Gen2WorldScript.TEXT_PROMPT:
 			continue
-		text_data[key] = Array(bytes.slice(0, index + 1))
+		var bounded: PackedByteArray = bytes.slice(0, index + 1)
+		text_data[key] = Array(bounded)
+		_collect_far_texts(rom, bounded, text_data)
 		return
 	# Preserve an unterminated bounded slice for diagnostics. Runtime decoding
 	# still fails explicitly instead of reading into an adjacent resource.
+	# A `text_far` stub always lands here: it ends in `TX_END` rather than in one
+	# of the two run terminators, so it is the whole of what this branch holds.
 	text_data[key] = Array(bytes)
+	_collect_far_texts(rom, bytes, text_data)
+
+
+## `TextCommand_FAR` banks in and prints another text whole, so a `text_far` stub
+## is unreadable without its target. Following the command is what collects the
+## other half; nothing else in the cache points at it, since it is reached from
+## inside a text rather than from a script.
+static func _collect_far_texts(
+	rom: RomFile, bytes: PackedByteArray, text_data: Dictionary
+) -> void:
+	var at: int = 0
+	while at + 3 < bytes.size():
+		if bytes[at] == Gen2TextStream.TX_END:
+			return
+		if bytes[at] != Gen2TextStream.TX_FAR:
+			at += 1
+			continue
+		_collect_text(
+			rom, int(bytes[at + 3]), bytes[at + 1] | (bytes[at + 2] << 8), text_data
+		)
+		at += 4
 
 
 static func _valid_coord(x: int, y: int, width: int, height: int) -> bool:

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -114,7 +114,7 @@ static func read_services(
 	if not bool(menus.get("ok", false)):
 		return menus
 	var phone_scripts: int = _collect_phone_scripts(
-		rom, phone["data"], scripts, text_data, movement_data
+		rom, layout, phone["data"], scripts, text_data, movement_data
 	)
 	return {
 		"ok": true,
@@ -555,6 +555,7 @@ static func _read_phone_non_trainer_names(rom: RomFile, layout: Dictionary) -> D
 
 static func _collect_phone_scripts(
 	rom: RomFile,
+	layout: Dictionary,
 	phone: Dictionary,
 	scripts: Dictionary,
 	text_data: Dictionary,
@@ -572,6 +573,15 @@ static func _collect_phone_scripts(
 		var pointer: Dictionary = special_call.get("script", {})
 		Gen2WorldImporter.collect_script(
 			rom, int(pointer.get("bank", -1)), int(pointer.get("address", -1)),
+			scripts, text_data, movement_data
+		)
+	## `Mom_GetScriptPointer`'s two, which no table points at: the routine writes
+	## the pointer into `wCallerContact` itself, so they are roots of their own.
+	var mom: Dictionary = RomImporter.read_mom_phone(rom, layout)
+	for field: String in ["item_script", "doll_script"]:
+		var mom_pointer: Dictionary = mom.get(field, {})
+		Gen2WorldImporter.collect_script(
+			rom, int(mom_pointer.get("bank", -1)), int(mom_pointer.get("address", -1)),
 			scripts, text_data, movement_data
 		)
 	var metadata: Dictionary = phone.get("metadata", {})

--- a/game/world/mystery_gift.gd
+++ b/game/world/mystery_gift.gd
@@ -201,7 +201,9 @@ static func receive_decoration(section: Dictionary, deco: int) -> bool:
 
 ## `CopyMysteryGiftReceivedDecorationsToPC`, run once per Continue: every flag
 ## the array carries becomes the decoration's own event flag, which is where
-## ownership lives ([Gen2WorldDecoration]). The array is not cleared, so the
+## ownership lives ([Gen2WorldDecoration]). The array holds `DECOFLAG_*` indices
+## and the walk is `SetSpecificDecorationFlag`, so `GetDecorationID` maps each
+## one onto a decoration first. The array is not cleared, so the
 ## walk is idempotent and a decoration received while a different slot was
 ## loaded still arrives.
 static func copy_decorations_to_pc(
@@ -209,7 +211,7 @@ static func copy_decorations_to_pc(
 ) -> int:
 	var given: int = 0
 	for deco: int in section.get("decorations_received", []) as Array:
-		if Gen2WorldDecoration.set_owned(data, state, deco):
+		if Gen2WorldDecoration.set_owned_by_flag(data, state, deco):
 			given += 1
 	return given
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1282,6 +1282,14 @@ func _confirm_use() -> void:
 			if number == Gen2WorldPack.ITEM_COIN_CASE:
 				_show_pack_result(_coin_case_text(), true)
 				return
+			## `BlueCardEffect` is the same routine over a different text and a
+			## different counter, and it closes nothing either.
+			if number == Gen2WorldPack.ITEM_BLUE_CARD:
+				_show_pack_result(_blue_card_text(), true)
+				return
+			if Gen2WorldPack.TROPHY_BOXES.has(number):
+				_open_trophy_box(number)
+				return
 			_use_selected_item(-1)
 		Gen2WorldPack.ITEMMENU_CLOSE:
 			_use_field_item(number)
@@ -1842,6 +1850,45 @@ func _coin_case_text() -> String:
 		return "Coins:\n%4d" % _coins()
 	return Gen2TextStream.fill_marker(
 		text, Gen2TextStream.NUMBER_MARKER, "%4d" % _coins()
+	)
+
+
+## `_BlueCardBalanceText`, whose `text_decimal wBlueCardBalance, 1, 2` is the one
+## byte [Gen2WorldState] keeps for Buena's points.
+func _blue_card_text() -> String:
+	var text: String = _data.menu_text("blue_card") if _data != null else ""
+	var balance: int = _world.state.blue_card_balance() \
+		if _world != null and _world.state != null else 0
+	if text.is_empty():
+		return "You now have\n%2d points." % balance
+	return Gen2TextStream.fill_marker(
+		text, Gen2TextStream.NUMBER_MARKER, "%2d" % balance
+	)
+
+
+## `OpenBox`: `SetSpecificDecorationFlag` on the box's own `DECOFLAG_*`, the one
+## text, and `UseDisposableItem`. Nothing can refuse it, so the flag is set and
+## the box is spent whether or not the trophy was already owned.
+func _open_trophy_box(item: int) -> void:
+	if _world == null or _world.state == null or _data == null:
+		_show_pack_result("No world is loaded.", false)
+		return
+	Gen2WorldDecoration.set_owned_by_flag(
+		_data, _world.state, int(Gen2WorldPack.TROPHY_BOXES[item])
+	)
+	if _world.inventory != null:
+		_world.inventory.change_item_quantity(item, -1)
+	_show_pack_result(_trophy_text(), true)
+
+
+## `_SentTrophyHomeText`, whose second paragraph names `wPlayerName`.
+func _trophy_text() -> String:
+	var text: String = _data.menu_text("sent_trophy_home") if _data != null else ""
+	if text.is_empty():
+		return "There was a trophy\ninside!"
+	return Gen2TextStream.fill_all_markers(
+		text, Gen2TextStream.RAM_MARKER,
+		_pack_save.player_name if _pack_save != null else ""
 	)
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2459,10 +2459,78 @@ func request_incoming_phone_call(
 	return _start_phone_ring(request)
 
 
+## `MomTriesToBuySomething` whole: the decision, the purchase and the call, in
+## the source's order. [param random_row] is `RandomRange` over `MomItems_1`,
+## passed in the way every other roll here is.
+##
+## Answers `{ ok, bought, reason, results }`. `bought` is false when nothing was
+## due, and the trigger balance the walk climbed to is still stored, because
+## `.AddMoney` writes it before `.less_than` returns.
+func mom_purchase(random_row: int = 0) -> Dictionary:
+	if data == null or state == null:
+		return {"ok": false, "reason": &"mom_data_unavailable", "results": []}
+	var resolved: Dictionary = Gen2WorldMomPhone.resolve(
+		data, state, current_map, random_row
+	)
+	if not bool(resolved.get("ok", false)):
+		if resolved.has("trigger_balance"):
+			state.set_mom_purchase(
+				state.mom_item_index(), state.mom_item_set(),
+				int(resolved["trigger_balance"])
+			)
+		return {
+			"ok": true, "bought": false,
+			"reason": resolved.get("reason", &"mom_bought_nothing"), "results": [],
+		}
+	var item: int = int(resolved["item"])
+	var doll: bool = bool(resolved["doll"])
+	## `Mom_GiveItemOrDoll`. The item half is `ReceiveItem` into `wNumPCItems`,
+	## and a full PC returns before `MomBuysItem_DeductFunds`, so she keeps the
+	## money and tries the same row again next time.
+	if doll:
+		Gen2WorldDecoration.set_owned(data, state, item)
+	else:
+		var held: int = state.pc_item_quantity(item)
+		if held == 0 and state.pc_items().size() >= Gen2WorldPack.MAX_PC_ITEMS:
+			return {"ok": true, "bought": false, "reason": &"pc_full", "results": []}
+		var stored: Dictionary = state.apply_changes({}, {}, {
+			"pc_items": {item: mini(held + 1, Gen2WorldPack.MAX_ITEM_STACK)},
+		})
+		if not bool(stored.get("ok", false)):
+			return {"ok": true, "bought": false, "reason": &"pc_full", "results": []}
+	## `MomBuysItem_DeductFunds`, and then `.ASMFunction`'s three writes.
+	var savings: int = state.money(Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY)
+	state.apply_changes({}, {}, {
+		"money": {
+			Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY:
+				maxi(savings - int(resolved["cost"]), 0),
+		},
+	})
+	state.set_mom_purchase(
+		int(resolved["next_index"]), int(resolved["set"]),
+		int(resolved["trigger_balance"])
+	)
+	return {
+		"ok": true,
+		"bought": true,
+		"doll": doll,
+		"item": item,
+		"cost": int(resolved["cost"]),
+		"results": request_caller_phone_call(
+			Gen2WorldMomPhone.CONTACT_MOM, data.mom_phone_script(doll)
+		),
+	}
+
+
 ## `Script_SpecialBillCall`: `LoadCallerScript PHONE_BILL` and then
 ## `Script_ReceivePhoneCall`, which is the same two rings an incoming call
 ## spends. Nothing gates it, so the only caller is the event that owes it.
-func request_caller_phone_call(contact_id: int) -> Array:
+## [param script_override] is `Mom_GetScriptPointer`'s own answer: her call is
+## the one place the contact's `PHONE_CONTACT_SCRIPT2` is written before the ring
+## rather than read out of the table.
+func request_caller_phone_call(
+	contact_id: int, script_override: Dictionary = {}
+) -> Array:
 	if phone_ring_active():
 		return [{"ok": true, "status": &"phone_ring", "event": pending_phone_ring()}]
 	if current_map == null:
@@ -2473,12 +2541,15 @@ func request_caller_phone_call(contact_id: int) -> Array:
 			"ok": false, "status": &"phone_unavailable",
 			"reason": resolved.get("reason", &"phone_unavailable"),
 		}]
+	var script: Dictionary = resolved["script"]
+	if not script_override.is_empty():
+		script = script_override
 	return _start_phone_ring({
 		"kind": &"phone_incoming",
 		"map_group": current_map.group,
 		"map_number": current_map.number,
-		"bank": int(resolved["script"]["bank"]),
-		"script": int(resolved["script"]["address"]),
+		"bank": int(script.get("bank", 0)),
+		"script": int(script.get("address", 0)),
 		"phone": resolved["phone"],
 		"contact": resolved["contact"],
 		"reset_receive_timer": true,

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -192,8 +192,32 @@ static func owns(data: GameData, state: Gen2WorldState, deco: int) -> bool:
 	return state.is_event_flag_active(int(row.get("flag", -1)))
 
 
-## `SetSpecificDecorationFlag`, which is what a doll Mom buys and a trophy the
-## Bug Contest awards go through.
+## `DecorationIDs` indices the code names for itself. The two trophy dolls sit
+## past `NUM_NON_TROPHY_DECOS`, which is why Mystery Gift can never send one.
+const DECOFLAG_GOLD_TROPHY_DOLL: int = 43
+const DECOFLAG_SILVER_TROPHY_DOLL: int = 44
+
+
+## `GetDecorationID`: which decoration a `DECOFLAG_*` index names. The two orders
+## are not the same, and neither is a rule: the flag order runs the dolls in
+## front of the big dolls where the id order runs them behind, and the flag order
+## has no header rows in it at all. Answers 0, the CANCEL row, for an index the
+## imported table does not carry.
+static func decoration_for_flag(data: GameData, flag_index: int) -> int:
+	return data.decoration_id_for_flag(flag_index) if data != null else 0
+
+
+## `SetSpecificDecorationFlag`, the one entry every gift takes: Mystery Gift's
+## own copy walk, and the two trophy boxes. Its argument is a `DECOFLAG_*`, so it
+## runs `GetDecorationID` first.
+static func set_owned_by_flag(
+	data: GameData, state: Gen2WorldState, flag_index: int, owned: bool = true
+) -> bool:
+	return set_owned(data, state, decoration_for_flag(data, flag_index), owned)
+
+
+## `DecorationFlagAction SET_FLAG` on a decoration id, which is what
+## `SetSpecificDecorationFlag` reaches once the index is resolved.
 static func set_owned(
 	data: GameData, state: Gen2WorldState, deco: int, owned: bool = true
 ) -> bool:

--- a/game/world/world_mom_phone.gd
+++ b/game/world/world_mom_phone.gd
@@ -1,0 +1,85 @@
+class_name Gen2WorldMomPhone
+extends RefCounted
+
+## `engine/events/mom_phone.asm`: what Mom's savings buy while the player is out,
+## and the call she makes about it.
+##
+## `MomTriesToBuySomething` runs after a trainer battle, on the same
+## `Script_reloadmapafterbattle` branch `Script_SpecialBillCall` sits opposite
+## (`Gen2WorldScreen._start_box_full_call`). It reads her balance, decides
+## whether a purchase is due, hands the item over and puts her on the line.
+##
+## Scene-free like the other world hosts, and split the way the source is: this
+## file is `CheckBalance_MomItem2` and `Mom_GetScriptPointer`, the decision;
+## applying it is [method Gen2WorldAPI.mom_purchase] and the call is
+## [method Gen2WorldAPI.request_caller_phone_call].
+
+## `PhoneContacts` index. Mom is the second row on all three cartridges.
+const CONTACT_MOM: int = 1
+
+## `MOMITEM_KIND`. An item goes to the PC, a doll to the player's room.
+const KIND_ITEM: int = 1
+const KIND_DOLL: int = 2
+
+
+## `MomTriesToBuySomething` down to its `scf`: whether a purchase is due, and
+## which row it is. [param random_row] is `RandomRange`'s answer over
+## `MomItems_1`, drawn by the caller so nothing here reaches a global generator.
+##
+## Answers `{ ok, reason }` when nothing is bought, and otherwise the row, the
+## set and index to store, and the trigger balance the walk left behind.
+static func resolve(
+	data: GameData,
+	state: Gen2WorldState,
+	map: Gen2WorldMap,
+	random_row: int = 0
+) -> Dictionary:
+	if data == null or state == null:
+		return {"ok": false, "reason": &"mom_data_unavailable"}
+	## `GetMapPhoneService`: she cannot ring where a phone cannot.
+	if not Gen2WorldPhoneHost.map_has_phone_service(map):
+		return {"ok": false, "reason": &"phone_service_unavailable"}
+	var savings: int = state.money(Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY)
+	## `CheckBalance_MomItem2`'s first half: the ladder, in order, and only while
+	## a row is left. `wWhichMomItem` never goes back.
+	var index: int = state.mom_item_index()
+	if index < data.mom_item_count(0):
+		var row: Dictionary = data.mom_item(0, index)
+		if not row.is_empty() and savings >= int(row.get("trigger", 0)):
+			return _purchase(row, index, 0, state.mom_item_trigger_balance())
+	## `.check_have_2300`: the trigger balance climbs by `MOM_MONEY` until it
+	## reaches her savings, and she buys only when it lands on them exactly.
+	var trigger: int = state.mom_item_trigger_balance()
+	while trigger < savings:
+		trigger += RomLayout.MOM_MONEY
+	if trigger != savings:
+		return {
+			"ok": false, "reason": &"mom_balance_not_on_a_boundary",
+			"trigger_balance": trigger,
+		}
+	trigger += RomLayout.MOM_MONEY
+	var count: int = data.mom_item_count(1)
+	if count <= 0:
+		return {"ok": false, "reason": &"mom_items_unavailable"}
+	var chosen: int = posmod(random_row, count)
+	return _purchase(data.mom_item(1, chosen), index, chosen + 1, trigger)
+
+
+static func _purchase(
+	row: Dictionary, index: int, set_number: int, trigger_balance: int
+) -> Dictionary:
+	if row.is_empty():
+		return {"ok": false, "reason": &"mom_items_unavailable"}
+	var doll: bool = int(row.get("kind", KIND_ITEM)) == KIND_DOLL
+	return {
+		"ok": true,
+		"row": row.duplicate(),
+		"doll": doll,
+		"item": int(row.get("item", 0)),
+		"cost": int(row.get("cost", 0)),
+		## `.ASMFunction`'s `inc [hl]`, which only the ladder reaches: a random
+		## pick out of `MomItems_1` leaves `wWhichMomItem` where it was.
+		"next_index": index + 1 if set_number == 0 else index,
+		"set": set_number,
+		"trigger_balance": trigger_balance,
+	}

--- a/game/world/world_mom_phone.gd.uid
+++ b/game/world/world_mom_phone.gd.uid
@@ -1,0 +1,1 @@
+uid://cw3wavmrspak1

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -245,6 +245,15 @@ const ITEM_ESCAPE_ROPE: int = 0x13
 ## prints its count inside the pack and closes nothing, so it has no field
 ## effect and the screen answers it where the other CURRENT rows are answered.
 const ITEM_COIN_CASE: int = 0x36
+## `BlueCardEffect`, the Coin Case's twin: `MenuTextboxWaitButton` over the
+## balance. Crystal's alone, because Buena is.
+const ITEM_BLUE_CARD: int = 0x74
+## `NormalBoxEffect` and `GorgeousBoxEffect`, which are `OpenBox` twice over: the
+## `DECOFLAG_*` each one sets, and then the same box and the same `UseDisposableItem`.
+const TROPHY_BOXES: Dictionary = {
+	0xA7: Gen2WorldDecoration.DECOFLAG_SILVER_TROPHY_DOLL,
+	0xA8: Gen2WorldDecoration.DECOFLAG_GOLD_TROPHY_DOLL,
+}
 const ITEM_ITEMFINDER: int = 0x37
 const ITEM_SACRED_ASH: int = 0x9C
 const ITEM_CARD_KEY: int = 0x7F

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -254,6 +254,10 @@ var _start_menu_cursor: int = 0
 var _reopen_start_menu: bool = false
 var _trainer_approach: Dictionary = {}
 var _active_battle_save: Gen2SaveData = null
+## `wBattleScriptFlags` bit 7, which `Script_loadtrainer` sets and
+## `Script_reloadmapafterbattle` reads: a trainer fight is the branch
+## `MomTriesToBuySomething` sits on, a wild one the branch Bill does.
+var _active_battle_trainer: bool = false
 ## How many battles this run has started, which is what a replay compares beside
 ## the party: a route that fought and one that walked past the grass reach
 ## different states for the same reason.
@@ -4505,6 +4509,7 @@ func _open_battle_host(request: Dictionary) -> void:
 	var save: Gen2SaveData = _injected_save if _injected_save != null else _selected_runtime_save()
 	_active_battle_save = save
 	_active_battle_persist = save != null and _injected_save == null
+	_active_battle_trainer = StringName(values.get("kind", &"")) == &"trainer"
 	_battles_fought += 1
 	var host: Gen2BattleScreen = BATTLE_SCENE.instantiate() as Gen2BattleScreen
 	host.set_data(_data)
@@ -4797,6 +4802,7 @@ func _finish_battle_exit(result: Dictionary, fought_save: Gen2SaveData) -> void:
 	## map's own track back over the one `PlayBattleMusic` started.
 	_play_current_map_music()
 	_start_box_full_call()
+	_start_mom_purchase_call()
 	_refresh_labels()
 
 
@@ -4812,6 +4818,21 @@ func _start_box_full_call() -> void:
 		Gen2WorldPhoneHost.CONTACT_BILL
 	)
 	if not results.is_empty() and bool(results[0].get("ok", false)):
+		_show_script_results(results)
+
+
+## `Script_reloadmapafterbattle`'s other branch. Bill rings after a wild battle
+## that filled the box; Mom rings after a trainer battle, if her savings have
+## reached the next thing she is buying. The two are exclusive on the cartridge
+## because one bit decides which, so the flag is read here and nowhere else.
+func _start_mom_purchase_call() -> void:
+	if _world == null or not _active_battle_trainer:
+		return
+	_active_battle_trainer = false
+	var bought: Dictionary = _world.mom_purchase(_encounter_random.randi())
+	var results: Array = bought.get("results", [])
+	if bool(bought.get("bought", false)) and not results.is_empty() \
+		and bool((results[0] as Dictionary).get("ok", false)):
 		_show_script_results(results)
 
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -332,6 +332,15 @@ var _buenas_password: int = 0
 ## own `ifequal` in front of the award, not a rule the byte enforces.
 var _blue_card_balance: int = 0
 
+## `wWhichMomItem`, `wWhichMomItemSet` and `wMomItemTriggerBalance`, the three
+## `MomTriesToBuySomething` reads and writes. The index walks `MomItems_2` in
+## order and never goes back; the set is 0 for that ladder and 1 plus a row for
+## the five she picks from at random; the balance is the next `MOM_MONEY`
+## boundary her savings have to land on exactly.
+var _mom_item_index: int = 0
+var _mom_item_set: int = 0
+var _mom_item_trigger_balance: int = RomLayout.MOM_MONEY
+
 ## `wVariableSprites`, the sixteen `SPRITE_VARS` slots `GetMonSprite` resolves a
 ## variable sprite through. It sits inside `wPlayerData`, which `SaveData` copies
 ## whole into `sPlayerData`, so the table is saved and restored: an assignment
@@ -515,6 +524,9 @@ func to_dict() -> Dictionary:
 			"ot": _best_magikarp_ot,
 		},
 		"mom_savings_flags": _mom_savings_flags,
+		"mom_item_index": _mom_item_index,
+		"mom_item_set": _mom_item_set,
+		"mom_item_trigger_balance": _mom_item_trigger_balance,
 		"blue_card_balance": _blue_card_balance,
 		"buenas_password": _buenas_password,
 		"variable_sprites": _variable_sprites.duplicate(),
@@ -642,6 +654,15 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 		restored._best_magikarp_inches = int((record as Dictionary).get("inches", 0)) & 0xFF
 		restored._best_magikarp_ot = String((record as Dictionary).get("ot", ""))
 	restored._mom_savings_flags = int(source.get("mom_savings_flags", 0)) & 0xFF
+	restored._mom_item_index = maxi(int(source.get("mom_item_index", 0)), 0)
+	restored._mom_item_set = maxi(int(source.get("mom_item_set", 0)), 0)
+	## `NewGame` writes `MOM_MONEY` here rather than zero, so a save from before
+	## the field existed reads as a new game rather than as a balance she has
+	## already passed.
+	restored._mom_item_trigger_balance = clampi(
+		int(source.get("mom_item_trigger_balance", RomLayout.MOM_MONEY)),
+		0, Gen2WorldInventory.MAX_MONEY
+	)
 	restored._blue_card_balance = int(source.get("blue_card_balance", 0)) & 0xFF
 	restored._buenas_password = int(source.get("buenas_password", 0)) & 0xFF
 	## Defaults rather than versioning: a slot written before the tower existed
@@ -724,6 +745,9 @@ func restore_from_dict(raw: Variant) -> void:
 	_best_magikarp_inches = restored._best_magikarp_inches
 	_best_magikarp_ot = restored._best_magikarp_ot
 	_mom_savings_flags = restored._mom_savings_flags
+	_mom_item_index = restored._mom_item_index
+	_mom_item_set = restored._mom_item_set
+	_mom_item_trigger_balance = restored._mom_item_trigger_balance
 	_blue_card_balance = restored._blue_card_balance
 	_buenas_password = restored._buenas_password
 	_variable_sprites = restored._variable_sprites.duplicate()
@@ -1138,6 +1162,34 @@ func set_mom_savings_flags(flags: int) -> void:
 
 func blue_card_balance() -> int:
 	return _blue_card_balance
+
+
+func mom_item_index() -> int:
+	return _mom_item_index
+
+
+func mom_item_set() -> int:
+	return _mom_item_set
+
+
+func mom_item_trigger_balance() -> int:
+	return _mom_item_trigger_balance
+
+
+## The three written together, because `MomTriesToBuySomething` never moves one
+## without the others: the balance climbs while the set is chosen, and the index
+## advances only on the ladder.
+func set_mom_purchase(index: int, set_number: int, trigger_balance: int) -> void:
+	var next_index: int = maxi(index, 0)
+	var next_set: int = maxi(set_number, 0)
+	var next_balance: int = clampi(trigger_balance, 0, Gen2WorldInventory.MAX_MONEY)
+	if next_index == _mom_item_index and next_set == _mom_item_set \
+		and next_balance == _mom_item_trigger_balance:
+		return
+	_mom_item_index = next_index
+	_mom_item_set = next_set
+	_mom_item_trigger_balance = next_balance
+	changed.emit()
 
 
 func buenas_password() -> int:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -13,6 +13,11 @@ const FLOWER_MAIL: int = 158
 ## menu nibble.
 const ITEMFINDER: int = 0x37
 const CARD_KEY: int = 0x7F
+## `BLUE_CARD`, `NORMAL_BOX` and `GORGEOUS_BOX`, the three `.Current` rows that
+## are not a repel and not the Coin Case.
+const BLUE_CARD: int = Gen2WorldPack.ITEM_BLUE_CARD
+const NORMAL_BOX: int = 0xA7
+const GORGEOUS_BOX: int = 0xA8
 const OLD_ROD: int = Gen2WorldInventory.ITEM_OLD_ROD
 
 ## The least a registered world renderer can be, for the VIEW row's own case.
@@ -93,6 +98,21 @@ func _write_pack_item() -> void:
 				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
 				raw["permissions"] = Gen2WorldPack.CANT_TOSS
 				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+			BLUE_CARD:
+				raw["name"] = "BLUE CARD"
+				raw["pocket"] = Gen2WorldPack.TYPE_KEY_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT | Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
+			NORMAL_BOX:
+				raw["name"] = "NORMAL BOX"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
+			GORGEOUS_BOX:
+				raw["name"] = "GORGEOUS BOX"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
 			FLOWER_MAIL:
 				## `MailItems`' first entry at its real number, with FLOWER
 				## MAIL's own row: `ItemIsMail` checks the number, so a stand-in
@@ -1798,6 +1818,55 @@ func test_select_says_an_item_may_be_registered_when_none_is() -> void:
 	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
 	assert_eq(String(host.get("_pack_result")), Gen2WorldPack.may_register_text())
+
+
+## `BlueCardEffect`: `MenuTextboxWaitButton` over `_BlueCardBalanceText` and
+## nothing else, so the count is shown and the card is not spent.
+func test_the_blue_card_shows_its_balance_and_is_not_spent() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {BLUE_CARD: 1}})
+	_world_screen._world.state.set_blue_card_balance(7)
+	var host: Gen2StartMenuScreen = await _open_pack(Gen2WorldPack.TYPE_KEY_ITEM)
+	host.set("_pack_cursor", 0)
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(String(host.get("_pack_result")), "You now have\n 7 points.")
+	assert_eq(
+		_world_screen._world.state.item_quantity(BLUE_CARD), 1,
+		"nothing in the routine reaches UseDisposableItem"
+	)
+
+
+## `NormalBoxEffect` and `GorgeousBoxEffect`, which are `OpenBox` twice over:
+## `SetSpecificDecorationFlag` on the box's own `DECOFLAG_*`, and then
+## `UseDisposableItem`. `GetDecorationID` is what makes the two land on different
+## dolls, since the flag order and the id order are not the same list.
+func test_a_trophy_box_sets_its_own_doll_and_is_spent() -> void:
+	await _open_world()
+	var state: Gen2WorldState = _world_screen._world.state
+	state.apply_changes({}, {}, {"items": {NORMAL_BOX: 1, GORGEOUS_BOX: 1}})
+	var data: GameData = _world_screen._world.data
+	assert_false(
+		Gen2WorldDecoration.owns(data, state, Fixture.DECO_SILVER_TROPHY_DOLL)
+	)
+
+	var host: Gen2StartMenuScreen = await _open_pack()
+	var rows: Array = host._current_pocket_items()
+	for index: int in rows.size():
+		if int((rows[index] as Dictionary).get("item", 0)) == NORMAL_BOX:
+			host.set("_pack_cursor", index)
+			break
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	assert_string_contains(String(host.get("_pack_result")), "There was a trophy")
+	assert_true(
+		Gen2WorldDecoration.owns(data, state, Fixture.DECO_SILVER_TROPHY_DOLL),
+		"NORMAL BOX is DECOFLAG_SILVER_TROPHY_DOLL"
+	)
+	assert_false(
+		Gen2WorldDecoration.owns(data, state, Fixture.DECO_GOLD_TROPHY_DOLL),
+		"and it is the only one it sets"
+	)
+	assert_eq(state.item_quantity(NORMAL_BOX), 0, "UseDisposableItem")
 
 
 ## `RegisterItem` and `UseRegisteredItem`'s `.Current`, which is the whole

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -71,7 +71,7 @@ const TRAINER_SPECIES: int = 16
 const TRAINER_SPRITE: int = 1
 ## The decoration table's own length here, which is one past the second ornament
 ## rather than the cartridge's fifty-three.
-const DECORATION_ROWS: int = 32
+const DECORATION_ROWS: int = 34
 ## [id, action, event flag, block or sprite] per row the fixture fills. The ids
 ## and the actions are the source's; the flags are `EVENT_DECO_*` and the last
 ## column is a block for the first four categories and a sprite for the rest.
@@ -83,11 +83,14 @@ const DECORATION_FIXTURE: Array[Array] = [
 	[20, 10, 0, 0], [21, 9, 691, 0x5C],
 	[25, 12, 0, 0], [26, 11, 719, 0x33],
 	[29, 14, 0, 0], [30, 13, 695, 0x8E], [31, 13, 696, 0x34],
+	[32, 13, 717, 0x5E], [33, 13, 718, 0x5F],
 ]
 ## The two the fixture's own tests reach for by name.
 const DECO_FEATHERY_BED: int = 2
 const DECO_PIKACHU_DOLL: int = 30
 const DECO_SURF_PIKACHU_DOLL: int = 31
+const DECO_GOLD_TROPHY_DOLL: int = 32
+const DECO_SILVER_TROPHY_DOLL: int = 33
 
 
 ## Every caller but the Gold/Silver profile tests uses the default id, so the
@@ -587,6 +590,8 @@ static func _write_menu_text(manifest: Dictionary) -> void:
 		"toss_ask": "Throw away how\nmany?",
 		"toss_ask_quantity": "Throw away <NUM_D009>\n<RAM_CF7E>(S)?",
 		"toss_threw": "Threw away\n<RAM_CF7E>(S).",
+		"blue_card": "You now have\n<NUM_DC4B> points.",
+		"sent_trophy_home": "There was a trophy\ninside!\ue000<RAM_D47D> sent the\ntrophy home.",
 	}
 
 
@@ -757,7 +762,25 @@ static func _write_decorations(manifest: Dictionary) -> void:
 			"type": 1, "name": int(row[0]), "action": int(row[1]),
 			"flag": int(row[2]), "sprite": int(row[3]),
 		}
-	manifest["decorations"] = {"attributes": attributes, "names": names}
+	## `DecorationIDs`, the `DECOFLAG_*` order. The fixture's set-up rows come
+	## first, in id order, and the two trophy dolls sit at the source's own 43 and
+	## 44 so the trophy boxes reach them; the run between is the CANCEL row, which
+	## is what an index no fixture decoration answers gives on a cartridge too.
+	var ids: Array = []
+	for _index: int in RomLayout.DECORATION_ID_COUNT:
+		ids.append(0)
+	var flag_index: int = 0
+	for row: Array in DECORATION_FIXTURE:
+		var deco: int = int(row[0])
+		if deco == DECO_GOLD_TROPHY_DOLL or deco == DECO_SILVER_TROPHY_DOLL:
+			continue
+		var pair: Variant = Gen2WorldDecoration.ACTIONS.get(int(row[1]), null)
+		if pair is Array and bool((pair as Array)[1]):
+			ids[flag_index] = deco
+			flag_index += 1
+	ids[Gen2WorldDecoration.DECOFLAG_GOLD_TROPHY_DOLL] = DECO_GOLD_TROPHY_DOLL
+	ids[Gen2WorldDecoration.DECOFLAG_SILVER_TROPHY_DOLL] = DECO_SILVER_TROPHY_DOLL
+	manifest["decorations"] = {"attributes": attributes, "names": names, "ids": ids}
 
 
 static func _write_pokecenter_pc(manifest: Dictionary) -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -362,6 +362,19 @@ func _write_cache(game_id: String = "testworld") -> void:
 		## category header and one decoration behind it, so a slot's own block or
 		## sprite is read from the table rather than guessed.
 		"decorations": _decoration_fixture(),
+		## `MomItems_1`, `MomItems_2` and `Mom_GetScriptPointer`'s two answers, in
+		## the shape a real cache carries. Two ladder rows are enough for a walk
+		## that has to stop after the last one, and the doll row is decoration 30,
+		## the one this fixture's own table owns.
+		"mom_phone": {
+			"items_1": [{"trigger": 0, "cost": 90, "kind": 1, "item": 7}],
+			"items_2": [
+				{"trigger": 900, "cost": 600, "kind": 1, "item": 7},
+				{"trigger": 10000, "cost": 1800, "kind": 2, "item": 30},
+			],
+			"item_script": {"bank": 48, "address": 0x4234},
+			"doll_script": {"bank": 48, "address": 0x5678},
+		},
 		## The `RomLayout.SPECIAL_TEXT_RUNS` boxes the deferred routines print,
 		## with the `text_ram` markers a real cache carries so a filled buffer is
 		## told from an unfilled one.
@@ -483,6 +496,14 @@ func _write_service_cache() -> void:
 			"callee_script": {"bank": 48, "address": 0x5678},
 			"callee_time": Gen2WorldPhoneHost.TIME_ANY,
 			"caller_time": Gen2WorldPhoneHost.TIME_ANY,
+		}, {
+			## `PHONE_MOM`, whose row exists so the ring has a contact; the script
+			## her call runs is `Mom_GetScriptPointer`'s, not this one.
+			"index": Gen2WorldMomPhone.CONTACT_MOM,
+			"caller_script": {"bank": 48, "address": 0x4234},
+			"callee_script": {"bank": 48, "address": 0x5678},
+			"callee_time": Gen2WorldPhoneHost.TIME_ANY,
+			"caller_time": Gen2WorldPhoneHost.TIME_ANY,
 		}],
 		"special_calls": [{"index": 0, "condition_kind": "anywhere", "contact": 0,
 			"script": {"bank": 48, "address": 0x7000}}],
@@ -564,6 +585,99 @@ func test_an_event_call_rings_the_contact_caller_script() -> void:
 	assert_true(world.phone_ring_active())
 	assert_eq(world.pending_phone_ring()["phone"]["role"], &"caller")
 	assert_false(Gen2WorldPhoneHost.resolve_caller(data, 999)["ok"])
+
+
+## `CheckBalance_MomItem2`'s ladder half: she buys the next `MomItems_2` row the
+## moment her savings reach its trigger, one row at a time, and never goes back.
+## An item lands in the PC, a doll in the room, and `MomBuysItem_DeductFunds`
+## takes the cost out of her savings rather than out of the player's.
+func test_mom_buys_the_next_ladder_row_when_her_savings_reach_it() -> void:
+	_write_service_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var savings: int = Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY
+
+	world.state.apply_changes({}, {}, {"money": {savings: 800}})
+	var early: Dictionary = world.mom_purchase()
+	assert_false(bool(early["bought"]), JSON.stringify(early))
+	assert_eq(world.state.money(savings), 800, "and nothing is spent")
+
+	world.state.apply_changes({}, {}, {"money": {savings: 900}})
+	var bought: Dictionary = world.mom_purchase()
+	assert_true(bool(bought["bought"]), JSON.stringify(bought))
+	assert_false(bool(bought["doll"]))
+	assert_eq(world.state.pc_item_quantity(7), 1, "ReceiveItem into wNumPCItems")
+	assert_eq(world.state.money(savings), 300, "900 less the row's 600")
+	assert_eq(world.state.mom_item_index(), 1, ".ASMFunction's inc [hl]")
+	assert_true(world.phone_ring_active(), "and she rings about it")
+
+
+## The doll half of `Mom_GiveItemOrDoll`, which is `DecorationFlagAction_c` on a
+## `DECO_*` id rather than on a `DECOFLAG_*`: the row names the decoration.
+func test_mom_buys_a_doll_straight_into_the_room() -> void:
+	_write_service_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var savings: int = Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY
+	world.state.set_mom_purchase(1, 0, world.state.mom_item_trigger_balance())
+	world.state.apply_changes({}, {}, {"money": {savings: 10000}})
+
+	var bought: Dictionary = world.mom_purchase()
+	assert_true(bool(bought["bought"]), JSON.stringify(bought))
+	assert_true(bool(bought["doll"]))
+	assert_true(Gen2WorldDecoration.owns(data, world.state, 30))
+	assert_eq(world.state.money(savings), 8200)
+	assert_eq(world.state.mom_item_index(), 2, "past the last ladder row")
+
+	## `CheckBalance_MomItem2` falls straight through once the ladder is spent.
+	world.state.apply_changes({}, {}, {"money": {savings: 8201}})
+	assert_false(bool(world.mom_purchase()["bought"]))
+
+
+## `.check_have_2300`: past the ladder, the trigger balance climbs by
+## `MOM_MONEY` until it reaches her savings, and she buys one of `MomItems_1` at
+## random only when it lands on them exactly. The climb is stored either way,
+## because `.AddMoney` writes it before `.less_than` returns.
+func test_mom_picks_at_random_only_on_a_mom_money_boundary() -> void:
+	_write_service_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var savings: int = Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY
+	world.state.set_mom_purchase(2, 0, RomLayout.MOM_MONEY)
+
+	world.state.apply_changes({}, {}, {"money": {savings: 5000}})
+	assert_false(bool(world.mom_purchase()["bought"]), "5000 is not a multiple")
+	assert_eq(
+		world.state.mom_item_trigger_balance(), RomLayout.MOM_MONEY * 3,
+		"and the walk's own climb is kept"
+	)
+
+	world.state.set_mom_purchase(2, 0, RomLayout.MOM_MONEY)
+	world.state.apply_changes({}, {}, {"money": {savings: RomLayout.MOM_MONEY * 4}})
+	var bought: Dictionary = world.mom_purchase()
+	assert_true(bool(bought["bought"]), JSON.stringify(bought))
+	assert_eq(world.state.mom_item_index(), 2, "a random pick leaves the ladder alone")
+	assert_eq(world.state.mom_item_set(), 1)
+	assert_eq(
+		world.state.mom_item_trigger_balance(), RomLayout.MOM_MONEY * 5,
+		"and the next boundary is one step past the one she landed on"
+	)
+
+
+## `GetMapPhoneService`, which is the routine's second test: she cannot ring from
+## a map a phone does not reach, so nothing is bought there either.
+func test_mom_buys_nothing_where_the_phone_has_no_service() -> void:
+	_write_service_cache()
+	var data: GameData = GameData.open_directory(_directory)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	world.current_map.phone_flag = 1
+	world.state.apply_changes(
+		{}, {}, {"money": {Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY: 900}}
+	)
+	var refused: Dictionary = world.mom_purchase()
+	assert_false(bool(refused["bought"]))
+	assert_eq(StringName(refused["reason"]), &"phone_service_unavailable")
+	assert_eq(world.state.mom_item_index(), 0)
 
 
 ## `CheckSpecialPhoneCall` is `CountStep`'s first test and answers with carry,

--- a/tools/checks/decorations.gd
+++ b/tools/checks/decorations.gd
@@ -101,6 +101,22 @@ const EXPECTED_CATEGORIES: Dictionary = {
 }
 
 
+## `DecorationIDs`, transcribed from the source's own list rather than read off
+## the table this check reads: the flag order is not the id order, since the
+## dolls come in front of the big dolls here and behind them there.
+const EXPECTED_IDS: Array[int] = [
+	2, 3, 4, 5,
+	7, 8, 9, 10,
+	12, 13, 14,
+	16, 17, 18, 19,
+	21, 22, 23, 24,
+	30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+	48, 49, 50,
+	26, 27, 28,
+	51, 52,
+]
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	_r.each_game(_verify_game)
@@ -116,9 +132,35 @@ func _verify_game() -> void:
 	for deco: int in EXPECTED.size():
 		_verify_row(data, deco)
 	_verify_categories(data)
-	_r.note("%d decoration rows in %d categories" % [
-		EXPECTED.size(), EXPECTED_CATEGORIES.size(),
+	_verify_ids(data)
+	_r.note("%d decoration rows in %d categories, %d flag indices" % [
+		EXPECTED.size(), EXPECTED_CATEGORIES.size(), EXPECTED_IDS.size(),
 	])
+
+
+## `GetDecorationID`, which is the whole of what `SetSpecificDecorationFlag` and
+## Mystery Gift's copy walk do before they touch a flag. The two trophy dolls sit
+## past `NUM_NON_TROPHY_DECOS`, which is the reason the walk stops short of them.
+func _verify_ids(data: GameData) -> void:
+	for index: int in EXPECTED_IDS.size():
+		var deco: int = Gen2WorldDecoration.decoration_for_flag(data, index)
+		_r.check(
+			deco == EXPECTED_IDS[index],
+			"flag %d names decoration %d, not %d" % [index, deco, EXPECTED_IDS[index]]
+		)
+	_r.check(
+		Gen2WorldDecoration.decoration_for_flag(data, EXPECTED_IDS.size()) == 0,
+		"the run past the table's end answers a decoration"
+	)
+	_r.check(
+		Gen2WorldDecoration.decoration_for_flag(
+			data, Gen2WorldDecoration.DECOFLAG_GOLD_TROPHY_DOLL
+		) == 51
+		and Gen2WorldDecoration.decoration_for_flag(
+			data, Gen2WorldDecoration.DECOFLAG_SILVER_TROPHY_DOLL
+		) == 52,
+		"the two trophy boxes do not reach their own dolls"
+	)
 
 
 func _verify_row(data: GameData, deco: int) -> void:

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -203,6 +203,32 @@ func _verify_field_effects(game_id: StringName, data: GameData) -> void:
 				== Gen2WorldPack.ITEMMENU_CURRENT,
 		"%s: the COIN CASE is not ITEMMENU_CURRENT." % game_id
 	)
+	## The whole of `.Current` past the three repels: the Coin Case above, the
+	## two trophy boxes, and the Blue Card, which is Crystal's alone because
+	## Buena is. A row here that the cache does not make CURRENT is a row the
+	## pack would answer with `.Oak`.
+	var current_rows: Array[int] = [Gen2WorldPack.ITEM_COIN_CASE]
+	current_rows.append_array(Gen2WorldPack.TROPHY_BOXES.keys())
+	if Gen2WorldState.is_crystal_profile(data):
+		current_rows.append(Gen2WorldPack.ITEM_BLUE_CARD)
+	for number: int in current_rows:
+		_r.check(
+			Gen2WorldPack.field_use_kind(data, number) == Gen2WorldPack.ITEMMENU_CURRENT,
+			"%s: $%02X (%s) is not ITEMMENU_CURRENT." % [
+				game_id, number, data.item_name(number),
+			]
+		)
+	for number: int in Gen2WorldPack.TROPHY_BOXES:
+		var deco: int = Gen2WorldDecoration.decoration_for_flag(
+			data, int(Gen2WorldPack.TROPHY_BOXES[number])
+		)
+		_r.check(
+			Gen2WorldDecoration.slot_of(data, deco) \
+				== Gen2WorldDecoration.SLOT_LEFT_ORNAMENT,
+			"%s: $%02X opens on decoration %d, which is not a doll." % [
+				game_id, number, deco,
+			]
+		)
 
 
 ## The three key items whose effect is a `farsjump` at a named map script, each

--- a/tools/checks/phone.gd
+++ b/tools/checks/phone.gd
@@ -24,6 +24,7 @@ func run(r: RefCounted) -> void:
 			continue
 		_contacts(game_id, data)
 		_special_calls(game_id, data)
+		_mom_purchases(game_id, data)
 
 
 ## Every row carries both scripts, and `PHONE_BILL` resolves through the seam
@@ -56,6 +57,120 @@ func _contacts(game_id: StringName, data: GameData) -> void:
 			game_id, String(bill.get("reason", &"unknown")),
 		]
 	)
+
+
+## `MomTriesToBuySomething`'s whole block against `data/items/mom_phone.asm`.
+##
+## The two tables are pinned here rather than read off the cache, so a wrong
+## address fails on content: the ladder's ten triggers and costs, the five she
+## picks between, and which of each is a doll. Both scripts have to reach Mom's
+## own four lines through the `text_far` each `writetext` names, which is the
+## seam a stub collected without its target used to leave blank.
+const EXPECTED_LADDER: Array[Array] = [
+	[900, 600, 1, "SUPER POTION"],
+	[4000, 270, 1, "REPEL"],
+	[7000, 600, 1, "SUPER POTION"],
+	[10000, 1800, 2, "CHARMANDER DOLL"],
+	[15000, 3000, 1, "MOON STONE"],
+	[19000, 600, 1, "SUPER POTION"],
+	[30000, 4800, 2, "CLEFAIRY DOLL"],
+	[40000, 900, 1, "HYPER POTION"],
+	[50000, 8000, 2, "PIKACHU DOLL"],
+	[100000, 22800, 2, "BIG SNORLAX"],
+]
+const EXPECTED_RANDOM: Array[Array] = [
+	[0, 600, 1, "SUPER POTION"],
+	[0, 90, 1, "ANTIDOTE"],
+	[0, 180, 1, "POKé BALL"],
+	[0, 450, 1, "ESCAPE ROPE"],
+	[0, 500, 1, "GREAT BALL"],
+]
+## Her four lines, in `.ItemScript`'s order and then `.DollScript`'s. The first
+## and third are shared, which is what says both pointers were read right.
+const EXPECTED_SCRIPTS: Dictionary = {
+	false: ["Hi, ", "I found a useful", "I bought it with", "It's in your PC."],
+	true: ["Hi, ", "While shopping", "I bought it with", "It's in your room."],
+}
+
+
+func _mom_purchases(game_id: StringName, data: GameData) -> void:
+	for row: Array in [[0, EXPECTED_LADDER], [1, EXPECTED_RANDOM]]:
+		var set_number: int = int(row[0])
+		var expected: Array = row[1]
+		if not _r.check(
+			data.mom_item_count(set_number) == expected.size(),
+			"%s: MomItems set %d holds %d rows, not %d." % [
+				game_id, set_number, data.mom_item_count(set_number), expected.size(),
+			]
+		):
+			continue
+		for index: int in expected.size():
+			_mom_row(game_id, data, set_number, index, expected[index] as Array)
+	for doll: bool in [false, true]:
+		_mom_script(game_id, data, doll)
+	_r.note("%s: Mom's %d ladder rows and %d random rows, both scripts" % [
+		game_id, EXPECTED_LADDER.size(), EXPECTED_RANDOM.size(),
+	])
+
+
+func _mom_row(
+	game_id: StringName, data: GameData, set_number: int, index: int, expected: Array
+) -> void:
+	var actual: Dictionary = data.mom_item(set_number, index)
+	var kind: int = int(actual.get("kind", 0))
+	var item: int = int(actual.get("item", 0))
+	var name: String = Gen2WorldDecoration.decoration_name(data, item) 		if kind == Gen2WorldMomPhone.KIND_DOLL else data.item_name(item)
+	_r.check(
+		int(actual.get("trigger", -1)) == int(expected[0])
+			and int(actual.get("cost", -1)) == int(expected[1])
+			and kind == int(expected[2]) and name == String(expected[3]),
+		"%s: MomItems set %d row %d is %s (%s), not %s." % [
+			game_id, set_number, index, JSON.stringify(actual), name, str(expected),
+		]
+	)
+
+
+func _mom_script(game_id: StringName, data: GameData, doll: bool) -> void:
+	var pointer: Dictionary = data.mom_phone_script(doll)
+	if not _r.check(
+		not pointer.is_empty(),
+		"%s: Mom's %s script is absent." % [game_id, "doll" if doll else "item"]
+	):
+		return
+	var bank: int = int(pointer["bank"])
+	var bytes: PackedByteArray = data.world_script(bank, int(pointer["address"]))
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	var lines: Array[String] = []
+	var offset: int = 0
+	while offset < bytes.size():
+		var command: Dictionary = Gen2WorldScript.command_at(bytes, offset, crystal)
+		if not bool(command.get("ok", false)):
+			break
+		if String(command.get("name", "")) == "writetext":
+			lines.append(String(Gen2TextStream.decode(
+				data.world_text(bank, int(command["address"])), 0, {
+					"far": func(far_bank: int, address: int) -> PackedByteArray:
+						return data.world_text(far_bank, address),
+				}
+			).get("text", "")))
+		offset += int(command["width"])
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal):
+			break
+	var expected: Array = EXPECTED_SCRIPTS[doll]
+	if not _r.check(
+		lines.size() == expected.size(),
+		"%s: Mom's %s script says %d lines, not %d." % [
+			game_id, "doll" if doll else "item", lines.size(), expected.size(),
+		]
+	):
+		return
+	for index: int in expected.size():
+		_r.check(
+			lines[index].begins_with(String(expected[index])),
+			"%s: Mom's %s line %d is \"%s\"." % [
+				game_id, "doll" if doll else "item", index, lines[index],
+			]
+		)
 
 
 ## `CheckSpecialPhoneCall` walks this list by index, so every row must name a

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -87,7 +87,13 @@ func _validate(game_id: StringName) -> bool:
 	var raw_bytes: Dictionary = {}
 	for raw_key: Variant in (text_value as Dictionary):
 		var raw_text: PackedByteArray = _pointer_bytes(data, String(raw_key), true)
-		var decoded: Dictionary = Gen2WorldScript.decode_text(raw_text)
+		## The same `far` resolver [Gen2WorldScriptRunner] builds. Without it every
+		## `text_far` stub reads as unresolved, which counted the cache's own
+		## shape as a defect and hid the ones that really are.
+		var decoded: Dictionary = Gen2TextStream.decode(raw_text, 0, {
+			"far": func(bank: int, address: int) -> PackedByteArray:
+				return data.world_text(bank, address),
+		})
 		if not bool(decoded.get("ok", false)):
 			invalid_text += 1
 			var reason: String = String(decoded.get("reason", "unknown"))


### PR DESCRIPTION
Two rungs of the coverage programme, and the defect underneath each.

## `_DoItemEffect`'s `.Current` half

The Blue Card, the NORMAL BOX and the GORGEOUS BOX were the three rows the pack
answered with OAK's "this isn't the time". They are the whole of `ITEMMENU_CURRENT`
past the three repels and the Coin Case.

Under the boxes is `SetSpecificDecorationFlag`, which runs `GetDecorationID`
first. `DecorationIDs` was not imported at all, so its one existing caller,
Mystery Gift's copy walk, passed a `DECOFLAG_*` index where a `DECO_*` id was
wanted. The two orders are not the same list: the flag order runs the dolls in
front of the big dolls and carries no category headers, so every decoration a
partner sent arrived as a different one. The table is imported and pinned per
cartridge now, and both callers go through it.

## Mom's purchases

`MomTriesToBuySomething` runs after every trainer battle and was absent, so the
bank the player deposits into never bought anything in any of the three games.
The ladder, the random pick past it, the PC item, the doll in the room and the
call she makes are here, on the same `Script_reloadmapafterbattle` branch that
Bill's box-full call sits opposite.

## The far-text collection gap

Mom's four lines are `text_far` stubs. The importer collected a stub and never
followed the command inside it, so the half carrying the words stayed in the
cartridge. Ten texts in the existing corpus were already unreadable for this,
and the check could not see it: it decoded with no resolver, so it counted every
stub as a failure and the real ones were lost in the noise.

## Proof

| | |
|---|---|
| `tools/validate.gd -- all` | 76 topics pass, on all three cartridges |
| GUT, unit and scene tiers | 3812 of 3812 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| Unresolved far text | 0, where it was 10 |
| Cache format | 93; all three re-imported, `Layout verified.` on each |

New sweeps: `DecorationIDs` under the `decorations` topic, Mom's two tables and
both her scripts under `phone`, and the `.Current` rows under `pack`. Each was
confirmed to go red against a deliberately broken input.