### PR TITLE
Draw the fly map's own label, and end a phone call the way the cartridge does

### DIFF
--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -255,8 +255,12 @@ func _pack_bundle(directory: String) -> Dictionary:
 	if _pack(packer, "report.txt", report().to_utf8_buffer()):
 		written += 1
 	for file: String in log_files():
-		var bytes: PackedByteArray = FileAccess.get_file_as_bytes("%s/%s" % [DIRECTORY, file])
-		if not bytes.is_empty() and _pack(packer, "logs/%s" % file, bytes):
+		# Empty is a length, not a failure: a session that logged nothing still
+		# rotated a file, and dropping it here left `files` disagreeing with
+		# what [method log_files] named.
+		var full: String = "%s/%s" % [DIRECTORY, file]
+		if FileAccess.file_exists(full) \
+			and _pack(packer, "logs/%s" % file, FileAccess.get_file_as_bytes(full)):
 			written += 1
 	packer.close()
 	return {"ok": true, "message": "", "path": path, "files": written}

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -82,7 +82,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 96
+const FORMAT_VERSION: int = 97
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -970,6 +970,10 @@ static func verify_town_map(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if not bool(nest_check["ok"]):
 		return nest_check
 
+	var label_check: Dictionary = verify_fly_map_label(rom, layout)
+	if not bool(label_check["ok"]):
+		return label_check
+
 	var cards: Dictionary = read_pokegear_cards(rom, layout)
 	if cards.size() != RomLayout.POKEGEAR_CARD_ORDER.size():
 		return {
@@ -1053,6 +1057,36 @@ static func verify_dex_nest_icon(rom: RomFile, layout: Dictionary) -> Dictionary
 					"ok": false,
 					"message": "Dex nest icon row %d is not symmetric." % row,
 				}
+	return {"ok": true, "message": ""}
+
+
+## `FlyMapLabelBorderGFX`, six 1bpp tiles behind the nest icon with no header of
+## their own, so they are identified by their own symmetry: the four corners are
+## one corner mirrored across each axis, and the two arrow tiles are equal and
+## symmetric about their own middle row. Byte identical on all three cartridges.
+static func verify_fly_map_label(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = RomLayout.fly_map_label_offset(layout)
+	var bytes: int = RomLayout.FLY_MAP_LABEL_TILES * Gen2Tiles.TILE_1BPP_BYTES
+	if not rom.in_bounds(at, bytes):
+		return {"ok": false, "message": "The fly map label border is outside the cartridge."}
+	var tiles: Array[PackedByteArray] = []
+	for tile: int in RomLayout.FLY_MAP_LABEL_TILES:
+		var rows := PackedByteArray()
+		for row: int in Gen2Tiles.TILE_HEIGHT:
+			rows.append(rom.u8(at + tile * Gen2Tiles.TILE_1BPP_BYTES + row))
+		tiles.append(rows)
+	for row: int in Gen2Tiles.TILE_HEIGHT:
+		if _reverse_byte(tiles[0][row]) != tiles[1][row] \
+			or tiles[0][Gen2Tiles.TILE_HEIGHT - 1 - row] != tiles[2][row] \
+			or tiles[1][Gen2Tiles.TILE_HEIGHT - 1 - row] != tiles[3][row] \
+			or tiles[4][row] != tiles[5][row] \
+			or tiles[4][Gen2Tiles.TILE_HEIGHT - 1 - row] != tiles[4][row]:
+			return {
+				"ok": false,
+				"message": "Fly map label row %d is not the border's own shape." % row,
+			}
+	if tiles[0].count(0) == Gen2Tiles.TILE_HEIGHT or tiles[4].count(0) == Gen2Tiles.TILE_HEIGHT:
+		return {"ok": false, "message": "The fly map label border is blank."}
 	return {"ok": true, "message": ""}
 
 
@@ -6277,6 +6311,16 @@ func _import_town_map_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 		if not RomCache.write_indices(RomCache.tile_path(directory, name), indices):
 			return {}
 		out[name] = _strip_sheet_entry(tiles)
+	# `_FlyMap`'s own `Request1bpp`, which lands over the first six Pokegear
+	# tiles and so is a sheet of its own rather than part of the run above.
+	var label: PackedByteArray = Gen2Tiles.decode_1bpp_strip(
+		rom.bytes(), RomLayout.fly_map_label_offset(layout), RomLayout.FLY_MAP_LABEL_TILES
+	)
+	if not RomCache.write_indices(
+		RomCache.tile_path(directory, "fly_map_label"), label
+	):
+		return {}
+	out["fly_map_label"] = _strip_sheet_entry(RomLayout.FLY_MAP_LABEL_TILES)
 	return out
 
 

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -958,6 +958,13 @@ const TOWN_MAP_REGION_BYTES: int = TOWN_MAP_REGION_CELLS + 1
 ## `KantoMap`, so the region map locates it rather than a fourth offset.
 const DEX_NEST_ICON_TILES: int = 1
 
+## `FlyMapLabelBorderGFX`, the six 1bpp tiles `_FlyMap` loads over `PokegearGFX`
+## at `vTiles2 tile $30`: the bubble's four corners, its up/down arrow and one
+## spare. Uncompressed and directly behind `PokedexNestIconGFX`, so the region
+## map locates it too.
+const FLY_MAP_LABEL_TILES: int = 6
+const FLY_MAP_LABEL_FIRST_TILE: int = POKEGEAR_FIRST_TILE
+
 ## `RadioTilemapRLE`, `PhoneTilemapRLE` and `ClockTilemapRLE`: the other three
 ## Pokegear cards, one contiguous run in that order directly behind
 ## `PokegearSpritesGFX`, byte identical on all three cartridges.
@@ -973,12 +980,18 @@ const POKEGEAR_CARD_TERMINATOR: int = 0xFF
 ## The whole run, which is what bounds the walk over the three.
 const POKEGEAR_CARD_TILEMAP_BYTES: int = 305
 
-## `_PokegearAskWhoCallText` and its two neighbours, adjacent in
+## `_GearEllipseText` and the four texts behind it, adjacent in
 ## `data/text/common_3.asm` and decoded in that order from the one offset: the
-## phone card asks the first when it opens, the clock card says the second, and
-## the phone submenu's DELETE row asks the third.
-const POKEGEAR_TEXT_NAMES: Array[String] = ["ask_who", "press_button", "ask_delete"]
+## two the phone card places while a call is being made or refused, then the
+## question it opens with, the clock card's line, and the DELETE row's question.
+const POKEGEAR_TEXT_NAMES: Array[String] = [
+	"ellipse", "out_of_service", "ask_who", "press_button", "ask_delete",
+]
 const POKEGEAR_TEXT_MAX_BYTES: int = 64
+
+## `PhoneClickText` and `PhoneEllipseText`, the two lines `HangUp` prints. Both
+## are short; the window only has to hold each one whole.
+const PHONE_CALL_TEXT_MAX_BYTES: int = 32
 
 ## `TownMapPals`: a palette per tile id, condensed to nybbles, least significant
 ## first. It covers $00 to $5f; $60 and above take palette 0.
@@ -2329,7 +2342,8 @@ const GOLD_SILVER: Dictionary = {
 	# at every offset and keeping the run reproducing the PNG, and the landmark
 	# table by its x,y pairs at a stride of four, which nothing else matches.
 	# Every hit is unique per dump. `cards` is the three card tilemaps as one run
-	# from the pinned .rle files and `card_texts` the two Pokegear texts. Nested
+	# from the pinned .rle files and `card_texts` the run of five that opens on
+	# `_GearEllipseText`. Nested
 	# like trainer_card, so Gold and Silver's absent female palette stays out of
 	# the flat offset checks.
 	"town_map": {
@@ -2337,7 +2351,7 @@ const GOLD_SILVER: Dictionary = {
 		"pokegear_gfx": 0x1C0E43,
 		"sprites": 0x9149C,
 		"cards": 0x914CC,
-		"card_texts": 0x198089,
+		"card_texts": 0x198066,
 		"fast_ship": 0x90C7C,
 		"johto": 0x91F52,
 		"kanto": 0x920BB,
@@ -2703,6 +2717,9 @@ const GOLD_SILVER: Dictionary = {
 	"special_phone_calls": 0x905F6,
 	"phone_out_of_area_bank": 0x24,
 	"phone_out_of_area_address": 0x4626,
+	# `_PhoneClickText` and the `_PhoneEllipseText` behind it, the two lines
+	# `HangUp` prints. Matched on "Click!" itself, which hits once per dump.
+	"phone_call_texts": 0x1980FC,
 	"phone_just_talk_bank": 0x24,
 	"phone_just_talk_address": 0x462F,
 	# SpecialCallOnlyWhenOutside and SpecialCallWhereverYouAre in engine/phone/phone.asm.
@@ -2924,7 +2941,7 @@ const CRYSTAL: Dictionary = {
 		"pokegear_gfx": 0x1DE2E4,
 		"sprites": 0x914DD,
 		"cards": 0x9150D,
-		"card_texts": 0x1C5847,
+		"card_texts": 0x1C5824,
 		"fast_ship": 0x90CB2,
 		"johto": 0x91FFF,
 		"kanto": 0x92168,
@@ -3279,6 +3296,7 @@ const CRYSTAL: Dictionary = {
 	"special_phone_calls": 0x90627,
 	"phone_out_of_area_bank": 0x24,
 	"phone_out_of_area_address": 0x4657,
+	"phone_call_texts": 0x1C5580,
 	"phone_just_talk_bank": 0x24,
 	"phone_just_talk_address": 0x4660,
 	# Crystal's relocated special-call condition routines.
@@ -3972,6 +3990,13 @@ static func credits_string_offset(rom: RomFile, layout: Dictionary, index: int) 
 static func dex_nest_icon_offset(layout: Dictionary) -> int:
 	var kanto: int = int((layout.get("town_map", {}) as Dictionary).get("kanto", -1))
 	return kanto + TOWN_MAP_REGION_BYTES if kanto >= 0 else -1
+
+
+## `FlyMapLabelBorderGFX`, one 2bpp tile behind the nest icon; -1 for a cartridge
+## with no region map.
+static func fly_map_label_offset(layout: Dictionary) -> int:
+	var nest: int = dex_nest_icon_offset(layout)
+	return nest + DEX_NEST_ICON_TILES * Gen2Tiles.TILE_BYTES if nest >= 0 else -1
 
 
 static func landmark_count(layout: Dictionary) -> int:

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -373,6 +373,9 @@ static func _read_phone(rom: RomFile, layout: Dictionary) -> Dictionary:
 	)
 	if out_of_area.is_empty() or just_talk.is_empty():
 		return _error("Phone service script pointers are invalid.")
+	var hang_up: Dictionary = _hang_up_texts(rom, layout)
+	if hang_up.is_empty():
+		return _error("The hang-up texts did not decode.")
 
 	return {
 		"ok": true,
@@ -386,9 +389,31 @@ static func _read_phone(rom: RomFile, layout: Dictionary) -> Dictionary:
 				"receive_call_delays": [20, 10, 5, 3],
 				"out_of_area_script": out_of_area,
 				"just_talk_script": just_talk,
+				"hang_up_click": String(hang_up["click"]),
+				"hang_up_ellipse": String(hang_up["ellipse"]),
 			},
 		},
 	}
+
+
+## `HangUp_Beep`'s `PhoneClickText` and `HangUp_BoopOn`'s `PhoneEllipseText`,
+## adjacent in `data/text/common_3.asm` and decoded in that order from the one
+## offset. Both end on `done`, so neither holds the routine for a button.
+static func _hang_up_texts(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("phone_call_texts", -1))
+	var window: int = 2 * RomLayout.PHONE_CALL_TEXT_MAX_BYTES
+	if at < 0 or not rom.in_bounds(at, window):
+		return {}
+	var data: PackedByteArray = rom.slice(at, window)
+	var out: Dictionary = {}
+	var offset: int = 0
+	for name: String in ["click", "ellipse"]:
+		var decoded: Dictionary = Gen2TextStream.decode(data, offset)
+		if not bool(decoded.get("ok", false)) or String(decoded["text"]).is_empty():
+			return {}
+		out[name] = String(decoded["text"])
+		offset = int(decoded["bytes"])
+	return out
 
 
 static func _phone_pointer(rom: RomFile, at: int) -> Dictionary:

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -128,6 +128,21 @@ const PHONE_SUBMENU_CURSOR_COLUMN: int = 10
 const YES_NO_BOX: Array[int] = [14, 7, 19, 11]
 const YES_NO_OPTIONS: Array[String] = ["YES", "NO"]
 
+## `TownMapBubble`, the fly map's own three-row label: a bordered strip across
+## the top with `Where?` on its first row, the chosen flypoint's name on its
+## second and an up/down arrow at its right edge. Its five tiles are
+## `FlyMapLabelBorderGFX`, loaded over the Pokegear sheet's first six.
+const FLY_BUBBLE_CORNERS: Array[Array] = [
+	[Vector2i(1, 0), 0x30], [Vector2i(18, 0), 0x31],
+	[Vector2i(1, 2), 0x32], [Vector2i(18, 2), 0x33],
+]
+const FLY_BUBBLE_ROWS: int = 3
+const FLY_BUBBLE_WHERE: String = "Where?"
+const FLY_BUBBLE_WHERE_AT: Vector2i = Vector2i(2, 0)
+const FLY_BUBBLE_NAME_AT: Vector2i = Vector2i(2, 1)
+const FLY_BUBBLE_ARROW_AT: Vector2i = Vector2i(18, 1)
+const FLY_BUBBLE_ARROW_TILE: int = 0x34
+
 ## `PokegearMap_UpdateLandmarkName`: a 2x12 box cleared at (8,0), the name placed
 ## at (9,0) and the sheet's own marker left in the corner it opened.
 const NAME_BOX_AT: Vector2i = Vector2i(8, 0)
@@ -150,6 +165,9 @@ var frame_style: int = 0
 var _tiles: Dictionary = {}
 ## The three card tilemaps, by the names the cache keys them with.
 var _cards: Dictionary = {}
+## `FlyMapLabelBorderGFX`, which the fly map loads over the first six Pokegear
+## tiles, so it is a second window rather than more of the first.
+var _fly_tiles: Dictionary = {}
 
 
 ## [param data] supplies the glyphs and both graphics sheets; a cache without
@@ -161,8 +179,16 @@ static func from_data(data: GameData) -> Gen2TownMapPage:
 	var out := Gen2TownMapPage.new()
 	out.font = glyphs
 	out.frame_style = Gen2OptionsStore.current().textbox_frame
-	out._load_sheet(data, "town_map", TOWN_MAP_FIRST_TILE, RomLayout.TOWN_MAP_TILES)
-	out._load_sheet(data, "pokegear", POKEGEAR_FIRST_TILE, RomLayout.POKEGEAR_TILES)
+	out._load_sheet(
+		data, "town_map", TOWN_MAP_FIRST_TILE, RomLayout.TOWN_MAP_TILES, out._tiles
+	)
+	out._load_sheet(
+		data, "pokegear", POKEGEAR_FIRST_TILE, RomLayout.POKEGEAR_TILES, out._tiles
+	)
+	out._load_sheet(
+		data, "fly_map_label", RomLayout.FLY_MAP_LABEL_FIRST_TILE,
+		RomLayout.FLY_MAP_LABEL_TILES, out._fly_tiles,
+	)
 	for card: String in RomLayout.POKEGEAR_CARD_ORDER:
 		var cells: PackedByteArray = data.pokegear_card(StringName(card))
 		if cells.size() == RomLayout.POKEGEAR_CARD_CELLS:
@@ -174,7 +200,12 @@ func ready() -> bool:
 	return font != null and _tiles.size() >= RomLayout.TOWN_MAP_TILES + RomLayout.POKEGEAR_TILES
 
 
-func _load_sheet(data: GameData, name: String, first_tile: int, count: int) -> void:
+## [param window] is which VRAM window the strip lands in: the shared one, or the
+## fly map's own six tiles, which stand over the Pokegear sheet rather than
+## beside it.
+func _load_sheet(
+	data: GameData, name: String, first_tile: int, count: int, window: Dictionary
+) -> void:
 	var indices: PackedByteArray = data.tile_indices(name)
 	if indices.is_empty():
 		return
@@ -187,7 +218,7 @@ func _load_sheet(data: GameData, name: String, first_tile: int, count: int) -> v
 		for y: int in TILE:
 			for x: int in TILE:
 				cell[y * TILE + x] = indices[y * width + tile * TILE + x]
-		_tiles[first_tile + tile] = cell
+		window[first_tile + tile] = cell
 
 
 ## The whole screen as tile numbers, in the order the source writes them: the
@@ -214,6 +245,8 @@ func tilemap(
 			_draw_card_icons(map, cards)
 		Gen2TownMap.SCREEN_DEX_AREA:
 			_draw_nest_header(map, name_codes)
+		Gen2TownMap.SCREEN_FLY:
+			_draw_fly_bubble(map, name_codes)
 		_:
 			_draw_town_map_frame(map)
 			_draw_name(map, name_codes)
@@ -403,6 +436,22 @@ func _draw_town_map_frame(map: PackedInt32Array) -> void:
 	_put(map, Vector2i(COLUMNS - 1, TOWN_MAP_FRAME_BAR_AT.y), TOWN_MAP_FRAME_RIGHT_TILE)
 
 
+## `TownMapBubble`. The three rows are blanked first and the corners written
+## into them, so the arrow and both strings stand over a cleared strip.
+func _draw_fly_bubble(map: PackedInt32Array, name_codes: PackedByteArray) -> void:
+	for row: int in FLY_BUBBLE_ROWS:
+		for column: int in range(1, COLUMNS - 1):
+			_put(map, Vector2i(column, row), BLANK_TILE)
+	for corner: Array in FLY_BUBBLE_CORNERS:
+		_put(map, corner[0] as Vector2i, int(corner[1]))
+	_draw_string(map, FLY_BUBBLE_WHERE_AT, FLY_BUBBLE_WHERE)
+	var at: Vector2i = FLY_BUBBLE_NAME_AT
+	for code: int in name_codes:
+		_put(map, at, code)
+		at.x += 1
+	_put(map, FLY_BUBBLE_ARROW_AT, FLY_BUBBLE_ARROW_TILE)
+
+
 func _draw_bar(map: PackedInt32Array, row: int) -> void:
 	for column: int in range(1, COLUMNS - 1):
 		_put(map, Vector2i(column, row), TOWN_MAP_FRAME_TOP_TILE)
@@ -460,7 +509,9 @@ func _draw_name(map: PackedInt32Array, name_codes: PackedByteArray) -> void:
 	_put(map, NAME_BOX_AT, NAME_MARKER_TILE)
 
 
-## `TownMapPals`, as one palette slot per tile.
+## `TownMapPals`, as one palette slot per tile. The attribute map is read off the
+## tile number whatever sheet the tile came from, so the fly map's border takes
+## the Pokegear sheet's own slots.
 func attributes(data: GameData, map: PackedInt32Array) -> PackedInt32Array:
 	var out := PackedInt32Array()
 	out.resize(map.size())
@@ -474,8 +525,11 @@ func attributes(data: GameData, map: PackedInt32Array) -> PackedInt32Array:
 ##
 ## This cannot go through [method Gen2PicImage.from_indices] whole: the screen is
 ## six palettes at once.
-func image(data: GameData, map: PackedInt32Array, female: bool = false) -> Image:
-	var indices: PackedByteArray = compose(map)
+func image(
+	data: GameData, map: PackedInt32Array, female: bool = false,
+	screen: StringName = Gen2TownMap.SCREEN_TOWN_MAP,
+) -> Image:
+	var indices: PackedByteArray = compose(map, screen)
 	var slots: PackedInt32Array = attributes(data, map)
 	var out: PackedInt32Array = Gen2PicImage.canvas(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	var tables: Array[PackedInt32Array] = []
@@ -504,15 +558,22 @@ func image(data: GameData, map: PackedInt32Array, female: bool = false) -> Image
 ## Resolves every tile number to pixels: the two graphics sheets out of the VRAM
 ## window, a card's text box out of the chosen frame, everything else out of the
 ## font.
-func compose(map: PackedInt32Array) -> PackedByteArray:
+func compose(
+	map: PackedInt32Array, screen: StringName = Gen2TownMap.SCREEN_TOWN_MAP
+) -> PackedByteArray:
 	var width: int = COLUMNS * TILE
 	var indices := PackedByteArray()
 	indices.resize(width * ROWS * TILE)
+	# `_FlyMap`'s `Request1bpp` lands on top of the Pokegear sheet, so its six
+	# tiles answer first and only on that screen.
+	var over: Dictionary = _fly_tiles if screen == Gen2TownMap.SCREEN_FLY else {}
 	for row: int in ROWS:
 		for column: int in COLUMNS:
 			var tile: int = map[row * COLUMNS + column]
 			var at := Vector2i(column * TILE, row * TILE)
-			if _tiles.has(tile):
+			if over.has(tile):
+				_blit(indices, width, over[tile], at)
+			elif _tiles.has(tile):
 				_blit(indices, width, _tiles[tile], at)
 			elif tile >= RomLayout.FRAME_FIRST_CODE \
 				and tile < RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TILES:

--- a/game/world/phone_ring.gd
+++ b/game/world/phone_ring.gd
@@ -14,6 +14,22 @@ const WAIT_FRAMES: int = 20
 const RING_FRAMES: int = WAITS_PER_RING * WAIT_FRAMES
 const TOTAL_FRAMES: int = RING_COUNT * RING_FRAMES
 
+## `HangUp`, the same twenty-frame wait counted seven times: `HangUp_Beep`'s
+## `Click!`, then three turns of `HangUp_BoopOn`'s `……` and the empty box
+## `HangUp_BoopOff` redraws over it. Every phone call in the game ends on it and
+## none of it waits for a button.
+const HANG_UP_PHASES: Array[StringName] = [
+	&"click", &"ellipse", &"clear", &"ellipse", &"clear", &"ellipse", &"clear",
+]
+const HANG_UP_PHASE_COUNT: int = 7
+const HANG_UP_FRAMES: int = HANG_UP_PHASE_COUNT * WAIT_FRAMES
+
+
+## Which of the seven `HangUp` writes is on the box [param elapsed] frames in.
+static func hang_up_phase(elapsed: int) -> StringName:
+	var index: int = clampi(elapsed / WAIT_FRAMES, 0, HANG_UP_PHASES.size() - 1)
+	return HANG_UP_PHASES[index]
+
 var _elapsed_frames: int = 0
 var _lead_frames: int = 0
 

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -100,6 +100,9 @@ var _service: bool = true
 ## `PokegearPhoneContactSubmenu` while it is up, and the yes/no box DELETE opens
 ## over it. Both are drawn on the card rather than on a layer of their own, the
 ## way `Textbox` writes into the same tilemap.
+## `PokegearPhone_MakePhoneCall`'s own `PrintText`: whatever the card has said
+## over its opening question, empty when it is asking that question again.
+var _message: String = ""
 var _submenu: Array = []
 var _submenu_cursor: int = 0
 var _asking_delete: bool = false
@@ -173,6 +176,7 @@ func open(
 	_scroll = 0
 	_cursor = 0
 	_close_submenu()
+	_message = ""
 	_open = true
 	visible = true
 	if is_inside_tree() and _background != null:
@@ -209,6 +213,13 @@ func set_contacts(contacts: Array, service: bool) -> void:
 	_refresh()
 
 
+## `PokegearPhone_MakePhoneCall`'s two `PrintText` calls, the refusal and the
+## `……` a placed call opens on. The card keeps its list under the line.
+func say(text: String) -> void:
+	_message = text
+	_refresh()
+
+
 func card() -> StringName:
 	return _card
 
@@ -228,6 +239,13 @@ func selected_contact() -> int:
 func handle_button(button: int) -> bool:
 	if not _open:
 		return false
+	if not _message.is_empty():
+		# `_GearOutOfServiceText` ends on `prompt`, so `PrintText` holds the card
+		# until a button; `PokegearAskWhoCallText` is printed behind it.
+		if button in [Gen2Button.A, Gen2Button.B]:
+			_message = ""
+			_refresh()
+		return true
 	if _asking_delete:
 		_press_yes_no(button)
 		return true
@@ -434,9 +452,13 @@ func _tilemap() -> PackedInt32Array:
 		return _page.radio_tilemap(_owned, _station, _show_lines)
 	if _card != CARD_PHONE:
 		return _page.clock_tilemap(_owned, _weekday, _hour, _minute, _text)
+	var box: String = _text
+	if _asking_delete:
+		box = _delete_text
+	elif not _message.is_empty():
+		box = _message
 	var map: PackedInt32Array = _page.phone_tilemap(
-		_owned, _phone_rows(), _cursor, _service,
-		_delete_text if _asking_delete else _text
+		_owned, _phone_rows(), _cursor, _service, box
 	)
 	if not _submenu.is_empty():
 		# The yes/no box is a window over the submenu rather than a replacement,

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -464,7 +464,7 @@ func _background_image() -> Image:
 	return _page.image(_data, _page.tilemap(
 		_data.town_map_region(Gen2TownMap.region_name(_map.region())),
 		codes, _map.screen, _cards
-	), _female)
+	), _female, _map.screen)
 
 
 ## The landmark name each map screen puts in its own box, or `GetPokemonName`

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5454,6 +5454,12 @@ func advance_script_wait_frame() -> Array:
 	return _complete_script_wait()
 
 
+## How many frames of the counted wait are left, or -1 when none is running or
+## it has not been entered yet. What a host draws the wait's own animation from.
+func script_wait_remaining() -> int:
+	return _script_wait_frames
+
+
 ## Whether anything a script set walking is still being drawn. This is
 ## wStateFlags' SCRIPTED_MOVEMENT_STATE_F: one flag for all of them, cleared by
 ## whichever stream reaches its own `step_end`.

--- a/game/world/world_phone_host.gd
+++ b/game/world/world_phone_host.gd
@@ -141,6 +141,9 @@ static func resolve_outgoing(
 	var contact: Dictionary = data.world_phone_contact(contact_id)
 	if contact.is_empty():
 		return _phone_unavailable(&"phone_contact_missing")
+	# `MakePhoneCallFromPokegear`'s own `.OutOfArea`, which the cartridge cannot
+	# reach from the Pokegear either: `PokegearPhone_MakePhoneCall` refuses in
+	# front of it and says so on the card.
 	if not map_has_phone_service(map):
 		return _out_of_area_result(data, contact, contact_id, &"phone_service_unavailable")
 	if not time_mask_matches(int(contact.get("caller_time", 0)), hour):

--- a/game/world/world_radio.gd
+++ b/game/world/world_radio.gd
@@ -99,8 +99,13 @@ const CHANNELS: Array[Dictionary] = [
 ]
 
 ## The strings LoadStation_* leaves in `de` for UpdateRadioStation to place under
-## the dial, identical in both pins. Rocket Radio really does reuse Let's All
-## Sing's, and Buena's own name is blank until Team Rocket takes the tower.
+## the dial, identical in both pins. `LoadStation_RocketRadio` really does reuse
+## Let's All Sing's, though only `PlayRadioStationPointers` reaches it and a map
+## radio prints no name. `LoadStation_BuenasPassword` answers with
+## `NotBuenasPasswordName`, an empty string, until Team Rocket takes the tower.
+##
+## `.returnafterstation` places this before `PlayRadioShow` runs, so the name is
+## the station the dial is on and never the Rocket broadcast standing in for it.
 const STATION_NAMES: Dictionary = {
 	OAKS_POKEMON_TALK: "OAK's <PK><MN> Talk",
 	POKEDEX_SHOW: "#DEX Show",
@@ -187,6 +192,7 @@ static func station_for(knob: int, context: Dictionary = {}) -> Dictionary:
 	var channel: int = _channel_for_rule(entry, context)
 	if channel < 0:
 		return _no_signal(knob)
+	var name: String = _station_name(channel, context)
 	channel = _rocket_override(channel, context)
 	return {
 		"ok": true,
@@ -195,7 +201,7 @@ static func station_for(knob: int, context: Dictionary = {}) -> Dictionary:
 		"channel": channel,
 		"raw_channel": raw_channel(channel, crystal),
 		"music": CHANNEL_SONGS[channel],
-		"name": String(STATION_NAMES.get(channel, "")),
+		"name": name,
 	}
 
 
@@ -274,6 +280,15 @@ static func _channel_for_rule(entry: Dictionary, context: Dictionary) -> int:
 ## station below the Poke Flute channel broadcasts Rocket Radio instead. The
 ## three at or above it are untouched, which is why the Poke Flute channel still
 ## answers during the takeover.
+## The name the tuned station places, which is `LoadStation_*`'s own `de` and so
+## is read before the Rocket broadcast replaces the programme.
+static func _station_name(channel: int, context: Dictionary) -> String:
+	if channel == BUENAS_PASSWORD \
+		and not bool(context.get("rockets_in_radio_tower", false)):
+		return ""
+	return String(STATION_NAMES.get(channel, ""))
+
+
 static func _rocket_override(channel: int, context: Dictionary) -> int:
 	if channel >= POKE_FLUTE_RADIO:
 		return channel

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -42,6 +42,8 @@ const SFX_WATERFALL: int = 0x51
 ## plays (engine/events/field_moves.asm). SFX_HEADBUTT is a battle-move effect
 ## and is referenced by nothing in either pin's overworld code.
 const SFX_HEADBUTT_TREE: int = 0x6D
+## `HangUp_Beep`, the click every phone call ends on.
+const SFX_HANG_UP: int = 0x6B
 ## `.PlayPoisonSFX`, the sound the overworld poison pass plays whether or not
 ## anything fainted to it.
 const SFX_POISON: int = 0x0B
@@ -269,6 +271,9 @@ var _last_battle_outcome: StringName = &""
 ## The audio driver's rendered-frame count as of the last frame, for the one
 ## script wait that reads it. See [method Gen2AudioPlayer.timeline_updates].
 var _audio_rendered_seen: int = 0
+## Which of `HangUp`'s seven writes is on the box, so each is written once
+## rather than every frame of its twenty.
+var _hang_up_phase: StringName = &""
 var _active_battle_persist: bool = false
 var _encounter_random := RandomNumberGenerator.new()
 ## NPC movement rolls from its own generator, so a seeded route keeps the same
@@ -924,6 +929,7 @@ func advance_frame() -> void:
 	# After the trail, because the frame it finishes drawing is the frame the
 	# script waiting on it resumes.
 	if _world != null and not _world.pending_script_wait().is_empty():
+		_draw_hang_up()
 		var wait_results: Array = _world.advance_script_wait_frame()
 		if not wait_results.is_empty():
 			_show_script_results(wait_results)
@@ -7832,6 +7838,33 @@ func _refresh_labels() -> void:
 		_hint.text += "    1-%d: select    F: fish" % rods.size()
 	if not _script_prompt.is_empty():
 		_hint.text += "    " + _script_prompt
+
+
+## `HangUp`'s own three writes, driven off the counted wait `hangup` staged: the
+## click, the `……` and the empty box `HangUp_BoopOff` redraws, twenty frames
+## each. Nothing here waits for a button, so the box is written rather than
+## opened as a page.
+func _draw_hang_up() -> void:
+	var wait: Dictionary = _world.pending_script_wait()
+	if not bool(wait.get("hang_up", false)) or _data == null \
+		or _text_box == null or _text_box.font == null:
+		return
+	var total: int = int(wait.get("frames", 0))
+	var remaining: int = _world.script_wait_remaining()
+	var elapsed: int = 0 if remaining < 0 else total - remaining
+	var phase: StringName = Gen2WorldPhoneRing.hang_up_phase(elapsed)
+	if phase == _hang_up_phase:
+		return
+	_hang_up_phase = phase
+	var metadata: Dictionary = _data.world_phone_metadata()
+	var line: String = ""
+	if phase == &"click":
+		line = String(metadata.get("hang_up_click", ""))
+		_play_sfx(SFX_HANG_UP)
+	elif phase == &"ellipse":
+		line = String(metadata.get("hang_up_ellipse", ""))
+	_text_box.visible = true
+	_text_box.show_text(line, false)
 
 
 func _phone_contact_label(contact: Dictionary) -> String:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -2516,7 +2516,14 @@ func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) 
 				"address": int(command.get("address", 0)),
 			})
 		0x98:
-			_emit_runtime_event(&"phone_hangup", {})
+			## `Script_hangup` is `HangUp` inline: seven twenty-frame waits with
+			## its own two lines on the box, and no button anywhere in it.
+			_emit_runtime_event(&"phone_hangup", {
+				"frames": Gen2WorldPhoneRing.HANG_UP_FRAMES,
+			})
+			return _stage_frame_wait(
+				Gen2WorldPhoneRing.HANG_UP_FRAMES, {"hang_up": true}
+			)
 		0x99:
 			return _stage_decoration_description(int(command.get("value", 0)))
 		0x9A:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -99,6 +99,10 @@ const SFX_TRANSACTION: int = 0x22
 const SFX_SWITCH_POKEMON: int = 0x20
 ## `BillsPC_PlaceEmptyBoxString_SFX`'s own `SFX_WRONG`.
 const SFX_WRONG: int = 0x19
+## `PokegearPhone_MakePhoneCall`'s own `SFX_CALL`, and the `SFX_NO_SIGNAL`
+## `Phone_NoSignal` answers a map with no service with.
+const SFX_CALL: int = 0x6A
+const SFX_NO_SIGNAL: int = 0x6C
 
 ## `BillsPC_ChangeBoxSubmenu.MenuData`'s four rows, inline in `bills_pc.asm` and
 ## reached by no script, so they are this screen's the way the machine's own top
@@ -2158,6 +2162,14 @@ func _on_card_tuned(knob: int) -> void:
 
 
 func _on_card_called(contact: int) -> void:
+	# `.no_service` refuses in front of `MakePhoneCallFromPokegear`, so a map
+	# without service says so on the card and never reaches a phone script.
+	if not Gen2WorldPhoneHost.map_has_phone_service(_world.current_map):
+		sfx_requested.emit(SFX_NO_SIGNAL, false)
+		_pokegear.say(_data.pokegear_text("out_of_service"))
+		return
+	sfx_requested.emit(SFX_CALL, false)
+	_pokegear.say(_data.pokegear_text("ellipse"))
 	var results: Array = _world.request_outgoing_phone_call(contact)
 	_close_card()
 	_mode = -1

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -559,6 +559,39 @@ func test_phone_list_starts_the_source_timed_outgoing_ring() -> void:
 	assert_eq(" ".join(_world_screen._text_box.text_lines()), "PHONE SCRIPT")
 
 
+## `PokegearPhone_MakePhoneCall.no_service`: a map the phone cannot reach refuses
+## in front of `MakePhoneCallFromPokegear`, so the card says so over its own list
+## and the call never happens. The button behind the `prompt` puts the opening
+## question back.
+func test_a_map_without_phone_service_refuses_the_call_on_the_card() -> void:
+	_write_phone_request()
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world()
+	var registered: Dictionary = _world_screen._world.state.apply_changes({}, {}, {
+		"phone_contacts": {0: true},
+	})
+	assert_true(registered["ok"])
+	_world_screen._world.current_map.phone_flag = 1
+	_world_screen._open_phone_list()
+	await get_tree().process_frame
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(host.handle_button(Gen2Button.A))
+	await get_tree().process_frame
+	assert_not_null(_world_screen._service_host, "the card stays open")
+	assert_true(
+		_row_text(host._pokegear._tilemap(), Gen2TownMapPage.CARD_TEXT_AT, 19)
+			.begins_with(_data.pokegear_text("out_of_service"))
+	)
+	assert_false(_world_screen._world.phone_ring_active())
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_true(
+		_row_text(host._pokegear._tilemap(), Gen2TownMapPage.CARD_TEXT_AT, 19)
+			.begins_with(_data.pokegear_text("ask_who"))
+	)
+
+
 ## `PokegearPhoneContactSubmenu`'s DELETE row and the yes/no box behind it:
 ## MOM is one of the two `CheckCanDeletePhoneNumber` refuses, so the contact the
 ## fixture registers is offered all three rows and answering YES drops it.

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -1175,6 +1175,7 @@ static func _town_map() -> Dictionary:
 		"card_texts": {
 			"ask_who": "WHOM TO CALL?", "press_button": "PRESS A BUTTON",
 			"ask_delete": "DELETE THIS NUMBER?",
+			"ellipse": "...", "out_of_service": "NO SERVICE HERE",
 		},
 	}
 

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -1498,13 +1498,16 @@ func test_the_pokegear_texts_are_read_in_sequence() -> void:
 	var data: PackedByteArray = _dump()
 	var at: int = int((_layout["town_map"] as Dictionary)["card_texts"])
 	var offset: int = at
-	for words: String in ["WHOM?", "PRESS", "DELETE?"]:
+	for words: String in ["...", "NO SERVICE", "WHOM?", "PRESS", "DELETE?"]:
 		_write(data, offset, _text(words))
 		offset += _text(words).size()
 	var texts: Dictionary = RomImporter.read_pokegear_texts(_rom(data), _layout)
 	assert_eq(
 		texts,
-		{"ask_who": "WHOM?", "press_button": "PRESS", "ask_delete": "DELETE?"}
+		{
+			"ellipse": "...", "out_of_service": "NO SERVICE",
+			"ask_who": "WHOM?", "press_button": "PRESS", "ask_delete": "DELETE?",
+		}
 	)
 	data[at] = 0xFF
 	assert_true(RomImporter.read_pokegear_texts(_rom(data), _layout).is_empty())

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4603,6 +4603,27 @@ func test_a_movement_sleep_holds_the_wait_without_moving_anything() -> void:
 	assert_eq(object.cell, start)
 
 
+## `Script_hangup` is `HangUp` inline, which spends seven twenty-frame waits and
+## asks for no button. Before this the command emitted an event nothing answered
+## and the script ran straight on.
+func test_hangup_holds_the_script_for_the_whole_hang_up_sequence() -> void:
+	_write_service_cache()
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x99, 0x91],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+	var wait: Dictionary = world.pending_script_wait()
+	assert_true(bool(wait.get("hang_up", false)))
+	assert_eq(int(wait.get("frames", 0)), Gen2WorldPhoneRing.HANG_UP_FRAMES)
+	for _frame: int in Gen2WorldPhoneRing.HANG_UP_FRAMES - 1:
+		world.advance_script_wait_frame()
+	assert_false(world.pending_script_wait().is_empty(), "one frame of the boop left")
+	assert_eq(_final_status(world.advance_script_wait_frame()), &"complete")
+
+
 ## `Script_pause` delays two frames per counted unit inside the command, and
 ## `Script_deactivatefacing` hands the same count to SCRIPT_WAIT, which
 ## `WaitScript` spends one a frame. Both write wScriptDelay only when their

--- a/tests/unit/test_world_phone_ring.gd
+++ b/tests/unit/test_world_phone_ring.gd
@@ -28,3 +28,24 @@ func test_special_call_lead_precedes_the_same_two_rings() -> void:
 	_spend(ring, 30)
 	assert_eq(ring.snapshot()["phase"], &"ringing")
 	assert_eq(ring.snapshot()["ring"], 1)
+
+
+## `HangUp`: `HangUp_Beep`'s click, then `HangUp_BoopOn` and `HangUp_BoopOff`
+## three times each, twenty frames apiece and no button anywhere in it.
+func test_hang_up_writes_the_click_then_three_boops() -> void:
+	assert_eq(
+		Gen2WorldPhoneRing.HANG_UP_PHASES.size(), Gen2WorldPhoneRing.HANG_UP_PHASE_COUNT
+	)
+	assert_eq(Gen2WorldPhoneRing.HANG_UP_FRAMES, 140)
+	var phases: Array[StringName] = []
+	for phase_index: int in Gen2WorldPhoneRing.HANG_UP_PHASE_COUNT:
+		phases.append(Gen2WorldPhoneRing.hang_up_phase(
+			phase_index * Gen2WorldPhoneRing.WAIT_FRAMES
+		))
+	assert_eq(phases, Gen2WorldPhoneRing.HANG_UP_PHASES)
+	assert_eq(Gen2WorldPhoneRing.hang_up_phase(19), &"click")
+	assert_eq(Gen2WorldPhoneRing.hang_up_phase(20), &"ellipse")
+	assert_eq(
+		Gen2WorldPhoneRing.hang_up_phase(Gen2WorldPhoneRing.HANG_UP_FRAMES), &"clear",
+		"the last twenty frames are the box HangUp_BoopOff redraws"
+	)

--- a/tests/unit/test_world_radio.gd
+++ b/tests/unit/test_world_radio.gd
@@ -82,6 +82,22 @@ func test_the_fast_ship_counts_as_johto() -> void:
 		"Vermilion is one lower there too")
 
 
+## `LoadStation_BuenasPassword` leaves `NotBuenasPasswordName`, a bare `@`, in
+## `de` unless Team Rocket is in the tower, so the dial names the station only
+## while its own programme has been taken off the air.
+func test_buenas_password_is_named_only_while_rockets_hold_the_tower() -> void:
+	assert_eq(
+		String(Gen2WorldRadio.station_for(KNOB_BUENAS, _johto()).get("name", "?")), "",
+		"NotBuenasPasswordName is an empty string"
+	)
+	assert_eq(
+		String(Gen2WorldRadio.station_for(
+			KNOB_BUENAS, _johto({"rockets_in_radio_tower": true})
+		).get("name", "")),
+		"BUENA'S PASSWORD"
+	)
+
+
 func test_gold_and_silver_carry_no_buenas_password_channel() -> void:
 	assert_true(
 		bool(Gen2WorldRadio.station_for(KNOB_BUENAS, _johto()).get("ok", false)),
@@ -134,8 +150,8 @@ func test_the_rocket_takeover_overrides_every_johto_station_below_the_flute() ->
 	)
 	assert_eq(int(seized.get("channel", -1)), Gen2WorldRadio.ROCKET_RADIO,
 		"PlayRadioShow rewrites wCurRadioLine before it jumps")
-	assert_eq(String(seized.get("name", "")), "Let's All Sing!",
-		"LoadStation_RocketRadio really does reuse that name")
+	assert_eq(String(seized.get("name", "")), "#DEX Show",
+		"`.returnafterstation` places the name before PlayRadioShow rewrites the line")
 	# Kanto is exempt, and so is anything at or above the Poke Flute channel.
 	var kanto: Dictionary = Gen2WorldRadio.station_for(
 		KNOB_POKE_FLUTE, _kanto({"rockets_in_radio_tower": true})

--- a/tests/unit/test_world_services_importer.gd
+++ b/tests/unit/test_world_services_importer.gd
@@ -45,6 +45,8 @@ func test_marts_phone_audio_and_referenced_menu_are_imported() -> void:
 	assert_eq((phone["special_calls"] as Array).size(), RomLayout.SPECIAL_PHONE_CALL_COUNT)
 	assert_eq(phone["special_calls"][0]["condition_kind"], &"outside")
 	assert_eq(phone["special_calls"][1]["condition_kind"], &"anywhere")
+	assert_eq(phone["metadata"]["hang_up_click"], "Click!")
+	assert_eq(phone["metadata"]["hang_up_ellipse"], "...")
 	assert_eq(phone["metadata"]["max_contacts"], 10)
 	assert_eq(phone["metadata"]["receive_call_delays"], [20, 10, 5, 3])
 	assert_eq(phone["metadata"]["just_talk_script"], {
@@ -273,6 +275,14 @@ func _write_phone(data: PackedByteArray) -> void:
 		_write_u16(data, at, condition)
 		data[at + 2] = 4
 		_write_far(data, at + 3, 5, 0x7400)
+	var call_texts: int = int(_layout["phone_call_texts"])
+	for words: String in ["Click!", "..."]:
+		var text := PackedByteArray([Gen2TextStream.TX_START])
+		text.append_array(Gen2Text.encode(words))
+		text.append(Gen2TextStream.CHAR_DONE)
+		for byte_index: int in text.size():
+			data[call_texts + byte_index] = text[byte_index]
+		call_texts += text.size()
 
 
 func _write_audio(data: PackedByteArray) -> void:

--- a/tools/checks/phone.gd
+++ b/tools/checks/phone.gd
@@ -25,6 +25,24 @@ func run(r: RefCounted) -> void:
 		_contacts(game_id, data)
 		_special_calls(game_id, data)
 		_mom_purchases(game_id, data)
+		_hang_up_texts(game_id, data)
+
+
+## `HangUp`'s own two lines, transcribed from `data/text/common_3.asm` rather
+## than read off the importer: they are pinned by one offset per cartridge and a
+## wrong one decodes to something rather than to nothing.
+const HANG_UP_TEXTS: Dictionary = {"hang_up_click": "Click!", "hang_up_ellipse": "……"}
+
+
+func _hang_up_texts(game_id: StringName, data: GameData) -> void:
+	var metadata: Dictionary = data.world_phone_metadata()
+	for key: String in HANG_UP_TEXTS:
+		_r.check(
+			String(metadata.get(key, "")) == String(HANG_UP_TEXTS[key]),
+			"%s: %s decoded as %s, wanted %s." % [
+				game_id, key, String(metadata.get(key, "")), String(HANG_UP_TEXTS[key]),
+			]
+		)
 
 
 ## Every row carries both scripts, and `PHONE_BILL` resolves through the seam

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -56,6 +56,8 @@ const CARD_PINS: Array[Array] = [
 const CARD_TEXTS: Dictionary = {
 	"ask_who": "Whom do you want\nto call?",
 	"press_button": "Press any button\nto exit.",
+	"ellipse": "……",
+	"out_of_service": "You're out of the\nservice area.",
 }
 
 ## `wShadowOAMEnd - wShadowOAM` in sprites, which is what `.nestloop` would run
@@ -348,6 +350,7 @@ func _verify_page(game_id: StringName, _data: GameData, crystal: bool) -> void:
 	for sheet: Array in [
 		["pokegear_sprites", RomLayout.POKEGEAR_SPRITE_TILES],
 		["fast_ship", RomLayout.FAST_SHIP_TILES],
+		["fly_map_label", RomLayout.FLY_MAP_LABEL_TILES],
 	]:
 		_r.check(
 			_data.tile_indices(String(sheet[0])).size()
@@ -356,7 +359,7 @@ func _verify_page(game_id: StringName, _data: GameData, crystal: bool) -> void:
 		)
 	for screen: StringName in [
 		Gen2TownMap.SCREEN_TOWN_MAP, Gen2TownMap.SCREEN_POKEGEAR_CARD,
-		Gen2TownMap.SCREEN_DEX_AREA,
+		Gen2TownMap.SCREEN_DEX_AREA, Gen2TownMap.SCREEN_FLY,
 	]:
 		for region: String in ["johto", "kanto"]:
 			var landmark: int = BROKEN_NAME if region == "johto" \
@@ -367,12 +370,46 @@ func _verify_page(game_id: StringName, _data: GameData, crystal: bool) -> void:
 				screen,
 				[&"map", &"phone", &"radio"] as Array,
 			)
-			var image: Image = page.image(_data, map)
+			var image: Image = page.image(_data, map, false, screen)
 			_r.check(
 				image.get_width() == Gen2Screen.WIDTH \
 					and image.get_height() == Gen2Screen.HEIGHT,
 				"%s: the %s %s screen did not compose." % [game_id, region, screen]
 			)
+			if screen == Gen2TownMap.SCREEN_FLY:
+				_verify_fly_bubble(game_id, region, map)
+
+
+## `TownMapBubble`'s own cells, transcribed here rather than read off the page:
+## the four corners of the label border, the arrow at the right of its middle row
+## and `Where?` in the top left.
+const FLY_BUBBLE_CELLS: Array[Array] = [
+	[Vector2i(1, 0), 0x30], [Vector2i(18, 0), 0x31],
+	[Vector2i(1, 2), 0x32], [Vector2i(18, 2), 0x33],
+	[Vector2i(18, 1), 0x34],
+]
+const FLY_BUBBLE_WHERE_AT: Vector2i = Vector2i(2, 0)
+
+
+func _verify_fly_bubble(game_id: StringName, region: String, map: PackedInt32Array) -> void:
+	for cell: Array in FLY_BUBBLE_CELLS:
+		var at: Vector2i = cell[0]
+		var tile: int = map[at.y * Gen2TownMapPage.COLUMNS + at.x]
+		_r.check(
+			tile == int(cell[1]),
+			"%s: the %s fly bubble has $%02X at (%d,%d), wanted $%02X." % [
+				game_id, region, tile, at.x, at.y, int(cell[1]),
+			]
+		)
+	var where: PackedByteArray = Gen2Text.encode("Where?")
+	for index: int in where.size():
+		var at: Vector2i = FLY_BUBBLE_WHERE_AT + Vector2i(index, 0)
+		_r.check(
+			map[at.y * Gen2TownMapPage.COLUMNS + at.x] == where[index],
+			"%s: the %s fly bubble does not say Where? at (%d,%d)." % [
+				game_id, region, at.x, at.y,
+			]
+		)
 
 
 ## `FindNest` over the whole species range, which is the only sweep that can say


### PR DESCRIPTION
Walking `engine/pokegear/pokegear.asm` and `engine/phone/phone.asm` found five
things.

**The fly map drew the wrong screen.** `_FlyMap` puts `TownMapBubble` across the
top three rows: `Where?`, the chosen flypoint's name and an up/down arrow, in a
border of six 1bpp tiles loaded over the first six Pokegear tiles. This port
drew `_TownMap`'s corner box and put the name in the Pokegear card's own box, so
every Fly opened a screen the cartridge never shows. `FlyMapLabelBorderGFX` is
imported, one 2bpp tile behind the dex nest icon on all three cartridges.

**The radio card named the wrong station under the Rocket takeover.**
`.returnafterstation` places what `LoadStation_*` left in `de`, and
`PlayRadioShow` rewrites the line afterwards, so Team Rocket changes the
programme and never the name. Every Johto station under 20.0 said "Let's All
Sing!". Buena's Password is also blank until the Rockets hold the tower, which
is what `NotBuenasPasswordName` is.

**A call from a map with no phone service left the Pokegear** and ran the
out-of-area script. `PokegearPhone_MakePhoneCall.no_service` refuses on the card
and puts its own question back.

**`hangup` emitted an event nothing answered.** `HangUp` is seven twenty-frame
waits: the click with `SFX_HANG_UP`, then three turns of the ellipse and an
empty box. Every phone call in the game ends on it.

**A log file of zero bytes was dropped from a diagnostics bundle**, so the
packed count disagreed with the files the report named.

`TownMapMon` reads like a sixth and is not one: `depixel 0, 0` with
`.OAMData_RedWalk`'s `dbsprite -1, -1` puts all four objects off screen, and
`SPRITE_ANIM_FUNC_NULL` never moves them.

Cache format 96 to 97: the fly map's border strip, the hang-up texts and three
more Pokegear card texts.

| Proof | Result |
|---|---|
| `gut -gdir=res://tests -ginclude_subdirs` | 3,942 tests, 72,527 asserts, green |
| `validate.gd -- all` | 78 topics, 0 failures, three cartridges |
| `import_rom.gd` | `layout: Layout verified.` on all three |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | complete, no `"ok": false` |

The fly bubble check goes red when the arrow tile is changed on purpose.