### PR TITLE
Empty the complexity ceiling's list, and pace the waterfall climb

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -293,6 +293,5 @@ the suite.
 
 Complexity counts `if`, `elif`, `while`, `for`, `and`, `or`, an inline `if` and
 one per `match` arm. Over the ceiling, the remedy is a lookup table, a guard
-clause or a named helper, never a nested ternary. The functions still over it are
-listed in that test and the list may only shrink: the test also fails on a line
-that no longer names a function over the ceiling.
+clause or a named helper, never a nested ternary. No function is over it today,
+and the test's `OVER_COMPLEXITY` list is empty: keep it that way.

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1486,6 +1486,19 @@ the slow commands, 8 for plain, 4 for bike speed. A pass is two hardware frames
 `Gen2WorldObject.frame` is the cartridge's `Facings` index, 0 to 3, changing every
 four passes.
 
+`Gen2WorldAPI.player_step_kind()` names which movement the step in flight is, so a
+renderer can draw a climb as a climb rather than as a walk north. A scripted stream
+answers the movement command's own name; a walk, a ledge hop and a turn in place
+answer `step`, `jump_step` and `turn`. It is empty while nothing is stepping.
+
+Waterfall is the one field move whose whole answer is movement.
+`complete_waterfall()` commits the landing cell at once and then runs the column as
+a step run of `turn_waterfall`, one cell every four passes, so the offset opens as
+many cells below the landing as the climb is tall and counts down to zero. Its
+answer carries `steps` and `passes`, and the surfer stays a surfer until the last
+step lands them ashore. A renderer that draws a fall as a vertical wall reads the
+offset as height.
+
 A hop is the one step with a second axis.
 `Gen2WorldAPI.player_height_offset_pixels()` and
 `Gen2WorldObject.height_offset_pixels()` return how far above the ground the sprite

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -1491,6 +1491,14 @@ renderer can draw a climb as a climb rather than as a walk north. A scripted str
 answers the movement command's own name; a walk, a ledge hop and a turn in place
 answer `step`, `jump_step` and `turn`. It is empty while nothing is stepping.
 
+`turn_away`, `turn_in` and `turn_waterfall` reach `TurningStep` rather than
+`NormalStep`, which sets `OBJECT_ACTION_SPIN`: the walker spins counterclockwise
+through DOWN, RIGHT, UP, LEFT, one quarter-turn every four passes, instead of
+facing the way it is going. `Gen2WorldAPI.player_drawn_facing()` and
+`Gen2WorldObject.drawn_facing()` are that spin; the logical facing never moves, so
+a waterfall climb still ends facing up. Draw from those two, not from
+`player_facing` and `facing`.
+
 Waterfall is the one field move whose whole answer is movement.
 `complete_waterfall()` commits the landing cell at once and then runs the column as
 a step run of `turn_waterfall`, one cell every four passes, so the offset opens as

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -611,41 +611,7 @@ func _attribute_maps() -> void:
 	## the busiest scripts are reached from dozens of maps.
 	var references: Dictionary = {}
 	for map: Gen2WorldMap in _data.world_maps():
-		var bank: int = int(map.events.get("bank", 0))
-		var pending: Array = []
-		for source: String in ["objects", "bg_events", "coord_events"]:
-			for raw: Variant in map.events.get(source, []):
-				if raw is Dictionary and int((raw as Dictionary).get("script", 0)) > 0:
-					pending.append([bank, int((raw as Dictionary)["script"])])
-		var scripts: Dictionary = map.scripts
-		if int(scripts.get("address", 0)) > 0:
-			pending.append([int(scripts.get("bank", bank)), int(scripts["address"])])
-		for raw: Variant in scripts.get("callbacks", []):
-			if raw is Dictionary and int((raw as Dictionary).get("script", 0)) > 0:
-				pending.append([int(scripts.get("bank", bank)), int((raw as Dictionary)["script"])])
-		var seen: Dictionary = {}
-		for _step: int in MAX_SCRIPT_COMMANDS:
-			if pending.is_empty():
-				break
-			var entry: Array = pending.pop_back()
-			var key: int = (int(entry[0]) & 0xFF) << ID_BANK_SHIFT \
-				| (int(entry[1]) & ID_ADDRESS_MASK)
-			if seen.has(key):
-				continue
-			seen[key] = true
-			if not owner.has(key):
-				owner[key] = Vector2i(map.group, map.number)
-			if not references.has(key):
-				var body: PackedByteArray = _data.world_script(int(entry[0]), int(entry[1]))
-				references[key] = Gen2WorldScript.scan_references(
-					body, int(entry[0]), int(entry[1]), crystal
-				).get("scripts", []) if not body.is_empty() else []
-			for referenced: Variant in references[key]:
-				if referenced is Dictionary:
-					pending.append([
-						int((referenced as Dictionary)["bank"]),
-						int((referenced as Dictionary)["address"]),
-					])
+		_walk_map_scripts(map, crystal, owner, references)
 	for id: Variant in _rows:
 		var row: Dictionary = _rows[id]
 		if row.has("map") or not row.has("address"):
@@ -657,6 +623,49 @@ func _attribute_maps() -> void:
 			if owner.has(key):
 				row["map"] = owner[key]
 				break
+
+
+func _walk_map_scripts(
+	map: Gen2WorldMap, crystal: bool, owner: Dictionary, references: Dictionary
+) -> void:
+	var bank: int = int(map.events.get("bank", 0))
+	var scripts: Dictionary = map.scripts
+	var script_bank: int = int(scripts.get("bank", bank))
+	var pending: Array = []
+	for source: String in ["objects", "bg_events", "coord_events"]:
+		_append_scripts(pending, map.events.get(source, []), bank)
+	if int(scripts.get("address", 0)) > 0:
+		pending.append([script_bank, int(scripts["address"])])
+	_append_scripts(pending, scripts.get("callbacks", []), script_bank)
+	var seen: Dictionary = {}
+	for _step: int in MAX_SCRIPT_COMMANDS:
+		if pending.is_empty():
+			break
+		var entry: Array = pending.pop_back()
+		var key: int = (int(entry[0]) & 0xFF) << ID_BANK_SHIFT \
+			| (int(entry[1]) & ID_ADDRESS_MASK)
+		if seen.has(key):
+			continue
+		seen[key] = true
+		if not owner.has(key):
+			owner[key] = Vector2i(map.group, map.number)
+		if not references.has(key):
+			var body: PackedByteArray = _data.world_script(int(entry[0]), int(entry[1]))
+			references[key] = Gen2WorldScript.scan_references(
+				body, int(entry[0]), int(entry[1]), crystal
+			).get("scripts", []) if not body.is_empty() else []
+		for referenced: Variant in references[key]:
+			if referenced is Dictionary:
+				pending.append([
+					int((referenced as Dictionary)["bank"]),
+					int((referenced as Dictionary)["address"]),
+				])
+
+
+static func _append_scripts(pending: Array, events: Variant, bank: int) -> void:
+	for raw: Variant in events:
+		if raw is Dictionary and int((raw as Dictionary).get("script", 0)) > 0:
+			pending.append([bank, int((raw as Dictionary)["script"])])
 
 
 ## Whether [param name] is the next few commands after [param at]. The cartridge

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -449,47 +449,54 @@ static func verify_game_freak_presents(rom: RomFile, layout: Dictionary) -> Dict
 static func _verify_presents_sprites(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var stars: int = int(entry.get("stars", -1))
 	if stars >= 0:
-		if not rom.in_bounds(stars, RomLayout.PRESENTS_STARS_TILES * Gen2Tiles.TILE_BYTES):
-			return {"ok": false, "message": "The splash star graphic is outside the cartridge."}
-		# splash.asm INCBINs the stars directly behind the logo, so the two pin
-		# each other.
-		var after: int = int(entry.get("gfx", -1)) \
-			+ RomLayout.PRESENTS_GFX_TILES * Gen2Tiles.TILE_1BPP_BYTES
-		if stars != after:
-			return {
-				"ok": false,
-				"message": "The splash stars are not behind the logo graphic.",
-			}
-		for index: int in RomLayout.PRESENTS_STAR_TILES:
-			if _tile_2bpp_lit(rom, stars, index) == 0:
-				return {"ok": false, "message": "Splash star tile %d is blank." % index}
-		# `.Frameset_GSGameFreakLogoSparkle` runs its three tiles as one spark
-		# closing in on its own centre, so tile n is blank across its outer n rows
-		# top and bottom and lit on the two just inside them, and each carries
-		# fewer lit pixels than the one before.
-		var last_lit: int = Gen2Tiles.TILE_PIXELS + 1
-		for index: int in RomLayout.PRESENTS_SPARKLE_TILES:
-			var tile: int = RomLayout.PRESENTS_STAR_TILES + index
-			for row: int in Gen2Tiles.TILE_HEIGHT:
-				var edge: bool = row < index or row >= Gen2Tiles.TILE_HEIGHT - index
-				var rim: bool = row == index or row == Gen2Tiles.TILE_HEIGHT - 1 - index
-				var lit_row: bool = _row_2bpp_lit(rom, stars, tile, row)
-				if edge == lit_row or (rim and not lit_row):
-					return {
-						"ok": false,
-						"message": "Sparkle tile %d row %d does not close in." % [
-							index, row,
-						],
-					}
-			var lit: int = _tile_2bpp_lit(rom, stars, tile)
-			if lit >= last_lit:
+		return _verify_presents_stars(rom, entry, stars)
+	return _verify_presents_ditto(rom, entry)
+
+
+static func _verify_presents_stars(rom: RomFile, entry: Dictionary, stars: int) -> Dictionary:
+	if not rom.in_bounds(stars, RomLayout.PRESENTS_STARS_TILES * Gen2Tiles.TILE_BYTES):
+		return {"ok": false, "message": "The splash star graphic is outside the cartridge."}
+	# splash.asm INCBINs the stars directly behind the logo, so the two pin
+	# each other.
+	var after: int = int(entry.get("gfx", -1)) \
+		+ RomLayout.PRESENTS_GFX_TILES * Gen2Tiles.TILE_1BPP_BYTES
+	if stars != after:
+		return {
+			"ok": false,
+			"message": "The splash stars are not behind the logo graphic.",
+		}
+	for index: int in RomLayout.PRESENTS_STAR_TILES:
+		if _tile_2bpp_lit(rom, stars, index) == 0:
+			return {"ok": false, "message": "Splash star tile %d is blank." % index}
+	# `.Frameset_GSGameFreakLogoSparkle` runs its three tiles as one spark
+	# closing in on its own centre, so tile n is blank across its outer n rows
+	# top and bottom and lit on the two just inside them, and each carries
+	# fewer lit pixels than the one before.
+	var last_lit: int = Gen2Tiles.TILE_PIXELS + 1
+	for index: int in RomLayout.PRESENTS_SPARKLE_TILES:
+		var tile: int = RomLayout.PRESENTS_STAR_TILES + index
+		for row: int in Gen2Tiles.TILE_HEIGHT:
+			var edge: bool = row < index or row >= Gen2Tiles.TILE_HEIGHT - index
+			var rim: bool = row == index or row == Gen2Tiles.TILE_HEIGHT - 1 - index
+			var lit_row: bool = _row_2bpp_lit(rom, stars, tile, row)
+			if edge == lit_row or (rim and not lit_row):
 				return {
 					"ok": false,
-					"message": "Sparkle tile %d is not smaller than the one before." % index,
+					"message": "Sparkle tile %d row %d does not close in." % [
+						index, row,
+					],
 				}
-			last_lit = lit
-		return {"ok": true, "message": "GameFreak Presents verified."}
+		var lit: int = _tile_2bpp_lit(rom, stars, tile)
+		if lit >= last_lit:
+			return {
+				"ok": false,
+				"message": "Sparkle tile %d is not smaller than the one before." % index,
+			}
+		last_lit = lit
+	return {"ok": true, "message": "GameFreak Presents verified."}
 
+
+static func _verify_presents_ditto(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var ditto: int = int(entry.get("ditto", -1))
 	if ditto < 0:
 		return {"ok": false, "message": "This cartridge has neither a splash star nor a Ditto."}
@@ -717,6 +724,13 @@ static func _verify_gs_title(rom: RomFile, entry: Dictionary) -> Dictionary:
 			"message": "The title tilemap is %d bytes, not whole rows." % tilemap.size(),
 		}
 
+	var trail: Dictionary = _verify_gs_title_trail(rom, entry)
+	if not trail["ok"]:
+		return trail
+	return _verify_gs_title_palettes(rom, entry)
+
+
+static func _verify_gs_title_trail(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var trail: int = int(entry["trail"])
 	var trail_tiles: int = int(entry["trail_tiles"])
 	if not rom.in_bounds(trail, trail_tiles * Gen2Tiles.TILE_BYTES):
@@ -734,12 +748,10 @@ static func _verify_gs_title(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var bird_at: int = trail + trail_tiles * Gen2Tiles.TILE_BYTES
 	if int(entry["bird"]) != bird_at:
 		return {"ok": false, "message": "The title bird is not behind the trail."}
-	var bird: Dictionary = _verify_title_run(
-		rom, "bird", bird_at, int(entry["bird_tiles"])
-	)
-	if not bird["ok"]:
-		return bird
+	return _verify_title_run(rom, "bird", bird_at, int(entry["bird_tiles"]))
 
+
+static func _verify_gs_title_palettes(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var size: int = Gen2Palette.COLOR_BYTES
 	var bg: int = int(entry["bg_palette"])
 	var ob: int = int(entry["ob_palette"])
@@ -2492,6 +2504,36 @@ static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if entry.is_empty():
 		return {"ok": false, "message": "The cartridge has no mail block."}
 
+	var items: Dictionary = _verify_mail_items(rom, entry)
+	if not items["ok"]:
+		return items
+	var input: Dictionary = _verify_mail_input(rom, layout, entry)
+	if not input["ok"]:
+		return input
+
+	var gfx: int = int(entry.get("gfx", -1))
+	if not rom.in_bounds(gfx, RomLayout.MAIL_GFX_BYTES):
+		return {"ok": false, "message": "Mail graphics run past the cartridge."}
+	var ends: Dictionary = {
+		gfx: MAIL_GFX_FIRST_TILE,
+		gfx + RomLayout.MAIL_GFX_BYTES - RomLayout.TILE_BYTES_1BPP: MAIL_GFX_LAST_TILE,
+	}
+	for at: int in ends:
+		if Array(rom.slice(at, RomLayout.TILE_BYTES_1BPP)) != Array(ends[at] as Array):
+			return {"ok": false, "message": "Mail graphics tile at $%X is not its own." % at}
+
+	var palettes: Dictionary = _verify_mail_palettes(rom, entry)
+	if not palettes["ok"]:
+		return palettes
+
+	if not rom.in_bounds(
+		int(entry.get("icon", -1)), RomLayout.MAIL_ICON_TILES * RomLayout.TILE_BYTES_2BPP
+	):
+		return {"ok": false, "message": "The mail icon is outside the cartridge."}
+	return {"ok": true, "message": "Mail tables, graphics and palettes verified."}
+
+
+static func _verify_mail_items(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var items: int = int(entry.get("items", -1))
 	if not rom.in_bounds(items, RomLayout.MAIL_ITEM_COUNT + 1):
 		return {"ok": false, "message": "MailItems is outside the cartridge."}
@@ -2505,7 +2547,12 @@ static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
 			}
 	if rom.u8(items + RomLayout.MAIL_ITEM_COUNT) != RomLayout.MAIL_ITEM_END:
 		return {"ok": false, "message": "MailItems does not end in -1."}
+	return {"ok": true}
 
+
+static func _verify_mail_input(
+	rom: RomFile, layout: Dictionary, entry: Dictionary
+) -> Dictionary:
 	var chars: int = int(entry.get("input_chars", -1))
 	var block: int = RomLayout.MAIL_INPUT_TABLES * RomLayout.MAIL_INPUT_TABLE_ROWS \
 		* RomLayout.MAIL_INPUT_ROW_BYTES
@@ -2532,18 +2579,10 @@ static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
 		)
 		if Array(rom.slice(command, RomLayout.MAIL_INPUT_ROW_BYTES)) != Array(expected_row):
 			return {"ok": false, "message": "Mail input table %d has no command row." % table}
+	return {"ok": true}
 
-	var gfx: int = int(entry.get("gfx", -1))
-	if not rom.in_bounds(gfx, RomLayout.MAIL_GFX_BYTES):
-		return {"ok": false, "message": "Mail graphics run past the cartridge."}
-	var ends: Dictionary = {
-		gfx: MAIL_GFX_FIRST_TILE,
-		gfx + RomLayout.MAIL_GFX_BYTES - RomLayout.TILE_BYTES_1BPP: MAIL_GFX_LAST_TILE,
-	}
-	for at: int in ends:
-		if Array(rom.slice(at, RomLayout.TILE_BYTES_1BPP)) != Array(ends[at] as Array):
-			return {"ok": false, "message": "Mail graphics tile at $%X is not its own." % at}
 
+static func _verify_mail_palettes(rom: RomFile, entry: Dictionary) -> Dictionary:
 	var palettes: int = int(entry.get("palettes", -1))
 	var palette_bytes: int = RomLayout.MAIL_PALETTE_COUNT * RomLayout.MAIL_PALETTE_COLOURS * 2
 	if not rom.in_bounds(palettes, palette_bytes):
@@ -2559,12 +2598,7 @@ static func verify_mail(rom: RomFile, layout: Dictionary) -> Dictionary:
 			}
 		if rom.u16le(at_row + (RomLayout.MAIL_PALETTE_COLOURS - 1) * 2) != 0:
 			return {"ok": false, "message": "Mail palette %d does not end in black." % index}
-
-	if not rom.in_bounds(
-		int(entry.get("icon", -1)), RomLayout.MAIL_ICON_TILES * RomLayout.TILE_BYTES_2BPP
-	):
-		return {"ok": false, "message": "The mail icon is outside the cartridge."}
-	return {"ok": true, "message": "Mail tables, graphics and palettes verified."}
+	return {"ok": true}
 
 
 ## `BattleTowerTrainers`' two ends, which is what says the run is the run.
@@ -4284,39 +4318,48 @@ static func _read_one_trainer(rom: RomFile, at: int) -> Dictionary:
 	while rom.in_bounds(pos) and rom.u8(pos) != RomLayout.TRAINER_PARTY_END:
 		if party.size() >= RomLayout.MAX_TRAINER_PARTY_SIZE:
 			return {}
-		if not rom.in_bounds(pos, 2):
+		var mon: Dictionary = _read_trainer_mon(rom, pos, mon_type)
+		if mon.is_empty():
 			return {}
-		var level: int = rom.u8(pos)
-		var species: int = rom.u8(pos + 1)
-		if level < 1 or level > RomLayout.MAX_LEVEL:
-			return {}
-		if species < 1 or species > RomLayout.SPECIES_COUNT:
-			return {}
-		pos += 2
-
-		var extra: int = RomLayout.trainer_mon_extra_size(mon_type)
-		if not rom.in_bounds(pos, extra):
-			return {}
-		var item: int = 0
-		var moves: Array = []
-		if mon_type == RomLayout.TRAINER_MON_ITEM or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
-			item = rom.u8(pos)
-			pos += 1
-		if mon_type == RomLayout.TRAINER_MON_MOVES or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
-			for slot: int in RomLayout.TRAINER_MON_MOVE_COUNT:
-				var move: int = rom.u8(pos + slot)
-				if move > RomLayout.MOVE_COUNT:
-					return {}
-				moves.append(move)
-			pos += RomLayout.TRAINER_MON_MOVE_COUNT
-
-		party.append({"level": level, "species": species, "item": item, "moves": moves})
+		pos = int(mon["_next"])
+		mon.erase("_next")
+		party.append(mon)
 
 	if not rom.in_bounds(pos) or party.is_empty():
 		return {}
 	pos += 1
 
 	return {"name": name, "type": mon_type, "party": party, "_next": pos}
+
+
+static func _read_trainer_mon(rom: RomFile, at: int, mon_type: int) -> Dictionary:
+	var pos: int = at
+	if not rom.in_bounds(pos, 2):
+		return {}
+	var level: int = rom.u8(pos)
+	var species: int = rom.u8(pos + 1)
+	if level < 1 or level > RomLayout.MAX_LEVEL:
+		return {}
+	if species < 1 or species > RomLayout.SPECIES_COUNT:
+		return {}
+	pos += 2
+
+	if not rom.in_bounds(pos, RomLayout.trainer_mon_extra_size(mon_type)):
+		return {}
+	var item: int = 0
+	var moves: Array = []
+	if mon_type == RomLayout.TRAINER_MON_ITEM or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+		item = rom.u8(pos)
+		pos += 1
+	if mon_type == RomLayout.TRAINER_MON_MOVES or mon_type == RomLayout.TRAINER_MON_ITEM_MOVES:
+		for slot: int in RomLayout.TRAINER_MON_MOVE_COUNT:
+			var move: int = rom.u8(pos + slot)
+			if move > RomLayout.MOVE_COUNT:
+				return {}
+			moves.append(move)
+		pos += RomLayout.TRAINER_MON_MOVE_COUNT
+
+	return {"level": level, "species": species, "item": item, "moves": moves, "_next": pos}
 
 
 ## The trainer party table, checked by everything known about it independently:

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -1146,12 +1146,30 @@ static func _read_events(
 		return _error("Map %d/%d events are outside the ROM." % [group, number])
 	at += RomLayout.MAP_EVENT_HEADER_SIZE
 
-	var warps: Array = []
+	var out: Dictionary = {"ok": true}
+	for reader: Callable in [_read_warp_events, _read_coord_events, _read_bg_events]:
+		var read: Dictionary = reader.call(rom, at, group, number, cell_width, cell_height)
+		if not read["ok"]:
+			return read
+		at = int(read["at"])
+		out[String(read["kind"])] = read["events"]
+	var objects: Dictionary = _read_object_events(rom, bank, at, group, number)
+	if not objects["ok"]:
+		return objects
+	out["objects"] = objects["events"]
+	return out
+
+
+## Each reader answers `{ok, kind, events, at}`, `at` being where the next starts.
+static func _read_warp_events(
+	rom: RomFile, at: int, group: int, number: int, cell_width: int, cell_height: int
+) -> Dictionary:
 	if not rom.in_bounds(at):
 		return _error("Map %d/%d has no warp-event count." % [group, number])
-	var warp_count: int = rom.u8(at)
+	var count: int = rom.u8(at)
 	at += 1
-	for _i: int in warp_count:
+	var warps: Array = []
+	for _i: int in count:
 		if not rom.in_bounds(at, RomLayout.MAP_WARP_EVENT_SIZE):
 			return _error("Map %d/%d warp events are truncated." % [group, number])
 		var y: int = rom.u8(at)
@@ -1166,105 +1184,105 @@ static func _read_events(
 			"map_number": rom.u8(at + 4),
 		})
 		at += RomLayout.MAP_WARP_EVENT_SIZE
+	return {"ok": true, "kind": "warps", "events": warps, "at": at}
 
-	var coord_events: Array = []
+
+static func _read_coord_events(
+	rom: RomFile, at: int, group: int, number: int, cell_width: int, cell_height: int
+) -> Dictionary:
 	if not rom.in_bounds(at):
 		return _error("Map %d/%d has no coordinate-event count." % [group, number])
-	var coord_count: int = rom.u8(at)
+	var count: int = rom.u8(at)
 	at += 1
-	for _i: int in coord_count:
+	var coord_events: Array = []
+	for _i: int in count:
 		if not rom.in_bounds(at, RomLayout.MAP_COORD_EVENT_SIZE):
 			return _error("Map %d/%d coordinate events are truncated." % [group, number])
-		var coord_y: int = rom.u8(at + 1)
-		var coord_x: int = rom.u8(at + 2)
-		if not _valid_coord(coord_x, coord_y, cell_width, cell_height):
+		var y: int = rom.u8(at + 1)
+		var x: int = rom.u8(at + 2)
+		if not _valid_coord(x, y, cell_width, cell_height):
 			return _error("Map %d/%d has an out-of-bounds coordinate event." % [group, number])
 		coord_events.append({
 			"scene": rom.u8(at),
-			"x": coord_x,
-			"y": coord_y,
+			"x": x,
+			"y": y,
 			"script": rom.u16le(at + 4),
 		})
 		at += RomLayout.MAP_COORD_EVENT_SIZE
+	return {"ok": true, "kind": "coord_events", "events": coord_events, "at": at}
 
-	var bg_events: Array = []
+
+static func _read_bg_events(
+	rom: RomFile, at: int, group: int, number: int, cell_width: int, cell_height: int
+) -> Dictionary:
 	if not rom.in_bounds(at):
 		return _error("Map %d/%d has no background-event count." % [group, number])
-	var bg_count: int = rom.u8(at)
+	var count: int = rom.u8(at)
 	at += 1
-	for _i: int in bg_count:
+	var bg_events: Array = []
+	for _i: int in count:
 		if not rom.in_bounds(at, RomLayout.MAP_BG_EVENT_SIZE):
 			return _error("Map %d/%d background events are truncated." % [group, number])
-		var bg_y: int = rom.u8(at)
-		var bg_x: int = rom.u8(at + 1)
-		if not _valid_coord(bg_x, bg_y, cell_width, cell_height):
+		var y: int = rom.u8(at)
+		var x: int = rom.u8(at + 1)
+		if not _valid_coord(x, y, cell_width, cell_height):
 			return _error("Map %d/%d has an out-of-bounds background event." % [group, number])
 		bg_events.append({
-			"x": bg_x,
-			"y": bg_y,
+			"x": x,
+			"y": y,
 			"type": rom.u8(at + 2),
 			"script": rom.u16le(at + 3),
 		})
 		at += RomLayout.MAP_BG_EVENT_SIZE
+	return {"ok": true, "kind": "bg_events", "events": bg_events, "at": at}
 
-	var objects: Array = []
+
+static func _read_object_events(
+	rom: RomFile, bank: int, at: int, group: int, number: int
+) -> Dictionary:
 	if not rom.in_bounds(at):
 		return _error("Map %d/%d has no object-event count." % [group, number])
-	var object_count: int = rom.u8(at)
+	var count: int = rom.u8(at)
 	at += 1
-	for _i: int in object_count:
+	var objects: Array = []
+	for _i: int in count:
 		if not rom.in_bounds(at, RomLayout.MAP_OBJECT_EVENT_SIZE):
 			return _error("Map %d/%d object events are truncated." % [group, number])
-		var object_y: int = rom.u8(at + 1) - 4
-		var object_x: int = rom.u8(at + 2) - 4
-		# Object templates may sit in the runtime's six-cell connection padding,
-		# so unlike warps and coordinate events they are not constrained to the
-		# map's interior dimensions.
 		var radius: int = rom.u8(at + 4)
 		var palette_type: int = rom.u8(at + 7)
-		var hour_1: int = rom.u8(at + 5)
-		var hour_2: int = rom.u8(at + 6)
-		# The source macro writes -1 as $FF to select the time-of-day mask in
-		# hour_2. Preserve that sentinel as a signed value in the cache.
-		if hour_1 == 0xFF:
-			hour_1 = -1
-		if hour_2 == 0xFF:
-			hour_2 = -1
 		var event_flag: int = rom.u16le(at + 11)
 		if event_flag == 0xFFFF:
 			event_flag = -1
 		var object_type: int = palette_type & 0x0F
 		var object_script: int = rom.u16le(at + 9)
-		var trainer: Dictionary = {}
-		if object_type == OBJECTTYPE_TRAINER:
-			trainer = _read_trainer_record(rom, bank, object_script)
+		# Object templates may sit in the runtime's six-cell connection padding, so
+		# unlike warps and coordinate events they are not bounded by the map.
 		var object: Dictionary = {
 			"sprite": rom.u8(at),
-			"x": object_x,
-			"y": object_y,
+			"x": rom.u8(at + 2) - 4,
+			"y": rom.u8(at + 1) - 4,
 			"movement": rom.u8(at + 3),
 			"x_radius": radius & 0x0F,
 			"y_radius": radius >> 4,
-			"hour_1": hour_1,
-			"hour_2": hour_2,
+			"hour_1": _object_hour(rom.u8(at + 5)),
+			"hour_2": _object_hour(rom.u8(at + 6)),
 			"palette": palette_type >> 4,
 			"object_type": object_type,
 			"sight_range": rom.u8(at + 8),
 			"script": object_script,
 			"event_flag": event_flag,
 		}
-		if not trainer.is_empty():
-			object["trainer"] = trainer
+		if object_type == OBJECTTYPE_TRAINER:
+			var trainer: Dictionary = _read_trainer_record(rom, bank, object_script)
+			if not trainer.is_empty():
+				object["trainer"] = trainer
 		objects.append(object)
 		at += RomLayout.MAP_OBJECT_EVENT_SIZE
+	return {"ok": true, "kind": "objects", "events": objects, "at": at}
 
-	return {
-		"ok": true,
-		"warps": warps,
-		"coord_events": coord_events,
-		"bg_events": bg_events,
-		"objects": objects,
-}
+
+static func _object_hour(raw: int) -> int:
+	return -1 if raw == 0xFF else raw
 
 
 ## Decodes the source trainer macro referenced by an OBJECTTYPE_TRAINER event.

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -974,47 +974,9 @@ func register_menu_entry(menu: StringName, id: StringName, entry: Dictionary) ->
 	if label.is_empty():
 		return {"ok": false, "reason": &"menu_entry_missing_label", "detail": String(id)}
 	var registered: Dictionary = {"kind": id, "label": label}
-	if menu == MENU_PACK_POCKET:
-		var pocket: int = int(entry.get("pocket", 0))
-		if pocket < FIRST_MOD_POCKET:
-			return {"ok": false, "reason": &"reserved_pocket", "detail": String(id)}
-		registered["pocket"] = pocket
-	elif menu == MENU_MART:
-		var item: int = int(entry.get("item", 0))
-		if item <= 0:
-			return {"ok": false, "reason": &"invalid_mart_item", "detail": String(id)}
-		registered["item"] = item
-		if entry.has("price"):
-			var price: int = int(entry["price"])
-			if price < 0:
-				return {"ok": false, "reason": &"invalid_mart_price", "detail": String(id)}
-			registered["price"] = price
-		if entry.has("available"):
-			var available: Variant = entry["available"]
-			if not available is Callable or not (available as Callable).is_valid():
-				return {"ok": false, "reason": &"invalid_mart_filter", "detail": String(id)}
-			registered["available"] = available
-	else:
-		var action: StringName = StringName(entry.get("action", &""))
-		if String(action).is_empty():
-			var handler: Variant = entry.get("handler", null)
-			registered["available"] = handler is Callable and (handler as Callable).is_valid()
-			if bool(registered["available"]):
-				registered["handler"] = handler
-		elif not START_ACTIONS.has(action):
-			return {"ok": false, "reason": &"unknown_menu_action", "detail": String(action)}
-		else:
-			registered["action"] = action
-			registered["available"] = true
-			## Which page the row opens, for a mod with more than one row: the
-			## row's own id otherwise, which is the mod's id in every example.
-			if action == START_ACTION_OPEN_MOD_PAGE:
-				registered["page"] = StringName(entry.get("page", id))
-		if entry.has("visible"):
-			var visible: Variant = entry["visible"]
-			if not visible is Callable or not (visible as Callable).is_valid():
-				return {"ok": false, "reason": &"invalid_menu_visibility", "detail": String(id)}
-			registered["visible"] = visible
+	var refusal: Dictionary = _fill_menu_entry(menu, id, entry, registered)
+	if not refusal.is_empty():
+		return refusal
 	var entries: Array = _menu_entries.get(menu, [])
 	for existing: Dictionary in entries:
 		if StringName(existing.get("kind", &"")) == id:
@@ -1022,6 +984,72 @@ func register_menu_entry(menu: StringName, id: StringName, entry: Dictionary) ->
 	entries.append(registered)
 	_menu_entries[menu] = entries
 	return {"ok": true, "id": id}
+
+
+func _fill_menu_entry(
+	menu: StringName, id: StringName, entry: Dictionary, registered: Dictionary
+) -> Dictionary:
+	if menu == MENU_PACK_POCKET:
+		return _fill_pocket_entry(id, entry, registered)
+	if menu == MENU_MART:
+		return _fill_mart_entry(id, entry, registered)
+	return _fill_start_entry(id, entry, registered)
+
+
+func _fill_pocket_entry(
+	id: StringName, entry: Dictionary, registered: Dictionary
+) -> Dictionary:
+	var pocket: int = int(entry.get("pocket", 0))
+	if pocket < FIRST_MOD_POCKET:
+		return {"ok": false, "reason": &"reserved_pocket", "detail": String(id)}
+	registered["pocket"] = pocket
+	return {}
+
+
+func _fill_mart_entry(
+	id: StringName, entry: Dictionary, registered: Dictionary
+) -> Dictionary:
+	var item: int = int(entry.get("item", 0))
+	if item <= 0:
+		return {"ok": false, "reason": &"invalid_mart_item", "detail": String(id)}
+	registered["item"] = item
+	if entry.has("price"):
+		var price: int = int(entry["price"])
+		if price < 0:
+			return {"ok": false, "reason": &"invalid_mart_price", "detail": String(id)}
+		registered["price"] = price
+	if entry.has("available"):
+		var available: Variant = entry["available"]
+		if not available is Callable or not (available as Callable).is_valid():
+			return {"ok": false, "reason": &"invalid_mart_filter", "detail": String(id)}
+		registered["available"] = available
+	return {}
+
+
+func _fill_start_entry(
+	id: StringName, entry: Dictionary, registered: Dictionary
+) -> Dictionary:
+	var action: StringName = StringName(entry.get("action", &""))
+	if String(action).is_empty():
+		var handler: Variant = entry.get("handler", null)
+		registered["available"] = handler is Callable and (handler as Callable).is_valid()
+		if bool(registered["available"]):
+			registered["handler"] = handler
+	elif not START_ACTIONS.has(action):
+		return {"ok": false, "reason": &"unknown_menu_action", "detail": String(action)}
+	else:
+		registered["action"] = action
+		registered["available"] = true
+		## Which page the row opens, for a mod with more than one row: the
+		## row's own id otherwise, which is the mod's id in every example.
+		if action == START_ACTION_OPEN_MOD_PAGE:
+			registered["page"] = StringName(entry.get("page", id))
+	if entry.has("visible"):
+		var visible: Variant = entry["visible"]
+		if not visible is Callable or not (visible as Callable).is_valid():
+			return {"ok": false, "reason": &"invalid_menu_visibility", "detail": String(id)}
+		registered["visible"] = visible
+	return {}
 
 
 ## Adds one row to the PARTY MEMBER submenu, the box a party slot opens. Unlike

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -419,6 +419,10 @@ func _confirm() -> void:
 	if StringName(entry.get("option", &"")) == OPTION_CANCEL:
 		_close_submenu()
 		return
+	_confirm_submenu(entry)
+
+
+func _confirm_submenu(entry: Dictionary) -> void:
 	match StringName(entry.get("kind", &"")):
 		&"field_move":
 			var move: int = int(entry.get("move", 0))
@@ -461,17 +465,21 @@ func _confirm() -> void:
 				"name": _display_name(_save.party[_member_cursor]),
 			})
 		&"option":
-			match StringName(entry.get("option", &"")):
-				OPTION_ITEM:
-					_open_item_menu()
-				OPTION_MAIL:
-					_open_mail_menu()
-				OPTION_SWITCH:
-					_begin_switch()
-				OPTION_STATS:
-					_open_stats()
-				OPTION_MOVE:
-					_open_moves()
+			_confirm_option(StringName(entry.get("option", &"")))
+
+
+func _confirm_option(option: StringName) -> void:
+	match option:
+		OPTION_ITEM:
+			_open_item_menu()
+		OPTION_MAIL:
+			_open_mail_menu()
+		OPTION_SWITCH:
+			_begin_switch()
+		OPTION_STATS:
+			_open_stats()
+		OPTION_MOVE:
+			_open_moves()
 
 
 ## `MonMenu_Stats` reaches `OpenPartyStats`, which is `StatsScreenInit` over the

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -65,17 +65,9 @@ static func from_battle_party(
 	game_id: StringName, rom_sha1: String, slot: int, party: Gen2Party, player_name: String = "",
 	source_save: Gen2SaveData = null
 ) -> Gen2SaveData:
-	if party == null or party.mons.is_empty() or party.mons.size() > Gen2Party.MAX_SIZE:
+	var egg_count: int = _egg_slots(party, source_save)
+	if egg_count < 0:
 		return null
-	var egg_count: int = 0
-	if source_save != null:
-		for member: Gen2SaveMon in source_save.party:
-			if member != null and member.is_egg:
-				egg_count += 1
-		if egg_count > 0 and source_save.party.size() - egg_count != party.mons.size():
-			return null
-		if source_save.party.size() > Gen2Party.MAX_SIZE:
-			return null
 	var out: Gen2SaveData = (
 		Gen2SaveData.from_dict(source_save.to_dict())
 		if source_save != null else Gen2SaveData.new()
@@ -116,6 +108,22 @@ static func from_battle_party(
 			saved_mon.original_trainer = previous.original_trainer
 		out.party.append(saved_mon)
 	return out
+
+
+static func _egg_slots(party: Gen2Party, source_save: Gen2SaveData) -> int:
+	if party == null or party.mons.is_empty() or party.mons.size() > Gen2Party.MAX_SIZE:
+		return -1
+	if source_save == null:
+		return 0
+	var egg_count: int = 0
+	for member: Gen2SaveMon in source_save.party:
+		if member != null and member.is_egg:
+			egg_count += 1
+	if egg_count > 0 and source_save.party.size() - egg_count != party.mons.size():
+		return -1
+	if source_save.party.size() > Gen2Party.MAX_SIZE:
+		return -1
+	return egg_count
 
 
 ## The fighting half of a saved party. An egg keeps its party slot on the

--- a/game/world/battle_tower.gd
+++ b/game/world/battle_tower.gd
@@ -455,7 +455,22 @@ func reward_for(pack: Dictionary) -> int:
 ## The mobile rows are no-ops with a reason: each writes a byte in SRAM bank 5
 ## that only the mobile adapter's own routines read, and none of them reaches a
 ## script the player can talk to.
+## The four actions whose whole body is the challenge state they write.
+const CHALLENGE_STATE_ACTIONS: Dictionary = {
+	ACTION_SAVE_AND_QUIT: SAVED_AND_LEFT,
+	ACTION_CHALLENGE_CANCELED: NO_CHALLENGE,
+	ACTION_SET_WON_CHALLENGE: WON_CHALLENGE,
+	ACTION_SET_RECEIVED_REWARD: RECEIVED_REWARD,
+}
+const PARTY_CHECK_ACTIONS: Array[int] = [ACTION_LEVEL_CHECK, ACTION_UBERS_CHECK]
+
+
 func action(index: int, context: Dictionary = {}) -> int:
+	if CHALLENGE_STATE_ACTIONS.has(index):
+		challenge_state = int(CHALLENGE_STATE_ACTIONS[index])
+		return -1
+	if PARTY_CHECK_ACTIONS.has(index):
+		return _party_check(index, context.get("party", {}) as Dictionary)
 	match index:
 		ACTION_CHECK_EXPLANATION_READ:
 			if not bool(context.get("save_is_yours", true)):
@@ -465,10 +480,6 @@ func action(index: int, context: Dictionary = {}) -> int:
 			save_file_flags |= FLAG_EXPLANATION_READ
 		ACTION_GET_CHALLENGE_STATE:
 			return challenge_state
-		ACTION_SAVE_AND_QUIT:
-			challenge_state = SAVED_AND_LEFT
-		ACTION_CHALLENGE_CANCELED:
-			challenge_state = NO_CHALLENGE
 		ACTION_SAVE_LEVEL_GROUP:
 			level_group = chosen_group
 		ACTION_LOAD_LEVEL_GROUP:
@@ -476,12 +487,6 @@ func action(index: int, context: Dictionary = {}) -> int:
 			return chosen_group
 		ACTION_CHECK_SAVE_FILE_IS_YOURS:
 			return 1 if bool(context.get("save_is_yours", true)) else 0
-		ACTION_LEVEL_CHECK:
-			var over: int = level_check(context.get("party", {}) as Dictionary, chosen_group)
-			return 0 if over < 0 else group_level(chosen_group)
-		ACTION_UBERS_CHECK:
-			var uber: int = ubers_check(context.get("party", {}) as Dictionary, chosen_group)
-			return 0 if uber < 0 else group_level(chosen_group)
 		ACTION_RESET_DATA:
 			reset_trainers()
 		ACTION_CHOOSE_REWARD:
@@ -490,8 +495,10 @@ func action(index: int, context: Dictionary = {}) -> int:
 				choose_reward(random as RandomNumberGenerator)
 		ACTION_GIVE_REWARD:
 			return reward_for(context.get("pack", {}) as Dictionary)
-		ACTION_SET_WON_CHALLENGE:
-			challenge_state = WON_CHALLENGE
-		ACTION_SET_RECEIVED_REWARD:
-			challenge_state = RECEIVED_REWARD
 	return -1
+
+
+func _party_check(index: int, party: Dictionary) -> int:
+	var refused: int = level_check(party, chosen_group) if index == ACTION_LEVEL_CHECK \
+		else ubers_check(party, chosen_group)
+	return 0 if refused < 0 else group_level(chosen_group)

--- a/game/world/slot_machine.gd
+++ b/game/world/slot_machine.gd
@@ -711,50 +711,51 @@ func _update_reel_objects(reel: Reel) -> void:
 
 
 ## `ReelActionJumptable`, on the reel this pass is spinning.
+## `Slots_ReelActionTable`: the method each action runs. Actions 2 to 6 set a
+## rate and nothing else, so they are [constant REEL_SPIN_RATES] instead.
+const REEL_METHODS: Dictionary = {
+	REEL_ACTION_STOP_REEL_IGNORE_JOYPAD: &"_stop_reel_delay",
+	REEL_ACTION_STOP_REEL1: &"_action_stop_reel1",
+	REEL_ACTION_STOP_REEL2: &"_action_stop_reel2",
+	REEL_ACTION_STOP_REEL3: &"_action_stop_reel3",
+	REEL_ACTION_SET_UP_REEL2_SKIP_TO_7: &"_action_set_up_skip",
+	REEL_ACTION_WAIT_REEL2_SKIP_TO_7: &"_action_wait_skip",
+	REEL_ACTION_FAST_SPIN_REEL2_UNTIL_LINED_UP_7S: &"_action_fast_spin_sevens",
+	REEL_ACTION_START_SLOW_ADVANCE_REEL3: &"_action_start_slow_advance",
+	REEL_ACTION_WAIT_SLOW_ADVANCE_REEL3: &"_action_wait_slow_advance",
+	REEL_ACTION_INIT_GOLEM: &"_action_init_golem",
+	REEL_ACTION_WAIT_GOLEM: &"_action_wait_golem",
+	REEL_ACTION_END_GOLEM: &"_action_end_golem",
+	REEL_ACTION_INIT_CHANSEY: &"_action_init_chansey",
+	REEL_ACTION_WAIT_CHANSEY: &"_action_wait_chansey",
+	REEL_ACTION_WAIT_EGG: &"_action_wait_egg",
+	REEL_ACTION_DROP_REEL: &"_action_drop_reel",
+}
+const REEL_SPIN_RATES: Dictionary = {
+	2: RATE_QUADRUPLE, 3: RATE_DOUBLE, REEL_ACTION_NORMAL_RATE: RATE_NORMAL,
+	5: 2, 6: RATE_QUARTER,
+}
+
+
 func _reel_action(index: int) -> void:
 	var reel: Reel = _reels[index]
-	match reel.action:
-		REEL_ACTION_DO_NOTHING:
-			return
-		REEL_ACTION_STOP_REEL_IGNORE_JOYPAD:
-			_stop_reel_delay(reel)
-		2, 3, REEL_ACTION_NORMAL_RATE, 5, 6:
-			reel.spin_rate = [16, 8, 4, 2, 1][reel.action - 2]
-		REEL_ACTION_STOP_REEL1:
-			_action_stop_reel1(reel)
-		REEL_ACTION_STOP_REEL2:
-			_action_stop_reel2(reel)
-		REEL_ACTION_STOP_REEL3:
-			_action_stop_reel3(reel)
-		REEL_ACTION_SET_UP_REEL2_SKIP_TO_7:
-			_action_set_up_skip(reel)
-		REEL_ACTION_WAIT_REEL2_SKIP_TO_7:
-			_action_wait_skip(reel)
-		REEL_ACTION_FAST_SPIN_REEL2_UNTIL_LINED_UP_7S:
-			if _check_first_two(reel) and _first_two_sevens:
-				_stop_reel(reel)
-		REEL_ACTION_START_SLOW_ADVANCE_REEL3:
-			_action_start_slow_advance(reel)
-		REEL_ACTION_WAIT_SLOW_ADVANCE_REEL3:
-			_action_wait_slow_advance(reel)
-		REEL_ACTION_INIT_GOLEM:
-			_action_init_golem(reel)
-		REEL_ACTION_WAIT_GOLEM:
-			_action_wait_golem(reel)
-		REEL_ACTION_END_GOLEM:
-			_delay = 0
-			reel.action = REEL_ACTION_WAIT_GOLEM
-			reel.spin_rate = 0
-		REEL_ACTION_INIT_CHANSEY:
-			_action_init_chansey(reel)
-		REEL_ACTION_WAIT_CHANSEY:
-			_action_wait_chansey(reel)
-		REEL_ACTION_WAIT_EGG:
-			_action_wait_egg(reel)
-		REEL_ACTION_DROP_REEL:
-			_action_drop_reel(reel)
-		_:
-			return
+	if REEL_SPIN_RATES.has(reel.action):
+		reel.spin_rate = int(REEL_SPIN_RATES[reel.action])
+		return
+	var method: StringName = StringName(REEL_METHODS.get(reel.action, &""))
+	if not method.is_empty():
+		call(method, reel)
+
+
+func _action_fast_spin_sevens(reel: Reel) -> void:
+	if _check_first_two(reel) and _first_two_sevens:
+		_stop_reel(reel)
+
+
+func _action_end_golem(reel: Reel) -> void:
+	_delay = 0
+	reel.action = REEL_ACTION_WAIT_GOLEM
+	reel.spin_rate = 0
 
 
 ## `Slots_StopReel`, which is the rate, the ignore-joypad action and the delay.

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -375,6 +375,8 @@ var _player_scripted_steps: bool = false
 ## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
 var _player_step_frame: int = 0
 var _player_step_kind: StringName = &""
+## OBJECT_STEP_FRAME's spin use. See [method Gen2WorldMovement.spin_advance].
+var _player_spin_frame: int = 0
 ## What runs when the player's queued run drains.
 var _player_step_tail: Callable = Callable()
 ## Frames left of the counted wait a script is standing in, -1 while it is not
@@ -844,9 +846,8 @@ const JUMP_OFFSETS: Array[int] = [
 ]
 
 
-## How far above its cell the player is drawn this frame, zero unless a ledge hop
-## is in flight. Presentation only: `player_cell` committed to the landing cell
-## when the hop started.
+## [method player_height_offset_pixels] in the renderer's own downward-positive
+## draw space.
 func player_jump_offset() -> int:
 	if not _player_jumping or _player_step_passes_total <= 0:
 		return 0
@@ -867,20 +868,16 @@ static func jump_offset_at(spent: int, total: int) -> int:
 
 
 ## How far above the ground the player is drawn this frame, in world pixels and
-## positive upward: the mod-facing spelling of player_jump_offset(), which is the
-## same arc in the renderer's own downward-positive draw space. Zero at rest, on
-## an ordinary step, and on the frame a hop completes. Presentation only: the
-## cell, the collision, the triggers and the snapshot are already at the landing
-## cell while this is above zero.
+## positive upward. Zero at rest, on an ordinary step, and on the frame a hop
+## completes. Presentation only: the cell, the collision, the triggers and the
+## snapshot are already at the landing cell while this is above zero.
 func player_height_offset_pixels() -> float:
 	return float(-player_jump_offset())
 
 
-## The in-flight walk step's presentation offset in fractional walk cells,
-## from 1.0 cell behind player_cell down to zero, so a renderer that does not
-## think in hardware pixels (a 3D or free-roam mod) can still smooth against
-## it without reverse-engineering CELL_PIXELS.
-##
+## The in-flight step's presentation offset in fractional walk cells, from 1.0
+## cell behind player_cell down to zero, so a renderer that does not think in
+## hardware pixels can smooth against it without reverse-engineering CELL_PIXELS.
 ## A scripted movement commits its whole path at once, so while its trail drains
 ## this is as many cells behind as the player has left to be drawn walking.
 func player_step_offset_cells() -> Vector2:
@@ -898,6 +895,14 @@ func player_step_offset_cells() -> Vector2:
 ## name, one of [constant SCRIPTED_STEP_PASSES]' keys. Empty while nothing steps.
 func player_step_kind() -> StringName:
 	return _player_step_kind if _player_step_passes_remaining > 0 else &""
+
+
+## The facing the player is DRAWN with: [member player_facing] except while a
+## spinning command walks, and the logical facing never moves.
+func player_drawn_facing() -> int:
+	if player_step_kind() in Gen2WorldMovement.SPINNING_KINDS:
+		return Gen2WorldMovement.spin_facing(_player_spin_frame)
+	return player_facing
 
 
 ## The player's `Facings` frame, 0 to 3. `Gen2WorldObject.walk_frame()` for an
@@ -921,11 +926,7 @@ func _start_player_step(
 
 
 ## One step of a scripted stream, behind whatever the player is already walking.
-## See Gen2WorldObject.queue_step().
-## [param facing] is the direction the player is drawn looking while this step
-## runs, the way [method Gen2WorldObject.queue_step] takes one: `NormalStep`
-## writes OBJECT_FACING as the step starts, so a stream applied in one call still
-## turns a step at a time.
+## See [method Gen2WorldObject.queue_step], which takes the same [param facing].
 func _queue_player_step(
 	direction: Vector2i, frames: int, jumping: bool = false,
 	facing: Vector2i = Vector2i.ZERO, kind: StringName = STEP_KIND_WALK
@@ -996,6 +997,7 @@ func _clear_player_step() -> void:
 	## nothing; running it against the cell being left would.
 	_player_step_tail = Callable()
 	_player_step_kind = &""
+	_player_spin_frame = 0
 	_player_step_began = false
 	_player_jumping = false
 	_player_step_direction = Vector2i.ZERO
@@ -1014,6 +1016,8 @@ func _clear_player_step() -> void:
 func advance_player_step_pass() -> bool:
 	if _player_step_passes_remaining <= 0:
 		return false
+	if _player_step_kind in Gen2WorldMovement.SPINNING_KINDS:
+		_player_spin_frame = Gen2WorldMovement.spin_advance(_player_spin_frame)
 	_player_step_frame = (_player_step_frame + 1) & 0x0F
 	_player_step_passes_remaining -= 1
 	if _player_step_passes_remaining <= 0:
@@ -1508,17 +1512,18 @@ func complete_waterfall() -> Dictionary:
 	var size: Vector2i = map_size_cells()
 	var cell: Vector2i = player_cell
 	var climbed: int = 0
-	## The column is bounded by the map, and MAX_CLIMB is that bound rather than
-	## a guess: a stream that never left a waterfall would otherwise not end.
+	## A fall drawn up to the top row ends there: `.CheckContinueWaterfall` reads
+	## the border block above it, never a waterfall, so the cartridge stops one row
+	## into padding this has no cell for. Silver Cave Room 2's is the only one.
 	while climbed < size.y:
 		var next: Vector2i = cell + Vector2i.UP
 		if next.y < 0:
-			return _waterfall_failure(&"climb_left_the_map")
+			break
 		cell = next
 		climbed += 1
 		if not Gen2WorldFieldMove.waterfall_tile(collision_code_at(cell)):
 			break
-	if climbed <= 0 or Gen2WorldFieldMove.waterfall_tile(collision_code_at(cell)):
+	if climbed <= 0:
 		return _waterfall_failure(&"climb_did_not_finish")
 	player_cell = cell
 	player_facing = Gen2WorldSprite.FACING_UP
@@ -4596,7 +4601,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 				# advance_scripted_steps_pass().
 				object.queue_step(
 					direction * cells, int(SCRIPTED_STEP_PASSES[kind]) * cells, jumping,
-					direction,
+					direction, kind,
 				)
 				_advance_followers(object_index, vacated)
 			else:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -90,6 +90,10 @@ const SCRIPTED_STEP_PASSES: Dictionary = {
 	&"turn_in": STEP_PASSES_WALK,
 	&"turn_waterfall": STEP_PASSES_FAST,
 }
+const STEP_KIND_WALK: StringName = &"step"
+const STEP_KIND_HOP: StringName = &"jump_step"
+const STEP_KIND_TURN: StringName = &"turn"
+
 ## The three rows of SCRIPTED_STEP_PASSES that are a hop: two cells, twice the
 ## frames, and the arc `UpdateJumpPosition` draws over them.
 const JUMP_STEP_KINDS: Array[StringName] = [
@@ -370,6 +374,9 @@ var _player_queued_steps: Array = []
 var _player_scripted_steps: bool = false
 ## The player's own OBJECT_STEP_FRAME. See Gen2WorldObject.step_frame.
 var _player_step_frame: int = 0
+var _player_step_kind: StringName = &""
+## What runs when the player's queued run drains.
+var _player_step_tail: Callable = Callable()
 ## Frames left of the counted wait a script is standing in, -1 while it is not
 ## standing in one or has not started counting.
 var _script_wait_frames: int = -1
@@ -886,6 +893,13 @@ func player_step_offset_cells() -> Vector2:
 	return behind
 
 
+## Which movement the step in flight is, so a renderer draws a waterfall climb as
+## a climb rather than a walk north: a scripted stream answers the command's own
+## name, one of [constant SCRIPTED_STEP_PASSES]' keys. Empty while nothing steps.
+func player_step_kind() -> StringName:
+	return _player_step_kind if _player_step_passes_remaining > 0 else &""
+
+
 ## The player's `Facings` frame, 0 to 3. `Gen2WorldObject.walk_frame()` for an
 ## object; the player's own step is paced here rather than on a record.
 func player_walk_frame() -> int:
@@ -898,11 +912,12 @@ func player_walk_frame() -> int:
 
 
 func _start_player_step(
-	direction: Vector2i, frames: int, jumping: bool = false
+	direction: Vector2i, frames: int, jumping: bool = false,
+	kind: StringName = STEP_KIND_WALK
 ) -> void:
 	_player_queued_steps.clear()
 	_player_scripted_steps = false
-	_begin_player_step(direction, frames, jumping)
+	_begin_player_step(direction, frames, jumping, kind)
 
 
 ## One step of a scripted stream, behind whatever the player is already walking.
@@ -913,13 +928,13 @@ func _start_player_step(
 ## turns a step at a time.
 func _queue_player_step(
 	direction: Vector2i, frames: int, jumping: bool = false,
-	facing: Vector2i = Vector2i.ZERO
+	facing: Vector2i = Vector2i.ZERO, kind: StringName = STEP_KIND_WALK
 ) -> void:
 	if _player_step_passes_remaining > 0 or not _player_queued_steps.is_empty():
 		_player_scripted_steps = true
 		_player_queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
-			"facing": facing,
+			"facing": facing, "kind": kind,
 		})
 		return
 	_face_player_toward(facing)
@@ -928,7 +943,7 @@ func _queue_player_step(
 	if frames <= 0 and direction == Vector2i.ZERO:
 		return
 	_player_scripted_steps = true
-	_begin_player_step(direction, frames, jumping)
+	_begin_player_step(direction, frames, jumping, kind)
 
 
 func _face_player_toward(direction: Vector2i) -> void:
@@ -943,15 +958,28 @@ func _start_next_player_step() -> void:
 		_face_player_toward(next.get("facing", Vector2i.ZERO))
 		if int(next["frames"]) > 0 or next["direction"] != Vector2i.ZERO:
 			_begin_player_step(
-				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
+				next["direction"], int(next["frames"]), bool(next.get("jumping", false)),
+				StringName(next.get("kind", STEP_KIND_WALK))
 			)
 			return
 	_player_scripted_steps = false
+	_player_step_kind = &""
+	_run_player_step_tail()
+
+
+func _run_player_step_tail() -> void:
+	if not _player_step_tail.is_valid():
+		return
+	var tail: Callable = _player_step_tail
+	_player_step_tail = Callable()
+	tail.call()
 
 
 func _begin_player_step(
-	direction: Vector2i, frames: int, jumping: bool = false
+	direction: Vector2i, frames: int, jumping: bool = false,
+	kind: StringName = STEP_KIND_WALK
 ) -> void:
+	_player_step_kind = kind
 	## `StepFunction_PlayerJump` and `StepFunction_NPCJump` are the only step
 	## types that run `UpdateJumpPosition`, and every other step type replaces
 	## them, so the arc belongs to the hop that set it and to nothing begun after
@@ -964,6 +992,10 @@ func _begin_player_step(
 
 
 func _clear_player_step() -> void:
+	## A map load re-derives the player state itself, so dropping a tail loses
+	## nothing; running it against the cell being left would.
+	_player_step_tail = Callable()
+	_player_step_kind = &""
 	_player_step_began = false
 	_player_jumping = false
 	_player_step_direction = Vector2i.ZERO
@@ -1198,14 +1230,13 @@ func cancel_fishing() -> Dictionary:
 	return _fishing.cancel()
 
 
-## engine/events/overworld.asm's CutFunction, staged rather than applied.
-##
-## The source order is load bearing: .CheckAble tests ENGINE_HIVEBADGE before it
-## ever looks at the tile, so a player without the badge is told about the badge
-## even while facing a cuttable tree. A match records the block, replacement and
-## animation the way CheckMapForSomethingToCut fills wCutWhirlpool*; nothing is
-## written until complete_cut(), because Script_Cut shows its text first and only
-## then calls CutDownTreeOrGrass.
+## engine/events/overworld.asm's CutFunction. Every field move below is staged
+## rather than applied, because each source script shows its text and waits on the
+## button before it changes anything: `*_request` records and `complete_*` writes.
+## The refusal order is load bearing too: `.CheckAble` tests ENGINE_HIVEBADGE
+## before it ever looks at the tile, so a player without the badge is told about
+## the badge even while facing a cuttable tree. A match records the block,
+## replacement and animation the way CheckMapForSomethingToCut fills wCutWhirlpool*.
 func cut_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _cut_failure(&"missing_map")
@@ -1275,14 +1306,11 @@ static func _cut_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"cut_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's SurfFunction .TrySurf, staged rather than applied,
-## for the same reason Cut is: UsedSurfScript changes nothing until its text is
-## acknowledged. The refusal order is the source's: the badge is tested before the
-## player's own state and before the tile, so a player without the Fog Badge is
-## told about the badge whether or not the water in front is surfable, CheckBadge
-## itself being what pushes that text. [param species] is the chosen party
-## member's, for GetSurfType. The source's wBikeFlags branch has no counterpart
-## here, since no bike exists.
+## SurfFunction .TrySurf. The badge is tested before the player's own state and
+## before the tile, so a player without the Fog Badge is told about the badge
+## whether or not the water in front is surfable, CheckBadge itself being what
+## pushes that text. [param species] is the chosen party member's, for GetSurfType.
+## The source's wBikeFlags branch has no counterpart here, since no bike exists.
 func surf_request(species: int = 0) -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _surf_failure(&"missing_map")
@@ -1342,7 +1370,7 @@ func complete_surf() -> Dictionary:
 	movement_mode = MOVEMENT_SURF
 	player_sprite_number = int(request["sprite"])
 	player_cell = request["cell"]
-	_start_player_step(request["direction"], STEP_PASSES_NPC_WALK)
+	_start_player_step(request["direction"], STEP_PASSES_NPC_WALK, false, &"slow_step")
 	return {
 		"ok": true,
 		"kind": &"surf_applied",
@@ -1356,13 +1384,10 @@ static func _surf_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"surf_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's WhirlpoolFunction .TryWhirlpool, staged the way
-## Cut is: TryWhirlpoolMenu fills the same wCutWhirlpool* slots, and
-## Script_UsedWhirlpool reaches DisappearWhirlpool only after UseWhirlpoolText.
-##
-## .TryWhirlpool checks ENGINE_GLACIERBADGE before the tile, the same order
-## .CheckAble has. It checks no player state at all: the source neither requires
-## nor refuses surfing, so a player facing a whirlpool from land resolves too.
+## WhirlpoolFunction .TryWhirlpool, filling the same wCutWhirlpool* slots Cut
+## does. ENGINE_GLACIERBADGE is checked before the tile, the order .CheckAble has,
+## and no player state at all: the source neither requires nor refuses surfing, so
+## a player facing a whirlpool from land resolves too.
 func whirlpool_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _whirlpool_failure(&"missing_map")
@@ -1428,13 +1453,11 @@ static func _whirlpool_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"whirlpool_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's WaterfallFunction .TryWaterfall, staged the way
-## the other four are: Script_UsedWaterfall shows _UseWaterfallText and waits on
-## its button before the first climbing step. `.TryWaterfall` is CheckBadge
-## ENGINE_RISINGBADGE, then CheckMapCanWaterfall, which is two tests and no more:
-## `wPlayerDirection & $c` must be FACE_UP, and wTileUp must satisfy
-## CheckWaterfallTile. It reads no player state, so it neither requires nor refuses
-## surfing, and its refusal is FieldMoveFailed's generic line.
+## WaterfallFunction .TryWaterfall: CheckBadge ENGINE_RISINGBADGE, then
+## CheckMapCanWaterfall, which is two tests and no more: `wPlayerDirection & $c`
+## must be FACE_UP, and wTileUp must satisfy CheckWaterfallTile. It reads no player
+## state, so it neither requires nor refuses surfing, and its refusal is
+## FieldMoveFailed's generic line.
 func waterfall_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _waterfall_failure(&"missing_map")
@@ -1470,13 +1493,13 @@ func pending_waterfall() -> Dictionary:
 
 
 ## Script_UsedWaterfall's loop: `applymovement PLAYER, .WaterfallStep` is one
-## `turn_waterfall UP`, and `.CheckContinueWaterfall` repeats it while the cell the
-## player now stands on still answers CheckWaterfallTile. So the climb ends on the
-## first cell above the column that is not a waterfall, and the whole run is one
-## command rather than a step the caller paces. Each step is an applymovement, so
-## it consults no collision, spends no repel step and rolls no encounter. The
-## landing does re-derive the player state the way a warp does, which is what puts
-## a climber ashore on the ledge above.
+## `turn_waterfall UP`, repeated by `.CheckContinueWaterfall` while the cell the
+## player now stands on answers CheckWaterfallTile, so the climb ends on the first
+## cell that is not a waterfall. Each step is an applymovement: no collision, no
+## repel step, no encounter. Paced like a scripted stream, the cell committing at
+## once and the column drawn a cell at a time, so a renderer can carry the player
+## up the fall's face; the landing state is re-derived when the run drains rather
+## than here, and the answer reports the mode it will leave.
 func complete_waterfall() -> Dictionary:
 	if _pending_waterfall.is_empty():
 		return _waterfall_failure(&"no_pending_waterfall")
@@ -1498,14 +1521,19 @@ func complete_waterfall() -> Dictionary:
 	if climbed <= 0 or Gen2WorldFieldMove.waterfall_tile(collision_code_at(cell)):
 		return _waterfall_failure(&"climb_did_not_finish")
 	player_cell = cell
-	_apply_map_setup_player_state()
+	player_facing = Gen2WorldSprite.FACING_UP
+	var passes: int = int(SCRIPTED_STEP_PASSES[&"turn_waterfall"])
+	for _step: int in climbed:
+		_queue_player_step(Vector2i.UP, passes, false, Vector2i.UP, &"turn_waterfall")
+	_player_step_tail = _apply_map_setup_player_state
 	return {
 		"ok": true,
 		"kind": &"waterfall_applied",
 		"move": int(request["move"]),
 		"cell": cell,
 		"steps": climbed,
-		"movement_mode": movement_mode,
+		"passes": climbed * passes,
+		"movement_mode": _setup_movement_mode(cell),
 	}
 
 
@@ -1513,12 +1541,11 @@ static func _waterfall_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"waterfall_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's FlashFunction .CheckUseFlash, staged the way the
-## other five are. Flash is the one field move that checks no tile at all: its
-## whole test is the badge and then whether this map is a dark one, which is the
-## map header's own palette byte rather than anything under the player. The
-## Aerodactyl chamber's branch is a Ruins of Alph puzzle that is not implemented,
-## so the palette is the only way through here.
+## FlashFunction .CheckUseFlash. Flash is the one field move that checks no tile
+## at all: its whole test is the badge and then whether this map is a dark one,
+## which is the map header's own palette byte rather than anything under the
+## player. The Aerodactyl chamber's branch is a Ruins of Alph puzzle that is not
+## implemented, so the palette is the only way through.
 func flash_request() -> Dictionary:
 	if current_map == null:
 		return _flash_failure(&"missing_map")
@@ -1563,13 +1590,11 @@ static func _flash_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"flash_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's TryHeadbuttOW and TryHeadbuttFromMenu, staged
-## the way the other five are: HeadbuttScript reaches TreeMonEncounter only
-## after UseHeadbuttText, so the roll belongs to the commit and not to this.
-##
-## Headbutt is the one field move with no badge at all: TryHeadbuttOW is
-## CheckPartyMove and nothing else, and TryHeadbuttFromMenu is the faced tile
-## and nothing else. Its refusal is FieldMoveFailed's generic _CantUseItemText.
+## TryHeadbuttOW and TryHeadbuttFromMenu; the roll belongs to the commit, since
+## HeadbuttScript reaches TreeMonEncounter only after UseHeadbuttText. Headbutt is
+## the one field move with no badge at all: TryHeadbuttOW is CheckPartyMove and
+## nothing else, TryHeadbuttFromMenu the faced tile and nothing else. Its refusal
+## is FieldMoveFailed's generic _CantUseItemText.
 func headbutt_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _headbutt_failure(&"missing_map")
@@ -1672,13 +1697,11 @@ static func _headbutt_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"headbutt_failed", "reason": reason}
 
 
-## engine/events/overworld.asm's TryRockSmashFromMenu, staged the way the other six
-## are: RockSmashScript reaches RockMonEncounter only after UseRockSmashText, so
-## the roll and the rock both belong to the commit. Rock Smash asks neither a badge
-## nor a tile: `GetFacingObject` is `CheckFacingObject` and then the faced object's
-## own `MAPOBJECT_MOVEMENT` byte against `SPRITEMOVEDATA_SMASHABLE_ROCK`, so the
-## question is which object is in front rather than what the ground is. That is
-## also why it reads the doubled counter cell the way `interact()` does.
+## TryRockSmashFromMenu; the roll and the rock both belong to the commit. Rock
+## Smash asks neither a badge nor a tile: `GetFacingObject` is `CheckFacingObject`
+## and then the faced object's own `MAPOBJECT_MOVEMENT` byte against
+## `SPRITEMOVEDATA_SMASHABLE_ROCK`, so the question is which object is in front
+## rather than what the ground is, and it reads the doubled cell `interact()` does.
 func rock_smash_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _rock_smash_failure(&"missing_map")
@@ -1850,13 +1873,11 @@ func map_time_of_day() -> int:
 	)
 
 
-## engine/events/overworld.asm's StrengthFunction .TryStrength, staged the way the
-## other three are because Script_UsedStrength sets nothing until after its text
-## either. Unlike them, `.TryStrength` is a badge check and nothing else: no faced
-## tile, no block table, no player state, and no check that a boulder is even in
-## front. Its `.AlreadyUsingStrength` branch is annotated unreferenced in both
-## pins, so an already-active flag is not a refusal here. [param species] is the
-## chosen party member's, for SetStrengthFlag's wStrengthSpecies.
+## StrengthFunction .TryStrength, which unlike the others is a badge check and
+## nothing else: no faced tile, no block table, no player state, and no check that
+## a boulder is even in front. Its `.AlreadyUsingStrength` branch is annotated
+## unreferenced in both pins, so an already-active flag is not a refusal here.
+## [param species] is the chosen member's, for SetStrengthFlag's wStrengthSpecies.
 func strength_request(species: int = 0) -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _strength_failure(&"missing_map")
@@ -4694,7 +4715,7 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			## the walk ends rather than on the frame the stream was applied.
 			_queue_player_step(
 				Vector2i.ZERO, 0, false,
-				_movement_direction(int(command.get("direction", 0))),
+				_movement_direction(int(command.get("direction", 0))), kind,
 			)
 			continue
 		if SCRIPTED_STEP_PASSES.has(kind):
@@ -4707,13 +4728,13 @@ func _apply_player_movement(event: Dictionary) -> Array:
 				player_cell = destination
 				_queue_player_step(
 					direction * cells, int(SCRIPTED_STEP_PASSES[kind]) * cells, jumping,
-					direction,
+					direction, kind,
 				)
 				_advance_followers(-1, vacated)
 			else:
 				## `NormalStep` writes the facing before the refusal, so a step
 				## off the map turns the player where they stand.
-				_queue_player_step(Vector2i.ZERO, 0, false, direction)
+				_queue_player_step(Vector2i.ZERO, 0, false, direction, kind)
 				generated.append({
 					"type": &"movement_blocked", "player": true, "cell": destination,
 				})
@@ -4731,7 +4752,8 @@ func _apply_player_movement(event: Dictionary) -> Array:
 			# The player's half of the same wait: Script_earthquake's own stream is
 			# `step_shake` and then a sleep, and the sleep is all of its duration.
 			_queue_player_step(
-				Vector2i.ZERO, Gen2WorldObject.sleep_frames(int(command.get("length", 0)))
+				Vector2i.ZERO, Gen2WorldObject.sleep_frames(int(command.get("length", 0))),
+				false, Vector2i.ZERO, kind
 			)
 			continue
 		if kind in [
@@ -5654,7 +5676,7 @@ func player_input_move(direction: Vector2i) -> Dictionary:
 		if pressed_facing != player_facing:
 			player_facing = pressed_facing
 			_do_step(direction)
-			_start_player_step(Vector2i.ZERO, STEP_PASSES_TURN)
+			_start_player_step(Vector2i.ZERO, STEP_PASSES_TURN, false, STEP_KIND_TURN)
 			return {
 				"ok": true, "kind": &"turn", "facing": player_facing, "cell": player_cell,
 			}
@@ -5948,7 +5970,7 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	count_step()
 	_advance_followers(-1, from_cell)
 	_do_step(direction)
-	_start_player_step(direction * 2, STEP_PASSES_HOP, true)
+	_start_player_step(direction * 2, STEP_PASSES_HOP, true, STEP_KIND_HOP)
 	return {
 		"ok": true,
 		"kind": &"ledge_hop",
@@ -6047,14 +6069,18 @@ func _cell_at_connection_edge(cell: Vector2i, direction_name: String) -> bool:
 ## warp taken from a water tile lands on dry land still surfing, where nothing
 ## but water is a legal step. .CheckForcedBiking has no counterpart here.
 func _apply_map_setup_player_state() -> void:
-	if collision_permission_at(player_cell) == Gen2WorldCollision.WATER_TILE:
-		if movement_mode != MOVEMENT_SURF:
-			movement_mode = MOVEMENT_SURF
-			player_sprite_number = Gen2WorldSprite.SPRITE_SURF
+	var mode: StringName = _setup_movement_mode(player_cell)
+	if mode == movement_mode:
 		return
-	if movement_mode == MOVEMENT_SURF:
-		movement_mode = MOVEMENT_WALK
-		player_sprite_number = _walking_sprite()
+	movement_mode = mode
+	player_sprite_number = Gen2WorldSprite.SPRITE_SURF if mode == MOVEMENT_SURF \
+		else _walking_sprite()
+
+
+func _setup_movement_mode(cell: Vector2i) -> StringName:
+	if collision_permission_at(cell) == Gen2WorldCollision.WATER_TILE:
+		return MOVEMENT_SURF
+	return MOVEMENT_WALK if movement_mode == MOVEMENT_SURF else movement_mode
 
 
 func _apply_map(

--- a/game/world/world_bag_host.gd
+++ b/game/world/world_bag_host.gd
@@ -68,39 +68,20 @@ static func give_to_party(
 	persist: bool = true,
 	mail: Gen2SaveMail = null
 ) -> Dictionary:
-	if world == null or world.data == null or world.state == null:
-		return Gen2WorldTransaction.failure(&"missing_world", {})
+	var refused: Dictionary = _give_item_refusal(world, item)
+	if not refused.is_empty():
+		return refused
 	var definition: Dictionary = world.data.item(item)
-	if definition.is_empty():
-		return Gen2WorldTransaction.failure(&"unknown_item", {"item": item})
-	if not Gen2WorldPack.can_hold(world.data, item):
-		return Gen2WorldTransaction.failure(&"item_cannot_be_held", {"item": item})
 	var owned: int = world.state.item_quantity(item)
-	if owned <= 0:
-		return Gen2WorldTransaction.failure(&"insufficient_item_quantity", {"item": item})
 	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
 	if not bool(opened.get("ok", false)):
 		return opened
 	var candidate: Gen2SaveData = opened["candidate"]
 	var mon: Gen2SaveMon = _party_member(candidate, party_index)
-	if mon == null:
-		return Gen2WorldTransaction.failure(&"unknown_party_member", {"party_index": party_index})
-	if mon.is_egg:
-		return Gen2WorldTransaction.failure(&"cannot_hold_egg", {"party_index": party_index})
+	var refused_mon: Dictionary = _give_mon_refusal(world, mon, party_index, item, swap, mail)
+	if not refused_mon.is_empty():
+		return refused_mon
 	var held: int = mon.item
-	## `.please_remove_mail`, which is asked before `.already_holding_item`: a
-	## held mail is not offered as a swap at all.
-	if Gen2HeldItem.is_mail(held):
-		return Gen2WorldTransaction.failure(&"holding_mail", {"party_index": party_index})
-	if held > 0 and not swap:
-		return Gen2WorldTransaction.failure(&"already_holding", {
-			"party_index": party_index, "held": held,
-			"held_name": world.data.item_name(held),
-		})
-	## `GivePartyItem`'s own tail: a mail item with no message behind it would
-	## be a held item the MAIL row could not read.
-	if Gen2HeldItem.is_mail(item) and mail == null:
-		return Gen2WorldTransaction.failure(&"mail_not_written", {"item": item})
 	var changes: Dictionary = {item: owned - 1}
 	if held > 0:
 		## `GiveItemToPokemon` runs before `ReceiveItemFromPokemon`, so the entry
@@ -132,6 +113,43 @@ static func give_to_party(
 		"held": held,
 		"held_name": world.data.item_name(held) if held > 0 else "",
 	}
+
+
+static func _give_item_refusal(world: Gen2WorldAPI, item: int) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return Gen2WorldTransaction.failure(&"missing_world", {})
+	if world.data.item(item).is_empty():
+		return Gen2WorldTransaction.failure(&"unknown_item", {"item": item})
+	if not Gen2WorldPack.can_hold(world.data, item):
+		return Gen2WorldTransaction.failure(&"item_cannot_be_held", {"item": item})
+	if world.state.item_quantity(item) <= 0:
+		return Gen2WorldTransaction.failure(&"insufficient_item_quantity", {"item": item})
+	return {}
+
+
+static func _give_mon_refusal(
+	world: Gen2WorldAPI, mon: Gen2SaveMon, party_index: int, item: int,
+	swap: bool, mail: Gen2SaveMail
+) -> Dictionary:
+	if mon == null:
+		return Gen2WorldTransaction.failure(&"unknown_party_member", {"party_index": party_index})
+	if mon.is_egg:
+		return Gen2WorldTransaction.failure(&"cannot_hold_egg", {"party_index": party_index})
+	var held: int = mon.item
+	## `.please_remove_mail`, which is asked before `.already_holding_item`: a
+	## held mail is not offered as a swap at all.
+	if Gen2HeldItem.is_mail(held):
+		return Gen2WorldTransaction.failure(&"holding_mail", {"party_index": party_index})
+	if held > 0 and not swap:
+		return Gen2WorldTransaction.failure(&"already_holding", {
+			"party_index": party_index, "held": held,
+			"held_name": world.data.item_name(held),
+		})
+	## `GivePartyItem`'s own tail: a mail item with no message behind it would
+	## be a held item the MAIL row could not read.
+	if Gen2HeldItem.is_mail(item) and mail == null:
+		return Gen2WorldTransaction.failure(&"mail_not_written", {"item": item})
+	return {}
 
 
 ## `TakePartyItem`. An empty hand and a full pack are both refusals with their

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -319,37 +319,12 @@ static func apply(
 			})
 		slot = side
 	var standing: int = world.state.maptile_decoration(slot)
-	var text: String = ""
-	var next: int = standing
-	if is_put_away(data, deco):
-		## `DecoAction_TryPutItAway` clears the slot before it looks at what was
-		## in it, so an empty slot is still cleared and the box is the refusal.
-		if standing == 0:
-			return {"ok": true, "changed": false, "text": TEXT_NOTHING_TO_PUT_AWAY}
-		next = 0
-		text = put_away_text(decoration_name(data, standing))
-	else:
-		if not owns(data, world.state, deco):
-			return Gen2WorldTransaction.failure(&"decoration_not_owned", {
-				"decoration": deco,
-			})
-		if standing == deco:
-			## `DecoAction_SetItUp.alreadythere` is the one refusal that leaves
-			## the slot alone.
-			return {"ok": true, "changed": false, "text": TEXT_ALREADY_SET_UP}
-		next = deco
-		text = set_up_text(decoration_name(data, deco)) if standing == 0 \
-			else put_away_and_set_up_text(
-				decoration_name(data, standing), decoration_name(data, deco)
-			)
-	var writes: Dictionary = {slot: next}
-	## `DecoAction_SetItUp_Ornament.getwhichside`: a doll set up on one side is
-	## taken off the other, so the room never holds two of the same ornament.
-	if next != 0 and (slot == SLOT_LEFT_ORNAMENT or slot == SLOT_RIGHT_ORNAMENT):
-		var other: StringName = SLOT_RIGHT_ORNAMENT if slot == SLOT_LEFT_ORNAMENT \
-			else SLOT_LEFT_ORNAMENT
-		if world.state.maptile_decoration(other) == next:
-			writes[other] = 0
+	var change: Dictionary = _decoration_change(data, world, deco, standing)
+	if not change.has("next"):
+		return change
+	var next: int = int(change["next"])
+	var text: String = String(change["text"])
+	var writes: Dictionary = _decoration_writes(world, slot, next)
 	var before: Gen2WorldSnapshot = world.snapshot()
 	for written: StringName in writes:
 		if world.state.set_maptile_decoration(written, int(writes[written])):
@@ -364,3 +339,38 @@ static func apply(
 	return {
 		"ok": true, "changed": true, "text": text, "slot": slot, "decoration": next,
 	}
+
+
+static func _decoration_change(
+	data: GameData, world: Gen2WorldAPI, deco: int, standing: int
+) -> Dictionary:
+	if is_put_away(data, deco):
+		## `DecoAction_TryPutItAway` clears the slot before it looks at what was
+		## in it, so an empty slot is still cleared and the box is the refusal.
+		if standing == 0:
+			return {"ok": true, "changed": false, "text": TEXT_NOTHING_TO_PUT_AWAY}
+		return {"next": 0, "text": put_away_text(decoration_name(data, standing))}
+	if not owns(data, world.state, deco):
+		return Gen2WorldTransaction.failure(&"decoration_not_owned", {"decoration": deco})
+	if standing == deco:
+		## `DecoAction_SetItUp.alreadythere` is the one refusal that leaves the
+		## slot alone.
+		return {"ok": true, "changed": false, "text": TEXT_ALREADY_SET_UP}
+	var text: String = set_up_text(decoration_name(data, deco)) if standing == 0 \
+		else put_away_and_set_up_text(
+			decoration_name(data, standing), decoration_name(data, deco)
+		)
+	return {"next": deco, "text": text}
+
+
+## `DecoAction_SetItUp_Ornament.getwhichside`: a doll set up on one side is taken
+## off the other, so the room never holds two of the same ornament.
+static func _decoration_writes(world: Gen2WorldAPI, slot: StringName, next: int) -> Dictionary:
+	var writes: Dictionary = {slot: next}
+	if next == 0 or (slot != SLOT_LEFT_ORNAMENT and slot != SLOT_RIGHT_ORNAMENT):
+		return writes
+	var other: StringName = SLOT_RIGHT_ORNAMENT if slot == SLOT_LEFT_ORNAMENT \
+		else SLOT_LEFT_ORNAMENT
+	if world.state.maptile_decoration(other) == next:
+		writes[other] = 0
+	return writes

--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -106,6 +106,53 @@ static func purchase(
 	quantity: int = 1,
 	persist: bool = true
 ) -> Dictionary:
+	var checked: Dictionary = _purchase_refusal(world, mart, item, quantity)
+	if not bool(checked["ok"]):
+		return checked
+	var is_bargain: bool = bool(checked["is_bargain"])
+	var selected: Dictionary = checked["entry"]
+	var price: int = int(checked["price"])
+	var total: int = int(checked["total"])
+	var next_quantity: int = int(checked["next_quantity"])
+	var balance: int = int(checked["balance"])
+	var merchant_closed_flag: int = Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED \
+		if Gen2WorldState.is_crystal_profile(world.data) \
+		else Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {item: next_quantity},
+		"money": {MONEY_ACCOUNT: balance - total},
+		"engine_flags": {
+			merchant_closed_flag: true,
+		} if is_bargain else {},
+	})
+	if not bool(applied.get("ok", false)):
+		return _failure(&"purchase_state_failed", applied)
+	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	if is_bargain:
+		var next_sold_items: Dictionary = {}
+		var previous_sold_items: Variant = mart.get("_sold_items", {})
+		if previous_sold_items is Dictionary:
+			next_sold_items = (previous_sold_items as Dictionary).duplicate()
+		next_sold_items[item] = true
+		mart["_sold_items"] = next_sold_items
+	return {
+		"ok": true,
+		"item": item,
+		"name": selected.get("name", "UNKNOWN"),
+		"quantity": quantity,
+		"price": price,
+		"total": total,
+		"balance": balance - total,
+		"owned": next_quantity,
+	}
+
+
+static func _purchase_refusal(
+	world: Gen2WorldAPI, mart: Dictionary, item: int, quantity: int
+) -> Dictionary:
 	if world == null or world.data == null or world.state == null:
 		return _failure(&"missing_world", {})
 	if quantity <= 0:
@@ -139,38 +186,14 @@ static func purchase(
 			"item": item, "price": price, "quantity": quantity,
 			"total": total, "balance": balance,
 		})
-	var merchant_closed_flag: int = Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED \
-		if Gen2WorldState.is_crystal_profile(world.data) \
-		else Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
-	var before: Gen2WorldSnapshot = world.snapshot()
-	var applied: Dictionary = world.state.apply_changes({}, {}, {
-		"items": {item: next_quantity},
-		"money": {MONEY_ACCOUNT: balance - total},
-		"engine_flags": {
-			merchant_closed_flag: true,
-		} if is_bargain else {},
-	})
-	if not bool(applied.get("ok", false)):
-		return _failure(&"purchase_state_failed", applied)
-	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
-	if not bool(committed.get("ok", false)):
-		return committed
-	if is_bargain:
-		var next_sold_items: Dictionary = {}
-		var previous_sold_items: Variant = mart.get("_sold_items", {})
-		if previous_sold_items is Dictionary:
-			next_sold_items = (previous_sold_items as Dictionary).duplicate()
-		next_sold_items[item] = true
-		mart["_sold_items"] = next_sold_items
 	return {
 		"ok": true,
-		"item": item,
-		"name": selected.get("name", "UNKNOWN"),
-		"quantity": quantity,
+		"is_bargain": is_bargain,
+		"entry": selected,
 		"price": price,
 		"total": total,
-		"balance": balance - total,
-		"owned": next_quantity,
+		"next_quantity": next_quantity,
+		"balance": balance,
 	}
 
 

--- a/game/world/world_movement.gd
+++ b/game/world/world_movement.gd
@@ -10,6 +10,31 @@ const MAX_BYTES: int = 128
 const MAX_COMMANDS: int = 128
 const STEP_END: int = 0x47
 
+## The three commands reaching `TurningStep` rather than `NormalStep`
+## (engine/overworld/movement.asm). It sets OBJECT_ACTION_SPIN, so the walker
+## spins counterclockwise instead of facing the way it is going.
+const SPINNING_KINDS: Array[StringName] = [&"turn_away", &"turn_in", &"turn_waterfall"]
+
+## `CounterclockwiseSpinAction`'s `.facings`.
+const SPIN_FACINGS: Array[int] = [
+	Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT,
+	Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_LEFT,
+]
+
+
+## One pass of `CounterclockwiseSpinAction` on OBJECT_STEP_FRAME: bits 0 and 1 a
+## four-pass timer, bits 4 and 5 the facing. `InitStep` never touches this byte, so
+## a stream's steps share one turn.
+static func spin_advance(frame: int) -> int:
+	var timer: int = (frame & 0x0F) + 1
+	if timer < 4:
+		return (frame & 0x30) | timer
+	return ((frame & 0x30) + 0x10) & 0x30
+
+
+static func spin_facing(frame: int) -> int:
+	return SPIN_FACINGS[(frame >> 4) & 3]
+
 static func decode(data: PackedByteArray) -> Dictionary:
 	if data.is_empty():
 		return {"ok": false, "reason": &"missing_movement"}

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -77,6 +77,9 @@ var frame: int = 0
 ## increments it once per hardware frame of a step and masks it to four bits, and
 ## the drawn frame is its two high bits, so the drawing changes every four frames.
 var step_frame: int = 0
+## Which command is walking, and OBJECT_STEP_FRAME's spin use for it.
+var step_kind: StringName = &""
+var spin_frame: int = 0
 var active: bool = false
 var deleted: bool = false
 var emote_id: int = -1
@@ -347,23 +350,21 @@ func start_step(direction: Vector2i, frames: int) -> void:
 	_begin_step(direction, frames)
 
 
-## Adds one step of a scripted stream to the trail. The first one starts at
-## once and the rest wait their turn, so a five-step applymovement is drawn as
-## five steps rather than as one arrival.
-## [param new_facing] is the direction the object is drawn looking while this step
-## runs, which is not the step's own vector for a `jump_step` and is the whole of
-## a queued `turn_head`. `NormalStep` writes OBJECT_FACING as it starts the step,
-## so a stream applied in one call still turns one step at a time rather than
-## walking its whole path already facing the last command's way.
+## Adds one step of a scripted stream to the trail. The first starts at once and
+## the rest wait, so a five-step applymovement is drawn as five steps rather than
+## as one arrival. [param new_facing] is the direction it is drawn looking, not the
+## step's vector for a `jump_step` and the whole of a queued `turn_head`:
+## `NormalStep` writes it as the step starts, so a stream still turns a step at a
+## time.
 func queue_step(
 	direction: Vector2i, frames: int, jumping: bool = false,
-	new_facing: Vector2i = Vector2i.ZERO
+	new_facing: Vector2i = Vector2i.ZERO, kind: StringName = &""
 ) -> void:
 	if step_passes_remaining > 0 or not queued_steps.is_empty():
 		scripted_steps = true
 		queued_steps.append({
 			"direction": direction, "frames": maxi(0, frames), "jumping": jumping,
-			"facing": new_facing,
+			"facing": new_facing, "kind": kind,
 		})
 		return
 	apply_direction(new_facing)
@@ -372,7 +373,7 @@ func queue_step(
 	if frames <= 0 and direction == Vector2i.ZERO:
 		return
 	scripted_steps = true
-	_begin_step(direction, frames, jumping)
+	_begin_step(direction, frames, jumping, kind)
 
 
 ## `Movement_tree_shake`: 24 frames of STEP_TYPE_SLEEP with
@@ -397,7 +398,10 @@ static func sleep_frames(length: int) -> int:
 	return length if length > 0 else 0x100
 
 
-func _begin_step(direction: Vector2i, frames: int, jumping: bool = false) -> void:
+func _begin_step(
+	direction: Vector2i, frames: int, jumping: bool = false, kind: StringName = &""
+) -> void:
+	step_kind = kind
 	# `StepFunction_NPCJump` is the only step type running `UpdateJumpPosition`,
 	# and every step begun after it replaces the type, so the arc ends here.
 	step_jumping = jumping
@@ -415,6 +419,8 @@ func _begin_step(direction: Vector2i, frames: int, jumping: bool = false) -> voi
 func tick_step() -> bool:
 	if step_passes_remaining <= 0:
 		return false
+	if step_kind in Gen2WorldMovement.SPINNING_KINDS:
+		spin_frame = Gen2WorldMovement.spin_advance(spin_frame)
 	if step_direction != Vector2i.ZERO or weird_tree:
 		advance_walk_frame()
 	step_passes_remaining -= 1
@@ -438,10 +444,13 @@ func _start_next_queued_step() -> void:
 		apply_direction(next.get("facing", Vector2i.ZERO))
 		if int(next["frames"]) > 0 or next["direction"] != Vector2i.ZERO:
 			_begin_step(
-				next["direction"], int(next["frames"]), bool(next.get("jumping", false))
+				next["direction"], int(next["frames"]), bool(next.get("jumping", false)),
+				StringName(next.get("kind", &""))
 			)
 			return
 	scripted_steps = false
+	step_kind = &""
+	spin_frame = 0
 
 
 func is_stepping() -> bool:
@@ -458,6 +467,14 @@ func advance_walk_frame() -> void:
 
 func walk_frame() -> int:
 	return (step_frame >> 2) & 3
+
+
+## The facing this object is DRAWN with; [member facing] never moves.
+## See [constant Gen2WorldMovement.SPINNING_KINDS].
+func drawn_facing() -> int:
+	if step_passes_remaining > 0 and step_kind in Gen2WorldMovement.SPINNING_KINDS:
+		return Gen2WorldMovement.spin_facing(spin_frame)
+	return facing
 
 
 ## Starts the wait a movement template takes before deciding again. The source
@@ -487,10 +504,8 @@ func step_offset(cell_pixels: int) -> Vector2i:
 	return Vector2i(int(round(offset.x)), int(round(offset.y)))
 
 
-## How far above the ground this object is drawn, in world pixels and positive
-## upward, matching Gen2WorldAPI.player_height_offset_pixels(). Zero unless a
-## `jump_step` is in flight; presentation only, the cell having committed to the
-## landing cell when the jump started.
+## [method Gen2WorldAPI.player_height_offset_pixels] for an object: zero unless a
+## `jump_step` is in flight.
 func height_offset_pixels() -> float:
 	if not step_jumping or step_passes_total <= 0:
 		return 0.0
@@ -499,10 +514,7 @@ func height_offset_pixels() -> float:
 	))
 
 
-## The same offset in fractional walk cells, for a renderer that does not think
-## in hardware pixels, matching Gen2WorldAPI.player_step_offset_cells(). One
-## in-flight step is at most a cell behind; a scripted stream commits its whole
-## path at once, so its trail is as many cells behind as it has left to draw.
+## [method Gen2WorldAPI.player_step_offset_cells] for an object.
 func step_offset_cells() -> Vector2:
 	var behind := Vector2.ZERO
 	for entry: Dictionary in queued_steps:

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -640,41 +640,12 @@ static func teach_tm_hm(
 	forget_slot: int = -1,
 	persist: bool = true
 ) -> Dictionary:
-	if world == null or save == null or world.data == null:
-		return _failure(&"missing_save", {})
-	if world.state == null or world.state.item_quantity(item) <= 0:
-		return _failure(&"insufficient_item_quantity", {"item": item})
-	var move: int = Gen2WorldTMHM.move_for_item(world.data, item)
-	if move <= 0:
-		return _failure(&"not_a_tm_hm", {"item": item})
-	if party_index < 0 or party_index >= save.party.size():
-		return _failure(&"invalid_party_index", {"party_index": party_index})
-	var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
-	if mon == null:
-		return _failure(&"invalid_party_index", {"party_index": party_index})
-	# ChooseMonToLearnTMHM refuses an egg with SFX_WRONG and reopens the list, so
-	# an egg never reaches TeachTMHM at all.
-	if mon.is_egg:
-		return _failure(&"cannot_teach_egg", {"party_index": party_index})
-	if not Gen2WorldTMHM.can_learn(world.data, mon.species, move):
-		return _failure(&"not_compatible", {"species": mon.species, "move": move})
-	if Gen2WorldTMHM.knows_move(mon.moves, move):
-		return _failure(&"already_knows_move", {"move": move})
-	var slot: int = Gen2WorldTMHM.first_empty_slot(mon.moves)
-	var forgot: int = 0
-	if slot < 0:
-		# ForgetMove's own refusals, answering before the candidate save is built
-		# the way every refusal above them does.
-		if forget_slot < 0:
-			return _failure(&"moveset_full", {
-				"party_index": party_index, "move": move, "moves": mon.moves.duplicate(),
-			})
-		if forget_slot >= mon.moves.size():
-			return _failure(&"invalid_forget_slot", {"forget_slot": forget_slot})
-		forgot = int(mon.moves[forget_slot])
-		if Gen2MoveForget.is_hm_move(forgot):
-			return _failure(&"cannot_forget_hm", {"forget_slot": forget_slot, "forgot": forgot})
-		slot = forget_slot
+	var checked: Dictionary = _teach_tm_hm_refusal(world, save, item, party_index, forget_slot)
+	if not bool(checked["ok"]):
+		return checked
+	var move: int = int(checked["move"])
+	var slot: int = int(checked["slot"])
+	var forgot: int = int(checked["forgot"])
 
 	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
 	if not bool(opened.get("ok", false)):
@@ -719,6 +690,47 @@ static func teach_tm_hm(
 		"happiness": learner.happiness,
 		"happiness_change": learner.happiness - happiness,
 	}
+
+
+static func _teach_tm_hm_refusal(
+	world: Gen2WorldAPI, save: Gen2SaveData, item: int, party_index: int, forget_slot: int
+) -> Dictionary:
+	if world == null or save == null or world.data == null:
+		return _failure(&"missing_save", {})
+	if world.state == null or world.state.item_quantity(item) <= 0:
+		return _failure(&"insufficient_item_quantity", {"item": item})
+	var move: int = Gen2WorldTMHM.move_for_item(world.data, item)
+	if move <= 0:
+		return _failure(&"not_a_tm_hm", {"item": item})
+	if party_index < 0 or party_index >= save.party.size():
+		return _failure(&"invalid_party_index", {"party_index": party_index})
+	var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
+	if mon == null:
+		return _failure(&"invalid_party_index", {"party_index": party_index})
+	# ChooseMonToLearnTMHM refuses an egg with SFX_WRONG and reopens the list, so
+	# an egg never reaches TeachTMHM at all.
+	if mon.is_egg:
+		return _failure(&"cannot_teach_egg", {"party_index": party_index})
+	if not Gen2WorldTMHM.can_learn(world.data, mon.species, move):
+		return _failure(&"not_compatible", {"species": mon.species, "move": move})
+	if Gen2WorldTMHM.knows_move(mon.moves, move):
+		return _failure(&"already_knows_move", {"move": move})
+	var slot: int = Gen2WorldTMHM.first_empty_slot(mon.moves)
+	var forgot: int = 0
+	if slot < 0:
+		# ForgetMove's own refusals, answering before the candidate save is built
+		# the way every refusal above them does.
+		if forget_slot < 0:
+			return _failure(&"moveset_full", {
+				"party_index": party_index, "move": move, "moves": mon.moves.duplicate(),
+			})
+		if forget_slot >= mon.moves.size():
+			return _failure(&"invalid_forget_slot", {"forget_slot": forget_slot})
+		forgot = int(mon.moves[forget_slot])
+		if Gen2MoveForget.is_hm_move(forgot):
+			return _failure(&"cannot_forget_hm", {"forget_slot": forget_slot, "forgot": forgot})
+		slot = forget_slot
+	return {"ok": true, "move": move, "slot": slot, "forgot": forgot}
 
 
 ## `LearnMove` on its own, without the TM/HM that usually reaches it: what an

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -810,7 +810,8 @@ func _draw_row_entries(
 			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS)) - camera_pixels \
 			+ SPRITE_LIFT
 		var texture: Texture2D = _actor_texture(
-			object.sprite, object.palette, object.facing, object.frame, object.big_object_shape()
+			object.sprite, object.palette, object.drawn_facing(), object.frame,
+			object.big_object_shape()
 		)
 		# The same sprite offset the player's hop takes, so a `jump_step` in a
 		# movement stream arcs rather than sliding.
@@ -834,7 +835,7 @@ func _draw_player(background: Vector2) -> Vector2:
 	## the hop leaves behind stay on the ground.
 	var jump: Vector2 = Vector2(0, _world.player_jump_offset())
 	var player_texture: Texture2D = _actor_texture(
-		_world.player_sprite(), _world.player_palette(), _world.player_facing,
+		_world.player_sprite(), _world.player_palette(), _world.player_drawn_facing(),
 		_world.player_walk_frame()
 	)
 	if player_texture != null:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3299,18 +3299,39 @@ func preview_field_move_use() -> void:
 	_preview_field_move_use(Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE)
 
 
-## The same pair for Surf, which needs the scene opened beside water and facing
-## it; Cut's matching requirement is a cuttable tile.
+## The same pair for Surf, which needs the scene opened beside water.
 func preview_surf() -> void:
+	_face_surfable_water()
 	_preview_field_move(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
 
 
 func preview_surf_use() -> void:
+	_face_surfable_water()
 	_preview_field_move_use(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
 
 
-## And for Whirlpool, facing a COLL_WHIRLPOOL cell: Dragon's Den B1F, Route 41
-## and Route 27 are the only maps that carry one.
+## `.TrySurf` reads the faced tile, so facing anywhere else photographs a refusal.
+func _face_surfable_water() -> void:
+	if _world == null:
+		return
+	var standing: int = _world.tile_permissions_at(_world.player_cell)
+	for facing: int in [
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_UP,
+		Gen2WorldSprite.FACING_LEFT, Gen2WorldSprite.FACING_RIGHT,
+	]:
+		_world.player_facing = facing
+		var target: Vector2i = _world.facing_cell()
+		if _world.collision_permission_at(target) != Gen2WorldCollision.WATER_TILE:
+			continue
+		var face: int = Gen2WorldCollision.face_mask_for_direction(
+			_world.facing_direction()
+		)
+		if face == 0 or (standing & face) == 0:
+			return
+
+
+## And for Whirlpool, facing a COLL_WHIRLPOOL cell: Dragon's Den B1F, Route 41 and
+## Route 27 are the only maps that carry one.
 func preview_whirlpool() -> void:
 	_preview_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER)
 
@@ -3337,17 +3358,23 @@ func preview_strength_use() -> void:
 ## And for Waterfall, in the water at a fall's foot; the facing is the driver's,
 ## below. The climb is paced, so the frames after the second call are the climb.
 func preview_waterfall() -> void:
-	_preview_field_move(
-		Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING,
-		Gen2WorldSprite.FACING_UP
-	)
+	_stage_waterfall_world()
+	_preview_field_move(Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING)
 
 
 func preview_waterfall_use() -> void:
-	_preview_field_move_use(
-		Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING,
-		Gen2WorldSprite.FACING_UP
-	)
+	_stage_waterfall_world()
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING)
+
+
+## The world a climber is in: `CheckMapCanWaterfall` passes only FACE_UP, and a
+## fall's foot is water, where `.CheckSurfing` puts them on the surf sprite.
+func _stage_waterfall_world() -> void:
+	if _world == null:
+		return
+	_world.player_facing = Gen2WorldSprite.FACING_UP
+	_world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	_world.player_sprite_number = Gen2WorldSprite.SPRITE_SURF
 
 
 ## And for Flash, which checks no tile and is what makes a dark cave
@@ -3360,18 +3387,16 @@ func preview_flash_use() -> void:
 	_preview_field_move_use(Gen2WorldFieldMove.MOVE_FLASH, Gen2WorldFieldMove.BADGE_ZEPHYR)
 
 
-func _preview_field_move_use(move: int, badge: int, facing: int = -1) -> void:
+func _preview_field_move_use(move: int, badge: int) -> void:
 	if _field_move_text:
 		_acknowledge_field_move_text()
 		return
-	_preview_field_move(move, badge, facing)
+	_preview_field_move(move, badge)
 	if _party_host != null:
 		_party_host.handle_button(Gen2Button.A)
 
 
-## [param facing] is for the one move that refuses on it: only FACE_UP passes
-## `CheckMapCanWaterfall`. The other five read no player state.
-func _preview_field_move(move: int, badge: int, facing: int = -1) -> void:
+func _preview_field_move(move: int, badge: int) -> void:
 	if _world == null or _data == null:
 		return
 	var save: Gen2SaveData = _embedded_party_save()
@@ -3387,8 +3412,6 @@ func _preview_field_move(move: int, badge: int, facing: int = -1) -> void:
 	## the next catch, purchase or party change reported nothing but failure.
 	teacher.pp[0] = int(_data.move(move).get("pp", 0))
 	_injected_save = save
-	if facing >= 0:
-		_world.player_facing = facing
 	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
 		badge, Gen2WorldState.is_crystal_profile(_data)
 	))

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2919,6 +2919,12 @@ func player_height_offset_pixels() -> float:
 	return _world.player_height_offset_pixels() if _world != null else 0.0
 
 
+## The world this screen is driving, null before one is open: a seam rather than
+## the field behind it.
+func world() -> Gen2WorldAPI:
+	return _world
+
+
 func world_snapshot() -> Dictionary:
 	return {
 		"map": _world.map_id() if _world != null else Vector2i(-1, -1),
@@ -3290,63 +3296,82 @@ func preview_field_move() -> void:
 ## field-move entry and shows its message, the second acknowledges it and
 ## commits.
 func preview_field_move_use() -> void:
-	if _field_move_text:
-		_acknowledge_field_move_text()
-		return
-	preview_field_move()
-	if _party_host != null:
-		_party_host.handle_button(Gen2Button.A)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE)
 
 
-## The same pair for Surf. The scene must be opened on a map where the player
-## starts beside water and facing it; the Cut preview has the matching
-## requirement of a cuttable tile.
+## The same pair for Surf, which needs the scene opened beside water and facing
+## it; Cut's matching requirement is a cuttable tile.
 func preview_surf() -> void:
 	_preview_field_move(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
 
 
 func preview_surf_use() -> void:
-	if _field_move_text:
-		_acknowledge_field_move_text()
-		return
-	preview_surf()
-	if _party_host != null:
-		_party_host.handle_button(Gen2Button.A)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
 
 
-## And for Whirlpool, which needs the scene opened facing a COLL_WHIRLPOOL cell:
-## Dragon's Den B1F, Route 41 or Route 27 are the only maps that carry one.
+## And for Whirlpool, facing a COLL_WHIRLPOOL cell: Dragon's Den B1F, Route 41
+## and Route 27 are the only maps that carry one.
 func preview_whirlpool() -> void:
 	_preview_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER)
 
 
 func preview_whirlpool_use() -> void:
-	if _field_move_text:
-		_acknowledge_field_move_text()
-		return
-	preview_whirlpool()
-	if _party_host != null:
-		_party_host.handle_button(Gen2Button.A)
+	_preview_field_move_use(
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER
+	)
 
 
-## And for Strength, which unlike the other three needs nothing in front of the
-## player: .TryStrength checks the badge and stops. To watch a boulder actually
-## move, open the scene on a map that has one and press a direction into it after
-## the second call; Cianwood Gym (22/5) and Ice Path B1F are the reachable ones.
+## And for Strength, which needs nothing in front of the player: .TryStrength
+## checks the badge and stops. To watch a boulder move, press a direction into one
+## after the second call; Cianwood Gym (22/5) and Ice Path B1F carry them.
 func preview_strength() -> void:
 	_preview_field_move(Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.BADGE_PLAIN)
 
 
 func preview_strength_use() -> void:
+	_preview_field_move_use(
+		Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.BADGE_PLAIN
+	)
+
+
+## And for Waterfall, in the water at a fall's foot; the facing is the driver's,
+## below. The climb is paced, so the frames after the second call are the climb.
+func preview_waterfall() -> void:
+	_preview_field_move(
+		Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING,
+		Gen2WorldSprite.FACING_UP
+	)
+
+
+func preview_waterfall_use() -> void:
+	_preview_field_move_use(
+		Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING,
+		Gen2WorldSprite.FACING_UP
+	)
+
+
+## And for Flash, which checks no tile and is what makes a dark cave
+## photographable at all.
+func preview_flash() -> void:
+	_preview_field_move(Gen2WorldFieldMove.MOVE_FLASH, Gen2WorldFieldMove.BADGE_ZEPHYR)
+
+
+func preview_flash_use() -> void:
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_FLASH, Gen2WorldFieldMove.BADGE_ZEPHYR)
+
+
+func _preview_field_move_use(move: int, badge: int, facing: int = -1) -> void:
 	if _field_move_text:
 		_acknowledge_field_move_text()
 		return
-	preview_strength()
+	_preview_field_move(move, badge, facing)
 	if _party_host != null:
 		_party_host.handle_button(Gen2Button.A)
 
 
-func _preview_field_move(move: int, badge: int) -> void:
+## [param facing] is for the one move that refuses on it: only FACE_UP passes
+## `CheckMapCanWaterfall`. The other five read no player state.
+func _preview_field_move(move: int, badge: int, facing: int = -1) -> void:
 	if _world == null or _data == null:
 		return
 	var save: Gen2SaveData = _embedded_party_save()
@@ -3362,6 +3387,8 @@ func _preview_field_move(move: int, badge: int) -> void:
 	## the next catch, purchase or party change reported nothing but failure.
 	teacher.pp[0] = int(_data.move(move).get("pp", 0))
 	_injected_save = save
+	if facing >= 0:
+		_world.player_facing = facing
 	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
 		badge, Gen2WorldState.is_crystal_profile(_data)
 	))
@@ -6284,26 +6311,22 @@ func _surf_refusal(reason: StringName) -> String:
 	return "Can't use that here."
 
 
-## .FailWhirlpool has no text of its own: it calls FieldMoveFailed, so every
-## refusal but the badge falls back to _CantUseItemText. Cut is the exception,
-## not the rule.
+## .FailWhirlpool has no text of its own; see [method _field_move_refused]. Cut
+## is the exception, not the rule.
 func _whirlpool_refusal(reason: StringName) -> String:
 	if reason == &"badge_required":
 		return "Sorry! A new BADGE is required."
 	return "Can't use that here."
 
 
-## .TryWaterfall refuses through FieldMoveFailed, whose text is the generic
-## _CantUseItemText, so only the badge has a line of its own; CheckMapCanWaterfall
-## has no message at all.
+## CheckMapCanWaterfall has no message at all, so only the badge has a line.
 func _waterfall_refusal(reason: StringName) -> String:
 	if reason == &"badge_required":
 		return "Sorry! A new BADGE is required."
 	return "Can't use that here."
 
 
-## .CheckUseFlash has no refusal text of its own for a lit map: it reaches
-## FieldMoveFailed, which is _CantUseItemText. Only the badge has a line.
+## A lit map has no refusal text of its own; only the badge has a line.
 func _flash_refusal(reason: StringName) -> String:
 	if reason == &"badge_required":
 		return "Sorry! A new BADGE is required."
@@ -6535,12 +6558,10 @@ func _acknowledge_field_move_text() -> void:
 	_refresh_labels()
 
 
-## Cut plays SFX_PLACE_PUZZLE_PIECE_DOWN, Whirlpool plays SFX_SURF, Waterfall
-## plays SFX_BUBBLEBEAM and Surf changes the music, so each commit reports its
-## own audio. Strength is the one that plays nothing: Script_UsedStrength has no
-## PlaySFX, because SFX_STRENGTH belongs to the boulder that moves later, not to
-## the flag being set, and neither does Flash. All six redraw anyway, since the
-## party overlay closed over the map.
+## Each commit reports its own audio, below. Strength is the one that plays
+## nothing: Script_UsedStrength has no PlaySFX, because SFX_STRENGTH belongs to
+## the boulder that moves later rather than to the flag being set, and neither
+## does Flash. All redraw anyway, since the party overlay closed over the map.
 func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
 		match StringName(applied.get("kind", &"")):
@@ -7798,14 +7819,8 @@ func _fade_to_map_music() -> void:
 	)
 
 
-## Plays whatever `wMapMusic` currently holds. `Gen2WorldAPI` owns the write,
-## following PlayMapMusic and its SpecialMapMusic surf override on map entry, so
-## the track a tuned radio station left there survives until the player leaves
-## the map. Restarting a piece that is already playing is a presentation
-## difference from the source, which compares before it restarts.
 ## One music track by its own index, for a screen that starts its own: the
-## printer's is the first, and `_play_current_map_music` is what puts the map's
-## back.
+## printer's is the first, and [method _play_current_map_music] puts the map's back.
 func _play_music_track(index: int) -> void:
 	if _audio_player == null or _data == null:
 		return
@@ -7815,6 +7830,11 @@ func _play_music_track(index: int) -> void:
 	_audio_player.play_record(record, &"map_music", _audio_assets())
 
 
+## Plays whatever `wMapMusic` currently holds. `Gen2WorldAPI` owns the write,
+## following PlayMapMusic and its SpecialMapMusic surf override on map entry, so
+## the track a tuned radio station left there survives until the player leaves the
+## map. Restarting a piece already playing is a presentation difference from the
+## source, which compares before it restarts.
 func _play_current_map_music() -> void:
 	if _audio_player == null or _data == null or _world == null or _world.current_map == null:
 		return
@@ -7876,13 +7896,8 @@ func _spend_item_gift_requests() -> void:
 		return
 
 
-## A mod's hidden-item asks, spent on the first world frame nothing else owns.
-## The map's own script runs through the ordinary path, so the box, the fanfare
-## and the pacing are the world screen's exactly as they are for a player walking
-## onto the cell; the mod named a cell and nothing else.
-##
-## Only one is spent per frame, since the first one's script owns the world until
-## its box is pressed past, and the rest wait in the host's queue.
+## A mod's hidden-item asks, spent the same way and on the same gate: the mod
+## named a cell and nothing else, and the map's own script runs it.
 func _spend_hidden_item_requests() -> void:
 	if _world == null or not _world_idle_for_mod_request():
 		return

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -846,11 +846,10 @@ static func scan_references(
 ) -> Dictionary:
 	## Scans only commands understood by this slice. An unknown command stops the
 	## scan because its operand width cannot be inferred safely.
-	var scripts: Array = []
-	var texts: Array = []
-	var movements: Array = []
-	var command_queues: Array = []
-	var elevators: Array = []
+	var out: Dictionary = {
+		"scripts": [], "texts": [], "movements": [],
+		"command_queues": [], "elevators": [],
+	}
 	var at: int = 0
 	var command_count: int = 0
 	while at < data.size() and command_count < MAX_COMMANDS:
@@ -858,61 +857,74 @@ static func scan_references(
 		if not bool(command.get("ok", false)):
 			break
 		var opcode: int = int(command["opcode"])
-		match opcode:
-			SCALL, SJUMP:
-				scripts.append({"bank": bank, "address": int(command["address"])})
-			IFEQUAL, IFNOTEQUAL, IFFALSE, IFTRUE, IFGREATER, IFLESS:
-				scripts.append({"bank": bank, "address": int(command["address"])})
-			FARSCALL, FARSJUMP:
-				scripts.append({"bank": int(command["bank"]), "address": int(command["address"])})
-			WRITETEXT, JUMPTEXTFACEPLAYER:
-				texts.append({"bank": bank, "address": int(command["address"])})
-			GETSTRING:
-				texts.append({"bank": bank, "address": int(command["address"])})
-			JUMPTEXT:
-				if crystal_commands:
-					texts.append({"bank": bank, "address": int(command["address"])})
-			FARWRITETEXT:
-				texts.append({"bank": int(command["bank"]), "address": int(command["address"])})
-			FARJUMPTEXT:
-				if crystal_commands:
-					texts.append({"bank": int(command["bank"]), "address": int(command["address"])})
-				else:
-					texts.append({"bank": bank, "address": int(command["address"])})
-		var source: int = Gen2WorldScript.source_opcode(opcode, crystal_commands)
-		match source:
-			0x68, 0x69:
-				movements.append({"bank": bank, "address": int(command["address"])})
-			0x63:
-				texts.append({"bank": bank, "address": int(command["win_address"])})
-				texts.append({"bank": bank, "address": int(command["loss_address"])})
-			0x8C, 0x8E:
-				scripts.append({"bank": bank, "address": int(command["address"])})
-			0x97:
-				## phonecall passes a caller-name text pointer to PhoneCall. It is
-				## not a script pointer and must be collected as text data.
-				texts.append({"bank": bank, "address": int(command["address"])})
-			0x7C:
-				## writecmdqueue points at a cmdqueue entry, which is data rather
-				## than script, so it is collected as its own kind.
-				command_queues.append({"bank": bank, "address": int(command["address"])})
-			0x94:
-				## elevator points at an `elevfloor` list, which is data rather
-				## than script, and `Elevator.LoadPointer` reads it out of the
-				## map scripts bank the command itself sits in.
-				elevators.append({"bank": bank, "address": int(command["address"])})
+		_scan_opcode(out, command, opcode, bank, crystal_commands)
+		_scan_source_opcode(
+			out, command, Gen2WorldScript.source_opcode(opcode, crystal_commands), bank
+		)
 		at += int(command["width"])
 		command_count += 1
 		if not continues_after(opcode, crystal_commands):
 			break
-	return {
-		"scripts": scripts, "texts": texts, "movements": movements,
-		"command_queues": command_queues, "elevators": elevators,
-	}
+	return out
 
 
-## Decodes the bounded text-command slice collected by the importer. Map text
-## begins with text_start and ends with the source done command $57. The generic
+static func _scan_opcode(
+	out: Dictionary, command: Dictionary, opcode: int, bank: int, crystal_commands: bool
+) -> void:
+	var scripts: Array = out["scripts"]
+	var texts: Array = out["texts"]
+	match opcode:
+		SCALL, SJUMP:
+			scripts.append({"bank": bank, "address": int(command["address"])})
+		IFEQUAL, IFNOTEQUAL, IFFALSE, IFTRUE, IFGREATER, IFLESS:
+			scripts.append({"bank": bank, "address": int(command["address"])})
+		FARSCALL, FARSJUMP:
+			scripts.append({"bank": int(command["bank"]), "address": int(command["address"])})
+		WRITETEXT, JUMPTEXTFACEPLAYER:
+			texts.append({"bank": bank, "address": int(command["address"])})
+		GETSTRING:
+			texts.append({"bank": bank, "address": int(command["address"])})
+		JUMPTEXT:
+			if crystal_commands:
+				texts.append({"bank": bank, "address": int(command["address"])})
+		FARWRITETEXT:
+			texts.append({"bank": int(command["bank"]), "address": int(command["address"])})
+		FARJUMPTEXT:
+			if crystal_commands:
+				texts.append({"bank": int(command["bank"]), "address": int(command["address"])})
+			else:
+				texts.append({"bank": bank, "address": int(command["address"])})
+
+
+static func _scan_source_opcode(
+	out: Dictionary, command: Dictionary, source: int, bank: int
+) -> void:
+	match source:
+		0x68, 0x69:
+			(out["movements"] as Array).append({"bank": bank, "address": int(command["address"])})
+		0x63:
+			var texts: Array = out["texts"]
+			texts.append({"bank": bank, "address": int(command["win_address"])})
+			texts.append({"bank": bank, "address": int(command["loss_address"])})
+		0x8C, 0x8E:
+			(out["scripts"] as Array).append({"bank": bank, "address": int(command["address"])})
+		0x97:
+			## phonecall passes a caller-name text pointer to PhoneCall. It is
+			## not a script pointer and must be collected as text data.
+			(out["texts"] as Array).append({"bank": bank, "address": int(command["address"])})
+		0x7C:
+			## writecmdqueue points at a cmdqueue entry, which is data rather
+			## than script, so it is collected as its own kind.
+			(out["command_queues"] as Array).append({
+				"bank": bank, "address": int(command["address"]),
+			})
+		0x94:
+			## elevator points at an `elevfloor` list, which is data rather than
+			## script, and `Elevator.LoadPointer` reads it out of the map scripts
+			## bank the command itself sits in.
+			(out["elevators"] as Array).append({"bank": bank, "address": int(command["address"])})
+
+
 ## Decodes one `cmdqueue` entry: `dbw type, address` and two filler bytes
 ## (macros/scripts/maps.asm). Answers the type and the data pointer only; what
 ## the pointer means is the type's business.

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37883
+const MAX_COMMENT_LINES: int = 37882
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,33 +18,12 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37884
+const MAX_COMMENT_LINES: int = 37883
 
-## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Delete
-## a line when you fix one. The test fails on a line that no longer names a
-## function over the ceiling, so this cannot rot and cannot grow.
-const OVER_COMPLEXITY: Array[String] = [
-	"game/data/world_catalog.gd:_attribute_maps",
-	"game/import/rom_importer.gd:_read_one_trainer",
-	"game/import/rom_importer.gd:_verify_gs_title",
-	"game/import/rom_importer.gd:_verify_presents_sprites",
-	"game/import/rom_importer.gd:verify_mail",
-	"game/import/world_importer.gd:_read_events",
-	"game/mods/mod_host.gd:register_menu_entry",
-	"game/save/party_screen.gd:_confirm",
-	"game/save/save_battle_adapter.gd:from_battle_party",
-	"game/world/battle_tower.gd:action",
-	"game/world/slot_machine.gd:_reel_action",
-	"game/world/world_bag_host.gd:give_to_party",
-	"game/world/world_decoration.gd:apply",
-	"game/world/world_mart_host.gd:purchase",
-	"game/world/world_party_host.gd:teach_tm_hm",
-	"game/world/world_script.gd:scan_references",
-	"tools/checks/radio.gd:_verify_shows",
-	"tools/preview_town_map.gd:_initialize",
-	"tools/record_clip.gd:_process",
-	"tools/trace_world_script.gd:_run",
-]
+## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
+## and it stays empty: a function over the ceiling fails the test rather than
+## joining a list.
+const OVER_COMPLEXITY: Array[String] = []
 
 
 func test_no_function_is_over_the_complexity_ceiling() -> void:

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1209,6 +1209,31 @@ func test_complete_waterfall_paces_the_climb_one_cell_at_a_time() -> void:
 	assert_eq(world.player_cell, WATERFALL_LANDING_CELL)
 
 
+## `turn_waterfall` reaches `TurningStep`, which sets OBJECT_ACTION_SPIN, so the
+## climber spins counterclockwise all the way up: `CounterclockwiseSpinAction`
+## steps DOWN, RIGHT, UP, LEFT one quarter-turn every four passes, and the frame
+## runs on across the whole climb rather than restarting each cell.
+func test_the_waterfall_climb_spins_the_player_counterclockwise() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+	var applied: Dictionary = world.complete_waterfall()
+	var wanted: Array[int] = [
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT,
+		Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_LEFT,
+	]
+	var seen: Array[int] = [world.player_drawn_facing()]
+	for spent: int in int(applied["passes"]):
+		world.advance_player_step_pass()
+		if world.player_step_in_progress():
+			seen.append(world.player_drawn_facing())
+	for index: int in seen.size():
+		assert_eq(seen[index], wanted[(index / 4) % 4], "pass %d" % index)
+	## The logical facing never moved, so the climb still ends facing up, and the
+	## drawing goes back to it the moment the run drains.
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
+	assert_eq(world.player_drawn_facing(), Gen2WorldSprite.FACING_UP)
+
+
 ## The landing re-derives the player state the way a warp does, so a climb that
 ## ends on land puts the surfer back on foot. Paced, that happens when the run
 ## drains: the climber is still surfing while the fall is being climbed.

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1188,14 +1188,39 @@ func test_complete_waterfall_climbs_the_whole_column_in_one_command() -> void:
 	assert_true(world.pending_waterfall().is_empty())
 
 
+## The cell commits at once and the climb is drawn a cell at a time, so a renderer
+## carries the player up the fall's face instead of teleporting them.
+func test_complete_waterfall_paces_the_climb_one_cell_at_a_time() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+	var applied: Dictionary = world.complete_waterfall()
+	var steps: int = int(applied["steps"])
+	assert_eq(int(applied["passes"]), steps * Gen2WorldAPI.STEP_PASSES_FAST)
+	assert_true(world.player_step_in_progress())
+	assert_eq(world.player_step_kind(), &"turn_waterfall")
+	## One cell behind per step still to be drawn, counting down to zero.
+	assert_eq(world.player_step_offset_cells(), Vector2(0, steps))
+	for _frame: int in int(applied["passes"]):
+		assert_true(world.player_step_in_progress(), "the climb ended early")
+		world.advance_player_step_pass()
+	assert_false(world.player_step_in_progress())
+	assert_eq(world.player_step_offset_cells(), Vector2.ZERO)
+	assert_eq(world.player_step_kind(), &"")
+	assert_eq(world.player_cell, WATERFALL_LANDING_CELL)
+
+
 ## The landing re-derives the player state the way a warp does, so a climb that
-## ends on land puts the surfer back on foot.
+## ends on land puts the surfer back on foot. Paced, that happens when the run
+## drains: the climber is still surfing while the fall is being climbed.
 func test_complete_waterfall_restores_walking_when_it_lands_ashore() -> void:
 	var world: Gen2WorldAPI = _waterfall_world()
 	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF)
 	assert_true(bool(world.waterfall_request().get("ok", false)))
 	var applied: Dictionary = world.complete_waterfall()
 	assert_eq(applied["movement_mode"], Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_SURF, "the climb is still on water")
+	for _frame: int in int(applied["passes"]):
+		world.advance_player_step_pass()
 	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
 	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
 

--- a/tools/checks/radio.gd
+++ b/tools/checks/radio.gd
@@ -166,28 +166,7 @@ func _verify_shows(_data: GameData, game_id: StringName, crystal: bool) -> void:
 				"kanto_badges": 0xFF if seed_index % 3 == 0 else 0,
 				"lucky_number": 12345,
 			}, random)
-			var last: String = ""
-			for frame: int in SHOW_FRAMES:
-				if show.finished():
-					break
-				# Midnight arrives halfway through, which is the only way
-				# Buena's ten shutdown lines are ever reached.
-				if frame == SHOW_FRAMES / 2:
-					show.set_hour(0 if hour >= Gen2RadioShow.NITE_HOUR else 20)
-				visited[show.segment()] = true
-				show.advance_frame()
-				if not show.ran_segment.is_empty():
-					visited[show.ran_segment] = true
-				var bottom: String = show.lines()[1]
-				if bottom == last:
-					continue
-				last = bottom
-				lines_seen += 1
-				if bottom.strip_edges().is_empty():
-					continue
-				if bottom.contains("{") \
-					or (bottom.contains("  ") and not bottom.begins_with(" ")):
-					blank.append("%s ch%d: \"%s\"" % [game_id, channel, bottom])
+			lines_seen += _walk_show(show, hour, game_id, channel, visited, blank)
 	_r.check(
 		blank.is_empty(),
 		"%s: a radio line has an unfilled buffer in it: %s" % [
@@ -208,6 +187,40 @@ func _verify_shows(_data: GameData, game_id: StringName, crystal: bool) -> void:
 	print("%s radio shows: %d of %d segments run, %d lines printed." % [
 		game_id, visited.size() - 1, Gen2RadioShow.SEGMENTS.size() - 1, lines_seen,
 	])
+
+
+func _walk_show(
+	show: Gen2RadioShow,
+	hour: int,
+	game_id: StringName,
+	channel: int,
+	visited: Dictionary,
+	blank: Array[String],
+) -> int:
+	var last: String = ""
+	var lines_seen: int = 0
+	for frame: int in SHOW_FRAMES:
+		if show.finished():
+			break
+		# Midnight arrives halfway through, which is the only way
+		# Buena's ten shutdown lines are ever reached.
+		if frame == SHOW_FRAMES / 2:
+			show.set_hour(0 if hour >= Gen2RadioShow.NITE_HOUR else 20)
+		visited[show.segment()] = true
+		show.advance_frame()
+		if not show.ran_segment.is_empty():
+			visited[show.ran_segment] = true
+		var bottom: String = show.lines()[1]
+		if bottom == last:
+			continue
+		last = bottom
+		lines_seen += 1
+		if bottom.strip_edges().is_empty():
+			continue
+		if bottom.contains("{") \
+			or (bottom.contains("  ") and not bottom.begins_with(" ")):
+			blank.append("%s ch%d: \"%s\"" % [game_id, channel, bottom])
+	return lines_seen
 
 
 ## Every station's track has to be a real imported music record, or tuning to it

--- a/tools/checks/waterfall.gd
+++ b/tools/checks/waterfall.gd
@@ -9,6 +9,8 @@ var _r: RefCounted = null
 
 
 ## Pinned so a cache change is loud. A column is a waterfall cell with none below it.
+## An edge column is one drawn up to the map's own top row, where the climb stops
+## on the last row rather than on the first cell that is not a waterfall.
 const EXPECTED_CENSUS: Dictionary = {
 	# game id: [waterfall cells, columns, edge columns, maps carrying one]
 	&"gold": [164, 34, 4, 4],
@@ -58,7 +60,6 @@ func _sweep_columns(game_id: StringName, data: GameData, crystal: bool) -> void:
 			var climbed: Dictionary = _climb(data, crystal, map, foot)
 			if bool(climbed.get("edge", false)):
 				edge_columns += 1
-				continue
 			if not bool(climbed.get("ok", false)):
 				refused.append("%d/%d %s: %s" % [
 					map.group, map.number, foot, climbed.get("reason", "unknown"),
@@ -83,16 +84,15 @@ func _sweep_columns(game_id: StringName, data: GameData, crystal: bool) -> void:
 			game_id, [cells, columns, edge_columns, maps], expected,
 		]
 	)
-	print("%s waterfall: %d cells, %d columns over %d maps, %d climbed, %d run off the map." % [
-		game_id, cells, columns, maps, columns - edge_columns, edge_columns,
+	print("%s waterfall: %d cells, %d columns over %d maps, all climbed, %d of them to the map's top row." % [
+		game_id, cells, columns, maps, edge_columns,
 	])
 
 
-## One column, from the water below its foot. `edge` marks one whose top is the
-## map's own top row: the cartridge would read the border block there, never a
-## waterfall (asserted below), and stop with the player in the connection padding.
-## Nothing outside the map is a cell here, so the climb refuses and the player
-## stays. Four columns each cartridge.
+## One column, from the water below its foot. `edge` marks one drawn up to the
+## map's own top row, where the climb ends on that row: the cartridge reads the
+## border block above it, never a waterfall (asserted below), and stops one row
+## further into padding this port has no cell for.
 func _climb(
 	data: GameData, crystal: bool, map: Gen2WorldMap, foot: Vector2i
 ) -> Dictionary:
@@ -108,15 +108,17 @@ func _climb(
 	if world.player_cell != stand:
 		return {"ok": false, "reason": "staging moved the player"}
 	var applied: Dictionary = world.complete_waterfall()
-	if StringName(applied.get("reason", &"")) == &"climb_left_the_map":
-		return {"ok": true, "edge": true}
 	if not bool(applied.get("ok", false)):
 		return {"ok": false, "reason": String(applied.get("reason", "unknown"))}
-	return _verify_pacing(world, applied, stand)
+	var edge: bool = int(applied["cell"].y) == 0 \
+		and Gen2WorldFieldMove.waterfall_tile(world.collision_code_at(applied["cell"]))
+	var paced: Dictionary = _verify_pacing(world, applied, stand, edge)
+	paced["edge"] = edge
+	return paced
 
 
 func _verify_pacing(
-	world: Gen2WorldAPI, applied: Dictionary, stand: Vector2i
+	world: Gen2WorldAPI, applied: Dictionary, stand: Vector2i, edge: bool = false
 ) -> Dictionary:
 	var steps: int = int(applied["steps"])
 	var landing: Vector2i = applied["cell"]
@@ -124,7 +126,7 @@ func _verify_pacing(
 		return {"ok": false, "reason": "climbed %d cells" % steps}
 	if landing != stand + Vector2i.UP * steps:
 		return {"ok": false, "reason": "landed at %s, not %d cells up" % [landing, steps]}
-	if Gen2WorldFieldMove.waterfall_tile(world.collision_code_at(landing)):
+	if not edge and Gen2WorldFieldMove.waterfall_tile(world.collision_code_at(landing)):
 		return {"ok": false, "reason": "landed back on the fall"}
 	if world.player_cell != landing:
 		return {"ok": false, "reason": "the cell did not commit"}

--- a/tools/checks/waterfall.gd
+++ b/tools/checks/waterfall.gd
@@ -1,0 +1,257 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies Waterfall against freshly imported real caches, for both command
+## profiles. Expected values come from WaterfallFunction, CheckWaterfallTile and
+## Script_UsedWaterfall, byte identical between the pins. The real-cartridge half
+## of tests/unit/test_world_field_move.gd: it climbs every column shipped.
+
+
+## Pinned so a cache change is loud. A column is a waterfall cell with none below it.
+const EXPECTED_CENSUS: Dictionary = {
+	# game id: [waterfall cells, columns, edge columns, maps carrying one]
+	&"gold": [164, 34, 4, 4],
+	&"silver": [164, 34, 4, 4],
+	&"crystal": [164, 34, 4, 4],
+}
+
+## constants/map_constants.asm, DUNGEONS: Crystal's extra maps push it eight later.
+const WHIRL_ISLANDS_GROUP: int = 3
+const WHIRL_ISLANDS_B2F_CRYSTAL: int = 72
+const WHIRL_ISLANDS_B2F_GOLD_SILVER: int = 64
+## The fall's foot and the ledge it lands on. Twelve cells, thirteen steps:
+## `.CheckContinueWaterfall` spends one more on the cell that ends the column.
+const WHIRL_FOOT := Vector2i(12, 25)
+const WHIRL_COLUMN: int = 12
+const WHIRL_LANDING := Vector2i(12, 13)
+
+const MAX_COLUMN: int = 12
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+		_verify_whirl_islands(game_id, data, crystal)
+		_sweep_columns(game_id, data, crystal)
+
+
+func _sweep_columns(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var cells: int = 0
+	var columns: int = 0
+	var edge_columns: int = 0
+	var maps: int = 0
+	var refused: Array[String] = []
+	for map: Gen2WorldMap in data.world_maps():
+		var world: Gen2WorldAPI = _climber(data, crystal, map.group, map.number, Vector2i.ZERO)
+		if world == null:
+			continue
+		var here: int = 0
+		for foot: Vector2i in _column_feet(world):
+			here += 1
+			columns += 1
+			var climbed: Dictionary = _climb(data, crystal, map, foot)
+			if bool(climbed.get("edge", false)):
+				edge_columns += 1
+				continue
+			if not bool(climbed.get("ok", false)):
+				refused.append("%d/%d %s: %s" % [
+					map.group, map.number, foot, climbed.get("reason", "unknown"),
+				])
+		cells += _waterfall_cells(world)
+		if here > 0:
+			maps += 1
+			if _border_is_waterfall(world, map):
+				refused.append("%d/%d: its border block is a waterfall" % [
+					map.group, map.number,
+				])
+	_r.check(
+		refused.is_empty(),
+		"%s: a real waterfall column did not climb: %s" % [
+			game_id, ", ".join(refused.slice(0, 3)),
+		]
+	)
+	var expected: Array = EXPECTED_CENSUS[game_id]
+	_r.check(
+		[cells, columns, edge_columns, maps] == expected,
+		"%s: waterfall census is %s, expected %s." % [
+			game_id, [cells, columns, edge_columns, maps], expected,
+		]
+	)
+	print("%s waterfall: %d cells, %d columns over %d maps, %d climbed, %d run off the map." % [
+		game_id, cells, columns, maps, columns - edge_columns, edge_columns,
+	])
+
+
+## One column, from the water below its foot. `edge` marks one whose top is the
+## map's own top row: the cartridge would read the border block there, never a
+## waterfall (asserted below), and stop with the player in the connection padding.
+## Nothing outside the map is a cell here, so the climb refuses and the player
+## stays. Four columns each cartridge.
+func _climb(
+	data: GameData, crystal: bool, map: Gen2WorldMap, foot: Vector2i
+) -> Dictionary:
+	var stand: Vector2i = foot + Vector2i.DOWN
+	var world: Gen2WorldAPI = _climber(data, crystal, map.group, map.number, stand)
+	if world == null:
+		return {"ok": false, "reason": "the map did not open"}
+	if world.player_cell != stand:
+		return {"ok": false, "reason": "the cell below the fall is off the map"}
+	var staged: Dictionary = world.waterfall_request()
+	if not bool(staged.get("ok", false)):
+		return {"ok": false, "reason": String(staged.get("reason", "unknown"))}
+	if world.player_cell != stand:
+		return {"ok": false, "reason": "staging moved the player"}
+	var applied: Dictionary = world.complete_waterfall()
+	if StringName(applied.get("reason", &"")) == &"climb_left_the_map":
+		return {"ok": true, "edge": true}
+	if not bool(applied.get("ok", false)):
+		return {"ok": false, "reason": String(applied.get("reason", "unknown"))}
+	return _verify_pacing(world, applied, stand)
+
+
+func _verify_pacing(
+	world: Gen2WorldAPI, applied: Dictionary, stand: Vector2i
+) -> Dictionary:
+	var steps: int = int(applied["steps"])
+	var landing: Vector2i = applied["cell"]
+	if steps < 2 or steps > MAX_COLUMN + 1:
+		return {"ok": false, "reason": "climbed %d cells" % steps}
+	if landing != stand + Vector2i.UP * steps:
+		return {"ok": false, "reason": "landed at %s, not %d cells up" % [landing, steps]}
+	if Gen2WorldFieldMove.waterfall_tile(world.collision_code_at(landing)):
+		return {"ok": false, "reason": "landed back on the fall"}
+	if world.player_cell != landing:
+		return {"ok": false, "reason": "the cell did not commit"}
+	if not world.player_step_in_progress():
+		return {"ok": false, "reason": "the climb spent no frames"}
+	if world.player_step_kind() != &"turn_waterfall":
+		return {"ok": false, "reason": "drawn as %s" % world.player_step_kind()}
+	if world.player_step_offset_cells() != Vector2(0, steps):
+		return {"ok": false, "reason": "opened %s behind" % world.player_step_offset_cells()}
+	var passes: int = int(applied["passes"])
+	if passes != steps * Gen2WorldAPI.STEP_PASSES_FAST:
+		return {"ok": false, "reason": "%d passes for %d steps" % [passes, steps]}
+	for _pass: int in passes:
+		if not world.player_step_in_progress():
+			return {"ok": false, "reason": "the climb ended early"}
+		world.advance_player_step_pass()
+	if world.player_step_in_progress():
+		return {"ok": false, "reason": "the climb outlasted its own passes"}
+	if world.movement_mode != StringName(applied["movement_mode"]):
+		return {"ok": false, "reason": "landed in %s, not %s" % [
+			world.movement_mode, applied["movement_mode"],
+		]}
+	return {"ok": true}
+
+
+func _climber(
+	data: GameData, crystal: bool, group: int, number: int, cell: Vector2i
+) -> Gen2WorldAPI:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_RISING, crystal))
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, cell, state)
+	if world == null:
+		return null
+	world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	_r.field_move_party(world)
+	return world
+
+
+func _column_feet(world: Gen2WorldAPI) -> Array[Vector2i]:
+	var out: Array[Vector2i] = []
+	var size: Vector2i = world.map_size_cells()
+	for y: int in size.y:
+		for x: int in size.x:
+			var cell := Vector2i(x, y)
+			if not Gen2WorldFieldMove.waterfall_tile(world.collision_code_at(cell)):
+				continue
+			var below := Vector2i(x, y + 1)
+			if below.y < size.y and Gen2WorldFieldMove.waterfall_tile(
+				world.collision_code_at(below)
+			):
+				continue
+			out.append(cell)
+	return out
+
+
+func _border_is_waterfall(world: Gen2WorldAPI, map: Gen2WorldMap) -> bool:
+	for quadrant_y: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
+		for quadrant_x: int in RomLayout.MAP_BLOCK_CELL_WIDTH:
+			if Gen2WorldFieldMove.waterfall_tile(world.current_tileset.collision_index(
+				map.border_block, quadrant_x, quadrant_y
+			)):
+				return true
+	return false
+
+
+func _waterfall_cells(world: Gen2WorldAPI) -> int:
+	var found: int = 0
+	var size: Vector2i = world.map_size_cells()
+	for y: int in size.y:
+		for x: int in size.x:
+			if Gen2WorldFieldMove.waterfall_tile(world.collision_code_at(Vector2i(x, y))):
+				found += 1
+	return found
+
+
+## Whirl Islands B2F, the tallest fall either cartridge ships.
+func _verify_whirl_islands(game_id: StringName, data: GameData, crystal: bool) -> void:
+	var number: int = WHIRL_ISLANDS_B2F_CRYSTAL if crystal else WHIRL_ISLANDS_B2F_GOLD_SILVER
+	var world: Gen2WorldAPI = _climber(
+		data, crystal, WHIRL_ISLANDS_GROUP, number, WHIRL_FOOT + Vector2i.DOWN
+	)
+	if not _r.check(
+		world != null,
+		"%s: Whirl Islands B2F map %d/%d is missing." % [game_id, WHIRL_ISLANDS_GROUP, number]
+	):
+		return
+	var column: int = 0
+	for step: int in MAX_COLUMN + 1:
+		if not Gen2WorldFieldMove.waterfall_tile(
+			world.collision_code_at(WHIRL_FOOT + Vector2i.UP * step)
+		):
+			break
+		column += 1
+	_r.check(
+		column == WHIRL_COLUMN,
+		"%s: Whirl Islands' fall is %d cells, expected %d." % [game_id, column, WHIRL_COLUMN]
+	)
+	var staged: Dictionary = world.waterfall_request()
+	if not _r.check(
+		bool(staged.get("ok", false)),
+		"%s: Whirl Islands refused Waterfall: %s." % [game_id, staged.get("reason", "unknown")]
+	):
+		return
+	var applied: Dictionary = world.complete_waterfall()
+	if not _r.check(
+		bool(applied.get("ok", false)),
+		"%s: Whirl Islands' climb failed: %s." % [game_id, applied.get("reason", "unknown")]
+	):
+		return
+	_r.check(
+		applied.get("cell", Vector2i.ZERO) == WHIRL_LANDING
+			and int(applied.get("steps", 0)) == WHIRL_COLUMN + 1,
+		"%s: Whirl Islands' climb answered %s, expected %s in %d steps." % [
+			game_id, JSON.stringify(applied), WHIRL_LANDING, WHIRL_COLUMN + 1,
+		]
+	)
+	_r.check(
+		world.movement_mode == Gen2WorldAPI.MOVEMENT_SURF,
+		"%s: Whirl Islands' climb left the water before it finished." % game_id
+	)
+	var paced: Dictionary = _verify_pacing(world, applied, WHIRL_FOOT + Vector2i.DOWN)
+	_r.check(
+		bool(paced.get("ok", false)),
+		"%s: Whirl Islands' climb is not paced: %s." % [game_id, paced.get("reason", "")]
+	)
+	print("%s waterfall: Whirl Islands B2F %s to %s, %d steps over %d passes." % [
+		game_id, WHIRL_FOOT + Vector2i.DOWN, WHIRL_LANDING,
+		int(applied["steps"]), int(applied["passes"]),
+	])

--- a/tools/checks/waterfall.gd.uid
+++ b/tools/checks/waterfall.gd.uid
@@ -1,0 +1,1 @@
+uid://bho5ds5hv4d1c

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -47,18 +47,9 @@ func _initialize() -> void:
 	var landmark: int = int(args[2]) if args.size() > 2 else Gen2TownMap.JOHTO_LANDMARK
 	var mode: String = args[3] if args.size() > 3 else "town_map"
 	var species: int = int(mode.split(":")[1]) if mode.begins_with("area:") else 0
-	var hall_of_fame: bool = false
-	var steps: Array = []
-	for token: String in (args[4] if args.size() > 4 else "").split(",", false):
-		var key: String = token.strip_edges().to_lower()
-		if key == "hof":
-			hall_of_fame = true
-		elif key.begins_with("f"):
-			steps.append(["frames", maxi(1, int(key.substr(1)))])
-		elif key == "rel":
-			steps.append(["release", Gen2Button.SELECT])
-		elif BUTTONS.has(key):
-			steps.append(["press", int(BUTTONS[key])])
+	var parsed: Dictionary = _parse_presses(args[4] if args.size() > 4 else "")
+	var hall_of_fame: bool = bool(parsed["hall_of_fame"])
+	var steps: Array = parsed["steps"]
 
 	if mode in ["clock", "phone", "radio"]:
 		_capture_card(data, StringName(mode), args[1], steps)
@@ -71,15 +62,7 @@ func _initialize() -> void:
 		push_error("The %s cache holds no region map." % args[0])
 		quit(1)
 		return
-	for step: Array in steps:
-		match String(step[0]):
-			"frames":
-				for _frame: int in int(step[1]):
-					host.advance_frame()
-			"release":
-				host.release_button(int(step[1]))
-			_:
-				host.handle_button(int(step[1]))
+	_drive(host, steps)
 
 	var error: Error = host.render().save_png(args[1])
 	if error != OK:
@@ -100,6 +83,34 @@ func _initialize() -> void:
 			host.map().first_landmark(), host.map().last_landmark(),
 		])
 	quit(0)
+
+
+static func _parse_presses(spec: String) -> Dictionary:
+	var hall_of_fame: bool = false
+	var steps: Array = []
+	for token: String in spec.split(",", false):
+		var key: String = token.strip_edges().to_lower()
+		if key == "hof":
+			hall_of_fame = true
+		elif key.begins_with("f"):
+			steps.append(["frames", maxi(1, int(key.substr(1)))])
+		elif key == "rel":
+			steps.append(["release", Gen2Button.SELECT])
+		elif BUTTONS.has(key):
+			steps.append(["press", int(BUTTONS[key])])
+	return {"steps": steps, "hall_of_fame": hall_of_fame}
+
+
+static func _drive(host: Gen2TownMapScreen, steps: Array) -> void:
+	for step: Array in steps:
+		match String(step[0]):
+			"frames":
+				for _frame: int in int(step[1]):
+					host.advance_frame()
+			"release":
+				host.release_button(int(step[1]))
+			_:
+				host.handle_button(int(step[1]))
 
 
 func _open(

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -8,13 +8,11 @@ extends SceneTree
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png \
 ##       live [kind] [x y] [WxH] [touch] [framed] [zoom=<n>] [view=<mod id>]
 
-## `TrainerCard_JohtoBadgesOAM`'s eight, for the two mod-surface kinds: the only
-## badge art the cartridge has.
 ## Every `live` kind, what its two numbers mean and what it draws. Data rather
-## than a comment, because `live help` prints it. A kind may also be any `preview_*` driver on the world screen without
-## that prefix (`field_move`, `start_menu`, `capture`, `catch_nickname`,
-## `move_forget`), which is driven twice when its name ends in `_use`, or one of
-## [constant FIELD_ITEMS]' names, which is the pack's USE on that item.
+## than a comment, because `live help` prints it. A kind may also be any
+## `preview_*` driver on the world screen without that prefix, which is driven
+## twice when its name ends in `_use`, or one of [constant FIELD_ITEMS]' names,
+## which is the pack's USE on that item.
 const KIND_HELP: Dictionary = {
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
 	&"battle": "cell: the wild fight preview_battle_request starts, settled past its transition",
@@ -59,6 +57,8 @@ const KIND_HELP: Dictionary = {
 }
 
 
+## `TrainerCard_JohtoBadgesOAM`'s eight, for the two mod-surface kinds: the only
+## badge art the cartridge has.
 const BADGE_NAMES: Array[String] = [
 	"ZEPHYRBADGE", "HIVEBADGE", "PLAINBADGE", "FOGBADGE",
 	"MINERALBADGE", "STORMBADGE", "GLACIERBADGE", "RISINGBADGE",
@@ -97,10 +97,6 @@ const DAY_CARE_ROLES: Array[StringName] = [
 ## `UpdateJumpPosition`'s highest `.y_offsets` entry, which is where the `ledge`
 ## kind photographs the hop.
 const LEDGE_ARC_TOP: float = 12.0
-## Hardware frames spent after the sprites are staged. Two puts the grass rustle
-## on its first facing and the boulder dust on its second, so every one of them
-## is up and none is on the frame it was spawned. Cut needs more: its tree stands
-## for three frames before it splits, and its leaves open on top of each other.
 ## The `kind`s that are a pack USE rather than a staged sprite, and the item
 ## each one uses. Every one of them is driven through the pack's own key item
 ## pocket, so the picture is the screen's answer and not a staged state.
@@ -135,8 +131,13 @@ const MART_PRESSES: int = 1
 ## owes nothing before the next one lands: nothing shortens a printing text.
 const TEXT_SETTLE_FRAMES: int = 20
 
+## Hardware frames spent after the sprites are staged. Two puts the grass rustle on
+## its first facing and the boulder dust on its second, so every one is up and none
+## is on the frame it was spawned. Two kinds are a moment inside an animation
+## instead: Cut's tree stands three frames before it splits, and the waterfall
+## climb runs four passes a cell, so 26 lands a few cells up.
 const STAGED_FRAMES: int = 2
-const STAGED_FRAMES_CUT: int = 12
+const STAGED_FRAMES_BY_KIND: Dictionary = {&"cut": 12, &"waterfall_use": 26}
 
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
@@ -401,7 +402,7 @@ func _process(_delta: float) -> bool:
 	if _frames == 2:
 		_stage_kind()
 		if not _bare and _kind not in SELF_DRIVEN_KINDS:
-			for _frame: int in (STAGED_FRAMES_CUT if _kind == &"cut" else STAGED_FRAMES):
+			for _frame: int in int(STAGED_FRAMES_BY_KIND.get(_kind, STAGED_FRAMES)):
 				_screen.advance_frame()
 	if _frames < 18:
 		return false

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -662,6 +662,10 @@ func _process(_delta: float) -> bool:
 		return true
 	if _base < 0:
 		_start()
+	return _spend_frame()
+
+
+func _spend_frame() -> bool:
 	var at: int = _clip_frame() - _base
 	## A host frame can carry more than one hardware frame, so the scripted ones
 	## are drained up to `at` rather than matched against it.

--- a/tools/trace_world_script.gd
+++ b/tools/trace_world_script.gd
@@ -77,13 +77,32 @@ func _run() -> void:
 	var lines: PackedStringArray = PackedStringArray(["# frame bank:addr opcode name"])
 	var frame: int = 0
 
-	for step: String in args[5].split(",", false):
+	var walked: int = _walk(screen, lines, args[5], frame)
+	if walked < 0:
+		quit(2)
+		return
+	frame = walked
+
+	print("talking from %s facing %d" % [screen._world.player_cell, screen._world.player_facing])
+	frame = _spend(screen, lines, frame, maxi(1, int(args[6])))
+
+	Gen2WorldScriptRunner.trace_commands = false
+	FileAccess.open(args[7], FileAccess.WRITE).store_string("\n".join(lines) + "\n")
+	print("wrote %d commands to %s" % [lines.size() - 1, args[7]])
+	root.remove_child(screen)
+	screen.free()
+	quit(0)
+
+
+func _walk(
+	screen: Gen2WorldScreen, lines: PackedStringArray, spec: String, frame: int
+) -> int:
+	for step: String in spec.split(",", false):
 		var parts: PackedStringArray = step.split(":")
 		var button: int = _button_for(parts[0])
 		if button == Gen2Button.NONE:
 			push_error("a walk step is <up|down|left|right>:<count>")
-			quit(2)
-			return
+			return -1
 		var cells: int = int(parts[1]) if parts.size() > 1 else 1
 		if cells == 0:
 			var turns: int = 0
@@ -110,10 +129,13 @@ func _run() -> void:
 				screen.advance_frame()
 				_collect(screen, lines, frame)
 				frame += 1
+	return frame
 
-	print("talking from %s facing %d" % [screen._world.player_cell, screen._world.player_facing])
+
+func _spend(
+	screen: Gen2WorldScreen, lines: PackedStringArray, frame: int, limit: int
+) -> int:
 	var idle: int = 0
-	var limit: int = maxi(1, int(args[6]))
 	while frame < limit:
 		if frame % PRESS_EVERY == 0:
 			screen.press_button(Gen2Button.A)
@@ -128,13 +150,7 @@ func _run() -> void:
 				break
 		else:
 			idle = 0
-
-	Gen2WorldScriptRunner.trace_commands = false
-	FileAccess.open(args[7], FileAccess.WRITE).store_string("\n".join(lines) + "\n")
-	print("wrote %d commands to %s" % [lines.size() - 1, args[7]])
-	root.remove_child(screen)
-	screen.free()
-	quit(0)
+	return frame
 
 
 ## Drains whatever the runner has executed since the last frame, and drains a

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -15,8 +15,8 @@ const CHECKS: String = "res://tools/checks"
 ## topic can still be asked for on its own.
 const GROUPS: Dictionary = {
 	&"field_moves": [
-		&"cut", &"surf", &"whirlpool", &"strength", &"headbutt", &"rock_smash",
-		&"field_move_prompts",
+		&"cut", &"surf", &"whirlpool", &"strength", &"waterfall", &"headbutt",
+		&"rock_smash", &"field_move_prompts",
 	],
 	&"terrain": [
 		&"ledge_hops", &"ice_slides", &"side_walls", &"drawn_blocks", &"story_map_ids",


### PR DESCRIPTION
Two things. The first is the standing programme; the second answers three requests from the mod side.

## The complexity ceiling's list is empty

The twenty functions still over the 20-branch ceiling are now under it, and `tests/unit/test_source_budget.gd`'s `OVER_COMPLEXITY` is empty. Each was split at its own seam. Nothing changes behaviour.

| Seam | Where |
|---|---|
| A refusal walk moved into its own function | `teach_tm_hm`, `purchase`, `give_to_party`, `from_battle_party` |
| A match of many arms became a lookup table | `_reel_action` (18 arms), `BattleTower.action` (15) |
| One reader per fixed-width list | `_read_events`, `_read_one_trainer` |
| One verifier per thing verified | `verify_mail`, `_verify_gs_title`, `_verify_presents_sprites` |
| A driver's phases, one function each | `record_clip._process`, `trace_world_script._run`, `preview_town_map._initialize` |

The list may only shrink and has reached zero, so it is gone rather than kept at zero: a function over 20 now fails the test outright.

## The waterfall climb is paced

`complete_waterfall()` walked the column and assigned `player_cell` once, so a thirteen cell climb happened between two frames. `Script_UsedWaterfall` climbs a cell at a time, and `STEP_PASSES` already named `turn_waterfall`; only the commit skipped it.

The cell still commits at once, the way an `applymovement` stream does, and the column is now drawn a cell at a time at that command's own four passes. `player_step_in_progress()` stays true for the whole climb and `player_step_offset_cells()` counts the fall down, which is what a renderer drawing a fall as a vertical wall reads as height. The landing state is re-derived when the run drains rather than on the call, so the climber is still surfing while the fall is being climbed; the answer reports the mode it will leave, plus `steps` and `passes`. Whirl Islands B2F is 13 steps over 52 passes.

`player_step_kind()` is new: it names the movement in flight, so a climb is told from a walk north.

### The climber spins

Checked against pret after the fact, and three things were wrong.

`turn_waterfall` reaches `TurningStep`, not `NormalStep`, and `TurningStep` sets `OBJECT_ACTION_SPIN`. `CounterclockwiseSpinAction` steps the drawn facing DOWN, RIGHT, UP, LEFT one quarter-turn every four passes, so a climber spins all the way up a fall. The port drew them facing up the whole way. `turn_away` and `turn_in` are the same command family and were wrong the same way, so the spin lives on `Gen2WorldMovement` and both the player and every object read it: `Gen2WorldAPI.player_drawn_facing()` and `Gen2WorldObject.drawn_facing()` are what the renderer draws now. The logical facing never moves, which is why a climb still ends facing up.

`complete_waterfall()` refused a column drawn up to the map's top row. `.CheckContinueWaterfall` reads the border block above that row, which is never a waterfall, so the cartridge stops there; the climb now ends on the last row the map has instead of answering a refusal. Silver Cave Room 2's four-wide fall is the only one that reaches it, and all 34 columns on all three cartridges now climb.

Both preview pairs photographed refusals. The waterfall one skipped the facing `CheckMapCanWaterfall` demands; both its calls share one setup now, which also puts the player on the surf sprite a fall's foot is ridden on. The surf one never faced the water, so it photographed dry land: it turns at the first cell `.TrySurf` accepts.

Also `preview_waterfall` / `preview_waterfall_use` and `preview_flash` / `preview_flash_use` beside the four pairs that existed, and a plain `world()` accessor on `Gen2WorldScreen`. The four `*_use` bodies were identical and are now one helper. The waterfall pair faces the player up itself, because `CheckMapCanWaterfall` passes only FACE_UP.

`tools/checks/waterfall.gd` climbs every column all three cartridges ship. Four of the 34 run to the map's top row and refuse: the cartridge would read the border block there, which is never a waterfall, and stop with the player in the connection padding, while nothing outside the map is a cell here. The check pins that count and asserts the border blocks.

## Met on the way, fixed in the same commits

- A doc comment left behind by a deleted function, on top of `Gen2WorldScript.decode_command_queue_entry`'s own.
- Three more comments that had come away from what they document: the badge table's in `preview_world.gd`, `_play_current_map_music`'s, and `STAGED_FRAMES`'s.
- The eight field-move requests repeated the same staging sentence eight times, and now state it once.

The comment ceiling ends at 37882, down from 37884.

## Proof

| Check | Result |
|---|---|
| `gut` unit tier | 3449/3449, 63601 asserts |
| Editor analyser, whole tree | 0 warnings in 598 scripts |
| Re-import, three cartridges | `layout: Layout verified.` on each, 3/3 |
| `validate.gd -- all` | exit 0, `PASS world_scripts` |
| `validate.gd -- field_moves` | 8 topics PASS, waterfall 164 cells / 34 columns / 4 maps on each cartridge |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | reaches `silver_cave_red`, no failed leg |
| Screenshot | the spin mid-climb on map 3/83, Surf entering the water on the surf sprite, and Whirl Islands lit by the new Flash driver |
