### PR TITLE
Show one Battle Tower room between two arrows

### DIFF
--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 95
+const FORMAT_VERSION: int = 96
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -2736,6 +2736,10 @@ func _import_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
 				rom, layout, RomLayout.battle_tower_text_offset(layout, true, trainer, kind)
 			))
 		texts[RomLayout.BATTLETOWER_TEXT_KINDS[kind]] = {"male": male, "female": female}
+	## Kept with its own padding rather than trimmed:
+	## `BattleTowerRoomMenu_UpdatePickLevelMenu` places the row straight at
+	## `hlcoord 13, 9`, so the leading space of `" L:10 "` is the column the
+	## level stands in and `"CANCEL"` has none.
 	var levels: Array = []
 	for index: int in RomLayout.BATTLETOWER_LEVEL_ROWS:
 		levels.append(Gen2Text.decode_fixed(
@@ -2743,7 +2747,7 @@ func _import_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
 				int(entry["level_strings"]) + index * RomLayout.BATTLETOWER_LEVEL_ROW_BYTES,
 				RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
 			), 0, RomLayout.BATTLETOWER_LEVEL_ROW_BYTES
-		).strip_edges())
+		))
 	var menu_text: Dictionary = {}
 	for name: String in RomLayout.BATTLETOWER_MENU_TEXT_ORDER:
 		var at: int = int((entry["text"] as Dictionary)[name])

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -81,6 +81,31 @@ func draw(
 		font.draw_code(CURSOR_CODE, indices, width, arrow.x * TILE, arrow.y * TILE)
 
 	_scroll_arrows(box, indices, width)
+	_pick_arrows(box, indices, width)
+
+
+## `BattleTowerRoomMenu_UpdatePickLevelMenu`'s two `PlaceString` calls of
+## `String_119d07`, three spaces and a `▼`, at `hlcoord 13, 8` and `hlcoord 13,
+## 10` inside a `menu_coords 12, 7, 19, 11` box: the arrow column is four in
+## from the border and the rows are the interior's first and last. The upper
+## tile is the same glyph under the attrmap's $40, so it is drawn from the
+## bottom row up rather than from a second imported tile.
+func _pick_arrows(box: Gen2MenuBox, indices: PackedByteArray, width: int) -> void:
+	if not box.pick_arrows:
+		return
+	var column: int = (box.left + 4) * TILE
+	font.draw_code(DOWN_ARROW_CODE, indices, width, column, (box.bottom - 1) * TILE)
+	var tile := PackedByteArray()
+	tile.resize(TILE * TILE)
+	font.draw_code(DOWN_ARROW_CODE, tile, TILE, 0, 0)
+	@warning_ignore("integer_division")
+	var height: int = indices.size() / width
+	for y: int in TILE:
+		var to_y: int = (box.top + 1) * TILE + y
+		if to_y < 0 or to_y >= height:
+			continue
+		for x: int in TILE:
+			indices[to_y * width + column + x] = tile[(TILE - 1 - y) * TILE + x]
 
 
 ## `ScrollingMenu_UpdateDisplay`'s two `Coord2Tile` writes, both onto the box's

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -42,6 +42,12 @@ var row_step: int = ROW_STEP
 ## `SCROLLINGMENU_*` by `ScrollingMenu`, and the two sets overlap.
 var scrolling_arrows: bool = false
 var scroll: int = 0
+## `BattleTowerRoomMenu_UpdatePickLevelMenu`, the one menu in the game that
+## shows a single row between two arrows instead of a list under a cursor. Both
+## are the `▼` of `String_119d07`, placed at `hlcoord 13, 8` and `hlcoord 13,
+## 10`; the upper one is the same tile with the attrmap's own $40, which is the
+## BG map's vertical flip.
+var pick_arrows: bool = false
 
 
 

--- a/game/world/world_menu.gd
+++ b/game/world/world_menu.gd
@@ -86,6 +86,7 @@ static func from_input(input: Dictionary) -> Gen2WorldMenu:
 func box() -> Gen2MenuBox:
 	var out := Gen2MenuBox.from_coords(box_left, box_top, box_right, box_bottom, flags)
 	out.scrolling_arrows = scrolling_arrows
+	out.pick_arrows = kind == &"room"
 	if kind == &"2d":
 		out.columns = maxi(1, columns)
 		out.column_spacing = _spacing
@@ -99,6 +100,8 @@ func move(direction: Vector2i) -> bool:
 		return _move_2d(direction)
 	if direction.x != 0:
 		return false
+	if kind == &"room":
+		return _move_room(direction.y)
 	return _move_vertical(direction.y)
 
 
@@ -122,6 +125,18 @@ func column() -> int:
 
 func horizontal_enabled() -> bool:
 	return kind == &"2d" or (flags & STATICMENU_ENABLE_LEFT_RIGHT) != 0
+
+
+## `BattleTowerRoomMenu_UpdatePickLevelMenu`'s `.d_up` and `.d_down`, which run
+## the other way round from every other menu here: the index is one-based, `up`
+## increments it and restarts at 1 past the last room, and `down` decrements it
+## and restarts at the last room past 1. So UP walks L:10 towards CANCEL. Both
+## wrap whatever the flags say, since neither branch consults them.
+func _move_room(delta: int) -> bool:
+	if delta == 0:
+		return false
+	cursor = posmod(cursor - signi(delta), options.size())
+	return true
 
 
 func _move_vertical(delta: int) -> bool:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -4552,12 +4552,16 @@ func _stage_room_menu() -> Dictionary:
 		"type": &"menu",
 		"command": &"battle_tower_room",
 		"options": options,
-		## `MenuHeader_119cf7`'s own `menu_coords 12, 7, SCREEN_WIDTH - 1,
-		## TEXTBOX_Y - 1`, the window `BattleTowerRoomMenu_PlacePickLevelMenu`
-		## opens beside the message it prints.
+		## `BattleTowerRoomMenu_PlacePickLevelMenu` draws one room at a time
+		## between two arrows rather than a list under a cursor, so this menu is
+		## its own kind. `MenuHeader_119cf7` carries `menu_coords 12, 7,
+		## SCREEN_WIDTH - 1, TEXTBOX_Y - 1` and `db 0` for its flags: no cursor
+		## and no title, which puts the room name at `hlcoord 13, 9` where
+		## `BattleTowerRoomMenu_UpdatePickLevelMenu` places it.
+		"menu_kind": &"room",
 		"header": {
 			"default": 1,
-			"data_flags": Gen2MenuBox.STATICMENU_CURSOR | Gen2WorldMenu.STATICMENU_WRAP,
+			"data_flags": 0,
 			"left": 12, "top": 7, "right": 19, "bottom": 11,
 		},
 		"text": String((_battle_tower_data().get("menu_text", {}) as Dictionary).get(

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -2402,8 +2402,8 @@ func _finish(results: Array) -> void:
 ## The rows this mode is offering, which is all [method _render_service_page]
 ## needs: there is no second list to keep in step with it any more.
 func _render_rows(override: Array = []) -> void:
-	if _is_dial() and override.is_empty():
-		## One value at a time, the way the dial itself shows it.
+	if _is_single_row() and override.is_empty():
+		## One value at a time, the way the dial and the room menu each show it.
 		override = [_choices[clampi(_cursor, 0, _choices.size() - 1)]] if not _choices.is_empty() \
 			else []
 	var values: Array = override if not override.is_empty() else (
@@ -2499,6 +2499,14 @@ func _apply_layer_visibility() -> void:
 
 func _is_dial() -> bool:
 	return _mode == MODE.MENU and _menu != null and _menu.kind == &"spinner"
+
+
+## The two menus that show one row rather than a list: `SetDayOfWeek`'s dial and
+## `BattleTowerRoomMenu_UpdatePickLevelMenu`'s room, which prints the chosen
+## level at `hlcoord 13, 9` between the two arrows and nothing else.
+func _is_single_row() -> bool:
+	return _is_dial() \
+		or (_mode == MODE.MENU and _menu != null and _menu.kind == &"room")
 
 
 ## `SetDayOfWeek`'s `.loop`: the box, the two arrows, the one weekday string at

--- a/tests/unit/test_menu_page.gd
+++ b/tests/unit/test_menu_page.gd
@@ -244,3 +244,28 @@ func test_the_up_arrow_waits_for_the_window_to_leave_the_top() -> void:
 	var corners: Array[bool] = _arrow_corners(1)
 	assert_true(corners[0])
 	assert_true(corners[1])
+
+
+## `BattleTowerRoomMenu_UpdatePickLevelMenu` writes `String_119d07` at
+## `hlcoord 13, 8` and `hlcoord 13, 10` and turns the upper tile over with the
+## attrmap's own $40, so the two arrows are one glyph drawn twice.
+func test_the_room_menus_upper_arrow_is_the_lower_one_turned_over() -> void:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(12, 7, 19, 11, 0)
+	box.pick_arrows = true
+	var indices: PackedByteArray = _blank()
+	_page.draw(box, [" L:10 "], -1, indices, WIDTH)
+	assert_true(_ink_in_tile(indices, Vector2i(16, 8)), "the flipped arrow")
+	assert_true(_ink_in_tile(indices, Vector2i(16, 10)), "and `String_119d07`'s own")
+	for row: int in TILE:
+		for column: int in TILE:
+			var top: int = (8 * TILE + row) * WIDTH + 16 * TILE + column
+			var bottom: int = (10 * TILE + TILE - 1 - row) * WIDTH + 16 * TILE + column
+			assert_eq(indices[top], indices[bottom], "row %d column %d" % [row, column])
+
+
+## A box without the field draws neither, which is every other menu in the game.
+func test_no_arrows_without_the_room_menus_own_field() -> void:
+	var indices: PackedByteArray = _blank()
+	_page.draw(Gen2MenuBox.from_coords(12, 7, 19, 11, 0), [" L:10 "], -1, indices, WIDTH)
+	assert_false(_ink_in_tile(indices, Vector2i(16, 8)))
+	assert_false(_ink_in_tile(indices, Vector2i(16, 10)))

--- a/tests/unit/test_world_menu.gd
+++ b/tests/unit/test_world_menu.gd
@@ -125,3 +125,38 @@ func test_a_loaded_header_keeps_its_own_flags() -> void:
 	})
 	assert_eq(menu.flags, 0)
 	assert_false(menu.box().has_flag(Gen2MenuBox.STATICMENU_CURSOR))
+
+
+## `BattleTowerRoomMenu_UpdatePickLevelMenu`'s `.d_up` increments the room index
+## and `.d_down` decrements it, so UP walks L:10 towards CANCEL: the opposite of
+## every other menu here. Both wrap, and neither branch reads the flags byte.
+func test_the_room_menu_runs_the_other_way_and_wraps_without_the_flag() -> void:
+	var menu: Gen2WorldMenu = Gen2WorldMenu.from_input({
+		"menu_kind": &"room", "header": {"data_flags": 0, "default": 1},
+		"options": [" L:10 ", " L:20 ", " L:30 ", " L:40 ", "CANCEL"],
+	})
+	assert_eq(menu.selected_index(), 0)
+	assert_true(menu.move(Vector2i.UP))
+	assert_eq(menu.selected_value(), " L:20 ", "UP is `.d_up`'s inc")
+	assert_true(menu.move(Vector2i.DOWN))
+	assert_true(menu.move(Vector2i.DOWN))
+	assert_eq(menu.selected_value(), "CANCEL", "and `.d_down` restarts at the last")
+	assert_true(menu.move(Vector2i.UP))
+	assert_eq(menu.selected_value(), " L:10 ", "past the last, `.d_up` restarts at 1")
+
+
+## `MenuHeader_119cf7` carries `db 0`: no cursor, and the two arrows instead.
+func test_the_room_menu_box_wears_the_arrows_rather_than_a_cursor() -> void:
+	var box: Gen2MenuBox = Gen2WorldMenu.from_input({
+		"menu_kind": &"room", "header": {
+			"data_flags": 0, "default": 1,
+			"left": 12, "top": 7, "right": 19, "bottom": 11,
+		},
+		"options": ["CANCEL"],
+	}).box()
+	assert_true(box.pick_arrows)
+	assert_false(box.has_flag(Gen2MenuBox.STATICMENU_CURSOR))
+	assert_eq(
+		box.item_position(0), Vector2i(13, 9),
+		"`hlcoord 13, 9`, which is the box's own text start with top spacing"
+	)

--- a/tools/checks/battle_tower.gd
+++ b/tools/checks/battle_tower.gd
@@ -53,9 +53,13 @@ const EXPECTED_FIRST_MONS: Array = [
 ]
 
 ## `Strings_L10ToL100` and `MenuData_ChallengeExplanationCancel`, decoded.
+## `Strings_L10ToL100`, with the padding each eight-byte row carries: the level
+## rows open with a space and CANCEL does not, which is the column each stands
+## in when `BattleTowerRoomMenu_UpdatePickLevelMenu` places it at `hlcoord 13,
+## 9`.
 const EXPECTED_LEVEL_ROWS: Array[String] = [
-	"L:10", "L:20", "L:30", "L:40", "L:50", "L:60", "L:70", "L:80", "L:90",
-	"L:100", "CANCEL",
+	" L:10 ", " L:20 ", " L:30 ", " L:40 ", " L:50 ", " L:60 ", " L:70 ",
+	" L:80 ", " L:90 ", " L:100", "CANCEL",
 ]
 const EXPECTED_MENU_ROWS: Array[String] = ["Challenge", "Explanation", "Cancel"]
 

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -12,6 +12,7 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc a,down,a
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/deco.png decoration
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/hof.png hall_of_fame
+##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/room.png battle_tower_room
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/unown.png unown_dex
 ##
 ## `presses` drives the overlay with its own buttons before the shot, which is
@@ -203,6 +204,10 @@ func _write_service_cache() -> void:
 		Gen2WorldScriptRunner.SPECIAL_POKEMON_CENTER_PC, 0x00,
 		Gen2WorldScript.END,
 	] if _kind in [&"pc", &"decoration", &"hall_of_fame"] else [
+		Gen2WorldScript.SPECIAL,
+		Gen2WorldScriptRunner.SPECIAL_BATTLE_TOWER_ROOM_MENU, 0x00,
+		Gen2WorldScript.END,
+	] if _kind == &"battle_tower_room" else [
 		0x94, 0, 0x00, 0x40, 0x91,
 	]
 	RomCache.write_json(RomCache.world_scripts_path(_fixture_directory), scripts)
@@ -215,3 +220,18 @@ func _write_service_cache() -> void:
 		events["coord_events"] = [{"x": 7, "y": 6, "script": 0x6320}]
 		raw["events"] = events
 	RomCache.write_json(RomCache.world_maps_path(_fixture_directory), maps)
+	if _kind == &"battle_tower_room":
+		_write_battle_tower_cache()
+
+
+## `Strings_L10ToL100` and `Text_WhatLevelDoYouWantToChallenge`, the two records
+## `BattleTowerRoomMenu_PlacePickLevelMenu` needs, written into the fixture the
+## way the mart's own row is: the rest of the tower is not on screen here.
+func _write_battle_tower_cache() -> void:
+	RomCache.write_json(RomCache.battle_tower_path(_fixture_directory), {
+		"level_rows": [
+			" L:10 ", " L:20 ", " L:30 ", " L:40 ", " L:50 ", " L:60 ", " L:70 ",
+			" L:80 ", " L:90 ", " L:100", "CANCEL",
+		],
+		"menu_text": {"what_level": "What level do you want to challenge?"},
+	})


### PR DESCRIPTION
`BattleTowerRoomMenu_UpdatePickLevelMenu` draws a single room in `MenuHeader_119cf7`'s box with an arrow above and below it. This port opened the same box through the ordinary cursor list, so several rooms stood in it at once and the arrows were the list's.

The menu is its own kind now.

- Its two arrows are `String_119d07`'s one glyph. The upper one is drawn from the bottom row up, because the source turns the tile over with `hlcoord 16, 8, wAttrmap / ld a, $40` rather than loading a second one. `FontsExtra2_UpArrowGFX` is the scrolling menu's arrow and is not what this screen draws.
- UP walks L:10 towards CANCEL and DOWN walks back: `.d_up` increments the index and `.d_down` decrements it. Both restart at the far end whatever the flags byte says, and `MenuHeader_119cf7`'s is `db 0`, so there is no cursor either.
- `Strings_L10ToL100` carries its own padding and the importer was trimming it away. " L:10 " opens with a space and "CANCEL" does not, and that is the column each stands in at `hlcoord 13, 9`.

The Hall of Fame gate was already right: four rooms before it, ten after.

Cache format 96. All three cartridges re-import with `layout: Layout verified.`

| Check | Result |
|---|---|
| `validate.gd -- all` | 78 topics pass, exit 0 |
| Unit tier | 3348 tests, 62903 asserts |
| Scene tier | 3874 tests, 72127 asserts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | each reaches Red in Silver Cave |
| Boot smoke, with and without mods | clean |