### PR TITLE
Ship the plugins a release needs, and let a finger scroll a page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ permissions:
 env:
   GODOT_VERSION: 4.8-dev3
   GODOT_TEMPLATE_DIR: 4.8.dev3
+  # The engine the iOS plugin compiles against. It must be the commit
+  # `export-templates.yml` builds the templates from, since the plugin is linked
+  # into them and the two have to agree about what a header declares.
+  GODOT_COMMIT: 51105ccbe58381774ecd7a7486d564b202a5192e
 
 jobs:
   version:
@@ -127,6 +131,17 @@ jobs:
           export/android/java_sdk_path = "$JAVA_HOME"
           EOF
 
+      # `addons/second_screen/bin/` is gitignored, so a checkout has no AAR and
+      # the Android exporter answers a plugin with no binary the way the iOS one
+      # does: it drops it and the build succeeds anyway. 0.1.0 shipped that way
+      # and no handheld with a lower panel got one. Checked for after the export.
+      - name: Build the Android second-screen plugin
+        run: |
+          set -euo pipefail
+          export ANDROID_HOME="$ANDROID_SDK_ROOT"
+          tools/build_android_plugin.sh
+          ls -l addons/second_screen/bin/*.aar
+
       - name: Materialize the Android signing key
         env:
           KEYSTORE_B64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_B64 }}
@@ -165,6 +180,18 @@ jobs:
           [ -s "dist/pokerecomp-${v}-android.apk" ] || { echo "::error::no APK"; exit 1; }
           chmod +x "dist/pokerecomp-${v}-linux-x86_64" "dist/pokerecomp-${v}-linux-arm64"
           ls -lh dist
+
+      - name: Refuse an APK with no second-screen plugin in it
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          apk="dist/pokerecomp-${v}-android.apk"
+          dex=$(unzip -Z1 "$apk" '*.dex')
+          if ! unzip -p "$apk" $dex | grep -qa SecondScreen; then
+            echo "::error::the APK carries no second-screen plugin; the AAR did not link"
+            exit 1
+          fi
+          echo "second screen ✓"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -221,6 +248,34 @@ jobs:
           ( cd /tmp/ios && zip -q "$dir/ios.zip" "$slice/libgodot.a" )
           echo "template directory: ${before} kB -> $(du -sk "$dir" | cut -f1) kB"
 
+      # iOS has no system file picker at this engine pin, so `ios/plugins` ships
+      # one and every import on that platform goes through it. Its libraries are
+      # gitignored, a checkout therefore has none, and the exporter answers a
+      # plugin whose binary is missing by quietly dropping it: the build still
+      # succeeds and ships the engine's own browser, which on iOS can only list
+      # the app's own data. That is a release nobody can import a cartridge
+      # with, so the plugin is built here and checked for after the export.
+      - name: Build the iOS file picker plugin
+        run: |
+          set -euo pipefail
+          brew install scons
+          # The plugin is linked into the templates `export-templates.yml`
+          # builds, so a pin that has drifted from that one is two engines.
+          grep -q "GODOT_COMMIT: $GODOT_COMMIT" .github/workflows/export-templates.yml \
+            || { echo "::error::the plugin pin disagrees with the template pin"; exit 1; }
+          git init -q .references/godot
+          git -C .references/godot remote add origin https://github.com/godotengine/godot.git
+          git -C .references/godot fetch -q --depth 1 origin "$GODOT_COMMIT"
+          git -C .references/godot checkout -q FETCH_HEAD
+          # Three headers the engine's own build generates and a plain checkout
+          # does not have. Nothing else of the engine is built.
+          ( cd .references/godot && scons platform=ios target=template_debug arch=arm64 \
+              core/extension/gdextension_interface.gen.h \
+              core/extension/ext_wrappers.gen.h \
+              core/disabled_classes.gen.h )
+          tools/build_ios_plugin.sh
+          ls -l ios/plugins/*/*.a
+
       - name: Import
         run: |
           set -euo pipefail
@@ -261,6 +316,22 @@ jobs:
           rm -rf "$RUNNER_TEMP/ipa" && mkdir -p "$RUNNER_TEMP/ipa/Payload"
           cp -R "$app" "$RUNNER_TEMP/ipa/Payload/"
           (cd "$RUNNER_TEMP/ipa" && zip -qry "$GITHUB_WORKSPACE/dist/pokerecomp-${v}-ios.ipa" Payload)
+
+      # 0.1.0 shipped without it and every player's only picker was a browser
+      # of the app's own empty data. Nothing else can notice: the exporter drops
+      # an invalid plugin silently, and the preset still says it is on.
+      - name: Refuse an IPA with no system file picker in it
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          rm -rf "$RUNNER_TEMP/audit" && mkdir -p "$RUNNER_TEMP/audit"
+          unzip -q "dist/pokerecomp-${v}-ios.ipa" -d "$RUNNER_TEMP/audit"
+          binary="$RUNNER_TEMP/audit/Payload/pokerecomp.app/pokerecomp"
+          if ! strings -a "$binary" | grep -q NativeFilePicker; then
+            echo "::error::the IPA carries no NativeFilePicker; the plugin did not link"
+            exit 1
+          fi
+          echo "system file picker ✓"
 
       # A signed IPA would be a private leak in a public download, so the gate
       # is here rather than in the release notes.

--- a/game/launcher/launcher_scroll.gd
+++ b/game/launcher/launcher_scroll.gd
@@ -12,9 +12,28 @@ extends ScrollContainer
 ##
 ## The pane only takes focus when it actually has somewhere to go, so a short
 ## page does not put a stop on the way down to the dock.
+##
+## A finger is the third way, and the engine gives none of it. [ScrollContainer]
+## drags off mouse events emulated from the touch, and
+## [constant Control.MOUSE_FILTER_STOP] ends a pointer event at the control it
+## reaches: [method Viewport._gui_call_input] stops there for every mouse, touch
+## and drag event, and only a wheel is passed on by `force_pass_scroll_events`.
+## Every launcher page is a column of buttons, each of them STOP, so a wheel
+## scrolls the pane and a finger on the same page moves nothing. The pane
+## therefore reads the touch in [method Node._input], ahead of the GUI, and
+## leaves the engine's own drag switched off.
 
 ## How far one press moves the pane, as a fraction of what it shows.
 const PAGE: float = 0.42
+## How far a finger travels before the touch is a scroll rather than a tap.
+const TOUCH_DEADZONE: float = 12.0
+
+## The finger this pane is following, or -1.
+var _touch_index: int = -1
+## Where it landed, in window units, so the button under it can be let go of.
+var _touch_from: Vector2 = Vector2.ZERO
+var _touch_travel: float = 0.0
+var _touch_dragging: bool = false
 
 
 static func create() -> Gen2LauncherScroll:
@@ -30,12 +49,29 @@ static func create() -> Gen2LauncherScroll:
 
 
 func _ready() -> void:
+	# A [Control] is not handed raw input unless it asks.
+	set_process_input(true)
 	get_v_scroll_bar().changed.connect(_refresh_focus_mode)
 	resized.connect(_refresh_focus_mode)
 	_refresh_focus_mode()
 
 
+## The finger, read before the GUI has a chance to stop it at a button.
+func _input(event: InputEvent) -> void:
+	if event is InputEventScreenTouch:
+		_on_screen_touch(event)
+	elif event is InputEventScreenDrag:
+		_on_screen_drag(event)
+
+
 func _gui_input(event: InputEvent) -> void:
+	# The engine drags this pane off the mouse events `emulate_mouse_from_touch`
+	# makes from the same finger [method _input] is already following, so both
+	# left on scroll the page twice as far as the finger moved.
+	if event.device == InputEvent.DEVICE_ID_EMULATION \
+		and (event is InputEventMouseButton or event is InputEventMouseMotion):
+		accept_event()
+		return
 	if not _scrollable():
 		return
 	var step: float = maxf(size.y * PAGE, 40.0)
@@ -45,6 +81,74 @@ func _gui_input(event: InputEvent) -> void:
 	elif event.is_action_pressed("ui_up", true):
 		accept_event()
 		scroll_vertical = int(float(scroll_vertical) - step)
+
+
+func _on_screen_touch(touch: InputEventScreenTouch) -> void:
+	if not touch.pressed:
+		if touch.index == _touch_index:
+			# The release is left for the GUI whether or not the finger scrolled:
+			# a button that saw the press keeps waiting for its own release, and
+			# _release_pressed_button has already taken the press away from it.
+			_touch_index = -1
+			_touch_dragging = false
+		return
+	if _touch_index != -1 or not _scrollable() or not _takes_touches(touch.position):
+		return
+	_touch_index = touch.index
+	_touch_from = touch.position
+	_touch_travel = 0.0
+	_touch_dragging = false
+
+
+func _on_screen_drag(drag: InputEventScreenDrag) -> void:
+	if drag.index != _touch_index:
+		return
+	_touch_travel += drag.relative.y
+	if not _touch_dragging:
+		if absf(_touch_travel) < TOUCH_DEADZONE:
+			return
+		_touch_dragging = true
+		_release_pressed_button()
+	scroll_vertical = int(float(scroll_vertical) - drag.relative.y)
+	get_viewport().set_input_as_handled()
+
+
+## Whether a touch at [param point] is this pane's. A page's pane is still in
+## the tree and still under the point while a sheet covers it, so the modal
+## convention [Gen2FocusGuard] already keeps is what decides between the two.
+func _takes_touches(point: Vector2) -> bool:
+	if not is_visible_in_tree() or not get_global_rect().has_point(point):
+		return false
+	for modal: Node in get_tree().get_nodes_in_group(Gen2FocusGuard.MODAL_GROUP):
+		if modal != self and not modal.is_ancestor_of(self):
+			return false
+	return true
+
+
+## Takes the press off the button the finger landed on, now that the finger has
+## turned out to be scrolling. [BaseButton] tracks a touch itself, and nothing
+## public cancels one; disabling clears the attempt and re-enabling in the same
+## call leaves the button live for the release that is still to come, which is
+## what clears its own record of the finger.
+func _release_pressed_button() -> void:
+	var button: BaseButton = _button_at(self, _touch_from)
+	if button == null or button.disabled:
+		return
+	button.set_disabled(true)
+	button.set_disabled(false)
+
+
+static func _button_at(node: Node, point: Vector2) -> BaseButton:
+	for child: Node in node.get_children():
+		var control := child as Control
+		if control == null or not control.is_visible_in_tree():
+			continue
+		var found: BaseButton = _button_at(control, point)
+		if found != null:
+			return found
+		if control is BaseButton and control.get_global_rect().has_point(point):
+			return control
+	return null
 
 
 ## Whether there is more here than fits, which is the only case where the pane is

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -464,6 +464,64 @@ func test_a_scroll_pane_only_stops_a_pad_when_there_is_more_to_see() -> void:
 	assert_eq(pane.focus_mode, Control.FOCUS_ALL, "one with more to see takes focus")
 
 
+## Every launcher page is a column of buttons, and a button is
+## `MOUSE_FILTER_STOP`, which is where `_gui_call_input` ends a pointer event.
+## The engine's own touch drag never sees one, so a phone could read a page and
+## not reach the bottom of it.
+func test_a_finger_scrolls_a_pane_full_of_buttons_without_pressing_one() -> void:
+	var pane: Gen2LauncherScroll = Gen2LauncherScroll.create()
+	var column: VBoxContainer = Gen2LauncherUI.column()
+	pane.add_child(column)
+	add_child_autofree(pane)
+	pane.position = Vector2.ZERO
+	pane.size = Vector2(200, 120)
+	var pressed: Array[String] = []
+	for index: int in range(8):
+		var button: Gen2LauncherButton = Gen2LauncherButton.create(_light, "row %d" % index)
+		button.custom_minimum_size = Vector2(0, 60)
+		button.pressed.connect(func() -> void: pressed.append(button.text))
+		column.add_child(button)
+	await wait_seconds(0.2)
+	assert_eq(pane.scroll_vertical, 0)
+
+	var at := Vector2(60, 30)
+	_finger(_finger_touch(at, true))
+	# Short of the deadzone the pane stays put, so a tap is still a tap.
+	_finger(_finger_drag(at, Vector2(0, -6)))
+	assert_eq(pane.scroll_vertical, 0, "a finger that barely moves is not a scroll")
+	_finger(_finger_drag(at + Vector2(0, -6), Vector2(0, -40)))
+	_finger(_finger_touch(at + Vector2(0, -46), false))
+	# 40 rather than 46: the travel spent reaching the deadzone is what told the
+	# pane this was a scroll, and is not also scrolled.
+	assert_eq(pane.scroll_vertical, 40, "the pane follows the finger")
+	assert_eq(pressed, [], "and the button it started on is let go of")
+
+	# A tap that never becomes a drag still presses.
+	_finger(_finger_touch(at, true))
+	_finger(_finger_touch(at, false))
+	assert_eq(pressed.size(), 1, "a tap on the same button still presses it")
+
+
+func _finger(event: InputEvent) -> void:
+	get_tree().root.push_input(event, true)
+
+
+func _finger_touch(at: Vector2, down: bool) -> InputEventScreenTouch:
+	var touch := InputEventScreenTouch.new()
+	touch.index = 0
+	touch.position = at
+	touch.pressed = down
+	return touch
+
+
+func _finger_drag(from: Vector2, by: Vector2) -> InputEventScreenDrag:
+	var drag := InputEventScreenDrag.new()
+	drag.index = 0
+	drag.position = from + by
+	drag.relative = by
+	return drag
+
+
 func test_arrow_keys_move_the_selection_and_wrap() -> void:
 	var page: Gen2ShelfPage = Gen2ShelfPage.create(_light, false)
 	add_child_autofree(page)


### PR DESCRIPTION
Two reports from a 0.1.0 player on iOS. Both are wider than iOS.

## An empty slot opened the engine's own browser, not the system picker

`ios/plugins/file_picker` is the system document picker this project ships
because `DisplayServerIOS` implements none. Its libraries are gitignored and
neither workflow built them, so CI's checkout had none.
`PluginConfigAppleEmbedded::validate_plugin` drops a plugin whose binary is not
on disk, and the export then succeeds with the preset still saying
`plugins/NativeFilePicker=true`. The published IPA carries no
`NativeFilePicker` string; a locally built one carries it twice. That is why the
same version behaves differently on a phone the maintainer built for.

`addons/second_screen` has the same shape and the same hole: the shipped APK's
dex has no `SecondScreen` in it either.

The release workflow now builds both plugins and refuses a build that lost one.
Verified in both directions against real artifacts:

| Build | `NativeFilePicker` in the IPA | `SecondScreen` in the APK |
|---|---|---|
| Published 0.1.0 | 0 | no |
| Built here | 2 | yes |

## A finger could not scroll a launcher page

`Viewport::_gui_call_input` ends a mouse, touch or drag event at the first
`MOUSE_FILTER_STOP` control it reaches, and only a wheel is passed on by
`force_pass_scroll_events`. `ScrollContainer` drags off mouse events emulated
from the touch, so on a page that is a column of buttons a wheel scrolled the
pane and a finger moved nothing. Not an iOS bug: Android does the same.

`Gen2LauncherScroll` reads the touch in `_input`, ahead of the GUI. A deadzone
keeps a tap a tap; crossing it takes the press off the button the finger landed
on, so scrolling never presses anything; the engine's own drag is switched off
in the same pane so the two do not both move it. Nine screens share the one
class, so all nine are fixed.

Measured on the Medium_Phone emulator, the same swipe starting on a "Change"
button in Settings:

| | Page moved | Sheet opened |
|---|---|---|
| Before | 0 px | no |
| After | to the foot of the controls list | no |

## Checks

3356/3356 unit tests pass, one of them new for the finger. `validate.gd -- all`
exits 0, `replay_world.gd` runs 33 routes with no failures, and the boot smoke
test is clean.