### PR TITLE
Give a quiet button a shape, and keep the cartridge options over the carousel

### DIFF
--- a/game/launcher/launcher_button.gd
+++ b/game/launcher/launcher_button.gd
@@ -12,7 +12,9 @@ enum Variant {
 	PRIMARY,
 	## A chip that fills with the accent when it is reached.
 	NEUTRAL,
-	## No fill until hovered. Rows of these read as labels.
+	## A hairline and nothing else until it is reached. The outline is what says
+	## a control rather than a caption: without one "Which bugs..." was read as
+	## the line of text above it.
 	QUIET,
 	## Quiet, but standing on the toast's chip rather than on the page. The
 	## page's own muted ink is all but invisible against a surface that is the
@@ -147,6 +149,7 @@ func repaint() -> void:
 			ink = _theme.on_accent
 		Variant.QUIET:
 			fill = _theme.accent_wash(0.13) if _active else Color(0, 0, 0, 0)
+			border = _theme.accent_wash(0.45) if _active else _theme.line
 			ink = _theme.accent if _active else _theme.muted
 		Variant.ON_CHIP:
 			fill = _theme.with_alpha(_theme.on_surface, 0.16) if reached else Color(0, 0, 0, 0)

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -164,6 +164,9 @@ func _build() -> void:
 	var listing: Gen2LauncherButton = Gen2LauncherButton.create(
 		_theme, "Which bugs...", Gen2LauncherButton.Variant.QUIET
 	)
+	# Wide as its own words, not as the card: a secondary action stretched from
+	# edge to edge reads as a field to type in rather than something to press.
+	listing.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 	listing.pressed.connect(_open_rules_sheet)
 	rules.add_child(listing)
 	_refresh_rules()

--- a/game/launcher/shelf_page.gd
+++ b/game/launcher/shelf_page.gd
@@ -13,6 +13,14 @@ signal manage_requested(game_id: StringName)
 ## The shell paints its backdrop for the selected cartridge.
 signal selection_changed(game_id: StringName)
 
+## How much of the stage's height the band above the carousel may cost. The band
+## is reserved rather than found, so a short window pays for it out of the
+## cartridge. Past this share the cartridge has given up more than the button is
+## worth and the button goes to the corner instead. A flat height cannot answer
+## this: 600 px cornered the button on a 1920x600 window where the cartridge
+## still had 130 px to spare below it.
+const MANAGE_BAND_SHARE: float = 0.22
+
 var _theme: Gen2LauncherTheme = null
 var _stage: Gen2CartridgeStage = null
 var _manage: Gen2LauncherButton = null
@@ -105,22 +113,35 @@ func _action_side() -> float:
 	return Gen2LauncherUI.TOUCH_TARGET if _compact else Gen2LauncherButton.DOCK_SIDE
 
 
+## Whether a stage of [param stage_size] sends the button to its corner rather
+## than reserving [param band] above the carousel for it. Separate from the
+## placement because the placement needs a real window behind it and this rule
+## is the whole of what went wrong.
+static func corners_manage(stage_size: Vector2, band: float) -> bool:
+	return stage_size.x > stage_size.y and band > stage_size.y * MANAGE_BAND_SHARE
+
+
 func _place_manage() -> void:
 	if _stage == null or _manage == null:
 		return
 	var card: Gen2Cartridge = _stage.selected_cartridge()
 	if card == null:
 		return
-	var landscape: bool = _stage.size.x > _stage.size.y and _stage.size.y < 600.0
-	var side: float = Gen2LauncherUI.TOUCH_TARGET if landscape else _action_side()
+	var band: float = _action_side() + Gen2LauncherUI.GAP_LG
+	var cornered: bool = corners_manage(_stage.size, band)
+	var side: float = Gen2LauncherUI.TOUCH_TARGET if cornered else _action_side()
 	if not is_equal_approx(_manage.size.x, side):
 		_manage.set_side(side)
-	var inset: float = 0.0 if landscape or not _manage.visible else side + Gen2LauncherUI.GAP_LG
+	var inset: float = 0.0 if cornered or not _manage.visible else side + Gen2LauncherUI.GAP_LG
 	if not is_equal_approx(_stage.top_inset, inset):
 		_stage.set_top_inset(inset)
 		return
-	if landscape:
-		_manage.position = Vector2(_stage.size.x - side, 0.0)
+	if cornered:
+		# Clear of the edge, because a disc flush into the corner reads as
+		# something that slipped rather than something placed there.
+		_manage.position = Vector2(
+			_stage.size.x - side - Gen2LauncherUI.GAP_MD, float(Gen2LauncherUI.GAP_MD)
+		)
 		_stage.move_child(_manage, _stage.get_child_count() - 1)
 		return
 	var gap: float = Gen2LauncherUI.GAP_MD + card.size.x * 0.05

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -588,6 +588,28 @@ func test_a_crashed_session_is_reported_at_the_next_launch() -> void:
 	)
 
 
+## A wide window is not a short one. The band above the carousel used to be
+## given up on a flat 600 px of stage height, which sent the button to the top
+## right corner of a 1920x600 window where the cartridge still had 130 px to
+## spare underneath it.
+func test_the_cartridge_options_button_only_leaves_the_carousel_when_the_stage_is_short() -> void:
+	var desktop: float = Gen2LauncherButton.DOCK_SIDE + Gen2LauncherUI.GAP_LG
+	var touch: float = Gen2LauncherUI.TOUCH_TARGET + Gen2LauncherUI.GAP_LG
+	for stage: Vector2 in [Vector2(1860, 539), Vector2(2340, 559), Vector2(1220, 739)]:
+		assert_false(
+			Gen2ShelfPage.corners_manage(stage, desktop),
+			"a %s stage has the room" % stage,
+		)
+	assert_false(Gen2ShelfPage.corners_manage(Vector2(812, 335), touch), "a phone held over")
+	# Tall is never cornered, whatever the band costs: the button is above the
+	# carousel on every portrait window and that is where a thumb expects it.
+	assert_false(Gen2ShelfPage.corners_manage(Vector2(390, 700), touch))
+	# Short enough that the band would come out of the cartridge rather than out
+	# of the space around it.
+	assert_true(Gen2ShelfPage.corners_manage(Vector2(1240, 240), touch))
+	assert_true(Gen2ShelfPage.corners_manage(Vector2(1240, 300), desktop))
+
+
 func _open_launcher_keeping_the_marker() -> void:
 	if is_instance_valid(_launcher):
 		_launcher.free()

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -583,7 +583,12 @@ func test_landscape_keeps_at_least_two_fifths_of_the_stage_for_the_cartridge() -
 		var card: Gen2Cartridge = stage.selected_cartridge()
 		assert_gte(card.size.y, stage.size.y * 0.4)
 		assert_false(card.get_rect().intersects(page._manage.get_rect()))
-		assert_eq(page._manage.position.y, 0.0)
+		# Wherever it lands, it lands on the stage: a disc half over the edge
+		# is a disc half missing.
+		assert_true(
+			Rect2(Vector2.ZERO, stage.size).encloses(page._manage.get_rect()),
+			"the button is on the stage at %s" % dimensions,
+		)
 
 
 func _finger_touch(at: Vector2, down: bool) -> InputEventScreenTouch:


### PR DESCRIPTION
Two things the owner reported on the launcher.

## "Which bugs..." did not look like a button

The `QUIET` variant painted no fill and no outline at rest, only muted ink, so
the button under the Bugs row read as a caption of the line above it. Its own
comment already promised a fill until hovered, which the code never did: only
the active state was ever drawn.

It carries the theme's hairline now, which fixes every other quiet button with
it: Change on each key-binding row, Reset controls, and Back to Current in the
bugs sheet. "Which bugs..." is also only as wide as its own words, because a
secondary action stretched across the whole card reads as a field to type in
rather than something to press.

## The cartridge options button left the carousel on a wide window

It chose between sitting over the carousel and sitting in the corner on a flat
rule: wider than tall, and under 600 px of stage height. A 1920x600 window
gives a 539 px stage, so the button went to the top right corner while the
cartridge still had 130 px of empty space underneath it.

The band above the carousel is reserved rather than found, so the honest
question is what it costs. It goes to the corner only where that band would
take more than a fifth of the stage height, and it stands clear of the edge
when it does, rather than flush into it.

## Proof

Measured inside a real launcher window, the button's bottom clears the
cartridge's top every time:

| Window | Stage | Clearance |
|---|---|---|
| 1920x600 | 1860x539 | 27 px |
| 1280x800 | 1220x739 | 33 px |
| 2400x620 | 2340x559 | 28 px |
| 844x390 | 812x335 | 22 px |

| Check | Result |
|---|---|
| GUT, unit tier | 3401 tests, 3401 passing |
| GUT, with scene integration | 3938 tests, 3938 passing |
| GDScript analyser over `game/launcher` and `tests/unit` | 0 warnings in 157 scripts |

The placement rule is a static function so it can be tested without a window
behind it, and the new test was run against the old 600 px rule first to check
it actually fails on it. One assertion in `test_launcher_ui.gd` pinned the
cornered button to `y == 0`; it now asserts what the test is about, which is
that the button lands on the stage and never over the cartridge.