### PR TITLE
End a Bug Catching Contest the way the cartridge ends it

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2748,6 +2748,13 @@ func complete_capture(result: Dictionary) -> Dictionary:
 		_capture_messages.append("The ball shook!")
 	if caught:
 		_capture_messages.append("Gotcha! %s was caught!" % _name_of(_enemy))
+		## `.catch_bug_contest_mon` runs after `Text_GotchaMonWasCaught`, and
+		## `BugContest_SetCaughtContestMon`'s `.firstcatch` says a second line.
+		## A catch that has one to replace says `DisplayAlreadyCaughtText`
+		## instead, which comes with the switch question rather than here.
+		if bool(result.get("contest", false)) \
+			and not bool(result.get("replace_offer", false)):
+			_capture_messages.append("Caught %s!" % _name_of(_enemy))
 		_capture_terminal = true
 		_capture_caught_event = _caught_event(result)
 	else:

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -299,6 +299,10 @@ var _capture_messages: Array[String] = []
 ## before the nickname prompt opens.
 var _capture_caught_event: Dictionary = {}
 var _capture_terminal: bool = false
+## Whether `DisplayAlreadyCaughtText` has been said for this throw. The line
+## comes once, before the switch question, and the question is asked again on
+## every pump until it is answered.
+var _contest_already_caught_said: bool = false
 ## Whether this capture's experience award has already run. See
 ## [method _spend_capture_experience].
 var _capture_experience_spent: bool = false
@@ -2964,6 +2968,7 @@ func _clear_capture_action() -> void:
 	_capture_messages.clear()
 	_capture_caught_event = {}
 	_capture_terminal = false
+	_contest_already_caught_said = false
 	_capture_result.clear()
 	_close_capture_nickname()
 	_capture_nickname = ""
@@ -3378,6 +3383,13 @@ func _continue_after_messages() -> void:
 		## `BugContest_SetCaughtContestMon` asks before replacing the Pokemon
 		## already caught, over the same `PlaceYesNoBox` a switch offer uses.
 		if bool(_capture_result.get("replace_offer", false)) and _switch_stage == &"":
+			## `DisplayAlreadyCaughtText` before `DisplayCaughtContestMonStats`
+			## and the box: the line about the one already held is prompted past
+			## first, and the question is asked over the comparison.
+			if not _contest_already_caught_said:
+				_contest_already_caught_said = true
+				show_message(CONTEST_ALREADY_CAUGHT_TEXT % _contest_stock_name())
+				return
 			_open_yes_no(&"contest_replace", CONTEST_REPLACE_TEXT)
 			return
 		## A registered policy's award and every level up, move offer and
@@ -3950,7 +3962,11 @@ func _answer_switch(button: int) -> void:
 ## `BugContest_SetCaughtContestMon`'s own `PlaceYesNoBox`, which `ret c` reads as
 ## keeping the Pokemon already caught. The answer rides out on the capture
 ## result, since what it decides is world state rather than battle state.
-const CONTEST_REPLACE_TEXT: String = "Replace the one you caught?"
+## `_ContestAskSwitchText`, which is what `PlaceYesNoBox` stands under.
+const CONTEST_REPLACE_TEXT: String = "Switch #MON?"
+## `_ContestAlreadyCaughtText`, said first and prompted past.
+## `DisplayAlreadyCaughtText` names the Pokemon already held.
+const CONTEST_ALREADY_CAUGHT_TEXT: String = "You already caught\na %s."
 
 
 func _answer_contest_replace(button: int) -> void:
@@ -5492,6 +5508,12 @@ func _box_raster_offsets() -> PackedInt32Array:
 		return PackedInt32Array()
 	var top: int = Gen2TextBox.STANDARD_TOP * Gen2Font.TILE
 	return _intro.offsets().slice(top, top + _box.rows * Gen2Font.TILE)
+
+
+## The Pokemon `wContestMon` already holds, which is what
+## `DisplayAlreadyCaughtText` names and the comparison's STOCK box shows.
+func _contest_stock_name() -> String:
+	return _name_of(int(_capture_result.get("stock_species", 0)))
 
 
 func _name_of(species: int) -> String:

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -895,7 +895,8 @@ const MENU_DESCRIPTION_COUNT: int = 9
 ## has not found its terminator and is not the table.
 const MENU_DESCRIPTION_MAX: int = 64
 ## The order the strings are laid out in, as the start menu's own item kinds.
-## `quit` is the Bug Contest's, which this project never shows.
+## `quit` is the Bug Catching Contest's, which stands where `save` does while
+## one runs ([constant Gen2WorldStartMenu.ITEM_QUIT]).
 const MENU_DESCRIPTION_ORDER: Array[StringName] = [
 	&"pokedex", &"pokemon", &"pack", &"pokegear", &"player", &"save", &"option",
 	&"exit", &"quit",

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -21,6 +21,19 @@ const LIST_LEFT: int = 10
 const LIST_RIGHT: int = COLUMNS - 1
 const LIST_TOP: int = 0
 const LIST_CONTEST_TOP: int = 2
+## `StartMenu_DrawBugContestStatusBox`'s `Textbox` at `hlcoord 0, 0` with
+## `b = 5` and `c = 17`, which draws a frame two cells wider and taller than
+## its own span. It is why `.ContestMenuHeader` starts two rows down.
+const CONTEST_BOX_SIZE: Vector2i = Vector2i(19, 7)
+## `StartMenu_PrintBugContestStatus`' own `hlcoord`s, in its own order.
+const CONTEST_CAUGHT_AT: Vector2i = Vector2i(1, 1)
+const CONTEST_NAME_AT: Vector2i = Vector2i(8, 1)
+const CONTEST_LEVEL_AT: Vector2i = Vector2i(1, 3)
+## `Print8BitNumLeftAlign` starts one cell past where `PlaceString` left off,
+## and "LEVEL" is five cells from column 1.
+const CONTEST_LEVEL_NUMBER_AT: Vector2i = Vector2i(7, 3)
+const CONTEST_BALLS_AT: Vector2i = Vector2i(1, 5)
+const CONTEST_BALLS_NUMBER_AT: Vector2i = Vector2i(8, 5)
 ## `.MenuData`'s own flags.
 const LIST_FLAGS: int = (
 	Gen2MenuBox.STATICMENU_CURSOR
@@ -147,7 +160,7 @@ static func list_box(count: int, contest: bool = false) -> Gen2MenuBox:
 ## names rather than the eight-character words the source list holds.
 func render_list(
 	labels: Array, cursor: int, description: String = "", contest: bool = false,
-	frame: Gen2MenuBox = null
+	frame: Gen2MenuBox = null, status: Dictionary = {}
 ) -> Image:
 	if menu == null or font == null:
 		return null
@@ -155,6 +168,11 @@ func render_list(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
 	var box: Gen2MenuBox = frame if frame != null else list_box(labels.size(), contest)
+	if contest:
+		## `.DrawBugContestStatusBox` and `.DrawBugContestStatus`, both of which
+		## the flag alone decides. Drawn before the list, because the list's box
+		## sits two rows into it.
+		_blit(image, _render_contest_status(status), Vector2i.ZERO)
 	_blit(image, menu.render(box, labels, cursor), box.border_position())
 	if not description.is_empty():
 		_blit(image, _render_account(description), ACCOUNT_AT)
@@ -255,6 +273,40 @@ func _render_save_textbox(state: Dictionary) -> Image:
 		)
 	return Gen2PicImage.from_indices(
 		indices, width, SAVE_TEXTBOX_SIZE.y * TILE, _palette()
+	)
+
+
+## `StartMenu_PrintBugContestStatus`: what has been caught, its level and how
+## many park balls are left. [param status] carries `name`, `level` and `balls`;
+## an empty name is `wContestMon` still zero, which prints `.NoneString` and
+## skips the LEVEL row entirely.
+func _render_contest_status(status: Dictionary) -> Image:
+	var width: int = CONTEST_BOX_SIZE.x * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * CONTEST_BOX_SIZE.y * TILE)
+	font.draw_box(
+		frame_style, indices, width, 0, 0, CONTEST_BOX_SIZE.x, CONTEST_BOX_SIZE.y
+	)
+	var caught: String = String(status.get("name", ""))
+	for entry: Array in [
+		["CAUGHT", CONTEST_CAUGHT_AT],
+		[caught if not caught.is_empty() else "None", CONTEST_NAME_AT],
+		["BALLS:", CONTEST_BALLS_AT],
+		["%d" % maxi(int(status.get("balls", 0)), 0), CONTEST_BALLS_NUMBER_AT],
+	]:
+		var at: Vector2i = entry[1]
+		font.draw_text(String(entry[0]), indices, width, at.x * TILE, at.y * TILE)
+	if not caught.is_empty():
+		font.draw_text(
+			"LEVEL", indices, width,
+			CONTEST_LEVEL_AT.x * TILE, CONTEST_LEVEL_AT.y * TILE
+		)
+		font.draw_text(
+			"%d" % maxi(int(status.get("level", 0)), 0), indices, width,
+			CONTEST_LEVEL_NUMBER_AT.x * TILE, CONTEST_LEVEL_NUMBER_AT.y * TILE
+		)
+	return Gen2PicImage.from_indices(
+		indices, width, CONTEST_BOX_SIZE.y * TILE, _palette()
 	)
 
 

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -42,6 +42,14 @@ var gender: int = GENDER_MALE
 var game_time: Gen2GameTime = null
 var label: String = ""
 var party: Array = []
+## The party members `ContestDropOffMons` masks off while the Bug Catching
+## Contest runs. The cartridge leaves them in `wPartyMon` and drops
+## `wPartyCount` to 1; this project moves them here, so nothing that walks the
+## party has to know about the mask. `ContestReturnMons` puts them back. Like
+## `mailbox` this defaults rather than versioning: an empty list is the truth
+## about a slot written before the mask existed and about every slot outside a
+## contest.
+var contest_stashed_party: Array = []
 var boxes: Array = []
 var world: Gen2WorldSnapshot = null
 ## Per-slot, per-mod JSON objects. This namespace travels with the save.
@@ -117,6 +125,9 @@ func to_dict() -> Dictionary:
 	var saved_party: Array = []
 	for mon: Gen2SaveMon in party:
 		saved_party.append(mon.to_dict() if mon != null else {})
+	var stashed_party: Array = []
+	for mon: Gen2SaveMon in contest_stashed_party:
+		stashed_party.append(mon.to_dict() if mon != null else {})
 	var saved_boxes: Array = []
 	for box: Gen2SaveBox in boxes:
 		saved_boxes.append(box.to_dict() if box != null else [])
@@ -131,6 +142,7 @@ func to_dict() -> Dictionary:
 		"game_time": game_time.to_dict() if game_time != null else Gen2GameTime.new().to_dict(),
 		"label": label,
 		"party": saved_party,
+		"contest_stashed_party": stashed_party,
 		"boxes": saved_boxes,
 		"current_box": current_box,
 		"hall_of_fame": hall_of_fame.duplicate(true),
@@ -188,6 +200,10 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	if raw_party is Array:
 		for raw_mon: Variant in raw_party as Array:
 			out.party.append(Gen2SaveMon.from_dict(raw_mon))
+	var raw_stash: Variant = source.get("contest_stashed_party", [])
+	if raw_stash is Array:
+		for raw_mon: Variant in raw_stash as Array:
+			out.contest_stashed_party.append(Gen2SaveMon.from_dict(raw_mon))
 	var raw_boxes: Variant = source.get("boxes", null)
 	out.boxes_shape_valid = raw_boxes is Array and (raw_boxes as Array).size() == BOX_COUNT
 	if raw_boxes is Array:
@@ -352,6 +368,7 @@ func copy_from(source: Gen2SaveData) -> bool:
 	game_time = copied.game_time
 	label = copied.label
 	party = copied.party
+	contest_stashed_party = copied.contest_stashed_party
 	boxes = copied.boxes
 	current_box = copied.current_box
 	hall_of_fame = copied.hall_of_fame.duplicate(true)

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -40,7 +40,7 @@ enum Mode {
 	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING, PACK_PP_MOVE,
 	PACK_TOSS_QUANTITY, PACK_TOSS_CONFIRM, PACK_GIVE_SWAP,
 	PACK_RESULT, SAVE_ASK, SAVE_OVERWRITE, SAVE_SAVING, SAVE_SAVED,
-	SAVE_FAILED, OPTIONS, MODS, MOD_OPTIONS, FIELD_MOVES,
+	SAVE_FAILED, QUIT_ASK, OPTIONS, MODS, MOD_OPTIONS, FIELD_MOVES,
 }
 
 ## `SaveMenu`'s four texts, out of `data/text/common_3.asm` on Crystal and
@@ -53,6 +53,12 @@ const SAVE_ASK_LINES: Array[String] = [
 ## `AlreadyASaveFileText`. `AnotherSaveFileText` is its sibling for a save file
 ## belonging to another player, and `CompareLoadedAndSavedPlayerID` cannot
 ## reach it here: a world is always played from the slot it was started in.
+## `_StartMenuContestEndText`, which `StartMenu_Quit` asks over the same
+## `YesNoMenuHeader` box the save question uses. Authored here beside the save
+## texts for the same reason: no importer reads either.
+const QUIT_ASK_LINES: Array[String] = [
+	"Would you like to", "end the Contest?",
+]
 const SAVE_OVERWRITE_LINES: Array[String] = [
 	"There is already a", "save file. Is it", "OK to overwrite?",
 ]
@@ -444,7 +450,7 @@ func _move(direction: Vector2i) -> void:
 				_render_targets()
 		## `VerticalMenu` over `YesNoMenuHeader`, which is only up while a
 		## question is; the two timed modes read no joypad at all.
-		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE:
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.QUIT_ASK:
 			if _save_cursor >= 0 and (direction.x != 0 or direction.y != 0):
 				_save_cursor = 1 - _save_cursor
 				_render_save()
@@ -537,7 +543,7 @@ func _confirm() -> void:
 			else:
 				_open_pack_mode(false)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED:
+		Mode.SAVE_FAILED, Mode.QUIT_ASK:
 			_confirm_save()
 		## Options_Cancel is the only handler that reads A.
 		Mode.OPTIONS:
@@ -596,7 +602,7 @@ func _cancel() -> void:
 		Mode.PACK_TOSS_CONFIRM, Mode.PACK_GIVE_SWAP:
 			_open_pack_mode(false)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED:
+		Mode.SAVE_FAILED, Mode.QUIT_ASK:
 			_cancel_save()
 		## `_Option.joypad_loop` exits on PAD_START | PAD_B from any row.
 		Mode.OPTIONS, Mode.MODS, Mode.FIELD_MOVES:
@@ -615,6 +621,8 @@ func _confirm_list() -> void:
 			_open_pack_mode()
 		Gen2WorldStartMenu.ITEM_SAVE:
 			_open_save_confirm_mode()
+		Gen2WorldStartMenu.ITEM_QUIT:
+			_enter_save_mode(Mode.QUIT_ASK, QUIT_ASK_LINES, 0)
 		Gen2WorldStartMenu.ITEM_OPTION:
 			_open_options_mode()
 		Gen2WorldStartMenu.ITEM_MODS:
@@ -638,6 +646,22 @@ func _confirm_list() -> void:
 			var handler: Variant = entry.get("handler", null)
 			if handler is Callable:
 				(handler as Callable).call()
+
+
+## `StartMenu_PrintBugContestStatus`' three values: `wContestMon` and its level,
+## and `wParkBallsRemaining`. An unset `wContestMon` is the empty name the page
+## prints `.NoneString` for.
+func _contest_status() -> Dictionary:
+	if _world == null:
+		return {}
+	var caught: Dictionary = _world.state.contest_mon()
+	var species: int = int(caught.get("species", 0))
+	return {
+		"name": String(_world.data.species(species).get("name", "")) \
+			if species > 0 and _world.data != null else "",
+		"level": int(caught.get("level", 0)),
+		"balls": _world.state.park_balls(),
+	}
 
 
 func _open_list_mode() -> void:
@@ -1941,6 +1965,14 @@ func _confirm_save() -> void:
 	match _mode:
 		## `.refused` on NO, which is the carry `StartMenu_Save` answers with 0:
 		## back to the list rather than out of the menu.
+		## `StartMenu_Quit`'s `jr c, .DontEndContest`, which is the same 0 the
+		## save question answers NO with: back to the list. YES queues
+		## `BugCatchingContestReturnToGateScript`, which is the world's.
+		Mode.QUIT_ASK:
+			if _save_cursor == 1:
+				_open_list_mode()
+			else:
+				action_chosen.emit(Gen2WorldStartMenu.ITEM_QUIT)
 		Mode.SAVE_ASK:
 			if _save_cursor == 1:
 				_open_list_mode()
@@ -2157,10 +2189,11 @@ func _hardware_image() -> Image:
 				if Gen2OptionsStore.current().menu_account else ""
 			return _page.render_list(
 				labels.slice(_list_scroll, _list_scroll + shown),
-				_menu.cursor - _list_scroll, description, contest
+				_menu.cursor - _list_scroll, description, contest, null,
+				_contest_status() if contest else {}
 			)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED:
+		Mode.SAVE_FAILED, Mode.QUIT_ASK:
 			return _page.render_save(_save_state())
 		Mode.OPTIONS:
 			if _options_menu == null:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -213,6 +213,10 @@ var last_spawn_map: Vector2i = Vector2i(-1, -1)
 ## the player last came into a cave through, which is where Dig and an Escape
 ## Rope put them back. Empty until one is walked.
 var dig_warp: Dictionary = {}
+## Whether the escape just taken ran `Script_AbortBugContest` with a contest
+## running. Not saved: it is read by the host on the same frame the warp is
+## applied, and a save written after that has the restored party in it.
+var _contest_abort_pending: bool = false
 ## `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`: where a warp
 ## whose destination is -1 sends the player, and whose landmark a map with
 ## `LANDMARK_SPECIAL` borrows. `GetWarpDestCoords`'s `.backup` writes it on
@@ -2040,12 +2044,21 @@ func check_bug_contest_timer() -> Array:
 		over = &"out_of_balls"
 	if over == &"":
 		return []
-	var entry: Dictionary = data.world_standard_script(STD_BUG_CONTEST_RESULTS_WARP)
+	return queue_bug_contest_results(over)
+
+
+## `jumpstd BugContestResultsWarpScript`, which three readings reach: the timer
+## above, the last ball, and `Script_Whiteout`'s own `iftrue .bug_contest`.
+## Answers the queued results, or an empty Array when the cache holds no such
+## standard script.
+func queue_bug_contest_results(reason: StringName) -> Array:
+	var entry: Dictionary = data.world_standard_script(STD_BUG_CONTEST_RESULTS_WARP) \
+		if data != null else {}
 	if entry.is_empty():
 		return []
 	_enqueue_script({
 		"kind": &"bug_contest_over",
-		"reason": over,
+		"reason": reason,
 		"map_group": current_map.group if current_map != null else -1,
 		"map_number": current_map.number if current_map != null else -1,
 		"cell": player_cell,
@@ -4381,6 +4394,10 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 				"second_species": state.contest_second_party_species(),
 			})
 			continue
+		if event_type == &"warp_to_spawn_point":
+			warp_to_spawn_point()
+			generated.append({"type": &"warp_to_spawn_point"})
+			continue
 		if event_type == &"contest_mons_returned":
 			state.set_contest_second_party_species(0)
 			generated.append({"type": &"contest_mons_returned"})
@@ -6222,6 +6239,50 @@ func whiteout_spawn() -> int:
 	return index if index >= 0 else RomLayout.SPAWN_HOME
 
 
+## `Script_AbortBugContest`, which is `checkflag ENGINE_BUG_CONTEST_TIMER`, the
+## once-a-day flag and `special ContestReturnMons`. The mons themselves are the
+## party host's, so this answers whether they are owed rather than moving them.
+func abort_bug_contest() -> Dictionary:
+	if not bug_contest_active():
+		return {"ok": true, "kind": &"bug_contest_abort", "aborted": false}
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	state.set_engine_flag(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_DAILY_BUG_CONTEST, crystal), true
+	)
+	return {"ok": true, "kind": &"bug_contest_abort", "aborted": true}
+
+
+## `WarpToSpawnPoint`, whose whole body is two `res` on `wStatusFlags2`. It is
+## the timer flag rather than the contest's balls or its clock that a running
+## contest is known by, so clearing it is what ends one.
+func warp_to_spawn_point() -> Dictionary:
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	for flag: int in [
+		Gen2WorldState.ENGINE_SAFARI_ZONE, Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
+	]:
+		state.set_engine_flag(Gen2WorldState.engine_flag(flag, crystal), false)
+	return {"ok": true, "kind": &"warp_to_spawn_point"}
+
+
+## The two-line tail every escape from a map shares: `farscall
+## Script_AbortBugContest` then `special WarpToSpawnPoint`, in `.FlyScript`,
+## `.UsedDigOrEscapeRopeScript`, `.TeleportScript` and `Script_Whiteout`. It
+## lives on the two warps below rather than on each of the four callers, because
+## those two warps are the whole of what an escape does here.
+func _escape_map_tail() -> void:
+	if bool(abort_bug_contest().get("aborted", false)):
+		_contest_abort_pending = true
+	warp_to_spawn_point()
+
+
+## Whether the escape just taken aborted a running contest, read once. The party
+## the contest masked off belongs to the save, so the host is what puts it back.
+func take_contest_abort() -> bool:
+	var pending: bool = _contest_abort_pending
+	_contest_abort_pending = false
+	return pending
+
+
 ## `EnterMapSpawnPoint` plus the map load behind it: the player put down at
 ## spawn [param index], facing the way a warp leaves them. Answers the same
 ## record a warp does, or a refusal when the cache holds no such spawn.
@@ -6238,6 +6299,7 @@ func warp_to_spawn(index: int) -> Dictionary:
 		return {"ok": false, "kind": &"spawn_warp", "reason": &"missing_map"}
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
+	_escape_map_tail()
 	_apply_map(target_map, target_tileset, Vector2i(int(point["x"]), int(point["y"])))
 	return {
 		"ok": true,
@@ -6331,8 +6393,9 @@ static func _sweet_scent_failure(reason: StringName) -> Dictionary:
 ## being a spawn point, and it checks no badge at all.
 ##
 ## The warp is applied here rather than staged, because `.TeleportScript` is the
-## source's own script and everything in it but `WarpToSpawnPoint` is animation
-## this project has no frames for.
+## source's own script and everything in it but its shared tail is animation
+## this project has no frames for. That tail is [method _escape_map_tail], which
+## [method warp_to_spawn] runs.
 func teleport_request() -> Dictionary:
 	if current_map == null:
 		return _teleport_failure(&"missing_map")
@@ -6765,6 +6828,7 @@ func warp_to_dig_point() -> Dictionary:
 	var destination: Dictionary = warps[index]
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
+	_escape_map_tail()
 	_apply_map(
 		target_map, target_tileset,
 		Vector2i(int(destination["x"]), int(destination["y"]))

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1023,6 +1023,8 @@ static func whited_out_text(player_name: String) -> String:
 
 ## `Script_Whiteout` past its own text: `HealParty`, `HalveMoney`,
 ## `GetWhiteoutSpawn` and the `WarpToSpawnPoint` behind them, in that order.
+## The last is [method Gen2WorldAPI.warp_to_spawn]'s own tail here, since every
+## escape shares it.
 ##
 ## One routine, because every way of blacking out reaches this one script: a
 ## battle lost anywhere goes through `Script_reloadmapafterbattle`, and the last
@@ -1061,6 +1063,40 @@ static func whiteout(
 		"spawn": spawn,
 		"warp": warped,
 	}
+
+
+## `ContestDropOffMons` past its fainted-lead branch: the party masked to its
+## lead for the length of the Bug Catching Contest. The cartridge drops
+## `wPartyCount` to 1 and writes a terminator over the second species byte,
+## leaving the members themselves in `wPartyMon`; nothing here counts a party by
+## a terminator, so the masked members move to
+## [member Gen2SaveData.contest_stashed_party] instead and the stashed species
+## byte stays as the world state's own.
+##
+## Answers the species `wBugContestSecondPartySpecies` takes, or 0 when the
+## party was one long already.
+static func contest_drop_off_mons(save: Gen2SaveData) -> int:
+	if save == null or save.party.size() <= 1:
+		return 0
+	if not save.contest_stashed_party.is_empty():
+		## A second drop-off with a stash still standing would lose the first
+		## one. The gate cannot reach this twice; a mod calling the special can.
+		return 0
+	var second: Variant = save.party[1]
+	save.contest_stashed_party = save.party.slice(1)
+	save.party = save.party.slice(0, 1)
+	return int((second as Gen2SaveMon).species) if second is Gen2SaveMon else 0
+
+
+## `ContestReturnMons`: the masked members put back and the count recomputed.
+## Answers how many rejoined the party.
+static func contest_return_mons(save: Gen2SaveData) -> int:
+	if save == null or save.contest_stashed_party.is_empty():
+		return 0
+	var returned: int = save.contest_stashed_party.size()
+	save.party.append_array(save.contest_stashed_party)
+	save.contest_stashed_party = []
+	return returned
 
 
 ## Attempts to catch one wild battle mon and consumes the ball on either result.

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1966,6 +1966,11 @@ static func capture_contest(
 		return result
 	result["mon"] = contest_mon_from(wild)
 	result["replace_offer"] = not world.state.contest_mon().is_empty()
+	## `DisplayAlreadyCaughtText` names the one already held, not the new one:
+	## `ld a, [wContestMon]` into `wNamedObjectIndex` before the farcall.
+	result["stock_species"] = int(world.state.contest_mon().get("species", 0))
+	result["stock_level"] = int(world.state.contest_mon().get("level", 0))
+	result["stock_max_hp"] = int(world.state.contest_mon().get("max_hp", 0))
 	if not bool(result["replace_offer"]):
 		world.state.set_contest_mon(result["mon"])
 	return result

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1757,6 +1757,16 @@ func _finish_whiteout() -> void:
 	if _world == null:
 		return
 	var save: Gen2SaveData = active_save()
+	## `Script_Whiteout` tests `ENGINE_BUG_CONTEST_TIMER` after `special
+	## HealParty` and before `HalveMoney`, so blacking out inside the Bug
+	## Catching Contest is judged rather than paid for: no money is halved, the
+	## spawn is not read, and the results gate is what the player wakes up in.
+	if _world.bug_contest_active():
+		Gen2WorldPartyHost.heal_party_rows(_world.data, save)
+		_zero_map_name_sign_timer()
+		_script_prompt = ""
+		_show_script_results(_world.queue_bug_contest_results(&"whiteout"))
+		return
 	var recovered: Dictionary = Gen2WorldPartyHost.whiteout(
 		_world, save, _injected_save == null
 	)
@@ -5469,6 +5479,11 @@ func _on_start_menu_action(kind: StringName) -> void:
 			_open_trainer_card()
 		Gen2WorldStartMenu.ITEM_POKEDEX:
 			_open_pokedex()
+		Gen2WorldStartMenu.ITEM_QUIT:
+			## `StartMenu_Quit`'s `FarQueueScript
+			## BugCatchingContestReturnToGateScript` and the 4 it returns, which
+			## is `.ExitMenuRunScript`: the menu closes and the script runs.
+			_show_script_results(_world.queue_bug_contest_results(&"retired"))
 	_refresh_labels()
 
 
@@ -6499,6 +6514,13 @@ func _show_script_results(results: Array) -> void:
 			elif result_event.get("type", &"") == &"presentation_special_applied" \
 				and StringName(result_event.get("kind", &"")) == &"palette_fade":
 				_start_script_fade(result_event)
+			elif result_event.get("type", &"") == &"contest_mons_dropped_off":
+				## `ContestDropOffMons` masks the party to its lead; the world
+				## state keeps the stashed species byte and the save keeps the
+				## members themselves.
+				Gen2WorldPartyHost.contest_drop_off_mons(_active_party_save())
+			elif result_event.get("type", &"") == &"contest_mons_returned":
+				Gen2WorldPartyHost.contest_return_mons(_active_party_save())
 			elif result_event.get("type", &"") == &"hall_of_fame_requested":
 				## An event, not a runtime request: `halloffame` commits its flag
 				## and runs on, and the source's own `end` is the next command,
@@ -6826,6 +6848,10 @@ func _show_script_results(results: Array) -> void:
 func _refresh_after_escape() -> void:
 	if _world == null:
 		return
+	## `Script_AbortBugContest`'s `special ContestReturnMons`, which the warp
+	## itself cannot run: the masked party members are the save's.
+	if _world.take_contest_abort():
+		Gen2WorldPartyHost.contest_return_mons(_active_party_save())
 	_animation.configure(_world, _render_time_of_day())
 	_set_renderer_world()
 	if _renderer != null:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -149,6 +149,12 @@ const SPECIAL_BUG_CONTEST_JUDGING: int = 20
 const SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST: int = 21
 const SPECIAL_CONTEST_DROP_OFF_MONS: int = 22
 const SPECIAL_CONTEST_RETURN_MONS: int = 23
+## `WarpToSpawnPoint`, which clears `STATUSFLAGS2_SAFARI_GAME_F` and
+## `STATUSFLAGS2_BUG_CONTEST_TIMER_F` and does no warping at all. The four
+## escape scripts that call it are the port's own
+## ([method Gen2WorldAPI.warp_to_spawn_point]); this is the entry a decoded
+## script reaches it by.
+const SPECIAL_WARP_TO_SPAWN_POINT: int = 0
 const SPECIAL_GIVE_PARK_BALLS: int = 24
 const SPECIAL_SELECT_RANDOM_BUG_CONTESTANTS: int = 71
 const SPECIAL_ACTIVATE_FISHING_SWARM: int = 72
@@ -3670,6 +3676,8 @@ func _execute_special(special: int) -> Dictionary:
 				})
 		SPECIAL_CONTEST_RETURN_MONS:
 			_emit_runtime_event(&"contest_mons_returned", {"special": special})
+		SPECIAL_WARP_TO_SPAWN_POINT:
+			_emit_runtime_event(&"warp_to_spawn_point", {"special": special})
 		SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST:
 			## `CheckPartyFullAfterContest` does not only answer where the
 			## Pokemon caught in the contest would go: it takes it home, asks

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -8,8 +8,10 @@ extends RefCounted
 ## Pokemon behind a non-zero wPartyCount, Pokegear behind
 ## wPokegearFlags/POKEGEAR_OBTAINED_F.
 ##
-## QUIT never appears because its Bug Contest and link-mode gate is never true
-## here.
+## QUIT stands where SAVE does while the Bug Catching Contest runs, and PACK
+## leaves the list with it: `SetUpMenuItems` reads
+## `STATUSFLAGS2_BUG_CONTEST_TIMER_F` twice, once for each. Link mode is the
+## other half of both gates and has no menu here.
 ##
 ## Entries registered on `Gen2ModHost` are spliced in ahead of EXIT, so a mod can
 ## add a screen without reordering or removing anything the cartridge shipped.
@@ -33,6 +35,9 @@ const ITEM_PLAYER: StringName = &"player"
 const ITEM_SAVE: StringName = &"save"
 const ITEM_OPTION: StringName = &"option"
 const ITEM_EXIT: StringName = &"exit"
+## `STARTMENUITEM_QUIT`, the Bug Catching Contest's own row: it retires from the
+## contest and is judged on what has been caught so far.
+const ITEM_QUIT: StringName = &"quit"
 ## Not the cartridge's either. Appears only while a registered field-move source
 ## has an HM move to offer that no party member knows and the badge is in hand,
 ## so a game with no such source shows the source menu exactly. It sits ahead of
@@ -49,6 +54,9 @@ const ITEM_MODS: StringName = &"mods"
 const GATE_POKEDEX: StringName = &"pokedex"
 const GATE_PARTY: StringName = &"party"
 const GATE_POKEGEAR: StringName = &"pokegear"
+## `bit STATUSFLAGS2_BUG_CONTEST_TIMER_F` the other way round: PACK is dropped
+## while a contest runs, because the only ball a contest throws is the park's.
+const GATE_NO_CONTEST: StringName = &"no_contest"
 
 ## `SetUpMenuItems` in source order, as data rather than a run of appends, so the
 ## host's registered entries can be spliced in without the order becoming a
@@ -61,7 +69,7 @@ const GATE_POKEGEAR: StringName = &"pokegear"
 const SOURCE_ENTRIES: Array[Dictionary] = [
 	{"kind": ITEM_POKEDEX, "label": "#DEX", "available": true, "gate": GATE_POKEDEX},
 	{"kind": ITEM_POKEMON, "label": "#MON", "available": true, "gate": GATE_PARTY},
-	{"kind": ITEM_PACK, "label": "PACK", "available": true, "gate": &""},
+	{"kind": ITEM_PACK, "label": "PACK", "available": true, "gate": GATE_NO_CONTEST},
 	{"kind": ITEM_POKEGEAR, "label": "<POKE>GEAR", "available": true, "gate": GATE_POKEGEAR},
 	{"kind": ITEM_PLAYER, "label": "<PLAYER>", "available": true, "gate": &""},
 	{"kind": ITEM_SAVE, "label": "SAVE", "available": true, "gate": &""},
@@ -91,12 +99,14 @@ static func build(
 	previous_cursor: int = 0,
 	player_name: String = "",
 	field_moves: bool = false,
+	bug_contest: bool = false,
 ) -> Gen2WorldStartMenu:
 	var menu := Gen2WorldStartMenu.new()
 	var passes: Dictionary = {
 		GATE_POKEDEX: pokedex_obtained,
 		GATE_PARTY: party_count > 0,
 		GATE_POKEGEAR: pokegear_obtained,
+		GATE_NO_CONTEST: not bug_contest,
 	}
 	var rows: Array = []
 	for entry: Dictionary in SOURCE_ENTRIES:
@@ -125,9 +135,12 @@ static func build(
 		## rather than printing the marker's own characters.
 		if entry["kind"] == ITEM_PLAYER:
 			label = player_name if not player_name.is_empty() else "PLAYER"
-		rows.append(_entry(
-			StringName(entry["kind"]), label, bool(entry["available"])
-		))
+		## `.write`: the one slot holds SAVE or QUIT, never both.
+		var kind: StringName = StringName(entry["kind"])
+		if kind == ITEM_SAVE and bug_contest:
+			kind = ITEM_QUIT
+			label = "QUIT"
+		rows.append(_entry(kind, label, bool(entry["available"])))
 	menu._items = rows
 	menu.cursor = clampi(previous_cursor, 0, maxi(rows.size() - 1, 0))
 	return menu
@@ -147,6 +160,7 @@ static func from_world(world: Gen2WorldAPI, previous_cursor: int = 0) -> Gen2Wor
 		previous_cursor,
 		world.player_name(),
 		not world.item_field_move_offers().is_empty(),
+		world.bug_contest_active(),
 	)
 	menu.load_descriptions(world.data)
 	return menu

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -1490,6 +1490,10 @@ func consume_wild_encounter_cooldown() -> bool:
 ## `wStatusFlags2`' own bit, so it sits past `ENGINE_MOBILE_SYSTEM` and shifts on
 ## Gold and Silver like every other flag there.
 const ENGINE_BUG_CONTEST_TIMER: int = 17
+## `ENGINE_SAFARI_ZONE`, the next entry of the same `wStatusFlags2` run.
+## `WarpToSpawnPoint` clears it beside the contest timer, and nothing in either
+## pin sets it: Gen 2 ships no Safari Zone.
+const ENGINE_SAFARI_ZONE: int = 18
 ## Five entries further down the same run (data/events/engine_flags.asm), so it
 ## shifts on Gold and Silver the way every flag past ENGINE_MOBILE_SYSTEM does.
 const ENGINE_REACHED_GOLDENROD: int = 22

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1078,6 +1078,27 @@ func test_the_contest_quit_row_asks_before_it_retires() -> void:
 	assert_false(String(status["name"]).is_empty())
 	assert_not_null(host.call("_hardware_image"), "the box is drawn")
 
+	## `Script_AbortBugContest`'s `special ContestReturnMons` through the screen:
+	## the members `ContestDropOffMons` masked off come back when an escape ends
+	## the contest, which is the one seam every escape refreshes through.
+	var save: Gen2SaveData = _world_screen._injected_save
+	while save.party.size() < 2:
+		save.party.append(Gen2SaveMon.from_dict(save.party[0].to_dict()))
+	Gen2WorldPartyHost.contest_drop_off_mons(save)
+	assert_eq(save.party.size(), 1, "masked for the contest")
+	## An Escape Rope out, which is the same tail Fly and Teleport spend: the
+	## fixture map is its own dig warp, so the walk stays on one map.
+	world.dig_warp = {
+		"warp": 1, "map_group": world.map_id().x, "map_number": world.map_id().y,
+	}
+	assert_true(
+		bool(world.warp_to_dig_point().get("ok", false)), "the fixture has no warp 1"
+	)
+	_world_screen.call("_refresh_after_escape")
+	assert_eq(save.party.size(), 2, "ContestReturnMons put the rest back")
+	assert_true(save.contest_stashed_party.is_empty())
+	assert_false(world.bug_contest_active())
+
 
 func test_save_writes_a_snapshot_to_the_injected_save_without_touching_disk() -> void:
 	await _open_world()

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1044,6 +1044,41 @@ func test_pokegear_reaches_the_existing_phone_list() -> void:
 	assert_not_null(_world_screen._service_host)
 
 
+## `StartMenu_Quit`: the Bug Catching Contest's own row asks
+## `_StartMenuContestEndText` and queues `BugCatchingContestReturnToGateScript`.
+func test_the_contest_quit_row_asks_before_it_retires() -> void:
+	await _open_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	world.state.set_engine_flag(Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
+		Gen2WorldState.is_crystal_profile(world.data)
+	))
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_QUIT)
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.QUIT_ASK)
+	## `jr c, .DontEndContest`: NO is the second column and goes back to the list.
+	host.handle_button(Gen2Button.RIGHT)
+	host.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+	assert_true(world.bug_contest_active(), "still catching")
+
+	## `StartMenu_PrintBugContestStatus`' three values. `wContestMon` still zero
+	## is the empty name the box prints `None` for, and no LEVEL row with it.
+	assert_eq(host.call("_contest_status"), {"name": "", "level": 0, "balls": 0})
+	world.state.set_park_balls(17)
+	world.state.set_contest_mon({"species": 10, "level": 12, "max_hp": 30})
+	var status: Dictionary = host.call("_contest_status")
+	assert_eq(int(status["balls"]), 17)
+	assert_eq(int(status["level"]), 12)
+	assert_false(String(status["name"]).is_empty())
+	assert_not_null(host.call("_hardware_image"), "the box is drawn")
+
+
 func test_save_writes_a_snapshot_to_the_injected_save_without_touching_disk() -> void:
 	await _open_world()
 	var save: Gen2SaveData = _world_screen._injected_save

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1084,7 +1084,11 @@ func test_the_contest_quit_row_asks_before_it_retires() -> void:
 	var save: Gen2SaveData = _world_screen._injected_save
 	while save.party.size() < 2:
 		save.party.append(Gen2SaveMon.from_dict(save.party[0].to_dict()))
-	Gen2WorldPartyHost.contest_drop_off_mons(save)
+	## The gate's `special ContestDropOffMons` as the runner emits it, which is
+	## what masks the party on the way into the park.
+	_world_screen._show_script_results(
+		[{"events": [{"type": &"contest_mons_dropped_off", "second_species": 0}]}]
+	)
 	assert_eq(save.party.size(), 1, "masked for the contest")
 	## An Escape Rope out, which is the same tail Fly and Teleport spend: the
 	## fixture map is its own dig warp, so the walk stays on one map.

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -826,6 +826,34 @@ func test_phone_special_ids_match_the_source_phone_routines() -> void:
 	assert_eq(_event_value(result[0]["events"], &"phone_special_requested", "kind", 3), &"random_phone_mon")
 
 
+## `special WarpToSpawnPoint`, whose whole body is two `res` on `wStatusFlags2`.
+## The port's own escapes call it directly; this is the entry a decoded script
+## reaches it by, and the four scripts that carry it are engine ones.
+func test_the_spawn_point_special_clears_the_contest_and_safari_flags() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6270"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_WARP_TO_SPAWN_POINT, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6270
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	var timer: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_BUG_CONTEST_TIMER, crystal
+	)
+	var safari: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_SAFARI_ZONE, crystal
+	)
+	world.state.set_engine_flag(timer)
+	world.state.set_engine_flag(safari)
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_false(world.state.is_engine_flag_active(timer))
+	assert_false(world.state.is_engine_flag_active(safari))
+
+
 func test_map_decoration_specials_stamp_the_selected_room_blocks() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6250"] = [

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1538,6 +1538,53 @@ func test_dig_is_refused_outside_a_cave_and_with_no_warp_recorded() -> void:
 	assert_eq(StringName(unknowing.dig_request()["reason"]), &"move_not_known")
 
 
+## The tail all four escapes share: `farscall Script_AbortBugContest` then
+## `special WarpToSpawnPoint` (engine/events/overworld.asm, engine/events/
+## whiteout.asm). Both warps run it, so every escape gets it.
+func test_an_escape_aborts_a_running_contest_and_clears_both_status_flags() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	var timer: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_BUG_CONTEST_TIMER, crystal
+	)
+	var safari: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_SAFARI_ZONE, crystal
+	)
+	var daily: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_DAILY_BUG_CONTEST, crystal
+	)
+	world.player_cell = ESCAPE_CAVE_DOOR
+	world.try_warp()
+	world.state.set_engine_flag(timer)
+	world.state.set_engine_flag(safari)
+	world.player_cell = Vector2i(4, 4)
+
+	assert_true(bool(world.dig_request().get("ok", false)))
+	assert_false(world.state.is_engine_flag_active(timer), "the contest is over")
+	assert_false(world.state.is_engine_flag_active(safari))
+	assert_true(
+		world.state.is_engine_flag_active(daily), "one contest a day, aborted or not"
+	)
+	## Read once: the host puts the masked party back on the frame it is told.
+	assert_true(world.take_contest_abort())
+	assert_false(world.take_contest_abort())
+
+
+func test_an_escape_with_no_contest_running_owes_the_party_nothing() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	var daily: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_DAILY_BUG_CONTEST,
+		Gen2WorldState.is_crystal_profile(world.data)
+	)
+	world.player_cell = ESCAPE_CAVE_DOOR
+	world.try_warp()
+	world.player_cell = Vector2i(4, 4)
+	assert_true(bool(world.escape_rope_request().get("ok", false)))
+	assert_false(world.take_contest_abort())
+	## `Script_AbortBugContest`'s `iffalse .finish` jumps the setflag too.
+	assert_false(world.state.is_engine_flag_active(daily))
+
+
 ## `BikeFunction`: `.CheckEnvironment`, then the two directions of `.TryBike`.
 func test_the_bike_goes_on_and_off_outdoors_and_carries_its_own_music() -> void:
 	var world: Gen2WorldAPI = _escape_world()

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1096,6 +1096,45 @@ func test_master_ball_captures_a_wild_mon_and_records_catch_metadata() -> void:
 	assert_eq(_world.state.item_quantity(0x01), 0)
 
 
+## `BugContest_SetCaughtContestMon`: the first catch is kept outright, and a
+## second one is only offered, with the Pokemon already held named by
+## `DisplayAlreadyCaughtText` rather than the new one.
+func test_a_second_contest_catch_is_offered_and_names_the_one_already_held() -> void:
+	_world.state.set_park_balls(20)
+	var first: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	first.hp = 1
+	var caught: Dictionary = Gen2WorldPartyHost.capture_contest(_world, first, _random)
+	assert_true(bool(caught["ok"]), JSON.stringify(caught))
+	if bool(caught["caught"]):
+		assert_false(bool(caught.get("replace_offer", false)), "nothing to replace")
+		assert_eq(int(_world.state.contest_mon()["species"]), 25)
+	_world.state.set_contest_mon({"species": 10, "level": 5, "max_hp": 21})
+
+	var second: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 7, _data.moves_at_level(25, 7), 0x1234
+	)
+	## A Park Ball on a full-health wild almost never lands; the rate is the
+	## catch's own and not what this is about.
+	second.hp = 1
+	var offered: Dictionary = {}
+	for _throw: int in 2000:
+		_world.state.set_park_balls(20)
+		offered = Gen2WorldPartyHost.capture_contest(_world, second, _random)
+		if bool(offered.get("caught", false)):
+			break
+	assert_true(bool(offered.get("caught", false)), "no park ball ever landed")
+	assert_true(bool(offered["replace_offer"]))
+	assert_eq(int(offered["stock_species"]), 10, "the line names the one held")
+	assert_eq(int(offered["stock_level"]), 5)
+	assert_eq(int(offered["stock_max_hp"]), 21)
+	assert_eq(
+		int(_world.state.contest_mon()["species"]), 10,
+		"the state is left alone until the question is answered"
+	)
+
+
 func test_a_full_party_capture_uses_the_first_pc_box_slot() -> void:
 	while _save.party.size() < Gen2SaveData.MAX_PARTY:
 		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1569,6 +1569,64 @@ func test_the_tutor_asks_before_replacing_a_full_moveset_and_charges_nothing() -
 	assert_eq(_save.party[0].happiness, 71)
 
 
+## `ContestDropOffMons` and `ContestReturnMons` (engine/events/bug_contest/
+## contest_2.asm): the party masked to its lead for the length of a contest, and
+## the count recomputed when it is put back.
+func test_the_contest_mask_moves_the_party_aside_and_puts_it_back_in_order() -> void:
+	while _save.party.size() > 1:
+		_save.party.remove_at(1)
+	var second: Gen2SaveMon = Gen2SaveMon.new()
+	second.species = 10
+	second.level = 7
+	var third: Gen2SaveMon = Gen2SaveMon.new()
+	third.species = 13
+	third.level = 8
+	_save.party.append(second)
+	_save.party.append(third)
+	var lead: Gen2SaveMon = _save.party[0]
+
+	assert_eq(Gen2WorldPartyHost.contest_drop_off_mons(_save), 10, "wPartySpecies + 1")
+	assert_eq(_save.party.size(), 1, "wPartyCount is 1 for the whole contest")
+	assert_eq(_save.party[0], lead)
+	assert_eq(_save.contest_stashed_party.size(), 2)
+
+	## A second call with a stash standing would lose it; the gate cannot reach
+	## this twice and a mod calling the special can.
+	assert_eq(Gen2WorldPartyHost.contest_drop_off_mons(_save), 0)
+	assert_eq(_save.contest_stashed_party.size(), 2)
+
+	assert_eq(Gen2WorldPartyHost.contest_return_mons(_save), 2)
+	assert_eq(_save.party, [lead, second, third])
+	assert_true(_save.contest_stashed_party.is_empty())
+	assert_eq(Gen2WorldPartyHost.contest_return_mons(_save), 0, "nothing owed twice")
+
+
+func test_a_one_member_party_needs_no_contest_mask() -> void:
+	while _save.party.size() > 1:
+		_save.party.remove_at(1)
+	assert_eq(Gen2WorldPartyHost.contest_drop_off_mons(_save), 0)
+	assert_eq(_save.party.size(), 1)
+	assert_true(_save.contest_stashed_party.is_empty())
+
+
+func test_the_masked_party_survives_a_save_round_trip() -> void:
+	while _save.party.size() > 1:
+		_save.party.remove_at(1)
+	var second: Gen2SaveMon = Gen2SaveMon.new()
+	second.species = 10
+	second.level = 7
+	_save.party.append(second)
+	Gen2WorldPartyHost.contest_drop_off_mons(_save)
+	var restored: Gen2SaveData = Gen2SaveData.from_dict(_save.to_dict())
+	assert_eq(restored.party.size(), 1)
+	assert_eq(restored.contest_stashed_party.size(), 1)
+	assert_eq(int(restored.contest_stashed_party[0].species), 10)
+	## A slot written before the mask existed reads as one outside a contest.
+	var older: Dictionary = _save.to_dict()
+	older.erase("contest_stashed_party")
+	assert_true(Gen2SaveData.from_dict(older).contest_stashed_party.is_empty())
+
+
 ## `DoPoisonStep`'s `.DamageMonIfPoisoned`: one HP off a poisoned member that is
 ## still standing, and nothing at all off one that is already down.
 func test_a_poison_step_takes_one_hp_off_every_poisoned_member() -> void:

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -24,6 +24,25 @@ func test_default_list_omits_pokedex_pokemon_and_pokegear() -> void:
 	])
 
 
+## `SetUpMenuItems` reads `STATUSFLAGS2_BUG_CONTEST_TIMER_F` twice: PACK is
+## dropped and the SAVE slot holds QUIT instead.
+func test_a_running_contest_drops_pack_and_puts_quit_where_save_was() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(
+		1, true, true, 0, "GOLD", false, true
+	)
+	var kinds: Array = _kinds(menu)
+	assert_false(kinds.has(Gen2WorldStartMenu.ITEM_PACK), "only park balls throw")
+	assert_false(kinds.has(Gen2WorldStartMenu.ITEM_SAVE))
+	assert_eq(
+		kinds.find(Gen2WorldStartMenu.ITEM_QUIT),
+		kinds.find(Gen2WorldStartMenu.ITEM_PLAYER) + 1,
+		"`.write` fills the one slot SAVE would have"
+	)
+	for entry: Dictionary in menu.items():
+		if entry.get("kind") == Gen2WorldStartMenu.ITEM_QUIT:
+			assert_eq(String(entry.get("label", "")), "QUIT")
+
+
 func test_pokemon_appears_only_with_a_non_empty_party() -> void:
 	var empty: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
 	assert_false(_kinds(empty).has(Gen2WorldStartMenu.ITEM_POKEMON))

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -44,7 +44,7 @@ const EXPECTED_DEFERRED: Dictionary = {
 
 	## Reached by one script row each and by nothing the player can talk to.
 	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table.
-	0: "WarpToSpawnPoint", 64: "FindPartyMonAboveLevel",
+	64: "FindPartyMonAboveLevel",
 }
 
 ## Decoded `special` operands that name no `SpecialsPointers` entry. Pinned

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -37,13 +37,9 @@ const EXPECTED_DEFERRED: Dictionary = {
 	155: "Function1037eb", 156: "Function10383c", 159: "Function1037c2",
 	161: "Function103780", 162: "Function10387b",
 
-	## Screens and facilities with no routine here yet. Each is its own piece of
-	## work, not a dispatch entry: it opens a screen, spends a transaction, or
-	## reads a save field nothing writes.
-	##
-
-	## Reached by one script row each and by nothing the player can talk to.
-	## `FindPartyMonAboveLevel` is marked `; unused` in the pin's own table.
+	## What is left of the screens and facilities that had no routine here: one
+	## row, and the pin's own table marks it `; unused`. `_FindPartyMonAboveLevel`
+	## is reached by no script in either pin.
 	64: "FindPartyMonAboveLevel",
 }
 

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -263,6 +263,43 @@ func _verify_gate_errand() -> void:
 	)
 	_r.note("the contest ended on map %s." % str(world.map_id()))
 
+	## The other way a contest ends: `farscall Script_AbortBugContest` and
+	## `special WarpToSpawnPoint`, which Fly, Dig, an Escape Rope and Teleport
+	## all share. Run against the same cache rather than a fixture, because the
+	## flag indices split by profile.
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	var timer: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_BUG_CONTEST_TIMER, crystal
+	)
+	var daily: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_DAILY_BUG_CONTEST, crystal
+	)
+	world.state.set_engine_flag(daily, false)
+	world.state.set_engine_flag(timer)
+	world.state.set_engine_flag(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_SAFARI_ZONE, crystal)
+	)
+	var escaped: Dictionary = world.warp_to_spawn(RomLayout.SPAWN_HOME)
+	_r.check(
+		bool(escaped.get("ok", false)),
+		"an escape to SPAWN_HOME answered %s." % str(escaped.get("reason", ""))
+	)
+	_r.check(
+		not world.state.is_engine_flag_active(timer),
+		"WarpToSpawnPoint left the contest timer set."
+	)
+	_r.check(
+		not world.state.is_engine_flag_active(
+			Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_SAFARI_ZONE, crystal)
+		),
+		"WarpToSpawnPoint left STATUSFLAGS2_SAFARI_GAME_F set."
+	)
+	_r.check(
+		world.state.is_engine_flag_active(daily),
+		"Script_AbortBugContest did not spend the day's contest."
+	)
+	_r.check(world.take_contest_abort(), "the masked party was not owed back.")
+
 
 ## The step each facing looks along, in FACING_* order.
 const FACING_STEPS: Array[Vector2i] = [

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -636,7 +636,15 @@ func _process(_delta: float) -> bool:
 			## photographing is the eight rows a finished save carries: they fill
 			## the box exactly, so the host's MODS row and any a mod registered
 			## are what the window has to be scrolled to. The first number is how
-			## many rows down to walk before the picture.
+			## many rows down to walk before the picture, and a second number of
+			## 1 or more runs the Bug Catching Contest, which is the list
+			## `SetUpMenuItems` drops PACK from and puts QUIT in SAVE's slot.
+			if _cell.y >= 1:
+				var contest_world: Gen2WorldAPI = _screen.get("_world")
+				contest_world.state.set_engine_flag(Gen2WorldState.engine_flag(
+					Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
+					Gen2WorldState.is_crystal_profile(contest_world.data)
+				))
 			_screen.get("_world").state.set_engine_flag(
 				Gen2WorldStartMenu.ENGINE_POKEDEX, true
 			)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -645,6 +645,14 @@ func _process(_delta: float) -> bool:
 					Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
 					Gen2WorldState.is_crystal_profile(contest_world.data)
 				))
+				contest_world.state.set_park_balls(Gen2WorldBugContest.BALLS)
+				## A second number of 2 or more has something caught, which is
+				## the LEVEL row `StartMenu_PrintBugContestStatus` skips while
+				## `wContestMon` is still zero.
+				if _cell.y >= 2:
+					contest_world.state.set_contest_mon({
+						"species": 10, "level": 7, "max_hp": 22, "hp": 22,
+					})
 			_screen.get("_world").state.set_engine_flag(
 				Gen2WorldStartMenu.ENGINE_POKEDEX, true
 			)


### PR DESCRIPTION
Four ways out of the Bug Catching Contest reached it and none of them touched it. A walk of the engine's own script labels found the whole set at once, so they are fixed at the seam they share rather than one at a time.

## What was wrong

- **No escape aborted a contest.** Fly, Dig, an Escape Rope and Teleport each end with the same two lines, `farscall Script_AbortBugContest` then `special WarpToSpawnPoint`, and neither was built. The contest ran on across the warp, `ENGINE_SAFARI_ZONE` was cleared by nothing, and the once-a-day flag was set by nothing outside the results script.
- **The party mask was decoded and discarded.** `ContestDropOffMons` emitted an event that reached no host, so the whole party competed instead of the lead alone.
- **Blacking out in a contest halved the player's money.** `Script_Whiteout` tests the timer flag after `HealParty` and jumps to the results gate instead.
- **The START menu was the ordinary one.** `SetUpMenuItems` drops PACK and puts QUIT where SAVE is, and `.ContestMenuHeader` leaves two rows for a status box that was not drawn.
- **The second-catch question said the wrong thing.** The source says "You already caught a X." and then "Switch #MON?"; a first catch says "Caught X!" after the Gotcha line.

## Where the fix sits

The escape tail lives on `warp_to_spawn` and `warp_to_dig_point`, which between them are every escape this port has, so a fifth one cannot forget it. `special WarpToSpawnPoint` also gets its own entry in the script runner and leaves `EXPECTED_DEFERRED` with the work.

The masked party members move to a new `Gen2SaveData.contest_stashed_party`, which defaults rather than versioning: an empty list is the truth about every slot written before it and about every slot outside a contest.

## Proof

| Run | Result |
|---|---|
| GUT, both tiers | 3,914 of 3,914 |
| `validate.gd -- all` | 78 topics pass, 0 fail |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | each reaches Red |

`tools/checks/wild_encounters.gd` now sweeps the abort on all three caches beside the gate errand it already walked. Breaking the tail on purpose turns all three red.

Screenshots of the contest START menu are in the thread.