### PR TITLE
Split fourteen functions off the complexity list

### DIFF
--- a/game/audio/gen2_apu.gd
+++ b/game/audio/gen2_apu.gd
@@ -506,10 +506,7 @@ func _render_noise(mix: PackedInt32Array) -> void:
 				len_counter = 0
 		if not enabled:
 			continue
-		## `env_inc` is zeroed once the envelope has run out of steps, and a
-		## note holds far longer than it takes; the drain below cannot fire with
-		## nothing being added, since it always leaves the counter under the
-		## reference.
+		## The envelope guard [method _render_square] explains.
 		if env_inc != 0:
 			env_counter += env_inc
 			while env_counter > FREQ_INC_REF:

--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -19,6 +19,43 @@ const NOISE_CHAN_BIT: int = 2
 
 const FIRST_MUSIC_COMMAND: int = 0xD0
 const SOUND_RETURN: int = 0xFF
+
+## `MusicCommands`, the jump table `ParseMusicCommand` indexes. Its first eight
+## rows are the octaves, read straight off the byte, and `Music_Nothing` owns
+## 0xF1 to 0xF9: a byte missing from this table does nothing.
+const MUSIC_COMMANDS: Dictionary = {
+	0xD8: &"_music_note_type",
+	0xD9: &"_music_transpose",
+	0xDA: &"_music_tempo",
+	0xDB: &"_music_duty_cycle",
+	0xDC: &"_music_volume_envelope",
+	0xDD: &"_music_pitch_sweep",
+	0xDE: &"_music_duty_cycle_pattern",
+	0xDF: &"_music_toggle_sfx",
+	0xE0: &"_music_pitch_slide",
+	0xE1: &"_music_vibrato",
+	0xE2: &"_music_skip_byte",
+	0xE3: &"_music_toggle_noise",
+	0xE4: &"_music_force_stereo_panning",
+	0xE5: &"_music_volume",
+	0xE6: &"_music_pitch_offset",
+	0xE7: &"_music_skip_byte",
+	0xE8: &"_music_skip_byte",
+	0xE9: &"_music_tempo_relative",
+	0xEA: &"_music_restart_channel",
+	0xEB: &"_music_new_song",
+	0xEC: &"_music_sfx_priority_on",
+	0xED: &"_music_sfx_priority_off",
+	0xEE: &"_music_unknown_ee",
+	0xEF: &"_music_stereo_panning",
+	0xF0: &"_music_sfx_toggle_noise",
+	0xFA: &"_music_set_condition",
+	0xFB: &"_music_jump_if",
+	0xFC: &"_music_jump_channel",
+	0xFD: &"_music_loop_channel",
+	0xFE: &"_music_call_channel",
+	SOUND_RETURN: &"_music_ret_channel",
+}
 const MAX_VOLUME: int = 0x77
 const VOLUME_LEVEL_MASK: int = 0x07
 const MUSIC_FADE_IN_BIT: int = 7
@@ -862,156 +899,212 @@ func _get_noise_sample() -> void:
 
 func _parse_music_command(command: int) -> void:
 	var channel: Channel = channels[_cur_channel]
-	match command:
-		0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7:
-			channel.octave = _cur_music_byte & 0x07
-		0xD8:
-			channel.note_length = _get_music_byte()
-			if (_cur_channel & 0x03) != CHAN4:
-				channel.volume_envelope = _get_music_byte()
-		0xD9:
-			channel.transposition = _get_music_byte()
-		0xDA:
-			# `bigdw`: the high byte is written first.
-			var tempo: int = _get_music_byte() << 8
-			tempo |= _get_music_byte()
-			_set_global_tempo(tempo)
-		0xDB:
-			channel.duty_cycle = (_get_music_byte() << 6) & 0xFF
-		0xDC:
-			channel.volume_envelope = _get_music_byte()
-		0xDD:
-			pitch_sweep_value = _get_music_byte()
-			channel.pitch_sweep = true
-		0xDE:
-			channel.duty_loop = true
-			var pattern: int = _get_music_byte()
-			channel.duty_cycle_pattern = ((pattern >> 2) | (pattern << 6)) & 0xFF
-			channel.duty_cycle = channel.duty_cycle_pattern & 0xC0
-		0xDF:
-			channel.sfx = not channel.sfx
-		0xE0:
-			_cur_note_duration = _get_music_byte()
-			var note: int = _get_music_byte()
-			channel.pitch_slide_target = _get_frequency(note & 0x0F, note >> 4)
-			channel.pitch_slide = true
-		0xE1:
-			channel.vibrato = true
-			channel.vibrato_dir = false
-			channel.vibrato_delay = _get_music_byte()
-			channel.vibrato_delay_count = channel.vibrato_delay
-			var shape: int = _get_music_byte()
-			var extent: int = (shape & 0xF0) >> 4
-			# The two halves are stored apart so the up swing rounds away from
-			# zero and the down swing rounds toward it.
-			channel.vibrato_extent = (((extent >> 1) + (extent & 1)) << 4) | (extent >> 1)
-			var rate: int = shape & 0x0F
-			channel.vibrato_rate = (rate << 4) | rate
-		0xE2:
-			var _unused_e2: int = _get_music_byte()
-		0xE3:
-			channel.noise = not channel.noise
-			if channel.noise:
-				_music_noise_sample_set = _get_music_byte()
-		0xE4:
-			_set_lr_tracks()
-			channel.tracks &= _get_music_byte()
-		0xE5:
-			var level: int = _get_music_byte()
-			if music_fade == 0:
-				volume = level
-		0xE6:
-			# `bigdw`, like tempo.
-			var offset: int = _get_music_byte() << 8
-			offset |= _get_music_byte()
-			channel.pitch_offset_enabled = true
-			channel.pitch_offset = offset
-		0xE7:
-			var _unused_e7: int = _get_music_byte()
-		0xE8:
-			var _unused_e8: int = _get_music_byte()
-		0xE9:
-			var relative: int = _get_music_byte()
-			if relative >= 0x80:
-				relative -= 0x100
-			_set_global_tempo((channel.tempo + relative) & 0xFFFF)
-		0xEA:
-			var header: int = _get_music_byte()
-			header |= _get_music_byte() << 8
-			_music_id = channel.music_id
-			_music_bank = channel.music_bank
-			var entry: int = _music_byte(_music_bank, header)
-			entry |= _music_byte(_music_bank, header + 1) << 8
-			var saved: int = _cur_channel
-			_load_channel(entry)
-			_start_channel()
-			_cur_channel = saved
-		0xEB:
-			# `Music_NewSong` names a song id, and no cartridge stream uses it.
-			# Reaching it would need a song table this driver does not own.
-			var _song_low: int = _get_music_byte()
-			var _song_high: int = _get_music_byte()
-		0xEC:
-			sfx_priority = 1
-		0xED:
-			sfx_priority = 0
-		0xEE:
-			var slot: int = _cur_channel & 0x03
-			if _channel_jump_condition[slot] != 0:
-				_channel_jump_condition[slot] = 0
-				var target: int = _get_music_byte()
-				channel.music_address = (target | (_get_music_byte() << 8)) & 0xFFFF
-			else:
-				channel.music_address = (channel.music_address + 2) & 0xFFFF
-		0xEF:
-			if stereo:
-				_set_lr_tracks()
-				channel.tracks &= _get_music_byte()
-			else:
-				var _skipped: int = _get_music_byte()
-		0xF0:
-			channel.noise = not channel.noise
-			if channel.noise:
-				_sfx_noise_sample_set = _get_music_byte()
-		0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7, 0xF8, 0xF9:
-			pass
-		0xFA:
-			channel.condition = _get_music_byte()
-		0xFB:
-			if _get_music_byte() == channel.condition:
-				var target: int = _get_music_byte()
-				channel.music_address = (target | (_get_music_byte() << 8)) & 0xFFFF
-			else:
-				channel.music_address = (channel.music_address + 2) & 0xFFFF
-		0xFC:
-			var target: int = _get_music_byte()
-			channel.music_address = (target | (_get_music_byte() << 8)) & 0xFFFF
-		0xFD:
-			var count: int = _get_music_byte()
-			if not channel.looping:
-				if count == 0:
-					var target: int = _get_music_byte()
-					channel.music_address = (target | (_get_music_byte() << 8)) & 0xFFFF
-					return
-				channel.looping = true
-				channel.loop_count = (count - 1) & 0xFF
-			if channel.loop_count == 0:
-				channel.looping = false
-				channel.music_address = (channel.music_address + 2) & 0xFFFF
-			else:
-				channel.loop_count -= 1
-				var target: int = _get_music_byte()
-				channel.music_address = (target | (_get_music_byte() << 8)) & 0xFFFF
-		0xFE:
-			var target: int = _get_music_byte()
-			target |= _get_music_byte() << 8
-			channel.last_music_address = channel.music_address
-			channel.music_address = target & 0xFFFF
-			channel.subroutine = true
-		SOUND_RETURN:
-			channel.subroutine = false
-			channel.music_address = channel.last_music_address
+	if command < 0xD8:
+		## `Music_Octave8` to `Music_Octave1`, the jump table's first eight rows.
+		channel.octave = _cur_music_byte & 0x07
+		return
+	var handler: StringName = MUSIC_COMMANDS.get(command, &"")
+	if handler != &"":
+		call(handler, channel)
 
+
+func _music_note_type(channel: Channel) -> void:
+	channel.note_length = _get_music_byte()
+	if (_cur_channel & 0x03) != CHAN4:
+		channel.volume_envelope = _get_music_byte()
+
+
+func _music_transpose(channel: Channel) -> void:
+	channel.transposition = _get_music_byte()
+
+
+func _music_tempo(_channel: Channel) -> void:
+	# `bigdw`: the high byte is written first.
+	var tempo: int = _get_music_byte() << 8
+	tempo |= _get_music_byte()
+	_set_global_tempo(tempo)
+
+
+func _music_duty_cycle(channel: Channel) -> void:
+	channel.duty_cycle = (_get_music_byte() << 6) & 0xFF
+
+
+func _music_volume_envelope(channel: Channel) -> void:
+	channel.volume_envelope = _get_music_byte()
+
+
+func _music_pitch_sweep(channel: Channel) -> void:
+	pitch_sweep_value = _get_music_byte()
+	channel.pitch_sweep = true
+
+
+func _music_duty_cycle_pattern(channel: Channel) -> void:
+	channel.duty_loop = true
+	var pattern: int = _get_music_byte()
+	channel.duty_cycle_pattern = ((pattern >> 2) | (pattern << 6)) & 0xFF
+	channel.duty_cycle = channel.duty_cycle_pattern & 0xC0
+
+
+func _music_toggle_sfx(channel: Channel) -> void:
+	channel.sfx = not channel.sfx
+
+
+func _music_pitch_slide(channel: Channel) -> void:
+	_cur_note_duration = _get_music_byte()
+	var note: int = _get_music_byte()
+	channel.pitch_slide_target = _get_frequency(note & 0x0F, note >> 4)
+	channel.pitch_slide = true
+
+
+func _music_vibrato(channel: Channel) -> void:
+	channel.vibrato = true
+	channel.vibrato_dir = false
+	channel.vibrato_delay = _get_music_byte()
+	channel.vibrato_delay_count = channel.vibrato_delay
+	var shape: int = _get_music_byte()
+	var extent: int = (shape & 0xF0) >> 4
+	# The two halves are stored apart so the up swing rounds away from zero and
+	# the down swing rounds toward it.
+	channel.vibrato_extent = (((extent >> 1) + (extent & 1)) << 4) | (extent >> 1)
+	var rate: int = shape & 0x0F
+	channel.vibrato_rate = (rate << 4) | rate
+
+
+## `Music_Unknown_E2`, `_E7` and `_E8` all read one byte and drop it.
+func _music_skip_byte(_channel: Channel) -> void:
+	var _skipped: int = _get_music_byte()
+
+
+func _music_toggle_noise(channel: Channel) -> void:
+	channel.noise = not channel.noise
+	if channel.noise:
+		_music_noise_sample_set = _get_music_byte()
+
+
+func _music_force_stereo_panning(channel: Channel) -> void:
+	_set_lr_tracks()
+	channel.tracks &= _get_music_byte()
+
+
+func _music_volume(_channel: Channel) -> void:
+	var level: int = _get_music_byte()
+	if music_fade == 0:
+		volume = level
+
+
+func _music_pitch_offset(channel: Channel) -> void:
+	# `bigdw`, like tempo.
+	var offset: int = _get_music_byte() << 8
+	offset |= _get_music_byte()
+	channel.pitch_offset_enabled = true
+	channel.pitch_offset = offset
+
+
+func _music_tempo_relative(channel: Channel) -> void:
+	var relative: int = _get_music_byte()
+	if relative >= 0x80:
+		relative -= 0x100
+	_set_global_tempo((channel.tempo + relative) & 0xFFFF)
+
+
+func _music_restart_channel(channel: Channel) -> void:
+	var header: int = _get_music_byte()
+	header |= _get_music_byte() << 8
+	_music_id = channel.music_id
+	_music_bank = channel.music_bank
+	var entry: int = _music_byte(_music_bank, header)
+	entry |= _music_byte(_music_bank, header + 1) << 8
+	var saved: int = _cur_channel
+	_load_channel(entry)
+	_start_channel()
+	_cur_channel = saved
+
+
+## `Music_NewSong` names a song id, and no cartridge stream uses it. Reaching it
+## would need a song table this driver does not own.
+func _music_new_song(_channel: Channel) -> void:
+	var _song_low: int = _get_music_byte()
+	var _song_high: int = _get_music_byte()
+
+
+func _music_sfx_priority_on(_channel: Channel) -> void:
+	sfx_priority = 1
+
+
+func _music_sfx_priority_off(_channel: Channel) -> void:
+	sfx_priority = 0
+
+
+func _music_unknown_ee(channel: Channel) -> void:
+	var slot: int = _cur_channel & 0x03
+	if _channel_jump_condition[slot] != 0:
+		_channel_jump_condition[slot] = 0
+		_music_take_jump(channel)
+	else:
+		channel.music_address = (channel.music_address + 2) & 0xFFFF
+
+
+func _music_stereo_panning(channel: Channel) -> void:
+	if stereo:
+		_set_lr_tracks()
+		channel.tracks &= _get_music_byte()
+	else:
+		var _skipped: int = _get_music_byte()
+
+
+func _music_sfx_toggle_noise(channel: Channel) -> void:
+	channel.noise = not channel.noise
+	if channel.noise:
+		_sfx_noise_sample_set = _get_music_byte()
+
+
+func _music_set_condition(channel: Channel) -> void:
+	channel.condition = _get_music_byte()
+
+
+func _music_jump_if(channel: Channel) -> void:
+	if _get_music_byte() == channel.condition:
+		_music_take_jump(channel)
+	else:
+		channel.music_address = (channel.music_address + 2) & 0xFFFF
+
+
+func _music_jump_channel(channel: Channel) -> void:
+	_music_take_jump(channel)
+
+
+func _music_loop_channel(channel: Channel) -> void:
+	var count: int = _get_music_byte()
+	if not channel.looping:
+		if count == 0:
+			_music_take_jump(channel)
+			return
+		channel.looping = true
+		channel.loop_count = (count - 1) & 0xFF
+	if channel.loop_count == 0:
+		channel.looping = false
+		channel.music_address = (channel.music_address + 2) & 0xFFFF
+	else:
+		channel.loop_count -= 1
+		_music_take_jump(channel)
+
+
+func _music_call_channel(channel: Channel) -> void:
+	var target: int = _get_music_byte()
+	target |= _get_music_byte() << 8
+	channel.last_music_address = channel.music_address
+	channel.music_address = target & 0xFFFF
+	channel.subroutine = true
+
+
+func _music_ret_channel(channel: Channel) -> void:
+	channel.subroutine = false
+	channel.music_address = channel.last_music_address
+
+
+func _music_take_jump(channel: Channel) -> void:
+	var target: int = _get_music_byte()
+	channel.music_address = (target | (_get_music_byte() << 8)) & 0xFFFF
 
 func _set_note_duration(duration: int) -> void:
 	var channel: Channel = channels[_cur_channel]

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -109,6 +109,37 @@ const STALL_MOVE_NUMBERS: Array = [
 
 ## The screen each of the three screen moves would raise, which is the whole of
 ## `AI_Redundant`'s `.LightScreen`, `.Reflect` and `.Safeguard`.
+## `AI_Redundant`'s rows that are one substatus bit on the target, by the move
+## effect that would set it.
+const REDUNDANT_TARGET_SUBSTATUS: Dictionary = {
+	## `.PerishSong` reads `wPlayerSubStatus1`, the target's: a second song over
+	## one already counting down would reset nothing.
+	Gen2MoveEffect.PERISH_SONG: Gen2Substatus.PERISH,
+	Gen2MoveEffect.LEECH_SEED: Gen2Substatus.LEECH_SEED,
+	Gen2MoveEffect.FORESIGHT: Gen2Substatus.IDENTIFIED,
+	Gen2MoveEffect.SWAGGER: Gen2Substatus.CONFUSED,
+}
+
+## The same read off the user's own side, which is where each of these lands.
+const REDUNDANT_USER_SUBSTATUS: Dictionary = {
+	Gen2MoveEffect.MIST: Gen2Substatus.MIST,
+	Gen2MoveEffect.FOCUS_ENERGY: Gen2Substatus.FOCUS_ENERGY,
+	Gen2MoveEffect.MEAN_LOOK: Gen2Substatus.CANT_RUN,
+	Gen2MoveEffect.SUBSTITUTE: Gen2Substatus.SUBSTITUTE,
+	Gen2MoveEffect.TRANSFORM: Gen2Substatus.TRANSFORMED,
+}
+
+## `.Heal`, `.MorningSun`, `.Synthesis` and `.Moonlight`, four labels on one row.
+const HEALING_EFFECTS: Array = [
+	Gen2MoveEffect.HEAL, Gen2MoveEffect.MORNING_SUN,
+	Gen2MoveEffect.SYNTHESIS, Gen2MoveEffect.MOONLIGHT,
+]
+
+## The two that need the user asleep to do anything at all.
+const SLEEP_REQUIRED_EFFECTS: Array = [
+	Gen2MoveEffect.SLEEP_TALK, Gen2MoveEffect.SNORE,
+]
+
 const SCREEN_FOR_EFFECT: Dictionary = {
 	Gen2MoveEffect.LIGHT_SCREEN: Gen2Screens.LIGHT_SCREEN,
 	Gen2MoveEffect.REFLECT: Gen2Screens.REFLECT,
@@ -400,96 +431,85 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 ## the attacker rather than the defender. A standing Substitute reads the attacker
 ## for the same reason; Leech Seed, Nightmare and Spikes read the target.
 static func _apply_basic(scores: Array, c: Context) -> void:
-	var attacker: Gen2BattleMon = c.attacker
-	var defender: Gen2BattleMon = c.defender
-	var data: GameData = c.data
-	var weather: int = c.weather
-	var attacker_screens: int = c.attacker_screens
-	var defender_screens: int = c.defender_screens
 	for slot: int in Gen2BattleMon.MAX_MOVES:
-		if not attacker.can_use(slot):
+		if not c.attacker.can_use(slot):
 			continue
-		var effect: int = _effect(_move_at(attacker, data, slot))
-		var redundant: bool = false
-		if effect == Gen2MoveEffect.CONFUSE:
-			# `.Confuse` is the one row with two clauses: already confused, or
-			# behind the player's own Safeguard.
-			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED) \
-				or Gen2Screens.has(defender_screens, Gen2Screens.SAFEGUARD)
-		elif STATUS_ONLY_EFFECTS.has(effect):
-			redundant = Gen2Status.is_afflicted(defender.status)
-		elif effect == Gen2MoveEffect.DISABLE:
-			redundant = defender.disabled_slot >= 0
-		elif effect == Gen2MoveEffect.ENCORE:
-			redundant = defender.encored_slot >= 0
-		elif effect == Gen2MoveEffect.ATTRACT:
-			var same_gender: bool = attacker.gender() == defender.gender()
-			var unknown_gender: bool = attacker.gender() == Gen2BattleMon.GENDER_NONE \
-				or defender.gender() == Gen2BattleMon.GENDER_NONE
-			redundant = same_gender or unknown_gender \
-				or Gen2Substatus.has(defender.substatus, Gen2Substatus.ATTRACTED)
-		elif effect == Gen2MoveEffect.MIST:
-			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.MIST)
-		elif effect == Gen2MoveEffect.FOCUS_ENERGY:
-			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY)
-		elif effect == Gen2MoveEffect.PERISH_SONG:
-			# `.PerishSong` reads `wPlayerSubStatus1`, the target's: a second song
-			# over one already counting down would reset nothing.
-			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.PERISH)
-		elif effect == Gen2MoveEffect.MEAN_LOOK:
-			# `.MeanLook` reads the user's own flag, the side the trap sits on.
-			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.CANT_RUN)
-		elif SCREEN_FOR_EFFECT.has(effect):
-			# `.LightScreen`, `.Reflect` and `.Safeguard` all read
-			# `wEnemyScreens`, the AI's own side: a screen it already holds is
-			# the wasted turn, not one the player holds.
-			redundant = Gen2Screens.has(attacker_screens, int(SCREEN_FOR_EFFECT[effect]))
-		elif effect == Gen2MoveEffect.SUBSTITUTE:
-			# `.Substitute` reads `wEnemySubStatus4`, the AI's own.
-			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.SUBSTITUTE)
-		elif effect == Gen2MoveEffect.LEECH_SEED:
-			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.LEECH_SEED)
-		elif effect == Gen2MoveEffect.NIGHTMARE:
-			# `.Nightmare` treats *no* status as the redundant case, so a target
-			# carrying any status stays encouraged even when it is awake and cannot
-			# have one. The source marks that as a bug; reproduced, not fixed.
-			redundant = not Gen2Status.is_afflicted(defender.status) \
-				or Gen2Substatus.has(defender.substatus, Gen2Substatus.NIGHTMARE)
-		elif effect == Gen2MoveEffect.SPIKES:
-			# `.Spikes` reads `wPlayerScreens`, the side they would land on.
-			redundant = Gen2Screens.has(defender_screens, Gen2Screens.SPIKES)
-		elif effect == Gen2MoveEffect.FORESIGHT:
-			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.IDENTIFIED)
-		elif effect == Gen2MoveEffect.TELEPORT:
-			# `.Teleport` is a label on `.Redundant` itself, so it is redundant
-			# unconditionally: a trainer's Pokémon is refused by the move anyway.
-			redundant = true
-		elif effect == Gen2MoveEffect.SLEEP_TALK or effect == Gen2MoveEffect.SNORE:
-			# `.SleepTalk` shares Snore's row: awake means the move is wasted.
-			redundant = not Gen2Status.is_asleep(attacker.status)
-		elif effect == Gen2MoveEffect.DREAM_EATER:
-			# `.DreamEater` is the same shape read the other way round, off the
-			# target's status rather than the user's.
-			redundant = not Gen2Status.is_asleep(defender.status)
-		elif effect == Gen2MoveEffect.SWAGGER:
-			redundant = Gen2Substatus.has(defender.substatus, Gen2Substatus.CONFUSED)
-		elif effect == Gen2MoveEffect.TRANSFORM:
-			redundant = Gen2Substatus.has(attacker.substatus, Gen2Substatus.TRANSFORMED)
-		elif effect == Gen2MoveEffect.FUTURE_SIGHT:
-			# `.FutureSight` reads `SCREENS_UNUSED`, a bit nothing ever writes, so
-			# a second Future Sight is never discouraged. `docs/bugs_and_glitches.md`
-			# records it as a bug; reproduced, not fixed.
-			redundant = false
-		elif effect == Gen2MoveEffect.HEAL or effect == Gen2MoveEffect.MORNING_SUN \
-				or effect == Gen2MoveEffect.SYNTHESIS or effect == Gen2MoveEffect.MOONLIGHT:
-			# Four labels on one body: healing a full bar does nothing, whatever
-			# the weather would have made of it.
-			redundant = _at_max_hp(attacker)
-		elif WEATHER_FOR_EFFECT.has(effect):
-			redundant = weather == int(WEATHER_FOR_EFFECT[effect])
-		if redundant:
+		if _is_redundant(_effect(_move_at(c.attacker, c.data, slot)), c):
 			_discourage(scores, slot)
 
+
+## `AI_Redundant`'s table, which is one read per row.
+static func _is_redundant(effect: int, c: Context) -> bool:
+	if REDUNDANT_TARGET_SUBSTATUS.has(effect):
+		return Gen2Substatus.has(c.defender.substatus, int(REDUNDANT_TARGET_SUBSTATUS[effect]))
+	if REDUNDANT_USER_SUBSTATUS.has(effect):
+		return Gen2Substatus.has(c.attacker.substatus, int(REDUNDANT_USER_SUBSTATUS[effect]))
+	# `.LightScreen`, `.Reflect` and `.Safeguard` all read `wEnemyScreens`, the
+	# AI's own side: a screen it already holds is the wasted turn, not one the
+	# player holds.
+	if SCREEN_FOR_EFFECT.has(effect):
+		return Gen2Screens.has(c.attacker_screens, int(SCREEN_FOR_EFFECT[effect]))
+	if WEATHER_FOR_EFFECT.has(effect):
+		return c.weather == int(WEATHER_FOR_EFFECT[effect])
+	if STATUS_ONLY_EFFECTS.has(effect):
+		return Gen2Status.is_afflicted(c.defender.status)
+	# Four labels on one body: healing a full bar does nothing, whatever the
+	# weather would have made of it.
+	if HEALING_EFFECTS.has(effect):
+		return _at_max_hp(c.attacker)
+	# `.SleepTalk` shares Snore's row: awake means the move is wasted.
+	if SLEEP_REQUIRED_EFFECTS.has(effect):
+		return not Gen2Status.is_asleep(c.attacker.status)
+	return _is_redundant_once(effect, c)
+
+
+## The `.Redundant` rows that read something no other row does.
+static func _is_redundant_once(effect: int, c: Context) -> bool:
+	match effect:
+		Gen2MoveEffect.CONFUSE:
+			# `.Confuse` is the one row with two clauses: already confused, or
+			# behind the player's own Safeguard.
+			return Gen2Substatus.has(c.defender.substatus, Gen2Substatus.CONFUSED) \
+				or Gen2Screens.has(c.defender_screens, Gen2Screens.SAFEGUARD)
+		Gen2MoveEffect.DISABLE:
+			return c.defender.disabled_slot >= 0
+		Gen2MoveEffect.ENCORE:
+			return c.defender.encored_slot >= 0
+		Gen2MoveEffect.ATTRACT:
+			return _attract_redundant(c)
+		Gen2MoveEffect.NIGHTMARE:
+			# `.Nightmare` treats *no* status as the redundant case, so a target
+			# carrying any status stays encouraged even when it is awake and
+			# cannot have one. The source marks that as a bug; reproduced, not
+			# fixed.
+			return not Gen2Status.is_afflicted(c.defender.status) \
+				or Gen2Substatus.has(c.defender.substatus, Gen2Substatus.NIGHTMARE)
+		Gen2MoveEffect.SPIKES:
+			# `.Spikes` reads `wPlayerScreens`, the side they would land on.
+			return Gen2Screens.has(c.defender_screens, Gen2Screens.SPIKES)
+		Gen2MoveEffect.TELEPORT:
+			# `.Teleport` is a label on `.Redundant` itself, so it is redundant
+			# unconditionally: a trainer's Pokemon is refused by the move anyway.
+			return true
+		Gen2MoveEffect.DREAM_EATER:
+			# `.DreamEater` is Snore's shape read the other way round, off the
+			# target's status rather than the user's.
+			return not Gen2Status.is_asleep(c.defender.status)
+		Gen2MoveEffect.FUTURE_SIGHT:
+			# `.FutureSight` reads `SCREENS_UNUSED`, a bit nothing ever writes,
+			# so a second Future Sight is never discouraged.
+			# `docs/bugs_and_glitches.md` records it as a bug; reproduced.
+			return false
+	return false
+
+
+static func _attract_redundant(c: Context) -> bool:
+	if c.attacker.gender() == c.defender.gender():
+		return true
+	if c.attacker.gender() == Gen2BattleMon.GENDER_NONE \
+		or c.defender.gender() == Gen2BattleMon.GENDER_NONE:
+		return true
+	return Gen2Substatus.has(c.defender.substatus, Gen2Substatus.ATTRACTED)
 
 ## [constant RomLayout.AI_SETUP]: use a stat move on the first turn. Raising is
 ## encouraged only on the attacker's first turn and lowering only on the

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -4442,6 +4442,73 @@ static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> Str
 	return Gen2Text.decode(rom.bytes(), offset, RomLayout.MAX_NAME_LENGTH)
 
 
+func _import_core_sections(
+	rom: RomFile, layout: Dictionary, on_progress: Callable, yield_ms: int
+) -> Dictionary:
+	var species: Array = _import_species(rom, layout, on_progress)
+	await _breathe(yield_ms)
+	if species.is_empty():
+		return {"ok": false, "message": "Decoded no species."}
+
+	var pics: Dictionary = _import_pics(rom, layout, species, on_progress)
+	await _breathe(yield_ms)
+	if pics.is_empty():
+		return {"ok": false, "message": "Could not decode pics."}
+
+	# Crystal's alone; Gold and Silver have no pic animation, so an empty answer
+	# is the honest one rather than a failure.
+	var pic_anims: Dictionary = _import_pic_anims(rom, layout, species)
+	await _breathe(yield_ms)
+	if pic_anims.is_empty() and not RomLayout.pic_anim(layout).is_empty():
+		return {"ok": false, "message": "Could not decode pic animations."}
+
+	var tiles: Dictionary = _import_tiles(rom, layout, on_progress)
+	await _breathe(yield_ms)
+	if tiles.is_empty():
+		return {"ok": false, "message": "Could not write the font."}
+
+	var dex_orders: Dictionary = _import_dex_orders(rom, layout)
+	await _breathe(yield_ms)
+	if dex_orders.is_empty():
+		return {"ok": false, "message": "Dex order tables are outside the cartridge."}
+	return {
+		"ok": true, "species": species, "pics": pics,
+		"pic_anims": pic_anims, "tiles": tiles, "dex_orders": dex_orders,
+	}
+
+
+func _import_world_sections(
+	rom: RomFile, layout: Dictionary, directory: String,
+	on_progress: Callable, yield_ms: int
+) -> Dictionary:
+	var world: Dictionary = Gen2WorldImporter.import_to_cache(rom, layout, directory, on_progress)
+	await _breathe(yield_ms)
+	if not bool(world.get("ok", false)):
+		return {"ok": false, "message": String(world.get("message", "Could not import overworld data."))}
+	var encounters: Dictionary = Gen2WorldEncounterImporter.import_to_cache(rom, layout, directory)
+	await _breathe(yield_ms)
+	if not bool(encounters.get("ok", false)):
+		return {"ok": false, "message": String(encounters.get("message", "Could not import wild encounter data."))}
+	var services: Dictionary = Gen2WorldServicesImporter.import_to_cache(
+		rom, layout, directory,
+		world.get("scripts", {}), world.get("standard_scripts", {}),
+		world.get("text", {}), world.get("movements", {})
+	)
+	await _breathe(yield_ms)
+	if not bool(services.get("ok", false)):
+		return {"ok": false, "message": String(services.get("message", "Could not import world service data."))}
+	var battle_anims: Dictionary = Gen2BattleAnimImporter.import_to_cache(rom, layout, directory)
+	await _breathe(yield_ms)
+	if not bool(battle_anims.get("ok", false)):
+		return {"ok": false, "message": String(
+			battle_anims.get("message", "Could not import battle animation data.")
+		)}
+	return {
+		"ok": true, "world": world, "encounters": encounters,
+		"services": services, "battle_anims": battle_anims,
+	}
+
+
 ## Imports [param rom] into its cache directory, replacing whatever was there.
 ##
 ## [param on_progress] is called as [code](stage, done, total)[/code] if given.
@@ -4499,37 +4566,15 @@ func import_rom(
 		result["message"] = "Could not create %s." % directory
 		return result
 
-	var species: Array = _import_species(rom, layout, on_progress)
-	await _breathe(yield_ms)
-	if species.is_empty():
-		result["message"] = "Decoded no species."
+	var core: Dictionary = await _import_core_sections(rom, layout, on_progress, yield_ms)
+	if not bool(core.get("ok", false)):
+		result["message"] = String(core["message"])
 		return result
-
-	var pics: Dictionary = _import_pics(rom, layout, species, on_progress)
-	await _breathe(yield_ms)
-	if pics.is_empty():
-		result["message"] = "Could not decode pics."
-		return result
-
-	# Crystal's alone; Gold and Silver have no pic animation, so an empty answer
-	# is the honest one rather than a failure.
-	var pic_anims: Dictionary = _import_pic_anims(rom, layout, species)
-	await _breathe(yield_ms)
-	if pic_anims.is_empty() and not RomLayout.pic_anim(layout).is_empty():
-		result["message"] = "Could not decode pic animations."
-		return result
-
-	var tiles: Dictionary = _import_tiles(rom, layout, on_progress)
-	await _breathe(yield_ms)
-	if tiles.is_empty():
-		result["message"] = "Could not write the font."
-		return result
-
-	var dex_orders: Dictionary = _import_dex_orders(rom, layout)
-	await _breathe(yield_ms)
-	if dex_orders.is_empty():
-		result["message"] = "Dex order tables are outside the cartridge."
-		return result
+	var species: Array = core["species"]
+	var pics: Dictionary = core["pics"]
+	var tiles: Dictionary = core["tiles"]
+	var pic_anims: Dictionary = core["pic_anims"]
+	var dex_orders: Dictionary = core["dex_orders"]
 
 	var moves: Array = _import_moves(rom, layout, on_progress)
 	await _breathe(yield_ms)
@@ -4561,36 +4606,17 @@ func import_rom(
 	var matchups: Array = read_matchups(rom, layout)
 	var trainers: Array = _import_trainers(rom, layout, on_progress)
 	await _breathe(yield_ms)
-	var world: Dictionary = Gen2WorldImporter.import_to_cache(rom, layout, directory, on_progress)
-	await _breathe(yield_ms)
-	if not bool(world.get("ok", false)):
-		result["message"] = String(world.get("message", "Could not import overworld data."))
-		return result
-	var encounters: Dictionary = Gen2WorldEncounterImporter.import_to_cache(rom, layout, directory)
-	await _breathe(yield_ms)
-	if not bool(encounters.get("ok", false)):
-		result["message"] = String(encounters.get("message", "Could not import wild encounter data."))
-		return result
-	var services: Dictionary = Gen2WorldServicesImporter.import_to_cache(
-		rom, layout, directory,
-		world.get("scripts", {}), world.get("standard_scripts", {}),
-		world.get("text", {}), world.get("movements", {})
+	var sections: Dictionary = await _import_world_sections(
+		rom, layout, directory, on_progress, yield_ms
 	)
-	await _breathe(yield_ms)
-	if not bool(services.get("ok", false)):
-		result["message"] = String(services.get("message", "Could not import world service data."))
+	if not bool(sections.get("ok", false)):
+		result["message"] = String(sections["message"])
 		return result
-	var battle_anims: Dictionary = Gen2BattleAnimImporter.import_to_cache(rom, layout, directory)
-	await _breathe(yield_ms)
-	if not bool(battle_anims.get("ok", false)):
-		result["message"] = String(
-			battle_anims.get("message", "Could not import battle animation data.")
-		)
-		return result
+	var world: Dictionary = sections["world"]
+	var encounters: Dictionary = sections["encounters"]
+	var services: Dictionary = sections["services"]
+	var battle_anims: Dictionary = sections["battle_anims"]
 
-	if not RomCache.write_json(RomCache.species_path(directory), species):
-		result["message"] = "Could not write species data."
-		return result
 	if not pic_anims.is_empty() and not RomCache.write_section(
 		RomCache.pic_anims_path(directory),
 		RomCache.blob_path(RomCache.pic_anims_path(directory)), pic_anims
@@ -4604,44 +4630,24 @@ func import_rom(
 	):
 		result["message"] = "Could not write Battle Tower data."
 		return result
-	if not RomCache.write_json(RomCache.moves_path(directory), moves):
-		result["message"] = "Could not write move data."
-		return result
-	if not RomCache.write_json(RomCache.tmhm_moves_path(directory), tmhm_moves):
-		result["message"] = "Could not write TM/HM move data."
-		return result
-	if not RomCache.write_json(
-		RomCache.happiness_changes_path(directory), happiness_changes
-	):
-		result["message"] = "Could not write happiness change data."
-		return result
-	if not RomCache.write_json(RomCache.name_input_chars_path(directory), name_input_chars):
-		result["message"] = "Could not write name input data."
-		return result
-	if not RomCache.write_json(RomCache.text_buffers_path(directory), string_buffers):
-		result["message"] = "Could not write string buffer pointers."
-		return result
-	if not RomCache.write_json(RomCache.intro_text_path(directory), intro_text):
-		result["message"] = "Could not write intro text."
-		return result
-	if not RomCache.write_json(RomCache.dex_orders_path(directory), dex_orders):
-		result["message"] = "Could not write dex order data."
-		return result
-	if not RomCache.write_json(RomCache.items_path(directory), items):
-		result["message"] = "Could not write item data."
-		return result
-	if not RomCache.write_json(RomCache.world_trades_path(directory), trades):
-		result["message"] = "Could not write world trade data."
-		return result
-	if not RomCache.write_json(RomCache.types_path(directory), types):
-		result["message"] = "Could not write type data."
-		return result
-	if not RomCache.write_json(RomCache.matchups_path(directory), matchups):
-		result["message"] = "Could not write the type matchup chart."
-		return result
-	if not RomCache.write_json(RomCache.trainers_path(directory), trainers):
-		result["message"] = "Could not write trainer data."
-		return result
+	for section: Array in [
+		[RomCache.species_path(directory), species, "species data"],
+		[RomCache.moves_path(directory), moves, "move data"],
+		[RomCache.tmhm_moves_path(directory), tmhm_moves, "TM/HM move data"],
+		[RomCache.happiness_changes_path(directory), happiness_changes, "happiness change data"],
+		[RomCache.name_input_chars_path(directory), name_input_chars, "name input data"],
+		[RomCache.text_buffers_path(directory), string_buffers, "string buffer pointers"],
+		[RomCache.intro_text_path(directory), intro_text, "intro text"],
+		[RomCache.dex_orders_path(directory), dex_orders, "dex order data"],
+		[RomCache.items_path(directory), items, "item data"],
+		[RomCache.world_trades_path(directory), trades, "world trade data"],
+		[RomCache.types_path(directory), types, "type data"],
+		[RomCache.matchups_path(directory), matchups, "the type matchup chart"],
+		[RomCache.trainers_path(directory), trainers, "trainer data"],
+	]:
+		if not RomCache.write_json(section[0], section[1]):
+			result["message"] = "Could not write %s." % section[2]
+			return result
 
 	var evolutions: int = _count_in(species, "evolutions")
 	var learnset_moves: int = _count_in(species, "learnset")

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -324,8 +324,7 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 			if flip_x:
 				dx = -TILE - dx
 			out.append({
-				# `UpdateAnimFrame` builds every position with `add`, so an
-				# offset past the screen wraps rather than clamping.
+				# The `add` wrap [Gen2TitlePage] records.
 				"y": (at.y + int(part[0])) & 0xFF,
 				"x": (at.x + dx) & 0xFF,
 				"tile": (int(sprite["vtile"]) + int(ordering["vtile"]) + int(part[2])) & 0xFF,

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -230,8 +230,7 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	var background: Array = _draw_background(pixels, movie)
 	var behind: PackedByteArray = background[0]
 	var forced: PackedByteArray = background[1]
-	# The lower OAM index wins a pixel, so a slot only paints where no earlier
-	# one did.
+	# The lower OAM index wins a pixel.
 	var taken := PackedByteArray()
 	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):
@@ -239,11 +238,7 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
 
 
-## Every live struct expanded into the shadow OAM the hardware would hold, in
-## struct order, which is the z-order `PlaySpriteAnimations` walks. `y` and `x`
-## are the OAM bytes and `tile` the byte `dbsprite` writes. [method draw] blits
-## this same list rather than re-deriving it, so a trace of it compares to a
-## cartridge's own buffer line for line.
+## [method Gen2GoldSilverIntroPage.shadow_oam]'s buffer for this movie.
 func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
 	if movie == null:
@@ -270,8 +265,7 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 			if flip_y:
 				dy = -TILE - dy
 			out.append({
-				# `UpdateAnimFrame` builds every position with `add`, so an
-				# offset past the screen wraps rather than clamping.
+				# The `add` wrap [Gen2TitlePage] records.
 				"y": (at.y + dy) & 0xFF,
 				"x": (at.x + dx) & 0xFF,
 				"tile": (int(sprite["vtile"]) + int(ordering["vtile"]) + int(part[2])) & 0xFF,

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -14,8 +14,7 @@ const COLUMNS: int = 20
 const ROWS: int = 18
 ## A sprite never draws its first colour.
 const TRANSPARENT_INDEX: int = 0
-## Shadow OAM counts from (8, 16), so a coordinate reaches the screen eight less
-## across and sixteen less down.
+## The shadow-OAM origin [Gen2GameFreakPresentsPage] records.
 const OAM_ORIGIN := Vector2i(8, 16)
 ## `wShadowOAM` holds forty sprites.
 const SHADOW_OAM_SPRITES: int = 40

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -988,8 +988,7 @@ func close_embedded() -> void:
 	closed.emit({"ok": true, "script_value": 0, "changed": false})
 
 
-## The screen the opener wants this drawn in, handed over before it is added to
-## the tree. Without one the field goes in whichever screen this ends up inside.
+## The screen the opener wants this drawn in, as [Gen2PokegearScreen] takes it.
 func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -179,6 +179,18 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 		return null
 	var source: Dictionary = migration["data"]
 	var out := Gen2SaveData.new()
+	_read_header(out, source)
+	_read_lists(out, source)
+	_read_boxes(out, source)
+	var raw_world: Variant = source.get("world", {})
+	if raw_world is Dictionary and not (raw_world as Dictionary).is_empty():
+		out.world = Gen2WorldSnapshot.from_dict(raw_world)
+	_read_mods(out, source)
+	_read_run(out, source)
+	return out
+
+
+static func _read_header(out: Gen2SaveData, source: Dictionary) -> void:
 	out.format_version = FORMAT_VERSION
 	out.game_id = StringName(source.get("game_id", ""))
 	out.rom_sha1 = String(source.get("rom_sha1", ""))
@@ -193,6 +205,9 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	out.link_record = Gen2LinkSession.normalize_record(source.get("link_record", {}))
 	out.mystery_gift = Gen2MysteryGift.normalize(source.get("mystery_gift", {}))
 	out.nuzlocke = Gen2Nuzlocke.normalize(source.get("nuzlocke", {}))
+
+
+static func _read_lists(out: Gen2SaveData, source: Dictionary) -> void:
 	var raw_box_names: Variant = source.get("box_names", [])
 	if raw_box_names is Array:
 		for index: int in mini((raw_box_names as Array).size(), BOX_COUNT):
@@ -213,6 +228,11 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 	if raw_stash is Array:
 		for raw_mon: Variant in raw_stash as Array:
 			out.contest_stashed_party.append(Gen2SaveMon.from_dict(raw_mon))
+
+
+## A file whose boxes are the wrong shape is marked rather than refused here, so
+## the validator is the one that turns it away.
+static func _read_boxes(out: Gen2SaveData, source: Dictionary) -> void:
 	var raw_boxes: Variant = source.get("boxes", null)
 	out.boxes_shape_valid = raw_boxes is Array and (raw_boxes as Array).size() == BOX_COUNT
 	if raw_boxes is Array:
@@ -228,9 +248,9 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 				out.boxes[box_index] = box
 	else:
 		out.boxes_shape_valid = false
-	var raw_world: Variant = source.get("world", {})
-	if raw_world is Dictionary and not (raw_world as Dictionary).is_empty():
-		out.world = Gen2WorldSnapshot.from_dict(raw_world)
+
+
+static func _read_mods(out: Gen2SaveData, source: Dictionary) -> void:
 	var raw_mods: Variant = source.get("mods", {})
 	if raw_mods is Dictionary:
 		for raw_id: Variant in raw_mods:
@@ -238,6 +258,9 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 			var value: Variant = raw_mods[raw_id]
 			if _valid_mod_id(id) and value is Dictionary:
 				out.mods[StringName(id)] = (value as Dictionary).duplicate(true)
+
+
+static func _read_run(out: Gen2SaveData, source: Dictionary) -> void:
 	var raw_run: Variant = source.get("run", {})
 	if raw_run is Dictionary:
 		out.run_seed = int((raw_run as Dictionary).get("seed", 0))
@@ -259,8 +282,6 @@ static func from_dict(raw: Variant) -> Gen2SaveData:
 				var options: Variant = (raw_run_options as Dictionary)[raw_id]
 				if _valid_mod_id(id) and options is Dictionary:
 					out.run_options[StringName(id)] = (options as Dictionary).duplicate(true)
-	return out
-
 
 ## Converts an older project save shape into the current schema, one version step
 ## at a time so a version 1 file reaches the current one through every step. Each

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -126,9 +126,7 @@ const SHELLDER_AT: Array[Vector2i] = [
 	Vector2i(7 * 8, 18 * 8), Vector2i(10 * 8, 14 * 8), Vector2i(15 * 8, 16 * 8),
 ]
 
-## The framesets, as (OAM set, duration, attributes) plus how the run ends.
-## `oamframe X, n` lasts n + 1 frames; `oamend` repeats its last entry forever,
-## `oamdelete` takes the struct away and `oamrestart` goes round again.
+## The framesets [Gen2IntroMovie] describes, in the same shape.
 const FRAMESET_END: StringName = &"end"
 const FRAMESET_DELETE: StringName = &"delete"
 const FRAMESET_RESTART: StringName = &"restart"

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -118,9 +118,7 @@ func _process(delta: float) -> void:
 	advance_frames(_frame_clock.tick(delta))
 
 
-## Runs [param count] source frames of whatever the screen is standing in.
-## Public so a test or a preview tool can spend the cartridge's own
-## `DelayFrames` without a clock; [method _process] is the only other caller.
+## [method Gen2ClockSetScreen.advance_frames] over this screen's own state.
 func advance_frames(count: int) -> void:
 	for _frame: int in count:
 		if _text_box != null:
@@ -132,8 +130,7 @@ func advance_frames(count: int) -> void:
 			return
 		_presentation.advance_frame()
 		_apply_frame()
-		# The last VBlank of a `DelayFrames` run is the frame the routine
-		# returns on, so no frame is spent at a call boundary.
+		# `DelayFrames` returns on its last VBlank; no frame goes at a boundary.
 		if _presentation.finished():
 			_finish_queue()
 

--- a/game/world/player_name_menu_screen.gd
+++ b/game/world/player_name_menu_screen.gd
@@ -15,9 +15,7 @@ var _page: Gen2MenuPage = null
 var _options: Array[String] = []
 var _background: TextureRect = null
 
-## The four colours the screen is drawn through, index 0 the field and 3 the
-## ink. Empty is the ordinary black-on-white; the intro sets it because
-## `RotateThreePalettesRight` fades this screen out before `ClearTilemap`.
+## The four colours [Gen2NamingScreenScreen] is drawn through, on the same terms.
 var palette: PackedColorArray = PackedColorArray():
 	set(value):
 		palette = value

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -45,6 +45,45 @@ enum Mode {
 	FIELD_MOVES,
 }
 
+## The two-row boxes, by the cursor each toggles and the method that repaints it.
+const TOGGLE_MODES: Dictionary = {
+	Mode.PACK_TEACH: [&"_teach_cursor", &"_render_teach"],
+	Mode.PACK_FORGET_ASK: [&"_forget_confirm_cursor", &"_render_forget_ask"],
+	Mode.PACK_STOP_LEARNING: [&"_forget_confirm_cursor", &"_render_stop_learning"],
+	Mode.PACK_TOSS_CONFIRM: [&"_toss_confirm_cursor", &"_render_toss_confirm"],
+	Mode.PACK_GIVE_SWAP: [&"_swap_cursor", &"_render_give_swap"],
+	Mode.SAVE_ASK: [&"_save_cursor", &"_render_save"],
+	Mode.SAVE_OVERWRITE: [&"_save_cursor", &"_render_save"],
+	Mode.QUIT_ASK: [&"_save_cursor", &"_render_save"],
+	Mode.LAUNCHER_ASK: [&"_save_cursor", &"_render_save"],
+	Mode.RESET_ASK: [&"_save_cursor", &"_render_save"],
+}
+
+## Every mode whose A press is one call. A ladder row is read with left and right,
+## so A does nothing on one, the way it does on the cartridge's own value rows; a
+## mod's button row is the exception, where pressing it is the whole setting.
+const CONFIRM_HANDLERS: Dictionary = {
+	Mode.LIST: &"_confirm_list",
+	Mode.PACK_ITEM: &"_confirm_item_action",
+	Mode.PACK_TEACH: &"_confirm_teach",
+	Mode.PACK_FORGET_ASK: &"_confirm_forget_ask",
+	Mode.PACK_FORGET: &"_confirm_forget",
+	Mode.PACK_PP_MOVE: &"_confirm_pp_move",
+	Mode.PACK_STOP_LEARNING: &"_confirm_stop_learning",
+	Mode.PACK_TOSS_CONFIRM: &"_confirm_toss",
+	Mode.PACK_GIVE_SWAP: &"_confirm_give_swap",
+	Mode.SAVE_ASK: &"_confirm_save",
+	Mode.SAVE_OVERWRITE: &"_confirm_save",
+	Mode.SAVE_SAVING: &"_confirm_save",
+	Mode.SAVE_SAVED: &"_confirm_save",
+	Mode.SAVE_FAILED: &"_confirm_save",
+	Mode.QUIT_ASK: &"_confirm_save",
+	Mode.LAUNCHER_ASK: &"_confirm_save",
+	Mode.RESET_ASK: &"_confirm_save",
+	Mode.MOD_OPTIONS: &"_press_mod_option",
+	Mode.FIELD_MOVES: &"_confirm_field_move",
+}
+
 ## `SaveMenu`'s four texts, out of `data/text/common_3.asm` on Crystal and
 ## `common_2.asm` on Gold and Silver, which no importer reads and which this
 ## project authors beside its other engine text. Verbatim, one entry a line, so
@@ -467,91 +506,104 @@ func _move(direction: Vector2i) -> void:
 			elif direction.y != 0:
 				_move_pack_cursor(direction.y)
 		Mode.PACK_ITEM:
-			if direction.y != 0 and not _item_actions.is_empty():
-				_item_cursor = wrapi(_item_cursor + signi(direction.y), 0, _item_actions.size())
-				_render_item_menu()
-		Mode.PACK_TEACH:
-			if direction.y != 0 or direction.x != 0:
-				_teach_cursor = 1 - _teach_cursor
-				_render_teach()
-		Mode.PACK_FORGET_ASK:
-			if direction.y != 0 or direction.x != 0:
-				_forget_confirm_cursor = 1 - _forget_confirm_cursor
-				_render_forget_ask()
+			_move_wrapped(
+				direction.y, &"_item_cursor", _item_actions.size(), &"_render_item_menu"
+			)
 		Mode.PACK_FORGET, Mode.PACK_PP_MOVE:
-			## w2DMenuNumCols is 1, so only vertical input moves the move list.
-			if direction.y != 0 and not _forget_moves.is_empty():
-				_forget_cursor = wrapi(
-					_forget_cursor + signi(direction.y), 0, _forget_moves.size()
-				)
-				_forget_refusal = ""
-				_render_forget_list()
-		Mode.PACK_STOP_LEARNING:
-			if direction.y != 0 or direction.x != 0:
-				_forget_confirm_cursor = 1 - _forget_confirm_cursor
-				_render_stop_learning()
-		Mode.PACK_TOSS_CONFIRM:
-			if direction.y != 0 or direction.x != 0:
-				_toss_confirm_cursor = 1 - _toss_confirm_cursor
-				_render_toss_confirm()
-		Mode.PACK_GIVE_SWAP:
-			if direction.y != 0 or direction.x != 0:
-				_swap_cursor = 1 - _swap_cursor
-				_render_give_swap()
+			_move_forget_list(direction.y)
 		Mode.PACK_TARGET:
-			## `InitPartyMenuWithCancel`: CANCEL is the row after the last member
-			## and the cursor wraps around it, which is `w2DMenuNumRows` being the
-			## party count plus one.
-			if direction.y != 0 and not _party_targets().is_empty():
-				_target_cursor = wrapi(
-					_target_cursor + signi(direction.y), 0, _party_targets().size() + 1
-				)
-				_render_targets()
-		## `VerticalMenu` over `YesNoMenuHeader`, which is only up while a
-		## question is; the two timed modes read no joypad at all.
-		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.QUIT_ASK, Mode.LAUNCHER_ASK, \
-		Mode.RESET_ASK:
-			if _save_cursor >= 0 and (direction.x != 0 or direction.y != 0):
-				_save_cursor = 1 - _save_cursor
-				_render_save()
-		Mode.OPTIONS:
-			if direction.y != 0:
-				_options_menu.move(direction.y)
-				_render_options_menu()
-			elif direction.x != 0 and _options_menu.adjust(direction.x):
-				_persist_options()
-				_render_options_menu()
-		Mode.MODS:
-			var mod_rows: Array = _mod_rows()
-			if mod_rows.is_empty():
-				return
-			if direction.y != 0:
-				_mod_cursor = wrapi(_mod_cursor + signi(direction.y), 0, mod_rows.size())
-				_render_mods()
-			elif direction.x != 0 and _mod_view_row(mod_rows):
-				_cycle_view(signi(direction.x))
-		Mode.MOD_OPTIONS:
-			var rows: Array = _mod_options()
-			if rows.is_empty():
-				return
-			if direction.y != 0:
-				_mod_option_cursor = wrapi(
-					_mod_option_cursor + signi(direction.y), 0, rows.size()
-				)
-				_render_mod_options()
-			elif direction.x != 0:
-				_adjust_mod_option(rows, direction.x)
+			_move_wrapped(
+				direction.y, &"_target_cursor", _target_rows(), &"_render_targets"
+			)
 		Mode.FIELD_MOVES:
-			if direction.y != 0 and not _field_move_rows.is_empty():
-				_field_move_cursor = wrapi(
-					_field_move_cursor + signi(direction.y), 0, _field_move_rows.size()
-				)
+			_move_wrapped(
+				direction.y, &"_field_move_cursor", _field_move_rows.size(), &""
+			)
+		Mode.PACK_TEACH, Mode.PACK_FORGET_ASK, Mode.PACK_STOP_LEARNING, \
+		Mode.PACK_TOSS_CONFIRM, Mode.PACK_GIVE_SWAP, Mode.SAVE_ASK, \
+		Mode.SAVE_OVERWRITE, Mode.QUIT_ASK, Mode.LAUNCHER_ASK, Mode.RESET_ASK:
+			_toggle_two_row(direction)
+		Mode.OPTIONS:
+			_move_options(direction)
+		Mode.MODS:
+			_move_mods(direction)
+		Mode.MOD_OPTIONS:
+			_move_mod_options(direction)
 
+
+func _move_wrapped(step: int, at: StringName, rows: int, render: StringName) -> void:
+	if step == 0 or rows <= 0:
+		return
+	set(at, wrapi(int(get(at)) + signi(step), 0, rows))
+	if render != &"":
+		call(render)
+
+
+## `InitPartyMenuWithCancel`: CANCEL is the row after the last member and the
+## cursor wraps around it, which is `w2DMenuNumRows` being the party count plus
+## one.
+func _target_rows() -> int:
+	var targets: Array = _party_targets()
+	return 0 if targets.is_empty() else targets.size() + 1
+
+
+## w2DMenuNumCols is 1, so only vertical input moves the move list.
+func _move_forget_list(step: int) -> void:
+	if step == 0 or _forget_moves.is_empty():
+		return
+	_forget_cursor = wrapi(_forget_cursor + signi(step), 0, _forget_moves.size())
+	_forget_refusal = ""
+	_render_forget_list()
+
+
+## `VerticalMenu` over a two-row box, where every direction toggles the cursor.
+## The save family parks its own at -1 while a box is timed rather than asked,
+## and reads no joypad then.
+func _toggle_two_row(direction: Vector2i) -> void:
+	var row: Array = TOGGLE_MODES[_mode]
+	var at: int = int(get(row[0]))
+	if at < 0 or direction == Vector2i.ZERO:
+		return
+	set(row[0], 1 - at)
+	call(row[1])
+
+
+func _move_options(direction: Vector2i) -> void:
+	if direction.y != 0:
+		_options_menu.move(direction.y)
+		_render_options_menu()
+	elif direction.x != 0 and _options_menu.adjust(direction.x):
+		_persist_options()
+		_render_options_menu()
+
+
+func _move_mods(direction: Vector2i) -> void:
+	var mod_rows: Array = _mod_rows()
+	if mod_rows.is_empty():
+		return
+	if direction.y != 0:
+		_mod_cursor = wrapi(_mod_cursor + signi(direction.y), 0, mod_rows.size())
+		_render_mods()
+	elif direction.x != 0 and _mod_view_row(mod_rows):
+		_cycle_view(signi(direction.x))
+
+
+func _move_mod_options(direction: Vector2i) -> void:
+	var rows: Array = _mod_options()
+	if rows.is_empty():
+		return
+	if direction.y != 0:
+		_mod_option_cursor = wrapi(_mod_option_cursor + signi(direction.y), 0, rows.size())
+		_render_mod_options()
+	elif direction.x != 0:
+		_adjust_mod_option(rows, direction.x)
 
 func _confirm() -> void:
+	var handler: StringName = CONFIRM_HANDLERS.get(_mode, &"")
+	if handler != &"":
+		call(handler)
+		return
 	match _mode:
-		Mode.LIST:
-			_confirm_list()
 		Mode.PACK:
 			## `.switching_item` reads A before anything else, so the A that
 			## would open an item's submenu places the held item instead.
@@ -569,22 +621,6 @@ func _confirm() -> void:
 				_give_selected_item(_give_target)
 			else:
 				_open_item_mode()
-		Mode.PACK_ITEM:
-			_confirm_item_action()
-		Mode.PACK_TEACH:
-			_confirm_teach()
-		Mode.PACK_FORGET_ASK:
-			_confirm_forget_ask()
-		Mode.PACK_FORGET:
-			_confirm_forget()
-		Mode.PACK_PP_MOVE:
-			_confirm_pp_move()
-		Mode.PACK_STOP_LEARNING:
-			_confirm_stop_learning()
-		Mode.PACK_TOSS_CONFIRM:
-			_confirm_toss()
-		Mode.PACK_GIVE_SWAP:
-			_confirm_give_swap()
 		Mode.PACK_TARGET:
 			## `PartyMenuSelect` returns carry on CANCEL, which the caller answers
 			## the same way it answers B.
@@ -596,20 +632,8 @@ func _confirm() -> void:
 				_give_selected_item(_target_cursor)
 			else:
 				_use_selected_item(_target_cursor)
-		## A pack opened over one Pokemon has no menu behind it to go back to:
-		## the party screen closed when it asked for this one.
 		Mode.PACK_RESULT:
-			if _pack_result_advanced():
-				return
-			if _pack_result_continued():
-				return
-			if _give_target >= 0:
-				closed.emit()
-			else:
-				_open_pack_mode(false)
-		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
-		Mode.SAVE_FAILED, Mode.QUIT_ASK, Mode.LAUNCHER_ASK, Mode.RESET_ASK:
-			_confirm_save()
+			_leave_pack_result()
 		## Options_Cancel is the only handler that reads A.
 		Mode.OPTIONS:
 			if _options_menu.is_cancel():
@@ -620,14 +644,18 @@ func _confirm() -> void:
 			var chosen: Dictionary = _mod_row()
 			if StringName(chosen.get("kind", &"")) == MOD_ROW_MOD:
 				_open_mod_options_mode(StringName(chosen["id"]))
-		## A ladder row is read with left and right, so A does nothing on one, the
-		## way it does on the cartridge's own value rows. A button row is the
-		## exception: pressing it is the whole setting.
-		Mode.MOD_OPTIONS:
-			_press_mod_option()
-		Mode.FIELD_MOVES:
-			_confirm_field_move()
 
+
+## A pack opened over one Pokemon has no menu to go back to; A and B agree.
+func _leave_pack_result() -> void:
+	if _pack_result_advanced():
+		return
+	if _pack_result_continued():
+		return
+	if _give_target >= 0:
+		closed.emit()
+	else:
+		_open_pack_mode(false)
 
 func _cancel() -> void:
 	match _mode:
@@ -645,14 +673,7 @@ func _cancel() -> void:
 		Mode.PACK_ITEM, Mode.PACK_TEACH:
 			_open_pack_mode(false)
 		Mode.PACK_RESULT:
-			if _pack_result_advanced():
-				return
-			if _pack_result_continued():
-				return
-			if _give_target >= 0:
-				closed.emit()
-			else:
-				_open_pack_mode(false)
+			_leave_pack_result()
 		## B at ForgetMove's ask is YesNoBox's no, and B in the move list is its
 		## own .cancel's scf. Both are the carry LearnMove.cancel tests.
 		Mode.PACK_FORGET_ASK, Mode.PACK_FORGET:
@@ -2340,55 +2361,22 @@ func _hardware_image() -> Image:
 		Mode.QUIT_ASK, Mode.LAUNCHER_ASK, Mode.RESET_ASK:
 			return _page.render_save(_save_state(), _list_image())
 		Mode.OPTIONS:
-			if _options_menu == null:
-				return null
-			return _page.render_options(_options_menu.rows(), _options_menu.cursor)
+			return _options_image()
 		Mode.PACK:
 			return _pack_image()
 		Mode.PACK_ITEM:
-			var labels: Array = []
-			for entry: Dictionary in _item_actions:
-				labels.append(String(entry.get("label", "")))
-			return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
-				_pack_page.draw_menu(map, _item_menu_box(labels.size()), labels, _item_cursor)
-			)
-		Mode.PACK_TEACH:
-			return _pack_yes_no(box_text(), _teach_cursor)
-		Mode.PACK_FORGET_ASK:
-			return _pack_yes_no(box_text(), _forget_confirm_cursor)
-		Mode.PACK_STOP_LEARNING:
-			return _pack_yes_no(box_text(), _forget_confirm_cursor)
-		Mode.PACK_TOSS_CONFIRM:
-			return _pack_yes_no(box_text(), _toss_confirm_cursor)
-		Mode.PACK_GIVE_SWAP:
-			return _pack_yes_no(box_text(), _swap_cursor)
+			return _item_menu_image()
+		Mode.PACK_TEACH, Mode.PACK_FORGET_ASK, Mode.PACK_STOP_LEARNING, \
+		Mode.PACK_TOSS_CONFIRM, Mode.PACK_GIVE_SWAP:
+			return _pack_yes_no(box_text(), int(get(TOGGLE_MODES[_mode][0])))
 		Mode.PACK_TOSS_QUANTITY:
-			return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
-				_pack_page.draw_quantity(
-					map,
-					Gen2MenuBox.from_coords(
-						TOSS_QUANTITY_AT.x, TOSS_QUANTITY_AT.y,
-						TOSS_QUANTITY_TO.x, TOSS_QUANTITY_TO.y, 0
-					),
-					_toss_prompt.value if _toss_prompt != null else 1
-				)
-			)
+			return _toss_quantity_image()
 		Mode.PACK_FORGET, Mode.PACK_PP_MOVE:
-			var moves: Array = []
-			for entry: Dictionary in _forget_moves:
-				moves.append(String(entry.get("name", "")))
-			return _pack_overlay(
-				box_text(), func(map: PackedInt32Array) -> void:
-					_pack_page.draw_move_list(map, moves, _forget_cursor)
-			)
+			return _move_list_image()
 		Mode.PACK_RESULT:
 			return _pack_overlay(box_text(), Callable())
 		Mode.PACK_TARGET:
-			if _party_menu_page() == null:
-				return null
-			return _target_page.render(
-				_party_targets(), _target_cursor, _target_prompt()
-			)
+			return _target_image()
 		Mode.FIELD_MOVES:
 			var moves: Array = _field_move_labels()
 			return _page.render_list(
@@ -2396,38 +2384,89 @@ func _hardware_image() -> Image:
 				Gen2PartyScreen.mon_menu_box(moves.size())
 			)
 		Mode.MODS:
-			var rows: Array = []
-			for row: Dictionary in _mod_rows():
-				if StringName(row["kind"]) == MOD_ROW_VIEW:
-					var host: Gen2ModHost = Gen2ModHost.instance()
-					rows.append({
-						"label": "VIEW", "value": host.view_label(host.selected_view()),
-					})
-					continue
-				rows.append({"label": _mod_name(StringName(row["id"])), "value": ""})
-			var window: Dictionary = _option_window(rows, _mod_cursor)
-			return _page.render_options(window["rows"], window["cursor"])
+			return _mod_rows_image()
 		Mode.MOD_OPTIONS:
-			var rows: Array = []
-			for raw: Dictionary in _mod_options():
-				var value: String = ""
-				match StringName(raw.get("kind", Gen2ModHost.OPTION_LADDER)):
-					Gen2ModHost.OPTION_BUTTON:
-						value = String(raw.get("press_label", "Go"))
-					Gen2ModHost.OPTION_NUMBER:
-						value = str(int(raw.get("value", 0)))
-					_:
-						var labels: Array = raw.get("labels", []) as Array
-						var index: int = int(raw.get("index", 0))
-						if index >= 0 and index < labels.size():
-							value = String(labels[index])
-				rows.append({"label": String(raw.get("label", "")), "value": value})
-			var window: Dictionary = _option_window(
-				rows, _mod_option_cursor, Gen2StartMenuPage.OPTIONS_VISIBLE_VALUE_ROWS
-			)
-			return _page.render_options(window["rows"], window["cursor"])
+			return _mod_options_image()
 	return null
 
+
+func _options_image() -> Image:
+	if _options_menu == null:
+		return null
+	return _page.render_options(_options_menu.rows(), _options_menu.cursor)
+
+
+func _item_menu_image() -> Image:
+	var labels: Array = []
+	for entry: Dictionary in _item_actions:
+		labels.append(String(entry.get("label", "")))
+	return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
+		_pack_page.draw_menu(map, _item_menu_box(labels.size()), labels, _item_cursor)
+	)
+
+
+func _toss_quantity_image() -> Image:
+	return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
+		_pack_page.draw_quantity(
+			map,
+			Gen2MenuBox.from_coords(
+				TOSS_QUANTITY_AT.x, TOSS_QUANTITY_AT.y,
+				TOSS_QUANTITY_TO.x, TOSS_QUANTITY_TO.y, 0
+			),
+			_toss_prompt.value if _toss_prompt != null else 1
+		)
+	)
+
+
+func _move_list_image() -> Image:
+	var moves: Array = []
+	for entry: Dictionary in _forget_moves:
+		moves.append(String(entry.get("name", "")))
+	return _pack_overlay(
+		box_text(), func(map: PackedInt32Array) -> void:
+			_pack_page.draw_move_list(map, moves, _forget_cursor)
+	)
+
+
+func _target_image() -> Image:
+	if _party_menu_page() == null:
+		return null
+	return _target_page.render(_party_targets(), _target_cursor, _target_prompt())
+
+
+func _mod_rows_image() -> Image:
+	var rows: Array = []
+	for row: Dictionary in _mod_rows():
+		if StringName(row["kind"]) == MOD_ROW_VIEW:
+			var host: Gen2ModHost = Gen2ModHost.instance()
+			rows.append({"label": "VIEW", "value": host.view_label(host.selected_view())})
+			continue
+		rows.append({"label": _mod_name(StringName(row["id"])), "value": ""})
+	var window: Dictionary = _option_window(rows, _mod_cursor)
+	return _page.render_options(window["rows"], window["cursor"])
+
+
+func _mod_options_image() -> Image:
+	var rows: Array = []
+	for raw: Dictionary in _mod_options():
+		rows.append({
+			"label": String(raw.get("label", "")), "value": _mod_option_value(raw),
+		})
+	var window: Dictionary = _option_window(
+		rows, _mod_option_cursor, Gen2StartMenuPage.OPTIONS_VISIBLE_VALUE_ROWS
+	)
+	return _page.render_options(window["rows"], window["cursor"])
+
+
+func _mod_option_value(raw: Dictionary) -> String:
+	match StringName(raw.get("kind", Gen2ModHost.OPTION_LADDER)):
+		Gen2ModHost.OPTION_BUTTON:
+			return String(raw.get("press_label", "Go"))
+		Gen2ModHost.OPTION_NUMBER:
+			return str(int(raw.get("value", 0)))
+	var labels: Array = raw.get("labels", []) as Array
+	var index: int = int(raw.get("index", 0))
+	return String(labels[index]) if index >= 0 and index < labels.size() else ''
 
 ## Keeps the active global row on the hardware page. Input and mutations retain
 ## the global cursor; only the rows handed to the page move.

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -610,8 +610,7 @@ func _icon_position(landmark: int) -> Vector2i:
 		- Vector2i(ICON_ORIGIN, ICON_ORIGIN)
 
 
-## The screen the opener wants this drawn in, handed over before it is added to
-## the tree. Without one the field goes in whichever screen this ends up inside.
+## The screen the opener wants this drawn in, as [Gen2PokegearScreen] takes it.
 func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -230,66 +230,13 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 	var values: Dictionary = request.get("values", {})
 	match kind:
 		&"mart_requested":
-			var dialog_id: int = int(values.get("dialog", 0))
-			var mart_id: int = int(values.get("address", 0)) & 0xFF
-			var mart_result: Dictionary = Gen2WorldMartHost.resolve_mart(
-				world.data, dialog_id, mart_id, world.state.hall_of_fame(), world.state
-			)
-			if not bool(mart_result.get("ok", false)):
-				return {
-					"ok": false,
-					"reason": StringName(mart_result.get("reason", &"mart_data_unavailable")),
-				}
-			var mart: Dictionary = mart_result["mart"]
-			## A catalog site may sell its own shelf. `{item, price}` is the shape
-			## `Gen2WorldMartHost.entries` already reads, so a patched price is
-			## the price the counter charges and nothing else changes.
-			if values.has("items") and values["items"] is Array \
-				and not (values["items"] as Array).is_empty():
-				mart = mart.duplicate(true)
-				mart["items"] = (values["items"] as Array).duplicate(true)
-			return {
-				"ok": true,
-				"data": {"mart": mart, "mart_id": mart_id, "dialog": dialog_id},
-			}
+			return _resolve_mart(world, values)
 		&"elevator_requested":
-			var floors: Dictionary = Gen2WorldScript.decode_elevator_floors(
-				world.data.world_script_at(
-					int(values.get("bank", 0)), int(values.get("address", 0))
-				)
-			)
-			if not bool(floors.get("ok", false)):
-				return {
-					"ok": false,
-					"reason": StringName(floors.get("reason", &"elevator_data_unavailable")),
-				}
-			## `.FindCurrentFloor` walks the list for the row whose map is the
-			## backup warp's, and quits the whole routine when none is: the car
-			## does not know where it is standing, so it does not move.
-			var rows: Array = floors["floors"]
-			var current: int = -1
-			for index: int in rows.size():
-				var row: Dictionary = rows[index]
-				if int(row["map_group"]) == int(world.backup_warp.get("map_group", -1)) \
-					and int(row["map_number"]) == int(world.backup_warp.get("map_number", -1)):
-					current = index
-					break
-			if current < 0:
-				return {"ok": false, "reason": &"elevator_floor_unknown"}
-			return {
-				"ok": true,
-				"data": {"elevator": {"floors": rows, "current": current}},
-			}
+			return _resolve_elevator(world, values)
 		&"name_rater_requested":
-			var lines: Dictionary = name_rater_texts(world.data)
-			if lines.is_empty():
-				return {"ok": false, "reason": &"name_rater_text_unavailable"}
-			return {"ok": true, "data": {"name_rater_text": lines}}
+			return _resolve_text_block(&"name_rater_text", name_rater_texts(world.data))
 		&"move_deleter_requested":
-			var boxes: Dictionary = move_deleter_texts(world.data)
-			if boxes.is_empty():
-				return {"ok": false, "reason": &"move_deleter_text_unavailable"}
-			return {"ok": true, "data": {"move_deleter_text": boxes}}
+			return _resolve_text_block(&"move_deleter_text", move_deleter_texts(world.data))
 		&"move_tutor_requested":
 			## Every box `MoveTutor` prints is `LearnMove`'s or `TeachTMHM`'s,
 			## which [Gen2MoveForget] and [Gen2WorldTMHM] already own, so the
@@ -301,10 +248,7 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 				))},
 			}
 		&"day_care_requested":
-			var day_care: Dictionary = day_care_texts(world.data)
-			if day_care.is_empty():
-				return {"ok": false, "reason": &"day_care_text_unavailable"}
-			return {"ok": true, "data": {"day_care_text": day_care}}
+			return _resolve_text_block(&"day_care_text", day_care_texts(world.data))
 		&"map_radio_requested":
 			## `PlayRadio` opens one station and prints its own line; the station
 			## the script named is all the routine needs.
@@ -329,48 +273,9 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 				},
 			}
 		&"special_phone_call_requested":
-			var call_id: int = int(values.get("address", 0))
-			var special: Dictionary = Gen2WorldPhoneHost.resolve_special(
-				world.data, world.current_map, call_id, world.world_hour
-			)
-			if not bool(special.get("ok", false)):
-				return {
-					"ok": false,
-					"reason": StringName(special.get("reason", &"phone_data_unavailable")),
-				}
-			return {"ok": true, "data": special}
+			return _resolve_special_phone_call(world, values)
 		&"phone_call_requested":
-			var source: Dictionary = request.get("source", {})
-			var address: int = int(values.get("address", 0))
-			if values.has("contact"):
-				var outgoing: Dictionary = Gen2WorldPhoneHost.resolve_outgoing(
-					world.data, world.state, world.current_map,
-					int(values.get("contact", -1)), world.world_hour
-				)
-				if not bool(outgoing.get("ok", false)):
-					return {
-						"ok": false,
-						"reason": StringName(outgoing.get("reason", &"phone_data_unavailable")),
-					}
-				return {"ok": true, "data": outgoing}
-			var bank: int = int(source.get("bank", -1))
-			var caller_name_raw: PackedByteArray = world.data.world_text(bank, address)
-			var caller_name: Dictionary = Gen2WorldScript.decode_text(caller_name_raw)
-			if not bool(caller_name.get("ok", false)):
-				return {"ok": false, "reason": &"phone_caller_name_unavailable"}
-			## The source phonecall command passes a text pointer directly to
-			## PhoneCall. It does not identify a phone contact or dispatch a
-			## contact script.
-			return {
-				"ok": true,
-				"data": {
-					"phone_call": {
-						"caller_name_pointer": {"bank": bank, "address": address},
-						"caller_name": String(caller_name.get("text", "")),
-					},
-					"phone": source.get("phone", {}).duplicate(true),
-				},
-			}
+			return _resolve_phone_call(world, request, values)
 		&"pc_requested":
 			## `PokemonCenterPC` and `_PlayersHousePC`. Both are menus over state
 			## the world already holds, so the only thing to resolve is which of
@@ -380,13 +285,126 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 				return {"ok": false, "reason": &"unsupported_pc_mode"}
 			return {"ok": true, "data": {"pc": {"mode": pc_mode}}}
 		&"audio_requested":
-			var audio: Dictionary = audio_for_request(world, request)
-			var audio_kind: StringName = StringName(request.get("values", {}).get("kind", &""))
-			if audio.is_empty() and audio_kind != &"sound_wait":
-				return {"ok": false, "reason": &"audio_data_unavailable"}
-			return {"ok": true, "data": {"audio": audio}}
+			return _resolve_audio(world, request)
 	return {}
 
+
+static func _resolve_mart(world: Gen2WorldAPI, values: Dictionary) -> Dictionary:
+	var dialog_id: int = int(values.get("dialog", 0))
+	var mart_id: int = int(values.get("address", 0)) & 0xFF
+	var mart_result: Dictionary = Gen2WorldMartHost.resolve_mart(
+		world.data, dialog_id, mart_id, world.state.hall_of_fame(), world.state
+	)
+	if not bool(mart_result.get("ok", false)):
+		return {
+			"ok": false,
+			"reason": StringName(mart_result.get("reason", &"mart_data_unavailable")),
+		}
+	var mart: Dictionary = mart_result["mart"]
+	## A catalog site may sell its own shelf. `{item, price}` is the shape
+	## `Gen2WorldMartHost.entries` already reads, so a patched price is
+	## the price the counter charges and nothing else changes.
+	if values.has("items") and values["items"] is Array \
+		and not (values["items"] as Array).is_empty():
+		mart = mart.duplicate(true)
+		mart["items"] = (values["items"] as Array).duplicate(true)
+	return {
+		"ok": true,
+		"data": {"mart": mart, "mart_id": mart_id, "dialog": dialog_id},
+	}
+
+
+static func _resolve_elevator(world: Gen2WorldAPI, values: Dictionary) -> Dictionary:
+	var floors: Dictionary = Gen2WorldScript.decode_elevator_floors(
+		world.data.world_script_at(
+			int(values.get("bank", 0)), int(values.get("address", 0))
+		)
+	)
+	if not bool(floors.get("ok", false)):
+		return {
+			"ok": false,
+			"reason": StringName(floors.get("reason", &"elevator_data_unavailable")),
+		}
+	## `.FindCurrentFloor` walks the list for the row whose map is the
+	## backup warp's, and quits the whole routine when none is: the car
+	## does not know where it is standing, so it does not move.
+	var rows: Array = floors["floors"]
+	var current: int = -1
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		if int(row["map_group"]) == int(world.backup_warp.get("map_group", -1)) \
+			and int(row["map_number"]) == int(world.backup_warp.get("map_number", -1)):
+			current = index
+			break
+	if current < 0:
+		return {"ok": false, "reason": &"elevator_floor_unknown"}
+	return {
+		"ok": true,
+		"data": {"elevator": {"floors": rows, "current": current}},
+	}
+
+
+static func _resolve_special_phone_call(world: Gen2WorldAPI, values: Dictionary) -> Dictionary:
+	var call_id: int = int(values.get("address", 0))
+	var special: Dictionary = Gen2WorldPhoneHost.resolve_special(
+		world.data, world.current_map, call_id, world.world_hour
+	)
+	if not bool(special.get("ok", false)):
+		return {
+			"ok": false,
+			"reason": StringName(special.get("reason", &"phone_data_unavailable")),
+		}
+	return {"ok": true, "data": special}
+
+
+static func _resolve_phone_call(
+	world: Gen2WorldAPI, request: Dictionary, values: Dictionary
+) -> Dictionary:
+	var source: Dictionary = request.get("source", {})
+	var address: int = int(values.get("address", 0))
+	if values.has("contact"):
+		var outgoing: Dictionary = Gen2WorldPhoneHost.resolve_outgoing(
+			world.data, world.state, world.current_map,
+			int(values.get("contact", -1)), world.world_hour
+		)
+		if not bool(outgoing.get("ok", false)):
+			return {
+				"ok": false,
+				"reason": StringName(outgoing.get("reason", &"phone_data_unavailable")),
+			}
+		return {"ok": true, "data": outgoing}
+	var bank: int = int(source.get("bank", -1))
+	var caller_name_raw: PackedByteArray = world.data.world_text(bank, address)
+	var caller_name: Dictionary = Gen2WorldScript.decode_text(caller_name_raw)
+	if not bool(caller_name.get("ok", false)):
+		return {"ok": false, "reason": &"phone_caller_name_unavailable"}
+	## The source phonecall command passes a text pointer directly to
+	## PhoneCall. It does not identify a phone contact or dispatch a
+	## contact script.
+	return {
+		"ok": true,
+		"data": {
+			"phone_call": {
+				"caller_name_pointer": {"bank": bank, "address": address},
+				"caller_name": String(caller_name.get("text", "")),
+			},
+			"phone": source.get("phone", {}).duplicate(true),
+		},
+	}
+
+
+static func _resolve_audio(world: Gen2WorldAPI, request: Dictionary) -> Dictionary:
+	var audio: Dictionary = audio_for_request(world, request)
+	var audio_kind: StringName = StringName(request.get("values", {}).get("kind", &""))
+	if audio.is_empty() and audio_kind != &"sound_wait":
+		return {"ok": false, "reason": &"audio_data_unavailable"}
+	return {"ok": true, "data": {"audio": audio}}
+
+
+static func _resolve_text_block(key: StringName, lines: Dictionary) -> Dictionary:
+	if lines.is_empty():
+		return {"ok": false, "reason": StringName("%s_unavailable" % key)}
+	return {"ok": true, "data": {key: lines}}
 
 ## The record one `audio_requested` resolves to, which is also what says a
 ## `PlaySlowCry` and a `cry` are one request with one field between them.

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1404,153 +1404,173 @@ static func _apply_party_request(
 	if kind == &"dratini_moveset_requested":
 		return _apply_dratini_moveset(world, candidate, request)
 	if kind == &"pokemon_requested":
-		var values: Dictionary = request.get("values", {})
-		var is_egg: bool = not values.has("pokemon")
-		var species: int = int(values.get("pokemon", values.get("value", 0)))
-		var level: int = int(values.get("level", values.get("value_2", 0)))
-		var held_item: int = int(values.get("item", 0))
-		if species <= 0 or world.data.species(species).is_empty():
-			return {"ok": false, "reason": &"unknown_species", "species": species}
-		if level < 1 or level > Gen2Experience.MAX_LEVEL:
-			return {"ok": false, "reason": &"invalid_level", "level": level}
-		if held_item < 0 or (held_item > 0 and world.data.item(held_item).is_empty()):
-			return {"ok": false, "reason": &"unknown_item", "item": held_item}
-		var mon: Gen2SaveMon = _new_mon(
-			world.data, candidate, species, level, held_item, random, is_egg
-		)
-		if mon == null:
-			return {"ok": false, "reason": &"could_not_create_pokemon"}
-		## `AddPartyMon`'s three caught-data branches. An egg's is overwritten by
-		## `SetEggMonCaughtData` when it hatches; a plain `givepoke` takes
-		## `SetCaughtData`, the map the player is standing on.
-		set_caught_data(
-			mon, level, world.object_time_of_day, world.player_female(), world.landmark_backup()
-		)
-		if is_egg:
-			## `GiveEgg` is `TryAddMonToParty` and nothing else, so a full party
-			## boxes no egg and leaves `Script_giveegg`'s own `xor a` in
-			## wScriptVar; only the `ret nc` past it writes 2.
-			if candidate.party.size() >= Gen2SaveData.MAX_PARTY:
-				return {
-					"ok": true, "accepted": false, "script_value": 0,
-					"reason": &"party_full",
-					"summary": {
-						"kind": &"egg", "accepted": false,
-						"species": species, "level": level,
-					},
-				}
-			return _append_mon(candidate, mon, 2, {
-				"kind": &"egg", "species": species, "level": level, "item": held_item,
-			})
-		var source: Dictionary = request.get("source", {})
-		var bank: int = int(source.get("bank", -1))
-		var nickname: String = _world_name(
-			world.data, bank, int(values.get("nickname_address", -1))
-		)
-		var ot_name: String = _world_name(
-			world.data, bank, int(values.get("ot_name_address", -1))
-		)
-		if not nickname.is_empty():
-			mon.nickname = nickname
-		if not ot_name.is_empty():
-			mon.original_trainer = ot_name
-			## `SetGiftPartyMonCaughtData`: a `givepoke` that names an OT is
-			## somebody's present, so its level byte is zero and its
-			## landmark is LANDMARK_GIFT rather than this map.
-			set_caught_data(mon, 0, -1, world.player_female(), LANDMARK_GIFT)
-		elif result.has("nickname"):
-			## `GiveANickname_YesNo` and `InitNickname`: the `.wildmon` branch,
-			## which is the thirteen `givepoke` sites that name no OT. The screen
-			## drew the question and the naming keyboard, and NO answers with the
-			## species name `.done` already left in the row.
-			var chosen: String = String(result["nickname"]).strip_edges()
-			if not chosen.is_empty():
-				mon.nickname = chosen
-		var appended: Dictionary = _append_mon(candidate, mon, 0, {
-			"kind": &"gift", "species": species, "level": level, "item": held_item,
-		})
-		if not bool(appended.get("ok", false)):
-			## `.FailedToGiveMon`'s `ld b, $2`: neither the party nor the box had
-			## room, so nothing is written and the script reads 2 and runs on.
-			if StringName(appended.get("reason", &"")) == &"storage_full":
-				return {
-					"ok": true, "accepted": false, "script_value": 2,
-					"reason": &"storage_full",
-					"summary": {
-						"kind": &"gift", "accepted": false,
-						"species": species, "level": level,
-					},
-				}
-			return appended
-		var destination: StringName = StringName(
-			(appended["summary"]["destination"] as Dictionary).get("destination", &"party")
-		)
-		if destination == &"box":
-			## `.skip_nickname`'s tail copies `wMonOrItemNameBuffer` over
-			## `sBoxMonNicknames` after `InitNickname` has written the player's
-			## entry, so a boxed gift always ends up with the species name.
-			mon.nickname = String(world.data.species(species).get("name", ""))
-			appended["script_value"] = 1
-		return appended
-
+		return _apply_pokemon_request(world, candidate, request, result, random)
 	if kind == &"trade_requested":
-		var values: Dictionary = request.get("values", {})
-		var trade_id: int = int(values.get("trade_id", -1))
-		var trade: Dictionary = world.data.world_trade(trade_id)
-		if trade.is_empty():
-			return {"ok": false, "reason": &"unknown_trade", "trade_id": trade_id}
-		## A visible-catalog site may name its own two halves. Applied to this
-		## call's COPY of the record: one cartridge trade row is named by more
-		## than one site, and writing the row would move the other one too. The
-		## nickname, OT, item and DVs stay the record's, since they belong to the
-		## Pokemon the cartridge wrote rather than to the species.
-		for half: Array in [
-			["offered_species", "offered_species"], ["requested_species", "requested_species"],
-		]:
-			if values.has(half[0]) and int(values[half[0]]) > 0:
-				trade[half[1]] = int(values[half[0]])
-		var requested_index: int = int(result.get("party_index", -1))
-		if requested_index < 0 or requested_index >= candidate.party.size():
-			requested_index = _find_trade_candidate(world.data, candidate, trade)
-		if requested_index < 0:
-			return {
-				"ok": true, "accepted": false, "script_value": 0,
-				"reason": &"requested_pokemon_missing",
-				"summary": {"kind": &"trade", "accepted": false, "trade_id": trade_id},
-			}
-		var requested: Gen2SaveMon = candidate.party[requested_index]
-		if requested.species != int(trade["requested_species"]):
-			return {"ok": false, "reason": &"trade_candidate_mismatch"}
-		if not _trade_gender_matches(
-			world.data, requested, int(trade.get("gender", RomLayout.TRADE_GENDER_EITHER))
-		):
-			return {"ok": false, "reason": &"trade_candidate_gender_mismatch"}
-		var received: Gen2SaveMon = _new_mon(
-			world.data, candidate, int(trade["offered_species"]), requested.level,
-			int(trade["item"]), random, false, int(trade["dvs"])
-		)
-		if received == null:
-			return {"ok": false, "reason": &"could_not_create_trade_pokemon"}
-		received.nickname = String(trade.get("nickname", ""))
-		received.original_trainer = String(trade.get("ot_name", ""))
-		received.ot_id = int(trade.get("ot_id", 0))
-		candidate.party[requested_index] = received
-		return {
-			"ok": true, "accepted": true, "script_value": 1,
-			"register_caught": received.species,
-			## A trade lands in the party slot the given Pokemon left, which is
-			## the PARTYMON `GeneratePartyMonStats` registers.
-			"register_unown": _unown_form(
-				received.species, received.dvs, {"destination": &"party"}
-			),
-			"summary": {
-				"kind": &"trade", "accepted": true, "trade_id": trade_id,
-				"given_species": requested.species,
-				"received_species": received.species,
-			},
-		}
+		return _apply_trade_request(world, candidate, request, result, random)
 	return {"ok": false, "reason": &"unsupported_party_request"}
 
+
+## `Script_givepoke` and `Script_giveegg`.
+static func _apply_pokemon_request(
+	world: Gen2WorldAPI,
+	candidate: Gen2SaveData,
+	request: Dictionary,
+	result: Dictionary,
+	random: RandomNumberGenerator
+) -> Dictionary:
+	var values: Dictionary = request.get("values", {})
+	var is_egg: bool = not values.has("pokemon")
+	var species: int = int(values.get("pokemon", values.get("value", 0)))
+	var level: int = int(values.get("level", values.get("value_2", 0)))
+	var held_item: int = int(values.get("item", 0))
+	if species <= 0 or world.data.species(species).is_empty():
+		return {"ok": false, "reason": &"unknown_species", "species": species}
+	if level < 1 or level > Gen2Experience.MAX_LEVEL:
+		return {"ok": false, "reason": &"invalid_level", "level": level}
+	if held_item < 0 or (held_item > 0 and world.data.item(held_item).is_empty()):
+		return {"ok": false, "reason": &"unknown_item", "item": held_item}
+	var mon: Gen2SaveMon = _new_mon(
+		world.data, candidate, species, level, held_item, random, is_egg
+	)
+	if mon == null:
+		return {"ok": false, "reason": &"could_not_create_pokemon"}
+	## `AddPartyMon`'s three caught-data branches. An egg's is overwritten by
+	## `SetEggMonCaughtData` when it hatches; a plain `givepoke` takes
+	## `SetCaughtData`, the map the player is standing on.
+	set_caught_data(
+		mon, level, world.object_time_of_day, world.player_female(), world.landmark_backup()
+	)
+	if is_egg:
+		## `GiveEgg` is `TryAddMonToParty` and nothing else, so a full party
+		## boxes no egg and leaves `Script_giveegg`'s own `xor a` in
+		## wScriptVar; only the `ret nc` past it writes 2.
+		if candidate.party.size() >= Gen2SaveData.MAX_PARTY:
+			return {
+				"ok": true, "accepted": false, "script_value": 0,
+				"reason": &"party_full",
+				"summary": {
+					"kind": &"egg", "accepted": false,
+					"species": species, "level": level,
+				},
+			}
+		return _append_mon(candidate, mon, 2, {
+			"kind": &"egg", "species": species, "level": level, "item": held_item,
+		})
+	var source: Dictionary = request.get("source", {})
+	var bank: int = int(source.get("bank", -1))
+	var nickname: String = _world_name(
+		world.data, bank, int(values.get("nickname_address", -1))
+	)
+	var ot_name: String = _world_name(
+		world.data, bank, int(values.get("ot_name_address", -1))
+	)
+	if not nickname.is_empty():
+		mon.nickname = nickname
+	if not ot_name.is_empty():
+		mon.original_trainer = ot_name
+		## `SetGiftPartyMonCaughtData`: a `givepoke` that names an OT is
+		## somebody's present, so its level byte is zero and its
+		## landmark is LANDMARK_GIFT rather than this map.
+		set_caught_data(mon, 0, -1, world.player_female(), LANDMARK_GIFT)
+	elif result.has("nickname"):
+		## `GiveANickname_YesNo` and `InitNickname`: the `.wildmon` branch,
+		## which is the thirteen `givepoke` sites that name no OT. The screen
+		## drew the question and the naming keyboard, and NO answers with the
+		## species name `.done` already left in the row.
+		var chosen: String = String(result["nickname"]).strip_edges()
+		if not chosen.is_empty():
+			mon.nickname = chosen
+	var appended: Dictionary = _append_mon(candidate, mon, 0, {
+		"kind": &"gift", "species": species, "level": level, "item": held_item,
+	})
+	if not bool(appended.get("ok", false)):
+		## `.FailedToGiveMon`'s `ld b, $2`: neither the party nor the box had
+		## room, so nothing is written and the script reads 2 and runs on.
+		if StringName(appended.get("reason", &"")) == &"storage_full":
+			return {
+				"ok": true, "accepted": false, "script_value": 2,
+				"reason": &"storage_full",
+				"summary": {
+					"kind": &"gift", "accepted": false,
+					"species": species, "level": level,
+				},
+			}
+		return appended
+	var destination: StringName = StringName(
+		(appended["summary"]["destination"] as Dictionary).get("destination", &"party")
+	)
+	if destination == &"box":
+		## `.skip_nickname`'s tail copies `wMonOrItemNameBuffer` over
+		## `sBoxMonNicknames` after `InitNickname` has written the player's
+		## entry, so a boxed gift always ends up with the species name.
+		mon.nickname = String(world.data.species(species).get("name", ""))
+		appended["script_value"] = 1
+	return appended
+
+
+## `Script_trade`, whose row is `world_trade`'s.
+static func _apply_trade_request(
+	world: Gen2WorldAPI,
+	candidate: Gen2SaveData,
+	request: Dictionary,
+	result: Dictionary,
+	random: RandomNumberGenerator
+) -> Dictionary:
+	var values: Dictionary = request.get("values", {})
+	var trade_id: int = int(values.get("trade_id", -1))
+	var trade: Dictionary = world.data.world_trade(trade_id)
+	if trade.is_empty():
+		return {"ok": false, "reason": &"unknown_trade", "trade_id": trade_id}
+	## A visible-catalog site may name its own two halves. Applied to this
+	## call's COPY of the record: one cartridge trade row is named by more
+	## than one site, and writing the row would move the other one too. The
+	## nickname, OT, item and DVs stay the record's, since they belong to the
+	## Pokemon the cartridge wrote rather than to the species.
+	for half: Array in [
+		["offered_species", "offered_species"], ["requested_species", "requested_species"],
+	]:
+		if values.has(half[0]) and int(values[half[0]]) > 0:
+			trade[half[1]] = int(values[half[0]])
+	var requested_index: int = int(result.get("party_index", -1))
+	if requested_index < 0 or requested_index >= candidate.party.size():
+		requested_index = _find_trade_candidate(world.data, candidate, trade)
+	if requested_index < 0:
+		return {
+			"ok": true, "accepted": false, "script_value": 0,
+			"reason": &"requested_pokemon_missing",
+			"summary": {"kind": &"trade", "accepted": false, "trade_id": trade_id},
+		}
+	var requested: Gen2SaveMon = candidate.party[requested_index]
+	if requested.species != int(trade["requested_species"]):
+		return {"ok": false, "reason": &"trade_candidate_mismatch"}
+	if not _trade_gender_matches(
+		world.data, requested, int(trade.get("gender", RomLayout.TRADE_GENDER_EITHER))
+	):
+		return {"ok": false, "reason": &"trade_candidate_gender_mismatch"}
+	var received: Gen2SaveMon = _new_mon(
+		world.data, candidate, int(trade["offered_species"]), requested.level,
+		int(trade["item"]), random, false, int(trade["dvs"])
+	)
+	if received == null:
+		return {"ok": false, "reason": &"could_not_create_trade_pokemon"}
+	received.nickname = String(trade.get("nickname", ""))
+	received.original_trainer = String(trade.get("ot_name", ""))
+	received.ot_id = int(trade.get("ot_id", 0))
+	candidate.party[requested_index] = received
+	return {
+		"ok": true, "accepted": true, "script_value": 1,
+		"register_caught": received.species,
+		## A trade lands in the party slot the given Pokemon left, which is
+		## the PARTYMON `GeneratePartyMonStats` registers.
+		"register_unown": _unown_form(
+			received.species, received.dvs, {"destination": &"party"}
+		),
+		"summary": {
+			"kind": &"trade", "accepted": true, "trade_id": trade_id,
+			"given_species": requested.species,
+			"received_species": received.species,
+		},
+	}
 
 ## `AddPartyMon`'s `.registerpokedex`, which an egg never reaches: the source
 ## checks `cp EGG` first and jumps past `SetSeenAndCaughtMon`, so a Pokemon is

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -720,6 +720,25 @@ func _draw() -> void:
 
 	var camera_pixels: Vector2 = _world.view_origin_pixels()
 	var background: Vector2 = _background_camera()
+	_draw_hidden_trees(background)
+	if not _transition_cells.is_empty():
+		_draw_transition(background)
+	if _transition_sprites == Gen2BattleTransition.SPRITES_NONE:
+		return
+
+	## `RespawnPlayerAndOpponent` at each outro's setup: from there the only map
+	## objects left in OAM are the player and, in a scripted battle, whoever
+	## `hLastTalked` names.
+	var battlers_only: bool = _transition_sprites == Gen2BattleTransition.SPRITES_BATTLERS
+	var drawn: Array = _row_entries(battlers_only)
+	_draw_row_entries(drawn, camera_pixels, background, battlers_only)
+	var player: Vector2 = _draw_player(background)
+	if battlers_only:
+		return
+	_draw_free_sprites(camera_pixels, player)
+
+
+func _draw_hidden_trees(background: Vector2) -> void:
 	## `Cut_Headbutt_GetPixelFacing`'s tree goes away while its own sprite
 	## animation plays, which the map quad knows nothing about: the four tiles of
 	## the cell are painted over with the tileset's own blank one.
@@ -740,17 +759,11 @@ func _draw() -> void:
 						Vector2(Gen2Tiles.TILE_WIDTH, Gen2Tiles.TILE_HEIGHT),
 					),
 				)
-	if not _transition_cells.is_empty():
-		_draw_transition(background)
-	if _transition_sprites == Gen2BattleTransition.SPRITES_NONE:
-		return
 
+
+func _row_entries(battlers_only: bool) -> Array:
 	var objects: Array = _world.visible_objects()
 	objects.sort_custom(_sort_objects)
-	## `RespawnPlayerAndOpponent` at each outro's setup: from there the only map
-	## objects left in OAM are the player and, in a scripted battle, whoever
-	## `hLastTalked` names.
-	var battlers_only: bool = _transition_sprites == Gen2BattleTransition.SPRITES_BATTLERS
 	## A mod's actors are drawn in the same pass and sorted into the same rows:
 	## a follower one cell below an NPC has to be drawn over it, and one cell
 	## above it under it. They carry no effect sprite and no grass of their own
@@ -781,6 +794,12 @@ func _draw() -> void:
 				"row": float(offset.y + neighbour.cell.y),
 			})
 	drawn.sort_custom(_sort_drawn)
+	return drawn
+
+
+func _draw_row_entries(
+	drawn: Array, camera_pixels: Vector2, background: Vector2, battlers_only: bool
+) -> void:
 	for entry: Dictionary in drawn:
 		if entry.has("actor"):
 			_draw_actor(entry["actor"], camera_pixels)
@@ -807,6 +826,9 @@ func _draw() -> void:
 		if not battlers_only:
 			_draw_effect_sprites(object.index, pixel)
 
+
+
+func _draw_player(background: Vector2) -> Vector2:
 	var player: Vector2 = Vector2(_world.player_view_pixel()) + SPRITE_LIFT
 	## The jump arc is a sprite offset, not a position: the shadow and the grass
 	## the hop leaves behind stay on the ground.
@@ -826,8 +848,11 @@ func _draw() -> void:
 		draw_rect(marker, PLAYER_COLOR, false, 1.0)
 		draw_line(marker.position, marker.end, PLAYER_COLOR, 1.0)
 		draw_line(Vector2(marker.end.x, marker.position.y), Vector2(marker.position.x, marker.end.y), PLAYER_COLOR, 1.0)
-	if battlers_only:
-		return
+	return player
+
+
+## The sprites the source draws from `wShadowOAMSprite36` up.
+func _draw_free_sprites(camera_pixels: Vector2, player: Vector2) -> void:
 	_draw_effect_sprites(-1, player)
 	## The tree sprite stands over its own cell rather than over an object, and
 	## the source draws every one of these from `wShadowOAMSprite36` up, which is
@@ -850,7 +875,6 @@ func _draw() -> void:
 		if bool(sprite.get("screen", false)):
 			_draw_effect_sprite(sprite, screen)
 	_draw_encounter_pulse(camera_pixels)
-
 
 ## `StartTrainerBattle_LoadPokeBallGraphics.copypals` writes the trainer palette
 ## over `wOBPals1/2 palette PAL_OW_TREE` and `PAL_OW_ROCK` as well as

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1265,6 +1265,62 @@ func press_button(button: int) -> bool:
 ## took it. A pause that owns the world swallows every button rather than
 ## refusing the ones it has no use for, which is what keeps a stray press from
 ## reaching the map behind it.
+## The overlays that own the whole screen, in the order a press is offered them.
+const OVERLAY_HOSTS: Array[StringName] = [
+	## In front of every other overlay: `EvolveAfterBattle` runs with the map
+	## loop suspended, and the pack path reaches it with the pack still open
+	## behind it, so its B is the animation's cancel rather than the pack's back.
+	&"_evolution_host",
+	## The same rule for `OverworldHatchEgg`, which `PlayerEvents` runs with the
+	## map loop suspended in exactly the same place.
+	&"_hatch_host",
+	## `GivePoke` runs inside `givepoke`, with the map loop suspended behind the
+	## script the same way, and its own naming screen is reached through it.
+	&"_nickname_host",
+	## `special NameRater` runs inside `opentext`, so the map loop is suspended
+	## behind it the same way and its own two screens are reached through it.
+	&"_name_rater_host",
+	## `special MoveTutor` and `special MoveDeletion`, the same shape again.
+	&"_move_tutor_host",
+	&"_move_deleter_host",
+	## The Day-Care's five, one screen with the same shape again.
+	&"_day_care_host",
+	## `special UnownPrinter`, which owns the whole screen until B off its list.
+	&"_unown_printer_host",
+	## `special Diploma`, which owns the whole screen until a button, and
+	## `special PrintDiploma`, which owns it until B.
+	&"_diploma_host",
+	## `special UnownPuzzle`, which owns the whole screen until START or the
+	## last piece.
+	&"_unown_puzzle_host",
+	## `special SlotMachine`, which owns the whole screen until the player says
+	## no to another game or runs out of coins.
+	&"_slot_machine_host",
+	## `special CardFlip`, the Game Corner's other machine, which owns the screen
+	## on the same terms.
+	&"_card_flip_host",
+	## Before the PC and the party overlay because the Hall of Fame is the one
+	## overlay a script opens with nothing behind it: there is no map to go back
+	## to until it has finished, and it takes no cancel.
+	&"_link_host",
+	&"_hall_of_fame_host",
+	&"_credits_host",
+	## `ReadPartyMonMail`, which `MonMailAction` opens over the party list and
+	## comes back to: it owns the screen while it is up.
+	&"_mail_host",
+	&"_party_host",
+]
+
+## The overlays that answer for themselves; a press one refuses reaches the map.
+const ANSWERING_HOSTS: Array[StringName] = [
+	&"_pokedex_host",
+	&"_trainer_card_host",
+	&"_mod_page_host",
+	&"_start_menu_host",
+	&"_service_host",
+]
+
+
 func _handle_button(button: int) -> bool:
 	## First, because a battle hides the map entirely and owns every button while
 	## it does. The fight takes it through this funnel rather than reading events
@@ -1273,116 +1329,19 @@ func _handle_button(button: int) -> bool:
 	if _battle_host != null:
 		_battle_host.press_button(button)
 		return true
-	## `DoBattleTransition` owns every frame between the encounter and the battle
-	## screen with the joypad unread, the same way a map fade does. Without it a
-	## press landing in those frames reached `script_input_waiting()` below and
-	## cancelled the request `startbattle` was waiting on, so the script died
-	## with `invalid_battle_outcome`: the fight still ran, and the gym leader's
-	## badge, the flag behind it and everything after it never arrived. A player
-	## holding A through a trainer's approach is what does it.
-	if not _map_fade.is_empty() or not _trainer_approach.is_empty() \
-		or _battle_transition != null or _world.phone_ring_active():
+	if _input_locked():
 		return true
-	## In front of every other overlay: `EvolveAfterBattle` runs with the map
-	## loop suspended, and the pack path reaches it with the pack still open
-	## behind it, so its B is the animation's cancel rather than the pack's back.
-	if _evolution_host != null:
-		_evolution_host.handle_button(button)
+	for host_name: StringName in OVERLAY_HOSTS:
+		var host: Object = get(host_name)
+		if host != null:
+			host.call(&"handle_button", button)
+			return true
+	if _handle_prompt_button(button):
 		return true
-	## The same rule for `OverworldHatchEgg`, which `PlayerEvents` runs with the
-	## map loop suspended in exactly the same place.
-	if _hatch_host != null:
-		_hatch_host.handle_button(button)
-		return true
-	## `GivePoke` runs inside `givepoke`, with the map loop suspended behind the
-	## script the same way, and its own naming screen is reached through it.
-	if _nickname_host != null:
-		_nickname_host.handle_button(button)
-		return true
-	## `special NameRater` runs inside `opentext`, so the map loop is suspended
-	## behind it the same way and its own two screens are reached through it.
-	if _name_rater_host != null:
-		_name_rater_host.handle_button(button)
-		return true
-	## `special MoveTutor` and `special MoveDeletion`, the same shape again.
-	if _move_tutor_host != null:
-		_move_tutor_host.handle_button(button)
-		return true
-	if _move_deleter_host != null:
-		_move_deleter_host.handle_button(button)
-		return true
-	## The Day-Care's five, one screen with the same shape again.
-	if _day_care_host != null:
-		_day_care_host.handle_button(button)
-		return true
-	## `special UnownPrinter`, which owns the whole screen until B off its list.
-	if _unown_printer_host != null:
-		_unown_printer_host.handle_button(button)
-		return true
-	## `special Diploma`, which owns the whole screen until a button, and
-	## `special PrintDiploma`, which owns it until B.
-	if _diploma_host != null:
-		_diploma_host.handle_button(button)
-		return true
-	## `special UnownPuzzle`, which owns the whole screen until START or the
-	## last piece.
-	if _unown_puzzle_host != null:
-		_unown_puzzle_host.handle_button(button)
-		return true
-	## `special SlotMachine`, which owns the whole screen until the player says
-	## no to another game or runs out of coins.
-	if _slot_machine_host != null:
-		_slot_machine_host.handle_button(button)
-		return true
-	## `special CardFlip`, the Game Corner's other machine, which owns the screen
-	## on the same terms.
-	if _card_flip_host != null:
-		_card_flip_host.handle_button(button)
-		return true
-	## Before the PC and the party overlay because the Hall of Fame is the one
-	## overlay a script opens with nothing behind it: there is no map to go back
-	## to until it has finished, and it takes no cancel.
-	if _link_host != null:
-		_link_host.handle_button(button)
-		return true
-	if _hall_of_fame_host != null:
-		_hall_of_fame_host.handle_button(button)
-		return true
-	if _credits_host != null:
-		_credits_host.handle_button(button)
-		return true
-	## `ReadPartyMonMail`, which `MonMailAction` opens over the party list and
-	## comes back to: it owns the screen while it is up.
-	if _mail_host != null:
-		_mail_host.handle_button(button)
-		return true
-	if _party_host != null:
-		_party_host.handle_button(button)
-		return true
-	if _field_move_text:
-		if button == Gen2Button.A:
-			_acknowledge_field_move_text()
-		return true
-	if not _oak_pc_pages.is_empty():
-		## `JoyWaitAorB`, which is what waits between each of the three texts.
-		if button in [Gen2Button.A, Gen2Button.B]:
-			_advance_prof_oaks_pc()
-		return true
-	if _unown_wall_box != null:
-		## `DisplayUnownWords`' own `JoyWaitAorB`, and the click it plays after.
-		if button in [Gen2Button.A, Gen2Button.B]:
-			_close_unown_wall()
-		return true
-	if _pokedex_host != null:
-		return _pokedex_host.handle_button(button)
-	if _trainer_card_host != null:
-		return _trainer_card_host.handle_button(button)
-	if _mod_page_host != null:
-		return _mod_page_host.handle_button(button)
-	if _start_menu_host != null:
-		return _start_menu_host.handle_button(button)
-	if _service_host != null:
-		return _service_host.handle_button(button)
+	for host_name: StringName in ANSWERING_HOSTS:
+		var host: Object = get(host_name)
+		if host != null:
+			return bool(host.call(&"handle_button", button))
 	if _world.fishing_busy():
 		if button == Gen2Button.A:
 			_handle_fishing_result(_world.advance_fishing())
@@ -1413,6 +1372,35 @@ func _handle_button(button: int) -> bool:
 			return true
 	return false
 
+
+## `DoBattleTransition` owns every frame between the encounter and the battle
+## screen with the joypad unread, the same way a map fade does. Without it a
+## press landing in those frames reached `script_input_waiting()` and cancelled
+## the request `startbattle` was waiting on, so the script died with
+## `invalid_battle_outcome`: the fight still ran, and the gym leader's badge, the
+## flag behind it and everything after it never arrived. A player holding A
+## through a trainer's approach is what does it.
+func _input_locked() -> bool:
+	return not _map_fade.is_empty() or not _trainer_approach.is_empty() \
+		or _battle_transition != null or _world.phone_ring_active()
+
+
+func _handle_prompt_button(button: int) -> bool:
+	if _field_move_text:
+		if button == Gen2Button.A:
+			_acknowledge_field_move_text()
+		return true
+	if not _oak_pc_pages.is_empty():
+		## `JoyWaitAorB`, which is what waits between each of the three texts.
+		if button in [Gen2Button.A, Gen2Button.B]:
+			_advance_prof_oaks_pc()
+		return true
+	if _unown_wall_box != null:
+		## `DisplayUnownWords`' own `JoyWaitAorB`, and the click it plays after.
+		if button in [Gen2Button.A, Gen2Button.B]:
+			_close_unown_wall()
+		return true
+	return false
 
 ## The two OPTION rows a box reads, applied on every box rather than once:
 ## `Textbox` reads wTextboxFrame and `PrintLetterDelay` reads the text speed as

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -1381,13 +1381,21 @@ func _dispatched_effects(function: String) -> Array[int]:
 
 ## Every row of `AI_Basic`'s redundancy table has an arm.
 func test_every_redundancy_row_has_a_handler() -> void:
-	var handled: Array[int] = _dispatched_effects("_apply_basic")
-	# Six rows are dispatched through a table rather than an arm, so the two
-	# tables count as dispatch too.
-	for effect: int in Gen2BattleAI.SCREEN_FOR_EFFECT.keys():
-		handled.append(int(effect))
-	for effect: int in Gen2BattleAI.WEATHER_FOR_EFFECT.keys():
-		handled.append(int(effect))
+	var handled: Array[int] = _dispatched_effects("_is_redundant_once")
+	# Most rows are dispatched through a table rather than an arm, so every
+	# table counts as dispatch too.
+	for table: Dictionary in [
+		Gen2BattleAI.SCREEN_FOR_EFFECT, Gen2BattleAI.WEATHER_FOR_EFFECT,
+		Gen2BattleAI.REDUNDANT_TARGET_SUBSTATUS, Gen2BattleAI.REDUNDANT_USER_SUBSTATUS,
+	]:
+		for effect: int in table.keys():
+			handled.append(int(effect))
+	for list: Array in [
+		Gen2BattleAI.STATUS_ONLY_EFFECTS, Gen2BattleAI.HEALING_EFFECTS,
+		Gen2BattleAI.SLEEP_REQUIRED_EFFECTS,
+	]:
+		for effect: int in list:
+			handled.append(int(effect))
 	var missing: Array[int] = []
 	for number: int in REDUNDANT_EFFECT_NUMBERS:
 		if not handled.has(number):

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37891
+const MAX_COMMENT_LINES: int = 37887
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Delete
 ## a line when you fix one. The test fails on a line that no longer names a
@@ -26,8 +26,6 @@ const MAX_COMMENT_LINES: int = 37891
 const OVER_COMPLEXITY: Array[String] = [
 	"game/audio/gen2_apu.gd:_render_square",
 	"game/audio/gen2_apu.gd:write",
-	"game/audio/gen2_sound_engine.gd:_parse_music_command",
-	"game/battle/ai.gd:_apply_basic",
 	"game/battle/battle_screen.gd:_handle_button",
 	"game/battle/battle_screen.gd:_refresh_menu_layer",
 	"game/battle/battle_screen.gd:start_world_battle",
@@ -38,7 +36,6 @@ const OVER_COMPLEXITY: Array[String] = [
 	"game/import/rom_importer.gd:_read_one_trainer",
 	"game/import/rom_importer.gd:_verify_gs_title",
 	"game/import/rom_importer.gd:_verify_presents_sprites",
-	"game/import/rom_importer.gd:import_rom",
 	"game/import/rom_importer.gd:verify_battle_graphics",
 	"game/import/rom_importer.gd:verify_battle_tower",
 	"game/import/rom_importer.gd:verify_mail",
@@ -55,14 +52,10 @@ const OVER_COMPLEXITY: Array[String] = [
 	"game/render/intro_movie_page.gd:_draw_background",
 	"game/save/party_screen.gd:_confirm",
 	"game/save/save_battle_adapter.gd:from_battle_party",
-	"game/save/save_data.gd:from_dict",
 	"game/save/save_validator.gd:validate",
 	"game/world/battle_tower.gd:action",
 	"game/world/intro_movie.gd:_run_scene",
 	"game/world/slot_machine.gd:_reel_action",
-	"game/world/start_menu_screen.gd:_confirm",
-	"game/world/start_menu_screen.gd:_hardware_image",
-	"game/world/start_menu_screen.gd:_move",
 	"game/world/world_animation.gd:tick",
 	"game/world/world_api.gd:_apply_object_movement",
 	"game/world/world_api.gd:_enqueue_script",
@@ -73,28 +66,21 @@ const OVER_COMPLEXITY: Array[String] = [
 	"game/world/world_decoration.gd:apply",
 	"game/world/world_encounter.gd:resolve",
 	"game/world/world_encounter.gd:resolve_fishing",
-	"game/world/world_host.gd:_resolve_data_request",
 	"game/world/world_mart_host.gd:purchase",
 	"game/world/world_party_host.gd:_apply_item_effect",
-	"game/world/world_party_host.gd:_apply_party_request",
 	"game/world/world_party_host.gd:capture_wild",
 	"game/world/world_party_host.gd:teach_tm_hm",
-	"game/world/world_renderer.gd:_draw",
 	"game/world/world_screen.gd:_apply_interface_mask",
-	"game/world/world_screen.gd:_handle_button",
 	"game/world/world_screen.gd:_overlay_open",
 	"game/world/world_screen.gd:_run_party_action",
 	"game/world/world_script.gd:scan_references",
 	"game/world/world_script_runner.gd:_complete",
 	"game/world/world_script_runner.gd:_read_runtime_variable",
 	"game/world/world_service_screen.gd:_confirm_pc_row",
-	"tools/checks/opening_lane.gd:_validate",
 	"tools/checks/pokedex.gd:_validate",
 	"tools/checks/radio.gd:_verify_shows",
-	"tools/preview_battle_switch.gd:_open",
 	"tools/preview_town_map.gd:_initialize",
 	"tools/preview_world.gd:_initialize",
-	"tools/record_clip.gd:_initialize",
 	"tools/record_clip.gd:_process",
 	"tools/trace_world_script.gd:_run",
 ]

--- a/tools/checks/cinnabar.gd
+++ b/tools/checks/cinnabar.gd
@@ -428,8 +428,7 @@ func _verify_viridian_gym(data: GameData, game_id: StringName) -> void:
 	])
 
 
-## The map [param region] crosses onto over [param axis], as the first edge cell
-## in it that really connects. Empty when the region reaches no such edge.
+## The map [param region] crosses onto over [param axis], as `mt_silver.gd` has it.
 func _crossing(world: Gen2WorldAPI, region: Dictionary, axis: String) -> Dictionary:
 	var size: Vector2i = world.map_size_cells()
 	var direction: Vector2i = {

--- a/tools/checks/fuchsia.gd
+++ b/tools/checks/fuchsia.gd
@@ -258,8 +258,7 @@ func _verify_gym(data: GameData, game_id: StringName) -> void:
 	])
 
 
-## Every cell in [param region] a trainer sees the player on, as object index to
-## the set of cells.
+## Every cell in [param region] a trainer sees the player on, by object index.
 func _sight_lines(
 	data: GameData, group: int, number: int, region: Dictionary
 ) -> Dictionary:

--- a/tools/checks/opening_lane.gd
+++ b/tools/checks/opening_lane.gd
@@ -44,59 +44,14 @@ func _validate(game_id: StringName) -> bool:
 	if data.id != game_id:
 		failures.append("source_profile_mismatch:%s" % data.id)
 	var counts: Dictionary = {}
-	for section: String in REQUIRED_SECTIONS:
-		var path: String = "%s/%s" % [data.directory, REQUIRED_SECTIONS[section]]
-		var value: Variant = RomCache.read_json(path)
-		if (value is Dictionary and (value as Dictionary).is_empty()) \
-			or (value is Array and (value as Array).is_empty()) \
-			or value == null:
-			failures.append("missing_%s" % section)
-		else:
-			counts[section] = value.size()
-
-	var home: Gen2WorldMap = data.world_map(24, Gen2WorldSpawn.PLAYERS_HOUSE_2F)
-	var town: Gen2WorldMap = data.world_map(24, 4)
-	if home == null:
-		failures.append("missing_bedroom_map:24:7")
-	if town == null:
-		failures.append("missing_new_bark_map:24:4")
-	for map: Gen2WorldMap in [home, town]:
-		if map == null:
-			continue
-		var tileset: Gen2WorldTileset = data.world_tileset(map.tileset)
-		if tileset == null or tileset.meta.is_empty() or tileset.collision.is_empty():
-			failures.append("missing_graphics_or_collision:map_%d_%d" % [map.group, map.number])
-		if map.blocks.is_empty() or map.collision.is_empty():
-			failures.append("missing_map_payload:map_%d_%d" % [map.group, map.number])
-
-	for table: int in 4:
-		if data.name_input_chars(table).is_empty():
-			failures.append("missing_name_keyboard:%d" % table)
-	for key: String in ["oak_1", "oak_2", "oak_4", "oak_5", "oak_6", "oak_7"]:
-		if data.intro_text(key).is_empty():
-			failures.append("missing_intro_text:%s" % key)
-	if game_id == &"crystal" and data.intro_text("gender").is_empty():
-		failures.append("missing_crystal_gender_text")
-
 	var audio_counts: Dictionary = data.world_service_counts()
-	for kind: String in ["music", "sfx", "cries"]:
-		if int(audio_counts.get(kind, 0)) <= 0:
-			failures.append("missing_audio:%s" % kind)
-	for asset: StringName in [&"wave_samples", &"drumkits"]:
-		if data.world_audio_asset_bytes(asset).is_empty():
-			failures.append("missing_audio_payload:%s" % asset)
-
+	failures.append_array(_audit_sections(data, counts))
+	failures.append_array(_audit_starting_maps(data))
+	failures.append_array(_audit_opening_text(data, game_id))
+	failures.append_array(_audit_audio_assets(data, audio_counts))
 	if counts.get("movements", 0) == 0:
 		failures.append("missing_movement_data")
-	for kind: StringName in [&"music", &"sfx", &"cries"]:
-		var kind_count: int = int(audio_counts.get(String(kind), 0))
-		for index: int in kind_count:
-			var record: Dictionary = data.world_audio(kind, index)
-			if record.is_empty():
-				failures.append("missing_audio_record:%s:%d" % [kind, index])
-			elif record.get("bytes", PackedByteArray()).is_empty():
-				failures.append("missing_audio_record_payload:%s:%d" % [kind, index])
-
+	failures.append_array(_audit_audio_records(data, audio_counts))
 	failures.append_array(_audit_opening_music(data))
 	failures.append_array(_audit_title_backdrop(data))
 
@@ -122,6 +77,74 @@ func _validate(game_id: StringName) -> bool:
 	print("  opening_lane=invalid failures=%s" % JSON.stringify(failures))
 	return false
 
+
+func _audit_sections(data: GameData, counts: Dictionary) -> Array[String]:
+	var out: Array[String] = []
+	for section: String in REQUIRED_SECTIONS:
+		var path: String = "%s/%s" % [data.directory, REQUIRED_SECTIONS[section]]
+		var value: Variant = RomCache.read_json(path)
+		if (value is Dictionary and (value as Dictionary).is_empty()) \
+			or (value is Array and (value as Array).is_empty()) \
+			or value == null:
+			out.append("missing_%s" % section)
+		else:
+			counts[section] = value.size()
+	return out
+
+
+func _audit_starting_maps(data: GameData) -> Array[String]:
+	var out: Array[String] = []
+	var home: Gen2WorldMap = data.world_map(24, Gen2WorldSpawn.PLAYERS_HOUSE_2F)
+	var town: Gen2WorldMap = data.world_map(24, 4)
+	if home == null:
+		out.append("missing_bedroom_map:24:7")
+	if town == null:
+		out.append("missing_new_bark_map:24:4")
+	for map: Gen2WorldMap in [home, town]:
+		if map == null:
+			continue
+		var tileset: Gen2WorldTileset = data.world_tileset(map.tileset)
+		if tileset == null or tileset.meta.is_empty() or tileset.collision.is_empty():
+			out.append("missing_graphics_or_collision:map_%d_%d" % [map.group, map.number])
+		if map.blocks.is_empty() or map.collision.is_empty():
+			out.append("missing_map_payload:map_%d_%d" % [map.group, map.number])
+	return out
+
+
+func _audit_opening_text(data: GameData, game_id: StringName) -> Array[String]:
+	var out: Array[String] = []
+	for table: int in 4:
+		if data.name_input_chars(table).is_empty():
+			out.append("missing_name_keyboard:%d" % table)
+	for key: String in ["oak_1", "oak_2", "oak_4", "oak_5", "oak_6", "oak_7"]:
+		if data.intro_text(key).is_empty():
+			out.append("missing_intro_text:%s" % key)
+	if game_id == &"crystal" and data.intro_text("gender").is_empty():
+		out.append("missing_crystal_gender_text")
+	return out
+
+
+func _audit_audio_assets(data: GameData, audio_counts: Dictionary) -> Array[String]:
+	var out: Array[String] = []
+	for kind: String in ["music", "sfx", "cries"]:
+		if int(audio_counts.get(kind, 0)) <= 0:
+			out.append("missing_audio:%s" % kind)
+	for asset: StringName in [&"wave_samples", &"drumkits"]:
+		if data.world_audio_asset_bytes(asset).is_empty():
+			out.append("missing_audio_payload:%s" % asset)
+	return out
+
+
+func _audit_audio_records(data: GameData, audio_counts: Dictionary) -> Array[String]:
+	var out: Array[String] = []
+	for kind: StringName in [&"music", &"sfx", &"cries"]:
+		for index: int in int(audio_counts.get(String(kind), 0)):
+			var record: Dictionary = data.world_audio(kind, index)
+			if record.is_empty():
+				out.append("missing_audio_record:%s:%d" % [kind, index])
+			elif record.get("bytes", PackedByteArray()).is_empty():
+				out.append("missing_audio_record_payload:%s:%d" % [kind, index])
+	return out
 
 ## What the title screen puts around itself in a window that is not 10:9.
 ##

--- a/tools/checks/pewter.gd
+++ b/tools/checks/pewter.gd
@@ -325,8 +325,7 @@ func _verify_pewter(data: GameData, game_id: StringName, crystal: bool) -> void:
 	])
 
 
-## Every cell in [param region] a trainer sees the player on, as object index to
-## the set of cells.
+## Every cell in [param region] a trainer sees the player on, by object index.
 func _sight_lines(
 	data: GameData, group: int, number: int, region: Dictionary
 ) -> Dictionary:
@@ -345,8 +344,7 @@ func _sight_lines(
 	return out
 
 
-## The map [param region] crosses onto over [param axis], as the first edge cell
-## in it that really connects. Empty when the region reaches no such edge.
+## The map [param region] crosses onto over [param axis], as `mt_silver.gd` has it.
 func _crossing(world: Gen2WorldAPI, region: Dictionary, axis: String) -> Dictionary:
 	var size: Vector2i = world.map_size_cells()
 	var direction: Vector2i = {

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -211,123 +211,135 @@ func _informing() -> bool:
 
 
 func _open() -> void:
+	if _stage == "prize":
+		_open_prize()
+		return
+	if _stage == "contest_replace":
+		_open_contest_replace()
+		return
+	if _stage in WORLD_STAGES:
+		_open_world_stage()
+		return
+	_open_battle_stage()
+
+
+## `GotMoneyForWinningText`, reached by winning the fight rather than staging it.
+func _open_prize() -> void:
+	## `.give_money` prints it behind `PrintWinLossText`, and the reward is
+	## `ComputeTrainerReward`'s off the party the request built.
+	_screen.start_world_battle({"values": {
+		"kind": &"trainer", "trainer_group": TRAINER_CLASS, "trainer_id": 0,
+	}})
+	var fight: Gen2Battle = _screen.get("_battle")
+	fight.player.item = AMULET_COIN
+	_screen.set("_pending", fight.entrance_events(Gen2Battle.PLAYER))
+	_drain_to_menu()
+	## Each of Falkner's two is put on one hit point and knocked out by the
+	## lead's first move. The switch offer his bench opens is declined, since
+	## what is being photographed is the line behind the last faint.
+	for _step: int in 400:
+		_settle()
+		var snapshot: Dictionary = _screen.battle_snapshot()
+		if "for winning" in String(snapshot["message"]):
+			## The box is still revealing on the frame it is spotted, and
+			## the figure is the whole point of the picture.
+			_read_question()
+			_settle()
+			return
+		if String(snapshot["switch_stage"]) != "":
+			_read_question()
+			_screen._handle_button(Gen2Button.B)
+			continue
+		if String(snapshot["menu_stage"]) == "main" and not fight.is_over():
+			fight.enemy.hp = 1
+			_screen.set("_pending", fight.take_actions(
+				Gen2Battle.use_move(0), Gen2Battle.use_move(0)
+			))
+		_screen.finish()
+		_screen.advance()
+	push_error("the prize line was never reached")
+
+
+## A Park Ball thrown and caught while `wContestMon` already holds one, which is
+## the only way to `DisplayAlreadyCaughtText` and the comparison behind it. A wild
+## through the world's own path, since a capture needs one; the result is written
+## rather than rolled, because what is photographed is the page and a real throw
+## would have to be repeated until it stuck.
+func _open_contest_replace() -> void:
+	_screen.start_world_battle({"values": {
+		"kind": &"wild", "pokemon": CONTEST_WILD_SPECIES,
+		"level": CONTEST_WILD_LEVEL,
+		"battle_type": Gen2Battle.BATTLETYPE_CONTEST,
+	}})
+	_screen.set_capture_balls(
+		[Gen2WorldPartyHost.ITEM_PARK_BALL],
+		{Gen2WorldPartyHost.ITEM_PARK_BALL: Gen2WorldBugContest.BALLS}
+	)
+	_drain_to_menu()
+	_screen.begin_capture()
+	_screen.select_capture_ball(0)
+	_screen.throw_capture_ball()
+	_screen.complete_capture({
+		"ok": true, "contest": true, "caught": true, "wobbles": 3,
+		"ball": Gen2WorldPartyHost.ITEM_PARK_BALL,
+		"quantity": Gen2WorldBugContest.BALLS - 1,
+		"replace_offer": true,
+		"mon": Gen2WorldPartyHost.contest_mon_from(_screen.capture_target()),
+		"stock_species": CONTEST_STOCK_SPECIES,
+		"stock_level": CONTEST_STOCK_LEVEL,
+		"stock_max_hp": CONTEST_STOCK_MAX_HP,
+	})
+	## The throw's animation, then the shake lines and
+	## `DisplayAlreadyCaughtText`, each prompted past the way a player would.
+	for _press: int in 20:
+		_settle()
+		if String(_screen.battle_snapshot()["switch_stage"]) == "contest_replace":
+			break
+		_screen.finish()
+		_screen.advance()
+	_read_question()
+	_settle_icons()
+
+
+## The wild the world starts, entered the way a step into the grass does:
+## `BATTLETYPE_FORCESHINY` is what writes the shiny word, so the picture is the
+## cartridge's own forced shiny rather than a number typed in here.
+func _open_world_stage() -> void:
+	var values: Dictionary = {
+		"kind": &"wild", "pokemon": SHINY_SPECIES, "level": SHINY_LEVEL,
+	}
+	if _stage == "shiny":
+		values["battle_type"] = Gen2Battle.BATTLETYPE_FORCESHINY
+	else:
+		## Named rather than rolled, so the two pictures differ in the four
+		## numbers alone: an unnamed wild would roll and could be anything.
+		values["dvs"] = Gen2BattleMon.PERFECT_DVS
+	_screen.start_world_battle({"values": values})
+	## Both sides in one picture: `CGB_BattleColors` reads `CheckShininess`
+	## for the back pic as well, and the player's own party is the only place
+	## a shiny back pic can come from. Written after the battle is built and
+	## the display re-read, since the palette is chosen there.
+	var started: Gen2Battle = _screen.get("_battle")
+	if started != null:
+		started.player.dvs = Gen2Stats.SHINY_DVS if _stage == "shiny" \
+			else Gen2BattleMon.PERFECT_DVS
+		_screen._init_battle_display()
+	_drain_to_menu()
+	## The second `_init_battle_display` leaves a shorter event queue behind
+	## it, so the drain can land a press further in than it does without one.
+	## Backed out rather than counted, so both stages photograph the same
+	## screen and the two pictures differ in the palettes alone.
+	for _press: int in 4:
+		if String(_screen.battle_snapshot()["menu_stage"]) == "main":
+			break
+		_screen._handle_button(Gen2Button.B)
+		_settle()
+
+
+func _open_battle_stage() -> void:
 	var data: GameData = _screen.get("_data")
 	var rng := RandomNumberGenerator.new()
 	rng.seed = 3
-
-	## The wild the world starts, entered the way a step into the grass does:
-	## `BATTLETYPE_FORCESHINY` is what writes the shiny word, so the picture is
-	## the cartridge's own forced shiny rather than a number typed in here.
-	if _stage == "prize":
-		## `GotMoneyForWinningText`, which `.give_money` prints behind
-		## `PrintWinLossText`. The fight is won rather than staged: the reward
-		## is `ComputeTrainerReward`'s, off the party the request built.
-		_screen.start_world_battle({"values": {
-			"kind": &"trainer", "trainer_group": TRAINER_CLASS, "trainer_id": 0,
-		}})
-		var fight: Gen2Battle = _screen.get("_battle")
-		fight.player.item = AMULET_COIN
-		_screen.set("_pending", fight.entrance_events(Gen2Battle.PLAYER))
-		_drain_to_menu()
-		## Each of Falkner's two is put on one hit point and knocked out by the
-		## lead's first move. The switch offer his bench opens is declined, since
-		## what is being photographed is the line behind the last faint.
-		for _step: int in 400:
-			_settle()
-			var snapshot: Dictionary = _screen.battle_snapshot()
-			if "for winning" in String(snapshot["message"]):
-				## The box is still revealing on the frame it is spotted, and
-				## the figure is the whole point of the picture.
-				_read_question()
-				_settle()
-				return
-			if String(snapshot["switch_stage"]) != "":
-				_read_question()
-				_screen._handle_button(Gen2Button.B)
-				continue
-			if String(snapshot["menu_stage"]) == "main" and not fight.is_over():
-				fight.enemy.hp = 1
-				_screen.set("_pending", fight.take_actions(
-					Gen2Battle.use_move(0), Gen2Battle.use_move(0)
-				))
-			_screen.finish()
-			_screen.advance()
-		push_error("the prize line was never reached")
-		return
-
-	## A Park Ball thrown and caught while `wContestMon` already holds one, which
-	## is the only way to `DisplayAlreadyCaughtText` and the comparison behind
-	## it. A wild through the world's own path, since a capture needs one; the
-	## result is written rather than rolled, because what is photographed is the
-	## page and a real throw would have to be repeated until it stuck.
-	if _stage == "contest_replace":
-		_screen.start_world_battle({"values": {
-			"kind": &"wild", "pokemon": CONTEST_WILD_SPECIES,
-			"level": CONTEST_WILD_LEVEL,
-			"battle_type": Gen2Battle.BATTLETYPE_CONTEST,
-		}})
-		_screen.set_capture_balls(
-			[Gen2WorldPartyHost.ITEM_PARK_BALL],
-			{Gen2WorldPartyHost.ITEM_PARK_BALL: Gen2WorldBugContest.BALLS}
-		)
-		_drain_to_menu()
-		_screen.begin_capture()
-		_screen.select_capture_ball(0)
-		_screen.throw_capture_ball()
-		_screen.complete_capture({
-			"ok": true, "contest": true, "caught": true, "wobbles": 3,
-			"ball": Gen2WorldPartyHost.ITEM_PARK_BALL,
-			"quantity": Gen2WorldBugContest.BALLS - 1,
-			"replace_offer": true,
-			"mon": Gen2WorldPartyHost.contest_mon_from(_screen.capture_target()),
-			"stock_species": CONTEST_STOCK_SPECIES,
-			"stock_level": CONTEST_STOCK_LEVEL,
-			"stock_max_hp": CONTEST_STOCK_MAX_HP,
-		})
-		## The throw's animation, then the shake lines and
-		## `DisplayAlreadyCaughtText`, each prompted past the way a player would.
-		for _press: int in 20:
-			_settle()
-			if String(_screen.battle_snapshot()["switch_stage"]) == "contest_replace":
-				break
-			_screen.finish()
-			_screen.advance()
-		_read_question()
-		_settle_icons()
-		return
-
-	if _stage in WORLD_STAGES:
-		var values: Dictionary = {
-			"kind": &"wild", "pokemon": SHINY_SPECIES, "level": SHINY_LEVEL,
-		}
-		if _stage == "shiny":
-			values["battle_type"] = Gen2Battle.BATTLETYPE_FORCESHINY
-		else:
-			## Named rather than rolled, so the two pictures differ in the four
-			## numbers alone: an unnamed wild would roll and could be anything.
-			values["dvs"] = Gen2BattleMon.PERFECT_DVS
-		_screen.start_world_battle({"values": values})
-		## Both sides in one picture: `CGB_BattleColors` reads `CheckShininess`
-		## for the back pic as well, and the player's own party is the only place
-		## a shiny back pic can come from. Written after the battle is built and
-		## the display re-read, since the palette is chosen there.
-		var started: Gen2Battle = _screen.get("_battle")
-		if started != null:
-			started.player.dvs = Gen2Stats.SHINY_DVS if _stage == "shiny" \
-				else Gen2BattleMon.PERFECT_DVS
-			_screen._init_battle_display()
-		_drain_to_menu()
-		## The second `_init_battle_display` leaves a shorter event queue behind
-		## it, so the drain can land a press further in than it does without one.
-		## Backed out rather than counted, so both stages photograph the same
-		## screen and the two pictures differ in the palettes alone.
-		for _press: int in 4:
-			if String(_screen.battle_snapshot()["menu_stage"]) == "main":
-				break
-			_screen._handle_button(Gen2Button.B)
-			_settle()
-		return
-
 	var members: Array = []
 	for species: int in PLAYER_SPECIES:
 		var lead: Array[int] = INFO_MOVES if _informing() else LEAD_MOVES
@@ -396,51 +408,7 @@ func _open() -> void:
 	## Both menu stages are what the intro leads into with nothing else staged,
 	## which is `BattleMenu`'s own first opening.
 	if _stage in MENU_STAGES:
-		## The state an information provider reads, which is the stage rather
-		## than the provider: a seen opponent, weather on, and two stages moved.
-		## Only `info` registers this tool's own, so a capture of a mod's
-		## annotations has exactly one provider answering and cannot attribute
-		## one mod's placements to the other.
-		if _informing():
-			## What `SetSeenMon` would have left behind, since a first sighting is
-			## not something the Pokedex could have told the player about.
-			_screen.set("_enemy_seen_before", true)
-			battle.weather = Gen2Weather.SUN
-			battle.weather_turns = 3
-			battle.player.stages["attack"] = 2
-			battle.player.stages["speed"] = -1
-		## The annotations are a mod's, over the move list they describe: the
-		## provider is synthetic and everything it is handed, and everything drawn
-		## from what it answers, is the host's.
-		if _stage == "info":
-			Gen2ModHost.instance().register_battle_info(&"preview", Annotations.new())
-		_drain_to_menu()
-		if _stage in ["move", "info"]:
-			_screen._handle_button(Gen2Button.A)
-		## `BattlePack`'s own list, over the bag the world hands the battle. The
-		## rows are a real cache's items, so the picture reads as the pack.
-		if _stage in ["pack", "info_pack"]:
-			_screen.set_battle_pack(PACK_ITEMS, PACK_QUANTITIES)
-			_screen._handle_button(Gen2Button.DOWN)
-			_screen._handle_button(Gen2Button.A)
-		## The BALL pocket of the same list. Every row of
-		## `BallMultiplierFunctionTable` is reachable, so the picture is the
-		## whole of what a player can throw.
-		if _stage == "balls":
-			_screen.set_battle_pack(
-				Gen2WorldPartyHost.capture_ball_items(), BALL_QUANTITIES
-			)
-			_screen._handle_button(Gen2Button.DOWN)
-			_screen._handle_button(Gen2Button.A)
-		## `BattleMenu_PKMN`'s party page, the other modal that covers the same
-		## cells: RIGHT from FIGHT is PKMN.
-		if _stage == "info_pkmn":
-			_screen._handle_button(Gen2Button.RIGHT)
-			_screen._handle_button(Gen2Button.A)
-		for press: String in _presses:
-			_screen._handle_button(_button(press))
-		_screen.finish()
-		_settle_icons()
+		_open_menu_stage(battle)
 		return
 
 	_drain()
@@ -456,6 +424,54 @@ func _open() -> void:
 	_screen.finish()
 	_settle_icons()
 
+
+## `BattleMenu`'s own first opening, with nothing else staged.
+func _open_menu_stage(battle: Gen2Battle) -> void:
+	## The state an information provider reads, which is the stage rather
+	## than the provider: a seen opponent, weather on, and two stages moved.
+	## Only `info` registers this tool's own, so a capture of a mod's
+	## annotations has exactly one provider answering and cannot attribute
+	## one mod's placements to the other.
+	if _informing():
+		## What `SetSeenMon` would have left behind, since a first sighting is
+		## not something the Pokedex could have told the player about.
+		_screen.set("_enemy_seen_before", true)
+		battle.weather = Gen2Weather.SUN
+		battle.weather_turns = 3
+		battle.player.stages["attack"] = 2
+		battle.player.stages["speed"] = -1
+	## The annotations are a mod's, over the move list they describe: the
+	## provider is synthetic and everything it is handed, and everything drawn
+	## from what it answers, is the host's.
+	if _stage == "info":
+		Gen2ModHost.instance().register_battle_info(&"preview", Annotations.new())
+	_drain_to_menu()
+	if _stage in ["move", "info"]:
+		_screen._handle_button(Gen2Button.A)
+	## `BattlePack`'s own list, over the bag the world hands the battle. The
+	## rows are a real cache's items, so the picture reads as the pack.
+	if _stage in ["pack", "info_pack"]:
+		_screen.set_battle_pack(PACK_ITEMS, PACK_QUANTITIES)
+		_screen._handle_button(Gen2Button.DOWN)
+		_screen._handle_button(Gen2Button.A)
+	## The BALL pocket of the same list. Every row of
+	## `BallMultiplierFunctionTable` is reachable, so the picture is the
+	## whole of what a player can throw.
+	if _stage == "balls":
+		_screen.set_battle_pack(
+			Gen2WorldPartyHost.capture_ball_items(), BALL_QUANTITIES
+		)
+		_screen._handle_button(Gen2Button.DOWN)
+		_screen._handle_button(Gen2Button.A)
+	## `BattleMenu_PKMN`'s party page, the other modal that covers the same
+	## cells: RIGHT from FIGHT is PKMN.
+	if _stage == "info_pkmn":
+		_screen._handle_button(Gen2Button.RIGHT)
+		_screen._handle_button(Gen2Button.A)
+	for press: String in _presses:
+		_screen._handle_button(_button(press))
+	_screen.finish()
+	_settle_icons()
 
 ## The icons animate on their own clock, so the screen keeps stepping them
 ## across the frames this tool spends laying the scene out. Taking its

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -72,6 +72,7 @@ var _cell := Vector2i(-1, -1)
 var _facing: int = -1
 var _hour: int = -1
 var _seed: int = 1
+var _mash: String = ""
 var _kind: StringName = SCREEN_WORLD
 var _challenge: StringName = Gen2Rules.CHALLENGE_VANILLA
 ## Each member as `{species, level, shiny, hp, brink}`, or empty for the default
@@ -251,71 +252,14 @@ func _initialize() -> void:
 		_quit_failed()
 		return
 
-	var cell := Vector2i(-1, -1)
-	var hour: int = -1
-	var seed_value: int = 1
-	## Expanded after the whole line is read, since its default last frame is
-	## `seconds=`, which may be named after it.
-	var mash: String = ""
 	for extra: String in args.slice(3):
 		var key: String = extra.get_slice("=", 0)
 		var value: String = extra.substr(key.length() + 1)
-		match key:
-			"cell":
-				cell = Vector2i(int(value.get_slice(",", 0)), int(value.get_slice(",", 1)))
-			"facing":
-				_facing = _facing_for(value)
-			"hour":
-				hour = int(value)
-			"view":
-				_view = StringName(value)
-			"size":
-				_window = Vector2i(int(value.get_slice("x", 0)), int(value.get_slice("x", 1)))
-			"seconds":
-				_length = int(maxf(0.1, float(value)) * FRAMES_PER_SECOND)
-			"seed":
-				seed_value = int(value)
-			"hold":
-				_hold = _direction(value)
-			"screen":
-				_kind = StringName(value)
-			"challenge":
-				_challenge = StringName(value)
-			"party":
-				_party = _parse_party(value)
-			"items":
-				_items = _parse_items(value)
-			"flags":
-				for raw: String in value.split(",", false):
-					_flags.append(int(raw))
-			"progress":
-				_progress = _parse_progress(value)
-			"read":
-				_read_gap = maxi(int(value), 0)
-			"beat":
-				_beat_gap = maxi(int(value), 0)
-			"text":
-				_auto_text = value == "auto"
-			"always":
-				_always[StringName(value.get_slice(":", 0))] = \
-					value.substr(value.find(":") + 1)
-			"at":
-				_waits.append({
-					"state": StringName(value.get_slice(":", 0)),
-					"action": value.substr(value.find(":") + 1),
-				})
-			"mash":
-				mash = value
-			"do":
-				_add_action(int(value.get_slice(":", 0)), value.substr(value.find(":") + 1))
-			"warmup":
-				_warmup = maxi(2, int(value))
-			"probe":
-				_probe = StringName(value)
-			_:
-				push_error("Unknown option: %s" % extra)
-				_quit_failed()
-				return
+		if _read_scalar_option(key, value) or _read_staging_option(key, value):
+			continue
+		push_error("Unknown option: %s" % extra)
+		_quit_failed()
+		return
 
 	if _kind not in [SCREEN_WORLD, SCREEN_SAVES]:
 		push_error("Unknown screen: %s" % _kind)
@@ -326,14 +270,77 @@ func _initialize() -> void:
 		_quit_failed()
 		return
 
-	if not mash.is_empty():
-		_add_mash(mash)
+	## Expanded once the whole line is read, since its default last frame is
+	## `seconds=`, which may be named after it.
+	if not _mash.is_empty():
+		_add_mash(_mash)
 	_game = StringName(args[0])
 	_map = Vector2i(int(args[1]), int(args[2]))
-	_cell = cell
-	_hour = hour
-	_seed = seed_value
 
+
+func _read_scalar_option(key: String, value: String) -> bool:
+	match key:
+		"cell":
+			_cell = Vector2i(int(value.get_slice(",", 0)), int(value.get_slice(",", 1)))
+		"facing":
+			_facing = _facing_for(value)
+		"hour":
+			_hour = int(value)
+		"view":
+			_view = StringName(value)
+		"size":
+			_window = Vector2i(int(value.get_slice("x", 0)), int(value.get_slice("x", 1)))
+		"seconds":
+			_length = int(maxf(0.1, float(value)) * FRAMES_PER_SECOND)
+		"seed":
+			_seed = int(value)
+		"hold":
+			_hold = _direction(value)
+		"screen":
+			_kind = StringName(value)
+		"challenge":
+			_challenge = StringName(value)
+		"read":
+			_read_gap = maxi(int(value), 0)
+		"beat":
+			_beat_gap = maxi(int(value), 0)
+		"text":
+			_auto_text = value == "auto"
+		"warmup":
+			_warmup = maxi(2, int(value))
+		"probe":
+			_probe = StringName(value)
+		_:
+			return false
+	return true
+
+
+func _read_staging_option(key: String, value: String) -> bool:
+	match key:
+		"party":
+			_party = _parse_party(value)
+		"items":
+			_items = _parse_items(value)
+		"flags":
+			for raw: String in value.split(",", false):
+				_flags.append(int(raw))
+		"progress":
+			_progress = _parse_progress(value)
+		"always":
+			_always[StringName(value.get_slice(":", 0))] = \
+				value.substr(value.find(":") + 1)
+		"at":
+			_waits.append({
+				"state": StringName(value.get_slice(":", 0)),
+				"action": value.substr(value.find(":") + 1),
+			})
+		"mash":
+			_mash = value
+		"do":
+			_add_action(int(value.get_slice(":", 0)), value.substr(value.find(":") + 1))
+		_:
+			return false
+	return true
 
 ## `party=` as one member per comma. `species:level` and then any of `shiny`,
 ## `brink` and `hp<n>`, which are the three a clip has needed: a shiny to catch,


### PR DESCRIPTION
The first fourteen entries of `tests/unit/test_source_budget.gd`'s own list, taken in difficulty order. Each dispatch becomes a lookup table and each long routine a set of named helpers; nothing changes what any of them decide.

| Was | Function |
|---|---|
| 52 | `start_menu_screen.gd:_move` |
| 45 | `gen2_sound_engine.gd:_parse_music_command` |
| 43 | `world_screen.gd:_handle_button` |
| 39 | `preview_battle_switch.gd:_open` |
| 36 | `opening_lane.gd:_validate` |
| 36 | `world_party_host.gd:_apply_party_request` |
| 36 | `Gen2BattleAI._apply_basic` |
| 35 | `record_clip.gd:_initialize` |
| 35 | `world_renderer.gd:_draw` |
| 35 | `start_menu_screen.gd:_hardware_image` |
| 35 | `save_data.gd:from_dict` |
| 35 | `rom_importer.gd:import_rom` |
| 34 | `world_host.gd:_resolve_data_request` |
| 29 | `start_menu_screen.gd:_confirm` |

`MusicCommands` and `AI_Redundant` are jump tables on the cartridge, so they are tables here now rather than thirty and twenty arms. The overlay chain in `_handle_button` is one ordered list of the hosts a press is offered to, and the pack's two-row boxes are one list of the cursor each toggles. The PC result's arm was the same eight lines in `_confirm` and in `_cancel`; it is one helper.

Two things met on the way and fixed in the same commit: `import_rom`'s doc had ended up over the wrong function, and nine comments said the same fact in two or three files. Each of those keeps the text where it is enforced and links from the others, which is what takes the comment ceiling from 37891 down to 37887.

Seventy-three functions were over the ceiling; fifty-nine are.

Proof:

| Check | Result |
|---|---|
| Full GUT tier | 4000 tests, 0 failing |
| Editor analyser | 0 warnings in 596 scripts |
| `validate.gd -- all` | 80 pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | byte-identical to `main` |
| World, start menu and switch-offer captures | byte-identical to `main` |
