### PR TITLE
Stabilize Mods page focus route

### DIFF
--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -53,6 +53,7 @@ var _read_once: Dictionary = {}
 ## count either way.
 var _reading_quietly: bool = false
 var _check_updates_button: Gen2LauncherButton = null
+var _install_button: Gen2LauncherButton = null
 ## Its own request, because the page's other one is serialised behind `_busy`
 ## and an icon must never make a player wait for a download or a feed.
 var _icons: HTTPRequest = null
@@ -116,12 +117,12 @@ func _build() -> void:
 	_check_updates_button.tooltip_text = "Check all followed sources for mod updates"
 	_check_updates_button.pressed.connect(check_for_updates)
 	actions.add_child(_check_updates_button)
-	var install: Gen2LauncherButton = Gen2LauncherButton.create(
+	_install_button = Gen2LauncherButton.create(
 		_theme, "Install", Gen2LauncherButton.Variant.PRIMARY, &"plus"
 	)
-	install.tooltip_text = "Install a mod .zip"
-	install.pressed.connect(func() -> void: install_requested.emit())
-	actions.add_child(install)
+	_install_button.tooltip_text = "Install a mod .zip"
+	_install_button.pressed.connect(func() -> void: install_requested.emit())
+	actions.add_child(_install_button)
 	var sources: Gen2LauncherButton = Gen2LauncherButton.create(
 		_theme, "Sources", Gen2LauncherButton.Variant.NEUTRAL, &"download"
 	)
@@ -133,6 +134,12 @@ func _build() -> void:
 	_list = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
 	_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	scroll.add_child(_list)
+
+
+## The page's primary action is stable while the source check starts and stops
+## in the background, so entering with a pad never depends on network timing.
+func focus_target() -> Control:
+	return _install_button
 
 
 ## Rebuilds the list from what is installed and what the followed sources last

--- a/tests/integration/test_launcher_focus.gd
+++ b/tests/integration/test_launcher_focus.gd
@@ -107,19 +107,18 @@ func test_mod_page_builds_a_visible_logical_focus_route() -> void:
 	_launcher.select_page(&"mods")
 	await get_tree().process_frame
 	await get_tree().process_frame
-	var check: Control = _focus_owner()
-	assert_not_null(check)
-	assert_string_contains(check.tooltip_text, "Check all followed sources")
-	var right: NodePath = check.focus_neighbor_right
+	var install: Control = _focus_owner()
+	assert_not_null(install)
+	assert_eq(install.tooltip_text, "Install a mod .zip")
+	var right: NodePath = install.focus_neighbor_right
 	assert_false(right.is_empty(), "the page explicitly names the next control")
-	var next: Control = check.get_node(right) as Control
-	assert_eq(next.tooltip_text, "Install a mod .zip", "right follows the visible action row")
-	next.grab_focus()
-	var down: NodePath = next.focus_neighbor_bottom
+	var next: Control = install.get_node(right) as Control
+	assert_eq(next.text, "Sources", "right follows the visible action row")
+	var down: NodePath = install.focus_neighbor_bottom
 	assert_false(down.is_empty(), "down enters the page rather than losing focus")
-	var below: Control = next.get_node(down) as Control
+	var below: Control = install.get_node(down) as Control
 	assert_true(below.is_visible_in_tree())
-	assert_ne(below, check)
+	assert_ne(below, install)
 
 
 ## A mouse needs no ring, and putting one up would move it away from whatever


### PR DESCRIPTION
## Summary

- make Install the Mods page primary focus target
- keep initial controller focus independent of source-cache and request timing
- cover the visible Install-to-Sources and Install-to-list routes

## Verification

- full GUT tier: 3,885/3,885 tests, 72,203 assertions
- launcher focus integration: 11/11 tests