### PR TITLE
Leave nothing in a workflow run's annotations

### DIFF
--- a/.github/workflows/export-templates.yml
+++ b/.github/workflows/export-templates.yml
@@ -83,8 +83,11 @@ jobs:
 
       # Building the engine costs the better part of an hour and the result only
       # changes when the pin or the flag set does, so the key carries both.
+      # v6, matching ci.yml: v4 runs on Node 20, which GitHub is removing from
+      # its runners. v5 and v6 are runtime and packaging changes only, so the
+      # caches v4 wrote still restore.
       - id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: templates
           key: templates-${{ matrix.host }}-${{ env.GODOT_VERSION }}-${{ hashFiles('tools/build_export_templates.sh') }}
@@ -109,7 +112,13 @@ jobs:
                 libxrandr-dev libwayland-dev libxkbcommon-dev libudev-dev \
                 libasound2-dev libpulse-dev libgl1-mesa-dev
               ;;
-            macOS) brew install scons ;;
+            # The runner image ships an untrusted aws/tap, and Homebrew warns
+            # about it on every install whatever is being installed. Dropping
+            # the tap is the fix Homebrew itself names; nothing here wants it.
+            macOS)
+              brew untap aws/tap 2>/dev/null || true
+              brew install scons
+              ;;
             Windows) python -m pip install --disable-pip-version-check scons ;;
           esac
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,9 @@ jobs:
       - name: Build the iOS file picker plugin
         run: |
           set -euo pipefail
+          # See export-templates.yml: the image's untrusted aws/tap makes
+          # Homebrew warn on every install until it is dropped.
+          brew untap aws/tap 2>/dev/null || true
           brew install scons
           # The plugin is linked into the templates `export-templates.yml`
           # builds, so a pin that has drifted from that one is two engines.


### PR DESCRIPTION
Seven warnings on the v0.1.2 run, two causes.

**`actions/cache@v4` runs on Node 20**, which GitHub is removing from its
runners; every job that caches was being force-run on Node 24 and warned about
it. `ci.yml` was already on v6, `export-templates.yml` was not. v5 and v6 are
runtime and packaging changes only — the cache service has not moved since v4 —
so the engine caches still restore and no rebuild is forced.

**The macOS runner image ships an untrusted `aws/tap`**, and Homebrew prints its
whole trust notice on every install until the tap is gone, whatever is being
installed. Both places that call `brew` now drop it first, which is the fix
Homebrew's own message names.

Nothing else in the workflows is deprecated: no `set-output`, no `save-state`,
and every other action is on its current major (`checkout@v7`,
`setup-java@v6`, `upload-artifact@v7`, `download-artifact@v8`).

Verified against the release notes for cache v5 and v6 rather than assumed;
`ci.yml`'s "Every action version resolves" step covers the tags themselves.