### PR TITLE
Bound every Godot run a workflow starts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
   tests:
     name: editor scan and GUT
     runs-on: ubuntu-latest
-    # The whole job is about four minutes. A step that has printed its result
-    # and not exited should fail here rather than sit for GitHub's six-hour
-    # default.
+    # The whole job is about four minutes. This is the backstop behind
+    # `tools/ci_godot.sh`, which caps each Godot run itself: nothing should ever
+    # reach this number, and a job that does is stuck somewhere else.
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -68,13 +68,29 @@ jobs:
           chmod +x ~/godot/godot
 
       - name: Import and resolve class_name
-        run: ~/godot/godot --headless --editor --path . --quit
-
-      - name: GUT
+        env:
+          GODOT_CAP: 600
         run: |
-          ~/godot/godot --headless --path . \
+          set -euo pipefail
+          tools/ci_godot.sh ~/godot/godot --headless --editor --path . --quit
+          [ -d .godot ] || { echo "::error::import produced no .godot"; exit 1; }
+
+      # The one step whose verdict is in its own output. Godot's teardown races
+      # with the threads a run leaves behind and has not always returned from it
+      # on a Linux runner, twenty minutes after the suite said it passed; that
+      # is now a warning with every thread's stack under it rather than a red
+      # build, and a suite that fails or hangs before printing this line is
+      # still red.
+      - name: GUT
+        env:
+          GODOT_CAP: 900
+          GODOT_DONE: "---- All tests passed! ----"
+        run: |
+          tools/ci_godot.sh ~/godot/godot --headless --path . \
             -s res://addons/gut/gut_cmdln.gd \
             -gdir=res://tests -ginclude_subdirs -gexit
 
       - name: Boot smoke test
-        run: ~/godot/godot --headless --path . --quit-after 30
+        env:
+          GODOT_CAP: 180
+        run: tools/ci_godot.sh ~/godot/godot --headless --path . --quit-after 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Import
         run: |
           set -euo pipefail
-          "$GODOT" --headless --editor --path . --quit
+          GODOT_CAP=900 tools/ci_godot.sh "$GODOT" --headless --editor --path . --quit
           [ -d .godot ] || { echo "::error::import produced no .godot"; exit 1; }
 
       # The Android preset builds through gradle, and Godot reads the SDK and
@@ -165,7 +165,8 @@ jobs:
           export_one() {
             local preset="$1" out="$2"
             mkdir -p "$(dirname "$out")"
-            "$GODOT" --headless --path . --export-release "$preset" "$out"
+            GODOT_CAP=1200 tools/ci_godot.sh "$GODOT" --headless --path . \
+              --export-release "$preset" "$out"
             [ -s "$out" ] || { echo "::error::$preset produced nothing at $out"; exit 1; }
           }
           export_one "Linux"                 "dist/pokerecomp-${v}-linux-x86_64"
@@ -175,7 +176,8 @@ jobs:
           # --install-android-build-template unpacks the gradle project the
           # preset builds through; it only acts alongside an export.
           mkdir -p dist
-          "$GODOT" --headless --path . --install-android-build-template \
+          GODOT_CAP=1800 tools/ci_godot.sh "$GODOT" --headless --path . \
+            --install-android-build-template \
             --export-release "Android" "dist/pokerecomp-${v}-android.apk"
           [ -s "dist/pokerecomp-${v}-android.apk" ] || { echo "::error::no APK"; exit 1; }
           chmod +x "dist/pokerecomp-${v}-linux-x86_64" "dist/pokerecomp-${v}-linux-arm64"
@@ -284,7 +286,7 @@ jobs:
       - name: Import
         run: |
           set -euo pipefail
-          "$GODOT" --headless --editor --path . --quit
+          GODOT_CAP=900 tools/ci_godot.sh "$GODOT" --headless --editor --path . --quit
           [ -d .godot ] || { echo "::error::import produced no .godot"; exit 1; }
 
       # Ad-hoc signed, not notarized: no Apple account is involved and none can
@@ -295,7 +297,8 @@ jobs:
           set -euo pipefail
           v="${{ needs.version.outputs.version }}"
           mkdir -p dist
-          "$GODOT" --headless --path . --export-release "macOS" "dist/pokerecomp-${v}-macos.zip"
+          GODOT_CAP=1200 tools/ci_godot.sh "$GODOT" --headless --path . \
+            --export-release "macOS" "dist/pokerecomp-${v}-macos.zip"
           [ -s "dist/pokerecomp-${v}-macos.zip" ] || { echo "::error::no macOS zip"; exit 1; }
 
       # The published IPA is unsigned on purpose: AltStore and SideStore re-sign
@@ -309,7 +312,8 @@ jobs:
           v="${{ needs.version.outputs.version }}"
           sed -i '' 's/app_store_team_id=""/app_store_team_id="0000000000"/' export_presets.cfg
           mkdir -p build/ios
-          "$GODOT" --headless --path . --export-release "iOS" build/ios/pokerecomp.ipa
+          GODOT_CAP=1200 tools/ci_godot.sh "$GODOT" --headless --path . \
+            --export-release "iOS" build/ios/pokerecomp.ipa
           git checkout export_presets.cfg
 
           xcodebuild -project build/ios/pokerecomp.xcodeproj -scheme pokerecomp \

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ real cartridge, so they run anywhere.
 godot --headless -s res://addons/gut/gut_cmdln.gd -gexit
 ```
 
-That is the unit tier, and the default: more than 2,700 tests in well under a
+That is the unit tier, and the default: more than 3,300 tests in about a
 minute. The scene integration tier drives real screens and is slower, so it is
 asked for explicitly, which is how CI runs both:
 

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -159,11 +159,24 @@ func refresh() -> void:
 	_read_unread_sources()
 
 
+## Whether the page may reach the network without a player having asked it to.
+##
+## [method HTTPRequest.request] refuses, loudly, from a node that is not in the
+## tree, and [method create] builds the whole page before the launcher adds it.
+## The rest is [method Gen2GameRuntime.is_player_launch]: a check, a test tier,
+## a screenshot driver or a replay has nobody to show a listing to, and its
+## user:// is usually empty, so every page it builds would fetch the feed and
+## then an icon per row. The test tier builds seven. What a player pressed --
+## Check for updates, a download -- is not gated here and works in any run.
+func _may_fetch_unprompted() -> bool:
+	return is_inside_tree() and Gen2GameRuntime.is_player_launch()
+
+
 ## Reads a source that has never been read, once. Every build follows this
 ## project's own index, and without this it would list nothing until the player
 ## thought to press Check for updates.
 func _read_unread_sources() -> void:
-	if _busy or not _check_queue.is_empty() or not is_inside_tree():
+	if _busy or not _check_queue.is_empty() or not _may_fetch_unprompted():
 		return
 	for source: Dictionary in Gen2ModIndex.followed():
 		var feed: String = String(source["feed"])
@@ -664,10 +677,9 @@ func _icon_square(row: Dictionary) -> Control:
 	return square
 
 
-## `HTTPRequest.request` refuses, loudly, from a node that is not in the tree,
-## and [method create] builds the whole page before the launcher adds it: the
-## queue is left standing until the page is on screen, and every icon it holds
-## is asked for then. Nothing else here starts a request on its own.
+## The icon queue is left standing until the page is on screen, and every icon
+## it holds is asked for here. Nothing else starts a request on its own; see
+## [method _may_fetch_unprompted] for which runs are allowed to.
 func _ready() -> void:
 	_fetch_next_icon()
 	# The page is built before it is in the tree, so the first `refresh` cannot
@@ -678,7 +690,7 @@ func _ready() -> void:
 func _fetch_next_icon() -> void:
 	if _icon_busy or _icon_queue.is_empty() or _icons == null:
 		return
-	if not is_inside_tree():
+	if not _may_fetch_unprompted():
 		return
 	var url: String = _icon_queue.pop_front()
 	_icon_busy = true

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -317,6 +317,24 @@ static func drop(node: Node) -> void:
 	node.queue_free()
 
 
+## The same from an [method Node._exit_tree], where the removal above is
+## refused.
+##
+## A parent is blocked from removing a child while it is already removing one,
+## and every screen that hosts a view it does not own drops that view as it
+## leaves: both hang off the same parent, so the parent is mid-removal when the
+## drop arrives and the engine raises an error instead. Hiding is the whole of
+## what the removal was for here, since nothing replaces a view whose screen is
+## going, and [method Node.queue_free] takes it off the tree either way.
+static func drop_on_exit(node: Node) -> void:
+	if node == null or not is_instance_valid(node):
+		return
+	var item: CanvasItem = node as CanvasItem
+	if item != null:
+		item.hide()
+	node.queue_free()
+
+
 ## The same for every child of [param parent], which is what a row list being
 ## rebuilt in place wants.
 static func drop_children(parent: Node) -> void:

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -1003,5 +1003,5 @@ func set_screen(screen: Gen2Screen) -> void:
 ## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
-		Gen2Screen.drop(_field)
+		Gen2Screen.drop_on_exit(_field)
 		_field = null

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -759,7 +759,7 @@ func set_screen(screen: Gen2Screen) -> void:
 ## The view lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _view != null:
-		Gen2Screen.drop(_view)
+		Gen2Screen.drop_on_exit(_view)
 		_view = null
 
 

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -742,5 +742,5 @@ func set_screen(screen: Gen2Screen) -> void:
 ## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
-		Gen2Screen.drop(_field)
+		Gen2Screen.drop_on_exit(_field)
 		_field = null

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -525,5 +525,5 @@ func set_screen(screen: Gen2Screen) -> void:
 ## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
-		Gen2Screen.drop(_field)
+		Gen2Screen.drop_on_exit(_field)
 		_field = null

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -2082,10 +2082,10 @@ func set_screen(screen: Gen2Screen) -> void:
 ## Frees the overlay, since it lives in a screen this node does not own.
 func _exit_tree() -> void:
 	if _view != null:
-		Gen2Screen.drop(_view)
+		Gen2Screen.drop_on_exit(_view)
 		_view = null
 	if _naming != null:
-		Gen2Screen.drop(_naming)
+		Gen2Screen.drop_on_exit(_naming)
 		_naming = null
 
 

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -627,5 +627,5 @@ func set_screen(screen: Gen2Screen) -> void:
 ## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
-		Gen2Screen.drop(_field)
+		Gen2Screen.drop_on_exit(_field)
 		_field = null

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -263,17 +263,17 @@ func set_screen(screen: Gen2Screen) -> void:
 ## Both views live in a screen this node may not own, so they go by hand.
 func _exit_tree() -> void:
 	if _hof != null:
-		Gen2Screen.drop(_hof)
+		Gen2Screen.drop_on_exit(_hof)
 		_hof = null
 	if _mail_reader != null:
-		Gen2Screen.drop(_mail_reader)
+		Gen2Screen.drop_on_exit(_mail_reader)
 		_mail_reader = null
 	if _naming != null:
-		Gen2Screen.drop(_naming)
+		Gen2Screen.drop_on_exit(_naming)
 		_naming = null
 	for view: TextureRect in [_service_view, _mart_view]:
 		if view != null:
-			Gen2Screen.drop(view)
+			Gen2Screen.drop_on_exit(view)
 	_service_view = null
 	_mart_view = null
 

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -40,6 +40,22 @@ func _mods_page() -> Gen2ModsPage:
 	return page
 
 
+## Every page built here would otherwise read the project's own index the moment
+## it entered the tree, and then an icon per row: a runner's user:// is empty, so
+## a warm cache never hides it and the suite makes a live request per page. Seven
+## are built. What a player pressed still reaches the network in any run.
+func test_a_page_fetches_on_its_own_only_for_a_player() -> void:
+	var loose: Gen2ModsPage = autofree(Gen2ModsPage.create(Gen2LauncherTheme.active()))
+	assert_false(loose._may_fetch_unprompted(), "a page off the tree asks for nothing")
+
+	var page: Gen2ModsPage = _mods_page()
+	assert_eq(
+		page._may_fetch_unprompted(),
+		Gen2GameRuntime.is_player_launch(),
+		"in the tree, the launch kind is the whole gate"
+	)
+
+
 func _open_launcher() -> void:
 	# The machine running the tests may itself have crashed last, and the notice
 	# that raises is a toast every other launcher test would then have to

--- a/tools/ci_godot.sh
+++ b/tools/ci_godot.sh
@@ -4,17 +4,20 @@
 # this; a bare invocation has no bound but the job's own timeout, which is
 # twenty minutes of a paid runner after the work was finished and printed.
 #
-# GODOT_CAP  seconds before the run is killed. Default 900.
-# GODOT_DONE a line the run prints when its work is complete. A run killed at
-#            the cap having printed it is reported as a warning and passes: the
-#            step asserts the work, not the engine's teardown. A run killed
-#            without it fails, and so does one with no GODOT_DONE set.
+# GODOT_CAP   seconds before the run is killed. Default 900.
+# GODOT_DONE  a line the run prints when its work is complete. A run killed
+#             having printed it is reported as a warning and passes: the step
+#             asserts the work, not the engine's teardown. A run killed without
+#             it fails, and so does one with no GODOT_DONE set.
+# GODOT_GRACE seconds a run gets to exit after it prints GODOT_DONE, rather than
+#             the rest of the cap. Default 60.
 #
 # Usage: GODOT_DONE='---- All tests passed! ----' tools/ci_godot.sh godot --headless ...
 set -u
 
 cap="${GODOT_CAP:-900}"
 done_line="${GODOT_DONE:-}"
+grace="${GODOT_GRACE:-60}"
 
 work="$(mktemp -d)"
 log="$work/output"
@@ -41,6 +44,11 @@ diagnose() {
 	# child and the run is this watchdog's sibling. Passwordless on the images
 	# and absent on nothing that matters: an attach that is refused leaves the
 	# /proc lines below, which name the syscall every thread is parked in.
+	# The Linux images carry no gdb, and this is the only moment it is worth
+	# the twenty seconds: without it a hang is seven thread states and no names.
+	if ! command -v gdb >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
+		sudo -n apt-get install -y -qq gdb >/dev/null 2>&1 || true
+	fi
 	if command -v gdb >/dev/null 2>&1; then
 		gdb_run=gdb
 		sudo -n true 2>/dev/null && gdb_run="sudo -n gdb"
@@ -49,10 +57,17 @@ diagnose() {
 	elif command -v sample >/dev/null 2>&1; then
 		sample "$1" 3 -f "$stacks" >/dev/null 2>&1
 	fi
+	# `/proc/<tid>/stat` opens with `pid (comm) state`, and a thread named
+	# "WorkerThread 0" puts a space inside those brackets, so the fields are
+	# counted from after them. The two times are the thread's own CPU in ticks:
+	# a teardown that never returns has one thread spending it and the rest
+	# parked, and this is what says which.
 	for task in /proc/"$1"/task/*; do
 		[ -d "$task" ] || continue
-		echo "thread $(basename "$task") $(cat "$task/comm" 2>/dev/null)" \
-			"state=$(awk '{print $3}' "$task/stat" 2>/dev/null)" \
+		fields="$(sed 's/^[0-9]* (.*) //' "$task/stat" 2>/dev/null)"
+		echo "thread $(basename "$task") [$(cat "$task/comm" 2>/dev/null)]" \
+			"state=$(echo "$fields" | awk '{print $1}')" \
+			"cpu_ticks=$(echo "$fields" | awk '{print $12 + $13}')" \
 			"wchan=$(cat "$task/wchan" 2>/dev/null)" >>"$stacks"
 	done
 	echo "----- $1 was still running -----"
@@ -61,13 +76,25 @@ diagnose() {
 }
 
 # The watchdog rather than the wait is what is bounded: POSIX `wait` takes no
-# timeout, and polling `kill -0` on an unreaped child answers yes forever.
+# timeout, and polling `kill -0` on an unreaped child answers yes forever. The
+# cap is what a run that never finishes gets; one that has printed GODOT_DONE is
+# only racing its own teardown, so it gets GODOT_GRACE and no more.
 (
 	slept=0
-	while [ "$slept" -lt "$cap" ]; do
+	left=""
+	while :; do
 		sleep 1
-		slept=$((slept + 1))
 		kill -0 "$run" 2>/dev/null || exit 0
+		slept=$((slept + 1))
+		if [ -n "$done_line" ] && [ -z "$left" ] \
+			&& grep -qF -e "$done_line" "$log" 2>/dev/null; then
+			left="$grace"
+		fi
+		if [ -n "$left" ]; then
+			left=$((left - 1))
+			if [ "$left" -le 0 ]; then break; fi
+		fi
+		if [ "$slept" -ge "$cap" ]; then break; fi
 	done
 	: >"$work/capped"
 	diagnose "$run"
@@ -88,9 +115,9 @@ if [ ! -f "$work/capped" ]; then
 	exit "$status"
 fi
 
-if [ -n "$done_line" ] && grep -qF "$done_line" "$log"; then
-	echo "::warning::the run printed \"$done_line\" and then never exited;" \
-		"it was killed after ${cap}s and the stacks above say where it was"
+if [ -n "$done_line" ] && grep -qF -e "$done_line" "$log"; then
+	echo "::warning::the run printed \"$done_line\" and then took longer than" \
+		"${grace}s to exit; it was killed and the stacks above say where it was"
 	exit 0
 fi
 echo "::error::the run reached its ${cap}s cap without finishing"

--- a/tools/ci_godot.sh
+++ b/tools/ci_godot.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Runs one Godot invocation under a wall-clock cap and says what it was doing if
+# the cap has to be used. Every workflow step that starts Godot goes through
+# this; a bare invocation has no bound but the job's own timeout, which is
+# twenty minutes of a paid runner after the work was finished and printed.
+#
+# GODOT_CAP  seconds before the run is killed. Default 900.
+# GODOT_DONE a line the run prints when its work is complete. A run killed at
+#            the cap having printed it is reported as a warning and passes: the
+#            step asserts the work, not the engine's teardown. A run killed
+#            without it fails, and so does one with no GODOT_DONE set.
+#
+# Usage: GODOT_DONE='---- All tests passed! ----' tools/ci_godot.sh godot --headless ...
+set -u
+
+cap="${GODOT_CAP:-900}"
+done_line="${GODOT_DONE:-}"
+
+work="$(mktemp -d)"
+log="$work/output"
+fifo="$work/stream"
+mkfifo "$fifo"
+trap 'rm -rf "$work"' EXIT
+
+# The reader is started first: opening a fifo for writing blocks until there is
+# one, and `tee` is what keeps the step's log live rather than arriving in one
+# block when the run is over.
+tee "$log" <"$fifo" &
+reader=$!
+
+"$@" >"$fifo" 2>&1 &
+run=$!
+
+# Every thread's stack, so a run that had to be killed is evidence rather than
+# another attempt. Nothing here is installed by the workflow: gdb ships with the
+# Linux images and sample with macOS, and /proc answers even when neither does.
+diagnose() {
+	stacks="$work/stacks"
+	: >"$stacks"
+	# `sudo -n` because Ubuntu's yama only lets a debugger attach to its own
+	# child and the run is this watchdog's sibling. Passwordless on the images
+	# and absent on nothing that matters: an attach that is refused leaves the
+	# /proc lines below, which name the syscall every thread is parked in.
+	if command -v gdb >/dev/null 2>&1; then
+		gdb_run=gdb
+		sudo -n true 2>/dev/null && gdb_run="sudo -n gdb"
+		$gdb_run -p "$1" -batch -ex 'set pagination off' \
+			-ex 'thread apply all bt' >>"$stacks" 2>&1
+	elif command -v sample >/dev/null 2>&1; then
+		sample "$1" 3 -f "$stacks" >/dev/null 2>&1
+	fi
+	for task in /proc/"$1"/task/*; do
+		[ -d "$task" ] || continue
+		echo "thread $(basename "$task") $(cat "$task/comm" 2>/dev/null)" \
+			"state=$(awk '{print $3}' "$task/stat" 2>/dev/null)" \
+			"wchan=$(cat "$task/wchan" 2>/dev/null)" >>"$stacks"
+	done
+	echo "----- $1 was still running -----"
+	head -400 "$stacks"
+	echo "----- end -----"
+}
+
+# The watchdog rather than the wait is what is bounded: POSIX `wait` takes no
+# timeout, and polling `kill -0` on an unreaped child answers yes forever.
+(
+	slept=0
+	while [ "$slept" -lt "$cap" ]; do
+		sleep 1
+		slept=$((slept + 1))
+		kill -0 "$run" 2>/dev/null || exit 0
+	done
+	: >"$work/capped"
+	diagnose "$run"
+	kill -TERM "$run" 2>/dev/null
+	sleep 5
+	kill -KILL "$run" 2>/dev/null
+) >&2 &
+watchdog=$!
+
+trap 'kill -TERM "$run" "$watchdog" 2>/dev/null; exit 143' TERM INT HUP
+
+wait "$run"
+status=$?
+kill "$watchdog" 2>/dev/null
+wait "$reader" 2>/dev/null
+
+if [ ! -f "$work/capped" ]; then
+	exit "$status"
+fi
+
+if [ -n "$done_line" ] && grep -qF "$done_line" "$log"; then
+	echo "::warning::the run printed \"$done_line\" and then never exited;" \
+		"it was killed after ${cap}s and the stacks above say where it was"
+	exit 0
+fi
+echo "::error::the run reached its ${cap}s cap without finishing"
+exit 124


### PR DESCRIPTION
CI has been failing at random with every test passing. The GUT step printed
`---- All tests passed! ----` and the process then never returned from Godot's
teardown. Nothing bounded it, so the job's own twenty-minute timeout ended it and
the run showed as red. Eight of the last fifty-nine `ci` runs went that way: one
in nine of the runs that reached the end of the suite. Run 33038099540 is one of
them, with the suite finishing at 04:03:51, the job cancelled at 04:21:16, and
the runner reporting `Terminate orphan process: pid (2137) (godot)`.

**Every workflow step now starts Godot through `tools/ci_godot.sh`.** It caps the
run on wall clock, gives a run that has printed its verdict 60 seconds to exit
rather than the rest of the cap, dumps every thread's stack and CPU time when it
has to kill one, and takes an optional line the run prints when its work is done.
The GUT step is judged on that line, so a teardown that never returns is a
warning with a backtrace under it instead of a red build. A suite that fails, or
that hangs before printing it, is still red, and every step without such a line
fails on the cap: in seconds now rather than in twenty minutes.

The teardown itself is Godot's, not this project's. It came back on the eleventh
run of this branch, long after the mods page had stopped fetching, and the dump
says where: the main thread is in `__pthread_clockjoin_ex` waiting on one thread,
and that thread is in state R with five engine frames under `Thread`'s trampoline
and no libc frame at all. It had spent 182 of the run's 286 seconds on the CPU,
so it ran all along rather than starting to spin at the end. The four
`WorkerThread`s and the remaining thread are all parked on condition variables
with no CPU at all. That run finished green in 5m19s.

Two defects met on the way, both fixed here.

**The mods page fetched on its own outside a player's launch.** A runner's
`user://` is empty, so each of the seven pages the test tier builds read the
project's index over the network and then an icon a row. A warm cache hides that
from anyone running the suite locally. Check for updates and a download are what
a player pressed and are not gated.

**A screen dropping its view from `_exit_tree` asked a parent to remove a child
while it was already removing one**, which the engine refuses with an error.
Seven screens did it and a full run raised it twice. `Gen2Screen.drop_on_exit`
hides the view and queues the free instead, which is what the removal was for.

A stale README count goes with them: the unit tier is 3,365 tests, not "more than
2,700".

| Check | Result |
|---|---|
| GUT, both tiers | 3,895 pass |
| Engine errors in a full run | 0, against 2 before |
| `tools/validate.gd -- all` | exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | exit 0 |
| Warning scan over the changed scripts | 0 warnings in 10 scripts |
| CI on the final commit | 11 runs, 11 green in 3m08s to 5m19s; the one that hit the teardown is the 5m19s |