### PR TITLE
Repeat a held direction at the source's rate, and give the game a way out

### DIFF
--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -24,6 +24,10 @@ signal touch_controls_changed(shown: bool)
 ## A rebind landed. What is bound has already been installed in the [InputMap]
 ## by the time this arrives; a screen only needs it to redraw a legend.
 signal scheme_changed()
+## A + B + START + SELECT, the console's own reset, reported once per press of
+## the chord. The machine's rather than the game's, so it is detected here and
+## whichever screen is up decides what a reset costs.
+signal reset_chord_pressed()
 
 var _scheme: Dictionary = {}
 ## What the player bound each mod's own actions to, keyed by action name. See
@@ -37,6 +41,15 @@ var _touch_shown: bool = false
 ## directions at once is normal play, not an error: a player turning a corner
 ## presses the next one before releasing the last.
 var _direction_order: Array[int] = []
+## Seconds until the next repeat, per held direction. A direction with no entry
+## is not held, so the next press on it is a fresh one.
+var _repeat_clock: Dictionary = {}
+## The direction a repeat has just been sent for, cleared by the event arriving.
+## Without it the gate would swallow the very press it emitted.
+var _repeat_open: Dictionary = {}
+## Whether all four reset buttons were down last frame, so the chord fires once
+## per press rather than once per frame it is held.
+var _reset_chord_down: bool = false
 ## Every on-screen controller in the tree, innermost last. A battle opened over
 ## the map puts a second one on screen, and only the top of this stack may draw
 ## or read a finger.
@@ -44,6 +57,23 @@ var _direction_order: Array[int] = []
 ## that draws it: the pad has to name this class, and two class names that name
 ## each other do not compile.
 var _pads: Array[Control] = []
+
+## `JoyTextDelay`, which is the whole of the hardware's menu auto-repeat
+## (`home/joypad.asm`): a fresh press reloads `wTextDelayFrames` with 15, and
+## every later frame the counter reaches zero the held button is reported
+## pressed again and the counter is reloaded with 5.
+const REPEAT_DELAY_FRAMES: int = 15
+const REPEAT_INTERVAL_FRAMES: int = 5
+## Counted in seconds so the repeat keeps the source's rate on a host drawing at
+## something other than 60 Hz.
+const FRAME_SECONDS: float = 1.0 / 60.0
+
+## The four buttons a Game Boy resets on. `home/init.asm` wires them to the
+## hardware rather than to any routine, so the chord works from anywhere the
+## console is running and is not something the game can decline.
+const RESET_CHORD: Array[int] = [
+	Gen2Button.A, Gen2Button.B, Gen2Button.START, Gen2Button.SELECT,
+]
 
 ## The autoload, cached after the first lookup.
 static var _instance: Gen2InputRuntime = null
@@ -198,6 +228,31 @@ func send_action(action: StringName, pressed: bool) -> void:
 	Input.parse_input_event(event)
 
 
+## Whether this event is a directional press nothing should act on.
+##
+## An analog stick reports a fresh [InputEventJoypadMotion] every time its value
+## moves, and every one of those is an action press: one push of the stick walked
+## a menu cursor the length of the list. A held key repeats at the operating
+## system's rate for the same reason. The extra presses are swallowed here, in
+## front of the engine's own focus navigation as well as every screen, and
+## [method _advance_direction_repeat] puts back the repeat the hardware had.
+##
+## The cost is that a held stick past the deadzone reaches nothing else while it
+## is held, which a free camera reading raw motion would want. Nothing does
+## today; a renderer that did would read the axis rather than the event.
+func _gate_direction_repeat(event: InputEvent) -> bool:
+	var button: int = Gen2Button.direction_in(event)
+	if button == Gen2Button.NONE:
+		return false
+	if bool(_repeat_open.get(button, false)):
+		_repeat_open[button] = false
+		return false
+	if _repeat_clock.has(button):
+		return true
+	_repeat_clock[button] = FRAME_SECONDS * float(REPEAT_DELAY_FRAMES)
+	return false
+
+
 ## The direction currently held, most recently pressed first, or [constant
 ## Gen2Button.NONE]. Polled rather than read off events, because walking
 ## continues while a direction is held and the operating system's key repeat is
@@ -206,7 +261,7 @@ func held_direction() -> int:
 	return _direction_order.back() if not _direction_order.is_empty() else Gen2Button.NONE
 
 
-func _process(_delta: float) -> void:
+func _process(delta: float) -> void:
 	for button: int in Gen2Button.DIRECTIONS:
 		var held: bool = Gen2Button.held(button)
 		var at: int = _direction_order.find(button)
@@ -214,12 +269,63 @@ func _process(_delta: float) -> void:
 			_direction_order.append(button)
 		elif not held and at >= 0:
 			_direction_order.remove_at(at)
+	_advance_direction_repeat(delta)
+	_poll_reset_chord()
 
 
-## Watches every event and consumes none. Device recon has to see input the
-## screens never get, including the mouse motion that says the player has put
-## the pad down.
+## The reset chord, polled rather than read off events: four buttons at once is
+## a state, and no single press says it.
+func _poll_reset_chord() -> void:
+	var down: bool = true
+	for button: int in RESET_CHORD:
+		if not Gen2Button.held(button):
+			down = false
+			break
+	if down and not _reset_chord_down:
+		reset_chord_pressed.emit()
+	_reset_chord_down = down
+
+
+## `JoyTextDelay`'s counter, one direction at a time. A direction the gate has
+## seen pressed carries a clock; when it runs out the direction is pressed again
+## on the player's behalf, which is what lets a held d-pad walk a list at all.
+func _advance_direction_repeat(delta: float) -> void:
+	for button: int in Gen2Button.DIRECTIONS:
+		if not _direction_pressed(button):
+			_repeat_clock.erase(button)
+			_repeat_open.erase(button)
+			continue
+		if not _repeat_clock.has(button):
+			continue
+		var left: float = float(_repeat_clock[button]) - delta
+		if left > 0.0:
+			_repeat_clock[button] = left
+			continue
+		_repeat_clock[button] = FRAME_SECONDS * float(REPEAT_INTERVAL_FRAMES)
+		_repeat_open[button] = true
+		## Only a press. A release would take the action away from
+		## [method Gen2Button.held] while the player is still holding the button,
+		## and the map walks on that answer.
+		send_action(Gen2Button.action(button), true)
+
+
+## Whether a direction is down on either vocabulary; see
+## [constant Gen2Button.UI_ACTIONS].
+static func _direction_pressed(button: int) -> bool:
+	return Gen2Button.held(button) \
+		or Input.is_action_pressed(Gen2Button.UI_ACTIONS[button])
+
+
+## Watches every event and consumes none, except a directional press the
+## hardware would not have reported: see [method _gate_direction_repeat]. Device
+## recon has to see input the screens never get, including the mouse motion that
+## says the player has put the pad down.
 func _input(event: InputEvent) -> void:
+	if _gate_direction_repeat(event):
+		var viewport: Viewport = get_viewport()
+		if viewport != null:
+			viewport.set_input_as_handled()
+		return
 	var kind: StringName = Gen2InputDevice.kind_of(event)
 	if kind.is_empty():
 		return

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -159,7 +159,9 @@ var _rng := RandomNumberGenerator.new()
 ## this screen is an overlay inside the overworld, so a press is recorded once, by
 ## the world, and a replayed log reaches the fight: see
 ## [method Gen2WorldScreen.press_button] and `tools/replay_world.gd`.
-var _external_input: bool = false
+## Whether the screen that opened this one owns its input and its frames. See
+## [method set_driven].
+var _driven: bool = false
 var _save_slot: int = -1
 var _save_written: bool = false
 var _source_save: Gen2SaveData = null
@@ -445,6 +447,13 @@ var _bg_map: PackedByteArray = Gen2BattleScreenMap.seeded()
 ## the imported tables, opened once.
 var _anim_data: Gen2BattleAnimData = null
 var _anim: Gen2BattleAnimPlayer = null
+## `anim_keepsprites`: what the last script left on the screen. `BattleAnim_ClearOAM`
+## is skipped for it, so the objects stay drawn after the script has returned and
+## until something clears OAM. The catch is the one script that asks
+## (`BattleAnim_ThrowPokeBall.Click`), and the ball has to stay under
+## `Text_GotchaMonWasCaught`.
+var _kept_sprites: Array = []
+var _kept_tiles: Array = []
 var _anim_plan: Array = []
 var _anim_delay: int = 0
 var _anim_event: Dictionary = {}
@@ -469,6 +478,14 @@ var _battle_music: int = Gen2Battle.MUSIC_NONE
 func _process(delta: float) -> void:
 	if _box != null:
 		_box.accelerated = Gen2Button.text_accelerating()
+	## A screen someone else spends frames for must not also spend them off real
+	## time. The world drives a battle from its own pump
+	## ([method advance_hardware_frame]), so with this clock running as well every
+	## bar drained, every animation ran and the box's own arrow blinked at twice
+	## the source's rate. Same rule, and the same caller, as
+	## [member Gen2TextBox.driven].
+	if _driven:
+		return
 	## The yes/no box appears when the question above it has finished printing,
 	## and the box prints on its own clock rather than on a press.
 	if _switch_stage != &"":
@@ -784,11 +801,14 @@ func set_random_seed(value: int) -> void:
 	_rng.seed = value
 
 
-## Hands the input funnel to whoever opened this screen. The world does while a
-## battle is an overlay on it: one funnel is what makes a recorded log complete,
-## and two would record every press twice or none.
-func set_external_input(external: bool) -> void:
-	_external_input = external
+## Hands the input funnel and the frame pump to whoever opened this screen.
+##
+## The world does both while a battle is an overlay on it. One funnel is what
+## makes a recorded log complete, and two would record every press twice or none;
+## one pump is what makes a replay land on the same frame, and two spend every
+## frame twice.
+func set_driven(driven: bool) -> void:
+	_driven = driven
 
 
 ## The request this fight was started from, as the adapter prepared it: the
@@ -1811,6 +1831,7 @@ func advance_animation() -> bool:
 func _begin_animation(event: Dictionary) -> void:
 	_anim_event = event
 	_anim_plan = []
+	_clear_kept_sprites()
 
 	var index: int = int(event.get("index", 0))
 	var after: int = int(event.get("after_anim", 0))
@@ -2038,8 +2059,22 @@ func _restamp_battler(player_side: bool) -> void:
 func _end_script() -> void:
 	if _anim != null:
 		_bg_map = _anim.background().bg_map.duplicate()
+		## `BattleAnim_ClearOAM` has already run inside the player, so what is
+		## left here is what `anim_keepsprites` kept.
+		_kept_sprites = _anim.sprites()
+		_kept_tiles = _anim.tiles()
 	_anim = null
 	_run_next_anim_step()
+
+
+## `ClearSprites`. Nothing is drawn from the kept objects once they are gone, so
+## a caller that has nothing to clear pays only the push.
+func _clear_kept_sprites() -> void:
+	if _kept_sprites.is_empty() and _kept_tiles.is_empty():
+		return
+	_kept_sprites = []
+	_kept_tiles = []
+	_push_view()
 
 
 ## `PlayBattleMusic`, which `FindFirstAliveMonAndStartBattle` runs in front of
@@ -3445,6 +3480,10 @@ func _continue_after_messages() -> void:
 	if not _capture_messages.is_empty():
 		_show_next_capture_message()
 		return
+	## `PokeBallEffect`'s own `call ClearSprites`, which is the first thing after
+	## `Text_GotchaMonWasCaught` has been pressed past: the ball `anim_keepsprites`
+	## left at rest stays under that box and goes with it.
+	_clear_kept_sprites()
 	## After the line a mod asked from and before the nickname prompt, which is
 	## where a line about the catch reads.
 	if _show_next_mod_message():
@@ -4765,6 +4804,14 @@ func _show_next_event() -> void:
 			else:
 				show_message(text)
 			return
+		## `AnimateHPBar` and `MonFaintedAnimation` both block: the source does
+		## not reach the next command until the bar has emptied and the picture
+		## has sunk. Without this stop, a hit with no line of its own popped the
+		## faint in the same pass and the picture left the field while its own bar
+		## was still draining. [method _resume_after_frames] brings the queue back
+		## when the frames are spent.
+		if not _bars.is_empty() or fainting():
+			return
 	## The queue ran dry with nothing to print. `DoTurn` does not read a button
 	## between its last command and `BattleMenu`, so the screen runs on rather
 	## than leaving a stale box up until a press nobody owes.
@@ -5332,7 +5379,7 @@ func _read_hp() -> void:
 ## The cartridge's own controls first, then the development drivers that stand
 ## in for a battle menu this screen does not have yet.
 func _unhandled_input(event: InputEvent) -> void:
-	if not is_ready() or _external_input:
+	if not is_ready() or _driven:
 		return
 	var button: int = Gen2Button.pressed_in(event)
 	if button != Gen2Button.NONE:
@@ -5702,8 +5749,8 @@ func _push_view() -> void:
 		"bg_vbank1": _bg_vbank1,
 		"bg_palette_maps": _background_maps(&"bg"),
 		"ob_palette_maps": _background_maps(&"ob"),
-		"anim_sprites": _anim.sprites() if _anim != null else [],
-		"anim_tiles": _anim.tiles() if _anim != null else [],
+		"anim_sprites": _anim.sprites() if _anim != null else _kept_sprites,
+		"anim_tiles": _anim.tiles() if _anim != null else _kept_tiles,
 		## Whether both panels are on the map, which is the summary of the two
 		## keys above rather than a third state.
 		"hud_visible": _hud_visible(),

--- a/game/input/button.gd
+++ b/game/input/button.gd
@@ -46,6 +46,16 @@ const LABELS: Dictionary = {
 	SELECT: "SELECT",
 }
 
+## Godot's own navigation actions, one per direction. The engine moves a focus
+## ring on these and nothing else, so a screen built out of [Control]s and a
+## screen built out of tiles are driven by two vocabularies that have to agree.
+const UI_ACTIONS: Dictionary = {
+	UP: &"ui_up",
+	DOWN: &"ui_down",
+	LEFT: &"ui_left",
+	RIGHT: &"ui_right",
+}
+
 const VECTORS: Dictionary = {
 	UP: Vector2i.UP,
 	DOWN: Vector2i.DOWN,
@@ -90,6 +100,19 @@ static func from_vector(direction: Vector2i) -> int:
 static func pressed_in(event: InputEvent) -> int:
 	for button: int in ALL:
 		if event.is_action_pressed(ACTIONS[button]):
+			return button
+	return NONE
+
+
+## The direction an event presses, counting Godot's own `ui_*` family beside the
+## cartridge's four. A focus ring moves on `ui_up`, a menu on `gen2_up`, and the
+## same key, pad button and stick produce both, so anything that reads a
+## direction off an event has to answer for either. [constant Gen2Button.NONE]
+## when the event presses none of the eight.
+static func direction_in(event: InputEvent) -> int:
+	for button: int in DIRECTIONS:
+		if event.is_action_pressed(ACTIONS[button], true) \
+			or event.is_action_pressed(UI_ACTIONS[button], true):
 			return button
 	return NONE
 

--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -43,17 +43,10 @@ func _process(_delta: float) -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	var direction := Vector2.ZERO
-	if event.is_action_pressed("ui_up", true):
-		direction = Vector2.UP
-	elif event.is_action_pressed("ui_down", true):
-		direction = Vector2.DOWN
-	elif event.is_action_pressed("ui_left", true):
-		direction = Vector2.LEFT
-	elif event.is_action_pressed("ui_right", true):
-		direction = Vector2.RIGHT
-	else:
+	var button: int = Gen2Button.direction_in(event)
+	if button == Gen2Button.NONE:
 		return
+	var direction := Vector2(Gen2Button.vector(button))
 	if move_focus(direction):
 		_root.get_viewport().set_input_as_handled()
 

--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -154,13 +154,8 @@ func _on_pressed(index: int) -> void:
 
 
 func _gui_input(event: InputEvent) -> void:
-	if event.is_action_pressed("ui_left"):
+	if _step_by(event):
 		accept_event()
-		step(-1)
-		return
-	if event.is_action_pressed("ui_right"):
-		accept_event()
-		step(1)
 		return
 	if event.is_action_pressed("ui_accept"):
 		accept_event()
@@ -174,6 +169,24 @@ func _gui_input(event: InputEvent) -> void:
 			_on_drag(event)
 		else:
 			_hover(_at((event as InputEventMouseMotion).position))
+
+
+## The repeat a held direction produces is an [InputEventAction], which the
+## engine routes to no `_gui_input`, so the stage reads its repeats here.
+func _unhandled_input(event: InputEvent) -> void:
+	if has_focus() and _step_by(event):
+		get_viewport().set_input_as_handled()
+
+
+func _step_by(event: InputEvent) -> bool:
+	match Gen2Button.direction_in(event):
+		Gen2Button.LEFT:
+			step(-1)
+			return true
+		Gen2Button.RIGHT:
+			step(1)
+			return true
+	return false
 
 
 ## The row is dragged rather than paged: a press takes hold of it, the pointer

--- a/game/launcher/launcher_scroll.gd
+++ b/game/launcher/launcher_scroll.gd
@@ -7,8 +7,8 @@ extends ScrollContainer
 ## controls inside a pane has to bring the pane with it, which is
 ## [member ScrollContainer.follow_focus]. And a pane whose content is mostly text
 ## has stretches with nothing focusable in them, so the pane itself takes focus
-## and reads `ui_up` and `ui_down` as scrolling, which is the only way past a
-## wall of prose on a keyboard.
+## and reads an up or a down ([method Gen2Button.direction_in]) as scrolling,
+## which is the only way past a wall of prose on a keyboard.
 ##
 ## The pane only takes focus when it actually has somewhere to go, so a short
 ## page does not put a stop on the way down to the dock.
@@ -72,15 +72,30 @@ func _gui_input(event: InputEvent) -> void:
 		and (event is InputEventMouseButton or event is InputEventMouseMotion):
 		accept_event()
 		return
+	if _scroll_by(event):
+		accept_event()
+
+
+## The repeat a held direction produces is an [InputEventAction]
+## ([method Gen2InputRuntime._advance_direction_repeat]), and the engine routes
+## no action to `_gui_input`, so a pane holding focus reads its repeats here.
+func _unhandled_input(event: InputEvent) -> void:
+	if has_focus() and _scroll_by(event):
+		get_viewport().set_input_as_handled()
+
+
+func _scroll_by(event: InputEvent) -> bool:
 	if not _scrollable():
-		return
+		return false
 	var step: float = maxf(size.y * PAGE, 40.0)
-	if event.is_action_pressed("ui_down", true):
-		accept_event()
-		scroll_vertical = int(float(scroll_vertical) + step)
-	elif event.is_action_pressed("ui_up", true):
-		accept_event()
-		scroll_vertical = int(float(scroll_vertical) - step)
+	match Gen2Button.direction_in(event):
+		Gen2Button.DOWN:
+			scroll_vertical = int(float(scroll_vertical) + step)
+			return true
+		Gen2Button.UP:
+			scroll_vertical = int(float(scroll_vertical) - step)
+			return true
+	return false
 
 
 func _on_screen_touch(touch: InputEventScreenTouch) -> void:

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -154,34 +154,14 @@ func _build() -> void:
 		_flash.color = Color(_flash_color(), 1.0)
 		ready.connect(fade_in, CONNECT_ONE_SHOT)
 
+	## Every launcher screen is drawn in points, and only a launcher screen is:
+	## the world upscales a 160x144 screen by a whole number of real pixels, and
+	## a window drawn in points would make that number wrong.
+	Gen2LauncherUI.attach_density(self)
 	resized.connect(_apply_layout)
 	_apply_layout()
 	_place_toast()
 	_focus = Gen2FocusGuard.attach(self)
-
-
-## Every launcher screen is drawn in points, and only a launcher screen is: the
-## world upscales a 160x144 screen by a whole number of real pixels, and a
-## window drawn in points would make that number wrong.
-##
-## The factor is worked out against the window's own size, so turning the device
-## has to redo it.
-func _enter_tree() -> void:
-	var window: Window = get_window()
-	Gen2LauncherUI.apply_display_density(window, true)
-	if window != null and not window.size_changed.is_connected(_update_density):
-		window.size_changed.connect(_update_density)
-
-
-func _update_density() -> void:
-	Gen2LauncherUI.apply_display_density(get_window(), true)
-
-
-func _exit_tree() -> void:
-	var window: Window = get_window()
-	if window != null and window.size_changed.is_connected(_update_density):
-		window.size_changed.disconnect(_update_density)
-	Gen2LauncherUI.apply_display_density(window, false)
 
 
 ## The wall clock, on the twenty-four hour dial the rest of the project uses.
@@ -406,17 +386,18 @@ func _on_dock_input(event: InputEvent, id: StringName) -> void:
 	if at < 0:
 		return
 	var target: Control = null
-	if event.is_action_pressed("ui_left", true):
-		target = _buttons.get(StringName(_entries[posmod(at - 1, _entries.size())]["id"]))
-	elif event.is_action_pressed("ui_right", true):
-		target = _buttons.get(StringName(_entries[posmod(at + 1, _entries.size())]["id"]))
-	elif event.is_action_pressed("ui_up", true):
-		var page: Control = _page_nodes.get(_current)
-		if page != null:
-			target = page.call("focus_target") if page.has_method("focus_target") \
-				else Gen2FocusGuard.first_focusable(page)
-	else:
-		return
+	match Gen2Button.direction_in(event):
+		Gen2Button.LEFT:
+			target = _buttons.get(StringName(_entries[posmod(at - 1, _entries.size())]["id"]))
+		Gen2Button.RIGHT:
+			target = _buttons.get(StringName(_entries[posmod(at + 1, _entries.size())]["id"]))
+		Gen2Button.UP:
+			var page: Control = _page_nodes.get(_current)
+			if page != null:
+				target = page.call("focus_target") if page.has_method("focus_target") \
+					else Gen2FocusGuard.first_focusable(page)
+		_:
+			return
 	if target == null or not target.is_visible_in_tree():
 		return
 	(_buttons[id] as Control).accept_event()

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -82,6 +82,40 @@ static func apply_display_density(window: Window, on: bool) -> void:
 	)
 
 
+## Keeps [param root]'s window drawn in launcher units for as long as [param root]
+## is in the tree, and puts it back when it leaves.
+##
+## Every screen written in launcher units needs this and only those do, so it is
+## a guard a screen attaches rather than something a shell happens to own: the
+## save editor is drawn in the same units and has no shell, and without the
+## factor it arrived on a phone at a third of its size. The factor is worked out
+## against the window, so turning the device redoes it.
+static func attach_density(root: Control) -> DensityGuard:
+	var guard := DensityGuard.new()
+	guard.name = "DensityGuard"
+	root.add_child(guard)
+	return guard
+
+
+## See [method attach_density]. A node rather than a call so entering and leaving
+## the tree, and the window changing size, are all one thing to get right.
+class DensityGuard extends Node:
+	func _enter_tree() -> void:
+		var window: Window = get_window()
+		Gen2LauncherUI.apply_display_density(window, true)
+		if window != null and not window.size_changed.is_connected(_update):
+			window.size_changed.connect(_update)
+
+	func _exit_tree() -> void:
+		var window: Window = get_window()
+		if window != null and window.size_changed.is_connected(_update):
+			window.size_changed.disconnect(_update)
+		Gen2LauncherUI.apply_display_density(window, false)
+
+	func _update() -> void:
+		Gen2LauncherUI.apply_display_density(get_window(), true)
+
+
 ## How many window pixels one unit of the base viewport is drawn at before the
 ## density factor above. The game leaves the factor off and is drawn at exactly
 ## this, which is what puts a 160x144 screen on whole pixels.

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -115,6 +115,10 @@ var controls: Dictionary = Gen2InputActions.defaults()
 var mod_controls: Dictionary = {}
 var touch_mode: StringName = TOUCH_AUTO
 var touch_layout: Gen2TouchLayout = Gen2TouchLayout.new()
+## Whether the player has answered the question the reset chord asks the first
+## time it is used. An installation setting rather than a run's, because the
+## chord belongs to the machine: see [method Gen2InputRuntime.reset_chord_held].
+var soft_reset_acknowledged: bool = false
 
 
 ## The cartridge block as the bytes the hardware kept, `DefaultOptions` order.
@@ -224,6 +228,7 @@ func to_dict() -> Dictionary:
 		"mod_controls": mod_controls.duplicate(true),
 		"touch_mode": String(touch_mode),
 		"touch_layout": touch_layout.to_dict(),
+		"soft_reset_acknowledged": soft_reset_acknowledged,
 	}
 
 
@@ -261,6 +266,7 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.mod_controls = Gen2InputActions.sanitize_mod_controls(row.get("mod_controls"))
 	options.touch_mode = _one_of(row.get("touch_mode", ""), TOUCH_MODES)
 	options.touch_layout = Gen2TouchLayout.parse(row.get("touch_layout"))
+	options.soft_reset_acknowledged = bool(row.get("soft_reset_acknowledged", false))
 	return options
 
 

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -197,13 +197,19 @@ func render_list(
 ##   "cursor": int,       # -1 while no yes/no box is up
 ## }
 ## [/codeblock]
-func render_save(state: Dictionary) -> Image:
+## [param behind] is what the question stands over. `SaveMenu` puts
+## `Continue_LoadMenuHeader`'s own panel there, which is what an empty one draws;
+## `StartMenu_Quit` and the rows below it stand over the list instead.
+func render_save(state: Dictionary, behind: Image = null) -> Image:
 	if menu == null or font == null:
 		return null
 	var image: Image = Image.create_empty(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
-	_blit(image, _render_save_info(state), Vector2i(SAVE_INFO_LEFT, SAVE_INFO_TOP))
+	if behind != null:
+		_blit(image, behind, Vector2i.ZERO)
+	else:
+		_blit(image, _render_save_info(state), Vector2i(SAVE_INFO_LEFT, SAVE_INFO_TOP))
 	_blit(image, _render_save_textbox(state), SAVE_TEXTBOX_AT)
 	var cursor: int = int(state.get("cursor", -1))
 	if cursor >= 0:

--- a/game/save/save_editor_screen.gd
+++ b/game/save/save_editor_screen.gd
@@ -32,6 +32,7 @@ var _dex_list: ItemList = null
 var _selected_party: int = -1
 var _selected_box: int = 0
 var _palette: Gen2LauncherTheme = null
+var _margin: MarginContainer = null
 
 
 func _ready() -> void:
@@ -140,11 +141,17 @@ func _build_ui() -> void:
 	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	add_child(backdrop)
 
-	var margin := MarginContainer.new()
-	margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	for side: String in ["left", "top", "right", "bottom"]:
-		margin.add_theme_constant_override("margin_%s" % side, Gen2LauncherUI.GAP_LG)
-	add_child(margin)
+	## Drawn in launcher units like the pages it borrows its controls from, so it
+	## needs the same factor: without it every word here arrived on a phone at a
+	## third of its size. See [method Gen2LauncherUI.attach_density].
+	Gen2LauncherUI.attach_density(self)
+
+	_margin = MarginContainer.new()
+	_margin.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	add_child(_margin)
+	_apply_margins()
+	resized.connect(_apply_margins)
+	var margin: MarginContainer = _margin
 
 	var root: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_MD)
 	margin.add_child(root)
@@ -174,6 +181,22 @@ func _build_ui() -> void:
 
 	_status = Gen2LauncherUI.muted(_palette, "")
 	root.add_child(_status)
+	Gen2FocusGuard.attach(self)
+
+
+## The page's own edges, standing off the notch, the rounded corners and the home
+## indicator the way [Gen2LauncherShell] does, and closer in on a phone than on a
+## desktop.
+func _apply_margins() -> void:
+	if _margin == null:
+		return
+	var insets: Dictionary = Gen2LauncherUI.safe_area_insets(get_window())
+	var narrow: bool = size.x < Gen2LauncherShell.COMPACT_WIDTH
+	var pad: int = Gen2LauncherUI.GAP_SM if narrow else Gen2LauncherUI.GAP_LG
+	_margin.add_theme_constant_override("margin_left", pad + int(insets["left"]))
+	_margin.add_theme_constant_override("margin_right", pad + int(insets["right"]))
+	_margin.add_theme_constant_override("margin_top", pad + int(insets["top"]))
+	_margin.add_theme_constant_override("margin_bottom", pad + int(insets["bottom"]))
 
 
 ## A tab's contents, scrolled. A tab is whatever size the window leaves it, so a

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -36,13 +36,17 @@ signal sfx_requested(sfx: int, waited: bool)
 ## A field move chosen off the MOVES row, in the same shape a party member's own
 ## submenu emits: the world runs the one and the other through one path.
 signal field_move_chosen(action: Dictionary)
+## The reset chord's question was answered YES. Only the screen hosting this one
+## can restart the game, the same way it is the one that opens the launcher.
+signal soft_reset_confirmed
 
 enum Mode {
 	LIST, PACK, PACK_ITEM, PACK_TEACH, PACK_TARGET,
 	PACK_FORGET_ASK, PACK_FORGET, PACK_STOP_LEARNING, PACK_PP_MOVE,
 	PACK_TOSS_QUANTITY, PACK_TOSS_CONFIRM, PACK_GIVE_SWAP,
 	PACK_RESULT, SAVE_ASK, SAVE_OVERWRITE, SAVE_SAVING, SAVE_SAVED,
-	SAVE_FAILED, QUIT_ASK, OPTIONS, MODS, MOD_OPTIONS, FIELD_MOVES,
+	SAVE_FAILED, QUIT_ASK, LAUNCHER_ASK, RESET_ASK, OPTIONS, MODS, MOD_OPTIONS,
+	FIELD_MOVES,
 }
 
 ## `SaveMenu`'s four texts, out of `data/text/common_3.asm` on Crystal and
@@ -60,6 +64,18 @@ const SAVE_ASK_LINES: Array[String] = [
 ## texts for the same reason: no importer reads either.
 const QUIT_ASK_LINES: Array[String] = [
 	"Would you like to", "end the Contest?",
+]
+## This port's own words, over the same `YesNoBox` the two above use. The
+## launcher is where a cartridge goes back to here, and leaving takes whatever
+## has not been saved with it, which is the only reason the row asks at all.
+const LAUNCHER_ASK_LINES: Array[String] = [
+	"Would you like to", "quit this game?",
+]
+## The reset chord's own question, asked once ever: see
+## [signal Gen2InputRuntime.reset_chord_pressed]. Three lines, so the first two
+## are prompted past before the box appears, the way the overwrite question is.
+const RESET_ASK_LINES: Array[String] = [
+	"You pressed the", "RESET buttons.", "Reset the game?",
 ]
 const SAVE_OVERWRITE_LINES: Array[String] = [
 	"There is already a", "save file. Is it", "OK to overwrite?",
@@ -497,7 +513,8 @@ func _move(direction: Vector2i) -> void:
 				_render_targets()
 		## `VerticalMenu` over `YesNoMenuHeader`, which is only up while a
 		## question is; the two timed modes read no joypad at all.
-		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.QUIT_ASK:
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.QUIT_ASK, Mode.LAUNCHER_ASK, \
+		Mode.RESET_ASK:
 			if _save_cursor >= 0 and (direction.x != 0 or direction.y != 0):
 				_save_cursor = 1 - _save_cursor
 				_render_save()
@@ -595,7 +612,7 @@ func _confirm() -> void:
 			else:
 				_open_pack_mode(false)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED, Mode.QUIT_ASK:
+		Mode.SAVE_FAILED, Mode.QUIT_ASK, Mode.LAUNCHER_ASK, Mode.RESET_ASK:
 			_confirm_save()
 		## Options_Cancel is the only handler that reads A.
 		Mode.OPTIONS:
@@ -658,7 +675,7 @@ func _cancel() -> void:
 		Mode.PACK_TOSS_CONFIRM, Mode.PACK_GIVE_SWAP:
 			_open_pack_mode(false)
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED, Mode.QUIT_ASK:
+		Mode.SAVE_FAILED, Mode.QUIT_ASK, Mode.LAUNCHER_ASK, Mode.RESET_ASK:
 			_cancel_save()
 		## `_Option.joypad_loop` exits on PAD_START | PAD_B from any row.
 		Mode.OPTIONS, Mode.MODS, Mode.FIELD_MOVES:
@@ -687,6 +704,8 @@ func _confirm_list() -> void:
 			_open_field_moves_mode()
 		Gen2WorldStartMenu.ITEM_EXIT:
 			closed.emit()
+		Gen2WorldStartMenu.ITEM_LAUNCHER:
+			_enter_save_mode(Mode.LAUNCHER_ASK, LAUNCHER_ASK_LINES, 0)
 		Gen2WorldStartMenu.ITEM_POKEDEX, Gen2WorldStartMenu.ITEM_POKEMON, \
 		Gen2WorldStartMenu.ITEM_POKEGEAR, Gen2WorldStartMenu.ITEM_PLAYER:
 			action_chosen.emit(_menu.selected_kind(), &"")
@@ -2046,6 +2065,30 @@ func _confirm_save() -> void:
 				_open_list_mode()
 			else:
 				action_chosen.emit(Gen2WorldStartMenu.ITEM_QUIT, &"")
+		## NO goes back to the list the row was chosen from, the same as every
+		## other question here. YES is the world's: only the screen hosting this
+		## one can put the launcher back.
+		Mode.LAUNCHER_ASK:
+			if _save_cursor == 1:
+				_open_list_mode()
+			else:
+				action_chosen.emit(Gen2WorldStartMenu.ITEM_LAUNCHER, &"")
+		## The chord opened this menu with nothing else to do, so both answers
+		## close it. Either one is also the acknowledgement: the player now knows
+		## the shortcut is there, and it is never asked again.
+		Mode.RESET_ASK:
+			## `_ContText`'s own `PromptButton` before the third line, the way
+			## the overwrite question reads its own.
+			if _save_cursor < 0:
+				_save_line = 1
+				_save_cursor = 0
+				_render_save()
+				return
+			_acknowledge_reset()
+			if _save_cursor == 1:
+				closed.emit()
+			else:
+				soft_reset_confirmed.emit()
 		Mode.SAVE_ASK:
 			if _save_cursor == 1:
 				_open_list_mode()
@@ -2074,10 +2117,32 @@ func _confirm_save() -> void:
 ## button while the text still has a line to come. The two timed modes read no
 ## joypad at all.
 func _cancel_save() -> void:
-	if _save_cursor < 0 and _mode == Mode.SAVE_OVERWRITE:
+	if _save_cursor < 0 and _mode in [Mode.SAVE_OVERWRITE, Mode.RESET_ASK]:
 		_confirm_save()
+	elif _mode == Mode.RESET_ASK:
+		## B is `YesNoBox`'s NO, and the menu was opened for the question alone.
+		_acknowledge_reset()
+		closed.emit()
 	elif _save_cursor >= 0:
 		_open_list_mode()
+
+
+## The reset chord has now been used once, so the question is never asked again.
+## Written whichever way it was answered: what the box is for is telling the
+## player the shortcut exists, and it has done that either way.
+func _acknowledge_reset() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	if options.soft_reset_acknowledged:
+		return
+	options.soft_reset_acknowledged = true
+	Gen2OptionsStore.save(options)
+
+
+## Opens the reset chord's own question over whatever this menu was showing. The
+## world calls it instead of a row being chosen, so the list behind it is never
+## the thing the player is answering about.
+func ask_soft_reset() -> void:
+	_enter_save_mode(Mode.RESET_ASK, RESET_ASK_LINES, -1)
 
 
 ## One hardware frame of the two timed modes. Public so a test or a preview owns
@@ -2194,6 +2259,27 @@ func _exit_tree() -> void:
 		_naming = null
 
 
+## `StartMenu`'s own list, which is the picture behind every question asked off
+## a row of it.
+func _list_image() -> Image:
+	if _menu == null or _page == null:
+		return null
+	var contest: bool = _world != null and _world.bug_contest_active()
+	var shown: int = Gen2StartMenuPage.visible_rows(contest)
+	var labels: Array = []
+	for entry: Variant in _menu.items():
+		labels.append(String((entry as Dictionary).get("label", "")))
+	## `.PrintMenuAccount` reads the option on every cursor move, so turning MENU
+	## ACCOUNT off takes the block away at once.
+	var description: String = _menu.selected_description() \
+		if Gen2OptionsStore.current().menu_account else ""
+	return _page.render_list(
+		labels.slice(_list_scroll, _list_scroll + shown),
+		_menu.cursor - _list_scroll, description, contest, null,
+		_contest_status() if contest else {}
+	)
+
+
 ## Whichever of the cartridge's screens this mode is. `_hardware_image()` answers
 ## every one of them, so there is no window-resolution fallback behind it.
 func _render_hardware() -> void:
@@ -2249,25 +2335,16 @@ func _hardware_image() -> Image:
 		return null
 	match _mode:
 		Mode.LIST:
-			if _menu == null:
-				return null
-			var contest: bool = _world != null and _world.bug_contest_active()
-			var shown: int = Gen2StartMenuPage.visible_rows(contest)
-			var labels: Array = []
-			for entry: Variant in _menu.items():
-				labels.append(String((entry as Dictionary).get("label", "")))
-			## `.PrintMenuAccount` reads the option on every cursor move, so
-			## turning MENU ACCOUNT off takes the block away at once.
-			var description: String = _menu.selected_description() \
-				if Gen2OptionsStore.current().menu_account else ""
-			return _page.render_list(
-				labels.slice(_list_scroll, _list_scroll + shown),
-				_menu.cursor - _list_scroll, description, contest, null,
-				_contest_status() if contest else {}
-			)
+			return _list_image()
 		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED, Mode.QUIT_ASK:
+		Mode.SAVE_FAILED:
 			return _page.render_save(_save_state())
+		## `StartMenu_Quit` and the two rows this port added below it ask over the
+		## list they were chosen from. Only `SaveMenu` puts up
+		## `Continue_LoadMenuHeader`'s panel of badges, Pokedex and play time,
+		## because only the save question is about the file.
+		Mode.QUIT_ASK, Mode.LAUNCHER_ASK, Mode.RESET_ASK:
+			return _page.render_save(_save_state(), _list_image())
 		Mode.OPTIONS:
 			if _options_menu == null:
 				return null

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -13,6 +13,11 @@ const BATTLE_SCENE: PackedScene = preload("res://game/battle/battle_screen.tscn"
 const SERVICE_SCENE: PackedScene = preload("res://game/world/world_service_screen.tscn")
 const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_screen.tscn")
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
+## The launcher is this port's boot menu and the save screen is its title
+## screen, so a cartridge taken out goes to the first and a console reset to the
+## second, where CONTINUE is.
+const LAUNCHER_SCENE: String = "res://game/main/main.tscn"
+const SAVE_SCENE: String = "res://game/save/save_screen.tscn"
 const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
 ## How far into a view switch's close [method preview_view_cover] photographs:
 ## part way down the scatter, where the wipe is readable and the screen is not
@@ -338,6 +343,9 @@ func _ready() -> void:
 	_hint.visible = Gen2DebugKeys.enabled()
 	_data = _injected_data if _injected_data != null else _selected_runtime_data()
 	_build_world()
+	var input: Gen2InputRuntime = Gen2InputRuntime.instance()
+	if input != null and not input.reset_chord_pressed.is_connected(_on_reset_chord):
+		input.reset_chord_pressed.connect(_on_reset_chord)
 
 
 ## Why the overworld could not be built, on the two labels the debug readout
@@ -1876,7 +1884,32 @@ func _end_nuzlocke_run(save: Gen2SaveData) -> void:
 	## lists what the run caught and what it lost, and it will not open this one
 	## again.
 	if is_inside_tree():
-		get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
+		get_tree().change_scene_to_file.call_deferred(SAVE_SCENE)
+
+
+## `Reset`, which on hardware is the four buttons wired straight to the console
+## and nothing the game may decline. Nothing is written: what is on disk is what
+## the last SAVE put there, which is the whole point of the shortcut.
+func _soft_reset() -> void:
+	if is_inside_tree():
+		get_tree().change_scene_to_file.call_deferred(SAVE_SCENE)
+
+
+## The reset chord, from anywhere the world is up. The first one ever asks first,
+## over the pause menu's own box, so a player who hit four buttons by accident
+## does not lose the walk between here and their last save; after that answer it
+## resets where it is pressed. A fight or an overlay owning the screen has no
+## room for the question, so the first chord there is refused and the second,
+## once the question has been answered on the map, is not.
+func _on_reset_chord() -> void:
+	if _world == null:
+		return
+	if Gen2OptionsStore.current().soft_reset_acknowledged:
+		_soft_reset()
+		return
+	_open_start_menu_host(func(host: Gen2StartMenuScreen) -> void:
+		host.ask_soft_reset()
+	)
 
 
 ## One player event's lines put up in order, the tail run once the last has been
@@ -3958,6 +3991,33 @@ func preview_start_menu() -> void:
 	_start_menu_host.handle_button(Gen2Button.DOWN)
 
 
+## Public screenshot driver for the reset chord's own question, which no cell
+## reaches: the chord is the console's rather than the map's. One press per call,
+## so a driver calling twice photographs the `YesNoBox` rather than the first
+## page of the text.
+func preview_reset_question() -> void:
+	if _start_menu_host == null:
+		_injected_save = _embedded_party_save()
+		_refresh_party_summary()
+		_open_start_menu_host(func(host: Gen2StartMenuScreen) -> void:
+			host.ask_soft_reset()
+		)
+		return
+	_start_menu_host.handle_button(Gen2Button.A)
+
+
+## The same for the HOME row's own question, walked to off the list the way a
+## player reaches it.
+func preview_launcher_question() -> void:
+	if _start_menu_host == null:
+		preview_start_menu()
+		return
+	var menu: Gen2WorldStartMenu = _start_menu_host.get("_menu")
+	while menu != null and menu.selected_kind() != Gen2WorldStartMenu.ITEM_LAUNCHER:
+		_start_menu_host.handle_button(Gen2Button.DOWN)
+	_start_menu_host.handle_button(Gen2Button.A)
+
+
 ## Public screenshot driver for the cover a view switch is hidden behind: the
 ## switch itself, photographed part way down its close. See
 ## [method Gen2Screen.play_view_cover].
@@ -4679,7 +4739,7 @@ func _open_battle_host(request: Dictionary) -> void:
 	## anything about the battle. Its frames and its buttons both come through this
 	## screen from here on.
 	host.set_random_seed(_encounter_random.randi())
-	host.set_external_input(true)
+	host.set_driven(true)
 	host.set_time_of_day(time_of_day)
 	# The clock's row is what the battle's own heals read; the drawn row is what
 	# a renderer staging the fight on this map has to match, so the context
@@ -5654,6 +5714,7 @@ func _open_start_menu_host(entry: Callable) -> void:
 	## map is already in rather than into one of the host's own.
 	host.set_screen(_screen)
 	host.action_chosen.connect(_on_start_menu_action)
+	host.soft_reset_confirmed.connect(_soft_reset)
 	host.closed.connect(_on_start_menu_closed)
 	host.field_item_used.connect(_on_field_item_used)
 	host.field_move_chosen.connect(_on_start_menu_field_move)
@@ -5704,6 +5765,13 @@ func _on_start_menu_action(kind: StringName, id: StringName = &"") -> void:
 			## BugCatchingContestReturnToGateScript` and the 4 it returns, which
 			## is `.ExitMenuRunScript`: the menu closes and the script runs.
 			_show_script_results(_world.queue_bug_contest_results(&"retired"))
+		Gen2WorldStartMenu.ITEM_LAUNCHER:
+			## Nothing is written: the row asked first, and a player who wanted
+			## this run kept chose SAVE before it. The cartridge comes out of the
+			## console exactly as it went in.
+			if is_inside_tree():
+				get_tree().change_scene_to_file.call_deferred(LAUNCHER_SCENE)
+			return
 	_refresh_labels()
 
 
@@ -6786,9 +6854,7 @@ func _show_script_results(results: Array) -> void:
 				## left Battle Tower challenge leaves the battle room. The save
 				## has already been written by the action in front of it.
 				persist_world_snapshot()
-				get_tree().change_scene_to_file.call_deferred(
-					"res://game/world/intro_screen.tscn"
-				)
+				_soft_reset()
 				return
 			elif result_event.get("type", &"") == &"battle_tower_opponent_loaded":
 				## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail, which

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -48,6 +48,12 @@ const ITEM_FIELD_MOVES: StringName = &"field_moves"
 ## menu exactly. It sits after OPTION and before the entries mods registered
 ## themselves, which keeps both additions in one block ahead of EXIT.
 const ITEM_MODS: StringName = &"mods"
+## Not the cartridge's. The launcher is this port's boot menu, and a cartridge
+## comes out of a console rather than out of a menu, so the one thing the source
+## has no row for is the way back. Last, under EXIT, and behind the same contest
+## gate PACK is: a contest is a timed errand and leaving one is what the
+## cartridge's own QUIT is for.
+const ITEM_LAUNCHER: StringName = &"launcher"
 
 ## What `SetUpMenuItems` gates each source entry on. An empty gate is always
 ## appended, matching the entries the source adds unconditionally.
@@ -60,8 +66,9 @@ const GATE_NO_CONTEST: StringName = &"no_contest"
 
 ## `SetUpMenuItems` in source order, as data rather than a run of appends, so the
 ## host's registered entries can be spliced in without the order becoming a
-## question. EXIT stays last: it is what closes the menu, and the source never
-## puts anything after it.
+## question. EXIT stays last of the source's own: it is what closes the menu, and
+## the source never puts anything after it. Only [constant ITEM_LAUNCHER], which
+## the source has no row for at all, is below it.
 ## The labels are `.PokedexString` and its siblings verbatim, which is what the
 ## box over the map prints. `#` is the charmap's own $54 and expands to "POKe";
 ## `<PLAYER>`, which the source's own `.StatusString` is, is filled in by
@@ -75,6 +82,10 @@ const SOURCE_ENTRIES: Array[Dictionary] = [
 	{"kind": ITEM_SAVE, "label": "SAVE", "available": true, "gate": &""},
 	{"kind": ITEM_OPTION, "label": "OPTION", "available": true, "gate": &""},
 	{"kind": ITEM_EXIT, "label": "EXIT", "available": true, "gate": &""},
+	## Four tiles, because the box only has seven: `GetMenuTextStartCoord` puts
+	## the first letter at column 12 and the frame's right edge is at 19, which
+	## is what `#DEX` fills exactly.
+	{"kind": ITEM_LAUNCHER, "label": "HOME", "available": true, "gate": GATE_NO_CONTEST},
 ]
 
 ## `.Items`' third column, the one MENU ACCOUNT draws under the list

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -404,6 +404,55 @@ func test_a_hit_drains_the_bar_before_it_says_what_the_hit_was() -> void:
 	assert_eq(_battle_screen.battle_snapshot()["message"], "It's super effective!")
 
 
+## `AnimateHPBar` blocks, so the picture does not start sinking until the bar it
+## belongs to has emptied. A hit with no line of its own used to pop the faint in
+## the same pass, and the opponent left the field over a bar still draining.
+func test_a_hit_that_says_nothing_still_empties_the_bar_before_the_faint() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+	_battle_screen.set_hp(48, 48, 40, 40)
+
+	_battle_screen._pending = [
+		{
+			"type": Gen2Battle.HIT, "side": Gen2Battle.PLAYER,
+			"target": Gen2Battle.ENEMY, "hp": 0, "max_hp": 48, "critical": false,
+			"effectiveness": RomLayout.MATCHUP_EFFECTIVE,
+		},
+		{"type": Gen2Battle.FAINTED, "side": Gen2Battle.ENEMY},
+	]
+	## A turn is being resolved, so `BattleMenu` is not up: with it up the queue
+	## waits on the press that closes it and no frame would pop the faint at all.
+	_battle_screen._menu_stage = &""
+	_battle_screen._show_next_event()
+
+	assert_true(_battle_screen.bars_animating(), "the bar is on its way down")
+	assert_false(_battle_screen.fainting(), "and the picture has not moved yet")
+
+	var guard: int = 4000
+	while _battle_screen.bars_animating() and guard > 0:
+		_battle_screen.advance_frame()
+		guard -= 1
+	assert_eq(int(_battle_screen.get("_enemy_hp")), 0)
+	assert_true(_battle_screen.fainting(), "the faint follows the bar it waited for")
+
+
+## `anim_keepsprites` skips `BattleAnim_ClearOAM`, so what the last script left is
+## still drawn after it has returned: the ball at rest under "Gotcha!". The view
+## used to read the running player alone and the ball vanished with the script.
+func test_what_a_script_kept_is_still_drawn_once_the_script_has_ended() -> void:
+	await _open_battle()
+	_battle_screen._kept_sprites = [{"tile": 3, "attributes": 0, "x": 8, "y": 16}]
+	_battle_screen._push_view()
+	assert_eq(
+		(_battle_screen._renderer._view["anim_sprites"] as Array).size(), 1,
+		"the ball stays on the screen with no script running"
+	)
+	## `PokeBallEffect`'s own `ClearSprites`, which is what takes it away.
+	_battle_screen._clear_kept_sprites()
+	assert_true((_battle_screen._renderer._view["anim_sprites"] as Array).is_empty())
+
+
 ## A Pokemon coming out gets its bar drawn rather than drained: the maximum
 ## moved under it, so it is not the same bar.
 func test_a_new_pokemon_does_not_animate_its_bar_up() -> void:

--- a/tests/integration/test_input_runtime.gd
+++ b/tests/integration/test_input_runtime.gd
@@ -135,3 +135,50 @@ func test_reveal_does_nothing_unless_the_controller_is_switched_off() -> void:
 	options.touch_mode = Gen2Options.TOUCH_AUTO
 	_runtime.apply_options(options)
 	assert_false(_runtime.reveal_touch_controls(), "there is nothing to reveal")
+
+
+## `JoyTextDelay`: the second press of a direction the player never let go of is
+## the hardware's own repeat, and it does not arrive for fifteen frames. Without
+## the gate an analog stick reported one on every event it sent, which walked a
+## menu cursor the length of its list on one push.
+func test_a_held_direction_repeats_at_the_source_rate_and_not_faster() -> void:
+	var down := InputEventJoypadMotion.new()
+	down.axis = JOY_AXIS_LEFT_Y
+	down.axis_value = 1.0
+	assert_false(_runtime._gate_direction_repeat(down), "the first press is the player's")
+	down.axis_value = 0.98
+	assert_true(_runtime._gate_direction_repeat(down), "the stick has not been let go")
+	assert_true(_runtime._gate_direction_repeat(down))
+
+	## The repeat the gate owes, spent as frames rather than as presses.
+	_runtime.press(Gen2Button.DOWN)
+	await _settle()
+	var owed: int = 0
+	for _frame: int in Gen2InputRuntime.REPEAT_DELAY_FRAMES + 1:
+		_runtime._advance_direction_repeat(Gen2InputRuntime.FRAME_SECONDS)
+		if bool(_runtime._repeat_open.get(Gen2Button.DOWN, false)):
+			owed += 1
+			_runtime._repeat_open[Gen2Button.DOWN] = false
+	assert_eq(owed, 1, "one repeat in the first fifteen frames, not fifteen")
+	_runtime.release(Gen2Button.DOWN)
+	await _settle()
+
+
+## Four buttons at once is a state no single press says, so the chord is polled
+## and reported once per press of it.
+func test_the_reset_chord_is_reported_once_while_it_is_held() -> void:
+	var fired: Array = []
+	_runtime.reset_chord_pressed.connect(func() -> void: fired.append(true))
+	for button: int in Gen2InputRuntime.RESET_CHORD:
+		_runtime.press(button)
+	await _settle()
+	await _settle()
+	assert_eq(fired.size(), 1, "held for four frames, reported once")
+	_runtime.release(Gen2Button.SELECT)
+	await _settle()
+	_runtime.press(Gen2Button.SELECT)
+	await _settle()
+	assert_eq(fired.size(), 2, "let go and pressed again is a second reset")
+	for button: int in Gen2InputRuntime.RESET_CHORD:
+		_runtime.release(button)
+	await _settle()

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -156,14 +156,63 @@ func test_exit_closes_the_menu_and_restores_movement() -> void:
 	_world_screen._open_start_menu()
 	await get_tree().process_frame
 	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
-	## EXIT is the source's guaranteed last entry.
-	while host.cursor() < host.get("_menu").size() - 1:
+	## EXIT is the source's guaranteed last entry; HOME, which this port added
+	## for the way back to the launcher, is the one row under it.
+	while host.cursor() < host.get("_menu").size() - 2:
 		host.handle_button(Gen2Button.DOWN)
 	assert_eq(host.get("_menu").selected_kind(), Gen2WorldStartMenu.ITEM_EXIT)
 	host.handle_button(Gen2Button.A)
 	await get_tree().process_frame
 	assert_null(_world_screen._start_menu_host)
 	assert_true(_world_screen._objects_may_move())
+
+
+## The way out of the cartridge, which the console owned and the source has no
+## row for. It asks first, because leaving takes whatever has not been saved.
+func test_home_asks_before_it_gives_the_cartridge_back() -> void:
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	while host.cursor() < host.get("_menu").size() - 1:
+		host.handle_button(Gen2Button.DOWN)
+	assert_eq(host.get("_menu").selected_kind(), Gen2WorldStartMenu.ITEM_LAUNCHER)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LAUNCHER_ASK)
+
+	## NO is the second row, and it goes back to the list rather than out.
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.LIST)
+	assert_not_null(_world_screen._start_menu_host, "the menu is still up")
+
+
+## The reset chord asks once ever, and the answer is written whichever way it
+## went: what the box is for is saying the shortcut exists.
+func test_the_reset_question_is_asked_once_and_answered_either_way() -> void:
+	Gen2OptionsStore.use_test_path()
+	var options: Gen2Options = Gen2OptionsStore.current()
+	options.soft_reset_acknowledged = false
+	Gen2OptionsStore.save(options)
+
+	await _open_world()
+	_world_screen._on_reset_chord()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_not_null(host, "the chord opened the menu to ask")
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.RESET_ASK)
+
+	## Three lines, so the first press is `PromptButton` and the box only then
+	## appears; B on it is `YesNoBox`'s NO.
+	host.handle_button(Gen2Button.A)
+	var confirmed: Array = []
+	host.soft_reset_confirmed.connect(func() -> void: confirmed.append(true))
+	host.handle_button(Gen2Button.B)
+	assert_true(confirmed.is_empty(), "NO resets nothing")
+	assert_true(
+		Gen2OptionsStore.current().soft_reset_acknowledged,
+		"and is never asked again"
+	)
 
 
 func test_cancel_closes_the_menu_the_same_as_exit() -> void:
@@ -2111,13 +2160,13 @@ func test_a_list_longer_than_the_screen_is_scrolled_rather_than_drawn_past_it() 
 	assert_gt(rows, visible, "the fixture's own list already overflows the box")
 	assert_eq(host._list_scroll, 0, "and it opens at the top of itself")
 
-	## Down to the last row, which is EXIT: the window follows the cursor.
+	## Down to the last row, which is HOME: the window follows the cursor.
 	for _press: int in rows - 1:
 		host.handle_button(Gen2Button.DOWN)
-	assert_eq(host._menu.selected_kind(), Gen2WorldStartMenu.ITEM_EXIT)
+	assert_eq(host._menu.selected_kind(), Gen2WorldStartMenu.ITEM_LAUNCHER)
 	assert_eq(host._list_scroll, rows - visible)
 	assert_true(
-		host._menu.cursor - host._list_scroll < visible, "EXIT is inside the window"
+		host._menu.cursor - host._list_scroll < visible, "HOME is inside the window"
 	)
 
 	## `STATICMENU_WRAP` in both directions, with the window going round with it.

--- a/tests/unit/test_input_actions.gd
+++ b/tests/unit/test_input_actions.gd
@@ -234,3 +234,25 @@ func test_installing_twice_adds_one_ui_pad_binding() -> void:
 	var once: int = InputMap.action_get_events(&"ui_accept").size()
 	Gen2InputActions.install(Gen2InputActions.defaults())
 	assert_eq(InputMap.action_get_events(&"ui_accept").size(), once)
+
+
+## Godot moves a focus ring on `ui_up` and a menu moves on `gen2_up`, and one key
+## or pad button produces both. Anything reading a direction off an event has to
+## answer for either, or the launcher and the game disagree about the same press.
+func test_a_direction_is_read_off_either_vocabulary() -> void:
+	Gen2InputActions.install(Gen2InputActions.defaults())
+	var key := InputEventKey.new()
+	key.physical_keycode = KEY_DOWN
+	key.pressed = true
+	assert_eq(Gen2Button.direction_in(key), Gen2Button.DOWN)
+
+	## W is bound to the cartridge's UP and to nothing of Godot's.
+	var wasd := InputEventKey.new()
+	wasd.physical_keycode = KEY_W
+	wasd.pressed = true
+	assert_eq(Gen2Button.direction_in(wasd), Gen2Button.UP)
+
+	var accept := InputEventKey.new()
+	accept.physical_keycode = KEY_Z
+	accept.pressed = true
+	assert_eq(Gen2Button.direction_in(accept), Gen2Button.NONE, "A is not a direction")

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -886,6 +886,24 @@ func test_a_platform_that_cannot_open_a_second_window_draws_in_screen_pixels() -
 		assert_eq(Gen2LauncherUI.safe_area_insets(get_tree().root)["top"], 0.0)
 
 
+## Every screen written in launcher units needs the factor, and only a launcher
+## screen does. The save editor is drawn in those units and has no shell to own
+## it, which is what left it on a phone at a third of its size.
+func test_a_screen_in_launcher_units_carries_its_own_density_guard() -> void:
+	Gen2LauncherUI.preview_density = 3.0
+	var window: Window = get_tree().root
+	var before: float = window.content_scale_factor
+	var page := Control.new()
+	Gen2LauncherUI.attach_density(page)
+	add_child_autofree(page)
+	await get_tree().process_frame
+	assert_ne(window.content_scale_factor, before, "the page is drawn in points")
+	page.get_parent().remove_child(page)
+	assert_eq(window.content_scale_factor, 1.0, "and the game is not")
+	window.content_scale_factor = before
+	Gen2LauncherUI.preview_density = 0.0
+
+
 func test_the_preview_density_still_overrides_the_display_server() -> void:
 	Gen2LauncherUI.preview_density = 2.5
 	assert_eq(Gen2LauncherUI.display_density(), 2.5)

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -20,7 +20,7 @@ func test_default_list_omits_pokedex_pokemon_and_pokegear() -> void:
 	assert_eq(_kinds(menu), [
 		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
 		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
-		Gen2WorldStartMenu.ITEM_EXIT,
+		Gen2WorldStartMenu.ITEM_EXIT, Gen2WorldStartMenu.ITEM_LAUNCHER,
 	])
 
 
@@ -74,6 +74,7 @@ func test_full_list_matches_the_source_item_order_when_every_gate_is_open() -> v
 		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_POKEGEAR,
 		Gen2WorldStartMenu.ITEM_PLAYER, Gen2WorldStartMenu.ITEM_SAVE,
 		Gen2WorldStartMenu.ITEM_OPTION, Gen2WorldStartMenu.ITEM_EXIT,
+		Gen2WorldStartMenu.ITEM_LAUNCHER,
 	])
 
 
@@ -92,6 +93,19 @@ func test_every_entry_the_gates_admit_is_available() -> void:
 	assert_true(available_by_kind[Gen2WorldStartMenu.ITEM_POKEDEX])
 
 
+## The way back out of the cartridge, which the console rather than the game
+## owned. It is behind the contest gate PACK is: a contest is a timed errand and
+## the cartridge's own QUIT is what leaves one.
+func test_home_is_last_and_leaves_with_the_pack_during_a_contest() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
+	assert_eq(_kinds(menu).back(), Gen2WorldStartMenu.ITEM_LAUNCHER)
+	var contest: Gen2WorldStartMenu = Gen2WorldStartMenu.build(
+		1, true, true, 0, "", false, true
+	)
+	assert_false(_kinds(contest).has(Gen2WorldStartMenu.ITEM_LAUNCHER))
+	assert_false(_kinds(contest).has(Gen2WorldStartMenu.ITEM_PACK))
+
+
 func test_quit_never_appears_because_this_project_has_no_bug_contest() -> void:
 	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(1, true, true)
 	assert_false(_kinds(menu).has(&"quit"))
@@ -101,9 +115,9 @@ func test_quit_never_appears_because_this_project_has_no_bug_contest() -> void:
 ## both ends instead of stopping.
 func test_cursor_wraps_at_both_ends() -> void:
 	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(0, false, false)
-	assert_eq(menu.size(), 5)
+	assert_eq(menu.size(), 6)
 	assert_true(menu.move(-1))
-	assert_eq(menu.cursor, 4)
+	assert_eq(menu.cursor, 5)
 	assert_true(menu.move(1))
 	assert_eq(menu.cursor, 0)
 
@@ -157,8 +171,9 @@ func test_from_world_reads_party_count_and_engine_flags_off_the_live_world() -> 
 	RomCache.clear(Fixture.directory())
 
 
-## The registry seam: a mod entry is spliced in ahead of EXIT, which stays last
-## because it is what closes the menu, and no source entry moves.
+## The registry seam: a mod entry is spliced in ahead of EXIT, which stays last of
+## the source's own because it is what closes the menu, and no source entry
+## moves. Only HOME, which the cartridge has no row for, is below it.
 func test_a_registered_entry_lands_before_exit() -> void:
 	Gen2ModHost.reset()
 	var called: Array = []
@@ -171,6 +186,7 @@ func test_a_registered_entry_lands_before_exit() -> void:
 		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
 		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
 		&"atlas", Gen2WorldStartMenu.ITEM_EXIT,
+		Gen2WorldStartMenu.ITEM_LAUNCHER,
 	])
 	var entry: Dictionary = menu.items()[4]
 	assert_eq(String(entry.get("label", "")), "Atlas")
@@ -236,6 +252,7 @@ func test_mods_appears_only_for_a_mod_that_registered_a_setting() -> void:
 		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
 		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
 		Gen2WorldStartMenu.ITEM_MODS, &"atlas", Gen2WorldStartMenu.ITEM_EXIT,
+		Gen2WorldStartMenu.ITEM_LAUNCHER,
 	])
 	assert_true(bool(menu.items()[4].get("available", false)))
 	Gen2ModHost.reset()
@@ -250,6 +267,7 @@ func test_the_labels_are_the_source_strings_with_the_player_name_filled_in() -> 
 		labels.append(String((entry as Dictionary).get("label", "")))
 	assert_eq(labels, [
 		"#DEX", "#MON", "PACK", "<POKE>GEAR", "GOLD", "SAVE", "OPTION", "EXIT",
+		"HOME",
 	])
 	## A world with no save selected has no name to read.
 	assert_eq(String(Gen2WorldStartMenu.build(0, false, false).items()[1]["label"]), "PLAYER")
@@ -363,6 +381,7 @@ func test_moves_appears_only_when_a_field_move_source_has_something_to_offer() -
 		Gen2WorldStartMenu.ITEM_PACK, Gen2WorldStartMenu.ITEM_PLAYER,
 		Gen2WorldStartMenu.ITEM_SAVE, Gen2WorldStartMenu.ITEM_OPTION,
 		Gen2WorldStartMenu.ITEM_FIELD_MOVES, &"atlas", Gen2WorldStartMenu.ITEM_EXIT,
+		Gen2WorldStartMenu.ITEM_LAUNCHER,
 	])
 	assert_true(bool(menu.items()[4].get("available", false)))
 	Gen2ModHost.reset()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -65,6 +65,8 @@ extends SceneTree
 ## | `repel_renewal` | cell | The question a Repel running out asks. Needs a registered renewal provider |
 ## | `mod_notice` | badge | `Gen2ModHost.request_notice`'s banner over the map, wearing that badge |
 ## | `mod_page` | badges won | `START_ACTION_OPEN_MOD_PAGE`'s screen, listing the eight Johto badges |
+## | `reset_question` | none | The reset chord's own question, asked once ever. Driven twice for the `YesNoBox` behind its second page |
+## | `launcher_question` | none | The HOME row's question, walked to off the list. Driven twice |
 ##
 ## A kind may also be the name of any `preview_*` driver on the world screen
 ## without that prefix: `field_move` (`PartyMenu` with a taught CUT),
@@ -736,7 +738,7 @@ func _process(_delta: float) -> bool:
 			## prefix. A `*_use` driver is one step per call, so it is called
 			## twice: the first opens the menu and the second answers it.
 			_screen.call(SCREEN_DRIVER % _kind)
-			if String(_kind).ends_with("_use"):
+			if String(_kind).ends_with("_use") or String(_kind).ends_with("_question"):
 				_screen.call(SCREEN_DRIVER % _kind)
 		elif not _bare:
 			_screen.preview_effect_sprites(_kind)
@@ -747,6 +749,7 @@ func _process(_delta: float) -> bool:
 			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
 			&"catch_nickname", &"mom_bank", &"bills_pc", &"players_pc",
 			&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page",
+			&"reset_question", &"launcher_question",
 		]:
 			## Those kinds drove themselves to the frame they want; every other
 			## kind stages a sprite and then spends the frames it needs.


### PR DESCRIPTION
Seven reported defects, each fixed at the seam every occurrence goes through.

**A held direction had no rate of its own.** `JoyTextDelay` (`home/joypad.asm`) is the hardware's whole menu auto-repeat: a fresh press reloads `wTextDelayFrames` with 15, and every later frame the counter reaches zero the button is reported pressed again and the counter is reloaded with 5. Nothing here modelled it, so a direction was whatever the device happened to report. An analog stick sends a fresh `InputEventJoypadMotion` every time its value moves and every one of those is an action press, which is why one push of the stick walked a menu cursor the length of its list. `Gen2InputRuntime` now swallows a directional press the hardware would not have reported, in front of the engine's own focus navigation as well as in front of every screen, and puts the source's repeat back at 15 frames then 5. A held d-pad, which sent no repeat at all before, now scrolls a list. The launcher reads a direction through `Gen2Button.direction_in`, which answers for `ui_up` and `gen2_up` together, so the focus ring and the tile menus move on one vocabulary.

**A battle inside the world spent every frame twice.** The world drives the fight from its own pump (`advance_hardware_frame`) and the battle screen ran its own clock beside it. Bars drained, animations ran and the text box blinked its arrow at double the source's rate. A screen someone else spends frames for no longer counts real time, which is the rule `Gen2TextBox.driven` already had.

**The picture left the field over a bar still draining.** `_show_next_event` walked past an event with no line of its own, so a plain hit popped the faint in the same pass. `AnimateHPBar` blocks: the queue now waits for the frames it started.

**The caught ball vanished with its own script.** `BattleAnim_ThrowPokeBall.Click` is `anim_keepsprites` and `anim_ret`, so the ball stays at rest under `Text_GotchaMonWasCaught`. The animation player kept it and the screen dropped it the moment the script returned. It is now kept until `PokeBallEffect`'s own `ClearSprites`.

**`StartMenu_Quit` asked over the wrong picture.** `Continue_LoadMenuHeader`'s panel of badges, Pokedex and play time belongs to `SaveMenu`; the contest's question stands over the list it was chosen from, and so do the two rows added below.

**The save editor was drawn at a third of its size on a phone.** Every launcher screen is drawn in points and only a launcher screen is, and the factor was owned by `Gen2LauncherShell`. The save editor is written in the same units with no shell. It is now a guard a screen attaches (`Gen2LauncherUI.attach_density`), the shell uses the same one, and the editor stands off the notch, the rounded corners and the home indicator like every other page.

**Two things the source has no row for.** HOME sits under EXIT and hands the cartridge back to the launcher after asking, and it leaves the list with PACK while a Bug Catching Contest runs. Four tiles because the box has seven: `GetMenuTextStartCoord` puts the first letter at column 12 and the frame's right edge is at 19, which is what `#DEX` fills exactly.

A + B + START + SELECT is the console's own reset, wired to the hardware rather than to any routine, so it is polled beside the buttons and answered from anywhere the world is up. It lands on the save screen, which is this port's title screen. The first one ever asks over the pause menu's own box, and either answer is the acknowledgement: what the box is for is saying the shortcut exists. `special Reset`, which the Battle Tower already used, went to the new-game intro with no pending slot and sat there dead; it goes to the same place now.

| Check | Result |
|---|---|
| GUT, both tiers | 3,988 tests, 0 failures |
| `tools/validate.gd -- all` | 79 topics, 0 failures |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no refused step |
| `--warning-scan` | 0 warnings in 591 scripts |
| Boot smoke test | clean |