### PR TITLE
Move to Godot 4.8.dev4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  GODOT_VERSION: 4.8-dev3
+  GODOT_VERSION: 4.8-dev4
 
 jobs:
   tests:

--- a/.github/workflows/export-templates.yml
+++ b/.github/workflows/export-templates.yml
@@ -38,15 +38,15 @@ on:
         type: string
 
 env:
-  GODOT_VERSION: 4.8-dev3
+  GODOT_VERSION: 4.8-dev4
   # A development snapshot is tagged nowhere in the engine repository, so the
   # pin is the commit the stock templates name themselves after:
-  # `4.8.dev3.official.51105ccbe`. The build checks that it still agrees.
-  GODOT_COMMIT: 51105ccbe58381774ecd7a7486d564b202a5192e
+  # `4.8.dev4.official.b56a91878`. The build checks that it still agrees.
+  GODOT_COMMIT: b56a91878e7c94977e4af978968e41d0670c0a8b
   # Nintendo ships no Godot platform and upstream carries none, so the Switch
   # template is built from a fork of the same pin that adds `platform/nx`.
   GODOT_NX_REMOTE: https://github.com/Decryptu/godot.git
-  GODOT_NX_COMMIT: ada239b4354f12b38a23ab8f6c6b4fa22000485f
+  GODOT_NX_COMMIT: e25f31c1248c0955994e865a80d94d32520a53b9
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,12 @@ permissions:
   contents: write
 
 env:
-  GODOT_VERSION: 4.8-dev3
-  GODOT_TEMPLATE_DIR: 4.8.dev3
+  GODOT_VERSION: 4.8-dev4
+  GODOT_TEMPLATE_DIR: 4.8.dev4
   # The engine the iOS plugin compiles against. It must be the commit
   # `export-templates.yml` builds the templates from, since the plugin is linked
   # into them and the two have to agree about what a header declares.
-  GODOT_COMMIT: 51105ccbe58381774ecd7a7486d564b202a5192e
+  GODOT_COMMIT: b56a91878e7c94977e4af978968e41d0670c0a8b
 
 jobs:
   version:
@@ -91,7 +91,7 @@ jobs:
           curl -fsSL "$base/Godot_v${GODOT_VERSION}_export_templates.tpz" -o /tmp/templates.tpz
           unzip -q /tmp/templates.tpz -d /tmp/tpz
           # The directory is named by version.txt inside the archive, never by
-          # the release tag: 4.8.dev3 rather than 4.8-dev3.
+          # the release tag: 4.8.dev4 rather than 4.8-dev4.
           mkdir -p "$HOME/.local/share/godot/export_templates/${GODOT_TEMPLATE_DIR}"
           cp -R /tmp/tpz/templates/. "$HOME/.local/share/godot/export_templates/${GODOT_TEMPLATE_DIR}/"
 
@@ -130,6 +130,23 @@ jobs:
           export/android/android_sdk_path = "$ANDROID_SDK_ROOT"
           export/android/java_sdk_path = "$JAVA_HOME"
           EOF
+
+      # 4.8.dev4 refuses the export before gradle runs if any package in its own
+      # list is absent, and a runner image carries whichever NDK it was built
+      # with rather than this one. `sdkmanager` is a no-op for what is already
+      # there, so the whole list is asked for rather than the one that moved.
+      - name: Install the SDK packages the exporter insists on
+        run: |
+          set -euo pipefail
+          # The image names the directory by the tools' own version, not always
+          # `latest`, so the binary is found rather than assumed.
+          sdkmanager=$(find "$ANDROID_SDK_ROOT/cmdline-tools" -name sdkmanager -type f | head -1)
+          [ -n "$sdkmanager" ] || { echo "::error::no sdkmanager in the image"; exit 1; }
+          yes | "$sdkmanager" --licenses > /dev/null
+          "$sdkmanager" "platform-tools" "build-tools;36.1.0" "platforms;android-36" \
+            "ndk;29.0.14206865" "cmake;3.22.1"
+          [ -d "$ANDROID_SDK_ROOT/ndk/29.0.14206865" ] || {
+            echo "::error::the NDK the exporter checks for is still missing"; exit 1; }
 
       # `addons/second_screen/bin/` is gitignored, so a checkout has no AAR and
       # the Android exporter answers a plugin with no binary the way the iOS one

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Godot-4.8.dev3-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="Godot 4.8.dev3">
+  <img src="https://img.shields.io/badge/Godot-4.8.dev4-478CBF?style=flat-square&logo=godotengine&logoColor=white" alt="Godot 4.8.dev4">
   <img src="https://img.shields.io/badge/GDScript-355570?style=flat-square&logo=godotengine&logoColor=white" alt="GDScript">
   <img src="https://img.shields.io/badge/platforms-Windows%20%C2%B7%20macOS%20%C2%B7%20Linux%20%C2%B7%20Android%20%C2%B7%20iOS%20%C2%B7%20Switch-8f8c98?style=flat-square" alt="Platforms">
   <img src="https://img.shields.io/badge/arm64-Windows%20%C2%B7%20Linux%20%C2%B7%20Apple-8f8c98?style=flat-square" alt="arm64">

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -4317,14 +4317,14 @@ func _draw_contest_stats() -> void:
 ## where its `hlcoord`s put them, measured from the box rather than the screen.
 func _draw_contest_box(
 	indices: PackedByteArray, width: int, top: int,
-	title: String, name: String, level: int, max_hp: int
+	title: String, mon_name: String, level: int, max_hp: int
 ) -> void:
 	var tile: int = Gen2Font.TILE
 	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
 		CONTEST_STATS_LEFT, top, CONTEST_STATS_RIGHT, top + CONTEST_STATS_HEIGHT, 0
 	)
 	_menu_page.draw(box, [], -1, indices, width, "", 0, [
-		{"text": name, "at": CONTEST_NAME_AT + Vector2i(0, top)},
+		{"text": mon_name, "at": CONTEST_NAME_AT + Vector2i(0, top)},
 		{"text": CONTEST_HEALTH, "at": CONTEST_HEALTH_AT + Vector2i(0, top)},
 		{
 			"text": String("%d" % max_hp).lpad(CONTEST_HP_DIGITS, " "),

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -276,7 +276,7 @@ static func preferred_width(control: Control) -> float:
 
 
 ## Label on the left, control on the right, which is every settings line.
-static func field(theme: Gen2LauncherTheme, text: String, control: Control) -> Container:
+static func field(theme: Gen2LauncherTheme, text: String, control: Control) -> Control:
 	var line := FieldRow.new()
 	var label: Label = body(theme, text)
 	label.size_flags_vertical = Control.SIZE_SHRINK_CENTER
@@ -293,9 +293,32 @@ static func field(theme: Gen2LauncherTheme, text: String, control: Control) -> C
 ## cut off rather than reachable, and a settings row is exactly the shape that
 ## outgrows a portrait phone: the label wants its whole text and the control
 ## carries its own minimum width. Stacking is what keeps the control on screen.
-class FieldRow extends Container:
+##
+## A [Container] is not usable here: from 4.8.dev4 the engine answers a
+## container's minimum size itself and never calls a script's
+## [method Control._get_minimum_size], and asking for less than both halves is
+## the whole point of this row.
+class FieldRow extends Control:
+	var _pending: bool = false
+
 	func _init() -> void:
-		resized.connect(update_minimum_size)
+		resized.connect(_queue_layout)
+
+	func _ready() -> void:
+		for half: Control in _halves():
+			half.minimum_size_changed.connect(_queue_layout)
+			half.visibility_changed.connect(_queue_layout)
+		_queue_layout()
+
+	## What [method Container.queue_sort] does: at most one layout per frame,
+	## so a half whose minimum size answers the width it was just given cannot
+	## drive this in circles.
+	func _queue_layout() -> void:
+		update_minimum_size()
+		if _pending:
+			return
+		_pending = true
+		_layout.call_deferred()
 
 	func _halves() -> Array[Control]:
 		var found: Array[Control] = []
@@ -325,25 +348,33 @@ class FieldRow extends Container:
 			return Vector2(control.x, label.y + float(GAP_XS) + control.y)
 		return Vector2(control.x, maxf(label.y, control.y))
 
-	func _notification(what: int) -> void:
-		if what != NOTIFICATION_SORT_CHILDREN:
-			return
+	func _layout() -> void:
+		_pending = false
 		var halves: Array[Control] = _halves()
 		if halves.size() < 2:
 			return
 		var label: Vector2 = halves[0].get_combined_minimum_size()
 		if _stacks(halves):
-			fit_child_in_rect(halves[0], Rect2(0.0, 0.0, size.x, label.y))
-			fit_child_in_rect(halves[1], Rect2(
+			_place(halves[0], Rect2(0.0, 0.0, size.x, label.y))
+			_place(halves[1], Rect2(
 				0.0, label.y + float(GAP_XS), size.x, size.y - label.y - float(GAP_XS)
 			))
 			return
 		var control_width: float = Gen2LauncherUI.preferred_width(halves[1])
 		var label_width: float = maxf(size.x - control_width - float(GAP_MD), 0.0)
-		fit_child_in_rect(halves[0], Rect2(0.0, 0.0, label_width, size.y))
-		fit_child_in_rect(halves[1], Rect2(
-			label_width + float(GAP_MD), 0.0, control_width, size.y
-		))
+		_place(halves[0], Rect2(0.0, 0.0, label_width, size.y))
+		_place(halves[1], Rect2(label_width + float(GAP_MD), 0.0, control_width, size.y))
+
+	## [method Container.fit_child_in_rect] for the flags both halves carry:
+	## the whole width given, however narrow, and their own height centred in
+	## it. The width is not clamped to the minimum, which is what lets a long
+	## label be squeezed rather than widening the page.
+	static func _place(half: Control, rect: Rect2) -> void:
+		var high: float = half.get_combined_minimum_size().y
+		half.position = Vector2(
+			rect.position.x, rect.position.y + floorf((rect.size.y - high) / 2.0)
+		)
+		half.size = Vector2(rect.size.x, high)
 
 
 ## A row of choices in one track, the chosen one filled.

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -254,13 +254,13 @@ static func switch_items(order: Array, held: int, cursor: int) -> Dictionary:
 	return {"order": moved, "held": -1}
 
 
-## The whole item map with one pocket's rows put in [param pocket_order], for
+## The whole item map with one pocket's rows put in [param wanted_order], for
 ## [method Gen2WorldState.apply_changes]' `item_order`. The cartridge has four
 ## packed arrays and this port one insertion-ordered map, so a move inside a
 ## pocket permutes only the positions that pocket already occupies.
-static func reordered_items(owned: Dictionary, pocket_order: Array) -> Array[int]:
+static func reordered_items(owned: Dictionary, wanted_order: Array) -> Array[int]:
 	var wanted: Array[int] = []
-	for entry: Variant in pocket_order:
+	for entry: Variant in wanted_order:
 		wanted.append(int(entry))
 	var result: Array[int] = []
 	var occupied: int = 0

--- a/tests/unit/test_export_presets.gd
+++ b/tests/unit/test_export_presets.gd
@@ -89,6 +89,43 @@ func test_a_published_release_is_announced_without_committing_the_webhook() -> v
 	assert_false(workflow.contains("discord.com/api/webhooks/"), "the credential stays in secrets")
 
 
+## Four files name the engine, and a release mixes two engines the moment they
+## disagree: the templates come from one commit and the iOS plugin linked into
+## them from another. The 4.8.dev4 bump left `release.yml` behind by itself.
+func test_every_file_that_names_the_engine_names_the_same_one() -> void:
+	var templates: String = FileAccess.get_file_as_string(
+		"res://.github/workflows/export-templates.yml"
+	)
+	var release: String = FileAccess.get_file_as_string("res://.github/workflows/release.yml")
+	var ci: String = FileAccess.get_file_as_string("res://.github/workflows/ci.yml")
+	var android: String = FileAccess.get_file_as_string("res://tools/build_android_plugin.sh")
+	var readme: String = FileAccess.get_file_as_string("res://README.md")
+	var tag: String = _engine_pin(templates, "GODOT_VERSION")
+	var commit: String = _engine_pin(templates, "GODOT_COMMIT")
+	# The tag and the directory the templates unpack into differ by one
+	# character, which is what `release.yml` says and DEVICES.md repeats.
+	var directory: String = tag.replace("-", ".")
+	assert_ne(tag, "", "export-templates.yml names a Godot release")
+	assert_ne(commit, "", "export-templates.yml names a Godot commit")
+	assert_eq(_engine_pin(release, "GODOT_VERSION"), tag)
+	assert_eq(_engine_pin(release, "GODOT_COMMIT"), commit)
+	assert_eq(_engine_pin(release, "GODOT_TEMPLATE_DIR"), directory)
+	assert_eq(_engine_pin(ci, "GODOT_VERSION"), tag)
+	assert_string_contains(android, 'GODOT_TAG="${GODOT_TAG:-%s}"' % tag)
+	assert_string_contains(
+		android, 'GODOT_LIB_VERSION="${GODOT_LIB_VERSION:-%s}"' % directory
+	)
+	assert_string_contains(readme, "Godot-%s-" % directory)
+
+
+## One `key: value` from a workflow's own `env:` block, which is two spaces in.
+static func _engine_pin(workflow: String, key: String) -> String:
+	for line: String in workflow.split("\n"):
+		if line.begins_with("  %s: " % key):
+			return line.split(": ", true, 1)[1].strip_edges()
+	return ""
+
+
 ## Android refuses an in-place update whose version code did not rise, so the
 ## code is a function of the version rather than a number bumped by hand.
 func test_the_android_version_code_derives_from_the_app_version() -> void:

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -185,7 +185,7 @@ func _scripts_under(root: String) -> Array[String]:
 func test_a_settings_row_stacks_rather_than_running_off_a_narrow_page() -> void:
 	var choices: Array = ["Windowed", "Fullscreen", "Borderless"]
 	var control: Control = Gen2LauncherUI.segmented(_light, choices, 0, func(_i: int) -> void: pass)
-	var row: Container = Gen2LauncherUI.field(_light, "Window", control)
+	var row: Control = Gen2LauncherUI.field(_light, "Window", control)
 	var host := Control.new()
 	add_child_autofree(host)
 	host.add_child(row)

--- a/tools/build_android_plugin.sh
+++ b/tools/build_android_plugin.sh
@@ -17,8 +17,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLUGIN="$ROOT/addons/second_screen"
 # The engine pin, which is the release the Android library is taken from. Bump
 # with the pin in DEVICES.md.
-GODOT_TAG="${GODOT_TAG:-4.8-dev3}"
-GODOT_LIB_VERSION="${GODOT_LIB_VERSION:-4.8.dev3}"
+GODOT_TAG="${GODOT_TAG:-4.8-dev4}"
+GODOT_LIB_VERSION="${GODOT_LIB_VERSION:-4.8.dev4}"
 # Built through a wrapper at a pinned Gradle rather than whatever gradle is on
 # the machine: 9.6 removed an internal API the Android plugin below still uses,
 # and a CI runner picking up 9.7 failed a release while this machine's 9.5

--- a/tools/make_nro_icon.gd.uid
+++ b/tools/make_nro_icon.gd.uid
@@ -1,0 +1,1 @@
+uid://dtwydgy2s31fk


### PR DESCRIPTION
The editor moved to 4.8.dev4, so the pin moves with it: the three workflows, the
Android plugin script and the README badge. The Switch fork is rebased onto the
same snapshot and rebuilt.

## What the snapshot broke

`Container::get_minimum_size` is new in dev4 (upstream `14dd3c714e`, added for
the `SIZE_MAXIMIZE` flag). It overrides `Control`'s and answers max-of-children
without ever reaching the script virtual, so a GDScript `_get_minimum_size` on a
container subclass is now dead code and nothing says so.

A settings row is the one place here that had one. It asks for less than its two
halves on purpose, so that a label wider than its control cannot widen the page
it sits in. Measured by the engine's rule instead, the row came out too short: at
a phone width the stacked control was centred into a rectangle smaller than
itself and rode up over its label.

`FieldRow` is a plain `Control` now. It queues one layout per frame the way
`queue_sort` does, and places its two halves the way `fit_child_in_rect` did for
the flags they carry. The settings page is pixel for pixel what dev3 drew, both
at 1280 wide and at 390.

The exporter also refuses an Android build before gradle starts unless the SDK
carries the exact package list it names, whatever the build links. A runner image
ships whichever NDK it was built with, so the release workflow installs the list
first.

`release.yml` carried its own copy of the engine commit and it was left behind by
hand on the last bump, so a test now holds every file that names the engine to
one answer.

## Proof

| Check | Result |
|---|---|
| GUT, unit tier | 3400 tests, 3400 passing |
| GUT, with scene integration | 3936 tests, 3936 passing |
| `validate.gd -- all` | exit 0, three cartridges |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 43, 43 and 44 steps, all clean |
| GDScript analyser | 0 warnings in 591 scripts |
| Settings page, 1280 and 390 wide | identical to dev3, pixel for pixel |
| macOS, Linux, Windows, Android, iOS exports | all clean on the dev4 templates |
| iOS | `** BUILD SUCCEEDED **`, 33 MB unsigned IPA, both audits silent |
| Switch template | builds in 4m22s, and the NRO boots with 0 errors |

Two parameters shadowing names the analyser can see are renamed, and the UID the
Switch icon tool was missing is committed.