### PR TITLE
Cap the branching and the prose, and measure both

### DIFF
--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -1,21 +1,14 @@
 class_name Gen2Diagnostics
 extends Node
 
-## What a player hands over when something goes wrong: one file holding this
-## build, this machine, the settings and mods in force, and the engine's own log
-## of the session that broke.
+## What a player hands over when something goes wrong: this build, this machine,
+## the settings and mods in force, and the engine's own log of the session.
 ##
-## It is a sink rather than a set of call sites. [Logger] is installed with
-## [method OS.add_logger], so every `print`, `push_warning`, `push_error`,
-## engine error and GDScript runtime error anywhere in the game, in a tool or in
-## a mod passes through here without that code knowing. Adding a message to a
-## screen therefore adds it to a bug report; nothing has to be routed twice.
-##
-## The file on disk is the engine's own, at [constant DIRECTORY]: the crash
-## handler writes its backtrace to stderr, which a script-side sink never sees
-## and the file logger does. What this class adds around it is the header the
-## file opens with, the pruning the engine does not do, and the bundle a player
-## can actually attach to an issue.
+## A sink rather than a set of call sites: [Logger] goes in through
+## [method OS.add_logger], so every print, warning and runtime error in the game,
+## a tool or a mod reaches the report without being routed twice. The file at
+## [constant DIRECTORY] is the engine's own, so it catches the crash handler's
+## backtrace too; this class adds the header, the pruning and the bundle.
 
 ## Where the engine's file logger writes, mirrored from `project.godot` so the
 ## prune and the bundle read the directory the logs are actually in.
@@ -266,16 +259,12 @@ func _pack_bundle(directory: String) -> Dictionary:
 	return {"ok": true, "message": "", "path": path, "files": written}
 
 
-## The kept log files, newest first, named relative to [param directory]. An
-## absolute path carries the player's own account name and this list is read
-## out into a file they are about to publish.
-##
-## The engine's live file sorts first whatever its timestamp says, and the
-## rotated ones fall back to their names. [method FileAccess.get_modified_time]
-## has one-second resolution and a rotation writes several files inside one
-## second, so mtime alone leaves the order arbitrary: the prune below would then
-## sometimes take the session it is being run to preserve. A rotated name is the
-## live one with an ISO stamp inserted, so name-descending IS newest-first.
+## The kept log files, newest first, named relative to [param directory]: an
+## absolute path carries the player's account name into a file they are about to
+## publish. Sorted by name rather than mtime, which has one-second resolution
+## while a rotation writes several files inside one second; a rotated name is the
+## live one with an ISO stamp inserted, so name-descending is newest-first and the
+## prune below cannot take the session it was run to preserve.
 func log_files(directory: String = DIRECTORY) -> PackedStringArray:
 	var live: String = String(
 		ProjectSettings.get_setting("debug/file_logging/log_path", "")

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -111,17 +111,10 @@ func _ready() -> void:
 	load_mods()
 
 
-## Brings the lower display up for the whole process rather than for the world.
-##
-## Here rather than in [Gen2WorldScreen] because a handheld with two panels has
-## two panels in the launcher as well, and a black one reads as a fault. The
-## screen shows the project's own mark until a world is handed to it and again
-## when that world closes; [method set_second_screen_world] is the one way it
-## changes hands.
-##
-## Refused on anything but a player's own launch, for the reason
-## [method apply_display_options] gives: a check or a screenshot driver must not
-## open a window of its own.
+## Brings the lower display up for the whole process rather than for the world: a
+## handheld with two panels has two in the launcher as well, and a black one reads
+## as a fault. Refused on anything but a player's own launch, for the reason
+## [method apply_display_options] gives.
 func _attach_second_screen() -> void:
 	if not is_player_launch():
 		return
@@ -162,15 +155,12 @@ func _process(_delta: float) -> void:
 		_second_screen.refresh()
 
 
-## Puts the app block's window and frame-rate settings into the engine.
-##
-## The settings page calls this after every change, the way it calls
-## [method Gen2InputRuntime.apply_options] for the control scheme; nothing else
-## needs to. Refused on anything but a player's own launch: a headless check or a
-## `-s` tool would otherwise be capped at whatever frame rate the developer last
-## chose, and a screenshot driver would take the window with it. GAME SPEED is
-## not here: it reaches the game through [Gen2WorldAnimation.FrameClock], which
-## is what keeps it off the audio driver.
+## Puts the app block's window and frame-rate settings into the engine. The
+## settings page calls it after every change and nothing else needs to. Refused on
+## anything but a player's own launch: a headless check would be capped at
+## whatever frame rate the developer last chose, and a screenshot driver would
+## take the window with it. GAME SPEED reaches the game through
+## [Gen2WorldAnimation.FrameClock] instead, which keeps it off the audio driver.
 static func apply_display_options(options: Gen2Options) -> void:
 	if options == null or not is_player_launch():
 		return

--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -3,18 +3,11 @@ extends Node
 
 ## The live control scheme, and which device the player is actually using.
 ##
-## Two things need one owner. Bindings, because the [InputMap] is engine state
-## with no memory of where it came from, so something has to hold the scheme the
-## options file describes and put it back after every rebind. And the active
-## device, because "is a controller plugged in" is not the question any screen
-## asks: what decides whether an on-screen d-pad is drawn is whether the player
-## is touching the screen right now.
-##
-## Screens read this; only the settings page writes to it. They reach it through
-## [method instance] rather than through the `InputRuntime` global, for the same
-## reason [Gen2WorldScreen] reaches GameRuntime by path: a script handed to
-## Godot's `-s` is compiled before the tree that owns the autoloads exists, so a
-## preview tool that names a screen by type would fail to load it.
+## Bindings need an owner because the [InputMap] has no memory of where it came
+## from; the active device needs one because what decides whether an on-screen
+## d-pad is drawn is whether the player is touching the screen right now. Screens
+## read this through [method instance] rather than the `InputRuntime` global: a
+## `-s` script compiles before the tree that owns the autoloads exists.
 
 signal device_changed(kind: StringName)
 ## The effective answer, after both the setting and the active device. Also
@@ -228,18 +221,12 @@ func send_action(action: StringName, pressed: bool) -> void:
 	Input.parse_input_event(event)
 
 
-## Whether this event is a directional press nothing should act on.
-##
-## An analog stick reports a fresh [InputEventJoypadMotion] every time its value
-## moves, and every one of those is an action press: one push of the stick walked
-## a menu cursor the length of the list. A held key repeats at the operating
-## system's rate for the same reason. The extra presses are swallowed here, in
-## front of the engine's own focus navigation as well as every screen, and
+## Whether this event is a directional press nothing should act on. An analog
+## stick reports a fresh [InputEventJoypadMotion] on every value change and each
+## is an action press, so one push walked a menu the length of the list; a held
+## key repeats at the OS rate for the same reason. The extras are swallowed in
+## front of the engine's own focus navigation, and
 ## [method _advance_direction_repeat] puts back the repeat the hardware had.
-##
-## The cost is that a held stick past the deadzone reaches nothing else while it
-## is held, which a free camera reading raw motion would want. Nothing does
-## today; a renderer that did would read the axis rather than the event.
 func _gate_direction_repeat(event: InputEvent) -> bool:
 	var button: int = Gen2Button.direction_in(event)
 	if button == Gen2Button.NONE:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -268,9 +268,31 @@ subject. Before creating any file, name the existing one it cannot go in.
 - **Docs.** State each fact once, where it is enforced, and link instead of
   repeating. Source findings and constants go next to the code; contracts go in
   `docs/`.
-- **Comments.** A source symbol plus a one-line reason. Comment non-obvious
-  constraints and quirks; never restate the line below. No section banners, no
-  doc comment on a self-evident function. `rom_layout.gd` is the one exemption:
-  a comment recording how an offset was located is the evidence for that number.
+- **Comments.** Write none you do not have to: a name, a guard clause or a small
+  named helper says it once and cannot go stale. The one worth writing is a
+  source fact, the pret symbol a behaviour comes from plus the line saying why it
+  is not obvious. Never restate the line below, no section banners, no doc
+  comment on a self-evident function, and no paragraph of prose about a decision
+  the code makes plainly. A comment explaining a workaround is a bug report: fix
+  the code instead. `rom_layout.gd` records how an offset was located, which is
+  evidence for a number rather than restatement, and is still held to the cap.
 
 When something changes, replace the old text. Never append a correction.
+
+## The budget
+
+`tests/unit/test_source_budget.gd` caps how much branching and how much prose the
+tree may carry, because both track defect count the way line count does. It fails
+the suite.
+
+| Rule | Ceiling |
+|---|---|
+| Cyclomatic complexity of one function | 20 |
+| Lines in one comment block | 8 |
+| Comment lines under `game/`, `tools/` and `autoload/` | the number recorded in the test, which only goes down |
+
+Complexity counts `if`, `elif`, `while`, `for`, `and`, `or`, an inline `if` and
+one per `match` arm. Over the ceiling, the remedy is a lookup table, a guard
+clause or a named helper, never a nested ternary. The functions still over it are
+listed in that test and the list may only shrink: the test also fails on a line
+that no longer names a function over the ceiling.

--- a/game/audio/gen2_apu.gd
+++ b/game/audio/gen2_apu.gd
@@ -3,24 +3,12 @@ extends RefCounted
 
 ## DMG audio processing unit: the four hardware channels behind $ff10-$ff3f.
 ##
-## The sound engine only ever writes registers; everything audible is decided
-## here. Ported from MiniGBS by way of minigb_apu, which is what suiCune renders
-## pokecrystal's engine through, so a register trace taken from either lands on
-## the same samples.
-##
-## One [method render_frame] call is one LCD frame: registers are sampled once
-## and held for the whole block, exactly as a per-VBlank driver observes them.
-##
-## Two things are counted rather than walked, and both answer the same samples.
-## `update_freq`'s loop adds `freq_inc` to a counter that resets to zero on every
-## crossing of `FREQ_INC_REF`, so the crossings a sample makes are
-## `(counter + freq_inc - 1) / FREQ_INC_REF` and what is left is the remainder;
-## the duty counter and the wave position are advanced by that count in one step,
-## since only where they end up is read. And minigb_apu's sub-sample average,
-## `((pos - prev) / freq_inc) * val`, is integer division on `uint32_t` with
-## `pos - prev` always below `freq_inc`, so every term of it is zero and the
-## sample is the last value the walk left. The noise channel runs sixteen
-## crossings a sample at its fastest rate, which is what both of these cost.
+## Everything audible is decided here; the sound engine only writes registers.
+## Ported from MiniGBS by way of minigb_apu, the path suiCune renders pokecrystal
+## through, so a register trace from either lands on the same samples. One
+## [method render_frame] is one LCD frame. `update_freq`'s walk and minigb_apu's
+## sub-sample average are both counted instead: only where the duty counter ends
+## is read, and every term of that average is integer zero.
 
 const SAMPLE_RATE: int = 32768
 ## AUDIO_SAMPLE_RATE / (DMG clock / 70,224 clocks per frame), truncated.

--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -17,14 +17,10 @@ const BUFFER_SECONDS: float = 0.1
 
 ## Driver frames kept queued ahead of the output, and so the press-to-sound delay
 ## this player adds before the platform's own: three frames is 50 ms at
-## [constant Gen2Apu.SAMPLE_RATE].
-##
-## The buffer used to be kept as full as it would go, which spent its whole
-## 125 ms depth as latency. Measured worst emptiness on a desktop run was a
-## quarter of the depth, so about two driver frames are consumed between two
-## services there; three is that with a frame to spare, and a device that cannot
-## hold it says so by running the queue dry, which raises the target rather than
-## needing a build per target and an ear.
+## [constant Gen2Apu.SAMPLE_RATE]. Measured worst emptiness on a desktop run was a
+## quarter of the buffer's 125 ms depth, about two driver frames between two
+## services; three is that with one to spare, and a device that cannot hold it
+## says so by running the queue dry, which raises the target.
 const TARGET_FRAMES_MIN: int = 3
 ## The ceiling the target grows to, which is the whole buffer: past it there is
 ## nothing left to raise.
@@ -79,20 +75,16 @@ var _underruns: int = 0
 var _restarts: int = 0
 
 
-## The driver exists before the node enters the tree: a host that plays its map
-## music while it is still building itself has to reach a live engine.
 ## How many of the CALLER's frames the driver may go without rendering before a
-## wait on a sound decides nobody is servicing it and gives up.
-##
-## Not one. The buffer is filled to a depth rather than by the frame, and a host
-## drawing faster than the driver renders leaves gaps of several frames in the
-## count: read as one frame, every `waitsfx` in the game ended on the frame after
-## it started, so a badge, a TM and every item jingle printed their line and
-## replaced it before it could be read. Long enough to cover a gap, short enough
-## that a run with no audio device at all pays a fifth of a second for it.
+## wait on a sound decides nobody is servicing it and gives up. Not one: the
+## buffer is filled to a depth rather than by the frame, and read as one frame
+## every `waitsfx` in the game ended on the frame after it started, so every item
+## jingle printed its line and replaced it before it could be read.
 const SERVICE_GAP_FRAMES: int = 12
 
 
+## The driver exists before the node enters the tree: a host that plays its map
+## music while it is still building itself has to reach a live engine.
 func _init() -> void:
 	_apu = Gen2Apu.new()
 	_engine = Gen2SoundEngine.new(_apu)
@@ -112,19 +104,13 @@ func _process(delta: float) -> void:
 	_service_timeline(delta)
 
 
-## The audio session, on every platform that says anything about it.
-##
-## Android and iOS send the two APPLICATION notifications when a call, Siri, the
-## audio focus or a home press takes the session away, and desktop sends the two
-## FOCUS ones. Coming back is what needs handling: the driver kept running, the
-## stream player still reports `playing`, and pushing into a playback nothing
-## consumes is silence over live music until a screen change builds another one.
-## A resume does not rebuild outright, because an alt-tab is a FOCUS_IN too and
-## a live output would be cut for nothing; it shortens the watchdog's window
-## instead, so an output that is still there proves it on the next tick and one
-## that is not is replaced a tenth of a second later. Going away needs nothing:
-## `_process` stops with the main loop, and where it does not the generator fills
-## and the fill stops.
+## The audio session, on every platform that says anything about it. Android and
+## iOS send the two APPLICATION notifications and desktop the two FOCUS ones.
+## Coming back is what needs handling: the driver kept running and the player
+## still reports `playing`, so pushing into a playback nothing consumes is silence
+## over live music. A resume shortens the watchdog's window rather than rebuilding
+## outright, because an alt-tab is a FOCUS_IN too. Going away needs nothing:
+## `_process` stops with the main loop.
 func _notification(what: int) -> void:
 	match what:
 		NOTIFICATION_APPLICATION_RESUMED, NOTIFICATION_APPLICATION_FOCUS_IN:
@@ -293,16 +279,13 @@ func effect_playing() -> bool:
 	return _engine.sfx_active()
 
 
-## How many driver frames this player has actually rendered.
-##
-## The engine only advances inside [method _service_timeline], which needs an
-## output stream with room in it: a headless run, a check or a replay leaves the
-## channels exactly as the last request set them, so [method effect_playing] would
-## answer true for the rest of the run. Anything WAITING on a sound compares this
-## count across frames instead of trusting that answer, and stops waiting once it
-## has stood still for [constant SERVICE_GAP_FRAMES]. `AudioStreamPlayer.playing`
-## is not that test: the dummy audio driver reports true and consumes nothing.
-## See `Gen2BattleScreen`'s `ANIM_WAIT_SFX`.
+## How many driver frames this player has actually rendered. The engine only
+## advances inside [method _service_timeline], which needs room in an output
+## stream, so a headless run, a check or a replay would leave [method
+## effect_playing] true for the rest of the run. Anything waiting on a sound
+## compares this count across frames and stops once it has stood still for
+## [constant SERVICE_GAP_FRAMES]. `AudioStreamPlayer.playing` is not that test:
+## the dummy audio driver reports true and consumes nothing.
 func timeline_updates() -> int:
 	return _timeline_updates
 
@@ -424,15 +407,11 @@ func _service_timeline(delta: float = 0.0) -> void:
 
 
 ## Rebuilds an output that has taken nothing from the driver for
-## [constant STALL_SECONDS] while the driver had sound for it.
-##
-## The platforms that announce an interruption are handled in
-## [method _notification]; this is the ones that do not, and it is also what
-## makes that handler cheap, since a resume only has to shorten this window
-## rather than rebuild a live output. `AudioStreamPlayer` reports `playing` over
-## a dead device, so what the queue does is the only honest evidence: a live one
-## consumes 59.7 driver frames a second and so takes a fill within a few ticks,
-## whatever the host's frame rate.
+## [constant STALL_SECONDS] while the driver had sound for it. The platforms that
+## announce an interruption are handled in [method _notification]; this is the
+## ones that do not. `AudioStreamPlayer` reports `playing` over a dead device, so
+## what the queue does is the only honest evidence: a live one consumes 59.7
+## driver frames a second whatever the host's frame rate.
 func _watch_for_a_dead_output(delta: float, pushed: int) -> void:
 	if pushed > 0 or not _engine.any_channel_active():
 		_starved_seconds = 0.0

--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -3,14 +3,11 @@ extends RefCounted
 
 ## The cartridge sound driver, ported from `audio/engine.asm`.
 ##
-## [method update_sound] is one `_UpdateSound`, which the cartridge runs once
-## per LCD frame. It parses each of the eight channel streams and writes the
-## hardware registers; [Gen2Apu] turns those writes into samples. Nothing here
-## decides what a note sounds like, exactly as on the cartridge.
-##
-## Every audible behaviour that used to be approximated - vibrato, pitch slides,
-## the rotating duty pattern, envelopes, the noise channel, sfx stealing music
-## channels - is now the driver's own state machine running at its own rate.
+## [method update_sound] is one `_UpdateSound`, which the cartridge runs once per
+## LCD frame: it parses each of the eight channel streams and writes the hardware
+## registers, and [Gen2Apu] turns those writes into samples. Vibrato, pitch
+## slides, the rotating duty pattern, envelopes, noise and sfx stealing music
+## channels are all the driver's own state machine at its own rate.
 
 const NUM_MUSIC_CHANNELS: int = 4
 const NUM_CHANNELS: int = 8
@@ -329,17 +326,11 @@ func sfx_channels_off() -> void:
 
 ## `PlaySFX`: the wrapper every `playsound`, `specialsound` and menu beep goes
 ## through, and the reason two of them do not pile onto each other. The table is
-## ordered highest priority first, so a request is refused while a *lower*-
-## numbered effect is still on the four channels; the same id restarts, since
-## the comparison is `cp e / jr c`.
-##
-## Only `PlayStereoSFX` and the battle animations behind it reach [method
-## play_sfx] without this gate. Without it every request restarted the channels
-## mid-effect, which is a fanfare cut in half by whatever the next box beeped.
-##
-## [param after_wait] is `WaitPlaySFX`, and the handful of sites that spend a
-## `WaitSFX` of their own first: the cartridge holds there until the channels
-## are free, so the gate can never be the thing that refuses those.
+## ordered highest priority first, so a request is refused while a lower-numbered
+## effect is still on the four channels; the same id restarts, since the
+## comparison is `cp e / jr c`. Only `PlayStereoSFX` and the battle animations
+## skip it. [param after_wait] is `WaitPlaySFX` and the sites that spend a
+## `WaitSFX` first, where the gate must never be what refuses them.
 func play_sfx_gated(record: Dictionary, after_wait: bool = false) -> bool:
 	var index: int = int(record.get("index", 0))
 	if not after_wait and sfx_active() and cur_sfx < index:

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -4,24 +4,11 @@ extends RefCounted
 ## Scores an enemy trainer's move choice the way the cartridge's own AI does.
 ##
 ## Every slot starts at 20, or 80 with no PP. Each bit set in the trainer class's
-## [constant RomLayout.ATTR_AI_MOVE_WEIGHTS] word runs one scoring layer over the
-## four slots in the cartridge's bit order ([constant RomLayout.AI_BASIC] through
-## [constant RomLayout.AI_RISKY]), nudging scores up (discourage) or down
-## (encourage). Lowest score wins, ties broken at random.
-##
-## [RefCounted], scene-free, randomness injected, so a whole decision can be
-## asserted on in a test.
-##
-## `engine/battle/ai/scoring.asm` finds that minimum by decrementing every slot's
-## counter per pass until one reaches zero, then walking backward to give tied
-## slots the same outcome. That is an argmin without a MIN instruction, not a
-## rule of its own, so [method choose_slot] takes the minimum directly.
-##
-## Percent chances use the cartridge's `X * 255 / 100` macro rather than the odd
-## byte a few call sites adjust by one; the difference is one part in 256.
-##
-## Every row of `AI_Redundant` and of `AI_Smart`'s own jumptable has a handler;
-## `tests/unit/test_ai.gd` pins the latter against the source table.
+## [constant RomLayout.ATTR_AI_MOVE_WEIGHTS] runs one scoring layer over the four
+## slots, nudging scores up (discourage) or down (encourage); lowest wins, ties
+## broken at random. `scoring.asm` finds that minimum by decrementing counters,
+## which is an argmin rather than a rule, so [method choose_slot] takes it
+## directly. Percent chances use the cartridge's `X * 255 / 100` macro.
 
 ## Everything one scoring layer is allowed to read, gathered once so a handler
 ## takes the fact it needs rather than a thirteenth positional argument.
@@ -161,17 +148,12 @@ const SANDSTORM_IMMUNE_TYPES: Array = Gen2Weather.SANDSTORM_EXEMPT_TYPES
 const RESIDUAL_MOVE_NUMBERS: Array = [54, 73, 77, 78, 86, 116, 117, 139, 144, 160, 164, 191]
 
 
-## What the enemy does with its turn: pull its Pokémon out, reach for an item, or
-## use a move.
-##
-## `AI_SwitchOrTryItem`, which runs before the turn and settles ahead of it.
-## Switching is considered first and an item only when it is refused, which is
-## the cartridge's `DontSwitch` fallthrough rather than a separate decision.
-##
-## Answers a [Gen2Battle] action dictionary. [param item_switch_flags] is the
-## class's own [constant RomLayout.ATTR_AI_ITEM_SWITCH] word, and
-## [param move_slot] is what [method choose_slot] already picked, used when
-## nothing else is worth doing.
+## What the enemy does with its turn: pull its Pokemon out, reach for an item, or
+## use a move. `AI_SwitchOrTryItem`, which runs before the turn and settles ahead
+## of it: switching is considered first and an item only when it is refused,
+## which is the cartridge's `DontSwitch` fallthrough rather than a separate
+## decision. [param item_switch_flags] is the class's own
+## [constant RomLayout.ATTR_AI_ITEM_SWITCH].
 static func choose_action(
 	battle: Gen2Battle, item_switch_flags: int, move_slot: int, rng: RandomNumberGenerator
 ) -> Dictionary:
@@ -222,32 +204,14 @@ static func _locked_in(mon: Gen2BattleMon) -> bool:
 	return false
 
 
-## Picks a move slot for [param attacker] to use against [param defender], the
-## way [param ai_move_weights] (a trainer class's own
-## [constant RomLayout.ATTR_AI_MOVE_WEIGHTS]) says to score it.
-##
-## [param attacker_turns_taken] and [param defender_turns_taken] are
-## `wEnemyTurnsTaken` and `wPlayerTurnsTaken`, each side's own
-## [member Gen2BattleMon.turns_taken] read before the turn is spent, which is
-## when the cartridge's AI reads them too. Every handler that wants them wants
-## the same thing: whether this is the Pokémon's first turn out.
-##
-## [param weather] is [member Gen2Battle.weather], and the two screen words are
-## [member Gen2Battle.screens] for each side. [param attacker_screens] is the
-## AI's own, which is the `wEnemyScreens` every `AI_Redundant` screen row reads;
-## [param defender_screens] is the player's, which is what its Confuse row and
-## its damage estimate read.
-##
-## [param has_bench] and [param matchup_score] are the two routines the smart
-## layer farcalls out of a handler rather than reads off a battler:
-## `FindAliveEnemyMons`, which is whether the AI has anybody left to send, and
-## `CheckPlayerMoveTypeMatchups`, which is `wEnemyAISwitchScore` and is
-## [method Gen2AISwitch.matchup_score] here. Both are supplied the way
-## [param weather] is, since this routine scores a pairing rather than a battle;
-## the defaults are the neutral states, a lone Pokémon and an unnudged score.
-##
-## Always returns a slot in range: [method Gen2Battle.move_for] turns an
-## unusable slot into Struggle, so no empty-moveset case is needed here.
+## Picks a move slot for [param attacker] against [param defender], scored the
+## way [param ai_move_weights] says to. The two turn counts are `wEnemyTurnsTaken`
+## and `wPlayerTurnsTaken` read before the turn is spent, which is when the
+## cartridge reads them; every handler wants the same thing out of them, whether
+## this is the Pokemon's first turn out. [param has_bench] and
+## [param matchup_score] are `FindAliveEnemyMons` and `CheckPlayerMoveTypeMatchups`
+## supplied rather than read, since this scores a pairing rather than a battle.
+## Always returns a slot in range: an unusable one becomes Struggle.
 static func choose_slot(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -431,14 +395,10 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 
 ## [constant RomLayout.AI_BASIC]: nothing redundant. A status move against an
 ## already-statused target, confusion against a confused one, Disable or Encore
-## against a locked one, Attract against a target already in love or of the same
-## or unknown gender, and a second Mist or Focus Energy, which is why those two
-## read the attacker rather than the defender, and a screen the attacker's own
-## side already holds. A standing Substitute reads the attacker for the same
-## reason; Leech Seed, Nightmare and Spikes read the target.
-##
-## `AI_Redundant`'s own thirty rows are the rest of it, each reading whichever
-## side the effect would land on.
+## against a locked one, Attract against a target in love or of the same or
+## unknown gender, and a second Mist or Focus Energy, which is why those two read
+## the attacker rather than the defender. A standing Substitute reads the attacker
+## for the same reason; Leech Seed, Nightmare and Spikes read the target.
 static func _apply_basic(scores: Array, c: Context) -> void:
 	var attacker: Gen2BattleMon = c.attacker
 	var defender: Gen2BattleMon = c.defender
@@ -943,15 +903,11 @@ static func _smart_sandstorm(
 		_encourage(scores, slot, 1)
 
 
-## `AI_Smart_RainDance` and `AI_Smart_SunnyDay`, which are one routine with two
-## type pairs: the weather is a bad idea if it would suit the target and a good
-## one if it would hurt it, and otherwise worth setting only with a move that
-## wants it.
-##
-## [param favours_target] is the type the weather helps and
-## [param disfavours_target] the one it hurts, in the order the cartridge tests
-## them: the target's first type answers before its second, so a Water/Fire
-## target under Rain Dance is a Water target.
+## `AI_Smart_RainDance` and `AI_Smart_SunnyDay`, one routine with two type pairs:
+## the weather is a bad idea if it would suit the target and a good one if it
+## would hurt it, and otherwise worth setting only with a move that wants it. The
+## two types are tested in the cartridge's order, so a Water/Fire target under
+## Rain Dance is a Water target.
 static func _smart_weather_move(
 	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
 	rng: RandomNumberGenerator, atk_turns: int, def_turns: int,
@@ -1107,17 +1063,12 @@ static func _smart_heal(
 		_discourage(scores, slot, 1)
 
 
-## `AI_Smart_PerishSong`: worth singing when the player cannot leave, not worth
-## singing when the AI has nobody to leave for.
-##
-## Three branches in the source's own order. `.no`, with nobody on the bench, is
-## the only one that moves a score without a roll: five points against, since a
-## song the AI cannot walk away from kills it too. A player held by Mean Look or
-## Spider Web is `.yes`, 50% to encourage. Otherwise the AI only bothers when the
-## matchup is one it is not losing: `CheckPlayerMoveTypeMatchups` below
-## [constant Gen2AISwitch.BASE_SCORE] returns with nothing said, and at or above
-## it is 50% to discourage. Reading that as "sing when things are going badly"
-## has it backwards; the branch that says yes is the trapped one.
+## `AI_Smart_PerishSong`, three branches in the source's own order. `.no`, with
+## nobody on the bench, is the only one that moves a score without a roll: five
+## points against, since a song the AI cannot walk away from kills it too. A
+## player held by Mean Look or Spider Web is `.yes`, 50% to encourage. Otherwise
+## the AI only bothers when the matchup is one it is not losing. The branch that
+## says yes is the trapped one, not the winning one.
 static func _smart_perish_song(
 	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator,
 	has_bench: bool, matchup_score: int
@@ -1147,17 +1098,11 @@ static func _smart_pain_split(
 		_discourage(scores, slot, 1)
 
 
-## `AI_Smart_LockOn`, whose two halves ask opposite questions.
-##
-## With the player already locked on, aiming again is wasted: every inaccurate
-## move the enemy knows is encouraged instead, and Lock On itself is dismissed.
-## The walk stops at the first empty slot, which is `.dismiss`.
-##
-## Without it, the ladder is health, then speed, then whether the accuracy is
-## actually a problem: a sharply raised evasion or a sharply lowered accuracy is
-## worth aiming for, a mild one is not worth a turn, and past both it comes down
-## to whether any move in the list is inaccurate enough to want the help and at
-## least neutral against the target.
+## `AI_Smart_LockOn`, whose two halves ask opposite questions. With the player
+## already locked on, aiming again is wasted: every inaccurate move the enemy
+## knows is encouraged instead and Lock On itself is dismissed, the walk stopping
+## at the first empty slot. Without it the ladder is health, then speed, then
+## whether the accuracy is actually a problem.
 static func _smart_lock_on(
 	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
 	data: GameData, rng: RandomNumberGenerator
@@ -1406,14 +1351,10 @@ const PROTECT_DISCOURAGE_SKIP_PERCENT: int = 8
 
 
 ## `AI_Smart_Endure`: the same opening test as Protect, then health, then the one
-## reason to want to survive on a single point.
-##
-## Reversal is looked for by effect rather than by move number, which is
-## `AIHasMoveEffect`, and Flail carries the same byte, so either move answers.
-##
-## `.no_reversal` is the other reason: `wEnemySubStatus5`, the flag a Lock On the
-## *player* used left on the enemy. A guaranteed incoming hit is exactly what
-## surviving on one point is for.
+## reason to want to survive on a single point. Reversal is looked for by effect
+## rather than by move number, which is `AIHasMoveEffect`, and Flail carries the
+## same byte. `.no_reversal` is the other reason: `wEnemySubStatus5`, the flag a
+## Lock On the player used left on the enemy.
 static func _smart_endure(
 	scores: Array, slot: int, attacker: Gen2BattleMon, data: GameData,
 	rng: RandomNumberGenerator
@@ -1540,22 +1481,13 @@ static func _apply_aggressive(scores: Array, c: Context) -> void:
 
 
 ## `AIDamageCalc`: the AI's own damage prediction, which is `EnemyAttackDamage`
-## and `BattleCommand_DamageCalc` themselves rather than an approximation of
-## them, so it reads the player's screens exactly as a real hit would.
-##
-## [constant Gen2Damage.CONSTANT_DAMAGE_EFFECTS] leaves the formula alone and
-## answers with `BattleCommand_ConstantDamage`'s own number, the same one the hit
-## will deal. All six of those moves carry a power the AI's callers test, so the
-## branch is live: without it Seismic Toss and Night Shade are read at power 1
-## and Super Fang at 1, and an aggressive or risky trainer plays them blind.
-##
-## [param constant] is what `AI_Smart_PriorityHit` is missing: it inlines the
-## three formula calls and never consults the list.
-##
-## Psywave's prediction really does roll, `BattleCommand_ConstantDamage` calling
-## `BattleRandom` inside the estimate, so the roll is spent here too. The
-## cartridge spends it on the battle's stream rather than the AI's; this engine
-## injects one generator for both, which is the same object either way.
+## and `BattleCommand_DamageCalc` themselves rather than an approximation, so it
+## reads the player's screens exactly as a real hit would.
+## [constant Gen2Damage.CONSTANT_DAMAGE_EFFECTS] answers with
+## `BattleCommand_ConstantDamage`'s own number instead; without that branch
+## Seismic Toss, Night Shade and Super Fang are read at power 1. [param constant]
+## is what `AI_Smart_PriorityHit` is missing. Psywave's prediction really rolls,
+## and the roll is spent on the one generator both sides share.
 static func _estimate_damage(c: Context, move: Dictionary, constant: bool = true) -> int:
 	var effect: int = _effect(move)
 	if constant and Gen2Damage.CONSTANT_DAMAGE_EFFECTS.has(effect):

--- a/game/battle/ai_items.gd
+++ b/game/battle/ai_items.gd
@@ -1,17 +1,13 @@
 class_name Gen2AIItems
 extends RefCounted
 
-## What a trainer reaches into its bag for, and what happens when it does.
-##
-## `AI_TryItem` and the `EnemyUsed*` routines in
-## [code]engine/battle/ai/items.asm[/code]. A trainer class carries at most two
-## item numbers ([code]TRNATTR_ITEM1[/code] and [code]TRNATTR_ITEM2[/code],
-## already in the cache as [method GameData.trainer_attributes]), and the same
-## class's [code]TRNATTR_AI_ITEM_SWITCH[/code] word decides how freely they are
-## spent.
-##
-## Only the enemy has any of this: the player's own pack has no X items and no
-## in-battle healing beyond what [Gen2HeldItem] does on its own.
+## What a trainer reaches into its bag for, and what happens when it does:
+## `AI_TryItem` and the `EnemyUsed*` routines in `engine/battle/ai/items.asm`. A
+## class carries at most two item numbers (`TRNATTR_ITEM1` and `_ITEM2`, already
+## in the cache as [method GameData.trainer_attributes]) and its
+## `TRNATTR_AI_ITEM_SWITCH` word decides how freely they are spent. Only the enemy
+## has any of this: the player's pack has no X items and no in-battle healing
+## beyond what [Gen2HeldItem] does on its own.
 
 ## The thirteen items the AI knows, at their cartridge numbers.
 const FULL_RESTORE: int = 0x0E

--- a/game/battle/ai_switch.gd
+++ b/game/battle/ai_switch.gd
@@ -1,19 +1,14 @@
 class_name Gen2AISwitch
 extends RefCounted
 
-## Whether a trainer pulls its Pokémon out, and which one it sends instead.
+## Whether a trainer pulls its Pokemon out, and which one it sends instead:
+## `CheckAbleToSwitch` and its five party scans in `engine/battle/ai/switch.asm`,
+## plus the three frequency gates in `items.asm`.
 ##
-## `CheckAbleToSwitch` and its five party scans in
-## [code]engine/battle/ai/switch.asm[/code], plus the three frequency gates in
-## [code]engine/battle/ai/items.asm[/code] that decide how often the answer is
-## acted on.
-##
-## The cartridge works in six-bit masks over the enemy party and reuses one
-## variable as both a score and a party index. Here the masks are arrays of party
-## indices and the two uses are separate return values, which changes nothing:
-## every scan keeps party order, and every place the cartridge converts a mask to
-## an index it takes the lowest index set, which is what every scan here answers
-## with too.
+## The cartridge works in six-bit masks and reuses one variable as both a score
+## and a party index; here the masks are arrays of indices and the two uses are
+## separate return values. Nothing changes: every scan keeps party order, and
+## every mask-to-index conversion takes the lowest index set.
 
 ## `BASE_AI_SWITCH_SCORE`, where [method matchup_score] starts before anything
 ## nudges it.
@@ -118,18 +113,13 @@ static func evaluate(battle: Gen2Battle) -> Dictionary:
 	return _no_counter_choice(battle, alive)
 
 
-## `CheckAbleToSwitch`'s opening branch: the turn before Perish Song finishes
-## the Pokémon that is out, get somebody else in. Empty means the branch did not
-## apply and the matchup half decides instead.
-##
-## Only a count of exactly one qualifies. Two is too early and zero has already
-## killed, so a Pokémon that will survive the song is left to fight.
-##
-## The tier is [constant TIER_HIGH] either way, which is the whole point of the
-## branch: what the shortlist changes is who comes in, not how much the AI wants
-## the switch. With a super-effective answer standing it is that Pokémon; without
-## one, `.not_2` walks the alive mask from the top and takes the first bit, which
-## is the lowest party index still standing, shortlist or no shortlist.
+## `CheckAbleToSwitch`'s opening branch: the turn before Perish Song finishes the
+## Pokemon that is out, get somebody else in. Empty means the matchup half decides
+## instead. Only a count of exactly one qualifies; two is too early and zero has
+## already killed. The tier is [constant TIER_HIGH] either way, so what the
+## shortlist changes is who comes in rather than how much the AI wants the switch:
+## without a super-effective answer, `.not_2` takes the lowest party index still
+## standing.
 static func _perish_choice(battle: Gen2Battle, alive: Array) -> Dictionary:
 	var enemy: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
 	if not Gen2Substatus.has(enemy.substatus, Gen2Substatus.PERISH):

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -364,15 +364,12 @@ const EVADED: StringName = &"evaded"
 ## floor gets.
 const MIST_PROTECTED: StringName = &"mist_protected"
 
-## `ANIM_SEND_OUT_MON` (constants/move_constants.asm) and the two
-## `wBattleAnimParam` values every entrance plays it with: `BattleAnim_SendOutMon`
-## branches on the parameter, `$0` being the ball and `$1` the shiny sparkle.
-##
-## The constant is `$101`, not 101: the comments in that file are hexadecimal,
-## and the animations past the moves start at `const_next $ff`. Read as a
-## decimal it is NIGHT SHADE, which decodes, runs and draws, so nothing falls
-## over: the ball is a night shade with the wrong palette and four times the
-## frames. `tools/checks/battle_anims.gd` pins the body each parameter reaches.
+## `ANIM_SEND_OUT_MON` and the two `wBattleAnimParam` values every entrance plays
+## it with: `$0` the ball, `$1` the shiny sparkle. The constant is `$101`, not
+## 101, because the comments in `constants/move_constants.asm` are hexadecimal.
+## Read as a decimal it is NIGHT SHADE, which decodes, runs and draws, so nothing
+## falls over: the ball was a night shade with the wrong palette and four times
+## the frames. `tools/checks/battle_anims.gd` pins the body each parameter reaches.
 const ANIM_SEND_OUT_MON: int = 0x101
 const SEND_OUT_ANIM_NORMAL: int = 0
 const SEND_OUT_ANIM_SHINY: int = 1
@@ -937,17 +934,14 @@ func has_fled() -> bool:
 	return _fled
 
 
-## `TryToRunAwayFromBattle`, resolved without spending anything. Answers
-## `outcome`: [code]&"fled"[/code], [code]&"failed"[/code] for the short roll,
-## which costs the turn, or [code]&"blocked"[/code] for a refusal that costs
-## nothing, with `how` or `reason` naming the branch. Both trapping checks are
-## refusals rather than failed rolls: `.cant_escape` returns without writing
+## `TryToRunAwayFromBattle`, resolved without spending anything. Answers `outcome`
+## `fled`, `failed` for the short roll, which costs the turn, or `blocked` for a
+## refusal that costs nothing. Both trapping checks are refusals rather than
+## failed rolls: `.cant_escape` returns without writing
 ## `BATTLEPLAYERACTION_USEITEM`, so only `.cant_escape_2` spends the turn.
-##
 ## [param runner_speed] is the Speed the caller hands the routine, which is not
-## always the Pokémon out: `BattleMenu_Run` passes `wBattleMonSpeed` and
-## `AskUseNextPokemon` `wPartyMon1Speed`, and below zero takes the former. The
-## source's `hl` covers the Speed word alone, so the rest is the battle copy's.
+## always the Pokemon out: `BattleMenu_Run` passes `wBattleMonSpeed` and
+## `AskUseNextPokemon` `wPartyMon1Speed`.
 func run_odds(runner_speed: int = -1) -> Dictionary:
 	if battle_type in ALWAYS_ESCAPES:
 		return {"outcome": &"fled", "how": &"battle_type", "battle_type": battle_type}
@@ -1398,16 +1392,12 @@ func send_out(
 	return events
 
 
-## `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation`, which every
-## entrance in the source runs and which are the same three steps on both sides:
-## `ANIM_SEND_OUT_MON`, a second pass of it for a shiny, and the cry Crystal's
-## own `CheckFaintedFrzSlp` allows. Public because a battle's opening entrance is not
-## a [method send_out]: both sides are already standing there when the pics
-## finish sliding, and the screen plays the same list for them.
-##
-## [param ball] is false for `BattleStartMessage`'s wild branch, which is the one
-## entrance with no ball in it: the Pokemon is already standing there when the
-## pics stop sliding, so only the shiny pass and the cry are left of the list.
+## `SendOutPlayerMon` and `ShowSetEnemyMonAndSendOutAnimation`: the same three
+## steps on both sides, `ANIM_SEND_OUT_MON`, a second pass of it for a shiny, and
+## the cry Crystal's `CheckFaintedFrzSlp` allows. Public because a battle's
+## opening entrance is not a [method send_out]. [param ball] is false for
+## `BattleStartMessage`'s wild branch, the one entrance with no ball in it: the
+## Pokemon is already standing there when the pics stop sliding.
 func entrance_events(side: int, ball: bool = true) -> Array:
 	var entering: Gen2BattleMon = mon(side)
 	if entering == null:
@@ -2298,15 +2288,12 @@ func award_win_experience() -> Array:
 
 
 ## What a successful capture owes when a registered policy says a caught wild is
-## worth its experience. `PokeBallEffect` awards none: the wild is filed and the
-## battle ends, so this is an addition rather than a correction, and it is off
-## until [method Gen2ModHost.awards_catch_experience] answers yes.
-##
-## The same pass a faint takes, so the participant set, the Exp. Share split,
-## stat experience, the level ups, the move offers, the happiness gain, the
-## evolution eligibility and the EXP-bar events are one implementation. The
-## opponent is NOT fainted: it is caught and about to be filed, so its HP is left
-## where the throw left it and only the award runs.
+## worth its experience. `PokeBallEffect` awards none, so this is an addition
+## rather than a correction and it is off until
+## [method Gen2ModHost.awards_catch_experience] answers yes. The same pass a faint
+## takes, so participants, the Exp. Share split, level ups, move offers and
+## evolution eligibility are one implementation. The opponent is NOT fainted: its
+## HP is left where the throw left it and only the award runs.
 func award_capture_experience() -> Array:
 	var events: Array = []
 	if data == null or parties.is_empty():

--- a/game/battle/battle_anim_background.gd
+++ b/game/battle/battle_anim_background.gd
@@ -2,14 +2,10 @@ class_name Gen2BattleAnimBackground
 extends RefCounted
 
 ## The video state a battle animation's background effects write, and the
-## primitives they write it with (engine/battle_anims/bg_effects.asm).
-##
-## A bg effect does not draw: it edits the scanline tables, the screen scroll,
-## the DMG palette bytes the CGB palettes are remapped from, and the tilemap the
-## battler's picture sits in. This holds all four, so an effect stays arithmetic
-## the way a motion callback does and a renderer reads the result.
-##
-## Scene-free like the rest of the layer.
+## primitives they write it with (engine/battle_anims/bg_effects.asm). A bg effect
+## does not draw: it edits the scanline tables, the screen scroll, the DMG palette
+## bytes and the tilemap the battler's picture sits in. All four are held here, so
+## an effect stays arithmetic the way a motion callback does.
 
 const SCREEN_WIDTH: int = 20
 const SCREEN_HEIGHT: int = 18
@@ -100,21 +96,13 @@ var bg_map_third: int = 0
 ## `wSurfWaveBGEffect`.
 var surf_wave: PackedByteArray = PackedByteArray()
 
-## What the tilemap effects did to each battler's picture, said plainly beside
-## the map they said it in. Keyed by `player_side`, the same bool the effects
-## already carry.
-##
-## `BattleBGEffect_HideMon`, `..._RemoveMon` and `..._RunPicResizeScript` are the
-## three that move or take away a whole picture, and all three say it by editing
-## `wTilemap`: a renderer with no background plane cannot read a shrink or a
-## removal back out of a 20x18 grid of tile ids, because a resize script's
-## arrangement and a faint sink look the same there. These three are that state
-## said plainly, and [method Gen2BattleScreen.battler_side] is what composes them
-## with the entrance, the faint and the scanline window into one block per side.
-##
-## `visible` is whether a picture is on the square at all, `shift` how far
-## `RemoveMon` has pushed it off in pixels, and `scale` the side of the square
-## the resize script last placed over the side of the whole picture.
+## What the tilemap effects did to each battler's picture, keyed by `player_side`.
+## `BattleBGEffect_HideMon`, `..._RemoveMon` and `..._RunPicResizeScript` all say
+## it by editing `wTilemap`, and a renderer with no background plane cannot read a
+## shrink or a removal back out of a grid of tile ids. `visible` is whether a
+## picture is on the square at all, `shift` how far `RemoveMon` has pushed it off
+## in pixels, and `scale` the side of the square the resize script last placed
+## over the side of the whole picture.
 var battler_visible: Dictionary = {true: true, false: true}
 var battler_shift: Dictionary = {true: Vector2.ZERO, false: Vector2.ZERO}
 var battler_scale: Dictionary = {true: 1.0, false: 1.0}
@@ -133,19 +121,13 @@ const PLAYER_WINDOW_TOP: int = 0x2D
 
 
 ## How far the open scanline window has moved one side's picture, in pixels.
-##
-## Every per-battler deformation is one window over that side's own rows:
 ## Tackle, Withdraw, Dig, Psychic, DoubleTeam, AcidArmor, Wobble, Flail,
 ## WaveDeformMon, BounceDown and Vibrate all move a battler by writing scroll
-## values into it. The mean of the window on the axis `hLCDCPointer` names is
-## what this reports, with the whole-screen scroll taken off because `raster_scx`
-## and `raster_scy` already carry that. A scroll of n draws the content n pixels
-## further left or up, so the picture's own offset is its negation, and a row
-## pushed off with `$90` is not part of the mean: the rows that are left carry
-## the displacement, which is what makes a Withdraw read as a sink.
-##
-## WaveDeformMon and Psychic stretch the picture rather than move it, and there
-## the mean is the honest summary of one rather than an exact answer.
+## values into it. The mean of the window on the axis `hLCDCPointer` names, less
+## the whole-screen scroll `raster_scx`/`raster_scy` already carry. A scroll of n
+## draws n pixels further left or up, so the offset is its negation, and a row
+## pushed off with `$90` is not part of the mean. WaveDeformMon and Psychic
+## stretch rather than move, where the mean is a summary rather than an answer.
 func battler_window_offset(player_side: bool) -> Vector2:
 	if lcdc_pointer != LCDC_SCX and lcdc_pointer != LCDC_SCY:
 		return Vector2.ZERO

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -2,24 +2,13 @@ class_name Gen2BattleAnimBgEffects
 extends RefCounted
 
 ## The `BATTLE_BG_EFFECT_*` jumptable and the routines it dispatches
-## (engine/battle_anims/bg_effects.asm).
-##
-## A bg effect is the half of an animation that is not an object: the screen
-## shakes, the scanline deformations, the palette fades and the tilemap edits
-## that hide, shrink and slide a battler's picture. Five run at once, each a
-## four-byte `battle_bg_effect` the script queues with `anim_bgeffect`.
+## (engine/battle_anims/bg_effects.asm): the screen shakes, the scanline
+## deformations, the palette fades and the tilemap edits. Five run at once.
 ##
 ## **An effect id is profile-local and is never normalised.** pokegold ships no
-## `BATTLE_BG_EFFECT_BODY_SLAM`, so its list is 53 long against Crystal's 54 and
-## every id from $25 on names a different effect in the two games. The two
-## jumptables are kept whole here for that reason, and dispatch is by name.
-##
-## The Color hardware's branch is the one taken wherever the source asks `hCGB`
-## or `hSGB`, which is the same choice every `_CGB_*` layout in this project
-## makes. The DMG halves of `BGEffect_RapidCyclePals` and
-## `BattleBGEffect_FadeMonsToBlackRepeating` are therefore not built; the effects
-## that write `wBGP` unconditionally still reach the screen, because
-## `BattleAnimRequestPals` turns that byte into a CGB palette remap.
+## `BATTLE_BG_EFFECT_BODY_SLAM`, so every id from $25 on names a different effect
+## in the two games; both jumptables are kept whole and dispatch is by name. The
+## Color branch is taken wherever the source asks `hCGB`, as everywhere else here.
 
 ## `BattleBGEffects`, Crystal's own order. The index is the cartridge's effect
 ## id and entry 0 is `BattleBGEffect_End`, which is also the free-slot marker.
@@ -186,6 +175,60 @@ static func names_for(profile: StringName) -> Array[StringName]:
 	return EFFECTS_CRYSTAL if profile == &"crystal" else EFFECTS_GOLD
 
 
+## Every effect whose whole body is one call on the background or the player, as
+## name to [the call, whether it takes the player rather than the background]. A
+## `bind` is the argument the source passes after the two; the handful that write
+## a palette byte themselves are the match in [method run].
+static var HANDLERS: Dictionary = {
+	&"flash_inverted": [_flash.bind(PALS_FLASH_INVERTED), false],
+	&"flash_white": [_flash.bind(PALS_FLASH_WHITE), false],
+	&"white_hues": [_hues.bind(PALS_WHITE_HUES, false), false],
+	&"black_hues": [_hues.bind(PALS_BLACK_HUES, false), false],
+	&"alternate_hues": [_hues.bind(PALS_ALTERNATE_HUES, true), false],
+	&"hide_mon": [_hide_mon, true],
+	&"show_mon": [_show_mon, true],
+	&"enter_mon": [_enter_mon, true],
+	&"return_mon": [_return_mon, true],
+	&"surf": [_surf, false],
+	&"whirlpool": [_whirlpool, true],
+	&"teleport": [_teleport, true],
+	&"night_shade": [_night_shade, true],
+	&"battler_obj_1row": [_battler_obj.bind(false), true],
+	&"battler_obj_2row": [_battler_obj.bind(true), true],
+	&"double_team": [_double_team, true],
+	&"acid_armor": [_acid_armor, true],
+	&"rapid_flash": [_rapid_cycle_pals.bind(PALS_RAPID_FLASH), true],
+	&"fade_mon_to_light": [_rapid_cycle_pals.bind(PALS_TO_LIGHT), true],
+	&"fade_mon_to_black": [_rapid_cycle_pals.bind(PALS_TO_BLACK), true],
+	&"fade_mon_to_light_repeating": [_rapid_cycle_pals.bind(PALS_TO_LIGHT_REPEATING), true],
+	&"fade_mon_to_black_repeating": [_rapid_cycle_pals.bind(PALS_TO_BLACK_REPEATING), true],
+	&"cycle_mon_light_dark_repeating": [_rapid_cycle_pals.bind(PALS_LIGHT_DARK_REPEATING), true],
+	&"flash_mon_repeating": [_rapid_cycle_pals.bind(PALS_FLASH_MON_REPEATING), true],
+	&"fade_mons_to_black_repeating": [_fade_mons_to_black_repeating, true],
+	&"fade_mon_to_white_wait_fade_back": [_rapid_cycle_pals.bind(PALS_TO_WHITE_WAIT_BACK), true],
+	&"fade_mon_from_white": [_rapid_cycle_pals.bind(PALS_FROM_WHITE), true],
+	&"withdraw": [_withdraw, true],
+	&"bounce_down": [_bounce_down, true],
+	&"dig": [_dig, true],
+	&"tackle": [_tackle.bind(false), true],
+	&"body_slam": [_tackle.bind(true), true],
+	&"wobble_mon": [_wobble_mon, true],
+	&"remove_mon": [_remove_mon, true],
+	&"wave_deform_mon": [_wave_deform_mon, true],
+	&"psychic": [_psychic, true],
+	&"beta_send_out_mon1": [_beta_send_out_mon1, true],
+	&"beta_send_out_mon2": [_beta_send_out_mon2, true],
+	&"flail": [_flail, true],
+	&"beta_pursuit": [_beta_pursuit, true],
+	&"rollout": [_rollout, true],
+	&"vital_throw": [_vital_throw, true],
+	&"water": [_water, true],
+	&"vibrate_mon": [_vibrate_mon, true],
+	&"wobble_player": [_wobble_player, true],
+	&"wobble_screen": [_wobble_screen, true],
+}
+
+
 ## `DoBattleBGEffectFunction`. Answers false when the id is past this profile's
 ## own table, which cartridge data never asks for.
 static func run(
@@ -195,118 +238,34 @@ static func run(
 	if effect.id < 0 or effect.id >= names.size():
 		return false
 	var background: Gen2BattleAnimBackground = player.background()
-	match names[effect.id]:
+	var name: StringName = names[effect.id]
+	if HANDLERS.has(name):
+		var row: Array = HANDLERS[name]
+		var subject: Object = background
+		if bool(row[1]):
+			subject = player
+		(row[0] as Callable).call(subject, effect)
+		return true
+	match name:
 		&"end":
 			effect.end()
-		&"flash_inverted":
-			_flash(background, effect, PALS_FLASH_INVERTED)
-		&"flash_white":
-			_flash(background, effect, PALS_FLASH_WHITE)
-		&"white_hues":
-			_hues(background, effect, PALS_WHITE_HUES, false)
-		&"black_hues":
-			_hues(background, effect, PALS_BLACK_HUES, false)
-		&"alternate_hues":
-			_hues(background, effect, PALS_ALTERNATE_HUES, true)
 		&"cycle_ob_pals_gray_and_yellow":
 			background.obp0 = _nth_dmg_pal(effect, PALS_OB_GRAY_YELLOW)
 		&"cycle_mid_ob_pals_gray_and_yellow":
 			background.obp0 = _nth_dmg_pal(effect, PALS_MID_OB_GRAY_YELLOW)
 		&"cycle_bg_pals_inverted":
 			background.bgp = _nth_dmg_pal(effect, PALS_BG_INVERTED)
-		&"hide_mon":
-			_hide_mon(player, effect)
-		&"show_mon":
-			_show_mon(player, effect)
-		&"enter_mon":
-			_enter_mon(player, effect)
-		&"return_mon":
-			_return_mon(player, effect)
-		&"surf":
-			_surf(background, effect)
-		&"whirlpool":
-			_whirlpool(player, effect)
-		&"teleport":
-			_teleport(player, effect)
-		&"night_shade":
-			_night_shade(player, effect)
-		&"battler_obj_1row":
-			_battler_obj(player, effect, false)
-		&"battler_obj_2row":
-			_battler_obj(player, effect, true)
-		&"double_team":
-			_double_team(player, effect)
-		&"acid_armor":
-			_acid_armor(player, effect)
-		&"rapid_flash":
-			_rapid_cycle_pals(player, effect, PALS_RAPID_FLASH)
-		&"fade_mon_to_light":
-			_rapid_cycle_pals(player, effect, PALS_TO_LIGHT)
-		&"fade_mon_to_black":
-			_rapid_cycle_pals(player, effect, PALS_TO_BLACK)
-		&"fade_mon_to_light_repeating":
-			_rapid_cycle_pals(player, effect, PALS_TO_LIGHT_REPEATING)
-		&"fade_mon_to_black_repeating":
-			_rapid_cycle_pals(player, effect, PALS_TO_BLACK_REPEATING)
-		&"cycle_mon_light_dark_repeating":
-			_rapid_cycle_pals(player, effect, PALS_LIGHT_DARK_REPEATING)
-		&"flash_mon_repeating":
-			_rapid_cycle_pals(player, effect, PALS_FLASH_MON_REPEATING)
-		&"fade_mons_to_black_repeating":
-			_fade_mons_to_black_repeating(player, effect)
-		&"fade_mon_to_white_wait_fade_back":
-			_rapid_cycle_pals(player, effect, PALS_TO_WHITE_WAIT_BACK)
-		&"fade_mon_from_white":
-			_rapid_cycle_pals(player, effect, PALS_FROM_WHITE)
 		&"shake_screen_x":
 			background.scx = _shake_amount(background, effect)
 		&"shake_screen_y":
 			background.scy = _shake_amount(background, effect)
-		&"withdraw":
-			_withdraw(player, effect)
-		&"bounce_down":
-			_bounce_down(player, effect)
-		&"dig":
-			_dig(player, effect)
-		&"tackle":
-			_tackle(player, effect, false)
-		&"body_slam":
-			_tackle(player, effect, true)
-		&"wobble_mon":
-			_wobble_mon(player, effect)
-		&"remove_mon":
-			_remove_mon(player, effect)
-		&"wave_deform_mon":
-			_wave_deform_mon(player, effect)
-		&"psychic":
-			_psychic(player, effect)
-		&"beta_send_out_mon1":
-			_beta_send_out_mon1(player, effect)
-		&"beta_send_out_mon2":
-			_beta_send_out_mon2(player, effect)
-		&"flail":
-			_flail(player, effect)
-		&"beta_pursuit":
-			_beta_pursuit(player, effect)
-		&"rollout":
-			_rollout(player, effect)
-		&"vital_throw":
-			_vital_throw(player, effect)
 		&"start_water":
 			background.set_ly_overrides(0)
 			_set_lcd_stat_customs(player, effect, Gen2BattleAnimBackground.LCDC_SCY, false)
 			effect.end()
-		&"water":
-			_water(player, effect)
 		&"end_water":
 			background.reset_lcd_stat_custom()
 			effect.end()
-		&"vibrate_mon":
-			_vibrate_mon(player, effect)
-		&"wobble_player":
-			_wobble_player(player, effect)
-		&"wobble_screen":
-			_wobble_screen(player, effect)
 		_:
 			return false
 	return true

--- a/game/battle/battle_anim_data.gd
+++ b/game/battle/battle_anim_data.gd
@@ -2,15 +2,10 @@ class_name Gen2BattleAnimData
 extends RefCounted
 
 ## The five imported battle animation tables, read the way the cartridge reads
-## them.
-##
-## [Gen2BattleAnimImporter] caches each table as a whole region, table and data
-## together, because every pointer inside one is bank-local. This resolves those
-## pointers: an address minus the region's base is an index into its bytes, which
-## is the same arithmetic `add hl, de` does with the bank paged in.
-##
-## Scene-free and [GameData]-free once built, so a test can hand-build one the
-## way a battle fixture hand-builds a party.
+## them. [Gen2BattleAnimImporter] caches each table as a whole region because
+## every pointer inside one is bank-local; this resolves them, an address minus
+## the region's base being an index into its bytes, which is what `add hl, de`
+## does with the bank paged in.
 
 ## `BattleAnimObjects` row fields, in the order `InitBattleAnimation` copies them.
 const OBJECT_FIELDS: Array[StringName] = [

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -2,18 +2,12 @@ class_name Gen2BattleAnimFunctions
 extends RefCounted
 
 ## The eighty motion callbacks `DoBattleAnimFrame` dispatches
-## (engine/battle_anims/functions.asm), plus the five helpers they are built
-## from.
-##
-## An object row names one of these and the `anim_obj` that spawned it supplies
-## the parameter it reads. Nearly every one is a `BattleAnim_AnonJumptable` over
-## two to four states, which is a match on the object's own `jumptable_index`,
-## and the arithmetic is on that object's coordinates, offsets and two spare
-## bytes. Every value here is a cartridge byte and wraps like one.
-##
-## Scene-free: a callback moves an object and nothing else. The three that reach
-## past the object, the ball palette, the Sky Attack `wOBP0` cycle and Surf's
-## scanline window, write player state a renderer reads rather than drawing.
+## (engine/battle_anims/functions.asm), plus the five helpers they are built from.
+## Nearly every one is a `BattleAnim_AnonJumptable` over two to four states, which
+## is a match on the object's own `jumptable_index`, and every value is a
+## cartridge byte and wraps like one. Scene-free: the three that reach past the
+## object, the ball palette, Sky Attack's `wOBP0` cycle and Surf's scanline
+## window, write player state a renderer reads rather than drawing.
 
 ## `BattleAnimSineWave` has 32 samples over half a turn, so the full turn is 64
 ## and `BattleAnim_Sine` masks its argument with $3f.

--- a/game/battle/battle_anim_object.gd
+++ b/game/battle/battle_anim_object.gd
@@ -2,19 +2,13 @@ class_name Gen2BattleAnimObject
 extends RefCounted
 
 ## One animation object: a `battle_anim_struct` and the two routines that read it
-## (engine/battle_anims/core.asm, engine/battle_anims/helpers.asm).
+## (engine/battle_anims/core.asm, helpers.asm). `anim_obj` names a row of
+## `BattleAnimObjects`, which supplies the frameset, the motion callback, the
+## palette and the graphics sheet, and a place to put it.
 ##
-## An object is spawned by `anim_obj`, which names a row of `BattleAnimObjects`
-## and a place to put it. The row supplies the frameset, the motion callback, the
-## palette and which graphics sheet its tiles come from; the command supplies the
-## coordinates and a parameter the callback reads.
-##
-## Every field is a cartridge byte and is kept as one. The coordinates wrap at
-## 256 because they are single bytes on hardware, and several animations rely on
-## that: an object walking off one side is the wrap, not a clamp.
-##
-## `frame` starts at -1 rather than 0. `GetBattleAnimFrame` increments before it
-## reads, so the first frame drawn is the frameset's first entry.
+## Every field is a cartridge byte: coordinates wrap at 256, and an object walking
+## off one side is that wrap rather than a clamp. `frame` starts at -1 because
+## `GetBattleAnimFrame` increments before it reads.
 
 ## Byte positions inside the struct, as `battleanimobj` orders them. Only the
 ## six a `BattleAnimObjects` row carries; the rest are runtime state.

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -3,15 +3,12 @@ extends RefCounted
 
 ## One battle animation playing: `RunBattleAnimScript`'s frame loop
 ## (engine/battle_anims/anim_commands.asm). [Gen2BattleAnimScript] is the
-## interpreter and knows only bytes, [Gen2BattleAnimObject] is one object and
-## knows only itself; this is what the cartridge does with both once a frame,
-## running the script until it yields, stepping every live object and collecting
-## what they would put in `wShadowOAM`.
-##
-## Scene-free: a frame answers with sprites, a tile window and the palette each
-## sprite wants. All five of `.playframe`'s steps are here, and
-## [method unimplemented] reports what an animation asked for and did not get,
-## which cartridge data no longer produces and a hand-built region still can.
+## interpreter and [Gen2BattleAnimObject] is one object; this is what the
+## cartridge does with both once a frame, running the script until it yields,
+## stepping every live object and collecting what they would put in `wShadowOAM`.
+## Scene-free: a frame answers with sprites, a tile window and a palette per
+## sprite. [method unimplemented] reports what an animation asked for and did not
+## get, which cartridge data no longer produces.
 
 ## `NUM_BATTLE_ANIM_STRUCTS`: an eleventh object is simply not spawned.
 const MAX_OBJECTS: int = 10
@@ -369,18 +366,12 @@ func _load_graphics(operands: Array) -> void:
 
 
 ## `BattleAnimCmd_BattlerGFX_1Row` and `..._2Row`: one or two rows of each
-## battler's picture copied into the top of the animation window, so an effect
-## can lift a battler's feet or head off the tilemap and move them as objects,
-## which three bg effects including `BattleBGEffect_Tackle` do.
-##
-## The two dict entries are crosswise with what is copied, `PLAYERHEAD` holding
-## the enemy's rows and `ENEMYFEET` the player's, and the object rows are crossed
-## the same way, `BATTLE_ANIM_OBJ_ENEMYFEET_*` naming
-## `BATTLE_ANIM_GFX_PLAYERHEAD`, so the two cancel. Both crossings are the
-## cartridge's and neither is tidied.
-##
-## The window tiles these fill name a tile of `vTiles2`, where the battle's own
-## pictures live, in the numbering [Gen2BattleScreenMap] writes.
+## battler's picture copied into the top of the animation window, so an effect can
+## lift a battler's feet or head off the tilemap and move them as objects.
+## The dict entries are crosswise with what is copied, `PLAYERHEAD` holding the
+## enemy's rows, and the object rows are crossed the same way, so the two cancel.
+## Both crossings are the cartridge's and neither is tidied. The window tiles name
+## a tile of `vTiles2` in the numbering [Gen2BattleScreenMap] writes.
 func _load_battler_graphics(rows: int) -> void:
 	var slot: int = _free_tile_dict_slot()
 	if slot < 0 or slot + 1 >= TILE_DICT_ENTRIES:
@@ -486,16 +477,13 @@ func _execute_bg_effects() -> void:
 			_note(&"bg_effects", effect.id)
 
 
-## `BattleAnim_UpdateOAM_All`: every live object stepped and drawn, in slot
-## order, stopping at the first one whose sprites would not fit.
-##
-## The slot's index byte is tested once, at the top of the loop, so an object
-## whose own callback calls `DeinitBattleAnimation` still reaches
-## `BattleAnimOAMUpdate` and is **drawn one last time where it stands**;
-## `DeinitBattleAnimation` clears the index and nothing else, so the frameset
-## steps normally on that pass. Measured against a real cartridge: TACKLE's
-## `anim_incobj 1` frees the target's two rows on the frame it runs and OAM
-## still holds their fourteen sprites for that frame.
+## `BattleAnim_UpdateOAM_All`: every live object stepped and drawn in slot order,
+## stopping at the first whose sprites would not fit. The slot's index byte is
+## tested once, at the top of the loop, so an object whose own callback calls
+## `DeinitBattleAnimation` still reaches `BattleAnimOAMUpdate` and is **drawn one
+## last time where it stands**. Measured against a real cartridge: TACKLE's
+## `anim_incobj 1` frees the target's two rows on the frame it runs and OAM still
+## holds their fourteen sprites for that frame.
 func _update_oam() -> void:
 	_sprites = []
 	for object: Gen2BattleAnimObject in _objects:

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -1,46 +1,25 @@
 class_name Gen2BattleAnimScript
 extends RefCounted
 
-## The battle animation command interpreter
-## (engine/battle_anims/anim_commands.asm).
+## The battle animation command interpreter (engine/battle_anims/anim_commands.asm).
+## Nothing here draws, plays a sound or touches a palette: the commands are
+## reported and whoever is drawing decides what they look like.
 ##
-## Scene-free like the rest of the battle layer: the screen ticks this once per
-## hardware frame and reads back the commands that ran, the way it ticks the
-## bars and the intro. Nothing here draws, plays a sound or touches a palette;
-## the commands are reported and whoever is drawing decides what they look like.
-##
-## A script is a byte stream in one bank. Anything below
-## [constant FIRST_COMMAND] is not a command at all: `RunBattleAnimCommand`
-## stores it in `wBattleAnimDelay` and `.CheckTimer` then decrements it once a
-## frame and runs nothing while it is non-zero, so `anim_wait N` is exactly N
-## frames of pause. Everything from [constant FIRST_COMMAND] up dispatches
-## through `BattleAnimCommands`, which is what [constant COMMANDS] is.
-##
-## The control-flow state is the cartridge's, which means one level of nesting
-## and no more: `anim_call` saves the return address in the single
-## `wBattleAnimParent` word and `anim_loop` counts in the single
-## `wBattleAnimLoops` byte, so a call inside a call or a loop inside a loop
-## loses the outer one. Both are reproduced rather than generalised.
-##
-## `wBattleAnimParam` is an input the battle engine writes before playing
-## (engine/battle/effect_commands.asm), and `wBattleAnimVar` is animation-local:
-## `ClearBattleAnims` zeroes `wLYOverrides` through `wBattleAnimEnd`, which
-## covers the var and not the param.
+## Anything below [constant FIRST_COMMAND] is a delay rather than a command, so
+## `anim_wait N` is exactly N frames. The control flow is the cartridge's single
+## `wBattleAnimParent` word and single `wBattleAnimLoops` byte, so a call inside a
+## call loses the outer one; both are reproduced rather than generalised.
 
 ## `FIRST_BATTLE_ANIM_CMD` (macros/scripts/battle_anims.asm). Every byte under it
 ## is a delay.
 const FIRST_COMMAND: int = 0xD0
 
-## `BattleAnimCommands` in order, from [constant FIRST_COMMAND].
-##
-## The names are the jumptable's, not the macros': `$d9` assembles from
-## `anim_battlergfx_2row` but dispatches to `BattleAnimCmd_BattlerGFX_1Row`, and
-## `$da` the other way round. The routines are what run, so they are what the
-## commands are called here; the two are genuinely crosswise in both pins.
-##
-## `operands` is how many bytes follow the command byte. `target` is where the
-## low byte of a jump address sits inside them, or -1 for a command that never
-## branches.
+## `BattleAnimCommands` in order, from [constant FIRST_COMMAND]. The names are the
+## jumptable's, not the macros': `$d9` assembles from `anim_battlergfx_2row` but
+## dispatches to `BattleAnimCmd_BattlerGFX_1Row`, and `$da` the other way round.
+## The two are genuinely crosswise in both pins. `operands` is how many bytes
+## follow the command byte; `target` is where the low byte of a jump address sits
+## inside them, or -1 for a command that never branches.
 const COMMANDS: Array[Dictionary] = [
 	{"name": &"obj", "operands": 4, "target": -1},
 	{"name": &"gfx_1", "operands": 1, "target": -1},

--- a/game/battle/battle_intro.gd
+++ b/game/battle/battle_intro.gd
@@ -3,27 +3,12 @@ extends RefCounted
 
 ## `BattleIntroSlidingPics` (engine/battle/sliding_intro.asm) is a background
 ## scroll, not a moving object: `SCX` is rewritten part way down the frame so the
-## top band comes in from one side and the middle from the other while the bottom
-## holds. A band edge falls inside the player's status panel, hence per scanline.
-## `InitBattleDisplay.BlankBGMap` leaves everything past the scene blank, so an
-## offset wraps at [constant MAP_WIDTH] and blank scrolls in.
-##
-## The one part of the battle presentation the two games do not share: Crystal
-## drives `wLYOverrides` while pokegold busy-waits on `rLY` and writes `rSCX`
-## twice a frame, so band edges, starting offsets and the walk all differ.
-## Neither band lands on zero (Crystal's middle ends at 2, Gold's top at 4);
-## `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles it and [method
-## finished] is that write.
-##
-## The player is in two pieces while it runs, and reading `.subfunction3` as the
-## overworld's leftovers cost a session: the eighteen sprites it walks are
-## `CopyBackpic.LoadTrainerBackpicAsOAM`'s own, which is the top three tile rows
-## of the player's back pic drawn as OAM. The bottom of that pic is on the
-## background and comes in with the middle band, and the two track each other to
-## within the two pixels `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles.
-## Without the sprites the player has no head and no shoulders for the whole
-## slide. `HideSprites` is what takes them off, after which `PlaceGraphic` puts
-## the whole pic on the background at its own square.
+## top band comes in from one side and the middle from the other, and a band edge
+## falls inside the status panel, hence per scanline. The one part of the battle
+## presentation the two games do not share: Crystal drives `wLYOverrides` while
+## pokegold busy-waits on `rLY`. Neither band lands on zero, and
+## `InitBattleDisplay`'s `xor a` / `ldh [hSCX], a` settles it.
+## [method sprites] says why the player is in two pieces while it runs.
 
 ## 32 tiles of 8, what an offset wraps at; past the screen's 160 is blank.
 const MAP_WIDTH: int = 256
@@ -97,15 +82,13 @@ func advance_frame() -> bool:
 	return true
 
 
-## `.LoadTrainerBackpicAsOAM` and `.subfunction3` together: the player's own
-## eighteen sprites where this frame leaves them, each { tile, x, y } with OAM's
-## own biased coordinates, which is what a renderer of one already takes.
-##
-## Gold and Silver walk the same eighteen: `.LoadTrainerBackpicAsOAM` is
-## byte-identical in both disassemblies and their own `.subfunction1` steps them
-## by two beside its `rSCX` writes. Crystal's walk is measured against a real
-## cartridge, sprite by sprite, from x 158 to 16, and Gold's ends on the same 16:
-## its lead frame spends no step, but its loop skips none either.
+## `.LoadTrainerBackpicAsOAM` and `.subfunction3` together: the top three tile
+## rows of the player's back pic drawn as OAM, where this frame leaves them, each
+## { tile, x, y } with OAM's own biased coordinates. The bottom of that pic is on
+## the background and comes in with the middle band; without the sprites the
+## player has no head or shoulders for the whole slide. Gold and Silver walk the
+## same eighteen, and Crystal's walk is measured against a real cartridge sprite
+## by sprite, x 158 to 16, with Gold ending on the same 16.
 func sprites() -> Array:
 	var out: Array = []
 	if finished():
@@ -151,21 +134,14 @@ func offsets() -> PackedInt32Array:
 	return out
 
 
-## How far the picture standing in each band is from its resting square, along
-## x and in pixels, for a renderer with no background plane to read a scroll off.
-## Zero once the slide has returned.
-##
-## Taken from the band's own arithmetic rather than from the byte [method
-## offsets] reports, because a scroll register cannot say which way a picture is
-## travelling: the two bands come in from opposite sides, and Crystal's middle
-## runs two pixels past its square and back, so the same `$02` reads as +254 or
-## -2 depending only on when in the slide it was sampled. The unwrapped step
-## count has no such ambiguity.
-##
-## The top band carries the opponent, which is in from the left, so its
-## displacement is negative and climbs to zero. The middle carries the player,
-## in from the right, so its own falls to zero and then to the -2 Crystal
-## overshoots by before `InitBattleDisplay`'s `xor a` settles it.
+## How far the picture standing in each band is from its resting square, along x
+## and in pixels, for a renderer with no background plane. Taken from the band's
+## own arithmetic rather than from [method offsets], because a scroll register
+## cannot say which way a picture is travelling: the same `$02` reads as +254 or
+## -2 depending only on when it was sampled. The top band carries the opponent, in
+## from the left, so its displacement climbs to zero; the middle carries the
+## player, in from the right, so its own falls to zero and then to the -2 Crystal
+## overshoots by.
 func enemy_offset() -> float:
 	return 0.0 if finished() else float(-_top_scx())
 

--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -133,16 +133,13 @@ const FORGET_RIGHT: int = 19
 const FORGET_BOTTOM: int = 11
 const FORGET_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_WRAP
 
-## The other three lists a battle puts in front of the player: the pack, the
-## balls it can throw, and the move an Ether goes on.
-##
-## `BattleMenu_Pack` opens `Pack` itself on the cartridge, four pockets with a
-## description under them, and `RestorePPEffect` borrows the same screen. The
-## battle here is handed the flat list of items it can use rather than the
-## pockets, so there is no pocket axis to draw and the box above is what is left:
-## the same rows, opened out to the full width so a count fits beside a name, and
-## `ScrollingMenu`'s arrows for the rows outside the window. The text box below
-## it stays for the description, which is where `UpdateItemDescription` writes.
+## The other three lists a battle puts in front of the player: the pack, the balls
+## it can throw, and the move an Ether goes on. `BattleMenu_Pack` opens `Pack`
+## itself on the cartridge, four pockets with a description under them. The battle
+## here is handed the flat list of usable items rather than the pockets, so there
+## is no pocket axis to draw: the same rows opened out to the full width, with
+## `ScrollingMenu`'s arrows for the rows outside the window and the text box below
+## kept for `UpdateItemDescription`.
 const LIST_LEFT: int = 0
 const LIST_TOP: int = 2
 const LIST_RIGHT: int = 19

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -385,15 +385,12 @@ func reset_stages() -> void:
 
 
 ## What Baton Pass hands to whoever comes in behind it. On the cartridge none of
-## this is the Pokémon's: `wPlayerSubStatus1` through `5` and their counters are
-## battle-position state, cleared on an ordinary entrance only because
-## `NewBattleMonStatus` says so, where `PassedBattleMonEntrance` and
-## `EnemySwitch_SetMode` do not. Here the same state is per-Pokémon and copied
-## across instead, with `ResetBatonPassStatus` naming what does not survive the
-## trip ([method Gen2Battle._reset_baton_pass_status]).
-##
-## The list is [method reset_volatile]'s plus the stages, which is why the two
-## sit together: a field added to one belongs in the other.
+## this is the Pokemon's: `wPlayerSubStatus1` through `5` are battle-position
+## state, cleared on an ordinary entrance only because `NewBattleMonStatus` says
+## so, where `PassedBattleMonEntrance` does not. Here the same state is
+## per-Pokemon and copied across, with `ResetBatonPassStatus` naming what does not
+## survive the trip. The list is [method reset_volatile]'s plus the stages, which
+## is why the two sit together: a field added to one belongs in the other.
 const PASSED_FIELDS: Array[String] = [
 	"substatus", "confusion_turns", "charged_move", "rollout_count",
 	"rampage_turns", "rampage_move", "toxic_counter", "disabled_slot",

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -2,26 +2,13 @@ class_name Gen2BattleRenderer
 extends Control
 
 ## Draws the battle field: two pics, two status panels, two HP bars, the exp bar
-## and whatever a battle animation is putting over them. It does not own the
-## battle; call [method set_battle_data] once, then [method set_view] whenever
-## the screen has new display values to show.
+## and whatever an animation is putting over them. Call [method set_battle_data]
+## once, then [method set_view] whenever the screen has new display values.
 ##
 ## The pics are drawn through `wTilemap` rather than placed at a corner, because
-## that map is what a battle animation edits: `BattleBGEffect_HideMon` blanks a
-## battler's box, `..._RemoveMon` shifts it a column at a time and the pic-resize
-## script stamps smaller arrangements of the same tiles over it. The screen owns
-## the map and hands it in; a tile id is the hardware's, `$00` up for the enemy's
-## front pic and `$31` up for the player's back pic.
-##
-## Panels compose into one screen-sized index buffer drawn over the pics with
-## index 0 transparent: a panel is a shape on a white field, drawn into the
-## background layer on hardware, so the pics show through everything that is not
-## ink.
-##
-## Every background layer is part of one plane, so a scroll applies to all of
-## them alike: the view hands over a per-scanline offset and each layer is
-## scrolled through [Gen2Raster] by the same one. The animation's own objects are
-## not part of that plane and do not scroll, the way OAM does not.
+## that map is what an animation edits. Panels compose into one screen-sized index
+## buffer with index 0 transparent. Every background layer is one plane, so the
+## per-scanline scroll applies to all of them and to none of the objects.
 
 const TILE: int = Gen2Font.TILE
 
@@ -246,20 +233,12 @@ func _bg_map() -> PackedByteArray:
 
 ## One screen-sized index buffer holding every cell of [param map] whose tile id
 ## falls inside this pic's own run, drawn from the pic's padded box. A tile is
-## `base + column * side + row`, which is the column-major order `PlaceGraphic`
-## walks and `.BGSquares` indexes.
-## [param vbank1] is `wAttrmap` bit 3, which is the VRAM bank each cell's tile
-## number is read from, and [param animated] is whether this layer owns bank 1.
-##
-## `PokeAnim_SetVBank1` is the whole reason both are needed. Bank 0 holds the
-## enemy's padded picture at tiles 0 to 48 and the player's back pic from `$31`,
-## which is 49; bank 1 holds the enemy's picture *and* `AnimateFrontpic`'s frames,
-## which run from that same 49. So the two sheets overlap in tile number and are
-## told apart by the bank alone: on a bank 0 cell this layer sees its own square
-## and nothing behind it, on a bank 1 cell only the layer that owns bank 1 draws
-## at all, and it may reach the frames. Reading one flat sheet instead puts the
-## animation's tiles over the player and the player's over the enemy, which is
-## the same defect from either side.
+## `base + column * side + row`, the column-major order `PlaceGraphic` walks.
+## [param vbank1] is `wAttrmap` bit 3 and [param animated] is whether this layer
+## owns bank 1. `PokeAnim_SetVBank1` is why both are needed: bank 1 holds the
+## enemy's picture *and* `AnimateFrontpic`'s frames from the same tile 49, so the
+## two sheets overlap in number and are told apart by the bank alone. One flat
+## sheet puts the animation's tiles over the player and the player's over the enemy.
 func _pic_layer(
 	map: PackedByteArray, base: int, side: int, pixels: PackedByteArray,
 	vbank1: PackedByteArray = PackedByteArray(), animated: bool = false
@@ -574,16 +553,12 @@ func _palette_map(key: String, slot: int) -> int:
 	return int((maps as PackedByteArray)[slot])
 
 
-## The panels, and then each bar over them in its own colour.
-##
-## The hardware gives every background tile its own palette, so a green HP bar
-## sits in a panel of black text without either being separate. Here that is one
-## buffer per palette, which is why the bars are drawn apart from the panels.
-##
-## `BattleAnimClearHud` takes one side off the map for the length of a move
-## animation and `BattleAnimRestoreHuds` puts it back; a battle opening has
-## neither of them up for several seconds. Both are the two per-side keys, and
-## the view's own `hud_visible` is the summary of them.
+## The panels, and then each bar over them in its own colour. The hardware gives
+## every background tile its own palette, so a green HP bar sits in a panel of
+## black text; here that is one buffer per palette, which is why the bars are
+## drawn apart from the panels. `BattleAnimClearHud` takes one side off the map
+## for the length of a move animation and `BattleAnimRestoreHuds` puts it back,
+## and the view's `hud_visible` is the summary of the two per-side keys.
 func _draw_panels() -> void:
 	var raster: Array = _raster_key()
 	var enemy_hp: int = int(_view.get("enemy_hp", 0))

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -16,14 +16,10 @@ signal item_used(item: int, target: int)
 signal enemy_seen(species: int, unown_form: int)
 
 ## Owns the battle, the events and the text box; decides nothing about how they
-## are drawn. A [Gen2Battle] resolves the turn and answers with events; this
-## shows them one at a time, reading every number out of the event rather than
-## asking the engine again, which is why the setters still take plain values.
-##
-## Presentation is a registered renderer, the same boundary the overworld's map
-## goes through: [method _push_view] hands plain display values to whatever
-## [Gen2ModHost] constructs, and the text box stays hardware pixels over it, as
-## menus do over the world renderer.
+## are drawn. A [Gen2Battle] resolves the turn and answers with events; this shows
+## them one at a time, reading every number out of the event rather than asking
+## the engine again. Presentation is a registered renderer, the same boundary the
+## overworld's map goes through, with the text box staying hardware pixels over it.
 
 ## `anim_sound` and `anim_cry` have to reach a player, and a battle had none:
 ## this is the world screen's own route (`game/world/world_screen.gd`).
@@ -534,13 +530,9 @@ func _process(delta: float) -> void:
 
 ## Whether anything is counting hardware frames right now. Public with
 ## [method advance_frame] so a test or a screenshot driver can settle the screen
-## without waiting on real time.
-##
-## An exp bar stopped at a level boundary is waiting on the press that dismisses
-## `.LoopLevels`' textbox, not on frames: it cannot move until
-## [method Gen2ExpBarAnimation.resume]. It is excluded here so a caller draining
-## frames stops instead of spinning, which [method bars_animating] does not do
-## because that answers whether a bar is on screen.
+## without waiting on real time. An exp bar stopped at a level boundary is waiting
+## on the press that dismisses `.LoopLevels`' textbox rather than on frames, so it
+## is excluded and a caller draining frames stops instead of spinning.
 func frames_running() -> bool:
 	var bars: bool = not _bars.is_empty() or (_exp_bar != null and not _exp_bar.paused())
 	return bars or _intro != null or animation_running() or fainting() or sliding() \
@@ -1339,30 +1331,13 @@ func advance_intro() -> bool:
 
 
 ## `BattleStartMessage` and the opening of `DoBattle`, which the sliding pics run
-## straight into and which is the whole of a battle's entrance.
-##
-## One stage per step, spent in order by [method _advance_entrance]. Measured
-## against a real cartridge frame by frame, which is where the frame counts and
-## the two presses come from:
-##
-## | | Wild | Trainer |
-## |---|---|---|
-## | 1 | the shiny pass and the enemy's cry | `SFX_SHINE`, `WaitSFX`, twenty frames |
-## | 2 | the party balls, then the start line, which waits on a press | the same |
-## | 3 | the balls go and the enemy's panel arrives | the balls go and the trainer slides off |
-## | 4 | - | `ShowBattleTextEnemySentOut`, a press, the enemy's ball, cry and panel |
-## | 5 | `DoBattle`'s forty frames | the same |
-## | 6 | the player slides off, `SendOutMonText` prints without waiting | the same |
-## | 7 | the ball, the cry and the player's panel | the same |
-##
-## `AnimateFrontpic` is the enemy's alone and is where its cry comes from:
-## `BattleStartMessage`'s wild branch runs `ANIM_MON_NORMAL` and
-## `ShowSetEnemyMonAndSendOutAnimation` runs `ANIM_MON_SLOW`, both at
-## `hlcoord 12, 0`, and both `jr .skip_cry` past `PlayStereoCry` because the
-## animation plays it. Crystal's alone: pokegold has no `pic_animation.asm` and
-## both of its send-outs reach `PlayStereoCry` directly, which is the
-## `.cry_no_anim` branch and what this project falls back on. The player's own
-## send-out has no animation on either cartridge.
+## straight into: one stage per step, spent in order by
+## [method _advance_entrance]. Measured against a real cartridge frame by frame,
+## which is where the frame counts and the two presses come from.
+## `AnimateFrontpic` is the enemy's alone and is where its cry comes from, both
+## send-outs `jr .skip_cry` past `PlayStereoCry`. Crystal's alone: pokegold has no
+## `pic_animation.asm` and reaches `PlayStereoCry` directly, the `.cry_no_anim`
+## branch this project falls back on. The player's send-out has no animation.
 func _build_entrance() -> void:
 	_entrance_stages = []
 	var text: String = _intro_message
@@ -1724,15 +1699,12 @@ const ANIM_APPEAR_USER: StringName = &"appear_user"
 ## come out of its script.
 const ANIM_SFX: StringName = &"sfx"
 
-## Whose square is showing the substitute's doll rather than the mon itself,
-## keyed by [constant Gen2Battle.PLAYER] and [constant Gen2Battle.ENEMY].
-##
-## The cartridge keeps this in VRAM rather than in a variable: `GetSubstitutePic`
-## writes the doll over the battler's own tiles and `DropPlayerSub` writes the
-## picture back, so what is on the field is whatever was drawn there last. The
-## three writers are the animation's `anim_raisesub` and `anim_dropsub`, the two
-## `noanim` commands the battle-scene option reaches instead, and a send-out,
-## which draws a fresh picture either way.
+## Whose square is showing the substitute's doll rather than the mon itself. The
+## cartridge keeps this in VRAM rather than in a variable: `GetSubstitutePic`
+## writes the doll over the battler's tiles and `DropPlayerSub` writes the picture
+## back, so what is on the field is whatever was drawn last. The three writers are
+## `anim_raisesub`/`anim_dropsub`, the two `noanim` commands the battle-scene
+## option reaches instead, and a send-out.
 var _substitute_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: false}
 
 ## The second answer the same three writers give. `GetBattleMonBackpic` tests
@@ -1759,14 +1731,12 @@ const ANIM_MOVE_LIMIT: int = 0x100
 const ANIM_THROW_POKE_BALL: int = 0x100
 
 ## `.shake_and_break_free`'s four texts, indexed by how many times the ball
-## rocked. `PokeBallEffect` reads `wThrownBallWobbleCount`, which is one higher
-## than the count of rocks; the count itself is what
-## [method Gen2WorldPartyHost._failed_wobbles] answers with. There is no line for
-## a rock on its own: the rocking is the animation, and one of these is the whole
-## of what a failed throw says.
-## `BallBlockedText` and `BallDontBeAThiefText`, which are two boxes rather than
-## one line, and `BallBoxFullText`, said before the ball is even thrown.
-## `_NewDexDataText`, which names the Pokemon and plays a sound of its own.
+## rocked. `PokeBallEffect` reads `wThrownBallWobbleCount`, one higher than the
+## count of rocks, which is what [method Gen2WorldPartyHost._failed_wobbles]
+## answers. There is no line for a rock on its own. Beside them:
+## `BallBlockedText` and `BallDontBeAThiefText`, two boxes rather than one line,
+## `BallBoxFullText`, said before the ball is thrown, and `_NewDexDataText`, which
+## names the Pokemon and plays a sound of its own.
 const NEW_DEX_DATA_TEXT: String = "%s's data\nwas newly added to\nthe #DEX."
 const BALL_BLOCKED_TEXT: String = "The trainer\nblocked the BALL!"
 const BALL_DONT_BE_A_THIEF_TEXT: String = "Don't be a thief!"
@@ -2254,16 +2224,11 @@ func _drawn_exp() -> int:
 
 
 ## Begins the fill [param event]'s award earns, which is `AnimateExpBar`, from
-## the [param from_pixels] the bar stood at before the award was committed.
-##
-## The segments are read out of the events still queued behind this one: one
-## ending at the end of the bar per level this gain crosses, then the partial
-## fill `.FinishExpBar` computes from the exp and level the gain settled on.
-##
-## Two of the routine's own guards return before any of that, and both are kept:
-## a gainer who is not the Pokémon on the field animates nothing
-## (`wCurPartyMon` against `wCurBattleMon`), and neither does one already at
-## `MAX_LEVEL`.
+## the [param from_pixels] the bar stood at before the award was committed. The
+## segments are read out of the events still queued behind this one: one per level
+## crossed, then `.FinishExpBar`'s partial fill. Both of the routine's own guards
+## are kept: a gainer who is not the Pokemon on the field animates nothing
+## (`wCurPartyMon` against `wCurBattleMon`), and neither does one at `MAX_LEVEL`.
 func _start_exp_bar(event: Dictionary, from_pixels: int) -> void:
 	_exp_bar = null
 	if _battle == null or _battle.player == null:
@@ -2418,17 +2383,12 @@ func battle_snapshot() -> Dictionary:
 	}
 
 
-## The plain reading a registered battle-information provider annotates from.
-##
-## Everything such a provider could otherwise only guess at from past events:
+## The plain reading a registered battle-information provider annotates from:
 ## both sides' live stat stages, the weather and what is left of it, who is
-## standing, what is on screen, whether this opponent had been seen in this save
-## before the fight, and the move rows with the exact effectiveness of each
-## against the defender.
-##
-## The effectiveness is [method GameData.type_effectiveness] over the defender's
-## own [method Gen2BattleMon.types], carrying Foresight's identified state, so a
-## provider never copies the type chart, never resolves a dual type itself and
+## standing, what is on screen, whether this opponent had been seen in this save,
+## and each move's exact effectiveness against the defender. That effectiveness is
+## [method GameData.type_effectiveness] over [method Gen2BattleMon.types] carrying
+## Foresight's identified state, so a provider never copies the type chart and
 ## never rebuilds state from the event stream.
 func info_snapshot() -> Dictionary:
 	var player: Gen2BattleMon = _battle.mon(Gen2Battle.PLAYER) if _battle != null else null
@@ -2955,18 +2915,14 @@ func complete_capture(result: Dictionary) -> Dictionary:
 	return result
 
 
-## `PokeBallEffect`'s own `PlayBattleAnim` on `ANIM_THROW_POKE_BALL`, which is
-## the throw, the poof, the opponent going into the ball, the wobbles and the
-## click or the break free: one script, not five.
-##
-## The catch is already resolved when this runs, the way the source resolves it
-## in front of the animation and hands the drawing `wWildMon` and
-## `wThrownBallWobbleCount` rather than a roll. `anim_checkpokeball` is what
-## reads them, so the queue is `GetPokeBallWobble`'s answers in order.
-##
-## The opponent leaving the field and coming back are `BATTLE_BG_EFFECT_RETURN_MON`
-## and `..._ENTER_MON` inside the script, which is why nothing here touches the
-## picture: both report through [method battler_side] like every other resize.
+## `PokeBallEffect`'s own `PlayBattleAnim` on `ANIM_THROW_POKE_BALL`: the throw,
+## the poof, the opponent going in, the wobbles and the click or the break free,
+## one script rather than five. The catch is already resolved when this runs, the
+## way the source resolves it in front of the animation and hands the drawing
+## `wThrownBallWobbleCount` rather than a roll, so the queue is
+## `GetPokeBallWobble`'s answers in order. The opponent leaving and coming back
+## are `BATTLE_BG_EFFECT_RETURN_MON` and `..._ENTER_MON` inside the script, which
+## is why nothing here touches the picture.
 func _begin_capture_animation(ball: int, wobbles: int, caught: bool) -> void:
 	if ball <= 0:
 		return
@@ -3591,41 +3547,14 @@ func advance() -> void:
 ## reached both by the press that dismissed the last box and by
 ## [method _show_next_event] finding no line left to print.
 func _continue_after_messages() -> void:
-	if _box == null:
-		return
-	## `PokeBallEffect` does not return until the naming is over, so nothing
-	## behind it runs while the prompt is up.
-	if _capture_nickname_host != null:
-		return
-	## The same waits [method _resume_after_frames] respects: a box still up, a
-	## line held behind a bar, or frames nobody has spent yet.
-	if _intro != null or bars_animating() or fainting() or animation_running():
-		return
-	## `applydamage` animates the bar and sinks the picture before `criticaltext`
-	## prints, so a line produced while either was running was held rather than
-	## raced. Released here, where every wait it can be held behind ends: a faint
-	## with no bar beside it is one, and the bar pump never sees that frame.
-	if not _held_message.is_empty():
-		var held: String = _held_message
-		_held_message = ""
-		show_message(held)
-		return
-	if _message_awaits_press:
-		return
-	## `BattleStartMessage` and `DoBattle`'s opening: each step is either frames
-	## or a line, so the pump and the press both arrive back here for the next.
-	if _advance_entrance():
+	if _messages_held():
 		return
 	## Nothing is left to print, so the line the box stood beside is gone even
 	## though no event was popped to take it away.
 	_clear_level_up_box()
 	if _capture_selecting or _capture_waiting:
 		return
-	## A list already up owns the joypad: the battle menu, the pack and its two
-	## sub-lists, and the forget offer are each answered by a press rather than
-	## run past by the pump.
-	if _menu_stage != &"" or _pack_selecting or _pack_move_selecting \
-		or _pack_action_stage != &"" or _forget_stage != &"":
+	if _a_list_owns_the_joypad():
 		return
 	if _world_battle_tutorial:
 		return
@@ -3641,73 +3570,10 @@ func _continue_after_messages() -> void:
 	if _show_next_mod_message():
 		return
 	if _capture_terminal:
-		## `BugContest_SetCaughtContestMon` asks before replacing the Pokemon
-		## already caught, over the same `PlaceYesNoBox` a switch offer uses.
-		if bool(_capture_result.get("replace_offer", false)) and _switch_stage == &"":
-			## `DisplayAlreadyCaughtText` before `DisplayCaughtContestMonStats`
-			## and the box: the line about the one already held is prompted past
-			## first, and the question is asked over the comparison.
-			if not _contest_already_caught_said:
-				_contest_already_caught_said = true
-				show_message(CONTEST_ALREADY_CAUGHT_TEXT % _contest_stock_name())
-				return
-			_open_yes_no(&"contest_replace", CONTEST_REPLACE_TEXT)
-			return
-		## `NewDexDataText` and `NewPokedexEntry`, which stand between
-		## `Text_GotchaMonWasCaught` and everything else a catch does. Only for a
-		## species the dex had not caught yet, and only once the player has the
-		## dex at all: `CheckCaughtMon` and `CheckReceivedDex` are both read
-		## before the throw, because the throw is what registers the catch.
-		if _open_new_dex_entry():
-			return
-		## A registered policy's award and every level up, move offer and
-		## evolution flag behind it, spent between `Text_GotchaMonWasCaught` and
-		## `AskGiveNicknameText` so nothing is filed with a level up still owed.
-		if _spend_capture_experience():
-			return
-		if _capture_experience_spent:
-			if not _pending.is_empty():
-				_show_next_event()
-				return
-			if _open_move_learn():
-				return
-		## `.skip_pokedex` reaches `.catch_bug_contest_mon` before either
-		## `AskGiveNicknameText`, so a contest catch is never named.
-		if _open_capture_nickname():
-			return
-		var capture: Dictionary = _capture_result.duplicate(true)
-		if not _capture_nickname.is_empty():
-			capture["nickname"] = _capture_nickname
-		if _capture_experience_spent:
-			## The experience landed on the party the battle owns, so the save
-			## the world holds needs it before that world files the catch.
-			sync_live_party()
-			capture["experience_awarded"] = true
-		_clear_capture_action()
-		_finish_world_capture(capture)
+		_continue_capture()
 		return
-	if not _capture_result.is_empty():
-		## `.UseItem` returns with no carry on a ball that did not land, so
-		## `BattleMenu` falls back into `DoBattle` and the enemy takes the turn
-		## the throw was paid with. Only a catch escapes it, through `.run`.
-		var spent: Dictionary = _capture_spent_turn
-		_capture_spent_turn = {}
-		_clear_capture_action()
-		if not spent.is_empty() and _battle != null and not _battle.is_over():
-			_pending = _battle.take_actions(spent, _enemy_action())
-			if not _pending.is_empty():
-				_show_next_event()
-				return
+	if _continue_capture_turn():
 		return
-	if not _capture_spent_turn.is_empty():
-		## The blocked throw in a trainer battle, whose two boxes are behind it.
-		var blocked: Dictionary = _capture_spent_turn
-		_capture_spent_turn = {}
-		if _battle != null and not _battle.is_over():
-			_pending = _battle.take_actions(blocked, _enemy_action())
-			if not _pending.is_empty():
-				_show_next_event()
-				return
 	if not _pending.is_empty():
 		_show_next_event()
 		return
@@ -3722,32 +3588,142 @@ func _continue_after_messages() -> void:
 	if _replace_the_fallen():
 		return
 	if _battle != null and _battle.is_over():
-		if _world_battle_active and not _battle.has_fled():
-			# A run shows neither a win nor a loss text and blacks nobody out:
-			# `wBattleResult` is DRAW and the party is still standing.
-			if _show_world_battle_terminal_text():
-				return
-			## `.give_money` is the next thing `BattleWon` does once
-			## `PrintWinLossText` has been answered.
-			if _show_prize_money_text():
-				return
-			## `LostBattle`'s `.not_canlose` is the grayscale and a `ret`: the
-			## battle prints nothing about blacking out, because `_WhitedOutText`
-			## belongs to `Script_Whiteout` on the overworld. What is checked
-			## here is only that the party the whiteout will heal can be read.
-			if _battle.winner() != Gen2Battle.PLAYER and not _world_battle_recovery_shown:
-				if not _prepare_world_battle_recovery():
-					return
-				_world_battle_recovery_shown = true
-		## `CheckPayDay` is `.HandleEndOfBattle`'s, outside the battle loop and
-		## behind whichever of the two win or loss texts was printed. A wild
-		## battle reaches it with no `_world_battle_active` in front of it.
-		if _show_pay_day_text():
-			return
-		if _save_battle_result() and _world_battle_active:
-			_finish_world_battle()
+		_finish_battle()
 		return
 	_open_battle_menu()
+
+
+## A list already up owns the joypad: the battle menu, the pack and its two
+## sub-lists, and the forget offer are each answered by a press rather than run
+## past by the pump.
+func _a_list_owns_the_joypad() -> bool:
+	return _menu_stage != &"" or _pack_selecting or _pack_move_selecting \
+		or _pack_action_stage != &"" or _forget_stage != &""
+
+
+## Whether a box, a bar or a frame nobody has spent yet still owns the screen.
+## The same waits [method _resume_after_frames] respects.
+func _messages_held() -> bool:
+	if _box == null:
+		return true
+	## `PokeBallEffect` does not return until the naming is over, so nothing
+	## behind it runs while the prompt is up.
+	if _capture_nickname_host != null:
+		return true
+	if _intro != null or bars_animating() or fainting() or animation_running():
+		return true
+	## `applydamage` animates the bar and sinks the picture before `criticaltext`
+	## prints, so a line produced while either was running was held rather than
+	## raced. Released here, where every wait it can be held behind ends: a faint
+	## with no bar beside it is one, and the bar pump never sees that frame.
+	if not _held_message.is_empty():
+		var held: String = _held_message
+		_held_message = ""
+		show_message(held)
+		return true
+	if _message_awaits_press:
+		return true
+	## `BattleStartMessage` and `DoBattle`'s opening: each step is either frames
+	## or a line, so the pump and the press both arrive back here for the next.
+	return _advance_entrance()
+
+
+## Everything `PokeBallEffect` does between `Text_GotchaMonWasCaught` and handing
+## the catch back to the world.
+func _continue_capture() -> void:
+	## `BugContest_SetCaughtContestMon` asks before replacing the Pokemon
+	## already caught, over the same `PlaceYesNoBox` a switch offer uses.
+	if bool(_capture_result.get("replace_offer", false)) and _switch_stage == &"":
+		## `DisplayAlreadyCaughtText` before `DisplayCaughtContestMonStats`
+		## and the box: the line about the one already held is prompted past
+		## first, and the question is asked over the comparison.
+		if not _contest_already_caught_said:
+			_contest_already_caught_said = true
+			show_message(CONTEST_ALREADY_CAUGHT_TEXT % _contest_stock_name())
+			return
+		_open_yes_no(&"contest_replace", CONTEST_REPLACE_TEXT)
+		return
+	## `NewDexDataText` and `NewPokedexEntry`, which stand between
+	## `Text_GotchaMonWasCaught` and everything else a catch does. Only for a
+	## species the dex had not caught yet, and only once the player has the
+	## dex at all: `CheckCaughtMon` and `CheckReceivedDex` are both read
+	## before the throw, because the throw is what registers the catch.
+	if _open_new_dex_entry():
+		return
+	## A registered policy's award and every level up, move offer and
+	## evolution flag behind it, spent between `Text_GotchaMonWasCaught` and
+	## `AskGiveNicknameText` so nothing is filed with a level up still owed.
+	if _spend_capture_experience():
+		return
+	if _capture_experience_spent:
+		if not _pending.is_empty():
+			_show_next_event()
+			return
+		if _open_move_learn():
+			return
+	## `.skip_pokedex` reaches `.catch_bug_contest_mon` before either
+	## `AskGiveNicknameText`, so a contest catch is never named.
+	if _open_capture_nickname():
+		return
+	var capture: Dictionary = _capture_result.duplicate(true)
+	if not _capture_nickname.is_empty():
+		capture["nickname"] = _capture_nickname
+	if _capture_experience_spent:
+		## The experience landed on the party the battle owns, so the save
+		## the world holds needs it before that world files the catch.
+		sync_live_party()
+		capture["experience_awarded"] = true
+	_clear_capture_action()
+	_finish_world_capture(capture)
+
+
+## The turn a throw was paid with. `.UseItem` returns with no carry on a ball
+## that did not land, so `BattleMenu` falls back into `DoBattle` and the enemy
+## takes it; only a catch escapes, through `.run`. Answers whether the turn it
+## started owns the screen.
+func _continue_capture_turn() -> bool:
+	var thrown: bool = not _capture_result.is_empty()
+	if not thrown and _capture_spent_turn.is_empty():
+		return false
+	## The blocked throw in a trainer battle, whose two boxes are behind it.
+	var spent: Dictionary = _capture_spent_turn
+	_capture_spent_turn = {}
+	if thrown:
+		_clear_capture_action()
+	if not spent.is_empty() and _battle != null and not _battle.is_over():
+		_pending = _battle.take_actions(spent, _enemy_action())
+		if not _pending.is_empty():
+			_show_next_event()
+			return true
+	return thrown
+
+
+## `.HandleEndOfBattle`, outside the battle loop.
+func _finish_battle() -> void:
+	if _world_battle_active and not _battle.has_fled():
+		# A run shows neither a win nor a loss text and blacks nobody out:
+		# `wBattleResult` is DRAW and the party is still standing.
+		if _show_world_battle_terminal_text():
+			return
+		## `.give_money` is the next thing `BattleWon` does once
+		## `PrintWinLossText` has been answered.
+		if _show_prize_money_text():
+			return
+		## `LostBattle`'s `.not_canlose` is the grayscale and a `ret`: the
+		## battle prints nothing about blacking out, because `_WhitedOutText`
+		## belongs to `Script_Whiteout` on the overworld. What is checked
+		## here is only that the party the whiteout will heal can be read.
+		if _battle.winner() != Gen2Battle.PLAYER and not _world_battle_recovery_shown:
+			if not _prepare_world_battle_recovery():
+				return
+			_world_battle_recovery_shown = true
+	## `CheckPayDay` is `.HandleEndOfBattle`'s, outside the battle loop and
+	## behind whichever of the two win or loss texts was printed. A wild
+	## battle reaches it with no `_world_battle_active` in front of it.
+	if _show_pay_day_text():
+		return
+	if _save_battle_result() and _world_battle_active:
+		_finish_world_battle()
 
 
 ## The fought party over the live save, with nothing written to disk.
@@ -3972,15 +3948,12 @@ func _prepare_world_battle_recovery() -> bool:
 	return true
 
 
-## Answers a Baton Pass that stopped the turn, and whether there was one.
-##
-## The player's target is `ForcePickSwitchMonInBattle`, which is the party menu
-## with no way out of it, so the list is opened and the turn stays standing until
-## a row answers it. The enemy's is `FindMonInOTPartyToSwitchIntoBattle`, the
-## AI's own type-matchup pick, which [method Gen2Battle.baton_pass_target] makes.
-##
-## It is answered before a replacement, because a turn left standing here has not
-## finished and nothing behind it can be asked yet.
+## Answers a Baton Pass that stopped the turn, and whether there was one. The
+## player's target is `ForcePickSwitchMonInBattle`, the party menu with no way out
+## of it, so the list stays open until a row answers; the enemy's is
+## `FindMonInOTPartyToSwitchIntoBattle`, which
+## [method Gen2Battle.baton_pass_target] makes. Answered before a replacement,
+## because a turn left standing here has not finished.
 func _answer_baton_pass() -> bool:
 	if _battle == null:
 		return false
@@ -4151,14 +4124,11 @@ func _answer_switch_offer() -> bool:
 
 
 ## `OfferSwitch`'s own `lb bc, 1, 7` through `_YesNoBox`, which stores the left
-## and top coordinates it is handed and adds five and four for the other two
-## (`home/menu.asm`). The flags, the two options and the `db 1` that opens the
-## cursor on YES are `YesNoMenuHeader`'s. `InterpretTwoOptionMenu`'s fifteen
-## frames between the answer and the box coming down are not spent, the way no
-## other menu delay here is.
-## `ItemSubmenu.UsableMenuHeader`'s own `menu_coords 13, 7, SCREEN_WIDTH - 1,
-## TEXTBOX_Y - 1` and its two rows. Every item a battle lists is usable, so
-## `.UnusableMenuData`'s single QUIT row is unreachable here.
+## and top it is handed and adds five and four for the other two. The flags, the
+## options and the `db 1` that opens the cursor on YES are `YesNoMenuHeader`'s.
+## `InterpretTwoOptionMenu`'s fifteen frames are not spent, as no menu delay here
+## is. Below: `ItemSubmenu.UsableMenuHeader`'s two rows. Every item a battle lists
+## is usable, so `.UnusableMenuData`'s single QUIT row is unreachable here.
 const PACK_ACTION_LEFT: int = 13
 const PACK_ACTION_TOP: int = 7
 const PACK_ACTION_SPAN: Vector2i = Vector2i(6, 4)
@@ -5797,18 +5767,12 @@ func _build_renderer() -> void:
 	_apply_renderer_interface_style()
 
 
-## Who fills the buffer SCREEN FILL gave the fight.
-##
-## The built-in arena is `_BattleScene`'s own 160x144 and has nothing to put in a
-## wider buffer, exactly like the pack or the PC, so the screen fills the
-## surround with the arena's own field. A renderer on the native layer, staged on
-## the map the encounter fired on, has the same world the overworld was filling
-## the window with a frame earlier and fills the surface itself, so the mask
-## would only crop it.
-##
-## The interface does not move either way: the panels, the bars and the boxes are
-## hardware pixels laid out in 160x144 and stay in the rectangle
-## [Gen2Screen] centres in the buffer.
+## Who fills the buffer SCREEN FILL gave the fight. The built-in arena is
+## `_BattleScene`'s own 160x144 and has nothing to put in a wider buffer, so the
+## screen fills the surround with the arena's own field. A renderer on the native
+## layer, staged on the map the encounter fired on, fills the surface itself and
+## the mask would only crop it. The interface does not move either way: panels,
+## bars and boxes stay in the rectangle [Gen2Screen] centres in the buffer.
 func _apply_screen_fill() -> void:
 	_screen.interface_masked = Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
 
@@ -6014,15 +5978,12 @@ func _push_view() -> void:
 	_refresh_annotations()
 
 
-## What is standing on one side's square, whether it is on it, how far it is
-## from resting there and how big it is drawn. `docs/MODS.md` documents the
-## block; this is where it is filled.
-##
+## What is standing on one side's square, whether it is on it, how far it is from
+## resting there and how big it is drawn; `docs/MODS.md` documents the block.
 ## Every other battler field says it in the terms the hardware draws it in, so a
 ## renderer with no background plane would have to rebuild host state to read a
-## faint, a recall or a deformation. These four say it plainly instead, read out
-## of the state the screen already runs (`faint_step`, `slide_step`, the resize
-## scripts and the scanline window) rather than simulated again.
+## faint, a recall or a deformation. These four are read out of the state the
+## screen already runs rather than simulated again.
 func battler_side(side: int) -> Dictionary:
 	var player_side: bool = side == Gen2Battle.PLAYER
 	var backpic: String = _player_backpic if player_side else ""

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -1,19 +1,12 @@
 class_name Gen2BattleScreenMap
 extends RefCounted
 
-## `wTilemap` as a battle leaves it: which tile of which battler's picture sits
-## in each of the 20x18 cells.
-##
-## A battle animation does not draw a picture, it edits this map:
-## `BattleBGEffect_HideMon` blanks a battler's box, `..._RemoveMon` shifts it a
-## column at a time, `..._EnterMon` and `..._ReturnMon` stamp smaller
-## arrangements of the same tiles, and `AppearUser` puts a whole one back. The
-## screen owns the map, hands it to [Gen2BattleAnimBackground] before an
-## animation and takes back whatever the animation left, which is why a Fly is
-## still gone after its own animation ends.
-##
-## Node-free: a map is data, so what an effect did to one can be asserted
-## headless.
+## `wTilemap` as a battle leaves it: which tile of which battler's picture sits in
+## each of the 20x18 cells. An animation does not draw a picture, it edits this
+## map, and the screen hands it to [Gen2BattleAnimBackground] and takes back
+## whatever the animation left, which is why a Fly is still gone after its own
+## animation ends. Node-free: a map is data, so what an effect did to one can be
+## asserted headless.
 
 const COLUMNS: int = Gen2BattleAnimBackground.SCREEN_WIDTH
 const ROWS: int = Gen2BattleAnimBackground.SCREEN_HEIGHT

--- a/game/battle/battle_switch_menu.gd
+++ b/game/battle/battle_switch_menu.gd
@@ -2,19 +2,13 @@ class_name Gen2BattleSwitchMenu
 extends RefCounted
 
 ## `PickSwitchMonInBattle` and `ForcePickSwitchMonInBattle`
-## (`engine/battle/core.asm`).
-##
-## Three callers, one list. `OfferSwitch`'s YES can be backed out of; Baton Pass
-## reaches `ForcePickPartyMonInBattle`, which cannot and answers a refusal with
-## `SFX_WRONG` and the list again; `ForcePlayerMonChoice` is that forced list one
-## wrapper lower, so it makes no `SwitchMonAlreadyOut` check, which costs nothing
-## because `CheckIfCurPartyMonIsFitToFight` refuses the fainted slot first. Both
-## wrap `PickPartyMonInBattle` and its two refusals.
-##
-## Scene-free: [Gen2PartyMenuPage] draws the rows and the battle screen owns the
-## presses. `SetUpBattlePartyMenu` goes through `InitPartyMenuWithCancel`, so
-## CANCEL is a row in both variants and the forced one refuses rather than drops
-## it.
+## (`engine/battle/core.asm`): three callers, one list. `OfferSwitch`'s YES can be
+## backed out of; Baton Pass reaches `ForcePickPartyMonInBattle`, which cannot and
+## answers a refusal with `SFX_WRONG` and the list again; `ForcePlayerMonChoice`
+## is that forced list one wrapper lower, so it makes no `SwitchMonAlreadyOut`
+## check. Scene-free: [Gen2PartyMenuPage] draws the rows and the battle screen
+## owns the presses, and CANCEL is a row in both variants because
+## `SetUpBattlePartyMenu` goes through `InitPartyMenuWithCancel`.
 
 ## `PartyMenu2DMenuData`'s `_2DMENU_WRAP_UP_DOWN`, its only movement flag.
 const WRAPS: bool = true

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -2,18 +2,12 @@ class_name Gen2BattleTransition
 extends RefCounted
 
 ## `DoBattleTransition` (engine/battle/battle_transition.asm): what the overworld
-## does between the encounter and the battle screen.
-##
-## Four animations, picked by the lead's level against the opponent's and by the
-## environment, each of them a Poke Ball drawn over the map for a trainer, three
-## passes of a palette flash, and then one of four ways of going black. The
-## jumptable is walked one entry per frame, which is what `DoBattleTransition`'s
-## own `.loop` does with its `DelayFrame`.
-##
-## Node-free: it answers with a screen of cells, a DMG palette order and a
-## per-scanline offset, and the world screen draws those over whatever it was
-## already drawing. Nothing here reaches a renderer, so a whole transition can be
-## stepped and read headless.
+## does between the encounter and the battle screen. Four animations, picked by
+## the lead's level against the opponent's and by the environment, three passes of
+## a palette flash, then one of four ways of going black. The jumptable is walked
+## one entry per frame, which is `.loop`'s own `DelayFrame`. Node-free: it answers
+## with a screen of cells, a DMG palette order and a per-scanline offset, so a
+## whole transition can be stepped headless.
 
 const COLUMNS: int = 20
 const ROWS: int = 18
@@ -143,17 +137,12 @@ const SINE_STEP_FRAMES: Array[int] = [2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 
 ## the Route 30 trace it runs on frame 813 and `..._SetUpBGMap` on 817.
 const BALL_FRAMES: int = 3
 
-## `DoBattleTransition.InitGFX` before the jumptable, and `.done` after it.
-##
-## Both are runs of VRAM copies this port does at once: `ReanchorBGMap`,
-## `Request2bpp` twice for the two tiles and again for the forty the BG map is
-## filled with, `BattleStart_CopyTilemapAtOnce`, and then the palette wipe at the
-## end. The counts are measured against a real cartridge rather than derived,
-## because a `WaitBGMap` is worth whatever the copy in front of it left.
-## `.InitGFX` is 19 frames on that trace, 793 to 811, and
-## `..._DetermineWhichAnimation` is the twentieth. The tail is
-## `StartTrainerBattle_Finish` on 959, the loop's own `DelayFrame` behind it and
-## `.done`'s two, which is the screen fully black on 962.
+## `DoBattleTransition.InitGFX` before the jumptable, and `.done` after it. Both
+## are runs of VRAM copies this port does at once, and the counts are measured
+## against a real cartridge rather than derived, because a `WaitBGMap` is worth
+## whatever the copy in front of it left. `.InitGFX` is 19 frames on that trace,
+## 793 to 811, and `._DetermineWhichAnimation` is the twentieth; the tail is
+## `StartTrainerBattle_Finish` on 959 and the screen fully black on 962.
 const LEAD_FRAMES: int = 19
 const TAIL_FRAMES: int = 4
 

--- a/game/battle/battle_world_context.gd
+++ b/game/battle/battle_world_context.gd
@@ -1,20 +1,13 @@
 class_name Gen2BattleWorldContext
 extends RefCounted
 
-## Where a battle is being fought, as the world was when it started.
-##
-## [Gen2BattleScreen] hands a battle renderer display values and nothing else,
-## which is all the cartridge's own battle needs. A renderer staging the fight on
-## the map instead of on a white field needs the place as well, so this carries
-## it: the map and its tileset, the player's cell and facing, and the time of day
-## the world was drawn with.
-##
-## It is a copy taken at battle start, not a handle on the world: a renderer
-## cannot reach live world state through it and the two screens stay
-## independent. The map and tileset are named by number, which is what
-## [method GameData.world_map] and [method GameData.world_tileset] take, so a
-## renderer resolves the records it wants through the [GameData] it was already
-## given.
+## Where a battle is being fought, as the world was when it started: the map and
+## its tileset, the player's cell and facing, and the time of day. A renderer
+## staging the fight on the map rather than on a white field needs the place as
+## well as the display values [Gen2BattleScreen] hands it. A copy taken at battle
+## start, not a handle on the world, so the two screens stay independent; the map
+## and tileset are named by number, which is what [method GameData.world_map]
+## takes.
 
 ## Group and number, the pair every map is addressed by, as
 ## [member Gen2WorldSnapshot.map_id] holds it.

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -1,18 +1,14 @@
 class_name Gen2Damage
 extends RefCounted
 
-## The damage formula, in the order and the arithmetic the hardware uses.
-##
-## Every step truncates and none of them commute, so this is a sequence rather
-## than an expression: the matchup applies one type at a time with a truncation
-## between, the critical multiplier lands before the cap and minimum, and the
-## spread after everything.
-##
-## The cartridge's four commands are [method damage_stats], [method damage_calc],
-## [method stab_damage] and [method apply_variation], run one at a time by
-## [Gen2EffectCommands] because half a dozen effects write between two of them.
-## [method calculate_with] is the composition, for a caller with no list to put
-## the four in.
+## The damage formula, in the order and the arithmetic the hardware uses. Every
+## step truncates and none of them commute, so this is a sequence rather than an
+## expression: the matchup applies one type at a time with a truncation between,
+## the critical multiplier lands before the cap and minimum, and the spread after
+## everything. The cartridge's four commands are [method damage_stats],
+## [method damage_calc], [method stab_damage] and [method apply_variation], run
+## one at a time because half a dozen effects write between two of them;
+## [method calculate_with] is the composition.
 
 ## The cap lands before the minimum is added, so the biggest hit is 999 and the
 ## smallest that connects at all is 2.
@@ -54,19 +50,13 @@ const TRUNCATE_SHIFT: int = 4
 
 
 ## A hit with both rolls decided: deterministic, and the whole formula, for a
-## caller (the AI, a test) that has no list to put the four steps in. Present,
-## Triple Kick, Fury Cutter and Rollout each write between two of them, which is
-## why the effect commands call the four rather than this.
-##
-## Returns { damage, critical, effectiveness, stab, immune }.
-## [code]effectiveness[/code] is in tenths and is the announced number, not
-## always the one damage used (see [method GameData.type_effectiveness]);
-## [code]immune[/code] is a matchup of zero, which is a miss rather than a hit
-## for nothing.
-##
-## Selfdestruct's halved defense comes off the move's own effect byte here, the
-## way `BattleCommand_DamageCalc` reads it, so a caller predicting a hit gets the
-## same number the hit will deal.
+## caller with no list to put the four steps in. Present, Triple Kick, Fury Cutter
+## and Rollout each write between two of them, which is why the effect commands
+## call the four rather than this. Returns { damage, critical, effectiveness,
+## stab, immune }: the effectiveness is in tenths and is the announced number
+## rather than always the one damage used, and `immune` is a matchup of zero.
+## Selfdestruct's halved defense comes off the move's own effect byte, the way
+## `BattleCommand_DamageCalc` reads it.
 static func calculate_with(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -244,15 +234,13 @@ static func base_damage(level: int, power: int, attack: int, defense: int) -> in
 	return out
 
 
-## `TruncateHL_BC`: both stats shifted right two bits at a time until each fits
-## in a byte, flooring at one. Not cosmetic: `base_damage` multiplies by the
-## attack before it divides by the defense, so shifting both changes the answer.
-##
+## `TruncateHL_BC`: both stats shifted right two bits at a time until each fits in
+## a byte, flooring at one. Not cosmetic: `base_damage` multiplies by the attack
+## before it divides by the defense, so shifting both changes the answer.
 ## [param crystal] is the single-player fix, `.finish` looping back while
-## `wLinkMode` is not `LINK_COLOSSEUM`. pokegold has no such check, so one pass
-## is all a value gets and anything still over a byte wraps, which is
-## `docs/bugs_and_glitches.md`'s "Reflect and Light Screen can make (Special)
-## Defense wrap around above 1024".
+## `wLinkMode` is not `LINK_COLOSSEUM`. pokegold has no such check, so anything
+## still over a byte wraps, which is `docs/bugs_and_glitches.md`'s Reflect and
+## Light Screen wrap.
 static func truncate_stats(attack: int, defense: int, crystal: bool = true) -> Array:
 	var out_attack: int = attack
 	var out_defense: int = defense
@@ -514,14 +502,11 @@ static func _defense_stat(
 
 
 ## `DittoMetalPowder`, called at `.done` after `TruncateHL_BC`, so the half again
-## lands on the byte rather than on the stat it was truncated from.
-##
-## Its overflow is reproduced by default: `srl a / add c` carries for a byte over
-## 170 and the recovery halves the *attack* and shifts the carry back into the
-## defence, which is `docs/bugs_and_glitches.md`'s "Metal Powder can increase
-## damage taken with boosted (Special) Defense". Turning
-## `metal_powder_overflow` off keeps the boosted defence at the byte it would
-## have overflowed past, which is what the boost was for.
+## lands on the byte rather than on the stat it was truncated from. Its overflow
+## is reproduced by default: `srl a / add c` carries for a byte over 170 and the
+## recovery halves the *attack* and shifts the carry back into the defence, which
+## is `docs/bugs_and_glitches.md`'s Metal Powder entry. Turning
+## `metal_powder_overflow` off keeps the boosted defence at the byte instead.
 static func metal_powder_pair(defender: Gen2BattleMon, pair: Array) -> Array:
 	if defender == null or not Gen2HeldItem.boosts_defence(defender.species, defender.item):
 		return pair

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -1,17 +1,13 @@
 class_name Gen2EffectCommands
 extends RefCounted
 
-## The steps a move is made of.
-##
-## A move is a short program rather than a switch case: the cartridge keeps a
-## command list per effect and runs it in order. An ordinary attack announces,
-## spends the PP, works out damage, rolls the hit, applies it and checks for a
-## faint, and every other move is that list with steps added, removed or replaced.
-## None of it reaches [Gen2Battle], which only runs a list.
-##
-## The names are the cartridge's, so a sequence reads against
-## [code]data/moves/effects.asm[/code] line for line; [Gen2MoveEffect] holds
-## them.
+## The steps a move is made of. A move is a short program rather than a switch
+## case: the cartridge keeps a command list per effect and runs it in order. An
+## ordinary attack announces, spends the PP, works out damage, rolls the hit,
+## applies it and checks for a faint, and every other move is that list with steps
+## added, removed or replaced. None of it reaches [Gen2Battle], which only runs a
+## list. The names are the cartridge's, so a sequence reads against
+## `data/moves/effects.asm` line for line.
 
 ## Announces the move. First, because a move that fails still says it was used.
 const USED_MOVE_TEXT: StringName = &"usedmovetext"
@@ -586,267 +582,159 @@ static func is_engine_command(command: StringName) -> bool:
 	return _engine_commands.has(command)
 
 
+## Every command whose whole body is one call, name to that call. A `bind` is the
+## second argument the source passes; the commands with more than one step are the
+## match in [method run].
+static var HANDLERS: Dictionary = {
+	USED_MOVE_TEXT: _used_move_text,
+	DO_TURN: _do_turn,
+	CRITICAL: _critical,
+	DAMAGE_STATS: _damage_stats,
+	DAMAGE_CALC: _damage_calc,
+	STAB: _stab,
+	DAMAGE_VARIATION: _damage_variation,
+	DOUBLE_DAMAGE: _double_damage,
+	HAPPINESS_POWER: _happiness_power.bind(false),
+	FRUSTRATION_POWER: _happiness_power.bind(true),
+	GET_MAGNITUDE: _get_magnitude,
+	HIDDEN_POWER: _hidden_power,
+	PRESENT: _present,
+	FURY_CUTTER: _fury_cutter,
+	TRIPLE_KICK: _triple_kick,
+	KICK_COUNTER: _kick_counter,
+	FALSE_SWIPE: _false_swipe,
+	RESET_TYPE_MATCHUP: _reset_type_matchup,
+	HEAL_BELL: _heal_bell,
+	SNORE: _snore,
+	TRI_STATUS_CHANCE: _tri_status_chance,
+	DEFROST: _defrost_user,
+	SPLASH: _splash,
+	MIRROR_MOVE: _mirror_move,
+	MIMIC: _mimic,
+	METRONOME: _metronome,
+	SKETCH: _sketch,
+	SLEEP_TALK: _sleep_talk,
+	CONVERSION: _conversion,
+	CONVERSION_2: _conversion_2,
+	STORE_ENERGY: _store_energy,
+	UNLEASH_ENERGY: _unleash_energy,
+	RAGE: _rage,
+	RAGE_DAMAGE: _rage_damage,
+	BUILD_OPPONENT_RAGE: _build_opponent_rage,
+	CHECK_FUTURE_SIGHT: _check_future_sight,
+	FUTURE_SIGHT: _future_sight,
+	PAY_DAY: _pay_day,
+	TRANSFORM: _transform,
+	SWITCH_TURN: _switch_turn,
+	CHECK_IMMUNE: _check_immune,
+	CHECK_HIT: _check_hit,
+	COUNTER: _counter.bind(false),
+	MIRROR_COAT: _counter.bind(true),
+	SELFDESTRUCT: _selfdestruct,
+	APPLY_DAMAGE: _apply_damage,
+	RECOIL: _recoil,
+	CHECK_FAINT: _check_faint,
+	CHECK_STATUS: _check_status,
+	EFFECT_CHANCE: _effect_chance,
+	SLEEP_TARGET: _status_target.bind(Gen2Status.SLEEP_MASK),
+	POISON_TARGET: _status_target.bind(Gen2Status.POISON),
+	BURN_TARGET: _status_target.bind(Gen2Status.BURN),
+	FREEZE_TARGET: _status_target.bind(Gen2Status.FREEZE),
+	PARALYZE_TARGET: _status_target.bind(Gen2Status.PARALYSIS),
+	TOXIC_TARGET: _toxic_target,
+	FLINCH_TARGET: _flinch_target,
+	CONFUSE_TARGET: _confuse_target,
+	DRAIN_TARGET: _drain_target,
+	FIXED_DAMAGE: _fixed_damage,
+	OHKO: _ohko,
+	RECHARGE: _recharge,
+	CHARGE_MOVE: _check_charge,
+	CHARGE: _charge,
+	END_LOOP: _end_loop,
+	ROLLOUT_CHECK: _rollout_check,
+	ROLLOUT_POWER: _rollout_power,
+	CHECK_RAMPAGE: _check_rampage,
+	RAMPAGE: _rampage,
+	CURL: _curl,
+	HAZE: _haze,
+	BELLY_DRUM: _belly_drum,
+	PSYCH_UP: _psych_up,
+	DISABLE: _disable,
+	ENCORE: _encore,
+	ATTRACT: _attract,
+	MIST: _mist,
+	FOCUS_ENERGY: _focus_energy,
+	TRAP_TARGET: _trap_target,
+	ARENA_TRAP: _arena_trap,
+	START_RAIN: _start_weather.bind(Gen2Weather.RAIN),
+	START_SUN: _start_weather.bind(Gen2Weather.SUN),
+	START_SANDSTORM: _start_weather.bind(Gen2Weather.SANDSTORM),
+	SCREEN: _screen,
+	SAFEGUARD: _safeguard,
+	PERISH_SONG: _perish_song,
+	SUBSTITUTE: _substitute,
+	LEECH_SEED: _leech_seed,
+	NIGHTMARE: _nightmare,
+	CURSE: _curse,
+	SPIKES: _spikes,
+	CLEAR_HAZARDS: _clear_hazards,
+	PROTECT: _protect,
+	ENDURE: _endure,
+	DESTINY_BOND: _destiny_bond,
+	FORCE_SWITCH: _force_switch,
+	BATON_PASS: _baton_pass,
+	TELEPORT: _teleport,
+	FORESIGHT: _foresight,
+	LOCK_ON: _lock_on,
+	SPITE: _spite,
+	PAIN_SPLIT: _pain_split,
+	THIEF: _thief,
+	PURSUIT: _pursuit,
+	BEAT_UP: _beat_up,
+	BEAT_UP_FAIL_TEXT: _beat_up_fail_text,
+	CHECK_SAFEGUARD: _check_safeguard,
+	HEAL: _heal,
+	TIMED_HEAL: _timed_heal,
+	THUNDER_ACCURACY: _thunder_accuracy,
+	SKIP_SUN_CHARGE: _skip_sun_charge,
+	MOVE_ANIM_NO_SUB: _move_anim,
+	LOWER_SUB: _lower_sub,
+	RAISE_SUB: _raise_sub,
+	LOWER_SUB_NO_ANIM: _sub_pic.bind(false),
+	STAT_UP_ANIM: _stat_change_anim.bind(Gen2BattleAnimPlayer.AFTER_ANIM_NONE),
+	KINGS_ROCK: _kings_rock,
+	ALL_STATS_UP: _all_stats_up,
+	STAT_UP_MESSAGE: _stat_message,
+	STAT_DOWN_MESSAGE: _stat_message,
+	STAT_UP_FAIL_TEXT: _stat_fail_text,
+	STAT_DOWN_FAIL_TEXT: _stat_fail_text,
+}
+
+
 ## Runs one command against [param turn]. An unknown command is an error rather
 ## than a no-op, a sequence naming a step nobody wrote being a move that quietly
 ## does less. A mod's own is reached through [Gen2MoveEffect] after this refuses.
 static func run(command: StringName, turn: Gen2Turn) -> void:
+	if HANDLERS.has(command):
+		(HANDLERS[command] as Callable).call(turn)
+		return
 	match command:
-		USED_MOVE_TEXT:
-			_used_move_text(turn)
-		DO_TURN:
-			_do_turn(turn)
-		CRITICAL:
-			_critical(turn)
-		DAMAGE_STATS:
-			_damage_stats(turn)
-		DAMAGE_CALC:
-			_damage_calc(turn)
-		STAB:
-			_stab(turn)
-		DAMAGE_VARIATION:
-			_damage_variation(turn)
-		DOUBLE_DAMAGE:
-			_double_damage(turn)
-		HAPPINESS_POWER:
-			_happiness_power(turn, false)
-		FRUSTRATION_POWER:
-			_happiness_power(turn, true)
-		GET_MAGNITUDE:
-			_get_magnitude(turn)
-		HIDDEN_POWER:
-			_hidden_power(turn)
-		PRESENT:
-			_present(turn)
-		FURY_CUTTER:
-			_fury_cutter(turn)
-		TRIPLE_KICK:
-			_triple_kick(turn)
-		KICK_COUNTER:
-			_kick_counter(turn)
-		FALSE_SWIPE:
-			_false_swipe(turn)
-		RESET_TYPE_MATCHUP:
-			_reset_type_matchup(turn)
-		HEAL_BELL:
-			_heal_bell(turn)
-		SNORE:
-			_snore(turn)
-		TRI_STATUS_CHANCE:
-			_tri_status_chance(turn)
-		DEFROST:
-			_defrost_user(turn)
-		SPLASH:
-			_splash(turn)
-		MIRROR_MOVE:
-			_mirror_move(turn)
-		MIMIC:
-			_mimic(turn)
-		METRONOME:
-			_metronome(turn)
-		SKETCH:
-			_sketch(turn)
-		SLEEP_TALK:
-			_sleep_talk(turn)
-		CONVERSION:
-			_conversion(turn)
-		CONVERSION_2:
-			_conversion_2(turn)
-		STORE_ENERGY:
-			_store_energy(turn)
-		UNLEASH_ENERGY:
-			_unleash_energy(turn)
-		RAGE:
-			_rage(turn)
-		RAGE_DAMAGE:
-			_rage_damage(turn)
-		BUILD_OPPONENT_RAGE:
-			_build_opponent_rage(turn)
-		CHECK_FUTURE_SIGHT:
-			_check_future_sight(turn)
-		FUTURE_SIGHT:
-			_future_sight(turn)
-		PAY_DAY:
-			_pay_day(turn)
-		TRANSFORM:
-			_transform(turn)
-		SWITCH_TURN:
-			_switch_turn(turn)
-		CHECK_IMMUNE:
-			_check_immune(turn)
-		CHECK_HIT:
-			_check_hit(turn)
-		COUNTER:
-			_counter(turn, false)
-		MIRROR_COAT:
-			_counter(turn, true)
-		SELFDESTRUCT:
-			_selfdestruct(turn)
-		APPLY_DAMAGE:
-			_apply_damage(turn)
-		RECOIL:
-			_recoil(turn)
-		CHECK_FAINT:
-			_check_faint(turn)
 		END_MOVE:
 			turn.end()
-		CHECK_STATUS:
-			_check_status(turn)
-		EFFECT_CHANCE:
-			_effect_chance(turn)
-		SLEEP_TARGET:
-			_status_target(turn, Gen2Status.SLEEP_MASK)
-		POISON_TARGET:
-			_status_target(turn, Gen2Status.POISON)
-		BURN_TARGET:
-			_status_target(turn, Gen2Status.BURN)
-		FREEZE_TARGET:
-			_status_target(turn, Gen2Status.FREEZE)
-		PARALYZE_TARGET:
-			_status_target(turn, Gen2Status.PARALYSIS)
-		TOXIC_TARGET:
-			_toxic_target(turn)
-		FLINCH_TARGET:
-			_flinch_target(turn)
-		CONFUSE_TARGET:
-			_confuse_target(turn)
-		DRAIN_TARGET:
-			_drain_target(turn)
-		FIXED_DAMAGE:
-			_fixed_damage(turn)
-		OHKO:
-			_ohko(turn)
-		RECHARGE:
-			_recharge(turn)
-		CHARGE_MOVE:
-			_check_charge(turn)
-		CHARGE:
-			_charge(turn)
 		END_TURN:
 			turn.end()
 		START_LOOP:
 			turn.attacker().rollout_count = 0
-		END_LOOP:
-			_end_loop(turn)
-		ROLLOUT_CHECK:
-			_rollout_check(turn)
-		ROLLOUT_POWER:
-			_rollout_power(turn)
-		CHECK_RAMPAGE:
-			_check_rampage(turn)
-		RAMPAGE:
-			_rampage(turn)
-		CURL:
-			_curl(turn)
-		HAZE:
-			_haze(turn)
-		BELLY_DRUM:
-			_belly_drum(turn)
-		PSYCH_UP:
-			_psych_up(turn)
-		DISABLE:
-			_disable(turn)
-		ENCORE:
-			_encore(turn)
-		ATTRACT:
-			_attract(turn)
-		MIST:
-			_mist(turn)
-		FOCUS_ENERGY:
-			_focus_energy(turn)
-		TRAP_TARGET:
-			_trap_target(turn)
-		ARENA_TRAP:
-			_arena_trap(turn)
-		START_RAIN:
-			_start_weather(turn, Gen2Weather.RAIN)
-		START_SUN:
-			_start_weather(turn, Gen2Weather.SUN)
-		START_SANDSTORM:
-			_start_weather(turn, Gen2Weather.SANDSTORM)
-		SCREEN:
-			_screen(turn)
-		SAFEGUARD:
-			_safeguard(turn)
-		PERISH_SONG:
-			_perish_song(turn)
-		SUBSTITUTE:
-			_substitute(turn)
-		LEECH_SEED:
-			_leech_seed(turn)
-		NIGHTMARE:
-			_nightmare(turn)
-		CURSE:
-			_curse(turn)
-		SPIKES:
-			_spikes(turn)
-		CLEAR_HAZARDS:
-			_clear_hazards(turn)
-		PROTECT:
-			_protect(turn)
-		ENDURE:
-			_endure(turn)
-		DESTINY_BOND:
-			_destiny_bond(turn)
-		FORCE_SWITCH:
-			_force_switch(turn)
-		BATON_PASS:
-			_baton_pass(turn)
-		TELEPORT:
-			_teleport(turn)
-		FORESIGHT:
-			_foresight(turn)
-		LOCK_ON:
-			_lock_on(turn)
-		SPITE:
-			_spite(turn)
-		PAIN_SPLIT:
-			_pain_split(turn)
-		THIEF:
-			_thief(turn)
-		PURSUIT:
-			_pursuit(turn)
-		BEAT_UP:
-			_beat_up(turn)
-		BEAT_UP_FAIL_TEXT:
-			_beat_up_fail_text(turn)
-		CHECK_SAFEGUARD:
-			_check_safeguard(turn)
-		HEAL:
-			_heal(turn)
-		TIMED_HEAL:
-			_timed_heal(turn)
-		THUNDER_ACCURACY:
-			_thunder_accuracy(turn)
-		SKIP_SUN_CHARGE:
-			_skip_sun_charge(turn)
 		MOVE_ANIM:
 			_lower_sub(turn)
 			_move_anim(turn)
 			_raise_sub(turn)
-		MOVE_ANIM_NO_SUB:
-			_move_anim(turn)
-		LOWER_SUB:
-			_lower_sub(turn)
-		RAISE_SUB:
-			_raise_sub(turn)
-		LOWER_SUB_NO_ANIM:
-			_sub_pic(turn, false)
-		STAT_UP_ANIM:
-			_stat_change_anim(turn, Gen2BattleAnimPlayer.AFTER_ANIM_NONE)
 		STAT_DOWN_ANIM:
 			_stat_change_anim(
 				turn,
 				Gen2BattleAnimPlayer.AFTER_ANIM_ENEMY_STAT_DOWN if turn.side == Gen2Battle.PLAYER
 					else Gen2BattleAnimPlayer.AFTER_ANIM_WOBBLE
 			)
-		KINGS_ROCK:
-			_kings_rock(turn)
-		ALL_STATS_UP:
-			_all_stats_up(turn)
-		STAT_UP_MESSAGE, STAT_DOWN_MESSAGE:
-			_stat_message(turn)
-		STAT_UP_FAIL_TEXT, STAT_DOWN_FAIL_TEXT:
-			_stat_fail_text(turn)
 		_:
 			if STAT_COMMANDS.has(command):
 				_stat_change(command, turn)
@@ -1574,15 +1462,12 @@ static func _check_hit(turn: Gen2Turn) -> void:
 
 
 ## `BattleCommand_FailureText`, the half of it that is state rather than words.
-## Which line a miss says is the standing divergence; what it leaves behind is
-## not, and two of its three branches were missing here.
-##
+## Which line a miss says is the standing divergence; what it leaves behind is not.
 ## `.fly_dig` reads `BATTLE_VARS_MOVE_ANIM` rather than the effect byte, so it is
-## the move that names it. `checkcharge` has already cleared both bits on the
-## release turn, which is what makes `AppearUserRaiseSub` the branch's substance:
-## a missed Fly or Dig owes the picture back, and nothing here paid it. Whether
-## it shows depends on what the charge animation left behind, which
-## [method Gen2BattleScreen.animation_snapshot]'s `battler_visible` reports.
+## the move that names it, and `checkcharge` has already cleared both bits on the
+## release turn: a missed Fly or Dig owes the picture back, which is what
+## `AppearUserRaiseSub` pays. Whether it shows depends on what the charge
+## animation left, which [method Gen2BattleScreen.animation_snapshot] reports.
 static func _failure_text(turn: Gen2Turn) -> void:
 	_jump_kick_crash(turn)
 	if turn.move_number in [Gen2MoveEffect.FLY_MOVE, Gen2MoveEffect.DIG_MOVE]:
@@ -1614,16 +1499,13 @@ static func _jump_kick_crash(turn: Gen2Turn) -> void:
 
 
 ## Takes the damage off and reports what was taken.
-##
 ## `BattleCommand_ApplyDamage` rolls the defender's Focus Band first, and a band
-## that fires calls `BattleCommand_FalseSwipe`, leaving one hit point. The roll
-## happens whether or not the hit was lethal, and only the survival shows.
-##
-## The band sits in front of the substitute routing, which is the source's order
-## rather than a tidying opportunity: `FalseSwipe` clamps against the *real*
-## health, so a band can fire, cut the figure, and have the doll spend the cut
-## figure with "hung on" printed anyway. `.update_damage_taken` then returns early
-## against a doll, which is what stops Counter answering a hit it took.
+## that fires calls `BattleCommand_FalseSwipe`, leaving one hit point; the roll
+## happens whether or not the hit was lethal. The band sits in front of the
+## substitute routing, which is the source's order: `FalseSwipe` clamps against
+## the *real* health, so a band can fire, cut the figure, and have the doll spend
+## the cut figure with "hung on" printed anyway. `.update_damage_taken` then
+## returns early against a doll, which stops Counter answering a hit it took.
 static func _apply_damage(turn: Gen2Turn) -> void:
 	if turn.missed or turn.damage <= 0:
 		return
@@ -2059,15 +1941,12 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 
 
 ## Whether the target's type refuses this status, which two of the five ask.
-##
 ## Poison asks `CheckIfTargetIsPoisonType`, comparing the target's types against
 ## POISON rather than the move's, so a Poison-type is refused whatever poisons it.
 ## Burn and freeze ask `CheckMoveTypeMatchesTarget`, comparing the *move's* type,
-## so a Fire-type shrugs off a Fire-type burn; its `.normal` branch returns
-## non-zero without comparing, so Tri Attack can burn and freeze anything.
-##
-## Sleep and paralysis ask neither, which is why Body Slam paralyses a
-## Ground-type: those immunities are a later generation's.
+## and its `.normal` branch returns non-zero without comparing, so Tri Attack can
+## burn and freeze anything. Sleep and paralysis ask neither, which is why Body
+## Slam paralyses a Ground-type.
 static func _status_type_refuses(turn: Gen2Turn, flag: int) -> bool:
 	var types: Array = turn.defender().types()
 	if flag == Gen2Status.POISON:
@@ -2203,13 +2082,10 @@ static func _drain_target(turn: Gen2Turn) -> void:
 
 
 ## `BattleCommand_ConstantDamage`: the whole hit without the ordinary formula.
-## [constant Gen2MoveEffect.LEVEL_DAMAGE] is the user's level,
-## [constant Gen2MoveEffect.PSYWAVE] a roll of it,
-## [constant Gen2MoveEffect.SUPER_FANG] half the target's HP and
-## [constant Gen2MoveEffect.STATIC_DAMAGE] the power field. None criticals or
-## announces an effectiveness, the number having been multiplied by neither, which
-## is what [constant RESET_TYPE_MATCHUP] behind them says.
-##
+## LEVEL_DAMAGE is the user's level, PSYWAVE a roll of it, SUPER_FANG half the
+## target's HP and STATIC_DAMAGE the power field. None criticals or announces an
+## effectiveness, the number having been multiplied by neither, which is what
+## [constant RESET_TYPE_MATCHUP] behind them says.
 ## [constant Gen2MoveEffect.REVERSAL] shares the command and not the shape: it
 ## sets a power and runs the formula, its list carrying `stab`, so Flail against a
 ## Ghost really is super effective.
@@ -2397,12 +2273,10 @@ static func _rollout_check(turn: Gen2Turn) -> void:
 ## `BattleCommand_RolloutPower`, both halves of Rollout: the count and the
 ## doubling. It runs after `stab` and the hit check and before `damagevariation`,
 ## so the doubling lands on the matched-up damage and the spread comes off the
-## doubled figure; a miss, immunity included, ends the chain, and a fifth hit
-## clears the flag while keeping its count until the next Rollout resets it.
-##
-## The count is raised before the doubling and one doubling does nothing
-## (`inc [hl]`, then `dec b / jr z`), so the first hit is worth its own power and
-## the fifth sixteen times it. Defense Curl adds one more.
+## doubled figure; a miss ends the chain, and a fifth hit clears the flag while
+## keeping its count. The count is raised before the doubling and one doubling
+## does nothing (`inc [hl]`, then `dec b / jr z`), so the first hit is worth its
+## own power and the fifth sixteen times it. Defense Curl adds one more.
 static func _rollout_power(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	# Sleep Talk can call Rollout while the user remains asleep. The cartridge's
@@ -3099,18 +2973,13 @@ static func _force_switch_wild(turn: Gen2Turn) -> void:
 	turn.emit(line, {"target": turn.target})
 
 
-## `BattleCommand_BatonPass`: switch, and hand the arrival everything the
-## position was carrying.
-##
-## The two halves differ in one thing, which is why this is the first effect that
-## cannot be resolved in one go: the enemy's target is picked by the routine that
-## picks an ordinary AI switch, and the player's is
-## `ForcePickSwitchMonInBattle`, a menu inside the move that cannot be backed out
-## of, so the turn stops here until [method Gen2Battle.pass_to]. Committing a
-## target before the turn would be wrong: a pass that moves second is picked once
-## the opponent's move has landed.
-##
-## `AnimateCurrentMove` is in front of both, so it runs before the question.
+## `BattleCommand_BatonPass`: switch, and hand the arrival everything the position
+## was carrying. The two halves differ in one thing, which is why this is the
+## first effect that cannot be resolved in one go: the enemy's target is picked by
+## the ordinary AI switch and the player's by `ForcePickSwitchMonInBattle`, a menu
+## inside the move that cannot be backed out of, so the turn stops here until
+## [method Gen2Battle.pass_to]. Committing a target before the turn would be
+## wrong: a pass that moves second is picked once the opponent's move has landed.
 static func _baton_pass(turn: Gen2Turn) -> void:
 	var battle: Gen2Battle = turn.battle
 	var side: int = turn.side
@@ -3136,18 +3005,13 @@ static func _baton_pass(turn: Gen2Turn) -> void:
 
 
 ## `BattleCommand_Teleport`: the user takes itself out of a wild battle, which
-## [method Gen2Battle.force_out] ends as a draw, the pair Whirlwind and Roar
-## reach except that the side leaving is the user's.
-##
-## Four refusals in the source's order: the four scripted `wBattleType` values,
-## Mean Look or Spider Web, a trainer battle, and `BattleCommand_ForceSwitch`'s
-## level comparison, where a user at or above the other's level always gets away
-## and below it the roll is drawn out of the two levels summed and one more.
-##
-## The enemy's half draws that roll and throws it away, `cp b / jr nc, .run_away`
-## falling straight into `.run_away`, so a wild Pokémon always teleports
-## (`docs/bugs_and_glitches.md`). Mirrored rather than fixed, and the roll is
-## still drawn so the generator moves the same way.
+## [method Gen2Battle.force_out] ends as a draw. Four refusals in the source's
+## order: the four scripted `wBattleType` values, Mean Look or Spider Web, a
+## trainer battle, and `BattleCommand_ForceSwitch`'s level comparison. The enemy's
+## half draws that roll and throws it away, `cp b / jr nc, .run_away` falling
+## straight into `.run_away`, so a wild Pokemon always teleports
+## (`docs/bugs_and_glitches.md`). Mirrored rather than fixed, and the roll is still
+## drawn so the generator moves the same way.
 static func _teleport(turn: Gen2Turn) -> void:
 	if FORCE_SWITCH_REFUSED_TYPES.has(turn.battle.battle_type) \
 		or Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.CANT_RUN) \
@@ -3172,13 +3036,11 @@ static func _teleport(turn: Gen2Turn) -> void:
 
 ## `BattleCommand_Foresight`: the flag that drops the target's evasion out of the
 ## accuracy sum and opens the two Ghost immunities the matchup table keeps past
-## its own `-2` marker. It sits on the target and nothing but a switch clears it.
-##
-## Two refusals: a target that is flying or underground, and one already
-## identified. Only the second is reached through the cartridge's own list, on the
-## cartridge as well as here, since `checkhit` in front of the command has already
-## turned a hidden target away. The first is kept for a registered list that
-## carries no `checkhit`.
+## its `-2` marker. It sits on the target and nothing but a switch clears it. Two
+## refusals: a target that is flying or underground, and one already identified.
+## Only the second is reached through the cartridge's own list, since `checkhit`
+## in front of the command has already turned a hidden target away; the first is
+## kept for a registered list that carries no `checkhit`.
 static func _foresight(turn: Gen2Turn) -> void:
 	var defender: Gen2BattleMon = turn.defender()
 	if _is_hidden(defender.substatus) \
@@ -3500,14 +3362,11 @@ static func _play_fx_anim(
 
 ## `PlayOpponentBattleAnim`, the fifth route an animation reaches the screen by
 ## and the only one that is not the move's own: `wFXAnimID` from `de`,
-## `wBattleAfterAnim` cleared, `PlayBattleAnim` between two
-## `BattleCommand_SwitchTurn` calls. `wBattleAnimParam` is left alone, so whatever
-## the move's animation wrote stands.
-##
-## Its five callers are all secondary-effect commands with ids past `wFXAnimID`'s
-## low byte, so `BattleAnimRunScript` takes `.not_move`, skipping
-## `CheckBattleScene`, both hud calls and the after-anim: a status animation plays
-## with the battle-scene option off.
+## `wBattleAfterAnim` cleared, `PlayBattleAnim` between two `SwitchTurn` calls,
+## and `wBattleAnimParam` left alone. Its five callers are all secondary-effect
+## commands with ids past `wFXAnimID`'s low byte, so `BattleAnimRunScript` takes
+## `.not_move` and skips `CheckBattleScene`: a status animation plays with the
+## battle-scene option off.
 static func _play_opponent_battle_anim(turn: Gen2Turn, index: int) -> void:
 	_play_fx_anim(turn, index, Gen2BattleAnimPlayer.AFTER_ANIM_NONE, false, true)
 
@@ -3649,13 +3508,10 @@ static func _status_target_anim(turn: Gen2Turn, flag: int) -> int:
 
 ## `AnimateCurrentMove`, which is `LoadMoveAnim` between a `lowersub` and a
 ## `raisesub`: the move's own animation with `wBattleAfterAnim` cleared, so no
-## damage flash follows it.
-##
-## Not a list command. Fifteen commands call it from inside their own bodies,
-## and it is the whole animation of every move whose effect list carries no
-## animation command at all. `wBattleAnimParam` is pushed across the drop rather
-## than cleared, so whatever the last animation left stands; the raise behind it
-## is last and leaves its own 2 there.
+## damage flash follows it. Not a list command. Fifteen commands call it from
+## inside their own bodies, and it is the whole animation of every move whose
+## effect list carries no animation command. `wBattleAnimParam` is pushed across
+## the drop rather than cleared, so whatever the last animation left stands.
 static func _animate_current_move(turn: Gen2Turn) -> void:
 	var param: int = turn.battle.battle_anim_param
 	_lower_sub(turn)
@@ -3688,17 +3544,12 @@ static func _kings_rock(turn: Gen2Turn) -> void:
 
 
 ## Moves one stat by one command's worth and writes down who it happened to and
-## whether it moved, for the message step behind it. A secondary effect's failed
-## roll skips this as it skips a status, the damage having landed.
-##
-## A drop against Mist never reaches [method Gen2BattleMon.change_stage]: every
-## lowering entry targets the opponent (`entry[2]` false), which is what Mist
-## blocks, and a rise always targets the user, matching `CheckMist` gating the
-## "down" and "down2" ranges alone.
-##
-## The order is `BattleCommand_StatDown`'s: `CheckMist`, the stage that cannot
-## move, then `.DidntMiss`'s `CheckSubstituteOpp` and `wEffectFailed`, each with
-## its own `wFailedMessage`, so a failed secondary roll still says the line.
+## whether it moved, for the message step behind it. A drop against Mist never
+## reaches [method Gen2BattleMon.change_stage]: every lowering entry targets the
+## opponent, which is what Mist blocks, and a rise always targets the user. The
+## order is `BattleCommand_StatDown`'s: `CheckMist`, the stage that cannot move,
+## then `.DidntMiss`'s `CheckSubstituteOpp` and `wEffectFailed`, each with its own
+## `wFailedMessage`, so a failed secondary roll still says the line.
 static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	var entry: Array = STAT_COMMANDS[command]
 	var stat_key: String = String(entry[0])

--- a/game/battle/evolution.gd
+++ b/game/battle/evolution.gd
@@ -138,14 +138,12 @@ static func stopped_evolving_text(mon_name: String) -> String:
 
 ## `EvolveAfterBattle`'s master loop, as a list of plans rather than a walk that
 ## evolves as it goes: nothing here writes a party row, so a caller can show
-## `EvolutionAnimation` for each and apply only the ones that were not cancelled.
-##
-## [param evolvable] is `wEvolvableFlags` as [method Gen2Battle.evolvable_indices]
-## answers it: BATTLE-party indices, mapped here through the one rule that knows
-## an egg keeps its party slot without being a combatant. Only `.level`,
-## `.happiness` and `.stat` are reachable on this path: `wForceEvolution` is zero,
-## which is what `.item` demands, and `.trade` demands a `wLinkMode` this project
-## has none of.
+## `EvolutionAnimation` for each and apply only the ones not cancelled.
+## [param evolvable] is `wEvolvableFlags` as
+## [method Gen2Battle.evolvable_indices] answers it, mapped through the one rule
+## that knows an egg keeps its party slot without being a combatant. Only
+## `.level`, `.happiness` and `.stat` are reachable here: `wForceEvolution` is
+## zero and `.trade` demands a `wLinkMode` this project has none of.
 static func after_battle(
 	data: GameData, save: Gen2SaveData, evolvable: Array, time_of_day: int
 ) -> Array:

--- a/game/battle/exp_bar_animation.gd
+++ b/game/battle/exp_bar_animation.gd
@@ -1,19 +1,13 @@
 class_name Gen2ExpBarAnimation
 extends RefCounted
 
-## The exp bar filling, one pixel at a time (`AnimateExpBar`,
-## engine/battle/core.asm).
-##
-## Not the HP bar again: `.LoopLevels` fills to the end, raises the level and
-## refills from empty (`ld c, $40`, then `ld b, $0`), so this is a list of
-## segments, one per level crossed plus `.FinishExpBar`'s partial fill. Its text
-## ordering is the opposite of the HP bar's: `Text_MonGainedExpPoint` is printed
-## before `AnimateExpBar` and `BattleText_StringBuffer1GrewToLevel` inside the
-## loop, after that segment has reached the end.
-##
-## The three guards Gold and Silver lack (`.NoOverflow`'s `$ffffff` clamp, the
-## `cp e` after `CalcLevel`, `.LoopLevels`' `cp MAX_LEVEL`) are unreachable from
-## a gain, so nothing here is profile split.
+## The exp bar filling, one pixel at a time (`AnimateExpBar`). Not the HP bar
+## again: `.LoopLevels` fills to the end, raises the level and refills from empty,
+## so this is a list of segments, one per level crossed plus `.FinishExpBar`'s
+## partial fill. Its text ordering is the opposite of the HP bar's:
+## `Text_MonGainedExpPoint` is printed before `AnimateExpBar` and
+## `BattleText_StringBuffer1GrewToLevel` inside the loop. The three guards Gold
+## and Silver lack are unreachable from a gain, so nothing here is profile split.
 
 ## `EXP_BAR_LENGTH * TILE_WIDTH`: `CalcExpBar` returns `$40 - b` over eight
 ## tiles.

--- a/game/battle/hp_bar_animation.gd
+++ b/game/battle/hp_bar_animation.gd
@@ -2,19 +2,12 @@ class_name Gen2HpBarAnimation
 extends RefCounted
 
 ## The HP bar draining or filling, one pixel at a time
-## (engine/battle/anim_hp_bar.asm).
-##
-## Scene-free like the rest of the battle layer: the screen ticks this once per
-## hardware frame and draws [method pixels], and the bar arrives before the
-## message that describes the hit is printed. That ordering is the source's, not
-## a choice: `NormalHit` runs `applydamage` before `criticaltext` and
-## `supereffectivetext`, and `DoEnemyDamage` ends with `predef AnimateHPBar`.
-##
-## `_AnimateHPBar` has two branches, keyed on whether the maximum is at least
-## `HP_BAR_LENGTH_PX`: over it the loop steps real HP and redraws only when the
-## pixel moves, under it the loop steps the pixel itself. Both redraw exactly one
-## pixel per iteration, so both are one pixel per step here; what differs is only
-## the HP *number* printed beside the bar, which [method hp] answers.
+## (engine/battle/anim_hp_bar.asm). The bar arrives before the message that
+## describes the hit, which is the source's order rather than a choice: `NormalHit`
+## runs `applydamage` before `criticaltext`. `_AnimateHPBar` has two branches, keyed
+## on whether the maximum is at least `HP_BAR_LENGTH_PX`; both redraw exactly one
+## pixel per iteration, so both are one pixel per step here, and what differs is
+## only the HP number printed beside the bar, which [method hp] answers.
 
 ## `HP_BAR_LENGTH * TILE_WIDTH`, the bar's full width in pixels.
 const LENGTH_PX: int = Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
@@ -90,18 +83,12 @@ func hp() -> int:
 
 
 ## `ShortHPBar_CalcPixelFrame`, which is how a maximum under the bar's own width
-## recovers an HP number from a pixel count: multiply, subtract the width until it
-## borrows, then round with its `add hl, $80` and one more subtraction.
-##
-## Its loop subtracts before it tests, so an exact multiple of the width is
-## counted and then rounded up again: one HP too many, which is
-## `docs/bugs_and_glitches.md`'s "HP bar animation off-by-one error for low HP".
-## pret's fix stops the loop on the zero, and the rounding then lands on the
-## quotient itself. Everything else about the routine is the same either way.
-##
-## The answer is clamped to the two ends of this animation, which is the routine's
-## own `wCurHPAnimLowHP`/`wCurHPAnimHighHP` comparison and is why the extra HP is
-## invisible until the drain passes through an exact multiple.
+## recovers an HP number from a pixel count. Its loop subtracts before it tests,
+## so an exact multiple of the width is counted and then rounded up again: one HP
+## too many, which is `docs/bugs_and_glitches.md`'s low-HP off-by-one. pret's fix
+## stops the loop on the zero. The answer is clamped to the two ends of this
+## animation, the routine's own `wCurHPAnimLowHP`/`wCurHPAnimHighHP` comparison,
+## which is why the extra HP is invisible until the drain passes through a multiple.
 func _short_bar_hp() -> int:
 	var total: int = _max_hp * _pixels
 	var counted: int = 0

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -1,16 +1,11 @@
 class_name Gen2MoveEffect
 extends RefCounted
 
-## What each move's effect byte makes it do, as a list of commands.
-##
-## The table the cartridge keeps in [code]data/moves/effects.asm[/code], to be
-## read against it. A move number picks an effect byte and an effect byte picks a
-## list.
-##
-## Almost every list is [constant NORMAL_HIT] with something inserted, which is
-## the reason for keeping the shape: burn, paralysis, stat changes and the
-## multi-hit moves are commands added to a list rather than branches added to the
-## turn loop. The effect bytes are the cartridge's own.
+## What each move's effect byte makes it do, as a list of commands: the table the
+## cartridge keeps in `data/moves/effects.asm`, to be read against it. Almost every
+## list is [constant NORMAL_HIT] with something inserted, which is the reason for
+## keeping the shape: burn, paralysis, stat changes and the multi-hit moves are
+## commands added to a list rather than branches added to the turn loop.
 
 ## The effect bytes with a list of their own, numbered as the cartridge's move
 ## table numbers them.
@@ -1300,13 +1295,11 @@ const DREAM_EATER_SEQUENCE: Array = [
 
 ## [constant SUPER_FANG], [constant STATIC_DAMAGE], [constant LEVEL_DAMAGE] and
 ## [constant PSYWAVE]: one shared list, the way the cartridge shares one script
-## (`StaticDamage:`) across all four labels.
-##
-## The shortest damaging list in the game: no critical, no stats, no formula, no
-## matchup and no spread, because the number is
-## [constant Gen2EffectCommands.FIXED_DAMAGE]'s to decide outright.
-## [constant Gen2EffectCommands.RESET_TYPE_MATCHUP] behind the hit check is what
-## answers an immunity and flattens the effectiveness none of the four earned.
+## (`StaticDamage:`) across all four labels. The shortest damaging list in the
+## game, with no critical, stats, formula, matchup or spread, because the number
+## is [constant Gen2EffectCommands.FIXED_DAMAGE]'s to decide outright.
+## [constant Gen2EffectCommands.RESET_TYPE_MATCHUP] behind the hit check answers
+## an immunity and flattens the effectiveness none of the four earned.
 const FIXED_DAMAGE_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,

--- a/game/battle/screens.gd
+++ b/game/battle/screens.gd
@@ -2,15 +2,11 @@ class_name Gen2Screens
 extends RefCounted
 
 ## `wPlayerScreens` and `wEnemyScreens`: the flags that belong to a side of the
-## field rather than to whoever is standing on it.
-##
-## Nothing clears these on a switch, which is the whole difference between them
-## and [Gen2Substatus]: a Reflect put up by one Pokémon still halves damage for
-## the one sent out behind it. Only the counters ending them do, in
-## [method Gen2Battle._tick_screens] and [method Gen2Battle._tick_safeguard].
-##
-## Pure arithmetic and no state, the same shape as [Gen2Weather]; the flags and
-## the three counters live on [Gen2Battle], one of each per side.
+## field rather than to whoever is standing on it. Nothing clears these on a
+## switch, which is the whole difference between them and [Gen2Substatus]: a
+## Reflect put up by one Pokemon still halves damage for the one sent out behind
+## it. Only the counters ending them do. Pure arithmetic and no state, the same
+## shape as [Gen2Weather].
 
 ## `constants/battle_constants.asm`'s bit numbers, kept rather than renumbered so
 ## a `bit SCREENS_REFLECT` in the source reads across. Bit 1 is skipped there and

--- a/game/battle/trainer_party.gd
+++ b/game/battle/trainer_party.gd
@@ -2,25 +2,13 @@ class_name Gen2TrainerParty
 extends RefCounted
 
 ## Turns one of a trainer class's individual trainers into a battle-ready party.
+## Lives here rather than beside [Gen2Learnset] because it produces
+## [Gen2BattleMon]s and the data layer holds no battle types.
 ##
-## Lives in [code]game/battle/[/code] rather than beside [Gen2Learnset] because
-## it produces [Gen2BattleMon]s and [Gen2Party]s, and the data layer holds no
-## battle types. [RefCounted] and static: it needs only [GameData] and a trainer
-## number.
-##
-## A NORMAL or ITEM trainer's Pokémon knows what its level teaches, from the
-## learnset, like a wild one; a MOVES or ITEM_MOVES trainer's knows exactly the
-## moves stored with it. Hence [method GameData.moves_at_level] for one and the
-## stored list for the other.
-##
-## Trainer Pokémon carry the per-class DVs ([method GameData.trainer_dvs]), not
-## [constant Gen2BattleMon.PERFECT_DVS]: a trainer's whole team shares one fixed
-## word, asked for once per class.
-##
-## This is the one place a trainer's party is made out of the cartridge's own
-## tables, so it is also where [constant Gen2Rules.CHALLENGE_HARD]'s level, DV
-## and stat-experience rules land. They are one global rule each rather than 800
-## rewritten teams.
+## A NORMAL or ITEM trainer's Pokemon knows what its level teaches; a MOVES or
+## ITEM_MOVES trainer's knows exactly the moves stored with it. DVs are the
+## per-class word rather than [constant Gen2BattleMon.PERFECT_DVS]. This is also
+## where [constant Gen2Rules.CHALLENGE_HARD]'s rules land, one rule not 800 teams.
 
 
 ## The party a trainer class's [param index]th trainer brings, or null if

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -2,18 +2,12 @@ class_name Gen2ContentOverlay
 extends RefCounted
 
 ## Content a mod adds or changes, consulted ahead of the cartridge's own tables.
-##
 ## [GameData] funnels every species, move, item and trainer read through one
-## place, so this is the one place that has to answer. Nothing downstream knows a
-## mod exists: a defined species has a learnset, evolutions and TM flags because
-## those live on the species row.
-##
-## [method define] adds content at a number the cartridge does not use;
-## [method patch] changes fields of a row it does. Definitions are normalized
+## place, so this is the one place that has to answer and nothing downstream knows
+## a mod exists. [method define] adds content at a number the cartridge does not
+## use; [method patch] changes fields of a row it does. Definitions are normalized
 ## against [constant DEFAULTS] on the way in, because readers index these rows
-## directly ([method GameData.palette] reads [code]palette.normal[/code],
-## [method GameData.species_pic] reads [code]front_tiles[/code]) and an omitted
-## field would crash the reader rather than draw wrong.
+## directly and an omitted field would crash the reader rather than draw wrong.
 
 ## The kinds a mod may reach. Types are zero-based while the other numbered
 ## content is one-based; [method define] and [method patch] keep that distinction

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1,20 +1,14 @@
 class_name GameData
 extends RefCounted
 
-## A decoded cartridge, read back out of the cache.
-##
-## The importer's counterpart and the only way the engine sees cartridge content:
-## nothing downstream opens a ROM, and nothing here knows what a ROM is.
-## [RefCounted] and scene-free, so a battle or menu can run in a test.
+## A decoded cartridge, read back out of the cache: the importer's counterpart
+## and the only way the engine sees cartridge content. [RefCounted] and
+## scene-free, so a battle or menu can run in a test.
 ##
 ## JSON has one number type, so every cached number returns as a float and every
-## comparison against an int quietly fails. Coercion happens here, once.
-##
-## Index buffers load on first use and are kept: a pic atlas is about a megabyte
-## of indices. World sections load the same way for a blunter reason, that
-## scripts, text and audio are almost all of a cache and the launcher, pic viewer
-## and battle never read them; reading them at open() made listing three games
-## cost more than entering one and put the whole cache in phone memory.
+## comparison against an int quietly fails; coercion happens here, once. Index
+## buffers and world sections load on first use, because reading them at open()
+## made listing three games cost more than entering one.
 
 var id: StringName = &""
 var sha1: String = ""
@@ -148,18 +142,73 @@ static func open(game_id: StringName) -> GameData:
 
 ## Opens whichever of the two [param argument] names: a directory
 ## [method RomCache.is_usable] accepts is a cache path, and anything else is a
-## [RomRegistry] id. Null when neither resolves.
-##
-## For a tool whose command line carries one string and cannot say which form it
-## is. Which of the two an argument means is a fact about the cache layout and
-## the registry, so it is answered here rather than sniffed by every tool that
-## would otherwise copy it and go stale when the cache naming moves. [member id]
-## is filled off the manifest either way. Named for its argument rather than
-## `open_any`, which already means the first cartridge that has a cache at all.
+## [RomRegistry] id. Null when neither resolves. For a tool whose command line
+## carries one string and cannot say which form it is; answered here rather than
+## sniffed by every tool that would go stale when the cache naming moves. Named
+## for its argument rather than `open_any`, which already means the first
+## cartridge that has a cache at all.
 static func open_argument(argument: String) -> GameData:
 	if RomCache.is_usable(argument):
 		return open_directory(argument)
 	return open(StringName(argument))
+
+
+## Manifest sections copied into a member as they stand, key to member. A section
+## that is missing or the wrong type leaves the member's own default, which is
+## what lets a cache written by an older import still open.
+const MANIFEST_DICTIONARIES: Dictionary = {
+	"atlases": "_atlases",
+	"egg_pic": "_egg_pic",
+	"tiles": "_tiles",
+	"bar_palettes": "_bar_palettes",
+	"stats_screen_palettes": "_stats_screen_palettes",
+	"player_palettes": "_player_palettes",
+	"transition_palettes": "_transition_palettes",
+	"card_palettes": "_card_palettes",
+	"pokedex_palettes": "_pokedex_palettes",
+	"pack": "_pack",
+	"battle_object_palettes": "_battle_object_palettes",
+	"presents_palettes": "_presents_palettes",
+	"title": "_title",
+	"town_map": "_town_map",
+	"oak_ratings": "_oak_ratings",
+	"pokecenter_pc": "_pokecenter_pc",
+	"decorations": "_decorations",
+	"mom_phone": "_mom_phone",
+	"credits": "_credits",
+	"intro_movie": "_intro_movie",
+	"unown_puzzle": "_unown_puzzle",
+	"diploma": "_diploma",
+	"mystery_gift": "_mystery_gift",
+	"link_border": "_link_border",
+	"printer_strings": "_printer_strings",
+	"slots": "_slots",
+	"slots_text": "_slots_text",
+	"card_flip": "_card_flip",
+	"card_flip_text": "_card_flip_text",
+	"gs_intro": "_gs_intro",
+	"menu_text": "_menu_text",
+	"mart_text": "_mart_text",
+	"name_rater_text": "_name_rater_text",
+	"move_deleter_text": "_move_deleter_text",
+	"day_care_text": "_day_care_text",
+	"special_text": "_special_text",
+	"special_text_ram": "_special_text_ram",
+}
+
+## The same for the sections that are lists.
+const MANIFEST_ARRAYS: Dictionary = {
+	"battle_grayscale_palette": "_battle_grayscale_palette",
+	"move_screen_palette": "_move_screen_palette",
+	"mail_palettes": "_mail_palettes",
+	"mail_items": "_mail_items",
+	"pc_palette": "_pc_palette",
+	"gender_screen_palette": "_gender_screen_palette",
+	"copyright_string": "_copyright_string",
+	"copyright_palette": "_copyright_palette",
+	"text_bg_palette": "_text_bg_palette",
+	"odd_eggs": "_odd_eggs",
+}
 
 
 ## Opens a cache directory, or null if it is missing, incomplete, or was written
@@ -174,111 +223,46 @@ static func open_directory(path: String) -> GameData:
 	data.directory = path
 	data.id = StringName(manifest.get("game_id", ""))
 	data.sha1 = String(manifest.get("sha1", ""))
-	data._atlases = manifest.get("atlases", {})
-	data._egg_pic = manifest.get("egg_pic", {})
-	data._tiles = manifest.get("tiles", {})
-	data._bar_palettes = manifest.get("bar_palettes", {})
-	data._battle_grayscale_palette = manifest.get("battle_grayscale_palette", [])
-	data._move_screen_palette = manifest.get("move_screen_palette", [])
-	data._stats_screen_palettes = manifest.get("stats_screen_palettes", {})
-	data._player_palettes = manifest.get("player_palettes", {})
-	data._transition_palettes = manifest.get("transition_palettes", {})
-	data._card_palettes = manifest.get("card_palettes", {})
-	var mail_palettes: Variant = manifest.get("mail_palettes", [])
-	data._mail_palettes = mail_palettes if mail_palettes is Array else []
-	var raw_mail_items: Variant = manifest.get("mail_items", [])
-	data._mail_items = raw_mail_items if raw_mail_items is Array else []
-	data._pokedex_palettes = manifest.get("pokedex_palettes", {})
-	data._pack = manifest.get("pack", {})
-	var raw_pc_palette: Variant = manifest.get("pc_palette", [])
-	data._pc_palette = raw_pc_palette if raw_pc_palette is Array else []
-	var gender_palette: Variant = manifest.get("gender_screen_palette", [])
-	data._gender_screen_palette = gender_palette if gender_palette is Array else []
-	var raw_copyright_string: Variant = manifest.get("copyright_string", [])
-	data._copyright_string = raw_copyright_string if raw_copyright_string is Array else []
-	var raw_copyright_palette: Variant = manifest.get("copyright_palette", [])
-	data._copyright_palette = raw_copyright_palette if raw_copyright_palette is Array else []
-	var text_palette: Variant = manifest.get("text_bg_palette", [])
-	data._text_bg_palette = text_palette if text_palette is Array else []
-	data._battle_object_palettes = manifest.get("battle_object_palettes", {})
-	var presents_palettes: Variant = manifest.get("presents_palettes", {})
-	data._presents_palettes = presents_palettes if presents_palettes is Dictionary else {}
-	var raw_title: Variant = manifest.get("title", {})
-	data._title = raw_title if raw_title is Dictionary else {}
-	var town_map: Variant = manifest.get("town_map", {})
-	data._town_map = town_map if town_map is Dictionary else {}
-	var raw_oak_ratings: Variant = manifest.get("oak_ratings", {})
-	data._oak_ratings = raw_oak_ratings if raw_oak_ratings is Dictionary else {}
-	var pokecenter_pc: Variant = manifest.get("pokecenter_pc", {})
-	data._pokecenter_pc = pokecenter_pc if pokecenter_pc is Dictionary else {}
-	var decorations: Variant = manifest.get("decorations", {})
-	data._decorations = decorations if decorations is Dictionary else {}
-	var mom_phone: Variant = manifest.get("mom_phone", {})
-	data._mom_phone = mom_phone if mom_phone is Dictionary else {}
-	var unown_words: Variant = manifest.get("unown_words", [])
-	if unown_words is Array:
-		for word: Variant in unown_words as Array:
-			data._unown_words.append(String(word))
-	var unown_walls: Variant = manifest.get("unown_walls", [])
-	if unown_walls is Array:
-		for wall: Variant in unown_walls as Array:
-			data._unown_walls.append(String(wall))
-	var eggs: Variant = manifest.get("odd_eggs", [])
-	data._odd_eggs = eggs if eggs is Array else []
-	var credits: Variant = manifest.get("credits", {})
-	data._credits = credits if credits is Dictionary else {}
-	var intro_movie: Variant = manifest.get("intro_movie", {})
-	data._intro_movie = intro_movie if intro_movie is Dictionary else {}
-	var unown_puzzle: Variant = manifest.get("unown_puzzle", {})
-	data._unown_puzzle = unown_puzzle if unown_puzzle is Dictionary else {}
-	var diploma: Variant = manifest.get("diploma", {})
-	data._diploma = diploma if diploma is Dictionary else {}
-	var mystery_gift: Variant = manifest.get("mystery_gift", {})
-	data._mystery_gift = mystery_gift if mystery_gift is Dictionary else {}
-	var link_border: Variant = manifest.get("link_border", {})
-	data._link_border = link_border if link_border is Dictionary else {}
+	for key: String in MANIFEST_DICTIONARIES:
+		var section: Variant = manifest.get(key, {})
+		if section is Dictionary:
+			data.set(MANIFEST_DICTIONARIES[key], section)
+	for key: String in MANIFEST_ARRAYS:
+		var section: Variant = manifest.get(key, [])
+		if section is Array:
+			data.set(MANIFEST_ARRAYS[key], section)
+	data._unown_words = _string_list(manifest.get("unown_words", []))
+	data._unown_walls = _string_list(manifest.get("unown_walls", []))
 	data._other_player_link_mode = int(manifest.get("other_player_link_mode", -1))
-	var printer_strings: Variant = manifest.get("printer_strings", {})
-	data._printer_strings = printer_strings if printer_strings is Dictionary else {}
-	var slots: Variant = manifest.get("slots", {})
-	data._slots = slots if slots is Dictionary else {}
-	var raw_slots_text: Variant = manifest.get("slots_text", {})
-	data._slots_text = raw_slots_text if raw_slots_text is Dictionary else {}
-	var card_flip: Variant = manifest.get("card_flip", {})
-	data._card_flip = card_flip if card_flip is Dictionary else {}
-	var raw_card_flip_text: Variant = manifest.get("card_flip_text", {})
-	data._card_flip_text = raw_card_flip_text if raw_card_flip_text is Dictionary else {}
-	var gs_intro: Variant = manifest.get("gs_intro", {})
-	data._gs_intro = gs_intro if gs_intro is Dictionary else {}
-	var raw_menu_text: Variant = manifest.get("menu_text", {})
-	data._menu_text = raw_menu_text if raw_menu_text is Dictionary else {}
-	var raw_mart_text: Variant = manifest.get("mart_text", {})
-	data._mart_text = raw_mart_text if raw_mart_text is Dictionary else {}
-	var raw_name_rater_text: Variant = manifest.get("name_rater_text", {})
-	data._name_rater_text = raw_name_rater_text if raw_name_rater_text is Dictionary else {}
-	var raw_move_deleter_text: Variant = manifest.get("move_deleter_text", {})
-	data._move_deleter_text = raw_move_deleter_text if raw_move_deleter_text is Dictionary else {}
-	var raw_day_care_text: Variant = manifest.get("day_care_text", {})
-	data._day_care_text = raw_day_care_text if raw_day_care_text is Dictionary else {}
-	var raw_special_text: Variant = manifest.get("special_text", {})
-	data._special_text = raw_special_text if raw_special_text is Dictionary else {}
-	var raw_special_text_ram: Variant = manifest.get("special_text_ram", {})
-	data._special_text_ram = raw_special_text_ram if raw_special_text_ram is Dictionary else {}
-	data._species = data._read_array(RomCache.species_path(path))
-	data._moves = data._read_array(RomCache.moves_path(path))
-	data._tmhm_moves = data._read_int_array(RomCache.tmhm_moves_path(path))
-	data._happiness_changes = data._read_array(RomCache.happiness_changes_path(path))
-	data._name_input_chars = data._read_array(RomCache.name_input_chars_path(path))
-	data._string_buffer_pointers = data._read_int_array(RomCache.text_buffers_path(path))
-	var intro: Variant = RomCache.read_json(RomCache.intro_text_path(path))
-	data._intro_text = intro if intro is Dictionary else {}
-	data._load_dex_orders(RomCache.dex_orders_path(path))
-	data._items = data._read_array(RomCache.items_path(path))
-	data._world_trades = data._read_array(RomCache.world_trades_path(path))
-	data._types = data._read_array(RomCache.types_path(path))
-	data._trainers = data._read_array(RomCache.trainers_path(path))
-	data._build_matchups(data._read_array(RomCache.matchups_path(path)))
+	data._read_cache(path)
 	return data
+
+
+static func _string_list(raw: Variant) -> PackedStringArray:
+	var out := PackedStringArray()
+	if not raw is Array:
+		return out
+	for entry: Variant in raw as Array:
+		out.append(String(entry))
+	return out
+
+
+## The tables that live beside the manifest as their own files.
+func _read_cache(path: String) -> void:
+	_species = _read_array(RomCache.species_path(path))
+	_moves = _read_array(RomCache.moves_path(path))
+	_tmhm_moves = _read_int_array(RomCache.tmhm_moves_path(path))
+	_happiness_changes = _read_array(RomCache.happiness_changes_path(path))
+	_name_input_chars = _read_array(RomCache.name_input_chars_path(path))
+	_string_buffer_pointers = _read_int_array(RomCache.text_buffers_path(path))
+	var intro: Variant = RomCache.read_json(RomCache.intro_text_path(path))
+	_intro_text = intro if intro is Dictionary else {}
+	_load_dex_orders(RomCache.dex_orders_path(path))
+	_items = _read_array(RomCache.items_path(path))
+	_world_trades = _read_array(RomCache.world_trades_path(path))
+	_types = _read_array(RomCache.types_path(path))
+	_trainers = _read_array(RomCache.trainers_path(path))
+	_build_matchups(_read_array(RomCache.matchups_path(path)))
 
 
 ## The first registry game with a usable cache, or null if none has been
@@ -320,13 +304,10 @@ func world_maps() -> Array:
 
 ## Every imported script's `bank:address` key, sorted, for a caller that has to
 ## walk the whole corpus rather than follow one pointer. See [Gen2WorldCatalog].
-##
 ## The keys an item ball, a hidden item or a conditional background event points
-## at are NOT here. Their bytes live in the map-scripts bank and are cached with
-## the scripts because every runtime reader asks [method world_script] for them,
-## but they are `db item, quantity`, `dwb event, item` and a `conditional_event`
-## record rather than commands, and a corpus walk that decoded them read item
-## counts as opcodes.
+## at are NOT here: their bytes live in the map-scripts bank and are cached with
+## the scripts, but they are `db item, quantity` and the like rather than
+## commands, and a corpus walk that decoded them read item counts as opcodes.
 func world_script_keys() -> Array:
 	var data_only: Dictionary = _script_data_pointers()
 	var out: Array = []
@@ -1504,22 +1485,13 @@ func mod_type_numbers() -> Array[int]:
 
 
 ## How effective [param attacking] is against [param defending], in tenths: 0 for
-## an immunity, 5 for a resistance, 20 for a weakness and 10 for everything else.
-##
-## Tenths rather than a float, because that is what the cartridge stores and what
-## the damage formula divides by, and the games truncate after each of a
-## defender's two types. A float would disagree exactly where it matters.
-##
-## Only exceptions are listed, so an absent pair is neutral, as is a type number
-## missing from the chart entirely (the padding run, where Curse lives).
-##
-## [param foresight] is whether the defender has been identified, which cancels
-## the Ghost immunities and nothing else.
-##
-## The key keeps both ids whole ([method Gen2ContentOverlay.matchup_number]) so a
-## mod type cannot alias a cartridge pair. An unmodded game answers off the
-## folded lookup alone; the overlay is asked only when a mod loaded, this being
-## the damage formula's own path.
+## an immunity, 5 for a resistance, 20 for a weakness, 10 otherwise. Tenths
+## because that is what the cartridge stores and what the damage formula divides
+## by, truncating after each of a defender's two types. Only exceptions are
+## listed, so an absent pair is neutral, as is a type missing from the chart.
+## [param foresight] cancels the Ghost immunities and nothing else. The key keeps
+## both ids whole so a mod type cannot alias a cartridge pair, and the overlay is
+## asked only when a mod loaded, this being the damage formula's own path.
 func type_matchup(attacking: int, defending: int, foresight: bool = false) -> int:
 	var key: int = Gen2ContentOverlay.matchup_number(attacking, defending)
 	if _overlay != null and not _overlay.is_empty():
@@ -1545,18 +1517,14 @@ func _matchup_row(key: int) -> Dictionary:
 	}
 
 
-## How effective [param attacking] is against a defender of one or two types,
-## in tenths, accumulated the way the cartridge accumulates it: start at ten,
-## multiply by each matching type in turn, and truncate after each.
+## How effective [param attacking] is against a defender of one or two types, in
+## tenths, accumulated the way the cartridge accumulates it: start at ten,
+## multiply by each matching type in turn, truncate after each.
 ##
 ## The number a battle announces, not the one it deals damage with. The hardware
-## computes them separately and they disagree: this accumulator truncates in
-## tenths, so a move resisted by both halves of a dual type reports 2 rather than
-## 2.5, while damage multiplies the damage itself once per type. Use this for the
-## message and [method type_matchup] per type for damage.
-##
-## A single-type Pokémon carries its type in both slots, and the cartridge
-## applies a row at most once, so a repeat is skipped here too.
+## computes them separately and they disagree: a move resisted by both halves of
+## a dual type reports 2 rather than 2.5. Use [method type_matchup] per type for
+## damage. A single-type Pokemon carries its type in both slots and repeats skip.
 func type_effectiveness(attacking: int, defending: Array, foresight: bool = false) -> int:
 	var out: int = RomLayout.MATCHUP_EFFECTIVE
 	var applied: Array = []
@@ -2130,15 +2098,14 @@ func mystery_gift_table(decorations: bool) -> Array:
 	return (_mystery_gift.get("decos" if decorations else "items", []) as Array).duplicate()
 
 
-## `LinkCommsBorderGFX`'s own strip and, on Crystal alone, the three tilemaps
-## the trade screen is laid out from. A cache imported before the border existed
+## `LinkCommsBorderGFX`'s own strip and, on Crystal alone, the three tilemaps the
+## trade screen is laid out from. A cache imported before the border existed
 ## carries neither, which is what [method has_link_border] answers for; a cache
-## that carries the strip but no screen is Gold or Silver, whose trade screen is
-## two `LinkTextboxAtHL` boxes rather than a tilemap.
-## `wOtherPlayerLinkMode`, whose address the two cartridges do not share: the
-## three receptionist scripts `readmem` it by their own profile's address, so a
-## runner writing Crystal's would leave Gold's read as zero and send every
-## player down the "can't link to the past" branch.
+## with the strip but no screen is Gold or Silver, whose trade screen is two
+## `LinkTextboxAtHL` boxes rather than a tilemap.
+## Below it, `wOtherPlayerLinkMode`, whose address the two cartridges do not
+## share: a runner writing Crystal's would leave Gold's read as zero and send
+## every player down the "can't link to the past" branch.
 func other_player_link_mode_address() -> int:
 	return _other_player_link_mode
 
@@ -2537,14 +2504,11 @@ func trainer_party_count(number: int) -> int:
 
 
 ## One of a trainer class's individual trainers, as { name, type, party }, where
-## [code]party[/code] is that trainer's Pokémon in the cartridge's own order, each
+## `party` is that trainer's Pokemon in the cartridge's own order, each
 ## { level, species, item, moves }. Empty for a class or an index this class does
-## not have.
-##
-## [code]type[/code] is one of the [code]RomLayout.TRAINER_MON_*[/code]
-## constants and decides what a member's own Pokémon means: whether it knows
-## what its level teaches it or the moves stored with it, and whether it holds
-## an item. See [Gen2TrainerParty], which turns this into battle-ready Pokémon.
+## not have. `type` is one of the `RomLayout.TRAINER_MON_*` constants and decides
+## whether a member knows what its level teaches or the moves stored with it, and
+## whether it holds an item. See [Gen2TrainerParty].
 func trainer_party(number: int, index: int) -> Dictionary:
 	var trainers: Array = trainer(number).get("trainers", [])
 	if index < 0 or index >= trainers.size():
@@ -2601,13 +2565,11 @@ func trainer_dvs(number: int) -> int:
 
 ## Where a trainer class sits in the trainer atlas. Every trainer is drawn at the
 ## same size, so unlike a species pic this one always fills its cell.
-## `GetTrainerBackpic`: the player's own 6x6 picture, which is what stands on
-## the player's square until a Pokemon is sent out. [param kind] is one of
-## [constant RomLayout.PLAYER_BACKPICS]; Gold and Silver ship no Kris, and the
-## empty Dictionary is what says so.
-## `GetPlayerOrMonPalettePointer`: the player's own colours, which is what the
-## back pic on the field is drawn in until a Pokemon replaces it. The Dude wears
-## the player's, so [param kind] is a gender rather than a picture.
+## `GetTrainerBackpic` below it is the player's own 6x6 picture, which stands on
+## the player's square until a Pokemon is sent out; Gold and Silver ship no Kris
+## and the empty Dictionary says so. `GetPlayerOrMonPalettePointer` is its
+## colours, and the Dude wears the player's, so [param kind] is a gender rather
+## than a picture.
 func player_palette(kind: String) -> PackedColorArray:
 	var stored: Variant = _player_palettes.get(kind, null)
 	if not stored is Array or (stored as Array).size() < 2:
@@ -3168,15 +3130,12 @@ func _entry(rows: Array, index: int) -> Dictionary:
 	return rows[index]
 
 
-## One numbered content row, with the mod overlay consulted first.
-##
-## The chokepoint species, moves, items and trainers all read through, and so the
-## one place that has to know a mod may have added or changed one. Everything
-## carried on a species row rides along: a defined species has a learnset,
-## evolutions and TM flags because [method learnset], [method evolutions] and the
-## TM/HM gate all read them back off this row.
-##
-## Numbering is one-based, the cartridge's own; see [Gen2ContentOverlay].
+## One numbered content row, with the mod overlay consulted first: the chokepoint
+## species, moves, items and trainers all read through, and so the one place that
+## has to know a mod may have added or changed one. Everything carried on a
+## species row rides along, because [method learnset], [method evolutions] and the
+## TM/HM gate all read them back off this row. Numbering is one-based, the
+## cartridge's own.
 func _content(kind: StringName, rows: Array, number: int) -> Dictionary:
 	return _overlaid(kind, number, _entry(rows, number - 1))
 

--- a/game/data/learnset.gd
+++ b/game/data/learnset.gd
@@ -1,25 +1,14 @@
 class_name Gen2Learnset
 extends RefCounted
 
-## What a Pokémon knows, worked out from its level-up moves.
-##
-## The cartridge asks two different questions and gets two different answers, so
-## both are here and neither is the other's shortcut:
-##
-## [method moves_at_level] furnishes a newly created Pokémon, wild, trainer-owned
-## or a starter. It walks from the beginning and stops at the first move above
-## the level being filled for.
-##
-## [method moves_learned_at] offers a just-levelled Pokémon something new. It
-## reads the whole list and takes entries at exactly the level reached.
-##
-## One species' list is not ascending (see
-## [constant RomLayout.UNSORTED_LEARNSET_SPECIES]), so the first stops early and
-## misses moves the second finds: a wild Muk really is short three moves a raised
-## Muk has.
-##
-## [RefCounted] and static: a learnset is an Array of { level, move } from
-## [GameData], and nothing here needs a cache, scene or Pokémon.
+## What a Pokemon knows, worked out from its level-up moves. The cartridge asks
+## two different questions and neither answer is the other's shortcut:
+## [method moves_at_level] furnishes a newly created Pokemon and stops at the
+## first move above the level being filled for; [method moves_learned_at] offers a
+## just-levelled one something new and takes entries at exactly the level reached.
+## One species' list is not ascending
+## ([constant RomLayout.UNSORTED_LEARNSET_SPECIES]), so a wild Muk really is short
+## three moves a raised Muk has.
 
 ## How many moves a Pokémon can know at once.
 const MOVE_SLOTS: int = 4
@@ -38,14 +27,11 @@ static func moves_at_level(learnset: Array, level: int) -> Array:
 
 
 ## `FillMoves` itself, which is what [method moves_at_level] is one call of.
-##
 ## [param known] is filled in place and may already hold moves: a slot is taken
-## when one is empty, and the four are shifted down when none is. [param above]
-## is `wPrevPartyLevel`, and passing anything above zero is the
-## `wSkipMovesBeforeLevelUp` branch, which offers only the levels *between* the
-## two. `known` grows to at most [constant MOVE_SLOTS] entries and is padded with
-## zeroes only if it arrived that way, so a party row's four-slot array stays
-## four slots.
+## when one is empty, and the four are shifted down when none is. [param above] is
+## `wPrevPartyLevel`, and anything above zero is the `wSkipMovesBeforeLevelUp`
+## branch, which offers only the levels between the two. `known` is padded with
+## zeroes only if it arrived that way, so a party row's four slots stay four.
 static func fill_moves(
 	learnset: Array, known: Array, level: int, above: int = 0
 ) -> void:

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -2,31 +2,13 @@ class_name Gen2WorldCatalog
 extends RefCounted
 
 ## Every stable gameplay SITE the cartridge hands something out at, decoded once
-## and addressed by an id that does not move: a starter, a gift, a static battle,
-## a trade, a Game Corner prize, an item on the ground, a badge and a shop.
+## and addressed by an id that does not move: starters, gifts, static battles,
+## trades, prizes, ground items, badges and shops. The host owns the decoding and
+## the mod owns the placement, so a randomizer needs no private copy of cartridge
+## semantics. A patch changes a FIELD of a row and never the script behind it.
 ##
-## Why this exists rather than a mod holding a list of script addresses: a
-## randomizer that shuffled starters by patching `ElmsLab` at $58F3 would be a
-## private copy of cartridge semantics, wrong on Gold the moment an address
-## shifts, and silently broken by any change here. The host owns the decoding;
-## the mod owns the placement.
-##
-## Nothing is imported for this. Every row is derived from data the cache already
-## holds: the decoded scripts, the map events, the mart lists and the trade
-## records. That is why there is no cache-format bump behind it and why a fresh
-## cartridge needs no re-import.
-##
-## The scan is not cheap: it decodes every command of every imported script,
-## about thirteen seconds for Crystal, and it answered 547 rows for that. So it
-## is written beside the cache as a sidecar and read back ([method to_dict]).
-## The sidecar is derived, not imported: an absent, stale or unreadable one is
-## rebuilt and written, so no cache format covers it and a cache from an older
-## build needs no re-import.
-##
-## A patch changes a FIELD of a row. It never replaces a script, a completion
-## flag, a dialogue, an inventory transaction or a battle flow: the site still
-## runs the cartridge's own code, and only the number it hands over is the mod's.
-## See [method Gen2ModHost.patch_check].
+## Nothing is imported for this: every row is derived from the cache and written
+## beside it as a sidecar, so an absent or stale one is rebuilt rather than bumped.
 
 const KIND_STARTER: StringName = &"starter"
 const KIND_GIFT: StringName = &"gift"
@@ -43,17 +25,13 @@ const KINDS: Array[StringName] = [
 	KIND_BADGE, KIND_SHOP,
 ]
 
-## `id = kind << 40 | bank << 24 | absolute address`. The address is ABSOLUTE, the
-## script's own base plus the command's offset inside it, and that is what makes
-## the id stable: the cache stores one blob per entry point and two entry points
-## into one routine overlap, so a site addressed by (blob, offset) would be
-## counted once per blob that reaches it. Addressed by the byte it lives at, it
-## is one site however many ways in there are, and a runtime reader computes the
-## same number from its own frame.
-##
-## A site that is a map EVENT rather than a script has no address: it uses the
-## map's group as the bank and [constant ID_EVENT_BIT] over the map number and
-## the event index, so the two spaces cannot collide.
+## `id = kind << 40 | bank << 24 | absolute address`. The address is ABSOLUTE,
+## the script's own base plus the command's offset, and that is what makes the id
+## stable: two entry points into one routine overlap, so a site addressed by
+## (blob, offset) would be counted once per blob that reaches it. A site that is a
+## map EVENT has no address and uses the map's group as the bank with
+## [constant ID_EVENT_BIT] over the map number and event index, so the two spaces
+## cannot collide.
 const ID_KIND_SHIFT: int = 40
 const ID_BANK_SHIFT: int = 24
 const ID_ADDRESS_MASK: int = 0xFFFFFF
@@ -121,15 +99,11 @@ static func build(data: GameData) -> Gen2WorldCatalog:
 	return out
 
 
-## The same scan, in chunks, handing the main loop a frame between them and
-## saying how far along it is.
-##
-## This walk is seven eighths of a cartridge import's wall clock: it decodes
-## every command of every script the import just wrote. Run whole it is the one
-## stretch long enough for a player to decide the launcher has stopped, so the
-## import uses this and the lazy rebuild behind [method GameData.catalog] uses
-## [method build], which has no screen to keep alive and no loop to give a frame
-## back to.
+## The same scan, in chunks, handing the main loop a frame between them and saying
+## how far along it is. This walk is seven eighths of a cartridge import's wall
+## clock, and run whole it is the one stretch long enough for a player to decide
+## the launcher has stopped. The lazy rebuild behind [method GameData.catalog]
+## uses [method build] instead, having no screen to keep alive.
 static func build_reporting(
 	data: GameData, on_progress: Callable = Callable(), yield_ms: int = 0
 ) -> Gen2WorldCatalog:
@@ -431,18 +405,13 @@ func _scan_one_script(
 
 	var commands: Array = []
 	var offset: int = 0
-	## The walk does NOT stop at the first `end` or `sjump`. A bounded blob holds
-	## a routine and the branch bodies behind it, and the Game Corner's three
-	## prizes are exactly that: one `.loop` and three labels after its jump.
-	## The bound counts `end`s, not every command that never returns: a `sjump`
-	## into a label below it is one routine, not two.
-	##
-	## It DOES stop at the first byte no command owns. Everything decoded before
-	## that came from a real entry point at a real offset; everything after would
-	## be text or a data table read as code. Two more guards sit behind this one:
-	## a site's numbers have to be ones the cartridge can hold ([method
-	## _plausible]), and a static has to be followed by the `startbattle` that
-	## makes it one.
+	## The walk does NOT stop at the first `end` or `sjump`: a bounded blob holds a
+	## routine and the branch bodies behind it, and the Game Corner's three prizes
+	## are exactly that. The bound counts `end`s rather than every command that
+	## never returns. It DOES stop at the first byte no command owns, since
+	## everything after would be text or a data table read as code. Two guards sit
+	## behind it: a site's numbers have to be ones the cartridge can hold, and a
+	## static has to be followed by the `startbattle` that makes it one.
 	var terminators: int = 0
 	for _step: int in MAX_SCRIPT_COMMANDS:
 		if offset >= body.size():
@@ -631,13 +600,10 @@ func _mart_items(index: int) -> Array:
 
 ## Stamps every script site with the MAP whose events reach it, which is the one
 ## thing a script address does not carry and a placement cannot do without: a
-## badge is only completable if its gym can be walked to.
-##
-## Each map's own event scripts are followed through `scall`, `sjump`, `farscall`
-## and the branch commands, which is the same closure the importer walks. A
-## script two maps both reach is stamped with the first in map order, so the
-## answer is stable; a script no map reaches keeps no map at all rather than a
-## guessed one.
+## badge is only completable if its gym can be walked to. Each map's event scripts
+## are followed through `scall`, `sjump`, `farscall` and the branch commands, the
+## same closure the importer walks. A script two maps reach is stamped with the
+## first in map order, so the answer is stable; one no map reaches keeps none.
 func _attribute_maps() -> void:
 	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
 	var owner: Dictionary = {}

--- a/game/data/world_progression.gd
+++ b/game/data/world_progression.gd
@@ -1,33 +1,14 @@
 class_name Gen2WorldProgression
 extends RefCounted
 
-## Whether a proposed placement can still be finished, answered by the host.
+## Whether a proposed placement can still be finished, answered by the host: a mod
+## shuffling badges and key items can write a seed nobody can beat, and the gates
+## are the cartridge's. Walks the [Gen2WorldCatalog] as a dependency graph and
+## answers with the FIRST requirement that was never satisfiable.
 ##
-## A mod shuffling badges and key items can write a seed nobody can beat, and it
-## cannot tell on its own: the gates are the cartridge's. This walks the
-## [Gen2WorldCatalog] as a dependency graph and answers deterministically, with
-## the FIRST requirement that was never satisfiable so generation can retry
-## against a reason rather than a guess.
-##
-## What it proves is one thing, exactly: that nothing critical is locked behind
-## itself. Start with nothing in hand, take every check whose requirements are
-## met, take what those checks hand over, and repeat until no new check opens.
-## A placement passes when every critical check is inside that closure.
-##
-## What it does NOT model, and why:
-##
-## - Story EVENTS. `checkevent` guards are set by story scripts a placement does
-##   not move, so an event requirement is treated as satisfiable. A shuffle that
-##   only moves rewards cannot make one unreachable.
-##
-## - A site the catalog could not attribute to a MAP. It is taken as standing
-##   wherever the player already is, which can pass a seed a walk would not; the
-##   opposite would reject good ones.
-##
-## The gates it DOES model are the ones a placement can break: an item or badge a
-## check asks for, the badge an HM needs before its move works at all, and
-## whether the map a check stands on can be WALKED to with the field moves in
-## hand, which [Gen2WorldReachability] answers off the cartridge's own collision.
+## It proves one thing: nothing critical is locked behind itself. Story events
+## and a site with no attributed map are both taken as satisfiable, since a
+## shuffle that only moves rewards cannot make either unreachable.
 
 ## What a validation answers with when it fails: which check could not be
 ## reached, and the one requirement of it that never became satisfiable.
@@ -54,13 +35,9 @@ static func reset() -> void:
 
 ## Validates [param patches], a map of catalog check id to the fields a mod
 ## proposes for it, WITHOUT installing any of them: the rows are resolved through
-## an overlay of this call's own, so the shared one and the live game are
-## untouched and two validations of two seeds cannot see each other.
-##
-## Answers
-## [code]{ok, reached, critical, missing: {check, requirement, kind}}[/code].
-## Deterministic: every walk is over ids in sorted order, so one placement always
-## answers the same way.
+## an overlay of this call's own, so two validations of two seeds cannot see each
+## other. Answers `{ok, reached, critical, missing: {check, requirement, kind}}`.
+## Deterministic: every walk is over ids in sorted order.
 static func validate(data: GameData, patches: Dictionary = {}) -> Dictionary:
 	if data == null:
 		return {"ok": false, "reason": REASON_NO_CATALOG, "reached": 0, "critical": 0}

--- a/game/data/world_reachability.gd
+++ b/game/data/world_reachability.gd
@@ -2,26 +2,13 @@ class_name Gen2WorldReachability
 extends RefCounted
 
 ## Which maps a player can stand on with a given set of field moves, derived from
-## the cartridge's own collision, warps and connections.
+## the cartridge's own collision, warps and connections: the half of a progression
+## proof that is not about rewards. Nothing here is written down, the flood asking
+## [Gen2WorldCollision] and [Gen2WorldFieldMove] what `DoPlayerMovement` asks.
 ##
-## The half of a progression proof that is not about rewards. A shuffled badge is
-## only completable if the gym holding it can be WALKED to, and walking is gated
-## by Surf, Cut, Strength, Whirlpool and Waterfall, each of which is gated by a
-## badge. Nothing here is written down: the flood asks
-## [Gen2WorldCollision] and [Gen2WorldFieldMove] the same questions
-## `DoPlayerMovement` asks.
-##
-## The unit is the MAP, not the cell. A cell-exact frontier would be the truer
-## model and is not the one to build: it would need the block-level surf rules,
-## the ledge one-way tests and the forced-tile paths as a second copy of
-## `Gen2WorldAPI`'s, and the two would drift. A map is reachable here when some
-## walkable cell of it is, which is the granularity a placement is decided at
-## anyway, since a check sits on a map.
-##
-## Deliberately CONSERVATIVE in one direction only: an edge is offered when the
-## cartridge's own collision says a step across it is possible, so this can call
-## a map reachable that a cell-exact walk would not. It never calls a reachable
-## map unreachable, which is the direction that would reject a good seed.
+## The unit is the MAP rather than the cell, which is the granularity a placement
+## is decided at, and the flood is conservative in one direction only: it can call
+## a map reachable that a cell-exact walk would not, never the reverse.
 
 ## The moves an edge can ask for, in the order a report lists them.
 const GATE_MOVES: Array[int] = [

--- a/game/import/battle_anim_importer.gd
+++ b/game/import/battle_anim_importer.gd
@@ -1,29 +1,14 @@
 class_name Gen2BattleAnimImporter
 extends RefCounted
 
-## Imports the battle animation data layer: `BattleAnimations`
-## (data/moves/animations.asm) and the four tables in data/battle_anims that the
-## objects it spawns are built from.
+## Imports the battle animation data layer: `BattleAnimations` and the four tables
+## in data/battle_anims the objects it spawns are built from. Each is a pointer
+## table immediately followed by its data with every pointer bank-local, so each
+## is cached as a whole region and a cached address resolves by subtraction.
 ##
-## Each of the five is a pointer table immediately followed by the data it points
-## at, and every pointer inside one is bank-local, so each is cached as a whole
-## region rather than entry by entry: the bytes stay the cartridge's own and a
-## cached address resolves by subtraction. Nothing is rewritten on the way in.
-##
-## The three regions in bank $33 are contiguous and do not overlap: the frameset
-## streams end where `BattleAnimOAMData` begins and its sprite data ends where
-## `AnimObjGFX` begins. Each region is still measured from its own table's
-## pointers rather than from its neighbour, so a profile that moved one would
-## still import.
-##
-## Validation walks what it stores. Every script is run to a top-level
-## `anim_ret`, every frameset stream to its terminator and every table index is
-## range-checked before anything is written, which is what makes a wrong offset
-## a refused import rather than a screen full of noise.
-##
-## The object graphics are the exception: they are LZ streams reached by far
-## pointer, so they are decoded into tile strips the way the pics and the trainer
-## card's sheets are.
+## Validation walks what it stores, which is what makes a wrong offset a refused
+## import rather than a screen full of noise. The object graphics are the
+## exception: LZ streams reached by far pointer, decoded into tile strips.
 
 ## `BattleAnim_Pound` whole, the anchor the script table was located from. Held
 ## here rather than in [RomLayout] because it is a check, not an offset: the

--- a/game/import/lz_decompressor.gd
+++ b/game/import/lz_decompressor.gd
@@ -1,27 +1,14 @@
 class_name Gen2Lz
 extends RefCounted
 
-## The LZ variant Generation 1 and 2 use for every compressed graphic.
-##
-## A stream is a run of commands, terminated by $FF. Each command byte packs a
-## 3-bit opcode and a length; opcode 7 escapes to a long form that borrows two
-## more length bits and a following byte, so a single command can span up to
-## 1024 bytes.
-##
-##   000 literal    copy the next N bytes verbatim
-##   001 iterate    repeat the next byte N times
-##   010 alternate  repeat the next two bytes, alternating, N times
-##   011 zero       N zero bytes
-##   100 repeat     copy N bytes already written, forwards
-##   101 flipped    same, with each byte's bits reversed
-##   110 reversed   same, but reading backwards from the source
-##
-## The three back-references take an offset that is either a one-byte distance
-## back from the write head (high bit set) or a two-byte absolute position from
-## the output's start (high bit clear). Sources may overlap the bytes being
-## written, which is how the format expresses runs, so the copy is
-## byte-at-a-time, not a slice. The bit-reversing opcode exists because these
-## streams encode 2bpp tiles: a mirrored sprite half is the same bytes flipped.
+## The LZ variant Generation 1 and 2 use for every compressed graphic. A stream is
+## a run of commands terminated by $FF, each packing a 3-bit opcode and a length;
+## opcode 7 escapes to a long form so one command can span 1024 bytes. The seven
+## are literal, iterate, alternate, zero, and the three back-references repeat,
+## flipped and reversed. A back-reference offset is a one-byte distance back (high
+## bit set) or a two-byte absolute position (high bit clear), and sources may
+## overlap the bytes being written, so the copy is byte-at-a-time. The
+## bit-reversing opcode exists because a mirrored 2bpp sprite half is those bytes.
 
 enum Op {
 	LITERAL,

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -1,15 +1,11 @@
 class_name Gen2Palette
 extends RefCounted
 
-## Game Boy Color palette entries.
-##
-## A colour is 15 bits packed little-endian as $0BBBBBGG GGGRRRRR, five bits
-## per channel, red in the low bits. The hardware ignores bit 15.
-##
-## A stored Pokémon palette holds only two colours; every pic uses index 0 for
-## white and index 3 for black, so only the middle pair varies. Each species
-## stores two such pairs, normal and shiny, which is all being shiny means to the
-## renderer.
+## Game Boy Color palette entries. A colour is 15 bits packed little-endian as
+## $0BBBBBGG GGGRRRRR, five bits per channel, red low, bit 15 ignored. A stored
+## Pokemon palette holds only two colours, every pic using index 0 for white and 3
+## for black, and each species stores two such pairs, normal and shiny, which is
+## all being shiny means to the renderer.
 
 const COLOR_BYTES: int = 2
 ## The two middle colours a pic is drawn with. A trainer class stores one such

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -1,18 +1,13 @@
 class_name RomCache
 extends RefCounted
 
-## Where decoded cartridge data lives between runs.
-##
-## Under [code]user://[/code], never inside the project: cartridge-derived data
-## must not be committed or exported. This is the runtime half of the rule
-## .gitignore and the pre-commit hook enforce at build time.
-##
-## One directory per dump, named by game and hash, so two revisions never share a
-## cache and a re-import cannot half-overwrite the last one.
-##
-## Pixel data is raw colour indices rather than images: it is what the renderer
-## wants, with palettes applied per species and shiny state at draw time, and it
-## avoids a decode round-trip whose exactness would have to be trusted.
+## Where decoded cartridge data lives between runs: under `user://`, never inside
+## the project, which is the runtime half of the rule .gitignore and the
+## pre-commit hook enforce at build time. One directory per dump, named by game
+## and hash, so two revisions never share a cache and a re-import cannot
+## half-overwrite the last one. Pixel data is raw colour indices rather than
+## images, which is what the renderer wants and avoids a decode round-trip whose
+## exactness would have to be trusted.
 
 const ROOT: String = "user://rom_cache"
 const MANIFEST: String = "manifest.json"

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -1,15 +1,12 @@
 class_name RomImporter
 extends RefCounted
 
-## Decodes a verified cartridge into the cache under [code]user://[/code].
-##
-## The ROM is an asset database, read once and released. Nothing downstream holds
-## a reference, and nothing in the engine reads cartridge bytes at play time.
-##
-## The order matters: verify the hash, then the layout, then decode. A wrong
-## offset produces plausible garbage rather than an error, and garbage in the
-## cache is indistinguishable from real data later, so [method verify_layout]
-## checks values whose correct answers are known independently.
+## Decodes a verified cartridge into the cache under `user://`. The ROM is an
+## asset database, read once and released: nothing downstream holds a reference
+## and nothing in the engine reads cartridge bytes at play time. The order
+## matters, hash then layout then decode, because a wrong offset produces
+## plausible garbage rather than an error and garbage in the cache is
+## indistinguishable from real data later.
 
 ## Atlas cells are the largest pic of their kind so a renderer can index them
 ## arithmetically; smaller pics sit in the top-left of their cell and record
@@ -110,33 +107,111 @@ func _breathe(yield_ms: int) -> void:
 	await Engine.get_main_loop().process_frame
 
 
+## Every layout check, in the order they run: the first that answers not ok is
+## the whole answer. `docs/CONTRIBUTING.md` says an offset lands here with its
+## check in the same commit, and this list is that list. The four importers at
+## the end own their own tables and read the cartridge without a layout.
+static var LAYOUT_CHECKS: Array[Callable] = [
+	_verify_species_names,
+	_verify_base_stats,
+	_verify_palettes,
+	_verify_move_names,
+	_verify_move_data,
+	_verify_item_names,
+	verify_item_metadata,
+	verify_world_trades,
+	_verify_type_names,
+	verify_matchups,
+	verify_evos_attacks,
+	verify_egg_moves,
+	verify_pokedex,
+	verify_font,
+	verify_frames,
+	verify_battle_graphics,
+	verify_trainers,
+	verify_trainer_parties,
+	verify_trainer_attributes,
+	verify_trainer_dvs,
+	Gen2WorldImporter.verify_layout.unbind(1),
+	Gen2WorldEncounterImporter.verify_layout.unbind(1),
+	Gen2WorldServicesImporter.verify_layout.unbind(1),
+	Gen2BattleAnimImporter.verify_layout.unbind(1),
+	verify_name_input_chars,
+	verify_mail,
+	verify_mystery_gift,
+	verify_battle_tower,
+	verify_intro_text,
+	verify_string_buffer_pointers,
+	verify_gender_screen,
+	verify_text_bg_palette,
+	verify_shrink_pics,
+	verify_copyright,
+	verify_game_freak_presents,
+	verify_title,
+	verify_town_map,
+	verify_oak_ratings,
+	verify_pokecenter_pc,
+	verify_decorations,
+	verify_mom_phone,
+	verify_unown_words,
+	verify_unown_walls,
+	verify_odd_eggs,
+	verify_intro_movie,
+	verify_gs_intro,
+	verify_unown_puzzle,
+	verify_slots,
+	verify_printer,
+	verify_link_border,
+	verify_card_flip,
+	verify_credits,
+	verify_menu_text,
+	verify_mart_text,
+	verify_name_rater_text,
+	verify_move_deleter_text,
+	verify_day_care_text,
+	verify_special_text,
+	verify_map_entry_sign,
+	verify_pack,
+	verify_pc,
+	verify_descriptions,
+]
+
+
 ## Sanity-checks [RomLayout] against the cartridge before anything is decoded.
 ## Returns { ok, message }.
 static func verify_layout(rom: RomFile) -> Dictionary:
 	var layout: Dictionary = RomLayout.for_id(rom.id)
 	if layout.is_empty():
 		return {"ok": false, "message": "No layout for %s." % rom.id}
+	for check: Callable in LAYOUT_CHECKS:
+		var result: Dictionary = check.call(rom, layout)
+		if not bool(result.get("ok", false)):
+			return result
+	return {"ok": true, "message": "Layout verified."}
 
+
+## The first and last species, decoded through the text codec. Wrong offset,
+## wrong table or wrong character map all fail here.
+static func _verify_species_names(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
-
-	# The first and last species, decoded through the text codec. Wrong offset,
-	# wrong table or wrong character map all fail here.
 	var first: String = Gen2Text.decode(
 		data, RomLayout.species_name_offset(layout, 1), RomLayout.NAME_LENGTH
 	)
 	if first != "BULBASAUR":
 		return {"ok": false, "message": "Species name table: expected BULBASAUR, read %s." % first}
-
 	var last: String = Gen2Text.decode(
 		data, RomLayout.species_name_offset(layout, RomLayout.SPECIES_COUNT),
 		RomLayout.NAME_LENGTH
 	)
 	if last != "CELEBI":
 		return {"ok": false, "message": "Species name table: expected CELEBI, read %s." % last}
+	return {"ok": true}
 
-	# Every base stats entry opens with its own Pokédex number, so the whole
-	# table self-checks in one pass, and a stride that is off by any amount
-	# stops matching immediately.
+
+## Every base stats entry opens with its own Pokedex number, so the whole table
+## self-checks in one pass, and a stride that is off by any amount stops matching
+## immediately.
+static func _verify_base_stats(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
 		var stored: int = rom.u8(RomLayout.base_stats_offset(layout, species))
 		if stored != species:
@@ -144,17 +219,19 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 				"ok": false,
 				"message": "Base stats entry %d claims to be %d." % [species, stored],
 			}
+	return {"ok": true}
 
-	# Palettes have no self-identifying field, so they are checked structurally:
-	# a colour is 15 bits, and no species is drawn in two blacks. An offset that
-	# lands on the wrong table, or a stride that runs past the end of the right
-	# one, breaks one of those. This check exists because a palette table that
-	# was one whole table too far along still decoded into sprites that were the
-	# correct shapes in the wrong colours, which nothing else would catch.
+
+## Palettes have no self-identifying field, so they are checked structurally: a
+## colour is 15 bits, and no species is drawn in two blacks. A palette table one
+## whole table too far along still decoded into sprites that were the correct
+## shapes in the wrong colours, which nothing else would catch.
+static func _verify_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var colors: int = int(float(Gen2Palette.ENTRY_BYTES) / float(Gen2Palette.COLOR_BYTES))
 	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
 		var entry: int = RomLayout.palette_offset(layout, species)
 		var packed: Array = []
-		for i: int in int(float(Gen2Palette.ENTRY_BYTES) / float(Gen2Palette.COLOR_BYTES)):
+		for i: int in colors:
 			packed.append(rom.u16le(entry + i * Gen2Palette.COLOR_BYTES))
 		for color: int in packed:
 			if color & 0x8000:
@@ -166,12 +243,16 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 				}
 		if packed.count(0) == packed.size():
 			return {"ok": false, "message": "Palette %d is blank." % species}
+	return {"ok": true}
 
-	# Move and item names are variable-length, so one wrong byte at the start
-	# slides every entry after it and still reads as words. Checking the last
-	# entry of each table catches that; checking only the first would not.
+
+## Move and item names are variable-length, so one wrong byte at the start slides
+## every entry after it and still reads as words. Checking the last entry of each
+## table catches that; checking only the first would not.
+static func _verify_move_names(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var moves: PackedStringArray = Gen2Text.decode_sequence(
-		data, int(layout["move_names"]), RomLayout.MOVE_COUNT, RomLayout.MAX_NAME_LENGTH
+		rom.bytes(), int(layout["move_names"]), RomLayout.MOVE_COUNT,
+		RomLayout.MAX_NAME_LENGTH
 	)
 	if moves.size() != RomLayout.MOVE_COUNT:
 		return {"ok": false, "message": "Move name table ran out after %d." % moves.size()}
@@ -184,10 +265,13 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 				RomLayout.MOVE_COUNT - 1
 			],
 		}
+	return {"ok": true}
 
-	# Every move entry opens with its animation, which is the move's own number,
-	# so the whole table self-checks the way the base stats do. The type byte is
-	# range-checked in the same pass because it indexes the type name table.
+
+## Every move entry opens with its animation, which is the move's own number, so
+## the whole table self-checks the way the base stats do. The type byte is
+## range-checked in the same pass because it indexes the type name table.
+static func _verify_move_data(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for move: int in range(1, RomLayout.MOVE_COUNT + 1):
 		var entry: int = RomLayout.move_data_offset(layout, move)
 		var animation: int = rom.u8(entry + RomLayout.MOVE_ANIMATION)
@@ -201,247 +285,34 @@ static func verify_layout(rom: RomFile) -> Dictionary:
 					move, type_number,
 				],
 			}
+	return {"ok": true}
 
+
+static func _verify_item_names(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var items: PackedStringArray = Gen2Text.decode_sequence(
-		data, int(layout["item_names"]), RomLayout.ITEM_COUNT, RomLayout.MAX_NAME_LENGTH
+		rom.bytes(), int(layout["item_names"]), RomLayout.ITEM_COUNT,
+		RomLayout.MAX_NAME_LENGTH
 	)
 	if items.size() != RomLayout.ITEM_COUNT:
 		return {"ok": false, "message": "Item name table ran out after %d." % items.size()}
 	if items[0] != "MASTER BALL":
 		return {"ok": false, "message": "Item name table: expected MASTER BALL, read %s." % items[0]}
-	# Four entries in, so a start that is right but a walk that is not still
-	# fails here.
+	## Four entries in, so a start that is right but a walk that is not still
+	## fails here.
 	if items[3] != "GREAT BALL":
 		return {"ok": false, "message": "Item 4: expected GREAT BALL, read %s." % items[3]}
+	return {"ok": true}
 
-	var item_metadata: Dictionary = verify_item_metadata(rom, layout)
-	if not bool(item_metadata.get("ok", false)):
-		return item_metadata
 
-	var trades: Dictionary = verify_world_trades(rom, layout)
-	if not bool(trades.get("ok", false)):
-		return trades
-
-	# The first and last type, either side of the padding run in the middle.
-	var first_type: String = type_name(rom, layout, 0)
-	if first_type != "NORMAL":
-		return {"ok": false, "message": "Type table: expected NORMAL, read %s." % first_type}
-	var last_type: String = type_name(rom, layout, RomLayout.TYPE_COUNT - 1)
-	if last_type != "DARK":
-		return {"ok": false, "message": "Type table: expected DARK, read %s." % last_type}
-
-	var matchups: Dictionary = verify_matchups(rom, layout)
-	if not matchups["ok"]:
-		return matchups
-
-	var evos_attacks: Dictionary = verify_evos_attacks(rom, layout)
-	if not evos_attacks["ok"]:
-		return evos_attacks
-
-	var egg_moves: Dictionary = verify_egg_moves(rom, layout)
-	if not egg_moves["ok"]:
-		return egg_moves
-
-	var pokedex: Dictionary = verify_pokedex(rom, layout)
-	if not pokedex["ok"]:
-		return pokedex
-
-	var font: Dictionary = verify_font(rom, layout)
-	if not font["ok"]:
-		return font
-
-	var frames: Dictionary = verify_frames(rom, layout)
-	if not frames["ok"]:
-		return frames
-
-	var battle: Dictionary = verify_battle_graphics(rom, layout)
-	if not battle["ok"]:
-		return battle
-
-	var trainers: Dictionary = verify_trainers(rom, layout)
-	if not trainers["ok"]:
-		return trainers
-
-	var trainer_parties: Dictionary = verify_trainer_parties(rom, layout)
-	if not trainer_parties["ok"]:
-		return trainer_parties
-
-	var trainer_attributes: Dictionary = verify_trainer_attributes(rom, layout)
-	if not trainer_attributes["ok"]:
-		return trainer_attributes
-
-	var trainer_dvs: Dictionary = verify_trainer_dvs(rom, layout)
-	if not trainer_dvs["ok"]:
-		return trainer_dvs
-
-	var world: Dictionary = Gen2WorldImporter.verify_layout(rom)
-	if not world["ok"]:
-		return world
-
-	var encounters: Dictionary = Gen2WorldEncounterImporter.verify_layout(rom)
-	if not encounters["ok"]:
-		return encounters
-
-	var services: Dictionary = Gen2WorldServicesImporter.verify_layout(rom)
-	if not services["ok"]:
-		return services
-
-	var battle_anims: Dictionary = Gen2BattleAnimImporter.verify_layout(rom)
-	if not battle_anims["ok"]:
-		return battle_anims
-
-	var name_input: Dictionary = verify_name_input_chars(rom, layout)
-	if not name_input["ok"]:
-		return name_input
-
-	var mail: Dictionary = verify_mail(rom, layout)
-	if not mail["ok"]:
-		return mail
-
-	var mystery_gift: Dictionary = verify_mystery_gift(rom, layout)
-	if not mystery_gift["ok"]:
-		return mystery_gift
-
-	var battle_tower: Dictionary = verify_battle_tower(rom, layout)
-	if not battle_tower["ok"]:
-		return battle_tower
-
-	var intro_text: Dictionary = verify_intro_text(rom, layout)
-	if not intro_text["ok"]:
-		return intro_text
-
-	var string_buffers: Dictionary = verify_string_buffer_pointers(rom, layout)
-	if not string_buffers["ok"]:
-		return string_buffers
-
-	var gender_screen: Dictionary = verify_gender_screen(rom, layout)
-	if not gender_screen["ok"]:
-		return gender_screen
-
-	var text_palette: Dictionary = verify_text_bg_palette(rom, layout)
-	if not text_palette["ok"]:
-		return text_palette
-
-	var shrink: Dictionary = verify_shrink_pics(rom, layout)
-	if not shrink["ok"]:
-		return shrink
-
-	var copyright: Dictionary = verify_copyright(rom, layout)
-	if not copyright["ok"]:
-		return copyright
-
-	var presents: Dictionary = verify_game_freak_presents(rom, layout)
-	if not presents["ok"]:
-		return presents
-
-	var title: Dictionary = verify_title(rom, layout)
-	if not title["ok"]:
-		return title
-
-	var town_map: Dictionary = verify_town_map(rom, layout)
-	if not town_map["ok"]:
-		return town_map
-
-	var oak_ratings: Dictionary = verify_oak_ratings(rom, layout)
-	if not oak_ratings["ok"]:
-		return oak_ratings
-
-	var pokecenter_pc: Dictionary = verify_pokecenter_pc(rom, layout)
-	if not pokecenter_pc["ok"]:
-		return pokecenter_pc
-
-	var decorations: Dictionary = verify_decorations(rom, layout)
-	if not decorations["ok"]:
-		return decorations
-	var mom_phone: Dictionary = verify_mom_phone(rom, layout)
-	if not mom_phone["ok"]:
-		return mom_phone
-
-	var unown_words: Dictionary = verify_unown_words(rom, layout)
-	if not unown_words["ok"]:
-		return unown_words
-
-	var unown_walls: Dictionary = verify_unown_walls(rom, layout)
-	if not unown_walls["ok"]:
-		return unown_walls
-
-	var odd_eggs: Dictionary = verify_odd_eggs(rom, layout)
-	if not odd_eggs["ok"]:
-		return odd_eggs
-
-	var intro_movie: Dictionary = verify_intro_movie(rom, layout)
-	if not intro_movie["ok"]:
-		return intro_movie
-
-	var gs_intro: Dictionary = verify_gs_intro(rom, layout)
-	if not gs_intro["ok"]:
-		return gs_intro
-
-	var unown_puzzle: Dictionary = verify_unown_puzzle(rom, layout)
-	if not unown_puzzle["ok"]:
-		return unown_puzzle
-
-	var slots: Dictionary = verify_slots(rom, layout)
-	if not slots["ok"]:
-		return slots
-
-	var printer: Dictionary = verify_printer(rom, layout)
-	if not printer["ok"]:
-		return printer
-
-	var link_border: Dictionary = verify_link_border(rom, layout)
-	if not link_border["ok"]:
-		return link_border
-
-	var card_flip: Dictionary = verify_card_flip(rom, layout)
-	if not card_flip["ok"]:
-		return card_flip
-
-	var credits: Dictionary = verify_credits(rom, layout)
-	if not credits["ok"]:
-		return credits
-
-	var menu_text: Dictionary = verify_menu_text(rom, layout)
-	if not menu_text["ok"]:
-		return menu_text
-
-	var mart_text: Dictionary = verify_mart_text(rom, layout)
-	if not mart_text["ok"]:
-		return mart_text
-
-	var name_rater_text: Dictionary = verify_name_rater_text(rom, layout)
-	if not name_rater_text["ok"]:
-		return name_rater_text
-
-	var move_deleter_text: Dictionary = verify_move_deleter_text(rom, layout)
-	if not move_deleter_text["ok"]:
-		return move_deleter_text
-
-	var day_care_text: Dictionary = verify_day_care_text(rom, layout)
-	if not day_care_text["ok"]:
-		return day_care_text
-
-	var special_text: Dictionary = verify_special_text(rom, layout)
-	if not special_text["ok"]:
-		return special_text
-
-	var map_entry_sign: Dictionary = verify_map_entry_sign(rom, layout)
-	if not map_entry_sign["ok"]:
-		return map_entry_sign
-
-	var pack: Dictionary = verify_pack(rom, layout)
-	if not pack["ok"]:
-		return pack
-
-	var pc: Dictionary = verify_pc(rom, layout)
-	if not pc["ok"]:
-		return pc
-
-	var descriptions: Dictionary = verify_descriptions(rom, layout)
-	if not descriptions["ok"]:
-		return descriptions
-
-	return {"ok": true, "message": "Layout verified."}
+## The first and last type, either side of the padding run in the middle.
+static func _verify_type_names(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var first: String = type_name(rom, layout, 0)
+	if first != "NORMAL":
+		return {"ok": false, "message": "Type table: expected NORMAL, read %s." % first}
+	var last: String = type_name(rom, layout, RomLayout.TYPE_COUNT - 1)
+	if last != "DARK":
+		return {"ok": false, "message": "Type table: expected DARK, read %s." % last}
+	return {"ok": true}
 
 
 ## `gfx/sgb/predef.pal`'s PREDEFPAL_GAMEFREAK_LOGO_BG, the palette
@@ -524,15 +395,13 @@ const PRESENTS_DITTO_OAM_BASES: Array[int] = [
 ]
 
 
-## `GameFreakPresents`' art, identified by content rather than by bounds.
-##
-## The 1bpp run is two graphics, so it is checked as two: every tile of the
-## thirteen-tile word strip carries ink, the six that spell "PRESENTS" are clear
-## across their top rows because that word sits a row lower than the one above
-## it, and the fourteenth tile - the logo's own top-left corner - is blank,
+## `GameFreakPresents`' art, identified by content rather than by bounds. The 1bpp
+## run is two graphics, so it is checked as two: every tile of the thirteen-tile
+## word strip carries ink, the six that spell "PRESENTS" are clear across their
+## top rows because that word sits a row lower, and the fourteenth tile is blank,
 ## which is why `GameFreakPresents_PlaceGameFreak` can use it as the space in
-## "GAME FREAK". A neighbouring 1bpp run would have to be blank in exactly that
-## tile and inked in exactly the other twelve.
+## "GAME FREAK". A neighbouring run would have to be blank in exactly that tile
+## and inked in exactly the other twelve.
 static func verify_game_freak_presents(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("game_freak_presents", {})
 	if entry.is_empty():
@@ -913,16 +782,14 @@ static func _verify_title_run(
 	return {"ok": true, "sheet": sheet, "end": at + lz.consumed}
 
 
-## The region map, identified by content rather than by bounds.
-##
-## The two region tilemaps pin the graphic they are drawn out of: every one of
-## their 720 cells names a tile inside `TownMapGFX`'s 48, which no unrelated
-## 360-byte run does, and each ends on its own `-1`. The palette map is checked
-## the same way, against the six palettes it selects between, and the palette run
-## by the off-white all six open on. The landmark table checks its two ends and
-## every name pointer in between: `SPECIAL` sits at (0,0) with the only zeroed
-## record, the last row is the Fast Ship, and a pointer that leaves the table's
-## own bank is not a name.
+## The region map, identified by content rather than by bounds. The two region
+## tilemaps pin the graphic they are drawn out of: every one of their 720 cells
+## names a tile inside `TownMapGFX`'s 48, which no unrelated 360-byte run does,
+## and each ends on its own `-1`. The palette map is checked the same way and the
+## palette run by the off-white all six open on. The landmark table checks both
+## ends and every name pointer between: `SPECIAL` sits at (0,0) with the only
+## zeroed record, the last row is the Fast Ship, and a pointer that leaves the
+## table's bank is not a name.
 static func verify_town_map(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("town_map", {})
 	if entry.is_empty():
@@ -1660,16 +1527,12 @@ static func read_oak_text(rom: RomFile, _layout: Dictionary, stub: int) -> Strin
 	return String(decoded["text"])
 
 
-## `CrystalIntro`'s art section, walked whole from its one pinned address.
-##
-## Every entry is decompressed and its length checked against what the routine
-## that loads it asks VRAM for, then the next entry's address is that length
-## rounded up to [constant RomLayout.INTRO_ENTRY_ALIGN]. Thirty-five entries in a
-## row landing on their exact sizes is what says the address is right; a walk
-## that starts anywhere else fails inside the first two.
-##
-## Returns {name: PackedByteArray} in `INTRO_SECTION` order, or an empty
-## Dictionary if any entry does not decompress to its own size.
+## `CrystalIntro`'s art section, walked whole from its one pinned address. Every
+## entry is decompressed and its length checked against what the routine that
+## loads it asks VRAM for, and the next address is that length rounded up to
+## [constant RomLayout.INTRO_ENTRY_ALIGN]. Thirty-five entries landing on their
+## exact sizes is what says the address is right; a walk that starts anywhere else
+## fails inside the first two. Returns {name: PackedByteArray}, or empty.
 static func read_intro_section(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("intro_movie", {})
 	var at: int = int(entry.get("section", -1))
@@ -1698,16 +1561,12 @@ static func read_intro_section(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return out
 
 
-## `GoldSilverIntro`'s art section, walked the same way `CrystalIntro`'s is: one
-## pinned address, each entry checked against the size the routine that loads it
-## asks VRAM for, and the next address that size rounded up to
-## [constant RomLayout.INTRO_ENTRY_ALIGN].
-##
-## The two `.tilemap`s and two `.bin`s are uncompressed and pret checks them in
-## as binary, so their lengths are the file's rather than a tile count.
-##
-## Returns {name: PackedByteArray} in `GS_INTRO_SECTION` order, or an empty
-## Dictionary if any entry does not decompress to its own size.
+## `GoldSilverIntro`'s art section, walked the way `CrystalIntro`'s is: one pinned
+## address, each entry checked against the size the routine that loads it asks
+## VRAM for, the next address that size rounded up. The two `.tilemap`s and two
+## `.bin`s are uncompressed and pret checks them in as binary, so their lengths
+## are the file's rather than a tile count. Returns {name: PackedByteArray} in
+## `GS_INTRO_SECTION` order, or empty.
 static func read_gs_intro_section(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("gs_intro", {})
 	var at: int = int(entry.get("section", -1))
@@ -2035,14 +1894,12 @@ static func _verify_intro_palette_run(
 
 
 ## The credits (`engine/movie/credits.asm`), whose five runs each pin the next.
-##
 ## `CreditsBorderGFX` is the only pinned graphics offset: the four mon sheets
 ## follow it and `CreditsScript` follows them, so the run's own length is what
 ## says the offset is right. The script's terminator then puts
-## `CreditsStringsPointers` where the layout claims it is, and the string the
-## `copyright` index names has to be the copyright screen's own, which the layout
-## pins separately in another bank. Content, not neighbours, identifies the two
-## uncompressed graphics and the palettes.
+## `CreditsStringsPointers` where the layout claims, and the string the
+## `copyright` index names has to be the copyright screen's own. Content, not
+## neighbours, identifies the two uncompressed graphics and the palettes.
 static func verify_credits(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("credits", {})
 	if entry.is_empty():
@@ -2536,18 +2393,14 @@ static func read_menu_descriptions(rom: RomFile, layout: Dictionary) -> Array[St
 	return out
 
 
-## data/text/name_input_chars.asm. Nothing in the block identifies itself, so it
-## is pinned by content at both ends of every table: row 0 has to be the nine
-## letters the table opens with, and the last row has to be the command row,
-## which is what NamingScreen_GetCursorPosition reads by column. A run of text
-## bytes elsewhere in the bank passes neither.
-## StringBufferPointers checked against what `ram/wram.asm` says about its
-## targets, not against an address this project chose.
-##
-## wStringBuffer1..5 are five consecutive `ds STRING_BUFFER_LENGTH` runs, so the
-## five general entries must sit one stride apart in the order
-## `data/text_buffers.asm` lists them. A wrong offset lands on unrelated words
-## and fails the stride; a right offset in the wrong dump fails the WRAM range.
+## data/text/name_input_chars.asm, pinned by content at both ends of every table:
+## row 0 has to be the nine letters the table opens with and the last row the
+## command row, which `NamingScreen_GetCursorPosition` reads by column. A run of
+## text bytes elsewhere passes neither.
+## Below it, `StringBufferPointers` checked against `ram/wram.asm` rather than an
+## address this project chose: `wStringBuffer1..5` are five consecutive
+## `ds STRING_BUFFER_LENGTH` runs, so the five general entries must sit one stride
+## apart in the order `data/text_buffers.asm` lists them.
 static func verify_string_buffer_pointers(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var at: int = int(layout.get("string_buffer_pointers", -1))
 	var bytes: int = RomLayout.STRING_BUFFER_POINTER_COUNT * RomLayout.STRING_BUFFER_POINTER_SIZE
@@ -2602,18 +2455,13 @@ const MAIL_PALETTE_FIRST: Array[int] = [
 
 
 ## The five mail pins, each against something only the right offset carries:
-## `MailItems`' own eleven bytes, the two mail keyboards at both ends the way
-## the name keyboards are checked, the flat tiles `gfx/mail.asm` begins and ends
-## on, and `mail.pal`'s first colour per row with black behind every one.
-##
-## The icon is checked for bounds alone: eight 2bpp tiles of a picture with no
-## structure a wrong offset would fail, and `tools/checks/mail.gd` is what looks
-## at it.
-## `data/items/mystery_gift_items.asm` and
-## `data/decorations/mystery_gift_decos.asm`, resolved through their own
-## constant blocks rather than read back out of a dump: these are what say the
-## two pins are the tables and not some other pair of adjacent runs. Identical
-## in both disassemblies.
+## `MailItems`' own eleven bytes, the two mail keyboards at both ends, the flat
+## tiles `gfx/mail.asm` begins and ends on, and `mail.pal`'s first colour per row
+## with black behind every one. The icon is checked for bounds alone, eight 2bpp
+## tiles with no structure a wrong offset would fail, and `tools/checks/mail.gd`
+## looks at it. Below, the two mystery gift tables resolved through their own
+## constant blocks rather than read back out of a dump, which is what says the
+## pins are the tables and not some other pair of adjacent runs.
 const MYSTERY_GIFT_ITEM_NUMBERS: Array[int] = [
 	0xAD, 0x4E, 0x54, 0x50, 0x4F, 0x4A, 0x29, 0x33, 0x31, 0x53, 0x2C, 0x35,
 	0x21, 0xB9, 0xBA, 0xBC, 0x6D, 0xAE, 0x27, 0x04, 0x2A, 0x2B, 0x41, 0x3F,
@@ -2807,14 +2655,12 @@ func _import_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## The Battle Tower's seven pins, each against something only the right offset
-## carries: the first and last of `BattleTowerTrainers`' 70 names with every
-## class byte in range, `BattleTowerMons`' first row and every row's level
-## agreeing with the level group it sits in, the two per-class tables' own
-## widths and values, all 120 `text_far` stubs, `Strings_L10ToL100`'s CANCEL row
-## and `MenuData_ChallengeExplanationCancel`'s three rows.
-##
-## A cartridge with no tower answers ok: Gold and Silver ship no map, routine or
-## table for it, so an absent block is the truth about them.
+## carries: the first and last of `BattleTowerTrainers`' 70 names with every class
+## byte in range, `BattleTowerMons`' first row and every row's level agreeing with
+## its level group, the two per-class tables' widths and values, all 120
+## `text_far` stubs, `Strings_L10ToL100`'s CANCEL row and
+## `MenuData_ChallengeExplanationCancel`'s three rows. A cartridge with no tower
+## answers ok: Gold and Silver ship no map, routine or table for it.
 static func verify_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if not RomLayout.has_battle_tower(layout):
 		return {"ok": true, "message": "The cartridge has no Battle Tower."}
@@ -3366,17 +3212,12 @@ static func verify_matchups(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## Walks one species' entry in the combined evolution and level-up move table.
-##
 ## Returns { evolutions, learnset }, empty if both terminators were not where a
-## well-formed entry has them. An evolution is
-## { method, parameter, condition, target }, a level-up move { level, move };
-## [code]condition[/code] is zero except for [constant RomLayout.EVOLVE_STAT],
-## the only method asking two questions.
-##
+## well-formed entry has them. `condition` is zero except for
+## [constant RomLayout.EVOLVE_STAT], the only method asking two questions.
 ## Level-up moves keep the cartridge's order rather than being sorted: the order
-## decides which move a fresh Pokémon ends up with when more than four are on
-## offer, and one species really is out of order (see
-## [constant RomLayout.UNSORTED_LEARNSET_SPECIES]).
+## decides which move a fresh Pokemon ends up with when more than four are on
+## offer, and one species really is out of order.
 static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) -> Dictionary:
 	var table: int = RomLayout.evos_attacks_pointer_offset(layout, species)
 	if not rom.in_bounds(table, RomLayout.EVOS_ATTACKS_POINTER_SIZE):
@@ -3523,18 +3364,13 @@ static func verify_egg_moves(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"ok": true, "message": ""}
 
 
-## Walks one species' Pokedex entry (data/pokemon/dex_entries.asm).
-##
-## Returns { category, height, weight, pages }, empty if the pointer or the walk
-## left the cartridge. [code]pages[/code] is always
-## [constant RomLayout.DEX_ENTRY_PAGES] strings.
-##
-## Height and weight are the cartridge's own numbers rather than converted
-## measurements: height is decimal digits of feet and inches and weight is tenths
-## of a pound, and `DisplayDexEntry` prints both by punctuating the digits. A
-## zero in either is the source's own "no measurement" and is kept, since
-## `.skip_height` and `.skip_weight` leave the row blank rather than printing a
-## zero.
+## Walks one species' Pokedex entry (data/pokemon/dex_entries.asm). Returns
+## { category, height, weight, pages }, empty if the pointer or the walk left the
+## cartridge. Height and weight are the cartridge's own numbers rather than
+## converted measurements, height being decimal digits of feet and inches and
+## weight tenths of a pound, both punctuated by `DisplayDexEntry`. A zero in
+## either is the source's own "no measurement" and is kept, since `.skip_height`
+## leaves the row blank rather than printing a zero.
 static func read_dex_entry(rom: RomFile, layout: Dictionary, species: int) -> Dictionary:
 	var table: int = RomLayout.dex_entry_pointer_offset(layout, species)
 	if not rom.in_bounds(table, RomLayout.DEX_ENTRY_POINTER_SIZE):
@@ -3577,15 +3413,13 @@ static func read_dex_entry(rom: RomFile, layout: Dictionary, species: int) -> Di
 	return {"category": category, "height": height, "weight": weight, "pages": pages}
 
 
-## The evolution and learnset table, checked species by species.
-##
-## Nothing says which species an entry belongs to, so the shape is checked: 251
-## pointers into the banked window, each naming evolutions whose methods come
-## from a set of five and whose targets are real species, then level-up moves at
-## real levels teaching real moves. A wrong pointer fails on its first byte,
-## since most byte values are neither an evolution method nor a terminator. On
-## top of that, levels ascend in all but one species, the totals are known, and
-## both ends are independently known content.
+## The evolution and learnset table, checked species by species. Nothing says
+## which species an entry belongs to, so the shape is checked: 251 pointers into
+## the banked window, each naming evolutions whose methods come from a set of five
+## and whose targets are real species, then level-up moves at real levels teaching
+## real moves. A wrong pointer fails on its first byte, since most byte values are
+## neither a method nor a terminator. On top of that, levels ascend in all but one
+## species, the totals are known, and both ends are independently known content.
 static func verify_evos_attacks(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entries: Array = []
 	var evolutions: int = 0
@@ -3755,19 +3589,13 @@ static func read_dex_order(rom: RomFile, layout: Dictionary, key: String) -> Pac
 	return out
 
 
-## The Pokedex entries and the two order tables.
-##
-## The entries have no self-identifying field, so they are checked the way the
-## palettes are: every one of the 251 has to walk to a category and two pages
-## without leaving the cartridge, and the two ends have to say what they are
-## independently known to say. A pointer table that is one entry out still walks
-## into readable text, which is why the measurements are checked and not just
-## the strings.
-##
-## Each order table has to be a permutation of the whole species range. That is
-## a stronger check than a range check: a run of legal species numbers elsewhere
-## in the bank would pass the latter, and only the real table has every species
-## exactly once.
+## The Pokedex entries and the two order tables. The entries have no
+## self-identifying field, so they are checked the way the palettes are: every one
+## of the 251 has to walk to a category and two pages without leaving the
+## cartridge, and both ends have to say what they are independently known to say.
+## A pointer table one entry out still walks into readable text, which is why the
+## measurements are checked too. Each order table has to be a permutation of the
+## whole species range, which a run of legal species numbers elsewhere would fail.
 static func verify_pokedex(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if not layout.has("pokedex"):
 		return {"ok": false, "message": "No Pokedex offsets for this game."}
@@ -3989,14 +3817,12 @@ static func verify_frames(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## The battle HUD's graphics, checked by the one thing they do that nothing else
-## in the section does: they count. The pinned palette values every bar and page
-## is drawn with are checked here too, the stats screen's included: they are the
-## same bars and the same kind of check.
-##
-## A bar's fill levels are consecutive tiles each lighting one more column, so
-## the ink climbs by exactly two pixels a step, which a wrong offset does not
-## land on. The two HUD borders have neither content nor a progression, so they
-## are checked like the text box frames: every tile has ink, no two alike.
+## in the section does: they count. A bar's fill levels are consecutive tiles each
+## lighting one more column, so the ink climbs by exactly two pixels a step, which
+## a wrong offset does not land on. The two HUD borders have neither content nor a
+## progression, so they are checked like the text box frames, every tile inked and
+## no two alike. The pinned palette values every bar and page is drawn with are
+## checked here too, the stats screen's included.
 static func verify_battle_graphics(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 
@@ -4293,20 +4119,13 @@ static func _trainer_palette_check(
 
 
 ## Reads the whole trainer party table in one pass: every class's individual
-## trainers, each a name, a type and a party.
-##
-## Not [method verify_trainers]'s table: that is the class every gym leader
-## shares ("LEADER"), this is the trainer inside it ("FALKNER"), read through
-## different pointers, one per class in both.
-##
-## Nothing in a class's bytes says where its group ends, so its span is bounded
-## by the *next* class's pointer, and the last class is walked until a byte that
-## cannot open a name. One class per game shares its pointer with the next, the
-## one class never sent into battle: its honest span is empty, not a copy of the
-## next. See [constant RomLayout.EMPTY_TRAINER_CLASS].
-##
-## Returns { ok, message, classes, total }, [code]classes[/code] being one Array
-## of trainers per class, in order.
+## trainers, each a name, a type and a party. Not [method verify_trainers]'s
+## table, which is the class every gym leader shares ("LEADER") rather than the
+## trainer inside it ("FALKNER"). Nothing in a class's bytes says where its group
+## ends, so its span is bounded by the next class's pointer and the last is walked
+## until a byte that cannot open a name. One class per game shares its pointer
+## with the next, the one class never sent into battle, and its honest span is
+## empty: see [constant RomLayout.EMPTY_TRAINER_CLASS].
 static func read_trainer_parties(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var table: int = int(layout["trainer_parties"])
@@ -5458,14 +5277,11 @@ func _import_types(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 
 
 ## Decodes the trainer classes: a name and the two colours the class is drawn in.
-##
 ## A class has one palette and no shiny counterpart, so the pair is stored flat,
-## and the pic is found by class number in the trainer atlas.
-##
-## Behind the classes sit the party table (who carries what), the attributes
-## table (how the class's AI plays it) and the DVs table. All four stay on one
-## entry rather than in separate cache files, because they are four tables one
-## class number addresses, not four separate questions.
+## and the pic is found by class number in the trainer atlas. Behind the classes
+## sit the party table, the attributes table and the DVs table, all on one entry
+## rather than in separate cache files, because they are four tables one class
+## number addresses rather than four separate questions.
 func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
 	var count: int = RomLayout.trainer_class_count(layout)
 	var names: PackedStringArray = Gen2Text.decode_sequence(
@@ -5494,13 +5310,11 @@ func _import_trainers(rom: RomFile, layout: Dictionary, on_progress: Callable) -
 
 ## The four colours a battle draws its bars in. Small enough to live in the
 ## manifest beside the atlas metadata rather than in a file of its own.
-## `GetPlayerOrMonPalettePointer`'s two: the colours the player's own back pic is
-## drawn in while it is standing on the field, before a Pokemon is sent out.
-##
-## They are the first two rows of `TrainerPalettes`, which the cartridge shares
-## with two trainer classes on purpose ("Chris uses the same colors as Cal",
-## "Kris shares Falkner's palette"), so they are read at the table rather than
-## through a class number.
+## Below, `GetPlayerOrMonPalettePointer`'s two: the colours the player's back pic
+## is drawn in before a Pokemon is sent out. They are the first two rows of
+## `TrainerPalettes`, which the cartridge shares with two trainer classes on
+## purpose ("Chris uses the same colors as Cal"), so they are read at the table
+## rather than through a class number.
 func _import_player_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var out: Dictionary = {}
 	for index: int in RomLayout.PLAYER_PALETTE_NAMES.size():
@@ -6087,13 +5901,10 @@ func _import_title(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 ## The region map's data half: both region tilemaps, `TownMapPals`' palette map,
 ## the landmark table, the palettes the six tile classes are drawn through, and
-## the other three Pokegear cards, which share the whole of that VRAM window.
-##
-## A landmark's name is kept as the codes it is rather than as text, because
+## the other three Pokegear cards, which share the whole of that VRAM window. A
+## landmark's name is kept as the codes it is rather than as text, because
 ## `TownMap_ConvertLineBreakCharacters` rewrites one of those codes before the
-## name is placed and a decoded string cannot say which byte it was: `<BSP>` is a
-## space everywhere else and a ligature ahead of it moves the character index off
-## the tile index.
+## name is placed and a decoded string cannot say which byte it was.
 func _import_town_map(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var entry: Dictionary = layout.get("town_map", {})
 	if entry.is_empty():
@@ -7059,16 +6870,12 @@ func _import_ditto_sheet(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## Decodes the fixed tile sheets: the font, the eight text box borders and the
-## battle HUD's graphics, each as one strip of tiles.
-##
-## None is compressed or per-species, so there is nothing to look up: each is a
-## fixed run of tiles at a known place. Strips, because each is addressed by a
-## number (a character code, a tile in a bar) and a strip turns that number into
-## a horizontal offset and nothing else.
-##
-## [code]first_code[/code] is the character code the first tile draws, zero for
-## graphics sheets. [code]bits[/code] is the cartridge's storage: font and
-## borders 1bpp, battle graphics 2bpp.
+## battle HUD's graphics, each as one strip of tiles. None is compressed or
+## per-species, so there is nothing to look up. Strips, because each is addressed
+## by a number (a character code, a tile in a bar) and a strip turns that number
+## into a horizontal offset and nothing else. `first_code` is the character code
+## the first tile draws, zero for graphics sheets; `bits` is the cartridge's
+## storage, font and borders 1bpp and battle graphics 2bpp.
 func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
 	var card: Dictionary = layout["trainer_card"]
@@ -7737,13 +7544,10 @@ func _blit_pic(
 
 ## `AnimateFrontpic`'s tables: one record per species and one per Unown letter,
 ## each carrying the two scripts and the frames they name. Empty for a cartridge
-## with no `pic_anim` pins, which is Gold and Silver: neither ships
-## `pic_animation.asm` and both send-outs reach `PlayStereoCry` directly.
-##
-## A frame is stored as its bitmask followed by its tile numbers, which is what
-## `PokeAnim_GetFrame` reads in that order, so one byte run holds a frame and
-## the bitmask table's own deduplication is resolved here rather than at every
-## draw.
+## with no `pic_anim` pins, which is Gold and Silver. A frame is stored as its
+## bitmask followed by its tile numbers, which is what `PokeAnim_GetFrame` reads
+## in that order, so one byte run holds a frame and the bitmask table's own
+## deduplication is resolved here rather than at every draw.
 func _import_pic_anims(rom: RomFile, layout: Dictionary, species: Array) -> Dictionary:
 	var pins: Dictionary = RomLayout.pic_anim(layout)
 	if pins.is_empty():

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -3,20 +3,12 @@ extends RefCounted
 
 ## Where the data lives inside each supported cartridge. Offsets are absolute
 ## positions in the 2 MiB dump rather than bank:address pairs, so a decoder never
-## thinks about banking; Gold and Silver share the bank map with a few per-game
-## sections, and Crystal moved almost everything and is its own table.
-##
-## Every offset was located in the cartridges themselves, by searching for
-## independently known bytes (the encoded "BULBASAUR", Bulbasaur's published base
-## stats), then cross-checked against pret for structure. A table is a claim
-## about a specific dump, which is why an uncharacterised ROM is refused rather
-## than guessed at, and an offset is only trustworthy alongside its check in
-## [method RomImporter.verify_layout].
-##
-## So the comments here are dense on purpose and this file is the one exemption
-## from the density rule in `docs/CONTRIBUTING.md`: most of them record how an
-## offset was found, which is the evidence for a number rather than a restatement
-## of the code beside it. Tighten the wording, never delete the derivation.
+## thinks about banking; Gold and Silver share the bank map and Crystal is its own
+## table. Every offset was located in the cartridges themselves, by searching for
+## independently known bytes, then cross-checked against pret for structure. A
+## table is a claim about a specific dump, so an uncharacterised ROM is refused
+## rather than guessed at, and a comment here records how an offset was FOUND:
+## that is evidence rather than restatement, so tighten it and never delete it.
 
 const SPECIES_COUNT: int = 251
 ## `GetMonFramesPointer`'s `cp JOHTO_POKEMON`: the frame data below this species
@@ -100,18 +92,14 @@ const ASLEEP_TREEMON_MAX_ROWS: int = 16
 ## values are the source's integer `$FF / 100 * percent` expressions.
 const WILD_SURF_LEVEL_THRESHOLDS: Array[int] = [89, 165, 216, 242]
 
-## Two blocks of 96 tiles: `LoadTilesetGFX` (home/map.asm) copies the first to
-## vTiles2 in VRAM bank 0 and the second to vTiles5 in bank 1 at the same tile
-## numbers, and a metatile byte with bit 7 set names the second, since
-## `_LoadOverworldAttrmapPals` reads the palette map at the full byte, takes bit
-## 3 of the nibble as the bank, then clears bit 7. So the span is 224: block 0 at
-## 0..95, `_LoadFontsExtra1`'s 32 font tiles at 96..127, block 1 at 128..223. The
-## strip carries all 224 with the font gap blank, indexed directly.
-##
-## Eight tilesets compress one block only; the cartridge copies whatever follows
-## into bank 1 and no block of theirs names it, so the import blanks it. Metatile
-## and collision tables are shorter for tilesets under 128 blocks and unused
-## entries may hold $FF, which is why a tile past the span resolves to 0.
+## Two blocks of 96 tiles: `LoadTilesetGFX` copies the first to vTiles2 in VRAM
+## bank 0 and the second to vTiles5 in bank 1 at the same tile numbers, and a
+## metatile byte with bit 7 set names the second. So the span is 224: block 0 at
+## 0..95, `_LoadFontsExtra1`'s 32 font tiles at 96..127, block 1 at 128..223, and
+## the strip carries all 224 with the font gap blank. Eight tilesets compress one
+## block only and no block of theirs names the second, so the import blanks it;
+## tables are shorter under 128 blocks and unused entries may hold $FF, which is
+## why a tile past the span resolves to 0.
 const TILESET_RECORD_SIZE: int = 15
 const TILESET_TILE_COUNT: int = 224
 const TILESET_BLOCK_TILES: int = 96
@@ -498,14 +486,12 @@ const MAX_LEVEL_UP_MOVES: int = 32
 const EVOLUTION_COUNT: int = 122
 
 ## Muk, whose level-up moves are not in ascending order. The cartridges ship it
-## that way in all three games, and it is not a decoding artefact: pret's own
-## listing carries a comment saying so.
-##
+## that way in all three games and pret's own listing carries a comment saying so.
 ## Named rather than worked around, because the order is load bearing: filling a
-## fresh Pokémon stops at the first entry above its level, so a Muk below 45
-## never reaches the three moves after the level 45 one. Checking the order
-## everywhere else is worth the exception, since scrambled levels are exactly
-## what a wrong offset produces.
+## fresh Pokemon stops at the first entry above its level, so a Muk below 45 never
+## reaches the three moves after the level 45 one. Checking the order everywhere
+## else is worth the exception, since scrambled levels are what a wrong offset
+## produces.
 const UNSORTED_LEARNSET_SPECIES: int = 89
 
 ## Unown's entry in the main pic table is a deliberate $FF placeholder: its 26
@@ -513,16 +499,13 @@ const UNSORTED_LEARNSET_SPECIES: int = 89
 const UNOWN_SPECIES: int = 201
 const UNOWN_FORMS: int = 26
 
-## `UnownWords` (data/pokemon/unown_words.asm): a pointer per form and then the
-## words themselves, laid down in the same order, so the table's own first entry
-## is where the run behind it starts. The table has one entry more than there are
-## forms because its zeroth is an unused duplicate of A's, and `PrintUnownWord`
-## indexes it by form number rather than by position.
-##
-## A word is not text: `unownword` stores each letter as `FIRST_UNOWN_CHAR + the
-## letter's rank`, which is the tile number of the Unown font
-## `Pokedex_LoadUnownFont` builds, and terminates with $FF. So it decodes with
-## the alphabet alone and never through [Gen2Text].
+## `UnownWords`: a pointer per form and then the words themselves in the same
+## order, so the table's first entry is where the run behind it starts. The table
+## has one entry more than there are forms because its zeroth is an unused
+## duplicate of A's, and `PrintUnownWord` indexes it by form number. A word is not
+## text: `unownword` stores each letter as `FIRST_UNOWN_CHAR + the letter's rank`,
+## the tile number of the font `Pokedex_LoadUnownFont` builds, terminated with
+## $FF, so it decodes with the alphabet alone and never through [Gen2Text].
 const UNOWN_WORD_ENTRIES: int = UNOWN_FORMS + 1
 const UNOWN_WORD_POINTER_SIZE: int = 2
 const FIRST_UNOWN_CHAR: int = 0x40
@@ -530,15 +513,13 @@ const UNOWN_WORD_TERMINATOR: int = 0xFF
 ## Well past REASSURE, the longest at eight.
 const UNOWN_WORD_MAX_LENGTH: int = 16
 
-## `UnownWalls` (data/events/unown_walls.asm): the four words the Ruins of Alph
-## chamber walls spell, in `UNOWNWORDS_*` order, ending at $FF. Crystal only,
-## since Gold and Silver's chambers carry the puzzle sign where Crystal carries
-## the pattern.
-##
-## A letter is stored under the `unown` charmap rather than the ordinary one:
-## `$10 * (i / 8) + 2 * i` over "ABCDEFGHIJKLMNOPQRSTUVWXYZ-", which is the
-## top-left tile of that letter's 2x2 block in a sixteen-tile-wide font. So the
-## codes run 0-14, 32-46, 64-78 and 96-100, always even, and nothing else decodes.
+## `UnownWalls`: the four words the Ruins of Alph chamber walls spell, in
+## `UNOWNWORDS_*` order, ending at $FF. Crystal only, since Gold and Silver's
+## chambers carry the puzzle sign where Crystal carries the pattern. A letter is
+## stored under the `unown` charmap: `$10 * (i / 8) + 2 * i` over the alphabet and
+## a dash, which is the top-left tile of that letter's 2x2 block in a
+## sixteen-tile-wide font, so the codes run 0-14, 32-46, 64-78 and 96-100, always
+## even, and nothing else decodes.
 const UNOWN_WALL_COUNT: int = 4
 const UNOWN_WALL_MAX_LENGTH: int = 12
 const UNOWN_WALL_TERMINATOR: int = 0xFF
@@ -575,13 +556,12 @@ const FONT_BLANK_RUNS: Array = [[0xBA, 0xBF], [0xC6, 0xCF], [0xD7, 0xDE]]
 
 ## `FontExtra`, the 2bpp sheet `_LoadFontsExtra1` parks under the main font.
 ## Thirty-two tiles stored, of which it copies `FontExtra + 3 tiles` to
-## `vTiles2 tile '<BOLD_D>'` for 22, so a tile is addressed by its code minus
-## $60 and the run that reaches the screen is $63 to $78. That run carries the
+## `vTiles2 tile '<BOLD_D>'` for 22, so a tile is addressed by its code minus $60
+## and the run that reaches the screen is $63 to $78. That run carries the
 ## ellipsis, the two quotes, the middle dot and `<COLON>`, which is every
-## character [Gen2Text] decodes below the main font's own $80 and the reason a
-## text saying "…" drew nothing without it. Codes $60 to $62 are overwritten by
-## `FontsExtra_SolidBlackGFX`, `FontsExtra2_UpArrowGFX` and
-## `PokegearPhoneIconGFX` and are stored but never drawn from here.
+## character [Gen2Text] decodes below the main font's $80 and the reason a text
+## saying an ellipsis drew nothing without it. Codes $60 to $62 are overwritten
+## elsewhere and are stored but never drawn from here.
 const FONT_EXTRA_TILES: int = 32
 const FONT_EXTRA_FIRST_CODE: int = 0x60
 const FONT_EXTRA_LOADED_FIRST: int = 0x63
@@ -661,11 +641,8 @@ const STATS_SHINY_TILE: int = 14
 ## is six tiles but `_Option`'s page 1 asks for 86, running on into `LeaderGFX`,
 ## so page 1's strip is those 86 from the card_status offset; pages 2 and 3 load
 ## 86 from the leaders offset, which overlaps it, and both are imported because
-## that is what each page draws.
-##
-## The pic is 5x7. Crystal stores it column-major (`--columns` plus
-## `PlaceGraphic`) and Gold and Silver row-major (their inline `.row`/`.col`
-## loop), so the importer reorders Crystal's and both reach the screen alike.
+## that is what each page draws. The pic is 5x7, stored column-major on Crystal
+## and row-major on Gold and Silver, so the importer reorders Crystal's.
 const CARD_STATUS_TILES: int = 86
 const CARD_LEADER_TILES: int = 86
 const CARD_BADGE_TILES: int = 44
@@ -675,24 +652,14 @@ const CARD_PIC_COLUMNS: int = 5
 const CARD_PIC_ROWS: int = 7
 const CARD_PIC_TILES: int = CARD_PIC_COLUMNS * CARD_PIC_ROWS
 
-## The Pokedex's graphics (engine/pokedex/pokedex.asm). `PokedexLZ` is the 58
-## tiles `Pokedex_LoadGFX` decompresses to `vTiles2 tile $31` and
-## `PokedexSlowpokeLZ` the 55 it decompresses to `vTiles0` straight after.
-##
-## Neither is what an unseen species is drawn as: `Pokedex_LoadSelectedMonTiles`
-## sends that case to `LoadQuestionMarkPic` and `gfx/pokedex/question_mark.2bpp.lz`,
-## which is `question_mark` below.
-## The first two were located by compressing the pinned `gfx/pokedex` PNGs with
-## pret's `tools/lzcompress` flags: each hits once per dump and the second follows
-## the first, which is the source's own order. The question mark's own PNG would
-## not match a compressed stream in any tile order or polarity, so it was found
-## by its shape instead: exactly one LZ run in each dump decompresses to 49
-## tiles and nothing else does, and all three carry the same picture.
-##
-## `Footprints` is 1bpp and uncompressed, 251 species of four tiles stored as
-## eight top halves then the eight matching bottoms, which is why a bottom half
-## sits [constant FOOTPRINT_HALF_STRIDE] tiles past its top. The 8 KiB run
-## matches once per dump and is byte identical on all three.
+## The Pokedex's graphics (engine/pokedex/pokedex.asm): `PokedexLZ`'s 58 tiles to
+## `vTiles2 tile $31` and `PokedexSlowpokeLZ`'s 55 to `vTiles0` straight after.
+## Neither is what an unseen species is drawn as; that is `question_mark` below.
+## The first two were located by compressing the pinned PNGs with pret's
+## `lzcompress` flags, each hitting once per dump in the source's own order. The
+## question mark's PNG matched nothing, so it was found by shape: exactly one LZ
+## run per dump decompresses to 49 tiles. `Footprints` is 1bpp and uncompressed,
+## eight top halves then their bottoms, hence [constant FOOTPRINT_HALF_STRIDE].
 const POKEDEX_TILES: int = 58
 const POKEDEX_SLOWPOKE_TILES: int = 55
 ## `LoadQuestionMarkPic`, whose `ld c, 7 * 7` is what the copy out of `sScratch`
@@ -1168,29 +1135,13 @@ const GS_INTRO_MAGIKARP_PALETTES: int = 2
 const GS_INTRO_SHELLDER_LAPRAS_PALETTES: int = 3
 
 ## `PREDEFPAL_BLACKOUT`, which is what `_CGB_BattleGrayscale` fills every
-## background and object palette with: `PalPacket_BattleGrayscale` is
-## `sgb_pal_set BLACKOUT, BLACKOUT, BLACKOUT, BLACKOUT` and `CopyPalettes` reads
-## each of those bytes as an index into `PredefPals` rather than as a colour.
-##
-## Despite the name it is not black: $7FFF, $1CE7, $0C62, $0000, the grayscale
-## ramp the whole battle is drawn in until `GetSGBLayout SCGB_BATTLE_COLORS`
-## runs, which is after `BattleIntroSlidingPics`. Identical in all three dumps.
-## `_CGB_MoveList`'s own background palette, which is why the move screen is
-## the same warm gold as Goldenrod City rather than white.
-## `_UnownPuzzle`'s art (engine/games/unown_puzzle.asm), as (cache name, kind,
-## tiles). `raw` is an uncompressed strip, everything else an LZ one of that many
-## tiles. The order is the routine's own INCBIN order and is what the walk
-## depends on: `UnownPuzzleCursorGFX` pins the six behind it, each address the
-## previous entry's own consumed length, and all six reproduce pret's build byte
-## for byte on all three cartridges.
-##
-## `tile_borders` is pinned separately because it is not in that run:
-## `LoadUnownPuzzlePiecesGFX` and its pointer table sit between the borders and
-## the cursor, which is thirty-four bytes of code inside the data.
-##
-## A puzzle picture is six by six tiles and `ConvertLoadedPuzzlePieces` doubles
-## it to twelve by twelve, so the sixteen three-by-three pieces come out of one
-## 36-tile strip.
+## background and object palette with. Despite the name it is not black: $7FFF,
+## $1CE7, $0C62, $0000, the grayscale ramp the whole battle is drawn in until
+## `GetSGBLayout SCGB_BATTLE_COLORS` runs after `BattleIntroSlidingPics`.
+## Below it, `_CGB_MoveList`'s own background palette, and `_UnownPuzzle`'s art as
+## (cache name, kind, tiles) in the routine's own INCBIN order, which is what the
+## walk depends on. `tile_borders` is pinned separately because thirty-four bytes
+## of code sit inside that data.
 const UNOWN_PUZZLE_SECTION: Array[Array] = [
 	["cursor", "raw", 4],
 	["start_cancel", "lz", 19],
@@ -1239,13 +1190,11 @@ const DIPLOMA_TILEMAP_BYTES: int = 360
 
 ## `LinkCommsBorderGFX`, the trade screen's own border, and the tilemaps behind
 ## it. The two cartridges draw the same screen out of very different amounts of
-## data: Gold and Silver load nine tiles to `vTiles2 tile $76` and let
-## `PlaceTradeScreenTextbox` draw two ordinary boxes with them, while Crystal
-## loads seventy tiles to `vTiles2` and lays a whole screen of them down from
-## `MobileTradeBorderTilemap` with the two cable rows written over its top and
-## bottom. `_LinkTextbox`'s own eight corner and edge tiles are `$30` to `$37`
-## of Crystal's block, which is what `LinkComms_LoadPleaseWaitTextboxBorderGFX`
-## copies to `$76` when only the box is wanted.
+## data: Gold and Silver load nine tiles and let `PlaceTradeScreenTextbox` draw
+## two ordinary boxes, while Crystal loads seventy and lays a whole screen down
+## from `MobileTradeBorderTilemap` with the two cable rows over its top and
+## bottom. `_LinkTextbox`'s eight corner and edge tiles are `$30` to `$37` of
+## Crystal's block, which is what is copied to `$76` when only the box is wanted.
 const LINK_BORDER_TILES_CRYSTAL: int = 70
 const LINK_BORDER_TILES_GOLD_SILVER: int = 9
 ## `_LinkTextbox`'s `$30`, the first of the eight tiles it draws a box from.
@@ -1316,14 +1265,12 @@ const SLOTS_TEXT_RUNS: Array = [
 
 
 ## `_CardFlip`'s own art run (engine/games/card_flip.asm), as (cache name, kind,
-## tiles). `raw` is an uncompressed strip of that many tiles, `lz` a compressed
-## one. The order is the routine's own INCBIN order and the walk is what pins
+## tiles). The order is the routine's own INCBIN order and the walk is what pins
 ## it: `.palettes` sits nine palettes in front of `CardFlipLZ03` and
 ## `CardFlipTilemap` behind `CardFlipLZ02`, so five entries landing on their own
-## sizes puts the walk on the tilemap's own independently found address.
-##
-## `off` and `on` are the two light bulbs `_CardFlip` copies over the font's own
-## "♂" and "♀", which is why `CARD_FLIP_LIGHT_OFF_TILE` is a character code.
+## sizes puts the walk on the tilemap's independently found address. `off` and
+## `on` are the two light bulbs `_CardFlip` copies over the font's own gender
+## signs, which is why `CARD_FLIP_LIGHT_OFF_TILE` is a character code.
 const CARD_FLIP_SECTION: Array[Array] = [
 	["card_flip_3", "lz", 7],
 	["card_flip_off", "raw", 1],
@@ -1712,14 +1659,12 @@ const LANDMARK_NAME_BYTES: int = 18
 
 ## The battle animation data layer: the per-move scripts and the four tables the
 ## objects they spawn are built from. All five are stored as contiguous regions
-## rather than entry by entry, each being a pointer table followed by the
-## bank-local data it points at, so a cached address resolves by subtraction and
-## the bytes stay the cartridge's ([Gen2BattleAnimImporter]).
-##
-## `BattleAnimations` (data/moves/animations.asm) is indexed by move number, so
-## entry 0 is `BattleAnim_Dummy` and 1 `BattleAnim_Pound`. Entries past
-## [constant MOVE_COUNT] are the four the table pads to $100 with and then the
-## non-move animations `wFXAnimID`'s high byte reaches.
+## rather than entry by entry, each a pointer table followed by the bank-local
+## data it points at, so a cached address resolves by subtraction.
+## `BattleAnimations` is indexed by move number, so entry 0 is `BattleAnim_Dummy`
+## and 1 `BattleAnim_Pound`; entries past [constant MOVE_COUNT] are the four the
+## table pads to $100 with and the non-move animations `wFXAnimID`'s high byte
+## reaches.
 const BATTLE_ANIM_SCRIPT_COUNT: int = 278
 const BATTLE_ANIM_OBJECT_COUNT: int = 188
 const BATTLE_ANIM_OBJECT_SIZE: int = 6
@@ -2338,14 +2283,13 @@ const GOLD_SILVER: Dictionary = {
 		"badge_palette": 0xA385,
 	},
 	# The region map. `johto`, `kanto`, `palette_map` and `palette` were matched
-	# from the assembled gfx/pokegear files, the three graphics by decompressing
-	# at every offset and keeping the run reproducing the PNG, and the landmark
-	# table by its x,y pairs at a stride of four, which nothing else matches.
-	# Every hit is unique per dump. `cards` is the three card tilemaps as one run
-	# from the pinned .rle files and `card_texts` the run of five that opens on
-	# `_GearEllipseText`. Nested
-	# like trainer_card, so Gold and Silver's absent female palette stays out of
-	# the flat offset checks.
+	# from the assembled gfx/pokegear files, the graphics by decompressing at every
+	# offset and keeping the run reproducing the PNG, and the landmark table by its
+	# x,y pairs at a stride of four, which nothing else matches. Every hit is
+	# unique per dump. `cards` is the three card tilemaps as one run and
+	# `card_texts` the run of five opening on `_GearEllipseText`. Nested like
+	# trainer_card, so Gold and Silver's absent female palette stays out of the
+	# flat offset checks.
 	"town_map": {
 		"gfx": 0xF8C92,
 		"pokegear_gfx": 0x1C0E43,
@@ -2812,14 +2756,12 @@ const CRYSTAL: Dictionary = {
 	# The same table; Crystal has no Gold and Silver intro to pin it under.
 	"predef_pals": 0x9DF6,
 	# `AnimateFrontpic`'s five tables, Crystal's alone: pokegold ships no
-	# `pic_animation.asm`, no `anim.asm`, no bitmasks and no frames, and both of
-	# its send-outs reach `PlayStereoCry` directly. Every address here is
-	# rgblink's own, from a `pokecrystal11.gbc` byte identical to the dump.
-	#
-	# A script pointer and a bitmask pointer are read in the table's own bank; a
-	# frames pointer is read in the bank its *data* lives in, which is
-	# `KantoFrames` below species [constant JOHTO_SPECIES] and `JohtoFrames`
-	# from it (`GetMonFramesPointer`).
+	# `pic_animation.asm`, no bitmasks and no frames, and both of its send-outs
+	# reach `PlayStereoCry` directly. Every address here is rgblink's own, from a
+	# `pokecrystal11.gbc` byte identical to the dump. A script pointer and a
+	# bitmask pointer are read in the table's own bank; a frames pointer is read in
+	# the bank its *data* lives in, `KantoFrames` below
+	# [constant JOHTO_SPECIES] and `JohtoFrames` from it.
 	"pic_anim": {
 		"scripts": 0xD0695,
 		"idle_scripts": 0xD16A3,
@@ -3041,17 +2983,13 @@ const CRYSTAL: Dictionary = {
 	# strings: `db "GAME FREAK@"` is eleven bytes and the INCBIN follows it.
 	"diploma": 0x1DD805,
 	# `LinkCommsBorderGFX` and, sixty-eight bytes of code behind it,
-	# `MobileTradeBorderTilemap` with the two cable strips laid out after it.
-	# Located off the border tiles themselves, which are a byte-exact match for
-	# `gfx/trade/border_tiles.png`; the tilemaps are pinned separately because
-	# `__LoadTradeScreenBorderGFX`, `LoadMobileTradeBorderTilemap` and
-	# `TestMobileTradeBorderTilemap` sit between the two.
-	# `InitMysteryGiftLayout`'s own `ld bc, $43 tiles`, uncompressed and
-	# straight into vTiles2, so the pin is a bounds check against the run the
-	# routine indexes rather than a decompression. `_CGB_MysteryGift` copies two
-	# palettes where Gold and Silver copy one. Located off
-	# `.String_PressAToLink_BToCancel`, the inline `db` string a page in front of
-	# the eight `text_far` stubs, which is the only plain text in the routine.
+	# `MobileTradeBorderTilemap` with the two cable strips after it. Located off the
+	# border tiles themselves, a byte-exact match for `gfx/trade/border_tiles.png`;
+	# the tilemaps are pinned separately because three routines sit between them.
+	# Below, `InitMysteryGiftLayout`'s own `ld bc, $43 tiles`, uncompressed and
+	# straight into vTiles2, so the pin is a bounds check rather than a
+	# decompression. Located off `.String_PressAToLink_BToCancel`, the only plain
+	# text in the routine.
 	"mystery_gift": {
 		"gfx": 0x105258, "tiles": 0x43,
 		"background": -1, "gfx2": -1,
@@ -3153,17 +3091,13 @@ const CRYSTAL: Dictionary = {
 		"icon": 0x11EF4,
 	},
 	# The Battle Tower, which Gold and Silver have no map, routine or table for.
-	# `trainers` is `BattleTowerTrainers`' 70 rows, `mons` the ten level groups
-	# of 21 nicknamed party-mon structs, `class_genders` and `class_sprites` the
-	# two per-class tables `BattleTowerText` and
-	# `LoadOpponentTrainerAndPokemonWithOTSprite` index, `trainer_text` the 120
-	# `text_far` stubs behind `BTMaleTrainerTexts`, `level_strings`
+	# `trainers` is `BattleTowerTrainers`' 70 rows, `mons` the ten level groups of
+	# 21 nicknamed party-mon structs, `class_genders` and `class_sprites` the two
+	# per-class tables, `trainer_text` the 120 `text_far` stubs, `level_strings`
 	# `Strings_L10ToL100` and `challenge_menu`
 	# `MenuData_ChallengeExplanationCancel`. Each hits once.
-	#
-	# `BattleTowerTrainerData` is deliberately not here: its 36 bytes per trainer
-	# are the mobile greeting's easy-chat word pairs, which `Function17042c`
-	# alone walks, and nothing on the local challenge reads them.
+	# `BattleTowerTrainerData` is deliberately absent: its 36 bytes per trainer are
+	# the mobile greeting's word pairs and nothing on a local challenge reads them.
 	"battle_tower": {
 		"trainers": 0x1F814E,
 		"mons": 0x1F8450,

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -3,16 +3,12 @@ extends RefCounted
 
 ## The Generation 2 character encoding, for the international ROMs. One byte per
 ## character terminated by $50, the alphabet in runs: $80 is "A", $A0 is "a", $F6
-## is "0". Some codes expand to whole words ($5D is "TRAINER") or name the player
-## at print time ($52); those stay bracketed markers so nothing is silently lost.
-## The Japanese cartridges reuse most of this range for kana, are not in
-## [RomRegistry], and would decode into nonsense here.
-##
-## A byte does not name a character on its own: `constants/charmap.asm` maps the
-## $60 to $7F run twice, from `gfx/font/font.png` and from
-## `gfx/font/font_battle_extra.png`, and $6e three times, so a byte means
-## whichever strip the hardware last loaded. Every entry point takes the strip,
-## defaulting to the main font that all but the battle and Hall of Fame have up.
+## is "0". Some codes expand to whole words or name the player at print time;
+## those stay bracketed markers so nothing is silently lost. The Japanese
+## cartridges reuse most of this range for kana and are not in [RomRegistry]. A
+## byte does not name a character on its own: `constants/charmap.asm` maps the
+## $60 to $7F run twice and $6e three times, so a byte means whichever strip the
+## hardware last loaded, and every entry point takes the strip.
 
 const TERMINATOR: int = 0x50
 const SPACE: int = 0x7F

--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -1,24 +1,14 @@
 class_name Gen2TextStream
 extends RefCounted
 
-## `home/text.asm`'s printer: the layer above [Gen2Text].
-##
-## A cartridge text is two languages, not one. `DoTextUntilTerminator` reads
-## *text commands*, `$00` to `$16`, each with its own operand width; `TX_START`
-## hands the bytes after it to `PlaceString`, which reads *characters* and runs
-## `CheckDict` over the ones that are not glyphs. The same byte means different
-## things in the two: `$16` is `TX_FAR` to the command loop and `<CR>` to
-## `CheckDict`, `$50` ends a literal for one and the whole text for the other.
-##
-## Reading a text with the character table alone prints the command bytes. That
-## is where `?06?` (`TX_PROMPT_BUTTON`), `?00?` (`TX_START`) and a whole
-## `text_ram` pointer drawn as `?01?e?CF?` came from, and why `$50` looked like a
-## page break: it is `@`, and `_OakText2` ends on one, so a reader that treated
-## it as a break walked straight into `_OakText3` and `_OakText4`.
-##
-## Names are substituted here rather than left as markers, because this is the
-## layer that knows them: `PrintPlayerName` and its siblings are `CheckDict`
-## entries, not something a later pass can spot in a string.
+## `home/text.asm`'s printer: the layer above [Gen2Text]. A cartridge text is two
+## languages, not one. `DoTextUntilTerminator` reads *text commands*, `$00` to
+## `$16`, each with its own operand width; `TX_START` hands what follows to
+## `PlaceString`, which reads *characters*. The same byte means different things
+## in the two: `$16` is `TX_FAR` to one and `<CR>` to the other, and `$50` ends a
+## literal for one and the whole text for the other, which is why a reader that
+## treated it as a page break walked straight into the next text. Names are
+## substituted here, because `PrintPlayerName` is a `CheckDict` entry.
 
 ## `macros/scripts/text.asm`, the `TextCommands` indices.
 const TX_START: int = 0x00
@@ -69,16 +59,12 @@ const CHAR_DONE: int = 0x57
 const CHAR_PROMPT: int = 0x58
 const CHAR_DEXEND: int = 0x5F
 
-## What the two waits become in the laid-out string.
-##
-## `Paragraph` clears the box and starts again at the top line; `_ContText`
-## scrolls by one line and starts at the bottom, so the line above stays on
-## screen. They are different breaks, and a layout that cannot tell them apart
-## drops a line every time a paragraph runs past two lines.
-##
-## Private-use code points rather than control characters: a cache is JSON,
-## and Godot writes U+000B as `\v`, which JSON has no escape for. Nothing in
-## [method Gen2Text.character] can produce either of these.
+## What the two waits become in the laid-out string. `Paragraph` clears the box
+## and starts again at the top line; `_ContText` scrolls by one line and starts at
+## the bottom, so the line above stays on screen. A layout that cannot tell them
+## apart drops a line every time a paragraph runs past two lines. Private-use code
+## points rather than control characters: a cache is JSON and Godot writes U+000B
+## as `\v`, which JSON has no escape for.
 const PAGE_BREAK: String = "\ue000"
 const SCROLL_BREAK: String = "\ue001"
 ## `_ContTextNoPause`, which `<SCROLL>` and `TextCommand_SCROLL` reach directly:

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -1,15 +1,11 @@
 class_name Gen2Tiles
 extends RefCounted
 
-## Game Boy 2bpp tile data to one-byte-per-pixel colour indices.
-##
-## A tile is 8x8 pixels in 16 bytes: two bytes per row, the first holding the
-## low bit of every pixel in that row and the second the high bit. Bit 7 is the
-## leftmost pixel.
-##
-## Decoding stops at indices 0-3; turning those into colours needs a palette (see
-## [Gen2Palette]). Keeping the two apart makes shiny variants free: same pixels,
-## different palette.
+## Game Boy 2bpp tile data to one-byte-per-pixel colour indices. A tile is 8x8 in
+## 16 bytes: two bytes per row, the first holding the low bit of every pixel in
+## that row and the second the high bit, bit 7 leftmost. Decoding stops at indices
+## 0-3, since turning those into colours needs a palette; keeping the two apart
+## makes shiny variants free.
 
 const TILE_WIDTH: int = 8
 const TILE_HEIGHT: int = 8
@@ -102,16 +98,12 @@ static func decode_2bpp_strip(data: PackedByteArray, offset: int, count: int) ->
 	return out
 
 
-## Decodes a Pokémon or trainer pic into a row-major index buffer
-## [param columns] * 8 wide and [param rows] * 8 tall.
-##
-## Pics store tiles column-major, the whole left column top to bottom then the
-## next, because the game streams them into VRAM a column at a time. Every other
-## tilemap here is row-major, so this is the one place the ordering flips.
-##
-## Trailing data is ignored: Crystal's front pics carry Pokédex animation frames
-## after the still image, so a stream is routinely longer than
-## [param columns] * [param rows] tiles.
+## Decodes a Pokemon or trainer pic into a row-major index buffer
+## [param columns] * 8 wide and [param rows] * 8 tall. Pics store tiles
+## column-major, the whole left column top to bottom then the next, because the
+## game streams them into VRAM a column at a time, so this is the one place the
+## ordering flips. Trailing data is ignored: Crystal's front pics carry Pokedex
+## animation frames after the still image.
 static func decode_pic(data: PackedByteArray, columns: int, rows: int) -> PackedByteArray:
 	var width: int = columns * TILE_WIDTH
 	var out: PackedByteArray = PackedByteArray()

--- a/game/import/world_encounter_importer.gd
+++ b/game/import/world_encounter_importer.gd
@@ -184,15 +184,12 @@ static func read_world_encounters(rom: RomFile, layout: Dictionary) -> Dictionar
 
 
 ## `ContestMons` and `BugContestantPointers`, the Bug Catching Contest's own two
-## tables. Both ship byte identical on all three cartridges; they are read
-## rather than constants because they are cartridge data with a locator, unlike
-## `RadioChannelSongs`.
-##
-## A contestant record is `db class, id` then three `dbw mon, score` placings,
-## which `ComputeAIContestantScores` picks one of at random and then perturbs.
-## Entry zero of the pointer table is the player's own slot (`BUG_CONTEST_PLAYER`
-## is 1), and the source repeats the first real entry there, so the ten that
-## follow are what is read.
+## tables. Both ship byte identical on all three cartridges; they are read rather
+## than made constants because they are cartridge data with a locator. A
+## contestant record is `db class, id` then three `dbw mon, score` placings, which
+## `ComputeAIContestantScores` picks one of at random and then perturbs. Entry zero
+## of the pointer table is the player's own slot and the source repeats the first
+## real entry there, so the ten that follow are what is read.
 static func read_bug_contest(rom: RomFile, configured: Dictionary) -> Dictionary:
 	var mons_offset: int = int(configured.get("bug_contest_mons", -1))
 	var mon_count: int = int(configured.get("bug_contest_mon_count", -1))
@@ -550,17 +547,13 @@ static func _read_roaming_maps(
 	return {"ok": true, "count": rows.size(), "roaming": {"maps": rows, "mons": mons}}
 
 
-## TreeMonMaps, RockMonMaps and the TreeMons pointer table
-## (engine/events/treemons.asm, data/wild/treemon_maps.asm, treemons.asm),
-## plus Crystal's AsleepTreeMons* lists. All three tables live in one bank, so
-## a set pointer resolves against the pointer table's own bank.
-##
-## Several pointers alias one address in both profiles: Crystal's NONE and its
-## trailing unused entry both point at CANYON's bytes, and pokegold stacks
-## NONE, UNUSED and CITY on one label. That is the source's own shape, so
-## repeated addresses are kept rather than deduplicated.
-## Public because the whole-cartridge fixture the other readers would need to
-## be tested through is impractical: the anchors below are real cartridge rows.
+## TreeMonMaps, RockMonMaps and the TreeMons pointer table, plus Crystal's
+## AsleepTreeMons* lists. All three tables live in one bank, so a set pointer
+## resolves against the pointer table's own bank. Several pointers alias one
+## address in both profiles: Crystal's NONE and its trailing unused entry both
+## point at CANYON's bytes, and pokegold stacks NONE, UNUSED and CITY on one
+## label, so repeated addresses are kept rather than deduplicated. Public because
+## the whole-cartridge fixture the other readers would need is impractical.
 static func read_treemons(
 	rom: RomFile, layout: Dictionary, configured: Dictionary
 ) -> Dictionary:

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -253,22 +253,14 @@ static func read_world(
 	}
 
 
-## The `cmdqueue` payloads, as a second pass over the scripts already collected.
-##
-## A `writecmdqueue` operand points at data, not at script, so the recursive
-## walk in _collect_script() cannot follow it the way it follows a call: the
-## bytes there are a queue entry, and behind that a stone table. Both are read
-## here, and each table row's own script is collected like any other.
-##
-## Only Blackthorn Gym 2F and Ice Path B1F write a queue, and both write a
-## CMDQUEUE_STONETABLE, so an entry of any other type is kept for its pointer
-## and left undecoded rather than guessed at.
-##
-## A pointer that does not resolve is skipped, not fatal. Scripts are collected
-## as fixed slices, so a slice that runs past its own end can decode stray bytes
-## as a `writecmdqueue`; the corpus counts already treat that as expected. What
-## keeps this honest is `tools/checks/command_queues.gd`, which asserts the two
-## real tables against the pinned sources rather than trusting the scan.
+## The `cmdqueue` payloads, as a second pass over the scripts already collected. A
+## `writecmdqueue` operand points at data rather than script, so the recursive
+## walk cannot follow it the way it follows a call. Only Blackthorn Gym 2F and Ice
+## Path B1F write a queue and both write a CMDQUEUE_STONETABLE, so an entry of any
+## other type is kept for its pointer and left undecoded. A pointer that does not
+## resolve is skipped rather than fatal, since a slice running past its own end
+## can decode stray bytes as a `writecmdqueue`; what keeps this honest is
+## `tools/checks/command_queues.gd`, which asserts the two real tables.
 static func _read_command_queues(
 	rom: RomFile, script_data: Dictionary, text_data: Dictionary, movement_data: Dictionary
 ) -> Dictionary:
@@ -474,15 +466,13 @@ static func _read_overworld_sprites(rom: RomFile, layout: Dictionary) -> Diction
 	return {"ok": true, "sprites": sprites, "palettes": palettes, "graphics": graphics}
 
 
-## LoadOverworldMonIcon reads the contiguous eight-tile IconPointers region.
-## The pointer table is redundant for this use: every icon is 8 tiles and the
-## source stores them in the same order as constants/icon_constants.asm. It is
-## read anyway, as the check on the offset: `IconPointers` sits immediately in
-## front of the art and its entries walk it eight tiles at a time.
-##
-## `MonMenuIcons` is in front of that again (`ReadMonMenuIcon`), which is what
-## turns a species into one of the 38 shapes, and `HeldItemIcons` and
-## `PartyMenuOBPals` are the other two things a party menu icon needs.
+## LoadOverworldMonIcon reads the contiguous eight-tile IconPointers region. The
+## pointer table is redundant for this use, every icon being 8 tiles in the
+## source's own order, and is read anyway as the check on the offset: it sits
+## immediately in front of the art and its entries walk it eight tiles at a time.
+## `MonMenuIcons` is in front of that again, which turns a species into one of the
+## 38 shapes, and `HeldItemIcons` and `PartyMenuOBPals` are the other two things a
+## party menu icon needs.
 static func _read_overworld_icons(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var offset: int = int(layout.get("overworld_icons", -1))
 	var size: int = RomLayout.MON_ICON_COUNT * RomLayout.MON_ICON_BYTES
@@ -621,14 +611,12 @@ static func _read_party_menu_ob_palettes(rom: RomFile, layout: Dictionary) -> Di
 
 ## The sprites the engine draws over an object rather than as one: the eight
 ## showemote bubbles, the jump shadow, the fishing rod, Strength's boulder dust
-## and the tall-grass rustle, plus ShakeHeadbuttTree's own sheet.
-##
-## The emote table pins its own entries: LoadEmote copies each sheet to the VRAM
-## address the record carries, and the twelve tile numbers are the layout
-## FacingEmote ($f8, four tiles), FacingShadow and the fishing rod ($fc) and
-## FacingBoulderDust1/FacingGrass1 ($fe) index. A record naming any other tile
-## is a wrong table rather than a cartridge difference: all three ship this one
-## byte identical.
+## and the tall-grass rustle, plus ShakeHeadbuttTree's own sheet. The emote table
+## pins its own entries: LoadEmote copies each sheet to the VRAM address the
+## record carries, and the twelve tile numbers are the layout FacingEmote,
+## FacingShadow and FacingBoulderDust1 index. A record naming any other tile is a
+## wrong table rather than a cartridge difference: all three ship this byte
+## identical.
 const EMOTE_TILE_LAYOUT: Array = [
 	[4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8], [4, 0xF8],
 	[1, 0xFC], [2, 0xFC], [2, 0xFE], [1, 0xFE],
@@ -1332,16 +1320,13 @@ static func _read_map_scripts(
 	return {"ok": true, "scenes": scenes, "callbacks": callbacks}
 
 
-## Whether an event record's own pointer addresses commands.
-##
-## Only `ObjectEventTypeArray`'s `.script` and `BGEventJumptable`'s five reading
-## entries reach `CallScript` with it. An item ball's word is the `itemball`
-## macro's `db item, quantity`, a hidden item's is `hiddenitem`'s
-## `dwb event, item`, a conditional background event's is a `conditional_event`
-## record, and `OBJECTTYPE_3` through `OBJECTTYPE_6` are dummy events that run
-## nothing. Decoding those as commands and following what they named is where 50
-## Crystal and 20 Gold `loadmenu` records came from, and the `special` operands
-## that name no `SpecialsPointers` entry with them.
+## Whether an event record's own pointer addresses commands. Only
+## `ObjectEventTypeArray`'s `.script` and `BGEventJumptable`'s five reading
+## entries reach `CallScript` with it. An item ball's word is `db item, quantity`,
+## a hidden item's is `dwb event, item`, a conditional background event's is a
+## `conditional_event` record, and `OBJECTTYPE_3` through `_6` run nothing.
+## Decoding those as commands is where 50 Crystal and 20 Gold `loadmenu` records
+## came from, and the `special` operands naming no `SpecialsPointers` entry.
 static func event_pointer_is_script(source: String, event: Dictionary) -> bool:
 	match source:
 		"objects":

--- a/game/input/debug_keys.gd
+++ b/game/input/debug_keys.gd
@@ -1,19 +1,13 @@
 class_name Gen2DebugKeys
 extends RefCounted
 
-## Whether the development shortcuts and readouts are live.
-##
-## The game screens carry scaffolding that reaches parts of the world no
-## cartridge control does: fishing rods by number, the phone list, a renderer
-## switch, a snapshot write, and battle drivers that stand in for a battle menu.
-## They are how the world is inspected without a save file, and they are not
-## controls a player should find.
-##
-## The editor, a headless run and a debug export all answer true here, which is
-## every context those shortcuts exist for; a release export answers false and
-## offers exactly the eight buttons the hardware had. Each shortcut's method
-## stays public either way, so the preview tools drive the same paths in a
-## release build without a key press.
+## Whether the development shortcuts and readouts are live. The game screens carry
+## scaffolding that reaches parts of the world no cartridge control does: fishing
+## rods by number, the phone list, a renderer switch, a snapshot write and battle
+## drivers. The editor, a headless run and a debug export all answer true; a
+## release export answers false and offers exactly the eight buttons the hardware
+## had. Each shortcut's method stays public either way, so the preview tools drive
+## the same paths in a release build without a key press.
 
 static func enabled() -> bool:
 	return OS.is_debug_build()

--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -1,25 +1,14 @@
 class_name Gen2FocusGuard
 extends Node
 
-## Gives a controller somewhere to start.
-##
-## Godot moves focus between [Control]s on `ui_up` and the rest of that family,
-## but only once something already has focus, and nothing does when a screen
-## opens. That is the whole reason a pad did nothing in the launcher: every
-## button was focusable and reachable, and none of them was the first.
-##
-## A mouse or a finger needs no focus ring, so one is only put up while the
-## player is on a keyboard or a pad. It is never taken away again, because a
-## click that dropped focus would empty the field the click had just filled.
-##
-## Add one to a screen with [method attach] and call [method refresh] whenever
-## what is on that screen changes.
-##
-## A modal over the screen takes the whole guard with it. Everything below is
-## still in the tree and still focusable, so without this the geometric search
-## joins a control in the modal to whatever happens to sit beside it on the page
-## behind, and one press walks out of the modal and scrolls the page. See
-## [constant MODAL_GROUP].
+## Gives a controller somewhere to start. Godot moves focus on `ui_up` and the
+## rest of that family, but only once something already has focus, and nothing
+## does when a screen opens. A ring is only put up while the player is on a
+## keyboard or a pad, and never taken away again, because a click that dropped
+## focus would empty the field the click had just filled. A modal takes the whole
+## guard with it: everything below is still focusable, so without that the
+## geometric search joins a control in the modal to one on the page behind. Add
+## one with [method attach] and call [method refresh] when the screen changes.
 
 ## Nodes in this group are modal: while one is in the tree, it is the only part
 ## of the screen the guard looks at. Named rather than typed so the guard owes

--- a/game/input/input_actions.gd
+++ b/game/input/input_actions.gd
@@ -1,24 +1,14 @@
 class_name Gen2InputActions
 extends RefCounted
 
-## What a device has to do to produce a [Gen2Button], as data.
-##
-## A binding is a plain dictionary so the whole control scheme survives a trip
-## through the options file, and so the remap UI can describe one without
-## holding an [InputEvent]. Three kinds cover every device the engine reports:
-##
-## [codeblock]
-## {"kind": "key",        "code": <physical keycode>}
-## {"kind": "pad_button", "code": <JoyButton>}
-## {"kind": "pad_axis",   "code": <JoyAxis>, "sign": -1 or 1}
-## [/codeblock]
-##
-## Keys bind by physical keycode, so the d-pad keeps the WASD positions on a
-## layout that does not spell WASD there. [method describe] asks the platform
-## what the key in that position is actually labelled.
-##
-## Nothing here reads or writes the options file: [Gen2OptionsStore] owns that,
-## and the runtime hands the result to [method install].
+## What a device has to do to produce a [Gen2Button], as data: a plain dictionary,
+## so the whole control scheme survives a trip through the options file and the
+## remap UI can describe one without holding an [InputEvent]. Three kinds cover
+## every device the engine reports, `key`, `pad_button` and `pad_axis`, each with
+## a `code` and the axis one a `sign`. Keys bind by physical keycode, so the d-pad
+## keeps the WASD positions on a layout that does not spell WASD there, and
+## [method describe] asks the platform what that key is labelled. Nothing here
+## reads or writes the options file.
 
 const KIND_KEY: StringName = &"key"
 const KIND_PAD_BUTTON: StringName = &"pad_button"
@@ -379,17 +369,13 @@ static func button_bound_to(scheme: Dictionary, binding: Dictionary) -> int:
 	return found[0] if not found.is_empty() else Gen2Button.NONE
 
 
-## A mod's own actions, installed beside the eight.
-##
-## Same three binding kinds, same deadzone, same physical keycodes: an action a
-## mod declares is bound, rebound and described by the code that does it for the
-## cartridge's own buttons, and reaches the mod as an id rather than as an
-## [InputEvent]. See [method Gen2ModHost.register_action].
-##
-## [param actions] is `[{name, default}]` and [param stored] is the player's
-## overrides keyed by the same names. Actions installed by an earlier call and
-## absent from this one are erased, so a mod switched off does not leave a live
-## action behind.
+## A mod's own actions, installed beside the eight. Same three binding kinds, same
+## deadzone, same physical keycodes: an action a mod declares is bound, rebound
+## and described by the code that does it for the cartridge's own buttons, and
+## reaches the mod as an id rather than as an [InputEvent]. [param actions] is
+## `[{name, default}]` and [param stored] the player's overrides; actions
+## installed by an earlier call and absent from this one are erased, so a mod
+## switched off does not leave a live action behind.
 static func install_mod_actions(actions: Array, stored: Dictionary) -> void:
 	var wanted: Dictionary = {}
 	for action: Dictionary in actions:

--- a/game/input/tap_gesture.gd
+++ b/game/input/tap_gesture.gd
@@ -1,15 +1,11 @@
 class_name Gen2TapGesture
 extends RefCounted
 
-## Counts quick repeated taps in roughly one place.
-##
-## The one way back from hidden on-screen controls. A player who turns them off
-## for a plugged-in pad, then unplugs it on a device with no keyboard, has no
-## button left to press, so the gesture has to be something no ordinary play
-## produces and no button can swallow.
-##
-## Timing and counting only, with the clock passed in, so a test does not have
-## to wait half a second three times.
+## Counts quick repeated taps in roughly one place: the one way back from hidden
+## on-screen controls. A player who turns them off for a plugged-in pad, then
+## unplugs it on a device with no keyboard, has no button left to press, so the
+## gesture has to be something no ordinary play produces and no button can
+## swallow. Timing and counting only, with the clock passed in.
 
 const TAPS: int = 3
 ## Between consecutive taps. Long enough to be comfortable, short enough that

--- a/game/input/touch_layout.gd
+++ b/game/input/touch_layout.gd
@@ -2,17 +2,12 @@ class_name Gen2TouchLayout
 extends RefCounted
 
 ## Where the on-screen controller's five clusters sit, how big they are and how
-## much of the screen they hide.
-##
-## Geometry only: [Gen2TouchPad] draws and reads touches, and this answers where
-## everything is. Keeping them apart is what lets the settings page show a live
-## preview and lets a test check placement without a viewport.
-##
-## Positions are stored as a fraction of the area the controller was given, not
-## as pixels, so a layout arranged on a phone still means the same thing on a
-## tablet, in the other orientation, or after the window is resized. Portrait and
-## landscape keep separate positions, because a cluster reachable by the thumb in
-## one is in the middle of the screen in the other.
+## much of the screen they hide. Geometry only: [Gen2TouchPad] draws and reads
+## touches, which is what lets the settings page show a live preview and a test
+## check placement without a viewport. Positions are a fraction of the area the
+## controller was given rather than pixels, so a layout arranged on a phone means
+## the same on a tablet; portrait and landscape keep separate positions, because a
+## cluster reachable by the thumb in one is mid-screen in the other.
 
 const GROUP_PAD: StringName = &"pad"
 const GROUP_A: StringName = &"a"
@@ -320,17 +315,13 @@ static func parse(raw: Variant) -> Gen2TouchLayout:
 	return layout
 
 
-## A layout written while A and B were one cluster carries a `face` centre and
-## no `a` or `b`. The pair sat on a fixed diagonal inside that cluster, B up and
+## A layout written while A and B were one cluster carries a `face` centre and no
+## `a` or `b`. The pair sat on a fixed diagonal inside that cluster, B up and
 ## right, A down and left, half [constant FACE_SPACING] from the centre each way,
-## so the two anchors it becomes are the ones the player already had.
-##
-## The offset is in points and an anchor is a fraction of an area this has never
-## been shown, so it is taken against the portrait phone the layout was arranged
-## on. [method group_rect] clamps whatever comes out.
-## [param stored] is what the file itself carried, not the merged anchors: every
-## group has a default, so asking the layout whether it has an `a` would answer
-## yes before the file has said anything.
+## so the two anchors it becomes are the ones the player already had. The offset
+## is in points against the portrait phone the layout was arranged on, and
+## [method group_rect] clamps whatever comes out. [param stored] is what the file
+## carried rather than the merged anchors, since every group has a default.
 func _split_face(orientation: StringName, stored: Dictionary) -> void:
 	var groups: Dictionary = anchors.get(orientation, {})
 	if not stored.has(String(GROUP_FACE)) \

--- a/game/input/touch_pad.gd
+++ b/game/input/touch_pad.gd
@@ -1,20 +1,12 @@
 class_name Gen2TouchPad
 extends Control
 
-## The on-screen controller: a d-pad, A and B, START and SELECT.
-##
-## Godot ships no such thing for a [Control] interface, so this is ours. It
-## draws what [Gen2TouchLayout] places and turns a finger into the same button a
-## key or a pad produces, by way of [Gen2InputRuntime], so no screen has to know a
-## touchscreen exists.
-##
-## Touches are read in [method _input] rather than [method _gui_input] because
-## more than one finger is normal here: a thumb walking while the other presses
-## A is two live touches, and the GUI layer only ever tracks one pointer.
-##
-## In edit mode nothing is pressed and a drag moves a cluster instead. The
-## layout handed to [method set_layout] is edited in place, which is how the
-## settings page arranges the live one and has nothing to copy back.
+## The on-screen controller: a d-pad, A and B, START and SELECT. It draws what
+## [Gen2TouchLayout] places and turns a finger into the same button a key or a pad
+## produces, so no screen has to know a touchscreen exists. Touches are read in
+## [method _input] rather than [method _gui_input] because more than one finger is
+## normal here and the GUI layer only tracks one pointer. In edit mode nothing is
+## pressed and a drag moves a cluster instead, editing the layout in place.
 
 const FILL: Color = Color(0.04, 0.06, 0.09, 0.80)
 const FILL_PRESSED: Color = Color(0.30, 0.55, 0.80, 0.95)

--- a/game/launcher/launcher_battery.gd
+++ b/game/launcher/launcher_battery.gd
@@ -1,23 +1,13 @@
 class_name Gen2LauncherBattery
 extends HBoxContainer
 
-## The charge indicator in the top right: a cell that fills and empties, with the
-## percentage written beside it.
-##
-## Godot reports no power state on any platform, so every reading here is this
-## project's own. There is one probe per platform and no fallback: a machine
-## whose charge cannot be read draws no indicator at all rather than a full cell
-## that is not true. That is what [method reading_available] answers, and it is
-## why a desktop with no battery in it shows nothing either.
-##
-## | Platform | Where the reading comes from |
-## |---|---|
-## | macOS | `pmset -g batt`, on a worker thread |
-## | Windows | `Get-CimInstance Win32_Battery`, on a worker thread |
-## | Linux, BSD | `/sys/class/power_supply/BAT*/capacity` and `status` |
-## | Android | `ACTION_BATTERY_CHANGED`, through the platform plugin |
-## | iOS | `UIDevice.batteryLevel`, through the platform plugin |
-##
+## The charge indicator in the top right. Godot reports no power state on any
+## platform, so every reading here is this project's own. There is one probe per
+## platform and no fallback: a machine whose charge cannot be read draws no
+## indicator rather than a full cell that is not true, which is what
+## [method reading_available] answers. macOS reads `pmset -g batt` and Windows
+## `Get-CimInstance Win32_Battery`, both on a worker thread; Linux and BSD read
+## `/sys/class/power_supply`; Android and iOS come through the platform plugin.
 ## Anything else, the Switch build included, has no probe and no indicator.
 
 const FULL: int = 100

--- a/game/launcher/launcher_file_picker.gd
+++ b/game/launcher/launcher_file_picker.gd
@@ -1,24 +1,14 @@
 class_name Gen2LauncherFilePicker
 extends FileDialog
 
-## The one file picker every launcher dialog is built from. Any new file-picking
-## UI goes through [method Gen2LauncherUI.file_picker] rather than building its
-## own, and shows it with [method show_picker] rather than [method
-## Window.popup_centered].
-##
-## Three ways a platform offers a file, in the order they are preferred:
-##
-## 1. The engine's own native dialog, asked for with `use_native_dialog`. Windows,
-##    macOS, Linux and Android all answer, and Android's grants access to the one
-##    file chosen, which is why the app declares no storage permission.
-## 2. The `NativeFilePicker` singleton from `ios/plugins/file_picker`, for iOS,
-##    where `DisplayServerIOS` implements no `file_dialog_show` and so the engine
-##    has no system picker to offer. It hands back a file already copied into the
-##    app's own storage, so what a caller reads is an ordinary path.
-## 3. The engine's built-in browser, for anything left. Rooted at the app's own
-##    data where the filesystem is sandboxed, since every path outside it is one
-##    [FileAccess] would then be refused, and at the top of the volume where
-##    there is no pointer to steer it with. See [method _pointerless_start_dir].
+## The one file picker every launcher dialog is built from, reached through
+## [method Gen2LauncherUI.file_picker] and shown with [method show_picker]. Three
+## ways a platform offers a file, in the order they are preferred: the engine's
+## own native dialog, which Windows, macOS, Linux and Android all answer and whose
+## Android grant covers the one file chosen; the `NativeFilePicker` singleton for
+## iOS, where `DisplayServerIOS` implements no `file_dialog_show`, which hands back
+## a file already copied into app storage; and the built-in browser for anything
+## left, rooted per [method _pointerless_start_dir].
 
 ## The plugin's singleton, present only on a build that carries it.
 const NATIVE_SINGLETON: StringName = &"NativeFilePicker"

--- a/game/launcher/launcher_icon.gd
+++ b/game/launcher/launcher_icon.gd
@@ -2,18 +2,13 @@ class_name Gen2LauncherIcon
 extends TextureRect
 
 ## The launcher's custom filled icon set, rasterised from SVG at the size it is
-## drawn. Source SVGs remain editable in `assets/launcher/icons`; their
-## `currentColor` fill is replaced with the active palette colour at runtime.
-##
-## `github`, `discord` and `bug` are the project's own drawings rather than
-## Material Symbols, so `LICENSE-MATERIAL-SYMBOLS.txt` beside them does not cover
-## those three; the two logos are the services' trade marks and are drawn only to
-## point at those services.
-##
-## Each source carries `importer="keep"`, because this reads the SVG text rather
-## than the texture Godot's own SVG importer makes: an imported `.svg` ships as
-## its `.ctex` alone, so `_svg()` came back empty on every exported build and
-## every glyph drew nothing. `test_launcher_ui.gd` asserts the importer.
+## drawn; the sources stay editable in `assets/launcher/icons` and their
+## `currentColor` fill is replaced with the palette colour at runtime. `github`,
+## `discord` and `bug` are the project's own drawings, so the Material Symbols
+## licence beside them does not cover those three. Each source carries
+## `importer="keep"` because this reads the SVG text rather than Godot's imported
+## texture: an imported `.svg` ships as its `.ctex` alone, so every glyph drew
+## nothing on an exported build. `test_launcher_ui.gd` asserts the importer.
 const GRID: int = 24
 
 const ICON_DIRECTORY: String = "res://assets/launcher/icons"

--- a/game/launcher/launcher_scroll.gd
+++ b/game/launcher/launcher_scroll.gd
@@ -1,27 +1,14 @@
 class_name Gen2LauncherScroll
 extends ScrollContainer
 
-## A vertical scroll pane that can be read without a pointer.
-##
-## Two things are needed and Godot gives neither by default. A pad walking the
-## controls inside a pane has to bring the pane with it, which is
-## [member ScrollContainer.follow_focus]. And a pane whose content is mostly text
-## has stretches with nothing focusable in them, so the pane itself takes focus
-## and reads an up or a down ([method Gen2Button.direction_in]) as scrolling,
-## which is the only way past a wall of prose on a keyboard.
-##
-## The pane only takes focus when it actually has somewhere to go, so a short
-## page does not put a stop on the way down to the dock.
-##
-## A finger is the third way, and the engine gives none of it. [ScrollContainer]
-## drags off mouse events emulated from the touch, and
-## [constant Control.MOUSE_FILTER_STOP] ends a pointer event at the control it
-## reaches: [method Viewport._gui_call_input] stops there for every mouse, touch
-## and drag event, and only a wheel is passed on by `force_pass_scroll_events`.
-## Every launcher page is a column of buttons, each of them STOP, so a wheel
-## scrolls the pane and a finger on the same page moves nothing. The pane
-## therefore reads the touch in [method Node._input], ahead of the GUI, and
-## leaves the engine's own drag switched off.
+## A vertical scroll pane that can be read without a pointer, since Godot gives
+## neither thing by default. A pad walking the controls inside a pane has to bring
+## the pane with it, and a pane whose content is mostly text has stretches with
+## nothing focusable, so the pane itself takes focus and reads an up or a down as
+## scrolling. It only takes focus when it has somewhere to go. A finger is the
+## third way: [constant Control.MOUSE_FILTER_STOP] ends a pointer event at the
+## control it reaches and every launcher button is STOP, so the pane reads the
+## touch in [method Node._input] and leaves the engine's own drag switched off.
 
 ## How far one press moves the pane, as a fraction of what it shows.
 const PAGE: float = 0.42

--- a/game/launcher/launcher_sheet.gd
+++ b/game/launcher/launcher_sheet.gd
@@ -1,18 +1,13 @@
 class_name Gen2LauncherSheet
 extends Control
 
-## A modal card over the launcher, used instead of an OS dialog.
-##
-## Godot's own dialogs open a second window with its own decorations, which no
-## amount of theming makes belong here and which mobile has no place to put. A
-## sheet is drawn inside the launcher, so it is one look on every platform.
-##
-## It is sized against the window rather than against its own content: a
-## [CenterContainer] grants a card its minimum size whatever that is, so a sheet
-## with more rows than the window is tall used to hang its actions off the bottom
-## edge with no way to reach them. The body scrolls and the card is capped, so
-## the title, the actions and the close button are always on screen and the rows
-## between them are what gives.
+## A modal card over the launcher, used instead of an OS dialog: Godot's own open
+## a second window with its own decorations, which no amount of theming makes
+## belong here and which mobile has no place to put. Sized against the window
+## rather than against its own content, because a [CenterContainer] grants a card
+## its minimum size whatever that is and a sheet with more rows than the window is
+## tall hung its actions off the bottom edge. The body scrolls and the card is
+## capped, so the title, the actions and the close button are always on screen.
 
 signal closed
 

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -295,16 +295,11 @@ func _art_layer() -> TextureRect:
 
 ## The screen-to-screen transition, in the family of the cartridge's own:
 ## `FadeOutToWhite` walks `Gen2WorldPalette.FADE_OUT_ORDERS` one row at a time,
-## holding each for `FADE_STEP_FRAMES`, so the screen leaves in four discrete
-## steps rather than on a continuous ramp. The launcher is not a cartridge
-## screen, so the colour it flattens onto is the palette's own rather than a
-## map's white, and the steps are alpha rather than palette rows.
-##
-## The next shell built after one of these fades in from the same colour, so a
-## launch is one transition across the scene change instead of a wipe and a cut.
-## [param hand_over] is false when the screen after this one is not a shell
-## screen: the world arrives on its own map fade, which is the cartridge's, so
-## it must not be walked back out of the launcher's sheet as well.
+## holding each for `FADE_STEP_FRAMES`, so the screen leaves in four discrete steps
+## rather than on a ramp. The colour it flattens onto is the palette's own and the
+## steps are alpha rather than palette rows. [param hand_over] is false when the
+## screen after this one is not a shell screen: the world arrives on its own map
+## fade, so it must not be walked back out of the launcher's sheet as well.
 func flash(hand_over: bool = true) -> void:
 	if not is_inside_tree():
 		return

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -1,16 +1,12 @@
 class_name Gen2LauncherTheme
 extends RefCounted
 
-## Colours, metrics and a stock-control [Theme] for every launcher screen.
-##
-## One instance describes one appearance. Screens read [method active], which
-## follows `ui_theme` in the options file, and rebuild themselves when it
-## changes: everything the launcher draws is built in code, so a rebuild is
-## cheaper and more reliable than repainting live nodes.
-##
-## Depth is carried by fills and hairlines, not by shadows. Only what genuinely
-## floats over the page casts one, which is why a shadow is never cut off by the
-## scroll or margin container it happens to sit in.
+## Colours, metrics and a stock-control [Theme] for every launcher screen. One
+## instance describes one appearance; screens read [method active], which follows
+## `ui_theme` in the options file, and rebuild themselves when it changes, since
+## everything the launcher draws is built in code. Depth is carried by fills and
+## hairlines rather than shadows, so a shadow is never cut off by the scroll or
+## margin container it happens to sit in.
 
 const LIGHT: StringName = &"light"
 const DARK: StringName = &"dark"

--- a/game/launcher/launcher_toast.gd
+++ b/game/launcher/launcher_toast.gd
@@ -2,18 +2,12 @@ class_name Gen2LauncherToast
 extends Control
 
 ## What the launcher has to say about the last thing that happened, shown only
-## while it is worth saying.
-##
-## It replaces a permanent status strip: a screen with nothing to report should
-## look like a screen with nothing to report. Success and information fade out on
-## their own; a refusal and a running import stay until they are replaced.
-##
-## A message that stays carries a dismiss button, because "until it is replaced"
-## is forever on a screen the player is not about to do anything else on. A
-## running import is the exception: it goes when the import does, and a button
-## offering to hide it would be offering to cancel something it cannot. Its
-## glyph turns instead, which is the whole of the difference between a launcher
-## that is working and one that has stopped.
+## while it is worth saying: a screen with nothing to report should look like one.
+## Success and information fade out on their own; a refusal and a running import
+## stay until they are replaced, and a message that stays carries a dismiss
+## button. A running import is the exception, since a button offering to hide it
+## would be offering to cancel something it cannot: its glyph turns instead, which
+## is the whole difference between a launcher that is working and one stopped.
 
 ## How long a message that reports no problem stays up.
 const LINGER: float = 3.6

--- a/game/launcher/launcher_ui.gd
+++ b/game/launcher/launcher_ui.gd
@@ -22,15 +22,12 @@ const TOUCH_TARGET: float = 48.0
 
 
 ## Whether this display server hands out the screen's own pixels rather than
-## points.
-##
-## A platform that cannot open a second window is one whose window is the whole
-## screen, and every one of them measures in physical pixels: a phone, a tablet,
-## a console. A desktop is already in points and wants no factor at all. Asked of
-## the display server rather than of a list of platform names, so a console this
+## points. A platform that cannot open a second window is one whose window is the
+## whole screen, and every one of them measures in physical pixels. Asked of the
+## display server rather than of a list of platform names, so a console this
 ## project has not met yet is covered on the day it arrives. A headless run
-## answers no to every feature there is, so it is asked first whether it draws
-## at all; without that a test tier would measure itself as a handheld.
+## answers no to every feature there is, so it is asked first whether it draws at
+## all; without that a test tier would measure itself as a handheld.
 static func draws_in_screen_pixels() -> bool:
 	return (
 		DisplayServer.window_can_draw()
@@ -38,16 +35,14 @@ static func draws_in_screen_pixels() -> bool:
 	)
 
 
-## How many window pixels one launcher unit is drawn at, so that a unit is a
-## device-independent point rather than a pixel.
-##
-## Every size the launcher is written in is a desktop pixel, which is a comfortable
-## reading size only because a desktop screen is about 100 pixels to the inch. A
-## phone is three to four times that, so the same numbers arrive at a third of the
-## size and the window measures wide enough to be taken for a desktop. The screen's
-## own backing scale is exactly that ratio, and iOS and Android both report it. A
-## Switch reports neither a scale nor a phone's density: 237 dots per inch held
-## in the hands, 96 in the dock, which the same formula turns into 1.5 and 1.
+## How many window pixels one launcher unit is drawn at, so a unit is a
+## device-independent point rather than a pixel. Every size the launcher is
+## written in is a desktop pixel, comfortable only because a desktop screen is
+## about 100 pixels to the inch; a phone is three to four times that, so the same
+## numbers arrive at a third of the size and the window measures wide enough to be
+## taken for a desktop. iOS and Android both report the backing scale. A Switch
+## reports neither: 237 dots per inch in the hands and 96 in the dock, which the
+## same formula turns into 1.5 and 1.
 static func display_density() -> float:
 	if preview_density > 0.0:
 		return preview_density
@@ -321,17 +316,12 @@ static func field(theme: Gen2LauncherTheme, text: String, control: Control) -> C
 
 
 ## The two halves of a [method field], side by side while they both fit and
-## stacked when they do not.
-##
-## Every launcher page scrolls vertically only, so a row wider than the window is
-## cut off rather than reachable, and a settings row is exactly the shape that
-## outgrows a portrait phone: the label wants its whole text and the control
-## carries its own minimum width. Stacking is what keeps the control on screen.
-##
-## A [Container] is not usable here: from 4.8.dev4 the engine answers a
-## container's minimum size itself and never calls a script's
-## [method Control._get_minimum_size], and asking for less than both halves is
-## the whole point of this row.
+## stacked when they do not. Every launcher page scrolls vertically only, so a row
+## wider than the window is cut off rather than reachable, and a settings row is
+## exactly the shape that outgrows a portrait phone. A [Container] is not usable
+## here: from 4.8.dev4 the engine answers a container's minimum size itself and
+## never calls a script's [method Control._get_minimum_size], and asking for less
+## than both halves is the whole point of this row.
 class FieldRow extends Control:
 	var _pending: bool = false
 
@@ -448,14 +438,11 @@ static func segmented(
 
 
 ## One control kept at the width it would like rather than the width it is given.
-##
 ## An [HFlowContainer] measures as one column, since that is the narrowest it can
 ## be drawn, so a track asking for its minimum would always stack. This asks for
 ## that minimum, which is what lets it wrap on a phone, and then draws the child
-## at [method Gen2LauncherUI.preferred_width] whenever the row is wide enough to
-## hold it on one line.
-##
-## A [Container] is not usable here for the reason [FieldRow] gives.
+## at [method Gen2LauncherUI.preferred_width] whenever the row is wide enough. A
+## [Container] is not usable here for the reason [FieldRow] gives.
 class HugRow extends Control:
 	var _pending: bool = false
 
@@ -561,15 +548,12 @@ static func file_picker(
 	return Gen2LauncherFilePicker.create(theme, title_text, mode, filters)
 
 
-## The square a mod's icon is drawn in, on a list row and on its own page.
-##
-## Always the same node whether or not there is a picture, because the alternative
-## is a list whose names start at two different places depending on whose mod it
-## is. A mod with no icon gets the generic glyph, greyed, in the same square.
-##
-## Nearest filtering, and never stretched: an icon is 32x32 pixel art drawn at
-## about 40, so smoothing it would blur exactly the edges it is made of, and
-## letting it fill a square it is not square for would distort it.
+## The square a mod's icon is drawn in, on a list row and on its own page. Always
+## the same node whether or not there is a picture, because the alternative is a
+## list whose names start at two different places depending on whose mod it is; a
+## mod with no icon gets the generic glyph, greyed, in the same square. Nearest
+## filtering and never stretched: an icon is 32x32 pixel art drawn at about 40, so
+## smoothing it would blur exactly the edges it is made of.
 static func mod_icon(
 	theme: Gen2LauncherTheme, texture: Texture2D, side: float = MOD_ICON_SIDE
 ) -> Control:

--- a/game/launcher/mod_sources_page.gd
+++ b/game/launcher/mod_sources_page.gd
@@ -1,15 +1,11 @@
 class_name Gen2ModSourcesPage
 extends VBoxContainer
 
-## The sources the player follows, and what to add.
-##
-## A source is a published index: a JSON listing naming mods that live wherever
-## their authors put them. Following one is trusting whoever publishes it, so
-## none ships with the game and none is ever added on its own.
-##
-## The page decides nothing. Following, forgetting and what a URL resolves to
-## are [Gen2ModIndex]'s, and fetching is the mods page's, which owns the one
-## request this launcher makes.
+## The sources the player follows, and what to add. A source is a published index:
+## a JSON listing naming mods that live wherever their authors put them. Following
+## one is trusting whoever publishes it, so none ships with the game and none is
+## ever added on its own. The page decides nothing: following, forgetting and what
+## a URL resolves to are [Gen2ModIndex]'s, and fetching is the mods page's.
 
 signal closed
 signal followed(feed: String)

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -2,22 +2,13 @@ class_name Gen2ModsPage
 extends VBoxContainer
 
 ## The mod manager: a list grouped by where each mod came from, a page per mod,
-## and a page for the sources the player follows.
-##
-## The model is a package manager's. A source is a followed index; a mod no
-## source lists came from a file. Removing a mod that a source lists uninstalls
-## it and leaves it listed, so it can be downloaded again; removing one that
-## came from a file deletes the only copy there was. [Gen2ModCatalogue] decides
-## both, and this page draws what it decided.
-##
-## The list itself carries only what a list is for: what a mod is, whether it is
-## on, and one action. Settings, description and the install history live on the
-## mod's own page, reached by pressing its row.
-##
-## A change to the list is applied where it is made: the host is reset and every
-## entry script runs again, which is the same reload a cartridge change already
-## did. Nothing here can withdraw one registration on its own, so the whole list
-## is reloaded rather than half of it.
+## and a page for the sources the player follows. The model is a package
+## manager's, so removing a mod a source lists uninstalls it and leaves it listed
+## while removing one that came from a file deletes the only copy there was;
+## [Gen2ModCatalogue] decides both. The list carries only what a list is for, with
+## settings and history on the mod's own page. A change is applied where it is
+## made: the host is reset and every entry script runs again, because nothing here
+## can withdraw one registration on its own.
 
 ## Asks the launcher for its file picker: the page owns no OS dialog.
 signal install_requested
@@ -160,14 +151,12 @@ func refresh() -> void:
 
 
 ## Whether the page may reach the network without a player having asked it to.
-##
 ## [method HTTPRequest.request] refuses, loudly, from a node that is not in the
 ## tree, and [method create] builds the whole page before the launcher adds it.
-## The rest is [method Gen2GameRuntime.is_player_launch]: a check, a test tier,
-## a screenshot driver or a replay has nobody to show a listing to, and its
-## user:// is usually empty, so every page it builds would fetch the feed and
-## then an icon per row. The test tier builds seven. What a player pressed --
-## Check for updates, a download -- is not gated here and works in any run.
+## The rest is [method Gen2GameRuntime.is_player_launch]: a check, a test tier, a
+## screenshot driver or a replay has nobody to show a listing to and its user:// is
+## usually empty, so every page it builds would fetch the feed and then an icon
+## per row. What a player pressed is not gated here and works in any run.
 func _may_fetch_unprompted() -> bool:
 	return is_inside_tree() and Gen2GameRuntime.is_player_launch()
 

--- a/game/launcher/title_backdrop.gd
+++ b/game/launcher/title_backdrop.gd
@@ -2,14 +2,11 @@ class_name Gen2LauncherTitleBackdrop
 extends Node
 
 ## A non-interactive title-screen loop, picture and music, for the launcher
-## backdrop.
-##
-## This deliberately hosts only [Gen2TitleScene] and [Gen2TitlePage]. The boot
-## cinema that advances into the intro and menu is never created. What it does
-## create is the cartridge sound driver, so the screen is heard as well as seen:
-## the same `MUSIC_TITLE` the title screen itself plays, at [constant
-## VOLUME_SCALE] of the player's settings, looping for as long as the backdrop
-## is up.
+## backdrop. It hosts only [Gen2TitleScene] and [Gen2TitlePage]; the boot cinema
+## that advances into the intro and menu is never created. What it does create is
+## the cartridge sound driver, so the screen is heard as well as seen: the same
+## `MUSIC_TITLE` the title screen plays, at [constant VOLUME_SCALE] of the
+## player's settings, looping for as long as the backdrop is up.
 
 const FRAME_TIME: float = 1.0 / 60.0
 const MAX_STEPS_PER_TICK: int = 4

--- a/game/launcher/touch_layout_sheet.gd
+++ b/game/launcher/touch_layout_sheet.gd
@@ -2,15 +2,12 @@ class_name Gen2TouchLayoutSheet
 extends Control
 
 ## Arranging the on-screen controller: drag each cluster where a thumb wants it,
-## and set how large and how solid it is.
-##
-## Full screen rather than a card, because the thing being arranged is measured
-## against the rectangle the game hands the controller and a preview in a box of
-## its own would place it against the wrong one.
-##
-## The layout is per orientation, and this edits the one the window is currently
-## in. On the device that matters, turning it sideways is how the other is
-## reached, which is also the only way to see what that one will look like.
+## and set how large and how solid it is. Full screen rather than a card, because
+## what is being arranged is measured against the rectangle the game hands the
+## controller and a preview in a box of its own would place it against the wrong
+## one. The layout is per orientation and this edits the one the window is in;
+## turning the device sideways is both how the other is reached and the only way
+## to see what it will look like.
 
 signal closed()
 

--- a/game/mods/mod_art.gd
+++ b/game/mods/mod_art.gd
@@ -2,16 +2,11 @@ class_name Gen2ModArt
 extends RefCounted
 
 ## A mod's own pictures: the icon the launcher draws beside its name, and the
-## thumbnail a listing site shows for it.
-##
-## Both are optional and neither is declared for the usual mod: dropping
-## `icon.png` beside `mod.json` is the whole of it, because a convention an
-## author has to read a document to obey is one most will not. A manifest may
-## still name another path, which is what a mod keeping its art in a
-## subdirectory or inside a pack needs.
-##
-## The game never draws a thumbnail. It is resolved here anyway so one rule
-## covers both files and a packaging script has one place to ask.
+## thumbnail a listing site shows for it. Both are optional and neither is
+## declared for the usual mod, since dropping `icon.png` beside `mod.json` is the
+## whole of it and a convention an author has to read a document to obey is one
+## most will not. A manifest may still name another path. The game never draws a
+## thumbnail; it is resolved here anyway so one rule covers both files.
 
 ## Tried in order, and the first that exists wins. PNG leads because an icon is
 ## 32x32 pixel art off the cartridge, where lossy compression only costs.

--- a/game/mods/mod_catalogue.gd
+++ b/game/mods/mod_catalogue.gd
@@ -1,15 +1,12 @@
 class_name Gen2ModCatalogue
 extends RefCounted
 
-## One list of every mod the player can see, grouped by where it came from.
-##
-## A source is a followed index; a mod that no index lists came from a file the
-## player chose. That is the whole ownership rule, and it needs nothing written
-## down: a mod belongs to the source that lists its id, so uninstalling one from
-## a source leaves it listed and re-downloadable, while uninstalling one that
-## came from a file removes the only copy there was.
-##
-## Pure. It takes what [Gen2ModHost], [Gen2ModIndex] and [Gen2ModState] already
+## One list of every mod the player can see, grouped by where it came from. A
+## source is a followed index; a mod that no index lists came from a file the
+## player chose. That is the whole ownership rule and it needs nothing written
+## down: uninstalling one from a source leaves it listed and re-downloadable,
+## while uninstalling one that came from a file removes the only copy there was.
+## Pure: it takes what [Gen2ModHost], [Gen2ModIndex] and [Gen2ModState] already
 ## answer and decides nothing about the network or the screen.
 
 ## The group a mod nothing lists belongs to.

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -1,21 +1,14 @@
 class_name Gen2ModHost
 extends RefCounted
 
-## What a mod is allowed to change, and the only way it gets to change it.
-##
-## A mod never touches scene nodes or engine internals: it is handed this host,
-## registers what it provides, and is done. All it reaches is cartridge content
+## What a mod is allowed to change, and the only way it gets to change it. A mod
+## never touches scene nodes or engine internals: it is handed this host,
+## registers what it provides, and is done, reaching only cartridge content
 ## through [GameData] and live world state through [Gen2WorldAPI].
 ##
-## The world renderer and the battle renderer are replaceable this way. Neither
-## requires 2D, so a renderer building geometry from the same block and collision
-## data is a registration rather than a fork, and [method select_view] swaps
-## between them, which is why the contract is a factory. A mod registering both
-## under its own id is saying they are one view of one world, and choosing that
-## view is one choice: see [method select_view].
-##
-## Mods are interpreted GDScript: iOS forbids JIT and runtime native loading, so
-## a compiled extension is not an option for a distributed mod.
+## Both renderers are replaceable this way, neither requiring 2D, which is why
+## the contract is a factory and [method select_view] swaps between them. Mods are
+## interpreted GDScript, iOS forbidding JIT and runtime native loading.
 
 ## Where installed mods live. Under user:// because a mod is not part of the
 ## build and must survive an update of it.
@@ -73,9 +66,7 @@ const RENDERER_WORLD_CONTEXT_METHOD: String = "set_world_context"
 ## Optional, world renderers only. Offered every input event the world screen did
 ## not use, so a renderer can own camera pitch or first person; answering true
 ## consumes the event. The screen decides first, so a renderer can never take a
-## movement or interaction key: it reads world state and must not write it, and
-## free-roam movement is the separate pose layer docs/MODS.md describes.
-##
+## movement or interaction key: it reads world state and must not write it.
 ## Implement this rather than [method Node._input] or
 ## [method Node._unhandled_input], which are offered events before the screen
 ## decides and so race the gameplay keys instead of taking what is left.
@@ -89,13 +80,11 @@ const RENDERER_INPUT_METHOD: String = "handle_world_input"
 ## ball selection all take their press before a renderer could see it, and what
 ## is left is pointer and stick motion the screen has no opinion about.
 const RENDERER_BATTLE_INPUT_METHOD: String = "handle_battle_input"
-## Optional, both renderer kinds. How opaque the screen draws the field of its
-## own text box while this renderer is on the native layer, from 0 for invisible
-## to 1 for the cartridge's own solid white. The frame's lines and the glyphs are
-## ink and stay opaque, so nothing becomes harder to read.
-##
-## Only honoured for a renderer that answered [constant
-## RENDERER_SURFACE_METHOD] false: a renderer drawing in hardware pixels paints
+## Optional, both renderer kinds. How opaque the screen draws the field of its own
+## text box while this renderer is on the native layer, from 0 to 1. The frame's
+## lines and the glyphs are ink and stay opaque, so nothing becomes harder to
+## read. Only honoured for a renderer that answered
+## [constant RENDERER_SURFACE_METHOD] false: one drawing in hardware pixels paints
 ## the background the box sits on, and a hole in the box would show the window
 ## behind the screen rather than the map.
 const RENDERER_INTERFACE_OPACITY_METHOD: String = "interface_opacity"
@@ -105,16 +94,13 @@ const RENDERER_INTERFACE_OPACITY_METHOD: String = "interface_opacity"
 ## instead of assuming the standard twenty by six at row twelve.
 const RENDERER_TEXT_BOX_METHOD: String = "set_text_box_rect"
 ## Optional, both renderer kinds. Called when a screen laid out in 160x144 takes
-## the picture over the view, and again when it gives it back.
-##
-## A renderer drawing in hardware pixels needs nothing: the screen paints its own
-## letterbox around the rectangle and that mask is inside the hardware viewport.
-## A native-layer renderer is not covered by it, deliberately, since the mask
-## would crop a view that already filled the whole surface. This is how such a
-## renderer closes its own surround instead, and `DoBattleTransition` is the case
-## it exists for: twenty by eighteen cells cannot be widened, so the wedge
-## closing over a filled window is a shape only the view drawing that window can
-## draw. A renderer that does not take it keeps drawing what it was drawing.
+## the picture over the view, and again when it gives it back. A renderer drawing
+## in hardware pixels needs nothing, the screen painting its own letterbox inside
+## the hardware viewport; a native-layer renderer is deliberately not covered,
+## since the mask would crop a view that already filled the surface. This is how
+## such a renderer closes its own surround, and `DoBattleTransition` is the case it
+## exists for: twenty by eighteen cells cannot be widened, so the wedge closing
+## over a filled window is a shape only that view can draw.
 const RENDERER_INTERFACE_MASK_METHOD: String = "set_interface_masked"
 ## Optional, both renderer kinds, and only meaningful on the native layer. Called
 ## beside [constant RENDERER_RESIZE_METHOD] with the cartridge's own 160x144
@@ -357,48 +343,26 @@ func create_world_renderer() -> Node:
 
 
 ## Registers a world ACTOR under [param id]: one sprite in the overworld, drawn
-## with the map's own objects.
-##
-## [param actor] is an object and not a script, because an actor is a pose and
-## not a view: the host drives the one it is handed rather than building one per
-## world. It must be a [RefCounted] and never a [Node], and must answer the three
-## methods in [constant Gen2WorldActors.ACTOR_METHODS]; a registration missing
-## one is refused here, where the mod's name is still in hand.
-##
+## with the map's own objects. [param actor] is an object and not a script,
+## because an actor is a pose and not a view: it must be a [RefCounted], never a
+## [Node], and must answer [constant Gen2WorldActors.ACTOR_METHODS], a
+## registration missing one being refused here where the mod's name is in hand.
 ## Two more are OPTIONAL and offered only to an actor that defines them, so every
-## actor already written keeps working: [constant
-## Gen2WorldActors.ACTOR_INTERACT_METHOD], offered a press of A no cartridge
-## branch answered, and [constant Gen2WorldActors.ACTOR_REQUESTS_METHOD], the
-## one-shot outbox the host drains once a world frame.
-##
-## What an actor draws is presentation and takes part in nothing else. See
-## [Gen2WorldActors] for the contract and `docs/MODS.md` for the entry shape.
+## actor already written keeps working. What an actor draws is presentation and
+## takes part in nothing else; see `docs/MODS.md` for the entry shape.
 func register_world_actor(id: StringName, actor: Object) -> Dictionary:
 	return _register_provider(
 		_world_actors, Gen2WorldActors.ACTOR_METHODS, id, actor, "actor"
 	)
 
 
-## Asks the world screen to pick up the hidden item at [param cell] on the map
-## the player is on. A REQUEST and never the act: taking one writes the bag, the
-## event flag and the save, and runs `hiddenitem`'s own `verbosegiveitem` with
-## its FOUND text, its fanfare and its pack-full branch, none of which a mod may
-## do. So the mod names a cell, exactly as a visible-encounter provider names the
-## entry the host then starts a wild battle from.
-##
-## Queued rather than answered: the screen validates the cell against
-## [method Gen2WorldAPI.hidden_items] and runs the map's own script on the next
-## world frame it is idle for, so an ask inside a battle, a text box or a warp is
-## spent when the world can spend it. Which cell to name is the mod's business.
-##
-## An ask for a cell already queued, or one whose `CheckBGEventFlag` is already
-## set, is dropped here rather than at spend time. A provider reading
-## [method Gen2WorldAPI.hidden_items] every frame and naming what it stands on
-## would otherwise queue sixty asks a second for one cell, and would have to keep
-## a private set of what it has already named: a copy of state the host holds. It
-## is dropped and not refused, because the pack-full branch leaves the flag clear
-## and the mod has no way to tell that cell from one it has never asked about, so
-## asking again has to stay free and correct.
+## Asks the world screen to pick up the hidden item at [param cell]. A REQUEST and
+## never the act: taking one writes the bag, the event flag and the save, and runs
+## `hiddenitem`'s own `verbosegiveitem`, none of which a mod may do. Queued rather
+## than answered, so an ask inside a battle, a text box or a warp is spent when
+## the world can spend it. An ask for a cell already queued, or one whose
+## `CheckBGEventFlag` is set, is dropped rather than refused: the pack-full branch
+## leaves the flag clear, so asking again has to stay free and correct.
 func request_hidden_item(cell: Vector2i) -> void:
 	if _hidden_item_requests.has(cell) or _hidden_item_taken(cell):
 		return
@@ -444,15 +408,10 @@ func requeue_hidden_items(cells: Array[Vector2i]) -> void:
 ## through `verbosegiveitem`'s own transaction: the bag write, the fanfare, the
 ## received line, the pocket line and the pack-full branch. A REQUEST and never
 ## the act, for the reason [method request_hidden_item] is one, and answering
-## nothing for the same reason: a mod names an item and the host runs the screen.
-##
-## Queued the way a hidden item's ask is, so one made inside a battle, a text
-## box, a warp or an overlay is spent on the first world frame nothing else owns
-## rather than dropped. An item number the cartridge does not know is refused
-## when the queue is spent, not here.
-##
-## Unlike a hidden item there is no cell, no event flag and no map: this is the
-## give a script would have made, from a mod that has no script.
+## nothing for the same reason. Queued the same way, so one made inside a battle
+## or a warp is spent on the first world frame nothing else owns. An item number
+## the cartridge does not know is refused when the queue is spent, not here.
+## Unlike a hidden item there is no cell, no event flag and no map.
 func request_item_gift(item: int, quantity: int = 1) -> void:
 	if item <= 0 or quantity <= 0:
 		return
@@ -476,22 +435,12 @@ func requeue_item_gifts(gifts: Array[Dictionary]) -> void:
 
 ## One line's worth of the cartridge's own font, printed in the battle's own box
 ## with its own pacing and its own press, after the line being shown when the
-## request was made. Asked for from a [constant Gen2Battle.CAUGHT] handler it
-## lands between `Gotcha!` and the nickname prompt.
-##
-## Queued and spent in request order, the way [method request_hidden_item] and
-## [method request_item_gift] are, so a mod never prints over the line the player
-## is reading. Unlike those two it is DROPPED where no battle is showing
-## messages rather than held: a line about a moment that has passed is worse than
-## no line, and a mod that wants one later asks then.
-##
+## request was made. Queued and spent in request order, the way the other two ask
+## methods are. Unlike those it is DROPPED where no battle is showing messages
+## rather than held: a line about a moment that has passed is worse than no line.
 ## Refused rather than clipped when it does not fit one line of
-## [constant Gen2TextBox.STANDARD_COLUMNS], and the refusal reaches
-## [method failures] under [param id] so the launcher says whose it was.
-##
-## A `register_event_mutator` on the battle channel could rewrite an existing
-## line instead, but there is one mutator per channel and a renderer wants it, so
-## adding a line must not cost a mod that seam.
+## [constant Gen2TextBox.STANDARD_COLUMNS], with the refusal reaching
+## [method failures] under [param id].
 func request_battle_message(id: StringName, text: String) -> Dictionary:
 	var line: String = text.strip_edges()
 	if String(id).is_empty():
@@ -534,22 +483,14 @@ const NOTICE_SOUND_DEFAULT: StringName = &"item"
 const MAX_NOTICES: int = 8
 
 
-## Asks the world screen to raise a banner over the map: an icon, a title, a
-## line and a sound. A REQUEST and never the act, the way
-## [method request_hidden_item] is one.
-##
-## Drawn as `PlaceMapNameSign` draws the landmark banner, which is the only thing
-## the cartridge ever puts over a live map. Queued and spent the way a hidden
-## item is: held rather than dropped while a battle, a menu, an overlay, a text
-## box, a warp or a script owns the world, one spent per free world frame, and
-## [constant Gen2WorldAPI.MAP_NAME_SIGN_PASSES] between two so a run of them
-## reads rather than flickers.
-##
-## `title` and `line` are each one line of the cartridge's own font and are
-## REFUSED rather than clipped, the way [method request_battle_message] is.
-## `icon` is the vocabulary an actor's `sprites()` and a battle annotation's
-## `tile` share, resolved by [method Gen2MapNameSignPage.render_notice_icon].
-## `sound` is a [constant NOTICE_SOUNDS] name.
+## Asks the world screen to raise a banner over the map: an icon, a title, a line
+## and a sound. A REQUEST and never the act, the way [method request_hidden_item]
+## is. Drawn as `PlaceMapNameSign` draws the landmark banner, the only thing the
+## cartridge ever puts over a live map, and held rather than dropped while
+## something else owns the world, with [constant Gen2WorldAPI.MAP_NAME_SIGN_PASSES]
+## between two. `title` and `line` are REFUSED rather than clipped, `icon` is the
+## vocabulary an actor's `sprites()` shares, and `sound` is a
+## [constant NOTICE_SOUNDS] name.
 func request_notice(id: StringName, notice: Dictionary) -> Dictionary:
 	if String(id).is_empty():
 		return {"ok": false, "reason": &"invalid_provider"}
@@ -699,17 +640,11 @@ func world_actors() -> Array:
 
 ## Registers a VISIBLE ENCOUNTER provider under [param id]: a bounded population
 ## of wild Pokemon standing on the map, met by walking into one, instead of the
-## roll a step takes.
-##
-## [param provider] is an object and not a script, for the reason an actor is:
-## the host drives the one it is handed. It must be a [RefCounted] and never a
-## [Node], and must answer the four methods in
-## [constant Gen2WorldEncounters.PROVIDER_METHODS].
-##
-## The provider owns its population and nothing else. Which cells are eligible,
-## which table is active, whether an entry is inside both, what a shiny is and
-## what meeting one starts are all the host's, and while at least one provider is
-## registered the ordinary post-step roll is off. See [Gen2WorldEncounters].
+## roll a step takes. [param provider] is an object and not a script, for the
+## reason an actor is; it must be a [RefCounted], never a [Node], and must answer
+## [constant Gen2WorldEncounters.PROVIDER_METHODS]. The provider owns its
+## population and nothing else, and while at least one is registered the ordinary
+## post-step roll is off.
 func register_visible_encounters(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(
 		_visible_encounters, Gen2WorldEncounters.PROVIDER_METHODS, id, provider
@@ -757,16 +692,12 @@ func visible_encounter_providers() -> Array:
 
 
 ## Registers an alternate FIELD MOVE SOURCE under [param id]: a read-only policy
-## saying that an HM's own field move may be used without a party member who
-## knows it.
-##
-## [param provider] is a [RefCounted] answering
-## [constant FIELD_MOVE_SOURCE_METHODS]: `allows_field_move(move)`, one question
-## per move, answered true or false. That is the whole of what a mod decides.
-## Which item teaches which move, whether it is in the bag, whether the badge is
-## in hand, whether the tile in front allows it and everything the move then
-## does are the host's, in [method Gen2WorldAPI.field_move_source] and the
-## staged requests behind it.
+## saying that an HM's own field move may be used without a party member who knows
+## it. [param provider] answers [constant FIELD_MOVE_SOURCE_METHODS]'
+## `allows_field_move(move)`, one question per move, and that is the whole of what
+## a mod decides. Which item teaches which move, whether the badge is in hand,
+## whether the tile in front allows it and everything the move then does are the
+## host's.
 func register_field_move_source(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(
 		_field_move_sources, FIELD_MOVE_SOURCE_METHODS, id, provider
@@ -819,26 +750,13 @@ func repel_renewal_item(bag: Dictionary) -> int:
 
 
 ## Registers a SHINY ROLLS provider under [param id]: how many DV words the host
-## draws for one wild before it settles, which is the later games' charm.
-##
-## [param provider] answers [constant SHINY_ROLLS_METHODS]' `shiny_rolls(context)`
-## with a whole number. The host draws up to that many words off the battle's own
-## generator, keeps the first [method Gen2Stats.is_shiny] accepts and otherwise
-## keeps the last, and clamps to [constant MAX_SHINY_ROLLS]. 0 and 1 both mean
-## the cartridge's own single roll, which is also what an unregistered host does.
-##
-## [param context] carries `species`, `level`, `method`, `map_group` and
-## `map_number`, so an answer may vary by encounter. It does not carry the bag:
-## [method inventory] is what a mod asks the bag with, and asking it here would
-## give a provider one snapshot per wild rather than the live one.
-##
-## Two providers COMPOSE ADDITIVELY rather than by registration order, which is
-## what [method shiny_roll_count] takes: each provider's answer past the
-## cartridge's own one roll is added to the rest. Refusing the second by name
-## would make two charms an install error over a number that has an obvious
-## join, and taking the largest would silently drop one of them. A provider
-## still answers the total it would give alone, so nothing registered changes
-## and one provider alone answers exactly what it did before.
+## draws for one wild before it settles, which is the later games' charm. The host
+## keeps the first [method Gen2Stats.is_shiny] accepts and otherwise the last, and
+## clamps to [constant MAX_SHINY_ROLLS]; 0 and 1 both mean the cartridge's own
+## single roll. [param context] carries the encounter but not the bag, since
+## [method inventory] is live and this would be one snapshot per wild. Two
+## providers COMPOSE ADDITIVELY rather than by registration order: refusing the
+## second would make two charms an install error over a number with an obvious join.
 func register_shiny_rolls(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(_shiny_rolls, SHINY_ROLLS_METHODS, id, provider)
 
@@ -861,14 +779,12 @@ static func shiny_roll_count(context: Dictionary) -> int:
 
 
 ## Registers a CATCH EXPERIENCE policy for [param manifest]'s own run: whether a
-## successful wild capture awards the caught Pokemon's experience.
-##
-## Save bound, so [param manifest] is the capability the way it is for
-## [method register_save_lifecycle]: a manifest this host did not discover
-## registers nothing. [param provider] answers
-## [constant CATCH_EXPERIENCE_METHODS]' `awards_catch_experience()`, which is
-## read every capture rather than once, so a mod that switched its own option
-## off mid-run is off from the next throw.
+## successful wild capture awards the caught Pokemon's experience. Save bound, so
+## [param manifest] is the capability the way it is for
+## [method register_save_lifecycle] and a manifest this host did not discover
+## registers nothing. [param provider] answers `awards_catch_experience()`, read
+## every capture rather than once, so a mod that switched its own option off
+## mid-run is off from the next throw.
 func register_catch_experience(manifest: Gen2ModManifest, provider: Object) -> Dictionary:
 	if not _owns_manifest(manifest):
 		return {"ok": false, "reason": &"unknown_mod_save_owner"}
@@ -892,16 +808,12 @@ static func awards_catch_experience() -> bool:
 	return false
 
 
-## Registers a BATTLE INFORMATION provider under [param id]: read-only
-## annotations drawn on the hardware interface over whichever battle renderer is
-## selected.
-##
-## [param provider] answers [constant BATTLE_INFO_METHODS]'
-## `annotate_battle(snapshot)` with an array of placements on the 20x18 tile
-## grid, each `{"at": Vector2i}` plus either a `text` string or a `tile` of 8x8
-## pixel indices. The snapshot is [method Gen2BattleScreen.info_snapshot]: both
-## sides' stages, the weather, the move rows with their exact effectiveness
-## against the defender, and what is on screen. A provider computes nothing the
+## Registers a BATTLE INFORMATION provider under [param id]: read-only annotations
+## drawn on the hardware interface over whichever battle renderer is selected.
+## [param provider] answers `annotate_battle(snapshot)` with an array of
+## placements on the 20x18 tile grid, each `{"at": Vector2i}` plus either a `text`
+## string or a `tile` of 8x8 pixel indices. The snapshot is
+## [method Gen2BattleScreen.info_snapshot], so a provider computes nothing the
 ## host already knows.
 func register_battle_info(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(_battle_info, BATTLE_INFO_METHODS, id, provider)
@@ -914,12 +826,10 @@ func battle_info_ids() -> Array:
 ## Every provider's placements for [param snapshot], validated and with
 ## overlapping ownership refused rather than resolved by load order: a cell a
 ## later provider claims after an earlier one is dropped and reported, so which
-## mod loaded first cannot decide what a player sees.
-##
-## A placement the grid refuses is reported by name too. A provider is a pure
-## function of a snapshot and this runs once a frame, so each distinct refusal
-## is recorded once: repeating it sixty times a second would bury every other
-## failure the launcher lists.
+## mod loaded first cannot decide what a player sees. A placement the grid refuses
+## is reported by name too. This runs once a frame over a pure function, so each
+## distinct refusal is recorded once: repeating it sixty times a second would bury
+## every other failure the launcher lists.
 func battle_info_placements(snapshot: Dictionary) -> Array:
 	var out: Array = []
 	var claimed: Dictionary = {}
@@ -1029,15 +939,12 @@ func selected_view() -> StringName:
 
 
 ## Chooses the view, by mod id, for both surfaces at once: whichever of the two
-## renderer kinds [param id] registered is used, and the built-in one keeps the
-## other. Registering a world renderer and a battle renderer under one id is how
-## a mod says the two are one view of one world, and this is the only thing that
-## ever selects either.
-##
-## Persisted per installation, so the choice survives a restart the way a mod's
-## own options do. A live screen rebuilds on [signal view_changed], so the
-## launcher's page, the start menu's row and the key that cycles views are one
-## path rather than three, and a caller that holds no screen needs nothing.
+## renderer kinds [param id] registered is used and the built-in one keeps the
+## other. Registering both under one id is how a mod says the two are one view of
+## one world, and this is the only thing that ever selects either. Persisted per
+## installation, so the choice survives a restart. A live screen rebuilds on
+## [signal view_changed], so the launcher's page, the start menu's row and the key
+## that cycles views are one path rather than three.
 func select_view(id: StringName) -> Dictionary:
 	if id != BUILT_IN_RENDERER and not _world_renderers.has(id) \
 		and not _battle_renderers.has(id):
@@ -1051,15 +958,13 @@ func select_view(id: StringName) -> Dictionary:
 	return {"ok": true, "id": id}
 
 
-## Adds one entry to [param menu]. [param entry] needs a [code]label[/code]; the
-## start menu takes an optional [code]handler[/code] Callable the screen calls
-## when the entry is chosen, a pack pocket needs a [code]pocket[/code] type
-## number at or above [constant FIRST_MOD_POCKET], and a mart entry names an
-## [code]item[/code], optional [code]price[/code], and optional
-## [code]available(mart)[/code] Callable.
-##
-## An entry without a handler still appears, marked unavailable, which is what
-## every unimplemented cartridge entry already does.
+## Adds one entry to [param menu]. [param entry] needs a `label`; the start menu
+## takes an optional `handler` Callable the screen calls when the entry is chosen,
+## a pack pocket needs a `pocket` type number at or above
+## [constant FIRST_MOD_POCKET], and a mart entry names an `item`, an optional
+## `price` and an optional `available(mart)` Callable. An entry without a handler
+## still appears, marked unavailable, which is what every unimplemented cartridge
+## entry already does.
 func register_menu_entry(menu: StringName, id: StringName, entry: Dictionary) -> Dictionary:
 	if not MENU_IDS.has(menu):
 		return {"ok": false, "reason": &"unknown_menu", "detail": String(menu)}
@@ -1119,17 +1024,13 @@ func register_menu_entry(menu: StringName, id: StringName, entry: Dictionary) ->
 	return {"ok": true, "id": id}
 
 
-## Adds one row to the PARTY MEMBER submenu, the box a party slot opens.
-##
-## Unlike [method register_menu_entry] a row here is about a SLOT rather than
-## about the menu, so both halves are Callables taking the one-based slot: the
-## label so a mod can say something different on the slot it already owns, and
-## the handler so it knows which one was chosen. Both are validated here, where
-## the mod's name is still in hand.
-##
-## Outside battle only. A battle's party list is a switch, and a row that ran a
-## mod's field action in the middle of a turn would be world state changing while
-## the turn owns it.
+## Adds one row to the PARTY MEMBER submenu, the box a party slot opens. Unlike
+## [method register_menu_entry] a row here is about a SLOT, so both halves are
+## Callables taking the one-based slot: the label so a mod can say something
+## different on the slot it owns, and the handler so it knows which was chosen.
+## Outside battle only: a battle's party list is a switch, and a row that ran a
+## mod's field action mid-turn would be world state changing while the turn owns
+## it.
 func register_party_member_menu(id: StringName, entry: Dictionary) -> Dictionary:
 	if String(id).is_empty():
 		return {"ok": false, "reason": &"invalid_party_menu_entry"}
@@ -1164,17 +1065,13 @@ func party_member_entries(slot: int, in_battle: bool = false) -> Array:
 
 
 ## Adds one page to the stats screen, after the cartridge's pink, green and blue.
-##
-## [param entry] carries a `build(page)` Callable taking [method
-## Gen2MonStatsScreen.snapshot] and answering placements on the screen's own tile
-## grid: `{"text": String, "at": Vector2i}` for a string and `{"divider": int}`
-## for a vertical divider down that column of the lower half. The mod says where
-## its strings go and the host writes them with the screen's own font, so a page
-## needs no renderer, no node and no picture of its own.
-##
-## The ceiling is [constant Gen2StatsScreenPage.MAX_PAGES]: the page indicators
-## are centred between the two arrows and the left arrow moves with them, and one
-## more block than that reaches the front pic.
+## [param entry] carries a `build(page)` Callable taking
+## [method Gen2MonStatsScreen.snapshot] and answering placements on the screen's
+## own tile grid, `{"text", "at"}` for a string and `{"divider"}` for a vertical
+## rule. The host writes them with the screen's own font, so a page needs no
+## renderer, node or picture. The ceiling is
+## [constant Gen2StatsScreenPage.MAX_PAGES], past which the indicators reach the
+## front pic.
 func register_stats_page(id: StringName, entry: Dictionary) -> Dictionary:
 	if String(id).is_empty():
 		return {"ok": false, "reason": &"invalid_stats_page"}
@@ -1200,14 +1097,11 @@ func stats_pages() -> Array:
 
 ## A screen of the mod's own, listed and drawn by the host: [param entry] carries
 ## a `title` and a `rows` Callable answering an Array of
-## `{label, detail, icon, locked}`.
-##
-## The host draws it with the screen's own font and frame, so a mod needs no
-## node, no renderer and no art of its own; `icon` is
-## [method request_notice]'s vocabulary. A `MENU_START` entry registered under
-## the same id naming [constant START_ACTION_OPEN_MOD_PAGE] is what opens it.
-##
-## One page per mod, refused by name for a second, the way a stats page is.
+## `{label, detail, icon, locked}`. The host draws it with the screen's own font
+## and frame, so a mod needs no node, renderer or art of its own, and `icon` is
+## [method request_notice]'s vocabulary. A `MENU_START` entry registered under the
+## same id naming [constant START_ACTION_OPEN_MOD_PAGE] is what opens it. One page
+## per mod, refused by name for a second.
 func register_page(id: StringName, entry: Dictionary) -> Dictionary:
 	if String(id).is_empty():
 		return {"ok": false, "reason": &"invalid_mod_page"}
@@ -1332,17 +1226,13 @@ func mart_entries(mart: Dictionary) -> Array:
 	return out
 
 
-## One setting the player can change: a ladder of values, a number in a range or
-## a button, chosen by [code]kind[/code] and defaulting to
-## [constant OPTION_LADDER]. A ladder needs a [code]key[/code], a
-## [code]label[/code] and a non-empty [code]values[/code] array;
-## [code]labels[/code] names each rung and defaults to the values themselves, and
-## [code]default[/code] is the rung used until the player picks, defaulting to
-## the first. A toggle is a two-rung ladder, and [constant OPTION_NUMBER] takes a
-## range instead ([method _register_number_option]).
-##
-## A mod describes a setting rather than drawing one: the start menu's MODS entry
-## and the launcher's mods page are both built from these, so the two surfaces
+## One setting the player can change: a ladder of values, a number in a range or a
+## button, chosen by `kind` and defaulting to [constant OPTION_LADDER]. A ladder
+## needs a `key`, a `label` and a non-empty `values` array; `labels` names each
+## rung and defaults to the values themselves, and `default` is the rung used
+## until the player picks. A toggle is a two-rung ladder and
+## [constant OPTION_NUMBER] takes a range instead. A mod describes a setting rather
+## than drawing one, so the start menu's MODS entry and the launcher's mods page
 ## cannot disagree.
 func register_option(id: StringName, spec: Dictionary) -> Dictionary:
 	var key: StringName = StringName(spec.get("key", &""))
@@ -1578,21 +1468,12 @@ func _stored_number(id: StringName, row: Dictionary) -> int:
 	return clampi(int(stored), int(row["minimum"]), int(row["maximum"]))
 
 
-## Declares a control of the mod's own, in the shape [method register_option]
-## uses for a setting.
-##
-## [codeblock]
-## host.register_action(manifest.id, {
-##     "key": &"pitch_up",
-##     "label": "Raise the camera",
-##     "default": [{"kind": "key", "code": KEY_R}],
-## })
-## [/codeblock]
-##
-## `default` is [Gen2InputActions]' binding shape, so a mod's action binds by key,
-## pad button or stick and is rebound by the same controls card. A default on one
-## of the cartridge's buttons is dropped and reported, since the screen claims
-## those first and such a binding would never fire.
+## Declares a control of the mod's own, in the shape [method register_option] uses
+## for a setting: a `key`, a `label` and a `default` in [Gen2InputActions]'
+## binding shape, so a mod's action binds by key, pad button or stick and is
+## rebound by the same controls card. A default on one of the cartridge's buttons
+## is dropped and reported, since the screen claims those first and such a binding
+## would never fire.
 func register_action(id: StringName, action: Dictionary) -> Dictionary:
 	var key: StringName = StringName(action.get("key", &""))
 	if String(id).is_empty() or String(key).is_empty():
@@ -1858,19 +1739,13 @@ func patch_fishing_time_group(id: StringName, index: int, fields: Dictionary) ->
 	)
 
 
-## One [Gen2WorldCatalog] site, by the stable id the catalog gave it. This is how
-## a mod reaches a starter, a gift, a static battle, a trade, a Game Corner
-## prize, an item on the ground, a badge or a shop.
-##
-## Name only the field that moves: `species` and `level` for anything that hands
-## over a Pokemon, `item` and `quantity` for anything that hands over an item,
-## `price` for a prize, `mart` for a shop, `badge` for a badge. The site still
-## runs the cartridge's own script, so its completion flag, its dialogue, its
-## inventory transaction and its battle flow are untouched.
-##
-## An id no cartridge site carries changes nothing, exactly as a species patch of
-## a number this cartridge lacks does. Read the ids from
-## `GameData.catalog().rows(kind)` rather than computing one.
+## One [Gen2WorldCatalog] site, by the stable id the catalog gave it: how a mod
+## reaches a starter, a gift, a static battle, a trade, a prize, a ground item, a
+## badge or a shop. Name only the field that moves, `species` and `level`, `item`
+## and `quantity`, `price`, `mart` or `badge`. The site still runs the cartridge's
+## own script, so its completion flag, dialogue, inventory transaction and battle
+## flow are untouched. An id no cartridge site carries changes nothing; read the
+## ids from `GameData.catalog().rows(kind)` rather than computing one.
 func patch_check(id: StringName, check_id: int, fields: Dictionary) -> Dictionary:
 	if check_id < 0:
 		return {"ok": false, "reason": &"not_a_check_id", "detail": str(check_id)}
@@ -1880,14 +1755,11 @@ func patch_check(id: StringName, check_id: int, fields: Dictionary) -> Dictionar
 
 
 ## Whether [param patches] leaves the game finishable, WITHOUT installing any of
-## them. [param patches] is catalog check id to the fields a mod proposes, which
-## is the same shape [method patch_check] takes one row at a time.
-##
-## Answers `{ok, reached, critical, missing}`, and on a failure `missing` names
-## the check that could not be reached and the one requirement of it that never
-## became satisfiable, so a generator retries against a reason. Deterministic:
-## one placement always answers the same way. See [Gen2WorldProgression] for what
-## the proof does and does not cover.
+## them; the same shape [method patch_check] takes one row at a time. Answers
+## `{ok, reached, critical, missing}`, and on a failure `missing` names the check
+## that could not be reached and the one requirement of it that never became
+## satisfiable, so a generator retries against a reason. Deterministic. See
+## [Gen2WorldProgression] for what the proof does and does not cover.
 func validate_placement(data: GameData, patches: Dictionary) -> Dictionary:
 	return Gen2WorldProgression.validate(data, patches)
 
@@ -2210,18 +2082,13 @@ const SAVE_LIFECYCLE_METHODS: Array[String] = [
 
 
 ## Registers a provider told which save is being played, so a mod can hold a run
-## rather than an installation.
-##
-## [param manifest] is the object `register()` was handed, and it is the
-## capability: the host keeps it beside the provider, so a callback can reach
-## [method read_save_data] and [method write_save_data] for its OWN namespace and
-## no other mod's. A manifest this host did not discover registers nothing.
-##
-## [param provider] is a [RefCounted] answering
-## [constant SAVE_LIFECYCLE_METHODS]. Ordering is in `docs/MODS.md`; the part
-## that matters here is that the host drops every lifecycle mod's overlay
-## contributions before a `save_activated` runs, so two slots cannot leak
-## patches into one another and a provider that fails leaves nothing installed.
+## rather than an installation. [param manifest] is the object `register()` was
+## handed and it is the capability: the host keeps it beside the provider, so a
+## callback reaches [method read_save_data] for its OWN namespace and no other
+## mod's. [param provider] answers [constant SAVE_LIFECYCLE_METHODS]. Ordering is
+## in `docs/MODS.md`; what matters here is that the host drops every lifecycle
+## mod's overlay contributions before a `save_activated` runs, so two slots cannot
+## leak patches into one another.
 func register_save_lifecycle(manifest: Gen2ModManifest, provider: Object) -> Dictionary:
 	if not _owns_manifest(manifest):
 		return {"ok": false, "reason": &"unknown_mod_save_owner"}
@@ -2264,18 +2131,13 @@ func created_save(save: Gen2SaveData) -> void:
 		entry["provider"].call("save_created", save)
 
 
-## The save about to be played, or null for a DEVELOPMENT run: one started
-## without a selected slot, which has no namespace to read and must not be handed
-## an invented save to write into.
-##
-## Every lifecycle mod's overlay contributions are dropped first, in one pass, so
-## the callbacks that follow all start from the cartridge whatever order they run
-## in. A mod that patches at load time and registers no provider is untouched.
-##
-## The save's own mod settings are bound before any callback runs, so a provider
-## reads the values this run was played with rather than the installation's. A
-## slot written before that snapshot existed adopts the installation once, here,
-## which is the one place the two can honestly be reconciled.
+## The save about to be played, or null for a DEVELOPMENT run: one started without
+## a selected slot, which has no namespace to read and must not be handed an
+## invented save to write into. Every lifecycle mod's overlay contributions are
+## dropped first, in one pass, so the callbacks that follow all start from the
+## cartridge whatever order they run in. The save's own mod settings are bound
+## before any callback, so a provider reads the values this run was played with;
+## a slot written before that snapshot existed adopts the installation once, here.
 func activate_save(save: Gen2SaveData) -> void:
 	_clear_save_overlays()
 	if save == null:

--- a/game/mods/mod_index.gd
+++ b/game/mods/mod_index.gd
@@ -1,22 +1,13 @@
 class_name Gen2ModIndex
 extends RefCounted
 
-## A published list of mods a player chose to follow.
-##
-## An index is metadata only: a JSON feed naming mods that live wherever their
-## authors put them. Nothing here installs anything. A chosen entry hands its
-## download to [Gen2ModInstaller] like any other archive, with the listed id
-## required to match, so appearing in a feed buys a mod no trust that picking
-## the same file by hand would not.
-##
-## One index ships with the game: this project's own, in [constant
-## BUILT_IN_FEED]. It is a listing and nothing more, so a build carrying it has
-## installed nothing and downloaded nothing until the player picks a mod out of
-## it. Every other index is the player trusting a publisher we did not choose
-## for them, so adding one is always their act and only theirs.
-##
-## Everything above "fetching" is pure: no HTTP, no filesystem. The feed format
-## is a contract with people we will never meet, so its rules are worth testing
+## A published list of mods a player chose to follow: metadata only, a JSON feed
+## naming mods that live wherever their authors put them. Nothing here installs
+## anything, and a chosen entry hands its download to [Gen2ModInstaller] with the
+## listed id required to match, so appearing in a feed buys a mod no trust that
+## picking the same file by hand would not. One index ships with the game, this
+## project's own; every other is the player trusting a publisher we did not choose
+## for them. Everything above "fetching" is pure, so the feed format can be tested
 ## without a network.
 
 ## Feeds declare this. A later format may reuse a field name for something else,

--- a/game/mods/mod_installer.gd
+++ b/game/mods/mod_installer.gd
@@ -1,16 +1,13 @@
 class_name Gen2ModInstaller
 extends RefCounted
 
-## Installs a mod from a `.zip` into [constant Gen2ModHost.ROOT].
-##
-## This is the only way a mod gets onto disk, whichever way the player found it:
-## a file they picked, a file they dropped on the window, or one downloaded from
-## an index. A listing therefore buys a mod no trust that picking the same file
-## by hand would not, and there is one place to harden rather than three.
-##
-## Nothing is written until the archive has been opened, its layout resolved and
-## its manifest validated, so a refused archive leaves the mods directory
-## exactly as it was. A copy that fails part way removes what it wrote.
+## Installs a mod from a `.zip` into [constant Gen2ModHost.ROOT]. The only way a
+## mod gets onto disk, whichever way the player found it: a file they picked, a
+## file they dropped on the window, or one downloaded from an index. So a listing
+## buys a mod no trust that picking the same file by hand would not, and there is
+## one place to harden rather than three. Nothing is written until the archive has
+## been opened, its layout resolved and its manifest validated, and a copy that
+## fails part way removes what it wrote.
 
 ## A single mod's uncompressed size. Well above the voxel example and far below
 ## anything that fills a phone, so a hostile or broken archive stops here rather

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -1,15 +1,12 @@
 class_name Gen2ModManifest
 extends RefCounted
 
-## One mod's declared identity, read from its `mod.json`.
-##
-## Parsing is separate from loading, so the launcher can list what is installed
-## and say why something was refused without running a line of mod code.
-##
-## [code]api_version[/code] is [Gen2ModHost]'s contract, not the mod's own
-## version. A mod built against a NEWER host is refused rather than allowed to
-## fail somewhere less obvious; one built against an older one still runs, since
-## every version so far has only added to the contract.
+## One mod's declared identity, read from its `mod.json`. Parsing is separate from
+## loading, so the launcher can list what is installed and say why something was
+## refused without running a line of mod code. `api_version` is [Gen2ModHost]'s
+## contract rather than the mod's own version: a mod built against a NEWER host is
+## refused rather than allowed to fail somewhere less obvious, and one built
+## against an older one still runs, since every version so far has only added.
 
 const FILENAME: String = "mod.json"
 ## Bumped when the host contract changes in a way an existing mod would notice.

--- a/game/mods/mod_options.gd
+++ b/game/mods/mod_options.gd
@@ -1,23 +1,13 @@
 class_name Gen2ModOptions
 extends RefCounted
 
-## What the player chose for each mod's registered settings.
-##
-## The file under user:// is the installation's own values, beside
-## [Gen2ModState]'s disabled list: it is what a NEW run is created from and what
-## the launcher edits with no slot open. Per-mod *save* data is a separate thing
-## and is not this.
-##
-## A run bound with [method bind_run] takes over while it is played, because a
-## draw distance that changed under a loaded slot would make that slot's own
-## recorded walk unreproducible ([member Gen2SaveData.run_options]). The bound
-## Dictionary is the save's, so a setting changed mid-run is kept by the save that
-## was played rather than by the installation alone.
-##
-## Only values are kept. What a setting is, what it may be and what it falls back
-## to is the mod's own registration on [Gen2ModHost], so an uninstalled mod's
-## leftover row costs nothing and a mod that changed its ladder between versions
-## sees its stored value refused and its default used instead.
+## What the player chose for each mod's registered settings. The file under
+## user:// is the installation's own values and is what a NEW run is created from;
+## per-mod save data is a separate thing. A run bound with [method bind_run] takes
+## over while it is played, because a draw distance that changed under a loaded
+## slot would make that slot's recorded walk unreproducible. Only values are kept:
+## what a setting is and what it falls back to is the mod's own registration, so a
+## leftover row costs nothing and a changed ladder sees its stored value refused.
 
 const PATH: String = "user://mod_options.json"
 

--- a/game/mods/mod_progress.gd
+++ b/game/mods/mod_progress.gd
@@ -1,22 +1,13 @@
 class_name Gen2ModProgress
 extends RefCounted
 
-## What a run has achieved, as one flat read-only dictionary.
-##
-## A mod is deliberately given no world and no save: [method Gen2ModHost.progress]
-## and [method Gen2ModHost.progress_for] hand it this instead, the way
-## [method Gen2ModHost.inventory] hands it the bag. Every field is a state the
-## run has REACHED rather than a moment it passed, so a mod installed onto a save
-## already played reads what that save has and a mod watching
-## [signal Gen2ModHost.progress_changed] sees the same field move.
-##
-## Cartridge differences are resolved here. `badges` is a Crystal-ordered mask
-## whichever profile is open, so a mod never touches
-## [method Gen2WorldState.badge_flag] or the Gold and Silver flag table.
-##
-## A field this cannot answer is LEFT OUT rather than zeroed, so a mod written
-## against a later build reads a missing answer as nothing achieved rather than
-## as an achievement lost.
+## What a run has achieved, as one flat read-only dictionary. A mod is
+## deliberately given no world and no save: [method Gen2ModHost.progress] hands it
+## this instead, the way [method Gen2ModHost.inventory] hands it the bag. Every
+## field is a state the run has REACHED rather than a moment it passed, so a mod
+## installed onto a save already played reads what that save has. Cartridge
+## differences are resolved here, `badges` being a Crystal-ordered mask whichever
+## profile is open. A field this cannot answer is LEFT OUT rather than zeroed.
 
 ## The live run: [param world] for everything the world owns and [param save] for
 ## the party, the boxes and the play timer, which are the save's.

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -1,16 +1,12 @@
 class_name Gen2ModRefusal
 extends RefCounted
 
-## Why a mod was refused, said to a player rather than to a log.
-##
-## One table for every reason the mod layer produces: the installer's, the index
-## feed's, the manifest reader's and the host's registrations alike. The launcher
-## and the index dialog each used to keep their own, covering different halves of
-## the same set, so a mod refused through the wrong screen showed a raw
-## StringName. A new reason is worded here, once, and both screens have it.
-##
-## Anything unworded falls back to the reason itself, which is a poor line but an
-## honest one: it names something a search finds.
+## Why a mod was refused, said to a player rather than to a log: one table for
+## the installer's reasons, the index feed's, the manifest reader's and the
+## host's registrations alike. The launcher and the index dialog each used to keep
+## their own, covering different halves of the same set, so a mod refused through
+## the wrong screen showed a raw StringName. Anything unworded falls back to the
+## reason itself, which is a poor line but an honest one.
 
 ## Reasons that read the same wherever they come from. A [code]%s[/code] is
 ## filled with the result's own [code]detail[/code]; a reason wanting anything

--- a/game/mods/mod_state.gd
+++ b/game/mods/mod_state.gd
@@ -2,15 +2,11 @@ class_name Gen2ModState
 extends RefCounted
 
 ## The installation's own choices about installed mods: which are switched off,
-## and which one's view the game is drawn with.
-##
-## Disabled ids are stored rather than enabled ones, so a mod that was just
-## installed runs without needing an entry written for it, and a file lost or
-## damaged means every mod runs rather than none.
-##
-## A disabled mod is still discovered and still listed. Only [method
-## Gen2ModHost.load_discovered] skips it, so the launcher can show it, say it
-## is off, and switch it back on without reinstalling.
+## and which one's view the game is drawn with. Disabled ids are stored rather
+## than enabled ones, so a mod just installed runs without needing an entry, and a
+## file lost or damaged means every mod runs rather than none. A disabled mod is
+## still discovered and still listed; only [method Gen2ModHost.load_discovered]
+## skips it, so the launcher can switch it back on without reinstalling.
 
 ## Named for the list it was written for; it now also carries the selected view.
 const PATH: String = "user://mods_disabled.json"

--- a/game/options/rules.gd
+++ b/game/options/rules.gd
@@ -3,24 +3,12 @@ extends RefCounted
 
 ## Which behaviour a run is played under: the places this project and the
 ## cartridge disagree on purpose, and which challenge the run was created under.
-##
-## Separate from [Gen2Options], which is the installation's own settings: a rule
-## changes what the engine DOES, so it belongs to the run that produced a save
-## rather than to whichever machine is playing it. A divergence becomes a named
-## flag here one at a time, each with a live branch on both sides and a test on
-## each.
-##
-## The two halves differ in one way. A flag is edited in Settings and the next
-## new game takes a copy; [member challenge] is chosen on the save screen when
-## the game is made and never moves again, because a Hard run that could be
-## turned down after a loss, or a Nuzlocke that could be turned off after a
-## death, would be neither. See [Gen2Nuzlocke] for what one of them spends.
-##
-## Every flag is named for the cartridge's behaviour and answers "reproduce the
-## hardware", so a flag that is off is this project's own corrected answer. That
-## way a flag added later cannot silently change what an existing run did: the
-## default for a new flag is whatever [constant MODE_CURRENT] says, which is the
-## behaviour that shipped before the flag existed.
+## Separate from [Gen2Options], because a rule changes what the engine DOES and so
+## belongs to the run that produced a save. A flag is edited in Settings and the
+## next new game takes a copy; [member challenge] is chosen when the game is made
+## and never moves again. Every flag is named for the cartridge's behaviour, so a
+## flag that is off is this project's corrected answer and a flag added later
+## defaults to whatever [constant MODE_CURRENT] says.
 
 ## Every named flag, mapped to what [constant MODE_CURRENT] does today. The
 ## descriptions belong beside the branch, not here; each key names the

--- a/game/render/battle_annotations.gd
+++ b/game/render/battle_annotations.gd
@@ -1,17 +1,12 @@
 class_name Gen2BattleAnnotations
 extends RefCounted
 
-## What a registered battle-information provider draws on the hardware
-## interface, validated once and drawn once.
-##
-## The grid is the cartridge's own screen in tiles, so a placement is said in the
-## same coordinates `hlcoord` is and lands in the same cells whichever renderer
-## is underneath: the annotations are interface, and the interface is 20x18
-## whether the battle behind it is the built-in arena or a native-layer view.
-##
-## A mod supplies a string or a tile and nothing else. Where a cell may be drawn,
-## what a tile's bytes mean, which provider owns a cell and when the layer is
-## hidden are all the host's.
+## What a registered battle-information provider draws on the hardware interface,
+## validated once and drawn once. The grid is the cartridge's own screen in tiles,
+## so a placement is said in the same coordinates `hlcoord` is and lands in the
+## same cells whichever renderer is underneath. A mod supplies a string or a tile
+## and nothing else: where a cell may be drawn, what a tile's bytes mean, which
+## provider owns a cell and when the layer is hidden are all the host's.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = Gen2Screen.WIDTH / TILE
@@ -48,15 +43,12 @@ static func from_data(data: GameData) -> Gen2BattleAnnotations:
 
 
 ## [param placement] as the host will keep it, or `{}` when it cannot be drawn.
-##
-## `field` is the one optional key: with it set the host draws the cartridge's
-## own interface field behind exactly the cells [method cells] answers, so ink a
-## provider puts on bare battle scenery is readable over a native renderer. It
-## is kept only when it was asked for, so a placement without it is exactly the
-## dictionary an API 13 provider already got back.
-##
-## Refused rather than clipped: a symbol half off the screen, or a stage summary
-## running through the border, is worse than one the player never sees.
+## `field` is the one optional key: with it set the host draws the cartridge's own
+## interface field behind exactly the cells [method cells] answers, so ink on bare
+## battle scenery is readable over a native renderer. It is kept only when it was
+## asked for, so a placement without it is exactly what an API 13 provider already
+## got back. Refused rather than clipped: a symbol half off the screen is worse
+## than one the player never sees.
 static func validate(placement: Dictionary) -> Dictionary:
 	var checked: Dictionary = validated(placement)
 	return checked["placement"] if bool(checked["ok"]) else {}

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -1,20 +1,13 @@
 class_name Gen2BattleHud
 extends RefCounted
 
-## The two status panels a battle draws, on the tile grid the hardware uses.
-##
-## Everything is in tiles at the positions the games use. The enemy's panel hangs
-## from a side on its left at the top, the player's from a side on its right
-## below the middle. Neither is a box: an edge and two corners with the contents
-## printed inside, which is why both come from the HUD sheets rather than a text
-## box frame.
-##
-## The player's panel also carries HP as numbers and an exp bar along its bottom
-## edge, closed by the cap hanging off the other side. The enemy's has neither,
-## because the player is not supposed to know either number.
-##
-## Node-free: it writes indices into a buffer, so a HUD can be drawn and read
-## back headless.
+## The two status panels a battle draws, on the tile grid the hardware uses. The
+## enemy's hangs from a side on its left at the top, the player's from a side on
+## its right below the middle; neither is a box, but an edge and two corners with
+## the contents printed inside, which is why both come from the HUD sheets. The
+## player's also carries HP as numbers and an exp bar along its bottom edge, and
+## the enemy's has neither because the player is not supposed to know either
+## number. Node-free: it writes indices into a buffer.
 
 const TILE: int = Gen2Font.TILE
 
@@ -147,20 +140,14 @@ func draw_hp_bar(
 		)
 
 
-## The exp bar, whose ends are the HP bar's own tiles and whose partial fills
-## are the only thing its own sheet is for.
-##
-## [param pixels] is `PlaceExpBar`'s own `b`: the bar is a pixel count, never a
-## ratio, because `CalcExpBar` has already done the division and rounded it the
-## cartridge's way.
-##
-## `PlaceExpBar` starts at `hlcoord 17, 11` and writes with `ld [hld], a`, so
-## the full tiles land at the right-hand end and the run walks left; unlike
-## `DrawBattleHPBar` it lays no empty template first and instead writes $62 for
-## every tile the fill did not reach. Filling the other way put the bar's lit
-## end on the wrong side, and skipping the empties left the trough unpainted.
-## [param at] is the bar's left-hand tile, which is the HUD's own everywhere but
-## the stats screen, where `LoadPinkPage` fills the same bar in at (11,16).
+## The exp bar, whose ends are the HP bar's own tiles and whose partial fills are
+## the only thing its own sheet is for. [param pixels] is `PlaceExpBar`'s own `b`:
+## a pixel count and never a ratio, `CalcExpBar` having already divided and rounded
+## it. `PlaceExpBar` starts at `hlcoord 17, 11` and writes with `ld [hld], a`, so
+## the full tiles land at the right-hand end and the run walks left, and unlike
+## `DrawBattleHPBar` it lays no empty template and writes $62 for every tile the
+## fill did not reach. [param at] is the bar's left-hand tile, the HUD's own
+## everywhere but the stats screen, where `LoadPinkPage` fills it in at (11,16).
 func draw_exp_bar(
 	into: PackedByteArray, width: int, pixels: int, at: Vector2i = PLAYER_EXP
 ) -> void:

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -1,16 +1,12 @@
 class_name Gen2BattleTiles
 extends RefCounted
 
-## The battle screen's tile page, assembled the way the hardware assembles it.
-##
-## A battle loads four sheets into one run of tile numbers, overlapping on
-## purpose: the battle font goes in first and the two HUD borders over the middle
-## of it, so thirteen of its tiles are never seen. This copies them in the same
-## order into one strip and keeps the cartridge's tile numbers, so the constants
-## below are the disassembly's own.
-##
-## Node-free like the rest of the drawing layer: indices into a buffer, so a
-## whole HUD can be laid out and checked with no display.
+## The battle screen's tile page, assembled the way the hardware assembles it. A
+## battle loads four sheets into one run of tile numbers, overlapping on purpose:
+## the battle font goes in first and the two HUD borders over the middle of it, so
+## thirteen of its tiles are never seen. This copies them in the same order into
+## one strip and keeps the cartridge's tile numbers, so the constants below are
+## the disassembly's own. Node-free like the rest of the drawing layer.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/card_flip_page.gd
+++ b/game/render/card_flip_page.gd
@@ -1,29 +1,14 @@
 class_name Gen2CardFlipPage
 extends RefCounted
 
-## `_CardFlip`'s screen: `CardFlipTilemap` and the two card slots beside it,
-## under the border and cursor objects `CardFlip_CopyOAM` writes.
-##
-## Node-free, so the whole table can be read back headless. [Gen2CardFlip] owns
-## the state and the background it writes; this is the two boxes over it, the
-## palettes and shadow OAM.
-##
-## Four things the source states that a reading gets wrong:
-##
-## - **Every object here is eight by eight.** `_CardFlip` never touches
-##   `B_LCDC_OBJ_SIZE`, and the slot machine's `set` is its own, reset on the way
-##   out; the intro menu leaves the hardware on 8x8. A cursor tile is one tile.
-## - **The objects are drawn in the map's own palettes.** `CardFlip_InitAttrPals`
-##   writes `wBGPals1` and nothing else, and `DmgToCgbObjPals` reorders
-##   `wOBPals1` into the live buffer with `%11100100`, which is the identity. So
-##   object palette 0 is still `PAL_OW_RED` from the Game Corner's own map.
-## - **The lamps are characters.** `_CardFlip` copies its two bulbs over the
-##   font's "♂" and "♀", so `CARD_FLIP_LIGHT_OFF_TILE` sits in the font's
-##   half of the window and every other cell of the board is under it.
-## - **Crystal's digits stand one pixel higher.** `CardFlip_ShiftDigitsUpOnePixel`
-##   copies each of "0" to "9" back two bytes over itself, which is one pixel
-##   row, and blanks the last row of "9". pokegold marks the routine
-##   `; unreferenced` and its digits sit where the font puts them.
+## `_CardFlip`'s screen: `CardFlipTilemap` and the two card slots beside it, under
+## the border and cursor objects `CardFlip_CopyOAM` writes. Node-free, so the
+## whole table can be read back headless. Four things a reading gets wrong: every
+## object here is eight by eight, since `_CardFlip` never touches
+## `B_LCDC_OBJ_SIZE`; the objects are drawn in the map's own palettes, since
+## `DmgToCgbObjPals` reorders with the identity; the lamps are characters, copied
+## over the font's gender signs; and Crystal's digits stand one pixel higher, from
+## `CardFlip_ShiftDigitsUpOnePixel`, which pokegold marks unreferenced.
 
 const TILE: int = Gen2Font.TILE
 const SCREEN_COLUMNS: int = Gen2CardFlip.SCREEN_COLUMNS
@@ -378,15 +363,9 @@ func set_object_palette(colors: PackedColorArray) -> void:
 
 
 ## The whole screen for [param game]. [param state] is what the host holds over
-## it:
-##
-## [codeblock]
-## {
-##   "text": String,   # the box under the table, empty for none
-##   "yes_no": int,    # 1 or 2 while a YES/NO box is up, 0 for none
-##   "blink": int,     # the frame a loaded blinking cursor is counted on, -1 none
-## }
-## [/codeblock]
+## it: `text`, the box under the table and empty for none; `yes_no`, 1 or 2 while
+## a YES/NO box is up and 0 for none; and `blink`, the frame a loaded blinking
+## cursor is counted on, -1 for none.
 func render(game: Gen2CardFlip, state: Dictionary = {}) -> Image:
 	if not ready():
 		return null

--- a/game/render/copyright_page.gd
+++ b/game/render/copyright_page.gd
@@ -2,20 +2,12 @@ class_name Gen2CopyrightPage
 extends RefCounted
 
 ## The copyright screen (`Copyright`, `engine/menus/intro_menu.asm`), on the tile
-## grid the hardware uses.
-##
-## The whole screen is one graphic and one code run: `ClearTilemap` blanks the
-## map, `CopyrightGFX` is requested into `vTiles2 tile $60`, and
-## `CopyrightString` is placed at (2,7). None of its codes is a character, so
-## nothing here reads the font: each code is a tile of that strip, and the
-## screen is white everywhere else.
-##
-## `PlaceString` pushes the line's own start and `NextLineChar` pops it and adds
-## `SCREEN_WIDTH * 2`, so the three rows start in the same column, two rows
-## apart: (2,7), (2,9) and (2,11).
-##
-## Node-free, like the other `render/*_page.gd`: it writes indices into a buffer,
-## so a page can be drawn and read back headless.
+## grid the hardware uses. The whole screen is one graphic and one code run:
+## `ClearTilemap` blanks the map, `CopyrightGFX` is requested into
+## `vTiles2 tile $60`, and `CopyrightString` is placed at (2,7). None of its codes
+## is a character, so nothing here reads the font. `PlaceString` pushes the line's
+## own start and `NextLineChar` pops it and adds `SCREEN_WIDTH * 2`, so the three
+## rows start in the same column two rows apart. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/credits_page.gd
+++ b/game/render/credits_page.gd
@@ -1,26 +1,14 @@
 class_name Gen2CreditsPage
 extends RefCounted
 
-## The credits screen, on the tile grid the hardware uses.
-##
-## [Gen2Credits] owns the BG map and the attribute map, because
-## `ConstructCreditsTilemap` and `ParseCredits` are what write them; this
-## resolves a tile number to pixels and colours it through `CreditsPalettes`.
-##
-## `Credits`' own VRAM window:
-##
-## | Tiles | Contents |
-## |---|---|
-## | $00-$0f | the banner's current 4x4 mon cell, out of `CreditsMonsGFX` |
-## | $20-$28 | `CreditsBorderGFX` |
-## | $40-$4f | `TheEndGFX` |
-## | $60-$7c | `CopyrightGFX`, where `LoadFontsBattleExtra` would put its strip |
-## | $80+ | the font, untouched |
-##
-## The two border bands are the only thing that scrolls: `hLCDCPointer` is
-## LOW(rSCX) and `Credits_LYOverride` fills eight scanlines of `wLYOverrides` per
-## band, so those rows are sampled through an offset that walks two pixels a
-## cycle.
+## The credits screen, on the tile grid the hardware uses. [Gen2Credits] owns the
+## BG map and the attribute map, because `ConstructCreditsTilemap` and
+## `ParseCredits` are what write them; this resolves a tile number to pixels and
+## colours it through `CreditsPalettes`. The VRAM window is the banner's 4x4 mon
+## cell at $00, `CreditsBorderGFX` at $20, `TheEndGFX` at $40, `CopyrightGFX` at
+## $60 and the font untouched from $80. The two border bands are the only thing
+## that scrolls: `Credits_LYOverride` fills eight scanlines of `wLYOverrides` per
+## band, so those rows are sampled through an offset walking two pixels a cycle.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = Gen2Credits.COLUMNS

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -1,26 +1,14 @@
 class_name Gen2Font
 extends RefCounted
 
-## The cartridge's own font, drawn a tile at a time.
-##
-## Text here is tilemapped, not typeset: every character is one 8x8 tile of equal
-## width, and a character code is already the tile number that draws it. Nothing
-## is measured or kerned; indices are copied into a buffer at multiples of eight.
-##
-## Every sheet is one row of tiles ([method Gen2Tiles.decode_1bpp_strip]), so a
-## code is a horizontal offset and nothing else. A code with no tile draws
-## nothing rather than a placeholder, which is what the space at $7F is and what
-## the hardware does.
-##
-## Three sheets, because the hardware has three loaded at once and one of them
-## changes. The main font covers $80 upward and the frames $79 to $7E in both
-## strips; `_LoadFontsBattleExtra` replaces $60 to $78, which is where `№`,
-## `<ID>` and `<LV>` live. Which of the two is up is [Gen2Text]'s font argument,
-## carried through to the tile it addresses, so a caller says which screen it is
-## drawing rather than which sheet a byte came from.
-##
-## Node-free: it writes into an index buffer, not the screen, so a whole text box
-## can be laid out and checked headless.
+## The cartridge's own font, drawn a tile at a time. Text here is tilemapped, not
+## typeset: every character is one 8x8 tile of equal width and a character code is
+## already the tile number that draws it, so nothing is measured or kerned. A code
+## with no tile draws nothing rather than a placeholder, which is what the space
+## at $7F is. Three sheets, because the hardware has three loaded at once and one
+## changes: `_LoadFontsBattleExtra` replaces $60 to $78, and which is up is
+## [Gen2Text]'s font argument, so a caller says which screen it is drawing rather
+## than which sheet a byte came from. Node-free.
 
 const TILE: int = 8
 
@@ -133,19 +121,13 @@ func draw_code(
 
 
 ## Draws a string left to right from [param at_x], advancing eight pixels per
-## tile. Returns how many tiles were drawn, which is not the string's length
-## when it contains a ligature.
-##
-## [param max_tiles] stops the run short. `PlaceString` has no such bound and
-## needs none: every cartridge string is written to fit the box it is placed in.
-## A label a mod supplies is not, so a caller drawing into a fixed width passes
-## the room it has. Negative means no bound.
-##
-## A bounded run that does not fit ends in the charmap's own "…" rather than
-## stopping mid-word, so a cut value is never read as a whole one: two views
-## labelled "Game Boy Color 2D" and "Game Boy Advance" would otherwise draw the
-## same eight characters. The battle-extra strip has no ellipsis tile under $75,
-## so under that font the run is cut without one.
+## tile. Returns how many tiles were drawn, which is not the string's length when
+## it contains a ligature. [param max_tiles] stops the run short; `PlaceString`
+## has no such bound and needs none, every cartridge string being written to fit
+## its box, but a label a mod supplies is not. A bounded run that does not fit
+## ends in the charmap's own ellipsis rather than stopping mid-word, so a cut
+## value is never read as a whole one. The battle-extra strip has no ellipsis
+## tile under $75, so under that font the run is cut without one.
 func draw_text(
 	text: String, into: PackedByteArray, into_width: int, at_x: int, at_y: int,
 	font: StringName = Gen2Text.FONT_MAIN, max_tiles: int = -1

--- a/game/render/game_frame.gd
+++ b/game/render/game_frame.gd
@@ -1,21 +1,14 @@
 class_name Gen2GameFrame
 extends Control
 
-## Places the hardware screen and the on-screen controller, in either
-## orientation and at any window size.
-##
-## Portrait sends the screen to the top and gives the controller the room under
-## it, which is the shape a phone held upright has and the only arrangement
-## where a thumb is not over the map. Landscape centres the screen and leaves
-## the margins either side, which is where the thumbs already are on a phone
-## held sideways.
-##
-## With no controller on screen both cases are the same: the screen centres in
-## the whole frame, so a desktop window looks exactly as it did.
-##
-## The frame also owns the way back from hidden controls. The gesture is watched
+## Places the hardware screen and the on-screen controller, in either orientation
+## and at any window size. Portrait sends the screen to the top and gives the
+## controller the room under it, the only arrangement where a thumb is not over
+## the map; landscape centres the screen and leaves the margins either side, where
+## the thumbs already are. With no controller on screen both cases centre in the
+## whole frame. The frame also owns the way back from hidden controls, watched
 ## here rather than in [Gen2TouchPad] because a hidden pad is exactly when it is
-## needed, and it has to be reachable from anywhere on the game screen.
+## needed and it has to be reachable from anywhere on the game screen.
 
 ## How much of a portrait screen the controller may take. The hardware screen is
 ## 10:9, so even a tall phone has this much left over once the map has its share.

--- a/game/render/game_freak_presents_page.gd
+++ b/game/render/game_freak_presents_page.gd
@@ -1,17 +1,13 @@
 class_name Gen2GameFreakPresentsPage
 extends RefCounted
 
-## The GameFreak Presents screen, on the tile grid the hardware uses.
-##
-## A cleared background with two `PlaceString`s on it and one object layer over
-## the top, which is where the two profiles part: Crystal's Ditto comes out of
-## `GameFreakDittoGFX` and reads eleven OAM sets off one 16x16 sheet, while Gold
-## and Silver's logo, star and sparkles are the tail of `GameFreakLogoGFX`
-## followed by `GameFreakLogoStarsGFX`, one contiguous run from `vTiles1` tile
-## $0d, which is what `SPRITE_ANIM_DICT_GS_SPLASH` maps to.
-##
-## [Gen2GameFreakPresents] owns the frames and the positions; this owns the
-## pixels. Node-free like the other `render/*_page.gd`.
+## The GameFreak Presents screen, on the tile grid the hardware uses: a cleared
+## background with two `PlaceString`s and one object layer over the top, which is
+## where the two profiles part. Crystal's Ditto comes out of `GameFreakDittoGFX`
+## and reads eleven OAM sets off one 16x16 sheet, while Gold and Silver's logo,
+## star and sparkles are the tail of `GameFreakLogoGFX` followed by
+## `GameFreakLogoStarsGFX`, one contiguous run from `vTiles1` tile $0d.
+## [Gen2GameFreakPresents] owns the frames and the positions; this owns the pixels.
 
 const TILE: int = Gen2Tiles.TILE_WIDTH
 const COLUMNS: int = 20

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -1,30 +1,14 @@
 class_name Gen2Screen
 extends Control
 
-## A Game Boy Color screen: 160x144 pixels, scaled by a whole number to fit.
-##
-## What the game draws goes into a hardware-sized [SubViewport] blown up by an
-## integer factor, since any other scale resamples an 8x8 tile into something
-## that crawls when it moves. Surrounding chrome is ordinary Godot UI at window
-## resolution, which is why this is a [Control] and not a stretch setting.
-##
-## [method display_native] is a second layer behind it, covering the same
-## rectangle at window resolution, for a view that cannot be drawn into a 160x144
-## buffer and magnified but still has to line up with the boxes above it.
-##
-## [member expanded] widens the buffer instead of framing it. The window is not
-## 10:9 and never was; the black bars are the shape of a screen this project can
-## draw past, so the buffer is the size of the whole control and is filled.
-## Interface is unmoved: [method display] puts a screen inside a 160x144
-## rectangle centred in that surface, so every box, menu and cursor is laid out
-## exactly where the cartridge laid it out and only the surround grows.
-## [member zoom_step] is how many whole pixels a hardware pixel is drawn as,
-## counted from the largest that fits.
-##
-## SCREEN FILL is read here rather than by each screen, and the surround is
-## filled here rather than by each screen, because the two together are what
-## "no screen is letterboxed" means: a screen that says nothing about either is
-## responsive, and one that is written next year is too.
+## A Game Boy Color screen: 160x144 pixels, scaled by a whole number to fit. What
+## the game draws goes into a hardware-sized [SubViewport] blown up by an integer
+## factor, since any other scale resamples an 8x8 tile into something that crawls
+## when it moves. [method display_native] is a second layer behind it at window
+## resolution. [member expanded] widens the buffer instead of framing it, and
+## [method display] still centres a 160x144 rectangle in it, so only the surround
+## grows. SCREEN FILL is read here rather than by each screen, which is what makes
+## a screen written next year responsive without saying anything about it.
 
 const WIDTH: int = 160
 const HEIGHT: int = 144
@@ -93,14 +77,11 @@ var interface_masked: bool = true:
 			_mask.visible = value
 
 ## What the surround is painted with: the shown picture's own field, so a screen
-## carries its background out to the window edge wherever it is opened.
-##
-## Followed automatically from [method Gen2PicImage.show], which is the one place
-## a screen hands a redrawn picture to the node that shows it. A screen with more
-## art than the hardware framed hands [method set_backdrop] the real thing
-## instead, and this is what is left for one without.
-##
-## Meaningless until something has said what it is: see [method has_field].
+## carries its background out to the window edge wherever it is opened. Followed
+## automatically from [method Gen2PicImage.show], the one place a screen hands a
+## redrawn picture to the node that shows it; a screen with more art than the
+## hardware framed hands [method set_backdrop] the real thing instead. Meaningless
+## until something has said what it is: see [method has_field].
 var surround_color: Color = Color.BLACK:
 	set(value):
 		var told: bool = _field_told
@@ -196,18 +177,12 @@ func _ready() -> void:
 	_fit()
 
 
-## Takes SCREEN FILL from the options file and applies it.
-##
-## Every screen, rather than the two that remembered to ask: a window is not
-## 10:9, and a screen that does not fill it leaves bars a player reads as a
-## fault. What a screen puts in the room is its own business; having the room is
-## not.
-##
-## Public and idempotent because the option is the file's rather than this
-## frame's: a caller that changed it after the screen entered the tree, which is
-## every tool that stages a framed shot and would be a live Settings toggle,
-## calls this and is obeyed. [member expanded]'s setter refits and answers
-## nothing when the value has not moved.
+## Takes SCREEN FILL from the options file and applies it, for every screen rather
+## than the two that remembered to ask: a window is not 10:9, and a screen that
+## does not fill it leaves bars a player reads as a fault. What a screen puts in
+## the room is its own business; having the room is not. Public and idempotent
+## because the option is the file's rather than this frame's, so a caller that
+## changed it after the screen entered the tree is obeyed.
 func apply_screen_fill() -> void:
 	expanded = Gen2OptionsStore.current().screen_fill
 
@@ -222,14 +197,11 @@ func display(node: Node) -> void:
 
 ## Renderer content, in hardware pixels, kept below every node [method display]
 ## placed. A renderer rebuilt mid-screen would otherwise be appended after a live
-## text box and paint over it.
-##
-## [param fills_buffer] is a view that draws the whole expanded surface, and gets
-## the buffer's own origin. A view that does not is laid out in the hardware's
-## 160x144 like everything else here, so it goes where that rectangle is and is
-## clipped to it; in the buffer's corner it would sit off to one side with the
-## boxes above it somewhere else. That is the default, because it is the answer
-## for a view that was written without the question in mind.
+## text box and paint over it. [param fills_buffer] is a view that draws the whole
+## expanded surface and gets the buffer's own origin; a view that does not is laid
+## out in the hardware's 160x144 like everything else here and is clipped to it,
+## since in the buffer's corner it would sit off to one side with the boxes above
+## it somewhere else.
 func display_content(node: Node, fills_buffer: bool = false) -> void:
 	if not fills_buffer:
 		_content.add_child(node)
@@ -312,14 +284,11 @@ func clear() -> void:
 
 
 ## Takes a node off the screen now and frees it at the end of the frame.
-##
 ## `queue_free` on its own only does the second half: the node stays in the tree,
-## and drawn, until the frame it was dropped on is served. A replacement added on
-## the same frame is then composited over its predecessor rather than instead of
-## it, which is a stale panel showing under the live one for exactly the frame a
-## screenshot catches; inside a [Container] the two are laid out side by side.
-##
-## Static, and the one way a screen drops a child it is replacing.
+## and drawn, until the frame it was dropped on is served, so a replacement added
+## on the same frame is composited over its predecessor rather than instead of it.
+## Inside a [Container] the two are laid out side by side. Static, and the one way
+## a screen drops a child it is replacing.
 static func drop(node: Node) -> void:
 	if node == null or not is_instance_valid(node):
 		return
@@ -329,15 +298,12 @@ static func drop(node: Node) -> void:
 	node.queue_free()
 
 
-## The same from an [method Node._exit_tree], where the removal above is
-## refused.
-##
-## A parent is blocked from removing a child while it is already removing one,
-## and every screen that hosts a view it does not own drops that view as it
-## leaves: both hang off the same parent, so the parent is mid-removal when the
-## drop arrives and the engine raises an error instead. Hiding is the whole of
-## what the removal was for here, since nothing replaces a view whose screen is
-## going, and [method Node.queue_free] takes it off the tree either way.
+## The same from an [method Node._exit_tree], where the removal above is refused.
+## A parent is blocked from removing a child while it is already removing one, and
+## every screen that hosts a view it does not own drops that view as it leaves:
+## both hang off the same parent, so the parent is mid-removal when the drop
+## arrives. Hiding is the whole of what the removal was for here, since nothing
+## replaces a view whose screen is going.
 static func drop_on_exit(node: Node) -> void:
 	if node == null or not is_instance_valid(node):
 		return
@@ -393,18 +359,13 @@ static func owner_of(node: Node) -> Gen2Screen:
 	return found
 
 
-## The screen a host's own 160x144 view belongs in.
-##
-## [param handed] is the one the opener gave it, for a host mounted beside a
-## screen rather than inside it; failing that the one [param node] is already
-## standing in; failing both a new one over [param node], which is what a host
-## opened on its own -- the launcher's PC, a preview -- really does need.
-##
-## A second screen over a window that already has one is what made the surround
-## ambiguous. Two viewports each pick their own scale and their own place for the
-## hardware rectangle, so an overlay meant to sit on the map is drawn at a
-## different size beside it, and both of them paint a surround the other did not
-## ask for. One window, one screen.
+## The screen a host's own 160x144 view belongs in: [param handed] is the one the
+## opener gave it, failing that the one [param node] is already standing in,
+## failing both a new one over [param node], which is what a host opened on its
+## own really does need. A second screen over a window that already has one is
+## what made the surround ambiguous: two viewports each pick their own scale and
+## their own place for the hardware rectangle, so an overlay meant to sit on the
+## map is drawn at a different size beside it. One window, one screen.
 static func host_for(node: Control, handed: Gen2Screen = null) -> Gen2Screen:
 	if handed != null:
 		return handed
@@ -421,15 +382,12 @@ static func host_for(node: Control, handed: Gen2Screen = null) -> Gen2Screen:
 	return built
 
 
-## Real art for the surround, the size of [method view_size], from [param source].
-##
-## A flat [member surround_color] is what a screen laid out in 160x144 has to
-## offer; a screen whose background is more than one colour -- the title's sky
-## over its cloud bank -- draws the whole buffer instead and hands it here. Only
-## the surround is taken from it, so the hardware rectangle stays exactly the
-## picture the cartridge drew.
-##
-## Dropped with [param source], so the screen after it does not inherit its sky.
+## Real art for the surround, the size of [method view_size], from
+## [param source]. A flat [member surround_color] is what a screen laid out in
+## 160x144 has to offer; a screen whose background is more than one colour draws
+## the whole buffer instead and hands it here. Only the surround is taken from it,
+## so the hardware rectangle stays exactly the picture the cartridge drew. Dropped
+## with [param source], so the screen after it does not inherit its sky.
 func set_backdrop(source: Node, image: Image) -> void:
 	if image == null or Vector2i(image.get_width(), image.get_height()) != _view_size:
 		if _backdrop_source == source:
@@ -487,18 +445,14 @@ static func note_field(target: CanvasItem, field: Color) -> void:
 	screen._take_field(target, field)
 
 
-## Takes the surround's colour from a picture a screen has just drawn.
-##
-## Called from [method Gen2PicImage.show] rather than by each screen: that is the
-## one place a redrawn picture reaches the node showing it, so the surround
-## follows a palette fade and a screen swap without either knowing this exists.
-## Only a picture the size of the hardware screen counts, and only one that is
-## opaque everywhere it is sampled: see [method Gen2PicImage.field_color].
-##
-## Whether the surround is showing is deliberately not a condition. A screen
-## draws its field on the frame it opens and the host raises the mask on that
-## same frame, in the other order; a colour only recorded while the mask was
-## already up would be the colour of the screen before this one.
+## Takes the surround's colour from a picture a screen has just drawn. Called from
+## [method Gen2PicImage.show] rather than by each screen: that is the one place a
+## redrawn picture reaches the node showing it, so the surround follows a palette
+## fade and a screen swap without either knowing this exists. Only a picture the
+## size of the hardware screen counts, and only one opaque everywhere it is
+## sampled. Whether the surround is showing is deliberately not a condition: the
+## mask goes up on the same frame in the other order, so a colour recorded only
+## while it was up would be the colour of the screen before this one.
 static func note_picture(target: CanvasItem, image: Image) -> void:
 	if target == null or image == null:
 		return
@@ -551,25 +505,14 @@ func clear_field() -> void:
 		_mask.queue_redraw()
 
 
-## Hides a view switch behind the cartridge's own way of going black.
-##
-## Building a renderer is a stall: a 3D view meshes a whole map on the frame it
-## is turned on, and nothing on one thread can animate over its own freeze. Only
-## the middle is frozen, though, and the middle is a still picture, so the close
-## is spent on the renderer that is still running, [param rebuild] is called on
-## the frame the screen is fully black, and the open is spent on the one it
-## built. The player sees a wipe with a long middle instead of a jump.
-##
-## `StartTrainerBattle_SpeckleToBlack` is the pattern
-## ([method Gen2BattleTransition.create_outro]), so the switch reads as the
-## game's own and costs no art. The open is the close's frames backwards, which
-## is the same picture rather than a second animation.
-##
-## This is around the switch rather than at one caller: every way of choosing a
-## view reaches [signal Gen2ModHost.view_changed], and every screen listening to
-## it comes through here. A screen that cannot animate -- a headless check, a
-## screenshot driver, a screen not in the tree -- rebuilds at once, because a
-## cover measured by nobody is only a delay.
+## Hides a view switch behind the cartridge's own way of going black. Building a
+## renderer is a stall, and nothing on one thread can animate over its own freeze,
+## but the middle of a wipe is a still picture: the close is spent on the renderer
+## still running, [param rebuild] is called on the frame the screen is fully
+## black, and the open is spent on the one it built.
+## `StartTrainerBattle_SpeckleToBlack` is the pattern, so the switch reads as the
+## game's own and costs no art. Around the switch rather than at one caller,
+## because every way of choosing a view reaches [signal Gen2ModHost.view_changed].
 func play_view_cover(rebuild: Callable) -> void:
 	if not _can_animate_cover():
 		if rebuild.is_valid():

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -2,22 +2,13 @@ class_name Gen2GoldSilverIntroPage
 extends RefCounted
 
 ## `GoldSilverIntro`'s screen, on the tile grid the hardware uses.
-##
-## [Gen2GoldSilverIntro] owns the BG map, the palettes, the scroll and the
-## sprite structs; this turns a tile number into pixels. The split is
-## [Gen2IntroMoviePage]'s, with two differences that come from the movie itself:
-##
-## - The BG map is 32 tiles wide and wraps, and `hLCDCPointer` = LOW(rSCY) gives
-##   every scanline its own `hSCY` rather than its own `hSCX`, so the screen is
-##   sampled row by row through [method Gen2GoldSilverIntro.scroll_y_at].
-## - Every attribute byte is zero, so there is one background palette rather
-##   than eight: `IntroScene1` blanks the VRAM bank 1 map and each
-##   `_CGB_GSIntro` scene ends in `WipeAttrmap`.
-##
-## The starters are the one thing not read out of the intro's own sheets.
-## `Intro_GetMonFrontpic` decompresses three front pics into `vTiles0` over the
-## fire sheet already there, so their OAM sets index the pic atlas the cache
-## holds instead, column-major the way a `--columns` pic is stored.
+## [Gen2GoldSilverIntro] owns the BG map, palettes, scroll and sprite structs;
+## this turns a tile number into pixels. Two differences from
+## [Gen2IntroMoviePage]: the BG map wraps and `hLCDCPointer` = LOW(rSCY) gives
+## every scanline its own `hSCY`, so the screen is sampled row by row; and every
+## attribute byte is zero, so there is one background palette rather than eight.
+## The starters are the one thing not read out of the intro's own sheets, their
+## OAM sets indexing the pic atlas the cache holds.
 
 const TILE: int = Gen2Tiles.TILE_WIDTH
 const WIDTH: int = Gen2Screen.WIDTH

--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -1,20 +1,13 @@
 class_name Gen2HallOfFamePage
 extends RefCounted
 
-## One Hall of Fame induction panel, on the tile grid the hardware uses.
-##
-## Positions are `engine/events/halloffame.asm`'s own: DisplayHOFMon's two text
-## boxes, its frontpic at (6,5) and every field row it prints, and
-## HOF_AnimatePlayerPic's name box for the player's page.
-##
-## `halloffame.asm:298` calls `LoadFontsBattleExtra` before any of this, so the
-## panel prints with `gfx/font/font_battle_extra.png` over $60 to $78 and `№`,
-## `<ID>` and `<LV>` are real tiles. Every glyph and column here is the
-## cartridge's; see [constant Gen2Text.FONT_BATTLE_EXTRA].
-##
-## Node-free: it writes indices into a buffer, so a page can be drawn and read
-## back headless. The Pokémon's own pic is not in that buffer; it has its own
-## palette and is composed over the page by the screen.
+## One Hall of Fame induction panel, on the tile grid the hardware uses. Positions
+## are `engine/events/halloffame.asm`'s own: DisplayHOFMon's two text boxes, its
+## frontpic at (6,5) and every field row it prints, plus
+## HOF_AnimatePlayerPic's name box for the player's page. `halloffame.asm:298`
+## calls `LoadFontsBattleExtra` first, so the panel prints with the battle-extra
+## strip over $60 to $78. Node-free; the Pokemon's own pic is not in that buffer,
+## having its own palette, and is composed over the page by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -1,31 +1,14 @@
 class_name Gen2IntroMoviePage
 extends RefCounted
 
-## The intro movie's screen, on the tile grid the hardware uses.
-##
-## [Gen2IntroMovie] owns the BG map, the attribute plane, the palettes, the
-## scroll and the sprite structs; this turns a tile number into pixels. The
-## split is the credits' and the title screen's.
-##
-## Two things here are not a plain tilemap draw:
-##
-## - The BG map is 32 tiles wide and wraps. `hSCX` and `hSCY` are bytes, the
-##   panorama scenes scroll past both edges, and `hLCDCPointer` = LOW(rSCX)
-##   gives every scanline its own `hSCX`, which is what
-##   `Intro_PerspectiveScrollBG` uses to run the grass and the trees at
-##   different speeds. So the screen is sampled scanline by scanline rather than
-##   blitted tile by tile.
-## - A BG tile number below $80 reads from `vTiles2` and $80 and up from
-##   `vTiles1`, which are two different sheets in the scenes that load both.
-##
-## An object is drawn through the palette its own `dbsprite` attribute names,
-## which is one of the eight a scene's palette run wrote past the background
-## buffer's end.
-##
-## Shadow OAM holds forty sprites and `UpdateAnimFrame` stops filling it at
-## `wShadowOAMEnd`, so a frame that asks for more loses the last of them rather
-## than growing. `IntroScene10` is the one frame that does: Wooper's sixteen and
-## Pichu's twenty-five come to forty-one, and Pichu's last tile is not drawn.
+## The intro movie's screen, on the tile grid the hardware uses. [Gen2IntroMovie]
+## owns the BG map, the attribute plane, the palettes, the scroll and the sprite
+## structs; this turns a tile number into pixels. Two things are not a plain
+## tilemap draw: the BG map wraps and `hLCDCPointer` = LOW(rSCX) gives every
+## scanline its own `hSCX`, which is what runs the grass and the trees at
+## different speeds, so the screen is sampled scanline by scanline; and a BG tile
+## below $80 reads from `vTiles2` and $80 up from `vTiles1`. Shadow OAM holds
+## forty sprites, so `IntroScene10`'s forty-first, Pichu's last tile, is not drawn.
 
 const TILE: int = Gen2Tiles.TILE_WIDTH
 const WIDTH: int = Gen2Screen.WIDTH

--- a/game/render/link_page.gd
+++ b/game/render/link_page.gd
@@ -1,20 +1,13 @@
 class_name Gen2LinkPage
 extends RefCounted
 
-## The two screens the cable club draws: `InitTradeMenuDisplay`'s trade screen
-## (`engine/link/link.asm`) and `ReadAndPrintLinkBattleRecord`'s record page
-## (`engine/battle/core.asm`).
-##
-## Both are drawn with `LinkTextboxAtHL` rather than `Textbox`, which is a border
-## of its own out of `LinkCommsBorderGFX` and not the frame the OPTION menu
-## chooses. The two cartridges lay that border out differently and this is the
-## one place that difference shows: Crystal loads seventy tiles at `vTiles2` and
-## `LoadCableTradeBorderTilemap` puts a whole screen of them down, while Gold
-## and Silver load nine at `$76` and `PlaceTradeScreenTextbox` draws two ordinary
-## boxes with them.
-##
-## Node-free, the way [Gen2DiplomaPage] is: it writes palette indices into a
-## buffer so a check can read a screen back headless.
+## The two screens the cable club draws: `InitTradeMenuDisplay`'s trade screen and
+## `ReadAndPrintLinkBattleRecord`'s record page. Both are drawn with
+## `LinkTextboxAtHL` rather than `Textbox`, which is a border of its own out of
+## `LinkCommsBorderGFX` and not the frame the OPTION menu chooses. The two
+## cartridges lay that border out differently and this is the one place it shows:
+## Crystal puts a whole screen of seventy tiles down, while Gold and Silver load
+## nine and draw two ordinary boxes. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -156,14 +149,13 @@ func has_screen_tilemap() -> bool:
 
 
 ## `InitTradeMenuDisplay` and everything `LinkTradeMenu` draws over it.
-##
 ## [param state] carries what is on screen rather than what the player may do:
-## `player`/`partner` are `{name, species}` with the species names already
-## resolved, `list` is 0 for the player's half and 1 for the partner's, `index`
-## the cursor row, `partner_choice` the row `LinkTradePlaceArrow` marks or -1,
-## `footer` -1 for no footer and 0 or 1 for STATS or TRADE, `cancel` whether the
-## cursor is on CANCEL, `message` the lines the bottom box prints, `confirm` the
-## TRADE/CANCEL row or -1, and `waiting` whether `WAITING..!` stands.
+## `player`/`partner` are `{name, species}` with the species names resolved,
+## `list` is 0 for the player's half and 1 for the partner's, `index` the cursor
+## row, `partner_choice` the row `LinkTradePlaceArrow` marks or -1, `footer` -1 or
+## 0/1 for STATS or TRADE, `cancel` whether the cursor is on CANCEL, `message` the
+## bottom box's lines, `confirm` the TRADE/CANCEL row or -1, and `waiting` whether
+## `WAITING..!` stands.
 func draw_trade(state: Dictionary) -> PackedByteArray:
 	var indices := PackedByteArray()
 	indices.resize(WIDTH * HEIGHT)

--- a/game/render/mail_page.gd
+++ b/game/render/mail_page.gd
@@ -1,26 +1,14 @@
 class_name Gen2MailPage
 extends RefCounted
 
-## `ReadAnyMail` and the ten `Load*MailGFX` routines behind it
-## (`engine/pokemon/mail_2.asm`) on the hardware tile grid.
-##
-## Each mail type builds its own VRAM window out of one flat 1bpp run and then
-## writes a tilemap over it, so the page is two transcribed programs per type
-## rather than a picture: [constant LOADS] is the routine's `LoadMailGFX_Color*`
-## calls and [constant PLACES] its `hlcoord` writes. Keeping them as data is what
-## makes ten near-identical routines readable and what lets
-## `tools/checks/mail.gd` sweep every one on every cartridge.
-##
-## The 1bpp run has one ink level; `LoadMailGFX_Color1`, `_Color2` and `_Color3`
-## are the same bytes written into plane 0, plane 1 or both, so a lit pixel comes
-## out as palette index 1, 2 or 3 and an unlit one as 0. That is the whole reason
-## one sheet draws in three shades.
-##
-## Node-free like the other pages: it writes indices into a buffer.
-## PORTRAITMAIL's `PrepMonFrontpic` is in that buffer too rather than being a
-## layer over it: `PlaceGraphic` writes the picture into the tilemap, under the
-## frame the routine then draws, so a host laying it on top would cover the mail
-## with the Pokemon or the Pokemon with the mail.
+## `ReadAnyMail` and the ten `Load*MailGFX` routines behind it on the hardware
+## tile grid. Each mail type builds its own VRAM window out of one flat 1bpp run
+## and then writes a tilemap over it, so the page is two transcribed programs per
+## type rather than a picture, which is what makes ten near-identical routines
+## readable and lets `tools/checks/mail.gd` sweep every one. The 1bpp run has one
+## ink level and the three `LoadMailGFX_Color*` write it into plane 0, plane 1 or
+## both, which is why one sheet draws in three shades. PORTRAITMAIL's pic is in
+## the buffer rather than a layer, since `PlaceGraphic` writes it into the tilemap.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/map_name_sign_page.gd
+++ b/game/render/map_name_sign_page.gd
@@ -1,24 +1,14 @@
 class_name Gen2MapNameSignPage
 extends RefCounted
 
-## `PlaceMapNameFrame` and `PlaceMapNameCenterAlign`
-## (engine/events/map_name_sign.asm): the sign a map entry raises, drawn out of
-## `MapEntryFrameGFX`'s own fourteen tiles with the landmark's name centred on
-## its lower interior row.
-##
-## Four rows of the window, which the hardware can only start at a scanline and
-## run to the bottom of the screen from: `rWY` $70 is what puts the sign in the
-## bottom four rows rather than the top.
-##
-## Crystal's own screen. Gold and Silver ship neither `InitMapNameSign` nor the
-## sheet, so a cache without it renders nothing at all.
-##
-## [method render_notice] is the same four rows carrying a mod's own two lines
-## and an icon, which is what [method Gen2ModHost.request_notice] draws with: the
-## banner is the only thing the cartridge ever puts over a live map, so a notice
-## drawn this way is vanilla by construction. A cache with no sheet falls back to
-## the ordinary text-box frame rather than to nothing, since a mod's notice has
-## to reach a Gold or Silver player too.
+## `PlaceMapNameFrame` and `PlaceMapNameCenterAlign`: the sign a map entry raises,
+## drawn out of `MapEntryFrameGFX`'s own fourteen tiles with the landmark's name
+## centred on its lower interior row. Four rows of the window, which the hardware
+## can only run to the bottom of the screen from, so `rWY` $70 is what puts the
+## sign at the bottom. Crystal's own screen: Gold and Silver ship neither routine
+## nor sheet. [method render_notice] is the same four rows carrying a mod's two
+## lines and an icon, so a notice is vanilla by construction; a cache with no
+## sheet falls back to the ordinary text-box frame.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -160,14 +150,11 @@ static func render_notice(
 
 ## The 16x16 a notice wears, out of the vocabulary an actor and a battle
 ## annotation already share. Null where the cache carries no art for what was
-## asked, which draws a notice with no icon rather than a placeholder.
-##
-## | Key | Drawn from |
-## |---|---|
-## | `badge` | `TrainerCard_JohtoBadgesOAM`'s four tiles, which is the only place the game draws a badge. 0 to 7; the Kanto eight have no art on the cartridge |
-## | `species` | [method GameData.species_icon_indices], the party menu's own icon |
-## | `sprite` | An `OverworldSprites` row, facing down |
-## | `tile` | Raw indices, [Gen2BattleAnnotations]' own shape, drawn in the frame's palette |
+## asked, which draws a notice with no icon rather than a placeholder. `badge` is
+## `TrainerCard_JohtoBadgesOAM`'s four tiles, 0 to 7, the Kanto eight having no
+## art on the cartridge; `species` is [method GameData.species_icon_indices];
+## `sprite` is an `OverworldSprites` row facing down; and `tile` is raw indices in
+## [Gen2BattleAnnotations]' own shape, drawn in the frame's palette.
 static func render_notice_icon(
 	data: GameData, icon: Dictionary, time_of_day: int = Gen2WorldPalette.TIME_MORNING
 ) -> Image:

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -1,25 +1,14 @@
 class_name Gen2MartPage
 extends RefCounted
 
-## `BuyMenu`'s screen (`engine/items/mart.asm`): `BlankScreen`, the money box
-## `PlaceMoneyTopRight` puts in the corner, `MenuHeader_Buy`'s scrolling list of
-## names and BCD prices, and the speech box `UpdateItemDescription` writes into.
-##
-## [Gen2WorldMartHost] owns the list, the money and the transaction; this is the
-## picture, and node-free so it can be read back headless. The quantity box is
-## `BuyItem_MenuHeader`, which stands over the speech box rather than replacing
-## it, and the yes/no over it is the host's own [Gen2MenuPage].
-##
-## Three things the source does that a redraw here has to keep:
-##
-## - `ScrollingMenu` draws no frame around the list. Only `ClearWholeMenuBox`
-##   runs, so the names sit on the blank screen and the arrows stand where a
-##   border would have been.
-## - The fourth row's price lands on the box's own bottom coordinate, row 11,
-##   because `.PrintBCDPrices` prints one row below a name that is already on
-##   the last row the height allows.
-## - `▼` is drawn whenever the list has arrows at all, while `▲` waits for
-##   `wMenuScrollPosition` to leave zero.
+## `BuyMenu`'s screen (`engine/items/mart.asm`): `BlankScreen`, the money box in
+## the corner, `MenuHeader_Buy`'s scrolling list of names and BCD prices, and the
+## speech box `UpdateItemDescription` writes into. [Gen2WorldMartHost] owns the
+## list and the transaction; this is the picture. Three things a redraw has to
+## keep: `ScrollingMenu` draws no frame, so the names sit on the blank screen; the
+## fourth row's price lands on row 11, because `.PrintBCDPrices` prints one row
+## below a name already on the last row the height allows; and the down arrow is
+## drawn whenever the list has arrows while the up one waits for a scroll.
 
 const TILE: int = Gen2Font.TILE
 
@@ -125,19 +114,10 @@ static func from_data(data: GameData) -> Gen2MartPage:
 	return out
 
 
-## The whole screen. [param state] is what the host holds:
-##
-## [codeblock]
-## {
-##   "money": int,
-##   "rows": Array,      # {"name": String, "price": int} or {"cancel": true}
-##   "cursor": int,      # which visible row the arrow stands on
-##   "scrolled": bool,   # wMenuScrollPosition is past zero
-##   "text": String,     # the speech box's lines
-##   "quantity": int,    # -1 while no quantity box is up
-##   "subtotal": int,
-## }
-## [/codeblock]
+## The whole screen. [param state] is what the host holds: `money`, `rows` of
+## `{name, price}` or `{cancel}`, `cursor` for the visible row the arrow stands
+## on, `scrolled` for `wMenuScrollPosition` past zero, `text` for the speech box's
+## lines, `quantity` at -1 while no quantity box is up, and `subtotal`.
 func render(state: Dictionary) -> Image:
 	if font == null:
 		return null
@@ -210,16 +190,13 @@ static func balance_window(
 	}
 
 
-## `Mom_ContinueMenuSetup`'s box (`engine/events/mom.asm`), drawn here for the
-## reason the three balance windows are: it is a money box, and `PrintNum` with
-## PRINTNUM_MONEY is what fills all four of them.
-##
-## `Textbox` at `hlcoord 0, 0` with `lb bc, 6, 18`, so eight rows and the whole
-## screen's width; SAVED against her balance, HELD against the player's and the
-## transaction's own word against the amount being typed.
+## `Mom_ContinueMenuSetup`'s box, drawn here for the reason the three balance
+## windows are: it is a money box, and `PrintNum` with PRINTNUM_MONEY fills all
+## four. `Textbox` at `hlcoord 0, 0` with `lb bc, 6, 18`, so eight rows and the
+## whole screen's width, SAVED against her balance and HELD against the player's.
 ## `Mom_WithdrawDepositMenuJoypad` blanks the digit the cursor stands on for
-## sixteen frames in every thirty-two, which is `hVBlankCounter`'s bit 4, so an
-## off half of the blink is a missing digit rather than a mark beside one.
+## sixteen frames in every thirty-two, `hVBlankCounter`'s bit 4, so an off half of
+## the blink is a missing digit rather than a mark beside one.
 static func bank_window(
 	data: GameData, word: String, saved: int, held: int, amount: String,
 	cursor: int, cursor_up: bool

--- a/game/render/move_screen_page.gd
+++ b/game/render/move_screen_page.gd
@@ -2,21 +2,13 @@ class_name Gen2MoveScreenPage
 extends RefCounted
 
 ## The move screen (`MoveScreenLoop` in `engine/pokemon/mon_menu.asm`), on the
-## tile grid the hardware uses.
-##
-## `SetUpMoveScreenBG` draws the two boxes and the nickname once and
-## `MoveScreenLoop` adds the two arrows, which `ChooseMoveToDelete` does not;
-## `SetUpMoveList` fills the list; `PlaceMoveData` fills the bottom box with
-## whichever row the cursor is on. Swapping replaces that box with `Where?`
-## instead, which is `.moving_move`.
-##
-## It loads `LoadStatsScreenPageTilesGFX` and nothing else the stats screen does
-## not, so the two share [method Gen2BattleTiles.stats_page] and the move-list
-## rows are drawn by [Gen2StatsScreenPage], whose green page lists the same four.
-##
-## Node-free: it writes indices into a buffer. The mon icon is not in that
-## buffer; it is an object with a palette of its own, composed over the page by
-## the screen.
+## tile grid the hardware uses. `SetUpMoveScreenBG` draws the two boxes and the
+## nickname once and `MoveScreenLoop` adds the two arrows, which
+## `ChooseMoveToDelete` does not; `PlaceMoveData` fills the bottom box with
+## whichever row the cursor is on, and swapping replaces it with `Where?`. It
+## loads nothing the stats screen does not, so the two share
+## [method Gen2BattleTiles.stats_page]. Node-free; the mon icon is an object with
+## a palette of its own and is composed over the page by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/mystery_gift_page.gd
+++ b/game/render/mystery_gift_page.gd
@@ -1,17 +1,13 @@
 class_name Gen2MysteryGiftPage
 extends RefCounted
 
-## `InitMysteryGiftLayout` and the boxes `DoMysteryGift` prints over it.
-##
-## Two screens under one name: Crystal builds its frame out of one sixty-seven
-## tile run and colours it with two palettes, and Gold and Silver build theirs
-## out of three runs and one palette. Neither has a stored tilemap, so the
-## screen is the routine's own `hlcoord` writes transcribed rather than a map
-## read out of the dump; [constant CRYSTAL_LAYOUT] and [constant GS_LAYOUT] are
-## those writes in the order the routine makes them, and drawing is a walk over
-## them.
-##
-## Node-free, so a check can read the tilemap back headless.
+## `InitMysteryGiftLayout` and the boxes `DoMysteryGift` prints over it. Two
+## screens under one name: Crystal builds its frame out of one sixty-seven tile
+## run and colours it with two palettes, and Gold and Silver build theirs out of
+## three runs and one palette. Neither has a stored tilemap, so the screen is the
+## routine's own `hlcoord` writes transcribed rather than a map read out of the
+## dump, and drawing is a walk over [constant CRYSTAL_LAYOUT] and
+## [constant GS_LAYOUT]. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/naming_screen_page.gd
+++ b/game/render/naming_screen_page.gd
@@ -1,22 +1,14 @@
 class_name Gen2NamingScreenPage
 extends RefCounted
 
-## `engine/menus/naming_screen.asm`'s screen on the hardware tile grid.
-##
-## The naming screen is a tilemap screen rather than a text one, the way the
-## trainer card is, so the page keeps the cartridge's own VRAM window and writes
-## tile numbers into a map: $60 the border `LoadNamingScreenGFX` copies over the
-## font-extra slot, $eb and $f2 the two entry markers, and the font from $80 up.
-##
-## Positions are `NamingScreen_InitText` and `NamingScreen_ApplyTextInputMode`'s
-## own. The layout is the same shape on both keyboards and differs only in where
-## the two `ClearBox` calls land and how many rows are printed, which is the
-## whole of `NamingScreen_IsTargetBox` here. `_ComposeMailMessage.InitCharset`
-## is the third layout: the same tiles and the same cursor over a wider
-## keyboard, a two-line entry and an icon instead of a prompt.
-##
-## Node-free: it writes indices into a buffer, so a page can be drawn and read
-## back headless.
+## `engine/menus/naming_screen.asm`'s screen on the hardware tile grid. The naming
+## screen is a tilemap screen rather than a text one, the way the trainer card is,
+## so the page keeps the cartridge's own VRAM window: $60 the border, $eb and $f2
+## the two entry markers, and the font from $80 up. The layout is the same shape
+## on both keyboards and differs only in where the two `ClearBox` calls land and
+## how many rows are printed. `_ComposeMailMessage.InitCharset` is the third
+## layout: the same tiles and cursor over a wider keyboard, a two-line entry and
+## an icon instead of a prompt. Node-free.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -2,23 +2,13 @@ class_name Gen2PackPage
 extends RefCounted
 
 ## The pack's own tile screen (`Pack_InitGFX`, engine/items/pack.asm).
-##
-## [Gen2WorldPack] owns the pockets and what a row may do; this is the picture,
-## the way [Gen2PokedexPage] is the dex's. The screen is a 20x18 grid of tile
-## numbers plus one palette per cell, since `_CGB_PackPals` fills the attrmap
-## with six palettes at once and a single-palette blit cannot say what it draws.
-##
-## `Pack_InitGFX`'s VRAM window:
-##
-## | Tiles | Contents |
-## |---|---|
-## | $00-$4f | `PackMenuGFX`, the background, the header row and the pocket names |
-## | $50-$5e | the current pocket's picture, which `DrawPackGFX` swaps per pocket |
-## | $80+ | the font, so printed text addresses glyphs as usual |
-##
-## The copy is `$60 tiles` of an 80-tile sheet, so the sixteen it lands on $50
-## are `PackGFX`'s own first sixteen; `DrawPackGFX` overwrites fifteen of them
-## before the screen is shown and no tilemap names the sixteenth.
+## [Gen2WorldPack] owns the pockets and what a row may do; this is the picture.
+## The screen is a 20x18 grid of tile numbers plus one palette per cell, since
+## `_CGB_PackPals` fills the attrmap with six palettes at once. The VRAM window is
+## `PackMenuGFX` at $00, the current pocket's picture at $50 and the font from
+## $80. The copy is `$60 tiles` of an 80-tile sheet, so the sixteen landing on $50
+## are `PackGFX`'s own first sixteen; `DrawPackGFX` overwrites fifteen of them and
+## no tilemap names the sixteenth.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -2,23 +2,13 @@ class_name Gen2PartyMenuPage
 extends RefCounted
 
 ## The party menu as the hardware draws it: `WritePartyMenuTilemap`'s
-## `PARTYMENUACTION_SWITCH` quality set plus `PlacePartyMenuText`
-## (`engine/pokemon/party_menu.asm`).
-##
-## `SetUpBattlePartyMenu` clears the battle off the screen and puts this in its
-## place, so the page is the whole 160x144 rather than a box over the field.
-## Every column below is `hlcoord`'s own, and each quality steps two rows per
-## member because `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`.
-##
-## [Gen2BattleSwitchMenu] owns the rows and the cursor; this is presentation
-## only, and node-free, so the page can be read back headless. The one thing it
-## owns itself is `InitPartyMenuGFX`'s icons, because the sprite anim structs
-## behind them are per-frame state and nothing else here holds it: [method
-## advance] is one pass of `PlaySpriteAnimations` over them.
-##
-## A row carrying `egg` is `PartyMenuCheckEgg`'s: its nickname and its icon are
-## drawn and every other quality is stepped past. Only the overworld menu can
-## show one; a battle party cannot hold an egg.
+## `PARTYMENUACTION_SWITCH` quality set plus `PlacePartyMenuText`.
+## `SetUpBattlePartyMenu` clears the battle off the screen, so the page is the
+## whole 160x144 rather than a box over the field, and each quality steps two rows
+## per member because `PartyMenu2DMenuData`'s cursor offset is `dn 2, 0`.
+## [Gen2BattleSwitchMenu] owns the rows and the cursor. The one thing this owns is
+## `InitPartyMenuGFX`'s icons, whose sprite anim structs are per-frame state. A row
+## carrying `egg` is `PartyMenuCheckEgg`'s and only the overworld menu shows one.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/pc_box_page.gd
+++ b/game/render/pc_box_page.gd
@@ -2,17 +2,12 @@ class_name Gen2PCBoxPage
 extends RefCounted
 
 ## Bill's PC on the tile grid the hardware uses (`engine/pokemon/bills_pc.asm`).
-##
 ## `Gen2BoxScreen` owns the party, the boxes and what a row may do; this is the
 ## picture, the way [Gen2PackPage] is the pack's. Every position is the source's
 ## own: `BillsPC_BoxName`'s header box, `BillsPC_RefreshTextboxes`' listing,
-## `PCMonInfo`'s left column and `BillsPC_PlaceString`'s bottom box.
-##
-## Node-free: it writes indices into a buffer, so a page can be drawn and read
-## back headless. The selected Pokemon's pic is not in that buffer and neither is
-## the cursor, since both are drawn through palettes of their own; the screen
-## composes them over the page from [method pic_position] and
-## [method cursor_sprites].
+## `PCMonInfo`'s left column and `BillsPC_PlaceString`'s bottom box. Node-free;
+## the selected Pokemon's pic and the cursor are drawn through palettes of their
+## own and are composed over the page by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -59,16 +54,13 @@ const MAIL_CODE: int = 0x5C
 const ITEM_CODE: int = 0x5D
 
 ## `BillsPC_UpdateSelectionCursor`'s OAM, as (x, y, tile, x flip, y flip) in
-## screen pixels: `dbsprite` is x tile, y tile, x pixel, y pixel, and a shadow
-## OAM position carries the hardware's own 8 and 16 pixel bias, which is taken
-## off here. The whole set moves down sixteen pixels per cursor row
-## (`and $7 / swap a`), so only the row inside the listing is stored.
-##
-## The two profiles draw different rings out of different sheets, the way
-## `.Frameset_GSTitleTrail` does: Crystal's twenty-four objects are two tiles
-## flipped into four edges, and Gold and Silver's twenty are six tiles with no
-## flip in them at all. Reading either set out of the other's sheet draws the
-## side pieces along the top.
+## screen pixels: `dbsprite` is x tile, y tile, x pixel, y pixel, and the
+## hardware's own 8 and 16 pixel bias is taken off here. The whole set moves down
+## sixteen pixels per cursor row, so only the row inside the listing is stored.
+## The two profiles draw different rings out of different sheets: Crystal's
+## twenty-four objects are two tiles flipped into four edges, and Gold and
+## Silver's twenty are six tiles with no flip in them. Reading either set out of
+## the other's sheet draws the side pieces along the top.
 const CURSOR_STEP: int = 16
 const CURSOR_SPRITES: Array = [
 	[72, 22, 0, false, false], [80, 22, 0, false, false],

--- a/game/render/pic_animation.gd
+++ b/game/render/pic_animation.gd
@@ -1,25 +1,14 @@
 class_name Gen2PicAnimation
 extends RefCounted
 
-## `AnimateFrontpic` (engine/gfx/pic_animation.asm), the wobble a front pic does
-## when it is sent out, looked at in a menu, traded, evolved or hatched.
-##
-## The cartridge's shape is a per-frame interpreter over two nested state
-## machines, and so is this one: `SetUpPokeAnim` spends one scene command a
-## frame, and `PokeAnim_DoAnimScript` spends one script command over as many
-## frames as its own duration. Neither is flattened into a list of frames
-## computed once, because a `dorepeat` counter and a `SetWait` are read while
-## the animation runs.
-##
-## What it produces is a 7x7 box of tile numbers, which is exactly what
-## `PokeAnim_PlaceGraphic` writes into `wTilemap` and what
-## [method Gen2BattleScreenMap.stamp] already writes for the enemy's square. The
-## caller stamps that box into its own map; nothing here draws.
-##
-## Crystal only. pokegold ships no `pic_animation.asm`, no `anim.asm`, no
-## bitmasks and no frames, and both of its send-outs reach `PlayStereoCry`
-## directly, so a record this has none of animates nothing and the caller plays
-## the cry on its own.
+## `AnimateFrontpic`, the wobble a front pic does when it is sent out, looked at
+## in a menu, traded, evolved or hatched. The cartridge's shape is a per-frame
+## interpreter over two nested state machines and so is this one, because a
+## `dorepeat` counter and a `SetWait` are read while the animation runs. What it
+## produces is a 7x7 box of tile numbers, which is what `PokeAnim_PlaceGraphic`
+## writes into `wTilemap`; the caller stamps that box and nothing here draws.
+## Crystal only: pokegold ships no `pic_animation.asm`, so a record this has none
+## of animates nothing and the caller plays the cry on its own.
 
 ## The `ANIM_MON_*` constants, in `PokeAnims`' own order.
 enum {

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -242,16 +242,12 @@ static func lookup(
 
 
 ## What `wBoxAlignment` produces, a plain horizontal mirror. The flag is read
-## twice and only both halves make sense of it: `LoadOrientedFrontpic`'s
-## `.x_flip` bit-reverses every byte as it loads, mirroring each tile's pixels,
-## and `PlaceGraphic`'s `.right` then walks the tile columns with `dec hl`, so
-## the first column lands in the box's last. Reversing the columns alone
-## scrambles the sprite, which is what a column-strip reversal did here.
-##
-## The two compose exactly into [method Image.flip_x]: a pixel at
-## `x = 8 * column + px` lands at `8 * (columns - 1 - column) + (7 - px)`, which
-## is `width - 1 - x`. `PrepMonFrontpic` is the one caller that sets the flag and
-## the Oak speech the one screen that reaches it.
+## twice and only both halves make sense of it: `LoadOrientedFrontpic`'s `.x_flip`
+## bit-reverses every byte as it loads, mirroring each tile's pixels, and
+## `PlaceGraphic`'s `.right` then walks the tile columns with `dec hl`. Reversing
+## the columns alone scrambles the sprite. The two compose exactly into
+## [method Image.flip_x]. `PrepMonFrontpic` is the one caller that sets the flag
+## and the Oak speech the one screen that reaches it.
 static func x_flipped(image: Image) -> Image:
 	if image == null:
 		return image
@@ -338,16 +334,13 @@ static func canvas_image(pixels: PackedInt32Array, width: int, height: int) -> I
 	)
 
 
-## One 8x8 tile of [param strip] into a [method canvas] buffer.
-##
-## [param strip] is a horizontal run of [param strip_tiles] tiles, one byte of
-## colour index per pixel, which is the shape every sheet in the cache is stored
-## in; [param table] is [method lookup]'s. [param skip_index] is the colour the
-## blit leaves standing, -1 for none: an object palette never draws index 0 and
-## a background tile draws all four.
-##
-## Clipped rather than refused, so a caller places a sprite partly off screen
-## the way OAM does.
+## One 8x8 tile of [param strip] into a [method canvas] buffer. [param strip] is
+## a horizontal run of [param strip_tiles] tiles, one byte of colour index per
+## pixel, which is the shape every sheet in the cache is stored in.
+## [param skip_index] is the colour the blit leaves standing, -1 for none: an
+## object palette never draws index 0 and a background tile draws all four.
+## Clipped rather than refused, so a caller places a sprite partly off screen the
+## way OAM does.
 static func blit_tile(
 	pixels: PackedInt32Array,
 	width: int,
@@ -401,22 +394,14 @@ static func show(target: TextureRect, image: Image) -> void:
 	Gen2Screen.note_picture(target, image)
 
 
-## What a picture is mostly made of, which is the colour a screen carries out
-## past the hardware rectangle it was laid out in.
-##
-## The picture's own field rather than its border: a cartridge screen puts a box
-## frame or a header strip along its edge often enough that the edge says black
-## where the screen reads white. Sampled on a stride, because tile art is flat in
-## blocks of eight and a quarter of the pixels answers the same question as all
-## of them for a sixteenth of the walk.
-##
-## A picture with any transparency in it has no field at all. The hardware has no
-## alpha, so a screen's own picture is opaque everywhere; one that is not is a
-## layer drawn over another screen -- a `MENU_BACKUP_TILES` box, a sprite pass
-## composed over a background -- and answering for the screen underneath is what
-## painted a black band over the map. Whether the clear pixels outnumber the
-## drawn ones is not the question: a `PokemonCenterPC` menu with a text box
-## under it covers half the screen and still owns none of it.
+## What a picture is mostly made of, which is the colour a screen carries out past
+## the hardware rectangle it was laid out in. The picture's own field rather than
+## its border, since a cartridge screen puts a box frame along its edge often
+## enough that the edge says black where the screen reads white. Sampled on a
+## stride, because tile art is flat in blocks of eight. A picture with any
+## transparency has no field at all: the hardware has no alpha, so one that is not
+## opaque is a layer over another screen, and answering for the screen underneath
+## is what painted a black band over the map.
 static func field_color(image: Image, stride: int = FIELD_STRIDE) -> Color:
 	if image == null or image.is_empty() or image.get_format() != Image.FORMAT_RGBA8:
 		return TRANSPARENT
@@ -452,18 +437,13 @@ static func field_color(image: Image, stride: int = FIELD_STRIDE) -> Color:
 	return Color.hex(best)
 
 
-## The texture [param texture] becomes once it holds [param image].
-##
-## A screen redrawn every frame used to answer `ImageTexture.create_from_image`
-## each time, which allocates a texture and frees the last one on every frame it
-## draws; `update` writes into the one already on the GPU. The size and format
-## have to match for that, so a first frame and a resize still create.
-##
-## Not headless. There is no GPU there to save the upload to, and the dummy
-## driver hands `ImageTexture.get_image` back the picture the texture was
-## created with rather than the one it was last updated with, so a check or a
-## test that reads a screen back would read the frame before the one it asked
-## for.
+## The texture [param texture] becomes once it holds [param image]. A screen
+## redrawn every frame used to answer `ImageTexture.create_from_image` each time,
+## which allocates a texture and frees the last one on every frame it draws;
+## `update` writes into the one already on the GPU. The size and format have to
+## match for that, so a first frame and a resize still create. Not headless: the
+## dummy driver hands `ImageTexture.get_image` back the picture the texture was
+## created with rather than the one it was last updated with.
 static func refreshed_texture(texture: ImageTexture, image: Image) -> ImageTexture:
 	if image == null:
 		return texture

--- a/game/render/pic_viewer.gd
+++ b/game/render/pic_viewer.gd
@@ -1,14 +1,11 @@
 extends Control
 
-## Development view: one species on a real 160x144 screen.
-##
-## Deliberate scaffolding: it proves the whole path from cartridge to lit pixel
-## (cache, indices, palette, viewport, integer-scaled window) and makes a wrong
-## decode visible without a tool writing a PNG.
-##
-## Left/right change species, S toggles shiny, B swaps front for back, T switches
-## to the trainer classes, which have one palette each and no back pic. Each is
-## also a plain method so `tools/screenshot.gd` can drive it.
+## Development view: one species on a real 160x144 screen. Deliberate
+## scaffolding: it proves the whole path from cartridge to lit pixel and makes a
+## wrong decode visible without a tool writing a PNG. Left/right change species, S
+## toggles shiny, B swaps front for back, T switches to the trainer classes, which
+## have one palette each and no back pic. Each is also a plain method so
+## `tools/screenshot.gd` can drive it.
 
 ## The white the hardware fills a pic window with. Index 0 of every pic is this
 ## colour, so a sprite on it looks exactly as it does in the game.

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -1,27 +1,14 @@
 class_name Gen2PokedexPage
 extends RefCounted
 
-## The Pokedex's own tile screens (engine/pokedex/pokedex.asm).
-##
-## [Gen2Pokedex] owns the listing, the cursor and the mode; this is the picture,
-## the way [Gen2TownMapPage] is the region map's. Every layout here is one of the
-## source's `Pokedex_Draw*BG` routines read as tile writes, so a screen is a
-## 20x18 grid of tile numbers in the dex's own VRAM numbering and nothing else.
-##
-## Three sheets share that numbering, which is what `Pokedex_LoadGFX` leaves in
-## `vTiles2`:
-##
-## - `$00` to `$30` is the font, **inverted**. `Pokedex_LoadInvertedFont` XORs
-##   every byte, so a lit pixel becomes an unlit one and the whole screen is
-##   light text on dark rather than the overworld's dark on light.
-## - `$31` to `$6a` is `PokedexLZ`'s 58 tiles, which the decompress lands on top
-##   of whatever was there.
-## - `$6b` up is `LoadFontsExtra`, inverted by the same `Pokedex_InvertTiles`
-##   pass over `$60` to `$7f`. Only the run past the dex sheet survives it.
-##
-## The main screen is the one that is not a plain grid: its listing is in the
-## *window* layer at `hWX`, over a background scrolled by `POKEDEX_SCX`, so it
-## is composed in pixels by [method image_main] rather than written into one map.
+## The Pokedex's own tile screens (engine/pokedex/pokedex.asm). [Gen2Pokedex] owns
+## the listing, the cursor and the mode; this is the picture. Every layout is one
+## of the source's `Pokedex_Draw*BG` routines read as tile writes. Three sheets
+## share the dex's VRAM numbering: `$00` to `$30` is the font **inverted**, since
+## `Pokedex_LoadInvertedFont` XORs every byte and the whole screen is light on
+## dark; `$31` to `$6a` is `PokedexLZ`; `$6b` up is `LoadFontsExtra`, inverted by
+## the same pass. The main screen is not a plain grid: its listing is in the
+## window layer at `hWX`, so it is composed in pixels by [method image_main].
 
 const COLUMNS: int = 20
 const ROWS: int = 18
@@ -349,14 +336,12 @@ func window_map(rows: Array, old_mode: bool) -> PackedInt32Array:
 
 
 ## `Pokedex_PrintListing`, which both listing screens share: one entry every two
-## rows from row 2, at column 0.
-##
-## `.PrintEntry` reaches the name by one `inc hl` from that column, and the
-## caught symbol is what it writes into the cell it steps over, so a name runs
-## from column 1 to column 10 and the scroll bar's column 11 is clear of it.
-## DEXMODE_OLD's number is three digits at column 0 of the row above. The cursor
-## is not in this map at all: it is the object frame `Pokedex_LoadCursorOAM`
-## draws over the whole screen.
+## rows from row 2, at column 0. `.PrintEntry` reaches the name by one `inc hl`
+## from that column and the caught symbol is what it writes into the cell it steps
+## over, so a name runs from column 1 to column 10 and the scroll bar's column 11
+## is clear of it. DEXMODE_OLD's number is three digits at column 0 of the row
+## above. The cursor is not in this map at all: it is the object frame
+## `Pokedex_LoadCursorOAM` draws over the whole screen.
 func _window_rows(map: PackedInt32Array, rows: Array, old_mode: bool) -> void:
 	for index: int in rows.size():
 		var entry: Dictionary = rows[index]
@@ -762,12 +747,10 @@ func _blit_object(
 ## `Pokedex_LoadSelectedMonTiles`'s `.QuestionMark`, which is what an unseen
 ## species' box is drawn with: `LoadQuestionMarkPic` decompresses
 ## `gfx/pokedex/question_mark.2bpp.lz` and copies its 7 * 7 tiles into the pic
-## slot. Column major, like every pic, and drawn through the dex's own
-## `question_mark` palette rather than a species one.
-##
-## Not `PokedexSlowpokeLZ`, which this used to draw: that is a different asset
-## entirely, five Slowpoke reading a book decompressed to `vTiles0` for the
-## search screen and the listing's objects.
+## slot, column major like every pic and drawn through the dex's own
+## `question_mark` palette. Not `PokedexSlowpokeLZ`, which this used to draw:
+## that is a different asset, five Slowpoke reading a book decompressed to
+## `vTiles0` for the search screen and the listing's objects.
 func unseen_pic() -> Image:
 	if _question_mark.is_empty() or _question_mark_palette.size() != Gen2Palette.COLORS_PER_PIC:
 		return null

--- a/game/render/pokepic_page.gd
+++ b/game/render/pokepic_page.gd
@@ -4,14 +4,10 @@ extends RefCounted
 ## `Pokepic` (engine/events/pokepic.asm): the box a script's `pokepic` command
 ## shows a species in, on the hardware tile grid. `MenuBox` at
 ## `menu_coords 6, 4, 14, 13`, then `PlaceGraphic` writing a 7x7 block of the
-## front pic one tile in from the box's top-left corner.
-##
-## `_CGB_Pokepic` fills the whole box with `PAL_BG_GRAY`, so the pic wears the
-## map's first background palette rather than the species' own colours: the
-## picture a script shows is grey.
-##
-## Node-free: the image is the whole product, so the box can be read back
-## headless.
+## front pic one tile in from the box's top-left corner. `_CGB_Pokepic` fills the
+## whole box with `PAL_BG_GRAY`, so the pic wears the map's first background
+## palette rather than the species' own colours: the picture a script shows is
+## grey. Node-free.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/render/raster.gd
+++ b/game/render/raster.gd
@@ -1,17 +1,13 @@
 class_name Gen2Raster
 extends RefCounted
 
-## A background scrolled by a different amount on each scanline, which is what
-## the hardware's `SCX` is once a routine rewrites it part way down a frame.
-##
-## The background map is wider than the screen, [param map_width] against the
-## image's own width, and everything past what was drawn is blank. So an offset
-## does not slide an image sideways and leave a gap: it wraps, and blank is what
-## comes in. An offset is a distance to look *right* into the map, so a larger
-## one puts the drawn content further left.
-##
-## Node-free and pure: it takes an image and answers a new one, which is what
-## lets a scroll be asserted headless rather than photographed.
+## A background scrolled by a different amount on each scanline, which is what the
+## hardware's `SCX` is once a routine rewrites it part way down a frame. The
+## background map is wider than the screen, [param map_width] against the image's
+## own width, and everything past what was drawn is blank, so an offset wraps
+## rather than leaving a gap. An offset is a distance to look *right* into the
+## map, so a larger one puts the drawn content further left. Node-free and pure,
+## which is what lets a scroll be asserted headless rather than photographed.
 
 ## Rows sharing an offset are moved together, since a run of scanlines with one
 ## value is the shape every routine that does this produces: three bands for

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -2,24 +2,13 @@ class_name Gen2SecondScreen
 extends Control
 
 ## The lower display: one of the game's own pages, with a row of tabs under it.
-##
-## Every page here is the screen the START menu opens, built and drawn exactly
-## as the overworld builds it, and then never handed a button. That is what
-## "read only" means in this file: the pages are not copies with a viewer's
-## shortcuts taken out, they are the same nodes with no input routed to them, so
-## a page cannot drift from the one the player sees on the top screen and cannot
-## change anything either.
-##
-## The tab row is the one thing that takes a touch. It moves the cursor in
-## [Gen2SecondScreenTabs] and nothing else; which tabs exist at all is the START
-## menu's own gate, so a page appears on the frame the cartridge would have
-## offered it and not before.
-##
-## Everything is drawn inside a [SubViewport] the size of [member canvas_size],
-## in hardware pixels, because that is what a host has to hand a display: a
-## second panel is reached by a bitmap and a scale factor, and a canvas of a few
-## hundred pixels a side is a copy small enough to make sixty times a second
-## where the panel's own 1240x1080 is not.
+## Every page is the screen the START menu opens, built and drawn exactly as the
+## overworld builds it and then never handed a button, so a page cannot drift from
+## the one the player sees and cannot change anything either. The tab row is the
+## one thing that takes a touch, and which tabs exist is the START menu's own
+## gate. Everything is drawn inside a [SubViewport] the size of
+## [member canvas_size] in hardware pixels, because a second panel is reached by a
+## bitmap and a copy that size can be made sixty times a second.
 
 ## The page, which is the cartridge's own screen and never another size.
 const PAGE_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
@@ -575,16 +564,11 @@ func _build_page() -> void:
 
 
 ## What the panel shows with no world on it: the launcher is up, or a game has
-## just been closed, and the game's own pages are not a thing that exists yet.
-##
-## Drawn in the launcher's own language rather than the cartridge's, because at
-## this point there may be no cartridge: the shelf is a list of bays and one of
-## them is empty. It is the shelf's own silhouette for a slot with nothing in it,
-## with the project's name under it, on the same field every launcher page has.
-##
-## Laid out in the panel's own pixels at a whole multiple of the launcher's
-## units, so the type is rasterised at the size it is shown rather than blown up
-## from a 206-pixel canvas.
+## just been closed. Drawn in the launcher's own language rather than the
+## cartridge's, because at this point there may be no cartridge: the shelf is a
+## list of bays and one of them is empty. Laid out in the panel's own pixels at a
+## whole multiple of the launcher's units, so the type is rasterised at the size
+## it is shown rather than blown up from a 206-pixel canvas.
 func _build_idle() -> Node:
 	var skin: Gen2LauncherTheme = Gen2LauncherTheme.active()
 	var units: int = idle_scale(panel_size)

--- a/game/render/second_screen_host.gd
+++ b/game/render/second_screen_host.gd
@@ -2,35 +2,21 @@ class_name Gen2SecondScreenHost
 extends Node
 
 ## Puts a [Gen2SecondScreen] on a real second display, and reports touches back.
-##
-## There are two ways a second panel is reached and this owns both, because the
-## screen above must not know which one it got:
-##
-## | Backend | Where it runs | How a frame arrives |
-## |---|---|---|
-## | `panel` | A handheld whose lower display is a secondary Android display | the platform plugin, one bitmap per drawn frame |
-## | `window` | Any desktop | a second [Window] holding the screen itself |
-##
-## The panel backend copies pixels rather than sharing a rendering context, and
-## that is the whole reason [Gen2SecondScreen] draws in hardware pixels instead
-## of the panel's own: a copy of a 206x180 picture is 148 KB and one of a
-## 1240x1080 panel is 5.4 MB, and the far side can scale a bitmap by a whole
-## number for nothing. Sharing a context instead would mean a Vulkan swapchain
-## per display, which this project cannot have while it renders through the
-## compatibility backend.
-##
-## The plugin is named by [constant PLUGIN], and is absent on every platform but
-## Android; [method available] is false there and nothing above this cares.
+## Two backends, because the screen above must not know which one it got: `panel`
+## is a handheld's secondary Android display reached through the platform plugin,
+## one bitmap per drawn frame, and `window` is a second [Window] on any desktop.
+## The panel backend copies pixels rather than sharing a context, which is why
+## [Gen2SecondScreen] draws in hardware pixels: 148 KB a frame against the panel's
+## own 5.4 MB. Sharing would mean a Vulkan swapchain per display, which this
+## project cannot have while it renders through the compatibility backend.
 
 ## The Android plugin singleton. Its contract is four calls and three signals:
-##
-## - `open() -> bool`, `close()`, `panel_size() -> PackedInt32Array` of two
-## - `present(pixels: PackedByteArray, width: int, height: int)`
-## - `panel_connected(width, height)`, `panel_disconnected()`,
-##   `panel_touched(x, y)` in the presented picture's own pixels
-## Not the screen's own class name: a plugin singleton is a global identifier in
-## GDScript, and one that collided would shadow [Gen2SecondScreen] on Android
-## and nowhere else.
+## `open() -> bool`, `close()`, `panel_size() -> PackedInt32Array` of two,
+## `present(pixels, width, height)`, and `panel_connected(width, height)`,
+## `panel_disconnected()` and `panel_touched(x, y)` in the presented picture's own
+## pixels. Not the screen's own class name: a plugin singleton is a global
+## identifier in GDScript, and one that collided would shadow [Gen2SecondScreen]
+## on Android and nowhere else.
 const PLUGIN: String = "Gen2SecondScreenPanel"
 
 ## The panel a `window` backend pretends to be, so what is looked at on a desktop
@@ -45,12 +31,10 @@ const WINDOW_SCALE: int = 4
 ## An animating page is copied at half the host's rate rather than every drawn
 ## frame. The trainer card's colon, the party's icons and the region map's player
 ## are the only things on the panel that move, and all three are slower than this.
-##
 ## A still page is not copied on a clock at all: it is sent for a few frames after
-## the screen says it has redrawn, and not again. That matters because the
-## launcher's own page is drawn at the panel's full resolution rather than in
-## hardware pixels, and one of those is 5.4 MB where a hardware-pixel canvas is
-## 148 KB.
+## the screen says it has redrawn, and not again, which matters because the
+## launcher's own page is drawn at the panel's full resolution and one of those is
+## 5.4 MB where a hardware-pixel canvas is 148 KB.
 const PANEL_HZ: float = 30.0
 ## How many frames a still page is sent for after it changes. More than one,
 ## because the viewport draws what it was given on the frame after it was given

--- a/game/render/second_screen_tabs.gd
+++ b/game/render/second_screen_tabs.gd
@@ -1,18 +1,13 @@
 class_name Gen2SecondScreenTabs
 extends RefCounted
 
-## Which pages a second display may show, and the icon each is reached by.
-##
-## The gate is not this file's: it is [Gen2WorldStartMenu]'s, filtered to the
-## entries that are a picture rather than an action. A tab therefore appears on
-## exactly the frame its START menu row does, so the team page cannot be opened
-## before Elm has handed over a starter and the Pokegear page cannot be opened
-## before the phone call that gives one. SAVE, OPTION and EXIT do something
-## rather than show something, and a mod's own row is a screen this cannot draw,
-## so neither reaches a tab.
-##
-## Node-free: it answers a list and an icon image, and the view decides where to
-## put them.
+## Which pages a second display may show, and the icon each is reached by. The
+## gate is [Gen2WorldStartMenu]'s, filtered to the entries that are a picture
+## rather than an action, so a tab appears on exactly the frame its START menu row
+## does: the team page cannot be opened before Elm has handed over a starter.
+## SAVE, OPTION and EXIT do something rather than show something, and a mod's own
+## row is a screen this cannot draw, so neither reaches a tab. Node-free: it
+## answers a list and an icon image, and the view decides where to put them.
 
 ## The START menu rows that are a page. In `SetUpMenuItems` order, which is the
 ## order they are drawn in.
@@ -36,16 +31,11 @@ const ICON_MAX: int = 18
 ## Where each tab's icon is cut from: the cache's own sheet name, the top-left
 ## pixel in that sheet's own grid, how many tiles wide that grid is, and how many
 ## whole pixels one source pixel is drawn as. Every one is art the page it opens
-## already draws:
-##
-## | Tab | Icon |
-## |---|---|
-## | #DEX | the caught marker, as `HUDBallIcons` draws it: the same ball the dex listing puts beside a caught row, off the sheet that draws it on white rather than on the dex's black field |
-## | PACK | the middle of `PackGFX`'s five-by-three bag |
-## | GEAR | `.PlacePokegearCardIcon`'s MAP icon, tile $40 less [constant RomLayout.POKEGEAR_FIRST_TILE] |
-## | player | the head of `GetCardPic`'s own player picture |
-##
-## #MON has no entry: its icon is the party's lead, read live.
+## already draws: #DEX is the caught marker as `HUDBallIcons` draws it, on white
+## rather than on the dex's black field; PACK is the middle of `PackGFX`'s bag;
+## GEAR is `.PlacePokegearCardIcon`'s MAP icon; and the player tab is the head of
+## `GetCardPic`'s own picture. #MON has no entry: its icon is the party's lead,
+## read live.
 const ICONS: Dictionary = {
 	Gen2WorldStartMenu.ITEM_POKEDEX: {
 		"sheet": "ball_icons", "at": Vector2i(0, 0), "size": Vector2i(8, 8),
@@ -195,16 +185,12 @@ static func _species_icon(data: GameData, species: int, egg: bool) -> Image:
 
 
 ## The [param extent] rectangle of a sheet at [param at], as one picture, drawn
-## [param scale] whole pixels per source pixel.
-##
-## The cache stores every sheet as a single row of tiles, so a rectangle that
-## crosses a tile boundary is assembled here rather than blitted: [param stride]
-## is how many tiles wide the sheet was before it was flattened, which is the
-## only thing that says where its second row of tiles went.
-##
-## [param skip] is the colour left standing: zero for a species icon, which is an
-## object and never draws its own index 0, and -1 for a background sheet, whose
-## four colours are all drawn.
+## [param scale] whole pixels per source pixel. The cache stores every sheet as a
+## single row of tiles, so a rectangle that crosses a tile boundary is assembled
+## here rather than blitted: [param stride] is how many tiles wide the sheet was
+## before it was flattened, which is the only thing that says where its second row
+## went. [param skip] is the colour left standing: zero for a species icon, which
+## is an object and never draws its own index 0, and -1 for a background sheet.
 static func _crop(
 	strip: PackedByteArray, stride: int, at: Vector2i, extent: Vector2i, scale: int,
 	colors: PackedColorArray, skip: int

--- a/game/render/slot_machine_page.gd
+++ b/game/render/slot_machine_page.gd
@@ -2,30 +2,13 @@ class_name Gen2SlotMachinePage
 extends RefCounted
 
 ## `_SlotMachine`'s screen: `SlotsTilemap` under the three reels' own objects.
-##
-## Node-free, so the whole machine can be read back headless. [Gen2SlotMachine]
-## owns the state and this is `.InitGFX`'s picture plus what `SlotsLoop` writes
-## into it every frame.
-##
-## Four things the source states and a reading gets wrong:
-##
-## - **The reels are objects, not background.** `Slots_UpdateReelPositionAndOAM`
-##   writes twenty-four shadow-OAM entries and `SlotsTilemap` leaves the three
-##   columns they stand in empty, which is why a reel can sit between two
-##   symbols at all: an object y is a pixel and a tilemap row is not.
-## - **`.InitGFX` sets `rLCDC`'s `B_LCDC_OBJ_SIZE` itself**, so every object here
-##   is eight by sixteen and draws its own tile and the one behind it, which is
-##   why a symbol is two OAM entries and not four. The exit path resets it, and
-##   no other screen in the game turns it on.
-## - **An object's palette is its own tile number shifted twice.**
-##   `.LoadOAM` writes `srl a / srl a / set B_OAM_PRIO, a` as the attribute
-##   byte, so symbol `SLOTS_STARYU` ($14) draws in object palette 5. The unused
-##   `GetUnknownSlotReelData` beside it is the table that would have said the
-##   same thing.
-## - **The bet lights are four cells each and thirteen apart.**
-##   `Slots_TurnLightsOnOrOff` writes the tile at the coordinate, again at
-##   `SCREEN_WIDTH / 2 + 3` past it, and then the tile behind it on the row
-##   below both, which is the pair of lamps down each side of the window.
+## Node-free, so the whole machine can be read back headless. Four things a
+## reading gets wrong: the reels are objects rather than background, which is why
+## a reel can sit between two symbols at all; `.InitGFX` sets `rLCDC`'s
+## `B_LCDC_OBJ_SIZE` itself, so a symbol is two OAM entries and not four; an
+## object's palette is its own tile number shifted twice, so `SLOTS_STARYU` ($14)
+## draws in object palette 5; and the bet lights are four cells each and thirteen
+## apart, a pair of lamps down each side of the window.
 
 const TILE: int = Gen2Font.TILE
 const SCREEN_COLUMNS: int = RomLayout.SLOTS_TILEMAP_COLUMNS
@@ -237,16 +220,10 @@ func attributes() -> PackedInt32Array:
 	return slots
 
 
-## The whole screen for [param machine]. [param state] is what the host holds
-## over it:
-##
-## [codeblock]
-## {
-##   "text": String,   # the box under the machine, empty for none
-##   "menu": int,      # which bet row the cursor is on, 0 for no menu
-##   "yes_no": int,    # 1 or 2 while the play-again box is up, 0 for none
-## }
-## [/codeblock]
+## The whole screen for [param machine]. [param state] is what the host holds over
+## it: `text`, the box under the machine and empty for none; `menu`, which bet row
+## the cursor is on and 0 for no menu; and `yes_no`, 1 or 2 while the play-again
+## box is up and 0 for none.
 func render(machine: Gen2SlotMachine, state: Dictionary = {}) -> Image:
 	if not ready():
 		return null

--- a/game/render/start_menu_page.gd
+++ b/game/render/start_menu_page.gd
@@ -182,24 +182,11 @@ func render_list(
 ## `SaveMenu`'s screen: `DisplaySaveInfoOnSave`'s box in the top-right,
 ## `SpeechTextbox` at the foot, and `PlaceYesNoBox`'s own box on the left when a
 ## question is up. Transparent everywhere else, since the map stays behind it.
-##
-## [param state] is what [Gen2StartMenuScreen] holds:
-##
-## [codeblock]
-## {
-##   "player_name": String,
-##   "badges": int,
-##   "pokedex": bool,     # STATUSFLAGS_POKEDEX_F, which blanks the #DEX row
-##   "caught": int,
-##   "hours": int, "minutes": int,
-##   "lines": Array,      # the text's own lines, whole
-##   "line": int,         # which of them is on the box's top row
-##   "cursor": int,       # -1 while no yes/no box is up
-## }
-## [/codeblock]
-## [param behind] is what the question stands over. `SaveMenu` puts
-## `Continue_LoadMenuHeader`'s own panel there, which is what an empty one draws;
-## `StartMenu_Quit` and the rows below it stand over the list instead.
+## [param state] is what [Gen2StartMenuScreen] holds: `player_name`, `badges`,
+## `pokedex` (STATUSFLAGS_POKEDEX_F, which blanks the #DEX row), `caught`, `hours`
+## and `minutes`, the text's own whole `lines`, `line` for which is on the top row
+## and `cursor` at -1 while no yes/no box is up. [param behind] is what the
+## question stands over.
 func render_save(state: Dictionary, behind: Image = null) -> Image:
 	if menu == null or font == null:
 		return null

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -2,21 +2,13 @@ class_name Gen2StatsScreenPage
 extends RefCounted
 
 ## The stats screen (`engine/pokemon/stats_screen.asm`), on the tile grid the
-## hardware uses.
-##
-## `StatsScreen_InitUpperHalf` draws the top seven rows once and each of
-## `LoadPinkPage`, `LoadGreenPage` and `LoadBluePage` fills the ten rows under
-## the divider, so the page number picks the lower half and nothing else. An egg
-## replaces the whole screen with `EggStatsScreen` instead.
-##
-## `StatsScreen_LoadFont` is `_LoadFontsBattleExtra` plus the bar borders and
-## `LoadStatsScreenPageTilesGFX`, so every glyph here is the battle-extra strip's
-## (`<LV>`, `<ID>`, `№`, `◀`) and the dividers, the page indicators, the exp
-## bar's end caps and `⁂` are tiles off [method Gen2BattleTiles.stats_page].
-##
-## Node-free: it writes indices into a buffer, so a page can be drawn and read
-## back headless. The Pokémon's own pic is not in that buffer; it has its own
-## palette and is composed over the page by the screen.
+## hardware uses. `StatsScreen_InitUpperHalf` draws the top seven rows once and
+## each of the three page routines fills the ten under the divider, so the page
+## number picks the lower half and nothing else; an egg replaces the whole screen
+## with `EggStatsScreen`. `StatsScreen_LoadFont` is `_LoadFontsBattleExtra` plus
+## the bar borders, so every glyph here is that strip's and the dividers, page
+## indicators and end caps come off [method Gen2BattleTiles.stats_page].
+## Node-free; the Pokemon's pic has its own palette and is composed by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -308,13 +300,11 @@ static func attributes(count: int = NUM_PAGES) -> PackedInt32Array:
 
 ## The page as pixels. The hardware gives every tile a palette and one index
 ## buffer carries one, so the HP bar, the exp bar, the front pic's own square and
-## the three page indicators are the attrmap rather than four blended layers.
-## Slot 0 is the HP palette, which is what `WipeAttrmap` leaves every other cell on.
-##
-## `LoadStatsScreenPals` writes the open page's colour over colour 0 of the HP
-## and exp palettes, which is what tints the lower screen pink, green or blue.
-## An egg never reaches it: `EggStatsInit` jumps past `StatsScreen_LoadPage`, so
-## its screen keeps the white both palettes came in with.
+## the three page indicators are the attrmap rather than four blended layers. Slot
+## 0 is the HP palette, which is what `WipeAttrmap` leaves every other cell on.
+## `LoadStatsScreenPals` writes the open page's colour over colour 0 of the HP and
+## exp palettes, which is what tints the lower screen. An egg never reaches it:
+## `EggStatsInit` jumps past `StatsScreen_LoadPage`.
 func render(page: Dictionary, data: GameData) -> Image:
 	var indices: PackedByteArray = draw(page)
 	var width: int = COLUMNS * TILE

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -1,21 +1,14 @@
 class_name Gen2TextBox
 extends TextureRect
 
-## A bordered text window, drawn the way the hardware draws one.
-##
-## Everything is on the tile grid, at the games' own measurements rather than by
-## choice: the border is six tiles of the chosen frame printed as box-drawing
-## characters, the interior is white, and text sits one tile in from the left on
-## every second row, since a line is eight pixels tall in a box whose rows are
-## sixteen apart.
-##
-## The box composes into one index buffer and goes through the same
-## index-plus-palette path a sprite does, so a glyph and a Pokémon are lit by the
-## same code. Only indices 0 and 3 appear: 1bpp graphics have no middle colours.
-##
-## Text reveals a tile at a time and waits at the end of each page.
-## [method advance] and [method finish] are plain methods as well as key
-## handlers, so a screen can be photographed mid-sentence.
+## A bordered text window, drawn the way the hardware draws one. Everything is on
+## the tile grid at the games' own measurements: the border is six tiles of the
+## chosen frame printed as box-drawing characters, and text sits one tile in from
+## the left on every second row, since a line is eight pixels tall in a box whose
+## rows are sixteen apart. The box composes into one index buffer, so a glyph and
+## a Pokemon are lit by the same code. Text reveals a tile at a time;
+## [method advance] and [method finish] are plain methods as well as key handlers,
+## so a screen can be photographed mid-sentence.
 
 ## Emitted when the last page has been shown and advanced past.
 signal finished
@@ -185,19 +178,14 @@ func place_at_bottom() -> void:
 	position = Vector2(0, STANDARD_TOP * TILE)
 
 
-## Lays [param text] out and starts revealing its first page.
-##
-## [param blink_cursor] is whether the *last* page loads the arrow, and that is
-## not the same question as whether it waits. `WaitPressAorB_BlinkCursor`'s own
-## comment says it: "The cursor has to be shown before calling this function or
-## no cursor will be shown at all." Three routines show it, `Paragraph`,
-## `_ContText` and `PromptText`, so a page with another behind it always blinks;
-## the last page blinks only if the text ends in `prompt`.
-##
-## Two things therefore draw no arrow. A text ending in `done` reaches none of
-## the three, which is why `SendOutMonText` prints "Go! <MON>!" and runs on. And
-## a caller that waits with `JoyWaitAorB` instead loads no cursor whatever its
-## text ends in, which is every page of `ProfOaksPCBoot`.
+## Lays [param text] out and starts revealing its first page. [param blink_cursor]
+## is whether the *last* page loads the arrow, which is not the same question as
+## whether it waits: `WaitPressAorB_BlinkCursor`'s own comment says the cursor has
+## to be shown before it is called or none is shown at all. Three routines show
+## it, so a page with another behind it always blinks and the last page blinks
+## only if the text ends in `prompt`. Two things therefore draw no arrow: a text
+## ending in `done`, which is why `SendOutMonText` runs on, and a caller that
+## waits with `JoyWaitAorB`, which is every page of `ProfOaksPCBoot`.
 func show_text(text: String, blink_cursor: bool = true) -> void:
 	_pages = Gen2TextLayout.lay_out_pages(text, text_columns(), text_rows())
 	_blink_cursor = blink_cursor
@@ -273,14 +261,11 @@ func finish() -> void:
 
 
 ## What a button press does: moves to the next page. Returns false once there is
-## nothing left, having emitted [signal finished].
-##
-## A press while the page is still printing is SPENT and does nothing else. The
-## cartridge has no path from a press to the end of a page: `PrintLetterDelay`
-## is the only thing a button reaches while text is running and the most it does
-## is [member accelerated]. Completing the page on the press instead let a
-## repeated one tear through a whole text a page per press, which is what
-## holding the advance key looked like.
+## nothing left, having emitted [signal finished]. A press while the page is still
+## printing is SPENT and does nothing else: the cartridge has no path from a press
+## to the end of a page, `PrintLetterDelay` being the only thing a button reaches
+## while text is running. Completing the page on the press instead let a repeated
+## one tear through a whole text a page per press.
 func advance() -> bool:
 	if _pages.is_empty():
 		return false
@@ -475,16 +460,12 @@ func _draw_border(indices: PackedByteArray, width: int) -> void:
 	font.draw_box(frame_style, indices, width, 0, 0, columns, rows)
 
 
-## The arrow, drawn only while the box is actually waiting: a page still
-## revealing has not reached its `PromptButton` yet.
 ## Whether `LoadBlinkingCursor` has the arrow up right now, which is the whole
-## rule for drawing it: a page still revealing has not reached its
-## `PromptButton`, a `scroll_nowait` page turns itself, a last page nothing
-## loaded the cursor for never shows one, and the blink is the other half of
-## `hVBlankCounter`.
-##
-## Public because it is a rule rather than a drawing step, and because a text
-## that owes no press is easy to draw an arrow over by accident.
+## rule for drawing it: a page still revealing has not reached its `PromptButton`,
+## a `scroll_nowait` page turns itself, a last page nothing loaded the cursor for
+## never shows one, and the blink is the other half of `hVBlankCounter`. Public
+## because it is a rule rather than a drawing step, and because a text that owes
+## no press is easy to draw an arrow over by accident.
 func cursor_visible() -> bool:
 	if _pages.is_empty() or is_revealing() or not _cursor_up():
 		return false

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -1,19 +1,14 @@
 class_name Gen2TextLayout
 extends RefCounted
 
-## Breaking a string into the lines and pages a text box can show.
-##
-## Pure rules, no font and no screen: it counts tiles and returns strings, so a
-## conversation's pagination can be checked without drawing anything.
-##
-## Widths count tiles, never characters: a ligature like "'s" is two characters
-## in one glyph, so [method String.length] overstates a line and wraps it a
-## column early. [method Gen2Text.encoded_length] is the measure that matches the
-## screen.
-##
-## The cartridges do not wrap at runtime; their text is pre-broken at authoring
-## time with control codes, which works when every string is known in advance and
-## does not when a mod adds one or a name runs long.
+## Breaking a string into the lines and pages a text box can show. Pure rules, no
+## font and no screen: it counts tiles and returns strings, so a conversation's
+## pagination can be checked without drawing anything. Widths count tiles, never
+## characters: a ligature like "'s" is two characters in one glyph, so
+## [method String.length] overstates a line and wraps it a column early. The
+## cartridges do not wrap at runtime, their text being pre-broken at authoring
+## time, which works when every string is known in advance and does not when a mod
+## adds one or a name runs long.
 
 
 ## Breaks [param text] into lines of at most [param columns] tiles.
@@ -85,17 +80,13 @@ static func lay_out(text: String, columns: int, rows: int) -> Array:
 
 
 ## The same pages with what each of them costs to reach, which is what a box
-## animating a scroll needs and a caller only counting lines does not.
-##
-## `enter` is `&"page"` for a `Paragraph`, whose box is cleared and which waits
-## for a press first; `&"scroll"` for `_ContText`, which waits and then runs
-## `TextScroll` twice; and `&"scroll_nowait"` for `_ContTextNoPause`, which is
-## the same two scrolls with nothing waited for. The first page is `&"start"`.
-##
-## `carried` is how many of the page's first lines the scroll moved up rather
-## than printed. `TextScroll` copies tiles and `_ContTextNoPause` then writes at
-## `TEXTBOX_INNERY + 2`, so a carried line is already on screen and is never
-## typed a second time.
+## animating a scroll needs. `enter` is `page` for a `Paragraph`, whose box is
+## cleared and which waits for a press first; `scroll` for `_ContText`, which
+## waits and then runs `TextScroll` twice; and `scroll_nowait` for
+## `_ContTextNoPause`, the same two scrolls with nothing waited for. The first
+## page is `start`. `carried` is how many of the page's first lines the scroll
+## moved up rather than printed, since `TextScroll` copies tiles and a carried
+## line is already on screen.
 static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
 	var out: Array = []
 	if rows <= 0 or columns <= 0:

--- a/game/render/text_viewer.gd
+++ b/game/render/text_viewer.gd
@@ -1,17 +1,12 @@
 extends Control
 
 ## Development view: the cartridge's font and text box on a real 160x144 screen.
-##
 ## Scaffolding like `pic_viewer.tscn`, for the same reason: a font slid by one
 ## tile still draws letters and a border with its six tiles out of order still
-## draws a box, so both are checked by looking rather than by counting bytes.
-##
-## The chart draws all 128 glyphs in code order, so the alphabet runs, the gaps
-## between them and the trailing digits show up as the charmap describes, and
-## anything out of place is a blank mid-word or a letter in a gap.
-##
-## Space advances, F cycles the border, C toggles the chart. Each is also a plain
-## method so `tools/screenshot.gd` can drive it.
+## draws a box, so both are checked by looking rather than by counting bytes. The
+## chart draws all 128 glyphs in code order, so anything out of place is a blank
+## mid-word or a letter in a gap. Space advances, F cycles the border, C toggles
+## the chart, and each is a plain method `tools/screenshot.gd` can drive.
 
 const BACKGROUND: Color = Color.WHITE
 

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -1,16 +1,13 @@
 class_name Gen2TitlePage
 extends RefCounted
 
-## The title screen, on the tile grid the hardware uses.
-##
-## Two screens under one name, the way [Gen2TitleScene] is. Crystal draws its
-## logo with `DrawTitleGraphic`, keeps a strip of Suicune under it that
-## `LoadSuicuneFrame` re-points every eighth frame, and stands the crystal in
-## front as thirty 8x16 objects. Gold and Silver write `TitleScreenTilemap`
-## straight into the BG map and fly one bird over it.
-##
-## [Gen2TitleScene] owns the frames and the positions; this owns the pixels.
-## Node-free like the other `render/*_page.gd`.
+## The title screen, on the tile grid the hardware uses. Two screens under one
+## name, the way [Gen2TitleScene] is: Crystal draws its logo with
+## `DrawTitleGraphic`, keeps a strip of Suicune under it that `LoadSuicuneFrame`
+## re-points every eighth frame, and stands the crystal in front as thirty 8x16
+## objects, while Gold and Silver write `TitleScreenTilemap` straight into the BG
+## map and fly one bird over it. [Gen2TitleScene] owns the frames and the
+## positions; this owns the pixels.
 
 const TILE: int = Gen2Tiles.TILE_WIDTH
 const COLUMNS: int = 20
@@ -243,19 +240,12 @@ static func from_data(data: GameData) -> Gen2TitlePage:
 
 ## What a screen wider than the hardware's own draws behind it: [param view]
 ## pixels of background, with the 160x144 rectangle at [param origin] left to
-## [method draw].
-##
-## Nothing is invented and nothing is stretched. `LoadTitleScreenTilemap` writes
-## all thirty-two columns of the BG map and the hardware only ever shows twenty,
-## so the twelve the screen never reached are the cartridge's own answer to a
-## wider window: sky over the logo's rows, and the cloud bank's four-tile pattern
-## carried on. Past those twelve the band repeats, which is seamless because
-## twelve is three of that pattern; above and below, the first and last rows do,
-## which is the same field either way. Crystal writes no tilemap at all and its
-## map is cleared, so its surround is the colour the cartridge leaves there.
-##
-## Not the whole map through a wider window: it is 256 pixels across and wraps,
-## so a buffer past that would bring the logo back round a second time.
+## [method draw]. Nothing is invented and nothing is stretched:
+## `LoadTitleScreenTilemap` writes all thirty-two columns and the hardware only
+## shows twenty, so the twelve the screen never reached are the cartridge's own
+## answer to a wider window. Past those twelve the band repeats, seamless because
+## twelve is three of its pattern. Not the whole map through a wider window: it is
+## 256 pixels across and wraps, so the logo would come back round a second time.
 func draw_backdrop(view: Vector2i, origin: Vector2i) -> Image:
 	var width: int = maxi(view.x, 1)
 	var height: int = maxi(view.y, 1)

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -2,25 +2,13 @@ class_name Gen2TownMapPage
 extends RefCounted
 
 ## The region map (`_TownMap` and `InitPokegearTilemap.Map`) and the Pokegear's
-## other three cards, on the tile grid the hardware uses.
-##
-## Like the trainer card this is a tilemap screen: `FillTownMap` writes one tile
-## number per cell of the whole screen out of `JohtoMap` or `KantoMap`, the frame
-## overwrites a few of them and only the landmark's name is printed text. So the
-## page builds a map of tile numbers, colours it through `TownMapPals` and then
-## resolves each number to pixels.
-##
-## `Pokegear_LoadGFX`'s VRAM window:
-##
-## | Tiles | Contents |
-## |---|---|
-## | $00-$2f | `TownMapGFX`, which is every tile a region map names |
-## | $30-$5d | `PokegearGFX`, the card frame and its icons |
-## | $60+ | the font, so printed text addresses glyphs as usual |
-##
-## The other three cards are the same window with one of the RLE tilemaps over
-## it instead of a region map, so they are built here rather than in a page of
-## their own; `Pokegear_FinishTilemap`'s icon row runs on all four.
+## other three cards, on the tile grid the hardware uses. Like the trainer card
+## this is a tilemap screen: `FillTownMap` writes one tile number per cell out of
+## `JohtoMap` or `KantoMap` and only the landmark's name is printed text, so the
+## page builds a map of tile numbers, colours it through `TownMapPals` and
+## resolves each number to pixels. The VRAM window is `TownMapGFX` at $00,
+## `PokegearGFX` at $30 and the font from $60. The other three cards are the same
+## window with one of the RLE tilemaps over it, so they are built here too.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/trainer_card_page.gd
+++ b/game/render/trainer_card_page.gd
@@ -2,32 +2,13 @@ class_name Gen2TrainerCardPage
 extends RefCounted
 
 ## One page of the trainer card (`engine/menus/trainer_card.asm`), on the tile
-## grid the hardware uses.
-##
-## The card is a tilemap screen rather than a text screen: most of what it draws
-## are raw tile numbers into the window the card graphics are loaded at, and only
-## the player's name, the numbers and a handful of labels are printed text. So
-## this keeps the cartridge's own VRAM window and writes tile numbers into a map,
-## exactly like `TrainerCard_InitBorder` and `TrainerCardSetup_PlaceTilemapString`
-## do, then resolves each number to pixels at the end.
-##
-## VRAM, as `_Option`'s `.InitRAM` and each page's LoadGFX build it:
-##
-## | Tiles | Contents |
-## |---|---|
-## | $00-$22 | `GetCardPic`'s 35-tile player pic, gender selected |
-## | $1c | Crystal only, overwritten by `CardRightCornerGFX` |
-## | $23-$28 | `TrainerCardGFX`, the card's own frame pieces |
-## | $29-$7e | 86 tiles: `CardStatusGFX` on page 1, `LeaderGFX` on pages 2 and 3 |
-## | $80+ | the font, so printed text addresses glyphs as usual |
-##
-## Page 1's 86 tiles start at `CardStatusGFX`, which is only six tiles long, so
-## the copy runs straight on into `LeaderGFX`. That overrun is the cartridge's
-## own and is why the status strip and the leader strip overlap.
-##
-## Node-free: it writes tile numbers and then indices into a buffer, so a page
-## can be drawn and read back headless. The badge sprites are not in that buffer;
-## they are objects with their own palette, composed over the page by the screen.
+## grid the hardware uses. The card is a tilemap screen rather than a text screen,
+## so this keeps the cartridge's own VRAM window and writes tile numbers into a
+## map exactly as `TrainerCard_InitBorder` does, then resolves each number to
+## pixels. The window is `GetCardPic`'s 35-tile player pic at $00,
+## `TrainerCardGFX`'s frame pieces at $23, 86 tiles at $29 and the font from $80.
+## Page 1's 86 start at `CardStatusGFX`, which is only six tiles long, so the copy
+## runs straight on into `LeaderGFX`: that overrun is the cartridge's own.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -133,15 +114,13 @@ const LEADER_FACE_ROWS: int = 3
 const LEADER_FACE_TILES: int = 10
 const LEADER_STRIDE: int = 4
 
-## `_CGB_TrainerCard`'s attribute map, as `FillBoxCGB` writes it: rows first,
-## then columns. Its palette slots are [constant RomLayout.CARD_PALETTE_CLASSES]'
-## own order, and the leader boxes are filled whatever page is on screen, since
-## the layout runs once in `.InitRAM`.
-##
-## Both gender branches are the source's: the whole card takes the opposite
-## gender's palette and the pic area the player's own, Clair's box is filled only
-## for Kris, and the top-right corner is written twice, the second write being
-## the one that lasts.
+## `_CGB_TrainerCard`'s attribute map, as `FillBoxCGB` writes it: rows first, then
+## columns. Its palette slots are [constant RomLayout.CARD_PALETTE_CLASSES]' own
+## order, and the leader boxes are filled whatever page is on screen, since the
+## layout runs once in `.InitRAM`. Both gender branches are the source's: the
+## whole card takes the opposite gender's palette and the pic area the player's
+## own, Clair's box is filled only for Kris, and the top-right corner is written
+## twice, the second write being the one that lasts.
 const ATTRIBUTE_LEADER_BOXES: Array[Dictionary] = [
 	{"at": Vector2i(2, 11), "palette": 1},
 	{"at": Vector2i(6, 11), "palette": 2},

--- a/game/render/unown_printer_page.gd
+++ b/game/render/unown_printer_page.gd
@@ -1,15 +1,12 @@
 class_name Gen2UnownPrinterPage
 extends RefCounted
 
-## `_UnownPrinter` (`engine/events/print_unown.asm`), the ALPH RUINS STAMP
-## browser, and the page `PrintUnownStamp` builds out of it.
-##
-## Three `Textbox`es, three strings and one Unown frontpic; the menu's PRINT and
-## CANCEL rows are printed as `♂` and `♀` because `Request1bpp` has just
-## overwritten those two font tiles with a bold A and a bold B, so the two codes
-## are drawn from `UnownDexATile` rather than from the font.
-##
-## Node-free: the image is the whole product, so a check reads it back headless.
+## `_UnownPrinter`, the ALPH RUINS STAMP browser, and the page `PrintUnownStamp`
+## builds out of it: three `Textbox`es, three strings and one Unown frontpic. The
+## menu's PRINT and CANCEL rows are printed as the two gender signs because
+## `Request1bpp` has just overwritten those font tiles with a bold A and a bold B,
+## so the two codes are drawn from `UnownDexATile` rather than from the font.
+## Node-free: the image is the whole product.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20

--- a/game/render/unown_puzzle_page.gd
+++ b/game/render/unown_puzzle_page.gd
@@ -2,30 +2,13 @@ class_name Gen2UnownPuzzlePage
 extends RefCounted
 
 ## `_UnownPuzzle`'s screen: the board tilemap and the two object sets over it.
-##
-## Node-free, so the whole board can be read back headless. The tile bank is
-## built once per opened puzzle and the render is one index buffer.
-##
-## Four things the source states and a reading gets wrong:
-##
-## - **A puzzle picture is doubled, not drawn.** `ConvertLoadedPuzzlePieces`
-##   enlarges the 6x6 strip into a 12x12 one by taking each nibble through
-##   `.EnlargedTiles`, which is a two-times nearest scale of the whole picture:
-##   destination tile `(2r + h, 2c + w)` is source tile `(r, c)`'s own quarter.
-##   The sixteen three-by-three pieces are cut from that grid, so piece n's
-##   corner tile is `((n - 1) / 4) * 36 + ((n - 1) % 4) * 3`, which is
-##   `GetCurrentPuzzlePieceVTileCorner.Corners`.
-## - **The borders are ORed onto the pieces, in bitplanes.**
-##   `UnownPuzzle_AddPuzzlePieceBorders` runs `or [hl]` over the 2bpp bytes,
-##   which is a bitwise OR of the colour index per pixel, and it reaches the
-##   eight tiles around each piece's own centre rather than the picture's edge.
-## - **The board is drawn in vTiles0 and so from tile $00.** `ld a, %10010011`
-##   into `rLCDC` is the unsigned tile base, which is why a piece tile number is
-##   a small one and START>CANCEL sits at the top of the bank.
-## - **The cursor is red because of a palette write, not a tile.**
-##   `_CGB_UnownPuzzle` copies PREDEFPAL_UNOWN_PUZZLE everywhere and then
-##   overwrites object colour 0 with `palred 31`; `DmgToCgbObjPal0 $24` maps
-##   colour 3 onto colour 0, so the cursor's own ink draws in it.
+## Node-free, so the whole board can be read back headless. Four things a reading
+## gets wrong: a puzzle picture is doubled rather than drawn, destination tile
+## `(2r + h, 2c + w)` being source tile `(r, c)`'s own quarter; the borders are
+## ORed onto the pieces in bitplanes, reaching the eight tiles around each piece's
+## centre; the board is drawn in vTiles0 and so from tile $00, `rLCDC`'s
+## `%10010011` being the unsigned tile base; and the cursor is red because
+## `_CGB_UnownPuzzle` overwrites object colour 0, not because of a tile.
 
 const TILE: int = Gen2Tiles.TILE_WIDTH
 const TILE_PIXELS: int = Gen2Tiles.TILE_PIXELS

--- a/game/render/unown_wall_page.gd
+++ b/game/render/unown_wall_page.gd
@@ -2,14 +2,10 @@ class_name Gen2UnownWallPage
 extends RefCounted
 
 ## `DisplayUnownWords`' box on the hardware tile grid: `MenuBox`'s frame with
-## [Gen2UnownWall]'s 2x2 letter blocks placed in it.
-##
-## The letters come out of the chamber's own tileset strip rather than a font,
-## and wear `PAL_BG_BROWN` whatever the tileset's palette map says about those
-## tile numbers, which is what `_DisplayUnownWords_FillAttr` writes.
-##
-## Node-free: the image is the whole product, so the box can be read back
-## headless.
+## [Gen2UnownWall]'s 2x2 letter blocks placed in it. The letters come out of the
+## chamber's own tileset strip rather than a font, and wear `PAL_BG_BROWN`
+## whatever the tileset's palette map says about those tile numbers, which is what
+## `_DisplayUnownWords_FillAttr` writes. Node-free.
 
 const TILE: int = Gen2Font.TILE
 

--- a/game/rom/rom_file.gd
+++ b/game/rom/rom_file.gd
@@ -1,15 +1,12 @@
 class_name RomFile
 extends RefCounted
 
-## A cartridge dump held in memory for the duration of an import.
-##
-## Node-free like the rest of the ROM layer. [method open_verified] refuses
-## anything [RomVerifier] has not accepted, since every [RomLayout] offset is
-## only meaningful for a characterised dump.
-##
-## Reads are bounds-checked and return zero rather than faulting: decoders walk
-## data whose length is only known once decoded, and a corrupt stream should end
-## as an honest "that did not decode" rather than an engine error.
+## A cartridge dump held in memory for the duration of an import. Node-free like
+## the rest of the ROM layer. [method open_verified] refuses anything
+## [RomVerifier] has not accepted, since every [RomLayout] offset is only
+## meaningful for a characterised dump. Reads are bounds-checked and return zero
+## rather than faulting: decoders walk data whose length is only known once
+## decoded, and a corrupt stream should end as an honest "that did not decode".
 
 ## Cartridge banks are 16 KiB; the CPU sees one fixed and one switchable.
 const BANK_SIZE: int = 0x4000

--- a/game/rom/rom_registry.gd
+++ b/game/rom/rom_registry.gd
@@ -1,16 +1,12 @@
 class_name RomRegistry
 extends RefCounted
 
-## The allowlist of ROMs this project can import from.
-##
-## The project ships no game data. A user-supplied dump is matched here by SHA-1
-## before a byte is read for content. An unknown hash is a hard refusal: an
-## uncharacterised ROM has unknown bank layout, and guessing produces corrupt
-## assets rather than an honest error.
-##
-## Crystal's two common filenames (the "(UE) (V1.1)" and "(USA, Europe) (Rev 1)"
-## dumps) are byte-identical and collapse to one entry: matching is by hash,
-## never by filename.
+## The allowlist of ROMs this project can import from. The project ships no game
+## data: a user-supplied dump is matched here by SHA-1 before a byte is read for
+## content, and an unknown hash is a hard refusal, since an uncharacterised ROM
+## has unknown bank layout and guessing produces corrupt assets rather than an
+## honest error. Crystal's two common filenames are byte-identical and collapse to
+## one entry: matching is by hash, never by filename.
 
 ## Every Game Boy Color cartridge in this generation is 2 MiB. Used only as a
 ## cheap pre-filter so a wrong file is rejected before we hash it.

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -1,19 +1,13 @@
 class_name Gen2BoxScreen
 extends Control
 
-## Bill's PC's two lists, on the hardware's own grid.
-##
-## [Gen2PCBoxPage] is the picture and `engine/pokemon/bills_pc.asm` is the model.
-## `_DepositPKMN` and `_WithdrawPKMN` are this one screen with a different list
-## loaded: `wBillsPC_LoadedBox` is the party for one and the current box for the
-## other, `CopyBoxmonSpecies` builds the list with a CANCEL row on the end, and
-## `Withdraw_UpDown` walks it. `_BillsPC`'s own top menu is the panel's
-## ([Gen2WorldServiceScreen]), which is what opens this in either mode.
-##
-## A on a row opens the submenu both jumptables reach: the transfer, STATS,
+## Bill's PC's two lists, on the hardware's own grid. [Gen2PCBoxPage] is the
+## picture and `engine/pokemon/bills_pc.asm` is the model. `_DepositPKMN` and
+## `_WithdrawPKMN` are this one screen with a different list loaded, and
+## `_BillsPC`'s own top menu is the panel's, which is what opens this in either
+## mode. A on a row opens the submenu both jumptables reach: the transfer, STATS,
 ## RELEASE and CANCEL. Left and right do nothing, because the only routine that
-## reads them is `MoveMonWithoutMail_DPad`, and MOVE PKMN W/O MAIL is a screen of
-## its own that is not built.
+## reads them is `MoveMonWithoutMail_DPad` and that screen is not built.
 
 signal closed(result: Dictionary)
 ## `PlayMonCry2` from the stats screen this one can open, played by whoever owns

--- a/game/save/game_time.gd
+++ b/game/save/game_time.gd
@@ -1,16 +1,13 @@
 class_name Gen2GameTime
 extends RefCounted
 
-## The play timer the trainer card prints (`home/game_time.asm`, `GameTimer`).
-##
-## Not the day cycle: [Gen2WorldClock] is real time and answers what hour the
-## world is in, while this counts hardware frames of actual play and is what
-## `wGameTimeHours`/`wGameTimeMinutes` hold. The cartridge keeps both, and they
-## disagree the moment the game is closed.
-##
-## `GameTimer` counts 60 frames to a second even though a frame is 1/59.7275 s,
-## so the play timer runs about half a percent slow against a wall clock. That
-## is the cartridge's own arithmetic and is mirrored rather than corrected.
+## The play timer the trainer card prints (`home/game_time.asm`, `GameTimer`). Not
+## the day cycle: [Gen2WorldClock] is real time and answers what hour the world is
+## in, while this counts hardware frames of actual play. The cartridge keeps both
+## and they disagree the moment the game is closed. `GameTimer` counts 60 frames
+## to a second even though a frame is 1/59.7275 s, so the play timer runs about
+## half a percent slow against a wall clock: the cartridge's own arithmetic,
+## mirrored rather than corrected.
 
 ## `GameTimer.Function`'s own comparisons.
 const FRAMES_PER_SECOND: int = 60

--- a/game/save/mon_stats_screen.gd
+++ b/game/save/mon_stats_screen.gd
@@ -1,21 +1,14 @@
 class_name Gen2MonStatsScreen
 extends RefCounted
 
-## The stats screen's model (`engine/pokemon/stats_screen.asm`): which member of
-## a list is shown, which page is open, and what each page has to say about it.
-## The pages are the cartridge's three plus whatever mods have registered
-## ([method Gen2ModHost.register_stats_page]), which is
-## [method Gen2StatsScreenPage.page_count]. [Gen2StatsScreenPage] draws the answer.
-##
-## `StatsScreenInit` is opened over whatever screen asked for it and hands
-## control back on the way out, so this owns no nodes: whoever embedded it draws
-## [method snapshot] and feeds it [method handle_button].
-##
-## The list is the party in the two places STATS is reached from today, the
-## overworld's `MonMenu_Stats` and a battle's own party menu. `wMonType` picks a
-## different list on the cartridge (`sBoxMons`, the enemy's party, `wBufferMon`);
-## the shape here is the same for any of them, which is why the mons are passed
-## in rather than read out of a save.
+## The stats screen's model: which member of a list is shown, which page is open,
+## and what each page has to say about it. The pages are the cartridge's three plus
+## whatever mods have registered, and [Gen2StatsScreenPage] draws the answer.
+## `StatsScreenInit` is opened over whatever screen asked for it and hands control
+## back on the way out, so this owns no nodes. The list is the party in the two
+## places STATS is reached from today; `wMonType` picks a different list on the
+## cartridge, but the shape is the same for any of them, which is why the mons are
+## passed in rather than read out of a save.
 
 ## `StatsScreen_Exit`: B, or A on the last page.
 signal closed

--- a/game/save/nuzlocke.gd
+++ b/game/save/nuzlocke.gd
@@ -2,22 +2,13 @@ class_name Gen2Nuzlocke
 extends RefCounted
 
 ## The Nuzlocke challenge's own state and rules, for a run whose
-## [member Gen2Rules.challenge] is [constant Gen2Rules.CHALLENGE_NUZLOCKE].
-##
-## Its own file rather than [Gen2Rules] because a rule there names what the
-## engine DOES and never changes, while this is what the run has SPENT: which
-## areas have given up their one encounter, which Pokemon are gone, and whether
-## the run is over. It lives on the save for the same reason the party does.
-##
-## Not [Gen2WorldPartyHost] either: the launcher's save screen reads a slot's
-## graveyard and its verdict without a world, and the save model has to
-## serialize the block whether or not one is loaded.
-##
-## The ruleset is the one Bulbapedia records: two mandatory rules (one catch per
-## area, a faint is permanent) and the near-universal three beside them (every
-## Pokemon nicknamed, no undoing a death by reloading, a full wipe ends the run).
-## The optional clauses are not implemented: a dupes or shiny clause makes the
-## challenge easier, and a run that wants one can play it by hand.
+## [member Gen2Rules.challenge] is [constant Gen2Rules.CHALLENGE_NUZLOCKE]. Its
+## own file rather than [Gen2Rules] because a rule there names what the engine
+## DOES and never changes, while this is what the run has SPENT. Not
+## [Gen2WorldPartyHost] either: the launcher's save screen reads a slot's
+## graveyard without a world. The ruleset is the one Bulbapedia records, two
+## mandatory rules and the near-universal three; the optional clauses make the
+## challenge easier and a run that wants one can play it by hand.
 
 ## How many losses a run's memorial keeps. A full party six times over, which is
 ## more than a finished Nuzlocke has ever needed, and a bound so a save cannot

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -1,18 +1,14 @@
 class_name Gen2PartyScreen
 extends Control
 
-## The party menu, in the two places it is opened from.
-##
-## Embedded in the overworld it is `PartyMenu` itself: `StartMenu_Pokemon` runs
-## `InitPartyMenuWithCancel`, `WritePartyMenuTilemap` and `PlacePartyMenuText`,
-## and `PokemonActionSubmenu` opens `MonSubmenu`'s box over the bottom of it. So
+## The party menu, in the two places it is opened from. Embedded in the overworld
+## it is `PartyMenu` itself: `StartMenu_Pokemon` runs `InitPartyMenuWithCancel`
+## and `PokemonActionSubmenu` opens `MonSubmenu`'s box over the bottom of it, so
 ## the embedded view is [Gen2PartyMenuPage] and [Gen2MenuPage] at hardware
-## resolution, in a [Gen2Screen] of its own, and the model below is what
-## `PartyMenuSelect` and `MonMenuLoop` answer.
-##
-## The launcher's own party view, which is not a cartridge screen, keeps the
-## window-resolution panel: it is opened from the save slots with a mouse and
-## carries the PC storage and development battle buttons that no cartridge has.
+## resolution and the model below is what `PartyMenuSelect` answers. The
+## launcher's own party view, which is not a cartridge screen, keeps the
+## window-resolution panel and carries the PC storage and development battle
+## buttons that no cartridge has.
 
 ## Emitted only when embedded, mirroring Gen2BoxScreen.closed: the overworld
 ## start menu resumes on this rather than the screen navigating away with
@@ -242,17 +238,13 @@ func party_snapshot() -> Dictionary:
 	}
 
 
-## engine/pokemon/mon_submenu.asm's GetMonSubmenuItems for one party member.
-##
-## An egg gets three entries and no moves. Otherwise the four move slots are
-## walked in the mon's own slot order, appending every move that appears in
-## MonMenuOptions' field-move rows, then the fixed options follow. Every row is
-## acted on: the screens STATS and MOVE open are built, so a row that cannot be
-## chosen no longer exists here.
-##
-## [param slot] is one-based and [param in_battle] is whether the list belongs to
-## a turn: both only decide which mod rows are offered, and neither changes a
-## cartridge row.
+## engine/pokemon/mon_submenu.asm's GetMonSubmenuItems for one party member. An
+## egg gets three entries and no moves; otherwise the four move slots are walked
+## in the mon's own slot order, appending every move that appears in
+## MonMenuOptions' field-move rows, and the fixed options follow. Every row is
+## acted on, since the screens STATS and MOVE open are built. [param slot] is
+## one-based and [param in_battle] is whether the list belongs to a turn: both
+## only decide which mod rows are offered.
 static func submenu_items_for(
 	data: GameData, mon: Gen2SaveMon, slot: int = 0, in_battle: bool = false
 ) -> Array:

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -55,14 +55,12 @@ static func to_battle_mon(data: GameData, saved: Gen2SaveMon) -> Gen2BattleMon:
 
 
 ## Writes a fought party back over [param source_save]. Eggs never entered the
-## battle party, so they keep their own slots and the battle Pokémon fill the
-## rest in order; the write fails rather than dropping an egg or shifting a
-## slot when the two no longer line up.
-##
-## The candidate starts as a complete clone of [param source_save], so fields
-## the battle model does not carry cannot disappear as the save schema grows.
-## Happiness is not restored from that clone: Return and Frustration read it,
-## so [Gen2BattleMon] holds it and it round-trips with the fought party.
+## battle party, so they keep their own slots and the battle Pokemon fill the rest
+## in order; the write fails rather than dropping an egg or shifting a slot when
+## the two no longer line up. The candidate starts as a complete clone of
+## [param source_save], so fields the battle model does not carry cannot disappear
+## as the save schema grows. Happiness is not restored from that clone: Return and
+## Frustration read it, so it round-trips with the fought party.
 static func from_battle_party(
 	game_id: StringName, rom_sha1: String, slot: int, party: Gen2Party, player_name: String = "",
 	source_save: Gen2SaveData = null

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -262,22 +262,14 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	return out
 
 
-## Converts an older project save shape into the current schema, one version
-## step at a time so a version 1 file reaches the current one through every
-## step rather than skipping to it. Each step adds only what its version
-## lacked; a missing world snapshot stays missing throughout.
-##
-## Version 1 had no PC-box field. Version 2 had no slot label. Version 3 had no
-## player trainer ID; it migrates to zero rather than being invented, since a
-## rolled ID would silently change the headbutt encounters of an existing save.
-## Version 4 had neither gender nor a play timer; both migrate to the value a
-## new game starts with, male and 0:00, since neither can be recovered.
-## Version 5 had no per-mod namespace.
-##
-## The `run` block joined version 6 after it shipped and is not a version of its
-## own: it defaults to no seed, mod list, mod-option snapshot or rules, which is
-## the truth about a slot written before it existed rather than a value worth
-## inventing.
+## Converts an older project save shape into the current schema, one version step
+## at a time so a version 1 file reaches the current one through every step. Each
+## step adds only what its version lacked. Version 1 had no PC-box field, 2 no
+## slot label, 3 no player trainer ID (which migrates to zero rather than being
+## invented, since a rolled ID would change an existing save's headbutt
+## encounters), 4 neither gender nor a play timer, and 5 no per-mod namespace. The
+## `run` block joined version 6 after it shipped and is not a version of its own:
+## it defaults to nothing, which is the truth about a slot written before it.
 static func migrate_dict(raw: Variant) -> Dictionary:
 	if not raw is Dictionary:
 		return {"ok": false, "message": "save data is not an object"}

--- a/game/save/save_editor.gd
+++ b/game/save/save_editor.gd
@@ -1,17 +1,13 @@
 class_name Gen2SaveEditor
 extends RefCounted
 
-## Edits a save slot while keeping it loadable.
-##
-## Every setter here maintains the invariants [Gen2SaveValidator] enforces
-## rather than letting the player write a value and discover at save time that
-## the slot is dead: level and experience are kept in agreement through the
-## species' own growth curve, HP is clamped to the recomputed maximum, PP
-## follows the move it belongs to, and move slots stay contiguous. The
-## validator is still the gate on [method commit], so a bug here costs a
-## refused write, not a corrupted slot.
-##
-## Scene free on purpose. The editor screen owns presentation only.
+## Edits a save slot while keeping it loadable. Every setter maintains the
+## invariants [Gen2SaveValidator] enforces rather than letting the player write a
+## value and discover at save time that the slot is dead: level and experience are
+## kept in agreement through the species' own growth curve, HP is clamped to the
+## recomputed maximum, PP follows the move it belongs to, and move slots stay
+## contiguous. The validator is still the gate on [method commit], so a bug here
+## costs a refused write rather than a corrupted slot. Scene free on purpose.
 
 ## An empty move slot. The validator refuses any move after one of these, so
 ## removing a move compacts the list rather than leaving a hole.

--- a/game/save/save_mail.gd
+++ b/game/save/save_mail.gd
@@ -1,19 +1,13 @@
 class_name Gen2SaveMail
 extends RefCounted
 
-## One `mailmsg` struct (`macros/ram.asm`) and the four routines in
-## `engine/pokemon/mail.asm` that move one between a party member and the PC.
-##
-## The cartridge keeps party mail in `sPartyMail`, a sixth of SRAM indexed by
-## party slot, and the mailbox in `sMailboxes` behind its own count. The mailbox
-## is kept the same way here, on [member Gen2SaveData.mailbox]; a party member's
-## mail is kept on the member instead of on its slot, because everything that
-## moves a slot moves its mail with it (`SwitchPartyMons` swaps both) and
-## nothing can put a mailed Pokemon anywhere else: `BillsPC_CheckMail_Prevent
-## Blackout` and `Gen2WorldDayCare`'s own refusal are the two gates, and the
-## day care's is already built.
-##
-## Scene-free and cache-free, like the rest of `game/save/`.
+## One `mailmsg` struct and the four routines in `engine/pokemon/mail.asm` that
+## move one between a party member and the PC. The cartridge keeps party mail in
+## `sPartyMail` indexed by party slot and the mailbox in `sMailboxes`; the mailbox
+## is kept the same way here, but a party member's mail is kept on the member
+## rather than on its slot, because everything that moves a slot moves its mail
+## with it and nothing can put a mailed Pokemon anywhere else. Scene-free and
+## cache-free, like the rest of `game/save/`.
 
 ## `MAIL_LINE_LENGTH`, `MAIL_MSG_LENGTH` and `MAILBOX_CAPACITY`.
 const LINE_LENGTH: int = RomLayout.MAIL_LINE_LENGTH

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -97,16 +97,12 @@ func open_new_slot() -> bool:
 
 
 ## Starts a new game in the selected slot by running the cartridge's own intro.
-##
-## Nothing is written here. `NewGame` reaches `InitializeWorld` only after
+## Nothing is written here: `NewGame` reaches `InitializeWorld` only after
 ## `PlayerProfileSetup` and `OakSpeech` have returned, so the slot is staged on
-## [GameRuntime] and [Gen2IntroScreen] writes it once the trainer has a name and
-## a gender. Abandoning the intro leaves no file behind.
-##
-## [param label] is the save file's own name, the decorative one Rename edits.
-## It is optional; the trainer's name comes from the naming screen.
-## [param challenge] overrides the form's own pick, which is what a test and a
-## driver use; a name this build does not carry falls back to the form's.
+## [GameRuntime] and [Gen2IntroScreen] writes it once the trainer has a name and a
+## gender, and abandoning the intro leaves no file behind. [param label] is the
+## save file's decorative name, optional; [param challenge] overrides the form's
+## own pick, which is what a test and a driver use.
 func create_new_game(label: String = "", challenge: StringName = &"") -> bool:
 	if _data == null:
 		_set_status(&"error", "New game unavailable.", "No imported cartridge cache is selected.")

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -309,16 +309,14 @@ static func create_development_save(data: GameData, slot: int) -> Gen2SaveData:
 	return development
 
 
-## Creates the source-shaped Crystal new-game save. Crystal initializes an
-## empty party before the player reaches Elm's Lab; the imported GIVEPOKE
-## script creates the first party member later. The optional fourth argument
-## remains accepted for callers from the earlier development launcher, but it
-## is deliberately ignored so a new save cannot skip the story handoff.
-##
-## [param random] rolls wPlayerID. It is the one roll in this project that is
-## an identity rather than a game event, so an absent generator randomizes here
-## instead of being refused; pass one when a run has to reproduce itself, since
-## GetTreeScore reads the result.
+## Creates the source-shaped Crystal new-game save. Crystal initializes an empty
+## party before the player reaches Elm's Lab, and the imported GIVEPOKE script
+## creates the first party member later. The optional fourth argument remains
+## accepted for callers from the earlier development launcher but is deliberately
+## ignored, so a new save cannot skip the story handoff. [param random] rolls
+## wPlayerID, the one roll in this project that is an identity rather than a game
+## event, so an absent generator randomizes here instead of being refused; pass
+## one when a run has to reproduce itself, since GetTreeScore reads the result.
 static func create_new_game(
 	data: GameData, slot: int, player_name: String, _starter_species: int = -1,
 	random: RandomNumberGenerator = null

--- a/game/save/save_validator.gd
+++ b/game/save/save_validator.gd
@@ -82,19 +82,25 @@ static func _validate_world(world: Gen2WorldSnapshot, data: GameData) -> Diction
 		or world.world_minute < 0 \
 		or world.world_minute >= Gen2WorldClock.MINUTES_PER_HOUR:
 		return _failure("the saved world clock is invalid")
-	if world.world_state == null:
+	return _validate_world_state(world.world_state, data)
+
+
+## The flags, bag and balances the world screen would open with.
+static func _validate_world_state(state: Gen2WorldState, data: GameData) -> Dictionary:
+	if state == null:
 		return _failure("the saved world state is missing")
-	for raw_flag: Variant in world.world_state.engine_flags():
+	for raw_flag: Variant in state.engine_flags():
 		if int(raw_flag) < 0:
 			return _failure("the saved world engine flag is invalid")
-	for raw_item: Variant in world.world_state.items():
+	for raw_item: Variant in state.items():
 		if data.item(int(raw_item)).is_empty():
 			return _failure("the saved world contains unknown item %d" % int(raw_item))
-	for raw_account: Variant in world.world_state.money_balances():
-		var balance: int = int(world.world_state.money_balances()[raw_account])
+	var balances: Dictionary = state.money_balances()
+	for raw_account: Variant in balances:
+		var balance: int = int(balances[raw_account])
 		if balance < 0 or balance > Gen2WorldInventory.MAX_MONEY:
 			return _failure("the saved world money balance is invalid")
-	if world.world_state.coins() < 0 or world.world_state.coins() > Gen2WorldInventory.MAX_COINS:
+	if state.coins() < 0 or state.coins() > Gen2WorldInventory.MAX_COINS:
 		return _failure("the saved world coin balance is invalid")
 	return {"ok": true, "message": ""}
 
@@ -117,13 +123,29 @@ static func _validate_mon(
 	)
 	if expected_level != mon.level:
 		return _failure("%s level and experience disagree" % subject)
+	var stats: Dictionary = _validate_mon_stats(mon, data, subject)
+	if not stats["ok"]:
+		return stats
+	var moves: Dictionary = _validate_mon_moves(mon, data, subject)
+	if not moves["ok"]:
+		return moves
+	if mon.item < 0:
+		return _failure("%s has an invalid item" % subject)
+	if mon.item > 0 and data.item(mon.item).is_empty():
+		return _failure("%s has unknown item %d" % [subject, mon.item])
+	return {"ok": true, "message": ""}
+
+
+## DVs, stat experience, HP against the maximum the same formula gives, status.
+static func _validate_mon_stats(
+	mon: Gen2SaveMon, data: GameData, subject: String
+) -> Dictionary:
 	if mon.dvs < 0 or mon.dvs > 0xFFFF:
 		return _failure("%s has invalid DVs" % subject)
 	for key: String in Gen2SaveMon.STAT_EXP_KEYS:
 		var value: int = int(mon.stat_exp.get(key, -1))
 		if value < 0 or value > Gen2Stats.MAX_STAT_EXP:
 			return _failure("%s has invalid %s stat experience" % [subject, key])
-
 	var base: Dictionary = data.species(mon.species).get("stats", {})
 	var max_hp: int = Gen2Stats.calculate(
 		int(base.get("hp", 0)), Gen2Stats.hp_dv(mon.dvs), int(mon.stat_exp.get("hp", 0)),
@@ -133,7 +155,13 @@ static func _validate_mon(
 		return _failure("%s has invalid HP" % subject)
 	if not is_valid_status(mon.status):
 		return _failure("%s has invalid status" % subject)
+	return {"ok": true, "message": ""}
 
+
+## Four slots, filled from the front, each with PP its own move allows.
+static func _validate_mon_moves(
+	mon: Gen2SaveMon, data: GameData, subject: String
+) -> Dictionary:
 	if mon.moves.size() != Gen2SaveMon.MAX_MOVES or mon.pp.size() != Gen2SaveMon.MAX_MOVES:
 		return _failure("%s does not have four move slots" % subject)
 	var empty_seen: bool = false
@@ -150,14 +178,8 @@ static func _validate_mon(
 		var move: Dictionary = data.move(move_number)
 		if move.is_empty():
 			return _failure("%s has unknown move %d" % [subject, move_number])
-		var max_pp: int = int(move.get("pp", 0))
-		if pp < 0 or pp > max_pp:
+		if pp < 0 or pp > int(move.get("pp", 0)):
 			return _failure("%s has invalid PP for move %d" % [subject, move_number])
-
-	if mon.item < 0:
-		return _failure("%s has an invalid item" % subject)
-	if mon.item > 0 and data.item(mon.item).is_empty():
-		return _failure("%s has unknown item %d" % [subject, mon.item])
 	return {"ok": true, "message": ""}
 
 

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -27,16 +27,13 @@ const PP_UP_MASK: int = 0xC0
 const PLAYER_GENDER_MASK: int = 0x01
 
 ## `player_id` is wPlayerID, the two big-endian bytes wPlayerData opens with in
-## both pins (ram/wram.asm), which is why it shares an address with
-## `primary_data_start`.
-##
+## both pins, which is why it shares an address with `primary_data_start`.
 ## `player_gender` is Crystal's alone and sits nowhere near the rest: it is
 ## `sCrystalData`, its own SRAM section past the Active Box, Link Battle and Hall
-## of Fame ones, so no checksum covers it and `_SaveData` is the only routine
-## that ever writes it. `01:be3d` in `pokecrystal11.sym`, which is bank 1 offset
-## `0x3E3D` in a 32 KiB image; that build is byte identical to the cartridge this
-## project verifies, so the address is the linker's rather than a guess. Gold and
-## Silver have no such section and no such byte: their player is always male.
+## of Fame ones, so no checksum covers it and `_SaveData` is the only routine that
+## writes it. `01:be3d` in `pokecrystal11.sym`, bank 1 offset `0x3E3D` in a 32 KiB
+## image, from a build byte identical to the cartridge this project verifies. Gold
+## and Silver have no such section: their player is always male.
 const LAYOUTS: Dictionary = {
 	"gold": {
 		"primary_check_1": 0x2008,

--- a/game/world/battle_tower.gd
+++ b/game/world/battle_tower.gd
@@ -259,14 +259,12 @@ static func _values_are_unique(values: Array, eggs: Array) -> bool:
 
 
 ## `LoadOpponentTrainerAndPokemon`: a trainer this streak has not sampled, and
-## three Pokemon of the chosen level group that share no species or held item
-## with each other or with either of the last two teams.
-##
-## The sampled trainer is written into `sBTTrainers[beaten]` and the two
-## previous-team lists shift, so calling this twice in a row gives two different
-## opponents the way the cartridge's own streak does. Answers
-## { trainer, name, class, mons }, `mons` being three [Gen2SaveMon], or an empty
-## Dictionary when the cartridge has no tower.
+## three Pokemon of the chosen level group that share no species or held item with
+## each other or with either of the last two teams. The sampled trainer is written
+## into `sBTTrainers[beaten]` and the two previous-team lists shift, so calling
+## this twice in a row gives two different opponents the way the cartridge's own
+## streak does. Answers { trainer, name, class, mons }, or an empty Dictionary
+## when the cartridge has no tower.
 func load_opponent(data: GameData, random: RandomNumberGenerator) -> Dictionary:
 	if data == null or not data.has_battle_tower():
 		return {}

--- a/game/world/card_flip.gd
+++ b/game/world/card_flip.gd
@@ -1,38 +1,14 @@
 class_name Gen2CardFlip
 extends RefCounted
 
-## `_CardFlip`'s own state (engine/games/card_flip.asm), node-free.
-##
-## [Gen2CardFlipPage] owns the picture and [Gen2CardFlipScreen] the pump; this
-## is `.MasterLoop`: one pass of `.Jumptable` a frame, with the background this
-## screen writes kept here because almost everything the game shows is a
-## tilemap write rather than a state a page could infer.
-##
-## Five things the source states that a reading gets wrong:
-##
-## - **The deck is dealt, not drawn.** `CardFlip_ShuffleDeck` fills `wDeck` with
-##   an ordering once, and `.CheckTheCard` reads
-##   `wDeck[wCardFlipNumCardsPlayed * 2 + wCardFlipWhichCard]`, so the two cards
-##   on the table are the pair for this round and picking one decides which of
-##   two known cards turns over. Twelve rounds exhaust the twenty-four.
-## - **`.ChooseACard`'s toggle is the choice.** There is no cursor over the two
-##   cards: `wCardFlipWhichCard` flips every four frames on its own and A takes
-##   whichever is lit, which is what the border sprite is drawn on.
-## - **A bet is one of forty-eight cells, and six of them are unreachable.**
-##   `CollapseCursorPosition` is `y * 6 + x` and `CardFlip_CheckWinCondition`'s
-##   jumptable has four `.Impossible` entries, which lose. The four exist
-##   because `ChooseCard_HandleJoypad` cannot walk into columns 0 and 1 of the
-##   two Pokemon rows and does not test for them.
-## - **The board's own marks are drawn one round late.** `.KeepTheCurrentDeck`
-##   calls `CardFlip_BlankDiscardedCardSlot` for the card just turned over, and
-##   the pair it belongs to is what decides the tile: a cell whose other half is
-##   already discarded gets `$3d` rather than its own triangle.
-## - **A shuffle is not a reset.** `.Continue` reshuffles only on the twelfth
-##   round, and `CardFlip_ShuffleDeck` clears `wDiscardPile` with it, so the
-##   board's marks and the twelve lights are cleared by the same call.
-##
-## Randomness is injected: every `Random` here is a byte off the generator the
-## caller owns, so a seeded run repeats.
+## `_CardFlip`'s own state (engine/games/card_flip.asm), node-free, and
+## `.MasterLoop`'s side of it. Five things a reading gets wrong: the deck is dealt
+## rather than drawn, `.CheckTheCard` reading a pair fixed at shuffle time;
+## `.ChooseACard`'s toggle is the choice, there being no cursor over the two
+## cards; a bet is one of forty-eight cells and six are unreachable, four of them
+## `.Impossible` entries that lose; the board's marks are drawn one round late;
+## and a shuffle is not a reset, `.Continue` reshuffling only on the twelfth
+## round. Randomness is injected, so a seeded run repeats.
 
 ## `CARDFLIP_DECK_SIZE`, which is four Pokemon by six levels.
 const DECK_SIZE: int = 24

--- a/game/world/card_flip_screen.gd
+++ b/game/world/card_flip_screen.gd
@@ -1,24 +1,14 @@
 class_name Gen2CardFlipScreen
 extends Control
 
-## `_CardFlip`'s own loop, on the overworld's pump.
-##
-## [Gen2CardFlip] owns the rules and [Gen2CardFlipPage] the picture; this is
-## `.MasterLoop`: one pass a frame, the boxes the game asks for answered where
-## the cartridge's own blocking calls would have stood, and the exit
-## `JUMPTABLE_EXIT_F` sets.
-##
-## Two things the loop states that a screen would otherwise get wrong:
-##
-## - **`YesNoBox` spends frames inside a state.** `VerticalMenu` does not return
-##   until the player answers, so nothing deals, nothing toggles and no coin is
-##   paid while either box is up. `.ChooseACard`'s toggle and `.PlaceYourBet`'s
-##   cursor are the opposite: both read the joypad on frames the loop is still
-##   spending, so a press there is answered where it lands as well as on the
-##   frame.
-## - **`WaitSFX` is the driver's, not a frame count.** The screen holds while the
-##   player it was handed reports an effect; a screen with no player waits
-##   nothing, which is what a headless driver and every test see.
+## `_CardFlip`'s own loop, on the overworld's pump. [Gen2CardFlip] owns the rules
+## and [Gen2CardFlipPage] the picture; this is `.MasterLoop`, one pass a frame,
+## with the boxes answered where the cartridge's blocking calls stood. Two things
+## a screen would otherwise get wrong: `YesNoBox` spends frames inside a state, so
+## nothing deals and no coin is paid while either box is up, while
+## `.ChooseACard`'s toggle reads the joypad on frames the loop is still spending;
+## and `WaitSFX` is the driver's rather than a frame count, so a screen with no
+## player waits nothing.
 
 signal closed(coins: int)
 signal sfx_requested(index: int, waited: bool)

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -1,15 +1,12 @@
 class_name Gen2ClockSetScreen
 extends Control
 
-## `InitClock`, before Oak's first speech beat. Hour and minutes only: the
-## routine ends on `OakText_ResponseToSetTime` after `.MinutesAreSet` and never
-## calls `SetDayOfWeek`, which is Mom's own errand in `PlayersHouse1F.asm`. The
-## weekday the save starts on is whatever the RTC holds, SUNDAY on a fresh one.
-##
-## Every line here is a `PrintText`, so the box is a [Gen2TextBox] and reveals at
-## the cartridge's own rate, and every wait is a `DelayFrames` operand spent
-## through a [Gen2IntroPresentation]. `RotateFourPalettesLeft` is the caller's,
-## over the screen `InitGender` left standing; see [Gen2IntroScreen].
+## `InitClock`, before Oak's first speech beat. Hour and minutes only: the routine
+## ends on `OakText_ResponseToSetTime` after `.MinutesAreSet` and never calls
+## `SetDayOfWeek`, which is Mom's own errand, so the weekday a save starts on is
+## whatever the RTC holds. Every line is a `PrintText`, so the box is a
+## [Gen2TextBox] revealing at the cartridge's own rate and every wait is a
+## `DelayFrames` operand spent through a [Gen2IntroPresentation].
 
 signal finished(day: int, hour: int, minute: int)
 

--- a/game/world/credits.gd
+++ b/game/world/credits.gd
@@ -2,25 +2,13 @@ class_name Gen2Credits
 extends RefCounted
 
 ## The credits (`engine/movie/credits.asm`), as the frame-driven state machine
-## they are.
-##
-## `Credits_Jumptable` runs one entry per frame and loops back after thirteen, so
-## a `CREDITS_WAIT` tick is thirteen frames and not one: `ParseCredits` is the
-## first entry and spends a tick each time it comes round. The rest of the cycle
-## is what moves. `Credits_UpdateGFXRequestPath` steps the banner's frame, twice
-## a cycle on Crystal and once on Gold and Silver;`Credits_LYOverride` walks the
-## two border bands sideways two pixels, down on Crystal and up on the other two;
-## and the three `Credits_Next` entries behind a wait are the frames
-## `UpdateBGMap` spends copying the tilemap to the BG map a third at a time.
-##
-## That copy is why this owns two maps rather than one. `.parse` clears the text
-## region and places the next batch into `wTilemap` with `hBGMapMode` off, and
-## only `CREDITS_WAIT` turns the copy back on: a batch ending on `CREDITS_WAIT2`
-## or on `CREDITS_END` is written and never shown. The End stays on screen for
-## exactly that reason, since the clear in front of `CREDITS_END` is never
-## pushed.
-##
-## [Gen2CreditsPage] turns [method bg_map] into pixels; nothing here draws.
+## they are. `Credits_Jumptable` runs one entry per frame and loops back after
+## thirteen, so a `CREDITS_WAIT` tick is thirteen frames and not one. The rest of
+## the cycle is what moves: the banner's frame, the two border bands walking
+## sideways two pixels, and the three `Credits_Next` entries `UpdateBGMap` spends
+## copying the tilemap a third at a time. That copy is why this owns two maps: a
+## batch ending on `CREDITS_WAIT2` or `CREDITS_END` is written and never shown,
+## which is why The End stays on screen. Nothing here draws.
 
 ## `MUSIC_CREDITS` and the `MUSIC_POST_CREDITS` `.end` fades into, both the same
 ## number on all three cartridges.

--- a/game/world/credits_screen.gd
+++ b/game/world/credits_screen.gd
@@ -2,15 +2,11 @@ class_name Gen2CreditsScreen
 extends Control
 
 ## The credits, embedded in the overworld the way the Hall of Fame is.
-##
 ## [Gen2Credits] owns `Credits`' whole loop and [Gen2CreditsPage] draws it; this
 ## spends the frames and reads the two buttons `.execution_loop` reads. Both are
-## held states rather than presses (`hJoypadDown`), so the host has to say when
-## each is let go: A only leaves once the script has run out, and B burns a tick
-## of the current wait per frame and only on a replay.
-##
-## The two `PlayMusic` calls are the overworld's rather than this screen's, the
-## same way the Hall of Fame's rating sound is.
+## held states rather than presses, so the host says when each is let go: A only
+## leaves once the script has run out, and B burns a tick of the current wait per
+## frame and only on a replay. The two `PlayMusic` calls are the overworld's.
 
 signal closed()
 signal music_requested(music: int)

--- a/game/world/day_care_screen.gd
+++ b/game/world/day_care_screen.gd
@@ -2,18 +2,13 @@ class_name Gen2DayCareScreen
 extends Control
 
 ## `DayCareMan`, `DayCareLady`, `DayCareManOutside`, `DayCareMon1` and
-## `DayCareMon2` on the overworld's own pump.
-##
-## All five are straight lines of boxes, questions, a party list and two sounds,
-## so they are one screen with a queue rather than five: [Gen2WorldDayCare]
-## answers every question that needs a source reading and this owns the presses.
-##
-## Which of the five is running decides how it ends. The two counters and the man
-## outside are called from a script that follows them with `waitbutton`, so their
-## last box is handed to the caller through [signal finished] and stands in the
-## world's speech box for that one press; the two signs are called with no
-## `waitbutton` at all, because `DayCareMonCursor` and the compatibility text's
-## own `prompt` are the press.
+## `DayCareMon2` on the overworld's own pump. All five are straight lines of
+## boxes, questions, a party list and two sounds, so they are one screen with a
+## queue rather than five. Which of the five is running decides how it ends: the
+## two counters and the man outside are called from a script that follows them
+## with `waitbutton`, so their last box stands in the world's speech box for that
+## one press, while the two signs are called with no `waitbutton` because
+## `DayCareMonCursor` and the compatibility text's own `prompt` are the press.
 
 ## [param script_value] is -1 for the four routines that write no wScriptVar.
 signal finished(script_value: int, ending_text: String)

--- a/game/world/diploma_screen.gd
+++ b/game/world/diploma_screen.gd
@@ -1,19 +1,14 @@
 class_name Gen2DiplomaScreen
 extends Control
 
-## `_Diploma` and `_PrintDiploma` (`engine/events/diploma.asm`,
-## `engine/printer/printer.asm`), which are the same page under two loops.
-##
-## `_Diploma` is `PlaceDiplomaOnScreen` and `WaitPressAorB_BlinkCursor`, so
-## either button closes it. `_PrintDiploma` draws the same page and then holds
-## in `SendScreenToPrinter`, which prints whatever `CheckPrinterStatus` last
-## found; with nothing on the link `wPrinterHandshake` and `wPrinterStatusFlags`
-## both stay -1, which is PRINTER_ERROR_2, and B is the way out. That is not a
-## refusal invented here: it is the branch a Game Boy with no printer plugged in
-## takes, and there is no printer to plug in.
-##
-## Page 2 is therefore never drawn by the printing loop, because `.cancel` skips
-## it. [method preview_page] is what photographs it.
+## `_Diploma` and `_PrintDiploma`, which are the same page under two loops.
+## `_Diploma` is `PlaceDiplomaOnScreen` and `WaitPressAorB_BlinkCursor`, so either
+## button closes it. `_PrintDiploma` draws the same page and holds in
+## `SendScreenToPrinter`; with nothing on the link both printer variables stay -1,
+## which is PRINTER_ERROR_2, and B is the way out. That is the branch a Game Boy
+## with no printer takes rather than a refusal invented here. Page 2 is therefore
+## never drawn by the printing loop, because `.cancel` skips it, and
+## [method preview_page] is what photographs it.
 
 signal closed()
 signal music_requested(index: int)

--- a/game/world/egg_hatch_screen.gd
+++ b/game/world/egg_hatch_screen.gd
@@ -1,18 +1,14 @@
 class_name Gen2EggHatchScreen
 extends Control
 
-## `HatchEggs` and the `EggHatch_AnimationSequence` its `.Text_HatchEgg` runs,
-## for one party egg at a time.
-##
-## Presentation only: [method Gen2WorldPartyHost.hatch_egg] has already written
-## the party row, which is the source's own order, so the picture the sequence
-## ends on is the Pokemon the row now holds. What this screen owns after that is
-## the nickname: [signal named] carries the answer and the caller writes it.
-##
+## `HatchEggs` and the `EggHatch_AnimationSequence` its `.Text_HatchEgg` runs, for
+## one party egg at a time. Presentation only:
+## [method Gen2WorldPartyHost.hatch_egg] has already written the party row, which
+## is the source's own order, so the picture the sequence ends on is the Pokemon
+## the row now holds. What this owns after that is the nickname.
 ## `Hatch_InitShellFragments`' ten shell pieces are sprite-anim objects and this
-## project has no sprite-anim layer outside the intro, the same reason
-## `.PlayEvolvedSFX`'s balls of light are absent from [Gen2EvolutionScreen].
-## Their 130 frames are spent with the hatchling standing.
+## project has no sprite-anim layer outside the intro, so their 130 frames are
+## spent with the hatchling standing.
 
 ## The nickname the player settled on for the hatched party slot.
 signal named(party_index: int, nickname: String)

--- a/game/world/evolution_screen.gd
+++ b/game/world/evolution_screen.gd
@@ -1,18 +1,14 @@
 class_name Gen2EvolutionScreen
 extends Control
 
-## `EvolveAfterBattle`'s `.proceed` and the `EvolutionAnimation` it farcalls,
-## for one plan at a time out of [method Gen2Evolution.after_battle].
-##
-## Presentation only: nothing here writes a party row. Each plan is announced
-## with [signal resolved] at the point `.proceed` writes the new species, so the
-## caller applies it in the source's own order and the next plan starts after it.
-##
-## Two pieces of `.PlayEvolvedSFX` are not drawn: the thirty-two balls of light
-## are sprite-anim objects and this project has no sprite-anim layer outside the
-## intro, so their frames are spent and the screen holds the new picture through
-## them. Everything else, including both cries, the flash loop's own rising and
-## falling counters and `AnimateFrontpic ANIM_MON_EVOLVE`, is the routine's.
+## `EvolveAfterBattle`'s `.proceed` and the `EvolutionAnimation` it farcalls, for
+## one plan at a time out of [method Gen2Evolution.after_battle]. Presentation
+## only: nothing here writes a party row, and each plan is announced with
+## [signal resolved] at the point `.proceed` writes the new species, so the caller
+## applies it in the source's own order. Two pieces of `.PlayEvolvedSFX` are not
+## drawn: the thirty-two balls of light are sprite-anim objects and this project
+## has no such layer outside the intro, so their frames are spent and the screen
+## holds the new picture through them.
 
 signal resolved(plan: Dictionary, canceled: bool)
 signal closed()

--- a/game/world/game_freak_presents.gd
+++ b/game/world/game_freak_presents.gd
@@ -1,21 +1,13 @@
 class_name Gen2GameFreakPresents
 extends RefCounted
 
-## `GameFreakPresentsScene` and the sprite animation beside it
-## (`engine/movie/splash.asm`), which is the second half of `SplashScreen`.
-##
-## Two cartridges, two sequences. Crystal bounces a Ditto in on
-## `BattleAnim_Sine_e`, waits, and fades its pink to orange as it turns into the
-## logo; Gold and Silver throw a star that leaves the logo behind it, rotate
-## `rOBP1` until the logo is yellow, and spray sparkles out of it. The words
-## underneath are the same two `PlaceString`s on both, at different rows.
-##
-## Every frame here is a frame the cartridge spends. The scene jumptable and the
-## sprite's own jumptable run in one `advance_frame()`, in the order that
-## profile's loop calls them: Crystal's `.joy_loop` runs the scene and then
-## `PlaySpriteAnimations`, Gold's `GameFreakPresentsFrame` the other way round.
-##
-## Scene-free: a host reads [method sprites], [method words] and
+## `GameFreakPresentsScene` and the sprite animation beside it, which is the
+## second half of `SplashScreen`. Two cartridges, two sequences: Crystal bounces a
+## Ditto in on `BattleAnim_Sine_e` and fades its pink to orange as it turns into
+## the logo, while Gold and Silver throw a star that leaves the logo behind it and
+## spray sparkles out of it. Every frame here is a frame the cartridge spends, and
+## the two jumptables run in one `advance_frame()` in the order that profile's
+## loop calls them. Scene-free: a host reads [method sprites], [method words] and
 ## [method fade_step] and draws them.
 
 ## `GameFreakLogoSpriteAnim`'s own jumptable, which is the Ditto's, and Gold's

--- a/game/world/gender_screen.gd
+++ b/game/world/gender_screen.gd
@@ -2,14 +2,12 @@ class_name Gen2GenderScreen
 extends Control
 
 ## `engine/menus/init_gender.asm`'s boy-or-girl choice, Crystal only.
-##
 ## `InitGender` prints its question, runs a `VerticalMenu` and writes
 ## `wMenuCursorY - 1` into `wPlayerGender`, which is bit 0 of the byte
 ## [Gen2SaveData] already carries. The selection rules are [Gen2WorldMenu]'s and
-## the layout [Gen2GenderScreenPage]'s; this is the node between them.
-##
-## `.MenuData` sets STATICMENU_DISABLE_B, so there is no way out but a choice.
-## That is the source's own answer to a screen a new game cannot skip.
+## the layout [Gen2GenderScreenPage]'s. `.MenuData` sets STATICMENU_DISABLE_B, so
+## there is no way out but a choice, which is the source's own answer to a screen
+## a new game cannot skip.
 
 ## Carries [constant Gen2SaveData.GENDER_MALE] or `GENDER_FEMALE`.
 signal closed(gender: int)

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -1,27 +1,14 @@
 class_name Gen2GoldSilverIntro
 extends RefCounted
 
-## `GoldSilverIntro` (pokegold/engine/movie/intro.asm): the movie between the
-## GameFreak logo and the title screen on Gold and Silver.
-##
-## Seventeen scenes behind one jumptable, stepped once per hardware frame, over
-## three cutscenes: shellders and magikarp under water rising to a surfacing
-## Lapras, Jigglypuff and Pikachu in the grass, and Charizard breathing a
-## fireball over the three Johto starters. Crystal runs [Gen2IntroMovie]
-## instead, which is a different movie entirely.
-##
-## Two things here are not [Gen2IntroMovie]'s shape:
-##
-## - **The colour model is `DmgToCgbBGPals`, not palette runs.** Each cutscene
-##   loads one background palette and up to two object palettes through
-##   `SCGB_GS_INTRO`, and every fade after that is a table of DMG register bytes
-##   reordering those four colours. `WipeAttrmap` leaves every tile on palette 0,
-##   so the whole movie is one background palette at a time.
-## - **`hLCDCPointer` is `$42`, which is LOW(rSCY).** Crystal's movie gives each
-##   scanline its own `hSCX`; this one gives each its own `hSCY`, which is what
-##   makes the water wobble. [method scroll_y_at] is the seam.
-##
-## [Gen2GoldSilverIntroPage] turns all of it into pixels; nothing here draws.
+## `GoldSilverIntro`: the movie between the GameFreak logo and the title screen on
+## Gold and Silver. Seventeen scenes behind one jumptable, stepped once per
+## hardware frame, over three cutscenes. Crystal runs [Gen2IntroMovie] instead,
+## which is a different movie entirely. Two things are not that movie's shape: the
+## colour model is `DmgToCgbBGPals` rather than palette runs, so the whole movie is
+## one background palette at a time; and `hLCDCPointer` is LOW(rSCY) rather than
+## LOW(rSCX), which is what makes the water wobble, [method scroll_y_at] being the
+## seam. [Gen2GoldSilverIntroPage] turns all of it into pixels.
 
 ## `wBGPals1` and `wOBPals1`, of which this movie only ever fills the first
 ## background palette and the first two object ones.
@@ -114,15 +101,12 @@ const STARTERS: Dictionary = {
 }
 
 ## `Intro_InitBubble.pixel_table`, read `ld e, [hl] / inc hl / ld d, [hl]`, so
-## each row is (x, y) rather than the (y, x) every `depixel` in the file is.
-##
-## The index is `(wIntroFrameCounter1 & $70) swap 4`, which runs 0 to 7 over a
-## table of six: rows 6 and 7 are the first four bytes of `Intro_InitMagikarps`
-## read as coordinates. `depixel 8, 7, 0, 7` assembles to `ld de, $403f`, so
-## those bytes are $11 $3f $40 and then the `ldh a, [hSGB]` opcode $f0. The
-## counter opens at $80 and is decremented before the spawn, so 7 is the first
-## row the scene reaches and the two overread bubbles are the two the cartridge
-## shows first.
+## each row is (x, y) rather than the (y, x) every `depixel` in the file is. The
+## index runs 0 to 7 over a table of six: rows 6 and 7 are the first four bytes of
+## `Intro_InitMagikarps` read as coordinates, `depixel 8, 7, 0, 7` assembling to
+## `ld de, $403f`. The counter opens at $80 and is decremented before the spawn,
+## so 7 is the first row the scene reaches and the two overread bubbles are the
+## two the cartridge shows first.
 const BUBBLE_AT: Array[Vector2i] = [
 	Vector2i(6 * 8, 14 * 8 + 4), Vector2i(14 * 8, 18 * 8 + 4),
 	Vector2i(10 * 8, 16 * 8 + 4), Vector2i(12 * 8, 15 * 8),

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -2,18 +2,13 @@ class_name Gen2HallOfFame
 extends RefCounted
 
 ## The induction sequence `halloffame` asks for, as pages a screen can draw.
-##
-## `engine/events/halloffame.asm`'s AnimateHallOfFame walks the party built by
-## GetHallOfFameParty, showing one panel per Pokémon and then the player's own,
-## so the order and the contents here are that routine's, not a choice.
-## `HOF_AnimatePlayerPic` ends on `farcall ProfOaksPCRating`, whose two texts
-## print into the empty box that panel opens under itself, so the player's panel
-## is answered once per box rather than once.
-##
-## What this does not carry is what the project has no source for. The panel's
-## `<ID>№/` line needs the mon's OT ID, which the save does keep; the player's
-## panel additionally wants the trainer ID and PLAY TIME, which the save model
-## has neither of, so those lines are absent rather than drawn as zeros.
+## `AnimateHallOfFame` walks the party built by `GetHallOfFameParty`, showing one
+## panel per Pokemon and then the player's own, so the order and the contents are
+## that routine's. `HOF_AnimatePlayerPic` ends on `farcall ProfOaksPCRating`,
+## whose two texts print into the empty box that panel opens, so the player's
+## panel is answered once per box. The player's panel wants a trainer ID and PLAY
+## TIME the save model has neither of, so those lines are absent rather than drawn
+## as zeros.
 
 ## GetHallOfFameParty's own cap: it copies at most a full party and stops on the
 ## -1 terminator.

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -2,20 +2,13 @@ class_name Gen2HallOfFameScreen
 extends Control
 
 ## The screen behind `halloffame`, embedded in the overworld the way the PC and
-## the mart overlays are.
-##
-## `engine/events/halloffame.asm`'s HallOfFame saves, walks the party one panel
-## at a time and then shows the player's own with `ProfOaksPCRating` printed into
-## it, and finally runs the credits. What is here is that walk, advanced by A.
-## The credits, the backpic and frontpic slides and the palette rotations are
-## not.
-##
-## `_HallOfFamePC` reuses the same walk over a stored record ([member viewer]);
-## the record itself is [member Gen2SaveData.hall_of_fame].
-##
-## The source pauses 60 frames per panel and moves on by itself. This waits for
-## a key instead: there is no animation to watch yet, so a timer would only be a
-## delay.
+## the mart overlays are. `HallOfFame` saves, walks the party one panel at a time
+## and then shows the player's own with `ProfOaksPCRating` printed into it. What
+## is here is that walk, advanced by A; the credits, the two pic slides and the
+## palette rotations are not. `_HallOfFamePC` reuses the same walk over a stored
+## record. The source pauses 60 frames per panel and moves on by itself; this
+## waits for a key instead, since there is no animation to watch yet and a timer
+## would only be a delay.
 
 signal closed()
 

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -2,21 +2,13 @@ class_name Gen2IntroMovie
 extends RefCounted
 
 ## `CrystalIntro` (engine/movie/intro.asm): the movie between the GameFreak logo
-## and the title screen.
-##
-## Twenty-eight scenes behind one jumptable, stepped once per hardware frame.
-## Half of them are setup: they load a graphics sheet, a 32x32 BG map and its
-## attribute plane, copy a palette run into `wBGPals1` and `wBGPals2`, and call
-## `NextIntroScene`. The other half animate for a fixed number of frames by
-## writing the palettes, `hSCX`, `hSCY`, `wLYOverrides` and a handful of sprite
-## animation structs, then hand on.
-##
-## This owns all of that state; [Gen2IntroMoviePage] turns it into pixels. The
-## split is the credits': a per-frame jumptable, a tilemap the state machine
-## owns, and a page that only turns tile numbers into colours.
-##
-## Crystal only. Gold and Silver's `GoldSilverIntro` is a different movie and is
-## not built.
+## and the title screen. Twenty-eight scenes behind one jumptable, stepped once
+## per hardware frame. Half of them are setup, loading a sheet, a 32x32 BG map and
+## its attribute plane and a palette run; the other half animate for a fixed
+## number of frames by writing the palettes, `hSCX`, `hSCY`, `wLYOverrides` and a
+## handful of sprite animation structs. This owns all of that state and
+## [Gen2IntroMoviePage] turns it into pixels, the same split the credits use.
+## Crystal only: `GoldSilverIntro` is a different movie.
 
 ## `wBGPals2` and the `wOBPals2` behind it, which is what the screen shows.
 ##
@@ -148,13 +140,11 @@ const UNOWN_SOUNDS: Array[Array] = [
 
 ## What each setup scene loads, keyed by its scene index. `bg` is the sheet BG
 ## tile numbers below $80 read from, `bg_first` how far into it that half starts,
-## and `bg_high` the sheet $80 and up reads from; `obj` is the sheet a sprite
-## tile reads from and `obj_bank1` the one an `OAM_BANK1` sprite does. `map` and
-## `attr` name the 32x32 BG maps.
-##
-## The names are `RomLayout.INTRO_SECTION`'s. A missing key keeps what the scene
-## before it left in that part of VRAM, which is what the source's own
-## `Intro_DecompressRequest2bpp_*` calls do.
+## and `bg_high` the sheet $80 and up reads from; `obj` is the sheet a sprite tile
+## reads from and `obj_bank1` the one an `OAM_BANK1` sprite does. `map` and `attr`
+## name the 32x32 BG maps. The names are `RomLayout.INTRO_SECTION`'s, and a missing
+## key keeps what the scene before it left in that part of VRAM, which is what the
+## source's own `Intro_DecompressRequest2bpp_*` calls do.
 const SCENE_VRAM: Dictionary = {
 	0: {
 		"bg": "unowns", "map": "unown_a_map", "attr": "unown_a_attr", "obj": "pulse",
@@ -233,14 +223,12 @@ const CLEAR_BG_PALS_FRAMES: int = 2
 ## counter being frozen for the whole of its span.
 const SETUP_OVERRUN_KEY: int = -1
 ## Frames a pass costs over the one the loop would spend, keyed by scene and then
-## by `wIntroSceneFrameCounter` at the top of that pass.
-##
-## The cause is `Decompress`, the sprite pass and `Intro_ColoredSuicuneFrameSwap`
-## costing more CPU than a frame has left, so the `DelayFrame` the loop ends on
-## lands a frame late. Measured against a real dump under `.claude/oracle` rather
-## than derived, because nothing here counts cycles: with it the movie's own
-## `wJumptableIndex` and counter agree with the cartridge's on all 2,441 frames,
-## and without it the port ends 101 frames early.
+## by `wIntroSceneFrameCounter` at the top of that pass. The cause is `Decompress`,
+## the sprite pass and `Intro_ColoredSuicuneFrameSwap` costing more CPU than a
+## frame has left, so the `DelayFrame` the loop ends on lands a frame late.
+## Measured against a real dump under `.claude/oracle` rather than derived: with it
+## the movie's own `wJumptableIndex` and counter agree with the cartridge's on all
+## 2,441 frames, and without it the port ends 101 frames early.
 const SCENE_OVERRUN: Dictionary = {
 	# Each setup scene, over its `Intro_ClearBGPals`, `ClearTilemap` and
 	# `Request2bpp` waits.

--- a/game/world/intro_presentation.gd
+++ b/game/world/intro_presentation.gd
@@ -2,14 +2,13 @@ class_name Gen2IntroPresentation
 extends RefCounted
 
 ## The intro's own per-frame animation: `home/fade.asm`'s palette fades,
-## `Intro_RotatePalettesLeftFrontpic`, `Intro_WipeInFrontpic` and
-## `MovePlayerPic`, queued as steps a screen advances one VBlank at a time.
-##
-## A palette step is a DMG palette byte, not a rotation: `CopyPals` reads it two
-## bits at a time and writes the loaded colour each pair names, so a fade is an
-## index remap of the palette already loaded ([method apply_bgp]). Every count is
-## a `DelayFrames` operand, so a screen stepping this on
-## [Gen2WorldAnimation.FrameClock] spends the frames the cartridge spends.
+## `Intro_RotatePalettesLeftFrontpic`, `Intro_WipeInFrontpic` and `MovePlayerPic`,
+## queued as steps a screen advances one VBlank at a time. A palette step is a DMG
+## palette byte rather than a rotation: `CopyPals` reads it two bits at a time and
+## writes the loaded colour each pair names, so a fade is an index remap of the
+## palette already loaded. Every count is a `DelayFrames` operand, so a screen
+## stepping this on [Gen2WorldAnimation.FrameClock] spends the frames the cartridge
+## spends.
 
 ## A step that writes no palette byte, or that does not move the pic.
 const KEEP: int = -1

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -3,13 +3,9 @@ extends Control
 
 ## `engine/menus/intro_menu.asm`'s `NewGame`, less the title screen that reaches
 ## it: `PlayerProfileSetup`'s gender question, then `OakSpeech`, then the world.
-##
-## It is its own screen rather than a state of the overworld because that is
-## where the cartridge puts it: `NewGame` reaches `InitializeWorld` only after
-## both have returned, so there is no world to be a state of yet.
-##
-## Nothing is written to disk until the run is over. The launcher stages a slot
-## and a label on [GameRuntime], this adds the trainer name and the gender, and
+## Its own screen rather than a state of the overworld because that is where the
+## cartridge puts it: `NewGame` reaches `InitializeWorld` only after both have
+## returned. Nothing is written to disk until the run is over, so
 ## `Gen2SaveStore.create_new_game` is called once, at the end. That is also why
 ## `Gen2SaveValidator`'s rule that a save has a trainer needs no exception: the
 ## save does not exist until there is one.

--- a/game/world/link_screen.gd
+++ b/game/world/link_screen.gd
@@ -2,17 +2,13 @@ class_name Gen2LinkScreen
 extends Control
 
 ## `LinkCommunications` from the console the player used to the moment the room
-## lets them go: the trade screen's own two-list menu (`InitTradeMenuDisplay`
-## and `LinkTradeMenu`) and `_DisplayLinkRecord`'s one page.
-##
-## Embedded in the overworld the way the Hall of Fame viewer and BILL'S PC are.
-## The cable is [Gen2LinkTransport] and the commit is
-## [method Gen2WorldPartyHost.commit_link_trade]; this screen owns the cursor,
-## the boxes and the order they are shown in, and nothing else.
-##
-## The Colosseum is not here: `Colosseum` runs the same `LinkCommunications`
-## opening and then a battle, which the world screen already opens through its
-## own battle host.
+## lets them go: the trade screen's own two-list menu and `_DisplayLinkRecord`'s
+## one page. Embedded in the overworld the way the Hall of Fame viewer and BILL'S
+## PC are. The cable is [Gen2LinkTransport] and the commit is
+## [method Gen2WorldPartyHost.commit_link_trade]; this screen owns the cursor, the
+## boxes and the order they are shown in, and nothing else. The Colosseum is not
+## here: `Colosseum` runs the same opening and then a battle, which the world
+## screen already opens through its own battle host.
 
 signal closed()
 ## `LinkMonStatsScreen`, which the overworld opens over this the way the party

--- a/game/world/link_session.gd
+++ b/game/world/link_session.gd
@@ -5,13 +5,9 @@ extends RefCounted
 ## it: `wLinkMode`, `wPlayerLinkAction`, `wChosenCableClubRoom` and
 ## `wOtherPlayerLinkMode`, plus the answers `WaitForLinkedFriend`,
 ## `CheckLinkTimeout_Receptionist`, `CheckBothSelectedSameRoom`,
-## `CheckTimeCapsuleCompatibility`, `ValidateOTTrademon` and
-## `CheckAnyOtherAliveMonsForTrade` give from them.
-##
-## Scene free, and WRAM rather than save data: the cartridge keeps none of this
-## across a reset, and neither does [Gen2WorldState], which holds one live and
-## leaves it out of its snapshot. The cable itself is [Gen2LinkTransport], which
-## is injected; nothing here knows what it is made of.
+## `CheckTimeCapsuleCompatibility` and `ValidateOTTrademon` give from them. Scene
+## free, and WRAM rather than save data: the cartridge keeps none of this across a
+## reset and neither does [Gen2WorldState]. The cable itself is injected.
 
 const CONNECTION_NOT_ESTABLISHED: int = Gen2LinkTransport.CONNECTION_NOT_ESTABLISHED
 const USING_EXTERNAL_CLOCK: int = Gen2LinkTransport.USING_EXTERNAL_CLOCK
@@ -229,15 +225,12 @@ static func _incompatible(value: int, slot: int, species: int, move: int) -> Dic
 
 ## `ValidateOTTrademon`: the offered Pokemon's own species must match the row the
 ## party list names it by, unless that row says EGG, and its level must be one a
-## level can be. The Time Capsule adds a third test, and it is the only one that
-## needs the peer to say anything about itself: a Gen 1 game reports the typing
-## it holds for the species, and one whose typing this generation changed is
-## refused. Magnemite and Magneton are excused by name because theirs is that
-## change.
-##
-## [param mon] carries `types` only when the peer is a Gen 1 game, which is the
-## only sender `Link_ConvertPartyStruct1to2` fills `wLinkOTPartyMonTypes` from,
-## so a Gen 2 peer skips the test rather than failing an empty one.
+## level can be. The Time Capsule adds a third test, the only one that needs the
+## peer to say anything about itself: a Gen 1 game reports the typing it holds,
+## and one whose typing this generation changed is refused, Magnemite and Magneton
+## being excused by name because theirs is that change. [param mon] carries `types`
+## only when the peer is a Gen 1 game, so a Gen 2 peer skips the test rather than
+## failing an empty one.
 static func validate_ot_trademon(
 	mon: Dictionary, listed_species: int, listed_is_egg: bool, mode: int,
 	base_types: Array = []

--- a/game/world/link_transport.gd
+++ b/game/world/link_transport.gd
@@ -1,24 +1,14 @@
 class_name Gen2LinkTransport
 extends RefCounted
 
-## The cable, as the only thing above it needs it to be.
-##
-## `home/serial.asm` and `engine/link/link.asm` reach the other Game Boy through
-## exactly three operations, and every routine the cable club runs is built from
-## them: read `hSerialConnectionStatus`, exchange one byte with `Link_EnsureSync`
-## or `Serial_PlaceWaitingTextAndSyncAndExchangeNybble`, and exchange a block
-## with `Serial_ExchangeBytes`. There is no cable on a modern platform, so this
-## project chooses the transport, and this class is that choice: the three
-## operations, and nothing about wires, timing or bit order.
-##
-## Scene free, and injected the way randomness is. A transport with no peer is
-## the honest default and a real game path rather than a stub: `WaitForLinkedFriend`
-## times out and the receptionist says the friend is not ready, which is what
-## the cartridge does with one Game Boy.
-##
-## The one peer that exists today is another of this player's own save slots,
-## which [method peer_from_save] builds. A network transport subclasses this and
-## overrides the three operations; nothing above changes.
+## The cable, as the only thing above it needs it to be. `home/serial.asm` reaches
+## the other Game Boy through exactly three operations and every routine the cable
+## club runs is built from them: read `hSerialConnectionStatus`, exchange one byte,
+## and exchange a block. There is no cable on a modern platform, so this class is
+## the three operations and nothing about wires, timing or bit order. Scene free
+## and injected: a transport with no peer is the honest default and a real game
+## path, since `WaitForLinkedFriend` times out. The one peer today is another of
+## this player's slots; a network transport overrides the three operations.
 
 ## constants/serial_constants.asm. `CONNECTION_NOT_ESTABLISHED` is what
 ## `Link_ResetSerialRegistersAfterLinkClosure` writes back.

--- a/game/world/mail_screen.gd
+++ b/game/world/mail_screen.gd
@@ -1,17 +1,13 @@
 class_name Gen2MailScreen
 extends Control
 
-## `ReadAnyMail` (`engine/pokemon/mail_2.asm`), embedded the way the Hall of
-## Fame viewer is.
-##
-## The routine loads the type's own graphics, prints the message and the author
-## over them, and then does nothing but wait: `.loop` reads A, B and START and
-## returns on any of the first two. [Gen2MailPage] owns the picture; this is the
-## node between it and the buttons.
-##
+## `ReadAnyMail` (`engine/pokemon/mail_2.asm`), embedded the way the Hall of Fame
+## viewer is. The routine loads the type's own graphics, prints the message and
+## the author over them, and then does nothing but wait: `.loop` reads A, B and
+## START and returns on any of the first two. [Gen2MailPage] owns the picture.
 ## START is `PrintMailAndExit`, the Game Boy Printer, which this project has no
-## transport for. It is answered as a press that does nothing rather than left
-## to fall through to whatever is behind the screen.
+## transport for: it is answered as a press that does nothing rather than left to
+## fall through to whatever is behind the screen.
 
 signal closed()
 

--- a/game/world/mod_page_screen.gd
+++ b/game/world/mod_page_screen.gd
@@ -1,20 +1,14 @@
 class_name Gen2ModPageScreen
 extends Control
 
-## The one screen a mod may put behind a start-menu row
-## ([constant Gen2ModHost.START_ACTION_OPEN_MOD_PAGE]), embedded in the overworld
-## the way the trainer card and the Hall of Fame are.
-##
-## A record of what a run has done is what the cartridge's own trainer card is,
-## and this is drawn the same way: the screen's own frame and font, paged with
-## the d-pad and left with B. The mod supplies rows and nothing else, so it needs
-## no node, no renderer and no art; the icons are
-## [method Gen2MapNameSignPage.render_notice_icon]'s vocabulary, which is the one
-## an actor and a battle annotation already share.
-##
-## A locked row is drawn the way the Pokedex draws an unseen entry: the label is
-## replaced by `?`, which is what `PrintDexEntry`'s unseen branch does, and its
-## icon is left off.
+## The one screen a mod may put behind a start-menu row, embedded in the overworld
+## the way the trainer card and the Hall of Fame are. A record of what a run has
+## done is what the cartridge's own trainer card is, and this is drawn the same
+## way: the screen's own frame and font, paged with the d-pad and left with B. The
+## mod supplies rows and nothing else, and the icons are
+## [method Gen2MapNameSignPage.render_notice_icon]'s vocabulary. A locked row is
+## drawn the way the Pokedex draws an unseen entry, its label replaced by `?` and
+## its icon left off.
 
 signal closed()
 

--- a/game/world/move_deleter_screen.gd
+++ b/game/world/move_deleter_screen.gd
@@ -2,15 +2,11 @@ class_name Gen2MoveDeleterScreen
 extends Control
 
 ## `MoveDeletion` (`engine/events/move_deleter.asm`) on the overworld's own pump.
-##
 ## The same shape as [Gen2NameRaterScreen] and for the same reason: the routine
-## owns its boxes, its two `YesNoBox`es and the two screens it opens, and the
-## map script's own `waitbutton` is what dismisses the text `PrintText` left
-## standing, so the ending is handed back rather than pressed here.
-##
-## `ChooseMoveToDelete` is `MoveScreenLoop`'s own screen with
-## `DeleteMoveScreen2DMenuData` in front of it, so the list is [Gen2MoveScreen]
-## in its deletion mode and the picture is [Gen2MoveScreenPage].
+## owns its boxes, its two `YesNoBox`es and the two screens it opens, and the map
+## script's own `waitbutton` is what dismisses the text `PrintText` left standing,
+## so the ending is handed back rather than pressed here. `ChooseMoveToDelete` is
+## `MoveScreenLoop`'s own screen with `DeleteMoveScreen2DMenuData` in front of it.
 
 signal finished(party_index: int, move_index: int, ending_text: String)
 signal closed()

--- a/game/world/move_tutor_screen.gd
+++ b/game/world/move_tutor_screen.gd
@@ -1,16 +1,13 @@
 class_name Gen2MoveTutorScreen
 extends Control
 
-## `MoveTutor` (`engine/events/move_tutor.asm`) on the overworld's own pump.
-##
-## The same shape as [Gen2MoveDeleterScreen]: the routine owns the party list
+## `MoveTutor` (`engine/events/move_tutor.asm`) on the overworld's own pump. The
+## same shape as [Gen2MoveDeleterScreen]: the routine owns the party list
 ## `ChooseMonToLearnTMHM` opens, its refusals and the `ForgetMove` menu behind
 ## `LearnMove`, and the map script's own `waitbutton` presses the box it leaves
-## standing.
-##
-## The `.loop` is the whole of it. `.didnt_learn` returns carry clear and the
-## routine reopens the list, so every refusal comes back to the party list and
-## only a learned move or a backed-out list ends the special.
+## standing. The `.loop` is the whole of it: `.didnt_learn` returns carry clear and
+## the routine reopens the list, so only a learned move or a backed-out list ends
+## the special.
 
 signal finished(script_value: int, party_index: int, ending_text: String)
 signal closed()

--- a/game/world/mystery_gift.gd
+++ b/game/world/mystery_gift.gd
@@ -1,19 +1,13 @@
 class_name Gen2MysteryGift
 extends RefCounted
 
-## `engine/link/mystery_gift.asm` and `mystery_gift_2.asm`: the SRAM block, the
-## staged block the two Game Boys swap over IR, and `DoMysteryGift`'s own chain
-## of refusals between the exchange and the gift.
-##
-## Mystery Gift is not the cable link play [Gen2LinkSession] runs. It never
+## `engine/link/mystery_gift.asm`: the SRAM block, the staged block the two Game
+## Boys swap over IR, and `DoMysteryGift`'s own chain of refusals between the
+## exchange and the gift. Not the cable link play [Gen2LinkSession] runs: it never
 ## touches `wLinkMode`, it has its own `sMysteryGiftData` section outside the
-## checksummed save, and its peer is an infrared window rather than a wire, so
-## the transport is its own too ([Gen2MysteryGiftTransport]).
-##
-## Everything here is the section and the decision. The pixels are
-## [Gen2MysteryGiftPage] and the host is [Gen2MysteryGiftScreen]; the three
-## specials that reach the section from a script are
-## [Gen2WorldScriptRunner]'s.
+## checksummed save, and its peer is an infrared window rather than a wire, so the
+## transport is its own too. Everything here is the section and the decision; the
+## pixels are [Gen2MysteryGiftPage] and the host is [Gen2MysteryGiftScreen].
 
 ## `constants/serial_constants.asm`. Five gifts in a day, and one per person.
 const MAX_PARTNERS: int = 5
@@ -282,17 +276,13 @@ static func _rotated_bit(count: int) -> int:
 
 
 ## `DoMysteryGift` from the exchange down: every refusal in the routine's own
-## order, and the gift behind the last of them.
-##
-## The section is written in place, which is what the cartridge does to SRAM
-## between one box and the next: the partner ID is added and the trainer name
-## saved before the gift is chosen, so a partner who offers a decoration this
-## side already owns still counts against both daily limits.
-##
-## Answers `{ outcome, name, item, deco, retry }`. `outcome` names one of the
-## eight `text_far` stubs, `name` is what the box's `<PLAYER>`-style buffer
-## holds, and `retry` is `.CommunicationError`'s own `jp DoMysteryGift`: the
-## routine goes back to the prompt rather than leaving the screen.
+## order, and the gift behind the last of them. The section is written in place,
+## which is what the cartridge does to SRAM between one box and the next: the
+## partner ID is added and the trainer name saved before the gift is chosen, so a
+## partner who offers a decoration this side already owns still counts against
+## both daily limits. Answers `{ outcome, name, item, deco, retry }`, where
+## `outcome` names one of the eight `text_far` stubs and `retry` is
+## `.CommunicationError`'s own `jp DoMysteryGift`.
 static func exchange(
 	section: Dictionary, transport: Gen2MysteryGiftTransport,
 	player: Dictionary, tables: Dictionary, data: GameData = null

--- a/game/world/mystery_gift_screen.gd
+++ b/game/world/mystery_gift_screen.gd
@@ -1,21 +1,13 @@
 class_name Gen2MysteryGiftScreen
 extends Control
 
-## `DoMysteryGift` (`engine/link/mystery_gift.asm`), from the prompt the screen
-## opens on to the box it ends on.
-##
+## `DoMysteryGift`, from the prompt the screen opens on to the box it ends on.
 ## The routine is three steps and no menu: the layout with
 ## `.String_PressAToLink_BToCancel` under it, A to hold the infrared window open
 ## and B to leave it, and then one box. Everything the box could say is
-## [method Gen2MysteryGift.exchange]'s answer, so this screen owns the wait, the
-## two buttons and the picture; the decision is not here and neither is the
-## section.
-##
-## It is the main menu's row rather than an overworld one, so its host is the
-## save screen: the section lives outside the checksummed save on the cartridge
-## precisely so the exchange can happen with no file loaded, and the two slots
-## the save screen already has in front of it are the only two Mystery Gift
-## blocks that exist on one machine.
+## [method Gen2MysteryGift.exchange]'s answer. It is the main menu's row rather
+## than an overworld one, so its host is the save screen: the section lives outside
+## the checksummed save precisely so the exchange can happen with no file loaded.
 
 signal closed()
 

--- a/game/world/mystery_gift_transport.gd
+++ b/game/world/mystery_gift_transport.gd
@@ -2,22 +2,13 @@ class_name Gen2MysteryGiftTransport
 extends RefCounted
 
 ## The infrared window, as the only thing above it needs it to be.
-##
-## `ExchangeMysteryGiftData` reaches the other Game Boy through rRP rather than
-## through the cable, and what it does with it comes down to three things:
-## whether a partner is in the window at all, which of the two ends is the
-## sender, and one twenty-byte block swapped both ways. There is no infrared
-## port on a modern platform, so this project chooses the transport, and this
-## class is that choice.
-##
-## Scene free and injected, the way [Gen2LinkTransport] is. A window with
-## nobody in it is the honest default and a real game path rather than a stub:
-## the exchange times out, `hMGStatusFlags` comes back `MG_TIMED_OUT` and
-## `DoMysteryGift` prints its own communication-error box.
-##
-## The one partner that exists today is another of this player's own save
-## slots, which [method peer_from_save] builds. A network transport subclasses
-## this and overrides [method peer_block]; nothing above changes.
+## `ExchangeMysteryGiftData` reaches the other Game Boy through rRP, and what it
+## does with it comes down to three things: whether a partner is in the window,
+## which end is the sender, and one twenty-byte block swapped both ways. Scene
+## free and injected, the way [Gen2LinkTransport] is: a window with nobody in it
+## is the honest default and a real game path, since the exchange times out and
+## `DoMysteryGift` prints its own communication-error box. The one partner today
+## is another of this player's own slots.
 
 ## `hMGRole`. The side that holds the window open first is the receiver, which
 ## is what `InitializeIRCommunicationRoles` settles between two real Game Boys.

--- a/game/world/name_rater.gd
+++ b/game/world/name_rater.gd
@@ -1,16 +1,13 @@
 class_name Gen2NameRater
 extends RefCounted
 
-## `engine/events/name_rater.asm`, the rules half.
-##
-## `_NameRater` is a straight line of text, question, party selection, text and
-## naming screen; what needs a reading rather than a screen is which of its five
-## endings a chosen party member reaches, and the three routines beside it that
-## decide the last one. [Gen2NameRaterScreen] is the routine itself, on the
-## overworld's own pump; this holds nothing and answers questions.
-##
-## Every string is the cartridge's, read through [method GameData.name_rater_text]
-## off the ten `text_far` stubs `RomLayout.NAME_RATER_TEXT_ORDER` pins.
+## `engine/events/name_rater.asm`, the rules half. `_NameRater` is a straight line
+## of text, question, party selection, text and naming screen; what needs a reading
+## rather than a screen is which of its five endings a chosen party member reaches,
+## and the three routines beside it that decide the last one.
+## [Gen2NameRaterScreen] is the routine itself, on the overworld's own pump; this
+## holds nothing and answers questions. Every string is the cartridge's, off the
+## ten `text_far` stubs `RomLayout.NAME_RATER_TEXT_ORDER` pins.
 
 ## `MON_NAME_LENGTH - 1`: how many characters a nickname holds before its `@`.
 const NICKNAME_LENGTH: int = 10

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -1,18 +1,13 @@
 class_name Gen2NameRaterScreen
 extends Control
 
-## `_NameRater` (`engine/events/name_rater.asm`) on the overworld's own pump.
-##
-## The routine is a straight line: an introduction and a `YesNoBox`, the party
-## list `SelectMonFromParty` opens, three endings that need no new name, a second
+## `_NameRater` (`engine/events/name_rater.asm`) on the overworld's own pump. The
+## routine is a straight line: an introduction and a `YesNoBox`, the party list
+## `SelectMonFromParty` opens, three endings that need no new name, a second
 ## `YesNoBox`, `_NamingScreen`, and `.done`'s own text. [Gen2NameRater] answers
-## which ending a member reaches; this owns the boxes, the presses and the two
-## screens it opens over itself.
-##
-## The last text is deliberately not pressed here. `special NameRater` returns
-## the moment `PrintText` has drawn it and the map script's own `waitbutton` is
-## what dismisses it, so the ending text is handed to the caller through
-## [signal finished] and stands in the world's speech box for that one press.
+## which ending a member reaches; this owns the boxes and the presses. The last
+## text is deliberately not pressed here: `special NameRater` returns the moment
+## `PrintText` has drawn it and the map script's own `waitbutton` dismisses it.
 
 ## The chosen nickname, if the routine wrote one, and the text `.done` ends on.
 ## [param party_index] is -1 for every ending that renames nothing.

--- a/game/world/naming_screen.gd
+++ b/game/world/naming_screen.gd
@@ -2,12 +2,9 @@ class_name Gen2NamingScreen
 extends RefCounted
 
 ## `engine/menus/naming_screen.asm`'s model: which keyboard is live, where the
-## cursor is, what a press does to the name being typed and what comes out at
-## the end.
-##
-## Scene-free, so the whole walk can be tested without drawing it.
-## `Gen2NamingScreenPage` draws what this holds. The name is kept as the
-## cartridge keeps it, a fixed buffer of raw codes seeded with
+## cursor is, what a press does to the name being typed and what comes out at the
+## end. Scene-free, so the whole walk can be tested without drawing it. The name is
+## kept as the cartridge keeps it, a fixed buffer of raw codes seeded with
 ## NAMINGSCREEN_UNDERLINE and NAMINGSCREEN_MIDDLELINE rather than a String,
 ## because every routine here reads and writes those two markers.
 

--- a/game/world/nickname_prompt_screen.gd
+++ b/game/world/nickname_prompt_screen.gd
@@ -3,13 +3,11 @@ extends Control
 
 ## `GiveANickname_YesNo`, `InitNickname` and the `WasSentToBillsPCText` behind
 ## them, for a Pokemon that was received rather than hatched: `GivePoke`'s
-## `.wildmon` branch and, through it, every `givepoke` that names no OT.
-##
-## Text only, because the routine draws nothing else: it stands over whatever
-## screen the caller left up, which on the overworld is the map with a textbox
-## on it. [Gen2EggHatchScreen] keeps its own copy of the same pair rather than
-## opening this one, since its question is `_BreedAskNicknameText` and its box
-## stands over its own animation backdrop.
+## `.wildmon` branch and every `givepoke` that names no OT. Text only, because the
+## routine draws nothing else: it stands over whatever screen the caller left up.
+## [Gen2EggHatchScreen] keeps its own copy of the same pair rather than opening
+## this one, since its question is `_BreedAskNicknameText` and its box stands over
+## its own animation backdrop.
 
 ## The nickname the player settled on, emitted once, before [signal closed].
 signal named(nickname: String)

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -2,17 +2,12 @@ class_name Gen2OakSpeechScreen
 extends Control
 
 ## `OakSpeech` drawn: a pic above the standard text box, advanced with A, with
-## `NamePlayer`'s menu and keyboard where the source puts them.
-##
-## The routine is a run of `PrintText` calls separated by palette fades and
-## `ClearTilemap`, so this screen is a run of beats separated by
-## [Gen2IntroPresentation] queues. Nothing here waits a number of frames it
-## chose: every count is a `DelayFrames` operand, and a fade is the source's own
-## palette-byte remap applied to each palette on screen.
-##
-## Oak and the speech species use the ordinary imported pic tables. Gold and
-## Silver use CAL's trainer pic for the player; Crystal uses the imported raw
-## ChrisPic or KrisPic.
+## `NamePlayer`'s menu and keyboard where the source puts them. The routine is a
+## run of `PrintText` calls separated by palette fades and `ClearTilemap`, so this
+## screen is a run of beats separated by [Gen2IntroPresentation] queues. Nothing
+## here waits a number of frames it chose: every count is a `DelayFrames` operand.
+## Oak and the speech species use the ordinary imported pic tables; Gold and Silver
+## use CAL's trainer pic for the player and Crystal the imported raw ChrisPic.
 
 ## Carries the name the intro settled on, already through `InitName`'s default.
 signal finished(player_name: String)

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -486,15 +486,14 @@ func entry() -> Dictionary:
 	}
 
 
-## `_PrintNum` (engine/math/print_num.asm) for this screen's two calls:
-## [param digits] digits with [param before_point] before a decimal point, and
-## neither the money nor the leading-zero flag set. A leading zero is neither
-## printed nor replaced, `.PrintLeadingZero` writing nothing while the flag is
-## clear and `.AdvancePointer` stepping over the cell anyway, which is why this
-## answers a fixed-width field of spaces rather than a trimmed number.
-##
-## The digit in front of the point always prints, zero or not: `.PrintDigit`
-## latches as `e` runs out, which makes a height of 8 read 0'08" not blank.
+## `_PrintNum` for this screen's two calls: [param digits] digits with
+## [param before_point] before a decimal point, and neither the money nor the
+## leading-zero flag set. A leading zero is neither printed nor replaced,
+## `.PrintLeadingZero` writing nothing while the flag is clear and
+## `.AdvancePointer` stepping over the cell anyway, which is why this answers a
+## fixed-width field of spaces rather than a trimmed number. The digit in front of
+## the point always prints: `.PrintDigit` latches as `e` runs out, which makes a
+## height of 8 read 0'08" not blank.
 static func print_num(value: int, digits: int, before_point: int) -> String:
 	var text: String = ""
 	var padded: String = String.num_int64(maxi(value, 0)).lpad(digits, "0").right(digits)

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -1,21 +1,14 @@
 class_name Gen2PokedexScreen
 extends Control
 
-## The Pokedex (engine/pokedex/pokedex.asm), embedded in the overworld the way
-## the start menu and its own submenus are.
-##
-## Drawn on the hardware's own tile grid: [Gen2Pokedex] owns the listing, the
-## cursor and the mode, and [Gen2PokedexPage] the picture, the way the region map
-## and the trainer card are split. Every rule the screen obeys is the source's.
-##
-## All six of the source's states are here: the listing, the entry screen, the
-## OPTION screen, SEARCH, its results and the Unown dex. The OPTION screen draws
-## `.NoUnownModeArrowCursorData`'s three rows until the Ruins of Alph research
-## centre has set the flag, which is what the cartridge draws too.
-##
-## The entry screen's AREA is the exception to the panel above: `Pokedex_GetArea`
-## is the cartridge's own region map, so it opens [Gen2TownMapScreen], which
-## carries a hardware screen of its own.
+## The Pokedex (engine/pokedex/pokedex.asm), embedded in the overworld the way the
+## start menu and its own submenus are. Drawn on the hardware's own tile grid:
+## [Gen2Pokedex] owns the listing, the cursor and the mode and [Gen2PokedexPage]
+## the picture. All six of the source's states are here, and the OPTION screen
+## draws three rows until the Ruins of Alph research centre has set the flag. The
+## entry screen's AREA is the exception to that split: `Pokedex_GetArea` is the
+## cartridge's own region map, so it opens [Gen2TownMapScreen], which carries a
+## hardware screen of its own.
 
 ## Set by [method open_entry]: `NewPokedexEntry` has no listing behind it, so B
 ## on the entry closes the dex rather than going back to one.

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -2,16 +2,12 @@ class_name Gen2PokegearScreen
 extends Control
 
 ## The Pokegear's clock, phone and radio cards, embedded the way the MAP card is.
-##
 ## [Gen2TownMapPage] draws all four; this composes one of the three over a
 ## [Gen2Screen] and puts the two objects `InitPokegearTilemap` spawns on top: the
-## mode indicator arrow under the card icons, and the radio card's tuning knob.
-## The MAP card is [Gen2TownMapScreen], which owns the region map's own cursor,
-## player icon and landmark walk and is also the dex area and the fly map.
-##
-## Nothing here decides anything: the world owns the clock, the dial and the
-## contact list, so a press is reported and the host reopens the card with what
-## the world then says.
+## mode indicator arrow and the radio card's tuning knob. The MAP card is
+## [Gen2TownMapScreen], which owns the region map's own cursor, player icon and
+## landmark walk. Nothing here decides anything: the world owns the clock, the
+## dial and the contact list, so a press is reported and the host reopens the card.
 
 signal closed()
 ## Left or right, which is `Pokegear_SwitchPage` and is the host's to resolve:

--- a/game/world/radio_show.gd
+++ b/game/world/radio_show.gd
@@ -2,19 +2,13 @@ class_name Gen2RadioShow
 extends RefCounted
 
 ## `engine/pokegear/radio.asm`: the words a tuned station prints into the radio
-## card's text box, one line at a time.
-##
-## [Gen2WorldRadio] is the dial, its availability rules and the music a station
-## commits. This is the layer above it: `RadioJumptable`, dispatched once a
-## hardware frame the way `PlayRadioShow` is, with `PrintRadioLine`,
-## `NextRadioLine` and `RadioScroll` as the whole of its output.
-##
-## Scene-free and injected with its own generator, like the rest of the world:
-## a caller hands it the facts the source reads off WRAM and spends frames.
-##
-## Segments are named after the source's own labels rather than numbered,
-## because the numbers are profile split: Gold and Silver ship no Buena's
-## Password, so every segment past `$04` in their jumptable sits fifteen lower.
+## card's text box, one line at a time. [Gen2WorldRadio] is the dial, its
+## availability rules and the music a station commits; this is `RadioJumptable`,
+## dispatched once a hardware frame the way `PlayRadioShow` is. Scene-free and
+## injected with its own generator: a caller hands it the facts the source reads
+## off WRAM and spends frames. Segments are named after the source's own labels
+## rather than numbered, because the numbers are profile split: Gold and Silver
+## ship no Buena's Password, so every segment past `$04` sits fifteen lower.
 
 ## `wCurRadioLine`'s own RADIO_SCROLL entry, which every printing segment leaves
 ## behind it.

--- a/game/world/slot_machine.gd
+++ b/game/world/slot_machine.gd
@@ -1,38 +1,14 @@
 class_name Gen2SlotMachine
 extends RefCounted
 
-## `_SlotMachine`'s own state (engine/games/slot_machine.asm), node-free.
-##
-## [Gen2SlotMachinePage] owns the picture and [Gen2SlotMachineScreen] the pump;
-## this is `SlotsLoop`: one pass a frame, `SlotsJumptable` then
-## `Slots_SpinReels` then the two sprite objects, with the reels' own
-## `ReelActionJumptable` under them.
-##
-## Five things the source states that a reading gets wrong:
-##
-## - **A reel is manipulated after the button, not before.** `Slots_StopReel1`
-##   through `..._StopReel3` pick an action rather than a stop, and the action
-##   walks the reel on up to `REEL_MANIP_COUNTER` further slots looking for the
-##   biased symbol. The bias is rolled once a bet in `Slots_InitBias` and is
-##   what decides the spin; the button decides when the search starts.
-## - **`Slots_InitBias` keeps a seven.** Its first two lines are
-##   `ld a, [wSlotBias] / and a / ret z`, and SLOTS_SEVEN is zero, so a spin
-##   that left the bias on seven rolls nothing and stays there.
-##   `Slots_PayoutText.LinedUpSevens` is what clears it, on a roll whose odds
-##   `wKeepSevenBiasChance` picked at the top of the game.
-## - **Golem, Chansey and the slow advance are searches, not decorations.**
-##   Each is entered only when the third reel is standing on a match it must not
-##   keep, and each advances the reel until `Slots_CheckMatchedAllThreeReels`
-##   answers what the bias wants. `Slots_GetNumberOfGolems` runs that search
-##   ahead of the animation and hands it the count.
-## - **A reel action runs once every sixteen units of spin distance**, not once
-##   a frame: `.SpinReel` tests `REEL_SPIN_DISTANCE and $f` before calling it,
-##   and a rate of 0 stops the reel where it stands without ending its action.
-## - **The three reel strips repeat their own first three symbols.** A window is
-##   three consecutive bytes from `(position - 1) and $f`, so nothing wraps.
-##
-## Randomness is injected: every `Random` here is a byte off the generator the
-## caller owns, so a seeded run repeats.
+## `_SlotMachine`'s own state (engine/games/slot_machine.asm), node-free, which is
+## `SlotsLoop`'s side of it. Five things a reading gets wrong: a reel is
+## manipulated after the button rather than before, the bias being rolled once a
+## bet and the button only deciding when the search starts; `Slots_InitBias` keeps
+## a seven, since SLOTS_SEVEN is zero and its `ret z` leaves it there; Golem,
+## Chansey and the slow advance are searches rather than decorations; a reel action
+## runs once every sixteen units of spin distance rather than once a frame; and the
+## three reel strips repeat their own first three symbols, so nothing wraps.
 
 ## `wSlotMatched` values, which are the reel strips' own bytes.
 const SLOTS_SEVEN: int = 0x00

--- a/game/world/slot_machine_screen.gd
+++ b/game/world/slot_machine_screen.gd
@@ -1,25 +1,14 @@
 class_name Gen2SlotMachineScreen
 extends Control
 
-## `_SlotMachine`'s own loop, on the overworld's pump.
-##
-## [Gen2SlotMachine] owns the rules and [Gen2SlotMachinePage] the picture; this
-## is `SlotsLoop`: one pass a frame, the boxes the machine asks for answered
-## where the cartridge's own blocking calls would have stood, and the exit
-## `SLOTS_END_LOOP_F` sets.
-##
-## Three things the loop states that a screen would otherwise get wrong:
-##
-## - **`Slots_AskBet` and `Slots_AskPlayAgain` spend frames inside an action.**
-##   `VerticalMenu` and `PlaceYesNoBox` do not return until the player answers,
-##   so nothing spins, no reel moves and no sprite is pumped while either is up.
-##   The machine answers `prompt()` for exactly that reason.
-## - **A press is answered where it lands as well as on the frame.** The host is
-##   press-only, and `hJoypadSum` is a sum rather than a sample: a tap between
-##   two frames stops a reel on the cartridge and has to here.
-## - **`WaitSFX` is the driver's, not a frame count.** The screen holds while
-##   the player it was handed reports an effect; a screen with no player waits
-##   nothing, which is what a headless driver and every test see.
+## `_SlotMachine`'s own loop, on the overworld's pump. [Gen2SlotMachine] owns the
+## rules and [Gen2SlotMachinePage] the picture; this is `SlotsLoop`, one pass a
+## frame. Three things a screen would otherwise get wrong: `Slots_AskBet` and
+## `Slots_AskPlayAgain` spend frames inside an action, so nothing spins while
+## either box is up, which is what `prompt()` is for; a press is answered where it
+## lands as well as on the frame, `hJoypadSum` being a sum rather than a sample;
+## and `WaitSFX` is the driver's rather than a frame count, so a screen with no
+## player waits nothing.
 
 signal closed(coins: int)
 signal sfx_requested(index: int, waited: bool)

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -1,24 +1,14 @@
 class_name Gen2SplashScreen
 extends Control
 
-## `SplashScreen` (`engine/movie/splash.asm`), as far as this project has the art
-## for it.
-##
-## The source runs four things before a new game: the copyright screen, the
-## GameFreak logo animation, the intro movie, and the title screen. The movie is
-## the cartridge's own: `CrystalIntro` through [Gen2IntroMoviePage] on Crystal
-## and `GoldSilverIntro` through [Gen2GoldSilverIntroPage] on the other two.
-## [Gen2BootCinema] is started with the phases this cache has art for; a phase it
-## has none for is skipped rather than held on a blank screen for the frames it
-## would have taken.
-##
-## The pacing is the source's throughout. The copyright half is ten frames of
-## blank and the screen for a hundred, with no button read at all, since
-## `DelayFrames` does not look at the joypad; the GameFreak half is
-## `GameFreakPresentsScene` and its sprite, which do read one, and a press there
-## ends the animation early through [method Gen2BootCinema.skip_presents]. The
-## title screen reads a held button rather than a press, because every branch of
-## `TitleScreenMain` is `hJoyDown`.
+## `SplashScreen`, as far as this project has the art for it: the copyright
+## screen, the GameFreak logo animation, the intro movie and the title screen.
+## [Gen2BootCinema] is started with the phases this cache has art for, and one it
+## has none for is skipped rather than held on a blank screen. The pacing is the
+## source's: the copyright half is ten frames of blank and the screen for a hundred
+## with no button read at all, the GameFreak half reads one and a press there ends
+## the animation early, and the title screen reads a held button because every
+## `TitleScreenMain` branch is `hJoyDown`.
 
 ## Emitted once the last phase this host can draw has finished.
 signal closed()

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -2,16 +2,12 @@ class_name Gen2StartMenuScreen
 extends Control
 
 ## The overworld pause menu (engine/menus/start_menu.asm). The list, `_Option`,
-## `SaveMenu` and every box the pack opens are the cartridge's own screens
-## through [Gen2StartMenuPage] and [Gen2PackPage], drawn into whichever
-## [Gen2Screen] the host hands over. A caller that hands over none keeps the
-## window-resolution panel below, which is what a launcher preview gets.
-##
-## Pokedex, Pokemon and Pokegear are screens the world already owns
-## (Gen2PokedexScreen, Gen2PartyScreen, the phone list on
-## Gen2WorldServiceScreen), so this only reports the choice through
-## [signal action_chosen]. Pack and Save live here as internal modes, the way
-## Gen2WorldServiceScreen owns a mart mode beside its menu mode.
+## `SaveMenu` and every box the pack opens are the cartridge's own screens through
+## [Gen2StartMenuPage] and [Gen2PackPage], drawn into whichever [Gen2Screen] the
+## host hands over; a caller that hands over none keeps the window-resolution
+## panel below. Pokedex, Pokemon and Pokegear are screens the world already owns,
+## so this only reports the choice through [signal action_chosen]. Pack and Save
+## live here as internal modes.
 
 ## Emitted for an available entry this screen does not own itself
 ## (Pokedex, Pokemon, Pokegear, Player); the caller opens the matching screen.
@@ -808,12 +804,10 @@ func _open_mods_mode() -> void:
 
 ## The rows the MODS entry shows: the host's own VIEW row where the player has
 ## more than one view to choose from, then one row per mod that registered a
-## setting.
-##
-## The view is the host's and not any mod's: `Gen2ModHost` holds one selection
-## for both surfaces, persists it and draws it on the launcher's mod page, and a
-## mod registering a VIEW button of its own would be a private copy of that
-## state, six of them for six mods. This is the same list on the surface a
+## setting. The view is the host's and not any mod's: `Gen2ModHost` holds one
+## selection for both surfaces, persists it and draws it on the launcher's mod
+## page, and a mod registering a VIEW button of its own would be a private copy of
+## that state, six of them for six mods. This is the same list on the surface a
 ## player is already changing what a mod does from, which is the only place a
 ## shipped build has: `V` is behind [method Gen2DebugKeys.enabled].
 func _mod_rows() -> Array:

--- a/game/world/title_scene.gd
+++ b/game/world/title_scene.gd
@@ -1,15 +1,12 @@
 class_name Gen2TitleScene
 extends RefCounted
 
-## `TitleScreenScene` (`engine/menus/intro_menu.asm`), one source frame at a
-## time. Two screens under one name: Crystal opens on `TitleScreenEntrance`,
-## walking `hSCX` in from 112 while the crystal falls and the interlaced
-## `wLYOverrides` pull the logo together, and Gold and Silver go straight to the
-## timer with a bird on its own sine.
-##
-## Scene-free: the frames, the scroll, the sprites and the answer. The pixels are
-## [Gen2TitlePage]'s and the caller reads [method selected_option] once
-## [method finished] holds.
+## `TitleScreenScene` (`engine/menus/intro_menu.asm`), one source frame at a time.
+## Two screens under one name: Crystal opens on `TitleScreenEntrance`, walking
+## `hSCX` in from 112 while the crystal falls and the interlaced `wLYOverrides`
+## pull the logo together, and Gold and Silver go straight to the timer with a bird
+## on its own sine. Scene-free: the frames, the scroll, the sprites and the answer.
+## The pixels are [Gen2TitlePage]'s.
 
 ## `.scenes`. Crystal's table opens on the entrance and Gold and Silver's does
 ## not, so the phase is named rather than numbered here.
@@ -170,14 +167,11 @@ var _suicune_counter: int = 0
 ## by the page: the counter is read before it is raised, so the write lands late.
 var _suicune_base: int = SUICUNE_FIRST_BASE
 var _bird_var: int = 0
-## `SPRITEANIMSTRUCT_FRAME` and `..._DURATION` for the bird's own struct, and
-## the frame counter opens at 0 rather than `_InitSpriteAnimStruct`'s -1.
-## `_TitleScreen` copies the spawned struct into `wSpriteAnim10` with
-## `ld bc, NUM_SPRITE_ANIM_STRUCTS`, which is ten bytes where the struct is
-## sixteen, so the six fields from `..._FRAME` up are never copied. They are the
-## zeroes `ClearSpriteAnims` left, that routine having wiped the whole of
-## `wSpriteAnimData` at the top of `_TitleScreen`, so the values are the
-## cartridge's on every entry rather than boot-time WRAM. The one visible
+## `SPRITEANIMSTRUCT_FRAME` and `..._DURATION` for the bird's own struct, and the
+## frame counter opens at 0 rather than `_InitSpriteAnimStruct`'s -1.
+## `_TitleScreen` copies the spawned struct with `ld bc, NUM_SPRITE_ANIM_STRUCTS`,
+## ten bytes where the struct is sixteen, so the six fields from `..._FRAME` up are
+## never copied and are the zeroes `ClearSpriteAnims` left. The one visible
 ## consequence is `GetSpriteAnimFrame`'s `inc [hl]`: entry 0 is skipped on the
 ## first pass, and `oamrestart` writes -1, so every later cycle plays it.
 var _bird_frame: int = 0

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -1,22 +1,14 @@
 class_name Gen2TownMapScreen
 extends Control
 
-## The region map, embedded in the overworld the way the trainer card and the
-## Hall of Fame are.
-##
-## [Gen2TownMap] owns the cursor walk and the region choice, [Gen2TownMapPage]
-## the tile screen; this composes the two and draws the objects over them: the
-## cursor `PokegearMap_InitCursor` spawns and the player icon
-## `PokegearMap_InitPlayerIcon` does.
-##
-## `Pokedex_GetArea`'s AREA screen is the same two pieces with a third object
-## set: no cursor, one blinking nest icon per landmark the species is found at,
-## and the player icon in their place while SELECT is held.
-##
-## Landmark coordinates are shadow-OAM values with the hardware's own offsets
-## already in them (`data/maps/landmarks.asm`'s `db x + 8, y + 16`), which the
-## importer takes back off, so a landmark's stored point is the centre of its
-## 16x16 icon.
+## The region map, embedded in the overworld the way the trainer card and the Hall
+## of Fame are. [Gen2TownMap] owns the cursor walk and the region choice,
+## [Gen2TownMapPage] the tile screen; this composes the two and draws the cursor
+## and player icon over them. `Pokedex_GetArea`'s AREA screen is the same two
+## pieces with a third object set: no cursor, one blinking nest icon per landmark,
+## and the player icon while SELECT is held. Landmark coordinates are shadow-OAM
+## values with the hardware's offsets already in them, which the importer takes
+## back off, so a stored point is the centre of its 16x16 icon.
 
 signal closed()
 

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -2,16 +2,13 @@ class_name Gen2TrainerCardScreen
 extends Control
 
 ## The trainer card (`engine/menus/trainer_card.asm`), embedded in the overworld
-## the way the Hall of Fame and the PC overlays are.
-##
-## Three pages: the card itself, then the Johto and Kanto badge pages. Page 3 is
-## unreachable, exactly as it is on the cartridge: both `.KantoBadgeCheck`
-## branches that would reach it are unreferenced in either pin. It is built all
-## the same, so the day something references it there is nothing to add.
-##
-## The page's tiles come from [Gen2TrainerCardPage]; the badges are objects with
-## their own palette drawn over it, and the play timer's colon blinks off the
-## same frame counter the badges animate on.
+## the way the Hall of Fame and the PC overlays are. Three pages: the card itself,
+## then the Johto and Kanto badge pages. Page 3 is unreachable exactly as it is on
+## the cartridge, both `.KantoBadgeCheck` branches that would reach it being
+## unreferenced in either pin; it is built all the same, so the day something
+## references it there is nothing to add. The badges are objects with their own
+## palette drawn over the page, and the play timer's colon blinks off the same
+## frame counter.
 
 signal closed()
 

--- a/game/world/unown_printer_screen.gd
+++ b/game/world/unown_printer_screen.gd
@@ -1,16 +1,13 @@
 class_name Gen2UnownPrinterScreen
 extends Control
 
-## `_UnownPrinter`'s `.joy_loop` (`engine/events/print_unown.asm`): left and
-## right walk the twenty-six letters and the vacant slot behind them, wrapping
-## either way, B leaves and A sends the stamp to the printer.
-##
-## A therefore reaches `SendScreenToPrinter`, which prints whatever
-## `CheckPrinterStatus` last found. With nothing on the link `wPrinterHandshake`
-## and `wPrinterStatusFlags` stay -1, which is PRINTER_ERROR_2, and B is the way
-## back; the page under that box is `PlaceUnownPrinterFrontpic`'s, the stamp the
-## printer would have taken. There is no printer to plug in, so that is the
-## whole of what A can do here rather than a refusal invented for it.
+## `_UnownPrinter`'s `.joy_loop`: left and right walk the twenty-six letters and
+## the vacant slot behind them, wrapping either way, B leaves and A sends the stamp
+## to the printer. A therefore reaches `SendScreenToPrinter`, which prints whatever
+## `CheckPrinterStatus` last found; with nothing on the link both printer variables
+## stay -1, which is PRINTER_ERROR_2, and B is the way back. There is no printer to
+## plug in, so that is the whole of what A can do here rather than a refusal
+## invented for it.
 
 signal closed()
 signal music_requested(index: int)

--- a/game/world/unown_puzzle.gd
+++ b/game/world/unown_puzzle.gd
@@ -1,32 +1,14 @@
 class_name Gen2UnownPuzzle
 extends RefCounted
 
-## `_UnownPuzzle` (engine/games/unown_puzzle.asm), the sliding-piece puzzle the
-## four Ruins of Alph chambers open.
-##
-## The board is `wPuzzlePieces`, six by six cells holding a piece number 1 to 16
-## or zero. Only the inner four by four is the picture; the ring around it is
-## where the sixteen pieces are scattered, less the four cells the START>CANCEL
-## box stands on, which is why `.PuzzlePieceInitialPositions` is sixteen entries
-## for sixteen pieces and the scatter is a permutation rather than a placement.
-##
-## Node-free and scene-free: the screen owns the frames and the sound, this owns
-## the rules, and the generator is injected so a run replays.
-##
-## Three things a reading gets wrong:
-##
-## - **The cursor walks cells, not tiles, and its edges are hand-listed.** The
-##   bottom border row is reachable at its two ends alone: `.d_right`'s own
-##   `.right_overflow` jumps cell 30 straight to 35 over the four the box
-##   covers, and `.d_left` jumps back. Nothing steps down out of the bottom
-##   inner row either, which is the four `ret z` in front of `.d_down`'s bound.
-## - **A press is refused rather than ignored.** Lifting from an empty cell and
-##   placing onto a full one both reach `UnownPuzzle_InvalidAction`, which plays
-##   `SFX_WRONG` and waits it out, so the frame is spent either way.
-## - **Holding a piece stops the cursor blinking.** `_UnownPuzzle.loop` reads
-##   `hVBlankCounter and $10` only when `wHoldingUnownPuzzlePiece` is clear, so
-##   the empty cursor is up sixteen frames in thirty-two and a held piece is up
-##   on every one of them.
+## `_UnownPuzzle`, the sliding-piece puzzle the four Ruins of Alph chambers open.
+## The board is `wPuzzlePieces`, six by six cells holding a piece number or zero;
+## only the inner four by four is the picture and the ring around it is where the
+## pieces are scattered, less the four cells the START>CANCEL box stands on.
+## Node-free and scene-free, with the generator injected. Three things a reading
+## gets wrong: the cursor walks cells rather than tiles and its edges are
+## hand-listed; a press is refused rather than ignored, both bad presses reaching
+## `UnownPuzzle_InvalidAction`; and holding a piece stops the cursor blinking.
 
 ## `wPuzzlePieces` is six by six and `puzcoord` is `row * 6 + column`.
 const COLUMNS: int = 6

--- a/game/world/unown_puzzle_screen.gd
+++ b/game/world/unown_puzzle_screen.gd
@@ -1,21 +1,13 @@
 class_name Gen2UnownPuzzleScreen
 extends Control
 
-## `_UnownPuzzle`'s own loop, on the overworld's pump.
-##
-## [Gen2UnownPuzzle] owns the rules and [Gen2UnownPuzzlePage] the picture; this
-## is `.loop`: one pass a frame, `JoyTextDelay`'s repeat carried by the board,
-## and the exit `JUMPTABLE_EXIT_F` sets.
-##
-## Two things the loop states that a screen would otherwise get wrong:
-##
-## - **A press is answered where it lands as well as on the frame.** The host is
-##   press-only, so a tap between two frames would be lost; the pass runs on the
-##   press and the frame's own pass is skipped, which keeps one pass a frame.
-## - **`UnownPuzzle_A` ends on `WaitSFX` and nothing is read until it returns.**
-##   The wait is the driver's, not a frame count, so the screen holds while the
-##   player it was handed reports an effect. A screen with no player waits
-##   nothing, which is what a headless driver and every test see.
+## `_UnownPuzzle`'s own loop, on the overworld's pump. [Gen2UnownPuzzle] owns the
+## rules and [Gen2UnownPuzzlePage] the picture; this is `.loop`, one pass a frame,
+## with `JoyTextDelay`'s repeat carried by the board. Two things a screen would
+## otherwise get wrong: a press is answered where it lands as well as on the frame,
+## the pass running on the press and the frame's own pass being skipped; and
+## `UnownPuzzle_A` ends on `WaitSFX`, which is the driver's rather than a frame
+## count, so a screen with no player waits nothing.
 
 signal closed(solved: bool)
 signal sfx_requested(index: int, waited: bool)

--- a/game/world/unown_wall.gd
+++ b/game/world/unown_wall.gd
@@ -1,18 +1,13 @@
 class_name Gen2UnownWall
 extends RefCounted
 
-## `DisplayUnownWords` (engine/events/unown_walls.asm): the word a Ruins of Alph
-## chamber wall spells, as the box it is drawn in and the tiles that draw it.
-##
-## The letters are not font glyphs and are not `UnownFont`, which is the
-## Pokedex's own sheet: `_DisplayUnownWords_CopyWord` computes a tile number
-## from the character itself and places a 2x2 block of the *tileset's* own tiles,
-## which is why the chambers ship a tileset holding an alphabet
-## (gfx/tilesets/ruins_of_alph.png). So this needs no import: the word comes from
-## `UnownWalls`, which [method GameData.unown_wall_word] already carries, and the
-## tiles come from the tileset the chamber is already drawn with.
-##
-## Scene-free arithmetic. [Gen2UnownWallPage] draws what this places.
+## `DisplayUnownWords`: the word a Ruins of Alph chamber wall spells, as the box
+## it is drawn in and the tiles that draw it. The letters are not font glyphs and
+## are not `UnownFont`, which is the Pokedex's own sheet:
+## `_DisplayUnownWords_CopyWord` computes a tile number from the character itself
+## and places a 2x2 block of the *tileset's* own tiles, which is why the chambers
+## ship a tileset holding an alphabet. So this needs no import: the word comes from
+## `UnownWalls` and the tiles from the tileset the chamber is already drawn with.
 
 ## `constants/charmap.asm`'s `unown` charmap, `$10 * (i / 8) + 2 * i` over
 ## "ABCDEFGHIJKLMNOPQRSTUVWXYZ-": eight letters to a row of the sheet, each two

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -1,22 +1,14 @@
 class_name Gen2WorldActors
 extends RefCounted
 
-## The sprites a mod puts in the world, driven and resolved by the host. A mod
-## wanting one thing in the overworld, a follower or a marker, registers an actor
-## through [method Gen2ModHost.register_world_actor] rather than a whole
-## renderer. The screen drives it with one `advance_frame` per world frame and
-## one `sprites()` read after it, resolved into the same [Gen2WorldSprite] the
-## map's own objects are drawn from.
-##
-## PRESENTATION and nothing else: an actor's sprite occupies no cell, blocks
-## nothing, is talked to by nobody, is seen by no trainer and is in no snapshot.
-## That is why it is a layer of its own rather than a map object, which is world
-## state a mod must not be able to change.
-##
-## A mod names cartridge art and never composes pixels: an entry carries an
-## `IconPointers` row (`icon`) or an `OverworldSprites` row (`sprite`), and the
-## strip, palette, time of day and animation rate are resolved here the way they
-## are for a mon-icon object standing on a map.
+## The sprites a mod puts in the world, driven and resolved by the host: a mod
+## wanting a follower or a marker registers an actor rather than a whole renderer,
+## and the screen drives it with one `advance_frame` per world frame and one
+## `sprites()` read after it. PRESENTATION and nothing else: an actor's sprite
+## occupies no cell, blocks nothing, is talked to by nobody, is seen by no trainer
+## and is in no snapshot, which is why it is a layer of its own rather than a map
+## object. A mod names cartridge art and never composes pixels, the strip, palette
+## and animation rate being resolved here.
 
 ## Checked at registration, where the mod's name is still in hand.
 const ACTOR_METHODS: Array[String] = ["set_world", "advance_frame", "sprites"]
@@ -108,14 +100,12 @@ func advance_frame() -> bool:
 
 
 ## A press of A that no cartridge object, background event or tile branch
-## answered, offered to the actors in registration order; the first answering
-## true consumes it. [param cell] is the player's faced cell and [param facing]
-## the player's own, so an actor tests its own pose and the host never has to
-## invent an occupancy notion for a sprite that occupies nothing.
-##
-## Offered ONLY after [method Gen2WorldAPI.interact] answered nothing, so no
-## cartridge interaction can ever be shadowed by a mod. An actor without the
-## method is offered nothing.
+## answered, offered to the actors in registration order; the first answering true
+## consumes it. [param cell] is the player's faced cell and [param facing] the
+## player's own, so an actor tests its own pose and the host never has to invent
+## an occupancy notion for a sprite that occupies nothing. Offered ONLY after
+## [method Gen2WorldAPI.interact] answered nothing, so no cartridge interaction
+## can be shadowed by a mod.
 func interact(cell: Vector2i, facing: int) -> bool:
 	for actor: Object in _actors:
 		if not actor.has_method(ACTOR_INTERACT_METHOD):

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -223,15 +223,12 @@ func current_indices() -> PackedByteArray:
 	return _indices
 
 
-## Every frame one animated tile is ever drawn as, in the order the sequence
-## plays them, each entry the tile's sixty-four palette indices row by row. An
-## empty array for a tile no command touches.
-##
-## Read-only and one map resolve's question: a mesh cut from the live strip is
-## cut from whichever frame the atlas happened to hold, so geometry has to span
-## the union of every frame. The live sequence is not advanced, because the
-## running game shares this object and stepping it would move what the player
-## sees; the walk runs on a copy from the start of the command list.
+## Every frame one animated tile is ever drawn as, in the order the sequence plays
+## them, each entry the tile's sixty-four palette indices row by row; an empty
+## array for a tile no command touches. Read-only and one map resolve's question:
+## a mesh cut from the live strip is cut from whichever frame the atlas happened to
+## hold, so geometry has to span the union of every frame. The live sequence is not
+## advanced, because the running game shares this object; the walk runs on a copy.
 func tile_frames(tile: int) -> Array[PackedByteArray]:
 	var out: Array[PackedByteArray] = []
 	if _commands.is_empty() or tileset == null or tile < 0 or tile >= tileset.tile_count:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -69,23 +69,13 @@ const STEP_PASSES_FAST: int = 4
 ## then the new facing is written and two more, so a turn on the spot costs
 ## four frames and no cell.
 const STEP_PASSES_TURN: int = 4
-## How long each scripted step command takes, from the `STEP_*` speed it passes
-## to `InitStep` (engine/overworld/movement.asm) and that row of `StepVectors`.
-##
-## Every command here reaches `InitStep`: `NormalStep`, `SlideStep`, `JumpStep`
-## and `TurningStep` all call it and differ in the step type they set over the
-## top, a spin for the three turning rows and a jump for the three jumping ones.
-## The turning rows keep the direction the command names; `turn_away` does not
-## reverse it.
-##
-## The frames here are one cell's. The three jumping rows cover two: `JumpStep`
-## sets `STEP_TYPE_NPC_JUMP` or `STEP_TYPE_PLAYER_JUMP`, whose jumptables are
-## `.Jump` then `.Land` with a `GetNextTile` between them, so each spends this
-## many frames and the command lands two cells on (JUMP_STEP_KINDS below).
-##
-## `turn_step` is the one command that is not here: `TurnStep` sets
-## STEP_TYPE_TURN, never calls `InitStep`, and `StepFunction_Turn` is two frames
-## of standing and two of the new facing. It is filed with `turn_head` below.
+## How long each scripted step command takes, from the `STEP_*` speed it passes to
+## `InitStep` and that row of `StepVectors`. Every command here reaches `InitStep`
+## and they differ only in the step type set over the top; the turning rows keep
+## the direction the command names, `turn_away` not reversing it. The frames are
+## one cell's, and the three jumping rows cover two, `JumpStep`'s jumptable being
+## `.Jump` then `.Land`. `turn_step` is the one command not here: `TurnStep` never
+## calls `InitStep`, so it is filed with `turn_head` below.
 const SCRIPTED_STEP_PASSES: Dictionary = {
 	&"slow_step": STEP_PASSES_NPC_WALK,
 	&"step": STEP_PASSES_WALK,
@@ -145,16 +135,13 @@ static func passes_in_frames(passes: int) -> int:
 	return passes * FRAMES_PER_OVERWORLD_PASS
 
 
-## `InitMapNameSign`. `wCurLandmark` is -1 on a map that has no name to show,
-## and the five landmarks `.CheckSpecialMap` names get no sign either, alongside
-## `LANDMARK_SPECIAL` itself. Crystal indices, since the sign is Crystal's own
-## screen. The two National Park gates are `GROUP_ROUTE_35_NATIONAL_PARK_GATE`'s
-## maps 15 and 17, which `.CheckNationalParkGate` names because their
-## environment is not `GATE`.
-## A `warp_event`'s destination byte for `-1`, which names [member backup_warp]
-## rather than a warp on the map beside it. Six warp events across five maps
-## carry it: POKECENTER_2F's stairs, both dept store elevators' two doors and
-## FAST_SHIP_1F's cabin.
+## `InitMapNameSign`. `wCurLandmark` is -1 on a map with no name to show, and the
+## five landmarks `.CheckSpecialMap` names get no sign either, alongside
+## `LANDMARK_SPECIAL`. Crystal indices, since the sign is Crystal's own screen. The
+## two National Park gates are that group's maps 15 and 17, which
+## `.CheckNationalParkGate` names because their environment is not `GATE`.
+## Below, a `warp_event`'s destination byte for `-1`, which names
+## [member backup_warp]: six warp events across five maps carry it.
 const BACKUP_WARP_DESTINATION: int = 0xFF
 const MAP_NAME_SIGN_NO_LANDMARK: int = -1
 ## `wLandmarkSignTimer`, decremented once per `PlaceMapNameSign` and so once
@@ -513,18 +500,13 @@ func landmark() -> int:
 	return current_map.location if current_map != null else Gen2WorldRadio.LANDMARK_SPECIAL
 
 
-## The same lookup with the `LANDMARK_SPECIAL` fallback `RegionCheck`,
-## `IsInJohto`, `FlyMap`, `Pokedex_GetLandmark` and both `TownMap_*` routines
-## spell out: a map with no landmark of its own borrows [member backup_warp]'s.
-##
-## Six maps carry `LANDMARK_SPECIAL` and only one of them is ordinary: POKECENTER_2F
-## is every Pokemon Center's own upstairs, so the region a radio, a battle track,
-## the town map and the dex area screen answer with is the backup's on every visit
-## to one. The other five are the cable club's rooms.
-##
-## `SetCaughtData` tests POKECENTER_2F by name rather than the landmark, and the
-## two agree everywhere a caught mon can be made: nothing is caught in the five
-## cable club rooms, and a traded mon carries its own data.
+## The same lookup with the `LANDMARK_SPECIAL` fallback `RegionCheck`, `FlyMap`,
+## `Pokedex_GetLandmark` and both `TownMap_*` routines spell out: a map with no
+## landmark of its own borrows [member backup_warp]'s. Six maps carry it and only
+## one is ordinary, POKECENTER_2F being every Pokemon Center's own upstairs, so
+## the region a radio, a battle track and the dex area answer with is the backup's
+## on every visit. `SetCaughtData` tests POKECENTER_2F by name rather than the
+## landmark, and the two agree everywhere a caught mon can be made.
 func landmark_backup() -> int:
 	var here: int = landmark()
 	if here != Gen2WorldRadio.LANDMARK_SPECIAL or backup_warp.is_empty() or data == null:
@@ -1020,22 +1002,13 @@ func set_movement_mode(mode: StringName) -> Dictionary:
 
 
 ## Sets the read-only party mirror a queued script's VAR_PARTYCOUNT read, its
-## CheckPokerus special and its checkpoke consult. count must be non-negative;
-## has_pokerus is the source's own low-nibble-nonzero check across the whole
-## party, computed by the caller because Gen2WorldAPI does not read Gen2SaveMon
-## fields directly. [param species] mirrors `wPartySpecies` for `checkpoke`.
-## [param moves] is one move list per slot, mirroring the party's move slots for
-## `CheckPartyMove`, and [param names] one display name per slot for
-## `GetPartyNickname`; TryStrengthOW asks the first and Script_UsedStrength the
-## second. Only an absent summary fails a script-visible read; a summary whose
-## list is empty answers "not in the party", which is what the story preview's
-## own callers rely on.
-## [param eggs] marks which slots are eggs, because `CheckPartyMove` skips them:
-## an egg carries the moves it will hatch with and would otherwise answer for a
-## move no usable party member knows.
-## [param extra] carries the few party facts a script asks about that are not
-## per-slot: `lead_fainted` for `ContestDropOffMons`, `second_species` for the
-## byte it stashes, and `storage_full` for `CheckPartyFullAfterContest`.
+## CheckPokerus special and its checkpoke consult. `has_pokerus` is the source's
+## own low-nibble check across the party, computed by the caller because this
+## class does not read [Gen2SaveMon] fields. [param moves] mirrors the move slots
+## for `CheckPartyMove` and [param names] the display names for
+## `GetPartyNickname`. [param eggs] marks the slots `CheckPartyMove` skips, since
+## an egg carries the moves it will hatch with. [param extra] carries the few party
+## facts that are not per-slot. Only an absent summary fails a script-visible read.
 func set_party_summary(
 	count: int, has_pokerus: bool, species: Array[int] = [] as Array[int],
 	moves: Array = [], names: Array = [], eggs: Array = [], extra: Dictionary = {},
@@ -1057,16 +1030,13 @@ func set_party_summary(
 	return {"ok": true}
 
 
-## CheckPartyMove (`engine/events/overworld.asm`): the first party slot whose own
-## move list carries [param move], or -1 when none does. Eggs are skipped, empty
-## and terminator slots end the walk, and the answer is the slot index the source
-## leaves in `wCurPartyMon`.
-##
-## Every field move is gated on this. The party submenu reaches `CutFunction` and
-## friends only for a mon that knows the move, and the overworld prompts
-## (`TryCutOW`, `TrySurfOW`, `TryWhirlpoolOW`, `TryWaterfallOW`, `TryStrengthOW`)
-## each call `CheckPartyMove` themselves, so there is no path in either game that
-## uses a field move the party does not know.
+## CheckPartyMove: the first party slot whose own move list carries [param move],
+## or -1 when none does. Eggs are skipped, empty and terminator slots end the walk,
+## and the answer is the slot index the source leaves in `wCurPartyMon`. Every
+## field move is gated on this: the party submenu reaches `CutFunction` and friends
+## only for a mon that knows the move, and the overworld prompts each call
+## `CheckPartyMove` themselves, so there is no path in either game that uses a
+## field move the party does not know.
 func party_slot_with_move(move_id: int) -> int:
 	var moves: Array = _party_summary.get("moves", [])
 	var eggs: Array = _party_summary.get("eggs", [])
@@ -1084,19 +1054,14 @@ const FIELD_MOVE_SOURCE_PARTY: StringName = &"party"
 const FIELD_MOVE_SOURCE_ITEM: StringName = &"item"
 
 
-## WHERE a field move would be used from, which is the one question every
-## entrance to one asks: `{kind, move, slot, item}`, and `{}` when nothing can
-## use it.
-##
-## The party is asked first and answers exactly what [method
-## party_slot_with_move] did, so with no registered source every field move
-## resolves the way it always has. Only when no slot knows the move is an
-## alternate source considered, and only for the seven HM moves.
-##
-## The badge is deliberately NOT part of this. Every `Try*OW` and every staged
-## request tests its own `CheckBadge` in the source's own order, so a player
-## carrying HM01 without the Hive Badge is told about the badge, exactly as one
-## whose Pokemon knows CUT is.
+## WHERE a field move would be used from, which is the one question every entrance
+## to one asks: `{kind, move, slot, item}`, and `{}` when nothing can use it. The
+## party is asked first and answers exactly what [method party_slot_with_move]
+## did, so with no registered source every field move resolves the way it always
+## has; only when no slot knows the move is an alternate source considered, and
+## only for the seven HM moves. The badge is deliberately NOT part of this: every
+## `Try*OW` tests its own `CheckBadge` in the source's order, so a player carrying
+## HM01 without the Hive Badge is told about the badge.
 func field_move_source(move_id: int) -> Dictionary:
 	var slot: int = party_slot_with_move(move_id)
 	if slot >= 0:
@@ -1310,17 +1275,14 @@ static func _cut_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"cut_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's SurfFunction .TrySurf, staged rather than
-## applied, for the same reason Cut is: UsedSurfScript changes nothing until its
-## text is acknowledged.
-##
-## The refusal order is the source's. The badge is tested before the player's own
-## state and before the tile, so a player without the Fog Badge is told about the
-## badge whether or not the water in front of them is surfable. CheckBadge itself
-## is what pushes that text, which is why this reports the same badge_required
-## Cut does. [param species] is the chosen party member's, for GetSurfType.
-##
-## The source's wBikeFlags branch has no counterpart here, since no bike exists.
+## engine/events/overworld.asm's SurfFunction .TrySurf, staged rather than applied,
+## for the same reason Cut is: UsedSurfScript changes nothing until its text is
+## acknowledged. The refusal order is the source's: the badge is tested before the
+## player's own state and before the tile, so a player without the Fog Badge is
+## told about the badge whether or not the water in front is surfable, CheckBadge
+## itself being what pushes that text. [param species] is the chosen party
+## member's, for GetSurfType. The source's wBikeFlags branch has no counterpart
+## here, since no bike exists.
 func surf_request(species: int = 0) -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _surf_failure(&"missing_map")
@@ -1468,13 +1430,11 @@ static func _whirlpool_failure(reason: StringName) -> Dictionary:
 
 ## engine/events/overworld.asm's WaterfallFunction .TryWaterfall, staged the way
 ## the other four are: Script_UsedWaterfall shows _UseWaterfallText and waits on
-## its button before the first climbing step, so nothing moves until the commit.
-##
-## .TryWaterfall is CheckBadge ENGINE_RISINGBADGE, then CheckMapCanWaterfall,
-## which is two tests and no more: `wPlayerDirection & $c` must be FACE_UP, and
-## wTileUp must satisfy CheckWaterfallTile. It reads no player state, so like
-## .TryWhirlpool it neither requires nor refuses surfing, and its refusal is
-## FieldMoveFailed's generic _CantUseItemText rather than a move-specific line.
+## its button before the first climbing step. `.TryWaterfall` is CheckBadge
+## ENGINE_RISINGBADGE, then CheckMapCanWaterfall, which is two tests and no more:
+## `wPlayerDirection & $c` must be FACE_UP, and wTileUp must satisfy
+## CheckWaterfallTile. It reads no player state, so it neither requires nor refuses
+## surfing, and its refusal is FieldMoveFailed's generic line.
 func waterfall_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _waterfall_failure(&"missing_map")
@@ -1510,16 +1470,13 @@ func pending_waterfall() -> Dictionary:
 
 
 ## Script_UsedWaterfall's loop: `applymovement PLAYER, .WaterfallStep` is one
-## `turn_waterfall UP`, and `.CheckContinueWaterfall` repeats it while the cell
-## the player now stands on still answers CheckWaterfallTile. So the climb ends
-## on the first cell above the column that is not a waterfall, however tall it
-## is, and the whole run is one command rather than a step the caller paces.
-##
-## Each step is an applymovement, so it consults no collision, spends no repel
-## step and rolls no encounter, exactly as complete_surf()'s single slow_step
-## does. The landing does re-derive the player state, the way a warp does:
-## CheckUpdatePlayerSprite keeps surfing on water and restores walking anywhere
-## else, which is what puts a climber ashore on the ledge above.
+## `turn_waterfall UP`, and `.CheckContinueWaterfall` repeats it while the cell the
+## player now stands on still answers CheckWaterfallTile. So the climb ends on the
+## first cell above the column that is not a waterfall, and the whole run is one
+## command rather than a step the caller paces. Each step is an applymovement, so
+## it consults no collision, spends no repel step and rolls no encounter. The
+## landing does re-derive the player state the way a warp does, which is what puts
+## a climber ashore on the ledge above.
 func complete_waterfall() -> Dictionary:
 	if _pending_waterfall.is_empty():
 		return _waterfall_failure(&"no_pending_waterfall")
@@ -1557,14 +1514,11 @@ static func _waterfall_failure(reason: StringName) -> Dictionary:
 
 
 ## engine/events/overworld.asm's FlashFunction .CheckUseFlash, staged the way the
-## other five are.
-##
-## Flash is the one field move that checks no tile at all. Its whole test is the
-## badge and then whether this map is a dark one, which is the map header's own
-## palette byte rather than anything under the player. The Aerodactyl chamber's
-## `SpecialAerodactylChamber` branch, which lets Flash be used in a lit room
-## there, is a Ruins of Alph puzzle that is not implemented, so the palette is
-## the only way through here.
+## other five are. Flash is the one field move that checks no tile at all: its
+## whole test is the badge and then whether this map is a dark one, which is the
+## map header's own palette byte rather than anything under the player. The
+## Aerodactyl chamber's branch is a Ruins of Alph puzzle that is not implemented,
+## so the palette is the only way through here.
 func flash_request() -> Dictionary:
 	if current_map == null:
 		return _flash_failure(&"missing_map")
@@ -1718,16 +1672,13 @@ static func _headbutt_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"headbutt_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's TryRockSmashFromMenu, staged the way the other
-## six are: RockSmashScript reaches RockMonEncounter only after
-## UseRockSmashText, so the roll and the rock both belong to the commit.
-##
-## Rock Smash asks neither a badge nor a tile. `GetFacingObject` is
-## `CheckFacingObject` and then the faced object's own `MAPOBJECT_MOVEMENT`
-## byte, compared against `SPRITEMOVEDATA_SMASHABLE_ROCK`, so the question is
-## which object is in front rather than what the ground is. That is also why it
-## reads the doubled counter cell the way `interact()` does: it is the same
-## `CheckFacingObject`.
+## engine/events/overworld.asm's TryRockSmashFromMenu, staged the way the other six
+## are: RockSmashScript reaches RockMonEncounter only after UseRockSmashText, so
+## the roll and the rock both belong to the commit. Rock Smash asks neither a badge
+## nor a tile: `GetFacingObject` is `CheckFacingObject` and then the faced object's
+## own `MAPOBJECT_MOVEMENT` byte against `SPRITEMOVEDATA_SMASHABLE_ROCK`, so the
+## question is which object is in front rather than what the ground is. That is
+## also why it reads the doubled counter cell the way `interact()` does.
 func rock_smash_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _rock_smash_failure(&"missing_map")
@@ -1899,15 +1850,13 @@ func map_time_of_day() -> int:
 	)
 
 
-## engine/events/overworld.asm's StrengthFunction .TryStrength, staged the way
-## the other three are because Script_UsedStrength sets nothing until after its
-## text either.
-##
-## Unlike them, .TryStrength is a badge check and nothing else: no faced tile, no
-## block table, no player state, and no check that a boulder is even in front.
-## Its .AlreadyUsingStrength branch is annotated unreferenced in both pins, so an
-## already-active flag is not a refusal here. [param species] is the chosen party
-## member's, for SetStrengthFlag's wStrengthSpecies.
+## engine/events/overworld.asm's StrengthFunction .TryStrength, staged the way the
+## other three are because Script_UsedStrength sets nothing until after its text
+## either. Unlike them, `.TryStrength` is a badge check and nothing else: no faced
+## tile, no block table, no player state, and no check that a boulder is even in
+## front. Its `.AlreadyUsingStrength` branch is annotated unreferenced in both
+## pins, so an already-active flag is not a refusal here. [param species] is the
+## chosen party member's, for SetStrengthFlag's wStrengthSpecies.
 func strength_request(species: int = 0) -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _strength_failure(&"missing_map")
@@ -2127,17 +2076,13 @@ func can_encounter_wild_mon_at(cell: Vector2i) -> bool:
 	return not Gen2WorldCollision.is_ice(code)
 
 
-## Every cell of the current map a wild could be met on, grouped by the method
-## the terrain resolves to, as [method encounter_request] resolves it: WATER_TILE
-## is `surf` and LAND_TILE is `grass`, and a cave or dungeon floor is grass
-## whether or not it is drawn as grass.
-##
-## One narrowing on [method can_encounter_wild_mon]: a cell nothing can stand on
-## is not offered. A cave's walls pass the gate, since the cave branch skips the
-## grass test, and a Pokemon cannot be put inside one.
-##
-## The map's own collision grid and nothing past it: a connection's cells belong
-## to the connected map's own tables.
+## Every cell of the current map a wild could be met on, grouped by the method the
+## terrain resolves to, as [method encounter_request] resolves it: WATER_TILE is
+## `surf` and LAND_TILE is `grass`, and a cave or dungeon floor is grass whether or
+## not it is drawn as grass. One narrowing on
+## [method can_encounter_wild_mon]: a cell nothing can stand on is not offered,
+## since a cave's walls pass the gate and a Pokemon cannot be put inside one. The
+## map's own collision grid and nothing past it.
 func visible_encounter_cells() -> Dictionary:
 	var out: Dictionary = {
 		Gen2WorldEncounter.METHOD_GRASS: PackedVector2Array(),
@@ -2810,17 +2755,13 @@ func advance_emotes_frame() -> bool:
 	return changed
 
 
-## The grass rustles `NormalStep` spawned this frame, taken once.
-##
-## `ShakeGrass` runs where a step starts, for whichever object is stepping and
-## for the player alike, when the tile that step commits to is grass by
-## `SetTallGrassFlags`' own test. The temporary object it spawns lives one frame
-## less than the step (`MovementFunction_ShakingGrass`), tracks the object that
-## spawned it, and is drawn over that object's own sprite.
-##
-## Returned rather than emitted because nothing in the world reads it: it is
-## presentation, and [Gen2WorldEffects] is what holds it while it runs. Object
-## index -1 is the player.
+## The grass rustles `NormalStep` spawned this frame, taken once. `ShakeGrass` runs
+## where a step starts, for whichever object is stepping and for the player alike,
+## when the tile that step commits to is grass by `SetTallGrassFlags`' own test.
+## The temporary object it spawns lives one frame less than the step, tracks the
+## object that spawned it and is drawn over that object's own sprite. Returned
+## rather than emitted because nothing in the world reads it: it is presentation,
+## and [Gen2WorldEffects] holds it while it runs. Object index -1 is the player.
 func take_grass_rustles() -> Array:
 	var out: Array = []
 	if _player_step_began:
@@ -2918,19 +2859,13 @@ func trainer_approach_plan(
 
 
 ## Applies one step from an already validated approach plan and starts that
-## object's presentation offset for the pacing caller to consume; the object's
-## cell is already the destination when this returns.
-##
-## Only the map bounds refuse, as in _apply_object_movement(): the approach is
-## `applymovementlasttalked wMovementBuffer` (engine/events/trainer_scripts.asm)
-## and its steps reach NormalStep (engine/overworld/movement.asm), which never
-## calls CanObjectMoveInDirection. That is what walks Cerulean Gym's swimmers
-## over their own pool.
-##
-## STEP_PASSES_WALK, not the slow row: TrainerWalkToPlayer passes 1 in d and
-## `.GetPathToPlayer`'s `push de`/`pop af` hands it to
-## ComputePathToWalkToPlayer, whose `ld b, a` selects `.MovementData`'s `step`
-## row (engine/overworld/player_object.asm, home/movement.asm).
+## object's presentation offset for the pacing caller to consume; the object's cell
+## is already the destination when this returns. Only the map bounds refuse: the
+## approach is `applymovementlasttalked wMovementBuffer` and its steps reach
+## NormalStep, which never calls CanObjectMoveInDirection, which is what walks
+## Cerulean Gym's swimmers over their own pool. STEP_PASSES_WALK, not the slow row:
+## TrainerWalkToPlayer passes 1 in d and `.GetPathToPlayer` hands it to
+## ComputePathToWalkToPlayer, whose `ld b, a` selects `.MovementData`'s `step` row.
 func advance_trainer_approach_step(object_index: int, direction: Vector2i) -> Dictionary:
 	if current_map == null or object_index < 0 or object_index >= objects.size():
 		return {"ok": false, "reason": &"invalid_trainer_object"}
@@ -3115,18 +3050,13 @@ func warp_index_at(cell: Vector2i) -> int:
 	return 0
 
 
-## engine/overworld/cmd_queue.asm's CmdQueue_StoneTable and home/stone_queue.asm's
-## HandleStoneQueue, as one question: which script does this boulder's cell fire?
-##
-## The source's own order, all five tests. The object must be a Strength boulder,
-## standing on a pit tile (`CheckPitTile`, COLL_PIT or COLL_PIT_68), not mid-step,
-## on a warp event, and named by a written CMDQUEUE_STONETABLE row for that
-## warp. Answers an empty Dictionary when any of them refuses.
-##
-## The row's object id is an `object_const_def` constant, which starts at 2, so
-## it is compared against the object's own index plus two. That is the same
-## mapping `applymovement` uses, and the source makes it by comparing against
-## OBJECT_MAP_OBJECT_INDEX + 1 over a table whose index zero is the player.
+## `CmdQueue_StoneTable` and `HandleStoneQueue`, as one question: which script does
+## this boulder's cell fire? The source's own order, all five tests. The object
+## must be a Strength boulder, standing on a pit tile, not mid-step, on a warp
+## event, and named by a written CMDQUEUE_STONETABLE row for that warp; any refusal
+## answers an empty Dictionary. The row's object id is an `object_const_def`
+## constant, which starts at 2, so it is compared against the object's own index
+## plus two, the same mapping `applymovement` uses.
 func stone_queue_script(boulder: Gen2WorldObject) -> Dictionary:
 	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
 		return {}
@@ -3626,16 +3556,14 @@ func dispatch_callbacks(callback_type: int = -1) -> Array:
 	return run_event_queue(false)
 
 
-## Runs the callbacks that belong to entering the current map. The scene calls
-## this once after opening a new or validated snapshot; map transitions already
-## queue the same callback set from _apply_map().
-##
-## The scene script is armed only once per entry. `MAPSETUP_ENTER` runs it as
-## part of the map load, so a second call for the same entry is a caller
-## dispatching twice, not a second entry: replaying the scene would walk its
-## `applymovement`s again, which is what put the Dragon Shrine's player through
-## the north wall. The callbacks are re-queued, since each is written to run
-## whenever the map is refreshed.
+## Runs the callbacks that belong to entering the current map. The scene calls this
+## once after opening a new or validated snapshot; map transitions already queue
+## the same callback set from `_apply_map()`. The scene script is armed only once
+## per entry: `MAPSETUP_ENTER` runs it as part of the map load, so a second call is
+## a caller dispatching twice rather than a second entry, and replaying the scene
+## would walk its `applymovement`s again, which is what put the Dragon Shrine's
+## player through the north wall. The callbacks are re-queued, since each is
+## written to run whenever the map is refreshed.
 func dispatch_map_entry() -> Array:
 	if current_map == null:
 		return []
@@ -3648,19 +3576,14 @@ func dispatch_map_entry() -> Array:
 	return events
 
 
-## `LoadObjectMasks` (engine/overworld/map_objects_2.asm), which is what actually
-## masks an object rather than `ReadObjectEvents`: that one copies every event
-## into `wMapObjects` without looking at a flag.
-##
-## The distinction is the whole reason this is a step of its own.
-## `MapSetupScript_Warp` runs `LoadMapAttributes`, then `HandleNewMap`, whose
-## `MAPCALLBACK_NEWMAP` is where `ToggleDecorationsVisibility` sets the four
-## `EVENT_PLAYERS_HOUSE_2F_*` flags for a decoration the player does not own, and
-## only then `LoadMapObjects`, which runs `MAPCALLBACK_OBJECTS` and calls this.
-## So a flag a map-entry callback writes is read *after* it is written. Reading
-## it while the record is built puts the console, both dolls and the big doll in
-## the player's bedroom on a new game, each drawn as the `SPRITE_CHRIS` its
-## unassigned variable sprite falls back to.
+## `LoadObjectMasks`, which is what actually masks an object rather than
+## `ReadObjectEvents`: that one copies every event into `wMapObjects` without
+## looking at a flag. `MapSetupScript_Warp` runs `LoadMapAttributes`, then
+## `HandleNewMap`, whose `MAPCALLBACK_NEWMAP` is where `ToggleDecorationsVisibility`
+## sets the four `EVENT_PLAYERS_HOUSE_2F_*` flags, and only then `LoadMapObjects`,
+## which calls this. So a flag a map-entry callback writes is read *after* it is
+## written; reading it while the record is built puts the console, both dolls and
+## the big doll in the player's bedroom on a new game.
 func load_object_masks() -> void:
 	_object_masks_pending = false
 	for object: Gen2WorldObject in objects:
@@ -3708,17 +3631,12 @@ func interact() -> Array:
 
 
 ## TryTileCollisionEvent from `.cut` on. The faced tile picks the branch, in the
-## source's order: a cut tree, then a whirlpool, then a waterfall, then a
-## headbutt tree, and `.surf` as the fallback any other tile reaches.
-##
-## Only the tile-shaped half of each gate is answered here, because only this
-## layer can read the map: whether the branch applies at all, and for Whirlpool
-## and Waterfall whether TryWhirlpoolMenu and CheckMapCanWaterfall would pass.
-## The party and the badge belong to the runner, which replays the Ask*Script.
-##
-## `.surf` is the one branch that is silent rather than refused when its own
-## tile checks fail: TrySurfOW answers no carry and the player event ends, so an
-## ordinary wall produces no request at all.
+## source's order: a cut tree, then a whirlpool, then a waterfall, then a headbutt
+## tree, and `.surf` as the fallback any other tile reaches. Only the tile-shaped
+## half of each gate is answered here, because only this layer can read the map;
+## the party and the badge belong to the runner, which replays the Ask*Script.
+## `.surf` is the one branch that is silent rather than refused when its own tile
+## checks fail, so an ordinary wall produces no request at all.
 func _field_move_prompt_request(cell: Vector2i) -> Dictionary:
 	if current_map == null or current_tileset == null or data == null:
 		return {}
@@ -3883,15 +3801,13 @@ func _resume_after(advanced: Dictionary) -> Array:
 	return results
 
 
-## Starts each queued script in turn and stops at the first one that waits for
-## the host.
-##
-## A warp applied while resuming a host request leaves the destination's map
+## Starts each queued script in turn and stops at the first one that waits for the
+## host. A warp applied while resuming a host request leaves the destination's map
 ## scene pending exactly as one applied inside [method run_event_queue] does, so
 ## this has to pick it up too. Boarding the S.S. Aqua is where that shows:
 ## `OlivinePortSailorAtGangwayScript` warps mid-script and the ship's own
-## `FastShip1FEnterShipScript` is what walks the player away from the door, so
-## dropping it left the player boxed in against the sailor who blocks it.
+## `FastShip1FEnterShipScript` walks the player away from the door, so dropping it
+## left the player boxed in against the sailor who blocks it.
 func _drain_script_queue() -> Array:
 	var results: Array = []
 	while _active_script == null:
@@ -4295,6 +4211,43 @@ func _coord_event_condition_active(event: Dictionary) -> bool:
 	return int(event.get("scene", -1)) == state.map_scene(current_map.group, current_map.number)
 
 
+## Script event to the method that applies it, each taking the event and
+## answering the events it generated.
+const SCRIPT_EVENT_HANDLERS: Dictionary = {
+	&"warp_check_requested": &"_script_warp_check",
+	&"player_facing_requested": &"_script_player_facing",
+	&"player_movement_requested": &"_apply_player_movement",
+	&"object_movement_requested": &"_apply_object_movement",
+	&"object_write_position": &"_script_write_object_position",
+	&"map_block_changed": &"_script_change_block",
+	&"map_reload_requested": &"_script_reload_map",
+	&"map_refresh_requested": &"_script_refresh_map",
+	&"bug_contest_started": &"_script_start_bug_contest",
+	&"bug_contestants_selected": &"_script_select_contestants",
+	&"contest_mons_dropped_off": &"_script_contest_drop_off",
+	&"contest_mons_returned": &"_script_contest_return",
+	&"warp_to_spawn_point": &"_script_warp_to_spawn",
+	&"wild_encounters_changed": &"_script_wild_encounters",
+	&"command_queue_written": &"_script_queue_write",
+	&"command_queue_deleted": &"_script_queue_delete",
+	&"earthquake_requested": &"_script_earthquake",
+	&"object_follow": &"_script_object_follow",
+	&"object_stop_follow": &"_script_object_stop_follow",
+	&"player_face_object": &"_script_player_face_object",
+}
+
+## The three that edit the loaded object itself, all behind the same bounds test.
+const LOCAL_OBJECT_EVENTS: Array[StringName] = [
+	&"object_deleted", &"object_emote", &"object_event_flag",
+]
+
+## The five that record an override the next object load reads.
+const OBJECT_OVERRIDE_EVENTS: Array[StringName] = [
+	&"object_visibility", &"object_position", &"object_facing",
+	&"object_face_player", &"object_face_object",
+]
+
+
 func _apply_script_object_events(raw_events: Variant) -> Array:
 	var generated: Array = []
 	if not raw_events is Array:
@@ -4304,248 +4257,247 @@ func _apply_script_object_events(raw_events: Variant) -> Array:
 		if not raw_event is Dictionary:
 			continue
 		var event: Dictionary = raw_event as Dictionary
-		var event_type: StringName = StringName(event.get("type", &""))
-		if event_type == &"warp_check_requested":
-			## Script_warpcheck asks whether the player is standing on a warp
-			## and takes it if so, which is how the Burned Tower rival scene
-			## drops the player through the hole it just opened. A cell with no
-			## warp answers nothing, exactly as WarpCheck's carry does.
-			var checked: Dictionary = try_warp()
-			generated.append({
-				"type": &"warp_check",
-				"taken": bool(checked.get("ok", false)),
-				"transition": checked.duplicate(true),
-			})
-			continue
-		if event_type == &"player_facing_requested":
-			## Script_warpfacing writes the player's facing before the warp, and
-			## the map load never touches it, so the facing outlives the
-			## transition. Lance's room is where it shows: `warpfacing UP` is
-			## what the player enters the Hall of Fame already facing.
-			player_facing = int(event.get("facing", player_facing))
-			generated.append({"type": &"player_facing", "facing": player_facing})
-			continue
-		if event_type == &"player_movement_requested":
-			generated.append_array(_apply_player_movement(event))
-			continue
-		if event_type == &"object_movement_requested":
-			generated.append_array(_apply_object_movement(event))
-			continue
-		if event_type == &"object_write_position":
-			var write_map_group: int = int(event.get("map_group", -1))
-			var write_map_number: int = int(event.get("map_number", -1))
-			var write_index: int = int(event.get("object_index", -1))
-			if current_map == null or write_map_group != current_map.group \
-				or write_map_number != current_map.number \
-				or write_index < 0 or write_index >= objects.size():
-				generated.append({"type": &"object_change_failed", "reason": &"invalid_object"})
-				continue
-			var write_object: Gen2WorldObject = objects[write_index]
-			var write_key: String = _object_key(
-				write_map_group, write_map_number, write_index
-			)
-			_object_position_overrides[write_key] = write_object.cell
-			generated.append({
-				"type": &"object_position_written",
-				"object_index": write_index, "cell": write_object.cell,
-			})
-			continue
-		if event_type == &"map_block_changed":
-			if current_map == null or int(event.get("map_group", -1)) != current_map.group \
-				or int(event.get("map_number", -1)) != current_map.number:
-				generated.append({"type": &"map_change_failed", "reason": &"invalid_map"})
-				continue
-			var source_cell := Vector2i(
-				int(event.get("x", -1)), int(event.get("y", -1))
-			)
-			var block_cell: Vector2i = _script_block_cell(source_cell)
-			var changed_block: Dictionary = change_block(
-				block_cell.x, block_cell.y, int(event.get("block", -1))
-			)
-			if bool(changed_block.get("ok", false)):
-				changed_block["source_cell"] = source_cell
-				generated.append({"type": &"map_block_changed", "change": changed_block})
-			else:
-				generated.append({
-					"type": &"map_change_failed",
-					"reason": changed_block.get("reason", &"invalid_block"),
-					"source_cell": source_cell,
-					"block_cell": block_cell,
-				})
-			continue
-		if event_type == &"map_reload_requested":
-			generated.append(reload_current_map())
-			continue
-		if event_type == &"bug_contest_started":
-			generated.append(start_bug_contest())
-			continue
-		if event_type == &"bug_contestants_selected":
-			var withdrawn: Dictionary = Gen2WorldBugContest.select_withdrawn(
-				schedule_random if schedule_random != null else RandomNumberGenerator.new()
-			)
-			for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
-				state.set_event_flag(
-					Gen2WorldState.EVENT_BUG_CATCHING_CONTESTANT_FIRST + index,
-					bool(withdrawn.get(index, false))
-				)
-			generated.append({
-				"type": &"bug_contestants_selected",
-				"withdrawn": withdrawn.keys(),
-			})
-			continue
-		if event_type == &"contest_mons_dropped_off":
-			state.set_contest_second_party_species(int(event.get("second_species", 0)))
-			generated.append({
-				"type": &"contest_mons_dropped_off",
-				"second_species": state.contest_second_party_species(),
-			})
-			continue
-		if event_type == &"warp_to_spawn_point":
-			warp_to_spawn_point()
-			generated.append({"type": &"warp_to_spawn_point"})
-			continue
-		if event_type == &"contest_mons_returned":
-			state.set_contest_second_party_species(0)
-			generated.append({"type": &"contest_mons_returned"})
-			continue
-		if event_type == &"wild_encounters_changed":
-			var wild_enabled: bool = bool(event.get("enabled", true))
-			state.set_wild_encounters_off(not wild_enabled)
-			generated.append({
-				"type": &"wild_encounters_changed", "enabled": wild_enabled,
-			})
-			continue
-		if event_type == &"variable_sprite_changed":
-			var variable_sprite: int = int(event.get("variable_sprite", -1))
+		var type: StringName = StringName(event.get("type", &""))
+		if SCRIPT_EVENT_HANDLERS.has(type):
+			generated.append_array(call(SCRIPT_EVENT_HANDLERS[type], event) as Array)
+		elif type == &"variable_sprite_changed":
+			var slot: int = int(event.get("variable_sprite", -1))
 			var sprite: int = int(event.get("sprite", 0))
-			if variable_sprite < Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE \
-				or sprite <= 0:
+			if slot < Gen2WorldScriptRunner.VARIABLE_SPRITE_BASE or sprite <= 0:
 				generated.append({"type": &"variable_sprite_change_failed"})
 				continue
-			state.set_variable_sprite(variable_sprite, sprite)
+			state.set_variable_sprite(slot, sprite)
 			## The table is `wPlayerData`, not the loaded map, so the people
 			## SCREEN FILL draws on the maps next door resolve through it too.
 			_connected_objects = []
 			reload_objects = true
 			generated.append({
 				"type": &"variable_sprite_changed",
-				"variable_sprite": variable_sprite,
-				"sprite": sprite,
+				"variable_sprite": slot, "sprite": sprite,
 			})
-			continue
-		if event_type == &"map_refresh_requested":
-			generated.append({"type": &"map_refreshed", "map": map_id()})
-			continue
-		if event_type == &"command_queue_written":
-			generated.append(apply_command_queue_write(
-				int(event.get("bank", 0)), int(event.get("address", 0))
-			))
-			continue
-		if event_type == &"command_queue_deleted":
-			generated.append(apply_command_queue_delete(int(event.get("queue_id", -1))))
-			continue
-		if event_type == &"earthquake_requested":
-			generated.append({
-				"type": &"screen_shake_requested",
-				"strength": int(event.get("strength", 0)),
-			})
-			continue
-		if event_type == &"object_follow":
-			## `wObjectFollow_Leader` and `wObjectFollow_Follower` are one byte
-			## each, so a second `follow` replaces the pair rather than adding to
-			## it.
-			_start_object_follow(event)
-			continue
-		if event_type == &"object_stop_follow":
-			_object_followers.clear()
-			continue
-		if event_type in [&"object_deleted", &"object_emote", &"object_event_flag"]:
-			var local_map_group: int = int(event.get("map_group", -1))
-			var local_map_number: int = int(event.get("map_number", -1))
-			var local_index: int = int(event.get("object_index", -1))
-			if current_map == null or local_map_group != current_map.group \
-				or local_map_number != current_map.number \
-				or local_index < 0 or local_index >= objects.size():
-				generated.append({"type": &"object_change_failed", "reason": &"invalid_object"})
-				continue
-			var local_object: Gen2WorldObject = objects[local_index]
-			var local_key: String = _object_key(local_map_group, local_map_number, local_index)
-			match event_type:
-				&"object_deleted":
-					local_object.deleted = true
-					local_object.active = false
-					_object_followers.erase(local_key)
-					generated.append({"type": &"object_deleted", "object_index": local_index})
-				&"object_emote":
-					local_object.set_emote(
-						int(event.get("emote_id", -1)), bool(event.get("visible", false)),
-						int(event.get("duration", 0))
-					)
-				&"object_event_flag":
-					var flag: int = local_object.event_flag
-					if flag > 0:
-						state.set_event_flag(flag, bool(event.get("active", false)))
-			continue
-		if event_type == &"player_face_object":
-			var player_target_index: int = int(event.get("target_index", -1))
-			if current_map != null and int(event.get("map_group", -1)) == current_map.group \
-				and int(event.get("map_number", -1)) == current_map.number \
-				and player_target_index >= 0 and player_target_index < objects.size():
-				player_facing = _facing_toward(
-					player_cell, (objects[player_target_index] as Gen2WorldObject).cell
-				)
-			continue
-		if event_type not in [
-			&"object_visibility", &"object_position", &"object_facing",
-			&"object_face_player", &"object_face_object",
-		]:
-			continue
-		var map_group: int = int(event.get("map_group", -1))
-		var map_number: int = int(event.get("map_number", -1))
-		var object_index: int = int(event.get("object_index", -1))
-		if object_index < 0:
-			continue
-		var key: String = _object_key(map_group, map_number, object_index)
-		match event_type:
-			&"object_visibility":
-				_object_visibility_overrides[key] = bool(event.get("active", false))
-				if object_index < objects.size() \
-					and (objects[object_index] as Gen2WorldObject).event_flag <= 0:
-					_transient_object_visibility_overrides[key] = true
-				else:
-					_transient_object_visibility_overrides.erase(key)
-				reload_objects = true
-			&"object_position":
-				var cell: Variant = event.get("cell", Vector2i.ZERO)
-				if cell is Vector2i:
-					_object_position_overrides[key] = cell
-					reload_objects = true
-			&"object_facing":
-				_object_facing_overrides[key] = clampi(
-					int(event.get("facing", Gen2WorldSprite.FACING_DOWN)),
-					Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
-				)
-				reload_objects = true
-			&"object_face_player":
-				if map_group == current_map.group and map_number == current_map.number \
-					and object_index < objects.size():
-					var object: Gen2WorldObject = objects[object_index]
-					var facing: int = _facing_toward(object.cell, player_cell)
-					_object_facing_overrides[key] = facing
-				reload_objects = true
-			&"object_face_object":
-				var target_index: int = int(event.get("target_index", -1))
-				if map_group == current_map.group and map_number == current_map.number \
-					and object_index < objects.size() and target_index >= 0 \
-					and target_index < objects.size():
-					_object_facing_overrides[key] = _facing_toward(
-						(objects[object_index] as Gen2WorldObject).cell,
-						(objects[target_index] as Gen2WorldObject).cell
-					)
-				reload_objects = true
+		elif type in LOCAL_OBJECT_EVENTS:
+			generated.append_array(_apply_local_object_event(type, event))
+		elif type in OBJECT_OVERRIDE_EVENTS:
+			reload_objects = _apply_object_override(type, event) or reload_objects
 	if reload_objects and current_map != null:
 		_load_objects(true)
 	return generated
+
+
+## Script_warpcheck asks whether the player is standing on a warp and takes it if
+## so, which is how the Burned Tower rival scene drops the player through the
+## hole it just opened. A cell with no warp answers nothing, exactly as
+## WarpCheck's carry does.
+func _script_warp_check(_event: Dictionary) -> Array:
+	var checked: Dictionary = try_warp()
+	return [{
+		"type": &"warp_check",
+		"taken": bool(checked.get("ok", false)),
+		"transition": checked.duplicate(true),
+	}]
+
+
+## Script_warpfacing writes the player's facing before the warp and the map load
+## never touches it, so the facing outlives the transition. Lance's room is where
+## it shows: `warpfacing UP` is what the player enters the Hall of Fame facing.
+func _script_player_facing(event: Dictionary) -> Array:
+	player_facing = int(event.get("facing", player_facing))
+	return [{"type": &"player_facing", "facing": player_facing}]
+
+
+func _script_write_object_position(event: Dictionary) -> Array:
+	var index: int = int(event.get("object_index", -1))
+	if not _event_names_loaded_object(event, index):
+		return [{"type": &"object_change_failed", "reason": &"invalid_object"}]
+	var key: String = _object_key(
+		int(event.get("map_group", -1)), int(event.get("map_number", -1)), index
+	)
+	_object_position_overrides[key] = (objects[index] as Gen2WorldObject).cell
+	return [{
+		"type": &"object_position_written",
+		"object_index": index, "cell": _object_position_overrides[key],
+	}]
+
+
+func _script_change_block(event: Dictionary) -> Array:
+	if current_map == null or int(event.get("map_group", -1)) != current_map.group \
+		or int(event.get("map_number", -1)) != current_map.number:
+		return [{"type": &"map_change_failed", "reason": &"invalid_map"}]
+	var source_cell := Vector2i(int(event.get("x", -1)), int(event.get("y", -1)))
+	var block_cell: Vector2i = _script_block_cell(source_cell)
+	var changed: Dictionary = change_block(
+		block_cell.x, block_cell.y, int(event.get("block", -1))
+	)
+	if not bool(changed.get("ok", false)):
+		return [{
+			"type": &"map_change_failed",
+			"reason": changed.get("reason", &"invalid_block"),
+			"source_cell": source_cell,
+			"block_cell": block_cell,
+		}]
+	changed["source_cell"] = source_cell
+	return [{"type": &"map_block_changed", "change": changed}]
+
+
+func _script_reload_map(_event: Dictionary) -> Array:
+	return [reload_current_map()]
+
+
+func _script_refresh_map(_event: Dictionary) -> Array:
+	return [{"type": &"map_refreshed", "map": map_id()}]
+
+
+func _script_start_bug_contest(_event: Dictionary) -> Array:
+	return [start_bug_contest()]
+
+
+func _script_select_contestants(_event: Dictionary) -> Array:
+	var withdrawn: Dictionary = Gen2WorldBugContest.select_withdrawn(
+		schedule_random if schedule_random != null else RandomNumberGenerator.new()
+	)
+	for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
+		state.set_event_flag(
+			Gen2WorldState.EVENT_BUG_CATCHING_CONTESTANT_FIRST + index,
+			bool(withdrawn.get(index, false))
+		)
+	return [{"type": &"bug_contestants_selected", "withdrawn": withdrawn.keys()}]
+
+
+func _script_contest_drop_off(event: Dictionary) -> Array:
+	state.set_contest_second_party_species(int(event.get("second_species", 0)))
+	return [{
+		"type": &"contest_mons_dropped_off",
+		"second_species": state.contest_second_party_species(),
+	}]
+
+
+func _script_contest_return(_event: Dictionary) -> Array:
+	state.set_contest_second_party_species(0)
+	return [{"type": &"contest_mons_returned"}]
+
+
+func _script_warp_to_spawn(_event: Dictionary) -> Array:
+	warp_to_spawn_point()
+	return [{"type": &"warp_to_spawn_point"}]
+
+
+func _script_wild_encounters(event: Dictionary) -> Array:
+	var enabled: bool = bool(event.get("enabled", true))
+	state.set_wild_encounters_off(not enabled)
+	return [{"type": &"wild_encounters_changed", "enabled": enabled}]
+
+
+func _script_queue_write(event: Dictionary) -> Array:
+	return [apply_command_queue_write(
+		int(event.get("bank", 0)), int(event.get("address", 0))
+	)]
+
+
+func _script_queue_delete(event: Dictionary) -> Array:
+	return [apply_command_queue_delete(int(event.get("queue_id", -1)))]
+
+
+func _script_earthquake(event: Dictionary) -> Array:
+	return [{
+		"type": &"screen_shake_requested", "strength": int(event.get("strength", 0)),
+	}]
+
+
+## `wObjectFollow_Leader` and `wObjectFollow_Follower` are one byte each, so a
+## second `follow` replaces the pair rather than adding to it.
+func _script_object_follow(event: Dictionary) -> Array:
+	_start_object_follow(event)
+	return []
+
+
+func _script_object_stop_follow(_event: Dictionary) -> Array:
+	_object_followers.clear()
+	return []
+
+
+func _script_player_face_object(event: Dictionary) -> Array:
+	var target: int = int(event.get("target_index", -1))
+	if _event_names_loaded_object(event, target):
+		player_facing = _facing_toward(
+			player_cell, (objects[target] as Gen2WorldObject).cell
+		)
+	return []
+
+
+## Whether [param event] names the loaded map and an object on it. Every event
+## that edits one is refused rather than applied to whatever is at that index on
+## another map.
+func _event_names_loaded_object(event: Dictionary, index: int) -> bool:
+	return current_map != null \
+		and int(event.get("map_group", -1)) == current_map.group \
+		and int(event.get("map_number", -1)) == current_map.number \
+		and index >= 0 and index < objects.size()
+
+
+func _apply_local_object_event(type: StringName, event: Dictionary) -> Array:
+	var index: int = int(event.get("object_index", -1))
+	if not _event_names_loaded_object(event, index):
+		return [{"type": &"object_change_failed", "reason": &"invalid_object"}]
+	var object: Gen2WorldObject = objects[index]
+	match type:
+		&"object_deleted":
+			object.deleted = true
+			object.active = false
+			_object_followers.erase(_object_key(
+				int(event.get("map_group", -1)), int(event.get("map_number", -1)), index
+			))
+			return [{"type": &"object_deleted", "object_index": index}]
+		&"object_emote":
+			object.set_emote(
+				int(event.get("emote_id", -1)), bool(event.get("visible", false)),
+				int(event.get("duration", 0))
+			)
+		&"object_event_flag":
+			if object.event_flag > 0:
+				state.set_event_flag(object.event_flag, bool(event.get("active", false)))
+	return []
+
+
+## Records what the next object load reads back, and answers whether one is due.
+func _apply_object_override(type: StringName, event: Dictionary) -> bool:
+	var map_group: int = int(event.get("map_group", -1))
+	var map_number: int = int(event.get("map_number", -1))
+	var index: int = int(event.get("object_index", -1))
+	if index < 0:
+		return false
+	var key: String = _object_key(map_group, map_number, index)
+	var names_loaded: bool = _event_names_loaded_object(event, index)
+	match type:
+		&"object_visibility":
+			_object_visibility_overrides[key] = bool(event.get("active", false))
+			if index < objects.size() \
+				and (objects[index] as Gen2WorldObject).event_flag <= 0:
+				_transient_object_visibility_overrides[key] = true
+			else:
+				_transient_object_visibility_overrides.erase(key)
+		&"object_position":
+			var cell: Variant = event.get("cell", Vector2i.ZERO)
+			if not cell is Vector2i:
+				return false
+			_object_position_overrides[key] = cell
+		&"object_facing":
+			_object_facing_overrides[key] = clampi(
+				int(event.get("facing", Gen2WorldSprite.FACING_DOWN)),
+				Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
+			)
+		&"object_face_player":
+			if names_loaded:
+				_object_facing_overrides[key] = _facing_toward(
+					(objects[index] as Gen2WorldObject).cell, player_cell
+				)
+		&"object_face_object":
+			var target: int = int(event.get("target_index", -1))
+			if names_loaded and target >= 0 and target < objects.size():
+				_object_facing_overrides[key] = _facing_toward(
+					(objects[index] as Gen2WorldObject).cell,
+					(objects[target] as Gen2WorldObject).cell
+				)
+	return true
 
 
 func _apply_object_movement(event: Dictionary) -> Array:
@@ -4894,14 +4846,10 @@ func _apply_script_warp(request: Dictionary) -> Dictionary:
 
 
 ## Resolves and applies an ordinary warp at the current cell. The destination
-## field selects a one-based warp in the destination map, as in the original
-## map macro. An invalid target leaves this API unchanged and returns an error
-## record instead of silently placing the player on another map.
-## `CheckWarpTile`'s own answer, without walking through the warp: whether
-## the step that just landed on [param cell] has a warp to take. A host that
-## spends `MapSetupScript_Door`'s fade before the map swaps asks this first, and
-## [method try_warp] is the swap itself.
-##
+## field selects a one-based warp in the destination map, as in the original map
+## macro; an invalid target leaves this API unchanged and returns an error record.
+## Below, `CheckWarpTile`'s own answer without walking through the warp, for a
+## host that spends `MapSetupScript_Door`'s fade before the map swaps.
 ## `CheckWarpTile` is `GetDestinationWarpNumber` and then `CheckDirectionalWarp`,
 ## which clears carry on the four warp carpets: landing on one of those warps
 ## nothing, and only [method edge_warp_ready] takes it.
@@ -5026,18 +4974,13 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	}
 
 
-## Resolves the source connection for a cardinal step beyond the current map.
-## The stored offsets are the signed cell offsets generated by the cartridge's
-## connection macro. No map mutation occurs when the target is invalid.
-## Where a step in [param direction] off [param cell] would land, resolved
-## without moving anyone: the connection for that edge, the aligned target cell
-## and every refusal try_connection() reports. Empty when this map has no
-## connection that way at all.
-##
-## A caller planning a walk asks this rather than testing the edge coordinate,
-## because a connection spans only part of its edge: Route 8 is forty cells wide
-## and its east connection covers nine of them, so three of its four walkable
-## east-edge cells resolve to nothing.
+## Resolves the source connection for a cardinal step beyond the current map. The
+## stored offsets are the signed cell offsets the cartridge's connection macro
+## generates, and no map mutation occurs when the target is invalid. Below, where
+## a step would land, resolved without moving anyone, and every refusal
+## `try_connection()` reports. A caller planning a walk asks that rather than
+## testing the edge coordinate, because a connection spans only part of its edge:
+## Route 8 is forty cells wide and its east connection covers nine of them.
 func connection_target(cell: Vector2i, direction: Vector2i) -> Dictionary:
 	var direction_name: String = _direction_name(direction)
 	if direction_name.is_empty() or current_map == null or data == null:
@@ -5209,13 +5152,11 @@ func _step_permission_allows(cell: Vector2i, direction: Vector2i) -> bool:
 ## [param direction] matches CanObjectMoveInDirection's CanObjectLeaveTile
 ## (moving's own cell) and WillObjectBumpIntoTile (the destination) side-wall
 ## checks; Vector2i.ZERO skips them for callers that only want the destination
-## permission and occupancy.
-##
-## A swimming object wants the opposite permission: CanObjectMoveInDirection
-## (engine/overworld/npc_movement.asm) branches on OBJECT_PALETTE's SWIMMING bit
-## into WillObjectBumpIntoLand, which refuses anything but WATER_TILE, where the
-## not-swimming branch's WillObjectBumpIntoWater refuses anything but LAND_TILE.
-## Everything after that branch is shared, so only the permission differs.
+## permission and occupancy. A swimming object wants the opposite permission:
+## CanObjectMoveInDirection branches on OBJECT_PALETTE's SWIMMING bit into
+## WillObjectBumpIntoLand, which refuses anything but WATER_TILE, where the
+## not-swimming branch refuses anything but LAND_TILE. Everything after that
+## branch is shared, so only the permission differs.
 func can_object_walk_to(
 	cell: Vector2i, moving: Gen2WorldObject, direction: Vector2i = Vector2i.ZERO
 ) -> bool:
@@ -5378,22 +5319,13 @@ func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 
 
 ## Drains the presentation trail an `applymovement` left on the objects it moved,
-## and nothing else.
-##
-## Separate from [method advance_object_steps_pass] because that one decides
-## movement and a caller stops calling it while a script runs, which is exactly
-## when a scripted stream needs drawing. This decides nothing, rolls nothing and
+## and nothing else. Separate from [method advance_object_steps_pass] because that
+## one decides movement and a caller stops calling it while a script runs, which
+## is exactly when a scripted stream needs drawing. This decides nothing and
 ## writes no cell: every cell the stream names committed when it was applied.
-## Returns true when something a renderer draws moved.
-## `FreezeAllOtherObjects` (engine/overworld/map_objects.asm): `ApplyMovement`
-## freezes every object that has a sprite and then clears the bit on the one it
-## is about to move, so the map stands still around a scripted walk and nowhere
-## else. [param moving_index] is -1 for the player, who is object struct 0 on
-## the cartridge and not a member of `objects` here.
-##
-## `UnfreezeFollowerObject` behind it clears the follower's bit when the object
-## being moved is the leader it was told to follow, which is what keeps a
-## `follow` pair walking together through one `applymovement`.
+## Below, `FreezeAllOtherObjects`: `ApplyMovement` freezes every object with a
+## sprite and clears the bit on the one it is about to move, and
+## `UnfreezeFollowerObject` behind it keeps a `follow` pair walking together.
 func freeze_all_other_objects(moving_index: int) -> void:
 	for slot: int in objects.size():
 		var object: Gen2WorldObject = objects[slot]
@@ -5576,15 +5508,14 @@ func _follow_object_is_visible(object_index: int) -> bool:
 	return object.active and not object.deleted
 
 
-## Every follower of [param leader_index] steps into the cell that leader has
-## just left. `follow` names the leader first and the follower second, and the
-## follower may be the player, so this is driven by an object's scripted step as
-## well as by a player one; [param leader_index] is -1 for the player.
-##
-## Follower steps commit on the map bounds alone, for the same reason a scripted
-## step and a trainer approach do: MovementFunction_Follow is HandleMovementData
-## over the queued leader commands (engine/overworld/map_objects.asm), so every
-## one of them lands in NormalStep and never reaches CanObjectMoveInDirection.
+## Every follower of [param leader_index] steps into the cell that leader has just
+## left. `follow` names the leader first and the follower second, and the follower
+## may be the player, so this is driven by an object's scripted step as well as by
+## a player one; [param leader_index] is -1 for the player. Follower steps commit
+## on the map bounds alone, for the same reason a scripted step and a trainer
+## approach do: MovementFunction_Follow is HandleMovementData over the queued
+## leader commands, so every one of them lands in NormalStep and never reaches
+## CanObjectMoveInDirection.
 func _advance_followers(leader_index: int, leader_from_cell: Vector2i) -> void:
 	if current_map == null:
 		return
@@ -5661,22 +5592,14 @@ func _step_follower(follower_index: int, target_cell: Vector2i, exact: bool) -> 
 	_object_facing_overrides[override_key] = follower.facing
 
 
-## Moves one cell or enters a neighboring map when the step leaves a connected
-## map edge. The legacy boolean move() wrapper remains available to callers.
-## `DoPlayerMovement`, which is what a button press reaches: `.CheckTurning`
-## and then [method move_result]'s `.TryStep`.
-##
-## `.CheckTurning`'s own comment is "This also lets the player change facing
-## without moving by tapping a direction". It runs before any collision check,
-## so a direction that differs from the current facing turns on the spot even
-## into a wall, and the walk happens on the next poll, once the facing agrees.
-## It guards on `wPlayerTurningDirection`, which `.StandInPlace` clears, so a
-## turn is only ever taken from a standstill.
-##
-## Only the input path has it. `applymovement` drives an object through
-## `engine/overworld/movement.asm` and never reaches `DoPlayerMovement`, which
-## is why a scripted walk turns nothing and [method move_result] stays the
-## step on its own.
+## Moves one cell or enters a neighboring map when the step leaves a connected map
+## edge. Below, `DoPlayerMovement`, which is what a button press reaches:
+## `.CheckTurning` and then [method move_result]'s `.TryStep`. `.CheckTurning` runs
+## before any collision check, so a direction that differs from the current facing
+## turns on the spot even into a wall and the walk happens on the next poll; it
+## guards on `wPlayerTurningDirection`, so a turn is only taken from a standstill.
+## Only the input path has it: `applymovement` never reaches `DoPlayerMovement`,
+## which is why a scripted walk turns nothing.
 func player_input_move(direction: Vector2i) -> Dictionary:
 	if abs(direction.x) + abs(direction.y) != 1:
 		return {"ok": false, "kind": &"move", "reason": &"invalid_direction"}
@@ -5902,26 +5825,14 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	}
 
 
-## .CheckStrengthBoulder, then the boulder's own MovementFunction_Strength.
-##
-## The source splits these across two frames: the player's step flags the boulder
-## and bumps, and the boulder starts moving on its next movement tick. Nothing
-## observable sits between the two, because the boulder is not asked to decide
-## anything in between and the flag it carries is cleared unread by nobody, so
-## both are resolved here in one call. The player is not moved either way; the
-## caller still reports a blocked step.
-##
-## Refusals, in the source's own order: BIKEFLAGS_STRENGTH_ACTIVE_F, then a
-## boulder that is standing (OBJECT_WALKING == STANDING, so a boulder already
-## mid-push is not pushed again), then the destination the boulder would take.
-## The boulder's own cell being a pit stops it permanently
-## (MovementFunction_Strength .on_pit), which is Blackthorn Gym 2F's puzzle and
-## the only thing that reads it.
-##
-## [param destination] is the boulder's cell, already known to have refused the
-## player. Its permission is checked here because .CheckLandPerms runs before
-## .CheckNPC, so a boulder standing somewhere the player could not walk anyway is
-## never even considered.
+## `.CheckStrengthBoulder`, then the boulder's own `MovementFunction_Strength`.
+## The source splits these across two frames, but nothing observable sits between
+## the two, so both are resolved here in one call; the player is not moved either
+## way and the caller still reports a blocked step. Refusals in the source's own
+## order: BIKEFLAGS_STRENGTH_ACTIVE_F, a boulder that is not standing, then the
+## destination the boulder would take. The boulder's own cell being a pit stops it
+## permanently, which is Blackthorn Gym 2F's puzzle. [param destination]'s
+## permission is checked here because `.CheckLandPerms` runs before `.CheckNPC`.
 func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	if not strength_active():
 		return {}
@@ -6548,21 +6459,14 @@ static func _escape_rope_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"escape_rope_failed", "reason": reason}
 
 
-## `CheckForHiddenItems`, which is the whole of the Itemfinder: a BGEVENT_ITEM
-## whose flag is still clear, inside the screen the player stands in the middle
-## of. The window is the source's own arithmetic on the bottom right corner,
-## `wXCoord + SCREEN_WIDTH / 4` and `wYCoord + SCREEN_HEIGHT / 4`, accepted while
-## the difference stays below half a screen: four cells up and left of the
-## player, four down and five right.
-## Every BGEVENT_ITEM on the current map, as `{cell, item, flag, taken}`, whether
-## or not it has been picked up: `taken` is [method event_flag_active] on its own
-## flag, which is the Itemfinder's own test. A read and scene-free, like
-## [method visible_encounter_cells], so a probe can walk a map and print them
-## with no game running.
-##
-## The map's own events and nothing past them; a connection's belong to the
-## connected map. An event whose three bytes do not decode is dropped rather than
-## offered with a zero item, the way [method _hidden_item_record] refuses one.
+## `CheckForHiddenItems`, the whole of the Itemfinder: a BGEVENT_ITEM whose flag
+## is still clear, inside the screen the player stands in the middle of. The window
+## is the source's own arithmetic on the bottom right corner, four cells up and
+## left of the player and four down and five right. Below, every BGEVENT_ITEM on
+## the current map as `{cell, item, flag, taken}` whether or not it has been picked
+## up, read and scene-free so a probe can walk a map with no game running. The
+## map's own events and nothing past them; an event whose three bytes do not decode
+## is dropped rather than offered with a zero item.
 func hidden_items() -> Array:
 	var out: Array = []
 	if current_map == null:
@@ -6619,12 +6523,9 @@ func take_hidden_item(cell: Vector2i) -> Array:
 ## the ordinary script path, so the bag write, the save, the received line, the
 ## fanfare and the pack-full branch are all the host's exactly as they are for a
 ## give the map makes. Answers the script results [method take_hidden_item] does,
-## and an empty array when the item is not one the cartridge knows or when a
-## script is already running.
-##
-## There is no cell, no event flag and no map behind it: this is the give a mod
-## asked for through [method Gen2ModHost.request_item_gift], and the mod named
-## the item and nothing else.
+## and an empty array when the item is not one the cartridge knows or when a script
+## is already running. There is no cell, no event flag and no map behind it: the
+## mod named the item and nothing else.
 func give_item_gift(item: int, quantity: int = 1) -> Array:
 	if current_map == null or _active_script != null or not _script_queue.is_empty():
 		return []
@@ -6936,23 +6837,14 @@ func _day_care_species(sprite_number: int) -> int:
 	return 0 if mon == null else mon.species
 
 
-## One row of a map's object events as a live object.
-##
-## `GetMonSprite`'s `.Variable` branch reads wVariableSprites and falls through
-## to `.NoBreedmon` on a zero slot, whose `ld a, WALKING_SPRITE` is 1 and so
-## `SPRITE_CHRIS` by coincidence of two constant lists
-## (engine/overworld/overworld.asm). Reaching that fallback is the exception and
-## not the rule: `Gen2WorldState.INITIAL_VARIABLE_SPRITES` is what
-## `InitializeEventsScript` leaves in nine of the slots and
-## `ToggleDecorationsVisibility` fills the other four, so every slot any map
-## stands an object on has a row. An object drawn as the player means the table
-## lost one. An object that should not be there at all is masked by [method
-## load_object_masks], not by this fallback.
-## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail: it writes a sprite number
-## straight into `wMapObjects` and calls `GetUsedSprite`, because the Battle
-## Tower's opponent is drawn at random and its object event carries a placeholder
-## instead. The overworld sprite is replaced in place; nothing else about the
-## object moves.
+## One row of a map's object events as a live object. `GetMonSprite`'s `.Variable`
+## branch reads wVariableSprites and falls through to `.NoBreedmon` on a zero slot,
+## whose `ld a, WALKING_SPRITE` is 1 and so `SPRITE_CHRIS` by coincidence of two
+## constant lists. Reaching that fallback is the exception: every slot any map
+## stands an object on has a row, so an object drawn as the player means the table
+## lost one. Below, `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail, which
+## writes a sprite number straight into `wMapObjects` because the Battle Tower's
+## opponent is drawn at random and its object event carries a placeholder.
 func set_object_sprite(index: int, sprite_number: int) -> Dictionary:
 	if index < 0 or index >= objects.size() or sprite_number <= 0:
 		return {"ok": false, "reason": &"invalid_object_sprite", "object": index}
@@ -6979,17 +6871,13 @@ func _object_from_event(index: int, value: Dictionary) -> Gen2WorldObject:
 
 
 ## The people standing on the maps [method map_placements] puts around this one,
-## for a view wide enough to see them.
-##
-## Deliberately not part of [member objects]: `ReadObjectEvents` fills
-## `wMapObjects` from the loaded map alone, so on the cartridge a connected
-## map's people do not exist until its own map load builds them. These take no
-## step, run no script, answer no collision and are not talked to. They stand
-## where their map's event data puts them, which is what a town seen from the
-## route next to it looks like.
-##
-## Each entry is `{"object": Gen2WorldObject, "offset": Vector2i}`, the offset
-## being the map's own origin in walk cells.
+## for a view wide enough to see them. Deliberately not part of [member objects]:
+## `ReadObjectEvents` fills `wMapObjects` from the loaded map alone, so on the
+## cartridge a connected map's people do not exist until its own map load builds
+## them. These take no step, run no script, answer no collision and are not talked
+## to; they stand where their map's event data puts them, which is what a town seen
+## from the route next to it looks like. Each entry is `{object, offset}`, the
+## offset being the map's own origin in walk cells.
 func connected_map_objects() -> Array:
 	if not _connected_objects.is_empty() or current_map == null or data == null:
 		return _connected_objects

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -2,16 +2,12 @@ class_name Gen2WorldBagHost
 extends RefCounted
 
 ## Bag-only transactions: what the pack changes without a party, a mart or a
-## script behind it. `TossItem` (`home/item.asm`, `_TossItem`), the two halves of
-## `GiveTakePartyMonItem` and `RegisterItem`.
-##
-## The source routine walks `_TossItem`'s pocket jumptable to find which packed
-## array the item lives in and calls `RemoveItemFromPocket` on it. The flat item
-## model has one stack per item and no pocket arrays, so the whole walk is a
-## subtraction. Nothing observable differs until a save can hold two stacks.
-##
-## The commit boundary is [Gen2WorldTransaction], the same one the mart, Kurt
-## and the party hosts go through.
+## script behind it. `TossItem`, the two halves of `GiveTakePartyMonItem` and
+## `RegisterItem`. The source routine walks `_TossItem`'s pocket jumptable to find
+## which packed array the item lives in and calls `RemoveItemFromPocket` on it; the
+## flat item model has one stack per item and no pocket arrays, so the whole walk
+## is a subtraction and nothing observable differs until a save can hold two
+## stacks. The commit boundary is [Gen2WorldTransaction].
 
 ## `TossItem` with `wCurItemQuantity`, as one validated transaction.
 ##
@@ -55,17 +51,14 @@ static func toss(
 	}
 
 
-## `TryGiveItemToPartymon`, which the pack's GIVE and the party submenu's ITEM
-## both reach. [param swap] is the answer to `PokemonAskSwapItemText`: without it
-## a Pokemon already holding something is refused with nothing written, which is
-## where the source stops to ask.
-##
-## `ItemIsMail` is [method Gen2HeldItem.is_mail] and it is read twice here.
-## `.please_remove_mail` refuses in front of the swap, because a message cannot
-## be taken off with the item that carries it; and `GivePartyItem` runs
-## `ComposeMailMessage` when the item being given is mail, which is a screen
-## rather than a transaction, so the caller writes it and hands the finished
-## [param mail] in.
+## `TryGiveItemToPartymon`, which the pack's GIVE and the party submenu's ITEM both
+## reach. [param swap] is the answer to `PokemonAskSwapItemText`: without it a
+## Pokemon already holding something is refused with nothing written, which is
+## where the source stops to ask. `ItemIsMail` is read twice here:
+## `.please_remove_mail` refuses in front of the swap, because a message cannot be
+## taken off with the item that carries it, and `GivePartyItem` runs
+## `ComposeMailMessage` when the item given is mail, which is a screen rather than
+## a transaction, so the caller writes it and hands the finished [param mail] in.
 static func give_to_party(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -126,41 +126,14 @@ static func prepare(
 	}
 
 
-## `LoadEnemyMon`'s `.InitDVs` for a wild, which is the whole of what decides
-## whether the Pokemon in the grass is shiny, has a bad stat or answers a
-## different Hidden Power. Every wild reached this with 15/15/15/15 before,
-## because only the visible-encounter provider ever put `dvs` in the request and
-## the other eight sources (grass, surf, fishing, Headbutt, Rock Smash, the Bug
-## Contest, a static `loadwildmon`, a roamer) carried none.
-##
-## Rolled here rather than in each of those callers: this is the one place a
-## wild is built, and [param generator] is the battle's own, so an encounter
-## stays inside the run's reproducible sequence.
-##
-## Three cases keep an answer of their own, in the source's order:
-##
-## - a request already carrying `dvs` keeps it, which is what leaves the
-##   Pokemon a player walked up to the one they saw, and is also `.Roaming`'s
-##   stored word once the roamer's struct has been initialised;
-## - [constant Gen2Battle.BATTLETYPE_FORCESHINY] writes
-##   [constant Gen2Stats.SHINY_DVS] rather than rolling. This is the red
-##   Gyarados, which nothing read the type for until now;
-## - a wild UNOWN rerolls until its letter is one the Ruins of Alph puzzle has
-##   unlocked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`. The source
-##   notes the loop never ends if a forced shiny is also an Unown, so the shiny
-##   branch stays in front of it here the way it is there.
-## `BattleWon.give_money` and `CheckPayDay`, the two credits the way out of a
-## won battle pays, worked out once for whichever host fought it.
-##
-## Both are a win's own: `.give_money` is reached from the trainer branch of
-## `BattleWon`, and `CheckPayDay` sits behind `.HandleEndOfBattle`'s
-## `and $f / ret nz`, so a loss, a draw and a run all pay nothing. [param won] is
-## that `wBattleResult` test, passed in rather than read off the battle: a host
-## that settles a fight by fiat rather than playing it knows its own outcome.
-## [param state] is read for Mom's savings tier and her balance, never written.
-##
-## Returns `money` keyed by account, the figure `GotMoneyForWinningText` prints,
-## which of its four lines that is, and the Pay Day coins.
+## `LoadEnemyMon`'s `.InitDVs` for a wild, which decides whether the Pokemon in
+## the grass is shiny, has a bad stat or answers a different Hidden Power. Rolled
+## here rather than in each of the nine callers: this is the one place a wild is
+## built, and [param generator] is the battle's own. Three cases keep an answer of
+## their own, in the source's order: a request already carrying `dvs` keeps it,
+## which is what leaves a player the Pokemon they walked up to;
+## BATTLETYPE_FORCESHINY writes [constant Gen2Stats.SHINY_DVS]; and a wild UNOWN
+## rerolls until its letter is one the Ruins of Alph puzzle has unlocked.
 static func earnings(battle: Gen2Battle, state: Gen2WorldState, won: bool) -> Dictionary:
 	var result: Dictionary = {
 		"money": {}, "prize_shown": 0, "prize_line": &"", "pay_day": 0,
@@ -237,15 +210,13 @@ static func wild_dvs(
 	return word
 
 
-## Two `BattleRandom` bytes, high byte first, rerolled while the letter they give
-## a wild Unown is locked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`.
-##
+## Two `BattleRandom` bytes, high byte first, rerolled while the letter they give a
+## wild Unown is locked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`.
 ## Unbounded the way the source's is, and safe for the same reason: the mask is
-## narrowed to the four real sets first, and every one of them holds letters, so
-## any mask left standing is one a roll reaches. A mask of nothing is the save
-## that has solved no puzzle, and there the gate is dropped rather than looped
-## on: `ChooseWildEncounter` refuses a wild Unown outright on that save, so a
-## caller reaching here with one has already left the cartridge's own path.
+## narrowed to the four real sets first and every one of them holds letters, so any
+## mask left standing is one a roll reaches. A mask of nothing is the save that has
+## solved no puzzle, and there `ChooseWildEncounter` refuses a wild Unown outright,
+## so a caller reaching here with one has already left the cartridge's own path.
 static func _roll_dvs(
 	generator: RandomNumberGenerator, species: int, unlocked_unowns: int
 ) -> int:

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -1,28 +1,14 @@
 class_name Gen2WorldClock
 extends RefCounted
 
-## Deterministic host clock for the real-time Generation 2 day cycle.
-## One elapsed host second is one cartridge clock second. A tick is published at
-## each completed game minute, while time-of-day changes use the cartridge's
-## 04:00, 10:00 and 18:00 boundaries.
-##
-## Seconds, not hardware frames, on purpose. Everything else in the overworld is
-## a countdown spent by [method Gen2WorldScreen.advance_frame]; the cartridge
-## reads a real-time clock for the day cycle, so this one takes wall time and
-## [method Gen2WorldScreen._advance_day_cycle] is the only caller that hands it
-## `delta`. A test or a replay reaches any boundary by asking for the seconds
-## rather than by waiting for them
-## ([method Gen2WorldScreen.advance_world_time]).
-##
-## The clock keeps its own time while the game is not running, which is what a
-## cartridge's RTC does: a snapshot records the host second its time was written
-## at, and [method catch_up] moves the saved time on by what has passed since.
-## Without that a save resumed at the hour it was written at, so a player who set
-## the clock in the morning never saw a night.
-##
-## The clock does not move roaming Pokémon: the cartridge advances those during
-## map setup, so [method Gen2WorldAPI.advance_schedule] is driven by a map change
-## rather than elapsed time.
+## Deterministic host clock for the real-time Generation 2 day cycle: one elapsed
+## host second is one cartridge clock second, a tick is published at each completed
+## game minute, and time-of-day changes use the cartridge's 04:00, 10:00 and 18:00
+## boundaries. Seconds rather than hardware frames on purpose, since the cartridge
+## reads a real-time clock for the day cycle; a test or a replay reaches any
+## boundary by asking for the seconds. The clock keeps its own time while the game
+## is not running, which is what an RTC does: without that a save resumed at the
+## hour it was written at. It does not move roaming Pokemon.
 
 const SECONDS_PER_MINUTE: float = 60.0
 const MINUTES_PER_HOUR: int = 60

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -1,16 +1,14 @@
 class_name Gen2WorldCollision
 extends RefCounted
 
-## Collision-code permissions. A map's grid stores the raw code from the
-## tileset's four-cell table and the game looks it up in a second table before
-## letting ordinary walking in; keeping that lookup here leaves the code itself
-## available for water, ledges and warps.
-##
-## [constant PERMISSIONS] is [code]CollisionPermissionTable[/code] entry for
-## entry, the same 256 bytes in all three games. Carried whole rather than as a
-## list of interesting codes: a code left off such a list silently becomes
-## ordinary ground, which is how the waterfall, current and buoy families and one
-## of the two headbutt trees were once walkable here.
+## Collision-code permissions. A map's grid stores the raw code from the tileset's
+## four-cell table and the game looks it up in a second table before letting
+## ordinary walking in; keeping that lookup here leaves the code itself available
+## for water, ledges and warps. [constant PERMISSIONS] is
+## `CollisionPermissionTable` entry for entry, the same 256 bytes in all three
+## games, carried whole rather than as a list of interesting codes: a code left off
+## such a list silently becomes ordinary ground, which is how the waterfall,
+## current and buoy families were once walkable here.
 
 const LAND_TILE: int = 0x00
 const WATER_TILE: int = 0x01
@@ -264,14 +262,12 @@ static func side_wall_step_blocked(from_code: int, to_code: int, direction: Vect
 
 ## home/map.asm's GetMovementPermissions: the wTilePermissions byte for a player
 ## standing on [param standing_code] with its four neighbours already read. The
-## leave rule is byte identical between the games; the enter rule is not. The
-## pins diverge only in .ok_down/.ok_up/.ok_right/.ok_left, where Crystal ORs the
-## matching FACE_* and Gold always sets bit RIGHT, numerically FACE_DOWN, because
-## those four were written with wWalkingDirection's transposed bit layout. So
-## every enter-rule match blocks DOWN alone on Gold and Silver. No shipped map of
-## theirs carries a side-wall code whose low three bits differ from 2
-## (COLL_UP_WALL, which no opposite-face test below can match), so the split
-## changes no pinned map; it stays because a mod-authored map could reach it.
+## leave rule is byte identical between the games; the enter rule is not. The pins
+## diverge only in `.ok_down`/`.ok_up`/`.ok_right`/`.ok_left`, where Crystal ORs the
+## matching FACE_* and Gold always sets bit RIGHT, because those four were written
+## with wWalkingDirection's transposed bit layout, so every enter-rule match blocks
+## DOWN alone on Gold and Silver. No shipped map of theirs reaches it; the split
+## stays because a mod-authored map could.
 static func tile_permissions(
 	standing_code: int, up_code: int, down_code: int, left_code: int, right_code: int,
 	is_crystal: bool = true,

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -2,18 +2,13 @@ class_name Gen2WorldDayCare
 extends RefCounted
 
 ## `engine/events/daycare.asm` and `engine/pokemon/breeding.asm`, the rules half.
-##
-## The two Day-Care slots are world state rather than party members: the
-## cartridge keeps them in `wBreedMon1` and `wBreedMon2`, which are boxmon
-## structs beside the flag byte that says whether each is occupied. This answers
-## what the three routines ask of that state and nothing else; the boxes,
-## presses and party list are [Gen2DayCareScreen]'s.
-##
-## Every duration and every roll here is the source's own. What a reading gets
-## wrong is which parent a field comes from: `wBreedMotherOrNonDitto` is set once
-## in `DayCare_InitBreeding` and then read by four routines that each pick a
-## *different* side of it, so it is computed once here as
-## [method mother_or_non_ditto] and passed down.
+## The two Day-Care slots are world state rather than party members: the cartridge
+## keeps them in `wBreedMon1` and `wBreedMon2`, boxmon structs beside the flag byte
+## that says whether each is occupied. This answers what the three routines ask of
+## that state and nothing else. What a reading gets wrong is which parent a field
+## comes from: `wBreedMotherOrNonDitto` is set once in `DayCare_InitBreeding` and
+## then read by four routines that each pick a different side of it, so it is
+## computed once here as [method mother_or_non_ditto] and passed down.
 
 ## `wDayCareMan`'s four bits (constants/ram_constants.asm).
 const MAN_HAS_MON: int = 1 << 0

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -1,16 +1,13 @@
 class_name Gen2WorldDecoration
 extends RefCounted
 
-## `engine/overworld/decorations.asm`: which decorations the player owns, the
-## seven category menus `_PlayerDecorationMenu` opens over them, and the
-## `DecoAction_*` that move one between a `wDeco*` slot and the room.
-##
-## Scene-free like the other world hosts. Ownership is an event flag, which the
-## state already carries, and a placed decoration is a `wDeco*` slot, which is
-## [method Gen2WorldState.maptile_decoration]; nothing here is new save state.
-## The imported `DecorationAttributes` row is the only source of a decoration's
-## type, name parts, action, flag and block or sprite, so a mod repointing one
-## takes all five with it.
+## `engine/overworld/decorations.asm`: which decorations the player owns, the seven
+## category menus `_PlayerDecorationMenu` opens over them, and the `DecoAction_*`
+## that move one between a `wDeco*` slot and the room. Scene-free like the other
+## world hosts. Ownership is an event flag and a placed decoration is a `wDeco*`
+## slot, so nothing here is new save state. The imported `DecorationAttributes` row
+## is the only source of a decoration's type, name parts, action, flag and block or
+## sprite, so a mod repointing one takes all five with it.
 
 ## `constants/deco_constants.asm`' decoration types, which decide how
 ## `GetDecoName` spells a row rather than which category it is in.

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -1,15 +1,13 @@
 class_name Gen2WorldEffects
 extends RefCounted
 
-## Scene-free presentation state for effects that the overworld engine paces in
-## hardware frames. The renderer owns the pixels; this class owns the source
-## duration, amplitude and deterministic offsets.
-##
-## Two shapes live here. `ShakeScreen` is one packed byte of duration and
-## amplitude. The rest are the sprites the engine draws over the map rather than
-## as map objects: `SpawnStrengthBoulderDust`, `ShakeGrass`, `ShakeHeadbuttTree`,
-## `OWCutAnimation` and `SpawnShadow`, each its own frameset over one of the
-## sheets GameData.overworld_effect() holds.
+## Scene-free presentation state for effects the overworld engine paces in hardware
+## frames: the renderer owns the pixels and this owns the source duration,
+## amplitude and deterministic offsets. Two shapes live here. `ShakeScreen` is one
+## packed byte of duration and amplitude. The rest are the sprites the engine draws
+## over the map rather than as map objects, `SpawnStrengthBoulderDust`,
+## `ShakeGrass`, `ShakeHeadbuttTree`, `OWCutAnimation` and `SpawnShadow`, each its
+## own frameset over one of the sheets `GameData.overworld_effect()` holds.
 
 var _frame: int = 0
 var _duration: int = 0

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -1,22 +1,14 @@
 class_name Gen2WorldEncounters
 extends RefCounted
 
-## Wild Pokemon a mod puts on the map instead of a step roll, driven and
-## validated by the host. A mod registers a PROVIDER through
-## [method Gen2ModHost.register_visible_encounters]; the screen gives it a
-## snapshot of where a wild may stand and which table each method resolves to,
-## spends one frame of it per hardware frame, and takes back a bounded list of
-## entries.
-##
-## The division is the point. The PROVIDER owns the population: how many there
-## are, where each one goes, how it moves and what it does after a battle. The
-## HOST owns every rule a mod must not re-derive: which cells are eligible, which
-## table is active, whether an entry is inside both, what a shiny is, and what
-## meeting one starts. Nothing here reads a node.
-##
-## [Gen2WorldActors] is the layer next to this one and the two are different
-## contracts: an actor is presentation and takes part in nothing, a visible
-## encounter is met and fought.
+## Wild Pokemon a mod puts on the map instead of a step roll, driven and validated
+## by the host. The screen gives a registered PROVIDER a snapshot of where a wild
+## may stand and which table each method resolves to, spends one frame of it per
+## hardware frame, and takes back a bounded list of entries. The division is the
+## point: the provider owns the population, and the host owns every rule a mod
+## must not re-derive. Nothing here reads a node. [Gen2WorldActors] is the layer
+## next to this one and the two are different contracts: an actor is presentation,
+## a visible encounter is met and fought.
 
 ## Checked at registration, where the mod's name is still in hand.
 const PROVIDER_METHODS: Array[String] = [
@@ -40,24 +32,14 @@ const PULSE_FRAMES: int = 600
 ## The four `Gen2WorldSprite` facings.
 const MAX_FACING: int = Gen2WorldSprite.FACING_RIGHT
 
-## How many steps an entry's `glow` amount is rounded onto, and the palette
-## colour it leaves alone.
-##
-## The rung count is the host's rather than the mod's on purpose. Both world
-## renderers cache one sprite texture per distinct set of four colours and
-## neither evicts (`world_renderer.gd:_actor_texture` keys on `hash(colors)`), so
-## a glow interpolated freely would leave a texture behind on every frame the map
-## is up. Nine amounts is nine palettes per species, and the key carries a facing
-## and a frame beside them: eight of those, so seventy-two textures for a species
-## that glows and none for one that does not.
-##
-## Eight rather than four because a mark meant to be subtle has to keep a cycle
-## after the rounding. A glow whose peak is under half the walk, which is what
-## reads as a breath rather than a recolour, has four steps left on eighths and
-## one on quarters.
-##
-## Colour 0 is the icon's cut-out ([method Gen2PicImage.lookup] gives it alpha
-## zero), so walking it would change the cache key and no pixel.
+## How many steps an entry's `glow` amount is rounded onto, and the palette colour
+## it leaves alone. The rung count is the host's rather than the mod's: both world
+## renderers cache one sprite texture per distinct set of four colours and neither
+## evicts, so a glow interpolated freely would leave a texture behind on every
+## frame the map is up. Eight rather than four because a mark meant to be subtle
+## has to keep a cycle after the rounding: a glow whose peak is under half the
+## walk has four steps left on eighths and one on quarters. Colour 0 is the icon's
+## cut-out, so walking it would change the cache key and no pixel.
 const GLOW_RUNGS: int = 8
 const GLOW_CUTOUT_COLOR: int = 0
 
@@ -280,12 +262,10 @@ func _build_context() -> Dictionary:
 ## deliberately NOT folded into `eligible`: which cells a wild MAY stand on is
 ## `CanEncounterWildMon`'s rule and does not change while the map is up, and
 ## [method _validate] drops an entry standing outside `eligible`, so folding the
-## two together would delete a wild an NPC walks over.
-##
-## An object mid-step is DRAWN between two cells, so both are held: its committed
-## `cell` and the cell its drawing laps into, which is what `step_offset_cells()`
-## measures. A big object holds all four of the cells `occupies` answers for.
-## The player is not in it; `player` is where that cell is.
+## two together would delete a wild an NPC walks over. An object mid-step is DRAWN
+## between two cells, so both are held, and a big object holds all four of the
+## cells `occupies` answers for. The player is not in it; `player` is where that
+## cell is.
 func _occupied_cells() -> PackedVector2Array:
 	var out := PackedVector2Array()
 	if _world == null:
@@ -308,25 +288,13 @@ func _occupied_cells() -> PackedVector2Array:
 
 
 ## What moves while one map is up: the player's pose, the cells the map's own
-## objects hold, the tables, and `wildoff`. An object walks while the player
-## stands still, so the occupancy is on this pass rather than on the map change.
-##
-## The eligible sweep is the whole map and is taken only when `wildoff` is
-## toggled, which is the one thing that moves it: `CanEncounterWildMon`'s answer
-## for a cell is the terrain's and stands as long as the map does. A script may
-## run `wildoff` at any point in a walk, and an entry standing on a cell it just
-## emptied is dropped by [method _validate] rather than grandfathered: a wild is
-## admitted against a table, never against a map that has switched wilds off.
-##
-## The tables move without the map: six o'clock, a swarm arriving, and the Bug
-## Contest starting or ending each change what a roll would read. A provider that
-## mints an entry LATER than the map change plans it against whatever it was
-## handed, so a stale snapshot would spawn a day species at night and
-## [method _table_offers] would agree with it. `generation` is deliberately not
-## bumped: that means "the map changed, discard everything", and an hour boundary
-## is not a map change.
-##
-## Pushed once, so a frame that moves two of the three costs one call.
+## objects hold, the tables, and `wildoff`. The eligible sweep is the whole map and
+## is taken only when `wildoff` is toggled, which is the one thing that moves it,
+## and an entry standing on a cell it just emptied is dropped rather than
+## grandfathered. The tables move without the map: six o'clock, a swarm arriving
+## and the Bug Contest each change what a roll would read, so a provider minting an
+## entry later plans it against whatever it was handed. `generation` is deliberately
+## not bumped: an hour boundary is not a map change. Pushed once per frame.
 func _push_context_changes() -> void:
 	if _world == null or _context.is_empty():
 		return

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -11,14 +11,10 @@ extends RefCounted
 ## `giveegg` and a `givepoke` that names an OT each run to completion inside the
 ## command that asked for them and the script runs straight on, so a screen
 ## completes one where it is staged rather than waiting for a press.
-##
 ## `pokemon_requested` is here for those and no further: `GivePoke`'s `.wildmon`
-## branch reaches `GiveANickname_YesNo`, which is a box and a naming screen, so a
-## screen that can draw one intercepts the request in front of this list
-## (`Gen2WorldScreen._open_gift_nickname`) and a driver that cannot settles it
-## here with the species name, which is what NO answers.
-## `contest_mon_requested` is `CheckPartyFullAfterContest`, which reaches the
-## same routine one caller further on and is intercepted the same way.
+## branch reaches `GiveANickname_YesNo`, so a screen that can draw one intercepts
+## the request in front of this list and a driver that cannot settles it here with
+## the species name, which is what NO answers.
 const UNATTENDED_REQUESTS: Array[StringName] = [
 	&"party_heal_requested", &"pokemon_requested", &"trade_requested",
 	&"contest_mon_requested",

--- a/game/world/world_map_layer.gd
+++ b/game/world/world_map_layer.gd
@@ -1,23 +1,14 @@
 class_name Gen2WorldMapLayer
 extends Node2D
 
-## One map's blocks, drawn as a single quad.
-##
-## `LoadMetatiles` resolves a block byte to sixteen graphics tiles every time it
-## refreshes the screen, and the renderer used to do the same on the CPU: one
-## draw per 8x8 tile, 380 of them for a hardware screen. A view that fills the
-## window at one pixel per world pixel wants tens of thousands, and a view that
-## takes in a whole region wants hundreds of thousands, which no per-tile loop
-## reaches at sixty frames a second.
-##
-## So the fold moves to the GPU. The block buffer, the tileset's metatile table
-## and the coloured tile strip go across as three byte textures and the fragment
-## shader does exactly what [method Gen2WorldAPI.drawn_block_at] does: block
-## byte, `$00` to the map's border block, metatile slot, tile, pixel. Nothing is
-## baked, so the strip the animation and the map fades already repaint is the
-## one this samples and neither needs a second path.
-##
-## Drawn behind its parent, so the renderer's own sprites stay above the map.
+## One map's blocks, drawn as a single quad. `LoadMetatiles` resolves a block byte
+## to sixteen graphics tiles every time it refreshes the screen, and the renderer
+## used to do the same on the CPU: 380 draws for a hardware screen, tens of
+## thousands for a window-filling view and hundreds of thousands for a region.
+## So the fold moves to the GPU: the block buffer, the metatile table and the
+## coloured tile strip go across as three byte textures and the fragment shader
+## does what [method Gen2WorldAPI.drawn_block_at] does. Nothing is baked, so the
+## strip the animation repaints is the one this samples.
 
 ## The three lookups a tile costs, in one pass. `map_blocks` of zero is the void
 ## fill: every block is the border block, which is what surrounds a map on the

--- a/game/world/world_mom_phone.gd
+++ b/game/world/world_mom_phone.gd
@@ -2,16 +2,12 @@ class_name Gen2WorldMomPhone
 extends RefCounted
 
 ## `engine/events/mom_phone.asm`: what Mom's savings buy while the player is out,
-## and the call she makes about it.
-##
-## `MomTriesToBuySomething` runs after a trainer battle, on the same
-## `Script_reloadmapafterbattle` branch `Script_SpecialBillCall` sits opposite
-## (`Gen2WorldScreen._start_box_full_call`). It reads her balance, decides
-## whether a purchase is due, hands the item over and puts her on the line.
-##
-## Scene-free like the other world hosts, and split the way the source is: this
-## file is `CheckBalance_MomItem2` and `Mom_GetScriptPointer`, the decision;
-## applying it is [method Gen2WorldAPI.mom_purchase] and the call is
+## and the call she makes about it. `MomTriesToBuySomething` runs after a trainer
+## battle, on the same `Script_reloadmapafterbattle` branch `Script_SpecialBillCall`
+## sits opposite. It reads her balance, decides whether a purchase is due, hands
+## the item over and puts her on the line. Scene-free like the other world hosts,
+## and split the way the source is: this file is the decision, applying it is
+## [method Gen2WorldAPI.mom_purchase] and the call is
 ## [method Gen2WorldAPI.request_caller_phone_call].
 
 ## `PhoneContacts` index. Mom is the second row on all three cartridges.

--- a/game/world/world_money_dial.gd
+++ b/game/world/world_money_dial.gd
@@ -1,15 +1,13 @@
 class_name Gen2WorldMoneyDial
 extends RefCounted
 
-## `Mom_WithdrawDepositMenuJoypad` (`engine/events/mom.asm`), the six-digit money
-## dial her bank is the only caller of. It owns `wStringBuffer2`, the amount
-## being typed, and `wMomBankDigitCursorPosition`, which digit the cursor stands
-## on; the caller owns the box the three balances are drawn in.
-##
-## Not [Gen2WorldQuantityPrompt], which is `BuySellToss_InterpretJoypad`: that
-## dial steps one value against a ceiling and this one adds and subtracts a
-## power of ten per digit, so up on the hundreds column moves the amount by a
-## hundred rather than moving a digit.
+## `Mom_WithdrawDepositMenuJoypad`, the six-digit money dial her bank is the only
+## caller of. It owns `wStringBuffer2`, the amount being typed, and
+## `wMomBankDigitCursorPosition`, which digit the cursor stands on; the caller owns
+## the box the three balances are drawn in. Not [Gen2WorldQuantityPrompt], which is
+## `BuySellToss_InterpretJoypad`: that dial steps one value against a ceiling and
+## this one adds and subtracts a power of ten per digit, so up on the hundreds
+## column moves the amount by a hundred rather than moving a digit.
 
 ## `.DigitQuantities`, `10**x` for x from five down to nought. The table is
 ## written out three times in the source and only the first sixth is indexed:

--- a/game/world/world_options_menu.gd
+++ b/game/world/world_options_menu.gd
@@ -1,16 +1,12 @@
 class_name Gen2WorldOptionsMenu
 extends RefCounted
 
-## Scene-free model of the in-game OPTION menu (engine/menus/options_menu.asm).
-##
-## Seven value rows plus CANCEL, each row a left/right cycle over one field of
-## [Gen2Options]. The model edits that object in place and never touches the
-## file: [Gen2OptionsStore] owns persistence, the way [Gen2InputActions] leaves
-## it alone.
-##
-## `data/default_options.asm` and the whole menu are byte identical between the
-## pins except pokegold's `.ExitOptions` lacking the `SFX_TRANSACTION` play, so
-## nothing here is profile split.
+## Scene-free model of the in-game OPTION menu (engine/menus/options_menu.asm):
+## seven value rows plus CANCEL, each a left/right cycle over one field of
+## [Gen2Options]. The model edits that object in place and never touches the file,
+## the way [Gen2InputActions] leaves it alone. `data/default_options.asm` and the
+## whole menu are byte identical between the pins except pokegold's `.ExitOptions`
+## lacking the `SFX_TRANSACTION` play, so nothing here is profile split.
 
 ## GetOptionPointer.Pointers indexes.
 const OPT_TEXT_SPEED: int = 0

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -2,19 +2,13 @@ class_name Gen2WorldPack
 extends RefCounted
 
 ## Scene-free grouping of owned items into the cartridge's four pack pockets.
-##
-## `Gen2WorldState` stores items as a flat item-to-quantity map; this is
-## presentation only and does not change that. Classification uses the item type
-## byte GameData imports under the confusingly-named `pocket` field
-## (`data/items/attributes.asm`'s `item_attribute` macro calls it "pocket";
-## `constants/item_data_constants.asm` names the same values
-## `ITEM`/`KEY_ITEM`/`BALL`/`TM_HM`), which is what decides a real item's pocket.
-## Source capacities (the four `MAX_*` below) are enforced at data-aware receive
-## seams. The save remains a flat item-to-quantity map, so one item cannot be
-## split into two 99-count stacks like the source's packed pocket arrays can.
-##
-## Pockets registered on `Gen2ModHost` follow the four source ones, and the item
-## submenu below is `engine/items/pack.asm`'s own header selection.
+## [Gen2WorldState] stores items as a flat item-to-quantity map and this is
+## presentation only. Classification uses the item type byte GameData imports under
+## the confusingly-named `pocket` field, which is what decides a real item's
+## pocket. The save remains flat, so one item cannot be split into two 99-count
+## stacks like the source's packed pocket arrays can. Pockets registered on
+## [Gen2ModHost] follow the four source ones, and the item submenu below is
+## `engine/items/pack.asm`'s own header selection.
 
 const TYPE_ITEM: int = 1
 const TYPE_KEY_ITEM: int = 2
@@ -159,14 +153,10 @@ static func source_pocket_name(data: GameData, item: int) -> String:
 ## The five rows `ScrollingMenu_UpdateDisplay` writes, out of one pocket's own
 ## items and the CANCEL row after them. The TM/HM pocket is
 ## `TMHM_DisplayPocketItems`, which prints the TM number and the move it teaches
-## rather than the item's name.
-##
-## Here rather than in the screen that scrolls them, because the pack listing is
-## drawn on more than one screen and only one of them owns a cursor.
-##
-## [param cancel] is the row that closes the pack. A screen that cannot be closed
-## because nothing on it takes a button asks for the listing without it, the way
-## [method Gen2PartyMenuPage.render] is asked for one without its own CANCEL.
+## rather than the item's name. Here rather than in the screen that scrolls them,
+## because the pack listing is drawn on more than one screen and only one of them
+## owns a cursor. [param cancel] is the row that closes the pack: a screen that
+## cannot be closed asks for the listing without it.
 static func list_rows(
 	data: GameData, pocket_type: int, items: Array, scroll: int = 0,
 	cancel: bool = true
@@ -216,17 +206,13 @@ static func row_description(data: GameData, item: int) -> String:
 	return String(data.item(item).get("description", ""))
 
 
-## `SwitchItemsInBag` (`engine/items/switch_items.asm`), one press of SELECT or
-## of the A that places the held item.
-##
+## `SwitchItemsInBag`, one press of SELECT or of the A that places the held item.
 ## [param order] is one pocket's item numbers in list order, [param held] the row
 ## an earlier SELECT marked or -1 for none, and [param cursor] the row the press
 ## landed on, where a row past the last item is the CANCEL terminator the source
-## reads as -1. Answers the new order and the new held row.
-##
-## The source stores the held row as `wSwitchItem` = row + 1 so that zero means
-## none; -1 is that same "none" here. `.try_combining_stacks` cannot fire: the
-## flat item model has one stack per item, so no two rows ever carry the same
+## reads as -1. The source stores the held row as `wSwitchItem` = row + 1 so that
+## zero means none; -1 is that same "none" here. `.try_combining_stacks` cannot
+## fire: the flat item model has one stack per item, so no two rows carry the same
 ## item number.
 static func switch_items(order: Array, held: int, cursor: int) -> Dictionary:
 	var moved: Array[int] = []

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -105,13 +105,12 @@ const HAPPINESS_PROBABILITIES: Dictionary = {
 
 ## The bytes `HaircutOrGrooming`'s `.loop` reads when it walks off the end of
 ## `HappinessData_DaisysGrooming`, which is `docs/bugs_and_glitches.md`'s
-## "Daisy's grooming doesn't always increase happiness". `sub $ff` from `$ff`
-## sets no carry, so a roll of exactly 255 steps three bytes on into
-## `CopyPokemonName_Buffer1_Buffer3`'s own `ld hl, wStringBuffer1`: `$21`
-## borrows against the remaining zero, and the address's two bytes are then read
-## as the row. The address is the one part that is not shared, so the low byte
-## reaching wScriptVar and the high byte reaching `ChangeHappiness` are pinned
-## per profile out of rgblink's symbol table.
+## "Daisy's grooming doesn't always increase happiness". `sub $ff` from `$ff` sets
+## no carry, so a roll of exactly 255 steps three bytes on into
+## `CopyPokemonName_Buffer1_Buffer3`'s own `ld hl, wStringBuffer1`, and the
+## address's two bytes are then read as the row. The address is the one part that
+## is not shared, so the two bytes are pinned per profile out of rgblink's symbol
+## table.
 const STRING_BUFFER_1: Dictionary = {true: 0xD073, false: 0xCF6B}
 const HAPPINESS_TABLE_OVERRUN_OPCODE: int = 0x21
 
@@ -194,13 +193,12 @@ const HEAVY_BALL_LIGHT_PENALTY: int = 20
 
 ## `docs/bugs_and_glitches.md`'s "Heavy Ball uses wrong weight value for three
 ## Pokemon": `HeavyBall_GetDexEntryBank` masks the species without taking one off
-## first, so 64, 128 and 192 read their own entry's address out of the next
-## bank up. What is there is a different cartridge's business on each build, so
-## these are measured rather than derived: `.claude/oracle/battle/catch_rate.py`
-## on all three dumps says Gold and Silver land on the same row the right weight
-## would, and Crystal does not. KADABRA and TAUROS are what it answered there;
-## SUNFLORA is the third and has no answer, because the `.SkipText` walk never
-## finds its terminator and the cartridge locks up (see `HANDOFF.md`).
+## first, so 64, 128 and 192 read their own entry's address out of the next bank
+## up. What is there is a different cartridge's business on each build, so these
+## are measured rather than derived: `.claude/oracle/battle/catch_rate.py` says
+## Gold and Silver land on the same row the right weight would and Crystal does
+## not. SUNFLORA is the third and has no answer, because the `.SkipText` walk never
+## finds its terminator and the cartridge locks up.
 const HEAVY_BALL_WRONG_BANK: Dictionary = {64: 20, 128: 40}
 
 ## `FleeMons`' first three bytes, which is as far as `FastBallMultiplier`'s
@@ -362,17 +360,13 @@ static func heal_party(
 
 
 ## The link trade's own commit, which is `LinkTrade`'s `.do_trade` tail: the
-## offered slot leaves through `RemoveMonFromPartyOrBox` and the received
-## Pokemon is appended by `AddTempmonToParty`, so it lands at the END of the
-## party rather than in the slot that was emptied. That is the one place the
-## link trade differs from the in-game one, which writes into the vacated slot.
-##
-## `wForceEvolution` is set over the append, so a species that evolves by trade
-## evolves here and nowhere else. Mail travels with each Pokemon because it hangs
-## off the row: `sPartyMail` is shifted by the same removal.
-##
-## [param incoming] is the peer's [Gen2SaveMon] dictionary; [param peer] names
-## the trainer it came from, for the dex and for the box the caller prints.
+## offered slot leaves through `RemoveMonFromPartyOrBox` and the received Pokemon
+## is appended by `AddTempmonToParty`, so it lands at the END of the party rather
+## than in the slot that was emptied. That is the one place the link trade differs
+## from the in-game one. `wForceEvolution` is set over the append, so a species
+## that evolves by trade evolves here and nowhere else. Mail travels with each
+## Pokemon because it hangs off the row. [param incoming] is the peer's
+## [Gen2SaveMon] dictionary and [param peer] names the trainer it came from.
 static func commit_link_trade(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -502,16 +496,12 @@ static func heal_party_rows(data: GameData, save: Gen2SaveData) -> int:
 
 
 ## `Softboiled_MilkDrinkFunction`: a fifth of the user's own maximum health moved
-## from the user to another party member, as one candidate transaction.
-##
-## Both halves are the *user's* fifth. `GetOneFifthMaxHP` is called twice with
-## `wCurPartyMon` still holding the user, and only then is the recipient written
-## into it, so a big Pokemon heals a small one by a big number.
-##
-## The refusals are `.SelectMilkDrinkRecipient`'s own, in its order: the user
-## itself, a fainted recipient and one already at full health. The caller checks
-## the user's own health first, which is the `.CheckMonHasEnoughHP` this shares
-## with the party menu's line.
+## from the user to another party member, as one candidate transaction. Both halves
+## are the *user's* fifth, `GetOneFifthMaxHP` being called twice with
+## `wCurPartyMon` still holding the user, so a big Pokemon heals a small one by a
+## big number. The refusals are `.SelectMilkDrinkRecipient`'s own, in its order:
+## the user itself, a fainted recipient and one already at full health. The caller
+## checks the user's own health first.
 static func transfer_health(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -638,23 +628,13 @@ static func use_item(
 
 
 ## engine/items/tmhm.asm's TeachTMHM, as one candidate transaction beside
-## use_item(). The pack's own USE reaches this, not `UseItem`'s jumptable: the
-## TM/HM pocket runs AskTeachTMHM, ChooseMonToLearnTMHM and TeachTMHM instead
-## (engine/items/pack.asm's .UseItem).
-##
-## The refusal order is the source's. CanLearnTMHMMove comes first, then
-## KnowsMove, then LearnMove's own search for an empty slot; each answers before
-## anything is written.
-##
-## A full moveset is where LearnMove reaches ForgetMove, which is a menu, so this
-## is called twice: once with [param forget_slot] left at -1, which is what runs
-## the two compatibility checks and answers `moveset_full` having written
-## nothing, and again with the slot the player gave up. An empty slot always
-## wins over a passed [param forget_slot], because LearnMove.loop only reaches
-## ForgetMove when its own scan finds no zero.
-##
-## An HM is not consumed: TeachTMHM returns straight after IsHM, so it skips both
-## ConsumeTM and the happiness change.
+## `use_item()`. The pack's own USE reaches this rather than `UseItem`'s
+## jumptable. The refusal order is the source's: CanLearnTMHMMove, then KnowsMove,
+## then LearnMove's own search for an empty slot, each answering before anything is
+## written. A full moveset is where LearnMove reaches ForgetMove, which is a menu,
+## so this is called twice, once with [param forget_slot] at -1 to run the
+## compatibility checks and again with the slot the player gave up. An empty slot
+## always wins over a passed slot. An HM is not consumed: TeachTMHM skips both.
 static func teach_tm_hm(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -747,14 +727,11 @@ static func teach_tm_hm(
 ## `LearnMove` on its own, without the TM/HM that usually reaches it: what an
 ## evolution offers a Pokemon whose four slots are full. The refusal order is
 ## `LearnMove`'s own, an empty slot always winning over a passed
-## [param forget_slot] the way `.loop` does, and by default nothing is consumed
-## and no happiness moves because no item was used.
-##
-## [param compatibility_checked] is `CheckCanLearnMoveTutorMove`'s own
-## `predef CanLearnTMHMMove`, which stands in front of `KnowsMove` there and
-## nowhere else, and [param happiness_kind] its `ld c, HAPPINESS_LEARNMOVE`,
-## charged inside the same transaction the move is written in. A level-up offer
-## passes neither, which is what makes it the plain `LearnMove` it is.
+## [param forget_slot] the way `.loop` does, and by default nothing is consumed and
+## no happiness moves because no item was used. [param compatibility_checked] is
+## `CheckCanLearnMoveTutorMove`'s own `predef CanLearnTMHMMove` and
+## [param happiness_kind] its `ld c, HAPPINESS_LEARNMOVE`; a level-up offer passes
+## neither, which is what makes it the plain `LearnMove` it is.
 static func learn_move(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -842,14 +819,12 @@ static func teach_tutor_move(
 
 
 ## `ChangeHappiness` over the imported table, taking the byte rather than the
-## Pokemon: `wCurPartyMon`'s egg guard and the `wBattleMonHappiness` mirror
-## behind it are the caller's, because a caller here holds either a
-## [Gen2SaveMon] or a [Gen2BattleMon] and never both.
-##
-## The three rows are picked by HAPPINESS_THRESHOLD_1 and _2, and the sign of a
-## change is `cp $64`: a byte from 100 up is the subtracting branch, which is why
-## the table is read signed. Each branch answers the carry rather than clamping,
-## so a rise saturates at 255 and a fall at 0.
+## Pokemon: `wCurPartyMon`'s egg guard and the `wBattleMonHappiness` mirror behind
+## it are the caller's, because a caller here holds either a [Gen2SaveMon] or a
+## [Gen2BattleMon] and never both. The three rows are picked by
+## HAPPINESS_THRESHOLD_1 and _2, and the sign of a change is `cp $64`: a byte from
+## 100 up is the subtracting branch, which is why the table is read signed. Each
+## branch answers the carry rather than clamping, so a rise saturates at 255.
 static func change_happiness(data: GameData, happiness: int, kind: int) -> int:
 	var changes: Array[int] = []
 	if data != null:
@@ -1006,17 +981,13 @@ static func party_has_fit_mon(save: Gen2SaveData) -> bool:
 
 
 ## `DoPoisonStep`, the pass `CountStep` owes every fourth step. One HP off every
-## poisoned member that is still standing, and a member the point finishes has
-## its status cleared, which is what stops it being damaged again.
-##
-## The two flags `wPoisonStepFlagSum` collects decide what the pass costs:
-## `%10`, somebody fainted, is the only one that reaches a script, and `%01`
-## alone is the sound and nothing else. `.CheckWhitedOut` runs inside that
-## script, so the happiness penalty and the lines are charged on the faint
-## branch alone.
-##
-## Answers `{"damaged", "fainted", "sfx", "texts", "whiteout"}`; the caller owns
-## the sound, the box and the blackout behind it.
+## poisoned member that is still standing, and a member the point finishes has its
+## status cleared, which is what stops it being damaged again. The two flags
+## `wPoisonStepFlagSum` collects decide what the pass costs: `%10`, somebody
+## fainted, is the only one that reaches a script, and `%01` alone is the sound.
+## `.CheckWhitedOut` runs inside that script, so the happiness penalty and the
+## lines are charged on the faint branch alone. Answers `{damaged, fainted, sfx,
+## texts, whiteout}`; the caller owns the sound, the box and the blackout.
 static func apply_poison_step(data: GameData, save: Gen2SaveData) -> Dictionary:
 	var out: Dictionary = {
 		"damaged": PackedInt32Array(), "fainted": PackedInt32Array(),
@@ -1077,17 +1048,13 @@ static func whited_out_text(player_name: String) -> String:
 
 
 ## `Script_Whiteout` past its own text: `HealParty`, `HalveMoney`,
-## `GetWhiteoutSpawn` and the `WarpToSpawnPoint` behind them, in that order.
-## The last is [method Gen2WorldAPI.warp_to_spawn]'s own tail here, since every
-## escape shares it.
-##
-## One routine, because every way of blacking out reaches this one script: a
-## battle lost anywhere goes through `Script_reloadmapafterbattle`, and the last
-## party member fainting to poison goes through `.Script_MonFaintedToPoison`.
-##
-## The spawn is `wLastSpawnMapGroup`/`wLastSpawnMapNumber` read back through
-## `IsSpawnPoint`, so a map `blackoutmod` named is honoured here and SPAWN_HOME
-## is what a player who has entered no Pokemon Center gets.
+## `GetWhiteoutSpawn` and the `WarpToSpawnPoint` behind them, in that order. The
+## last is [method Gen2WorldAPI.warp_to_spawn]'s own tail here, since every escape
+## shares it. One routine, because every way of blacking out reaches this one
+## script: a battle lost anywhere goes through `Script_reloadmapafterbattle`, and
+## the last party member fainting to poison through `.Script_MonFaintedToPoison`.
+## The spawn is read back through `IsSpawnPoint`, so a map `blackoutmod` named is
+## honoured and SPAWN_HOME is what a player who has entered no Center gets.
 static func whiteout(
 	world: Gen2WorldAPI, save: Gen2SaveData, persist: bool = true
 ) -> Dictionary:
@@ -1120,16 +1087,13 @@ static func whiteout(
 	}
 
 
-## `ContestDropOffMons` past its fainted-lead branch: the party masked to its
-## lead for the length of the Bug Catching Contest. The cartridge drops
-## `wPartyCount` to 1 and writes a terminator over the second species byte,
-## leaving the members themselves in `wPartyMon`; nothing here counts a party by
-## a terminator, so the masked members move to
-## [member Gen2SaveData.contest_stashed_party] instead and the stashed species
-## byte stays as the world state's own.
-##
-## Answers the species `wBugContestSecondPartySpecies` takes, or 0 when the
-## party was one long already.
+## `ContestDropOffMons` past its fainted-lead branch: the party masked to its lead
+## for the length of the Bug Catching Contest. The cartridge drops `wPartyCount` to
+## 1 and writes a terminator over the second species byte, leaving the members in
+## `wPartyMon`; nothing here counts a party by a terminator, so the masked members
+## move to [member Gen2SaveData.contest_stashed_party] instead and the stashed
+## species byte stays as the world state's own. Answers the species
+## `wBugContestSecondPartySpecies` takes, or 0 when the party was one long already.
 static func contest_drop_off_mons(save: Gen2SaveData) -> int:
 	if save == null or save.party.size() <= 1:
 		return 0
@@ -1289,16 +1253,13 @@ static func _fills_its_box(save: Gen2SaveData, destination: Dictionary) -> bool:
 	return box != null and box.occupied_count() >= Gen2SaveBox.CAPACITY
 
 
-## `CheckPartyFullAfterContest`, which is what takes home whatever the Bug
-## Catching Contest caught. `wContestMon` is a party struct already, so the party
-## branch is a copy and the box branch an `InsertPokemonIntoBox`; each stands
-## behind its own `GiveANickname_YesNo`, and `SetCaughtData` is then overwritten
-## with LANDMARK_NATIONAL_PARK, the gender bit kept.
-##
-## Three things a reading gets wrong. `.BoxFull` writes nothing and still answers
-## BUGCONTEST_BOXED_MON, so a full party over a full box loses the catch; the box
-## branch prints no "sent to BILL's PC" line, because the script's own
-## `ContestResults_PartyFullText` is what BUGCONTEST_BOXED_MON reaches; and
+## `CheckPartyFullAfterContest`, which takes home whatever the Bug Catching
+## Contest caught. `wContestMon` is a party struct already, so the party branch is
+## a copy and the box branch an `InsertPokemonIntoBox`, each behind its own
+## `GiveANickname_YesNo`, and `SetCaughtData` is then overwritten with
+## LANDMARK_NATIONAL_PARK. Three things a reading gets wrong: `.BoxFull` writes
+## nothing and still answers BUGCONTEST_BOXED_MON, so a full party over a full box
+## loses the catch; the box branch prints no "sent to BILL's PC" line; and
 ## `wContestMon` is cleared on every branch but that last one.
 static func _apply_contest_mon(
 	world: Gen2WorldAPI,
@@ -2012,15 +1973,13 @@ static func apply_evolution(data: GameData, mon: Gen2SaveMon, row: Dictionary) -
 	}
 
 
-## A Park Ball thrown inside the Bug Catching Contest, which is a different
-## transaction from [method capture_wild]: the ball comes out of
-## `wParkBallsRemaining` rather than the bag, and what is caught goes to
-## `wContestMon` rather than to the party or a box, so no save is touched and
-## nothing can be refused for a full party.
-##
+## A Park Ball thrown inside the Bug Catching Contest, a different transaction
+## from [method capture_wild]: the ball comes out of `wParkBallsRemaining` rather
+## than the bag, and what is caught goes to `wContestMon` rather than to the party
+## or a box, so no save is touched and nothing can be refused for a full party.
 ## `BugContest_SetCaughtContestMon` asks before replacing a Pokemon already
-## caught, so a hit while one is held answers `replace_offer` and leaves the
-## state alone until the caller comes back with [method set_contest_mon].
+## caught, so a hit while one is held answers `replace_offer` and leaves the state
+## alone until the caller comes back with [method set_contest_mon].
 static func capture_contest(
 	world: Gen2WorldAPI, wild: Gen2BattleMon, random: RandomNumberGenerator = null
 ) -> Dictionary:
@@ -2257,14 +2216,12 @@ static func _love_ball(data: GameData, catch_rate: int, case: Dictionary) -> int
 
 
 ## The health term, as the cartridge's own bytes rather than as arithmetic that
-## happens to agree with them.
-##
-## Both operands are shifted right twice only when `3 * max HP` does not fit in
-## one byte, and everything after that is a byte: `ld b, e` keeps the low byte of
-## the divisor, `sub c` wraps, and `hQuotient + 3` is the low byte of the
-## quotient. Above 341 max HP the shifted divisor no longer fits either, which is
-## `docs/bugs_and_glitches.md`'s "Catch rate formula breaks for Pokemon with max
-## HP > 341", and all three truncations are what make it break.
+## happens to agree with them. Both operands are shifted right twice only when
+## `3 * max HP` does not fit in one byte, and everything after that is a byte:
+## `ld b, e` keeps the low byte of the divisor, `sub c` wraps, and `hQuotient + 3`
+## is the low byte of the quotient. Above 341 max HP the shifted divisor no longer
+## fits either, which is `docs/bugs_and_glitches.md`'s catch-rate break, and all
+## three truncations are what make it break.
 static func _source_hp_catch_rate(max_hp: int, current_hp: int, catch_rate: int) -> int:
 	var three_max: int = 3 * max_hp
 	var two_current: int = 2 * current_hp
@@ -2310,16 +2267,13 @@ static func _failed_wobbles(catch_rate: int, random: RandomNumberGenerator) -> i
 
 
 ## `GeneratePartyMonStats`' wild branch, which is what `TryAddMonToParty` and
-## `SendMonIntoBox` both build the caught row out of.
-##
-## Four of these read wrong from the outside and are the source's own. The
-## Pokemon keeps the health and the status condition it was standing there with,
-## because `PokeBallEffect` pushes `wEnemyMonStatus` and `wEnemyMonHP` in front
-## of `LoadEnemyMon` and writes them back after it. Its PP is full, because
-## `LoadEnemyMon`'s `FillPP` ran over whatever the fight had drained. Its stat
-## experience is zero and its experience is the minimum for its level, whatever
-## the battler had. The trainer ID is `wPlayerID`: a Pokemon caught by the player
-## is not a traded one.
+## `SendMonIntoBox` both build the caught row out of. Four of these read wrong from
+## the outside and are the source's own. The Pokemon keeps the health and status
+## it was standing there with, because `PokeBallEffect` pushes `wEnemyMonStatus`
+## and `wEnemyMonHP` in front of `LoadEnemyMon` and writes them back after it. Its
+## PP is full, because `FillPP` ran over whatever the fight had drained. Its stat
+## experience is zero and its experience the minimum for its level. The trainer ID
+## is `wPlayerID`: a Pokemon caught by the player is not a traded one.
 static func _captured_mon(
 	data: GameData,
 	save: Gen2SaveData,

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -1,20 +1,14 @@
 class_name Gen2WorldPC
 extends RefCounted
 
-## `engine/events/pokecenter_pc.asm`: the Pokemon Center's top menu, the item
-## PC behind its `<PLAYER>'S PC` row, and the two transactions that move a stack
-## between the bag and `wPCItems`.
-##
-## Scene-free like the other world hosts. The rows and their per-state lists are
-## the source's own tables; a host draws whichever list [method top_menu] and
-## [method players_pc_menu] return and calls the transactions below. The commit
-## boundary is [Gen2WorldTransaction], the same one the mart, Kurt and the bag
-## go through.
-##
-## Every row of both lists is built. MAIL BOX is `_PlayerMailBoxMenu` over
-## [member Gen2SaveData.mailbox] and its own submenu below, DECORATION is
-## [Gen2WorldDecoration]'s and HALL OF FAME is [Gen2HallOfFame]'s viewer over
-## [member Gen2SaveData.hall_of_fame].
+## `engine/events/pokecenter_pc.asm`: the Pokemon Center's top menu, the item PC
+## behind its `<PLAYER>'S PC` row, and the two transactions that move a stack
+## between the bag and `wPCItems`. Scene-free like the other world hosts: the rows
+## and their per-state lists are the source's own tables, a host draws whichever
+## list is returned, and the commit boundary is [Gen2WorldTransaction]. Every row
+## of both lists is built, MAIL BOX being `_PlayerMailBoxMenu` over the save's own
+## mailbox, DECORATION [Gen2WorldDecoration]'s and HALL OF FAME [Gen2HallOfFame]'s
+## viewer.
 
 ## `PokemonCenterPC.Jumptable` indexes.
 const PCPCITEM_PLAYERS_PC: int = 0

--- a/game/world/world_radio.gd
+++ b/game/world/world_radio.gd
@@ -2,22 +2,13 @@ class_name Gen2WorldRadio
 extends RefCounted
 
 ## The Pokegear radio card's tuning knob, its station table, and the music each
-## station leaves in `wMapMusic`.
-##
-## Scene-free and stateless: a caller passes the knob position and the facts the
-## source reads off WRAM, and gets back the station that answers. The knob and
-## the tuned channel live on `Gen2WorldState`; the music a station commits lands
-## in `Gen2WorldState.map_music`, which is what `SnorlaxAwake` reads.
-##
-## Modelled here: `UpdateRadioStation`, `RadioChannels`, each handler's
-## availability check, `LoadStation_*`, `PlayRadioShow`'s Rocket override and
-## `StartRadioStation`'s music commit, which is the whole of what the overworld
-## can observe. The words a station then prints are [Gen2RadioShow].
-##
-## Channel ids are Crystal-canonical, the way `Gen2WorldScript.special_index()`
-## keeps specials Crystal-canonical: Gold and Silver ship no Buena's Password
-## channel, so their own ids from PLACES_AND_PEOPLE on sit one lower.
-## `raw_channel()` converts when a cartridge-shaped number is wanted.
+## station leaves in `wMapMusic`. Scene-free and stateless: a caller passes the
+## knob position and the facts the source reads off WRAM and gets back the station
+## that answers. Modelled here: `UpdateRadioStation`, `RadioChannels`, each
+## handler's availability check, `LoadStation_*`, `PlayRadioShow`'s Rocket override
+## and `StartRadioStation`'s music commit. The words a station prints are
+## [Gen2RadioShow]. Channel ids are Crystal-canonical, so Gold and Silver's own
+## ids from PLACES_AND_PEOPLE on sit one lower; `raw_channel()` converts.
 
 ## constants/radio_constants.asm.
 const OAKS_POKEMON_TALK: int = 0
@@ -206,14 +197,12 @@ static func station_for(knob: int, context: Dictionary = {}) -> Dictionary:
 
 
 ## The knob position a channel is carried on, or -1 where this profile has none.
-## `PlayRadioStationPointers`, the nine `MAPRADIO_*` rows a `special MapRadio`
-## indexes. Only two of them are reachable: `Radio1Script` names the Pokemon
-## Channel and `Radio2Script` the Lucky Channel, and those two std scripts are
-## every radio on every map.
-##
-## `LoadStation_PokemonChannel` is a branch rather than a station: Kanto reads
-## Places and People, a Johto morning the Pokedex Show, and any other Johto hour
-## Oak's Pokemon Talk.
+## Below, `PlayRadioStationPointers`, the nine `MAPRADIO_*` rows a
+## `special MapRadio` indexes. Only two are reachable: `Radio1Script` names the
+## Pokemon Channel and `Radio2Script` the Lucky Channel, and those two std scripts
+## are every radio on every map. `LoadStation_PokemonChannel` is a branch rather
+## than a station: Kanto reads Places and People, a Johto morning the Pokedex Show,
+## and any other Johto hour Oak's Pokemon Talk.
 const MAP_RADIO_STATIONS: Array[int] = [
 	-1, OAKS_POKEMON_TALK, POKEDEX_SHOW, POKEMON_MUSIC, LUCKY_CHANNEL,
 	UNOWN_RADIO, PLACES_AND_PEOPLE, LETS_ALL_SING, ROCKET_RADIO,

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -2,27 +2,24 @@ class_name Gen2WorldRenderer
 extends Node2D
 
 ## Draws the visible map page and the development player marker in hardware
-## pixels. It does not own map state; call [method set_world] when the API
-## changes or [method refresh] after a movement.
-##
-## The surface is the cartridge's 160x144 unless the world has been given a
-## larger [member Gen2WorldAPI.view_pixels], in which case the map fills all of
-## it: the connected maps the graph places around this one are drawn as well, on
-## [Gen2WorldMapLayer] quads under the sprites, and the border block fills
-## whatever no map covers.
+## pixels. It does not own map state; call [method set_world] when the API changes
+## or [method refresh] after a movement. The surface is the cartridge's 160x144
+## unless the world has been given a larger [member Gen2WorldAPI.view_pixels], in
+## which case the map fills all of it: the connected maps the graph places around
+## this one are drawn as well, on [Gen2WorldMapLayer] quads under the sprites, and
+## the border block fills whatever no map covers.
 
 const PLAYER_COLOR: Color = Color("#d34a5a")
 const FALLBACK_BACKGROUND: Color = Color("#f5f1d8")
 
-## `.InitSprite` (engine/overworld/map_objects.asm) writes an object's OAM y as
-## `add OAM_Y_OFS - 4` against a plain `add OAM_X_OFS` on the other axis, so a
-## 16x16 overworld sprite stands four pixels above its own cell and nothing
-## shifts it sideways. Every map object shares the one write: the emote, the
-## shadow, the boulder dust and the shaking grass are tracking objects that copy
-## the tracked object's `OBJECT_SPRITE_Y` and go through it too, and the jump
-## arc, the tracking bob and the fishing rod are offsets added in front of it.
-## The tuft of grass over a sprite's legs is background rather than OAM and takes
-## no lift; it moves with the sprite because OAM_PRIO is what draws it.
+## `.InitSprite` writes an object's OAM y as `add OAM_Y_OFS - 4` against a plain
+## `add OAM_X_OFS` on the other axis, so a 16x16 overworld sprite stands four
+## pixels above its own cell and nothing shifts it sideways. Every map object
+## shares the one write: the emote, the shadow, the boulder dust and the shaking
+## grass are tracking objects that copy the tracked object's `OBJECT_SPRITE_Y`,
+## and the jump arc, the tracking bob and the fishing rod are offsets added in
+## front of it. The tuft of grass over a sprite's legs is background rather than
+## OAM and takes no lift; OAM_PRIO is what draws it.
 const SPRITE_LIFT := Vector2(0, -4)
 
 var _world: Gen2WorldAPI = null
@@ -392,18 +389,13 @@ func _palette_tables(palettes: Array) -> Array:
 
 
 ## `DoBattleTransition`, drawn over whatever the map was already showing.
-##
 ## [param cells] is [method Gen2BattleTransition.cells], [param tiles] the two
-## tiles `LoadBattleTransitionGFX` loads as index buffers, and [param palette]
-## the four colours the whole map is flooded with while a trainer's ball is up.
-## An empty palette is the wild branch, which floods nothing: its black tile is
-## colour 3 of whatever palette the cell under it was already drawn in. Every
-## overworld palette's colour 3 is `gfx/overworld/trainer_battle.pal`'s own
-## (7,7,7), so both kinds of wedge come out the same dark grey.
-##
-## [param sprites] is [method Gen2BattleTransition.sprites] and [param opponent]
-## the map object `hLastTalked` names; [param order] is the flash's `wBGP`, which
-## `DmgToCgbBGPals` applies to the background alone.
+## tiles `LoadBattleTransitionGFX` loads as index buffers, and [param palette] the
+## four colours the whole map is flooded with while a trainer's ball is up. An
+## empty palette is the wild branch, which floods nothing: its black tile is colour
+## 3 of whatever palette the cell was already drawn in, and every overworld
+## palette's colour 3 is the same (7,7,7), so both kinds of wedge come out the same
+## dark grey. [param order] is the flash's `wBGP`, applied to the background alone.
 func set_transition(
 	cells: PackedByteArray, tiles: PackedByteArray, palette: PackedColorArray,
 	sprites: int = Gen2BattleTransition.SPRITES_ALL, opponent: int = -1,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -689,14 +689,12 @@ func _render_time_of_day() -> int:
 
 
 ## SCREEN FILL: the overworld has more to show than the hardware framed, so it
-## fills the window with map where every other screen fills it with its own
-## field. Every menu, box and cursor over it stays inside the 160x144 rectangle
-## [Gen2Screen] centres in the buffer.
-##
-## The setting itself is the screen's ([method Gen2Screen.apply_screen_fill]) and
-## is taken again here rather than trusted from the frame the screen was born on:
-## a tool that stages a framed shot sets the option around building this scene,
-## and either order has to mean the same thing. The zoom is the map's alone.
+## fills the window with map where every other screen fills it with its own field.
+## Every menu, box and cursor over it stays inside the 160x144 rectangle
+## [Gen2Screen] centres in the buffer. The setting itself is the screen's and is
+## taken again here rather than trusted from the frame the screen was born on: a
+## tool that stages a framed shot sets the option around building this scene, and
+## either order has to mean the same thing. The zoom is the map's alone.
 func _apply_screen_fill() -> void:
 	var options: Gen2Options = Gen2OptionsStore.current()
 	_screen.apply_screen_fill()
@@ -706,25 +704,14 @@ func _apply_screen_fill() -> void:
 	_apply_interface_mask()
 
 
-## A screen that hides the map takes the whole picture with it: it is laid out
-## in 160x144 and has nothing to put in a wider buffer, so the surround becomes
-## that screen's own field rather than the map behind it. The start menu is not
-## one of these -- it is a box the map is still visible around, as on the
-## cartridge -- and neither is a map fade, which fades the whole picture.
-##
-## `DoBattleTransition` is: it writes twenty by eighteen screen cells and
-## nothing wider, so a wedge pattern in a filled window would stop where the
-## cartridge's screen ended. It closes the surround for the battle that follows
-## it, which is masked for the same reason.
-##
-## The mask is drawn inside the hardware viewport and the viewport is composited
-## over the native layer, so raising it would crop a renderer that is not drawing
-## in the buffer it describes: one of those has already filled the whole surface,
-## and a letterbox around a rectangle it never used has nothing to say about it.
-## Such a renderer is told instead
-## ([constant Gen2ModHost.RENDERER_INTERFACE_MASK_METHOD]) and closes its own
-## surround in its own units, which is the only way a transition's wedge reaches
-## the edge of a filled window.
+## A screen that hides the map takes the whole picture with it: it is laid out in
+## 160x144 and has nothing to put in a wider buffer, so the surround becomes that
+## screen's own field. The start menu is not one of these, being a box the map is
+## still visible around, and neither is a map fade. `DoBattleTransition` is: it
+## writes twenty by eighteen cells and nothing wider. The mask is drawn inside the
+## hardware viewport, so raising it would crop a renderer that already filled the
+## whole surface; such a renderer is told instead and closes its own surround,
+## which is the only way a wedge reaches the edge of a filled window.
 func _apply_interface_mask() -> void:
 	var owned: bool = (
 		_battle_transition != null
@@ -832,17 +819,34 @@ func advance_frames(count: int) -> void:
 		advance_frame()
 
 
-## One hardware frame of the overworld, in the order the frame is drawn in.
-##
-## Every countdown below is spent exactly once here, so each is a function of
-## [member Gen2WorldAPI.frame_number] and not of banked real time.
-##
-## Half of what follows is `HandleMap`'s own pass and runs once per two frames:
-## see [member Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS] and `map_pass` below. The
-## other half is what the source spends its own `DelayFrames` on from inside a
-## command, which the pass does not gate: a text box, either fade, the battle
-## transition, `GameTimer` and `AnimateTileset` are all VBlank's or a routine's
-## own and are spent on every frame.
+## Every host that runs inside the map's own loop, member and the method that
+## spends its frame. Their `DelayFrames` counts come from this pump rather than
+## from real time, which is what makes a fight, a hatch or a trade inside a
+## replay reach the same place on the same frame.
+const FRAME_HOSTS: Array[Array] = [
+	## `PlayRadioShow` runs from the Pokegear's own loop, so an open radio card
+	## spends this frame too rather than counting one of its own.
+	["_service_host", "advance_frame"],
+	["_battle_host", "advance_hardware_frame"],
+	["_evolution_host", "advance_frame"],
+	["_link_host", "advance_frame"],
+	["_hatch_host", "advance_frame"],
+	["_nickname_host", "advance_frame"],
+	["_name_rater_host", "advance_frame"],
+	["_move_deleter_host", "advance_frame"],
+	["_move_tutor_host", "advance_frame"],
+	["_day_care_host", "advance_frame"],
+	["_unown_puzzle_host", "advance_frame"],
+	["_slot_machine_host", "advance_frame"],
+	["_card_flip_host", "advance_frame"],
+]
+
+
+## One hardware frame of the overworld, in the order it is drawn. Every countdown
+## is spent exactly once here, so each is a function of
+## [member Gen2WorldAPI.frame_number] rather than of banked real time. Half of
+## what follows is `HandleMap`'s own pass and runs once per two frames; the other
+## half is what a command spends its own `DelayFrames` on and is not gated.
 func advance_frame() -> void:
 	_spending_frame = true
 	## `ResetOverworldDelay` and `NextOverworldFrame`: the pass reloads the delay
@@ -852,6 +856,27 @@ func advance_frame() -> void:
 	var map_pass: bool = _overworld_delay <= 0
 	if map_pass:
 		_overworld_delay = Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
+	_advance_presentation(map_pass)
+	_advance_movement(map_pass)
+	_advance_population(map_pass)
+	_advance_waits(map_pass)
+	for row: Array in FRAME_HOSTS:
+		var host: Object = get(row[0])
+		if host != null:
+			host.call(row[1])
+	_spending_frame = false
+
+
+## Redraws when [param moved] says something under the renderer changed.
+func _refresh_if(moved: bool) -> void:
+	if moved and _renderer != null:
+		_renderer.refresh()
+
+
+## The text box, the fades, the transition and the two animation timers, none of
+## which the pass gates: they are what the source spends its own `DelayFrames`
+## on from inside a command, plus VBlank's `GameTimer` and `AnimateTileset`.
+func _advance_presentation(map_pass: bool) -> void:
 	if _text_box != null:
 		_text_box.accelerated = Gen2Button.text_accelerating()
 		_text_box.advance_frame()
@@ -883,75 +908,72 @@ func advance_frame() -> void:
 		var effects_moved: bool = _effects.advance_frame()
 		if map_pass:
 			effects_moved = _effects.advance_pass() or effects_moved
-		if effects_moved and _renderer != null:
-			_renderer.refresh()
+		_refresh_if(effects_moved)
 	## `AnimateTileset` is VBlank's, not the pass's, so the water and the flowers
 	## animate on every frame while the objects standing on them move on passes.
 	if _animation != null and _animation.advance_frame() and _renderer != null:
 		_renderer.refresh_animation()
-	## `GetJoypad` and `PlayerEvents` are both inside the pass, so a held
-	## direction starts a step on a pass and never between two. Before the step
-	## below, which is `HandleMap`'s own order: `MapEvents` starts the step and
-	## `HandleMapObjects` moves it in the same pass, so a walk begun from
-	## standing covers its first two pixels on the pass the press landed on.
+
+
+## `GetJoypad` and `PlayerEvents` are both inside the pass, so a held direction
+## starts a step on a pass and never between two. `MapEvents` starts the step and
+## `HandleMapObjects` moves it in the same pass, so a walk begun from standing
+## covers its first two pixels on the pass the press landed on.
+func _advance_movement(map_pass: bool) -> void:
 	if map_pass:
 		_advance_forced_movement()
 		_advance_held_direction()
-	if map_pass and _world != null and _world.advance_player_step_pass() \
-		and _renderer != null:
-		_renderer.refresh()
-	## `CheckPlayerState` reads the step flags at the end of `HandleMap`, after
-	## `HandleMapObjects`, so the step that finishes on this frame is the one
-	## whose events this frame runs.
-	if map_pass and not _pending_step_events.is_empty() and _world != null \
-		and not _world.player_step_in_progress():
-		var landed: Dictionary = _pending_step_events
-		_pending_step_events = {}
-		_complete_player_step(landed)
+		_refresh_if(_world != null and _world.advance_player_step_pass())
+		## `CheckPlayerState` reads the step flags at the end of `HandleMap`,
+		## after `HandleMapObjects`, so the step that finishes on this frame is
+		## the one whose events this frame runs.
+		if not _pending_step_events.is_empty() and _world != null \
+			and not _world.player_step_in_progress():
+			var landed: Dictionary = _pending_step_events
+			_pending_step_events = {}
+			_complete_player_step(landed)
 	## Not the pass's: an emote's own countdown stands in for the `pause` between
 	## `ShowEmoteScript`'s two movements, and a script's `DelayFrames` is spent
 	## from inside the command rather than by `NextOverworldFrame`.
-	if _world != null and _world.advance_emotes_frame() and _renderer != null:
-		_renderer.refresh()
-	## After the player's own step, so an actor reading
-	## `player_step_offset_cells()` sees this frame rather than the last one's.
-	## Before the actors, which draw its population: a wild that moved this frame
-	## has to be in the sprite list the actor layer collects after it.
-	##
+	_refresh_if(_world != null and _world.advance_emotes_frame())
+
+
+## Everything drawn on the map that is not the player. Wilds move after the
+## player's own step, so an actor reading `player_step_offset_cells()` sees this
+## frame, and before the actors, which draw its population.
+func _advance_population(map_pass: bool) -> void:
 	## Gated on the same predicate the map's own objects step behind, so a
 	## provider's frame count is the time the player spent on the overworld: a
-	## population stands still behind a battle, a menu, a text box and a fade,
-	## which is what the map does with its objects. Not the pass's: a wild is
-	## drawn between cells like an object mid-step, and the source moves those on
-	## every frame.
+	## population stands still behind a battle, a menu, a text box and a fade.
+	## Not the pass's: a wild is drawn between cells like an object mid-step.
 	if _encounters != null and _objects_may_move() and _encounters.advance_frame():
 		_play_encounter_sounds()
-		if _renderer != null:
-			_renderer.refresh()
+		_refresh_if(true)
 	## Deliberately not gated with it: an actor owns no state the host validates
 	## and is drawn only on the frames the map is, so an animation running behind
 	## an overlay costs a mod nothing and freezing one would strand a walk cycle
 	## mid-step.
-	if _actors != null and _actors.advance_frame() and _renderer != null:
-		_renderer.refresh()
+	_refresh_if(_actors != null and _actors.advance_frame())
 	_spend_actor_requests()
 	_spend_hidden_item_requests()
 	_spend_item_gift_requests()
 	_spend_notice_requests()
-	if map_pass and _objects_may_move() \
-		and _world.advance_object_steps_pass(_object_random) \
-		and _renderer != null:
-		_renderer.refresh()
+	if not map_pass:
+		return
+	_refresh_if(_objects_may_move() and _world.advance_object_steps_pass(_object_random))
 	# Not gated on _objects_may_move(): an applymovement is drawn while the
 	# script that ran it is still going, which is when a script runs one.
-	if map_pass and _world != null and _world.advance_scripted_steps_pass() \
-		and _renderer != null:
-		_renderer.refresh()
+	_refresh_if(_world != null and _world.advance_scripted_steps_pass())
 	# After both trails: `ShakeGrass` is called where the step starts, so a
 	# rustle taken now belongs to a step begun on this frame.
-	if map_pass:
-		_spawn_grass_rustles()
-	if not _pending_headbutt_finish.is_empty() and (_effects == null or not _effects.sprites_active()):
+	_spawn_grass_rustles()
+
+
+## What a frame owes something already waiting on it, each behind the trail it
+## waits for.
+func _advance_waits(map_pass: bool) -> void:
+	if not _pending_headbutt_finish.is_empty() \
+		and (_effects == null or not _effects.sprites_active()):
 		var headbutt: Dictionary = _pending_headbutt_finish
 		_pending_headbutt_finish = {}
 		_finish_headbutt(headbutt)
@@ -973,61 +995,29 @@ func advance_frame() -> void:
 		if not ring_results.is_empty():
 			_show_script_results(ring_results)
 		_refresh_labels()
-	# The condition is the audio device's, not a counter's, but the request it
-	# completes is a script's, so it lands on a frame like every other resume.
-	## The same rule the battle's `ANIM_WAIT_SFX` follows: a driver nobody is
-	## servicing leaves `effect_playing()` true for the rest of the run, so the
-	## rendered-frame count is what decides whether this is a wait at all.
+	_advance_audio_wait()
+
+
+## The one wait whose condition is the audio device's rather than a counter's.
+## The same rule the battle's `ANIM_WAIT_SFX` follows: a driver nobody is
+## servicing leaves `effect_playing()` true for the rest of the run, so the
+## rendered-frame count is what decides whether this is a wait at all.
+func _advance_audio_wait() -> void:
 	var audio_rendered: int = _audio_player.timeline_updates() if _audio_player != null else 0
 	_audio_still_frames = 0 if audio_rendered != _audio_rendered_seen \
 		else _audio_still_frames + 1
 	_audio_rendered_seen = audio_rendered
-	if _audio_waiting and _audio_player != null \
-		and (not _audio_player.effect_playing()
-			or _audio_still_frames > Gen2AudioPlayer.SERVICE_GAP_FRAMES):
-		_audio_waiting = false
-		var audio_result: Dictionary = Gen2WorldHost.complete_runtime_request(
-			_world, {"ok": true, "sound_finished": true}
-		)
-		if bool(audio_result.get("ok", false)):
-			_show_script_results(audio_result.get("results", []))
-	# `PlayRadioShow` runs from the Pokegear's own loop, so an open radio card
-	# spends this frame too rather than counting one of its own.
-	if _service_host != null:
-		_service_host.advance_frame()
-	## A battle is `BattleIntro` onward running inside the map's own loop, so its
-	## bars, its animations and its faints are spent from this pump rather than
-	## from real time. That is what makes a fight inside a replay reach the same
-	## place on the same frame.
-	if _battle_host != null:
-		_battle_host.advance_hardware_frame()
-	## `EvolveAfterBattle` runs inside the map's own loop the same way, so its
-	## `DelayFrames` counts are spent from this pump.
-	if _evolution_host != null:
-		_evolution_host.advance_frame()
-	## `LinkCommunications` spends its own `DelayFrames` inside the map's loop
-	## too, which is what the trade screen's waits are counted from.
-	if _link_host != null:
-		_link_host.advance_frame()
-	if _hatch_host != null:
-		_hatch_host.advance_frame()
-	if _nickname_host != null:
-		_nickname_host.advance_frame()
-	if _name_rater_host != null:
-		_name_rater_host.advance_frame()
-	if _move_deleter_host != null:
-		_move_deleter_host.advance_frame()
-	if _move_tutor_host != null:
-		_move_tutor_host.advance_frame()
-	if _day_care_host != null:
-		_day_care_host.advance_frame()
-	if _unown_puzzle_host != null:
-		_unown_puzzle_host.advance_frame()
-	if _slot_machine_host != null:
-		_slot_machine_host.advance_frame()
-	if _card_flip_host != null:
-		_card_flip_host.advance_frame()
-	_spending_frame = false
+	if not _audio_waiting or _audio_player == null:
+		return
+	if _audio_player.effect_playing() \
+		and _audio_still_frames <= Gen2AudioPlayer.SERVICE_GAP_FRAMES:
+		return
+	_audio_waiting = false
+	var audio_result: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"ok": true, "sound_finished": true}
+	)
+	if bool(audio_result.get("ok", false)):
+		_show_script_results(audio_result.get("results", []))
 
 
 ## Whether a battle owns the screen right now. Public beside
@@ -1113,15 +1103,14 @@ func _advance_day_cycle(delta: float) -> void:
 	_refresh_labels()
 
 
-## .CheckTile's forced walk, which the source polls every frame with no input:
-## a waterfall pushes the player back down and a door, staircase or cave tile
-## steps them off it. The step already in progress paces it.
-##
-## PLAYERMOVEMENT_FORCE_TURN is deliberately not drained here. Its
-## Script_ForcedMovement is a queued script whose two step_dig runs pace the spin,
-## and this project renders none of that, so draining it per frame would flip the
-## facing at the frame rate. Gen2WorldAPI.move_result() answers it on the movement
-## attempt instead, which is where a player meets it.
+## `.CheckTile`'s forced walk, which the source polls every frame with no input: a
+## waterfall pushes the player back down and a door, staircase or cave tile steps
+## them off it. The step already in progress paces it.
+## PLAYERMOVEMENT_FORCE_TURN is deliberately not drained here: its
+## `Script_ForcedMovement` is a queued script whose two step_dig runs pace the
+## spin, and this project renders none of that, so draining it per frame would flip
+## the facing at the frame rate. `move_result()` answers it on the movement attempt
+## instead, which is where a player meets it.
 func _advance_forced_movement() -> void:
 	if not _objects_may_move() or _world.script_input_waiting() \
 		or _world.player_step_in_progress():
@@ -1799,14 +1788,12 @@ func _whiteout_texts() -> PackedStringArray:
 
 
 ## Whether this blackout is the end of a Nuzlocke rather than a walk back to a
-## Pokemon Center. A run whose every Pokemon is dead has nothing to heal: the
-## rule is a full wipe ending the run, storage or no storage.
-##
-## Not inside the Bug Catching Contest. `ContestDropOffMons` masks the rest of
-## the party into [member Gen2SaveData.contest_stashed_party] and leaves one
-## Pokemon standing, so a faint there empties a party that is not the run's:
-## `Script_Whiteout`'s own contest branch judges the contest and gives the
-## others back, and the run carries on with them.
+## Pokemon Center. A run whose every Pokemon is dead has nothing to heal: the rule
+## is a full wipe ending the run, storage or no storage. Not inside the Bug
+## Catching Contest: `ContestDropOffMons` masks the rest of the party into
+## [member Gen2SaveData.contest_stashed_party] and leaves one Pokemon standing, so
+## a faint there empties a party that is not the run's, and `Script_Whiteout`'s own
+## contest branch gives the others back.
 func _nuzlocke_ends_here(save: Gen2SaveData) -> bool:
 	return _world != null and _world.rules != null and _world.rules.is_nuzlocke() \
 		and save != null and not _world.bug_contest_active() \
@@ -2027,7 +2014,7 @@ func _open_gift_nickname(request: Dictionary) -> bool:
 ##
 ## False when the routine reaches no prompt: nothing was caught, and `.BoxFull`,
 ## which writes nothing and answers BUGCONTEST_BOXED_MON where it stands.
-func _open_contest_nickname() -> bool:
+func _open_contest_nickname(_request: Dictionary = {}) -> bool:
 	if _nickname_host != null or _world == null or _data == null or _world.state == null:
 		return false
 	var caught: Dictionary = _world.state.contest_mon()
@@ -2103,7 +2090,7 @@ func _on_hatch_closed() -> void:
 ## `special NameRater`. `_NameRater` owns its own boxes and both of the screens
 ## it opens, so the whole routine is one host and the script stays suspended
 ## behind it, which is what `opentext` left it doing.
-func _open_name_rater() -> bool:
+func _open_name_rater(_request: Dictionary = {}) -> bool:
 	if _name_rater_host != null or _world == null or _data == null:
 		return false
 	var texts: Dictionary = Gen2WorldHost.name_rater_texts(_data)
@@ -2158,12 +2145,10 @@ func _on_name_rater_closed() -> void:
 ## The Day-Care's five specials, hosted exactly as `special NameRater` is. The
 ## routine writes the party, the two slots and the money itself, so nothing is
 ## staged: the cartridge's own routines write WRAM straight and the save is only
-## committed when the player saves.
-## `special UnownPuzzle`. `FadeToMenu` in front of it and `ExitAllMenus` behind
-## it are what the host's own overlay already is: the board covers the map and
-## the map is redrawn when it closes.
-## `_Diploma`'s page, or `_PrintDiploma`'s with the printer's own status box
-## over it. The screen owns both loops; this only hands it the two things the
+## committed when the player saves. Below, `special UnownPuzzle`, whose
+## `FadeToMenu` and `ExitAllMenus` are what the host's own overlay already is; and
+## `_Diploma`'s page, or `_PrintDiploma`'s with the printer's own status box over
+## it, where the screen owns both loops and this only hands it the two things the
 ## page prints that the cache does not carry.
 func _open_diploma(request: Dictionary) -> bool:
 	if _diploma_host != null or _world == null or _data == null:
@@ -2422,7 +2407,7 @@ func _on_day_care_closed() -> void:
 
 
 ## `special MoveDeletion`, hosted exactly as `special NameRater` is.
-func _open_move_deleter() -> bool:
+func _open_move_deleter(_request: Dictionary = {}) -> bool:
 	if _move_deleter_host != null or _world == null or _data == null:
 		return false
 	var texts: Dictionary = Gen2WorldHost.move_deleter_texts(_data)
@@ -2580,12 +2565,10 @@ func _after_map_settled() -> bool:
 	## `CheckTileEvent`'s own order: the warp and the coord events above, then
 	## `CountStep`, and only then `RandomEncounter`. A poison pass that reaches a
 	## script answers with carry, so the step it runs on rolls no wild, and
-	## `CheckTimeEvents` below is a caller further on.
-	##
-	## `CheckSpecialPhoneCall` is `CountStep`'s first test and stands in front of
-	## the counters, so the step a special call rings on is charged nothing:
-	## [method Gen2WorldAPI.count_step] already refused it, and the poison pass
-	## below reads the counter that refusal left standing.
+	## `CheckTimeEvents` below is a caller further on. `CheckSpecialPhoneCall` is
+	## `CountStep`'s first test and stands in front of the counters, so the step a
+	## special call rings on is charged nothing: `count_step()` already refused it,
+	## and the poison pass below reads the counter that refusal left standing.
 	var special_attempt: Dictionary = _world.try_special_phone_call()
 	var special_results: Array = special_attempt.get("results", [])
 	if bool(special_attempt.get("attempted", false)) and not special_results.is_empty():
@@ -3819,15 +3802,14 @@ func _tap_puzzle(button: int) -> void:
 	host.release_button(button)
 
 
-## Public screenshot driver and scene-test entry for `OverworldHatchEgg`: it
-## stands an egg with one cycle left in the first party slot of an injected
-## save, spends the egg step, and opens the sequence on whatever hatched.
-##
-## [param species] is what is inside the egg; 0 takes the first species the
-## cache holds, so the driver works on all three without a table.
-## One of the five fade specials on the map that is already open, for a
-## screenshot. The frames it spends are the script's on the real path, so this
-## opens the fade and the caller advances into it.
+## Public screenshot driver and scene-test entry for `OverworldHatchEgg`: it stands
+## an egg with one cycle left in the first party slot of an injected save, spends
+## the egg step, and opens the sequence on whatever hatched. [param species] is
+## what is inside the egg; 0 takes the first species the cache holds, so the driver
+## works on all three without a table. Below, one of the five fade specials on the
+## map that is already open, for a screenshot: the frames it spends are the
+## script's on the real path, so this opens the fade and the caller advances into
+## it.
 func preview_script_fade(special: int) -> void:
 	if not Gen2WorldScriptRunner.FADE_ORDERS_OF.has(special):
 		return
@@ -4801,18 +4783,14 @@ func _open_battle_host(request: Dictionary) -> void:
 	_refresh_labels()
 
 
-## The Nuzlocke's first rule, at the one place every battle is opened.
-##
-## An area gives up one encounter, and it gives it up the moment the Pokemon is
-## met rather than when a ball lands: beating it or running from it spends it
-## just the same, which is the rule's "no second chances". The claim is written
-## to disk here for the same reason a death is, so a reload cannot hand the area
-## back.
-##
-## Two wild battles claim nothing. The Bug Catching Contest has its own park
-## balls and its own judging, and a roamer belongs to no area at all: its
-## landmark is wherever it caught the player, so counting it would spend a route
-## the player never chose to spend.
+## The Nuzlocke's first rule, at the one place every battle is opened. An area
+## gives up one encounter, and it gives it up the moment the Pokemon is met rather
+## than when a ball lands: beating it or running from it spends it just the same,
+## which is the rule's "no second chances". The claim is written to disk here for
+## the same reason a death is, so a reload cannot hand the area back. Two wild
+## battles claim nothing: the Bug Catching Contest has its own park balls, and a
+## roamer belongs to no area at all, its landmark being wherever it caught the
+## player.
 func _claim_nuzlocke_encounter(
 	host: Gen2BattleScreen, values: Dictionary, save: Gen2SaveData
 ) -> void:
@@ -5104,14 +5082,11 @@ func _finish_battle_exit(result: Dictionary, fought_save: Gen2SaveData) -> void:
 	_refresh_labels()
 
 
-## The Nuzlocke's second rule: a faint is a death, so every party member at zero
-## HP is released and recorded. The battle said the line as each one fell; this
-## is where the row actually goes.
-##
-## Written to disk the moment it happens, whatever the outcome was, which is the
-## whole of the no-resets rule this project can enforce: quitting to the launcher
-## and reopening the slot cannot bring anything back.
-##
+## The Nuzlocke's second rule: a faint is a death, so every party member at zero HP
+## is released and recorded. The battle said the line as each one fell; this is
+## where the row actually goes. Written to disk the moment it happens, whatever the
+## outcome was, which is the whole of the no-resets rule this project can enforce:
+## quitting to the launcher and reopening the slot cannot bring anything back.
 ## Answers what it took, so a caller that is about to end the run can say so.
 func _reap_nuzlocke_faints(save: Gen2SaveData, cause: StringName) -> Array:
 	if _world == null or _world.rules == null or not _world.rules.is_nuzlocke():
@@ -5284,14 +5259,12 @@ func _advance_script_input() -> void:
 	_refresh_labels()
 
 
-## `Script_writetext` is `MapTextbox` and returns as soon as the string is
-## placed, so a text ending in `<DONE>` owes no press of its own and the script
-## runs on the moment its last page is up. The box reaches that page three ways:
-## shown whole, turned to by the press that clears a `<PARA>`, or scrolled into
-## by `_ContText`, and only the first two are a press. The scroll ends on a
-## frame, which is why [method advance_frame] asks this as well; without it the
-## last page sat there with the script still suspended and the press that closed
-## the box paid for the `waitbutton` behind it, so every `<CONT>`-terminated
+## `Script_writetext` is `MapTextbox` and returns as soon as the string is placed,
+## so a text ending in `<DONE>` owes no press of its own and the script runs on the
+## moment its last page is up. The box reaches that page three ways: shown whole,
+## turned to by the press that clears a `<PARA>`, or scrolled into by `_ContText`,
+## and only the first two are a press. The scroll ends on a frame, which is why
+## [method advance_frame] asks this as well; without it every `<CONT>`-terminated
 ## text cost one press more than the cartridge spends.
 func _continue_if_text_settled() -> bool:
 	if _text_box == null or not _text_box.visible or _world == null:
@@ -6822,343 +6795,404 @@ func _on_service_completed(results: Array) -> void:
 	_reopen_start_menu_if_due()
 
 
-func _show_script_results(results: Array) -> void:
-	## Whether this result staged a text at all; whether it owes a press is
-	## [method _continue_if_text_settled]'s question, asked once the loop is done.
-	var continue_after_text: bool = false
-	var waiting: bool = false
-	var failed: bool = false
-	var map_changed: bool = false
+## Script event to the method that spends it, each taking the event. Four types
+## are not here: `soft_reset_requested` ends the screen, `tree_shake_requested`
+## has nothing for a host to start because the object animates itself for the
+## frames the stream sleeps, and the rest are in [constant EVENT_FLAGS] and
+## [constant EVENT_PROMPTS].
+const EVENT_HANDLERS: Dictionary = {
+	&"presentation_special_applied": &"_apply_presentation",
+	&"contest_mons_dropped_off": &"_event_contest_drop_off",
+	&"contest_mons_returned": &"_event_contest_return",
+	&"hall_of_fame_requested": &"_event_hall_of_fame",
+	&"credits_requested": &"_event_credits",
+	&"battle_tower_opponent_loaded": &"_event_battle_tower_opponent",
+	&"field_move_confirmed": &"_event_field_move_confirmed",
+	&"pokemon_picture_requested": &"_event_show_picture",
+	&"pokemon_picture_closed": &"_event_hide_picture",
+	&"money_window_opened": &"_show_money_window",
+	&"money_window_closed": &"_event_hide_money_window",
+	&"party_happiness_changed": &"_apply_party_happiness",
+	&"party_member_removed": &"_remove_party_member",
+	&"party_mail_given": &"_give_party_mail",
+	&"screen_shake_requested": &"_event_screen_shake",
+}
+
+## `presentation_special_applied` kind to the method that starts it.
+const PRESENTATION_HANDLERS: Dictionary = {
+	&"prof_oaks_pc_boot": &"_event_prof_oaks_pc",
+	&"heal_machine_anim": &"_start_heal_machine_sounds",
+	&"palette_fade": &"_start_script_fade",
+}
+
+## Events the results loop only records, and what each raises.
+const EVENT_FLAGS: Dictionary = {
 	## `Script_reloadmap`'s own entry method, which a warp does not share: only
 	## this one re-enters the map the player is already standing on.
-	var map_reloaded: bool = false
-	var clock_changed: bool = false
-	var blacked_out: bool = false
+	&"battle_map_reload_requested": [&"map_changed", &"map_reloaded"],
+	&"warp": [&"map_changed"],
+	&"world_clock_changed": [&"clock_changed"],
+	## `Script_reloadmapafterbattle`'s LOSE branch, which is `ScriptJump
+	## Script_BattleWhiteout` and ends the script: the runner has already
+	## stopped, so the sequence is started once the loop is done.
+	&"blackout": [&"blacked_out"],
+}
+
+## Events with nothing for a host to do but say so.
+const EVENT_PROMPTS: Array[StringName] = [
+	&"rock_smash_effect_requested", &"movement_command_requested", &"item_changed",
+	&"money_changed", &"coins_changed", &"movement_blocked", &"movement_failed",
+]
+
+## Runtime requests the screen answers itself. Each method takes the request and
+## answers what the results loop does next: `break`, `return` when it has already
+## shown its own results, or `none`.
+const REQUEST_HANDLERS: Dictionary = {
+	&"trainer_approach_requested": &"_request_trainer_approach",
+	&"battle_requested": &"_request_battle",
+	&"catch_tutorial_requested": &"_request_battle",
+	&"bug_contest_judging_requested": &"_request_bug_contest_judging",
+	&"quick_save_requested": &"_request_quick_save",
+	&"swarm_requested": &"_request_swarm",
+	&"map_radio_requested": &"_request_map_radio",
+	&"audio_requested": &"_request_audio",
+}
+
+## Runtime requests the screen answers by opening a page: the method that opens
+## it, and what a refusal does. `continue` leaves the script where it is,
+## `prompt` falls through to the generic acknowledge, and the rest complete the
+## request themselves with the values beside them.
+const REQUEST_OPENERS: Dictionary = {
+	&"link_record_requested": [&"_open_link_record", &"continue", {}],
+	&"link_room_requested": [&"_open_link_room", &"continue", {}],
+	&"party_selection_requested": [&"_open_party_selection", &"continue", {}],
+	&"name_rater_requested": [&"_open_name_rater", &"continue", {}],
+	&"move_deleter_requested": [&"_open_move_deleter", &"continue", {}],
+	&"move_tutor_requested": [&"_open_move_tutor", &"continue", {}],
+	&"day_care_requested": [&"_open_day_care", &"continue", {}],
+	&"pokedex_entry_requested": [&"_open_pokedex_entry", &"continue", {}],
+	## A cartridge whose cache has no slots or card flip art gives the coins back
+	## untouched rather than stopping the script.
+	&"slot_machine_requested": [&"_open_slot_machine", &"coins", {}],
+	&"card_flip_requested": [&"_open_card_flip", &"coins", {}],
+	## `ret z` on an empty dex, and the same answer for a cache with no glyphs or
+	## no diploma art: the script runs straight on and writes nothing either.
+	&"unown_printer_requested": [&"_open_unown_printer", &"values", {"ok": true}],
+	&"diploma_requested": [&"_open_diploma", &"values", {"ok": true}],
+	## A cache with no puzzle art answers an unsolved board, which is the
+	## `iftrue` the map takes either way.
+	&"unown_puzzle_requested": [
+		&"_open_unown_puzzle", &"values", {"ok": true, "script_value": 0},
+	],
+	&"pokemon_requested": [&"_open_gift_nickname", &"prompt", {}],
+	&"contest_mon_requested": [&"_open_contest_nickname", &"prompt", {}],
+}
+
+## Requests the service host draws, all on one screen.
+const SERVICE_HOST_REQUESTS: Array[StringName] = [
+	&"mart_requested", &"phone_call_requested", &"special_phone_call_requested",
+	&"town_map_requested", &"apricorn_selection_requested", &"pc_requested",
+	&"mom_bank_dial_requested", &"elevator_requested",
+]
+
+
+func _show_script_results(results: Array) -> void:
+	var flags: Dictionary = {}
 	for source_result: Dictionary in results:
 		var result: Dictionary = Gen2ModHost.publish(Gen2ModHost.CHANNEL_WORLD, source_result)
-		## Applied before the status below, and before any branch of it that leaves
+		## Spent before the status below, and before any branch of it that leaves
 		## the loop: a command's presentation effect happened before the wait the
-		## same result ends on, and a `break` that skipped this dropped it. That is
-		## what left a `pokepic` undrawn, since `Script_pokepic` is followed by the
-		## `cry` whose runtime request breaks out of the loop.
+		## same result ends on. A `break` that skipped this left a `pokepic`
+		## undrawn, since `Script_pokepic` is followed by the `cry` whose runtime
+		## request breaks out of the loop.
 		for result_event: Dictionary in result.get("events", []):
-			if result_event.get("type", &"") == &"presentation_special_applied" \
-				and StringName(result_event.get("kind", &"")) == &"prof_oaks_pc_boot":
-				open_prof_oaks_pc()
-			elif result_event.get("type", &"") == &"presentation_special_applied" \
-				and StringName(result_event.get("kind", &"")) == &"heal_machine_anim":
-				_start_heal_machine_sounds(result_event)
-			elif result_event.get("type", &"") == &"presentation_special_applied" \
-				and StringName(result_event.get("kind", &"")) == &"palette_fade":
-				_start_script_fade(result_event)
-			elif result_event.get("type", &"") == &"contest_mons_dropped_off":
-				## `ContestDropOffMons` masks the party to its lead; the world
-				## state keeps the stashed species byte and the save keeps the
-				## members themselves.
-				Gen2WorldPartyHost.contest_drop_off_mons(_active_party_save())
-			elif result_event.get("type", &"") == &"contest_mons_returned":
-				Gen2WorldPartyHost.contest_return_mons(_active_party_save())
-			elif result_event.get("type", &"") == &"hall_of_fame_requested":
-				## An event, not a runtime request: `halloffame` commits its flag
-				## and runs on, and the source's own `end` is the next command,
-				## so nothing is waiting to be resumed when this opens.
-				open_hall_of_fame()
-			elif result_event.get("type", &"") == &"credits_requested":
-				## `Script_credits` farcalls `RedCredits`, whose own
-				## `ld a, SPAWN_RED` puts the next CONTINUE on Mount Silver.
-				if _world != null:
-					_world.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_RED
-				open_credits()
-			elif result_event.get("type", &"") == &"soft_reset_requested":
-				## `special Reset` restarts the console, which is how a saved and
-				## left Battle Tower challenge leaves the battle room. The save
-				## has already been written by the action in front of it.
-				persist_world_snapshot()
-				_soft_reset()
+			if not _apply_result_event(result_event, flags):
 				return
-			elif result_event.get("type", &"") == &"battle_tower_opponent_loaded":
-				## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail, which
-				## writes the sampled class's sprite into `wMapObjects` and loads
-				## it: the opponent is chosen at random and has to appear as
-				## whoever was drawn.
-				_world.set_object_sprite(
-					int(result_event.get("object", 0)), int(result_event.get("sprite", 0))
-				)
-			elif result_event.get("type", &"") == &"field_move_confirmed":
-				## `iftrue Script_Cut` and its four counterparts. The move is the
-				## host's, and it is the same staged request and acknowledge the
-				## party submenu reaches, so the two ways in stay one path.
-				_use_prompted_field_move(int(result_event.get("move", 0)),
-					int(result_event.get("slot", -1)))
-			elif result_event.get("type", &"") == &"pokemon_picture_requested":
-				_show_story_picture(int(result_event.get("pokemon", 0)))
-			elif result_event.get("type", &"") == &"pokemon_picture_closed":
-				_hide_story_picture()
-			elif result_event.get("type", &"") == &"money_window_opened":
-				_show_money_window(result_event)
-			elif result_event.get("type", &"") == &"money_window_closed":
-				_hide_money_window()
-			elif result_event.get("type", &"") == &"party_happiness_changed":
-				_apply_party_happiness(result_event)
-			elif result_event.get("type", &"") == &"party_member_removed":
-				_remove_party_member(result_event)
-			elif result_event.get("type", &"") == &"party_mail_given":
-				_give_party_mail(result_event)
-			elif result_event.get("type", &"") == &"screen_shake_requested":
-				if _effects != null:
-					_effects.start_screen_shake(
-						int(result_event.get("strength", 0)),
-						&"screen_shake",
-						result_event,
-					)
-				if _renderer != null:
-					_renderer.refresh()
-			elif result_event.get("type", &"") == &"tree_shake_requested":
-				## The object animates itself for the frames the stream sleeps;
-				## there is nothing for a host to start.
-				pass
-			elif result_event.get("type", &"") in [
-				&"rock_smash_effect_requested",
-				&"movement_command_requested",
-			]:
-				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
-			elif result_event.get("type", &"") == &"warp":
-				map_changed = true
-			elif result_event.get("type", &"") == &"world_clock_changed":
-				clock_changed = true
-			elif result_event.get("type", &"") == &"battle_map_reload_requested":
-				map_changed = true
-				map_reloaded = true
-			elif result_event.get("type", &"") == &"blackout":
-				## `Script_reloadmapafterbattle`'s LOSE branch, which is
-				## `ScriptJump Script_BattleWhiteout` and ends the script: the
-				## runner has already stopped, so the sequence is started here
-				## and owns the screen from its first line.
-				blacked_out = true
-			elif result_event.get("type", &"") in [
-				&"item_changed", &"money_changed", &"coins_changed", &"movement_blocked",
-				&"movement_failed",
-			]:
-				_script_prompt = "Applied: %s" % String(result_event.get("type", &"effect"))
 		if result.has("clock"):
-			clock_changed = true
-		var status: StringName = StringName(result.get("status", &""))
-		if status == &"phone_ring":
-			waiting = true
-			var ring: Dictionary = result.get("event", {})
-			var contact: Dictionary = ring.get("contact", {})
-			_script_prompt = "Phone ringing: %s" % _phone_contact_label(contact)
-		elif status == &"waiting":
-			waiting = true
-			var event: Dictionary = result.get("event", {})
-			var event_type: StringName = StringName(event.get("type", &""))
-			if event_type == &"text" and event.has("unown_wall") \
-				and _open_unown_wall(String(event.get("text", ""))):
-				break
-			if event_type == &"text" and _text_box != null and _text_box.font != null:
-				## Prof Oak's PC is the one special that draws on its own and
-				## whose script runs on past it, so its pages are shown first and
-				## this text waits behind them.
-				# `LoadBlinkingCursor` is `Paragraph`, `_ContText` and
-				# `PromptText`; a `writetext` whose text ends in `done` reaches
-				# none of them, so its last page carries no arrow and the script
-				# runs straight on.
-				_text_awaits_press = bool(event.get("prompt", true))
-				if _oak_pc_pages.is_empty():
-					_apply_text_box_options()
-					_text_box.show_text(
-						String(event.get("text", "")), _text_awaits_press
-					)
-					_text_box.visible = true
-				_script_prompt = "A: advance text"
-				continue_after_text = true
-			elif event_type == &"button":
-				if _text_box != null:
-					_text_box.visible = true
-				_script_prompt = "A: continue script"
-			elif event_type == &"wait":
-				_script_prompt = "Script waiting on %s" % String(event.get("wait", &"frames"))
-			elif event_type in [&"choice", &"menu"]:
-				_open_service_host()
-				break
-			elif event_type == &"runtime_request":
-				var request: Dictionary = event.get("request", {})
-				if StringName(request.get("kind", &"")) == &"trainer_approach_requested":
-					_start_trainer_approach(request)
-					break
-				if StringName(request.get("kind", &"")) == &"battle_requested":
-					_start_battle_request(request)
-					break
-				if StringName(request.get("kind", &"")) == &"catch_tutorial_requested":
-					_start_battle_request(request)
-					break
-				if StringName(request.get("kind", &"")) == &"bug_contest_judging_requested":
-					## `_BugContestJudging` scores the player, ranks them against
-					## the contestants who turned up and leaves the placing in
-					## wScriptVar, which the results script branches on.
-					var judged: Dictionary = _world.judge_bug_contest(_encounter_random)
-					var judged_results: Array = _world.complete_runtime_request({
-						"ok": true,
-						"script_value": int(judged.get("player_place", 0)),
-						"judging": judged.duplicate(true),
-					})
-					_script_prompt = _bug_contest_placings_text(judged)
-					_show_script_results(judged_results)
-					return
-				if StringName(request.get("kind", &"")) == &"link_record_requested":
-					if _open_link_screen(Gen2LinkScreen.MODE_RECORD):
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"link_room_requested":
-					if _open_link_room(request):
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"quick_save_requested":
-					## `TryQuickSave` writes the save where it stands and answers
-					## TRUE; a write that fails answers FALSE, which is the same
-					## "no" the source gives a player who declines.
-					var written: Dictionary = persist_world_snapshot()
-					_show_script_results(_world.complete_runtime_request({
-						"ok": true,
-						"script_value": 1 if bool(written.get("ok", false)) else 0,
-					}))
-					return
-				if StringName(request.get("kind", &"")) == &"party_selection_requested":
-					if _open_party_selection():
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"name_rater_requested":
-					if _open_name_rater():
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"move_deleter_requested":
-					if _open_move_deleter():
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"move_tutor_requested":
-					if _open_move_tutor(request):
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"day_care_requested":
-					if _open_day_care(request):
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"slot_machine_requested":
-					if _open_slot_machine(request):
-						break
-					## A cartridge whose cache has no slots art gives the coins
-					## back untouched rather than stopping the script.
-					_show_script_results(_world.complete_runtime_request({
-						"ok": true,
-						"coins": int((request.get("values", {}) as Dictionary).get(
-							"coins", 0
-						)),
-					}))
-					return
-				if StringName(request.get("kind", &"")) == &"card_flip_requested":
-					if _open_card_flip(request):
-						break
-					## A cartridge whose cache has no card flip art gives the
-					## coins back untouched rather than stopping the script.
-					_show_script_results(_world.complete_runtime_request({
-						"ok": true,
-						"coins": int((request.get("values", {}) as Dictionary).get(
-							"coins", 0
-						)),
-					}))
-					return
-				if StringName(request.get("kind", &"")) == &"unown_printer_requested":
-					if _open_unown_printer(request):
-						break
-					## `ret z` on an empty dex, and the same answer for a cache
-					## with no glyphs: the script runs straight on.
-					_show_script_results(_world.complete_runtime_request({"ok": true}))
-					return
-				if StringName(request.get("kind", &"")) == &"diploma_requested":
-					if _open_diploma(request):
-						break
-					## A cache with no diploma art answers the script the way a
-					## page that has been read does: it writes nothing either.
-					_show_script_results(_world.complete_runtime_request({"ok": true}))
-					return
-				if StringName(request.get("kind", &"")) == &"unown_puzzle_requested":
-					if _open_unown_puzzle(request):
-						break
-					## A cartridge whose cache has no puzzle art answers the
-					## script an unsolved board rather than stopping it, which is
-					## the `iftrue` the map takes either way.
-					_show_script_results(_world.complete_runtime_request({
-						"ok": true, "script_value": 0,
-					}))
-					return
-				if StringName(request.get("kind", &"")) == &"swarm_requested":
-					var values: Dictionary = request.get("values", {})
-					var swarm_results: Array = _world.complete_runtime_request({
-						"ok": true,
-						"active": true,
-						"map_group": int(values.get("map_group", -1)),
-						"map_number": int(values.get("map_number", -1)),
-					})
-					_show_script_results(swarm_results)
-					return
-				if StringName(request.get("kind", &"")) == &"pokemon_requested" \
-					and _open_gift_nickname(request):
-					break
-				if StringName(request.get("kind", &"")) == &"contest_mon_requested" \
-					and _open_contest_nickname():
-					break
-				if StringName(request.get("kind", &"")) in \
-					Gen2WorldHost.UNATTENDED_REQUESTS:
-					var settled: Array = _complete_unattended_request()
-					if not settled.is_empty():
-						_show_script_results(settled)
-						return
-					continue
-				if StringName(request.get("kind", &"")) in [
-					&"mart_requested", &"phone_call_requested",
-					&"special_phone_call_requested", &"town_map_requested",
-					&"apricorn_selection_requested", &"pc_requested",
-					&"mom_bank_dial_requested", &"elevator_requested",
-				]:
-					_open_service_host()
-					break
-				if StringName(request.get("kind", &"")) == &"map_radio_requested":
-					var radio_results: Array = _handle_map_radio_request(request)
-					if not radio_results.is_empty():
-						_show_script_results(radio_results)
-					break
-				if StringName(request.get("kind", &"")) == &"pokedex_entry_requested":
-					if _open_pokedex_entry(request):
-						break
-					continue
-				if StringName(request.get("kind", &"")) == &"audio_requested":
-					var audio_results: Array = _handle_audio_request(request)
-					if not audio_results.is_empty():
-						_show_script_results(audio_results)
-					break
-				_script_prompt = "Runtime request: %s, press A to acknowledge" % String(
-					request.get("kind", "effect")
-				)
-		elif status == &"recovered":
-			## `_recovered_result`'s own status, raised on the same result the
-			## `blackout` event above is on.
-			blacked_out = true
-		elif not bool(result.get("ok", false)):
-			failed = true
+			flags[&"clock_changed"] = true
+		var verdict: StringName = _apply_result_status(result, flags)
+		if verdict == &"return":
+			return
+		if verdict == &"break":
+			break
+	_settle_after_results(flags)
+
+
+## Spends one script event, raising its rows of [constant EVENT_FLAGS] in
+## [param flags]. False when the screen is gone and the rest is dropped.
+func _apply_result_event(event: Dictionary, flags: Dictionary) -> bool:
+	var type: StringName = StringName(event.get("type", &""))
+	if type == &"soft_reset_requested":
+		## `special Reset` restarts the console, which is how a saved and left
+		## Battle Tower challenge leaves the battle room. The save has already
+		## been written by the action in front of it.
+		persist_world_snapshot()
+		_soft_reset()
+		return false
+	for flag: StringName in EVENT_FLAGS.get(type, []):
+		flags[flag] = true
+	if EVENT_PROMPTS.has(type):
+		_script_prompt = "Applied: %s" % String(type)
+	elif EVENT_HANDLERS.has(type):
+		call(EVENT_HANDLERS[type], event)
+	return true
+
+
+func _apply_presentation(event: Dictionary) -> void:
+	var kind: StringName = StringName(event.get("kind", &""))
+	if PRESENTATION_HANDLERS.has(kind):
+		call(PRESENTATION_HANDLERS[kind], event)
+
+
+## `ContestDropOffMons` masks the party to its lead; the world state keeps the
+## stashed species byte and the save keeps the members themselves.
+## An event, not a runtime request: `halloffame` commits its flag and runs on,
+## and the source's own `end` is the next command, so nothing is waiting to be
+## resumed when this opens.
+func _event_hall_of_fame(_event: Dictionary) -> void:
+	open_hall_of_fame()
+
+
+func _event_prof_oaks_pc(_event: Dictionary) -> void:
+	open_prof_oaks_pc()
+
+
+func _event_hide_picture(_event: Dictionary) -> void:
+	_hide_story_picture()
+
+
+func _event_hide_money_window(_event: Dictionary) -> void:
+	_hide_money_window()
+
+
+func _event_contest_drop_off(_event: Dictionary) -> void:
+	Gen2WorldPartyHost.contest_drop_off_mons(_active_party_save())
+
+
+func _event_contest_return(_event: Dictionary) -> void:
+	Gen2WorldPartyHost.contest_return_mons(_active_party_save())
+
+
+## `Script_credits` farcalls `RedCredits`, whose own `ld a, SPAWN_RED` puts the
+## next CONTINUE on Mount Silver.
+func _event_credits(_event: Dictionary) -> void:
+	if _world != null:
+		_world.spawn_after_champion = Gen2WorldSnapshot.SPAWN_AFTER_RED
+	open_credits()
+
+
+## `LoadOpponentTrainerAndPokemonWithOTSprite`'s tail: the opponent is chosen at
+## random and has to appear as whoever was drawn.
+func _event_battle_tower_opponent(event: Dictionary) -> void:
+	_world.set_object_sprite(int(event.get("object", 0)), int(event.get("sprite", 0)))
+
+
+## `iftrue Script_Cut` and its four counterparts. The move is the host's, and it
+## is the same staged request and acknowledge the party submenu reaches, so the
+## two ways in stay one path.
+func _event_field_move_confirmed(event: Dictionary) -> void:
+	_use_prompted_field_move(int(event.get("move", 0)), int(event.get("slot", -1)))
+
+
+func _event_show_picture(event: Dictionary) -> void:
+	_show_story_picture(int(event.get("pokemon", 0)))
+
+
+func _event_screen_shake(event: Dictionary) -> void:
+	if _effects != null:
+		_effects.start_screen_shake(int(event.get("strength", 0)), &"screen_shake", event)
+	if _renderer != null:
+		_renderer.refresh()
+
+
+## What the result's own status leaves the loop doing: `break`, `return` when it
+## has already shown results of its own, or `none`.
+func _apply_result_status(result: Dictionary, flags: Dictionary) -> StringName:
+	var status: StringName = StringName(result.get("status", &""))
+	if status == &"phone_ring":
+		flags[&"waiting"] = true
+		var ring: Dictionary = result.get("event", {})
+		_script_prompt = "Phone ringing: %s" % _phone_contact_label(
+			ring.get("contact", {})
+		)
+		return &"none"
+	if status == &"recovered":
+		## `_recovered_result`'s own status, raised on the same result the
+		## `blackout` event is on.
+		flags[&"blacked_out"] = true
+		return &"none"
+	if status != &"waiting":
+		if not bool(result.get("ok", false)):
+			flags[&"failed"] = true
 			_script_prompt = "Script stopped: %s" % String(result.get("reason", "unknown"))
-	if not waiting and not failed:
+		return &"none"
+
+	flags[&"waiting"] = true
+	var event: Dictionary = result.get("event", {})
+	var event_type: StringName = StringName(event.get("type", &""))
+	if event_type == &"text":
+		return _apply_text_pause(event, flags)
+	if event_type == &"button":
+		if _text_box != null:
+			_text_box.visible = true
+		_script_prompt = "A: continue script"
+		return &"none"
+	if event_type == &"wait":
+		_script_prompt = "Script waiting on %s" % String(event.get("wait", &"frames"))
+		return &"none"
+	if event_type in [&"choice", &"menu"]:
+		_open_service_host()
+		return &"break"
+	if event_type == &"runtime_request":
+		return _handle_runtime_request(event.get("request", {}))
+	return &"none"
+
+
+## A `writetext` pause. Prof Oak's PC is the one special that draws on its own
+## and whose script runs on past it, so its pages are shown first and this text
+## waits behind them.
+func _apply_text_pause(event: Dictionary, flags: Dictionary) -> StringName:
+	if event.has("unown_wall") and _open_unown_wall(String(event.get("text", ""))):
+		return &"break"
+	if _text_box == null or _text_box.font == null:
+		return &"none"
+	# `LoadBlinkingCursor` is `Paragraph`, `_ContText` and `PromptText`; a
+	# `writetext` whose text ends in `done` reaches none of them, so its last page
+	# carries no arrow and the script runs straight on.
+	_text_awaits_press = bool(event.get("prompt", true))
+	if _oak_pc_pages.is_empty():
+		_apply_text_box_options()
+		_text_box.show_text(String(event.get("text", "")), _text_awaits_press)
+		_text_box.visible = true
+	_script_prompt = "A: advance text"
+	flags[&"continue_after_text"] = true
+	return &"none"
+
+
+## What the open runtime request leaves the results loop doing.
+func _handle_runtime_request(request: Dictionary) -> StringName:
+	var kind: StringName = StringName(request.get("kind", &""))
+	if REQUEST_HANDLERS.has(kind):
+		return call(REQUEST_HANDLERS[kind], request) as StringName
+	if REQUEST_OPENERS.has(kind):
+		var opened: StringName = _open_requested_page(kind, request)
+		if opened != &"prompt":
+			return opened
+	elif kind in Gen2WorldHost.UNATTENDED_REQUESTS:
+		var settled: Array = _complete_unattended_request()
+		if settled.is_empty():
+			return &"none"
+		_show_script_results(settled)
+		return &"return"
+	elif kind in SERVICE_HOST_REQUESTS:
+		_open_service_host()
+		return &"break"
+	_script_prompt = "Runtime request: %s, press A to acknowledge" % String(
+		request.get("kind", "effect")
+	)
+	return &"none"
+
+
+## Opens [param kind]'s page, or spends its [constant REQUEST_OPENERS] refusal.
+func _open_requested_page(kind: StringName, request: Dictionary) -> StringName:
+	var row: Array = REQUEST_OPENERS[kind]
+	if call(row[0], request):
+		return &"break"
+	if row[1] == &"continue":
+		return &"none"
+	if row[1] == &"prompt":
+		return &"prompt"
+	var values: Dictionary = (row[2] as Dictionary).duplicate()
+	if row[1] == &"coins":
+		values = {
+			"ok": true,
+			"coins": int((request.get("values", {}) as Dictionary).get("coins", 0)),
+		}
+	_show_script_results(_world.complete_runtime_request(values))
+	return &"return"
+
+
+func _open_link_record(_request: Dictionary) -> bool:
+	return _open_link_screen(Gen2LinkScreen.MODE_RECORD)
+
+
+func _request_trainer_approach(request: Dictionary) -> StringName:
+	_start_trainer_approach(request)
+	return &"break"
+
+
+func _request_battle(request: Dictionary) -> StringName:
+	_start_battle_request(request)
+	return &"break"
+
+
+## `_BugContestJudging` scores the player, ranks them against the contestants who
+## turned up and leaves the placing in wScriptVar, which the results script
+## branches on.
+func _request_bug_contest_judging(_request: Dictionary) -> StringName:
+	var judged: Dictionary = _world.judge_bug_contest(_encounter_random)
+	var judged_results: Array = _world.complete_runtime_request({
+		"ok": true,
+		"script_value": int(judged.get("player_place", 0)),
+		"judging": judged.duplicate(true),
+	})
+	_script_prompt = _bug_contest_placings_text(judged)
+	_show_script_results(judged_results)
+	return &"return"
+
+
+## `TryQuickSave` writes the save where it stands and answers TRUE; a write that
+## fails answers FALSE, which is the same "no" the source gives a player who
+## declines.
+func _request_quick_save(_request: Dictionary) -> StringName:
+	var written: Dictionary = persist_world_snapshot()
+	_show_script_results(_world.complete_runtime_request({
+		"ok": true,
+		"script_value": 1 if bool(written.get("ok", false)) else 0,
+	}))
+	return &"return"
+
+
+func _request_swarm(request: Dictionary) -> StringName:
+	var values: Dictionary = request.get("values", {})
+	_show_script_results(_world.complete_runtime_request({
+		"ok": true,
+		"active": true,
+		"map_group": int(values.get("map_group", -1)),
+		"map_number": int(values.get("map_number", -1)),
+	}))
+	return &"return"
+
+
+func _request_map_radio(request: Dictionary) -> StringName:
+	var radio_results: Array = _handle_map_radio_request(request)
+	if not radio_results.is_empty():
+		_show_script_results(radio_results)
+	return &"break"
+
+
+func _request_audio(request: Dictionary) -> StringName:
+	var audio_results: Array = _handle_audio_request(request)
+	if not audio_results.is_empty():
+		_show_script_results(audio_results)
+	return &"break"
+
+
+## The renderer, the clock and the music the drained results owe the screen.
+func _settle_after_results(flags: Dictionary) -> void:
+	if not flags.has(&"waiting") and not flags.has(&"failed"):
 		_script_prompt = ""
-	if clock_changed:
+	if flags.has(&"clock_changed"):
 		_sync_host_clock()
 	if _renderer != null:
-		if map_changed:
+		if flags.has(&"map_changed"):
 			## A warp redraws the whole tilemap, so a balance window a script
 			## left standing goes with it the way `closetext`'s redraw takes it.
 			_hide_money_window()
 			## A warp has already run `_apply_map`, which is `EnterMap` whole;
 			## re-entering it here would take MAPSETUP_RELOADMAP's own poison
 			## reset on a step that never asked for one.
-			if map_reloaded:
+			if flags.has(&"map_reloaded"):
 				_world.reload_current_map()
 			_animation.configure(_world, _render_time_of_day())
 			_set_renderer_world()
@@ -7166,11 +7200,11 @@ func _show_script_results(results: Array) -> void:
 			_play_current_map_music()
 		else:
 			_renderer.refresh()
-	## Decided in the loop and spent here, because a special drawing its own
-	## pages is an event on the same result as the text waiting behind them.
-	if continue_after_text and _continue_if_text_settled():
+	## Decided in the loop and spent here, because a special drawing its own pages
+	## is an event on the same result as the text waiting behind them.
+	if flags.has(&"continue_after_text") and _continue_if_text_settled():
 		return
-	if blacked_out:
+	if flags.has(&"blacked_out"):
 		_start_whiteout()
 		return
 	_refresh_labels()
@@ -7324,17 +7358,14 @@ func money_window_open() -> bool:
 	return _money_window != null
 
 
-## `HaircutOrGrooming`'s own `call ChangeHappiness`. The row is the runner's,
-## since the roll that picked it has to belong to the seeded generator; the byte
-## it changes belongs to the save this screen holds.
-## `RemoveMonFromPartyOrBox` with REMOVE_PARTY, which `ReturnShuckie` runs on
-## the row the player handed back. An event rather than a runtime request: the
-## routine writes wScriptVar and runs straight on, and the removal is the same
+## `HaircutOrGrooming`'s own `call ChangeHappiness`. The row is the runner's, since
+## the roll that picked it has to belong to the seeded generator; the byte it
+## changes belongs to the save this screen holds. Below, `RemoveMonFromPartyOrBox`
+## with REMOVE_PARTY, which `ReturnShuckie` runs on the row the player handed back,
+## and `GivePokeMail`, the item onto the member's own MON_ITEM and the script's
+## message into its `sPartyMail` row. Both are events rather than runtime requests:
+## each routine answers nothing and runs straight on, and the write is the same
 ## save write a happiness change is.
-## `GivePokeMail`: the item onto the member's own MON_ITEM and the script's
-## message into its `sPartyMail` row, whose author, ID and species are the
-## member's own. An event rather than a runtime request, for the same reason the
-## removal below is one: the routine answers nothing and runs straight on.
 func _give_party_mail(event: Dictionary) -> void:
 	var save: Gen2SaveData = _embedded_party_save()
 	var slot: int = int(event.get("slot", -1))
@@ -7440,7 +7471,7 @@ func _apply_party_happiness(event: Dictionary) -> void:
 ## routines. The same list the Name Rater and the move deleter open, and the
 ## same `_party_host` the start menu uses, so an overlay is named in one place
 ## and a press reaches it through one branch.
-func _open_party_selection() -> bool:
+func _open_party_selection(_request: Dictionary = {}) -> bool:
 	if _party_host != null or _world == null or _data == null:
 		return false
 	var save: Gen2SaveData = _embedded_party_save()

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -152,256 +152,180 @@ static func pointer_key(bank: int, address: int) -> String:
 	return "%d:%04X" % [bank, address]
 
 
+## Every opcode's command name, on pokegold's numbering. The eight commands the
+## two profiles spell differently are [constant PROFILE_COMMAND_NAMES]; an opcode
+## in neither is not a command on this profile.
+const COMMAND_NAMES: Dictionary = {
+	SCALL: &"scall",
+	FARSCALL: &"farscall",
+	MEMCALL: &"memcall",
+	SJUMP: &"sjump",
+	FARSJUMP: &"farsjump",
+	MEMJUMP: &"memjump",
+	IFEQUAL: &"ifequal",
+	IFNOTEQUAL: &"ifnotequal",
+	IFFALSE: &"iffalse",
+	IFTRUE: &"iftrue",
+	IFGREATER: &"ifgreater",
+	IFLESS: &"ifless",
+	JUMPSTD: &"jumpstd",
+	CALLSTD: &"callstd",
+	CALLASM: &"callasm",
+	SPECIAL: &"special",
+	MEMCALLASM: &"memcallasm",
+	CHECKMAPSCENE: &"checkmapscene",
+	SETMAPSCENE: &"setmapscene",
+	CHECKSCENE: &"checkscene",
+	SETSCENE: &"setscene",
+	SETVAL: &"setval",
+	ADDVAL: &"addval",
+	RANDOM: &"random",
+	CHECKVER: &"checkver",
+	READMEM: &"readmem",
+	WRITEMEM: &"writemem",
+	LOADMEM: &"loadmem",
+	READVAR: &"readvar",
+	WRITEVAR: &"writevar",
+	LOADVAR: &"loadvar",
+	GIVEITEM: &"giveitem",
+	TAKEITEM: &"takeitem",
+	CHECKITEM: &"checkitem",
+	GIVEMONEY: &"givemoney",
+	TAKEMONEY: &"takemoney",
+	CHECKMONEY: &"checkmoney",
+	GIVECOINS: &"givecoins",
+	TAKECOINS: &"takecoins",
+	CHECKCOINS: &"checkcoins",
+	ADDCELLNUM: &"addcellnum",
+	DELCELLNUM: &"delcellnum",
+	CHECKCELLNUM: &"checkcellnum",
+	CHECKTIME: &"checktime",
+	CHECKPOKE: &"checkpoke",
+	GIVEPOKE: &"givepoke",
+	GIVEEGG: &"giveegg",
+	GIVEPOKEMAIL: &"givepokemail",
+	CHECKPOKEMAIL: &"checkpokemail",
+	CHECKEVENT: &"checkevent",
+	CLEAREVENT: &"clearevent",
+	SETEVENT: &"setevent",
+	CHECKFLAG: &"checkflag",
+	CLEARFLAG: &"clearflag",
+	SETFLAG: &"setflag",
+	WILDON: &"wildon",
+	WILDOFF: &"wildoff",
+	XYCOMPARE: &"xycompare",
+	WARPMOD: &"warpmod",
+	BLACKOUTMOD: &"blackoutmod",
+	WARP: &"warp",
+	GETMONEY: &"getmoney",
+	GETCOINS: &"getcoins",
+	GETNUM: &"getnum",
+	GETMONNAME: &"getmonname",
+	GETITEMNAME: &"getitemname",
+	GETCURLANDMARKNAME: &"getcurlandmarkname",
+	GETTRAINERNAME: &"gettrainername",
+	GETSTRING: &"getstring",
+	ITEMNOTIFY: &"itemnotify",
+	POCKETISFULL: &"pocketisfull",
+	OPENTEXT: &"opentext",
+	REANCHORMAP: &"reanchormap",
+	CLOSETEXT: &"closetext",
+	WRITEUNUSEDBYTE: &"writeunusedbyte",
+	FARWRITETEXT: &"farwritetext",
+	WRITETEXT: &"writetext",
+	REPEATTEXT: &"repeattext",
+	YESORNO: &"yesorno",
+	LOADMENU: &"loadmenu",
+	CLOSEWINDOW: &"closewindow",
+	JUMPTEXTFACEPLAYER: &"jumptextfaceplayer",
+	FACEPLAYER: &"faceplayer",
+}
+
+## The opcodes Crystal and pokegold give different names, as [crystal, gold]. An
+## empty name is an opcode that profile does not have.
+const PROFILE_COMMAND_NAMES: Dictionary = {
+	FARJUMPTEXT: [&"farjumptext", &"jumptext"],
+	JUMPTEXT: [&"jumptext", &"waitbutton"],
+	WAITBUTTON: [&"waitbutton", &"promptbutton"],
+	PROMPTBUTTON: [&"promptbutton", &"pokepic"],
+	GOLD_FACEPLAYER: [&"", &"faceplayer"],
+	GOLD_ENDCALLBACK: [&"", &"endcallback"],
+	ENDCALLBACK: [&"endcallback", &"end"],
+	END: [&"end", &""],
+}
+
+
 static func command_name(opcode: int, crystal_commands: bool = true) -> StringName:
 	var later_name: StringName = _later_command_name(opcode, crystal_commands)
 	if not later_name.is_empty():
 		return later_name
-	match opcode:
-		SCALL:
-			return &"scall"
-		FARSCALL:
-			return &"farscall"
-		MEMCALL:
-			return &"memcall"
-		SJUMP:
-			return &"sjump"
-		FARSJUMP:
-			return &"farsjump"
-		MEMJUMP:
-			return &"memjump"
-		IFEQUAL:
-			return &"ifequal"
-		IFNOTEQUAL:
-			return &"ifnotequal"
-		IFFALSE:
-			return &"iffalse"
-		IFTRUE:
-			return &"iftrue"
-		IFGREATER:
-			return &"ifgreater"
-		IFLESS:
-			return &"ifless"
-		JUMPSTD:
-			return &"jumpstd"
-		CALLSTD:
-			return &"callstd"
-		CALLASM:
-			return &"callasm"
-		SPECIAL:
-			return &"special"
-		MEMCALLASM:
-			return &"memcallasm"
-		CHECKMAPSCENE:
-			return &"checkmapscene"
-		SETMAPSCENE:
-			return &"setmapscene"
-		CHECKSCENE:
-			return &"checkscene"
-		SETSCENE:
-			return &"setscene"
-		SETVAL:
-			return &"setval"
-		ADDVAL:
-			return &"addval"
-		RANDOM:
-			return &"random"
-		CHECKVER:
-			return &"checkver"
-		READMEM:
-			return &"readmem"
-		WRITEMEM:
-			return &"writemem"
-		LOADMEM:
-			return &"loadmem"
-		READVAR:
-			return &"readvar"
-		WRITEVAR:
-			return &"writevar"
-		LOADVAR:
-			return &"loadvar"
-		GIVEITEM:
-			return &"giveitem"
-		TAKEITEM:
-			return &"takeitem"
-		CHECKITEM:
-			return &"checkitem"
-		GIVEMONEY:
-			return &"givemoney"
-		TAKEMONEY:
-			return &"takemoney"
-		CHECKMONEY:
-			return &"checkmoney"
-		GIVECOINS:
-			return &"givecoins"
-		TAKECOINS:
-			return &"takecoins"
-		CHECKCOINS:
-			return &"checkcoins"
-		ADDCELLNUM:
-			return &"addcellnum"
-		DELCELLNUM:
-			return &"delcellnum"
-		CHECKCELLNUM:
-			return &"checkcellnum"
-		CHECKTIME:
-			return &"checktime"
-		CHECKPOKE:
-			return &"checkpoke"
-		GIVEPOKE:
-			return &"givepoke"
-		GIVEEGG:
-			return &"giveegg"
-		GIVEPOKEMAIL:
-			return &"givepokemail"
-		CHECKPOKEMAIL:
-			return &"checkpokemail"
-		CHECKEVENT:
-			return &"checkevent"
-		CLEAREVENT:
-			return &"clearevent"
-		SETEVENT:
-			return &"setevent"
-		CHECKFLAG:
-			return &"checkflag"
-		CLEARFLAG:
-			return &"clearflag"
-		SETFLAG:
-			return &"setflag"
-		WILDON:
-			return &"wildon"
-		WILDOFF:
-			return &"wildoff"
-		XYCOMPARE:
-			return &"xycompare"
-		WARPMOD:
-			return &"warpmod"
-		BLACKOUTMOD:
-			return &"blackoutmod"
-		WARP:
-			return &"warp"
-		GETMONEY:
-			return &"getmoney"
-		GETCOINS:
-			return &"getcoins"
-		GETNUM:
-			return &"getnum"
-		GETMONNAME:
-			return &"getmonname"
-		GETITEMNAME:
-			return &"getitemname"
-		GETCURLANDMARKNAME:
-			return &"getcurlandmarkname"
-		GETTRAINERNAME:
-			return &"gettrainername"
-		GETSTRING:
-			return &"getstring"
-		ITEMNOTIFY:
-			return &"itemnotify"
-		POCKETISFULL:
-			return &"pocketisfull"
-		OPENTEXT:
-			return &"opentext"
-		REANCHORMAP:
-			return &"reanchormap"
-		CLOSETEXT:
-			return &"closetext"
-		WRITEUNUSEDBYTE:
-			return &"writeunusedbyte"
-		FARWRITETEXT:
-			return &"farwritetext"
-		WRITETEXT:
-			return &"writetext"
-		REPEATTEXT:
-			return &"repeattext"
-		YESORNO:
-			return &"yesorno"
-		LOADMENU:
-			return &"loadmenu"
-		CLOSEWINDOW:
-			return &"closewindow"
-		JUMPTEXTFACEPLAYER:
-			return &"jumptextfaceplayer"
-		FARJUMPTEXT:
-			return &"farjumptext" if crystal_commands else &"jumptext"
-		JUMPTEXT:
-			return &"jumptext" if crystal_commands else &"waitbutton"
-		WAITBUTTON:
-			return &"waitbutton" if crystal_commands else &"promptbutton"
-		PROMPTBUTTON:
-			return &"promptbutton" if crystal_commands else &"pokepic"
-		GOLD_FACEPLAYER:
-			return &"faceplayer" if not crystal_commands else &""
-		FACEPLAYER:
-			return &"faceplayer"
-		GOLD_ENDCALLBACK:
-			return &"endcallback" if not crystal_commands else &""
-		ENDCALLBACK:
-			return &"endcallback" if crystal_commands else &"end"
-		END:
-			return &"end" if crystal_commands else &""
-	return &""
+	if PROFILE_COMMAND_NAMES.has(opcode):
+		return PROFILE_COMMAND_NAMES[opcode][0 if crystal_commands else 1]
+	return COMMAND_NAMES.get(opcode, &"")
+
+
+## Command widths in bytes, opcode run by width, on pokegold's numbering. The
+## eight the two profiles disagree about are [constant PROFILE_COMMAND_WIDTHS];
+## an opcode in neither falls through to the two tables further down.
+const COMMAND_WIDTHS: Dictionary = {
+	0: [
+		GIVEPOKE
+	],
+	1: [
+		CHECKSCENE, CHECKVER, WILDON, WILDOFF, ITEMNOTIFY, POCKETISFULL, OPENTEXT,
+		CLOSETEXT, YESORNO, CLOSEWINDOW, WAITBUTTON, ENDCALLBACK
+	],
+	2: [
+		SETSCENE, SETVAL, ADDVAL, RANDOM, READVAR, WRITEVAR, CHECKITEM, ADDCELLNUM,
+		DELCELLNUM, CHECKCELLNUM, CHECKTIME, CHECKPOKE, GETNUM, GETCURLANDMARKNAME,
+		REANCHORMAP, WRITEUNUSEDBYTE
+	],
+	3: [
+		SCALL, MEMCALL, SJUMP, MEMJUMP, WRITETEXT, JUMPTEXTFACEPLAYER, IFFALSE, IFTRUE,
+		JUMPSTD, CALLSTD, READMEM, WRITEMEM, XYCOMPARE, GIVEPOKEMAIL, CHECKPOKEMAIL,
+		LOADMENU, SPECIAL, MEMCALLASM, CHECKMAPSCENE, LOADVAR, GIVEITEM, TAKEITEM,
+		GIVECOINS, TAKECOINS, CHECKCOINS, CHECKFLAG, CLEARFLAG, SETFLAG, CLEAREVENT,
+		SETEVENT, BLACKOUTMOD, GETMONEY, GETMONNAME, GETITEMNAME, GIVEEGG, CHECKEVENT,
+		REPEATTEXT
+	],
+	4: [
+		FARSCALL, FARSJUMP, CALLASM, FARWRITETEXT, IFEQUAL, IFNOTEQUAL, IFGREATER, IFLESS,
+		LOADMEM, SETMAPSCENE, WARPMOD, GETTRAINERNAME, GETSTRING
+	],
+	5: [
+		GIVEMONEY, TAKEMONEY, CHECKMONEY, WARP
+	],
+}
+
+## [constant COMMAND_WIDTHS] flattened to opcode: width, built once.
+static var WIDTH_OF: Dictionary = _width_of(COMMAND_WIDTHS)
+
+
+static func _width_of(runs: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for width: int in runs:
+		for opcode: int in runs[width]:
+			out[opcode] = width
+	return out
+
+## The opcodes Crystal and pokegold give different widths, as [crystal, gold].
+const PROFILE_COMMAND_WIDTHS: Dictionary = {
+	GETCOINS: [3, 2],
+	FARJUMPTEXT: [4, 3],
+	JUMPTEXT: [3, 1],
+	PROMPTBUTTON: [1, 2],
+	GOLD_FACEPLAYER: [0, 1],
+	FACEPLAYER: [1, 0],
+	GOLD_ENDCALLBACK: [0, 1],
+	END: [1, 0],
+}
 
 
 static func command_width(opcode: int, crystal_commands: bool = true) -> int:
-	match opcode:
-		SCALL, MEMCALL, SJUMP, MEMJUMP, WRITETEXT, JUMPTEXTFACEPLAYER, IFFALSE, IFTRUE, JUMPSTD, CALLSTD, READMEM, WRITEMEM, XYCOMPARE, GIVEPOKEMAIL, CHECKPOKEMAIL, LOADMENU:
-			return 3
-		FARSCALL, FARSJUMP, CALLASM, FARWRITETEXT:
-			return 4
-		IFEQUAL, IFNOTEQUAL, IFGREATER, IFLESS, LOADMEM:
-			return 4
-		SPECIAL, MEMCALLASM, SETMAPSCENE, WARPMOD:
-			return 3 if opcode == SPECIAL or opcode == MEMCALLASM else 4
-		CHECKMAPSCENE:
-			return 3
-		CHECKSCENE, CHECKVER, WILDON, WILDOFF, ITEMNOTIFY, POCKETISFULL, OPENTEXT, CLOSETEXT, YESORNO, CLOSEWINDOW:
-			return 1
-		SETSCENE:
-			return 2
-		SETVAL, ADDVAL, RANDOM, READVAR, WRITEVAR, CHECKITEM, ADDCELLNUM, DELCELLNUM, CHECKCELLNUM, CHECKTIME, CHECKPOKE, GETNUM, GETCURLANDMARKNAME, REANCHORMAP, WRITEUNUSEDBYTE:
-			return 2
-		LOADVAR, GIVEITEM, TAKEITEM:
-			return 3
-		GIVECOINS, TAKECOINS, CHECKCOINS, CHECKFLAG, CLEARFLAG, SETFLAG, CLEAREVENT, SETEVENT, BLACKOUTMOD:
-			return 3
-		GIVEMONEY, TAKEMONEY, CHECKMONEY:
-			return 5
-		GETMONEY:
-			return 3
-		GETCOINS:
-			return 3 if crystal_commands else 2
-		GETMONNAME, GETITEMNAME:
-			return 3
-		GETTRAINERNAME, GETSTRING:
-			return 4
-		GIVEEGG:
-			return 3
-		GIVEPOKE:
-			return 0
-		CHECKEVENT:
-			return 3
-		WARP:
-			return 5
-		REPEATTEXT:
-			return 3
-		FARJUMPTEXT:
-			return 4 if crystal_commands else 3
-		JUMPTEXT:
-			return 3 if crystal_commands else 1
-		WAITBUTTON:
-			return 1
-		PROMPTBUTTON:
-			return 1 if crystal_commands else 2
-		GOLD_FACEPLAYER:
-			return 1 if not crystal_commands else 0
-		FACEPLAYER:
-			return 1 if crystal_commands else 0
-		GOLD_ENDCALLBACK:
-			return 1 if not crystal_commands else 0
-		ENDCALLBACK:
-			return 1
-		END:
-			return 1 if crystal_commands else 0
+	if PROFILE_COMMAND_WIDTHS.has(opcode):
+		return PROFILE_COMMAND_WIDTHS[opcode][0 if crystal_commands else 1]
+	if WIDTH_OF.has(opcode):
+		return WIDTH_OF[opcode]
 	if crystal_commands:
 		var crystal_width: int = _crystal_only_command_width(opcode)
 		if crystal_width > 0:
@@ -547,15 +471,13 @@ static func _later_command_name(opcode: int, crystal_commands: bool) -> StringNa
 
 
 ## Normalizes a raw command byte onto pokegold's numbering, which every width,
-## name and handler table here is keyed with. Crystal's stream inserts two
-## commands pokegold does not have: `farjumptext` at $52 and
-## `verbosegiveitemvar` at $9f (macros/scripts/events.asm in both pins). So
-## Crystal is one ahead from $53 and two ahead from $a0, and the commands
-## Crystal added themselves have no source opcode: callers handle those from the
-## raw byte before asking.
-##
-## The low boundary is $56 rather than $53 because every caller resolves
-## farjumptext, jumptext, waitbutton and promptbutton from the raw opcode first.
+## name and handler table here is keyed with. Crystal's stream inserts two commands
+## pokegold does not have, `farjumptext` at $52 and `verbosegiveitemvar` at $9f, so
+## Crystal is one ahead from $53 and two ahead from $a0, and the commands Crystal
+## added themselves have no source opcode: callers handle those from the raw byte
+## before asking. The low boundary is $56 rather than $53 because every caller
+## resolves farjumptext, jumptext, waitbutton and promptbutton from the raw opcode
+## first.
 static func source_opcode(opcode: int, crystal_commands: bool = true) -> int:
 	if not crystal_commands or opcode < 0x56:
 		return opcode

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -210,16 +210,13 @@ const SNORLAX_PROXIMITY_CELLS: Array[Vector2i] = [
 ## special_index() already normalizes. maps/KurtsHouse.asm's `.AskApricorn`
 ## branches on wScriptVar afterwards, one label per apricorn.
 const SPECIAL_SELECT_APRICORN_FOR_KURT: int = 86
-## MoveDeletion, 33 in both profiles: it sits below the first index the two
-## tables disagree on, so `special_index()` leaves it alone. `MoveDeletion` owns
-## the same shape `NameRater` does, one house further on, so it is one host
-## request as well.
-## The Battle Tower's own six specials, Crystal's alone. `BattleTowerAction` is
-## one routine reached with a `setval` in front of it, `BattleTowerRoomMenu` and
-## `Menu_ChallengeExplanationCancel` are the two menus the receptionist opens,
-## `LoadOpponentTrainerAndPokemon...` samples the next opponent and
-## `BattleTowerBattle` fights it. `CheckForBattleTowerRules` is the party check
-## in front of the whole challenge.
+## MoveDeletion, 33 in both profiles: it sits below the first index the two tables
+## disagree on, so `special_index()` leaves it alone, and it owns the same shape
+## `NameRater` does one house further on. Below, the Battle Tower's own six
+## specials, Crystal's alone: `BattleTowerAction` is one routine reached with a
+## `setval` in front of it, two of them are the menus the receptionist opens, one
+## samples the next opponent and one fights it, and `CheckForBattleTowerRules` is
+## the party check in front of the whole challenge.
 const SPECIAL_BATTLE_TOWER_ROOM_MENU: int = 116
 const SPECIAL_BATTLE_TOWER_BATTLE: int = 119
 const SPECIAL_LOAD_BATTLE_TOWER_OPPONENT: int = 122
@@ -352,22 +349,13 @@ const MONEY_WINDOW_KIND_OF: Dictionary = {
 	SPECIAL_PLACE_MONEY_TOP_RIGHT: &"money_top_right",
 }
 
-## DisplayUnownWords, which is Crystal's alone: pokegold's table stops well
-## before it, so no Gold or Silver script can reach this index and neither dump
-## ships the words. The four wall patterns are Crystal bg events, two per
-## chamber, where Gold and Silver's cells carry only the puzzle sign. A preceding
-## `setval` puts the `UNOWNWORDS_*` index in wScriptVar. Not to be read as 41,
-## which is `UnownPuzzle` on both and is the sliding puzzle itself.
-## `UnownPuzzle`, the sliding puzzle each of the four Ruins of Alph chambers
-## opens. The map's own `setval` in front of it names which picture; the special
-## answers `wSolvedUnownPuzzle` in wScriptVar, which the `iftrue` after the
-## `closetext` reads. 41 on both profiles, being under `special_index`'s split.
-## `SlotMachine`, the Game Corner's own machine. The map's `setval` in front of
-## it is `wScriptVar`, which `Slots_InitBias` reads: TRUE picks `.Lucky`'s own
-## bias table, and a `random 6 / ifequal 0` in front of the two scripts is which
-## machine a player sat down at. 42 on both profiles, being under
-## `special_index`'s split, and the machine's own `wCoins` writes are the coins
-## the request answers with.
+## DisplayUnownWords, Crystal's alone: pokegold's table stops well before it and
+## neither dump ships the words. The four wall patterns are Crystal bg events, two
+## per chamber, where Gold and Silver's cells carry only the puzzle sign. Not to be
+## read as 41, which is `UnownPuzzle` on both. That one is the sliding puzzle each
+## chamber opens, its `setval` naming the picture and its answer read by the
+## `iftrue`; 42 is `SlotMachine`, whose `setval` is what `Slots_InitBias` reads,
+## TRUE picking `.Lucky`'s own bias table. Both are under `special_index`'s split.
 const SPECIAL_SLOT_MACHINE: int = 42
 ## `CardFlip`, the Game Corner's other machine. Both Game Corners reach it and
 ## neither puts a `setval` in front of it: the routine reads no `wScriptVar` and
@@ -761,368 +749,56 @@ static func begin(
 	return runner
 
 
+## `_pending`'s type and `special` tag to the method that resumes it, taking the
+## caller's choice and answering a result. A pause with no row here gets the
+## generic answer in [method _resume_pending].
+const PENDING_RESUMES: Dictionary = {
+	&"menu/set_day_of_week": &"_resume_day_of_week_menu",
+	&"menu/battle_tower_challenge_menu": &"_resume_challenge_menu",
+	&"menu/battle_tower_room_menu": &"_resolve_room_menu",
+	&"text/battle_tower_room_refusal": &"_resume_room_refusal",
+	&"menu/buenas_password": &"_resume_buenas_password",
+	&"text/set_day_of_week_confirmation": &"_resume_day_of_week_text",
+	&"choice/set_day_of_week_confirmation": &"_resume_day_of_week_choice",
+	&"text/strength_ask": &"_resume_strength_ask_text",
+	&"choice/strength_ask": &"_resume_strength_ask_choice",
+	&"text/fruit_tree": &"_resume_fruit_tree",
+	&"text/item_received": &"_resume_item_received",
+	&"text/pocket_is_full": &"_resume_pocket_is_full",
+	&"text/strength_used": &"_resume_strength_used",
+	&"menu/buena_prize": &"_resume_buena_prize_menu",
+	&"choice/buena_prize_confirm": &"_resume_buena_prize_confirm",
+	&"menu/bank_of_mom_menu": &"_resume_mom_menu",
+	&"choice/bank_of_mom_choice": &"_resume_mom_choice",
+	&"text/field_move_ask": &"_resume_field_move_text",
+	&"choice/field_move_ask": &"_resume_field_move_choice",
+	&"choice/ask_remember_password": &"_resume_remember_password",
+	&"text/rock_smash_ask": &"_resume_rock_smash_text",
+	&"choice/rock_smash_ask": &"_resume_rock_smash_choice",
+	&"text/rock_smash_used": &"_resume_rock_smash_used",
+}
+
+## The continuations that carry their payload in a `_pending` key rather than a
+## tag, in the order a pause carrying two of them is resumed.
+const PENDING_CONTINUATIONS: Dictionary = {
+	"next_internal_texts": &"_resume_internal_texts",
+	"bank_of_mom_after_text": &"_resume_mom_after_text",
+	"bank_of_mom_dial": &"_resume_mom_dial",
+	"buena_prize_after_text": &"_resume_buena_after_text",
+	"party_selection_after_text": &"_resume_party_selection",
+	"special_after_text": &"_resume_special_after_text",
+}
+
+
 ## Advances until a text/button pause, completion or a bounded failure.
 func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 	if not _phone_context.is_empty() and not _phone_started:
 		_phone_started = true
 		_emit_runtime_event(&"phone_call_started", _phone_context)
 	if _pending:
-		if _pending.has("text"):
-			_standing_text = String(_pending["text"])
-		var pending_request: Dictionary = _pending.get("request", {})
-		if _pending.get("type", &"") == &"runtime_request" \
-			and StringName(pending_request.get("kind", &"")) == &"battle_requested":
-			return _waiting_result()
-		## Only frames end a wait, so a button press cannot: the source is inside
-		## WaitScriptMovement or a DelayFrames loop, which read no input at all.
-		if _pending.get("type", &"") == &"wait":
-			return _waiting_result()
-		if not acknowledge:
-			return _waiting_result()
-		var pending_type: StringName = StringName(_pending.get("type", &""))
-		if pending_type == &"menu" and _pending_tag() == &"set_day_of_week":
-			if choice < 0:
-				return _waiting_result()
-			var selected_day: int = posmod(choice, WEEKDAY_NAMES.size())
-			_pending = {
-				"type": &"text",
-				## `.ConfirmWeekdayText` places the weekday at `hlcoord 1, 14` and
-				## `_OakTimeIsItText` carries on from where `PlaceString` left
-				## off, so the two are one line.
-				"text": "%s, is it?" % WEEKDAY_NAMES[selected_day],
-				"special": &"set_day_of_week_confirmation",
-				"day": selected_day,
-				"source": _request.duplicate(true),
-			}
-			return _waiting_result()
-		if pending_type == &"menu" and _pending_tag() == &"battle_tower_challenge_menu":
-			## `Function17d246`: a row answers its own one-based number and B
-			## answers the same 4 the routine writes before it opens the menu.
-			_pending = {}
-			_script_value = CHALLENGE_MENU_CANCEL if choice < 0 else choice + 1
-			return advance()
-		if pending_type == &"menu" and _pending_tag() == &"battle_tower_room_menu":
-			return _resolve_room_menu(choice)
-		## The two refusals the room menu prints put its jumptable back at zero
-		## rather than leaving the routine, so the menu opens again behind them.
-		if pending_type == &"text" and _pending_tag() == &"battle_tower_room_refusal":
-			_pending = {}
-			return _stage_room_menu()
-		if pending_type == &"menu" and _pending_tag() == &"buenas_password":
-			## `STATICMENU_DISABLE_B`: B does not close the list, so the only way
-			## out is a row. The answer is whether it is the row the byte's own
-			## low nibble names, which `maskbits NUM_PASSWORDS_PER_CATEGORY`
-			## takes off it.
-			if choice < 0:
-				return _waiting_result()
-			var password: int = int(_pending.get("password", 0))
-			_pending = {}
-			_script_value = 1 if choice == (password & 0x3) else 0
-			return advance()
-		if pending_type == &"text" and _pending_tag() == &"set_day_of_week_confirmation":
-			var confirmation_day: int = int(_pending.get("day", 0))
-			_stage_day_of_week_confirmation(confirmation_day)
-			return _waiting_result()
-		if pending_type == &"choice" and _pending_tag() == &"set_day_of_week_confirmation":
-			var confirmed_day: int = int(_pending.get("day", 0))
-			_pending = {}
-			if choice == 0:
-				_staged_day_of_week = confirmed_day
-				_script_value = 1
-				return advance()
-			_stage_day_of_week_menu()
-			return _waiting_result()
-		## AskStrengthScript's `.AskStrength`: opentext, writetext, yesorno. The
-		## text pause is acknowledged first, then the choice is offered.
-		if pending_type == &"text" and _pending_tag() == &"strength_ask":
-			_pending = {
-				"type": &"choice",
-				"command": &"yesorno",
-				"choices": [&"yes", &"no"],
-				"text": _standing_text,
-				"special": &"strength_ask",
-				"slot": int(_pending.get("slot", -1)),
-				"source": _request.duplicate(true),
-			}
-			return _waiting_result()
-		if pending_type == &"choice" and _pending_tag() == &"strength_ask":
-			var chosen_slot: int = int(_pending.get("slot", -1))
-			_pending = {}
-			## `iftrue Script_UsedStrength`, and a no falls to closetext/end.
-			_script_value = 1 if choice == 0 else 0
-			if choice != 0:
-				return _complete()
-			_stage_strength_used(chosen_slot)
-			return _waiting_result()
-		## FruitTreeScript's promptbutton, behind which its two callasms sit.
-		if pending_type == &"text" and _pending_tag() == &"fruit_tree":
-			var fruit_tree: int = int(_pending.get("tree_id", 0))
-			var fruit_item: int = int(_pending.get("item", 0))
-			_pending = {}
-			_finish_after_pending = false
-			var picked: Dictionary = _resolve_fruit_tree(fruit_tree, fruit_item)
-			if not bool(picked.get("ok", false)):
-				return _fail(StringName(picked.get("reason", &"fruit_tree_failed")), picked)
-			return _waiting_result()
-		## The tail every item receipt shares behind its own line: the sound, and
-		## then `itemnotify`'s box once the host has played it.
-		if pending_type == &"text" and _pending_tag() == &"item_received":
-			var receipt_item: int = int(_pending.get("item", 0))
-			var receipt_sfx: int = int(_pending.get("sfx", 0))
-			var receipt_finish: bool = bool(_pending.get("finish", false))
-			_pending = {}
-			_finish_after_pending = false
-			_stage_receipt_tail(receipt_item, receipt_sfx, receipt_finish)
-			return _waiting_result()
-		## `GiveItemScript.Full`, whose `promptbutton` is the acknowledge above.
-		if pending_type == &"text" and _pending_tag() == &"pocket_is_full":
-			var full_item: int = int(_pending.get("item", 0))
-			var full_finish: bool = bool(_pending.get("finish", false))
-			_pending = {}
-			_finish_after_pending = false
-			_stage_pocket_is_full(full_item, full_finish)
-			return _waiting_result()
-		## Script_UsedStrength's second writetext, _MoveBoulderText.
-		if pending_type == &"text" and _pending_tag() == &"strength_used":
-			var used_name: String = String(_pending.get("name", "#MON"))
-			_stage_internal_text("%s can\nmove boulders." % used_name, true)
-			return _waiting_result()
-		## A run of boxes with nothing between them, which is what `PokeSeer`'s
-		## own actions print and what `PhotoStudio` prints once the printer it
-		## cannot reach has answered.
-		if pending_type == &"text" and _pending.has("next_internal_texts"):
-			var chained: Array = (_pending["next_internal_texts"] as Array).duplicate()
-			_pending = {}
-			_finish_after_pending = false
-			if chained.is_empty():
-				return advance()
-			var head: String = String(chained.pop_front())
-			_stage_internal_text(head, false, {} if chained.is_empty() else {
-				"next_internal_texts": chained,
-			})
-			return _waiting_result()
-		if pending_type == &"menu" and _pending_tag() == &"buena_prize":
-			var prize_special: int = int(_pending.get("prize_special", 0))
-			if choice < 0:
-				## `Buena_PrizeMenu`'s `.cancel`: B leaves the counter, and both
-				## `CloseWindow`s are behind her own parting box.
-				_pending = {}
-				return _buena_prize_box(prize_special, "come_again", true)
-			var prize_row: int = clampi(choice, 0, BUENA_PRIZES.size() - 1)
-			_pending = {}
-			_set_text_buffer(
-				RomLayout.STRING_BUFFER_1,
-				data.item_name(int(BUENA_PRIZES[prize_row][0])) if data != null else "",
-				&"buena_prize", {"special": prize_special, "prize": prize_row}
-			)
-			var confirm_box: String = _special_box("buena_prize", "is_that_right")
-			if confirm_box.is_empty():
-				return _fail(&"missing_special_text", {"special": prize_special})
-			_pending = {
-				"type": &"choice",
-				"command": &"buena_prize_confirm",
-				"choices": [&"yes", &"no"],
-				"text": confirm_box,
-				"special": &"buena_prize_confirm",
-				"prize": prize_row,
-				"prize_special": prize_special,
-				"source": _request.duplicate(true),
-			}
-			return _waiting_result()
-		if pending_type == &"choice" and _pending_tag() == &"buena_prize_confirm":
-			var confirm_row: int = int(_pending.get("prize", 0))
-			var confirm_special: int = int(_pending.get("prize_special", 0))
-			_pending = {}
-			if choice != 0:
-				return _stage_buena_prize_menu(confirm_special)
-			return _buy_buena_prize(confirm_special, confirm_row)
-		if pending_type == &"menu" and _pending_tag() == &"bank_of_mom_menu":
-			_pending = {}
-			if choice < 0:
-				return _mom_result(_bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN))
-			return _mom_result(_bank_of_mom(
-				MOM_MENU_TARGETS[clampi(choice, 0, MOM_MENU_TARGETS.size() - 1)]
-			))
-		if pending_type == &"choice" and _pending_tag() == &"bank_of_mom_choice":
-			var mom_state: int = int(_pending.get("mom_state", MOM_EXIT))
-			var mom_yes: bool = choice == 0
-			_pending = {}
-			match mom_state:
-				MOM_INITIALIZE:
-					## `MomLeavingText3` is printed either way; YES adds the tier
-					## she keeps and NO leaves the account open and saving
-					## nothing.
-					_staged_mom_savings_flags = MOM_ACTIVE \
-						| (MOM_SAVING_SOME_MONEY if mom_yes else 0)
-					if not mom_yes:
-						return _mom_result(_mom_box("leaving_3", MOM_EXIT))
-					var second: String = _special_box("bank_of_mom", "leaving_2")
-					var third: String = _special_box("bank_of_mom", "leaving_3")
-					if second.is_empty() or third.is_empty():
-						return _fail(
-							&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM}
-						)
-					return _mom_result(_stage_internal_text(second, false, {
-						"special": SPECIAL_BANK_OF_MOM, "next_internal_texts": [third],
-					}))
-				MOM_IS_THIS_ABOUT_YOUR_MONEY:
-					return _mom_result(_bank_of_mom(
-						MOM_ACCESS_BANK if mom_yes else MOM_JUST_DO_WHAT_YOU_CAN
-					))
-				MOM_STOP_OR_START_SAVING:
-					_staged_mom_savings_flags = MOM_ACTIVE \
-						| (MOM_SAVING_SOME_MONEY if mom_yes else 0)
-					if not mom_yes:
-						return _mom_result(_bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN))
-					return _mom_result(_mom_box("start_saving_money", MOM_EXIT))
-			return _fail(&"invalid_bank_of_mom_state", {"state": mom_state})
-		## Her own boxes, each with the jumptable index that follows it.
-		if pending_type == &"text" and _pending.has("bank_of_mom_after_text"):
-			var mom_next: int = int(_pending["bank_of_mom_after_text"])
-			_pending = {}
-			_finish_after_pending = false
-			return _mom_result(_bank_of_mom(mom_next))
-		## `Mom_SetUpDepositMenu` stands behind the question rather than over it.
-		if pending_type == &"text" and _pending.has("bank_of_mom_dial"):
-			var mom_mode: StringName = StringName(_pending["bank_of_mom_dial"])
-			_pending = {}
-			_finish_after_pending = false
-			_stage_runtime_request(&"mom_bank_dial_requested", {
-				"special": SPECIAL_BANK_OF_MOM,
-				"mode": mom_mode,
-				"saved": _money_balance(ACCOUNT_MOMS_MONEY),
-				"held": _money_balance(ACCOUNT_YOUR_MONEY),
-			})
-			return _waiting_result()
-		## A box the prize counter printed, which goes back to her list rather
-		## than ending: `.print` falls into `.loop`.
-		if pending_type == &"text" and _pending.has("buena_prize_after_text"):
-			var after_special: int = int(_pending["buena_prize_after_text"])
-			_pending = {}
-			_finish_after_pending = false
-			return _stage_buena_prize_menu(after_special)
-		## `PokeSeer` prints its opening box, waits for a button and only then
-		## opens the list; the box is not the list's own backdrop.
-		if pending_type == &"text" and _pending.has("party_selection_after_text"):
-			var selection: Dictionary = _pending["party_selection_after_text"]
-			_pending = {}
-			_finish_after_pending = false
-			_stage_runtime_request(&"party_selection_requested", selection)
-			return _waiting_result()
-		## describedecoration is a local script in the cartridge. Its text must be
-		## acknowledged before the one decoration that needs a host, the town map,
-		## calls OverworldTownMap. Keeping this continuation on the text pause
-		## preserves the source's opentext/waitbutton/special/closetext/end order.
-		if pending_type == &"text" and _pending.has("special_after_text"):
-			var decoration_special: int = int(_pending.get("special_after_text", -1))
-			_pending = {}
-			_finish_after_pending = false
-			var special_result: Dictionary = _execute_special(decoration_special)
-			if not bool(special_result.get("ok", false)):
-				return _fail(
-					StringName(special_result.get("reason", &"special_failed")),
-					special_result
-				)
-			return _waiting_result() if _pending else advance()
-		## The five Ask*Scripts TryTileCollisionEvent reaches, all one shape:
-		## opentext, writetext, yesorno, iftrue <the move>, closetext, end.
-		if pending_type == &"text" and _pending_tag() == &"field_move_ask":
-			_pending = {
-				"type": &"choice",
-				"command": &"yesorno",
-				"choices": [&"yes", &"no"],
-				"text": _standing_text,
-				"special": &"field_move_ask",
-				"move": int(_pending.get("move", 0)),
-				"slot": int(_pending.get("slot", -1)),
-				"source": _request.duplicate(true),
-			}
-			return _waiting_result()
-		if pending_type == &"choice" and _pending_tag() == &"field_move_ask":
-			var asked_move: int = int(_pending.get("move", 0))
-			var asked_slot: int = int(_pending.get("slot", -1))
-			_pending = {}
-			_script_value = 1 if choice == 0 else 0
-			if choice == 0:
-				## `iftrue Script_Cut` and its four counterparts. The move
-				## itself belongs to the host, which owns the staged request
-				## and the commit the party submenu already reaches.
-				_emit_runtime_event(&"field_move_confirmed", {
-					"move": asked_move, "slot": asked_slot,
-				})
-			return _complete()
-		if pending_type == &"choice" and _pending_tag() == &"ask_remember_password":
-			_pending = {}
-			_script_value = 1 if choice == 0 else 0
-			_stage_frame_wait(ASK_REMEMBER_PASSWORD_CLOSE_FRAMES)
-			return _waiting_result()
-		## AskRockSmashScript, the same opentext/writetext/yesorno shape.
-		if pending_type == &"text" and _pending_tag() == &"rock_smash_ask":
-			_pending = {
-				"type": &"choice",
-				"command": &"yesorno",
-				"choices": [&"yes", &"no"],
-				"text": _standing_text,
-				"special": &"rock_smash_ask",
-				"slot": int(_pending.get("slot", -1)),
-				"source": _request.duplicate(true),
-			}
-			return _waiting_result()
-		if pending_type == &"choice" and _pending_tag() == &"rock_smash_ask":
-			var smash_slot: int = int(_pending.get("slot", -1))
-			_pending = {}
-			## `iftrue RockSmashScript`, and a no falls to closetext/end.
-			_script_value = 1 if choice == 0 else 0
-			if choice != 0:
-				return _complete()
-			_stage_rock_smash_used(smash_slot)
-			return _waiting_result()
-		## RockSmashScript's `closetext`, `special WaitSFX` and
-		## `playsound SFX_STRENGTH`. The rest of the script waits on the sound
-		## the way a trainer's approach waits on its encounter music.
-		if pending_type == &"text" and _pending_tag() == &"rock_smash_used":
-			_pending = {}
-			_rock_smash_after_sound = true
-			_stage_audio_request(&"sound", {"address": SFX_STRENGTH})
-			return _waiting_result()
-		if pending_type in [&"choice", &"menu"]:
-			if choice < 0:
-				return _waiting_result()
-			if pending_type == &"menu":
-				## Script_verticalmenu and Script__2dmenu store wMenuCursorY and
-				## wMenuCursorPosition, which count from one; cancel_input()
-				## already writes the zero their carry branch does. So a caller's
-				## zero-based option is the source's option minus one.
-				_script_value = choice + 1
-			elif pending_type == &"choice" \
-				and _pending.get("choices", []) == [&"yes", &"no"]:
-				_script_value = 1 if choice == 0 else 0
-			else:
-				_script_value = choice
-		if pending_type == &"choice" and _pending.has("contact"):
-			var contact: int = int(_pending.get("contact", -1))
-			if choice == 0:
-				var phone_result: Dictionary = _stage_phone_contact(contact)
-				if not bool(phone_result.get("ok", false)):
-					return _fail(
-						StringName(phone_result.get("reason", &"phone_contact_failed")),
-						phone_result
-					)
-			else:
-				_script_value = PHONE_CONTACT_REFUSED
-			_emit_runtime_event(&"phone_number_result", {
-				"contact": contact,
-				"accepted": choice == 0 and _script_value == PHONE_CONTACT_GOT,
-				"result": _script_value,
-			})
-		if pending_type == &"battle":
-			_stage_just_battled(true)
-		var finish_after_pending: bool = _finish_after_pending
-		_pending = {}
-		_finish_after_pending = false
-		if finish_after_pending:
-			return _complete()
-
+		var resumed: Dictionary = _resume_pending(acknowledge, choice)
+		if not resumed.is_empty():
+			return resumed
 	if not _active:
 		return _failure_result() if not _failure.is_empty() else _complete_result()
 
@@ -1161,6 +837,422 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 			return outcome if outcome.has("status") else _complete_result()
 
 	return _complete()
+
+
+## The open pause's own answer to [param acknowledge] and [param choice], or an
+## empty result when it is spent and the command loop takes over.
+func _resume_pending(acknowledge: bool, choice: int) -> Dictionary:
+	if _pending.has("text"):
+		_standing_text = String(_pending["text"])
+	var pending_type: StringName = StringName(_pending.get("type", &""))
+	var request: Dictionary = _pending.get("request", {})
+	if pending_type == &"runtime_request" \
+		and StringName(request.get("kind", &"")) == &"battle_requested":
+		return _waiting_result()
+	## Only frames end a wait, so a button press cannot: the source is inside
+	## WaitScriptMovement or a DelayFrames loop, which read no input at all.
+	if pending_type == &"wait" or not acknowledge:
+		return _waiting_result()
+
+	var resume: StringName = PENDING_RESUMES.get(
+		StringName("%s/%s" % [pending_type, _pending_tag()]), &""
+	)
+	if resume != &"":
+		return call(resume, choice) as Dictionary
+	for key: String in PENDING_CONTINUATIONS:
+		if pending_type == &"text" and _pending.has(key):
+			return call(PENDING_CONTINUATIONS[key], choice) as Dictionary
+
+	if pending_type in [&"choice", &"menu"]:
+		if choice < 0:
+			return _waiting_result()
+		_script_value = _answered_value(pending_type, choice)
+	if pending_type == &"choice" and _pending.has("contact"):
+		var refused: Dictionary = _resume_phone_contact(choice)
+		if not refused.is_empty():
+			return refused
+	if pending_type == &"battle":
+		_stage_just_battled(true)
+	var finish_after_pending: bool = _finish_after_pending
+	_pending = {}
+	_finish_after_pending = false
+	return _complete() if finish_after_pending else {}
+
+
+## What a row or a yes/no answers with. Script_verticalmenu and Script__2dmenu
+## store wMenuCursorY and wMenuCursorPosition, which count from one, and
+## cancel_input() already writes the zero their carry branch does.
+func _answered_value(pending_type: StringName, choice: int) -> int:
+	if pending_type == &"menu":
+		return choice + 1
+	if _pending.get("choices", []) == [&"yes", &"no"]:
+		return 1 if choice == 0 else 0
+	return choice
+
+
+## `AskNumber1M`'s yes: the number is taken or refused, and either way the caller
+## is told which. Answers empty unless the contact itself failed.
+func _resume_phone_contact(choice: int) -> Dictionary:
+	var contact: int = int(_pending.get("contact", -1))
+	if choice == 0:
+		var phone_result: Dictionary = _stage_phone_contact(contact)
+		if not bool(phone_result.get("ok", false)):
+			return _fail(
+				StringName(phone_result.get("reason", &"phone_contact_failed")),
+				phone_result
+			)
+	else:
+		_script_value = PHONE_CONTACT_REFUSED
+	_emit_runtime_event(&"phone_number_result", {
+		"contact": contact,
+		"accepted": choice == 0 and _script_value == PHONE_CONTACT_GOT,
+		"result": _script_value,
+	})
+	return {}
+
+
+func _resume_day_of_week_menu(choice: int) -> Dictionary:
+	if choice < 0:
+		return _waiting_result()
+	var selected_day: int = posmod(choice, WEEKDAY_NAMES.size())
+	_pending = {
+		"type": &"text",
+		## `.ConfirmWeekdayText` places the weekday at `hlcoord 1, 14` and
+		## `_OakTimeIsItText` carries on from where `PlaceString` left off, so the
+		## two are one line.
+		"text": "%s, is it?" % WEEKDAY_NAMES[selected_day],
+		"special": &"set_day_of_week_confirmation",
+		"day": selected_day,
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+## `Function17d246`: a row answers its own one-based number and B answers the
+## same 4 the routine writes before it opens the menu.
+func _resume_challenge_menu(choice: int) -> Dictionary:
+	_pending = {}
+	_script_value = CHALLENGE_MENU_CANCEL if choice < 0 else choice + 1
+	return advance()
+
+
+## The two refusals the room menu prints put its jumptable back at zero rather
+## than leaving the routine, so the menu opens again behind them.
+func _resume_room_refusal(_choice: int) -> Dictionary:
+	_pending = {}
+	return _stage_room_menu()
+
+
+## `STATICMENU_DISABLE_B`: B does not close the list, so the only way out is a
+## row. The answer is whether it is the row the byte's own low nibble names,
+## which `maskbits NUM_PASSWORDS_PER_CATEGORY` takes off it.
+func _resume_buenas_password(choice: int) -> Dictionary:
+	if choice < 0:
+		return _waiting_result()
+	var password: int = int(_pending.get("password", 0))
+	_pending = {}
+	_script_value = 1 if choice == (password & 0x3) else 0
+	return advance()
+
+
+func _resume_day_of_week_text(_choice: int) -> Dictionary:
+	_stage_day_of_week_confirmation(int(_pending.get("day", 0)))
+	return _waiting_result()
+
+
+func _resume_day_of_week_choice(choice: int) -> Dictionary:
+	var confirmed_day: int = int(_pending.get("day", 0))
+	_pending = {}
+	if choice != 0:
+		_stage_day_of_week_menu()
+		return _waiting_result()
+	_staged_day_of_week = confirmed_day
+	_script_value = 1
+	return advance()
+
+
+## AskStrengthScript's `.AskStrength`: opentext, writetext, yesorno. The text
+## pause is acknowledged first, then the choice is offered.
+func _resume_strength_ask_text(_choice: int) -> Dictionary:
+	return _stage_yes_or_no(&"strength_ask", {"slot": int(_pending.get("slot", -1))})
+
+
+func _resume_strength_ask_choice(choice: int) -> Dictionary:
+	var chosen_slot: int = int(_pending.get("slot", -1))
+	_pending = {}
+	## `iftrue Script_UsedStrength`, and a no falls to closetext/end.
+	_script_value = 1 if choice == 0 else 0
+	if choice != 0:
+		return _complete()
+	_stage_strength_used(chosen_slot)
+	return _waiting_result()
+
+
+## FruitTreeScript's promptbutton, behind which its two callasms sit.
+func _resume_fruit_tree(_choice: int) -> Dictionary:
+	var fruit_tree: int = int(_pending.get("tree_id", 0))
+	var fruit_item: int = int(_pending.get("item", 0))
+	_pending = {}
+	_finish_after_pending = false
+	var picked: Dictionary = _resolve_fruit_tree(fruit_tree, fruit_item)
+	if not bool(picked.get("ok", false)):
+		return _fail(StringName(picked.get("reason", &"fruit_tree_failed")), picked)
+	return _waiting_result()
+
+
+## The tail every item receipt shares behind its own line: the sound, and then
+## `itemnotify`'s box once the host has played it.
+func _resume_item_received(_choice: int) -> Dictionary:
+	var receipt_item: int = int(_pending.get("item", 0))
+	var receipt_sfx: int = int(_pending.get("sfx", 0))
+	var receipt_finish: bool = bool(_pending.get("finish", false))
+	_pending = {}
+	_finish_after_pending = false
+	_stage_receipt_tail(receipt_item, receipt_sfx, receipt_finish)
+	return _waiting_result()
+
+
+## `GiveItemScript.Full`, whose `promptbutton` is the acknowledge above.
+func _resume_pocket_is_full(_choice: int) -> Dictionary:
+	var full_item: int = int(_pending.get("item", 0))
+	var full_finish: bool = bool(_pending.get("finish", false))
+	_pending = {}
+	_finish_after_pending = false
+	_stage_pocket_is_full(full_item, full_finish)
+	return _waiting_result()
+
+
+## Script_UsedStrength's second writetext, _MoveBoulderText.
+func _resume_strength_used(_choice: int) -> Dictionary:
+	_stage_internal_text(
+		"%s can\nmove boulders." % String(_pending.get("name", "#MON")), true
+	)
+	return _waiting_result()
+
+
+## A run of boxes with nothing between them, which is what `PokeSeer`'s own
+## actions print and what `PhotoStudio` prints once the printer it cannot reach
+## has answered.
+func _resume_internal_texts(_choice: int) -> Dictionary:
+	var chained: Array = (_pending["next_internal_texts"] as Array).duplicate()
+	_pending = {}
+	_finish_after_pending = false
+	if chained.is_empty():
+		return advance()
+	var head: String = String(chained.pop_front())
+	_stage_internal_text(head, false, {} if chained.is_empty() else {
+		"next_internal_texts": chained,
+	})
+	return _waiting_result()
+
+
+func _resume_buena_prize_menu(choice: int) -> Dictionary:
+	var prize_special: int = int(_pending.get("prize_special", 0))
+	if choice < 0:
+		## `Buena_PrizeMenu`'s `.cancel`: B leaves the counter, and both
+		## `CloseWindow`s are behind her own parting box.
+		_pending = {}
+		return _buena_prize_box(prize_special, "come_again", true)
+	var prize_row: int = clampi(choice, 0, BUENA_PRIZES.size() - 1)
+	_pending = {}
+	_set_text_buffer(
+		RomLayout.STRING_BUFFER_1,
+		data.item_name(int(BUENA_PRIZES[prize_row][0])) if data != null else "",
+		&"buena_prize", {"special": prize_special, "prize": prize_row}
+	)
+	var confirm_box: String = _special_box("buena_prize", "is_that_right")
+	if confirm_box.is_empty():
+		return _fail(&"missing_special_text", {"special": prize_special})
+	_pending = {
+		"type": &"choice",
+		"command": &"buena_prize_confirm",
+		"choices": [&"yes", &"no"],
+		"text": confirm_box,
+		"special": &"buena_prize_confirm",
+		"prize": prize_row,
+		"prize_special": prize_special,
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+func _resume_buena_prize_confirm(choice: int) -> Dictionary:
+	var confirm_row: int = int(_pending.get("prize", 0))
+	var confirm_special: int = int(_pending.get("prize_special", 0))
+	_pending = {}
+	if choice != 0:
+		return _stage_buena_prize_menu(confirm_special)
+	return _buy_buena_prize(confirm_special, confirm_row)
+
+
+func _resume_mom_menu(choice: int) -> Dictionary:
+	_pending = {}
+	if choice < 0:
+		return _mom_result(_bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN))
+	return _mom_result(_bank_of_mom(
+		MOM_MENU_TARGETS[clampi(choice, 0, MOM_MENU_TARGETS.size() - 1)]
+	))
+
+
+func _resume_mom_choice(choice: int) -> Dictionary:
+	var mom_state: int = int(_pending.get("mom_state", MOM_EXIT))
+	var mom_yes: bool = choice == 0
+	_pending = {}
+	match mom_state:
+		MOM_INITIALIZE:
+			## `MomLeavingText3` is printed either way; YES adds the tier she
+			## keeps and NO leaves the account open and saving nothing.
+			_staged_mom_savings_flags = MOM_ACTIVE \
+				| (MOM_SAVING_SOME_MONEY if mom_yes else 0)
+			if not mom_yes:
+				return _mom_result(_mom_box("leaving_3", MOM_EXIT))
+			var second: String = _special_box("bank_of_mom", "leaving_2")
+			var third: String = _special_box("bank_of_mom", "leaving_3")
+			if second.is_empty() or third.is_empty():
+				return _fail(&"missing_special_text", {"special": SPECIAL_BANK_OF_MOM})
+			return _mom_result(_stage_internal_text(second, false, {
+				"special": SPECIAL_BANK_OF_MOM, "next_internal_texts": [third],
+			}))
+		MOM_IS_THIS_ABOUT_YOUR_MONEY:
+			return _mom_result(_bank_of_mom(
+				MOM_ACCESS_BANK if mom_yes else MOM_JUST_DO_WHAT_YOU_CAN
+			))
+		MOM_STOP_OR_START_SAVING:
+			_staged_mom_savings_flags = MOM_ACTIVE \
+				| (MOM_SAVING_SOME_MONEY if mom_yes else 0)
+			if not mom_yes:
+				return _mom_result(_bank_of_mom(MOM_JUST_DO_WHAT_YOU_CAN))
+			return _mom_result(_mom_box("start_saving_money", MOM_EXIT))
+	return _fail(&"invalid_bank_of_mom_state", {"state": mom_state})
+
+
+## Her own boxes, each with the jumptable index that follows it.
+func _resume_mom_after_text(_choice: int) -> Dictionary:
+	var mom_next: int = int(_pending["bank_of_mom_after_text"])
+	_pending = {}
+	_finish_after_pending = false
+	return _mom_result(_bank_of_mom(mom_next))
+
+
+## `Mom_SetUpDepositMenu` stands behind the question rather than over it.
+func _resume_mom_dial(_choice: int) -> Dictionary:
+	var mom_mode: StringName = StringName(_pending["bank_of_mom_dial"])
+	_pending = {}
+	_finish_after_pending = false
+	_stage_runtime_request(&"mom_bank_dial_requested", {
+		"special": SPECIAL_BANK_OF_MOM,
+		"mode": mom_mode,
+		"saved": _money_balance(ACCOUNT_MOMS_MONEY),
+		"held": _money_balance(ACCOUNT_YOUR_MONEY),
+	})
+	return _waiting_result()
+
+
+## A box the prize counter printed, which goes back to her list rather than
+## ending: `.print` falls into `.loop`.
+func _resume_buena_after_text(_choice: int) -> Dictionary:
+	var after_special: int = int(_pending["buena_prize_after_text"])
+	_pending = {}
+	_finish_after_pending = false
+	return _stage_buena_prize_menu(after_special)
+
+
+## `PokeSeer` prints its opening box, waits for a button and only then opens the
+## list; the box is not the list's own backdrop.
+func _resume_party_selection(_choice: int) -> Dictionary:
+	var selection: Dictionary = _pending["party_selection_after_text"]
+	_pending = {}
+	_finish_after_pending = false
+	_stage_runtime_request(&"party_selection_requested", selection)
+	return _waiting_result()
+
+
+## describedecoration is a local script in the cartridge. Its text must be
+## acknowledged before the one decoration that needs a host, the town map, calls
+## OverworldTownMap, which preserves the source's
+## opentext/waitbutton/special/closetext/end order.
+func _resume_special_after_text(_choice: int) -> Dictionary:
+	var decoration_special: int = int(_pending.get("special_after_text", -1))
+	_pending = {}
+	_finish_after_pending = false
+	var special_result: Dictionary = _execute_special(decoration_special)
+	if not bool(special_result.get("ok", false)):
+		return _fail(
+			StringName(special_result.get("reason", &"special_failed")), special_result
+		)
+	return _waiting_result() if _pending else advance()
+
+
+## The five Ask*Scripts TryTileCollisionEvent reaches, all one shape: opentext,
+## writetext, yesorno, iftrue <the move>, closetext, end.
+func _resume_field_move_text(_choice: int) -> Dictionary:
+	return _stage_yes_or_no(&"field_move_ask", {
+		"move": int(_pending.get("move", 0)), "slot": int(_pending.get("slot", -1)),
+	})
+
+
+func _resume_field_move_choice(choice: int) -> Dictionary:
+	var asked_move: int = int(_pending.get("move", 0))
+	var asked_slot: int = int(_pending.get("slot", -1))
+	_pending = {}
+	_script_value = 1 if choice == 0 else 0
+	if choice == 0:
+		## `iftrue Script_Cut` and its four counterparts. The move itself belongs
+		## to the host, which owns the staged request and the commit the party
+		## submenu already reaches.
+		_emit_runtime_event(&"field_move_confirmed", {
+			"move": asked_move, "slot": asked_slot,
+		})
+	return _complete()
+
+
+func _resume_remember_password(choice: int) -> Dictionary:
+	_pending = {}
+	_script_value = 1 if choice == 0 else 0
+	_stage_frame_wait(ASK_REMEMBER_PASSWORD_CLOSE_FRAMES)
+	return _waiting_result()
+
+
+## AskRockSmashScript, the same opentext/writetext/yesorno shape.
+func _resume_rock_smash_text(_choice: int) -> Dictionary:
+	return _stage_yes_or_no(&"rock_smash_ask", {"slot": int(_pending.get("slot", -1))})
+
+
+func _resume_rock_smash_choice(choice: int) -> Dictionary:
+	var smash_slot: int = int(_pending.get("slot", -1))
+	_pending = {}
+	## `iftrue RockSmashScript`, and a no falls to closetext/end.
+	_script_value = 1 if choice == 0 else 0
+	if choice != 0:
+		return _complete()
+	_stage_rock_smash_used(smash_slot)
+	return _waiting_result()
+
+
+## RockSmashScript's `closetext`, `special WaitSFX` and `playsound SFX_STRENGTH`.
+## The rest of the script waits on the sound the way a trainer's approach waits
+## on its encounter music.
+func _resume_rock_smash_used(_choice: int) -> Dictionary:
+	_pending = {}
+	_rock_smash_after_sound = true
+	_stage_audio_request(&"sound", {"address": SFX_STRENGTH})
+	return _waiting_result()
+
+
+## The yesorno an Ask*Script offers behind the box it has just printed, carrying
+## [param values] through to the answer.
+func _stage_yes_or_no(tag: StringName, values: Dictionary) -> Dictionary:
+	_pending = {
+		"type": &"choice",
+		"command": &"yesorno",
+		"choices": [&"yes", &"no"],
+		"text": _standing_text,
+		"special": tag,
+		"source": _request.duplicate(true),
+	}
+	for key: Variant in values:
+		_pending[key] = values[key]
+	return _waiting_result()
 
 
 ## Completes a host-owned runtime request without treating a button press as its
@@ -3462,16 +3554,12 @@ func _execute_special(special: int) -> Dictionary:
 		SPECIAL_FADE_OUT_TO_WHITE, SPECIAL_BATTLE_TOWER_FADE, SPECIAL_FADE_OUT_TO_BLACK, \
 		SPECIAL_FADE_IN_FROM_WHITE, SPECIAL_FADE_IN_FROM_BLACK:
 			## `FadeOutToWhite` is 46 in both pins, since Crystal's inserted
-			## `BattleTowerFade` sits at 47, so it needs no profile split;
-			## `FadeInFromWhite` is 49 here and 48 in Gold/Silver, which
-			## special_index() already normalizes (maps/OlivineLighthouse6F.asm's
-			## Amphy cure runs 46 then 49).
-			##
-			## Each of the five is `GetTimePalFade` and then four rows of the
-			## fade table, and none of them is free: `ConvertTimePals*HL` spends
-			## `ld c, 2` on every row and `BattleTowerFade`'s own loop `ld c, 7`,
-			## so the script holds for the whole walk the way it does on the
-			## cartridge. `FillWhiteBGColor` is the two white fades' alone.
+			## `BattleTowerFade` sits at 47; `FadeInFromWhite` is 49 here and 48 in
+			## Gold/Silver, which `special_index()` already normalizes. Each of the
+			## five is `GetTimePalFade` and then four rows of the fade table, and
+			## none is free: `ConvertTimePals*HL` spends `ld c, 2` on every row, so
+			## the script holds for the whole walk the way it does on the cartridge.
+			## `FillWhiteBGColor` is the two white fades' alone.
 			var orders: Array[int] = FADE_ORDERS_OF[special]
 			var step_frames: int = Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES \
 				if special == SPECIAL_BATTLE_TOWER_FADE \
@@ -3487,28 +3575,22 @@ func _execute_special(special: int) -> Dictionary:
 			})
 		51, 52, 53, 55, 56, 94, 152, 157, 158, 164:
 			## Sprite reload, palette reload and the dummied trainer-ranking
-			## bookkeeping affect presentation or source-only counters, not
-			## scene-free state. `LoadUsedSpritesGFX` (94), `UpdateSprites` (55),
-			## `UpdatePlayerSprite` (56), `ReloadSpritesNoPalettes` (51) and
-			## `RefreshSprites` (158) reload the sprite set a `variablesprite`
-			## just changed. `ClearBGPalettes` (52), `UpdateTimePals` (53),
-			## `SetPlayerPalette` (152) and `LoadMapPalettes` (164) are the
-			## palette pair `BugContestResultsWarpScript` and the day/night
-			## scripts open with; the renderer takes its palettes from the map
-			## and the clock, so all four are presentation here too.
+			## bookkeeping affect presentation or source-only counters rather than
+			## scene-free state. `LoadUsedSpritesGFX`, `UpdateSprites`,
+			## `UpdatePlayerSprite`, `ReloadSpritesNoPalettes` and `RefreshSprites`
+			## reload the sprite set a `variablesprite` just changed;
+			## `ClearBGPalettes`, `UpdateTimePals`, `SetPlayerPalette` and
+			## `LoadMapPalettes` are the palette pair the day/night scripts open
+			## with, and the renderer takes its palettes from the map and the clock.
 			_emit_runtime_event(&"presentation_special_applied", {"special": special})
 		95, 100:
-			## `PlaySlowCry` (95) is `LoadCry` with the record's own pitch
-			## lowered by `$140` and its length raised by `$60`, and
-			## `PlayCurMonCry` (100) is `PlayMonCry` straight. Neither writes
-			## anything back, so what they owe is the sound and the `WaitSFX`
-			## each ends on, which is `Script_cry`'s own request.
-			##
-			## They do not read the same byte. 95 is `ld a, [wScriptVar]`, which
-			## the `setval` in front of it has just set; 100 is
-			## `ld a, [wCurPartySpecies]`, and all four of its scripts are a
-			## grooming routine's, which leaves a `HappinessData_*` row rather
-			## than a species in wScriptVar.
+			## `PlaySlowCry` (95) is `LoadCry` with the record's own pitch lowered
+			## by `$140` and its length raised by `$60`, and `PlayCurMonCry` (100) is
+			## `PlayMonCry` straight. Neither writes anything back, so what they owe
+			## is the sound and the `WaitSFX` each ends on. They do not read the same
+			## byte: 95 is `ld a, [wScriptVar]`, which the `setval` in front of it
+			## has just set, and 100 is `ld a, [wCurPartySpecies]`, all four of whose
+			## scripts are a grooming routine's.
 			return _stage_audio_request(&"cry", {
 				"special": special,
 				"species": _script_value if special == 95 else _cur_party_species,
@@ -4219,13 +4301,11 @@ func _buena_prize_box(special: int, name: String, closing: bool) -> Dictionary:
 
 ## `BankOfMom`'s jumptable, one index at a time (`engine/events/mom.asm`). Every
 ## state either prints a box, opens her menu or opens the dial, so the source's
-## `.loop` is the chain of pendings each of them leaves behind.
-##
-## `DSTChecks` is the one branch not built, and it is a save-format bump: `.nope`
-## asks whether to move the clock an hour, which needs a saved `wDST` bit and the
-## `wStartHour`/`wStartDay` shift behind it, and nothing here carries either. The
-## branch taken instead is `.JustDoWhatYouCan`, which is what a clock nowhere
-## near a boundary reaches.
+## `.loop` is the chain of pendings each of them leaves behind. `DSTChecks` is the
+## one branch not built, and it is a save-format bump: `.nope` asks whether to move
+## the clock an hour, which needs a saved `wDST` bit and the `wStartHour` shift
+## behind it. The branch taken instead is `.JustDoWhatYouCan`, which is what a
+## clock nowhere near a boundary reaches.
 func _bank_of_mom(index: int) -> Dictionary:
 	match index:
 		MOM_CHECK_INITIALIZED:
@@ -4310,14 +4390,12 @@ func _mom_yes_no(name: String, state_index: int) -> Dictionary:
 
 
 ## `.StoreMoney`'s tail and `.TakeMoney`'s, which differ only in which account is
-## which. Three things the source does that a rewrite loses:
-##
-## - `GiveMoney` here adds into `wStringBuffer2` rather than into an account, so
-##   the ceiling is tested against the balance the transaction would leave and
-##   nothing is written when it fails.
-## - Both refusals `ret` with `wJumptableIndex` unchanged, so her question is
-##   asked again and the dial reopens rather than the routine ending.
-## - A dial left at zero is `.CancelDeposit`, the same branch B takes.
+## which. Three things the source does that a rewrite loses: `GiveMoney` adds into
+## `wStringBuffer2` rather than into an account, so the ceiling is tested against
+## the balance the transaction would leave and nothing is written when it fails;
+## both refusals `ret` with `wJumptableIndex` unchanged, so her question is asked
+## again and the dial reopens; and a dial left at zero is `.CancelDeposit`, the
+## same branch B takes.
 func _finish_mom_bank_dial(mode: StringName, amount: int) -> Dictionary:
 	var deposit: bool = mode == MOM_DIAL_DEPOSIT
 	var state_index: int = MOM_STORE_MONEY if deposit else MOM_TAKE_MONEY
@@ -5130,14 +5208,11 @@ func _finish_deferred_party_selection(
 
 ## `Script_givepokemail`, which copies the pointer's `db item` and the
 ## `MAIL_MSG_LENGTH` bytes behind it into `wMonMailMessageBuffer`, and
-## `GivePokeMail`, which hangs both on the last party member. Nothing is asked
-## and nothing is answered: the routine writes no wScriptVar and cannot fail, so
-## the write is an event the way a happiness change is.
-##
-## The mail's author, ID and species are the member's own `wPartyMonOTs`,
-## `wPartyMon1ID` and `wCurPartySpecies`, so the screen reads the first two off
-## the row it is writing and the runner carries the third, which the `givepoke`
-## in front of this one left standing.
+## `GivePokeMail`, which hangs both on the last party member. Nothing is asked and
+## nothing is answered: the routine writes no wScriptVar and cannot fail, so the
+## write is an event the way a happiness change is. The mail's author, ID and
+## species are the member's own, so the screen reads the first two off the row it
+## is writing and the runner carries the third.
 func _give_poke_mail(command: Dictionary) -> Dictionary:
 	var bytes: PackedByteArray = _mail_bytes(int(command.get("address", 0)))
 	if bytes.size() < Gen2SaveMail.MESSAGE_LENGTH + 1:
@@ -5359,17 +5434,13 @@ func _emit_object_event(event_type: StringName, values: Dictionary) -> void:
 	_events.append(event)
 
 
-## engine/events/overworld.asm's AskStrengthScript, synthesized.
-##
-## StrengthBoulderScript is `farsjump AskStrengthScript`, whose first command is
-## `callasm TryStrengthOW`. `callasm` has no runner here and its operand is a
-## link-time address absent from the pinned disassemblies, so the seam sits on
-## the standard-script index instead, which is 14 in both pins and verified by
-## the imported table. The synthesized body is the same shape trainer object
-## dispatch takes: source sequence, project metadata.
-##
-## Every branch of AskStrengthScript terminates, so this never returns to a
-## caller and jumpstd and callstd resolve alike.
+## engine/events/overworld.asm's AskStrengthScript, synthesized. StrengthBoulderScript
+## is `farsjump AskStrengthScript`, whose first command is `callasm TryStrengthOW`;
+## `callasm` has no runner here and its operand is a link-time address absent from
+## the pinned disassemblies, so the seam sits on the standard-script index instead,
+## which is 14 in both pins and verified by the imported table. The synthesized
+## body is the same shape trainer object dispatch takes. Every branch of
+## AskStrengthScript terminates, so this never returns to a caller.
 func _stage_strength_boulder() -> Dictionary:
 	var party: Dictionary = _request.get("party", {})
 	if party.is_empty():
@@ -5398,24 +5469,14 @@ func _stage_strength_boulder() -> Dictionary:
 	return {"ok": true}
 
 
-## engine/events/misc_scripts.asm's FindItemInBallScript, synthesized.
-##
-## An item ball's script pointer is not code: it is the `itemball` macro's
-## `db item, quantity`, which `ObjectEventTypeArray.itemball` copies into
-## wItemBallData before raising PLAYEREVENT_ITEMBALL. So the seam is the object
-## type, not a script address, and Gen2WorldAPI hands the two decoded bytes over
-## as an item_ball request. The script's own first command is `callasm
-## .TryReceiveItem` and both its texts are engine text rather than map text, so
-## the body is replayed here the way AskStrengthScript's is.
-##
-## Source order is receive, `disappear LAST_TALKED`, then the text, so the ball
-## is already gone when the box is drawn. Behind that text the script plays
-## SFX_ITEM by name rather than through `specialsound` and then runs
-## `itemnotify`; its own `pause 60` is the acknowledge here, since nothing draws
-## a text box that closes itself.
-##
-## The receive seam preserves the source's no-room branch without committing
-## the item, hiding the ball, or setting its event flag.
+## engine/events/misc_scripts.asm's FindItemInBallScript, synthesized. An item
+## ball's script pointer is not code: it is the `itemball` macro's
+## `db item, quantity`, which is copied into wItemBallData before
+## PLAYEREVENT_ITEMBALL is raised, so the seam is the object type rather than a
+## script address. Source order is receive, `disappear LAST_TALKED`, then the
+## text, so the ball is already gone when the box is drawn; its own `pause 60` is
+## the acknowledge here, since nothing draws a text box that closes itself. The
+## receive seam preserves the no-room branch without committing anything.
 func _stage_item_ball() -> Dictionary:
 	var item: int = int(_request.get("item", 0))
 	var quantity: int = maxi(1, int(_request.get("quantity", 1)))
@@ -5505,20 +5566,14 @@ func _fruit_tree_picked(tree_id: int) -> bool:
 	return state.fruit_tree_picked(tree_id)
 
 
-## HiddenItemScript, the BGEVENT_ITEM half of the same source area. The pointer
-## is the `hiddenitem` macro's `dwb event, item`, which `.itemifset` copies into
-## wHiddenItemData, so Gen2WorldAPI hands the decoded flag and item over the way
-## it hands over an item ball's two bytes.
-##
-## The differences from _stage_item_ball() are the flag and the object. There is
-## no object to hide, since the item is a background event rather than a ball,
-## and the flag `callasm SetMemEvent` writes is the record's own rather than the
-## object's. `_PlayerFoundItemText` is `_FoundItemText`'s wording, so the two
-## share FOUND_ITEM_TEXT and its <PLAYER> boundary.
-##
-## The source writes the text before `giveitem` and sets the flag after it. A
-## full pocket leaves both the item and the event flag untouched, then shows the
-## source's no-space branch in one scene-free text pause.
+## HiddenItemScript, the BGEVENT_ITEM half of the same source area. The pointer is
+## the `hiddenitem` macro's `dwb event, item`, handed over the way an item ball's
+## two bytes are. The differences from [method _stage_item_ball] are the flag and
+## the object: there is no object to hide, and the flag `callasm SetMemEvent`
+## writes is the record's own rather than the object's. `_PlayerFoundItemText` is
+## `_FoundItemText`'s wording, so the two share one constant. The source writes the
+## text before `giveitem` and sets the flag after it, so a full pocket leaves both
+## the item and the flag untouched.
 func _stage_hidden_item() -> Dictionary:
 	var item: int = int(_request.get("item", 0))
 	var flag: int = int(_request.get("flag", -1))
@@ -5593,16 +5648,11 @@ func _stage_strength_used(slot: int) -> Dictionary:
 
 
 ## engine/overworld/events.asm's TryTileCollisionEvent, from `.cut` on: the five
-## field-move branches a faced tile can reach, each of which is a `Try*OW` gate
-## and then an `Ask*Script`. Synthesized for the reason AskStrengthScript is,
-## and dispatched on the request kind rather than a standard-script index
-## because these are reached through `CallScript` rather than `jumpstd`.
-##
-## Which move the tile offers is [Gen2WorldAPI]'s answer, since only it can read
-## the map; so is `tile_ok`, the tile-shaped half of the gate that
-## TryWhirlpoolMenu and CheckMapCanWaterfall own. What is left here is the party
-## and the badge, which is what this runner already reads for the boulder.
-##
+## field-move branches a faced tile can reach, each a `Try*OW` gate and then an
+## `Ask*Script`. Synthesized for the reason AskStrengthScript is, and dispatched on
+## the request kind rather than a standard-script index because these are reached
+## through `CallScript`. Which move the tile offers is [Gen2WorldAPI]'s answer,
+## since only it can read the map; what is left here is the party and the badge.
 ## Three of the five have a refusal text and two do not: TryHeadbuttOW and
 ## TrySurfOW return no carry and the player event ends with nothing shown.
 func _stage_field_move_prompt() -> Dictionary:
@@ -5685,12 +5735,10 @@ func _field_move_prompt_refusal(move: int) -> String:
 ## engine/events/overworld.asm's AskRockSmashScript, synthesized for the same
 ## reason AskStrengthScript is: SmashRockScript is `farsjump AskRockSmashScript`
 ## and its first command is `callasm HasRockSmash`, whose operand is a link-time
-## address absent from the pins. The seam is the standard-script index, 15 in
-## both.
-##
-## `HasRockSmash` is CheckPartyMove and nothing else, so unlike the boulder
-## there is no badge and no already-active flag to check: the whole gate is
-## whether a party member knows ROCK SMASH.
+## address absent from the pins, so the seam is the standard-script index, 15 in
+## both. `HasRockSmash` is CheckPartyMove and nothing else, so unlike the boulder
+## there is no badge and no already-active flag to check: the whole gate is whether
+## a party member knows ROCK SMASH.
 func _stage_smash_rock() -> Dictionary:
 	var party: Dictionary = _request.get("party", {})
 	if party.is_empty():

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -6,18 +6,14 @@ extends Control
 ## hosts and API.
 
 signal completed(results: Array)
-## The sound this screen asks for, played by whoever owns the driver.
-##
-## Nothing here reaches [Gen2AudioPlayer]: the world screen owns the one player
-## a map's music and its effects share, so a second surface asking for a sound
-## goes through it the way the start menu, the party screen and the move screen
-## already do. [Gen2WorldAudioHost] is an inspection probe that renders no
-## samples and must never stand in for it.
-##
-## [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent in front of the sound
-## by hand: the cartridge holds there until the four effect channels are free,
-## so the request can never be the one `PlaySFX`'s own priority gate refuses.
-## The wait itself is not spent; what it carries is that the sound is heard.
+## The sound this screen asks for, played by whoever owns the driver. Nothing here
+## reaches [Gen2AudioPlayer]: the world screen owns the one player a map's music
+## and its effects share, so a second surface asking for a sound goes through it.
+## [Gen2WorldAudioHost] is an inspection probe that renders no samples and must
+## never stand in for it. [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent in
+## front of the sound by hand: the cartridge holds there until the four effect
+## channels are free, so the request can never be the one `PlaySFX`'s priority gate
+## refuses. The wait itself is not spent.
 signal sfx_requested(index: int, waited: bool)
 ## `PlayMonCry2` from a screen this one opens, the box screen's stats page today.
 ## Passed on for the same reason [signal sfx_requested] is: the world screen owns

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -127,18 +127,13 @@ func is_walking() -> bool:
 	return sprite_type == TYPE_WALKING
 
 
-## Returns the first tile of a 4-tile frame in the source strip.
-##
-## A walking sprite's strip is two halves of twelve tiles: down, up and left
-## standing, then the same three walking. `GetUsedSprite`
-## (engine/overworld/overworld.asm) copies the first half to `vTiles0` and the
-## second to `vTiles1`, which is the `$80` the walking rows of `Facings`
-## (data/sprites/facings.asm) add to the object's own base tile.
-##
-## `Facings` gives each direction four frames: 0 and 2 are the standing drawing,
-## 1 and 3 the walking one. Right reuses left, flipped by the renderer, and so
-## does frame 3 of down and up: `FacingStepDown3` is `FacingStepDown1` with
-## `OAM_XFLIP` on every tile and its two columns swapped.
+## Returns the first tile of a 4-tile frame in the source strip. A walking
+## sprite's strip is two halves of twelve tiles: down, up and left standing, then
+## the same three walking. `GetUsedSprite` copies the first half to `vTiles0` and
+## the second to `vTiles1`, which is the `$80` the walking rows of `Facings` add to
+## the object's own base tile. `Facings` gives each direction four frames: 0 and 2
+## are the standing drawing, 1 and 3 the walking one. Right reuses left, flipped by
+## the renderer, and so does frame 3 of down and up.
 func frame_tile_offset(facing: int, frame: int) -> int:
 	if sprite_type == TYPE_MON_ICON:
 		return MON_ICON_FRAME_TILES if animate_icon_frames and is_walking_frame(frame) \

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -2,22 +2,13 @@ class_name Gen2WorldStartMenu
 extends RefCounted
 
 ## Scene-free model of the cartridge start menu (engine/menus/start_menu.asm).
-##
 ## `StartMenu.SetUpMenuItems` appends items in a fixed source order, skipping only
-## what its own gate refuses: Pokedex behind wStatusFlags/STATUSFLAGS_POKEDEX_F,
-## Pokemon behind a non-zero wPartyCount, Pokegear behind
-## wPokegearFlags/POKEGEAR_OBTAINED_F.
-##
-## QUIT stands where SAVE does while the Bug Catching Contest runs, and PACK
-## leaves the list with it: `SetUpMenuItems` reads
-## `STATUSFLAGS2_BUG_CONTEST_TIMER_F` twice, once for each. Link mode is the
-## other half of both gates and has no menu here.
-##
-## Entries registered on `Gen2ModHost` are spliced in ahead of EXIT, so a mod can
-## add a screen without reordering or removing anything the cartridge shipped.
-##
-## `STATICMENU_WRAP` is source flag data on `.MenuData`, so the cursor wraps at
-## both ends like a cached cartridge menu.
+## what its own gate refuses: Pokedex behind STATUSFLAGS_POKEDEX_F, Pokemon behind
+## a non-zero wPartyCount, Pokegear behind POKEGEAR_OBTAINED_F. QUIT stands where
+## SAVE does while the Bug Catching Contest runs and PACK leaves the list with it.
+## Entries registered on [Gen2ModHost] are spliced in ahead of EXIT, so a mod can
+## add a screen without reordering anything the cartridge shipped.
+## `STATICMENU_WRAP` is source flag data, so the cursor wraps at both ends.
 
 ## constants/engine_flags.asm: ENGINE_POKEGEAR = 4, ENGINE_POKEDEX = 11. Both
 ## indices are identical in pokecrystal and pokegold (unlike the badge and
@@ -68,11 +59,10 @@ const GATE_NO_CONTEST: StringName = &"no_contest"
 ## host's registered entries can be spliced in without the order becoming a
 ## question. EXIT stays last of the source's own: it is what closes the menu, and
 ## the source never puts anything after it. Only [constant ITEM_LAUNCHER], which
-## the source has no row for at all, is below it.
-## The labels are `.PokedexString` and its siblings verbatim, which is what the
-## box over the map prints. `#` is the charmap's own $54 and expands to "POKe";
-## `<PLAYER>`, which the source's own `.StatusString` is, is filled in by
-## [method build] because `PlaceString` reads `wPlayerName` for it.
+## the source has no row for at all, is below it. The labels are `.PokedexString`
+## and its siblings verbatim; `#` is the charmap's own $54 and expands to "POKe",
+## and `<PLAYER>` is filled in by [method build] because `PlaceString` reads
+## `wPlayerName` for it.
 const SOURCE_ENTRIES: Array[Dictionary] = [
 	{"kind": ITEM_POKEDEX, "label": "#DEX", "available": true, "gate": GATE_POKEDEX},
 	{"kind": ITEM_POKEMON, "label": "#MON", "available": true, "gate": GATE_PARTY},

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -252,14 +252,12 @@ var _phone_receive_minutes: int = PHONE_RECEIVE_DELAYS[0]
 var _pending_special_phone_call: int = 0
 var _script_memory: Dictionary = {}
 ## `wMapMusic`, `wRadioTuningKnob` and `wCurRadioLine`. The music is state rather
-## than something derived from the current map because `PlayMapMusic` writes it
-## and compares against it, and because a tuned radio station overwrites it and
-## survives the Pokegear closing. `SnorlaxAwake` reads exactly that byte.
-## `wStatusFlags`' `STATUSFLAGS_FLASH_F`. Its own byte on the cartridge rather
-## than an engine flag, saved with the rest of `wPlayerData` the way its
-## byte-neighbours here are, and it does not survive walking out into the open:
-## `ResetFlashIfOutOfCave` clears it on entering a ROUTE or a TOWN, so a lit cave
-## goes dark again the moment the player leaves and comes back.
+## than something derived from the current map because `PlayMapMusic` writes it and
+## compares against it, and because a tuned radio station overwrites it and survives
+## the Pokegear closing; `SnorlaxAwake` reads exactly that byte. Below,
+## `wStatusFlags`' `STATUSFLAGS_FLASH_F`, its own byte on the cartridge rather than
+## an engine flag: `ResetFlashIfOutOfCave` clears it on entering a ROUTE or a TOWN,
+## so a lit cave goes dark again the moment the player leaves and comes back.
 var _used_flash: bool = false
 
 ## `wBikeStep`, the two bytes `DoBikeStep` counts a bike ride in. Saved player
@@ -350,16 +348,13 @@ var _mom_item_trigger_balance: int = RomLayout.MOM_MONEY
 ## INITIAL_VARIABLE_SPRITES]).
 var _variable_sprites: Dictionary = {}
 
-## `InitializeEventsScript` (engine/events/std_scripts.asm), which the player's
-## bedroom runs once at new game behind `EVENT_INITIALIZED_EVENTS`. A fresh state
-## starts with these for the same reason [method Gen2WorldSpawn.apply_initial_decorations]
-## exists: every state the game can be in has run it, and a slot with no row is
-## `.NoBreedmon`'s `WALKING_SPRITE`, which is the player.
-##
-## The four `SPRITE_CONSOLE`..`SPRITE_BIG_DOLL` slots are deliberately absent:
-## `ToggleDecorationsVisibility` fills those on every entry to the bedroom, so
-## they are the one group that needs no default. The numbers are the same on all
-## three cartridges (constants/sprite_constants.asm).
+## `InitializeEventsScript`, which the player's bedroom runs once at new game
+## behind `EVENT_INITIALIZED_EVENTS`. A fresh state starts with these for the same
+## reason [method Gen2WorldSpawn.apply_initial_decorations] exists: every state the
+## game can be in has run it, and a slot with no row is `.NoBreedmon`'s
+## `WALKING_SPRITE`, which is the player. The four `SPRITE_CONSOLE`..`SPRITE_BIG_DOLL`
+## slots are deliberately absent, `ToggleDecorationsVisibility` filling those on
+## every entry to the bedroom. The numbers are the same on all three cartridges.
 const INITIAL_VARIABLE_SPRITES: Dictionary = {
 	0xF4: 0x52,  # SPRITE_WEIRD_TREE      -> SPRITE_SUDOWOODO
 	0xF5: 0x04,  # SPRITE_OLIVINE_RIVAL   -> SPRITE_RIVAL
@@ -410,57 +405,63 @@ func _init(
 	initial_caught_species: Dictionary = {},
 	initial_maptile_decorations: Dictionary = {},
 ) -> void:
-	for flag: Variant in initial_event_flags:
-		if int(flag) >= 0 and bool(initial_event_flags[flag]):
-			_event_flags[int(flag)] = true
-	for flag: Variant in initial_engine_flags:
-		if int(flag) >= 0 and bool(initial_engine_flags[flag]):
-			_engine_flags[int(flag)] = true
+	_seed_flags(_event_flags, initial_event_flags, 0)
+	_seed_flags(_engine_flags, initial_engine_flags, 0)
+	_seed_flags(_seen_species, initial_seen_species, 1)
+	## Caught implies seen, the way `SetSeenAndCaughtMon` falls through, so a
+	## restored state cannot hold a caught species it has not seen.
+	_seed_flags(_caught_species, initial_caught_species, 1)
+	for species: int in _caught_species:
+		_seen_species[species] = true
+	_seed_flags(_phone_contacts, initial_phone_contacts, 0, PHONE_CONTACT_CAPACITY)
 	for map_key: Variant in initial_map_scenes:
 		var scene: int = int(initial_map_scenes[map_key])
 		if scene >= 0:
 			_map_scenes[String(map_key)] = scene
-	for raw_item: Variant in initial_items:
-		var item: int = int(raw_item)
-		var quantity: int = int(initial_items[raw_item])
-		if item > 0 and quantity > 0:
-			_items[item] = quantity
-	for raw_account: Variant in initial_money:
-		var account: int = int(raw_account)
-		var balance: int = int(initial_money[raw_account])
-		if account >= 0 and balance > 0:
-			_money[account] = balance
+	_seed_counts(_items, initial_items, 1)
+	_seed_counts(_money, initial_money, 0)
+	_seed_counts(_script_memory, initial_script_memory, 1, 0xFF, SCRIPT_MEMORY_CAPACITY)
+	for category: StringName in MAPTILE_DECORATION_SLOTS:
+		var decoration: int = int(initial_maptile_decorations.get(category, 0)) & 0xFF
+		if decoration > 0:
+			_maptile_decorations[category] = decoration
 	_coins = maxi(0, initial_coins)
-	for raw_contact: Variant in initial_phone_contacts:
-		if bool(initial_phone_contacts[raw_contact]) and _phone_contacts.size() < PHONE_CONTACT_CAPACITY:
-			_phone_contacts[int(raw_contact)] = true
 	_repel_steps = maxi(0, initial_repel_steps)
 	_swarm_maps[SWARM_DUNSPARCE] = initial_swarm_map
-	_fishing_swarm_species = initial_fishing_swarm_species if initial_fishing_swarm_species in [0, 0xD3, 0xDF] else 0
+	_fishing_swarm_species = initial_fishing_swarm_species \
+		if initial_fishing_swarm_species in [0, 0xD3, 0xDF] else 0
 	_roaming_mons = _copy_roaming_mons(initial_roaming_mons)
-	for raw_species: Variant in initial_seen_species:
-		if int(raw_species) > 0 and bool(initial_seen_species[raw_species]):
-			_seen_species[int(raw_species)] = true
-	## Caught implies seen, the way `SetSeenAndCaughtMon` falls through, so a
-	## restored state cannot hold a caught species it has not seen.
-	for raw_species: Variant in initial_caught_species:
-		if int(raw_species) > 0 and bool(initial_caught_species[raw_species]):
-			_caught_species[int(raw_species)] = true
-			_seen_species[int(raw_species)] = true
 	_just_battled = initial_just_battled
-	_phone_receive_cycle = clampi(initial_phone_receive_cycle, 0, PHONE_RECEIVE_DELAYS.size() - 1)
+	_phone_receive_cycle = clampi(
+		initial_phone_receive_cycle, 0, PHONE_RECEIVE_DELAYS.size() - 1
+	)
 	_phone_receive_minutes = maxi(0, initial_phone_receive_minutes)
 	_pending_special_phone_call = maxi(0, initial_pending_special_phone_call)
-	for raw_address: Variant in initial_script_memory:
-		var address: int = int(raw_address)
-		var value: int = int(initial_script_memory[raw_address]) & 0xFF
-		if address > 0 and value != 0 and _script_memory.size() < SCRIPT_MEMORY_CAPACITY:
-			_script_memory[address] = value
-	for category: StringName in MAPTILE_DECORATION_SLOTS:
-		var decoration: int = int(initial_maptile_decorations.get(category, 0))
-		if decoration > 0 and decoration <= 0xFF:
-			_maptile_decorations[category] = decoration
 	_variable_sprites = INITIAL_VARIABLE_SPRITES.duplicate()
+
+
+## Keeps the true keys of [param source] that are at least [param low], up to
+## [param capacity] of them.
+static func _seed_flags(
+	target: Dictionary, source: Dictionary, low: int, capacity: int = UNBOUNDED
+) -> void:
+	for raw_key: Variant in source:
+		var key: int = int(raw_key)
+		if key >= low and bool(source[raw_key]) and target.size() < capacity:
+			target[key] = true
+
+
+## Keeps the non-zero counts of [param source] whose key is at least [param low],
+## each masked to [param mask], up to [param capacity] of them.
+static func _seed_counts(
+	target: Dictionary, source: Dictionary, low: int, mask: int = -1,
+	capacity: int = UNBOUNDED
+) -> void:
+	for raw_key: Variant in source:
+		var key: int = int(raw_key)
+		var value: int = int(source[raw_key]) & mask
+		if key >= low and value > 0 and target.size() < capacity:
+			target[key] = value
 
 
 ## JSON-safe representation of the mutable overworld state. Cartridge records
@@ -540,62 +541,32 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	if not raw is Dictionary:
 		return Gen2WorldState.new()
 	var source: Dictionary = raw
-	var swarm: Vector2i = _vector_from_value(source.get("swarm_map", [-1, -1]))
 	var restored: Gen2WorldState = Gen2WorldState.new(
-		source.get("event_flags", {}) if source.get("event_flags", {}) is Dictionary else {},
-		source.get("map_scenes", {}) if source.get("map_scenes", {}) is Dictionary else {},
-		source.get("items", {}) if source.get("items", {}) is Dictionary else {},
-		source.get("money", {}) if source.get("money", {}) is Dictionary else {},
-		int(source.get("coins", 0)),
-		source.get("phone_contacts", {}) if source.get("phone_contacts", {}) is Dictionary else {},
-		int(source.get("repel_steps", 0)), swarm,
+		_map(source, "event_flags"), _map(source, "map_scenes"), _map(source, "items"),
+		_map(source, "money"), int(source.get("coins", 0)),
+		_map(source, "phone_contacts"), int(source.get("repel_steps", 0)),
+		_vector_from_value(source.get("swarm_map", [-1, -1])),
 		int(source.get("fishing_swarm_species", 0)),
-		source.get("roaming_mons", []) if source.get("roaming_mons", []) is Array else [],
-		bool(source.get("just_battled", false)),
+		_list(source, "roaming_mons"), bool(source.get("just_battled", false)),
 		int(source.get("phone_receive_cycle", 0)),
 		int(source.get("phone_receive_minutes", PHONE_RECEIVE_DELAYS[0])),
 		int(source.get("pending_special_phone_call", 0)),
-		source.get("seen_species", {}) if source.get("seen_species", {}) is Dictionary else {},
-		source.get("engine_flags", {}) if source.get("engine_flags", {}) is Dictionary else {},
-		source.get("script_memory", {}) if source.get("script_memory", {}) is Dictionary else {},
-		source.get("caught_species", {}) if source.get("caught_species", {}) is Dictionary else {},
-		source.get("maptile_decorations", {}) if source.get("maptile_decorations", {}) is Dictionary else {},
+		_map(source, "seen_species"), _map(source, "engine_flags"),
+		_map(source, "script_memory"), _map(source, "caught_species"),
+		_map(source, "maptile_decorations"),
 	)
-	## Absent in a state written before the radio existed. Zero is the same
-	## MUSIC_NONE a fresh state starts on, and the next map load writes the real
-	## track, so an old save needs no migration.
-	var stored_pc_items: Variant = source.get("pc_items", {})
-	if stored_pc_items is Dictionary:
-		for raw_item: Variant in stored_pc_items as Dictionary:
-			var pc_item: int = int(raw_item)
-			var pc_quantity: int = int((stored_pc_items as Dictionary)[raw_item])
-			if pc_item > 0 and pc_quantity > 0 \
-				and restored._pc_items.size() < Gen2WorldPack.MAX_PC_ITEMS:
-				restored._pc_items[pc_item] = pc_quantity
-	## Absent in a state written while there was one swarm slot. Crystal's Yanma
-	## swarm reads as inactive then, which is what a save taken before the news
-	## announced one would hold anyway.
+	_seed_counts(restored._pc_items, _map(source, "pc_items"), 1, -1, Gen2WorldPack.MAX_PC_ITEMS)
+	_seed_flags(restored._picked_fruit_trees, _map(source, "picked_fruit_trees"), 1)
 	restored._swarm_maps[SWARM_YANMA] = _vector_from_value(
 		source.get("yanma_swarm_map", [-1, -1])
 	)
-	## Absent in a state written before the byte was saved, which reads as a cave
-	## that has not been lit. `ResetFlashIfOutOfCave` clears it on the next ROUTE
-	## or TOWN either way, so an old save loses at most one cave's light.
 	restored._used_flash = bool(source.get("used_flash", false))
-	## Absent in a state written before the counter was kept, which reads as a
-	## ride that has not started: zero is what a new game holds and the only
-	## reader is the 1024-step threshold below it.
 	restored._bike_step = clampi(int(source.get("bike_step", 0)), 0, MAX_BIKE_STEP)
 	restored._map_music = maxi(0, int(source.get("map_music", MUSIC_NONE)))
 	restored.set_radio_knob(int(source.get("radio_knob", Gen2WorldRadio.KNOB_MIN)))
 	restored._radio_channel = int(source.get("radio_channel", -1))
 	restored.set_last_dex_mode(int(source.get("last_dex_mode", RomLayout.DEXMODE_NEW)))
 	restored.set_kurt_apricorn_quantity(int(source.get("kurt_apricorn_quantity", 0)))
-	var picked: Variant = source.get("picked_fruit_trees", {})
-	if picked is Dictionary:
-		for raw_tree: Variant in picked as Dictionary:
-			if int(raw_tree) > 0 and bool((picked as Dictionary)[raw_tree]):
-				restored._picked_fruit_trees[int(raw_tree)] = true
 	## Absent in a state written before the Unown dex, which reads as an empty
 	## one: the flag that unlocks the mode is an engine flag and survives on its
 	## own, so an old save shows the mode with nothing listed under it, which is
@@ -605,80 +576,78 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	## byte was kept falls back to the first form caught, which is the same
 	## answer for every save whose first Unown was caught rather than only met.
 	restored.note_first_unown_seen(int(source.get("first_unown_seen", 0)))
-	var stored_unown: Variant = source.get("unown_dex", [])
-	if stored_unown is Array:
-		for raw_form: Variant in stored_unown as Array:
-			restored.update_unown_dex(int(raw_form))
+	for raw_form: Variant in _list(source, "unown_dex"):
+		restored.update_unown_dex(int(raw_form))
 	restored.set_registered_item(int(source.get("registered_item", 0)))
 	restored.set_wild_encounter_cooldown(int(source.get("wild_encounter_cooldown", 0)))
-	## Absent in a state written before the step counters existed, which restores
-	## as a fresh walk: zero is what a new game starts on and no reader of these
-	## can tell a migrated save from one that has taken no step.
 	restored._step_count = int(source.get("step_count", 0)) & 0xFF
 	restored._poison_step_count = int(source.get("poison_step_count", 0)) & 0xFF
 	restored._happiness_step_count = int(source.get("happiness_step_count", 0)) & 1
 	restored.set_wild_encounters_off(bool(source.get("wild_encounters_off", false)))
 	restored.set_park_balls(int(source.get("park_balls", 0)))
-	var started: Variant = source.get("bug_contest_started", {})
-	if started is Dictionary:
-		restored._bug_contest_started = _clock_dict(started as Dictionary)
-	var caught: Variant = source.get("contest_mon", {})
-	if caught is Dictionary and int((caught as Dictionary).get("species", 0)) > 0:
-		restored._contest_mon = (caught as Dictionary).duplicate()
+	restored._bug_contest_started = _clock_dict(_map(source, "bug_contest_started"))
+	var caught: Dictionary = _map(source, "contest_mon")
+	if int(caught.get("species", 0)) > 0:
+		restored._contest_mon = caught.duplicate()
 	restored.set_contest_second_party_species(
 		int(source.get("contest_second_party_species", 0))
 	)
-	## Absent in a state written before the Day-Care existed, which restores as
-	## two empty slots: nothing is deposited, so no flag, counter or egg has
-	## anything to be wrong about.
+	_restore_day_care(restored, source)
+	_restore_deferred(restored, source)
+	restored._battle_tower = Gen2BattleTower.from_dict(source.get("battle_tower", {}))
+	var sprites: Dictionary = _map(source, "variable_sprites")
+	for raw_slot: Variant in sprites:
+		restored.set_variable_sprite(int(raw_slot), int(sprites[raw_slot]))
+	return restored
+
+
+## [param source]'s [param key] when it is a Dictionary, and an empty one when it
+## is missing or something else. A field absent from a state written by an older
+## build reads as the value a new game holds, which is why nothing here versions.
+static func _map(source: Dictionary, key: String) -> Dictionary:
+	var value: Variant = source.get(key, {})
+	return value if value is Dictionary else {}
+
+
+## The same for a list.
+static func _list(source: Dictionary, key: String) -> Array:
+	var value: Variant = source.get(key, [])
+	return value if value is Array else []
+
+
+static func _restore_day_care(restored: Gen2WorldState, source: Dictionary) -> void:
 	restored._day_care_man = int(source.get("day_care_man", 0)) & 0xFF
 	restored._day_care_lady = int(source.get("day_care_lady", 0)) & 0xFF
 	restored._steps_to_egg = int(source.get("steps_to_egg", 0)) & 0xFF
-	var stored_mons: Variant = source.get("day_care_mons", [])
-	if stored_mons is Array:
-		for slot: int in mini((stored_mons as Array).size(), 2):
-			restored._day_care_mons[slot] = _mon_from_value((stored_mons as Array)[slot])
+	var stored: Array = _list(source, "day_care_mons")
+	for slot: int in mini(stored.size(), 2):
+		restored._day_care_mons[slot] = _mon_from_value(stored[slot])
 	restored._day_care_egg = _mon_from_value(source.get("day_care_egg", {}))
-	## Absent in a state written before the deferred routines were built. Zero
-	## reads as "never drawn" for the lucky number, "no record" for the Magikarp
-	## house and "Mom has not been asked" for her bank, which is what a save
-	## taken before any of them was reachable says anyway.
+
+
+## The lucky number, the Magikarp record, Mom's bank and Buena's password. Zero
+## reads as "never drawn", "no record" and "Mom has not been asked"; the one
+## field that does not default to zero is hers, because `NewGame` writes
+## `MOM_MONEY` there rather than a balance she has already passed.
+static func _restore_deferred(restored: Gen2WorldState, source: Dictionary) -> void:
 	restored._battle_caught_celebi = bool(source.get("battle_caught_celebi", false))
 	restored._lucky_id_number = int(source.get("lucky_id_number", 0)) & 0xFFFF
 	restored._lucky_number_day = int(source.get("lucky_number_day", 0)) & 0xFF
 	restored._lucky_number_days_left = int(source.get("lucky_number_days_left", 0)) & 0xFF
 	restored._kenji_break_timer = int(source.get("kenji_break_timer", 0)) & 0xFF
-	var record: Variant = source.get("best_magikarp", {})
-	if record is Dictionary:
-		restored._best_magikarp_feet = int((record as Dictionary).get("feet", 0)) & 0xFF
-		restored._best_magikarp_inches = int((record as Dictionary).get("inches", 0)) & 0xFF
-		restored._best_magikarp_ot = String((record as Dictionary).get("ot", ""))
+	var record: Dictionary = _map(source, "best_magikarp")
+	restored._best_magikarp_feet = int(record.get("feet", 0)) & 0xFF
+	restored._best_magikarp_inches = int(record.get("inches", 0)) & 0xFF
+	restored._best_magikarp_ot = String(record.get("ot", ""))
 	restored._mom_savings_flags = int(source.get("mom_savings_flags", 0)) & 0xFF
 	restored._mom_item_index = maxi(int(source.get("mom_item_index", 0)), 0)
 	restored._mom_item_set = maxi(int(source.get("mom_item_set", 0)), 0)
-	## `NewGame` writes `MOM_MONEY` here rather than zero, so a save from before
-	## the field existed reads as a new game rather than as a balance she has
-	## already passed.
 	restored._mom_item_trigger_balance = clampi(
 		int(source.get("mom_item_trigger_balance", RomLayout.MOM_MONEY)),
 		0, Gen2WorldInventory.MAX_MONEY
 	)
 	restored._blue_card_balance = int(source.get("blue_card_balance", 0)) & 0xFF
 	restored._buenas_password = int(source.get("buenas_password", 0)) & 0xFF
-	## Defaults rather than versioning: a slot written before the tower existed
-	## reads as one with no challenge in it, which is the truth about it.
-	restored._battle_tower = Gen2BattleTower.from_dict(source.get("battle_tower", {}))
-	## Absent in a state written before the table was saved. Those slots are
-	## whatever `InitializeEventsScript` left, which is what the constructor
-	## already seeded, so an old save needs no migration.
-	var stored_sprites: Variant = source.get("variable_sprites", {})
-	if stored_sprites is Dictionary:
-		for raw_slot: Variant in stored_sprites as Dictionary:
-			restored.set_variable_sprite(
-				int(raw_slot), int((stored_sprites as Dictionary)[raw_slot])
-			)
-
-	return restored
 
 
 ## Restores the mutable state after a host transaction could not be persisted.
@@ -957,15 +926,12 @@ static func engine_flag(crystal_index: int, crystal: bool = true) -> int:
 	return crystal_index - 1 if crystal_index > ENGINE_MOBILE_SYSTEM else -1
 
 
-## The `ENGINE_FLYPOINT_*` run, which is `wVisitedSpawns` a bit at a time: the
-## flag `CheckIfVisitedFlypoint` tests for spawn [param spawn], as a Crystal
-## index resolved onto [param crystal]'s own table.
-##
-## The rows are the spawns in order with one hole in them: `SPAWN_UNION_CAVE`
-## has no flag of its own (`data/events/engine_flags.asm`), so every spawn past
+## The `ENGINE_FLYPOINT_*` run, which is `wVisitedSpawns` a bit at a time: the flag
+## `CheckIfVisitedFlypoint` tests for spawn [param spawn], as a Crystal index
+## resolved onto [param crystal]'s own table. The rows are the spawns in order with
+## one hole in them: `SPAWN_UNION_CAVE` has no flag of its own, so every spawn past
 ## it sits one row lower than its own number. -1 for the Union Cave spawn and for
-## anything outside the run, which [method is_engine_flag_active] reads as
-## inactive.
+## anything outside the run, which [method is_engine_flag_active] reads as inactive.
 static func flypoint_flag(spawn: int, crystal: bool = true) -> int:
 	if spawn < 0 or spawn >= NUM_SPAWNS or spawn == SPAWN_UNION_CAVE:
 		return -1
@@ -1213,15 +1179,13 @@ func set_blue_card_balance(points: int) -> void:
 
 
 ## True unless [param data] is a verified Gold or Silver cache, matching
-## Gen2WorldScriptRunner._crystal_commands(). Both engine flag tables and
-## `_GetVarAction.CountBadges` agree on everything except this table's
-## offset, so every profile-dependent flag lookup here keys off the same
-## question the script command-width split already answers.
-##
-## A null cache answers Crystal, which is what every caller that has no cache in
-## hand has always meant. A caller holding only an id, such as a save's own
-## [member Gen2SaveData.game_id], asks [method is_crystal_game_id] instead: that
-## one knows the difference between "not told" and "told Gold".
+## `Gen2WorldScriptRunner._crystal_commands()`. Both engine flag tables and
+## `_GetVarAction.CountBadges` agree on everything except this table's offset, so
+## every profile-dependent flag lookup here keys off the same question the script
+## command-width split already answers. A null cache answers Crystal, which is what
+## every caller with no cache in hand has always meant; a caller holding only an id
+## asks [method is_crystal_game_id] instead, which knows the difference between
+## "not told" and "told Gold".
 static func is_crystal_profile(data: GameData) -> bool:
 	return data == null or is_crystal_game_id(data.id)
 
@@ -1700,14 +1664,12 @@ func count_step() -> bool:
 
 
 ## `DoBikeStep`, which `CountStep` reaches behind the poison branch. The caller
-## answers the three gates in front of the counter, since only it knows the map
-## and the player's state: [param armed] is `STATUSFLAGS2_BIKE_SHOP_CALL_F` and
-## the bike, and [param in_service] is `GetMapPhoneService`.
-##
-## The counter saturates at `$ffff` rather than wrapping, which is what the two
-## `cp 255` tests do, and the call is queued the first counted step past 1024
-## that finds no other special call already waiting. Answers whether the call was
-## queued.
+## answers the three gates in front of the counter, since only it knows the map and
+## the player's state: [param armed] is `STATUSFLAGS2_BIKE_SHOP_CALL_F` and the
+## bike, and [param in_service] is `GetMapPhoneService`. The counter saturates at
+## `$ffff` rather than wrapping, which is what the two `cp 255` tests do, and the
+## call is queued the first counted step past 1024 that finds no other special call
+## already waiting.
 func do_bike_step(armed: bool, in_service: bool) -> bool:
 	if not armed or not in_service:
 		return false
@@ -2089,15 +2051,12 @@ func _copy_roaming_mons(source: Array) -> Array:
 
 
 ## `BattleEnd_HandleRoamMons`, which every roaming battle ends through. A win,
-## which is the source's word for caught or defeated alike, empties the struct:
-## `GetRoamMonHP` writes 0, the two map bytes become `GROUP_N_A`/`MAP_N_A` and
-## the species byte becomes 0, so `CheckEncounterRoamMon` can never select that
-## slot again. Any other ending stores the HP the fight left the roamer on.
-##
-## [param dvs] is the word `LoadEnemyMon`'s `.Roaming` rolled on the first
-## encounter and read back on every later one; it is stored beside the HP so a
-## roamer keeps the Pokemon it was, shininess included. Answers whether the
-## record moved.
+## which is the source's word for caught or defeated alike, empties the struct: the
+## HP becomes 0, the two map bytes `GROUP_N_A`/`MAP_N_A` and the species byte 0, so
+## `CheckEncounterRoamMon` can never select that slot again. Any other ending stores
+## the HP the fight left the roamer on. [param dvs] is the word `.Roaming` rolled
+## on the first encounter and read back on every later one, stored beside the HP so
+## a roamer keeps the Pokemon it was, shininess included.
 func note_roam_battle_end(species: int, won: bool, hp: int, dvs: int) -> bool:
 	for index: int in _roaming_mons.size():
 		var mon: Dictionary = _roaming_mons[index]
@@ -2179,317 +2138,242 @@ static func _reordered(source: Dictionary, order: Array) -> Dictionary:
 	return result
 
 
-## Applies a script's staged state as one transaction. Validation happens before
-## either dictionary is replaced, so a failed script cannot leave half a flag
-## transition behind.
+## An unbounded key, value or capacity in [constant CHANGE_MAPS] and
+## [constant CHANGE_SCALARS].
+const UNBOUNDED: int = 0x7FFFFFFF
+## A change map whose values are bools: a true sets the key, a false erases it.
+const MERGE_FLAGS: int = 0
+## A change map whose values are counts: a non-zero stores it, a zero erases it.
+const MERGE_COUNTS: int = 1
+
+## Every map [method apply_changes] accepts, in the order a bad one is reported:
+## the `runtime_changes` key, the member, the merge mode, the smallest and
+## largest key, the largest value ([constant UNBOUNDED] for a flag map), the
+## reason a non-Dictionary answers with, the reason a bad entry answers with, and
+## the capacity the merged map may not pass with the reason it answers with.
+const CHANGE_MAPS: Array[Array] = [
+	["items", "_items", MERGE_COUNTS, 1, UNBOUNDED, UNBOUNDED,
+		&"invalid_items", &"invalid_item_quantity", UNBOUNDED, &""],
+	["pc_items", "_pc_items", MERGE_COUNTS, 1, UNBOUNDED, UNBOUNDED,
+		&"invalid_pc_items", &"invalid_pc_item_quantity",
+		Gen2WorldPack.MAX_PC_ITEMS, &"pc_item_capacity"],
+	["engine_flags", "_engine_flags", MERGE_FLAGS, 0, UNBOUNDED, UNBOUNDED,
+		&"invalid_engine_flags", &"invalid_engine_flag", UNBOUNDED, &""],
+	["money", "_money", MERGE_COUNTS, 0, UNBOUNDED, UNBOUNDED,
+		&"invalid_money", &"invalid_money_balance", UNBOUNDED, &""],
+	["phone_contacts", "_phone_contacts", MERGE_FLAGS, 0, UNBOUNDED, UNBOUNDED,
+		&"invalid_phone_contacts", &"invalid_phone_contact",
+		PHONE_CONTACT_CAPACITY, &"phone_contact_capacity"],
+	["fruit_trees", "_picked_fruit_trees", MERGE_FLAGS, 1, RomLayout.FRUIT_TREE_COUNT,
+		UNBOUNDED, &"invalid_fruit_trees", &"invalid_fruit_trees", UNBOUNDED, &""],
+	["seen_species", "_seen_species", MERGE_FLAGS, 1, UNBOUNDED, UNBOUNDED,
+		&"invalid_seen_species", &"invalid_seen_species", UNBOUNDED, &""],
+	["caught_species", "_caught_species", MERGE_FLAGS, 1, UNBOUNDED, UNBOUNDED,
+		&"invalid_caught_species", &"invalid_caught_species", UNBOUNDED, &""],
+	["script_memory", "_script_memory", MERGE_COUNTS, 1, UNBOUNDED, 0xFF,
+		&"invalid_script_memory", &"invalid_script_memory",
+		SCRIPT_MEMORY_CAPACITY, &"script_memory_capacity"],
+]
+
+## Every bounded integer `runtime_changes` may carry: the key, the member, the
+## largest value and the reason a value outside 0..that answers with.
+static var CHANGE_SCALARS: Array[Array] = [
+	["coins", "_coins", UNBOUNDED, &"invalid_coins"],
+	["phone_receive_cycle", "_phone_receive_cycle", PHONE_RECEIVE_DELAYS.size() - 1,
+		&"invalid_phone_receive_cycle"],
+	["phone_receive_minutes", "_phone_receive_minutes", UNBOUNDED,
+		&"invalid_phone_receive_minutes"],
+	["pending_special_phone_call", "_pending_special_phone_call", UNBOUNDED,
+		&"invalid_special_phone_call"],
+	["repel_steps", "_repel_steps", UNBOUNDED, &"invalid_repel_steps"],
+	["kurt_apricorn_quantity", "_kurt_apricorn_quantity", 0xFF,
+		&"invalid_kurt_apricorn_quantity"],
+	["blue_card_balance", "_blue_card_balance", 0xFF, &"invalid_blue_card_balance"],
+	["mom_savings_flags", "_mom_savings_flags", 0xFF, &"invalid_mom_savings_flags"],
+	["kenji_break_timer", "_kenji_break_timer", 0xFF, &"invalid_kenji_break_timer"],
+	["lucky_number_days_left", "_lucky_number_days_left", 0xFF,
+		&"invalid_lucky_number_timer"],
+	["lucky_id_number", "_lucky_id_number", 0xFFFF, &"invalid_lucky_id_number"],
+	["lucky_number_day", "_lucky_number_day", 0xFF, &"invalid_lucky_number_day"],
+]
+
+## The members a pack listing reads in insertion order, so the same quantities in
+## another order still count as a change.
+const ORDERED_MEMBERS: Array[String] = ["_items", "_pc_items"]
+
+
+## [param source] merged with [param changes] under [constant MERGE_FLAGS] or
+## [constant MERGE_COUNTS].
+static func _merged(source: Dictionary, changes: Dictionary, mode: int) -> Dictionary:
+	var out: Dictionary = source.duplicate()
+	for raw_key: Variant in changes:
+		var key: int = int(raw_key)
+		var value: int = int(changes[raw_key]) if mode == MERGE_COUNTS else int(bool(changes[raw_key]))
+		if value == 0:
+			out.erase(key)
+		elif mode == MERGE_FLAGS:
+			out[key] = true
+		else:
+			out[key] = value
+	return out
+
+
+## Why [param changes] is not a map of keys in [param low]..[param high] with
+## values in 0..[param ceiling], or an empty name when it is.
+static func _map_reason(
+	changes: Dictionary, low: int, high: int, ceiling: int, reason: StringName
+) -> StringName:
+	for raw_key: Variant in changes:
+		var key: int = int(raw_key)
+		if key < low or key > high:
+			return reason
+		var value: int = int(changes[raw_key])
+		if value < 0 or value > ceiling:
+			return reason
+	return &""
+
+
+## Applies a script's staged state as one transaction. Nothing is replaced until
+## every field validates, so a failed script cannot leave half a flag transition
+## behind.
 func apply_changes(
 	flag_changes: Dictionary, scene_changes: Dictionary, runtime_changes: Dictionary = {}
 ) -> Dictionary:
-	for raw_flag: Variant in flag_changes:
-		if int(raw_flag) < 0:
-			return {"ok": false, "reason": &"invalid_event_flag"}
-	for raw_map: Variant in scene_changes:
-		if String(raw_map).is_empty() or int(scene_changes[raw_map]) < 0:
-			return {"ok": false, "reason": &"invalid_scene"}
-	var item_changes: Dictionary = runtime_changes.get("items", {})
-	if not item_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_items"}
-	for raw_item: Variant in item_changes:
-		if int(raw_item) <= 0 or int(item_changes[raw_item]) < 0:
-			return {"ok": false, "reason": &"invalid_item_quantity"}
-	## `SwitchItemsInBag`' whole effect: the same items in another order. A
-	## quantity map compares equal whatever order it holds, so a reorder has to
-	## be asked for by name or the transaction below would call it no change.
-	var item_order: Variant = runtime_changes.get("item_order", null)
-	if item_order != null and not item_order is Array:
-		return {"ok": false, "reason": &"invalid_item_order"}
-	var pc_item_changes: Dictionary = runtime_changes.get("pc_items", {})
-	if not pc_item_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_pc_items"}
-	var pc_item_order: Variant = runtime_changes.get("pc_item_order", null)
-	if pc_item_order != null and not pc_item_order is Array:
-		return {"ok": false, "reason": &"invalid_pc_item_order"}
-	for raw_item: Variant in pc_item_changes:
-		if int(raw_item) <= 0 or int(pc_item_changes[raw_item]) < 0:
-			return {"ok": false, "reason": &"invalid_pc_item_quantity"}
-	var engine_flag_changes: Dictionary = runtime_changes.get("engine_flags", {})
-	if not engine_flag_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_engine_flags"}
-	for raw_flag: Variant in engine_flag_changes:
-		if int(raw_flag) < 0:
-			return {"ok": false, "reason": &"invalid_engine_flag"}
-	var money_changes: Dictionary = runtime_changes.get("money", {})
-	if not money_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_money"}
-	for raw_account: Variant in money_changes:
-		if int(raw_account) < 0 or int(money_changes[raw_account]) < 0:
-			return {"ok": false, "reason": &"invalid_money_balance"}
-	var next_coins: int = int(runtime_changes.get("coins", _coins))
-	if next_coins < 0:
-		return {"ok": false, "reason": &"invalid_coins"}
-	var phone_changes: Dictionary = runtime_changes.get("phone_contacts", {})
-	if not phone_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_phone_contacts"}
-	for raw_contact: Variant in phone_changes:
-		if int(raw_contact) < 0:
-			return {"ok": false, "reason": &"invalid_phone_contact"}
-	var next_receive_cycle: int = int(
-		runtime_changes.get("phone_receive_cycle", _phone_receive_cycle)
+	var next: Dictionary = {}
+	var reason: StringName = _stage_changes(
+		flag_changes, scene_changes, runtime_changes, next
 	)
-	if next_receive_cycle < 0 or next_receive_cycle >= PHONE_RECEIVE_DELAYS.size():
-		return {"ok": false, "reason": &"invalid_phone_receive_cycle"}
-	var next_receive_minutes: int = int(
-		runtime_changes.get("phone_receive_minutes", _phone_receive_minutes)
-	)
-	if next_receive_minutes < 0:
-		return {"ok": false, "reason": &"invalid_phone_receive_minutes"}
-	var next_special_phone_call: int = int(
-		runtime_changes.get("pending_special_phone_call", _pending_special_phone_call)
-	)
-	if next_special_phone_call < 0:
-		return {"ok": false, "reason": &"invalid_special_phone_call"}
-	var swarm_change: Variant = runtime_changes.get("swarm", null)
-	if swarm_change != null and not swarm_change is Dictionary:
-		return {"ok": false, "reason": &"invalid_swarm"}
-	var next_swarm_maps: Array[Vector2i] = _swarm_maps.duplicate()
-	var next_fishing_swarm_species: int = _fishing_swarm_species
-	if swarm_change is Dictionary:
-		var swarm: Dictionary = swarm_change
-		var swarm_active: bool = bool(swarm.get("active", true))
-		var swarm_group: int = int(swarm.get("map_group", -1))
-		var swarm_number: int = int(swarm.get("map_number", -1))
-		if swarm_active and (swarm_group < 0 or swarm_number < 0):
-			return {"ok": false, "reason": &"invalid_swarm_map"}
-		var swarm_species: int = int(swarm.get("fishing_species", 0))
-		if swarm_species not in [0, 0xD3, 0xDF]:
-			return {"ok": false, "reason": &"invalid_fishing_swarm_species"}
-		var swarm_kind: int = int(swarm.get("kind", SWARM_DUNSPARCE))
-		if swarm_kind != SWARM_DUNSPARCE and swarm_kind != SWARM_YANMA:
-			return {"ok": false, "reason": &"invalid_swarm_kind"}
-		next_swarm_maps[swarm_kind] = (
-			Vector2i(swarm_group, swarm_number) if swarm_active else Vector2i(-1, -1)
-		)
-		next_fishing_swarm_species = swarm_species
-	var next_repel_steps: int = int(runtime_changes.get("repel_steps", _repel_steps))
-	if next_repel_steps < 0:
-		return {"ok": false, "reason": &"invalid_repel_steps"}
-	var next_kurt_apricorns: int = int(
-		runtime_changes.get("kurt_apricorn_quantity", _kurt_apricorn_quantity)
-	)
-	if next_kurt_apricorns < 0 or next_kurt_apricorns > 0xFF:
-		return {"ok": false, "reason": &"invalid_kurt_apricorn_quantity"}
-	var next_blue_card: int = int(
-		runtime_changes.get("blue_card_balance", _blue_card_balance)
-	)
-	if next_blue_card < 0 or next_blue_card > 0xFF:
-		return {"ok": false, "reason": &"invalid_blue_card_balance"}
-	var next_mom_savings: int = int(
-		runtime_changes.get("mom_savings_flags", _mom_savings_flags)
-	)
-	if next_mom_savings < 0 or next_mom_savings > 0xFF:
-		return {"ok": false, "reason": &"invalid_mom_savings_flags"}
-	var next_kenji: int = int(runtime_changes.get("kenji_break_timer", _kenji_break_timer))
-	if next_kenji < 0 or next_kenji > 0xFF:
-		return {"ok": false, "reason": &"invalid_kenji_break_timer"}
-	var next_lucky_days: int = int(
-		runtime_changes.get("lucky_number_days_left", _lucky_number_days_left)
-	)
-	if next_lucky_days < 0 or next_lucky_days > 0xFF:
-		return {"ok": false, "reason": &"invalid_lucky_number_timer"}
-	var next_lucky_id: int = int(runtime_changes.get("lucky_id_number", _lucky_id_number))
-	if next_lucky_id < 0 or next_lucky_id > 0xFFFF:
-		return {"ok": false, "reason": &"invalid_lucky_id_number"}
-	var next_lucky_day: int = int(runtime_changes.get("lucky_number_day", _lucky_number_day))
-	if next_lucky_day < 0 or next_lucky_day > 0xFF:
-		return {"ok": false, "reason": &"invalid_lucky_number_day"}
-	var magikarp_change: Variant = runtime_changes.get("best_magikarp", null)
-	if magikarp_change != null and not magikarp_change is Dictionary:
-		return {"ok": false, "reason": &"invalid_best_magikarp"}
-	var next_karp_feet: int = _best_magikarp_feet
-	var next_karp_inches: int = _best_magikarp_inches
-	var next_karp_ot: String = _best_magikarp_ot
-	if magikarp_change is Dictionary:
-		next_karp_feet = int((magikarp_change as Dictionary).get("feet", 0))
-		next_karp_inches = int((magikarp_change as Dictionary).get("inches", 0))
-		next_karp_ot = String((magikarp_change as Dictionary).get("ot", ""))
-		if next_karp_feet < 0 or next_karp_feet > 0xFF \
-			or next_karp_inches < 0 or next_karp_inches > 0xFF:
-			return {"ok": false, "reason": &"invalid_best_magikarp"}
-	var fruit_tree_changes: Dictionary = runtime_changes.get("fruit_trees", {})
-	if not fruit_tree_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_fruit_trees"}
-	for raw_tree: Variant in fruit_tree_changes:
-		if int(raw_tree) < 1 or int(raw_tree) > RomLayout.FRUIT_TREE_COUNT:
-			return {"ok": false, "reason": &"invalid_fruit_trees"}
-	var seen_changes: Dictionary = runtime_changes.get("seen_species", {})
-	if not seen_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_seen_species"}
-	for raw_species: Variant in seen_changes:
-		if int(raw_species) <= 0:
-			return {"ok": false, "reason": &"invalid_seen_species"}
-	var caught_changes: Dictionary = runtime_changes.get("caught_species", {})
-	if not caught_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_caught_species"}
-	for raw_species: Variant in caught_changes:
-		if int(raw_species) <= 0:
-			return {"ok": false, "reason": &"invalid_caught_species"}
-	var memory_changes: Dictionary = runtime_changes.get("script_memory", {})
-	if not memory_changes is Dictionary:
-		return {"ok": false, "reason": &"invalid_script_memory"}
-	for raw_address: Variant in memory_changes:
-		var change_value: int = int(memory_changes[raw_address])
-		if int(raw_address) <= 0 or change_value < 0 or change_value > 0xFF:
-			return {"ok": false, "reason": &"invalid_script_memory"}
+	if reason != &"":
+		return {"ok": false, "reason": reason}
 
-	var next_flags: Dictionary = _event_flags.duplicate()
-	for raw_flag: Variant in flag_changes:
-		var flag: int = int(raw_flag)
-		if bool(flag_changes[raw_flag]):
-			next_flags[flag] = true
-		else:
-			next_flags.erase(flag)
-	var next_engine_flags: Dictionary = _engine_flags.duplicate()
-	for raw_flag: Variant in engine_flag_changes:
-		var flag_id: int = int(raw_flag)
-		if bool(engine_flag_changes[raw_flag]):
-			next_engine_flags[flag_id] = true
-		else:
-			next_engine_flags.erase(flag_id)
-	var next_scenes: Dictionary = _map_scenes.duplicate()
-	for raw_map: Variant in scene_changes:
-		next_scenes[String(raw_map)] = int(scene_changes[raw_map])
-	var next_items: Dictionary = _items.duplicate()
-	for raw_item: Variant in item_changes:
-		var item: int = int(raw_item)
-		var quantity: int = int(item_changes[raw_item])
-		if quantity == 0:
-			next_items.erase(item)
-		else:
-			next_items[item] = quantity
-	var next_pc_items: Dictionary = _pc_items.duplicate()
-	for raw_item: Variant in pc_item_changes:
-		var pc_item: int = int(raw_item)
-		var pc_quantity: int = int(pc_item_changes[raw_item])
-		if pc_quantity == 0:
-			next_pc_items.erase(pc_item)
-		else:
-			next_pc_items[pc_item] = pc_quantity
-	if next_pc_items.size() > Gen2WorldPack.MAX_PC_ITEMS:
-		return {"ok": false, "reason": &"pc_item_capacity"}
-	if item_order != null:
-		if not _is_permutation(next_items, item_order as Array):
-			return {"ok": false, "reason": &"invalid_item_order"}
-		next_items = _reordered(next_items, item_order as Array)
-	if pc_item_order != null:
-		if not _is_permutation(next_pc_items, pc_item_order as Array):
-			return {"ok": false, "reason": &"invalid_pc_item_order"}
-		next_pc_items = _reordered(next_pc_items, pc_item_order as Array)
-	var next_money: Dictionary = _money.duplicate()
-	for raw_account: Variant in money_changes:
-		var account: int = int(raw_account)
-		var balance: int = int(money_changes[raw_account])
-		if balance == 0:
-			next_money.erase(account)
-		else:
-			next_money[account] = balance
-	var next_seen_species: Dictionary = _seen_species.duplicate()
-	for raw_species: Variant in seen_changes:
-		var species: int = int(raw_species)
-		if bool(seen_changes[raw_species]):
-			next_seen_species[species] = true
-		else:
-			next_seen_species.erase(species)
-	var next_caught_species: Dictionary = _caught_species.duplicate()
-	for raw_species: Variant in caught_changes:
-		var caught_species_number: int = int(raw_species)
-		if bool(caught_changes[raw_species]):
-			next_caught_species[caught_species_number] = true
-			next_seen_species[caught_species_number] = true
-		else:
-			next_caught_species.erase(caught_species_number)
-	var next_contacts: Dictionary = _phone_contacts.duplicate()
-	for raw_contact: Variant in phone_changes:
-		var contact: int = int(raw_contact)
-		if bool(phone_changes[raw_contact]):
-			next_contacts[contact] = true
-		else:
-			next_contacts.erase(contact)
-	if next_contacts.size() > PHONE_CONTACT_CAPACITY:
-		return {"ok": false, "reason": &"phone_contact_capacity"}
-	var next_script_memory: Dictionary = _script_memory.duplicate()
-	for raw_address: Variant in memory_changes:
-		var address: int = int(raw_address)
-		var value: int = int(memory_changes[raw_address])
-		if value == 0:
-			next_script_memory.erase(address)
-		else:
-			next_script_memory[address] = value
-	if next_script_memory.size() > SCRIPT_MEMORY_CAPACITY:
-		return {"ok": false, "reason": &"script_memory_capacity"}
-	var next_fruit_trees: Dictionary = _picked_fruit_trees.duplicate()
-	for raw_tree: Variant in fruit_tree_changes:
-		var tree: int = int(raw_tree)
-		if bool(fruit_tree_changes[raw_tree]):
-			next_fruit_trees[tree] = true
-		else:
-			next_fruit_trees.erase(tree)
-	var next_just_battled: bool = bool(
-		runtime_changes.get("just_battled", _just_battled)
-	)
-	var karp_changed: bool = next_karp_feet != _best_magikarp_feet \
-		or next_karp_inches != _best_magikarp_inches or next_karp_ot != _best_magikarp_ot
-
-	var did_change: bool = next_flags != _event_flags or next_engine_flags != _engine_flags \
-		or next_scenes != _map_scenes \
-		or next_items != _items or next_pc_items != _pc_items \
-		or next_items.keys() != _items.keys() \
-		or next_pc_items.keys() != _pc_items.keys() \
-		or next_money != _money or next_coins != _coins \
-		or next_contacts != _phone_contacts or next_just_battled != _just_battled \
-		or next_seen_species != _seen_species \
-		or next_caught_species != _caught_species \
-		or next_repel_steps != _repel_steps or next_swarm_maps != _swarm_maps \
-		or next_fishing_swarm_species != _fishing_swarm_species \
-		or next_receive_cycle != _phone_receive_cycle \
-		or next_receive_minutes != _phone_receive_minutes \
-		or next_special_phone_call != _pending_special_phone_call \
-		or next_script_memory != _script_memory \
-		or next_kurt_apricorns != _kurt_apricorn_quantity \
-		or next_fruit_trees != _picked_fruit_trees \
-		or next_blue_card != _blue_card_balance \
-		or next_mom_savings != _mom_savings_flags \
-		or next_kenji != _kenji_break_timer \
-		or next_lucky_days != _lucky_number_days_left or karp_changed \
-		or next_lucky_id != _lucky_id_number or next_lucky_day != _lucky_number_day
-	_event_flags = next_flags
-	_engine_flags = next_engine_flags
-	_map_scenes = next_scenes
-	_items = next_items
-	_pc_items = next_pc_items
-	_money = next_money
-	_seen_species = next_seen_species
-	_caught_species = next_caught_species
-	_coins = next_coins
-	_phone_contacts = next_contacts
-	_just_battled = next_just_battled
-	_repel_steps = next_repel_steps
-	_swarm_maps = next_swarm_maps
-	_fishing_swarm_species = next_fishing_swarm_species
-	_phone_receive_cycle = next_receive_cycle
-	_phone_receive_minutes = next_receive_minutes
-	_pending_special_phone_call = next_special_phone_call
-	_script_memory = next_script_memory
-	_kurt_apricorn_quantity = next_kurt_apricorns
-	_picked_fruit_trees = next_fruit_trees
-	_blue_card_balance = next_blue_card
-	_mom_savings_flags = next_mom_savings
-	_kenji_break_timer = next_kenji
-	_lucky_number_days_left = next_lucky_days
-	_lucky_id_number = next_lucky_id
-	_lucky_number_day = next_lucky_day
-	_best_magikarp_feet = next_karp_feet
-	_best_magikarp_inches = next_karp_inches
-	_best_magikarp_ot = next_karp_ot
+	var did_change: bool = false
+	for member: String in next:
+		var current: Variant = get(member)
+		if current != next[member]:
+			did_change = true
+		elif member in ORDERED_MEMBERS and current.keys() != (next[member] as Dictionary).keys():
+			did_change = true
+		set(member, next[member])
 	if did_change:
 		changed.emit()
 	return {"ok": true, "changed": did_change}
+
+
+## Fills [param next] with the member values [method apply_changes] would commit,
+## or answers why it may not.
+func _stage_changes(
+	flag_changes: Dictionary, scene_changes: Dictionary, runtime_changes: Dictionary,
+	next: Dictionary
+) -> StringName:
+	for raw_flag: Variant in flag_changes:
+		if int(raw_flag) < 0:
+			return &"invalid_event_flag"
+	next["_event_flags"] = _merged(_event_flags, flag_changes, MERGE_FLAGS)
+
+	var next_scenes: Dictionary = _map_scenes.duplicate()
+	for raw_map: Variant in scene_changes:
+		if String(raw_map).is_empty() or int(scene_changes[raw_map]) < 0:
+			return &"invalid_scene"
+		next_scenes[String(raw_map)] = int(scene_changes[raw_map])
+	next["_map_scenes"] = next_scenes
+
+	for row: Array in CHANGE_MAPS:
+		var changes: Variant = runtime_changes.get(row[0], {})
+		if not changes is Dictionary:
+			return row[6]
+		var row_reason: StringName = _map_reason(changes, row[3], row[4], row[5], row[7])
+		if row_reason != &"":
+			return row_reason
+		var merged: Dictionary = _merged(get(row[1]), changes, row[2])
+		if merged.size() > int(row[8]):
+			return row[9]
+		next[row[1]] = merged
+	## `SetSeenAndCaughtMon` sets both bits, so a species newly caught is seen
+	## whatever the caller passed.
+	var caught: Dictionary = runtime_changes.get("caught_species", {})
+	for raw_species: Variant in caught:
+		if bool(caught[raw_species]):
+			(next["_seen_species"] as Dictionary)[int(raw_species)] = true
+
+	var order_reason: StringName = _stage_orders(runtime_changes, next)
+	if order_reason != &"":
+		return order_reason
+
+	for row: Array in CHANGE_SCALARS:
+		var value: int = int(runtime_changes.get(row[0], get(row[1])))
+		if value < 0 or value > int(row[2]):
+			return row[3]
+		next[row[1]] = value
+	next["_just_battled"] = bool(runtime_changes.get("just_battled", _just_battled))
+
+	var swarm_reason: StringName = _stage_swarm(runtime_changes, next)
+	if swarm_reason != &"":
+		return swarm_reason
+	return _stage_magikarp(runtime_changes, next)
+
+
+## `SwitchItemsInBag`'s whole effect: the same items in another order. A quantity
+## map compares equal whatever order it holds, so a reorder has to be asked for
+## by name.
+func _stage_orders(runtime_changes: Dictionary, next: Dictionary) -> StringName:
+	for row: Array in [
+		["item_order", "_items", &"invalid_item_order"],
+		["pc_item_order", "_pc_items", &"invalid_pc_item_order"],
+	]:
+		var order: Variant = runtime_changes.get(row[0], null)
+		if order == null:
+			continue
+		if not order is Array or not _is_permutation(next[row[1]], order):
+			return row[2]
+		next[row[1]] = _reordered(next[row[1]], order)
+	return &""
+
+
+## The Dunsparce and Yanma swarm maps and the fishing swarm that shares their
+## script. An inactive swarm clears its map rather than carrying one nothing
+## reads.
+func _stage_swarm(runtime_changes: Dictionary, next: Dictionary) -> StringName:
+	var maps: Array[Vector2i] = _swarm_maps.duplicate()
+	next["_swarm_maps"] = maps
+	next["_fishing_swarm_species"] = _fishing_swarm_species
+	var change: Variant = runtime_changes.get("swarm", null)
+	if change == null:
+		return &""
+	if not change is Dictionary:
+		return &"invalid_swarm"
+	var swarm: Dictionary = change
+	var active: bool = bool(swarm.get("active", true))
+	var group: int = int(swarm.get("map_group", -1))
+	var number: int = int(swarm.get("map_number", -1))
+	if active and (group < 0 or number < 0):
+		return &"invalid_swarm_map"
+	var species: int = int(swarm.get("fishing_species", 0))
+	if species not in [0, 0xD3, 0xDF]:
+		return &"invalid_fishing_swarm_species"
+	var kind: int = int(swarm.get("kind", SWARM_DUNSPARCE))
+	if kind != SWARM_DUNSPARCE and kind != SWARM_YANMA:
+		return &"invalid_swarm_kind"
+	maps[kind] = Vector2i(group, number) if active else Vector2i(-1, -1)
+	next["_fishing_swarm_species"] = species
+	return &""
+
+
+## `sBestMagikarpLength`: feet, inches and the trainer who caught it, written
+## together or not at all.
+func _stage_magikarp(runtime_changes: Dictionary, next: Dictionary) -> StringName:
+	next["_best_magikarp_feet"] = _best_magikarp_feet
+	next["_best_magikarp_inches"] = _best_magikarp_inches
+	next["_best_magikarp_ot"] = _best_magikarp_ot
+	var change: Variant = runtime_changes.get("best_magikarp", null)
+	if change == null:
+		return &""
+	if not change is Dictionary:
+		return &"invalid_best_magikarp"
+	var feet: int = int((change as Dictionary).get("feet", 0))
+	var inches: int = int((change as Dictionary).get("inches", 0))
+	if feet < 0 or feet > 0xFF or inches < 0 or inches > 0xFF:
+		return &"invalid_best_magikarp"
+	next["_best_magikarp_feet"] = feet
+	next["_best_magikarp_inches"] = inches
+	next["_best_magikarp_ot"] = String((change as Dictionary).get("ot", ""))
+	return &""

--- a/game/world/world_tmhm.gd
+++ b/game/world/world_tmhm.gd
@@ -1,16 +1,13 @@
 class_name Gen2WorldTMHM
 extends RefCounted
 
-## Scene-free tables and gates for teaching a TM or HM
-## (engine/items/tmhm.asm, engine/items/tmhm2.asm).
-##
-## The TM/HM pocket does not reach `UseItem`'s jumptable at all: its own USE
-## entry runs AskTeachTMHM, then ChooseMonToLearnTMHM, then TeachTMHM
-## (engine/items/pack.asm's .UseItem). This class owns the first and the checks
-## the third makes; Gen2WorldPartyHost.teach_tm_hm() owns the transaction.
-##
-## Everything here is byte identical between the pins. pokegold's TeachTMHM
-## differs by one line, a stubbed trainer-ranking call that does nothing.
+## Scene-free tables and gates for teaching a TM or HM (engine/items/tmhm.asm).
+## The TM/HM pocket does not reach `UseItem`'s jumptable at all: its own USE entry
+## runs AskTeachTMHM, then ChooseMonToLearnTMHM, then TeachTMHM. This class owns
+## the first and the checks the third makes;
+## [method Gen2WorldPartyHost.teach_tm_hm] owns the transaction. Everything here is
+## byte identical between the pins, pokegold's TeachTMHM differing by one line, a
+## stubbed trainer-ranking call that does nothing.
 
 ## constants/item_constants.asm. The run from TM01 to HM07 is not contiguous:
 ## ITEM_C3 and ITEM_DC sit inside it as dummies, which is why the number a TM

--- a/game/world/world_transaction.gd
+++ b/game/world/world_transaction.gd
@@ -1,18 +1,14 @@
 class_name Gen2WorldTransaction
 extends RefCounted
 
-## The commit boundary every world-owned transaction here shares.
-##
-## A mart purchase, Kurt's apricorns, a party request, a heal, a field item and
-## the pack's TOSS all do the same four things around whatever they actually
-## change: validate the save they were handed, build a candidate from it,
-## validate that candidate against the world it now describes and write it, and
-## put the live world back when any of the three refuses. That shape was
-## repeated in three hosts; it lives here instead.
-##
-## Scene-free and save-model-free: it validates through [Gen2SaveValidator] and
-## writes through [Gen2SaveStore], and knows nothing about what the caller
-## changed.
+## The commit boundary every world-owned transaction here shares. A mart purchase,
+## Kurt's apricorns, a party request, a heal, a field item and the pack's TOSS all
+## do the same four things around whatever they change: validate the save they were
+## handed, build a candidate from it, validate that candidate against the world it
+## now describes and write it, and put the live world back when any of the three
+## refuses. That shape was repeated in three hosts. Scene-free and
+## save-model-free: it validates through [Gen2SaveValidator] and writes through
+## [Gen2SaveStore], and knows nothing about what the caller changed.
 
 ## Validates [param save] and returns a candidate to work on, which is a full
 ## copy rather than a reference: nothing a caller writes to it reaches the live
@@ -110,15 +106,13 @@ static func copy_into(target: Gen2SaveData, source: Gen2SaveData) -> void:
 	target.run_rules = source.run_rules.duplicate_rules() if source.run_rules != null else null
 	target.boxes_shape_valid = source.boxes_shape_valid
 	## `game_time` is the one field the live save owns rather than the candidate:
-	## `Gen2WorldScreen._advance_game_time_frame` has been counting frames into it
-	## since the candidate was cloned, and copying the clone back loses them.
-	##
-	## This list is deliberately named field by field rather than delegated to
-	## [method Gen2SaveData.copy_from], which round-trips through `to_dict` and
-	## would rebuild every party member and renormalize the mod keys on every
+	## the screen has been counting frames into it since the candidate was cloned,
+	## and copying the clone back loses them. This list is deliberately named field
+	## by field rather than delegated to [method Gen2SaveData.copy_from], which
+	## round-trips through `to_dict` and would rebuild every party member on every
 	## commit. `test_the_transaction_write_back_carries_every_field_but_the_live_clock`
-	## is what keeps the two lists in step: a field added to the save and
-	## forgotten here fails there.
+	## keeps the two lists in step: a field added to the save and forgotten here
+	## fails there.
 
 
 static func failure(reason: StringName, details: Dictionary) -> Dictionary:

--- a/mods/examples/voxel_preview/renderer.gd
+++ b/mods/examples/voxel_preview/renderer.gd
@@ -1,21 +1,13 @@
 extends SubViewportContainer
 
-## A world renderer that draws geometry instead of hardware tiles.
-##
-## The point is that nothing about the world requires the view to be 2D. It reads
-## exactly what the built-in renderer reads (each walk cell's collision
-## permission, the block grid, the tileset's palettes, the player's cell) and
-## extrudes a solid per cell with a camera on the player.
-##
-## It answers [code]uses_hardware_viewport[/code] false, so it gets the screen's
-## own rectangle at window resolution rather than a 160x144 buffer, which under
-## SCREEN FILL is the whole window. Text boxes and menus stay hardware pixels
-## over the top, inside the rectangle [method set_screen_rect] names, and the
-## letterbox around them is this view's own to draw ([method
-## set_interface_masked]) because the screen's cannot reach this layer.
-##
-## It reads the world and never writes it, so the two renderers can be swapped
-## mid-step and neither can tell the other what changed.
+## A world renderer that draws geometry instead of hardware tiles. The point is
+## that nothing about the world requires the view to be 2D: it reads exactly what
+## the built-in renderer reads and extrudes a solid per cell with a camera on the
+## player. It answers `uses_hardware_viewport` false, so it gets the screen's own
+## rectangle at window resolution, and the letterbox around the hardware-pixel
+## boxes over it is this view's own to draw because the screen's cannot reach this
+## layer. It reads the world and never writes it, so the two renderers can be
+## swapped mid-step and neither can tell the other what changed.
 
 ## What mod.json declares, which is how the renderer names itself to the host
 ## when it reads its own settings back.

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -822,22 +822,14 @@ func test_a_transformed_side_draws_the_species_it_copied() -> void:
 	assert_false(bool(renderer._view["player_shiny"]))
 
 
-## The whole entrance as `view["battlers"]` reports it, one side at a time: who
-## is standing on each square, and how far off it they are.
-##
-## This is the field a renderer with no background plane has instead of the
-## scanline scroll and the blanking `bg_map` columns, so it is asserted as the
-## sequence a fight actually opens with rather than at one sampled frame: two
-## trainers slide in, each walks off its own square, and a Pokemon takes it.
-##
-## The two sides do not pass through the same states, and the reason is one line
-## of the source. `ShowBattleTextEnemySentOut` waits on a press, so the
-## opponent's square stands empty for as long as the player takes to read it;
-## `SendOutMonText` "ends in `done`" and prints with the ball already in the air,
-## so the player's square is never empty at the end of a frame. That also costs
-## the player's walk its last step at a frame boundary: the ninth column shifts
-## and the Pokemon is stamped in the same frame, so what a renderer is handed is
-## the eighth, which is what every other field says at that frame too.
+## The whole entrance as `view["battlers"]` reports it, one side at a time: who is
+## standing on each square, and how far off it they are. This is the field a
+## renderer with no background plane has instead of the scanline scroll, so it is
+## asserted as the sequence a fight actually opens with rather than at one sampled
+## frame. The two sides do not pass through the same states, and the reason is one
+## line of the source: `ShowBattleTextEnemySentOut` waits on a press, so the
+## opponent's square stands empty, while `SendOutMonText` ends in `done` and prints
+## with the ball already in the air.
 func test_the_entrance_says_who_is_on_each_square_and_how_far_off_it() -> void:
 	await _open_battle()
 	_battle_screen.show_trainer(Fixture.TRAINER_CLASS, 0)

--- a/tests/integration/test_renderer_interface.gd
+++ b/tests/integration/test_renderer_interface.gd
@@ -1,15 +1,12 @@
 extends GutTest
 
-## The interface seam a native-layer renderer gets: how opaque the screen draws
-## its own text box, where that box is, when a screen laid out in 160x144 takes
-## the picture over it, and whether the surface it is handed fills the window.
-## Plus the seam a mod's world actor gets, which is the same shape one layer
-## down. Both screens are the production paths; only the renderer and the actor
-## are synthetic.
-##
-## The contract is that the box stays the screen's. A renderer asks and is told;
-## it never draws or moves the box, and the frame and the glyphs are opaque
-## whatever it asks for, so nothing it can request makes text harder to read.
+## The interface seam a native-layer renderer gets: how opaque the screen draws its
+## own text box, where that box is, when a screen laid out in 160x144 takes the
+## picture over it, and whether the surface it is handed fills the window. Plus the
+## seam a mod's world actor gets, which is the same shape one layer down. Both
+## screens are the production paths; only the renderer and the actor are synthetic.
+## The contract is that the box stays the screen's: a renderer asks and is told, and
+## the frame and the glyphs are opaque whatever it asks for.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -1,24 +1,13 @@
 extends GutTest
 
-## `StepVectors`' normal row (`engine/overworld/map_objects.asm`): two pixels a
-## pass for eight passes, which is one cell.
-##
-## A pass is not a frame. `HandleMap` ends every iteration in
-## `NextOverworldFrame`, whose `MaxOverworldDelay` is 2, so the whole overworld
-## runs once per two hardware frames and an ordinary walk step takes sixteen.
-## Measured on a real cartridge, `.claude/oracle/overworld/trace_walk.py` on
-## Route 29: `wPlayerStepDuration` counts 7 down to 0 over frames 19 to 34 while
-## `wPlayerSpriteX` walks 208 to 224 two pixels at a time, and a hook on
-## `HandleMapObjects` fires on every other frame and no other.
-##
-## The constant on its own is not the question; the pacing around it is. A step
-## that costs nine passes because the pass the last one ended on is spent
-## starting the next reads as sluggish, and no constant would be wrong. In the
-## source it costs eight: `HandleObjectStep`'s `.one` calls
-## `StepFunction_FromMovement`, and when that starts a step the step type is no
-## longer STEP_TYPE_FROM_MOVEMENT, so the `ret z` is skipped and `.ok3` runs the
-## new step function on the same frame. `StepFunction_PlayerWalk`'s `.init`
-## falls into `.step`, which moves.
+## `StepVectors`' normal row: two pixels a pass for eight passes, which is one
+## cell. A pass is not a frame, `MaxOverworldDelay` being 2, so an ordinary walk
+## step takes sixteen. Measured on a real cartridge on Route 29:
+## `wPlayerStepDuration` counts 7 down to 0 over frames 19 to 34 while
+## `wPlayerSpriteX` walks 208 to 224 two pixels at a time. The constant on its own
+## is not the question; the pacing around it is. In the source a step costs eight
+## passes rather than nine because `.ok3` runs the new step function on the same
+## frame, and `StepFunction_PlayerWalk`'s `.init` falls into `.step`.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1,15 +1,13 @@
 extends GutTest
 
-## Scene integration for Cut, Surf and Whirlpool: the party submenu, the
-## field-move message and the change each commits, driven through the production
-## world screen and party screen.
-##
-## The shared trainer fixture is patched here rather than extended, the same way
-## test_world_start_menu_screen.gd patches its Potion in: the map moves onto
-## TILESET_JOHTO so the real CutTreeBlockPointers and WhirlpoolBlockPointers rows
-## apply, block $5b's bottom-left quadrant becomes the cut tree and block $07's
-## the whirlpool. The fixture's own water cell at (8,7) is what Surf is driven
-## against.
+## Scene integration for Cut, Surf and Whirlpool: the party submenu, the field-move
+## message and the change each commits, driven through the production world screen
+## and party screen. The shared trainer fixture is patched here rather than
+## extended, the same way test_world_start_menu_screen.gd patches its Potion in:
+## the map moves onto TILESET_JOHTO so the real CutTreeBlockPointers and
+## WhirlpoolBlockPointers rows apply, block $5b's bottom-left quadrant becomes the
+## cut tree and block $07's the whirlpool. The fixture's own water cell at (8,7) is
+## what Surf is driven against.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 const BattleFixture := preload("res://tests/unit/battle_fixture.gd")

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -2214,14 +2214,12 @@ func test_a_ball_that_missed_costs_the_turn() -> void:
 
 ## `PokeBallEffect` plays `ANIM_THROW_POKE_BALL` between the throw text and the
 ## result text, and that one script is the whole capture: the ball, the poof, the
-## opponent going into it through `BATTLE_BG_EFFECT_RETURN_MON`, the wobbles that
-## `anim_checkpokeball` counts out, and the click or the break free. Nothing
-## played it here, so no renderer could draw a capture and the built-in one drew
-## nothing either.
-##
-## This fixture ships no animation layer, so what it can say is that the screen
-## asks for the animation and spends its frames. What the script then draws is
-## swept against real caches by `tools/checks/battle_anims.gd`.
+## opponent going into it, the wobbles `anim_checkpokeball` counts out, and the
+## click or the break free. Nothing played it here, so no renderer could draw a
+## capture and the built-in one drew nothing either. This fixture ships no
+## animation layer, so what it can say is that the screen asks for the animation
+## and spends its frames; what the script then draws is swept against real caches
+## by `tools/checks/battle_anims.gd`.
 func test_a_thrown_ball_asks_for_the_throw_animation() -> void:
 	await _open_world()
 	_data.species(Fixture.TRAINER_SPECIES)["catch_rate"] = 1

--- a/tests/integration/test_world_unown_puzzle.gd
+++ b/tests/integration/test_world_unown_puzzle.gd
@@ -1,13 +1,11 @@
 extends GutTest
 
 ## Scene integration for `special UnownPuzzle`, which is the whole line from the
-## chamber's script to the `iftrue` it branches on.
-##
-## `UnownPuzzle` is `FadeToMenu`, the board, and then
-## `ld a, [wSolvedUnownPuzzle] / ld [wScriptVar], a`, so the two things a unit
-## test cannot see are covered here: the board owns the screen while it is up,
-## and what it answers reaches the script. [Gen2UnownPuzzle]'s own rules are
-## `tests/unit/test_unown_puzzle.gd` and the art is
+## chamber's script to the `iftrue` it branches on. `UnownPuzzle` is `FadeToMenu`,
+## the board, and then `ld a, [wSolvedUnownPuzzle] / ld [wScriptVar], a`, so the
+## two things a unit test cannot see are covered here: the board owns the screen
+## while it is up, and what it answers reaches the script. [Gen2UnownPuzzle]'s own
+## rules are `tests/unit/test_unown_puzzle.gd` and the art is
 ## `tools/checks/unown_puzzle.gd`.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -1,14 +1,11 @@
 extends RefCounted
 
-## A cache the battle tests are fought inside.
-##
-## Not a fake cartridge: a real cache directory with a handful of real species
-## and moves, written the way the importer writes one. The battle engine reads
-## cartridge content only through [GameData], so four Pokémon exercise the same
-## path 251 do and the suite runs on a machine with no ROM.
-##
-## The numbers are the published ones, so a stat or damage figure in a test can
-## be checked against a calculator rather than against this file.
+## A cache the battle tests are fought inside. Not a fake cartridge: a real cache
+## directory with a handful of real species and moves, written the way the importer
+## writes one. The battle engine reads cartridge content only through [GameData],
+## so four Pokemon exercise the same path 251 do and the suite runs on a machine
+## with no ROM. The numbers are the published ones, so a stat or damage figure in a
+## test can be checked against a calculator rather than against this file.
 
 const PIKACHU: int = 25
 const GEODUDE: int = 74

--- a/tests/unit/test_battle_animation_commands.gd
+++ b/tests/unit/test_battle_animation_commands.gd
@@ -1,14 +1,12 @@
 extends GutTest
 
-## The five routes an animation reaches the screen by.
-##
-## `moveanim` and `moveanimnosub` sit in the effect lists, `statupanim` and
-## `statdownanim` between a stat change and its message, and `AnimateCurrentMove`
-## inside individual command bodies rather than in any list at all. Those four
-## are the move's own animation. `PlayOpponentBattleAnim` is the fifth and is
-## not: five secondary-effect commands play a status animation on the target,
-## with `hBattleTurn` inverted for its length. All five write the same event,
-## since the engine is scene-free and the screen is what spends the frames.
+## The five routes an animation reaches the screen by. `moveanim` and
+## `moveanimnosub` sit in the effect lists, `statupanim` and `statdownanim` between
+## a stat change and its message, and `AnimateCurrentMove` inside individual command
+## bodies rather than in any list at all; those four are the move's own animation.
+## `PlayOpponentBattleAnim` is the fifth and is not: five secondary-effect commands
+## play a status animation on the target, with `hBattleTurn` inverted for its
+## length. All five write the same event, since the engine is scene-free.
 
 const Fixture := preload("res://tests/unit/battle_fixture.gd")
 

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -181,15 +181,12 @@ func test_the_hp_bar_fill_is_drawn_apart_from_the_panel() -> void:
 	assert_eq(_ink_in_row(empty, Gen2BattleHud.ENEMY_BAR.y), 0, "a fainted bar draws nothing")
 
 
-## `PlaceExpBar` takes a pixel count in `b`, and it is never a ratio:
-## `CalcExpBar` has already divided. It starts at `hlcoord 17, 11` and writes
-## with `ld [hld], a`, so the full tiles land at the right-hand end and the run
-## walks left, and unlike `DrawBattleHPBar` it lays no empty template first:
-## every tile the fill did not reach is written $62 by `.loop2`.
-##
-## The fixture fills each sheet with one index, so a column says which sheet
-## drew it: the seven partial fills are the exp bar's own (2) and the empty and
-## full tiles are the battle font's (1). A column of 0 is a hole.
+## `PlaceExpBar` takes a pixel count in `b`, and it is never a ratio: `CalcExpBar`
+## has already divided. It starts at `hlcoord 17, 11` and writes with `ld [hld], a`,
+## so the full tiles land at the right-hand end and the run walks left, and unlike
+## `DrawBattleHPBar` it lays no empty template first: every tile the fill did not
+## reach is written $62 by `.loop2`. The fixture fills each sheet with one index, so
+## a column says which sheet drew it, and a column of 0 is a hole.
 func test_the_exp_bar_is_drawn_from_a_pixel_count() -> void:
 	_write_cache()
 	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())

--- a/tests/unit/test_party_menu_page.gd
+++ b/tests/unit/test_party_menu_page.gd
@@ -1,19 +1,13 @@
 extends GutTest
 
 ## `WritePartyMenuTilemap`'s `PARTYMENUACTION_SWITCH` columns and
-## `PlacePartyMenuText`'s box (`engine/pokemon/party_menu.asm`), checked by where
-## the ink lands rather than by eye.
-##
-## Every sheet in the cache is filled with one index, so a glyph is a solid tile
-## and a column that drew something can be told from one that did not. That is
-## the whole claim here: the page is geometry, and the drawing under it is
-## [Gen2Font]'s and [Gen2BattleHud]'s own.
-##
-## The battle-extra strip is filled with a different index from the rest, since
-## the bars come off it and are the one thing on the page drawn through a palette
-## that is not black on white. The icons are the other: one fixture shape whose
-## two frames carry different indices, so which pass is on screen and where it
-## landed can both be read off the picture.
+## `PlacePartyMenuText`'s box, checked by where the ink lands rather than by eye.
+## Every sheet in the cache is filled with one index, so a glyph is a solid tile and
+## a column that drew something can be told from one that did not: the page is
+## geometry, and the drawing under it is [Gen2Font]'s and [Gen2BattleHud]'s own. The
+## battle-extra strip is filled with a different index, since the bars come off it
+## and are the one thing drawn through a palette that is not black on white; the
+## icons are the other, one shape whose two frames carry different indices.
 
 ## The fixture's one icon shape and the species that names it, plus the two
 ## colours its frames are drawn in.

--- a/tests/unit/test_slot_machine.gd
+++ b/tests/unit/test_slot_machine.gd
@@ -1,15 +1,13 @@
 extends GutTest
 
-## `_SlotMachine`'s rules (engine/games/slot_machine.asm), driven headless.
-##
-## The reel strips here are the cartridge's own, so a window is a real one; the
-## art is `tools/checks/slots.gd` and the screen around it
-## `tests/integration/test_world_slot_machine.gd`.
-##
-## What is asserted is what a reading gets wrong rather than what a spin looks
-## like: that a bet is taken once and paid once, that an unbiased spin can only
-## stop where nothing is lined up, that a seven keeps its own bias, and that the
-## payout animation walks the coins over rather than adding them at once.
+## `_SlotMachine`'s rules (engine/games/slot_machine.asm), driven headless. The
+## reel strips here are the cartridge's own, so a window is a real one; the art is
+## `tools/checks/slots.gd` and the screen around it
+## `tests/integration/test_world_slot_machine.gd`. What is asserted is what a
+## reading gets wrong rather than what a spin looks like: that a bet is taken once
+## and paid once, that an unbiased spin can only stop where nothing is lined up,
+## that a seven keeps its own bias, and that the payout animation walks the coins
+## over rather than adding them at once.
 
 const REELS: Array = [
 	[

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -1,0 +1,274 @@
+extends GutTest
+
+## The source budget: how much branching and how much prose the tree is allowed.
+## Both are capped because both track defect count the way line count does, and a
+## ceiling nothing measures is a wish. `CLAUDE.md`'s "The budget" is this table
+## in prose; this file is what fails.
+
+const ROOTS: Array[String] = ["autoload", "game", "mods", "tests", "tools"]
+## Where the comment total is counted. The tests and the shipped example mods are
+## left out: one is scaffolding and the other is written to be read.
+const COUNTED_ROOTS: Array[String] = ["autoload", "game", "tools"]
+## The project on disk. `res://` is the wrong door here: a test that has mounted
+## a resource pack leaves entries under it whose backing zip is closed, and
+## walking those raises `Parameter "zfile" is null` from inside the tier.
+static var PROJECT: String = ProjectSettings.globalize_path("res://")
+
+const MAX_COMPLEXITY: int = 20
+const MAX_COMMENT_BLOCK: int = 8
+## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
+## it whenever a pass leaves room, and never raise it.
+const MAX_COMMENT_LINES: int = 37924
+
+## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Delete
+## a line when you fix one. The test fails on a line that no longer names a
+## function over the ceiling, so this cannot rot and cannot grow.
+const OVER_COMPLEXITY: Array[String] = [
+	"game/audio/gen2_apu.gd:_render_square",
+	"game/audio/gen2_apu.gd:write",
+	"game/audio/gen2_sound_engine.gd:_parse_music_command",
+	"game/battle/ai.gd:_apply_basic",
+	"game/battle/ai.gd:_apply_smart",
+	"game/battle/battle_screen.gd:_describe",
+	"game/battle/battle_screen.gd:_handle_button",
+	"game/battle/battle_screen.gd:_refresh_menu_layer",
+	"game/battle/battle_screen.gd:start_world_battle",
+	"game/battle/effect_commands.gd:_check_hit",
+	"game/data/content_overlay.gd:_validate_fields",
+	"game/data/world_catalog.gd:_attribute_maps",
+	"game/import/lz_decompressor.gd:decompress",
+	"game/import/rom_importer.gd:_read_one_trainer",
+	"game/import/rom_importer.gd:_verify_gs_title",
+	"game/import/rom_importer.gd:_verify_presents_sprites",
+	"game/import/rom_importer.gd:import_rom",
+	"game/import/rom_importer.gd:verify_battle_graphics",
+	"game/import/rom_importer.gd:verify_battle_tower",
+	"game/import/rom_importer.gd:verify_mail",
+	"game/import/rom_importer.gd:verify_town_map",
+	"game/import/text_stream.gd:_run",
+	"game/import/world_encounter_importer.gd:_read_roaming_maps",
+	"game/import/world_encounter_importer.gd:read_bug_contest",
+	"game/import/world_importer.gd:_read_events",
+	"game/import/world_importer.gd:_read_map",
+	"game/import/world_importer.gd:import_to_cache",
+	"game/launcher/launcher_button.gd:repaint",
+	"game/mods/mod_host.gd:register_menu_entry",
+	"game/mods/mod_manifest.gd:from_dictionary",
+	"game/render/intro_movie_page.gd:_draw_background",
+	"game/save/party_screen.gd:_confirm",
+	"game/save/save_battle_adapter.gd:from_battle_party",
+	"game/save/save_data.gd:from_dict",
+	"game/save/save_validator.gd:validate",
+	"game/world/battle_tower.gd:action",
+	"game/world/intro_movie.gd:_run_scene",
+	"game/world/radio_show.gd:_run",
+	"game/world/slot_machine.gd:_reel_action",
+	"game/world/start_menu_screen.gd:_confirm",
+	"game/world/start_menu_screen.gd:_hardware_image",
+	"game/world/start_menu_screen.gd:_move",
+	"game/world/world_animation.gd:tick",
+	"game/world/world_api.gd:_apply_object_movement",
+	"game/world/world_api.gd:_enqueue_script",
+	"game/world/world_api.gd:can_object_walk_to",
+	"game/world/world_api.gd:encounter_request",
+	"game/world/world_bag_host.gd:give_to_party",
+	"game/world/world_battle.gd:prepare",
+	"game/world/world_decoration.gd:apply",
+	"game/world/world_encounter.gd:resolve",
+	"game/world/world_encounter.gd:resolve_fishing",
+	"game/world/world_host.gd:_resolve_data_request",
+	"game/world/world_mart_host.gd:purchase",
+	"game/world/world_party_host.gd:_apply_item_effect",
+	"game/world/world_party_host.gd:_apply_party_request",
+	"game/world/world_party_host.gd:capture_wild",
+	"game/world/world_party_host.gd:teach_tm_hm",
+	"game/world/world_renderer.gd:_draw",
+	"game/world/world_screen.gd:_apply_interface_mask",
+	"game/world/world_screen.gd:_handle_button",
+	"game/world/world_screen.gd:_overlay_open",
+	"game/world/world_screen.gd:_run_party_action",
+	"game/world/world_script.gd:command_at",
+	"game/world/world_script.gd:scan_references",
+	"game/world/world_script_runner.gd:_complete",
+	"game/world/world_script_runner.gd:_execute",
+	"game/world/world_script_runner.gd:_execute_later_command",
+	"game/world/world_script_runner.gd:_execute_special",
+	"game/world/world_script_runner.gd:_read_runtime_variable",
+	"game/world/world_script_runner.gd:complete_runtime_request",
+	"game/world/world_service_screen.gd:_confirm_pc_row",
+	"tools/checks/opening_lane.gd:_validate",
+	"tools/checks/pokedex.gd:_validate",
+	"tools/checks/radio.gd:_verify_shows",
+	"tools/preview_battle_switch.gd:_open",
+	"tools/preview_town_map.gd:_initialize",
+	"tools/preview_world.gd:_initialize",
+	"tools/preview_world.gd:_process",
+	"tools/preview_world_story.gd:_drain_story",
+	"tools/preview_world_story.gd:_fog_badge_path",
+	"tools/preview_world_story.gd:_glacier_badge_path",
+	"tools/preview_world_story.gd:_hive_badge_path",
+	"tools/preview_world_story.gd:_mineral_badge_path",
+	"tools/preview_world_story.gd:_plain_badge_path",
+	"tools/preview_world_story.gd:_story_path",
+	"tools/record_clip.gd:_initialize",
+	"tools/record_clip.gd:_process",
+	"tools/trace_world_script.gd:_run",
+]
+
+
+func test_no_function_is_over_the_complexity_ceiling() -> void:
+	var over: Array[String] = []
+	for path: String in _scripts():
+		var source: PackedStringArray = _lines(path)
+		for row: Dictionary in _functions(source):
+			if int(row["complexity"]) > MAX_COMPLEXITY:
+				over.append("%s:%s" % [path, row["name"]])
+	over.sort()
+	var listed: Array[String] = OVER_COMPLEXITY.duplicate()
+	listed.sort()
+	var added: Array[String] = _missing_from(over, listed)
+	var fixed: Array[String] = _missing_from(listed, over)
+	_report("over complexity %d and not listed" % MAX_COMPLEXITY, added)
+	_report("listed and no longer over the ceiling; delete the line", fixed)
+
+
+func test_no_comment_block_is_longer_than_the_ceiling() -> void:
+	var over: Array[String] = []
+	for path: String in _scripts():
+		var run: int = 0
+		var line_number: int = 0
+		for line: String in _lines(path):
+			line_number += 1
+			if line.strip_edges().begins_with("#"):
+				run += 1
+				continue
+			if run > MAX_COMMENT_BLOCK:
+				over.append("%s:%d is %d lines" % [path, line_number - run, run])
+			run = 0
+	_report("comment blocks over %d lines" % MAX_COMMENT_BLOCK, over)
+
+
+func test_the_comment_total_is_under_the_recorded_ceiling() -> void:
+	var total: int = 0
+	for path: String in _scripts():
+		if not _under(path, COUNTED_ROOTS):
+			continue
+		for line: String in _lines(path):
+			if line.strip_edges().begins_with("#"):
+				total += 1
+	assert_true(total <= MAX_COMMENT_LINES, "%d comment lines under %s, ceiling %d" % [
+		total, ", ".join(COUNTED_ROOTS), MAX_COMMENT_LINES,
+	])
+	if total < MAX_COMMENT_LINES:
+		gut.p("Comment lines: %d. Lower MAX_COMMENT_LINES to it." % total)
+
+
+## Fails with [param message] and prints every offender, since an assertion
+## message is truncated long before a list like this ends.
+func _report(message: String, offenders: Array[String]) -> void:
+	for entry: String in offenders:
+		gut.p("  %s" % entry)
+	assert_eq(offenders.size(), 0, message)
+
+
+## Every entry of [param wanted] that [param known] does not carry. Both are
+## sorted, so this is the difference either way round.
+func _missing_from(wanted: Array[String], known: Array[String]) -> Array[String]:
+	var out: Array[String] = []
+	for entry: String in wanted:
+		if not known.has(entry):
+			out.append(entry)
+	return out
+
+
+func _under(path: String, roots: Array[String]) -> bool:
+	for root: String in roots:
+		if path.begins_with(root + "/"):
+			return true
+	return false
+
+
+func _lines(path: String) -> PackedStringArray:
+	return FileAccess.get_file_as_string(PROJECT.path_join(path)).split("\n")
+
+
+## Every project script, by its path from the project root, in a stable order.
+## `addons/` is third-party.
+func _scripts() -> PackedStringArray:
+	var out := PackedStringArray()
+	for root: String in ROOTS:
+		_collect(root, out)
+	out.sort()
+	return out
+
+
+func _collect(directory: String, out: PackedStringArray) -> void:
+	var absolute: String = PROJECT.path_join(directory)
+	for file: String in DirAccess.get_files_at(absolute):
+		if file.ends_with(".gd"):
+			out.append(directory.path_join(file))
+	for child: String in DirAccess.get_directories_at(absolute):
+		_collect(directory.path_join(child), out)
+
+
+## Every top-level function in [param source] with its cyclomatic complexity,
+## counted the way a linter counts it: one for the function, one per `if`,
+## `elif`, `while`, `for`, `and`, `or` and inline `if`, and one per `match` arm.
+func _functions(source: PackedStringArray) -> Array[Dictionary]:
+	var branches := RegEx.create_from_string(
+		"(?<![A-Za-z0-9_.])(if|elif|while|for|and|or)(?![A-Za-z0-9_])"
+	)
+	var opener := RegEx.create_from_string("^(static\\s+)?func\\s+([A-Za-z0-9_]+)")
+	var out: Array[Dictionary] = []
+	var current: Dictionary = {}
+	## One entry per open `match`: the indent the statement sits at, so an arm is
+	## a line one deeper that ends in a colon.
+	var matches: Array[int] = []
+	for raw: String in source:
+		var code: String = _code(raw)
+		var text: String = code.strip_edges()
+		var opened: RegExMatch = opener.search(code)
+		if opened != null and not code.begins_with("\t"):
+			current = {"name": opened.get_string(2), "complexity": 1}
+			out.append(current)
+			matches.clear()
+			continue
+		if current.is_empty() or text.is_empty():
+			continue
+		var indent: int = code.length() - code.lstrip("\t").length()
+		while not matches.is_empty() and indent <= matches[matches.size() - 1]:
+			matches.resize(matches.size() - 1)
+		if not matches.is_empty() and indent == matches[matches.size() - 1] + 1 \
+			and text.ends_with(":"):
+			current["complexity"] = int(current["complexity"]) + 1
+		current["complexity"] = int(current["complexity"]) + branches.search_all(text).size()
+		if text.begins_with("match ") and text.ends_with(":"):
+			matches.append(indent)
+	return out
+
+
+## [param line] with its string literals and its comment blanked, so a keyword
+## inside a text never reads as a branch.
+func _code(line: String) -> String:
+	var out: String = ""
+	var quote: String = ""
+	var index: int = 0
+	while index < line.length():
+		var symbol: String = line[index]
+		if quote != "":
+			if symbol == "\\":
+				index += 2
+				out += "  "
+				continue
+			if symbol == quote:
+				quote = ""
+			out += " "
+		elif symbol == "\"" or symbol == "'":
+			quote = symbol
+			out += " "
+		elif symbol == "#":
+			break
+		else:
+			out += symbol
+		index += 1
+	return out

--- a/tests/unit/test_source_budget.gd.uid
+++ b/tests/unit/test_source_budget.gd.uid
@@ -1,0 +1,1 @@
+uid://bx0nnwxanh170

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4412,18 +4412,14 @@ func test_script_movement_steps_through_a_wall_the_way_normal_step_does() -> voi
 	assert_eq(world.player_cell, Vector2i(9, 6))
 
 
-## An applymovement applies its whole stream in one call, so every cell of the
-## path commits at once and the drawing is what trails. Presentation only: the
-## cells below are already the stream's last one while the offset is still two
-## behind it.
-## The four turning commands, which are not what their names suggest.
+## An applymovement applies its whole stream in one call, so every cell of the path
+## commits at once and the drawing is what trails.
+## Below, the four turning commands, which are not what their names suggest.
 ## `TurnStep` sets STEP_TYPE_TURN and never calls `InitStep`, so it only turns;
-## `turn_away`, `turn_in` and `turn_waterfall` all reach `TurningStep`, which
-## does call it, so each steps one cell in the direction it names and only the
-## spin over the top tells them from a plain step. `turn_away` does not reverse
-## anything. `engine/events/forced_movement.asm` is the case that shows it: a
-## whirlpool spins the player, `turn_in` steps them back off the tile, and they
-## would stand on it for good if it turned in place.
+## `turn_away`, `turn_in` and `turn_waterfall` all reach `TurningStep`, which does
+## call it, so each steps one cell in the direction it names. `turn_away` does not
+## reverse anything, and `engine/events/forced_movement.asm` is the case that shows
+## it: a whirlpool spins the player and `turn_in` steps them back off the tile.
 func test_the_turning_movement_commands_step_or_turn_as_their_source_does() -> void:
 	RomCache.write_json(RomCache.world_movements_path(_directory), {
 		# turn_step down, then turn_in up.

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1,14 +1,12 @@
 extends GutTest
 
 ## Field-move tables and the Cut, Surf and Whirlpool boundaries, against a
-## synthetic cache built for this file so the shared world fixture stays
-## untouched.
-##
-## The cache uses tileset number 1 (TILESET_JOHTO) so the real CutTreeBlockPointers
-## rows apply: block $5b is a tree replaced by $3c, block $03 is grass replaced
-## by $02. WhirlpoolBlockPointers names the same tileset, where block $07 is
-## replaced by $36. Tileset 5 is TILESET_PLAYERS_HOUSE, which neither source
-## table has an entry for.
+## synthetic cache built for this file so the shared world fixture stays untouched.
+## The cache uses tileset number 1 (TILESET_JOHTO) so the real
+## CutTreeBlockPointers rows apply: block $5b is a tree replaced by $3c, block $03
+## is grass replaced by $02. WhirlpoolBlockPointers names the same tileset, where
+## block $07 is replaced by $36. Tileset 5 is TILESET_PLAYERS_HOUSE, which neither
+## source table has an entry for.
 
 const TILESET_CUTTABLE: int = Gen2WorldFieldMove.TILESET_JOHTO
 const TILESET_NO_ENTRY: int = 5

--- a/tools/checks/backup_warp.gd
+++ b/tools/checks/backup_warp.gd
@@ -1,24 +1,13 @@
 extends RefCounted
 
 ## Verifies the backup warp against freshly imported real caches on all three
-## cartridges: `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`,
-## which `SavePlayerData` copies into `sCurMapData` and which two unrelated
-## routines both read.
+## cartridges: `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`, which
+## `SavePlayerData` copies into `sCurMapData` and which two unrelated routines both
+## read. Expected values come from the pinned pokecrystal and pokegold sources.
 ##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## home/map.asm's `CopyWarpData` and `GetWarpDestCoords`, home/region.asm's
-## `IsInJohto`, engine/overworld/landmarks.asm's `RegionCheck`,
-## engine/overworld/scripting.asm's `Script_warpmod`, ram/wram.asm and
-## engine/menus/save.asm.
-##
-## The finding the topic carries: a `warp_event` whose destination is -1 names
-## no warp and no map of its own, and this port read the placeholder beside it,
-## so the stairs out of every Pokemon Center's second floor led nowhere. The
-## same three bytes are the landmark a `LANDMARK_SPECIAL` map borrows, so the
-## radio, the battle track, the town map and the dex area screen all answered
-## with Johto's defaults up there whatever region the player was in.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- backup_warp
+## The finding the topic carries: a `warp_event` whose destination is -1 names no
+## warp and no map of its own, and this port read the placeholder beside it, so the
+## stairs out of every Pokemon Center's second floor led nowhere.
 
 ## The six `warp_event`s in either corpus whose destination is -1, as
 ## [group, number, warp index]. Crystal and Gold and Silver disagree only on the

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -2,20 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Runs every battle animation out of a freshly imported real cache, on all
-## three cartridges, and checks the four tables behind them.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/moves/animations.asm's BattleAnimations, data/battle_anims/objects.asm,
-## framesets.asm, oam.asm and object_gfx.asm, and
-## engine/battle_anims/anim_commands.asm's own interpreter.
-##
-## The real-cartridge counterpart to tests/unit/test_battle_anim_script.gd. What
-## pins it is running all 278 to completion rather than spot checking: an
-## operand width that is wrong by one byte still decodes, and only walking every
-## body past every branch makes it fall over.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- battle_anims
+## Runs every battle animation out of a freshly imported real cache, on all three
+## cartridges, and checks the four tables behind them. Expected values come from
+## the pinned pokecrystal and pokegold sources: BattleAnimations, the three
+## data/battle_anims tables and the interpreter itself. The real-cartridge
+## counterpart to tests/unit/test_battle_anim_script.gd. What pins it is running
+## all 278 to completion rather than spot checking: an operand width that is wrong
+## by one byte still decodes, and only walking every body past every branch makes
+## it fall over.
 
 
 ## `assert_table_length` in each pinned data file. All five are shared by the
@@ -45,16 +39,14 @@ const EXPECTED_POUND: Array = [
 const DUMMY_INDEX: int = 0
 const POUND_INDEX: int = 1
 
-## Both shapes the profile split in data/moves/animations.asm takes, as the
-## whole `anim_bgeffect` sequence of the animation that shows each. Neither is
-## reachable without following the animation properly: every one of these
-## sequences opens and closes inside a subroutine.
-##
-## TACKLE shows the split in which routine is called: Crystal calls
-## `BattleAnim_TargetObj_2Row` and Gold and Silver `..._1Row`, and the two
-## differ only in the effect they run, `BATTLE_BG_EFFECT_BATTLEROBJ_2ROW` ($12)
-## against `..._1ROW` ($11). Its own `BATTLE_BG_EFFECT_TACKLE` ($24) and the
-## closing `BattleAnim_ShowMon_0`'s `..._SHOW_MON` ($0a) are shared.
+## Both shapes the profile split in data/moves/animations.asm takes, as the whole
+## `anim_bgeffect` sequence of the animation that shows each. Neither is reachable
+## without following the animation properly: every one of these sequences opens and
+## closes inside a subroutine. TACKLE shows the split in which routine is called:
+## Crystal calls `BattleAnim_TargetObj_2Row` and Gold and Silver `..._1Row`, and
+## the two differ only in the effect they run, `..._BATTLEROBJ_2ROW` ($12) against
+## `..._1ROW` ($11). Its own `BATTLE_BG_EFFECT_TACKLE` ($24) and the closing
+## `..._SHOW_MON` ($0a) are shared.
 const TACKLE_INDEX: int = 0x21
 const TACKLE_BG_EFFECTS: Dictionary = {
 	&"gold": [0x11, 0x24, 0x0A],
@@ -139,27 +131,14 @@ const SEND_OUT_EFFECTS: Dictionary = {0: [0x0B], 1: [0x01, 0x06]}
 const SEND_OUT_FRAMES: Dictionary = {0: 39, 1: 69}
 
 
-## TACKLE, frame by frame, against a real cartridge: `.claude/oracle/battle`'s
-## `trace_move_anim.py` reads the shadow OAM and `wBattleAnimDelay` of a live
-## fight, and these are the three runs of sprite counts it recorded.
-##
-## Fourteen is the target's two rows, lifted off the tilemap by
-## `anim_battlergfx_1row`; thirty adds `BATTLE_ANIM_OBJ_HIT_BIG_YFIX`, whose
-## frameset is `oamframe 0, 6` and so lasts seven frames.
-##
-## The last run is the one number a reading gets wrong. `anim_incobj 1` frees the
-## target's rows through `BattleAnimFunc_Null`, and `BattleAnim_UpdateOAM_All`
-## has already passed the index test for that slot, so the freed object is drawn
-## one last time: eleven frames, not ten. The cartridge's own frames are 26 to
-## 56, one of them a repeat of the frame before it, which is a loop that overran
-## VBlank rather than a state of its own.
-## Crystal's row is the measured one. Gold and Silver run
-## `BattleAnim_TargetObj_1Row` where Crystal runs `..._2Row`, which is the
-## profile split [constant TACKLE_BG_EFFECTS] already pins, so their target is
-## seven sprites rather than fourteen and every run length is the same.
-## Both sides are measured. On the enemy's turn the target is the player, whose
-## picture is six columns rather than seven, so the two runs differ by the two
-## rows and nothing else.
+## TACKLE, frame by frame, against a real cartridge: `trace_move_anim.py` reads the
+## shadow OAM and `wBattleAnimDelay` of a live fight, and these are the three runs
+## of sprite counts it recorded. Fourteen is the target's two rows and thirty adds
+## `BATTLE_ANIM_OBJ_HIT_BIG_YFIX`. The last run is the one number a reading gets
+## wrong: `anim_incobj 1` frees the target's rows after the index test has passed,
+## so the freed object is drawn one last time, eleven frames rather than ten.
+## Crystal's row is the measured one and Gold and Silver's target is seven sprites
+## rather than fourteen. Both sides are measured.
 const TACKLE_SPRITE_RUNS: Dictionary = {
 	&"crystal": [
 		[[14, 12], [30, 7], [14, 11], [0, 2]],
@@ -210,16 +189,10 @@ func _verify_tackle_frames(game_id: StringName, data: GameData) -> void:
 ## `ANIM_THROW_POKE_BALL`, which is the whole of a capture: the ball, the poof,
 ## `BATTLE_BG_EFFECT_RETURN_MON` taking the opponent off the field, the wobble
 ## loop, and either `.Click` or `.BreakFree`'s `..._ENTER_MON` putting it back.
-##
-## Only `anim_checkpokeball` decides which way the loop leaves, so the two
-## endings are two runs of the same script with two answers, and the sweep above
-## reaches neither: with no answers queued the loop takes the escape on its
-## first turn and the click body is never decoded.
-##
-## What is checked is what a renderer with no background plane reads, which is
-## the resize scripts reporting through the battler block rather than the
-## tilemap: the opponent is on its square, goes off it, and comes back only when
-## it got out.
+## Only `anim_checkpokeball` decides which way the loop leaves, so the two endings
+## are two runs of the same script with two answers, and the sweep above reaches
+## neither. What is checked is what a renderer with no background plane reads: the
+## opponent is on its square, goes off it, and comes back only when it got out.
 func _verify_the_thrown_ball(game_id: StringName, data: GameData) -> void:
 	var anims: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(data)
 	if not _r.check(anims != null, "%s: no battle animation data in the cache." % game_id):

--- a/tools/checks/battle_music.gd
+++ b/tools/checks/battle_music.gd
@@ -2,25 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies `PlayBattleMusic` (engine/battle/start_battle.asm) against freshly
-## imported real caches, on all three cartridges.
-##
-## The routine is a walk down a list of compares, so the failure it can have is
-## not an arithmetic one: it is a row that stops being reachable, or a track it
-## names that the audio importer does not hold. Both are swept here over the
-## whole corpus rather than sampled, which is two sweeps:
-##
-## - every map in the cache, through `RegionCheck`, so the wild rows are asked
-##   at every landmark the cartridge has rather than at one;
-## - every trainer class the cartridge ships and every individual trainer inside
-##   it, so the RIVAL2 id split and both leader lists are reached by real data.
-##
-## Every track either sweep names is then looked up in the imported audio index,
-## which is what says the piece can actually be played. Gold and Silver have no
-## `MUSIC_SUICUNE_BATTLE` and never write the two battle types that reach it, so
-## that row is asked of Crystal alone.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- battle_music
+## Verifies `PlayBattleMusic` against freshly imported real caches, on all three
+## cartridges. The routine is a walk down a list of compares, so its failure is a
+## row that stops being reachable or a track the audio importer does not hold. Both
+## are swept over the whole corpus: every map through `RegionCheck`, so the wild
+## rows are asked at every landmark, and every trainer class and individual trainer,
+## so the RIVAL2 id split and both leader lists are reached by real data. Every
+## track named is then looked up in the imported audio index. Gold and Silver never
+## reach `MUSIC_SUICUNE_BATTLE`, so that row is asked of Crystal alone.
 
 ## The two hours the wild rows split on. Only Johto has a night track.
 const HOURS: Array[int] = [Gen2WorldPalette.TIME_DAY, Gen2WorldPalette.TIME_NIGHT]

--- a/tools/checks/battle_tower.gd
+++ b/tools/checks/battle_tower.gd
@@ -3,20 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the Battle Tower against freshly imported real caches, on all three
-## games.
-##
-## Expected values come from the pinned pokecrystal source: the 70 rows of
-## data/battle_tower/classes.asm, the ten level groups of
-## data/battle_tower/parties.asm, data/trainers/genders.asm,
-## data/trainers/sprites.asm and mobile/mobile_46.asm's own menu strings. The
-## pins here are counted off the asm rather than read from [Gen2BattleTower]'s
-## own tables, so a mistranscribed row is a failure instead of an agreement.
-##
-## Gold and Silver ship no tower at all, which is checked as an absence rather
-## than as an empty table: the cartridge has no map, no routine and no data for
-## one, and a cache that claims otherwise is a wrong pin.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- battle_tower
+## games. Expected values come from the pinned pokecrystal source: the 70 class
+## rows, the ten level groups, the two per-class tables and the menu strings. The
+## pins are counted off the asm rather than read from [Gen2BattleTower]'s own
+## tables, so a mistranscribed row is a failure instead of an agreement. Gold and
+## Silver ship no tower at all, which is checked as an absence rather than as an
+## empty table: a cache that claims otherwise is a wrong pin.
 
 ## `BattleTowerTrainers`' four corners: the run's own ends and the two rows
 ## either side of `assert_table_length BATTLETOWER_NUM_UNIQUE_MON`, which is

--- a/tools/checks/card_flip.gd
+++ b/tools/checks/card_flip.gd
@@ -1,23 +1,13 @@
 extends RefCounted
 
-## Sweeps `_CardFlip` on freshly imported real caches, all three cartridges.
-##
-## Every expectation below is transcribed from pokecrystal's own
-## engine/games/card_flip.asm rather than read back out of the implementation,
-## which is the only way the topic can go red: the win jumptable's own
-## forty-eight entries, the deck's twenty-four pictures, the section's sizes and
-## the board's own tilemap are the source's tables, and the art is re-read out
-## of the dump beside the cache rather than compared with itself.
-##
-## The class of bug it exists to catch is a bet that pays the wrong cell.
-## `CardFlip_CheckWinCondition` is a jumptable of forty-eight, most of whose
-## entries differ from their neighbour by one bit test, so a cursor read one
-## cell out still pays *something*. The check therefore drives the whole
-## forty-eight by twenty-four grid against the jumptable rather than sampling,
-## and drives whole games on a pinned seed for the rest: the shuffle, the deck's
-## twelve rounds and the board's own discard marks.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- card_flip
+## Sweeps `_CardFlip` on freshly imported real caches, all three cartridges. Every
+## expectation is transcribed from pokecrystal's own engine/games/card_flip.asm
+## rather than read back out of the implementation, which is the only way the topic
+## can go red. The class of bug it exists to catch is a bet that pays the wrong
+## cell: `CardFlip_CheckWinCondition` is a jumptable of forty-eight, most of whose
+## entries differ from their neighbour by one bit test, so a cursor read one cell
+## out still pays something. It therefore drives the whole forty-eight by
+## twenty-four grid rather than sampling, and whole games on a pinned seed.
 
 ## `_CardFlip`'s own loads: which run is decompressed to how many tiles.
 const SECTION: Dictionary = {

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -3,21 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies [Gen2WorldCatalog] against freshly imported real caches, on all three
-## cartridges.
-##
-## The catalog is derived, not imported: it walks the decoded scripts and the map
-## events and calls certain shapes starters, gifts, statics, trades, prizes,
-## items, badges and shops. A derivation like that is exactly the thing that
-## quietly stops being true, so what is pinned here is not a count alone but the
-## SEMANTICS: the three starters are Chikorita, Cyndaquil and Totodile, the
-## badges are sixteen distinct ones, the legendaries are among the statics at
-## their own levels, and the Game Corner's prices are the cartridge's.
-##
-## A census pin catches a decode that drifts. A semantic pin catches a decode
-## that drifts into something still plausible, which is the failure a census
-## cannot see.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- catalog
+## cartridges. The catalog is derived rather than imported: it walks the decoded
+## scripts and map events and calls certain shapes starters, gifts, statics,
+## trades, prizes, items, badges and shops. A derivation like that quietly stops
+## being true, so what is pinned is not a count alone but the SEMANTICS: the three
+## starters by name, sixteen distinct badges, the legendaries among the statics at
+## their own levels, and the Game Corner's own prices. A census pin catches a decode
+## that drifts; a semantic pin catches one that drifts into something plausible.
 
 ## constants/pokemon_constants.asm.
 const CHIKORITA: int = 152

--- a/tools/checks/catch_rate.gd
+++ b/tools/checks/catch_rate.gd
@@ -3,22 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## `wFinalCatchRate` on all three cartridges, against what the cartridges
-## themselves answered.
-##
-## `PokeBallEffect` settles the whole catch rate before it rolls, so the answer
-## is a pure function of eleven bytes and can be asked of a real dump directly:
-## `.claude/oracle/battle/catch_rate.py` sets those bytes, runs the instructions
-## between `.get_multiplier_loop` and the `call Random` in `.skip_hp_calc`, and
-## prints one line per case. This topic builds the same 4,779 cases here.
-##
-## The sweep is the whole corpus: every species against every ball, because
-## Heavy, Moon, Fast and Love are the only rows that differ per species; every
-## byte boundary of the health term against every status bit; and Level Ball's
-## whole level ladder. What is pinned is the digest of all of them plus the rows
-## below, which name the branch each one proves, so a break is both caught and
-## readable.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- catch_rate
+## themselves answered. `PokeBallEffect` settles the whole catch rate before it
+## rolls, so the answer is a pure function of eleven bytes and can be asked of a
+## real dump directly; `.claude/oracle/battle/catch_rate.py` prints one line per
+## case and this topic builds the same 4,779 here. The sweep is the whole corpus:
+## every species against every ball, every byte boundary of the health term against
+## every status bit, and Level Ball's whole ladder. What is pinned is the digest
+## plus the rows below, which name the branch each one proves.
 
 ## `data/items/apricorn_balls.asm` and the four ordinary ones. MASTER_BALL is not
 ## here: it never reaches the multiplier table.

--- a/tools/checks/celadon.gd
+++ b/tools/checks/celadon.gd
@@ -3,24 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the way west from Saffron City to Celadon City and its gym against
-## freshly imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/SaffronCity.asm, maps/Route7SaffronGate.asm, maps/Route7.asm,
-## maps/CeladonCity.asm, maps/CeladonGym.asm and data/maps/attributes.asm.
-## Route7.asm, Route7SaffronGate.asm and all four .blk files are byte identical
-## between the pins; CeladonCity.asm and CeladonGym.asm differ only in NPC text
-## and an `_CRYSTAL_AU` block, so nothing here is profile split.
-##
-## Three things are worth pinning. Saffron has a real west connection to Route 7
-## and it is a dead end, landing in a sealed four-cell corner, so
-## `ROUTE_7_SAFFRON_GATE` carries that crossing the way it does the Route 6 one.
-## Route 7's own west edge is the open half: a real connection onto Celadon City
-## that needs no gate. And the gate that replaces it is inside the city, one
-## COLL_CUT_TREE on (28,35) sealing the whole gym yard, which makes Cut the price
-## of the Rainbow Badge the way it was of the Thunder Badge.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- celadon
+## freshly imported real caches, for both command profiles. Route7.asm, its gate
+## and all four .blk files are byte identical between the pins, so nothing here is
+## profile split. Three things are worth pinning: Saffron's west connection to
+## Route 7 is a dead end landing in a sealed four-cell corner; Route 7's own west
+## edge is the open half, a real connection onto Celadon that needs no gate; and
+## the gate that replaces it is inside the city, one COLL_CUT_TREE on (28,35)
+## sealing the whole gym yard, which makes Cut the price of the Rainbow Badge.
 
 
 ## constants/map_constants.asm: the CELADON group is 21 and the SAFFRON group 25.

--- a/tools/checks/cerulean.gd
+++ b/tools/checks/cerulean.gd
@@ -2,38 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the walk north from Saffron to Cerulean City and the way from there
-## to the Power Plant, against freshly imported real caches for both command
-## profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/SaffronCity.asm, maps/Route5SaffronGate.asm, maps/Route5.asm,
-## maps/CeruleanCity.asm, maps/CeruleanGym.asm, maps/Route9.asm,
-## maps/Route10North.asm, maps/PowerPlant.asm and data/maps/attributes.asm.
-##
-## The load-bearing finding is the last one. Misty and her three swimmers all
-## carry EVENT_TRAINERS_IN_CERULEAN_GYM as their hide flag and
-## `InitializeEventsScript` sets it, so the gym is empty until
-## `Route25MistyDate1Script` clears it; that scene is armed by the gym's own
-## grunt, and the grunt by `PowerPlantManager`. So the badge waits on the Power
-## Plant, and the plant is not walked to: Cerulean's east edge crosses on one
-## cell into a fourteen-cell pocket of Route 9 whose one cut tree opens 368 cells
-## reaching a single south crossing, and what that lands in is a yard holding
-## nothing but the Route 10 Pokecenter. The plant's own door sits in a region
-## with no map edge and no walkable neighbour, and Route 10 North's southern half
-## cannot even enter the water beside it, because row 14 is a buoy line whose own
-## permission walls its north face. The way in is Route 9's river, whose shore
-## the same cut opens: sixty cells of water that meet the south edge on columns
-## 56 and 57 and come out in Route 10 North's own lake, one step from the
-## plant's shore.
-##
-## The gym behind that errand is a pool. Its three swimmers stand on the water,
-## and the walk to Misty cannot avoid Diana's sight line or both of the other
-## two, so the badge needs approaches that cross water. They do, because
-## SeenByTrainerScript is `applymovementlasttalked` and NormalStep consults no
-## permission.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- cerulean
+## Verifies the walk north from Saffron to Cerulean City and the way from there to
+## the Power Plant, for both command profiles. The load-bearing finding: Misty and
+## her three swimmers all hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, cleared by a
+## scene armed by the gym's grunt and he by `PowerPlantManager`, so the badge waits
+## on the Power Plant. The plant is not walked to: its door sits in a region with no
+## map edge and no walkable neighbour, and the way in is Route 9's river, sixty
+## cells of water opened by the same cut, meeting the south edge on columns 56 and
+## 57 and coming out one step from the plant's shore.
 
 
 ## constants/map_constants.asm: the CERULEAN group is 7, SAFFRON 25, LAVENDER 18.
@@ -224,15 +200,14 @@ func _verify_cerulean(data: GameData, game_id: StringName) -> void:
 	print("%s cerulean: one east crossing onto Route 9." % game_id)
 
 
-## The gym, which is a pool with three swimmers standing on it.
-##
-## Five of its six objects hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, which is
-## what makes the badge an errand; the sixth is the grunt, whose own scene takes
-## him off the ladder column. The load-bearing part is the last: no walk to Misty
-## avoids Diana's sight line or both of the other two, and every approach stops
-## on water that `can_object_walk_to()` refuses. They resolve anyway, because
-## SeenByTrainerScript is `applymovementlasttalked` and every step in that buffer
-## reaches NormalStep, which consults no permission at all.
+## The gym, which is a pool with three swimmers standing on it. Five of its six
+## objects hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, which is what makes the
+## badge an errand; the sixth is the grunt, whose own scene takes him off the ladder
+## column. The load-bearing part is the last: no walk to Misty avoids Diana's sight
+## line or both of the other two, and every approach stops on water that
+## `can_object_walk_to()` refuses. They resolve anyway, because SeenByTrainerScript
+## is `applymovementlasttalked` and every step in that buffer reaches NormalStep,
+## which consults no permission at all.
 func _verify_cerulean_gym(data: GameData, game_id: StringName) -> void:
 	var gym: Gen2WorldAPI = _open(data, CERULEAN_GROUP, CERULEAN_GYM, CERULEAN_GYM_LANDING)
 	if gym == null:

--- a/tools/checks/cinnabar.gd
+++ b/tools/checks/cinnabar.gd
@@ -2,24 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the walk south from Pewter to Cinnabar Island, east to Seafoam Gym,
-## and back north to Viridian Gym, against freshly imported real caches for both
-## command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/maps/attributes.asm, maps/PalletTown.asm, maps/Route21.asm,
-## maps/CinnabarIsland.asm, maps/Route20.asm, maps/SeafoamGym.asm and
-## maps/ViridianGym.asm.
-##
-## Three findings carry the leg. Cinnabar Island is two land regions with no
-## seam between them, and the crossing off Route 21 can land on either, so which
-## cell it lands on decides whether Blue is reachable at all. Route 20's west
-## channel is walled off from the open sea on every side, so the island holding
-## the gym mouth is landed on from the east and not the west. And Viridian Gym
-## has no puzzle and no trainer: both its objects carry EVENT_VIRIDIAN_GYM_BLUE
-## as their hide flag, so the whole gate is Cinnabar's Blue clearing it.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- cinnabar
+## Verifies the walk south from Pewter to Cinnabar Island, east to Seafoam Gym and
+## back north to Viridian Gym, for both command profiles. Three findings carry the
+## leg: Cinnabar Island is two land regions with no seam between them and the
+## crossing off Route 21 can land on either, so which cell it lands on decides
+## whether Blue is reachable at all; Route 20's west channel is walled off from the
+## open sea on every side, so the gym mouth's island is landed on from the east; and
+## Viridian Gym has no puzzle and no trainer, both its objects hiding behind
+## EVENT_VIRIDIAN_GYM_BLUE, so the whole gate is Cinnabar's Blue clearing it.
 
 
 ## constants/map_constants.asm. Nothing on this leg splits between the profiles.

--- a/tools/checks/command_queues.gd
+++ b/tools/checks/command_queues.gd
@@ -2,22 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the imported `cmdqueue` payloads against freshly imported real
-## caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## macros/scripts/maps.asm's `cmdqueue` and `stonetable`, engine/overworld/
-## cmd_queue.asm's CmdQueue_StoneTable, home/stone_queue.asm's HandleStoneQueue,
-## and the two maps that write one, maps/BlackthornGym2F.asm and
-## maps/IcePathB1F.asm. Both files are byte identical between the pins.
-##
-## The importer skips a queue pointer it cannot resolve, because scripts are
-## collected as fixed slices and a slice running past its own end can decode
-## stray bytes as a `writecmdqueue`. This is what makes that tolerance safe: it
-## asserts the two real tables are present, complete and correct rather than
-## trusting the scan not to have missed one.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- command_queues
+## Verifies the imported `cmdqueue` payloads against freshly imported real caches,
+## for both command profiles. Expected values come from the pinned sources' own
+## macros, `CmdQueue_StoneTable`, `HandleStoneQueue` and the two maps that write
+## one, BlackthornGym2F and IcePathB1F, both byte identical between the pins. The
+## importer skips a queue pointer it cannot resolve, because a script slice running
+## past its own end can decode stray bytes as a `writecmdqueue`; this is what makes
+## that tolerance safe, asserting the two real tables are present, complete and
+## correct rather than trusting the scan not to have missed one.
 
 
 ## Blackthorn Gym 2F and Ice Path B1F, the only two maps in either game with a

--- a/tools/checks/credits.gd
+++ b/tools/checks/credits.gd
@@ -3,15 +3,11 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the credits against freshly imported real caches, for both command
-## profiles.
-##
-## The whole script is run to `CREDITS_END` rather than sampled: every command it
-## carries, every string it names and every scene it selects is exercised once,
-## which is the sweep tests/integration/test_credits.gd's four-string fixture
-## cannot be. The expected values come from pokecrystal and pokegold's
-## engine/movie/credits.asm, data/credits_script.asm and credits_strings.asm.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- credits
+## profiles. The whole script is run to `CREDITS_END` rather than sampled: every
+## command it carries, every string it names and every scene it selects is exercised
+## once, which is the sweep tests/integration/test_credits.gd's four-string fixture
+## cannot be. Expected values come from pokecrystal and pokegold's
+## engine/movie/credits.asm and the two data files behind it.
 
 
 ## Long enough for either script, whose own totals are pinned below.

--- a/tools/checks/cut.gd
+++ b/tools/checks/cut.gd
@@ -3,19 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Cut against freshly imported real caches, for both command profiles.
-##
-## The expected values come from the pinned pokecrystal and pokegold sources:
-## engine/events/overworld.asm's CutFunction and CheckMapForSomethingToCut,
-## engine/overworld/tile_events.asm's CheckCutCollision,
-## data/collision/field_move_blocks.asm's CutTreeBlockPointers, and
-## constants/tileset_constants.asm, whose PARK and FOREST numbers are the only
-## part of that table that differs between the two games.
-##
-## The real-cartridge counterpart to tests/unit/test_world_field_move.gd, which
-## uses a synthetic cache. Ilex Forest is the acceptance case, because its single
-## cut tree is what gates the route west out of the forest.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- cut
+## Expected values come from the pinned sources: CutFunction,
+## CheckMapForSomethingToCut, CheckCutCollision, CutTreeBlockPointers, and
+## constants/tileset_constants.asm, whose PARK and FOREST numbers are the only part
+## of that table that differs between the two games. The real-cartridge counterpart
+## to tests/unit/test_world_field_move.gd, which uses a synthetic cache. Ilex
+## Forest is the acceptance case, because its single cut tree gates the route west
+## out of the forest.
 
 
 ## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push

--- a/tools/checks/day_care.gd
+++ b/tools/checks/day_care.gd
@@ -1,17 +1,12 @@
 extends RefCounted
 
 ## Sweeps the Day-Care and the breeding rules behind it on freshly imported real
-## caches, all three cartridges, whole corpus.
-##
-## What this exists to catch is a rule that is right for the pair a test was
-## written for and wrong for the corpus: `GetPreEvolution` is a search over every
-## species, `CheckBreedmonCompatibility` reads two records at once, and
-## `FillMoves` is the same routine the retrieval and the egg both go through. A
-## sampled pair answers none of those.
-##
-## The real-cartridge counterpart to tests/unit/test_world_day_care.gd.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- day_care
+## caches, all three cartridges, whole corpus. What this exists to catch is a rule
+## that is right for the pair a test was written for and wrong for the corpus:
+## `GetPreEvolution` is a search over every species, `CheckBreedmonCompatibility`
+## reads two records at once, and `FillMoves` is the same routine the retrieval and
+## the egg both go through, and a sampled pair answers none of those. The
+## real-cartridge counterpart to tests/unit/test_world_day_care.gd.
 
 ## `PrintDayCareText.TextTable`'s twenty, `.NotYetText`, `DayCareManOutside`'s
 ## five and `engine/pokemon/breeding.asm`'s two plus five.

--- a/tools/checks/decorations.gd
+++ b/tools/checks/decorations.gd
@@ -2,23 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies `DecorationAttributes` and the `DecorationNames` run behind it
-## against freshly imported real caches, in all three games, and the name
-## [Gen2WorldDecoration] spells from each row.
-##
-## Expected values are the pinned pokecrystal and pokegold sources'
-## `data/decorations/attributes.asm`, `data/decorations/names.asm` and
-## `GetDecoName`. One pinned address per cartridge finds the lot, so what says
-## the address is right is the content: fifty-three rows whose types, actions,
-## event flags and block or sprite bytes are all the source's, and the names they
-## are spelled from.
-##
-## The two pins are byte identical bar one name: Gold and Silver spell the third
-## console "NINTENDO64" where Crystal spells it "NINTENDO 64". That is checked
-## here rather than assumed, and it is why the whole run is not compared between
-## cartridges the way the Pokemon Center PC's is.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- decorations
+## Verifies `DecorationAttributes` and the `DecorationNames` run behind it against
+## freshly imported real caches, in all three games, and the name
+## [Gen2WorldDecoration] spells from each row. One pinned address per cartridge
+## finds the lot, so what says the address is right is the content: fifty-three rows
+## whose types, actions, event flags and block or sprite bytes are all the source's.
+## The two pins are byte identical bar one name, Gold and Silver spelling the third
+## console "NINTENDO64" where Crystal spells it "NINTENDO 64", which is why the
+## whole run is not compared between cartridges.
 
 ## Every row, as [name, type, action, event flag, block or sprite]. The name is
 ## what `GetDecoName` assembles, not the `DecorationNames` entry the row points

--- a/tools/checks/drawn_blocks.gd
+++ b/tools/checks/drawn_blocks.gd
@@ -3,27 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## The drawn-block fold, from a map record rather than from a loaded world.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- drawn_blocks
-##
-## `Gen2WorldAPI.drawn_block_for` is what a caller with no world has: a battle
-## staged on a map knows the map by number and never opens one. It has to be the
-## same fold `drawn_block_at` performs, so this sweeps every map of every cache
-## over its whole padded rectangle and refuses a single disagreement.
-##
-## The count of padded blocks that came from a neighbour rather than from the
-## border block is reported per game, because two implementations that both
-## answer the border block everywhere would agree and prove nothing.
-##
-## SCREEN FILL adds a second question to the same sweep, since it is the same
-## fold one step further out. `expanded_block_at` places whole connected maps
-## past the padding, and the two things that has to be true of it are checked
-## here rather than photographed:
-##
-## - inside `wOverworldMapBlocks` it is `drawn_block_at`, byte for byte, so
-##   nothing a 20x18 screen can reach moved;
-## - where the padding took a block off a neighbour, the placed map answers the
-##   same block, which is the seam being continuous rather than merely adjacent.
+## `Gen2WorldAPI.drawn_block_for` is what a caller with no world has, and it has to
+## be the same fold `drawn_block_at` performs, so this sweeps every map of every
+## cache over its whole padded rectangle. The count of padded blocks that came from
+## a neighbour is reported per game, because two implementations that both answer
+## the border block everywhere would agree and prove nothing. SCREEN FILL is the
+## same fold one step further out: inside `wOverworldMapBlocks` it is
+## `drawn_block_at` byte for byte, and the placed map answers the padding's block.
 
 ## `FillMapConnections` writes three blocks of padding on each side.
 const PADDING: int = 3

--- a/tools/checks/elite_four.gd
+++ b/tools/checks/elite_four.gd
@@ -3,23 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the corridor from the Indigo Plateau Pokemon Center to the Hall of
-## Fame, against freshly imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `maps/IndigoPlateauPokecenter1F.asm`, `maps/WillsRoom.asm`,
-## `maps/KogasRoom.asm`, `maps/BrunosRoom.asm`, `maps/KarensRoom.asm`,
-## `maps/LancesRoom.asm` and `maps/HallOfFame.asm`. The Pokemon Center and the
-## Hall of Fame are byte identical between the pins and the four rooms differ
-## only in their `reanchormap` operand ($86 Crystal, $85 Gold/Silver). Lance's
-## room is the profile split: Gold and Silver put Lance one row further up, its
-## exit warps on y=0 rather than y=1, and end the champion scene with `warp`
-## rather than `warpfacing`.
-##
-## What is worth pinning is the two block changes each room turns on. Nothing
-## else stops the leg: the door behind the player is walled by the entrance
-## scene, and the door ahead is opened only by the boss.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- elite_four
+## Fame, for both command profiles. The Pokemon Center and the Hall of Fame are byte
+## identical between the pins and the four rooms differ only in their `reanchormap`
+## operand; Lance's room is the profile split, Gold and Silver putting Lance one row
+## further up, warping out on y=0 and ending the champion scene with `warp` rather
+## than `warpfacing`. What is worth pinning is the two block changes each room turns
+## on: nothing else stops the leg, the door behind the player being walled by the
+## entrance scene and the door ahead opened only by the boss.
 
 
 ## constants/map_constants.asm's INDIGO group, the 16th `newgroup`.

--- a/tools/checks/evolutions.gd
+++ b/tools/checks/evolutions.gd
@@ -3,16 +3,11 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies every evolution row on freshly imported real caches against
-## engine/pokemon/evolve.asm's `EvolveAfterBattle`, for all three cartridges.
-##
-## The predicates in [Gen2Evolution] are what the field host and any link host
-## share, so the census is what pins them: every row of every species is walked
-## and answered rather than spot checked, which is what catches a method the
-## importer misread or a predicate that answers the wrong branch.
-##
-## The real-cartridge counterpart to tests/unit/test_evolution.gd.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- evolutions
+## `EvolveAfterBattle`, for all three cartridges. The predicates in [Gen2Evolution]
+## are what the field host and any link host share, so the census is what pins them:
+## every row of every species is walked and answered rather than spot checked, which
+## is what catches a method the importer misread or a predicate that answers the
+## wrong branch. The real-cartridge counterpart to tests/unit/test_evolution.gd.
 
 ## data/pokemon/evos_attacks.asm, counted from the pins: every `db EVOLVE_*` in
 ## the file. Identical across the three, since no evolution changed between them.

--- a/tools/checks/field_move_prompts.gd
+++ b/tools/checks/field_move_prompts.gd
@@ -2,21 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the overworld field-move prompts against freshly imported real
-## caches, for both command profiles.
-##
-## The expected values come from the pinned pokecrystal and pokegold sources:
-## engine/overworld/events.asm's TryTileCollisionEvent from `.cut` on, and
-## engine/events/overworld.asm's TryCutOW, TryWhirlpoolOW, TryWaterfallOW,
-## TryHeadbuttOW, TrySurfOW and the five Ask*Scripts behind them, all of which
-## are byte identical between the pins.
-##
-## The real-cartridge counterpart to the prompt half of
+## Verifies the overworld field-move prompts against freshly imported real caches,
+## for both command profiles. Expected values come from the pinned sources:
+## TryTileCollisionEvent from `.cut` on, and the five `Try*OW` routines and the
+## Ask*Scripts behind them, all byte identical between the pins. The real-cartridge
+## counterpart to the prompt half of
 ## tests/integration/test_world_field_move_screen.gd. Each move is driven on the
 ## same map its own validator uses, so a failure here is about the prompt rather
 ## than about the move.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- field_move_prompts
 
 
 ## validate_cut.gd's Ilex Forest tree, and the cell it is faced from.

--- a/tools/checks/fuchsia.gd
+++ b/tools/checks/fuchsia.gd
@@ -3,24 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the walk south from Lavender Town to Fuchsia City and the Soul Badge,
-## against freshly imported real caches for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/Route12.asm, maps/Route13.asm, maps/Route14.asm, maps/Route15.asm,
-## maps/Route15FuchsiaGate.asm, maps/FuchsiaCity.asm, maps/FuchsiaGym.asm and
-## data/maps/attributes.asm.
-##
-## Two findings carry the leg. The way south is four plain connections with one
-## gate at the end, so what it costs is trainers rather than errands, and which
-## trainers is not the same question as how many: shutting each sight line's own
-## cells in turn shows that Crystal owes two of Route 13's five and nothing at
-## all on Routes 12, 14 and 15, while Gold and Silver owe a different set on
-## three profile-split routes. And Fuchsia Gym is a maze rather than a gate: its
-## fifty wall cells leave 130 walkable ones and its six objects stand on six of
-## them, so the door reaches 124; none of those six is an
+## for both command profiles. Two findings carry the leg. The way south is four
+## plain connections with one gate at the end, so what it costs is trainers rather
+## than errands, and which trainers is not the same question as how many: shutting
+## each sight line's cells in turn shows Crystal owes two of Route 13's five and
+## nothing on Routes 12, 14 and 15, while Gold and Silver owe a different set. And
+## Fuchsia Gym is a maze rather than a gate: none of its six objects is an
 ## OBJECTTYPE_TRAINER, and Janine sets her four disguised trainers' flags herself.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- fuchsia
 
 
 ## constants/map_constants.asm. Route 12 belongs to the LAVENDER group; Routes

--- a/tools/checks/gs_intro.gd
+++ b/tools/checks/gs_intro.gd
@@ -3,19 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies `GoldSilverIntro`'s art against freshly imported real caches, on all
-## three cartridges.
-##
-## The section walk is what says the one pinned address is right: eleven entries
-## in a row landing on their exact sizes, each rounded up to a sixteen-byte
-## boundary to reach the next. This sweeps the imported result rather than the
-## walk, so a cache built from the wrong offset shows up as a sheet of the wrong
-## length or a metatile map naming a metatile its own `.bin` does not hold.
-##
-## Gold and Silver ship the same art byte for byte, which is checked here rather
-## than assumed: the two caches are compared against each other entry by entry.
-## Crystal runs `CrystalIntro` instead and is checked for saying so.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- gs_intro
+## three cartridges. The section walk is what says the one pinned address is right:
+## eleven entries in a row landing on their exact sizes, each rounded up to a
+## sixteen-byte boundary to reach the next. This sweeps the imported result rather
+## than the walk, so a cache built from the wrong offset shows up as a sheet of the
+## wrong length. Gold and Silver ship the same art byte for byte, which is checked
+## rather than assumed; Crystal runs `CrystalIntro` and is checked for saying so.
 
 const MOVIE_GAMES: Array[StringName] = [&"gold", &"silver"]
 

--- a/tools/checks/headbutt.gd
+++ b/tools/checks/headbutt.gd
@@ -3,20 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Headbutt against freshly imported real caches, for both command
-## profiles.
-##
-## The expected values come from the pinned pokecrystal and pokegold sources:
-## engine/events/overworld.asm's TryHeadbuttOW and HeadbuttScript,
-## engine/events/treemons.asm's TreeMonEncounter, GetTreeMonSet, GetTreeMons,
-## GetTreeMon and SelectTreeMon, home/map_objects.asm's CheckHeadbuttTreeTile,
-## and data/wild/treemon_maps.asm and treemons.asm.
-##
-## The real-cartridge counterpart to tests/unit/test_world_treemon.gd and the
-## headbutt half of tests/unit/test_world_field_move.gd, both of which use
-## hand-built tables. Ilex Forest is the acceptance case, because its trees are
-## the same cells in all three games.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- headbutt
+## profiles. Expected values come from the pinned sources: TryHeadbuttOW and
+## HeadbuttScript, the five treemon routines behind them, CheckHeadbuttTreeTile,
+## and the two data/wild tables. The real-cartridge counterpart to
+## tests/unit/test_world_treemon.gd and the headbutt half of
+## tests/unit/test_world_field_move.gd, both of which use hand-built tables. Ilex
+## Forest is the acceptance case, because its trees are the same cells in all three
+## games.
 
 
 ## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push

--- a/tools/checks/ice_slides.gd
+++ b/tools/checks/ice_slides.gd
@@ -5,17 +5,11 @@ var _r: RefCounted = null
 ## Sweeps every ice cell on every map of all three cartridges through the slide
 ## `DoPlayerMovement.CheckForced` and `CheckStandingOnIce` produce, rather than
 ## sampling the Ice Path. The expected shapes come from the pinned
-## engine/overworld/player_movement.asm, identical in pokecrystal and pokegold:
-## a step onto ice leaves `wPlayerTurningDirection` set, the next poll ORs that
-## direction back into `wCurInput`, and the run ends at the first refused step,
-## whose `._WalkInPlace` clears the byte.
-##
-## Two invariants are what a broken slide trips. It has to terminate, which it
-## only does because a refusal clears the byte; and with nothing held it has to
-## keep the one direction, since a slide that could turn on its own would carry
-## the player off a run the map laid out.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- ice_slides
+## player_movement.asm, identical in both: a step onto ice leaves
+## `wPlayerTurningDirection` set, the next poll ORs that direction back into
+## `wCurInput`, and the run ends at the first refused step. Two invariants are what
+## a broken slide trips: it has to terminate, which it only does because a refusal
+## clears the byte, and with nothing held it has to keep the one direction.
 
 ## A slide can be no longer than the map, so anything past this is a loop.
 const RUN_CEILING: int = 512

--- a/tools/checks/intro_movie.gd
+++ b/tools/checks/intro_movie.gd
@@ -3,17 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the intro movie against freshly imported real caches, on all three
-## cartridges.
-##
-## The whole movie is run to `JUMPTABLE_EXIT_F` rather than sampled: every scene
-## of the jumptable, every sprite it spawns and every sound it asks for is
-## exercised once. The expected values come from pokecrystal's
-## engine/movie/intro.asm and data/sprite_anims/.
-##
-## Gold and Silver carry `GoldSilverIntro`, a different movie that is not
-## imported, so they are checked for saying so rather than for running.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- intro_movie
+## cartridges. The whole movie is run to `JUMPTABLE_EXIT_F` rather than sampled:
+## every scene of the jumptable, every sprite it spawns and every sound it asks for
+## is exercised once. Expected values come from pokecrystal's
+## engine/movie/intro.asm and data/sprite_anims/. Gold and Silver carry
+## `GoldSilverIntro`, a different movie that is not imported, so they are checked
+## for saying so rather than for running.
 
 const MOVIE_GAMES: Array[StringName] = [&"crystal"]
 
@@ -106,16 +101,14 @@ func _sheet_tiles(data: GameData, name: String) -> int:
 	return int(data.tile_sheet("intro_%s" % name).get("tiles", 0))
 
 
-## Every BG cell the movie actually samples has to name a tile the sheet that
-## part of VRAM currently holds, and every attribute byte a palette its own run
-## has. Sampled rather than whole, because only 360 of a map's 1,024 cells are
-## the picture: the rest of the Unown maps is $ff, which nothing scrolls onto and
-## no scene has loaded a sheet for.
-##
-## This is what says `SCENE_VRAM` pairs a map with a sheet the way the setup
-## scenes do, and that the halves a scene does not reload carry forward: the
-## close-up's own map names thirty-three tiles below $80, which read the leaping
-## Suicune `IntroScene15` left in `vTiles2`.
+## Every BG cell the movie actually samples has to name a tile the sheet that part
+## of VRAM currently holds, and every attribute byte a palette its own run has.
+## Sampled rather than whole, because only 360 of a map's 1,024 cells are the
+## picture: the rest of the Unown maps is $ff, which nothing scrolls onto. This is
+## what says `SCENE_VRAM` pairs a map with a sheet the way the setup scenes do, and
+## that the halves a scene does not reload carry forward: the close-up's own map
+## names thirty-three tiles below $80, which read the leaping Suicune
+## `IntroScene15` left in `vTiles2`.
 func _verify_sampled_tiles(game_id: StringName, movie: Gen2IntroMovie, data: GameData) -> bool:
 	var map: PackedByteArray = movie.bg_map()
 	var attr: PackedByteArray = movie.bg_attr()

--- a/tools/checks/item_balls.gd
+++ b/tools/checks/item_balls.gd
@@ -3,22 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies `OBJECTTYPE_ITEMBALL` and `BGEVENT_ITEM` dispatch against freshly
-## imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `engine/overworld/events.asm`'s `ObjectEventTypeArray.itemball` and
-## `.itemifset`, `engine/events/misc_scripts.asm`'s `FindItemInBallScript`,
-## `engine/events/hidden_item.asm`'s `HiddenItemScript`, and the `itemball` and
-## `hiddenitem` macros in `macros/scripts/maps.asm`.
-##
-## The point of pinning both is that neither pointer is a script. A ball's
-## addresses `db item, quantity` and a hidden item's `dwb event, item`, and
-## before these dispatches existed `interact()` handed those bytes to the runner
-## as opcodes. Two of them matter most: Ice Path 1F's HM07, since nothing else in
-## either game gives Waterfall, and Cerulean Gym's MACHINE_PART, since nothing
-## else opens the Power Plant and with it the Cascade Badge.
-##
-##   Godot --headless -s res://tools/checks/item_balls.gd
+## imported real caches, for both command profiles. The point of pinning both is
+## that neither pointer is a script: a ball's addresses `db item, quantity` and a
+## hidden item's `dwb event, item`, and before these dispatches existed
+## `interact()` handed those bytes to the runner as opcodes. Two of them matter
+## most: Ice Path 1F's HM07, since nothing else in either game gives Waterfall, and
+## Cerulean Gym's MACHINE_PART, since nothing else opens the Power Plant and with
+## it the Cascade Badge.
 
 
 ## data/maps/maps.asm group/number pairs. Crystal's own extra maps push both
@@ -83,9 +74,8 @@ const HIDDEN_ITEMS: Array[Dictionary] = [
 ## `data/items/fruit_trees.asm`'s whole `FruitTreeItems`, in `FRUITTREE_*` order
 ## and byte identical between the two pins, named as `data/items/names.asm` names
 ## them. `GetFruitTreeItem` indexes this at the `fruittree` operand less one.
-##
-## Pinned by name rather than by number because the question a player asks about
-## a tree is what the bag then says: `BERRY` really is what four Johto trees and
+## Pinned by name rather than by number because the question a player asks about a
+## tree is what the bag then says: `BERRY` really is what four Johto trees and
 ## Route 11 bear, Oran and Sitrus being a Gen 3 renaming, and the table has no
 ## terminator and no pointer, so nothing but its contents says it decoded at the
 ## right offset.
@@ -291,22 +281,14 @@ func _verify_hidden_items(data: GameData, game_id: StringName) -> void:
 		)
 
 
-## `Gen2WorldAPI.hidden_items()` over EVERY map of the cartridge, which is the
-## only thing that can say the public read agrees with the dispatch the two
-## cases above drive one map at a time.
-##
-## What it proves, over every record rather than the two driven above: each one
-## decodes on a fresh state, none of them reads as already taken, and the read
-## and the ask agree on the item and the flag for every one of them.
-##
-## What it does NOT prove, and the reason is worth keeping so it is not chased
-## again: `_hidden_item_record` addresses the gameplay catalog's patch by
-## `event_index`, and on an unpatched cache `_catalogued_item` falls back to the
-## record's own byte, so a wrong index is inert over the whole corpus. It bites
-## only where a mod has moved what is in a hidden item, and the read is stamped
-## by `events_at()`'s own rule rather than by a second copy of it for that
-## reason. Maps carrying more than one record are counted below because that is
-## the population such a patch would be visible on.
+## `Gen2WorldAPI.hidden_items()` over EVERY map of the cartridge, which is the only
+## thing that can say the public read agrees with the dispatch the two cases above
+## drive one map at a time: each record decodes on a fresh state, none reads as
+## already taken, and the read and the ask agree on the item and the flag. What it
+## does NOT prove, kept so it is not chased again: `_hidden_item_record` addresses
+## the catalog's patch by `event_index` and falls back to the record's own byte, so
+## a wrong index is inert over the whole corpus and bites only where a mod has moved
+## what is in a hidden item.
 func _sweep_the_public_read(data: GameData, game_id: StringName) -> void:
 	var maps: int = 0
 	var records: int = 0

--- a/tools/checks/lavender.gd
+++ b/tools/checks/lavender.gd
@@ -3,22 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the walk east out of Saffron to Lavender Town and the EXPN CARD the
-## Kanto Radio Tower hands over, against freshly imported real caches for both
-## command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/SaffronCity.asm, maps/Route8SaffronGate.asm, maps/Route8.asm,
-## maps/LavenderTown.asm, maps/LavRadioTower1F.asm and data/maps/attributes.asm.
-##
-## Two findings carry the leg. Route 8's five trainers look like a wall and are
-## not one: the three bikers stand in a column facing west, and the route's eight
-## `$a3` hop-down ledges drop an eastbound walk onto row 8 east of them, so only
-## Super Nerd Tom's line cannot be routed around. And the town needs no errand of
-## its own, but the tower does: `LavRadioTower1FGentlemanScript` gates the EXPN
-## CARD on EVENT_RETURNED_MACHINE_PART, so the Power Plant the Cascade Badge
-## needed is what puts the Kanto station back on the air.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- lavender
+## Kanto Radio Tower hands over, for both command profiles. Two findings carry the
+## leg. Route 8's five trainers look like a wall and are not one: the three bikers
+## stand in a column facing west, and the route's eight `$a3` hop-down ledges drop
+## an eastbound walk onto row 8 east of them, so only Super Nerd Tom's line cannot
+## be routed around. And the town needs no errand of its own, but the tower does:
+## its gentleman gates the EXPN CARD on EVENT_RETURNED_MACHINE_PART, so the Power
+## Plant the Cascade Badge needed is what puts the Kanto station back on the air.
 
 
 ## constants/map_constants.asm: gates belong to the group of the route they open

--- a/tools/checks/ledge_hops.gd
+++ b/tools/checks/ledge_hops.gd
@@ -4,17 +4,12 @@ var _r: RefCounted = null
 
 ## Verifies the two `DoPlayerMovement` branches a step is refused into against
 ## freshly imported real caches, for both command profiles: `.TryJump` and the
-## `.CheckWarp` behind it. The expected codes come from the pinned pokecrystal
-## and pokegold sources: engine/overworld/player_movement.asm's .TryJump, its
-## .ledge_table, .EdgeWarps, and data/collision/collision_permissions.asm.
-##
-## The real-cartridge counterpart to tests/unit/test_world_collision.gd and the
-## ledge cases in tests/unit/test_world_api.gd, which use synthetic caches. It
-## also pins what gates Route 30's corridor north, which
+## `.CheckWarp` behind it. The expected codes come from the pinned sources'
+## `.TryJump`, its `.ledge_table`, `.EdgeWarps` and the collision permissions. The
+## real-cartridge counterpart to tests/unit/test_world_collision.gd, which uses
+## synthetic caches. It also pins what gates Route 30's corridor north, which
 ## tools/preview_world_story.gd walks: terrain and hops carry the route, and
 ## EVENT_ROUTE_30_BATTLE opens the last two cells.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- ledge_hops
 
 const ROUTE30_GROUP: int = 26
 const ROUTE30_NUMBER: int = 1

--- a/tools/checks/link.gd
+++ b/tools/checks/link.gd
@@ -1,18 +1,13 @@
 extends RefCounted
 
-## Sweeps link play against freshly imported real caches, all three cartridges.
-##
-## The class this exists to catch is a cable club that answers a question the
-## cartridge does not ask. Every one of the three receptionist scripts is the
-## same shape and none of them can be reached without a peer, so the two paths
-## that matter are the one a single console gets and the one a peer gets, and
-## both are driven here on the real map rather than asserted about the session.
-##
-## `LinkCommsBorderGFX` is checked as the two different things it is: seventy
-## tiles and a screen tilemap on Crystal, nine tiles and no tilemap on Gold and
+## Sweeps link play against freshly imported real caches, all three cartridges. The
+## class this exists to catch is a cable club that answers a question the cartridge
+## does not ask: every one of the three receptionist scripts is the same shape and
+## none can be reached without a peer, so the two paths that matter are the one a
+## single console gets and the one a peer gets, and both are driven on the real map.
+## `LinkCommsBorderGFX` is checked as the two different things it is, seventy tiles
+## and a screen tilemap on Crystal against nine tiles and no tilemap on Gold and
 ## Silver, which is the whole difference between the two trade screens.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- link
 
 ## `newgroup CABLE_CLUB`, the same group and numbers in both pins.
 const CABLE_CLUB_GROUP: int = 20

--- a/tools/checks/magnet_train.gd
+++ b/tools/checks/magnet_train.gd
@@ -2,28 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the lost-doll errand between Saffron and Vermilion and the Magnet
-## Train ride it pays for, against freshly imported real caches for both command
-## profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## constants/map_constants.asm, maps/SaffronCity.asm, maps/CopycatsHouse1F.asm,
-## maps/CopycatsHouse2F.asm, maps/VermilionCity.asm, maps/PokemonFanClub.asm,
-## maps/SaffronMagnetTrainStation.asm and
-## maps/GoldenrodMagnetTrainStation.asm.
-##
-## Three findings carry the leg. The Copycat is a variable sprite, SPRITE_COPYCAT
-## ($fb), whose row is InitializeEventsScript's SPRITE_LASS until her own script
-## overwrites it; GetMonSprite answers SPRITE_CHRIS for a slot with no row at
-## all, which is what a lost table looks like. Each
-## station is two regions with no walkable seam: row 9 is solid, so the lobby
-## never reaches the platform and the only way onto a train is the officer's own
-## `applymovement`, which is a forced step. And the errand is a three-legged
-## loop with an order the cartridge enforces, since the Fan Club's Clefairy guy
-## reads EVENT_MET_COPYCAT_FOUND_OUT_ABOUT_LOST_ITEM before he parts with the
-## doll.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- magnet_train
+## Verifies the lost-doll errand between Saffron and Vermilion and the Magnet Train
+## ride it pays for, for both command profiles. Three findings carry the leg. The
+## Copycat is a variable sprite whose row is InitializeEventsScript's SPRITE_LASS
+## until her own script overwrites it, and GetMonSprite answers SPRITE_CHRIS for a
+## slot with no row at all, which is what a lost table looks like. Each station is
+## two regions with no walkable seam, so the only way onto a train is the officer's
+## own forced `applymovement`. And the errand is a three-legged loop whose order the
+## cartridge enforces through the Fan Club's own event check.
 
 
 ## constants/map_constants.asm. Nothing on this leg splits between the profiles.

--- a/tools/checks/mail.gd
+++ b/tools/checks/mail.gd
@@ -3,19 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies mail against freshly imported real caches, in all three games.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/items/mail_items.asm's MailItems, data/text/mail_input_chars.asm's two
-## keyboards, gfx/mail/mail.pal, and the ten Load*MailGFX routines in
-## engine/pokemon/mail_2.asm.
-##
-## The pins here are counted off the asm rather than read from
-## [Gen2MailPage]'s own tables, so a mistranscribed byte count or tile number is
-## a failure instead of an agreement: LOADED_RANGES is what each routine's
-## `ld c, n * TILE_1BPP_SIZE` calls add up to, and every tile a routine places
-## has to fall inside its own range.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- mail
+## Expected values come from the pinned sources: `MailItems`, the two keyboards,
+## `gfx/mail/mail.pal` and the ten `Load*MailGFX` routines. The pins are counted off
+## the asm rather than read from [Gen2MailPage]'s own tables, so a mistranscribed
+## byte count or tile number is a failure instead of an agreement: LOADED_RANGES is
+## what each routine's `ld c, n * TILE_1BPP_SIZE` calls add up to, and every tile a
+## routine places has to fall inside its own range.
 
 ## `MailItems`, which is also [constant Gen2HeldItem.MAIL_ITEMS]' pin.
 const EXPECTED_ITEMS: Array[int] = [158, 181, 182, 183, 184, 185, 186, 187, 188, 189]

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -2,24 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## The imported map corpus against the pins' own copies of the same bytes.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- map_data
-##
-## pret assembles to a bit-identical ROM, so `maps/*.blk`,
-## `data/tilesets/*_metatiles.bin`, `data/tilesets/*_collision.asm` and
-## `gfx/tilesets/*_palette_map.asm` are the cartridge's own bytes read a second
-## way. Agreement proves the importer's addressing, stride and fold, which is
-## where an offset or a stride read one row out hides; it proves nothing about
-## what the bytes mean. `drawn_blocks` and `side_walls` are the semantic half.
-##
-## Gold and Silver both run against `pokegold`, and every identity here comes
-## from the pin's own tables rather than from a number: a map is found by
-## walking `constants/map_constants.asm` in order, and a tileset's files by
-## following `TilesetXMeta` through `gfx/tilesets.asm`, because `Tileset0` and
-## `TilesetJohto` are the same record under two labels.
-##
-## The checkouts are local-only, so a missing one skips rather than fails.
+## The imported map corpus against the pins' own copies of the same bytes. pret
+## assembles to a bit-identical ROM, so the `.blk`, metatile, collision and palette
+## map files are the cartridge's own bytes read a second way. Agreement proves the
+## importer's addressing, stride and fold, which is where an offset read one row out
+## hides; it proves nothing about what the bytes mean, and `drawn_blocks` and
+## `side_walls` are the semantic half. Every identity comes from the pin's own
+## tables rather than from a number, because `Tileset0` and `TilesetJohto` are the
+## same record under two labels. A missing checkout skips rather than fails.
 
 const PINS: Dictionary = {
 	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",

--- a/tools/checks/map_name_sign.gd
+++ b/tools/checks/map_name_sign.gd
@@ -5,14 +5,10 @@ var _r: RefCounted = null
 ## Verifies `InitMapNameSign` and its sign against freshly imported real caches:
 ## every map on all three cartridges is asked what landmark it would raise, and
 ## every name that answers is drawn through the same [Gen2MapNameSignPage] the
-## overworld displays.
-##
-## What a sampled map cannot say: the rule is three tests over the whole corpus
-## (`GATE`, the two National Park gates, and `.CheckSpecialMap`'s six landmarks),
-## and the sign is Crystal's own screen, so Gold and Silver must raise none at
-## all rather than draw one out of a sheet they do not ship.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- map_name_sign
+## overworld displays. What a sampled map cannot say: the rule is three tests over
+## the whole corpus (`GATE`, the two National Park gates, and `.CheckSpecialMap`'s
+## six landmarks), and the sign is Crystal's own screen, so Gold and Silver must
+## raise none at all rather than draw one out of a sheet they do not ship.
 
 const TILE: int = Gen2Font.TILE
 const SIZE: Vector2i = Vector2i(

--- a/tools/checks/mart.gd
+++ b/tools/checks/mart.gd
@@ -2,21 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the mart's own boxes and its buy screen against freshly imported
-## real caches, over every mart the cartridge ships rather than a sampled one.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `engine/items/mart.asm`'s `GetMartDialogGroup.MartTextFunctionPointers`, the
-## twenty-nine `text_far` stubs behind it, and `MenuHeader_Buy`'s own geometry.
-##
-## One pinned address per cartridge finds every text, so what says the address
-## is right is the content: each stub has to decode, each group's opening has to
-## be that shop's own words, and every marker a box carries has to be one of the
-## three values `MartConfirmPurchase` fills. The screen itself is swept by
-## drawing all thirty-four marts: a name or a price that ran past the list's own
-## columns is what a wrong geometry looks like.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- mart
+## Verifies the mart's own boxes and its buy screen against freshly imported real
+## caches, over every mart the cartridge ships rather than a sampled one. Expected
+## values come from the pinned sources' `MartTextFunctionPointers`, the twenty-nine
+## `text_far` stubs behind it, and `MenuHeader_Buy`'s own geometry. One pinned
+## address per cartridge finds every text, so what says the address is right is the
+## content: each stub has to decode and each group's opening has to be that shop's
+## own words. The screen itself is swept by drawing all thirty-four marts, since a
+## name that ran past the list's columns is what a wrong geometry looks like.
 
 ## Enough of each group's boxes to say which stub decoded, without pinning a
 ## whole one. `bargain_sold_out` is the only refusal that is not shared.

--- a/tools/checks/mon_specials.gd
+++ b/tools/checks/mon_specials.gd
@@ -4,22 +4,12 @@ var _r: RefCounted = null
 
 ## Verifies the two specials that open `SelectMonFromParty` against freshly
 ## imported real caches: the boxes each prints, the markers they carry, and every
-## map script in the corpus that reaches either, rather than a sampled one.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `engine/events/name_rater.asm` and `engine/events/move_deleter.asm`,
-## `data/text/common_2.asm`'s ten `_NameRater*` texts and `common_3.asm`'s eight
-## `_Deleter*` ones, `data/events/special_pointers.asm`, and the two
-## `*NameRater.asm` maps beside `MoveDeletersHouse.asm`.
-##
-## One pinned address per cartridge finds every text, so what says the address is
-## right is the content, the way the mart's own topic reads its stubs. The corpus
-## half is the script sweep: the Name Rater's index differs by one between the two
-## command profiles where the deleter's does not, so a wrong normalization shows
-## up as a map reaching a different routine, and the surrounding `opentext`/`waitbutton`/`closetext` is
-## what says the ending text is pressed once rather than twice.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- mon_specials
+## map script in the corpus that reaches either. One pinned address per cartridge
+## finds every text, so what says the address is right is the content, the way the
+## mart's own topic reads its stubs. The corpus half is the script sweep: the Name
+## Rater's index differs by one between the two command profiles where the
+## deleter's does not, so a wrong normalization shows up as a map reaching a
+## different routine.
 
 ## Enough of each of the Name Rater's boxes to say which stub decoded. His two
 ## questions and the three endings that need no new name are the branches a

--- a/tools/checks/move_effects.gd
+++ b/tools/checks/move_effects.gd
@@ -3,21 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Every effect byte's command list against the pins' own `data/moves/effects.asm`.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- move_effects
-##
 ## A move is a short program and [Gen2MoveEffect] is the whole table of them
-## transcribed by hand, so the comparable artefact is the command list itself:
-## the pin's `MoveEffectsPointers` in order, each label's commands resolved
-## through its fallthrough, against [method Gen2MoveEffect.sequence_for]. That
-## catches a step in the wrong place, which no unit test of one move can, and it
-## is the static half of the battle-command trace
-## `.claude/oracle/battle/trace_move_commands.py` runs against a real cartridge.
-##
-## `pokecrystal` and `pokegold` ship the same two files byte for byte, so the
-## corpus is one table read against all three caches.
-##
-## The checkouts are local-only, so a missing one skips rather than fails.
+## transcribed by hand, so the comparable artefact is the command list itself: the
+## pin's `MoveEffectsPointers` in order, each label's commands resolved through its
+## fallthrough, against [method Gen2MoveEffect.sequence_for]. That catches a step in
+## the wrong place, which no unit test of one move can, and it is the static half of
+## the battle-command trace an oracle runs against a real cartridge. A missing
+## checkout skips rather than fails.
 
 const PINS: Dictionary = {
 	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",
@@ -69,13 +61,11 @@ const FOLDED: Dictionary = {
 
 ## `toxictarget` is the second half of `BattleCommand_Poison`, which reads the
 ## effect byte back to decide between a flat poison and a ramping one; the two
-## readings are two commands here and one there.
-##
-## `checkimmune` is this port's own, and the one command with no cartridge name:
-## `BattleCommand_Stab` writes `wAttackMissed` when the matchup is zero and the
-## later steps read it back, so the immunity is split out of `stab` here rather
-## than carried in a register. It is dropped from our side before the lists are
-## compared.
+## readings are two commands here and one there. `checkimmune` is this port's own
+## and the one command with no cartridge name: `BattleCommand_Stab` writes
+## `wAttackMissed` when the matchup is zero and the later steps read it back, so the
+## immunity is split out of `stab` here rather than carried in a register. It is
+## dropped from our side before the lists are compared.
 const OURS_ONLY: Array[String] = ["checkimmune"]
 
 ## Ours named for what it does where the pin names the register it writes.

--- a/tools/checks/mt_silver.gd
+++ b/tools/checks/mt_silver.gd
@@ -2,26 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the walk from Viridian Gym to Red on Silver Cave Room 3, against
-## freshly imported real caches for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/maps/attributes.asm, constants/map_constants.asm, maps/PalletTown.asm,
-## maps/OaksLab.asm, maps/Route22.asm, maps/VictoryRoadGate.asm,
-## maps/Route28.asm, maps/SilverCaveOutside.asm and maps/SilverCaveRoom1.asm
-## through maps/SilverCaveRoom3.asm.
-##
-## Three findings carry the leg. The Victory Road Gate is three regions joined
-## by two single cells, and a black belt stands in each, so each belt's hide
-## flag is the gate on its own arm: EVENT_FOUGHT_SNORLAX opens the Route 22 arm
-## and EVENT_OPENED_MT_SILVER the Route 28 one, which makes Oak a hard gate on
-## Mt. Silver rather than a courtesy. Each Silver Cave room is one region, so no
-## room needs a hand-named intermediate cell the way Cinnabar did. And Red
-## carries EVENT_RED_IN_MT_SILVER as his hide flag, which InitializeEventsScript
-## sets at a new game and only HallOfFameEnterScript clears, so the room is
-## empty until the Hall of Fame.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- mt_silver
+## Verifies the walk from Viridian Gym to Red on Silver Cave Room 3, for both
+## command profiles. Three findings carry the leg. The Victory Road Gate is three
+## regions joined by two single cells with a black belt standing in each, so each
+## belt's hide flag is the gate on its own arm, which makes Oak a hard gate on Mt.
+## Silver rather than a courtesy. Each Silver Cave room is one region, so no room
+## needs a hand-named intermediate cell the way Cinnabar did. And Red carries
+## EVENT_RED_IN_MT_SILVER as his hide flag, set at a new game and cleared only by
+## HallOfFameEnterScript, so the room is empty until the Hall of Fame.
 
 
 ## constants/map_constants.asm. The DUNGEONS group is the one split on this leg:

--- a/tools/checks/mystery_gift.gd
+++ b/tools/checks/mystery_gift.gd
@@ -3,16 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Sweeps Mystery Gift against freshly imported real caches on all three
-## cartridges: both gift tables end to end, every box `DoMysteryGift` can end
-## on, the screen each cartridge draws, and the whole decision chain the
-## routine runs between the exchange and the gift.
-##
-## The class this exists to stop is a chain that answers the wrong box: every
-## refusal in `DoMysteryGift` is one `jp` away from the next, and a test that
-## drives only the happy path never sees the other seven. So the chain is
-## driven once per outcome, with the section built to reach exactly that jump.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- mystery_gift
+## cartridges: both gift tables end to end, every box `DoMysteryGift` can end on,
+## the screen each cartridge draws, and the whole decision chain the routine runs
+## between the exchange and the gift. The class this exists to stop is a chain that
+## answers the wrong box: every refusal in `DoMysteryGift` is one `jp` away from the
+## next, and a test that drives only the happy path never sees the other seven. So
+## the chain is driven once per outcome, with the section built to reach exactly
+## that jump.
 
 ## `MysteryGiftItems` and `MysteryGiftDecos`. The first and last row of each is
 ## what tells a table read forwards from one read backwards, and the pair of

--- a/tools/checks/naming.gd
+++ b/tools/checks/naming.gd
@@ -2,20 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the four name-input keyboards against freshly imported real caches,
-## in all three games.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/text/name_input_chars.asm's NameInputLower, BoxNameInputLower,
-## NameInputUpper and BoxNameInputUpper, read by engine/menus/naming_screen.asm's
-## NamingScreen_ApplyTextInputMode and NamingScreen_GetLastCharacter.
-##
-## The block is one contiguous 374-byte run with every row 17 bytes, so a wrong
-## offset slides every table after it. What pins it is the content: the letter
-## rows, the symbol rows and the command row are all checked by value, and the
-## whole block is compared between the three games, which ship it byte identical.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- naming
+## Verifies the four name-input keyboards against freshly imported real caches, in
+## all three games. Expected values come from the pinned sources'
+## `data/text/name_input_chars.asm`, read by `NamingScreen_ApplyTextInputMode` and
+## `NamingScreen_GetLastCharacter`. The block is one contiguous 374-byte run with
+## every row 17 bytes, so a wrong offset slides every table after it. What pins it
+## is the content: the letter rows, the symbol rows and the command row are all
+## checked by value, and the whole block is compared between the three games, which
+## ship it byte identical.
 
 
 ## Rows per table, in block order. A name keyboard is 5 rows and a box keyboard

--- a/tools/checks/nuzlocke.gd
+++ b/tools/checks/nuzlocke.gd
@@ -3,21 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## The Nuzlocke's area rule against freshly imported real caches, for all three
-## cartridges.
-##
-## A Nuzlocke counts by AREA, and the area a catch belongs to is the landmark
-## `SetCaughtData` writes: `Gen2WorldAPI.landmark_backup`, the same number the
-## Pokemon's own met location carries. So the rule only works if every map a
-## wild can be met on has a landmark of its own. A map that answered
-## `LANDMARK_SPECIAL` would put its encounter on whatever the player last warped
-## from, which is a different area on every visit.
-##
-## The census is the point, the way `wild_encounters.gd`'s is: it is what a
-## Nuzlocke actually has to spend. A landmark shared by several maps is ONE
-## area, which is what makes a multi-floor cave one encounter rather than one
-## per floor, and the two counts differing is what proves that.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- nuzlocke
+## cartridges. A Nuzlocke counts by AREA, and the area a catch belongs to is the
+## landmark `SetCaughtData` writes, so the rule only works if every map a wild can
+## be met on has a landmark of its own: a map answering `LANDMARK_SPECIAL` would put
+## its encounter on whatever the player last warped from. The census is the point,
+## the way `wild_encounters.gd`'s is: a landmark shared by several maps is ONE area,
+## which is what makes a multi-floor cave one encounter rather than one per floor,
+## and the two counts differing is what proves that.
 
 ## Per game: maps carrying a wild table, and the distinct landmarks behind them,
 ## which is how many encounters a Nuzlocke of that cartridge gets.

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -3,18 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the sprites the overworld draws over an object rather than as one,
-## against freshly imported real caches: `data/sprites/emotes.asm`'s twelve
-## sheets and ShakeHeadbuttTree's own.
-##
-## Every expectation comes from the pinned sources: the emote table's tile
-## numbers are `Facings`' own ($f8 for the four-tile bubbles, $fc for the jump
-## shadow and the fishing rod, $fe for the boulder dust and the grass rustle),
-## and all three cartridges ship the art itself byte identical, which is what
-## the cross-cartridge comparison checks. A sheet read at the wrong offset
-## decodes neighbouring code into legal-looking pixels, so shape alone would not
-## catch it.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- overworld_effects
+## against freshly imported real caches: `data/sprites/emotes.asm`'s twelve sheets
+## and ShakeHeadbuttTree's own. Every expectation comes from the pinned sources: the
+## emote table's tile numbers are `Facings`' own, and all three cartridges ship the
+## art itself byte identical, which is what the cross-cartridge comparison checks. A
+## sheet read at the wrong offset decodes neighbouring code into legal-looking
+## pixels, so shape alone would not catch it.
 
 ## The names Gen2WorldImporter writes, with the tile count and VRAM tile each
 ## record must name.

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -2,23 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the pack submenu's three permission tests against freshly imported
-## real caches, over every item row rather than a sampled one.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `engine/items/pack.asm`'s `.ItemBallsKey_LoadSubmenu`, which asks
-## `_CheckTossableItem`, `CheckSelectableItem` and `CheckItemMenu` in that order,
-## `RegisterItem`, and `engine/pokemon/mon_menu.asm`'s `.GiveItem`, whose loop
-## refuses the key item pocket and then whatever `CheckTossableItem` refuses.
-## `data/items/attributes.asm` is byte identical between the pins, so nothing
-## here is profile split.
-##
-## The point of sweeping all 256 rows is that a permission bit read the wrong way
-## round is invisible on the one item a screen test picks: the bit is set on the
-## item that *cannot* do the thing, so an inverted read offers TOSS on every key
-## item and SEL on none.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pack
+## Verifies the pack submenu's three permission tests against freshly imported real
+## caches, over every item row rather than a sampled one. Expected values come from
+## the pinned sources' `.ItemBallsKey_LoadSubmenu`, which asks `_CheckTossableItem`,
+## `CheckSelectableItem` and `CheckItemMenu` in that order, `RegisterItem`, and
+## `.GiveItem`. `data/items/attributes.asm` is byte identical between the pins. The
+## point of sweeping all 256 rows is that a permission bit read the wrong way round
+## is invisible on the one item a screen test picks: the bit is set on the item that
+## *cannot* do the thing, so an inverted read offers TOSS on every key item.
 
 ## The ten rows whose field-menu nibble is ITEMMENU_CLOSE, byte identical
 ## between the pins. The unit tier writes the nibble onto its own fixture, so

--- a/tools/checks/party_icons.gd
+++ b/tools/checks/party_icons.gd
@@ -3,17 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the menu mon icons a party page draws, against freshly imported real
-## caches: `MonMenuIcons` (one of the 38 `ICON_*` shapes per species),
-## `IconPointers`' art behind it, `HeldItemIcons` and `PartyMenuOBPals`.
-##
-## The whole corpus rather than a sample: every species on all three cartridges
-## resolves to an icon whose eight tiles decode and carry ink. The table is a
-## plain byte run, so a wrong offset lands on neighbouring data that still reads
-## as numbers; what says it is the right run is that every entry is in range,
-## that the first and last species are the shapes the source names, and that the
-## three cartridges agree entry for entry.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- party_icons
+## caches: `MonMenuIcons`, `IconPointers`' art behind it, `HeldItemIcons` and
+## `PartyMenuOBPals`. The whole corpus rather than a sample: every species on all
+## three cartridges resolves to an icon whose eight tiles decode and carry ink. The
+## table is a plain byte run, so a wrong offset lands on neighbouring data that
+## still reads as numbers; what says it is the right run is that every entry is in
+## range, that the first and last species are the shapes the source names, and that
+## the three cartridges agree entry for entry.
 
 ## `constants/icon_constants.asm`, the entries the census names.
 const ICON_BULBASAUR: int = 22

--- a/tools/checks/pc.gd
+++ b/tools/checks/pc.gd
@@ -3,16 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Bill's PC's own graphics and its screen against freshly imported real
-## caches, over every species rather than a sampled one.
-##
-## Expected values come from `engine/pokemon/bills_pc.asm`: `BillsPC_InitGFX`'s
-## two runs, `_CGB_BillsPC`'s palettes, `BillsPC_RefreshTextboxes`' listing and
-## `PCMonInfo`'s left column. The sweep is over species because that column is
-## the one thing on the screen whose width is not fixed: a pic wider than its
-## seven-tile cell, or a name wider than the two boxes `ClearBox` leaves for it,
-## would overrun the listing, and no one-species screenshot says so.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pc
+## caches, over every species rather than a sampled one. Expected values come from
+## `engine/pokemon/bills_pc.asm`: `BillsPC_InitGFX`'s two runs, `_CGB_BillsPC`'s
+## palettes, `BillsPC_RefreshTextboxes`' listing and `PCMonInfo`'s left column. The
+## sweep is over species because that column is the one thing on the screen whose
+## width is not fixed: a pic wider than its seven-tile cell, or a name wider than
+## the two boxes `ClearBox` leaves for it, would overrun the listing, and no
+## one-species screenshot says so.
 
 ## `BillsPCOrangePalette`, `gfx/pc/orange.pal`, which is the same four colours in
 ## all three dumps.

--- a/tools/checks/pewter.gd
+++ b/tools/checks/pewter.gd
@@ -3,28 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the walk back from Fuchsia City to Vermilion, through Diglett's Cave
-## onto Route 2, and north to Pewter Gym, against freshly imported real caches
-## for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/maps/attributes.asm, maps/Route11.asm, maps/VermilionCity.asm,
-## maps/DiglettsCave.asm, maps/Route2.asm, maps/PewterCity.asm and
-## maps/PewterGym.asm.
-##
-## Three findings carry the leg. The way back to Vermilion is five plain
-## connections with one gate at the start, not the walk through Lavender and
-## Saffron the route came by, because Route 12 connects west onto Route 11 and
-## Route 11 declares no warps at all. The Route 11 crossing lands inside the
-## eight-cell pocket the Snorlax's own two-by-two body seals off Vermilion's
-## east edge, which is why SnorlaxAwake lists five proximity coordinates rather
-## than the two the port side can stand on. And Diglett's Cave is three
-## disjoint regions joined by two ladders, so it is crossed by warps rather than
-## walked.
-##
-## The Snorlax chain itself, the Route 2 cut and their counts belong to
-## tools/checks/radio.gd and are not repeated here.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pewter
+## onto Route 2, and north to Pewter Gym, for both command profiles. Three findings
+## carry the leg. The way back is five plain connections with one gate at the
+## start, not the walk through Lavender and Saffron the route came by, because
+## Route 12 connects west onto Route 11 and Route 11 declares no warps at all. The
+## Route 11 crossing lands inside the pocket the Snorlax's two-by-two body seals
+## off Vermilion's east edge. And Diglett's Cave is three disjoint regions joined by
+## two ladders, so it is crossed by warps rather than walked.
 
 
 ## constants/map_constants.asm. Only Diglett's Cave splits between the profiles.

--- a/tools/checks/phone.gd
+++ b/tools/checks/phone.gd
@@ -1,16 +1,13 @@
 extends RefCounted
 
 ## Sweeps every imported phone contact and special call on all three cartridges.
-##
 ## `PhoneContacts` is a fixed-width table of two scripts per row and
-## `SpecialPhoneCallList` a table of a condition and a third, and every one of
-## them is reached by a routine rather than by a script the catalog walks: an
-## incoming call takes `PHONE_CONTACT_SCRIPT1`, `Script_SpecialBillCall` takes
-## `PHONE_CONTACT_SCRIPT2` for `PHONE_BILL` alone, and `CheckSpecialPhoneCall`
-## takes the list's own. So a row the importer read short reaches no test and no
-## story walk; it reaches a silent phone.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- phone
+## `SpecialPhoneCallList` a table of a condition and a third, and every one of them
+## is reached by a routine rather than by a script the catalog walks: an incoming
+## call takes `PHONE_CONTACT_SCRIPT1`, `Script_SpecialBillCall` takes `SCRIPT2` for
+## `PHONE_BILL` alone, and `CheckSpecialPhoneCall` takes the list's own. So a row
+## the importer read short reaches no test and no story walk; it reaches a silent
+## phone.
 
 var _r: RefCounted = null
 

--- a/tools/checks/pic_anim.gd
+++ b/tools/checks/pic_anim.gd
@@ -5,25 +5,12 @@ var _collisions: int = 0
 
 ## Sweeps `AnimateFrontpic` over the whole corpus on all three cartridges: every
 ## species and every Unown letter, both scripts, every frame each names, run to
-## completion through [Gen2PicAnimation].
-##
-## What a sampled case cannot say: a frame's tile numbers are remapped by the
-## pic's own height (`.GetTilemap` adds 24 to a 5x5's, 13 to a 6x6's and nothing
-## to a 7x7's), a bitmask is 4, 5 or 7 bytes for the same reason, and the three
-## sizes are 84, 84 and 83 of Crystal's 251. One size proves a third of it.
-##
-## The invariants, all of them the cartridge's own arithmetic rather than a
-## transcribed expectation:
-##
-## - every frame names exactly as many tiles as its bitmask has set bits;
-## - every tile a frame names is inside the run `GetAnimatedEnemyFrontpic`
-##   loads, which is the padded 7x7 box plus the pic's own `w * h` behind it;
-## - every script terminates, and running it leaves no cell of the box outside
-##   that run either;
-## - Gold and Silver have no records at all, which is `pic_animation.asm` being
-##   Crystal's alone rather than an import that failed.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pic_anim
+## completion. What a sampled case cannot say: a frame's tile numbers are remapped
+## by the pic's own height, a bitmask is 4, 5 or 7 bytes for the same reason, and
+## the three sizes are 84, 84 and 83 of Crystal's 251. The invariants are the
+## cartridge's own arithmetic: a frame names as many tiles as its bitmask has set
+## bits, every tile is inside the run `GetAnimatedEnemyFrontpic` loads, every script
+## terminates, and Gold and Silver have no records at all.
 
 const FIRST_SPECIES: int = 1
 const LAST_SPECIES: int = RomLayout.SPECIES_COUNT

--- a/tools/checks/pokecenter_pc.gd
+++ b/tools/checks/pokecenter_pc.gd
@@ -2,23 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the Pokemon Center PC's imported menu tables against freshly
-## imported real caches, in all three games.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `engine/events/pokecenter_pc.asm`'s `PokemonCenterPC.Jumptable`, its
-## `.WhichPC`, `PlayersPCMenuData.PlayersPCMenuPointers` and that menu's own
-## `.WhichPC`, plus the fourteen `text_far` stubs the two routines print
-## through.
-##
-## One pinned address per cartridge finds all of it, so what says the address is
-## right is the content: two runs of `@`-terminated strings, five lists whose
-## entries all name rows those runs have, and fourteen stubs that decode. The
-## three games ship the block identical bar the two boxes that carry a
-## `text_ram` and a `text_decimal` slot, whose addresses are each cartridge's own
-## WRAM; that is checked here rather than assumed.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pokecenter_pc
+## Verifies the Pokemon Center PC's imported menu tables against freshly imported
+## real caches, in all three games. Expected values come from the pinned sources'
+## `PokemonCenterPC.Jumptable`, its `.WhichPC`, `PlayersPCMenuPointers` and that
+## menu's own `.WhichPC`, plus the fourteen `text_far` stubs. One pinned address per
+## cartridge finds all of it, so what says the address is right is the content: two
+## runs of `@`-terminated strings, five lists whose entries all name rows those runs
+## have, and fourteen stubs that decode. The three games ship the block identical
+## bar the two boxes carrying a WRAM address of their own.
 
 ## `.Jumptable`'s strings, in its own order. The first keeps the `<PLAYER>`
 ## marker the cartridge stores.

--- a/tools/checks/pokedex.gd
+++ b/tools/checks/pokedex.gd
@@ -2,21 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the Pokedex's own graphics against freshly imported real caches, on
-## all three cartridges.
-##
-## The expected values come from the pinned sources: `Pokedex_LoadGFX`'s two LZ
-## runs, `gfx/footprints.asm`'s 16x64-tile grid, `Pokedex_LoadUnownFont` and
-## `_CGB_Pokedex`'s three palettes.
-##
-## The real-cartridge counterpart to tests/unit/test_pokedex.gd, which uses a
-## synthetic cache. What only a real cache can say is that the runs decompressed
-## to exactly the tiles the source asks for, that all three dumps carry the same
-## art, that every one of the 251 footprints is a real picture rather than the
-## blank the grid's tail is, and that every species draws an entry screen whose
-## own four footprint cells resolve.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pokedex
+## Verifies the Pokedex's own graphics against freshly imported real caches, on all
+## three cartridges. Expected values come from the pinned sources:
+## `Pokedex_LoadGFX`'s two LZ runs, `gfx/footprints.asm`'s 16x64-tile grid,
+## `Pokedex_LoadUnownFont` and `_CGB_Pokedex`'s three palettes. The real-cartridge
+## counterpart to tests/unit/test_pokedex.gd, which uses a synthetic cache. What
+## only a real cache can say is that the runs decompressed to exactly the tiles the
+## source asks for, that all three dumps carry the same art, and that every one of
+## the 251 footprints is a real picture rather than the blank the grid's tail is.
 
 ## `Pokedex_LoadGFX` decompresses `PokedexLZ` to `vTiles2 tile $31`, so the sheet
 ## number a layout writes is offset by this and the last one it can name is

--- a/tools/checks/pokepic.gd
+++ b/tools/checks/pokepic.gd
@@ -3,17 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies `PadFrontpic`'s placement against freshly imported real caches: the
-## whole species corpus on all three cartridges, through both boxes a front pic
-## is drawn in, `Script_pokepic`'s [Gen2PokepicPage] and the battle screen's own
-## 7x7 block.
-##
-## What a sampled case cannot say: `PadFrontpic` gives a 5x5, a 6x6 and a 7x7
-## three different corners inside `PlaceGraphic`'s block, so a page that centres
-## a pic instead is right about roughly half the corpus. Every species is drawn
-## and its ink is required to sit inside the frame and above the interior's last
-## row, which is the row `lb bc, 7, 7` leaves empty in an eight-row interior.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- pokepic
+## whole species corpus on all three cartridges, through both boxes a front pic is
+## drawn in, `Script_pokepic`'s [Gen2PokepicPage] and the battle screen's own 7x7
+## block. What a sampled case cannot say: `PadFrontpic` gives a 5x5, a 6x6 and a
+## 7x7 three different corners inside `PlaceGraphic`'s block, so a page that centres
+## a pic instead is right about roughly half the corpus. Every species is drawn and
+## its ink is required to sit inside the frame and above the interior's last row.
 
 ## `data/pokemon/base_stats/`'s own range.
 const FIRST_SPECIES: int = 1

--- a/tools/checks/printer.gd
+++ b/tools/checks/printer.gd
@@ -2,16 +2,13 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the diploma's art, the printer's status run and the Unown printer's
-## own browser against freshly imported real caches on all three cartridges.
-##
+## Verifies the diploma's art, the printer's status run and the Unown printer's own
+## browser against freshly imported real caches on all three cartridges.
 ## `DiplomaGFX` and its two tilemaps are one pinned run: the LZ stream has to
-## decompress to exactly its own tile count and both tilemaps have to index
-## inside it, so an address one byte out fails rather than drawing rubbish. The
-## strings are the other half of the pin: `GBPrinterStrings` opens on the empty
-## string a status of zero prints, and a run pinned wrong would put a line there.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- printer
+## decompress to exactly its own tile count and both tilemaps have to index inside
+## it, so an address one byte out fails rather than drawing rubbish. The strings are
+## the other half of the pin: `GBPrinterStrings` opens on the empty string a status
+## of zero prints, and a run pinned wrong would put a line there.
 
 ## `PlaceDiplomaOnScreen`'s tilemaps are whole screens, and page 1's own corner
 ## is the certificate's top-left border tile.

--- a/tools/checks/prize_money.gd
+++ b/tools/checks/prize_money.gd
@@ -3,18 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies what a beaten trainer pays, against freshly imported real caches, on
-## all three cartridges.
-##
-## Two halves. `TrainerClassAttributes`' base rewards are transcribed below from
-## the pinned `data/trainers/attributes.asm` rather than read back out of the
-## cache, so an importer that shifted a row by a byte goes red. Then every
-## individual trainer in the corpus is walked through the seam a battle uses,
-## `ComputeTrainerReward` into [method Gen2Battle.prize_money_split], and what
-## comes out is checked against the arithmetic the source spells: four quarters
-## of base times the last member's level, doubled by the Amulet Coin, split with
-## Mom whole.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- prize_money
+## all three cartridges. Two halves. `TrainerClassAttributes`' base rewards are
+## transcribed below from the pinned `data/trainers/attributes.asm` rather than read
+## back out of the cache, so an importer that shifted a row by a byte goes red. Then
+## every individual trainer in the corpus is walked through the seam a battle uses,
+## and what comes out is checked against the arithmetic the source spells: four
+## quarters of base times the last member's level, doubled by the Amulet Coin,
+## split with Mom whole.
 
 ## `data/trainers/attributes.asm`, in class order from FALKNER. Gold and Silver
 ## are the first 66 of these; Crystal adds MYSTICALMAN, the 67th, and the rows

--- a/tools/checks/radio.gd
+++ b/tools/checks/radio.gd
@@ -2,24 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the Pokegear radio card and the one thing in the overworld that
-## reads what it leaves behind: Vermilion City's Snorlax.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## engine/pokegear/pokegear.asm (RadioChannels, LoadStation_*,
-## ExitPokegearRadio_HandleMusic), engine/pokegear/radio.asm
-## (StartRadioStation), data/radio/channel_music.asm,
-## engine/events/specials.asm (SnorlaxAwake), data/sprites/map_objects.asm
-## (BIG_OBJECT) and maps/VermilionCity.asm.
-##
-## Two findings carry it. The Poke Flute channel is the only way a track other
-## than the map's own reaches `wMapMusic`, because a station's music id is
-## neither of the two sentinels ExitPokegearRadio_HandleMusic restores on; and
-## the Snorlax is a BIG_OBJECT, so it fills four cells rather than one, which is
-## exactly why SnorlaxAwake's five proximity coordinates are the cells they are
-## and why the Diglett's Cave mouth above it has no approach while it stands.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- radio
+## Verifies the Pokegear radio card and the one thing in the overworld that reads
+## what it leaves behind: Vermilion City's Snorlax. Expected values come from the
+## pinned sources' radio tables, `SnorlaxAwake`, the BIG_OBJECT row and
+## maps/VermilionCity.asm. Two findings carry it. The Poke Flute channel is the only
+## way a track other than the map's own reaches `wMapMusic`, because a station's
+## music id is neither of the two sentinels the exit restores on. And the Snorlax is
+## a BIG_OBJECT filling four cells rather than one, which is why SnorlaxAwake's five
+## proximity coordinates are the cells they are.
 
 
 ## constants/map_constants.asm.

--- a/tools/checks/radio_tower.gd
+++ b/tools/checks/radio_tower.gd
@@ -2,22 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the gates the Goldenrod Radio Tower leg turns, against freshly
-## imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `maps/BlackthornCity.asm`, `maps/RadioTower2F.asm`, `maps/RadioTower3F.asm`
-## and `maps/GoldenrodUndergroundSwitchRoomEntrances.asm`. Blackthorn City's
-## event rows, RadioTower3F whole, and the switch room's `ugdoor_def` table and
-## `..._UpdateDoors` body are byte identical between the pins, and every event
-## flag below has the same number in both.
-##
-## The leg is route work, so what is worth pinning is not the scripts but the
-## three places a wrong flag or a missed `changeblock` would silently seal the
-## route: Blackthorn Gym's door, Radio Tower 2F's stairs and 3F's card-key
-## shutter, and the switch room's eleven doors.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- radio_tower
+## Verifies the gates the Goldenrod Radio Tower leg turns, for both command
+## profiles. Expected values come from the pinned sources' BlackthornCity,
+## RadioTower2F, RadioTower3F and the switch room; Blackthorn's event rows,
+## RadioTower3F whole, and the switch room's `ugdoor_def` table and update body are
+## byte identical between the pins, and every event flag below has the same number
+## in both. The leg is route work, so what is worth pinning is not the scripts but
+## the three places a wrong flag or a missed `changeblock` would silently seal it:
+## the gym door, the tower's stairs and card-key shutter, and the eleven doors.
 
 
 ## data/maps/maps.asm group/number pairs. Blackthorn City and the Radio Tower

--- a/tools/checks/rising_badge.gd
+++ b/tools/checks/rising_badge.gd
@@ -2,23 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the gates between Blackthorn Gym's door and the Rising Badge,
-## against freshly imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `maps/BlackthornGym2F.asm`, `maps/BlackthornGym1F.asm`,
-## `maps/BlackthornCity.asm` and `maps/DragonsDenB1F.asm`. Gym 2F's map events
-## and `BlackthornGym1FBouldersCallback` are byte identical between the pins;
-## Gold and Silver have no Dragon Shrine, so their B1F carries no warp to it and
-## the shrine checks are Crystal only.
-##
-## What is worth pinning here is not the scripts but the four places the leg
-## would silently stop: the two boulders that seal 2F's pockets, the two 1F
-## `changeblock`s that actually open Clair's room, the lake that is the only way
-## to the Dragon's Den door, and the whirlpool between the den ladder and the
-## shrine's one landfall.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- rising_badge
+## Verifies the gates between Blackthorn Gym's door and the Rising Badge, for both
+## command profiles. Gym 2F's map events and `BlackthornGym1FBouldersCallback` are
+## byte identical between the pins; Gold and Silver have no Dragon Shrine, so their
+## B1F carries no warp to it and the shrine checks are Crystal only. What is worth
+## pinning is not the scripts but the four places the leg would silently stop: the
+## two boulders that seal 2F's pockets, the two 1F `changeblock`s that open Clair's
+## room, the lake that is the only way to the Dragon's Den door, and the whirlpool
+## between the den ladder and the shrine's one landfall.
 
 
 ## data/maps/maps.asm group/number pairs. The gym floors and the city sit at the

--- a/tools/checks/rock_smash.gd
+++ b/tools/checks/rock_smash.gd
@@ -3,21 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Rock Smash against freshly imported real caches, for both command
-## profiles.
-##
-## The expected values come from the pinned pokecrystal and pokegold sources:
-## engine/events/overworld.asm's TryRockSmashFromMenu, RockSmashScript and
-## AskRockSmashScript, engine/events/treemons.asm's RockMonEncounter,
-## engine/events/std_scripts.asm's SmashRockScript, and
-## data/sprites/map_objects.asm's SPRITEMOVEDATA_SMASHABLE_ROCK row.
-##
-## The real-cartridge counterpart to the rock half of
-## tests/unit/test_world_treemon.gd and
-## tests/integration/test_world_field_move_screen.gd. Cianwood City is the
-## acceptance case, because its six rocks are the largest population and its map
-## is one of the four RockMonMaps names.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- rock_smash
+## profiles. Expected values come from the pinned sources: TryRockSmashFromMenu,
+## RockSmashScript and AskRockSmashScript, RockMonEncounter, SmashRockScript and the
+## SPRITEMOVEDATA_SMASHABLE_ROCK row. The real-cartridge counterpart to the rock
+## half of tests/unit/test_world_treemon.gd and the field-move screen test. Cianwood
+## City is the acceptance case, because its six rocks are the largest population and
+## its map is one of the four RockMonMaps names.
 
 
 ## constants/map_constants.asm. Cianwood City and Route 40 keep their numbers

--- a/tools/checks/route_27.gd
+++ b/tools/checks/route_27.gd
@@ -2,27 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies why the walked route stops on Route 27, against freshly imported
-## real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## `maps/Route27.asm`, `maps/TohjoFalls.asm` and
-## `engine/overworld/player_movement.asm`. `TohjoFalls.blk` is byte identical
-## between the pins; `Route27.blk` is not, so its land census is profile split
-## while every water figure happens to match.
-##
-## Two halves. The first is geometry, and it is why this leg waited on
-## Waterfall: Route 27's landfall region reaches no map edge; the only crossing
-## of the channel east of it starts in a pocket that can only be left through
-## Tohjo Falls; and the cave's two lower channels reach each other only over
-## `COLL_WATERFALL` cells, which `.CheckTile` will only ever step a player down.
-##
-## The second is the way through, now that there is one. With the Rising Badge
-## the climb at the foot of the west column reaches the pool in a single
-## commit, and the east column is ridden back down by the same forced-tile rule
-## that made it a wall in the first place.
-##
-##   Godot --headless -s res://tools/checks/route_27.gd
+## Verifies why the walked route stops on Route 27, for both command profiles.
+## `TohjoFalls.blk` is byte identical between the pins; `Route27.blk` is not, so its
+## land census is profile split. Two halves. The first is geometry, and it is why
+## this leg waited on Waterfall: Route 27's landfall region reaches no map edge, the
+## only crossing east of it starts in a pocket that can only be left through Tohjo
+## Falls, and the cave's two lower channels reach each other only over
+## `COLL_WATERFALL` cells. The second is the way through: with the Rising Badge the
+## climb reaches the pool in a single commit.
 
 
 ## data/maps/maps.asm group/number pairs. Route 27 sits at the same pair in both

--- a/tools/checks/saffron.gd
+++ b/tools/checks/saffron.gd
@@ -2,24 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the way into Saffron City and its gym's warp maze against freshly
-## imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/SaffronCity.asm, maps/SaffronGym.asm, maps/Route6.asm,
-## maps/Route6SaffronGate.asm and data/maps/attributes.asm. The city, the gym and
-## the gate are byte identical between the pins; Route 6 differs only in the two
-## extra Pokefans Crystal puts on (9,12) and (10,12), both sight range 0, so
-## nothing here is profile split.
-##
-## Two things are worth pinning. Saffron has a real south connection to Route 6,
-## but the city's own south row is wall everywhere Route 6's north edge aligns
-## to, so `ROUTE_6_SAFFRON_GATE` is the only way in, the way Route 31's gate is
-## into Violet. And Saffron Gym is nine rooms with no walkable path between them,
-## joined only by fifteen pairs of self-warps: Sabrina's room holds exactly one
-## pad and exactly one pad reaches it, so the way in is a fixed chain.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- saffron
+## Verifies the way into Saffron City and its gym's warp maze, for both command
+## profiles. The city, the gym and the gate are byte identical between the pins;
+## Route 6 differs only in the two extra Pokefans Crystal puts on (9,12) and
+## (10,12), both sight range 0, so nothing here is profile split. Two things are
+## worth pinning. Saffron has a real south connection to Route 6, but the city's own
+## south row is wall everywhere that edge aligns to, so the gate is the only way in.
+## And Saffron Gym is nine rooms with no walkable path between them, joined by
+## fifteen pairs of self-warps, so the way to Sabrina is a fixed chain.
 
 
 ## constants/map_constants.asm.

--- a/tools/checks/screen_palettes.gd
+++ b/tools/checks/screen_palettes.gd
@@ -3,32 +3,22 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies `_CGB_StatsScreenHPPals` and `_CGB_MoveList` against freshly imported
-## real caches: every species, every page, on all three cartridges.
-##
-## What a sampled case cannot say: the two screens are drawn in six palettes at
-## once and every one of them is a different table. A page drawn in one palette
-## is right about the text and wrong about everything else, and a slot one out
-## still produces a legible screen, so what is checked here is CONTAINMENT: the
-## colours a region is drawn in have to come from the palette its attrmap slot
-## names and from no other. The regions differ per species (the mon palette),
-## per page (the tint) and per hit points (the HP palette), which is why the
-## sweep is the corpus rather than one Pokémon.
-##
-## `LoadStatsScreenPals` writes the open page's colour over colour 0 of the HP
-## and exp palettes alone, so the tint is checked as an identity as well: the
-## lower half's background IS `StatsScreenPals`' own entry for that page.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- screen_palettes
+## real caches: every species, every page, on all three cartridges. What a sampled
+## case cannot say: the two screens are drawn in six palettes at once and every one
+## is a different table, and a slot one out still produces a legible screen. So what
+## is checked is CONTAINMENT: the colours a region is drawn in have to come from the
+## palette its attrmap slot names and from no other. `LoadStatsScreenPals` writes
+## the open page's colour over colour 0 of the HP and exp palettes alone, so the
+## tint is checked as an identity as well.
 
-## Every screen the source draws a Pokemon's SHINY colours on, by the layout it
-## asks for: `_CGB_BattleColors`, `_CGB_StatsScreenHPPals`, `_CGB_BillsPC`,
+## Every screen the source draws a Pokemon's SHINY colours on, by the layout it asks
+## for: `_CGB_BattleColors`, `_CGB_StatsScreenHPPals`, `_CGB_BillsPC`,
 ## `_CGB_Evolution` (which breeding's hatch asks for too) and
-## `_CGB_PlayerOrMonFrontpicPals` (the Hall of Fame and the trade animation).
-## Every one of them reaches `GetMonNormalOrShinyPalettePointer`.
-##
-## Named here because the list is the point: `_CGB_Pokedex` and `_CGB_PartyMenu`
-## are NOT on it, so the dex and the party menu's icons are drawn in ordinary
-## colours on the cartridge and must not be "fixed" here.
+## `_CGB_PlayerOrMonFrontpicPals` (the Hall of Fame and the trade animation). Every
+## one reaches `GetMonNormalOrShinyPalettePointer`. Named here because the list is
+## the point: `_CGB_Pokedex` and `_CGB_PartyMenu` are NOT on it, so the dex and the
+## party menu's icons are drawn in ordinary colours on the cartridge and must not be
+## "fixed" here.
 const SHINY_LAYOUTS: Array[String] = [
 	"battle", "stats screen", "Bill's PC", "evolution and hatch",
 	"Hall of Fame and trade",

--- a/tools/checks/second_screen.gd
+++ b/tools/checks/second_screen.gd
@@ -3,20 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the lower display against freshly imported real caches, on all three
-## cartridges.
-##
-## Three things only a real cache can say. That every tab the START menu's gate
-## opens has a page this cache can actually draw, which is what
-## [method Gen2SecondScreen._build_page] refuses on. That every tab's icon is
-## really in the sheet it names, at the pixels it names, rather than a rectangle
-## of one colour cut from the wrong place. And that Kris's own pack and card
-## picture are taken where Crystal ships them and fall back to Chris's where
-## pokegold does not.
-##
-## The gate itself is `SetUpMenuItems`' and is asserted against the START menu in
+## cartridges. Three things only a real cache can say. That every tab the START
+## menu's gate opens has a page this cache can actually draw. That every tab's icon
+## is really in the sheet it names, at the pixels it names, rather than a rectangle
+## of one colour cut from the wrong place. And that Kris's own pack and card picture
+## are taken where Crystal ships them and fall back to Chris's where pokegold does
+## not. The gate itself is asserted against the START menu in
 ## tests/unit/test_second_screen.gd, which needs no cartridge.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- second_screen
 
 ## Every state the three gates can be in, as `[party, pokedex, pokegear]`. All
 ## eight, because a run reaches most of them: the Pokegear arrives before the dex

--- a/tools/checks/side_walls.gd
+++ b/tools/checks/side_walls.gd
@@ -2,18 +2,13 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies side-wall and side-buoy directional masks against freshly imported
-## real caches, for both command profiles. The expected codes come from the
-## pinned pokecrystal and pokegold sources: home/map.asm's
-## GetMovementPermissions and engine/overworld/npc_movement.asm's
-## CanObjectLeaveTile/WillObjectBumpIntoTile.
-##
-## The real-cartridge counterpart to the side-wall cases in
-## tests/unit/test_world_collision.gd and tests/unit/test_world_api.gd, which
-## use synthetic caches. It also pins the map census, so a future cache change
-## is loud.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- side_walls
+## Verifies side-wall and side-buoy directional masks against freshly imported real
+## caches, for both command profiles. The expected codes come from the pinned
+## sources: `GetMovementPermissions` and
+## `CanObjectLeaveTile`/`WillObjectBumpIntoTile`. The real-cartridge counterpart to
+## the side-wall cases in tests/unit/test_world_collision.gd and
+## tests/unit/test_world_api.gd, which use synthetic caches. It also pins the map
+## census, so a future cache change is loud.
 
 ## constants/map_constants.asm's CELADON_MANSION_ROOF, Crystal map group 21
 ## number 15. The only map in either pinned cartridge with $b0 or $b1 cells: a

--- a/tools/checks/slots.gd
+++ b/tools/checks/slots.gd
@@ -1,21 +1,13 @@
 extends RefCounted
 
 ## Sweeps `_SlotMachine` on freshly imported real caches, all three cartridges.
-##
-## Every expectation below is transcribed from pokecrystal's own
-## engine/games/slot_machine.asm rather than read back out of the
-## implementation, which is the only way the topic can go red: the three reel
-## strips, the payout table, both bias tables, the six symbols' own line rules
-## and the section's own sizes are the source's tables, and the art is re-read
-## out of the dump beside the cache rather than compared with itself.
-##
-## The class of bug it exists to catch is a reel that lines up something the
-## bias did not ask for. `Slots_CheckMatchedAllThreeReels` is five row tests
-## behind a bet, and a window read one symbol out still matches *something*, so
-## the check drives whole spins on a pinned seed and asserts what stopped where:
-## every bet, every bias, every reel, on all three cartridges.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- slots
+## Every expectation is transcribed from pokecrystal's own
+## engine/games/slot_machine.asm rather than read back out of the implementation,
+## which is the only way the topic can go red, and the art is re-read out of the
+## dump beside the cache. The class of bug it catches is a reel that lines up
+## something the bias did not ask for: `Slots_CheckMatchedAllThreeReels` is five row
+## tests behind a bet and a window read one symbol out still matches something, so
+## the check drives whole spins on a pinned seed and asserts what stopped where.
 
 ## `Reel1Tilemap`, `Reel2Tilemap` and `Reel3Tilemap`, byte for byte, including
 ## the first three symbols each repeats behind itself.

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -1,22 +1,13 @@
 extends RefCounted
 
-## Sweeps every cached map script on all three cartridges for the `special`
-## command and asserts that each index it reaches is one this project answers,
-## or one of the named routines it deliberately does not.
-##
-## The class this exists to stop is a dispatch gap rather than a wrong reading:
-## `Gen2WorldScriptRunner._execute_special` fails an index it does not name, and
-## `_run_command`'s own `_fail` then stops the script where it stands, so one
-## missing entry is a wall in front of every NPC that reaches it. Nothing else
-## in the suite sees that, because a test reaches the specials it was written
-## for and a story walk reaches the maps it was written for.
-##
-## `data/events/special_pointers.asm` is the corpus and the runner's own match
-## is the claim, so the difference is derived rather than kept by hand:
-## `EXPECTED_DEFERRED` names what is left, and a routine leaving that list is a
-## line deleted here rather than a number edited.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- specials
+## Sweeps every cached map script on all three cartridges for the `special` command
+## and asserts that each index it reaches is one this project answers, or one of the
+## named routines it deliberately does not. The class this exists to stop is a
+## dispatch gap rather than a wrong reading: an index the runner does not name stops
+## the script where it stands, so one missing entry is a wall in front of every NPC
+## that reaches it. `data/events/special_pointers.asm` is the corpus and the
+## runner's own match is the claim, so the difference is derived:
+## `EXPECTED_DEFERRED` names what is left.
 
 ## Every index the corpus reaches that this project answers with nothing, and
 ## the feature each belongs to. `Gen2WorldScriptRunner` is checked against this
@@ -43,16 +34,14 @@ const EXPECTED_DEFERRED: Dictionary = {
 	64: "FindPartyMonAboveLevel",
 }
 
-## Decoded `special` operands that name no `SpecialsPointers` entry. Pinned
-## rather than filtered, so a walker that starts overrunning a script again is
-## caught here: every one of these comes from a cached script pointer, and a
-## pointer only exists because some walk collected it.
-##
-## Crystal's one is the cartridge's own. BattleTowerElevator.asm's receptionist
-## is an `OBJECTTYPE_SCRIPT` object whose script word is
-## `MovementData_BattleTowerElevatorReceptionistWalksIn`, so the bytes behind it
-## are movement rather than commands; the object stands in a room the scene
-## script drives and is never talked to.
+## Decoded `special` operands that name no `SpecialsPointers` entry. Pinned rather
+## than filtered, so a walker that starts overrunning a script again is caught here:
+## every one of these comes from a cached script pointer, and a pointer only exists
+## because some walk collected it. Crystal's one is the cartridge's own.
+## BattleTowerElevator.asm's receptionist is an `OBJECTTYPE_SCRIPT` object whose
+## script word is a movement data label, so the bytes behind it are movement rather
+## than commands; the object stands in a room the scene script drives and is never
+## talked to.
 const EXPECTED_OUT_OF_TABLE: Dictionary = {&"crystal": 1, &"gold": 0, &"silver": 0}
 
 ## The five fades and what each of them costs, from `ConvertTimePals*HL`'s own

--- a/tools/checks/ss_aqua.gd
+++ b/tools/checks/ss_aqua.gd
@@ -2,24 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the S.S. Aqua's interior against freshly imported real caches, for
-## both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/FastShip1F.asm, maps/FastShipB1F.asm, maps/FastShipCabins_NNW_NNE_NE.asm,
-## maps/FastShipCabins_SE_SSE_CaptainsCabin.asm and constants/event_flags.asm.
-## All five maps' event tables are byte identical between the pins and every
-## event flag below has the same number in both, so nothing here is profile
-## split; only the text and Crystal's own gender branch differ.
-##
-## The crossing is one puzzle. B1F's two sailors stand on (30,6) and (31,6) and
-## the coord events below them each move the visible one onto the player's own
-## column, so the corridor west is sealed for as long as the map scene is
-## SCENE_FASTSHIPB1F_SAILOR_BLOCKS. Nothing on B1F opens it: the on-duty sailor
-## reveals the lazy one in the NE cabin, and that sailor's own script sets
-## SCENE_FASTSHIPB1F_NOOP, which retires both coord events.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- ss_aqua
+## Verifies the S.S. Aqua's interior against freshly imported real caches, for both
+## command profiles. All five maps' event tables are byte identical between the pins
+## and every event flag below has the same number in both, so nothing here is
+## profile split; only the text and Crystal's own gender branch differ. The crossing
+## is one puzzle: B1F's two sailors stand on (30,6) and (31,6) and the coord events
+## below them each move the visible one onto the player's own column, so the corridor
+## west is sealed while the map scene is SCENE_FASTSHIPB1F_SAILOR_BLOCKS. Nothing on
+## B1F opens it: the lazy sailor's own script is what retires both coord events.
 
 
 ## `constants/map_constants.asm`'s 15th `newgroup`.

--- a/tools/checks/story_map_ids.gd
+++ b/tools/checks/story_map_ids.gd
@@ -3,22 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the profile map ids `tools/preview_world_story.gd` resolves by name
-## against freshly imported real caches, for both command profiles.
-##
-## A map number counts from its group's first entry, so a map pokegold does not
-## ship shifts every later number in that group: group 3 runs eight lower from
-## UNION_CAVE_1F on, because pokecrystal inserts eight Ruins of Alph word and
-## item rooms (constants/map_constants.asm). The route walker names only the
-## maps it reaches by id rather than by cell, and only Ilex Forest is on a
-## walked leg today; the other three are read by the Mahogany and Rocket Base
-## legs, which no Gold walk reaches yet, so a wrong number there would be
-## silent. That is what this file is for.
-##
-## Each row carries the map's own block dimensions from its `map_const`, which
-## is what makes a wrong number loud: every number in this table resolves to a
-## differently sized map on the other profile.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- story_map_ids
+## against freshly imported real caches, for both command profiles. A map number
+## counts from its group's first entry, so a map pokegold does not ship shifts every
+## later number in that group: group 3 runs eight lower from UNION_CAVE_1F on. The
+## route walker names only the maps it reaches by id, and only Ilex Forest is on a
+## walked leg today, so a wrong number in the other three would be silent. Each row
+## carries the map's own block dimensions from its `map_const`, which is what makes
+## a wrong number loud.
 
 
 ## name: [crystal id, gold id, block width, block height]. The dimensions are

--- a/tools/checks/strength.gd
+++ b/tools/checks/strength.gd
@@ -2,23 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies Strength and boulder pushing against freshly imported real caches,
-## for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## engine/events/overworld.asm's StrengthFunction, TryStrengthOW and
-## AskStrengthScript, engine/overworld/player_movement.asm's
-## DoPlayerMovement.CheckStrengthBoulder, engine/overworld/map_objects.asm's
-## MovementFunction_Strength and engine/overworld/npc_movement.asm's
-## CanObjectMoveInDirection. All five are byte identical between the pins, so
-## nothing here is profile split except the two engine flag numbers.
-##
-## The real-cartridge counterpart to the Strength cases in
-## tests/unit/test_world_field_move.gd and tests/unit/test_world_api.gd.
-## Cianwood Gym is the acceptance case, because its three-boulder wall is what a
-## playthrough meets first.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- strength
+## Verifies Strength and boulder pushing against freshly imported real caches, for
+## both command profiles. Expected values come from the pinned sources:
+## StrengthFunction, TryStrengthOW, AskStrengthScript, `.CheckStrengthBoulder`,
+## `MovementFunction_Strength` and `CanObjectMoveInDirection`, all byte identical
+## between the pins, so nothing here is profile split except the two engine flag
+## numbers. The real-cartridge counterpart to the Strength cases in the two world
+## unit tests; Cianwood Gym is the acceptance case, its three-boulder wall being
+## what a playthrough meets first.
 
 
 ## constants/map_constants.asm, CIANWOOD group. Unlike Dragon's Den, the group

--- a/tools/checks/surf.gd
+++ b/tools/checks/surf.gd
@@ -3,19 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Surf against freshly imported real caches, for both command profiles.
-##
-## The expected values come from the pinned pokecrystal and pokegold sources:
-## engine/events/overworld.asm's SurfFunction (.TrySurf, GetSurfType,
-## CheckDirection) and UsedSurfScript, engine/overworld/player_object.asm's
-## SurfStartStep, and engine/overworld/player_movement.asm's .TrySurf/.ExitWater.
-##
-## The real-cartridge counterpart to tests/unit/test_world_field_move.gd, which
-## uses a synthetic cache. New Bark Town is the acceptance case: its east shore
-## is the first real water a player walks up to, and maps/NewBarkTown.blk and
-## data/tilesets/johto_collision.asm are byte identical between the pins, so the
-## same cells answer on all three games.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- surf
+## Expected values come from the pinned sources: SurfFunction (.TrySurf,
+## GetSurfType, CheckDirection) and UsedSurfScript, SurfStartStep, and
+## `.TrySurf`/`.ExitWater`. The real-cartridge counterpart to
+## tests/unit/test_world_field_move.gd, which uses a synthetic cache. New Bark Town
+## is the acceptance case: its east shore is the first real water a player walks up
+## to, and both its `.blk` and the johto collision table are byte identical between
+## the pins, so the same cells answer on all three games.
 
 
 ## constants/map_constants.asm, NEW_BARK group. Unlike Ilex Forest, Crystal's

--- a/tools/checks/tile_anims.gd
+++ b/tools/checks/tile_anims.gd
@@ -2,22 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Every tileset's `wTilesetAnim` command list, on all three cartridges, run for
-## a whole cycle.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- tile_anims
-##
-## The list is `data/tileset_anims.asm` and the commands are
-## `engine/tilesets/tileset_anims.asm`, both byte identical between the pins
-## apart from the addresses `RomLayout`'s `world_animation_functions` names. What
-## a reading of them costs is which command ticks `wTileAnimationTimer`:
+## Every tileset's `wTilesetAnim` command list, on all three cartridges, run for a
+## whole cycle. The list and its commands are byte identical between the pins apart
+## from the addresses `RomLayout`'s `world_animation_functions` names. What a
+## reading of them costs is which command ticks `wTileAnimationTimer`:
 ## `StandingTileFrame8` and `StandingTileFrame` do, and so does
 ## `ScrollTileRightLeft`, which is the **only** tick the cave, dark cave and ice
 ## path lists have. A timer that never moves leaves those three maps with a still
-## water palette, a still cave flicker and a tile scrolling one way for ever.
-##
-## `.claude/oracle/overworld/trace_tiles.py` and `tools/trace_world_tiles.gd` are
-## the frame-by-frame half of this, against a real cartridge.
+## water palette and a tile scrolling one way for ever.
 
 ## The whole set `Gen2WorldAnimation.tick` implements, which is every label
 ## `_AnimateTileset` can `jp hl` to. An operation outside it is an unread

--- a/tools/checks/tmhm.gd
+++ b/tools/checks/tmhm.gd
@@ -2,21 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the TM/HM table and compatibility flags against freshly imported
-## real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## data/moves/tmhm_moves.asm's TMHMMoves, engine/items/items.asm's
-## GetTMHMNumber and GetNumberedTMHM, engine/items/tmhm2.asm's CanLearnTMHMMove
-## and engine/items/tmhm.asm's AskTeachTMHM and TeachTMHM. All are byte identical
-## between the pins apart from one stubbed trainer-ranking call, so nothing here
-## is profile split except the table's own length.
-##
-## The real-cartridge counterpart to tests/unit/test_world_tmhm.gd. The census is
-## what actually pins it: every species' learnable set is compared against the
-## table rather than spot checked, so a wrong flag bit order shows up at once.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- tmhm
+## Verifies the TM/HM table and compatibility flags against freshly imported real
+## caches, for both command profiles. Expected values come from the pinned sources:
+## `TMHMMoves`, `GetTMHMNumber`, `GetNumberedTMHM`, `CanLearnTMHMMove`,
+## `AskTeachTMHM` and `TeachTMHM`, all byte identical between the pins apart from
+## one stubbed trainer-ranking call. The real-cartridge counterpart to
+## tests/unit/test_world_tmhm.gd. The census is what actually pins it: every
+## species' learnable set is compared against the table rather than spot checked, so
+## a wrong flag bit order shows up at once.
 
 
 ## constants/item_constants.asm: fifty TMs and seven HMs in both games, plus

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -3,24 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies the region map against freshly imported real caches, on all three
-## cartridges.
-##
-## The expected values come from the pinned sources: data/maps/landmarks.asm,
-## gfx/pokegear/johto.bin and kanto.bin, gfx/pokegear/town_map_palette_map.asm,
-## and engine/pokegear/pokegear.asm's `_TownMap`, `PokegearMap` and
-## `TownMap_GetKantoLandmarkLimits`.
-##
-## The Pokegear's other three cards are swept here too: they are the same VRAM
-## window, the same palettes and the same page.
-##
-## The real-cartridge counterpart to tests/unit/test_town_map.gd and
-## test_town_map_page.gd, which use a synthetic cache. What only a real cache can
-## say is that the 96 landmarks and the two 360-cell maps decoded, that the
-## Gold/Silver split is exactly the one `BATTLE TOWER` causes, that every
-## landmark's icon lands on the screen it is drawn on, and that `FindNest` keeps
-## each region's own wild tables over all 251 species.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- town_map
+## cartridges, and the Pokegear's other three cards with it, since they are the same
+## VRAM window, palettes and page. Expected values come from the pinned sources'
+## landmarks, the two region `.bin`s, the palette map and `_TownMap`. The
+## real-cartridge counterpart to tests/unit/test_town_map.gd. What only a real cache
+## can say is that the 96 landmarks and the two 360-cell maps decoded, that the
+## Gold/Silver split is exactly the one `BATTLE TOWER` causes, and that `FindNest`
+## keeps each region's own wild tables over all 251 species.
 
 
 ## The one landmark Gold and Silver do not ship, and the two either side of it in
@@ -83,17 +72,14 @@ func run(r: RefCounted) -> void:
 		_verify_cards(game_id, _data)
 
 
-## `Flypoints` and `SpawnPoints` against the cache they were imported beside:
-## every flypoint names a landmark the region map draws and a spawn the table
-## holds, and every spawn names a map this cartridge ships.
-##
-## The landmark column is the profile-split half, so this is where it is swept:
-## Gold and Silver ship one landmark fewer, and a Crystal number read on either
-## of them lands on the wrong city.
-## `_FlyMap`'s own walk on a real cache: with every flypoint visited, one press
-## per row reaches each of the region's twelve and comes back to where it
-## started, and every cursor lands on a landmark the region map draws an icon
-## for.
+## `Flypoints` and `SpawnPoints` against the cache they were imported beside: every
+## flypoint names a landmark the region map draws and a spawn the table holds, and
+## every spawn names a map this cartridge ships. The landmark column is the
+## profile-split half, so this is where it is swept: Gold and Silver ship one
+## landmark fewer, and a Crystal number read on either lands on the wrong city.
+## Below, `_FlyMap`'s own walk on a real cache: with every flypoint visited, one
+## press per row reaches each of the region's twelve and comes back to where it
+## started.
 func _verify_fly_walk(game_id: StringName, _data: GameData) -> void:
 	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
 	var visited: Array[int] = []

--- a/tools/checks/unown_dex.gd
+++ b/tools/checks/unown_dex.gd
@@ -5,16 +5,11 @@ var _r: RefCounted = null
 ## Verifies the Unown dex against freshly imported real caches: `UnownWords`, the
 ## twenty-six pics `Pokedex_LoadUnownFrontpicTiles` draws from, `GetUnownLetter`
 ## over every DV word a Pokemon can carry, and `UnownWalls` on the eight Ruins of
-## Alph patterns that ask for one.
-##
-## The whole corpus rather than a sample: all 65,536 DV words on each cartridge,
-## every letter, every form's picture and every chamber wall. The words are a
-## plain byte run behind their own pointer table, so a wrong offset lands on
-## neighbouring data that still reads as letters; what says it is the right run
-## is that each word opens on its own letter, that the run starts where the table
-## ends, and that the three cartridges agree word for word.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- unown_dex
+## Alph patterns that ask for one. The whole corpus rather than a sample: all 65,536
+## DV words on each cartridge. The words are a plain byte run behind their own
+## pointer table, so a wrong offset lands on neighbouring data that still reads as
+## letters; what says it is the right run is that each word opens on its own letter
+## and that the three cartridges agree word for word.
 
 ## `data/pokemon/unown_words.asm`'s first and last, either side of the run.
 const FIRST_WORD: String = "ANGRY"

--- a/tools/checks/unown_puzzle.gd
+++ b/tools/checks/unown_puzzle.gd
@@ -1,22 +1,13 @@
 extends RefCounted
 
-## Sweeps `_UnownPuzzle` on freshly imported real caches, all three cartridges,
-## all four pictures, all thirty-six cells and all sixteen pieces.
-##
-## Every expectation below is transcribed from pokecrystal's own
-## engine/games/unown_puzzle.asm rather than read back out of the
-## implementation, which is the only way the topic can go red: the corners, the
-## solved configuration, the two OAM sets and the cursor's own hand-listed edges
-## are the source's tables, and the art is re-read out of the dump beside the
-## cache rather than compared with itself.
-##
-## The class of bug it exists to catch is the doubling. `ConvertLoadedPuzzlePieces`
-## and `UnownPuzzle_AddPuzzlePieceBorders` are two passes over one strip, and a
-## picture that is off by a nibble, a half-tile or a bitplane still draws
-## something. So the check asserts the pixel identity per piece rather than a
-## checksum: 144 tiles a picture, four pictures, three cartridges.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- unown_puzzle
+## Sweeps `_UnownPuzzle` on freshly imported real caches, all three cartridges, all
+## four pictures, all thirty-six cells and all sixteen pieces. Every expectation is
+## transcribed from pokecrystal's own engine/games/unown_puzzle.asm rather than read
+## back out of the implementation, and the art is re-read out of the dump beside the
+## cache. The class of bug it catches is the doubling:
+## `ConvertLoadedPuzzlePieces` and the border pass are two passes over one strip, and
+## a picture off by a nibble, a half-tile or a bitplane still draws something, so
+## the check asserts the pixel identity per piece rather than a checksum.
 
 const TILE: int = Gen2Tiles.TILE_WIDTH
 

--- a/tools/checks/variable_sprites.gd
+++ b/tools/checks/variable_sprites.gd
@@ -2,25 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies `wVariableSprites` against freshly imported real caches for both
-## command profiles: every object either wears a row the source wrote or is
-## drawn as the player, and the table survives a save the way `wPlayerData` does.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## engine/overworld/overworld.asm's `GetMonSprite`, engine/events/std_scripts.asm's
-## `InitializeEventsScript`, engine/overworld/decorations.asm's
-## `ToggleDecorationsVisibility`, ram/wram.asm and engine/menus/save.asm.
-##
-## Two findings carry the topic. `wVariableSprites` sits inside `wPlayerData`,
-## which `SaveData` copies whole into `sPlayerData`, so a row assigned in one
-## session is still there in the next; keeping the table on the loaded world
-## instead drew nine slots' worth of people as the player on every reload, which
-## is what Route 40's swimmers reported. And a slot with no row at all is
-## `.NoBreedmon`'s `WALKING_SPRITE`, which is `SPRITE_CHRIS` by coincidence of
-## two constant lists, so the fallback is a symptom rather than a feature: the
-## nineteen slot-carrying objects in either corpus all have a row.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- variable_sprites
+## Verifies `wVariableSprites` against freshly imported real caches for both command
+## profiles: every object either wears a row the source wrote or is drawn as the
+## player, and the table survives a save the way `wPlayerData` does. Two findings
+## carry the topic. `wVariableSprites` sits inside `wPlayerData`, which `SaveData`
+## copies whole, so a row assigned in one session is still there in the next; keeping
+## the table on the loaded world instead drew nine slots' worth of people as the
+## player on every reload. And a slot with no row at all is `.NoBreedmon`'s
+## `WALKING_SPRITE`, so the fallback is a symptom rather than a feature.
 
 ## constants/sprite_constants.asm, the same numbers on all three cartridges.
 const SPRITE_CHRIS: int = 0x01

--- a/tools/checks/vermilion.gd
+++ b/tools/checks/vermilion.gd
@@ -3,21 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Vermilion City, its gym and the passage up from the dock against
-## freshly imported real caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## maps/VermilionCity.asm, maps/VermilionGym.asm, maps/VermilionPortPassage.asm
-## and constants/map_constants.asm. `VermilionCity.asm` and `VermilionCity.blk`
-## are byte identical between the pins and the gym differs only in Surge's text,
-## so nothing here is profile split.
-##
-## The one thing worth pinning is that this gym is not its Gen 1 self. There is
-## no trash-can puzzle: `VermilionGym_MapScripts` declares neither a scene nor a
-## callback, so the gym is open from the door. The gate is outside it, in the
-## city: the whole 42-cell gym yard is walled off by a single COLL_CUT_TREE on
-## (13,18), which makes Cut the price of the Thunder Badge.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- vermilion
+## freshly imported real caches, for both command profiles. `VermilionCity.asm` and
+## its `.blk` are byte identical between the pins and the gym differs only in
+## Surge's text, so nothing here is profile split. The one thing worth pinning is
+## that this gym is not its Gen 1 self: there is no trash-can puzzle,
+## `VermilionGym_MapScripts` declaring neither a scene nor a callback, so the gym is
+## open from the door. The gate is outside it, the whole 42-cell yard walled off by
+## a single COLL_CUT_TREE on (13,18), which makes Cut the price of the badge.
 
 
 ## constants/map_constants.asm: the VERMILION group is 12 and the FAST_SHIP

--- a/tools/checks/whirlpool.gd
+++ b/tools/checks/whirlpool.gd
@@ -3,22 +3,13 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## Verifies Whirlpool and the forced-tile layer against freshly imported real
-## caches, for both command profiles.
-##
-## Expected values come from the pinned pokecrystal and pokegold sources:
-## engine/events/overworld.asm's WhirlpoolFunction and TryWhirlpoolMenu,
-## home/map_objects.asm's CheckWhirlpoolTile, data/collision/field_move_blocks.asm's
-## WhirlpoolBlockPointers and engine/overworld/player_movement.asm's
-## DoPlayerMovement.CheckTile. All four are byte identical between the pins, and
-## WhirlpoolBlockPointers names only TILESET_JOHTO, which is $01 in both games, so
-## nothing here is profile split except the badge flag number and Dragon's Den's
-## map number.
-##
-## The real-cartridge counterpart to tests/unit/test_world_field_move.gd and the
-## forced-tile tests in tests/unit/test_world_api.gd. Dragon's Den B1F is the
-## acceptance case, because its whirlpool is the one a Crystal playthrough meets.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- whirlpool
+## caches, for both command profiles. Expected values come from the pinned sources:
+## WhirlpoolFunction and TryWhirlpoolMenu, CheckWhirlpoolTile,
+## WhirlpoolBlockPointers and `DoPlayerMovement.CheckTile`. All four are byte
+## identical between the pins, and WhirlpoolBlockPointers names only TILESET_JOHTO,
+## which is $01 in both games. The real-cartridge counterpart to
+## tests/unit/test_world_field_move.gd; Dragon's Den B1F is the acceptance case,
+## because its whirlpool is the one a Crystal playthrough meets.
 
 
 ## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -2,25 +2,14 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies where a wild encounter can be rolled at all, against freshly
-## imported real caches, for all three cartridges.
-##
-## The expected shape comes from engine/overworld/events.asm's RandomEncounter,
-## CanEncounterWildMon and CheckWildEncounterCooldown,
-## engine/overworld/tile_events.asm's CheckGrassCollision and
-## home/map_objects.asm's CheckIceTile. The real-cartridge counterpart to the
-## gate cases in tests/unit/test_world_api.gd, which use a hand-built map.
-##
-## The visible-encounter sweep is checked against the same rule on the same
-## corpus: `visible_encounter_cells` has to name exactly the cells the step roll
-## accepts, grouped by the method the terrain resolves to.
-##
-## The census is the point: an encounter cell is a small minority of a map's
-## walkable cells, and the defect this topic exists to catch was every land cell
-## rolling. A route whose grass moves, or a collision code that stops being read
-## as grass, moves these counts.
-##
-##   Godot --headless --path . -s res://tools/validate.gd -- wild_encounters
+## Verifies where a wild encounter can be rolled at all, against freshly imported
+## real caches, for all three cartridges. The expected shape comes from
+## RandomEncounter, CanEncounterWildMon, CheckWildEncounterCooldown,
+## CheckGrassCollision and CheckIceTile. The visible-encounter sweep is checked
+## against the same rule on the same corpus: `visible_encounter_cells` has to name
+## exactly the cells the step roll accepts. The census is the point: an encounter
+## cell is a small minority of a map's walkable cells, and the defect this exists to
+## catch was every land cell rolling.
 
 ## Census of the real caches, pinned so a cache or a rule change is loud.
 ## Per game: encounter cells, maps holding one, and cells refused for ice.
@@ -66,20 +55,14 @@ const DV_SWEEP_SPECIES: int = 19
 const DV_SWEEP_LEVEL: int = 5
 
 
-## `LoadEnemyMon`'s `.InitDVs` against the real caches: every wild the game
-## builds now rolls its own DVs, where before only a visible encounter carried
-## any and all eight other sources entered at 15/15/15/15. The sweep is the
-## point, the way the census above is: one wild proves nothing about a roll.
-##
-## Four claims, in the source's own order of precedence:
-##
-## - a request carrying `dvs` keeps them, which is the visible encounter and the
-##   roamer's stored word;
-## - `BATTLETYPE_FORCESHINY` writes `ATKDEFDV_SHINY`/`SPDSPCDV_SHINY`, which is
-##   the red Gyarados and is a shiny;
-## - an ordinary wild spreads over the whole 16-bit word rather than sitting on
-##   one number, and every nibble reaches both ends of 0 to 15;
-## - a wild UNOWN takes only a letter the puzzle has unlocked, per set.
+## `LoadEnemyMon`'s `.InitDVs` against the real caches: every wild the game builds
+## now rolls its own DVs, where before only a visible encounter carried any and all
+## eight other sources entered at 15/15/15/15. The sweep is the point: one wild
+## proves nothing about a roll. Four claims, in the source's own order of
+## precedence: a request carrying `dvs` keeps them; `BATTLETYPE_FORCESHINY` writes
+## the shiny word, which is the red Gyarados; an ordinary wild spreads over the
+## whole 16-bit word with every nibble reaching both ends of 0 to 15; and a wild
+## UNOWN takes only a letter the puzzle has unlocked, per set.
 func _verify_rolled_dvs() -> void:
 	var party: Gen2Party = Gen2WorldBattleAdapter.fallback_party(_r.data)
 	if not _r.check(party != null, "no party could be built for the DV sweep."):

--- a/tools/dump_editor_errors.gd
+++ b/tools/dump_editor_errors.gd
@@ -2,20 +2,12 @@
 extends EditorScript
 
 ## Editor > File > Run: writes the Debugger's error list to
-## user://editor_errors.txt and prints a tally per warning code.
-##
-## The GDScript analyzer runs only inside the editor and reports to that panel
-## alone: no CLI mode prints its warnings, `--check-only` suppresses them and
-## file logging records the running game rather than the editor. Scraping the
-## panel is the only way to read them outside it.
-##
-## The panel holds what this editor session has analysed, so a full sweep is
-## Project > Reload Current Project first, then this. It is also where a running
-## game's warnings arrive, which is how a mod's `user://` scripts are seen.
-##
-## For the analyser alone, with no editor to drive, see
-## `addons/warning_scan/plugin.gd`: it opens named scripts headlessly and prints
-## what the analyser says about each.
+## user://editor_errors.txt and prints a tally per warning code. The GDScript
+## analyzer runs only inside the editor and reports to that panel alone, so
+## scraping it is the only way to read the warnings outside it. The panel holds what
+## this editor session has analysed, so a full sweep is Project > Reload Current
+## Project first, then this. For the analyser alone, with no editor to drive, see
+## `addons/warning_scan/plugin.gd`.
 
 const OUTPUT_PATH: String = "user://editor_errors.txt"
 

--- a/tools/lib/tool_path.gd
+++ b/tools/lib/tool_path.gd
@@ -1,24 +1,13 @@
 class_name Gen2ToolPath
 extends RefCounted
 
-## Refuses an output path that would be written inside this project.
-##
-## A tool runs with `--path <this project>`, so the project is what a path
-## resolves against rather than the directory the command was run from. A bare
-## `out.png` lands in the checkout and the editor then makes an `.import` file
-## beside it. That is a hazard this project owns, since it is what `--path`
-## points at, and it belongs to anything run against it: the mod repository's own
-## twenty-five tools hit it too, which is why this is a `class_name` rather than
-## a copy per tool.
-##
-## The test is where the path ends up, not how it is spelt. `res://out.png` is
+## Refuses an output path that would be written inside this project. A tool runs
+## with `--path <this project>`, so a bare `out.png` lands in the checkout and the
+## editor then makes an `.import` file beside it. That hazard belongs to anything run
+## against this project, which is why this is a `class_name` rather than a copy per
+## tool. The test is where the path ends up, not how it is spelt: `res://out.png` is
 ## absolute to `is_absolute_path()` and lands in the project just as a bare name
-## does, so a guard written on prefixes lets through the one thing it exists to
-## stop. Globalizing answers the question directly and also catches an absolute
-## path that happens to point into the checkout.
-##
-## `user://` is allowed: it is the userdata directory, which is where a tool's
-## own scratch belongs and is not the project.
+## does, so globalizing answers the question directly. `user://` is allowed.
 
 
 ## True when [param path] is refused, having printed why. A tool quits on true.

--- a/tools/make_nro_icon.gd
+++ b/tools/make_nro_icon.gd
@@ -5,13 +5,9 @@ extends SceneTree
 ##     Godot --headless --path . -s res://tools/make_nro_icon.gd -- <out.jpg>
 ##
 ## `elf2nro --icon=` takes a JPEG of exactly that size and nothing else, and the
-## repository's icon is a 1024 PNG, so one is made from the other at package
-## time rather than the same picture being committed twice.
-##
-## Godot does it rather than ImageMagick because Godot is already installed
-## wherever this runs and is the project's own tool: the release job used
-## whichever of `magick` and `convert` the runner image happened to carry, and
-## the 0.1.6 build failed when it carried neither.
+## repository's icon is a 1024 PNG, so one is made from the other at package time
+## rather than the same picture being committed twice. Godot does it rather than
+## ImageMagick because Godot is already installed wherever this runs.
 
 const SOURCE: String = "res://app_icon.png"
 const SIDE: int = 256

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -2,45 +2,12 @@ extends SceneTree
 
 ## Captures a battle animation mid-flight against a real imported cache, which
 ## `tools/screenshot.gd` cannot drive: an animation needs a turn taken, an event
-## queue walked to the animation it wants, and then a counted number of hardware
-## frames spent inside it.
+## queue walked to the animation it wants, and a counted number of frames spent
+## inside it. The flags and the `catch`, `0`, `miss` and frame-range forms are
+## documented below.
 ##
 ##   Godot --path . -s res://tools/preview_battle_anim.gd -- \
 ##       <game> <output.png> <move> <side> <frames> [scene_off]
-##
-## `<move>` is a move number, given to both Pokemon so either side's animation
-## can be photographed; `<side>` is 0 for the player's own and 1 for the
-## enemy's; `<frames>` is how many frames into the animation to stop.
-##
-## `<move> catch` throws a ball instead of taking a turn, which is
-## `ANIM_THROW_POKE_BALL` and the whole of a capture: the ball, the poof, the
-## opponent going into it, three wobbles and then the click or the break free.
-## `<side>` picks the ending, 0 caught and 1 broken free.
-##
-## `<move> 0` photographs the entrance instead, which is `BattleStartMessage` and
-## the opening of `DoBattle` rather than a turn: a wild one, or a trainer's with
-## `<side>` at 1, and `<frames>` counted from the frame the pics stop sliding.
-## `<frames>` may be a range, `lo-hi`, which writes one `<output>_f<N>.png` per
-## frame in it instead of a single file: that is what a frame by frame diff
-## against a real cartridge reads. A line the entrance waits on is pressed
-## [constant PRESS_AFTER] frames after it has finished printing, since the
-## cartridge waits on a person there and nothing here can.
-## `scene_off` clears the OPTION menu's battle-scene row first, which is what
-## `CheckBattleScene` reads, and the capture should then show the field
-## untouched. `with_intro` counts `<frames>` from the battle screen's own first
-## frame instead, so `BattleIntroSlidingPics` is inside the range rather than
-## spent before it; a cartridge trace is aligned to the slide's end, so use it
-## for a recording and not for a diff.
-##
-## `miss` forces the turn to miss instead, by putting the target's evasion at the
-## top and the user's accuracy at the bottom, and photographs the field once the
-## whole turn has been drawn rather than a counted frame inside an animation.
-## That is what `BattleCommand_FailureText`'s `.fly_dig` is read on: a two-turn
-## move is charged first, so the picture in the shot is the one the miss put back.
-## The printed `battler_visible` pair is the reading; the picture alone cannot
-## tell a square that was never emptied from one that was filled again.
-##
-## All three flags may be given, in any order.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Enough frames for the scene to lay out before anything is driven, and enough

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -1,36 +1,12 @@
 extends SceneTree
 
-## Captures the menus a battle is answered through, against a real imported
-## cache: `BattleMenu`'s own FIGHT/PKMN/PACK/RUN and the `MoveSelectionScreen`
-## behind FIGHT, `OfferSwitch`'s yes/no box over the field,
-## `AskUseNextPokemon`'s box in the same place, and the party list they open.
+## Captures the menus a battle is answered through, against a real imported cache:
+## `BattleMenu`'s own four rows and the `MoveSelectionScreen` behind FIGHT,
+## `OfferSwitch`'s yes/no box over the field, `AskUseNextPokemon`'s box in the same
+## place, and the party list they open. The stages are [constant MENU_STAGES] and [constant WORLD_STAGES].
 ##
-##   Godot --path . -s res://tools/preview_battle_switch.gd -- crystal /tmp/s.png [stage] [presses] [passes]
-##
-## [stage] is one of `offer` (the default), `balls` (the pack showing every ball
-## a throw can be made with), `prize` (a trainer battle fought to
-## its win, photographed on `GotMoneyForWinningText`), `menu`, `move`, `info` (the move
-## list with a registered battle-information provider's annotations over it:
-## a mark per row for the effectiveness against the defender, the non-zero stat
-## stages, and a tile of the provider's own for the weather), `info_pack` and
-## `info_pkmn` (the same battle state, with the modal that covers the
-## annotations open and no provider of this tool's own registered, so a mod
-## under test is the only thing answering), `contest`, `pack`,
-## `pick`, `use_next`, `replace`, `level_up`, which is the stats box
-## `.skip_exp_bar_animation` draws beside its grew-to-level line, and `shiny`
-## and `normal`, the same wild entered through the world's own path with and
-## without the shiny DV word, which is the pair `CGB_BattleColors` is read from;
-## [presses] is a `u,d,l,r,a,b` list driven into the menu before the shot, so a
-## cursor row or a refusal can be photographed; [passes] is how many sprite
-## passes the party page's icons are given, which is what moves the chosen row's
-## icon off its resting offset. The screen's own processing is taken away before
-## those are spent, so the same arguments photograph the same frame. The battle is a real trainer's
-## party out of the cache with the player on a bench of three, since both a
-## switch and a replacement need somebody to send.
-##
-## The two faint stages take the player's Pokémon down rather than fighting it
-## down: what is being photographed is the question a faint leads to, and a real
-## turn would have to be repeated until a move happened to land.
+##   Godot --path . -s res://tools/preview_battle_switch.gd -- \
+##       crystal /tmp/s.png [stage] [presses] [passes]
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Enough frames for the scene to lay out and for the hardware viewport to hold

--- a/tools/preview_clickable.gd
+++ b/tools/preview_clickable.gd
@@ -4,22 +4,10 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_clickable.gd
 ##
-## Not headless, and not a `tools/checks/` topic: it reads `root` and
-## `gui_get_hovered_control()`, so it needs a real window the way
-## `tools/screenshot.gd` does. Run with `--headless` it reports every button as
-## unreachable, which is the absent window rather than the screen.
-##
-## A button that is wired correctly and drawn in the right place is still dead
-## if something transparent is sitting on top of it, and nothing in the scene
-## tree says so: the overlay is visible, the button is visible, and only the
-## viewport's own hit test knows which one a click reaches. So this asks the
-## viewport, one button at a time, through the same path a mouse takes.
-##
-## Not a GUT test. These screens lay themselves out against the window, and the
-## test harness gives them neither its size nor a real hit test, so under GUT
-## every rect falls outside the viewport and the walk finds nothing to check.
-## `test_launcher.gd` keeps the half that is checkable headlessly, which is that
-## a toast contains nothing a click can land on.
+## Not headless and not a `tools/checks/` topic: it reads `root` and
+## `gui_get_hovered_control()`, so it needs a real window. A button drawn in the
+## right place is still dead if something transparent is sitting on top of it, and
+## only the viewport's own hit test knows, so this asks it one button at a time.
 
 ## The size the launcher is designed against. A window this size puts every
 ## screen's own actions on screen without scrolling.

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -1,16 +1,11 @@
 extends SceneTree
 
 ## Draws a whole map as the game draws it, with every walk cell's permission
-## checkerboarded over the top: red for WALL, blue for WATER, nothing for LAND.
-##
-## For a report that a player can stand somewhere they should not. The art and
-## the permission come from the same two sources the runtime reads, the map's
-## block grid and the tileset's four-bytes-per-block collision table, so a wall
-## drawn without a red square is a real disagreement between what is drawn and
-## what is walked, rather than a rendering offset.
-##
-## Objects are not drawn: this is the map's own answer. Use
-## `Gen2WorldAPI.active_objects()` for who is standing on it.
+## checkerboarded over the top: red for WALL, blue for WATER, nothing for LAND. For
+## a report that a player can stand somewhere they should not. The art and the
+## permission come from the same two sources the runtime reads, so a wall drawn
+## without a red square is a real disagreement rather than a rendering offset.
+## Objects are not drawn: this is the map's own answer.
 ##
 ##   Godot --headless --path . -s res://tools/preview_collision.gd -- crystal 26 2 /tmp/route31.png
 

--- a/tools/preview_controls.gd
+++ b/tools/preview_controls.gd
@@ -6,16 +6,8 @@ extends SceneTree
 ##   Godot --path . --resolution 480x960 -s res://tools/preview_controls.gd -- <out.png> [mod]
 ##
 ## A `mod` argument registers two controls of a mod's own and switches their
-## on-screen buttons on, which is what a phone player who wants a mod's camera
-## has to be able to reach.
-##
-## The orientation is the window's, so `--resolution` chooses which arrangement
-## is captured: portrait puts the screen at the top and the controller under it,
-## landscape centres the screen and leaves the margins for the controller.
-##
-## The controller is forced on for the capture, since a desktop is not a
-## touchscreen and `auto` would correctly hide the thing being photographed. The
-## options file is never written, so the developer's own settings are untouched.
+## on-screen buttons on. The controller is forced on for the capture, since `auto`
+## would correctly hide it on a desktop; the options file is never written.
 
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")
 

--- a/tools/preview_credits.gd
+++ b/tools/preview_credits.gd
@@ -1,21 +1,13 @@
 extends SceneTree
 
-## Captures the credits against a real imported cache, one source frame at a
-## time.
+## Captures the credits against a real imported cache, one source frame at a time.
 ##
 ##   Godot --headless --path . -s res://tools/preview_credits.gd -- crystal /tmp/c.png [frame] [live]
 ##
-## [frame] is how many source frames to spend before the shot. A `CREDITS_WAIT`
-## tick is thirteen frames, so the batches land a long way apart; several frames
-## separated by `;` write one file each, numbered. A frame suffixed `b` holds B
-## down for it, which is the skip a replay allows.
-##
-## `live` drives the production world screen's own overlay instead of the page
-## directly, which is what says `open_credits` reaches it. One frame only, since
-## the screen owns its own clock.
-##
-## Headless either way: the page draws into an [Image] rather than through a
-## viewport, so no window and no settle are needed.
+## [frame] is how many source frames to spend before the shot; a `CREDITS_WAIT` tick
+## is thirteen frames, several separated by `;` write one file each, and a frame
+## suffixed `b` holds B down for it. `live` drives the production world screen's own
+## overlay instead of the page directly. Headless either way.
 
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""

--- a/tools/preview_fishing.gd
+++ b/tools/preview_fishing.gd
@@ -1,15 +1,11 @@
 extends SceneTree
 
-## Captures the production fishing cast screen.
-##
-## With only an output path it uses the deterministic integration fixture:
+## Captures the production fishing cast screen. With only an output path it uses
+## the deterministic integration fixture; pass a real imported cache and map to
+## capture authentic map art instead.
 ##
 ##   Godot --path . -s res://tools/preview_fishing.gd -- /tmp/fishing.png
-##
-## Pass a real imported cache and map to capture authentic map art instead:
-##
 ##   Godot --path . -s res://tools/preview_fishing.gd -- /tmp/fishing.png silver 2 5
-##
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")

--- a/tools/preview_gs_intro.gd
+++ b/tools/preview_gs_intro.gd
@@ -1,17 +1,13 @@
 extends SceneTree
 
-## Captures Gold and Silver's intro movie against a real imported cache, one
-## source frame at a time.
+## Captures Gold and Silver's intro movie against a real imported cache, one source
+## frame at a time.
 ##
 ##   Godot --headless --path . -s res://tools/preview_gs_intro.gd -- gold /tmp/i.png [frame;frame]
 ##
-## [frame] is how many source frames to spend before the shot; several separated
-## by `;` write one file each, numbered. With no frame list the tool runs the
-## whole movie and prints the frame each scene starts on, which is what pins the
-## budgets.
-##
-## Headless: the page draws into an [Image] rather than through a viewport, so
-## there is no window and no settle.
+## [frame] is how many source frames to spend before the shot; several separated by
+## `;` write one file each, numbered. With no frame list the tool runs the whole
+## movie and prints the frame each scene starts on, which is what pins the budgets.
 
 const MAX_FRAMES: int = 20000
 

--- a/tools/preview_hall_of_fame.gd
+++ b/tools/preview_hall_of_fame.gd
@@ -1,17 +1,13 @@
 extends SceneTree
 
 ## Captures the production Hall of Fame overlay against a real imported cache,
-## which is what makes it worth looking at: the panel draws a real front pic,
-## the real font and the real text-box frame.
+## which is what makes it worth looking at: the panel draws a real front pic, the
+## real font and the real text-box frame.
 ##
 ##   Godot --path . -s res://tools/preview_hall_of_fame.gd -- crystal /tmp/hof.png [page]
 ##
-## A fourth argument of `shiny` makes the lead shiny, which is the one thing
-## about the panel a check cannot read off the buffer.
-##
-## [page] is how many times to advance before the capture, so 0 is the first
-## party member and the last pages are the player's own panel with each box
-## `ProfOaksPCRating` prints into it.
+## A fourth argument of `shiny` makes the lead shiny. [page] is how many times to
+## advance, so 0 is the first party member and the last pages are the player's own.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Enough frames for the scene to lay out and the overlay to draw once.

--- a/tools/preview_intro.gd
+++ b/tools/preview_intro.gd
@@ -5,20 +5,9 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_intro.gd -- <game> <out.png> [what] [steps] [WxH]
 ##
 ## `what` is `copyright`, `presents`, `title`, `gender`, `clock`, `speech` or
-## `shrink`; `steps` is how many source frames or
-## advances to run first, so any beat of `OakSpeech` can be photographed. Several
-## comma-separated steps write one file each, suffixed with the step, which is
-## how a whole fade is looked at without paying for a process per frame. The
-## screens are built directly rather than through `intro_screen.tscn`, which
-## reads `GameRuntime` and so cannot compile under `-s`.
-##
-## `WxH` photographs the opening in a real window through [Gen2Screen] instead,
-## which is the only way to see what SCREEN FILL puts around a screen laid out in
-## 160x144:
-##
-##   ... gold /tmp/title.png title 0 1920x1080
-##
-## Opens a window: rendering needs a display.
+## `shrink`; `steps` is how many source frames to run first, several separated by
+## commas writing one file each. `WxH` photographs the opening in a real window
+## through [Gen2Screen] instead, which is the only way to see SCREEN FILL.
 
 ## Captured at hardware resolution, so a frame here compares to an emulator
 ## frame pixel for pixel rather than by eye.

--- a/tools/preview_intro_movie.gd
+++ b/tools/preview_intro_movie.gd
@@ -5,13 +5,9 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/preview_intro_movie.gd -- crystal /tmp/i.png [frame;frame]
 ##
-## [frame] is how many source frames to spend before the shot; several separated
-## by `;` write one file each, numbered. With no frame list the tool runs the
-## whole movie and prints the frame each scene starts on, which is what pins the
-## budgets.
-##
-## Headless: the page draws into an [Image] rather than through a viewport, so
-## there is no window and no settle.
+## [frame] is how many source frames to spend before the shot; several separated by
+## `;` write one file each, numbered. With no frame list the tool runs the whole
+## movie and prints the frame each scene starts on, which is what pins the budgets.
 
 const MAX_FRAMES: int = 20000
 

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -1,35 +1,13 @@
 extends SceneTree
 
-## Photographs the launcher in one appearance, at one window size, with a
-## chosen set of cartridges present.
+## Photographs the launcher in one appearance, at one window size, with a chosen
+## set of cartridges present.
 ##
-##   Godot --path . -s res://tools/preview_launcher.gd -- \
-##       <out.png> [light|dark] [width] [height] [page] [empty|mixed|full] [view] [mod id] \
-##       [scroll] [focus index] [fade step] [insets]
+##   Godot --path . -s res://tools/preview_launcher.gd -- <out.png> [light|dark] \
+##       [width] [height] [page] [empty|mixed|full] [view] [mod id] [scroll] \
+##       [focus index] [fade step] [insets]
 ##
-## `view` opens a sheet (`manage`, `touch`, `binding`, `bugs`, `report`,
-## `delete_mod`), raises the `toast` that stays until it is dismissed, runs an
-## `import` of the cartridge named in the `mod id` slot so the progress the
-## launcher draws from inside that job can be photographed from outside, or
-## picks the mods page's own: `list`, `sources`, or `mod` with an id.
-## `fade` is which step of the screen transition to photograph, 0 for none and 1
-## to 4 for one of `FadeOutToWhite`'s own rows: the launcher's leave-the-screen
-## sheet is stepped rather than tweened, so a still is the only way to see that
-## it is discrete. See [method Gen2LauncherShell.flash].
-##
-## `insets` is the screen furniture a phone would take, as `left,top,right,bottom`
-## in launcher units, so the notch and home indicator cases can be photographed on
-## a desktop. Give the window a phone's size in points and one of these to see
-## what the phone shows. See [method Gen2LauncherUI.safe_area_insets].
-##
-## `scroll` is how far down the page's own scroll to photograph, in pixels, for a
-## card that does not fit the window. `focus` puts the keyboard on the nth
-## focusable control in tree order, which is the only way to photograph a focus
-## ring: nothing takes focus until the player presses something.
-##
-## The state argument uses the preview seams on the launcher, so an empty shelf
-## can be photographed on a machine that has every cache imported. Like
-## `tools/screenshot.gd` this opens a real window and cannot run headless.
+## Every argument is documented at the parse below. Opens a real window.
 
 const STATES: Dictionary = {
 	"empty": {"gold": false, "silver": false, "crystal": false},

--- a/tools/preview_link.gd
+++ b/tools/preview_link.gd
@@ -4,17 +4,10 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/preview_link.gd -- <game> <out.png> [screen]
 ##
-## [screen] is `trade`, `wait`, `confirm`, `record` or `all` for a contact sheet
-## of every one. `all` is the default.
-##
-## The trade screen is the one page whose picture differs between the two
-## cartridges for a reason rather than by accident: Crystal lays it out from
-## `MobileTradeBorderTilemap` and Gold and Silver draw two `LinkTextboxAtHL`
-## boxes on an empty screen, so the same call on the three caches is the whole
-## comparison.
-##
-## Composed into an [Image] rather than through a window, so this runs headless
-## and needs no settling frames.
+## [screen] is `trade`, `wait`, `confirm`, `record` or `all`, the default. The trade
+## screen is the one page whose picture differs between the two cartridges for a
+## reason rather than by accident, so the same call on the three caches is the whole
+## comparison. Composed into an [Image], so this runs headless.
 
 const COLUMNS: int = 2
 const SCREENS: Array[String] = ["wait", "trade", "confirm", "record"]

--- a/tools/preview_mail.gd
+++ b/tools/preview_mail.gd
@@ -1,18 +1,13 @@
 extends SceneTree
 
-## Captures `ReadAnyMail` against a real imported cache. The ten mail types are
-## the one screen in this project drawn through four cartridge colours rather
-## than a white-to-black pair, and every one of them is a different VRAM window
-## over the same 1bpp run, so the picture is what says a transcription is right.
+## Captures `ReadAnyMail` against a real imported cache. The ten mail types are the
+## one screen in this project drawn through four cartridge colours rather than a
+## white-to-black pair, and every one is a different VRAM window over the same 1bpp
+## run, so the picture is what says a transcription is right.
 ##
 ##   Godot --headless --path . -s res://tools/preview_mail.gd -- crystal /tmp/mail.png [type]
 ##
-## [type] is a `MailGFXPointers` index, 0 to 9, or `all` for a contact sheet of
-## every one. PORTRAITMAIL draws a Pokemon, which is `wCurPartySpecies` at the
-## moment the message was written.
-##
-## The page is composed into an [Image] rather than through a window, so this
-## runs headless and needs no settling frames.
+## [type] is a `MailGFXPointers` index, 0 to 9, or `all` for a contact sheet.
 
 const COLUMNS: int = 5
 const SAMPLE_SPECIES: int = 1

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -4,23 +4,10 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/preview_mom_scene.gd -- <game> [png] [frame]
 ##
-## The story walker already proves the script's own results on [Gen2WorldAPI];
-## what it cannot say is whether the presentation runs. This drives the real
-## screen at the source frame rate from the cell the coord event sits on and
-## reports, per frame: the script's state, the object `applymovement` is walking,
-## and whether the text box is up. A `png` argument writes a frame, the last one
-## traced unless a `frame` number names an earlier one, so the emote, the walk
-## and the box can each be looked at.
-##
-## `maps/PlayersHouse1F.asm`: the two coord events at (8,4) and (9,4) are
-## Crystal's trigger. Gold and Silver ship none; their scene 0 is an `sdefer` of
-## the same script, so the trace there starts from the map entry instead, which
-## is why its three checkpoints sit later than Crystal's.
-##
-## It is a regression test, not only a report: the three frames the emote, the
-## walk and the box first appear on are pinned in [constant CHECKPOINTS] and a
-## run that moves one of them exits non-zero. Change those numbers only with a
-## reading of the asm that says why.
+## The story walker proves the script's results; what it cannot say is whether the
+## presentation runs. Crystal's trigger is the two coord events at (8,4) and (9,4);
+## Gold and Silver ship none and `sdefer` the same script from the map entry, which
+## is why their checkpoints sit later. A run that moves one exits non-zero.
 
 const WINDOW_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 const FRAME: float = 1.0 / 59.7275

--- a/tools/preview_mystery_gift.gd
+++ b/tools/preview_mystery_gift.gd
@@ -4,17 +4,10 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/preview_mystery_gift.gd -- <game> <out.png> [box]
 ##
-## [box] is `prompt` or one of `DoMysteryGift`'s eight outcome names
-## (`canceled`, `comm_error`, `retrieve`, `friend_not_ready`, `five_a_day`,
-## `one_a_day`, `sent`, `sent_home`), or `all` for a contact sheet of every one.
-## `all` is the default.
-##
-## The frame is the one picture that differs between the two cartridges for a
-## reason: Crystal builds it out of one run and two palettes, Gold and Silver
-## out of three runs and one, so the same call on the three caches is the whole
-## comparison.
-##
-## Composed into an [Image] rather than through a window, so this runs headless.
+## [box] is `prompt` or one of `DoMysteryGift`'s eight outcome names, or `all` for a
+## contact sheet, which is the default. The frame is the one picture that differs
+## between the two cartridges for a reason: Crystal builds it out of one run and two
+## palettes and Gold and Silver out of three runs and one.
 
 const COLUMNS: int = 3
 const PARTNER: String = "KRIS"

--- a/tools/preview_naming_screen.gd
+++ b/tools/preview_naming_screen.gd
@@ -1,17 +1,13 @@
 extends SceneTree
 
-## Captures the naming screen against a real imported cache, which is what makes
-## it worth looking at: the keyboard, the border, the two entry markers and the
-## cursor bracket are all cartridge graphics rather than stand-ins.
+## Captures the naming screen against a real imported cache, which is what makes it
+## worth looking at: the keyboard, the border, the two entry markers and the cursor
+## bracket are all cartridge graphics rather than stand-ins.
 ##
 ##   Godot --path . -s res://tools/preview_naming_screen.gd -- crystal /tmp/name.png [presses]
 ##
-## A `mail` argument after the presses opens `_ComposeMailMessage` instead: the
-## same screen class over its own six-row keyboard and two-line entry.
-##
-## [presses] is a button script driving the screen before the capture: `r`, `l`,
-## `u`, `d` for the d-pad, `a`, `b`, `s` for START and `c` for SELECT. So
-## `aaardc` types three letters, steps right and down and flips the case.
+## A `mail` argument after the presses opens `_ComposeMailMessage` instead.
+## [presses] is a button script: `r`, `l`, `u`, `d`, `a`, `b`, `s` and `c`.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 const SETTLE_FRAMES: int = 8

--- a/tools/preview_overworld_sprites.gd
+++ b/tools/preview_overworld_sprites.gd
@@ -1,22 +1,13 @@
 extends SceneTree
 
-## Draws every overworld sprite a cache holds as one contact sheet, so a human
-## can see at a glance whether the strip was read at the right offset and the
-## frames were composed the right way round.
-##
-## Each sprite is a four-by-four block: the four facings across, in
-## `Gen2WorldSprite`'s down/up/left/right order, and the four `Facings` frames
-## down. Frames 0 and 2 are the standing drawing and 1 and 3 the walking one, so
-## a correct walking sprite reads as two poses alternating down the block, with
-## the right column mirroring the left.
-##
-## A still sprite draws the same picture sixteen times, which is right. A big
-## object (`SPRITE_BIG_SNORLAX`, `SPRITE_BIG_ONIX`, the dolls) draws as a
-## scramble, which is a known gap: those use `FacingBigDollSymmetric` and
-## `..._Asymmetric`, sixteen and fourteen tiles in a 32x32 square, and
-## `Gen2WorldSprite.image_for()` only knows the four-tile layout.
-##
-##   Godot --headless --path . -s res://tools/preview_overworld_sprites.gd -- crystal /tmp/sprites.png
+## Draws every overworld sprite a cache holds as one contact sheet, so a human can
+## see at a glance whether the strip was read at the right offset and the frames
+## composed the right way round. Each sprite is a four-by-four block: the four
+## facings across and the four `Facings` frames down, so a correct walking sprite
+## reads as two poses alternating with the right column mirroring the left. A big
+## object draws as a scramble, which is a known gap:
+## [method Gen2WorldSprite.image_for] only knows the four-tile layout, not the
+## sixteen-tile 32x32 one.
 
 const CELL: int = 16
 const COLUMNS: int = 8

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -5,16 +5,9 @@ extends SceneTree
 ##   Godot --headless --path . -s res://tools/preview_pack.gd -- \
 ##       crystal /tmp/pack.png [items|balls|key|tmhm|use|give] [presses] [female]
 ##
-## The world behind it is a new game holding enough of each pocket to fill the
-## five visible rows and scroll past them, with a development party behind it so
-## `use` and `give` reach `.Party`'s own list. Those two are the party menu
-## `GiveItem` and every `.Party` item effect open, so what they photograph is
-## [Gen2PartyMenuPage] with the prompt that entrance writes. [presses] is a `u,d,l,r,a,b,s` list
-## driven into the real screen before the shot, so the picture is what the
-## cartridge's own listing would show after those buttons.
-##
-## Headless: the page composes into an [Image] rather than through a viewport,
-## so no window and no settle are needed.
+## The world behind it is a new game holding enough of each pocket to scroll, with a
+## development party so `use` and `give` reach `.Party`'s own list. [presses] is a
+## `u,d,l,r,a,b,s` list driven into the real screen before the shot.
 
 const NEW_BARK_GROUP: int = 24
 const NEW_BARK_MAP: int = 7

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -3,25 +3,11 @@ extends SceneTree
 ## Captures the window-resolution save overlays against a real cache: the party,
 ## the PC boxes and the start menu's pack.
 ##
-##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> [party|box|pack|select|stats] [presses] [shiny]
+##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> \
+##       [party|box|pack|select|stats] [presses] [shiny]
 ##
-## A final `shiny` makes the lead shiny. The PC's pic and the stats page draw it;
-## the party menu's icons deliberately do not, which is the cartridge's own
-## answer and is what the three captures together say.
-##
-## `presses` is a comma-separated button list driven into the overlay before the
-## shot, the way `preview_world_services.gd` photographs a second page: `d` is
-## down, `u` up, `l` left, `r` right, `a` and `b` the two buttons. Several
-## comma-separated lists write one file each.
-##
-## Each is built directly rather than through the overworld, which is what makes
-## this a screen test rather than a world one; the pack is given a world of its
-## own because its transactions read one. They reach the runtime
-## through `Gen2GameRuntime`, so they compile under `-s` where naming the
-## autoload by identifier would not.
-##
-## Opens a window: rendering needs a display. Pass `--resolution` for a size
-## other than the project's own.
+## The PC's pic and the stats page draw a shiny lead; the party menu's icons
+## deliberately do not, which is the cartridge's own answer. Opens a window.
 
 const FRAMES_BEFORE_CAPTURE: int = 6
 

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -4,16 +4,10 @@ extends SceneTree
 ##
 ##   Godot --headless --path . -s res://tools/preview_pics.gd -- <game> <out.png> [what] [--shiny]
 ##
-## e.g. gold /tmp/gold_front.png front
-##
-## The cache stores colour indices, not pixels, with a palette applied at draw
-## time so shiny is free. This applies one and writes the result out, the only
-## way to tell a correct decode from a plausible wrong one. Headless: it writes
-## an image and opens no window.
-##
-## The font and borders come out too. Both are one row of tiles, so the font is
-## folded to sixteen a row, the shape the charmap describes, putting the
-## alphabets, the gaps and the digits where they can be read at a glance.
+## The cache stores colour indices rather than pixels, with a palette applied at
+## draw time so shiny is free; this applies one, which is the only way to tell a
+## correct decode from a plausible wrong one. The font comes out folded to sixteen
+## tiles a row, the shape the charmap describes.
 
 const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back", "trainers"]
 const SHEETS: PackedStringArray = [

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -6,13 +6,8 @@ extends SceneTree
 ##       crystal /tmp/dex.png [list|entry|option|search|results|unown] [presses]
 ##
 ## The world behind it is a new game with every species seen and every second one
-## caught, which is what puts a full listing, both row states and a real entry on
-## screen at once. [presses] is a
-## `u,d,l,r,a,b,sel,start` list driven in before the shot, and `f<n>` spends n
-## hardware frames, which is how the arrow is caught blinking either way.
-##
-## Headless: the screen composes into an [Image] rather than through a viewport,
-## so no window and no settle are needed.
+## caught, which puts a full listing, both row states and a real entry on screen at
+## once. `f<n>` in [presses] spends n hardware frames, which catches the arrow blink.
 
 const NEW_BARK_GROUP: int = 24
 const NEW_BARK_MAP: int = 7

--- a/tools/preview_saves.gd
+++ b/tools/preview_saves.gd
@@ -4,14 +4,10 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_saves.gd -- <out.png> [light|dark] [WxH] [page]
 ##
-## [page] is `saves`, `new`, `party`, `boxes` or `editor`, the pages the save
-## slots lead to. They are one command because they are one section and share
-## this harness; each is its own scene, and `new` is the slot list with the
-## new-game form open on a free slot.
-##
-## The size is what says whether a page is responsive, so it is an argument
-## rather than a constant: a phone portrait and a desktop window are the same
-## command twice.
+## [page] is `saves`, `new`, `party`, `boxes` or `editor`. They are one command
+## because they are one section and share this harness. The size is what says
+## whether a page is responsive, so it is an argument rather than a constant: a
+## phone portrait and a desktop window are the same command twice.
 
 var _output: String = ""
 var _frames: int = 0

--- a/tools/preview_second_screen.gd
+++ b/tools/preview_second_screen.gd
@@ -2,25 +2,12 @@ extends SceneTree
 
 ## Photographs the lower display against a real cache.
 ##
-##   Godot --path . -s res://tools/preview_second_screen.gd -- <game> <out.png> [tab] [progress] [panel] [theme]
+##   Godot --path . -s res://tools/preview_second_screen.gd -- \
+##       <game> <out.png> [tab] [progress] [panel] [theme]
 ##
-## `tab` is one of `pokedex`, `pokemon`, `pack`, `pokegear`, `player`, `idle` for
-## the picture the panel shows with no world on it, or `all` to write one file per
-## open tab with the tab's name before the extension.
-## `progress` is how far the run has got, which is the only thing that decides
-## which tabs exist: `start` is a player who has just left their bedroom,
-## `starter` has Elm's Pokemon, `gear` has the Pokegear and the MAP card, and
-## `full` has everything the START menu can offer. `panel` is a lower display's
-## own pixel size, `WIDTHxHEIGHT`, which chooses the canvas the way a real one
-## would; the default is the AYN Thor's 1240x1080. `theme` is `light` or `dark`,
-## which only the idle page reads: it is launcher UI and wears the launcher's own
-## appearance.
-##
-## The picture written is the canvas itself, one file pixel per hardware pixel,
-## so a diff against it is exact. Look at it with an image viewer that does not
-## smooth.
-##
-## Opens a window: a [SubViewport] needs a rendering device.
+## `progress` is the only thing that decides which tabs exist: `start`, `starter`,
+## `gear` or `full`. `panel` is a lower display's own `WIDTHxHEIGHT`, defaulting to
+## the AYN Thor's 1240x1080. The picture is the canvas itself, one pixel per pixel.
 
 const WINDOW_SIZE := Vector2i(640, 480)
 const FRAMES_BEFORE_CAPTURE: int = 8

--- a/tools/preview_title.gd
+++ b/tools/preview_title.gd
@@ -1,17 +1,13 @@
 extends SceneTree
 
-## Captures the title screen against a real imported cache, one source frame at
-## a time.
+## Captures the title screen against a real imported cache, one source frame at a
+## time.
 ##
 ##   Godot --headless --path . -s res://tools/preview_title.gd -- crystal /tmp/t.png [frame]
 ##
 ## [frame] is how many source frames to spend before the shot, so Crystal's
-## twenty-eight-frame entrance, its Suicune cycle and Gold's bird can each be
-## looked at where they actually are. Several frames separated by `;` write one
-## file each, numbered.
-##
-## Headless: the page is drawn into an [Image] rather than through a viewport, so
-## no window and no settle are needed.
+## twenty-eight-frame entrance, its Suicune cycle and Gold's bird can each be looked
+## at where they are. Several separated by `;` write one file each, numbered.
 
 
 func _initialize() -> void:

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -3,23 +3,11 @@ extends SceneTree
 ## Captures the region map against a real imported cache.
 ##
 ##   Godot --headless --path . -s res://tools/preview_town_map.gd -- \
-##       crystal /tmp/map.png [landmark] [town_map|card|clock|phone|radio|area:<species>|fly[:all]] [presses]
+##       crystal /tmp/map.png [landmark] [card|clock|phone|radio|area:<species>|fly[:all]] [presses]
 ##
 ## [landmark] is `TownMap_GetCurrentLandmark`'s answer, which picks the region and
-## where the player icon stands; `card` draws the Pokegear's own MAP frame instead
-## of `_TownMap`'s corner box, `area:19` draws `Pokedex_GetArea` for that
-## species, and `fly` draws `_FlyMap` with its own cursor, `fly:all` with every
-## flypoint visited rather than none. `clock`, `phone` and `radio` are the
-## Pokegear's other three cards, each read off a real world the way the service
-## host reads it. [presses] is a `u,d,l,r,a,b` list driven into the screen before the
-## shot, which is how a cursor walk is photographed. Three other tokens: `hof`
-## opens with `STATUSFLAGS_HALL_OF_FAME_F` set, which widens the Kanto window past
-## Victory Road and is what lets the dex area reach Kanto at all; `sel` and `rel`
-## press and release SELECT, the dex area's held button; and `f<n>` spends n
-## hardware frames, which is how the nest blink is caught either way up.
-##
-## Headless: the screen composes into an [Image] rather than through a viewport,
-## so no window and no settle are needed.
+## where the player icon stands. `hof` widens the Kanto window, `sel`/`rel` press and
+## release the dex area's held SELECT, and `f<n>` spends n frames for the nest blink.
 
 ## Where a card preview's world stands, which is what its clock, dial and contact
 ## list are read from.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -1,86 +1,63 @@
 extends SceneTree
 
-## Renders one imported map's expanded 4x4-tile blocks to a PNG.
+## Renders one imported map's expanded 4x4-tile blocks to a PNG, or photographs
+## the real screen on that map. `live help` prints [constant KIND_HELP], which is
+## every kind and what its two numbers mean.
 ##
-##   Godot --headless --path . -s res://tools/preview_world.gd -- gold 1 1 /tmp/world.png
-##
-## A fifth `live` argument photographs the real screen on that map instead. It
-## drives the screen's own path and needs a display, so it runs without
-## `--headless`:
-##
-##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png live [kind] [x y] [WxH] [touch]
-##
-## The two numbers after `kind` are that kind's own arguments; where a kind reads
-## them as something else, the player's cell is written on the kind itself as
-## `<kind>@x,y`, for example `battle_transition@5,7`.
-##
-## Extra flags, in any order after the kind:
-##
-## | Flag | Effect |
-## | `WxH` | The window to photograph in, for a phone's two shapes |
-## | `touch` | Draw the on-screen controller, the only way to see how [Gen2GameFrame] splits a portrait screen |
-## | `framed` | The 160x144 letterbox the hardware had, instead of SCREEN FILL |
-## | `zoom=<n>` | The zoom ladder; `zoom=-3` is the whole-region survey |
-## | `view=<mod id>` | A registered renderer instead of the built-in one. Needs `--mods` in front of the `--` |
-##
-##   ... live effects 4 4 430x932 touch
-##   Godot --path . -s res://tools/preview_world.gd --mods -- crystal 26 2 \
-##     /tmp/out.png live effects 4 4 1920x1080 zoom=-3 view=voxel3d
-##
-## Kinds, with what their two numbers mean. A kind saying "no fixture cell" is
-## driven directly because no map cell reaches it.
-##
-## | Kind | Numbers | Draws |
-## | `effects` | cell | The emote, boulder dust, grass rustle and headbutt tree over the first visible object |
-## | `battle` | cell | The wild fight `preview_battle_request` starts, settled past its transition |
-## | `cut` | cell | `OWCutAnimation`'s two halves and the jump shadow |
-## | `tile_anim` | frames | The map that many `AnimateTileset` frames in: water, flowers, lava, cave scroll |
-## | `unown_wall` | cell | `DisplayUnownWords`' box, read off the chamber wall above the cell. Group 3 maps 23 to 26 say HO-OH, ESCAPE, WATER, LIGHT |
-## | `mart`, `mart_sell` | cell in front of the counter | `BuyMenu`, and the SELL row (`DepositSellPack`) |
-## | `pokepic` | cell | `Script_pokepic`'s box over the map, holding Chikorita |
-## | `pet_actor` | cell | A mod's world actor one cell ahead, pressed with A so it wears a `showemote` heart |
-## | `warp` | warp tile | `MapSetupScript_Door` at its whitest, which is the frame the new map loads on |
-## | `script_fade` | special, frames | One of the five fade specials over the map |
-## | `door` | door mat | `.CheckWarp`'s carpet, standing on an interior door's mat |
-## | `ice_slide` | direction, frames | `DoPlayerMovement.CheckForced`'s run. Direction is down, up, left, right |
-## | `ledge` | start cell | The ledge hop at the top of its arc, walking south until one allows it |
-## | `map_name_sign` | cell | `InitMapNameSign`'s window, raised by walking west onto the neighbouring map |
-## | `yes_no` | script, presses | `Script_yesorno`'s box over the map's script |
-## | `battle_tower` | A presses, DOWN presses | `BattleTower1FReceptionistScript`, talked to from the cell below her |
-## | `name_rater`, `move_deleter` | presses | `special NameRater` / `special MoveDeletion`. 0 is the introduction, 2 the last page with YES/NO, 4 the party list |
-## | `gift_nickname` | presses, species | `GiveANickname_YesNo`. 1 is the question, 2 the `WasSentToBillsPCText` behind NO. Add 1000 to the species for the box branch |
-## | `unown_printer` | slot, page | `_UnownPrinter`'s ALPH RUINS STAMP browser. Slot 26 is the vacant one; page 1 is what A sends to a printer that is not there |
-## | `diploma` | loop, page | `_Diploma`'s page. 1 stands `_PrintDiploma`'s connection error over it; page 2 needs a printer that answered |
-## | `bills_pc` | rows down, A presses | `_BillsPC`'s top menu and the lists behind it |
-## | `players_pc`, `pokemon_center_pc` | rows down, A presses | The bedroom's item PC and the Pokemon Center's machine |
-## | `mom_bank` | wallet, balance, both in hundreds | `Mom_WithdrawDepositMenuJoypad`'s dial. Add 1000 for the WITHDRAW header |
-## | `move_tutor` | presses | `special MoveTutor`. 0 is `ChooseMonToLearnTMHM`'s list, not a box |
-## | `day_care` | presses, routine | 0 the man, 1 the lady, 2 the man outside, 3 and 4 the two signs |
-## | `slot_machine` | frames, bet | `special SlotMachine`. Bet is 1 to 3, plus 4 for the lucky machine |
-## | `card_flip` | frames, coins in hundreds | `special CardFlip` |
-## | `unown_puzzle` | frames, picture | `special UnownPuzzle`. 0 Kabuto, 1 Omanyte, 2 Aerodactyl, 3 Ho-Oh, or 4 to 7 solved. The cursor blinks off `hVBlankCounter`, so a frame with bit 4 clear has none |
-## | `visible_encounter` | cell | A shiny of the map's own table on the eligible cell nearest the player, with the sparkle over it |
-## | `visible_encounter_glow` | cell | The same population with ordinary DVs wearing an entry's `glow` |
-## | `field_moves_menu` | cell | The start menu's MOVES row and the HM list behind it. Needs a registered field-move source, and is driven twice |
-## | `repel_renewal` | cell | The question a Repel running out asks. Needs a registered renewal provider |
-## | `mod_notice` | badge | `Gen2ModHost.request_notice`'s banner over the map, wearing that badge |
-## | `mod_page` | badges won | `START_ACTION_OPEN_MOD_PAGE`'s screen, listing the eight Johto badges |
-## | `reset_question` | none | The reset chord's own question, asked once ever. Driven twice for the `YesNoBox` behind its second page |
-## | `launcher_question` | none | The HOME row's question, walked to off the list. Driven twice |
-##
-## A kind may also be the name of any `preview_*` driver on the world screen
-## without that prefix: `field_move` (`PartyMenu` with a taught CUT),
-## `start_menu`, `capture`, `catch_nickname` (`PokeBallEffect`'s question over
-## the battle the throw was made in), `move_forget` and the rest. A `*_use` name
-## is driven twice, since each call is one step of its own sequence.
-##
-## Or one of [constant FIELD_ITEMS]' names, which is the pack's USE on that item:
-## the Itemfinder closes the pack over the world's answer, the Coin Case prints
-## inside the pack, and the three in [constant FACE_UP_FIRST] each need their own
-## map and the cell below their target.
+##   Godot --headless --path . -s res://tools/preview_world.gd -- gold 1 1 /tmp/w.png
+##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png \
+##       live [kind] [x y] [WxH] [touch] [framed] [zoom=<n>] [view=<mod id>]
 
 ## `TrainerCard_JohtoBadgesOAM`'s eight, for the two mod-surface kinds: the only
 ## badge art the cartridge has.
+## Every `live` kind, what its two numbers mean and what it draws. Data rather
+## than a comment, because `live help` prints it. A kind may also be any `preview_*` driver on the world screen without
+## that prefix (`field_move`, `start_menu`, `capture`, `catch_nickname`,
+## `move_forget`), which is driven twice when its name ends in `_use`, or one of
+## [constant FIELD_ITEMS]' names, which is the pack's USE on that item.
+const KIND_HELP: Dictionary = {
+	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
+	&"battle": "cell: the wild fight preview_battle_request starts, settled past its transition",
+	&"cut": "cell: OWCutAnimation's two halves and the jump shadow",
+	&"tile_anim": "frames: the map that many AnimateTileset frames in",
+	&"unown_wall": "cell: DisplayUnownWords' box. Group 3 maps 23 to 26 say HO-OH, ESCAPE, WATER, LIGHT",
+	&"mart": "cell in front of the counter: BuyMenu",
+	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
+	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
+	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
+	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
+	&"script_fade": "special, frames: one of the five fade specials over the map",
+	&"door": "door mat: .CheckWarp's carpet, standing on an interior door's mat",
+	&"ice_slide": "direction, frames: DoPlayerMovement.CheckForced's run. Direction is down, up, left, right",
+	&"ledge": "start cell: the ledge hop at the top of its arc, walking south until one allows it",
+	&"map_name_sign": "cell: InitMapNameSign's window, raised by walking west onto the neighbouring map",
+	&"yes_no": "script, presses: Script_yesorno's box over the map's script",
+	&"battle_tower": "A presses, DOWN presses: BattleTower1FReceptionistScript, talked to from the cell below her",
+	&"name_rater": "presses: special NameRater. 0 is the introduction, 2 the last page with YES/NO, 4 the party list",
+	&"move_deleter": "presses: special MoveDeletion, the same three stages",
+	&"gift_nickname": "presses, species: GiveANickname_YesNo. 1 the question, 2 the WasSentToBillsPCText behind NO; add 1000 for the box branch",
+	&"unown_printer": "slot, page: _UnownPrinter's browser. Slot 26 is the vacant one; page 1 is what A sends to a printer that is not there",
+	&"diploma": "loop, page: _Diploma's page. 1 stands _PrintDiploma's connection error over it; page 2 needs a printer that answered",
+	&"bills_pc": "rows down, A presses: _BillsPC's top menu and the lists behind it",
+	&"players_pc": "rows down, A presses: the bedroom's item PC",
+	&"pokemon_center_pc": "rows down, A presses: the Pokemon Center's machine",
+	&"mom_bank": "wallet, balance, both in hundreds: Mom_WithdrawDepositMenuJoypad's dial. Add 1000 for the WITHDRAW header",
+	&"move_tutor": "presses: special MoveTutor. 0 is ChooseMonToLearnTMHM's list, not a box",
+	&"day_care": "presses, routine: 0 the man, 1 the lady, 2 the man outside, 3 and 4 the two signs",
+	&"slot_machine": "frames, bet: special SlotMachine. Bet is 1 to 3, plus 4 for the lucky machine",
+	&"card_flip": "frames, coins in hundreds: special CardFlip",
+	&"unown_puzzle": "frames, picture: special UnownPuzzle. 0 Kabuto, 1 Omanyte, 2 Aerodactyl, 3 Ho-Oh, 4 to 7 solved",
+	&"visible_encounter": "cell: a shiny of the map's own table on the eligible cell nearest the player",
+	&"visible_encounter_glow": "cell: the same population with ordinary DVs wearing an entry's glow",
+	&"field_moves_menu": "cell: the start menu's MOVES row and the HM list. Needs a registered field-move source",
+	&"repel_renewal": "cell: the question a Repel running out asks. Needs a registered renewal provider",
+	&"mod_notice": "badge: Gen2ModHost.request_notice's banner over the map, wearing that badge",
+	&"mod_page": "badges won: START_ACTION_OPEN_MOD_PAGE's screen, listing the eight Johto badges",
+	&"reset_question": "none: the reset chord's own question, asked once ever. Driven twice",
+	&"launcher_question": "none: the HOME row's question, walked to off the list. Driven twice",
+}
+
+
 const BADGE_NAMES: Array[String] = [
 	"ZEPHYRBADGE", "HIVEBADGE", "PLAINBADGE", "FOGBADGE",
 	"MINERALBADGE", "STORMBADGE", "GLACIERBADGE", "RISINGBADGE",
@@ -193,6 +170,11 @@ func _initialize() -> void:
 			return
 		_output_path = args[3]
 		var kind_arg: String = args[5] if args.size() >= 6 else "effects"
+		if kind_arg == "help":
+			for kind: StringName in KIND_HELP:
+				print("%-24s %s" % [kind, KIND_HELP[kind]])
+			quit(0)
+			return
 		if kind_arg.contains("@"):
 			var halves: PackedStringArray = kind_arg.split("@")
 			kind_arg = halves[0]
@@ -493,16 +475,13 @@ func _process(_delta: float) -> bool:
 				_screen.press_button(Gen2Button.A)
 				_settle_mon_special(host_property)
 		elif _kind == &"battle_tower":
-			## `BattleTower1FReceptionistScript` from the cell below her, which
-			## is where `Script_WalkToBattleTowerElevator` puts the player back.
-			## The first number is how many A presses to spend, which walks the
-			## welcome box, the explanation question and the Challenge /
-			## Explanation / Cancel menu; the second is how many DOWN presses to
-			## spend on whichever menu is up, so `battle_tower 6 2` stands on the
-			## third room of the level list.
-			## `_CheckForBattleTowerRules` refuses anything but three different
-			## species holding three different items, and the development save's
-			## party is not one, so the challenge would never open a room.
+			## `BattleTower1FReceptionistScript` from the cell below her, which is
+			## where `Script_WalkToBattleTowerElevator` puts the player back. The
+			## first number is how many A presses to spend, walking the welcome box,
+			## the explanation question and the three-row menu; the second is how many
+			## DOWN presses on whichever menu is up. `_CheckForBattleTowerRules`
+			## refuses anything but three different species holding three different
+			## items, and the development save's party is not one.
 			_stage_battle_tower_party()
 			_screen.press_button(Gen2Button.UP)
 			_screen.interact()

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -1,22 +1,12 @@
 extends SceneTree
 
-## Captures the production world-service overlay with a deterministic cache.
+## Captures the production world-service overlay with a deterministic cache. The
+## mode is the third argument and the fourth a press list, which is how the apricorn
+## mode's second box is photographed. The modes are `apricorn`, `town_map`,
+## `pokegear`, `trainer_card`, `oak_pc`, `pc`, `decoration`, `hall_of_fame`,
+## `battle_tower_room` and `unown_dex`; with none the mart is drawn.
 ##
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/mart.png
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/kurt.png apricorn
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/map.png town_map
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/clock.png pokegear a
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/card.png trainer_card
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/oak.png oak_pc
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc a,down,a
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/deco.png decoration
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/hof.png hall_of_fame
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/room.png battle_tower_room
-##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/unown.png unown_dex
-##
-## `presses` drives the overlay with its own buttons before the shot, which is
-## how the apricorn mode's second box is photographed.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 const Fixture := preload("res://tests/integration/world_trainer_fixture.gd")

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -4,14 +4,10 @@ extends SceneTree
 ## cartridge cache without opening the ROM at runtime.
 ##
 ##   Godot --headless --path . -s res://tools/preview_world_story.gd -- \
-##     crystal 3 19 3 5 1 37,1744
+##     crystal 3 19 3 5 1 37,1744 home story
 ##
-## The optional final argument is a comma-separated list of event flags. Facing
-## uses the runtime values: down=0, up=1, left=2, right=3. The optional eighth
-## argument `home` follows the imported bedroom stair warp into the first floor
-## and then the imported first-floor warp into New Bark Town. A ninth argument
-## `story` drives the imported first-floor Mom event and the New Bark entry
-## event through explicit source inputs.
+## The optional seventh argument is a comma-separated event flag list. `home`
+## follows the bedroom stair warp out; `story` drives the Mom and New Bark events.
 
 ## A ring is 30 lead frames plus two 60-frame rings; the budget only has to
 ## outlast that.
@@ -117,17 +113,12 @@ const EVENT_ANSWERED_DRAGON_MASTER_QUIZ_WRONG: int = 193
 const BADGE_RISING: int = 7
 
 ## Blackthorn Gym 2F's pushes in order, each an approach cell and the direction
-## stepped from it (`maps/BlackthornGym2F.asm`).
-##
-## Four of the six boulders move. BOULDER5 on (6,1) and BOULDER6 on (8,14) are
-## in neither the `stonetable` nor any event flag: they seal the two pockets the
-## puzzle needs, the top-right one holding BOULDER1 and its hole, and the
-## bottom one holding the row BOULDER3 has to be pushed from. Shoving each three
-## cells clears both. BOULDER1 is then one push into (8,3), and BOULDER3 goes
-## north until the wall at (6,6) stops it and then east into (8,7).
-##
-## BOULDER2 is left alone. Its hole is a `stonetable` row like the other two,
-## but the 1F cell its flag opens, (2,5), is a dead end beside the entrance.
+## stepped from it. Four of the six boulders move: BOULDER5 on (6,1) and BOULDER6 on
+## (8,14) are in neither the `stonetable` nor any event flag and seal the two pockets
+## the puzzle needs, so shoving each three cells clears both; BOULDER1 is then one
+## push into (8,3), and BOULDER3 goes north until the wall at (6,6) stops it and then
+## east into (8,7). BOULDER2 is left alone: its hole is a `stonetable` row like the
+## other two, but the 1F cell its flag opens is a dead end beside the entrance.
 const BLACKTHORN_GYM_PUSHES: Array = [
 	{
 		"step": "blackthorn_gym_clear_top_pocket",
@@ -174,17 +165,13 @@ const DRAGON_SHRINE_ANSWERS: Array[int] = [0, 0, 1, 0, 1]
 const OBJECT_STEP_FRAME_BUDGET: int = 64
 
 ## Route 44's Ice Path door and then every warp cell the cave is crossed by, in
-## order (`maps/Route44.asm`, `maps/IcePath*.asm`).
-##
-## The cave is six floor-crossings, not one. Stepping on a warp takes it, so a
-## floor is only crossed between warps its own walk connects, and on Ice Path
-## those regions are disjoint: 1F's Route 44 door reaches the first staircase
-## and nothing else, while the Blackthorn door is reached only from the second
-## staircase, at the far end of the loop through B1F, both B2Fs and B3F.
-##
-## The `stonetable` boulders on B1F are not on this path. Their holes (B1F warps
-## 3 to 6) are shortcuts into B2F Mahogany side, which the walk already reaches
-## through warp 2.
+## order. The cave is six floor-crossings, not one: stepping on a warp takes it, so a
+## floor is only crossed between warps its own walk connects, and on Ice Path those
+## regions are disjoint. 1F's Route 44 door reaches the first staircase and nothing
+## else, while the Blackthorn door is reached only from the second staircase, at the
+## far end of the loop through B1F, both B2Fs and B3F. The `stonetable` boulders on
+## B1F are not on this path: their holes are shortcuts into B2F Mahogany side, which
+## the walk already reaches through warp 2.
 const ICE_PATH_DOORS: Array = [
 	{"step": "route_44_to_ice_path_1f", "cell": Vector2i(56, 7), "hm07": true},
 	{"step": "ice_path_1f_to_b1f", "cell": Vector2i(37, 5)},
@@ -239,15 +226,14 @@ const VICTORY_ROAD_LADDERS: Array = [
 	{"step": "victory_road_second_ladder", "cell": Vector2i(13, 31)},
 ]
 
-## The Elite Four, in the order their doors join them. Every map is in the
-## INDIGO group (16); `maps/IndigoPlateauPokecenter1F.asm` warp 4 at (14,3) is
-## the only way in and each room's exit pair leads to the next.
-##
-## The four rooms share one shape. `<Room>DoorLocksBehindYouScript` walks the
-## player four cells north of the arrival warp and walls the entrance, the boss
-## stands on (5,7) and is faced from (5,8), and beating them opens the exit
-## block over (4,2)/(5,2). Lance's room is taller and is not talked to at all:
-## its coord events on (4,5) and (5,5) run the approach and the champion scene.
+## The Elite Four, in the order their doors join them. Every map is in the INDIGO
+## group (16); the Pokemon Center's warp 4 at (14,3) is the only way in and each
+## room's exit pair leads to the next. The four rooms share one shape:
+## `<Room>DoorLocksBehindYouScript` walks the player four cells north of the
+## arrival warp and walls the entrance, the boss stands on (5,7) and is faced from
+## (5,8), and beating them opens the exit block over (4,2)/(5,2). Lance's room is
+## taller and is not talked to at all: its coord events on (4,5) and (5,5) run the
+## approach and the champion scene.
 const ELITE_FOUR_ROOM_ARRIVAL: Vector2i = Vector2i(5, 17)
 const ELITE_FOUR_ROOM_BOSS_FACE: Vector2i = Vector2i(5, 8)
 const ELITE_FOUR_ROOM_EXIT: Vector2i = Vector2i(5, 2)
@@ -399,15 +385,14 @@ const SAFFRON_CITY_NUMBER: int = 2
 const SAFFRON_GYM_NUMBER: int = 4
 const SAFFRON_GYM_DOOR: Vector2i = Vector2i(34, 3)
 
-## The lost-doll errand and the Magnet Train it pays for. `maps/SaffronCity.asm`
-## warp 8 is the Copycat's house, warp 12 the Route 6 gate and warp 6 the train
-## station; `maps/VermilionCity.asm` warp 3 is the Pokemon Fan Club.
-##
-## The order is the cartridge's own. `PokemonFanClubClefairyGuyScript` reads
-## EVENT_MET_COPYCAT_FOUND_OUT_ABOUT_LOST_ITEM before he parts with the doll, and
-## only `Copycat`'s `.TalkAboutLostItem` sets it, which itself needs
-## EVENT_RETURNED_MACHINE_PART from the Power Plant. So the Copycat is visited
-## first, empty-handed, and the walk to Vermilion is what the visit buys.
+## The Elite Four, in the order their doors join them. Every map is in the INDIGO
+## group (16); the Pokemon Center's warp 4 at (14,3) is the only way in and each
+## room's exit pair leads to the next. The four rooms share one shape:
+## `<Room>DoorLocksBehindYouScript` walks the player four cells north of the
+## arrival warp and walls the entrance, the boss stands on (5,7) and is faced from
+## (5,8), and beating them opens the exit block over (4,2)/(5,2). Lance's room is
+## taller and is not talked to at all: its coord events on (4,5) and (5,5) run the
+## approach and the champion scene.
 const SAFFRON_COPYCAT_HOUSE_DOOR: Vector2i = Vector2i(9, 11)
 const COPYCAT_HOUSE_STAIRS_UP: Vector2i = Vector2i(2, 0)
 const COPYCAT_HOUSE_STAIRS_DOWN: Vector2i = Vector2i(3, 0)
@@ -619,20 +604,14 @@ const FUCHSIA_GYM_EXIT: Vector2i = Vector2i(4, 17)
 const FUCHSIA_ROUTE_15_GATE_DOOR: Vector2i = Vector2i(37, 22)
 const ROUTE_11_NUMBER: int = 2
 
-## Vermilion's Snorlax. The whole chain is pinned and checked against the cache
-## by `tools/checks/radio.gd`, which is where these values are explained; only
-## the cells the walk needs are repeated here.
-##
-## `maps/VermilionCity.asm` object 4 is a BIG_OBJECT filling (34,8) to (35,9),
-## and the cave mouth on (34,7) is sealed until it moves.
-##
-## The route arrives from Route 11, not from the port, and that lands it inside
-## the eight-cell pocket the Snorlax's own body seals off the city's east edge:
-## (36..39, 8) and (36..39, 9), measured against the cache. So the walk uses
-## (36,9) facing left, which is the last of `SnorlaxAwake.ProximityCoords` and
-## the only kind of cell an eastbound player ever has. Three of those five
-## coordinates sit in pockets like this one, which is why the source lists all
-## five rather than only the two the port side can stand on.
+## The lost-doll errand and the Magnet Train it pays for. Saffron's warp 8 is the
+## Copycat's house, warp 12 the Route 6 gate and warp 6 the train station;
+## Vermilion's warp 3 is the Pokemon Fan Club. The order is the cartridge's own:
+## `PokemonFanClubClefairyGuyScript` reads
+## EVENT_MET_COPYCAT_FOUND_OUT_ABOUT_LOST_ITEM before he parts with the doll, and
+## only `Copycat`'s `.TalkAboutLostItem` sets it, which itself needs
+## EVENT_RETURNED_MACHINE_PART from the Power Plant. So the Copycat is visited
+## first, empty-handed, and the walk to Vermilion is what the visit buys.
 const SNORLAX_TALK: Vector2i = Vector2i(36, 9)
 const DIGLETTS_CAVE_MOUTH: Vector2i = Vector2i(34, 7)
 ## `engine/pokegear/pokegear.asm` RadioChannels: 20.0, the Poke Flute channel.
@@ -838,15 +817,14 @@ const EVENT_TELEPORT_GUY: int = 1916
 const EVENT_RIVAL_SPROUT_TOWER: int = 1732
 const EVENT_RED_IN_MT_SILVER: int = 1890
 
-## Maps this walk names by id rather than by cell, where the two profiles
-## disagree (`constants/map_constants.asm`). A map number counts from its
-## group's first entry, so a map pokegold does not ship shifts every later
-## number in that group: group 3 runs eight lower from `UNION_CAVE_1F` on,
-## because pokecrystal inserts eight Ruins of Alph word and item rooms, and
-## group 11 shifts around `GOLDENROD_POKECENTER_1F` and the absent
-## `GOLDENROD_DEPT_STORE_ROOF`. Only the ids this walk resolves are listed;
-## everything else it reaches is found by the cell it stands on, which no
-## renumbering moves.
+## Vermilion's Snorlax. The whole chain is pinned and checked against the cache by
+## `tools/checks/radio.gd`, which is where these values are explained; only the
+## cells the walk needs are repeated here. Object 4 is a BIG_OBJECT filling (34,8)
+## to (35,9), and the cave mouth on (34,7) is sealed until it moves. The route
+## arrives from Route 11 rather than the port, which lands it inside the eight-cell
+## pocket the Snorlax's own body seals off the east edge, so the walk uses (36,9)
+## facing left: the last of `SnorlaxAwake.ProximityCoords` and the only kind of
+## cell an eastbound player ever has.
 const MAP_IDS: Dictionary = {
 	&"ILEX_FOREST": {&"crystal": Vector2i(3, 52), &"gold": Vector2i(3, 44)},
 	&"MAHOGANY_MART_1F": {&"crystal": Vector2i(3, 48), &"gold": Vector2i(3, 40)},
@@ -965,15 +943,13 @@ func _story_path(data: GameData) -> Dictionary:
 	save.world = world.snapshot()
 	var random := RandomNumberGenerator.new()
 	random.seed = 7
-	# Every map load advances the roaming beasts. Supply a dedicated schedule
-	# stream rather than relying on an implicit random source, as the live screen
-	# does at world_screen.gd:153. Without this the route's reported roaming
-	# positions cannot be diffed against itself.
-	#
-	# Its own generator, not the route's: the schedule rolls once per map load,
-	# and drawing them from the same stream would shift every encounter and catch
-	# behind them. That separation is the whole point of Gen2WorldAPI keeping
-	# three.
+	## Maps this walk names by id rather than by cell, where the two profiles disagree.
+	## A map number counts from its group's first entry, so a map pokegold does not
+	## ship shifts every later number in that group: group 3 runs eight lower from
+	## `UNION_CAVE_1F` on, because pokecrystal inserts eight Ruins of Alph rooms, and
+	## group 11 shifts around `GOLDENROD_POKECENTER_1F` and the absent
+	## `GOLDENROD_DEPT_STORE_ROOF`. Only the ids this walk resolves are listed;
+	## everything else it reaches is found by the cell it stands on.
 	var schedule_random := RandomNumberGenerator.new()
 	schedule_random.seed = 11
 	world.schedule_random = schedule_random
@@ -2424,19 +2400,12 @@ func _goldenrod_flower_shop(
 	return {"ok": true}
 
 
-## Goldenrod to the Fog Badge. Two errands gate it: the SquirtBottle, whose
-## shape is the leg's one profile split, and Morty, who is absent until the
-## Burned Tower's beasts are released.
-##
-## Crystal spends the bottle on a round trip. `Route36FloriaScript` has to be
-## met on Route 36 first (EVENT_MET_FLORIA), then talked to again in the shop
-## (EVENT_TALKED_TO_FLORIA_AT_FLOWER_SHOP), and only then does
-## `FlowerShopTeacherScript` reach its `verbosegiveitem SQUIRTBOTTLE`. Gold and
-## Silver ship no Floria on Route 36 at all (`maps/Route36.asm`) and their
-## teacher is `checkflag ENGINE_PLAINBADGE` and nothing else
-## (`maps/GoldenrodFlowerShop.asm`), so the badge the walk already holds is the
-## whole gate and the trip north before the shop buys nothing. The shop's own
-## Floria wanders there and gates nothing either.
+# Every map load advances the roaming beasts, so this supplies a dedicated
+# schedule stream rather than relying on an implicit random source, as the live
+# screen does. Its own generator, not the route's: the schedule rolls once per
+# map load, and drawing them from the same stream would shift every encounter
+# and catch behind them. That separation is the whole point of [Gen2WorldAPI]
+# keeping three.
 func _fog_badge_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -2758,18 +2727,14 @@ func _fog_badge_path(
 	return {"ok": true}
 
 
-## The Fog Badge to the Mineral Badge, taking the Storm Badge on the way, on the
-## same world, state and save. This is the first leg that needs Surf on the real
-## route: HM03 is the Dance Theater's reward for the five Kimono Girls, and
-## Routes 40 and 41 are the only way to Cianwood, whose pharmacy holds the
-## SecretPotion that maps/OlivineLighthouse6F.asm wants before it clears
-## EVENT_OLIVINE_GYM_JASMINE.
-##
-## Chuck is on this leg rather than one of its own because the crossing is: the
-## Mineral Badge sends the player to Cianwood for the SecretPotion anyway, and
-## maps/CianwoodGym.asm is two doors from the pharmacy. Doing it here costs no
-## extra Route 40/41 crossing, which is also the order a player walks. HM04 is
-## collected before the outbound crossing, from maps/OlivineCafe.asm.
+## Goldenrod to the Fog Badge. Two errands gate it: the SquirtBottle, whose shape
+## is the leg's one profile split, and Morty, who is absent until the Burned
+## Tower's beasts are released. Crystal spends the bottle on a round trip, Floria
+## having to be met on Route 36 first and talked to again in the shop before
+## `FlowerShopTeacherScript` reaches its `verbosegiveitem SQUIRTBOTTLE`. Gold and
+## Silver ship no Floria on Route 36 at all and their teacher is
+## `checkflag ENGINE_PLAINBADGE` and nothing else, so the badge the walk already
+## holds is the whole gate and the trip north before the shop buys nothing.
 func _mineral_badge_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -2998,16 +2963,14 @@ func _mineral_badge_path(
 	return {"ok": true}
 
 
-## The Mineral Badge to the Glacier Badge. Mahogany's gym is closed until the
-## Rocket hideout under its souvenir shop is cleared
-## (`EVENT_MAHOGANY_TOWN_POKEFAN_M_BLOCKS_GYM`, `maps/MahoganyTown.asm`), and the
-## hideout only opens after Lance is met at the Lake of Rage, which is behind the
-## Red Gyarados in the middle of the water.
-##
-## The hideout is three floors of one-way halves rather than one maze: each floor
-## is cut in two and the halves are joined through the other floor, so the route
-## climbs and drops the same ladders several times. Its own doors are the only
-## other links, and each opens on something learned a floor away.
+## The Fog Badge to the Mineral Badge, taking the Storm Badge on the way, on the
+## same world, state and save. The first leg that needs Surf on the real route:
+## HM03 is the Dance Theater's reward for the five Kimono Girls, and Routes 40 and
+## 41 are the only way to Cianwood, whose pharmacy holds the SecretPotion Olivine
+## Lighthouse wants before it clears EVENT_OLIVINE_GYM_JASMINE. Chuck is on this
+## leg rather than one of its own because the crossing is: the Mineral Badge sends
+## the player to Cianwood anyway and the gym is two doors from the pharmacy, which
+## is also the order a player walks. HM04 is collected before the outbound crossing.
 func _glacier_badge_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3603,19 +3566,13 @@ func _glacier_badge_path(
 	return {"ok": true}
 
 
-## Mahogany Town west to Goldenrod City and back, clearing the Radio Tower.
-##
-## This leg is what opens Blackthorn Gym. `maps/BlackthornCity.asm` stands
-## BLACKTHORNCITY_SUPER_NERD1 on (18,12), the only cell that reaches the gym
-## door warp at (18,11), and its event flag is set only by
-## `maps/RadioTower5F.asm`'s boss script. Beating Pryce already ran
-## `RadioTowerRocketsScript` (`engine/events/std_scripts.asm`), so the takeover
-## is armed before the leg starts: the Rockets are visible and the Black Belt
-## who would block 2F's stairs is hidden.
-##
-## The walk back is six connections west, all of them crossed eastward earlier
-## in the route, and the two Route 42 lakes are surfed in reverse. Appends to
-## [param path] and answers only ok or the failure.
+## The Mineral Badge to the Glacier Badge. Mahogany's gym is closed until the
+## Rocket hideout under its souvenir shop is cleared, and the hideout only opens
+## after Lance is met at the Lake of Rage, which is behind the Red Gyarados in the
+## middle of the water. The hideout is three floors of one-way halves rather than
+## one maze: each floor is cut in two and the halves are joined through the other
+## floor, so the route climbs and drops the same ladders several times. Its own
+## doors are the only other links, and each opens on something learned a floor away.
 func _radio_tower_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3765,25 +3722,13 @@ func _radio_tower_boss(
 	return {"ok": true}
 
 
-## Goldenrod City to the warehouse director's CARD_KEY, and back.
-##
-## Three maps, each cut into regions the others join. GoldenrodUnderground's
-## north half is reached from the switch room's south corridor and ends at the
-## basement door (18,6), which `BasementDoorScript` unlocks with the
-## BASEMENT_KEY and which then warps to the underground's south half. That half
-## reaches the switch room's top corridor, where the three switches are.
-##
-## The puzzle is `GoldenrodUndergroundSwitchRoomEntrances_UpdateDoors`: switch 1,
-## 2 and 3 add 1, 2 and 3 to `wUndergroundSwitchPositions` and each position
-## opens some doors and closes others, leaving the ones it does not name alone,
-## so states accumulate. Turning 3, then 2, then 1 walks positions 3, 5 and 6 and
-## ends with doors 3, 5, 6, 8, 9 and 11 open, which is the one chain from the top
-## corridor to the warehouse doors at (22,10) and (23,10).
-##
-## Coming back needs the emergency switch: the warehouse's own
-## MAPCALLBACK_NEWMAP clears every door event, so re-entering the switch room
-## seals the room the warehouse opens into, and `EmergencySwitchScript` at
-## (20,11) is the only switch reachable from inside it.
+## Mahogany Town west to Goldenrod City and back, clearing the Radio Tower. This
+## leg is what opens Blackthorn Gym: BLACKTHORNCITY_SUPER_NERD1 stands on (18,12),
+## the only cell that reaches the gym door warp at (18,11), and its event flag is
+## set only by `maps/RadioTower5F.asm`'s boss script. Beating Pryce already ran
+## `RadioTowerRocketsScript`, so the takeover is armed before the leg starts. The
+## walk back is six connections west, all crossed eastward earlier in the route,
+## and the two Route 42 lakes are surfed in reverse. Appends to [param path].
 func _goldenrod_underground_card_key(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -3985,16 +3930,14 @@ func _warp_chain(
 	return {"ok": true}
 
 
-## Mahogany Town and Goldenrod City in either direction, on the same world,
-## state and save. [param heading] is "west" for Mahogany to Goldenrod and
-## "east" for the return.
-##
-## The chain is Mahogany, Route 42, Ecruteak City, Route 37, Route 36, Route 35,
-## Goldenrod (`data/maps/attributes.asm`), with Route 35's south end a gate
-## building rather than a connection (`maps/Route35.asm` warp to
-## ROUTE_35_GOLDENROD_GATE). Route 42's two lakes have no land path around them,
-## so both are surfed, and Route 35's cut tree regrows on every map load, so it
-## is cut on every crossing.
+## Goldenrod City to the warehouse director's CARD_KEY, and back. Three maps, each
+## cut into regions the others join: the underground's north half ends at the
+## basement door the BASEMENT_KEY unlocks, which warps to the south half, and that
+## half reaches the switch room's top corridor. The puzzle is
+## `..._UpdateDoors`: each switch adds to `wUndergroundSwitchPositions` and opens
+## some doors and closes others, leaving the rest alone, so states accumulate and
+## 3, then 2, then 1 is the one chain to the warehouse. Coming back needs the
+## emergency switch, since the warehouse's own callback clears every door event.
 func _goldenrod_crossing(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4182,16 +4125,13 @@ func _lake_crossing(
 	return _walk_cell_resolving(world, landfall, save, random, data, true)
 
 
-## Blackthorn City to the Rising Badge, on the same world, state and save.
-##
-## The badge is not won in the gym. `BlackthornGymClairScript` sets only
-## `EVENT_BEAT_CLAIR` and swaps the two Blackthorn gramps so the Dragon's Den
-## door at (20,1) opens. `maps/DragonShrine.asm` is what runs
-## `setflag ENGINE_RISINGBADGE` on Crystal, at the end of the elder's
-## five-question quiz; Gold and Silver have no shrine and put the same line in
-## `DragonsDenB1FDragonFangScript` (`maps/DragonsDenB1F.asm`).
-##
-## Appends to [param path] and answers only ok or the failure.
+## Mahogany Town and Goldenrod City in either direction, on the same world, state
+## and save. [param heading] is "west" for Mahogany to Goldenrod and "east" for the
+## return. The chain is Mahogany, Route 42, Ecruteak City, Route 37, Route 36,
+## Route 35, Goldenrod, with Route 35's south end a gate building rather than a
+## connection. Route 42's two lakes have no land path around them, so both are
+## surfed, and Route 35's cut tree regrows on every map load, so it is cut on every
+## crossing.
 func _rising_badge_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4235,21 +4175,13 @@ func _rising_badge_path(
 	return {"ok": true}
 
 
-## Blackthorn Gym's boulder puzzle and Clair.
-##
-## 1F is four regions, and the entrance reaches only one of them. 2F's three
-## holes are `stonetable` rows, and a boulder that falls through one is
-## `disappear`ed and sets its own event flag, which
-## `BlackthornGym1FBouldersCallback` turns into a `changeblock` on 1F. Two of
-## those changes are the route: BOULDER1 through the (8,3) hole opens 1F (8,3),
-## joining the middle corridor to Clair's room, and BOULDER3 through the (8,7)
-## hole opens 1F (8,7), joining that corridor to the pocket 2F's (7,9) staircase
-## drops into. BOULDER2's hole adds one 1F cell beside the entrance and reaches
-## nothing, so the walk leaves it alone.
-##
-## BOULDER1 is one push; BOULDER3 starts nine cells south of the row it has to
-## cross on, so it goes north until the wall at (6,6) stops it and then east
-## into the hole.
+## Blackthorn City to the Rising Badge, on the same world, state and save. The
+## badge is not won in the gym: `BlackthornGymClairScript` sets only
+## `EVENT_BEAT_CLAIR` and swaps the two Blackthorn gramps so the Dragon's Den door
+## at (20,1) opens. `maps/DragonShrine.asm` is what runs
+## `setflag ENGINE_RISINGBADGE` on Crystal, at the end of the elder's five-question
+## quiz; Gold and Silver have no shrine and put the same line in
+## `DragonsDenB1FDragonFangScript`. Appends to [param path].
 func _blackthorn_gym_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4329,18 +4261,14 @@ func _blackthorn_gym_leg(
 	return {"ok": true}
 
 
-## Blackthorn City to the Dragon Shrine, and the elder's quiz.
-##
-## Clair's script sets `EVENT_BLACKTHORN_CITY_GRAMPS_BLOCKS_DRAGONS_DEN` and
-## clears its partner, which swaps the gramps standing on (20,2) for one beside
-## it and opens the den door at (20,1). Neither den floor needs a field move:
-## B1F's shrine warp at (19,29) is on the same land region as the ladder from
-## 1F, and the whirlpool at (10,20) guards the water pocket rather than the way
-## through.
-##
-## The quiz is answered correctly. `.WrongAnswer` on the last question checks
-## `EVENT_TEMPORARY_UNTIL_MAP_RELOAD_6`, which question 5 has already set, so it
-## asks question 5 again: a wrong answer there is the one that does not move on.
+## Blackthorn Gym's boulder puzzle and Clair. 1F is four regions and the entrance
+## reaches only one. 2F's three holes are `stonetable` rows, and a boulder that
+## falls through one sets its own event flag, which
+## `BlackthornGym1FBouldersCallback` turns into a `changeblock` on 1F. Two of those
+## are the route: BOULDER1 through the (8,3) hole joins the middle corridor to
+## Clair's room, and BOULDER3 through the (8,7) hole joins it to the pocket 2F's
+## staircase drops into. BOULDER2's hole reaches nothing. BOULDER1 is one push;
+## BOULDER3 goes north until the wall at (6,6) stops it and then east.
 func _dragon_shrine_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4468,23 +4396,14 @@ func _dragon_shrine_leg(
 	return {"ok": true}
 
 
-## Dragon's Den B1F's DRAGON_FANG ball, which is where Gold and Silver keep the
-## Rising Badge.
-##
-## pokegold ships no DRAGON_SHRINE map: `maps/DragonsDenB1F.asm` has one warp
-## rather than two and no coord event, and blocks (7..11, 13..15) of its `.blk`
-## wall the shrine mouth off, which is the whole difference between the two
-## grids. `DragonsDenB1FDragonFangScript` is the errand instead: the ball on
-## (35,16) gives the fang, then Clair walks in, runs `setflag ENGINE_RISINGBADGE`
-## and hands over TM24 in the same conversation Crystal splits between the elder
-## and a later coord event.
-##
-## The ball's land strip is (34..35, 16..21) and touches no other land, so the
-## lake is the only way onto it and (34,22) is its one shore: the water west of
-## the strip is a pocket of its own, sealed off by the COLL_BUOY column on
-## (30, 16..19), which `data/collision/collision_permissions.asm` gives
-## WALL_TILE. The whirlpool on (10,20) is on this route as much as on Crystal's,
-## since it is the only cell joining the ladder's own lake to the southern one.
+## Blackthorn City to the Dragon Shrine, and the elder's quiz. Clair's script swaps
+## the gramps standing on (20,2) for one beside it and opens the den door at
+## (20,1). Neither den floor needs a field move: B1F's shrine warp at (19,29) is on
+## the same land region as the ladder from 1F, and the whirlpool at (10,20) guards
+## the water pocket rather than the way through. The quiz is answered correctly:
+## `.WrongAnswer` on the last question checks a flag question 5 has already set, so
+## it asks question 5 again, and a wrong answer there is the one that does not move
+## on.
 func _dragons_den_dragon_fang(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4554,20 +4473,14 @@ func _dragons_den_dragon_fang(
 	return {"ok": true}
 
 
-## The Dragon Shrine to Indigo Plateau, on the same world, state and save.
-##
-## `VictoryRoadGate`'s coord event at (10,11) is a `readvar VAR_BADGES` against
-## `NUM_JOHTO_BADGES - 1`, so it is the first script on the walked route that
-## reads the badge count back, and the eighth badge is what opens the leg.
-##
-## Route 27 is the reason this leg waited on Waterfall. Its Kanto landfall sits
-## in a region that reaches no map edge, and the only crossing of the channel
-## east of it starts in a pocket reached solely by leaving Tohjo Falls there.
-## The cave in turn is two lower channels that reach the pool feeding them only
-## by climbing `COLL_WATERFALL` cells. `tools/checks/route_27.gd` pins all of
-## it.
-##
-## Appends to [param path] and answers only ok or the failure.
+## Dragon's Den B1F's DRAGON_FANG ball, which is where Gold and Silver keep the
+## Rising Badge. pokegold ships no DRAGON_SHRINE map: B1F has one warp rather than
+## two and no coord event, and blocks (7..11, 13..15) wall the shrine mouth off.
+## `DragonsDenB1FDragonFangScript` is the errand instead: the ball on (35,16) gives
+## the fang, then Clair walks in, runs `setflag ENGINE_RISINGBADGE` and hands over
+## TM24. The ball's land strip touches no other land, so the lake is the only way
+## onto it and (34,22) is its one shore; the whirlpool on (10,20) is on this route
+## as much as on Crystal's.
 func _kanto_approach_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4594,19 +4507,14 @@ func _kanto_approach_path(
 	return _elite_four_leg(world, save, random, data, path)
 
 
-## The Dragon's Den back to New Bark Town.
-##
-## The way out is the way in reversed. Crystal clears the whirlpool twice:
-## `complete_whirlpool()` is a transient block override, so the warp into the
-## shrine restored (10,20), and the water south of it reaches the shrine's
-## landfall and nothing else. Gold and Silver enter no map in between, so their
-## first clear still holds.
-##
-## Blackthorn's own exit is south, not west: Route 45 into Route 46 into the
-## Route 29 gate. Route 46 is walked downhill only. Its ledges leave the region
-## around the gate cells reaching no map edge at all, so a route that tried to
-## climb it from Route 29 would stop; entered from Route 45's west edge it
-## reaches the gate.
+## The Dragon Shrine to Indigo Plateau, on the same world, state and save.
+## `VictoryRoadGate`'s coord event at (10,11) is a `readvar VAR_BADGES` against
+## `NUM_JOHTO_BADGES - 1`, so it is the first script on the walked route that reads
+## the badge count back. Route 27 is the reason this leg waited on Waterfall: its
+## Kanto landfall sits in a region that reaches no map edge, the only crossing east
+## of it starts in a pocket reached solely by leaving Tohjo Falls there, and the
+## cave's two lower channels reach the pool feeding them only by climbing
+## `COLL_WATERFALL` cells. `tools/checks/route_27.gd` pins all of it.
 func _blackthorn_departure(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4798,20 +4706,14 @@ func _blackthorn_departure(
 	return {"ok": true}
 
 
-## New Bark Town to Route 26, along Route 27 and through Tohjo Falls.
-##
-## New Bark's east column is wall except the four water rows 6 to 9, so leaving
-## town east is a crossing rather than a step. The far side is still water, so
-## one water-only walk comes ashore on ROUTE_27_LANDFALL, one of the two
-## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord cells, and the scene runs on
-## arrival.
-##
-## From there the way east is the cave, twice over. Row 5 of Route 27 is solid
-## cliff apart from Tohjo Falls' two mouths, and both are `COLL_CAVE`, whose
-## `.CheckTile` `.warps` branch forces a step DOWN: a player leaving either
-## mouth always ends south of it. So the west mouth is entered from the
-## landfall's region, the cave is crossed, and the east mouth drops the player
-## into the pocket whose own shore is the channel across to Route 26's edge.
+## The Dragon's Den back to New Bark Town. The way out is the way in reversed.
+## Crystal clears the whirlpool twice: `complete_whirlpool()` is a transient block
+## override, so the warp into the shrine restored (10,20), and the water south of
+## it reaches the shrine's landfall and nothing else. Gold and Silver enter no map
+## in between, so their first clear still holds. Blackthorn's own exit is south
+## rather than west: Route 45 into Route 46 into the Route 29 gate. Route 46 is
+## walked downhill only, its ledges leaving the gate region reaching no map edge
+## at all.
 func _kanto_approach(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -4902,15 +4804,14 @@ func _kanto_approach(
 	return {"ok": true}
 
 
-## Tohjo Falls, west mouth to east mouth, which is one Waterfall climb and one
-## ride back down.
-##
-## The cave is three water bodies joined only by its waterfalls. From the west
-## door's landing the surf runs west and north to the foot of the x 8 to 11
-## column; the climb ends on the pool above it, still on water. The east
-## waterfall is then ridden down rather than climbed: stepping onto its top cell
-## leaves the player standing on a `COLL_WATERFALL`, and `.CheckTile` takes over
-## from there, which is `advance_forced_movement()` here.
+## New Bark Town to Route 26, along Route 27 and through Tohjo Falls. New Bark's
+## east column is wall except the four water rows 6 to 9, so leaving town east is a
+## crossing rather than a step, and the far side is still water: one water-only
+## walk comes ashore on ROUTE_27_LANDFALL, one of the two
+## `SCENE_ROUTE27_FIRST_STEP_INTO_KANTO` coord cells. From there the way east is
+## the cave, twice over. Row 5 is solid cliff apart from Tohjo Falls' two mouths,
+## both `COLL_CAVE`, whose `.warps` branch forces a step DOWN, so the east mouth
+## drops the player into the pocket whose shore crosses to Route 26.
 func _tohjo_falls_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5221,16 +5122,13 @@ func _victory_road_leg(
 	return {"ok": true}
 
 
-## The Indigo Plateau Pokemon Center to the Hall of Fame.
-##
-## The five rooms are one corridor with a door between each pair, and no heal
-## anywhere in it. `_drain_story()` answers every battle with a win, so what
-## this walks is the doors, the scenes and the flags, not five fights a party
-## survived.
-##
-## `IndigoPlateauPokecenter1FPrepareElite4Callback` has already run on the
-## Pokemon Center's own map entry: it sets all six scenes and clears the twelve
-## room flags, so each room arrives on its `_LOCK_DOOR` scene.
+## The Indigo Plateau Pokemon Center to the Hall of Fame. The five rooms are one
+## corridor with a door between each pair, and no heal anywhere in it.
+## `_drain_story()` answers every battle with a win, so what this walks is the
+## doors, the scenes and the flags rather than five fights a party survived.
+## `IndigoPlateauPokecenter1FPrepareElite4Callback` has already run on the Pokemon
+## Center's own map entry: it sets all six scenes and clears the twelve room flags,
+## so each room arrives on its `_LOCK_DOOR` scene.
 func _elite_four_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5427,16 +5325,13 @@ func _hall_of_fame_leg(
 	return {"ok": true}
 
 
-## The Hall of Fame to Kanto: the post-credits spawn, Elm's S.S. Ticket, the
-## walk back to Olivine, the S.S. Aqua and landfall in Vermilion City.
-##
-## This leg starts on a new world. `SpawnAfterE4` (`engine/menus/intro_menu.asm`)
-## answers the next Continue with SPAWN_NEW_BARK and MAPSETUP_WARP, so the
-## cartridge does not walk out of the Hall of Fame either; it reloads the map.
-## The state and the save carry over, which is what makes the flags the Hall of
-## Fame just set visible to Elm.
-##
-## Returns the world it built, since everything after it runs there.
+## The Hall of Fame to Kanto: the post-credits spawn, Elm's S.S. Ticket, the walk
+## back to Olivine, the S.S. Aqua and landfall in Vermilion City. This leg starts on
+## a new world: `SpawnAfterE4` answers the next Continue with SPAWN_NEW_BARK and
+## MAPSETUP_WARP, so the cartridge does not walk out of the Hall of Fame either, it
+## reloads the map. The state and the save carry over, which is what makes the flags
+## the Hall of Fame just set visible to Elm. Returns the world it built, since
+## everything after it runs there.
 func _kanto_crossing_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -5496,18 +5391,14 @@ func _kanto_crossing_path(
 	return {"ok": true, "world": spawned}
 
 
-## Olivine Port to Vermilion City on the S.S. Aqua.
-##
-## The Hall of Fame is what opens this: `HallOfFameEnterScript` sets
-## EVENT_OLIVINE_PORT_SPRITES_BEFORE_HALL_OF_FAME and clears the `AFTER` one, and
-## the sailor those flags swap is the one standing on the port's own coord event
-## at (7,15). Before the Hall of Fame he blocks it.
-##
-## The first crossing is the granddaughter's: `.CanArrive` in
-## `maps/FastShipCabins_SW_SSW_NW.asm` wants EVENT_FAST_SHIP_FOUND_GIRL or
-## EVENT_FAST_SHIP_FIRST_TIME, and neither is set on the way out, so the ship
-## only docks once `SSAquaMetalCoatAndDocking` has run. The bed is not needed;
-## that script sets both the arrival and the found-girl flags itself.
+## Olivine Port to Vermilion City on the S.S. Aqua. The Hall of Fame is what opens
+## this: `HallOfFameEnterScript` swaps the two port sprite flags, and the sailor
+## those flags swap is the one standing on the port's own coord event at (7,15).
+## Before the Hall of Fame he blocks it. The first crossing is the granddaughter's:
+## `.CanArrive` wants EVENT_FAST_SHIP_FOUND_GIRL or EVENT_FAST_SHIP_FIRST_TIME and
+## neither is set on the way out, so the ship only docks once
+## `SSAquaMetalCoatAndDocking` has run. The bed is not needed; that script sets both
+## flags itself.
 func _ss_aqua_crossing(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6236,17 +6127,14 @@ func _celadon_gym_leg(
 	return {"ok": true}
 
 
-## Celadon Gym to Cerulean City, by way of Saffron and Route 5.
-##
-## Two gate buildings and one open connection. Cerulean is as far as this walk
-## goes: the Cascade Badge is an errand, not a cell. Misty and her three swimmers
-## all carry EVENT_TRAINERS_IN_CERULEAN_GYM as their hide flag and
-## `InitializeEventsScript` sets it, so the gym stays empty until
-## `Route25MistyDate1Script` clears it; that scene is armed by the gym's own
-## grunt, who is armed by the Power Plant manager. The plant is not walked to
-## either: it sits in a region with no map edge and no walkable neighbour, and
-## the way in is Route 9's river, which the same cut that opens the route also
-## opens the shore of. `tools/checks/cerulean.gd` pins all of it.
+## Celadon Gym to Cerulean City, by way of Saffron and Route 5: two gate buildings
+## and one open connection. Cerulean is as far as this walk goes, because the
+## Cascade Badge is an errand rather than a cell. Misty and her three swimmers all
+## hide behind EVENT_TRAINERS_IN_CERULEAN_GYM, cleared by a scene armed by the
+## gym's own grunt, who is armed by the Power Plant manager. The plant is not walked
+## to either: it sits in a region with no map edge and no walkable neighbour, and
+## the way in is Route 9's river, whose shore the same cut opens.
+## `tools/checks/cerulean.gd` pins all of it.
 func _cerulean_approach_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6390,19 +6278,14 @@ func _machine_part_errand(
 	return _cerulean_gym_leg(world, save, random, data, path)
 
 
-## Misty, once the errand has put her in her gym.
-##
-## The gym is a pool with the leader on an island, and its trainers are what the
-## walk has to answer: Swimmer Diana watches the one row every route to Misty
-## crosses, and Swimmers Parker and Briana watch the pool's two alternative
-## columns, so one of the pair is met whichever way round it goes. All three stand
-## on water and walk over it to reach the player, which the cartridge allows
-## because `SeenByTrainerScript` is `applymovementlasttalked` and its steps reach
-## `NormalStep`, checking no permission. `tools/checks/cerulean.gd` pins the
-## geometry and each approach.
-##
-## Misty herself sets all three of their beaten flags along with her own, the way
-## Surge, Erika and Sabrina do, so they are reported rather than gated on.
+## Misty, once the errand has put her in her gym. The gym is a pool with the leader
+## on an island, and its trainers are what the walk has to answer: Swimmer Diana
+## watches the one row every route to Misty crosses, and Parker and Briana watch the
+## pool's two alternative columns, so one of the pair is met whichever way round it
+## goes. All three stand on water and walk over it to reach the player, which the
+## cartridge allows because `SeenByTrainerScript`'s steps reach `NormalStep` and
+## check no permission. Misty sets all three of their beaten flags along with her
+## own, so they are reported rather than gated on.
 func _cerulean_gym_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6452,22 +6335,13 @@ func _cerulean_gym_leg(
 
 
 ## Cerulean Gym back through Saffron to Lavender Town and the Kanto Radio Tower.
-##
-## Two gate buildings and one open connection, the same shape as the walk that
-## reached Cerulean, run in reverse and then east: Route 5's own warp at (8,17)
-## into the Saffron gate, Saffron's warp 14 into the Route 8 gate, and Route 8's
-## single east crossing at (39,8) onto Lavender's (0,8). No cut tree and no
-## errand stand in the way of the town itself; Route 8's five trainers are the
-## only thing between the gate and the crossing, and just one of them, Super Nerd
-## Tom, cannot be routed around. The three bikers watch the corridor west of the
-## route's eight `$a3` hop-down ledges, and the eastbound walk hops off row 6
-## onto row 8 east of them, so it never enters a line they cover.
-##
-## What the leg is for is the EXPN CARD. `LavRadioTower1FGentlemanScript` gates it
-## on `EVENT_RETURNED_MACHINE_PART`, which the Cerulean errand already set, so
-## this is the second time a Kanto opener sat before its gate rather than behind
-## it: the tower is off the air until the Power Plant runs, and the card is what
-## eventually answers `special SnorlaxAwake` on Route 11.
+## Two gate buildings and one open connection, the same shape run in reverse and
+## then east. Route 8's five trainers are the only thing between the gate and the
+## crossing, and just one, Super Nerd Tom, cannot be routed around: the three bikers
+## watch the corridor west of the route's eight `$a3` hop-down ledges, and the
+## eastbound walk hops off row 6 onto row 8 east of them. What the leg is for is the
+## EXPN CARD, gated on `EVENT_RETURNED_MACHINE_PART`, which the Cerulean errand
+## already set: the third Kanto opener that sat before its gate.
 func _lavender_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6564,21 +6438,14 @@ func _lavender_leg(
 	return _fuchsia_leg(world, save, random, data, path)
 
 
-## The lost-doll errand and the Magnet Train, run from Saffron City.
-##
-## An errand rather than a walk, and the one leg on the route whose order the
-## cartridge fixes rather than the geography: the Fan Club's Clefairy guy reads
+## The lost-doll errand and the Magnet Train, run from Saffron City. An errand
+## rather than a walk, and the one leg whose order the cartridge fixes rather than
+## the geography: the Fan Club's Clefairy guy reads
 ## EVENT_MET_COPYCAT_FOUND_OUT_ABOUT_LOST_ITEM before he parts with the doll, and
-## only the Copycat sets it, so she is visited first with nothing to give her.
-## Her own branch needs EVENT_RETURNED_MACHINE_PART, which the Cerulean leg set
-## at the Power Plant, so this is the third Kanto opener that sat before its gate.
-##
-## The ride itself never touches the platform on foot. Each station is two
-## regions with row 9 solid between them; the officer stands inside that row and
-## is talked to across it, and his script's `applymovement` walks the player over
-## the wall onto the train door, because a scripted step ignores collision. The
-## `warpcheck` after it takes the door, and the arrival coord event on the far
-## station is stepped onto rather than walked to, since it is live.
+## only the Copycat sets it. The ride itself never touches the platform on foot:
+## each station is two regions with row 9 solid between them, the officer is talked
+## to across that row, and his script's `applymovement` walks the player over the
+## wall onto the train door, because a scripted step ignores collision.
 func _magnet_train_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6859,24 +6726,14 @@ func _magnet_train_ride(
 	return {"ok": true}
 
 
-## Lavender Town south to Fuchsia City and the Soul Badge.
-##
-## The longest open walk in Kanto and the first leg since Vermilion with no
-## errand in it at all: Routes 12, 13, 14 and 15 are four plain connections, and
-## the only door is `ROUTE_15_FUCHSIA_GATE` at the end. What it costs is
-## trainers, eighteen of them, and `tools/checks/fuchsia.gd` measures which
-## ones a walk owes rather than guessing: on this profile only Route 13's
-## Pokefan Joshua and Hiker Kenny stand where shutting their sight line seals the
-## way south. The other three routes can be crossed without meeting anyone, and
-## Route 12, Route 14 and Route 15 are all profile splits, so Gold and Silver
-## owe a different set.
-##
-## The gym is a maze rather than a puzzle with a gate: 128 walkable cells behind
-## the door, and Janine on (1,10) reachable from (1,9). Her four disguised
-## trainers are `OBJECTTYPE_SCRIPT`, so nothing sees the player and none of them
-## has to be fought; `FuchsiaGymJanineScript` sets all four beaten flags itself
-## along with `ENGINE_SOULBADGE`, and hands over TM06 through its own
-## `verbosegiveitem`.
+## Lavender Town south to Fuchsia City and the Soul Badge. The longest open walk in
+## Kanto and the first leg since Vermilion with no errand in it at all: four plain
+## connections and one door at the end. What it costs is trainers, eighteen of them,
+## and `tools/checks/fuchsia.gd` measures which ones a walk owes: on this profile
+## only Route 13's Pokefan Joshua and Hiker Kenny stand where shutting their sight
+## line seals the way south. The gym is a maze rather than a puzzle with a gate, and
+## its four disguised trainers are `OBJECTTYPE_SCRIPT`, so Janine sets all four
+## beaten flags herself along with the badge.
 func _fuchsia_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -6986,21 +6843,13 @@ func _fuchsia_leg(
 
 
 ## Fuchsia Gym back to Vermilion, through Diglett's Cave to Route 2, and up to
-## Pewter Gym for the Boulder Badge.
-##
-## The order is forced. Measured against a real Crystal cache, a walk out of
-## Cerulean reaches 91 maps and none of Route 3, Route 4's main region, Mount
-## Moon, Route 2, Viridian, Pallet, Cinnabar, Route 20 or Seafoam Gym, and
+## Pewter Gym for the Boulder Badge. The order is forced: measured against a real
+## Crystal cache, a walk out of Cerulean reaches 91 maps and none of west Kanto, and
 ## Fuchsia's own south edge is sealed the other way while
-## EVENT_CINNABAR_ROCKS_CLEARED is clear. Diglett's Cave is the one door into
-## west Kanto, and the Snorlax on top of it is the lock.
-##
-## What opens that lock is the radio, which is why the Goldenrod leg now takes
-## the Radio Card: `SnorlaxAwake` answers only while the Poke Flute channel is
-## the track in `wMapMusic`, and a station's music id is neither sentinel
-## `ExitPokegearRadio_HandleMusic` restores on, so it survives the Pokegear
-## closing. `tools/checks/radio.gd` owns that whole chain and the Route 2
-## counts behind it.
+## EVENT_CINNABAR_ROCKS_CLEARED is clear. Diglett's Cave is the one door into west
+## Kanto and the Snorlax on top of it is the lock. What opens that lock is the
+## radio, which is why the Goldenrod leg takes the Radio Card: `SnorlaxAwake`
+## answers only while the Poke Flute channel is the track in `wMapMusic`.
 func _pewter_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -7227,16 +7076,14 @@ func _pewter_gym_leg(
 	return _cinnabar_leg(world, save, random, data, path)
 
 
-## Pewter Gym south to Cinnabar Island and east to Seafoam Gym's Volcano Badge.
-##
-## Six plain connections carry the walk down the west coast, and then it is water
-## the rest of the way: Pallet's own pond is the last land, and Route 21,
-## Cinnabar's west side and Route 20 are all surfed. Two things make this leg the
-## one that has to come before Viridian's. Blue stands on Cinnabar until he is
-## talked to, and `CinnabarIslandBlue` is the only `clearevent` for
-## EVENT_VIRIDIAN_GYM_BLUE in either pin; and `Route20ClearRocksCallback` is a
-## MAPCALLBACK_NEWMAP, so simply arriving on Route 20 sets
-## EVENT_CINNABAR_ROCKS_CLEARED and takes the six `$7a` wall blocks off Route 19.
+## Pewter Gym south to Cinnabar Island and east to Seafoam Gym's Volcano Badge. Six
+## plain connections carry the walk down the west coast and then it is water the
+## rest of the way, Pallet's own pond being the last land. Two things make this leg
+## come before Viridian's: Blue stands on Cinnabar until he is talked to, and
+## `CinnabarIslandBlue` is the only `clearevent` for EVENT_VIRIDIAN_GYM_BLUE in
+## either pin; and `Route20ClearRocksCallback` is a MAPCALLBACK_NEWMAP, so simply
+## arriving on Route 20 sets EVENT_CINNABAR_ROCKS_CLEARED and takes the six `$7a`
+## wall blocks off Route 19.
 func _cinnabar_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -7577,21 +7424,14 @@ func _viridian_leg(
 	return _mt_silver_leg(world, save, random, data, path)
 
 
-## Viridian Gym to Red, which is Oak's errand and then a walk west.
-##
-## The sixteenth badge is what opens this leg and Oak is what spends it:
-## `maps/OaksLab.asm` takes `.OpenMtSilver` only on `ifequal NUM_BADGES`, so the
-## walk goes south to Pallet before it goes west. That is not a courtesy call.
-## The Victory Road Gate is three regions joined by two single cells and a black
-## belt stands in each, so EVENT_OPENED_MT_SILVER is the one thing that joins
-## the corridor to the Route 28 arm, exactly as EVENT_FOUGHT_SNORLAX joins it to
-## the Route 22 arm the leg arrives through. `tools/checks/mt_silver.gd` pins
-## all four combinations.
-##
-## Red himself is the route's second presentation boundary: his script ends on
-## `credits`, which commits nothing and emits one event, the way `halloffame`
-## does. `disappear` then sets EVENT_RED_IN_MT_SILVER again, so the room the
-## Hall of Fame opened closes behind the walk.
+## Viridian Gym to Red, which is Oak's errand and then a walk west. The sixteenth
+## badge opens the leg and Oak is what spends it: `maps/OaksLab.asm` takes
+## `.OpenMtSilver` only on `ifequal NUM_BADGES`, so the walk goes south to Pallet
+## before it goes west. That is not a courtesy call: the Victory Road Gate is three
+## regions joined by two single cells with a black belt in each, so
+## EVENT_OPENED_MT_SILVER is the one thing that joins the corridor to the Route 28
+## arm. Red's own script ends on `credits`, which commits nothing and emits one
+## event, and `disappear` then closes the room behind the walk.
 func _mt_silver_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -8275,23 +8115,14 @@ func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) ->
 		world.advance_object_steps_pass(random)
 
 
-## Mahogany Town east to Blackthorn City, on the same world, state and save.
-## Starts in the town, since the Radio Tower leg before it left the gym.
-##
-## Route 44 carries seven trainers and no scripted gate, so the leg is a walk
-## the trainers interrupt rather than a sequence of errands. Its one warp is the
-## Ice Path door at (56,7) (`maps/Route44.asm`); the east connection to
-## Blackthorn exists in `data/maps/attributes.asm` but the cartridge's own way
-## through is the cave.
-##
-## Ice Path 1F is the only floor on the way: its second warp is Blackthorn's own
-## (`maps/IcePath1F.asm` warp 2 to BLACKTHORN_CITY 7), so the `stonetable`
-## boulder puzzle on B1F is beside the route rather than across it. The floor is
-## COLL_ICE, which is LAND_TILE, so the walk crosses it without the source's
-## sliding; sliding only ever removes choices, so nothing reachable with it is
-## unreachable here.
-##
-## Appends to [param path] and answers only ok or the failure.
+## Mahogany Town east to Blackthorn City, on the same world, state and save. Starts
+## in the town, since the Radio Tower leg before it left the gym. Route 44 carries
+## seven trainers and no scripted gate, so the leg is a walk the trainers interrupt.
+## Its one warp is the Ice Path door at (56,7); the east connection to Blackthorn
+## exists but the cartridge's own way through is the cave. Ice Path 1F is the only
+## floor on the way, its second warp being Blackthorn's own, so the `stonetable`
+## puzzle on B1F is beside the route rather than across it. The floor is COLL_ICE,
+## which is LAND_TILE, so the walk crosses it without the source's sliding.
 func _blackthorn_path(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -8542,19 +8373,13 @@ func _olivine_cafe_hm04(
 
 
 ## Cianwood City's gym, whose only corridor is walled by three
-## SPRITEMOVEDATA_STRENGTH_BOULDER objects at (3,7), (4,7) and (5,7).
-##
-## Row 7 is the sole link between the entrance half and Chuck, its ends are walls
-## at x=2 and x=6, and row 5 above it opens only at (4,5) and (5,5), the second of
-## which a Black Belt stands on for good. So no single push opens it: pushing any
-## boulder north just moves the wall up a row. The corridor opens by clearing
-## (3,7) and (5,7) north first, then pushing the middle boulder sideways into the
-## cell (3,7) left behind, which leaves (4,6) and (4,5) free above the freed
-## (4,7). A state-space search over player cell plus boulder cells finds no
-## shorter answer.
-##
-## Chuck himself needs no Strength: his script throws BOULDER1 aside with an
-## applymovement of its own before the battle.
+## SPRITEMOVEDATA_STRENGTH_BOULDER objects at (3,7), (4,7) and (5,7). Row 7 is the
+## sole link between the entrance half and Chuck, its ends are walls, and row 5
+## above it opens only at (4,5) and (5,5), the second of which a Black Belt stands
+## on for good. So no single push opens it: the corridor opens by clearing (3,7) and
+## (5,7) north first, then pushing the middle boulder sideways into the cell (3,7)
+## left behind. A state-space search over player cell plus boulder cells finds no
+## shorter answer. Chuck himself needs no Strength.
 func _storm_badge_leg(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -8690,17 +8515,13 @@ func _push_boulder_at(
 	}
 
 
-## A mart clerk, talked to across their own counter.
-##
-## Elm's aide gives five Poké Balls, which is not what three catches cost: the
-## route fights each wild down and throws until one sticks, and every throw that
-## does not is a ball. So it buys before the two catches it can and before the
-## one it cannot, Blackthorn being the last town the route stands in before the
-## Dragon's Den.
-##
-## The clerk stands on (1,3) behind the `$90` counter on (2,3), so this is a
-## CheckFacingObject doubled reach like the Radio Card woman's, and the buying
-## itself happens inside the clerk's own `pokemart` pause rather than beside it.
+## A mart clerk, talked to across their own counter. Elm's aide gives five Poke
+## Balls, which is not what three catches cost: the route fights each wild down and
+## throws until one sticks, and every throw that does not is a ball. So it buys
+## before the two catches it can and before the one it cannot, Blackthorn being the
+## last town the route stands in before the Dragon's Den. The clerk stands on (1,3)
+## behind the `$90` counter on (2,3), so this is a CheckFacingObject doubled reach,
+## and the buying happens inside the clerk's own `pokemart` pause.
 func _buy_balls(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -8736,21 +8557,14 @@ func _buy_balls(
 	return {"ok": true}
 
 
-## Route 32's Pokemon Center for the OLD ROD, and then the shore below it for
-## what the rod is here to catch.
-##
-## This is the route's answer to Surf and Whirlpool, and it has to be a rod
-## rather than a walk. Every grass wild in reach before Route 40's south edge
-## that CanLearnTMHMMove accepts for SURF is night only except Slowpoke Well's
-## Slowpoke, and Slowpoke does not take WHIRLPOOL at all; the walked route runs
-## on the new game's own 06:00 clock, so a night slot is not something it can
-## honestly reach. Route 32's own Old Rod row is the one time-independent source
-## of a mon that takes both, at Tentacool on the last threshold
-## (`data/wild/fish.asm`).
-##
-## `Route32Pokecenter1FFishingGuruScript` gates the rod on its own yes/no and
-## then `verbosegiveitem OLD_ROD`, which is what `Gen2WorldInventory.owns_rod()`
-## reads back.
+## Route 32's Pokemon Center for the OLD ROD, and then the shore below it for what
+## the rod is here to catch. This is the route's answer to Surf and Whirlpool, and
+## it has to be a rod rather than a walk: every grass wild in reach before Route
+## 40's south edge that CanLearnTMHMMove accepts for SURF is night only except
+## Slowpoke Well's Slowpoke, and Slowpoke does not take WHIRLPOOL at all. The walked
+## route runs on the new game's own 06:00 clock, so Route 32's Old Rod row is the
+## one time-independent source of a mon that takes both, at Tentacool on the last
+## threshold.
 func _route_32_old_rod(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -8810,19 +8624,14 @@ func _route_32_old_rod(
 	)
 
 
-## Catches something on the current map that can learn [param move], which is
-## how this route gets both of the HMs its own party cannot take.
-##
-## Neither is optional. The starter is still unevolved by Olivine and Chikorita,
-## Cyndaquil and Totodile all learn STRENGTH only after evolving, so Union Cave
-## 1F's Geodude and Onix are the first catch; none of the party learns WATERFALL
-## at all, so Dragon's Den B1F's Dratini is the second
-## (`data/pokemon/base_stats/*.asm`, `data/wild/johto_water.asm`).
-##
-## The walk itself never rolls a wild encounter, so this forces one, checks the
-## species against CanLearnTMHMMove and throws a Poké Ball, retrying until the
-## bag runs out. Both rolls come from the route's seeded generator, so the answer
-## is the same on every run.
+## Catches something on the current map that can learn [param move], which is how
+## this route gets both of the HMs its own party cannot take. Neither is optional:
+## the starter is still unevolved by Olivine and all three starters learn STRENGTH
+## only after evolving, so Union Cave 1F's Geodude and Onix are the first catch, and
+## none of the party learns WATERFALL at all, so Dragon's Den B1F's Dratini is the
+## second. The walk itself never rolls a wild encounter, so this forces one, checks
+## the species against CanLearnTMHMMove and throws a Poke Ball; both rolls come from
+## the route's seeded generator.
 func _catch_field_move_mon(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -8897,14 +8706,13 @@ func _catch_field_move_mon(
 
 
 ## TeachTMHM against the first party member the machine will take, which is what
-## ChooseMonToLearnTMHM leaves the player to pick. Compatibility, a known move
-## and a full moveset are all real refusals, so the walk tries each slot in party
-## order and reports the last reason when none of them can learn it.
-##
-## A full moveset everywhere is the second pass rather than a failure: it is
-## `ForgetMove`'s own prompt, which the walk answers with the first slot that is
-## not an HM, since every HM it has taught is load bearing. A levelled party
-## reaches it, because four level-up moves leave the starter no room for CUT.
+## ChooseMonToLearnTMHM leaves the player to pick. Compatibility, a known move and a
+## full moveset are all real refusals, so the walk tries each slot in party order
+## and reports the last reason when none of them can learn it. A full moveset
+## everywhere is the second pass rather than a failure: it is `ForgetMove`'s own
+## prompt, which the walk answers with the first slot that is not an HM, since every
+## HM it has taught is load bearing. A levelled party reaches it, because four
+## level-up moves leave the starter no room for CUT.
 func _teach_tm_hm(world: Gen2WorldAPI, save: Gen2SaveData, item: int) -> Dictionary:
 	var reason: String = "no party member"
 	for index: int in save.party.size():
@@ -9237,15 +9045,13 @@ func _party_species(save: Gen2SaveData) -> Array:
 
 
 ## The experience a won trainer battle pays, since this walk answers every one of
-## them with a win rather than fighting it. [method Gen2Battle.award_win_experience]
-## is the engine's own split, level up, evolution and move learning; the fought
-## party is written back over the saved one through the adapter that owns that
-## seam, so a leg arrives carrying the levels its fights paid for rather than the
-## ones it started the game with.
-##
-## What is still not a played route: no party member takes damage, and a move
-## offered into a full moveset is left in the engine's queue, which is the same
-## answer as declining it.
+## them with a win rather than fighting it.
+## [method Gen2Battle.award_win_experience] is the engine's own split, level up,
+## evolution and move learning; the fought party is written back over the saved one
+## through the adapter that owns that seam, so a leg arrives carrying the levels its
+## fights paid for. What is still not a played route: no party member takes damage,
+## and a move offered into a full moveset is left in the engine's queue, which is
+## the same answer as declining it.
 func _award_battle_experience(
 	data: GameData, world: Gen2WorldAPI, save: Gen2SaveData, battle: Gen2Battle,
 	player_party: Gen2Party
@@ -9852,18 +9658,14 @@ func _walk_to_connection(
 	}
 
 
-## The cell [param step] from [param cell] reaches by an ordinary walk or, when
-## that is blocked, a ledge hop (Gen2WorldCollision.allows_hop, mirroring
-## Gen2WorldAPI._try_ledge_hop's order and its surf and map-bounds refusals).
-## Returns (-1, -1) when neither applies, so a BFS frontier can use it as one
-## reachability test. Replaying the recorded direction through
-## world.move_result() performs the same hop, so no separate replay step exists.
-##
-## [param water_only] is what a surfing plan needs. can_walk_to() lets a surfing
-## player step onto land, and that step is .ExitWater, so a plan drawn once and
-## replayed would stop surfing partway and see every later water step refused.
-## Restricting the frontier to WATER_TILE keeps the whole plan legal in the mode
-## it was drawn in; the caller enters and leaves the water explicitly.
+## The cell [param step] from [param cell] reaches by an ordinary walk or, when that
+## is blocked, a ledge hop, mirroring `_try_ledge_hop`'s order and its surf and
+## map-bounds refusals. Returns (-1, -1) when neither applies, so a BFS frontier can
+## use it as one reachability test. [param water_only] is what a surfing plan needs:
+## `can_walk_to()` lets a surfing player step onto land, and that step is
+## `.ExitWater`, so a plan drawn once and replayed would stop surfing partway and
+## see every later water step refused. Restricting the frontier to WATER_TILE keeps
+## the plan legal in the mode it was drawn in.
 func _reachable_step(
 	world: Gen2WorldAPI, cell: Vector2i, step: Vector2i,
 	warp_target: Vector2i = Vector2i(-1, -1),
@@ -10004,14 +9806,12 @@ func _walk_to_story_cell(
 
 
 ## What a failed walk hit, when what it hit was somebody standing there.
-## `Gen2WorldAPI.can_walk_to()` refuses a cell an object holds exactly as it
-## refuses a wall, so without this a route blocked by an NPC or an item ball
-## reads the same as one blocked by the map, and both of Route 40's beach rocks
-## and the Lake of Rage's gramps cost a hand-routed detour to find.
-##
-## [param target] is the cell the walk wanted, or `(-1, -1)` for a connection
-## edge that has none; [param visited] is the frontier's own `previous` map.
-## Answers "" when nothing is in the way, so it appends to a reason.
+## `Gen2WorldAPI.can_walk_to()` refuses a cell an object holds exactly as it refuses
+## a wall, so without this a route blocked by an NPC or an item ball reads the same
+## as one blocked by the map, and both of Route 40's beach rocks and the Lake of
+## Rage's gramps cost a hand-routed detour to find. [param target] is the cell the
+## walk wanted, or `(-1, -1)` for a connection edge that has none; [param visited]
+## is the frontier's own `previous` map. Answers "" when nothing is in the way.
 func _objects_in_the_way(
 	world: Gen2WorldAPI, target: Vector2i, visited: Dictionary
 ) -> String:

--- a/tools/profile.gd
+++ b/tools/profile.gd
@@ -3,22 +3,11 @@ extends SceneTree
 ## What a drawn frame costs, per screen, in milliseconds.
 ##
 ##   Godot --path . -s res://tools/profile.gd -- [subject ...] [game] [frames]
-##   Godot --path . -s res://tools/profile.gd -- all crystal 900
 ##
-## Not a check and not a preview: `tools/checks/` runs headless under
-## `validate.gd` and answers right or wrong, and a `preview_*.gd` photographs one
-## frame. Neither can say what sixty of them cost, which is the only question
-## that decides whether a weaker machine holds its frame rate.
-##
-## A real window, vsync off and no frame cap, so the number is the whole frame:
-## the screen's own hardware pass, whatever it rebuilds, and the draw. Every
-## subject is driven by counted `advance_frame()` calls with the node's own
-## `_process` off, so one drawn frame is one hardware frame whatever the host
-## does, and two runs compare.
-##
-## The number is this machine's. What carries across machines is the ratio
-## between two runs of the same subject, which is what an optimisation is
-## measured by.
+## Neither a check nor a preview can say what sixty frames cost, which is the only
+## question that decides whether a weaker machine holds its frame rate. A real
+## window, vsync off and no frame cap, with every subject driven by counted
+## `advance_frame()` calls, so two runs compare; the ratio is what carries.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Frames spent before the first one is timed: a screen builds its textures on

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -1,138 +1,13 @@
 extends SceneTree
 
-## Records one clip to a video, for a trailer rather than for a check.
-##
-## Godot's Movie Maker is what makes this reproducible: `--write-movie` pins the
-## frame delta, so the world's own clock spends exactly one hardware frame per
-## recorded frame and a clip is the same clip twice. Nothing here steps the
-## screen by hand for that reason: the game runs its ordinary `_process`, mods
-## included, and only the buttons are scripted.
+## Records one clip to a video, for a trailer rather than for a check. Godot's
+## Movie Maker is what makes it reproducible: `--write-movie` pins the frame delta,
+## so the world spends exactly one hardware frame per recorded frame. Nothing here
+## steps the screen by hand for that reason: the game runs its ordinary `_process`,
+## mods included, and only the buttons are scripted. [constant USAGE] is every key.
 ##
 ##   Godot --path . --mods --write-movie /tmp/clip.avi --fixed-fps 60 \
 ##     -s res://tools/record_clip.gd -- <game> <group> <map> [key=value ...]
-##
-## The AVI is Motion JPEG with the game's own audio in it. What a trailer wants
-## is the clip proper at 1080p, and `TRIM=<frame>` on stdout is where that
-## starts: the mod load and the warm-up in front of it are as long as they are,
-## so the number is printed rather than assumed. The nearest-neighbour step is
-## what keeps the pixels square through a scale that is not a whole number:
-##
-##   ffmpeg -i clip.avi -vf "trim=start_frame=$TRIM,setpts=PTS-STARTPTS,\
-##     scale=2304:1296:flags=neighbor,scale=1920:1080:flags=lanczos" \
-##     -c:v libx264 -crf 18 -pix_fmt yuv420p -r 60 clip.mp4
-##
-## Keys, all optional:
-##   screen=<world|saves>  which screen the clip is shot on. `world` is the game
-##                  and is the default; `saves` is the launcher's save page,
-##                  where a run's challenge is chosen. The group and map are
-##                  ignored by `saves` and still have to be given.
-##   cell=<x>,<y>   where the player stands when the map opens
-##   facing=<dir>   which way the player faces when it opens: up, down, left,
-##                  right. Untouched by default, which is the map's own answer.
-##   hour=<0-23>    the clock the map is drawn on, which is its palette
-##   view=<mod id>  a mod's renderer instead of the built-in one (`voxel3d`)
-##   size=<W>x<H>   the size the game lays itself out for. The video's own size
-##                  by default, which is the one size that costs nothing: Movie
-##                  Maker fixes the frame at the project's own viewport before a
-##                  line of this script runs, and a layout of any other size is
-##                  scaled into it, which is what makes a launcher page's text
-##                  soft. Give this only to shoot a shape the frame is not, a
-##                  portrait phone being the one that earns it: `--resolution`
-##                  moves the window on the desktop and not the frame.
-##   seconds=<n>    how long the clip runs after the warm-up
-##   seed=<n>       the run seed, which is what a mod's spawn plan is built from
-##   hold=<dir>     a direction held for the whole clip: up, down, left, right
-##   challenge=<c>  the challenge the recording run is played under: vanilla,
-##                  hard or nuzlocke. What `Gen2Rules` gives a real run, so a
-##                  Nuzlocke clip meets the Nuzlocke's own rules.
-##   party=<spec>   the party the clip plays with, `species:level` per member
-##                  separated by commas, six at most. Each may carry `shiny`,
-##                  `hp<n>` for a member standing at that many hit points, and
-##                  `brink` for one a single point of experience short of its
-##                  next level. Six healthy level 40s by default.
-##   items=<spec>   items in the bag, `item:count` separated by commas. A capture
-##                  clip needs its own balls: 5 is a POKE BALL.
-##   progress=<spec>  how far along the run is, `badges:8,caught:120`. What a mod
-##                  reading [Gen2ModProgress] answers about, so a clip of a list
-##                  a run fills in is shot part way through one rather than at
-##                  nothing. `badges` is the first n in source order and `caught`
-##                  the first n species numbers; `pokedex:1` and `pokegear:1` are
-##                  the start menu's own two gates. `spent:1` is a Nuzlocke whose
-##                  area has already given up its one encounter, which is what a
-##                  clip of the refusal starts from.
-##   flags=<n>[,<n>]  event flags the run has already set, by their index in
-##                  `constants/event_flags.asm`. What puts a script on the branch
-##                  a clip wants: 8 is `EVENT_GOT_TM31_MUD_SLAP`, which takes the
-##                  TM speech off the end of the Violet Gym badge.
-##   text=auto      an A press whenever the box is waiting for one, which is a
-##                  player reading. A battle's own text is as long as its text is
-##                  and no frame number can be worked out in advance, so a clip
-##                  that has to reach a menu says this rather than counting.
-##   read=<frames>  how long a finished page is left standing before `text=auto`
-##                  turns it. The default is [constant TEXT_GAP], which is a
-##                  viewer's reading speed rather than a player's.
-##   beat=<frames>  the same between one `at=` or `always=` action and the next,
-##                  which is how long a chosen menu row is seen before it is
-##                  pressed. The default is [constant STATE_GAP].
-##   at=<state>:<action>  one action, performed the first time the screen reaches
-##                  that state: `menu` is the battle's FIGHT/PKMN/PACK/RUN,
-##                  `move` its move list, `pack` the pack it opens, `capture` the
-##                  ball selector, `switch` the party list, `ask` the nickname
-##                  question a catch reaches, `name` the keyboard behind it and
-##                  `map` the overworld with no battle over it. Repeatable, and they are
-##                  spent in the order they are written, a beat apart. What aims
-##                  a press at a menu rather than at a frame.
-##   always=<state>:<action>  the same, but never spent: it answers that state
-##                  every time the screen reaches it, once the `at=` queue has
-##                  nothing waiting for it. `always=menu:a always=move:a` is a
-##                  player fighting with the first move for as many turns as the
-##                  fight lasts, which is not a number a clip can know.
-##   mash=<first>:<every>[:<last>]  an A press every `every` frames from `first`,
-##                  which is a player holding a battle or a script along. Runs to
-##                  the end of the clip unless `last` says otherwise, and adds to
-##                  whatever `do=` already asked for.
-##   do=<frame>:<action>   one scripted action, repeatable
-##
-## World actions are a button name (`a`, `b`, `start`, `select`, `up`, `down`,
-## `left`, `right`), `hold-<dir>` or `hold-none` to change what is held from that
-## frame, `surf` to mount the water the player is facing, `battle` to start a
-## wild fight, `meet` to face the nearest wild a mod has drawn on the map and
-## fight THAT one, `meet-shiny` for the nearest one that is shiny,
-## `wild-<species>-<level>[-shiny]` to start one against a named Pokemon that is
-## on no map, `menu-off` to close whatever is open, `text-off` and `text-on` to
-## stop and restart `text=auto` so the last line of a clip is left up rather
-## than turned, or `view-<mod id>` to switch
-## the renderer on camera, cover and all. Frames are the world's own, counted
-## from the first recorded one.
-##
-## Save-screen actions are `new-slot` to open the new-game form on the first
-## free slot, `slot-<n>` to select one, `name-<text>` to type a save name, and
-## `focus-<label>` and `click-<label>` for one of the page's own buttons, found
-## by the words on it. The focus ring is what a viewer follows, so a click is
-## worth a `focus-` a moment before it.
-##
-## A `probe=` records nothing and answers a question instead, which is how a clip
-## is aimed before it is shot:
-##   probe=map    an ASCII plan of the map: `.` land, `~` water, `#` blocked,
-##                `o` an object standing on it, `@` the player's own cell
-##   probe=walk   runs the clip's own buttons and prints the path the player
-##                actually took, so a walk that hits a wall is seen before it is
-##                recorded rather than after
-##   probe=wilds  the wild population this `seed=` really puts on the map
-##   probe=shiny  asks the installed visible-encounter providers for the plan
-##                every seed would build on this map and prints the ones holding
-##                a shiny, which is how a sparkle clip gets its `seed=`
-##   probe=menu   the start menu's own rows in order, which is how many DOWN
-##                presses a mod's row costs: a mod adds one and the count moves
-##   probe=trace  runs the clip's own buttons and prints the frame every visible
-##                thing changed on: the text on screen, the battle's menu and
-##                whether it is waiting for a press. A clip that has to land a
-##                press on a menu is aimed with this and shot afterwards
-##
-## A `probe=` takes the same arguments as the clip it is aiming, and `cell=` is
-## not optional among them: where the player stands is part of the context a
-## spawn plan is built from, so a seed found from one cell puts its shiny
-## somewhere else from another. `probe=wilds` is the check on that.
 
 ## Only for a run with no window to ask, which is every headless one.
 const DEFAULT_WINDOW := Vector2i(1280, 720)
@@ -241,6 +116,122 @@ var _always: Dictionary = {}
 var _state_ready: int = 0
 
 
+const USAGE: String = """
+Keys, all optional:
+  screen=<world|saves>  which screen the clip is shot on. `world` is the game
+				 and is the default; `saves` is the launcher's save page,
+				 where a run's challenge is chosen. The group and map are
+                 ignored by `saves` and still have to be given.
+  cell=<x>,<y>   where the player stands when the map opens
+  facing=<dir>   which way the player faces when it opens: up, down, left,
+				 right. Untouched by default, which is the map's own answer.
+  hour=<0-23>    the clock the map is drawn on, which is its palette
+  view=<mod id>  a mod's renderer instead of the built-in one (`voxel3d`)
+  size=<W>x<H>   the size the game lays itself out for. The video's own size
+				 by default, which is the one size that costs nothing: Movie
+				 Maker fixes the frame at the project's own viewport before a
+                 line of this script runs, and a layout of any other size is
+				 scaled into it, which is what makes a launcher page's text
+				 soft. Give this only to shoot a shape the frame is not, a
+				 portrait phone being the one that earns it: `--resolution`
+				 moves the window on the desktop and not the frame.
+  seconds=<n>    how long the clip runs after the warm-up
+  seed=<n>       the run seed, which is what a mod's spawn plan is built from
+  hold=<dir>     a direction held for the whole clip: up, down, left, right
+  challenge=<c>  the challenge the recording run is played under: vanilla,
+                 hard or nuzlocke. What `Gen2Rules` gives a real run, so a
+				 Nuzlocke clip meets the Nuzlocke's own rules.
+  party=<spec>   the party the clip plays with, `species:level` per member
+				 separated by commas, six at most. Each may carry `shiny`,
+				 `hp<n>` for a member standing at that many hit points, and
+				 `brink` for one a single point of experience short of its
+				 next level. Six healthy level 40s by default.
+  items=<spec>   items in the bag, `item:count` separated by commas. A capture
+				 clip needs its own balls: 5 is a POKE BALL.
+  progress=<spec>  how far along the run is, `badges:8,caught:120`. What a mod
+				 reading [Gen2ModProgress] answers about, so a clip of a list
+				 a run fills in is shot part way through one rather than at
+				 nothing. `badges` is the first n in source order and `caught`
+				 the first n species numbers; `pokedex:1` and `pokegear:1` are
+				 the start menu's own two gates. `spent:1` is a Nuzlocke whose
+                 area has already given up its one encounter, which is what a
+                 clip of the refusal starts from.
+  flags=<n>[,<n>]  event flags the run has already set, by their index in
+                 `constants/event_flags.asm`. What puts a script on the branch
+                 a clip wants: 8 is `EVENT_GOT_TM31_MUD_SLAP`, which takes the
+                 TM speech off the end of the Violet Gym badge.
+  text=auto      an A press whenever the box is waiting for one, which is a
+				 player reading. A battle's own text is as long as its text is
+				 and no frame number can be worked out in advance, so a clip
+				 that has to reach a menu says this rather than counting.
+  read=<frames>  how long a finished page is left standing before `text=auto`
+				 turns it. The default is [constant TEXT_GAP], which is a
+				 viewer's reading speed rather than a player's.
+  beat=<frames>  the same between one `at=` or `always=` action and the next,
+				 which is how long a chosen menu row is seen before it is
+				 pressed. The default is [constant STATE_GAP].
+  at=<state>:<action>  one action, performed the first time the screen reaches
+				 that state: `menu` is the battle's FIGHT/PKMN/PACK/RUN,
+                 `move` its move list, `pack` the pack it opens, `capture` the
+                 ball selector, `switch` the party list, `ask` the nickname
+                 question a catch reaches, `name` the keyboard behind it and
+                 `map` the overworld with no battle over it. Repeatable, and they are
+                 spent in the order they are written, a beat apart. What aims
+                 a press at a menu rather than at a frame.
+  always=<state>:<action>  the same, but never spent: it answers that state
+                 every time the screen reaches it, once the `at=` queue has
+                 nothing waiting for it. `always=menu:a always=move:a` is a
+                 player fighting with the first move for as many turns as the
+                 fight lasts, which is not a number a clip can know.
+  mash=<first>:<every>[:<last>]  an A press every `every` frames from `first`,
+                 which is a player holding a battle or a script along. Runs to
+                 the end of the clip unless `last` says otherwise, and adds to
+                 whatever `do=` already asked for.
+  do=<frame>:<action>   one scripted action, repeatable
+
+World actions are a button name (`a`, `b`, `start`, `select`, `up`, `down`,
+`left`, `right`), `hold-<dir>` or `hold-none` to change what is held from that
+frame, `surf` to mount the water the player is facing, `battle` to start a
+wild fight, `meet` to face the nearest wild a mod has drawn on the map and
+fight THAT one, `meet-shiny` for the nearest one that is shiny,
+`wild-<species>-<level>[-shiny]` to start one against a named Pokemon that is
+on no map, `menu-off` to close whatever is open, `text-off` and `text-on` to
+stop and restart `text=auto` so the last line of a clip is left up rather
+than turned, or `view-<mod id>` to switch
+the renderer on camera, cover and all. Frames are the world's own, counted
+from the first recorded one.
+
+Save-screen actions are `new-slot` to open the new-game form on the first
+free slot, `slot-<n>` to select one, `name-<text>` to type a save name, and
+`focus-<label>` and `click-<label>` for one of the page's own buttons, found
+by the words on it. The focus ring is what a viewer follows, so a click is
+worth a `focus-` a moment before it.
+
+A `probe=` records nothing and answers a question instead, which is how a clip
+is aimed before it is shot:
+  probe=map    an ASCII plan of the map: `.` land, `~` water, `#` blocked,
+			   `o` an object standing on it, `@` the player's own cell
+  probe=walk   runs the clip's own buttons and prints the path the player
+               actually took, so a walk that hits a wall is seen before it is
+               recorded rather than after
+  probe=wilds  the wild population this `seed=` really puts on the map
+  probe=shiny  asks the installed visible-encounter providers for the plan
+               every seed would build on this map and prints the ones holding
+               a shiny, which is how a sparkle clip gets its `seed=`
+  probe=menu   the start menu's own rows in order, which is how many DOWN
+			   presses a mod's row costs: a mod adds one and the count moves
+  probe=trace  runs the clip's own buttons and prints the frame every visible
+			   thing changed on: the text on screen, the battle's menu and
+               whether it is waiting for a press. A clip that has to land a
+               press on a menu is aimed with this and shot afterwards
+
+A `probe=` takes the same arguments as the clip it is aiming, and `cell=` is
+not optional among them: where the player stands is part of the context a
+spawn plan is built from, so a seed found from one cell puts its shiny
+somewhere else from another. `probe=wilds` is the check on that.
+"""
+
+
 func _initialize() -> void:
 	## Movie Maker's frame is the PROJECT's viewport rather than the window, so
 	## `--resolution` moves what is on the desktop and not what is written.
@@ -256,6 +247,7 @@ func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 3:
 		push_error("Usage: record_clip.gd -- <game> <group> <map> [key=value ...]")
+		print(USAGE)
 		_quit_failed()
 		return
 
@@ -402,14 +394,12 @@ func _parse_items(spec: String) -> Dictionary:
 
 
 ## Whether the mods are still loading, which the screen has to be built after.
-##
 ## `GameRuntime` loads them from its own `_ready`, and that has not run while
-## `_initialize` runs nor on the first frame after it. A screen built before it
-## has no follower walking behind the player and no wild Pokemon on the map, and
-## which of those a clip caught was a race. Waited out rather than loaded again
-## here: a second `load_mods` registers every mod twice, and `reload_mods` runs
-## the save lifecycle, which is what puts a development run's randomizer over a
-## clip that never asked for one.
+## `_initialize` runs nor on the first frame after it, so a screen built before it
+## has no follower and no wild Pokemon on the map. Waited out rather than loaded
+## again here: a second `load_mods` registers every mod twice, and `reload_mods`
+## runs the save lifecycle, which puts a development run's randomizer over a clip
+## that never asked for one.
 func _waiting_for_mods() -> bool:
 	if _frames > MOD_LOAD_FRAMES or not Gen2GameRuntime.mods_are_allowed():
 		return false

--- a/tools/render_audio.gd
+++ b/tools/render_audio.gd
@@ -1,18 +1,13 @@
 extends SceneTree
 
 ## Renders one imported audio record through the sound engine and the APU, and
-## writes a WAV plus the per-frame hardware-register trace beside it.
+## writes a WAV plus the per-frame hardware-register trace beside it. The trace is
+## the parity artefact: any faithful implementation of the same driver writes the
+## same registers in the same order on the same frames. Kinds are `music`, `sfx`,
+## `cry` and `mon_cry`; the id is the record index, the species for `mon_cry`, or
+## `all` to sweep the table into `<prefix>_<index>`.
 ##
-## The trace is the parity artefact: any faithful implementation of the same
-## driver has to write the same registers in the same order on the same frames.
-##
-## ```sh
-## G=/Applications/Godot.app/Contents/MacOS/Godot
-## $G --headless --path . -s res://tools/render_audio.gd -- crystal music 1 600 /tmp/out
-## ```
-## Kinds are `music`, `sfx`, `cry` and `mon_cry`; the id is the record index, or
-## the species number for `mon_cry`, or `all` to sweep the whole table into
-## `<prefix>_<index>`.
+##   ... -s res://tools/render_audio.gd -- crystal music 1 600 /tmp/out
 
 
 func _initialize() -> void:

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -1,35 +1,13 @@
 extends SceneTree
 
 ## Records `(frame, button)` from a run of the real world screen and replays it
-## into a fresh world, then diffs the two worlds.
-##
-##   Godot --headless --path . -s res://tools/replay_world.gd -- [game ...] [frames]
-##
-## A seed, an input log and a frame number should reproduce a world exactly.
-## That is what `Gen2WorldScreen.advance_frame()` is for, and this is the
-## artefact it is proved by: the compared value is `Gen2WorldSnapshot` JSON plus
-## the play timer, which either matches byte for byte or does not.
-##
-## Four runs per route, all from the same seed and the same log:
-##
-## | Run | Driven by | Proves |
-## |---|---|---|
-## | record | `advance_frames`, a generated input program | the log the world consumed |
-## | replay | `advance_frames`, the recorded log | a log alone reproduces the run |
-## | 30 fps | `_process(1/30)`, the recorded log | the pump, not the host, spends frames |
-## | 144 fps | `_process(1/144)` , the recorded log | the same, from the other side |
-##
-## The corpus is twenty-seven generated walks over the spawn group, one scripted
-## errand and one wild battle. The battle route is the seam this tool exists to
-## close: a fight is spent from the world's own pump and its buttons arrive
-## through the world's own funnel, so the encounter, the enemy's own choices and
-## the party that comes out are all functions of the run's seed and its log.
-##
-## The two `_process` runs top up the last frame or two with `advance_frame()`,
-## because a host slower than the hardware cannot land on every frame; the run is
-## otherwise entirely theirs. They also feed `Gen2WorldClock` real seconds, which
-## is deliberate (`Gen2WorldScreen._advance_day_cycle`), so a route stays under a
-## cartridge minute and the day cycle cannot move under one run and not another.
+## into a fresh world, then diffs the two. A seed, an input log and a frame number
+## should reproduce a world exactly, and the compared value is
+## [Gen2WorldSnapshot] JSON plus the play timer, which either matches byte for byte
+## or does not. Four runs per route from the same seed and log: record, replay, and
+## the same log driven by `_process` at 30 and 144 fps, which is what says the pump
+## rather than the host spends frames. The corpus is twenty-seven generated walks,
+## one scripted errand and one wild battle, the battle being the seam this closes.
 
 const GAMES: Array[StringName] = [&"gold", &"silver", &"crystal"]
 ## Twenty seconds of hardware frames: long enough for several walks, a script
@@ -469,12 +447,10 @@ func _walk_frames() -> int:
 ## The scripted errand: walk the door column up to the counter, turn into the
 ## clerk, and then press A on a cadence for the rest of the run. That one button
 ## carries the whole leg, because every step of it answers a press: the clerk's
-## `pokemart` dialog, the mart overlay's own A, and the boxes on either side.
-##
-## Held rather than counted out step by step: `move_player` refuses while a step
-## is in flight, so a direction held to the counter arrives on the cell whatever
-## the walk rate is, and the turn into the counter is a press the wall refuses to
-## move on.
+## `pokemart` dialog, the mart overlay's own A, and the boxes on either side. Held
+## rather than counted out step by step: `move_player` refuses while a step is in
+## flight, so a direction held to the counter arrives on the cell whatever the walk
+## rate is.
 func _errand_program(frames: int) -> Array:
 	var log_lines: Array = []
 	var walk: int = mini(frames, (MART_DOOR.y - MART_COUNTER.y) * _walk_frames())

--- a/tools/screenshot.gd
+++ b/tools/screenshot.gd
@@ -6,10 +6,8 @@ extends SceneTree
 ##   Godot --path . -s res://tools/screenshot.gd -- <scene> <output.png> [frames] [method] [times]
 ##
 ## The optional method/times pair calls a no-argument method on the scene root
-## before capturing, which is how a screen is photographed mid-interaction.
-##
-## This opens a real window for a moment: rendering needs a display, so it cannot
-## run under --headless.
+## before capturing, which is how a screen is photographed mid-interaction. Opens a
+## real window for a moment: rendering needs a display.
 
 const DEFAULT_FRAMES: int = 12
 const WINDOW_SIZE := Vector2i(1152, 648)

--- a/tools/trace_battle_commands.gd
+++ b/tools/trace_battle_commands.gd
@@ -1,20 +1,11 @@
 extends SceneTree
 
 ## Every effect command one turn of a battle runs here, in the same shape
-## `.claude/oracle/battle/trace_move_commands.py` prints off a real cartridge.
-##
-##   Godot --headless --path . -s res://tools/trace_battle_commands.gd -- \
-##       <game> <out.txt> <player_move> <enemy_move>
-##
-## It fights until one side is down, so the artefact is a whole wild battle
-## rather than one turn.
-##
-## `DoMove`'s read cycle is [method Gen2Battle.run_move_effect] and its artefact
-## is [member Gen2Battle.command_trace], so the two files diff line for line and
-## a step in the wrong place is the first difference rather than a wrong number
-## on a screenshot. The opcode is the pin's own
-## `macros/scripts/battle_commands.asm` index, which this side does not carry, so
-## it is printed as `--` and the name is what a diff reads.
+## `.claude/oracle/battle/trace_move_commands.py` prints off a real cartridge. It
+## fights until one side is down, so the artefact is a whole wild battle rather than
+## one turn. The two files diff line for line, so a step in the wrong place is the
+## first difference; the opcode is printed as `--`, since this side carries no
+## index. Arguments: `<game> <out.txt> <player_move> <enemy_move>`.
 
 ## The matchup `.claude/oracle/battle/states/in_wild` stands in: a level five
 ## Cyndaquil against the level two Rattata that state walked into. The DVs and

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -1,38 +1,12 @@
 extends SceneTree
 
 ## Dumps the opening's shadow OAM, one line per sprite per frame, against a real
-## cache.
-##
-##   Godot --headless --path . -s res://tools/trace_opening_oam.gd -- <game> <phase> [out.txt]
-##
-## `phase` is `presents`, `intro` (Crystal's movie), `gs_intro` (Gold and
-## Silver's) or `title`. The artefact is the one `.claude/verification.md`
-## step 2 asks for: two faithful implementations of `PlaySpriteAnimations` put
-## the same sprites in the same slots on the same frames, so a `diff` against a
-## cartridge running under an emulator settles the port rather than a frame count
-## measured from the port itself. `tools/render_audio.gd` is the same shape for
-## the driver's register writes.
-##
-## A line is `frame slot y x tile`, with `y` and `x` the OAM bytes: a cartridge's
-## own buffer is read at the frame boundary, where hDMATransfer copies it.
-##
-## Either movie also writes `<out>.state`, one `frame scene counter` line per
-## frame. Gold and Silver append their second scene counter, since their scroll
-## scenes advance that one while the first stays fixed. These are the cartridge
-## state that aligns a pixel diff: a setup
-## scene's decompression overruns VBlank by three to twelve frames there and by
-## none here, so a per-scene offset is still several frames out inside the scene
-## and every frame of a fade compares against the wrong step of it. A frame
-## spending the setup's own delay is written under the setup scene's index,
-## which is where the source spends it.
-##
-## A fourth argument writes the page's own picture for those frames, named after
-## each, so the frame a diff points at can be looked at beside the emulator's.
-## It is a comma list, and an entry may be a `lo-hi` range, which is what a
-## per-frame pixel diff over a whole scene wants rather than a hand-listed set.
-## The page draws into an `Image`, so this stays headless;
-## `tools/preview_intro.gd` photographs the same screen through the boot
-## cinema, whose frames count from the copyright rather than from this phase.
+## cache. `phase` is `presents`, `intro`, `gs_intro` or `title`, and the artefact is
+## the one `.claude/verification.md` step 2 asks for: two faithful implementations
+## of `PlaySpriteAnimations` put the same sprites in the same slots on the same
+## frames. A line is `frame slot y x tile`, the OAM bytes as a cartridge's own
+## buffer holds them at the frame boundary. Arguments:
+## `<game> <phase> [out.txt] [frames]`.
 
 const PHASES: Array[String] = ["presents", "intro", "gs_intro", "title"]
 

--- a/tools/trace_world_script.gd
+++ b/tools/trace_world_script.gd
@@ -1,23 +1,13 @@
 extends SceneTree
 
-## Every script command a walked conversation runs on the real world screen, in
-## the order it ran and with the `bank:address` the cartridge would hold in
-## wScriptBank:wScriptPos for it.
-##
-##   Godot --headless --path . -s res://tools/trace_world_script.gd -- \
-##       <game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>
-##
-## The port half of `.claude/oracle/overworld/trace_script.py`, which prints the
-## same artefact off a real cartridge. The line is `frame bank:addr opcode name`,
-## so the two command orders diff directly and a branch taken on the wrong side
-## of a flag shows up as the first differing address rather than as a wrong box
-## on a screenshot.
-##
-## The walk list is the steps taken before A is pressed, so a run reaches the
-## object it is about to talk to. A count of zero is a turn on the spot, which
-## is what a press into the object being talked to does. A is then pressed every
-## fourteenth frame, the cadence the cartridge trace mashes at, until the one
-## conversation it started has ended.
+## Every script command a walked conversation runs on the real world screen, in the
+## order it ran and with the `bank:address` the cartridge would hold for it. The
+## port half of `.claude/oracle/overworld/trace_script.py`: the line is
+## `frame bank:addr opcode name`, so a branch taken on the wrong side of a flag
+## shows up as the first differing address. The walk list is the steps taken before
+## A is pressed, a count of zero being a turn on the spot; A is then pressed every
+## fourteenth frame, the cadence the cartridge trace mashes at. Arguments:
+## `<game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>`.
 
 ## The cartridge trace's own pace: slow enough that a box waiting for a press is
 ## not pressed twice.

--- a/tools/trace_world_tiles.gd
+++ b/tools/trace_world_tiles.gd
@@ -1,16 +1,12 @@
 extends SceneTree
 
-## Every hardware frame of a map's tileset animation: which of the tileset's
-## tiles `_AnimateTileset` rewrote, where the command list stands, and what the
-## two palette commands are holding.
-##
-##   Godot --headless --path . -s res://tools/trace_world_tiles.gd -- \
-##       <game> <group> <map> <frames> <out.txt> [time_of_day]
-##
-## The port half of `.claude/oracle/overworld/trace_tiles.py`, which prints the
-## same artefact off a real cartridge by reading vTiles2 once a frame. The line
-## is `frame anim_frame timer water cave tiles`, and `anim_frame` is read after
+## Every hardware frame of a map's tileset animation: which of the tileset's tiles
+## `_AnimateTileset` rewrote, where the command list stands, and what the two
+## palette commands are holding. The port half of
+## `.claude/oracle/overworld/trace_tiles.py`, which reads vTiles2 once a frame. The
+## line is `frame anim_frame timer water cave tiles`, and `anim_frame` is read after
 ## the frame is spent, which is where `hTileAnimFrame` stands on that side.
+## Arguments: `<game> <group> <map> <frames> <out.txt> [time_of_day]`.
 
 func _initialize() -> void:
 	_run.call_deferred()

--- a/tools/trace_world_walk.gd
+++ b/tools/trace_world_walk.gd
@@ -1,25 +1,13 @@
 extends SceneTree
 
 ## Every hardware frame of a walk on the real world screen: where the map is
-## scrolled to, where the player is drawn, and which of `Facings` is up.
-##
-##   Godot --headless --path . -s res://tools/trace_world_walk.gd -- \
-##       <game> <group> <map> <x> <y> <direction> <frames> <out.txt>
-##
-## The port half of `.claude/oracle/overworld/trace_walk.py`, which prints the
-## same artefact off a real cartridge. The line is
-## `frame cam_x cam_y x y screen_x screen_y facing walk_frame`, where `cam_x`
-## and `cam_y` are hSCX/hSCY in map pixels rather than modulo the BG map and
-## `screen_x`/`screen_y` are the player's own drawn pixel.
-##
-## Diff `screen_x` against the cartridge's OAM slot 0 minus rSCX, not against its
-## `wPlayerSpriteX - hSCX`: `HandleMapObjects` writes the object field before
-## `NextOverworldFrame` spends its two frames and `_UpdateSprites` does not copy
-## it into shadow OAM until after them, so that pair reads two pixels of lead the
-## screen never shows.
-##
-## Ten standing frames come first, the way the cartridge trace opens, so a diff
-## aligns on the frame the direction starts being held rather than on the file.
+## scrolled to, where the player is drawn, and which of `Facings` is up. The port
+## half of `.claude/oracle/overworld/trace_walk.py`. Diff `screen_x` against the
+## cartridge's OAM slot 0 minus rSCX, not against its `wPlayerSpriteX - hSCX`:
+## `HandleMapObjects` writes the object field before `NextOverworldFrame` spends its
+## two frames, so that pair reads two pixels of lead the screen never shows. Ten
+## standing frames come first. Arguments:
+## `<game> <group> <map> <x> <y> <direction> <frames> <out.txt>`.
 
 const STANDING_FRAMES: int = 10
 

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -2,15 +2,11 @@ extends SceneTree
 
 ## The real-cache check suite. Every topic runs all three cartridges against a
 ## freshly imported cache; expected values come from the pinned pokecrystal and
-## pokegold sources and are named in each topic's own file.
+## pokegold sources and are named in each topic's own file. A topic is a script
+## under `tools/checks/` with `func run(r) -> void`, found by its file name; add one
+## there rather than writing another entry point.
 ##
-##   Godot --headless --path . -s res://tools/validate.gd -- all
-##   Godot --headless --path . -s res://tools/validate.gd -- cut surf
-##   Godot --headless --path . -s res://tools/validate.gd -- field_moves
-##
-## A topic is a script under `tools/checks/` with `func run(r) -> void`, found by
-## its file name. Add one there rather than writing another entry point; nothing
-## here needs editing for it to be picked up.
+##   Godot --headless --path . -s res://tools/validate.gd -- all cut surf
 
 const CheckRun := preload("res://tools/lib/check_run.gd")
 const CHECKS: String = "res://tools/checks"


### PR DESCRIPTION
Every dispatch chain that had grown past reading is a lookup table now, and no comment block in the tree is longer than eight lines. What holds both down from here is `tests/unit/test_source_budget.gd`, which fails the suite on any of three counts: a function over cyclomatic complexity 20, a comment block over eight lines, or more comment lines under `game/`, `tools/` and `autoload/` than the number it records. Complexity is counted the way a linter counts it, one per `if`, `elif`, `while`, `for`, `and`, `or`, inline `if` and `match` arm.

## What moved

| | Before | After |
|---|---|---|
| Comment lines under `game/`, `tools/`, `autoload/` | 41,951 | 37,924 |
| Comment blocks longer than eight lines | 676 | 0 |
| Functions over cyclomatic complexity 20 | 94 | 89 |
| Lines | | 3,880 fewer |

Nothing was dropped for being long. Every source symbol, measured number and derivation is still here, said once rather than three ways; `rom_layout.gd` keeps its derivations and is held to the same cap as everything else.

## The sixteen functions

Cyclomatic complexity before and after:

| Function | Before | After |
|---|---|---|
| `world_state.apply_changes` | 139 | 7 |
| `effect_commands.run` | 130 | 11 |
| `world_script_runner.advance` | 123 | 16 |
| `world_screen._show_script_results` | 104 | 7 |
| `world_script.command_name` | 101 | 4 |
| `rom_importer.verify_layout` | 77 | 4 |
| `world_api._apply_script_object_events` | 73 | 13 |
| `world_screen.advance_frame` | 72 | 4 |
| `battle_anim_bg_effects.run` | 58 | 14 |
| `battle_screen._continue_after_messages` | 58 | 17 |
| `world_script.command_width` | 42 | 6 |
| `game_data.open_directory` | 41 | 6 |
| `world_state._init` | 32 | 7 |
| `world_state.from_dict` | 32 | 5 |
| `save_validator._validate_mon` | 29 | 14 |
| `save_validator._validate_world` | 27 | 17 |

The shapes are the same five every time. A run of `if x == A ... elif x == B` becomes a name-to-method table; a run of near-identical field validations becomes one row per field; a long sequence becomes named phases; a `match` that only names things becomes a `Dictionary`; and a condition worth a sentence becomes a predicate with that sentence on it. No behaviour moved: the same reasons come back in the same order and the same events are emitted on the same frames.

Two development tools documented themselves in comments nobody could run. `tools/preview_world.gd`'s forty kinds and `tools/record_clip.gd`'s thirty keys are data now, printed by `live help` and by running the clip recorder with no arguments.

`docs/CONTRIBUTING.md` carries the budget and the comment rule beside it: write none you do not have to, and a comment explaining a workaround is a bug report rather than a comment.

## What is left

Eighty-nine functions are still over the complexity ceiling. They are named in the test, and that list may only shrink: it also fails on a line that no longer names a function over the ceiling, so a fix deletes its line and the list cannot rot.

## Proof

| Check | Result |
|---|---|
| `gut_cmdln.gd -gdir=res://tests -ginclude_subdirs` | 3,999 tests, 3,999 pass |
| `tools/validate.gd -- all` | every topic passes on all three cartridges |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| `tools/preview_world_story.gd ... home story` | crystal, gold and silver all walk |
| `--quit-after 30` boot | clean |
| `--warning-scan` | 0 warnings in 598 analysed scripts |
