### PR TITLE
Pay out what a beaten trainer is worth

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -602,9 +602,29 @@ var _future_sight: Dictionary = {
 	ENEMY: {"count": 0, "damage": 0},
 }
 
+## `GotMoneyForWinningText` and `.SentToMomTexts`, which
+## [method prize_money_split] picks between. The screen owns the words.
+const PRIZE_KEPT_IT_ALL: StringName = &"kept_it_all"
+const PRIZE_SENT_SOME_TO_MOM: StringName = &"sent_some_to_mom"
+const PRIZE_SENT_HALF_TO_MOM: StringName = &"sent_half_to_mom"
+const PRIZE_SENT_ALL_TO_MOM: StringName = &"sent_all_to_mom"
+const PRIZE_MOM_LINES: Array[StringName] = [
+	PRIZE_SENT_SOME_TO_MOM, PRIZE_SENT_HALF_TO_MOM, PRIZE_SENT_ALL_TO_MOM,
+]
+
 ## `wPayDayMoney`, capped to its three-byte storage. Awarding it belongs to the
 ## world completion boundary; the move command only scatters the coins.
 var pay_day_money: int = 0
+
+## `wBattleReward`, `ComputeTrainerReward`'s base reward times the level of the
+## last party member `ReadTrainerParty` loaded. A quarter of what a win pays:
+## `.give_money` credits it four times over.
+var battle_reward: int = 0
+
+## `wAmuletCoin`. `CheckAmuletCoin` sets it at every player send-out and clears
+## it nowhere, so one Amulet Coin doubles the reward and the Pay Day money for
+## the rest of the battle whatever is holding it later.
+var amulet_coin: bool = false
 
 ## `wEvolvableFlags`, cleared by `FindFirstAliveMonAndStartBattle` and set per
 ## party member that gained a level. `ExitBattle` hands it to `EvolveAfterBattle`
@@ -707,7 +727,11 @@ static func use_item(item: int) -> Dictionary:
 ## `InitEnemyTrainer`: the class's own `TRNATTR_ITEM1` and `TRNATTR_ITEM2` into
 ## the two working slots, and then `IsGymLeader`'s own party walk. `NO_ITEM` is
 ## zero and is not carried.
-func init_enemy_trainer(trainer_class: int) -> void:
+##
+## [param rewarded] is false for the two opponents `ReadTrainerParty` returns in
+## front of, the Battle Tower's and a link partner's: neither reaches
+## `ComputeTrainerReward`, and neither win branch pays money either.
+func init_enemy_trainer(trainer_class: int, rewarded: bool = true) -> void:
 	enemy_items = []
 	if data == null or trainer_class <= 0:
 		return
@@ -716,7 +740,25 @@ func init_enemy_trainer(trainer_class: int) -> void:
 		var item: int = int(attributes.get(key, 0))
 		if item != 0:
 			enemy_items.append(item)
+	_compute_trainer_reward(int(attributes.get("base_reward", 0)) if rewarded else 0)
 	_gain_gym_battle_happiness(trainer_class)
+
+
+## `ComputeTrainerReward`, which `ReadTrainerParty` runs once the whole party is
+## in: `wCurPartyLevel` is still the last member's, so a reward is the class's
+## base times the level of whoever the trainer sends out last rather than of
+## whoever is strongest. `Multiply`'s product is read two bytes wide.
+func _compute_trainer_reward(base_reward: int) -> void:
+	battle_reward = 0
+	if base_reward <= 0:
+		return
+	var mons: Array = party(ENEMY).mons
+	if mons.is_empty():
+		return
+	var last: Gen2BattleMon = mons[mons.size() - 1]
+	if last == null:
+		return
+	battle_reward = (base_reward * last.level) & 0xFFFF
 
 
 ## `InitEnemyTrainer`'s `.partyloop`, which runs on the frame the trainer's pic
@@ -1352,6 +1394,8 @@ func entrance_events(side: int, ball: bool = true) -> Array:
 	var entering: Gen2BattleMon = mon(side)
 	if entering == null:
 		return []
+	if side == PLAYER:
+		_check_amulet_coin()
 	var enemy_turn: bool = side == ENEMY
 	var out: Array = []
 	if ball:
@@ -1369,6 +1413,58 @@ func entrance_events(side: int, ball: bool = true) -> Array:
 		return out
 	out.append({"type": CRY, "side": side, "species": entering.species})
 	return out
+
+
+## `CheckAmuletCoin`, run by `SendOutPlayerMon` and so by the opening entrance
+## too. It only ever writes a one, which is why the flag is sticky.
+func _check_amulet_coin() -> void:
+	if amulet_coin or data == null:
+		return
+	var entering: Gen2BattleMon = mon(PLAYER)
+	if entering == null:
+		return
+	if Gen2HeldItem.effect_of(data, entering.item) == Gen2HeldItem.AMULET_COIN:
+		amulet_coin = true
+
+
+## `.DoubleReward` and `CheckPayDay`'s copy of it: a three-byte shift that
+## saturates rather than wrapping.
+static func double_reward(amount: int) -> int:
+	return mini(amount * 2, 0xFFFFFF)
+
+
+## `BattleWon.give_money`, the whole of what a beaten trainer pays.
+##
+## [param reward] is [member battle_reward], a quarter of the prize: the Amulet
+## Coin doubles that quarter, four quarters are handed out one at a time, and
+## the two `.DoubleReward` calls at `.done` put the total back for the line that
+## announces it. [param mom_flags] is `wMomSavingMoney`.
+##
+## Returns the two credits, the figure the line prints and which line it is.
+static func prize_money_split(
+	reward: int, amulet: bool, mom_flags: int, moms_money: int, max_money: int
+) -> Dictionary:
+	var quarter: int = double_reward(reward) if amulet else reward
+	## `.CheckMaxedOutMomMoney`: a full account sends her nothing and says
+	## nothing, whatever the savings bits are.
+	var saving: int = mom_flags & Gen2WorldScriptRunner.MOM_SAVING_MONEY_MASK
+	var to_mom: int = 0
+	if moms_money < max_money:
+		## `cp (1 << SOME) | (1 << HALF)` then `inc a`: both bits together mean
+		## all four quarters, which is why the count is not the mask.
+		to_mom = 4 if saving == 3 else mini(saving, 4)
+	var shown: int = double_reward(double_reward(quarter))
+	var line: StringName = PRIZE_KEPT_IT_ALL
+	if to_mom > 0 and saving > 0:
+		## `dec a` indexes `.SentToMomTexts`, three entries long. A savings mask
+		## of 4 would read past it; no script writes one.
+		line = PRIZE_MOM_LINES[mini(saving, 3) - 1]
+	return {
+		"wallet": quarter * (4 - to_mom),
+		"mom": quarter * to_mom,
+		"shown": shown,
+		"line": line,
+	}
 
 
 ## `Call_PlayBattleAnim` rather than `PlayFXAnimID`: `WaitBGMap` in place of the

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -173,6 +173,14 @@ var _world_battle_completion_sent: bool = false
 var _world_battle_terminal_text_shown: bool = false
 var _world_battle_recovery_shown: bool = false
 var _world_battle_recovery: Dictionary = {}
+## `.give_money` and `CheckPayDay`, the two credits the way out of a won battle
+## pays. Computed once by [method _earnings] and then read by the snapshot
+## [method _save_battle_result] writes, by the line that announces the prize and
+## by the completion result the world credits its live state from, so no two of
+## the three can disagree about what the fight was worth.
+var _earnings_computed: Dictionary = {}
+var _prize_text_shown: bool = false
+var _pay_day_text_shown: bool = false
 var _last_message: String = ""
 ## A running [Gen2HpBarAnimation] per side. A side with no entry is not moving.
 var _bars: Dictionary = {}
@@ -830,6 +838,9 @@ func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: i
 	_world_battle_completion_sent = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
+	_earnings_computed = {}
+	_prize_text_shown = false
+	_pay_day_text_shown = false
 	_world_battle_recovery = {}
 	_enemy = _wrap_species(enemy)
 	_player = _wrap_species(player)
@@ -866,6 +877,9 @@ func show_trainer(
 	_world_battle_completion_sent = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
+	_earnings_computed = {}
+	_prize_text_shown = false
+	_pay_day_text_shown = false
 	_world_battle_recovery = {}
 	var enemy_party: Gen2Party = Gen2TrainerParty.build(_data, trainer_class, index)
 	if enemy_party == null:
@@ -907,6 +921,9 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 	_world_battle_completion_sent = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
+	_earnings_computed = {}
+	_prize_text_shown = false
+	_pay_day_text_shown = false
 	_world_battle_recovery = {}
 	var player_party: Gen2Party = Gen2SaveBattleAdapter.to_battle_party(_data, save)
 	var enemy_party: Gen2Party = _party_from(DEFAULT_ENEMY, DEFAULT_LEVEL)
@@ -984,6 +1001,9 @@ func start_world_battle(
 	_world_battle_completion_sent = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
+	_earnings_computed = {}
+	_prize_text_shown = false
+	_pay_day_text_shown = false
 	_world_battle_recovery = {}
 	_pending = []
 	_save_slot = save.slot if save != null else -1
@@ -997,7 +1017,6 @@ func start_world_battle(
 	## `LevelUpHappinessMod` compares it against the winner's caught location.
 	_battle.landmark = _world_context.landmark if _world_context != null \
 		else Gen2Battle.LANDMARK_NONE
-	_battle.init_enemy_trainer(_enemy_trainer_class)
 	var player_party_ready: Gen2Party = prepared["player_party"]
 	var enemy_party_ready: Gen2Party = prepared["enemy_party"]
 	_player = player_party_ready.active_mon().species
@@ -3336,6 +3355,10 @@ func _continue_after_messages() -> void:
 			# `wBattleResult` is DRAW and the party is still standing.
 			if _show_world_battle_terminal_text():
 				return
+			## `.give_money` is the next thing `BattleWon` does once
+			## `PrintWinLossText` has been answered.
+			if _show_prize_money_text():
+				return
 			## `LostBattle`'s `.not_canlose` is the grayscale and a `ret`: the
 			## battle prints nothing about blacking out, because `_WhitedOutText`
 			## belongs to `Script_Whiteout` on the overworld. What is checked
@@ -3344,6 +3367,11 @@ func _continue_after_messages() -> void:
 				if not _prepare_world_battle_recovery():
 					return
 				_world_battle_recovery_shown = true
+		## `CheckPayDay` is `.HandleEndOfBattle`'s, outside the battle loop and
+		## behind whichever of the two win or loss texts was printed. A wild
+		## battle reaches it with no `_world_battle_active` in front of it.
+		if _show_pay_day_text():
+			return
 		if _save_battle_result() and _world_battle_active:
 			_finish_world_battle()
 		return
@@ -3384,14 +3412,13 @@ func _save_battle_result() -> bool:
 		_data.id, _data.sha1, _save_slot, _battle.party(Gen2Battle.PLAYER), "", _source_save
 	)
 	# The world host credits its live state from the completion result below;
-	# mirror the same award into the snapshot being written now so Pay Day is not
-	# lost between the battle save and that callback.
-	if save != null and save.world != null and save.world.world_state != null \
-			and _battle.pay_day_money > 0:
-		var balance: int = save.world.world_state.money(0)
-		save.world.world_state.apply_changes({}, {}, {"money": {
-			0: mini(balance + _battle.pay_day_money, Gen2WorldInventory.MAX_MONEY),
-		}})
+	# mirror the same award into the snapshot being written now so neither the
+	# prize nor the Pay Day money is lost between the battle save and that
+	# callback.
+	if save != null and save.world != null:
+		Gen2WorldBattleAdapter.credit_earnings(
+			save.world.world_state, _earnings()["money"]
+		)
 	var result: Dictionary = Gen2SaveStore.save(save, _data)
 	if not result["ok"]:
 		push_error("Could not save battle result: %s" % result["message"])
@@ -3429,8 +3456,11 @@ func _finish_world_battle() -> void:
 		"save_written": _save_written,
 	}
 	if outcome == Gen2WorldBattleAdapter.OUTCOME_WON:
-		if _battle.pay_day_money > 0:
-			result["pay_day_money"] = _battle.pay_day_money
+		## `.give_money` and `CheckPayDay` as one credit per account, so the
+		## world applies exactly what the save already carries.
+		var earned: Dictionary = _earnings()["money"]
+		if not earned.is_empty():
+			result["money_awarded"] = earned.duplicate()
 		## `ExitBattle`'s `and $f / ret nz`: `wEvolvableFlags` is only ever read
 		## after a battle that was WON, so a fight that was lost or run from
 		## carries nothing for the overworld's own `EvolveAfterBattle` to walk.
@@ -3466,6 +3496,58 @@ func _finish_world_capture(capture: Dictionary) -> void:
 		"capture": capture.duplicate(true),
 		"enemy": _enemy_battler_record(),
 	})
+
+
+## [method Gen2WorldBattleAdapter.earnings] for this battle, worked out once so
+## the snapshot [method _save_battle_result] writes, the line that announces the
+## prize and the completion result the world credits its live state from cannot
+## disagree about what the fight was worth.
+func _earnings() -> Dictionary:
+	if _earnings_computed.is_empty():
+		_earnings_computed = Gen2WorldBattleAdapter.earnings(
+			_battle,
+			_source_save.world.world_state
+			if _source_save != null and _source_save.world != null else null,
+			_battle != null and not _battle.has_fled() \
+				and _battle.winner() == Gen2Battle.PLAYER
+		)
+	return _earnings_computed
+
+
+## `GotMoneyForWinningText` and the three `.SentToMomTexts`, printed by
+## `.give_money` right behind `PrintWinLossText`.
+func _show_prize_money_text() -> bool:
+	if _prize_text_shown:
+		return false
+	_prize_text_shown = true
+	var earned: Dictionary = _earnings()
+	if int(earned["prize_shown"]) <= 0:
+		return false
+	var got: String = "%s got ¥%d\nfor winning!" % [
+		_player_label(), int(earned["prize_shown"]),
+	]
+	match StringName(earned["prize_line"]):
+		Gen2Battle.PRIZE_SENT_SOME_TO_MOM:
+			show_message("%s\nSent some to MOM!" % got)
+		Gen2Battle.PRIZE_SENT_HALF_TO_MOM:
+			show_message("Sent half to MOM!")
+		Gen2Battle.PRIZE_SENT_ALL_TO_MOM:
+			show_message("Sent all to MOM!")
+		_:
+			show_message(got)
+	return true
+
+
+## `BattleText_PlayerPickedUpPayDayMoney`, which `CheckPayDay` prints once the
+## coins have been added.
+func _show_pay_day_text() -> bool:
+	if _pay_day_text_shown:
+		return false
+	_pay_day_text_shown = true
+	if int(_earnings()["pay_day"]) <= 0:
+		return false
+	show_message("%s picked up\n¥%d!" % [_player_label(), int(_earnings()["pay_day"])])
+	return true
 
 
 func _show_world_battle_terminal_text() -> bool:

--- a/game/battle/held_item.gd
+++ b/game/battle/held_item.gd
@@ -54,7 +54,8 @@ const QUICK_CLAW: int = 74
 ## King's Rock: a chance to make an ordinary attack flinch.
 const FLINCH: int = 75
 
-## Amulet Coin: prize money, which [Gen2Battle] does not pay.
+## Amulet Coin: `CheckAmuletCoin` at every player send-out, which doubles both
+## `.give_money`'s prize and `CheckPayDay`'s coins.
 const AMULET_COIN: int = 76
 
 ## BrightPowder: its parameter comes straight off the attacker's accuracy.

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -104,6 +104,13 @@ static func prepare(
 	if battle == null:
 		return _failure(&"battle_setup_failed")
 	battle.battle_type = battle_type
+	## `InitEnemyTrainer` belongs to setting the opponent up rather than to
+	## whoever draws the fight, so every host gets the class's two items, its
+	## gym-leader happiness and `ComputeTrainerReward` from one place. Only a
+	## `kind` of `trainer` reaches `ComputeTrainerReward`: `ReadTrainerParty`
+	## returns in front of it for the Battle Tower and for a link partner.
+	if trainer_class > 0:
+		battle.init_enemy_trainer(trainer_class, kind == &"trainer")
 
 	return {
 		"ok": true,
@@ -140,6 +147,66 @@ static func prepare(
 ##   unlocked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`. The source
 ##   notes the loop never ends if a forced shiny is also an Unown, so the shiny
 ##   branch stays in front of it here the way it is there.
+## `BattleWon.give_money` and `CheckPayDay`, the two credits the way out of a
+## won battle pays, worked out once for whichever host fought it.
+##
+## Both are a win's own: `.give_money` is reached from the trainer branch of
+## `BattleWon`, and `CheckPayDay` sits behind `.HandleEndOfBattle`'s
+## `and $f / ret nz`, so a loss, a draw and a run all pay nothing. [param won] is
+## that `wBattleResult` test, passed in rather than read off the battle: a host
+## that settles a fight by fiat rather than playing it knows its own outcome.
+## [param state] is read for Mom's savings tier and her balance, never written.
+##
+## Returns `money` keyed by account, the figure `GotMoneyForWinningText` prints,
+## which of its four lines that is, and the Pay Day coins.
+static func earnings(battle: Gen2Battle, state: Gen2WorldState, won: bool) -> Dictionary:
+	var result: Dictionary = {
+		"money": {}, "prize_shown": 0, "prize_line": &"", "pay_day": 0,
+	}
+	if battle == null or not won:
+		return result
+	var wallet: int = 0
+	var to_mom: int = 0
+	if battle.battle_reward > 0:
+		var split: Dictionary = Gen2Battle.prize_money_split(
+			battle.battle_reward,
+			battle.amulet_coin,
+			state.mom_savings_flags() if state != null else 0,
+			state.money(Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY) if state != null else 0,
+			Gen2WorldInventory.MAX_MONEY,
+		)
+		wallet += int(split["wallet"])
+		to_mom += int(split["mom"])
+		result["prize_shown"] = int(split["shown"])
+		result["prize_line"] = split["line"]
+	## `CheckPayDay` doubles the coins with the same Amulet Coin the prize used,
+	## and does it whether or not there was a trainer to pay a prize.
+	if battle.pay_day_money > 0:
+		var coins: int = battle.pay_day_money
+		if battle.amulet_coin:
+			coins = Gen2Battle.double_reward(coins)
+		result["pay_day"] = coins
+		wallet += coins
+	if wallet > 0:
+		(result["money"] as Dictionary)[Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY] = wallet
+	if to_mom > 0:
+		(result["money"] as Dictionary)[Gen2WorldScriptRunner.ACCOUNT_MOMS_MONEY] = to_mom
+	return result
+
+
+## `AddBattleMoneyToAccount`, which caps each account at `MAX_MONEY` on its own.
+## [param money] is [method earnings]' own dictionary.
+static func credit_earnings(state: Gen2WorldState, money: Dictionary) -> void:
+	if state == null or money.is_empty():
+		return
+	var balances: Dictionary = {}
+	for account: int in money:
+		balances[account] = mini(
+			state.money(account) + int(money[account]), Gen2WorldInventory.MAX_MONEY
+		)
+	state.apply_changes({}, {}, {"money": balances})
+
+
 static func wild_dvs(
 	values: Dictionary, battle_type: int, species: int, generator: RandomNumberGenerator
 ) -> int:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4679,11 +4679,13 @@ func _on_battle_finished(result: Dictionary) -> void:
 	_record_roam_battle(result)
 	if not _link_battle_peer.is_empty():
 		_record_link_battle(result)
-	var pay_day_money: int = int(result.get("pay_day_money", 0))
-	if pay_day_money > 0 and StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON:
-		_world.state.apply_changes({}, {}, {"money": {
-			0: mini(_world.state.money(0) + pay_day_money, Gen2WorldInventory.MAX_MONEY),
-		}})
+	## `.give_money`'s prize and `CheckPayDay`'s coins, worked out once by the
+	## battle screen and handed over per account: this is the live state, and the
+	## snapshot that screen wrote already carries the same credit.
+	var awarded: Variant = result.get("money_awarded", {})
+	if awarded is Dictionary \
+			and StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON:
+		Gen2WorldBattleAdapter.credit_earnings(_world.state, awarded as Dictionary)
 	## `ExitBattle`'s own tail, in its order: `CheckPayDay`, then
 	## `EvolveAfterBattle`, then `GivePokerusAndConvertBerries`, and only then
 	## does the map come back. The evolution owns frames, so the rest of the exit

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -543,9 +543,10 @@ const ACCOUNT_MOMS_MONEY: int = 1
 ## `ram_constants.asm`'s wMomSavingMoney. Bit 7 is whether the bank has ever
 ## been opened; the low three are how much of a battle prize she keeps, and only
 ## MOM_SAVING_SOME_MONEY is ever written, since that is the one tier her menu
-## offers. Nothing spends the tier here: prize money is a deliberate divergence.
+## offers. [method Gen2Battle.prize_money_split] is what spends the tier.
 const MOM_ACTIVE: int = 1 << 7
 const MOM_SAVING_SOME_MONEY: int = 1 << 0
+const MOM_SAVING_MONEY_MASK: int = 0b111
 ## `BankOfMom.dw`, the jumptable this routine walks. `wJumptableIndex` is the
 ## whole of its state, so each index below is one staged box, menu or dial and
 ## the loop around `.RunJumptable` is the chain of them.

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -29,6 +29,13 @@ func before_each() -> void:
 	Gen2ModHost.reset()
 
 
+## `<PLAYER>` in `GotMoneyForWinningText`. A battle opened with no save behind it
+## has no name to read, so `NewGame`'s own default stands in; the saved fixture
+## carries the name [method _open_world] gives it.
+const UNSAVED_PLAYER: String = Gen2OakSpeech.DEFAULT_MALE
+const SAVED_PLAYER: String = "TEST"
+
+
 func after_each() -> void:
 	if is_instance_valid(_world_screen):
 		_world_screen.free()
@@ -302,6 +309,12 @@ func test_victory_displays_imported_text_reloads_objects_and_keeps_player_cell()
 	var result_text: Dictionary = host.battle_snapshot()
 	assert_eq(result_text["message"], "YOU WON.")
 
+	## `.give_money` prints behind `PrintWinLossText`, so the win takes one more
+	## press: 25 base times the last member's level of 5, four quarters over.
+	host.finish()
+	host.advance()
+	assert_eq(host.battle_snapshot()["message"], "%s got ¥500\nfor winning!" % UNSAVED_PLAYER)
+
 	host.finish()
 	host.advance()
 	await get_tree().process_frame
@@ -351,6 +364,12 @@ func test_gold_profile_victory_commits_beaten_flag_and_reloads_objects() -> void
 		host.hurt_enemy()
 	host = _battle_host()
 	assert_eq(host.battle_snapshot()["message"], "YOU WON.")
+
+	## `.give_money` prints behind `PrintWinLossText`, so the win takes one more
+	## press: 25 base times the last member's level of 5, four quarters over.
+	host.finish()
+	host.advance()
+	assert_eq(host.battle_snapshot()["message"], "%s got ¥500\nfor winning!" % UNSAVED_PLAYER)
 
 	host.finish()
 	host.advance()
@@ -848,6 +867,12 @@ func test_a_trainer_battle_fights_and_writes_back_with_an_egg_in_the_party() -> 
 		host.hurt_enemy()
 	host = _battle_host()
 	assert_eq(host.battle_snapshot()["message"], "YOU WON.")
+	## `.give_money` prints behind `PrintWinLossText`, so the win takes one more
+	## press: 25 base times the last member's level of 5, four quarters over.
+	host.finish()
+	host.advance()
+	assert_eq(host.battle_snapshot()["message"], "%s got ¥500\nfor winning!" % SAVED_PLAYER)
+
 	host.finish()
 	host.advance()
 	await get_tree().process_frame

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -358,6 +358,7 @@ const QUICK_CLAW: int = 73
 const KINGS_ROCK: int = 82
 const BRIGHTPOWDER: int = 3
 const FOCUS_BAND: int = 119
+const AMULET_COIN: int = 0x5B
 const LEFTOVERS: int = 146
 const GOLD_BERRY: int = 174
 const MYSTERYBERRY: int = 150
@@ -434,7 +435,7 @@ static func build(directory: String, id: String = "testgame") -> GameData:
 	RomCache.write_json(RomCache.items_path(directory), _items())
 	RomCache.write_json(RomCache.types_path(directory), _types())
 	RomCache.write_json(RomCache.matchups_path(directory), _matchups())
-	RomCache.write_json(RomCache.trainers_path(directory), [])
+	RomCache.write_json(RomCache.trainers_path(directory), _trainers())
 	RomCache.write_json(RomCache.happiness_changes_path(directory), HAPPINESS_CHANGES)
 	## `TMHMMoves` with one entry, which is what the fixture's TM flag byte
 	## names: enough for `CanLearnTMHMMove` to have a table to answer from.
@@ -823,6 +824,7 @@ const HELD_ITEMS: Dictionary = {
 	KINGS_ROCK: ["KING'S ROCK", Gen2HeldItem.FLINCH, 30],
 	BRIGHTPOWDER: ["BRIGHTPOWDER", Gen2HeldItem.BRIGHTPOWDER, 20],
 	FOCUS_BAND: ["FOCUS BAND", Gen2HeldItem.FOCUS_BAND, 30],
+	AMULET_COIN: ["AMULET COIN", Gen2HeldItem.AMULET_COIN, 0],
 	# The berries, with the HP each of the two restoring ones puts back. The
 	# plain BERRY at [constant BERRY_ITEM] is the ten-point one.
 	LEFTOVERS: ["LEFTOVERS", Gen2HeldItem.LEFTOVERS, 10],
@@ -833,6 +835,27 @@ const HELD_ITEMS: Dictionary = {
 	MIRACLEBERRY: ["MIRACLEBERRY", Gen2HeldItem.HEAL_STATUS, 0],
 	BITTER_BERRY: ["BITTER BERRY", Gen2HeldItem.HEAL_CONFUSION, 0],
 }
+
+
+## `TrainerClassAttributes`' first row, FALKNER, with its real base reward, so
+## `ComputeTrainerReward` has a class to multiply. Every other class answers the
+## empty entry `trainer()` gives a number the cache does not carry.
+const FALKNER: int = 1
+const FALKNER_BASE_REWARD: int = 25
+
+
+static func _trainers() -> Array:
+	return [{
+		"number": FALKNER,
+		"name": "FALKNER",
+		"palette": [0, 0],
+		"trainers": [],
+		"attributes": {
+			"item1": 0, "item2": 0, "base_reward": FALKNER_BASE_REWARD,
+			"ai_move_weights": 0, "ai_item_switch": 0,
+		},
+		"dvs": [],
+	}]
 
 
 static func _items() -> Array:

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -4413,6 +4413,111 @@ func test_a_gym_leader_raises_the_whole_standing_party_at_the_start() -> void:
 	assert_eq(battle.party(Gen2Battle.PLAYER).at(1).happiness, before, "a fainted member is skipped")
 
 
+## `ComputeTrainerReward`: `wCurPartyLevel` is still the last member's when
+## `ReadTrainerParty` reaches it, so the reward is the class base times the
+## level of whoever is sent out last. Falkner is 25 and his Pidgeotto is 9,
+## which is the ¥900 the gym pays once `.give_money` has quadrupled it.
+func test_a_trainer_reward_is_the_base_times_the_last_members_level() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 7, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 9, [Fixture.TACKLE])]
+	)
+	battle.init_enemy_trainer(Fixture.FALKNER)
+	assert_eq(battle.battle_reward, Fixture.FALKNER_BASE_REWARD * 9)
+	assert_eq(
+		int(Gen2Battle.prize_money_split(battle.battle_reward, false, 0, 0, 999999)["shown"]),
+		900
+	)
+
+
+## `ReadTrainerParty` returns in front of `ComputeTrainerReward` for the Battle
+## Tower and for a link partner, and neither win branch reaches `.give_money`.
+func test_the_battle_tower_and_a_link_partner_are_worth_nothing() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 9, [Fixture.TACKLE])
+	)
+	battle.init_enemy_trainer(Fixture.FALKNER, false)
+	assert_eq(battle.battle_reward, 0)
+
+
+## `.give_money` hands out four quarters. With Mom saving nothing they all reach
+## the wallet and the line is `GotMoneyForWinningText`.
+func test_a_whole_prize_reaches_the_wallet() -> void:
+	var split: Dictionary = Gen2Battle.prize_money_split(225, false, 0, 0, 999999)
+	assert_eq(int(split["wallet"]), 900)
+	assert_eq(int(split["mom"]), 0)
+	assert_eq(int(split["shown"]), 900)
+	assert_eq(StringName(split["line"]), Gen2Battle.PRIZE_KEPT_IT_ALL)
+
+
+## The Amulet Coin doubles the quarter before it is handed out, so the whole
+## prize and the figure the line prints are both doubled.
+func test_the_amulet_coin_doubles_the_prize() -> void:
+	var split: Dictionary = Gen2Battle.prize_money_split(225, true, 0, 0, 999999)
+	assert_eq(int(split["wallet"]), 1800)
+	assert_eq(int(split["shown"]), 1800)
+
+
+## The three savings tiers, which are how many of the four quarters Mom keeps.
+## `cp (1 << SOME) | (1 << HALF)` then `inc a` is why both bits mean four rather
+## than three.
+func test_moms_savings_take_their_share_of_the_quarters() -> void:
+	var flags: int = Gen2WorldScriptRunner.MOM_ACTIVE
+	var some: Dictionary = Gen2Battle.prize_money_split(
+		225, false, flags | Gen2WorldScriptRunner.MOM_SAVING_SOME_MONEY, 0, 999999
+	)
+	assert_eq(int(some["wallet"]), 675)
+	assert_eq(int(some["mom"]), 225)
+	assert_eq(StringName(some["line"]), Gen2Battle.PRIZE_SENT_SOME_TO_MOM)
+
+	var half: Dictionary = Gen2Battle.prize_money_split(225, false, flags | 0b010, 0, 999999)
+	assert_eq(int(half["wallet"]), 450)
+	assert_eq(int(half["mom"]), 450)
+	assert_eq(StringName(half["line"]), Gen2Battle.PRIZE_SENT_HALF_TO_MOM)
+
+	var all: Dictionary = Gen2Battle.prize_money_split(225, false, flags | 0b011, 0, 999999)
+	assert_eq(int(all["wallet"]), 0)
+	assert_eq(int(all["mom"]), 900)
+	assert_eq(StringName(all["line"]), Gen2Battle.PRIZE_SENT_ALL_TO_MOM)
+
+
+## `.CheckMaxedOutMomMoney`: an account already at `MAX_MONEY` is sent nothing
+## and said nothing about, whatever the savings bits say.
+func test_a_full_account_at_moms_keeps_the_whole_prize() -> void:
+	var split: Dictionary = Gen2Battle.prize_money_split(
+		225, false,
+		Gen2WorldScriptRunner.MOM_ACTIVE | Gen2WorldScriptRunner.MOM_SAVING_SOME_MONEY,
+		999999, 999999
+	)
+	assert_eq(int(split["wallet"]), 900)
+	assert_eq(int(split["mom"]), 0)
+	assert_eq(StringName(split["line"]), Gen2Battle.PRIZE_KEPT_IT_ALL)
+
+
+## `.DoubleReward`'s three-byte shift saturates rather than wrapping.
+func test_a_doubled_reward_saturates_at_three_bytes() -> void:
+	assert_eq(Gen2Battle.double_reward(0x800000), 0xFFFFFF)
+
+
+## `CheckAmuletCoin`, which `SendOutPlayerMon` runs and so the opening entrance
+## does too. It only ever writes a one, so the flag survives the holder leaving.
+func test_the_amulet_coin_is_read_at_a_player_entrance_and_sticks() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.CHARMANDER, 5, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 5, [Fixture.TACKLE])]
+	)
+	battle.entrance_events(Gen2Battle.PLAYER)
+	assert_false(battle.amulet_coin, "nobody is holding one")
+	battle.party(Gen2Battle.PLAYER).at(0).item = Fixture.AMULET_COIN
+	battle.entrance_events(Gen2Battle.PLAYER)
+	assert_true(battle.amulet_coin)
+	battle.send_out(Gen2Battle.PLAYER, 1)
+	assert_true(battle.amulet_coin, "nothing clears it")
+
+
 ## `IsGymLeader` answers no for every other class, so an ordinary trainer moves
 ## nothing. Class 9 is RIVAL1.
 func test_an_ordinary_trainer_moves_no_happiness() -> void:

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -51,6 +51,12 @@ func _write_cache() -> void:
 	RomCache.write_json(RomCache.matchups_path(_directory), [])
 	RomCache.write_json(RomCache.trainers_path(_directory), [{
 		"number": 1, "name": "ACE", "palette": [0x1234, 0x5678], "dvs": 0xFFFF,
+		## `TrainerClassAttributes`' base reward, which `ComputeTrainerReward`
+		## multiplies by the last party member's level. 25 is Falkner's row.
+		"attributes": {
+			"item1": 0, "item2": 0, "base_reward": 25,
+			"ai_move_weights": 0, "ai_item_switch": 0,
+		},
 		"trainers": [{
 			"name": "ACE", "type": RomLayout.TRAINER_MON_NORMAL,
 			"party": [{"level": 5, "species": SPECIES_TWO, "item": 0, "moves": []}],
@@ -365,4 +371,64 @@ func test_the_battle_track_is_answerable_from_the_request_alone() -> void:
 			{"values": 5}, Gen2Battle.LANDMARK_NONE, Gen2WorldPalette.TIME_DAY
 		),
 		Gen2Battle.MUSIC_NONE
+	)
+
+
+## `InitEnemyTrainer` and `ComputeTrainerReward` belong to preparing the
+## opponent, so a host that answers a fight without drawing it gets the same
+## reward the battle screen would. 25 times the last member's level of 5.
+func test_a_prepared_trainer_carries_its_reward() -> void:
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data,
+		{"kind": &"battle_requested", "values": {
+			"kind": &"trainer", "trainer_group": 1, "trainer_id": 0,
+		}},
+		_player_party(), RandomNumberGenerator.new()
+	)
+	assert_true(prepared["ok"])
+	assert_eq((prepared["battle"] as Gen2Battle).battle_reward, 125)
+
+
+## `.give_money`'s four quarters and `CheckPayDay`'s coins as one credit per
+## account, which is the whole of what a won battle pays.
+func test_earnings_credit_the_wallet_with_the_prize_and_the_coins() -> void:
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data,
+		{"kind": &"battle_requested", "values": {
+			"kind": &"trainer", "trainer_group": 1, "trainer_id": 0,
+		}},
+		_player_party(), RandomNumberGenerator.new()
+	)
+	var battle: Gen2Battle = prepared["battle"]
+	battle.pay_day_money = 40
+	var earned: Dictionary = Gen2WorldBattleAdapter.earnings(battle, null, true)
+	assert_eq(
+		int((earned["money"] as Dictionary)[Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY]), 540
+	)
+	assert_eq(int(earned["prize_shown"]), 500)
+	assert_eq(int(earned["pay_day"]), 40)
+	assert_eq(StringName(earned["prize_line"]), Gen2Battle.PRIZE_KEPT_IT_ALL)
+
+	## `CheckAmuletCoin`'s one flag doubles both.
+	battle.amulet_coin = true
+	var doubled: Dictionary = Gen2WorldBattleAdapter.earnings(battle, null, true)
+	assert_eq(
+		int((doubled["money"] as Dictionary)[Gen2WorldScriptRunner.ACCOUNT_YOUR_MONEY]), 1080
+	)
+	assert_eq(int(doubled["pay_day"]), 80)
+
+
+## A loss, a draw and a run all reach `and $f / ret nz` and pay nothing.
+func test_a_battle_that_was_not_won_pays_nothing() -> void:
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data,
+		{"kind": &"battle_requested", "values": {
+			"kind": &"trainer", "trainer_group": 1, "trainer_id": 0,
+		}},
+		_player_party(), RandomNumberGenerator.new()
+	)
+	var battle: Gen2Battle = prepared["battle"]
+	battle.pay_day_money = 40
+	assert_true(
+		(Gen2WorldBattleAdapter.earnings(battle, null, false)["money"] as Dictionary).is_empty()
 	)

--- a/tools/checks/prize_money.gd
+++ b/tools/checks/prize_money.gd
@@ -1,0 +1,136 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies what a beaten trainer pays, against freshly imported real caches, on
+## all three cartridges.
+##
+## Two halves. `TrainerClassAttributes`' base rewards are transcribed below from
+## the pinned `data/trainers/attributes.asm` rather than read back out of the
+## cache, so an importer that shifted a row by a byte goes red. Then every
+## individual trainer in the corpus is walked through the seam a battle uses,
+## `ComputeTrainerReward` into [method Gen2Battle.prize_money_split], and what
+## comes out is checked against the arithmetic the source spells: four quarters
+## of base times the last member's level, doubled by the Amulet Coin, split with
+## Mom whole.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- prize_money
+
+## `data/trainers/attributes.asm`, in class order from FALKNER. Gold and Silver
+## are the first 66 of these; Crystal adds MYSTICALMAN, the 67th, and the rows
+## in front of it are identical between the two pins.
+const BASE_REWARDS: Array[int] = [
+	25, 25, 25, 25, 25, 25, 25, 25, 15, 25, 25, 25, 25, 25, 25, 25, 25,
+	25, 25, 25, 25, 4, 8, 6, 6, 25, 12, 12, 22, 15, 10, 18, 18, 18, 25,
+	4, 10, 2, 5, 10, 8, 25, 8, 8, 8, 25, 22, 12, 10, 6, 18, 8, 5, 5, 18,
+	8, 10, 18, 20, 18, 5, 20, 25, 25, 10, 10, 25,
+]
+const CRYSTAL_CLASSES: int = 67
+const GOLD_CLASSES: int = 66
+
+## `MAX_MONEY`, which `AddBattleMoneyToAccount` caps every account at.
+const MAX_MONEY: int = 999999
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		if not _verify_base_rewards(game_id, data):
+			continue
+		_verify_prizes(game_id, data)
+	_r.game_id = &""
+
+
+## The transcribed table against the imported one, row for row.
+func _verify_base_rewards(game_id: StringName, data: GameData) -> bool:
+	var expected: int = CRYSTAL_CLASSES if game_id == &"crystal" else GOLD_CLASSES
+	if not _r.check(
+		data.trainer_count() == expected,
+		"%s: %d trainer classes, expected %d." % [game_id, data.trainer_count(), expected]
+	):
+		return false
+	for trainer_class: int in range(1, expected + 1):
+		var reward: int = int(
+			data.trainer_attributes(trainer_class).get("base_reward", -1)
+		)
+		if not _r.check(
+			reward == BASE_REWARDS[trainer_class - 1],
+			"%s: class %d pays a base of %d, expected %d." % [
+				game_id, trainer_class, reward, BASE_REWARDS[trainer_class - 1]
+			]
+		):
+			return false
+	return true
+
+
+## Every individual trainer on the cartridge through the whole seam.
+func _verify_prizes(game_id: StringName, data: GameData) -> void:
+	var walked: int = 0
+	var biggest: int = 0
+	for trainer_class: int in range(1, data.trainer_count() + 1):
+		var base: int = int(data.trainer_attributes(trainer_class).get("base_reward", 0))
+		for index: int in data.trainer_party_count(trainer_class):
+			var party: Gen2Party = Gen2TrainerParty.build(data, trainer_class, index)
+			if not _r.check(
+				party != null and not party.mons.is_empty(),
+				"%s: class %d trainer %d builds no party." % [game_id, trainer_class, index]
+			):
+				return
+			var last: Gen2BattleMon = party.mons[party.mons.size() - 1]
+			var quarter: int = base * last.level
+			## `Multiply`'s product is read two bytes wide, so a reward that
+			## needed three would truncate. The corpus must never reach it.
+			if not _r.check(
+				quarter <= 0xFFFF,
+				"%s: class %d trainer %d is worth %d, past two bytes." % [
+					game_id, trainer_class, index, quarter
+				]
+			):
+				return
+			var plain: Dictionary = Gen2Battle.prize_money_split(
+				quarter, false, 0, 0, MAX_MONEY
+			)
+			if not _r.check(
+				int(plain["wallet"]) == quarter * 4 and int(plain["mom"]) == 0
+					and int(plain["shown"]) == quarter * 4
+					and StringName(plain["line"]) == Gen2Battle.PRIZE_KEPT_IT_ALL,
+				"%s: class %d trainer %d pays %s, expected %d whole." % [
+					game_id, trainer_class, index, plain, quarter * 4
+				]
+			):
+				return
+			## The Amulet Coin doubles the quarter before it is handed out, so
+			## the whole prize and the printed figure both double.
+			var doubled: Dictionary = Gen2Battle.prize_money_split(
+				quarter, true, 0, 0, MAX_MONEY
+			)
+			if not _r.check(
+				int(doubled["wallet"]) == quarter * 8
+					and int(doubled["shown"]) == quarter * 8,
+				"%s: class %d trainer %d doubles to %s." % [
+					game_id, trainer_class, index, doubled
+				]
+			):
+				return
+			## `.loop`/`.loop2` hand out four quarters between them however the
+			## savings bits fall, so nothing is ever lost or minted.
+			for saving: int in [0, 1, 2, 3]:
+				var split: Dictionary = Gen2Battle.prize_money_split(
+					quarter, false,
+					Gen2WorldScriptRunner.MOM_ACTIVE | saving, 0, MAX_MONEY
+				)
+				if not _r.check(
+					int(split["wallet"]) + int(split["mom"]) == quarter * 4,
+					"%s: class %d trainer %d loses money at tier %d: %s." % [
+						game_id, trainer_class, index, saving, split
+					]
+				):
+					return
+			walked += 1
+			biggest = maxi(biggest, quarter * 8)
+	_r.note("%s: %d trainers, the richest worth ¥%d." % [game_id, walked, biggest])

--- a/tools/checks/prize_money.gd.uid
+++ b/tools/checks/prize_money.gd.uid
@@ -1,0 +1,1 @@
+uid://bi60xgkg0ugjn

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -7,7 +7,8 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses] [passes]
 ##
-## [stage] is one of `offer` (the default), `menu`, `move`, `info` (the move
+## [stage] is one of `offer` (the default), `prize` (a trainer battle fought to
+## its win, photographed on `GotMoneyForWinningText`), `menu`, `move`, `info` (the move
 ## list with a registered battle-information provider's annotations over it:
 ## a mark per row for the effectiveness against the defender, the non-zero stat
 ## stages, and a tile of the provider's own for the weather), `info_pack` and
@@ -64,7 +65,12 @@ const SHINY_LEVEL: int = 30
 ## The two stages that go through `start_world_battle` rather than a staged
 ## `_battle`, because the palette is chosen in `_init_battle_display` and only
 ## the world path runs it.
-const WORLD_STAGES: Array[String] = ["shiny", "normal"]
+const WORLD_STAGES: Array[String] = ["shiny", "normal", "prize"]
+
+## The `prize` stage's held item, AMULET_COIN (constants/item_constants.asm).
+## `CheckAmuletCoin` doubles the reward off it, so the figure in the picture is
+## `.DoubleReward`'s rather than the plain one.
+const AMULET_COIN: int = 0x5B
 
 ## The stages `BattleMenu`'s own first opening leads into with nothing staged
 ## behind it, rather than a question a turn has to reach.
@@ -217,6 +223,43 @@ func _open() -> void:
 	## The wild the world starts, entered the way a step into the grass does:
 	## `BATTLETYPE_FORCESHINY` is what writes the shiny word, so the picture is
 	## the cartridge's own forced shiny rather than a number typed in here.
+	if _stage == "prize":
+		## `GotMoneyForWinningText`, which `.give_money` prints behind
+		## `PrintWinLossText`. The fight is won rather than staged: the reward
+		## is `ComputeTrainerReward`'s, off the party the request built.
+		_screen.start_world_battle({"values": {
+			"kind": &"trainer", "trainer_group": TRAINER_CLASS, "trainer_id": 0,
+		}})
+		var fight: Gen2Battle = _screen.get("_battle")
+		fight.player.item = AMULET_COIN
+		_screen.set("_pending", fight.entrance_events(Gen2Battle.PLAYER))
+		_drain_to_menu()
+		## Each of Falkner's two is put on one hit point and knocked out by the
+		## lead's first move. The switch offer his bench opens is declined, since
+		## what is being photographed is the line behind the last faint.
+		for _step: int in 400:
+			_settle()
+			var snapshot: Dictionary = _screen.battle_snapshot()
+			if "for winning" in String(snapshot["message"]):
+				## The box is still revealing on the frame it is spotted, and
+				## the figure is the whole point of the picture.
+				_read_question()
+				_settle()
+				return
+			if String(snapshot["switch_stage"]) != "":
+				_read_question()
+				_screen._handle_button(Gen2Button.B)
+				continue
+			if String(snapshot["menu_stage"]) == "main" and not fight.is_over():
+				fight.enemy.hp = 1
+				_screen.set("_pending", fight.take_actions(
+					Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+				))
+			_screen.finish()
+			_screen.advance()
+		push_error("the prize line was never reached")
+		return
+
 	if _stage in WORLD_STAGES:
 		var values: Dictionary = {
 			"kind": &"wild", "pokemon": SHINY_SPECIES, "level": SHINY_LEVEL,

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -54,8 +54,9 @@ const APRICORN_WHT: int = 0x61
 ## the Route 44 door and the first staircase (`maps/IcePath1F.asm`). Three of its
 ## four neighbours are wall, so (30,7) facing right is the only approach.
 const HM07_APPROACH: Vector2i = Vector2i(30, 7)
-## How many balls the route buys is its own choice, not the cartridge's, and the
-## source start money is the whole budget: no battle here pays prize money.
+## How many balls the route buys is its own choice, not the cartridge's. The
+## budget is the source start money plus what the fights on the way pay: the
+## walk credits `.give_money`'s prize the way the battle screen would.
 ## `MartViolet` sells Poké Balls and `MartBlackthorn` does not, so the two catches
 ## before Goldenrod are stocked in Violet and Dratini's far lower catch rate is
 ## answered with the cheapest ball Blackthorn does stock.
@@ -9235,9 +9236,6 @@ func _party_species(save: Gen2SaveData) -> Array:
 	return values
 
 
-## The whole read-only mirror in one call, so every leg answers VAR_PARTYCOUNT,
-## CheckPokerus, checkpoke and CheckPartyMove the same way. Pokerus is false
-## throughout: nothing on this route gives it.
 ## The experience a won trainer battle pays, since this walk answers every one of
 ## them with a win rather than fighting it. [method Gen2Battle.award_win_experience]
 ## is the engine's own split, level up, evolution and move learning; the fought
@@ -9619,7 +9617,16 @@ func _drain_story(
 					last_reason = String(levelled.get("reason", "experience write-back failed"))
 					last_details = JSON.stringify(levelled)
 					break
+				## `.give_money` and `CheckPayDay`, the other thing a win pays.
+				## This walk answers the request itself instead of opening a
+				## battle screen, so it credits the same accounts that screen
+				## would have.
+				var earned: Dictionary = Gen2WorldBattleAdapter.earnings(
+					prepared.get("battle", null), world.state, true
+				)
+				Gen2WorldBattleAdapter.credit_earnings(world.state, earned["money"])
 				battles.append({
+					"money": (earned["money"] as Dictionary).duplicate(),
 					"trainer_class": int(prepared.get("trainer_class", 0)),
 					"trainer_index": int(prepared.get("trainer_index", 0)),
 					"enemy_species": int(enemy_party.active_mon().species)

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -45,7 +45,7 @@ const GROUPS: Dictionary = {
 		&"pack", &"unown_dex", &"pokedex", &"pc", &"mart", &"evolutions",
 		&"mon_specials", &"specials", &"day_care", &"unown_puzzle", &"slots",
 		&"card_flip", &"move_effects", &"phone", &"decorations", &"mail",
-		&"mystery_gift", &"variable_sprites",
+		&"mystery_gift", &"variable_sprites", &"prize_money",
 		&"battle_tower",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],


### PR DESCRIPTION
`BattleWon`'s `.give_money` was never built. No trainer in the game paid any
money, so the whole of a playthrough's income was `NewGame`'s start money and
whatever a script handed over. `TrainerClassAttributes`' base reward was
imported and reached `GameData.trainer_attributes` with no reader anywhere.

## What the source says

- `ComputeTrainerReward` stores the class base times the level of the last
  party member `ReadTrainerParty` loaded. `.give_money` hands that quarter out
  four times and then doubles it twice at `.done` for the line that prints it,
  so Falkner is 25 x 9 x 4 = ¥900.
- `CheckAmuletCoin` runs at every `SendOutPlayerMon` and only ever writes a
  one, so the flag is sticky. It doubles the quarter before the split, and
  `CheckPayDay` doubles its coins off the same flag.
- `.CheckMaxedOutMomMoney` runs before the split: a full account at Mom's is
  sent nothing and said nothing about.
- `cp (1 << SOME) | (1 << HALF)` then `inc a`: both bits together mean four
  quarters, not three. Her own menu only ever writes `MOM_SAVING_SOME_MONEY`.
- `ReadTrainerParty` returns in front of `ComputeTrainerReward` for the Battle
  Tower and a link partner, and neither win branch reaches `.give_money`.

## What the reading found underneath

`InitEnemyTrainer` was the battle screen's call rather than the battle
request's. The story walk fought 109 trainers a game with no class items, no
gym-leader happiness and no reward; it is `Gen2WorldBattleAdapter.prepare`'s
now. `BattleText_PlayerPickedUpPayDayMoney` was never printed, and the Pay Day
credit was two capped adds in two places that could disagree. Both go through
`Gen2WorldBattleAdapter.earnings` now.

## Proof

| Check | Before | After |
|---|---|---|
| Unit and scene tiers | 3,864 of 3,867 | 3,867 of 3,867 |
| `validate.gd -- all` | 77 topics | 78 topics, `prize_money` added |
| `prize_money` sweep | - | 1,531 trainers on three cartridges, richest ¥15,400 |
| Story walk, Crystal | no prize paid | 109 paying fights, ¥181,208 credited |
| Story walk, Gold/Silver | no prize paid | 115 paying fights, ¥187,020 credited |

`tools/checks/prize_money.gd` transcribes the 67 base rewards from
`data/trainers/attributes.asm` rather than reading them back out of the cache;
changing one row goes red, and so does deleting the savings-tier arm.

`tools/preview_battle_switch.gd` gains a `prize` stage that fights Falkner to
his win and photographs the line: "CHRIS got ¥1800 for winning!", which is
25 x 9 x 4 with an Amulet Coin on the lead.