### PR TITLE
Make the NRO icon with Godot rather than with the runner's ImageMagick

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,17 +420,14 @@ jobs:
           v="${{ needs.version.outputs.version }}"
           cp /tmp/switch/switch_release.elf switch_release.elf
           # An NRO icon is a 256x256 JPEG and nothing else; the repository's is
-          # a PNG, so it is converted here rather than committed twice.
-          # ImageMagick 7 renamed `convert` to `magick` and the runner image has
-          # carried one or the other for years, so both are tried by name.
-          if command -v magick >/dev/null; then
-            magick app_icon.png -resize 256x256! -quality 92 app_icon.jpg
-          elif command -v convert >/dev/null; then
-            convert app_icon.png -resize 256x256! -quality 92 app_icon.jpg
-          else
-            echo "::error::no ImageMagick on the runner; the NRO icon cannot be made"
-            exit 1
-          fi
+          # a PNG, so it is converted here rather than committed twice. Godot
+          # does it because Godot is already installed in this job and is the
+          # project's own tool: this step used to reach for whichever of
+          # `magick` and `convert` the runner image carried, and the 0.1.6 build
+          # failed when it carried neither.
+          GODOT_CAP=300 tools/ci_godot.sh "$GODOT" --headless --path . \
+            -s res://tools/make_nro_icon.gd -- "$PWD/app_icon.jpg"
+          [ -s app_icon.jpg ] || { echo "::error::the NRO icon is empty"; exit 1; }
           docker run --rm -v "$PWD:/w" -w /w devkitpro/devkita64:latest bash -c "
             set -euo pipefail
             nacptool --create pokerecomp '${{ github.repository_owner }}' '$v' control.nacp

--- a/tools/make_nro_icon.gd
+++ b/tools/make_nro_icon.gd
@@ -1,0 +1,58 @@
+extends SceneTree
+
+## Writes the 256x256 JPEG an NRO carries, out of the repository's own PNG.
+##
+##     Godot --headless --path . -s res://tools/make_nro_icon.gd -- <out.jpg>
+##
+## `elf2nro --icon=` takes a JPEG of exactly that size and nothing else, and the
+## repository's icon is a 1024 PNG, so one is made from the other at package
+## time rather than the same picture being committed twice.
+##
+## Godot does it rather than ImageMagick because Godot is already installed
+## wherever this runs and is the project's own tool: the release job used
+## whichever of `magick` and `convert` the runner image happened to carry, and
+## the 0.1.6 build failed when it carried neither.
+
+const SOURCE: String = "res://app_icon.png"
+const SIDE: int = 256
+## `elf2nro` reads the file as it is given, so the quality is this end's choice.
+## 92 keeps the icon clean at the size hbmenu draws it and stays well under the
+## NRO header's own room for it.
+const QUALITY: float = 0.92
+
+
+func _init() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	if args.is_empty():
+		push_error("Usage: make_nro_icon.gd -- <out.jpg>")
+		quit(1)
+		return
+	var image: Image = _load()
+	if image == null:
+		push_error("%s could not be read" % SOURCE)
+		quit(1)
+		return
+	## Exactly square, the way `-resize 256x256!` was: the source is square
+	## already, so nothing is distorted and a source that stopped being square
+	## would still produce a file the header accepts.
+	image.resize(SIDE, SIDE, Image.INTERPOLATE_LANCZOS)
+	## A JPEG has no alpha, and saving one straight from RGBA leaves the
+	## transparent corners black on some decoders.
+	image.convert(Image.FORMAT_RGB8)
+	var error: int = image.save_jpg(args[0], QUALITY)
+	if error != OK:
+		push_error("could not write %s (error %d)" % [args[0], error])
+		quit(1)
+		return
+	print("Wrote %s, %dx%d" % [args[0], SIDE, SIDE])
+	quit()
+
+
+## The imported texture where there is one, and the file itself where the
+## project has not been imported: this runs on a release job either way round.
+func _load() -> Image:
+	if ResourceLoader.exists(SOURCE):
+		var texture: Texture2D = load(SOURCE) as Texture2D
+		if texture != null:
+			return texture.get_image()
+	return Image.load_from_file(ProjectSettings.globalize_path(SOURCE))


### PR DESCRIPTION
The 0.1.6 release failed on the Switch job: the step that turns the repository's 1024 PNG into the 256x256 JPEG `elf2nro` wants used whichever of `magick` and `convert` the runner image carried, and it now carries neither.

`tools/make_nro_icon.gd` does it instead. Godot is already installed in that job and is the project's own tool, so the release stops depending on what a runner image ships. It converts to RGB8 before saving, since a JPEG has no alpha and the PNG's transparent corners came out black on some decoders.

Verified locally: 256x256, RGB, from the real `app_icon.png`.

Swept the workflows for the same shape. This was the only step whose success depended on a tool the runner image happened to have; `tools/ci_godot.sh`'s `gdb` is the other `command -v` and already carries on without one.