### PR TITLE
Hold a script for its sound, and let a clip aim at what is on screen

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -105,19 +105,33 @@ An optional `<method> <times> [int arg]` drives a scene before capture. Keep
 state changes as callable methods, not only input branches, so screens stay
 inspectable without a key press.
 
-`tools/record_clip.gd` records one overworld clip to video, mods and all, for a
-trailer rather than for a check. Godot's Movie Maker pins the frame delta, so the
-world spends exactly one hardware frame per recorded frame and the same arguments
-give the same clip:
+`tools/record_clip.gd` records one clip to video, mods and all, for a trailer
+rather than for a check. Godot's Movie Maker pins the frame delta, so the world
+spends exactly one hardware frame per recorded frame and the same arguments give
+the same clip:
 
 ```bash
 godot --path . --mods --write-movie /tmp/clip.avi --fixed-fps 60 \
   -s res://tools/record_clip.gd -- crystal 24 3 cell=20,10 hold=left seconds=5
 ```
 
-Buttons are scripted per hardware frame through `Gen2WorldScreen.replay_input`,
-and its `probe=` modes answer where a walk may go and what a seed puts on the
-map before a clip is shot. The header has the options and the ffmpeg line.
+`screen=saves` shoots the launcher's save page instead of the world, which is
+where a run's challenge is chosen. What the clip plays with is arguments:
+`party=`, `items=`, `challenge=` and `progress=` build the recording save and the
+run behind it, and nothing is written to disk.
+
+Buttons are scripted per hardware frame through `Gen2WorldScreen.replay_input`.
+`text=auto` answers a box that is waiting for a press and `at=<state>:<action>`
+lands one on a menu the first time the screen reaches it, so a clip that has to
+fight, open the pack or throw a ball is aimed at what is on screen rather than at
+a frame number. The `probe=` modes answer where a walk may go, what a seed puts
+on the map, what the start menu's rows are and, with `probe=trace`, the frame
+every visible thing changed on. The header has the options and the ffmpeg line.
+
+The recording window is put in front and kept there: the engine does not draw an
+occluded window and Movie Maker writes a frame per drawn frame, so a covered one
+records a clip with its middle missing. A run that loses frames anyway fails
+rather than writing a short clip.
 
 `tools/profile.gd` answers what a drawn frame costs, per screen, in
 milliseconds. It needs a window, and turns the frame cap and vsync off so the

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -116,17 +116,23 @@ godot --path . --mods --write-movie /tmp/clip.avi --fixed-fps 60 \
 ```
 
 `screen=saves` shoots the launcher's save page instead of the world, which is
-where a run's challenge is chosen. What the clip plays with is arguments:
-`party=`, `items=`, `challenge=` and `progress=` build the recording save and the
-run behind it, and nothing is written to disk.
+where a run's challenge is chosen. Movie Maker's frame is the project's own
+viewport, so `size=` defaults to it: a layout of any other size is scaled into
+the frame, which is what makes a page's text soft. What the clip plays with is
+arguments: `party=`, `items=`, `challenge=` and `progress=` build the recording
+save and the run behind it, and nothing is written to disk.
 
 Buttons are scripted per hardware frame through `Gen2WorldScreen.replay_input`.
 `text=auto` answers a box that is waiting for a press and `at=<state>:<action>`
 lands one on a menu the first time the screen reaches it, so a clip that has to
 fight, open the pack or throw a ball is aimed at what is on screen rather than at
-a frame number. The `probe=` modes answer where a walk may go, what a seed puts
-on the map, what the start menu's rows are and, with `probe=trace`, the frame
-every visible thing changed on. The header has the options and the ffmpeg line.
+a frame number; `read=` and `beat=` set how long a finished page and a chosen
+menu row are left standing, which is what makes a clip readable rather than
+merely correct. `meet` fights the wild a mod has drawn on the map instead of
+inventing one, so the entry's id travels with the battle and its sprite goes
+when the fight is over. The `probe=` modes answer where a walk may go, what a
+seed puts on the map, what the start menu's rows are and, with `probe=trace`,
+the frame every visible thing changed on. The header has the options and the ffmpeg line.
 
 The recording window is put in front and kept there: the engine does not draw an
 occluded window and Movie Maker writes a frame per drawn frame, so a covered one

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -81,6 +81,18 @@ var _restarts: int = 0
 
 ## The driver exists before the node enters the tree: a host that plays its map
 ## music while it is still building itself has to reach a live engine.
+## How many of the CALLER's frames the driver may go without rendering before a
+## wait on a sound decides nobody is servicing it and gives up.
+##
+## Not one. The buffer is filled to a depth rather than by the frame, and a host
+## drawing faster than the driver renders leaves gaps of several frames in the
+## count: read as one frame, every `waitsfx` in the game ended on the frame after
+## it started, so a badge, a TM and every item jingle printed their line and
+## replaced it before it could be read. Long enough to cover a gap, short enough
+## that a run with no audio device at all pays a fifth of a second for it.
+const SERVICE_GAP_FRAMES: int = 12
+
+
 func _init() -> void:
 	_apu = Gen2Apu.new()
 	_engine = Gen2SoundEngine.new(_apu)
@@ -287,10 +299,10 @@ func effect_playing() -> bool:
 ## output stream with room in it: a headless run, a check or a replay leaves the
 ## channels exactly as the last request set them, so [method effect_playing] would
 ## answer true for the rest of the run. Anything WAITING on a sound compares this
-## count across two frames instead of trusting that answer, and stops waiting when
-## it has not moved. `AudioStreamPlayer.playing` is not that test: the dummy audio
-## driver reports true and consumes nothing. See `Gen2BattleScreen`'s
-## `ANIM_WAIT_SFX`.
+## count across frames instead of trusting that answer, and stops waiting once it
+## has stood still for [constant SERVICE_GAP_FRAMES]. `AudioStreamPlayer.playing`
+## is not that test: the dummy audio driver reports true and consumes nothing.
+## See `Gen2BattleScreen`'s `ANIM_WAIT_SFX`.
 func timeline_updates() -> int:
 	return _timeline_updates
 

--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -123,6 +123,61 @@ static func level_up_box() -> Gen2MenuBox:
 	)
 
 
+## `ForgetMove`'s own list, drawn over the field while `MoveAskForgetText` stands
+## in the text box below it: `hlcoord 5, 2` with `b, NUM_MOVES * 2` and
+## `c, MOVE_NAME_LENGTH`, its rows placed from `hlcoord 5 + 2, 2 + 2` a whole two
+## rows apart, and `w2DMenuFlags1` $20, which is STATICMENU_WRAP alone.
+const FORGET_LEFT: int = 5
+const FORGET_TOP: int = 2
+const FORGET_RIGHT: int = 19
+const FORGET_BOTTOM: int = 11
+const FORGET_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
+
+## The other three lists a battle puts in front of the player: the pack, the
+## balls it can throw, and the move an Ether goes on.
+##
+## `BattleMenu_Pack` opens `Pack` itself on the cartridge, four pockets with a
+## description under them, and `RestorePPEffect` borrows the same screen. The
+## battle here is handed the flat list of items it can use rather than the
+## pockets, so there is no pocket axis to draw and the box above is what is left:
+## the same rows, opened out to the full width so a count fits beside a name, and
+## `ScrollingMenu`'s arrows for the rows outside the window. The text box below
+## it stays for the description, which is where `UpdateItemDescription` writes.
+const LIST_LEFT: int = 0
+const LIST_TOP: int = 2
+const LIST_RIGHT: int = 19
+const LIST_BOTTOM: int = 11
+const LIST_ROWS: int = 4
+const LIST_FLAGS: int = FORGET_FLAGS
+## How many columns a row has, from [method Gen2MenuBox.text_start] to the frame
+## on the right.
+const LIST_TEXT_WIDTH: int = LIST_RIGHT - LIST_LEFT - 2
+
+
+static func forget_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(
+		FORGET_LEFT, FORGET_TOP, FORGET_RIGHT, FORGET_BOTTOM, FORGET_FLAGS
+	)
+
+
+## [param scroll] is `wMenuScrollPosition`, which the up arrow is drawn from, and
+## [param more] whether anything is outside the window at all.
+static func list_box(scroll: int = 0, more: bool = false) -> Gen2MenuBox:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		LIST_LEFT, LIST_TOP, LIST_RIGHT, LIST_BOTTOM, LIST_FLAGS
+	)
+	box.scrolling_arrows = more
+	box.scroll = scroll
+	return box
+
+
+## `wMenuScrollPosition` after a cursor move: the window travels the least that
+## keeps the cursor inside it, which is what `ScrollingMenu`'s own clamp does.
+static func list_scrolled(scroll: int, cursor: int, count: int) -> int:
+	var last: int = maxi(count - LIST_ROWS, 0)
+	return clampi(clampi(scroll, cursor - LIST_ROWS + 1, cursor), 0, last)
+
+
 ## `_2DMenuInterpretJoypad` over the main menu's own two-by-two: a press that
 ## would leave the grid is ignored, since it sets no wrap flag and no exit one.
 ## [param position] and the answer are `wBattleMenuCursorPosition`.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -270,10 +270,13 @@ var _world_context: Gen2BattleWorldContext = null
 var _pack_rows: Array[int] = []
 var _pack_quantities: Dictionary = {}
 var _pack_index: int = 0
+## `wMenuScrollPosition` for each list that can outgrow its window, kept apart so
+## a sub-list opened over the pack does not move the pack's own.
+var _list_scroll: Dictionary = {}
 var _pack_selecting: bool = false:
 	set(value):
 		_pack_selecting = value
-		_gate_annotations()
+		_list_state_changed()
 var _pack_item: int = 0
 ## `RestorePPEffect`'s own `.loop`, which asks which move before it restores
 ## anything. Only the three items that fill one slot ever open it.
@@ -283,7 +286,7 @@ var _pack_move_target: int = -1
 var _pack_move_selecting: bool = false:
 	set(value):
 		_pack_move_selecting = value
-		_gate_annotations()
+		_list_state_changed()
 
 var _capture_balls: Array[int] = []
 var _capture_quantities: Dictionary = {}
@@ -294,7 +297,7 @@ var _capture_refusal: String = ""
 var _capture_selecting: bool = false:
 	set(value):
 		_capture_selecting = value
-		_gate_annotations()
+		_list_state_changed()
 var _capture_waiting: bool = false
 var _capture_messages: Array[String] = []
 ## The [constant Gen2Battle.CAUGHT] event built by [method complete_capture] and
@@ -347,7 +350,7 @@ var _capture_nickname_asked: bool = false
 var _forget_stage: StringName = &"":
 	set(value):
 		_forget_stage = value
-		_gate_annotations()
+		_list_state_changed()
 var _forget_moves: Array = []
 var _forget_cursor: int = 0
 var _forget_confirm_cursor: int = 0
@@ -1711,6 +1714,19 @@ const ANIM_MOVE_LIMIT: int = 0x100
 ## (constants/move_constants.asm).
 const ANIM_THROW_POKE_BALL: int = 0x100
 
+## `.shake_and_break_free`'s four texts, indexed by how many times the ball
+## rocked. `PokeBallEffect` reads `wThrownBallWobbleCount`, which is one higher
+## than the count of rocks; the count itself is what
+## [method Gen2WorldPartyHost._failed_wobbles] answers with. There is no line for
+## a rock on its own: the rocking is the animation, and one of these is the whole
+## of what a failed throw says.
+const BREAK_FREE_TEXT: Array[String] = [
+	"Oh no! The #MON\nbroke free!",
+	"Aww! It appeared\nto be caught!",
+	"Aargh!\nAlmost had it!",
+	"Shoot! It was so\nclose too!",
+]
+
 ## `SendOutMonText`'s four texts, in [constant Gen2Battle.SEND_OUT_GO]'s order.
 const SEND_OUT_LINES: Array[String] = [
 	"Go! %s!", "Do it! %s!", "Go for it,\n%s!", "Your foe's weak!\nGet'm, %s!",
@@ -2401,6 +2417,16 @@ func _annotations_visible() -> bool:
 		and not _capture_selecting and _forget_stage == &""
 
 
+## One of the four lists in front of the fight opened or closed: the pack, its
+## two sub-lists and the forget offer. Both layers follow the state rather than
+## every call site that changes one remembering to take it down. A ball thrown
+## from the pack left its list standing over the whole fight, because the throw
+## is a message and no message redraws a menu.
+func _list_state_changed() -> void:
+	_gate_annotations()
+	_reopen_menu_layer()
+
+
 ## Rebuilds the layer the frame a modal takes the interface or gives it back.
 ##
 ## Every state [method _annotations_visible] reads writes through a setter that
@@ -2557,11 +2583,11 @@ func select_pack_row(index: int) -> Dictionary:
 	return {"ok": true, "item": selected_pack_item()}
 
 
+## The list itself is the menu layer's; the box below it is
+## `UpdateItemDescription`'s, which prints the row the cursor is on.
 func _show_pack_selection() -> void:
-	var item: int = selected_pack_item()
-	show_message("Use %s x%d. Left and right: choose, A: use, B: back" % [
-		_item_name(item), int(_pack_quantities.get(item, 1)),
-	])
+	show_message(Gen2WorldPack.row_description(_data, selected_pack_item()))
+	_reopen_menu_layer()
 
 
 func close_battle_pack() -> void:
@@ -2618,12 +2644,19 @@ func _open_pack_move(item: int, target: int) -> void:
 
 
 func _show_pack_move_selection() -> void:
+	show_message(String(_selected_pack_move().get("description", "")))
+	_reopen_menu_layer()
+
+
+## The move the Ether would go on, as [GameData] holds it.
+func _selected_pack_move() -> Dictionary:
+	if _data == null or _pack_move_slots.is_empty():
+		return {}
 	var mon: Gen2BattleMon = _battle.party(Gen2Battle.PLAYER).at(_pack_move_target)
-	var slot: int = int(_pack_move_slots[_pack_move_index])
-	var move: Dictionary = _data.move(int(mon.moves[slot])) if _data != null else {}
-	show_message("Restore %s %d PP. Left and right: choose, A: use, B: back" % [
-		String(move.get("name", "MOVE")), mon.pp_left(slot),
-	])
+	if mon == null:
+		return {}
+	var slot: int = int(_pack_move_slots[posmod(_pack_move_index, _pack_move_slots.size())])
+	return _data.move(int(mon.moves[slot]))
 
 
 func _close_pack_move() -> void:
@@ -2646,9 +2679,7 @@ func _use_pack_item(item: int, target: int, move_slot: int = -1) -> Dictionary:
 		_pack_selecting = true
 		return used
 	item_used.emit(item, target)
-	## `ItemUsedText`, less its `<PLAYER>` the way every other host-authored line
-	## here drops one.
-	show_message("Used the %s." % _item_name(item))
+	show_message(_item_used_text(item))
 	if _battle.is_over():
 		## `PokeDollEffect`'s `wForcedSwitch`: the battle is already over, so no
 		## turn is taken and the terminal text is what follows this line.
@@ -2735,7 +2766,7 @@ func throw_capture_ball() -> Dictionary:
 	var ball: int = _selected_capture_ball()
 	_capture_selecting = false
 	_capture_waiting = true
-	show_message("You threw a %s!" % _item_name(ball))
+	show_message(_item_used_text(ball))
 	capture_requested.emit(ball)
 	return {"ok": true, "status": &"waiting", "ball": ball}
 
@@ -2764,8 +2795,6 @@ func complete_capture(result: Dictionary) -> Dictionary:
 
 	var wobbles: int = clampi(int(result.get("wobbles", 0)), 0, 3)
 	var caught: bool = bool(result.get("caught", false))
-	for _wobble: int in wobbles:
-		_capture_messages.append("The ball shook!")
 	if caught:
 		_capture_messages.append("Gotcha! %s was caught!" % _name_of(_enemy))
 		## `.catch_bug_contest_mon` runs after `Text_GotchaMonWasCaught`, and
@@ -2778,7 +2807,7 @@ func complete_capture(result: Dictionary) -> Dictionary:
 		_capture_terminal = true
 		_capture_caught_event = _caught_event(result)
 	else:
-		_capture_messages.append("%s broke free!" % _name_of(_enemy))
+		_capture_messages.append(BREAK_FREE_TEXT[wobbles])
 	_begin_capture_animation(result_ball, wobbles, caught)
 	return result
 
@@ -2818,10 +2847,8 @@ func _begin_capture_animation(ball: int, wobbles: int, caught: bool) -> void:
 
 
 func _show_capture_selection() -> void:
-	show_message(
-		"Choose %s x%d. Left and right: select, A: throw"
-		% [_item_name(_selected_capture_ball()), _capture_quantity(_selected_capture_ball())]
-	)
+	show_message(Gen2WorldPack.row_description(_data, _selected_capture_ball()))
+	_reopen_menu_layer()
 
 
 func _show_next_capture_message() -> void:
@@ -2893,6 +2920,14 @@ func _item_name(item: int) -> String:
 		return "BALL"
 	var item_name: String = _data.item_name(item)
 	return item_name if not item_name.is_empty() else "BALL %d" % item
+
+
+## `ItemUsedText`, the one line `PokeBallEffect` and every other battle item
+## print before their effect runs. A ball says it too: the throw, the rocking and
+## the click are the animation behind this line, and the next thing said is
+## already the outcome.
+func _item_used_text(item: int) -> String:
+	return "%s used the\n%s." % [_player_label(), _item_name(item)]
 
 
 func _is_wild_battle() -> bool:
@@ -3227,23 +3262,19 @@ func _show_forget_stage(stage: StringName) -> void:
 		_show_forget_confirm()
 
 
-## The two yes/no boxes, which open on YES the way YesNoBox does.
+## The two yes/no boxes, which open on YES the way YesNoBox does. The question is
+## the box's own and the answer is `PlaceYesNoBox`', drawn over the field once the
+## question has been read.
 func _show_forget_confirm() -> void:
-	show_message("%s %s Left and right: move, A: choose" % [
-		_forget_prompt_text(),
-		">YES  NO" if _forget_confirm_cursor == 0 else " YES >NO",
-	])
+	show_message(_forget_prompt_text())
+	_reopen_menu_layer()
 
 
+## `ForgetMove.loop`: `MoveAskForgetText` in the box and the list in its own
+## frame over the field, both drawn again on every pass round the loop.
 func _show_forget_list() -> void:
-	var names: PackedStringArray = []
-	for index: int in _forget_moves.size():
-		var entry: Dictionary = _forget_moves[index]
-		var move_name: String = String(entry.get("name", ""))
-		names.append("[%s]" % move_name if index == _forget_cursor else move_name)
-	show_message("%s %s Up and down: move, A: forget, B: back" % [
-		Gen2MoveForget.which_text(), " ".join(names),
-	])
+	show_message(Gen2MoveForget.which_text())
+	_reopen_menu_layer()
 
 
 ## The offer's own name fields, which [method Gen2Battle.pending_learn] carries
@@ -4254,13 +4285,22 @@ func _reopen_menu_layer() -> void:
 func _refresh_menu_layer() -> void:
 	if _menu_layer == null:
 		return
-	var signature: String = "%s|%s|%d|%d|%d|%s" % [
+	var signature: String = "%s|%s|%d|%d|%d|%s|%s" % [
 		_switch_stage, _menu_stage,
 		_switch_offer.selected_index() if _switch_offer != null else (
 			_switch_menu.cursor if _switch_menu != null else -1
 		),
 		int(_offer_still_reading()),
 		_menu_position * 8 + _move_cursor,
+		## The four lists in front of the fight, each with the cursor it is
+		## drawn from: which one is up is part of what the layer is holding.
+		"%s%d,%d,%d,%d,%d,%d" % [
+			_forget_stage, _forget_cursor, _forget_confirm_cursor,
+			_pack_index if _pack_selecting else -1,
+			_pack_move_index if _pack_move_selecting else -1,
+			_capture_ball_index if _capture_selecting else -1,
+			_pack_rows.size(),
+		],
 		## The icons move on their own clock, so the cursor alone does not say
 		## whether the page still draws what the layer is holding.
 		_party_page.animation_signature() if _party_page != null else "",
@@ -4286,6 +4326,20 @@ func _refresh_menu_layer() -> void:
 		&"pick", &"refused":
 			_draw_party_page()
 			return
+	## Each of these is a list in front of the fight, and each owns the joypad
+	## while it stands, so at most one of them is up at a time.
+	if _forget_stage != &"":
+		_draw_forget_stage()
+		return
+	if _pack_move_selecting:
+		_draw_pack_move_menu()
+		return
+	if _pack_selecting:
+		_draw_pack_menu()
+		return
+	if _capture_selecting:
+		_draw_capture_menu()
+		return
 	match _menu_stage:
 		&"main":
 			_draw_battle_menu()
@@ -4399,7 +4453,9 @@ func _blank_tiles(
 				indices[offset] = 0
 
 
-func _draw_yes_no_box() -> void:
+## [param cursor] is which row is chosen, and -1 asks the switch offer that owns
+## every other one of these boxes.
+func _draw_yes_no_box(cursor: int = -1) -> void:
 	if _menu_page == null or _offer_still_reading():
 		_menu_layer.visible = false
 		return
@@ -4408,7 +4464,10 @@ func _draw_yes_no_box() -> void:
 		YES_NO_LEFT + YES_NO_SPAN.x, YES_NO_TOP + YES_NO_SPAN.y, YES_NO_FLAGS
 	)
 	_show_menu_image(
-		_menu_page.render(box, YES_NO_OPTIONS, _switch_offer.selected_index()),
+		_menu_page.render(
+			box, YES_NO_OPTIONS,
+			cursor if cursor >= 0 else _switch_offer.selected_index()
+		),
 		box.border_position() * Gen2Font.TILE
 	)
 
@@ -4451,6 +4510,93 @@ func _draw_move_menu() -> void:
 		box.border_position() * Gen2Font.TILE
 	)
 	_draw_move_info(_move_rows[_move_cursor])
+
+
+## One of the lists standing in front of the fight, windowed onto
+## [constant Gen2BattleMenu.LIST_ROWS] rows with the cursor kept inside it.
+func _draw_list_menu(key: StringName, labels: Array, cursor: int) -> void:
+	_menu_layer.visible = false
+	if _menu_page == null or labels.is_empty():
+		return
+	var scroll: int = Gen2BattleMenu.list_scrolled(
+		int(_list_scroll.get(key, 0)), cursor, labels.size()
+	)
+	_list_scroll[key] = scroll
+	var box: Gen2MenuBox = Gen2BattleMenu.list_box(
+		scroll, labels.size() > Gen2BattleMenu.LIST_ROWS
+	)
+	_show_layer_image(
+		_battle_menu_layer,
+		_menu_page.render(
+			box,
+			labels.slice(scroll, scroll + Gen2BattleMenu.LIST_ROWS),
+			cursor - scroll
+		),
+		box.border_position() * Gen2Font.TILE
+	)
+
+
+## A row with [param tail] against the box's right-hand edge, which is where the
+## pack writes a count and the move list a PP pair.
+static func _list_row(text: String, tail: String) -> String:
+	var room: int = maxi(Gen2BattleMenu.LIST_TEXT_WIDTH - tail.length(), 0)
+	return text.left(room).rpad(room) + tail
+
+
+## `Pack`'s own rows for the items a battle can use, with what is left of each.
+func _draw_pack_menu() -> void:
+	var labels: Array = []
+	for item: int in _pack_rows:
+		labels.append(
+			_list_row(_item_name(item), "×%d" % int(_pack_quantities.get(item, 1)))
+		)
+	_draw_list_menu(&"pack", labels, _pack_index)
+
+
+## The BALL pocket of the same list: what choosing a ball in the pack opens, and
+## the whole of what a fight with no bag behind it is handed.
+func _draw_capture_menu() -> void:
+	var labels: Array = []
+	for ball: int in _capture_balls:
+		labels.append(_list_row(_item_name(ball), "×%d" % _capture_quantity(ball)))
+	_draw_list_menu(&"capture", labels, _capture_ball_index)
+
+
+## `RestorePPEffect`'s question, as the pack's own move list: which slot the
+## Ether goes on, with the PP it stands on.
+func _draw_pack_move_menu() -> void:
+	var mon: Gen2BattleMon = _battle.party(Gen2Battle.PLAYER).at(_pack_move_target) \
+		if _battle != null else null
+	if mon == null or _data == null:
+		_menu_layer.visible = false
+		return
+	var labels: Array = []
+	for raw_slot: int in _pack_move_slots:
+		var record: Dictionary = _data.move(int(mon.moves[raw_slot]))
+		labels.append(_list_row(
+			String(record.get("name", "")),
+			"%2d/%2d" % [mon.pp_left(raw_slot), int(record.get("pp", 0))]
+		))
+	_draw_list_menu(&"pack_move", labels, _pack_move_index)
+
+
+## `ForgetMove`'s own frame over the field, or the `YesNoBox` of the two
+## questions either side of the list.
+func _draw_forget_stage() -> void:
+	if _forget_stage != &"list":
+		_draw_yes_no_box(_forget_confirm_cursor)
+		return
+	_menu_layer.visible = false
+	if _menu_page == null or _forget_moves.is_empty():
+		return
+	var labels: Array = []
+	for entry: Dictionary in _forget_moves:
+		labels.append(String(entry.get("name", "")))
+	var box: Gen2MenuBox = Gen2BattleMenu.forget_box()
+	_show_layer_image(
+		_battle_menu_layer, _menu_page.render(box, labels, _forget_cursor),
+		box.border_position() * Gen2Font.TILE
+	)
 
 
 ## `MoveInfoBox`: the type and the PP pair of the row the cursor is on, or its
@@ -5247,10 +5393,10 @@ func _handle_button(button: int) -> bool:
 
 	if _pack_move_selecting:
 		match button:
-			Gen2Button.RIGHT:
+			Gen2Button.RIGHT, Gen2Button.DOWN:
 				_pack_move_index = posmod(_pack_move_index + 1, _pack_move_slots.size())
 				_show_pack_move_selection()
-			Gen2Button.LEFT:
+			Gen2Button.LEFT, Gen2Button.UP:
 				_pack_move_index = posmod(_pack_move_index - 1, _pack_move_slots.size())
 				_show_pack_move_selection()
 			Gen2Button.A:
@@ -5266,9 +5412,9 @@ func _handle_button(button: int) -> bool:
 
 	if _pack_selecting:
 		match button:
-			Gen2Button.RIGHT:
+			Gen2Button.RIGHT, Gen2Button.DOWN:
 				select_pack_row(_pack_index + 1)
-			Gen2Button.LEFT:
+			Gen2Button.LEFT, Gen2Button.UP:
 				select_pack_row(_pack_index - 1)
 			Gen2Button.A:
 				use_selected_pack_item()
@@ -5280,9 +5426,9 @@ func _handle_button(button: int) -> bool:
 
 	if _capture_selecting:
 		match button:
-			Gen2Button.RIGHT:
+			Gen2Button.RIGHT, Gen2Button.DOWN:
 				select_capture_ball(_capture_ball_index + 1)
-			Gen2Button.LEFT:
+			Gen2Button.LEFT, Gen2Button.UP:
 				select_capture_ball(_capture_ball_index - 1)
 			Gen2Button.A:
 				throw_capture_ball()

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1912,8 +1912,11 @@ func _run_next_anim_step() -> void:
 				## and it costs one frame either way.
 				if _audio_player != null and _audio_player.effect_playing():
 					var rendered: int = _audio_player.timeline_updates()
-					if int(step.get("rendered", -1)) != rendered:
+					var still: int = 0 if int(step.get("rendered", -1)) != rendered \
+						else int(step.get("still", 0)) + 1
+					if still <= Gen2AudioPlayer.SERVICE_GAP_FRAMES:
 						step["rendered"] = rendered
+						step["still"] = still
 						_anim_plan.push_front(step)
 						_anim_delay = 1
 						return
@@ -2925,6 +2928,13 @@ func _open_capture_nickname() -> bool:
 	var species_name: String = _name_of(_enemy)
 	if species_name.is_empty():
 		return false
+	## `PokeBallEffect` reaches `AskGiveNicknameText` only once
+	## `Text_GotchaMonWasCaught` has finished printing, so the prompt waits for
+	## the box rather than opening over it. True, because the pump is meant to
+	## wait here: without it a Nuzlocke, whose question is skipped, put its
+	## keyboard on screen halfway through "Gotcha! X was caught!".
+	if _box != null and (_box.is_revealing() or _box.has_pages_left()):
+		return true
 	_capture_nickname_asked = true
 	_capture_nickname = species_name
 	var host := Gen2NicknamePromptScreen.new()

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -404,7 +404,65 @@ static func segmented(
 	if selected >= 0 and selected < buttons.size():
 		buttons[selected].set_active(true)
 	track.set_meta(&"wrapping_row", line)
-	return track
+	var hug := HugRow.new()
+	hug.add_child(track)
+	## A [FieldRow] asks a wrapping control how wide it would like to be; a page
+	## body does not, and gives it the whole column. Carried onto the wrapper so
+	## a segmented control in a field is measured exactly as it was.
+	hug.set_meta(&"wrapping_row", line)
+	return hug
+
+
+## One control kept at the width it would like rather than the width it is given.
+##
+## An [HFlowContainer] measures as one column, since that is the narrowest it can
+## be drawn, so a track asking for its minimum would always stack. This asks for
+## that minimum, which is what lets it wrap on a phone, and then draws the child
+## at [method Gen2LauncherUI.preferred_width] whenever the row is wide enough to
+## hold it on one line.
+##
+## A [Container] is not usable here for the reason [FieldRow] gives.
+class HugRow extends Control:
+	var _pending: bool = false
+
+	func _init() -> void:
+		resized.connect(_queue_layout)
+
+	func _ready() -> void:
+		var child: Control = _child()
+		if child != null:
+			child.minimum_size_changed.connect(_queue_layout)
+		_queue_layout()
+
+	func _queue_layout() -> void:
+		update_minimum_size()
+		if _pending:
+			return
+		_pending = true
+		_layout.call_deferred()
+
+	func _child() -> Control:
+		for node: Node in get_children():
+			var control := node as Control
+			if control != null and control.visible:
+				return control
+		return null
+
+	func _get_minimum_size() -> Vector2:
+		var child: Control = _child()
+		return child.get_combined_minimum_size() if child != null else Vector2.ZERO
+
+	func _layout() -> void:
+		_pending = false
+		var child: Control = _child()
+		if child == null:
+			return
+		var wide: float = Gen2LauncherUI.preferred_width(child)
+		child.position = Vector2.ZERO
+		child.size = Vector2(
+			minf(wide, size.x) if size.x > 0.0 else wide,
+			maxf(size.y, child.get_combined_minimum_size().y)
+		)
 
 
 ## One whole number, typed or stepped. A slider is the wrong shape for a value

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -2055,6 +2055,12 @@ static func _source_hp_catch_rate(max_hp: int, current_hp: int, catch_rate: int)
 	return clampi(maxi(1, int(remaining * catch_rate / float(divisor))), 1, 255)
 
 
+## How many times the ball rocks before it opens, which is
+## `GetPokeBallWobble`'s own count minus the call that ends it: the routine
+## increments `wThrownBallWobbleCount` before it rolls, so a throw that escapes
+## on the first roll has rocked no times at all and `.shake_and_break_free`
+## answers it with `BallBrokeFreeText`. Three is the whole run, which is both a
+## catch and the `cp 3 + 1` escape.
 static func _failed_wobbles(catch_rate: int, random: RandomNumberGenerator) -> int:
 	var chance: int = 63
 	for row: Array in WOBBLE_PROBABILITIES:
@@ -2063,7 +2069,7 @@ static func _failed_wobbles(catch_rate: int, random: RandomNumberGenerator) -> i
 			break
 	for wobble: int in 3:
 		if random.randi_range(0, 255) >= chance:
-			return wobble + 1
+			return wobble
 	return 3
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -273,6 +273,9 @@ var _last_battle_outcome: StringName = &""
 ## The audio driver's rendered-frame count as of the last frame, for the one
 ## script wait that reads it. See [method Gen2AudioPlayer.timeline_updates].
 var _audio_rendered_seen: int = 0
+## How many frames it has stood still for, against
+## [constant Gen2AudioPlayer.SERVICE_GAP_FRAMES].
+var _audio_still_frames: int = 0
 ## Which of `HangUp`'s seven writes is on the box, so each is written once
 ## rather than every frame of its twenty.
 var _hang_up_phase: StringName = &""
@@ -431,8 +434,14 @@ func _build_world() -> void:
 	var initial_day: int = day
 	var initial_hour: int = hour
 	var initial_minute: int = minute
+	## A world opened for a save plays that save's rules, whoever opened it.
+	## `Gen2GameRuntime._activate_rules` installs the slot's own set when the
+	## launcher chooses one, and nothing does when a test or a tool injects one
+	## through [method set_save]: a Nuzlocke slot then played as the cartridge's
+	## own game, which is the one difference a rules block exists to make.
+	var save_rules: Gen2Rules = selected_save.run_rules if selected_save != null else null
 	if selected_save != null and selected_save.world != null:
-		_world = Gen2WorldAPI.open_snapshot(_data, selected_save.world)
+		_world = Gen2WorldAPI.open_snapshot(_data, selected_save.world, save_rules)
 		if _world == null:
 			_show_load_failure(
 				"Saved overworld unavailable",
@@ -461,7 +470,7 @@ func _build_world() -> void:
 		var saveless_state := Gen2WorldState.new()
 		Gen2WorldSpawn.apply_initial_decorations(saveless_state)
 		_world = Gen2WorldAPI.open(
-			_data, map_group, map_number, start_cell, saveless_state
+			_data, map_group, map_number, start_cell, saveless_state, save_rules
 		)
 	else:
 		var development_state := Gen2WorldState.new(
@@ -962,10 +971,12 @@ func advance_frame() -> void:
 	## servicing leaves `effect_playing()` true for the rest of the run, so the
 	## rendered-frame count is what decides whether this is a wait at all.
 	var audio_rendered: int = _audio_player.timeline_updates() if _audio_player != null else 0
-	var audio_moved: bool = audio_rendered != _audio_rendered_seen
+	_audio_still_frames = 0 if audio_rendered != _audio_rendered_seen \
+		else _audio_still_frames + 1
 	_audio_rendered_seen = audio_rendered
 	if _audio_waiting and _audio_player != null \
-		and (not _audio_player.effect_playing() or not audio_moved):
+		and (not _audio_player.effect_playing()
+			or _audio_still_frames > Gen2AudioPlayer.SERVICE_GAP_FRAMES):
 		_audio_waiting = false
 		var audio_result: Dictionary = Gen2WorldHost.complete_runtime_request(
 			_world, {"ok": true, "sound_finished": true}
@@ -1266,8 +1277,15 @@ func _handle_button(button: int) -> bool:
 	if _battle_host != null:
 		_battle_host.press_button(button)
 		return true
+	## `DoBattleTransition` owns every frame between the encounter and the battle
+	## screen with the joypad unread, the same way a map fade does. Without it a
+	## press landing in those frames reached `script_input_waiting()` below and
+	## cancelled the request `startbattle` was waiting on, so the script died
+	## with `invalid_battle_outcome`: the fight still ran, and the gym leader's
+	## badge, the flag behind it and everything after it never arrived. A player
+	## holding A through a trainer's approach is what does it.
 	if not _map_fade.is_empty() or not _trainer_approach.is_empty() \
-		or _world.phone_ring_active():
+		or _battle_transition != null or _world.phone_ring_active():
 		return true
 	## In front of every other overlay: `EvolveAfterBattle` runs with the map
 	## loop suspended, and the pack path reaches it with the pack still open
@@ -3320,7 +3338,13 @@ func _preview_field_move(move: int, badge: int) -> void:
 		_script_prompt = "Field move preview needs a party"
 		_refresh_labels()
 		return
-	(save.party[0] as Gen2SaveMon).moves[0] = move
+	var teacher: Gen2SaveMon = save.party[0]
+	teacher.moves[0] = move
+	## The slot's PP with it. `Gen2SaveValidator` refuses a row carrying more PP
+	## than its move has, so a Tackle at 35 replaced by a Surf at 15 left a save
+	## every world transaction after it would refuse: the field move worked and
+	## the next catch, purchase or party change reported nothing but failure.
+	teacher.pp[0] = int(_data.move(move).get("pp", 0))
 	_injected_save = save
 	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
 		badge, Gen2WorldState.is_crystal_profile(_data)
@@ -4227,10 +4251,20 @@ func _teachable_tmhm_for(species: int) -> int:
 ## Public screenshot driver for the battle-request host path. It starts the
 ## same request shape emitted by [Gen2WorldScriptRunner], without pretending a
 ## map event was present in the selected development map.
-func preview_battle_request() -> void:
+##
+## [param battle_type] is `wBattleType`, so
+## [constant Gen2Battle.BATTLETYPE_FORCESHINY] opens the fight the Lake of Rage
+## Gyarados is met in.
+func preview_battle_request(
+	species: int = 16, at_level: int = 5,
+	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL
+) -> void:
 	_start_battle_request({
 		"kind": &"battle_requested",
-		"values": {"kind": &"wild", "pokemon": 16, "level": 5},
+		"values": {
+			"kind": &"wild", "pokemon": species, "level": at_level,
+			"battle_type": battle_type,
+		},
 	})
 
 
@@ -7840,8 +7874,11 @@ func _advance_sound_schedule() -> void:
 		if bool(due.get("wait", false)):
 			if _audio_player != null and _audio_player.effect_playing():
 				var rendered: int = _audio_player.timeline_updates()
-				if int(due.get("rendered", -1)) != rendered:
+				var still: int = 0 if int(due.get("rendered", -1)) != rendered \
+					else int(due.get("still", 0)) + 1
+				if still <= Gen2AudioPlayer.SERVICE_GAP_FRAMES:
 					due["rendered"] = rendered
+					due["still"] = still
 					break
 		elif int(due.get("frame", 0)) > _sound_schedule_frame:
 			break

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4268,6 +4268,23 @@ func preview_battle_request(
 	})
 
 
+## Public screenshot driver for a wild that is already standing on the map: the
+## one a provider put on [param cell], met exactly as a step onto that cell meets
+## it. The entry's id travels with the request, so the provider is told how the
+## fight ended and can take its Pokemon off the map; a battle started any other
+## way leaves the sprite standing where it was.
+func preview_meet_visible_encounter(cell: Vector2i) -> bool:
+	if _encounters == null or not _encounters.active():
+		return false
+	var request: Dictionary = _encounters.battle_request_at(cell)
+	if request.is_empty():
+		return false
+	_battle_encounter_id = StringName(request["visible_encounter"])
+	_zero_map_name_sign_timer()
+	_start_battle_request(request)
+	return true
+
+
 ## Public screenshot driver for the real wild capture bridge. It adds one
 ## development Master Ball, starts an imported wild encounter, and leaves the
 ## production battle overlay on its throw message.

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -248,10 +248,9 @@ func test_a_capture_publishes_and_a_mod_line_lands_behind_it() -> void:
 		"destination": {"ok": true, "destination": &"box"},
 	})
 
-	_battle_screen._show_next_capture_message()
-	assert_string_contains(String(_battle_screen.battle_snapshot()["message"]), "shook")
+	## `Text_GotchaMonWasCaught` is the whole of what a caught throw says: the
+	## rocking is the animation, and nothing is published before the line.
 	assert_eq(_caught.size(), 0, "published before the line that says why")
-
 	_battle_screen._show_next_capture_message()
 	assert_string_contains(String(_battle_screen.battle_snapshot()["message"]), "Gotcha!")
 	assert_eq(_caught.size(), 1)

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -473,6 +473,65 @@ func test_the_end_of_a_turn_opens_the_battle_menu() -> void:
 	assert_false(_screen._renderer_input_free(), "the menu owns the joypad")
 
 
+## PACK opened a list whose whole presentation was a line of key bindings in the
+## text box. It is a drawn list like every other one the battle puts up, and the
+## box under it is `UpdateItemDescription`'s.
+func test_the_pack_is_a_drawn_list_with_the_row_description_under_it() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	var items: Array[int] = [BattleFixture.POTION, BattleFixture.FULL_HEAL]
+	_screen.set_battle_pack(
+		items, {BattleFixture.POTION: 3, BattleFixture.FULL_HEAL: 1}
+	)
+
+	await _step(Gen2Button.DOWN)
+	assert_eq(int(_screen.battle_snapshot()["menu_position"]), Gen2BattleMenu.PACK)
+	await _step(Gen2Button.A)
+	assert_true(bool(_screen.get("_pack_selecting")))
+	assert_true(_menu_layer().visible, "the rows are drawn, not spelled out")
+	var message: String = String(_screen.battle_snapshot()["message"])
+	assert_eq(message, Gen2WorldPack.row_description(_data, BattleFixture.POTION))
+	assert_false(message.contains("Left and right"), "a key binding is not a screen")
+
+	await _step(Gen2Button.DOWN)
+	assert_eq(
+		_screen.selected_pack_item(), BattleFixture.FULL_HEAL, "a list walks downwards"
+	)
+	assert_eq(
+		String(_screen.battle_snapshot()["message"]),
+		Gen2WorldPack.row_description(_data, BattleFixture.FULL_HEAL)
+	)
+
+
+## The throw is a message and no message redraws a menu, so the ball list stood
+## over the whole of the fight it had just started.
+func test_throwing_a_ball_takes_the_list_off_the_screen() -> void:
+	var battle: Gen2Battle = _menu_battle()
+	await _open(battle, [Gen2Battle.use_move(0), Gen2Battle.use_move(0)])
+	await _advance_to_menu()
+	_screen.set_battle_pack(
+		[BattleFixture.POTION, BattleFixture.POKE_BALL],
+		{BattleFixture.POTION: 1, BattleFixture.POKE_BALL: 4}
+	)
+	_screen.set_capture_balls([BattleFixture.POKE_BALL], {BattleFixture.POKE_BALL: 4})
+	## A ball is only thrown in a wild battle, which is what the world tells the
+	## screen when it hands one over.
+	_screen.set("_world_battle_active", true)
+	_screen.set("_world_battle_request", {"values": {"kind": &"wild"}})
+
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
+	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
+	assert_true(bool(_screen.get("_capture_selecting")), "the ball pocket is up")
+	assert_true(_menu_layer().visible)
+
+	await _step(Gen2Button.A)
+	assert_true(bool(_screen.get("_capture_waiting")), "the ball is in the air")
+	assert_false(_menu_layer().visible, "and nothing is drawn over the fight")
+
+
 ## `_2DMenuInterpretJoypad` with neither wrap flag: a press off the grid is
 ## ignored, and the four positions are the source's own order.
 func test_the_battle_menu_walks_its_two_by_two_and_does_not_wrap() -> void:

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -394,6 +394,46 @@ func battle_finished(id, result) -> void:
 """
 
 
+## A driver that aims a shot at a wild already on the map goes through the same
+## seam a step does, so the fight carries the entry's id and its Pokemon is taken
+## off the map when the fight is over. `preview_battle_request` invents a wild
+## instead, and the one standing there is left where it was however it ended.
+func test_meeting_a_drawn_wild_carries_its_id_the_way_a_step_does() -> void:
+	var provider: Object = _script(PROVIDER_SOURCE).new()
+	assert_true(
+		Gen2ModHost.instance().register_visible_encounters(&"wilds", provider)["ok"]
+	)
+	var packed: PackedScene = load("res://game/world/world_screen.tscn")
+	_world_screen = packed.instantiate() as Gen2WorldScreen
+	_world_screen.map_group = Fixture.MAP_GROUP
+	_world_screen.map_number = Fixture.MAP_NUMBER
+	_world_screen.start_cell = Vector2i(7, 6)
+	_world_screen.set_data(_data)
+	add_child(_world_screen)
+	await get_tree().process_frame
+	_world_screen.set_process(false)
+	_world_screen._world.current_map.environment = Gen2WorldAPI.ENVIRONMENT_CAVE
+	_world_screen._encounters.set_providers([provider])
+	var cell := Vector2i(7, 7)
+	provider.set("entry", {
+		"id": &"a", "cell": cell, "species": Fixture.TRAINER_SPECIES,
+		"level": 5, "method": Gen2WorldEncounter.METHOD_GRASS,
+	})
+	_world_screen.advance_frames(1)
+
+	assert_true(_world_screen.preview_meet_visible_encounter(cell))
+	assert_eq(_world_screen._battle_encounter_id, &"a")
+	_world_screen._on_battle_finished({"outcome": Gen2WorldBattleAdapter.OUTCOME_CAUGHT})
+	var reported: Array = provider.get("results")
+	assert_eq(reported.size(), 1, "the provider is told, so it can take it away")
+	assert_eq(StringName(reported[0][0]), &"a")
+
+	assert_false(
+		_world_screen.preview_meet_visible_encounter(Vector2i(0, 0)),
+		"nothing stands there"
+	)
+
+
 ## The whole seam in one walk: the provider is contexted from the map's own
 ## tables, its entry is validated against them, drawn with the SPECIES' colours,
 ## and met by stepping onto it instead of by a roll.

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -377,6 +377,33 @@ func test_cut_facing_nothing_reports_the_source_refusal() -> void:
 	assert_eq(_world_screen._world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
 
 
+## `preview_surf` rewrites the first move slot, and `Gen2SaveValidator` refuses a
+## row carrying more PP than its move has. Without the slot's PP moving with it,
+## a Tackle at 35 replaced by a Surf at 15 left a save every world transaction
+## after it refused: the field move worked, and the next catch, purchase or party
+## change reported nothing but failure.
+func test_the_surf_driver_leaves_a_save_a_transaction_will_accept() -> void:
+	await _open_surf_world()
+	var before: Gen2SaveData = _world_screen._injected_save
+	## More PP than any move has, so the slot is only valid afterwards if the
+	## driver wrote the new move's own maximum into it.
+	(before.party[0] as Gen2SaveMon).pp[0] = 99
+
+	_world_screen.preview_surf()
+	var save: Gen2SaveData = _world_screen._injected_save
+	assert_not_null(save)
+	assert_eq(int((save.party[0] as Gen2SaveMon).moves[0]), Gen2WorldFieldMove.MOVE_SURF)
+	assert_eq(
+		int((save.party[0] as Gen2SaveMon).pp[0]),
+		int(_data.move(Gen2WorldFieldMove.MOVE_SURF).get("pp", 0)),
+		"the slot carries the PP of the move now in it"
+	)
+	assert_true(
+		bool(Gen2SaveValidator.validate(save, _data).get("ok", false)),
+		"so a transaction opened on this save is not refused"
+	)
+
+
 func test_submenu_lists_surf_for_a_mon_that_knows_it() -> void:
 	await _open_surf_world()
 	var party: Gen2PartyScreen = await _open_party()

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -291,6 +291,37 @@ func test_a_party_heal_request_is_settled_where_it_is_staged() -> void:
 	assert_true((save.party[0] as Gen2SaveMon).hp > 1, "the party healed with no press")
 
 
+## `Script_waitsfx` holds the script until the effect channels are free, and a
+## driver nobody is servicing would hold it for ever, so the wait gives up once
+## the rendered-frame count has stood still. Counted over
+## [constant Gen2AudioPlayer.SERVICE_GAP_FRAMES] rather than over one frame: the
+## buffer is filled to a depth rather than by the frame, and read as one frame
+## every `waitsfx` in the game ended on the frame after it started, so a badge, a
+## TM and every item jingle printed their line and replaced it unread.
+func test_a_sound_wait_survives_a_frame_the_driver_rendered_nothing_in() -> void:
+	_world_screen = await _open_world()
+	var player: Gen2AudioPlayer = _world_screen._audio_player
+	assert_not_null(player)
+	## What `playsound` leaves behind: `_CheckSFX` reads the channels rather than
+	## the request, so one of them being on is the whole of "a sound is playing".
+	var engine: Gen2SoundEngine = player.get("_engine")
+	engine.channels[Gen2SoundEngine.NUM_MUSIC_CHANNELS].channel_on = true
+	assert_true(player.effect_playing())
+
+	_world_screen._audio_waiting = true
+	_world_screen.advance_frame()
+	assert_true(
+		_world_screen._audio_waiting,
+		"one frame the driver rendered nothing in is not a stall"
+	)
+	for _frame: int in Gen2AudioPlayer.SERVICE_GAP_FRAMES + 2:
+		_world_screen.advance_frame()
+	assert_false(
+		_world_screen._audio_waiting,
+		"and a driver nobody services still gives the script back"
+	)
+
+
 ## `Script_pokepic` puts its box up and `Script_cry` is the next command, so the
 ## picture and the runtime request the cry stages land on the same result. The
 ## request takes the pump out of the result loop, and the events beside it are

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -633,7 +633,7 @@ func test_master_ball_capture_runs_through_the_real_battle_overlay() -> void:
 	_settle_frames(host)
 	assert_eq(
 		host.battle_snapshot()["message"],
-		"You threw a %s!" % _data.item_name(Gen2WorldPartyHost.ITEM_MASTER_BALL)
+		host._item_used_text(Gen2WorldPartyHost.ITEM_MASTER_BALL)
 	)
 
 	var caught: String = "Gotcha! %s was caught!" % _wild_name()
@@ -716,14 +716,16 @@ func test_failed_capture_shows_break_free_and_returns_to_battle() -> void:
 	_settle_frames(host)
 	assert_eq(
 		host.battle_snapshot()["message"],
-		"You threw a %s!" % _data.item_name(Gen2WorldPartyHost.ITEM_POKE_BALL)
+		host._item_used_text(Gen2WorldPartyHost.ITEM_POKE_BALL)
 	)
 
+	## One of `.shake_and_break_free`'s four lines and nothing else: which one is
+	## the rock count's to decide, and no line is said for a rock of its own.
 	var saw_break_free: bool = false
 	for _message: int in 5:
 		host.finish()
 		host.advance()
-		if host.battle_snapshot()["message"] == "%s broke free!" % _wild_name():
+		if Gen2BattleScreen.BREAK_FREE_TEXT.has(host.battle_snapshot()["message"]):
 			saw_break_free = true
 
 	assert_true(saw_break_free)

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -37,6 +37,11 @@ const SAVED_PLAYER: String = "TEST"
 
 
 func after_each() -> void:
+	## Opening a world installs the rules it was opened under, which is the whole
+	## point of them (`Gen2WorldAPI._init`), so a test that opened a Nuzlocke
+	## leaves every test after it playing one: its catches ask for no nickname
+	## and its faints are permanent. Put back before the next one builds a save.
+	Gen2Rules.install(null)
 	if is_instance_valid(_world_screen):
 		_world_screen.free()
 		_world_screen = null
@@ -46,7 +51,12 @@ func after_each() -> void:
 	Gen2ModHost.reset()
 
 
-func _open_world(with_save: bool = false, seed_value: int = 0) -> void:
+## [param challenge] is written onto the injected save rather than installed by
+## hand: which rules a run is played under belongs to the slot, and the world is
+## what reads them off it.
+func _open_world(
+	with_save: bool = false, seed_value: int = 0, challenge: StringName = &""
+) -> void:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
@@ -66,6 +76,9 @@ func _open_world(with_save: bool = false, seed_value: int = 0) -> void:
 		snapshot.player_cell = Vector2i(4, 5)
 		snapshot.world_state = Gen2WorldState.new()
 		save.world = snapshot
+		if not challenge.is_empty():
+			save.run_rules = Gen2Rules.new()
+			save.run_rules.challenge = challenge
 		_world_screen.set_save(save)
 	add_child(_world_screen)
 	await get_tree().process_frame
@@ -638,6 +651,54 @@ func test_master_ball_capture_runs_through_the_real_battle_overlay() -> void:
 	assert_null(_battle_host())
 	assert_eq(_world_screen._world.state.item_quantity(Gen2WorldPartyHost.ITEM_MASTER_BALL), 0)
 	assert_eq(_world_screen.world_snapshot()["script_prompt"], "Caught %s" % _wild_name())
+
+
+## `PokeBallEffect` reaches `AskGiveNicknameText` only once
+## `Text_GotchaMonWasCaught` has finished printing. A Nuzlocke is where an early
+## prompt shows, because it skips the question and opens the keyboard outright:
+## the naming screen stood over a box halfway through "Gotcha! X was caught!".
+func test_the_catch_prompt_waits_for_the_gotcha_line() -> void:
+	await _open_world(true, 0, Gen2Rules.CHALLENGE_NUZLOCKE)
+	assert_true(bool(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	)["ok"]))
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.select_capture_ball(
+		host.available_capture_balls().find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
+	)["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
+
+	var caught: String = "Gotcha! %s was caught!" % _wild_name()
+	for _message: int in 10:
+		if String(host.battle_snapshot()["message"]) == caught:
+			break
+		host.finish()
+		host.advance()
+	assert_eq(String(host.battle_snapshot()["message"]), caught)
+	var box: Gen2TextBox = host.get("_box")
+	assert_true(box.is_revealing(), "the caught line has only just been put up")
+	assert_true(
+		host._open_capture_nickname(),
+		"the prompt is owed, so the pump waits here rather than running on"
+	)
+	assert_null(
+		host.get("_capture_nickname_host"),
+		"and nothing is built over a line that is still printing"
+	)
+
+	box.finish()
+	assert_true(host._open_capture_nickname())
+	assert_not_null(
+		host.get("_capture_nickname_host"),
+		"once the line is done the keyboard opens, no question asked"
+	)
 
 
 func test_failed_capture_shows_break_free_and_returns_to_battle() -> void:
@@ -1380,6 +1441,48 @@ func test_a_battle_runs_its_transition_before_the_overlay_exists() -> void:
 	assert_not_null(_battle_child(), "and the battle behind it once it lands")
 
 
+## `DoBattleTransition` owns every frame between the encounter and the overlay
+## with the joypad unread. A press landing in one of them used to reach
+## `script_input_waiting()` below it and cancel the request `startbattle` waits
+## on, so the script died with `invalid_battle_outcome`: the fight still ran, and
+## everything the trainer's script does after it -- its beaten flag, its text and
+## a gym leader's badge -- never arrived. A player holding A through the approach
+## is what does it.
+func test_a_press_during_the_battle_transition_leaves_the_script_running() -> void:
+	await _open_world()
+	await _walk_one(Vector2i.RIGHT)
+	for _frame: int in 400:
+		_world_screen.advance_frame()
+		if _world_screen.battle_transition_running():
+			break
+		var waiting: Dictionary = _world_screen._world.pending_script_input()
+		if StringName(waiting.get("type", &"")) in [&"text", &"button"]:
+			_world_screen._advance_script_input()
+	assert_true(_world_screen.battle_transition_running(), "the transition is on screen")
+	_world_screen.press_button(Gen2Button.A)
+	assert_eq(
+		_world_screen.world_snapshot()["script_prompt"], "Battle starting",
+		"the press was swallowed rather than answering the script"
+	)
+
+	var host: Gen2BattleScreen = _battle_child()
+	assert_not_null(host)
+	for _hit: int in 12:
+		host.hurt_enemy()
+	host = _battle_host()
+	host.finish()
+	host.advance()
+	host.finish()
+	host.advance()
+	await get_tree().process_frame
+	var world: Dictionary = _world_screen.world_snapshot()
+	assert_true(world["just_battled"])
+	assert_eq(
+		world["visible_objects"], 0,
+		"the script ran on past the fight and set the trainer's beaten flag"
+	)
+
+
 ## `ExitBattle`'s `predef EvolveAfterBattle`, which is the pass this screen runs
 ## on the overworld: the level evolution the fight paid for is presented, and
 ## the party row is only written when the animation has finished.
@@ -1786,10 +1889,23 @@ func test_the_last_member_fainting_to_poison_opens_the_whiteout() -> void:
 ## The Nuzlocke's own ending, on the same pass the whiteout above walks. A faint
 ## is a death, so the row leaves the party rather than being healed, and a party
 ## with nothing left is a wipe: the run is over rather than set back to a Center.
+## `Gen2GameRuntime._activate_rules` installs a slot's own rules when the
+## launcher chooses one, and nothing does when [method Gen2WorldScreen.set_save]
+## injects one, so the world reads them off the save it opened. Without it a
+## Nuzlocke slot played as the cartridge's own game: no death was permanent and
+## no area was ever spent.
+func test_the_world_plays_the_rules_the_save_it_opened_carries() -> void:
+	Gen2Rules.install(null)
+	await _open_world(true, 0, Gen2Rules.CHALLENGE_NUZLOCKE)
+	assert_true(_world_screen._world.rules.is_nuzlocke(), "the world's own set")
+	assert_true(
+		Gen2Rules.active().is_nuzlocke(),
+		"and the installed one every static reads"
+	)
+
+
 func test_a_nuzlocke_wipe_ends_the_run_instead_of_whiting_out() -> void:
-	await _open_world(true)
-	_world_screen._world.rules = Gen2Rules.new()
-	_world_screen._world.rules.challenge = Gen2Rules.CHALLENGE_NUZLOCKE
+	await _open_world(true, 0, Gen2Rules.CHALLENGE_NUZLOCKE)
 	var save: Gen2SaveData = _world_screen._injected_save
 	var mon: Gen2SaveMon = save.party[0]
 	mon.is_egg = false

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -331,12 +331,18 @@ const ETHER: int = 0x3F
 const ELIXER: int = 0x41
 const POKE_BALL: int = 0x05
 const BATTLE_ITEMS: Dictionary = {
-	POTION: {"name": "POTION", "battle_menu": 5, "pocket": 1, "heal_amount": 20},
+	POTION: {
+		"name": "POTION", "battle_menu": 5, "pocket": 1, "heal_amount": 20,
+		"description": "Restores HP by 20.",
+	},
 	FULL_RESTORE: {
 		"name": "FULL RESTORE", "battle_menu": 5, "pocket": 1,
 		"heal_amount": 999, "status_mask": 0xFF,
 	},
-	FULL_HEAL: {"name": "FULL HEAL", "battle_menu": 5, "pocket": 1, "status_mask": 0xFF},
+	FULL_HEAL: {
+		"name": "FULL HEAL", "battle_menu": 5, "pocket": 1, "status_mask": 0xFF,
+		"description": "Heals all status problems.",
+	},
 	REVIVE: {"name": "REVIVE", "battle_menu": 5, "pocket": 1},
 	POKE_DOLL: {"name": "POKE DOLL", "battle_menu": 6, "pocket": 1},
 	X_ATTACK: {"name": "X ATTACK", "battle_menu": 6, "pocket": 1},

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -309,13 +309,36 @@ func test_a_segmented_control_moves_its_choice_and_reports_the_index() -> void:
 	await get_tree().process_frame
 
 	var buttons: Array[Gen2LauncherButton] = []
-	for child: Node in control.get_child(0).get_children():
+	for child: Node in (control.get_meta(&"wrapping_row") as Control).get_children():
 		buttons.append(child)
 	assert_true(buttons[0].is_active())
 	buttons[2].pressed.emit()
 	assert_eq(chosen, [2] as Array[int])
 	assert_true(buttons[2].is_active())
 	assert_false(buttons[0].is_active(), "only one segment can be chosen")
+
+
+## A page body gives its children the whole column, and a segmented track filled
+## it while its three choices sat bunched at the left. The track is the choices,
+## so it is as wide as they are while they fit on one line.
+func test_a_segmented_track_is_as_wide_as_its_choices_and_no_wider() -> void:
+	var control: Control = Gen2LauncherUI.segmented(
+		_light, ["Vanilla", "Hard", "Nuzlocke"], 0, func(_index: int) -> void: pass
+	)
+	var body := VBoxContainer.new()
+	add_child_autofree(body)
+	body.add_child(control)
+	body.size = Vector2(900.0, 200.0)
+	await wait_process_frames(2)
+
+	var wanted: float = Gen2LauncherUI.preferred_width(control)
+	assert_gt(control.size.x, wanted - 1.0, "the row itself is given the column")
+	assert_almost_eq(control.get_child(0).size.x, wanted, 1.0)
+
+	# Narrower than one line, the track takes what there is and the flow wraps.
+	body.size = Vector2(wanted / 2.0, 200.0)
+	await wait_process_frames(2)
+	assert_almost_eq(control.get_child(0).size.x, wanted / 2.0, 1.0)
 
 
 func test_the_stage_holds_one_cartridge_per_supported_game() -> void:

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1096,6 +1096,22 @@ func test_master_ball_captures_a_wild_mon_and_records_catch_metadata() -> void:
 	assert_eq(_world.state.item_quantity(0x01), 0)
 
 
+## `GetPokeBallWobble` increments its count before it rolls, so the roll that
+## ends a throw names how many rocks came before it and not how many there were.
+## A throw that escapes on the first roll has rocked no times at all, which is
+## `BallBrokeFreeText`'s own case and was unreachable while the answer here was
+## the source's count rather than the rocks.
+func test_a_failed_throw_counts_the_rocks_and_not_the_rolls() -> void:
+	var seen: Dictionary = {}
+	for seed_value: int in 200:
+		var random := RandomNumberGenerator.new()
+		random.seed = seed_value
+		seen[Gen2WorldPartyHost._failed_wobbles(1, random)] = true
+	assert_true(seen.has(0), "a throw that escapes on the first roll has not rocked")
+	assert_eq(seen.keys().min(), 0)
+	assert_eq(seen.keys().max(), 3, "the ball rocks three times at most")
+
+
 ## The Nuzlocke's first rule at the one place a ball is ever thrown. The battle
 ## claims the area when it opens and leaves it on the world; anything else is an
 ## area that already gave up its encounter, and the ball is refused whole: no

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -1,6 +1,6 @@
 extends SceneTree
 
-## Records one overworld clip to a video, for a trailer rather than for a check.
+## Records one clip to a video, for a trailer rather than for a check.
 ##
 ## Godot's Movie Maker is what makes this reproducible: `--write-movie` pins the
 ## frame delta, so the world's own clock spends exactly one hardware frame per
@@ -22,7 +22,13 @@ extends SceneTree
 ##     -c:v libx264 -crf 18 -pix_fmt yuv420p -r 60 clip.mp4
 ##
 ## Keys, all optional:
+##   screen=<world|saves>  which screen the clip is shot on. `world` is the game
+##                  and is the default; `saves` is the launcher's save page,
+##                  where a run's challenge is chosen. The group and map are
+##                  ignored by `saves` and still have to be given.
 ##   cell=<x>,<y>   where the player stands when the map opens
+##   facing=<dir>   which way the player faces when it opens: up, down, left,
+##                  right. Untouched by default, which is the map's own answer.
 ##   hour=<0-23>    the clock the map is drawn on, which is its palette
 ##   view=<mod id>  a mod's renderer instead of the built-in one (`voxel3d`)
 ##   size=<W>x<H>   the size the game lays itself out for, 1280x720 by default.
@@ -31,14 +37,66 @@ extends SceneTree
 ##   seconds=<n>    how long the clip runs after the warm-up
 ##   seed=<n>       the run seed, which is what a mod's spawn plan is built from
 ##   hold=<dir>     a direction held for the whole clip: up, down, left, right
+##   challenge=<c>  the challenge the recording run is played under: vanilla,
+##                  hard or nuzlocke. What `Gen2Rules` gives a real run, so a
+##                  Nuzlocke clip meets the Nuzlocke's own rules.
+##   party=<spec>   the party the clip plays with, `species:level` per member
+##                  separated by commas, six at most. Each may carry `shiny`,
+##                  `hp<n>` for a member standing at that many hit points, and
+##                  `brink` for one a single point of experience short of its
+##                  next level. Six healthy level 40s by default.
+##   items=<spec>   items in the bag, `item:count` separated by commas. A capture
+##                  clip needs its own balls: 5 is a POKE BALL.
+##   progress=<spec>  how far along the run is, `badges:8,caught:120`. What a mod
+##                  reading [Gen2ModProgress] answers about, so a clip of a list
+##                  a run fills in is shot part way through one rather than at
+##                  nothing. `badges` is the first n in source order and `caught`
+##                  the first n species numbers; `pokedex:1` and `pokegear:1` are
+##                  the start menu's own two gates. `spent:1` is a Nuzlocke whose
+##                  area has already given up its one encounter, which is what a
+##                  clip of the refusal starts from.
+##   flags=<n>[,<n>]  event flags the run has already set, by their index in
+##                  `constants/event_flags.asm`. What puts a script on the branch
+##                  a clip wants: 8 is `EVENT_GOT_TM31_MUD_SLAP`, which takes the
+##                  TM speech off the end of the Violet Gym badge.
+##   text=auto      an A press whenever the box is waiting for one, which is a
+##                  player reading. A battle's own text is as long as its text is
+##                  and no frame number can be worked out in advance, so a clip
+##                  that has to reach a menu says this rather than counting.
+##   at=<state>:<action>  one action, performed the first time the screen reaches
+##                  that state: `menu` is the battle's FIGHT/PKMN/PACK/RUN,
+##                  `move` its move list, `pack` the pack it opens, `capture` the
+##                  ball selector, `switch` the party list, `ask` the nickname
+##                  question a catch reaches, `name` the keyboard behind it and
+##                  `map` the overworld with no battle over it. Repeatable, and they are
+##                  spent in the order they are written, a beat apart. What aims
+##                  a press at a menu rather than at a frame.
+##   always=<state>:<action>  the same, but never spent: it answers that state
+##                  every time the screen reaches it, once the `at=` queue has
+##                  nothing waiting for it. `always=menu:a always=move:a` is a
+##                  player fighting with the first move for as many turns as the
+##                  fight lasts, which is not a number a clip can know.
+##   mash=<first>:<every>[:<last>]  an A press every `every` frames from `first`,
+##                  which is a player holding a battle or a script along. Runs to
+##                  the end of the clip unless `last` says otherwise, and adds to
+##                  whatever `do=` already asked for.
 ##   do=<frame>:<action>   one scripted action, repeatable
 ##
-## Actions are a button name (`a`, `b`, `start`, `select`, `up`, `down`, `left`,
-## `right`), `hold-<dir>` or `hold-none` to change what is held from that frame,
-## `surf` to mount the water the player is facing, `battle` to start a wild
-## fight, `menu-off` to close whatever is open, or `view-<mod id>` to switch the
-## renderer on camera, cover and all. Frames are the world's own, counted from
-## the first recorded one.
+## World actions are a button name (`a`, `b`, `start`, `select`, `up`, `down`,
+## `left`, `right`), `hold-<dir>` or `hold-none` to change what is held from that
+## frame, `surf` to mount the water the player is facing, `battle` to start a
+## wild fight, `wild-<species>-<level>[-shiny]` to start one against a named
+## Pokemon, `menu-off` to close whatever is open, `text-off` and `text-on` to
+## stop and restart `text=auto` so the last line of a clip is left up rather
+## than turned, or `view-<mod id>` to switch
+## the renderer on camera, cover and all. Frames are the world's own, counted
+## from the first recorded one.
+##
+## Save-screen actions are `new-slot` to open the new-game form on the first
+## free slot, `slot-<n>` to select one, `name-<text>` to type a save name, and
+## `focus-<label>` and `click-<label>` for one of the page's own buttons, found
+## by the words on it. The focus ring is what a viewer follows, so a click is
+## worth a `focus-` a moment before it.
 ##
 ## A `probe=` records nothing and answers a question instead, which is how a clip
 ## is aimed before it is shot:
@@ -51,6 +109,12 @@ extends SceneTree
 ##   probe=shiny  asks the installed visible-encounter providers for the plan
 ##                every seed would build on this map and prints the ones holding
 ##                a shiny, which is how a sparkle clip gets its `seed=`
+##   probe=menu   the start menu's own rows in order, which is how many DOWN
+##                presses a mod's row costs: a mod adds one and the count moves
+##   probe=trace  runs the clip's own buttons and prints the frame every visible
+##                thing changed on: the text on screen, the battle's menu and
+##                whether it is waiting for a press. A clip that has to land a
+##                press on a menu is aimed with this and shot afterwards
 ##
 ## A `probe=` takes the same arguments as the clip it is aiming, and `cell=` is
 ## not optional among them: where the player stands is part of the context a
@@ -72,7 +136,25 @@ const FRAMES_PER_SECOND: float = 60.0
 ## in 8192, and a plan holds up to `maximum` of them.
 const PROBE_SEEDS: int = 20000
 
+## What `progress=` names. `badges` and `caught` are the two a mod's reading is
+## built on; the other two are the start menu's own gates, so a run eight badges
+## in has the rows one really would.
+const PROGRESS_KEYS: Array[String] = [
+	"badges", "caught", "pokedex", "pokegear", "spent",
+]
+
+## Which screen the clip is shot on.
+const SCREEN_WORLD: StringName = &"world"
+const SCREEN_SAVES: StringName = &"saves"
+
+## The party a clip carries when no `party=` names one: six healthy level 40s,
+## which is what the follower mod draws from and what a battle opens on.
+const DEFAULT_PARTY: Array[int] = [160, 157, 154, 26, 197, 130]
+const DEFAULT_PARTY_LEVEL: int = 40
+
 var _screen: Gen2WorldScreen = null
+## The launcher page a `screen=saves` clip is shot on, and null for a world one.
+var _page: Control = null
 var _window: Vector2i = DEFAULT_WINDOW
 var _view: StringName = &""
 var _restore_view: StringName = &""
@@ -95,8 +177,22 @@ var _chosen: bool = false
 var _game: StringName = &""
 var _map := Vector2i.ZERO
 var _cell := Vector2i(-1, -1)
+var _facing: int = -1
 var _hour: int = -1
 var _seed: int = 1
+var _kind: StringName = SCREEN_WORLD
+var _challenge: StringName = Gen2Rules.CHALLENGE_VANILLA
+## Each member as `{species, level, shiny, hp, brink}`, or empty for the default
+## six.
+var _party: Array[Dictionary] = []
+## Bag contents as item number to count.
+var _items: Dictionary = {}
+## `progress=`, as name to amount.
+var _progress: Dictionary = {}
+## `flags=`, the event flags the run has already set.
+var _flags: Array[int] = []
+## The last line `probe=trace` printed, so only a change is printed.
+var _traced: String = ""
 ## Frames spent before the clip proper, which the video is trimmed by. Raised
 ## for a clip waiting on something the map spends on its own clock rather than on
 ## a button: the visible-encounter mod's shiny sparkle is one, and it runs for
@@ -105,9 +201,24 @@ var _seed: int = 1
 var _warmup: int = WARMUP_FRAMES
 ## The frame the screen was built on, which every count below is relative to.
 var _built_at: int = 0
+## Whether the screen has been built, which `_page` being set cannot answer for a
+## build that failed.
+var _built: bool = false
 ## Whether this clip holds a direction at all, which is what [method
 ## _input_arrived] can check for.
 var _holds_scripted: bool = false
+## `Engine.get_frames_drawn()` when the clip proper started, which is what
+## [method _every_frame_drawn] measures the video against.
+var _drawn_at_start: int = 0
+## Whether `text=auto` is on: an A press whenever the box wants one.
+var _auto_text: bool = false
+## `at=` entries still waiting for their state, in the order they were written.
+var _waits: Array[Dictionary] = []
+## `always=` entries, state to action, none of which is ever spent.
+var _always: Dictionary = {}
+## The world frame before which nothing scripted by state may be spent, so two
+## presses a viewer has to follow are a beat apart rather than on one frame.
+var _state_ready: int = 0
 
 
 func _initialize() -> void:
@@ -120,12 +231,17 @@ func _initialize() -> void:
 	var cell := Vector2i(-1, -1)
 	var hour: int = -1
 	var seed_value: int = 1
+	## Expanded after the whole line is read, since its default last frame is
+	## `seconds=`, which may be named after it.
+	var mash: String = ""
 	for extra: String in args.slice(3):
 		var key: String = extra.get_slice("=", 0)
 		var value: String = extra.substr(key.length() + 1)
 		match key:
 			"cell":
 				cell = Vector2i(int(value.get_slice(",", 0)), int(value.get_slice(",", 1)))
+			"facing":
+				_facing = _facing_for(value)
 			"hour":
 				hour = int(value)
 			"view":
@@ -138,6 +254,31 @@ func _initialize() -> void:
 				seed_value = int(value)
 			"hold":
 				_hold = _direction(value)
+			"screen":
+				_kind = StringName(value)
+			"challenge":
+				_challenge = StringName(value)
+			"party":
+				_party = _parse_party(value)
+			"items":
+				_items = _parse_items(value)
+			"flags":
+				for raw: String in value.split(",", false):
+					_flags.append(int(raw))
+			"progress":
+				_progress = _parse_progress(value)
+			"text":
+				_auto_text = value == "auto"
+			"always":
+				_always[StringName(value.get_slice(":", 0))] = \
+					value.substr(value.find(":") + 1)
+			"at":
+				_waits.append({
+					"state": StringName(value.get_slice(":", 0)),
+					"action": value.substr(value.find(":") + 1),
+				})
+			"mash":
+				mash = value
 			"do":
 				_add_action(int(value.get_slice(":", 0)), value.substr(value.find(":") + 1))
 			"warmup":
@@ -149,11 +290,80 @@ func _initialize() -> void:
 				_quit_failed()
 				return
 
+	if _kind not in [SCREEN_WORLD, SCREEN_SAVES]:
+		push_error("Unknown screen: %s" % _kind)
+		_quit_failed()
+		return
+	if not Gen2Rules.CHALLENGES.has(_challenge):
+		push_error("Unknown challenge: %s" % _challenge)
+		_quit_failed()
+		return
+
+	if not mash.is_empty():
+		_add_mash(mash)
 	_game = StringName(args[0])
 	_map = Vector2i(int(args[1]), int(args[2]))
 	_cell = cell
 	_hour = hour
 	_seed = seed_value
+
+
+## `party=` as one member per comma. `species:level` and then any of `shiny`,
+## `brink` and `hp<n>`, which are the three a clip has needed: a shiny to catch,
+## a member one point short of the level it is filmed reaching, and one standing
+## low enough to be knocked out on camera.
+func _parse_party(spec: String) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for raw: String in spec.split(",", false):
+		var fields: PackedStringArray = raw.split(":", false)
+		if fields.size() < 2:
+			push_error("A party member is species:level, not %s" % raw)
+			_quit_failed()
+			return []
+		var member: Dictionary = {
+			"species": int(fields[0]), "level": int(fields[1]),
+			"shiny": false, "brink": false, "hp": -1,
+		}
+		for flag: String in Array(fields).slice(2):
+			if flag == "shiny":
+				member["shiny"] = true
+			elif flag == "brink":
+				member["brink"] = true
+			elif flag.begins_with("hp"):
+				member["hp"] = int(flag.trim_prefix("hp"))
+			else:
+				push_error("Unknown party flag: %s" % flag)
+				_quit_failed()
+				return []
+		out.append(member)
+	return out
+
+
+## `progress=`, whose keys are the readings [Gen2ModProgress] carries rather than
+## the flags behind them: a clip says how far along the run is and the world
+## state is what answers for it.
+func _parse_progress(spec: String) -> Dictionary:
+	var out: Dictionary = {}
+	for raw: String in spec.split(",", false):
+		var pair: PackedStringArray = raw.split(":", false)
+		if pair.size() != 2 or pair[0] not in PROGRESS_KEYS:
+			push_error("Progress is one of %s, not %s" % [str(PROGRESS_KEYS), raw])
+			_quit_failed()
+			return {}
+		out[pair[0]] = int(pair[1])
+	return out
+
+
+func _parse_items(spec: String) -> Dictionary:
+	var out: Dictionary = {}
+	for raw: String in spec.split(",", false):
+		var pair: PackedStringArray = raw.split(":", false)
+		if pair.size() != 2:
+			push_error("An item is item:count, not %s" % raw)
+			_quit_failed()
+			return {}
+		out[int(pair[0])] = int(pair[1])
+	return out
 
 
 ## Whether the mods are still loading, which the screen has to be built after.
@@ -173,11 +383,6 @@ func _waiting_for_mods() -> bool:
 
 ## The screen, built once the mods are in.
 func _build() -> void:
-	## The mods, before the screen and against this cartridge. `GameRuntime`
-	## loads them from its own `_ready`, but a `-s` driver cannot depend on
-	## having run after that: a screen built first has no follower walking
-	## behind the player and no wild Pokemon on the map, and which of those a
-	## clip caught was a race.
 	var data: GameData = GameData.open(_game)
 	if data == null:
 		push_error("No cache for %s. Import roms/%s.gbc first." % [_game, _game])
@@ -187,6 +392,42 @@ func _build() -> void:
 	DisplayServer.window_set_size(_window)
 	root.set_content_scale_size(_window)
 	root.size = _window
+	## In front of everything else and kept there, because the engine does not
+	## DRAW an occluded window and Movie Maker writes a frame per drawn frame:
+	## a window another one covered records the clip with most of its middle
+	## missing, and the run reports no error at all. Costs the desktop the front
+	## window for as long as the recording takes.
+	DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_ALWAYS_ON_TOP, true)
+	DisplayServer.window_move_to_foreground()
+	if _kind == SCREEN_SAVES:
+		_build_saves(data)
+		return
+	_build_world(data)
+
+
+## The launcher's save page, on the cartridge this clip names. It reads the
+## installation's own slots, and nothing here writes one: the new-game form is
+## opened and filled in, and `Gen2SaveScreen.create_new_game` is the button this
+## never presses.
+func _build_saves(data: GameData) -> void:
+	var runtime: Node = root.get_node_or_null(NodePath("GameRuntime"))
+	if runtime != null:
+		runtime.call("select_game", data.id)
+	var page: Node = load("res://game/save/save_screen.tscn").instantiate()
+	page.call("set_data", data)
+	root.add_child(page)
+	current_scene = page as Node
+	_page = page as Control
+
+
+## The world screen, the recording save behind it and the mods told which save
+## is being played.
+func _build_world(data: GameData) -> void:
+	## The mods, before the screen and against this cartridge. `GameRuntime`
+	## loads them from its own `_ready`, but a `-s` driver cannot depend on
+	## having run after that: a screen built first has no follower walking
+	## behind the player and no wild Pokemon on the map, and which of those a
+	## clip caught was a race.
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_screen = packed.instantiate() as Gen2WorldScreen
 	_screen.map_group = _map.x
@@ -205,26 +446,130 @@ func _build() -> void:
 		_quit_failed()
 		return
 	_screen.set_save(save)
+	## The save lifecycle a real run spends, which nothing else here would: a
+	## slot is chosen through `GameRuntime` and this driver has none, so without
+	## this a mod holding per-save state is played with none of it. The
+	## achievements mod is the visible case, and it is what a clip of one being
+	## unlocked depends on.
+	Gen2ModHost.instance().created_save(save)
+	Gen2ModHost.instance().activate_save(save)
 	root.add_child(_screen)
 	current_scene = _screen
+	_stock_bag()
+	_seed_progress()
 
 
-## A save that can carry every clip: six healthy Pokemon, which is what the
-## follower mod draws from and what a battle opens on. No badge is set here; the
+## `items=`, into the world's own bag. After the screen is in the tree, since the
+## world it writes to is built from `_ready`.
+func _stock_bag() -> void:
+	if _items.is_empty():
+		return
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world == null:
+		push_error("The world was not built, so the bag could not be stocked.")
+		_quit_failed()
+		return
+	var added: Dictionary = world.state.apply_changes({}, {}, {"items": _items})
+	if not bool(added.get("ok", false)):
+		push_error("The bag refused %s." % str(_items))
+		_quit_failed()
+
+
+## `progress=`, into the world state, which is what [Gen2ModProgress] reads for
+## everything a save does not carry itself.
+func _seed_progress() -> void:
+	if _progress.is_empty() and _flags.is_empty():
+		return
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world == null:
+		push_error("The world was not built, so its progress could not be set.")
+		_quit_failed()
+		return
+	for flag: int in _flags:
+		world.state.set_event_flag(flag)
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	for badge: int in int(_progress.get("badges", 0)):
+		world.state.set_engine_flag(Gen2WorldState.badge_flag(badge, crystal))
+	for species: int in range(1, int(_progress.get("caught", 0)) + 1):
+		world.state.set_species_caught(species)
+	if int(_progress.get("pokedex", 0)) > 0:
+		world.state.set_engine_flag(
+			Gen2WorldState.engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX, crystal)
+		)
+	if int(_progress.get("pokegear", 0)) > 0:
+		world.state.set_engine_flag(
+			Gen2WorldState.engine_flag(Gen2WorldStartMenu.ENGINE_POKEGEAR, crystal)
+		)
+	## The area this map belongs to, already spent. Species 0: what the run met
+	## here is not part of the picture, only that it did.
+	if int(_progress.get("spent", 0)) > 0:
+		Gen2Nuzlocke.claim_area(
+			_screen.active_save().nuzlocke, world.landmark_backup(), 0
+		)
+
+
+## A save that can carry every clip: the party `party=` names or six healthy
+## level 40s, under the challenge `challenge=` names. No badge is set here; the
 ## `surf` action goes through `Gen2WorldScreen.preview_surf`, which grants the
 ## one its own field move needs.
 func _recording_save(data: GameData) -> Gen2SaveData:
 	var members: Array = []
-	for species: int in [160, 157, 154, 26, 197, 130]:
+	for member: Dictionary in _party_rows():
 		var mon: Gen2BattleMon = Gen2BattleMon.create(
-			data, species, 40, data.moves_at_level(species, 40)
+			data, int(member["species"]), int(member["level"]),
+			data.moves_at_level(int(member["species"]), int(member["level"])),
+			Gen2Stats.SHINY_DVS if bool(member["shiny"]) else Gen2BattleMon.PERFECT_DVS
 		)
-		if mon != null:
-			members.append(mon)
+		if mon == null:
+			push_error("No species %d in this cache." % int(member["species"]))
+			return null
+		## One point short of the next level, so the clip's own first knockout is
+		## what carries it over rather than a grind nobody wants to watch.
+		if bool(member["brink"]):
+			mon.exp = maxi(
+				Gen2Experience.total_exp_at(mon.growth_rate(), mon.level + 1) - 1, mon.exp
+			)
+		if int(member["hp"]) >= 0:
+			mon.hp = clampi(int(member["hp"]), 0, mon.max_hp())
+		members.append(mon)
 	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
 		data.id, data.sha1, 0, Gen2Party.create(members), "GOLD"
 	)
+	if save == null:
+		return null
+	var rules := Gen2Rules.new()
+	rules.challenge = _challenge
+	save.run_rules = rules
 	return save
+
+
+func _party_rows() -> Array[Dictionary]:
+	if not _party.is_empty():
+		return _party
+	var out: Array[Dictionary] = []
+	for species: int in DEFAULT_PARTY:
+		out.append({
+			"species": species, "level": DEFAULT_PARTY_LEVEL,
+			"shiny": false, "brink": false, "hp": -1,
+		})
+	return out
+
+
+## `mash=`, as one A press per interval. Spelled here rather than as a hundred
+## `do=` arguments: a battle is thirty boxes long and every one of them wants the
+## same press.
+func _add_mash(spec: String) -> void:
+	var fields: PackedStringArray = spec.split(":", false)
+	if fields.size() < 2:
+		push_error("A mash is first:every[:last], not %s" % spec)
+		_quit_failed()
+		return
+	var every: int = maxi(int(fields[1]), 1)
+	var last: int = int(fields[2]) if fields.size() > 2 else _length
+	var frame: int = int(fields[0])
+	while frame <= last:
+		_add_action(frame, "a")
+		frame += every
 
 
 func _add_action(frame: int, action: String) -> void:
@@ -242,15 +587,27 @@ func _direction(name: String) -> int:
 	return Gen2Button.NONE
 
 
+func _facing_for(name: String) -> int:
+	match name:
+		"down": return Gen2WorldSprite.FACING_DOWN
+		"up": return Gen2WorldSprite.FACING_UP
+		"left": return Gen2WorldSprite.FACING_LEFT
+		"right": return Gen2WorldSprite.FACING_RIGHT
+	push_error("Unknown facing: %s" % name)
+	_quit_failed()
+	return -1
+
+
 func _process(_delta: float) -> bool:
 	if _failed:
 		return true
 	_frames += 1
-	if _screen == null:
+	if not _built:
 		if _waiting_for_mods():
 			return false
 		_build()
 		_built_at = _frames
+		_built = true
 		return _failed
 	if _frames == _built_at + 1:
 		_open()
@@ -261,43 +618,141 @@ func _process(_delta: float) -> bool:
 		_choose_view()
 	if _frames - _built_at < _warmup:
 		return false
-	if _frames - _built_at == _warmup and _probe in [&"shiny", &"map", &"wilds"]:
-		if _probe == &"shiny":
-			_run_shiny_probe()
-		elif _probe == &"wilds":
-			_print_wilds()
-		else:
-			_print_map()
-		_restore_selected_view()
+	if _frames - _built_at == _warmup and _probe in [&"shiny", &"map", &"wilds", &"menu"]:
+		_answer_static_probe()
+		_finish()
 		quit(0)
 		return true
 	if _base < 0:
 		_start()
-	var at: int = _world_frame() - _base
+	var at: int = _clip_frame() - _base
 	## A host frame can carry more than one hardware frame, so the scripted ones
 	## are drained up to `at` rather than matched against it.
 	while not _pending.is_empty() and _pending[0] <= at:
 		for action: String in _actions.get(_pending[0], []) as Array:
 			_perform(action)
 		_pending.remove_at(0)
+	if _screen != null:
+		_spend_by_state()
 	if _probe == &"walk":
 		var cell: Vector2i = (_screen.get("_world") as Gen2WorldAPI).player_cell
 		if _path.is_empty() or _path[-1] != cell:
 			_path.append(cell)
+	if _probe == &"trace":
+		_trace(at)
 	if at >= _length:
 		if _probe == &"walk":
 			_print_path()
-		_restore_selected_view()
-		quit(0 if _input_arrived() else 1)
+		_finish()
+		quit(0 if _input_arrived() and _every_frame_drawn() else 1)
 		return true
 	return false
+
+
+func _answer_static_probe() -> void:
+	match _probe:
+		&"shiny": _run_shiny_probe()
+		&"wilds": _print_wilds()
+		&"menu": _print_start_menu()
+		_: _print_map()
+
+
+## How long the clip waits between one action spent on a state and the next: a
+## press a viewer is meant to follow lands a beat after the one before it rather
+## than on the same frame.
+const STATE_GAP: int = 26
+## The same for `text=auto`, which is not a decision to watch but a page being
+## turned. A press while the page is still printing is spent and does nothing
+## (`Gen2TextBox.advance`), so this only decides how soon after a page finishes
+## the next one starts.
+const TEXT_GAP: int = 8
+
+
+## `text=auto` and the `at=` queue, both of which watch the screen rather than
+## the frame count. The text first: a menu is only reached once the box in front
+## of it is done, so answering the box is what puts the next state on screen.
+func _spend_by_state() -> void:
+	## Counted in the world's own frames rather than the host's: a probe run
+	## draws twice as often as it steps the world, and a gap measured in drawn
+	## frames would put every press somewhere else in the clip it is aiming.
+	var now: int = _clip_frame()
+	if now < _state_ready:
+		return
+	var state: StringName = _screen_state()
+	if _auto_text and state == &"text":
+		_screen.press_button(Gen2Button.A)
+		_state_ready = now + TEXT_GAP
+		return
+	var action: String = ""
+	if not _waits.is_empty() and StringName(_waits[0]["state"]) == state:
+		action = String(_waits[0]["action"])
+		_waits.remove_at(0)
+	elif _always.has(state):
+		action = String(_always[state])
+	else:
+		return
+	var button: int = _button(action)
+	if button != Gen2Button.NONE:
+		_screen.press_button(button)
+	else:
+		_perform(action)
+	_state_ready = now + STATE_GAP
+
+
+## What is on screen, as the vocabulary `at=` and `text=auto` are written in.
+## A box waiting for a press wins over everything behind it, which is the order
+## the player meets them in.
+func _screen_state() -> StringName:
+	var battle: Object = _screen.get("_battle_host")
+	if battle == null:
+		var world: Gen2WorldAPI = _screen.get("_world")
+		if world != null and world.script_input_waiting():
+			return &"text"
+		var box: Object = _screen.get("_text_box")
+		if box != null and bool(box.call("has_pages_left")) \
+			and not bool(box.call("is_revealing")):
+			return &"text"
+		return &"map"
+	## In front of the battle's own state: the nickname prompt stands over the
+	## fight. Its two halves are two states, because a press means opposite
+	## things in them: `ask` is the YES/NO, which only answers once its own text
+	## has finished, and `name` is the keyboard behind it, which a Nuzlocke opens
+	## with no question asked at all. Between the two it is `busy`, so nothing
+	## answers a question that is still being printed.
+	var prompt: Object = battle.get("_capture_nickname_host")
+	if prompt != null:
+		if bool(prompt.call("question_ready")):
+			return &"ask"
+		return &"name" if prompt.call("naming_screen") != null else &"busy"
+	var shot: Dictionary = battle.call("battle_snapshot")
+	## The three lists in front of the box, because each of them SAYS what it is
+	## in the box itself: the pack, the ball selector and the switch list all
+	## draw their prompt as a message, so a state read off `awaits_press` first
+	## would call every one of them text and answer them with A.
+	if bool(shot.get("capture_selecting", false)):
+		return &"capture"
+	if bool(battle.get("_pack_selecting")):
+		return &"pack"
+	## `OfferSwitch`'s question is two paragraphs and
+	## `_answer_switch_offer_button` reads them before it answers anything, so a
+	## NO pressed while a page is still owed is thrown away. The box itself is
+	## what says which half of that it is in; `awaits_press` stays true across
+	## both, and reading the state off it answered the question with YES.
+	if String(shot.get("switch_stage", &"")) != "":
+		return &"text" if _reading(battle, "_box") else &"switch"
+	if bool(shot.get("awaits_press", false)):
+		return &"text"
+	match StringName(shot.get("menu_stage", &"")):
+		&"main": return &"menu"
+		&"move": return &"move"
+	return &"busy"
 
 
 ## Whether the buttons this clip scripted reached the world. Holds are the half
 ## the world records, and they are also the half a stuck clip loses, so a clip
 ## that scripted one and consumed none is refused rather than written.
 func _input_arrived() -> bool:
-	if not _holds_scripted or _screen.input_recording().size() > 0:
+	if _screen == null or not _holds_scripted or _screen.input_recording().size() > 0:
 		return true
 	push_error("The scripted input never reached the world: the clip is the "
 		+ "player standing still. Record it again.")
@@ -307,6 +762,8 @@ func _input_arrived() -> bool:
 ## The mod's renderer, once it is registered. Refused only when the warm-up ran
 ## out, since that is the point at which it is not coming.
 func _choose_view() -> void:
+	if _screen == null:
+		return
 	var chosen: Dictionary = _screen.select_view(_view)
 	if bool(chosen.get("ok", false)):
 		_chosen = true
@@ -325,6 +782,28 @@ func _world_frame() -> int:
 	return world.frame_number if world != null else 0
 
 
+## The frame a `do=` is counted in. The world's own where there is a world, and
+## the recorded frame otherwise: a launcher page spends no hardware frames, and
+## Movie Maker pins the two together anyway.
+func _clip_frame() -> int:
+	return _world_frame() if _screen != null else _frames
+
+
+## Whether the video has a frame for every frame of the clip. Movie Maker writes
+## one per DRAWN frame and this driver counts the ones it was called on, and a
+## machine that is loaded enough drops the difference in silence: a nine-second
+## clip comes out under one second long, with its whole middle missing, which
+## looks exactly like a clip that was aimed wrong. Checked rather than watched
+## for, the same way the scripted input is.
+func _every_frame_drawn() -> bool:
+	var drawn: int = Engine.get_frames_drawn() - _drawn_at_start
+	if drawn >= _length:
+		return true
+	push_error(("The video is %d frames of the %d this clip spent: the machine "
+		+ "dropped the rest. Record it again with less running.") % [drawn, _length])
+	return false
+
+
 ## The clip proper: the button log is handed over now rather than in [method
 ## _open], because the frames it names are counted from this frame and the
 ## warm-up's length in hardware frames is not known until it is over.
@@ -333,13 +812,13 @@ func _start() -> void:
 	## one, and a base of zero names frames the world spent during the warm-up:
 	## every entry is then already in the past and the clip comes out with the
 	## player standing still, which is what a stuck clip every few runs was.
-	var world: Gen2WorldAPI = _screen.get("_world")
-	if world == null:
+	if _screen != null and _screen.get("_world") == null:
 		return
 	## The NEXT hardware frame, not this one: `advance_frame` counts before it
 	## reads the replay, so an entry named for the frame already spent is never
 	## applied and `do=0:<button>` was dropped in silence.
-	_base = world.frame_number + 1
+	_base = _clip_frame() + 1
+	_drawn_at_start = Engine.get_frames_drawn()
 	## The recorded frame the clip proper starts on, which is what the video is
 	## trimmed to. Printed rather than assumed: the mod load in front of it is
 	## as long as it is, and a caller cannot know that in advance.
@@ -347,6 +826,8 @@ func _start() -> void:
 	for frame: int in _actions:
 		_pending.append(frame)
 	_pending.sort()
+	if _screen == null:
+		return
 	var log_entries: Array = _input_log()
 	for entry: Dictionary in log_entries:
 		if String(entry.get("kind", "")) == "hold":
@@ -359,14 +840,20 @@ func _start() -> void:
 	_screen.record_input()
 
 
-## The frame after the screen was built: the readout off, and the view the
-## installation was on remembered, whether or not this run changes it.
+## The frame after the screen was built: the readout off, the facing set, and
+## the view the installation was on remembered, whether or not this run changes
+## it.
 func _open() -> void:
+	_restore_view = Gen2ModHost.instance().selected_view()
+	if _screen == null:
+		return
 	## The map and cell readout and the shortcut legend are scaffolding drawn
 	## over the screen, and a trailer is the game and nothing else.
 	_screen.hide_debug_readout()
-	_restore_view = Gen2ModHost.instance().selected_view()
-
+	if _facing >= 0:
+		var world: Gen2WorldAPI = _screen.get("_world")
+		if world != null:
+			world.player_facing = _facing
 
 
 ## Every held frame and every press, as `Gen2WorldScreen.replay_input` entries.
@@ -393,6 +880,9 @@ func _input_log() -> Array:
 ## The actions that are not a button. Everything a button can do is left to the
 ## log above, so the two never disagree about which frame something lands on.
 func _perform(action: String) -> void:
+	if _screen == null:
+		_perform_on_page(action)
+		return
 	match action:
 		"surf":
 			_screen.preview_surf()
@@ -402,11 +892,99 @@ func _perform(action: String) -> void:
 			_screen.preview_battle_request()
 		"menu-off":
 			_screen.press_button(Gen2Button.B)
+		"text-off":
+			_auto_text = false
+		"text-on":
+			_auto_text = true
 		_:
+			if action.begins_with("wild-"):
+				_perform_wild(action.trim_prefix("wild-"))
+				return
 			## `view-<id>`: the live renderer switch, cover and all, which is the
 			## one thing here worth filming rather than settling.
 			if action.begins_with("view-"):
 				_screen.select_view(StringName(action.trim_prefix("view-")))
+
+
+## `wild-<species>-<level>[-shiny]`, the one wild a clip has to name rather than
+## roll: a red Gyarados is a scripted encounter on the cartridge and a rolled one
+## is whatever the seed says.
+func _perform_wild(spec: String) -> void:
+	var fields: PackedStringArray = spec.split("-", false)
+	if fields.size() < 2:
+		push_error("A wild is wild-<species>-<level>[-shiny], not wild-%s" % spec)
+		_quit_failed()
+		return
+	_screen.preview_battle_request(
+		int(fields[0]), int(fields[1]),
+		Gen2Battle.BATTLETYPE_FORCESHINY if Array(fields).has("shiny")
+		else Gen2Battle.BATTLETYPE_NORMAL
+	)
+
+
+## The save page's own actions. Nothing here presses "Start game": the form is
+## what this clip is about, and creating the save is the player's press.
+func _perform_on_page(action: String) -> void:
+	if action == "new-slot":
+		if not bool(_page.call("open_new_slot")):
+			push_error("Every slot on this cartridge is in use.")
+			_quit_failed()
+		return
+	if action.begins_with("slot-"):
+		_page.call("select_slot", int(action.trim_prefix("slot-")))
+		return
+	if action.begins_with("name-"):
+		var input: LineEdit = _find_line_edit(_page)
+		if input == null:
+			push_error("No name field is on screen: open the form first.")
+			_quit_failed()
+			return
+		input.text = action.trim_prefix("name-")
+		return
+	if action.begins_with("focus-"):
+		_reach_button(action.trim_prefix("focus-"), false)
+		return
+	if action.begins_with("click-"):
+		_reach_button(action.trim_prefix("click-"), true)
+		return
+	push_error("Unknown save-page action: %s" % action)
+	_quit_failed()
+
+
+## The button wearing [param label], focused and optionally pressed. The focus
+## ring is the only cursor a recorded clip has, so it goes on the thing about to
+## be pressed rather than being left where the page put it.
+func _reach_button(label: String, press: bool) -> void:
+	var button: Button = _find_button(_page, label)
+	if button == null:
+		push_error("No button says %s on this page." % label)
+		_quit_failed()
+		return
+	button.grab_focus()
+	if press:
+		button.pressed.emit()
+
+
+static func _find_button(node: Node, label: String) -> Button:
+	var button: Button = node as Button
+	if button != null and button.text == label:
+		return button
+	for child: Node in node.get_children():
+		var found: Button = _find_button(child, label)
+		if found != null:
+			return found
+	return null
+
+
+static func _find_line_edit(node: Node) -> LineEdit:
+	var input: LineEdit = node as LineEdit
+	if input != null:
+		return input
+	for child: Node in node.get_children():
+		var found: LineEdit = _find_line_edit(child)
+		if found != null:
+			return found
+	return null
 
 
 func _button(action: String) -> int:
@@ -416,6 +994,101 @@ func _button(action: String) -> int:
 		"start": return Gen2Button.START
 		"select": return Gen2Button.SELECT
 	return _direction(action)
+
+
+## Everything a viewer can see change, printed on the frame it changed. What
+## aims a press at a menu: a battle's own opening is as long as its text is, and
+## the frame the menu appears on is not a number anyone can work out in advance.
+func _trace(at: int) -> void:
+	var line: String = "waits=%d:%s %s" % [
+		_waits.size(),
+		_waits[0]["state"] if not _waits.is_empty() else &"-",
+		_trace_line(),
+	]
+	if line == _traced:
+		return
+	_traced = line
+	print("frame=%d recorded=%d %s" % [at, _frames, line])
+
+
+func _trace_line() -> String:
+	if _screen == null:
+		return "focus=%s" % _focused_label()
+	var world: Dictionary = _screen.world_snapshot()
+	var text: String = " / ".join(Array(_text_box_lines()))
+	var battle: Object = _screen.get("_battle_host")
+	if battle == null:
+		return "state=%s map text=%s prompt=%s %s" % [
+			_screen_state(),
+			text, world.get("script_prompt", ""), _overlay_state()
+		]
+	var shot: Dictionary = battle.call("battle_snapshot")
+	return "state=%s battle menu=%s pos=%d press=%s capture=%s over=%s box=%s" % [
+		_screen_state(), shot.get("menu_stage", &""), int(shot.get("menu_position", 0)),
+		shot.get("awaits_press", false), shot.get("capture_selecting", false),
+		shot.get("battle_over", false), " / ".join(Array(_box_lines(battle, "_box"))),
+	]
+
+
+## Which overlay owns the map, for the trace. A press that has to land on a menu
+## row is aimed at the frame the menu opened on, and the banner a mod raises is
+## in front of it for sixty passes.
+func _overlay_state() -> String:
+	var menu: Object = _screen.get("_start_menu_host")
+	var page: Object = _screen.get("_mod_page_host")
+	return "menu=%s page=%s sign=%s" % [
+		menu.get("_menu").cursor if menu != null else -1,
+		page != null,
+		_screen.get("_map_name_sign") != null,
+	]
+
+
+## The line ON SCREEN rather than the message that was handed to the box: a
+## faint and the Nuzlocke death behind it are two pages of one message, and only
+## the box says which of them is up.
+## Whether the box still owes letters or pages, which is what a question with
+## more than one paragraph waits on before it will take an answer.
+static func _reading(owner: Object, property: String) -> bool:
+	var box: Object = owner.get(property)
+	if box == null:
+		return false
+	return bool(box.call("is_revealing")) or bool(box.call("has_pages_left"))
+
+
+static func _box_lines(owner: Object, property: String) -> PackedStringArray:
+	var box: Object = owner.get(property)
+	return box.call("text_lines") if box != null else PackedStringArray()
+
+
+func _text_box_lines() -> PackedStringArray:
+	return _box_lines(_screen, "_text_box")
+
+
+func _focused_label() -> String:
+	var focused: Control = _page.get_viewport().gui_get_focus_owner() if _page != null else null
+	if focused == null:
+		return "<none>"
+	var button: Button = focused as Button
+	if button != null and not button.text.is_empty():
+		return button.text
+	return String(focused.name)
+
+
+## The start menu's own rows, in the order a DOWN press walks them. A mod row is
+## registered rather than written here, so the count moves with what is installed
+## and a clip that opens a mod's page is aimed with this rather than by guessing.
+func _print_start_menu() -> void:
+	_screen.preview_start_menu()
+	var host: Object = _screen.get("_start_menu_host")
+	var menu: Gen2WorldStartMenu = host.get("_menu") if host != null else null
+	if menu == null:
+		push_error("The start menu did not open.")
+		_quit_failed()
+		return
+	var rows: Array = menu.items()
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		print("%2d %s %s" % [index, row.get("kind", &""), row.get("label", "")])
 
 
 ## The installed visible-encounter providers, asked what they would build on this
@@ -460,8 +1133,6 @@ func _run_shiny_probe() -> void:
 				found += 1
 	if found == 0:
 		print("No shiny in %d seeds on this map." % PROBE_SEEDS)
-	_restore_selected_view()
-	quit(0)
 
 
 ## The wild population this map really has under `seed=`, as the host validated
@@ -530,9 +1201,12 @@ static func _is_shiny(dvs: int) -> bool:
 	return ((dvs >> 12) & 0xf) in [2, 3, 6, 7, 10, 11, 14, 15]
 
 
-## A view is chosen per installation and persisted, so a recording puts the
-## player's own back rather than leaving them on a mod's renderer.
-func _restore_selected_view() -> void:
+## What the installation was on before the clip, put back: a view is chosen per
+## installation and persisted, and a save this driver invented must not be left
+## as the one the mods think is being played.
+func _finish() -> void:
+	if _screen != null:
+		Gen2ModHost.instance().deactivate_save()
 	if _restore_view.is_empty():
 		return
 	Gen2ModHost.instance().select_view(_restore_view)

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -31,9 +31,14 @@ extends SceneTree
 ##                  right. Untouched by default, which is the map's own answer.
 ##   hour=<0-23>    the clock the map is drawn on, which is its palette
 ##   view=<mod id>  a mod's renderer instead of the built-in one (`voxel3d`)
-##   size=<W>x<H>   the size the game lays itself out for, 1280x720 by default.
-##                  NOT the video's: Movie Maker fixes that at the project's own
-##                  viewport before a line of this script runs.
+##   size=<W>x<H>   the size the game lays itself out for. The video's own size
+##                  by default, which is the one size that costs nothing: Movie
+##                  Maker fixes the frame at the project's own viewport before a
+##                  line of this script runs, and a layout of any other size is
+##                  scaled into it, which is what makes a launcher page's text
+##                  soft. Give this only to shoot a shape the frame is not, a
+##                  portrait phone being the one that earns it: `--resolution`
+##                  moves the window on the desktop and not the frame.
 ##   seconds=<n>    how long the clip runs after the warm-up
 ##   seed=<n>       the run seed, which is what a mod's spawn plan is built from
 ##   hold=<dir>     a direction held for the whole clip: up, down, left, right
@@ -63,6 +68,12 @@ extends SceneTree
 ##                  player reading. A battle's own text is as long as its text is
 ##                  and no frame number can be worked out in advance, so a clip
 ##                  that has to reach a menu says this rather than counting.
+##   read=<frames>  how long a finished page is left standing before `text=auto`
+##                  turns it. The default is [constant TEXT_GAP], which is a
+##                  viewer's reading speed rather than a player's.
+##   beat=<frames>  the same between one `at=` or `always=` action and the next,
+##                  which is how long a chosen menu row is seen before it is
+##                  pressed. The default is [constant STATE_GAP].
 ##   at=<state>:<action>  one action, performed the first time the screen reaches
 ##                  that state: `menu` is the battle's FIGHT/PKMN/PACK/RUN,
 ##                  `move` its move list, `pack` the pack it opens, `capture` the
@@ -85,8 +96,10 @@ extends SceneTree
 ## World actions are a button name (`a`, `b`, `start`, `select`, `up`, `down`,
 ## `left`, `right`), `hold-<dir>` or `hold-none` to change what is held from that
 ## frame, `surf` to mount the water the player is facing, `battle` to start a
-## wild fight, `wild-<species>-<level>[-shiny]` to start one against a named
-## Pokemon, `menu-off` to close whatever is open, `text-off` and `text-on` to
+## wild fight, `meet` to face the nearest wild a mod has drawn on the map and
+## fight THAT one, `meet-shiny` for the nearest one that is shiny,
+## `wild-<species>-<level>[-shiny]` to start one against a named Pokemon that is
+## on no map, `menu-off` to close whatever is open, `text-off` and `text-on` to
 ## stop and restart `text=auto` so the last line of a clip is left up rather
 ## than turned, or `view-<mod id>` to switch
 ## the renderer on camera, cover and all. Frames are the world's own, counted
@@ -121,6 +134,7 @@ extends SceneTree
 ## spawn plan is built from, so a seed found from one cell puts its shiny
 ## somewhere else from another. `probe=wilds` is the check on that.
 
+## Only for a run with no window to ask, which is every headless one.
 const DEFAULT_WINDOW := Vector2i(1280, 720)
 ## Frames spent before the clip proper: the map loads, a mod's renderer is
 ## chosen and its cover is settled. Trimmed off the video afterwards.
@@ -155,6 +169,9 @@ const DEFAULT_PARTY_LEVEL: int = 40
 var _screen: Gen2WorldScreen = null
 ## The launcher page a `screen=saves` clip is shot on, and null for a world one.
 var _page: Control = null
+## The frame Movie Maker writes, which is the window as the engine started it.
+## Read before anything here resizes anything.
+var _frame_size: Vector2i = DEFAULT_WINDOW
 var _window: Vector2i = DEFAULT_WINDOW
 var _view: StringName = &""
 var _restore_view: StringName = &""
@@ -212,6 +229,9 @@ var _holds_scripted: bool = false
 var _drawn_at_start: int = 0
 ## Whether `text=auto` is on: an A press whenever the box wants one.
 var _auto_text: bool = false
+## `read=` and `beat=`, the two gaps above.
+var _read_gap: int = TEXT_GAP
+var _beat_gap: int = STATE_GAP
 ## `at=` entries still waiting for their state, in the order they were written.
 var _waits: Array[Dictionary] = []
 ## `always=` entries, state to action, none of which is ever spent.
@@ -222,6 +242,17 @@ var _state_ready: int = 0
 
 
 func _initialize() -> void:
+	## Movie Maker's frame is the PROJECT's viewport rather than the window, so
+	## `--resolution` moves what is on the desktop and not what is written.
+	var frame := Vector2i(
+		int(ProjectSettings.get_setting("display/window/size/viewport_width", 0)),
+		int(ProjectSettings.get_setting("display/window/size/viewport_height", 0))
+	)
+	if frame.x <= 0 or frame.y <= 0:
+		frame = DisplayServer.window_get_size()
+	if frame.x > 0 and frame.y > 0:
+		_frame_size = frame
+		_window = frame
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 3:
 		push_error("Usage: record_clip.gd -- <game> <group> <map> [key=value ...]")
@@ -267,6 +298,10 @@ func _initialize() -> void:
 					_flags.append(int(raw))
 			"progress":
 				_progress = _parse_progress(value)
+			"read":
+				_read_gap = maxi(int(value), 0)
+			"beat":
+				_beat_gap = maxi(int(value), 0)
 			"text":
 				_auto_text = value == "auto"
 			"always":
@@ -389,6 +424,11 @@ func _build() -> void:
 		_quit_failed()
 		return
 
+	## Read by `.claude/clip.sh`, which scales a hardware screen and a launcher
+	## page differently: one is square pixels and the other is not.
+	print("FRAME=%dx%d LAYOUT=%dx%d SCREEN=%s" % [
+		_frame_size.x, _frame_size.y, _window.x, _window.y, _kind,
+	])
 	DisplayServer.window_set_size(_window)
 	root.set_content_scale_size(_window)
 	root.size = _window
@@ -659,13 +699,14 @@ func _answer_static_probe() -> void:
 
 ## How long the clip waits between one action spent on a state and the next: a
 ## press a viewer is meant to follow lands a beat after the one before it rather
-## than on the same frame.
-const STATE_GAP: int = 26
-## The same for `text=auto`, which is not a decision to watch but a page being
-## turned. A press while the page is still printing is spent and does nothing
-## (`Gen2TextBox.advance`), so this only decides how soon after a page finishes
-## the next one starts.
-const TEXT_GAP: int = 8
+## than on the same frame. `beat=` moves it.
+const STATE_GAP: int = 40
+## The same for `text=auto`. A press while the page is still printing is spent and
+## does nothing (`Gen2TextBox.advance`), so this is how long a FINISHED page is
+## left standing, which is the one thing that decides whether a clip can be read.
+## Three quarters of a second: shorter and the last words of a line are gone
+## before a viewer reaches them. `read=` moves it.
+const TEXT_GAP: int = 45
 
 
 ## `text=auto` and the `at=` queue, both of which watch the screen rather than
@@ -681,7 +722,7 @@ func _spend_by_state() -> void:
 	var state: StringName = _screen_state()
 	if _auto_text and state == &"text":
 		_screen.press_button(Gen2Button.A)
-		_state_ready = now + TEXT_GAP
+		_state_ready = now + _read_gap
 		return
 	var action: String = ""
 	if not _waits.is_empty() and StringName(_waits[0]["state"]) == state:
@@ -696,7 +737,7 @@ func _spend_by_state() -> void:
 		_screen.press_button(button)
 	else:
 		_perform(action)
-	_state_ready = now + STATE_GAP
+	_state_ready = now + _beat_gap
 
 
 ## What is on screen, as the vocabulary `at=` and `text=auto` are written in.
@@ -890,6 +931,10 @@ func _perform(action: String) -> void:
 			_screen.preview_surf_use()
 		"battle":
 			_screen.preview_battle_request()
+		"meet":
+			_meet_visible_encounter(false)
+		"meet-shiny":
+			_meet_visible_encounter(true)
 		"menu-off":
 			_screen.press_button(Gen2Button.B)
 		"text-off":
@@ -904,6 +949,53 @@ func _perform(action: String) -> void:
 			## one thing here worth filming rather than settling.
 			if action.begins_with("view-"):
 				_screen.select_view(StringName(action.trim_prefix("view-")))
+
+
+## The wild a provider has put on the map nearest the player, met the way walking
+## onto it meets it. Faces the player at it first, since a clip of an encounter
+## is a clip of the thing on screen.
+##
+## Not the same as `wild-`: that one invents a battle and the entry standing on
+## the map is not part of it, so its Pokemon is still there afterwards however
+## the fight ended.
+func _meet_visible_encounter(shiny_only: bool) -> void:
+	var encounters: Object = _screen.get("_encounters")
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if encounters == null or world == null:
+		push_error("meet needs a world with a visible-encounter provider on it.")
+		_quit_failed()
+		return
+	var from: Vector2i = world.player_cell
+	var nearest := Vector2i(-1, -1)
+	var closest: int = 1 << 30
+	for raw: Variant in encounters.call("entries"):
+		var entry: Dictionary = raw
+		if shiny_only and not _is_shiny(int(entry.get("dvs", 0))):
+			continue
+		var cell: Vector2i = entry["cell"]
+		var away: int = absi(cell.x - from.x) + absi(cell.y - from.y)
+		if away < closest:
+			closest = away
+			nearest = cell
+	if nearest.x < 0:
+		push_error("No %svisible encounter is on this map. Did you pass --mods?" % [
+			"shiny " if shiny_only else "",
+		])
+		_quit_failed()
+		return
+	world.player_facing = _facing_towards(from, nearest)
+	if not bool(_screen.preview_meet_visible_encounter(nearest)):
+		push_error("The wild at %s refused to be met." % nearest)
+		_quit_failed()
+
+
+## Which way [param from] looks to see [param at]. The longer axis wins, which is
+## what a player walking towards one would end up facing.
+static func _facing_towards(from: Vector2i, at: Vector2i) -> int:
+	var away: Vector2i = at - from
+	if absi(away.x) >= absi(away.y):
+		return Gen2WorldSprite.FACING_RIGHT if away.x >= 0 else Gen2WorldSprite.FACING_LEFT
+	return Gen2WorldSprite.FACING_DOWN if away.y >= 0 else Gen2WorldSprite.FACING_UP
 
 
 ## `wild-<species>-<level>[-shiny]`, the one wild a clip has to name rather than


### PR DESCRIPTION
Five defects, all found while shooting trailer clips of the Nuzlocke rules and the achievements mod.

**A press during a battle transition killed the map script.** `DoBattleTransition` owns every frame between the encounter and the battle screen with the joypad unread, and `Gen2WorldScreen._handle_button` did not say so. A press landing in one of those frames reached `script_input_waiting()` and cancelled the request `startbattle` was waiting on, so the script died with `invalid_battle_outcome`. The fight still ran and everything the trainer's script does afterwards never arrived: a gym leader's badge, the flag behind it and its text. Holding A through a trainer's approach is what does it.

**A world played the installed rules rather than the save's own.** `Gen2GameRuntime._activate_rules` installs a slot's set when the launcher chooses one, and nothing did when `Gen2WorldScreen.set_save` injected one, so a Nuzlocke slot opened by a test or a tool played as the cartridge's own game: no faint was permanent and no area was ever spent.

**`waitsfx` ended on the frame after it started.** The wait compares the audio driver's rendered-frame count across frames and read a single still frame as a stall. The buffer is filled to a depth rather than by the frame, so any host drawing faster than the driver renders produces those gaps: the badge, TM and item jingles printed their line and replaced it before it could be read. The tolerance is now `Gen2AudioPlayer.SERVICE_GAP_FRAMES`, and the battle's `ANIM_WAIT_SFX` and the world's sound schedule follow the same rule.

**The catch prompt opened over a line still printing.** `PokeBallEffect` reaches `AskGiveNicknameText` only once `Text_GotchaMonWasCaught` has finished. A Nuzlocke is where it shows, because it skips the question and opens the keyboard outright, so the naming screen stood over a half-written "Gotcha! X was caught!".

**`preview_surf` left a save the validator refuses.** It rewrote the first move slot without its PP, so a Tackle at 35 replaced by a Surf at 15 made every world transaction after it fail: the field move worked and the next catch reported nothing but failure.

## The recording tool

`tools/record_clip.gd` grows what a trailer needs.

| Key | What it does |
|---|---|
| `screen=saves` | Shoots the launcher's save page, where a run's challenge is chosen |
| `party=`, `items=`, `challenge=`, `progress=`, `flags=` | Build the run behind the clip; nothing is written to disk |
| `text=auto` | Answers a box that is waiting for a press |
| `at=<state>:<action>`, `always=<state>:<action>` | Land a press on a menu the first time, or every time, the screen reaches it |
| `probe=menu`, `probe=trace` | The start menu's rows, and the frame every visible thing changed on |

A battle's text is as long as its text is and no frame number can be worked out in advance, so a clip that has to fight, open the pack or throw a ball is aimed at what is on screen instead.

The recording window is now brought to the front and kept there. The engine does not draw an occluded window and Movie Maker writes a frame per drawn frame, so a covered window recorded a clip with most of its middle missing and reported nothing; a run that loses frames anyway now fails rather than writing a short clip.


## A second pass, off the clips themselves

**The capture text was invented.** "The ball shook!" is in neither pin. The rocking is `ANIM_THROW_POKE_BALL`'s own, and `PokeBallEffect` prints `ItemUsedText` in front of the animation and exactly one line after it. So a throw said "You threw a ULTRA BALL!", then three "The ball shook!" boxes after the ball had already clicked shut. A failed throw now says one of `.shake_and_break_free`'s four lines, chosen by how many times the ball rocked, and a caught one says `Text_GotchaMonWasCaught` alone. The throw and every other battle item print `ItemUsedText` itself.

**A failed throw rocked one time too many.** `GetPokeBallWobble` increments `wThrownBallWobbleCount` before it rolls, so the count is one higher than the rocks it has drawn. `_failed_wobbles` answered with the count, which also made `BallBrokeFreeText`, the line for a ball that never rocked at all, unreachable.

**Five lists a battle asks with were a line of key bindings in the text box.** The pack, the balls it can throw, the move an Ether goes on, and the forget offer's list and its yes/no each printed something like `Use POTION x3. Left and right: choose, A: use, B: back`. Each is a drawn list now, in `ForgetMove`'s own frame over the field with the text box under it for `UpdateItemDescription`'s line, and each takes up and down as well as left and right. `BattleMenu_Pack` opens the whole four-pocket `Pack` on the cartridge; this battle is handed the flat list of items it can use, so the box is `ForgetMove`'s rather than the Pack screen's.

**A ball thrown from the pack left its list standing over the whole fight.** The throw is a message and no message redraws a menu. Both layers now follow the four list states through their setters rather than through each call site that changes one.

**A segmented track filled the column it was added to.** Its three choices sat bunched at the left of a full-width well, because a `FieldRow` asks a wrapping control how wide it would like to be and a page body does not. The track is now as wide as its choices while they fit on one line, and still wraps on a phone.

`tools/record_clip.gd` grows what a *readable* clip needs: `read=` and `beat=` are how long a finished page and a chosen menu row are left standing, and both defaults are a viewer's speed rather than a player's. `size=` defaults to Movie Maker's own frame, since a layout of any other size is scaled into it, which is what made a launcher page's text soft. `meet` and `meet-shiny` fight the wild a mod has drawn on the map through the seam a step uses, so the entry's id travels with the battle and its sprite goes when the fight is over; `wild-` invents one and leaves whatever is standing there.

## Proving it

| Check | Result |
|---|---|
| GUT, `tests/` with subdirs | 3978 passing, 0 failing |
| `tools/validate.gd -- all` | exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | `ok`, 16 badges, 295/292/292 steps |
| `--warning-scan` | 0 warnings in 596 scripts |

Each fix has a test that fails without it: the transition press, the save's rules and the catch prompt in `test_world_trainer_battle.gd`, the sound wait in `test_world_frame_pump.gd`, and the surf driver's PP in `test_world_field_move_screen.gd`. For the second pass: the rock count in `test_world_party_host.gd`, the drawn pack and the list left standing in `test_battle_switch_screen.gd`, the capture line in `test_battle_renderer.gd`, the entry id in `test_renderer_interface.gd`, and the segmented track's width in `test_launcher_ui.gd`.
