### PR TITLE
Name action versions that exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,26 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # A workflow that names an action version which does not exist fails at
+      # "Set up job", and release.yml only runs on a tag, so without this the
+      # first place anyone learns of it is a release that never built.
+      - name: Every action version resolves
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          missing=0
+          for ref in $(grep -rhoE 'actions/[a-z-]+@v[0-9.]+' .github/workflows/ \
+                        | sort -u); do
+            if gh api "repos/${ref%@*}/git/ref/tags/${ref#*@}" >/dev/null 2>&1; then
+              echo "ok       $ref"
+            else
+              echo "::error::$ref does not resolve"
+              missing=1
+            fi
+          done
+          exit $missing
+
       - name: Cache Godot binary
         id: godot-cache
         uses: actions/cache@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           ref: ${{ needs.version.outputs.tag }}
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "21"
@@ -142,7 +142,7 @@ jobs:
           chmod +x "dist/pokerecomp-${v}-linux-x86_64" "dist/pokerecomp-${v}-linux-arm64"
           ls -lh dist
 
-      - uses: actions/upload-artifact@v8
+      - uses: actions/upload-artifact@v7
         with:
           name: linux-windows-android
           path: dist/*
@@ -220,7 +220,7 @@ jobs:
           fi
           echo "unsigned ✓"
 
-      - uses: actions/upload-artifact@v8
+      - uses: actions/upload-artifact@v7
         with:
           name: apple
           path: dist/*


### PR DESCRIPTION
`v0.1.0` failed at "Set up job" before a single build step ran:

```
Unable to resolve action `actions/upload-artifact@v8`, unable to find version `v8`
```

`actions/upload-artifact` is on v7; v8 is `download-artifact`. `setup-java` was also pinned a major behind at v5.

| Action | Was | Now | Latest |
|---|---|---|---|
| `upload-artifact` | v8 | **v7** | v7.0.1 |
| `setup-java` | v5 | **v6** | v6.0.0 |
| `checkout` | v7 | v7 | v7.0.1 |
| `download-artifact` | v8 | v8 | v8.0.1 |
| `cache` | v6 | v6 | v6.1.0 |

`release.yml` runs on a tag and nothing else, so the first place a bad version could surface was a release that never built. `ci.yml` now resolves every `uses:` line against the tag it names, on every pull request. Run locally against this branch, all five resolve and it exits 0.

Unit tier 3354/3354.