### PR TITLE
Browse for a file in the launcher where there is no pointer

### DIFF
--- a/autoload/diagnostics.gd
+++ b/autoload/diagnostics.gd
@@ -495,14 +495,11 @@ static func _setting(key: String, fallback: String) -> String:
 static func _file_picker_kind() -> String:
 	if Engine.has_singleton(Gen2LauncherFilePicker.NATIVE_SINGLETON):
 		return "the system picker, through the platform plugin"
-	if DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE):
+	if Gen2LauncherFilePicker.use_native_dialog_here():
 		return "the system picker, through the engine"
-	# Where it opens is the whole story on a machine with no pointer, whose
-	# d-pad can walk the browser down and never back up.
-	var start: String = Gen2LauncherFilePicker._pointerless_start_dir()
-	if start.is_empty():
+	if DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE):
 		return "the engine's own browser"
-	return "the engine's own browser, opening at %s" % start
+	return "the launcher's own browser, opening at %s" % Gen2BrowseSheet.start_dir()
 
 
 ## Empty on a headless run, and on a machine whose driver never answered.

--- a/game/audio/gen2_apu.gd
+++ b/game/audio/gen2_apu.gd
@@ -191,10 +191,7 @@ func write(address: int, value: int) -> void:
 	if address == 0xFF26:
 		_registers[index] = value & 0x80
 		if (value & 0x80) == 0:
-			for cleared: int in 0xFF26 - FIRST_REGISTER:
-				_registers[cleared] = 0
-			for channel: int in 4:
-				_enabled[channel] = 0
+			_power_off()
 		return
 	# Every register except NR52 is inert while the APU is powered down.
 	if _registers[0xFF26 - FIRST_REGISTER] == 0:
@@ -203,17 +200,7 @@ func write(address: int, value: int) -> void:
 	var channel: int = index / 5
 	match address:
 		0xFF12, 0xFF17, 0xFF21:
-			_volume_init[channel] = value >> 4
-			_powered[channel] = 1 if (value >> 3) != 0 else 0
-			# Zombie mode: rewriting the envelope of a live channel nudges its
-			# volume instead of reloading it.
-			if _powered[channel] != 0 and _enabled[channel] != 0:
-				if _env_step[channel] == 0 and _env_inc[channel] != 0:
-					_volume[channel] += 1 if (value & 0x08) != 0 else 2
-				else:
-					_volume[channel] = 16 - _volume[channel]
-				_volume[channel] &= 0x0F
-				_env_step[channel] = value & 0x07
+			_write_envelope(channel, value)
 		0xFF1C:
 			_volume[2] = (value >> 5) & 0x03
 			_volume_init[2] = _volume[2]
@@ -229,13 +216,9 @@ func write(address: int, value: int) -> void:
 			_set_enabled(2, (value & 0x80) != 0)
 		0xFF14, 0xFF19, 0xFF1E:
 			_freq[channel] = (_freq[channel] & 0x00FF) | ((value & 0x07) << 8)
-			_len_enabled[channel] = 1 if (value & 0x40) != 0 else 0
-			if (value & 0x80) != 0:
-				_trigger(channel)
+			_write_control(channel, value)
 		0xFF23:
-			_len_enabled[3] = 1 if (value & 0x40) != 0 else 0
-			if (value & 0x80) != 0:
-				_trigger(3)
+			_write_control(3, value)
 		0xFF22:
 			_freq[3] = value >> 4
 			_lfsr_wide = (value & 0x08) == 0
@@ -244,9 +227,41 @@ func write(address: int, value: int) -> void:
 			_master_left = (value >> 4) & 0x07
 			_master_right = value & 0x07
 		0xFF25:
-			for output: int in 4:
-				_on_left[output] = (value >> (4 + output)) & 1
-				_on_right[output] = (value >> output) & 1
+			_write_output_mix(value)
+
+
+func _power_off() -> void:
+	for cleared: int in 0xFF26 - FIRST_REGISTER:
+		_registers[cleared] = 0
+	for channel: int in 4:
+		_enabled[channel] = 0
+
+
+## NR12, NR22 and NR42. Zombie mode: rewriting the envelope of a live channel
+## nudges its volume instead of reloading it.
+func _write_envelope(channel: int, value: int) -> void:
+	_volume_init[channel] = value >> 4
+	_powered[channel] = 1 if (value >> 3) != 0 else 0
+	if _powered[channel] == 0 or _enabled[channel] == 0:
+		return
+	if _env_step[channel] == 0 and _env_inc[channel] != 0:
+		_volume[channel] += 1 if (value & 0x08) != 0 else 2
+	else:
+		_volume[channel] = 16 - _volume[channel]
+	_volume[channel] &= 0x0F
+	_env_step[channel] = value & 0x07
+
+
+func _write_control(channel: int, value: int) -> void:
+	_len_enabled[channel] = 1 if (value & 0x40) != 0 else 0
+	if (value & 0x80) != 0:
+		_trigger(channel)
+
+
+func _write_output_mix(value: int) -> void:
+	for output: int in 4:
+		_on_left[output] = (value >> (4 + output)) & 1
+		_on_right[output] = (value >> output) & 1
 
 
 ## Renders one LCD frame. The returned buffer is reused, so a caller that keeps
@@ -316,6 +331,23 @@ func _trigger(channel: int) -> void:
 	_len_counter[channel] = 0
 
 
+## One sample of channel 1's sweep; a switch-off is read back off `_enabled`.
+func _advance_sweep(freq_inc: int) -> int:
+	_sweep_counter += _sweep_inc
+	while _sweep_counter > FREQ_INC_REF:
+		if _sweep_shift != 0:
+			var step: int = _sweep_freq >> _sweep_shift
+			_freq[0] = (_freq[0] + (step if _sweep_up else -step)) & 0xFFFF
+			if _freq[0] > 2047:
+				_enabled[0] = 0
+			else:
+				freq_inc = (DMG_CLOCK / ((2048 - _freq[0]) << 5)) * 16 * 8
+		elif _sweep_rate != 0:
+			_enabled[0] = 0
+		_sweep_counter -= FREQ_INC_REF
+	return freq_inc
+
+
 func _render_square(mix: PackedInt32Array, channel: int) -> void:
 	if _powered[channel] == 0 or _enabled[channel] == 0 or _freq[channel] >= 2048:
 		return
@@ -362,20 +394,8 @@ func _render_square(mix: PackedInt32Array, channel: int) -> void:
 					volume = clampi(volume, 0, MAX_CHAN_VOLUME)
 				env_counter -= FREQ_INC_REF
 		if channel == 0 and _sweep_inc != 0:
-			_sweep_counter += _sweep_inc
-			while _sweep_counter > FREQ_INC_REF:
-				if _sweep_shift != 0:
-					var step: int = _sweep_freq >> _sweep_shift
-					_freq[0] = (_freq[0] + (step if _sweep_up else -step)) & 0xFFFF
-					if _freq[0] > 2047:
-						enabled = false
-						_enabled[0] = 0
-					else:
-						freq_inc = (DMG_CLOCK / ((2048 - _freq[0]) << 5)) * 16 * 8
-				elif _sweep_rate != 0:
-					enabled = false
-					_enabled[0] = 0
-				_sweep_counter -= FREQ_INC_REF
+			freq_inc = _advance_sweep(freq_inc)
+			enabled = _enabled[0] != 0
 		var total: int = freq_counter + freq_inc
 		if total > FREQ_INC_REF:
 			@warning_ignore("integer_division")

--- a/game/launcher/browse_sheet.gd
+++ b/game/launcher/browse_sheet.gd
@@ -1,0 +1,174 @@
+class_name Gen2BrowseSheet
+extends Gen2LauncherSheet
+
+## The launcher's own file browser, for a machine with no pointer. [FileDialog]'s
+## is a pointer's browser: its path field is a [LineEdit] a d-pad cannot leave and
+## whose editing kills the process on Horizon, and it descends on `item_activated`,
+## which neither a pad nor Ryujinx's touch sends. Every row here is a button, and
+## nothing on the card is editable.
+
+signal chosen(path: String)
+
+const MAX_ROWS: int = 400
+
+var _dir: String = ""
+var _extensions: PackedStringArray = PackedStringArray()
+var _save_name: String = ""
+var _list: VBoxContainer = null
+var _where: Label = null
+var _up: Gen2LauncherButton = null
+
+
+static func browse(
+	palette: Gen2LauncherTheme,
+	title: String,
+	dir: String,
+	extensions: PackedStringArray,
+	save_name: String = "",
+) -> Gen2BrowseSheet:
+	var sheet := Gen2BrowseSheet.new()
+	sheet._theme = palette
+	sheet._extensions = extensions
+	sheet._save_name = save_name
+	sheet._build(title)
+	sheet._build_browser()
+	sheet.go_to(dir)
+	return sheet
+
+
+static func start_dir() -> String:
+	return volume_root(OS.get_data_dir())
+
+
+## The top of the volume [param path] is on. Horizon names one with a colon and
+## mounts it at its own root, so the SD card is `sdmc:/` and nothing is above it.
+static func volume_root(path: String) -> String:
+	var root: String = path
+	while true:
+		var parent: String = root.get_base_dir()
+		if parent.is_empty() or parent == root:
+			break
+		root = parent
+	if root.is_empty():
+		return ""
+	return root + "/" if root.ends_with(":") else root
+
+
+## The directory above [param dir], or an empty string at the top of a volume.
+static func parent_of(dir: String) -> String:
+	var root: String = volume_root(dir)
+	if dir.trim_suffix("/") == root.trim_suffix("/"):
+		return ""
+	var up: String = dir.trim_suffix("/").get_base_dir()
+	if up.is_empty():
+		return root
+	return up + "/" if up.ends_with(":") else up
+
+
+## What [param dir] offers as rows of `{"name", "path", "directory"}`: directories
+## first, each sorted, files kept to [param extensions] unless it is empty.
+static func rows(dir: String, extensions: PackedStringArray) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	if not DirAccess.dir_exists_absolute(dir):
+		return out
+	var directories: PackedStringArray = DirAccess.get_directories_at(dir)
+	directories.sort()
+	for entry: String in directories:
+		if entry.begins_with("."):
+			continue
+		out.append({"name": entry, "path": dir.path_join(entry), "directory": true})
+	var files: PackedStringArray = DirAccess.get_files_at(dir)
+	files.sort()
+	for entry: String in files:
+		if extensions.is_empty() or extensions.has(entry.get_extension().to_lower()):
+			out.append({"name": entry, "path": dir.path_join(entry), "directory": false})
+	return out
+
+
+func directory() -> String:
+	return _dir
+
+
+func go_to(dir: String) -> void:
+	if DirAccess.dir_exists_absolute(dir):
+		_dir = dir
+	elif _dir.is_empty():
+		_dir = start_dir()
+	_refresh()
+
+
+func _build_browser() -> void:
+	_where = Gen2LauncherUI.muted(_theme, "")
+	_where.add_theme_color_override("font_color", _theme.faint)
+	_where.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	body().add_child(_where)
+	_list = Gen2LauncherUI.column(Gen2LauncherUI.GAP_XS)
+	_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	body().add_child(_list)
+	_up = Gen2LauncherButton.create(_theme, "Up", Gen2LauncherButton.Variant.NEUTRAL, &"back")
+	_up.pressed.connect(func() -> void: go_to(parent_of(_dir)))
+	add_action(_up)
+	if not _save_name.is_empty():
+		var here: Gen2LauncherButton = Gen2LauncherButton.create(
+			_theme, "Save here", Gen2LauncherButton.Variant.PRIMARY, &"save"
+		)
+		here.pressed.connect(func() -> void: _choose(_dir.path_join(_save_name)))
+		add_action(here)
+
+
+func _refresh() -> void:
+	if _list == null:
+		return
+	Gen2Screen.drop_children(_list)
+	_where.text = _dir
+	_up.disabled = parent_of(_dir).is_empty()
+	var listing: Array[Dictionary] = rows(_dir, _extensions)
+	for row: Dictionary in listing.slice(0, MAX_ROWS):
+		_list.add_child(_row_button(row))
+	if listing.is_empty():
+		_list.add_child(Gen2LauncherUI.muted(_theme, "Nothing here to open."))
+	elif listing.size() > MAX_ROWS:
+		_list.add_child(Gen2LauncherUI.muted(
+			_theme, "%d more, not listed." % (listing.size() - MAX_ROWS)
+		))
+	_focus_first()
+
+
+func _row_button(row: Dictionary) -> Gen2LauncherButton:
+	var folder: bool = bool(row["directory"])
+	var button: Gen2LauncherButton = Gen2LauncherButton.create(
+		_theme,
+		String(row["name"]),
+		Gen2LauncherButton.Variant.QUIET,
+		&"folder" if folder else &"save",
+	)
+	button.alignment = HORIZONTAL_ALIGNMENT_LEFT
+	button.clip_text = true
+	button.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	var path: String = String(row["path"])
+	button.pressed.connect(func() -> void:
+		if folder:
+			go_to(path)
+		else:
+			_choose(path)
+	)
+	return button
+
+
+func _first_focus() -> Control:
+	var row: Control = Gen2FocusGuard.first_focusable(_list)
+	return row if row != null else super()
+
+
+## The list is rebuilt under the focus, so a descent leaves a pad on a freed row.
+func _focus_first() -> void:
+	if not is_inside_tree():
+		return
+	var first: Control = _first_focus()
+	if first != null:
+		first.grab_focus()
+
+
+func _choose(path: String) -> void:
+	chosen.emit(path)
+	close()

--- a/game/launcher/browse_sheet.gd.uid
+++ b/game/launcher/browse_sheet.gd.uid
@@ -1,0 +1,1 @@
+uid://b7abawjpfkhe3

--- a/game/launcher/launcher_file_picker.gd
+++ b/game/launcher/launcher_file_picker.gd
@@ -2,18 +2,20 @@ class_name Gen2LauncherFilePicker
 extends FileDialog
 
 ## The one file picker every launcher dialog is built from, reached through
-## [method Gen2LauncherUI.file_picker] and shown with [method show_picker]. Three
+## [method Gen2LauncherUI.file_picker] and shown with [method show_picker]. Four
 ## ways a platform offers a file, in the order they are preferred: the engine's
-## own native dialog, which Windows, macOS, Linux and Android all answer and whose
-## Android grant covers the one file chosen; the `NativeFilePicker` singleton for
-## iOS, where `DisplayServerIOS` implements no `file_dialog_show`, which hands back
-## a file already copied into app storage; and the built-in browser for anything
-## left, rooted per [method _pointerless_start_dir].
+## native dialog, which Windows, macOS, Linux and Android answer and whose Android
+## grant covers the one file chosen; the `NativeFilePicker` singleton for iOS,
+## where `DisplayServerIOS` implements no `file_dialog_show`; [Gen2BrowseSheet]
+## wherever there is no pointer; and the engine's own browser for the rest.
 
 ## The plugin's singleton, present only on a build that carries it.
 const NATIVE_SINGLETON: StringName = &"NativeFilePicker"
 
 var _native: Object = null
+var _palette: Gen2LauncherTheme = null
+## Where the sheet last was, shared so a second import starts where the first ended.
+static var _last_dir: String = ""
 
 
 static func create(
@@ -23,6 +25,7 @@ static func create(
 	patterns: PackedStringArray,
 ) -> Gen2LauncherFilePicker:
 	var dialog := Gen2LauncherFilePicker.new()
+	dialog._palette = palette
 	dialog.file_mode = picker_mode
 	dialog.filters = patterns
 	dialog.title = title_text
@@ -39,73 +42,22 @@ static func create(
 	return dialog
 
 
-## Points the browser at [method _pointerless_start_dir] before it is shown.
-##
-## Set here rather than in [method create]: the dialog is built once at startup
-## and reaches its directory through a `chdir`, which only holds once it is in
-## the tree. A volume that refuses its name with the trailing slash is tried
-## without one, and a refusal leaves the engine's own answer in place.
-func _open_where_a_pad_can_reach() -> void:
-	if access != FileDialog.ACCESS_FILESYSTEM:
-		return
-	var start: String = _pointerless_start_dir()
-	if start.is_empty():
-		return
-	# Every time, not only the first: the dialog remembers where it was left, and
-	# a machine that cannot climb back up would be stuck wherever it last went.
-	current_dir = start
-	if not current_dir.begins_with(start):
-		current_dir = start.trim_suffix("/")
-
-
-## Where the engine's own browser should open on a machine with no pointer, or
-## an empty string where it should keep the engine's answer.
-##
-## The browser's file list takes the d-pad and descends fine, but its path field
-## is a [LineEdit] and eats left and right, so the toolbar's "up" button behind
-## it cannot be reached: a console can walk down the tree and never back up.
-## Starting at the top of the volume means it never has to. The app's own data
-## sits several levels down, which is exactly the corner it cannot climb out of.
-static func _pointerless_start_dir() -> String:
-	if DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE):
-		return ""
-	return volume_root(OS.get_data_dir())
-
-
-## The top of the volume [param path] is on, as a directory a browser can open.
-##
-## `/` on anything Unix-shaped. Horizon names a volume with a colon and mounts
-## each one at its own root, so the SD card is `sdmc:/` and there is nothing
-## above it.
-static func volume_root(path: String) -> String:
-	var root: String = path
-	while true:
-		var parent: String = root.get_base_dir()
-		if parent.is_empty() or parent == root:
-			break
-		root = parent
-	if root.is_empty():
-		return ""
-	return root + "/" if root.ends_with(":") else root
-
-
-## Whether the browser in 3. above would list anything the app may then open. A
-## sandboxed platform reaching this far has only its own data to offer.
+## Whether a browser would list anything the app may then open: a sandboxed
+## platform reaching this far has only its own data.
 func _can_browse_freely() -> bool:
 	if _native != null:
 		return true
-	return (
-		DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE)
-		or not OS.has_feature("mobile")
-	)
+	return use_native_dialog_here() or not OS.has_feature("mobile")
 
 
 ## Asks for a file. [signal FileDialog.file_selected] carries the answer and
-## [signal FileDialog.canceled] the refusal, whichever of the three presented it.
+## [signal FileDialog.canceled] the refusal, whichever of the four presented it.
 func show_picker(fallback_size: Vector2i) -> void:
 	if _native == null:
-		_open_where_a_pad_can_reach()
-		popup_centered(fallback_size)
+		if uses_browse_sheet():
+			show_browse_sheet()
+		else:
+			popup_centered(fallback_size)
 		return
 	# One singleton serves every picker on screen, and a request left outstanding
 	# by a backgrounded app would otherwise still be listening when the next one
@@ -149,3 +101,46 @@ func _release_native() -> void:
 	if _native.file_selected.is_connected(_on_native_selected):
 		_native.file_selected.disconnect(_on_native_selected)
 		_native.canceled.disconnect(_on_native_cancelled)
+
+
+## Whether the launcher browses for the file itself: only where nothing else
+## can, since a machine with no pointer cannot drive the engine's browser.
+func uses_browse_sheet() -> bool:
+	return (
+		_native == null
+		and access == FileDialog.ACCESS_FILESYSTEM
+		and not use_native_dialog_here()
+		and not DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE)
+	)
+
+
+## Whether [member FileDialog.use_native_dialog] gets a dialog of the platform's own.
+static func use_native_dialog_here() -> bool:
+	return DisplayServer.has_feature(DisplayServer.FEATURE_NATIVE_DIALOG_FILE)
+
+
+## Shows the sheet over whatever screen added this picker. Public for the preview.
+func show_browse_sheet(dir: String = "") -> void:
+	if not dir.is_empty():
+		_last_dir = dir
+	var host := get_parent() as Control
+	if host == null:
+		canceled.emit()
+		return
+	if _last_dir.is_empty():
+		_last_dir = Gen2BrowseSheet.start_dir()
+	var sheet: Gen2BrowseSheet = Gen2BrowseSheet.browse(
+		_palette, title, _last_dir, extensions(), current_file
+	)
+	# A chosen row closes the sheet, so the close is where the answer is counted.
+	var answered: Array[bool] = [false]
+	sheet.chosen.connect(func(path: String) -> void:
+		answered[0] = true
+		file_selected.emit(path)
+	)
+	sheet.closed.connect(func() -> void:
+		_last_dir = sheet.directory()
+		if not answered[0]:
+			canceled.emit()
+	)
+	sheet.open(host)

--- a/game/launcher/launcher_sheet.gd
+++ b/game/launcher/launcher_sheet.gd
@@ -123,7 +123,7 @@ func open(host: Control) -> void:
 	await get_tree().process_frame
 	# The sheet is modal, so focus goes into it whatever the player is using: a
 	# pad needs it to navigate and a keyboard needs it for the cancel below.
-	var first: Control = Gen2FocusGuard.first_focusable(_card)
+	var first: Control = _first_focus()
 	if first != null:
 		first.grab_focus()
 	_card.pivot_offset = _card.size * 0.5
@@ -134,6 +134,12 @@ func open(host: Control) -> void:
 	tween.tween_property(_card, "scale", Vector2.ONE, 0.22).set_ease(
 		Tween.EASE_OUT
 	).set_trans(Tween.TRANS_BACK)
+
+
+## Where an opened sheet puts the pad. A subclass with a better answer than the
+## first control on the card overrides this.
+func _first_focus() -> Control:
+	return Gen2FocusGuard.first_focusable(_card)
 
 
 func close() -> void:

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -22,6 +22,7 @@ var _title_backdrop: Gen2LauncherTitleBackdrop = null
 
 var _file_dialog: Gen2LauncherFilePicker = null
 var _mod_dialog: Gen2LauncherFilePicker = null
+var _preview_browse_dir: String = ""
 var _update_http: HTTPRequest = null
 
 var _importing: bool = false
@@ -458,6 +459,9 @@ func preview_sheet(view: StringName) -> void:
 				"The last session ended unexpectedly.",
 				"About > Report a bug will save a file with the logs in it.",
 			)
+		&"browse":
+			select_page(&"shelf")
+			_file_dialog.show_browse_sheet(_preview_browse_dir)
 		&"binding":
 			select_page(&"settings")
 			var sheet: Gen2BindingSheet = Gen2BindingSheet.for_button(

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -251,6 +251,7 @@ func _build_ui() -> void:
 	)
 	_slot_import_dialog.file_selected.connect(_import_slot_file)
 
+
 func _picker(
 	title: String, mode: FileDialog.FileMode, filters: PackedStringArray
 ) -> Gen2LauncherFilePicker:
@@ -427,6 +428,9 @@ func _add_slot_management(body: VBoxContainer) -> void:
 	body.add_child(file_row)
 	file_row.add_child(_action("Edit save", Gen2LauncherButton.Variant.NEUTRAL, &"settings", _open_editor))
 	file_row.add_child(_action("Export", Gen2LauncherButton.Variant.NEUTRAL, &"", func() -> void:
+		# A suggested name, which the system dialogs offer for editing and which
+		# is the whole name on a machine that browses without a keyboard.
+		_export_dialog.current_file = export_file_name()
 		_export_dialog.show_picker(Vector2i(900, 600))
 	))
 	file_row.add_child(_action("Import", Gen2LauncherButton.Variant.NEUTRAL, &"", func() -> void:
@@ -491,6 +495,19 @@ func _delete_selected_slot() -> void:
 	_selected_slot = -1
 	GameRuntime.reload_selected_save()
 	_refresh()
+
+
+## What an exported slot is called: the cartridge, the slot and the label the
+## player gave it, with anything a file system might refuse taken out.
+func export_file_name() -> String:
+	var parts := PackedStringArray()
+	if _data != null:
+		parts.append(String(_data.id))
+	parts.append("slot-%d" % (_selected_slot + 1))
+	var label: String = String(_row_for(_selected_slot).get("label", "")).strip_edges()
+	if not label.is_empty():
+		parts.append(label)
+	return "%s.json" % "-".join(parts).to_lower().replace(" ", "-").validate_filename()
 
 
 func _export_selected_slot(path: String) -> void:

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -117,32 +117,110 @@ func test_every_file_picker_asks_for_the_systems_own() -> void:
 			continue
 		assert_false(source.contains("FileDialog.new()"), path)
 		assert_false(source.contains("FEATURE_NATIVE_DIALOG_FILE"), path)
-		assert_false(source.contains("popup_centered") and path.ends_with("save_screen.gd"), path)
 
 
-## A d-pad can descend the engine's browser and cannot climb it: the path field
-## is a LineEdit and eats left and right, so the toolbar's "up" button behind it
-## is unreachable. On a machine with no pointer the browser therefore has to open
-## somewhere the player never needs to leave upwards.
-func test_a_pointerless_browser_opens_at_the_top_of_the_volume() -> void:
-	var start: String = Gen2LauncherFilePicker._pointerless_start_dir()
-	if DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE):
-		assert_eq(start, "", "a pointer can reach the up button, so nothing is forced")
-		return
-	assert_false(start.is_empty(), "a console is given a root")
+## The engine's browser needs a pointer: its path field is a LineEdit a d-pad
+## cannot leave and whose editing kills the process on Horizon, and its list
+## enters a directory on an activation neither a pad nor Ryujinx's touch sends.
+## So a machine with no pointer browses in the launcher's own sheet instead.
+func test_a_pointerless_machine_browses_in_the_launchers_own_sheet() -> void:
+	var dialog: Gen2LauncherFilePicker = Gen2LauncherUI.file_picker(
+		_light, "Choose", FileDialog.FILE_MODE_OPEN_FILE, PackedStringArray(["*.gbc; Dump"])
+	)
+	autofree(dialog)
+	assert_eq(
+		dialog.uses_browse_sheet(),
+		not DisplayServer.has_feature(DisplayServer.FEATURE_MOUSE)
+			and not Gen2LauncherFilePicker.use_native_dialog_here(),
+		"the sheet is for exactly the machines nothing else serves",
+	)
+	# Whatever this machine is, no launcher screen may open a browser of its own.
+	for path: String in _scripts_under("res://game"):
+		if path.ends_with("launcher/launcher_file_picker.gd"):
+			continue
+		assert_false(FileAccess.get_file_as_string(path).contains("popup_centered("), path)
+
+
+func test_the_browse_sheet_opens_at_the_top_of_the_volume_and_stops_there() -> void:
+	var start: String = Gen2BrowseSheet.start_dir()
+	assert_false(start.is_empty(), "a machine with no pointer is given a root")
 	assert_true(
 		OS.get_data_dir().begins_with(start.trim_suffix("/")),
 		"and the root is the volume the user data is on",
 	)
+	assert_eq(Gen2BrowseSheet.parent_of(start), "", "the top of a volume has no up")
+	assert_eq(Gen2BrowseSheet.parent_of("sdmc:/games/dumps"), "sdmc:/games")
+	assert_eq(Gen2BrowseSheet.parent_of("sdmc:/games"), "sdmc:/")
+	assert_eq(Gen2BrowseSheet.parent_of("/home/a/roms"), "/home/a")
+	assert_eq(Gen2BrowseSheet.parent_of("C:/Users"), "C:/")
 
 
 func test_the_volume_root_is_the_top_of_a_path_on_any_shape_of_volume() -> void:
-	assert_eq(Gen2LauncherFilePicker.volume_root("/home/a/.local/share"), "/")
-	assert_eq(Gen2LauncherFilePicker.volume_root("/"), "/")
+	assert_eq(Gen2BrowseSheet.volume_root("/home/a/.local/share"), "/")
+	assert_eq(Gen2BrowseSheet.volume_root("/"), "/")
 	# Horizon mounts the SD card as its own volume, named with a colon.
-	assert_eq(Gen2LauncherFilePicker.volume_root("sdmc:/config/godot"), "sdmc:/")
-	assert_eq(Gen2LauncherFilePicker.volume_root("sdmc:/config"), "sdmc:/")
-	assert_eq(Gen2LauncherFilePicker.volume_root("C:/Users/a/AppData"), "C:/")
+	assert_eq(Gen2BrowseSheet.volume_root("sdmc:/config/godot"), "sdmc:/")
+	assert_eq(Gen2BrowseSheet.volume_root("sdmc:/config"), "sdmc:/")
+	assert_eq(Gen2BrowseSheet.volume_root("C:/Users/a/AppData"), "C:/")
+
+
+func test_the_browse_sheet_lists_directories_first_and_only_the_files_asked_for() -> void:
+	var dir: String = OS.get_user_data_dir().path_join("browse_test")
+	DirAccess.make_dir_recursive_absolute(dir.path_join("saves"))
+	DirAccess.make_dir_recursive_absolute(dir.path_join("dumps"))
+	for entry: String in ["b.gbc", "a.gbc", "notes.txt"]:
+		var file: FileAccess = FileAccess.open(dir.path_join(entry), FileAccess.WRITE)
+		file.store_string("x")
+		file.close()
+	var listed: Array = Gen2BrowseSheet.rows(dir, PackedStringArray(["gbc"]))
+	var names: Array = []
+	for row: Dictionary in listed:
+		names.append(row["name"])
+	assert_eq(names, ["dumps", "saves", "a.gbc", "b.gbc"], "directories first, each sorted")
+	assert_true(bool(listed[0]["directory"]))
+	assert_false(bool(listed[2]["directory"]))
+	assert_eq(String(listed[2]["path"]), dir.path_join("a.gbc"))
+	assert_eq(Gen2BrowseSheet.rows(dir, PackedStringArray()).size(), 5, "no filter means every file")
+	assert_eq(Gen2BrowseSheet.rows(dir.path_join("nowhere"), PackedStringArray()), [])
+	OS.move_to_trash(ProjectSettings.globalize_path(dir))
+
+
+func test_a_browse_sheet_walks_into_a_directory_and_answers_with_a_file() -> void:
+	var dir: String = OS.get_user_data_dir().path_join("browse_walk")
+	DirAccess.make_dir_recursive_absolute(dir.path_join("inner"))
+	var file: FileAccess = FileAccess.open(dir.path_join("inner/rom.gbc"), FileAccess.WRITE)
+	file.store_string("x")
+	file.close()
+	var host := Control.new()
+	add_child_autofree(host)
+	var sheet: Gen2BrowseSheet = Gen2BrowseSheet.browse(
+		_light, "Choose", dir, PackedStringArray(["gbc"])
+	)
+	var answers: Array[String] = []
+	sheet.chosen.connect(func(path: String) -> void: answers.append(path))
+	sheet.open(host)
+	await wait_frames(2)
+	var rows: Array[Button] = _row_buttons(sheet)
+	assert_eq(rows.size(), 1, "the directory is the only row at the top")
+	rows[0].pressed.emit()
+	assert_eq(sheet.directory(), dir.path_join("inner"), "and pressing it descends")
+	rows = _row_buttons(sheet)
+	assert_eq(rows.size(), 1)
+	rows[0].pressed.emit()
+	assert_eq(answers, [dir.path_join("inner/rom.gbc")], "a file row is the answer")
+	OS.move_to_trash(ProjectSettings.globalize_path(dir))
+
+
+func _row_buttons(sheet: Gen2BrowseSheet) -> Array[Button]:
+	var found: Array[Button] = []
+	var queue: Array[Node] = [sheet.body()]
+	while not queue.is_empty():
+		var node: Node = queue.pop_front()
+		for child: Node in node.get_children():
+			if child is Button:
+				found.append(child as Button)
+			queue.append(child)
+	return found
 
 
 func test_a_picker_reads_its_extensions_out_of_its_own_filters() -> void:

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -130,6 +130,20 @@ func test_save_screen_distinguishes_an_occupied_slot() -> void:
 	assert_eq(_screen.save_screen_snapshot()["selected_slot"], 1)
 
 
+## A console browsing without a keyboard cannot type a name, so the export
+## carries one already. It is also what the system dialogs suggest.
+func test_an_exported_slot_is_named_after_the_cartridge_the_slot_and_its_label() -> void:
+	assert_true(Gen2SaveStore.save(_save(), _data)["ok"])
+	await _open_save_screen()
+	assert_true(_screen.select_slot(1))
+	assert_eq(_screen.export_file_name(), "testgame-slot-2.json")
+	assert_true(Gen2SaveStore.rename_slot(_data.id, _data.sha1, 1, "Run two", _data)["ok"])
+	_screen.set_data(_data)
+	await get_tree().process_frame
+	assert_true(_screen.select_slot(1))
+	assert_eq(_screen.export_file_name(), "testgame-slot-2-run-two.json")
+
+
 func test_save_screen_marks_an_invalid_existing_slot_incompatible() -> void:
 	var path: String = Gen2SaveStore.path_for(_data.id, _data.sha1, 0)
 	DirAccess.make_dir_recursive_absolute(path.get_base_dir())

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -24,8 +24,6 @@ const MAX_COMMENT_LINES: int = 37887
 ## a line when you fix one. The test fails on a line that no longer names a
 ## function over the ceiling, so this cannot rot and cannot grow.
 const OVER_COMPLEXITY: Array[String] = [
-	"game/audio/gen2_apu.gd:_render_square",
-	"game/audio/gen2_apu.gd:write",
 	"game/battle/battle_screen.gd:_handle_button",
 	"game/battle/battle_screen.gd:_refresh_menu_layer",
 	"game/battle/battle_screen.gd:start_world_battle",

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -86,7 +86,8 @@ func _process(_delta: float) -> bool:
 			# goes, so the ordinary shot below lands in the middle of it, which
 			# is the screen worth photographing.
 			_launcher.import_rom_path(_mod)
-		elif _view in ["manage", "touch", "binding", "delete_mod", "bugs", "report", "toast"]:
+		elif _view in ["manage", "touch", "binding", "browse", "delete_mod", "bugs", "report", "toast"]:
+			_launcher._preview_browse_dir = _mod
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():
 			_launcher.preview_mods_view(StringName(_view), StringName(_mod))


### PR DESCRIPTION
Both Switch reports, and the pair meant a console could only import a dump sitting at the root of the SD card.

The engine's `FileDialog` browser is a pointer's browser. Editing its path field kills the process on Horizon, a null dereference inside the engine binary at `godot.nx.template_release.arm64:0x1521ee8`; and its file list enters a directory on `item_activated`, which neither a pad nor Ryujinx's touch sends, so Open stays greyed out on a folder and the browser descends nowhere.

`Gen2BrowseSheet` is a fourth way to ask for a file, and every picker takes it on a machine with no pointer: the launcher's own modal card, a button per row, Up in the actions, and no editable field anywhere. `Gen2LauncherSheet` gained a `_first_focus` seam so an opened sheet puts the pad on the list instead of on the close button.

An exported save now carries a suggested name. The system dialogs offer it for editing; where there is no keyboard it is the whole name.

Two functions also come off the complexity list. `Gen2Apu.write` splits four register groups into named helpers, and `_render_square` hands channel 1's sweep to `_advance_sweep`.

| Check | Result |
|---|---|
| Unit tier | 3445 tests, 63520 asserts, all pass |
| Editor analyser | 0 warnings in 597 scripts |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | complete, no refusal |
| Audio corpus before and after | 103 songs, 207 effects, 68 cries; WAV and register trace byte for byte identical |
| One frame of music | 996 us before, 995 us after |