### PR TITLE
Make a catch what the cartridge makes it

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -432,6 +432,11 @@ const PP_ITEM_AMOUNTS: Dictionary = {
 ## everything else reaches the ordinary speed check.
 const BATTLETYPE_NORMAL: int = 0
 const BATTLETYPE_DEBUG: int = 2
+## The Dude's tutorial, which `PokeBallEffect` catches without a roll.
+const BATTLETYPE_TUTORIAL: int = 3
+## Written by `FishFunction`'s `.goodtofish`. It names the battle-start line and
+## is the one condition `LureBallMultiplier` boosts on.
+const BATTLETYPE_FISH: int = 4
 const BATTLETYPE_CONTEST: int = 6
 const BATTLETYPE_FORCESHINY: int = 7
 ## Named by `PlayBattleMusic` alone: nothing else here branches on it.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3,6 +3,9 @@ extends Control
 
 signal battle_finished(result: Dictionary)
 signal capture_requested(ball: int)
+## `NewPokedexEntry` behind `Text_GotchaMonWasCaught`: the page belongs to the
+## world, which owns the dex, so the battle asks for it and waits.
+signal dex_entry_requested(species: int)
 ## A bag item spent inside the battle, so the world takes one off the pocket.
 ## `target` is the party index an ITEMMENU_PARTY item was used on, or -1.
 signal item_used(item: int, target: int)
@@ -293,6 +296,17 @@ var _pack_move_selecting: bool = false:
 var _capture_balls: Array[int] = []
 var _capture_quantities: Dictionary = {}
 var _capture_ball_index: int = 0
+## `ItemSubmenu`, which stands between a pack row and its effect. Empty when no
+## submenu is up; `&"pack"` and `&"capture"` name the list it was opened over.
+var _pack_action_stage: StringName = &""
+var _pack_action_index: int = 0
+## The action `.UseItem` returning with `wBattlePlayerAction` still
+## BATTLEPLAYERACTION_USEITEM owes the enemy. Empty when the throw was refused
+## before `_DoItemEffect` ran, which is what `.didnt_use_item` takes it back to.
+var _capture_spent_turn: Dictionary = {}
+## Which list the ball was chosen from, so a refused throw reopens it the way
+## `.didnt_use_item` drops back into the pack it was still standing in.
+var _capture_origin: StringName = &"capture"
 ## What [method begin_capture] says instead of opening, when the run's rules
 ## forbid a catch in this fight. Empty means the selector opens.
 var _capture_refusal: String = ""
@@ -331,6 +345,14 @@ var _annotations_drawn: String = ""
 ## Whether the enemy species was in this save's Pokedex before the battle began,
 ## read once at the start because the first sight of it registers immediately.
 var _enemy_seen_before: bool = false
+## `CheckCaughtMon` and `CheckReceivedDex`, both read before the throw registers
+## anything: a species already in the dex adds no data, and a player who has not
+## been handed the dex is shown no page at all.
+var _enemy_caught_before: bool = false
+var _dex_received: bool = false
+## How far `NewDexDataText` and the page behind it have got. Empty until the
+## catch is terminal.
+var _capture_dex_stage: StringName = &""
 var _capture_result: Dictionary = {}
 ## `PokeBallEffect`'s own `AskGiveNicknameText`, which stands over the battle
 ## because the whole routine runs inside it. Null while nothing is being named.
@@ -1070,6 +1092,8 @@ func start_world_battle(
 	_enemy_seen_before = save != null and save.world != null \
 		and save.world.world_state != null \
 		and save.world.world_state.has_seen_species(_enemy)
+	_enemy_caught_before = false
+	_dex_received = false
 	_init_battle_display()
 	_play_battle_music()
 
@@ -1740,6 +1764,17 @@ const ANIM_THROW_POKE_BALL: int = 0x100
 ## [method Gen2WorldPartyHost._failed_wobbles] answers with. There is no line for
 ## a rock on its own: the rocking is the animation, and one of these is the whole
 ## of what a failed throw says.
+## `BallBlockedText` and `BallDontBeAThiefText`, which are two boxes rather than
+## one line, and `BallBoxFullText`, said before the ball is even thrown.
+## `_NewDexDataText`, which names the Pokemon and plays a sound of its own.
+const NEW_DEX_DATA_TEXT: String = "%s's data\nwas newly added to\nthe #DEX."
+const BALL_BLOCKED_TEXT: String = "The trainer\nblocked the BALL!"
+const BALL_DONT_BE_A_THIEF_TEXT: String = "Don't be a thief!"
+const BALL_BOX_FULL_TEXT: String = "The #MON BOX\nis full. That\ncan't be used now."
+## `anim_if_param_equal NO_ITEM`, `BattleAnim_ThrowPokeBall`'s own first branch
+## and the one `UseBallInTrainerBattle` sets `wBattleAnimParam` to.
+const ANIM_PARAM_NO_ITEM: int = 0
+
 const BREAK_FREE_TEXT: Array[String] = [
 	"Oh no! The #MON\nbroke free!",
 	"Aww! It appeared\nto be caught!",
@@ -2641,15 +2676,11 @@ func use_selected_pack_item() -> Dictionary:
 	if _data != null and int(_data.item(item).get("pocket", 0)) == Gen2WorldPack.TYPE_BALL:
 		_pack_selecting = false
 		if not _is_wild_battle():
-			## `PokeBallEffect`'s `UseBallInTrainerBattle`, which spends neither
-			## the ball nor the turn.
-			show_message("The trainer blocked the BALL!
-Don't be a thief!")
-			return {"ok": false, "reason": &"ball_in_trainer_battle"}
-		var opened: Dictionary = begin_capture()
-		if bool(opened.get("ok", false)):
-			select_capture_ball(_capture_balls.find(item))
-		return opened
+			return _block_ball_in_trainer_battle(item)
+		var refused: Dictionary = _capture_guard()
+		if not refused.is_empty():
+			return refused
+		return _throw_ball(item, &"pack")
 	if _data != null \
 		and int(_data.item(item).get("battle_menu", 0)) == Gen2WorldPack.ITEMMENU_PARTY:
 		_pack_selecting = false
@@ -2657,6 +2688,27 @@ Don't be a thief!")
 		_open_switch_pick(&"item")
 		return {"ok": true, "status": &"choosing_target", "item": item}
 	return _use_pack_item(item, -1)
+
+
+## `UseBallInTrainerBattle`, which is where `PokeBallEffect` jumps before it says
+## anything at all: no ITEM USED line, the throw animation on
+## `BattleAnim_ThrowPokeBall`'s own NO_ITEM branch, two boxes, and then
+## `UseDisposableItem` spends the ball anyway. The turn goes with it, because
+## `wItemEffectSucceeded` and `wBattlePlayerAction` are one byte and
+## `_DoItemEffect` set it to BATTLEPLAYERACTION_USEITEM on the way in.
+func _block_ball_in_trainer_battle(ball: int) -> Dictionary:
+	_capture_messages.clear()
+	_capture_messages.append(BALL_BLOCKED_TEXT)
+	_capture_messages.append(BALL_DONT_BE_A_THIEF_TEXT)
+	_begin_animation({
+		"param": ANIM_PARAM_NO_ITEM,
+		"index": ANIM_THROW_POKE_BALL,
+		"enemy_turn": false,
+	})
+	item_used.emit(ball, -1)
+	if not _battle.is_over():
+		_capture_spent_turn = Gen2Battle.use_item(ball)
+	return {"ok": true, "status": &"blocked", "ball": ball}
 
 
 ## `RestorePPEffect`'s question: which of the target's moves the Ether goes on.
@@ -2729,6 +2781,17 @@ func set_capture_refusal(message: String) -> void:
 	_capture_refusal = message
 
 
+## `SetSeenMon`, `CheckCaughtMon` and `CheckReceivedDex`, off the world's live
+## state rather than off the save's own snapshot: that snapshot is only as fresh
+## as the last write to disk, so a species seen or caught since then reads as
+## new. Called by the host that owns the world, before the entrance runs and
+## therefore before anything registers this sight.
+func set_dex_context(seen: bool, caught: bool, received: bool) -> void:
+	_enemy_seen_before = seen
+	_enemy_caught_before = caught
+	_dex_received = received
+
+
 ## Supplies the wild battle with the supported balls currently owned by the
 ## overworld. The battle scene never reads or mutates world inventory itself.
 func set_capture_balls(balls: Array, quantities: Dictionary = {}) -> void:
@@ -2756,6 +2819,12 @@ func capture_target() -> Gen2BattleMon:
 	return _battle.enemy if _is_wild_battle() and _battle != null else null
 
 
+## The battler the ball is thrown past, which LEVEL_BALL reads a level off and
+## LOVE_BALL a species and a gender (`wBattleMonLevel`, `wTempBattleMonSpecies`).
+func capture_thrower() -> Gen2BattleMon:
+	return _battle.player if _is_wild_battle() and _battle != null else null
+
+
 ## `wBattleType`, which `PokeBallEffect` reads once the catch has landed: a
 ## BATTLETYPE_CELEBI catch is the one that raises BATTLERESULT_CAUGHT_CELEBI.
 func capture_battle_type() -> int:
@@ -2765,19 +2834,11 @@ func capture_battle_type() -> int:
 ## Opens the small wild-battle ball selector. The full bag UI remains a later
 ## world-service host; this boundary exposes only the capture action.
 func begin_capture() -> Dictionary:
-	if not _is_wild_battle() or _battle == null or _battle.is_over():
-		return _capture_failure(&"capture_not_available")
-	## A Nuzlocke area that has already given up its encounter, said the way the
-	## empty-bag line below is said: the ball is in the bag, the rules are what
-	## refuse it.
-	if not _capture_refusal.is_empty():
-		show_message(_capture_refusal)
-		return _capture_failure(&"capture_refused_by_rules")
-	if _capture_selecting or _capture_waiting or not _capture_messages.is_empty() \
-		or not _capture_result.is_empty():
+	var refused: Dictionary = _capture_guard()
+	if not refused.is_empty():
+		return refused
+	if _capture_selecting:
 		return _capture_failure(&"capture_input_busy")
-	if not _pending.is_empty():
-		return _capture_failure(&"battle_events_pending")
 	if _capture_balls.is_empty():
 		show_message("You have no POKE BALLS!")
 		return _capture_failure(&"no_capture_balls")
@@ -2785,6 +2846,26 @@ func begin_capture() -> Dictionary:
 	_capture_ball_index = 0
 	_show_capture_selection()
 	return {"ok": true, "ball": _selected_capture_ball()}
+
+
+## Every refusal a throw is reached through, shared by the pack's own BALL row
+## and by the small selector a fight with no bag behind it is handed. Empty means
+## the ball may be thrown.
+func _capture_guard() -> Dictionary:
+	if not _is_wild_battle() or _battle == null or _battle.is_over():
+		return _capture_failure(&"capture_not_available")
+	## A Nuzlocke area that has already given up its encounter, said the way the
+	## empty-bag line above is said: the ball is in the bag, the rules are what
+	## refuse it.
+	if not _capture_refusal.is_empty():
+		show_message(_capture_refusal)
+		return _capture_failure(&"capture_refused_by_rules")
+	if _capture_waiting or not _capture_messages.is_empty() \
+		or not _capture_result.is_empty():
+		return _capture_failure(&"capture_input_busy")
+	if not _pending.is_empty():
+		return _capture_failure(&"battle_events_pending")
+	return {}
 
 
 func select_capture_ball(index: int) -> Dictionary:
@@ -2798,9 +2879,21 @@ func select_capture_ball(index: int) -> Dictionary:
 func throw_capture_ball() -> Dictionary:
 	if not _capture_selecting or _capture_balls.is_empty():
 		return _capture_failure(&"capture_selection_not_active")
-	var ball: int = _selected_capture_ball()
 	_capture_selecting = false
+	return _throw_ball(_selected_capture_ball(), &"capture")
+
+
+## `PokeBallEffect` from the item onwards, which the pack's own BALL row and the
+## selector both arrive at: `ItemUsedText`, and then the world resolves the
+## throw. The turn is banked here because `_DoItemEffect` has already written
+## BATTLEPLAYERACTION_USEITEM into the byte it shares with
+## `wItemEffectSucceeded`; a refusal takes it back.
+func _throw_ball(ball: int, origin: StringName = &"capture") -> Dictionary:
+	if ball <= 0:
+		return _capture_failure(&"capture_selection_not_active")
+	_capture_origin = origin
 	_capture_waiting = true
+	_capture_spent_turn = Gen2Battle.use_item(ball)
 	show_message(_item_used_text(ball))
 	capture_requested.emit(ball)
 	return {"ok": true, "status": &"waiting", "ball": ball}
@@ -2816,7 +2909,22 @@ func complete_capture(result: Dictionary) -> Dictionary:
 	_capture_result = result.duplicate(true)
 	_capture_terminal = false
 	if not bool(result.get("ok", false)):
-		_capture_messages.append("The capture could not be completed.")
+		## `Ball_BoxIsFullMessage` writes `$2` into the byte that is also
+		## `wBattlePlayerAction`, so `.didnt_use_item` zeroes it and the pack is
+		## reopened with the ball still in the bag and the turn still the
+		## player's. Every other refusal this host can answer with is the same
+		## shape, which is why the box takes them all back.
+		_capture_result.clear()
+		_capture_spent_turn = {}
+		show_message(
+			BALL_BOX_FULL_TEXT if StringName(result.get("reason", &"")) == &"storage_full"
+			else "The capture could not be completed."
+		)
+		if _capture_origin == &"pack" and not _pack_rows.is_empty():
+			_pack_selecting = true
+		elif not _capture_balls.is_empty():
+			_capture_selecting = true
+		_reopen_menu_layer()
 		return result
 	var result_ball: int = int(result.get("ball", 0))
 	if result_ball > 0 and result.has("quantity"):
@@ -2879,6 +2987,14 @@ func _begin_capture_animation(ball: int, wobbles: int, caught: bool) -> void:
 		"enemy_turn": false,
 		"wobbles": answers,
 	})
+
+
+## `ItemSubmenu` over the list [param over] names, opened on USE the way
+## `.UsableMenuHeader`'s `db 1 ; default option` does.
+func _open_pack_action(over: StringName) -> void:
+	_pack_action_stage = over
+	_pack_action_index = 0
+	_reopen_menu_layer()
 
 
 func _show_capture_selection() -> void:
@@ -3032,6 +3148,38 @@ func _open_capture_nickname() -> bool:
 	return true
 
 
+## `NewDexDataText`, then the page. True while either is still owed, so the pump
+## that called this waits. The world owns the dex and draws the page; this only
+## says when.
+func _open_new_dex_entry() -> bool:
+	if _capture_dex_stage == &"done" or _world_battle_tutorial \
+		or bool(_capture_result.get("contest", false)) \
+		or not bool(_capture_result.get("caught", false)) \
+		or _enemy_caught_before or not _dex_received:
+		return false
+	match _capture_dex_stage:
+		&"":
+			_capture_dex_stage = &"text"
+			show_message(NEW_DEX_DATA_TEXT % _name_of(_enemy))
+			return true
+		&"text":
+			## `call ClearSprites` between the line and the page, which is the
+			## same call the catch's own box is followed by.
+			_clear_kept_sprites()
+			_capture_dex_stage = &"page"
+			dex_entry_requested.emit(_enemy)
+			return true
+	return true
+
+
+## The page closing, which is `ExitAllMenus` behind `NewPokedexEntry`.
+func complete_dex_entry() -> void:
+	if _capture_dex_stage != &"page":
+		return
+	_capture_dex_stage = &"done"
+	_continue_after_messages()
+
+
 func _on_capture_named(nickname: String) -> void:
 	_capture_nickname = nickname
 
@@ -3069,6 +3217,9 @@ func _spend_capture_experience() -> bool:
 
 func _clear_capture_action() -> void:
 	_capture_experience_spent = false
+	_pack_action_stage = &""
+	_capture_dex_stage = &""
+	_capture_spent_turn = {}
 	_capture_selecting = false
 	_capture_waiting = false
 	_capture_messages.clear()
@@ -3082,6 +3233,7 @@ func _clear_capture_action() -> void:
 
 
 func _reset_capture_state() -> void:
+	_capture_spent_turn = {}
 	_capture_balls.clear()
 	_capture_quantities.clear()
 	_capture_ball_index = 0
@@ -3473,7 +3625,7 @@ func _continue_after_messages() -> void:
 	## sub-lists, and the forget offer are each answered by a press rather than
 	## run past by the pump.
 	if _menu_stage != &"" or _pack_selecting or _pack_move_selecting \
-		or _forget_stage != &"":
+		or _pack_action_stage != &"" or _forget_stage != &"":
 		return
 	if _world_battle_tutorial:
 		return
@@ -3500,6 +3652,13 @@ func _continue_after_messages() -> void:
 				show_message(CONTEST_ALREADY_CAUGHT_TEXT % _contest_stock_name())
 				return
 			_open_yes_no(&"contest_replace", CONTEST_REPLACE_TEXT)
+			return
+		## `NewDexDataText` and `NewPokedexEntry`, which stand between
+		## `Text_GotchaMonWasCaught` and everything else a catch does. Only for a
+		## species the dex had not caught yet, and only once the player has the
+		## dex at all: `CheckCaughtMon` and `CheckReceivedDex` are both read
+		## before the throw, because the throw is what registers the catch.
+		if _open_new_dex_entry():
 			return
 		## A registered policy's award and every level up, move offer and
 		## evolution flag behind it, spent between `Text_GotchaMonWasCaught` and
@@ -3528,8 +3687,27 @@ func _continue_after_messages() -> void:
 		_finish_world_capture(capture)
 		return
 	if not _capture_result.is_empty():
+		## `.UseItem` returns with no carry on a ball that did not land, so
+		## `BattleMenu` falls back into `DoBattle` and the enemy takes the turn
+		## the throw was paid with. Only a catch escapes it, through `.run`.
+		var spent: Dictionary = _capture_spent_turn
+		_capture_spent_turn = {}
 		_clear_capture_action()
+		if not spent.is_empty() and _battle != null and not _battle.is_over():
+			_pending = _battle.take_actions(spent, _enemy_action())
+			if not _pending.is_empty():
+				_show_next_event()
+				return
 		return
+	if not _capture_spent_turn.is_empty():
+		## The blocked throw in a trainer battle, whose two boxes are behind it.
+		var blocked: Dictionary = _capture_spent_turn
+		_capture_spent_turn = {}
+		if _battle != null and not _battle.is_over():
+			_pending = _battle.take_actions(blocked, _enemy_action())
+			if not _pending.is_empty():
+				_show_next_event()
+				return
 	if not _pending.is_empty():
 		_show_next_event()
 		return
@@ -3978,6 +4156,14 @@ func _answer_switch_offer() -> bool:
 ## cursor on YES are `YesNoMenuHeader`'s. `InterpretTwoOptionMenu`'s fifteen
 ## frames between the answer and the box coming down are not spent, the way no
 ## other menu delay here is.
+## `ItemSubmenu.UsableMenuHeader`'s own `menu_coords 13, 7, SCREEN_WIDTH - 1,
+## TEXTBOX_Y - 1` and its two rows. Every item a battle lists is usable, so
+## `.UnusableMenuData`'s single QUIT row is unreachable here.
+const PACK_ACTION_LEFT: int = 13
+const PACK_ACTION_TOP: int = 7
+const PACK_ACTION_SPAN: Vector2i = Vector2i(6, 4)
+const PACK_ACTIONS: Array[String] = ["USE", "QUIT"]
+
 const YES_NO_LEFT: int = 1
 const YES_NO_TOP: int = 7
 const YES_NO_SPAN: Vector2i = Vector2i(5, 4)
@@ -4324,7 +4510,7 @@ func _reopen_menu_layer() -> void:
 func _refresh_menu_layer() -> void:
 	if _menu_layer == null:
 		return
-	var signature: String = "%s|%s|%d|%d|%d|%s|%s" % [
+	var signature: String = "%s|%s|%d|%d|%d|%s|%s|%s" % [
 		_switch_stage, _menu_stage,
 		_switch_offer.selected_index() if _switch_offer != null else (
 			_switch_menu.cursor if _switch_menu != null else -1
@@ -4340,6 +4526,7 @@ func _refresh_menu_layer() -> void:
 			_capture_ball_index if _capture_selecting else -1,
 			_pack_rows.size(),
 		],
+		"%s%d" % [_pack_action_stage, _pack_action_index],
 		## The icons move on their own clock, so the cursor alone does not say
 		## whether the page still draws what the layer is holding.
 		_party_page.animation_signature() if _party_page != null else "",
@@ -4369,6 +4556,15 @@ func _refresh_menu_layer() -> void:
 	## while it stands, so at most one of them is up at a time.
 	if _forget_stage != &"":
 		_draw_forget_stage()
+		return
+	if _pack_action_stage != &"":
+		## `MENU_BACKUP_TILES`: the submenu's box is drawn over the list the row
+		## was chosen from, which stays where it was.
+		if _pack_action_stage == &"capture":
+			_draw_capture_menu()
+		else:
+			_draw_pack_menu()
+		_draw_pack_action_menu()
 		return
 	if _pack_move_selecting:
 		_draw_pack_move_menu()
@@ -4599,6 +4795,27 @@ func _draw_capture_menu() -> void:
 	for ball: int in _capture_balls:
 		labels.append(_list_row(_item_name(ball), "×%d" % _capture_quantity(ball)))
 	_draw_list_menu(&"capture", labels, _capture_ball_index)
+
+
+## `ItemSubmenu`'s USE/QUIT box, which stands over the list the row was chosen
+## from and is what the second A press answers.
+##
+## On [member _info_layer] rather than on the menu layer, which is under the
+## list: `LoadMenuHeader` draws this box into the tilemap after the pack's own,
+## so it covers the rows it was opened from.
+func _draw_pack_action_menu() -> void:
+	if _menu_page == null:
+		return
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		PACK_ACTION_LEFT, PACK_ACTION_TOP,
+		PACK_ACTION_LEFT + PACK_ACTION_SPAN.x, PACK_ACTION_TOP + PACK_ACTION_SPAN.y,
+		YES_NO_FLAGS
+	)
+	_show_layer_image(
+		_info_layer,
+		_menu_page.render(box, PACK_ACTIONS, _pack_action_index),
+		box.border_position() * Gen2Font.TILE
+	)
 
 
 ## `RestorePPEffect`'s question, as the pack's own move list: which slot the
@@ -5457,6 +5674,33 @@ func _handle_button(button: int) -> bool:
 				return false
 		return true
 
+	if _pack_action_stage != &"":
+		match button:
+			Gen2Button.RIGHT, Gen2Button.DOWN:
+				_pack_action_index = posmod(_pack_action_index + 1, PACK_ACTIONS.size())
+				_reopen_menu_layer()
+			Gen2Button.LEFT, Gen2Button.UP:
+				_pack_action_index = posmod(_pack_action_index - 1, PACK_ACTIONS.size())
+				_reopen_menu_layer()
+			Gen2Button.A:
+				var over: StringName = _pack_action_stage
+				_pack_action_stage = &""
+				if _pack_action_index == 0:
+					if over == &"capture":
+						throw_capture_ball()
+					else:
+						use_selected_pack_item()
+				else:
+					_reopen_menu_layer()
+			Gen2Button.B:
+				## `.Quit` is a bare `ret`, so the list the row was chosen from
+				## is still standing under the box that just closed.
+				_pack_action_stage = &""
+				_reopen_menu_layer()
+			_:
+				return false
+		return true
+
 	if _pack_selecting:
 		match button:
 			Gen2Button.RIGHT, Gen2Button.DOWN:
@@ -5464,7 +5708,7 @@ func _handle_button(button: int) -> bool:
 			Gen2Button.LEFT, Gen2Button.UP:
 				select_pack_row(_pack_index - 1)
 			Gen2Button.A:
-				use_selected_pack_item()
+				_open_pack_action(&"pack")
 			Gen2Button.B:
 				close_battle_pack()
 			_:
@@ -5478,7 +5722,7 @@ func _handle_button(button: int) -> bool:
 			Gen2Button.LEFT, Gen2Button.UP:
 				select_capture_ball(_capture_ball_index - 1)
 			Gen2Button.A:
-				throw_capture_ball()
+				_open_pack_action(&"capture")
 			Gen2Button.B:
 				_clear_capture_action()
 				show_message("Choose an action.")
@@ -5901,5 +6145,15 @@ func _name_of(species: int) -> String:
 	return String(_data.species(species).get("name", ""))
 
 
+## `.PrintBattleStartText`'s four lines, chosen by `wBattleType` in its order.
+## BATTLETYPE_CELEBI takes `WildCelebiAppearedText`, which is
+## `WildPokemonAppearedText` written a second time.
 func _announce() -> void:
-	show_message("Wild %s\nappeared!" % _name_of(_enemy))
+	var wild: String = _name_of(_enemy)
+	match _battle.battle_type if _battle != null else Gen2Battle.BATTLETYPE_NORMAL:
+		Gen2Battle.BATTLETYPE_FISH:
+			show_message("The hooked\n%s\nattacked!" % wild)
+		Gen2Battle.BATTLETYPE_TREE:
+			show_message("%s fell\nout of the tree!" % wild)
+		_:
+			show_message("Wild %s\nappeared!" % wild)

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -315,47 +315,60 @@ static func _empty_boxes() -> Array:
 	return empty_boxes
 
 
-func first_empty_box_slot() -> Dictionary:
-	for box_index: int in boxes.size():
-		var box: Gen2SaveBox = boxes[box_index]
-		if box == null:
-			continue
-		var empty_slot: int = box.first_empty_slot()
-		if empty_slot >= 0:
-			return {"ok": true, "box": box_index, "slot": empty_slot}
-	return {"ok": false, "reason": &"storage_full"}
+## Where a deposit lands, which on the cartridge is only ever the open box:
+## `SendMonIntoBox` and `InsertPokemonIntoBox` both write `sBoxCount` and neither
+## looks at another box. A full open box is refused with the other thirteen still
+## empty, which is what `Ball_BoxIsFullMessage` and `.FailedToGiveMon` say.
+func deposit_box_slot() -> Dictionary:
+	var box_index: int = clampi(current_box, 0, BOX_COUNT - 1)
+	var box: Gen2SaveBox = boxes[box_index] if box_index < boxes.size() else null
+	if box == null:
+		return {"ok": false, "reason": &"storage_full"}
+	var empty_slot: int = box.first_empty_slot()
+	if empty_slot < 0:
+		return {"ok": false, "reason": &"storage_full"}
+	return {"ok": true, "box": box_index, "slot": empty_slot}
 
 
-## `_GetVarAction`'s `.BoxFreeSpace`, which is `MONS_PER_BOX - [sBoxCount]`. The
-## save model keeps no current-box pointer, so the box a deposit would land in is
-## the one [method first_empty_box_slot] picks; a full storage answers 0, which is
-## the same refusal the source's zero gives every script that reads the var.
+## `_GetVarAction`'s `.BoxFreeSpace`, which is `MONS_PER_BOX - [sBoxCount]` on
+## the open box alone. A full one answers 0, which is the same refusal the
+## source's zero gives every script that reads the var.
 func box_free_space() -> int:
-	var destination: Dictionary = first_empty_box_slot()
-	if not bool(destination.get("ok", false)):
+	var box_index: int = clampi(current_box, 0, BOX_COUNT - 1)
+	var box: Gen2SaveBox = boxes[box_index] if box_index < boxes.size() else null
+	if box == null:
 		return 0
-	var box: Gen2SaveBox = boxes[int(destination["box"])]
 	return Gen2SaveBox.CAPACITY - box.occupied_count()
 
 
-func add_party_or_box(mon: Gen2SaveMon) -> Dictionary:
+## `TryAddMonToParty` and then the box behind it. [param to_front] is
+## `SendMonIntoBox`'s own `ShiftBoxMon`, which puts a catch at the head of the
+## box and moves everything already there down one; every other deposit runs
+## `InsertPokemonIntoBox`, which appends.
+func add_party_or_box(mon: Gen2SaveMon, to_front: bool = false) -> Dictionary:
 	if mon == null:
 		return {"ok": false, "reason": &"missing_pokemon"}
 	if party.size() < MAX_PARTY:
 		party.append(mon)
 		return {"ok": true, "destination": &"party", "party_index": party.size() - 1}
-	var destination: Dictionary = first_empty_box_slot()
+	var destination: Dictionary = deposit_box_slot()
 	if not bool(destination.get("ok", false)):
 		return destination
 	var box: Gen2SaveBox = boxes[int(destination["box"])]
-	var placed: Dictionary = box.put(mon, int(destination["slot"]))
+	var target: int = int(destination["slot"])
+	if to_front:
+		for index: int in range(target, 0, -1):
+			box.slots[index] = box.slots[index - 1]
+		target = 0
+		box.slots[0] = null
+	var placed: Dictionary = box.put(mon, target)
 	if not bool(placed.get("ok", false)):
 		return {"ok": false, "reason": placed.get("reason", &"box_insert_failed")}
 	return {
 		"ok": true,
 		"destination": &"box",
 		"box": int(destination["box"]),
-		"slot": int(destination["slot"]),
+		"slot": target,
 	}
 
 

--- a/game/save/save_storage.gd
+++ b/game/save/save_storage.gd
@@ -223,7 +223,7 @@ static func _box_destination(
 	save: Gen2SaveData, box_index: int, box_slot: int
 ) -> Dictionary:
 	if box_index < 0:
-		return save.first_empty_box_slot()
+		return save.deposit_box_slot()
 	if box_index >= save.boxes.size():
 		return _failure(&"invalid_box_index")
 	var box: Gen2SaveBox = save.boxes[box_index]

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -190,7 +190,12 @@ static func resolve_fishing(
 		"slot_roll": slot_roll,
 		"time_group": time_group,
 		"forced": force_encounter,
-		"values": {"kind": &"wild", "pokemon": species, "level": level},
+		## `.goodtofish`'s own `ld a, BATTLETYPE_FISH`, which names the
+		## battle-start line and is what `LureBallMultiplier` boosts on.
+		"values": {
+			"kind": &"wild", "pokemon": species, "level": level,
+			"battle_type": Gen2Battle.BATTLETYPE_FISH,
+		},
 	}
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -13,6 +13,9 @@ extends RefCounted
 const CAUGHT_EGG_LEVEL: int = 1
 ## `HatchEggs`' own `ld [hl], $78`, the happiness a hatchling starts on.
 const HATCHED_HAPPINESS: int = 0x78
+## `BASE_HAPPINESS`, which `GeneratePartyMonStats` writes into every row it
+## builds (`constants/pokemon_data_constants.asm`).
+const BASE_HAPPINESS: int = 70
 ## `LANDMARK_GIFT`, the landmark `SetGiftMonCaughtData` writes instead of a map.
 const LANDMARK_GIFT: int = 0x7E
 ## `LANDMARK_NATIONAL_PARK`, which `CheckPartyFullAfterContest` writes over
@@ -45,6 +48,19 @@ const ITEM_MASTER_BALL: int = 0x01
 const ITEM_ULTRA_BALL: int = 0x02
 const ITEM_GREAT_BALL: int = 0x04
 const ITEM_POKE_BALL: int = 0x05
+## The seven balls Kurt makes out of apricorns (`data/items/apricorn_balls.asm`),
+## each with its own row in `BallMultiplierFunctionTable`. FRIEND_BALL has no
+## row: its effect is the happiness it writes after the catch has landed.
+const ITEM_HEAVY_BALL: int = 0x9D
+const ITEM_LEVEL_BALL: int = 0x9F
+const ITEM_LURE_BALL: int = 0xA0
+const ITEM_FAST_BALL: int = 0xA1
+const ITEM_FRIEND_BALL: int = 0xA4
+const ITEM_MOON_BALL: int = 0xA5
+const ITEM_LOVE_BALL: int = 0xA6
+## `FRIEND_BALL_HAPPINESS` (`constants/pokemon_data_constants.asm`), written over
+## `BASE_HAPPINESS` on both the party and the box branch of `PokeBallEffect`.
+const FRIEND_BALL_HAPPINESS: int = 200
 ## The Bug Contest's own ball. It is never in the bag: `wParkBallsRemaining` is
 ## what holds it and `BattleMenu_Pack`'s contest branch loads it by name.
 const ITEM_PARK_BALL: int = 0xB1
@@ -157,9 +173,48 @@ const MAGIKARP_LENGTHS: Array = [
 	[65210, 5], [65410, 2], [65510, 1],
 ]
 
+## Every ball `PokeBallEffect` can be reached with, in ball-pocket order.
+## SAFARI_BALL is left out on purpose: it is `$08`, the same number as
+## MOON_STONE, so its `BallMultiplierFunctionTable` row is unreachable with any
+## item whose effect is `PokeBallEffect`.
 const CAPTURE_BALLS: Array[int] = [
 	ITEM_POKE_BALL, ITEM_GREAT_BALL, ITEM_ULTRA_BALL, ITEM_MASTER_BALL,
+	ITEM_HEAVY_BALL, ITEM_LEVEL_BALL, ITEM_LURE_BALL, ITEM_FAST_BALL,
+	ITEM_FRIEND_BALL, ITEM_MOON_BALL, ITEM_LOVE_BALL,
 ]
+
+## `HeavyBallMultiplier.WeightsTable`: the high byte of the converted weight the
+## row applies below, and what it adds to the catch rate there. The `.lightmon`
+## branch in front of it takes 20 off below `HIGH(1024)`.
+const HEAVY_BALL_WEIGHTS: Array = [
+	[0x08, 0], [0x0C, 20], [0x10, 30], [0xFF, 40],
+]
+const HEAVY_BALL_LIGHT_HIGH: int = 0x04
+const HEAVY_BALL_LIGHT_PENALTY: int = 20
+
+## `docs/bugs_and_glitches.md`'s "Heavy Ball uses wrong weight value for three
+## Pokemon": `HeavyBall_GetDexEntryBank` masks the species without taking one off
+## first, so 64, 128 and 192 read their own entry's address out of the next
+## bank up. What is there is a different cartridge's business on each build, so
+## these are measured rather than derived: `.claude/oracle/battle/catch_rate.py`
+## on all three dumps says Gold and Silver land on the same row the right weight
+## would, and Crystal does not. KADABRA and TAUROS are what it answered there;
+## SUNFLORA is the third and has no answer, because the `.SkipText` walk never
+## finds its terminator and the cartridge locks up (see `HANDOFF.md`).
+const HEAVY_BALL_WRONG_BANK: Dictionary = {64: 20, 128: 40}
+
+## `FleeMons`' first three bytes, which is as far as `FastBallMultiplier`'s
+## `ld d, 3` reads: MAGNEMITE, GRIMER and TANGELA are the whole list the boost
+## can match (`docs/bugs_and_glitches.md`, "Fast Ball only boosts catch rate for
+## three Pokemon").
+const FAST_BALL_SPECIES: Array[int] = [0x51, 0x58, 0x72]
+
+## `MOON_STONE_RED`, which is BURN_HEAL's number rather than MOON_STONE's, read
+## three bytes past the evolution method instead of one. Both halves of
+## `docs/bugs_and_glitches.md`'s "Moon Ball does not boost catch rate": the byte
+## reached is the next evolution's method or the list terminator, and no
+## evolution method is 10, so no species is ever boosted.
+const MOON_BALL_STONE: int = 0x0A
 
 const WOBBLE_PROBABILITIES: Array = [
 	[1, 63], [2, 75], [3, 84], [4, 90], [5, 95], [7, 103], [10, 113],
@@ -912,7 +967,7 @@ static func gift_destination(save: Gen2SaveData) -> StringName:
 		return &"full"
 	if save.party.size() < Gen2SaveData.MAX_PARTY:
 		return &"party"
-	return &"box" if bool(save.first_empty_box_slot().get("ok", false)) else &"full"
+	return &"box" if bool(save.deposit_box_slot().get("ok", false)) else &"full"
 
 
 ## `DoEggStep`, spent [param times] over. Each pass walks the party from the
@@ -1102,7 +1157,11 @@ static func contest_return_mons(save: Gen2SaveData) -> int:
 ## Attempts to catch one wild battle mon and consumes the ball on either result.
 ## The battle screen owns the animation; this host owns the cartridge outcome and
 ## the save/world writeback. A caught mon enters the party when there is room and
-## otherwise uses the first free PC-box slot.
+## otherwise goes to the front of the box the player has open, which is the one
+## `SendMonIntoBox` deposits into.
+##
+## [param thrower] is the player's active battler, which LEVEL_BALL and LOVE_BALL
+## read; see [method _ball_multiplier].
 static func capture_wild(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -1111,15 +1170,18 @@ static func capture_wild(
 	random: RandomNumberGenerator = null,
 	caught_location: int = 0,
 	persist: bool = true,
-	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL
+	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL,
+	thrower: Gen2BattleMon = null
 ) -> Dictionary:
 	if world == null or save == null or world.data == null or wild == null:
 		return _failure(&"missing_capture_context", {})
 	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
 	if not bool(opened.get("ok", false)):
 		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	## `Ball_BoxIsFullMessage`, which stands in front of everything else the
+	## effect does: no line is said about the ball and the ball is not spent.
 	if save.party.size() >= Gen2SaveData.MAX_PARTY:
-		var storage: Dictionary = save.first_empty_box_slot()
+		var storage: Dictionary = save.deposit_box_slot()
 		if not bool(storage.get("ok", false)):
 			return _failure(&"storage_full", {"ball": ball})
 	var definition: Dictionary = world.data.item(ball)
@@ -1127,7 +1189,7 @@ static func capture_wild(
 		return _failure(&"unknown_ball", {"ball": ball})
 	if int(definition.get("pocket", 0)) != RomLayout.ITEM_POCKET_BALL:
 		return _failure(&"item_is_not_a_ball", {"ball": ball})
-	if ball not in [ITEM_MASTER_BALL, ITEM_ULTRA_BALL, ITEM_GREAT_BALL, ITEM_POKE_BALL]:
+	if ball not in CAPTURE_BALLS:
 		return _failure(&"unsupported_ball_effect", {"ball": ball})
 	if world.state == null or world.state.item_quantity(ball) <= 0:
 		return _failure(&"insufficient_ball_quantity", {"ball": ball})
@@ -1146,12 +1208,14 @@ static func capture_wild(
 	var generator: RandomNumberGenerator = random if random != null else RandomNumberGenerator.new()
 	if random == null:
 		generator.randomize()
-	var outcome: Dictionary = _capture_outcome(world.data, wild, ball, generator)
+	var outcome: Dictionary = _capture_outcome(
+		world.data, wild, ball, generator, battle_type, thrower
+	)
 	var candidate: Gen2SaveData = opened["candidate"]
 	var destination: Dictionary = {}
 	var box_full: bool = false
 	if bool(outcome.get("caught", false)):
-		var captured: Gen2SaveMon = _captured_mon(world.data, save, wild, generator)
+		var captured: Gen2SaveMon = _captured_mon(world.data, save, wild, ball)
 		if captured == null:
 			return _failure(&"could_not_create_captured_pokemon", outcome)
 		## `SetCaughtData` runs on the caught Pokemon itself.
@@ -1159,7 +1223,9 @@ static func capture_wild(
 			captured, wild.level, world.object_time_of_day, world.player_female(),
 			catch_landmark
 		)
-		destination = candidate.add_party_or_box(captured)
+		## `SendMonIntoBox`'s own `ShiftBoxMon`: a catch that lands in a box goes
+		## to the front of it, which every other deposit does not.
+		destination = candidate.add_party_or_box(captured, true)
 		if not bool(destination.get("ok", false)):
 			return _failure(StringName(destination.get("reason", &"storage_full")), {
 				"ball": ball, "outcome": outcome,
@@ -1249,7 +1315,7 @@ static func _apply_contest_mon(
 			"summary": {"kind": &"contest_mon", "accepted": false},
 		}
 	var boxed: bool = candidate.party.size() >= Gen2SaveData.MAX_PARTY
-	if boxed and not bool(candidate.first_empty_box_slot().get("ok", false)):
+	if boxed and not bool(candidate.deposit_box_slot().get("ok", false)):
 		## `.BoxFull`: nothing is written and the catch is gone, which is the
 		## cartridge's own answer rather than a refusal of this port's.
 		world.state.set_contest_mon({})
@@ -2009,29 +2075,36 @@ static func contest_mon_from(wild: Gen2BattleMon) -> Dictionary:
 	}
 
 
+## `PokeBallEffect`'s roll, from `wEnemyMonCatchRate` down to `wFinalCatchRate`.
+##
+## [param battle_type] is `wBattleType`: BATTLETYPE_TUTORIAL catches without a
+## roll, the way a MASTER_BALL does. [param thrower] is the player's active
+## battler, which LEVEL_BALL reads a level off and LOVE_BALL a species and a
+## gender; a caller with none passes null and both rows answer with no boost.
 static func _capture_outcome(
-	data: GameData, wild: Gen2BattleMon, ball: int, random: RandomNumberGenerator
+	data: GameData,
+	wild: Gen2BattleMon,
+	ball: int,
+	random: RandomNumberGenerator,
+	battle_type: int = Gen2Battle.BATTLETYPE_NORMAL,
+	thrower: Gen2BattleMon = null
 ) -> Dictionary:
-	if ball == ITEM_MASTER_BALL:
+	if ball == ITEM_MASTER_BALL or battle_type == Gen2Battle.BATTLETYPE_TUTORIAL:
 		return {"caught": true, "catch_rate": 255, "wobbles": 3}
-	var species: Dictionary = data.species(wild.species)
-	var catch_rate: int = clampi(int(species.get("catch_rate", 0)), 1, 255)
-	match ball:
-		ITEM_ULTRA_BALL:
-			catch_rate = mini(catch_rate * 2, 255)
-		## `GreatBallMultiplier` and `ParkBallMultiplier` are the same routine
-		## written twice: catch rate times one and a half.
-		ITEM_GREAT_BALL, ITEM_PARK_BALL:
-			catch_rate = mini(catch_rate + int(catch_rate / 2.0), 255)
-		ITEM_POKE_BALL:
-			pass
 	var max_hp: int = maxi(wild.max_hp(), 1)
-	var current_hp: int = clampi(wild.hp, 1, max_hp)
-	var final_rate: int = _source_hp_catch_rate(max_hp, current_hp, catch_rate)
-	# This is the actual Gen 2 behavior: sleep and freeze add 10, while the
-	# intended +5 for burn, poison and paralysis is skipped by the source bug.
-	if Gen2Status.has(wild.status, Gen2Status.FREEZE) or Gen2Status.is_asleep(wild.status):
-		final_rate = mini(final_rate + 10, 255)
+	var final_rate: int = final_catch_rate(data, ball, {
+		"base_rate": clampi(int(data.species(wild.species).get("catch_rate", 0)), 1, 255),
+		"max_hp": max_hp,
+		"current_hp": clampi(wild.hp, 1, max_hp),
+		"status": wild.status,
+		"species": wild.species,
+		"dvs": wild.persistent_dvs(),
+		"level": wild.level,
+		"thrower_species": thrower.species if thrower != null else 0,
+		"thrower_dvs": thrower.persistent_dvs() if thrower != null else 0,
+		"thrower_level": thrower.level if thrower != null else 0,
+		"battle_type": battle_type,
+	})
 	var caught: bool = random.randi_range(0, 255) <= final_rate
 	return {
 		"caught": caught,
@@ -2040,19 +2113,182 @@ static func _capture_outcome(
 	}
 
 
+## `wFinalCatchRate`: everything `PokeBallEffect` settles between
+## `ld a, [wEnemyMonCatchRate]` and the `call Random` that reads the answer.
+##
+## Split out from the throw because the cartridge can be asked the same question
+## directly: `.claude/oracle/battle/catch_rate.py` runs those instructions on a
+## real dump for a grid of cases, and [param case] is that grid's own row. The
+## keys are the bytes the routine reads, named for the WRAM labels it reads them
+## from.
+static func final_catch_rate(data: GameData, ball: int, case: Dictionary) -> int:
+	var catch_rate: int = _ball_multiplier(data, ball, int(case["base_rate"]), case)
+	## `.skip_or_return_from_ball_fn`'s own `cp LEVEL_BALL`: a Level Ball jumps
+	## straight to `.skip_hp_calc`, so its final rate is the multiplied catch
+	## rate with no health, status or held-item term at all.
+	if ball == ITEM_LEVEL_BALL:
+		return catch_rate
+	var final_rate: int = _source_hp_catch_rate(
+		int(case["max_hp"]), int(case["current_hp"]), catch_rate
+	)
+	# This is the actual Gen 2 behavior: sleep and freeze add 10, while the
+	# intended +5 for burn, poison and paralysis is skipped by the source bug.
+	var status: int = int(case.get("status", 0))
+	if Gen2Status.has(status, Gen2Status.FREEZE) or Gen2Status.is_asleep(status):
+		final_rate = mini(final_rate + 10, 255)
+	## HELD_CATCH_CHANCE would be added here. No item in either pin carries that
+	## held effect, so the branch has nothing to reach it with.
+	return final_rate
+
+
+## `BallMultiplierFunctionTable`, every row of it. Each bug the table carries is
+## reproduced rather than corrected, and each names the entry in
+## `docs/bugs_and_glitches.md` that describes it.
+static func _ball_multiplier(
+	data: GameData, ball: int, catch_rate: int, case: Dictionary
+) -> int:
+	match ball:
+		ITEM_ULTRA_BALL:
+			return _ball_shift(catch_rate, 1)
+		## `GreatBallMultiplier` and `ParkBallMultiplier` are the same routine
+		## written twice: catch rate times one and a half.
+		ITEM_GREAT_BALL, ITEM_PARK_BALL:
+			return mini(catch_rate + (catch_rate >> 1), 255)
+		ITEM_HEAVY_BALL:
+			return _heavy_ball(data, int(case["species"]), catch_rate)
+		ITEM_LEVEL_BALL:
+			return _level_ball(
+				int(case["level"]), int(case.get("thrower_level", 0)), catch_rate
+			)
+		## `LureBallMultiplier`: three times the rate, and only on a rod battle.
+		ITEM_LURE_BALL:
+			if int(case.get("battle_type", 0)) != Gen2Battle.BATTLETYPE_FISH:
+				return catch_rate
+			return mini(catch_rate * 3, 255)
+		ITEM_FAST_BALL:
+			return _ball_shift(catch_rate, 2) \
+				if int(case["species"]) in FAST_BALL_SPECIES else catch_rate
+		ITEM_MOON_BALL:
+			return _moon_ball(data, int(case["species"]), catch_rate)
+		ITEM_LOVE_BALL:
+			return _love_ball(data, catch_rate, case)
+	return catch_rate
+
+
+## The `sla b / jr c, .max` chain every boosting row is written as: one shift per
+## doubling, and a carry out of the byte pins the rate at 255 rather than
+## wrapping it.
+static func _ball_shift(catch_rate: int, doublings: int) -> int:
+	var out: int = catch_rate
+	for _step: int in doublings:
+		out <<= 1
+		if out > 0xFF:
+			return 0xFF
+	return out
+
+
+## `HeavyBallMultiplier`. The dex entry's weight is converted with the routine's
+## own three shifts and two subtractions, and only the high byte of the result
+## decides which row of `.WeightsTable` applies.
+static func _heavy_ball(data: GameData, species: int, catch_rate: int) -> int:
+	if HEAVY_BALL_WRONG_BANK.has(species) and Gen2WorldState.is_crystal_profile(data):
+		return mini(catch_rate + int(HEAVY_BALL_WRONG_BANK[species]), 255)
+	var weight: int = int(data.dex_entry(species).get("weight", 0)) & 0xFFFF
+	var halved: int = weight >> 1
+	var part: int = halved >> 4
+	var converted: int = (halved - part) & 0xFFFF
+	part >>= 1
+	converted = (converted - part) & 0xFFFF
+	var high: int = converted >> 8
+	if high < HEAVY_BALL_LIGHT_HIGH:
+		## `.lightmon`'s `sub 20 / ret nc / ld b, $1`: a borrow floors at one
+		## rather than at zero.
+		var lowered: int = catch_rate - HEAVY_BALL_LIGHT_PENALTY
+		return lowered if lowered >= 0 else 1
+	for row: Array in HEAVY_BALL_WEIGHTS:
+		if high < int(row[0]):
+			return mini(catch_rate + int(row[1]), 255)
+	return catch_rate
+
+
+## `LevelBallMultiplier`: double for each halving of the player's level the wild
+## still sits under, up to eight times.
+static func _level_ball(wild_level: int, thrower_level: int, catch_rate: int) -> int:
+	var threshold: int = thrower_level
+	var doublings: int = 0
+	while doublings < 3 and wild_level < threshold:
+		doublings += 1
+		threshold >>= 1
+	return _ball_shift(catch_rate, doublings)
+
+
+## `MoonBallMultiplier`, bug included: the item byte is read three bytes past the
+## evolution method instead of one, so what it compares against BURN_HEAL is the
+## next evolution's method or the terminator. Nothing is ever boosted.
+static func _moon_ball(data: GameData, species: int, catch_rate: int) -> int:
+	var rows: Array = data.evolutions(species)
+	if rows.is_empty() or int((rows[0] as Dictionary).get("method", 0)) != RomLayout.EVOLVE_ITEM:
+		return catch_rate
+	var next_method: int = int((rows[1] as Dictionary).get("method", 0)) if rows.size() > 1 else 0
+	if next_method != MOON_BALL_STONE:
+		return catch_rate
+	return _ball_shift(catch_rate, 2)
+
+
+## `LoveBallMultiplier`, bug included: the comparison that should refuse a
+## matching gender is the one that refuses a differing one, so the eightfold
+## boost lands on a wild of the SAME gender as the battler facing it. Either
+## side being genderless answers with no boost at all.
+static func _love_ball(data: GameData, catch_rate: int, case: Dictionary) -> int:
+	var species: int = int(case["species"])
+	if int(case.get("thrower_species", 0)) != species:
+		return catch_rate
+	var player_gender: StringName = Gen2BattleMon.gender_for(
+		data, species, int(case.get("thrower_dvs", 0))
+	)
+	if player_gender == Gen2BattleMon.GENDER_NONE:
+		return catch_rate
+	var wild_gender: StringName = Gen2BattleMon.gender_for(
+		data, species, int(case.get("dvs", 0))
+	)
+	if wild_gender == Gen2BattleMon.GENDER_NONE:
+		return catch_rate
+	return _ball_shift(catch_rate, 3) if wild_gender == player_gender else catch_rate
+
+
+## The health term, as the cartridge's own bytes rather than as arithmetic that
+## happens to agree with them.
+##
+## Both operands are shifted right twice only when `3 * max HP` does not fit in
+## one byte, and everything after that is a byte: `ld b, e` keeps the low byte of
+## the divisor, `sub c` wraps, and `hQuotient + 3` is the low byte of the
+## quotient. Above 341 max HP the shifted divisor no longer fits either, which is
+## `docs/bugs_and_glitches.md`'s "Catch rate formula breaks for Pokemon with max
+## HP > 341", and all three truncations are what make it break.
 static func _source_hp_catch_rate(max_hp: int, current_hp: int, catch_rate: int) -> int:
-	# The cartridge shifts both operands by two only when 3 * max HP does not
-	# fit in one byte. It then keeps the low byte, including the documented
-	# high-HP overflow behavior, instead of using a wider modern formula.
 	var three_max: int = 3 * max_hp
 	var two_current: int = 2 * current_hp
 	if (three_max >> 8) != 0:
 		three_max >>= 2
 		two_current >>= 2
-	var divisor: int = maxi(three_max & 0xFF, 1)
-	var current_part: int = maxi(two_current & 0xFF, 1)
-	var remaining: int = maxi((three_max & 0xFF) - current_part, 0)
-	return clampi(maxi(1, int(remaining * catch_rate / float(divisor))), 1, 255)
+		## `.okay_1`'s own `ld c, $1`, which the unshifted branch never reaches.
+		if (two_current & 0xFF) == 0:
+			two_current = 1
+	var divisor: int = three_max & 0xFF
+	var current_part: int = two_current & 0xFF
+	if divisor == 0:
+		## 342 and 683 max HP are the two values whose shifted divisor is a whole
+		## multiple of 256, and `_Divide`'s `.loop` never leaves on a zero
+		## divisor: the cartridge locks up here rather than answering. Measured,
+		## not read: `.claude/oracle/battle/catch_rate.py` never returns on
+		## either. Guarded with both operands untruncated, which is the ratio the
+		## routine was reaching for; there is no cartridge answer to match.
+		divisor = three_max
+		current_part = two_current
+	var remaining: int = (divisor - current_part) & 0xFF if divisor <= 0xFF \
+		else maxi(divisor - current_part, 0)
+	var quotient: int = int(remaining * catch_rate / divisor) & 0xFF
+	return quotient if quotient > 0 else 1
 
 
 ## How many times the ball rocks before it opens, which is
@@ -2073,21 +2309,40 @@ static func _failed_wobbles(catch_rate: int, random: RandomNumberGenerator) -> i
 	return 3
 
 
+## `GeneratePartyMonStats`' wild branch, which is what `TryAddMonToParty` and
+## `SendMonIntoBox` both build the caught row out of.
+##
+## Four of these read wrong from the outside and are the source's own. The
+## Pokemon keeps the health and the status condition it was standing there with,
+## because `PokeBallEffect` pushes `wEnemyMonStatus` and `wEnemyMonHP` in front
+## of `LoadEnemyMon` and writes them back after it. Its PP is full, because
+## `LoadEnemyMon`'s `FillPP` ran over whatever the fight had drained. Its stat
+## experience is zero and its experience is the minimum for its level, whatever
+## the battler had. The trainer ID is `wPlayerID`: a Pokemon caught by the player
+## is not a traded one.
 static func _captured_mon(
 	data: GameData,
 	save: Gen2SaveData,
 	wild: Gen2BattleMon,
-	random: RandomNumberGenerator
+	ball: int
 ) -> Gen2SaveMon:
 	var out: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(wild)
 	if out == null:
 		return null
-	out.hp = wild.max_hp()
-	out.status = Gen2Status.NONE
 	out.nickname = String(data.species(wild.species).get("name", ""))
 	out.original_trainer = save.player_name
-	out.ot_id = random.randi_range(0, 0xFFFF)
-	out.happiness = 70
+	out.ot_id = save.player_id & 0xFFFF
+	out.exp = Gen2Experience.total_exp_at(
+		int(data.species(wild.species).get("growth_rate", 0)), wild.level
+	)
+	for key: Variant in Gen2SaveMon.STAT_EXP_KEYS:
+		out.stat_exp[key] = 0
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		var known: int = int(out.moves[slot])
+		out.pp[slot] = int(data.move(known).get("pp", 0)) if known > 0 else 0
+	## `.SkipPartyMonFriendBall` and `.SkipBoxMonFriendBall`, which write the same
+	## byte on either side of the deposit.
+	out.happiness = FRIEND_BALL_HAPPINESS if ball == ITEM_FRIEND_BALL else BASE_HAPPINESS
 	out.is_egg = false
 	return out
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4755,6 +4755,7 @@ func _open_battle_host(request: Dictionary) -> void:
 	host.enemy_seen.connect(_on_enemy_seen)
 	if not tutorial:
 		host.capture_requested.connect(_on_capture_requested)
+		host.dex_entry_requested.connect(_on_battle_dex_entry_requested)
 		host.item_used.connect(_on_battle_item_used)
 	_battle_host = host
 	## Started after the connections and here rather than left to the host's own
@@ -4767,6 +4768,15 @@ func _open_battle_host(request: Dictionary) -> void:
 	_play_battle_music(request)
 	host.start_world_battle(request.duplicate(true), save, badges)
 	_claim_nuzlocke_encounter(host, values, save)
+	## The three dex answers `PokeBallEffect` reads, taken off live state before
+	## the entrance registers the sight it is about to show.
+	if _world != null and _world.state != null:
+		var species: int = int(values.get("pokemon", 0))
+		host.set_dex_context(
+			species > 0 and _world.state.has_seen_species(species),
+			species > 0 and _world.state.has_caught_species(species),
+			_world.state.is_engine_flag_active(Gen2WorldState.ENGINE_POKEDEX)
+		)
 	## After the fight exists, because starting one clears whatever capture action
 	## was staged: the bag belongs to this battle rather than to the last one.
 	if _world != null and not tutorial:
@@ -4872,11 +4882,21 @@ func _on_capture_requested(ball: int) -> void:
 		if _world.bug_contest_active()
 		else Gen2WorldPartyHost.capture_wild(
 			_world, save, target, ball, _encounter_random, 0, _active_battle_persist,
-			_battle_host.capture_battle_type()
+			_battle_host.capture_battle_type(), _battle_host.capture_thrower()
 		)
 	)
 	_battle_host.complete_capture(result)
 	_refresh_labels()
+
+
+## `NewPokedexEntry` behind `Text_GotchaMonWasCaught`: the page stands over the
+## battle, and the battle waits for it. The world opens it because the world owns
+## the dex; a cache with no entry for the species answers straight away.
+func _on_battle_dex_entry_requested(species: int) -> void:
+	if _battle_host == null:
+		return
+	if not _open_pokedex_entry({"values": {"species": species}}):
+		_battle_host.complete_dex_entry()
 
 
 ## `UseDisposableItem` inside a battle: the effect has already landed on the
@@ -7392,6 +7412,12 @@ func _on_pokedex_entry_closed() -> void:
 	if host != null:
 		_pokedex_prev_entry = host.previous_entry()
 		Gen2Screen.drop(host)
+	## A catch's page has a battle behind it rather than a script, and that
+	## battle is what the page returns to.
+	if _battle_host != null:
+		_battle_host.complete_dex_entry()
+		_refresh_labels()
+		return
 	if _world != null and not _world.pending_runtime_request().is_empty():
 		_show_script_results(_world.complete_runtime_request({"ok": true, "script_value": 0}))
 	_refresh_labels()
@@ -8069,7 +8095,7 @@ func _refresh_party_summary() -> void:
 			"lead_fainted": lead == null or lead.hp <= 0,
 			"second_species": int(second.species) if second != null else 0,
 			"storage_full": save.party.size() >= Gen2SaveData.MAX_PARTY \
-				and not bool(save.first_empty_box_slot().get("ok", false)),
+				and not bool(save.deposit_box_slot().get("ok", false)),
 			## `VAR_BOXSPACE`, which Route 29's catching tutorial reads before it
 			## offers to hand a POKé BALL over.
 			"box_free_space": save.box_free_space(),

--- a/tests/integration/test_battle_switch_screen.gd
+++ b/tests/integration/test_battle_switch_screen.gd
@@ -524,9 +524,11 @@ func test_throwing_a_ball_takes_the_list_off_the_screen() -> void:
 	await _step(Gen2Button.A)
 	await _step(Gen2Button.DOWN)
 	await _step(Gen2Button.A)
-	assert_true(bool(_screen.get("_capture_selecting")), "the ball pocket is up")
+	assert_eq(_screen.get("_pack_action_stage"), &"pack", "ItemSubmenu is up")
 	assert_true(_menu_layer().visible)
 
+	## `.BattleOnly` runs the effect on USE; the row was already chosen in the
+	## pack, so nothing asks which ball a second time.
 	await _step(Gen2Button.A)
 	assert_true(bool(_screen.get("_capture_waiting")), "the ball is in the air")
 	assert_false(_menu_layer().visible, "and nothing is drawn over the fight")
@@ -687,7 +689,9 @@ func test_the_pack_uses_an_item_on_the_chosen_member_and_spends_the_turn() -> vo
 	assert_true(bool(_screen.get("_pack_selecting")), "the pack list is up")
 	assert_eq(_screen.selected_pack_item(), BattleFixture.POTION)
 
-	# The party list `UseItem_SelectMon` opens, and the bench member on it.
+	# `ItemSubmenu`'s USE, and then the party list `UseItem_SelectMon` opens
+	# with the bench member on it.
+	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
 	await _step(Gen2Button.DOWN)
@@ -711,11 +715,13 @@ func test_the_item_target_list_takes_the_one_out_and_backs_out_to_the_pack() -> 
 	await _step(Gen2Button.DOWN)
 	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")
 	await _step(Gen2Button.B)
 	assert_eq(_stage(), "", "the list is gone")
 	assert_true(bool(_screen.get("_pack_selecting")), "and the pack is back")
 
+	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
 	## Healed to 21 and then hit, because the item spends the turn and the enemy
@@ -739,6 +745,7 @@ func test_an_x_item_needs_no_target_and_b_closes_the_pack() -> void:
 
 	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
+	await _step(Gen2Button.A)
 	assert_eq(battle.mon(Gen2Battle.PLAYER).stage("attack"), 1)
 	assert_eq(_stage(), "", "no target list for an item used on the one that is out")
 
@@ -755,6 +762,7 @@ func test_an_ether_asks_which_move_and_fills_that_slot() -> void:
 	user.pp[1] = 0
 
 	await _step(Gen2Button.DOWN)
+	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
 	await _step(Gen2Button.A)
 	assert_eq(_stage(), "pick")

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -2060,6 +2060,158 @@ func test_a_capture_pays_nothing_with_no_policy_registered() -> void:
 	assert_false(bool(host.get("_capture_experience_spent")))
 
 
+## `NewDexDataText` and `NewPokedexEntry` behind `Text_GotchaMonWasCaught`: a
+## species the dex has not caught yet says a line and opens its page, and the
+## catch waits there. `CheckCaughtMon` and `CheckReceivedDex` are both read
+## before the throw, because the throw is what registers the catch.
+func test_a_first_catch_says_its_dex_line_and_asks_for_the_page() -> void:
+	await _open_world()
+	_world_screen._world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+	assert_true(bool(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	).get("ok", false)))
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	var asked: Array[int] = []
+	host.dex_entry_requested.connect(func(species: int) -> void: asked.append(species))
+	assert_false(bool(host.get("_enemy_caught_before")), "the dex has never had one")
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.select_capture_ball(
+		host.available_capture_balls().find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
+	)["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
+
+	var said: Array[String] = []
+	for _message: int in 12:
+		var line: String = String(host.battle_snapshot()["message"])
+		if said.is_empty() or said.back() != line:
+			said.append(line)
+		if not asked.is_empty():
+			break
+		host.finish()
+		host.advance()
+	var expected: String = Gen2BattleScreen.NEW_DEX_DATA_TEXT % _wild_name()
+	assert_true(said.has(expected), JSON.stringify(said))
+	assert_gt(said.find(expected), said.find("Gotcha! %s was caught!" % _wild_name()))
+	assert_eq(asked.size(), 1, "and the page was asked for once")
+
+
+## A species already in the dex adds no data and opens no page.
+func test_a_catch_of_a_known_species_says_no_dex_line() -> void:
+	await _open_world()
+	_world_screen._world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+	_world_screen._world.state.set_species_caught(Fixture.TRAINER_SPECIES)
+	assert_true(bool(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	).get("ok", false)))
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_true(bool(host.get("_enemy_caught_before")))
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.select_capture_ball(
+		host.available_capture_balls().find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
+	)["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
+	for _message: int in 10:
+		assert_false(
+			String(host.battle_snapshot()["message"]).contains("was newly added"),
+			"nothing is added to a dex that already has one",
+		)
+		if host.get("_capture_nickname_host") != null:
+			break
+		host.finish()
+		host.advance()
+
+
+## `UseBallInTrainerBattle` is jumped to before `PokeBallEffect` says anything:
+## there is no ITEM USED line, the throw is drawn on
+## `BattleAnim_ThrowPokeBall`'s own NO_ITEM branch, the refusal is two boxes
+## rather than one, and `UseDisposableItem` spends the ball anyway.
+func test_a_ball_thrown_at_a_trainer_is_blocked_drawn_and_spent() -> void:
+	await _open_world()
+	assert_true(bool(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_POKE_BALL: 2}}
+	).get("ok", false)))
+	await _trigger_trainer()
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	host.set_battle_pack(
+		[Gen2WorldPartyHost.ITEM_POKE_BALL], {Gen2WorldPartyHost.ITEM_POKE_BALL: 2}
+	)
+	assert_true(bool(host.open_battle_pack().get("ok", false)))
+	var thrown: Dictionary = host.use_selected_pack_item()
+	assert_eq(StringName(thrown.get("status", &"")), &"blocked", JSON.stringify(thrown))
+	assert_true(host.animation_running(), "the throw is drawn before it is refused")
+	assert_eq(
+		int(host._anim_event["param"]), Gen2BattleScreen.ANIM_PARAM_NO_ITEM,
+		"`anim_if_param_equal NO_ITEM`, the branch the trainer blocks it on",
+	)
+	assert_eq(
+		_world_screen._world.state.item_quantity(Gen2WorldPartyHost.ITEM_POKE_BALL), 1,
+		"`jr UseDisposableItem`: the ball is gone whatever the trainer did",
+	)
+	_settle_frames(host)
+
+	var said: Array[String] = []
+	for _message: int in 6:
+		var line: String = String(host.battle_snapshot()["message"])
+		if said.is_empty() or said.back() != line:
+			said.append(line)
+		host.finish()
+		host.advance()
+	assert_true(
+		said.has(Gen2BattleScreen.BALL_BLOCKED_TEXT), JSON.stringify(said)
+	)
+	assert_true(said.has(Gen2BattleScreen.BALL_DONT_BE_A_THIEF_TEXT), JSON.stringify(said))
+
+
+## `.UseItem` returns with no carry on a ball that did not land, so the enemy
+## takes the turn the throw was paid with: `wItemEffectSucceeded` and
+## `wBattlePlayerAction` are the same byte, and `_DoItemEffect` wrote
+## BATTLEPLAYERACTION_USEITEM into it on the way in.
+func test_a_ball_that_missed_costs_the_turn() -> void:
+	await _open_world()
+	_data.species(Fixture.TRAINER_SPECIES)["catch_rate"] = 1
+	assert_true(bool(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_POKE_BALL: 4}}
+	).get("ok", false)))
+	_world_screen._encounter_random.seed = 1
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	var battle: Gen2Battle = host.get("_battle")
+	var before: int = battle.mon(Gen2Battle.PLAYER).hp
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
+	for _message: int in 12:
+		if battle.mon(Gen2Battle.PLAYER).hp < before:
+			break
+		if host.bars_animating() or host.frames_running():
+			host.advance_hardware_frame()
+			continue
+		host.finish()
+		host.advance()
+	assert_lt(
+		battle.mon(Gen2Battle.PLAYER).hp, before,
+		"the enemy moved in the turn the ball was thrown in",
+	)
+
+
 ## `PokeBallEffect` plays `ANIM_THROW_POKE_BALL` between the throw text and the
 ## result text, and that one script is the whole capture: the ball, the poof, the
 ## opponent going into it through `BATTLE_BG_EFFECT_RETURN_MON`, the wobbles that

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -3972,18 +3972,20 @@ func test_readvar_boxspace_reads_the_party_summary_mirror() -> void:
 	assert_eq(refused["reason"], &"missing_party_summary")
 
 
-## An empty box is the whole box; a storage with no free slot anywhere answers 0,
-## which is the refusal every reader of the var already branches on.
-func test_box_free_space_answers_the_box_a_deposit_would_land_in() -> void:
+## `_GetVarAction`'s `.BoxFreeSpace` is `MONS_PER_BOX - [sBoxCount]`, and
+## `sBoxCount` is the open box alone: a full one answers 0 with the other
+## thirteen still empty, and CHANGE BOX is what the player is expected to do
+## about it.
+func test_box_free_space_answers_the_open_box_and_no_other() -> void:
 	var save: Gen2SaveData = Gen2SaveData.new()
 	assert_eq(save.box_free_space(), Gen2SaveBox.CAPACITY)
 	for slot: int in Gen2SaveBox.CAPACITY:
 		(save.boxes[0] as Gen2SaveBox).put(Gen2SaveMon.new())
+	assert_eq(save.box_free_space(), 0, "box 1 is full and box 2 is not the open one")
+	assert_false(bool(save.deposit_box_slot().get("ok", false)))
+	save.current_box = 1
 	assert_eq(save.box_free_space(), Gen2SaveBox.CAPACITY)
-	for box: Gen2SaveBox in save.boxes:
-		for slot: int in Gen2SaveBox.CAPACITY:
-			box.put(Gen2SaveMon.new())
-	assert_eq(save.box_free_space(), 0)
+	assert_eq(int(save.deposit_box_slot()["box"]), 1)
 
 
 func test_initial_dst_specials_publish_source_confirmation_text_and_commit_state() -> void:

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1096,6 +1096,126 @@ func test_master_ball_captures_a_wild_mon_and_records_catch_metadata() -> void:
 	assert_eq(_world.state.item_quantity(0x01), 0)
 
 
+## `PokeBallEffect` pushes `wEnemyMonStatus` and `wEnemyMonHP` in front of
+## `LoadEnemyMon` and writes them back after it, so a Pokemon caught at three HP
+## and asleep joins the party at three HP and asleep. Everything else about the
+## row is `GeneratePartyMonStats`': the trainer ID is the player's rather than a
+## rolled one, the PP is full because `FillPP` ran over whatever the fight had
+## drained, the stat experience is zero and the experience is the minimum for the
+## level.
+func test_a_caught_pokemon_keeps_its_health_and_its_status() -> void:
+	_save.player_id = 0x1234
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	wild.hp = 3
+	wild.status = Gen2Status.SLEEP_MASK & 2
+	wild.stat_exp["attack"] = 5000
+	for slot: int in wild.pp.size():
+		wild.pp[slot] = 0
+	assert_true(bool(Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)["caught"]))
+	var caught: Gen2SaveMon = _save.party[2]
+	assert_eq(caught.hp, 3, "the health it was standing there with")
+	assert_eq(caught.status, wild.status, "and the status it was standing there in")
+	assert_eq(caught.ot_id, 0x1234, "the player's ID, so it is not a traded mon")
+	assert_eq(int(caught.stat_exp["attack"]), 0)
+	assert_eq(caught.happiness, Gen2WorldPartyHost.BASE_HAPPINESS)
+	assert_eq(caught.exp, Gen2Experience.total_exp_at(
+		int(_data.species(25).get("growth_rate", 0)), 5
+	))
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		var move: int = int(caught.moves[slot])
+		assert_eq(
+			int(caught.pp[slot]),
+			int(_data.move(move).get("pp", 0)) if move > 0 else 0,
+			"FillPP fills every slot"
+		)
+
+
+## `.SkipPartyMonFriendBall`: the one thing a FRIEND_BALL does, and the one ball
+## with no `BallMultiplierFunctionTable` row.
+func test_a_friend_ball_catch_starts_on_two_hundred_happiness() -> void:
+	_world.state.apply_changes({}, {}, {"items": {
+		Gen2WorldPartyHost.ITEM_FRIEND_BALL: 2, Gen2WorldPartyHost.ITEM_LOVE_BALL: 1,
+	}})
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	wild.hp = 1
+	var caught: Dictionary = {}
+	for _throw: int in 200:
+		_world.state.apply_changes({}, {}, {"items": {
+			Gen2WorldPartyHost.ITEM_FRIEND_BALL: 2,
+		}})
+		caught = Gen2WorldPartyHost.capture_wild(
+			_world, _save, wild, Gen2WorldPartyHost.ITEM_FRIEND_BALL, _random, 42, false
+		)
+		if bool(caught.get("caught", false)):
+			break
+	assert_true(bool(caught.get("caught", false)), "no friend ball ever landed")
+	assert_eq(
+		(_save.party[_save.party.size() - 1] as Gen2SaveMon).happiness,
+		Gen2WorldPartyHost.FRIEND_BALL_HAPPINESS
+	)
+
+
+## Every row of `BallMultiplierFunctionTable` is reachable, which is the whole of
+## what Kurt makes: before this the seven apricorn balls were refused outright
+## and the player could carry a ball nothing would throw.
+func test_every_ball_kurt_makes_can_be_thrown() -> void:
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	for ball: int in Gen2WorldApricorn.APRICORN_BALLS.map(
+		func(row: Array) -> int: return int(row[1])
+	):
+		_world.state.apply_changes({}, {}, {"items": {ball: 1}})
+		var thrown: Dictionary = Gen2WorldPartyHost.capture_wild(
+			_world, _save, wild, ball, _random, 42, false
+		)
+		assert_true(bool(thrown.get("ok", false)), "%d: %s" % [ball, JSON.stringify(thrown)])
+		assert_eq(_world.state.item_quantity(ball), 0, "and the ball was spent")
+
+
+## `SendMonIntoBox` writes `sBoxCount`, which is the open box and no other, and
+## `ShiftBoxMon` puts what it wrote at the head of it. A full open box refuses
+## the throw with the other thirteen still empty, which is
+## `Ball_BoxIsFullMessage`, and the ball is not spent.
+func test_a_full_party_catch_goes_to_the_front_of_the_open_box() -> void:
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	_save.current_box = 2
+	var resident: Gen2SaveMon = Gen2SaveMon.from_dict(_save.party[0].to_dict())
+	(_save.boxes[2] as Gen2SaveBox).put(resident)
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	var caught: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)
+	assert_true(bool(caught["caught"]))
+	assert_eq(int(caught["destination"]["box"]), 2, "the box the player has open")
+	assert_eq(int(caught["destination"]["slot"]), 0)
+	assert_eq((_save.boxes[2] as Gen2SaveBox).slots[0].species, 25)
+	assert_eq(
+		(_save.boxes[2] as Gen2SaveBox).slots[1].species, resident.species,
+		"and what was there moved down"
+	)
+	assert_true(_save.boxes[0].slots[0] == null, "box 1 is untouched")
+
+	for slot: int in Gen2SaveBox.CAPACITY:
+		(_save.boxes[2] as Gen2SaveBox).put(Gen2SaveMon.from_dict(resident.to_dict()), slot)
+	_world.state.apply_changes({}, {}, {"items": {0x01: 1}})
+	var refused: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x01, _random, 42, false
+	)
+	assert_false(bool(refused["ok"]))
+	assert_eq(StringName(refused["reason"]), &"storage_full")
+	assert_eq(_world.state.item_quantity(0x01), 1, "and the ball is still in the bag")
+
+
 ## `GetPokeBallWobble` increments its count before it rolls, so the roll that
 ## ends a throw names how many rocks came before it and not how many there were.
 ## A throw that escapes on the first roll has rocked no times at all, which is
@@ -1371,7 +1491,8 @@ func _add_capture_metadata() -> void:
 	RomCache.write_json(RomCache.species_path(Fixture.directory()), species)
 	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
 	for raw: Dictionary in items:
-		if int(raw["number"]) in [0x01, 0x02, 0x04, 0x05]:
+		if int(raw["number"]) in [0x01, 0x02, 0x04, 0x05] \
+			or int(raw["number"]) in Gen2WorldPartyHost.CAPTURE_BALLS:
 			raw["pocket"] = RomLayout.ITEM_POCKET_BALL
 	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
 

--- a/tools/checks/catch_rate.gd
+++ b/tools/checks/catch_rate.gd
@@ -1,0 +1,204 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## `wFinalCatchRate` on all three cartridges, against what the cartridges
+## themselves answered.
+##
+## `PokeBallEffect` settles the whole catch rate before it rolls, so the answer
+## is a pure function of eleven bytes and can be asked of a real dump directly:
+## `.claude/oracle/battle/catch_rate.py` sets those bytes, runs the instructions
+## between `.get_multiplier_loop` and the `call Random` in `.skip_hp_calc`, and
+## prints one line per case. This topic builds the same 4,779 cases here.
+##
+## The sweep is the whole corpus: every species against every ball, because
+## Heavy, Moon, Fast and Love are the only rows that differ per species; every
+## byte boundary of the health term against every status bit; and Level Ball's
+## whole level ladder. What is pinned is the digest of all of them plus the rows
+## below, which name the branch each one proves, so a break is both caught and
+## readable.
+##
+##   Godot --headless --path . -s res://tools/validate.gd -- catch_rate
+
+## `data/items/apricorn_balls.asm` and the four ordinary ones. MASTER_BALL is not
+## here: it never reaches the multiplier table.
+const BALLS: Array[int] = [0x05, 0x04, 0x02, 0x9D, 0x9F, 0xA0, 0xA1, 0xA4, 0xA5, 0xA6]
+
+## The health pairs the sweep uses. 85 is the last max HP whose `3 * max` fits in
+## a byte, 341 is the documented cliff, and 342 is where the shifted divisor's
+## low byte reaches zero.
+const HEALTH: Array = [
+	[20, 20], [20, 10], [20, 1], [85, 85], [85, 43], [85, 1],
+	[86, 86], [86, 43], [86, 1], [100, 100], [100, 50], [100, 1],
+	[200, 200], [200, 100], [200, 1], [255, 255], [255, 128], [255, 1],
+	[341, 341], [341, 171], [341, 1], [342, 342], [342, 171], [342, 1],
+	[400, 400], [400, 200], [400, 1], [703, 703], [703, 352], [703, 1],
+]
+## A sleep count of 1, 3 and 7, then PSN, BRN, FRZ and PAR one bit at a time.
+const STATUSES: Array[int] = [0, 1, 3, 7, 8, 16, 32, 64]
+const RATES: Array[int] = [1, 3, 25, 45, 90, 120, 190, 255]
+const LEVELS: Array[int] = [1, 3, 5, 10, 20, 50, 100]
+const PLAYER_LEVELS: Array[int] = [1, 5, 10, 20, 40, 80, 100]
+
+## SHA-1 of the whole sweep, one digest per cartridge, taken from a run that
+## agreed with the dump case for case. Re-earn it with
+## `venv/bin/python battle/catch_rate.py <game> /tmp/cart_catch_<game>.txt`
+## rather than by copying whatever this prints.
+const DIGESTS: Dictionary = {
+	&"crystal": "b4baef4d9894675f3620862c7591b3c16d8b9377",
+	&"gold": "32d91f998347f09f67f15c65098cc112907b699d",
+	&"silver": "32d91f998347f09f67f15c65098cc112907b699d",
+}
+
+## What each pinned row proves, and the rate the cartridge answered.
+## [ball, species, base rate, max HP, current HP, status, wild level,
+##  player level, fishing] -> final rate.
+const PINNED: Array = [
+	# The health term with nothing else on it, on both sides of the byte
+	# boundary at 85 max HP: `3 * 86` no longer fits and both operands shift.
+	[[0x05, 25, 255, 85, 85, 0, 10, 50, 0], 85],
+	[[0x05, 25, 255, 85, 1, 0, 10, 50, 0], 253],
+	[[0x05, 25, 255, 86, 86, 0, 10, 50, 0], 83],
+	[[0x05, 25, 255, 86, 1, 0, 10, 50, 0], 251],
+	# Sleep and freeze add ten; the +5 the other three were meant to add never
+	# runs, which is the whole of "BRN/PSN/PAR do not affect catch rate".
+	[[0x05, 25, 45, 100, 50, 0, 10, 50, 0], 30],
+	[[0x05, 25, 45, 100, 50, 3, 10, 50, 0], 40],
+	[[0x05, 25, 45, 100, 50, 32, 10, 50, 0], 40],
+	[[0x05, 25, 45, 100, 50, 8, 10, 50, 0], 30],
+	[[0x05, 25, 45, 100, 50, 16, 10, 50, 0], 30],
+	[[0x05, 25, 45, 100, 50, 64, 10, 50, 0], 30],
+	# Past 341 max HP the shifted divisor stops fitting too, and a wild at full
+	# health then reads as easier to catch than one at half.
+	[[0x05, 25, 255, 341, 341, 0, 10, 50, 0], 85],
+	[[0x05, 25, 255, 400, 400, 0, 10, 50, 0], 67],
+	[[0x05, 25, 255, 400, 200, 0, 10, 50, 0], 135],
+	# Great and Ultra.
+	[[0x04, 25, 100, 100, 100, 0, 10, 50, 0], 50],
+	[[0x02, 25, 100, 100, 100, 0, 10, 50, 0], 66],
+	# Lure Ball, which is three times the rate and only on a rod battle.
+	[[0xA0, 25, 100, 100, 100, 0, 10, 50, 0], 33],
+	[[0xA0, 25, 100, 100, 100, 0, 10, 50, 1], 85],
+	# Fast Ball, whose list is three species long: MAGNEMITE against MR. MIME.
+	[[0xA1, 81, 100, 100, 100, 0, 10, 50, 0], 85],
+	[[0xA1, 122, 100, 100, 100, 0, 10, 50, 0], 33],
+	# Moon Ball never boosts anything, NIDORINA included.
+	[[0xA5, 30, 100, 100, 100, 0, 10, 50, 0], 33],
+	# Love Ball boosts a matching gender rather than a differing one, and
+	# answers nothing for a genderless species. Both DVs are $FFFF here, so
+	# both sides are male wherever the ratio allows one.
+	[[0xA6, 25, 100, 100, 100, 0, 10, 50, 0], 85],
+	[[0xA6, 201, 100, 100, 100, 0, 10, 50, 0], 33],
+	# Friend Ball has no multiplier row at all: its effect is the happiness.
+	[[0xA4, 25, 100, 100, 100, 0, 10, 50, 0], 33],
+	# Level Ball skips the health term outright, so its answer is the multiplied
+	# rate: eight times under a quarter of the player's level, then four, then
+	# two, then nothing once the wild has caught up.
+	[[0x9F, 25, 45, 100, 100, 0, 5, 40, 0], 255],
+	[[0x9F, 25, 45, 100, 100, 0, 10, 40, 0], 180],
+	[[0x9F, 25, 45, 100, 100, 0, 20, 40, 0], 90],
+	[[0x9F, 25, 45, 100, 100, 0, 50, 40, 0], 45],
+	# Heavy Ball: twenty off a light species, forty onto SNORLAX.
+	[[0x9D, 25, 100, 100, 100, 0, 10, 50, 0], 26],
+	[[0x9D, 143, 100, 100, 100, 0, 10, 50, 0], 46],
+]
+
+## `docs/bugs_and_glitches.md`'s three wrong-bank species, whose Heavy Ball
+## answer differs between the profiles. SUNFLORA is not here: the cartridge does
+## not answer at all (see `HANDOFF.md`).
+const PINNED_CRYSTAL: Array = [
+	[[0x9D, 64, 100, 100, 100, 0, 10, 50, 0], 40],
+	[[0x9D, 128, 100, 100, 100, 0, 10, 50, 0], 46],
+]
+const PINNED_GOLD: Array = [
+	[[0x9D, 64, 100, 100, 100, 0, 10, 50, 0], 26],
+	[[0x9D, 128, 100, 100, 100, 0, 10, 50, 0], 26],
+]
+
+## The two max HP values whose shifted divisor is a whole multiple of 256, where
+## `_Divide` never leaves its loop: the cartridge locks up rather than answering,
+## so nothing here can be pinned against a dump. What is checked instead is that
+## the guard is live and the divisor it falls back on is the untruncated one.
+## [max HP, current HP] -> the rate a base of 255 answers with.
+const DIVIDE_BY_ZERO: Array = [
+	[[342, 342], 84], [[342, 171], 170], [[683, 683], 85], [[683, 342], 169],
+]
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		for row: Array in PINNED:
+			_verify(game_id, data, row[0] as Array, int(row[1]))
+		for row: Array in (PINNED_CRYSTAL if crystal else PINNED_GOLD):
+			_verify(game_id, data, row[0] as Array, int(row[1]))
+		for row: Array in DIVIDE_BY_ZERO:
+			var pair: Array = row[0]
+			_verify(game_id, data, [
+				0x05, 25, 255, int(pair[0]), int(pair[1]), 0, 10, 50, 0,
+			], int(row[1]))
+		_verify_sweep(game_id, data)
+
+
+## Every case the oracle runs, hashed. The digest is what makes this the whole
+## corpus rather than the rows above.
+func _verify_sweep(game_id: StringName, data: GameData) -> void:
+	var lines: PackedStringArray = PackedStringArray()
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		for ball: int in BALLS:
+			lines.append(_line(data, [ball, species, 100, 100, 100, 0, 10, 50, 0]))
+			if ball == 0xA0:
+				lines.append(_line(data, [ball, species, 100, 100, 100, 0, 10, 50, 1]))
+	for rate: int in RATES:
+		for pair: Array in HEALTH:
+			for status: int in STATUSES:
+				lines.append(_line(
+					data, [0x05, 25, rate, int(pair[0]), int(pair[1]), status, 10, 50, 0]
+				))
+	for player: int in PLAYER_LEVELS:
+		for wild: int in LEVELS:
+			for rate: int in [45, 190]:
+				lines.append(_line(data, [0x9F, 25, rate, 100, 100, 0, wild, player, 0]))
+	var digest: String = ("\n".join(lines) + "\n").sha1_text()
+	var expected: String = String(DIGESTS.get(game_id, ""))
+	if expected.is_empty():
+		_r.fail("%s: no pinned digest for the sweep. It answered %s." % [game_id, digest])
+		return
+	if digest != expected:
+		_r.fail("%s: the %d-case sweep is %s, pinned %s." % [
+			game_id, lines.size(), digest, expected,
+		])
+
+
+func _verify(game_id: StringName, data: GameData, case: Array, expected: int) -> void:
+	var answered: int = _rate(data, case)
+	if answered != expected:
+		_r.fail("%s: %s answered %d, the cartridge %d." % [
+			game_id, str(case), answered, expected,
+		])
+
+
+func _line(data: GameData, case: Array) -> String:
+	return "%s -> %d" % [" ".join(case.map(func(v: int) -> String: return str(v))), _rate(data, case)]
+
+
+func _rate(data: GameData, case: Array) -> int:
+	return Gen2WorldPartyHost.final_catch_rate(data, int(case[0]), {
+		"base_rate": int(case[2]),
+		"max_hp": int(case[3]),
+		"current_hp": int(case[4]),
+		"status": int(case[5]),
+		"species": int(case[1]),
+		"dvs": 0xFFFF,
+		"level": int(case[6]),
+		"thrower_species": int(case[1]),
+		"thrower_dvs": 0xFFFF,
+		"thrower_level": int(case[7]),
+		"battle_type": Gen2Battle.BATTLETYPE_FISH if int(case[8]) == 1 \
+			else Gen2Battle.BATTLETYPE_NORMAL,
+	})

--- a/tools/checks/catch_rate.gd.uid
+++ b/tools/checks/catch_rate.gd.uid
@@ -1,0 +1,1 @@
+uid://d3khuk0uuhdg2

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -7,7 +7,8 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses] [passes]
 ##
-## [stage] is one of `offer` (the default), `prize` (a trainer battle fought to
+## [stage] is one of `offer` (the default), `balls` (the pack showing every ball
+## a throw can be made with), `prize` (a trainer battle fought to
 ## its win, photographed on `GotMoneyForWinningText`), `menu`, `move`, `info` (the move
 ## list with a registered battle-information provider's annotations over it:
 ## a mark per row for the effectiveness against the defender, the non-zero stat
@@ -53,6 +54,13 @@ const CONTEST_STOCK_MAX_HP: int = 27
 const PACK_ITEMS: Array[int] = [0x12, 0x26, 0x31]
 const PACK_QUANTITIES: Dictionary = {0x12: 3, 0x26: 1, 0x31: 2}
 
+## The `balls` stage's rows: every ball `PokeBallEffect` has an effect for, which
+## is the four ordinary ones plus the seven Kurt makes out of apricorns.
+const BALL_QUANTITIES: Dictionary = {
+	0x05: 12, 0x04: 5, 0x02: 3, 0x01: 1, 0x9D: 2, 0x9F: 2, 0xA0: 2,
+	0xA1: 2, 0xA4: 2, 0xA5: 2, 0xA6: 2,
+}
+
 ## Falkner, and three of the player's own, all at a level where nothing faints
 ## before the question is asked.
 const TRAINER_CLASS: int = 1
@@ -84,7 +92,7 @@ const AMULET_COIN: int = 0x5B
 ## The stages `BattleMenu`'s own first opening leads into with nothing staged
 ## behind it, rather than a question a turn has to reach.
 const MENU_STAGES: Array[String] = [
-	"menu", "move", "info", "info_pack", "info_pkmn", "contest", "pack",
+	"menu", "move", "info", "info_pack", "info_pkmn", "contest", "pack", "balls",
 ]
 
 var _screen: Gen2BattleScreen = null
@@ -437,6 +445,15 @@ func _open() -> void:
 		## rows are a real cache's items, so the picture reads as the pack.
 		if _stage in ["pack", "info_pack"]:
 			_screen.set_battle_pack(PACK_ITEMS, PACK_QUANTITIES)
+			_screen._handle_button(Gen2Button.DOWN)
+			_screen._handle_button(Gen2Button.A)
+		## The BALL pocket of the same list. Every row of
+		## `BallMultiplierFunctionTable` is reachable, so the picture is the
+		## whole of what a player can throw.
+		if _stage == "balls":
+			_screen.set_battle_pack(
+				Gen2WorldPartyHost.capture_ball_items(), BALL_QUANTITIES
+			)
 			_screen._handle_button(Gen2Button.DOWN)
 			_screen._handle_button(Gen2Button.A)
 		## `BattleMenu_PKMN`'s party page, the other modal that covers the same


### PR DESCRIPTION
The catch rate is now the cartridge's own answer rather than one that agrees with it in the easy cases. `PokeBallEffect` settles the whole rate before it rolls, so the routine can be asked directly: a harness writes the eleven bytes it reads, runs the instructions between `.get_multiplier_loop` and the `call Random` in `.skip_hp_calc` on a real dump, and reads `wFinalCatchRate` back. 4,779 cases on each of the three cartridges.

| Cartridge | Cases | Exact | Differing |
|---|---|---|---|
| Crystal | 4,779 | 4,586 | 193, all of them cases the hardware locks up on |
| Gold | 4,779 | 4,587 | 192, the same |
| Silver | 4,779 | 4,587 | 192, the same |

`tools/checks/catch_rate.gd` is the durable half: it rebuilds every case, pins the digest per cartridge and names the branch each of its thirty-odd rows proves.

## Eleven balls instead of four

Every row of `BallMultiplierFunctionTable` is built, with the bugs `docs/bugs_and_glitches.md` records reproduced rather than corrected.

| Ball | What it does here |
|---|---|
| Ultra | Twice the rate |
| Great, Park | One and a half times |
| Heavy | Twenty off under 102.4 kg, up to forty on above 409.6 kg, off the dex entry's own weight through the routine's three shifts |
| Level | Twice, four times or eight under a half or a quarter of the player's level, and the health term skipped outright |
| Lure | Three times, on a rod battle only |
| Fast | Four times, for the three species `ld d, 3` reaches |
| Friend | No multiplier: 200 happiness after the catch lands |
| Moon | Nothing, ever: the item byte is read three bytes past the evolution method |
| Love | Eight times, on a wild of the same gender as the battler facing it |

The seven balls Kurt makes could not be thrown at all before this. The host refused them with `unsupported_ball_effect` and the selector never listed them, so a player could carry a ball nothing would use.

## The health term is the cartridge's bytes

`ld b, e` keeps the low byte of the divisor, `sub c` wraps, and `hQuotient + 3` is the low byte of the quotient. Those three truncations are what make the formula break over 341 max HP, and reproducing them is why a 400 HP wild now reads as easier to catch at full health than at half, exactly as it does on hardware.

At 342 and 683 max HP the shifted divisor is a whole multiple of 256, the divisor byte is zero and `_Divide` never leaves its loop. Measured rather than read: the harness never returns on either. That one is guarded, because there is no answer to match.

## What is caught keeps what it was

`PokeBallEffect` pushes `wEnemyMonStatus` and `wEnemyMonHP` in front of `LoadEnemyMon` and writes them back after it. A Pokemon caught at three HP and asleep now joins the party at three HP and asleep, rather than healed and cured.

Three more off `GeneratePartyMonStats`. Its trainer ID is the player's rather than a rolled one, which was giving every catch the traded-Pokemon experience bonus for the rest of the game. Its PP is full, because `FillPP` ran over whatever the fight had drained. Its stat experience is zero.

## Where it lands

`SendMonIntoBox` writes `sBoxCount`, which is the open box and no other, and `ShiftBoxMon` puts the catch at the head of it. Before this a full party sent the catch to the first box with room anywhere in storage and appended it. A full open box now refuses the throw with `BallBoxFullText` and the ball still in the bag.

## The flow

- `ItemSubmenu`'s USE/QUIT box stands between a pack row and its effect, so choosing a ball no longer asks which ball a second time.
- A ball that missed costs the turn. `wItemEffectSucceeded` and `wBattlePlayerAction` are one byte, and `_DoItemEffect` wrote BATTLEPLAYERACTION_USEITEM into it on the way in, so the enemy moves.
- A ball thrown at a trainer is drawn being knocked away on `BattleAnim_ThrowPokeBall`'s NO_ITEM branch, says its two lines rather than one, and is spent.
- A catch of a species the dex has not caught says `NewDexDataText` and opens its page, between the Gotcha line and the nickname question.
- A rod battle carries BATTLETYPE_FISH, which names its own battle-start line and is what Lure Ball boosts on. The headbutt line is built beside it.
- The three dex answers are read off live world state rather than off the save's snapshot, which is only as fresh as the last write to disk.

## Proof

- 3,996 GUT tests green, twelve of them new.
- `tools/validate.gd -- all` green, 80 topics.
- `replay_world.gd`: 33 routes, 0 failures.
- The three-profile story walk clean on Crystal, Gold and Silver.
- 0 GDScript warnings across 463 analysed scripts.