### PR TITLE
Let go of a direction the moment the key does

### DIFF
--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -10,16 +10,14 @@ extends Node
 ## `-s` script compiles before the tree that owns the autoloads exists.
 
 signal device_changed(kind: StringName)
-## The effective answer, after both the setting and the active device. Also
-## emitted when the frontmost controller changes, since that changes which pad
-## should be drawing even though the setting has not moved.
+## The effective answer, after both the setting and the active device. Emitted for
+## a change of frontmost controller too, which changes which pad should draw.
 signal touch_controls_changed(shown: bool)
 ## A rebind landed. What is bound has already been installed in the [InputMap]
 ## by the time this arrives; a screen only needs it to redraw a legend.
 signal scheme_changed()
-## A + B + START + SELECT, the console's own reset, reported once per press of
-## the chord. The machine's rather than the game's, so it is detected here and
-## whichever screen is up decides what a reset costs.
+## A + B + START + SELECT, the console's own reset, reported once per press. The
+## machine's rather than the game's, so whichever screen is up decides its cost.
 signal reset_chord_pressed()
 
 var _scheme: Dictionary = {}
@@ -43,12 +41,10 @@ var _repeat_open: Dictionary = {}
 ## Whether all four reset buttons were down last frame, so the chord fires once
 ## per press rather than once per frame it is held.
 var _reset_chord_down: bool = false
-## Every on-screen controller in the tree, innermost last. A battle opened over
-## the map puts a second one on screen, and only the top of this stack may draw
-## or read a finger.
+## Every on-screen controller in the tree, innermost last: a battle over the map
+## puts a second one up, and only the top of this stack draws or reads a finger.
 ## Typed as Control rather than as the pad, which keeps this script off the one
-## that draws it: the pad has to name this class, and two class names that name
-## each other do not compile.
+## that draws it; two class names that name each other do not compile.
 var _pads: Array[Control] = []
 
 ## `JoyTextDelay`, which is the whole of the hardware's menu auto-repeat
@@ -62,8 +58,7 @@ const REPEAT_INTERVAL_FRAMES: int = 5
 const FRAME_SECONDS: float = 1.0 / 60.0
 
 ## The four buttons a Game Boy resets on. `home/init.asm` wires them to the
-## hardware rather than to any routine, so the chord works from anywhere the
-## console is running and is not something the game can decline.
+## hardware rather than to a routine, so no game code can decline the chord.
 const RESET_CHORD: Array[int] = [
 	Gen2Button.A, Gen2Button.B, Gen2Button.START, Gen2Button.SELECT,
 ]
@@ -72,11 +67,10 @@ const RESET_CHORD: Array[int] = [
 static var _instance: Gen2InputRuntime = null
 
 
-## Named relative to the root rather than as `/root/InputRuntime`: a script
-## handed to `-s` runs outside the active scene tree, where an absolute path
-## makes even `get_node_or_null` push an error before returning null. The
-## no-runtime answer is the intended one for every headless run, so it has to be
-## silent.
+## Named relative to the root rather than as `/root/InputRuntime`: a script handed
+## to `-s` runs outside the active scene tree, where an absolute path makes even
+## `get_node_or_null` push an error, and no runtime is the intended headless
+## answer.
 static func instance() -> Gen2InputRuntime:
 	if _instance == null:
 		var loop: SceneTree = Engine.get_main_loop() as SceneTree
@@ -154,9 +148,9 @@ func touch_controls_shown() -> bool:
 
 ## Turns the on-screen controller back on and writes it to the options file.
 ##
-## The escape from [constant Gen2Options.TOUCH_NEVER], which is the one setting
-## that can leave a touch-only player with nothing to press. It restores `auto`
-## rather than `always`, so a pad the player picks up again still hides it.
+## The escape from [constant Gen2Options.TOUCH_NEVER], the one setting that can
+## leave a touch-only player with nothing to press. It restores `auto` rather than
+## `always`, so a pad picked up again still hides it.
 func reveal_touch_controls() -> bool:
 	if _touch_mode != Gen2Options.TOUCH_NEVER:
 		return false
@@ -192,12 +186,11 @@ func active_touch_pad() -> Control:
 	return _pads.back() if not _pads.is_empty() else null
 
 
-## Presses a button from something that is not a device: the on-screen
-## controller, a preview, or a test.
-##
-## Sent as an [InputEventAction] through [method Input.parse_input_event] rather
-## than delivered to a screen directly, so it takes the same path a key does and
-## arrives at both the event handlers and [method Input.is_action_pressed].
+## Presses a button from something that is not a device: the on-screen controller,
+## a preview, or a test. Sent as an [InputEventAction] through
+## [method Input.parse_input_event], so it takes the same path a key does and
+## reaches both the event handlers and [method Input.is_action_pressed]. That is a
+## state, so every caller owes the matching [method release].
 func press(button: int) -> void:
 	_send(button, true)
 
@@ -221,12 +214,12 @@ func send_action(action: StringName, pressed: bool) -> void:
 	Input.parse_input_event(event)
 
 
-## Whether this event is a directional press nothing should act on. An analog
-## stick reports a fresh [InputEventJoypadMotion] on every value change and each
-## is an action press, so one push walked a menu the length of the list; a held
-## key repeats at the OS rate for the same reason. The extras are swallowed in
-## front of the engine's own focus navigation, and
-## [method _advance_direction_repeat] puts back the repeat the hardware had.
+## Whether this event is a directional press nothing should act on. A stick sends
+## a fresh [InputEventJoypadMotion] on every value change and each is an action
+## press, so one push walked a menu the length of its list; a held key repeats at
+## the OS rate for the same reason. The extras are swallowed in front of the
+## engine's own focus navigation, and [method _advance_direction_repeat] puts back
+## the repeat the hardware had.
 func _gate_direction_repeat(event: InputEvent) -> bool:
 	var button: int = Gen2Button.direction_in(event)
 	if button == Gen2Button.NONE:
@@ -240,10 +233,9 @@ func _gate_direction_repeat(event: InputEvent) -> bool:
 	return false
 
 
-## The direction currently held, most recently pressed first, or [constant
-## Gen2Button.NONE]. Polled rather than read off events, because walking
-## continues while a direction is held and the operating system's key repeat is
-## not the rate the hardware walked at.
+## The direction currently held, or [constant Gen2Button.NONE]. Polled rather than
+## read off events: walking continues while a direction is held, and the operating
+## system's key repeat is not the rate the hardware walked at.
 func held_direction() -> int:
 	return _direction_order.back() if not _direction_order.is_empty() else Gen2Button.NONE
 
@@ -290,10 +282,23 @@ func _advance_direction_repeat(delta: float) -> void:
 			continue
 		_repeat_clock[button] = FRAME_SECONDS * float(REPEAT_INTERVAL_FRAMES)
 		_repeat_open[button] = true
-		## Only a press. A release would take the action away from
-		## [method Gen2Button.held] while the player is still holding the button,
-		## and the map walks on that answer.
-		send_action(Gen2Button.action(button), true)
+		_emit_repeat(button)
+
+
+## One repeat, pushed into the tree rather than sent through
+## [method Input.parse_input_event]: a repeat is an edge, not a state. `Input`
+## keeps an action's API half apart from its device half and reports either as
+## pressed, and only an action release clears the API half, so a repeat sent as a
+## press latched the direction. The key came up, [method Gen2Button.held] stayed
+## true, and the walk, the menu and the repeat ran on with nothing to stop them.
+func _emit_repeat(button: int) -> void:
+	var viewport: Viewport = get_viewport()
+	if viewport == null:
+		return
+	var event := InputEventAction.new()
+	event.action = Gen2Button.action(button)
+	event.pressed = true
+	viewport.push_input(event)
 
 
 ## Whether a direction is down on either vocabulary; see

--- a/game/input/touch_pad.gd
+++ b/game/input/touch_pad.gd
@@ -165,6 +165,11 @@ func _on_touch_controls_changed(shown: bool) -> void:
 func _notification(what: int) -> void:
 	if what == NOTIFICATION_RESIZED:
 		queue_redraw()
+	elif what == NOTIFICATION_APPLICATION_FOCUS_OUT:
+		# The engine releases every pressed action when the app goes to the
+		# background and the finger that was down sends no up, so the pad has to
+		# forget it or that button is held here, released there, and dead.
+		release_all()
 
 
 func _input(event: InputEvent) -> void:

--- a/tests/integration/test_input_runtime.gd
+++ b/tests/integration/test_input_runtime.gd
@@ -153,15 +153,48 @@ func test_a_held_direction_repeats_at_the_source_rate_and_not_faster() -> void:
 	## The repeat the gate owes, spent as frames rather than as presses.
 	_runtime.press(Gen2Button.DOWN)
 	await _settle()
-	var owed: int = 0
-	for _frame: int in Gen2InputRuntime.REPEAT_DELAY_FRAMES + 1:
-		_runtime._advance_direction_repeat(Gen2InputRuntime.FRAME_SECONDS)
-		if bool(_runtime._repeat_open.get(Gen2Button.DOWN, false)):
-			owed += 1
-			_runtime._repeat_open[Gen2Button.DOWN] = false
-	assert_eq(owed, 1, "one repeat in the first fifteen frames, not fifteen")
+	assert_eq(_spend(Gen2InputRuntime.REPEAT_DELAY_FRAMES + 1), 1,
+		"one repeat in the first fifteen frames, not fifteen")
 	_runtime.release(Gen2Button.DOWN)
 	await _settle()
+
+
+func _key(pressed: bool) -> InputEventKey:
+	var key := InputEventKey.new()
+	key.physical_keycode = KEY_DOWN
+	key.pressed = pressed
+	return key
+
+
+## Spends [param frames] of repeat and answers how many reached the tree.
+func _spend(frames: int) -> int:
+	var counter := RepeatCounter.new()
+	add_child_autoqfree(counter)
+	for _frame: int in frames:
+		_runtime._advance_direction_repeat(Gen2InputRuntime.FRAME_SECONDS)
+	var seen: int = counter.seen
+	counter.queue_free()
+	return seen
+
+
+## A repeat is an edge, not a state. `Input` keeps an action's API state apart
+## from its device state and reports either as pressed, and only an action
+## release clears the API half, so a repeat sent through
+## [method Input.parse_input_event] latched the direction: the key came up, the
+## action stayed pressed, and the walk, the menu and the repeat itself all ran on
+## with nothing able to stop them.
+func test_a_held_direction_lets_go_the_moment_the_key_does() -> void:
+	Input.parse_input_event(_key(true))
+	_runtime._input(_key(true))
+	await _settle()
+	assert_eq(_runtime.held_direction(), Gen2Button.DOWN)
+	assert_gt(_spend(120), 15, "two seconds of a held key is repeating")
+
+	Input.parse_input_event(_key(false))
+	await _settle()
+	assert_false(Input.is_action_pressed(&"gen2_down"), "a repeat must not latch it")
+	assert_eq(_runtime.held_direction(), Gen2Button.NONE, "the walk stops with the key")
+	assert_eq(_spend(120), 0, "and so does the menu")
 
 
 ## Four buttons at once is a state no single press says, so the chord is polled
@@ -182,3 +215,14 @@ func test_the_reset_chord_is_reported_once_while_it_is_held() -> void:
 	for button: int in Gen2InputRuntime.RESET_CHORD:
 		_runtime.release(button)
 	await _settle()
+
+
+## Counts the repeats the runtime pushes into the tree, which is what a screen
+## sees. [member Gen2InputRuntime._repeat_open] cannot be read for this: the gate
+## clears it as the event arrives, and the event arrives inside the same call.
+class RepeatCounter extends Node:
+	var seen: int = 0
+
+	func _input(event: InputEvent) -> void:
+		if event is InputEventAction and event.is_action_pressed(&"gen2_down"):
+			seen += 1

--- a/tests/integration/test_world_renderer_input.gd
+++ b/tests/integration/test_world_renderer_input.gd
@@ -119,6 +119,53 @@ func test_a_controller_opens_and_walks_the_start_menu() -> void:
 	assert_ne(host.cursor(), second, "a held direction keeps moving it")
 
 
+## The reported defect, end to end. A repeat used to be sent as an action press,
+## which latched the direction in `Input`: the key came up, the pause menu went
+## on scrolling and the player went on walking with nothing able to stop them.
+func test_a_held_direction_stops_the_menu_the_moment_the_key_comes_up() -> void:
+	await _open_world_with_renderer()
+	var runtime: Gen2InputRuntime = Gen2InputRuntime.instance()
+	_world_screen._unhandled_input(_pad(JOY_BUTTON_START))
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	assert_not_null(host)
+
+	Input.parse_input_event(_key(true))
+	runtime._input(_key(true))
+	await get_tree().process_frame
+	var at: int = host.cursor()
+	var moved: int = 0
+	for _frame: int in 120:
+		runtime._advance_direction_repeat(Gen2InputRuntime.FRAME_SECONDS)
+		if host.cursor() != at:
+			moved += 1
+			at = host.cursor()
+	assert_gt(moved, 15, "two seconds of a held key walks the list")
+
+	## Two frames: one for the release to reach the input state, one for the
+	## runtime's own poll of it, which is what the walk reads.
+	Input.parse_input_event(_key(false))
+	await get_tree().process_frame
+	await get_tree().process_frame
+	assert_eq(runtime.held_direction(), Gen2Button.NONE, "the walk stops with it")
+
+	at = host.cursor()
+	var after: int = 0
+	for _frame: int in 120:
+		runtime._advance_direction_repeat(Gen2InputRuntime.FRAME_SECONDS)
+		if host.cursor() != at:
+			after += 1
+			at = host.cursor()
+	assert_eq(after, 0, "and so does the menu")
+
+
+func _key(pressed: bool) -> InputEventKey:
+	var key := InputEventKey.new()
+	key.physical_keycode = KEY_DOWN
+	key.pressed = pressed
+	return key
+
+
 func test_a_renderer_receives_the_input_the_screen_does_not_use() -> void:
 	var renderer: Node = await _open_world_with_renderer()
 	assert_true(renderer.has_method(Gen2ModHost.RENDERER_INPUT_METHOD))

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37886
+const MAX_COMMENT_LINES: int = 37884
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Delete
 ## a line when you fix one. The test fails on a line that no longer names a


### PR DESCRIPTION
A held direction never let go. Hold DOWN in the pause menu and it kept scrolling after the key came up; leave the menu and the player walked down with nothing able to stop them, and that direction could not be pressed again either. Every screen was affected, in the game and in the launcher, on a keyboard and on a pad.

## What it was

`Input` keeps two halves of an action's pressed state, the device half and the API half, and reports the action pressed if either is. A physical release clears only the device half. The API half is cleared by an action release and by nothing else.

`_advance_direction_repeat` sent each repeat as an `InputEventAction` press through `Input.parse_input_event`, which is the API half. The first repeat therefore latched the direction for the rest of the session:

| Reader | Effect |
|---|---|
| `Gen2Button.held` | stayed true, so `held_direction` walked the player for ever |
| `_direction_pressed` | stayed true, so the repeat clock was never cleared and the repeat ran on at twelve a second |
| `_gate_direction_repeat` | swallows a press while a clock is live, so that direction could never be pressed again |

Measured, two seconds after the key came up:

| | Before | After |
|---|---|---|
| `is_action_pressed("gen2_down")` | true | false |
| `held_direction()` | DOWN | NONE |
| Repeats still sent | 19, and no end | 0 |

## What it is

A repeat is an edge, not a state: the button is already held and only the screens need telling again. `_emit_repeat` pushes the event into the tree, so it reaches every `_input`, `_gui_input` and `_unhandled_input` exactly as it did and touches no action state.

`press` and `release` are unchanged. The on-screen controller has no device behind it and its hold really is a state; the contract that every `press` owes a `release` is now written on it.

The one other way to leave a button held is an app sent to the background: the engine releases every pressed action, the finger that was down sends no up, and the pad went on believing that button held, so it never pressed it again. The pad now lets go on `NOTIFICATION_APPLICATION_FOCUS_OUT`, as it already does when it is hidden, edited or removed.

## Proving it

Three new cases, two of them the reported symptom itself. The runtime lets go the moment the key does and owes no repeat afterwards. The pause menu, driven by a real key event through the real world screen, walks its list while the key is held and stops on the frame it is released. The rate test now counts events reaching the tree rather than reading the gate's own flag, which the event clears in the same call.

| Check | Result |
|---|---|
| GUT, both tiers | 4016 pass |
| Editor analyser | 0 warnings in 597 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
