### PR TITLE
Put five of the START menu's pages on a second display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ export_credentials.cfg
 # Built iOS plugin libraries. The sources beside them are tracked; the binaries
 # are produced by tools/build_ios_plugin.sh against the engine checkout.
 /ios/plugins/*/*.a
+
+# The same for the Android plugin: the Kotlin beside it is tracked, the library
+# is produced by tools/build_android_plugin.sh.
+/addons/second_screen/bin/

--- a/README.md
+++ b/README.md
@@ -155,6 +155,21 @@ never had.
 Icons come from [Lucide](https://lucide.dev). See
 [docs/THIRD_PARTY.md](docs/THIRD_PARTY.md).
 
+### The second screen
+
+A handheld with two displays -- the AYN Thor and its kind -- puts five of those
+entries on the lower one, with a row of tabs cut from the cartridge's own art
+under them: the Pokedex, the party, the pack, the Pokegear's map and the trainer
+card.
+
+It is a view. The only thing on it that takes a touch is the tab row, and a tab
+is there exactly when the START menu's own gate would have offered its row, so
+the team page appears with the starter and the Pokegear page with the phone
+call. Nothing on the lower screen can change the game.
+
+Settings > Second screen switches it off, or opens the same panel in a desktop
+window on a machine with no such hardware.
+
 ## Controls
 
 The games are played with the eight buttons the hardware had. A key, a
@@ -303,7 +318,7 @@ Exit code `0` means all tests passed. Run one script with `-gselect=<name>`.
 | `game/` | Feature folders with colocated scenes and scripts |
 | `autoload/` | Project singletons |
 | `assets/` | Authored or freely licensed assets; `assets/brand/` has its own README |
-| `addons/` | Third-party plugins |
+| `addons/` | Third-party plugins, and this project's own Android editor plugin |
 | `tests/` | `unit/` is the fast tier, `integration/` drives real screens |
 | `tools/` | Headless developer scripts; `tools/checks/` are validate topics |
 | `roms/` | User cartridges, excluded from Git and Godot imports |
@@ -323,6 +338,11 @@ godot --headless --path . --export-release "Linux" builds/linux/pokerecomp.x86_6
 Tests, tools and GUT are excluded, and `roms/` and the `user://` cache are not
 reachable from an export. Signing identities are placeholders: set the bundle
 identifiers, Android SDK paths and Apple team ID before publishing.
+
+Android builds through gradle, because the second display is reached by a
+platform plugin and a plugin needs one. Install the Android build template from
+the editor, or pass `--install-android-build-template` alongside the export, and
+build the plugin with `tools/build_android_plugin.sh` first.
 
 iOS forbids JIT and runtime native code, so mods must be interpreted GDScript,
 not compiled extensions. The project is therefore GDScript-first. See

--- a/addons/second_screen/export_plugin.gd
+++ b/addons/second_screen/export_plugin.gd
@@ -1,0 +1,52 @@
+@tool
+extends EditorPlugin
+
+## Links the second display's Android library into the gradle build.
+##
+## The library itself is Kotlin, under `kotlin/`, and is built by
+## `tools/build_android_plugin.sh` into `bin/`. Nothing here runs at play time:
+## the game reaches the plugin through [Gen2SecondScreenHost], which asks the
+## engine for the singleton and finds nothing on every other platform.
+
+const LIBRARY: String = "res://addons/second_screen/bin/second_screen.aar"
+
+var _export: AndroidExportPlugin = null
+
+
+func _enter_tree() -> void:
+	_export = AndroidExportPlugin.new()
+	add_export_plugin(_export)
+
+
+func _exit_tree() -> void:
+	if _export != null:
+		remove_export_plugin(_export)
+	_export = null
+
+
+class AndroidExportPlugin extends EditorExportPlugin:
+	func _get_name() -> String:
+		return "second_screen"
+
+	func _supports_platform(platform: EditorExportPlatform) -> bool:
+		return platform is EditorExportPlatformAndroid
+
+	## One library for both targets: the plugin has no DEBUG_ENABLED of its own,
+	## unlike the iOS one, because it links against nothing of the engine's C++.
+	func _get_android_libraries(
+		_platform: EditorExportPlatform, _debug: bool
+	) -> PackedStringArray:
+		if not FileAccess.file_exists(LIBRARY):
+			push_warning(
+				"No second-screen library at %s. Run tools/build_android_plugin.sh."
+					% LIBRARY
+			)
+			return PackedStringArray()
+		return PackedStringArray([LIBRARY])
+
+	## None. The panel is a window on a display the platform already offers this
+	## app, and Android asks for no permission to put one there.
+	func _get_android_permissions(
+		_platform: EditorExportPlatform, _debug: bool
+	) -> PackedStringArray:
+		return PackedStringArray()

--- a/addons/second_screen/export_plugin.gd.uid
+++ b/addons/second_screen/export_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://bmd4hona1rpy3

--- a/addons/second_screen/kotlin/Gen2SecondScreenPlugin.kt
+++ b/addons/second_screen/kotlin/Gen2SecondScreenPlugin.kt
@@ -1,0 +1,277 @@
+package io.github.decryptu.pokerecomp.secondscreen
+
+import android.app.Presentation
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.hardware.display.DisplayManager
+import android.os.Bundle
+import android.view.Display
+import android.view.MotionEvent
+import android.view.View
+import android.view.WindowManager
+import org.godotengine.godot.Godot
+import org.godotengine.godot.plugin.GodotPlugin
+import org.godotengine.godot.plugin.SignalInfo
+import org.godotengine.godot.plugin.UsedByGodot
+import java.nio.ByteBuffer
+
+/**
+ * The lower display of a dual-screen Android handheld, as a bitmap the game
+ * hands over and a touch it hands back.
+ *
+ * This is not a second rendering context. The game draws its lower screen into a
+ * small offscreen viewport and copies the pixels here, and this scales that
+ * picture by a whole number with filtering off. That is what keeps the port on
+ * the compatibility renderer: a shared context would mean a swapchain per
+ * display and a graphics backend that has one.
+ *
+ * Nothing about the AYN Thor is hardcoded. Any secondary display the platform
+ * offers for a Presentation is used, which is the same answer on a Retroid
+ * Pocket 5 or an RG DS, and no display at all is not an error.
+ */
+class Gen2SecondScreenPlugin(godot: Godot) : GodotPlugin(godot) {
+
+    private var presentation: PanelPresentation? = null
+    private var listening = false
+
+    /** Whether the game asked for the panel, so a resume can put it back. */
+    private var requested = false
+
+    // Not "Gen2SecondScreen": a plugin singleton becomes a global name in
+    // GDScript, and that one is already the screen's own class.
+    override fun getPluginName() = "Gen2SecondScreenPanel"
+
+    override fun getPluginSignals(): Set<SignalInfo> = setOf(
+        SignalInfo("panel_connected", Integer::class.java, Integer::class.java),
+        SignalInfo("panel_disconnected"),
+        SignalInfo(
+            "panel_touched",
+            java.lang.Float::class.java,
+            java.lang.Float::class.java
+        )
+    )
+
+    /**
+     * The secondary display's own pixels as `[width, height]`, or an empty array
+     * where there is no second display. The game reads this before it decides on
+     * a canvas, so it is answered without showing anything.
+     */
+    @UsedByGodot
+    fun panel_size(): IntArray {
+        val display = findPanel() ?: return IntArray(0)
+        val mode = display.mode
+        return intArrayOf(mode.physicalWidth, mode.physicalHeight)
+    }
+
+    /** Puts the panel up. Answers false when there is nothing to put it on. */
+    @UsedByGodot
+    fun open(): Boolean {
+        if (findPanel() == null) return false
+        requested = true
+        activity?.runOnUiThread { show() }
+        return true
+    }
+
+    @UsedByGodot
+    fun close() {
+        requested = false
+        activity?.runOnUiThread { dismiss() }
+    }
+
+    /**
+     * One frame, as [width] x [height] pixels of RGBA8, which is the byte order
+     * an ARGB_8888 bitmap already stores.
+     *
+     * Called from the game thread; the copy happens here and the draw on the UI
+     * thread, so a frame is never half-written while it is being scaled.
+     */
+    @UsedByGodot
+    fun present(pixels: ByteArray, width: Int, height: Int) {
+        if (width <= 0 || height <= 0) return
+        if (pixels.size < width * height * BYTES_PER_PIXEL) return
+        val panel = presentation ?: return
+        panel.submit(pixels, width, height)
+    }
+
+    /**
+     * Resolved on demand rather than kept from `onMainCreate`: the game asks
+     * whether there is a panel as soon as its first world is built, and on some
+     * devices that is the same frame the activity is still being set up on.
+     */
+    private fun displays(): DisplayManager? {
+        val manager =
+            activity?.getSystemService(Context.DISPLAY_SERVICE) as? DisplayManager ?: return null
+        if (!listening) {
+            listening = true
+            manager.registerDisplayListener(displayListener, null)
+        }
+        return manager
+    }
+
+    override fun onMainResume() {
+        super.onMainResume()
+        if (requested) activity?.runOnUiThread { show() }
+    }
+
+    override fun onMainPause() {
+        super.onMainPause()
+        activity?.runOnUiThread { dismiss() }
+    }
+
+    override fun onMainDestroy() {
+        if (listening) {
+            displays()?.unregisterDisplayListener(displayListener)
+            listening = false
+        }
+        close()
+        super.onMainDestroy()
+    }
+
+    private val displayListener = object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) {
+            if (requested) activity?.runOnUiThread { show() }
+        }
+
+        override fun onDisplayChanged(displayId: Int) {}
+
+        override fun onDisplayRemoved(displayId: Int) {
+            if (presentation?.display?.displayId != displayId) return
+            activity?.runOnUiThread { dismiss() }
+            emitSignal("panel_disconnected")
+        }
+    }
+
+    /**
+     * The display a Presentation may be put on: the platform's own list first,
+     * since that is the one that excludes mirrors and untrusted displays, and
+     * any display that is not the default after it.
+     */
+    private fun findPanel(): Display? {
+        val manager = displays() ?: return null
+        val offered = manager.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
+        if (offered.isNotEmpty()) return offered[0]
+        return manager.displays.firstOrNull { it.displayId != Display.DEFAULT_DISPLAY }
+    }
+
+    private fun show() {
+        if (presentation != null || !requested) return
+        val host = activity ?: return
+        val display = findPanel() ?: return
+        val panel = PanelPresentation(host, display)
+        try {
+            panel.show()
+        } catch (_: WindowManager.BadTokenException) {
+            return
+        } catch (_: WindowManager.InvalidDisplayException) {
+            return
+        }
+        presentation = panel
+        val mode = display.mode
+        emitSignal("panel_connected", mode.physicalWidth, mode.physicalHeight)
+    }
+
+    private fun dismiss() {
+        presentation?.dismiss()
+        presentation = null
+    }
+
+    private inner class PanelPresentation(context: Context, display: Display) :
+        Presentation(context, display) {
+
+        private lateinit var surface: PanelView
+
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            setCancelable(false)
+            surface = PanelView(context)
+            setContentView(surface)
+            window?.setBackgroundDrawableResource(android.R.color.black)
+            window?.decorView?.systemUiVisibility =
+                View.SYSTEM_UI_FLAG_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+        }
+
+        fun submit(pixels: ByteArray, width: Int, height: Int) {
+            if (!::surface.isInitialized) return
+            surface.submit(pixels, width, height)
+        }
+    }
+
+    /**
+     * The panel itself: one bitmap, scaled by the largest whole number that fits
+     * and centred, with the leftover painted black.
+     *
+     * Whole numbers only, and filtering off, for the reason the game's own
+     * screen gives: a hardware pixel drawn as a fraction of a panel pixel
+     * crawls when the picture moves.
+     */
+    private inner class PanelView(context: Context) : View(context) {
+        private var bitmap: Bitmap? = null
+        private val paint = Paint().apply {
+            isFilterBitmap = false
+            isAntiAlias = false
+            isDither = false
+        }
+        private val source = Rect()
+        private val target = Rect()
+
+        fun submit(pixels: ByteArray, width: Int, height: Int) {
+            synchronized(this) {
+                var image = bitmap
+                if (image == null || image.width != width || image.height != height) {
+                    image = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+                    bitmap = image
+                    source.set(0, 0, width, height)
+                }
+                image.copyPixelsFromBuffer(ByteBuffer.wrap(pixels))
+            }
+            postInvalidateOnAnimation()
+        }
+
+        override fun onDraw(canvas: Canvas) {
+            canvas.drawColor(Color.BLACK)
+            val image = synchronized(this) { bitmap } ?: return
+            layoutTarget(image.width, image.height)
+            canvas.drawBitmap(image, source, target, paint)
+        }
+
+        private fun layoutTarget(imageWidth: Int, imageHeight: Int) {
+            val scale = maxOf(1, minOf(width / imageWidth, height / imageHeight))
+            val drawnWidth = imageWidth * scale
+            val drawnHeight = imageHeight * scale
+            val left = (width - drawnWidth) / 2
+            val top = (height - drawnHeight) / 2
+            target.set(left, top, left + drawnWidth, top + drawnHeight)
+        }
+
+        override fun onTouchEvent(event: MotionEvent): Boolean {
+            if (event.actionMasked != MotionEvent.ACTION_DOWN &&
+                event.actionMasked != MotionEvent.ACTION_POINTER_DOWN
+            ) {
+                return true
+            }
+            val image = synchronized(this) { bitmap } ?: return true
+            layoutTarget(image.width, image.height)
+            val scale = maxOf(1, target.width() / image.width)
+            // Reported in the presented picture's own pixels: the game laid its
+            // tab row out in those and knows nothing about this panel's size.
+            val x = (event.getX(event.actionIndex) - target.left) / scale
+            val y = (event.getY(event.actionIndex) - target.top) / scale
+            if (x < 0f || y < 0f || x >= image.width || y >= image.height) return true
+            emitSignal("panel_touched", x, y)
+            return true
+        }
+    }
+
+    private companion object {
+        const val BYTES_PER_PIXEL = 4
+    }
+}

--- a/addons/second_screen/plugin.cfg
+++ b/addons/second_screen/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Second screen"
+description="Puts the lower display of a dual-screen Android handheld into the Android build."
+author="pokerecomp"
+version="1.0"
+script="export_plugin.gd"

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -98,7 +98,7 @@ dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
-exclude_filter="tests/*, tools/*, addons/gut/*, artifacts/*, mods/*, *.md"
+exclude_filter="tests/*, tools/*, addons/gut/*, addons/second_screen/*, artifacts/*, mods/*, *.md"
 export_path="builds/android/pokerecomp.apk"
 encryption_include_filters=""
 encryption_exclude_filters=""
@@ -109,7 +109,7 @@ script_export_mode=2
 
 [preset.3.options]
 
-gradle_build/use_gradle_build=false
+gradle_build/use_gradle_build=true
 gradle_build/export_format=0
 gradle_build/min_sdk=""
 gradle_build/target_sdk=""

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -95,6 +95,21 @@ func _build() -> void:
 			_options.screen_fill = index == 1
 			_persist()
 	)))
+	app.add_child(Gen2LauncherUI.field(_theme, "Second screen", Gen2LauncherUI.segmented(
+		_theme, _titles(Gen2Options.SECOND_SCREENS),
+		maxi(Gen2Options.SECOND_SCREENS.find(_options.second_screen), 0),
+		func(index: int) -> void:
+			_options.second_screen = Gen2Options.SECOND_SCREENS[index]
+			_persist()
+	)))
+	app.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"A handheld with a lower panel gets the map, the team, the pack, the "
+		+ "Pokedex and the trainer card on it, with a row of tabs to pick between "
+		+ "them. It is a view: nothing on it takes a button, and a page appears "
+		+ "only once the START menu would have offered it. Window opens the same "
+		+ "panel in a desktop window instead."
+	))
 	app.add_child(Gen2LauncherUI.muted(
 		_theme,
 		"Fill gives every screen the whole window instead of black bars. The "

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -56,6 +56,11 @@ const GAME_SPEEDS: Array[StringName] = [&"normal", &"double", &"half"]
 ## GAME_SPEEDS]. See [method speed_scale].
 const GAME_SPEED_SCALES: Array[float] = [1.0, 2.0, 0.5]
 const FPS_CHOICES: Array[int] = [30, 60, 120, 144, 0]
+## What a second display is offered. `auto` uses a real lower panel where the
+## platform reports one and does nothing anywhere else; `window` opens a desktop
+## window as well, which is how the panel is looked at on a machine that has no
+## such hardware; `off` never builds one.
+const SECOND_SCREENS: Array[StringName] = [&"auto", &"window", &"off"]
 const UI_THEMES: Array[StringName] = [&"light", &"dark"]
 ## `auto` shows the on-screen controller while the player is using the
 ## touchscreen and hides it the moment they press a key or a pad. `never` is for
@@ -90,6 +95,8 @@ var screen_fill: bool = true
 ## because it is a view preference rather than part of a run.
 var zoom_step: int = 0
 var max_fps: int = 60
+## See [constant SECOND_SCREENS] and [Gen2SecondScreenHost].
+var second_screen: StringName = &"auto"
 var game_speed: StringName = &"normal"
 var ui_theme: StringName = &"light"
 ## Button bindings, in the shape [Gen2InputActions] stores. Held as data rather
@@ -209,6 +216,7 @@ func to_dict() -> Dictionary:
 		"screen_fill": screen_fill,
 		"zoom_step": zoom_step,
 		"max_fps": max_fps,
+		"second_screen": String(second_screen),
 		"game_speed": String(game_speed),
 		"ui_theme": String(ui_theme),
 		"rules": rules.to_dict(),
@@ -247,6 +255,7 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.ui_theme = _one_of(row.get("ui_theme", ""), UI_THEMES)
 	var fps: int = int(row.get("max_fps", 60))
 	options.max_fps = fps if FPS_CHOICES.has(fps) else 60
+	options.second_screen = _one_of(row.get("second_screen", ""), SECOND_SCREENS)
 	options.rules = Gen2Rules.parse(row.get("rules"))
 	options.controls = Gen2InputActions.sanitize(row.get("controls"))
 	options.mod_controls = Gen2InputActions.sanitize_mod_controls(row.get("mod_controls"))

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -1,0 +1,542 @@
+class_name Gen2SecondScreen
+extends Control
+
+## The lower display: one of the game's own pages, with a row of tabs under it.
+##
+## Every page here is the screen the START menu opens, built and drawn exactly
+## as the overworld builds it, and then never handed a button. That is what
+## "read only" means in this file: the pages are not copies with a viewer's
+## shortcuts taken out, they are the same nodes with no input routed to them, so
+## a page cannot drift from the one the player sees on the top screen and cannot
+## change anything either.
+##
+## The tab row is the one thing that takes a touch. It moves the cursor in
+## [Gen2SecondScreenTabs] and nothing else; which tabs exist at all is the START
+## menu's own gate, so a page appears on the frame the cartridge would have
+## offered it and not before.
+##
+## Everything is drawn inside a [SubViewport] the size of [member canvas_size],
+## in hardware pixels, because that is what a host has to hand a display: a
+## second panel is reached by a bitmap and a scale factor, and a canvas of a few
+## hundred pixels a side is a copy small enough to make sixty times a second
+## where the panel's own 1240x1080 is not.
+
+## The page, which is the cartridge's own screen and never another size.
+const PAGE_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+## The underline that says which tab is open: two rows at the foot of the tab
+## row, inset so two neighbouring tabs never touch.
+const UNDERLINE_HEIGHT: int = 2
+const UNDERLINE_INSET: int = 4
+## The shortest tab row that still fits the tallest icon with a little air and
+## that underline. A host with a taller panel gets a taller row.
+const MIN_TAB_HEIGHT: int = Gen2SecondScreenTabs.ICON_MAX + UNDERLINE_HEIGHT + 6
+const CANVAS_MIN := Vector2i(PAGE_SIZE.x, PAGE_SIZE.y + MIN_TAB_HEIGHT)
+
+const FIELD_COLOR := Color(0.0, 0.0, 0.0, 1.0)
+const MARK_COLOR := Color(1.0, 1.0, 1.0, 1.0)
+
+## Emitted after the shown page changes, so a host knows a still picture is worth
+## sending again even when nothing is animating.
+signal page_changed(kind: StringName)
+
+## The whole drawn surface, in hardware pixels. Never smaller than
+## [constant CANVAS_MIN]: the page is a fixed 160x144 and the tab row has to hold
+## an icon.
+var canvas_size: Vector2i = CANVAS_MIN:
+	set(value):
+		var clamped := Vector2i(
+			maxi(value.x, CANVAS_MIN.x), maxi(value.y, CANVAS_MIN.y)
+		)
+		if canvas_size == clamped:
+			return
+		canvas_size = clamped
+		_relayout()
+
+var _data: GameData = null
+var _world: Gen2WorldAPI = null
+var _save: Gen2SaveData = null
+var _tabs := Gen2SecondScreenTabs.new()
+
+var _viewport: SubViewport = null
+var _screen: Gen2Screen = null
+var _strip: Control = null
+## The page on screen, whichever of the cartridge's screens it is, and which tab
+## built it. Kept so a rebuild is skipped when the answer would be the same node.
+var _page: Node = null
+var _page_kind: StringName = &""
+## The tab row's icons, one [TextureRect] per tab, rebuilt with the tab set.
+var _icons: Array[TextureRect] = []
+## What [method _gate] answered when the row was last built.
+var _gate_read: String = ""
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	_build()
+	## A caller may hand over the world before this is in the tree, which is what
+	## a tool building the screen in `_initialize` does. The world is kept either
+	## way and read here once there is something to draw it into.
+	refresh()
+
+
+## The world this mirrors. Called once by the host that owns the overworld; every
+## later change is picked up by [method refresh].
+func set_world(data: GameData, world: Gen2WorldAPI, save: Gen2SaveData) -> void:
+	_data = data
+	_world = world
+	_save = save
+	refresh()
+
+
+## Re-reads the world: which tabs are open, and whether the page on screen is
+## still the one the cursor names.
+##
+## Called every hardware frame and does nothing on almost all of them: the gates
+## are three numbers and the row's one live picture is the party's lead, so the
+## whole question is a short string. Rebuilding the START menu here instead would
+## allocate one per frame for an answer that changes about six times a game.
+func refresh() -> void:
+	if _viewport == null:
+		return
+	var gate: String = _gate()
+	if gate == _gate_read:
+		return
+	_gate_read = gate
+	var chosen: StringName = _tabs.selected_kind()
+	_tabs = Gen2SecondScreenTabs.from_world(_world)
+	if not chosen.is_empty():
+		_tabs.select(chosen)
+	_build_row()
+	if _tabs.selected_kind() != _page_kind:
+		_build_page()
+
+
+## Everything the tab row is a function of: the three gates `SetUpMenuItems`
+## reads, and the lead the #MON tab wears.
+func _gate() -> String:
+	if _world == null or _world.state == null:
+		return ""
+	return "%d|%d|%d|%d|%d" % [
+		int(_world.party_summary().get("count", 0)),
+		int(_world.state.is_engine_flag_active(Gen2WorldStartMenu.ENGINE_POKEDEX)),
+		int(_world.state.is_engine_flag_active(Gen2WorldStartMenu.ENGINE_POKEGEAR)),
+		_lead_species(),
+		int(_lead_is_egg()),
+	]
+
+
+## Which tab a tap at [param at] landed on, counting from zero, or -1 for a tap
+## that missed the row.
+##
+## Static and pure, so where a touch lands is asserted without a display: the row
+## is the only part of this screen that takes one.
+static func tab_index_at(at: Vector2, canvas: Vector2i, count: int) -> int:
+	if count <= 0 or canvas.x <= 0:
+		return -1
+	if at.y < float(PAGE_SIZE.y) or at.y >= float(canvas.y):
+		return -1
+	if at.x < 0.0 or at.x >= float(canvas.x):
+		return -1
+	## The inverse of [method tab_cell]'s own division rather than a second one:
+	## a cell starts at `index * width / count`, so the tab a pixel is in is the
+	## largest index whose start is not past it. Dividing the pixel by the count
+	## instead disagrees with the cells wherever the width does not divide evenly.
+	return ((int(at.x) + 1) * count - 1) / canvas.x
+
+
+## One tab's share of the row, in canvas pixels. Whole pixels, and the last cell
+## takes whatever the division left over, so the row is exactly as wide as the
+## canvas.
+static func tab_cell(index: int, canvas: Vector2i, count: int) -> Rect2i:
+	var tabs: int = maxi(count, 1)
+	var left: int = index * canvas.x / tabs
+	var right: int = (index + 1) * canvas.x / tabs
+	return Rect2i(left, 0, right - left, maxi(canvas.y - PAGE_SIZE.y, 0))
+
+
+## The tab the tap at [param at] landed on, in canvas pixels, or the empty name
+## for a tap that missed the row.
+##
+## Public because a host on a real panel converts its own touch to these pixels
+## and a test drives it without one.
+func tab_at(at: Vector2) -> StringName:
+	var index: int = tab_index_at(at, canvas_size, _tabs.size())
+	if index < 0:
+		return &""
+	return StringName((_tabs.items()[index] as Dictionary).get("kind", &""))
+
+
+## A touch on the tab row, in canvas pixels. Answers whether it opened a page.
+##
+## The only input this screen accepts, and the reason it stays read only: there
+## is no path from here into a page.
+func touch(at: Vector2) -> bool:
+	var kind: StringName = tab_at(at)
+	if kind.is_empty() or kind == _tabs.selected_kind():
+		return false
+	if not _tabs.select(kind):
+		return false
+	_build_page()
+	return true
+
+
+## Opens [param kind], answering whether that tab exists. For a preview or a
+## check driving the panel without a touch; a player reaches it through
+## [method touch].
+func select_tab(kind: StringName) -> bool:
+	if not _tabs.select(kind):
+		return false
+	if kind != _page_kind:
+		_build_page()
+	return true
+
+
+## The tab the cursor is on, for a host reporting what the panel shows.
+func selected_kind() -> StringName:
+	return _tabs.selected_kind()
+
+
+## The drawn surface as pixels, which is what a panel behind a bitmap is handed.
+## Null before the viewport has drawn a frame.
+func frame() -> Image:
+	if _viewport == null:
+		return null
+	var texture: ViewportTexture = _viewport.get_texture()
+	return texture.get_image() if texture != null else null
+
+
+## The viewport itself, for a host that can show it directly rather than copy it.
+func viewport() -> SubViewport:
+	return _viewport
+
+
+func _build() -> void:
+	Gen2Screen.drop_children(self)
+	## A [SubViewportContainer] is not used: it would size the viewport to
+	## whatever the control is, and the canvas is a fixed count of hardware
+	## pixels that the display scales rather than a resolution the window picks.
+	_viewport = SubViewport.new()
+	_viewport.name = "Viewport"
+	_viewport.transparent_bg = false
+	_viewport.disable_3d = true
+	_viewport.render_target_update_mode = SubViewport.UPDATE_ALWAYS
+	add_child(_viewport)
+	var shown := TextureRect.new()
+	shown.name = "Shown"
+	shown.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	shown.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	shown.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+	shown.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	shown.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	shown.texture = _viewport.get_texture()
+	add_child(shown)
+
+	var field := ColorRect.new()
+	field.name = "Field"
+	field.color = FIELD_COLOR
+	field.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_viewport.add_child(field)
+
+	var scene: PackedScene = load(Gen2Screen.SCENE_PATH) as PackedScene
+	_screen = scene.instantiate() as Gen2Screen if scene != null else null
+	if _screen != null:
+		_screen.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		## The packed scene anchors to its parent's whole rectangle, which inside
+		## a viewport is the whole canvas. The page is a fixed 160x144 placed in
+		## it, so the anchors are cleared before [method _relayout] positions it.
+		_screen.set_anchors_and_offsets_preset(Control.PRESET_TOP_LEFT)
+		## The packed scene also grows in both directions, which would move the
+		## page's own corner every time its size was set.
+		_screen.grow_horizontal = Control.GROW_DIRECTION_END
+		_screen.grow_vertical = Control.GROW_DIRECTION_END
+		_viewport.add_child(_screen)
+
+	_strip = Control.new()
+	_strip.name = "Tabs"
+	_strip.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_strip.draw.connect(_draw_strip)
+	_viewport.add_child(_strip)
+	_relayout()
+	_build_row()
+	_build_page()
+
+
+func _relayout() -> void:
+	if _viewport == null:
+		return
+	_viewport.size = canvas_size
+	var field: ColorRect = _viewport.get_node_or_null(^"Field") as ColorRect
+	if field != null:
+		field.size = Vector2(canvas_size)
+	if _screen != null:
+		## The page is the hardware's own rectangle, centred across a canvas that
+		## may be wider. It is given exactly its own size, so the screen inside
+		## it draws at one whole pixel per hardware pixel.
+		_screen.size = Vector2(PAGE_SIZE)
+		_screen.position = Vector2(float((canvas_size.x - PAGE_SIZE.x) / 2), 0.0)
+	if _strip != null:
+		_strip.position = Vector2(0.0, float(PAGE_SIZE.y))
+		_strip.size = Vector2(float(canvas_size.x), float(canvas_size.y - PAGE_SIZE.y))
+		_strip.queue_redraw()
+	_place_icons()
+
+
+## The party's lead, whose menu icon is the #MON tab's. Zero for an empty party,
+## which is also when that tab is absent.
+func _lead_species() -> int:
+	if _world == null:
+		return 0
+	var summary: Dictionary = _world.party_summary()
+	var species: Variant = summary.get("species", [])
+	if not species is Array or (species as Array).is_empty():
+		return 0
+	return int((species as Array)[0])
+
+
+func _lead_is_egg() -> bool:
+	if _world == null:
+		return false
+	var eggs: Variant = _world.party_summary().get("eggs", [])
+	if not eggs is Array or (eggs as Array).is_empty():
+		return false
+	return bool((eggs as Array)[0])
+
+
+## `wPlayerGender`, which picks Kris's pack, her card picture and her palettes.
+func _is_female() -> bool:
+	if _world != null:
+		return _world.player_female()
+	return _save != null and _save.gender == Gen2SaveData.GENDER_FEMALE
+
+
+func _build_row() -> void:
+	for icon: TextureRect in _icons:
+		Gen2Screen.drop(icon)
+	_icons = []
+	var female: bool = _is_female()
+	for entry: Dictionary in _tabs.items():
+		var kind: StringName = StringName(entry.get("kind", &""))
+		var picture: Image = Gen2SecondScreenTabs.icon(
+			_data, kind, _lead_species(), female, _lead_is_egg()
+		)
+		var rect := TextureRect.new()
+		rect.name = String(kind)
+		rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+		## Each icon is the size of the picture the cartridge draws rather than a
+		## common cell, so a bag is a bag rather than a crop of one. A cache that
+		## cannot supply one leaves the cell empty and still counted, so the row
+		## keeps its shape.
+		rect.size = Vector2(
+			Gen2SecondScreenTabs.ICON_SIZE, Gen2SecondScreenTabs.ICON_SIZE
+		)
+		if picture != null:
+			Gen2PicImage.show(rect, picture)
+			rect.size = Vector2(picture.get_size())
+		_strip.add_child(rect)
+		_icons.append(rect)
+	_place_icons()
+
+
+func _place_icons() -> void:
+	if _strip == null or _icons.is_empty():
+		return
+	var room: float = _strip.size.y - UNDERLINE_HEIGHT
+	for index: int in _icons.size():
+		var cell: Rect2 = _cell(index)
+		var icon: TextureRect = _icons[index]
+		icon.position = Vector2(
+			cell.position.x + floorf((cell.size.x - icon.size.x) * 0.5),
+			maxf(floorf((room - icon.size.y) * 0.5), 0.0),
+		)
+
+
+func _cell(index: int) -> Rect2:
+	return Rect2(tab_cell(index, canvas_size, _icons.size()))
+
+
+func _draw_strip() -> void:
+	if _strip == null:
+		return
+	_strip.draw_rect(Rect2(Vector2.ZERO, _strip.size), FIELD_COLOR)
+	if _icons.is_empty():
+		return
+	var cell: Rect2 = _cell(_tabs.cursor)
+	_strip.draw_rect(
+		Rect2(
+			Vector2(cell.position.x + UNDERLINE_INSET, _strip.size.y - UNDERLINE_HEIGHT),
+			Vector2(maxf(cell.size.x - UNDERLINE_INSET * 2, 1.0), UNDERLINE_HEIGHT),
+		),
+		MARK_COLOR
+	)
+
+
+## Replaces the page with the one the cursor names. Every branch builds the
+## overworld's own screen the way the overworld builds it, less the signal
+## connections: nothing here listens for a page closing, because nothing here
+## can close one.
+func _build_page() -> void:
+	if _screen == null:
+		return
+	if _page != null:
+		Gen2Screen.drop(_page)
+		_page = null
+	_screen.clear()
+	_page_kind = _tabs.selected_kind()
+	match _page_kind:
+		Gen2WorldStartMenu.ITEM_POKEDEX:
+			_page = _build_pokedex()
+		Gen2WorldStartMenu.ITEM_POKEMON:
+			_page = _build_party()
+		Gen2WorldStartMenu.ITEM_PACK:
+			_page = _build_pack()
+		Gen2WorldStartMenu.ITEM_POKEGEAR:
+			_page = _build_pokegear()
+		Gen2WorldStartMenu.ITEM_PLAYER:
+			_page = _build_trainer_card()
+	if _strip != null:
+		_strip.queue_redraw()
+	page_changed.emit(_page_kind)
+
+
+func _build_pokedex() -> Node:
+	if _data == null or _world == null:
+		return null
+	var host := Gen2PokedexScreen.new()
+	if not host.open(_data, _world):
+		host.free()
+		return null
+	host.set_screen(_screen)
+	_viewport.add_child(host)
+	return host
+
+
+func _build_party() -> Node:
+	if _data == null or _save == null:
+		return null
+	var scene: PackedScene = load("res://game/save/party_screen.tscn") as PackedScene
+	var host: Gen2PartyScreen = scene.instantiate() as Gen2PartyScreen if scene != null \
+		else null
+	if host == null:
+		return null
+	host.set_context(_data, _save, true)
+	host.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	host.set_screen(_screen)
+	_viewport.add_child(host)
+	return host
+
+
+## The pack has no screen of its own: the START menu owns it as a mode, and that
+## mode is a cursor this display does not have. The listing is therefore built
+## straight off [Gen2WorldPack] and [Gen2PackPage], which is what the START menu
+## draws too, with the cursor left on the first row.
+func _build_pack() -> Node:
+	if _data == null or _world == null or _world.state == null:
+		return null
+	var page: Gen2PackPage = Gen2PackPage.from_data(_data)
+	if page == null or not page.ready():
+		return null
+	var pockets: Array = Gen2WorldPack.build(_data, _world.state)
+	if pockets.is_empty():
+		return null
+	var pocket: Dictionary = pockets[0]
+	var items: Array = pocket.get("items", [])
+	var rows: Array = Gen2WorldPack.list_rows(
+		_data, int(pocket.get("pocket", 0)), items
+	)
+	var description: String = ""
+	if not items.is_empty():
+		description = Gen2WorldPack.row_description(
+			_data, int((items[0] as Dictionary).get("item", 0))
+		)
+	var picture: Image = page.image(
+		_data,
+		page.pocket_map(0, rows, 0, description, _data.pack_pocket_name(0)),
+		0,
+		_is_female(),
+	)
+	if picture == null:
+		return null
+	var rect := TextureRect.new()
+	rect.name = "Pack"
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	rect.size = Vector2(PAGE_SIZE)
+	Gen2PicImage.show(rect, picture)
+	_screen.display(rect)
+	return rect
+
+
+## The MAP card where the player owns it, and the CLOCK card where they do not.
+## Both are cards the Pokegear itself opens on, so this tab shows whatever the
+## cartridge would have shown a player who pressed it.
+func _build_pokegear() -> Node:
+	if _data == null or _world == null or _world.state == null:
+		return null
+	var owned: Array = Gen2PokegearScreen.owned_card_ids(_world.state)
+	var female: bool = _is_female()
+	if owned.has(Gen2PokegearScreen.CARD_MAP):
+		var map := Gen2TownMapScreen.new()
+		map.set_screen(_screen)
+		_viewport.add_child(map)
+		if not map.open(
+			_data,
+			_world.landmark_backup(),
+			_world.state.hall_of_fame(),
+			Gen2TownMap.SCREEN_POKEGEAR_CARD,
+			owned,
+			female,
+			_world.map_time_of_day(),
+		):
+			Gen2Screen.drop(map)
+			return null
+		return map
+	var card := Gen2PokegearScreen.new()
+	card.set_screen(_screen)
+	_viewport.add_child(card)
+	if not card.open(
+		_data,
+		Gen2PokegearScreen.CARD_CLOCK,
+		owned,
+		_data.pokegear_text("press_button"),
+		"",
+		_world.map_time_of_day(),
+	):
+		Gen2Screen.drop(card)
+		return null
+	var clock: Dictionary = _world.world_clock()
+	card.set_clock(
+		int(clock.get("day", 0)), int(clock.get("hour", 0)), int(clock.get("minute", 0))
+	)
+	return card
+
+
+func _build_trainer_card() -> Node:
+	if _data == null or _world == null or _save == null:
+		return null
+	var host := Gen2TrainerCardScreen.new()
+	if not host.open(_data, _world, _save):
+		host.free()
+		return null
+	## The card sizes itself in the 160x144 space, so it goes on the screen's own
+	## interface layer rather than beside it.
+	_screen.display(host)
+	return host
+
+
+func _gui_input(event: InputEvent) -> void:
+	var pressed: Vector2 = Vector2.INF
+	var touched := event as InputEventScreenTouch
+	if touched != null and touched.pressed:
+		pressed = touched.position
+	var clicked := event as InputEventMouseButton
+	if clicked != null and clicked.pressed and clicked.button_index == MOUSE_BUTTON_LEFT:
+		pressed = clicked.position
+	if pressed == Vector2.INF or size.x <= 0.0 or size.y <= 0.0:
+		return
+	## The control may be shown at any size; a tap is reported in canvas pixels
+	## because that is the only space the tab row is laid out in.
+	touch(Vector2(
+		pressed.x * float(canvas_size.x) / size.x,
+		pressed.y * float(canvas_size.y) / size.y
+	))

--- a/game/render/second_screen.gd.uid
+++ b/game/render/second_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://dm2yvmw8j2ayt

--- a/game/render/second_screen_host.gd
+++ b/game/render/second_screen_host.gd
@@ -1,0 +1,233 @@
+class_name Gen2SecondScreenHost
+extends Node
+
+## Puts a [Gen2SecondScreen] on a real second display, and reports touches back.
+##
+## There are two ways a second panel is reached and this owns both, because the
+## screen above must not know which one it got:
+##
+## | Backend | Where it runs | How a frame arrives |
+## |---|---|---|
+## | `panel` | A handheld whose lower display is a secondary Android display | the platform plugin, one bitmap per drawn frame |
+## | `window` | Any desktop | a second [Window] holding the screen itself |
+##
+## The panel backend copies pixels rather than sharing a rendering context, and
+## that is the whole reason [Gen2SecondScreen] draws in hardware pixels instead
+## of the panel's own: a copy of a 206x180 picture is 148 KB and one of a
+## 1240x1080 panel is 5.4 MB, and the far side can scale a bitmap by a whole
+## number for nothing. Sharing a context instead would mean a Vulkan swapchain
+## per display, which this project cannot have while it renders through the
+## compatibility backend.
+##
+## The plugin is named by [constant PLUGIN], and is absent on every platform but
+## Android; [method available] is false there and nothing above this cares.
+
+## The Android plugin singleton. Its contract is four calls and three signals:
+##
+## - `open() -> bool`, `close()`, `panel_size() -> PackedInt32Array` of two
+## - `present(pixels: PackedByteArray, width: int, height: int)`
+## - `panel_connected(width, height)`, `panel_disconnected()`,
+##   `panel_touched(x, y)` in the presented picture's own pixels
+## Not the screen's own class name: a plugin singleton is a global identifier in
+## GDScript, and one that collided would shadow [Gen2SecondScreen] on Android
+## and nowhere else.
+const PLUGIN: String = "Gen2SecondScreenPanel"
+
+## The panel a `window` backend pretends to be, so what is looked at on a desktop
+## is the canvas a real lower display would ask for rather than the smallest one
+## this screen can draw. An AYN Thor's is 1240x1080; a handheld with another one
+## is a whole scale away and the layout does not change.
+const WINDOW_PANEL := Vector2i(1240, 1080)
+## Four whole pixels per hardware pixel, which fits the window on an ordinary
+## laptop. The panel itself gets six.
+const WINDOW_SCALE: int = 4
+
+## The panel is a still page most of the time and a slow animation the rest, so
+## it is copied at half the host's rate rather than every drawn frame. The
+## trainer card's colon and the party's icons are the only things on it that
+## move, and both are slower than this.
+const PANEL_HZ: float = 30.0
+
+const BACKEND_NONE: StringName = &"none"
+const BACKEND_PANEL: StringName = &"panel"
+const BACKEND_WINDOW: StringName = &"window"
+
+var backend: StringName = BACKEND_NONE
+
+var _view: Gen2SecondScreen = null
+var _plugin: Object = null
+var _window: Window = null
+var _since_present: float = 0.0
+
+
+## Attaches [param view] to whatever second display this build can reach, or
+## answers null when there is none.
+##
+## [param mode] is [member Gen2Options.second_screen]. The view is not built
+## here: the world owns it, because it mirrors the world, and this only decides
+## where it is drawn.
+static func attach(view: Gen2SecondScreen, mode: StringName = &"auto") -> Gen2SecondScreenHost:
+	if view == null or mode == &"off":
+		return null
+	var host := Gen2SecondScreenHost.new()
+	host.name = "SecondScreenHost"
+	host._view = view
+	if host._attach_panel():
+		return host
+	if mode == &"window" and host._attach_window():
+		return host
+	host.free()
+	return null
+
+
+## Whether this build can reach a lower panel at all, which is the plugin being
+## present and answering with a size. False on every desktop and on an Android
+## device with one display.
+static func available() -> bool:
+	var plugin: Object = _singleton()
+	if plugin == null:
+		return false
+	return _plugin_panel_size(plugin) != Vector2i.ZERO
+
+
+static func _singleton() -> Object:
+	return Engine.get_singleton(PLUGIN) if Engine.has_singleton(PLUGIN) else null
+
+
+## The plugin answers a pair of integers rather than a [Vector2i]: an Android
+## plugin marshals primitives and arrays, and no engine vector type among them.
+## A plugin singleton is asked rather than interrogated: `has_method` answers
+## false on a [JNISingleton] whose calls all work, so a guard written that way
+## turns every device with a panel into a device without one.
+static func _plugin_panel_size(plugin: Object) -> Vector2i:
+	if plugin == null:
+		return Vector2i.ZERO
+	var size: Variant = plugin.call("panel_size")
+	## Either packed or plain: which of the two an `int[]` arrives as is the
+	## platform's business, and a caller that insists on one gets nothing on a
+	## device that sends the other.
+	if size is PackedInt32Array:
+		var packed: PackedInt32Array = size
+		return Vector2i(packed[0], packed[1]) if packed.size() >= 2 else Vector2i.ZERO
+	if size is Array:
+		var plain: Array = size
+		return Vector2i(int(plain[0]), int(plain[1])) if plain.size() >= 2 else Vector2i.ZERO
+	return Vector2i.ZERO
+
+
+## The panel this is drawn on, in its own pixels, or zero for a `window` backend
+## sized by the desktop.
+func panel_size() -> Vector2i:
+	if backend == BACKEND_PANEL:
+		return _plugin_panel_size(_plugin)
+	if _window != null:
+		return _window.size
+	return Vector2i.ZERO
+
+
+func close() -> void:
+	if _plugin != null:
+		_plugin.call("close")
+	_plugin = null
+	if _window != null:
+		## The view came from the world's own tree and goes back to it, so
+		## closing the window does not take the screen with it.
+		if _view != null and _view.get_parent() == _window:
+			_window.remove_child(_view)
+		_window.queue_free()
+		_window = null
+	backend = BACKEND_NONE
+	set_process(false)
+
+
+func _exit_tree() -> void:
+	close()
+
+
+func _attach_panel() -> bool:
+	_plugin = _singleton()
+	var size: Vector2i = _plugin_panel_size(_plugin)
+	if size == Vector2i.ZERO:
+		_plugin = null
+		return false
+	if _plugin.has_signal("panel_touched"):
+		_plugin.connect("panel_touched", _on_panel_touched)
+	if _plugin.has_signal("panel_disconnected"):
+		_plugin.connect("panel_disconnected", _on_panel_disconnected)
+	if not bool(_plugin.call("open")):
+		_plugin = null
+		return false
+	backend = BACKEND_PANEL
+	_view.canvas_size = canvas_for(size)
+	## The control draws nothing on the game's own window: the panel is fed by
+	## the viewport inside it, which has a size of its own and keeps drawing.
+	_view.position = Vector2.ZERO
+	_view.size = Vector2.ZERO
+	set_process(true)
+	return true
+
+
+func _attach_window() -> bool:
+	if DisplayServer.get_name() == "headless":
+		return false
+	_view.canvas_size = canvas_for(WINDOW_PANEL)
+	var canvas: Vector2i = _view.canvas_size
+	_window = Window.new()
+	_window.title = "pokerecomp: second screen"
+	_window.size = canvas * WINDOW_SCALE
+	_window.content_scale_size = canvas
+	_window.content_scale_mode = Window.CONTENT_SCALE_MODE_VIEWPORT
+	_window.content_scale_aspect = Window.CONTENT_SCALE_ASPECT_KEEP
+	## A machine with a second monitor puts it there, which is the case this
+	## backend is really for; one without gets an ordinary window beside the game.
+	if DisplayServer.get_screen_count() > 1:
+		_window.current_screen = 1
+	add_child(_window)
+	if _view.get_parent() != null:
+		_view.get_parent().remove_child(_view)
+	_view.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	_window.add_child(_view)
+	backend = BACKEND_WINDOW
+	set_process(false)
+	return true
+
+
+## The largest hardware-pixel canvas that fills [param panel] at a whole scale.
+##
+## Whole numbers only, for the reason [Gen2Screen] gives: a hardware pixel drawn
+## as 6.43 screen pixels crawls. The leftover is a bar the far side fills with
+## the field colour, and it is never more than one scale factor wide.
+static func canvas_for(panel: Vector2i) -> Vector2i:
+	var minimum: Vector2i = Gen2SecondScreen.CANVAS_MIN
+	if panel.x < minimum.x or panel.y < minimum.y:
+		return minimum
+	var scale: int = maxi(mini(panel.x / minimum.x, panel.y / minimum.y), 1)
+	return Vector2i(maxi(panel.x / scale, minimum.x), maxi(panel.y / scale, minimum.y))
+
+
+func _process(delta: float) -> void:
+	if backend != BACKEND_PANEL or _view == null or _plugin == null:
+		return
+	_since_present += delta
+	if _since_present < 1.0 / PANEL_HZ:
+		return
+	_since_present = 0.0
+	var picture: Image = _view.frame()
+	if picture == null:
+		return
+	if picture.get_format() != Image.FORMAT_RGBA8:
+		picture.convert(Image.FORMAT_RGBA8)
+	_plugin.call(
+		"present", picture.get_data(), picture.get_width(), picture.get_height()
+	)
+
+
+## A touch reported by the panel, already in the presented picture's own pixels:
+## the plugin knows the scale it drew with and this side never has to.
+func _on_panel_touched(x: float, y: float) -> void:
+	if _view != null:
+		_view.touch(Vector2(x, y))
+
+
+func _on_panel_disconnected() -> void:
+	close()

--- a/game/render/second_screen_host.gd.uid
+++ b/game/render/second_screen_host.gd.uid
@@ -1,0 +1,1 @@
+uid://ck6heqwcquay0

--- a/game/render/second_screen_tabs.gd
+++ b/game/render/second_screen_tabs.gd
@@ -1,0 +1,272 @@
+class_name Gen2SecondScreenTabs
+extends RefCounted
+
+## Which pages a second display may show, and the icon each is reached by.
+##
+## The gate is not this file's: it is [Gen2WorldStartMenu]'s, filtered to the
+## entries that are a picture rather than an action. A tab therefore appears on
+## exactly the frame its START menu row does, so the team page cannot be opened
+## before Elm has handed over a starter and the Pokegear page cannot be opened
+## before the phone call that gives one. SAVE, OPTION and EXIT do something
+## rather than show something, and a mod's own row is a screen this cannot draw,
+## so neither reaches a tab.
+##
+## Node-free: it answers a list and an icon image, and the view decides where to
+## put them.
+
+## The START menu rows that are a page. In `SetUpMenuItems` order, which is the
+## order they are drawn in.
+const VIEWABLE: Array[StringName] = [
+	Gen2WorldStartMenu.ITEM_POKEDEX,
+	Gen2WorldStartMenu.ITEM_POKEMON,
+	Gen2WorldStartMenu.ITEM_PACK,
+	Gen2WorldStartMenu.ITEM_POKEGEAR,
+	Gen2WorldStartMenu.ITEM_PLAYER,
+]
+
+## A species icon is two tiles by two, the size every 16x16 object the cartridge
+## draws is. A crop out of a screen's own sheet is whatever that picture is:
+## `PackGFX`'s bag is 32 by 20 and no smaller rectangle of it reads as a bag.
+## [constant ICON_MAX] is the tallest any of them is, which is what the tab row
+## has to be able to hold.
+const ICON_TILE: int = 8
+const ICON_SIZE: int = ICON_TILE * 2
+const ICON_MAX: int = 20
+
+## Where each tab's icon is cut from: the cache's own sheet name, the top-left
+## pixel in that sheet's own grid, how many tiles wide that grid is, and how many
+## whole pixels one source pixel is drawn as. Every one is art the page it opens
+## already draws:
+##
+## | Tab | Icon |
+## |---|---|
+## | #DEX | the caught marker on the dex listing, which is one tile and so is drawn at two |
+## | PACK | the middle of `PackGFX`'s five-by-three bag |
+## | GEAR | `.PlacePokegearCardIcon`'s MAP icon, tile $40 less [constant RomLayout.POKEGEAR_FIRST_TILE] |
+## | player | the head of `GetCardPic`'s own player picture |
+##
+## #MON has no entry: its icon is the party's lead, read live.
+const ICONS: Dictionary = {
+	Gen2WorldStartMenu.ITEM_POKEDEX: {
+		"sheet": "pokedex", "at": Vector2i(112, 8), "size": Vector2i(8, 8),
+		"stride": 16, "scale": 2,
+	},
+	Gen2WorldStartMenu.ITEM_PACK: {
+		"sheet": "pack", "at": Vector2i(4, 2), "size": Vector2i(32, 20), "stride": 5,
+	},
+	Gen2WorldStartMenu.ITEM_POKEGEAR: {
+		"sheet": "pokegear", "at": Vector2i(0, 8), "stride": 16,
+	},
+	Gen2WorldStartMenu.ITEM_PLAYER: {
+		"sheet": "card_pic", "at": Vector2i(12, 0), "size": Vector2i(24, 20), "stride": 5,
+	},
+}
+
+## `Gen2PackPage.ATTRIBUTES`' last row, which is the palette `_CGB_PackPals`
+## gives the five-by-three picture.
+const PACK_PICTURE_PALETTE: int = 5
+
+var cursor: int = 0
+var _items: Array = []
+
+
+## [param party_count], [param pokedex] and [param pokegear] are the three gates
+## `SetUpMenuItems` reads, and are handed straight to the START menu so the two
+## lists cannot drift. [param player_name] is the STATUS row's own label.
+static func build(
+	party_count: int,
+	pokedex: bool,
+	pokegear: bool,
+	player_name: String = "",
+) -> Gen2SecondScreenTabs:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(
+		party_count, pokedex, pokegear, 0, player_name
+	)
+	var out := Gen2SecondScreenTabs.new()
+	for entry: Dictionary in menu.items():
+		var kind: StringName = StringName(entry.get("kind", &""))
+		if not VIEWABLE.has(kind):
+			continue
+		out._items.append({"kind": kind, "label": String(entry.get("label", ""))})
+	return out
+
+
+## The same list off the live world, the way [method Gen2WorldStartMenu.from_world]
+## reads it. A world with no state has no page at all, which is what a screen
+## opened before the overworld exists shows.
+static func from_world(world: Gen2WorldAPI) -> Gen2SecondScreenTabs:
+	if world == null or world.state == null:
+		return Gen2SecondScreenTabs.new()
+	return build(
+		int(world.party_summary().get("count", 0)),
+		world.state.is_engine_flag_active(Gen2WorldStartMenu.ENGINE_POKEDEX),
+		world.state.is_engine_flag_active(Gen2WorldStartMenu.ENGINE_POKEGEAR),
+		world.player_name(),
+	)
+
+
+func items() -> Array:
+	return _items.duplicate(true)
+
+
+func size() -> int:
+	return _items.size()
+
+
+func is_empty() -> bool:
+	return _items.is_empty()
+
+
+func selected_kind() -> StringName:
+	if cursor < 0 or cursor >= _items.size():
+		return &""
+	return StringName(_items[cursor].get("kind", &""))
+
+
+func has_kind(kind: StringName) -> bool:
+	for entry: Dictionary in _items:
+		if StringName(entry.get("kind", &"")) == kind:
+			return true
+	return false
+
+
+## Puts the cursor on [param kind], answering whether that tab is there. The one
+## way a tap changes the page, so a tab that has not been earned yet cannot be
+## opened by asking for it.
+func select(kind: StringName) -> bool:
+	for index: int in _items.size():
+		if StringName(_items[index].get("kind", &"")) == kind:
+			cursor = index
+			return true
+	return false
+
+
+## What is drawn right now, so a host redrawing on change knows when nothing
+## has. The tab set and the chosen tab are both in it: a gate opening mid-walk
+## adds a tab and moves nothing else.
+func signature() -> String:
+	var parts: Array[String] = []
+	for entry: Dictionary in _items:
+		parts.append(String(entry.get("kind", &"")))
+	return "%s|%s" % [",".join(parts), selected_kind()]
+
+
+## The 16x16 icon for [param kind], or null where the cache cannot supply it.
+##
+## [param species] is the party's lead, which is the #MON tab's own icon and the
+## one that is not a fixed crop; [param female] picks Kris's pack and card
+## picture on a cartridge that carries them.
+static func icon(
+	data: GameData, kind: StringName, species: int = 0, female: bool = false,
+	egg: bool = false
+) -> Image:
+	if data == null:
+		return null
+	if kind == Gen2WorldStartMenu.ITEM_POKEMON:
+		return _species_icon(data, species, egg)
+	var spec: Variant = ICONS.get(kind, null)
+	if not spec is Dictionary:
+		return null
+	var row: Dictionary = spec
+	var strip: PackedByteArray = _sheet(data, String(row["sheet"]), female)
+	var colors: PackedColorArray = _palette(data, kind, female)
+	if strip.is_empty() or colors.size() < Gen2Palette.COLORS_PER_PIC:
+		return null
+	return _crop(
+		strip, int(row["stride"]), row.get("at", Vector2i.ZERO),
+		row.get("size", Vector2i(ICON_SIZE, ICON_SIZE)),
+		int(row.get("scale", 1)), colors, -1
+	)
+
+
+## `ReadMonMenuIcon`'s first frame, drawn with `InitPartyMenuOBPals`' own
+## palette, which is what the party menu puts beside a nickname. The frame is its
+## own two-tile-wide grid, so it is cut exactly like a sheet is.
+static func _species_icon(data: GameData, species: int, egg: bool) -> Image:
+	if species <= 0 and not egg:
+		return null
+	var strip: PackedByteArray = data.species_icon_indices(species, egg)
+	var colors: PackedColorArray = data.party_menu_icon_palette()
+	if strip.is_empty() or colors.size() < Gen2Palette.COLORS_PER_PIC:
+		return null
+	return _crop(
+		strip, 2, Vector2i.ZERO, Vector2i(ICON_SIZE, ICON_SIZE), 1, colors, 0
+	)
+
+
+## The [param extent] rectangle of a sheet at [param at], as one picture, drawn
+## [param scale] whole pixels per source pixel.
+##
+## The cache stores every sheet as a single row of tiles, so a rectangle that
+## crosses a tile boundary is assembled here rather than blitted: [param stride]
+## is how many tiles wide the sheet was before it was flattened, which is the
+## only thing that says where its second row of tiles went.
+##
+## [param skip] is the colour left standing: zero for a species icon, which is an
+## object and never draws its own index 0, and -1 for a background sheet, whose
+## four colours are all drawn.
+static func _crop(
+	strip: PackedByteArray, stride: int, at: Vector2i, extent: Vector2i, scale: int,
+	colors: PackedColorArray, skip: int
+) -> Image:
+	var factor: int = maxi(scale, 1)
+	var out := Vector2i(extent.x * factor, extent.y * factor)
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(out.x, out.y)
+	var lookup: PackedInt32Array = Gen2PicImage.lookup(colors)
+	if stride <= 0 or lookup.is_empty() or out.x <= 0 or out.y <= 0:
+		return Gen2PicImage.canvas_image(pixels, maxi(out.x, 1), maxi(out.y, 1))
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / Gen2Tiles.TILE_HEIGHT
+	for y: int in out.y:
+		@warning_ignore("integer_division")
+		var source_y: int = at.y + y / factor
+		@warning_ignore("integer_division")
+		var row: int = source_y / Gen2Tiles.TILE_HEIGHT
+		var line: int = source_y % Gen2Tiles.TILE_HEIGHT
+		for x: int in out.x:
+			@warning_ignore("integer_division")
+			var source_x: int = at.x + x / factor
+			@warning_ignore("integer_division")
+			var tile: int = row * stride + source_x / Gen2Tiles.TILE_WIDTH
+			var offset: int = line * width \
+				+ tile * Gen2Tiles.TILE_WIDTH + source_x % Gen2Tiles.TILE_WIDTH
+			if offset < 0 or offset >= strip.size():
+				continue
+			var index: int = strip[offset]
+			if index == skip:
+				continue
+			pixels[y * out.x + x] = lookup[mini(index, lookup.size() - 1)]
+	return Gen2PicImage.canvas_image(pixels, out.x, out.y)
+
+
+## The cache's own name for a sheet, which differs from the tab's for the two
+## that have a Kris counterpart.
+static func _sheet(data: GameData, name: String, female: bool) -> PackedByteArray:
+	match name:
+		"pack":
+			var pockets: String = "pack_pockets_female" if female else "pack_pockets"
+			var strip: PackedByteArray = data.tile_indices(pockets)
+			return strip if not strip.is_empty() else data.tile_indices("pack_pockets")
+		"card_pic":
+			var card: String = "card_pic_female" if female else "card_pic_male"
+			var pic: PackedByteArray = data.tile_indices(card)
+			return pic if not pic.is_empty() else data.tile_indices("card_pic_male")
+	return data.tile_indices(name)
+
+
+## The palette the page each icon was cut from draws it with, so a tab is the
+## same colours as the screen it opens.
+static func _palette(data: GameData, kind: StringName, female: bool) -> PackedColorArray:
+	match kind:
+		Gen2WorldStartMenu.ITEM_POKEDEX:
+			return data.pokedex_palette("interface")
+		Gen2WorldStartMenu.ITEM_PACK:
+			var pack: PackedColorArray = data.pack_palette(PACK_PICTURE_PALETTE, female)
+			return pack if not pack.is_empty() else data.pack_palette(PACK_PICTURE_PALETTE)
+		Gen2WorldStartMenu.ITEM_POKEGEAR:
+			return data.town_map_palette(
+				data.town_map_palette_of(RomLayout.POKEGEAR_FIRST_TILE + 0x10), female
+			)
+		Gen2WorldStartMenu.ITEM_PLAYER:
+			return data.card_palette(1 if female else 0)
+	return PackedColorArray()

--- a/game/render/second_screen_tabs.gd.uid
+++ b/game/render/second_screen_tabs.gd.uid
@@ -1,0 +1,1 @@
+uid://c105ewjfh7i32

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -28,6 +28,21 @@ signal deleted(contact: int)
 const CARD_CLOCK: StringName = &"clock"
 const CARD_PHONE: StringName = &"phone"
 const CARD_RADIO: StringName = &"radio"
+## The MAP card, which is [Gen2TownMapScreen] rather than a card drawn here.
+const CARD_MAP: StringName = &"map"
+
+## engine/pokegear/pokegear.asm's card order. Each is behind its own
+## wPokegearFlags bit, named by the engine flag that carries it, since that is
+## what the state holds. The clock card needs no flag.
+##
+## Here rather than in the screen that lists them, because the Pokegear is not
+## the only thing that has to know which cards a player owns.
+const CARDS: Array[Dictionary] = [
+	{"card": CARD_CLOCK, "name": "CLOCK"},
+	{"card": CARD_MAP, "name": "MAP", "flag": Gen2WorldState.ENGINE_MAP_CARD},
+	{"card": CARD_PHONE, "name": "PHONE", "flag": Gen2WorldState.ENGINE_PHONE_CARD},
+	{"card": CARD_RADIO, "name": "RADIO", "flag": Gen2WorldState.ENGINE_RADIO_CARD},
+]
 
 ## `InitPokegearModeIndicatorArrow`'s `depixel 4, 2, 4, 0`, less the hardware's
 ## own OAM offsets and `.OAMData_RedWalk`'s `dbsprite -1, -1`, plus the card's
@@ -96,6 +111,29 @@ var _field: Control = null
 var _background: TextureRect = null
 var _arrow: TextureRect = null
 var _knob_icon: TextureRect = null
+
+
+## [constant CARDS] filtered to what [param state] says the player owns, in
+## source order. An absent state owns the clock alone, which is what the
+## cartridge starts with.
+static func owned_cards(state: Gen2WorldState) -> Array:
+	var out: Array = []
+	for entry: Dictionary in CARDS:
+		if entry.has("flag") and (
+			state == null or not state.is_engine_flag_active(int(entry["flag"]))
+		):
+			continue
+		out.append(entry)
+	return out
+
+
+## The same list as card ids alone, which is what [method Gen2TownMapScreen.open]
+## takes for its card row.
+static func owned_card_ids(state: Gen2WorldState) -> Array:
+	var out: Array = []
+	for entry: Dictionary in owned_cards(state):
+		out.append(StringName(entry.get("card", &"")))
+	return out
 
 
 func _ready() -> void:

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -912,45 +912,13 @@ func _render_pack() -> void:
 	_render_hardware()
 
 
-## The five rows `ScrollingMenu_UpdateDisplay` writes, out of the pocket's own
-## items and the CANCEL row after them. The TM/HM pocket is
-## `TMHM_DisplayPocketItems`, which prints the TM number and the move it teaches
-## rather than the item's name.
 func _pack_rows() -> Array:
-	var items: Array = _current_pocket_items()
-	var tmhm: bool = int(_current_pocket().get("pocket", 0)) == Gen2WorldPack.TYPE_TM_HM
-	var scroll: int = _pack_scroll[_pack_pocket_index]
-	var out: Array = []
-	for offset: int in Gen2PackPage.LIST_HEIGHT:
-		var index: int = scroll + offset
-		if index > items.size():
-			break
-		if index == items.size():
-			out.append({"kind": Gen2PackPage.ROW_CANCEL})
-			break
-		var entry: Dictionary = items[index]
-		var item: int = int(entry.get("item", 0))
-		## `PlaceMenuItemQuantity` asks `_CheckTossableItem`, so a key item and
-		## an HM carry no count on this screen.
-		var row: Dictionary = {
-			"kind": Gen2PackPage.ROW_ITEM,
-			"name": String(entry.get("name", "")),
-			"quantity": int(entry.get("quantity", 0)),
-			"show_quantity": Gen2WorldPack.can_toss(_data, item),
-		}
-		if tmhm:
-			var number: int = RomLayout.tmhm_number_for_item(
-				item, _data.tmhm_moves().size() if _data != null else 0
-			)
-			var hm: bool = Gen2WorldTMHM.is_hm(item)
-			row["kind"] = Gen2PackPage.ROW_TM
-			row["hm"] = hm
-			row["number"] = number - RomLayout.TMHM_TM_COUNT if hm else number
-			row["name"] = _data.move(
-				Gen2WorldTMHM.move_for_item(_data, item)
-			).get("name", "") if _data != null else ""
-		out.append(row)
-	return out
+	return Gen2WorldPack.list_rows(
+		_data,
+		int(_current_pocket().get("pocket", 0)),
+		_current_pocket_items(),
+		_pack_scroll[_pack_pocket_index],
+	)
 
 
 ## The pack as the cartridge draws it. `UpdateItemDescription` prints the item's
@@ -1042,12 +1010,7 @@ func _pack_result_text() -> String:
 func _pack_description() -> String:
 	if _pack_cursor_on_cancel() or _data == null:
 		return ""
-	var item: int = int(_selected_item().get("item", 0))
-	if Gen2WorldTMHM.is_tm_hm(item):
-		return String(_data.move(
-			Gen2WorldTMHM.move_for_item(_data, item)
-		).get("description", ""))
-	return String(_data.item(item).get("description", ""))
+	return Gen2WorldPack.row_description(_data, int(_selected_item().get("item", 0)))
 
 
 ## `wPlayerGender`, which picks Kris's pack and her own palettes.

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -154,6 +154,60 @@ static func source_pocket_name(data: GameData, item: int) -> String:
 	return pocket_name(pocket)
 
 
+## The five rows `ScrollingMenu_UpdateDisplay` writes, out of one pocket's own
+## items and the CANCEL row after them. The TM/HM pocket is
+## `TMHM_DisplayPocketItems`, which prints the TM number and the move it teaches
+## rather than the item's name.
+##
+## Here rather than in the screen that scrolls them, because the pack listing is
+## drawn on more than one screen and only one of them owns a cursor.
+static func list_rows(
+	data: GameData, pocket_type: int, items: Array, scroll: int = 0
+) -> Array:
+	var tmhm: bool = pocket_type == TYPE_TM_HM
+	var out: Array = []
+	for offset: int in Gen2PackPage.LIST_HEIGHT:
+		var index: int = scroll + offset
+		if index > items.size():
+			break
+		if index == items.size():
+			out.append({"kind": Gen2PackPage.ROW_CANCEL})
+			break
+		var entry: Dictionary = items[index]
+		var item: int = int(entry.get("item", 0))
+		## `PlaceMenuItemQuantity` asks `_CheckTossableItem`, so a key item and
+		## an HM carry no count on this screen.
+		var row: Dictionary = {
+			"kind": Gen2PackPage.ROW_ITEM,
+			"name": String(entry.get("name", "")),
+			"quantity": int(entry.get("quantity", 0)),
+			"show_quantity": can_toss(data, item),
+		}
+		if tmhm:
+			var number: int = RomLayout.tmhm_number_for_item(
+				item, data.tmhm_moves().size() if data != null else 0
+			)
+			var hm: bool = Gen2WorldTMHM.is_hm(item)
+			row["kind"] = Gen2PackPage.ROW_TM
+			row["hm"] = hm
+			row["number"] = number - RomLayout.TMHM_TM_COUNT if hm else number
+			row["name"] = data.move(
+				Gen2WorldTMHM.move_for_item(data, item)
+			).get("name", "") if data != null else ""
+		out.append(row)
+	return out
+
+
+## What `UpdateItemDescription` prints under a listing: the item's own text, or
+## the move's on a TM or an HM, which is what `TMHM_ItemDescription` reads.
+static func row_description(data: GameData, item: int) -> String:
+	if data == null or item <= 0:
+		return ""
+	if Gen2WorldTMHM.is_tm_hm(item):
+		return String(data.move(Gen2WorldTMHM.move_for_item(data, item)).get("description", ""))
+	return String(data.item(item).get("description", ""))
+
+
 static func pocket_name(pocket_type: int) -> String:
 	if POCKET_NAMES.has(pocket_type):
 		return String(POCKET_NAMES[pocket_type])

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -306,6 +306,11 @@ var _sound_schedule_frame: int = 0
 var _interface_owned: bool = false
 var _interface_owned_pushed: bool = false
 
+## The lower display and whatever puts it on real hardware. Both null on a
+## machine with one screen, which is every desktop and most phones.
+var _second_screen: Gen2SecondScreen = null
+var _second_screen_host: Gen2SecondScreenHost = null
+
 @onready var _screen: Gen2Screen = %Screen
 @onready var _caption: Label = %Caption
 @onready var _hint: Label = %Hint
@@ -548,7 +553,33 @@ func _build_world() -> void:
 	var entry_results: Array = _world.dispatch_map_entry()
 	if not entry_results.is_empty():
 		_show_script_results(entry_results)
+	_build_second_screen()
 	_refresh_labels()
+
+
+## The lower display, where the build is running on hardware that has one.
+##
+## It mirrors this world and takes no button, so it is built here rather than
+## anywhere a page is opened: the pages on it are the START menu's, and which of
+## them exist is the START menu's gate rather than this screen's business.
+## [method Gen2SecondScreenHost.attach] answers null on every machine with no
+## second display, which is the ordinary case and not a failure.
+func _build_second_screen() -> void:
+	if _second_screen != null:
+		return
+	var view := Gen2SecondScreen.new()
+	view.name = "SecondScreen"
+	add_child(view)
+	view.set_world(_data, _world, active_save())
+	var host: Gen2SecondScreenHost = Gen2SecondScreenHost.attach(
+		view, Gen2OptionsStore.current().second_screen
+	)
+	if host == null:
+		Gen2Screen.drop(view)
+		return
+	add_child(host)
+	_second_screen = view
+	_second_screen_host = host
 
 
 ## Builds the view for the selected renderer and attaches it to the layer that
@@ -810,6 +841,8 @@ func advance_frame() -> void:
 		_world.advance_frame_counter()
 		if _replaying_input:
 			_apply_replayed_input(_world.frame_number)
+	if _second_screen != null:
+		_second_screen.refresh()
 	_advance_game_time_frame()
 	## Before everything the map draws: the fade owns the frame the map swaps on,
 	## and nothing else runs while `RunMapSetupScript` is spending its own.

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -50,16 +50,6 @@ const BOX_SCENE := preload("res://game/save/box_screen.tscn")
 ## and the move tutor open.
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 
-## engine/pokegear/pokegear.asm's card order. Each is behind its own
-## wPokegearFlags bit, named here by the engine flag that carries it, since that
-## is what the state holds. The clock card needs no flag.
-const POKEGEAR_CARDS: Array[Dictionary] = [
-	{"card": &"clock", "name": "CLOCK"},
-	{"card": &"map", "name": "MAP", "flag": Gen2WorldState.ENGINE_MAP_CARD},
-	{"card": &"phone", "name": "PHONE", "flag": Gen2WorldState.ENGINE_PHONE_CARD},
-	{"card": &"radio", "name": "RADIO", "flag": Gen2WorldState.ENGINE_RADIO_CARD},
-]
-
 ## `wPokegearRadioMusicPlaying`, which is what `ExitPokegearRadio_HandleMusic`
 ## branches on: zero while nothing in this overlay has touched the music, and
 ## one of the source's own two values once the radio card has.
@@ -387,13 +377,7 @@ func _open_pokegear(
 	if _world == null or _data == null:
 		_show_error("%s has no world or cartridge cache." % label)
 		return false
-	_pokegear_cards = []
-	for card: Dictionary in POKEGEAR_CARDS:
-		var owned: bool = not card.has("flag") \
-			or _world.state.is_engine_flag_active(int(card["flag"]))
-		if not owned:
-			continue
-		_pokegear_cards.append(card)
+	_pokegear_cards = Gen2PokegearScreen.owned_cards(_world.state)
 	return true
 
 
@@ -2223,9 +2207,7 @@ func _open_town_map(from_request: bool) -> void:
 	_town_map.closed.connect(_on_town_map_closed)
 	# The Pokegear's own MAP card when the Pokegear opened it, `_TownMap`'s
 	# corner box when `OverworldTownMap` did.
-	var owned: Array = []
-	for card: Dictionary in _pokegear_cards:
-		owned.append(StringName(card.get("card", &"")))
+	var owned: Array = Gen2PokegearScreen.owned_card_ids(_world.state)
 	var screen: StringName = Gen2TownMap.SCREEN_TOWN_MAP if from_request \
 		else Gen2TownMap.SCREEN_POKEGEAR_CARD
 	var opened: bool = _town_map.open(

--- a/project.godot
+++ b/project.godot
@@ -36,7 +36,7 @@ window/handheld/orientation=6
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/gut/plugin.cfg", "res://addons/warning_scan/plugin.cfg")
+enabled=PackedStringArray("res://addons/gut/plugin.cfg", "res://addons/second_screen/plugin.cfg", "res://addons/warning_scan/plugin.cfg")
 
 [input_devices]
 

--- a/tests/unit/test_second_screen.gd
+++ b/tests/unit/test_second_screen.gd
@@ -1,0 +1,165 @@
+extends GutTest
+
+## The lower display: which pages it offers, and where a touch lands.
+##
+## Its gate is the START menu's, so what is asserted here is that the two answer
+## the same thing rather than that a second list was copied correctly.
+
+const PLAYER: String = "CHRIS"
+
+
+func _tabs(party: int, pokedex: bool, pokegear: bool) -> Gen2SecondScreenTabs:
+	return Gen2SecondScreenTabs.build(party, pokedex, pokegear, PLAYER)
+
+
+func _kinds(tabs: Gen2SecondScreenTabs) -> Array:
+	var out: Array = []
+	for entry: Dictionary in tabs.items():
+		out.append(StringName(entry["kind"]))
+	return out
+
+
+## A player who has not been to Elm's lab has a pack and a trainer card, which is
+## exactly what `SetUpMenuItems` leaves once its three gates all refuse.
+func test_bedroom_offers_only_the_ungated_pages() -> void:
+	assert_eq(
+		_kinds(_tabs(0, false, false)),
+		[Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER]
+	)
+
+
+func test_the_team_page_waits_for_the_starter() -> void:
+	assert_false(
+		_tabs(0, false, false).has_kind(Gen2WorldStartMenu.ITEM_POKEMON),
+		"an empty party has no team page"
+	)
+	assert_true(
+		_tabs(1, false, false).has_kind(Gen2WorldStartMenu.ITEM_POKEMON),
+		"one Pokemon opens it"
+	)
+
+
+func test_the_dex_and_gear_pages_wait_for_their_engine_flags() -> void:
+	assert_false(_tabs(1, false, false).has_kind(Gen2WorldStartMenu.ITEM_POKEDEX))
+	assert_false(_tabs(1, false, false).has_kind(Gen2WorldStartMenu.ITEM_POKEGEAR))
+	assert_true(_tabs(1, true, false).has_kind(Gen2WorldStartMenu.ITEM_POKEDEX))
+	assert_true(_tabs(1, false, true).has_kind(Gen2WorldStartMenu.ITEM_POKEGEAR))
+
+
+## The tabs are the START menu's own rows in the START menu's own order, less the
+## ones that do something rather than show something.
+func test_every_tab_is_a_start_menu_row_in_source_order() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(3, true, true, 0, PLAYER)
+	var expected: Array = []
+	for entry: Dictionary in menu.items():
+		var kind: StringName = StringName(entry["kind"])
+		if Gen2SecondScreenTabs.VIEWABLE.has(kind):
+			expected.append(kind)
+	assert_eq(_kinds(_tabs(3, true, true)), expected)
+
+
+func test_save_option_and_exit_never_reach_a_tab() -> void:
+	var kinds: Array = _kinds(_tabs(6, true, true))
+	for kind: StringName in [
+		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
+		Gen2WorldStartMenu.ITEM_EXIT,
+	]:
+		assert_false(kinds.has(kind), "%s is an action, not a page" % kind)
+
+
+func test_selecting_a_missing_tab_is_refused() -> void:
+	var tabs: Gen2SecondScreenTabs = _tabs(0, false, false)
+	assert_false(tabs.select(Gen2WorldStartMenu.ITEM_POKEMON))
+	assert_eq(tabs.selected_kind(), Gen2WorldStartMenu.ITEM_PACK)
+	assert_true(tabs.select(Gen2WorldStartMenu.ITEM_PLAYER))
+	assert_eq(tabs.selected_kind(), Gen2WorldStartMenu.ITEM_PLAYER)
+
+
+## A gate opening mid-walk changes the signature, which is what makes a host
+## redraw the row rather than leave a tab the player has just earned off it.
+func test_the_signature_follows_the_tab_set_and_the_chosen_tab() -> void:
+	var before: String = _tabs(0, false, false).signature()
+	assert_ne(before, _tabs(1, false, false).signature(), "a starter adds a tab")
+	var tabs: Gen2SecondScreenTabs = _tabs(1, false, false)
+	var first: String = tabs.signature()
+	tabs.select(Gen2WorldStartMenu.ITEM_PLAYER)
+	assert_ne(first, tabs.signature(), "the chosen tab is in it")
+
+
+## The canvas is the largest whole-scale rectangle that fills the panel, so a
+## hardware pixel is a square block of panel pixels and the leftover is a bar
+## rather than a resampled picture.
+func test_the_canvas_fills_a_panel_at_a_whole_scale() -> void:
+	## The AYN Thor's lower display. 1080 / 172 is 6, and 1240 / 6 is 206.
+	assert_eq(
+		Gen2SecondScreenHost.canvas_for(Vector2i(1240, 1080)), Vector2i(206, 180)
+	)
+
+
+func test_a_panel_smaller_than_the_page_gets_the_smallest_canvas() -> void:
+	assert_eq(
+		Gen2SecondScreenHost.canvas_for(Vector2i(128, 96)),
+		Gen2SecondScreen.CANVAS_MIN
+	)
+	assert_eq(
+		Gen2SecondScreenHost.canvas_for(Vector2i.ZERO), Gen2SecondScreen.CANVAS_MIN
+	)
+
+
+func test_the_canvas_never_loses_the_page_or_the_tab_row() -> void:
+	for panel: Vector2i in [
+		Vector2i(1240, 1080), Vector2i(1280, 720), Vector2i(960, 544),
+		Vector2i(320, 240), Vector2i(1080, 1240),
+	]:
+		var canvas: Vector2i = Gen2SecondScreenHost.canvas_for(panel)
+		assert_true(
+			canvas.x >= Gen2SecondScreen.CANVAS_MIN.x
+				and canvas.y >= Gen2SecondScreen.CANVAS_MIN.y,
+			"%s left room for the page and the row" % panel
+		)
+
+
+const CANVAS := Vector2i(206, 180)
+
+
+## A touch above the row is on the page, and a page takes nothing: that is the
+## whole of what "read only" is enforced by.
+func test_a_touch_on_the_page_lands_on_no_tab() -> void:
+	assert_eq(Gen2SecondScreen.tab_index_at(Vector2(100.0, 0.0), CANVAS, 5), -1)
+	assert_eq(Gen2SecondScreen.tab_index_at(Vector2(100.0, 143.0), CANVAS, 5), -1)
+	assert_eq(Gen2SecondScreen.tab_index_at(Vector2(100.0, 70.0), CANVAS, 5), -1)
+
+
+## Five tabs across 206 pixels: each cell is its own share, and the last one
+## reaches the right edge rather than stopping a pixel short of it.
+func test_the_row_is_split_into_one_cell_per_tab() -> void:
+	var count: int = 5
+	var covered: int = 0
+	for index: int in count:
+		var cell: Rect2i = Gen2SecondScreen.tab_cell(index, CANVAS, count)
+		covered += cell.size.x
+		assert_eq(
+			Gen2SecondScreen.tab_index_at(
+				Vector2(float(cell.position.x), 150.0), CANVAS, count
+			),
+			index, "the left edge of cell %d" % index
+		)
+		assert_eq(
+			Gen2SecondScreen.tab_index_at(
+				Vector2(float(cell.position.x + cell.size.x - 1), 150.0), CANVAS, count
+			),
+			index, "the right edge of cell %d" % index
+		)
+	assert_eq(covered, CANVAS.x, "the cells cover the row exactly")
+
+
+func test_a_touch_off_the_canvas_lands_on_no_tab() -> void:
+	for at: Vector2 in [
+		Vector2(-1.0, 150.0), Vector2(206.0, 150.0), Vector2(100.0, 180.0),
+		Vector2(100.0, -1.0),
+	]:
+		assert_eq(Gen2SecondScreen.tab_index_at(at, CANVAS, 5), -1, str(at))
+
+
+func test_a_row_with_no_tabs_takes_no_touch() -> void:
+	assert_eq(Gen2SecondScreen.tab_index_at(Vector2(100.0, 150.0), CANVAS, 0), -1)

--- a/tests/unit/test_second_screen.gd.uid
+++ b/tests/unit/test_second_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://1hsfkfy8tek7

--- a/tools/build_android_plugin.sh
+++ b/tools/build_android_plugin.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Builds the Android plugin under addons/second_screen into the AAR the Android
+# exporter links into its gradle build.
+#
+#   tools/build_android_plugin.sh
+#
+# Unlike the iOS plugin beside it, nothing here is compiled against the engine's
+# own headers: an Android plugin is Kotlin against `godot-lib`, and that library
+# is a compile-time dependency only, so one AAR serves both export targets. The
+# library is fetched once into .references/ and cached there.
+#
+# Needs a JDK, gradle and the Android SDK. See DEVICES.md for where each comes
+# from; ANDROID_HOME and JAVA_HOME override the defaults below.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLUGIN="$ROOT/addons/second_screen"
+# The engine pin, which is the release the Android library is taken from. Bump
+# with the pin in DEVICES.md.
+GODOT_TAG="${GODOT_TAG:-4.8-dev3}"
+GODOT_LIB_VERSION="${GODOT_LIB_VERSION:-4.8.dev3}"
+NAMESPACE="io.github.decryptu.pokerecomp.secondscreen"
+PACKAGE_PATH="io/github/decryptu/pokerecomp/secondscreen"
+
+export ANDROID_HOME="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+if [ -z "${JAVA_HOME:-}" ] && [ -x /usr/libexec/java_home ]; then
+	JAVA_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null || /usr/libexec/java_home)"
+	export JAVA_HOME
+fi
+
+if [ ! -d "$ANDROID_HOME" ]; then
+	echo "No Android SDK at $ANDROID_HOME. See DEVICES.md." >&2
+	exit 1
+fi
+
+CACHE="$ROOT/.references/godot-android"
+mkdir -p "$CACHE"
+LIB="$CACHE/godot-lib.aar"
+if [ ! -f "$LIB" ]; then
+	URL="https://github.com/godotengine/godot-builds/releases/download/$GODOT_TAG/godot-lib.$GODOT_LIB_VERSION.template_release.aar"
+	echo "Fetching $URL"
+	curl -fsSL -o "$LIB" "$URL"
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/src/main/java/$PACKAGE_PATH"
+cp "$PLUGIN"/kotlin/*.kt "$WORK/src/main/java/$PACKAGE_PATH/"
+cp "$LIB" "$WORK/godot-lib.aar"
+
+# The meta-data name is the contract: `org.godotengine.plugin.v2.<PluginName>`
+# has to match getPluginName(), which is what the game asks Engine for.
+cat > "$WORK/src/main/AndroidManifest.xml" <<MANIFEST
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <meta-data
+            android:name="org.godotengine.plugin.v2.Gen2SecondScreenPanel"
+            android:value="$NAMESPACE.Gen2SecondScreenPlugin" />
+    </application>
+</manifest>
+MANIFEST
+
+cat > "$WORK/settings.gradle" <<'SETTINGS'
+pluginManagement {
+	repositories { google(); mavenCentral(); gradlePluginPortal() }
+}
+dependencyResolutionManagement {
+	repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+	repositories { google(); mavenCentral() }
+}
+rootProject.name = 'second_screen'
+SETTINGS
+
+cat > "$WORK/build.gradle" <<GRADLE
+plugins {
+	id 'com.android.library' version '8.13.0'
+	id 'org.jetbrains.kotlin.android' version '2.1.20'
+}
+android {
+	namespace '$NAMESPACE'
+	compileSdk 34
+	defaultConfig { minSdk = 24 }
+	compileOptions {
+		sourceCompatibility JavaVersion.VERSION_17
+		targetCompatibility JavaVersion.VERSION_17
+	}
+}
+kotlin { jvmToolchain(17) }
+dependencies { compileOnly files('godot-lib.aar') }
+GRADLE
+
+( cd "$WORK" && gradle --quiet --no-daemon assembleRelease )
+
+mkdir -p "$PLUGIN/bin"
+OUT="$PLUGIN/bin/second_screen.aar"
+cp "$WORK/build/outputs/aar/second_screen-release.aar" "$OUT"
+echo "  $(basename "$OUT")  $(du -h "$OUT" | tr -s '\t' ' ' | cut -d' ' -f1)"

--- a/tools/checks/second_screen.gd
+++ b/tools/checks/second_screen.gd
@@ -1,0 +1,150 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the lower display against freshly imported real caches, on all three
+## cartridges.
+##
+## Three things only a real cache can say. That every tab the START menu's gate
+## opens has a page this cache can actually draw, which is what
+## [method Gen2SecondScreen._build_page] refuses on. That every tab's icon is
+## really in the sheet it names, at the pixels it names, rather than a rectangle
+## of one colour cut from the wrong place. And that Kris's own pack and card
+## picture are taken where Crystal ships them and fall back to Chris's where
+## pokegold does not.
+##
+## The gate itself is `SetUpMenuItems`' and is asserted against the START menu in
+## tests/unit/test_second_screen.gd, which needs no cartridge.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- second_screen
+
+## Every state the three gates can be in, as `[party, pokedex, pokegear]`. All
+## eight, because a run reaches most of them: the Pokegear arrives before the dex
+## on the cartridge's own path and after it on a walk that skips Elm's errand.
+const GATES: Array[Array] = [
+	[0, false, false], [0, true, false], [0, false, true], [0, true, true],
+	[1, false, false], [1, true, false], [1, false, true], [1, true, true],
+]
+
+## Cyndaquil, which every cartridge here ships and which has a menu icon, so the
+## #MON tab has something to draw whatever the profile.
+const LEAD_SPECIES: int = 155
+
+## An icon cut from the wrong pixels is usually one flat colour, so this is what
+## says a crop landed on a picture rather than on a sheet's blank margin.
+const MINIMUM_COLORS: int = 2
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_verify_pages(game_id, data)
+		_verify_icons(game_id, data, false)
+		_verify_icons(game_id, data, true)
+		_verify_gender_sheets(game_id, data)
+
+
+## Every tab any gate can open has the page renderer that tab is built from.
+##
+## A tab whose page refuses would be a row on the panel that opens a black
+## rectangle, which is worse than the tab not being there.
+func _verify_pages(game_id: StringName, data: GameData) -> void:
+	var offered: Dictionary = {}
+	for gate: Array in GATES:
+		var tabs: Gen2SecondScreenTabs = Gen2SecondScreenTabs.build(
+			int(gate[0]), bool(gate[1]), bool(gate[2]), "CHRIS"
+		)
+		for entry: Dictionary in tabs.items():
+			offered[StringName(entry["kind"])] = true
+	_r.check(
+		offered.size() == Gen2SecondScreenTabs.VIEWABLE.size(),
+		"%s: the eight gates between them offer every tab (%d of %d)" % [
+			game_id, offered.size(), Gen2SecondScreenTabs.VIEWABLE.size()
+		]
+	)
+	for kind: StringName in offered:
+		_r.check(_page_ready(data, kind), "%s: the %s page is drawable" % [game_id, kind])
+
+
+## What each tab's page is built from, asked the same question
+## [method Gen2SecondScreen._build_page] asks it.
+func _page_ready(data: GameData, kind: StringName) -> bool:
+	match kind:
+		Gen2WorldStartMenu.ITEM_POKEDEX:
+			var dex: Gen2PokedexPage = Gen2PokedexPage.from_data(data)
+			return dex != null and dex.ready()
+		Gen2WorldStartMenu.ITEM_POKEMON:
+			return Gen2PartyMenuPage.from_data(data) != null
+		Gen2WorldStartMenu.ITEM_PACK:
+			var pack: Gen2PackPage = Gen2PackPage.from_data(data)
+			return pack != null and pack.ready()
+		Gen2WorldStartMenu.ITEM_POKEGEAR:
+			## Both cards the tab can show come off the same page, and the MAP
+			## card also needs the region map itself.
+			var gear: Gen2TownMapPage = Gen2TownMapPage.from_data(data)
+			return gear != null and gear.ready() and gear.cards_ready() \
+				and data.landmark_count() > 0
+		Gen2WorldStartMenu.ITEM_PLAYER:
+			var card: Gen2TrainerCardPage = Gen2TrainerCardPage.from_data(
+				data, false, Gen2WorldState.is_crystal_profile(data)
+			)
+			return card != null and card.ready()
+	return false
+
+
+func _verify_icons(game_id: StringName, data: GameData, female: bool) -> void:
+	var who: String = "Kris" if female else "Chris"
+	for kind: StringName in Gen2SecondScreenTabs.VIEWABLE:
+		var icon: Image = Gen2SecondScreenTabs.icon(data, kind, LEAD_SPECIES, female)
+		if not _r.check(icon != null, "%s: the %s icon is cut (%s)" % [game_id, kind, who]):
+			continue
+		var colors: int = _colors(icon)
+		_r.check(
+			colors >= MINIMUM_COLORS,
+			"%s: the %s icon is a picture rather than one flat colour (%s, %d)" % [
+				game_id, kind, who, colors
+			]
+		)
+		_r.check(
+			icon.get_height() <= Gen2SecondScreenTabs.ICON_MAX,
+			"%s: the %s icon fits the tab row (%s, %d high)" % [
+				game_id, kind, who, icon.get_height()
+			]
+		)
+
+
+## An egg has no species and still has an icon, which is the one #MON tab a
+## player can reach with nothing else in the party.
+func _verify_gender_sheets(game_id: StringName, data: GameData) -> void:
+	_r.check(
+		Gen2SecondScreenTabs.icon(data, Gen2WorldStartMenu.ITEM_POKEMON, 0, false, true) != null,
+		"%s: a party led by an egg has a #MON icon" % game_id
+	)
+	## Kris's own sheets ship with Crystal alone. pokegold has no female player
+	## at all, so the fallback to Chris's is unreachable in a game and is the
+	## honest answer for a tool that asks anyway.
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	for sheet: String in ["pack_pockets_female", "card_pic_female"]:
+		_r.check(
+			data.tile_indices(sheet).is_empty() != crystal,
+			"%s: %s is shipped only by Crystal" % [game_id, sheet]
+		)
+	for kind: StringName in [
+		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
+	]:
+		_r.check(
+			Gen2SecondScreenTabs.icon(data, kind, 0, true) != null,
+			"%s: the %s icon is drawn without Kris's own sheet" % [game_id, kind]
+		)
+
+
+func _colors(image: Image) -> int:
+	var seen: Dictionary = {}
+	for y: int in image.get_height():
+		for x: int in image.get_width():
+			seen[image.get_pixel(x, y)] = true
+	return seen.size()

--- a/tools/checks/second_screen.gd.uid
+++ b/tools/checks/second_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://daikwcm8d5njg

--- a/tools/preview_second_screen.gd
+++ b/tools/preview_second_screen.gd
@@ -1,0 +1,185 @@
+extends SceneTree
+
+## Photographs the lower display against a real cache.
+##
+##   Godot --path . -s res://tools/preview_second_screen.gd -- <game> <out.png> [tab] [progress] [panel]
+##
+## `tab` is one of `pokedex`, `pokemon`, `pack`, `pokegear`, `player`, or `all`
+## to write one file per open tab with the tab's name before the extension.
+## `progress` is how far the run has got, which is the only thing that decides
+## which tabs exist: `start` is a player who has just left their bedroom,
+## `starter` has Elm's Pokemon, `gear` has the Pokegear and the MAP card, and
+## `full` has everything the START menu can offer. `panel` is a lower display's
+## own pixel size, `WIDTHxHEIGHT`, which chooses the canvas the way a real one
+## would; the default is the AYN Thor's 1240x1080.
+##
+## The picture written is the canvas itself, one file pixel per hardware pixel,
+## so a diff against it is exact. Look at it with an image viewer that does not
+## smooth.
+##
+## Opens a window: a [SubViewport] needs a rendering device.
+
+const WINDOW_SIZE := Vector2i(640, 480)
+const FRAMES_BEFORE_CAPTURE: int = 8
+const DEFAULT_PANEL := Vector2i(1240, 1080)
+
+## `data/maps/spawn_points.asm`'s `spawn NEW_BARK_TOWN, 13, 6`, which is where a
+## run starts and so where the region map's cursor honestly sits.
+const MAP_GROUP: int = 24
+const MAP_NUMBER: int = 4
+const START_CELL := Vector2i(13, 6)
+
+const TABS: Array[StringName] = [
+	Gen2WorldStartMenu.ITEM_POKEDEX,
+	Gen2WorldStartMenu.ITEM_POKEMON,
+	Gen2WorldStartMenu.ITEM_PACK,
+	Gen2WorldStartMenu.ITEM_POKEGEAR,
+	Gen2WorldStartMenu.ITEM_PLAYER,
+]
+
+## What each progress step has, as the engine flags [Gen2WorldStartMenu] gates
+## on plus whether Elm has handed over a starter.
+const PROGRESS: Dictionary = {
+	&"start": {"party": false, "flags": []},
+	&"starter": {"party": true, "flags": []},
+	&"gear": {"party": true, "flags": [
+		Gen2WorldStartMenu.ENGINE_POKEGEAR, Gen2WorldState.ENGINE_MAP_CARD,
+	]},
+	&"full": {"party": true, "flags": [
+		Gen2WorldStartMenu.ENGINE_POKEGEAR, Gen2WorldStartMenu.ENGINE_POKEDEX,
+		Gen2WorldState.ENGINE_MAP_CARD, Gen2WorldState.ENGINE_PHONE_CARD,
+		Gen2WorldState.ENGINE_RADIO_CARD,
+	]},
+}
+
+## A pocket with something in it, so the pack tab is a listing rather than one
+## CANCEL row: a Potion, a Poke Ball, the Bicycle and TM01.
+const ITEMS: Dictionary = {0x12: 5, 0x04: 10, 0x07: 1, 0xBF: 1}
+
+var _output_path: String = ""
+var _tab: StringName = &"all"
+var _progress: StringName = &"full"
+var _panel: Vector2i = DEFAULT_PANEL
+var _view: Gen2SecondScreen = null
+var _frames: int = 0
+var _written: int = 0
+## The tabs still to photograph, the one whose page is drawn but not yet copied,
+## and how many frames are left before it is.
+var _pending: Array = []
+var _armed: StringName = &""
+var _wait: int = 0
+
+
+func _initialize() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.size() < 2:
+		push_error(
+			"Usage: preview_second_screen.gd -- <game> <out.png> [tab] [progress] [panel]"
+		)
+		quit(1)
+		return
+	var game: StringName = StringName(args[0])
+	_output_path = args[1]
+	if Gen2ToolPath.refuses(_output_path):
+		quit(2)
+		return
+	if args.size() > 2:
+		_tab = StringName(args[2])
+	if args.size() > 3:
+		_progress = StringName(args[3])
+	if args.size() > 4:
+		var parts: PackedStringArray = args[4].split("x")
+		if parts.size() == 2:
+			_panel = Vector2i(int(parts[0]), int(parts[1]))
+	if not PROGRESS.has(_progress):
+		push_error("Unknown progress %s; one of %s" % [_progress, PROGRESS.keys()])
+		quit(1)
+		return
+
+	var sha1: String = RomRegistry.sha1_for(game)
+	var directory: String = RomCache.directory_for(game, sha1) if not sha1.is_empty() else ""
+	if directory.is_empty() or not RomCache.is_usable(directory):
+		push_error("No cache for %s. Run tools/import_rom.gd first." % game)
+		quit(1)
+		return
+	var data: GameData = GameData.open_directory(directory)
+
+	var step: Dictionary = PROGRESS[_progress]
+	var state := Gen2WorldState.new({}, {}, ITEMS.duplicate(), {0: 3000})
+	for flag: int in (step["flags"] as Array):
+		state.set_engine_flag(flag, true)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, MAP_GROUP, MAP_NUMBER, START_CELL, state
+	)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if bool(step["party"]):
+		world.set_party_summary(
+			save.party.size(), false, _species(save), [], [], _eggs(save)
+		)
+	else:
+		save.party = []
+		world.set_party_summary(0, false)
+
+	root.set_content_scale_size(WINDOW_SIZE)
+	root.size = WINDOW_SIZE
+	_view = Gen2SecondScreen.new()
+	_view.canvas_size = Gen2SecondScreenHost.canvas_for(_panel)
+	root.add_child(_view)
+	_view.size = Vector2(_view.canvas_size)
+	_view.set_world(data, world, save)
+	_pending = [_tab] if _tab != &"all" else TABS.duplicate()
+	current_scene = _view
+
+
+static func _species(save: Gen2SaveData) -> Array[int]:
+	var out: Array[int] = []
+	for member: Gen2SaveMon in save.party:
+		out.append(member.species)
+	return out
+
+
+static func _eggs(save: Gen2SaveData) -> Array:
+	var out: Array = []
+	for member: Gen2SaveMon in save.party:
+		out.append(member.is_egg)
+	return out
+
+
+func _process(_delta: float) -> bool:
+	_frames += 1
+	if _frames < FRAMES_BEFORE_CAPTURE:
+		return false
+	if _wait > 0:
+		_wait -= 1
+		return false
+	if not _armed.is_empty():
+		_capture(_armed)
+		_armed = &""
+	if _pending.is_empty():
+		if _written == 0:
+			push_error("No tab was open at progress %s." % _progress)
+			quit(1)
+			return true
+		quit(0)
+		return true
+	var kind: StringName = StringName(_pending.pop_front())
+	if _view.select_tab(kind):
+		_armed = kind
+		## The page is built now and the viewport carries it a frame later, which
+		## is what every capture in this directory waits for.
+		_wait = 2
+	return false
+
+
+func _capture(kind: StringName) -> void:
+	var picture: Image = _view.frame()
+	if picture == null:
+		return
+	var path: String = _output_path
+	if _tab == &"all":
+		path = "%s_%s.%s" % [
+			_output_path.get_basename(), kind, _output_path.get_extension()
+		]
+	picture.save_png(path)
+	print("%s  %dx%d" % [path, picture.get_width(), picture.get_height()])
+	_written += 1

--- a/tools/preview_second_screen.gd.uid
+++ b/tools/preview_second_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://c0rh0enkute3s


### PR DESCRIPTION
A handheld with two screens, such as the AYN Thor, draws the Pokedex, the party, the pack, the Pokegear's map and the trainer card on the lower one, with a row of tabs under them cut from the cartridge's own art.

## What it is

Each page is the screen the overworld already builds. No button is ever routed to one, so a page cannot drift from the one on the top screen and cannot change anything either. The tab row is the only thing that takes a touch.

Which tabs exist is `SetUpMenuItems`' own gate rather than a second list, so a page appears exactly when the START menu would have offered its row: the team page with the starter, the Pokegear page with the phone call. `Gen2SecondScreenTabs` asks `Gen2WorldStartMenu` and filters to the rows that are a picture rather than an action.

Icons are cut from the art of the page each opens: the dex listing's caught marker, the party's lead read live, `PackGFX`'s bag, `.PlacePokegearCardIcon`'s MAP icon and the head of `GetCardPic`'s player picture.

## How it reaches the panel

By copying a small bitmap, not by sharing a rendering context. That is what keeps the port on the compatibility renderer: a shared context would mean a swapchain per display. The screen draws at a few hundred hardware pixels a side and the far side scales it by a whole number with filtering off, so a hardware pixel stays a square block.

`addons/second_screen` is the Android half: a Kotlin `Presentation` that takes the bitmap and reports touches back in the picture's own pixels. It hardcodes nothing about any particular handheld, and uses whatever secondary display the platform offers. A desktop opens the same panel in a window instead. Settings > Second screen chooses between panel, window and off.

Android exports through gradle now, because a plugin needs it.

## Cleanups met on the way

Three things that every occurrence went through were private to one screen and are now where both callers can read them: the Pokegear's owned-card list and the pack listing's rows and description line, on `Gen2PokegearScreen` and `Gen2WorldPack`.

## Checks

- `tests/unit/test_second_screen.gd`: the gate against the START menu's own list, the canvas geometry and where a touch lands. Full GUT tier green, 3826 tests.
- `tools/checks/second_screen.gd`: every tab any gate can open has a page the cache can draw, and every icon is a picture rather than a flat crop, on all three cartridges. The whole validate suite passes.
- `tools/preview_second_screen.gd` photographs the panel per tab and per progress step against a real cache.
- Driven on an emulated dual-screen device with the AYN Thor's 1240x1080 lower panel: the panel comes up, tapping a tab opens its page, and the main display is untouched.