### PR TITLE
Stop an unending writer deciding whether a release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,13 @@ jobs:
           # `latest`, so the binary is found rather than assumed.
           sdkmanager=$(find "$ANDROID_SDK_ROOT/cmdline-tools" -name sdkmanager -type f | head -1)
           [ -n "$sdkmanager" ] || { echo "::error::no sdkmanager in the image"; exit 1; }
-          yes | "$sdkmanager" --licenses > /dev/null
+          # Not `yes |`: it never ends, so it is still writing when sdkmanager
+          # stops reading, dies of SIGPIPE and returns 1, which `pipefail`
+          # reports as this whole step failing. Whether that happens is a race
+          # against how much the reader consumes, and it decided a release. A
+          # bounded run of the same answer fits inside the pipe buffer, so the
+          # writer is finished before the reader has to be asked anything.
+          printf 'y\n%.0s' {1..100} | "$sdkmanager" --licenses > /dev/null
           "$sdkmanager" "platform-tools" "build-tools;36.1.0" "platforms;android-36" \
             "ndk;29.0.14206865" "cmake;3.22.1"
           [ -d "$ANDROID_SDK_ROOT/ndk/29.0.14206865" ] || {


### PR DESCRIPTION
`yes | sdkmanager --licenses` runs under `set -euo pipefail`. `yes` never ends, so when sdkmanager stops reading first it takes SIGPIPE and returns 141, and `pipefail` reports the whole step by it. Whether that happens is a race against how much of the pipe the reader drains.

On the `v0.1.7` tag it lost. The Android export was skipped, the job failed, and nothing was published.

```
$ bash -euo pipefail -c 'yes | true'                       ; echo $?
141
$ bash -euo pipefail -c "printf 'y\n%.0s' {1..100} | true"  ; echo $?
0
```

A hundred lines is 200 bytes and a pipe buffer is 64 KiB, so the writer finishes before the reader has to be asked anything and there is no race left to lose. Every licence sdkmanager can ask about is still answered.

This is the same trap the `Refuse an IPA with either iOS plugin missing` step already carries a note about, met from the writer's side rather than the reader's. `DEVICES.md`'s one-time setup line is the same pipeline and moves with it.

`v0.1.7` will be re-tagged onto this once it lands; no release was published for the old tag, so nothing is being replaced.
