### PR TITLE
Ship a Nintendo Switch build

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -34,6 +34,7 @@ file before using it. Bring your own Crystal, Gold or Silver ROM.
 | Linux on a Raspberry Pi, an SBC or an arm64 handheld | `pokerecomp-{VERSION}-linux-arm64` |
 | Android, including handhelds like the Ayn Thor | `pokerecomp-{VERSION}-android.apk` |
 | iPhone or iPad | `pokerecomp-{VERSION}-ios.ipa` |
+| A Nintendo Switch running homebrew | `pokerecomp-{VERSION}-switch.zip` |
 
 Every download is one file. `sha256sums.txt` covers all of them.
 
@@ -50,6 +51,9 @@ Every download is one file. `sha256sums.txt` covers all of them.
   [AltStore](https://altstore.io) or [SideStore](https://sidestore.io), which
   sign it on your own machine with your own Apple ID. A free Apple ID works;
   apps signed that way need re-signing every 7 days.
+- **Switch**: extract the zip at the root of your microSD, so the file lands at
+  `switch/pokerecomp.nro`, and launch **pokerecomp** from the homebrew menu. It
+  needs a console that already runs homebrew; nothing here installs one.
 
 ## Updating
 

--- a/.github/workflows/export-templates.yml
+++ b/.github/workflows/export-templates.yml
@@ -43,11 +43,16 @@ env:
   # pin is the commit the stock templates name themselves after:
   # `4.8.dev3.official.51105ccbe`. The build checks that it still agrees.
   GODOT_COMMIT: 51105ccbe58381774ecd7a7486d564b202a5192e
+  # Nintendo ships no Godot platform and upstream carries none, so the Switch
+  # template is built from a fork of the same pin that adds `platform/nx`.
+  GODOT_NX_REMOTE: https://github.com/Decryptu/godot.git
+  GODOT_NX_COMMIT: ada239b4354f12b38a23ab8f6c6b4fa22000485f
 
 jobs:
   build:
     name: ${{ matrix.host }}
     runs-on: ${{ matrix.runs-on }}
+    container: ${{ matrix.container || null }}
     timeout-minutes: 240
     strategy:
       fail-fast: false
@@ -73,6 +78,12 @@ jobs:
           - host: android
             runs-on: ubuntu-latest
             targets: android
+          # devkitA64 and switch-mesa come from devkitPro's own image, which is
+          # the only place they are packaged for CI.
+          - host: switch
+            runs-on: ubuntu-latest
+            container: devkitpro/devkita64:latest
+            targets: switch
     defaults:
       run:
         shell: bash
@@ -102,6 +113,20 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
+          if [ "${{ matrix.host }}" = "switch" ]; then
+            # The devkitPro image carries devkitA64 and nothing else, and it is
+            # root without sudo. switch-mesa is the GLES3 driver; the rest are
+            # what detect.py links when the matching builtin_* is off.
+            dkp-pacman -Sy --noconfirm --needed \
+              switch-pkg-config switch-mesa switch-libdrm_nouveau \
+              switch-zlib switch-libpng switch-freetype switch-bzip2 \
+              switch-libwebp switch-libogg switch-libvorbis switch-libtheora \
+              switch-opusfile switch-libopus switch-libvpx switch-miniupnpc \
+              switch-zstd switch-pcre2 switch-libenet
+            apt-get update
+            apt-get install -y --no-install-recommends git python3 scons
+            exit 0
+          fi
           case "${{ runner.os }}" in
             Linux)
               sudo apt-get update
@@ -126,9 +151,15 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
+          remote="https://github.com/godotengine/godot.git"
+          commit="$GODOT_COMMIT"
+          if [ "${{ matrix.host }}" = "switch" ]; then
+            remote="$GODOT_NX_REMOTE"
+            commit="$GODOT_NX_COMMIT"
+          fi
           git init -q godot-src
-          git -C godot-src remote add origin https://github.com/godotengine/godot.git
-          git -C godot-src fetch -q --depth 1 origin "$GODOT_COMMIT"
+          git -C godot-src remote add origin "$remote"
+          git -C godot-src fetch -q --depth 1 origin "$commit"
           git -C godot-src checkout -q FETCH_HEAD
 
           # A pin that has drifted from the version the release installs stock

--- a/.github/workflows/export-templates.yml
+++ b/.github/workflows/export-templates.yml
@@ -114,17 +114,26 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ matrix.host }}" = "switch" ]; then
-            # The devkitPro image carries devkitA64 and nothing else, and it is
-            # root without sudo. switch-mesa is the GLES3 driver; the rest are
-            # what detect.py links when the matching builtin_* is off.
-            dkp-pacman -Sy --noconfirm --needed \
-              switch-pkg-config switch-mesa switch-libdrm_nouveau \
-              switch-zlib switch-libpng switch-freetype switch-bzip2 \
-              switch-libwebp switch-libogg switch-libvorbis switch-libtheora \
-              switch-opusfile switch-libopus switch-libvpx switch-miniupnpc \
-              switch-zstd switch-pcre2 switch-libenet
+            # The devkitPro image ships devkitA64 and the whole switch portlibs
+            # set already, and it is root without sudo. Only SCons is missing.
             apt-get update
-            apt-get install -y --no-install-recommends git python3 scons
+            apt-get install -y --no-install-recommends scons
+            # The image tag moves, so the libraries the build links are checked
+            # here: a base that has dropped one fails in seconds with its name
+            # rather than at the link step three quarters of an hour later.
+            # switch-mesa answers the first four; the rest are what detect.py
+            # links wherever the matching builtin_* is off.
+            missing=""
+            for lib in libEGL libGLESv2 libglapi libdrm_nouveau \
+                       libz libpng16 libfreetype libbz2 libwebp \
+                       libogg libvorbis libtheora libopusfile libvpx \
+                       libminiupnpc libzstd libpcre2-32 libenet; do
+              [ -f "/opt/devkitpro/portlibs/switch/lib/$lib.a" ] || missing="$missing $lib"
+            done
+            if [ -n "$missing" ]; then
+              echo "::error::devkitpro/devkita64 no longer ships:$missing"
+              exit 1
+            fi
             exit 0
           fi
           case "${{ runner.os }}" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,7 +421,16 @@ jobs:
           cp /tmp/switch/switch_release.elf switch_release.elf
           # An NRO icon is a 256x256 JPEG and nothing else; the repository's is
           # a PNG, so it is converted here rather than committed twice.
-          convert app_icon.png -resize 256x256! -quality 92 app_icon.jpg
+          # ImageMagick 7 renamed `convert` to `magick` and the runner image has
+          # carried one or the other for years, so both are tried by name.
+          if command -v magick >/dev/null; then
+            magick app_icon.png -resize 256x256! -quality 92 app_icon.jpg
+          elif command -v convert >/dev/null; then
+            convert app_icon.png -resize 256x256! -quality 92 app_icon.jpg
+          else
+            echo "::error::no ImageMagick on the runner; the NRO icon cannot be made"
+            exit 1
+          fi
           docker run --rm -v "$PWD:/w" -w /w devkitpro/devkita64:latest bash -c "
             set -euo pipefail
             nacptool --create pokerecomp '${{ github.repository_owner }}' '$v' control.nacp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,9 +365,90 @@ jobs:
           name: dist-apple
           path: dist/*
 
+  switch:
+    name: switch
+    needs: [version, templates]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.version.outputs.tag }}
+
+      - name: Install Godot and its export templates
+        run: |
+          set -euo pipefail
+          base="https://github.com/godotengine/godot-builds/releases/download/${GODOT_VERSION}"
+          curl -fsSL "$base/Godot_v${GODOT_VERSION}_linux.x86_64.zip" -o /tmp/godot.zip
+          unzip -q /tmp/godot.zip -d /tmp/godot
+          sudo install -m755 "/tmp/godot/Godot_v${GODOT_VERSION}_linux.x86_64" /usr/local/bin/godot
+          echo "GODOT=/usr/local/bin/godot" >> "$GITHUB_ENV"
+          curl -fsSL "$base/Godot_v${GODOT_VERSION}_export_templates.tpz" -o /tmp/templates.tpz
+          unzip -q /tmp/templates.tpz -d /tmp/tpz
+          mkdir -p "$HOME/.local/share/godot/export_templates/${GODOT_TEMPLATE_DIR}"
+          cp -R /tmp/tpz/templates/. "$HOME/.local/share/godot/export_templates/${GODOT_TEMPLATE_DIR}/"
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: templates-switch
+          path: /tmp/switch
+
+      - name: Import
+        run: |
+          set -euo pipefail
+          GODOT_CAP=900 tools/ci_godot.sh "$GODOT" --headless --editor --path . --quit
+          [ -d .godot ] || { echo "::error::import produced no .godot"; exit 1; }
+
+      # A stock editor knows no NX platform, so `export_presets.cfg` carries no
+      # Switch preset and this exports the pack alone. Every preset here ships
+      # the same file set, and a pack holds each feature-tagged setting rather
+      # than one platform's answer, so the Linux preset's pack is the game.
+      - name: Export the pack
+        run: |
+          set -euo pipefail
+          mkdir -p romfs dist
+          GODOT_CAP=900 tools/ci_godot.sh "$GODOT" --headless --path . \
+            --export-pack "Linux" "$PWD/romfs/game.pck"
+          [ -s romfs/game.pck ] || { echo "::error::the pack is empty"; exit 1; }
+
+      # nacptool writes the title, author and version hbmenu shows; elf2nro
+      # wraps the template around the pack as a RomFS image. Both are devkitPro
+      # tools and the image is where they are packaged.
+      - name: Wrap the template into an NRO
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          cp /tmp/switch/switch_release.elf switch_release.elf
+          # An NRO icon is a 256x256 JPEG and nothing else; the repository's is
+          # a PNG, so it is converted here rather than committed twice.
+          convert app_icon.png -resize 256x256! -quality 92 app_icon.jpg
+          docker run --rm -v "$PWD:/w" -w /w devkitpro/devkita64:latest bash -c "
+            set -euo pipefail
+            nacptool --create pokerecomp '${{ github.repository_owner }}' '$v' control.nacp
+            elf2nro switch_release.elf pokerecomp.nro \
+              --icon=app_icon.jpg --nacp=control.nacp --romfsdir=romfs
+          "
+          [ -s pokerecomp.nro ] || { echo "::error::elf2nro produced nothing"; exit 1; }
+
+      # The zip extracts at the root of a microSD: hbmenu lists what is in
+      # `switch/`, and Ryujinx and the yuzu forks read the same tree.
+      - name: Stage the SD tree
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          mkdir -p sd/switch
+          cp pokerecomp.nro sd/switch/pokerecomp.nro
+          ( cd sd && zip -qr "../dist/pokerecomp-${v}-switch.zip" switch )
+          unzip -l "dist/pokerecomp-${v}-switch.zip"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-switch
+          path: dist/*
+
   publish:
     name: publish
-    needs: [version, linux-windows-android, apple]
+    needs: [version, linux-windows-android, apple, switch]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Godot-4.8.dev3-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="Godot 4.8.dev3">
   <img src="https://img.shields.io/badge/GDScript-355570?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript">
-  <img src="https://img.shields.io/badge/platforms-Windows%20%C2%B7%20macOS%20%C2%B7%20Linux%20%C2%B7%20Android%20%C2%B7%20iOS-8f8c98?style=flat-square" alt="Platforms">
+  <img src="https://img.shields.io/badge/platforms-Windows%20%C2%B7%20macOS%20%C2%B7%20Linux%20%C2%B7%20Android%20%C2%B7%20iOS%20%C2%B7%20Switch-8f8c98?style=flat-square" alt="Platforms">
   <img src="https://img.shields.io/badge/arm64-Windows%20%C2%B7%20Linux%20%C2%B7%20Apple-8f8c98?style=flat-square" alt="arm64">
   <img src="https://img.shields.io/badge/status-alpha-e0a138?style=flat-square" alt="Status: alpha">
   <a href="https://github.com/Decryptu/pokerecomp/releases/latest"><img src="https://img.shields.io/github/v/release/Decryptu/pokerecomp?style=flat-square&color=4c9a5a&label=download" alt="Latest release"></a>
@@ -34,6 +34,7 @@ one file per platform. `sha256sums.txt` covers every one of them.
 | Linux on a Pi, an SBC or an ARM handheld | `pokerecomp-<version>-linux-arm64` |
 | Android, handhelds included | `pokerecomp-<version>-android.apk` |
 | iPhone or iPad | `pokerecomp-<version>-ios.ipa` |
+| Nintendo Switch running homebrew | `pokerecomp-<version>-switch.zip` |
 
 Nothing is signed with a paid certificate, so each platform asks once:
 
@@ -45,6 +46,9 @@ Nothing is signed with a paid certificate, so each platform asks once:
   [AltStore](https://altstore.io) or [SideStore](https://sidestore.io), which
   sign it on your own machine with your own Apple ID. A free Apple ID works and
   needs re-signing weekly.
+- **Switch**: extract the zip at the root of your microSD and launch
+  `pokerecomp` from the homebrew menu. It needs a console that already runs
+  homebrew; nothing here installs one.
 
 The About page tells you when a newer release exists. It does not install it:
 download the new file and replace the old one. Saves live elsewhere and survive.
@@ -362,14 +366,20 @@ Exit code `0` means all tests passed. Run one script with `-gselect=<name>`.
 
 ## Platforms
 
-Windows, macOS, Linux, Android and iOS use GL Compatibility.
-`export_presets.cfg` covers seven presets, x86_64 and arm64 for Windows and
+Every platform uses GL Compatibility. `export_presets.cfg` covers seven presets
+for Windows, macOS, Linux, Android and iOS, x86_64 and arm64 for Windows and
 Linux, and writes into `builds/`. Install the matching export templates first,
 then:
 
 ```bash
 godot --headless --path . --export-release "Linux" builds/linux/pokerecomp.x86_64
 ```
+
+The Switch has no preset, because a stock editor knows no such platform and
+would drop one from the file. `.github/workflows/release.yml` exports the pack
+and wraps it with devkitPro's `elf2nro` instead, around a template built from a
+fork of the engine pin that adds `platform/nx`; `docs/CONTRIBUTING.md` has the
+whole lane.
 
 Tests, tools and GUT are excluded, and `roms/` and the `user://` cache are not
 reachable from an export. **No signing identity is committed**: the iOS preset's

--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -504,7 +504,12 @@ static func _file_picker_kind() -> String:
 		return "the system picker, through the platform plugin"
 	if DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE):
 		return "the system picker, through the engine"
-	return "the engine's own browser"
+	# Where it opens is the whole story on a machine with no pointer, whose
+	# d-pad can walk the browser down and never back up.
+	var start: String = Gen2LauncherFilePicker._pointerless_start_dir()
+	if start.is_empty():
+		return "the engine's own browser"
+	return "the engine's own browser, opening at %s" % start
 
 
 ## Empty on a headless run, and on a machine whose driver never answered.

--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -66,8 +66,10 @@ func _ready() -> void:
 	# Before any event has arrived the only evidence is the hardware. A phone
 	# should show its controller on the first frame rather than after the first
 	# tap, and a desktop should not show one at all.
-	_device = Gen2InputDevice.TOUCH if DisplayServer.is_touchscreen_available() \
-		else Gen2InputDevice.KEYBOARD
+	_device = Gen2InputDevice.kind_for_hardware(
+		not Input.get_connected_joypads().is_empty(),
+		DisplayServer.is_touchscreen_available(),
+	)
 	apply_options(Gen2OptionsStore.current())
 
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -166,6 +166,37 @@ approximating its output, find a second executable implementation to diff
 against, pick an artefact that compares exactly, sweep the whole corpus, and
 settle every disagreement against pret.
 
+## Switch
+
+Nintendo ships no Godot platform and upstream carries none, so the Switch
+template is built from a fork of the same engine pin that adds `platform/nx`.
+`.github/workflows/export-templates.yml` holds both pins side by side:
+`GODOT_COMMIT` for every other target, `GODOT_NX_REMOTE` and `GODOT_NX_COMMIT`
+for this one. The two must stay on the same Godot series; the build already
+refuses a pin whose `version.py` disagrees with the release's stock templates.
+
+`tools/build_export_templates.sh switch` builds it, against devkitPro's
+devkitA64 and switch-mesa, and writes `switch_release.elf`. The toolchain is
+only packaged for CI as `devkitpro/devkita64`, so the workflow runs that host in
+that container.
+
+There is no export preset. A stock editor knows no NX platform and drops a
+preset it cannot resolve, so the release exports the pack with the Linux preset
+and wraps it with `nacptool` and `elf2nro`, which is what the fork's own export
+plugin does when the editor is built from it. The published zip extracts at the
+root of a microSD and puts one file at `switch/pokerecomp.nro`.
+
+Two things a Switch build changes for every platform, both fixed at the seam
+rather than behind a platform name:
+
+- Godot's `ui_accept` carries three keys and no pad button, so a machine with no
+  keyboard could move every focus ring and choose nothing under it.
+  `Gen2InputActions.UI_PAD_BUTTONS` gives it one.
+- The launcher draws in device-independent points, and a platform that cannot
+  open a second window is one whose window is the whole screen and whose sizes
+  are physical pixels. `Gen2LauncherUI.draws_in_screen_pixels` asks the display
+  server rather than listing platforms.
+
 ## Pitfalls
 
 - GUT silently skips scripts that fail to parse. `test_smoke.gd` loads every

--- a/game/input/input_actions.gd
+++ b/game/input/input_actions.gd
@@ -38,6 +38,18 @@ const DEADZONE: float = 0.5
 ## the controller into the other port.
 const ALL_DEVICES: int = -1
 
+## The pad button Godot's own UI actions are missing.
+##
+## `ui_accept` ships as Enter, Keypad Enter and Space, and `ui_cancel` as Escape
+## alone, so on a machine with no keyboard every focus ring in the launcher can
+## be moved and nothing under it can be chosen. The eight game buttons are the
+## player's to rebind; these two are the engine's, and are added rather than
+## replaced so the keys keep working.
+const UI_PAD_BUTTONS: Dictionary = {
+	&"ui_accept": JOY_BUTTON_A,
+	&"ui_cancel": JOY_BUTTON_B,
+}
+
 ## How many bindings one button may carry. The remap UI shows a fixed number of
 ## slots, and an options file claiming hundreds is a file to clamp, not to obey.
 const MAX_BINDINGS: int = 6
@@ -154,6 +166,27 @@ static func install(scheme: Dictionary) -> void:
 			var event: InputEvent = to_event(binding)
 			if event != null:
 				InputMap.action_add_event(name, event)
+	install_ui_pad_buttons()
+
+
+## Gives [constant UI_PAD_BUTTONS] to the engine's own UI actions. Idempotent:
+## an action that already answers to that button is left alone.
+static func install_ui_pad_buttons() -> void:
+	for action: StringName in UI_PAD_BUTTONS:
+		if not InputMap.has_action(action):
+			continue
+		var code: int = int(UI_PAD_BUTTONS[action])
+		var bound: bool = false
+		for existing: InputEvent in InputMap.action_get_events(action):
+			if existing is InputEventJoypadButton and existing.button_index == code:
+				bound = true
+				break
+		if bound:
+			continue
+		var event := InputEventJoypadButton.new()
+		event.device = ALL_DEVICES
+		event.button_index = code as JoyButton
+		InputMap.action_add_event(action, event)
 
 
 ## Builds the [InputEvent] an [InputMap] entry needs, or null for a binding this
@@ -209,13 +242,13 @@ static func from_event(event: InputEvent) -> Dictionary:
 
 ## The key actually printed where this physical one sits, as a keycode.
 ## `keyboard_get_label_from_physical` returns a key rather than a string, and
-## refuses on a display server with no keyboard to read a layout off: a headless
-## run, and every handheld, whose display server answers no whether or not a
-## keyboard happens to be paired. There is no feature flag to ask instead, and
-## the refusal is an error, so a settings page put fourteen of them into every
-## bug report a phone ever sent.
+## refuses with an error on a display server that reads no keyboard layout: a
+## headless run, every handheld, and the console. Asking how many layouts it has
+## is the same question without the error, and it is answered by every display
+## server rather than by a list of platform names, so a settings page no longer
+## puts fourteen refusals into every bug report a phone or a Switch sends.
 static func _labelled_key(code: int) -> int:
-	if DisplayServer.get_name() == "headless" or OS.has_feature("mobile"):
+	if DisplayServer.keyboard_get_layout_count() <= 0:
 		return code
 	var labelled: int = DisplayServer.keyboard_get_label_from_physical(code)
 	return labelled if labelled != 0 else code

--- a/game/input/input_device.gd
+++ b/game/input/input_device.gd
@@ -24,6 +24,20 @@ const LABELS: Dictionary = {
 }
 
 
+## The kind to assume before any event has arrived, from what the machine has.
+##
+## A pad comes first where there is both, because a machine with both is being
+## held by its buttons: a Switch in the hands has a touchscreen nobody is
+## touching, and so does a phone with a controller paired to it. The first real
+## event replaces this answer anyway; what it decides is the first frame.
+static func kind_for_hardware(has_pad: bool, has_touch: bool) -> StringName:
+	if has_pad:
+		return GAMEPAD
+	if has_touch:
+		return TOUCH
+	return KEYBOARD
+
+
 ## The device kind an event came from, or an empty name for an event that says
 ## nothing about one.
 ##

--- a/game/launcher/launcher_file_picker.gd
+++ b/game/launcher/launcher_file_picker.gd
@@ -17,7 +17,8 @@ extends FileDialog
 ##    app's own storage, so what a caller reads is an ordinary path.
 ## 3. The engine's built-in browser, for anything left. Rooted at the app's own
 ##    data where the filesystem is sandboxed, since every path outside it is one
-##    [FileAccess] would then be refused.
+##    [FileAccess] would then be refused, and at the top of the volume where
+##    there is no pointer to steer it with. See [method _pointerless_start_dir].
 
 ## The plugin's singleton, present only on a build that carries it.
 const NATIVE_SINGLETON: StringName = &"NativeFilePicker"
@@ -48,6 +49,56 @@ static func create(
 	return dialog
 
 
+## Points the browser at [method _pointerless_start_dir] before it is shown.
+##
+## Set here rather than in [method create]: the dialog is built once at startup
+## and reaches its directory through a `chdir`, which only holds once it is in
+## the tree. A volume that refuses its name with the trailing slash is tried
+## without one, and a refusal leaves the engine's own answer in place.
+func _open_where_a_pad_can_reach() -> void:
+	if access != FileDialog.ACCESS_FILESYSTEM:
+		return
+	var start: String = _pointerless_start_dir()
+	if start.is_empty():
+		return
+	# Every time, not only the first: the dialog remembers where it was left, and
+	# a machine that cannot climb back up would be stuck wherever it last went.
+	current_dir = start
+	if not current_dir.begins_with(start):
+		current_dir = start.trim_suffix("/")
+
+
+## Where the engine's own browser should open on a machine with no pointer, or
+## an empty string where it should keep the engine's answer.
+##
+## The browser's file list takes the d-pad and descends fine, but its path field
+## is a [LineEdit] and eats left and right, so the toolbar's "up" button behind
+## it cannot be reached: a console can walk down the tree and never back up.
+## Starting at the top of the volume means it never has to. The app's own data
+## sits several levels down, which is exactly the corner it cannot climb out of.
+static func _pointerless_start_dir() -> String:
+	if DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE):
+		return ""
+	return volume_root(OS.get_data_dir())
+
+
+## The top of the volume [param path] is on, as a directory a browser can open.
+##
+## `/` on anything Unix-shaped. Horizon names a volume with a colon and mounts
+## each one at its own root, so the SD card is `sdmc:/` and there is nothing
+## above it.
+static func volume_root(path: String) -> String:
+	var root: String = path
+	while true:
+		var parent: String = root.get_base_dir()
+		if parent.is_empty() or parent == root:
+			break
+		root = parent
+	if root.is_empty():
+		return ""
+	return root + "/" if root.ends_with(":") else root
+
+
 ## Whether the browser in 3. above would list anything the app may then open. A
 ## sandboxed platform reaching this far has only its own data to offer.
 func _can_browse_freely() -> bool:
@@ -63,6 +114,7 @@ func _can_browse_freely() -> bool:
 ## [signal FileDialog.canceled] the refusal, whichever of the three presented it.
 func show_picker(fallback_size: Vector2i) -> void:
 	if _native == null:
+		_open_where_a_pad_can_reach()
 		popup_centered(fallback_size)
 		return
 	# One singleton serves every picker on screen, and a request left outstanding

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -21,6 +21,23 @@ const DOCK_VERTICAL_PADDING: float = 28.0
 const TOUCH_TARGET: float = 48.0
 
 
+## Whether this display server hands out the screen's own pixels rather than
+## points.
+##
+## A platform that cannot open a second window is one whose window is the whole
+## screen, and every one of them measures in physical pixels: a phone, a tablet,
+## a console. A desktop is already in points and wants no factor at all. Asked of
+## the display server rather than of a list of platform names, so a console this
+## project has not met yet is covered on the day it arrives. A headless run
+## answers no to every feature there is, so it is asked first whether it draws
+## at all; without that a test tier would measure itself as a handheld.
+static func draws_in_screen_pixels() -> bool:
+	return (
+		DisplayServer.window_can_draw()
+		and not DisplayServer.has_feature(DisplayServer.FEATURE_SUBWINDOWS)
+	)
+
+
 ## How many window pixels one launcher unit is drawn at, so that a unit is a
 ## device-independent point rather than a pixel.
 ##
@@ -28,11 +45,13 @@ const TOUCH_TARGET: float = 48.0
 ## reading size only because a desktop screen is about 100 pixels to the inch. A
 ## phone is three to four times that, so the same numbers arrive at a third of the
 ## size and the window measures wide enough to be taken for a desktop. The screen's
-## own backing scale is exactly that ratio, and iOS and Android both report it.
+## own backing scale is exactly that ratio, and iOS and Android both report it. A
+## Switch reports neither a scale nor a phone's density: 237 dots per inch held
+## in the hands, 96 in the dock, which the same formula turns into 1.5 and 1.
 static func display_density() -> float:
 	if preview_density > 0.0:
 		return preview_density
-	if not OS.has_feature("mobile"):
+	if not draws_in_screen_pixels():
 		return 1.0
 	var scale: float = DisplayServer.screen_get_scale()
 	if scale > 1.0:
@@ -78,7 +97,7 @@ static func base_stretch(window: Window) -> float:
 
 static func point_scale(control: Control) -> float:
 	var window: Window = control.get_window()
-	if window == null or (not OS.has_feature("mobile") and preview_density <= 0.0):
+	if window == null or (not draws_in_screen_pixels() and preview_density <= 0.0):
 		return 1.0
 	var pixels_per_unit: float = float(window.size.x) / maxf(window.get_visible_rect().size.x, 1.0)
 	pixels_per_unit *= control.get_global_transform_with_canvas().x.length()
@@ -103,7 +122,7 @@ static func safe_area_insets(window: Window) -> Dictionary:
 	var none: Dictionary = {"left": 0.0, "top": 0.0, "right": 0.0, "bottom": 0.0}
 	if not preview_insets.is_empty():
 		return preview_insets
-	if window == null or not OS.has_feature("mobile"):
+	if window == null or not draws_in_screen_pixels():
 		return none
 	var safe: Rect2i = DisplayServer.get_display_safe_area()
 	var screen: Vector2i = DisplayServer.screen_get_size()

--- a/tests/unit/test_input_actions.gd
+++ b/tests/unit/test_input_actions.gd
@@ -204,3 +204,33 @@ func test_a_key_beyond_the_named_pad_buttons_still_reads() -> void:
 	assert_string_contains(
 		Gen2InputActions.describe({"kind": Gen2InputActions.KIND_PAD_BUTTON, "code": 99}), "99"
 	)
+
+
+func test_the_engines_ui_actions_answer_to_a_pad() -> void:
+	# Godot binds ui_accept to three keys and nothing else, so a machine with no
+	# keyboard could move every focus ring and choose nothing under it. The
+	# engine's own events are put back afterwards, the way the scheme is.
+	var stock: Dictionary = {}
+	for action: StringName in Gen2InputActions.UI_PAD_BUTTONS:
+		stock[action] = InputMap.action_get_events(action)
+		InputMap.action_erase_events(action)
+	Gen2InputActions.install(Gen2InputActions.defaults())
+
+	for action: StringName in Gen2InputActions.UI_PAD_BUTTONS:
+		var pad := InputEventJoypadButton.new()
+		pad.device = Gen2InputActions.ALL_DEVICES
+		pad.button_index = int(Gen2InputActions.UI_PAD_BUTTONS[action]) as JoyButton
+		pad.pressed = true
+		assert_true(InputMap.event_is_action(pad, action), "%s answers to its pad button" % action)
+
+	for action: StringName in stock:
+		for event: InputEvent in stock[action]:
+			if not InputMap.action_has_event(action, event):
+				InputMap.action_add_event(action, event)
+
+
+func test_installing_twice_adds_one_ui_pad_binding() -> void:
+	Gen2InputActions.install(Gen2InputActions.defaults())
+	var once: int = InputMap.action_get_events(&"ui_accept").size()
+	Gen2InputActions.install(Gen2InputActions.defaults())
+	assert_eq(InputMap.action_get_events(&"ui_accept").size(), once)

--- a/tests/unit/test_input_device.gd
+++ b/tests/unit/test_input_device.gd
@@ -36,3 +36,12 @@ func test_every_kind_is_named() -> void:
 	for kind: StringName in Gen2InputDevice.KINDS:
 		assert_false(Gen2InputDevice.label(kind).is_empty(), String(kind))
 	assert_eq(Gen2InputDevice.label(&"nothing"), "")
+
+
+func test_the_first_frame_prefers_a_pad_over_a_touchscreen() -> void:
+	# A Switch in the hands and a phone with a controller both report both, and
+	# on both the player is holding buttons rather than touching glass.
+	assert_eq(Gen2InputDevice.kind_for_hardware(true, true), Gen2InputDevice.GAMEPAD)
+	assert_eq(Gen2InputDevice.kind_for_hardware(true, false), Gen2InputDevice.GAMEPAD)
+	assert_eq(Gen2InputDevice.kind_for_hardware(false, true), Gen2InputDevice.TOUCH)
+	assert_eq(Gen2InputDevice.kind_for_hardware(false, false), Gen2InputDevice.KEYBOARD)

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -120,6 +120,31 @@ func test_every_file_picker_asks_for_the_systems_own() -> void:
 		assert_false(source.contains("popup_centered") and path.ends_with("save_screen.gd"), path)
 
 
+## A d-pad can descend the engine's browser and cannot climb it: the path field
+## is a LineEdit and eats left and right, so the toolbar's "up" button behind it
+## is unreachable. On a machine with no pointer the browser therefore has to open
+## somewhere the player never needs to leave upwards.
+func test_a_pointerless_browser_opens_at_the_top_of_the_volume() -> void:
+	var start: String = Gen2LauncherFilePicker._pointerless_start_dir()
+	if DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE):
+		assert_eq(start, "", "a pointer can reach the up button, so nothing is forced")
+		return
+	assert_false(start.is_empty(), "a console is given a root")
+	assert_true(
+		OS.get_data_dir().begins_with(start.trim_suffix("/")),
+		"and the root is the volume the user data is on",
+	)
+
+
+func test_the_volume_root_is_the_top_of_a_path_on_any_shape_of_volume() -> void:
+	assert_eq(Gen2LauncherFilePicker.volume_root("/home/a/.local/share"), "/")
+	assert_eq(Gen2LauncherFilePicker.volume_root("/"), "/")
+	# Horizon mounts the SD card as its own volume, named with a colon.
+	assert_eq(Gen2LauncherFilePicker.volume_root("sdmc:/config/godot"), "sdmc:/")
+	assert_eq(Gen2LauncherFilePicker.volume_root("sdmc:/config"), "sdmc:/")
+	assert_eq(Gen2LauncherFilePicker.volume_root("C:/Users/a/AppData"), "C:/")
+
+
 func test_a_picker_reads_its_extensions_out_of_its_own_filters() -> void:
 	# What the system picker is asked to offer comes from the same filter string
 	# the built-in browser uses, so the two can never be told different things.
@@ -817,3 +842,23 @@ func _buttons_under(root: Node) -> Array[Gen2LauncherButton]:
 	for child: Node in root.get_children():
 		found.append_array(_buttons_under(child))
 	return found
+
+
+func test_a_platform_that_cannot_open_a_second_window_draws_in_screen_pixels() -> void:
+	# The question is asked of the display server rather than of a platform name,
+	# so a phone, a tablet and a console are all covered by the same answer, and
+	# a desktop keeps its 1.0 whatever its screen reports. A headless run answers
+	# no to every feature, so it must not read as a handheld: this whole tier
+	# would measure itself at a phone's density.
+	var drawing: bool = DisplayServer.window_can_draw()
+	var subwindows: bool = DisplayServer.has_feature(DisplayServer.FEATURE_SUBWINDOWS)
+	assert_eq(Gen2LauncherUI.draws_in_screen_pixels(), drawing and not subwindows)
+	if not drawing or subwindows:
+		assert_eq(Gen2LauncherUI.display_density(), 1.0, "a desktop is already in points")
+		assert_eq(Gen2LauncherUI.safe_area_insets(get_tree().root)["top"], 0.0)
+
+
+func test_the_preview_density_still_overrides_the_display_server() -> void:
+	Gen2LauncherUI.preview_density = 2.5
+	assert_eq(Gen2LauncherUI.display_density(), 2.5)
+	Gen2LauncherUI.preview_density = 0.0

--- a/tools/build_export_templates.sh
+++ b/tools/build_export_templates.sh
@@ -101,6 +101,16 @@ for t in "$@"; do
       build android arch=arm32 generate_android_binary=no
       ( cd "$src/platform/android/java" && ./gradlew generateGodotTemplates )
       cp "$src/bin/android_release.apk" "$out/android_release.apk" ;;
+    # The Switch platform is not in godotengine/godot: the source directory has
+    # to be a checkout that carries platform/nx. devkitA64 and switch-mesa are
+    # what it builds against, and DEVKITPRO is where detect.py looks for both.
+    switch)
+      [ -d "$src/platform/nx" ] || {
+        echo "the source at $src carries no platform/nx; check out the Switch fork" >&2
+        exit 2
+      }
+      build nx arch=arm64
+      cp "$src/bin/godot.nx.template_release.arm64.elf" "$out/switch_release.elf" ;;
     *) echo "unknown target: $t" >&2; exit 2 ;;
   esac
 done


### PR DESCRIPTION
pokerecomp now builds and runs as Switch homebrew. The launcher draws, the
d-pad and buttons work, a cartridge imports from the SD card and the shelf
seats it, at 60 fps.

## The engine was the blocker

Upstream Godot has no Switch platform and the homebrew ports stopped at 4.1,
so `platform/nx` is ported onto this project's own 4.8 pin. Five things had
moved since 4.1: `Main::start` returns an exit code rather than a bool, every
DisplayServer enum lives in `DisplayServerEnums`, a template refuses
`--main-pack` unless path overrides are left on, `Input` only releases what a
driver hands it when the display server flushes, and a joypad with no GUID is
put behind a fallback mapping that remaps buttons the driver already reports
in Godot's own terms.

`.github/workflows/export-templates.yml` holds that fork beside the stock pin.
`tools/build_export_templates.sh switch` builds the template against
devkitPro's devkitA64 and switch-mesa, in devkitPro's own image, because that
is the only place the toolchain is packaged for CI.

There is no export preset: a stock editor knows no NX platform and drops one
it cannot resolve, so the release exports the pack and wraps it with
`nacptool` and `elf2nro`. The published zip extracts at the root of a microSD
and puts one file at `switch/pokerecomp.nro`.

## Four things it found wrong everywhere

Each is fixed at the seam rather than behind a platform name, and each has a
caller today.

| What | Why it matters off the Switch |
|---|---|
| `ui_accept` carries three keys and no pad button, `ui_cancel` only Escape | Any machine with a pad and no keyboard can move every focus ring and choose nothing |
| `_labelled_key` named headless and mobile to avoid an unsupported call | Sixteen refusals per session in the log on anything else without a keyboard layout |
| The launcher's density asked `OS.has_feature("mobile")` | What it means is a window that is the whole screen, which is what a display server with no subwindows says |
| The first frame preferred a touchscreen over a pad | A phone with a controller paired drew an on-screen controller nobody was using |

The engine's file browser is the last one. Its file list takes the d-pad and
descends fine, but the path field above it is a `LineEdit` that eats left and
right, so the toolbar's "up" button is unreachable: a console walks down the
tree and never back up. The browser now opens at the top of the volume every
time it is shown, and the diagnostics report says where that is.

## Checks

| Check | Result |
|---|---|
| Unit tier | 3373 pass |
| Whole suite | 3905 pass |
| `validate.gd -- all` | 78 topics, no failures |
| `replay_world.gd` | 33 routes, 0 failures |
| Boot smoke | clean apart from the recorded audio-teardown leak |
| On device | Ryubing, firmware 22.1.0, GLES3 on nouveau, 60 fps: launcher, d-pad, buttons, import from `sdmc:/roms` |

One thing is not explained: after an import finishes, the page behind the
seated cartridge stays dimmed and the "Import complete" toast never draws.
Everything else on the screen keeps running at 60 fps and answers the pad, so
it looks like a compositing difference on that GL driver rather than a stuck
state.