### PR TITLE
Build both plugins on a runner as well as on this machine

### DIFF
--- a/tools/build_android_plugin.sh
+++ b/tools/build_android_plugin.sh
@@ -19,6 +19,11 @@ PLUGIN="$ROOT/addons/second_screen"
 # with the pin in DEVICES.md.
 GODOT_TAG="${GODOT_TAG:-4.8-dev3}"
 GODOT_LIB_VERSION="${GODOT_LIB_VERSION:-4.8.dev3}"
+# Built through a wrapper at a pinned Gradle rather than whatever gradle is on
+# the machine: 9.6 removed an internal API the Android plugin below still uses,
+# and a CI runner picking up 9.7 failed a release while this machine's 9.5
+# passed. Bump this with AGP, and only together.
+GRADLE_VERSION="${GRADLE_VERSION:-9.5}"
 NAMESPACE="io.github.decryptu.pokerecomp.secondscreen"
 PACKAGE_PATH="io/github/decryptu/pokerecomp/secondscreen"
 
@@ -89,9 +94,20 @@ kotlin { jvmToolchain(17) }
 dependencies { compileOnly files('godot-lib.aar') }
 GRADLE
 
-( cd "$WORK" && gradle --quiet --no-daemon assembleRelease )
+# The wrapper is generated in an empty directory, because `gradle wrapper` in
+# this one would configure the project first and hit the very incompatibility
+# the wrapper exists to avoid.
+WRAPPER="$(mktemp -d)"
+trap 'rm -rf "$WORK" "$WRAPPER"' EXIT
+# Gradle 9 refuses `wrapper` where there is no build at all, and an empty
+# settings file is a build with nothing in it.
+: > "$WRAPPER/settings.gradle"
+( cd "$WRAPPER" && gradle --quiet --no-daemon wrapper --gradle-version "$GRADLE_VERSION" )
+cp -R "$WRAPPER/gradle" "$WRAPPER/gradlew" "$WORK/"
+
+( cd "$WORK" && ./gradlew --quiet --no-daemon assembleRelease )
 
 mkdir -p "$PLUGIN/bin"
 OUT="$PLUGIN/bin/second_screen.aar"
 cp "$WORK/build/outputs/aar/second_screen-release.aar" "$OUT"
-echo "  $(basename "$OUT")  $(du -h "$OUT" | tr -s '\t' ' ' | cut -d' ' -f1)"
+echo "  $(basename "$OUT")  $(du -h "$OUT" | awk '{print $1}')"

--- a/tools/build_ios_plugin.sh
+++ b/tools/build_ios_plugin.sh
@@ -40,9 +40,12 @@ build_one() {
 		object="$work/$(basename "$source").o"
 		local arc=()
 		[ "${source##*.}" = "mm" ] && arc=(-fobjc-arc)
+		# `"${arc[@]}"` on an empty array is an unbound variable under `set -u`
+		# in bash 3.2, which is the bash a macOS runner has and this machine
+		# does not. The `+` form expands to nothing instead.
 		xcrun --sdk iphoneos clang++ -c "$source" -o "$object" \
 			-arch arm64 -isysroot "$SDK" "-miphoneos-version-min=$MIN_IOS" \
-			-std=gnu++17 -fno-exceptions -fblocks "${arc[@]}" \
+			-std=gnu++17 -fno-exceptions -fblocks ${arc[@]+"${arc[@]}"} \
 			"${defines[@]}" -I "$GODOT_SOURCE" -I "$GODOT_SOURCE/platform/ios" \
 			-I "$plugin_dir" \
 			-Wall -Werror=return-type -Wno-unused-parameter
@@ -50,7 +53,7 @@ build_one() {
 	done
 	xcrun --sdk iphoneos libtool -static -o "$out" "${objects[@]}"
 	rm -rf "$work"
-	echo "  $(basename "$out")  $(du -h "$out" | tr -s '\t' ' ' | cut -d' ' -f1)"
+	echo "  $(basename "$out")  $(du -h "$out" | awk '{print $1}')"
 }
 
 for plugin_dir in "$ROOT"/ios/plugins/*/; do


### PR DESCRIPTION
The v0.1.2 release built both plugins for the first time and both steps failed.
Neither script had ever run anywhere but this machine.

| Script | Failed on | Because |
|---|---|---|
| `build_ios_plugin.sh` | `arc[@]: unbound variable` | `"${arc[@]}"` on an empty array is unbound under `set -u` in bash 3.2, which a macOS runner has and this machine does not |
| `build_android_plugin.sh` | AGP 8.13 against Gradle 9.7.1 | Gradle 9.6 removed `InternalProblems`; the runner has 9.7.1, this machine has 9.5.1 |

The iOS fix is `${arc[@]+"${arc[@]}"}`, which expands to nothing on either bash.
The Android one builds through a wrapper at a pinned Gradle, so the version is
the same everywhere instead of being whatever the machine happens to have. The
wrapper is generated in an empty directory: `gradle wrapper` in the project's
own would configure it first and hit the very incompatibility it exists to
avoid.

Also fixed on the way: macOS `du -h` right-aligns its size, so the
`cut -d' ' -f1` in both scripts took the padding and printed a library with no
size beside it whenever the number was short enough to be padded.

Both scripts were then run under `/bin/bash`, which is the 3.2 a runner uses:

```
  second_screen.aar  12K
file_picker:
  native_file_picker.debug.a  124K
  native_file_picker.release.a  116K
```