### PR TITLE
Draw the Pokedex the way the cartridge draws it

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -223,8 +223,8 @@ static func open_directory(path: String) -> GameData:
 	if unown_walls is Array:
 		for wall: Variant in unown_walls as Array:
 			data._unown_walls.append(String(wall))
-	var odd_eggs: Variant = manifest.get("odd_eggs", [])
-	data._odd_eggs = odd_eggs if odd_eggs is Array else []
+	var eggs: Variant = manifest.get("odd_eggs", [])
+	data._odd_eggs = eggs if eggs is Array else []
 	var credits: Variant = manifest.get("credits", {})
 	data._credits = credits if credits is Dictionary else {}
 	var intro_movie: Variant = manifest.get("intro_movie", {})

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 93
+const FORMAT_VERSION: int = 94
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -6300,6 +6300,10 @@ func _import_pokedex_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for run: Array in [
 		["pokedex", int(entry["gfx"]), RomLayout.POKEDEX_TILES],
 		["pokedex_slowpoke", int(entry["slowpoke"]), RomLayout.POKEDEX_SLOWPOKE_TILES],
+		[
+			"pokedex_question_mark", int(entry["question_mark"]),
+			RomLayout.POKEDEX_QUESTION_MARK_TILES,
+		],
 	]:
 		var name: String = String(run[0])
 		var tiles: int = int(run[2])

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -672,12 +672,15 @@ const CARD_PIC_TILES: int = CARD_PIC_COLUMNS * CARD_PIC_ROWS
 ## tiles `Pokedex_LoadGFX` decompresses to `vTiles2 tile $31` and
 ## `PokedexSlowpokeLZ` the 55 it decompresses to `vTiles0` straight after.
 ##
-## Not what an unseen species is drawn as, whatever this comment used to say:
-## `Pokedex_LoadSelectedMonTiles` sends that case to `LoadQuestionMarkPic` and
-## `gfx/pokedex/question_mark.2bpp.lz`, which no offset here names yet.
-## Both were located by compressing the pinned `gfx/pokedex` PNGs with pret's
-## `tools/lzcompress` flags: each hits once per dump and the second follows the
-## first, which is the source's own order.
+## Neither is what an unseen species is drawn as: `Pokedex_LoadSelectedMonTiles`
+## sends that case to `LoadQuestionMarkPic` and `gfx/pokedex/question_mark.2bpp.lz`,
+## which is `question_mark` below.
+## The first two were located by compressing the pinned `gfx/pokedex` PNGs with
+## pret's `tools/lzcompress` flags: each hits once per dump and the second follows
+## the first, which is the source's own order. The question mark's own PNG would
+## not match a compressed stream in any tile order or polarity, so it was found
+## by its shape instead: exactly one LZ run in each dump decompresses to 49
+## tiles and nothing else does, and all three carry the same picture.
 ##
 ## `Footprints` is 1bpp and uncompressed, 251 species of four tiles stored as
 ## eight top halves then the eight matching bottoms, which is why a bottom half
@@ -685,6 +688,10 @@ const CARD_PIC_TILES: int = CARD_PIC_COLUMNS * CARD_PIC_ROWS
 ## matches once per dump and is byte identical on all three.
 const POKEDEX_TILES: int = 58
 const POKEDEX_SLOWPOKE_TILES: int = 55
+## `LoadQuestionMarkPic`, whose `ld c, 7 * 7` is what the copy out of `sScratch`
+## sends to the pic slot. Column major, the way every pic is stored.
+const POKEDEX_QUESTION_MARK_TILES: int = 49
+const POKEDEX_QUESTION_MARK_COLUMNS: int = 7
 ## `Pokedex_GetAndPlaceFootprint` asks for two 1bpp tiles at a time, twice.
 const FOOTPRINT_TILES: int = 4
 const FOOTPRINT_HALF_TILES: int = 2
@@ -2513,6 +2520,7 @@ const GOLD_SILVER: Dictionary = {
 		# the addresses differ.
 		"gfx": 0x41511,
 		"slowpoke": 0x416B3,
+		"question_mark": 0x1C0C40,
 		"footprints": 0xF930E,
 		"interface_palette": 0xA34D,
 		"unown_font": 0xFB30E,
@@ -3082,6 +3090,7 @@ const CRYSTAL: Dictionary = {
 		# way `trainer_card.badge_palette` pins PREDEFPAL_CGB_BADGE.
 		"gfx": 0x4150E,
 		"slowpoke": 0x416B0,
+		"question_mark": 0x1DE0E1,
 		"footprints": 0xF9434,
 		"interface_palette": 0x9EDE,
 		"unown_font": 0x1DC000,

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -32,6 +32,9 @@ const HEIGHT: int = ROWS * TILE
 ## Where `PokedexLZ` lands, which is what a sheet tile number is offset by.
 const SHEET_FIRST_TILE: int = 0x31
 
+## `Pokedex_PlaceFrontpicAtHL`'s own box, which is also `PadFrontpic`'s.
+const PIC_COLUMNS: int = 7
+
 ## `Pokedex_FillBackgroundColor2`'s fill, and the tile every cleared cell is.
 const BACKGROUND_TILE: int = 0x32
 
@@ -88,6 +91,98 @@ const NUMBER_DOT: int = 0x5D
 const HEIGHT_FEET: int = 0x5E
 const HEIGHT_INCHES: int = 0x5F
 
+## The objects, which come out of `PokedexSlowpokeLZ` rather than the background
+## sheet: `Pokedex_PutScrollbarOAM`'s knob, the search screen's Slowpoke and the
+## seven tiles the listing cursor's frame is built from.
+const SCROLLBAR_TILE: int = 0x0F
+## `DoDexSearchSlowpokeFrame.SlowpokeSpriteData`: three by three tiles at
+## (9,11), with the frame's own offset added to each tile number.
+const SLOWPOKE_AT := Vector2i(9, 11)
+const SLOWPOKE_TILES: Array[int] = [
+	0x00, 0x01, 0x02, 0x10, 0x11, 0x12, 0x20, 0x21, 0x22,
+]
+## `AnimateDexSearchSlowpoke.FrameIDs`: five frames, each held seven frames, run
+## twenty-five times through and then left on frame 0 for thirty-two more.
+const SLOWPOKE_FRAMES: int = 5
+const SLOWPOKE_FRAME_HOLD: int = 7
+const SLOWPOKE_STEPS: int = 25
+const SLOWPOKE_SETTLE: int = 32
+
+## `Pokedex_LoadCursorOAM`'s own rows, as (x tile, y tile, dx, dy, tile, x flip,
+## y flip). The y of every row is `wDexListingCursor` * 16 lower, which is what
+## `and $7 / swap a` adds.
+const CURSOR_NEW_MODE: Array = [
+	[9, 3, -1, 3, 0x30, false, false], [9, 2, -1, 3, 0x31, false, false],
+	[10, 2, -1, 3, 0x32, false, false], [11, 2, -1, 3, 0x32, false, false],
+	[12, 2, -1, 3, 0x33, false, false], [16, 2, 0, 3, 0x33, true, false],
+	[17, 2, 0, 3, 0x32, true, false], [18, 2, 0, 3, 0x32, true, false],
+	[19, 2, 0, 3, 0x31, true, false], [19, 3, 0, 3, 0x30, true, false],
+	[9, 4, -1, 3, 0x30, false, true], [9, 5, -1, 3, 0x31, false, true],
+	[10, 5, -1, 3, 0x32, false, true], [11, 5, -1, 3, 0x32, false, true],
+	[12, 5, -1, 3, 0x33, false, true], [16, 5, 0, 3, 0x33, true, true],
+	[17, 5, 0, 3, 0x32, true, true], [18, 5, 0, 3, 0x32, true, true],
+	[19, 5, 0, 3, 0x31, true, true], [19, 4, 0, 3, 0x30, true, true],
+]
+## `Pokedex_PutOldModeCursorOAM.CursorOAM`, which is two columns wider because
+## DEXMODE_OLD's listing has no scroll bar, and sits three pixels higher.
+const CURSOR_OLD_MODE: Array = [
+	[9, 3, -1, 0, 0x30, false, false], [9, 2, -1, 0, 0x31, false, false],
+	[10, 2, -1, 0, 0x32, false, false], [11, 2, -1, 0, 0x32, false, false],
+	[12, 2, -1, 0, 0x32, false, false], [13, 2, -1, 0, 0x33, false, false],
+	[16, 2, -2, 0, 0x33, true, false], [17, 2, -2, 0, 0x32, true, false],
+	[18, 2, -2, 0, 0x32, true, false], [19, 2, -2, 0, 0x32, true, false],
+	[20, 2, -2, 0, 0x31, true, false], [20, 3, -2, 0, 0x30, true, false],
+	[9, 4, -1, 0, 0x30, false, true], [9, 5, -1, 0, 0x31, false, true],
+	[10, 5, -1, 0, 0x32, false, true], [11, 5, -1, 0, 0x32, false, true],
+	[12, 5, -1, 0, 0x32, false, true], [13, 5, -1, 0, 0x33, false, true],
+	[16, 5, -2, 0, 0x33, true, true], [17, 5, -2, 0, 0x32, true, true],
+	[18, 5, -2, 0, 0x32, true, true], [19, 5, -2, 0, 0x32, true, true],
+	[20, 5, -2, 0, 0x31, true, true], [20, 4, -2, 0, 0x30, true, true],
+]
+## `.CursorAtTopOAM`, which DEXMODE_OLD swaps in for a cursor on the top row: the
+## frame's own top edge would otherwise be drawn above the listing.
+const CURSOR_OLD_MODE_TOP: Array = [
+	[9, 3, -1, 0, 0x30, false, false], [9, 2, -1, 0, 0x34, false, false],
+	[10, 2, -1, 0, 0x35, false, false], [11, 2, -1, 0, 0x35, false, false],
+	[12, 2, -1, 0, 0x35, false, false], [13, 2, -1, 0, 0x36, false, false],
+	[16, 2, -2, 0, 0x36, true, false], [17, 2, -2, 0, 0x35, true, false],
+	[18, 2, -2, 0, 0x35, true, false], [19, 2, -2, 0, 0x35, true, false],
+	[20, 2, -2, 0, 0x34, true, false], [20, 3, -2, 0, 0x30, true, false],
+	[9, 4, -1, 0, 0x30, false, true], [9, 5, -1, 0, 0x31, false, true],
+	[10, 5, -1, 0, 0x32, false, true], [11, 5, -1, 0, 0x32, false, true],
+	[12, 5, -1, 0, 0x32, false, true], [13, 5, -1, 0, 0x33, false, true],
+	[16, 5, -2, 0, 0x33, true, true], [17, 5, -2, 0, 0x32, true, true],
+	[18, 5, -2, 0, 0x32, true, true], [19, 5, -2, 0, 0x32, true, true],
+	[20, 5, -2, 0, 0x31, true, true], [20, 4, -2, 0, 0x30, true, true],
+]
+## `Pokedex_UpdateSearchResultsCursorOAM.CursorOAM`, the wide frame at the new
+## mode's own three-pixel drop.
+const CURSOR_RESULTS: Array = [
+	[9, 3, -1, 3, 0x30, false, false], [9, 2, -1, 3, 0x31, false, false],
+	[10, 2, -1, 3, 0x32, false, false], [11, 2, -1, 3, 0x32, false, false],
+	[12, 2, -1, 3, 0x32, false, false], [13, 2, -1, 3, 0x33, false, false],
+	[16, 2, -2, 3, 0x33, true, false], [17, 2, -2, 3, 0x32, true, false],
+	[18, 2, -2, 3, 0x32, true, false], [19, 2, -2, 3, 0x32, true, false],
+	[20, 2, -2, 3, 0x31, true, false], [20, 3, -2, 3, 0x30, true, false],
+	[9, 4, -1, 3, 0x30, false, true], [9, 5, -1, 3, 0x31, false, true],
+	[10, 5, -1, 3, 0x32, false, true], [11, 5, -1, 3, 0x32, false, true],
+	[12, 5, -1, 3, 0x32, false, true], [13, 5, -1, 3, 0x33, false, true],
+	[16, 5, -2, 3, 0x33, true, true], [17, 5, -2, 3, 0x32, true, true],
+	[18, 5, -2, 3, 0x32, true, true], [19, 5, -2, 3, 0x32, true, true],
+	[20, 5, -2, 3, 0x31, true, true], [20, 4, -2, 3, 0x30, true, true],
+]
+## How much one row of the listing moves the cursor frame, which is
+## `Pokedex_LoadCursorOAM`'s `swap a` on the low three bits.
+const CURSOR_ROW_HEIGHT: int = 16
+## `Pokedex_PutScrollbarOAM`'s own three numbers: the knob's column and the top
+## and bottom of the run it slides down.
+const SCROLLBAR_X: int = 161
+const SCROLLBAR_MIN_Y: int = 20
+const SCROLLBAR_RANGE: int = 121
+## `dbsprite` writes an object's own bytes with no origin added, and the hardware
+## counts them from (8, 16), so a row reaches the screen eight and sixteen less.
+const OAM_ORIGIN := Vector2i(8, 16)
+
 ## `Pokedex_PlaceCaughtSymbolIfCaught`'s own tile, which is a character.
 const CAUGHT_SYMBOL: int = 0x4F
 ## `Pokedex_BlinkArrowCursor`'s two, which are characters as well.
@@ -122,6 +217,14 @@ var _sheet: PackedByteArray = PackedByteArray()
 var _footprints: PackedByteArray = PackedByteArray()
 var _unown_font: PackedByteArray = PackedByteArray()
 var _palette: PackedColorArray = PackedColorArray()
+## `PokedexSlowpokeLZ`, which `Pokedex_LoadGFX` decompresses to `vTiles0`: the
+## objects, not a background sheet. Its 55 tiles carry the search screen's five
+## Slowpoke frames, the scroll bar's knob and the listing cursor's frame.
+var _objects: PackedByteArray = PackedByteArray()
+var _object_palette: PackedColorArray = PackedColorArray()
+## `LoadQuestionMarkPic`'s own 7x7 pic and the palette it is drawn through.
+var _question_mark: PackedByteArray = PackedByteArray()
+var _question_mark_palette: PackedColorArray = PackedColorArray()
 
 
 ## [param data] supplies the glyphs and the three strips; a cache without them
@@ -138,11 +241,17 @@ static func from_data(data: GameData) -> Gen2PokedexPage:
 	out._footprints = data.tile_indices("footprints")
 	out._unown_font = data.tile_indices("unown_font")
 	out._palette = data.pokedex_palette("interface")
+	out._objects = data.tile_indices("pokedex_slowpoke")
+	out._object_palette = data.pokedex_palette("cursor")
+	out._question_mark = data.tile_indices("pokedex_question_mark")
+	out._question_mark_palette = data.pokedex_palette("question_mark")
 	return out
 
 
 func ready() -> bool:
 	return font != null and not _sheet.is_empty() and not _footprints.is_empty() \
+		and not _objects.is_empty() and not _question_mark.is_empty() \
+		and _object_palette.size() == Gen2Palette.COLORS_PER_PIC \
 		and _palette.size() == Gen2Palette.COLORS_PER_PIC
 
 
@@ -213,9 +322,8 @@ func search_results_background(count: int, type_line: String) -> PackedInt32Arra
 ## [param rows] is [method Gen2Pokedex.rows]' own shape: `number`, `name`,
 ## `seen` and `caught` per visible entry. [param old_mode] swaps the scroll bar
 ## for the two tiles that replace it and is what prints a dex number above each
-## name; [param cursor] is which row the arrow stands on, or -1 while it blinks
-## off.
-func window_map(rows: Array, old_mode: bool, cursor: int) -> PackedInt32Array:
+## name.
+func window_map(rows: Array, old_mode: bool) -> PackedInt32Array:
 	var map := PackedInt32Array()
 	map.resize(WINDOW_COLUMNS * ROWS)
 	map.fill(CURSOR_BLANK)
@@ -236,31 +344,33 @@ func window_map(rows: Array, old_mode: bool, cursor: int) -> PackedInt32Array:
 		map[(row + 1) * WINDOW_COLUMNS + 11] = NO_SCROLL if old_mode else SCROLL
 	map[(ROWS - 2) * WINDOW_COLUMNS + 11] = NO_SCROLL_BOTTOM if old_mode else SCROLL_BOTTOM
 
-	_window_rows(map, rows, old_mode, cursor)
+	_window_rows(map, rows, old_mode)
 	return map
 
 
 ## `Pokedex_PrintListing`, which both listing screens share: one entry every two
-## rows from row 2, the caught symbol one cell ahead of the name, and the arrow
-## in column 0.
-func _window_rows(
-	map: PackedInt32Array, rows: Array, old_mode: bool, cursor: int
-) -> void:
+## rows from row 2, at column 0.
+##
+## `.PrintEntry` reaches the name by one `inc hl` from that column, and the
+## caught symbol is what it writes into the cell it steps over, so a name runs
+## from column 1 to column 10 and the scroll bar's column 11 is clear of it.
+## DEXMODE_OLD's number is three digits at column 0 of the row above. The cursor
+## is not in this map at all: it is the object frame `Pokedex_LoadCursorOAM`
+## draws over the whole screen.
+func _window_rows(map: PackedInt32Array, rows: Array, old_mode: bool) -> void:
 	for index: int in rows.size():
 		var entry: Dictionary = rows[index]
 		var row: int = 2 + index * 2
 		if row >= ROWS:
 			break
 		if old_mode:
-			_window_number(map, 1, row - 1, int(entry.get("number", 0)))
+			_window_number(map, 0, row - 1, int(entry.get("number", 0)))
 		if not bool(entry.get("seen", false)):
-			_window_text(map, 2, row, Gen2Pokedex.NOT_SEEN_NAME)
+			_window_text(map, 1, row, Gen2Pokedex.NOT_SEEN_NAME)
 			continue
 		if bool(entry.get("caught", false)):
-			map[row * WINDOW_COLUMNS + 1] = CAUGHT_SYMBOL
-		_window_text(map, 2, row, String(entry.get("name", "")))
-	if cursor >= 0 and cursor < rows.size():
-		map[(2 + cursor * 2) * WINDOW_COLUMNS] = CURSOR_CODE
+			map[row * WINDOW_COLUMNS] = CAUGHT_SYMBOL
+		_window_text(map, 1, row, String(entry.get("name", "")))
 
 
 ## How much of the results window reaches the screen; see [method
@@ -270,7 +380,7 @@ const RESULTS_WINDOW_ROWS: int = 11
 
 ## `DrawPokedexSearchResultsWindow`: two stacked frames rather than the main
 ## screen's one, with the four-row listing in the upper.
-func results_window_map(rows: Array, cursor: int) -> PackedInt32Array:
+func results_window_map(rows: Array) -> PackedInt32Array:
 	var map := PackedInt32Array()
 	map.resize(WINDOW_COLUMNS * ROWS)
 	map.fill(CURSOR_BLANK)
@@ -290,7 +400,7 @@ func results_window_map(rows: Array, cursor: int) -> PackedInt32Array:
 		map[bottom * WINDOW_COLUMNS + 11] = NO_SCROLL_BOTTOM
 	map[5] = WINDOW_LEFT_JOINT
 	map[10 * WINDOW_COLUMNS + 5] = WINDOW_LEFT_JOINT_BOTTOM
-	_window_rows(map, rows, false, cursor)
+	_window_rows(map, rows, false)
 	return map
 
 
@@ -404,8 +514,11 @@ func search_map(
 		_put(map, 17, row, ARROW_RIGHT)
 	_text(map, 3, 4, "TYPE1")
 	_text(map, 3, 6, "TYPE2")
-	_text(map, 10, 4, type_1)
-	_text(map, 10, 6, type_2)
+	# `Pokedex_PlaceSearchScreenTypeStrings` clears a four by eight box at (9,3)
+	# and places each `PokedexTypeSearchStrings` entry at (9,4) and (9,6). The
+	# entries are eight cells wide, so the name is centred by the table itself.
+	_text(map, 9, 4, type_1)
+	_text(map, 9, 6, type_2)
 	_text(map, 3, 13, "BEGIN SEARCH!!")
 	_text(map, 3, 15, "CANCEL")
 	if cursor >= 0 and cursor < SEARCH_CURSOR_ROWS.size():
@@ -437,7 +550,9 @@ func unown_map(forms: Array, cursor: int, word: String = "") -> PackedInt32Array
 		var at: Array = UNOWN_COORDS[index]
 		_put(map, int(at[0]), int(at[1]), UNOWN_FIRST_CHAR + form - 1)
 		if index == cursor:
-			_put(map, int(at[2]), int(at[3]), CURSOR_CODE)
+			# `ld c, FIRST_UNOWN_CHAR + NUM_UNOWN`: the twenty-seventh tile of
+			# `UnownFont` is a diamond, not the arrow the other screens blink.
+			_put(map, int(at[2]), int(at[3]), UNOWN_CURSOR_CHAR)
 	# `PrintUnownWord` clears twelve cells at (4,15) and prints the cursor's own
 	# word into them.
 	_fill(map, 4, 15, 12, CURSOR_BLANK)
@@ -449,6 +564,8 @@ func unown_map(forms: Array, cursor: int, word: String = "") -> PackedInt32Array
 ## `UnownFont` inverted into the dex sheet's own numbering, so a form's cell is a
 ## sheet tile rather than a character.
 const UNOWN_FIRST_CHAR: int = RomLayout.UNOWN_FONT_FIRST_TILE
+## `FIRST_UNOWN_CHAR + NUM_UNOWN`, the diamond that follows the alphabet.
+const UNOWN_CURSOR_CHAR: int = UNOWN_FIRST_CHAR + RomLayout.UNOWN_FORMS
 ## `UnownModeLetterAndCursorCoords`, as (letter x, letter y, cursor x, cursor y)
 ## per form in catching order.
 const UNOWN_COORDS: Array = [
@@ -472,13 +589,33 @@ func image(map: PackedInt32Array, pic: Image = null, pic_at: Vector2i = Vector2i
 			_blit_tile(indices, WIDTH, map[row * COLUMNS + column], column * TILE, row * TILE)
 	var out: Image = Gen2PicImage.from_indices(indices, WIDTH, HEIGHT, _palette)
 	if pic != null:
-		# `_PrepMonFrontpic` centres a pic in its seven-tile cell and sits it on
-		# the cell's floor, so a 5x5 species is not drawn in the corner.
-		var cell: int = 7 * TILE
-		out.blend_rect(pic, Rect2i(Vector2i.ZERO, pic.get_size()), Vector2i(
-			pic_at.x * TILE + (cell - pic.get_width()) / 2,
-			pic_at.y * TILE + cell - pic.get_height()
-		))
+		out.blit_rect(
+			pic, Rect2i(Vector2i.ZERO, pic.get_size()), pic_at * TILE
+		)
+	return out
+
+
+## `PadFrontpic`, which is what makes every species fill the same seven by seven
+## box: one blank column on the left, the picture sitting on the box's floor, and
+## the rest filled with colour 0. A 5x5 species is padded to 7x7 before the copy,
+## so the box is never the screen's own background showing through.
+static func pad_pic(pic: Image, background: Color) -> Image:
+	var side: int = PIC_COLUMNS * TILE
+	var out: Image = Image.create_empty(side, side, false, Image.FORMAT_RGBA8)
+	out.fill(background)
+	if pic == null:
+		return out
+	out.blit_rect(pic, Rect2i(Vector2i.ZERO, pic.get_size()), Vector2i(
+		0 if pic.get_width() >= side else TILE, side - pic.get_height()
+	))
+	return out
+
+
+## The search screen and the Slowpoke object `DoDexSearchSlowpokeFrame` puts over
+## it, which is the one screen here whose objects are not a cursor.
+func search_image(map: PackedInt32Array, frame: int) -> Image:
+	var out: Image = image(map)
+	_draw_slowpoke(out, frame)
 	return out
 
 
@@ -486,9 +623,14 @@ func image(map: PackedInt32Array, pic: Image = null, pic_at: Vector2i = Vector2i
 ## scrolled left by [constant MAIN_SCX] and the listing window blitted over it at
 ## its own `hWX`. Both layers wrap at the background map's 256 pixels, which is
 ## why the background is drawn wide and sampled rather than blitted.
+## [param cursor] is `wDexListingCursor`, which the object frame is drawn around,
+## and [param scrollbar] the (position, listing end) pair
+## `Pokedex_PutScrollbarOAM` slides its knob by. A cursor below zero draws
+## neither, which is what `ClearSprites` leaves on a screen being read.
 func image_main(
 	background: PackedInt32Array, window: PackedInt32Array, old_mode: bool,
-	pic: Image = null, window_rows: int = ROWS
+	pic: Image = null, window_rows: int = ROWS, cursor: int = -1,
+	scrollbar: Vector2i = Vector2i.ZERO, results: bool = false
 ) -> Image:
 	var out: Image = image(background, pic)
 	var scrolled: Image = Image.create(WIDTH, HEIGHT, false, out.get_format())
@@ -513,25 +655,135 @@ func image_main(
 		Rect2i(0, 0, mini(layer.get_width(), WIDTH - at), window_rows * TILE),
 		Vector2i(at, 0)
 	)
+	_draw_listing_objects(scrolled, old_mode, cursor, scrollbar, results)
 	return scrolled
 
 
-## The Slowpoke picture, which is what `Pokedex_LoadSelectedMonTiles` puts in the
-## box for a species that has not been seen.
+## `Pokedex_UpdateCursorOAM` and `Pokedex_UpdateSearchResultsCursorOAM`: the
+## frame around the selected row, and the scroll bar's knob behind it. Both are
+## objects rather than tiles, which is why the listing's own names start in
+## column 1 of the window with nothing in front of them.
+func _draw_listing_objects(
+	onto: Image, old_mode: bool, cursor: int, scrollbar: Vector2i, results: bool
+) -> void:
+	if cursor < 0:
+		return
+	var buffer := PackedByteArray()
+	buffer.resize(WIDTH * HEIGHT)
+	var frame: Array = CURSOR_NEW_MODE
+	if old_mode:
+		frame = CURSOR_OLD_MODE_TOP if cursor == 0 else CURSOR_OLD_MODE
+	elif results:
+		frame = CURSOR_RESULTS
+	_copy_oam(buffer, frame, Vector2i(0, (cursor & 7) * CURSOR_ROW_HEIGHT))
+	# `Pokedex_UpdateCursorOAM` puts the scroll bar's knob out only in the two
+	# modes that draw a scroll bar, and the results screen draws none either.
+	if not old_mode and not results:
+		_put_scrollbar(buffer, scrollbar.x, scrollbar.y)
+	onto.blend_rect(
+		Gen2PicImage.from_indices(buffer, WIDTH, HEIGHT, _object_palette, true),
+		Rect2i(0, 0, WIDTH, HEIGHT), Vector2i.ZERO
+	)
+
+
+## `Pokedex_PutScrollbarOAM`: the knob's own y counts the selected position out
+## of [param listing_end] over the 121 pixels it can slide, and the last position
+## is pinned to the bottom rather than computed.
+func _put_scrollbar(into: PackedByteArray, position: int, listing_end: int) -> void:
+	if listing_end <= 0:
+		return
+	var offset: int = SCROLLBAR_RANGE
+	if position != listing_end - 1:
+		@warning_ignore("integer_division")
+		offset = (position * SCROLLBAR_RANGE) / listing_end
+	_blit_object(
+		into, SCROLLBAR_TILE,
+		Vector2i(SCROLLBAR_X - OAM_ORIGIN.x, SCROLLBAR_MIN_Y + offset - OAM_ORIGIN.y),
+		false, false
+	)
+
+
+## `DoDexSearchSlowpokeFrame`, whose nine tiles each take the frame number times
+## three. Drawn over the search screen, which is where its own OAM sits.
+func _draw_slowpoke(onto: Image, frame: int) -> void:
+	var buffer := PackedByteArray()
+	buffer.resize(WIDTH * HEIGHT)
+	for index: int in SLOWPOKE_TILES.size():
+		@warning_ignore("integer_division")
+		var at := Vector2i(
+			(SLOWPOKE_AT.x + index % 3) * TILE - OAM_ORIGIN.x,
+			(SLOWPOKE_AT.y + index / 3) * TILE - OAM_ORIGIN.y
+		)
+		_blit_object(buffer, SLOWPOKE_TILES[index] + frame * 3, at, false, false)
+	onto.blend_rect(
+		Gen2PicImage.from_indices(buffer, WIDTH, HEIGHT, _object_palette, true),
+		Rect2i(0, 0, WIDTH, HEIGHT), Vector2i.ZERO
+	)
+
+
+## `Pokedex_LoadCursorOAM`, which walks a table adding the cursor's own offset to
+## every row's y.
+func _copy_oam(into: PackedByteArray, objects: Array, offset: Vector2i) -> void:
+	for object: Array in objects:
+		_blit_object(
+			into, int(object[4]),
+			Vector2i(
+				int(object[0]) * TILE + int(object[2]) + offset.x - OAM_ORIGIN.x,
+				int(object[1]) * TILE + int(object[3]) + offset.y - OAM_ORIGIN.y
+			),
+			bool(object[5]), bool(object[6])
+		)
+
+
+## One eight by eight object out of `PokedexSlowpokeLZ`. Index zero is the
+## hardware's transparent colour and is not drawn.
+func _blit_object(
+	into: PackedByteArray, tile: int, at: Vector2i, flip_x: bool, flip_y: bool
+) -> void:
+	@warning_ignore("integer_division")
+	var slots: int = _objects.size() / TILE / TILE
+	if tile < 0 or tile >= slots:
+		return
+	var width: int = slots * TILE
+	for row: int in TILE:
+		var y: int = at.y + (TILE - 1 - row if flip_y else row)
+		if y < 0 or y >= HEIGHT:
+			continue
+		for pixel: int in TILE:
+			var x: int = at.x + (TILE - 1 - pixel if flip_x else pixel)
+			if x < 0 or x >= WIDTH:
+				continue
+			var index: int = _objects[row * width + tile * TILE + pixel]
+			if index == 0:
+				continue
+			into[y * WIDTH + x] = index
+
+
+## `Pokedex_LoadSelectedMonTiles`'s `.QuestionMark`, which is what an unseen
+## species' box is drawn with: `LoadQuestionMarkPic` decompresses
+## `gfx/pokedex/question_mark.2bpp.lz` and copies its 7 * 7 tiles into the pic
+## slot. Column major, like every pic, and drawn through the dex's own
+## `question_mark` palette rather than a species one.
 ##
-## Nothing, until the cache carries the picture. `Pokedex_LoadSelectedMonTiles`
-## sends an unseen species to `.QuestionMark`, which is `LoadQuestionMarkPic` and
-## `gfx/pokedex/question_mark.2bpp.lz`: a 7x7 question mark, and a sheet no
-## importer reads. `PokedexSlowpokeLZ`, which this used to draw, is a different
-## asset entirely -- five Slowpoke reading a book, decompressed to `vTiles0`
-## rather than to the pic slot -- and drawing 49 of its 55 tiles as a picture put
-## a rectangle of scrambled tiles in the box on every unseen row.
-##
-## An empty box is what the cartridge's own box looks like before its pic
-## arrives, and is the honest answer until the blob is located; see
-## `RomLayout.POKEDEX_TILES` for how its neighbours were found.
+## Not `PokedexSlowpokeLZ`, which this used to draw: that is a different asset
+## entirely, five Slowpoke reading a book decompressed to `vTiles0` for the
+## search screen and the listing's objects.
 func unseen_pic() -> Image:
-	return null
+	if _question_mark.is_empty() or _question_mark_palette.size() != Gen2Palette.COLORS_PER_PIC:
+		return null
+	var side: int = RomLayout.POKEDEX_QUESTION_MARK_COLUMNS * TILE
+	var indices := PackedByteArray()
+	indices.resize(side * side)
+	@warning_ignore("integer_division")
+	var width: int = _question_mark.size() / TILE
+	for slot: int in RomLayout.POKEDEX_QUESTION_MARK_TILES:
+		@warning_ignore("integer_division")
+		var column: int = slot / RomLayout.POKEDEX_QUESTION_MARK_COLUMNS
+		var row: int = slot % RomLayout.POKEDEX_QUESTION_MARK_COLUMNS
+		Gen2Font.blit_slot(
+			_question_mark, width, slot, indices, side, column * TILE, row * TILE
+		)
+	return Gen2PicImage.from_indices(indices, side, side, _question_mark_palette)
 
 
 ## `Pokedex_LoadCurrentFootprint`, as the four tiles the entry screen's grid
@@ -593,9 +845,11 @@ func _place_pic_corner(map: PackedInt32Array, x: int, y: int) -> void:
 
 ## `.Title`'s own three pieces: the SELECT picture, the name, and the START one.
 func _title(map: PackedInt32Array, y: int, label: String) -> void:
+	# `.Title` is `db $3b, " OPTION ", $3c`: the second picture follows the
+	# string's own trailing space rather than replacing it.
 	_put(map, 0, y, SELECT_OPTION[0])
 	_text(map, 1, y, " %s " % label)
-	_put(map, 2 + label.length(), y, START_SEARCH[0])
+	_put(map, 3 + label.length(), y, START_SEARCH[0])
 
 
 func _column(map: PackedInt32Array, x: int, y: int, height: int, tile: int) -> void:
@@ -629,17 +883,12 @@ func _number(
 	map: PackedInt32Array, x: int, y: int, value: int, width: int,
 	leading_zeros: bool = false, decimals: int = 0
 ) -> void:
-	var text: String = String.num_int64(maxi(value, 0))
 	if leading_zeros:
-		text = text.lpad(width, "0")
-	else:
-		text = text.lpad(width, " ")
-	if decimals > 0 and text.length() > decimals:
-		text = "%s.%s" % [
-			text.substr(0, text.length() - decimals),
-			text.substr(text.length() - decimals),
-		]
-	_text(map, x, y, text)
+		_text(map, x, y, String.num_int64(maxi(value, 0)).lpad(width, "0").right(width))
+		return
+	# `.PrintDigit` latches as `e` runs out, so the digit in front of the point
+	# is printed whether or not it is a zero: a weight of 8 reads "   0.8".
+	_text(map, x, y, Gen2Pokedex.print_num(value, width, width - decimals))
 
 
 ## One dex entry's page, wrapped into the five rows `ClearBox` cleared for it.

--- a/game/world/link_screen.gd
+++ b/game/world/link_screen.gd
@@ -421,10 +421,10 @@ func _cant_battle_message() -> Array:
 
 ## One of the trade screen's three imported boxes, with its buffers filled and
 ## its lines split the way the box would page them.
-func _special_text(name: String, buffers: Dictionary) -> Array:
+func _special_text(box: String, buffers: Dictionary) -> Array:
 	if _data == null:
 		return []
-	var text: String = _data.special_text("link", name)
+	var text: String = _data.special_text("link", box)
 	for name_or_address: Variant in buffers:
 		var address: int = _data.special_text_ram(String(name_or_address)) \
 			if name_or_address is String else int(name_or_address)

--- a/game/world/mystery_gift_screen.gd
+++ b/game/world/mystery_gift_screen.gd
@@ -170,12 +170,12 @@ static func box_text(
 		"mystery_gift_partner_name": partner,
 		"mystery_gift_player_name": player,
 	}
-	for name: String in buffers:
-		var address: int = data.special_text_ram(name)
+	for buffer: String in buffers:
+		var address: int = data.special_text_ram(buffer)
 		if address >= 0:
 			text = Gen2TextStream.fill_all_markers(
 				text, "%s%04X>" % [Gen2TextStream.RAM_MARKER, address],
-				String(buffers[name])
+				String(buffers[buffer])
 			)
 	var buffer_1: Array[int] = data.string_buffer_addresses()
 	if buffer_1.size() > RomLayout.STRING_BUFFER_1:

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -74,6 +74,9 @@ const SEARCH_TYPE_MAX: int = 17
 ## and the only value the second row can hold that the first cannot.
 const SEARCH_TYPE_NONE: int = 0
 const SEARCH_TYPE_NONE_NAME: String = "----"
+## `POKEDEX_TYPE_STRING_LENGTH` less the terminator, which is how wide every
+## entry of `PokedexTypeSearchStrings` is.
+const SEARCH_TYPE_WIDTH: int = 8
 
 ## `Pokedex_UpdateSearchScreen.ArrowCursorData`'s four rows. The two type rows
 ## are the ones left and right change, which is `Pokedex_UpdateSearchMonType`'s
@@ -224,13 +227,16 @@ func init_cursor_position() -> void:
 	if prev_entry > RomLayout.SPECIES_COUNT and not _order.has(prev_entry):
 		return
 	var index: int = 0
-	if listing_end >= listing_height + 1:
-		for step: int in listing_end - listing_height:
+	# Both walks count in sevens whatever `wDexListingHeight` holds: `cp $8`,
+	# `sub $7` and `ld c, $7` are the routine's own literals, and the search
+	# results screen's four never reach it.
+	if listing_end >= LISTING_HEIGHT + 1:
+		for step: int in listing_end - LISTING_HEIGHT:
 			if _order[index] == prev_entry:
 				return
 			index += 1
 			scroll += 1
-	for step: int in listing_height:
+	for step: int in LISTING_HEIGHT:
 		if index < _order.size() and _order[index] == prev_entry:
 			return
 		index += 1
@@ -493,16 +499,19 @@ static func print_num(value: int, digits: int, before_point: int) -> String:
 	var text: String = ""
 	var padded: String = String.num_int64(maxi(value, 0)).lpad(digits, "0").right(digits)
 	var printed: bool = false
+	## The high nibble of `c` is what puts a point in at all, so a call that
+	## leaves it zero prints a plain field and latches on its last digit alone.
+	var point_at: int = before_point - 1 if before_point < digits else -1
 	for index: int in digits:
 		var digit: String = padded[index]
 		## `dec e` reaching zero on this digit, which is the last one in front
-		## of the point.
-		if index == before_point - 1:
+		## of the point, or the last of all when there is no point.
+		if index == point_at or index == digits - 1:
 			printed = true
 		if digit != "0":
 			printed = true
 		text += digit if printed else " "
-		if index == before_point - 1:
+		if index == point_at:
 			text += "."
 	return text
 
@@ -564,6 +573,17 @@ func search_type_name(value: int) -> String:
 	if value <= SEARCH_TYPE_NONE or value > SEARCH_TYPES.size():
 		return SEARCH_TYPE_NONE_NAME
 	return _data.type_name(SEARCH_TYPES[value - 1]) if _data != null else ""
+
+
+## `PokedexTypeSearchStrings`' own entry for a search row: the type's name
+## centred in [constant SEARCH_TYPE_WIDTH] cells, with the odd cell on the right.
+## Named rather than imported for the same reason [constant SEARCH_TYPES] is, and
+## pinned entry by entry in tests/unit/test_pokedex.gd.
+func search_type_string(value: int) -> String:
+	var name: String = search_type_name(value)
+	@warning_ignore("integer_division")
+	var left: int = (SEARCH_TYPE_WIDTH - name.length()) / 2
+	return name.lpad(name.length() + maxi(left, 0)).rpad(SEARCH_TYPE_WIDTH)
 
 
 ## `Pokedex_UpdateSearchMonType`, which reads left and right on the two type rows

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -49,6 +49,15 @@ const CHANGING_MODES_FRAMES: int = 64
 ## constants/sfx_constants.asm.
 const SFX_CHANGE_DEX_MODE: int = 0x15
 
+## `AnimateDexSearchSlowpoke`: twenty-five steps of seven frames each, then
+## thirty-two more with the Slowpoke back on its first frame. The whole run is
+## spent between BEGIN SEARCH and the results, the way the source spends it.
+const _SEARCH_ANIMATION_FRAMES: int = \
+	Gen2PokedexPage.SLOWPOKE_STEPS * Gen2PokedexPage.SLOWPOKE_FRAME_HOLD
+const SEARCH_FRAMES: int = _SEARCH_ANIMATION_FRAMES + Gen2PokedexPage.SLOWPOKE_SETTLE
+## `Pokedex_DisplayTypeNotFoundMessage`'s own `ld c, $80`.
+const TYPE_NOT_FOUND_FRAMES: int = 0x80
+
 ## `DexEntryScreen_ArrowCursorData`'s four positions, in its own order. PRNT
 ## wants a printer, which is deliberately out, so it is drawn and refuses.
 const ENTRY_BUTTONS: Array[String] = ["PAGE", "AREA", "CRY", "PRNT"]
@@ -66,11 +75,21 @@ var _option_cursor: int = 0
 ## The entry screen's own `wDexArrowCursorPosIndex`, which
 ## `Pokedex_ReinitDexEntryScreen` puts back on PAGE for each new entry.
 var _entry_cursor: int = 0
+## `wPrevDexEntryJumptableIndex`, the listing an entry screen was opened from.
+var _entry_from: Mode = Mode.LIST
 var _mode_rows: Array = []
 ## Frames still owed to `Pokedex_DisplayChangingModesMessage`. The routine is a
 ## pair of blocking `DelayFrames`, so nothing else on this screen runs while it
 ## is above zero, the arrow's own blink included.
 var _changing_modes_frames: int = 0
+## Frames still owed to `AnimateDexSearchSlowpoke`, which holds the search screen
+## the same way. Zero whenever no search is being spent.
+var _search_frames: int = 0
+## What `Pokedex_SearchForMons` answered, held until the animation is spent.
+var _search_result: int = 0
+## Frames still owed to `Pokedex_DisplayTypeNotFoundMessage`, which holds its own
+## two lines up for $80 frames before the search screen is drawn clean again.
+var _message_frames: int = 0
 
 var _area: Gen2TownMapScreen = null
 
@@ -156,7 +175,8 @@ func current_mode() -> Mode:
 
 
 func handle_button(button: int) -> bool:
-	if _dex == null or _changing_modes_frames > 0:
+	if _dex == null or _changing_modes_frames > 0 or _search_frames > 0 \
+		or _message_frames > 0:
 		return false
 	if _mode == Mode.AREA:
 		return _area.handle_button(button)
@@ -192,7 +212,7 @@ func _handle_list(button: int) -> bool:
 		Gen2Button.A:
 			if _dex.can_open_entry():
 				_dex.open_entry()
-				_open_entry_mode()
+				_open_entry_mode(Mode.LIST)
 			return true
 		Gen2Button.SELECT:
 			_open_option_mode()
@@ -217,6 +237,13 @@ func _handle_entry(button: int) -> bool:
 			## `NewPokedexEntry` has no listing under it, so B is what closes it.
 			if _entry_only:
 				closed.emit()
+				return true
+			## `wPrevDexEntryJumptableIndex`, which `Pokedex_UpdateMainScreen`
+			## and `Pokedex_UpdateSearchResultsScreen` each write before they
+			## open an entry: B goes back to whichever listing that was, not
+			## always the main one.
+			if _entry_from == Mode.SEARCH_RESULTS:
+				_open_search_results_mode()
 				return true
 			_open_list_mode()
 			return true
@@ -355,8 +382,9 @@ func _open_list_mode() -> void:
 	_refresh()
 
 
-func _open_entry_mode() -> void:
+func _open_entry_mode(from: Mode = Mode.LIST) -> void:
 	_message = ""
+	_entry_from = from
 	_mode = Mode.ENTRY
 	_entry_cursor = 0
 	_refresh()
@@ -428,12 +456,11 @@ func _confirm_search_row() -> void:
 			_dex.move_search_type(Gen2Button.RIGHT)
 			_refresh()
 		Gen2Pokedex.SEARCH_ROW_BEGIN:
-			if _dex.begin_search() > 0:
-				_open_search_results_mode()
-				return
-			## `.MenuAction_BeginSearch`'s no-result branch redraws the search
-			## screen under its own message rather than leaving it.
-			_message = Gen2Pokedex.TYPE_NOT_FOUND_TEXT
+			## `.MenuAction_BeginSearch` searches first and only then spends
+			## `AnimateDexSearchSlowpoke`, so the count is already known while
+			## the Slowpoke is still moving.
+			_search_result = _dex.begin_search()
+			_search_frames = SEARCH_FRAMES
 			_refresh()
 		Gen2Pokedex.SEARCH_ROW_CANCEL:
 			_open_list_mode()
@@ -450,7 +477,7 @@ func _handle_search_results(button: int) -> bool:
 		Gen2Button.A:
 			if _dex.can_open_entry():
 				_dex.open_entry()
-				_open_entry_mode()
+				_open_entry_mode(Mode.SEARCH_RESULTS)
 			return true
 	if _dex.move_listing(button):
 		_refresh()
@@ -464,8 +491,23 @@ func _handle_search_results(button: int) -> bool:
 ## than its Update, so the search is not remembered.
 func _open_search_mode() -> void:
 	_message = ""
+	_message_frames = 0
+	_search_frames = 0
+	_search_result = 0
 	_mode = Mode.SEARCH
 	_dex.open_search()
+	_refresh()
+
+
+## What `.MenuAction_BeginSearch` does once `AnimateDexSearchSlowpoke` is spent:
+## a result opens the results screen, and none redraws the search screen under
+## `Pokedex_DisplayTypeNotFoundMessage`'s own two lines.
+func _finish_search() -> void:
+	if _search_result > 0:
+		_open_search_results_mode()
+		return
+	_message = Gen2Pokedex.TYPE_NOT_FOUND_TEXT
+	_message_frames = TYPE_NOT_FOUND_FRAMES
 	_refresh()
 
 
@@ -505,11 +547,14 @@ func render() -> Image:
 				)
 			))
 		Mode.SEARCH:
-			return _page.image(_page.search_map(
-				_dex.search_type_name(_dex.search_type_1),
-				_dex.search_type_name(_dex.search_type_2),
-				_dex.search_cursor if cursor == 0 else -1, _message
-			))
+			return _page.search_image(
+				_page.search_map(
+					_dex.search_type_string(_dex.search_type_1),
+					_dex.search_type_string(_dex.search_type_2),
+					_dex.search_cursor if cursor == 0 else -1, _message
+				),
+				_slowpoke_frame()
+			)
 		Mode.UNOWN:
 			return _page.image(
 				_page.unown_map(
@@ -526,14 +571,36 @@ func render() -> Image:
 				_page.search_results_background(
 					_dex.search_result_count, _search_type_line()
 				),
-				_page.results_window_map(_dex.rows(), cursor), true, _selected_pic(),
-				Gen2PokedexPage.RESULTS_WINDOW_ROWS
+				_page.results_window_map(_dex.rows()), true, _selected_pic(),
+				Gen2PokedexPage.RESULTS_WINDOW_ROWS, _listing_cursor(),
+				Vector2i.ZERO, true
 			)
+	# The listing's own cursor is an object frame rather than the arrow the other
+	# screens blink, so it is up on every frame the listing is.
+	var old_mode: bool = _dex.mode == RomLayout.DEXMODE_OLD
 	return _page.image_main(
 		_page.main_background(_dex.seen_count(), _dex.caught_count()),
-		_page.window_map(_dex.rows(), _dex.mode == RomLayout.DEXMODE_OLD, cursor),
-		_dex.mode == RomLayout.DEXMODE_OLD, _selected_pic()
+		_page.window_map(_dex.rows(), old_mode), old_mode, _selected_pic(),
+		Gen2PokedexPage.ROWS, _listing_cursor(),
+		Vector2i(_dex.cursor + _dex.scroll, _dex.listing_end)
 	)
+
+
+## `wDexListingCursor`, or -1 for a screen being read: `ClearSprites` is what
+## every other state opens with, and a readout draws no cursor at all.
+func _listing_cursor() -> int:
+	return -1 if _read_only else _dex.cursor
+
+
+## Which `AnimateDexSearchSlowpoke` frame the search screen is showing.
+## `Pokedex_InitSearchScreen` leaves `wDexSearchSlowpokeFrame` at zero, and the
+## animation runs only while a search is being spent.
+func _slowpoke_frame() -> int:
+	if _search_frames <= 0 or _search_frames <= Gen2PokedexPage.SLOWPOKE_SETTLE:
+		return 0
+	var spent: int = _SEARCH_ANIMATION_FRAMES - (_search_frames - Gen2PokedexPage.SLOWPOKE_SETTLE)
+	@warning_ignore("integer_division")
+	return (spent / Gen2PokedexPage.SLOWPOKE_FRAME_HOLD) % Gen2PokedexPage.SLOWPOKE_FRAMES
 
 
 ## `Pokedex_InitDexEntryScreen`, which loads the species' footprint before it
@@ -559,7 +626,11 @@ func _selected_pic() -> Image:
 		var forms: Array[int] = _dex.unown_forms()
 		if _dex.unown_cursor < 0 or _dex.unown_cursor >= forms.size():
 			return null
-		return _pic_image(_data.unown_pic(forms[_dex.unown_cursor] - 1), species)
+		# `ld a, UNOWN / ld [wCurPartySpecies], a`, so the box is drawn through
+		# UNOWN's palette whatever the listing was left on.
+		return _pic_image(
+			_data.unown_pic(forms[_dex.unown_cursor] - 1), RomLayout.UNOWN_SPECIES
+		)
 	# `Pokedex_CheckSeen`, which is what `can_open_entry` already answers for the
 	# selected row.
 	if species <= 0 or not _dex.can_open_entry():
@@ -572,14 +643,26 @@ func _selected_pic() -> Image:
 	return _pic_image(_data.species_pic(species), species)
 
 
-## One imported pic through `LoadPalette_White_Col1_Col2_Black`'s own four
-## colours, or the Slowpoke picture when the cache does not hold it.
+## One imported pic, or the question mark when the cache does not hold it.
+##
+## `_CGB_Pokedex` fills the picture box's attrmap with palette 1, and which
+## palette that is turns on `wCurPartySpecies`: the two listing screens set it to
+## `-1` and get `PokedexQuestionMarkPalette`, so every species is drawn in the
+## dex's own green there, while the entry screen and the Unown screen set it to
+## the species and get `LoadPalette_White_Col1_Col2_Black`'s four.
 func _pic_image(pic: Dictionary, species: int) -> Image:
 	if pic.is_empty():
 		return _page.unseen_pic()
-	return Gen2PicImage.from_atlas(
-		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
-		_data.palette(species)
+	var listing: bool = _mode == Mode.LIST or _mode == Mode.SEARCH_RESULTS
+	var palette: PackedColorArray = _data.pokedex_palette("question_mark") \
+		if listing else _data.palette(species)
+	if palette.size() < Gen2Palette.COLORS_PER_PIC:
+		return _page.unseen_pic()
+	return Gen2PokedexPage.pad_pic(
+		Gen2PicImage.from_atlas(
+			_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
+		),
+		palette[0]
 	)
 
 
@@ -608,6 +691,20 @@ func advance_frame() -> void:
 			sfx_requested.emit(SFX_CHANGE_DEX_MODE)
 		elif _changing_modes_frames == 0:
 			_open_list_mode()
+		return
+	if _message_frames > 0:
+		_message_frames -= 1
+		if _message_frames == 0:
+			_message = ""
+			_refresh()
+		return
+	if _search_frames > 0:
+		var frame: int = _slowpoke_frame()
+		_search_frames -= 1
+		if _search_frames == 0:
+			_finish_search()
+		elif _slowpoke_frame() != frame:
+			_refresh()
 		return
 	_blink = (_blink + 1) % (CURSOR_BLINK_FRAMES * 2)
 	if _blink == 0 or _blink == CURSOR_BLINK_FRAMES:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1654,10 +1654,25 @@ func test_a_dex_search_reaches_its_results_and_back() -> void:
 	dex.handle_button(Gen2Button.DOWN)
 	dex.handle_button(Gen2Button.DOWN)
 	dex.handle_button(Gen2Button.A)
+	## `.MenuAction_BeginSearch` spends `AnimateDexSearchSlowpoke` between the
+	## search and the results, and nothing reaches the screen while it runs.
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH)
+	assert_false(dex.handle_button(Gen2Button.B), "the animation holds the screen")
+	for _frame: int in Gen2PokedexScreen.SEARCH_FRAMES:
+		dex.advance_frame()
 	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH_RESULTS)
 	assert_eq(model.search_result_count, 1)
 	assert_eq(model.listing_height, Gen2Pokedex.SEARCH_RESULTS_HEIGHT)
 	assert_eq(model.selected_species(), Fixture.TRAINER_SPECIES)
+
+	## `wPrevDexEntryJumptableIndex`: an entry opened from the results goes back
+	## to them, not to the main listing.
+	_world_screen._world.state.set_species_seen(Fixture.TRAINER_SPECIES)
+	dex.handle_button(Gen2Button.A)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.ENTRY)
+	dex.handle_button(Gen2Button.B)
+	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH_RESULTS)
+	assert_eq(model.listing_height, Gen2Pokedex.SEARCH_RESULTS_HEIGHT)
 
 	dex.handle_button(Gen2Button.B)
 	assert_eq(dex.current_mode(), Gen2PokedexScreen.Mode.SEARCH)

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -1004,12 +1004,14 @@ static func _write_battle_graphics(cache_directory: String, manifest: Dictionary
 		"dex_nest_icon": [RomLayout.DEX_NEST_ICON_TILES, 3],
 		## `'▲'`, the single tile a scrolling menu draws its own arrow from.
 		"up_arrow": [1, 3],
-		## `Pokedex_LoadGFX`'s two runs, `UnownFont` and the footprint grid, at
+		## `Pokedex_LoadGFX`'s two runs, `LoadQuestionMarkPic`'s pic, `UnownFont`
+		## and the footprint grid, at
 		## their real lengths so the dex page can address every tile a layout
 		## names. Flat fills like the rest: what a test checks is where each
 		## lands.
 		"pokedex": [RomLayout.POKEDEX_TILES, 1],
 		"pokedex_slowpoke": [RomLayout.POKEDEX_SLOWPOKE_TILES, 2],
+		"pokedex_question_mark": [RomLayout.POKEDEX_QUESTION_MARK_TILES, 2],
 		"unown_font": [RomLayout.UNOWN_FONT_TILES, 3],
 		"footprints": [RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES, 1],
 		## `gfx/mail.asm`'s one run and `_ComposeMailMessage.MailIcon`. The run

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -113,6 +113,7 @@ static func _tiles(path: String) -> Dictionary:
 		["font", RomLayout.FONT_TILES, 3, RomLayout.FONT_FIRST_CODE],
 		["pokedex", RomLayout.POKEDEX_TILES, 1, 0],
 		["pokedex_slowpoke", RomLayout.POKEDEX_SLOWPOKE_TILES, 2, 0],
+		["pokedex_question_mark", RomLayout.POKEDEX_QUESTION_MARK_TILES, 2, 0],
 		["unown_font", RomLayout.UNOWN_FONT_TILES, 3, 0],
 		["footprints", RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES, 1, 0],
 	]:

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -221,6 +221,10 @@ func test_the_measurements_are_punctuated_the_way_print_num_punctuates_them() ->
 	assert_eq(Gen2Pokedex.weight_text(150), "  15.0", "Bulbasaur")
 	assert_eq(Gen2Pokedex.weight_text(10140), "1014.0", "Snorlax")
 	assert_eq(Gen2Pokedex.weight_text(2), "   0.2")
+	# A call whose decimal nibble is zero writes no point at all, and the last
+	# digit is then the one that always prints: `SEEN` reads "  0" at zero.
+	assert_eq(Gen2Pokedex.print_num(0, 3, 3), "  0")
+	assert_eq(Gen2Pokedex.print_num(21, 3, 3), " 21")
 
 
 ## `Pokedex_NextOrPreviousDexEntry` keeps moving until it reaches a species that
@@ -566,8 +570,8 @@ func test_the_picture_box_names_its_tiles_down_each_column() -> void:
 func test_the_listing_window_swaps_its_scroll_bar_in_old_mode() -> void:
 	var page: Gen2PokedexPage = _page()
 	var rows: Array = _dex([1, 2], [2]).rows()
-	var new_mode: PackedInt32Array = page.window_map(rows, false, 0)
-	var old_mode: PackedInt32Array = page.window_map(rows, true, 0)
+	var new_mode: PackedInt32Array = page.window_map(rows, false)
+	var old_mode: PackedInt32Array = page.window_map(rows, true)
 	var columns: int = Gen2PokedexPage.WINDOW_COLUMNS
 	assert_eq(new_mode[11], Gen2PokedexPage.SCROLL_TOP)
 	assert_eq(old_mode[11], Gen2PokedexPage.NO_SCROLL_TOP)
@@ -581,13 +585,19 @@ func test_a_listing_row_marks_caught_and_hides_an_unseen_name() -> void:
 	var page: Gen2PokedexPage = _page()
 	var order: Array = Fixture.new_order()
 	var caught: int = int(order[0])
-	var map: PackedInt32Array = page.window_map(_dex([caught], [caught]).rows(), false, 0)
+	var map: PackedInt32Array = page.window_map(_dex([caught], [caught]).rows(), false)
 	var columns: int = Gen2PokedexPage.WINDOW_COLUMNS
-	assert_eq(map[2 * columns], Gen2PokedexPage.CURSOR_CODE, "the arrow is in column 0")
-	assert_eq(map[2 * columns + 1], Gen2PokedexPage.CAUGHT_SYMBOL)
 	assert_eq(
-		map[4 * columns + 2], Gen2Text.encode(Gen2Pokedex.NOT_SEEN_NAME)[0],
+		map[2 * columns], Gen2PokedexPage.CAUGHT_SYMBOL,
+		"the caught symbol is the cell `.PrintEntry` steps over, which is column 0",
+	)
+	assert_eq(
+		map[4 * columns + 1], Gen2Text.encode(Gen2Pokedex.NOT_SEEN_NAME)[0],
 		"the second row has not been seen",
+	)
+	assert_eq(
+		map[4 * columns + 11], Gen2PokedexPage.SCROLL,
+		"a ten-letter name still stops short of the scroll bar's column",
 	)
 
 
@@ -653,5 +663,54 @@ func test_the_unown_screen_places_its_letters_and_word() -> void:
 		_cell(map, 4, 10), RomLayout.UNOWN_FONT_FIRST_TILE + 8,
 		"I caught second, in the second cell",
 	)
-	assert_eq(_cell(map, 3, 10), Gen2PokedexPage.CURSOR_CODE)
+	assert_eq(
+		_cell(map, 3, 10), Gen2PokedexPage.UNOWN_CURSOR_CHAR,
+		"`ld c, FIRST_UNOWN_CHAR + NUM_UNOWN` is a diamond, not the arrow",
+	)
 	assert_eq(_cell(map, 4, 15), Gen2Text.encode("ESCAPE")[0])
+
+
+## `.Title` is `db $3b, " OPTION ", $3c`, so the second button picture follows
+## the string's own trailing space rather than replacing it.
+func test_a_title_bar_keeps_the_space_in_front_of_its_second_picture() -> void:
+	var map: PackedInt32Array = _page().option_map(false, 0)
+	assert_eq(_cell(map, 0, 1), Gen2PokedexPage.SELECT_OPTION[0])
+	assert_eq(_cell(map, 8, 1), Gen2Text.encode(" ")[0], "OPTION's trailing space")
+	assert_eq(_cell(map, 9, 1), Gen2PokedexPage.START_SEARCH[0])
+
+
+## `Pokedex_PlaceSearchScreenTypeStrings` places a fixed-width
+## `PokedexTypeSearchStrings` entry at (9,4) and (9,6), so the name is centred by
+## the table rather than left where a variable-width one would start.
+func test_the_search_screen_centres_both_type_names_in_their_own_field() -> void:
+	var dex: Gen2Pokedex = _dex([])
+	for value: int in range(0, Gen2Pokedex.SEARCH_TYPE_MAX + 1):
+		var drawn: String = dex.search_type_string(value)
+		assert_eq(drawn.length(), Gen2Pokedex.SEARCH_TYPE_WIDTH, drawn)
+		assert_eq(drawn.strip_edges(), dex.search_type_name(value))
+		var left: int = drawn.length() - drawn.lstrip(" ").length()
+		var right: int = drawn.length() - drawn.rstrip(" ").length()
+		assert_true(right >= left and right - left <= 1, "the odd cell is on the right")
+	var map: PackedInt32Array = _page().search_map(
+		dex.search_type_string(Gen2Pokedex.SEARCH_TYPE_NONE),
+		dex.search_type_string(1), Gen2Pokedex.SEARCH_ROW_TYPE_1
+	)
+	assert_eq(_cell(map, 11, 4), Gen2Text.encode("-")[0], "\"  ----  \" starts at 9")
+
+
+## `PadFrontpic` fills the seven by seven box, so an unseen row's question mark
+## and a five-wide species both cover it entirely.
+func test_a_picture_fills_its_whole_box() -> void:
+	var side: int = Gen2PokedexPage.PIC_COLUMNS * Gen2PokedexPage.TILE
+	var question: Image = _page().unseen_pic()
+	assert_not_null(question, "the cache carries LoadQuestionMarkPic's own pic")
+	assert_eq(question.get_size(), Vector2i(side, side))
+	var padded: Image = Gen2PokedexPage.pad_pic(
+		Image.create_empty(40, 40, false, Image.FORMAT_RGBA8), Color.RED
+	)
+	assert_eq(padded.get_size(), Vector2i(side, side))
+	assert_eq(padded.get_pixel(0, 0), Color.RED, "the blank column PadFrontpic fills")
+	assert_eq(
+		padded.get_pixel(side - 1, side - 1), Color.RED,
+		"a narrow pic is one column in and sits on the box's floor",
+	)

--- a/tools/checks/pokedex.gd
+++ b/tools/checks/pokedex.gd
@@ -27,6 +27,15 @@ const SHEET_FIRST: int = Gen2PokedexPage.SHEET_FIRST_TILE
 ## rather than a species that has none.
 const SPECIES: int = RomLayout.FOOTPRINT_SPECIES
 
+## `PokedexTypeSearchStrings` (data/types/search_strings.asm) verbatim, minus its
+## terminator. [method Gen2Pokedex.search_type_string] centres the imported name
+## instead of holding this table, so this is where the two are made to agree.
+const SEARCH_STRINGS: Array[String] = [
+	"  ----  ", " NORMAL ", "  FIRE  ", " WATER  ", " GRASS  ", "ELECTRIC",
+	"  ICE   ", "FIGHTING", " POISON ", " GROUND ", " FLYING ", "PSYCHIC ",
+	"  BUG   ", "  ROCK  ", " GHOST  ", " DRAGON ", "  DARK  ", " STEEL  ",
+]
+
 
 func run(r: RefCounted) -> void:
 	_r = r
@@ -57,6 +66,7 @@ func _validate(game_id: StringName) -> String:
 	for sheet: Array in [
 		["pokedex", RomLayout.POKEDEX_TILES],
 		["pokedex_slowpoke", RomLayout.POKEDEX_SLOWPOKE_TILES],
+		["pokedex_question_mark", RomLayout.POKEDEX_QUESTION_MARK_TILES],
 		["unown_font", RomLayout.UNOWN_FONT_TILES],
 		["footprints", RomLayout.FOOTPRINT_SLOTS * RomLayout.FOOTPRINT_TILES],
 	]:
@@ -133,12 +143,36 @@ func _validate(game_id: StringName) -> String:
 		])
 		return ""
 
-	print("%s: sheet=%d slowpoke=%d unown_font=%d footprints=%d species=%d" % [
+	# `Pokedex_PlaceTypeString` reads a fixed-width table, so the two search rows
+	# and the results screen's line are only right if the centring answers it.
+	var dex: Gen2Pokedex = Gen2Pokedex.open(data, null, RomLayout.DEXMODE_NEW)
+	for value: int in SEARCH_STRINGS.size():
+		var drawn: String = dex.search_type_string(value)
+		if drawn != SEARCH_STRINGS[value]:
+			print("FAIL %s: search string %d is \"%s\", wanted \"%s\"" % [
+				game_id, value, drawn, SEARCH_STRINGS[value],
+			])
+			return ""
+
+	# The question mark is a picture, so a strip of the right length is not
+	# enough: an offset that landed on a neighbouring run would still be 49
+	# tiles. Its own lit pixels are counted, and the digest below pins the art.
+	var question: PackedByteArray = data.tile_indices("pokedex_question_mark")
+	var question_colours: Dictionary = {}
+	for index: int in question.size():
+		question_colours[question[index]] = true
+	if question_colours.size() < 2:
+		print("FAIL %s: the question mark pic is one flat colour" % game_id)
+		return ""
+
+	print("%s: sheet=%d slowpoke=%d question_mark=%d unown_font=%d footprints=%d species=%d" % [
 		game_id, RomLayout.POKEDEX_TILES, RomLayout.POKEDEX_SLOWPOKE_TILES,
+		RomLayout.POKEDEX_QUESTION_MARK_TILES,
 		RomLayout.UNOWN_FONT_TILES, SPECIES, RomLayout.SPECIES_COUNT,
 	])
-	return "%s/%s/%s" % [
+	return "%s/%s/%s/%s" % [
 		indices.slice(0, 4096).hex_encode().sha1_text().substr(0, 8),
 		data.tile_indices("pokedex").slice(0, 928).hex_encode().sha1_text().substr(0, 8),
 		data.tile_indices("unown_font").hex_encode().sha1_text().substr(0, 8),
+		question.hex_encode().sha1_text().substr(0, 8),
 	]

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -18,6 +18,8 @@ const NEW_BARK_GROUP: int = 24
 const NEW_BARK_MAP: int = 7
 ## How far down the dex the preview's save has been filled.
 const SEEN: int = 251
+## The one species left out of it, so the listing has an unseen row to draw.
+const UNSEEN: int = 1
 
 const BUTTONS: Dictionary = {
 	"u": Gen2Button.UP, "d": Gen2Button.DOWN,
@@ -30,10 +32,15 @@ const BUTTONS: Dictionary = {
 ## have to know the walk.
 const ROUTES: Dictionary = {
 	"list": "",
+	# BULBASAUR's own row, which is the one that is not seen: `NewPokedexOrder`
+	# holds it at position 226, which is thirty-two pages down and one row on.
+	"unseen": "r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,r,d",
 	"entry": "a",
 	"option": "sel",
 	"search": "start",
-	"results": "start,d,d,a",
+	# BEGIN SEARCH spends `AnimateDexSearchSlowpoke` before the results open, so
+	# the walk has to wait it out.
+	"results": "start,d,d,a,f%d" % Gen2PokedexScreen.SEARCH_FRAMES,
 	"unown": "sel,d,d,d,a",
 }
 
@@ -96,9 +103,14 @@ func _initialize() -> void:
 ## A world whose dex is filled far enough to draw every row state: seen up to
 ## [constant SEEN], caught on every second one, and the Unown dex unlocked so the
 ## OPTION screen offers its fourth row.
+##
+## [constant UNSEEN] is left out so one row is the not-seen one, which is the
+## only row that draws `LoadQuestionMarkPic`'s picture.
 static func _state() -> Gen2WorldState:
 	var state := Gen2WorldState.new({}, {}, {}, {})
 	for species: int in range(1, SEEN + 1):
+		if species == UNSEEN:
+			continue
 		state.set_species_seen(species)
 		if species % 2 == 0:
 			state.set_species_caught(species)


### PR DESCRIPTION
The Pokedex listing drew its cursor as a tile in column 0. That pushed every
name and every dex number one column right, so a ten-letter name ran into the
scroll bar. On the cartridge the cursor is an object frame drawn over the whole
screen, out of the same sheet as the scroll bar's knob and the search screen's
Slowpoke, and none of those three were drawn at all.

All three are drawn now, and `Pokedex_PrintListing` writes its rows at the
columns it really writes.

`LoadQuestionMarkPic`'s picture is imported as well, so an unseen row draws a
question mark instead of an empty box. Compressing the pinned PNG matches
nothing in any dump, in either tile order or polarity. Decompressing every
offset and keeping the streams of exactly 49 tiles finds it once in each dump,
byte identical on all three.

Also from the same reading:

- The two listing screens set `wCurPartySpecies` to -1, so `_CGB_Pokedex` draws
  their picture through `PokedexQuestionMarkPalette`. Every species is green
  there; only the entry and Unown screens use its own colours.
- `PadFrontpic` fills the seven by seven box, so a narrow species no longer
  leaves the screen's background showing around it.
- `PokedexTypeSearchStrings` is eight cells wide and centred. The search rows
  drew an unpadded name one column right of where the table starts.
- BEGIN SEARCH spends `AnimateDexSearchSlowpoke`, and the not-found message its
  own $80 frames. Neither held anything before.
- B on an entry opened from the search results goes back to them.
- The Unown cursor is `FIRST_UNOWN_CHAR + NUM_UNOWN`, a diamond.
- `.Title`'s second button picture follows the trailing space.
- `PrintNum` with no decimal nibble still prints its last digit.

Cache format 94: the new sheet needs a re-import.

Met on the way and fixed here: five shadowed variables the editor panel lists,
in `game_data.gd`, `mystery_gift_screen.gd` and `link_screen.gd`.

## Proving it

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3833 tests, 71867 asserts, all green |
| `validate.gd -- all` | exit 0 on all three cartridges |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | reaches Red, no failed leg |
| Re-import | 3/3, `layout: Layout verified.` on each |
| Editor error panel | 5 GDScript warnings before, 0 after |

`tools/checks/pokedex.gd` gained the search-string table verbatim and a check
that the question mark is a picture rather than a flat fill; breaking the
centring on purpose turns it red. Screenshots of all six screens before and
after went to the owner.