### PR TITLE
Give the Android back button somewhere to go

### DIFF
--- a/.github/altstore/source.json
+++ b/.github/altstore/source.json
@@ -2,6 +2,7 @@
   "name": "pokerecomp",
   "identifier": "io.github.decryptu.pokerecomp",
   "sourceURL": "https://raw.githubusercontent.com/Decryptu/pokerecomp/main/.github/altstore/source.json",
+  "fediUsername": "decrypt",
   "subtitle": "Gold, Silver and Crystal, rebuilt in Godot",
   "description": "A native Godot 4 reimplementation of the Generation 2 Game Boy Color games: Gold, Silver and Crystal. Written from scratch in GDScript, not an emulator, a static recompilation or a disassembly.\n\nNo game data ships with the app. You supply your own cartridge dump, which is SHA-1 verified, decoded once into a cache, and then released.\n\nThree challenge modes are built in, mods are supported, and the same save works on every platform pokerecomp runs on.",
   "iconURL": "https://raw.githubusercontent.com/Decryptu/pokerecomp/main/app_icon.png",

--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -5,9 +5,11 @@ break put in by hand only makes it ragged. -->
 
 ## New in this release
 
-Two things, both for iPhone and iPad.
+Three things: one for Android, two for iPhone and iPad.
 
 **pokerecomp has an AltStore and SideStore source.** Add it once and every future release arrives as an update instead of a file you download and re-install by hand. The URL is `https://raw.githubusercontent.com/Decryptu/pokerecomp/main/.github/altstore/source.json`. In AltStore or SideStore, open **Sources**, tap **+**, and paste it. The app still signs on your own machine with your own Apple ID, and a free Apple ID still needs re-signing every 7 days.
+
+**The Android back button no longer quits the game.** It used to close the app outright wherever you pressed it, mid-battle included. In the game it now opens the pause menu, or backs out of whatever is on screen. In the launcher it closes the sheet you have open, then walks back to the shelf, and only asks "Quit pokerecomp?" once there is nothing left to back out of.
 
 **The iOS build asks for nothing.** The exporter wrote camera, microphone and photo library permission entries into the app whether or not it wanted them, and an empty entry is what a store shows you as a permission the app is asking for. pokerecomp uses none of the three, so all three are now removed from the build.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   GODOT_VERSION: 4.8-dev4
@@ -522,26 +523,6 @@ jobs:
           gh release create "${{ needs.version.outputs.tag }}" \
             --title "$v" --notes "$notes" staged/*
 
-      # The feed AltStore and SideStore poll. Rebuilt from the releases rather
-      # than edited, and committed to `main` because the raw file on that branch
-      # is the URL players have already added.
-      - name: Refresh the AltStore source
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          git fetch --depth 1 origin main
-          git checkout -B main FETCH_HEAD
-          tools/altstore_source.sh "${{ github.repository }}"
-          git add .github/altstore/source.json
-          # A re-run of a tag that is already listed has nothing to commit, and
-          # an empty commit fails the step rather than the release.
-          git diff --cached --quiet && { echo "already listed"; exit 0; }
-          git -c user.name='github-actions[bot]' \
-              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
-              commit -m "List ${{ needs.version.outputs.version }} in the AltStore source"
-          git push origin main
-
       - name: Announce on Discord
         env:
           DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
@@ -554,3 +535,38 @@ jobs:
             -H 'Content-Type: application/json' \
             --data "$(jq -cn --arg content "$release_url" '{content: $content}')" \
             "$DISCORD_RELEASE_WEBHOOK"
+
+      # The feed AltStore and SideStore poll. Rebuilt from the releases rather
+      # than edited, and landed on `main` through a pull request: the raw file
+      # on that branch is the URL players add, and the `Protect main` ruleset
+      # takes nothing else. After the announcement, so a refusal here costs the
+      # feed one release rather than costing everyone the post.
+      - name: Refresh the AltStore source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          v="${{ needs.version.outputs.version }}"
+          branch="altstore-$v"
+          git fetch --depth 1 origin main
+          git checkout -B "$branch" FETCH_HEAD
+          tools/altstore_source.sh "${{ github.repository }}"
+          git add .github/altstore/source.json
+          # A re-run of a tag that is already listed has nothing to commit, and
+          # an empty commit fails the step rather than the release.
+          git diff --cached --quiet && { echo "already listed"; exit 0; }
+          git -c user.name='github-actions[bot]' \
+              -c user.email='41898282+github-actions[bot]@users.noreply.github.com' \
+              commit -m "List $v in the AltStore source"
+          git push --force origin "$branch"
+          gh pr create --base main --head "$branch" \
+            --title "List $v in the AltStore source" \
+            --body "\`tools/altstore_source.sh\` output for the $v release."
+          # The branch is a second old before the merge is asked for, and GitHub
+          # answers "not mergeable" until it has worked the base out.
+          for _ in 1 2 3 4 5 6; do
+            gh pr merge "$branch" --merge --delete-branch && exit 0
+            sleep 10
+          done
+          echo "::error::the feed pull request would not merge"
+          exit 1

--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -19,6 +19,8 @@ signal scheme_changed()
 ## A + B + START + SELECT, the console's own reset, reported once per press. The
 ## machine's rather than the game's, so whichever screen is up decides its cost.
 signal reset_chord_pressed()
+## Android's own Back, with `quit_on_go_back` off so nothing quits unasked.
+signal back_requested()
 
 var _scheme: Dictionary = {}
 ## What the player bound each mod's own actions to, keyed by action name. See
@@ -238,6 +240,11 @@ func _gate_direction_repeat(event: InputEvent) -> bool:
 ## system's key repeat is not the rate the hardware walked at.
 func held_direction() -> int:
 	return _direction_order.back() if not _direction_order.is_empty() else Gen2Button.NONE
+
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_GO_BACK_REQUEST:
+		back_requested.emit()
 
 
 func _process(delta: float) -> void:

--- a/game/launcher/launcher_button.gd
+++ b/game/launcher/launcher_button.gd
@@ -68,7 +68,6 @@ static func create(
 	return button
 
 
-## A square button carrying only an icon.
 static func icon_only(
 	palette: Gen2LauncherTheme,
 	glyph: StringName,

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -145,7 +145,6 @@ func tint_for(game_id: StringName) -> Color:
 	return GAME_TINTS.get(game_id, accent)
 
 
-## A translucent accent wash, used behind a selected control.
 func accent_wash(alpha: float = 0.14) -> Color:
 	var wash: Color = accent
 	wash.a = alpha

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -39,6 +39,9 @@ func _ready() -> void:
 	_print_allowlist()
 	_refresh_games()
 	_report_previous_crash()
+	var input: Gen2InputRuntime = Gen2InputRuntime.instance()
+	if input != null and not input.back_requested.is_connected(_on_back_requested):
+		input.back_requested.connect(_on_back_requested)
 
 
 ## Rebuilt whole when the appearance changes, which is the only way a launcher
@@ -222,6 +225,44 @@ func _confirm_mod_replace(path: String, mod_name: String) -> void:
 		import_mod_path(path, true)
 	)
 	sheet.add_action(replace)
+	sheet.open(self)
+
+
+func _on_back_requested() -> void:
+	if _importing:
+		return
+	if _close_top_layer():
+		return
+	if _shell != null and _shell.current_page() != &"shelf":
+		_shell.select(&"shelf")
+		return
+	_confirm_quit()
+
+
+func _close_top_layer() -> bool:
+	var pickers: Array[Gen2LauncherFilePicker] = [_file_dialog, _mod_dialog]
+	for picker: Gen2LauncherFilePicker in pickers:
+		if picker != null and picker.visible:
+			picker.hide()
+			return true
+	var sheets: Array[Node] = find_children("", "Gen2LauncherSheet", true, false)
+	if sheets.is_empty():
+		return false
+	var top: Gen2LauncherSheet = sheets[sheets.size() - 1] as Gen2LauncherSheet
+	top.close()
+	return true
+
+
+func _confirm_quit() -> void:
+	var sheet: Gen2LauncherSheet = Gen2LauncherSheet.create(_palette, "Quit pokerecomp")
+	sheet.body().add_child(Gen2LauncherUI.muted(
+		_palette, "Close the app? Nothing is running, so there is nothing to lose."
+	))
+	var quit: Gen2LauncherButton = Gen2LauncherButton.create(
+		_palette, "Quit", Gen2LauncherButton.Variant.DANGER, &"power"
+	)
+	quit.pressed.connect(func() -> void: get_tree().quit())
+	sheet.add_action(quit)
 	sheet.open(self)
 
 
@@ -451,6 +492,9 @@ func preview_sheet(view: StringName) -> void:
 		&"report":
 			select_page(&"about")
 			_about.open_report_sheet()
+		&"quit":
+			select_page(&"shelf")
+			_confirm_quit()
 		&"toast":
 			# The one message that stays until it is dismissed, over the shelf's
 			# own action row, which is what its dismiss button has to clear.

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -322,7 +322,6 @@ static func drop_children(parent: Node) -> void:
 		drop(child)
 
 
-## The viewport itself, for a caller that needs to read the drawn frame.
 func viewport() -> SubViewport:
 	return _viewport
 

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -46,6 +46,9 @@ func _ready() -> void:
 	_data = _data_override if _data_override != null else _resolve_data()
 	_build_ui()
 	_refresh()
+	var input: Gen2InputRuntime = Gen2InputRuntime.instance()
+	if input != null and not input.back_requested.is_connected(_on_back_requested):
+		input.back_requested.connect(_on_back_requested)
 
 
 ## Test and tooling seam for synthetic caches. Production callers use the
@@ -824,6 +827,14 @@ func _open_party() -> void:
 		)
 		return
 	get_tree().change_scene_to_file.call_deferred("res://game/save/party_screen.tscn")
+
+
+func _on_back_requested() -> void:
+	var sheets: Array[Node] = find_children("", "Gen2LauncherSheet", true, false)
+	if not sheets.is_empty():
+		(sheets[sheets.size() - 1] as Gen2LauncherSheet).close()
+		return
+	_back_to_launcher()
 
 
 ## The same transition the launcher opened this screen with, walked the other

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -348,6 +348,8 @@ func _ready() -> void:
 	var input: Gen2InputRuntime = Gen2InputRuntime.instance()
 	if input != null and not input.reset_chord_pressed.is_connected(_on_reset_chord):
 		input.reset_chord_pressed.connect(_on_reset_chord)
+	if input != null and not input.back_requested.is_connected(_on_back_requested):
+		input.back_requested.connect(_on_back_requested)
 
 
 ## Why the overworld could not be built, on the two labels the debug readout
@@ -1867,6 +1869,13 @@ func _end_nuzlocke_run(save: Gen2SaveData) -> void:
 func _soft_reset() -> void:
 	if is_inside_tree():
 		get_tree().change_scene_to_file.call_deferred(SAVE_SCENE)
+
+
+## Offered as a B, which backs out of whatever owns the screen. Nothing on a
+## bare map takes one, and a press nobody took is the pause menu.
+func _on_back_requested() -> void:
+	if not press_button(Gen2Button.B):
+		press_button(Gen2Button.START)
 
 
 ## The reset chord, from anywhere the world is up. The first one ever asks first,

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,7 @@ config/version="0.1.11"
 run/main_scene="res://game/main/main.tscn"
 config/features=PackedStringArray("4.8", "GL Compatibility")
 config/icon="res://app_icon.png"
+config/quit_on_go_back=false
 
 [autoload]
 

--- a/tests/integration/test_input_runtime.gd
+++ b/tests/integration/test_input_runtime.gd
@@ -226,3 +226,17 @@ class RepeatCounter extends Node:
 	func _input(event: InputEvent) -> void:
 		if event is InputEventAction and event.is_action_pressed(&"gen2_down"):
 			seen += 1
+
+
+## Android's Back reaches every node as a notification. The runtime turns it into
+## one signal so the screen that is up decides what it costs, and
+## `quit_on_go_back` is off so nothing leaves the app on its own.
+func test_the_back_notification_is_reported_as_a_signal() -> void:
+	var fired: Array = []
+	_runtime.back_requested.connect(func() -> void: fired.append(true))
+	_runtime.notification(NOTIFICATION_WM_GO_BACK_REQUEST)
+	assert_eq(fired.size(), 1, "one press, one report")
+	assert_false(
+		ProjectSettings.get_setting("application/config/quit_on_go_back", true),
+		"the engine must not quit before a screen has answered",
+	)

--- a/tests/integration/test_start_menu_reopen.gd
+++ b/tests/integration/test_start_menu_reopen.gd
@@ -94,3 +94,13 @@ func test_the_reopened_menu_keeps_the_cursor() -> void:
 	_screen._on_trainer_card_closed()
 	var reopened: Gen2WorldStartMenu = _screen._start_menu_host.get("_menu")
 	assert_eq(reopened.cursor, moved)
+
+
+## Android's Back over the map. Offered as a B first, which nothing on a bare map
+## takes, so it lands on the same menu START opens; with the menu up the B is
+## taken and closes it, rather than opening a second one.
+func test_back_opens_the_start_menu_and_then_closes_it() -> void:
+	_screen._on_back_requested()
+	assert_not_null(_screen._start_menu_host, "a back press on the map is a pause")
+	_screen._on_back_requested()
+	assert_null(_screen._start_menu_host, "and the next one backs out of it")

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -701,3 +701,27 @@ func test_only_the_platforms_with_a_probe_shell_out() -> void:
 		Gen2LauncherBattery._shells_out(), OS.get_name() in ["macOS", "Windows"],
 		"a process is launched for those two and nothing else",
 	)
+
+
+## Android's Back on the launcher. It quit the app outright before, from any page
+## and over any sheet; it now closes what is open, walks back to the shelf, and
+## only asks about quitting on a bare shelf.
+func test_back_closes_what_is_open_before_it_asks_about_quitting() -> void:
+	await _open_launcher()
+	var shell: Gen2LauncherShell = _launcher.get("_shell")
+
+	_launcher.select_page(&"about")
+	_launcher.call("_on_back_requested")
+	assert_eq(shell.current_page(), &"shelf", "a page other than the shelf is the way back")
+
+	_launcher.call("_confirm_quit")
+	await get_tree().process_frame
+	assert_eq(_sheet_count(), 1, "a bare shelf asks first")
+	_launcher.call("_on_back_requested")
+	await get_tree().process_frame
+	assert_eq(_sheet_count(), 0, "and a second Back is the cancel on that question")
+
+
+## The sheets open over the launcher, innermost last.
+func _sheet_count() -> int:
+	return _launcher.find_children("", "Gen2LauncherSheet", true, false).size()

--- a/tools/altstore_source.sh
+++ b/tools/altstore_source.sh
@@ -40,6 +40,7 @@ gh api "repos/$repo/releases" --paginate --jq '.[]' \
     | { name: "pokerecomp",
         identifier: $bundle,
         sourceURL: ($assets + "/source.json"),
+        fediUsername: "decrypt",
         subtitle: "Gold, Silver and Crystal, rebuilt in Godot",
         description: $description,
         iconURL: $icon,

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -86,7 +86,8 @@ func _process(_delta: float) -> bool:
 			# goes, so the ordinary shot below lands in the middle of it, which
 			# is the screen worth photographing.
 			_launcher.import_rom_path(_mod)
-		elif _view in ["manage", "touch", "binding", "browse", "delete_mod", "bugs", "report", "toast"]:
+		elif _view in ["manage", "touch", "binding", "browse", "delete_mod", "bugs", "report",
+				"toast", "quit"]:
 			_launcher._preview_browse_dir = _mod
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():


### PR DESCRIPTION
Reported on Discord: the Android back button closed the app outright, from the game and from the launcher alike.

`quit_on_go_back` is off now, and `Gen2InputRuntime` reports the notification as `back_requested` the way it already reports the reset chord: the machine's press, answered by whichever screen is up.

- The world screen offers it as a B, which backs out of whatever owns the screen. Nothing on a bare map takes a B, so a press nobody took opens the pause menu.
- The launcher closes the innermost sheet or picker, then walks back to the shelf, and only asks about quitting on a bare shelf. The question is a sheet, so a second back press cancels it.
- The save screen closes its sheet or returns to the launcher.

Also here, because the same release carries it: the feed step in the release workflow lands its commit through a pull request rather than pushing to `main`, which the `Protect main` ruleset refuses, and it now runs after the Discord announcement so it cannot swallow one. `fediUsername` is in the feed for explore.alt.store, and the 0.1.11 notes have both.

Unit tier 3447 passing, 0 editor warnings over 597 scripts, `validate.gd -- all` exit 0.