### PR TITLE
Send the enemy's damage prediction through ConstantDamage

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -1508,15 +1508,10 @@ static func _apply_opportunist(scores: Array, c: Context) -> void:
 ## ([constant RECKLESS_EFFECTS]) or does one point of damage that is really a
 ## fixed-damage move ([code]power < 2[/code]).
 ##
-## The estimate is [constant Gen2Damage.MAX_VARIATION] with no critical, the top
-## of a hit's real range. `AIDamageCalc` special-cases fixed-damage effects this
-## engine does not implement, so those use the ordinary formula: that shifts how
-## hard they rank, not which move is strongest.
+## The estimate is [method _estimate_damage], which is `AIDamageCalc` itself.
 static func _apply_aggressive(scores: Array, c: Context) -> void:
 	var attacker: Gen2BattleMon = c.attacker
-	var defender: Gen2BattleMon = c.defender
 	var data: GameData = c.data
-	var defender_screens: int = c.defender_screens
 	var best_slot: int = -1
 	var best_damage: int = -1
 	for slot: int in Gen2BattleMon.MAX_MOVES:
@@ -1525,7 +1520,7 @@ static func _apply_aggressive(scores: Array, c: Context) -> void:
 		var move: Dictionary = _move_at(attacker, data, slot)
 		if _power(move) <= 0:
 			continue
-		var damage: int = _estimate_damage(attacker, defender, move, defender_screens)
+		var damage: int = _estimate_damage(c, move)
 		if damage >= best_damage:
 			best_damage = damage
 			best_slot = slot
@@ -1544,16 +1539,30 @@ static func _apply_aggressive(scores: Array, c: Context) -> void:
 		_discourage(scores, slot, 1)
 
 
-## The AI's own damage prediction, which is `EnemyAttackDamage` and
-## `BattleCommand_DamageCalc` themselves rather than an approximation of them, so
-## it reads the player's screens exactly as a real hit would.
-static func _estimate_damage(
-	attacker: Gen2BattleMon, defender: Gen2BattleMon, move: Dictionary,
-	defender_screens: int = Gen2Screens.NONE
-) -> int:
+## `AIDamageCalc`: the AI's own damage prediction, which is `EnemyAttackDamage`
+## and `BattleCommand_DamageCalc` themselves rather than an approximation of
+## them, so it reads the player's screens exactly as a real hit would.
+##
+## [constant Gen2Damage.CONSTANT_DAMAGE_EFFECTS] leaves the formula alone and
+## answers with `BattleCommand_ConstantDamage`'s own number, the same one the hit
+## will deal. All six of those moves carry a power the AI's callers test, so the
+## branch is live: without it Seismic Toss and Night Shade are read at power 1
+## and Super Fang at 1, and an aggressive or risky trainer plays them blind.
+##
+## [param constant] is what `AI_Smart_PriorityHit` is missing: it inlines the
+## three formula calls and never consults the list.
+##
+## Psywave's prediction really does roll, `BattleCommand_ConstantDamage` calling
+## `BattleRandom` inside the estimate, so the roll is spent here too. The
+## cartridge spends it on the battle's stream rather than the AI's; this engine
+## injects one generator for both, which is the same object either way.
+static func _estimate_damage(c: Context, move: Dictionary, constant: bool = true) -> int:
+	var effect: int = _effect(move)
+	if constant and Gen2Damage.CONSTANT_DAMAGE_EFFECTS.has(effect):
+		return Gen2Damage.constant_damage(effect, c.attacker, c.defender, move, c.rng)
 	return int(Gen2Damage.calculate_with(
-		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, defender_screens
+		c.attacker, c.defender, move, false, Gen2Damage.MAX_VARIATION,
+		Gen2Weather.NONE, c.defender_screens
 	)["damage"])
 
 
@@ -1613,7 +1622,6 @@ static func _apply_risky(scores: Array, c: Context) -> void:
 	var defender: Gen2BattleMon = c.defender
 	var data: GameData = c.data
 	var rng: RandomNumberGenerator = c.rng
-	var defender_screens: int = c.defender_screens
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not attacker.can_use(slot):
 			continue
@@ -1627,7 +1635,7 @@ static func _apply_risky(scores: Array, c: Context) -> void:
 			if _roll(rng, 79):
 				continue
 
-		if _estimate_damage(attacker, defender, move, defender_screens) >= defender.hp:
+		if _estimate_damage(c, move) >= defender.hp:
 			_encourage(scores, slot, 5)
 
 
@@ -1964,7 +1972,7 @@ static func _smart_priority_hit(scores: Array, slot: int, c: Context) -> void:
 		_discourage(scores, slot)
 		return
 	var move: Dictionary = _move_at(c.attacker, c.data, slot)
-	if _estimate_damage(c.attacker, c.defender, move, c.defender_screens) > c.defender.hp:
+	if _estimate_damage(c, move, false) > c.defender.hp:
 		_encourage(scores, slot, 3)
 
 

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -11,7 +11,8 @@ extends RefCounted
 ## The cartridge's four commands are [method damage_stats], [method damage_calc],
 ## [method stab_damage] and [method apply_variation], run one at a time by
 ## [Gen2EffectCommands] because half a dozen effects write between two of them.
-## [method calculate] and [method calculate_with] are the composition.
+## [method calculate_with] is the composition, for a caller with no list to put
+## the four in.
 
 ## The cap lands before the minimum is added, so the biggest hit is 999 and the
 ## smallest that connects at all is 2.
@@ -52,27 +53,6 @@ const STAT_BYTE_MAX: int = 0xFF
 const TRUNCATE_SHIFT: int = 4
 
 
-## A hit, rolled.
-static func calculate(
-	attacker: Gen2BattleMon,
-	defender: Gen2BattleMon,
-	move: Dictionary,
-	rng: RandomNumberGenerator,
-	focus_energy: bool = false,
-	defense_halved: bool = false,
-	weather: int = Gen2Weather.NONE,
-	defender_screens: int = Gen2Screens.NONE,
-	foresight: bool = false
-) -> Dictionary:
-	var scope_lens: bool = attacker != null \
-		and Gen2HeldItem.effect_of(attacker.data, attacker.item) == Gen2HeldItem.CRITICAL_UP
-	return calculate_with(
-		attacker, defender, move,
-		roll_critical(move, rng, focus_energy, scope_lens),
-		roll_variation(rng), defense_halved, weather, defender_screens, foresight
-	)
-
-
 ## A hit with both rolls decided: deterministic, and the whole formula, for a
 ## caller (the AI, a test) that has no list to put the four steps in. Present,
 ## Triple Kick, Fury Cutter and Rollout each write between two of them, which is
@@ -83,13 +63,16 @@ static func calculate(
 ## always the one damage used (see [method GameData.type_effectiveness]);
 ## [code]immune[/code] is a matchup of zero, which is a miss rather than a hit
 ## for nothing.
+##
+## Selfdestruct's halved defense comes off the move's own effect byte here, the
+## way `BattleCommand_DamageCalc` reads it, so a caller predicting a hit gets the
+## same number the hit will deal.
 static func calculate_with(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
 	move: Dictionary,
 	critical: bool,
 	variation: int,
-	defense_halved: bool = false,
 	weather: int = Gen2Weather.NONE,
 	defender_screens: int = Gen2Screens.NONE,
 	foresight: bool = false
@@ -107,7 +90,8 @@ static func calculate_with(
 	)
 	var damage: int = damage_calc(
 		attacker, int(move.get("power", 0)), int(stats[0]), int(stats[1]),
-		defense_halved, move_type, critical
+		int(move.get("effect", 0)) == Gen2MoveEffect.SELFDESTRUCT,
+		move_type, critical
 	)
 
 	var stabbed: Dictionary = stab_damage(
@@ -438,6 +422,41 @@ static func hidden_power(dvs: int) -> Dictionary:
 	if move_type >= RomLayout.TYPE_UNUSED_START:
 		move_type += RomLayout.TYPE_UNUSED_END - RomLayout.TYPE_UNUSED_START
 	return {"type": move_type, "power": power}
+
+
+## `ConstantDamageEffects`: the four effects whose damage skips the formula
+## entirely. Reversal shares `BattleCommand_ConstantDamage` and not this list,
+## because it sets a power and runs the formula after it.
+const CONSTANT_DAMAGE_EFFECTS: Array[int] = [
+	Gen2MoveEffect.SUPER_FANG, Gen2MoveEffect.STATIC_DAMAGE,
+	Gen2MoveEffect.LEVEL_DAMAGE, Gen2MoveEffect.PSYWAVE,
+]
+
+
+## `BattleCommand_ConstantDamage`'s four listed arms, shared by the hit itself
+## and by `AIDamageCalc`, which routes the same four effects here rather than
+## through the formula. [param defender] is whoever the hit lands on, which is
+## the only mon Super Fang reads.
+##
+## A null [param rng] is a prediction rather than a hit, and answers Psywave with
+## the top of its range the way [constant MAX_VARIATION] does for the formula.
+static func constant_damage(
+	effect: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
+	move: Dictionary, rng: RandomNumberGenerator = null
+) -> int:
+	match effect:
+		Gen2MoveEffect.LEVEL_DAMAGE:
+			return attacker.level
+		Gen2MoveEffect.PSYWAVE:
+			if rng == null:
+				@warning_ignore("integer_division")
+				return maxi(attacker.level / 2 + attacker.level - 1, 1)
+			return psywave_damage(attacker.level, rng)
+		Gen2MoveEffect.SUPER_FANG:
+			@warning_ignore("integer_division")
+			return maxi(defender.hp / 2, 1)
+	# STATIC_DAMAGE: Sonicboom and Dragon Rage deal exactly their own power.
+	return int(move.get("power", 0))
 
 
 ## Psywave: one up to but excluding one and a half times the level, the halving

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -2180,13 +2180,6 @@ static func _fixed_damage(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 
 	match turn.effect():
-		Gen2MoveEffect.LEVEL_DAMAGE:
-			turn.damage = attacker.level
-		Gen2MoveEffect.PSYWAVE:
-			turn.damage = Gen2Damage.psywave_damage(attacker.level, turn.rng())
-		Gen2MoveEffect.SUPER_FANG:
-			@warning_ignore("integer_division")
-			turn.damage = maxi(defender.hp / 2, 1)
 		Gen2MoveEffect.REVERSAL:
 			# `.reversal` is the one branch that does not hand back a number: it
 			# picks a power off how much health is left and then runs
@@ -2198,8 +2191,10 @@ static func _fixed_damage(turn: Gen2Turn) -> void:
 			)
 			_damage_stats(turn)
 			_damage_calc(turn)
-		_: # STATIC_DAMAGE: Sonicboom and Dragon Rage deal exactly their own power.
-			turn.damage = int(turn.move.get("power", 0))
+		_:
+			turn.damage = Gen2Damage.constant_damage(
+				turn.effect(), attacker, defender, turn.move, turn.rng()
+			)
 
 
 ## How much an attacker's own level adds to an OHKO move's accuracy, doubled
@@ -2598,9 +2593,9 @@ static func _mist(turn: Gen2Turn) -> void:
 	turn.emit(Gen2Battle.MIST_SET)
 
 
-## Raises the user's critical rate until a switch: [method _damage_calc] and
-## [method _multi_hit] read the flag through [method Gen2Damage.calculate]'s
-## [code]focus_energy[/code] argument. A second use fails without re-applying.
+## Raises the user's critical rate until a switch: [method _critical] reads the
+## flag through [method Gen2Damage.roll_critical]'s [code]focus_energy[/code]
+## argument, once per hit. A second use fails without re-applying.
 static func _focus_energy(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.FOCUS_ENERGY):

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -151,6 +151,47 @@ func test_aggressive_prefers_whichever_move_deals_more_damage() -> void:
 		assert_eq(slot, stronger_slot, "the harder-hitting move should win every time")
 
 
+func test_aggressive_reads_a_constant_damage_move_at_its_real_number() -> void:
+	# `AIDamageCalc` sends `ConstantDamageEffects` through
+	# `BattleCommand_ConstantDamage`, so Seismic Toss is read at the user's level
+	# rather than at its stored power of 1. Through the formula it looks like the
+	# weakest move on the set and Tackle wins.
+	var pikachu: Gen2BattleMon = _mon(
+		Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.LEVEL_DAMAGE_MOVE]
+	)
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var tackle_damage: int = int(Gen2Damage.calculate_with(
+		pikachu, geodude, _data.move(Fixture.TACKLE), false, Gen2Damage.MAX_VARIATION
+	)["damage"])
+	assert_lt(tackle_damage, 50, "the scenario needs Seismic Toss to be the harder hit")
+
+	for seed_value: int in 10:
+		_rng.seed = seed_value
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_AGGRESSIVE, _rng
+		)
+		assert_eq(slot, 1, "fifty points beats Tackle against a Rock/Ground defender")
+
+
+func test_risky_sees_the_ko_a_constant_damage_move_would_land() -> void:
+	var pikachu: Gen2BattleMon = _mon(
+		Fixture.PIKACHU, 50, [Fixture.TACKLE, Fixture.LEVEL_DAMAGE_MOVE]
+	)
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var tackle_damage: int = int(Gen2Damage.calculate_with(
+		pikachu, geodude, _data.move(Fixture.TACKLE), false, Gen2Damage.MAX_VARIATION
+	)["damage"])
+	# Strictly between the two hits: Seismic Toss finishes it, Tackle does not.
+	geodude.hp = maxi(tackle_damage + 1, 1)
+	assert_lt(geodude.hp, 51, "the scenario needs Seismic Toss to be the only KO")
+	for seed_value: int in 10:
+		_rng.seed = seed_value
+		var slot: int = Gen2BattleAI.choose_slot(
+			pikachu, geodude, _data, RomLayout.AI_RISKY, _rng
+		)
+		assert_eq(slot, 1, "only Seismic Toss takes the last hit point")
+
+
 func test_risky_encourages_whichever_move_would_actually_ko() -> void:
 	var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.EMBER, Fixture.SLASH])
 	var bulbasaur: Gen2BattleMon = _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -179,15 +179,20 @@ func test_a_move_with_no_power_never_crits() -> void:
 		assert_false(Gen2Damage.roll_critical(_data.move(Fixture.GROWL), rng))
 
 
+## `BattleCommand_DamageCalc` reads the effect byte itself rather than taking the
+## halving from its caller, so every prediction of the hit gets it too. The
+## comparison is the same move with an effect that halves nothing.
 func test_selfdestruct_halves_defense_before_the_formula() -> void:
 	var attacker: Gen2BattleMon = _mon(Fixture.PIKACHU)
 	var defender: Gen2BattleMon = _mon(Fixture.BULBASAUR)
 	var move: Dictionary = _data.move(Fixture.SELFDESTRUCT)
+	var plain: Dictionary = move.duplicate()
+	plain["effect"] = Gen2MoveEffect.NORMAL_HIT_EFFECT
 	var ordinary: Dictionary = Gen2Damage.calculate_with(
-		attacker, defender, move, false, Gen2Damage.MAX_VARIATION, false
+		attacker, defender, plain, false, Gen2Damage.MAX_VARIATION
 	)
 	var halved: Dictionary = Gen2Damage.calculate_with(
-		attacker, defender, move, false, Gen2Damage.MAX_VARIATION, true
+		attacker, defender, move, false, Gen2Damage.MAX_VARIATION
 	)
 	assert_gt(int(halved["damage"]), int(ordinary["damage"]))
 
@@ -208,8 +213,7 @@ func test_the_weather_multiplies_before_stab_and_the_matchup() -> void:
 		[Gen2Weather.SANDSTORM, 54],
 	]:
 		var hit: Dictionary = Gen2Damage.calculate_with(
-			attacker, defender, _data.move(Fixture.EMBER), false, Gen2Damage.MAX_VARIATION,
-			false, int(pair[0])
+			attacker, defender, _data.move(Fixture.EMBER), false, Gen2Damage.MAX_VARIATION, int(pair[0])
 		)
 		assert_eq(int(hit["damage"]), int(pair[1]), "weather %d" % int(pair[0]))
 
@@ -253,8 +257,7 @@ func test_struggle_is_outside_the_weather_as_well() -> void:
 		attacker, defender, _data.move(Fixture.STRUGGLE), false, Gen2Damage.MAX_VARIATION
 	)
 	var sunny: Dictionary = Gen2Damage.calculate_with(
-		attacker, defender, _data.move(Fixture.STRUGGLE), false, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.SUN
+		attacker, defender, _data.move(Fixture.STRUGGLE), false, Gen2Damage.MAX_VARIATION, Gen2Weather.SUN
 	)
 	assert_eq(int(sunny["damage"]), int(plain["damage"]))
 
@@ -451,11 +454,11 @@ func test_light_screen_doubles_the_special_defence_a_special_move_divides_by() -
 	)
 	var screened: Dictionary = Gen2Damage.calculate_with(
 		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+		Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
 	)
 	var wrong_screen: Dictionary = Gen2Damage.calculate_with(
 		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, Gen2Screens.REFLECT
+		Gen2Weather.NONE, Gen2Screens.REFLECT
 	)
 
 	assert_eq(bare["damage"], 27)
@@ -473,11 +476,11 @@ func test_reflect_is_the_physical_screen_and_light_screen_guards_nothing_physica
 	)["damage"])
 	var reflected: int = int(Gen2Damage.calculate_with(
 		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, Gen2Screens.REFLECT
+		Gen2Weather.NONE, Gen2Screens.REFLECT
 	)["damage"])
 	var light: int = int(Gen2Damage.calculate_with(
 		attacker, defender, move, false, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+		Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
 	)["damage"])
 
 	assert_lt(reflected, bare)
@@ -500,7 +503,7 @@ func test_a_critical_that_ignores_the_stages_ignores_the_screen_with_them() -> v
 	)["damage"])
 	var critical_screened: int = int(Gen2Damage.calculate_with(
 		attacker, defender, move, true, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+		Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
 	)["damage"])
 
 	assert_eq(critical_screened, critical_bare, "the critical went through the screen")
@@ -513,7 +516,7 @@ func test_a_critical_that_ignores_the_stages_ignores_the_screen_with_them() -> v
 	)["damage"])
 	var kept_screened: int = int(Gen2Damage.calculate_with(
 		attacker, defender, move, true, Gen2Damage.MAX_VARIATION,
-		false, Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
+		Gen2Weather.NONE, Gen2Screens.LIGHT_SCREEN
 	)["damage"])
 
 	assert_lt(kept_screened, kept_bare, "this critical kept the screen")

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -9384,13 +9384,12 @@ func _weakening_member(battle: Gen2Battle, party: Gen2Party, target: Gen2BattleM
 		var slot: int = _throttled_slot(battle, member, target)
 		if slot < 0:
 			continue
-		var hit: Dictionary = Gen2Damage.calculate_with(
-			member, target, battle.data.move(int(member.moves[slot])),
-			true, Gen2Damage.MAX_VARIATION
+		var damage: int = _worst_case_damage(
+			member, target, battle.data.move(int(member.moves[slot]))
 		)
-		if int(hit.get("damage", 0)) > best_damage:
+		if damage > best_damage:
 			best = index
-			best_damage = int(hit.get("damage", 0))
+			best_damage = damage
 	return best
 
 
@@ -9407,16 +9406,31 @@ func _throttled_slot(battle: Gen2Battle, attacker: Gen2BattleMon, target: Gen2Ba
 		var move: Dictionary = battle.data.move(int(attacker.moves[slot]))
 		if move.is_empty() or int(move.get("power", 0)) <= 0:
 			continue
-		var hit: Dictionary = Gen2Damage.calculate_with(
-			attacker, target, move, true, Gen2Damage.MAX_VARIATION
-		)
-		var damage: int = int(hit.get("damage", 0))
-		if bool(hit.get("immune", false)) or damage >= target.hp:
+		var damage: int = _worst_case_damage(attacker, target, move)
+		if damage < 0 or damage >= target.hp:
 			continue
 		if best < 0 or damage > best_damage:
 			best = slot
 			best_damage = damage
 	return best
+
+
+## The hardest [param move] could hit for: a critical at
+## [constant Gen2Damage.MAX_VARIATION], or the constant number for the four
+## effects that skip the formula, whose stored power is 1 and whose real hit is
+## the user's level or half the target. Answers -1 when the target is immune.
+func _worst_case_damage(
+	attacker: Gen2BattleMon, target: Gen2BattleMon, move: Dictionary
+) -> int:
+	var effect: int = int(move.get("effect", 0))
+	if Gen2Damage.CONSTANT_DAMAGE_EFFECTS.has(effect):
+		return Gen2Damage.constant_damage(effect, attacker, target, move)
+	var hit: Dictionary = Gen2Damage.calculate_with(
+		attacker, target, move, true, Gen2Damage.MAX_VARIATION
+	)
+	if bool(hit.get("immune", false)):
+		return -1
+	return int(hit.get("damage", 0))
 
 
 ## What the wild does with the turn. `_random_slot`'s own answer


### PR DESCRIPTION
`AIDamageCalc` tests a move's effect against `ConstantDamageEffects` and hands Super Fang, Sonicboom, Dragon Rage, Seismic Toss, Night Shade and Psywave to `BattleCommand_ConstantDamage` instead of the formula. All six ran through the formula here, and each carries a stored power of 1 or 20 that the scoring layers test and then read as the hit. A trainer scoring with the aggressive or risky layer valued Seismic Toss at two points rather than fifty, so it discouraged its best move and never saw the KO it would land.

The prediction and the hit are one implementation now. `Gen2Damage.constant_damage` is what both `Gen2BattleAI._estimate_damage` and `Gen2EffectCommands._fixed_damage` call. `AI_Smart_PriorityHit` inlines the three formula calls and consults no list, which is the estimator's `constant` argument.

`BattleCommand_DamageCalc` also halves Selfdestruct's defense off the effect byte rather than off an argument, so every prediction of the hit gets the halving too. `calculate_with` took it as a defaulted parameter that `_estimate_damage` passed false for, undervaluing Selfdestruct and Explosion by about half against every defender. It reads the move now.

The story walk's catch throttle shared the blind spot: it cleared a party member holding Seismic Toss to swing at a wild it would have knocked out. Both of its callers go through one `_worst_case_damage`.

Multi-hit, OHKO, Rollout escalation and rampage were never divergences. None escalates inside `BattleCommand_DamageCalc`, so `AIDamageCalc` reads them at base power exactly as this project does, and Guillotine's power of 0 never reaches it at all.

`Gen2Damage.calculate` had no caller anywhere and is deleted, with the `_focus_energy` comment that pointed at it.

## Proving it

| Check | Result |
|---|---|
| `gut` unit tier | 3328 tests, 3328 passing, 62757 asserts |
| `validate.gd -- all` | 75 topics, all PASS, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | `ok`, 16 badges on each |
| Boot smoke, `--quit-after 30` | clean |

The two new scoring cases go red with the branch disabled and green with it, and the Selfdestruct case compares the move against a copy of itself carrying an effect byte that halves nothing.