### PR TITLE
Name the value a question asks about, and give a pad a way through the launcher

### DIFF
--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -1,25 +1,30 @@
 class_name Gen2FocusGuard
 extends Node
 
-## Gives a controller somewhere to start. Godot moves focus on `ui_up` and the
-## rest of that family, but only once something already has focus, and nothing
-## does when a screen opens. A ring is only put up while the player is on a
-## keyboard or a pad, and never taken away again, because a click that dropped
-## focus would empty the field the click had just filled. A modal takes the whole
-## guard with it: everything below is still focusable, so without that the
-## geometric search joins a control in the modal to one on the page behind. Add
-## one with [method attach] and call [method refresh] when the screen changes.
+## Gives a controller somewhere to start, and somewhere to go. Godot moves focus
+## on `ui_up` and the rest of that family, but only once something already has
+## it, and nothing does when a screen opens. The ring goes up only for a keyboard
+## or a pad, and is never taken away, since a click that dropped focus would
+## empty the field it had just filled. A modal takes the whole guard with it, or
+## the geometric search joins a control in it to one on the page behind.
 
-## Nodes in this group are modal: while one is in the tree, it is the only part
-## of the screen the guard looks at. Named rather than typed so the guard owes
-## nothing to the launcher, and joined by whoever puts a layer over a screen
-## ([Gen2LauncherSheet] is the one that does today).
+## Nodes in this group are modal: while one is in the tree it is the only part of
+## the screen the guard looks at. Named rather than typed, so the guard owes
+## nothing to the launcher; [Gen2LauncherSheet] is what joins it today.
 const MODAL_GROUP: StringName = &"gen2_focus_modal"
 
-## Where focus should land when there is somewhere better than the first control
-## in tree order. A screen whose first control is a corner toggle would otherwise
-## start a pad there rather than on what the screen is about.
+const SIDES: Dictionary = {
+	&"left": Vector2.LEFT, &"right": Vector2.RIGHT,
+	&"up": Vector2.UP, &"down": Vector2.DOWN,
+}
+
+## Where focus should land when tree order is not the best answer: a screen whose
+## first control is a corner toggle would start a pad there rather than on it.
 var preferred: Control = null
+## Direction to a [Callable] taking the control being left and answering where to
+## go when nothing on the screen lies that way. A floating dock is over the page
+## rather than under it, so a long page's last control has nothing below it.
+var edge_targets: Dictionary = {}
 
 var _root: Control = null
 
@@ -40,9 +45,13 @@ func _unhandled_input(event: InputEvent) -> void:
 		_root.get_viewport().set_input_as_handled()
 
 
-## Attaches a guard to [param root] and returns it. The guard is a child of the
-## screen it watches, so it goes away with it.
+## Attaches a guard to [param root] and returns it, or returns the one already
+## there: two guards answer the same arrow twice and the ring moves two controls
+## a press. A guard is a child of the screen it watches and goes away with it.
 static func attach(root: Control) -> Gen2FocusGuard:
+	var existing := root.get_node_or_null(^"FocusGuard") as Gen2FocusGuard
+	if existing != null:
+		return existing
 	var guard := Gen2FocusGuard.new()
 	guard.name = "FocusGuard"
 	guard._root = root
@@ -52,13 +61,11 @@ static func attach(root: Control) -> Gen2FocusGuard:
 
 func _ready() -> void:
 	Gen2InputRuntime.instance().device_changed.connect(_on_device_changed)
-	# One frame late: a screen built in code has nothing to focus while its own
-	# _ready is still running.
+	# One frame late: a screen built in code has nothing to focus yet.
 	refresh.call_deferred()
 
 
-## Puts focus on the first control that can take it, if the player is using a
-## device that wants one and nothing has it already.
+## Puts the ring on the first control that can take it, if the device wants one.
 func refresh() -> void:
 	if _root == null or not _root.is_inside_tree():
 		return
@@ -78,9 +85,8 @@ func refresh() -> void:
 		target.grab_focus()
 
 
-## The part of the screen the guard is allowed to look at: the last modal added
-## under [member _root], or the whole screen when there is none. The last, so a
-## sheet opened over a sheet owns the arrows.
+## What the guard may look at: the last modal under [member _root], so a sheet
+## opened over a sheet owns the arrows, or the whole screen when there is none.
 func _effective_root() -> Control:
 	var top: Control = _root
 	for node: Node in _root.get_tree().get_nodes_in_group(MODAL_GROUP):
@@ -97,8 +103,7 @@ func _wanted() -> Control:
 		preferred != null
 		and is_instance_valid(preferred)
 		and preferred.is_visible_in_tree()
-		and preferred.focus_mode == Control.FOCUS_ALL
-		and not _is_disabled(preferred)
+		and _focusable(preferred)
 	):
 		return preferred
 	return first_focusable(_effective_root())
@@ -108,10 +113,9 @@ func _on_device_changed(_kind: StringName) -> void:
 	refresh()
 
 
-## Directional fallback for layouts Godot cannot join geometrically, notably
-## the page host and the floating dock. It only receives an unhandled action,
-## so native traversal inside rows, sliders, text fields and scroll panes keeps
-## precedence.
+## Directional fallback for layouts Godot cannot join geometrically. It sees only
+## an unhandled action, so native traversal inside rows, sliders, text fields and
+## scroll panes keeps precedence.
 func move_focus(direction: Vector2) -> bool:
 	if _root == null or not _root.is_inside_tree() or direction == Vector2.ZERO:
 		return false
@@ -121,25 +125,41 @@ func move_focus(direction: Vector2) -> bool:
 	if current == null or not top.is_ancestor_of(current):
 		refresh()
 		return viewport.gui_get_focus_owner() != null
-	var best: Control = _neighbor(current, direction, focusable_controls(top))
-	if best == null:
+	var best: Control = _toward(current, direction, focusable_controls(top), top == _root)
+	if best == null or best == current:
 		return false
 	best.grab_focus()
 	return true
 
 
-## Godot's automatic search is unreliable across nested cards, scroll panes and
-## the floating dock. Explicit neighbours make the same visual layout produce
-## the same route for arrows, WASD mappings and controller d-pads.
+## Godot's automatic search is unreliable across nested cards and scroll panes.
+## Explicit neighbours give arrows, WASD and a d-pad the one visible route.
 func _refresh_focus_neighbors() -> void:
 	if _root == null or not _root.is_inside_tree():
 		return
-	var controls: Array[Control] = focusable_controls(_effective_root())
+	var top: Control = _effective_root()
+	var controls: Array[Control] = focusable_controls(top)
+	var edges: bool = top == _root
 	for control: Control in controls:
-		_set_neighbor(control, &"left", _neighbor(control, Vector2.LEFT, controls))
-		_set_neighbor(control, &"right", _neighbor(control, Vector2.RIGHT, controls))
-		_set_neighbor(control, &"up", _neighbor(control, Vector2.UP, controls))
-		_set_neighbor(control, &"down", _neighbor(control, Vector2.DOWN, controls))
+		for side: StringName in SIDES:
+			var direction: Vector2 = SIDES[side]
+			_set_neighbor(control, side, _toward(control, direction, controls, edges))
+
+
+## The neighbour that way, or the screen's edge target. [param edges] is false
+## inside a modal, whose own edges are its own.
+func _toward(
+	current: Control, direction: Vector2, controls: Array[Control], edges: bool
+) -> Control:
+	var best: Control = _neighbor(current, direction, controls)
+	if best != null or not edges:
+		return best
+	var make: Variant = edge_targets.get(Gen2Button.from_vector(Vector2i(direction)))
+	if make is not Callable:
+		return null
+	var target := (make as Callable).call(current) as Control
+	return target if target != null and target != current and target.is_visible_in_tree() \
+		else null
 
 
 static func _neighbor(
@@ -174,21 +194,9 @@ static func _set_neighbor(control: Control, side: StringName, target: Control) -
 		&"down": control.focus_neighbor_bottom = path
 
 
-## The first control under [param root] that would accept focus, depth first in
-## tree order, which for a screen built top to bottom is the first one a reader
-## would point at.
+## The first control under [param root] that would accept focus, depth first.
 static func first_focusable(root: Node) -> Control:
-	for child: Node in root.get_children():
-		var control := child as Control
-		if control != null:
-			if not control.visible:
-				continue
-			if control.focus_mode == Control.FOCUS_ALL and not _is_disabled(control):
-				return control
-		var found: Control = first_focusable(child)
-		if found != null:
-			return found
-	return null
+	return _first_focusable(root, true)
 
 
 static func focusable_controls(root: Node) -> Array[Control]:
@@ -203,16 +211,40 @@ static func _collect_focusable(root: Node, out: Array[Control]) -> void:
 		if control != null:
 			if not control.is_visible_in_tree():
 				continue
-			if control.focus_mode == Control.FOCUS_ALL and not _is_disabled(control) \
-				and not _scroll_with_controls(control):
+			if _takes_focus(control):
 				out.append(control)
 		_collect_focusable(child, out)
 
 
+## Whether the ring may rest here. One rule, so where it lands and where it may
+## travel are the same set; a landing spot it cannot leave strands a controller.
+static func _takes_focus(control: Control) -> bool:
+	return _focusable(control) and not _scroll_with_controls(control)
+
+
+static func _focusable(control: Control) -> bool:
+	return control.focus_mode == Control.FOCUS_ALL and not _is_disabled(control)
+
+
+static func _first_focusable(root: Node, skip_panes: bool) -> Control:
+	for child: Node in root.get_children():
+		var control := child as Control
+		if control != null:
+			if not control.visible:
+				continue
+			if _focusable(control) and not (skip_panes and _scroll_with_controls(control)):
+				return control
+		var found: Control = _first_focusable(child, skip_panes)
+		if found != null:
+			return found
+	return null
+
+
+## A pane takes focus so prose can be read without a pointer, and answers an up
+## or a down by scrolling ([Gen2LauncherScroll]). One holding controls is a dead
+## end: it eats every direction and the controls are never reached.
 static func _scroll_with_controls(control: Control) -> bool:
-	if not control is ScrollContainer:
-		return false
-	return first_focusable(control) != null
+	return control is ScrollContainer and _first_focusable(control, false) != null
 
 
 static func _is_disabled(control: Control) -> bool:

--- a/game/launcher/binding_sheet.gd
+++ b/game/launcher/binding_sheet.gd
@@ -189,17 +189,20 @@ func _finish_capture(binding: Dictionary) -> void:
 
 
 ## While capturing, every key and pad event belongs to the binding rather than to
-## the sheet, so the parent's cancel is deliberately not reached. That used to
-## leave a player on a pad alone with no way out but to bind something and then
-## remove it, so a capture now reads the press and acts on the release: a tap
-## binds, and holding past [constant HOLD_CANCEL_MSEC] closes the sheet instead.
-## The mouse and a finger still work as they did.
+## the sheet, so the parent's cancel is never reached. A capture reads the press
+## and acts on the release: a tap binds, holding past [constant HOLD_CANCEL_MSEC]
+## closes the sheet, and a pad player is left a way out. Mouse and finger are as
+## they were.
 func _unhandled_input(event: InputEvent) -> void:
 	if not _capturing:
 		super._unhandled_input(event)
 		return
 	if event is InputEventMouse or event is InputEventScreenTouch \
-		or event is InputEventScreenDrag or event is InputEventAction:
+		or event is InputEventScreenDrag:
+		return
+	if event is InputEventAction:
+		# A held direction's own repeat: it must not walk the ring behind here.
+		accept_event()
 		return
 	if event.is_echo():
 		return

--- a/game/launcher/launcher_scroll.gd
+++ b/game/launcher/launcher_scroll.gd
@@ -1,19 +1,21 @@
 class_name Gen2LauncherScroll
 extends ScrollContainer
 
-## A vertical scroll pane that can be read without a pointer, since Godot gives
-## neither thing by default. A pad walking the controls inside a pane has to bring
-## the pane with it, and a pane whose content is mostly text has stretches with
-## nothing focusable, so the pane itself takes focus and reads an up or a down as
-## scrolling. It only takes focus when it has somewhere to go. A finger is the
-## third way: [constant Control.MOUSE_FILTER_STOP] ends a pointer event at the
-## control it reaches and every launcher button is STOP, so the pane reads the
-## touch in [method Node._input] and leaves the engine's own drag switched off.
+## A vertical scroll pane that can be read without a pointer, which Godot does
+## not give. A pad walking the controls inside brings the pane with it; a pane of
+## prose has nothing focusable, so it takes focus itself and reads an up or a down
+## as scrolling. A finger is the third way: [constant Control.MOUSE_FILTER_STOP]
+## ends a pointer event at the button it reaches, so the pane reads the touch in
+## [method Node._input] and leaves the engine's own drag off.
 
 ## How far one press moves the pane, as a fraction of what it shows.
 const PAGE: float = 0.42
+## How far one repeat of a held direction moves it: a repeat every five frames
+## ([Gen2InputRuntime]) carrying a page each would be five screens a second.
+const LINE: float = 0.10
 ## How far a finger travels before the touch is a scroll rather than a tap.
 const TOUCH_DEADZONE: float = 12.0
+const WAYS: Dictionary = {Gen2Button.DOWN: 1, Gen2Button.UP: -1}
 
 ## The finger this pane is following, or -1.
 var _touch_index: int = -1
@@ -25,10 +27,9 @@ var _touch_dragging: bool = false
 
 static func create() -> Gen2LauncherScroll:
 	var scroll := Gen2LauncherScroll.new()
-	# Never `SCROLL_MODE_DISABLED`: that adds the child's whole minimum width to
-	# the pane, so one row wider than the window widens the launcher itself
-	# rather than being held inside the pane. Hidden instead, and the rows stack
-	# or wrap ([FieldRow], `controls_section.gd`) so nothing needs the axis.
+	# Never `SCROLL_MODE_DISABLED`: that adds the child's whole minimum width, so
+	# one row wider than the window widens the launcher rather than being held
+	# inside. Hidden instead, and the rows wrap so nothing needs the axis.
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_SHOW_NEVER
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	scroll.follow_focus = true
@@ -63,26 +64,26 @@ func _gui_input(event: InputEvent) -> void:
 		accept_event()
 
 
-## The repeat a held direction produces is an [InputEventAction]
-## ([method Gen2InputRuntime._advance_direction_repeat]), and the engine routes
-## no action to `_gui_input`, so a pane holding focus reads its repeats here.
+## A held direction repeats as an [InputEventAction], and the engine routes no
+## action to `_gui_input`, so a pane holding focus reads its repeats here.
 func _unhandled_input(event: InputEvent) -> void:
 	if has_focus() and _scroll_by(event):
 		get_viewport().set_input_as_handled()
 
 
+## Whether the pane took the direction. One already at that end of its travel
+## does not, or the player is stranded on a page they have finished reading.
 func _scroll_by(event: InputEvent) -> bool:
 	if not _scrollable():
 		return false
-	var step: float = maxf(size.y * PAGE, 40.0)
-	match Gen2Button.direction_in(event):
-		Gen2Button.DOWN:
-			scroll_vertical = int(float(scroll_vertical) + step)
-			return true
-		Gen2Button.UP:
-			scroll_vertical = int(float(scroll_vertical) - step)
-			return true
-	return false
+	var way: int = int(WAYS.get(Gen2Button.direction_in(event), 0))
+	if way == 0:
+		return false
+	var at: int = scroll_vertical
+	# A repeat is an InputEventAction; a press the player made is not.
+	var fraction: float = LINE if event is InputEventAction else PAGE
+	scroll_vertical = int(float(at) + float(way) * maxf(size.y * fraction, 40.0))
+	return scroll_vertical != at
 
 
 func _on_screen_touch(touch: InputEventScreenTouch) -> void:
@@ -127,11 +128,10 @@ func _takes_touches(point: Vector2) -> bool:
 	return true
 
 
-## Takes the press off the button the finger landed on, now that the finger has
-## turned out to be scrolling. [BaseButton] tracks a touch itself, and nothing
-## public cancels one; disabling clears the attempt and re-enabling in the same
-## call leaves the button live for the release that is still to come, which is
-## what clears its own record of the finger.
+## Takes the press off the button the finger landed on, now that it has turned
+## out to be scrolling. [BaseButton] tracks a touch itself and nothing public
+## cancels one; disabling clears the attempt and re-enabling in the same call
+## leaves it live for the release that clears its own record of the finger.
 func _release_pressed_button() -> void:
 	_cancel_card_presses(self)
 	var button: BaseButton = _button_at(self, _touch_from)
@@ -161,8 +161,7 @@ static func _button_at(node: Node, point: Vector2) -> BaseButton:
 	return null
 
 
-## Whether there is more here than fits, which is the only case where the pane is
-## worth stopping on.
+## Whether there is more here than fits, the only case worth stopping on.
 func _scrollable() -> bool:
 	var bar: VScrollBar = get_v_scroll_bar()
 	return bar != null and bar.max_value > bar.page

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -162,6 +162,7 @@ func _build() -> void:
 	_apply_layout()
 	_place_toast()
 	_focus = Gen2FocusGuard.attach(self)
+	_focus.edge_targets = {Gen2Button.DOWN: _dock_landing}
 
 
 ## The wall clock, on the twenty-four hour dial the rest of the project uses.
@@ -386,11 +387,17 @@ func _rebuild_dock() -> void:
 		select(_current)
 
 
-## The dock overlaps the page by design, which makes Godot's geometric focus
-## search prefer the large page control above it over a neighbouring disc.
-## Own the dock's axes explicitly: horizontal movement stays in the dock and
-## wraps, while up returns to the current page. Keyboard and controller arrows
-## are both the same ui_* actions here.
+## The dock floats over the page, so a page longer than the window has nothing
+## below its last control. Down out of a page lands on the disc it is on.
+func _dock_landing(from: Control) -> Control:
+	if _dock_host == null or not _dock_host.visible or _dock.is_ancestor_of(from):
+		return null
+	return _buttons.get(_current) as Control
+
+
+## The dock overlaps the page, so Godot's geometric search prefers the large page
+## control above a disc over the neighbouring disc. The dock owns its own axes:
+## left and right stay in it and wrap, up returns to the page.
 func _on_dock_input(event: InputEvent, id: StringName) -> void:
 	var at: int = -1
 	for index: int in _entries.size():

--- a/game/save/save_editor_screen.gd
+++ b/game/save/save_editor_screen.gd
@@ -181,7 +181,6 @@ func _build_ui() -> void:
 
 	_status = Gen2LauncherUI.muted(_palette, "")
 	root.add_child(_status)
-	Gen2FocusGuard.attach(self)
 
 
 ## The page's own edges, standing off the notch, the rounded corners and the home

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -14,9 +14,9 @@ enum Phase { WOKE_UP, HOUR, HOUR_CONFIRM, MINUTE, MINUTE_CONFIRM, RESPONSE, DONE
 
 const TILE: int = Gen2Font.TILE
 
-## `SetDayOfWeek`'s own `.WeekdayStrings`, padded the way the source pads them so
-## the name is centred in its nine-wide box. Drawn by Mom's errand rather than
-## here; this is where the strings live because the dial page is shared.
+## `SetDayOfWeek`'s own `.WeekdayStrings`, padded the way the source pads them to
+## centre the name in its nine-wide box. Drawn by Mom's errand; here because the
+## dial page is shared.
 const DAYS: Array[String] = [
 	" SUNDAY", " MONDAY", " TUESDAY", "WEDNESDAY", "THURSDAY", " FRIDAY", "SATURDAY",
 ]
@@ -34,10 +34,9 @@ const DAY_HOUR: int = 10
 const NITE_HOUR: int = 18
 const NOON_HOUR: int = 12
 
-## `.loop` and `.HourIsSet` both end on `ld c, 10 / call DelayFrames` before
-## their input loop, and `InterpretTwoOptionMenu` holds `ld c, $f` after an
-## answer, so neither a dial nor a YES/NO reads a button on the frame it is
-## drawn.
+## `.loop` and `.HourIsSet` end on `ld c, 10 / call DelayFrames` before their
+## input loop and `InterpretTwoOptionMenu` holds `ld c, $f` after an answer, so
+## neither a dial nor a YES/NO reads a button on the frame it is drawn.
 const DIAL_DELAY_FRAMES: int = 10
 const YES_NO_DELAY_FRAMES: int = 15
 
@@ -102,9 +101,8 @@ func advance_frames(count: int) -> void:
 		if _text_box != null:
 			_text_box.advance_frame()
 		if not _waiting:
-			# The YES/NO box is `YesNoBox`, which runs after its question has
-			# finished printing, so the screen behind the box is redrawn on the
-			# frame the reveal ends.
+			# `YesNoBox` runs after its question has printed, so the screen
+			# behind the box is redrawn on the frame the reveal ends.
 			if _text_box != null and _revealing != _text_box.is_revealing():
 				_render()
 			continue
@@ -199,9 +197,8 @@ func _accept_confirm(yes: bool) -> void:
 	_begin_response()
 
 
-## `OakSpeech`'s `farcall InitClock` opens on `RotateFourPalettesRight`: the
-## caller faded to black over the gender screen, this screen is built behind it
-## and comes back in. `PrintText OakTimeWokeUpText` is what follows.
+## `OakSpeech`'s `farcall InitClock` opens on `RotateFourPalettesRight`: the fade
+## to black was over the gender screen, and this one comes back in behind it.
 func _begin() -> void:
 	_presentation.clear()
 	_presentation.push_rotate_four_right()
@@ -234,12 +231,16 @@ func _begin_minute() -> void:
 	_hold(DIAL_DELAY_FRAMES)
 
 
-## `.ClearScreen` takes the dial off before either question, so a YES/NO box
-## stands on an otherwise empty screen.
+## `.ClearScreen` takes the dial off before either question. `OakTimeWhatHoursText`
+## places the hour at `hlcoord 1, 16`, the box's second line, and
+## `OakTimeWhoaMinutesText` the minutes at `hlcoord 7, 14` beside `Whoa!`.
 func _begin_confirm() -> void:
 	_phase = Phase.HOUR_CONFIRM if _phase == Phase.HOUR else Phase.MINUTE_CONFIRM
 	_confirm_cursor = 0
-	_show_line("What?" if _phase == Phase.HOUR_CONFIRM else "Whoa!")
+	if _phase == Phase.HOUR_CONFIRM:
+		_show_line("What?\n%s?" % _hour_value())
+		return
+	_show_line("Whoa! %s?" % _minute_value())
 
 
 ## `.MinutesAreSet`: `OakText_ResponseToSetTime` prints the time it was given and
@@ -298,10 +299,10 @@ func _render() -> void:
 	var value_text: String = ""
 	if _phase == Phase.HOUR:
 		kind = &"hour"
-		value_text = "%s o'clock" % _hour_text()
+		value_text = _hour_value()
 	elif _phase == Phase.MINUTE:
 		kind = &"minutes"
-		value_text = "%d min." % _minute
+		value_text = _minute_value()
 	# Every BG palette on screen goes through the frame's own byte, which is what
 	# a hardware fade does to a screen carrying more than one palette.
 	var colors: PackedColorArray = Gen2IntroPresentation.apply_bgp(
@@ -314,6 +315,16 @@ func _render() -> void:
 	if _text_box != null:
 		_text_box.palette = colors
 		_revealing = _text_box.is_revealing()
+
+
+## `DisplayHourOClock`, printed by the dial and by the hour's own question.
+func _hour_value() -> String:
+	return "%s o'clock" % _hour_text()
+
+
+## `DisplayMinutesWithMinString`, the same for the minutes.
+func _minute_value() -> String:
+	return "%d min." % _minute
 
 
 ## `PrintHour` prints `GetTimeOfDayString`'s own MORN/DAY/NITE ahead of the

--- a/tests/integration/test_intro_screen.gd
+++ b/tests/integration/test_intro_screen.gd
@@ -190,6 +190,35 @@ func test_clock_set_wraps_each_source_dial_and_reaches_the_speech() -> void:
 	assert_true(_screen.current() is Gen2OakSpeechScreen)
 
 
+## `OakTimeWhatHoursText` and `OakTimeWhoaMinutesText` are each a `text_asm` that
+## places the value its YES/NO is about: the hour at `hlcoord 1, 16`, the box's
+## second line, the minutes at `hlcoord 7, 14` beside `Whoa!`. Without it the box
+## asks nothing.
+func test_each_yes_no_names_the_value_it_is_asking_about() -> void:
+	_begin()
+	_screen.handle_button(Gen2Button.A)
+	_settle()
+	var clock: Gen2ClockSetScreen = _screen.current() as Gen2ClockSetScreen
+	for _page: int in 3:
+		_settle()
+		clock.handle_button(Gen2Button.A)
+	_settle()
+	var box: Gen2TextBox = clock.get("_text_box")
+	assert_eq(Array(box.text_lines()), ["What time is it?"])
+
+	clock.handle_button(Gen2Button.A)
+	_settle()
+	assert_eq(Array(box.text_lines()), ["What?", "DAY 10 o'clock?"])
+
+	clock.handle_button(Gen2Button.A)
+	_settle()
+	assert_eq(Array(box.text_lines()), ["How many minutes?"])
+
+	clock.handle_button(Gen2Button.A)
+	_settle()
+	assert_eq(Array(box.text_lines()), ["Whoa! 0 min.?"])
+
+
 ## `.loop` and `.HourIsSet` end on `ld c, 10 / call DelayFrames`, and
 ## `InterpretTwoOptionMenu` on `ld c, $f`, so neither a dial nor a YES/NO reads
 ## a button on the frame it is drawn.

--- a/tests/integration/test_launcher_focus.gd
+++ b/tests/integration/test_launcher_focus.gd
@@ -134,6 +134,104 @@ func test_a_mouse_is_left_alone() -> void:
 	assert_null(_focus_owner())
 
 
+## A scroll pane takes focus so prose can be read without a pointer, and answers
+## every up and down by scrolling. Landing the ring on one that holds controls
+## left a pad with no visible focus and no way past the page.
+func test_the_ring_never_lands_on_a_pane_that_holds_controls() -> void:
+	for page: StringName in [&"settings", &"about"]:
+		_use(InputEventJoypadButton.new())
+		_launcher.select_page(page)
+		await get_tree().process_frame
+		await get_tree().process_frame
+		var focused: Control = _focus_owner()
+		assert_not_null(focused, String(page))
+		assert_false(focused is ScrollContainer, "%s stranded the ring on its pane" % page)
+		assert_true(focused is BaseButton, String(page))
+
+
+## Every control on a scrolling page has to be reachable, and the page has to be
+## leavable: the walk ends on the dock rather than on a control with nothing
+## under it.
+func test_a_pad_walks_the_whole_settings_page_and_leaves_it() -> void:
+	_use(InputEventJoypadButton.new())
+	_launcher.select_page(&"settings")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var guard: Gen2FocusGuard = _launcher.find_child("FocusGuard", true, false)
+	var seen: Array[Control] = []
+	var on_dock: bool = false
+	for _step: int in 200:
+		var focused: Control = _focus_owner()
+		if focused == null:
+			break
+		if not seen.has(focused):
+			seen.append(focused)
+		if focused is Gen2LauncherButton and (focused as Gen2LauncherButton).tooltip_text == "Settings":
+			on_dock = true
+			break
+		if not guard.move_focus(Vector2.DOWN):
+			break
+		# The pane brings the newly focused control into view, and the next
+		# neighbour is chosen from where things are once it has.
+		await get_tree().process_frame
+	assert_true(on_dock, "down never reached the dock")
+	assert_gt(seen.size(), 5, "the walk skipped the page")
+
+
+## `JoyTextDelay`'s repeat arrives as one action press ([Gen2InputRuntime]), and
+## a screen that answered it twice would cross a page before the player let go.
+func test_one_repeat_of_a_held_direction_moves_the_ring_one_control() -> void:
+	_use(InputEventJoypadButton.new())
+	_launcher.select_page(&"settings")
+	await get_tree().process_frame
+	await get_tree().process_frame
+	var from: Control = _focus_owner()
+	assert_not_null(from)
+	var next: Control = from.get_node_or_null(from.focus_neighbor_bottom) as Control
+	assert_not_null(next, "the guard names what is below")
+
+	var runtime: Gen2InputRuntime = Gen2InputRuntime.instance()
+	runtime.send_action(Gen2Button.action(Gen2Button.DOWN), true)
+	await get_tree().process_frame
+	assert_same(_focus_owner(), next, "one repeat is one control, not two")
+	runtime.send_action(Gen2Button.action(Gen2Button.DOWN), false)
+	await get_tree().process_frame
+
+
+## A pane that answered a direction at the end of its travel was a trap: down
+## scrolled nothing forever and the dock was never reached.
+func test_a_pane_hands_a_direction_on_once_it_has_nowhere_left_to_scroll() -> void:
+	var pane: Gen2LauncherScroll = Gen2LauncherScroll.create()
+	pane.size = Vector2(200, 100)
+	add_child_autofree(pane)
+	var tall := Control.new()
+	tall.custom_minimum_size = Vector2(200, 2000)
+	pane.add_child(tall)
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var down := InputEventAction.new()
+	down.action = Gen2Button.action(Gen2Button.DOWN)
+	down.pressed = true
+	assert_true(pane._scroll_by(down), "there is room below")
+	for _step: int in 400:
+		if not pane._scroll_by(down):
+			break
+	assert_false(pane._scroll_by(down), "the bottom hands the press on")
+
+	var up := InputEventAction.new()
+	up.action = Gen2Button.action(Gen2Button.UP)
+	up.pressed = true
+	assert_true(pane._scroll_by(up), "and up still moves from there")
+
+
+func test_two_attaches_on_one_screen_are_one_guard() -> void:
+	var root := Control.new()
+	add_child_autofree(root)
+	var first: Gen2FocusGuard = Gen2FocusGuard.attach(root)
+	assert_same(Gen2FocusGuard.attach(root), first, "two rings move two controls a press")
+
+
 func test_the_first_focusable_skips_what_cannot_take_focus() -> void:
 	var root := Control.new()
 	add_child_autofree(root)
@@ -148,6 +246,32 @@ func test_the_first_focusable_skips_what_cannot_take_focus() -> void:
 	root.add_child(wanted)
 
 	assert_same(Gen2FocusGuard.first_focusable(root), wanted)
+
+
+func test_the_first_focusable_enters_a_pane_rather_than_stopping_on_it() -> void:
+	var root := Control.new()
+	add_child_autofree(root)
+	var pane := ScrollContainer.new()
+	pane.focus_mode = Control.FOCUS_ALL
+	root.add_child(pane)
+	var inside := Button.new()
+	pane.add_child(inside)
+
+	assert_same(Gen2FocusGuard.first_focusable(root), inside)
+	assert_false(Gen2FocusGuard.focusable_controls(root).has(pane))
+
+
+## A pane with nothing focusable in it is the one that keeps the ring: scrolling
+## it is the only way past a wall of prose without a pointer.
+func test_a_pane_of_prose_still_takes_the_ring() -> void:
+	var root := Control.new()
+	add_child_autofree(root)
+	var pane := ScrollContainer.new()
+	pane.focus_mode = Control.FOCUS_ALL
+	root.add_child(pane)
+	pane.add_child(Label.new())
+
+	assert_same(Gen2FocusGuard.first_focusable(root), pane)
 
 
 func test_nothing_focusable_is_not_an_error() -> void:

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -90,6 +90,35 @@ func _press(keycode: Key) -> InputEventKey:
 	return key
 
 
+func _pad(button: JoyButton) -> InputEventJoypadButton:
+	var event := InputEventJoypadButton.new()
+	event.button_index = button
+	event.pressed = true
+	return event
+
+
+## A game menu is driven by the eight buttons and nothing else, so what a pad has
+## to prove is that its own events make them: a face button, the d-pad, and the
+## [InputEventAction] a held direction repeats as ([Gen2InputRuntime]).
+func test_a_controller_opens_and_walks_the_start_menu() -> void:
+	await _open_world_with_renderer()
+	_world_screen._unhandled_input(_pad(JOY_BUTTON_START))
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_not_null(host, "START on a pad opens the pause menu")
+	var first: int = host.cursor()
+
+	_world_screen._unhandled_input(_pad(JOY_BUTTON_DPAD_DOWN))
+	var second: int = host.cursor()
+	assert_ne(second, first, "the d-pad moves the cursor")
+
+	var repeat := InputEventAction.new()
+	repeat.action = Gen2Button.action(Gen2Button.DOWN)
+	repeat.pressed = true
+	_world_screen._unhandled_input(repeat)
+	assert_ne(host.cursor(), second, "a held direction keeps moving it")
+
+
 func test_a_renderer_receives_the_input_the_screen_does_not_use() -> void:
 	var renderer: Node = await _open_world_with_renderer()
 	assert_true(renderer.has_method(Gen2ModHost.RENDERER_INPUT_METHOD))

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37887
+const MAX_COMMENT_LINES: int = 37886
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Delete
 ## a line when you fix one. The test fails on a line that no longer names a


### PR DESCRIPTION
Two reported defects, each fixed where every occurrence goes through.

## A new game asked "What?" and "Whoa!" and nothing else

`InitClock`'s two YES/NO questions are each a `text_asm` that places the value being confirmed. `OakTimeWhatHoursText` puts the hour at `hlcoord 1, 16`, the box's second line; `OakTimeWhoaMinutesText` puts the minutes at `hlcoord 7, 14`, beside `Whoa!`. Neither was here, so both boxes asked a question with no subject and the YES/NO had nothing to answer.

The box now reads `What?` over `DAY 10 o'clock?`, and `Whoa! 0 min.?`. One helper prints each value, so the dial and its question can no longer disagree.

Swept: `SetDayOfWeek`'s confirm already carried its weekday and the slot machine already draws its payout symbol beside its line. Those two boxes were the only `text_asm` values in the tree that had gone missing.

## A controller could not get through the launcher

`Gen2FocusGuard` had two rules for where the ring may be. Traversal skipped a scroll pane holding controls; the first-landing search did not. So Settings, About and every other scrolling page opened with the ring on the pane, where nothing is drawn and every up and down is answered by scrolling rather than by moving. Both searches now ask one predicate, so where the ring lands and where it can travel are the same set.

Three more from the same walk.

| What | Was | Is |
|---|---|---|
| The bottom of a long page | The dock floats over the page, so the last control had nothing below it and the discs were unreachable | A screen names where a direction goes when nothing on it lies that way; the launcher names the disc for the page being left |
| A pane at the end of its travel | Swallowed the direction forever | Hands it on |
| One repeat over a pane | A page, five screens a second at the source's five-frame repeat | A tenth of a screen |
| The save editor | Attached two guards to itself and moved the ring two controls a press | `attach` returns the one already there |
| A held direction while binding | Walked the ring behind the sheet | Swallowed |

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 4015 pass |
| Editor analyser | 0 warnings in 597 scripts |
| `validate.gd -- all` | 78 topics pass |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | unchanged |

Six new cases. The intro walk reads both YES/NO boxes back. The launcher walk lands a pad on a button rather than on a pane for Settings and About, crosses the whole of Settings and leaves it by the dock, and checks that one repeat moves one control. A pane at the bottom of its travel hands a direction on. The world screen opens and walks its pause menu from a real pad event, which nothing drove before.
