### PR TITLE
Answer the three questions that needed the owner's eyes

### DIFF
--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -244,6 +244,25 @@ func toast() -> Gen2LauncherToast:
 	return _toast
 
 
+## What the Switch build's washed-out page and missing toast need answered, twice
+## over since the veil and the toast both arrive on a tween.
+func log_layers(where: String) -> void:
+	print(layer_report(where))
+	if is_inside_tree():
+		get_tree().create_timer(1.0).timeout.connect(
+			func() -> void: print(layer_report(where + " +1s"))
+		)
+
+
+func layer_report(where: String) -> String:
+	if _art_holder == null or _art_veil == null or _host == null or _toast == null:
+		return "launcher layers %s: not built" % where
+	return "launcher layers %s: art=%.2f at %d, veil %s, page at %d, toast %s %.2f %s" % [
+		where, _art_holder.modulate.a, _art_holder.get_index(), _art_veil.color,
+		_host.get_index(), _toast.visible, _toast.modulate.a, _toast.get_global_rect(),
+	]
+
+
 ## Puts [param texture] behind the launcher, crossfading from whatever was there.
 ## Pass null for the plain gradient, which is what a page with no cartridge
 ## behind it wants.

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -226,8 +226,8 @@ func _empty_state() -> Control:
 ## on the mod's own page, which the row itself opens.
 func _card(row: Dictionary) -> Control:
 	var panel: Gen2LauncherCard = Gen2LauncherCard.create(_theme, Gen2LauncherTheme.RADIUS_MD, 18)
-	# Labels surrender their width before actions do, so the icon, text and the
-	# row's controls stay on one line even on a portrait phone.
+	# A portrait phone leaves a name eleven characters wide beside the controls,
+	# so the controls take a row of their own and the name takes the width.
 	var stack: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_SM)
 	panel.add_child(stack)
 	var line: HBoxContainer = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
@@ -244,6 +244,10 @@ func _card(row: Dictionary) -> Control:
 	text.add_child(_clipped(Gen2LauncherUI.muted(_theme, _version_line(row))))
 
 	var controls: HBoxContainer = line
+	if _compact:
+		controls = Gen2LauncherUI.row(Gen2LauncherUI.GAP_MD)
+		controls.alignment = BoxContainer.ALIGNMENT_END
+		stack.add_child(controls)
 
 	if bool(row["installed"]):
 		var switch: Gen2LauncherToggle = Gen2LauncherToggle.create(_theme, bool(row["enabled"]))
@@ -259,7 +263,7 @@ func _card(row: Dictionary) -> Control:
 	)
 	open.tooltip_text = "Open %s" % row["name"]
 	open.pressed.connect(func() -> void: open_mod(StringName(row["id"])))
-	line.add_child(open)
+	controls.add_child(open)
 	# Pressing the row is the same as pressing its chevron. The toggle and the
 	# action are buttons of their own and take their own press first.
 	panel.activated.connect(func() -> void: open_mod(StringName(row["id"])))

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -598,6 +598,8 @@ func _finish_import(success: bool, message: String) -> void:
 		"Import complete." if success else "Import stopped.",
 		message,
 	)
+	if _shell != null:
+		_shell.log_layers("import")
 
 
 func _set_status(kind: StringName, title: String, detail: String) -> void:

--- a/game/render/menu_page.gd
+++ b/game/render/menu_page.gd
@@ -157,11 +157,12 @@ func render(
 ## `Textbox`'s own `ClearBox`, so a menu over a filled page does not show it
 ## through. The source's blank is $7f, below the font, which draws as index 0.
 func _fill_interior(box: Gen2MenuBox, indices: PackedByteArray, width: int) -> void:
-	var interior: Vector2i = box.interior()
-	var left: int = (box.left + 1) * TILE
+	var corner: Vector2i = box.border_position()
+	var interior: Vector2i = box.border_size() - Vector2i(2, 2)
+	var left: int = (corner.x + 1) * TILE
 	var span: int = interior.x * TILE
 	for row: int in interior.y * TILE:
-		var start: int = ((box.top + 1) * TILE + row) * width + left
+		var start: int = ((corner.y + 1) * TILE + row) * width + left
 		if start < 0 or start + span > indices.size():
 			continue
 		for pixel: int in span:

--- a/game/render/world_service_page.gd
+++ b/game/render/world_service_page.gd
@@ -5,6 +5,7 @@ extends RefCounted
 ## caller supplies the imported rows; this page owns only MenuTextbox geometry.
 
 const TILE: int = Gen2Font.TILE
+const MESSAGE_BOX := Rect2i(0, 12, 20, 6)
 
 var font: Gen2Font = null
 var menu: Gen2MenuPage = null
@@ -17,54 +18,63 @@ static func from_data(data: GameData) -> Gen2WorldServicePage:
 	return out if out.font != null and out.menu != null else null
 
 
-## `MenuTextbox` over the map: every box here carries `MENU_BACKUP_TILES`, so
-## the map stays visible around it and nothing here fills the screen white.
-## The caller supplies its own `menu_coords` box; an empty [param rows] draws
-## no box at all, which is what a plain `MenuTextbox` print is.
-## [param note] is the small box a routine draws beside its list rather than
-## under it. `Elevator_GetCurrentFloorText` is the only one: `hlcoord 0, 0 /
-## ld b, 4 / ld c, 8 / call Textbox` with "Now on:" at (1, 2) and the floor's
-## own string at (4, 4).
+## `MenuTextbox` over the map: every box here carries `MENU_BACKUP_TILES`, so the
+## map stays visible around it. Empty [param rows] draws no box at all.
+##
+## [param note] is the box beside the list, `{rect, lines}` with each line
+## `{text, at}` from its own corner. [param message_box] is
+## [constant MESSAGE_BOX] everywhere but `_ChangeBox`'s `hlcoord 0, 14`.
 func render(title: String, prompt: String, rows: Array, cursor: int,
 		message: String = "", box: Gen2MenuBox = null,
-		note: PackedStringArray = PackedStringArray()) -> Image:
+		note: Dictionary = {}, message_box: Rect2i = MESSAGE_BOX) -> Image:
 	var image := Image.create_empty(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
 	if not rows.is_empty() and box != null:
 		_blit(image, menu.render(box, rows, cursor), box.border_position())
-	if note.size() >= 2:
-		## `Textbox` draws b + 2 rows by c + 2 columns, so `ld b, 4 / ld c, 8` is
-		## ten tiles by six and the menu beside it keeps the rest of the row.
-		var note_width: int = 10 * TILE
-		var note_indices := PackedByteArray()
-		note_indices.resize(note_width * 6 * TILE)
-		font.draw_box(Gen2OptionsStore.current().textbox_frame, note_indices,
-			note_width, 0, 0, 10, 6)
-		font.draw_text(note[0], note_indices, note_width, TILE, 2 * TILE)
-		font.draw_text(note[1], note_indices, note_width, 4 * TILE, 4 * TILE)
-		var note_part: Image = Gen2PicImage.from_indices(
-			note_indices, note_width, 6 * TILE,
-			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
-		)
-		image.blit_rect(note_part, Rect2i(Vector2i.ZERO, note_part.get_size()), Vector2i.ZERO)
+	if not note.is_empty():
+		_draw_note(image, note)
 	var words: String = message if not message.is_empty() else prompt
 	if words.is_empty():
 		words = title
 	if not words.is_empty():
-		var pages: Array = Gen2TextLayout.lay_out(words, 18, 2)
+		var text_rows: int = (message_box.size.y - 2) / 2
+		var pages: Array = Gen2TextLayout.lay_out(words, message_box.size.x - 2, text_rows)
 		var lines: PackedStringArray = pages[0] if not pages.is_empty() else PackedStringArray()
 		var indices := PackedByteArray()
-		indices.resize(Gen2Screen.WIDTH * 6 * TILE)
+		indices.resize(Gen2Screen.WIDTH * message_box.size.y * TILE)
 		font.draw_box(Gen2OptionsStore.current().textbox_frame, indices,
-			Gen2Screen.WIDTH, 0, 0, 20, 6)
-		for row: int in mini(2, lines.size()):
+			Gen2Screen.WIDTH, 0, 0, message_box.size.x, message_box.size.y)
+		for row: int in mini(text_rows, lines.size()):
 			font.draw_text(lines[row], indices, Gen2Screen.WIDTH, TILE, (2 + row * 2) * TILE)
-		var part: Image = Gen2PicImage.from_indices(indices, Gen2Screen.WIDTH, 6 * TILE,
-			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK])))
-		image.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), Vector2i(0, 12 * TILE))
+		var part: Image = Gen2PicImage.from_indices(
+			indices, Gen2Screen.WIDTH, message_box.size.y * TILE,
+			Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+		)
+		image.blit_rect(
+			part, Rect2i(Vector2i.ZERO, part.get_size()), message_box.position * TILE
+		)
 	return image
 
+
+
+func _draw_note(image: Image, note: Dictionary) -> void:
+	var rect: Rect2i = note.get("rect", Rect2i())
+	if rect.size.x <= 0 or rect.size.y <= 0:
+		return
+	var width: int = rect.size.x * TILE
+	var indices := PackedByteArray()
+	indices.resize(width * rect.size.y * TILE)
+	font.draw_box(Gen2OptionsStore.current().textbox_frame, indices,
+		width, 0, 0, rect.size.x, rect.size.y)
+	for line: Dictionary in note.get("lines", []) as Array:
+		var at: Vector2i = line.get("at", Vector2i.ZERO)
+		font.draw_text(String(line.get("text", "")), indices, width, at.x * TILE, at.y * TILE)
+	var part: Image = Gen2PicImage.from_indices(
+		indices, width, rect.size.y * TILE,
+		Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	image.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), rect.position * TILE)
 
 func _blit(into: Image, part: Image, at: Vector2i) -> void:
 	if part != null:

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -14,6 +14,9 @@ const STATICMENU_ENABLE_LEFT_RIGHT: int = 1 << 2
 const STATICMENU_ENABLE_START: int = 1 << 3
 const STATICMENU_PLACE_TITLE: int = 1 << 4
 const STATICMENU_WRAP: int = 1 << 5
+## `ScrollingMenu_UpdateDisplay` reaches its first row with `ld bc, SCREEN_WIDTH
+## + 1` where `_InitVerticalMenuCursor` spends a second row: every scrolling menu
+## carries this flag and no vertical one does.
 const STATICMENU_NO_TOP_SPACING: int = 1 << 6
 const STATICMENU_CURSOR: int = 1 << 7
 
@@ -42,6 +45,9 @@ var row_step: int = ROW_STEP
 ## `SCROLLINGMENU_*` by `ScrollingMenu`, and the two sets overlap.
 var scrolling_arrows: bool = false
 var scroll: int = 0
+## The frame a caller drew before the menu, `ScrollingMenu` drawing none. Empty
+## is every other menu, whose frame is its own corners.
+var frame: Rect2i = Rect2i()
 ## `BattleTowerRoomMenu_UpdatePickLevelMenu`, the one menu in the game that
 ## shows a single row between two arrows instead of a list under a cursor. Both
 ## are the `▼` of `String_119d07`, placed at `hlcoord 13, 8` and `hlcoord 13,
@@ -84,13 +90,13 @@ func interior() -> Vector2i:
 	return dims() - Vector2i.ONE
 
 
-## The drawn frame: the interior plus the two edge tiles on each axis.
+## The drawn frame, or [member frame] where the caller drew one of its own.
 func border_size() -> Vector2i:
-	return interior() + Vector2i(2, 2)
+	return frame.size if frame.size.x > 0 else interior() + Vector2i(2, 2)
 
 
 func border_position() -> Vector2i:
-	return Vector2i(left, top)
+	return frame.position if frame.size.x > 0 else Vector2i(left, top)
 
 
 ## `GetMenuTextStartCoord`: one in from the top-left corner, one row further

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -10,6 +10,8 @@ const BACKGROUND: Color = Color("#09111f")
 const TEXT: Color = Color("#f4f7fb")
 const MUTED: Color = Color("#9eacc0")
 const BATTLE_SCENE: PackedScene = preload("res://game/battle/battle_screen.tscn")
+const FLOWER_MAIL: int = 0xB6
+
 const SERVICE_SCENE: PackedScene = preload("res://game/world/world_service_screen.tscn")
 const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_screen.tscn")
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
@@ -3547,6 +3549,17 @@ func preview_pokemon_center_pc() -> void:
 
 
 func preview_players_pc() -> void:
+	_preview_pc(&"players_house")
+
+
+func preview_mailbox() -> void:
+	var save: Gen2SaveData = _embedded_party_save()
+	if save != null and save.mailbox.is_empty():
+		for author: String in ["MOM", "KURT", "BILL"]:
+			save.mailbox.append(Gen2SaveMail.compose(
+				Gen2SaveMail.blank_message(), author, save.player_id, 1, FLOWER_MAIL
+			))
+		_injected_save = save
 	_preview_pc(&"players_house")
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -201,6 +201,7 @@ var _hof: Gen2HallOfFameScreen = null
 ## `BillsPC_ChangeBoxSubmenu`'s `wMenuSelection`, which is the box the list's
 ## cursor was on rather than `wCurBox`, and the keyboard its NAME row opens.
 var _box_submenu_index: int = 0
+var _box_count: int = 0
 var _naming: Gen2NamingScreenScreen = null
 var _hof_index: int = 0
 ## `MailboxPC`: `wCurMessageIndex`, the message a submenu is acting on, the
@@ -211,6 +212,13 @@ var _mail_party: Gen2PartyScreen = null
 ## `_ChangeBox_MenuHeader`'s `db 4, 0`: four rows of a scrolling list, and where
 ## the window into the fourteen boxes stands.
 const BOX_LIST_ROWS: int = 4
+## Every mode whose rows are [member _pc_rows]. One missing falls through to the
+## "Continue" default, which hid the change-box list behind a single row.
+const PC_ROW_MODES: Array = [
+	MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST, MODE.PC_BOX_SUBMENU,
+	MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
+	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
+]
 ## The `db rows` byte of every scrolling menu this screen hosts, which is how
 ## many of its list a window shows at once. `wMenuScrollPosition` is one value
 ## here, the way it is one address on the cartridge: only one of these lists is
@@ -1803,19 +1811,18 @@ func _print_box() -> void:
 	_render_rows()
 
 
-## `GetBoxCount` for the row the cursor stands on, over MONS_PER_BOX.
+## `GetBoxCount` for the row the cursor stands on. It goes in the box beside the
+## list, so the words under it stay `.ChangeBoxString`'s.
 func _refresh_box_counts() -> void:
 	var index: int = clampi(_cursor, 0, Gen2SaveData.BOX_COUNT - 1)
 	var box: Gen2SaveBox = _save.boxes[index] if _save != null \
 		and index < _save.boxes.size() else null
-	var count: int = 0
-	if box != null:
-		for slot: int in Gen2SaveBox.CAPACITY:
-			if slot < box.slots.size() and box.slots[slot] != null:
-				count += 1
-	_status = "%d/%d PKMN, CURRENT BOX %d" % [
-		count, Gen2SaveBox.CAPACITY, _box_index + 1,
-	]
+	_box_count = 0
+	if box == null:
+		return
+	for slot: int in Gen2SaveBox.CAPACITY:
+		if slot < box.slots.size() and box.slots[slot] != null:
+			_box_count += 1
 
 
 ## BILL'S PC's own two lists. The panel steps aside for the box screen the way it
@@ -2465,12 +2472,7 @@ func _render_rows(override: Array = []) -> void:
 			else []
 	var values: Array = override if not override.is_empty() else (
 		_choices if _mode == MODE.MENU \
-		else _pc_rows if _mode in [
-			MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES,
-			MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
-			MODE.PC_BOX_SUBMENU,
-			MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
-		] \
+		else _pc_rows if PC_ROW_MODES.has(_mode) \
 		else _pc_entries if _mode == MODE.PC_ITEM_LIST \
 		else ["Continue"]
 	)
@@ -2518,7 +2520,7 @@ func _render_service_page(values: Array, cursor: int = -1) -> void:
 		else _dial_image() if _is_dial() else _service_page.render(
 		"" if quiet else _title, "" if quiet else _summary, labels,
 		_cursor if cursor < 0 else cursor, "" if quiet else _status,
-		_service_box(), _service_note()
+		_service_box(), _service_note(), _message_box()
 	)
 	if image != null:
 		Gen2PicImage.show(_service_view, image)
@@ -2526,17 +2528,38 @@ func _render_service_page(values: Array, cursor: int = -1) -> void:
 	_apply_layer_visibility()
 
 
-## `Elevator_GetCurrentFloorText`'s own box, which no other mode draws.
-func _service_note() -> PackedStringArray:
+## `BillsPC_PlaceChangeBoxString`'s `hlcoord 0, 14`, under the list's fourth row.
+func _message_box() -> Rect2i:
+	if _mode != MODE.PC_BOX_LIST:
+		return Gen2WorldServicePage.MESSAGE_BOX
+	return Rect2i(0, 14, 20, 4)
+
+
+## `Elevator_GetCurrentFloorText`'s `hlcoord 0, 0 / ld b, 4 / ld c, 8`.
+func _service_note() -> Dictionary:
+	if _mode == MODE.PC_BOX_LIST:
+		return _box_count_note()
 	if _mode != MODE.ELEVATOR:
-		return PackedStringArray()
+		return {}
 	var floors: Array = _elevator_floors()
 	var current: int = int(_elevator.get("current", -1))
 	if current < 0 or current >= floors.size():
-		return PackedStringArray()
-	return PackedStringArray([
-		"Now on:", _floor_name(int((floors[current] as Dictionary)["floor"])),
-	])
+		return {}
+	return {"rect": Rect2i(0, 0, 10, 6), "lines": [
+		{"text": "Now on:", "at": Vector2i(1, 2)},
+		{
+			"text": _floor_name(int((floors[current] as Dictionary)["floor"])),
+			"at": Vector2i(4, 4),
+		},
+	]}
+
+
+## `BillsPC_PrintBoxCountAndCapacity`'s `hlcoord 11, 7 / lb bc, 5, 7`.
+func _box_count_note() -> Dictionary:
+	return {"rect": Rect2i(11, 7, 9, 7), "lines": [
+		{"text": "#MON", "at": Vector2i(1, 2)},
+		{"text": "%d/%d" % [_box_count, Gen2SaveBox.CAPACITY], "at": Vector2i(2, 4)},
+	]}
 
 
 ## An overlay owns all 160x144 while it is up: the mart, box storage, a Pokegear
@@ -2594,14 +2617,8 @@ func _service_box() -> Gen2MenuBox:
 		MODE.PC_DECO_LIST:
 			return _deco_list_box()
 		MODE.ELEVATOR:
-			## `Elevator_MenuHeader`'s `menu_coords 12, 1, 18, 9`.
-			##
-			## `ScrollingMenu_UpdateDisplay` reaches its first row with
-			## `MenuBoxCoord2Tile / ld bc, SCREEN_WIDTH + 1`, which is one row
-			## down and one column right, where `_InitVerticalMenuCursor` spends
-			## a second row before the first item. A scrolling menu therefore has
-			## no top spacing, and this box's fourth floor sits on its own border
-			## without it.
+			## `Elevator_MenuHeader`'s `menu_coords 12, 1, 18, 9`, whose fourth
+			## floor only fits without the top row of spacing.
 			var elevator_box: Gen2MenuBox = Gen2MenuBox.from_coords(
 				12, 1, 18, 9,
 				Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
@@ -2611,9 +2628,10 @@ func _service_box() -> Gen2MenuBox:
 			return elevator_box
 		MODE.PC_MAILBOX:
 			## `.TopMenuHeader`'s `menu_coords 8, 1, SCREEN_WIDTH - 2, 10`.
-			return _scrolling_box(
-				Gen2MenuBox.from_coords(8, 1, 18, 10, Gen2MenuBox.STATICMENU_CURSOR)
-			)
+			return _scrolling_box(Gen2MenuBox.from_coords(
+				8, 1, 18, 10,
+				Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+			))
 		MODE.PC_MAIL_SUBMENU:
 			## `.SubMenuHeader`'s `menu_coords 0, 0, 13, 9`.
 			return Gen2MenuBox.from_coords(0, 0, 13, 9, Gen2MenuBox.STATICMENU_CURSOR)
@@ -2648,15 +2666,14 @@ func _pc_top_box() -> Gen2MenuBox:
 	)
 
 
-## `_ChangeBox_MenuHeader`'s `menu_coords 1, 5, 9, 12`, which is four rows of a
-## scrolling list rather than all fourteen at once.
+## `_ChangeBox_MenuHeader`'s `menu_coords 1, 5, 9, 12`, four rows of fourteen.
+## `_ChangeBox` draws the frame itself, `Textbox` at `hlcoord 0, 4 / lb bc, 8, 9`.
 func _pc_box_list_box() -> Gen2MenuBox:
 	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
-		1, 5, 9, 5 + BOX_LIST_ROWS + 2, Gen2MenuBox.STATICMENU_CURSOR
+		1, 5, 9, 12,
+		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
 	)
-	## `ScrollingMenu` writes its rows one apart, where `VerticalMenu` writes
-	## them two.
-	box.row_step = 1
+	box.frame = Rect2i(0, 4, 11, 10)
 	return box
 
 

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -542,6 +542,45 @@ func test_a_mod_registering_renderers_is_switched_on_from_its_own_page() -> void
 	Gen2ModState.reload()
 
 
+## A 390pt window leaves a mod's name about eleven characters wide beside its
+## toggle, bin and chevron, which trimmed every name on the page.
+func test_a_narrow_mods_page_gives_a_row_its_controls_a_line_of_their_own() -> void:
+	_write_probe_mod_zip()
+	assert_true(bool(Gen2ModInstaller.install_zip(_mod_archive).get("ok", false)))
+	Gen2ModHost.reset()
+	Gen2ModHost.instance().discover()
+	Gen2ModHost.instance().load_discovered()
+
+	var page: Gen2ModsPage = _mods_page()
+	assert_eq(_card_lines(page), 1, "a wide window keeps the row on one line")
+	page.set_compact(true)
+	assert_eq(_card_lines(page), 2, "a narrow one gives the controls their own")
+	page.set_compact(false)
+	assert_eq(_card_lines(page), 1, "and takes it back when there is room")
+	Gen2ModHost.reset()
+
+
+## How many lines the first mod card is stacked into.
+func _card_lines(page: Gen2ModsPage) -> int:
+	for card: Node in page.find_children("", "Gen2LauncherCard", true, false):
+		for child: Node in card.get_children():
+			if child is VBoxContainer:
+				return (child as VBoxContainer).get_child_count()
+	return 0
+
+
+## Only a run on the device can say why the Switch build dims its page and draws
+## no toast, so the launcher can say what it built (`HANDOFF.md`).
+func test_the_shell_can_report_what_it_layered() -> void:
+	await _open_launcher()
+	var shell: Gen2LauncherShell = _launcher.get("_shell")
+	assert_not_null(shell)
+	var line: String = shell.layer_report("test")
+	assert_string_contains(line, "veil", "the report names the sheet over the artwork")
+	assert_string_contains(line, "toast", "and whether the toast is on screen")
+	assert_false(line.contains("not built"), "a launcher that is up has both")
+
+
 ## A mod that replaces nothing about how the game is drawn gets no row at all,
 ## rather than a switch that would do nothing.
 func test_a_mod_with_no_renderer_has_no_view_switch() -> void:

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -848,7 +848,7 @@ func test_a_mod_row_fits_a_phone_rather_than_running_off_its_card() -> void:
 	}) as Gen2LauncherCard
 	page.add_child(download_card)
 	var stack: VBoxContainer = download_card.get_child(0) as VBoxContainer
-	assert_eq(stack.get_child_count(), 1, "the download stays on the content row")
+	assert_eq(stack.get_child_count(), 2, "the download takes the second row too")
 
 
 ## Every card in [param root]'s subtree.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -352,6 +352,7 @@ const STAGERS: Dictionary = {
 	&"start_menu": &"_stage_start_menu",
 	&"bills_pc": &"_stage_pc",
 	&"players_pc": &"_stage_pc",
+	&"mailbox": &"_stage_pc",
 	&"pokemon_center_pc": &"_stage_pc",
 	&"mom_bank": &"_stage_mom_bank",
 }


### PR DESCRIPTION
Three entries were parked because a decision about how a screen looks is the owner's rather than a session's. All three are answered.

## The mods list on a portrait phone

A 390pt window left a mod's name about eleven characters wide beside its toggle, bin and chevron, so the page read "Hidden ...", "Linking ...", "Overwo...". On a compact page each row now gives those controls a line of their own and the name and id take the width. Four cards fit where five did. A wide window is unchanged, byte for byte.

## Three scrolling menus, one geometry

`ScrollingMenu_UpdateDisplay` reaches its first row with `MenuBoxCoord2Tile / ld bc, SCREEN_WIDTH + 1`, where `_InitVerticalMenuCursor` spends a second row first. A scrolling menu has no top spacing and a vertical one does; the elevator was already drawn that way and the mailbox and the change-box list were a row low. Both carry the flag now, and the source fact moved onto the flag instead of sitting beside one of the three menus.

The change-box list gets the rest of its geometry too:

| What | Was | Is |
|---|---|---|
| Row step | 1, with a comment claiming `ScrollingMenu` writes rows one apart | `ld bc, 2 * SCREEN_WIDTH`, which is two |
| Frame | The menu's own corners, the box shortened to fit | `_ChangeBox`'s `Textbox` at `hlcoord 0, 4 / lb bc, 8, 9` |
| Box count | In the words under the list | `BillsPC_PrintBoxCountAndCapacity`'s box at `hlcoord 11, 7` |
| Those words | `MenuTextbox` at row 12, over the fourth row | `BillsPC_PlaceChangeBoxString`'s `hlcoord 0, 14` |

Met on the way and fixed here: `_render_rows` listed ten of the eleven modes whose rows are `_pc_rows`, and the one it missed was the change-box list. CHANGE BOX drew a single row reading "Conti..." instead of the fourteen boxes. It is a named constant now, so the next mode added is either in it or is not a list.

## The Switch build

No Switch here, so this ships the one thing a device run can settle. The washed-out sheet is `Gen2LauncherShell._art_veil`, the page colour over the cartridge art at alpha 0.72, which desktop draws behind the cards. `_finish_import` now prints what the shell built, and prints it again a second later once the veil and the toast tweens have landed: the veil's alpha and child index, the page's index, and whether the toast is visible, with what alpha and where. One import on the device answers whether the veil is over the cards or the toast was dropped.

## Proof

| Check | Result |
|---|---|
| Full GUT tier | 4002 tests, 0 failing |
| Editor analyser | 0 warnings in 596 scripts |
| `validate.gd -- all` | 80 pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | byte-identical to `main` |
| Elevator and the wide mods page | byte-identical to `main` |

One test changed rather than broke: it asserted the mod row stays on a single line on a phone, which is the decision this overturns. Two are new, for the compact row and for the layer report.
