### PR TITLE
Move an item with SELECT, and fit the save pages to a phone

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3975,6 +3975,41 @@ const CONTEST_REPLACE_TEXT: String = "Switch #MON?"
 ## `DisplayAlreadyCaughtText` names the Pokemon already held.
 const CONTEST_ALREADY_CAUGHT_TEXT: String = "You already caught\na %s."
 
+## `DisplayCaughtContestMonStats`' two `Textbox` calls, each `hlcoord 0, n` with
+## `ld b, 4 / ld c, 13`: an interior four rows by thirteen columns, so the border
+## runs to column 14 and five rows down from its own top.
+const CONTEST_STATS_LEFT: int = 0
+const CONTEST_STATS_RIGHT: int = 14
+const CONTEST_STOCK_TOP: int = 0
+const CONTEST_THIS_TOP: int = 6
+const CONTEST_STATS_HEIGHT: int = 5
+
+## Where the routine's own `PlaceString` calls land, relative to each box's top.
+## `.Stock` and `.This` are written at column 2 on the border row itself, spaces
+## and all, so the frame is blanked either side of the title.
+const CONTEST_TITLE_AT: Vector2i = Vector2i(2, 0)
+const CONTEST_NAME_AT: Vector2i = Vector2i(1, 2)
+const CONTEST_HEALTH_AT: Vector2i = Vector2i(5, 4)
+const CONTEST_HP_AT: Vector2i = Vector2i(11, 4)
+## `PrintNum` with `lb bc, 2, 3`: three digits out of two bytes, space padded.
+const CONTEST_HP_DIGITS: int = 3
+const CONTEST_STOCK_TITLE: String = " STOCK <PKMN> "
+const CONTEST_THIS_TITLE: String = " THIS <PKMN>  "
+const CONTEST_HEALTH: String = "HEALTH"
+
+## `lb bc, 14, 7` into `PlaceYesNoBox`, which is `YesNoBox`'s own corner rather
+## than `OfferSwitch`'s [constant YES_NO_LEFT]: the question stands beside the
+## THIS box rather than over the STOCK one.
+const CONTEST_YES_NO_LEFT: int = 14
+const CONTEST_YES_NO_TOP: int = 7
+
+## `LoadFontsBattleExtra`, so the page is drawn with the strip `<LV>` lives on,
+## the way the Hall of Fame panel is.
+const CONTEST_FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
+## `PrintLevel`'s `ld [hl], '<LV>'`, which puts a byte down rather than printing
+## a string, so it is placed as a code the way [Gen2HallOfFamePage] places one.
+const CONTEST_LEVEL_CODE: int = 0x6E
+
 
 func _answer_contest_replace(button: int) -> void:
 	if _offer_still_reading():
@@ -4210,7 +4245,10 @@ func _refresh_menu_layer() -> void:
 	if _battle_menu_layer != null:
 		_battle_menu_layer.visible = false
 	match _switch_stage:
-		&"offer", &"use_next", &"contest_replace":
+		&"contest_replace":
+			_draw_contest_stats()
+			return
+		&"offer", &"use_next":
 			_draw_yes_no_box()
 			return
 		&"pick", &"refused":
@@ -4223,6 +4261,110 @@ func _refresh_menu_layer() -> void:
 			_draw_move_menu()
 		_:
 			_menu_layer.visible = false
+
+
+## `DisplayCaughtContestMonStats`: the screen is cleared and the two boxes are
+## drawn over it, STOCK #MON above THIS #MON, each with a name, a level and a
+## HEALTH number, with `PlaceYesNoBox`' own box beside the lower one.
+##
+## One image on the menu layer, the way the party page is: all three boxes go
+## into the tilemap on the cartridge too, and the text box under them is this
+## screen's own, which is where `ContestAskSwitchText` is already being said.
+func _draw_contest_stats() -> void:
+	if _menu_page == null or _menu_page.font == null:
+		_menu_layer.visible = false
+		return
+	var width: int = Gen2Screen.WIDTH
+	var indices := PackedByteArray()
+	indices.resize(width * Gen2Screen.HEIGHT)
+	var caught: Dictionary = _capture_result.get("mon", {})
+	_draw_contest_box(
+		indices, width, CONTEST_STOCK_TOP, CONTEST_STOCK_TITLE,
+		_contest_stock_name(),
+		int(_capture_result.get("stock_level", 0)),
+		int(_capture_result.get("stock_max_hp", 0))
+	)
+	_draw_contest_box(
+		indices, width, CONTEST_THIS_TOP, CONTEST_THIS_TITLE,
+		_name_of(int(caught.get("species", 0))),
+		int(caught.get("level", 0)),
+		int(caught.get("max_hp", 0))
+	)
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		CONTEST_YES_NO_LEFT, CONTEST_YES_NO_TOP,
+		CONTEST_YES_NO_LEFT + YES_NO_SPAN.x, CONTEST_YES_NO_TOP + YES_NO_SPAN.y,
+		YES_NO_FLAGS
+	)
+	## The question is read before it is answered, the way every other offer here
+	## is: the box comes up once the line has finished appearing.
+	if not _offer_still_reading():
+		_menu_page.draw(
+			box, YES_NO_OPTIONS,
+			_switch_offer.selected_index() if _switch_offer != null else 0,
+			indices, width
+		)
+	## Only the rows the page occupies. Rows 12 to 17 are the text box's own, and
+	## this screen draws that itself.
+	var rows: int = (CONTEST_THIS_TOP + CONTEST_STATS_HEIGHT + 1) * Gen2Font.TILE
+	var image: Image = Gen2PicImage.from_indices(
+		indices, width, Gen2Screen.HEIGHT,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	).get_region(Rect2i(0, 0, width, rows))
+	_show_menu_image(image, Vector2i.ZERO)
+
+
+## One of the two, at [param top]. The strings are the routine's own and land
+## where its `hlcoord`s put them, measured from the box rather than the screen.
+func _draw_contest_box(
+	indices: PackedByteArray, width: int, top: int,
+	title: String, name: String, level: int, max_hp: int
+) -> void:
+	var tile: int = Gen2Font.TILE
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		CONTEST_STATS_LEFT, top, CONTEST_STATS_RIGHT, top + CONTEST_STATS_HEIGHT, 0
+	)
+	_menu_page.draw(box, [], -1, indices, width, "", 0, [
+		{"text": name, "at": CONTEST_NAME_AT + Vector2i(0, top)},
+		{"text": CONTEST_HEALTH, "at": CONTEST_HEALTH_AT + Vector2i(0, top)},
+		{
+			"text": String("%d" % max_hp).lpad(CONTEST_HP_DIGITS, " "),
+			"at": CONTEST_HP_AT + Vector2i(0, top),
+		},
+	])
+	## The title sits on the border row, and `PlaceString` writes its own leading
+	## and trailing spaces as $7f, which is a tile write like any other and blanks
+	## the frame under them. [method Gen2Font.draw_code] draws nothing for a
+	## space, on purpose, so the cells are cleared here first: without it the
+	## border shows through the gaps either side of STOCK #MON. Drawn after the
+	## box for the same reason the source places it after `Textbox`.
+	var title_at: Vector2i = CONTEST_TITLE_AT + Vector2i(0, top)
+	_blank_tiles(indices, width, title_at, Gen2Text.encoded_length(title))
+	_menu_page.font.draw_text(
+		title, indices, width, title_at.x * tile, title_at.y * tile
+	)
+	## `ld h, b / ld l, c`: `PlaceString` answers the cell after the name it
+	## wrote, and `PrintLevel` starts there.
+	var at: Vector2i = CONTEST_NAME_AT + Vector2i(Gen2Text.encoded_length(name), top)
+	_menu_page.font.draw_code(
+		CONTEST_LEVEL_CODE, indices, width, at.x * tile, at.y * tile, CONTEST_FONT
+	)
+	_menu_page.font.draw_text(
+		str(level), indices, width, (at.x + 1) * tile, at.y * tile, CONTEST_FONT
+	)
+
+
+## [param count] tiles of index 0 from [param at], which is what the source's own
+## $7f blank draws as.
+func _blank_tiles(
+	indices: PackedByteArray, width: int, at: Vector2i, count: int
+) -> void:
+	var tile: int = Gen2Font.TILE
+	for row: int in tile:
+		var start: int = (at.y * tile + row) * width + at.x * tile
+		for column: int in count * tile:
+			var offset: int = start + column
+			if offset >= 0 and offset < indices.size():
+				indices[offset] = 0
 
 
 func _draw_yes_no_box() -> void:

--- a/game/input/touch_layout.gd
+++ b/game/input/touch_layout.gd
@@ -1,7 +1,7 @@
 class_name Gen2TouchLayout
 extends RefCounted
 
-## Where the on-screen controller's four clusters sit, how big they are and how
+## Where the on-screen controller's five clusters sit, how big they are and how
 ## much of the screen they hide.
 ##
 ## Geometry only: [Gen2TouchPad] draws and reads touches, and this answers where
@@ -15,20 +15,24 @@ extends RefCounted
 ## one is in the middle of the screen in the other.
 
 const GROUP_PAD: StringName = &"pad"
-const GROUP_FACE: StringName = &"face"
+const GROUP_A: StringName = &"a"
+const GROUP_B: StringName = &"b"
 const GROUP_START: StringName = &"start"
 const GROUP_SELECT: StringName = &"select"
-const GROUPS: Array[StringName] = [GROUP_PAD, GROUP_FACE, GROUP_START, GROUP_SELECT]
+const GROUPS: Array[StringName] = [
+	GROUP_PAD, GROUP_A, GROUP_B, GROUP_START, GROUP_SELECT,
+]
 
-const GROUP_LABELS: Dictionary = {
-	GROUP_PAD: "D-pad",
-	GROUP_FACE: "A and B",
-	GROUP_START: "START",
-	GROUP_SELECT: "SELECT",
-}
+## The name A and B shared while they were one cluster on a fixed diagonal. Read
+## on the way in and never written, so a layout arranged before they came apart
+## still opens where the player left it.
+const GROUP_FACE: StringName = &"face"
 
-## The one button each single-button group carries.
+## The one button each single-button group carries. Every group but the d-pad is
+## one of these: the d-pad is one control with four answers.
 const GROUP_BUTTONS: Dictionary = {
+	GROUP_A: Gen2Button.A,
+	GROUP_B: Gen2Button.B,
 	GROUP_START: Gen2Button.START,
 	GROUP_SELECT: Gen2Button.SELECT,
 }
@@ -40,8 +44,14 @@ const ORIENTATIONS: Array[StringName] = [ORIENTATION_PORTRAIT, ORIENTATION_LANDS
 ## Sizes in display-independent points, shared by the game and its layout editor.
 const PAD_SIZE: float = 112.0
 const FACE_DIAMETER: float = 56.0
-## Centre-to-centre along the diagonal A and B sit on, so they never touch.
+## Centre-to-centre along the diagonal A and B sat on while they were one
+## cluster. Only [method _split_face] reads it now: the two are dragged
+## separately and nothing holds them apart.
 const FACE_SPACING: float = 68.0
+
+## The area a `face` centre is assumed to have been arranged against, in points.
+## A phone held upright, which is the only device that has ever drawn one.
+const MIGRATION_AREA: Vector2 = Vector2(390.0, 844.0)
 const MENU_SIZE: Vector2 = Vector2(80.0, 40.0)
 
 ## Inside this fraction of the d-pad's half-width nothing is pressed, so a thumb
@@ -60,13 +70,15 @@ const MAX_OPACITY: float = 1.0
 const DEFAULT_ANCHORS: Dictionary = {
 	ORIENTATION_PORTRAIT: {
 		GROUP_PAD: Vector2(0.24, 0.50),
-		GROUP_FACE: Vector2(0.76, 0.50),
+		GROUP_B: Vector2(0.86, 0.43),
+		GROUP_A: Vector2(0.68, 0.57),
 		GROUP_SELECT: Vector2(0.38, 0.88),
 		GROUP_START: Vector2(0.62, 0.88),
 	},
 	ORIENTATION_LANDSCAPE: {
 		GROUP_PAD: Vector2(0.12, 0.55),
-		GROUP_FACE: Vector2(0.88, 0.55),
+		GROUP_B: Vector2(0.93, 0.48),
+		GROUP_A: Vector2(0.79, 0.62),
 		GROUP_SELECT: Vector2(0.12, 0.90),
 		GROUP_START: Vector2(0.88, 0.90),
 	},
@@ -192,8 +204,8 @@ func group_size(group: StringName) -> Vector2:
 	match group:
 		GROUP_PAD:
 			return Vector2(PAD_SIZE, PAD_SIZE) * scale
-		GROUP_FACE:
-			return Vector2(FACE_SPACING + FACE_DIAMETER, FACE_SPACING + FACE_DIAMETER) * scale
+		GROUP_A, GROUP_B:
+			return Vector2(FACE_DIAMETER, FACE_DIAMETER) * scale
 		GROUP_START, GROUP_SELECT:
 			return MENU_SIZE * scale
 	# A mod's button is the same pill, since it is one press like those two.
@@ -226,15 +238,6 @@ func group_rect(group: StringName, area: Rect2, placing: StringName = &"") -> Re
 ## it is one control with four answers, which [method direction_at] resolves.
 func button_rects(area: Rect2, placing: StringName = &"") -> Dictionary:
 	var rects: Dictionary = {}
-	var face: Rect2 = group_rect(GROUP_FACE, area, placing)
-	var diameter: float = FACE_DIAMETER * scale
-	# A below and left of B, the diagonal the hardware used.
-	rects[Gen2Button.B] = Rect2(
-		Vector2(face.position.x + face.size.x - diameter, face.position.y), Vector2(diameter, diameter)
-	)
-	rects[Gen2Button.A] = Rect2(
-		Vector2(face.position.x, face.position.y + face.size.y - diameter), Vector2(diameter, diameter)
-	)
 	for group: StringName in GROUP_BUTTONS:
 		rects[GROUP_BUTTONS[group]] = group_rect(group, area, placing)
 	return rects
@@ -313,7 +316,36 @@ static func parse(raw: Variant) -> Gen2TouchLayout:
 				clampf(float((centre as Array)[0]), 0.0, 1.0),
 				clampf(float((centre as Array)[1]), 0.0, 1.0),
 			)
+		layout._split_face(orientation, groups as Dictionary)
 	return layout
+
+
+## A layout written while A and B were one cluster carries a `face` centre and
+## no `a` or `b`. The pair sat on a fixed diagonal inside that cluster, B up and
+## right, A down and left, half [constant FACE_SPACING] from the centre each way,
+## so the two anchors it becomes are the ones the player already had.
+##
+## The offset is in points and an anchor is a fraction of an area this has never
+## been shown, so it is taken against the portrait phone the layout was arranged
+## on. [method group_rect] clamps whatever comes out.
+## [param stored] is what the file itself carried, not the merged anchors: every
+## group has a default, so asking the layout whether it has an `a` would answer
+## yes before the file has said anything.
+func _split_face(orientation: StringName, stored: Dictionary) -> void:
+	var groups: Dictionary = anchors.get(orientation, {})
+	if not stored.has(String(GROUP_FACE)) \
+		or stored.has(String(GROUP_A)) or stored.has(String(GROUP_B)):
+		groups.erase(GROUP_FACE)
+		return
+	var centre: Vector2 = groups[GROUP_FACE]
+	var offset: Vector2 = Vector2(FACE_SPACING, FACE_SPACING) * 0.5 / MIGRATION_AREA
+	groups[GROUP_B] = Vector2(
+		clampf(centre.x + offset.x, 0.0, 1.0), clampf(centre.y - offset.y, 0.0, 1.0)
+	)
+	groups[GROUP_A] = Vector2(
+		clampf(centre.x - offset.x, 0.0, 1.0), clampf(centre.y + offset.y, 0.0, 1.0)
+	)
+	groups.erase(GROUP_FACE)
 
 
 func duplicate_layout() -> Gen2TouchLayout:

--- a/game/launcher/about_page.gd
+++ b/game/launcher/about_page.gd
@@ -71,7 +71,7 @@ func _build() -> void:
 	report.add_child(bug)
 
 	var project: VBoxContainer = _card(column, "The project")
-	var links: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+	var links: HFlowContainer = Gen2LauncherUI.actions()
 	project.add_child(links)
 	links.add_child(_link_button(
 		"GitHub", &"github", Gen2AppVersion.REPOSITORY, Gen2LauncherButton.Variant.NEUTRAL

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -173,6 +173,18 @@ static func muted(theme: Gen2LauncherTheme, text: String) -> Label:
 	return label
 
 
+## A muted word that does not wrap, for a line of short facts.
+##
+## [method muted] wraps, and a wrapping label reports almost no minimum width, so
+## one dropped into a flow row or an expanding box is squeezed to a character a
+## line. A fact is short enough to keep whole and long enough to be worth the
+## helper.
+static func tag(theme: Gen2LauncherTheme, text: String) -> Label:
+	var label: Label = muted(theme, text)
+	label.autowrap_mode = TextServer.AUTOWRAP_OFF
+	return label
+
+
 ## A section marker: small, spaced capitals in the faint colour.
 static func caption(theme: Gen2LauncherTheme, text: String) -> Label:
 	var label: Label = _label(text.to_upper(), Gen2LauncherTheme.FONT_TINY, theme.faint)

--- a/game/launcher/mod_sources_page.gd
+++ b/game/launcher/mod_sources_page.gd
@@ -51,11 +51,12 @@ func _build() -> void:
 			+ " whoever publishes it.",
 	))
 
-	var add_row: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+	var add_row: HFlowContainer = Gen2LauncherUI.actions()
 	add_child(add_row)
 	_entry = LineEdit.new()
 	_entry.placeholder_text = "owner/repo or https://..."
 	_entry.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_entry.custom_minimum_size = Vector2(220, 0)
 	_entry.text_submitted.connect(func(_text: String) -> void: _follow())
 	add_row.add_child(_entry)
 	var follow: Gen2LauncherButton = Gen2LauncherButton.create(
@@ -90,7 +91,12 @@ func _card(source: Dictionary) -> Control:
 	var text: VBoxContainer = Gen2LauncherUI.column(1)
 	text.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	line.add_child(text)
-	text.add_child(Gen2LauncherUI.body(_theme, String(source["label"])))
+	## A feed name is as long as its owner made it, and an unwrapped label
+	## reports that whole width as its minimum, which pushes the two buttons off
+	## the card on a narrow window.
+	var label: Label = Gen2LauncherUI.body(_theme, String(source["label"]))
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	text.add_child(label)
 	text.add_child(Gen2LauncherUI.muted(_theme, _listing_line(feed)))
 
 	var update: Gen2LauncherButton = Gen2LauncherButton.icon_only(

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -36,20 +36,12 @@ signal cry_requested(species: int)
 ## per-caller mode.
 signal selection_made(party_index: int)
 
-const BACKGROUND: Color = Color("#09111f")
-const PANEL: Color = Color("#14233a")
-const BORDER: Color = Color("#2d4566")
-const TEXT: Color = Color("#f4f7fb")
-const MUTED: Color = Color("#9eacc0")
 
 ## The two `MonMenuOptions` rows that open a second party list rather than
 ## leaving the menu: `MonMenu_Softboiled_MilkDrink` serves both.
 const HEAL_TRANSFER_MOVES: Array[int] = [
 	Gen2WorldFieldMove.MOVE_SOFTBOILED, Gen2WorldFieldMove.MOVE_MILK_DRINK,
 ]
-const ACCENT: Color = Color("#f3c969")
-const SUCCESS: Color = Color("#7bd89a")
-const ERROR: Color = Color("#ef8a8a")
 
 ## data/mon_menu.asm's MONMENUVALUE_* option strings, in that file's order.
 const OPTION_STATS: StringName = &"stats"
@@ -122,8 +114,13 @@ var _embedded: bool = false
 var _cards: VBoxContainer = null
 var _player_label: Label = null
 var _status: Label = null
-var _storage_button: Button = null
-var _battle_button: Button = null
+var _storage_button: Gen2LauncherButton = null
+var _battle_button: Gen2LauncherButton = null
+## The launcher's own appearance, the one [Gen2SaveScreen] is drawn in. The
+## window-resolution view is a launcher page and is built out of its parts, so a
+## theme change and a narrow window both reach it.
+var _palette: Gen2LauncherTheme = null
+var _shell: Gen2LauncherShell = null
 ## The cursor and per-mon submenu. Reachable only through handle_button(),
 ## which only the world screen calls, so the standalone save-screen view keeps
 ## its mouse-driven behavior unchanged.
@@ -707,8 +704,11 @@ func _render_submenu() -> void:
 		var label := Label.new()
 		label.text = ("> " if index == _submenu_cursor else "  ") \
 			+ String(entry.get("label", ""))
-		label.add_theme_color_override("font_color", ACCENT if index == _submenu_cursor else TEXT)
-		label.add_theme_font_size_override("font_size", 18)
+		label.add_theme_color_override(
+			"font_color",
+			_palette.accent if index == _submenu_cursor else _palette.text
+		)
+		label.add_theme_font_size_override("font_size", Gen2LauncherTheme.FONT_BODY)
 		_submenu.add_child(label)
 
 
@@ -947,79 +947,65 @@ func _build_ui() -> void:
 	if _embedded:
 		_build_hardware_ui()
 		return
-	var background := ColorRect.new()
-	background.color = BACKGROUND
-	background.mouse_filter = Control.MOUSE_FILTER_IGNORE
-	background.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(background)
+	_palette = Gen2LauncherTheme.active()
+	theme = _palette.control_theme()
+	_shell = Gen2LauncherShell.create(_palette)
+	add_child(_shell)
 
-	var margin := MarginContainer.new()
-	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	margin.add_theme_constant_override("margin_left", 64)
-	margin.add_theme_constant_override("margin_top", 42)
-	margin.add_theme_constant_override("margin_right", 64)
-	margin.add_theme_constant_override("margin_bottom", 42)
-	add_child(margin)
-
-	var content := VBoxContainer.new()
-	content.add_theme_constant_override("separation", 16)
-	margin.add_child(content)
-
-	var header := HBoxContainer.new()
-	header.add_theme_constant_override("separation", 18)
-	content.add_child(header)
-	var heading := VBoxContainer.new()
-	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	heading.add_theme_constant_override("separation", 3)
-	header.add_child(heading)
-	var title := Label.new()
-	title.text = "PARTY"
-	title.add_theme_color_override("font_color", TEXT)
-	title.add_theme_font_size_override("font_size", 32)
-	heading.add_child(title)
-	var subtitle := Label.new()
-	subtitle.text = "Player party and persistent condition"
-	subtitle.add_theme_color_override("font_color", MUTED)
-	heading.add_child(subtitle)
-	var back := _button("Close" if _embedded else "Back to save slots", TEXT)
-	back.custom_minimum_size = Vector2(190, 44)
+	var back: Gen2LauncherButton = Gen2LauncherButton.create(
+		_palette, "Save data", Gen2LauncherButton.Variant.QUIET, &"back"
+	)
 	back.pressed.connect(_back)
-	_storage_button = _button("Open PC storage", ACCENT)
-	_storage_button.custom_minimum_size = Vector2(170, 44)
-	_storage_button.pressed.connect(_open_storage)
-	_storage_button.visible = not _embedded
-	header.add_child(_storage_button)
-	header.add_child(back)
+	_shell.add_action(back)
 
-	_player_label = Label.new()
-	_player_label.add_theme_color_override("font_color", ACCENT)
-	_player_label.add_theme_font_size_override("font_size", 18)
-	content.add_child(_player_label)
+	var page: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_LG)
+	var head: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
+	page.add_child(head)
+	var heading: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_XS)
+	heading.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	head.add_child(heading)
+	heading.add_child(Gen2LauncherUI.title(
+		_palette, "Party", Gen2LauncherTheme.FONT_DISPLAY
+	))
+	heading.add_child(Gen2LauncherUI.muted(
+		_palette, "Player party and persistent condition"
+	))
+	_player_label = Gen2LauncherUI.caption(_palette, "")
+	_player_label.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	_player_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	head.add_child(_player_label)
 
 	var scroll: Gen2LauncherScroll = Gen2LauncherScroll.create()
-	content.add_child(scroll)
-	_cards = VBoxContainer.new()
-	_cards.add_theme_constant_override("separation", 9)
+	page.add_child(scroll)
+	var body: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(body)
+	_cards = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	_cards.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	scroll.add_child(_cards)
-
-	_submenu = VBoxContainer.new()
-	_submenu.add_theme_constant_override("separation", 4)
+	body.add_child(_cards)
+	_submenu = Gen2LauncherUI.column(Gen2LauncherUI.GAP_XS)
 	_submenu.visible = false
-	content.add_child(_submenu)
+	body.add_child(_submenu)
 
-	var footer := HBoxContainer.new()
-	footer.add_theme_constant_override("separation", 10)
-	content.add_child(footer)
-	_battle_button = _button("Start development battle", ACCENT)
+	## The three things this view offers that no cartridge screen does. A
+	## wrapping row, so a phone held upright drops them onto their own lines
+	## rather than pushing the page off its own width.
+	var actions: HFlowContainer = Gen2LauncherUI.actions()
+	body.add_child(actions)
+	_storage_button = Gen2LauncherButton.create(
+		_palette, "PC storage", Gen2LauncherButton.Variant.NEUTRAL, &"folder"
+	)
+	_storage_button.pressed.connect(_open_storage)
+	actions.add_child(_storage_button)
+	_battle_button = Gen2LauncherButton.create(
+		_palette, "Development battle", Gen2LauncherButton.Variant.PRIMARY, &"play"
+	)
 	_battle_button.pressed.connect(_start_battle)
-	_battle_button.visible = not _embedded
-	footer.add_child(_battle_button)
-	_status = Label.new()
-	_status.add_theme_color_override("font_color", MUTED)
-	_status.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_status.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	footer.add_child(_status)
+	actions.add_child(_battle_button)
+
+	_status = Gen2LauncherUI.muted(_palette, "")
+	body.add_child(_status)
+	_shell.add_page(&"party", "Party", &"save", page)
 
 
 ## A caller's own refusal in this list's box, for a selection the list itself
@@ -1040,7 +1026,7 @@ func _say(message: String) -> void:
 	if _status == null:
 		return
 	_status.text = message
-	_status.add_theme_color_override("font_color", MUTED)
+	_status.add_theme_color_override("font_color", _palette.muted)
 
 
 func _refresh() -> void:
@@ -1054,56 +1040,46 @@ func _refresh() -> void:
 		_player_label.text = "Player: %s" % (_save.player_name if _save != null else "Unavailable")
 	if _data == null or _save == null:
 		_status.text = "No validated save selected."
-		_status.add_theme_color_override("font_color", ERROR)
+		_status.add_theme_color_override("font_color", _palette.error)
 		return
 	for index: int in Gen2SaveData.MAX_PARTY:
 		_cards.add_child(_member_card(index))
 	_render_submenu()
 	_status.text = "Slot %d" % (_save.slot + 1)
-	_status.add_theme_color_override("font_color", SUCCESS)
+	_status.add_theme_color_override("font_color", _palette.success)
 
 
-func _member_card(index: int) -> PanelContainer:
-	var card := PanelContainer.new()
+func _member_card(index: int) -> Control:
 	var selected: bool = index == _member_cursor and index < _party_size()
-	card.add_theme_stylebox_override(
-		"panel", _panel_style(PANEL, ACCENT if selected else BORDER, 8)
+	var card: Gen2LauncherCard = (
+		Gen2LauncherCard.selected(_palette, Gen2LauncherTheme.RADIUS_MD, 16) if selected
+		else Gen2LauncherCard.create(_palette, Gen2LauncherTheme.RADIUS_MD, 16)
 	)
-	var content := HBoxContainer.new()
-	content.add_theme_constant_override("separation", 18)
+	var content: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
 	card.add_child(content)
-	var number := Label.new()
-	number.text = "%d" % (index + 1)
-	number.custom_minimum_size = Vector2(28, 0)
-	number.add_theme_color_override("font_color", ACCENT)
-	number.add_theme_font_size_override("font_size", 20)
+	var number: Label = Gen2LauncherUI.title(_palette, "%d" % (index + 1))
+	number.add_theme_color_override("font_color", _palette.accent)
+	number.custom_minimum_size = Vector2(24, 0)
+	number.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	content.add_child(number)
 	if _save == null or index >= _save.party.size():
-		var empty := Label.new()
-		empty.text = "Empty"
-		empty.add_theme_color_override("font_color", MUTED)
-		content.add_child(empty)
+		content.add_child(Gen2LauncherUI.tag(_palette, "Empty"))
 		return card
 	var mon: Gen2SaveMon = _save.party[index]
-	var summary := VBoxContainer.new()
+	var summary: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_XS)
 	summary.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	summary.add_theme_constant_override("separation", 3)
 	content.add_child(summary)
-	var name_label := Label.new()
-	name_label.text = _display_name(mon)
-	name_label.add_theme_color_override("font_color", TEXT)
-	name_label.add_theme_font_size_override("font_size", 20)
-	summary.add_child(name_label)
-	var details := Label.new()
-	details.text = "%s    Level %d    HP %d/%d" % [
-		_species_name(mon.species), mon.level, mon.hp, _max_hp(mon)
-	]
-	details.add_theme_color_override("font_color", MUTED)
-	summary.add_child(details)
-	var condition := Label.new()
-	condition.text = "Status: %s" % _status_name(mon.status)
+	summary.add_child(Gen2LauncherUI.title(_palette, _display_name(mon)))
+	## Level and HP wrap onto their own line on a narrow page rather than
+	## widening the card past the window.
+	var facts: HFlowContainer = Gen2LauncherUI.actions(Gen2LauncherUI.GAP_MD)
+	summary.add_child(facts)
+	facts.add_child(Gen2LauncherUI.tag(_palette, _species_name(mon.species)))
+	facts.add_child(Gen2LauncherUI.tag(_palette, "Lv.%d" % mon.level))
+	facts.add_child(Gen2LauncherUI.tag(_palette, "HP %d/%d" % [mon.hp, _max_hp(mon)]))
+	var condition: Label = Gen2LauncherUI.caption(_palette, _status_name(mon.status))
 	condition.add_theme_color_override("font_color", _status_color(mon.status))
-	summary.add_child(condition)
+	facts.add_child(condition)
 	return card
 
 
@@ -1139,7 +1115,7 @@ func _status_name(status: int) -> String:
 
 
 func _status_color(status: int) -> Color:
-	return SUCCESS if Gen2Status.name_of(status).is_empty() else ACCENT
+	return _palette.success if Gen2Status.name_of(status).is_empty() else _palette.warning
 
 
 func _start_battle() -> void:
@@ -1166,7 +1142,7 @@ func close_embedded() -> void:
 func _open_storage() -> void:
 	if _data == null or _save == null:
 		_status.text = "No validated save selected."
-		_status.add_theme_color_override("font_color", ERROR)
+		_status.add_theme_color_override("font_color", _palette.error)
 		return
 	if not _select_slot():
 		return
@@ -1181,27 +1157,5 @@ func _select_slot() -> bool:
 	if runtime != null and runtime.select_save_slot(_data.id, _save.slot):
 		return true
 	_status.text = "The selected cartridge is not in the registry."
-	_status.add_theme_color_override("font_color", ERROR)
+	_status.add_theme_color_override("font_color", _palette.error)
 	return false
-
-
-func _button(text: String, colour: Color) -> Button:
-	var button := Button.new()
-	button.text = text
-	button.add_theme_color_override("font_color", colour)
-	button.add_theme_color_override("font_hover_color", Color.WHITE)
-	button.add_theme_font_size_override("font_size", 14)
-	return button
-
-
-func _panel_style(fill: Color, line: Color, radius: int) -> StyleBoxFlat:
-	var style := StyleBoxFlat.new()
-	style.bg_color = fill
-	style.border_color = line
-	style.set_border_width_all(1)
-	style.set_corner_radius_all(radius)
-	style.content_margin_left = 18
-	style.content_margin_top = 14
-	style.content_margin_right = 18
-	style.content_margin_bottom = 14
-	return style

--- a/game/save/save_editor_screen.gd
+++ b/game/save/save_editor_screen.gd
@@ -3,8 +3,11 @@ extends Control
 ## The save editor. Presentation only: every rule lives in [Gen2SaveEditor],
 ## which is what keeps an edit from producing a slot that will not load.
 ##
-## Deliberately built from stock controls with no styling. The look is a later
-## pass, and a plain screen is the one that is cheapest to replace.
+## Stock controls, dressed in the launcher's own appearance: the palette's
+## [method Gen2LauncherTheme.control_theme] styles Button, Label, SpinBox and the
+## rest, so the editor matches the pages it is opened from without a widget of
+## its own. Every row of controls is a wrapping row, because this screen opens at
+## whatever size the window is, a phone held upright included.
 
 ## Kept in the order the tabs are drawn in, so a snapshot names a tab rather
 ## than an index a reader has to count.
@@ -28,6 +31,7 @@ var _dex_field: SpinBox = null
 var _dex_list: ItemList = null
 var _selected_party: int = -1
 var _selected_box: int = 0
+var _palette: Gen2LauncherTheme = null
 
 
 func _ready() -> void:
@@ -128,22 +132,30 @@ func reload_now() -> bool:
 
 
 func _build_ui() -> void:
+	_palette = Gen2LauncherTheme.active()
+	theme = _palette.control_theme()
+	var backdrop := ColorRect.new()
+	backdrop.color = _palette.backdrop_bottom
+	backdrop.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(backdrop)
+
 	var margin := MarginContainer.new()
 	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	for side: String in ["left", "top", "right", "bottom"]:
-		margin.add_theme_constant_override("margin_%s" % side, 8)
+		margin.add_theme_constant_override("margin_%s" % side, Gen2LauncherUI.GAP_LG)
 	add_child(margin)
 
-	var root := VBoxContainer.new()
+	var root: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
 	margin.add_child(root)
 
-	var header := HBoxContainer.new()
+	var header: HFlowContainer = Gen2LauncherUI.actions()
 	root.add_child(header)
-	var title := Label.new()
-	title.text = "Save editor"
-	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	header.add_child(title)
-	_validity = Label.new()
+	header.add_child(Gen2LauncherUI.title(
+		_palette, "Save editor", Gen2LauncherTheme.FONT_TITLE
+	))
+	_validity = Gen2LauncherUI.tag(_palette, "")
+	_validity.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	header.add_child(_validity)
 	header.add_child(_action("Reload", reload_now))
 	header.add_child(_action("Save", save_now))
@@ -152,33 +164,43 @@ func _build_ui() -> void:
 	_tabs = TabContainer.new()
 	_tabs.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	root.add_child(_tabs)
-	_tabs.add_child(_build_party_tab())
-	_tabs.add_child(_build_boxes_tab())
-	_tabs.add_child(_build_items_tab())
-	_tabs.add_child(_build_events_tab())
-	_tabs.add_child(_build_map_tab())
-	_tabs.add_child(_build_dex_tab())
+	for page: Control in [
+		_build_party_tab(), _build_boxes_tab(), _build_items_tab(),
+		_build_events_tab(), _build_map_tab(), _build_dex_tab(),
+	]:
+		_tabs.add_child(_scrolled(page))
 	for index: int in TABS.size():
 		_tabs.set_tab_title(index, String(TABS[index]).capitalize())
 
-	_status = Label.new()
-	_status.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_status = Gen2LauncherUI.muted(_palette, "")
 	root.add_child(_status)
 
 
+## A tab's contents, scrolled. A tab is whatever size the window leaves it, so a
+## page that does not fit is reachable rather than clipped.
+func _scrolled(page: Control) -> Control:
+	var scroll: Gen2LauncherScroll = Gen2LauncherScroll.create()
+	scroll.name = page.name
+	page.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(page)
+	return scroll
+
+
 func _build_party_tab() -> Control:
-	var page := HBoxContainer.new()
+	## The list and the form sit side by side while both fit and stack when they
+	## do not, which is what a flow container is for.
+	var page: HFlowContainer = Gen2LauncherUI.actions(Gen2LauncherUI.GAP_MD)
 	page.name = "Party"
 
-	var left := VBoxContainer.new()
-	left.custom_minimum_size = Vector2(260, 0)
+	var left: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
+	left.custom_minimum_size = Vector2(260, 320)
 	page.add_child(left)
 	_party_list = ItemList.new()
 	_party_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_party_list.item_selected.connect(func(index: int) -> void: select_party_member(index))
 	left.add_child(_party_list)
 
-	var add_row := HBoxContainer.new()
+	var add_row: HFlowContainer = Gen2LauncherUI.actions()
 	left.add_child(add_row)
 	var species_field := SpinBox.new()
 	species_field.max_value = 255
@@ -197,16 +219,17 @@ func _build_party_tab() -> Control:
 		_selected_party = -1
 	))
 
-	_party_form = VBoxContainer.new()
+	_party_form = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
+	_party_form.custom_minimum_size = Vector2(260, 0)
 	_party_form.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	page.add_child(_party_form)
 	return page
 
 
 func _build_boxes_tab() -> Control:
-	var page := VBoxContainer.new()
+	var page: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	page.name = "Boxes"
-	var row := HBoxContainer.new()
+	var row: HFlowContainer = Gen2LauncherUI.actions()
 	page.add_child(row)
 	_box_picker = OptionButton.new()
 	for index: int in Gen2SaveData.BOX_COUNT:
@@ -237,16 +260,17 @@ func _build_boxes_tab() -> Control:
 	))
 
 	_box_list = ItemList.new()
+	_box_list.custom_minimum_size = Vector2(0, 320)
 	_box_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	page.add_child(_box_list)
 	return page
 
 
 func _build_items_tab() -> Control:
-	var page := VBoxContainer.new()
+	var page: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	page.name = "Items"
 
-	var money_row := HBoxContainer.new()
+	var money_row: HFlowContainer = Gen2LauncherUI.actions()
 	page.add_child(money_row)
 	money_row.add_child(_label("Money"))
 	_money_field = SpinBox.new()
@@ -263,7 +287,7 @@ func _build_items_tab() -> Control:
 	)
 	money_row.add_child(_coins_field)
 
-	var item_row := HBoxContainer.new()
+	var item_row: HFlowContainer = Gen2LauncherUI.actions()
 	page.add_child(item_row)
 	var item_field := SpinBox.new()
 	item_field.max_value = 255
@@ -284,10 +308,10 @@ func _build_items_tab() -> Control:
 
 
 func _build_events_tab() -> Control:
-	var page := VBoxContainer.new()
+	var page: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	page.name = "Events"
 
-	var badges := HFlowContainer.new()
+	var badges: HFlowContainer = Gen2LauncherUI.actions()
 	page.add_child(badges)
 	_badge_boxes = []
 	for index: int in Gen2WorldState.BADGE_ENGINE_FLAGS.size():
@@ -297,7 +321,7 @@ func _build_events_tab() -> Control:
 		badges.add_child(box)
 		_badge_boxes.append(box)
 
-	var flag_row := HBoxContainer.new()
+	var flag_row: HFlowContainer = Gen2LauncherUI.actions()
 	page.add_child(flag_row)
 	flag_row.add_child(_label("Event flag"))
 	_flag_field = SpinBox.new()
@@ -313,10 +337,10 @@ func _build_events_tab() -> Control:
 
 
 func _build_map_tab() -> Control:
-	var page := VBoxContainer.new()
+	var page: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	page.name = "Map"
 	for field: String in ["group", "number", "x", "y"]:
-		var row := HBoxContainer.new()
+		var row: HFlowContainer = Gen2LauncherUI.actions()
 		page.add_child(row)
 		row.add_child(_label(field.capitalize()))
 		var spin := SpinBox.new()
@@ -326,7 +350,7 @@ func _build_map_tab() -> Control:
 	page.add_child(_action("Move player", _apply_position))
 
 	for field: String in ["day", "hour", "minute"]:
-		var row := HBoxContainer.new()
+		var row: HFlowContainer = Gen2LauncherUI.actions()
 		page.add_child(row)
 		row.add_child(_label(field.capitalize()))
 		var spin := SpinBox.new()
@@ -344,9 +368,9 @@ func _build_map_tab() -> Control:
 
 
 func _build_dex_tab() -> Control:
-	var page := VBoxContainer.new()
+	var page: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	page.name = "Dex"
-	var row := HBoxContainer.new()
+	var row: HFlowContainer = Gen2LauncherUI.actions()
 	page.add_child(row)
 	row.add_child(_label("Species"))
 	_dex_field = SpinBox.new()
@@ -428,7 +452,7 @@ func _refresh_party_form() -> void:
 			"Move %d" % (slot + 1), int(mon.moves[slot]), 0, 255,
 			func(value: int) -> void: _apply(_editor.set_move(mon, slot, value))
 		))
-	var dv_row := HBoxContainer.new()
+	var dv_row: HFlowContainer = Gen2LauncherUI.actions()
 	dv_row.add_child(_label("DVs"))
 	var dv_fields: Array[SpinBox] = []
 	for dv: int in [
@@ -581,8 +605,8 @@ func _action(text: String, handler: Callable) -> Button:
 	return button
 
 
-func _field(text: String, value: int, minimum: int, maximum: int, handler: Callable) -> HBoxContainer:
-	var row := HBoxContainer.new()
+func _field(text: String, value: int, minimum: int, maximum: int, handler: Callable) -> Container:
+	var row: HFlowContainer = Gen2LauncherUI.actions()
 	row.add_child(_label(text))
 	var spin := SpinBox.new()
 	spin.min_value = minimum

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -361,7 +361,7 @@ func _refresh_details() -> void:
 	var save: Gen2SaveData = _load_selected_save()
 	if save != null:
 		body.add_child(Gen2LauncherUI.muted(_palette, "Player: %s" % save.player_name))
-		var save_actions: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+		var save_actions: HFlowContainer = Gen2LauncherUI.actions()
 		body.add_child(save_actions)
 		save_actions.add_child(_action("Continue", Gen2LauncherButton.Variant.PRIMARY, &"play", _continue_selected))
 		save_actions.add_child(_action("Party", Gen2LauncherButton.Variant.NEUTRAL, &"", _open_party))
@@ -381,7 +381,7 @@ func _refresh_details() -> void:
 		return
 
 	body.add_child(Gen2LauncherUI.muted(_palette, _slot_message(row)))
-	var actions: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+	var actions: HFlowContainer = Gen2LauncherUI.actions()
 	body.add_child(actions)
 	actions.add_child(_action("New game", Gen2LauncherButton.Variant.PRIMARY, &"plus", _request_new_game))
 	actions.add_child(_action("Import .sav", Gen2LauncherButton.Variant.NEUTRAL, &"", _request_import))
@@ -396,19 +396,23 @@ func _refresh_details() -> void:
 ## only the last of them is reversible.
 func _add_slot_management(body: VBoxContainer) -> void:
 	body.add_child(Gen2LauncherUI.caption(_palette, "This slot as a file"))
-	var name_row: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+	var name_row: HFlowContainer = Gen2LauncherUI.actions()
 	body.add_child(name_row)
 	var name_input := LineEdit.new()
 	name_input.placeholder_text = "Slot name"
 	name_input.max_length = Gen2SaveData.MAX_LABEL
 	name_input.text = String(_row_for(_selected_slot).get("label", ""))
 	name_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	## A wrapping row gives a child its minimum width rather than the line, so
+	## the field says how wide it wants to be and drops the button under it when
+	## the page cannot hold both.
+	name_input.custom_minimum_size = Vector2(220, 0)
 	name_row.add_child(name_input)
 	name_row.add_child(_action("Rename", Gen2LauncherButton.Variant.NEUTRAL, &"", func() -> void:
 		_rename_slot(name_input.text)
 	))
 
-	var file_row: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+	var file_row: HFlowContainer = Gen2LauncherUI.actions()
 	body.add_child(file_row)
 	file_row.add_child(_action("Edit save", Gen2LauncherButton.Variant.NEUTRAL, &"settings", _open_editor))
 	file_row.add_child(_action("Export", Gen2LauncherButton.Variant.NEUTRAL, &"", func() -> void:
@@ -518,7 +522,7 @@ func _build_new_game_form(body: VBoxContainer) -> void:
 	_name_input.custom_minimum_size = Vector2(0, 42)
 	body.add_child(Gen2LauncherUI.caption(_palette, "Save name"))
 	body.add_child(_name_input)
-	var actions: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_SM)
+	var actions: HFlowContainer = Gen2LauncherUI.actions()
 	body.add_child(actions)
 	actions.add_child(_action("Start game", Gen2LauncherButton.Variant.PRIMARY, &"check", _create_from_form))
 	actions.add_child(_action("Cancel", Gen2LauncherButton.Variant.NEUTRAL, &"", cancel_new_game))

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -88,6 +88,12 @@ const SAVE_DONE_FRAMES: int = 30
 ## hex).
 const SFX_SAVE: int = 0x25
 
+## `SwitchItemsInBag`' own two, both hexadecimal the way the constants file
+## counts: `.place_insert` asks for SFX_SWITCH_POKEMON twice through
+## `WaitPlaySFX`, and a pocket cycle asks for SFX_SWITCH_POCKETS.
+const SFX_SWITCH_POKEMON: int = 0x20
+const SFX_SWITCH_POCKETS: int = 0x62
+
 ## The pack's five imported texts, by the key `GameData.menu_text` holds each
 ## under. `UseItem`'s two refusals and `TossMenu`'s three; "(S)" is three literal
 ## characters in the charmap rather than a plural rule, so the cartridge really
@@ -153,6 +159,9 @@ var _pack_scroll: Array[int] = [0, 0, 0, 0]
 ## [method _scroll_list_to_cursor].
 var _list_scroll: int = 0
 var _pack_cursors: Array[int] = [0, 0, 0, 0]
+## `wSwitchItem` less one: the row SELECT marked in the pocket the pack is on,
+## or -1 for `SwitchItemsInBag`' own zero.
+var _pack_switch: int = -1
 var _pack_page: Gen2PackPage = null
 var _pack_result_ok: bool = false
 ## `PrintText` waits per page, so a result longer than the box's two rows is
@@ -391,7 +400,43 @@ func handle_button(button: int) -> bool:
 			_cancel()
 			_render_hardware()
 			return true
+		Gen2Button.SELECT:
+			if _mode != Mode.PACK:
+				return false
+			_press_pack_select()
+			_render_hardware()
+			return true
 	return false
+
+
+## `Pack_InterpretJoypad`'s `.select` and `.switching_item`'s own SELECT, which
+## are the same press: the first marks a row and the second places the held item
+## on the row the cursor is on.
+func _press_pack_select() -> void:
+	if _give_target >= 0:
+		## `DepositSellPack` runs its own joypad handler with no `.select` in it,
+		## so a pack opened to pick one item does not reorder anything.
+		return
+	_apply_switch_press()
+
+
+## One press of `SwitchItemsInBag`: the pocket's own rows, the row an earlier
+## SELECT marked and the row the cursor is on. A press that moved something is
+## written through [Gen2WorldBagHost], so the order the player arranged is in the
+## save rather than in this screen.
+func _apply_switch_press() -> void:
+	var order: Array = []
+	for row: Dictionary in _current_pocket_items():
+		order.append(int(row.get("item", 0)))
+	var answer: Dictionary = Gen2WorldPack.switch_items(order, _pack_switch, _pack_cursor)
+	var next_order: Array = answer["order"]
+	if next_order != order and _world != null:
+		Gen2WorldBagHost.reorder(_world, _pack_save, next_order, false, _pack_persist)
+		_open_pack_mode(false)
+		## `.place_insert` asks for the same effect twice through `WaitPlaySFX`.
+		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
+		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
+	_pack_switch = int(answer["held"])
 
 
 func _move(direction: Vector2i) -> void:
@@ -493,6 +538,11 @@ func _confirm() -> void:
 		Mode.LIST:
 			_confirm_list()
 		Mode.PACK:
+			## `.switching_item` reads A before anything else, so the A that
+			## would open an item's submenu places the held item instead.
+			if _pack_switch >= 0:
+				_apply_switch_press()
+				return
 			## `ScrollingMenuJoyAction`'s `.a_button` answers `-1` on the CANCEL
 			## row and falls into `.b_button`, so choosing it leaves the pack.
 			if _pack_cursor_on_cancel():
@@ -569,6 +619,10 @@ func _cancel() -> void:
 		Mode.LIST:
 			closed.emit()
 		Mode.PACK:
+			## `.end_switch`, which drops the mark and leaves the pack open.
+			if _pack_switch >= 0:
+				_pack_switch = -1
+				return
 			if _give_target >= 0:
 				closed.emit()
 			else:
@@ -879,6 +933,9 @@ func _open_pack_mode(reset: bool = true) -> void:
 		_pack_cursor = 0
 		_pack_cursors.fill(0)
 		_pack_scroll.fill(0)
+	## `Pack_Jumptable`'s entry clears `wSwitchItem`, so a pack reopened after a
+	## submenu holds nothing.
+	_pack_switch = -1
 	_pack_pocket_index = clampi(_pack_pocket_index, 0, maxi(_pack_pockets.size() - 1, 0))
 	## The CANCEL row is always there, so an emptied pocket puts the cursor on it
 	## rather than on an item that is gone.
@@ -902,8 +959,14 @@ func _current_pocket_items() -> Array:
 func _cycle_pocket(delta: int) -> void:
 	if _pack_pockets.is_empty():
 		return
+	## `.switching_item` answers left and right with a plain carry, so the pocket
+	## cannot be changed while a row is held.
+	if _pack_switch >= 0:
+		return
 	_pack_cursors[_pack_pocket_index] = _pack_cursor
 	_pack_pocket_index = wrapi(_pack_pocket_index + signi(delta), 0, _pack_pockets.size())
+	## `.d_left` and `.d_right` each play it before they leave.
+	sfx_requested.emit(SFX_SWITCH_POCKETS, false)
 	_pack_cursor = clampi(
 		_pack_cursors[_pack_pocket_index], 0, _current_pocket_items().size()
 	)
@@ -1032,6 +1095,10 @@ func _pack_result_text() -> String:
 
 
 func _pack_description() -> String:
+	## `.select` prints `AskItemMoveText` over the description and nothing
+	## reprints one until the item is placed.
+	if _pack_switch >= 0:
+		return Gen2WorldPack.ask_item_move_text()
 	if _pack_cursor_on_cancel() or _data == null:
 		return ""
 	return Gen2WorldPack.row_description(_data, int(_selected_item().get("item", 0)))

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -210,6 +210,35 @@ static func register(
 	return {"ok": true, "item": item, "name": String(definition.get("name", "UNKNOWN"))}
 
 
+## `SwitchItemsInBag` as a committed transaction: one pocket's rows put in
+## [param pocket_order], with the rest of the bag left where it sits.
+##
+## The caller has already run [method Gen2WorldPack.switch_items] to work out the
+## order; this only writes it. `wPCItems` is the same routine over a different
+## list, which [param pc] selects.
+static func reorder(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	pocket_order: Array,
+	pc: bool = false,
+	persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return Gen2WorldTransaction.failure(&"missing_world", {})
+	var owned: Dictionary = world.state.pc_items() if pc else world.state.items()
+	var order: Array[int] = Gen2WorldPack.reordered_items(owned, pocket_order)
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var changes: Dictionary = {}
+	changes["pc_item_order" if pc else "item_order"] = order
+	var applied: Dictionary = world.state.apply_changes({}, {}, changes)
+	if not bool(applied.get("ok", false)):
+		return Gen2WorldTransaction.failure(&"reorder_state_failed", applied)
+	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {"ok": true, "order": order}
+
+
 ## `CheckRegisteredItem`, which is what SELECT asks first: a registration is only
 ## good while the pack still holds the item, and the check clears it where it
 ## does not. The clear is written straight onto the live state, the way the

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -108,9 +108,11 @@ static func build(data: GameData, state: Gen2WorldState) -> Array:
 	var owned: Dictionary = state.items()
 	for pocket_type: int in pocket_order():
 		var pocket_items: Array = []
-		var item_numbers: Array = owned.keys()
-		item_numbers.sort()
-		for raw_item: Variant in item_numbers:
+		## The order the map holds, which is the order the items were received:
+		## a cartridge pocket is a packed array `ReceiveItem` appends to, and
+		## `SwitchItemsInBag` is the only thing that ever reorders one. Sorting
+		## here would make SELECT unobservable.
+		for raw_item: Variant in owned.keys():
 			var item: int = int(raw_item)
 			var quantity: int = int(owned[raw_item])
 			if quantity <= 0:
@@ -212,6 +214,80 @@ static func row_description(data: GameData, item: int) -> String:
 	if Gen2WorldTMHM.is_tm_hm(item):
 		return String(data.move(Gen2WorldTMHM.move_for_item(data, item)).get("description", ""))
 	return String(data.item(item).get("description", ""))
+
+
+## `SwitchItemsInBag` (`engine/items/switch_items.asm`), one press of SELECT or
+## of the A that places the held item.
+##
+## [param order] is one pocket's item numbers in list order, [param held] the row
+## an earlier SELECT marked or -1 for none, and [param cursor] the row the press
+## landed on, where a row past the last item is the CANCEL terminator the source
+## reads as -1. Answers the new order and the new held row.
+##
+## The source stores the held row as `wSwitchItem` = row + 1 so that zero means
+## none; -1 is that same "none" here. `.try_combining_stacks` cannot fire: the
+## flat item model has one stack per item, so no two rows ever carry the same
+## item number.
+static func switch_items(order: Array, held: int, cursor: int) -> Dictionary:
+	var moved: Array[int] = []
+	for entry: Variant in order:
+		moved.append(int(entry))
+	if held < 0 or held >= moved.size():
+		## `.init`: the first press only marks. A press on CANCEL marks nothing,
+		## because `ItemSwitch_GetNthItem` would read the terminator.
+		if cursor < 0 or cursor >= moved.size():
+			return {"order": moved, "held": -1}
+		return {"order": moved, "held": cursor}
+	## `.trivial`, which is checked before the terminator is read: placing an
+	## item on its own row clears the mark and moves nothing.
+	if cursor == held:
+		return {"order": moved, "held": -1}
+	## The `cp -1 / ret z` after it. The mark survives, so the next press on a
+	## real row still places the item.
+	if cursor < 0 or cursor >= moved.size():
+		return {"order": moved, "held": held}
+	## `.above` and `.below` are one memmove each with the held item copied
+	## through `wSwitchItemBuffer`, which is a remove and an insert either way.
+	var item: int = moved[held]
+	moved.remove_at(held)
+	moved.insert(cursor, item)
+	return {"order": moved, "held": -1}
+
+
+## The whole item map with one pocket's rows put in [param pocket_order], for
+## [method Gen2WorldState.apply_changes]' `item_order`. The cartridge has four
+## packed arrays and this port one insertion-ordered map, so a move inside a
+## pocket permutes only the positions that pocket already occupies.
+static func reordered_items(owned: Dictionary, pocket_order: Array) -> Array[int]:
+	var wanted: Array[int] = []
+	for entry: Variant in pocket_order:
+		wanted.append(int(entry))
+	var result: Array[int] = []
+	var occupied: int = 0
+	for raw_item: Variant in owned.keys():
+		if wanted.has(int(raw_item)):
+			occupied += 1
+	if occupied != wanted.size():
+		## Not this map's pocket: leave the order alone rather than dropping or
+		## duplicating a row.
+		for raw_item: Variant in owned.keys():
+			result.append(int(raw_item))
+		return result
+	var next: int = 0
+	for raw_item: Variant in owned.keys():
+		var item: int = int(raw_item)
+		if wanted.has(item):
+			result.append(wanted[next])
+			next += 1
+		else:
+			result.append(item)
+	return result
+
+
+## `AskItemMoveText`, printed the moment SELECT marks a row and left up until the
+## item is placed.
+static func ask_item_move_text() -> String:
+	return "Where should this\nbe moved to?"
 
 
 static func pocket_name(pocket_type: int) -> String:

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -163,8 +163,9 @@ static func can_open(save: Gen2SaveData) -> bool:
 
 
 ## The bag as rows a deposit list can draw, and the PC as rows a withdraw or
-## toss list can. Both are sorted by item number, which is the only order a flat
-## map has; the source's packed arrays keep insertion order instead.
+## toss list can. Both keep the order the map holds, which is the order the
+## items were received: `wPCItems` is a packed array `ReceiveItemFromPC` appends
+## to, and `SwitchItemsInBag` is the only thing that reorders one.
 static func bag_entries(data: GameData, state: Gen2WorldState) -> Array:
 	return _entries(data, state.items() if state != null else {})
 
@@ -177,9 +178,7 @@ static func _entries(data: GameData, owned: Dictionary) -> Array:
 	var out: Array = []
 	if data == null:
 		return out
-	var numbers: Array = owned.keys()
-	numbers.sort()
-	for raw_item: Variant in numbers:
+	for raw_item: Variant in owned.keys():
 		var item: int = int(raw_item)
 		var quantity: int = int(owned[raw_item])
 		if quantity <= 0:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -93,6 +93,10 @@ const MART_TEXT_PREFIX: Dictionary = {
 }
 ## `PlayTransactionSound`, once the money has been taken.
 const SFX_TRANSACTION: int = 0x22
+
+## `PC_PlaySwapItemsSound`, which asks for the same effect twice through
+## `WaitPlaySFX`. Hexadecimal, the way `constants/sfx_constants.asm` counts.
+const SFX_SWITCH_POKEMON: int = 0x20
 ## `BillsPC_PlaceEmptyBoxString_SFX`'s own `SFX_WRONG`.
 const SFX_WRONG: int = 0x19
 
@@ -171,6 +175,8 @@ var _pc_rows: Array = []
 var _pc_house: bool = false
 var _pc_action: int = -1
 var _pc_entries: Array = []
+## `wSwitchItem` less one: the PC row an earlier SELECT marked, or -1 for none.
+var _pc_switch: int = -1
 var _pc_quantity: int = 1
 ## The PC's own text boxes and what happens once the last is acknowledged:
 ## `PROF.OAK'S PC` returns to the top menu and `TURN OFF` shuts the machine down.
@@ -421,7 +427,38 @@ func handle_button(button: int) -> bool:
 		Gen2Button.B:
 			_cancel()
 			return true
+		Gen2Button.SELECT:
+			return _press_pc_item_select()
 	return false
+
+
+## `PCItemsJoypad`'s `.select_1` and `.a_select_2`, which are one press of
+## `SwitchItemsInBag` over `wPCItems`. Only the two lists that show the PC's own
+## items reach it: a deposit is `DepositSellPack`, whose joypad handler has no
+## SELECT in it.
+func _press_pc_item_select() -> bool:
+	if _mode != MODE.PC_ITEM_LIST \
+		or _pc_action == Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM:
+		return false
+	_apply_pc_switch_press()
+	return true
+
+
+## One press, the same shape [Gen2StartMenuScreen] gives the pack's own SELECT.
+func _apply_pc_switch_press() -> void:
+	var order: Array = []
+	for entry: Dictionary in _pc_entries:
+		order.append(int(entry.get("item", 0)))
+	var answer: Dictionary = Gen2WorldPack.switch_items(order, _pc_switch, _cursor)
+	var next_order: Array = answer["order"]
+	if next_order != order and _world != null:
+		Gen2WorldBagHost.reorder(_world, _save, next_order, true)
+		_refresh_pc_entries()
+		## `PC_PlaySwapItemsSound`, which is the pack's own pair of effects.
+		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
+		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
+	_pc_switch = int(answer["held"])
+	_render_rows()
 
 
 func selected_index() -> int:
@@ -1328,6 +1365,8 @@ func _open_pc_items() -> void:
 ## Whichever of the bag and the PC the chosen action reads.
 func _open_pc_item_list(action: int) -> void:
 	_pc_action = action
+	## `PCItemsJoypad` clears `wSwitchItem` before its loop.
+	_pc_switch = -1
 	_cursor = 0
 	_pc_quantity = 1
 	_refresh_pc_entries()
@@ -2301,6 +2340,11 @@ func _confirm() -> void:
 		_confirm_pc_row()
 		return
 	if _mode == MODE.PC_ITEM_LIST:
+		## `.moving_stuff_around` reads A before anything else, so the A that
+		## would pick a quantity places the held row instead.
+		if _pc_switch >= 0:
+			_apply_pc_switch_press()
+			return
 		_confirm_pc_item()
 		return
 	if _mode == MODE.PC_TEXT:
@@ -2334,6 +2378,11 @@ func _cancel() -> void:
 		else:
 			_open_pc(&"pokemon_center")
 	elif _mode == MODE.PC_ITEM_LIST:
+		## `.b_2`: the mark is dropped and the list stays up.
+		if _pc_switch >= 0:
+			_pc_switch = -1
+			_render_rows()
+			return
 		_open_pc_items()
 	elif _mode == MODE.PC_MAILBOX:
 		## `ScrollingMenu`'s PAD_B, which is `.exit` and the way back to the

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -2142,6 +2142,31 @@ func _roaming_target(
 	return Vector2i(-1, -1)
 
 
+## Whether [param order] names every key of [param source] exactly once, which
+## is the only shape a reorder may have: a list that dropped or repeated a row
+## would change what is owned rather than where it sits.
+static func _is_permutation(source: Dictionary, order: Array) -> bool:
+	if order.size() != source.size():
+		return false
+	var seen: Dictionary = {}
+	for entry: Variant in order:
+		var key: int = int(entry)
+		if not source.has(key) or seen.has(key):
+			return false
+		seen[key] = true
+	return true
+
+
+## [param source] rebuilt so its keys come out in [param order]. Insertion order
+## is what a pack listing reads, so this is the whole of a reorder.
+static func _reordered(source: Dictionary, order: Array) -> Dictionary:
+	var result: Dictionary = {}
+	for entry: Variant in order:
+		var key: int = int(entry)
+		result[key] = source[key]
+	return result
+
+
 ## Applies a script's staged state as one transaction. Validation happens before
 ## either dictionary is replaced, so a failed script cannot leave half a flag
 ## transition behind.
@@ -2160,9 +2185,18 @@ func apply_changes(
 	for raw_item: Variant in item_changes:
 		if int(raw_item) <= 0 or int(item_changes[raw_item]) < 0:
 			return {"ok": false, "reason": &"invalid_item_quantity"}
+	## `SwitchItemsInBag`' whole effect: the same items in another order. A
+	## quantity map compares equal whatever order it holds, so a reorder has to
+	## be asked for by name or the transaction below would call it no change.
+	var item_order: Variant = runtime_changes.get("item_order", null)
+	if item_order != null and not item_order is Array:
+		return {"ok": false, "reason": &"invalid_item_order"}
 	var pc_item_changes: Dictionary = runtime_changes.get("pc_items", {})
 	if not pc_item_changes is Dictionary:
 		return {"ok": false, "reason": &"invalid_pc_items"}
+	var pc_item_order: Variant = runtime_changes.get("pc_item_order", null)
+	if pc_item_order != null and not pc_item_order is Array:
+		return {"ok": false, "reason": &"invalid_pc_item_order"}
 	for raw_item: Variant in pc_item_changes:
 		if int(raw_item) <= 0 or int(pc_item_changes[raw_item]) < 0:
 			return {"ok": false, "reason": &"invalid_pc_item_quantity"}
@@ -2330,6 +2364,14 @@ func apply_changes(
 			next_pc_items[pc_item] = pc_quantity
 	if next_pc_items.size() > Gen2WorldPack.MAX_PC_ITEMS:
 		return {"ok": false, "reason": &"pc_item_capacity"}
+	if item_order != null:
+		if not _is_permutation(next_items, item_order as Array):
+			return {"ok": false, "reason": &"invalid_item_order"}
+		next_items = _reordered(next_items, item_order as Array)
+	if pc_item_order != null:
+		if not _is_permutation(next_pc_items, pc_item_order as Array):
+			return {"ok": false, "reason": &"invalid_pc_item_order"}
+		next_pc_items = _reordered(next_pc_items, pc_item_order as Array)
 	var next_money: Dictionary = _money.duplicate()
 	for raw_account: Variant in money_changes:
 		var account: int = int(raw_account)
@@ -2388,6 +2430,8 @@ func apply_changes(
 	var did_change: bool = next_flags != _event_flags or next_engine_flags != _engine_flags \
 		or next_scenes != _map_scenes \
 		or next_items != _items or next_pc_items != _pc_items \
+		or next_items.keys() != _items.keys() \
+		or next_pc_items.keys() != _pc_items.keys() \
 		or next_money != _money or next_coins != _coins \
 		or next_contacts != _phone_contacts or next_just_battled != _just_battled \
 		or next_seen_species != _seen_species \

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -706,3 +706,77 @@ func test_an_ether_asks_which_move_and_fills_that_slot() -> void:
 	await _step(Gen2Button.A)
 	assert_eq(user.pp_left(0), 0, "the slot it was not used on")
 	assert_gt(user.pp_left(1), 0, "and the one it was")
+
+
+## `BugContest_SetCaughtContestMon`: a catch made while `wContestMon` already
+## holds one says `DisplayAlreadyCaughtText`, draws
+## `DisplayCaughtContestMonStats` and asks over it. The comparison is what the
+## question is answered from, so a screen that draws nothing is a question asked
+## blind.
+func test_a_second_contest_catch_is_asked_over_the_comparison() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([_mon(BattleFixture.PIKACHU, [BattleFixture.TACKLE])]),
+		Gen2Party.create([_mon(BattleFixture.GEODUDE, [BattleFixture.TACKLE])]),
+		_rng, false
+	)
+	battle.battle_type = Gen2Battle.BATTLETYPE_CONTEST
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	_screen.set("_pending", [])
+	## `_is_wild_battle` is what a capture is gated on, and it reads the world's
+	## own request rather than the battle: a contest catch is a wild one.
+	_screen.set("_world_battle_active", true)
+	_screen.set("_world_battle_request", {"values": {"kind": &"wild"}})
+	_screen.set_capture_balls(
+		[Gen2WorldPartyHost.ITEM_PARK_BALL],
+		{Gen2WorldPartyHost.ITEM_PARK_BALL: Gen2WorldBugContest.BALLS}
+	)
+	assert_true(bool(_screen.begin_capture().get("ok", false)))
+	assert_true(bool(_screen.throw_capture_ball().get("ok", false)))
+	_screen.complete_capture({
+		"ok": true, "contest": true, "caught": true, "wobbles": 3,
+		"ball": Gen2WorldPartyHost.ITEM_PARK_BALL,
+		"quantity": Gen2WorldBugContest.BALLS - 1,
+		"replace_offer": true,
+		"mon": Gen2WorldPartyHost.contest_mon_from(_screen.capture_target()),
+		"stock_species": BattleFixture.BULBASAUR,
+		"stock_level": 9,
+		"stock_max_hp": 27,
+	})
+
+	## The throw's own frames, then the shake lines and the already-caught line,
+	## each prompted past the way a player would.
+	for _press: int in 20:
+		_settle_bars()
+		if _stage() == "contest_replace":
+			break
+		_screen.finish()
+		_screen.advance()
+	assert_eq(_stage(), "contest_replace")
+
+	## The page is one image on the menu layer, the way the party page is: the
+	## two boxes and `PlaceYesNoBox`' own go into one tilemap on the cartridge.
+	var box: Gen2TextBox = _screen.get("_box")
+	while box != null and (box.is_revealing() or box.has_pages_left()):
+		box.finish()
+		if box.has_pages_left():
+			box.advance()
+	_screen.call("_refresh_menu_layer")
+	var layer: TextureRect = _screen.get("_menu_layer")
+	assert_true(layer.visible, "the comparison is drawn")
+	assert_eq(layer.position, Vector2.ZERO, "over the field rather than beside it")
+	## `hlcoord 0, 6` plus five border rows, which is where the lower box ends.
+	assert_eq(
+		int(layer.size.y),
+		(Gen2BattleScreen.CONTEST_THIS_TOP + Gen2BattleScreen.CONTEST_STATS_HEIGHT + 1)
+			* Gen2Font.TILE,
+		"and stops above the text box, which this screen draws itself"
+	)
+
+
+## `lb bc, 14, 7` rather than `OfferSwitch`'s `lb bc, 1, 7`: the question stands
+## beside the THIS box, not over the STOCK one.
+func test_the_contest_question_uses_its_own_corner() -> void:
+	assert_eq(Gen2BattleScreen.CONTEST_YES_NO_LEFT, 14)
+	assert_eq(Gen2BattleScreen.CONTEST_YES_NO_TOP, 7)
+	assert_ne(Gen2BattleScreen.CONTEST_YES_NO_LEFT, Gen2BattleScreen.YES_NO_LEFT)

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -997,3 +997,48 @@ func test_putting_a_message_in_the_pack_empties_the_mailbox() -> void:
 	assert_eq(save.mailbox.size(), 0)
 	assert_eq(_world_screen._world.state.item_quantity(item), 1)
 	assert_eq(host._status, Gen2WorldPC.MAILBOX_CLEARED)
+
+
+## `PCItemsJoypad`'s `.select_1` and `.moving_stuff_around` (`SwitchItemsInBag`).
+## The withdraw and toss lists show `wPCItems` and reach it; a deposit is
+## `DepositSellPack`, whose joypad handler has no SELECT in it.
+func test_select_reorders_the_pc_item_list_but_not_the_deposit_list() -> void:
+	_write_pc_request()
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {
+		"items": {7: 1}, "pc_items": {7: 1, 0x14: 1},
+	})
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6190
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(Vector2i(7, 6))
+	)
+	await get_tree().process_frame
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+
+	## WITHDRAW ITEM, which is the PC's own list.
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_ITEM_LIST)
+	assert_eq(_world_screen._world.state.pc_items().keys(), [7, 0x14])
+	host.handle_button(Gen2Button.SELECT)
+	assert_eq(host._pc_switch, 0)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._pc_switch, -1)
+	assert_eq(_world_screen._world.state.pc_items().keys(), [0x14, 7])
+	assert_eq(_pc_list_items(host), [0x14, 7], "and the list is drawn the new way")
+	assert_eq(_world_screen._world.state.pc_item_quantity(7), 1, "nothing withdrawn")
+
+	## DEPOSIT ITEM's own list answers SELECT with nothing.
+	host.handle_button(Gen2Button.B)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._pc_action, Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM)
+	assert_false(host.handle_button(Gen2Button.SELECT))
+	assert_eq(host._pc_switch, -1)
+
+
+func _pc_list_items(host: Gen2WorldServiceScreen) -> Array:
+	var out: Array = []
+	for entry: Dictionary in host._pc_entries:
+		out.append(int(entry.get("item", 0)))
+	return out

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -2164,3 +2164,69 @@ func test_giving_mail_writes_a_message_before_it_leaves_the_bag() -> void:
 	assert_eq(_mon.mail.author, save.player_name)
 	assert_eq(_mon.mail.species, _mon.species)
 	assert_eq(_world_screen._world.state.item_quantity(mail_item), 0)
+
+
+## `Pack_InterpretJoypad`'s `.select` and `.switching_item` (`SwitchItemsInBag`,
+## `engine/items/switch_items.asm`): SELECT marks a row and the next A or SELECT
+## places it, which is the only thing that reorders a pocket.
+func test_select_moves_an_item_inside_its_own_pocket() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {
+		"items": {7: 5, REPEL: 1, ITEMFINDER: 1},
+	})
+	var host: Gen2StartMenuScreen = await _open_pack()
+	assert_eq(_pocket_items(host), [7, REPEL], "received order, not sorted")
+
+	host.handle_button(Gen2Button.SELECT)
+	assert_eq(host.get("_pack_switch"), 0)
+	assert_eq(host.call("_pack_description"), "Where should this\nbe moved to?")
+
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_pack_switch"), -1, "the mark is dropped once it is placed")
+	assert_eq(_pocket_items(host), [REPEL, 7])
+	assert_eq(_world_screen._world.state.items().keys(), [REPEL, 7, ITEMFINDER],
+		"the key item pocket keeps the position it held")
+	assert_eq(_world_screen._world.state.item_quantity(7), 5, "and nothing is spent")
+
+
+## `.trivial` and `.end_switch`: placing a row on itself and B both clear the
+## mark without moving anything, and the pack stays open either way.
+func test_a_held_row_is_dropped_by_b_and_by_its_own_row() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {7: 5, REPEL: 1}})
+	var host: Gen2StartMenuScreen = await _open_pack()
+
+	host.handle_button(Gen2Button.SELECT)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_pack_switch"), -1)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK, "no submenu opened")
+	assert_eq(_pocket_items(host), [7, REPEL])
+
+	host.handle_button(Gen2Button.SELECT)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.B)
+	assert_eq(host.get("_pack_switch"), -1)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK, "and the pack is still up")
+	assert_eq(_pocket_items(host), [7, REPEL])
+
+
+## `.switching_item` answers left and right with a plain carry, so a held row
+## cannot be carried into another pocket.
+func test_a_held_row_blocks_the_pocket_cycle() -> void:
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {
+		"items": {7: 5, REPEL: 1, ITEMFINDER: 1},
+	})
+	var host: Gen2StartMenuScreen = await _open_pack()
+	host.handle_button(Gen2Button.SELECT)
+	var pocket: int = host.get("_pack_pocket_index")
+	host.handle_button(Gen2Button.RIGHT)
+	assert_eq(host.get("_pack_pocket_index"), pocket)
+
+
+func _pocket_items(host: Gen2StartMenuScreen) -> Array:
+	var out: Array = []
+	for row: Dictionary in host.call("_current_pocket_items"):
+		out.append(int(row.get("item", 0)))
+	return out

--- a/tests/unit/test_touch_layout.gd
+++ b/tests/unit/test_touch_layout.gd
@@ -178,7 +178,7 @@ func test_a_layout_survives_the_options_file() -> void:
 	layout.scale = 1.4
 	layout.opacity = 0.5
 	layout.set_anchor(
-		Gen2TouchLayout.ORIENTATION_LANDSCAPE, Gen2TouchLayout.GROUP_FACE,
+		Gen2TouchLayout.ORIENTATION_LANDSCAPE, Gen2TouchLayout.GROUP_A,
 		Vector2(0.7, 0.3), LANDSCAPE.size,
 	)
 	var restored: Gen2TouchLayout = Gen2TouchLayout.parse(
@@ -194,7 +194,7 @@ func test_an_unreadable_layout_clamps_to_the_defaults() -> void:
 	var partial: Gen2TouchLayout = Gen2TouchLayout.parse({
 		"scale": 99.0,
 		"opacity": -4.0,
-		"portrait": {"pad": "over there", "face": [2.0, -1.0]},
+		"portrait": {"pad": "over there", "a": [2.0, -1.0]},
 	})
 	assert_eq(partial.scale, Gen2TouchLayout.MAX_SCALE)
 	assert_eq(partial.opacity, Gen2TouchLayout.MIN_OPACITY)
@@ -203,8 +203,68 @@ func test_an_unreadable_layout_clamps_to_the_defaults() -> void:
 		Gen2TouchLayout.DEFAULT_ANCHORS[Gen2TouchLayout.ORIENTATION_PORTRAIT][Gen2TouchLayout.GROUP_PAD],
 	)
 	assert_eq(
-		partial.anchor(Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_FACE),
+		partial.anchor(Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_A),
 		Vector2(1.0, 0.0),
+	)
+
+
+## A layout written while A and B were one cluster carries a `face` centre and
+## neither of the two the pad places now. `_split_face` puts them on the diagonal
+## that cluster held them on, B up and right of the old centre and A down and
+## left, so a player who arranged one finds it where they left it.
+func test_a_layout_from_before_a_and_b_came_apart_is_split() -> void:
+	var migrated: Gen2TouchLayout = Gen2TouchLayout.parse({
+		"portrait": {"face": [0.76, 0.50]},
+	})
+	var a: Vector2 = migrated.anchor(
+		Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_A
+	)
+	var b: Vector2 = migrated.anchor(
+		Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_B
+	)
+	assert_lt(a.x, b.x, "A stays left of B")
+	assert_gt(a.y, b.y, "and below it")
+	assert_almost_eq((a.x + b.x) * 0.5, 0.76, 0.001, "around the cluster's own centre")
+	assert_almost_eq((a.y + b.y) * 0.5, 0.50, 0.001)
+	assert_false(
+		migrated.to_dict()["portrait"].has("face"), "and the old name is not written back"
+	)
+
+
+## A layout that already names the two is left alone, so a migration cannot run
+## twice and walk the pair apart.
+func test_a_layout_that_already_names_a_and_b_is_not_split_again() -> void:
+	var stored: Dictionary = {
+		"portrait": {"face": [0.10, 0.10], "a": [0.30, 0.60], "b": [0.50, 0.40]},
+	}
+	var parsed: Gen2TouchLayout = Gen2TouchLayout.parse(stored)
+	assert_eq(
+		parsed.anchor(Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_A),
+		Vector2(0.30, 0.60),
+	)
+	assert_eq(
+		parsed.anchor(Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_B),
+		Vector2(0.50, 0.40),
+	)
+
+
+## The whole point of the split: each is dragged on its own.
+func test_a_and_b_are_placed_separately() -> void:
+	var layout: Gen2TouchLayout = _layout()
+	var before: Vector2 = layout.anchor(
+		Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_B
+	)
+	layout.set_anchor(
+		Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_A,
+		Vector2(0.5, 0.2), PORTRAIT.size,
+	)
+	assert_eq(
+		layout.anchor(Gen2TouchLayout.ORIENTATION_PORTRAIT, Gen2TouchLayout.GROUP_B), before
+	)
+	var rects: Dictionary = layout.button_rects(PORTRAIT)
+	assert_false(
+		(rects[Gen2Button.A] as Rect2).intersects(rects[Gen2Button.B] as Rect2),
+		"and each has a rectangle of its own"
 	)
 
 

--- a/tests/unit/test_world_bag_host.gd
+++ b/tests/unit/test_world_bag_host.gd
@@ -554,3 +554,24 @@ func test_a_full_mailbox_refuses_the_next_message() -> void:
 	assert_false(bool(sent["ok"]))
 	assert_eq(sent["reason"], &"mailbox_full")
 	assert_eq((_save.party[0] as Gen2SaveMon).item, FLOWER_MAIL)
+
+
+## `SwitchItemsInBag` committed: the caller works out the order and this writes
+## it, so the arrangement is in the save rather than in a screen.
+func test_a_reorder_writes_the_new_bag_order() -> void:
+	var result: Dictionary = Gen2WorldBagHost.reorder(
+		_world, _save, [FLOWER_MAIL, POTION], false, false
+	)
+	assert_true(bool(result["ok"]), str(result))
+	assert_eq(_world.state.items().keys(), [FLOWER_MAIL, KEY_ITEM, POTION])
+	assert_eq(_world.state.item_quantity(POTION), 5)
+
+
+## The pocket the move happened in is the only one that moves: a key item keeps
+## the position it held, the way its own packed array would.
+func test_a_reorder_leaves_the_quantities_and_the_other_pockets_alone() -> void:
+	assert_true(bool(Gen2WorldBagHost.reorder(
+		_world, _save, [FLOWER_MAIL, POTION], false, false
+	)["ok"]))
+	assert_eq(_world.state.item_quantity(KEY_ITEM), 1)
+	assert_eq(_world.state.item_quantity(FLOWER_MAIL), 1)

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -13,6 +13,7 @@ const ITEM_MASTER_BALL: int = 2
 const ITEM_BICYCLE: int = 3
 const ITEM_TM01: int = 4
 const ITEM_UNCLASSIFIED: int = 5
+const ITEM_ANTIDOTE: int = 6
 
 var _data: GameData = null
 
@@ -46,6 +47,13 @@ func before_each() -> void:
 				raw["name"] = "ITEM5"
 				raw["pocket"] = 0
 				raw["battle_menu"] = 0
+			## A second item-pocket row, so an order inside one pocket is
+			## observable at all.
+			ITEM_ANTIDOTE:
+				raw["name"] = "ANTIDOTE"
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
 			ITEM_TM01:
 				raw["name"] = "TM01"
 				raw["pocket"] = Gen2WorldPack.TYPE_TM_HM
@@ -325,3 +333,104 @@ func test_an_empty_pocket_read_without_cancel_is_empty() -> void:
 		Gen2WorldPack.list_rows(_data, Gen2WorldPack.TYPE_ITEM, items, 0, false).size(),
 		0
 	)
+
+
+## SwitchItemsInBag (engine/items/switch_items.asm). wSwitchItem holds the marked
+## row plus one so that zero means none; -1 is that same "none" here.
+func test_the_first_select_only_marks_the_row_the_cursor_is_on() -> void:
+	var answer: Dictionary = Gen2WorldPack.switch_items([10, 20, 30], -1, 2)
+	assert_eq(answer["order"], [10, 20, 30])
+	assert_eq(answer["held"], 2)
+
+
+## `.init` reads the cursor through ItemSwitch_GetNthItem, so the CANCEL row past
+## the last item marks nothing.
+func test_select_on_the_cancel_row_marks_nothing() -> void:
+	var answer: Dictionary = Gen2WorldPack.switch_items([10, 20, 30], -1, 3)
+	assert_eq(answer["held"], -1)
+
+
+## `.trivial`, checked before the terminator is read.
+func test_placing_an_item_on_its_own_row_clears_the_mark_and_moves_nothing() -> void:
+	var answer: Dictionary = Gen2WorldPack.switch_items([10, 20, 30], 1, 1)
+	assert_eq(answer["order"], [10, 20, 30])
+	assert_eq(answer["held"], -1)
+
+
+## `.above` and `.below` are one memmove each, which is a remove and an insert.
+func test_a_held_row_moves_down_to_the_cursor() -> void:
+	var answer: Dictionary = Gen2WorldPack.switch_items([10, 20, 30, 40], 0, 2)
+	assert_eq(answer["order"], [20, 30, 10, 40])
+	assert_eq(answer["held"], -1)
+
+
+func test_a_held_row_moves_up_to_the_cursor() -> void:
+	var answer: Dictionary = Gen2WorldPack.switch_items([10, 20, 30, 40], 3, 1)
+	assert_eq(answer["order"], [10, 40, 20, 30])
+	assert_eq(answer["held"], -1)
+
+
+## The `cp -1 / ret z` after `.trivial`: the mark survives a press on CANCEL, so
+## the next press on a real row still places the item.
+func test_a_press_on_cancel_keeps_the_mark_and_moves_nothing() -> void:
+	var answer: Dictionary = Gen2WorldPack.switch_items([10, 20, 30], 0, 3)
+	assert_eq(answer["order"], [10, 20, 30])
+	assert_eq(answer["held"], 0)
+
+
+## The cartridge has four packed arrays and this port one insertion-ordered map,
+## so a move inside a pocket permutes only the positions that pocket holds.
+func test_a_pocket_reorder_leaves_the_other_pockets_where_they_sit() -> void:
+	var owned: Dictionary = {
+		ITEM_POTION: 1, ITEM_MASTER_BALL: 1, ITEM_BICYCLE: 1, ITEM_TM01: 1,
+	}
+	assert_eq(
+		Gen2WorldPack.reordered_items(owned, [ITEM_BICYCLE, ITEM_POTION]),
+		[ITEM_BICYCLE, ITEM_MASTER_BALL, ITEM_POTION, ITEM_TM01]
+	)
+
+
+func test_a_reorder_naming_rows_the_map_does_not_hold_changes_nothing() -> void:
+	var owned: Dictionary = {ITEM_POTION: 1, ITEM_MASTER_BALL: 1}
+	assert_eq(
+		Gen2WorldPack.reordered_items(owned, [ITEM_POTION, ITEM_BICYCLE]),
+		[ITEM_POTION, ITEM_MASTER_BALL]
+	)
+
+
+## A cartridge pocket is a packed array ReceiveItem appends to, so the listing is
+## in the order the items were received rather than by item number.
+func test_a_pocket_lists_its_items_in_the_order_they_were_received() -> void:
+	var state := Gen2WorldState.new({}, {}, {})
+	state.apply_changes({}, {}, {"items": {ITEM_ANTIDOTE: 1}})
+	state.apply_changes({}, {}, {"items": {ITEM_POTION: 1}})
+	var rows: Array = (Gen2WorldPack.build(_data, state)[0] as Dictionary)["items"]
+	assert_eq([(rows[0] as Dictionary)["item"], (rows[1] as Dictionary)["item"]],
+		[ITEM_ANTIDOTE, ITEM_POTION])
+
+
+## The listing is what a reorder is for, so it follows the map's own key order.
+func test_a_reordered_map_lists_its_pocket_the_new_way() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_ANTIDOTE: 1, ITEM_POTION: 1})
+	var applied: Dictionary = state.apply_changes({}, {}, {
+		"item_order": [ITEM_POTION, ITEM_ANTIDOTE],
+	})
+	assert_true(bool(applied.get("changed", false)))
+	var rows: Array = (Gen2WorldPack.build(_data, state)[0] as Dictionary)["items"]
+	assert_eq([(rows[0] as Dictionary)["item"], (rows[1] as Dictionary)["item"]],
+		[ITEM_POTION, ITEM_ANTIDOTE])
+
+
+## _is_permutation: a list that dropped or repeated a row would change what is
+## owned rather than where it sits.
+func test_an_order_that_is_not_a_permutation_is_refused() -> void:
+	var state := Gen2WorldState.new({}, {}, {ITEM_ANTIDOTE: 1, ITEM_POTION: 1})
+	assert_eq(
+		state.apply_changes({}, {}, {"item_order": [ITEM_POTION, ITEM_POTION]}),
+		{"ok": false, "reason": &"invalid_item_order"}
+	)
+	assert_eq(
+		state.apply_changes({}, {}, {"item_order": [ITEM_POTION]}),
+		{"ok": false, "reason": &"invalid_item_order"}
+	)
+	assert_eq(state.items().keys(), [ITEM_ANTIDOTE, ITEM_POTION])

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -38,6 +38,15 @@ const WINDOW_SIZE := Vector2i(1152, 648)
 ## was a few frames before the presses.
 const SETTLE_FRAMES: int = 30
 
+## The Pokemon `wContestMon` is holding for the `contest_replace` stage. A
+## CATERPIE in the low levels, which is what a contest is full of.
+## The wild the contest catch is made on, and the one already held.
+const CONTEST_WILD_SPECIES: int = 13
+const CONTEST_WILD_LEVEL: int = 12
+const CONTEST_STOCK_SPECIES: int = 10
+const CONTEST_STOCK_LEVEL: int = 9
+const CONTEST_STOCK_MAX_HP: int = 27
+
 ## `BattlePack`'s rows for the `pack` stage: a potion, a Full Heal and an X
 ## Attack, which are one of each of `UseItem`'s three battle branches
 ## (constants/item_constants.asm).
@@ -65,7 +74,7 @@ const SHINY_LEVEL: int = 30
 ## The two stages that go through `start_world_battle` rather than a staged
 ## `_battle`, because the palette is chosen in `_init_battle_display` and only
 ## the world path runs it.
-const WORLD_STAGES: Array[String] = ["shiny", "normal", "prize"]
+const WORLD_STAGES: Array[String] = ["shiny", "normal", "prize", "contest_replace"]
 
 ## The `prize` stage's held item, AMULET_COIN (constants/item_constants.asm).
 ## `CheckAmuletCoin` doubles the reward off it, so the figure in the picture is
@@ -260,6 +269,47 @@ func _open() -> void:
 			_screen.finish()
 			_screen.advance()
 		push_error("the prize line was never reached")
+		return
+
+	## A Park Ball thrown and caught while `wContestMon` already holds one, which
+	## is the only way to `DisplayAlreadyCaughtText` and the comparison behind
+	## it. A wild through the world's own path, since a capture needs one; the
+	## result is written rather than rolled, because what is photographed is the
+	## page and a real throw would have to be repeated until it stuck.
+	if _stage == "contest_replace":
+		_screen.start_world_battle({"values": {
+			"kind": &"wild", "pokemon": CONTEST_WILD_SPECIES,
+			"level": CONTEST_WILD_LEVEL,
+			"battle_type": Gen2Battle.BATTLETYPE_CONTEST,
+		}})
+		_screen.set_capture_balls(
+			[Gen2WorldPartyHost.ITEM_PARK_BALL],
+			{Gen2WorldPartyHost.ITEM_PARK_BALL: Gen2WorldBugContest.BALLS}
+		)
+		_drain_to_menu()
+		_screen.begin_capture()
+		_screen.select_capture_ball(0)
+		_screen.throw_capture_ball()
+		_screen.complete_capture({
+			"ok": true, "contest": true, "caught": true, "wobbles": 3,
+			"ball": Gen2WorldPartyHost.ITEM_PARK_BALL,
+			"quantity": Gen2WorldBugContest.BALLS - 1,
+			"replace_offer": true,
+			"mon": Gen2WorldPartyHost.contest_mon_from(_screen.capture_target()),
+			"stock_species": CONTEST_STOCK_SPECIES,
+			"stock_level": CONTEST_STOCK_LEVEL,
+			"stock_max_hp": CONTEST_STOCK_MAX_HP,
+		})
+		## The throw's animation, then the shake lines and
+		## `DisplayAlreadyCaughtText`, each prompted past the way a player would.
+		for _press: int in 20:
+			_settle()
+			if String(_screen.battle_snapshot()["switch_stage"]) == "contest_replace":
+				break
+			_screen.finish()
+			_screen.advance()
+		_read_question()
+		_settle_icons()
 		return
 
 	if _stage in WORLD_STAGES:

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -9,7 +9,7 @@ extends SceneTree
 ## five visible rows and scroll past them, with a development party behind it so
 ## `use` and `give` reach `.Party`'s own list. Those two are the party menu
 ## `GiveItem` and every `.Party` item effect open, so what they photograph is
-## [Gen2PartyMenuPage] with the prompt that entrance writes. [presses] is a `u,d,l,r,a,b` list
+## [Gen2PartyMenuPage] with the prompt that entrance writes. [presses] is a `u,d,l,r,a,b,s` list
 ## driven into the real screen before the shot, so the picture is what the
 ## cartridge's own listing would show after those buttons.
 ##
@@ -22,7 +22,7 @@ const NEW_BARK_MAP: int = 7
 const BUTTONS: Dictionary = {
 	"u": Gen2Button.UP, "d": Gen2Button.DOWN,
 	"l": Gen2Button.LEFT, "r": Gen2Button.RIGHT,
-	"a": Gen2Button.A, "b": Gen2Button.B,
+	"a": Gen2Button.A, "b": Gen2Button.B, "s": Gen2Button.SELECT,
 }
 
 ## Which presses each pocket is reached by, since the pack opens on Items and

--- a/tools/preview_saves.gd
+++ b/tools/preview_saves.gd
@@ -1,8 +1,16 @@
 extends SceneTree
 
-## Photographs the save screen for a cached cartridge.
+## Photographs a window-resolution save-section screen for a cached cartridge.
 ##
-##   Godot --path . -s res://tools/preview_saves.gd -- <out.png> [light|dark]
+##   Godot --path . -s res://tools/preview_saves.gd -- <out.png> [light|dark] [WxH] [page]
+##
+## [page] is `saves`, `party`, `boxes` or `editor`, the four pages the save slots
+## lead to. They are one command because they are one section and share this
+## harness; each is its own scene.
+##
+## The size is what says whether a page is responsive, so it is an argument
+## rather than a constant: a phone portrait and a desktop window are the same
+## command twice.
 
 var _output: String = ""
 var _frames: int = 0
@@ -17,9 +25,14 @@ func _initialize() -> void:
 	var mode: String = args[1] if args.size() > 1 else "light"
 	var options: Gen2Options = Gen2OptionsStore.current()
 	options.ui_theme = StringName(mode)
-	DisplayServer.window_set_size(Vector2i(1280, 800))
-	root.set_content_scale_size(Vector2i(1280, 800))
-	root.size = Vector2i(1280, 800)
+	var window: Vector2i = Vector2i(1280, 800)
+	if args.size() > 2:
+		var parts: PackedStringArray = args[2].split("x")
+		if parts.size() == 2 and parts[0].is_valid_int() and parts[1].is_valid_int():
+			window = Vector2i(int(parts[0]), int(parts[1]))
+	DisplayServer.window_set_size(window)
+	root.set_content_scale_size(window)
+	root.size = window
 	# Autoloads are not global identifiers inside a tool script, and an absolute
 	# path does not resolve from outside the running scene, so the runtime is
 	# found on the root by name.
@@ -28,8 +41,24 @@ func _initialize() -> void:
 		var data: GameData = GameData.open(game_id)
 		if data != null:
 			runtime.call("select_game", game_id)
+			## The party, box and editor pages all read the runtime's selected
+			## slot, so a page other than the slot list needs one chosen first.
+			for row: Dictionary in Gen2SaveStore.slots_for(data.id, data.sha1, data):
+				if runtime.call("select_save_slot", data.id, int(row["slot"])):
+					break
 			break
-	root.add_child(load("res://game/save/save_screen.tscn").instantiate())
+	var page: String = args[3] if args.size() > 3 else "saves"
+	var scenes: Dictionary = {
+		"saves": "res://game/save/save_screen.tscn",
+		"party": "res://game/save/party_screen.tscn",
+		"boxes": "res://game/save/box_screen.tscn",
+		"editor": "res://game/save/save_editor_screen.tscn",
+	}
+	if not scenes.has(page):
+		push_error("Unknown page %s" % page)
+		quit(2)
+		return
+	root.add_child(load(String(scenes[page])).instantiate())
 
 
 func _process(_delta: float) -> bool:


### PR DESCRIPTION
Two things: a pack routine that was never built, and four reports about
the launcher's own screens.

## SELECT moves an item

`SwitchItemsInBag` had no implementation, so SELECT did nothing in the
pack or in the item PC. Two things were missing under it.

The listing sorted by item number, so the received order a cartridge
pocket keeps was thrown away before a reorder could show. Both listings
now read the item map's own key order, which is the order the items
arrived in.

And nothing could reorder a bag. `Gen2WorldState.apply_changes` takes
`item_order` and `pc_item_order`, each refused unless it names every row
exactly once. A quantity map compares equal whatever order it holds, so a
reorder has to be asked for by name or the transaction would call it no
change. `Gen2WorldBagHost.reorder` commits one through the same boundary
the toss and the mart go through.

`Gen2WorldPack.switch_items` is the routine: the first press marks a row,
the next A or SELECT places it, its own row and B both drop the mark, and
a press on CANCEL keeps it. While a row is held the pocket cannot be
cycled. The pack prints `AskItemMoveText` over its description box until
the item lands; the PC list prints nothing, as its own handler does.

The pack's pocket cycle also plays `SFX_SWITCH_POCKETS` now, which
nothing here did.

## The save pages on a phone

One seam under three of the four reports: a row of buttons was an
`HBoxContainer`, which has no way to be narrower than its contents. On a
390pt window the save slot panel was pushed wider than the screen and
everything past Import .sav, Delete included, was off it with nothing to
scroll it there. `Gen2LauncherUI.actions` already existed and already
said why; the save screen, the About page and the mod sources page now
use it.

The party page was drawn in a palette of its own with stock buttons. It
is a launcher page now: the shell, the theme, cards and buttons, with
each member's species, level, HP and status on a wrapping line.

The save editor said in its own comment that its look was a later pass.
This is it: the launcher palette, page margins, a scroll per tab, and
every row of controls wrapping.

A and B were one cluster on a fixed diagonal, so the on-screen controller
could not place them apart. They are two clusters now, each with its own
anchor per orientation. A layout arranged before the split is read once
and turned into the two anchors the pair already had.

One thing is left and is recorded rather than taken: the mods list keeps
each row's toggle, bin and chevron on one line by an earlier deliberate
decision, so a portrait phone truncates the mod's name. Changing that
decision needs the owner's eyes.


## The Bug Contest comparison

`BugContest_SetCaughtContestMon` says `DisplayAlreadyCaughtText`, draws
`DisplayCaughtContestMonStats` and asks over it. Only the two lines were said
here, so the question was answered blind. The page is the routine's own two
boxes, STOCK #MON above THIS #MON, each with a name, a level and a HEALTH
number, drawn as one image the way the party page is.

The question's box moved with it: `PlaceYesNoBox` is handed `lb bc, 14, 7`
here, not `OfferSwitch`'s `lb bc, 1, 7`, so it stands beside the THIS box
rather than over the STOCK one.

## Proof

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 3,934 of 3,934 |
| `tools/validate.gd -- all` | exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 16 badges each, 0 failures |
| Boot smoke, 30 s | clean |

Screens captured at 390x844 and 1280x800: save slots, party, save
editor, and the on-screen controller in both orientations.