### PR TITLE
Turn eleven dispatch matches into lookup tables

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -581,228 +581,226 @@ static func _apply_offensive(scores: Array, c: Context) -> void:
 			_discourage(scores, slot, 2)
 
 
+## `AI_Smart`'s own jumptable: the move effect and what scores it. An effect the
+## table does not name is one the routine leaves alone.
+static var SMART_HANDLERS: Dictionary = {
+	Gen2MoveEffect.MIRROR_MOVE: _smart_mirror_move,
+	Gen2MoveEffect.MIMIC: _smart_mimic,
+	Gen2MoveEffect.CONVERSION_2: _smart_conversion_2,
+	Gen2MoveEffect.SLEEP: _smart_sleep,
+	Gen2MoveEffect.HAZE: _smart_reset_stats,
+	Gen2MoveEffect.TOXIC: _smart_toxic,
+	Gen2MoveEffect.CONFUSE: _smart_confuse,
+	Gen2MoveEffect.PARALYZE: _smart_paralyze,
+	Gen2MoveEffect.RECHARGE_HIT: _smart_hyper_beam,
+	Gen2MoveEffect.SKULL_BASH: _smart_skull_bash,
+	Gen2MoveEffect.REVERSAL: _smart_skull_bash,
+	Gen2MoveEffect.DESTINY_BOND: _smart_skull_bash,
+	Gen2MoveEffect.FORCE_SWITCH: _smart_force_switch,
+	Gen2MoveEffect.BATON_PASS: _smart_force_switch,
+	Gen2MoveEffect.PROTECT: _smart_protect,
+	Gen2MoveEffect.ENDURE: _smart_endure,
+	Gen2MoveEffect.BELLY_DRUM: _smart_belly_drum,
+	Gen2MoveEffect.PSYCH_UP: _smart_psych_up,
+	Gen2MoveEffect.SOLARBEAM: _smart_solarbeam,
+	Gen2MoveEffect.THUNDER: _smart_thunder,
+	Gen2MoveEffect.SANDSTORM: _smart_sandstorm,
+	Gen2MoveEffect.RAIN_DANCE: _smart_weather_move.bind(
+		RomLayout.TYPE_WATER, RomLayout.TYPE_FIRE, RAIN_DANCE_MOVE_NUMBERS
+	),
+	Gen2MoveEffect.SUNNY_DAY: _smart_weather_move.bind(
+		RomLayout.TYPE_FIRE, RomLayout.TYPE_WATER, SUNNY_DAY_MOVE_NUMBERS
+	),
+	Gen2MoveEffect.TRAP_TARGET: _smart_trap_target,
+	Gen2MoveEffect.HEAL: _smart_heal,
+	Gen2MoveEffect.MORNING_SUN: _smart_heal,
+	Gen2MoveEffect.SYNTHESIS: _smart_heal,
+	Gen2MoveEffect.MOONLIGHT: _smart_heal,
+	Gen2MoveEffect.PERISH_SONG: _smart_perish_song,
+	Gen2MoveEffect.PAIN_SPLIT: _smart_pain_split,
+	Gen2MoveEffect.LOCK_ON: _smart_lock_on,
+	Gen2MoveEffect.SPITE: _smart_spite,
+	Gen2MoveEffect.THIEF: _smart_thief,
+	Gen2MoveEffect.FORESIGHT: _smart_foresight,
+	Gen2MoveEffect.MEAN_LOOK: _smart_mean_look,
+	Gen2MoveEffect.PURSUIT: _smart_pursuit,
+	## `AI_Smart_Snore` is an empty label in front of `AI_Smart_SleepTalk`.
+	Gen2MoveEffect.SLEEP_TALK: _smart_sleep_talk,
+	Gen2MoveEffect.SNORE: _smart_sleep_talk,
+	Gen2MoveEffect.LEECH_HIT: _smart_leech_hit,
+	Gen2MoveEffect.SELFDESTRUCT: _smart_selfdestruct,
+	Gen2MoveEffect.DREAM_EATER: _smart_dream_eater,
+	Gen2MoveEffect.EVASION_UP: _smart_evasion_up,
+	Gen2MoveEffect.ACCURACY_DOWN: _smart_accuracy_down,
+	Gen2MoveEffect.ALWAYS_HIT: _smart_always_hit,
+	Gen2MoveEffect.BIDE: _smart_bide,
+	Gen2MoveEffect.LIGHT_SCREEN: _smart_light_screen,
+	Gen2MoveEffect.REFLECT: _smart_light_screen,
+	Gen2MoveEffect.OHKO: _smart_ohko,
+	Gen2MoveEffect.LEECH_SEED: _smart_leech_seed,
+	Gen2MoveEffect.SUPER_FANG: _smart_super_fang,
+	## `AI_Smart_RazorWind` is an empty label in front of `AI_Smart_Unused2B`.
+	Gen2MoveEffect.RAZOR_WIND: _smart_unused_2b,
+	Gen2MoveEffect.UNUSED_2B: _smart_unused_2b,
+	Gen2MoveEffect.SP_DEF_UP_2: _smart_sp_defense_up_2,
+	Gen2MoveEffect.SPEED_DOWN_HIT: _smart_speed_down_hit,
+	Gen2MoveEffect.SUBSTITUTE: _smart_substitute,
+	Gen2MoveEffect.RAGE: _smart_rage,
+	Gen2MoveEffect.DISABLE: _smart_disable,
+	Gen2MoveEffect.COUNTER: _smart_counter.bind(true),
+	Gen2MoveEffect.MIRROR_COAT: _smart_counter.bind(false),
+	Gen2MoveEffect.ENCORE: _smart_encore,
+	Gen2MoveEffect.DEFROST_OPPONENT: _smart_defrost_opponent,
+	Gen2MoveEffect.HEAL_BELL: _smart_heal_bell,
+	Gen2MoveEffect.PRIORITY_HIT: _smart_priority_hit,
+	Gen2MoveEffect.NIGHTMARE: _smart_nightmare,
+	Gen2MoveEffect.FLAME_WHEEL: _smart_flame_wheel,
+	Gen2MoveEffect.CURSE: _smart_curse,
+	Gen2MoveEffect.ROLLOUT: _smart_rollout,
+	Gen2MoveEffect.FURY_CUTTER: _smart_fury_cutter,
+	## `AI_Smart_Swagger` is an empty label in front of `AI_Smart_Attract`.
+	Gen2MoveEffect.SWAGGER: _smart_attract,
+	Gen2MoveEffect.ATTRACT: _smart_attract,
+	Gen2MoveEffect.SAFEGUARD: _smart_safeguard,
+	## `AI_Smart_Magnitude` is an empty label in front of `AI_Smart_Earthquake`, and
+	## `AI_Smart_Twister` in front of `AI_Smart_Gust`: each pair guesses at the move the
+	## other half of it punishes.
+	Gen2MoveEffect.MAGNITUDE: _smart_ground_or_air.bind(Gen2MoveEffect.DIG_MOVE, Gen2Substatus.UNDERGROUND),
+	Gen2MoveEffect.EARTHQUAKE: _smart_ground_or_air.bind(Gen2MoveEffect.DIG_MOVE, Gen2Substatus.UNDERGROUND),
+	Gen2MoveEffect.TWISTER: _smart_ground_or_air.bind(Gen2MoveEffect.FLY_MOVE, Gen2Substatus.FLYING),
+	Gen2MoveEffect.GUST: _smart_ground_or_air.bind(Gen2MoveEffect.FLY_MOVE, Gen2Substatus.FLYING),
+	Gen2MoveEffect.RAPID_SPIN: _smart_rapid_spin,
+	Gen2MoveEffect.HIDDEN_POWER: _smart_hidden_power,
+	Gen2MoveEffect.FUTURE_SIGHT: _smart_future_sight,
+	Gen2MoveEffect.STOMP: _smart_stomp,
+	Gen2MoveEffect.FLY_OR_DIG: _smart_fly_or_dig,
+}
+
+
 ## [constant RomLayout.AI_SMART]: context-specific scoring, per move effect.
-## See the constant above this function for which effects have a handler.
+## [constant SMART_HANDLERS] is which effects have a handler.
 static func _apply_smart(scores: Array, c: Context) -> void:
-	var attacker: Gen2BattleMon = c.attacker
-	var defender: Gen2BattleMon = c.defender
-	var data: GameData = c.data
-	var rng: RandomNumberGenerator = c.rng
-	var atk_turns: int = c.atk_turns
-	var def_turns: int = c.def_turns
-	var weather: int = c.weather
-	var has_bench: bool = c.has_bench
-	var matchup_score: int = c.matchup_score
 	for slot: int in Gen2BattleMon.MAX_MOVES:
-		if not attacker.can_use(slot):
+		if not c.attacker.can_use(slot):
 			continue
-		match _effect(_move_at(attacker, data, slot)):
-			Gen2MoveEffect.MIRROR_MOVE:
-				_smart_mirror_move(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.MIMIC:
-				_smart_mimic(scores, slot, attacker, defender, data, rng)
-			Gen2MoveEffect.CONVERSION_2:
-				_smart_conversion_2(scores, slot, defender, rng)
-			Gen2MoveEffect.SLEEP:
-				if not _skip_50_50(rng):
-					_encourage(scores, slot, 2)
-			Gen2MoveEffect.HAZE: # AI_Smart_ResetStats
-				_smart_reset_stats(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.TOXIC:
-				if not _above_half(defender):
-					_discourage(scores, slot, 1)
-			Gen2MoveEffect.CONFUSE:
-				_smart_confuse(scores, slot, defender, rng)
-			Gen2MoveEffect.PARALYZE:
-				_smart_paralyze(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.RECHARGE_HIT: # Hyper Beam
-				_smart_hyper_beam(scores, slot, attacker, rng)
-			# `AI_Smart_DestinyBond`, `AI_Smart_Reversal` and `AI_Smart_SkullBash`
-			# are one label and one body in the source, so they are one arm here.
-			Gen2MoveEffect.SKULL_BASH, Gen2MoveEffect.REVERSAL, \
-			Gen2MoveEffect.DESTINY_BOND:
-				if _above_quarter(attacker):
-					_discourage(scores, slot, 1)
-			# `AI_Smart_ForceSwitch`: discourage blowing the player away unless
-			# `CheckPlayerMoveTypeMatchups` says the pairing is going badly, which
-			# is the same score `AI_Smart_PerishSong` reads.
-			# `AI_Smart_BatonPass` is the same body under a second label, so the
-			# two share an arm the way Destiny Bond shares Skull Bash's.
-			Gen2MoveEffect.FORCE_SWITCH, Gen2MoveEffect.BATON_PASS:
-				if matchup_score >= Gen2AISwitch.BASE_SCORE:
-					_discourage(scores, slot, 1)
-			Gen2MoveEffect.PROTECT:
-				_smart_protect(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.ENDURE:
-				_smart_endure(scores, slot, attacker, data, rng)
-			Gen2MoveEffect.BELLY_DRUM:
-				_smart_belly_drum(scores, slot, attacker)
-			Gen2MoveEffect.PSYCH_UP:
-				_smart_psych_up(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.SOLARBEAM:
-				_smart_solarbeam(scores, slot, weather, rng)
-			Gen2MoveEffect.THUNDER:
-				_smart_thunder(scores, slot, weather, rng)
-			Gen2MoveEffect.SANDSTORM:
-				_smart_sandstorm(scores, slot, defender, rng)
-			Gen2MoveEffect.RAIN_DANCE:
-				_smart_weather_move(
-					scores, slot, attacker, defender, rng, atk_turns, def_turns,
-					RomLayout.TYPE_WATER, RomLayout.TYPE_FIRE, RAIN_DANCE_MOVE_NUMBERS
-				)
-			Gen2MoveEffect.SUNNY_DAY:
-				_smart_weather_move(
-					scores, slot, attacker, defender, rng, atk_turns, def_turns,
-					RomLayout.TYPE_FIRE, RomLayout.TYPE_WATER, SUNNY_DAY_MOVE_NUMBERS
-				)
-			Gen2MoveEffect.TRAP_TARGET:
-				_smart_trap_target(scores, slot, attacker, defender, def_turns, rng)
-			Gen2MoveEffect.HEAL, Gen2MoveEffect.MORNING_SUN, Gen2MoveEffect.SYNTHESIS, \
-			Gen2MoveEffect.MOONLIGHT:
-				_smart_heal(scores, slot, attacker, rng)
-			Gen2MoveEffect.PERISH_SONG:
-				_smart_perish_song(scores, slot, defender, rng, has_bench, matchup_score)
-			Gen2MoveEffect.PAIN_SPLIT:
-				_smart_pain_split(scores, slot, attacker, defender)
-			Gen2MoveEffect.LOCK_ON:
-				_smart_lock_on(scores, slot, attacker, defender, data, rng)
-			Gen2MoveEffect.SPITE:
-				_smart_spite(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.THIEF:
-				_discourage(scores, slot, THIEF_PENALTY)
-			Gen2MoveEffect.FORESIGHT:
-				_smart_foresight(scores, slot, attacker, defender, rng)
-			Gen2MoveEffect.MEAN_LOOK:
-				_smart_mean_look(scores, slot, attacker, defender, rng, has_bench, matchup_score)
-			Gen2MoveEffect.PURSUIT:
-				_smart_pursuit(scores, slot, defender, rng)
-			# `AI_Smart_Snore` is an empty label in front of
-			# `AI_Smart_SleepTalk`.
-			Gen2MoveEffect.SLEEP_TALK, Gen2MoveEffect.SNORE:
-				_smart_sleep_talk(scores, slot, attacker)
-			Gen2MoveEffect.LEECH_HIT:
-				_smart_leech_hit(scores, slot, c)
-			Gen2MoveEffect.SELFDESTRUCT:
-				_smart_selfdestruct(scores, slot, c)
-			Gen2MoveEffect.DREAM_EATER:
-				if not _roll(rng, 10):
-					_encourage(scores, slot, 3)
-			Gen2MoveEffect.EVASION_UP:
-				_smart_evasion_up(scores, slot, c)
-			Gen2MoveEffect.ACCURACY_DOWN:
-				_smart_accuracy_down(scores, slot, c)
-			Gen2MoveEffect.ALWAYS_HIT:
-				_smart_always_hit(scores, slot, c)
-			Gen2MoveEffect.BIDE:
-				# `AICheckEnemyMaxHP` and a 10% pass, which is the whole routine.
-				if not _at_max_hp(attacker) and not _roll(rng, 10):
-					_discourage(scores, slot, 1)
-			# `AI_Smart_LightScreen` is an empty label in front of
-			# `AI_Smart_Reflect`, so the two are one body.
-			Gen2MoveEffect.LIGHT_SCREEN, Gen2MoveEffect.REFLECT:
-				if not _at_max_hp(attacker) and not _roll(rng, 8):
-					_discourage(scores, slot, 1)
-			Gen2MoveEffect.OHKO:
-				_smart_ohko(scores, slot, attacker, defender)
-			# `AI_Smart_Toxic` falls into `AI_Smart_LeechSeed`.
-			Gen2MoveEffect.LEECH_SEED:
-				if not _above_half(defender):
-					_discourage(scores, slot, 1)
-			Gen2MoveEffect.SUPER_FANG:
-				if not _above_quarter(defender):
-					_discourage(scores, slot, 1)
-			# `AI_Smart_RazorWind` is an empty label in front of
-			# `AI_Smart_Unused2B`.
-			Gen2MoveEffect.RAZOR_WIND, Gen2MoveEffect.UNUSED_2B:
-				_smart_unused_2b(scores, slot, c)
-			Gen2MoveEffect.SP_DEF_UP_2:
-				_smart_sp_defense_up_2(scores, slot, c)
-			Gen2MoveEffect.SPEED_DOWN_HIT:
-				_smart_speed_down_hit(scores, slot, c)
-			Gen2MoveEffect.SUBSTITUTE:
-				if not _above_half(attacker):
-					_discourage(scores, slot)
-			Gen2MoveEffect.RAGE:
-				_smart_rage(scores, slot, attacker, rng)
-			Gen2MoveEffect.DISABLE:
-				_smart_disable(scores, slot, c)
-			Gen2MoveEffect.COUNTER:
-				_smart_counter(scores, slot, c, true)
-			Gen2MoveEffect.MIRROR_COAT:
-				_smart_counter(scores, slot, c, false)
-			Gen2MoveEffect.ENCORE:
-				_smart_encore(scores, slot, c)
-			Gen2MoveEffect.DEFROST_OPPONENT:
-				if Gen2Status.has(attacker.status, Gen2Status.FREEZE):
-					_encourage(scores, slot, 3)
-			Gen2MoveEffect.HEAL_BELL:
-				_smart_heal_bell(scores, slot, c)
-			Gen2MoveEffect.PRIORITY_HIT:
-				_smart_priority_hit(scores, slot, c)
-			Gen2MoveEffect.NIGHTMARE:
-				if not _skip_50_50(rng):
-					_encourage(scores, slot, 1)
-			Gen2MoveEffect.FLAME_WHEEL:
-				if Gen2Status.has(attacker.status, Gen2Status.FREEZE):
-					_encourage(scores, slot, 5)
-			Gen2MoveEffect.CURSE:
-				_smart_curse(scores, slot, c)
-			Gen2MoveEffect.ROLLOUT:
-				_smart_rollout(scores, slot, c)
-			Gen2MoveEffect.FURY_CUTTER:
-				_smart_fury_cutter(scores, slot, c)
-			# `AI_Smart_Swagger` is an empty label in front of
-			# `AI_Smart_Attract`.
-			Gen2MoveEffect.SWAGGER, Gen2MoveEffect.ATTRACT:
-				_smart_attract(scores, slot, c)
-			Gen2MoveEffect.SAFEGUARD:
-				if not _above_half(defender) and not _skip_80_20(rng):
-					_discourage(scores, slot, 1)
-			# `AI_Smart_Magnitude` is an empty label in front of
-			# `AI_Smart_Earthquake`, and `AI_Smart_Twister` in front of
-			# `AI_Smart_Gust`: each pair guesses at the move the other half of
-			# it punishes.
-			Gen2MoveEffect.MAGNITUDE, Gen2MoveEffect.EARTHQUAKE:
-				_smart_ground_or_air(
-					scores, slot, c, Gen2MoveEffect.DIG_MOVE, Gen2Substatus.UNDERGROUND
-				)
-			Gen2MoveEffect.TWISTER, Gen2MoveEffect.GUST:
-				_smart_ground_or_air(
-					scores, slot, c, Gen2MoveEffect.FLY_MOVE, Gen2Substatus.FLYING
-				)
-			Gen2MoveEffect.RAPID_SPIN:
-				_smart_rapid_spin(scores, slot, c)
-			Gen2MoveEffect.HIDDEN_POWER:
-				_smart_hidden_power(scores, slot, c)
-			Gen2MoveEffect.FUTURE_SIGHT:
-				if _faster(attacker, defender) and _is_semi_invulnerable(defender):
-					_encourage(scores, slot, 2)
-			Gen2MoveEffect.STOMP:
-				if defender.minimized and not _skip_80_20(rng):
-					_encourage(scores, slot, 1)
-			Gen2MoveEffect.FLY_OR_DIG:
-				if _is_semi_invulnerable(defender) and _faster(attacker, defender):
-					_encourage(scores, slot, 3)
+		var effect: int = _effect(_move_at(c.attacker, c.data, slot))
+		if SMART_HANDLERS.has(effect):
+			(SMART_HANDLERS[effect] as Callable).call(scores, slot, c)
 
 
+static func _smart_sleep(scores: Array, slot: int, c: Context) -> void:
+	if not _skip_50_50(c.rng):
+		_encourage(scores, slot, 2)
+
+
+static func _smart_toxic(scores: Array, slot: int, c: Context) -> void:
+	if not _above_half(c.defender):
+		_discourage(scores, slot, 1)
+
+
+## `AI_Smart_DestinyBond`, `AI_Smart_Reversal` and `AI_Smart_SkullBash` are one label
+## and one body in the source, so they are one arm here.
+static func _smart_skull_bash(scores: Array, slot: int, c: Context) -> void:
+	if _above_quarter(c.attacker):
+		_discourage(scores, slot, 1)
+
+
+## `AI_Smart_ForceSwitch`: discourage blowing the player away unless
+## `CheckPlayerMoveTypeMatchups` says the pairing is going badly, which is the same
+## score `AI_Smart_PerishSong` reads. `AI_Smart_BatonPass` is the same body under a
+## second label, so the two share an arm the way Destiny Bond shares Skull Bash's.
+static func _smart_force_switch(scores: Array, slot: int, c: Context) -> void:
+	if c.matchup_score >= Gen2AISwitch.BASE_SCORE:
+		_discourage(scores, slot, 1)
+
+
+static func _smart_thief(scores: Array, slot: int, _c: Context) -> void:
+	_discourage(scores, slot, THIEF_PENALTY)
+
+
+static func _smart_dream_eater(scores: Array, slot: int, c: Context) -> void:
+	if not _roll(c.rng, 10):
+		_encourage(scores, slot, 3)
+
+
+## `AICheckEnemyMaxHP` and a 10% pass, which is the whole routine.
+static func _smart_bide(scores: Array, slot: int, c: Context) -> void:
+	# `AICheckEnemyMaxHP` and a 10% pass, which is the whole routine.
+	if not _at_max_hp(c.attacker) and not _roll(c.rng, 10):
+		_discourage(scores, slot, 1)
+
+
+## `AI_Smart_LightScreen` is an empty label in front of `AI_Smart_Reflect`, so the two
+## are one body.
+static func _smart_light_screen(scores: Array, slot: int, c: Context) -> void:
+	if not _at_max_hp(c.attacker) and not _roll(c.rng, 8):
+		_discourage(scores, slot, 1)
+
+
+## `AI_Smart_Toxic` falls into `AI_Smart_LeechSeed`.
+static func _smart_leech_seed(scores: Array, slot: int, c: Context) -> void:
+	if not _above_half(c.defender):
+		_discourage(scores, slot, 1)
+
+
+static func _smart_super_fang(scores: Array, slot: int, c: Context) -> void:
+	if not _above_quarter(c.defender):
+		_discourage(scores, slot, 1)
+
+
+static func _smart_substitute(scores: Array, slot: int, c: Context) -> void:
+	if not _above_half(c.attacker):
+		_discourage(scores, slot)
+
+
+static func _smart_defrost_opponent(scores: Array, slot: int, c: Context) -> void:
+	if Gen2Status.has(c.attacker.status, Gen2Status.FREEZE):
+		_encourage(scores, slot, 3)
+
+
+static func _smart_nightmare(scores: Array, slot: int, c: Context) -> void:
+	if not _skip_50_50(c.rng):
+		_encourage(scores, slot, 1)
+
+
+static func _smart_flame_wheel(scores: Array, slot: int, c: Context) -> void:
+	if Gen2Status.has(c.attacker.status, Gen2Status.FREEZE):
+		_encourage(scores, slot, 5)
+
+
+static func _smart_safeguard(scores: Array, slot: int, c: Context) -> void:
+	if not _above_half(c.defender) and not _skip_80_20(c.rng):
+		_discourage(scores, slot, 1)
+
+
+static func _smart_future_sight(scores: Array, slot: int, c: Context) -> void:
+	if _faster(c.attacker, c.defender) and _is_semi_invulnerable(c.defender):
+		_encourage(scores, slot, 2)
+
+
+static func _smart_stomp(scores: Array, slot: int, c: Context) -> void:
+	if c.defender.minimized and not _skip_80_20(c.rng):
+		_encourage(scores, slot, 1)
+
+
+static func _smart_fly_or_dig(scores: Array, slot: int, c: Context) -> void:
+	if _is_semi_invulnerable(c.defender) and _faster(c.attacker, c.defender):
+		_encourage(scores, slot, 3)
 ## `AI_Smart_MirrorMove`: without a remembered player move, a faster AI
 ## dismisses Mirror Move because it will act before seeing one. A useful
 ## remembered move gets one 50% encouragement and, when the AI is faster, a
 ## second 90% encouragement.
-static func _smart_mirror_move(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
-	var copied: int = defender.last_counter_move
+static func _smart_mirror_move(scores: Array, slot: int, c: Context) -> void:
+	var copied: int = c.defender.last_counter_move
 	if copied == 0:
-		if _faster(attacker, defender):
+		if _faster(c.attacker, c.defender):
 			_discourage(scores, slot)
 		return
 	if not USEFUL_MOVE_NUMBERS.has(copied):
 		return
-	if not _skip_50_50(rng):
+	if not _skip_50_50(c.rng):
 		_encourage(scores, slot, 1)
-	if _faster(attacker, defender) and not _rolls_under(rng, 25):
+	if _faster(c.attacker, c.defender) and not _rolls_under(c.rng, 25):
 		_encourage(scores, slot, 1)
 
 
@@ -810,33 +808,30 @@ static func _smart_mirror_move(
 ## when faster, and only copy above half health. A resisted last move is
 ## discouraged; a super-effective or source-listed useful one gets its own 50%
 ## encouragement.
-static func _smart_mimic(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	data: GameData, rng: RandomNumberGenerator
-) -> void:
-	var copied: int = defender.last_counter_move
+static func _smart_mimic(scores: Array, slot: int, c: Context) -> void:
+	var copied: int = c.defender.last_counter_move
 	if copied == 0:
-		if _faster(attacker, defender):
+		if _faster(c.attacker, c.defender):
 			_discourage(scores, slot)
 		else:
 			_discourage(scores, slot, 1)
 		return
-	if not _above_half(attacker):
+	if not _above_half(c.attacker):
 		_discourage(scores, slot, 1)
 		return
-	var move: Dictionary = data.move(copied)
+	var move: Dictionary = c.data.move(copied)
 	if move.is_empty():
 		return
-	var effectiveness: int = data.type_effectiveness(
-		int(move.get("type", RomLayout.TYPE_NORMAL)), defender.types(),
-		Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
+	var effectiveness: int = c.data.type_effectiveness(
+		int(move.get("type", RomLayout.TYPE_NORMAL)), c.defender.types(),
+		Gen2Substatus.has(c.defender.substatus, Gen2Substatus.IDENTIFIED)
 	)
 	if effectiveness < RomLayout.MATCHUP_EFFECTIVE:
 		_discourage(scores, slot, 1)
 		return
-	if effectiveness > RomLayout.MATCHUP_EFFECTIVE and not _skip_50_50(rng):
+	if effectiveness > RomLayout.MATCHUP_EFFECTIVE and not _skip_50_50(c.rng):
 		_encourage(scores, slot, 1)
-	if USEFUL_MOVE_NUMBERS.has(copied) and not _skip_50_50(rng):
+	if USEFUL_MOVE_NUMBERS.has(copied) and not _skip_50_50(c.rng):
 		_encourage(scores, slot, 1)
 
 
@@ -844,8 +839,8 @@ static func _smart_mimic(
 ## of one wakes before the move and is discouraged; every other value gets the
 ## smart layer's encouragement. The basic layer independently discourages the
 ## awake case, leaving it a bad choice overall as on the cartridge.
-static func _smart_sleep_talk(scores: Array, slot: int, attacker: Gen2BattleMon) -> void:
-	if (attacker.status & Gen2Status.SLEEP_MASK) == 1:
+static func _smart_sleep_talk(scores: Array, slot: int, c: Context) -> void:
+	if (c.attacker.status & Gen2Status.SLEEP_MASK) == 1:
 		_discourage(scores, slot, 3)
 	else:
 		_encourage(scores, slot, 3)
@@ -855,51 +850,43 @@ static func _smart_sleep_talk(scores: Array, slot: int, attacker: Gen2BattleMon)
 ## move, the smart layer almost always discourages the very response designed
 ## for it. The no-last-move branch reads past move zero in the cartridge; this
 ## model leaves that undefined lookup neutral rather than inventing ROM bytes.
-static func _smart_conversion_2(
-	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	if defender.last_counter_move != 0 and not _rolls_under(rng, 25):
+static func _smart_conversion_2(scores: Array, slot: int, c: Context) -> void:
+	if c.defender.last_counter_move != 0 and not _rolls_under(c.rng, 25):
 		_discourage(scores, slot, 1)
 
 
 ## `AI_Smart_Solarbeam`: 80% to encourage it greatly in sun, where it needs no
 ## charge turn, and 90% to discourage it greatly in rain, where it also loses
 ## half its damage.
-static func _smart_solarbeam(
-	scores: Array, slot: int, weather: int, rng: RandomNumberGenerator
-) -> void:
-	if weather == Gen2Weather.SUN:
-		if not _skip_80_20(rng):
+static func _smart_solarbeam(scores: Array, slot: int, c: Context) -> void:
+	if c.weather == Gen2Weather.SUN:
+		if not _skip_80_20(c.rng):
 			_encourage(scores, slot, 2)
 		return
-	if weather == Gen2Weather.RAIN and not _roll(rng, 10):
+	if c.weather == Gen2Weather.RAIN and not _roll(c.rng, 10):
 		_discourage(scores, slot, 2)
 
 
 ## `AI_Smart_Thunder`: 90% to discourage it in sun, where its accuracy halves.
 ## Rain is not mentioned, because the accuracy step and `CheckHit` have already
 ## made it certain.
-static func _smart_thunder(
-	scores: Array, slot: int, weather: int, rng: RandomNumberGenerator
-) -> void:
-	if weather == Gen2Weather.SUN and not _roll(rng, 10):
+static func _smart_thunder(scores: Array, slot: int, c: Context) -> void:
+	if c.weather == Gen2Weather.SUN and not _roll(c.rng, 10):
 		_discourage(scores, slot, 1)
 
 
 ## `AI_Smart_Sandstorm`: worthless against a target the sand cannot touch, poor
 ## against one already low, and a 50% encouragement otherwise.
-static func _smart_sandstorm(
-	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	for defending_type: int in defender.types():
+static func _smart_sandstorm(scores: Array, slot: int, c: Context) -> void:
+	for defending_type: int in c.defender.types():
 		if SANDSTORM_IMMUNE_TYPES.has(int(defending_type)):
 			_discourage(scores, slot, 2)
 			return
 
-	if not _above_half(defender):
+	if not _above_half(c.defender):
 		_discourage(scores, slot, 1)
 		return
-	if not _skip_50_50(rng):
+	if not _skip_50_50(c.rng):
 		_encourage(scores, slot, 1)
 
 
@@ -909,31 +896,29 @@ static func _smart_sandstorm(
 ## two types are tested in the cartridge's order, so a Water/Fire target under
 ## Rain Dance is a Water target.
 static func _smart_weather_move(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator, atk_turns: int, def_turns: int,
-	favours_target: int, disfavours_target: int, wanted_moves: Array
+	scores: Array, slot: int, c: Context, favours_target: int, disfavours_target: int, wanted_moves: Array
 ) -> void:
-	for defending_type: int in defender.types():
+	for defending_type: int in c.defender.types():
 		if int(defending_type) == favours_target:
 			_discourage(scores, slot, 3)
 			return
 		if int(defending_type) == disfavours_target:
-			_good_weather_type(scores, slot, defender, atk_turns, def_turns)
+			_good_weather_type(scores, slot, c.defender, c.atk_turns, c.def_turns)
 			return
 
 	# `AIHasMoveInArray` walks the four slots by move number alone: no PP check
 	# and no usability check, so a wanted move with nothing left in it still
 	# counts as a reason to set the weather.
 	var has_wanted: bool = false
-	for known: Variant in attacker.moves:
+	for known: Variant in c.attacker.moves:
 		if wanted_moves.has(int(known)):
 			has_wanted = true
 			break
 
-	if not has_wanted or not _above_half(defender):
+	if not has_wanted or not _above_half(c.defender):
 		_discourage(scores, slot, 3)
 		return
-	if not _skip_50_50(rng):
+	if not _skip_50_50(c.rng):
 		_encourage(scores, slot, 1)
 
 
@@ -955,95 +940,82 @@ static func _good_weather_type(
 ## The five states it encourages on are Toxic and the four bits
 ## `and 1 << SUBSTATUS_IN_LOVE | 1 << SUBSTATUS_ROLLOUT | 1 << SUBSTATUS_IDENTIFIED
 ## | 1 << SUBSTATUS_NIGHTMARE` tests in one instruction.
-static func _smart_trap_target(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	def_turns: int, rng: RandomNumberGenerator
-) -> void:
-	var worth_it: bool = defender.trapped_turns <= 0 and (
-		defender.toxic_counter > 0
+static func _smart_trap_target(scores: Array, slot: int, c: Context) -> void:
+	var worth_it: bool = c.defender.trapped_turns <= 0 and (
+		c.defender.toxic_counter > 0
 		or Gen2Substatus.has(
-			defender.substatus,
+			c.defender.substatus,
 			Gen2Substatus.ATTRACTED | Gen2Substatus.ROLLOUT
 			| Gen2Substatus.IDENTIFIED | Gen2Substatus.NIGHTMARE
 		)
-		or def_turns == 0
+		or c.def_turns == 0
 	)
 
 	if not worth_it:
-		if not _skip_50_50(rng):
+		if not _skip_50_50(c.rng):
 			_discourage(scores, slot, 1)
 		return
 
-	if not _above_quarter(attacker):
+	if not _above_quarter(c.attacker):
 		return
-	if not _skip_50_50(rng):
+	if not _skip_50_50(c.rng):
 		_encourage(scores, slot, 2)
 
 
-static func _smart_reset_stats(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
+static func _smart_reset_stats(scores: Array, slot: int, c: Context) -> void:
 	var encourage: bool = false
 	for key: String in Gen2BattleMon.STAGED_STATS + Gen2BattleMon.STAGED_ODDS:
-		if attacker.stage(key) < -2:
+		if c.attacker.stage(key) < -2:
 			encourage = true
 			break
 	if not encourage:
 		for key: String in Gen2BattleMon.STAGED_STATS + Gen2BattleMon.STAGED_ODDS:
-			if defender.stage(key) > 2:
+			if c.defender.stage(key) > 2:
 				encourage = true
 				break
 
 	if not encourage:
 		_discourage(scores, slot, 1)
 		return
-	if not _roll(rng, 16):
+	if not _roll(c.rng, 16):
 		_encourage(scores, slot, 1)
 
 
-static func _smart_confuse(
-	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	if _above_half(defender):
+static func _smart_confuse(scores: Array, slot: int, c: Context) -> void:
+	if _above_half(c.defender):
 		return
-	if _roll(rng, 90):
+	if _roll(c.rng, 90):
 		_discourage(scores, slot, 1)
-	if not _above_quarter(defender):
+	if not _above_quarter(c.defender):
 		_discourage(scores, slot, 1)
 
 
-static func _smart_paralyze(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
-	if not _above_quarter(defender):
-		if not _skip_50_50(rng):
+static func _smart_paralyze(scores: Array, slot: int, c: Context) -> void:
+	if not _above_quarter(c.defender):
+		if not _skip_50_50(c.rng):
 			_discourage(scores, slot, 1)
 		return
-	if _faster(attacker, defender):
+	if _faster(c.attacker, c.defender):
 		return
-	if not _above_quarter(attacker):
+	if not _above_quarter(c.attacker):
 		return
-	if not _skip_80_20(rng):
+	if not _skip_80_20(c.rng):
 		_encourage(scores, slot, 2)
 
 
-static func _smart_hyper_beam(
-	scores: Array, slot: int, attacker: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	if _above_half(attacker):
-		if not _roll(rng, 16):
+static func _smart_hyper_beam(scores: Array, slot: int, c: Context) -> void:
+	if _above_half(c.attacker):
+		if not _roll(c.rng, 16):
 			return
 		_discourage(scores, slot, 1)
-		if _skip_50_50(rng):
+		if _skip_50_50(c.rng):
 			return
 		_discourage(scores, slot, 1)
 		return
 
-	if _above_quarter(attacker):
+	if _above_quarter(c.attacker):
 		return
-	if _skip_50_50(rng):
+	if _skip_50_50(c.rng):
 		return
 	_encourage(scores, slot, 1)
 
@@ -1052,14 +1024,12 @@ static func _smart_hyper_beam(
 ## `AI_Smart_Moonlight` are all labels on: 90% to encourage it greatly below a
 ## quarter health, discourage it above half, and nothing in between. The AI reads
 ## its own health here, never the player's.
-static func _smart_heal(
-	scores: Array, slot: int, attacker: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	if not _above_quarter(attacker):
-		if not _roll(rng, 10):
+static func _smart_heal(scores: Array, slot: int, c: Context) -> void:
+	if not _above_quarter(c.attacker):
+		if not _roll(c.rng, 10):
 			_encourage(scores, slot, 2)
 		return
-	if _above_half(attacker):
+	if _above_half(c.attacker):
 		_discourage(scores, slot, 1)
 
 
@@ -1069,32 +1039,27 @@ static func _smart_heal(
 ## player held by Mean Look or Spider Web is `.yes`, 50% to encourage. Otherwise
 ## the AI only bothers when the matchup is one it is not losing. The branch that
 ## says yes is the trapped one, not the winning one.
-static func _smart_perish_song(
-	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator,
-	has_bench: bool, matchup_score: int
-) -> void:
-	if not has_bench:
+static func _smart_perish_song(scores: Array, slot: int, c: Context) -> void:
+	if not c.has_bench:
 		_discourage(scores, slot, 5)
 		return
 
-	if Gen2Substatus.has(defender.substatus, Gen2Substatus.CANT_RUN):
-		if not _skip_50_50(rng):
+	if Gen2Substatus.has(c.defender.substatus, Gen2Substatus.CANT_RUN):
+		if not _skip_50_50(c.rng):
 			_encourage(scores, slot, 1)
 		return
 
-	if matchup_score < Gen2AISwitch.BASE_SCORE:
+	if c.matchup_score < Gen2AISwitch.BASE_SCORE:
 		return
-	if _skip_50_50(rng):
+	if _skip_50_50(c.rng):
 		return
 	_discourage(scores, slot, 1)
 
 
 ## `AI_Smart_PainSplit`: pointless while the enemy is the healthier of the two,
 ## which is `enemy hp * 2 > player hp` rather than a comparison of fractions.
-static func _smart_pain_split(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon
-) -> void:
-	if attacker.hp * 2 > defender.hp:
+static func _smart_pain_split(scores: Array, slot: int, c: Context) -> void:
+	if c.attacker.hp * 2 > c.defender.hp:
 		_discourage(scores, slot, 1)
 
 
@@ -1103,30 +1068,27 @@ static func _smart_pain_split(
 ## knows is encouraged instead and Lock On itself is dismissed, the walk stopping
 ## at the first empty slot. Without it the ladder is health, then speed, then
 ## whether the accuracy is actually a problem.
-static func _smart_lock_on(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	data: GameData, rng: RandomNumberGenerator
-) -> void:
-	if Gen2Substatus.has(defender.substatus, Gen2Substatus.LOCK_ON):
+static func _smart_lock_on(scores: Array, slot: int, c: Context) -> void:
+	if Gen2Substatus.has(c.defender.substatus, Gen2Substatus.LOCK_ON):
 		for other: int in Gen2BattleMon.MAX_MOVES:
-			if other >= attacker.moves.size() or int(attacker.moves[other]) == 0:
+			if other >= c.attacker.moves.size() or int(c.attacker.moves[other]) == 0:
 				break
-			var known: Dictionary = _move_at(attacker, data, other)
+			var known: Dictionary = _move_at(c.attacker, c.data, other)
 			if int(known.get("accuracy", Gen2Accuracy.ALWAYS_HITS)) < LOCK_ON_WANTED_ACCURACY:
 				_encourage(scores, other, 2)
 		_discourage(scores, slot)
 		return
 
-	if not _above_quarter(attacker):
+	if not _above_quarter(c.attacker):
 		_discourage(scores, slot, 1)
 		return
-	if not _above_half(attacker) and not _faster(attacker, defender):
+	if not _above_half(c.attacker) and not _faster(c.attacker, c.defender):
 		_discourage(scores, slot, 1)
 		return
 
 	# `.skip_speed_check`'s ladder, in its order: the first test that matches wins.
-	var evasion: int = defender.stage("evasion")
-	var accuracy: int = attacker.stage("accuracy")
+	var evasion: int = c.defender.stage("evasion")
+	var accuracy: int = c.attacker.stage("accuracy")
 	var wanted: bool = evasion >= 3
 	if not wanted:
 		if evasion >= 1:
@@ -1135,12 +1097,12 @@ static func _smart_lock_on(
 	if not wanted:
 		if accuracy < 0:
 			return
-		if _lock_on_has_wanting_move(attacker, defender, data):
+		if _lock_on_has_wanting_move(c.attacker, c.defender, c.data):
 			return
 		_discourage(scores, slot, 1)
 		return
 
-	if _skip_50_50(rng):
+	if _skip_50_50(c.rng):
 		return
 	_encourage(scores, slot, 2)
 
@@ -1175,33 +1137,30 @@ const LOCK_ON_WANTED_ACCURACY: int = 180
 ##
 ## The target has not moved yet in the first branch, so there is nothing to drain
 ## and the question is only whether the enemy would get to see a move first.
-static func _smart_spite(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
-	var last_move: int = defender.last_counter_move
+static func _smart_spite(scores: Array, slot: int, c: Context) -> void:
+	var last_move: int = c.defender.last_counter_move
 	if last_move == 0:
-		if _faster(attacker, defender):
+		if _faster(c.attacker, c.defender):
 			_discourage(scores, slot)
 			return
-		if _skip_50_50(rng):
+		if _skip_50_50(c.rng):
 			return
 		_discourage(scores, slot, 1)
 		return
 
 	# `.moveloop`, which walks the target's own list and returns without scoring
 	# when the move is not in it.
-	var drained: int = defender.moves.find(last_move)
+	var drained: int = c.defender.moves.find(last_move)
 	if drained < 0:
 		return
 
-	var left: int = defender.pp_left(drained)
+	var left: int = c.defender.pp_left(drained)
 	if left < SPITE_WANTED_PP:
-		if _rolls_under(rng, AI_39_PERCENT_PLUS_ONE):
+		if _rolls_under(c.rng, AI_39_PERCENT_PLUS_ONE):
 			return
 		_encourage(scores, slot, 2)
 		return
-	if left < SPITE_PLENTY_PP and not _rolls_under(rng, AI_39_PERCENT_PLUS_ONE):
+	if left < SPITE_PLENTY_PP and not _rolls_under(c.rng, AI_39_PERCENT_PLUS_ONE):
 		return
 	_discourage(scores, slot, 1)
 
@@ -1220,20 +1179,17 @@ const THIEF_PENALTY: int = 30
 ## `AI_Smart_Foresight`: worth it against a sharply raised evasion, a sharply
 ## lowered accuracy of its own, or a Ghost, which is the only target the flag
 ## opens a type matchup against. Otherwise almost always discouraged.
-static func _smart_foresight(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
-	var wanted: bool = attacker.stage("accuracy") < -2 \
-		or defender.stage("evasion") >= 3 \
-		or defender.types().has(RomLayout.TYPE_GHOST)
+static func _smart_foresight(scores: Array, slot: int, c: Context) -> void:
+	var wanted: bool = c.attacker.stage("accuracy") < -2 \
+		or c.defender.stage("evasion") >= 3 \
+		or c.defender.types().has(RomLayout.TYPE_GHOST)
 	if not wanted:
-		if _roll(rng, FORESIGHT_DISCOURAGE_SKIP_PERCENT):
+		if _roll(c.rng, FORESIGHT_DISCOURAGE_SKIP_PERCENT):
 			return
 		_discourage(scores, slot, 1)
 		return
 
-	if _rolls_under(rng, AI_39_PERCENT_PLUS_ONE):
+	if _rolls_under(c.rng, AI_39_PERCENT_PLUS_ONE):
 		return
 	_encourage(scores, slot, 2)
 
@@ -1242,30 +1198,27 @@ static func _smart_foresight(
 ## with a live bench, or against a player who is already trapped in a costly
 ## state. The Toxic branch is intentionally the cartridge's bug: it encourages
 ## Mean Look because the AI's own Pokémon is badly poisoned.
-static func _smart_mean_look(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator, has_bench: bool, matchup_score: int
-) -> void:
-	if attacker.hp * 2 < attacker.max_hp():
+static func _smart_mean_look(scores: Array, slot: int, c: Context) -> void:
+	if c.attacker.hp * 2 < c.attacker.max_hp():
 		_discourage(scores, slot)
 		return
-	if not has_bench:
+	if not c.has_bench:
 		_discourage(scores, slot)
 		return
 
-	var strongly_wanted: bool = attacker.toxic_counter > 0 or Gen2Substatus.has(
-		defender.substatus,
+	var strongly_wanted: bool = c.attacker.toxic_counter > 0 or Gen2Substatus.has(
+		c.defender.substatus,
 		Gen2Substatus.ATTRACTED | Gen2Substatus.ROLLOUT
 		| Gen2Substatus.IDENTIFIED | Gen2Substatus.NIGHTMARE
 	)
 	if strongly_wanted:
-		if not _skip_80_20(rng):
+		if not _skip_80_20(c.rng):
 			_encourage(scores, slot, 3)
 		return
 
 	# CheckPlayerMoveTypeMatchups returns 11 when the player has only resisted
 	# attacks. That is the one ordinary case where Mean Look is not discouraged.
-	if matchup_score < Gen2AISwitch.COMFORTABLE_SCORE:
+	if c.matchup_score < Gen2AISwitch.COMFORTABLE_SCORE:
 		_discourage(scores, slot, 1)
 
 
@@ -1276,15 +1229,13 @@ const FORESIGHT_DISCOURAGE_SKIP_PERCENT: int = 8
 
 ## `AI_Smart_Pursuit`: worth two points against a target nearly down, discouraged
 ## against one that is not, since a Pokémon with health left is unlikely to run.
-static func _smart_pursuit(
-	scores: Array, slot: int, defender: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	if not _above_quarter(defender):
-		if _skip_50_50(rng):
+static func _smart_pursuit(scores: Array, slot: int, c: Context) -> void:
+	if not _above_quarter(c.defender):
+		if _skip_50_50(c.rng):
 			return
 		_encourage(scores, slot, 2)
 		return
-	if _skip_80_20(rng):
+	if _skip_80_20(c.rng):
 		return
 	_discourage(scores, slot, 1)
 
@@ -1294,37 +1245,34 @@ static func _smart_pursuit(
 ## a two-point penalty that an 8% roll skips outright, and `.greatly_discourage`
 ## adds a point and falls into it, so the worst case is three.
 ##
-static func _smart_protect(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
-	if attacker.protect_count != 0:
-		_smart_protect_discourage(scores, slot, rng, true)
+static func _smart_protect(scores: Array, slot: int, c: Context) -> void:
+	if c.attacker.protect_count != 0:
+		_smart_protect_discourage(scores, slot, c, true)
 		return
 
 	# The second test reads `wPlayerSubStatus5`, the flag a Lock On the enemy used
 	# left on the player: with a guaranteed hit already lined up, sitting the turn
 	# out wastes it.
-	if Gen2Substatus.has(defender.substatus, Gen2Substatus.LOCK_ON):
-		_smart_protect_discourage(scores, slot, rng, false)
+	if Gen2Substatus.has(c.defender.substatus, Gen2Substatus.LOCK_ON):
+		_smart_protect_discourage(scores, slot, c, false)
 		return
 
-	var encourage: bool = defender.fury_cutter_count >= PROTECT_FURY_CUTTER_COUNT \
-		or Gen2Substatus.has(defender.substatus, Gen2Substatus.CHARGING) \
-		or defender.toxic_counter > 0 \
-		or Gen2Substatus.has(defender.substatus, Gen2Substatus.LEECH_SEED) \
-		or Gen2Substatus.has(defender.substatus, Gen2Substatus.CURSE)
+	var encourage: bool = c.defender.fury_cutter_count >= PROTECT_FURY_CUTTER_COUNT \
+		or Gen2Substatus.has(c.defender.substatus, Gen2Substatus.CHARGING) \
+		or c.defender.toxic_counter > 0 \
+		or Gen2Substatus.has(c.defender.substatus, Gen2Substatus.LEECH_SEED) \
+		or Gen2Substatus.has(c.defender.substatus, Gen2Substatus.CURSE)
 
 	if not encourage:
 		# The Rollout test is the fall-through, and it is two refusals in one: a
 		# player not rolling at all discourages, and one rolling under three
 		# discourages as well. Only a boosted Rollout reaches `.encourage`.
-		if not Gen2Substatus.has(defender.substatus, Gen2Substatus.ROLLOUT) \
-			or defender.rollout_count < PROTECT_ROLLOUT_COUNT:
-			_smart_protect_discourage(scores, slot, rng, false)
+		if not Gen2Substatus.has(c.defender.substatus, Gen2Substatus.ROLLOUT) \
+			or c.defender.rollout_count < PROTECT_ROLLOUT_COUNT:
+			_smart_protect_discourage(scores, slot, c, false)
 			return
 
-	if _skip_80_20(rng):
+	if _skip_80_20(c.rng):
 		return
 	_encourage(scores, slot, 1)
 
@@ -1337,11 +1285,11 @@ const PROTECT_ROLLOUT_COUNT: int = 3
 ## `.greatly_discourage` falls into `.discourage`, so the extra point is added in
 ## front of the roll that can skip the other two.
 static func _smart_protect_discourage(
-	scores: Array, slot: int, rng: RandomNumberGenerator, greatly: bool
+	scores: Array, slot: int, c: Context, greatly: bool
 ) -> void:
 	if greatly:
 		_discourage(scores, slot, 1)
-	if _roll(rng, PROTECT_DISCOURAGE_SKIP_PERCENT):
+	if _roll(c.rng, PROTECT_DISCOURAGE_SKIP_PERCENT):
 		return
 	_discourage(scores, slot, 2)
 
@@ -1355,24 +1303,21 @@ const PROTECT_DISCOURAGE_SKIP_PERCENT: int = 8
 ## rather than by move number, which is `AIHasMoveEffect`, and Flail carries the
 ## same byte. `.no_reversal` is the other reason: `wEnemySubStatus5`, the flag a
 ## Lock On the player used left on the enemy.
-static func _smart_endure(
-	scores: Array, slot: int, attacker: Gen2BattleMon, data: GameData,
-	rng: RandomNumberGenerator
-) -> void:
-	if attacker.protect_count != 0 or _at_max_hp(attacker):
+static func _smart_endure(scores: Array, slot: int, c: Context) -> void:
+	if c.attacker.protect_count != 0 or _at_max_hp(c.attacker):
 		_discourage(scores, slot, 2)
 		return
-	if _above_quarter(attacker):
+	if _above_quarter(c.attacker):
 		_discourage(scores, slot, 1)
 		return
-	if not _has_move_effect(attacker, data, Gen2MoveEffect.REVERSAL):
-		if not Gen2Substatus.has(attacker.substatus, Gen2Substatus.LOCK_ON):
+	if not _has_move_effect(c.attacker, c.data, Gen2MoveEffect.REVERSAL):
+		if not Gen2Substatus.has(c.attacker.substatus, Gen2Substatus.LOCK_ON):
 			return
-		if _skip_50_50(rng):
+		if _skip_50_50(c.rng):
 			return
 		_encourage(scores, slot, 2)
 		return
-	if _skip_80_20(rng):
+	if _skip_80_20(c.rng):
 		return
 	_encourage(scores, slot, 3)
 
@@ -1392,35 +1337,32 @@ static func _has_move_effect(mon: Gen2BattleMon, data: GameData, effect: int) ->
 	return false
 
 
-static func _smart_belly_drum(scores: Array, slot: int, attacker: Gen2BattleMon) -> void:
-	if attacker.stage("attack") >= 3:
+static func _smart_belly_drum(scores: Array, slot: int, c: Context) -> void:
+	if c.attacker.stage("attack") >= 3:
 		_discourage(scores, slot, 5)
 		return
-	if _at_max_hp(attacker):
+	if _at_max_hp(c.attacker):
 		return
 	_discourage(scores, slot, 1)
-	if not _above_half(attacker):
+	if not _above_half(c.attacker):
 		_discourage(scores, slot, 5)
 
 
-static func _smart_psych_up(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon,
-	rng: RandomNumberGenerator
-) -> void:
+static func _smart_psych_up(scores: Array, slot: int, c: Context) -> void:
 	var enemy_sum: int = 0
 	var player_sum: int = 0
 	for key: String in Gen2BattleMon.STAGED_STATS + Gen2BattleMon.STAGED_ODDS:
-		enemy_sum += attacker.stage(key)
-		player_sum += defender.stage(key)
+		enemy_sum += c.attacker.stage(key)
+		player_sum += c.defender.stage(key)
 
 	if enemy_sum >= player_sum:
 		_discourage(scores, slot, 2)
 		return
-	if defender.stage("accuracy") < -1:
+	if c.defender.stage("accuracy") < -1:
 		return
-	if attacker.stage("evasion") > 0:
+	if c.attacker.stage("evasion") > 0:
 		return
-	if _skip_80_20(rng):
+	if _skip_80_20(c.rng):
 		return
 	_encourage(scores, slot, 1)
 
@@ -1720,13 +1662,11 @@ static func _smart_always_hit(scores: Array, slot: int, c: Context) -> void:
 
 ## `AI_Smart_Ohko`: dismissed outright against a higher level, since the move
 ## itself refuses, and discouraged against a target still above half.
-static func _smart_ohko(
-	scores: Array, slot: int, attacker: Gen2BattleMon, defender: Gen2BattleMon
-) -> void:
-	if attacker.level < defender.level:
+static func _smart_ohko(scores: Array, slot: int, c: Context) -> void:
+	if c.attacker.level < c.defender.level:
 		_discourage(scores, slot)
 		return
-	if not _above_half(defender):
+	if not _above_half(c.defender):
 		_discourage(scores, slot, 1)
 
 
@@ -1781,21 +1721,19 @@ static func _smart_speed_down_hit(scores: Array, slot: int, c: Context) -> void:
 
 ## `AI_Smart_Rage`: worth more the longer the counter has been running, and
 ## worth starting only from a healthy mon.
-static func _smart_rage(
-	scores: Array, slot: int, attacker: Gen2BattleMon, rng: RandomNumberGenerator
-) -> void:
-	if not Gen2Substatus.has(attacker.substatus, Gen2Substatus.RAGE):
-		if not _above_half(attacker):
+static func _smart_rage(scores: Array, slot: int, c: Context) -> void:
+	if not Gen2Substatus.has(c.attacker.substatus, Gen2Substatus.RAGE):
+		if not _above_half(c.attacker):
 			_discourage(scores, slot, 1)
-		elif _skip_80_20(rng):
+		elif _skip_80_20(c.rng):
 			_encourage(scores, slot, 1)
 		return
-	if not _skip_50_50(rng):
+	if not _skip_50_50(c.rng):
 		_encourage(scores, slot, 1)
-	if attacker.rage_count < 2:
+	if c.attacker.rage_count < 2:
 		return
 	_encourage(scores, slot, 1)
-	if attacker.rage_count < 3:
+	if c.attacker.rage_count < 3:
 		return
 	_encourage(scores, slot, 1)
 

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -74,98 +74,103 @@ const FRAMESET_THUNDER_WAVE_EXTRA: int = 0x35
 const LCDC_POINTER_SCY: int = Gen2BattleAnimBackground.LCDC_SCY
 
 
+## `BattleAnimFunctions`' own jumptable: the object's function byte and the
+## routine that steps it. A byte the table does not name is one the cartridge
+## has no row for.
+static var FUNCTIONS: Dictionary = {
+	0x00: _null,
+	0x01: _user_to_target,
+	0x02: _user_to_target_disappear,
+	0x03: _move_in_circle,
+	0x04: _wave_to_target,
+	0x05: _throw_to_target,
+	0x06: _throw_to_target_disappear,
+	0x07: _drop,
+	0x08: _user_to_target_spin,
+	0x09: _shake,
+	0x0A: _fire_blast,
+	0x0B: _razor_leaf,
+	0x0C: _bubble,
+	0x0D: _surf,
+	0x0E: _sing,
+	0x0F: _water_gun,
+	0x10: _ember,
+	0x11: _powder,
+	0x12: _poke_ball,
+	0x13: _poke_ball_blocked,
+	0x14: _recover,
+	0x15: _thunder_wave,
+	0x16: _clamp_encore,
+	0x17: _bite,
+	0x18: _solar_beam,
+	0x19: _gust,
+	0x1A: _razor_wind,
+	0x1B: _kick,
+	0x1C: _absorb,
+	0x1D: _egg,
+	0x1E: _move_up,
+	0x1F: _wrap,
+	0x20: _leech_seed,
+	0x21: _sound,
+	0x22: _confuse_ray,
+	0x23: _dizzy,
+	0x24: _amnesia,
+	0x25: _float_up,
+	0x26: _dig,
+	0x27: _string,
+	0x28: _paralyzed,
+	0x29: _spiral_descent,
+	0x2A: _poison_gas,
+	0x2B: _horn,
+	0x2C: _needle,
+	0x2D: _petal_dance,
+	0x2E: _thief_payday,
+	0x2F: _absorb_circle,
+	0x30: _bonemerang,
+	0x31: _shiny,
+	0x32: _sky_attack,
+	0x33: _growth_swords_dance,
+	0x34: _smoke_flame_wheel,
+	0x35: _present_smokescreen,
+	0x36: _strength_seismic_toss,
+	0x37: _speed_line,
+	0x38: _sludge,
+	0x39: _metronome_hand,
+	0x3A: _metronome_sparkle_sketch,
+	0x3B: _agility,
+	0x3C: _sacred_fire,
+	0x3D: _safeguard_protect,
+	0x3E: _lock_on_mind_reader,
+	0x3F: _spikes,
+	0x40: _heal_bell_notes,
+	0x41: _baton_pass,
+	0x42: _conversion,
+	0x43: _encore_belly_drum,
+	0x44: _swagger_morning_sun,
+	0x45: _hidden_power,
+	0x46: _curse,
+	0x47: _perish_song,
+	0x48: _rapid_spin,
+	0x49: _beta_pursuit,
+	0x4A: _rain_sandstorm,
+	0x4B: _anim_obj_b0,
+	0x4C: _psych_up,
+	0x4D: _ancient_power,
+	0x4E: _rock_smash,
+	0x4F: _cotton,
+}
+
+
 ## `DoBattleAnimFrame`. Answers false when [param object]'s callback is outside
 ## the jumptable, which the importer's own range check makes unreachable with
 ## cartridge data and which a hand-built object can still ask for.
 static func run(
 	player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject
 ) -> bool:
-	var data: Gen2BattleAnimData = player.data()
-	match object.function:
-		0x00: _null(object)
-		0x01: _user_to_target(object)
-		0x02: _user_to_target_disappear(object)
-		0x03: _move_in_circle(data, object)
-		0x04: _wave_to_target(data, object)
-		0x05: _throw_to_target(data, object)
-		0x06: _throw_to_target_disappear(data, object)
-		0x07: _drop(data, object)
-		0x08: _user_to_target_spin(data, object)
-		0x09: _shake(object)
-		0x0A: _fire_blast(data, object)
-		0x0B: _razor_leaf(data, object)
-		0x0C: _bubble(object)
-		0x0D: _surf(player, data, object)
-		0x0E: _sing(data, object)
-		0x0F: _water_gun(data, object)
-		0x10: _ember(object)
-		0x11: _powder(object)
-		0x12: _poke_ball(player, data, object)
-		0x13: _poke_ball_blocked(player, data, object)
-		0x14: _recover(data, object)
-		0x15: _thunder_wave(object)
-		0x16: _clamp_encore(data, object)
-		0x17: _bite(data, object)
-		0x18: _solar_beam(data, object)
-		0x19: _gust(data, object)
-		0x1A: _razor_wind(data, object)
-		0x1B: _kick(data, object)
-		0x1C: _absorb(object)
-		0x1D: _egg(data, object)
-		0x1E: _move_up(object)
-		0x1F: _wrap(object)
-		0x20: _leech_seed(data, object)
-		0x21: _sound(player, data, object)
-		0x22: _confuse_ray(data, object)
-		0x23: _dizzy(data, object)
-		0x24: _amnesia(object)
-		0x25: _float_up(data, object)
-		0x26: _dig(data, object)
-		0x27: _string(object)
-		0x28: _paralyzed(object)
-		0x29: _spiral_descent(data, object)
-		0x2A: _poison_gas(data, object)
-		0x2B: _horn(data, object)
-		0x2C: _needle(data, object)
-		0x2D: _petal_dance(data, object)
-		0x2E: _thief_payday(data, object)
-		0x2F: _absorb_circle(data, object)
-		0x30: _bonemerang(data, object)
-		0x31: _shiny(data, object)
-		0x32: _sky_attack(player, object)
-		0x33: _growth_swords_dance(data, object)
-		0x34: _smoke_flame_wheel(data, object)
-		0x35: _present_smokescreen(data, object)
-		0x36: _strength_seismic_toss(object)
-		0x37: _speed_line(object)
-		0x38: _sludge(object)
-		0x39: _metronome_hand(data, object)
-		0x3A: _metronome_sparkle_sketch(data, object)
-		0x3B: _agility(object)
-		0x3C: _sacred_fire(data, object)
-		0x3D: _safeguard_protect(data, object)
-		0x3E: _lock_on_mind_reader(data, object)
-		0x3F: _spikes(data, object)
-		0x40: _heal_bell_notes(data, object)
-		0x41: _baton_pass(data, object)
-		0x42: _conversion(data, object)
-		0x43: _encore_belly_drum(data, object)
-		0x44: _swagger_morning_sun(data, object)
-		0x45: _hidden_power(data, object)
-		0x46: _curse(object)
-		0x47: _perish_song(data, object)
-		0x48: _rapid_spin(object)
-		0x49: _beta_pursuit(object)
-		0x4A: _rain_sandstorm(object)
-		0x4B: _anim_obj_b0(object)
-		0x4C: _psych_up(data, object)
-		0x4D: _ancient_power(data, object)
-		0x4E: _rock_smash(data, object)
-		0x4F: _cotton(data, object)
-		_: return false
+	if not FUNCTIONS.has(object.function):
+		return false
+	(FUNCTIONS[object.function] as Callable).call(player, player.data(), object)
 	return true
-
-
 ## `BattleAnim_IncAnonJumptableIndex`.
 static func _inc(object: Gen2BattleAnimObject) -> void:
 	object.jumptable_index = (object.jumptable_index + 1) & 0xFF
@@ -265,12 +270,16 @@ static func _ball_palette(player: Gen2BattleAnimPlayer, object: Gen2BattleAnimOb
 
 ## `BattleAnimFunc_Null`, which is not a no-op: its second state deletes the
 ## object, and that is how `anim_incobj` retires the sixty-two rows that use it.
-static func _null(object: Gen2BattleAnimObject) -> void:
+static func _null(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 1:
 		object.deinit()
 
 
-static func _user_to_target(object: Gen2BattleAnimObject) -> void:
+static func _user_to_target(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index != 0:
 		object.deinit()
 		return
@@ -279,7 +288,9 @@ static func _user_to_target(object: Gen2BattleAnimObject) -> void:
 	_step_to_target(object, object.param)
 
 
-static func _user_to_target_disappear(object: Gen2BattleAnimObject) -> void:
+static func _user_to_target_disappear(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.x >= 0x84:
 		object.deinit()
 		return
@@ -288,7 +299,9 @@ static func _user_to_target_disappear(object: Gen2BattleAnimObject) -> void:
 
 ## Bit 7 of the parameter starts the object on the other side of the circle and
 ## is then cleared, since the rest of the byte is the radius.
-static func _move_in_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _move_in_circle(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = 0x00 if (object.param & 0x80) == 0 else 0x20
@@ -298,7 +311,9 @@ static func _move_in_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObje
 	object.var1 = (object.var1 + 1) & 0xFF
 
 
-static func _wave_to_target(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _wave_to_target(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.x >= 0x88:
 		object.deinit()
 		return
@@ -313,7 +328,9 @@ static func _wave_to_target(data: Gen2BattleAnimData, object: Gen2BattleAnimObje
 ## `BattleAnimFunc_ThrowFromUserToTarget`, whose carry flag is its answer: false
 ## once the object has reached the far side, which is what the disappearing
 ## variant and the Poke Ball both branch on.
-static func _throw_to_target(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> bool:
+static func _throw_to_target(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> bool:
 	if object.x >= 0x88:
 		return false
 	object.x = (object.x + 2) & 0xFF
@@ -325,14 +342,16 @@ static func _throw_to_target(data: Gen2BattleAnimData, object: Gen2BattleAnimObj
 
 
 static func _throw_to_target_disappear(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
-	if _throw_to_target(data, object):
+	if _throw_to_target(player, data, object):
 		return
 	object.deinit()
 
 
-static func _drop(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _drop(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = 0x30
@@ -350,7 +369,7 @@ static func _drop(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> voi
 
 
 static func _user_to_target_spin(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
 	if object.jumptable_index == 0:
 		if object.x < 0x80:
@@ -381,7 +400,9 @@ static func _user_to_target_spin(
 	_step_to_target(object, object.param)
 
 
-static func _shake(object: Gen2BattleAnimObject) -> void:
+static func _shake(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -404,7 +425,9 @@ static func _shake_step(object: Gen2BattleAnimObject) -> void:
 
 ## The parameter is the state to start in, so one object row draws nine
 ## different flames.
-static func _fire_blast(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _fire_blast(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		object.jumptable_index = object.param
 		if object.jumptable_index != 7:
@@ -445,7 +468,9 @@ static func _fire_blast_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimO
 	object.var1 = (object.var1 + 1) & 0xFF
 
 
-static func _razor_leaf(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _razor_leaf(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -520,7 +545,9 @@ static func _scatter_horizontal(param: int) -> int:
 	return 0x200
 
 
-static func _bubble(object: Gen2BattleAnimObject) -> void:
+static func _bubble(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -599,7 +626,9 @@ static func _surf(
 			object.deinit()
 
 
-static func _sing(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _sing(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		_reinit(object, FRAMESET_MUSIC_NOTE_1 + object.param)
@@ -612,7 +641,9 @@ static func _sing(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> voi
 	object.y_offset = _sine(data, a, 0x8)
 
 
-static func _water_gun(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _water_gun(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 	match object.jumptable_index:
@@ -643,7 +674,9 @@ static func _water_gun_splash(object: Gen2BattleAnimObject) -> void:
 	_reinit(object, FRAMESET_WATER_GUN_3)
 
 
-static func _ember(object: Gen2BattleAnimObject) -> void:
+static func _ember(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			object.jumptable_index = (object.param >> 4) & 0xF
@@ -660,7 +693,9 @@ static func _ember(object: Gen2BattleAnimObject) -> void:
 			pass
 
 
-static func _powder(object: Gen2BattleAnimObject) -> void:
+static func _powder(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.y_offset >= 0x38:
 		object.deinit()
 		return
@@ -678,7 +713,7 @@ static func _poke_ball(
 			_ball_palette(player, object)
 			_inc(object)
 		1:
-			if _throw_to_target(data, object):
+			if _throw_to_target(player, data, object):
 				return
 			object.y = (object.y + object.y_offset) & 0xFF
 			_reinit(object, FRAMESET_POKE_BALL_3)
@@ -745,7 +780,7 @@ static func _poke_ball_blocked(
 			_inc(object)
 		1:
 			if object.x < 0x70:
-				_throw_to_target(data, object)
+				_throw_to_target(player, data, object)
 				return
 			_inc(object)
 			_poke_ball_fall(object)
@@ -763,7 +798,9 @@ static func _poke_ball_fall(object: Gen2BattleAnimObject) -> void:
 
 ## The parameter is both the starting angle and the radius, and the radius is
 ## what runs out: the object is deleted once the circle has closed.
-static func _recover(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _recover(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var2 = object.param & 0xF0
@@ -782,7 +819,9 @@ static func _recover(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> 
 	object.var2 = (object.var2 - 1) & 0xFF
 
 
-static func _thunder_wave(object: Gen2BattleAnimObject) -> void:
+static func _thunder_wave(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		1:
 			_inc(object)
@@ -793,7 +832,9 @@ static func _thunder_wave(object: Gen2BattleAnimObject) -> void:
 
 ## Two hands clapped together twice. The parameter is the distance from the
 ## centre, and its bit 7 picks the mirrored frameset of the pair.
-static func _clamp_encore(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _clamp_encore(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var2 = object.frameset
@@ -814,7 +855,9 @@ static func _clamp_encore(data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 			object.jumptable_index = 0x1
 
 
-static func _bite(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _bite(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = 0x30 if (object.param & 0x80) != 0 else 0x10
@@ -834,7 +877,9 @@ static func _bite(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> voi
 			object.jumptable_index = 0x1
 
 
-static func _solar_beam(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _solar_beam(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = 0x28
@@ -849,7 +894,9 @@ static func _solar_beam(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 	object.var1 = shrink >> 8
 
 
-static func _gust(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _gust(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -899,12 +946,16 @@ static func _gust_wobble(data: Gen2BattleAnimData, object: Gen2BattleAnimObject)
 	object.var2 = (object.var2 + 1) & 0xFF
 
 
-static func _razor_wind(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
-	_move_in_circle(data, object)
+static func _razor_wind(
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
+	_move_in_circle(player, data, object)
 	object.var1 = (object.var1 + 0xF) & 0xFF
 
 
-static func _kick(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _kick(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			pass
@@ -943,7 +994,9 @@ static func _rolling_kick(data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 
 ## The mirror of [method _user_to_target_disappear]: back towards the user, with
 ## the same 256-step vertical loop when the nybble is under two.
-static func _absorb(object: Gen2BattleAnimObject) -> void:
+static func _absorb(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.x < 0x30:
 		object.deinit()
 		return
@@ -955,7 +1008,9 @@ static func _absorb(object: Gen2BattleAnimObject) -> void:
 
 ## Egg Bomb and Softboiled share fourteen states; the parameter picks which one
 ## the object starts on.
-static func _egg(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _egg(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			object.var1 = 0x28
@@ -1034,14 +1089,18 @@ static func _egg_wave(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) ->
 	_inc(object)
 
 
-static func _move_up(object: Gen2BattleAnimObject) -> void:
+static func _move_up(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.y_offset != 0 and object.y_offset < 0xD8:
 		object.deinit()
 		return
 	object.y_offset = (object.y_offset - object.param) & 0xFF
 
 
-static func _wrap(object: Gen2BattleAnimObject) -> void:
+static func _wrap(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index != 1:
 		return
 	_reinit(object, object.frameset + 1)
@@ -1049,7 +1108,9 @@ static func _wrap(object: Gen2BattleAnimObject) -> void:
 	object.var1 = 0x8
 
 
-static func _leech_seed(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _leech_seed(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -1098,7 +1159,9 @@ static func _sound(
 	object.y_offset = step
 
 
-static func _confuse_ray(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _confuse_ray(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var2 = object.param & 0x3F
@@ -1121,7 +1184,9 @@ static func _confuse_ray(data: Gen2BattleAnimData, object: Gen2BattleAnimObject)
 	object.x = (object.x + 1) & 0xFF
 
 
-static func _dizzy(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _dizzy(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = object.frameset
@@ -1140,7 +1205,9 @@ static func _dizzy(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> vo
 	_reinit(object, object.var1 + 1)
 
 
-static func _amnesia(object: Gen2BattleAnimObject) -> void:
+static func _amnesia(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -1151,7 +1218,9 @@ static func _amnesia(object: Gen2BattleAnimObject) -> void:
 			object.deinit()
 
 
-static func _float_up(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _float_up(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.var1
 	object.var1 = (object.var1 + 2) & 0xFF
 	object.x_offset = _sine(data, a, 0x4)
@@ -1160,14 +1229,18 @@ static func _float_up(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) ->
 	object.var2 = rise & 0xFF
 
 
-static func _dig(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _dig(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.var1
 	object.var1 = (object.var1 - 2) & 0xFF
 	object.y_offset = _sine(data, a, 0x10)
 	object.x = (object.x + 1) & 0xFF
 
 
-static func _string(object: Gen2BattleAnimObject) -> void:
+static func _string(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index != 0:
 		return
 	_inc(object)
@@ -1178,7 +1251,9 @@ static func _string(object: Gen2BattleAnimObject) -> void:
 
 ## Bit 7 of the parameter picks the mirrored frameset and is then gone: the two
 ## nybbles left are how long between switches and how far each way.
-static func _paralyzed(object: Gen2BattleAnimObject) -> void:
+static func _paralyzed(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = 0x00
@@ -1197,11 +1272,15 @@ static func _paralyzed(object: Gen2BattleAnimObject) -> void:
 	object.x_offset = (-object.x_offset) & 0xFF
 
 
-static func _spiral_descent(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _spiral_descent(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	_descend(data, object, 0x7)
 
 
-static func _petal_dance(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _petal_dance(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	_descend(data, object, 0x3)
 
 
@@ -1222,9 +1301,11 @@ static func _descend(
 	object.var2 = (object.var2 + 1) & 0xFF
 
 
-static func _poison_gas(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _poison_gas(
+	player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index != 0:
-		_spiral_descent(data, object)
+		_spiral_descent(player, data, object)
 		return
 	if object.x >= 0x84:
 		_inc(object)
@@ -1238,7 +1319,9 @@ static func _poison_gas(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 	object.y = (object.y - 1) & 0xFF
 
 
-static func _horn(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _horn(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			object.jumptable_index = object.param
@@ -1265,7 +1348,9 @@ static func _horn_sweep(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 
 ## The parameter's high nybble picks the state and its low nybble the speed, so
 ## one row is both the straight needle and the arcing one.
-static func _needle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _needle(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			object.jumptable_index = (object.param & 0xF0) >> 4
@@ -1288,7 +1373,9 @@ static func _needle_advance(object: Gen2BattleAnimObject) -> void:
 	_step_to_target(object, object.param)
 
 
-static func _thief_payday(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _thief_payday(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var1 = 0x28
@@ -1305,7 +1392,9 @@ static func _thief_payday(data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 
 ## A ring that widens on the way in and closes on the way out, the object going
 ## when its radius reaches zero.
-static func _absorb_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _absorb_circle(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	object.y_offset = _sine(data, object.param, object.var1)
 	object.x_offset = _cosine(data, object.param, object.var1)
 	object.param = (object.param + 1) & 0xFF
@@ -1322,7 +1411,9 @@ static func _absorb_circle(data: Gen2BattleAnimData, object: Gen2BattleAnimObjec
 	object.var1 = (object.var1 - 1) & 0xFF
 
 
-static func _bonemerang(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _bonemerang(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		object.var2 = object.y
@@ -1331,7 +1422,9 @@ static func _bonemerang(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 	object.param = (object.param + 1) & 0xFF
 
 
-static func _shiny(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _shiny(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index != 0:
 		return
 	_inc(object)
@@ -1340,7 +1433,9 @@ static func _shiny(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> vo
 	object.var2 = 0xF
 
 
-static func _sky_attack(player: Gen2BattleAnimPlayer, object: Gen2BattleAnimObject) -> void:
+static func _sky_attack(
+	player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -1372,7 +1467,7 @@ static func _sky_attack_palette(
 
 
 static func _growth_swords_dance(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
 	object.y_offset = (_sra(_sra(_sra(_sine(data, object.param, 0x18)))) + object.var2) & 0xFF
 	object.x_offset = _cosine(data, object.param, 0x18)
@@ -1380,11 +1475,15 @@ static func _growth_swords_dance(
 	object.var2 = (object.var2 - 2) & 0xFF
 
 
-static func _smoke_flame_wheel(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _smoke_flame_wheel(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	_rise_in_circle(data, object, 0x7, 0xE8, 1)
 
 
-static func _sacred_fire(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _sacred_fire(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	_rise_in_circle(data, object, 0x3, 0xD0, 2)
 
 
@@ -1406,7 +1505,7 @@ static func _rise_in_circle(
 
 
 static func _present_smokescreen(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
 	match object.jumptable_index:
 		0:
@@ -1433,7 +1532,9 @@ static func _present_bounce(data: Gen2BattleAnimData, object: Gen2BattleAnimObje
 	# unreachable and the bounce never loses height. The cartridge's own.
 
 
-static func _strength_seismic_toss(object: Gen2BattleAnimObject) -> void:
+static func _strength_seismic_toss(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			if object.y_offset == 0xE0:
@@ -1457,7 +1558,9 @@ static func _strength_seismic_toss(object: Gen2BattleAnimObject) -> void:
 			_step_to_target(object, 0x4)
 
 
-static func _speed_line(object: Gen2BattleAnimObject) -> void:
+static func _speed_line(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		_reinit(object, FRAMESET_SPEED_LINE_1 + (object.param & 0x7F))
@@ -1467,7 +1570,9 @@ static func _speed_line(object: Gen2BattleAnimObject) -> void:
 	object.x_offset = (object.x_offset + 1) & 0xFF
 
 
-static func _sludge(object: Gen2BattleAnimObject) -> void:
+static func _sludge(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -1483,7 +1588,9 @@ static func _sludge(object: Gen2BattleAnimObject) -> void:
 			object.y_offset = (object.y_offset - 1) & 0xFF
 
 
-static func _metronome_hand(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _metronome_hand(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.var1
 	object.var1 = (object.var1 + 2) & 0xFF
 	object.y_offset = _sine(data, a, 0x2)
@@ -1491,7 +1598,7 @@ static func _metronome_hand(data: Gen2BattleAnimData, object: Gen2BattleAnimObje
 
 
 static func _metronome_sparkle_sketch(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
 	if object.y_offset >= 0x20:
 		object.deinit()
@@ -1503,14 +1610,18 @@ static func _metronome_sparkle_sketch(
 	object.y_offset = (object.y_offset + 1) & 0xFF
 
 
-static func _agility(object: Gen2BattleAnimObject) -> void:
+static func _agility(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index != 0:
 		object.deinit()
 		return
 	object.x = (object.x + object.param) & 0xFF
 
 
-static func _safeguard_protect(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _safeguard_protect(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	object.y_offset = _sine(data, object.param, 0x18)
 	object.x_offset = _sra(_cosine(data, object.param, 0x18))
 	object.param = (object.param + 1) & 0xFF
@@ -1519,7 +1630,7 @@ static func _safeguard_protect(data: Gen2BattleAnimData, object: Gen2BattleAnimO
 ## Four objects converging on one point, then a wait, then gone. The parameter's
 ## low nybble picks which of the four framesets this one is.
 static func _lock_on_mind_reader(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
@@ -1549,7 +1660,9 @@ static func _lock_on_wait(object: Gen2BattleAnimObject) -> void:
 	object.deinit()
 
 
-static func _spikes(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _spikes(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			_inc(object)
@@ -1561,7 +1674,9 @@ static func _spikes(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> v
 			_inc(object)
 
 
-static func _heal_bell_notes(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _heal_bell_notes(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		_inc(object)
 		_reinit(object, FRAMESET_MUSIC_NOTE_1 + object.param)
@@ -1577,7 +1692,9 @@ static func _heal_bell_notes(data: Gen2BattleAnimData, object: Gen2BattleAnimObj
 	object.x = (object.x - 1) & 0xFF
 
 
-static func _baton_pass(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _baton_pass(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.param == 0:
 		return
 	var a: int = object.var1
@@ -1591,7 +1708,9 @@ static func _baton_pass(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 	object.param >>= 1
 
 
-static func _conversion(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _conversion(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.param
 	object.param = (object.param + 1) & 0xFF
 	object.y_offset = _sine(data, a, object.var1)
@@ -1608,7 +1727,9 @@ static func _conversion(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 	object.deinit()
 
 
-static func _encore_belly_drum(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _encore_belly_drum(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.var1 >= 0x10:
 		object.deinit()
 		return
@@ -1621,7 +1742,7 @@ static func _encore_belly_drum(data: Gen2BattleAnimData, object: Gen2BattleAnimO
 ## The parameter's top two bits are the speed and the rest is the angle, and the
 ## radius is whatever var1 has grown to.
 static func _swagger_morning_sun(
-	data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
 ) -> void:
 	var radius: int = object.var1
 	object.var1 = (radius + ((object.param & 0xC0) >> 6)) & 0xFF
@@ -1630,7 +1751,9 @@ static func _swagger_morning_sun(
 	object.x_offset = _cosine(data, angle, radius)
 
 
-static func _hidden_power(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _hidden_power(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			var a: int = object.param
@@ -1655,7 +1778,9 @@ static func _hidden_power_expand(
 	_step_circle(data, object, object.param, radius)
 
 
-static func _curse(object: Gen2BattleAnimObject) -> void:
+static func _curse(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		return
 	if object.x < 0x30:
@@ -1665,7 +1790,9 @@ static func _curse(object: Gen2BattleAnimObject) -> void:
 	object.y = (object.y + 2) & 0xFF
 
 
-static func _perish_song(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _perish_song(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.param
 	object.param = (object.param + 2) & 0xFF
 	object.y_offset = (_sra(_sra(_sine(data, a, 0x50))) + object.var1) & 0xFF
@@ -1673,14 +1800,18 @@ static func _perish_song(data: Gen2BattleAnimData, object: Gen2BattleAnimObject)
 	object.x_offset = _cosine(data, a, 0x50)
 
 
-static func _rapid_spin(object: Gen2BattleAnimObject) -> void:
+static func _rapid_spin(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.y_offset == 0xD0:
 		object.deinit()
 		return
 	object.y_offset = (object.y_offset - 4) & 0xFF
 
 
-static func _beta_pursuit(object: Gen2BattleAnimObject) -> void:
+static func _beta_pursuit(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			if object.param != 0:
@@ -1711,7 +1842,9 @@ static func _beta_pursuit_up(object: Gen2BattleAnimObject) -> void:
 	object.y_offset = (object.y_offset - 4) & 0xFF
 
 
-static func _rain_sandstorm(object: Gen2BattleAnimObject) -> void:
+static func _rain_sandstorm(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	match object.jumptable_index:
 		0:
 			object.jumptable_index = object.param
@@ -1732,7 +1865,9 @@ static func _rain_step(object: Gen2BattleAnimObject, sideways: int) -> void:
 
 ## `BattleAnimFunc_AnimObjB0`, which no shipped animation reaches: object $b0 is
 ## in no `anim_obj`. Ported because the jumptable dispatches to it.
-static func _anim_obj_b0(object: Gen2BattleAnimObject) -> void:
+static func _anim_obj_b0(
+	_player: Gen2BattleAnimPlayer, _data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var de: int = (object.x << 8) | object.var1
 	var high: int = (object.param & 0xF0) | ((object.param & 0xF0) >> 4)
 	var hl: int = ((high << 8) | ((object.param & 0xF) << 4)) & 0xFFFF
@@ -1741,13 +1876,17 @@ static func _anim_obj_b0(object: Gen2BattleAnimObject) -> void:
 	object.var1 = hl & 0xFF
 
 
-static func _psych_up(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _psych_up(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.param
 	object.param = (object.param + 1) & 0xFF
 	_step_circle(data, object, a, 0x18)
 
 
-static func _ancient_power(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _ancient_power(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.var1 >= 0x20:
 		object.deinit()
 		return
@@ -1756,7 +1895,9 @@ static func _ancient_power(data: Gen2BattleAnimData, object: Gen2BattleAnimObjec
 	object.y_offset = (-_sine(data, a, object.param)) & 0xFF
 
 
-static func _rock_smash(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _rock_smash(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	if object.jumptable_index == 0:
 		# Written straight into the struct rather than through
 		# `ReinitBattleAnimFrameset`, so the frame and duration are not reset.
@@ -1769,7 +1910,9 @@ static func _rock_smash(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) 
 	_arc_horizontal(data, object)
 
 
-static func _cotton(data: Gen2BattleAnimData, object: Gen2BattleAnimObject) -> void:
+static func _cotton(
+	_player: Gen2BattleAnimPlayer, data: Gen2BattleAnimData, object: Gen2BattleAnimObject
+) -> void:
 	var a: int = object.var2
 	object.var2 = (object.var2 + 1) & 0xFF
 	_step_circle(data, object, ((a >> 1) + object.param) & 0xFF, 0x18)

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -884,7 +884,9 @@ func is_ready() -> bool:
 
 ## Puts two Pokémon on the screen at a level each, both at full health, and
 ## starts a battle between them.
-func show_matchup(enemy: int, player: int, enemy_level: int = 5, player_level: int = 5) -> void:
+func show_matchup(
+	enemy: int, player: int, enemy_level: int = 5, player_level: int = 5
+) -> void:
 	_reset_capture_state()
 	_world_battle_active = false
 	_world_battle_tutorial = false
@@ -5131,376 +5133,378 @@ func _apply_event_state(event: Dictionary) -> void:
 			_refresh_level_up_box()
 
 
+## Every event that reads as one sentence, as the sentence and the arguments it
+## takes. An argument is `kind:field`, which [method _line_argument] resolves off
+## the event: a battler's name, a move, an item, a species, a type or a number.
+const LINES: Dictionary = {
+	Gen2Battle.USED_MOVE: ["%s used %s!", &"name:side", &"move:move"],
+	Gen2Battle.MISSED: ["%s's attack missed!", &"name:side"],
+	Gen2Battle.NO_EFFECT: ["It doesn't affect %s!", &"name:target"],
+	Gen2Battle.RECOIL: ["%s is hit with recoil!", &"name:side"],
+	Gen2Battle.DRAINED: ["%s sucked health from %s!", &"name:side", &"name:from"],
+	Gen2Battle.OHKO: ["It's a one-hit KO!"],
+	Gen2Battle.WOKE_UP: ["%s woke up!", &"name:side"],
+	# `WasDefrostedText` and `DefrostedOpponentText` are the same line under two
+	# names, differing only in whether it is the user or the target that is named.
+	Gen2Battle.THAWED: ["%s was defrosted!", &"name:side"],
+	Gen2Battle.CONFUSE_INFLICTED: ["%s became confused!", &"name:target"],
+	Gen2Battle.CONFUSED: ["%s is confused!", &"name:side"],
+	Gen2Battle.SNAPPED_OUT: ["%s snapped out of confusion!", &"name:side"],
+	Gen2Battle.HURT_ITSELF: ["It hurt itself in its confusion!"],
+	Gen2Battle.STAGES_CLEARED: ["All stat changes were eliminated!"],
+	Gen2Battle.STAGES_COPIED: ["%s copied the target's stat changes!", &"name:side"],
+	# `PlayStereoCry` prints nothing.
+	Gen2Battle.CRY: [""],
+	Gen2Battle.EXP_GAINED: [
+		"%s gained %d EXP. Points!",
+		&"species:species",
+		&"int:amount",
+	],
+	# The cartridge never prints a line of its own for this: it happens silently
+	# behind the EXP. Points message above it.
+	Gen2Battle.STAT_EXP_GAINED: [""],
+	Gen2Battle.GREW_LEVEL: [
+		"%s grew to level %d!",
+		&"species:species",
+		&"int:new_level",
+	],
+	Gen2Battle.MOVE_LEARNED: ["%s learned %s!", &"species:species", &"move:move"],
+	Gen2Battle.MOVE_OFFERED: [
+		"%s wants to learn %s!",
+		&"species:species",
+		&"move:move",
+	],
+	Gen2Battle.MOVE_FORGOTTEN: [
+		"%s forgot %s and learned %s!",
+		&"species:species",
+		&"move:forgot",
+		&"move:learned",
+	],
+	Gen2Battle.MOVE_DECLINED: [
+		"%s did not learn %s.",
+		&"species:species",
+		&"move:move",
+	],
+	Gen2Battle.MOVE_FAILED: ["But it failed!"],
+	Gen2Battle.BIDE_STORING: ["%s is storing energy!", &"name:side"],
+	Gen2Battle.BIDE_UNLEASHED: ["%s unleashed energy!", &"name:side"],
+	Gen2Battle.RAGE_BUILDING: ["%s's RAGE is building!", &"name:target"],
+	Gen2Battle.FUTURE_SIGHT_SET: ["%s foresaw an attack!", &"name:side"],
+	Gen2Battle.FUTURE_SIGHT_HIT: ["%s was hit by FUTURE SIGHT!", &"name:target"],
+	Gen2Battle.MIMIC_LEARNED: ["%s learned %s!", &"name:side", &"move:move"],
+	Gen2Battle.SKETCHED_MOVE: ["%s SKETCHED %s!", &"name:side", &"move:move"],
+	Gen2Battle.TYPE_CHANGED: [
+		"%s transformed into the %s-type!",
+		&"name:side",
+		&"type:type_number",
+	],
+	Gen2Battle.DISABLE_INFLICTED: [
+		"%s's %s was disabled!",
+		&"name:target",
+		&"move:move",
+	],
+	Gen2Battle.DISABLE_ENDED: ["%s is disabled no more!", &"name:side"],
+	Gen2Battle.ATTRACT_INFLICTED: ["%s fell in love!", &"name:target"],
+	Gen2Battle.ENCORE_INFLICTED: ["%s got an encore!", &"name:target"],
+	Gen2Battle.ENCORE_ENDED: ["%s's encore ended!", &"name:side"],
+	# `EnemyUsedOnText`, one line for all thirteen: the trainer's own name is not in
+	# the event, so the class is all this can say.
+	Gen2Battle.TRAINER_USED_ITEM: ["Enemy used %s on %s!", &"item:item", &"name:side"],
+	Gen2Battle.HP_RESTORED: ["%s regained health!", &"name:side"],
+	Gen2Battle.HP_ALREADY_FULL: ["%s's HP is full!", &"name:side"],
+	Gen2Battle.WENT_TO_SLEEP: ["%s went to sleep!", &"name:side"],
+	Gen2Battle.RESTED: ["%s fell asleep and became healthy!", &"name:side"],
+	# `BellChimedText` names nobody, since the bell was heard by a party rather than
+	# by a Pokémon.
+	Gen2Battle.BELL_CHIMED: ["A bell chimed!"],
+	Gen2Battle.NOTHING_HAPPENED: ["But nothing happened."],
+	Gen2Battle.MAGNITUDE: ["Magnitude %d!", &"int:magnitude"],
+	Gen2Battle.PRESENT_REFUSED: ["%s refused the gift!", &"name:target"],
+	Gen2Battle.CRASHED: ["%s kept going and crashed!", &"name:side"],
+	Gen2Battle.HURT_BY_SANDSTORM: ["The SANDSTORM hits %s!", &"name:side"],
+	Gen2Battle.RECOVERED_WITH_ITEM: [
+		"%s recovered with %s.",
+		&"name:side",
+		&"item:item",
+	],
+	Gen2Battle.RECOVERED_USING_ITEM: [
+		"%s recovered using a %s!",
+		&"name:side",
+		&"item:item",
+	],
+	Gen2Battle.RESTORED_PP: ["%s recovered PP using %s.", &"name:side", &"item:item"],
+	Gen2Battle.ITEM_HEALED_CONFUSION: [
+		"A %s rid %s of its confusion.",
+		&"item:item",
+		&"name:side",
+	],
+	Gen2Battle.ENDURED: ["%s hung on with %s!", &"name:target", &"item:item"],
+	Gen2Battle.PROTECTED_ITSELF: ["%s PROTECTED itself!", &"name:side"],
+	Gen2Battle.PROTECTING_ITSELF: ["%s's PROTECTING itself!", &"name:target"],
+	Gen2Battle.BRACED_ITSELF: ["%s braced itself!", &"name:side"],
+	Gen2Battle.ENDURED_HIT: ["%s ENDURED the hit!", &"name:target"],
+	Gen2Battle.DESTINY_BOND_SET: [
+		"%s's trying to take its opponent with it!",
+		&"name:side",
+	],
+	Gen2Battle.TOOK_DOWN_WITH_IT: [
+		"%s took down with it, %s!",
+		&"name:target",
+		&"name:side",
+	],
+	# `DraggedOutText` is `<USER>`, so it names the Pokemon that used the move rather
+	# than the one dragged out. Mirrored, not corrected.
+	Gen2Battle.DRAGGED_OUT: ["%s was dragged out!", &"name:side"],
+	Gen2Battle.FLED_IN_FEAR: ["%s fled in fear!", &"name:target"],
+	Gen2Battle.BLOWN_AWAY: ["%s was blown away!", &"name:target"],
+	Gen2Battle.FLED_FROM_BATTLE: ["%s fled from battle!", &"name:side"],
+	Gen2Battle.IDENTIFIED_SET: ["%s identified %s!", &"name:side", &"name:target"],
+	Gen2Battle.TOOK_AIM: ["%s took aim!", &"name:side"],
+	Gen2Battle.PP_REDUCED: [
+		"%s's %s was reduced by %d!",
+		&"name:target",
+		&"move:move",
+		&"int:amount",
+	],
+	# SharedPainText names neither Pokemon, since both were levelled.
+	Gen2Battle.SHARED_PAIN: ["The battlers shared pain!"],
+	Gen2Battle.STOLE_ITEM: ["%s stole %s from its foe!", &"name:side", &"item:item"],
+	# BeatUpAttackText names the party member that is swinging, which is only
+	# sometimes the Pokemon on the field.
+	Gen2Battle.BEAT_UP_ATTACK: ["%s's attack!", &"species:species"],
+	Gen2Battle.HURT_BY_TRAP: ["%s's hurt by %s!", &"name:side", &"move:move"],
+	Gen2Battle.RELEASED_FROM_TRAP: [
+		"%s was released from %s!",
+		&"name:side",
+		&"move:move",
+	],
+	Gen2Battle.CANT_ESCAPE_SET: ["%s can't escape now!", &"name:target"],
+	Gen2Battle.SWITCH_BLOCKED: ["%s can't be recalled!", &"name:side"],
+	Gen2Battle.SAFEGUARD_PROTECTED: ["%s is protected by SAFEGUARD!", &"name:target"],
+	# StartPerishText names neither Pokémon, since the song caught both.
+	Gen2Battle.PERISH_SONG_STARTED: ["Both #MON will faint in 3 turns!"],
+	Gen2Battle.PERISH_COUNT: ["%s's PERISH count is %d!", &"name:side", &"int:count"],
+	Gen2Battle.SUBSTITUTE_MADE: ["%s made a SUBSTITUTE!", &"name:side"],
+	Gen2Battle.SUBSTITUTE_ALREADY: ["%s has a SUBSTITUTE!", &"name:side"],
+	# TooWeakSubText names nobody at all.
+	Gen2Battle.SUBSTITUTE_TOO_WEAK: ["Too weak to make a SUBSTITUTE!"],
+	Gen2Battle.SUBSTITUTE_TOOK_DAMAGE: [
+		"The SUBSTITUTE took damage for %s!",
+		&"name:target",
+	],
+	Gen2Battle.SUBSTITUTE_FADED: ["%s's SUBSTITUTE faded!", &"name:target"],
+	Gen2Battle.WAS_SEEDED: ["%s was seeded!", &"name:target"],
+	Gen2Battle.LEECH_SEED_SAPPED: ["LEECH SEED saps %s!", &"name:side"],
+	Gen2Battle.EVADED: ["%s evaded the attack!", &"name:target"],
+	Gen2Battle.NIGHTMARE_STARTED: ["%s started to have a NIGHTMARE!", &"name:target"],
+	Gen2Battle.HURT_BY_NIGHTMARE: ["%s has a NIGHTMARE!", &"name:side"],
+	# PutACurseText is one text with a paragraph break in it, so the two halves are
+	# one line here rather than two events.
+	Gen2Battle.CURSE_SET: [
+		"%s cut its own HP and put a CURSE on %s!",
+		&"name:side",
+		&"name:target",
+	],
+	Gen2Battle.HURT_BY_CURSE: ["%s's hurt by the CURSE!", &"name:side"],
+	Gen2Battle.SPIKES_SET: ["SPIKES scattered all around %s!", &"name:target"],
+	Gen2Battle.HURT_BY_SPIKES: ["%s's hurt by SPIKES!", &"name:side"],
+	Gen2Battle.SHED_LEECH_SEED: ["%s shed LEECH SEED!", &"name:side"],
+	Gen2Battle.BLEW_SPIKES: ["%s blew away SPIKES!", &"name:side"],
+	Gen2Battle.RELEASED_BY: ["%s was released by %s!", &"name:side", &"name:target"],
+	Gen2Battle.MIST_SET: ["%s is shrouded in mist!", &"name:side"],
+	Gen2Battle.FOCUS_ENERGY_SET: ["%s is getting pumped!", &"name:side"],
+	Gen2Battle.MIST_PROTECTED: ["%s's stat drop was blocked by mist!", &"name:target"],
+	Gen2Battle.RUN_FAILED: ["Can't escape!"],
+	Gen2Battle.COINS_SCATTERED: ["Coins scattered everywhere!"],
+	Gen2Battle.TRANSFORMED: ["%s transformed into %s!", &"name:side", &"name:target"],
+}
+
+## The events whose sentence is a branch rather than a template.
+const LINE_HANDLERS: Dictionary = {
+	Gen2Battle.HIT: &"_hit_text",
+	Gen2Battle.HIT_TIMES: &"_hit_times_text",
+	Gen2Battle.FAINTED: &"_fainted_text",
+	Gen2Battle.CANNOT_MOVE: &"_cannot_move_text",
+	Gen2Battle.STATUS_INFLICTED: &"_status_inflicted_text",
+	Gen2Battle.HURT_BY_STATUS: &"_hurt_by_status_text",
+	Gen2Battle.CHARGING_UP: &"_charging_up_text",
+	Gen2Battle.STAT_CHANGED: &"_stat_changed_text",
+	Gen2Battle.STAT_CHANGE_FAILED: &"_stat_failed_text",
+	Gen2Battle.WITHDREW: &"_withdrew_text",
+	Gen2Battle.SENT_OUT: &"_sent_out_text",
+	Gen2Battle.WEATHER_STARTED: &"_weather_text",
+	Gen2Battle.WEATHER_CONTINUES: &"_weather_text",
+	Gen2Battle.WEATHER_ENDED: &"_weather_text",
+	Gen2Battle.TRAPPED: &"_trapped_text",
+	Gen2Battle.SCREEN_SET: &"_screen_set_text",
+	Gen2Battle.SCREEN_FADED: &"_screen_faded_text",
+	Gen2Battle.FLED: &"_fled_text",
+	Gen2Battle.RUN_BLOCKED: &"_run_blocked_text",
+	Gen2Battle.OVER: &"_over_text",
+}
+
+## Which of the three weather tables an event reads.
+const WEATHER_TEXT_OF: Dictionary = {
+	Gen2Battle.WEATHER_STARTED: WEATHER_STARTED_TEXT,
+	Gen2Battle.WEATHER_CONTINUES: WEATHER_CONTINUES_TEXT,
+	Gen2Battle.WEATHER_ENDED: WEATHER_ENDED_TEXT,
+}
+
+
 ## An event as a sentence, or an empty string for one there is nothing to say
 ## about. A neutral hit has no line of its own in these games: the bar moving is
 ## the whole of the message.
 func _describe(event: Dictionary) -> String:
-	# Every event carries a side except the one that ends the battle, which is
-	# about both of them.
-	var side: int = int(event.get("side", Gen2Battle.PLAYER))
-	match event["type"]:
-		Gen2Battle.USED_MOVE:
-			return "%s used %s!" % [
-				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.MISSED:
-			return "%s's attack missed!" % _battler_name(side)
-		Gen2Battle.NO_EFFECT:
-			return "It doesn't affect %s!" % _battler_name(int(event["target"]))
-		Gen2Battle.HIT:
-			if bool(event["critical"]):
-				return "A critical hit!"
-			if int(event["effectiveness"]) > RomLayout.MATCHUP_EFFECTIVE:
-				return "It's super effective!"
-			if int(event["effectiveness"]) < RomLayout.MATCHUP_EFFECTIVE:
-				return "It's not very effective..."
-		Gen2Battle.RECOIL:
-			return "%s is hit with recoil!" % _battler_name(side)
-		Gen2Battle.HIT_TIMES:
-			return "Hit %d time%s!" % [int(event["times"]), "" if int(event["times"]) == 1 else "s"]
-		Gen2Battle.DRAINED:
-			return "%s sucked health from %s!" % [_battler_name(side), _battler_name(int(event["from"]))]
-		Gen2Battle.OHKO:
-			return "It's a one-hit KO!"
-		Gen2Battle.FAINTED:
-			var faint_line: String = "%s fainted!" % _battler_name(side)
-			## A Nuzlocke faint is a death, and it is said here rather than on
-			## the map: this is where the player is looking, and the row itself
-			## is taken off the party on the way out of the fight.
-			if side == Gen2Battle.PLAYER and _rules().is_nuzlocke():
-				faint_line += Gen2TextStream.PAGE_BREAK \
-					+ Gen2Nuzlocke.death_text(_battler_name(side))
-			return faint_line
-		Gen2Battle.CANNOT_MOVE:
-			return "%s %s" % [_battler_name(side), STOPPED_BY.get(event["reason"], "cannot move!")]
-		Gen2Battle.WOKE_UP:
-			return "%s woke up!" % _battler_name(side)
-		Gen2Battle.THAWED:
-			# `WasDefrostedText` and `DefrostedOpponentText` are the same line
-			# under two names, differing only in whether it is the user or the
-			# target that is named.
-			return "%s was defrosted!" % _battler_name(side)
-		Gen2Battle.STATUS_INFLICTED:
-			return "%s %s" % [
-				_battler_name(int(event["target"])),
-				INFLICTED.get(event["name"], "was hurt!"),
-			]
-		Gen2Battle.HURT_BY_STATUS:
-			return "%s is hurt by its %s!" % [_battler_name(side), event["name"]]
-		Gen2Battle.CONFUSE_INFLICTED:
-			return "%s became confused!" % _battler_name(int(event["target"]))
-		Gen2Battle.CONFUSED:
-			return "%s is confused!" % _battler_name(side)
-		Gen2Battle.SNAPPED_OUT:
-			return "%s snapped out of confusion!" % _battler_name(side)
-		Gen2Battle.HURT_ITSELF:
-			return "It hurt itself in its confusion!"
-		Gen2Battle.CHARGING_UP:
-			return "%s %s" % [
-				_battler_name(side), CHARGE_TEXT.get(int(event.get("move", 0)), CHARGE_DUG),
-			]
-		Gen2Battle.STAGES_CLEARED:
-			return "All stat changes were eliminated!"
-		Gen2Battle.STAGES_COPIED:
-			return "%s copied the target's stat changes!" % _battler_name(side)
-		Gen2Battle.STAT_CHANGED:
-			return _stat_changed_text(event)
-		Gen2Battle.STAT_CHANGE_FAILED:
-			return _stat_failed_text(event)
-		Gen2Battle.WITHDREW:
-			# Named out of the event, because by the time this is read the one on
-			# the field is already the one that came in.
-			if side == Gen2Battle.ENEMY:
-				return "Enemy withdrew %s!" % _name_of(int(event["species"]))
-			return "%s, come back!" % _name_of(int(event["species"]))
-		Gen2Battle.SENT_OUT:
-			if side == Gen2Battle.ENEMY:
-				return "Enemy sent out %s!" % _name_of(int(event["species"]))
-			return SEND_OUT_LINES[
-				clampi(int(event.get("line", Gen2Battle.SEND_OUT_GO)), 0, SEND_OUT_LINES.size() - 1)
-			] % _name_of(int(event["species"]))
-		Gen2Battle.CRY:
-			# `PlayStereoCry` prints nothing.
-			return ""
-		Gen2Battle.EXP_GAINED:
-			return "%s gained %d EXP. Points!" % [_name_of(int(event["species"])), int(event["amount"])]
-		Gen2Battle.STAT_EXP_GAINED:
-			# The cartridge never prints a line of its own for this: it happens
-			# silently behind the EXP. Points message above it.
-			return ""
-		Gen2Battle.GREW_LEVEL:
-			return "%s grew to level %d!" % [_name_of(int(event["species"])), int(event["new_level"])]
-		Gen2Battle.MOVE_LEARNED:
-			return "%s learned %s!" % [
-				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.MOVE_OFFERED:
-			return "%s wants to learn %s!" % [
-				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.MOVE_FORGOTTEN:
-			return "%s forgot %s and learned %s!" % [
-				_name_of(int(event["species"])),
-				String(_data.move(int(event["forgot"])).get("name", "")),
-				String(_data.move(int(event["learned"])).get("name", "")),
-			]
-		Gen2Battle.MOVE_DECLINED:
-			return "%s did not learn %s." % [
-				_name_of(int(event["species"])), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.MOVE_FAILED:
-			return "But it failed!"
-		Gen2Battle.BIDE_STORING:
-			return "%s is storing energy!" % _battler_name(side)
-		Gen2Battle.BIDE_UNLEASHED:
-			return "%s unleashed energy!" % _battler_name(side)
-		Gen2Battle.RAGE_BUILDING:
-			return "%s's RAGE is building!" % _battler_name(int(event["target"]))
-		Gen2Battle.FUTURE_SIGHT_SET:
-			return "%s foresaw an attack!" % _battler_name(side)
-		Gen2Battle.FUTURE_SIGHT_HIT:
-			return "%s was hit by FUTURE SIGHT!" % _battler_name(int(event["target"]))
-		Gen2Battle.MIMIC_LEARNED:
-			return "%s learned %s!" % [
-				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.SKETCHED_MOVE:
-			return "%s SKETCHED %s!" % [
-				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.TYPE_CHANGED:
-			return "%s transformed into the %s-type!" % [
-				_battler_name(side), _data.type_name(int(event["type_number"])),
-			]
-		Gen2Battle.DISABLE_INFLICTED:
-			return "%s's %s was disabled!" % [
-				_battler_name(int(event["target"])), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.DISABLE_ENDED:
-			return "%s is disabled no more!" % _battler_name(side)
-		Gen2Battle.ATTRACT_INFLICTED:
-			return "%s fell in love!" % _battler_name(int(event["target"]))
-		Gen2Battle.ENCORE_INFLICTED:
-			return "%s got an encore!" % _battler_name(int(event["target"]))
-		Gen2Battle.ENCORE_ENDED:
-			return "%s's encore ended!" % _battler_name(side)
-		Gen2Battle.TRAINER_USED_ITEM:
-			# `EnemyUsedOnText`, one line for all thirteen: the trainer's own
-			# name is not in the event, so the class is all this can say.
-			return "Enemy used %s on %s!" % [
-				_data.item_name(int(event["item"])), _battler_name(side),
-			]
-		Gen2Battle.HP_RESTORED:
-			return "%s regained health!" % _battler_name(side)
-		Gen2Battle.HP_ALREADY_FULL:
-			return "%s's HP is full!" % _battler_name(side)
-		Gen2Battle.WENT_TO_SLEEP:
-			return "%s went to sleep!" % _battler_name(side)
-		Gen2Battle.RESTED:
-			return "%s fell asleep and became healthy!" % _battler_name(side)
-		Gen2Battle.BELL_CHIMED:
-			# `BellChimedText` names nobody, since the bell was heard by a party
-			# rather than by a Pokémon.
-			return "A bell chimed!"
-		Gen2Battle.NOTHING_HAPPENED:
-			return "But nothing happened."
-		Gen2Battle.MAGNITUDE:
-			return "Magnitude %d!" % int(event["magnitude"])
-		Gen2Battle.PRESENT_REFUSED:
-			return "%s refused the gift!" % _battler_name(int(event["target"]))
-		Gen2Battle.CRASHED:
-			return "%s kept going and crashed!" % _battler_name(side)
-		Gen2Battle.WEATHER_STARTED:
-			return WEATHER_STARTED_TEXT.get(int(event["weather"]), "")
-		Gen2Battle.WEATHER_CONTINUES:
-			return WEATHER_CONTINUES_TEXT.get(int(event["weather"]), "")
-		Gen2Battle.WEATHER_ENDED:
-			return WEATHER_ENDED_TEXT.get(int(event["weather"]), "")
-		Gen2Battle.HURT_BY_SANDSTORM:
-			return "The SANDSTORM hits %s!" % _battler_name(side)
-		Gen2Battle.RECOVERED_WITH_ITEM:
-			return "%s recovered with %s." % [
-				_battler_name(side), _data.item_name(int(event["item"])),
-			]
-		Gen2Battle.RECOVERED_USING_ITEM:
-			return "%s recovered using a %s!" % [
-				_battler_name(side), _data.item_name(int(event["item"])),
-			]
-		Gen2Battle.RESTORED_PP:
-			return "%s recovered PP using %s." % [
-				_battler_name(side), _data.item_name(int(event["item"])),
-			]
-		Gen2Battle.ITEM_HEALED_CONFUSION:
-			return "A %s rid %s of its confusion." % [
-				_data.item_name(int(event["item"])), _battler_name(side),
-			]
-		Gen2Battle.ENDURED:
-			return "%s hung on with %s!" % [
-				_battler_name(int(event["target"])), _data.item_name(int(event["item"])),
-			]
-		Gen2Battle.PROTECTED_ITSELF:
-			return "%s PROTECTED itself!" % _battler_name(side)
-		Gen2Battle.PROTECTING_ITSELF:
-			return "%s's PROTECTING itself!" % _battler_name(int(event["target"]))
-		Gen2Battle.BRACED_ITSELF:
-			return "%s braced itself!" % _battler_name(side)
-		Gen2Battle.ENDURED_HIT:
-			return "%s ENDURED the hit!" % _battler_name(int(event["target"]))
-		Gen2Battle.DESTINY_BOND_SET:
-			return "%s's trying to take its opponent with it!" % _battler_name(side)
-		Gen2Battle.TOOK_DOWN_WITH_IT:
-			return "%s took down with it, %s!" % [
-				_battler_name(int(event["target"])), _battler_name(side),
-			]
-		Gen2Battle.DRAGGED_OUT:
-			# `DraggedOutText` is `<USER>`, so it names the Pokemon that used the
-			# move rather than the one dragged out. Mirrored, not corrected.
-			return "%s was dragged out!" % _battler_name(side)
-		Gen2Battle.FLED_IN_FEAR:
-			return "%s fled in fear!" % _battler_name(int(event["target"]))
-		Gen2Battle.BLOWN_AWAY:
-			return "%s was blown away!" % _battler_name(int(event["target"]))
-		Gen2Battle.FLED_FROM_BATTLE:
-			return "%s fled from battle!" % _battler_name(side)
-		Gen2Battle.IDENTIFIED_SET:
-			return "%s identified %s!" % [
-				_battler_name(side), _battler_name(int(event["target"])),
-			]
-		Gen2Battle.TOOK_AIM:
-			return "%s took aim!" % _battler_name(side)
-		Gen2Battle.PP_REDUCED:
-			return "%s's %s was reduced by %d!" % [
-				_battler_name(int(event["target"])),
-				String(_data.move(int(event["move"])).get("name", "")),
-				int(event["amount"]),
-			]
-		Gen2Battle.SHARED_PAIN:
-			# SharedPainText names neither Pokemon, since both were levelled.
-			return "The battlers shared pain!"
-		Gen2Battle.STOLE_ITEM:
-			return "%s stole %s from its foe!" % [
-				_battler_name(side), _data.item_name(int(event["item"])),
-			]
-		Gen2Battle.BEAT_UP_ATTACK:
-			# BeatUpAttackText names the party member that is swinging, which is
-			# only sometimes the Pokemon on the field.
-			return "%s's attack!" % _name_of(int(event["species"]))
-		Gen2Battle.TRAPPED:
-			return _trapped_text(event)
-		Gen2Battle.HURT_BY_TRAP:
-			return "%s's hurt by %s!" % [
-				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.RELEASED_FROM_TRAP:
-			return "%s was released from %s!" % [
-				_battler_name(side), String(_data.move(int(event["move"])).get("name", "")),
-			]
-		Gen2Battle.CANT_ESCAPE_SET:
-			return "%s can't escape now!" % _battler_name(int(event["target"]))
-		Gen2Battle.SWITCH_BLOCKED:
-			return "%s can't be recalled!" % _battler_name(side)
-		Gen2Battle.SCREEN_SET:
-			return SCREEN_SET_TEXT.get(int(event["screen"]), "") % _battler_name(side)
-		Gen2Battle.SCREEN_FADED:
-			var faded: int = int(event["screen"])
-			if faded == Gen2Screens.SAFEGUARD:
-				return "%s's SAFEGUARD faded!" % _battler_name(side)
-			return SCREEN_FADED_TEXT.get(faded, "") % (
-				"Enemy #MON" if side == Gen2Battle.ENEMY else "Your #MON"
-			)
-		Gen2Battle.SAFEGUARD_PROTECTED:
-			return "%s is protected by SAFEGUARD!" % _battler_name(int(event["target"]))
-		Gen2Battle.PERISH_SONG_STARTED:
-			# StartPerishText names neither Pokémon, since the song caught both.
-			return "Both #MON will faint in 3 turns!"
-		Gen2Battle.PERISH_COUNT:
-			return "%s's PERISH count is %d!" % [
-				_battler_name(side), int(event["count"]),
-			]
-		Gen2Battle.SUBSTITUTE_MADE:
-			return "%s made a SUBSTITUTE!" % _battler_name(side)
-		Gen2Battle.SUBSTITUTE_ALREADY:
-			return "%s has a SUBSTITUTE!" % _battler_name(side)
-		Gen2Battle.SUBSTITUTE_TOO_WEAK:
-			# TooWeakSubText names nobody at all.
-			return "Too weak to make a SUBSTITUTE!"
-		Gen2Battle.SUBSTITUTE_TOOK_DAMAGE:
-			return "The SUBSTITUTE took damage for %s!" % _battler_name(int(event["target"]))
-		Gen2Battle.SUBSTITUTE_FADED:
-			return "%s's SUBSTITUTE faded!" % _battler_name(int(event["target"]))
-		Gen2Battle.WAS_SEEDED:
-			return "%s was seeded!" % _battler_name(int(event["target"]))
-		Gen2Battle.LEECH_SEED_SAPPED:
-			return "LEECH SEED saps %s!" % _battler_name(side)
-		Gen2Battle.EVADED:
-			return "%s evaded the attack!" % _battler_name(int(event["target"]))
-		Gen2Battle.NIGHTMARE_STARTED:
-			return "%s started to have a NIGHTMARE!" % _battler_name(int(event["target"]))
-		Gen2Battle.HURT_BY_NIGHTMARE:
-			return "%s has a NIGHTMARE!" % _battler_name(side)
-		Gen2Battle.CURSE_SET:
-			# PutACurseText is one text with a paragraph break in it, so the two
-			# halves are one line here rather than two events.
-			return "%s cut its own HP and put a CURSE on %s!" % [
-				_battler_name(side), _battler_name(int(event["target"])),
-			]
-		Gen2Battle.HURT_BY_CURSE:
-			return "%s's hurt by the CURSE!" % _battler_name(side)
-		Gen2Battle.SPIKES_SET:
-			return "SPIKES scattered all around %s!" % _battler_name(int(event["target"]))
-		Gen2Battle.HURT_BY_SPIKES:
-			return "%s's hurt by SPIKES!" % _battler_name(side)
-		Gen2Battle.SHED_LEECH_SEED:
-			return "%s shed LEECH SEED!" % _battler_name(side)
-		Gen2Battle.BLEW_SPIKES:
-			return "%s blew away SPIKES!" % _battler_name(side)
-		Gen2Battle.RELEASED_BY:
-			return "%s was released by %s!" % [
-				_battler_name(side), _battler_name(int(event["target"])),
-			]
-		Gen2Battle.MIST_SET:
-			return "%s is shrouded in mist!" % _battler_name(side)
-		Gen2Battle.FOCUS_ENERGY_SET:
-			return "%s is getting pumped!" % _battler_name(side)
-		Gen2Battle.MIST_PROTECTED:
-			return "%s's stat drop was blocked by mist!" % _battler_name(int(event["target"]))
-		Gen2Battle.FLED:
-			# BattleText_UserFledUsingAStringBuffer1 is the Smoke Ball's own
-			# line; every other branch reaches BattleText_GotAwaySafely.
-			if StringName(event.get("how", &"")) == &"item":
-				return "%s fled using a %s!" % [
-					_battler_name(Gen2Battle.PLAYER),
-					_data.item_name(int(event.get("item", 0))),
-				]
-			return "Got away safely!"
-		Gen2Battle.RUN_FAILED:
-			return "Can't escape!"
-		Gen2Battle.RUN_BLOCKED:
-			if StringName(event.get("reason", &"")) == &"trainer":
-				return "No! There's no running from a trainer battle!"
-			return "Can't escape!"
-		Gen2Battle.OVER:
-			# A run is a draw with both parties standing, and the line before
-			# this one already said so.
-			if bool(event.get("fled", false)):
-				return ""
-			# Both sides can go down in the same turn, through recoil or a burn,
-			# and then there is nobody to declare.
-			if event["winner"] == null:
-				return "Both sides are out of Pokémon!"
-			return "%s won!" % ("The enemy" if event["winner"] == Gen2Battle.ENEMY else "Player")
-		Gen2Battle.COINS_SCATTERED:
-			return "Coins scattered everywhere!"
-		Gen2Battle.TRANSFORMED:
-			return "%s transformed into %s!" % [
-				_battler_name(side), _battler_name(int(event["target"])),
-			]
+	var kind: Variant = event["type"]
+	if LINE_HANDLERS.has(kind):
+		return String(call(LINE_HANDLERS[kind], event))
+	if not LINES.has(kind):
+		return ""
+	var row: Array = LINES[kind]
+	var values: Array = []
+	for code: StringName in row.slice(1):
+		values.append(_line_argument(code, event))
+	if values.is_empty():
+		return String(row[0])
+	return String(row[0]) % values
+
+
+## One [constant LINES] argument. Every event carries a side except the one that
+## ends the battle, which is about both of them, so a missing side is the player.
+func _line_argument(code: StringName, event: Dictionary) -> Variant:
+	var parts: PackedStringArray = String(code).split(":")
+	var field: String = parts[1]
+	match parts[0]:
+		"name":
+			return _battler_name(int(event.get(field, Gen2Battle.PLAYER)))
+		"species":
+			return _name_of(int(event[field]))
+		"move":
+			return String(_data.move(int(event[field])).get("name", ""))
+		"item":
+			return _data.item_name(int(event[field]))
+		"type":
+			return _data.type_name(int(event[field]))
+	return int(event[field])
+
+
+func _hit_text(event: Dictionary) -> String:
+	if bool(event["critical"]):
+		return "A critical hit!"
+	if int(event["effectiveness"]) > RomLayout.MATCHUP_EFFECTIVE:
+		return "It's super effective!"
+	if int(event["effectiveness"]) < RomLayout.MATCHUP_EFFECTIVE:
+		return "It's not very effective..."
 	return ""
 
 
-## The sentence for a stat that actually moved. Ancientpower's [code]"all"[/code]
-## reads as one sentence about the Pokémon rather than five about its stats,
-## because that is the one thing the event says that a single stat's does not.
+func _hit_times_text(event: Dictionary) -> String:
+	var times: int = int(event["times"])
+	return "Hit %d time%s!" % [times, "" if times == 1 else "s"]
+
+
+## A Nuzlocke faint is a death, and it is said here rather than on the map: this
+## is where the player is looking, and the row itself is taken off the party on
+## the way out of the fight.
+func _fainted_text(event: Dictionary) -> String:
+	var side: int = int(event.get("side", Gen2Battle.PLAYER))
+	var line: String = "%s fainted!" % _battler_name(side)
+	if side == Gen2Battle.PLAYER and _rules().is_nuzlocke():
+		line += Gen2TextStream.PAGE_BREAK + Gen2Nuzlocke.death_text(_battler_name(side))
+	return line
+
+
+func _cannot_move_text(event: Dictionary) -> String:
+	return "%s %s" % [
+		_battler_name(int(event.get("side", Gen2Battle.PLAYER))),
+		STOPPED_BY.get(event["reason"], "cannot move!"),
+	]
+
+
+func _status_inflicted_text(event: Dictionary) -> String:
+	return "%s %s" % [
+		_battler_name(int(event["target"])), INFLICTED.get(event["name"], "was hurt!"),
+	]
+
+
+func _hurt_by_status_text(event: Dictionary) -> String:
+	return "%s is hurt by its %s!" % [
+		_battler_name(int(event.get("side", Gen2Battle.PLAYER))), event["name"],
+	]
+
+
+func _charging_up_text(event: Dictionary) -> String:
+	return "%s %s" % [
+		_battler_name(int(event.get("side", Gen2Battle.PLAYER))),
+		CHARGE_TEXT.get(int(event.get("move", 0)), CHARGE_DUG),
+	]
+
+
+## Named out of the event, because by the time this is read the one on the field
+## is already the one that came in.
+func _withdrew_text(event: Dictionary) -> String:
+	if int(event.get("side", Gen2Battle.PLAYER)) == Gen2Battle.ENEMY:
+		return "Enemy withdrew %s!" % _name_of(int(event["species"]))
+	return "%s, come back!" % _name_of(int(event["species"]))
+
+
+func _sent_out_text(event: Dictionary) -> String:
+	if int(event.get("side", Gen2Battle.PLAYER)) == Gen2Battle.ENEMY:
+		return "Enemy sent out %s!" % _name_of(int(event["species"]))
+	return SEND_OUT_LINES[
+		clampi(int(event.get("line", Gen2Battle.SEND_OUT_GO)), 0, SEND_OUT_LINES.size() - 1)
+	] % _name_of(int(event["species"]))
+
+
+func _weather_text(event: Dictionary) -> String:
+	return String((WEATHER_TEXT_OF[event["type"]] as Dictionary).get(
+		int(event["weather"]), ""
+	))
+
+
+func _screen_set_text(event: Dictionary) -> String:
+	return SCREEN_SET_TEXT.get(int(event["screen"]), "") % _battler_name(
+		int(event.get("side", Gen2Battle.PLAYER))
+	)
+
+
+func _screen_faded_text(event: Dictionary) -> String:
+	var side: int = int(event.get("side", Gen2Battle.PLAYER))
+	var faded: int = int(event["screen"])
+	if faded == Gen2Screens.SAFEGUARD:
+		return "%s's SAFEGUARD faded!" % _battler_name(side)
+	return SCREEN_FADED_TEXT.get(faded, "") % (
+		"Enemy #MON" if side == Gen2Battle.ENEMY else "Your #MON"
+	)
+
+
+## BattleText_UserFledUsingAStringBuffer1 is the Smoke Ball's own line; every
+## other branch reaches BattleText_GotAwaySafely.
+func _fled_text(event: Dictionary) -> String:
+	if StringName(event.get("how", &"")) == &"item":
+		return "%s fled using a %s!" % [
+			_battler_name(Gen2Battle.PLAYER), _data.item_name(int(event.get("item", 0))),
+		]
+	return "Got away safely!"
+
+
+func _run_blocked_text(event: Dictionary) -> String:
+	if StringName(event.get("reason", &"")) == &"trainer":
+		return "No! There's no running from a trainer battle!"
+	return "Can't escape!"
+
+
+## A run is a draw with both parties standing, and the line before this one
+## already said so. Both sides can go down in the same turn, through recoil or a
+## burn, and then there is nobody to declare.
+func _over_text(event: Dictionary) -> String:
+	if bool(event.get("fled", false)):
+		return ""
+	if event["winner"] == null:
+		return "Both sides are out of Pokémon!"
+	return "%s won!" % ("The enemy" if event["winner"] == Gen2Battle.ENEMY else "Player")
+
+
 ## The sentence a trapping move lands with, which is a per-move line rather than
 ## one sentence with the move's name in it: `BattleCommand_TrapTarget`'s `.Traps`
 ## table names five texts, three of which spell the move out and two of which do
@@ -5519,6 +5523,9 @@ func _trapped_text(event: Dictionary) -> String:
 	return "%s was trapped!" % who
 
 
+## The sentence for a stat that actually moved. Ancientpower's [code]"all"[/code]
+## reads as one sentence about the Pokémon rather than five about its stats,
+## because that is the one thing the event says that a single stat's does not.
 func _stat_changed_text(event: Dictionary) -> String:
 	var who: String = _battler_name(int(event["target"]))
 	if String(event["stat"]) == "all":

--- a/game/world/radio_show.gd
+++ b/game/world/radio_show.gd
@@ -426,272 +426,351 @@ func _roll_percent(threshold: int) -> bool:
 	return _random.randi_range(0, 255) < threshold
 
 
+## The segments whose whole body is one line and the segment it hands over to,
+## which is what `RadioJumptable`'s rows mostly are.
+const SEGMENT_LINES: Dictionary = {
+	&"OaksPKMNTalk2": [&"OPT_IntroText2", &"OaksPKMNTalk3"],
+	&"OaksPKMNTalk3": [&"OPT_IntroText3", &"OaksPKMNTalk4"],
+	&"OaksPKMNTalk5": [&"OPT_OakText2", &"OaksPKMNTalk6"],
+	&"OaksPKMNTalk6": [&"OPT_OakText3", &"OaksPKMNTalk7"],
+	&"OaksPKMNTalk7": [&"OPT_MaryText1", &"OaksPKMNTalk8"],
+	&"BenMonMusic2": [&"BenIntroText2", &"BenMonMusic3"],
+	&"BenMonMusic3": [&"BenIntroText3", &"BenFernMusic4"],
+	&"FernMonMusic2": [&"FernIntroText2", &"BenFernMusic4"],
+	&"BenFernMusic4": [&"BenFernText1", &"BenFernMusic5"],
+	&"LuckyNumberShow2": [&"LC_Text2", &"LuckyNumberShow3"],
+	&"LuckyNumberShow3": [&"LC_Text3", &"LuckyNumberShow4"],
+	&"LuckyNumberShow4": [&"LC_Text4", &"LuckyNumberShow5"],
+	&"LuckyNumberShow5": [&"LC_Text5", &"LuckyNumberShow6"],
+	&"LuckyNumberShow6": [&"LC_Text6", &"LuckyNumberShow7"],
+	&"LuckyNumberShow7": [&"LC_Text7", &"LuckyNumberShow8"],
+	&"LuckyNumberShow8": [&"LC_Text8", &"LuckyNumberShow9"],
+	&"LuckyNumberShow9": [&"LC_Text9", &"LuckyNumberShow10"],
+	&"LuckyNumberShow10": [&"LC_Text7", &"LuckyNumberShow11"],
+	&"LuckyNumberShow11": [&"LC_Text8", &"LuckyNumberShow12"],
+	&"LuckyNumberShow12": [&"LC_Text10", &"LuckyNumberShow13"],
+	&"LuckyNumberShow14": [&"LC_DragText1", &"LuckyNumberShow15"],
+	&"LuckyNumberShow15": [&"LC_DragText2", &"LuckyNumberShow1"],
+	&"PeoplePlaces2": [&"PnP_Text2", &"PeoplePlaces3"],
+	&"RocketRadio2": [&"RocketRadioText2", &"RocketRadio3"],
+	&"RocketRadio3": [&"RocketRadioText3", &"RocketRadio4"],
+	&"RocketRadio4": [&"RocketRadioText4", &"RocketRadio5"],
+	&"RocketRadio5": [&"RocketRadioText5", &"RocketRadio6"],
+	&"RocketRadio6": [&"RocketRadioText6", &"RocketRadio7"],
+	&"RocketRadio7": [&"RocketRadioText7", &"RocketRadio8"],
+	&"RocketRadio8": [&"RocketRadioText8", &"RocketRadio9"],
+	&"RocketRadio9": [&"RocketRadioText9", &"RocketRadio10"],
+	&"RocketRadio10": [&"RocketRadioText10", &"RocketRadio1"],
+	&"BuenasPassword2": [&"BuenaRadioText2", &"BuenasPassword3"],
+	&"BuenasPassword5": [&"BuenaRadioText5", &"BuenasPassword6"],
+	&"BuenasPassword6": [&"BuenaRadioText6", &"BuenasPassword7"],
+	&"BuenasPassword9": [&"BuenaRadioMidnightText1", &"BuenasPassword10"],
+	&"BuenasPassword10": [&"BuenaRadioMidnightText2", &"BuenasPassword11"],
+	&"BuenasPassword11": [&"BuenaRadioMidnightText3", &"BuenasPassword12"],
+	&"BuenasPassword12": [&"BuenaRadioMidnightText4", &"BuenasPassword13"],
+	&"BuenasPassword13": [&"BuenaRadioMidnightText5", &"BuenasPassword14"],
+	&"BuenasPassword14": [&"BuenaRadioMidnightText6", &"BuenasPassword15"],
+	&"BuenasPassword15": [&"BuenaRadioMidnightText7", &"BuenasPassword16"],
+	&"BuenasPassword16": [&"BuenaRadioMidnightText8", &"BuenasPassword17"],
+	&"BuenasPassword17": [&"BuenaRadioMidnightText9", &"BuenasPassword18"],
+	&"BuenasPassword18": [&"BuenaRadioMidnightText10", &"BuenasPassword19"],
+	&"BuenasPassword19": [&"BuenaRadioMidnightText10", &"BuenasPassword20"],
+}
+
+## The segments that do more than say a line, as the handler that runs each.
+const SEGMENT_HANDLERS: Dictionary = {
+	&"OaksPKMNTalk1": &"_segment_oaks_pkmn_talk1",
+	&"OaksPKMNTalk4": &"_segment_oaks_pkmn_talk4",
+	&"OaksPKMNTalk8": &"_segment_oaks_pkmn_talk8",
+	&"OaksPKMNTalk9": &"_segment_oaks_pkmn_talk9",
+	&"OaksPKMNTalk10": &"_segment_oaks_pkmn_talk10",
+	&"OaksPKMNTalk11": &"_segment_oaks_pkmn_talk11",
+	&"OaksPKMNTalk12": &"_segment_oaks_pkmn_talk12",
+	&"OaksPKMNTalk13": &"_segment_oaks_pkmn_talk13",
+	&"OaksPKMNTalk14": &"_segment_oaks_pkmn_talk14",
+	&"PokedexShow1": &"_segment_pokedex_show1",
+	&"PokedexShow2": &"_segment_pokedex_show2",
+	&"PokedexShow3": &"_segment_pokedex_show3",
+	&"PokedexShow4": &"_segment_pokedex_show4",
+	&"PokedexShow5": &"_segment_pokedex_show5",
+	&"PokedexShow6": &"_segment_pokedex_show6",
+	&"PokedexShow7": &"_segment_pokedex_show7",
+	&"PokedexShow8": &"_segment_pokedex_show8",
+	&"BenMonMusic1": &"_segment_ben_mon_music1",
+	&"FernMonMusic1": &"_segment_fern_mon_music1",
+	&"BenFernMusic5": &"_segment_ben_fern_music5",
+	&"BenFernMusic6": &"_segment_ben_fern_music6",
+	&"BenFernMusic7": &"_segment_ben_fern_music7",
+	&"LuckyNumberShow1": &"_segment_lucky_number_show1",
+	&"LuckyNumberShow13": &"_segment_lucky_number_show13",
+	&"PeoplePlaces1": &"_segment_people_places1",
+	&"PeoplePlaces3": &"_segment_people_places3",
+	&"PeoplePlaces4": &"_segment_people_places4",
+	&"PeoplePlaces5": &"_segment_people_places5",
+	&"PeoplePlaces6": &"_segment_people_places6",
+	&"PeoplePlaces7": &"_segment_people_places7",
+	&"RocketRadio1": &"_segment_rocket_radio1",
+	&"PokeFluteRadio": &"_segment_music_only",
+	&"UnownRadio": &"_segment_music_only",
+	&"EvolutionRadio": &"_segment_music_only",
+	&"BuenasPassword1": &"_segment_buenas_password1",
+	&"BuenasPassword3": &"_segment_buenas_password3",
+	&"BuenasPassword4": &"_segment_buenas_password4",
+	&"BuenasPassword7": &"_segment_buenas_password7",
+	&"BuenasPassword8": &"_segment_buenas_password8",
+	&"BuenasPassword20": &"_segment_buenas_password20",
+	&"BuenasPassword21": &"_segment_buenas_password21",
+}
+
+
 func _run(segment_id: StringName) -> void:
 	ran_segment = segment_id
-	match segment_id:
-		&"OaksPKMNTalk1":
-			_oaks_counter = 5
-			_start_station(Gen2WorldRadio.OAKS_POKEMON_TALK)
-			_say(&"OPT_IntroText1", &"OaksPKMNTalk2")
-		&"OaksPKMNTalk2":
-			_say(&"OPT_IntroText2", &"OaksPKMNTalk3")
-		&"OaksPKMNTalk3":
-			_say(&"OPT_IntroText3", &"OaksPKMNTalk4")
-		&"OaksPKMNTalk4":
-			_oaks_pick_wild()
-			_say(&"OPT_OakText1", &"OaksPKMNTalk5")
-		&"OaksPKMNTalk5":
-			_say(&"OPT_OakText2", &"OaksPKMNTalk6")
-		&"OaksPKMNTalk6":
-			_say(&"OPT_OakText3", &"OaksPKMNTalk7")
-		&"OaksPKMNTalk7":
-			_say(&"OPT_MaryText1", &"OaksPKMNTalk8")
-		&"OaksPKMNTalk8":
-			_print(OPT_ADVERBS[_roll(OPT_ADVERBS.size())], &"OaksPKMNTalk9")
-		&"OaksPKMNTalk9":
-			var adjective: String = _oaks_adjective(_roll(OPT_ADJECTIVES.size()))
-			_oaks_counter -= 1
-			var next: StringName = &"OaksPKMNTalk4"
-			if _oaks_counter == 0:
-				_oaks_counter = 5
-				next = &"OaksPKMNTalk10"
-			_print(adjective, next)
-		&"OaksPKMNTalk10":
-			# `RadioMusicRestartPokemonChannel` and two `PrintText`s rather than
-			# radio lines: the box is cleared and "#MON" placed straight into it.
-			pending_music = MUSIC_POKEMON_TALK
-			_top = ""
-			_bottom = String(TEXTS[&"OPT_PokemonChannelText"])
-			_line = &"OaksPKMNTalk11"
-			_delay = LINE_FRAMES
-		&"OaksPKMNTalk11":
-			_place(_pad(RESTART_TOP_COLUMN, "#MON"), true, &"OaksPKMNTalk12")
-		&"OaksPKMNTalk12":
-			_place("#MON Channel", false, &"OaksPKMNTalk13")
-		&"OaksPKMNTalk13":
-			_place(_bottom, false, &"OaksPKMNTalk14")
-		&"OaksPKMNTalk14":
-			if _delay > 0:
-				_delay -= 1
-				return
-			pending_music = MUSIC_POKEMON_TALK
-			_top = ""
-			_bottom = ""
-			_next_line = &"OaksPKMNTalk4"
-			_lines_printed = 0
-			_line = SCROLL
-			_delay = RESTART_FRAMES
-
-		&"PokedexShow1":
-			_start_station(Gen2WorldRadio.POKEDEX_SHOW)
-			if not _pokedex_pick_mon():
-				# `.loop` retries until it finds a caught species, so an empty
-				# dex would spin forever on the cartridge; here the station
-				# simply has nothing to read.
-				_line = &""
-				return
-			_say(&"PokedexShowText", &"PokedexShow2")
-		&"PokedexShow2":
-			_print(_dex_line(), &"PokedexShow3")
-		&"PokedexShow3":
-			_print(_dex_line(), &"PokedexShow4")
-		&"PokedexShow4":
-			_print(_dex_line(), &"PokedexShow5")
-		&"PokedexShow5":
-			_print(_dex_line(), &"PokedexShow6")
-		&"PokedexShow6":
-			_print(_dex_line(), &"PokedexShow7")
-		&"PokedexShow7":
-			_print(_dex_line(), &"PokedexShow8")
-		&"PokedexShow8":
-			_print(_dex_line(), &"PokedexShow1")
-
-		&"BenMonMusic1":
-			_start_pokemon_music()
-			_say(&"BenIntroText1", &"BenMonMusic2")
-		&"BenMonMusic2":
-			_say(&"BenIntroText2", &"BenMonMusic3")
-		&"BenMonMusic3":
-			_say(&"BenIntroText3", &"BenFernMusic4")
-		&"FernMonMusic1":
-			_start_pokemon_music()
-			_say(&"FernIntroText1", &"FernMonMusic2")
-		&"FernMonMusic2":
-			_say(&"FernIntroText2", &"BenFernMusic4")
-		&"BenFernMusic4":
-			_say(&"BenFernText1", &"BenFernMusic5")
-		&"BenFernMusic5":
-			_say(
-				&"BenFernText2A" if _march_day() else &"BenFernText2B",
-				&"BenFernMusic6"
-			)
-		&"BenFernMusic6":
-			_say(
-				&"BenFernText3A" if _march_day() else &"BenFernText3B",
-				&"BenFernMusic7"
-			)
-		&"BenFernMusic7":
-			# A bare `ret`: the music channel says its three lines once and then
-			# leaves the box alone until the dial moves.
-			_line = &""
-
-		&"LuckyNumberShow1":
-			_start_station(Gen2WorldRadio.LUCKY_CHANNEL)
-			_say(&"LC_Text1", &"LuckyNumberShow2")
-		&"LuckyNumberShow2":
-			_say(&"LC_Text2", &"LuckyNumberShow3")
-		&"LuckyNumberShow3":
-			_say(&"LC_Text3", &"LuckyNumberShow4")
-		&"LuckyNumberShow4":
-			_say(&"LC_Text4", &"LuckyNumberShow5")
-		&"LuckyNumberShow5":
-			_say(&"LC_Text5", &"LuckyNumberShow6")
-		&"LuckyNumberShow6":
-			_say(&"LC_Text6", &"LuckyNumberShow7")
-		&"LuckyNumberShow7":
-			_say(&"LC_Text7", &"LuckyNumberShow8")
-		&"LuckyNumberShow8":
-			_say(&"LC_Text8", &"LuckyNumberShow9")
-		&"LuckyNumberShow9":
-			_say(&"LC_Text9", &"LuckyNumberShow10")
-		&"LuckyNumberShow10":
-			_say(&"LC_Text7", &"LuckyNumberShow11")
-		&"LuckyNumberShow11":
-			_say(&"LC_Text8", &"LuckyNumberShow12")
-		&"LuckyNumberShow12":
-			_say(&"LC_Text10", &"LuckyNumberShow13")
-		&"LuckyNumberShow13":
-			# `call Random / and a`: 255 of 256 rolls restart the show, and the
-			# one zero gets REED's two extra lines.
-			_say(
-				&"LC_Text11",
-				&"LuckyNumberShow14" if _roll(256) == 0 else &"LuckyNumberShow1"
-			)
-		&"LuckyNumberShow14":
-			_say(&"LC_DragText1", &"LuckyNumberShow15")
-		&"LuckyNumberShow15":
-			_say(&"LC_DragText2", &"LuckyNumberShow1")
-
-		&"PeoplePlaces1":
-			_start_station(Gen2WorldRadio.PLACES_AND_PEOPLE)
-			_say(&"PnP_Text1", &"PeoplePlaces2")
-		&"PeoplePlaces2":
-			_say(&"PnP_Text2", &"PeoplePlaces3")
-		&"PeoplePlaces3":
-			_say(&"PnP_Text3", _pnp_topic())
-		&"PeoplePlaces4":
-			_pnp_pick_person()
-			_say(&"PnP_Text4", &"PeoplePlaces5")
-		&"PeoplePlaces5":
-			_print(PNP_ADJECTIVES[_roll(PNP_ADJECTIVES.size())], _pnp_next())
-		&"PeoplePlaces6":
-			_pnp_pick_place()
-			_say(&"PnP_Text5", &"PeoplePlaces7")
-		&"PeoplePlaces7":
-			_print(PNP_ADJECTIVES[_roll(PNP_ADJECTIVES.size())], _pnp_next())
-
-		&"RocketRadio1":
-			_start_station(Gen2WorldRadio.ROCKET_RADIO)
-			_say(&"RocketRadioText1", &"RocketRadio2")
-		&"RocketRadio2":
-			_say(&"RocketRadioText2", &"RocketRadio3")
-		&"RocketRadio3":
-			_say(&"RocketRadioText3", &"RocketRadio4")
-		&"RocketRadio4":
-			_say(&"RocketRadioText4", &"RocketRadio5")
-		&"RocketRadio5":
-			_say(&"RocketRadioText5", &"RocketRadio6")
-		&"RocketRadio6":
-			_say(&"RocketRadioText6", &"RocketRadio7")
-		&"RocketRadio7":
-			_say(&"RocketRadioText7", &"RocketRadio8")
-		&"RocketRadio8":
-			_say(&"RocketRadioText8", &"RocketRadio9")
-		&"RocketRadio9":
-			_say(&"RocketRadioText9", &"RocketRadio10")
-		&"RocketRadio10":
-			_say(&"RocketRadioText10", &"RocketRadio1")
-
-		&"PokeFluteRadio", &"UnownRadio", &"EvolutionRadio":
-			# All three are `StartRadioStation` and a line count of 1, which is
-			# what stops `RadioScroll` clearing a box they never write to.
-			_start_station(_music_only_channel(segment_id))
-			_lines_printed = 1
-			_line = &""
-
-		&"BuenasPassword1":
-			if _off_air():
-				_run(&"BuenasPassword20" if _lines_printed == 0 else &"BuenasPassword8")
-				return
-			_start_station(Gen2WorldRadio.BUENAS_PASSWORD)
-			_say(&"BuenaRadioText1", &"BuenasPassword2")
-		&"BuenasPassword2":
-			_say(&"BuenaRadioText2", &"BuenasPassword3")
-		&"BuenasPassword3":
-			_say(
-				&"BuenaRadioText3",
-				&"BuenasPassword8" if _off_air() else &"BuenasPassword4"
-			)
-			if _off_air():
-				buenas_password_today = false
-		&"BuenasPassword4":
-			if _off_air():
-				_run(&"BuenasPassword8")
-				return
-			_roll_password()
-			_say(&"BuenaRadioText4", &"BuenasPassword5")
-		&"BuenasPassword5":
-			_say(&"BuenaRadioText5", &"BuenasPassword6")
-		&"BuenasPassword6":
-			_say(&"BuenaRadioText6", &"BuenasPassword7")
-		&"BuenasPassword7":
-			var midnight: bool = _off_air()
-			if midnight:
-				buenas_password_today = false
-			_say(
-				&"BuenaRadioText7",
-				&"BuenasPassword8" if midnight else &"BuenasPassword1"
-			)
-		&"BuenasPassword8":
-			buenas_password_today = false
-			_say(&"BuenaRadioMidnightText10", &"BuenasPassword9")
-		&"BuenasPassword9":
-			_say(&"BuenaRadioMidnightText1", &"BuenasPassword10")
-		&"BuenasPassword10":
-			_say(&"BuenaRadioMidnightText2", &"BuenasPassword11")
-		&"BuenasPassword11":
-			_say(&"BuenaRadioMidnightText3", &"BuenasPassword12")
-		&"BuenasPassword12":
-			_say(&"BuenaRadioMidnightText4", &"BuenasPassword13")
-		&"BuenasPassword13":
-			_say(&"BuenaRadioMidnightText5", &"BuenasPassword14")
-		&"BuenasPassword14":
-			_say(&"BuenaRadioMidnightText6", &"BuenasPassword15")
-		&"BuenasPassword15":
-			_say(&"BuenaRadioMidnightText7", &"BuenasPassword16")
-		&"BuenasPassword16":
-			_say(&"BuenaRadioMidnightText8", &"BuenasPassword17")
-		&"BuenasPassword17":
-			_say(&"BuenaRadioMidnightText9", &"BuenasPassword18")
-		&"BuenasPassword18":
-			_say(&"BuenaRadioMidnightText10", &"BuenasPassword19")
-		&"BuenasPassword19":
-			_say(&"BuenaRadioMidnightText10", &"BuenasPassword20")
-		&"BuenasPassword20":
-			# `NoRadioMusic` and `NoRadioName`: the station goes quiet and its
-			# name comes off the dial before the off-air line.
-			pending_music = Gen2WorldState.MUSIC_NONE
-			buenas_password_today = false
-			_lines_printed = 0
-			_say(&"BuenaOffTheAirText", &"BuenasPassword21")
-		&"BuenasPassword21":
-			_lines_printed = 0
-			if not _off_air():
-				_run(&"BuenasPassword1")
-				return
-			_say(&"BuenaOffTheAirText", &"BuenasPassword21")
+	if SEGMENT_LINES.has(segment_id):
+		var row: Array = SEGMENT_LINES[segment_id]
+		_say(row[0], row[1])
+		return
+	if SEGMENT_HANDLERS.has(segment_id):
+		call(SEGMENT_HANDLERS[segment_id], segment_id)
 
 
+func _segment_oaks_pkmn_talk1(_segment_id: StringName) -> void:
+	_oaks_counter = 5
+	_start_station(Gen2WorldRadio.OAKS_POKEMON_TALK)
+	_say(&"OPT_IntroText1", &"OaksPKMNTalk2")
+
+
+func _segment_oaks_pkmn_talk4(_segment_id: StringName) -> void:
+	_oaks_pick_wild()
+	_say(&"OPT_OakText1", &"OaksPKMNTalk5")
+
+
+func _segment_oaks_pkmn_talk8(_segment_id: StringName) -> void:
+	_print(OPT_ADVERBS[_roll(OPT_ADVERBS.size())], &"OaksPKMNTalk9")
+
+
+func _segment_oaks_pkmn_talk9(_segment_id: StringName) -> void:
+	var adjective: String = _oaks_adjective(_roll(OPT_ADJECTIVES.size()))
+	_oaks_counter -= 1
+	var next: StringName = &"OaksPKMNTalk4"
+	if _oaks_counter == 0:
+		_oaks_counter = 5
+		next = &"OaksPKMNTalk10"
+	_print(adjective, next)
+
+
+## `RadioMusicRestartPokemonChannel` and two `PrintText`s rather than radio lines: the
+## box is cleared and "#MON" placed straight into it.
+func _segment_oaks_pkmn_talk10(_segment_id: StringName) -> void:
+	pending_music = MUSIC_POKEMON_TALK
+	_top = ""
+	_bottom = String(TEXTS[&"OPT_PokemonChannelText"])
+	_line = &"OaksPKMNTalk11"
+	_delay = LINE_FRAMES
+
+
+func _segment_oaks_pkmn_talk11(_segment_id: StringName) -> void:
+	_place(_pad(RESTART_TOP_COLUMN, "#MON"), true, &"OaksPKMNTalk12")
+
+
+func _segment_oaks_pkmn_talk12(_segment_id: StringName) -> void:
+	_place("#MON Channel", false, &"OaksPKMNTalk13")
+
+
+func _segment_oaks_pkmn_talk13(_segment_id: StringName) -> void:
+	_place(_bottom, false, &"OaksPKMNTalk14")
+
+
+func _segment_oaks_pkmn_talk14(_segment_id: StringName) -> void:
+	if _delay > 0:
+		_delay -= 1
+		return
+	pending_music = MUSIC_POKEMON_TALK
+	_top = ""
+	_bottom = ""
+	_next_line = &"OaksPKMNTalk4"
+	_lines_printed = 0
+	_line = SCROLL
+	_delay = RESTART_FRAMES
+
+
+func _segment_pokedex_show1(_segment_id: StringName) -> void:
+	_start_station(Gen2WorldRadio.POKEDEX_SHOW)
+	if not _pokedex_pick_mon():
+		# `.loop` retries until it finds a caught species, so an empty
+		# dex would spin forever on the cartridge; here the station
+		# simply has nothing to read.
+		_line = &""
+		return
+	_say(&"PokedexShowText", &"PokedexShow2")
+
+
+func _segment_pokedex_show2(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow3")
+
+
+func _segment_pokedex_show3(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow4")
+
+
+func _segment_pokedex_show4(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow5")
+
+
+func _segment_pokedex_show5(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow6")
+
+
+func _segment_pokedex_show6(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow7")
+
+
+func _segment_pokedex_show7(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow8")
+
+
+func _segment_pokedex_show8(_segment_id: StringName) -> void:
+	_print(_dex_line(), &"PokedexShow1")
+
+
+func _segment_ben_mon_music1(_segment_id: StringName) -> void:
+	_start_pokemon_music()
+	_say(&"BenIntroText1", &"BenMonMusic2")
+
+
+func _segment_fern_mon_music1(_segment_id: StringName) -> void:
+	_start_pokemon_music()
+	_say(&"FernIntroText1", &"FernMonMusic2")
+
+
+func _segment_ben_fern_music5(_segment_id: StringName) -> void:
+	_say(
+		&"BenFernText2A" if _march_day() else &"BenFernText2B",
+		&"BenFernMusic6"
+	)
+
+
+func _segment_ben_fern_music6(_segment_id: StringName) -> void:
+	_say(
+		&"BenFernText3A" if _march_day() else &"BenFernText3B",
+		&"BenFernMusic7"
+	)
+
+
+## A bare `ret`: the music channel says its three lines once and then leaves the box
+## alone until the dial moves.
+func _segment_ben_fern_music7(_segment_id: StringName) -> void:
+	_line = &""
+
+
+func _segment_lucky_number_show1(_segment_id: StringName) -> void:
+	_start_station(Gen2WorldRadio.LUCKY_CHANNEL)
+	_say(&"LC_Text1", &"LuckyNumberShow2")
+
+
+## `call Random / and a`: 255 of 256 rolls restart the show, and the one zero gets
+## REED's two extra lines.
+func _segment_lucky_number_show13(_segment_id: StringName) -> void:
+	_say(
+		&"LC_Text11",
+		&"LuckyNumberShow14" if _roll(256) == 0 else &"LuckyNumberShow1"
+	)
+
+
+func _segment_people_places1(_segment_id: StringName) -> void:
+	_start_station(Gen2WorldRadio.PLACES_AND_PEOPLE)
+	_say(&"PnP_Text1", &"PeoplePlaces2")
+
+
+func _segment_people_places3(_segment_id: StringName) -> void:
+	_say(&"PnP_Text3", _pnp_topic())
+
+
+func _segment_people_places4(_segment_id: StringName) -> void:
+	_pnp_pick_person()
+	_say(&"PnP_Text4", &"PeoplePlaces5")
+
+
+func _segment_people_places5(_segment_id: StringName) -> void:
+	_print(PNP_ADJECTIVES[_roll(PNP_ADJECTIVES.size())], _pnp_next())
+
+
+func _segment_people_places6(_segment_id: StringName) -> void:
+	_pnp_pick_place()
+	_say(&"PnP_Text5", &"PeoplePlaces7")
+
+
+func _segment_people_places7(_segment_id: StringName) -> void:
+	_print(PNP_ADJECTIVES[_roll(PNP_ADJECTIVES.size())], _pnp_next())
+
+
+func _segment_rocket_radio1(_segment_id: StringName) -> void:
+	_start_station(Gen2WorldRadio.ROCKET_RADIO)
+	_say(&"RocketRadioText1", &"RocketRadio2")
+
+
+## All three are `StartRadioStation` and a line count of 1, which is what stops
+## `RadioScroll` clearing a box they never write to.
+func _segment_music_only(segment_id: StringName) -> void:
+	_start_station(_music_only_channel(segment_id))
+	_lines_printed = 1
+	_line = &""
+
+
+func _segment_buenas_password1(_segment_id: StringName) -> void:
+	if _off_air():
+		_run(&"BuenasPassword20" if _lines_printed == 0 else &"BuenasPassword8")
+		return
+	_start_station(Gen2WorldRadio.BUENAS_PASSWORD)
+	_say(&"BuenaRadioText1", &"BuenasPassword2")
+
+
+func _segment_buenas_password3(_segment_id: StringName) -> void:
+	_say(
+		&"BuenaRadioText3",
+		&"BuenasPassword8" if _off_air() else &"BuenasPassword4"
+	)
+	if _off_air():
+		buenas_password_today = false
+
+
+func _segment_buenas_password4(_segment_id: StringName) -> void:
+	if _off_air():
+		_run(&"BuenasPassword8")
+		return
+	_roll_password()
+	_say(&"BuenaRadioText4", &"BuenasPassword5")
+
+
+func _segment_buenas_password7(_segment_id: StringName) -> void:
+	var midnight: bool = _off_air()
+	if midnight:
+		buenas_password_today = false
+	_say(
+		&"BuenaRadioText7",
+		&"BuenasPassword8" if midnight else &"BuenasPassword1"
+	)
+
+
+func _segment_buenas_password8(_segment_id: StringName) -> void:
+	buenas_password_today = false
+	_say(&"BuenaRadioMidnightText10", &"BuenasPassword9")
+
+
+## `NoRadioMusic` and `NoRadioName`: the station goes quiet and its name comes off the
+## dial before the off-air line.
+func _segment_buenas_password20(_segment_id: StringName) -> void:
+	pending_music = Gen2WorldState.MUSIC_NONE
+	buenas_password_today = false
+	_lines_printed = 0
+	_say(&"BuenaOffTheAirText", &"BuenasPassword21")
+
+
+func _segment_buenas_password21(_segment_id: StringName) -> void:
+	_lines_printed = 0
+	if not _off_air():
+		_run(&"BuenasPassword1")
+		return
+	_say(&"BuenaOffTheAirText", &"BuenasPassword21")
 ## `PlaceRadioString`: a string written straight into the box at a column, with
 ## its own 100-frame wait counted by the segment that follows.
 func _place(text: String, top: bool, next: StringName) -> void:

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -370,6 +370,101 @@ static func _later_command_width(opcode: int) -> int:
 	return 0
 
 
+## The names Crystal gives the seven raw bytes it inserted, which have no
+## pokegold opcode to resolve through.
+const CRYSTAL_ONLY_COMMAND_NAMES: Dictionary = {
+	0x9F: &"verbosegiveitemvar",
+	0xA4: &"battletowertext",
+	0xA5: &"getlandmarkname",
+	0xA6: &"gettrainerclassname",
+	0xA7: &"getname",
+	0xA8: &"wait",
+	0xA9: &"checksave",
+}
+
+## The commands past $55, on pokegold's numbering, which is what
+## [method source_opcode] normalizes both profiles onto.
+const LATER_COMMAND_NAMES: Dictionary = {
+	0x55: &"pokepic",
+	0x56: &"closepokepic",
+	0x57: &"2dmenu",
+	0x58: &"verticalmenu",
+	0x59: &"loadpikachudata",
+	0x5A: &"randomwildmon",
+	0x5B: &"loadtemptrainer",
+	0x5C: &"loadwildmon",
+	0x5D: &"loadtrainer",
+	0x5E: &"startbattle",
+	0x5F: &"reloadmapafterbattle",
+	0x60: &"catchtutorial",
+	0x61: &"trainertext",
+	0x62: &"trainerflagaction",
+	0x63: &"winlosstext",
+	0x64: &"scripttalkafter",
+	0x65: &"endifjustbattled",
+	0x66: &"checkjustbattled",
+	0x67: &"setlasttalked",
+	0x68: &"applymovement",
+	0x69: &"applymovementlasttalked",
+	0x6A: &"faceplayer",
+	0x6B: &"faceobject",
+	0x6C: &"variablesprite",
+	0x6D: &"disappear",
+	0x6E: &"appear",
+	0x6F: &"follow",
+	0x70: &"stopfollow",
+	0x71: &"moveobject",
+	0x72: &"writeobjectxy",
+	0x73: &"loademote",
+	0x74: &"showemote",
+	0x75: &"turnobject",
+	0x76: &"follownotexact",
+	0x77: &"earthquake",
+	0x78: &"changemapblocks",
+	0x79: &"changeblock",
+	0x7A: &"reloadmap",
+	0x7B: &"refreshmap",
+	0x7C: &"writecmdqueue",
+	0x7D: &"delcmdqueue",
+	0x7E: &"playmusic",
+	0x7F: &"encountermusic",
+	0x80: &"musicfadeout",
+	0x81: &"playmapmusic",
+	0x82: &"dontrestartmapmusic",
+	0x83: &"cry",
+	0x84: &"playsound",
+	0x85: &"waitsfx",
+	0x86: &"warpsound",
+	0x87: &"specialsound",
+	0x88: &"autoinput",
+	0x89: &"newloadmap",
+	0x8A: &"pause",
+	0x8B: &"deactivatefacing",
+	0x8C: &"sdefer",
+	0x8D: &"warpcheck",
+	0x8E: &"stopandsjump",
+	0x8F: &"endcallback",
+	0x90: &"end",
+	0x91: &"reloadend",
+	0x92: &"endall",
+	0x93: &"pokemart",
+	0x94: &"elevator",
+	0x95: &"trade",
+	0x96: &"askforphonenumber",
+	0x97: &"phonecall",
+	0x98: &"hangup",
+	0x99: &"describedecoration",
+	0x9A: &"fruittree",
+	0x9B: &"specialphonecall",
+	0x9C: &"checkphonecall",
+	0x9D: &"verbosegiveitem",
+	0x9E: &"swarm",
+	0x9F: &"halloffame",
+	0xA0: &"credits",
+	0xA1: &"warpfacing",
+}
+
+
 static func _later_command_name(opcode: int, crystal_commands: bool) -> StringName:
 	if opcode < 0x55:
 		return &""
@@ -380,94 +475,9 @@ static func _later_command_name(opcode: int, crystal_commands: bool) -> StringNa
 	## `command_at` read the next command's first byte as a species.
 	if crystal_commands and opcode == PROMPTBUTTON:
 		return &""
-	if crystal_commands:
-		match opcode:
-			0x9F: return &"verbosegiveitemvar"
-			0xA4: return &"battletowertext"
-			0xA5: return &"getlandmarkname"
-			0xA6: return &"gettrainerclassname"
-			0xA7: return &"getname"
-			0xA8: return &"wait"
-			0xA9: return &"checksave"
-	match source_opcode(opcode, crystal_commands):
-		0x55: return &"pokepic"
-		0x56: return &"closepokepic"
-		0x57: return &"2dmenu"
-		0x58: return &"verticalmenu"
-		0x59: return &"loadpikachudata"
-		0x5A: return &"randomwildmon"
-		0x5B: return &"loadtemptrainer"
-		0x5C: return &"loadwildmon"
-		0x5D: return &"loadtrainer"
-		0x5E: return &"startbattle"
-		0x5F: return &"reloadmapafterbattle"
-		0x60: return &"catchtutorial"
-		0x61: return &"trainertext"
-		0x62: return &"trainerflagaction"
-		0x63: return &"winlosstext"
-		0x64: return &"scripttalkafter"
-		0x65: return &"endifjustbattled"
-		0x66: return &"checkjustbattled"
-		0x67: return &"setlasttalked"
-		0x68: return &"applymovement"
-		0x69: return &"applymovementlasttalked"
-		0x6A: return &"faceplayer"
-		0x6B: return &"faceobject"
-		0x6C: return &"variablesprite"
-		0x6D: return &"disappear"
-		0x6E: return &"appear"
-		0x6F: return &"follow"
-		0x70: return &"stopfollow"
-		0x71: return &"moveobject"
-		0x72: return &"writeobjectxy"
-		0x73: return &"loademote"
-		0x74: return &"showemote"
-		0x75: return &"turnobject"
-		0x76: return &"follownotexact"
-		0x77: return &"earthquake"
-		0x78: return &"changemapblocks"
-		0x79: return &"changeblock"
-		0x7A: return &"reloadmap"
-		0x7B: return &"refreshmap"
-		0x7C: return &"writecmdqueue"
-		0x7D: return &"delcmdqueue"
-		0x7E: return &"playmusic"
-		0x7F: return &"encountermusic"
-		0x80: return &"musicfadeout"
-		0x81: return &"playmapmusic"
-		0x82: return &"dontrestartmapmusic"
-		0x83: return &"cry"
-		0x84: return &"playsound"
-		0x85: return &"waitsfx"
-		0x86: return &"warpsound"
-		0x87: return &"specialsound"
-		0x88: return &"autoinput"
-		0x89: return &"newloadmap"
-		0x8A: return &"pause"
-		0x8B: return &"deactivatefacing"
-		0x8C: return &"sdefer"
-		0x8D: return &"warpcheck"
-		0x8E: return &"stopandsjump"
-		0x8F: return &"endcallback"
-		0x90: return &"end"
-		0x91: return &"reloadend"
-		0x92: return &"endall"
-		0x93: return &"pokemart"
-		0x94: return &"elevator"
-		0x95: return &"trade"
-		0x96: return &"askforphonenumber"
-		0x97: return &"phonecall"
-		0x98: return &"hangup"
-		0x99: return &"describedecoration"
-		0x9A: return &"fruittree"
-		0x9B: return &"specialphonecall"
-		0x9C: return &"checkphonecall"
-		0x9D: return &"verbosegiveitem"
-		0x9E: return &"swarm"
-		0x9F: return &"halloffame"
-		0xA0: return &"credits"
-		0xA1: return &"warpfacing"
-	return &""
+	if crystal_commands and CRYSTAL_ONLY_COMMAND_NAMES.has(opcode):
+		return CRYSTAL_ONLY_COMMAND_NAMES[opcode]
+	return LATER_COMMAND_NAMES.get(source_opcode(opcode, crystal_commands), &"")
 
 
 ## Normalizes a raw command byte onto pokegold's numbering, which every width,
@@ -578,6 +588,172 @@ static func read_u16(data: PackedByteArray, offset: int) -> int:
 	return int(data[offset]) | (int(data[offset + 1]) << 8)
 
 
+## The three operand kinds, which are also their widths in bytes: `db`, `dw` and
+## the money commands' own three.
+const OPERAND_U8: int = 1
+const OPERAND_U16: int = 2
+const OPERAND_MONEY: int = 3
+
+## Each command's operands in the order the macro emits them, read from the byte
+## after the opcode. Keyed by the raw byte, for the commands both profiles share.
+const OPERANDS: Dictionary = {
+	SPECIAL: [["value", OPERAND_U16]],
+	IFEQUAL: [["value", OPERAND_U8], ["address", OPERAND_U16]],
+	IFNOTEQUAL: [["value", OPERAND_U8], ["address", OPERAND_U16]],
+	IFGREATER: [["value", OPERAND_U8], ["address", OPERAND_U16]],
+	IFLESS: [["value", OPERAND_U8], ["address", OPERAND_U16]],
+	LOADMEM: [["address", OPERAND_U16], ["value", OPERAND_U8]],
+	CHECKMAPSCENE: [["map_group", OPERAND_U8], ["map_number", OPERAND_U8]],
+	SETMAPSCENE: [
+		["map_group", OPERAND_U8],
+		["map_number", OPERAND_U8],
+		["scene", OPERAND_U8]
+	],
+	SETSCENE: [["scene", OPERAND_U8]],
+	SETVAL: [["value", OPERAND_U8]],
+	ADDVAL: [["value", OPERAND_U8]],
+	RANDOM: [["value", OPERAND_U8]],
+	READVAR: [["value", OPERAND_U8]],
+	WRITEVAR: [["value", OPERAND_U8]],
+	CHECKITEM: [["value", OPERAND_U8]],
+	ADDCELLNUM: [["value", OPERAND_U8]],
+	DELCELLNUM: [["value", OPERAND_U8]],
+	CHECKCELLNUM: [["value", OPERAND_U8]],
+	CHECKTIME: [["value", OPERAND_U8]],
+	CHECKPOKE: [["value", OPERAND_U8]],
+	GETNUM: [["value", OPERAND_U8]],
+	GETCURLANDMARKNAME: [["value", OPERAND_U8]],
+	REANCHORMAP: [["value", OPERAND_U8]],
+	WRITEUNUSEDBYTE: [["value", OPERAND_U8]],
+	LOADVAR: [["value", OPERAND_U8], ["value_2", OPERAND_U8]],
+	GIVEITEM: [["value", OPERAND_U8], ["value_2", OPERAND_U8]],
+	TAKEITEM: [["value", OPERAND_U8], ["value_2", OPERAND_U8]],
+	GIVEEGG: [["value", OPERAND_U8], ["value_2", OPERAND_U8]],
+	GIVEMONEY: [["account", OPERAND_U8], ["amount_bytes", OPERAND_MONEY]],
+	TAKEMONEY: [["account", OPERAND_U8], ["amount_bytes", OPERAND_MONEY]],
+	CHECKMONEY: [["account", OPERAND_U8], ["amount_bytes", OPERAND_MONEY]],
+	GETMONEY: [["account", OPERAND_U8], ["string_buffer", OPERAND_U8]],
+	GETMONNAME: [["pokemon", OPERAND_U8], ["string_buffer", OPERAND_U8]],
+	GETITEMNAME: [["item", OPERAND_U8], ["string_buffer", OPERAND_U8]],
+	GETTRAINERNAME: [
+		["trainer_group", OPERAND_U8],
+		["trainer_id", OPERAND_U8],
+		["string_buffer", OPERAND_U8]
+	],
+	GETSTRING: [["address", OPERAND_U16], ["string_buffer", OPERAND_U8]],
+	CLEAREVENT: [["flag", OPERAND_U16]],
+	SETEVENT: [["flag", OPERAND_U16]],
+	CHECKFLAG: [["flag", OPERAND_U16]],
+	CLEARFLAG: [["flag", OPERAND_U16]],
+	SETFLAG: [["flag", OPERAND_U16]],
+	CHECKEVENT: [["flag", OPERAND_U16]],
+	GIVECOINS: [["value", OPERAND_U16]],
+	TAKECOINS: [["value", OPERAND_U16]],
+	CHECKCOINS: [["value", OPERAND_U16]],
+	BLACKOUTMOD: [["map_group", OPERAND_U8], ["map_number", OPERAND_U8]],
+	WARPMOD: [
+		["warp_id", OPERAND_U8],
+		["map_group", OPERAND_U8],
+		["map_number", OPERAND_U8]
+	],
+	WARP: [
+		["map_group", OPERAND_U8],
+		["map_number", OPERAND_U8],
+		["x", OPERAND_U8],
+		["y", OPERAND_U8]
+	],
+	REPEATTEXT: [["value", OPERAND_U8], ["value_2", OPERAND_U8]],
+	GETCOINS: [["string_buffer", OPERAND_U8]],
+}
+
+## The rows Crystal reads differently: the four commands it inserted, which have
+## no pokegold opcode behind them, and `getcoins`, which takes a second buffer.
+## A row here is the whole answer, so nothing else is read.
+const CRYSTAL_OPERANDS: Dictionary = {
+	0x9F: [["item", OPERAND_U8], ["variable", OPERAND_U8]],
+	0xA0: [
+		["flag", OPERAND_U8], ["map_group", OPERAND_U8], ["map_number", OPERAND_U8]
+	],
+	0xA4: [["value", OPERAND_U8]],
+	0xA8: [["value", OPERAND_U8]],
+	GETCOINS: [["string_buffer", OPERAND_U8], ["string_buffer_2", OPERAND_U8]],
+}
+
+## The commands past the seam, on pokegold's numbering.
+const LATER_OPERANDS: Dictionary = {
+	0x55: [["pokemon", OPERAND_U8]],
+	0x5C: [["pokemon", OPERAND_U8], ["level", OPERAND_U8]],
+	0x5D: [["trainer_group", OPERAND_U8], ["trainer_id", OPERAND_U8]],
+	0x60: [["value", OPERAND_U8]],
+	0x61: [["value", OPERAND_U8]],
+	0x62: [["value", OPERAND_U8]],
+	0x63: [["win_address", OPERAND_U16], ["loss_address", OPERAND_U16]],
+	0x67: [["object_id", OPERAND_U8]],
+	0x68: [["object_id", OPERAND_U8], ["address", OPERAND_U16]],
+	0x69: [["address", OPERAND_U16]],
+	0x6B: [["object_id", OPERAND_U8], ["object_id_2", OPERAND_U8]],
+	0x6C: [["value", OPERAND_U8], ["value_2", OPERAND_U8]],
+	0x6D: [["object_id", OPERAND_U8]],
+	0x6E: [["object_id", OPERAND_U8]],
+	0x72: [["object_id", OPERAND_U8]],
+	0x6F: [["object_id", OPERAND_U8], ["object_id_2", OPERAND_U8]],
+	0x76: [["object_id", OPERAND_U8], ["object_id_2", OPERAND_U8]],
+	0x71: [["object_id", OPERAND_U8], ["x", OPERAND_U8], ["y", OPERAND_U8]],
+	0x74: [["value", OPERAND_U8], ["object_id", OPERAND_U8], ["value_2", OPERAND_U8]],
+	0x75: [["object_id", OPERAND_U8], ["facing", OPERAND_U8]],
+	0x77: [["value", OPERAND_U8]],
+	0x78: [["bank", OPERAND_U8], ["address", OPERAND_U16]],
+	0x88: [["bank", OPERAND_U8], ["address", OPERAND_U16]],
+	0x79: [["x", OPERAND_U8], ["y", OPERAND_U8], ["block", OPERAND_U8]],
+	0x7C: [["address", OPERAND_U16]],
+	0x7E: [["address", OPERAND_U16]],
+	0x8C: [["address", OPERAND_U16]],
+	0x8E: [["address", OPERAND_U16]],
+	0x94: [["address", OPERAND_U16]],
+	0x97: [["address", OPERAND_U16]],
+	0x9B: [["address", OPERAND_U16]],
+	0x7D: [["value", OPERAND_U8]],
+	0x89: [["value", OPERAND_U8]],
+	0x8A: [["value", OPERAND_U8]],
+	0x8B: [["value", OPERAND_U8]],
+	0x80: [["value", OPERAND_U16], ["value_2", OPERAND_U8]],
+	0x83: [["value", OPERAND_U16]],
+	0x84: [["value", OPERAND_U16]],
+	0x93: [["value", OPERAND_U8], ["address", OPERAND_U16]],
+	0x95: [["value", OPERAND_U8]],
+	0x96: [["value", OPERAND_U8]],
+	0x99: [["value", OPERAND_U8]],
+	0x9A: [["value", OPERAND_U8]],
+	0x9D: [["item", OPERAND_U8], ["quantity", OPERAND_U8]],
+	0x9E: [["map_group", OPERAND_U8], ["map_number", OPERAND_U8]],
+	0xA1: [
+		["facing", OPERAND_U8],
+		["map_group", OPERAND_U8],
+		["map_number", OPERAND_U8],
+		["x", OPERAND_U8],
+		["y", OPERAND_U8]
+	],
+}
+
+
+## One command's operands, in the order [constant OPERANDS] lists them.
+static func _read_operands(
+	command: Dictionary, data: PackedByteArray, offset: int, rows: Array
+) -> void:
+	var at: int = offset + 1
+	for row: Array in rows:
+		var kind: int = int(row[1])
+		if kind == OPERAND_U16:
+			command[String(row[0])] = read_u16(data, at)
+		elif kind == OPERAND_MONEY:
+			command[String(row[0])] = PackedByteArray([
+				int(data[at]), int(data[at + 1]), int(data[at + 2])
+			])
+		else:
+			command[String(row[0])] = int(data[at])
+		at += kind
+
+
 static func command_at(
 	data: PackedByteArray, offset: int, crystal_commands: bool = true
 ) -> Dictionary:
@@ -617,185 +793,22 @@ static func command_at(
 		or (crystal_commands and opcode == JUMPTEXT) \
 		or (not crystal_commands and opcode == FARJUMPTEXT):
 		command["address"] = read_u16(data, offset + 1)
-	elif opcode in [FARSCALL, FARSJUMP, FARWRITETEXT, CALLASM] \
+		return command
+	if opcode in [FARSCALL, FARSJUMP, FARWRITETEXT, CALLASM] \
 		or (crystal_commands and opcode == FARJUMPTEXT):
-			command["bank"] = int(data[offset + 1])
-			command["address"] = read_u16(data, offset + 2)
-	else:
-		match opcode:
-			SPECIAL:
-				command["value"] = read_u16(data, offset + 1)
-			IFEQUAL, IFNOTEQUAL, IFGREATER, IFLESS:
-				command["value"] = int(data[offset + 1])
-				command["address"] = read_u16(data, offset + 2)
-			LOADMEM:
-				## `dw address` then `db value`, the reverse of the compare
-				## commands that share its width.
-				command["address"] = read_u16(data, offset + 1)
-				command["value"] = int(data[offset + 3])
-			CHECKMAPSCENE:
-				command["map_group"] = int(data[offset + 1])
-				command["map_number"] = int(data[offset + 2])
-			SETMAPSCENE:
-				command["map_group"] = int(data[offset + 1])
-				command["map_number"] = int(data[offset + 2])
-				command["scene"] = int(data[offset + 3])
-			SETSCENE:
-				command["scene"] = int(data[offset + 1])
-			SETVAL, ADDVAL, RANDOM, READVAR, WRITEVAR, CHECKITEM, ADDCELLNUM, DELCELLNUM, CHECKCELLNUM, CHECKTIME, CHECKPOKE, GETNUM, GETCURLANDMARKNAME, REANCHORMAP, WRITEUNUSEDBYTE:
-				command["value"] = int(data[offset + 1])
-			LOADVAR, GIVEITEM, TAKEITEM, GIVEEGG:
-				command["value"] = int(data[offset + 1])
-				command["value_2"] = int(data[offset + 2])
-			GIVEMONEY, TAKEMONEY, CHECKMONEY:
-				command["account"] = int(data[offset + 1])
-				command["amount_bytes"] = PackedByteArray([
-					int(data[offset + 2]), int(data[offset + 3]), int(data[offset + 4])
-				])
-			GETMONEY:
-				command["account"] = int(data[offset + 1])
-				command["string_buffer"] = int(data[offset + 2])
-			GETCOINS:
-				command["string_buffer"] = int(data[offset + 1])
-				if crystal_commands:
-					command["string_buffer_2"] = int(data[offset + 2])
-			GETMONNAME:
-				command["pokemon"] = int(data[offset + 1])
-				command["string_buffer"] = int(data[offset + 2])
-			GETITEMNAME:
-				command["item"] = int(data[offset + 1])
-				command["string_buffer"] = int(data[offset + 2])
-			GETTRAINERNAME:
-				command["trainer_group"] = int(data[offset + 1])
-				command["trainer_id"] = int(data[offset + 2])
-				command["string_buffer"] = int(data[offset + 3])
-			GETSTRING:
-				command["address"] = read_u16(data, offset + 1)
-				command["string_buffer"] = int(data[offset + 3])
-			CLEAREVENT, SETEVENT, CHECKFLAG, CLEARFLAG, SETFLAG, CHECKEVENT:
-				command["flag"] = read_u16(data, offset + 1)
-			GIVECOINS, TAKECOINS, CHECKCOINS:
-				command["value"] = read_u16(data, offset + 1)
-			BLACKOUTMOD:
-				## `Script_blackoutmod` reads two script bytes into
-				## `wLastSpawnMapGroup` and `wLastSpawnMapNumber`, so its operand
-				## is a map rather than the number those two bytes spell.
-				command["map_group"] = int(data[offset + 1])
-				command["map_number"] = int(data[offset + 2])
-			WARPMOD:
-				command["warp_id"] = int(data[offset + 1])
-				command["map_group"] = int(data[offset + 2])
-				command["map_number"] = int(data[offset + 3])
-			WARP:
-				command["map_group"] = int(data[offset + 1])
-				command["map_number"] = int(data[offset + 2])
-				command["x"] = int(data[offset + 3])
-				command["y"] = int(data[offset + 4])
-			REPEATTEXT:
-				command["value"] = int(data[offset + 1])
-				command["value_2"] = int(data[offset + 2])
-			0x55:
-				if not crystal_commands:
-					command["pokemon"] = int(data[offset + 1])
-		if crystal_commands:
-			match opcode:
-				0x9F: # verbosegiveitemvar
-					command["item"] = int(data[offset + 1])
-					command["variable"] = int(data[offset + 2])
-					return command
-				0xA0: # swarm, which carries a flag byte pokegold's does not
-					command["flag"] = int(data[offset + 1])
-					command["map_group"] = int(data[offset + 2])
-					command["map_number"] = int(data[offset + 3])
-					return command
-				0xA4: # battletowertext, a BATTLETOWERTEXT_* index
-					command["value"] = int(data[offset + 1])
-					return command
-				0xA8: # wait, in units of six frames
-					command["value"] = int(data[offset + 1])
-					return command
-		var source: int = Gen2WorldScript.source_opcode(opcode, crystal_commands)
-		match source:
-			0x55:
-				## Crystal's own $55 is `promptbutton`, one byte and no species;
-				## only pokegold's $55 is `pokepic`. See `_later_command_name`.
-				if command["name"] == &"pokepic":
-					command["pokemon"] = int(data[offset + 1])
-			0x5C:
-				command["pokemon"] = int(data[offset + 1])
-				command["level"] = int(data[offset + 2])
-			0x5D:
-				command["trainer_group"] = int(data[offset + 1])
-				command["trainer_id"] = int(data[offset + 2])
-			0x60, 0x61, 0x62:
-				command["value"] = int(data[offset + 1])
-			0x63:
-				command["win_address"] = read_u16(data, offset + 1)
-				command["loss_address"] = read_u16(data, offset + 3)
-			0x67:
-				command["object_id"] = int(data[offset + 1])
-			0x68:
-				command["object_id"] = int(data[offset + 1])
-				command["address"] = read_u16(data, offset + 2)
-			0x69:
-				command["address"] = read_u16(data, offset + 1)
-			0x6B:
-				command["object_id"] = int(data[offset + 1])
-				command["object_id_2"] = int(data[offset + 2])
-			0x6C:
-				command["value"] = int(data[offset + 1])
-				command["value_2"] = int(data[offset + 2])
-			0x6D, 0x6E, 0x72:
-				command["object_id"] = int(data[offset + 1])
-			0x6F, 0x76:
-				command["object_id"] = int(data[offset + 1])
-				command["object_id_2"] = int(data[offset + 2])
-			0x71:
-				command["object_id"] = int(data[offset + 1])
-				command["x"] = int(data[offset + 2])
-				command["y"] = int(data[offset + 3])
-			0x74:
-				command["value"] = int(data[offset + 1])
-				command["object_id"] = int(data[offset + 2])
-				command["value_2"] = int(data[offset + 3])
-			0x75:
-				command["object_id"] = int(data[offset + 1])
-				command["facing"] = int(data[offset + 2])
-			0x77:
-				command["value"] = int(data[offset + 1])
-			0x78, 0x88:
-				command["bank"] = int(data[offset + 1])
-				command["address"] = read_u16(data, offset + 2)
-			0x79:
-				command["x"] = int(data[offset + 1])
-				command["y"] = int(data[offset + 2])
-				command["block"] = int(data[offset + 3])
-			0x7C, 0x7E, 0x8C, 0x8E, 0x94, 0x97, 0x9B:
-				command["address"] = read_u16(data, offset + 1)
-			0x7D, 0x89, 0x8A, 0x8B:
-				command["value"] = int(data[offset + 1])
-			0x80:
-				command["value"] = read_u16(data, offset + 1)
-				command["value_2"] = int(data[offset + 3])
-			0x83, 0x84:
-				command["value"] = read_u16(data, offset + 1)
-			0x93:
-				command["value"] = int(data[offset + 1])
-				command["address"] = read_u16(data, offset + 2)
-			0x95, 0x96, 0x99, 0x9A:
-				command["value"] = int(data[offset + 1])
-			0x9D:
-				command["item"] = int(data[offset + 1])
-				command["quantity"] = int(data[offset + 2])
-			0x9E:
-				command["map_group"] = int(data[offset + 1])
-				command["map_number"] = int(data[offset + 2])
-			0xA1:
-				command["facing"] = int(data[offset + 1])
-				command["map_group"] = int(data[offset + 2])
-				command["map_number"] = int(data[offset + 3])
-				command["x"] = int(data[offset + 4])
-				command["y"] = int(data[offset + 5])
+		command["bank"] = int(data[offset + 1])
+		command["address"] = read_u16(data, offset + 2)
+		return command
+	if crystal_commands and CRYSTAL_OPERANDS.has(opcode):
+		_read_operands(command, data, offset, CRYSTAL_OPERANDS[opcode])
+		return command
+	_read_operands(command, data, offset, OPERANDS.get(opcode, []))
+	var source: int = source_opcode(opcode, crystal_commands)
+	## Crystal's own $55 is `promptbutton`, one byte and no species; only
+	## pokegold's $55 is `pokepic`. See [method _later_command_name].
+	if source == 0x55 and command["name"] != &"pokepic":
+		return command
+	_read_operands(command, data, offset, LATER_OPERANDS.get(source, []))
 	return command
 
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1255,6 +1255,70 @@ func _stage_yes_or_no(tag: StringName, values: Dictionary) -> Dictionary:
 	return _waiting_result()
 
 
+## What answers each runtime request the host has finished, as the handler that
+## reads it. The key is the pending request's own kind.
+const COMPLETION_HANDLERS: Dictionary = {
+	&"catch_tutorial_requested": &"_complete_catch_tutorial",
+	&"swarm_requested": &"_complete_swarm",
+	&"phone_call_requested": &"_complete_phone_call",
+	&"special_phone_call_requested": &"_complete_phone_call",
+	&"mom_bank_dial_requested": &"_complete_mom_bank_dial",
+	&"party_selection_requested": &"_complete_party_selection",
+	&"apricorn_selection_requested": &"_complete_apricorn_selection",
+	&"elevator_requested": &"_complete_elevator",
+	&"trainer_approach_requested": &"_complete_trainer_approach",
+	&"day_care_requested": &"_complete_day_care",
+	&"slot_machine_requested": &"_complete_coin_game",
+	&"card_flip_requested": &"_complete_coin_game",
+	&"mart_requested": &"_complete_plain_request",
+	&"audio_requested": &"_complete_plain_request",
+	&"pokemon_requested": &"_complete_plain_request",
+	&"trade_requested": &"_complete_plain_request",
+	&"pc_requested": &"_complete_plain_request",
+	&"party_heal_requested": &"_complete_plain_request",
+	&"town_map_requested": &"_complete_plain_request",
+	## `BugContestJudging` answers with the placing, which the results script
+	## reads out of wScriptVar exactly as the marts and the PC do.
+	&"bug_contest_judging_requested": &"_complete_plain_request",
+	## Neither routine writes anything a script reads: each returns and the
+	## map's own `waitbutton` presses the text it left standing.
+	&"name_rater_requested": &"_complete_plain_request",
+	&"move_deleter_requested": &"_complete_plain_request",
+	## `MoveTutor` answers FALSE when the move was learned and -1 when the
+	## list was backed out of, which is the one branch its script reads.
+	&"move_tutor_requested": &"_complete_plain_request",
+	## `UnownPuzzle` answers `wSolvedUnownPuzzle`, which is zero for a board
+	## left on START and one for a solved one.
+	&"unown_puzzle_requested": &"_complete_plain_request",
+	## `CheckPartyFullAfterContest`'s own three answers, which
+	## `BugContestResults_DidNotLeaveMons` branches on twice.
+	&"contest_mon_requested": &"_complete_plain_request",
+	## `PlayRadio` holds until A or B and writes nothing; the station it
+	## opened is the request's own.
+	&"map_radio_requested": &"_complete_plain_request",
+	## `NewPokedexEntry` behind `GameCornerPrizeMonCheckDex`'s dex writes,
+	## which are staged here rather than in the screen.
+	&"pokedex_entry_requested": &"_complete_plain_request",
+	## `GiveDratini` rewrites four move slots and answers nothing: every one
+	## of its scripts runs straight on.
+	&"dratini_moveset_requested": &"_complete_plain_request",
+	## `_Diploma`, `_PrintDiploma` and `_UnownPrinter` write nothing either:
+	## the page stands until a button and the script runs on behind it.
+	&"diploma_requested": &"_complete_plain_request",
+	&"unown_printer_requested": &"_complete_plain_request",
+	## `TryQuickSave` answers TRUE for a save that was written and FALSE for
+	## one that was not, which is the branch both of its sites read.
+	&"quick_save_requested": &"_complete_plain_request",
+	## `_DisplayLinkRecord` draws one page and holds for a button, and the
+	## three link rooms' own consoles run their exchange and come back to a
+	## `newloadmap`. Neither writes anything the script reads.
+	&"link_record_requested": &"_complete_plain_request",
+	&"link_room_requested": &"_complete_plain_request",
+	&"rival_name_requested": &"_complete_rival_name",
+	&"battle_requested": &"_complete_battle",
+}
+
+
 ## Completes a host-owned runtime request without treating a button press as its
 ## result. A confirmed loss ends this invocation through the explicit blackout
 ## recovery result without committing its staged world state.
@@ -1266,315 +1330,332 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 		}
 	var request: Dictionary = _pending.get("request", {})
 	var kind: StringName = StringName(request.get("kind", &""))
-	if kind == &"catch_tutorial_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"catch_tutorial_failed")), result
-			)
-		var catch_outcome: StringName = StringName(result.get("outcome", &""))
-		if catch_outcome != Gen2WorldBattleAdapter.OUTCOME_CAUGHT:
-			return _fail(&"invalid_catch_tutorial_outcome", result)
-		_script_value = 1
-		_events.append({
-			"type": &"catch_tutorial_completed",
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_events.append({"type": &"battle_map_reload_requested", "tutorial": true})
-		_pending = {}
-		return advance()
-	if kind == &"swarm_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"swarm_request_failed")), result
-			)
-		var values: Dictionary = request.get("values", {})
-		var active: bool = bool(result.get("active", true))
-		var map_group: int = int(result.get("map_group", values.get("map_group", -1)))
-		var map_number: int = int(result.get("map_number", values.get("map_number", -1)))
-		var fishing_species: int = int(result.get("fishing_species", 0))
-		var swarm_kind: int = int(
-			result.get("kind", values.get("kind", Gen2WorldState.SWARM_DUNSPARCE))
-		)
-		if active and (map_group < 0 or map_number < 0):
-			return _fail(&"invalid_swarm_map", result)
-		if fishing_species not in [0, 0xD3, 0xDF]:
-			return _fail(&"invalid_fishing_swarm_species", result)
-		if swarm_kind not in [Gen2WorldState.SWARM_DUNSPARCE, Gen2WorldState.SWARM_YANMA]:
-			return _fail(&"invalid_swarm_kind", result)
-		_staged_swarm = {
-			"active": active,
-			"kind": swarm_kind,
-			"map_group": map_group,
-			"map_number": map_number,
-			"fishing_species": fishing_species,
-		}
-		_has_staged_swarm = true
-		_events.append({
-			"type": &"swarm_changed",
-			"kind": swarm_kind,
-			"map_group": map_group,
-			"map_number": map_number,
-			"active": active,
-			"fishing_species": fishing_species,
-		})
-		_pending = {}
-		return advance()
-	if kind in [&"phone_call_requested", &"special_phone_call_requested"]:
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", "runtime_request_failed")), result
-			)
-		var phone_data: Dictionary = result.get("data", {})
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		if bool(phone_data.get("clear", false)):
-			_phone_context = {}
-			_script_value = 1
-			return advance()
-		var phone_script: Dictionary = phone_data.get("script", {})
-		if phone_script.is_empty():
-			_script_value = int(result.get("script_value", 1))
-			return advance()
-		_phone_context = phone_data.get("phone", {}).duplicate(true)
-		_phone_started = false
-		if not _push_frame(
-			int(phone_script.get("bank", -1)), int(phone_script.get("address", -1))
-		):
-			return _fail(&"phone_script_missing", phone_script)
-		return advance()
-	if kind == &"mom_bank_dial_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"mom_bank_dial_failed")), result
-			)
-		var dial_mode: StringName = StringName(
-			(request.get("values", {}) as Dictionary).get("mode", MOM_DIAL_DEPOSIT)
-		)
-		## A cancelled box answers -1, which is `.CancelDeposit`'s own zero
-		## amount one step earlier.
-		var dial_amount: int = int(result.get("amount", -1))
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		return _mom_result(_finish_mom_bank_dial(dial_mode, maxi(dial_amount, 0)))
-	if kind == &"party_selection_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"party_selection_failed")), result
-			)
-		return _finish_party_selection(request, result)
-	if kind == &"apricorn_selection_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"apricorn_selection_failed")), result
-			)
-		var apricorn: int = int(result.get("item", 0))
-		var apricorn_quantity: int = int(result.get("quantity", 0))
-		if apricorn != 0 and not Gen2WorldApricorn.is_apricorn(apricorn):
-			return _fail(&"invalid_apricorn", result)
-		## `SelectApricornForKurt` zeroes wKurtApricornQuantity on entry and
-		## writes it only past `Kurt_SelectQuantity`'s carry, so a cancelled
-		## selection leaves both bytes at zero.
-		if apricorn == 0:
-			apricorn_quantity = 0
-		elif apricorn_quantity < 1 or apricorn_quantity > Gen2WorldApricorn.MAX_QUANTITY:
-			return _fail(&"invalid_apricorn_quantity", result)
-		_script_value = apricorn
-		_staged_kurt_apricorn_quantity = apricorn_quantity
-		_has_staged_kurt_apricorn_quantity = true
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		return advance()
-	if kind == &"elevator_requested":
-		## `Script_elevator` zeroes `wScriptVar` before the call and writes TRUE
-		## only past `ret c`, so a cancelled ride and a car with no floor to
-		## match both leave the script's own FALSE branch standing.
-		if not bool(result.get("ok", false)):
-			return _fail(StringName(result.get("reason", &"elevator_failed")), result)
-		var rode: bool = result.has("floor") and result["floor"] is Dictionary
-		if rode:
-			## `Elevator_GoToFloor` copies the chosen row's last three bytes
-			## straight over `wBackupWarpNumber`, and the -1 warp out of the car
-			## is what spends them.
-			var floor_row: Dictionary = result["floor"]
-			_emit_runtime_event(&"backup_warp_changed", {
-				"warp": int(floor_row.get("warp", 0)),
-				"map_group": int(floor_row.get("map_group", 0)),
-				"map_number": int(floor_row.get("map_number", 0)),
-			})
-		_script_value = 1 if rode else 0
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		return advance()
-	if kind == &"trainer_approach_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"trainer_approach_failed")), result
-			)
-		_events.append({
-			"type": &"trainer_approach_completed",
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		return advance()
-	if kind == &"day_care_requested":
-		## Four of the five write nothing a script reads, so wScriptVar is left
-		## where it stood unless the result carries one: `DayCareManOutside` is
-		## the only routine of the five with an `ld [wScriptVar], a` in it.
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"runtime_request_failed")), result
-			)
-		if result.has("script_value"):
-			_script_value = int(result["script_value"])
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		return advance()
-	if kind == &"slot_machine_requested" or kind == &"card_flip_requested":
-		## `_SlotMachine` and `_CardFlip` both write `wCoins` themselves, over
-		## and over, so what comes back is the balance rather than a delta.
-		## Nothing reads `wScriptVar` after either: every map `closetext` and
-		## `end`.
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"slot_machine_failed")), result
-			)
-		var slot_coins: int = int(result.get("coins", _coins_value()))
-		if slot_coins < 0 or slot_coins > Gen2SlotMachine.MAX_COINS:
-			return _fail(&"invalid_coins", result)
-		_staged_coins = slot_coins
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		_pending = {}
-		return advance()
-	if kind in [
-		&"mart_requested", &"audio_requested", &"pokemon_requested", &"trade_requested",
-		&"pc_requested", &"party_heal_requested", &"town_map_requested",
-		## `BugContestJudging` answers with the placing, which the results script
-		## reads out of wScriptVar exactly as the marts and the PC do.
-		&"bug_contest_judging_requested",
-		## Neither routine writes anything a script reads: each returns and the
-		## map's own `waitbutton` presses the text it left standing.
-		&"name_rater_requested", &"move_deleter_requested",
-		## `MoveTutor` answers FALSE when the move was learned and -1 when the
-		## list was backed out of, which is the one branch its script reads.
-		&"move_tutor_requested",
-		## `UnownPuzzle` answers `wSolvedUnownPuzzle`, which is zero for a board
-		## left on START and one for a solved one.
-		&"unown_puzzle_requested",
-		## `CheckPartyFullAfterContest`'s own three answers, which
-		## `BugContestResults_DidNotLeaveMons` branches on twice.
-		&"contest_mon_requested",
-		## `PlayRadio` holds until A or B and writes nothing; the station it
-		## opened is the request's own.
-		&"map_radio_requested",
-		## `NewPokedexEntry` behind `GameCornerPrizeMonCheckDex`'s dex writes,
-		## which are staged here rather than in the screen.
-		&"pokedex_entry_requested",
-		## `GiveDratini` rewrites four move slots and answers nothing: every one
-		## of its scripts runs straight on.
-		&"dratini_moveset_requested",
-		## `_Diploma`, `_PrintDiploma` and `_UnownPrinter` write nothing either:
-		## the page stands until a button and the script runs on behind it.
-		&"diploma_requested", &"unown_printer_requested",
-		## `TryQuickSave` answers TRUE for a save that was written and FALSE for
-		## one that was not, which is the branch both of its sites read.
-		&"quick_save_requested",
-		## `_DisplayLinkRecord` draws one page and holds for a button, and the
-		## three link rooms' own consoles run their exchange and come back to a
-		## `newloadmap`. Neither writes anything the script reads.
-		&"link_record_requested", &"link_room_requested",
-	]:
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", "runtime_request_failed")), result
-			)
-		_script_value = int(result.get("script_value", 1))
-		_events.append({
-			"type": &"runtime_request_completed",
-			"kind": kind,
-			"request": request.duplicate(true),
-			"result": result.duplicate(true),
-		})
-		var approach_after_audio: bool = kind == &"audio_requested" \
-			and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
-			== &"encounter_music" and _trainer_intro_approach_pending
-		var smash_after_sound: bool = kind == &"audio_requested" \
-			and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
-			== &"sound" and _rock_smash_after_sound
-		var notify_after_sound: Dictionary = _item_notify_after_sound \
-			if kind == &"audio_requested" else {}
-		var mom_after_sound: int = _bank_of_mom_after_sound \
-			if kind == &"audio_requested" else -1
-		_pending = {}
-		if mom_after_sound >= 0:
-			_bank_of_mom_after_sound = -1
-			var receipt: String = _mom_receipt_box
-			_mom_receipt_box = ""
-			return _mom_result(_mom_box(receipt, mom_after_sound))
-		if approach_after_audio:
-			_trainer_intro_approach_pending = false
-			_stage_trainer_approach()
-		if smash_after_sound:
-			_rock_smash_after_sound = false
-			_stage_rock_smashed()
-		if not notify_after_sound.is_empty():
-			_item_notify_after_sound = {}
-			_stage_item_notify(
-				int(notify_after_sound.get("item", 0)),
-				bool(notify_after_sound.get("finish", false))
-			)
-		return advance()
-	if kind == &"rival_name_requested":
-		if not bool(result.get("ok", false)):
-			return _fail(
-				StringName(result.get("reason", &"runtime_request_failed")), result
-			)
-		var default_name: String = String(
-			(request.get("values", {}) as Dictionary).get("default_name", "SILVER")
-		)
-		_rival_name = String(result.get("name", default_name)).strip_edges()
-		if _rival_name.is_empty():
-			_rival_name = default_name
-		_script_value = 1
-		_events.append({"type": &"rival_name_changed", "name": _rival_name})
-		_pending = {}
-		return advance()
-	if kind != &"battle_requested":
+	if not COMPLETION_HANDLERS.has(kind):
 		return {
 			"ok": false, "status": &"failed", "reason": &"runtime_request_kind_mismatch",
 			"details": {"kind": kind},
 		}
+	return call(COMPLETION_HANDLERS[kind], kind, request, result)
+
+
+func _complete_catch_tutorial(
+	_kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"catch_tutorial_failed")), result
+		)
+	var catch_outcome: StringName = StringName(result.get("outcome", &""))
+	if catch_outcome != Gen2WorldBattleAdapter.OUTCOME_CAUGHT:
+		return _fail(&"invalid_catch_tutorial_outcome", result)
+	_script_value = 1
+	_events.append({
+		"type": &"catch_tutorial_completed",
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_events.append({"type": &"battle_map_reload_requested", "tutorial": true})
+	_pending = {}
+	return advance()
+
+
+func _complete_swarm(
+	_kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"swarm_request_failed")), result
+		)
+	var values: Dictionary = request.get("values", {})
+	var active: bool = bool(result.get("active", true))
+	var map_group: int = int(result.get("map_group", values.get("map_group", -1)))
+	var map_number: int = int(result.get("map_number", values.get("map_number", -1)))
+	var fishing_species: int = int(result.get("fishing_species", 0))
+	var swarm_kind: int = int(
+		result.get("kind", values.get("kind", Gen2WorldState.SWARM_DUNSPARCE))
+	)
+	if active and (map_group < 0 or map_number < 0):
+		return _fail(&"invalid_swarm_map", result)
+	if fishing_species not in [0, 0xD3, 0xDF]:
+		return _fail(&"invalid_fishing_swarm_species", result)
+	if swarm_kind not in [Gen2WorldState.SWARM_DUNSPARCE, Gen2WorldState.SWARM_YANMA]:
+		return _fail(&"invalid_swarm_kind", result)
+	_staged_swarm = {
+		"active": active,
+		"kind": swarm_kind,
+		"map_group": map_group,
+		"map_number": map_number,
+		"fishing_species": fishing_species,
+	}
+	_has_staged_swarm = true
+	_events.append({
+		"type": &"swarm_changed",
+		"kind": swarm_kind,
+		"map_group": map_group,
+		"map_number": map_number,
+		"active": active,
+		"fishing_species": fishing_species,
+	})
+	_pending = {}
+	return advance()
+
+
+func _complete_phone_call(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", "runtime_request_failed")), result
+		)
+	var phone_data: Dictionary = result.get("data", {})
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	if bool(phone_data.get("clear", false)):
+		_phone_context = {}
+		_script_value = 1
+		return advance()
+	var phone_script: Dictionary = phone_data.get("script", {})
+	if phone_script.is_empty():
+		_script_value = int(result.get("script_value", 1))
+		return advance()
+	_phone_context = phone_data.get("phone", {}).duplicate(true)
+	_phone_started = false
+	if not _push_frame(
+		int(phone_script.get("bank", -1)), int(phone_script.get("address", -1))
+	):
+		return _fail(&"phone_script_missing", phone_script)
+	return advance()
+
+
+func _complete_mom_bank_dial(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"mom_bank_dial_failed")), result
+		)
+	var dial_mode: StringName = StringName(
+		(request.get("values", {}) as Dictionary).get("mode", MOM_DIAL_DEPOSIT)
+	)
+	## A cancelled box answers -1, which is `.CancelDeposit`'s own zero
+	## amount one step earlier.
+	var dial_amount: int = int(result.get("amount", -1))
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	return _mom_result(_finish_mom_bank_dial(dial_mode, maxi(dial_amount, 0)))
+
+
+func _complete_party_selection(
+	_kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"party_selection_failed")), result
+		)
+	return _finish_party_selection(request, result)
+
+
+func _complete_apricorn_selection(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"apricorn_selection_failed")), result
+		)
+	var apricorn: int = int(result.get("item", 0))
+	var apricorn_quantity: int = int(result.get("quantity", 0))
+	if apricorn != 0 and not Gen2WorldApricorn.is_apricorn(apricorn):
+		return _fail(&"invalid_apricorn", result)
+	## `SelectApricornForKurt` zeroes wKurtApricornQuantity on entry and
+	## writes it only past `Kurt_SelectQuantity`'s carry, so a cancelled
+	## selection leaves both bytes at zero.
+	if apricorn == 0:
+		apricorn_quantity = 0
+	elif apricorn_quantity < 1 or apricorn_quantity > Gen2WorldApricorn.MAX_QUANTITY:
+		return _fail(&"invalid_apricorn_quantity", result)
+	_script_value = apricorn
+	_staged_kurt_apricorn_quantity = apricorn_quantity
+	_has_staged_kurt_apricorn_quantity = true
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	return advance()
+
+
+func _complete_elevator(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	## `Script_elevator` zeroes `wScriptVar` before the call and writes TRUE
+	## only past `ret c`, so a cancelled ride and a car with no floor to
+	## match both leave the script's own FALSE branch standing.
+	if not bool(result.get("ok", false)):
+		return _fail(StringName(result.get("reason", &"elevator_failed")), result)
+	var rode: bool = result.has("floor") and result["floor"] is Dictionary
+	if rode:
+		## `Elevator_GoToFloor` copies the chosen row's last three bytes
+		## straight over `wBackupWarpNumber`, and the -1 warp out of the car
+		## is what spends them.
+		var floor_row: Dictionary = result["floor"]
+		_emit_runtime_event(&"backup_warp_changed", {
+			"warp": int(floor_row.get("warp", 0)),
+			"map_group": int(floor_row.get("map_group", 0)),
+			"map_number": int(floor_row.get("map_number", 0)),
+		})
+	_script_value = 1 if rode else 0
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	return advance()
+
+
+func _complete_trainer_approach(
+	_kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"trainer_approach_failed")), result
+		)
+	_events.append({
+		"type": &"trainer_approach_completed",
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	return advance()
+
+
+func _complete_day_care(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	## Four of the five write nothing a script reads, so wScriptVar is left
+	## where it stood unless the result carries one: `DayCareManOutside` is
+	## the only routine of the five with an `ld [wScriptVar], a` in it.
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"runtime_request_failed")), result
+		)
+	if result.has("script_value"):
+		_script_value = int(result["script_value"])
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	return advance()
+
+
+func _complete_coin_game(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	## `_SlotMachine` and `_CardFlip` both write `wCoins` themselves, over
+	## and over, so what comes back is the balance rather than a delta.
+	## Nothing reads `wScriptVar` after either: every map `closetext` and
+	## `end`.
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"slot_machine_failed")), result
+		)
+	var slot_coins: int = int(result.get("coins", _coins_value()))
+	if slot_coins < 0 or slot_coins > Gen2SlotMachine.MAX_COINS:
+		return _fail(&"invalid_coins", result)
+	_staged_coins = slot_coins
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	_pending = {}
+	return advance()
+
+
+func _complete_plain_request(
+	kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", "runtime_request_failed")), result
+		)
+	_script_value = int(result.get("script_value", 1))
+	_events.append({
+		"type": &"runtime_request_completed",
+		"kind": kind,
+		"request": request.duplicate(true),
+		"result": result.duplicate(true),
+	})
+	var approach_after_audio: bool = kind == &"audio_requested" \
+		and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
+		== &"encounter_music" and _trainer_intro_approach_pending
+	var smash_after_sound: bool = kind == &"audio_requested" \
+		and StringName((request.get("values", {}) as Dictionary).get("kind", &"")) \
+		== &"sound" and _rock_smash_after_sound
+	var notify_after_sound: Dictionary = _item_notify_after_sound \
+		if kind == &"audio_requested" else {}
+	var mom_after_sound: int = _bank_of_mom_after_sound \
+		if kind == &"audio_requested" else -1
+	_pending = {}
+	if mom_after_sound >= 0:
+		_bank_of_mom_after_sound = -1
+		var receipt: String = _mom_receipt_box
+		_mom_receipt_box = ""
+		return _mom_result(_mom_box(receipt, mom_after_sound))
+	if approach_after_audio:
+		_trainer_intro_approach_pending = false
+		_stage_trainer_approach()
+	if smash_after_sound:
+		_rock_smash_after_sound = false
+		_stage_rock_smashed()
+	if not notify_after_sound.is_empty():
+		_item_notify_after_sound = {}
+		_stage_item_notify(
+			int(notify_after_sound.get("item", 0)),
+			bool(notify_after_sound.get("finish", false))
+		)
+	return advance()
+
+
+func _complete_rival_name(
+	_kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
+	if not bool(result.get("ok", false)):
+		return _fail(
+			StringName(result.get("reason", &"runtime_request_failed")), result
+		)
+	var default_name: String = String(
+		(request.get("values", {}) as Dictionary).get("default_name", "SILVER")
+	)
+	_rival_name = String(result.get("name", default_name)).strip_edges()
+	if _rival_name.is_empty():
+		_rival_name = default_name
+	_script_value = 1
+	_events.append({"type": &"rival_name_changed", "name": _rival_name})
+	_pending = {}
+	return advance()
+
+
+func _complete_battle(
+	_kind: StringName, request: Dictionary, result: Dictionary
+) -> Dictionary:
 	if not bool(result.get("ok", false)):
 		return _fail(
 			StringName(result.get("reason", &"runtime_request_failed")), result
@@ -1696,8 +1777,6 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 	})
 	_pending = {}
 	return advance()
-
-
 func pending_runtime_request() -> Dictionary:
 	if _pending.get("type", &"") != &"runtime_request":
 		return {}
@@ -1789,10 +1868,131 @@ func is_finished() -> bool:
 	return _completed or not _failure.is_empty()
 
 
+## Every script command this runner runs, as the handler that runs it.
+const COMMAND_HANDLERS: Dictionary = {
+	Gen2WorldScript.SCALL: &"_command_scall",
+	Gen2WorldScript.FARSCALL: &"_command_farscall",
+	Gen2WorldScript.MEMCALL: &"_command_memcall",
+	Gen2WorldScript.MEMJUMP: &"_command_memcall",
+	Gen2WorldScript.WARPMOD: &"_command_warpmod",
+	Gen2WorldScript.BLACKOUTMOD: &"_command_blackoutmod",
+	Gen2WorldScript.SJUMP: &"_command_sjump",
+	Gen2WorldScript.FARSJUMP: &"_command_farsjump",
+	Gen2WorldScript.IFEQUAL: &"_command_ifequal",
+	Gen2WorldScript.IFNOTEQUAL: &"_command_ifnotequal",
+	Gen2WorldScript.IFFALSE: &"_command_iffalse",
+	Gen2WorldScript.IFTRUE: &"_command_iftrue",
+	Gen2WorldScript.IFGREATER: &"_command_ifgreater",
+	Gen2WorldScript.IFLESS: &"_command_ifless",
+	Gen2WorldScript.JUMPSTD: &"_command_jumpstd",
+	Gen2WorldScript.CALLSTD: &"_command_callstd",
+	Gen2WorldScript.CHECKMAPSCENE: &"_command_checkmapscene",
+	Gen2WorldScript.SETMAPSCENE: &"_command_setmapscene",
+	Gen2WorldScript.CHECKSCENE: &"_command_checkscene",
+	Gen2WorldScript.SETSCENE: &"_command_setscene",
+	Gen2WorldScript.CHECKVER: &"_command_checkver",
+	Gen2WorldScript.SETVAL: &"_command_setval",
+	Gen2WorldScript.ADDVAL: &"_command_addval",
+	Gen2WorldScript.READMEM: &"_command_readmem",
+	Gen2WorldScript.WRITEMEM: &"_command_writemem",
+	Gen2WorldScript.LOADMEM: &"_command_loadmem",
+	Gen2WorldScript.READVAR: &"_command_readvar",
+	Gen2WorldScript.WRITEVAR: &"_command_writevar",
+	Gen2WorldScript.LOADVAR: &"_command_loadvar",
+	Gen2WorldScript.CHECKTIME: &"_command_checktime",
+	Gen2WorldScript.ADDCELLNUM: &"_command_addcellnum",
+	Gen2WorldScript.DELCELLNUM: &"_command_delcellnum",
+	Gen2WorldScript.CHECKCELLNUM: &"_command_checkcellnum",
+	Gen2WorldScript.SPECIAL: &"_command_special",
+	Gen2WorldScript.RANDOM: &"_command_random",
+	Gen2WorldScript.GIVEITEM: &"_command_giveitem",
+	Gen2WorldScript.TAKEITEM: &"_command_takeitem",
+	Gen2WorldScript.CHECKITEM: &"_command_checkitem",
+	Gen2WorldScript.GIVEMONEY: &"_command_givemoney",
+	Gen2WorldScript.TAKEMONEY: &"_command_givemoney",
+	Gen2WorldScript.CHECKMONEY: &"_command_checkmoney",
+	Gen2WorldScript.GIVECOINS: &"_command_givecoins",
+	Gen2WorldScript.TAKECOINS: &"_command_givecoins",
+	Gen2WorldScript.CHECKCOINS: &"_command_checkcoins",
+	Gen2WorldScript.GETMONEY: &"_command_getmoney",
+	Gen2WorldScript.GETCOINS: &"_command_getcoins",
+	Gen2WorldScript.GETITEMNAME: &"_command_getitemname",
+	Gen2WorldScript.GETMONNAME: &"_command_getmonname",
+	Gen2WorldScript.GETTRAINERNAME: &"_command_gettrainername",
+	Gen2WorldScript.GETSTRING: &"_command_getstring",
+	Gen2WorldScript.CLEAREVENT: &"_command_clearevent",
+	Gen2WorldScript.SETEVENT: &"_command_setevent",
+	Gen2WorldScript.CHECKEVENT: &"_command_checkevent",
+	Gen2WorldScript.CLEARFLAG: &"_command_clearflag",
+	Gen2WorldScript.SETFLAG: &"_command_setflag",
+	Gen2WorldScript.CHECKFLAG: &"_command_checkflag",
+	Gen2WorldScript.WILDON: &"_command_wildon",
+	Gen2WorldScript.WILDOFF: &"_command_wildoff",
+	Gen2WorldScript.WARP: &"_command_warp",
+	Gen2WorldScript.OPENTEXT: &"_command_opentext",
+	Gen2WorldScript.REANCHORMAP: &"_command_opentext",
+	Gen2WorldScript.CLOSETEXT: &"_command_opentext",
+	Gen2WorldScript.WRITEUNUSEDBYTE: &"_command_opentext",
+	Gen2WorldScript.CLOSEWINDOW: &"_command_opentext",
+	Gen2WorldScript.ITEMNOTIFY: &"_command_itemnotify",
+	Gen2WorldScript.POCKETISFULL: &"_command_pocketisfull",
+	Gen2WorldScript.WRITETEXT: &"_command_writetext",
+	Gen2WorldScript.FARWRITETEXT: &"_command_farwritetext",
+	Gen2WorldScript.JUMPTEXTFACEPLAYER: &"_command_jumptextfaceplayer",
+	Gen2WorldScript.REPEATTEXT: &"_command_repeattext",
+	Gen2WorldScript.YESORNO: &"_command_yesorno",
+	Gen2WorldScript.LOADMENU: &"_command_loadmenu",
+	Gen2WorldScript.CHECKPOKE: &"_command_checkpoke",
+	Gen2WorldScript.GIVEPOKE: &"_command_givepoke",
+	Gen2WorldScript.GIVEEGG: &"_command_givepoke",
+	Gen2WorldScript.GIVEPOKEMAIL: &"_command_givepokemail",
+	Gen2WorldScript.CHECKPOKEMAIL: &"_command_checkpokemail",
+	Gen2WorldScript.GOLD_FACEPLAYER: &"_command_gold_faceplayer",
+	Gen2WorldScript.FACEPLAYER: &"_command_gold_faceplayer",
+}
+
+## The two commands with nothing behind them yet: `getnum` reads a number into
+## a text buffer and `getcurlandmarkname` the landmark the player stands on, and
+## no script in either pin prints what they leave.
+const HANDLED_BASE: Array[int] = [
+	Gen2WorldScript.GETNUM, Gen2WorldScript.GETCURLANDMARKNAME,
+]
+
+
 func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 	var opcode: int = int(command["opcode"])
 	var bank: int = int(frame["bank"])
 	command = _catalogued(command, frame)
+	var early: Dictionary = _execute_early_command(opcode, command, bank)
+	if not early.is_empty():
+		return early
+	var source: int = Gen2WorldScript.source_opcode(opcode, _crystal_commands())
+	var object_result: Dictionary = _execute_object_command(source, command)
+	if not object_result.is_empty():
+		return object_result
+	var later_result: Dictionary = _execute_later_command(source, command, bank)
+	if not later_result.is_empty():
+		return later_result
+	if Gen2WorldScript.is_terminal(opcode, _crystal_commands()):
+		_frames.pop_back()
+		if _frames.is_empty():
+			return _complete()
+		return {"ok": true}
+	if COMMAND_HANDLERS.has(opcode):
+		return call(COMMAND_HANDLERS[opcode], opcode, command, bank)
+	if opcode in HANDLED_BASE:
+		return {"ok": true}
+	return {
+		"ok": false,
+		"reason": &"unsupported_runtime_command",
+		"command": command,
+	}
+
+
+## The commands that answer before the opcode is normalized: two text jumps whose
+## bank depends on the profile, the two button pauses, and the two raw bytes
+## Crystal added over pokegold commands. Empty when the command is not one of them.
+func _execute_early_command(opcode: int, command: Dictionary, bank: int) -> Dictionary:
 	if opcode == Gen2WorldScript.FARJUMPTEXT:
 		if _crystal_commands():
 			return _show_text(int(command["bank"]), int(command["address"]), true)
@@ -1831,387 +2031,504 @@ func _execute(command: Dictionary, frame: Dictionary) -> Dictionary:
 		if not bool(variable_given.get("ok", true)):
 			return variable_given
 		return _stage_give_item_script(variable_item, variable_name)
-	var source: int = Gen2WorldScript.source_opcode(opcode, _crystal_commands())
-	var object_result: Dictionary = _execute_object_command(source, command)
-	if not object_result.is_empty():
-		return object_result
-	var later_result: Dictionary = _execute_later_command(source, command, bank)
-	if not later_result.is_empty():
-		return later_result
-	if Gen2WorldScript.is_terminal(opcode, _crystal_commands()):
-		_frames.pop_back()
-		if _frames.is_empty():
-			return _complete()
-		return {"ok": true}
-	match opcode:
-		Gen2WorldScript.SCALL:
-			return {"ok": _push_frame(bank, int(command["address"]))}
-		Gen2WorldScript.FARSCALL:
-			return {"ok": _push_frame(int(command["bank"]), int(command["address"]))}
-		Gen2WorldScript.MEMCALL, Gen2WorldScript.MEMJUMP:
-			var runtime_pointer: Dictionary = _runtime_memory_pointer(
-				int(command.get("address", 0))
-			)
-			if runtime_pointer.is_empty():
-				return {
-					"ok": false, "reason": &"missing_runtime_pointer",
-					"address": int(command.get("address", 0)), "command": command,
-				}
-			var pointer_bank: int = int(runtime_pointer.get("bank", -1))
-			var pointer_address: int = int(runtime_pointer.get("address", -1))
-			if opcode == Gen2WorldScript.MEMCALL:
-				if not _push_frame(pointer_bank, pointer_address):
-					return {
-						"ok": false, "reason": &"missing_runtime_script",
-						"bank": pointer_bank, "address": pointer_address,
-					}
-				return {"ok": true}
-			var jump_result: Dictionary = _replace_frame(pointer_bank, pointer_address)
-			return jump_result
-		Gen2WorldScript.WARPMOD:
-			## `Script_warpmod` writes `wBackupWarpNumber`, `wBackupMapGroup` and
-			## `wBackupMapNumber` outright, which is how a map whose only exit is
-			## a -1 warp is given one before the player can reach it: both dept
-			## store elevators and the Fast Ship's cabin are entered by a script
-			## that runs this first.
-			_emit_runtime_event(&"backup_warp_changed", {
-				"warp": int(command.get("warp_id", 0)),
-				"map_group": int(command.get("map_group", 0)),
-				"map_number": int(command.get("map_number", 0)),
-			})
-		Gen2WorldScript.BLACKOUTMOD:
-			## `Script_blackoutmod` writes `wLastSpawnMapGroup` and
-			## `wLastSpawnMapNumber`, which is the pair `GetWhiteoutSpawn` reads
-			## back through `IsSpawnPoint`. Writing it here is what makes a
-			## scripted destination reach the blackout: nothing else consults the
-			## command.
-			_emit_runtime_event(&"blackout_destination_changed", {
-				"map_group": int(command.get("map_group", 0)),
-				"map_number": int(command.get("map_number", 0)),
-			})
-		Gen2WorldScript.SJUMP:
-			return _replace_frame(bank, int(command["address"]))
-		Gen2WorldScript.FARSJUMP:
-			return _replace_frame(int(command["bank"]), int(command["address"]))
-		Gen2WorldScript.IFEQUAL:
-			return _branch(int(_script_value) == int(command["value"]), bank, int(command["address"]))
-		Gen2WorldScript.IFNOTEQUAL:
-			return _branch(int(_script_value) != int(command["value"]), bank, int(command["address"]))
-		Gen2WorldScript.IFFALSE:
-			return _branch(_script_value == 0, bank, int(command["address"]))
-		Gen2WorldScript.IFTRUE:
-			return _branch(_script_value != 0, bank, int(command["address"]))
-		Gen2WorldScript.IFGREATER:
-			return _branch(_script_value > int(command["value"]), bank, int(command["address"]))
-		Gen2WorldScript.IFLESS:
-			return _branch(_script_value < int(command["value"]), bank, int(command["address"]))
-		Gen2WorldScript.JUMPSTD:
-			if int(command["address"]) == STD_STRENGTH_BOULDER:
-				return _stage_strength_boulder()
-			if int(command["address"]) == STD_SMASH_ROCK:
-				return _stage_smash_rock()
-			var jump_standard: Dictionary = _standard_script(int(command["address"]))
-			if jump_standard.is_empty():
-				return {
-					"ok": false,
-					"reason": &"missing_standard_script",
-					"standard_index": int(command["address"]),
-				}
-			return _replace_frame(
-				int(jump_standard["bank"]), int(jump_standard["address"]),
-				jump_standard["data"]
-			)
-		Gen2WorldScript.CALLSTD:
-			if int(command["address"]) == STD_STRENGTH_BOULDER:
-				return _stage_strength_boulder()
-			if int(command["address"]) == STD_SMASH_ROCK:
-				return _stage_smash_rock()
-			var call_standard: Dictionary = _standard_script(int(command["address"]))
-			if call_standard.is_empty():
-				return {
-					"ok": false,
-					"reason": &"missing_standard_script",
-					"standard_index": int(command["address"]),
-				}
+	return {}
+
+
+func _command_scall(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return {"ok": _push_frame(bank, int(command["address"]))}
+
+
+func _command_farscall(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return {"ok": _push_frame(int(command["bank"]), int(command["address"]))}
+
+
+func _command_memcall(opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var runtime_pointer: Dictionary = _runtime_memory_pointer(
+		int(command.get("address", 0))
+	)
+	if runtime_pointer.is_empty():
+		return {
+			"ok": false, "reason": &"missing_runtime_pointer",
+			"address": int(command.get("address", 0)), "command": command,
+		}
+	var pointer_bank: int = int(runtime_pointer.get("bank", -1))
+	var pointer_address: int = int(runtime_pointer.get("address", -1))
+	if opcode == Gen2WorldScript.MEMCALL:
+		if not _push_frame(pointer_bank, pointer_address):
 			return {
-				"ok": _push_frame(
-					int(call_standard["bank"]), int(call_standard["address"]),
-					call_standard["data"]
-				)
+				"ok": false, "reason": &"missing_runtime_script",
+				"bank": pointer_bank, "address": pointer_address,
 			}
-		Gen2WorldScript.CHECKMAPSCENE:
-			_script_value = _map_scene_value(
-				int(command["map_group"]), int(command["map_number"])
-			)
-		Gen2WorldScript.SETMAPSCENE:
-			var target_key: String = Gen2WorldState.map_scene_key(
-				int(command["map_group"]), int(command["map_number"])
-			)
-			_staged_scenes[target_key] = int(command["scene"])
-		Gen2WorldScript.CHECKSCENE:
-			_script_value = _map_scene_value(
-				int(_request.get("map_group", 0)), int(_request.get("map_number", 0))
-			)
-		Gen2WorldScript.SETSCENE:
-			var map_key: String = Gen2WorldState.map_scene_key(
-				int(_request.get("map_group", 0)), int(_request.get("map_number", 0))
-			)
-			_staged_scenes[map_key] = int(command["scene"])
-		Gen2WorldScript.CHECKVER:
-			## Script_checkver answers GS_VERSION, which
-			## `constants/misc_constants.asm` defines as 0 for Gold and 1 for
-			## Silver; pokecrystal defines it 0 unconditionally.
-			_script_value = 1 if data != null and data.id == &"silver" else 0
-		Gen2WorldScript.SETVAL:
-			_script_value = int(command["value"])
-		Gen2WorldScript.ADDVAL:
-			## Script_addval adds into wScriptVar, one byte, so it wraps there
-			## and not only where the value is later written. Goldenrod's switch
-			## room turns a switch off with `addval -1` and branches on it.
-			_script_value = (_script_value + int(command["value"])) & 0xFF
-		Gen2WorldScript.READMEM:
-			_script_value = _script_memory_value(int(command["address"]))
-		Gen2WorldScript.WRITEMEM:
-			return _stage_script_memory(int(command["address"]), _script_value)
-		Gen2WorldScript.LOADMEM:
-			return _stage_script_memory(int(command["address"]), int(command["value"]))
-		Gen2WorldScript.READVAR:
-			return _read_runtime_variable(int(command["value"]))
-		Gen2WorldScript.WRITEVAR:
-			return _write_runtime_variable(int(command["value"]))
-		Gen2WorldScript.LOADVAR:
-			return _load_runtime_variable(
-				int(command["value"]), int(command["value_2"])
-			)
-		Gen2WorldScript.CHECKTIME:
-			_script_value = 1 if Gen2WorldPhoneHost.time_mask_matches(
-				int(command["value"]), _clock_hour()
-			) else 0
-		Gen2WorldScript.ADDCELLNUM:
-			return _stage_phone_contact(int(command["value"]))
-		Gen2WorldScript.DELCELLNUM:
-			return _stage_phone_contact(int(command["value"]), false)
-		Gen2WorldScript.CHECKCELLNUM:
-			_script_value = 1 if _phone_contact_registered(int(command["value"])) else 0
-		Gen2WorldScript.SPECIAL:
-			return _execute_special(
-				Gen2WorldScript.special_index(int(command["value"]), _crystal_commands())
-			)
-		Gen2WorldScript.RANDOM:
-			var maximum: int = int(command["value"])
-			_script_value = _random.randi_range(0, maximum - 1) if maximum > 0 else 0
-		Gen2WorldScript.GIVEITEM:
-			return _stage_item_delta(int(command["value"]), int(command["value_2"]))
-		Gen2WorldScript.TAKEITEM:
-			return _stage_item_delta(int(command["value"]), -int(command["value_2"]))
-		Gen2WorldScript.CHECKITEM:
-			_script_value = 1 if _item_quantity(int(command["value"])) > 0 else 0
-		Gen2WorldScript.GIVEMONEY, Gen2WorldScript.TAKEMONEY:
-			return _stage_money_delta(
-				int(command["account"]), _decode_bcd(command["amount_bytes"]),
-				opcode == Gen2WorldScript.GIVEMONEY
-			)
-		Gen2WorldScript.CHECKMONEY:
-			_script_value = _compare_amount(
-				_money_balance(int(command["account"])),
-				_decode_bcd(command["amount_bytes"])
-			)
-		Gen2WorldScript.GIVECOINS, Gen2WorldScript.TAKECOINS:
-			return _stage_coins_delta(
-				int(command["value"]), opcode == Gen2WorldScript.GIVECOINS
-			)
-		Gen2WorldScript.CHECKCOINS:
-			_script_value = _compare_amount(_coins_value(), int(command["value"]))
-		Gen2WorldScript.GETMONEY:
-			var money: int = _money_balance(int(command["account"]))
-			_set_text_buffer(int(command["string_buffer"]), str(money), &"money")
-			_emit_runtime_event(&"text_value_requested", {
-				"value_kind": &"money", "account": int(command["account"]),
-				"value": money,
-				"string_buffer": int(command["string_buffer"]),
-			})
-		Gen2WorldScript.GETCOINS:
-			var coins: int = _coins_value()
-			_set_text_buffer(int(command["string_buffer"]), str(coins), &"coins")
-			_emit_runtime_event(&"text_value_requested", {
-				"value_kind": &"coins", "value": coins,
-				"string_buffer": int(command["string_buffer"]),
-			})
-		Gen2WorldScript.GETITEMNAME:
-			_set_text_buffer(
-				int(command["string_buffer"]),
-				data.item_name(int(command["item"])) if data != null else "",
-				&"item_name",
-				{"item": int(command["item"])}
-			)
-			_emit_runtime_event(&"text_buffer_requested", command)
-		Gen2WorldScript.GETMONNAME:
-			_set_text_buffer(
-				int(command["string_buffer"]),
-				String(data.species(int(command["pokemon"])).get("name", "")) if data != null else "",
-				&"mon_name",
-				{"pokemon": int(command["pokemon"])}
-			)
-			_emit_runtime_event(&"text_buffer_requested", command)
-		Gen2WorldScript.GETTRAINERNAME:
-			var trainer_name: String = ""
-			if data != null:
-				trainer_name = String(data.trainer_party(
-					int(command["trainer_group"]), int(command["trainer_id"]) - 1
-				).get("name", ""))
-			_set_text_buffer(
-				int(command["string_buffer"]), trainer_name, &"trainer_name",
-				{"trainer_group": int(command["trainer_group"]), "trainer_id": int(command["trainer_id"])}
-			)
-			_emit_runtime_event(&"text_buffer_requested", command)
-		Gen2WorldScript.GETSTRING:
-			## `Script_getstring` is `CopyName1`, which copies a plain character
-			## run up to its `@`. It is not a text: the first byte of
-			## `PokegearName` is `#`, which the command layer reads as an unknown
-			## command and refuses, so decoding this the way `writetext` is
-			## decoded leaves every `getstring` buffer empty and prints
-			## "<PLAYER> received !" with a hole where the name belongs.
-			var string_text: String = ""
-			if data != null:
-				var string_data: PackedByteArray = data.world_text(
-					int(_request.get("bank", 0)), int(command["address"])
-				)
-				string_text = Gen2Text.decode(string_data, 0, string_data.size())
-			_set_text_buffer(int(command["string_buffer"]), string_text, &"string", {
-				"bank": int(_request.get("bank", 0)), "address": int(command["address"]),
-			})
-			_emit_runtime_event(&"text_buffer_requested", command)
-		Gen2WorldScript.CLEAREVENT:
-			_staged_flags[int(command["flag"])] = false
-		Gen2WorldScript.SETEVENT:
-			_staged_flags[int(command["flag"])] = true
-		Gen2WorldScript.CHECKEVENT:
-			_script_value = 1 if _event_flag_active(int(command["flag"])) else 0
-		Gen2WorldScript.CLEARFLAG:
-			_staged_engine_flags[int(command["flag"])] = false
-		Gen2WorldScript.SETFLAG:
-			_staged_engine_flags[int(command["flag"])] = true
-		Gen2WorldScript.CHECKFLAG:
-			_script_value = 1 if _engine_flag_active(int(command["flag"])) else 0
-		## `Script_wildon` and `Script_wildoff`, which write
-		## `STATUSFLAGS_NO_WILD_ENCOUNTERS_F` outright rather than through a
-		## staged flag: it is scratch the next map entry does not clear, and the
-		## scripts that turn it off all turn it back on themselves.
-		Gen2WorldScript.WILDON:
-			_emit_runtime_event(&"wild_encounters_changed", {"enabled": true})
-		Gen2WorldScript.WILDOFF:
-			_emit_runtime_event(&"wild_encounters_changed", {"enabled": false})
-		Gen2WorldScript.WARP:
-			return _stage_warp(command)
-		Gen2WorldScript.OPENTEXT, Gen2WorldScript.REANCHORMAP, Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE, Gen2WorldScript.CLOSEWINDOW:
-			## `Script_closetext` takes the box down, so nothing stands behind a
-			## later choice; leaving the last question there would print it under
-			## an unrelated menu.
-			if opcode == Gen2WorldScript.CLOSETEXT:
-				_standing_text = ""
-				## The balance windows are tilemap, so the redraw behind the box
-				## is what takes them away too.
-				if _money_window != &"":
-					_money_window = &""
-					_emit_runtime_event(&"money_window_closed", {})
-		Gen2WorldScript.ITEMNOTIFY:
-			## `CurItemName` reads wCurItem, which whichever `giveitem` came
-			## before this wrote.
-			return _stage_item_notify(_last_item, false)
-		Gen2WorldScript.POCKETISFULL:
-			return _stage_pocket_is_full(_last_item, false)
-		Gen2WorldScript.WRITETEXT:
-			return _show_text(bank, int(command["address"]), false)
-		Gen2WorldScript.FARWRITETEXT:
-			return _show_text(int(command["bank"]), int(command["address"]), false)
-		Gen2WorldScript.JUMPTEXTFACEPLAYER:
-			## `Script_jumptextfaceplayer` jumps to JumpTextFacePlayerScript,
-			## whose first command is `faceplayer`; `jumptext` and `farjumptext`
-			## enter the same script one command later, at JumpTextScript. The
-			## four commands after it are `opentext`, `repeattext -1, -1`,
-			## `waitbutton` and `closetext`, which is what _show_text spends.
-			_face_player()
-			return _show_text(bank, int(command["address"]), true)
-		Gen2WorldScript.REPEATTEXT:
-			if int(command["value"]) == 0xFF and int(command["value_2"]) == 0xFF:
-				if _last_text.is_empty():
-					return {"ok": false, "reason": &"repeat_without_text"}
-				return _show_text(int(_last_text["bank"]), int(_last_text["address"]), false)
-		Gen2WorldScript.YESORNO:
-			return _stage_choice(command, [&"yes", &"no"])
-		Gen2WorldScript.LOADMENU:
-			_loaded_menu = {
-				"bank": int(_request.get("bank", 0)),
-				"address": int(command["address"]),
-			}
-			if data != null:
-				var cached_menu: Dictionary = data.world_menu(
-					int(_request.get("bank", 0)), int(command["address"])
-				)
-				for key: String in cached_menu:
-					_loaded_menu[key] = cached_menu[key]
-			_emit_runtime_event(&"menu_loaded", _loaded_menu)
-		Gen2WorldScript.CHECKPOKE:
-			## Script_checkpoke sets wScriptVar from whether the species is in
-			## wPartySpecies (engine/overworld/scripting.asm). The read-only party
-			## summary is the only party this scene-free runner may read, and an
-			## absent one fails the way VAR_PARTYCOUNT does. A summary carrying an
-			## empty species list answers 0, not a failure.
-			var party: Dictionary = _request.get("party", {})
-			if party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "command": command}
-			var species: Array = party.get("species", [])
-			_script_value = 1 if int(command.get("value", 0)) in species else 0
-		Gen2WorldScript.GIVEPOKE, Gen2WorldScript.GIVEEGG:
-			## Both write their species operand to wCurPartySpecies before the
-			## routine runs, whether or not the party had room for it.
-			_cur_party_species = int(command.get("pokemon", 0))
-			return _stage_runtime_request(&"pokemon_requested", command)
-		Gen2WorldScript.GIVEPOKEMAIL:
-			return _give_poke_mail(command)
-		Gen2WorldScript.CHECKPOKEMAIL:
-			return _check_poke_mail(command)
-		Gen2WorldScript.GOLD_FACEPLAYER, Gen2WorldScript.FACEPLAYER:
-			if Gen2WorldScript.is_faceplayer(opcode, _crystal_commands()):
-				pass
-	var handled_base: Array = [
-		Gen2WorldScript.CHECKMAPSCENE, Gen2WorldScript.SETMAPSCENE,
-		Gen2WorldScript.CHECKSCENE, Gen2WorldScript.SETSCENE,
-		Gen2WorldScript.CHECKVER,
-		Gen2WorldScript.SETVAL, Gen2WorldScript.ADDVAL, Gen2WorldScript.RANDOM,
-		Gen2WorldScript.CHECKEVENT, Gen2WorldScript.CLEAREVENT, Gen2WorldScript.SETEVENT,
-		Gen2WorldScript.CHECKFLAG, Gen2WorldScript.CLEARFLAG, Gen2WorldScript.SETFLAG,
-		Gen2WorldScript.WILDON, Gen2WorldScript.WILDOFF,
-		Gen2WorldScript.READMEM,
-		Gen2WorldScript.READVAR, Gen2WorldScript.WRITEVAR, Gen2WorldScript.LOADVAR,
-		Gen2WorldScript.CHECKTIME, Gen2WorldScript.SPECIAL,
-		Gen2WorldScript.CHECKITEM, Gen2WorldScript.CHECKPOKE,
-		Gen2WorldScript.ADDCELLNUM, Gen2WorldScript.DELCELLNUM,
-		Gen2WorldScript.CHECKCELLNUM,
-		Gen2WorldScript.GOLD_FACEPLAYER, Gen2WorldScript.FACEPLAYER,
-		Gen2WorldScript.OPENTEXT, Gen2WorldScript.REANCHORMAP,
-		Gen2WorldScript.CLOSETEXT, Gen2WorldScript.WRITEUNUSEDBYTE,
-		Gen2WorldScript.CLOSEWINDOW,
-		Gen2WorldScript.LOADMENU,
-		## Both comparisons answer through `_script_value` and stage nothing, so
-		## they never returned from their own branch and fell through to the
-		## refusal below. Every `checkcoins` in either game is a Game Corner or a
-		## Buena prize counter, and every one of them stopped its script here.
-		Gen2WorldScript.CHECKMONEY, Gen2WorldScript.CHECKCOINS,
-		Gen2WorldScript.GETMONEY, Gen2WorldScript.GETCOINS, Gen2WorldScript.GETNUM,
-		Gen2WorldScript.GETMONNAME, Gen2WorldScript.GETITEMNAME,
-		Gen2WorldScript.GETCURLANDMARKNAME, Gen2WorldScript.GETTRAINERNAME,
-		Gen2WorldScript.GETSTRING, Gen2WorldScript.BLACKOUTMOD,
-	]
-	if opcode in handled_base:
 		return {"ok": true}
+	var jump_result: Dictionary = _replace_frame(pointer_bank, pointer_address)
+	return jump_result
+
+
+## `Script_warpmod` writes `wBackupWarpNumber`, `wBackupMapGroup` and
+## `wBackupMapNumber` outright, which is how a map whose only exit is a -1 warp is
+## given one before the player can reach it: both dept store elevators and the Fast
+## Ship's cabin are entered by a script that runs this first.
+func _command_warpmod(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"backup_warp_changed", {
+		"warp": int(command.get("warp_id", 0)),
+		"map_group": int(command.get("map_group", 0)),
+		"map_number": int(command.get("map_number", 0)),
+	})
+	return {"ok": true}
+
+
+## `Script_blackoutmod` writes `wLastSpawnMapGroup` and `wLastSpawnMapNumber`, which
+## is the pair `GetWhiteoutSpawn` reads back through `IsSpawnPoint`. Writing it here
+## is what makes a scripted destination reach the blackout: nothing else consults the
+## command.
+func _command_blackoutmod(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"blackout_destination_changed", {
+		"map_group": int(command.get("map_group", 0)),
+		"map_number": int(command.get("map_number", 0)),
+	})
+	return {"ok": true}
+
+
+func _command_sjump(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _replace_frame(bank, int(command["address"]))
+
+
+func _command_farsjump(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _replace_frame(int(command["bank"]), int(command["address"]))
+
+
+func _command_ifequal(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _branch(int(_script_value) == int(command["value"]), bank, int(command["address"]))
+
+
+func _command_ifnotequal(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _branch(int(_script_value) != int(command["value"]), bank, int(command["address"]))
+
+
+func _command_iffalse(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _branch(_script_value == 0, bank, int(command["address"]))
+
+
+func _command_iftrue(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _branch(_script_value != 0, bank, int(command["address"]))
+
+
+func _command_ifgreater(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _branch(_script_value > int(command["value"]), bank, int(command["address"]))
+
+
+func _command_ifless(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _branch(_script_value < int(command["value"]), bank, int(command["address"]))
+
+
+func _command_jumpstd(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	if int(command["address"]) == STD_STRENGTH_BOULDER:
+		return _stage_strength_boulder()
+	if int(command["address"]) == STD_SMASH_ROCK:
+		return _stage_smash_rock()
+	var jump_standard: Dictionary = _standard_script(int(command["address"]))
+	if jump_standard.is_empty():
+		return {
+			"ok": false,
+			"reason": &"missing_standard_script",
+			"standard_index": int(command["address"]),
+		}
+	return _replace_frame(
+		int(jump_standard["bank"]), int(jump_standard["address"]),
+		jump_standard["data"]
+	)
+
+
+func _command_callstd(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	if int(command["address"]) == STD_STRENGTH_BOULDER:
+		return _stage_strength_boulder()
+	if int(command["address"]) == STD_SMASH_ROCK:
+		return _stage_smash_rock()
+	var call_standard: Dictionary = _standard_script(int(command["address"]))
+	if call_standard.is_empty():
+		return {
+			"ok": false,
+			"reason": &"missing_standard_script",
+			"standard_index": int(command["address"]),
+		}
 	return {
-		"ok": false,
-		"reason": &"unsupported_runtime_command",
-		"command": command,
+		"ok": _push_frame(
+			int(call_standard["bank"]), int(call_standard["address"]),
+			call_standard["data"]
+		)
 	}
 
 
+func _command_checkmapscene(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = _map_scene_value(
+		int(command["map_group"]), int(command["map_number"])
+	)
+	return {"ok": true}
+
+
+func _command_setmapscene(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var target_key: String = Gen2WorldState.map_scene_key(
+		int(command["map_group"]), int(command["map_number"])
+	)
+	_staged_scenes[target_key] = int(command["scene"])
+	return {"ok": true}
+
+
+func _command_checkscene(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = _map_scene_value(
+		int(_request.get("map_group", 0)), int(_request.get("map_number", 0))
+	)
+	return {"ok": true}
+
+
+func _command_setscene(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var map_key: String = Gen2WorldState.map_scene_key(
+		int(_request.get("map_group", 0)), int(_request.get("map_number", 0))
+	)
+	_staged_scenes[map_key] = int(command["scene"])
+	return {"ok": true}
+
+
+## Script_checkver answers GS_VERSION, which `constants/misc_constants.asm` defines as
+## 0 for Gold and 1 for Silver; pokecrystal defines it 0 unconditionally.
+func _command_checkver(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if data != null and data.id == &"silver" else 0
+	return {"ok": true}
+
+
+func _command_setval(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = int(command["value"])
+	return {"ok": true}
+
+
+## Script_addval adds into wScriptVar, one byte, so it wraps there and not only where
+## the value is later written. Goldenrod's switch room turns a switch off with `addval
+## -1` and branches on it.
+func _command_addval(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = (_script_value + int(command["value"])) & 0xFF
+	return {"ok": true}
+
+
+func _command_readmem(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = _script_memory_value(int(command["address"]))
+	return {"ok": true}
+
+
+func _command_writemem(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_script_memory(int(command["address"]), _script_value)
+
+
+func _command_loadmem(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_script_memory(int(command["address"]), int(command["value"]))
+
+
+func _command_readvar(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _read_runtime_variable(int(command["value"]))
+
+
+func _command_writevar(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _write_runtime_variable(int(command["value"]))
+
+
+func _command_loadvar(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _load_runtime_variable(
+		int(command["value"]), int(command["value_2"])
+	)
+
+
+func _command_checktime(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if Gen2WorldPhoneHost.time_mask_matches(
+		int(command["value"]), _clock_hour()
+	) else 0
+	return {"ok": true}
+
+
+func _command_addcellnum(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_phone_contact(int(command["value"]))
+
+
+func _command_delcellnum(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_phone_contact(int(command["value"]), false)
+
+
+func _command_checkcellnum(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if _phone_contact_registered(int(command["value"])) else 0
+	return {"ok": true}
+
+
+func _command_special(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _execute_special(
+		Gen2WorldScript.special_index(int(command["value"]), _crystal_commands())
+	)
+
+
+func _command_random(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var maximum: int = int(command["value"])
+	_script_value = _random.randi_range(0, maximum - 1) if maximum > 0 else 0
+	return {"ok": true}
+
+
+func _command_giveitem(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_item_delta(int(command["value"]), int(command["value_2"]))
+
+
+func _command_takeitem(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_item_delta(int(command["value"]), -int(command["value_2"]))
+
+
+func _command_checkitem(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if _item_quantity(int(command["value"])) > 0 else 0
+	return {"ok": true}
+
+
+func _command_givemoney(opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_money_delta(
+		int(command["account"]), _decode_bcd(command["amount_bytes"]),
+		opcode == Gen2WorldScript.GIVEMONEY
+	)
+
+
+func _command_checkmoney(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = _compare_amount(
+		_money_balance(int(command["account"])),
+		_decode_bcd(command["amount_bytes"])
+	)
+	return {"ok": true}
+
+
+func _command_givecoins(opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_coins_delta(
+		int(command["value"]), opcode == Gen2WorldScript.GIVECOINS
+	)
+
+
+func _command_checkcoins(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = _compare_amount(_coins_value(), int(command["value"]))
+	return {"ok": true}
+
+
+func _command_getmoney(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var money: int = _money_balance(int(command["account"]))
+	_set_text_buffer(int(command["string_buffer"]), str(money), &"money")
+	_emit_runtime_event(&"text_value_requested", {
+		"value_kind": &"money", "account": int(command["account"]),
+		"value": money,
+		"string_buffer": int(command["string_buffer"]),
+	})
+	return {"ok": true}
+
+
+func _command_getcoins(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var coins: int = _coins_value()
+	_set_text_buffer(int(command["string_buffer"]), str(coins), &"coins")
+	_emit_runtime_event(&"text_value_requested", {
+		"value_kind": &"coins", "value": coins,
+		"string_buffer": int(command["string_buffer"]),
+	})
+	return {"ok": true}
+
+
+func _command_getitemname(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_set_text_buffer(
+		int(command["string_buffer"]),
+		data.item_name(int(command["item"])) if data != null else "",
+		&"item_name",
+		{"item": int(command["item"])}
+	)
+	_emit_runtime_event(&"text_buffer_requested", command)
+	return {"ok": true}
+
+
+func _command_getmonname(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_set_text_buffer(
+		int(command["string_buffer"]),
+		String(data.species(int(command["pokemon"])).get("name", "")) if data != null else "",
+		&"mon_name",
+		{"pokemon": int(command["pokemon"])}
+	)
+	_emit_runtime_event(&"text_buffer_requested", command)
+	return {"ok": true}
+
+
+func _command_gettrainername(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var trainer_name: String = ""
+	if data != null:
+		trainer_name = String(data.trainer_party(
+			int(command["trainer_group"]), int(command["trainer_id"]) - 1
+		).get("name", ""))
+	_set_text_buffer(
+		int(command["string_buffer"]), trainer_name, &"trainer_name",
+		{"trainer_group": int(command["trainer_group"]), "trainer_id": int(command["trainer_id"])}
+	)
+	_emit_runtime_event(&"text_buffer_requested", command)
+	return {"ok": true}
+
+
+## `Script_getstring` is `CopyName1`, which copies a plain character run up to its
+## `@`. It is not a text: the first byte of `PokegearName` is `#`, which the command
+## layer reads as an unknown command and refuses, so decoding this the way `writetext`
+## is decoded leaves every `getstring` buffer empty and prints "<PLAYER> received !"
+## with a hole where the name belongs.
+func _command_getstring(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var string_text: String = ""
+	if data != null:
+		var string_data: PackedByteArray = data.world_text(
+			int(_request.get("bank", 0)), int(command["address"])
+		)
+		string_text = Gen2Text.decode(string_data, 0, string_data.size())
+	_set_text_buffer(int(command["string_buffer"]), string_text, &"string", {
+		"bank": int(_request.get("bank", 0)), "address": int(command["address"]),
+	})
+	_emit_runtime_event(&"text_buffer_requested", command)
+	return {"ok": true}
+
+
+func _command_clearevent(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_staged_flags[int(command["flag"])] = false
+	return {"ok": true}
+
+
+func _command_setevent(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_staged_flags[int(command["flag"])] = true
+	return {"ok": true}
+
+
+func _command_checkevent(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if _event_flag_active(int(command["flag"])) else 0
+	return {"ok": true}
+
+
+func _command_clearflag(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_staged_engine_flags[int(command["flag"])] = false
+	return {"ok": true}
+
+
+func _command_setflag(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_staged_engine_flags[int(command["flag"])] = true
+	return {"ok": true}
+
+
+func _command_checkflag(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if _engine_flag_active(int(command["flag"])) else 0
+## `Script_wildon` and `Script_wildoff`, which write
+## `STATUSFLAGS_NO_WILD_ENCOUNTERS_F` outright rather than through a
+## staged flag: it is scratch the next map entry does not clear, and the
+## scripts that turn it off all turn it back on themselves.
+	return {"ok": true}
+
+
+func _command_wildon(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"wild_encounters_changed", {"enabled": true})
+	return {"ok": true}
+
+
+func _command_wildoff(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"wild_encounters_changed", {"enabled": false})
+	return {"ok": true}
+
+
+func _command_warp(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_warp(command)
+
+
+## `Script_closetext` takes the box down, so nothing stands behind a later choice;
+## leaving the last question there would print it under an unrelated menu.
+func _command_opentext(opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	if opcode == Gen2WorldScript.CLOSETEXT:
+		_standing_text = ""
+		## The balance windows are tilemap, so the redraw behind the box
+		## is what takes them away too.
+		if _money_window != &"":
+			_money_window = &""
+			_emit_runtime_event(&"money_window_closed", {})
+	return {"ok": true}
+
+
+## `CurItemName` reads wCurItem, which whichever `giveitem` came before this wrote.
+func _command_itemnotify(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_item_notify(_last_item, false)
+
+
+func _command_pocketisfull(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_pocket_is_full(_last_item, false)
+
+
+func _command_writetext(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _show_text(bank, int(command["address"]), false)
+
+
+func _command_farwritetext(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _show_text(int(command["bank"]), int(command["address"]), false)
+
+
+## `Script_jumptextfaceplayer` jumps to JumpTextFacePlayerScript, whose first command
+## is `faceplayer`; `jumptext` and `farjumptext` enter the same script one command
+## later, at JumpTextScript. The four commands after it are `opentext`, `repeattext
+## -1, -1`, `waitbutton` and `closetext`, which is what _show_text spends.
+func _command_jumptextfaceplayer(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	_face_player()
+	return _show_text(bank, int(command["address"]), true)
+
+
+func _command_repeattext(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	if int(command["value"]) == 0xFF and int(command["value_2"]) == 0xFF:
+		if _last_text.is_empty():
+			return {"ok": false, "reason": &"repeat_without_text"}
+		return _show_text(int(_last_text["bank"]), int(_last_text["address"]), false)
+	return {"ok": true}
+
+
+func _command_yesorno(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_choice(command, [&"yes", &"no"])
+
+
+func _command_loadmenu(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_loaded_menu = {
+		"bank": int(_request.get("bank", 0)),
+		"address": int(command["address"]),
+	}
+	if data != null:
+		var cached_menu: Dictionary = data.world_menu(
+			int(_request.get("bank", 0)), int(command["address"])
+		)
+		for key: String in cached_menu:
+			_loaded_menu[key] = cached_menu[key]
+	_emit_runtime_event(&"menu_loaded", _loaded_menu)
+	return {"ok": true}
+
+
+## Script_checkpoke sets wScriptVar from whether the species is in wPartySpecies
+## (engine/overworld/scripting.asm). The read-only party summary is the only party
+## this scene-free runner may read, and an absent one fails the way VAR_PARTYCOUNT
+## does. A summary carrying an empty species list answers 0, not a failure.
+func _command_checkpoke(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "command": command}
+	var species: Array = party.get("species", [])
+	_script_value = 1 if int(command.get("value", 0)) in species else 0
+	return {"ok": true}
+
+
+## Both write their species operand to wCurPartySpecies before the routine runs,
+## whether or not the party had room for it.
+func _command_givepoke(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_cur_party_species = int(command.get("pokemon", 0))
+	return _stage_runtime_request(&"pokemon_requested", command)
+
+
+func _command_givepokemail(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _give_poke_mail(command)
+
+
+func _command_checkpokemail(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _check_poke_mail(command)
+
+
+func _command_gold_faceplayer(opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	if Gen2WorldScript.is_faceplayer(opcode, _crystal_commands()):
+		pass
+	return {"ok": true}
 ## A command whose numbers a mod may have moved, substituted before it runs.
 ##
 ## The site is addressed by the byte it sits at, `frame.address + offset`, which
@@ -2318,380 +2635,562 @@ const CATALOG_KINDS: Dictionary = {
 }
 
 
-func _execute_later_command(source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
-	match source_opcode:
-		0x55:
-			## `Script_pokepic` takes wScriptVar when its operand is zero and
-			## writes whichever it settled on to wCurPartySpecies, which is
-			## what a later `special PlayCurMonCry` reads.
-			var pic_species: int = int(command.get("pokemon", 0))
-			if pic_species == 0:
-				pic_species = _script_value
-			_cur_party_species = pic_species
-			_emit_runtime_event(&"pokemon_picture_requested", {
-				"pokemon": pic_species,
-			})
-		0x56:
-			_emit_runtime_event(&"pokemon_picture_closed", {})
-		0x57, 0x58:
-			return _stage_menu(source_opcode == 0x57, command)
-		0x5B:
-			var trainer_value: Variant = _request.get("trainer", {})
-			if trainer_value is Dictionary and not (trainer_value as Dictionary).is_empty():
-				var trainer: Dictionary = trainer_value as Dictionary
-				_battle_setup = _new_battle_setup({
-					"kind": &"trainer",
-					"trainer_group": int(trainer.get("trainer_group", 0)),
-					"trainer_id": maxi(int(trainer.get("trainer_id", 0)) - 1, 0),
-					"trainer_flag": int(trainer.get("event_flag", -1)),
-					"win_text": _trainer_text_pointer(trainer, "win_text", bank),
-					"loss_text": _trainer_text_pointer(trainer, "loss_text", bank),
-				})
-				_emit_runtime_event(&"battle_setup_changed", _battle_setup)
-		0x5C:
-			_battle_setup = _new_battle_setup({
-				"kind": &"wild", "pokemon": int(command.get("pokemon", 0)),
-				"level": int(command.get("level", 0)),
-			})
-			_emit_runtime_event(&"battle_setup_changed", _battle_setup)
-		0x5D:
-			_loaded_battle_type = -1
-			_battle_setup = _new_battle_setup({
-				"kind": &"trainer", "trainer_group": int(command.get("trainer_group", 0)),
-				# The cartridge's loadtrainer operand is one-based; the imported
-				# party table API is zero-based.
-				"trainer_id": maxi(int(command.get("trainer_id", 0)) - 1, 0),
-			})
-			_emit_runtime_event(&"battle_setup_changed", _battle_setup)
-		0x5E:
-			if _battle_setup.is_empty():
-				return {
-					"ok": false, "reason": &"battle_setup_missing", "command": command,
-				}
-			return _stage_runtime_request(&"battle_requested", _battle_request_values())
-		0x5F:
-			_emit_runtime_event(&"battle_map_reload_requested", {"requested": true})
-		0x60:
-			var tutorial_setup: Dictionary = _battle_setup.duplicate(true)
-			if tutorial_setup.is_empty() or StringName(tutorial_setup.get("kind", &"")) != &"wild":
-				return {"ok": false, "reason": &"tutorial_battle_setup_missing"}
-			tutorial_setup["tutorial"] = true
-			tutorial_setup["battle_type"] = int(command.get("value", 0))
-			tutorial_setup["can_lose"] = false
-			return _stage_runtime_request(&"catch_tutorial_requested", tutorial_setup)
-		0x61:
-			return _stage_runtime_request(&"trainer_text_requested", {
-				"text_id": int(command.get("value", 0)),
-				"setup": _battle_setup.duplicate(true),
-			})
-		0x62:
-			var trainer_event: Dictionary = _request.get("event", {})
-			var trainer_data: Variant = _request.get("trainer", {})
-			var trainer_flag: int = int(trainer_event.get("event_flag", 0))
-			if trainer_data is Dictionary and not (trainer_data as Dictionary).is_empty():
-				trainer_flag = int((trainer_data as Dictionary).get("event_flag", -1))
-			var action: int = int(command.get("value", 0))
-			if action == 0:
-				_staged_flags[trainer_flag] = false
-			elif action == 1:
-				_staged_flags[trainer_flag] = true
-			elif action == 2:
-				_script_value = 1 if _event_flag_active(trainer_flag) else 0
-			else:
-				return {"ok": false, "reason": &"unsupported_trainer_flag_action", "action": action}
-			_emit_runtime_event(&"trainer_flag_action", {
-				"action": action, "event_flag": trainer_flag,
-				"script_value": _script_value,
-			})
-		0x63:
-			_battle_setup["win_text"] = {
-				"bank": bank, "address": int(command.get("win_address", 0)),
-			}
-			_battle_setup["loss_text"] = {
-				"bank": bank, "address": int(command.get("loss_address", 0)),
-			}
-		0x64:
-			## Script_scripttalkafter jumps to wScriptAfterPointer in
-			## wSeenTrainerBank, which is the map's own script bank here. A
-			## record without one leaves the script to end, since the source
-			## always writes the pointer the trainer macro carries.
-			var after_trainer: Variant = _request.get("trainer", {})
-			var after_address: int = int((after_trainer as Dictionary).get("after_script", 0)) \
-				if after_trainer is Dictionary else 0
-			_emit_runtime_event(&"trainer_talk_after_requested", {
+## The commands numbered past the two profiles' seam, as the handler that runs
+## each. The key is the pokegold opcode [method Gen2WorldScript.source_opcode]
+## normalizes to, so one row serves both profiles.
+const LATER_HANDLERS: Dictionary = {
+	0x55: &"_command_pokepic",
+	0x56: &"_command_closepokepic",
+	0x57: &"_command_two_d_menu",
+	0x58: &"_command_two_d_menu",
+	0x5B: &"_command_loadtemptrainer",
+	0x5C: &"_command_loadwildmon",
+	0x5D: &"_command_loadtrainer",
+	0x5E: &"_command_startbattle",
+	0x5F: &"_command_reloadmapafterbattle",
+	0x60: &"_command_catchtutorial",
+	0x61: &"_command_trainertext",
+	0x62: &"_command_trainerflagaction",
+	0x63: &"_command_winlosstext",
+	0x64: &"_command_scripttalkafter",
+	0x65: &"_command_endifjustbattled",
+	0x66: &"_command_checkjustbattled",
+	0x73: &"_command_loademote",
+	0x74: &"_command_showemote",
+	0x77: &"_command_earthquake",
+	0x78: &"_command_changemapblocks",
+	0x79: &"_command_changeblock",
+	0x7A: &"_command_reloadmap",
+	0x7B: &"_command_refreshmap",
+	0x7C: &"_command_writecmdqueue",
+	0x7D: &"_command_delcmdqueue",
+	0x7E: &"_command_playmusic",
+	0x7F: &"_command_encountermusic",
+	0x80: &"_command_musicfadeout",
+	0x81: &"_command_playmapmusic",
+	0x82: &"_command_dontrestartmapmusic",
+	0x83: &"_command_cry",
+	0x84: &"_command_playsound",
+	0x85: &"_command_waitsfx",
+	0x86: &"_command_warpsound",
+	0x87: &"_command_specialsound",
+	0x6C: &"_command_variablesprite",
+	0x8A: &"_command_pause",
+	0x8B: &"_command_pause",
+	0x8C: &"_command_sdefer",
+	0x89: &"_command_newloadmap",
+	0x8D: &"_command_warpcheck",
+	0x93: &"_command_pokemart",
+	0x94: &"_command_elevator",
+	0x95: &"_command_trade",
+	0x96: &"_command_askforphonenumber",
+	0x97: &"_command_phonecall",
+	0x98: &"_command_hangup",
+	0x99: &"_command_describedecoration",
+	0x9A: &"_command_fruittree",
+	0x9B: &"_command_specialphonecall",
+	0x9C: &"_command_checkphonecall",
+	0x9D: &"_command_verbosegiveitem",
+	0x9E: &"_command_swarm",
+	0x9F: &"_command_halloffame",
+	0xA0: &"_command_credits",
+	0xA1: &"_command_warpfacing",
+	0xA2: &"_command_battletowertext",
+}
+
+
+func _execute_later_command(
+	source_opcode: int, command: Dictionary, bank: int
+) -> Dictionary:
+	if not LATER_HANDLERS.has(source_opcode):
+		return {}
+	return call(LATER_HANDLERS[source_opcode], source_opcode, command, bank)
+
+
+## `Script_pokepic` takes wScriptVar when its operand is zero and writes whichever it
+## settled on to wCurPartySpecies, which is what a later `special PlayCurMonCry`
+## reads.
+func _command_pokepic(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var pic_species: int = int(command.get("pokemon", 0))
+	if pic_species == 0:
+		pic_species = _script_value
+	_cur_party_species = pic_species
+	_emit_runtime_event(&"pokemon_picture_requested", {
+		"pokemon": pic_species,
+	})
+	return {"ok": true}
+
+
+func _command_closepokepic(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"pokemon_picture_closed", {})
+	return {"ok": true}
+
+
+func _command_two_d_menu(source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_menu(source_opcode == 0x57, command)
+
+
+func _command_loadtemptrainer(_source_opcode: int, _command: Dictionary, bank: int) -> Dictionary:
+	var trainer_value: Variant = _request.get("trainer", {})
+	if trainer_value is Dictionary and not (trainer_value as Dictionary).is_empty():
+		var trainer: Dictionary = trainer_value as Dictionary
+		_battle_setup = _new_battle_setup({
+			"kind": &"trainer",
+			"trainer_group": int(trainer.get("trainer_group", 0)),
+			"trainer_id": maxi(int(trainer.get("trainer_id", 0)) - 1, 0),
+			"trainer_flag": int(trainer.get("event_flag", -1)),
+			"win_text": _trainer_text_pointer(trainer, "win_text", bank),
+			"loss_text": _trainer_text_pointer(trainer, "loss_text", bank),
+		})
+		_emit_runtime_event(&"battle_setup_changed", _battle_setup)
+	return {"ok": true}
+
+
+func _command_loadwildmon(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_battle_setup = _new_battle_setup({
+		"kind": &"wild", "pokemon": int(command.get("pokemon", 0)),
+		"level": int(command.get("level", 0)),
+	})
+	_emit_runtime_event(&"battle_setup_changed", _battle_setup)
+	return {"ok": true}
+
+
+func _command_loadtrainer(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_loaded_battle_type = -1
+	_battle_setup = _new_battle_setup({
+		"kind": &"trainer", "trainer_group": int(command.get("trainer_group", 0)),
+		# The cartridge's loadtrainer operand is one-based; the imported
+		# party table API is zero-based.
+		"trainer_id": maxi(int(command.get("trainer_id", 0)) - 1, 0),
+	})
+	_emit_runtime_event(&"battle_setup_changed", _battle_setup)
+	return {"ok": true}
+
+
+func _command_startbattle(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	if _battle_setup.is_empty():
+		return {
+			"ok": false, "reason": &"battle_setup_missing", "command": command,
+		}
+	return _stage_runtime_request(&"battle_requested", _battle_request_values())
+
+
+func _command_reloadmapafterbattle(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"battle_map_reload_requested", {"requested": true})
+	return {"ok": true}
+
+
+func _command_catchtutorial(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var tutorial_setup: Dictionary = _battle_setup.duplicate(true)
+	if tutorial_setup.is_empty() or StringName(tutorial_setup.get("kind", &"")) != &"wild":
+		return {"ok": false, "reason": &"tutorial_battle_setup_missing"}
+	tutorial_setup["tutorial"] = true
+	tutorial_setup["battle_type"] = int(command.get("value", 0))
+	tutorial_setup["can_lose"] = false
+	return _stage_runtime_request(&"catch_tutorial_requested", tutorial_setup)
+
+
+func _command_trainertext(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_runtime_request(&"trainer_text_requested", {
+		"text_id": int(command.get("value", 0)),
+		"setup": _battle_setup.duplicate(true),
+	})
+
+
+func _command_trainerflagaction(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var trainer_event: Dictionary = _request.get("event", {})
+	var trainer_data: Variant = _request.get("trainer", {})
+	var trainer_flag: int = int(trainer_event.get("event_flag", 0))
+	if trainer_data is Dictionary and not (trainer_data as Dictionary).is_empty():
+		trainer_flag = int((trainer_data as Dictionary).get("event_flag", -1))
+	var action: int = int(command.get("value", 0))
+	if action == 0:
+		_staged_flags[trainer_flag] = false
+	elif action == 1:
+		_staged_flags[trainer_flag] = true
+	elif action == 2:
+		_script_value = 1 if _event_flag_active(trainer_flag) else 0
+	else:
+		return {"ok": false, "reason": &"unsupported_trainer_flag_action", "action": action}
+	_emit_runtime_event(&"trainer_flag_action", {
+		"action": action, "event_flag": trainer_flag,
+		"script_value": _script_value,
+	})
+	return {"ok": true}
+
+
+func _command_winlosstext(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	_battle_setup["win_text"] = {
+		"bank": bank, "address": int(command.get("win_address", 0)),
+	}
+	_battle_setup["loss_text"] = {
+		"bank": bank, "address": int(command.get("loss_address", 0)),
+	}
+	return {"ok": true}
+
+
+## Script_scripttalkafter jumps to wScriptAfterPointer in wSeenTrainerBank, which is
+## the map's own script bank here. A record without one leaves the script to end,
+## since the source always writes the pointer the trainer macro carries.
+func _command_scripttalkafter(_source_opcode: int, _command: Dictionary, bank: int) -> Dictionary:
+	var after_trainer: Variant = _request.get("trainer", {})
+	var after_address: int = int((after_trainer as Dictionary).get("after_script", 0)) \
+		if after_trainer is Dictionary else 0
+	_emit_runtime_event(&"trainer_talk_after_requested", {
+		"bank": bank, "address": after_address,
+	})
+	if after_address > 0:
+		_frames.clear()
+		if not _push_frame(bank, after_address):
+			return {
+				"ok": false, "reason": &"missing_trainer_after_script",
 				"bank": bank, "address": after_address,
-			})
-			if after_address > 0:
-				_frames.clear()
-				if not _push_frame(bank, after_address):
-					return {
-						"ok": false, "reason": &"missing_trainer_after_script",
-						"bank": bank, "address": after_address,
-					}
-		0x65:
-			if _just_battled():
-				_frames.clear()
-		0x66:
-			_script_value = 1 if _just_battled() else 0
-		0x73:
-			_loaded_emote = int(command.get("value", -1))
-			if _loaded_emote == 0xFF:
-				_loaded_emote = _script_value
-			_emit_runtime_event(&"emote_loaded", {"emote_id": _loaded_emote})
-		0x74:
-			## Script_showemote is `ScriptCall ShowEmoteScript`: loademote, an
-			## applymovement that shows the emote, `pause 0` over the delay this
-			## command just wrote, and an applymovement that hides it again. The two
-			## one-command movements are folded into the emote event and its hide;
-			## the pause is the wait, and it is what the operand measures.
-			var emote_id: int = int(command.get("value", _loaded_emote))
-			if emote_id == 0xFF:
-				emote_id = _loaded_emote
-			_loaded_emote = emote_id
-			## `cp LAST_TALKED / jr z` keeps hLastTalked as it was only when the
-			## operand is LAST_TALKED itself; every other id becomes the new one,
-			## which is what the two `applymovementlasttalked`s inside
-			## ShowEmoteScript then move.
-			var emote_object_id: int = int(command.get("object_id", 0))
-			if emote_object_id != LAST_TALKED:
-				_last_talked_object_index = _object_index_from_id(emote_object_id)
-			var emote_object: int = _object_index_from_id(emote_object_id)
-			_script_delay = int(command.get("value_2", 0))
-			_emit_object_event(&"object_emote", {
-				"object_index": emote_object,
-				"emote_id": emote_id,
-				"visible": true,
-				## Zero is "until the hide", not "for no time": the source takes the
-				## emote down from ShowEmoteScript's last command, not on a counter.
-				"duration": 0,
-			})
-			return _stage_frame_wait(
-				_script_delay * PAUSE_FRAMES_PER_UNIT,
-				{"hide_emote_object": emote_object, "emote_id": emote_id}
-			)
-		0x77:
-			## Script_earthquake is `ScriptCall` on `applymovement PLAYER,
-			## wEarthquakeMovementDataBuffer`, whose stream is `step_shake n` then
-			## `step_sleep (n & %00111111)`. The shake starts and the movement wait
-			## is that sleep, since step_shake itself reaches
-			## ContinueReadingMovement without spending a frame.
-			_emit_runtime_event(&"earthquake_requested", {
-				"strength": int(command.get("value", 0)),
-			})
-			return _stage_frame_wait(int(command.get("value", 0)) & 0x3F)
-		0x78:
-			_emit_runtime_event(&"map_blocks_requested", {
-				"bank": bank, "address": int(command.get("address", 0)),
-			})
-		0x79:
-			_emit_runtime_event(&"map_block_changed", {
-				"x": int(command.get("x", 0)), "y": int(command.get("y", 0)),
-				"block": int(command.get("block", 0)),
-			})
-		0x7A:
-			_emit_runtime_event(&"map_reload_requested", {})
-		0x7B:
-			_emit_runtime_event(&"map_refresh_requested", {})
-		0x7C:
-			_emit_runtime_event(&"command_queue_written", {
-				"bank": bank, "address": int(command.get("address", 0)),
-			})
-		0x7D:
-			_script_value = 1
-			_emit_runtime_event(&"command_queue_deleted", {
-				"queue_id": int(command.get("value", -1)),
-			})
-		0x7E:
-			return _stage_audio_request(&"music", {
-				"address": int(command.get("address", 0)),
-			})
-		0x7F:
-			return _stage_audio_request(&"encounter_music", {})
-		0x80:
-			return _stage_audio_request(&"music_fadeout", {
-				"music": int(command.get("value", 0)),
-				"fade_time": int(command.get("value_2", 0)),
-			})
-		0x81:
-			return _stage_audio_request(&"map_music", {})
-		0x82:
-			_emit_runtime_event(&"map_music_restart_disabled", {})
-		0x83:
-			return _stage_audio_request(&"cry", {"species": int(command.get("value", 0))})
-		0x84:
-			return _stage_audio_request(&"sound", {"address": int(command.get("value", 0))})
-		0x85:
-			return _stage_audio_request(&"sound_wait", {})
-		0x86:
-			return _stage_audio_request(&"warp_sound", {
-				"collision": int(_request.get("collision", -1)),
-			})
-		0x87:
-			return _stage_audio_request(&"special_sound", {"item": _last_item})
-		0x6C:
-			## variablesprite stores a sprite id in the source's variable-sprite
-			## table. The first operand is an index relative to SPRITE_VARS.
-			_emit_runtime_event(&"variable_sprite_changed", {
-				"variable_sprite": VARIABLE_SPRITE_BASE + int(command.get("value", 0)),
-				"sprite": int(command.get("value_2", 0)),
-			})
-		0x8A, 0x8B:
-			## Both write wScriptDelay when their operand is nonzero and reuse
-			## whatever is in it when it is zero. `Script_pause` then spends
-			## `DelayFrames 2` per unit inside the command; `Script_deactivatefacing`
-			## hands the same count to SCRIPT_WAIT, which WaitScript decrements once
-			## per frame.
-			var delay_operand: int = int(command.get("value", 0))
-			if delay_operand != 0:
-				_script_delay = delay_operand
-			var delay_frames: int = _script_delay * PAUSE_FRAMES_PER_UNIT \
-				if source_opcode == 0x8A else _script_delay
-			_emit_runtime_event(&"script_timing_requested", {
-				"kind": &"pause" if source_opcode == 0x8A else &"deactivate_facing",
-				"value": delay_operand,
-				"frames": delay_frames,
-			})
-			return _stage_frame_wait(delay_frames)
-		0x8C:
-			_ran_deferred = true
-			if not _push_frame(bank, int(command.get("address", 0))):
-				return {
-					"ok": false, "reason": &"missing_deferred_script",
-					"bank": bank, "address": int(command.get("address", 0)),
-				}
-		0x89:
-			## Script_newloadmap sets hMapEntryMethod and re-enters the current
-			## map. It yields rather than ending: StopScript only clears
-			## SCRIPT_RUNNING in wScriptFlags, so the commands after it run, as
-			## FallIntoMapScript's pitfall animation shows
-			## (engine/overworld/events.asm). The re-entry itself is already
-			## queued here, because the `warpcheck` before it took a warp and
-			## every map change queues its own callbacks, so what is left to
-			## carry is the entry method the transition is drawn with.
-			_emit_runtime_event(&"map_entry_method_requested", {
-				"method": int(command.get("value", 0)),
-			})
-		0x8D:
-			## Script_warpcheck runs WarpCheck against the cell the player is
-			## standing on, so the destination is the world's to resolve, not
-			## the script's. Burned Tower's rival scene opens the hole under the
-			## player and then relies on this to drop them through it.
-			_emit_runtime_event(&"warp_check_requested", {})
-		0x93:
-			var mart: Dictionary = {
-				"dialog": int(command.get("value", 0)),
-				"address": int(command.get("address", 0)),
 			}
-			if command.has("mart_items"):
-				mart["items"] = command["mart_items"]
-			return _stage_runtime_request(&"mart_requested", mart)
-		0x94:
-			## `Script_elevator` hands `Elevator` the pointer in `de` and the
-			## running script's own bank in `b`, which is where the `elevfloor`
-			## list lives.
-			return _stage_runtime_request(&"elevator_requested", {
-				"bank": bank,
-				"address": int(command.get("address", 0)),
-			})
-		0x95:
-			var trade: Dictionary = {"trade_id": int(command.get("value", 0))}
-			## A patched site names both halves; an unpatched one names neither
-			## and the record answers for both, as it always has.
-			for key: String in ["offered_species", "requested_species"]:
-				if command.has(key):
-					trade[key] = int(command[key])
-			return _stage_runtime_request(&"trade_requested", trade)
-		0x96:
-			return _stage_phone_choice(int(command.get("value", 0)))
-		0x97:
-			return _stage_runtime_request(&"phone_call_requested", {
-				"address": int(command.get("address", 0)),
-			})
-		0x98:
-			## `Script_hangup` is `HangUp` inline: seven twenty-frame waits with
-			## its own two lines on the box, and no button anywhere in it.
-			_emit_runtime_event(&"phone_hangup", {
-				"frames": Gen2WorldPhoneRing.HANG_UP_FRAMES,
-			})
-			return _stage_frame_wait(
-				Gen2WorldPhoneRing.HANG_UP_FRAMES, {"hang_up": true}
-			)
-		0x99:
-			return _stage_decoration_description(int(command.get("value", 0)))
-		0x9A:
-			return _stage_fruit_tree(int(command.get("value", 0)))
-		0x9B:
-			## The cartridge uses specialphonecall to store the pending special
-			## call. Imported phone scripts also use SPECIALCALL_NONE to clear it.
-			## This command never starts the call directly. CheckSpecialPhoneCall
-			## consumes the staged value during a later step.
-			var special_call_id: int = int(command.get("address", 0))
-			if not _phone_context.is_empty():
-				_phone_context["special_call_id"] = special_call_id
-			_staged_special_phone_call = special_call_id
-			_has_staged_special_phone_call = true
-			_script_value = 1
-			_emit_runtime_event(&"special_phone_call_changed", {
-				"call_id": special_call_id,
-			})
-			return {"ok": true}
-		0x9C:
-			_script_value = 1 if _current_special_phone_call() != 0 else 0
-		0x9D:
-			## Script_verbosegiveitem is Script_giveitem plus `CurItemName` and a
-			## CopyConvertedText into STRING_BUFFER_4, which is what GiveItemScript's
-			## _ReceivedItemText then prints as `text_ram wStringBuffer4`. Staging
-			## the item without filling the buffer leaves that text unresolved.
-			var verbose_item: int = int(command.get("item", 0))
-			var verbose_name: String = data.item_name(verbose_item) if data != null else ""
-			_set_text_buffer(
-				RomLayout.STRING_BUFFER_4, verbose_name, &"item_name",
-				{"item": verbose_item}
-			)
-			var given: Dictionary = _stage_item_delta(
-				verbose_item, int(command.get("quantity", 1))
-			)
-			if not bool(given.get("ok", true)):
-				return given
-			return _stage_give_item_script(verbose_item, verbose_name)
-		0x9E:
-			## Crystal's `swarm` carries which of the two swarms it is setting
-			## and pokegold's does not, because `StoreSwarmMapIndices` there
-			## writes one pair whatever `c` holds.
-			return _stage_runtime_request(&"swarm_requested", {
-				"kind": int(command.get("flag", Gen2WorldState.SWARM_DUNSPARCE)),
-				"map_group": int(command.get("map_group", 0)),
-				"map_number": int(command.get("map_number", 0)),
-			})
-		0x9F:
-			_staged_engine_flags[Gen2WorldState.ENGINE_HALL_OF_FAME] = true
-			_events.append({"type": &"hall_of_fame_requested"})
-		0xA0:
-			## Script_credits farcalls RedCredits and then falls into
-			## Script_endall the way Script_halloffame does
-			## (engine/overworld/scripting.asm's ReturnFromCredits). No flag and
-			## no state: presentation only, and both call sites are followed by
-			## the source's own `end`, so this runs on rather than stopping.
-			_events.append({"type": &"credits_requested"})
-		0xA1:
-			return _stage_warp_facing_request(command)
-		0xA2:
-			## Crystal's own `battletowertext`, raw $a4. Gold and Silver's
-			## command table stops at $a1, so nothing of theirs reaches here.
-			return _stage_battle_tower_text(int(command.get("value", 1)))
-	## The commands whose case above falls out of the match rather than returning
-	## a result of its own. The four that now wait (`showemote`, `earthquake`,
-	## `pause` and `deactivatefacing`) return from inside it and are not here.
-	var handled_sources: Array = [
-		0x55, 0x56, 0x57, 0x58, 0x5B, 0x5C, 0x5D, 0x5F, 0x60, 0x61, 0x62, 0x63, 0x64,
-		0x65, 0x66, 0x7F, 0x81, 0x82, 0x85, 0x8D, 0x98,
-		0x8C,
-		0x6C, 0x73, 0x78, 0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x9C, 0x9F,
-		0xA0, 0x89,
-	]
-	if source_opcode in handled_sources:
-		return {"ok": true}
-	return {}
+	return {"ok": true}
+
+
+func _command_endifjustbattled(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	if _just_battled():
+		_frames.clear()
+	return {"ok": true}
+
+
+func _command_checkjustbattled(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if _just_battled() else 0
+	return {"ok": true}
+
+
+func _command_loademote(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_loaded_emote = int(command.get("value", -1))
+	if _loaded_emote == 0xFF:
+		_loaded_emote = _script_value
+	_emit_runtime_event(&"emote_loaded", {"emote_id": _loaded_emote})
+	return {"ok": true}
+
+
+## Script_showemote is `ScriptCall ShowEmoteScript`: loademote, an applymovement that
+## shows the emote, `pause 0` over the delay this command just wrote, and an
+## applymovement that hides it again. The two one-command movements are folded into
+## the emote event and its hide; the pause is the wait, and it is what the operand
+## measures.
+func _command_showemote(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var emote_id: int = int(command.get("value", _loaded_emote))
+	if emote_id == 0xFF:
+		emote_id = _loaded_emote
+	_loaded_emote = emote_id
+	## `cp LAST_TALKED / jr z` keeps hLastTalked as it was only when the
+	## operand is LAST_TALKED itself; every other id becomes the new one,
+	## which is what the two `applymovementlasttalked`s inside
+	## ShowEmoteScript then move.
+	var emote_object_id: int = int(command.get("object_id", 0))
+	if emote_object_id != LAST_TALKED:
+		_last_talked_object_index = _object_index_from_id(emote_object_id)
+	var emote_object: int = _object_index_from_id(emote_object_id)
+	_script_delay = int(command.get("value_2", 0))
+	_emit_object_event(&"object_emote", {
+		"object_index": emote_object,
+		"emote_id": emote_id,
+		"visible": true,
+		## Zero is "until the hide", not "for no time": the source takes the
+		## emote down from ShowEmoteScript's last command, not on a counter.
+		"duration": 0,
+	})
+	return _stage_frame_wait(
+		_script_delay * PAUSE_FRAMES_PER_UNIT,
+		{"hide_emote_object": emote_object, "emote_id": emote_id}
+	)
+
+
+## Script_earthquake is `ScriptCall` on `applymovement PLAYER,
+## wEarthquakeMovementDataBuffer`, whose stream is `step_shake n` then `step_sleep (n
+## & %00111111)`. The shake starts and the movement wait is that sleep, since
+## step_shake itself reaches ContinueReadingMovement without spending a frame.
+func _command_earthquake(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"earthquake_requested", {
+		"strength": int(command.get("value", 0)),
+	})
+	return _stage_frame_wait(int(command.get("value", 0)) & 0x3F)
+
+
+func _command_changemapblocks(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	_emit_runtime_event(&"map_blocks_requested", {
+		"bank": bank, "address": int(command.get("address", 0)),
+	})
+	return {"ok": true}
+
+
+func _command_changeblock(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"map_block_changed", {
+		"x": int(command.get("x", 0)), "y": int(command.get("y", 0)),
+		"block": int(command.get("block", 0)),
+	})
+	return {"ok": true}
+
+
+func _command_reloadmap(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"map_reload_requested", {})
+	return {"ok": true}
+
+
+func _command_refreshmap(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"map_refresh_requested", {})
+	return {"ok": true}
+
+
+func _command_writecmdqueue(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	_emit_runtime_event(&"command_queue_written", {
+		"bank": bank, "address": int(command.get("address", 0)),
+	})
+	return {"ok": true}
+
+
+func _command_delcmdqueue(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1
+	_emit_runtime_event(&"command_queue_deleted", {
+		"queue_id": int(command.get("value", -1)),
+	})
+	return {"ok": true}
+
+
+func _command_playmusic(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"music", {
+		"address": int(command.get("address", 0)),
+	})
+
+
+func _command_encountermusic(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"encounter_music", {})
+
+
+func _command_musicfadeout(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"music_fadeout", {
+		"music": int(command.get("value", 0)),
+		"fade_time": int(command.get("value_2", 0)),
+	})
+
+
+func _command_playmapmusic(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"map_music", {})
+
+
+func _command_dontrestartmapmusic(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"map_music_restart_disabled", {})
+	return {"ok": true}
+
+
+func _command_cry(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"cry", {"species": int(command.get("value", 0))})
+
+
+func _command_playsound(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"sound", {"address": int(command.get("value", 0))})
+
+
+func _command_waitsfx(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"sound_wait", {})
+
+
+func _command_warpsound(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"warp_sound", {
+		"collision": int(_request.get("collision", -1)),
+	})
+
+
+func _command_specialsound(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_audio_request(&"special_sound", {"item": _last_item})
+
+
+## variablesprite stores a sprite id in the source's variable-sprite table. The first
+## operand is an index relative to SPRITE_VARS.
+func _command_variablesprite(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"variable_sprite_changed", {
+		"variable_sprite": VARIABLE_SPRITE_BASE + int(command.get("value", 0)),
+		"sprite": int(command.get("value_2", 0)),
+	})
+	return {"ok": true}
+
+
+## Both write wScriptDelay when their operand is nonzero and reuse whatever is in it
+## when it is zero. `Script_pause` then spends `DelayFrames 2` per unit inside the
+## command; `Script_deactivatefacing` hands the same count to SCRIPT_WAIT, which
+## WaitScript decrements once per frame.
+func _command_pause(source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var delay_operand: int = int(command.get("value", 0))
+	if delay_operand != 0:
+		_script_delay = delay_operand
+	var delay_frames: int = _script_delay * PAUSE_FRAMES_PER_UNIT \
+		if source_opcode == 0x8A else _script_delay
+	_emit_runtime_event(&"script_timing_requested", {
+		"kind": &"pause" if source_opcode == 0x8A else &"deactivate_facing",
+		"value": delay_operand,
+		"frames": delay_frames,
+	})
+	return _stage_frame_wait(delay_frames)
+
+
+func _command_sdefer(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	_ran_deferred = true
+	if not _push_frame(bank, int(command.get("address", 0))):
+		return {
+			"ok": false, "reason": &"missing_deferred_script",
+			"bank": bank, "address": int(command.get("address", 0)),
+		}
+	return {"ok": true}
+
+
+## Script_newloadmap sets hMapEntryMethod and re-enters the current map. It yields
+## rather than ending: StopScript only clears SCRIPT_RUNNING in wScriptFlags, so the
+## commands after it run, as FallIntoMapScript's pitfall animation shows
+## (engine/overworld/events.asm). The re-entry itself is already queued here, because
+## the `warpcheck` before it took a warp and every map change queues its own
+## callbacks, so what is left to carry is the entry method the transition is drawn
+## with.
+func _command_newloadmap(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"map_entry_method_requested", {
+		"method": int(command.get("value", 0)),
+	})
+	return {"ok": true}
+
+
+## Script_warpcheck runs WarpCheck against the cell the player is standing on, so the
+## destination is the world's to resolve, not the script's. Burned Tower's rival scene
+## opens the hole under the player and then relies on this to drop them through it.
+func _command_warpcheck(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"warp_check_requested", {})
+	return {"ok": true}
+
+
+func _command_pokemart(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var mart: Dictionary = {
+		"dialog": int(command.get("value", 0)),
+		"address": int(command.get("address", 0)),
+	}
+	if command.has("mart_items"):
+		mart["items"] = command["mart_items"]
+	return _stage_runtime_request(&"mart_requested", mart)
+
+
+## `Script_elevator` hands `Elevator` the pointer in `de` and the running script's own
+## bank in `b`, which is where the `elevfloor` list lives.
+func _command_elevator(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	return _stage_runtime_request(&"elevator_requested", {
+		"bank": bank,
+		"address": int(command.get("address", 0)),
+	})
+
+
+func _command_trade(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var trade: Dictionary = {"trade_id": int(command.get("value", 0))}
+	## A patched site names both halves; an unpatched one names neither
+	## and the record answers for both, as it always has.
+	for key: String in ["offered_species", "requested_species"]:
+		if command.has(key):
+			trade[key] = int(command[key])
+	return _stage_runtime_request(&"trade_requested", trade)
+
+
+func _command_askforphonenumber(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_phone_choice(int(command.get("value", 0)))
+
+
+func _command_phonecall(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_runtime_request(&"phone_call_requested", {
+		"address": int(command.get("address", 0)),
+	})
+
+
+## `Script_hangup` is `HangUp` inline: seven twenty-frame waits with its own two lines
+## on the box, and no button anywhere in it.
+func _command_hangup(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"phone_hangup", {
+		"frames": Gen2WorldPhoneRing.HANG_UP_FRAMES,
+	})
+	return _stage_frame_wait(
+		Gen2WorldPhoneRing.HANG_UP_FRAMES, {"hang_up": true}
+	)
+
+
+func _command_describedecoration(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_decoration_description(int(command.get("value", 0)))
+
+
+func _command_fruittree(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_fruit_tree(int(command.get("value", 0)))
+
+
+## The cartridge uses specialphonecall to store the pending special call. Imported
+## phone scripts also use SPECIALCALL_NONE to clear it. This command never starts the
+## call directly. CheckSpecialPhoneCall consumes the staged value during a later step.
+func _command_specialphonecall(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var special_call_id: int = int(command.get("address", 0))
+	if not _phone_context.is_empty():
+		_phone_context["special_call_id"] = special_call_id
+	_staged_special_phone_call = special_call_id
+	_has_staged_special_phone_call = true
+	_script_value = 1
+	_emit_runtime_event(&"special_phone_call_changed", {
+		"call_id": special_call_id,
+	})
+	return {"ok": true}
+
+
+func _command_checkphonecall(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_script_value = 1 if _current_special_phone_call() != 0 else 0
+	return {"ok": true}
+
+
+## Script_verbosegiveitem is Script_giveitem plus `CurItemName` and a
+## CopyConvertedText into STRING_BUFFER_4, which is what GiveItemScript's
+## _ReceivedItemText then prints as `text_ram wStringBuffer4`. Staging the item
+## without filling the buffer leaves that text unresolved.
+func _command_verbosegiveitem(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	var verbose_item: int = int(command.get("item", 0))
+	var verbose_name: String = data.item_name(verbose_item) if data != null else ""
+	_set_text_buffer(
+		RomLayout.STRING_BUFFER_4, verbose_name, &"item_name",
+		{"item": verbose_item}
+	)
+	var given: Dictionary = _stage_item_delta(
+		verbose_item, int(command.get("quantity", 1))
+	)
+	if not bool(given.get("ok", true)):
+		return given
+	return _stage_give_item_script(verbose_item, verbose_name)
+
+
+## Crystal's `swarm` carries which of the two swarms it is setting and pokegold's does
+## not, because `StoreSwarmMapIndices` there writes one pair whatever `c` holds.
+func _command_swarm(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_runtime_request(&"swarm_requested", {
+		"kind": int(command.get("flag", Gen2WorldState.SWARM_DUNSPARCE)),
+		"map_group": int(command.get("map_group", 0)),
+		"map_number": int(command.get("map_number", 0)),
+	})
+
+
+func _command_halloffame(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_staged_engine_flags[Gen2WorldState.ENGINE_HALL_OF_FAME] = true
+	_events.append({"type": &"hall_of_fame_requested"})
+	return {"ok": true}
+
+
+## Script_credits farcalls RedCredits and then falls into Script_endall the way
+## Script_halloffame does (engine/overworld/scripting.asm's ReturnFromCredits). No
+## flag and no state: presentation only, and both call sites are followed by the
+## source's own `end`, so this runs on rather than stopping.
+func _command_credits(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_events.append({"type": &"credits_requested"})
+	return {"ok": true}
+
+
+func _command_warpfacing(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_warp_facing_request(command)
+
+
+## Crystal's own `battletowertext`, raw $a4. Gold and Silver's command table stops at
+## $a1, so nothing of theirs reaches here.
+func _command_battletowertext(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	return _stage_battle_tower_text(int(command.get("value", 1)))
 
 
 func _execute_object_command(source_opcode: int, command: Dictionary) -> Dictionary:
@@ -3333,848 +3832,1190 @@ static func itemfinder_sounds() -> Array:
 	return schedule
 
 
+## Every special this runner answers, as the handler that answers it. SPECIAL is a
+## shared cartridge dispatch table: phone routines are one part of it, and map
+## callbacks and the new-game clock setup use the same table.
+const SPECIAL_HANDLERS: Dictionary = {
+	SPECIAL_OVERWORLD_TOWN_MAP: &"_special_overworld_town_map",
+	SPECIAL_PLAYERS_HOUSE_PC: &"_special_players_house_pc",
+	SPECIAL_POKEMON_CENTER_PC: &"_special_pokemon_center_pc",
+	SPECIAL_BATTLE_TOWER_ACTION: &"_special_battle_tower_action",
+	SPECIAL_CHECK_BATTLE_TOWER_RULES: &"_special_check_battle_tower_rules",
+	SPECIAL_TRY_QUICK_SAVE: &"_special_try_quick_save",
+	SPECIAL_RESET: &"_special_reset",
+	SPECIAL_CHALLENGE_MENU: &"_special_challenge_menu",
+	SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST: &"_special_request_link_room",
+	SPECIAL_SET_BITS_FOR_BATTLE_REQUEST: &"_special_request_link_room",
+	SPECIAL_SET_BITS_FOR_TIME_CAPSULE_REQUEST: &"_special_set_bits_for_time_capsule_request",
+	SPECIAL_WAIT_FOR_LINKED_FRIEND: &"_special_wait_for_linked_friend",
+	SPECIAL_CHECK_LINK_TIMEOUT_RECEPTIONIST: &"_special_check_link_timeout_receptionist",
+	SPECIAL_CHECK_BOTH_SELECTED_SAME_ROOM: &"_special_check_both_selected_same_room",
+	SPECIAL_FAILED_LINK_TO_PAST: &"_special_failed_link_to_past",
+	SPECIAL_CLOSE_LINK: &"_special_close_link",
+	SPECIAL_WAIT_FOR_OTHER_PLAYER_TO_EXIT: &"_special_wait_for_other_player_to_exit",
+	SPECIAL_CHECK_TIME_CAPSULE_COMPATIBILITY: &"_special_check_time_capsule_compatibility",
+	SPECIAL_ENTER_TIME_CAPSULE: &"_special_enter_time_capsule",
+	SPECIAL_TRADE_CENTER: &"_special_link_room",
+	SPECIAL_COLOSSEUM: &"_special_link_room",
+	SPECIAL_TIME_CAPSULE: &"_special_link_room",
+	SPECIAL_CHECK_MOBILE_ADAPTER_STATUS: &"_special_check_mobile_adapter_status",
+	SPECIAL_CABLE_CLUB_CHECK_WHICH_CHRIS: &"_special_cable_club_check_which_chris",
+	SPECIAL_DISPLAY_LINK_RECORD: &"_special_display_link_record",
+	SPECIAL_BATTLE_TOWER_ROOM_MENU: &"_special_battle_tower_room_menu",
+	SPECIAL_LOAD_BATTLE_TOWER_OPPONENT: &"_special_load_battle_tower_opponent",
+	SPECIAL_BATTLE_TOWER_BATTLE: &"_special_battle_tower_battle",
+	SPECIAL_SET_DAY_OF_WEEK: &"_special_set_day_of_week",
+	SPECIAL_INITIAL_SET_DST_FLAG: &"_special_initial_set_dst_flag",
+	SPECIAL_INITIAL_CLEAR_DST_FLAG: &"_special_initial_clear_dst_flag",
+	SPECIAL_PLAY_MAP_MUSIC: &"_special_map_music",
+	SPECIAL_RESTART_MAP_MUSIC: &"_special_map_music",
+	SPECIAL_FADE_OUT_MUSIC: &"_special_fade_out_music",
+	36: &"_special_rival_name",
+	27: &"_special_heal_party",
+	SPECIAL_HEAL_MACHINE_ANIM: &"_special_heal_machine_anim",
+	SPECIAL_MAGNET_TRAIN: &"_special_magnet_train",
+	SPECIAL_PROF_OAKS_PC_BOOT: &"_special_prof_oaks_pc_boot",
+	SPECIAL_CHECK_POKERUS: &"_special_check_pokerus",
+	SPECIAL_SNORLAX_AWAKE: &"_special_snorlax_awake",
+	SPECIAL_FADE_OUT_TO_WHITE: &"_special_palette_fade",
+	SPECIAL_BATTLE_TOWER_FADE: &"_special_palette_fade",
+	SPECIAL_FADE_OUT_TO_BLACK: &"_special_palette_fade",
+	SPECIAL_FADE_IN_FROM_WHITE: &"_special_palette_fade",
+	SPECIAL_FADE_IN_FROM_BLACK: &"_special_palette_fade",
+	51: &"_special_presentation_only",
+	52: &"_special_presentation_only",
+	53: &"_special_presentation_only",
+	55: &"_special_presentation_only",
+	56: &"_special_presentation_only",
+	94: &"_special_presentation_only",
+	152: &"_special_presentation_only",
+	157: &"_special_presentation_only",
+	158: &"_special_presentation_only",
+	164: &"_special_presentation_only",
+	95: &"_special_cry",
+	100: &"_special_cry",
+	59: &"_special_wait_sfx",
+	66: &"_special_find_party_mon",
+	67: &"_special_find_party_mon",
+	89: &"_special_first_mon_happiness",
+	90: &"_special_first_mon_is_egg",
+	102: &"_special_gameboy_check",
+	150: &"_special_mon_check",
+	151: &"_special_mon_check",
+	SPECIAL_INIT_ROAM_MONS: &"_special_init_roam_mons",
+	SPECIAL_BILLS_GRANDFATHER: &"_special_grooming",
+	SPECIAL_OLDER_HAIRCUT_BROTHER: &"_special_grooming",
+	SPECIAL_YOUNGER_HAIRCUT_BROTHER: &"_special_grooming",
+	SPECIAL_DAISYS_GROOMING: &"_special_grooming",
+	SPECIAL_DISPLAY_COIN_CASE_BALANCE: &"_special_money_window",
+	SPECIAL_DISPLAY_MONEY_AND_COIN_BALANCE: &"_special_money_window",
+	SPECIAL_PLACE_MONEY_TOP_RIGHT: &"_special_money_window",
+	SPECIAL_DAY_CARE_MAN: &"_special_day_care",
+	SPECIAL_DAY_CARE_LADY: &"_special_day_care",
+	SPECIAL_DAY_CARE_MAN_OUTSIDE: &"_special_day_care",
+	SPECIAL_DAY_CARE_MON_1: &"_special_day_care",
+	SPECIAL_DAY_CARE_MON_2: &"_special_day_care",
+	SPECIAL_NAME_RATER: &"_special_name_rater",
+	SPECIAL_MOVE_DELETION: &"_special_move_deletion",
+	SPECIAL_MOVE_TUTOR: &"_special_move_tutor",
+	SPECIAL_SELECT_APRICORN_FOR_KURT: &"_special_select_apricorn_for_kurt",
+	SPECIAL_GIVE_PARK_BALLS: &"_special_give_park_balls",
+	SPECIAL_SELECT_RANDOM_BUG_CONTESTANTS: &"_special_select_random_bug_contestants",
+	SPECIAL_CONTEST_DROP_OFF_MONS: &"_special_contest_drop_off_mons",
+	SPECIAL_CONTEST_RETURN_MONS: &"_special_contest_return_mons",
+	SPECIAL_WARP_TO_SPAWN_POINT: &"_special_warp_to_spawn_point",
+	SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST: &"_special_check_party_full_after_contest",
+	SPECIAL_BUG_CONTEST_JUDGING: &"_special_bug_contest_judging",
+	SPECIAL_ACTIVATE_FISHING_SWARM: &"_special_activate_fishing_swarm",
+	SPECIAL_TOGGLE_MAPTILE_DECORATIONS: &"_special_toggle_maptile_decorations",
+	SPECIAL_TOGGLE_DECORATIONS_VISIBILITY: &"_special_toggle_decorations_visibility",
+	SPECIAL_SLOT_MACHINE: &"_special_slot_machine",
+	SPECIAL_CARD_FLIP: &"_special_card_flip",
+	SPECIAL_UNOWN_PUZZLE: &"_special_unown_puzzle",
+	SPECIAL_DISPLAY_UNOWN_WORDS: &"_special_display_unown_words",
+	SPECIAL_SAMPLE_KENJI_BREAK_COUNTDOWN: &"_special_sample_kenji_break_countdown",
+	SPECIAL_TRAINER_HOUSE: &"_special_trainer_house",
+	SPECIAL_CHECK_MYSTERY_GIFT: &"_special_check_mystery_gift",
+	SPECIAL_UNLOCK_MYSTERY_GIFT: &"_special_unlock_mystery_gift",
+	SPECIAL_GET_MYSTERY_GIFT_ITEM: &"_special_get_mystery_gift_item",
+	SPECIAL_HO_OH_CHAMBER: &"_special_ho_oh_chamber",
+	SPECIAL_OMANYTE_CHAMBER: &"_special_omanyte_chamber",
+	SPECIAL_CHECK_CAUGHT_CELEBI: &"_special_check_caught_celebi",
+	SPECIAL_CELEBI_SHRINE_EVENT: &"_special_celebi_shrine_event",
+	SPECIAL_MAP_RADIO: &"_special_map_radio",
+	SPECIAL_CHECK_LUCKY_NUMBER_SHOW_FLAG: &"_special_check_lucky_number_show_flag",
+	SPECIAL_RESET_LUCKY_NUMBER_SHOW_FLAG: &"_special_reset_lucky_number_show_flag",
+	SPECIAL_PRINT_TODAYS_LUCKY_NUMBER: &"_special_print_todays_lucky_number",
+	SPECIAL_CHECK_FOR_LUCKY_NUMBER_WINNERS: &"_special_check_for_lucky_number_winners",
+	SPECIAL_MAGIKARP_HOUSE_SIGN: &"_special_magikarp_house_sign",
+	SPECIAL_BANK_OF_MOM: &"_special_bank_of_mom",
+	SPECIAL_UNOWN_PRINTER: &"_special_unown_printer",
+	SPECIAL_DIPLOMA: &"_special_diploma",
+	SPECIAL_PRINT_DIPLOMA: &"_special_diploma",
+	SPECIAL_BUENA_PRIZE: &"_special_buena_prize",
+	SPECIAL_POKE_SEER: &"_special_poke_seer",
+	SPECIAL_CHECK_MAGIKARP_LENGTH: &"_special_party_selection",
+	SPECIAL_PHOTO_STUDIO: &"_special_party_selection",
+	SPECIAL_RETURN_SHUCKIE: &"_special_party_selection",
+	SPECIAL_GIVE_SHUCKLE: &"_special_give_shuckle",
+	SPECIAL_ASK_REMEMBER_PASSWORD: &"_special_ask_remember_password",
+	SPECIAL_GIVE_ODD_EGG: &"_special_give_odd_egg",
+	SPECIAL_GIVE_DRATINI: &"_special_give_dratini",
+	SPECIAL_GAME_CORNER_PRIZE_MON_CHECK_DEX: &"_special_game_corner_prize_mon_check_dex",
+	SPECIAL_BUENAS_PASSWORD: &"_special_buenas_password",
+	SPECIAL_RANDOM_UNSEEN_WILD_MON: &"_special_random_unseen_wild_mon",
+	SPECIAL_RANDOM_PHONE_WILD_MON: &"_special_random_phone_wild_mon",
+	SPECIAL_RANDOM_PHONE_MON: &"_special_random_phone_mon",
+}
+
+
 ## [param special] is the Crystal-canonical index from
 ## Gen2WorldScript.special_index(), not the raw stream byte, so the payloads
 ## below report that index on both profiles.
 func _execute_special(special: int) -> Dictionary:
-	## SPECIAL is a shared cartridge dispatch table. Phone routines are only one
-	## part of it; map callbacks and the new-game clock setup use the same table.
-	match special:
-		SPECIAL_OVERWORLD_TOWN_MAP:
-			return _stage_runtime_request(&"town_map_requested", {
-				"special": special,
-				"landmark": int(_request.get("landmark", 0)),
-			})
-		SPECIAL_PLAYERS_HOUSE_PC:
-			return _stage_runtime_request(&"pc_requested", {
-				"special": special,
-				"mode": &"players_house",
-			})
-		SPECIAL_POKEMON_CENTER_PC:
-			return _stage_runtime_request(&"pc_requested", {
-				"special": special,
-				"mode": &"pokemon_center",
-			})
-		SPECIAL_BATTLE_TOWER_ACTION:
-			## `jumptable .dw, wScriptVar`: the `setval` in front of the special
-			## names the row, and the row's own answer replaces it.
-			var answered: int = _battle_tower().action(_script_value, {
-				"party": _battle_tower_party(),
-				"pack": _pack_items(),
-				"save_is_yours": true,
-				"random": _battle_tower_random(0),
-			})
-			if answered >= 0:
-				_script_value = answered
-			return {"ok": true}
-		SPECIAL_CHECK_BATTLE_TOWER_RULES:
-			return _check_battle_tower_rules()
-		SPECIAL_TRY_QUICK_SAVE:
-			return _stage_runtime_request(&"quick_save_requested", {"special": special})
-		SPECIAL_RESET:
-			## The console restarting, which is how a saved-and-left challenge
-			## leaves the battle room. Nothing follows it in any script.
-			_events.append({"type": &"soft_reset_requested"})
-			_pending = {}
-			_active = false
-			_completed = true
-			return {"ok": true}
-		SPECIAL_CHALLENGE_MENU:
-			return _stage_challenge_menu()
-		SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST, SPECIAL_SET_BITS_FOR_BATTLE_REQUEST:
-			_link_session().request_room(
-				Gen2LinkSession.CABLECLUBROOM_TRADECENTER \
-					if special == SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST \
-					else Gen2LinkSession.CABLECLUBROOM_COLOSSEUM
-			)
-		SPECIAL_SET_BITS_FOR_TIME_CAPSULE_REQUEST:
-			## The Time Capsule asks for `CABLECLUBROOM_NULL`, which is why its
-			## own script never reaches `CheckBothSelectedSameRoom` on a branch
-			## that could pass.
-			_link_session().request_time_capsule()
-		SPECIAL_WAIT_FOR_LINKED_FRIEND:
-			_script_value = _link_session().wait_for_linked_friend(_link_transport())
-			if _script_value == 0:
-				return {"ok": true}
-			return _stage_frame_wait(
-				Gen2LinkSession.WAIT_FOR_FRIEND_CONNECTED_FRAMES,
-				{"special": special, "kind": &"link_wait"}
-			)
-		SPECIAL_CHECK_LINK_TIMEOUT_RECEPTIONIST:
-			var session: Gen2LinkSession = _link_session()
-			_script_value = session.check_link_timeout(_link_transport())
-			## The `readmem wOtherPlayerLinkMode` every one of the three scripts
-			## runs on the next line reads this byte and not wScriptVar.
-			var stored: Dictionary = _stage_script_memory(
-				data.other_player_link_mode_address() if data != null else -1,
-				session.other_player_link_mode
-			)
-			if not bool(stored.get("ok", true)):
-				return stored
-			return _stage_frame_wait(
-				Gen2LinkSession.CHECK_LINK_TIMEOUT_FRAMES,
-				{"special": special, "kind": &"link_wait"}
-			)
-		SPECIAL_CHECK_BOTH_SELECTED_SAME_ROOM:
-			_script_value = _link_session().check_both_selected_same_room(_link_transport())
-		SPECIAL_FAILED_LINK_TO_PAST:
-			_link_session().failed_link_to_past(_link_transport())
-			return _stage_frame_wait(
-				Gen2LinkSession.FAILED_LINK_TO_PAST_FRAMES,
-				{"special": special, "kind": &"link_wait"}
-			)
-		SPECIAL_CLOSE_LINK:
-			_link_session().close_link(_link_transport())
-			return _stage_frame_wait(
-				Gen2LinkSession.CLOSE_LINK_FRAMES,
-				{"special": special, "kind": &"link_wait"}
-			)
-		SPECIAL_WAIT_FOR_OTHER_PLAYER_TO_EXIT:
-			_link_session().wait_for_other_player_to_exit(_link_transport())
-			return _stage_frame_wait(
-				Gen2LinkSession.WAIT_FOR_OTHER_PLAYER_FRAMES,
-				{"special": special, "kind": &"link_wait"}
-			)
-		SPECIAL_CHECK_TIME_CAPSULE_COMPATIBILITY:
-			return _check_time_capsule_compatibility()
-		SPECIAL_ENTER_TIME_CAPSULE:
-			_link_session().enter_time_capsule(_link_transport())
-			return _stage_frame_wait(
-				Gen2LinkSession.ENTER_TIME_CAPSULE_FRAMES,
-				{"special": special, "kind": &"link_wait"}
-			)
-		SPECIAL_TRADE_CENTER, SPECIAL_COLOSSEUM, SPECIAL_TIME_CAPSULE:
-			return _stage_link_room(special)
-		SPECIAL_CHECK_MOBILE_ADAPTER_STATUS:
-			## `CheckMobileAdapterStatusSpecial` answers whether a Mobile Adapter
-			## GB is plugged in, and none is: there is no such peripheral on any
-			## platform this runs on. FALSE is what both Crystal receptionists
-			## branch on to reach `.NoMobile`, which is the cable club proper,
-			## so this is the answer that opens the room rather than the one that
-			## closes it.
-			_script_value = 0
-		SPECIAL_CABLE_CLUB_CHECK_WHICH_CHRIS:
-			_script_value = _link_session().which_chris(_link_transport())
-		SPECIAL_DISPLAY_LINK_RECORD:
-			## `_DisplayLinkRecord` draws `sLinkBattleStats` and holds for A or
-			## B. It writes nothing, so the script runs straight on behind it.
-			return _stage_runtime_request(&"link_record_requested", {"special": special})
-		SPECIAL_BATTLE_TOWER_ROOM_MENU:
-			return _stage_room_menu()
-		SPECIAL_LOAD_BATTLE_TOWER_OPPONENT:
-			return _load_battle_tower_opponent()
-		SPECIAL_BATTLE_TOWER_BATTLE:
-			return _stage_battle_tower_battle()
-		SPECIAL_SET_DAY_OF_WEEK:
-			_stage_day_of_week_menu()
-			return {"ok": true}
-		SPECIAL_INITIAL_SET_DST_FLAG:
-			_staged_dst_enabled = true
-			_has_staged_dst = true
-			_stage_dst_confirmation_text(true)
-			return {"ok": true}
-		SPECIAL_INITIAL_CLEAR_DST_FLAG:
-			_staged_dst_enabled = false
-			_has_staged_dst = true
-			_stage_dst_confirmation_text(false)
-			return {"ok": true}
-		SPECIAL_PLAY_MAP_MUSIC, SPECIAL_RESTART_MAP_MUSIC:
-			# Entering a map with the music already playing does not restart it,
-			# which is why crossing a route boundary is one continuous track.
-			# RestartMapMusic exists to override exactly that, so it says so.
-			return _stage_audio_request(&"map_music", {
-				"special": special,
-				"restart": special == SPECIAL_RESTART_MAP_MUSIC,
-			})
-		SPECIAL_FADE_OUT_MUSIC:
-			_emit_runtime_event(&"music_fadeout_requested", {"special": special})
-		36:
-			return _stage_runtime_request(&"rival_name_requested", {
-				"special": special, "default_name": "SILVER",
-			})
-		27:
-			## HealParty is a save-owned transaction. It is deliberately a host
-			## request so HP, status and PP are changed together with the selected
-			## project save.
-			return _stage_runtime_request(&"party_heal_requested", {"special": special})
-		SPECIAL_HEAL_MACHINE_ANIM:
-			## wScriptVar selects the machine's screen position: 0 Pokemon Center,
-			## 1 Elm's Lab, 2 Hall of Fame. A preceding SETVAL loads it. Nothing
-			## here changes state, but the routine is not free: it spends thirty
-			## frames a ball and `.FlashPalettes8Times`' eighty, with a sound on
-			## each ball, so the script waits for it the way the cartridge does.
-			var machine_type: int = clampi(_script_value, 0, HEAL_MACHINE_HALL_OF_FAME)
-			var balls: int = int((_request.get("party", {}) as Dictionary).get("count", 0))
-			var sounds: Array = heal_machine_sounds(machine_type, balls)
-			_emit_runtime_event(&"presentation_special_applied", {
-				"special": special, "kind": &"heal_machine_anim",
-				"machine_type": machine_type,
-				"balls": balls,
-				"sounds": sounds.duplicate(true),
-			})
-			## `ld a, [wPartyCount] / and a / ret z`: an empty party leaves the
-			## machine alone and spends nothing.
-			if balls > 0:
-				return _stage_frame_wait(
-					balls * HEAL_MACHINE_BALL_FRAMES + HEAL_MACHINE_FLASH_FRAMES,
-					{"special": special, "kind": &"heal_machine_anim"}
-				)
-		SPECIAL_MAGNET_TRAIN:
-			## engine/events/magnet_train.asm's MagnetTrain is scroll positions,
-			## graphics, music and a VBlank cutscene handler. It reads
-			## wScriptVar for the direction and writes nothing the overworld can
-			## observe; the warp itself is the `warpcheck` that follows it.
-			_emit_runtime_event(&"presentation_special_applied", {
-				"special": special, "kind": &"magnet_train",
-				"to_goldenrod": _script_value != 0,
-			})
-		SPECIAL_PROF_OAKS_PC_BOOT:
-			## engine/events/prof_oaks_pc.asm's ProfOaksPCBoot prints, counts the
-			## set bits in wPokedexSeen and wPokedexCaught for `Rate`, plays that
-			## rating's sound and waits for A or B. Presentation only: it writes
-			## nothing, so the script runs straight on to its own `end` and
-			## [Gen2ProfOaksPC] is handed the counts by whoever draws this.
-			_emit_runtime_event(&"presentation_special_applied", {
-				"special": special, "kind": &"prof_oaks_pc_boot",
-			})
-		SPECIAL_CHECK_POKERUS:
-			var party: Dictionary = _request.get("party", {})
-			if party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			_script_value = 1 if bool(party.get("pokerus", false)) else 0
-		SPECIAL_SNORLAX_AWAKE:
-			## Two reads and nothing else: the track in wMapMusic and the cell the
-			## player stands on. The Poke Flute channel reaches wMapMusic through
-			## StartRadioStation and stays there because closing the Pokegear
-			## restores the map's music only for its two sentinel ids.
-			var cell: Vector2i = _player_cell()
-			_script_value = 1 if state != null \
-				and state.map_music() == Gen2WorldRadio.MUSIC_POKE_FLUTE_CHANNEL \
-				and cell in SNORLAX_PROXIMITY_CELLS else 0
-		SPECIAL_FADE_OUT_TO_WHITE, SPECIAL_BATTLE_TOWER_FADE, SPECIAL_FADE_OUT_TO_BLACK, \
-		SPECIAL_FADE_IN_FROM_WHITE, SPECIAL_FADE_IN_FROM_BLACK:
-			## `FadeOutToWhite` is 46 in both pins, since Crystal's inserted
-			## `BattleTowerFade` sits at 47; `FadeInFromWhite` is 49 here and 48 in
-			## Gold/Silver, which `special_index()` already normalizes. Each of the
-			## five is `GetTimePalFade` and then four rows of the fade table, and
-			## none is free: `ConvertTimePals*HL` spends `ld c, 2` on every row, so
-			## the script holds for the whole walk the way it does on the cartridge.
-			## `FillWhiteBGColor` is the two white fades' alone.
-			var orders: Array[int] = FADE_ORDERS_OF[special]
-			var step_frames: int = Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES \
-				if special == SPECIAL_BATTLE_TOWER_FADE \
-				else Gen2WorldPalette.FADE_STEP_FRAMES
-			_emit_runtime_event(&"presentation_special_applied", {
-				"special": special, "kind": &"palette_fade",
-				"orders": orders.duplicate(),
-				"step_frames": step_frames,
-				"white_fill": special in FADE_WHITE_FILL_SPECIALS,
-			})
-			return _stage_frame_wait(orders.size() * step_frames, {
-				"special": special, "kind": &"palette_fade",
-			})
-		51, 52, 53, 55, 56, 94, 152, 157, 158, 164:
-			## Sprite reload, palette reload and the dummied trainer-ranking
-			## bookkeeping affect presentation or source-only counters rather than
-			## scene-free state. `LoadUsedSpritesGFX`, `UpdateSprites`,
-			## `UpdatePlayerSprite`, `ReloadSpritesNoPalettes` and `RefreshSprites`
-			## reload the sprite set a `variablesprite` just changed;
-			## `ClearBGPalettes`, `UpdateTimePals`, `SetPlayerPalette` and
-			## `LoadMapPalettes` are the palette pair the day/night scripts open
-			## with, and the renderer takes its palettes from the map and the clock.
-			_emit_runtime_event(&"presentation_special_applied", {"special": special})
-		95, 100:
-			## `PlaySlowCry` (95) is `LoadCry` with the record's own pitch lowered
-			## by `$140` and its length raised by `$60`, and `PlayCurMonCry` (100) is
-			## `PlayMonCry` straight. Neither writes anything back, so what they owe
-			## is the sound and the `WaitSFX` each ends on. They do not read the same
-			## byte: 95 is `ld a, [wScriptVar]`, which the `setval` in front of it
-			## has just set, and 100 is `ld a, [wCurPartySpecies]`, all four of whose
-			## scripts are a grooming routine's.
-			return _stage_audio_request(&"cry", {
-				"special": special,
-				"species": _script_value if special == 95 else _cur_party_species,
-				"slow": special == 95,
-			})
-		59:
-			## `SpecialWaitSFX` is `WaitSFX`: it holds until the four effect
-			## channels are free rather than spending a counted number of
-			## frames, which is `Script_waitsfx`'s own request.
-			return _stage_audio_request(&"sound_wait", {"special": special})
-		66, 67:
-			## `FindPartyMonThatSpecies` and its ID-checking twin. Both answer
-			## TRUE/FALSE in wScriptVar off the species wScriptVar was loaded
-			## with; the second adds `CheckOwnMon`'s ID and OT test on the slot
-			## the first one found.
-			var party: Dictionary = _request.get("party", {})
-			if party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			_script_value = 1 if _party_slot_of_species(
-				party, _script_value, special == 67
-			) >= 0 else 0
-		89:
-			## `GetFirstPokemonHappiness` walks past every EGG in the list and
-			## answers the first hatched member's happiness byte, naming that
-			## member in the buffer its two boxes print.
-			var happy_party: Dictionary = _request.get("party", {})
-			if happy_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			var eggs: Array = happy_party.get("eggs", [])
-			var happiness: Array = happy_party.get("happiness", [])
-			var names: Array = happy_party.get("names", [])
-			var slot: int = 0
-			while slot < eggs.size() and bool(eggs[slot]):
-				slot += 1
-			_script_value = int(happiness[slot]) if slot < happiness.size() else 0
-			if slot < names.size():
-				_set_text_buffer(3, String(names[slot]), &"first_party_mon", {
-					"special": special, "slot": slot,
-				})
-		90:
-			## `CheckFirstMonIsEgg` reads slot zero alone, and names it whether
-			## or not it is an egg: `GetPokemonName` runs on both branches.
-			var first_party: Dictionary = _request.get("party", {})
-			if first_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			var first_eggs: Array = first_party.get("eggs", [])
-			var first_names: Array = first_party.get("names", [])
-			_script_value = 1 if not first_eggs.is_empty() and bool(first_eggs[0]) else 0
-			if not first_names.is_empty():
-				_set_text_buffer(3, String(first_names[0]), &"first_party_mon", {
-					"special": special, "slot": 0,
-				})
-		102:
-			## `GameboyCheck` reports which console the game booted on. This one
-			## is a Game Boy Color every time, since every screen here is drawn
-			## in the CGB palettes `hCGB` selects.
-			_script_value = GBCHECK_CGB
-		150, 151:
-			## `MonCheck` answers whether the player owns the species in
-			## wScriptVar and `BeastsCheck` runs the same test on all three
-			## beasts, leaving the last species it asked about behind in
-			## wScriptVar when one is missing.
-			var owner_party: Dictionary = _request.get("party", {})
-			if owner_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			var owned: Array = owner_party.get("owned_species", [])
-			if special == 151:
-				_script_value = 1 if owned.has(_script_value) else 0
-			else:
-				_script_value = 1
-				for beast: int in BEAST_SPECIES:
-					if not owned.has(beast):
-						_script_value = beast
-						break
-		SPECIAL_INIT_ROAM_MONS:
-			## InitRoamMons seeds the roam structs with Raikou and Entei at
-			## level 40 on their starting maps. Gen2WorldAPI.open() already
-			## seeds the same imported records, and ensure_roaming_mons() keeps
-			## positions a player has already moved, so this reports rather than
-			## resetting a beast that is already loose.
-			if state != null and data != null:
-				state.ensure_roaming_mons(data.world_roaming_mons())
-			_emit_runtime_event(&"roaming_mons_initialized", {
-				"special": special,
-				"count": state.roaming_mons().size() if state != null else 0,
-			})
-		SPECIAL_BILLS_GRANDFATHER, SPECIAL_OLDER_HAIRCUT_BROTHER, \
-		SPECIAL_YOUNGER_HAIRCUT_BROTHER, SPECIAL_DAISYS_GROOMING:
-			## `engine/events/haircut.asm`. All four open `SelectMonFromParty`
-			## and nothing else: every box either routine's script shows is the
-			## script's own, so the host owes a party list and an answer.
-			return _stage_runtime_request(&"party_selection_requested", {
-				"special": special,
-				"routine": GROOMING_TABLE_OF.get(special, &"bills_grandfather"),
-			})
-		SPECIAL_DISPLAY_COIN_CASE_BALANCE, SPECIAL_DISPLAY_MONEY_AND_COIN_BALANCE, \
-		SPECIAL_PLACE_MONEY_TOP_RIGHT:
-			## Three tilemap writes and a `ret`. The window stands over the map
-			## until `closetext` redraws it, so a script that spends money
-			## between two of them (the haircut brothers' `takemoney`) draws the
-			## second over the first.
-			_money_window = MONEY_WINDOW_KIND_OF[special]
-			_emit_runtime_event(&"money_window_opened", {
-				"special": special,
-				"kind": _money_window,
-				"money": _money_balance(ACCOUNT_YOUR_MONEY),
-				"coins": _coins_value(),
-			})
-		SPECIAL_DAY_CARE_MAN, SPECIAL_DAY_CARE_LADY, SPECIAL_DAY_CARE_MAN_OUTSIDE, \
-		SPECIAL_DAY_CARE_MON_1, SPECIAL_DAY_CARE_MON_2:
-			## Each of the five owns its own boxes, and the two counters own the
-			## party list and both `YesNoBox`es as well, so the whole routine is
-			## one host request the way `NameRater` is.
-			return _stage_runtime_request(&"day_care_requested", {
-				"special": special,
-				"role": DAY_CARE_ROLE_OF[special],
-			})
-		SPECIAL_NAME_RATER:
-			return _stage_runtime_request(&"name_rater_requested", {
-				"special": special,
-			})
-		SPECIAL_MOVE_DELETION:
-			return _stage_runtime_request(&"move_deleter_requested", {
-				"special": special,
-			})
-		SPECIAL_MOVE_TUTOR:
-			## `.GetMoveTutorMove` reads the value the map's own `setval` left,
-			## and a cartridge whose TMHMMoves stops at HM07 has no move to
-			## teach, which is the refusal rather than a guessed one.
-			var tutor_move: int = Gen2MoveTutor.move_for_value(data, _script_value)
-			if tutor_move <= 0:
-				return {
-					"ok": false,
-					"reason": &"unknown_move_tutor_move",
-					"special": special,
-					"value": _script_value,
-				}
-			return _stage_runtime_request(&"move_tutor_requested", {
-				"special": special,
-				"value": _script_value,
-				"move": tutor_move,
-			})
-		SPECIAL_SELECT_APRICORN_FOR_KURT:
-			## Both of the special's boxes are the host's; it answers with the
-			## chosen apricorn and how many of it, and a backed-out box is the
-			## source's own `wScriptVar = 0`.
-			return _stage_runtime_request(&"apricorn_selection_requested", {
-				"special": special,
-			})
-		SPECIAL_GIVE_PARK_BALLS:
-			## `GiveParkBalls` clears wContestMon, loads twenty balls and starts
-			## the timer. The flag itself is the script's own `setflag`, which
-			## has already run by here.
-			_emit_runtime_event(&"bug_contest_started", {"special": special})
-		SPECIAL_SELECT_RANDOM_BUG_CONTESTANTS:
-			## Five of the ten contestant flags set, which is both who competes
-			## in the judging and which sprites the park does not draw.
-			_emit_runtime_event(&"bug_contestants_selected", {"special": special})
-		SPECIAL_CONTEST_DROP_OFF_MONS:
-			## `ContestDropOffMons` answers 1 when the lead is fainted, which is
-			## the one branch its callers read, and otherwise masks the party to
-			## its first member.
-			var contest_party: Dictionary = _request.get("party", {})
-			if contest_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			var lead_fainted: bool = bool(contest_party.get("lead_fainted", false))
-			_script_value = 1 if lead_fainted else 0
-			if not lead_fainted:
-				_emit_runtime_event(&"contest_mons_dropped_off", {
-					"special": special,
-					"second_species": int(contest_party.get("second_species", 0)),
-				})
-		SPECIAL_CONTEST_RETURN_MONS:
-			_emit_runtime_event(&"contest_mons_returned", {"special": special})
-		SPECIAL_WARP_TO_SPAWN_POINT:
-			_emit_runtime_event(&"warp_to_spawn_point", {"special": special})
-		SPECIAL_CHECK_PARTY_FULL_AFTER_CONTEST:
-			## `CheckPartyFullAfterContest` does not only answer where the
-			## Pokemon caught in the contest would go: it takes it home, asks
-			## `GiveANickname_YesNo` about it and clears `wContestMon`. The
-			## answer is the party host's, since a nickname is a screen.
-			return _stage_runtime_request(&"contest_mon_requested", {
-				"special": special,
-			})
-		SPECIAL_BUG_CONTEST_JUDGING:
-			## The judging prints three placings and leaves the player's own in
-			## wScriptVar, which the results script branches on.
-			return _stage_runtime_request(&"bug_contest_judging_requested", {
-				"special": special,
-			})
-		SPECIAL_ACTIVATE_FISHING_SWARM:
-			_emit_runtime_event(&"phone_special_requested", {
-				"special": special, "kind": &"activate_fishing_swarm",
-				"species": _script_value,
-			})
-		SPECIAL_TOGGLE_MAPTILE_DECORATIONS:
-			_apply_maptile_decorations()
-			_emit_runtime_event(&"decoration_callback_applied", {
-				"special": special,
-				"kind": &"toggle_maptile_decorations",
-				"decorations": state.maptile_decorations() if state != null else {},
-			})
-		SPECIAL_TOGGLE_DECORATIONS_VISIBILITY:
-			## `ToggleDecorationVisibility` per slot: an empty slot sets the
-			## object's event flag and the renderer removes it, and a filled one
-			## clears the flag and writes the decoration's own variable sprite.
-			var shown: Dictionary = {}
-			for row: Dictionary in Gen2WorldDecoration.OBJECT_SLOTS:
-				var deco: int = state.maptile_decoration(
-					StringName(row["slot"])
-				) if state != null else 0
-				var sprite: int = int(data.decoration(deco).get("sprite", 0)) \
-					if data != null and deco > 0 else 0
-				_staged_flags[int(row["flag"])] = sprite <= 0
-				if sprite <= 0:
-					continue
-				shown[int(row["variable_sprite"])] = sprite
-				_emit_runtime_event(&"variable_sprite_changed", {
-					"variable_sprite": int(row["variable_sprite"]),
-					"sprite": sprite,
-				})
-			_emit_runtime_event(&"decoration_callback_applied", {
-				"special": special,
-				"kind": &"toggle_decorations_visibility",
-				"sprites": shown,
-			})
-		SPECIAL_SLOT_MACHINE:
-			return _stage_runtime_request(&"slot_machine_requested", {
-				"special": special,
-				## `Slots_InitBias`' own `ld a, [wScriptVar] / and a`, which is
-				## the only thing the operand decides.
-				"lucky": _script_value != 0,
-				"coins": _coins_value(),
-			})
-		SPECIAL_CARD_FLIP:
-			return _stage_runtime_request(&"card_flip_requested", {
-				"special": special,
-				"coins": _coins_value(),
-			})
-		SPECIAL_UNOWN_PUZZLE:
-			return _stage_runtime_request(&"unown_puzzle_requested", {
-				"special": special,
-				## `maskbits NUM_UNOWN_PUZZLES` is what bounds the operand, so a
-				## value outside the four wraps rather than failing.
-				"puzzle": _script_value & 0x3,
-			})
-		SPECIAL_DISPLAY_UNOWN_WORDS:
-			## The word the wall spells, staged as the text `JoyWaitAorB` holds
-			## until a button. A host that can reach the chamber's own tileset
-			## draws it as `_DisplayUnownWords_CopyWord`'s 2x2 letter blocks
-			## instead ([Gen2UnownWallPage]); the wait it answers is this one.
-			var wall_word: String = data.unown_wall_word(_script_value) if data != null \
-				else ""
-			if wall_word.is_empty():
-				return {
-					"ok": false,
-					"reason": &"unknown_unown_wall",
-					"special": special,
-					"wall": _script_value,
-				}
-			## `special` is a StringName tag on a pending text, not the index, so
-			## the wall is named under its own key.
-			return _stage_internal_text(wall_word, false, {"unown_wall": _script_value})
-		SPECIAL_SAMPLE_KENJI_BREAK_COUNTDOWN:
-			## `Random` masked to two bits plus three. The same byte is stepped
-			## by `CheckDailyResetTimer` on every day that passes, which is
-			## `Gen2WorldState.reset_daily_flags`; this is the resample its own
-			## script asks for.
-			_staged_kenji_break_timer = Gen2WorldState.kenji_break_countdown(_random)
-			_has_staged_kenji_break_timer = true
-		SPECIAL_TRAINER_HOUSE:
-			## `sMysteryGiftTrainerHouseFlag` straight into wScriptVar: a
-			## player who has never received a Mystery Gift is turned away, and
-			## one who has fights CAL under the partner's name.
-			_script_value = int(_mystery_gift_section().get("trainer_house_flag", 0))
-		SPECIAL_CHECK_MYSTERY_GIFT:
-			## Zero when nothing is waiting and the item plus one when something
-			## is. POKECENTER_2F's scene script branches on the zero, and the
-			## officer it puts on the floor is what hands the gift over.
-			_script_value = Gen2MysteryGift.check_value(_mystery_gift_section())
-		SPECIAL_UNLOCK_MYSTERY_GIFT:
-			## Carrie's own row on GOLDENROD DEPT. STORE 5F, behind a
-			## `GameboyCheck` this project always passes: there is no Game Boy
-			## here that is not a colour one.
-			Gen2MysteryGift.unlock(_mystery_gift_section())
-		SPECIAL_GET_MYSTERY_GIFT_ITEM:
-			return _stage_mystery_gift_item(special)
-		SPECIAL_HO_OH_CHAMBER:
-			## `wPartySpecies`' first byte and nothing else: the wall opens for a
-			## party led by Ho-Oh. `GetMapAttributesPointer` in front of it is
-			## marked pointless in the pin and answers nothing.
-			var chamber_party: Dictionary = _request.get("party", {})
-			if chamber_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			var chamber_species: Array = chamber_party.get("species", [])
-			if not chamber_species.is_empty() and int(chamber_species[0]) == SPECIES_HO_OH:
-				_staged_flags[EVENT_WALL_OPENED_IN_HO_OH_CHAMBER] = true
-		SPECIAL_OMANYTE_CHAMBER:
-			## A WATER STONE in the bag opens it, and so does one held by any
-			## party member: `.loop` walks the party backwards reading MON_ITEM.
-			## The flag is tested first, so a wall already open spends nothing.
-			if not _event_flag_active(EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER):
-				var stone_party: Dictionary = _request.get("party", {})
-				if stone_party.is_empty():
-					return {
-						"ok": false, "reason": &"missing_party_summary", "special": special,
-					}
-				var opens: bool = _item_quantity(ITEM_WATER_STONE) > 0
-				if not opens:
-					for held: Variant in stone_party.get("held_items", []):
-						if int(held) == ITEM_WATER_STONE:
-							opens = true
-							break
-				if opens:
-					_staged_flags[EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER] = true
-		SPECIAL_CHECK_CAUGHT_CELEBI:
-			## `wBattleResult`'s BATTLERESULT_CAUGHT_CELEBI, which
-			## `PokeBallEffect` sets on a catch made in a BATTLETYPE_CELEBI
-			## fight and nothing else clears until the next battle.
-			_script_value = 1 if state != null and state.battle_caught_celebi() else 0
-		SPECIAL_CELEBI_SHRINE_EVENT:
-			## The whole routine is a sprite-anim cutscene and a battle type.
-			## There is no sprite-anim layer outside the intro, so what it owes a
-			## script is the wait its own loop spends and the type the fight
-			## behind it starts with.
-			_loaded_battle_type = Gen2Battle.BATTLETYPE_CELEBI
-			if not _battle_setup.is_empty():
-				_battle_setup["battle_type"] = Gen2Battle.BATTLETYPE_CELEBI
-			_emit_runtime_event(&"presentation_special_applied", {
-				"special": special, "kind": &"celebi_shrine",
-			})
-			return _stage_frame_wait(
-				CELEBI_SHRINE_PASSES * CELEBI_SHRINE_FRAMES_PER_PASS,
-				{"special": special, "kind": &"celebi_shrine"}
-			)
-		SPECIAL_MAP_RADIO:
-			## `PlayRadio` opens the station wScriptVar names, prints its line in
-			## a four-row box and holds until A or B. It is the Pokegear's own
-			## radio without the Pokegear, so the station is the request and the
-			## host draws it.
-			return _stage_runtime_request(&"map_radio_requested", {
-				"special": special,
-				"station": _script_value,
-			})
-		SPECIAL_CHECK_LUCKY_NUMBER_SHOW_FLAG:
-			## `ScriptReturnCarry`: TRUE once `wLuckyNumberDayTimer` has run out,
-			## which is the Friday the show comes round on.
-			_script_value = 1 if state != null and state.lucky_number_show_ready() else 0
-		SPECIAL_RESET_LUCKY_NUMBER_SHOW_FLAG:
-			## `RestartLuckyNumberCountdown`, then the GAME_OVER bit off the show
-			## flag, then `LoadOrRegenerateLuckyIDNumber`. The bit is the radio
-			## segment's own and this project's radio reads the timer instead, so
-			## what is left is the countdown and the number.
-			_staged_lucky_number_days_left = _lucky_number_days_until_friday()
-			_has_staged_lucky_number_days_left = true
-			_refresh_lucky_id_number()
-		SPECIAL_PRINT_TODAYS_LUCKY_NUMBER:
-			## `PrintNum` with PRINTNUM_LEADINGZEROS over five digits into
-			## wStringBuffer3, which the radio tower's own text prints.
-			_refresh_lucky_id_number()
-			_set_text_buffer(
-				RomLayout.STRING_BUFFER_3, "%05d" % _lucky_id_number(), &"lucky_number",
-				{"special": special}
-			)
-		SPECIAL_CHECK_FOR_LUCKY_NUMBER_WINNERS:
-			## The whole walk is over ID numbers the party mirror carries, so the
-			## routine is the host's arithmetic rather than a screen.
-			var lucky_party: Dictionary = _request.get("party", {})
-			if lucky_party.is_empty():
-				return {"ok": false, "reason": &"missing_party_summary", "special": special}
-			_refresh_lucky_id_number()
-			var winner: Dictionary = Gen2WorldPartyHost.lucky_number_match(
-				_lucky_id_number(),
-				lucky_party.get("id_numbers", []),
-				lucky_party.get("species", []),
-				lucky_party.get("eggs", []),
-				lucky_party.get("stored_id_numbers", []),
-				lucky_party.get("stored_species", [])
-			)
-			_script_value = int(winner.get("script_value", 0))
-			if _script_value == 0:
-				return {"ok": true}
-			## `GetPokemonName` on the matching row's species, into the buffer
-			## both boxes print, and then the box the match's own location picks.
-			var winner_species: int = int(winner.get("species", 0))
-			_cur_party_species = winner_species
-			var winner_name: String = String(
-				data.species(winner_species).get("name", "")
-			) if data != null else ""
-			_set_text_buffer(RomLayout.STRING_BUFFER_1, winner_name, &"lucky_number_winner", {
-				"special": special, "species": winner_species,
-			})
-			var lucky_box: String = _special_box(
-				"lucky_number",
-				"match_pc" if bool(winner.get("in_storage", false)) else "match_party"
-			)
-			if lucky_box.is_empty():
-				return {"ok": false, "reason": &"missing_special_text", "special": special}
-			return _stage_internal_text(lucky_box, false, {"special": special})
-		SPECIAL_MAGIKARP_HOUSE_SIGN:
-			## The record straight out of the save into wMagikarpLength, printed
-			## the way `PrintMagikarpLength` prints it, and the sign's own box.
-			## An unbeaten record is two zero bytes, which is what the sign shows
-			## before anyone has measured one.
-			var record: Dictionary = state.best_magikarp() if state != null else {}
-			_set_text_buffer(RomLayout.STRING_BUFFER_1, Gen2WorldPartyHost.magikarp_length_string(
-				int(record.get("feet", 0)), int(record.get("inches", 0))
-			), &"magikarp_length", {"special": special})
-			_set_text_ram("magikarp_record_holder", String(record.get("ot", "")))
-			var sign_box: String = _special_box("magikarp", "record")
-			if sign_box.is_empty():
-				return {"ok": false, "reason": &"missing_special_text", "special": special}
-			return _stage_internal_text(sign_box, false, {"special": special})
-		SPECIAL_BANK_OF_MOM:
-			return _bank_of_mom(MOM_CHECK_INITIALIZED)
-		SPECIAL_UNOWN_PRINTER:
-			## `ld a, [wUnownDex] / and a / ret z`: with no Unown caught the
-			## routine draws nothing at all, which the host answers for since it
-			## is the one that holds the dex.
-			return _stage_runtime_request(&"unown_printer_requested", {
-				"special": special,
-				"caught": state.unown_caught_count() if state != null else 0,
-			})
-		SPECIAL_DIPLOMA, SPECIAL_PRINT_DIPLOMA:
-			## `_Diploma` draws `PlaceDiplomaOnScreen`'s page and waits for a
-			## button; `_PrintDiploma` draws the same page and then holds in
-			## `SendScreenToPrinter`. Neither writes anything a script reads, so
-			## the request carries only which of the two loops is standing.
-			return _stage_runtime_request(&"diploma_requested", {
-				"special": special,
-				"printing": special == SPECIAL_PRINT_DIPLOMA,
-			})
-		SPECIAL_BUENA_PRIZE:
-			## The counter is one loop: the prize list, a yes/no on the row, and
-			## whichever of the four boxes the answer reaches. B on the list is
-			## the only way out and prints her parting line.
-			return _stage_buena_prize_menu(special)
-		SPECIAL_POKE_SEER:
-			## `PrintSeerText SEER_INTRO`, `JoyWaitAorB`, and only then the list.
-			var seer_intro: String = _special_box("poke_seer", "see_all")
-			if seer_intro.is_empty():
-				return {"ok": false, "reason": &"missing_special_text", "special": special}
-			return _stage_internal_text(seer_intro, false, {
-				"special": special,
-				"party_selection_after_text": {
-					"special": special,
-					"routine": PARTY_SELECTION_ROUTINE_OF[special],
-				},
-			})
-		SPECIAL_CHECK_MAGIKARP_LENGTH, SPECIAL_PHOTO_STUDIO, SPECIAL_RETURN_SHUCKIE:
-			## All three open `SelectMonFromParty` and answer on what came back.
-			## `PhotoStudio` prints its own question in front of the list, which
-			## is the one box a script does not carry for it.
-			if special == SPECIAL_PHOTO_STUDIO:
-				var asked: String = _special_box("photo_studio", "which_mon")
-				if asked.is_empty():
-					return {"ok": false, "reason": &"missing_special_text", "special": special}
-				_standing_text = asked
-			return _stage_runtime_request(&"party_selection_requested", {
-				"special": special,
-				"routine": PARTY_SELECTION_ROUTINE_OF[special],
-			})
-		SPECIAL_GIVE_SHUCKLE:
-			## `TryAddMonToParty` with a level 15 SHUCKLE holding a BERRY, named
-			## SHUCKIE under MANIA's own OT and ID, and the daily flag behind it.
-			## A full party is `.NotGiven`, which answers zero and gives nothing:
-			## the box is never reached.
-			return _stage_runtime_request(&"pokemon_requested", {
-				"special": special,
-				"kind": &"give_shuckle",
-				"pokemon": Gen2WorldPartyHost.SHUCKLE,
-				"level": Gen2WorldPartyHost.SHUCKIE_LEVEL,
-				"item": Gen2WorldPartyHost.ITEM_BERRY,
-				"nickname": Gen2WorldPartyHost.SHUCKIE_NICKNAME,
-				"original_trainer": Gen2WorldPartyHost.MANIA_OT_NAME,
-				"ot_id": Gen2WorldPartyHost.MANIA_OT_ID,
-				"party_only": true,
-			})
-		SPECIAL_ASK_REMEMBER_PASSWORD:
-			## The box alone: the question is the `writetext` in front of it, and
-			## the answer is `yesorno`'s own, YES writing 1 and B writing 0.
-			_pending = {
-				"type": &"choice",
-				"command": &"yesorno",
-				"choices": [&"yes", &"no"],
-				"text": _standing_text,
-				"special": &"ask_remember_password",
-				"header": ASK_REMEMBER_PASSWORD_BOX.duplicate(),
-				"source": _request.duplicate(true),
-			}
-			return _waiting_result()
-		SPECIAL_GIVE_ODD_EGG:
-			## `AddMobileMonToParty` with one of `OddEggs`' fourteen rows, rolled
-			## against `OddEggProbabilities`. `TossKeyItem` runs first and
-			## removes nothing when the pack holds no ticket; it writes no
-			## wScriptVar either way, so the toss's own answer is put back.
-			if _item_quantity(ITEM_EGG_TICKET) > 0:
-				var kept: int = _script_value
-				var tossed: Dictionary = _stage_item_delta(ITEM_EGG_TICKET, -1)
-				_script_value = kept
-				if not bool(tossed.get("ok", true)):
-					return tossed
-			return _stage_runtime_request(&"pokemon_requested", {
-				"special": special,
-				"kind": &"give_odd_egg",
-				"party_only": true,
-			})
-		SPECIAL_GIVE_DRATINI:
-			## Not a gift at all: the Dragon Shrine's `givepoke` has already run,
-			## and this rewrites the last DRATINI in the party with one of two
-			## movesets. A wScriptVar above one returns before the search, which
-			## is what the elder's third answer leaves standing.
-			if _script_value > 1:
-				return {"ok": true}
-			return _stage_runtime_request(&"dratini_moveset_requested", {
-				"special": special,
-				"moveset": _script_value,
-			})
-		SPECIAL_GAME_CORNER_PRIZE_MON_CHECK_DEX:
-			## `CheckCaughtMon` on wScriptVar less one, and nothing at all when
-			## it is already caught: the prize counter has handed the Pokemon
-			## over by here, so this is the new-entry screen alone. The species
-			## byte is one high, which is the `dec a` in front of both calls.
-			var prize_species: int = _script_value
-			if prize_species <= 0:
-				return {"ok": false, "reason": &"invalid_prize_species", "special": special}
-			if state != null and state.has_caught_species(prize_species):
-				return {"ok": true}
-			_staged_caught_species[prize_species] = true
-			return _stage_runtime_request(&"pokedex_entry_requested", {
-				"special": special,
-				"species": prize_species,
-			})
-		SPECIAL_BUENAS_PASSWORD:
-			## `DoNthMenu` over the five words of today's category, and the
-			## answer is whether the row matches the low nibble of
-			## `wBuenasPassword`. The category is the high nibble, which is what
-			## the radio show drew this morning.
-			var password: int = _buenas_password()
-			if password < 0:
-				return {"ok": false, "reason": &"missing_buenas_password", "special": special}
-			_stage_buenas_password_menu(password)
-		SPECIAL_RANDOM_UNSEEN_WILD_MON:
-			var rare_species: int = _phone_unseen_rare_species()
-			if rare_species <= 0:
-				_emit_runtime_event(&"phone_special_requested", {
-					"special": special, "kind": &"random_unseen_wild_mon",
-					"internal_text": false, "script_value": 1,
-				})
-				_script_value = 1
-			else:
-				var rare_name: String = String(data.species(rare_species).get("name", ""))
-				_set_text_buffer(1, rare_name, &"phone_unseen_wild_mon", {
-					"special": special, "species": rare_species,
-				})
-				_emit_runtime_event(&"phone_special_requested", {
-					"special": special, "kind": &"random_unseen_wild_mon",
-					"internal_text": true, "buffer": 1, "value": rare_name,
-					"species": rare_species, "script_value": 0,
-				})
-				_script_value = 0
-		SPECIAL_RANDOM_PHONE_WILD_MON:
-			var wild_name: String = _phone_wild_mon_name()
-			_set_text_buffer(1, wild_name, &"phone_wild_mon", {"special": special})
-			_emit_runtime_event(&"phone_special_requested", {
-				"special": special, "kind": &"random_phone_wild_mon",
-				"buffer": 1, "value": wild_name,
-			})
-		SPECIAL_RANDOM_PHONE_MON:
-			var trainer_mon_name: String = _phone_trainer_mon_name()
-			_set_text_buffer(1, trainer_mon_name, &"phone_mon", {"special": special})
-			_emit_runtime_event(&"phone_special_requested", {
-				"special": special, "kind": &"random_phone_mon",
-				"buffer": 1, "value": trainer_mon_name,
-			})
-		_:
-			return {
-				"ok": false,
-				"reason": &"unsupported_phone_special",
-				"special": special,
-			}
+	if not SPECIAL_HANDLERS.has(special):
+		return {
+			"ok": false,
+			"reason": &"unsupported_phone_special",
+			"special": special,
+		}
+	return call(SPECIAL_HANDLERS[special], special)
+
+
+func _special_overworld_town_map(special: int) -> Dictionary:
+	return _stage_runtime_request(&"town_map_requested", {
+		"special": special,
+		"landmark": int(_request.get("landmark", 0)),
+	})
+
+
+func _special_players_house_pc(special: int) -> Dictionary:
+	return _stage_runtime_request(&"pc_requested", {
+		"special": special,
+		"mode": &"players_house",
+	})
+
+
+func _special_pokemon_center_pc(special: int) -> Dictionary:
+	return _stage_runtime_request(&"pc_requested", {
+		"special": special,
+		"mode": &"pokemon_center",
+	})
+
+
+## `jumptable .dw, wScriptVar`: the `setval` in front of the special names the row,
+## and the row's own answer replaces it.
+func _special_battle_tower_action(_special: int) -> Dictionary:
+	var answered: int = _battle_tower().action(_script_value, {
+		"party": _battle_tower_party(),
+		"pack": _pack_items(),
+		"save_is_yours": true,
+		"random": _battle_tower_random(0),
+	})
+	if answered >= 0:
+		_script_value = answered
 	return {"ok": true}
 
 
+func _special_check_battle_tower_rules(_special: int) -> Dictionary:
+	return _check_battle_tower_rules()
+
+
+func _special_try_quick_save(special: int) -> Dictionary:
+	return _stage_runtime_request(&"quick_save_requested", {"special": special})
+
+
+## The console restarting, which is how a saved-and-left challenge leaves the battle
+## room. Nothing follows it in any script.
+func _special_reset(_special: int) -> Dictionary:
+	_events.append({"type": &"soft_reset_requested"})
+	_pending = {}
+	_active = false
+	_completed = true
+	return {"ok": true}
+
+
+func _special_challenge_menu(_special: int) -> Dictionary:
+	return _stage_challenge_menu()
+
+
+func _special_request_link_room(special: int) -> Dictionary:
+	_link_session().request_room(
+		Gen2LinkSession.CABLECLUBROOM_TRADECENTER \
+			if special == SPECIAL_SET_BITS_FOR_LINK_TRADE_REQUEST \
+			else Gen2LinkSession.CABLECLUBROOM_COLOSSEUM
+	)
+	return {"ok": true}
+
+
+## The Time Capsule asks for `CABLECLUBROOM_NULL`, which is why its own script never
+## reaches `CheckBothSelectedSameRoom` on a branch that could pass.
+func _special_set_bits_for_time_capsule_request(_special: int) -> Dictionary:
+	_link_session().request_time_capsule()
+	return {"ok": true}
+
+
+func _special_wait_for_linked_friend(special: int) -> Dictionary:
+	_script_value = _link_session().wait_for_linked_friend(_link_transport())
+	if _script_value == 0:
+		return {"ok": true}
+	return _stage_frame_wait(
+		Gen2LinkSession.WAIT_FOR_FRIEND_CONNECTED_FRAMES,
+		{"special": special, "kind": &"link_wait"}
+	)
+
+
+func _special_check_link_timeout_receptionist(special: int) -> Dictionary:
+	var session: Gen2LinkSession = _link_session()
+	_script_value = session.check_link_timeout(_link_transport())
+	## The `readmem wOtherPlayerLinkMode` every one of the three scripts
+	## runs on the next line reads this byte and not wScriptVar.
+	var stored: Dictionary = _stage_script_memory(
+		data.other_player_link_mode_address() if data != null else -1,
+		session.other_player_link_mode
+	)
+	if not bool(stored.get("ok", true)):
+		return stored
+	return _stage_frame_wait(
+		Gen2LinkSession.CHECK_LINK_TIMEOUT_FRAMES,
+		{"special": special, "kind": &"link_wait"}
+	)
+
+
+func _special_check_both_selected_same_room(_special: int) -> Dictionary:
+	_script_value = _link_session().check_both_selected_same_room(_link_transport())
+	return {"ok": true}
+
+
+func _special_failed_link_to_past(special: int) -> Dictionary:
+	_link_session().failed_link_to_past(_link_transport())
+	return _stage_frame_wait(
+		Gen2LinkSession.FAILED_LINK_TO_PAST_FRAMES,
+		{"special": special, "kind": &"link_wait"}
+	)
+
+
+func _special_close_link(special: int) -> Dictionary:
+	_link_session().close_link(_link_transport())
+	return _stage_frame_wait(
+		Gen2LinkSession.CLOSE_LINK_FRAMES,
+		{"special": special, "kind": &"link_wait"}
+	)
+
+
+func _special_wait_for_other_player_to_exit(special: int) -> Dictionary:
+	_link_session().wait_for_other_player_to_exit(_link_transport())
+	return _stage_frame_wait(
+		Gen2LinkSession.WAIT_FOR_OTHER_PLAYER_FRAMES,
+		{"special": special, "kind": &"link_wait"}
+	)
+
+
+func _special_check_time_capsule_compatibility(_special: int) -> Dictionary:
+	return _check_time_capsule_compatibility()
+
+
+func _special_enter_time_capsule(special: int) -> Dictionary:
+	_link_session().enter_time_capsule(_link_transport())
+	return _stage_frame_wait(
+		Gen2LinkSession.ENTER_TIME_CAPSULE_FRAMES,
+		{"special": special, "kind": &"link_wait"}
+	)
+
+
+func _special_link_room(special: int) -> Dictionary:
+	return _stage_link_room(special)
+
+
+## `CheckMobileAdapterStatusSpecial` answers whether a Mobile Adapter GB is plugged
+## in, and none is: there is no such peripheral on any platform this runs on. FALSE is
+## what both Crystal receptionists branch on to reach `.NoMobile`, which is the cable
+## club proper, so this is the answer that opens the room rather than the one that
+## closes it.
+func _special_check_mobile_adapter_status(_special: int) -> Dictionary:
+	_script_value = 0
+	return {"ok": true}
+
+
+func _special_cable_club_check_which_chris(_special: int) -> Dictionary:
+	_script_value = _link_session().which_chris(_link_transport())
+	return {"ok": true}
+
+
+## `_DisplayLinkRecord` draws `sLinkBattleStats` and holds for A or B. It writes
+## nothing, so the script runs straight on behind it.
+func _special_display_link_record(special: int) -> Dictionary:
+	return _stage_runtime_request(&"link_record_requested", {"special": special})
+
+
+func _special_battle_tower_room_menu(_special: int) -> Dictionary:
+	return _stage_room_menu()
+
+
+func _special_load_battle_tower_opponent(_special: int) -> Dictionary:
+	return _load_battle_tower_opponent()
+
+
+func _special_battle_tower_battle(_special: int) -> Dictionary:
+	return _stage_battle_tower_battle()
+
+
+func _special_set_day_of_week(_special: int) -> Dictionary:
+	_stage_day_of_week_menu()
+	return {"ok": true}
+
+
+func _special_initial_set_dst_flag(_special: int) -> Dictionary:
+	_staged_dst_enabled = true
+	_has_staged_dst = true
+	_stage_dst_confirmation_text(true)
+	return {"ok": true}
+
+
+func _special_initial_clear_dst_flag(_special: int) -> Dictionary:
+	_staged_dst_enabled = false
+	_has_staged_dst = true
+	_stage_dst_confirmation_text(false)
+	return {"ok": true}
+
+
+func _special_map_music(special: int) -> Dictionary:
+	# Entering a map with the music already playing does not restart it,
+	# which is why crossing a route boundary is one continuous track.
+	# RestartMapMusic exists to override exactly that, so it says so.
+	return _stage_audio_request(&"map_music", {
+		"special": special,
+		"restart": special == SPECIAL_RESTART_MAP_MUSIC,
+	})
+
+
+func _special_fade_out_music(special: int) -> Dictionary:
+	_emit_runtime_event(&"music_fadeout_requested", {"special": special})
+	return {"ok": true}
+
+
+func _special_rival_name(special: int) -> Dictionary:
+	return _stage_runtime_request(&"rival_name_requested", {
+		"special": special, "default_name": "SILVER",
+	})
+
+
+## HealParty is a save-owned transaction. It is deliberately a host request so HP,
+## status and PP are changed together with the selected project save.
+func _special_heal_party(special: int) -> Dictionary:
+	return _stage_runtime_request(&"party_heal_requested", {"special": special})
+
+
+## wScriptVar selects the machine's screen position: 0 Pokemon Center, 1 Elm's Lab, 2
+## Hall of Fame. A preceding SETVAL loads it. Nothing here changes state, but the
+## routine is not free: it spends thirty frames a ball and `.FlashPalettes8Times`'
+## eighty, with a sound on each ball, so the script waits for it the way the cartridge
+## does.
+func _special_heal_machine_anim(special: int) -> Dictionary:
+	var machine_type: int = clampi(_script_value, 0, HEAL_MACHINE_HALL_OF_FAME)
+	var balls: int = int((_request.get("party", {}) as Dictionary).get("count", 0))
+	var sounds: Array = heal_machine_sounds(machine_type, balls)
+	_emit_runtime_event(&"presentation_special_applied", {
+		"special": special, "kind": &"heal_machine_anim",
+		"machine_type": machine_type,
+		"balls": balls,
+		"sounds": sounds.duplicate(true),
+	})
+	## `ld a, [wPartyCount] / and a / ret z`: an empty party leaves the
+	## machine alone and spends nothing.
+	if balls > 0:
+		return _stage_frame_wait(
+			balls * HEAL_MACHINE_BALL_FRAMES + HEAL_MACHINE_FLASH_FRAMES,
+			{"special": special, "kind": &"heal_machine_anim"}
+		)
+	return {"ok": true}
+
+
+## engine/events/magnet_train.asm's MagnetTrain is scroll positions, graphics, music
+## and a VBlank cutscene handler. It reads wScriptVar for the direction and writes
+## nothing the overworld can observe; the warp itself is the `warpcheck` that follows
+## it.
+func _special_magnet_train(special: int) -> Dictionary:
+	_emit_runtime_event(&"presentation_special_applied", {
+		"special": special, "kind": &"magnet_train",
+		"to_goldenrod": _script_value != 0,
+	})
+	return {"ok": true}
+
+
+## engine/events/prof_oaks_pc.asm's ProfOaksPCBoot prints, counts the set bits in
+## wPokedexSeen and wPokedexCaught for `Rate`, plays that rating's sound and waits for
+## A or B. Presentation only: it writes nothing, so the script runs straight on to its
+## own `end` and [Gen2ProfOaksPC] is handed the counts by whoever draws this.
+func _special_prof_oaks_pc_boot(special: int) -> Dictionary:
+	_emit_runtime_event(&"presentation_special_applied", {
+		"special": special, "kind": &"prof_oaks_pc_boot",
+	})
+	return {"ok": true}
+
+
+func _special_check_pokerus(special: int) -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	_script_value = 1 if bool(party.get("pokerus", false)) else 0
+	return {"ok": true}
+
+
+## Two reads and nothing else: the track in wMapMusic and the cell the player stands
+## on. The Poke Flute channel reaches wMapMusic through StartRadioStation and stays
+## there because closing the Pokegear restores the map's music only for its two
+## sentinel ids.
+func _special_snorlax_awake(_special: int) -> Dictionary:
+	var cell: Vector2i = _player_cell()
+	_script_value = 1 if state != null \
+		and state.map_music() == Gen2WorldRadio.MUSIC_POKE_FLUTE_CHANNEL \
+		and cell in SNORLAX_PROXIMITY_CELLS else 0
+	return {"ok": true}
+
+
+## `FadeOutToWhite` is 46 in both pins, since Crystal's inserted `BattleTowerFade`
+## sits at 47; `FadeInFromWhite` is 49 here and 48 in Gold/Silver, which
+## `special_index()` already normalizes. Each of the five is `GetTimePalFade` and then
+## four rows of the fade table, and none is free: `ConvertTimePals*HL` spends `ld c,
+## 2` on every row, so the script holds for the whole walk the way it does on the
+## cartridge. `FillWhiteBGColor` is the two white fades' alone.
+func _special_palette_fade(special: int) -> Dictionary:
+	var orders: Array[int] = FADE_ORDERS_OF[special]
+	var step_frames: int = Gen2WorldPalette.BATTLE_TOWER_FADE_STEP_FRAMES \
+		if special == SPECIAL_BATTLE_TOWER_FADE \
+		else Gen2WorldPalette.FADE_STEP_FRAMES
+	_emit_runtime_event(&"presentation_special_applied", {
+		"special": special, "kind": &"palette_fade",
+		"orders": orders.duplicate(),
+		"step_frames": step_frames,
+		"white_fill": special in FADE_WHITE_FILL_SPECIALS,
+	})
+	return _stage_frame_wait(orders.size() * step_frames, {
+		"special": special, "kind": &"palette_fade",
+	})
+
+
+## Sprite reload, palette reload and the dummied trainer-ranking bookkeeping affect
+## presentation or source-only counters rather than scene-free state.
+## `LoadUsedSpritesGFX`, `UpdateSprites`, `UpdatePlayerSprite`,
+## `ReloadSpritesNoPalettes` and `RefreshSprites` reload the sprite set a
+## `variablesprite` just changed; `ClearBGPalettes`, `UpdateTimePals`,
+## `SetPlayerPalette` and `LoadMapPalettes` are the palette pair the day/night scripts
+## open with, and the renderer takes its palettes from the map and the clock.
+func _special_presentation_only(special: int) -> Dictionary:
+	_emit_runtime_event(&"presentation_special_applied", {"special": special})
+	return {"ok": true}
+
+
+## `PlaySlowCry` (95) is `LoadCry` with the record's own pitch lowered by `$140` and
+## its length raised by `$60`, and `PlayCurMonCry` (100) is `PlayMonCry` straight.
+## Neither writes anything back, so what they owe is the sound and the `WaitSFX` each
+## ends on. They do not read the same byte: 95 is `ld a, [wScriptVar]`, which the
+## `setval` in front of it has just set, and 100 is `ld a, [wCurPartySpecies]`, all
+## four of whose scripts are a grooming routine's.
+func _special_cry(special: int) -> Dictionary:
+	return _stage_audio_request(&"cry", {
+		"special": special,
+		"species": _script_value if special == 95 else _cur_party_species,
+		"slow": special == 95,
+	})
+
+
+## `SpecialWaitSFX` is `WaitSFX`: it holds until the four effect channels are free
+## rather than spending a counted number of frames, which is `Script_waitsfx`'s own
+## request.
+func _special_wait_sfx(special: int) -> Dictionary:
+	return _stage_audio_request(&"sound_wait", {"special": special})
+
+
+## `FindPartyMonThatSpecies` and its ID-checking twin. Both answer TRUE/FALSE in
+## wScriptVar off the species wScriptVar was loaded with; the second adds
+## `CheckOwnMon`'s ID and OT test on the slot the first one found.
+func _special_find_party_mon(special: int) -> Dictionary:
+	var party: Dictionary = _request.get("party", {})
+	if party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	_script_value = 1 if _party_slot_of_species(
+		party, _script_value, special == 67
+	) >= 0 else 0
+	return {"ok": true}
+
+
+## `GetFirstPokemonHappiness` walks past every EGG in the list and answers the first
+## hatched member's happiness byte, naming that member in the buffer its two boxes
+## print.
+func _special_first_mon_happiness(special: int) -> Dictionary:
+	var happy_party: Dictionary = _request.get("party", {})
+	if happy_party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	var eggs: Array = happy_party.get("eggs", [])
+	var happiness: Array = happy_party.get("happiness", [])
+	var names: Array = happy_party.get("names", [])
+	var slot: int = 0
+	while slot < eggs.size() and bool(eggs[slot]):
+		slot += 1
+	_script_value = int(happiness[slot]) if slot < happiness.size() else 0
+	if slot < names.size():
+		_set_text_buffer(3, String(names[slot]), &"first_party_mon", {
+			"special": special, "slot": slot,
+		})
+	return {"ok": true}
+
+
+## `CheckFirstMonIsEgg` reads slot zero alone, and names it whether or not it is an
+## egg: `GetPokemonName` runs on both branches.
+func _special_first_mon_is_egg(special: int) -> Dictionary:
+	var first_party: Dictionary = _request.get("party", {})
+	if first_party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	var first_eggs: Array = first_party.get("eggs", [])
+	var first_names: Array = first_party.get("names", [])
+	_script_value = 1 if not first_eggs.is_empty() and bool(first_eggs[0]) else 0
+	if not first_names.is_empty():
+		_set_text_buffer(3, String(first_names[0]), &"first_party_mon", {
+			"special": special, "slot": 0,
+		})
+	return {"ok": true}
+
+
+## `GameboyCheck` reports which console the game booted on. This one is a Game Boy
+## Color every time, since every screen here is drawn in the CGB palettes `hCGB`
+## selects.
+func _special_gameboy_check(_special: int) -> Dictionary:
+	_script_value = GBCHECK_CGB
+	return {"ok": true}
+
+
+## `MonCheck` answers whether the player owns the species in wScriptVar and
+## `BeastsCheck` runs the same test on all three beasts, leaving the last species it
+## asked about behind in wScriptVar when one is missing.
+func _special_mon_check(special: int) -> Dictionary:
+	var owner_party: Dictionary = _request.get("party", {})
+	if owner_party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	var owned: Array = owner_party.get("owned_species", [])
+	if special == 151:
+		_script_value = 1 if owned.has(_script_value) else 0
+	else:
+		_script_value = 1
+		for beast: int in BEAST_SPECIES:
+			if not owned.has(beast):
+				_script_value = beast
+				break
+	return {"ok": true}
+
+
+## InitRoamMons seeds the roam structs with Raikou and Entei at level 40 on their
+## starting maps. Gen2WorldAPI.open() already seeds the same imported records, and
+## ensure_roaming_mons() keeps positions a player has already moved, so this reports
+## rather than resetting a beast that is already loose.
+func _special_init_roam_mons(special: int) -> Dictionary:
+	if state != null and data != null:
+		state.ensure_roaming_mons(data.world_roaming_mons())
+	_emit_runtime_event(&"roaming_mons_initialized", {
+		"special": special,
+		"count": state.roaming_mons().size() if state != null else 0,
+	})
+	return {"ok": true}
+
+
+## `engine/events/haircut.asm`. All four open `SelectMonFromParty` and nothing else:
+## every box either routine's script shows is the script's own, so the host owes a
+## party list and an answer.
+func _special_grooming(special: int) -> Dictionary:
+	return _stage_runtime_request(&"party_selection_requested", {
+		"special": special,
+		"routine": GROOMING_TABLE_OF.get(special, &"bills_grandfather"),
+	})
+
+
+## Three tilemap writes and a `ret`. The window stands over the map until `closetext`
+## redraws it, so a script that spends money between two of them (the haircut
+## brothers' `takemoney`) draws the second over the first.
+func _special_money_window(special: int) -> Dictionary:
+	_money_window = MONEY_WINDOW_KIND_OF[special]
+	_emit_runtime_event(&"money_window_opened", {
+		"special": special,
+		"kind": _money_window,
+		"money": _money_balance(ACCOUNT_YOUR_MONEY),
+		"coins": _coins_value(),
+	})
+	return {"ok": true}
+
+
+## Each of the five owns its own boxes, and the two counters own the party list and
+## both `YesNoBox`es as well, so the whole routine is one host request the way
+## `NameRater` is.
+func _special_day_care(special: int) -> Dictionary:
+	return _stage_runtime_request(&"day_care_requested", {
+		"special": special,
+		"role": DAY_CARE_ROLE_OF[special],
+	})
+
+
+func _special_name_rater(special: int) -> Dictionary:
+	return _stage_runtime_request(&"name_rater_requested", {
+		"special": special,
+	})
+
+
+func _special_move_deletion(special: int) -> Dictionary:
+	return _stage_runtime_request(&"move_deleter_requested", {
+		"special": special,
+	})
+
+
+## `.GetMoveTutorMove` reads the value the map's own `setval` left, and a cartridge
+## whose TMHMMoves stops at HM07 has no move to teach, which is the refusal rather
+## than a guessed one.
+func _special_move_tutor(special: int) -> Dictionary:
+	var tutor_move: int = Gen2MoveTutor.move_for_value(data, _script_value)
+	if tutor_move <= 0:
+		return {
+			"ok": false,
+			"reason": &"unknown_move_tutor_move",
+			"special": special,
+			"value": _script_value,
+		}
+	return _stage_runtime_request(&"move_tutor_requested", {
+		"special": special,
+		"value": _script_value,
+		"move": tutor_move,
+	})
+
+
+## Both of the special's boxes are the host's; it answers with the chosen apricorn and
+## how many of it, and a backed-out box is the source's own `wScriptVar = 0`.
+func _special_select_apricorn_for_kurt(special: int) -> Dictionary:
+	return _stage_runtime_request(&"apricorn_selection_requested", {
+		"special": special,
+	})
+
+
+## `GiveParkBalls` clears wContestMon, loads twenty balls and starts the timer. The
+## flag itself is the script's own `setflag`, which has already run by here.
+func _special_give_park_balls(special: int) -> Dictionary:
+	_emit_runtime_event(&"bug_contest_started", {"special": special})
+	return {"ok": true}
+
+
+## Five of the ten contestant flags set, which is both who competes in the judging and
+## which sprites the park does not draw.
+func _special_select_random_bug_contestants(special: int) -> Dictionary:
+	_emit_runtime_event(&"bug_contestants_selected", {"special": special})
+	return {"ok": true}
+
+
+## `ContestDropOffMons` answers 1 when the lead is fainted, which is the one branch
+## its callers read, and otherwise masks the party to its first member.
+func _special_contest_drop_off_mons(special: int) -> Dictionary:
+	var contest_party: Dictionary = _request.get("party", {})
+	if contest_party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	var lead_fainted: bool = bool(contest_party.get("lead_fainted", false))
+	_script_value = 1 if lead_fainted else 0
+	if not lead_fainted:
+		_emit_runtime_event(&"contest_mons_dropped_off", {
+			"special": special,
+			"second_species": int(contest_party.get("second_species", 0)),
+		})
+	return {"ok": true}
+
+
+func _special_contest_return_mons(special: int) -> Dictionary:
+	_emit_runtime_event(&"contest_mons_returned", {"special": special})
+	return {"ok": true}
+
+
+func _special_warp_to_spawn_point(special: int) -> Dictionary:
+	_emit_runtime_event(&"warp_to_spawn_point", {"special": special})
+	return {"ok": true}
+
+
+## `CheckPartyFullAfterContest` does not only answer where the Pokemon caught in the
+## contest would go: it takes it home, asks `GiveANickname_YesNo` about it and clears
+## `wContestMon`. The answer is the party host's, since a nickname is a screen.
+func _special_check_party_full_after_contest(special: int) -> Dictionary:
+	return _stage_runtime_request(&"contest_mon_requested", {
+		"special": special,
+	})
+
+
+## The judging prints three placings and leaves the player's own in wScriptVar, which
+## the results script branches on.
+func _special_bug_contest_judging(special: int) -> Dictionary:
+	return _stage_runtime_request(&"bug_contest_judging_requested", {
+		"special": special,
+	})
+
+
+func _special_activate_fishing_swarm(special: int) -> Dictionary:
+	_emit_runtime_event(&"phone_special_requested", {
+		"special": special, "kind": &"activate_fishing_swarm",
+		"species": _script_value,
+	})
+	return {"ok": true}
+
+
+func _special_toggle_maptile_decorations(special: int) -> Dictionary:
+	_apply_maptile_decorations()
+	_emit_runtime_event(&"decoration_callback_applied", {
+		"special": special,
+		"kind": &"toggle_maptile_decorations",
+		"decorations": state.maptile_decorations() if state != null else {},
+	})
+	return {"ok": true}
+
+
+## `ToggleDecorationVisibility` per slot: an empty slot sets the object's event flag
+## and the renderer removes it, and a filled one clears the flag and writes the
+## decoration's own variable sprite.
+func _special_toggle_decorations_visibility(special: int) -> Dictionary:
+	var shown: Dictionary = {}
+	for row: Dictionary in Gen2WorldDecoration.OBJECT_SLOTS:
+		var deco: int = state.maptile_decoration(
+			StringName(row["slot"])
+		) if state != null else 0
+		var sprite: int = int(data.decoration(deco).get("sprite", 0)) \
+			if data != null and deco > 0 else 0
+		_staged_flags[int(row["flag"])] = sprite <= 0
+		if sprite <= 0:
+			continue
+		shown[int(row["variable_sprite"])] = sprite
+		_emit_runtime_event(&"variable_sprite_changed", {
+			"variable_sprite": int(row["variable_sprite"]),
+			"sprite": sprite,
+		})
+	_emit_runtime_event(&"decoration_callback_applied", {
+		"special": special,
+		"kind": &"toggle_decorations_visibility",
+		"sprites": shown,
+	})
+	return {"ok": true}
+
+
+func _special_slot_machine(special: int) -> Dictionary:
+	return _stage_runtime_request(&"slot_machine_requested", {
+		"special": special,
+		## `Slots_InitBias`' own `ld a, [wScriptVar] / and a`, which is
+		## the only thing the operand decides.
+		"lucky": _script_value != 0,
+		"coins": _coins_value(),
+	})
+
+
+func _special_card_flip(special: int) -> Dictionary:
+	return _stage_runtime_request(&"card_flip_requested", {
+		"special": special,
+		"coins": _coins_value(),
+	})
+
+
+func _special_unown_puzzle(special: int) -> Dictionary:
+	return _stage_runtime_request(&"unown_puzzle_requested", {
+		"special": special,
+		## `maskbits NUM_UNOWN_PUZZLES` is what bounds the operand, so a
+		## value outside the four wraps rather than failing.
+		"puzzle": _script_value & 0x3,
+	})
+
+
+## The word the wall spells, staged as the text `JoyWaitAorB` holds until a button. A
+## host that can reach the chamber's own tileset draws it as
+## `_DisplayUnownWords_CopyWord`'s 2x2 letter blocks instead ([Gen2UnownWallPage]);
+## the wait it answers is this one.
+func _special_display_unown_words(special: int) -> Dictionary:
+	var wall_word: String = data.unown_wall_word(_script_value) if data != null \
+		else ""
+	if wall_word.is_empty():
+		return {
+			"ok": false,
+			"reason": &"unknown_unown_wall",
+			"special": special,
+			"wall": _script_value,
+		}
+	## `special` is a StringName tag on a pending text, not the index, so
+	## the wall is named under its own key.
+	return _stage_internal_text(wall_word, false, {"unown_wall": _script_value})
+
+
+## `Random` masked to two bits plus three. The same byte is stepped by
+## `CheckDailyResetTimer` on every day that passes, which is
+## `Gen2WorldState.reset_daily_flags`; this is the resample its own script asks for.
+func _special_sample_kenji_break_countdown(_special: int) -> Dictionary:
+	_staged_kenji_break_timer = Gen2WorldState.kenji_break_countdown(_random)
+	_has_staged_kenji_break_timer = true
+	return {"ok": true}
+
+
+## `sMysteryGiftTrainerHouseFlag` straight into wScriptVar: a player who has never
+## received a Mystery Gift is turned away, and one who has fights CAL under the
+## partner's name.
+func _special_trainer_house(_special: int) -> Dictionary:
+	_script_value = int(_mystery_gift_section().get("trainer_house_flag", 0))
+	return {"ok": true}
+
+
+## Zero when nothing is waiting and the item plus one when something is.
+## POKECENTER_2F's scene script branches on the zero, and the officer it puts on the
+## floor is what hands the gift over.
+func _special_check_mystery_gift(_special: int) -> Dictionary:
+	_script_value = Gen2MysteryGift.check_value(_mystery_gift_section())
+	return {"ok": true}
+
+
+## Carrie's own row on GOLDENROD DEPT. STORE 5F, behind a `GameboyCheck` this project
+## always passes: there is no Game Boy here that is not a colour one.
+func _special_unlock_mystery_gift(_special: int) -> Dictionary:
+	Gen2MysteryGift.unlock(_mystery_gift_section())
+	return {"ok": true}
+
+
+func _special_get_mystery_gift_item(special: int) -> Dictionary:
+	return _stage_mystery_gift_item(special)
+
+
+## `wPartySpecies`' first byte and nothing else: the wall opens for a party led by
+## Ho-Oh. `GetMapAttributesPointer` in front of it is marked pointless in the pin and
+## answers nothing.
+func _special_ho_oh_chamber(special: int) -> Dictionary:
+	var chamber_party: Dictionary = _request.get("party", {})
+	if chamber_party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	var chamber_species: Array = chamber_party.get("species", [])
+	if not chamber_species.is_empty() and int(chamber_species[0]) == SPECIES_HO_OH:
+		_staged_flags[EVENT_WALL_OPENED_IN_HO_OH_CHAMBER] = true
+	return {"ok": true}
+
+
+## A WATER STONE in the bag opens it, and so does one held by any party member:
+## `.loop` walks the party backwards reading MON_ITEM. The flag is tested first, so a
+## wall already open spends nothing.
+func _special_omanyte_chamber(special: int) -> Dictionary:
+	if not _event_flag_active(EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER):
+		var stone_party: Dictionary = _request.get("party", {})
+		if stone_party.is_empty():
+			return {
+				"ok": false, "reason": &"missing_party_summary", "special": special,
+			}
+		var opens: bool = _item_quantity(ITEM_WATER_STONE) > 0
+		if not opens:
+			for held: Variant in stone_party.get("held_items", []):
+				if int(held) == ITEM_WATER_STONE:
+					opens = true
+					break
+		if opens:
+			_staged_flags[EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER] = true
+	return {"ok": true}
+
+
+## `wBattleResult`'s BATTLERESULT_CAUGHT_CELEBI, which `PokeBallEffect` sets on a
+## catch made in a BATTLETYPE_CELEBI fight and nothing else clears until the next
+## battle.
+func _special_check_caught_celebi(_special: int) -> Dictionary:
+	_script_value = 1 if state != null and state.battle_caught_celebi() else 0
+	return {"ok": true}
+
+
+## The whole routine is a sprite-anim cutscene and a battle type. There is no
+## sprite-anim layer outside the intro, so what it owes a script is the wait its own
+## loop spends and the type the fight behind it starts with.
+func _special_celebi_shrine_event(special: int) -> Dictionary:
+	_loaded_battle_type = Gen2Battle.BATTLETYPE_CELEBI
+	if not _battle_setup.is_empty():
+		_battle_setup["battle_type"] = Gen2Battle.BATTLETYPE_CELEBI
+	_emit_runtime_event(&"presentation_special_applied", {
+		"special": special, "kind": &"celebi_shrine",
+	})
+	return _stage_frame_wait(
+		CELEBI_SHRINE_PASSES * CELEBI_SHRINE_FRAMES_PER_PASS,
+		{"special": special, "kind": &"celebi_shrine"}
+	)
+
+
+## `PlayRadio` opens the station wScriptVar names, prints its line in a four-row box
+## and holds until A or B. It is the Pokegear's own radio without the Pokegear, so the
+## station is the request and the host draws it.
+func _special_map_radio(special: int) -> Dictionary:
+	return _stage_runtime_request(&"map_radio_requested", {
+		"special": special,
+		"station": _script_value,
+	})
+
+
+## `ScriptReturnCarry`: TRUE once `wLuckyNumberDayTimer` has run out, which is the
+## Friday the show comes round on.
+func _special_check_lucky_number_show_flag(_special: int) -> Dictionary:
+	_script_value = 1 if state != null and state.lucky_number_show_ready() else 0
+	return {"ok": true}
+
+
+## `RestartLuckyNumberCountdown`, then the GAME_OVER bit off the show flag, then
+## `LoadOrRegenerateLuckyIDNumber`. The bit is the radio segment's own and this
+## project's radio reads the timer instead, so what is left is the countdown and the
+## number.
+func _special_reset_lucky_number_show_flag(_special: int) -> Dictionary:
+	_staged_lucky_number_days_left = _lucky_number_days_until_friday()
+	_has_staged_lucky_number_days_left = true
+	_refresh_lucky_id_number()
+	return {"ok": true}
+
+
+## `PrintNum` with PRINTNUM_LEADINGZEROS over five digits into wStringBuffer3, which
+## the radio tower's own text prints.
+func _special_print_todays_lucky_number(special: int) -> Dictionary:
+	_refresh_lucky_id_number()
+	_set_text_buffer(
+		RomLayout.STRING_BUFFER_3, "%05d" % _lucky_id_number(), &"lucky_number",
+		{"special": special}
+	)
+	return {"ok": true}
+
+
+## The whole walk is over ID numbers the party mirror carries, so the routine is the
+## host's arithmetic rather than a screen.
+func _special_check_for_lucky_number_winners(special: int) -> Dictionary:
+	var lucky_party: Dictionary = _request.get("party", {})
+	if lucky_party.is_empty():
+		return {"ok": false, "reason": &"missing_party_summary", "special": special}
+	_refresh_lucky_id_number()
+	var winner: Dictionary = Gen2WorldPartyHost.lucky_number_match(
+		_lucky_id_number(),
+		lucky_party.get("id_numbers", []),
+		lucky_party.get("species", []),
+		lucky_party.get("eggs", []),
+		lucky_party.get("stored_id_numbers", []),
+		lucky_party.get("stored_species", [])
+	)
+	_script_value = int(winner.get("script_value", 0))
+	if _script_value == 0:
+		return {"ok": true}
+	## `GetPokemonName` on the matching row's species, into the buffer
+	## both boxes print, and then the box the match's own location picks.
+	var winner_species: int = int(winner.get("species", 0))
+	_cur_party_species = winner_species
+	var winner_name: String = String(
+		data.species(winner_species).get("name", "")
+	) if data != null else ""
+	_set_text_buffer(RomLayout.STRING_BUFFER_1, winner_name, &"lucky_number_winner", {
+		"special": special, "species": winner_species,
+	})
+	var lucky_box: String = _special_box(
+		"lucky_number",
+		"match_pc" if bool(winner.get("in_storage", false)) else "match_party"
+	)
+	if lucky_box.is_empty():
+		return {"ok": false, "reason": &"missing_special_text", "special": special}
+	return _stage_internal_text(lucky_box, false, {"special": special})
+
+
+## The record straight out of the save into wMagikarpLength, printed the way
+## `PrintMagikarpLength` prints it, and the sign's own box. An unbeaten record is two
+## zero bytes, which is what the sign shows before anyone has measured one.
+func _special_magikarp_house_sign(special: int) -> Dictionary:
+	var record: Dictionary = state.best_magikarp() if state != null else {}
+	_set_text_buffer(RomLayout.STRING_BUFFER_1, Gen2WorldPartyHost.magikarp_length_string(
+		int(record.get("feet", 0)), int(record.get("inches", 0))
+	), &"magikarp_length", {"special": special})
+	_set_text_ram("magikarp_record_holder", String(record.get("ot", "")))
+	var sign_box: String = _special_box("magikarp", "record")
+	if sign_box.is_empty():
+		return {"ok": false, "reason": &"missing_special_text", "special": special}
+	return _stage_internal_text(sign_box, false, {"special": special})
+
+
+func _special_bank_of_mom(_special: int) -> Dictionary:
+	return _bank_of_mom(MOM_CHECK_INITIALIZED)
+
+
+## `ld a, [wUnownDex] / and a / ret z`: with no Unown caught the routine draws nothing
+## at all, which the host answers for since it is the one that holds the dex.
+func _special_unown_printer(special: int) -> Dictionary:
+	return _stage_runtime_request(&"unown_printer_requested", {
+		"special": special,
+		"caught": state.unown_caught_count() if state != null else 0,
+	})
+
+
+## `_Diploma` draws `PlaceDiplomaOnScreen`'s page and waits for a button;
+## `_PrintDiploma` draws the same page and then holds in `SendScreenToPrinter`.
+## Neither writes anything a script reads, so the request carries only which of the
+## two loops is standing.
+func _special_diploma(special: int) -> Dictionary:
+	return _stage_runtime_request(&"diploma_requested", {
+		"special": special,
+		"printing": special == SPECIAL_PRINT_DIPLOMA,
+	})
+
+
+## The counter is one loop: the prize list, a yes/no on the row, and whichever of the
+## four boxes the answer reaches. B on the list is the only way out and prints her
+## parting line.
+func _special_buena_prize(special: int) -> Dictionary:
+	return _stage_buena_prize_menu(special)
+
+
+## `PrintSeerText SEER_INTRO`, `JoyWaitAorB`, and only then the list.
+func _special_poke_seer(special: int) -> Dictionary:
+	var seer_intro: String = _special_box("poke_seer", "see_all")
+	if seer_intro.is_empty():
+		return {"ok": false, "reason": &"missing_special_text", "special": special}
+	return _stage_internal_text(seer_intro, false, {
+		"special": special,
+		"party_selection_after_text": {
+			"special": special,
+			"routine": PARTY_SELECTION_ROUTINE_OF[special],
+		},
+	})
+
+
+## All three open `SelectMonFromParty` and answer on what came back. `PhotoStudio`
+## prints its own question in front of the list, which is the one box a script does
+## not carry for it.
+func _special_party_selection(special: int) -> Dictionary:
+	if special == SPECIAL_PHOTO_STUDIO:
+		var asked: String = _special_box("photo_studio", "which_mon")
+		if asked.is_empty():
+			return {"ok": false, "reason": &"missing_special_text", "special": special}
+		_standing_text = asked
+	return _stage_runtime_request(&"party_selection_requested", {
+		"special": special,
+		"routine": PARTY_SELECTION_ROUTINE_OF[special],
+	})
+
+
+## `TryAddMonToParty` with a level 15 SHUCKLE holding a BERRY, named SHUCKIE under
+## MANIA's own OT and ID, and the daily flag behind it. A full party is `.NotGiven`,
+## which answers zero and gives nothing: the box is never reached.
+func _special_give_shuckle(special: int) -> Dictionary:
+	return _stage_runtime_request(&"pokemon_requested", {
+		"special": special,
+		"kind": &"give_shuckle",
+		"pokemon": Gen2WorldPartyHost.SHUCKLE,
+		"level": Gen2WorldPartyHost.SHUCKIE_LEVEL,
+		"item": Gen2WorldPartyHost.ITEM_BERRY,
+		"nickname": Gen2WorldPartyHost.SHUCKIE_NICKNAME,
+		"original_trainer": Gen2WorldPartyHost.MANIA_OT_NAME,
+		"ot_id": Gen2WorldPartyHost.MANIA_OT_ID,
+		"party_only": true,
+	})
+
+
+## The box alone: the question is the `writetext` in front of it, and the answer is
+## `yesorno`'s own, YES writing 1 and B writing 0.
+func _special_ask_remember_password(_special: int) -> Dictionary:
+	_pending = {
+		"type": &"choice",
+		"command": &"yesorno",
+		"choices": [&"yes", &"no"],
+		"text": _standing_text,
+		"special": &"ask_remember_password",
+		"header": ASK_REMEMBER_PASSWORD_BOX.duplicate(),
+		"source": _request.duplicate(true),
+	}
+	return _waiting_result()
+
+
+## `AddMobileMonToParty` with one of `OddEggs`' fourteen rows, rolled against
+## `OddEggProbabilities`. `TossKeyItem` runs first and removes nothing when the pack
+## holds no ticket; it writes no wScriptVar either way, so the toss's own answer is
+## put back.
+func _special_give_odd_egg(special: int) -> Dictionary:
+	if _item_quantity(ITEM_EGG_TICKET) > 0:
+		var kept: int = _script_value
+		var tossed: Dictionary = _stage_item_delta(ITEM_EGG_TICKET, -1)
+		_script_value = kept
+		if not bool(tossed.get("ok", true)):
+			return tossed
+	return _stage_runtime_request(&"pokemon_requested", {
+		"special": special,
+		"kind": &"give_odd_egg",
+		"party_only": true,
+	})
+
+
+## Not a gift at all: the Dragon Shrine's `givepoke` has already run, and this
+## rewrites the last DRATINI in the party with one of two movesets. A wScriptVar above
+## one returns before the search, which is what the elder's third answer leaves
+## standing.
+func _special_give_dratini(special: int) -> Dictionary:
+	if _script_value > 1:
+		return {"ok": true}
+	return _stage_runtime_request(&"dratini_moveset_requested", {
+		"special": special,
+		"moveset": _script_value,
+	})
+
+
+## `CheckCaughtMon` on wScriptVar less one, and nothing at all when it is already
+## caught: the prize counter has handed the Pokemon over by here, so this is the
+## new-entry screen alone. The species byte is one high, which is the `dec a` in front
+## of both calls.
+func _special_game_corner_prize_mon_check_dex(special: int) -> Dictionary:
+	var prize_species: int = _script_value
+	if prize_species <= 0:
+		return {"ok": false, "reason": &"invalid_prize_species", "special": special}
+	if state != null and state.has_caught_species(prize_species):
+		return {"ok": true}
+	_staged_caught_species[prize_species] = true
+	return _stage_runtime_request(&"pokedex_entry_requested", {
+		"special": special,
+		"species": prize_species,
+	})
+
+
+## `DoNthMenu` over the five words of today's category, and the answer is whether the
+## row matches the low nibble of `wBuenasPassword`. The category is the high nibble,
+## which is what the radio show drew this morning.
+func _special_buenas_password(special: int) -> Dictionary:
+	var password: int = _buenas_password()
+	if password < 0:
+		return {"ok": false, "reason": &"missing_buenas_password", "special": special}
+	_stage_buenas_password_menu(password)
+	return {"ok": true}
+
+
+func _special_random_unseen_wild_mon(special: int) -> Dictionary:
+	var rare_species: int = _phone_unseen_rare_species()
+	if rare_species <= 0:
+		_emit_runtime_event(&"phone_special_requested", {
+			"special": special, "kind": &"random_unseen_wild_mon",
+			"internal_text": false, "script_value": 1,
+		})
+		_script_value = 1
+	else:
+		var rare_name: String = String(data.species(rare_species).get("name", ""))
+		_set_text_buffer(1, rare_name, &"phone_unseen_wild_mon", {
+			"special": special, "species": rare_species,
+		})
+		_emit_runtime_event(&"phone_special_requested", {
+			"special": special, "kind": &"random_unseen_wild_mon",
+			"internal_text": true, "buffer": 1, "value": rare_name,
+			"species": rare_species, "script_value": 0,
+		})
+		_script_value = 0
+	return {"ok": true}
+
+
+func _special_random_phone_wild_mon(special: int) -> Dictionary:
+	var wild_name: String = _phone_wild_mon_name()
+	_set_text_buffer(1, wild_name, &"phone_wild_mon", {"special": special})
+	_emit_runtime_event(&"phone_special_requested", {
+		"special": special, "kind": &"random_phone_wild_mon",
+		"buffer": 1, "value": wild_name,
+	})
+	return {"ok": true}
+
+
+func _special_random_phone_mon(special: int) -> Dictionary:
+	var trainer_mon_name: String = _phone_trainer_mon_name()
+	_set_text_buffer(1, trainer_mon_name, &"phone_mon", {"special": special})
+	_emit_runtime_event(&"phone_special_requested", {
+		"special": special, "kind": &"random_phone_mon",
+		"buffer": 1, "value": trainer_mon_name,
+	})
+	return {"ok": true}
 ## ToggleMaptileDecorations and SetDecorationTile
 ## (engine/overworld/decorations.asm). Coordinates are changeblock coordinates;
 ## Gen2WorldAPI applies their padded-buffer conversion.

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -1396,14 +1396,13 @@ func test_every_redundancy_row_has_a_handler() -> void:
 
 
 ## The one assertion that cannot be made by running a single pairing: which
-## effects `_apply_smart` dispatches at all. The arms are read out of the file
-## and resolved through [Gen2MoveEffect]'s own constants, so a renamed constant
-## fails here rather than silently dropping a row.
+## effects `_apply_smart` dispatches at all. Its table is keyed by
+## [Gen2MoveEffect]'s own constants, so a renamed constant fails to parse rather
+## than silently dropping a row.
 func test_every_smart_jumptable_entry_has_a_handler() -> void:
-	var handled: Array[int] = _dispatched_effects("_apply_smart")
 	var missing: Array[int] = []
 	for number: int in SMART_EFFECT_NUMBERS:
-		if not handled.has(number):
+		if not Gen2BattleAI.SMART_HANDLERS.has(number):
 			missing.append(number)
 	assert_eq(missing, [] as Array[int], "every AI_Smart row needs an arm")
 

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37924
+const MAX_COMMENT_LINES: int = 37893
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Delete
 ## a line when you fix one. The test fails on a line that no longer names a
@@ -28,8 +28,6 @@ const OVER_COMPLEXITY: Array[String] = [
 	"game/audio/gen2_apu.gd:write",
 	"game/audio/gen2_sound_engine.gd:_parse_music_command",
 	"game/battle/ai.gd:_apply_basic",
-	"game/battle/ai.gd:_apply_smart",
-	"game/battle/battle_screen.gd:_describe",
 	"game/battle/battle_screen.gd:_handle_button",
 	"game/battle/battle_screen.gd:_refresh_menu_layer",
 	"game/battle/battle_screen.gd:start_world_battle",
@@ -61,7 +59,6 @@ const OVER_COMPLEXITY: Array[String] = [
 	"game/save/save_validator.gd:validate",
 	"game/world/battle_tower.gd:action",
 	"game/world/intro_movie.gd:_run_scene",
-	"game/world/radio_show.gd:_run",
 	"game/world/slot_machine.gd:_reel_action",
 	"game/world/start_menu_screen.gd:_confirm",
 	"game/world/start_menu_screen.gd:_hardware_image",
@@ -87,14 +84,9 @@ const OVER_COMPLEXITY: Array[String] = [
 	"game/world/world_screen.gd:_handle_button",
 	"game/world/world_screen.gd:_overlay_open",
 	"game/world/world_screen.gd:_run_party_action",
-	"game/world/world_script.gd:command_at",
 	"game/world/world_script.gd:scan_references",
 	"game/world/world_script_runner.gd:_complete",
-	"game/world/world_script_runner.gd:_execute",
-	"game/world/world_script_runner.gd:_execute_later_command",
-	"game/world/world_script_runner.gd:_execute_special",
 	"game/world/world_script_runner.gd:_read_runtime_variable",
-	"game/world/world_script_runner.gd:complete_runtime_request",
 	"game/world/world_service_screen.gd:_confirm_pc_row",
 	"tools/checks/opening_lane.gd:_validate",
 	"tools/checks/pokedex.gd:_validate",
@@ -102,7 +94,6 @@ const OVER_COMPLEXITY: Array[String] = [
 	"tools/preview_battle_switch.gd:_open",
 	"tools/preview_town_map.gd:_initialize",
 	"tools/preview_world.gd:_initialize",
-	"tools/preview_world.gd:_process",
 	"tools/preview_world_story.gd:_drain_story",
 	"tools/preview_world_story.gd:_fog_badge_path",
 	"tools/preview_world_story.gd:_glacier_badge_path",
@@ -213,7 +204,8 @@ func _collect(directory: String, out: PackedStringArray) -> void:
 
 ## Every top-level function in [param source] with its cyclomatic complexity,
 ## counted the way a linter counts it: one for the function, one per `if`,
-## `elif`, `while`, `for`, `and`, `or` and inline `if`, and one per `match` arm.
+## `elif`, `while`, `for`, `and`, `or` and inline `if`, and one per `match` arm,
+## whether the arm opens a block or carries its body on the same line.
 func _functions(source: PackedStringArray) -> Array[Dictionary]:
 	var branches := RegEx.create_from_string(
 		"(?<![A-Za-z0-9_.])(if|elif|while|for|and|or)(?![A-Za-z0-9_])"
@@ -222,8 +214,10 @@ func _functions(source: PackedStringArray) -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
 	var current: Dictionary = {}
 	## One entry per open `match`: the indent the statement sits at, so an arm is
-	## a line one deeper that ends in a colon.
+	## a line one deeper. An arm ends in a colon or carries its whole body after
+	## one, and both are a branch: a one-line arm hid 89 of them here once.
 	var matches: Array[int] = []
+	var arm := RegEx.create_from_string("^[^:]*:")
 	for raw: String in source:
 		var code: String = _code(raw)
 		var text: String = code.strip_edges()
@@ -239,7 +233,7 @@ func _functions(source: PackedStringArray) -> Array[Dictionary]:
 		while not matches.is_empty() and indent <= matches[matches.size() - 1]:
 			matches.resize(matches.size() - 1)
 		if not matches.is_empty() and indent == matches[matches.size() - 1] + 1 \
-			and text.ends_with(":"):
+			and arm.search(text) != null:
 			current["complexity"] = int(current["complexity"]) + 1
 		current["complexity"] = int(current["complexity"]) + branches.search_all(text).size()
 		if text.begins_with("match ") and text.ends_with(":"):

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -854,6 +854,24 @@ func test_the_spawn_point_special_clears_the_contest_and_safari_flags() -> void:
 	assert_false(world.state.is_engine_flag_active(safari))
 
 
+## `Script_warpmod` writes the three backup-warp bytes and returns, so the script
+## carries on to whatever puts the player on the -1 warp that spends them. Both
+## dept store elevators and the Fast Ship's cabin are entered that way.
+func test_warpmod_records_the_backup_warp_and_the_script_runs_on() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6280"] = [
+		Gen2WorldScript.WARPMOD, 3, 1, 2,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6280
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var result: Array = world.dispatch_script_events()
+	assert_eq(result[0]["status"], &"complete", JSON.stringify(result))
+	assert_eq(world.backup_warp, {"warp": 3, "map_group": 1, "map_number": 2})
+
+
 func test_map_decoration_specials_stamp_the_selected_room_blocks() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6250"] = [

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -298,6 +298,85 @@ func _settle_mon_special(host_property: String) -> void:
 	_screen.advance_frame()
 
 
+## The kinds that drove themselves to the frame they want. Every other kind
+## stages a sprite and then spends the frames it needs.
+const SELF_DRIVEN_KINDS: Array[StringName] = [
+	&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
+	&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
+	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
+	&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
+	&"catch_nickname", &"mom_bank", &"bills_pc", &"players_pc",
+	&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page",
+	&"reset_question", &"launcher_question",
+]
+
+
+## What stages each preview kind, as the driver that stages it. A kind the table
+## does not name is a field item, one of the screen's own `preview_*` drivers, or
+## an overworld effect sprite, in that order.
+const STAGERS: Dictionary = {
+	&"unown_wall": &"_stage_unown_wall",
+	&"battle": &"_stage_battle",
+	&"battle_transition": &"_stage_battle_transition",
+	&"script_fade": &"_stage_script_fade",
+	&"level_evolution": &"_stage_level_evolution",
+	&"egg_hatch": &"_stage_egg_hatch",
+	&"gift_nickname": &"_stage_gift_nickname",
+	&"whiteout": &"_stage_whiteout",
+	&"unown_puzzle": &"_stage_unown_puzzle",
+	&"slot_machine": &"_stage_slot_machine",
+	&"tile_anim": &"_stage_tile_anim",
+	&"card_flip": &"_stage_card_flip",
+	&"day_care": &"_stage_day_care",
+	&"name_rater": &"_stage_party_routine",
+	&"move_deleter": &"_stage_party_routine",
+	&"move_tutor": &"_stage_party_routine",
+	&"battle_tower": &"_stage_battle_tower",
+	&"yes_no": &"_stage_yes_no",
+	&"mart": &"_stage_mart",
+	&"mart_sell": &"_stage_mart",
+	&"elevator": &"_stage_elevator",
+	&"warp": &"_stage_warp",
+	&"door": &"_stage_door",
+	&"ledge": &"_stage_ledge",
+	&"ice_slide": &"_stage_ice_slide",
+	&"map_name_sign": &"_stage_map_name_sign",
+	&"mod_notice": &"_stage_mod_notice",
+	&"mod_page": &"_stage_mod_page",
+	&"pokepic": &"_stage_pokepic",
+	&"unown_printer": &"_stage_unown_printer",
+	&"diploma": &"_stage_diploma",
+	&"start_menu": &"_stage_start_menu",
+	&"bills_pc": &"_stage_pc",
+	&"players_pc": &"_stage_pc",
+	&"pokemon_center_pc": &"_stage_pc",
+	&"mom_bank": &"_stage_mom_bank",
+}
+
+
+## Puts the screen in the state the picture wants. Called once, on the frame the
+## screen is ready.
+func _stage_kind() -> void:
+	if STAGERS.has(_kind):
+		call(STAGERS[_kind])
+		return
+	if FIELD_ITEMS.has(_kind):
+		if _kind in FACE_UP_FIRST:
+			_screen.move_up()
+		_screen.preview_field_item(int(FIELD_ITEMS[_kind]))
+		return
+	if _screen.has_method(SCREEN_DRIVER % _kind):
+		## The screen's own `preview_*` drivers, by their name without the
+		## prefix. A `*_use` driver is one step per call, so it is called
+		## twice: the first opens the menu and the second answers it.
+		_screen.call(SCREEN_DRIVER % _kind)
+		if String(_kind).ends_with("_use") or String(_kind).ends_with("_question"):
+			_screen.call(SCREEN_DRIVER % _kind)
+		return
+	if not _bare:
+		_screen.preview_effect_sprites(_kind)
+
+
 func _process(_delta: float) -> bool:
 	if _screen == null:
 		return false
@@ -310,428 +389,8 @@ func _process(_delta: float) -> bool:
 	if _frames == 1:
 		_choose_view()
 	if _frames == 2:
-		if _kind == &"unown_wall":
-			## The chamber's own `bg_event ..., BGEVENT_UP`: face the wall from
-			## the cell below it and read it, which is the only way in.
-			_screen.move_up()
-			_screen.interact()
-			## `writetext` is one page: the first press finishes the reveal the
-			## text speed is still spending, and the second ends the page, which
-			## is what runs `special DisplayUnownWords` and puts the box up.
-			_screen.press_button(Gen2Button.A)
-			_screen.press_button(Gen2Button.A)
-		elif _kind == &"battle":
-			## Past the transition and into the fight it opens, which is the one
-			## picture a battle renderer staged on the map draws.
-			_screen.preview_battle_request()
-			_screen.settle_battle_transition()
-			_screen.advance_frames(STAGED_FRAMES)
-		elif _kind == &"battle_transition":
-			## `DoBattleTransition` over the map it runs on. The first of the two
-			## numbers is how many frames into it to photograph rather than a
-			## cell, since a transition is two hundred of them and every one is
-			## a different picture; the second is 1 for a trainer's, which is the
-			## branch that draws the Poke Ball and floods the map.
-			_screen.preview_battle_transition(_cell.x, _cell.y != 0)
-		elif _kind == &"script_fade":
-			## One of the five fade specials over the map it runs on. The first
-			## number is the special (46 `FadeOutToWhite`, 47 `BattleTowerFade`,
-			## 48 `FadeOutToBlack`, 49 `FadeInFromWhite`, 50 `FadeInFromBlack`)
-			## and the second how many of its frames to spend before the
-			## picture, since each of the four rows is a different screen.
-			_screen.preview_script_fade(maxi(_cell.x, 0))
-			for _frame: int in maxi(_cell.y, 0):
-				_screen.advance_frame()
-		elif _kind == &"level_evolution":
-			## `EvolveAfterBattle`'s own screen, which is a few hundred frames of
-			## picture. The first number is how far into it to photograph rather
-			## than a cell, the way `battle_transition`'s is; the box is pressed
-			## past on the frames it is waiting on, since neither `PrintText` nor
-			## `DelayFrames` shortens for a screenshot.
-			_screen.preview_level_evolution()
-			for _frame: int in maxi(_cell.x, 0):
-				_screen.advance_frame()
-				var evolving: Gen2EvolutionScreen = _screen.get("_evolution_host")
-				if evolving == null:
-					break
-				if evolving.awaiting_press():
-					_screen.press_button(Gen2Button.A)
-		elif _kind == &"egg_hatch":
-			## `OverworldHatchEgg`, driven the same way and for the same reason:
-			## the sequence is five hundred frames of picture, so the first
-			## number is how far into it to photograph and the second is the
-			## species inside the egg, 0 for the first the cache holds.
-			_screen.preview_egg_hatch(maxi(_cell.y, 0))
-			for _frame: int in maxi(_cell.x, 0):
-				_screen.advance_frame()
-				var hatching: Gen2EggHatchScreen = _screen.get("_hatch_host")
-				if hatching == null:
-					break
-				if hatching.awaiting_press():
-					_screen.press_button(Gen2Button.A)
-		elif _kind == &"gift_nickname":
-			## `GivePoke`'s own prompt. The presses are spent behind the frames
-			## the box owes, since nothing shortens a printing text; the second
-			## number's thousands digit is the box branch.
-			_screen.preview_gift_nickname(maxi(_cell.y, 0) % 1000, _cell.y >= 1000)
-			_settle_mon_special("_nickname_host")
-			for _press: int in maxi(_cell.x, 0):
-				var prompt: Gen2NicknamePromptScreen = _screen.get("_nickname_host")
-				if prompt == null:
-					break
-				## NO on the question, so the mode photographs the routine's own
-				## boxes; the keyboard behind YES has `preview_naming_screen.gd`.
-				_screen.press_button(
-					Gen2Button.B if prompt.question_ready() else Gen2Button.A
-				)
-				_settle_mon_special("_nickname_host")
-		elif _kind == &"whiteout":
-			## `Script_Whiteout`, which no fixture cell reaches: the party is
-			## poisoned down to its last point and the pass `CountStep` owes is
-			## spent. The first number is how many of its presses to spend, so 0
-			## is the faint line, 1 the first page of `_WhitedOutText` and 3 the
-			## map the player wakes up on.
-			_screen.preview_whiteout()
-			## The box reveals a letter at a time at the OPTION menu's own speed,
-			## so each press is given behind the frames its page costs.
-			for _press: int in maxi(_cell.x, 0) + 1:
-				for _frame: int in 120:
-					_screen.advance_frame()
-				if _press < maxi(_cell.x, 0):
-					_screen.press_button(Gen2Button.A)
-		elif _kind == &"unown_puzzle":
-			## `special UnownPuzzle`, which no fixture cell reaches. The first
-			## number is how many frames into the board to photograph and the
-			## second which picture: 0 Kabuto, 1 Omanyte, 2 Aerodactyl, 3 Ho-Oh.
-			## The empty cursor blinks off `hVBlankCounter`, so a frame with bit
-			## 4 clear photographs a board with no cursor on it.
-			## 4 to 7 are the same four pictures with the board walked into
-			## `.SolvedPuzzleConfiguration` through the screen's own presses,
-			## which is the only way to photograph the assembled picture.
-			_screen.preview_unown_puzzle(
-				maxi(_cell.y, 0) % RomLayout.UNOWN_PUZZLE_PICTURES.size(),
-				maxi(_cell.y, 0) >= RomLayout.UNOWN_PUZZLE_PICTURES.size()
-			)
-			for _frame: int in maxi(_cell.x, 0):
-				if _screen.get("_unown_puzzle_host") == null:
-					break
-				_screen.advance_frame()
-		elif _kind == &"slot_machine":
-			## `special SlotMachine`, which no fixture cell reaches either. The
-			## first number is how many frames into the game to photograph and
-			## the second is the bet, 1 to 3, plus 4 for the lucky machine the
-			## Game Corner's own `random 6` picks one time in six.
-			var slots_bet: int = maxi(_cell.y, 0) % 4
-			_screen.preview_slot_machine(
-				100, maxi(_cell.y, 0) >= 4, maxi(slots_bet, 1), maxi(_cell.x, 0)
-			)
-		elif _kind == &"tile_anim":
-			## `AnimateTileset` runs once a hardware frame, so any frame of a
-			## map's own water, flowers, lava or cave scroll is reachable by
-			## spending them: the first number is how many, and the cell goes in
-			## `tile_anim@x,y` as usual.
-			for _spent: int in maxi(_cell.x, 0):
-				_screen.advance_frame()
-		elif _kind == &"card_flip":
-			## `special CardFlip`, which no fixture cell reaches either. The
-			## first number is how many frames into the game to photograph and
-			## the second the balance in hundreds of coins, 0 meaning 100.
-			_screen.preview_card_flip(
-				maxi(_cell.y, 0) * 100 if _cell.y > 0 else 100, maxi(_cell.x, 0)
-			)
-		elif _kind == &"day_care":
-			## The Day-Care's five, driven the way the two above are. The first
-			## number is how many presses into the routine to photograph and the
-			## second is which routine: 0 the man, 1 the lady, 2 the man outside,
-			## 3 and 4 the two signs.
-			_screen.preview_day_care(DAY_CARE_ROLES[clampi(
-				_cell.y, 0, DAY_CARE_ROLES.size() - 1
-			)])
-			_settle_mon_special("_day_care_host")
-			for _press: int in maxi(_cell.x, 0):
-				if _screen.get("_day_care_host") == null:
-					break
-				_screen.press_button(Gen2Button.A)
-				_settle_mon_special("_day_care_host")
-		elif _kind in [&"name_rater", &"move_deleter", &"move_tutor"]:
-			## `special NameRater` and `special MoveDeletion`, neither of which
-			## any fixture cell reaches. The first number is how many presses
-			## into the routine to photograph: 2 is the introduction's last page
-			## with its YES/NO up, 4 the party list, and so on. Presses are spent
-			## only once the box owes no frames, since nothing shortens a
-			## printing text.
-			match _kind:
-				&"name_rater":
-					_screen.preview_name_rater()
-				&"move_tutor":
-					_screen.preview_move_tutor()
-				_:
-					_screen.preview_move_deleter()
-			var host_property: String = "_%s_host" % _kind
-			_settle_mon_special(host_property)
-			for _press: int in maxi(_cell.x, 0):
-				if _screen.get(host_property) == null:
-					break
-				_screen.press_button(Gen2Button.A)
-				_settle_mon_special(host_property)
-		elif _kind == &"battle_tower":
-			## `BattleTower1FReceptionistScript` from the cell below her, which is
-			## where `Script_WalkToBattleTowerElevator` puts the player back. The
-			## first number is how many A presses to spend, walking the welcome box,
-			## the explanation question and the three-row menu; the second is how many
-			## DOWN presses on whichever menu is up. `_CheckForBattleTowerRules`
-			## refuses anything but three different species holding three different
-			## items, and the development save's party is not one.
-			_stage_battle_tower_party()
-			_screen.press_button(Gen2Button.UP)
-			_screen.interact()
-			for _frame: int in TEXT_SETTLE_FRAMES:
-				_screen.advance_frame()
-			for _press: int in maxi(_cell.x, 0):
-				_screen.press_button(Gen2Button.A)
-				for _frame: int in TEXT_SETTLE_FRAMES:
-					_screen.advance_frame()
-			for _press: int in maxi(_cell.y, 0):
-				_screen.press_button(Gen2Button.DOWN)
-				for _frame: int in TEXT_SETTLE_FRAMES:
-					_screen.advance_frame()
-		elif _kind == &"yes_no":
-			## `Script_yesorno`'s own box: the NPC beside the player is talked
-			## to and each page answered until the choice the script ends on is
-			## up, which is what photographs `YesNoMenuHeader.MenuData`'s
-			## cursor. `crystal 26 3 ... yes_no 31 6` is Cherrygrove's guide.
-			_screen.press_button(Gen2Button.RIGHT)
-			_screen.interact()
-			for _press: int in WARP_FRAME_CAP:
-				if StringName(_screen._world.pending_script_input().get(
-					"command", &"")) == &"yesorno":
-					break
-				_screen.press_button(Gen2Button.A)
-				for _frame: int in 20:
-					_screen.advance_frame()
-		elif _kind == &"mart" or _kind == &"mart_sell":
-			## The clerk behind the counter, talked to from the cell in front of
-			## him: his `pokemart` is what opens `BuyMenu`, so the shop is
-			## reached the way a player reaches it. The presses are the dialog's
-			## own, the welcome box first and then the list.
-			_screen.press_button(Gen2Button.LEFT)
-			_screen.interact()
-			for _press: int in MART_PRESSES:
-				_screen.press_button(Gen2Button.A)
-			## `StandardMart`'s BUY/SELL/QUIT loop is what the welcome box hands
-			## the shop to. `mart` takes its BUY row, `mart_sell` the one below.
-			if _kind == &"mart_sell":
-				_screen.press_button(Gen2Button.DOWN)
-			_screen.press_button(Gen2Button.A)
-		elif _kind == &"elevator":
-			## The floor panel, read from the cell below it: `bg_event 3, 0`'s
-			## own `elevator` is what opens the floor list. The car has to know
-			## where it is standing first, which is what `warpmod` gives it, so
-			## the map's own script is left to run before the panel is read.
-			## The number is how many DOWN presses to spend on the list.
-			var car: Gen2WorldAPI = _screen.get("_world")
-			var door: Dictionary = (car.current_map.events.get("warps", []) as Array)[0]
-			## `.FindCurrentFloor` matches the backup warp's map, which walking
-			## into the car through its own -1 door is what writes. A preview
-			## opens the map instead of walking to it, so the floor the door
-			## names stands in for the one the player came from.
-			car.backup_warp = {
-				"warp": 1,
-				"map_group": int(door["map_group"]),
-				"map_number": int(door["map_number"]),
-			}
-			_screen.press_button(Gen2Button.UP)
-			_screen.interact()
-			for _press: int in maxi(_cell.x, 0):
-				_screen.press_button(Gen2Button.DOWN)
-		elif _kind == &"warp":
-			## `MapSetupScript_Door` at its whitest: the step onto the warp tile
-			## and then `FadeOutToWhite`'s last order, which is the frame the map
-			## is loaded on.
-			for _frame: int in WARP_FRAME_CAP:
-				## The first press turns, the second steps: the player is facing
-				## the room rather than the stairs when the map opens.
-				_screen.move_up()
-				_screen.advance_frame()
-				var fade: Dictionary = _screen.map_fade()
-				if StringName(fade.get("stage", &"")) == &"out" \
-					and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
-					break
-		elif _kind == &"door":
-			## `CheckDirectionalWarp`'s carpet: the step onto an interior door's
-			## mat lands and takes no warp, which is what this photographs. The
-			## press after it is `.CheckWarp`, and that is the one that warps.
-			for _frame: int in WARP_FRAME_CAP:
-				_screen.move_down()
-				_screen.advance_frame()
-				if Gen2WorldCollision.is_directional_warp(
-					int(_screen.world_snapshot().get("collision", -1))
-				):
-					## player_cell commits when the step starts, so the frames
-					## the player is still walking are spent before the picture.
-					_screen.advance_frames(
-						Gen2WorldAPI.passes_in_frames(Gen2WorldAPI.STEP_PASSES_WALK)
-					)
-					break
-		elif _kind == &"ledge":
-			## `StepFunction_PlayerJump` at the top of its arc: the player is
-			## walked south until a cell allows the hop below it, and the picture
-			## is the frame `UpdateJumpPosition` draws highest
-			## (`crystal 24 4 ... ledge 5 4`).
-			for _frame: int in WARP_FRAME_CAP:
-				_screen.move_down()
-				_screen.advance_frame()
-				if _screen.player_height_offset_pixels() >= LEDGE_ARC_TOP:
-					break
-		elif _kind == &"ice_slide":
-			## `DoPlayerMovement.CheckForced`: one press starts the run and the
-			## frames after it are the slide's own, since nothing is held. The
-			## first number is the direction in `.forced_dpad` order, down, up,
-			## left, right, and the second how many frames to spend after the
-			## press; the cell goes in `ice_slide@x,y`
-			## (`crystal 3 61 ... ice_slide@11,29 3 40`).
-			var slide_button: int = ICE_SLIDE_BUTTONS[posmod(maxi(_cell.x, 0), 4)]
-			for _press: int in WARP_FRAME_CAP:
-				if _screen.standing_on_ice():
-					break
-				_screen.press_button(slide_button)
-				_screen.advance_frame()
-			for _spent: int in maxi(_cell.y, 0):
-				_screen.advance_frame()
-		elif _kind == &"map_name_sign":
-			## `MapSetupScript_Connection`'s `InitMapNameSign`: walked west off
-			## New Bark Town's edge onto Route 29, photographed while the sign
-			## the crossing raised is still up (`crystal 24 4 ... map_name_sign
-			## 0 6`). The camera and the tile animation both keep running behind
-			## it, which is the whole point of the row.
-			for _frame: int in WARP_FRAME_CAP:
-				_screen.move_left()
-				_screen.advance_frame()
-				if _screen.map_name_sign_passes() > 0 \
-					and _screen.map_name_sign_passes() < Gen2WorldAPI.MAP_NAME_SIGN_PASSES:
-					break
-		elif _kind == &"mod_notice":
-			## `Gen2ModHost.request_notice`'s banner, raised over the map the
-			## way `InitMapNameSign` raises the landmark one. The first number
-			## is which badge the icon shows.
-			Gen2ModHost.instance().request_notice(&"preview", {
-				"title": "BADGE WON",
-				"line": BADGE_NAMES[clampi(_cell.x, 0, BADGE_NAMES.size() - 1)],
-				"icon": {"badge": clampi(_cell.x, 0, 7)},
-				"sound": &"none",
-			})
-			for _frame: int in WARP_FRAME_CAP:
-				_screen.advance_frame()
-				if _screen.map_name_sign_passes() > 0 \
-					and _screen.map_name_sign_passes() < Gen2WorldAPI.MAP_NAME_SIGN_PASSES:
-					break
-		elif _kind == &"mod_page":
-			## `START_ACTION_OPEN_MOD_PAGE`'s screen, with the eight Johto
-			## badges listed and the first number saying how many are won.
-			var won: int = clampi(_cell.x, 0, BADGE_NAMES.size())
-			Gen2ModHost.instance().register_page(&"preview", {
-				"title": "BADGES",
-				"rows": func() -> Array:
-					var rows: Array = []
-					for badge: int in BADGE_NAMES.size():
-						rows.append({
-							"label": BADGE_NAMES[badge],
-							"detail": "WON" if badge < won else "",
-							"icon": {"badge": badge},
-							"locked": badge >= won,
-						})
-					return rows,
-			})
-			_screen._open_mod_page(&"preview")
-			_screen.advance_frame()
-		elif _kind == &"pokepic":
-			_screen.preview_pokepic(POKEPIC_SPECIES)
-		elif _kind == &"unown_printer":
-			## `_UnownPrinter`'s browser: the first number is the slot, where 26
-			## is the vacant one, and the second is 1 for the page A sends.
-			_screen.preview_unown_printer(maxi(_cell.x, 0), _cell.y >= 1)
-		elif _kind == &"diploma":
-			## `_Diploma`'s page, `_PrintDiploma`'s with the printer's own status
-			## box over it, and page 2 behind a printer that answered: the first
-			## number is 1 for the printing loop and the second the page.
-			_screen.preview_diploma(_cell.x >= 1, maxi(_cell.y, 1))
-		elif _kind == &"start_menu":
-			## `SetUpMenuItems`' own gates opened, because the list worth
-			## photographing is the eight rows a finished save carries: they fill
-			## the box exactly, so the host's MODS row and any a mod registered
-			## are what the window has to be scrolled to. The first number is how
-			## many rows down to walk before the picture, and a second number of
-			## 1 or more runs the Bug Catching Contest, which is the list
-			## `SetUpMenuItems` drops PACK from and puts QUIT in SAVE's slot.
-			if _cell.y >= 1:
-				var contest_world: Gen2WorldAPI = _screen.get("_world")
-				contest_world.state.set_engine_flag(Gen2WorldState.engine_flag(
-					Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
-					Gen2WorldState.is_crystal_profile(contest_world.data)
-				))
-				contest_world.state.set_park_balls(Gen2WorldBugContest.BALLS)
-				## A second number of 2 or more has something caught, which is
-				## the LEVEL row `StartMenu_PrintBugContestStatus` skips while
-				## `wContestMon` is still zero.
-				if _cell.y >= 2:
-					contest_world.state.set_contest_mon({
-						"species": 10, "level": 7, "max_hp": 22, "hp": 22,
-					})
-			_screen.get("_world").state.set_engine_flag(
-				Gen2WorldStartMenu.ENGINE_POKEDEX, true
-			)
-			_screen.get("_world").state.set_engine_flag(
-				Gen2WorldStartMenu.ENGINE_POKEGEAR, true
-			)
-			_screen.preview_start_menu()
-			for _down: int in maxi(_cell.x, 0):
-				_screen.press_button(Gen2Button.DOWN)
-				_screen.advance_frame()
-		elif _kind in [&"bills_pc", &"players_pc", &"pokemon_center_pc"]:
-			## `_BillsPC`, which no preview cell reaches: the first number is how
-			## many rows down the top menu to stand and the second how many A
-			## presses to spend from there, so `1 1` is the DEPOSIT list and
-			## `1 2` its submenu on the first party member.
-			_screen.call(SCREEN_DRIVER % _kind)
-			for _down: int in maxi(_cell.x, 0):
-				_screen.press_button(Gen2Button.DOWN)
-				_screen.advance_frame()
-			for _press: int in maxi(_cell.y, 0):
-				_screen.press_button(Gen2Button.A)
-				_screen.advance_frame()
-		elif _kind == &"mom_bank":
-			## `Mom_SetUpDepositMenu` and its withdraw twin, which no fixture
-			## cell reaches: her house is not a preview map and the dial stands
-			## three questions into `BankOfMom`.
-			_screen.preview_mom_bank(
-				Gen2WorldMoneyDial.MODE_WITHDRAW if _cell.y >= 1000 \
-					else Gen2WorldMoneyDial.MODE_DEPOSIT,
-				(maxi(_cell.y, 0) % 1000) * 100, maxi(_cell.x, 0) * 100
-			)
-		elif FIELD_ITEMS.has(_kind):
-			if _kind in FACE_UP_FIRST:
-				_screen.move_up()
-			_screen.preview_field_item(int(FIELD_ITEMS[_kind]))
-		elif _screen.has_method(SCREEN_DRIVER % _kind):
-			## The screen's own `preview_*` drivers, by their name without the
-			## prefix. A `*_use` driver is one step per call, so it is called
-			## twice: the first opens the menu and the second answers it.
-			_screen.call(SCREEN_DRIVER % _kind)
-			if String(_kind).ends_with("_use") or String(_kind).ends_with("_question"):
-				_screen.call(SCREEN_DRIVER % _kind)
-		elif not _bare:
-			_screen.preview_effect_sprites(_kind)
-		if not _bare and _kind not in [
-			&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
-			&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
-			&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
-			&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
-			&"catch_nickname", &"mom_bank", &"bills_pc", &"players_pc",
-			&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page",
-			&"reset_question", &"launcher_question",
-		]:
-			## Those kinds drove themselves to the frame they want; every other
-			## kind stages a sprite and then spends the frames it needs.
+		_stage_kind()
+		if not _bare and _kind not in SELF_DRIVEN_KINDS:
 			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
 				_screen.advance_frame()
 	if _frames < 18:
@@ -756,6 +415,439 @@ func _process(_delta: float) -> bool:
 	return true
 
 
+## The chamber's own `bg_event ..., BGEVENT_UP`: face the wall from the cell below it
+## and read it, which is the only way in.
+func _stage_unown_wall() -> void:
+	_screen.move_up()
+	_screen.interact()
+	## `writetext` is one page: the first press finishes the reveal the
+	## text speed is still spending, and the second ends the page, which
+	## is what runs `special DisplayUnownWords` and puts the box up.
+	_screen.press_button(Gen2Button.A)
+	_screen.press_button(Gen2Button.A)
+
+
+## Past the transition and into the fight it opens, which is the one picture a battle
+## renderer staged on the map draws.
+func _stage_battle() -> void:
+	_screen.preview_battle_request()
+	_screen.settle_battle_transition()
+	_screen.advance_frames(STAGED_FRAMES)
+
+
+## `DoBattleTransition` over the map it runs on. The first of the two numbers is how
+## many frames into it to photograph rather than a cell, since a transition is two
+## hundred of them and every one is a different picture; the second is 1 for a
+## trainer's, which is the branch that draws the Poke Ball and floods the map.
+func _stage_battle_transition() -> void:
+	_screen.preview_battle_transition(_cell.x, _cell.y != 0)
+
+
+## One of the five fade specials over the map it runs on. The first number is the
+## special (46 `FadeOutToWhite`, 47 `BattleTowerFade`, 48 `FadeOutToBlack`, 49
+## `FadeInFromWhite`, 50 `FadeInFromBlack`) and the second how many of its frames to
+## spend before the picture, since each of the four rows is a different screen.
+func _stage_script_fade() -> void:
+	_screen.preview_script_fade(maxi(_cell.x, 0))
+	for _frame: int in maxi(_cell.y, 0):
+		_screen.advance_frame()
+
+
+## `EvolveAfterBattle`'s own screen, which is a few hundred frames of picture. The
+## first number is how far into it to photograph rather than a cell, the way
+## `battle_transition`'s is; the box is pressed past on the frames it is waiting on,
+## since neither `PrintText` nor `DelayFrames` shortens for a screenshot.
+func _stage_level_evolution() -> void:
+	_screen.preview_level_evolution()
+	for _frame: int in maxi(_cell.x, 0):
+		_screen.advance_frame()
+		var evolving: Gen2EvolutionScreen = _screen.get("_evolution_host")
+		if evolving == null:
+			break
+		if evolving.awaiting_press():
+			_screen.press_button(Gen2Button.A)
+
+
+## `OverworldHatchEgg`, driven the same way and for the same reason: the sequence is
+## five hundred frames of picture, so the first number is how far into it to
+## photograph and the second is the species inside the egg, 0 for the first the cache
+## holds.
+func _stage_egg_hatch() -> void:
+	_screen.preview_egg_hatch(maxi(_cell.y, 0))
+	for _frame: int in maxi(_cell.x, 0):
+		_screen.advance_frame()
+		var hatching: Gen2EggHatchScreen = _screen.get("_hatch_host")
+		if hatching == null:
+			break
+		if hatching.awaiting_press():
+			_screen.press_button(Gen2Button.A)
+
+
+## `GivePoke`'s own prompt. The presses are spent behind the frames the box owes,
+## since nothing shortens a printing text; the second number's thousands digit is the
+## box branch.
+func _stage_gift_nickname() -> void:
+	_screen.preview_gift_nickname(maxi(_cell.y, 0) % 1000, _cell.y >= 1000)
+	_settle_mon_special("_nickname_host")
+	for _press: int in maxi(_cell.x, 0):
+		var prompt: Gen2NicknamePromptScreen = _screen.get("_nickname_host")
+		if prompt == null:
+			break
+		## NO on the question, so the mode photographs the routine's own
+		## boxes; the keyboard behind YES has `preview_naming_screen.gd`.
+		_screen.press_button(
+			Gen2Button.B if prompt.question_ready() else Gen2Button.A
+		)
+		_settle_mon_special("_nickname_host")
+
+
+## `Script_Whiteout`, which no fixture cell reaches: the party is poisoned down to its
+## last point and the pass `CountStep` owes is spent. The first number is how many of
+## its presses to spend, so 0 is the faint line, 1 the first page of `_WhitedOutText`
+## and 3 the map the player wakes up on.
+func _stage_whiteout() -> void:
+	_screen.preview_whiteout()
+	## The box reveals a letter at a time at the OPTION menu's own speed,
+	## so each press is given behind the frames its page costs.
+	for _press: int in maxi(_cell.x, 0) + 1:
+		for _frame: int in 120:
+			_screen.advance_frame()
+		if _press < maxi(_cell.x, 0):
+			_screen.press_button(Gen2Button.A)
+
+
+## `special UnownPuzzle`, which no fixture cell reaches. The first number is how many
+## frames into the board to photograph and the second which picture: 0 Kabuto, 1
+## Omanyte, 2 Aerodactyl, 3 Ho-Oh. The empty cursor blinks off `hVBlankCounter`, so a
+## frame with bit 4 clear photographs a board with no cursor on it. 4 to 7 are the
+## same four pictures with the board walked into `.SolvedPuzzleConfiguration` through
+## the screen's own presses, which is the only way to photograph the assembled
+## picture.
+func _stage_unown_puzzle() -> void:
+	_screen.preview_unown_puzzle(
+		maxi(_cell.y, 0) % RomLayout.UNOWN_PUZZLE_PICTURES.size(),
+		maxi(_cell.y, 0) >= RomLayout.UNOWN_PUZZLE_PICTURES.size()
+	)
+	for _frame: int in maxi(_cell.x, 0):
+		if _screen.get("_unown_puzzle_host") == null:
+			break
+		_screen.advance_frame()
+
+
+## `special SlotMachine`, which no fixture cell reaches either. The first number is
+## how many frames into the game to photograph and the second is the bet, 1 to 3, plus
+## 4 for the lucky machine the Game Corner's own `random 6` picks one time in six.
+func _stage_slot_machine() -> void:
+	var slots_bet: int = maxi(_cell.y, 0) % 4
+	_screen.preview_slot_machine(
+		100, maxi(_cell.y, 0) >= 4, maxi(slots_bet, 1), maxi(_cell.x, 0)
+	)
+
+
+## `AnimateTileset` runs once a hardware frame, so any frame of a map's own water,
+## flowers, lava or cave scroll is reachable by spending them: the first number is how
+## many, and the cell goes in `tile_anim@x,y` as usual.
+func _stage_tile_anim() -> void:
+	for _spent: int in maxi(_cell.x, 0):
+		_screen.advance_frame()
+
+
+## `special CardFlip`, which no fixture cell reaches either. The first number is how
+## many frames into the game to photograph and the second the balance in hundreds of
+## coins, 0 meaning 100.
+func _stage_card_flip() -> void:
+	_screen.preview_card_flip(
+		maxi(_cell.y, 0) * 100 if _cell.y > 0 else 100, maxi(_cell.x, 0)
+	)
+
+
+## The Day-Care's five, driven the way the two above are. The first number is how many
+## presses into the routine to photograph and the second is which routine: 0 the man,
+## 1 the lady, 2 the man outside, 3 and 4 the two signs.
+func _stage_day_care() -> void:
+	_screen.preview_day_care(DAY_CARE_ROLES[clampi(
+		_cell.y, 0, DAY_CARE_ROLES.size() - 1
+	)])
+	_settle_mon_special("_day_care_host")
+	for _press: int in maxi(_cell.x, 0):
+		if _screen.get("_day_care_host") == null:
+			break
+		_screen.press_button(Gen2Button.A)
+		_settle_mon_special("_day_care_host")
+
+
+## `special NameRater` and `special MoveDeletion`, neither of which any fixture cell
+## reaches. The first number is how many presses into the routine to photograph: 2 is
+## the introduction's last page with its YES/NO up, 4 the party list, and so on.
+## Presses are spent only once the box owes no frames, since nothing shortens a
+## printing text.
+func _stage_party_routine() -> void:
+	_screen.call(SCREEN_DRIVER % _kind)
+	var host_property: String = "_%s_host" % _kind
+	_settle_mon_special(host_property)
+	for _press: int in maxi(_cell.x, 0):
+		if _screen.get(host_property) == null:
+			break
+		_screen.press_button(Gen2Button.A)
+		_settle_mon_special(host_property)
+
+
+## `BattleTower1FReceptionistScript` from the cell below her, which is where
+## `Script_WalkToBattleTowerElevator` puts the player back. The first number is how
+## many A presses to spend, walking the welcome box, the explanation question and the
+## three-row menu; the second is how many DOWN presses on whichever menu is up.
+## `_CheckForBattleTowerRules` refuses anything but three different species holding
+## three different items, and the development save's party is not one.
+func _stage_battle_tower() -> void:
+	_stage_battle_tower_party()
+	_screen.press_button(Gen2Button.UP)
+	_screen.interact()
+	for _frame: int in TEXT_SETTLE_FRAMES:
+		_screen.advance_frame()
+	for _press: int in maxi(_cell.x, 0):
+		_screen.press_button(Gen2Button.A)
+		for _frame: int in TEXT_SETTLE_FRAMES:
+			_screen.advance_frame()
+	for _press: int in maxi(_cell.y, 0):
+		_screen.press_button(Gen2Button.DOWN)
+		for _frame: int in TEXT_SETTLE_FRAMES:
+			_screen.advance_frame()
+
+
+## `Script_yesorno`'s own box: the NPC beside the player is talked to and each page
+## answered until the choice the script ends on is up, which is what photographs
+## `YesNoMenuHeader.MenuData`'s cursor. `crystal 26 3 ... yes_no 31 6` is
+## Cherrygrove's guide.
+func _stage_yes_no() -> void:
+	_screen.press_button(Gen2Button.RIGHT)
+	_screen.interact()
+	for _press: int in WARP_FRAME_CAP:
+		if StringName(_screen._world.pending_script_input().get(
+			"command", &"")) == &"yesorno":
+			break
+		_screen.press_button(Gen2Button.A)
+		for _frame: int in 20:
+			_screen.advance_frame()
+
+
+## The clerk behind the counter, talked to from the cell in front of him: his
+## `pokemart` is what opens `BuyMenu`, so the shop is reached the way a player reaches
+## it. The presses are the dialog's own, the welcome box first and then the list.
+func _stage_mart() -> void:
+	_screen.press_button(Gen2Button.LEFT)
+	_screen.interact()
+	for _press: int in MART_PRESSES:
+		_screen.press_button(Gen2Button.A)
+	## `StandardMart`'s BUY/SELL/QUIT loop is what the welcome box hands
+	## the shop to. `mart` takes its BUY row, `mart_sell` the one below.
+	if _kind == &"mart_sell":
+		_screen.press_button(Gen2Button.DOWN)
+	_screen.press_button(Gen2Button.A)
+
+
+## The floor panel, read from the cell below it: `bg_event 3, 0`'s own `elevator` is
+## what opens the floor list. The car has to know where it is standing first, which is
+## what `warpmod` gives it, so the map's own script is left to run before the panel is
+## read. The number is how many DOWN presses to spend on the list.
+func _stage_elevator() -> void:
+	var car: Gen2WorldAPI = _screen.get("_world")
+	var door: Dictionary = (car.current_map.events.get("warps", []) as Array)[0]
+	## `.FindCurrentFloor` matches the backup warp's map, which walking
+	## into the car through its own -1 door is what writes. A preview
+	## opens the map instead of walking to it, so the floor the door
+	## names stands in for the one the player came from.
+	car.backup_warp = {
+		"warp": 1,
+		"map_group": int(door["map_group"]),
+		"map_number": int(door["map_number"]),
+	}
+	_screen.press_button(Gen2Button.UP)
+	_screen.interact()
+	for _press: int in maxi(_cell.x, 0):
+		_screen.press_button(Gen2Button.DOWN)
+
+
+## `MapSetupScript_Door` at its whitest: the step onto the warp tile and then
+## `FadeOutToWhite`'s last order, which is the frame the map is loaded on.
+func _stage_warp() -> void:
+	for _frame: int in WARP_FRAME_CAP:
+		## The first press turns, the second steps: the player is facing
+		## the room rather than the stairs when the map opens.
+		_screen.move_up()
+		_screen.advance_frame()
+		var fade: Dictionary = _screen.map_fade()
+		if StringName(fade.get("stage", &"")) == &"out" \
+			and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
+			break
+
+
+## `CheckDirectionalWarp`'s carpet: the step onto an interior door's mat lands and
+## takes no warp, which is what this photographs. The press after it is `.CheckWarp`,
+## and that is the one that warps.
+func _stage_door() -> void:
+	for _frame: int in WARP_FRAME_CAP:
+		_screen.move_down()
+		_screen.advance_frame()
+		if Gen2WorldCollision.is_directional_warp(
+			int(_screen.world_snapshot().get("collision", -1))
+		):
+			## player_cell commits when the step starts, so the frames
+			## the player is still walking are spent before the picture.
+			_screen.advance_frames(
+				Gen2WorldAPI.passes_in_frames(Gen2WorldAPI.STEP_PASSES_WALK)
+			)
+			break
+
+
+## `StepFunction_PlayerJump` at the top of its arc: the player is walked south until a
+## cell allows the hop below it, and the picture is the frame `UpdateJumpPosition`
+## draws highest (`crystal 24 4 ... ledge 5 4`).
+func _stage_ledge() -> void:
+	for _frame: int in WARP_FRAME_CAP:
+		_screen.move_down()
+		_screen.advance_frame()
+		if _screen.player_height_offset_pixels() >= LEDGE_ARC_TOP:
+			break
+
+
+## `DoPlayerMovement.CheckForced`: one press starts the run and the frames after it
+## are the slide's own, since nothing is held. The first number is the direction in
+## `.forced_dpad` order, down, up, left, right, and the second how many frames to
+## spend after the press; the cell goes in `ice_slide@x,y` (`crystal 3 61 ...
+## ice_slide@11,29 3 40`).
+func _stage_ice_slide() -> void:
+	var slide_button: int = ICE_SLIDE_BUTTONS[posmod(maxi(_cell.x, 0), 4)]
+	for _press: int in WARP_FRAME_CAP:
+		if _screen.standing_on_ice():
+			break
+		_screen.press_button(slide_button)
+		_screen.advance_frame()
+	for _spent: int in maxi(_cell.y, 0):
+		_screen.advance_frame()
+
+
+## `MapSetupScript_Connection`'s `InitMapNameSign`: walked west off New Bark Town's
+## edge onto Route 29, photographed while the sign the crossing raised is still up
+## (`crystal 24 4 ... map_name_sign 0 6`). The camera and the tile animation both keep
+## running behind it, which is the whole point of the row.
+func _stage_map_name_sign() -> void:
+	for _frame: int in WARP_FRAME_CAP:
+		_screen.move_left()
+		_screen.advance_frame()
+		if _screen.map_name_sign_passes() > 0 \
+			and _screen.map_name_sign_passes() < Gen2WorldAPI.MAP_NAME_SIGN_PASSES:
+			break
+
+
+## `Gen2ModHost.request_notice`'s banner, raised over the map the way
+## `InitMapNameSign` raises the landmark one. The first number is which badge the icon
+## shows.
+func _stage_mod_notice() -> void:
+	Gen2ModHost.instance().request_notice(&"preview", {
+		"title": "BADGE WON",
+		"line": BADGE_NAMES[clampi(_cell.x, 0, BADGE_NAMES.size() - 1)],
+		"icon": {"badge": clampi(_cell.x, 0, 7)},
+		"sound": &"none",
+	})
+	for _frame: int in WARP_FRAME_CAP:
+		_screen.advance_frame()
+		if _screen.map_name_sign_passes() > 0 \
+			and _screen.map_name_sign_passes() < Gen2WorldAPI.MAP_NAME_SIGN_PASSES:
+			break
+
+
+## `START_ACTION_OPEN_MOD_PAGE`'s screen, with the eight Johto badges listed and the
+## first number saying how many are won.
+func _stage_mod_page() -> void:
+	var won: int = clampi(_cell.x, 0, BADGE_NAMES.size())
+	Gen2ModHost.instance().register_page(&"preview", {
+		"title": "BADGES",
+		"rows": func() -> Array:
+			var rows: Array = []
+			for badge: int in BADGE_NAMES.size():
+				rows.append({
+					"label": BADGE_NAMES[badge],
+					"detail": "WON" if badge < won else "",
+					"icon": {"badge": badge},
+					"locked": badge >= won,
+				})
+			return rows,
+	})
+	_screen._open_mod_page(&"preview")
+	_screen.advance_frame()
+
+
+func _stage_pokepic() -> void:
+	_screen.preview_pokepic(POKEPIC_SPECIES)
+
+
+## `_UnownPrinter`'s browser: the first number is the slot, where 26 is the vacant
+## one, and the second is 1 for the page A sends.
+func _stage_unown_printer() -> void:
+	_screen.preview_unown_printer(maxi(_cell.x, 0), _cell.y >= 1)
+
+
+## `_Diploma`'s page, `_PrintDiploma`'s with the printer's own status box over it, and
+## page 2 behind a printer that answered: the first number is 1 for the printing loop
+## and the second the page.
+func _stage_diploma() -> void:
+	_screen.preview_diploma(_cell.x >= 1, maxi(_cell.y, 1))
+
+
+## `SetUpMenuItems`' own gates opened, because the list worth photographing is the
+## eight rows a finished save carries: they fill the box exactly, so the host's MODS
+## row and any a mod registered are what the window has to be scrolled to. The first
+## number is how many rows down to walk before the picture, and a second number of 1
+## or more runs the Bug Catching Contest, which is the list `SetUpMenuItems` drops
+## PACK from and puts QUIT in SAVE's slot.
+func _stage_start_menu() -> void:
+	if _cell.y >= 1:
+		var contest_world: Gen2WorldAPI = _screen.get("_world")
+		contest_world.state.set_engine_flag(Gen2WorldState.engine_flag(
+			Gen2WorldState.ENGINE_BUG_CONTEST_TIMER,
+			Gen2WorldState.is_crystal_profile(contest_world.data)
+		))
+		contest_world.state.set_park_balls(Gen2WorldBugContest.BALLS)
+		## A second number of 2 or more has something caught, which is
+		## the LEVEL row `StartMenu_PrintBugContestStatus` skips while
+		## `wContestMon` is still zero.
+		if _cell.y >= 2:
+			contest_world.state.set_contest_mon({
+				"species": 10, "level": 7, "max_hp": 22, "hp": 22,
+			})
+	_screen.get("_world").state.set_engine_flag(
+		Gen2WorldStartMenu.ENGINE_POKEDEX, true
+	)
+	_screen.get("_world").state.set_engine_flag(
+		Gen2WorldStartMenu.ENGINE_POKEGEAR, true
+	)
+	_screen.preview_start_menu()
+	for _down: int in maxi(_cell.x, 0):
+		_screen.press_button(Gen2Button.DOWN)
+		_screen.advance_frame()
+
+
+## `_BillsPC`, which no preview cell reaches: the first number is how many rows down
+## the top menu to stand and the second how many A presses to spend from there, so `1
+## 1` is the DEPOSIT list and `1 2` its submenu on the first party member.
+func _stage_pc() -> void:
+	_screen.call(SCREEN_DRIVER % _kind)
+	for _down: int in maxi(_cell.x, 0):
+		_screen.press_button(Gen2Button.DOWN)
+		_screen.advance_frame()
+	for _press: int in maxi(_cell.y, 0):
+		_screen.press_button(Gen2Button.A)
+		_screen.advance_frame()
+
+
+## `Mom_SetUpDepositMenu` and its withdraw twin, which no fixture cell reaches: her
+## house is not a preview map and the dial stands three questions into `BankOfMom`.
+func _stage_mom_bank() -> void:
+	_screen.preview_mom_bank(
+		Gen2WorldMoneyDial.MODE_WITHDRAW if _cell.y >= 1000 \
+			else Gen2WorldMoneyDial.MODE_DEPOSIT,
+		(maxi(_cell.y, 0) % 1000) * 100, maxi(_cell.x, 0) * 100
+	)
 ## The mod's own renderer, once there is one to choose: `_initialize` runs before
 ## the autoloads are in the tree, so nothing is registered while the screen is
 ## being built and the choice has to wait for the first frame.


### PR DESCRIPTION
The source budget's list of functions over the complexity ceiling loses nine rows, and the two the counter could not see are fixed with them. Each was a `match` of forty arms or more; each is now a table from the key to the handler that answers it.

| Function | Was | Now |
|---|---|---|
| `world_script_runner.gd:_execute_special` | 177 | 3 |
| `battle_screen.gd:_describe` | 134 | 6 |
| `world_script_runner.gd:_execute` | 120 | 12 |
| `preview_world.gd:_process` | 109 | 8 |
| `radio_show.gd:_run` | 100 | 3 |
| `Gen2BattleAI:_apply_smart` | 94 | 4 |
| `world_script.gd:_later_command_name` | 89 | 5 |
| `world_script_runner.gd:_execute_later_command` | 88 | 2 |
| `battle_anim_functions.gd:run` | 82 | 2 |
| `world_script_runner.gd:complete_runtime_request` | 74 | 3 |
| `world_script.gd:command_at` | 71 | 12 |

## `warpmod` failed every script that carried it

`_execute`'s match had an arm that emitted the backup warp and then fell out of the match, and the second list that answered a fall-through did not name the command, so the script ended on `unsupported_runtime_command` instead of running on. That list is gone: every arm is now a handler that returns its own answer, so a command cannot be half-handled. Twelve corpus sites carry `warpmod` on Gold and Silver and eight on Crystal; the two dept store elevators and the Fast Ship's cabin are what they open. A new case in `test_world_api.gd` covers it and fails on the old code.

## The budget's own counter

A `match` arm that carried its whole body after the colon was not counted, which is how an 89-branch function scored 1. It counts both shapes now. Two functions were hiding behind it and both are in the table above. The comment ceiling drops to 37,893.

## Uniform handlers

`_apply_smart` and the animation jumptable needed one signature per table, so the scoring routines take the `Context` and the animation routines take the player, the data and the object. No body changed.

## Measured

| Check | Result |
|---|---|
| Unit and scene tiers | 4,000 tests, 0 failures |
| `validate.gd -- all` | 80 topics pass |
| `replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | byte-identical to `main`: 16 badges, 295/292/292 steps |
| Corpus decode | identical per command name: 29,639 Crystal commands, 20,972 Gold and Silver |
| Five preview screens | pixel-identical to `main` |
| Editor analyser | 0 warnings in 596 scripts |
