### PR TITLE
Make the second screen read as a readout, and keep it up in the launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ is the same screen the START menu opens. A tab is there exactly when that menu's
 own gate would have offered its row, so the team page appears with the starter
 and the Pokegear page with the phone call.
 
-Outside a game the panel shows the project's own mark: the pages belong to a
-world, and there is no world behind the launcher.
+Outside a game the panel shows a launcher page of its own: an empty cartridge
+bay, the project's name and a line saying nothing is running, on the same field
+and in the same light or dark appearance the shelf above it wears. The pages
+belong to a world, and there is no world behind the launcher.
 
 Settings > Second screen switches it off, or opens the same panel in a desktop
 window on a machine with no such hardware.

--- a/README.md
+++ b/README.md
@@ -158,14 +158,18 @@ Icons come from [Lucide](https://lucide.dev). See
 ### The second screen
 
 A handheld with two displays -- the AYN Thor and its kind -- puts five of those
-entries on the lower one, with a row of tabs cut from the cartridge's own art
-under them: the Pokedex, the party, the pack, the Pokegear's map and the trainer
-card.
+entries on the lower one: the Pokedex, the party, the pack, the Pokegear's map
+and the trainer card. Under them is a menu box in the frame the player chose,
+with a tab for each, drawn with the cartridge's own art.
 
-It is a view. The only thing on it that takes a touch is the tab row, and a tab
-is there exactly when the START menu's own gate would have offered its row, so
-the team page appears with the starter and the Pokegear page with the phone
-call. Nothing on the lower screen can change the game.
+It is a view. The only thing on it that takes a touch is the tab row; no page on
+it reads input at all, and none of them is a copy, so what is on the lower screen
+is the same screen the START menu opens. A tab is there exactly when that menu's
+own gate would have offered its row, so the team page appears with the starter
+and the Pokegear page with the phone call.
+
+Outside a game the panel shows the project's own mark: the pages belong to a
+world, and there is no world behind the launcher.
 
 Settings > Second screen switches it off, or opens the same panel in a desktop
 window on a machine with no such hardware.

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -77,6 +77,10 @@ func take_pending_new_game() -> Dictionary:
 var _save: Gen2SaveData = null
 var _save_key: String = ""
 var _loaded_mods: Array = []
+## The lower display and whatever puts it on real hardware. Both null on a
+## machine with one screen, which is every desktop and most phones.
+var _second_screen: Gen2SecondScreen = null
+var _second_screen_host: Gen2SecondScreenHost = null
 
 
 ## Loads installed mods before any screen exists.
@@ -87,7 +91,59 @@ var _loaded_mods: Array = []
 ## reported while there is still a launcher to report it in.
 func _ready() -> void:
 	apply_display_options(Gen2OptionsStore.current())
+	_attach_second_screen()
 	load_mods()
+
+
+## Brings the lower display up for the whole process rather than for the world.
+##
+## Here rather than in [Gen2WorldScreen] because a handheld with two panels has
+## two panels in the launcher as well, and a black one reads as a fault. The
+## screen shows the project's own mark until a world is handed to it and again
+## when that world closes; [method set_second_screen_world] is the one way it
+## changes hands.
+##
+## Refused on anything but a player's own launch, for the reason
+## [method apply_display_options] gives: a check or a screenshot driver must not
+## open a window of its own.
+func _attach_second_screen() -> void:
+	if not is_player_launch():
+		return
+	var view := Gen2SecondScreen.new()
+	view.name = "SecondScreen"
+	add_child(view)
+	var host: Gen2SecondScreenHost = Gen2SecondScreenHost.attach(
+		view, Gen2OptionsStore.current().second_screen
+	)
+	if host == null:
+		Gen2Screen.drop(view)
+		return
+	add_child(host)
+	_second_screen = view
+	_second_screen_host = host
+
+
+## The world the lower display mirrors, or nothing for the launcher's own mark.
+## Called by the screen that owns a world when it is built and again when it goes.
+func set_second_screen_world(
+	data: GameData, world: Gen2WorldAPI, save: Gen2SaveData
+) -> void:
+	if _second_screen != null:
+		_second_screen.set_world(data, world, save)
+
+
+## The lower display, or null on a machine with one screen. For a caller that has
+## to photograph it.
+func second_screen() -> Gen2SecondScreen:
+	return _second_screen
+
+
+## Follows the world without the world having to say so: the gates are three
+## numbers and [method Gen2SecondScreen.refresh] does nothing on a frame where
+## none of them moved.
+func _process(_delta: float) -> void:
+	if _second_screen != null:
+		_second_screen.refresh()
 
 
 ## Puts the app block's window and frame-rate settings into the engine.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -670,7 +670,11 @@ const CARD_PIC_TILES: int = CARD_PIC_COLUMNS * CARD_PIC_ROWS
 
 ## The Pokedex's graphics (engine/pokedex/pokedex.asm). `PokedexLZ` is the 58
 ## tiles `Pokedex_LoadGFX` decompresses to `vTiles2 tile $31` and
-## `PokedexSlowpokeLZ` the 55 at `vTiles0` that an unseen species is drawn as.
+## `PokedexSlowpokeLZ` the 55 it decompresses to `vTiles0` straight after.
+##
+## Not what an unseen species is drawn as, whatever this comment used to say:
+## `Pokedex_LoadSelectedMonTiles` sends that case to `LoadQuestionMarkPic` and
+## `gfx/pokedex/question_mark.2bpp.lz`, which no offset here names yet.
 ## Both were located by compressing the pinned `gfx/pokedex` PNGs with pret's
 ## `tools/lzcompress` flags: each hits once per dump and the second follows the
 ## first, which is the source's own order.

--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -41,6 +41,9 @@ var _art: TextureRect = null
 var _bay: Control = null
 var _bay_icon: Gen2LauncherIcon = null
 var _bay_label: Label = null
+## The icon and the name inside an empty bay, hidden together by
+## [method set_bay_prompt].
+var _bay_prompt: VBoxContainer = null
 var _hover: bool = false
 var _side_fade: ShaderMaterial = null
 var _bay_side_fade: ShaderMaterial = null
@@ -94,7 +97,8 @@ func _build() -> void:
 	_bay.draw.connect(_draw_bay)
 	add_child(_bay)
 
-	var invitation: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
+	_bay_prompt = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
+	var invitation: VBoxContainer = _bay_prompt
 	invitation.alignment = BoxContainer.ALIGNMENT_CENTER
 	invitation.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	invitation.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
@@ -124,6 +128,16 @@ func _build() -> void:
 	add_child(_art)
 
 	set_imported(false)
+
+
+## Hides the download icon and the cartridge's name inside an empty bay, leaving
+## the silhouette alone.
+##
+## For a caller that wants the shape rather than the invitation: the lower
+## display draws one to say no game is running, and nothing can be dropped on it.
+func set_bay_prompt(on: bool) -> void:
+	if _bay_prompt != null:
+		_bay_prompt.visible = on
 
 
 func set_imported(state: bool) -> void:

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -68,7 +68,7 @@ func _build() -> void:
 	theme = theme_palette.control_theme()
 
 	_backdrop = TextureRect.new()
-	_backdrop.texture = _page_gradient()
+	_backdrop.texture = theme_palette.backdrop_texture()
 	_backdrop.stretch_mode = TextureRect.STRETCH_SCALE
 	_backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
@@ -464,19 +464,6 @@ func _place_toast() -> void:
 		return
 	_toast.offset_bottom = -(Gen2LauncherUI.dock_reserve(get_window()) + 10.0)
 	_toast.offset_top = _toast.offset_bottom - TOAST_HEIGHT
-
-
-func _page_gradient() -> GradientTexture2D:
-	var ramp := Gradient.new()
-	ramp.set_color(0, theme_palette.backdrop_top)
-	ramp.set_color(1, theme_palette.backdrop_bottom)
-	var texture := GradientTexture2D.new()
-	texture.gradient = ramp
-	texture.fill_from = Vector2(0.15, 0.0)
-	texture.fill_to = Vector2(0.85, 1.0)
-	texture.width = 64
-	texture.height = 64
-	return texture
 
 
 func _dock_gradient() -> GradientTexture2D:

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -117,6 +117,25 @@ static func active() -> Gen2LauncherTheme:
 	return for_mode(Gen2OptionsStore.current().ui_theme)
 
 
+## The field every launcher page is drawn on: the backdrop's two colours on the
+## same diagonal, as a texture a [TextureRect] can stretch to any shape.
+##
+## On the theme rather than in the shell, because the shell is not the only thing
+## that draws a launcher page: the lower display draws one too, and a second copy
+## of these four numbers would drift from this one.
+func backdrop_texture() -> GradientTexture2D:
+	var ramp := Gradient.new()
+	ramp.set_color(0, backdrop_top)
+	ramp.set_color(1, backdrop_bottom)
+	var texture := GradientTexture2D.new()
+	texture.gradient = ramp
+	texture.fill_from = Vector2(0.15, 0.0)
+	texture.fill_to = Vector2(0.85, 1.0)
+	texture.width = 64
+	texture.height = 64
+	return texture
+
+
 func is_dark() -> bool:
 	return mode == DARK
 

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -117,17 +117,14 @@ const ARROW_LEFT: int = 0x3D
 const ARROW_RIGHT: int = 0x3E
 
 var font: Gen2Font = null
-## The dex sheet, the Slowpoke picture and the footprint strip, each as the
-## cache's own index buffer.
+## The dex sheet and the footprint strip, each as the cache's own index buffer.
 var _sheet: PackedByteArray = PackedByteArray()
-var _slowpoke: PackedByteArray = PackedByteArray()
 var _footprints: PackedByteArray = PackedByteArray()
 var _unown_font: PackedByteArray = PackedByteArray()
 var _palette: PackedColorArray = PackedColorArray()
-var _question_mark: PackedColorArray = PackedColorArray()
 
 
-## [param data] supplies the glyphs and all three sheets; a cache without them
+## [param data] supplies the glyphs and the three strips; a cache without them
 ## answers null rather than drawing a screen of blanks.
 static func from_data(data: GameData) -> Gen2PokedexPage:
 	if data == null:
@@ -138,11 +135,9 @@ static func from_data(data: GameData) -> Gen2PokedexPage:
 	var out := Gen2PokedexPage.new()
 	out.font = glyphs
 	out._sheet = data.tile_indices("pokedex")
-	out._slowpoke = data.tile_indices("pokedex_slowpoke")
 	out._footprints = data.tile_indices("footprints")
 	out._unown_font = data.tile_indices("unown_font")
 	out._palette = data.pokedex_palette("interface")
-	out._question_mark = data.pokedex_palette("question_mark")
 	return out
 
 
@@ -522,23 +517,21 @@ func image_main(
 
 
 ## The Slowpoke picture, which is what `Pokedex_LoadSelectedMonTiles` puts in the
-## box for a species that has not been seen. Drawn through its own palette, the
-## one `_CGB_Pokedex` fills the 7x7 box with.
+## box for a species that has not been seen.
+##
+## Nothing, until the cache carries the picture. `Pokedex_LoadSelectedMonTiles`
+## sends an unseen species to `.QuestionMark`, which is `LoadQuestionMarkPic` and
+## `gfx/pokedex/question_mark.2bpp.lz`: a 7x7 question mark, and a sheet no
+## importer reads. `PokedexSlowpokeLZ`, which this used to draw, is a different
+## asset entirely -- five Slowpoke reading a book, decompressed to `vTiles0`
+## rather than to the pic slot -- and drawing 49 of its 55 tiles as a picture put
+## a rectangle of scrambled tiles in the box on every unseen row.
+##
+## An empty box is what the cartridge's own box looks like before its pic
+## arrives, and is the honest answer until the blob is located; see
+## `RomLayout.POKEDEX_TILES` for how its neighbours were found.
 func unseen_pic() -> Image:
-	if _slowpoke.is_empty():
-		return null
-	var colors: PackedColorArray = _question_mark if _question_mark.size() \
-		== Gen2Palette.COLORS_PER_PIC else _palette
-	var side: int = 7 * TILE
-	var indices := PackedByteArray()
-	indices.resize(side * side)
-	for tile: int in mini(RomLayout.POKEDEX_SLOWPOKE_TILES, 49):
-		@warning_ignore("integer_division")
-		Gen2Font.blit_slot(
-			_slowpoke, _slowpoke.size() / TILE, tile, indices, side,
-			(tile / 7) * TILE, (tile % 7) * TILE
-		)
-	return Gen2PicImage.from_indices(indices, side, side, colors)
+	return null
 
 
 ## `Pokedex_LoadCurrentFootprint`, as the four tiles the entry screen's grid

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -41,19 +41,46 @@ const INK: int = 3
 const PAPER: int = 0
 const FIELD_COLOR := Color(0.0, 0.0, 0.0, 1.0)
 
-## The picture the panel shows with no world on it, and how big it is drawn. The
-## application's own icon, which is the one mark this project has that belongs to
-## no cartridge.
-const IDLE_ART: String = "res://app_icon.png"
-const IDLE_SIZE: int = 96
+## What the panel shows with no world on it, drawn in the launcher's own
+## language rather than the cartridge's: an empty cartridge silhouette, the
+## project's name and a line saying nothing is running.
+##
+## The launcher measures in points, so the design is written in these units and
+## drawn at whatever whole multiple of them the panel is; a launcher unit is
+## about a point at [constant IDLE_UNITS] on a handheld's lower display.
+const IDLE_UNITS: int = 540
+## The silhouette's height in launcher units, and the panel this screen assumes
+## before a host has said what it really is.
+const IDLE_CARTRIDGE: float = 200.0
+const IDLE_PANEL := Vector2i(1240, 1080)
+## The line under the name, which is the whole of what this page says.
+const IDLE_LINE: String = "No game running"
 
 ## Emitted after the shown page changes, so a host knows a still picture is worth
 ## sending again even when nothing is animating.
 signal page_changed(kind: StringName)
+## Emitted after the drawn surface has been rebuilt. A host that only copies a
+## still picture when it changes listens to this; one copying an animating page
+## every tick does not need it.
+signal redrawn()
 
 ## The whole drawn surface, in hardware pixels. Never smaller than
 ## [constant CANVAS_MIN]: the page is a fixed 160x144 and the tab row has to hold
 ## an icon.
+## The display this is shown on, in its own pixels. Only the idle screen is drawn
+## at this size: it is launcher UI rather than hardware pixels, and type laid out
+## in a 206-pixel canvas and blown up six times is unreadable.
+var panel_size: Vector2i = IDLE_PANEL:
+	set(value):
+		var clamped := Vector2i(maxi(value.x, 64), maxi(value.y, 64))
+		if panel_size == clamped:
+			return
+		panel_size = clamped
+		if _idle != null:
+			_build_page()
+		else:
+			_relayout()
+
 var canvas_size: Vector2i = CANVAS_MIN:
 	set(value):
 		var clamped := Vector2i(
@@ -75,9 +102,9 @@ var _strip: Control = null
 ## The row's own box: the cartridge's frame around the white every menu box has,
 ## redrawn when the row changes rather than every frame.
 var _strip_art: TextureRect = null
-## The launcher's own picture, kept so a canvas resized after it was built moves
-## it to the middle of the new one.
-var _idle: TextureRect = null
+## The launcher's own page, kept so a panel resized after it was built is filled
+## by it.
+var _idle: Control = null
 ## The page on screen, whichever of the cartridge's screens it is, and which tab
 ## built it. Kept so a rebuild is skipped when the answer would be the same node.
 var _page: Node = null
@@ -293,10 +320,32 @@ func _build() -> void:
 	_build_page()
 
 
+## Whether the panel is showing the launcher's own page rather than one of the
+## cartridge's. The two are drawn at different resolutions, so this decides the
+## viewport's size as well as what is in it.
+func idle() -> bool:
+	return _tabs.is_empty()
+
+
+## Whether what is drawn changes by itself. Every page the cartridge owns has
+## something moving on it -- the party's icons bob, the card's colon blinks, the
+## region map's player walks -- and the launcher's own page has nothing.
+func animated() -> bool:
+	return not idle()
+
+
 func _relayout() -> void:
 	if _viewport == null:
 		return
-	_viewport.size = canvas_size
+	var quiet: bool = idle()
+	_viewport.size = panel_size if quiet else canvas_size
+	if _screen != null:
+		_screen.visible = not quiet
+	if _strip != null:
+		_strip.visible = not quiet
+	if quiet:
+		_place_idle()
+		return
 	var field: ColorRect = _viewport.get_node_or_null(^"Field") as ColorRect
 	if field != null:
 		field.size = Vector2(canvas_size)
@@ -387,17 +436,17 @@ func _place_icons() -> void:
 		)
 
 
-## On the canvas rather than in the page's 160x144: this is not one of the
-## cartridge's screens, so it is centred on the whole panel. Placed here rather
-## than where it is built, because the host sets the canvas after this screen is
-## in the tree and the picture has to follow it.
+## The launcher's page fills the panel, and the panel's size is settled by the
+## host after this screen is already in the tree, so the size is applied here
+## rather than where the page is built.
 func _place_idle() -> void:
 	if _idle == null:
 		return
-	_idle.position = Vector2(
-		floorf((canvas_size.x - IDLE_SIZE) * 0.5),
-		floorf((canvas_size.y - IDLE_SIZE) * 0.5),
-	)
+	_idle.position = Vector2.ZERO
+	_idle.size = Vector2(panel_size)
+	for child: Node in _idle.get_children():
+		if child is Control:
+			(child as Control).size = Vector2(panel_size)
 
 
 func _cell(index: int) -> Rect2:
@@ -520,40 +569,86 @@ func _build_page() -> void:
 			_page = _build_pokegear()
 		Gen2WorldStartMenu.ITEM_PLAYER:
 			_page = _build_trainer_card()
-	_redraw_strip()
+	_relayout()
 	page_changed.emit(_page_kind)
+	redrawn.emit()
 
 
 ## What the panel shows with no world on it: the launcher is up, or a game has
 ## just been closed, and the game's own pages are not a thing that exists yet.
 ##
-## The project's own mark rather than a cartridge's, because at this point there
-## may be no cartridge: the shelf is a list of bays and one of them is empty. It
-## is drawn into the page's own rectangle so the panel is the same shape either
-## way.
+## Drawn in the launcher's own language rather than the cartridge's, because at
+## this point there may be no cartridge: the shelf is a list of bays and one of
+## them is empty. It is the shelf's own silhouette for a slot with nothing in it,
+## with the project's name under it, on the same field every launcher page has.
+##
+## Laid out in the panel's own pixels at a whole multiple of the launcher's
+## units, so the type is rasterised at the size it is shown rather than blown up
+## from a 206-pixel canvas.
 func _build_idle() -> Node:
-	var texture: Texture2D = load(IDLE_ART) as Texture2D
-	var picture: Image = texture.get_image() if texture != null else null
-	if picture == null:
-		return null
-	picture = picture.duplicate() as Image
-	if picture.get_format() != Image.FORMAT_RGBA8:
-		picture.convert(Image.FORMAT_RGBA8)
-	## Resampled once, here, rather than by the panel: this is the one thing on
-	## the lower screen that is not made of hardware pixels, and a smooth mark
-	## shrunk with a filter reads better than a whole-number one of a mark that
-	## was never on a tile grid.
-	picture.resize(IDLE_SIZE, IDLE_SIZE, Image.INTERPOLATE_LANCZOS)
-	var rect := TextureRect.new()
-	rect.name = "Idle"
-	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-	rect.size = Vector2(IDLE_SIZE, IDLE_SIZE)
-	Gen2PicImage.show(rect, picture)
-	_viewport.add_child(rect)
-	_idle = rect
+	var skin: Gen2LauncherTheme = Gen2LauncherTheme.active()
+	var units: int = idle_scale(panel_size)
+	var page := Control.new()
+	page.name = "Idle"
+	page.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	page.size = Vector2(panel_size)
+	page.theme = skin.control_theme()
+
+	var backdrop := TextureRect.new()
+	backdrop.texture = skin.backdrop_texture()
+	backdrop.stretch_mode = TextureRect.STRETCH_SCALE
+	backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	backdrop.size = Vector2(panel_size)
+	page.add_child(backdrop)
+
+	var centre := CenterContainer.new()
+	centre.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	centre.size = Vector2(panel_size)
+	page.add_child(centre)
+
+	var column: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD * units)
+	column.alignment = BoxContainer.ALIGNMENT_CENTER
+	var holder := CenterContainer.new()
+	## Any id: the silhouette is the same shape for all three and its prompt, which
+	## is the only part that names one, is off.
+	var slot: Gen2Cartridge = Gen2Cartridge.create(skin, RomRegistry.ORDER[0])
+	slot.set_imported(false)
+	## The shape, not the invitation: an empty bay on the shelf asks for a dump
+	## to be dropped on it, and nothing can be dropped on a panel.
+	slot.set_bay_prompt(false)
+	var tall: float = IDLE_CARTRIDGE * float(units)
+	slot.custom_minimum_size = Vector2(tall * Gen2Cartridge.ASPECT, tall)
+	holder.add_child(slot)
+	column.add_child(holder)
+	column.add_child(_idle_label(
+		skin, ProjectSettings.get_setting("application/config/name", "pokerecomp"),
+		Gen2LauncherTheme.FONT_TITLE * units, skin.text
+	))
+	column.add_child(_idle_label(
+		skin, IDLE_LINE, Gen2LauncherTheme.FONT_SMALL * units, skin.muted
+	))
+	centre.add_child(column)
+
+	_viewport.add_child(page)
+	_idle = page
 	_place_idle()
-	return rect
+	return page
+
+
+## The whole multiple of the launcher's own units this panel is. One on anything
+## smaller than [constant IDLE_UNITS] tall, which is a desktop window rather than
+## a handheld's lower display.
+static func idle_scale(panel: Vector2i) -> int:
+	return maxi(int(round(float(panel.y) / float(IDLE_UNITS))), 1)
+
+
+static func _idle_label(
+	skin: Gen2LauncherTheme, text: String, points: int, colour: Color
+) -> Label:
+	var label: Label = Gen2LauncherUI.title(skin, text, points)
+	label.add_theme_color_override("font_color", colour)
+	label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	return label
 
 
 func _build_pokedex() -> Node:

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -24,16 +24,28 @@ extends Control
 ## The page, which is the cartridge's own screen and never another size.
 const PAGE_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 ## The underline that says which tab is open: two rows at the foot of the tab
-## row, inset so two neighbouring tabs never touch.
+## row's interior, inset so two neighbouring tabs never touch. Drawn in the
+## frame's own ink, because the interior is the same white every menu box has.
 const UNDERLINE_HEIGHT: int = 2
 const UNDERLINE_INSET: int = 4
-## The shortest tab row that still fits the tallest icon with a little air and
-## that underline. A host with a taller panel gets a taller row.
-const MIN_TAB_HEIGHT: int = Gen2SecondScreenTabs.ICON_MAX + UNDERLINE_HEIGHT + 6
+## The shortest tab row that still fits a border, the tallest icon and that
+## underline. A host with a taller panel gets a taller row and the icons centre
+## in it. Two tiles of border, because a menu box has one at each end.
+const MIN_TAB_HEIGHT: int = Gen2Font.TILE * 2 + Gen2SecondScreenTabs.ICON_MAX
 const CANVAS_MIN := Vector2i(PAGE_SIZE.x, PAGE_SIZE.y + MIN_TAB_HEIGHT)
 
+## The two colours every text box in the game is drawn with, and the two the tab
+## row is drawn with for the same reason: it is a menu box, so it is white with
+## the frame the player chose around it.
+const INK: int = 3
+const PAPER: int = 0
 const FIELD_COLOR := Color(0.0, 0.0, 0.0, 1.0)
-const MARK_COLOR := Color(1.0, 1.0, 1.0, 1.0)
+
+## The picture the panel shows with no world on it, and how big it is drawn. The
+## application's own icon, which is the one mark this project has that belongs to
+## no cartridge.
+const IDLE_ART: String = "res://app_icon.png"
+const IDLE_SIZE: int = 96
 
 ## Emitted after the shown page changes, so a host knows a still picture is worth
 ## sending again even when nothing is animating.
@@ -60,6 +72,12 @@ var _tabs := Gen2SecondScreenTabs.new()
 var _viewport: SubViewport = null
 var _screen: Gen2Screen = null
 var _strip: Control = null
+## The row's own box: the cartridge's frame around the white every menu box has,
+## redrawn when the row changes rather than every frame.
+var _strip_art: TextureRect = null
+## The launcher's own picture, kept so a canvas resized after it was built moves
+## it to the middle of the new one.
+var _idle: TextureRect = null
 ## The page on screen, whichever of the cartridge's screens it is, and which tab
 ## built it. Kept so a rebuild is skipped when the answer would be the same node.
 var _page: Node = null
@@ -68,6 +86,8 @@ var _page_kind: StringName = &""
 var _icons: Array[TextureRect] = []
 ## What [method _gate] answered when the row was last built.
 var _gate_read: String = ""
+## The cartridge's glyphs, for the frame around the tab row.
+var _glyphs: Gen2Font = null
 
 
 func _ready() -> void:
@@ -82,9 +102,15 @@ func _ready() -> void:
 ## The world this mirrors. Called once by the host that owns the overworld; every
 ## later change is picked up by [method refresh].
 func set_world(data: GameData, world: Gen2WorldAPI, save: Gen2SaveData) -> void:
+	if data != _data:
+		_glyphs = null
 	_data = data
 	_world = world
 	_save = save
+	## A world handed over, or taken away, is not something the gate string can
+	## express on its own: an absent world answers the same empty string as the
+	## last absent one did.
+	_gate_read = "<unread>"
 	refresh()
 
 
@@ -109,6 +135,8 @@ func refresh() -> void:
 	_build_row()
 	if _tabs.selected_kind() != _page_kind:
 		_build_page()
+	else:
+		_redraw_strip()
 
 
 ## Everything the tab row is a function of: the three gates `SetUpMenuItems`
@@ -254,8 +282,12 @@ func _build() -> void:
 	_strip = Control.new()
 	_strip.name = "Tabs"
 	_strip.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	_strip.draw.connect(_draw_strip)
 	_viewport.add_child(_strip)
+	_strip_art = TextureRect.new()
+	_strip_art.name = "Box"
+	_strip_art.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_strip_art.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_strip.add_child(_strip_art)
 	_relayout()
 	_build_row()
 	_build_page()
@@ -277,8 +309,9 @@ func _relayout() -> void:
 	if _strip != null:
 		_strip.position = Vector2(0.0, float(PAGE_SIZE.y))
 		_strip.size = Vector2(float(canvas_size.x), float(canvas_size.y - PAGE_SIZE.y))
-		_strip.queue_redraw()
+		_redraw_strip()
 	_place_icons()
+	_place_idle()
 
 
 ## The party's lead, whose menu icon is the #MON tab's. Zero for an empty party,
@@ -341,34 +374,121 @@ func _build_row() -> void:
 func _place_icons() -> void:
 	if _strip == null or _icons.is_empty():
 		return
-	var room: float = _strip.size.y - UNDERLINE_HEIGHT
+	## The interior, which is the row less the border tile at each end. The
+	## underline sits in the bottom of it, so the icons centre above that.
+	var top: float = float(Gen2Font.TILE)
+	var room: float = _strip.size.y - Gen2Font.TILE * 2 - UNDERLINE_HEIGHT
 	for index: int in _icons.size():
 		var cell: Rect2 = _cell(index)
 		var icon: TextureRect = _icons[index]
 		icon.position = Vector2(
 			cell.position.x + floorf((cell.size.x - icon.size.x) * 0.5),
-			maxf(floorf((room - icon.size.y) * 0.5), 0.0),
+			top + maxf(floorf((room - icon.size.y) * 0.5), 0.0),
 		)
+
+
+## On the canvas rather than in the page's 160x144: this is not one of the
+## cartridge's screens, so it is centred on the whole panel. Placed here rather
+## than where it is built, because the host sets the canvas after this screen is
+## in the tree and the picture has to follow it.
+func _place_idle() -> void:
+	if _idle == null:
+		return
+	_idle.position = Vector2(
+		floorf((canvas_size.x - IDLE_SIZE) * 0.5),
+		floorf((canvas_size.y - IDLE_SIZE) * 0.5),
+	)
 
 
 func _cell(index: int) -> Rect2:
 	return Rect2(tab_cell(index, canvas_size, _icons.size()))
 
 
-func _draw_strip() -> void:
-	if _strip == null:
+## The row as the cartridge would have drawn it: the player's own text-box frame
+## around white paper, with the open tab underlined in the frame's ink.
+##
+## Redrawn when the tab set or the chosen tab changes, not per frame. Nothing
+## here is invented: the six frame tiles are `LoadFrame`'s own, chosen by the
+## same FRAME option the boxes on the top screen wear.
+func _redraw_strip() -> void:
+	if _strip == null or _strip_art == null:
 		return
-	_strip.draw_rect(Rect2(Vector2.ZERO, _strip.size), FIELD_COLOR)
-	if _icons.is_empty():
+	var width: int = canvas_size.x
+	var height: int = int(_strip.size.y)
+	if width <= 0 or height <= 0:
 		return
-	var cell: Rect2 = _cell(_tabs.cursor)
-	_strip.draw_rect(
-		Rect2(
-			Vector2(cell.position.x + UNDERLINE_INSET, _strip.size.y - UNDERLINE_HEIGHT),
-			Vector2(maxf(cell.size.x - UNDERLINE_INSET * 2, 1.0), UNDERLINE_HEIGHT),
-		),
-		MARK_COLOR
-	)
+	_strip_art.position = Vector2.ZERO
+	_strip_art.size = Vector2(float(width), float(height))
+	var paper := PackedByteArray()
+	paper.resize(width * height)
+	## A row with no tabs on it is not an empty menu box, it is no menu box: the
+	## panel is showing the launcher's own picture and there is nothing to pick.
+	paper.fill(INK if _icons.is_empty() else PAPER)
+	var glyphs: Gen2Font = _font()
+	if not _icons.is_empty() and glyphs != null:
+		_draw_box(glyphs, paper, width, height)
+		_draw_underline(paper, width, height)
+	Gen2PicImage.show(_strip_art, Gen2PicImage.from_indices(
+		paper, width, height,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	))
+
+
+## The six frame tiles around the row.
+##
+## Placed by hand rather than through [method Gen2Font.draw_box], because that
+## one takes whole tiles in both directions and this row is a whole number of
+## tiles in neither: the border tiles are laid at the four edges and the runs
+## between them overlap rather than stopping short, which a uniform edge tile
+## does not show.
+func _draw_box(glyphs: Gen2Font, into: PackedByteArray, width: int, height: int) -> void:
+	var style: int = Gen2OptionsStore.current().textbox_frame
+	var tile: int = Gen2Font.TILE
+	var right: int = width - tile
+	var bottom: int = height - tile
+	var horizontal: int = RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_HORIZONTAL
+	var vertical: int = RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_VERTICAL
+	var x: int = tile
+	while x < right:
+		glyphs.draw_frame_code(style, horizontal, into, width, mini(x, right - 1), 0)
+		glyphs.draw_frame_code(style, horizontal, into, width, mini(x, right - 1), bottom)
+		x += tile
+	var y: int = tile
+	while y < bottom:
+		glyphs.draw_frame_code(style, vertical, into, width, 0, mini(y, bottom - 1))
+		glyphs.draw_frame_code(style, vertical, into, width, right, mini(y, bottom - 1))
+		y += tile
+	for corner: Array in [
+		[RomLayout.FRAME_TOP_LEFT, 0, 0], [RomLayout.FRAME_TOP_RIGHT, right, 0],
+		[RomLayout.FRAME_BOTTOM_LEFT, 0, bottom],
+		[RomLayout.FRAME_BOTTOM_RIGHT, right, bottom],
+	]:
+		glyphs.draw_frame_code(
+			style, RomLayout.FRAME_FIRST_CODE + int(corner[0]), into, width,
+			int(corner[1]), int(corner[2])
+		)
+
+
+func _draw_underline(into: PackedByteArray, width: int, height: int) -> void:
+	var cell: Rect2i = tab_cell(_tabs.cursor, canvas_size, _icons.size())
+	var left: int = cell.position.x + UNDERLINE_INSET
+	var span: int = maxi(cell.size.x - UNDERLINE_INSET * 2, 1)
+	var top: int = height - Gen2Font.TILE - UNDERLINE_HEIGHT
+	for row: int in UNDERLINE_HEIGHT:
+		var y: int = top + row
+		if y < 0 or y >= height:
+			continue
+		for column: int in span:
+			var x: int = left + column
+			if x < 0 or x >= width:
+				continue
+			into[y * width + x] = INK
+
+
+func _font() -> Gen2Font:
+	if _glyphs == null and _data != null:
+		_glyphs = Gen2Font.from_data(_data)
+	return _glyphs
 
 
 ## Replaces the page with the one the cursor names. Every branch builds the
@@ -381,8 +501,14 @@ func _build_page() -> void:
 	if _page != null:
 		Gen2Screen.drop(_page)
 		_page = null
+	_idle = null
 	_screen.clear()
 	_page_kind = _tabs.selected_kind()
+	if _page_kind.is_empty():
+		_page = _build_idle()
+		_redraw_strip()
+		page_changed.emit(_page_kind)
+		return
 	match _page_kind:
 		Gen2WorldStartMenu.ITEM_POKEDEX:
 			_page = _build_pokedex()
@@ -394,9 +520,40 @@ func _build_page() -> void:
 			_page = _build_pokegear()
 		Gen2WorldStartMenu.ITEM_PLAYER:
 			_page = _build_trainer_card()
-	if _strip != null:
-		_strip.queue_redraw()
+	_redraw_strip()
 	page_changed.emit(_page_kind)
+
+
+## What the panel shows with no world on it: the launcher is up, or a game has
+## just been closed, and the game's own pages are not a thing that exists yet.
+##
+## The project's own mark rather than a cartridge's, because at this point there
+## may be no cartridge: the shelf is a list of bays and one of them is empty. It
+## is drawn into the page's own rectangle so the panel is the same shape either
+## way.
+func _build_idle() -> Node:
+	var texture: Texture2D = load(IDLE_ART) as Texture2D
+	var picture: Image = texture.get_image() if texture != null else null
+	if picture == null:
+		return null
+	picture = picture.duplicate() as Image
+	if picture.get_format() != Image.FORMAT_RGBA8:
+		picture.convert(Image.FORMAT_RGBA8)
+	## Resampled once, here, rather than by the panel: this is the one thing on
+	## the lower screen that is not made of hardware pixels, and a smooth mark
+	## shrunk with a filter reads better than a whole-number one of a mark that
+	## was never on a tile grid.
+	picture.resize(IDLE_SIZE, IDLE_SIZE, Image.INTERPOLATE_LANCZOS)
+	var rect := TextureRect.new()
+	rect.name = "Idle"
+	rect.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	rect.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	rect.size = Vector2(IDLE_SIZE, IDLE_SIZE)
+	Gen2PicImage.show(rect, picture)
+	_viewport.add_child(rect)
+	_idle = rect
+	_place_idle()
+	return rect
 
 
 func _build_pokedex() -> Node:
@@ -406,6 +563,7 @@ func _build_pokedex() -> Node:
 	if not host.open(_data, _world):
 		host.free()
 		return null
+	host.set_read_only(true)
 	host.set_screen(_screen)
 	_viewport.add_child(host)
 	return host
@@ -420,6 +578,7 @@ func _build_party() -> Node:
 	if host == null:
 		return null
 	host.set_context(_data, _save, true)
+	host.set_read_only(true)
 	host.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	host.set_screen(_screen)
 	_viewport.add_child(host)
@@ -441,8 +600,10 @@ func _build_pack() -> Node:
 		return null
 	var pocket: Dictionary = pockets[0]
 	var items: Array = pocket.get("items", [])
+	## No CANCEL row and no cursor: both are furniture for a press this display
+	## cannot take.
 	var rows: Array = Gen2WorldPack.list_rows(
-		_data, int(pocket.get("pocket", 0)), items
+		_data, int(pocket.get("pocket", 0)), items, 0, false
 	)
 	var description: String = ""
 	if not items.is_empty():
@@ -451,7 +612,7 @@ func _build_pack() -> Node:
 		)
 	var picture: Image = page.image(
 		_data,
-		page.pocket_map(0, rows, 0, description, _data.pack_pocket_name(0)),
+		page.pocket_map(0, rows, -1, description, _data.pack_pocket_name(0)),
 		0,
 		_is_female(),
 	)

--- a/game/render/second_screen_host.gd
+++ b/game/render/second_screen_host.gd
@@ -42,11 +42,20 @@ const WINDOW_PANEL := Vector2i(1240, 1080)
 ## laptop. The panel itself gets six.
 const WINDOW_SCALE: int = 4
 
-## The panel is a still page most of the time and a slow animation the rest, so
-## it is copied at half the host's rate rather than every drawn frame. The
-## trainer card's colon and the party's icons are the only things on it that
-## move, and both are slower than this.
+## An animating page is copied at half the host's rate rather than every drawn
+## frame. The trainer card's colon, the party's icons and the region map's player
+## are the only things on the panel that move, and all three are slower than this.
+##
+## A still page is not copied on a clock at all: it is sent for a few frames after
+## the screen says it has redrawn, and not again. That matters because the
+## launcher's own page is drawn at the panel's full resolution rather than in
+## hardware pixels, and one of those is 5.4 MB where a hardware-pixel canvas is
+## 148 KB.
 const PANEL_HZ: float = 30.0
+## How many frames a still page is sent for after it changes. More than one,
+## because the viewport draws what it was given on the frame after it was given
+## it: sending once and stopping put a blank panel up and left it there.
+const PANEL_SETTLE_FRAMES: int = 4
 
 const BACKEND_NONE: StringName = &"none"
 const BACKEND_PANEL: StringName = &"panel"
@@ -58,6 +67,8 @@ var _view: Gen2SecondScreen = null
 var _plugin: Object = null
 var _window: Window = null
 var _since_present: float = 0.0
+## Frames a still page is still owed. See [constant PANEL_SETTLE_FRAMES].
+var _settle: int = PANEL_SETTLE_FRAMES
 
 
 ## Attaches [param view] to whatever second display this build can reach, or
@@ -158,6 +169,10 @@ func _attach_panel() -> bool:
 		_plugin = null
 		return false
 	backend = BACKEND_PANEL
+	## Connected before the sizes are set, so the redraw those two cause is the
+	## first thing this hears rather than something it missed.
+	_view.redrawn.connect(_on_view_redrawn)
+	_view.panel_size = size
 	_view.canvas_size = canvas_for(size)
 	## The control draws nothing on the game's own window: the panel is fed by
 	## the viewport inside it, which has a size of its own and keeps drawing.
@@ -172,6 +187,7 @@ func _attach_window() -> bool:
 		return false
 	_view.canvas_size = canvas_for(WINDOW_PANEL)
 	var canvas: Vector2i = _view.canvas_size
+	_view.panel_size = canvas * WINDOW_SCALE
 	_window = Window.new()
 	_window.title = "pokerecomp: second screen"
 	_window.size = canvas * WINDOW_SCALE
@@ -208,10 +224,24 @@ static func canvas_for(panel: Vector2i) -> Vector2i:
 func _process(delta: float) -> void:
 	if backend != BACKEND_PANEL or _view == null or _plugin == null:
 		return
+	if not _view.animated():
+		if _settle <= 0:
+			return
+		_settle -= 1
+		_present()
+		return
 	_since_present += delta
 	if _since_present < 1.0 / PANEL_HZ:
 		return
 	_since_present = 0.0
+	_present()
+
+
+func _on_view_redrawn() -> void:
+	_settle = PANEL_SETTLE_FRAMES
+
+
+func _present() -> void:
 	var picture: Image = _view.frame()
 	if picture == null:
 		return

--- a/game/render/second_screen_tabs.gd
+++ b/game/render/second_screen_tabs.gd
@@ -27,11 +27,11 @@ const VIEWABLE: Array[StringName] = [
 ## A species icon is two tiles by two, the size every 16x16 object the cartridge
 ## draws is. A crop out of a screen's own sheet is whatever that picture is:
 ## `PackGFX`'s bag is 32 by 20 and no smaller rectangle of it reads as a bag.
-## [constant ICON_MAX] is the tallest any of them is, which is what the tab row
-## has to be able to hold.
+## [constant ICON_MAX] is the tallest any of them is, which is what the tab row's
+## interior has to hold above the open tab's underline.
 const ICON_TILE: int = 8
 const ICON_SIZE: int = ICON_TILE * 2
-const ICON_MAX: int = 20
+const ICON_MAX: int = 18
 
 ## Where each tab's icon is cut from: the cache's own sheet name, the top-left
 ## pixel in that sheet's own grid, how many tiles wide that grid is, and how many
@@ -40,7 +40,7 @@ const ICON_MAX: int = 20
 ##
 ## | Tab | Icon |
 ## |---|---|
-## | #DEX | the caught marker on the dex listing, which is one tile and so is drawn at two |
+## | #DEX | the caught marker, as `HUDBallIcons` draws it: the same ball the dex listing puts beside a caught row, off the sheet that draws it on white rather than on the dex's black field |
 ## | PACK | the middle of `PackGFX`'s five-by-three bag |
 ## | GEAR | `.PlacePokegearCardIcon`'s MAP icon, tile $40 less [constant RomLayout.POKEGEAR_FIRST_TILE] |
 ## | player | the head of `GetCardPic`'s own player picture |
@@ -48,17 +48,17 @@ const ICON_MAX: int = 20
 ## #MON has no entry: its icon is the party's lead, read live.
 const ICONS: Dictionary = {
 	Gen2WorldStartMenu.ITEM_POKEDEX: {
-		"sheet": "pokedex", "at": Vector2i(112, 8), "size": Vector2i(8, 8),
-		"stride": 16, "scale": 2,
+		"sheet": "ball_icons", "at": Vector2i(0, 0), "size": Vector2i(8, 8),
+		"stride": 4, "scale": 2,
 	},
 	Gen2WorldStartMenu.ITEM_PACK: {
-		"sheet": "pack", "at": Vector2i(4, 2), "size": Vector2i(32, 20), "stride": 5,
+		"sheet": "pack", "at": Vector2i(4, 3), "size": Vector2i(32, 18), "stride": 5,
 	},
 	Gen2WorldStartMenu.ITEM_POKEGEAR: {
 		"sheet": "pokegear", "at": Vector2i(0, 8), "stride": 16,
 	},
 	Gen2WorldStartMenu.ITEM_PLAYER: {
-		"sheet": "card_pic", "at": Vector2i(12, 0), "size": Vector2i(24, 20), "stride": 5,
+		"sheet": "card_pic", "at": Vector2i(12, 1), "size": Vector2i(24, 18), "stride": 5,
 	},
 }
 
@@ -175,7 +175,7 @@ static func icon(
 	return _crop(
 		strip, int(row["stride"]), row.get("at", Vector2i.ZERO),
 		row.get("size", Vector2i(ICON_SIZE, ICON_SIZE)),
-		int(row.get("scale", 1)), colors, -1
+		int(row.get("scale", 1)), colors, int(row.get("transparent", -1))
 	)
 
 
@@ -259,7 +259,11 @@ static func _sheet(data: GameData, name: String, female: bool) -> PackedByteArra
 static func _palette(data: GameData, kind: StringName, female: bool) -> PackedColorArray:
 	match kind:
 		Gen2WorldStartMenu.ITEM_POKEDEX:
-			return data.pokedex_palette("interface")
+			## `HUDBallIcons` is two colours, drawn through whatever the HUD's
+			## own palette is; the marker is black on white wherever it appears.
+			return Gen2Palette.pic_palette(
+				PackedColorArray([Color.WHITE, Color.BLACK])
+			)
 		Gen2WorldStartMenu.ITEM_PACK:
 			var pack: PackedColorArray = data.pack_palette(PACK_PICTURE_PALETTE, female)
 			return pack if not pack.is_empty() else data.pack_palette(PACK_PICTURE_PALETTE)

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -161,6 +161,8 @@ var _menu_page: Gen2MenuPage = null
 ## A refusal standing in the menu's own bottom box, which the next A or B
 ## clears. See [constant MESSAGE_NOT_ENOUGH_HP].
 var _message: String = ""
+## Whether this is being read rather than driven. See [method set_read_only].
+var _read_only: bool = false
 ## This screen's hardware-frame clock.
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## `OpenPartyStats`' own screen, standing over the whole party menu while it is
@@ -734,6 +736,20 @@ func _build_hardware_ui() -> void:
 	_hardware.display(_view)
 
 
+## Draws the party as a readout rather than as a menu: no cursor, no CANCEL row
+## and an empty bottom box.
+##
+## For a display that shows the party without being able to choose from it. The
+## three are one switch rather than three because they are one fact: an arrow, a
+## way out and a question are all furniture for a press that cannot happen here.
+func set_read_only(on: bool) -> void:
+	if _read_only == on:
+		return
+	_read_only = on
+	if is_inside_tree():
+		_render_hardware()
+
+
 ## The screen the opener wants this drawn in, handed over before it is added to
 ## the tree. Without one the view goes in whichever screen this ends up inside.
 func set_screen(screen: Gen2Screen) -> void:
@@ -826,7 +842,11 @@ func _render_hardware() -> void:
 		return
 	var rows: Array = _rows()
 	var image: Image = _page.render(
-		rows, _cursor_row(), _prompt(), _switch_from < 0, _switch_from
+		rows,
+		-1 if _read_only else _cursor_row(),
+		"" if _read_only else _prompt(),
+		_switch_from < 0 and not _read_only,
+		_switch_from,
 	)
 	if image == null:
 		return

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -87,6 +87,8 @@ var _message: String = ""
 ## `wDexArrowCursorBlinkCounter`, and the leftover of a hardware frame this
 ## screen has not counted yet.
 var _blink: int = 0
+## Whether this is being read rather than driven. See [method set_read_only].
+var _read_only: bool = false
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
@@ -491,7 +493,9 @@ func render() -> Image:
 		return Image.create_empty(
 			Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 		)
-	var cursor: int = -1 if _blink >= CURSOR_BLINK_FRAMES else 0
+	## `Pokedex_BlinkArrowCursor`'s own off phase, and the same answer on every
+	## frame for a screen that is being read rather than walked.
+	var cursor: int = -1 if _read_only or _blink >= CURSOR_BLINK_FRAMES else 0
 	match _mode:
 		Mode.OPTION:
 			return _page.image(_page.option_map(
@@ -627,6 +631,13 @@ func _build_ui() -> void:
 
 ## The screen the opener wants this drawn in, handed over before it is added to
 ## the tree. Without one the field goes in whichever screen this ends up inside.
+## Draws the listing with no arrow on it, for a display that shows the dex
+## without being able to walk it. The blink is left running: it costs nothing and
+## the flag is checked where the arrow is placed.
+func set_read_only(on: bool) -> void:
+	_read_only = on
+
+
 func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -161,8 +161,13 @@ static func source_pocket_name(data: GameData, item: int) -> String:
 ##
 ## Here rather than in the screen that scrolls them, because the pack listing is
 ## drawn on more than one screen and only one of them owns a cursor.
+##
+## [param cancel] is the row that closes the pack. A screen that cannot be closed
+## because nothing on it takes a button asks for the listing without it, the way
+## [method Gen2PartyMenuPage.render] is asked for one without its own CANCEL.
 static func list_rows(
-	data: GameData, pocket_type: int, items: Array, scroll: int = 0
+	data: GameData, pocket_type: int, items: Array, scroll: int = 0,
+	cancel: bool = true
 ) -> Array:
 	var tmhm: bool = pocket_type == TYPE_TM_HM
 	var out: Array = []
@@ -171,7 +176,8 @@ static func list_rows(
 		if index > items.size():
 			break
 		if index == items.size():
-			out.append({"kind": Gen2PackPage.ROW_CANCEL})
+			if cancel:
+				out.append({"kind": Gen2PackPage.ROW_CANCEL})
 			break
 		var entry: Dictionary = items[index]
 		var item: int = int(entry.get("item", 0))

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -306,11 +306,6 @@ var _sound_schedule_frame: int = 0
 var _interface_owned: bool = false
 var _interface_owned_pushed: bool = false
 
-## The lower display and whatever puts it on real hardware. Both null on a
-## machine with one screen, which is every desktop and most phones.
-var _second_screen: Gen2SecondScreen = null
-var _second_screen_host: Gen2SecondScreenHost = null
-
 @onready var _screen: Gen2Screen = %Screen
 @onready var _caption: Label = %Caption
 @onready var _hint: Label = %Hint
@@ -553,33 +548,26 @@ func _build_world() -> void:
 	var entry_results: Array = _world.dispatch_map_entry()
 	if not entry_results.is_empty():
 		_show_script_results(entry_results)
-	_build_second_screen()
+	_hand_over_second_screen()
 	_refresh_labels()
 
 
-## The lower display, where the build is running on hardware that has one.
+## Hands this world to the lower display, where the build has one.
 ##
-## It mirrors this world and takes no button, so it is built here rather than
-## anywhere a page is opened: the pages on it are the START menu's, and which of
-## them exist is the START menu's gate rather than this screen's business.
-## [method Gen2SecondScreenHost.attach] answers null on every machine with no
-## second display, which is the ordinary case and not a failure.
-func _build_second_screen() -> void:
-	if _second_screen != null:
-		return
-	var view := Gen2SecondScreen.new()
-	view.name = "SecondScreen"
-	add_child(view)
-	view.set_world(_data, _world, active_save())
-	var host: Gen2SecondScreenHost = Gen2SecondScreenHost.attach(
-		view, Gen2OptionsStore.current().second_screen
-	)
-	if host == null:
-		Gen2Screen.drop(view)
-		return
-	add_child(host)
-	_second_screen = view
-	_second_screen_host = host
+## The display itself belongs to [Gen2GameRuntime] and is up in the launcher too;
+## all this screen owns is which world is on it. Handed back on the way out, so
+## closing a game puts the launcher's own mark back rather than leaving the last
+## frame of a world nobody is playing.
+func _hand_over_second_screen() -> void:
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	if runtime != null:
+		runtime.set_second_screen_world(_data, _world, active_save())
+
+
+func _exit_tree() -> void:
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	if runtime != null:
+		runtime.set_second_screen_world(null, null, null)
 
 
 ## Builds the view for the selected renderer and attaches it to the layer that
@@ -841,8 +829,6 @@ func advance_frame() -> void:
 		_world.advance_frame_counter()
 		if _replaying_input:
 			_apply_replayed_input(_world.frame_number)
-	if _second_screen != null:
-		_second_screen.refresh()
 	_advance_game_time_frame()
 	## Before everything the map draws: the fade owns the frame the map swaps on,
 	## and nothing else runs while `RunMapSetupScript` is spending its own.

--- a/tests/unit/test_second_screen.gd
+++ b/tests/unit/test_second_screen.gd
@@ -204,3 +204,13 @@ func test_no_hosted_page_reads_input() -> void:
 				declared.has(callback),
 				"%s declares %s" % [path.get_file(), callback]
 			)
+
+
+## The launcher's own page is drawn at the panel's resolution rather than in the
+## hardware canvas, and how big it is drawn is a whole multiple of the launcher's
+## units. A desktop window smaller than one unit's worth still gets one.
+func test_the_launcher_page_scales_by_whole_units() -> void:
+	assert_eq(Gen2SecondScreen.idle_scale(Vector2i(1240, 1080)), 2)
+	assert_eq(Gen2SecondScreen.idle_scale(Vector2i(824, 720)), 1)
+	assert_eq(Gen2SecondScreen.idle_scale(Vector2i(64, 64)), 1)
+	assert_eq(Gen2SecondScreen.idle_scale(Vector2i(1920, 1620)), 3)

--- a/tests/unit/test_second_screen.gd
+++ b/tests/unit/test_second_screen.gd
@@ -90,7 +90,7 @@ func test_the_signature_follows_the_tab_set_and_the_chosen_tab() -> void:
 ## hardware pixel is a square block of panel pixels and the leftover is a bar
 ## rather than a resampled picture.
 func test_the_canvas_fills_a_panel_at_a_whole_scale() -> void:
-	## The AYN Thor's lower display. 1080 / 172 is 6, and 1240 / 6 is 206.
+	## The AYN Thor's lower display. 1080 / 178 is 6, and 1240 / 6 is 206.
 	assert_eq(
 		Gen2SecondScreenHost.canvas_for(Vector2i(1240, 1080)), Vector2i(206, 180)
 	)
@@ -163,3 +163,44 @@ func test_a_touch_off_the_canvas_lands_on_no_tab() -> void:
 
 func test_a_row_with_no_tabs_takes_no_touch() -> void:
 	assert_eq(Gen2SecondScreen.tab_index_at(Vector2(100.0, 150.0), CANVAS, 0), -1)
+
+
+## Every engine callback that could deliver a press to a page without the page
+## being asked for it. A screen that declares none of these cannot act on input
+## the second display never routes to it, whatever else it is doing.
+const INPUT_CALLBACKS: Array[String] = [
+	"_input", "_unhandled_input", "_unhandled_key_input", "_gui_input",
+	"_shortcut_input",
+]
+
+## The pages the lower display hosts, as their own scripts.
+const HOSTED: Array[String] = [
+	"res://game/world/pokedex_screen.gd",
+	"res://game/save/party_screen.gd",
+	"res://game/world/town_map_screen.gd",
+	"res://game/world/pokegear_screen.gd",
+	"res://game/world/trainer_card_screen.gd",
+]
+
+
+## The read-only promise, asserted where it is actually kept: none of the pages
+## the lower display shows reads input at all. Each is driven by its host calling
+## `handle_button`, and the lower display calls nothing.
+##
+## This is the test that fails the day someone gives one of these screens an
+## input callback of its own, which is the one change that would let a page on
+## the panel act on a press meant for the game.
+func test_no_hosted_page_reads_input() -> void:
+	for path: String in HOSTED:
+		var script: Script = load(path) as Script
+		assert_not_null(script, path)
+		if script == null:
+			continue
+		var declared: Array[String] = []
+		for entry: Dictionary in script.get_script_method_list():
+			declared.append(String(entry.get("name", "")))
+		for callback: String in INPUT_CALLBACKS:
+			assert_false(
+				declared.has(callback),
+				"%s declares %s" % [path.get_file(), callback]
+			)

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -293,3 +293,35 @@ func test_a_registered_pocket_follows_the_source_cycle() -> void:
 	assert_eq(pockets.size(), 5)
 	assert_eq(pockets[4]["name"], "Relics")
 	assert_eq((pockets[4]["items"] as Array)[0]["item"], ITEM_UNCLASSIFIED)
+
+
+## `ScrollingMenu_UpdateDisplay`'s CANCEL row closes the pack, and a screen that
+## cannot be closed asks for the listing without it. The rows either side of it
+## are the same either way.
+func test_the_listing_can_be_asked_for_without_its_cancel_row() -> void:
+	var pockets: Array = Gen2WorldPack.build(
+		_data, Gen2WorldState.new({}, {}, {ITEM_POTION: 3})
+	)
+	var items: Array = (pockets[0] as Dictionary)["items"]
+	var driven: Array = Gen2WorldPack.list_rows(_data, Gen2WorldPack.TYPE_ITEM, items)
+	assert_eq(driven.size(), 2, "one item and the row that closes the pack")
+	assert_eq(StringName(driven[1]["kind"]), Gen2PackPage.ROW_CANCEL)
+	var read: Array = Gen2WorldPack.list_rows(
+		_data, Gen2WorldPack.TYPE_ITEM, items, 0, false
+	)
+	assert_eq(read.size(), 1, "the item alone")
+	assert_eq(read[0], driven[0], "the item's own row is untouched")
+
+
+## A pocket with nothing in it is the CANCEL row and nothing else, so asking for
+## it without one is an empty listing rather than a listing of one blank.
+func test_an_empty_pocket_read_without_cancel_is_empty() -> void:
+	var pockets: Array = Gen2WorldPack.build(_data, Gen2WorldState.new({}, {}, {}))
+	var items: Array = (pockets[0] as Dictionary)["items"]
+	assert_eq(
+		Gen2WorldPack.list_rows(_data, Gen2WorldPack.TYPE_ITEM, items).size(), 1
+	)
+	assert_eq(
+		Gen2WorldPack.list_rows(_data, Gen2WorldPack.TYPE_ITEM, items, 0, false).size(),
+		0
+	)

--- a/tools/preview_second_screen.gd
+++ b/tools/preview_second_screen.gd
@@ -4,8 +4,9 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_second_screen.gd -- <game> <out.png> [tab] [progress] [panel]
 ##
-## `tab` is one of `pokedex`, `pokemon`, `pack`, `pokegear`, `player`, or `all`
-## to write one file per open tab with the tab's name before the extension.
+## `tab` is one of `pokedex`, `pokemon`, `pack`, `pokegear`, `player`, `idle` for
+## the picture the panel shows with no world on it, or `all` to write one file per
+## open tab with the tab's name before the extension.
 ## `progress` is how far the run has got, which is the only thing that decides
 ## which tabs exist: `start` is a player who has just left their bedroom,
 ## `starter` has Elm's Pokemon, `gear` has the Pokegear and the MAP card, and
@@ -28,6 +29,9 @@ const DEFAULT_PANEL := Vector2i(1240, 1080)
 const MAP_GROUP: int = 24
 const MAP_NUMBER: int = 4
 const START_CELL := Vector2i(13, 6)
+
+## The panel with no world on it, which is what the launcher shows.
+const TAB_IDLE: StringName = &"idle"
 
 const TABS: Array[StringName] = [
 	Gen2WorldStartMenu.ITEM_POKEDEX,
@@ -126,7 +130,10 @@ func _initialize() -> void:
 	_view.canvas_size = Gen2SecondScreenHost.canvas_for(_panel)
 	root.add_child(_view)
 	_view.size = Vector2(_view.canvas_size)
-	_view.set_world(data, world, save)
+	if _tab == TAB_IDLE:
+		_view.set_world(null, null, null)
+	else:
+		_view.set_world(data, world, save)
 	_pending = [_tab] if _tab != &"all" else TABS.duplicate()
 	current_scene = _view
 
@@ -163,6 +170,10 @@ func _process(_delta: float) -> bool:
 		quit(0)
 		return true
 	var kind: StringName = StringName(_pending.pop_front())
+	if kind == TAB_IDLE:
+		_armed = kind
+		_wait = 2
+		return false
 	if _view.select_tab(kind):
 		_armed = kind
 		## The page is built now and the viewport carries it a frame later, which

--- a/tools/preview_second_screen.gd
+++ b/tools/preview_second_screen.gd
@@ -2,7 +2,7 @@ extends SceneTree
 
 ## Photographs the lower display against a real cache.
 ##
-##   Godot --path . -s res://tools/preview_second_screen.gd -- <game> <out.png> [tab] [progress] [panel]
+##   Godot --path . -s res://tools/preview_second_screen.gd -- <game> <out.png> [tab] [progress] [panel] [theme]
 ##
 ## `tab` is one of `pokedex`, `pokemon`, `pack`, `pokegear`, `player`, `idle` for
 ## the picture the panel shows with no world on it, or `all` to write one file per
@@ -12,7 +12,9 @@ extends SceneTree
 ## `starter` has Elm's Pokemon, `gear` has the Pokegear and the MAP card, and
 ## `full` has everything the START menu can offer. `panel` is a lower display's
 ## own pixel size, `WIDTHxHEIGHT`, which chooses the canvas the way a real one
-## would; the default is the AYN Thor's 1240x1080.
+## would; the default is the AYN Thor's 1240x1080. `theme` is `light` or `dark`,
+## which only the idle page reads: it is launcher UI and wears the launcher's own
+## appearance.
 ##
 ## The picture written is the canvas itself, one file pixel per hardware pixel,
 ## so a diff against it is exact. Look at it with an image viewer that does not
@@ -95,6 +97,9 @@ func _initialize() -> void:
 		var parts: PackedStringArray = args[4].split("x")
 		if parts.size() == 2:
 			_panel = Vector2i(int(parts[0]), int(parts[1]))
+	if args.size() > 5 and Gen2Options.UI_THEMES.has(StringName(args[5])):
+		Gen2OptionsStore.use_test_path()
+		Gen2OptionsStore.current().ui_theme = StringName(args[5])
 	if not PROGRESS.has(_progress):
 		push_error("Unknown progress %s; one of %s" % [_progress, PROGRESS.keys()])
 		quit(1)
@@ -127,6 +132,7 @@ func _initialize() -> void:
 	root.set_content_scale_size(WINDOW_SIZE)
 	root.size = WINDOW_SIZE
 	_view = Gen2SecondScreen.new()
+	_view.panel_size = _panel
 	_view.canvas_size = Gen2SecondScreenHost.canvas_for(_panel)
 	root.add_child(_view)
 	_view.size = Vector2(_view.canvas_size)


### PR DESCRIPTION
Four changes to what the lower display shows, from feedback on the first pass, plus the launcher page that came out of the second round.

## The tab row is a menu box

It was a black band with icons on it, which belonged to no screen the cartridge ever drew. It is now the frame the player chose in OPTION, white paper inside it, and the open tab underlined in the frame's own ink. The Pokedex tab's icon moved to `HUDBallIcons`, which is the same ball the dex listing puts beside a caught row taken off the sheet that draws it on white rather than on the dex's black field.

## The pages no longer wear a cursor

The party had an arrow, a CANCEL row and "Choose a POKéMON."; the pack had an arrow and a CANCEL row. All of those are furniture for a press this display cannot take. `Gen2PartyScreen` and `Gen2PokedexScreen` gain `set_read_only`, and `Gen2WorldPack.list_rows` can now be asked for a listing with no CANCEL row.

## The display belongs to the runtime, not to the world

A handheld with two panels has two panels in the launcher too, and a black one reads as a fault. `Gen2GameRuntime` owns the screen for the whole process; `Gen2WorldScreen` now owns only which world is on it.

With no world it shows a page in the launcher's own language: the shelf's empty cartridge silhouette, the project's name and a line saying nothing is running, on the same field and in the same light or dark appearance the shelf above it wears. That page is drawn at the panel's own resolution rather than in hardware pixels, because launcher type laid out in a 206-pixel canvas and magnified six times is unreadable. The viewport therefore has two sizes, and a still page is copied for a few frames after it changes rather than on the 30 Hz clock an animating page needs.

Two seams rather than two copies: the backdrop gradient moves from `Gen2LauncherShell` onto `Gen2LauncherTheme`, and `Gen2Cartridge` gains `set_bay_prompt` so an empty bay can be asked for as a silhouette without the download icon and the cartridge's name.

## A Pokédex bug met on the way

The dex drew a rectangle of scrambled tiles where an unseen species' picture goes, on every unseen row. `Pokedex_LoadSelectedMonTiles` sends that case to `LoadQuestionMarkPic` and `gfx/pokedex/question_mark.2bpp.lz`; what was drawn instead was 49 tiles of `PokedexSlowpokeLZ`, which is five Slowpoke reading a book and is decompressed to `vTiles0` rather than to the pic slot. No importer reads the question mark, so the box is left empty until one does, and the comment in `RomLayout` that started the confusion is corrected.

## Checks

- The read-only promise is a test: none of the five screens the display hosts declares `_input`, `_unhandled_input`, `_unhandled_key_input`, `_gui_input` or `_shortcut_input`. Each is driven by its host calling `handle_button`, and the display calls nothing.
- Full GUT tier green, 3829 tests. `validate.gd -- all` clean, `replay_world` 33 routes, the story walk on all three profiles.
- Driven on the emulated dual-screen device: the launcher page on the panel with no probe at all, then the cartridge pages with a world handed over, and tapping between tabs. The cartridge silhouette measures 356x404 against the shell's own 1058:1201, so nothing is stretched.