### PR TITLE
Stop the plugin audits refusing the builds they should pass

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,11 +187,13 @@ jobs:
           v="${{ needs.version.outputs.version }}"
           apk="dist/pokerecomp-${v}-android.apk"
           dex=$(unzip -Z1 "$apk" '*.dex')
-          if ! unzip -p "$apk" $dex | grep -qa SecondScreen; then
+          # Counted rather than `grep -qa`, for the SIGPIPE reason above.
+          found=$(unzip -p "$apk" $dex | grep -ca SecondScreen || true)
+          if [ "$found" -eq 0 ]; then
             echo "::error::the APK carries no second-screen plugin; the AAR did not link"
             exit 1
           fi
-          echo "second screen ✓"
+          echo "second screen ✓ ($found)"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -327,11 +329,16 @@ jobs:
           rm -rf "$RUNNER_TEMP/audit" && mkdir -p "$RUNNER_TEMP/audit"
           unzip -q "dist/pokerecomp-${v}-ios.ipa" -d "$RUNNER_TEMP/audit"
           binary="$RUNNER_TEMP/audit/Payload/pokerecomp.app/pokerecomp"
-          if ! strings -a "$binary" | grep -q NativeFilePicker; then
+          # `grep -q` stops at the first match and the writer upstream then dies
+          # of SIGPIPE, which `pipefail` reports as the whole pipeline failing.
+          # A gate written that way refuses every build, including the ones that
+          # are right. Count instead: `grep -c` reads to the end.
+          found=$(strings -a "$binary" | grep -c NativeFilePicker || true)
+          if [ "$found" -eq 0 ]; then
             echo "::error::the IPA carries no NativeFilePicker; the plugin did not link"
             exit 1
           fi
-          echo "system file picker ✓"
+          echo "system file picker ✓ ($found)"
 
       # A signed IPA would be a private leak in a public download, so the gate
       # is here rather than in the release notes.


### PR DESCRIPTION
The v0.1.2 run failed on `the IPA carries no NativeFilePicker`. The plugin was
fine. The gate was not.

`grep -q` exits at the first match, the writer upstream dies of SIGPIPE, and
`pipefail` reports that as the whole pipeline failing, so the `if !` fires on
success. The step's own log says so a line above the error it raised:

```
error: .../usr/bin/strings: failed to flush output
##[error]the IPA carries no NativeFilePicker; the plugin did not link
```

Reproduced against a local release build that carries the symbol twice:

```
$ set -euo pipefail; if ! strings -a pokerecomp | grep -q NativeFilePicker; ...
AUDIT SAYS MISSING
$ set -euo pipefail; strings -a pokerecomp | grep -c NativeFilePicker
2
```

Both gates are counted now. `grep -c` reads to the end, so nothing upstream is
killed, and the number is printed beside the tick. The Android gate had the same
bug and passed only by luck of timing; it is fixed the same way.

Everything else in that run was correct: the iOS plugin built (`124K` debug,
`116K` release), and the Android job passed end to end with `second screen ✓`,
which is the first published APK that will carry the plugin at all.