### PR TITLE
Keep a phone's own buttons from putting the on-screen controller away

### DIFF
--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -29,6 +29,7 @@ var _mod_controls: Dictionary = {}
 var _touch_mode: StringName = Gen2Options.TOUCH_AUTO
 var _layout: Gen2TouchLayout = Gen2TouchLayout.new()
 var _device: StringName = Gen2InputDevice.KEYBOARD
+var _handheld: bool = Gen2InputDevice.is_handheld()
 var _touch_shown: bool = false
 ## Held directions in the order they were pressed, so the newest wins. Two
 ## directions at once is normal play, not an error: a player turning a corner
@@ -316,21 +317,17 @@ static func _direction_pressed(button: int) -> bool:
 
 
 ## Watches every event and consumes none, except a directional press the
-## hardware would not have reported: see [method _gate_direction_repeat]. Device
-## recon has to see input the screens never get, including the mouse motion that
-## says the player has put the pad down.
+## hardware would not have reported: see [method _gate_direction_repeat]. What
+## counts as another device being picked up is
+## [method Gen2InputDevice.evidence_of] rather than where the event came from.
 func _input(event: InputEvent) -> void:
 	if _gate_direction_repeat(event):
 		var viewport: Viewport = get_viewport()
 		if viewport != null:
 			viewport.set_input_as_handled()
 		return
-	var kind: StringName = Gen2InputDevice.kind_of(event)
+	var kind: StringName = Gen2InputDevice.evidence_of(event, _handheld)
 	if kind.is_empty():
-		return
-	# Mouse motion alone is not evidence: a desk knocked while the player holds
-	# a pad would hide the interface they are looking at. A click is.
-	if kind == Gen2InputDevice.MOUSE and event is InputEventMouseMotion:
 		return
 	_set_device(kind)
 

--- a/game/input/input_device.gd
+++ b/game/input/input_device.gd
@@ -39,12 +39,9 @@ static func kind_for_hardware(has_pad: bool, has_touch: bool) -> StringName:
 
 
 ## The device kind an event came from, or an empty name for an event that says
-## nothing about one.
-##
-## Mouse events emulated from a touch carry [constant
-## InputEvent.DEVICE_ID_EMULATION] and are reported as touch. Without that,
-## `emulate_mouse_from_touch` (on by default, and what makes the launcher work
-## under a finger) would flip the answer back to mouse on every tap.
+## nothing about one. A mouse event emulated from a touch carries [constant
+## InputEvent.DEVICE_ID_EMULATION]: without that, `emulate_mouse_from_touch`
+## would flip the answer to mouse on every tap of the launcher.
 static func kind_of(event: InputEvent) -> StringName:
 	if event is InputEventScreenTouch or event is InputEventScreenDrag:
 		return TOUCH
@@ -55,6 +52,27 @@ static func kind_of(event: InputEvent) -> StringName:
 	if event is InputEventMouse:
 		return TOUCH if event.device == InputEvent.DEVICE_ID_EMULATION else MOUSE
 	return &""
+
+
+## The kind an event is evidence the player has picked up, or an empty name.
+## Android sends its Back button, its navigation bar and its volume rocker as
+## key events, and a [param handheld] has no keyboard or mouse of its own:
+## reading Back as one put the on-screen controller away mid-game.
+static func evidence_of(event: InputEvent, handheld: bool) -> StringName:
+	var kind: StringName = kind_of(event)
+	if handheld and (kind == KEYBOARD or kind == MOUSE):
+		return &""
+	# A knocked desk and a drifting stick are nobody's hands; a click is.
+	if event is InputEventMouseMotion:
+		return &""
+	var motion := event as InputEventJoypadMotion
+	if motion != null and absf(motion.axis_value) < Gen2InputActions.DEADZONE:
+		return &""
+	return kind
+
+
+static func is_handheld() -> bool:
+	return OS.has_feature("mobile")
 
 
 static func label(kind: StringName) -> String:

--- a/game/render/game_frame.gd
+++ b/game/render/game_frame.gd
@@ -20,8 +20,8 @@ var _gesture := Gen2TapGesture.new()
 
 
 func _ready() -> void:
-	# Found by type rather than by name: both scenes that use a frame build the
-	# same two children, and neither should have to agree on a path as well.
+	# Found by type rather than by name: no scene using a frame should have to
+	# agree on a node path as well.
 	for child: Node in get_children():
 		if child is Gen2Screen:
 			_screen = child

--- a/tests/integration/test_input_runtime.gd
+++ b/tests/integration/test_input_runtime.gd
@@ -104,6 +104,27 @@ func test_automatic_shows_the_controller_only_while_a_finger_is_on_the_screen() 
 	assert_false(_runtime.touch_controls_shown(), "a pad puts them away")
 
 
+## Reported from a released Android build: Android's Back put the on-screen
+## controller away and grew the game screen into the room it left, on `auto`
+## only, since `always` never asks which device is in use. A phone's own
+## furniture arrives as key events and a phone has no keyboard to pick up.
+func test_a_phone_key_does_not_put_the_on_screen_controller_away() -> void:
+	_runtime._handheld = true
+	_runtime._input(InputEventScreenTouch.new())
+	assert_true(_runtime.touch_controls_shown(), "a finger shows them")
+
+	var back := InputEventKey.new()
+	back.physical_keycode = KEY_BACK
+	back.pressed = true
+	_runtime._input(back)
+	assert_eq(_runtime.device(), Gen2InputDevice.TOUCH, "Back is the phone, not a keyboard")
+	assert_true(_runtime.touch_controls_shown(), "and the controller stays up")
+
+	_runtime._input(InputEventJoypadButton.new())
+	assert_false(_runtime.touch_controls_shown(), "a pad plugged into it still does")
+	_runtime._handheld = Gen2InputDevice.is_handheld()
+
+
 func test_the_pinned_modes_ignore_the_device() -> void:
 	for pair: Array in [[Gen2Options.TOUCH_ALWAYS, true], [Gen2Options.TOUCH_NEVER, false]]:
 		var options := Gen2Options.new()

--- a/tests/integration/test_start_menu_reopen.gd
+++ b/tests/integration/test_start_menu_reopen.gd
@@ -104,3 +104,27 @@ func test_back_opens_the_start_menu_and_then_closes_it() -> void:
 	assert_not_null(_screen._start_menu_host, "a back press on the map is a pause")
 	_screen._on_back_requested()
 	assert_null(_screen._start_menu_host, "and the next one backs out of it")
+
+
+## Reported from a released Android build: Back over the map put the on-screen
+## controller away and the game screen grew into the room it left, on `auto`
+## only. `always` hid it because that mode never asks which device is in use.
+func test_back_leaves_the_on_screen_controller_where_it_was() -> void:
+	var runtime: Gen2InputRuntime = Gen2InputRuntime.instance()
+	runtime._input(InputEventScreenTouch.new())
+	assert_true(runtime.touch_controls_shown(), "a finger shows the controller")
+	var pad: Gen2TouchPad = _pad()
+	assert_not_null(pad, "the world screen builds one")
+	var was: Rect2 = Rect2(pad.position, pad.size)
+
+	_screen._on_back_requested()
+	await get_tree().process_frame
+	assert_true(runtime.touch_controls_shown(), "and Back is not another device")
+	assert_eq(Rect2(pad.position, pad.size), was, "the split does not move")
+
+
+func _pad() -> Gen2TouchPad:
+	for node: Node in _screen.find_children("*", "Control", true, false):
+		if node is Gen2TouchPad:
+			return node
+	return null

--- a/tests/unit/test_input_device.gd
+++ b/tests/unit/test_input_device.gd
@@ -25,6 +25,56 @@ func test_a_mouse_event_emulated_from_a_touch_reads_as_touch() -> void:
 	assert_eq(Gen2InputDevice.kind_of(click), Gen2InputDevice.TOUCH)
 
 
+## Android sends Back, its navigation bar and its volume rocker as key events,
+## and a phone has no keyboard of its own. Read as one they put the on-screen
+## controller away mid-game and the screen grew into the room it left, which is
+## what a player reported.
+func test_a_phone_has_no_keyboard_and_no_mouse_to_pick_up() -> void:
+	var back := InputEventKey.new()
+	back.physical_keycode = KEY_BACK
+	assert_eq(Gen2InputDevice.evidence_of(back, true), &"")
+	assert_eq(Gen2InputDevice.evidence_of(InputEventMouseButton.new(), true), &"")
+	assert_eq(
+		Gen2InputDevice.evidence_of(InputEventScreenTouch.new(), true), Gen2InputDevice.TOUCH
+	)
+	assert_eq(
+		Gen2InputDevice.evidence_of(InputEventJoypadButton.new(), true),
+		Gen2InputDevice.GAMEPAD,
+		"a pad plugged into a phone is still a pad",
+	)
+
+
+func test_evidence_is_the_kind_for_everything_a_player_holds() -> void:
+	var typed := InputEventKey.new()
+	typed.physical_keycode = KEY_Z
+	assert_eq(Gen2InputDevice.evidence_of(typed, false), Gen2InputDevice.KEYBOARD)
+	assert_eq(
+		Gen2InputDevice.evidence_of(InputEventScreenTouch.new(), false), Gen2InputDevice.TOUCH
+	)
+	assert_eq(
+		Gen2InputDevice.evidence_of(InputEventJoypadButton.new(), false),
+		Gen2InputDevice.GAMEPAD,
+	)
+	assert_eq(
+		Gen2InputDevice.evidence_of(InputEventMouseButton.new(), false), Gen2InputDevice.MOUSE
+	)
+
+
+## A desk knocked while the player holds a pad would otherwise hide the
+## interface they are looking at, and a drifting stick would do it with nobody
+## in the room. A click and a push past the deadzone are evidence; neither of
+## these is.
+func test_a_pointer_that_moved_and_a_stick_that_did_not_are_not_evidence() -> void:
+	assert_eq(Gen2InputDevice.kind_of(InputEventMouseMotion.new()), Gen2InputDevice.MOUSE)
+	assert_eq(Gen2InputDevice.evidence_of(InputEventMouseMotion.new(), false), &"")
+
+	var drift := InputEventJoypadMotion.new()
+	drift.axis_value = Gen2InputActions.DEADZONE - 0.01
+	assert_eq(Gen2InputDevice.evidence_of(drift, false), &"")
+	drift.axis_value = Gen2InputActions.DEADZONE
+	assert_eq(Gen2InputDevice.evidence_of(drift, false), Gen2InputDevice.GAMEPAD)
+
+
 func test_pointers_are_the_kinds_that_need_no_focus_ring() -> void:
 	assert_true(Gen2InputDevice.is_pointer(Gen2InputDevice.MOUSE))
 	assert_true(Gen2InputDevice.is_pointer(Gen2InputDevice.TOUCH))


### PR DESCRIPTION
Reported: on Android, the back button hides or resizes the on-screen buttons, and only with **On screen buttons: Automatic**.

Automatic draws the controller while the touchscreen is the device in use, and until now every event was read as evidence of which device that is. A phone reports its own furniture as input: Android sends Back, the navigation bar and the volume rocker as key events. One of those read as a keyboard being picked up, so the controller went away mid-game and the map grew into the room it left. Always never asks which device is in use, which is why it was unaffected.

Evidence is now narrower than where an event came from:

- a handheld has no keyboard and no mouse of its own, so neither counts there and only a pad plugged into it can take the controller away;
- a stick under the deadzone a binding is captured past counts nowhere, since a drifting one sends events with nobody in the room;
- mouse motion was already exempt and moves in with the rest, out of the runtime.

Checked on an Android emulator with a Crystal cache seeded in `user://`: from the map, both the gesture Back and the three-button navigation bar open and close the pause menu with the controller in place and the split unmoved.

| Check | Result |
|---|---|
| GUT, whole tree | 4028 tests, 4028 passing, 165 scripts |
| Editor analyser | 0 warnings in 598 scripts |
| `validate.gd -- all` | exit 0 |
| Boot smoke, 30 s | clean |