### PR TITLE
Draw the dot a minimized Pokemon leaves behind

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -317,6 +317,13 @@ const SUBSTITUTE_FADED: StringName = &"substitute_faded"
 ## battle state. An animated drop is the animation's own `anim_dropsub`.
 const SUBSTITUTE_PIC: StringName = &"substitute_pic"
 
+## `MinimizeDropSub`, `BattleCommand_StatUp`'s tail: the byte
+## `wPlayerMinimized`/`wEnemyMinimized` that reloads the actor's square as
+## `GetMinimizePic`'s dot, and keeps reloading it as that for as long as the
+## Pokemon stays in. Cleared by a send-out the way every other volatile is, so
+## there is no event for the other direction.
+const MINIMIZED: StringName = &"minimized"
+
 ## Leech Seed, on the Pokémon that was seeded rather than the one that seeded it.
 ## [constant LEECH_SEED_SAPPED] carries the healed side under `to`, `to_amount`,
 ## `to_hp` and `to_max_hp`, since one event moves health across the field.

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -114,6 +114,14 @@ const IF_VAR_EQUAL: StringName = &"if_var_equal"
 const SET_VAR: StringName = &"set_var"
 const INC_VAR: StringName = &"inc_var"
 const CHECK_POKEBALL: StringName = &"check_pokeball"
+## The three that write the actor's own picture. `BattleAnimCmd_Minimize` and
+## `..._Transform` write `vTiles0` and `..._UpdateActorPic` copies it onto the
+## square; `..._MinimizeOpp` writes the square itself and is reached from
+## `DropPlayerSub` rather than from any animation.
+const MINIMIZE: StringName = &"minimize"
+const MINIMIZE_OPP: StringName = &"minimize_opp"
+const UPDATE_ACTOR_PIC: StringName = &"update_actor_pic"
+const TRANSFORM: StringName = &"transform"
 
 ## `GetPokeBallWobble`'s three answers, which `BattleAnim_ThrowPokeBall.Loop`
 ## branches on: keep wobbling, click shut, or break free.

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -73,6 +73,11 @@ const SUBSTITUTE_SPRITE: int = 0x4C
 const SUBSTITUTE_AT: Dictionary = {false: Vector2i(2, 5), true: Vector2i(2, 4)}
 const SUBSTITUTE_FIRST_TILE: Dictionary = {false: 0, true: 4}
 
+## `GetMinimizePic` reads the same way, and drops its one tile a column right of
+## the doll's own: `sScratch + (3 * 7 + 5) tiles` on the enemy's box and
+## `sScratch + (3 * 6 + 4) tiles` on the player's.
+const MINIMIZE_AT: Dictionary = {false: Vector2i(3, 5), true: Vector2i(3, 4)}
+
 ## One 56x56 and one 48x48 index buffer, the two pics padded out to their own
 ## boxes, rebuilt only when the picture drawn changes.
 var _enemy_pixels: PackedByteArray = PackedByteArray()
@@ -306,6 +311,7 @@ func _ensure_pixels() -> void:
 	var enemy_key: Array = [
 		int(_view.get("enemy_species", 0)), bool(_view.get("enemy_substitute", false)),
 		int(_view.get("enemy_unown_form", 0)), int(_view.get("enemy_trainer_pic", 0)),
+		bool(_view.get("enemy_minimized", false)),
 	]
 	if enemy_key != _enemy_pixels_key:
 		if int(enemy_key[3]) > 0:
@@ -314,6 +320,8 @@ func _ensure_pixels() -> void:
 			)
 		elif bool(enemy_key[1]):
 			_enemy_pixels = _substitute_pic(false)
+		elif bool(enemy_key[4]):
+			_enemy_pixels = _minimize_pic(false)
 		else:
 			# `GetAnimatedFrontpic` is what the enemy's square is loaded with,
 			# so its frames stand behind the picture in the same run.
@@ -326,6 +334,7 @@ func _ensure_pixels() -> void:
 	var player_key: Array = [
 		int(_view.get("player_species", 0)), bool(_view.get("player_substitute", false)),
 		int(_view.get("player_unown_form", 0)), String(_view.get("player_backpic", "")),
+		bool(_view.get("player_minimized", false)),
 	]
 	if player_key != _player_pixels_key:
 		if not String(player_key[3]).is_empty():
@@ -335,6 +344,8 @@ func _ensure_pixels() -> void:
 			)
 		elif bool(player_key[1]):
 			_player_pixels = _substitute_pic(true)
+		elif bool(player_key[4]):
+			_player_pixels = _minimize_pic(true)
 		else:
 			_player_pixels = padded_pic(_data,
 				_battler_pic(int(player_key[0]), int(player_key[2]), true),
@@ -354,6 +365,29 @@ func _battler_pic(species: int, unown_form: int, back: bool) -> Dictionary:
 
 func _substitute_pic(player_side: bool) -> PackedByteArray:
 	return substitute_pixels(_data.overworld_sprite_indices(SUBSTITUTE_SPRITE), player_side)
+
+
+func _minimize_pic(player_side: bool) -> PackedByteArray:
+	return minimize_pixels(_data.tile_indices("minimize"), player_side)
+
+
+## `GetMinimizePic`: a blank box with `MinimizePic`'s single tile copied into it.
+## Static for the same reason [method substitute_pixels] is.
+static func minimize_pixels(tile: PackedByteArray, player_side: bool) -> PackedByteArray:
+	var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+		else Gen2BattleScreenMap.ENEMY_SIDE
+	var box: int = side * TILE
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(box * box)
+	if tile.size() < TILE * TILE:
+		return out
+
+	var at: Vector2i = MINIMIZE_AT[player_side]
+	for row: int in TILE:
+		var to: int = (at.y * TILE + row) * box + at.x * TILE
+		for column: int in TILE:
+			out[to + column] = tile[row * TILE + column]
+	return out
 
 
 ## `GetSubstitutePic`: a blank box with four tiles of [param strip], the monster

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1650,6 +1650,22 @@ const ANIM_SFX: StringName = &"sfx"
 ## which draws a fresh picture either way.
 var _substitute_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: false}
 
+## The second answer the same three writers give. `GetBattleMonBackpic` tests
+## `SUBSTATUS_SUBSTITUTE` first and `wPlayerMinimized` only after it, so a doll
+## stands in front of the dot and the dot is what is underneath when it comes
+## off. Written by [constant Gen2Battle.MINIMIZED] and cleared by a send-out.
+var _minimize_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: false}
+
+## `BattleAnimCmd_Minimize` writes `vTiles0`, which is off screen, and
+## `..._UpdateActorPic` copies it onto the square 48 frames later. The dot is
+## already on by then, `BattleCommand_StatUp` having set the byte two commands
+## before the animation, so this only keeps the two halves of the source's own
+## pair together. `BattleAnim_Transform` is the other user of the pair and no
+## list here reaches it: `BattleCommand_Transform` calls `LoadMoveAnim` inline
+## rather than through an `anim` command, and this port's Transform prints
+## without an animation.
+var _staged_minimize_pic: bool = false
+
 ## `wFXAnimID` is a word: an id past this is not a move and skips the whole
 ## battle-scene, hud and after-anim half of `BattleAnimRunScript`.
 const ANIM_MOVE_LIMIT: int = 0x100
@@ -1806,6 +1822,21 @@ func _set_substitute_pic(side: int, raised: bool) -> void:
 	_push_view()
 
 
+## The dot `GetMinimizePic` answers with, which outlives the animation that drew
+## it: nothing takes it off until the Pokemon leaves the field.
+func _set_minimize_pic(side: int, minimized: bool) -> void:
+	if bool(_minimize_pic.get(side, false)) == minimized:
+		return
+	_minimize_pic[side] = minimized
+	_push_view()
+
+
+## `hBattleTurn` inside an animation: whose animation this is.
+func _anim_actor() -> int:
+	return Gen2Battle.ENEMY if bool(_anim_event.get("enemy_turn", false)) \
+		else Gen2Battle.PLAYER
+
+
 func _step(kind: StringName, values: Dictionary) -> void:
 	var entry: Dictionary = values.duplicate()
 	entry["kind"] = kind
@@ -1906,10 +1937,20 @@ func _after_anim_frame() -> void:
 				# tiles, and the actor is `hBattleTurn`, which is whose animation
 				# this is.
 				_set_substitute_pic(
-					Gen2Battle.ENEMY if bool(_anim_event.get("enemy_turn", false))
-						else Gen2Battle.PLAYER,
+					_anim_actor(),
 					StringName(command["name"]) == Gen2BattleAnimScript.RAISE_SUB
 				)
+			Gen2BattleAnimScript.MINIMIZE:
+				_staged_minimize_pic = true
+			Gen2BattleAnimScript.UPDATE_ACTOR_PIC:
+				if _staged_minimize_pic:
+					_staged_minimize_pic = false
+					_set_minimize_pic(_anim_actor(), true)
+			Gen2BattleAnimScript.MINIMIZE_OPP:
+				# `GetMinimizePic` straight into `vTiles2`. No animation script
+				# names it: `DropPlayerSub` and `DropEnemySub` are its only
+				# callers, and both are the reload the byte already answers.
+				_set_minimize_pic(_anim_actor(), true)
 	_carry_battler_reports()
 	_push_view()
 
@@ -4270,6 +4311,20 @@ func _apply_event_state(event: Dictionary) -> void:
 			_begin_faint(int(event["side"]))
 		Gen2Battle.SUBSTITUTE_PIC:
 			_set_substitute_pic(int(event["side"]), bool(event["raised"]))
+		Gen2Battle.MINIMIZED:
+			_set_minimize_pic(int(event["side"]), true)
+		Gen2Battle.TRANSFORMED:
+			# `BattleCommand_Transform` copies the species and the DVs onto the
+			# actor, and every reload of the square after it draws the target.
+			if int(event["side"]) == Gen2Battle.ENEMY:
+				_enemy = int(event["species"])
+				_enemy_unown_form = int(event.get("unown_form", 0))
+				_enemy_shiny = bool(event.get("shiny", false))
+			else:
+				_player = int(event["species"])
+				_player_unown_form = int(event.get("unown_form", 0))
+				_player_shiny = bool(event.get("shiny", false))
+			_push_view()
 		Gen2Battle.CRY:
 			_play_entrance_cry(int(event["side"]), int(event["species"]))
 		Gen2Battle.SENT_OUT:
@@ -4294,6 +4349,9 @@ func _apply_event_state(event: Dictionary) -> void:
 			# `GetEnemyMonFrontpic`, and the doll it would answer with belongs to
 			# a Substitute that switching has already taken away.
 			_set_substitute_pic(int(event["side"]), false)
+			# `wPlayerMinimized` is one of the bytes a send-out zeroes, so the
+			# fresh picture is the Pokemon's own however the last one left.
+			_set_minimize_pic(int(event["side"]), false)
 			_reseed_bg_map()
 			_refresh_exp_bar()
 		Gen2Battle.EXP_GAINED:
@@ -5066,6 +5124,10 @@ func _push_view() -> void:
 		## Whose picture is the substitute's doll rather than the Pokémon's own.
 		"enemy_substitute": bool(_substitute_pic[Gen2Battle.ENEMY]),
 		"player_substitute": bool(_substitute_pic[Gen2Battle.PLAYER]),
+		## And whose is the dot `GetMinimizePic` draws, which a doll stands in
+		## front of for as long as one is up.
+		"enemy_minimized": bool(_minimize_pic[Gen2Battle.ENEMY]),
+		"player_minimized": bool(_minimize_pic[Gen2Battle.PLAYER]),
 		"enemy_name": _name_of(_enemy), "player_name": _name_of(_player),
 		"enemy_level": _enemy_level, "player_level": _player_level,
 		## Who the fight is against, which the values above do not say. A wild

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -977,8 +977,14 @@ static func _transform(turn: Gen2Turn) -> void:
 		turn.emit(Gen2Battle.MOVE_FAILED)
 		turn.end()
 		return
+	# `BattleAnimCmd_Transform` draws the copied species out of the copied DVs,
+	# so the letter and the shine are the target's from here on and not the
+	# user's own. Display values, the way a send-out's are.
 	turn.emit(Gen2Battle.TRANSFORMED, {
 		"species": turn.attacker().species, "target": turn.target,
+		"unown_form": Gen2Stats.unown_letter(turn.attacker().dvs) \
+			if turn.attacker().species == RomLayout.UNOWN_SPECIES else 0,
+		"shiny": Gen2Stats.is_shiny(turn.attacker().dvs),
 	})
 
 
@@ -3694,6 +3700,11 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	# carrying the ordinary `EFFECT_EVASION_UP` like Double Team.
 	if targets_user and turn.stat_moved and turn.move_number == MINIMIZE_MOVE:
 		turn.battle.mon(side).minimized = true
+		# The rest of `MinimizeDropSub`: `DropPlayerSub` reloads the square at
+		# once, and with the byte set it answers with the dot from here on. Its
+		# other half, taking a raised doll off the picture, is undone by the
+		# `raisesub` two commands later in every list that reaches here.
+		turn.emit(Gen2Battle.MINIMIZED, {"side": side})
 
 
 ## Minimize's move number, which is the whole of what `MinimizeDropSub` compares

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 94
+const FORMAT_VERSION: int = 95
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -4039,6 +4039,22 @@ static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictiona
 	if not levels["ok"]:
 		return levels
 
+	## `MinimizePic`, against [constant RomLayout.MINIMIZE_PIC_ROWS].
+	var minimize: PackedByteArray = Gen2Tiles.decode_2bpp_strip(
+		data, int(layout["minimize_pic"]), RomLayout.MINIMIZE_TILES
+	)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		for column: int in Gen2Tiles.TILE_WIDTH:
+			var index: int = minimize[row * Gen2Tiles.TILE_WIDTH + column]
+			var lit: bool = (RomLayout.MINIMIZE_PIC_ROWS[row] >> (7 - column)) & 1 == 1
+			if index != (3 if lit else 0):
+				return {
+					"ok": false,
+					"message": "Minimize pic: row %d column %d is colour %d." % [
+						row, column, index,
+					],
+				}
+
 	## `StatsScreenPageTilesGFX` carries no progression to sweep, so it is
 	## checked on the two tiles the source names by shape: tile 0 is the
 	## vertical divider, two lit columns on every row, and tile 14 is the `'⁂'`
@@ -7067,6 +7083,14 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 		"ball_icons": {
 			"offset": int(layout["ball_icons"]),
 			"tiles": RomLayout.BALL_ICON_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		## `MinimizePic`, the one tile `CopyMinimizePic` drops into a blank box
+		## for a Pokemon that has used Minimize.
+		"minimize": {
+			"offset": int(layout["minimize_pic"]),
+			"tiles": RomLayout.MINIMIZE_TILES,
 			"first_code": 0,
 			"bits": 2,
 		},

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -629,6 +629,13 @@ const BALL_ICON_FIRST_TILE: int = 0x31
 ## `BattleTransitionTiles`, the two `DoBattleTransition` fills the screen with,
 ## and the two four-colour palettes it draws them and the whole map in.
 const BATTLE_TRANSITION_TILES: int = 2
+## `MinimizePic`, the single tile `CopyMinimizePic` drops into an otherwise blank
+## box: the dot a minimized Pokemon is drawn as for as long as it stays in.
+const MINIMIZE_TILES: int = 1
+## Its eight rows, lit pixels set, transcribed off `gfx/battle/minimize.png`: a
+## solid diamond in colour 3 and nothing else. One tile has no neighbour to slide
+## against, so its own shape is the whole of what pins the address.
+const MINIMIZE_PIC_ROWS: Array[int] = [0x00, 0x00, 0x18, 0x3C, 0x7E, 0x3C, 0x24, 0x00]
 const TRANSITION_PALETTE_NAMES: Array[String] = ["day", "dark"]
 const TRANSITION_PALETTE_COLORS: int = 4
 ## `GetTrainerBackpic`: the player's own 6x6 picture, the one standing on the
@@ -2280,6 +2287,9 @@ const GOLD_SILVER: Dictionary = {
 	# `LoadBallIconGFX`'s four ball icons and `BattleTransitionTiles`' two, both
 	# uncompressed 2bpp runs read straight off the address.
 	"ball_icons": 0x2C1A4,
+	# `MinimizePic`, one uncompressed 2bpp tile; its sixteen bytes occur once in
+	# each of the three dumps.
+	"minimize_pic": 0xCC6C8,
 	# `BattleTransitionTiles` and the two palettes `LoadPokeBallGraphics` floods
 	# every background tile with, the second of which is the darkness palset's.
 	"battle_transition": {
@@ -2882,6 +2892,7 @@ const CRYSTAL: Dictionary = {
 	"exp_bar": 0xF8B10,
 	# See the Gold and Silver block above.
 	"ball_icons": 0x2C172,
+	"minimize_pic": 0xCC725,
 	"battle_transition": {
 		"tiles": 0x8C2F4, "palette": 0x8C6A1, "dark_palette": 0x8C6A9,
 	},

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -34,6 +34,9 @@ const PROMPT_WHATS_UP: String = "What's up?"
 const PROMPT_RELEASE: String = "Release PKMN?"
 const PROMPT_LAST_MON: String = "It's your last PKMN!"
 const PROMPT_NO_USABLE: String = "No more usable PKMN!"
+## `PCString_RemoveMail`, the third thing `BillsPC_CheckMail_PreventBlackout`
+## refuses on.
+const PROMPT_REMOVE_MAIL: String = "Remove MAIL."
 const PROMPT_BOX_FULL: String = "The BOX is full."
 const PROMPT_PARTY_FULL: String = "The party's full!"
 const PROMPT_NO_EGGS: String = "No releasing EGGS!"
@@ -475,8 +478,8 @@ func _confirm_submenu() -> void:
 
 
 ## `BillsPC_CheckMail_PreventBlackout`, which guards the party list's transfer
-## and its release alike. Its mail branch is unreachable here: no item is mail
-## until `ItemIsMail`'s list is imported (see [method _mon_state]).
+## and its release alike, in its own order: the last Pokemon, then a party with
+## nothing else standing, then mail.
 func _blackout_refusal() -> String:
 	if _loaded != LOADED_PARTY or _save == null:
 		return ""
@@ -484,14 +487,21 @@ func _blackout_refusal() -> String:
 		return PROMPT_LAST_MON
 	if _all_others_fainted():
 		return PROMPT_NO_USABLE
+	# `wBillsPC_MonHasMail`, which `BillsPC_PrintMonInfo` writes for the row the
+	# cursor stands on rather than for a stored selection.
+	var mon: Gen2SaveMon = _selected_mon()
+	if mon != null and not mon.is_egg and Gen2HeldItem.is_mail(mon.item):
+		return PROMPT_REMOVE_MAIL
 	return ""
 
 
 ## `CheckCurPartyMonFainted`: whether every party member but the chosen one has
-## no HP left.
+## no HP left. `wCurPartyMon` is `wBillsPC_CursorPosition` plus the scroll, so
+## the one left out is the row under the cursor.
 func _all_others_fainted() -> bool:
+	var chosen: int = _cursor + _scroll
 	for index: int in _save.party.size():
-		if index == _selected_party_index:
+		if index == chosen:
 			continue
 		var mon: Gen2SaveMon = _save.party[index]
 		if mon != null and mon.hp > 0:
@@ -748,9 +758,9 @@ func _mon_state(mon: Gen2SaveMon) -> Dictionary:
 		"gender": _gender_glyph(Gen2BattleMon.gender_for(_data, mon.species, mon.dvs)),
 		"species_name": String(_data.species(mon.species).get("name", "")),
 		"item": mon.item,
-		## `ItemIsMail` reads a list no importer reads, so no item is mail here
-		## and the mail marker is unreachable.
-		"mail": false,
+		## `ItemIsMail`, which picks the mail icon `$5c` over the item icon `$5d`
+		## and is what `wBillsPC_MonHasMail` records for the blackout guard.
+		"mail": Gen2HeldItem.is_mail(mon.item),
 	}
 
 

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -660,6 +660,71 @@ func test_the_doll_is_what_a_substituted_side_draws() -> void:
 	assert_eq(renderer._player_pixels, own)
 
 
+## `GetBattleMonBackpic` tests `SUBSTATUS_SUBSTITUTE` before `wPlayerMinimized`,
+## so a doll stands in front of the dot and the dot is what is underneath when
+## the doll comes off. Nothing takes the dot off but a send-out.
+func test_the_dot_is_what_a_minimized_side_draws_and_a_doll_stands_in_front_of_it() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+	var renderer: Gen2BattleRenderer = _battle_screen._renderer
+	var own: PackedByteArray = renderer._player_pixels.duplicate()
+	var dot: PackedByteArray = Gen2BattleRenderer.minimize_pixels(
+		_data.tile_indices("minimize"), true
+	)
+
+	_battle_screen._apply_event({
+		"type": Gen2Battle.MINIMIZED, "side": Gen2Battle.PLAYER,
+	})
+	assert_ne(renderer._player_pixels, own, "the dot replaced the picture")
+	assert_eq(renderer._player_pixels, dot)
+	assert_eq(renderer._enemy_pixels_key[4], false, "and only that side's")
+
+	_battle_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": true,
+	})
+	assert_eq(
+		renderer._player_pixels,
+		Gen2BattleRenderer.substitute_pixels(
+			_data.overworld_sprite_indices(Gen2BattleRenderer.SUBSTITUTE_SPRITE), true
+		),
+		"the doll is in front"
+	)
+	_battle_screen._apply_event({
+		"type": Gen2Battle.SUBSTITUTE_PIC, "side": Gen2Battle.PLAYER, "raised": false,
+	})
+	assert_eq(renderer._player_pixels, dot, "and the dot is underneath")
+
+
+## `BattleCommand_Transform` copies the species and the DVs onto the actor, and
+## every reload of the square after it draws the target: the Pokemon on the
+## field is the one it copied, not the one that used the move.
+func test_a_transformed_side_draws_the_species_it_copied() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+	var renderer: Gen2BattleRenderer = _battle_screen._renderer
+	assert_eq(int(renderer._player_pixels_key[0]), 155)
+
+	_battle_screen._apply_event({
+		"type": Gen2Battle.TRANSFORMED, "side": Gen2Battle.PLAYER, "target": Gen2Battle.ENEMY,
+		"species": 16, "unown_form": 0, "shiny": true,
+	})
+	assert_eq(
+		int(renderer._player_pixels_key[0]), 16, "the copied species is what is drawn"
+	)
+	assert_true(bool(renderer._view["player_shiny"]), "and the copied DVs are what shine")
+	assert_false(bool(renderer._view["enemy_shiny"]), "the target's own square is untouched")
+
+	# A send-out is the one thing that puts the user's own picture back.
+	_battle_screen._apply_event({
+		"type": Gen2Battle.SENT_OUT, "side": Gen2Battle.PLAYER, "species": 155,
+		"level": 7, "hp": 20, "max_hp": 20,
+	})
+	assert_eq(int(renderer._player_pixels_key[0]), 155)
+	assert_false(bool(renderer._view["player_shiny"]))
+
+
 ## The whole entrance as `view["battlers"]` reports it, one side at a time: who
 ## is standing on each square, and how far off it they are.
 ##

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -2517,8 +2517,12 @@ func test_the_doubling_lands_behind_the_spread_rather_than_in_front_of_it() -> v
 func test_minimize_is_what_makes_a_stomp_hurt_twice_as_much() -> void:
 	var battle: Gen2Battle = _battle()
 	assert_false(battle.enemy.minimized)
-	_run_enemy_move(battle, Fixture.MINIMIZE)
+	var turn: Gen2Turn = _run_enemy_move(battle, Fixture.MINIMIZE)
 	assert_true(battle.enemy.minimized, "the flag is set off the move number")
+	# `MinimizeDropSub`'s other half: the square is reloaded as the dot.
+	var pics: Array = _of_type(turn.events, Gen2Battle.MINIMIZED)
+	assert_eq(pics.size(), 1)
+	assert_eq(int(pics[0]["side"]), Gen2Battle.ENEMY)
 
 	var plain: Gen2Battle = _battle()
 	var against_plain: Gen2Turn = _run_move(plain, Fixture.STOMP)
@@ -4573,7 +4577,15 @@ func test_transform_copies_the_active_battle_struct_but_not_hp_level_or_status()
 	assert_eq(user.level, old_level)
 	assert_eq(user.status, Gen2Status.BURN)
 	assert_true(Gen2Substatus.has(user.substatus, Gen2Substatus.TRANSFORMED))
-	assert_eq(_of_type(turn.events, Gen2Battle.TRANSFORMED).size(), 1)
+	var transformed: Array = _of_type(turn.events, Gen2Battle.TRANSFORMED)
+	assert_eq(transformed.size(), 1)
+	# `BattleAnimCmd_Transform` draws the copied species out of the copied DVs,
+	# so both display values are the target's rather than the user's.
+	assert_eq(int(transformed[0]["species"]), target.species)
+	assert_eq(
+		bool(transformed[0]["shiny"]), Gen2Stats.is_shiny(target.dvs),
+		"the shine follows the DVs Transform copied"
+	)
 
 
 func test_transform_restores_party_data_on_switch_and_save_writeback() -> void:

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -702,7 +702,18 @@ func _battle_dump() -> PackedByteArray:
 	_write_battle_object_palettes(data)
 	_write_stats_screen_palettes(data)
 	_write_stats_tiles(data)
+	_write_minimize_pic(data)
 	return data
+
+
+## `MinimizePic`, the one tile whose own shape is what pins its address.
+func _write_minimize_pic(data: PackedByteArray) -> void:
+	var tile: PackedByteArray = PackedByteArray()
+	tile.resize(Gen2Tiles.TILE_BYTES)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		tile[row * 2] = RomLayout.MINIMIZE_PIC_ROWS[row]
+		tile[row * 2 + 1] = RomLayout.MINIMIZE_PIC_ROWS[row]
+	_write(data, int(_layout["minimize_pic"]), tile)
 
 
 ## `StatsScreenPageTilesGFX`, which sits immediately before the enemy HUD: the
@@ -837,6 +848,17 @@ func test_stats_tiles_that_are_not_where_the_enemy_hud_says_fail() -> void:
 	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(data), _layout)
 	assert_false(result["ok"])
 	assert_string_contains(String(result["message"]), "vertical divider")
+
+
+## The dot is drawn in colour 3, so a tile with one plane of it is a shape that
+## still decodes and is not `MinimizePic`.
+func test_a_minimize_pic_drawn_in_the_wrong_colour_fails() -> void:
+	var data: PackedByteArray = _battle_dump()
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		data[int(_layout["minimize_pic"]) + row * 2 + 1] = 0x00
+	var result: Dictionary = RomImporter.verify_battle_graphics(_rom(data), _layout)
+	assert_false(result["ok"])
+	assert_string_contains(String(result["message"]), "Minimize pic")
 
 
 func test_stats_tiles_missing_their_shiny_icon_fail() -> void:

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -279,6 +279,42 @@ func test_a_row_opens_the_submenu_and_its_first_row_is_the_transfer() -> void:
 	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
 
 
+## `BillsPC_CheckMail_PreventBlackout`'s three refusals, in its own order.
+## `CheckCurPartyMonFainted` leaves out `wCurPartyMon`, which is the row under
+## the cursor, so a party whose only standing Pokemon is the chosen one refuses;
+## and `wBillsPC_MonHasMail` is `ItemIsMail` on that same row.
+func test_the_party_list_refuses_a_transfer_that_would_leave_nobody_standing() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	var third: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.GEODUDE, 12, [Fixture.GROWL]
+	)
+	save.party.append(Gen2SaveBattleAdapter.from_battle_mon(third))
+	(save.party[1] as Gen2SaveMon).hp = 0
+	(save.party[2] as Gen2SaveMon).hp = 0
+	await _open_box_screen(save)
+
+	# The cursor stands on the one Pokemon still up, and it is the one left out.
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), Gen2BoxScreen.PROMPT_NO_USABLE)
+	assert_eq(save.party.size(), 3, "nothing moved")
+
+	# A fainted row has two others to fall back on, so only the mail stops it.
+	_box_screen.handle_button(Gen2Button.DOWN)
+	(save.party[1] as Gen2SaveMon).hp = 4
+	(save.party[1] as Gen2SaveMon).item = Gen2HeldItem.MAIL_ITEMS[0]
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(
+		String(_box_screen.box_snapshot()["prompt"]), Gen2BoxScreen.PROMPT_REMOVE_MAIL
+	)
+	assert_eq(save.party.size(), 3, "nothing moved")
+	assert_true(
+		bool(_box_screen._mon_state(save.party[1] as Gen2SaveMon)["mail"]),
+		"and the listing draws the mail icon rather than the item one"
+	)
+
+
 ## `_MovePKMNWithoutMail`: left and right load another list, the submenu drops
 ## RELEASE, and the second A puts the Pokemon where the insert cursor stands.
 func test_move_without_mail_reorders_a_list_and_moves_between_two() -> void:

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -114,6 +114,7 @@ func run(r: RefCounted) -> void:
 		_verify_palettes(game_id, data)
 		_verify_gfx(game_id, data)
 		_verify_substitute_pic(game_id, data)
+		_verify_minimize_pic(game_id, data)
 		_run_every_animation(game_id, data)
 		_play_every_animation(game_id, data)
 		_verify_tackle_frames(game_id, data)
@@ -468,6 +469,51 @@ func _verify_the_sliding_intro(game_id: StringName, data: GameData) -> void:
 ## tiles of `MonsterSpriteGFX` in an otherwise empty box, at the one place the
 ## routine copies them to. Nothing else in the box may carry ink, since the
 ## routine zeroes it first and the battler's own picture is gone while it is up.
+## `GetMinimizePic`, the same shape one tile smaller: `MinimizePic` alone in an
+## otherwise empty box, a column right of where the doll sits. The tile's own
+## content is pinned by `RomImporter.verify_layout`; what this sweeps is where it
+## lands on each side of each cartridge.
+func _verify_minimize_pic(game_id: StringName, data: GameData) -> void:
+	var tile: PackedByteArray = data.tile_indices("minimize")
+	if not _r.check(
+		tile.size() == Gen2Font.TILE * Gen2Font.TILE,
+		"%s: the minimize tile is %d pixels, not %d." % [
+			game_id, tile.size(), Gen2Font.TILE * Gen2Font.TILE,
+		]
+	):
+		return
+	for player_side: bool in [false, true]:
+		var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+			else Gen2BattleScreenMap.ENEMY_SIDE
+		var box: int = side * Gen2Font.TILE
+		var pixels: PackedByteArray = Gen2BattleRenderer.minimize_pixels(tile, player_side)
+		if not _r.check(
+			pixels.size() == box * box,
+			"%s: the dot's box is %d pixels, not %d." % [game_id, pixels.size(), box * box]
+		):
+			continue
+		var at: Vector2i = Gen2BattleRenderer.MINIMIZE_AT[player_side]
+		var dot := Rect2i(at * Gen2Font.TILE, Vector2i(Gen2Font.TILE, Gen2Font.TILE))
+		var inside: int = 0
+		var outside: int = 0
+		for y: int in box:
+			for x: int in box:
+				if pixels[y * box + x] == 0:
+					continue
+				if dot.has_point(Vector2i(x, y)):
+					inside += 1
+				else:
+					outside += 1
+		_r.check(inside == 18, "%s: the dot is %d lit pixels, not 18." % [game_id, inside])
+		_r.check(
+			outside == 0,
+			"%s: %d lit pixels outside the dot's own tile." % [game_id, outside]
+		)
+		print("%s: the %s dot is %d lit pixels at %s of a %dx%d box." % [
+			game_id, "player's" if player_side else "enemy's", inside, at, side, side,
+		])
+
+
 func _verify_substitute_pic(game_id: StringName, data: GameData) -> void:
 	var strip: PackedByteArray = data.overworld_sprite_indices(
 		Gen2BattleRenderer.SUBSTITUTE_SPRITE


### PR DESCRIPTION
`GetBattleMonBackpic` picks between three pictures for a battler's square: the substitute doll, `GetMinimizePic`'s dot, and the Pokemon's own. Only the first two existed here. `wPlayerMinimized` was tracked for Stomp's double damage and drawn nowhere, so a Pokemon that used Minimize went on standing there at full size.

`MinimizePic` is one uncompressed 2bpp tile whose sixteen bytes occur once in each of the three dumps, so it is imported rather than transcribed. `RomImporter.verify_layout` pins the address by the tile's own shape, and `tools/checks/battle_anims.gd` sweeps where it lands on both sides of all three cartridges. `Gen2Battle.MINIMIZED` is `MinimizeDropSub`'s reload; a send-out clears it the way it clears the doll.

Transform drew nothing either. `BattleCommand_Transform` copies the species and the DVs onto the actor, so every later reload of the square draws the target, letter and shine included. `Gen2Battle.TRANSFORMED` now carries the three display values and the screen applies them.

Two more things met on the way, both in the PC box screen:

- `CheckCurPartyMonFainted` leaves out `wCurPartyMon`, which is the row under the cursor. This left out a stored selection the joypad path never sets, so the party's own live Pokemon answered for itself and "No more usable PKMN!" could not fire.
- `ItemIsMail`'s list has been pinned in `Gen2HeldItem` for some time, so the box listing's mail icon and `BillsPC_CheckMail_PreventBlackout`'s third refusal were both reachable. Neither was built.

Cache format 95. All three cartridges re-imported, `layout: Layout verified.` on each.

| Check | Result |
|---|---|
| GUT, `tests/` with subdirectories | 3856 passing, 71993 asserts |
| `tools/validate.gd -- all` | 77 topics pass, 0 fail |
| `battle_anims` minimize sweep | 18 lit pixels at (3, 5) and (3, 4), none outside the tile, on all three |