### PR TITLE
Open the walls a field move opens, and let a whirlpool spit the player out

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -33,7 +33,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version. Strict `major.minor.patch` |
-| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 23 and a host accepts 1 to 23. [Contract versions](#contract-versions) says what each added |
+| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 24 and a host accepts 1 to 24. [Contract versions](#contract-versions) says what each added |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -125,6 +125,7 @@ runs, since every version so far has only added.
 | 21 | Reading the run, a notice over the map, and keeping a page |
 | 22 | `Gen2WorldScreen.world()`, `Gen2WorldAPI.player_drawn_facing()`, `Gen2WorldObject.drawn_facing()`, and the `preview_waterfall` and `preview_flash` pairs |
 | 23 | `Gen2WorldAPI.unown_wall_event()` and `always_on_bike()`, and `Gen2WorldFieldMove`'s field-move texts |
+| 24 | `Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span()` |
 
 ## Installing
 
@@ -1540,6 +1541,17 @@ many cells below the landing as the climb is tall and counts down to zero. Its
 answer carries `steps` and `passes`, and the surfer stays a surfer until the last
 step lands them ashore. A renderer that draws a fall as a vertical wall reads the
 offset as height.
+
+`Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span()` say which two
+cells the step in flight runs between: `{from, to, progress, kind}`, and `{}` while
+nothing steps. Moving `from` to `to` by `progress` is exactly what the offset
+above answers, so the two never disagree; the span is the one to read when the
+plan a renderer draws is not a plain grid. A view that folds a run of plan into
+height, or lifts or ramps it, puts `from` and `to` through its own geometry and
+moves between the two answers, which stays continuous where a fractional cell
+cannot: the fractional cell is one number and the fold is a step in it. The offset
+sums the whole remaining run into one vector, which cannot be taken apart again
+once a scripted stream turns.
 
 A hop is the one step with a second axis.
 `Gen2WorldAPI.player_height_offset_pixels()` and

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -33,7 +33,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version. Strict `major.minor.patch` |
-| `api_version` | The contract this mod is written against. Current: `Gen2ModManifest.API_VERSION`, 21. A host accepts 1 to 21 |
+| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 23 and a host accepts 1 to 23. [Contract versions](#contract-versions) says what each added |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -93,6 +93,38 @@ Two example mods are in `mods/examples/`. Copy either into `user://mods/`.
 
 The examples are excluded from every export preset. A distributed build ships the
 loader and no mod.
+
+## Contract versions
+
+What each `api_version` added. Declare the oldest one that carries every seam the
+mod reaches; a host refuses a number above its own, and an older number still
+runs, since every version so far has only added.
+
+| Version | Added |
+|---|---|
+| 1 | The mod boundary, and the world renderer registered through it |
+| 2 | Visible wild encounters |
+| 3 | Mart rows and named action axes |
+| 4 | Egg moves and the content seam |
+| 5 | A run's own rules and difficulty |
+| 6 | Who is standing where, for a visible-encounter provider |
+| 7 | A mod actor that can be talked to, and hidden-item requests |
+| 8 | A page on the stats screen |
+| 9 | An item naming the evolution using it causes |
+| 10 | Screen fill kept out of a view that declined the hardware buffer |
+| 11 | The battle entrance resolved for a renderer with no background plane |
+| 12 | Changing the view from inside the game |
+| 13 | Five read-only policies |
+| 14 | Ownership answered where it changes, and ink carrying its own field |
+| 15 | A visible encounter asking for a glow |
+| 16 | Every wild rolling its own DVs, and a shiny drawn shiny |
+| 17 | Plain battler events, and a thrown ball |
+| 18 | The four seams the mods repository asked to close |
+| 19 | A visible population stepped on overworld frames, snapshot kept current |
+| 20 | A capture seen, a line added to a battle, stacked shiny rolls |
+| 21 | Reading the run, a notice over the map, and keeping a page |
+| 22 | `Gen2WorldScreen.world()`, `Gen2WorldAPI.player_drawn_facing()`, `Gen2WorldObject.drawn_facing()`, and the `preview_waterfall` and `preview_flash` pairs |
+| 23 | `Gen2WorldAPI.unown_wall_event()` and `always_on_bike()`, and `Gen2WorldFieldMove`'s field-move texts |
 
 ## Installing
 
@@ -1495,9 +1527,11 @@ answer `step`, `jump_step` and `turn`. It is empty while nothing is stepping.
 `NormalStep`, which sets `OBJECT_ACTION_SPIN`: the walker spins counterclockwise
 through DOWN, RIGHT, UP, LEFT, one quarter-turn every four passes, instead of
 facing the way it is going. `Gen2WorldAPI.player_drawn_facing()` and
-`Gen2WorldObject.drawn_facing()` are that spin; the logical facing never moves, so
-a waterfall climb still ends facing up. Draw from those two, not from
-`player_facing` and `facing`.
+`Gen2WorldObject.drawn_facing()` are that spin. Draw from those two, not from
+`player_facing` and `facing`, which hold still for the length of a step.
+`SetFacingCounterclockwiseSpin` writes `OBJECT_DIRECTION`, which is
+`wPlayerDirection` itself, and nothing after the script puts it back, so a climb
+lands facing a quarter turn per cell round from DOWN rather than up.
 
 Waterfall is the one field move whose whole answer is movement.
 `complete_waterfall()` commits the landing cell at once and then runs the column as

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -9,11 +9,11 @@ extends RefCounted
 ## against an older one still runs, since every version so far has only added.
 
 const FILENAME: String = "mod.json"
-## Bumped when the host contract changes in a way an existing mod would notice.
-## What each version added is in the commit history; `docs/MODS.md` documents the
-## current contract only. An optional field a mod may send and an older host may
-## drop is deliberately not a bump.
-const API_VERSION: int = 21
+## Bumped in the same commit as any seam added to the contract, so a mod has a
+## number that says the seam is there: `docs/MODS.md` lists what each version
+## added. An optional field a mod may send and an older host may drop is
+## deliberately not a bump.
+const API_VERSION: int = 23
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -13,7 +13,7 @@ const FILENAME: String = "mod.json"
 ## number that says the seam is there: `docs/MODS.md` lists what each version
 ## added. An optional field a mod may send and an older host may drop is
 ## deliberately not a bump.
-const API_VERSION: int = 23
+const API_VERSION: int = 24
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -69,6 +69,8 @@ const STEP_PASSES_FAST: int = 4
 ## then the new facing is written and two more, so a turn on the spot costs
 ## four frames and no cell.
 const STEP_PASSES_TURN: int = 4
+## `Script_ForcedMovement`'s own `step_dig 16`, twice per whirlpool.
+const FORCED_TURN_SLEEP_PASSES: int = 16
 ## How long each scripted step command takes, from the `STEP_*` speed it passes to
 ## `InitStep` and that row of `StepVectors`. Every command here reaches `InitStep`
 ## and they differ only in the step type set over the top; the turning rows keep
@@ -898,7 +900,8 @@ func player_step_kind() -> StringName:
 
 
 ## The facing the player is DRAWN with: [member player_facing] except while a
-## spinning command walks, and the logical facing never moves.
+## spinning command walks. The spin also writes OBJECT_DIRECTION, so a stream
+## that ends leaves [member player_facing] where it stopped.
 func player_drawn_facing() -> int:
 	if player_step_kind() in Gen2WorldMovement.SPINNING_KINDS:
 		return Gen2WorldMovement.spin_facing(_player_spin_frame)
@@ -1090,14 +1093,11 @@ const FIELD_MOVE_SOURCE_PARTY: StringName = &"party"
 const FIELD_MOVE_SOURCE_ITEM: StringName = &"item"
 
 
-## WHERE a field move would be used from, which is the one question every entrance
-## to one asks: `{kind, move, slot, item}`, and `{}` when nothing can use it. The
-## party is asked first and answers exactly what [method party_slot_with_move]
-## did, so with no registered source every field move resolves the way it always
-## has; only when no slot knows the move is an alternate source considered, and
-## only for the seven HM moves. The badge is deliberately NOT part of this: every
-## `Try*OW` tests its own `CheckBadge` in the source's order, so a player carrying
-## HM01 without the Hive Badge is told about the badge.
+## WHERE a field move would be used from: `{kind, move, slot, item}`, and `{}`
+## when nothing can use it. The party answers first and exactly what [method
+## party_slot_with_move] did; only when no slot knows the move is an alternate
+## source considered, and only for the seven HM moves. The badge is deliberately
+## not part of this, since every `Try*OW` tests `CheckBadge` in its own order.
 func field_move_source(move_id: int) -> Dictionary:
 	var slot: int = party_slot_with_move(move_id)
 	if slot >= 0:
@@ -1111,9 +1111,8 @@ func field_move_source(move_id: int) -> Dictionary:
 
 
 ## The HM in the bag that teaches [param move_id] while a registered provider
-## allows that move, or 0. Which item teaches which move is `GetTMHMItemMove`'s
-## answer rather than a second table, so a cartridge whose HMs differ needs
-## nothing here.
+## allows it, or 0. Which item teaches which move is `GetTMHMItemMove`'s answer
+## rather than a second table.
 func item_field_move_source(move_id: int) -> int:
 	if data == null or state == null \
 		or not Gen2WorldFieldMove.is_hm_field_move(move_id) \
@@ -1126,13 +1125,10 @@ func item_field_move_source(move_id: int) -> int:
 	return 0
 
 
-## Every HM field move an item can currently supply and the party cannot, as
+## Every HM field move an item can supply and the party cannot, as
 ## `{move, item, badge}` in [constant Gen2WorldFieldMove.HM_FIELD_MOVES] order.
-##
-## The badge IS applied here, unlike in [method field_move_source]: this is what
-## a menu of usable moves is built from, and a row that can only answer "a new
-## BADGE is required" is not something to offer. A party member that knows the
-## move keeps its own submenu row and is not repeated here.
+## The badge IS applied here, unlike in [method field_move_source]: a row that
+## can only answer "a new BADGE is required" is not worth offering.
 func item_field_move_offers() -> Array:
 	var out: Array = []
 	if data == null or state == null:
@@ -1151,14 +1147,14 @@ func item_field_move_offers() -> Array:
 	return out
 
 
-## Clears the mirror so a stale count cannot answer a later read after the
-## caller stops refreshing it (for example, closing the injected preview save).
+## Cleared so a stale count cannot answer a read after the caller stops
+## refreshing it, for example when the injected preview save closes.
 func clear_party_summary() -> void:
 	_party_summary = {}
 
 
-## Empty when no caller has set a summary yet; a script-visible read must fail
-## rather than invent a count in that case.
+## Empty until a caller sets one: a script-visible read fails rather than
+## inventing a count.
 func party_summary() -> Dictionary:
 	return _party_summary.duplicate()
 
@@ -1234,13 +1230,36 @@ func cancel_fishing() -> Dictionary:
 	return _fishing.cancel()
 
 
+## `engine/events/unown_walls.asm`'s two farcalled chambers: `FlashFunction`
+## reaches `SpecialAerodactylChamber` and `EscapeRopeOrDig`'s escape-rope branch
+## reaches `SpecialKabutoChamber`, so neither is a `special` the runner can see.
+## Ho-Oh's and Omanyte's are, and live there. Crystal's alone.
+const RUINS_OF_ALPH_GROUP: int = 3
+const RUINS_OF_ALPH_KABUTO_CHAMBER: int = 24
+const RUINS_OF_ALPH_AERODACTYL_CHAMBER: int = 26
+const EVENT_WALL_OPENED_IN_KABUTO_CHAMBER: int = 807
+const EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER: int = 809
+const UNOWN_WALL_MAPS: Dictionary = {
+	EVENT_WALL_OPENED_IN_KABUTO_CHAMBER: RUINS_OF_ALPH_KABUTO_CHAMBER,
+	EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER: RUINS_OF_ALPH_AERODACTYL_CHAMBER,
+}
+
+
+## [param event] while the player stands in that wall's own chamber, or -1,
+## which is each routine's `GetMapAttributesPointer` comparison.
+func unown_wall_event(event: int) -> int:
+	if current_map == null or data == null \
+		or not Gen2WorldState.is_crystal_profile(data) \
+		or current_map.group != RUINS_OF_ALPH_GROUP \
+		or current_map.number != int(UNOWN_WALL_MAPS.get(event, -1)):
+		return -1
+	return event
+
+
 ## engine/events/overworld.asm's CutFunction. Every field move below is staged
-## rather than applied, because each source script shows its text and waits on the
-## button before it changes anything: `*_request` records and `complete_*` writes.
-## The refusal order is load bearing too: `.CheckAble` tests ENGINE_HIVEBADGE
-## before it ever looks at the tile, so a player without the badge is told about
-## the badge even while facing a cuttable tree. A match records the block,
-## replacement and animation the way CheckMapForSomethingToCut fills wCutWhirlpool*.
+## rather than applied, since each script shows its text and waits before it
+## changes anything: `*_request` records and `complete_*` writes. The refusal
+## order is load bearing: `.CheckAble` tests ENGINE_HIVEBADGE before the tile.
 func cut_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _cut_failure(&"missing_map")
@@ -1276,16 +1295,14 @@ func cut_request() -> Dictionary:
 	return _pending_cut.duplicate(true)
 
 
-## Empty until cut_request() succeeds. A host shows its text while this is set.
+## Empty until cut_request() succeeds.
 func pending_cut() -> Dictionary:
 	return _pending_cut.duplicate(true)
 
 
-## CutDownTreeOrGrass: writes the replacement into the loaded map's block grid.
-## change_block() already re-resolves collision through the tileset and drops the
-## override on a map change or reload, which is the cartridge's own behavior,
-## since the routine writes wOverworldMapBlocks and a map load re-reads the
-## block data from ROM. The tree regrows on the next visit.
+## CutDownTreeOrGrass, which writes wOverworldMapBlocks: change_block() drops the
+## override on a map load exactly as re-reading the block data from ROM does, so
+## the tree regrows on the next visit.
 func complete_cut() -> Dictionary:
 	if _pending_cut.is_empty():
 		return _cut_failure(&"no_pending_cut")
@@ -1314,7 +1331,6 @@ static func _cut_failure(reason: StringName) -> Dictionary:
 ## before the tile, so a player without the Fog Badge is told about the badge
 ## whether or not the water in front is surfable, CheckBadge itself being what
 ## pushes that text. [param species] is the chosen party member's, for GetSurfType.
-## The source's wBikeFlags branch has no counterpart here, since no bike exists.
 func surf_request(species: int = 0) -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _surf_failure(&"missing_map")
@@ -1329,6 +1345,8 @@ func surf_request(species: int = 0) -> Dictionary:
 	## badge rather than before it (`TrySurfOW`).
 	if field_move_source(Gen2WorldFieldMove.MOVE_SURF).is_empty():
 		return _surf_failure(&"move_not_known")
+	if always_on_bike():
+		return _surf_failure(&"cannot_surf")
 	if movement_mode == MOVEMENT_SURF:
 		return _surf_failure(&"already_surfing")
 	var target: Vector2i = facing_cell()
@@ -1355,17 +1373,15 @@ func surf_request(species: int = 0) -> Dictionary:
 	return _pending_surf.duplicate(true)
 
 
-## Empty until surf_request() succeeds. A host shows its text while this is set.
+## Empty until surf_request() succeeds.
 func pending_surf() -> Dictionary:
 	return _pending_surf.duplicate(true)
 
 
 ## The rest of UsedSurfScript after its waitbutton: writevar VAR_MOVEMENT,
 ## UpdatePlayerSprite, then SurfStartStep's single slow_step into the water.
-##
-## That step is an applymovement, not player input, so it neither consumes a
-## repel step nor rolls an encounter, and it is not re-validated: .TrySurf
-## already checked the cell, and the movement engine does not check again.
+## An applymovement rather than input, so it spends no repel step, rolls no
+## encounter and is not re-validated.
 func complete_surf() -> Dictionary:
 	if _pending_surf.is_empty():
 		return _surf_failure(&"no_pending_surf")
@@ -1389,9 +1405,8 @@ static func _surf_failure(reason: StringName) -> Dictionary:
 
 
 ## WhirlpoolFunction .TryWhirlpool, filling the same wCutWhirlpool* slots Cut
-## does. ENGINE_GLACIERBADGE is checked before the tile, the order .CheckAble has,
-## and no player state at all: the source neither requires nor refuses surfing, so
-## a player facing a whirlpool from land resolves too.
+## does. ENGINE_GLACIERBADGE before the tile, and no player state at all, so a
+## player facing a whirlpool from land resolves too.
 func whirlpool_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _whirlpool_failure(&"missing_map")
@@ -1425,14 +1440,13 @@ func whirlpool_request() -> Dictionary:
 	return _pending_whirlpool.duplicate(true)
 
 
-## Empty until whirlpool_request() succeeds. A host shows its text while this is set.
+## Empty until whirlpool_request() succeeds.
 func pending_whirlpool() -> Dictionary:
 	return _pending_whirlpool.duplicate(true)
 
 
-## DisappearWhirlpool, which writes the replacement block and re-runs
-## GetMovementPermissions exactly as CutDownTreeOrGrass does, so the override
-## dies with the loaded map and the whirlpool returns on the next visit.
+## DisappearWhirlpool, which writes the replacement block as CutDownTreeOrGrass
+## does, so the whirlpool returns with the next map load.
 func complete_whirlpool() -> Dictionary:
 	if _pending_whirlpool.is_empty():
 		return _whirlpool_failure(&"no_pending_whirlpool")
@@ -1458,10 +1472,9 @@ static func _whirlpool_failure(reason: StringName) -> Dictionary:
 
 
 ## WaterfallFunction .TryWaterfall: CheckBadge ENGINE_RISINGBADGE, then
-## CheckMapCanWaterfall, which is two tests and no more: `wPlayerDirection & $c`
-## must be FACE_UP, and wTileUp must satisfy CheckWaterfallTile. It reads no player
-## state, so it neither requires nor refuses surfing, and its refusal is
-## FieldMoveFailed's generic line.
+## CheckMapCanWaterfall, which is `wPlayerDirection & $c` being FACE_UP and
+## wTileUp satisfying CheckWaterfallTile. No player state, so it neither
+## requires nor refuses surfing.
 func waterfall_request() -> Dictionary:
 	if current_map == null or current_tileset == null:
 		return _waterfall_failure(&"missing_map")
@@ -1491,7 +1504,7 @@ func waterfall_request() -> Dictionary:
 	return _pending_waterfall.duplicate(true)
 
 
-## Empty until waterfall_request() succeeds. A host shows its text while this is set.
+## Empty until waterfall_request() succeeds.
 func pending_waterfall() -> Dictionary:
 	return _pending_waterfall.duplicate(true)
 
@@ -1502,8 +1515,8 @@ func pending_waterfall() -> Dictionary:
 ## cell that is not a waterfall. Each step is an applymovement: no collision, no
 ## repel step, no encounter. Paced like a scripted stream, the cell committing at
 ## once and the column drawn a cell at a time, so a renderer can carry the player
-## up the fall's face; the landing state is re-derived when the run drains rather
-## than here, and the answer reports the mode it will leave.
+## up the fall's face. [method _finish_waterfall_climb] is what the run drains
+## into, and the answer reports the mode it will leave.
 func complete_waterfall() -> Dictionary:
 	if _pending_waterfall.is_empty():
 		return _waterfall_failure(&"no_pending_waterfall")
@@ -1530,7 +1543,7 @@ func complete_waterfall() -> Dictionary:
 	var passes: int = int(SCRIPTED_STEP_PASSES[&"turn_waterfall"])
 	for _step: int in climbed:
 		_queue_player_step(Vector2i.UP, passes, false, Vector2i.UP, &"turn_waterfall")
-	_player_step_tail = _apply_map_setup_player_state
+	_player_step_tail = _finish_waterfall_climb
 	return {
 		"ok": true,
 		"kind": &"waterfall_applied",
@@ -1540,6 +1553,15 @@ func complete_waterfall() -> Dictionary:
 		"passes": climbed * passes,
 		"movement_mode": _setup_movement_mode(cell),
 	}
+
+
+## `SetFacingCounterclockwiseSpin` writes OBJECT_DIRECTION, which is
+## `wPlayerDirection` itself, and `movement_step_sleep`'s OBJECT_ACTION_STAND
+## reads it back rather than restoring anything: the climb ends a quarter turn
+## per cell round from DOWN. The landing state follows, as a warp's does.
+func _finish_waterfall_climb() -> void:
+	player_facing = Gen2WorldMovement.spin_facing(_player_spin_frame)
+	_apply_map_setup_player_state()
 
 
 static func _waterfall_failure(reason: StringName) -> Dictionary:
@@ -1564,31 +1586,44 @@ func flash_request() -> Dictionary:
 		Gen2WorldFieldMove.BADGE_ZEPHYR, Gen2WorldState.is_crystal_profile(data)
 	)):
 		return _flash_failure(&"badge_required")
-	if not Gen2WorldPalette.is_dark(current_map.palette):
-		return _flash_failure(&"not_dark")
-	if state.used_flash():
-		return _flash_failure(&"already_lit")
+	## `.CheckUseFlash` asks `SpecialAerodactylChamber` before the palette, so
+	## Flash works in that one room whatever the light.
+	var chamber: int = unown_wall_event(EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER)
+	if chamber < 0:
+		if not Gen2WorldPalette.is_dark(current_map.palette):
+			return _flash_failure(&"not_dark")
+		if state.used_flash():
+			return _flash_failure(&"already_lit")
 	_pending_flash = {
 		"ok": true,
 		"kind": &"flash_requested",
 		"move": Gen2WorldFieldMove.MOVE_FLASH,
+		"wall_event": chamber,
 	}
 	return _pending_flash.duplicate(true)
 
 
-## Empty until flash_request() succeeds. A host shows its text while this is set.
+## Empty until flash_request() succeeds.
 func pending_flash() -> Dictionary:
 	return _pending_flash.duplicate(true)
 
 
-## `BlindingFlash`, which Script_UseFlash reaches only after its text: the flag
-## goes on and every palette the map draws with changes with it.
+## `BlindingFlash`, reached only after Script_UseFlash's text: the flag goes on
+## and every palette the map draws with changes with it.
 func complete_flash() -> Dictionary:
 	if _pending_flash.is_empty():
 		return _flash_failure(&"no_pending_flash")
+	var wall_event: int = int(_pending_flash.get("wall_event", -1))
 	_pending_flash = {}
 	state.set_used_flash(true)
-	return {"ok": true, "kind": &"flash_used", "time_of_day": map_time_of_day()}
+	if wall_event >= 0:
+		state.set_event_flag(wall_event, true)
+	return {
+		"ok": true,
+		"kind": &"flash_used",
+		"time_of_day": map_time_of_day(),
+		"wall_event": wall_event,
+	}
 
 
 static func _flash_failure(reason: StringName) -> Dictionary:
@@ -1619,19 +1654,15 @@ func headbutt_request() -> Dictionary:
 	return _pending_headbutt.duplicate(true)
 
 
-## Empty until headbutt_request() succeeds. A host shows its text while this is
-## set, exactly as it does for the other staged moves.
+## Empty until headbutt_request() succeeds.
 func pending_headbutt() -> Dictionary:
 	return _pending_headbutt.duplicate(true)
 
 
 ## TreeMonEncounter: the map's treemon set, then GetTreeMons' profile limit,
-## then GetTreeMon's score and rolls. A miss is HeadbuttScript's .no_battle
-## branch, which is HeadbuttNothingText and no battle, so it is an applied
-## result with an empty encounter rather than a failure.
-##
-## The tree is not changed and the map is not touched: unlike Cut and
-## Whirlpool, ShakeHeadbuttTree is an animation over a block that stays.
+## then GetTreeMon's score and rolls. A miss is `.no_battle`, so it is an applied
+## result with an empty encounter rather than a failure. The tree stands:
+## ShakeHeadbuttTree is an animation, not a block change.
 func complete_headbutt(random: RandomNumberGenerator) -> Dictionary:
 	if _pending_headbutt.is_empty():
 		return _headbutt_failure(&"no_pending_headbutt")
@@ -1758,11 +1789,9 @@ func complete_rock_smash(random: RandomNumberGenerator) -> Dictionary:
 
 
 ## `Script_disappear`: `DeleteObjectStruct` plus
-## `ApplyEventActionAppearDisappear`, which writes the object's own event flag
-## only when it has one. Fifteen of the sixteen rocks carry `-1`, so they are
-## gone until the map reloads and back on the next visit; Mt. Moon Square's
-## carries `EVENT_MT_MOON_SQUARE_ROCK`, so that one stays smashed, which is what
-## gates the Clefairy dance.
+## `ApplyEventActionAppearDisappear`, which writes the object's event flag only
+## when it has one. Fifteen of the sixteen rocks carry `-1` and are back on the
+## next visit; Mt. Moon Square's stays smashed and gates the Clefairy dance.
 func smash_object(object_index: int) -> Dictionary:
 	if current_map == null or object_index < 0 or object_index >= objects.size():
 		return {"ok": false, "reason": &"missing_object"}
@@ -1777,8 +1806,8 @@ func smash_object(object_index: int) -> Dictionary:
 	return {"ok": true, "object_index": object_index, "event_flag": object.event_flag}
 
 
-## RockMonEncounter over the imported RockMonMaps and the ROCK set. Unlike a
-## tree it carries no BATTLETYPE_TREE, so nothing about it can start asleep.
+## RockMonEncounter over the imported RockMonMaps and the ROCK set. No
+## BATTLETYPE_TREE, so nothing out of a rock starts asleep.
 func _rock_encounter(random: RandomNumberGenerator) -> Dictionary:
 	var set_number: int = data.treemon_set_for_map(
 		current_map.group, current_map.number, true
@@ -1901,7 +1930,7 @@ func strength_request(species: int = 0) -> Dictionary:
 	return _pending_strength.duplicate(true)
 
 
-## Empty until strength_request() succeeds. A host shows its text while this is set.
+## Empty until strength_request() succeeds.
 func pending_strength() -> Dictionary:
 	return _pending_strength.duplicate(true)
 
@@ -3717,10 +3746,10 @@ func _field_move_prompt_request(cell: Vector2i) -> Dictionary:
 
 
 ## TrySurfOW's own checks, less the badge and the party the runner makes: not
-## already surfing, facing water, and CheckDirection's face mask. The bike flag
-## is not modelled, since nothing in this project sets one.
+## already surfing, facing water, CheckDirection's face mask and the bike flag
+## Route 16 and Route 17 set.
 func _surf_prompt_applies(cell: Vector2i) -> bool:
-	if movement_mode == MOVEMENT_SURF:
+	if movement_mode == MOVEMENT_SURF or always_on_bike():
 		return false
 	if collision_permission_at(cell) != Gen2WorldCollision.WATER_TILE:
 		return false
@@ -5836,9 +5865,8 @@ func forced_movement() -> Dictionary:
 	return Gen2WorldCollision.forced_action(collision_code_at(player_cell))
 
 
-## Applies whatever the standing tile forces, with no input at all, because the
-## source polls .CheckTile every frame rather than only on a press. Empty when
-## the tile forces nothing.
+## Whatever the standing tile forces, with no input: the source polls .CheckTile
+## every frame rather than only on a press. Empty when the tile forces nothing.
 func advance_forced_movement() -> Dictionary:
 	var forced: Dictionary = forced_movement()
 	match StringName(forced.get("kind", &"none")):
@@ -5850,26 +5878,40 @@ func advance_forced_movement() -> Dictionary:
 
 
 ## PLAYERMOVEMENT_FORCE_TURN, which queues Script_ForcedMovement: it reads
-## VAR_FACING, the committed facing rather than the pressed direction, and applies
-## a stream of step_dig, turn_in and turn_head. None of those opcodes moves a cell,
-## so the whole effect is that the player is spun to face the way they came. A
-## player who surfs onto a whirlpool therefore cannot walk off it, which is the
-## cartridge's own behavior and not a gap here.
+## VAR_FACING and runs `step_dig 16`, `turn_in <back>`, `step_dig 16`,
+## `turn_head <back>`. `turn_in` reaches `TurningStep` and so `InitStep`, which
+## moves a cell, so a whirlpool spits the player back rather than holding them.
+## `step_dig` is `STEP_TYPE_SLEEP` with OBJECT_ACTION_SPIN: it spins in place.
 func _forced_turn() -> Dictionary:
-	player_facing = facing_for_direction(-_direction_for_facing(player_facing))
+	var back: Vector2i = -_direction_for_facing(player_facing)
+	var landing: Vector2i = player_cell + back
+	var from_cell: Vector2i = player_cell
+	if _cell_in_bounds(landing):
+		player_cell = landing
+		_advance_followers(-1, from_cell)
+	player_facing = facing_for_direction(back)
+	## `Movement_step_dig` seeds OBJECT_STEP_FRAME from its direction, so the spin
+	## opens on `.facings`' row for it rather than at DOWN.
+	_player_spin_frame = (TURNING_DIRECTION_ORDER.find(back) << 4) & 0x30
+	_queue_player_step(Vector2i.ZERO, FORCED_TURN_SLEEP_PASSES, false, back, &"step_dig")
+	if player_cell != from_cell:
+		_queue_player_step(back, STEP_PASSES_WALK, false, back, &"turn_in")
+	_queue_player_step(Vector2i.ZERO, FORCED_TURN_SLEEP_PASSES, false, back, &"step_dig")
 	return {
 		"ok": true,
 		"kind": &"forced_turn",
 		"cell": player_cell,
+		"from_cell": from_cell,
 		"facing": player_facing,
+		"passes": FORCED_TURN_SLEEP_PASSES * 2
+			+ (STEP_PASSES_WALK if player_cell != from_cell else 0),
 	}
 
 
 ## .continue_walk: STEP_WALK through .DoStep, which never consults permissions, so
-## a forced step commits into a cell an ordinary step would refuse. It reaches
-## .CheckTile before .TrySurf, so it also never runs .ExitWater: a forced step from
-## water onto land keeps the surfing state. No shipped map places a forced tile
-## where either matters; both are kept because the source has no guard for them.
+## a forced step commits into a cell an ordinary step would refuse, and reaches
+## .CheckTile before .TrySurf, so it never runs .ExitWater either. No shipped map
+## places a forced tile where either matters.
 func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
@@ -6067,25 +6109,46 @@ func _cell_at_connection_edge(cell: Vector2i, direction_name: String) -> bool:
 
 
 ## engine/overworld/map_setup.asm's CheckUpdatePlayerSprite, which every warp and
-## connection reaches through warp_connection.asm. The cartridge re-derives the
-## player state from the cell it lands on rather than carrying it over:
-## .CheckSurfing starts surfing on water and keeps an existing surf state,
-## .ResetSurfingOrBikingState restores PLAYER_NORMAL anywhere else. Without it a
-## warp taken from a water tile lands on dry land still surfing, where nothing
-## but water is a legal step. .CheckForcedBiking has no counterpart here.
+## connection reaches through warp_connection.asm: the player state is re-derived
+## from the cell landed on rather than carried over.
 func _apply_map_setup_player_state() -> void:
 	var mode: StringName = _setup_movement_mode(player_cell)
 	if mode == movement_mode:
 		return
 	movement_mode = mode
-	player_sprite_number = Gen2WorldSprite.SPRITE_SURF if mode == MOVEMENT_SURF \
-		else _walking_sprite()
+	player_sprite_number = _map_setup_sprite(mode)
 
 
+func _map_setup_sprite(mode: StringName) -> int:
+	if mode == MOVEMENT_SURF:
+		return Gen2WorldSprite.SPRITE_SURF
+	if mode == MOVEMENT_BIKE:
+		return Gen2WorldSprite.player_bike_sprite(_player_female)
+	return _walking_sprite()
+
+
+## `.ResetSurfingOrBikingState`'s three, and no more: a cave and a gate are
+## legal to ride through, which is why `.CheckEnvironment` mounts one there.
+const BIKE_DISMOUNT_ENVIRONMENTS: Array[int] = [
+	ENVIRONMENT_INDOOR, ENVIRONMENT_5, ENVIRONMENT_DUNGEON,
+]
+
+
+## `CheckUpdatePlayerSprite`'s three branches in its own order: `.CheckForcedBiking`,
+## then `.CheckSurfing`, then `.ResetSurfingOrBikingState`.
 func _setup_movement_mode(cell: Vector2i) -> StringName:
+	if state != null and state.is_engine_flag_active(
+		Gen2WorldState.always_on_bike_flag(data)
+	):
+		return MOVEMENT_BIKE
 	if collision_permission_at(cell) == Gen2WorldCollision.WATER_TILE:
 		return MOVEMENT_SURF
-	return MOVEMENT_WALK if movement_mode == MOVEMENT_SURF else movement_mode
+	if movement_mode == MOVEMENT_SURF:
+		return MOVEMENT_WALK
+	if movement_mode == MOVEMENT_BIKE and current_map != null \
+		and BIKE_DISMOUNT_ENVIRONMENTS.has(current_map.environment):
+		return MOVEMENT_WALK
+	return movement_mode
 
 
 func _apply_map(
@@ -6349,14 +6412,10 @@ func visited_flypoints() -> Array[int]:
 	return out
 
 
-## `SweetScentEncounter`, the whole of what the party submenu's SWEET SCENT row
-## does: a wild appears where one could have been stepped into.
-##
-## Its own gates, in the source's order: `CanEncounterWildMon` for the tile,
-## then the Bug Contest's own tables, then the map's rate and
-## `ChooseWildEncounter`. The rate is read but never rolled against, which is
-## what makes the move worth using; the five-step cooldown a map entry sets is
-## not consulted either, since nothing here is a step.
+## `SweetScentEncounter`: a wild appears where one could have been stepped into.
+## Its gates in the source's order are `CanEncounterWildMon`, the Bug Contest's
+## own tables, then the map's rate and `ChooseWildEncounter`. The rate is read
+## and never rolled against, and no step means no cooldown either.
 func sweet_scent_request(random: RandomNumberGenerator = null) -> Dictionary:
 	if current_map == null or data == null:
 		return _sweet_scent_failure(&"missing_map")
@@ -6379,14 +6438,10 @@ static func _sweet_scent_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"sweet_scent_failed", "reason": reason}
 
 
-## `TeleportFunction`: the outdoor-only escape to wherever the last Pokemon
-## Center was. Its whole test is the map being outdoors and the last spawn map
-## being a spawn point, and it checks no badge at all.
-##
-## The warp is applied here rather than staged, because `.TeleportScript` is the
-## source's own script and everything in it but its shared tail is animation
-## this project has no frames for. That tail is [method _escape_map_tail], which
-## [method warp_to_spawn] runs.
+## `TeleportFunction`: the outdoor-only escape to the last Pokemon Center, whose
+## whole test is the map being outdoors and that spawn being a spawn point. No
+## badge. Applied rather than staged, since everything in `.TeleportScript` but
+## [method _escape_map_tail] is animation this project has no frames for.
 func teleport_request() -> Dictionary:
 	if current_map == null:
 		return _teleport_failure(&"missing_map")
@@ -6412,12 +6467,9 @@ static func _teleport_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"teleport_failed", "reason": reason}
 
 
-## `DigFunction`, which is `EscapeRopeOrDig` with the Dig half of its type byte:
-## a cave or a dungeon, and a recorded dig warp, and out through the warp the
-## player came in by.
-##
-## The source keeps three separate bytes and refuses when any is zero, which is
-## the same test as this project's record being empty.
+## `DigFunction`, `EscapeRopeOrDig` with the Dig half of its type byte: a cave or
+## a dungeon and a recorded dig warp, out through the warp the player came in by.
+## The source's three bytes each refusing on zero is this record being empty.
 func dig_request() -> Dictionary:
 	if current_map == null:
 		return _dig_failure(&"missing_map")
@@ -6464,7 +6516,7 @@ func bike_request() -> Dictionary:
 		}
 	if movement_mode != MOVEMENT_BIKE:
 		return _bike_failure(&"cannot_use_bike")
-	if state.is_engine_flag_active(Gen2WorldState.always_on_bike_flag(data)):
+	if always_on_bike():
 		return _bike_failure(&"always_on_bike")
 	movement_mode = MOVEMENT_WALK
 	player_sprite_number = _walking_sprite()
@@ -6473,6 +6525,13 @@ func bike_request() -> Dictionary:
 		"music": map_music_track(),
 		"sprite": player_sprite_number,
 	}
+
+
+## `BIKEFLAGS_ALWAYS_ON_BIKE_F`: Route 16 and Route 17 set it, and it refuses
+## both getting off and surfing.
+func always_on_bike() -> bool:
+	return state != null \
+		and state.is_engine_flag_active(Gen2WorldState.always_on_bike_flag(data))
 
 
 ## `.CheckEnvironment`: outdoors, a cave or a gate, and standing on a tile whose
@@ -6499,6 +6558,11 @@ func escape_rope_request() -> Dictionary:
 	var checked: StringName = _check_can_dig()
 	if checked != &"":
 		return _escape_rope_failure(checked)
+	## `.escaperope`'s `farcall SpecialKabutoChamber`, which runs while the
+	## chamber is still the loaded map.
+	var wall_event: int = unown_wall_event(EVENT_WALL_OPENED_IN_KABUTO_CHAMBER)
+	if wall_event >= 0:
+		state.set_event_flag(wall_event, true)
 	var warped: Dictionary = warp_to_dig_point()
 	if not bool(warped.get("ok", false)):
 		return _escape_rope_failure(StringName(warped.get("reason", &"no_dig_warp")))
@@ -6506,6 +6570,7 @@ func escape_rope_request() -> Dictionary:
 		"ok": true,
 		"kind": &"escape_rope_requested",
 		"warp": warped,
+		"wall_event": wall_event,
 	}
 
 
@@ -6528,13 +6593,11 @@ static func _escape_rope_failure(reason: StringName) -> Dictionary:
 
 
 ## `CheckForHiddenItems`, the whole of the Itemfinder: a BGEVENT_ITEM whose flag
-## is still clear, inside the screen the player stands in the middle of. The window
-## is the source's own arithmetic on the bottom right corner, four cells up and
-## left of the player and four down and five right. Below, every BGEVENT_ITEM on
-## the current map as `{cell, item, flag, taken}` whether or not it has been picked
-## up, read and scene-free so a probe can walk a map with no game running. The
-## map's own events and nothing past them; an event whose three bytes do not decode
-## is dropped rather than offered with a zero item.
+## is still clear, inside the screen the player stands in the middle of, which is
+## four cells up and left and four down and five right. Below, every BGEVENT_ITEM
+## on the map as `{cell, item, flag, taken}` whether or not it has been taken, and
+## scene-free so a probe can walk a map with no game running. An event whose three
+## bytes do not decode is dropped rather than offered with a zero item.
 func hidden_items() -> Array:
 	var out: Array = []
 	if current_map == null:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -870,9 +870,9 @@ static func jump_offset_at(spent: int, total: int) -> int:
 
 
 ## How far above the ground the player is drawn this frame, in world pixels and
-## positive upward. Zero at rest, on an ordinary step, and on the frame a hop
-## completes. Presentation only: the cell, the collision, the triggers and the
-## snapshot are already at the landing cell while this is above zero.
+## positive upward. Zero at rest, on an ordinary step and on the frame a hop
+## completes. Presentation only: the cell, the collision and the triggers are at
+## the landing cell while this is above zero.
 func player_height_offset_pixels() -> float:
 	return float(-player_jump_offset())
 
@@ -880,8 +880,8 @@ func player_height_offset_pixels() -> float:
 ## The in-flight step's presentation offset in fractional walk cells, from 1.0
 ## cell behind player_cell down to zero, so a renderer that does not think in
 ## hardware pixels can smooth against it without reverse-engineering CELL_PIXELS.
-## A scripted movement commits its whole path at once, so while its trail drains
-## this is as many cells behind as the player has left to be drawn walking.
+## A scripted movement commits its path at once, so while its trail drains this is
+## as many cells behind as the player has left to be drawn walking.
 func player_step_offset_cells() -> Vector2:
 	var behind := Vector2.ZERO
 	for entry: Dictionary in _player_queued_steps:
@@ -890,6 +890,27 @@ func player_step_offset_cells() -> Vector2:
 		behind -= Vector2(_player_step_direction) \
 			* (float(_player_step_passes_remaining) / float(_player_step_passes_total))
 	return behind
+
+
+## The two cells the step in flight runs between: `{from, to, progress, kind}`,
+## and `{}` while nothing steps. [method player_step_offset_cells] is this summed
+## over the run, which cannot be taken apart again once a stream turns. A renderer
+## whose plan is not a plain grid puts both ends through its own geometry and
+## moves between the answers, which a fractional cell cannot do across a fold.
+func player_step_span() -> Dictionary:
+	if _player_step_passes_remaining <= 0 or _player_step_passes_total <= 0:
+		return {}
+	var ahead := Vector2i.ZERO
+	for entry: Dictionary in _player_queued_steps:
+		ahead += entry["direction"] as Vector2i
+	var landing: Vector2i = player_cell - ahead
+	return {
+		"from": landing - _player_step_direction,
+		"to": landing,
+		"progress": 1.0 - float(_player_step_passes_remaining) \
+			/ float(_player_step_passes_total),
+		"kind": _player_step_kind,
+	}
 
 
 ## Which movement the step in flight is, so a renderer draws a waterfall climb as
@@ -1843,9 +1864,8 @@ static func _rock_smash_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"rock_smash_failed", "reason": reason}
 
 
-## Mirrors the selected save's wPlayerID, the way set_party_summary() mirrors
-## its party. Gen2WorldAPI owns no save, so this stays optional and unset
-## refuses rather than scoring against zero.
+## Mirrors the selected save's wPlayerID, as set_party_summary() mirrors its
+## party. Unset refuses rather than scoring against zero.
 func set_player_id(new_player_id: int) -> Dictionary:
 	if new_player_id < 0 or new_player_id > 0xFFFF:
 		return {"ok": false, "reason": &"invalid_player_id", "player_id": new_player_id}
@@ -1868,8 +1888,7 @@ func player_name() -> String:
 
 
 ## `GetPlayerSprite`'s table choice, mirrored from the save. Setting it re-runs
-## the PLAYER_NORMAL lookup, which is what a map load does, so a world already
-## open picks the new sprite up without waiting for a warp.
+## the PLAYER_NORMAL lookup a map load does, so an open world picks it up at once.
 func set_player_gender(female: bool) -> Dictionary:
 	_player_female = female and Gen2WorldState.is_crystal_profile(data)
 	if movement_mode == MOVEMENT_WALK:
@@ -1882,7 +1901,7 @@ func player_female() -> bool:
 
 
 ## `InitPlayerObject` writes the palette onto the player object rather than
-## reading the sprite's own default row, so the renderer is told which one.
+## reading the sprite's default row, so the renderer is told which one.
 func player_palette() -> int:
 	return Gen2WorldSprite.player_palette(_player_female)
 
@@ -5932,13 +5951,12 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 
 
 ## `.CheckStrengthBoulder`, then the boulder's own `MovementFunction_Strength`.
-## The source splits these across two frames, but nothing observable sits between
-## the two, so both are resolved here in one call; the player is not moved either
-## way and the caller still reports a blocked step. Refusals in the source's own
-## order: BIKEFLAGS_STRENGTH_ACTIVE_F, a boulder that is not standing, then the
-## destination the boulder would take. The boulder's own cell being a pit stops it
-## permanently, which is Blackthorn Gym 2F's puzzle. [param destination]'s
-## permission is checked here because `.CheckLandPerms` runs before `.CheckNPC`.
+## The source splits these across two frames with nothing observable between, so
+## both resolve in one call; the player is not moved and the caller still reports
+## a blocked step. Refusals in order: BIKEFLAGS_STRENGTH_ACTIVE_F, a boulder that
+## is not standing, then the destination it would take. A boulder standing on a
+## pit stops for good, which is Blackthorn Gym 2F's puzzle. [param destination]'s
+## permission is read here because `.CheckLandPerms` runs before `.CheckNPC`.
 func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	if not strength_active():
 		return {}
@@ -6412,10 +6430,9 @@ func visited_flypoints() -> Array[int]:
 	return out
 
 
-## `SweetScentEncounter`: a wild appears where one could have been stepped into.
-## Its gates in the source's order are `CanEncounterWildMon`, the Bug Contest's
-## own tables, then the map's rate and `ChooseWildEncounter`. The rate is read
-## and never rolled against, and no step means no cooldown either.
+## `SweetScentEncounter`: a wild where one could have been stepped into. Its
+## gates in order are `CanEncounterWildMon`, the Bug Contest's tables, then the
+## rate and `ChooseWildEncounter`. The rate is read and never rolled against.
 func sweet_scent_request(random: RandomNumberGenerator = null) -> Dictionary:
 	if current_map == null or data == null:
 		return _sweet_scent_failure(&"missing_map")
@@ -6593,9 +6610,8 @@ static func _escape_rope_failure(reason: StringName) -> Dictionary:
 
 
 ## `CheckForHiddenItems`, the whole of the Itemfinder: a BGEVENT_ITEM whose flag
-## is still clear, inside the screen the player stands in the middle of, which is
-## four cells up and left and four down and five right. Below, every BGEVENT_ITEM
-## on the map as `{cell, item, flag, taken}` whether or not it has been taken, and
+## is still clear, four cells up and left of the player and four down and five
+## right. Below, every BGEVENT_ITEM on the map as `{cell, item, flag, taken}`,
 ## scene-free so a probe can walk a map with no game running. An event whose three
 ## bytes do not decode is dropped rather than offered with a zero item.
 func hidden_items() -> Array:

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -127,7 +127,9 @@ static func put_away_text(name: String) -> String:
 
 ## `PutAwayAndSetUpText`, whose second half is a `para` rather than a line.
 static func put_away_and_set_up_text(put_away: String, set_up: String) -> String:
-	return "Put away the\n%s\n\nand set up the\n%s." % [put_away, set_up]
+	return "Put away the\n%s%sand set up the\n%s." % [
+		put_away, Gen2TextStream.PAGE_BREAK, set_up,
+	]
 
 
 ## `GetDecoName`: a row's type decides which parts its name is spelled from, and

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -152,6 +152,44 @@ const HM_FIELD_MOVES: Array[int] = [
 ]
 
 
+## What each move's own script writes, from data/text/common_2.asm, kept here
+## because the party submenu, the A-press prompt and the script runner all say
+## them. `%s` is `GetPartyNickname`'s buffer and each break is the source's own
+## `line`, which a name short enough to fit one line would otherwise lose.
+const USED_TEXTS: Dictionary = {
+	MOVE_CUT: "%s used\nCUT!",
+	MOVE_SURF: "%s used\nSURF!",
+	MOVE_STRENGTH: "%s used\nSTRENGTH!",
+	MOVE_WHIRLPOOL: "%s used\nWHIRLPOOL!",
+	MOVE_WATERFALL: "%s used\nWATERFALL!",
+	MOVE_HEADBUTT: "%s did a\nHEADBUTT!",
+	MOVE_ROCK_SMASH: "%s used\nROCK SMASH!",
+	MOVE_SWEET_SCENT: "%s used\nSWEET SCENT!",
+	MOVE_DIG: "%s used\nDIG!",
+	## `_BlindingFlashText` and `_TeleportReturnText`: neither script calls
+	## GetPartyNickname, so neither line names anyone.
+	MOVE_FLASH: "A blinding FLASH\nlights the area!",
+	MOVE_TELEPORT: "Return to the last\n#MON CENTER.",
+}
+
+## `FieldMoveFailed`'s `_CantUseItemText`, shared by every move with no refusal
+## of its own, and the five that have one.
+const CANT_USE_TEXT: String = "Can't use that\nhere."
+const BADGE_REQUIRED_TEXT: String = "Sorry! A new BADGE\nis required."
+const CUT_NOTHING_TEXT: String = "There's nothing to\nCUT here."
+const CANT_SURF_TEXT: String = "You can't SURF\nhere."
+const ALREADY_SURFING_TEXT: String = "You're already\nSURFING."
+const HEADBUTT_NOTHING_TEXT: String = "Nope. Nothing…"
+const SWEET_SCENT_NOTHING_TEXT: String = "Looks like there's\nnothing here…"
+
+
+## [constant USED_TEXTS]' row with the nickname filled in, or "" for a move with
+## no line of its own.
+static func used_text(move: int, user: String) -> String:
+	var text: String = String(USED_TEXTS.get(move, ""))
+	return text % user if text.contains("%s") else text
+
+
 static func is_field_move(move: int) -> bool:
 	return FIELD_MOVES.has(move)
 

--- a/game/world/world_movement.gd
+++ b/game/world/world_movement.gd
@@ -10,10 +10,12 @@ const MAX_BYTES: int = 128
 const MAX_COMMANDS: int = 128
 const STEP_END: int = 0x47
 
-## The three commands reaching `TurningStep` rather than `NormalStep`
-## (engine/overworld/movement.asm). It sets OBJECT_ACTION_SPIN, so the walker
-## spins counterclockwise instead of facing the way it is going.
-const SPINNING_KINDS: Array[StringName] = [&"turn_away", &"turn_in", &"turn_waterfall"]
+## The commands that set OBJECT_ACTION_SPIN, so the walker spins counterclockwise
+## instead of facing the way it is going: the three reaching `TurningStep` rather
+## than `NormalStep`, and `Movement_step_dig`, which spins standing still.
+const SPINNING_KINDS: Array[StringName] = [
+	&"turn_away", &"turn_in", &"turn_waterfall", &"step_dig",
+]
 
 ## `CounterclockwiseSpinAction`'s `.facings`.
 const SPIN_FACINGS: Array[int] = [

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -469,7 +469,7 @@ func walk_frame() -> int:
 	return (step_frame >> 2) & 3
 
 
-## The facing this object is DRAWN with; [member facing] never moves.
+## The facing this object is DRAWN with while a spin walks.
 ## See [constant Gen2WorldMovement.SPINNING_KINDS].
 func drawn_facing() -> int:
 	if step_passes_remaining > 0 and step_kind in Gen2WorldMovement.SPINNING_KINDS:

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -523,3 +523,19 @@ func step_offset_cells() -> Vector2:
 		behind -= Vector2(step_direction) \
 			* (float(step_passes_remaining) / float(step_passes_total))
 	return behind
+
+
+## [method Gen2WorldAPI.player_step_span] for an object.
+func step_span() -> Dictionary:
+	if step_passes_remaining <= 0 or step_passes_total <= 0:
+		return {}
+	var ahead := Vector2i.ZERO
+	for entry: Dictionary in queued_steps:
+		ahead += entry["direction"] as Vector2i
+	var landing: Vector2i = cell - ahead
+	return {
+		"from": landing - step_direction,
+		"to": landing,
+		"progress": 1.0 - float(step_passes_remaining) / float(step_passes_total),
+		"kind": step_kind,
+	}

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -45,6 +45,9 @@ const SFX_STRENGTH: int = 0x1B
 ## constants/sfx_constants.asm's SFX_BUBBLEBEAM, which Script_UsedWaterfall plays
 ## after its text and before the first climbing step.
 const SFX_WATERFALL: int = 0x51
+## constants/sfx_constants.asm's SFX_FLASH, played by `UseFlashTextScript`'s own
+## `text_asm` rather than by `BlindingFlash`, which fades in silence.
+const SFX_FLASH: int = 0xA9
 ## constants/sfx_constants.asm's SFX_SANDSTORM, which is what ShakeHeadbuttTree
 ## plays (engine/events/field_moves.asm). SFX_HEADBUTT is a battle-move effect
 ## and is referenced by nothing in either pin's overworld code.
@@ -1095,16 +1098,15 @@ func _advance_day_cycle(delta: float) -> void:
 ## `.CheckTile`'s forced walk, which the source polls every frame with no input: a
 ## waterfall pushes the player back down and a door, staircase or cave tile steps
 ## them off it. The step already in progress paces it.
-## PLAYERMOVEMENT_FORCE_TURN is deliberately not drained here: its
-## `Script_ForcedMovement` is a queued script whose two step_dig runs pace the
-## spin, and this project renders none of that, so draining it per frame would flip
-## the facing at the frame rate. `move_result()` answers it on the movement attempt
-## instead, which is where a player meets it.
+## PLAYERMOVEMENT_FORCE_TURN is drained here too: `.CheckTile` reads the standing
+## tile before `.GetAction`'s direction is honoured, so a whirlpool spits the
+## player back out with nothing pressed. Its own run is what stops it repeating,
+## since the cell it leaves them on is not a whirlpool.
 func _advance_forced_movement() -> void:
 	if not _objects_may_move() or _world.script_input_waiting() \
 		or _world.player_step_in_progress():
 		return
-	if StringName(_world.forced_movement().get("kind", &"none")) != &"walk":
+	if StringName(_world.forced_movement().get("kind", &"none")) == &"none":
 		return
 	var forced: Dictionary = _world.advance_forced_movement()
 	if bool(forced.get("ok", false)):
@@ -6189,8 +6191,7 @@ func _on_start_menu_field_move(action: Dictionary) -> void:
 
 
 ## What a chosen field action does, whichever list chose it. A slot of -1 is a
-## move used from its own HM rather than by a party member, which changes the
-## name in the text and the Surf sprite and nothing else.
+## move used from its own HM, which changes the name and the Surf sprite only.
 func _run_party_action(action: Dictionary) -> void:
 	# `PokemonActionSubmenu`'s `.quit` reaches `ExitAllMenus`, so a field move
 	# leaves the overworld rather than reopening the menu behind it.
@@ -6212,55 +6213,58 @@ func _run_party_action(action: Dictionary) -> void:
 
 
 ## Each field move: what it asks the world, the refusal, the line and what
-## follows it. [param user] is in the text already: Teleport's
-## `_TeleportReturnText` names nobody.
+## follows it. Every line is [constant Gen2WorldFieldMove.USED_TEXTS]' own. Fly
+## is the one row with no line: its script writes nothing before the region map.
 func _field_move_rows(slot: int, user: String) -> Dictionary:
+	var says: Callable = Gen2WorldFieldMove.used_text.bind(user)
 	return {
 		Gen2WorldFieldMove.MOVE_CUT: [
-			_world.cut_request, _cut_refusal, "%s used CUT!" % user, Callable(),
+			_world.cut_request, _cut_refusal,
+			says.call(Gen2WorldFieldMove.MOVE_CUT), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_SURF: [
 			_world.surf_request.bind(_party_species(slot)), _surf_refusal,
-			"%s used SURF!" % user, Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_SURF), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_STRENGTH: [
 			_world.strength_request.bind(_party_species(slot)), _strength_refusal,
-			"%s used STRENGTH!" % user, Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_STRENGTH), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_WHIRLPOOL: [
 			_world.whirlpool_request, _whirlpool_refusal,
-			"%s used WHIRLPOOL!" % user, Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_WHIRLPOOL), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_WATERFALL: [
 			_world.waterfall_request, _waterfall_refusal,
-			"%s used WATERFALL!" % user, Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_WATERFALL), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_FLASH: [
-			_world.flash_request, _flash_refusal, "%s used FLASH!" % user, Callable(),
+			_world.flash_request, _flash_refusal,
+			says.call(Gen2WorldFieldMove.MOVE_FLASH), Callable(),
 		],
-		## _UseHeadbuttText is "did a HEADBUTT!", not the "used" the others share.
 		Gen2WorldFieldMove.MOVE_HEADBUTT: [
 			_world.headbutt_request, _field_move_refused,
-			"%s did a HEADBUTT!" % user, Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_HEADBUTT), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_ROCK_SMASH: [
 			_world.rock_smash_request, _field_move_refused,
-			"%s used ROCK SMASH!" % user, Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_ROCK_SMASH), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_FLY: [
 			_world.fly_request, _field_move_refused, "", _open_fly_map,
 		],
 		Gen2WorldFieldMove.MOVE_SWEET_SCENT: [
-			_world.sweet_scent_request.bind(_encounter_random), _sweet_scent_refusal,
-			"%s used SWEET SCENT!" % user, _after_sweet_scent,
+			_world.sweet_scent_request.bind(_encounter_random),
+			_sweet_scent_refusal.bind(user),
+			says.call(Gen2WorldFieldMove.MOVE_SWEET_SCENT), _after_sweet_scent,
 		],
 		Gen2WorldFieldMove.MOVE_DIG: [
-			_world.dig_request, _field_move_refused, "%s used DIG!" % user,
-			_after_escape,
+			_world.dig_request, _field_move_refused,
+			says.call(Gen2WorldFieldMove.MOVE_DIG), _after_escape,
 		],
 		Gen2WorldFieldMove.MOVE_TELEPORT: [
 			_world.teleport_request, _field_move_refused,
-			"Return to the last\n#MON CENTER.", _after_escape,
+			says.call(Gen2WorldFieldMove.MOVE_TELEPORT), _after_escape,
 		],
 	}
 
@@ -6317,48 +6321,49 @@ func _party_species(slot: int) -> int:
 func _cut_refusal(reason: StringName) -> String:
 	match reason:
 		&"badge_required":
-			return "Sorry! A new BADGE is required."
+			return Gen2WorldFieldMove.BADGE_REQUIRED_TEXT
 		&"nothing_to_cut":
-			return "There's nothing to CUT here."
-	return "Can't use that here."
+			return Gen2WorldFieldMove.CUT_NOTHING_TEXT
+	return Gen2WorldFieldMove.CANT_USE_TEXT
 
 
 func _surf_refusal(reason: StringName) -> String:
 	match reason:
 		&"badge_required":
-			return "Sorry! A new BADGE is required."
+			return Gen2WorldFieldMove.BADGE_REQUIRED_TEXT
 		&"already_surfing":
-			return "You're already SURFING."
+			return Gen2WorldFieldMove.ALREADY_SURFING_TEXT
 		&"cannot_surf":
-			return "You can't SURF here."
-	return "Can't use that here."
+			return Gen2WorldFieldMove.CANT_SURF_TEXT
+	return Gen2WorldFieldMove.CANT_USE_TEXT
 
 
 ## .FailWhirlpool has no text of its own; see [method _field_move_refused]. Cut
 ## is the exception, not the rule.
 func _whirlpool_refusal(reason: StringName) -> String:
-	if reason == &"badge_required":
-		return "Sorry! A new BADGE is required."
-	return "Can't use that here."
+	return _badge_or_generic(reason)
 
 
 ## CheckMapCanWaterfall has no message at all, so only the badge has a line.
 func _waterfall_refusal(reason: StringName) -> String:
-	if reason == &"badge_required":
-		return "Sorry! A new BADGE is required."
-	return "Can't use that here."
+	return _badge_or_generic(reason)
 
 
 ## A lit map has no refusal text of its own; only the badge has a line.
 func _flash_refusal(reason: StringName) -> String:
-	if reason == &"badge_required":
-		return "Sorry! A new BADGE is required."
-	return "Can't use that here."
+	return _badge_or_generic(reason)
 
 
-## `SweetScentNothing`: a tile with no wild says what a map with no table does.
-func _sweet_scent_refusal(_reason: StringName) -> String:
-	return "Looks like there's\nnothing here…"
+func _badge_or_generic(reason: StringName) -> String:
+	return Gen2WorldFieldMove.BADGE_REQUIRED_TEXT if reason == &"badge_required" \
+		else Gen2WorldFieldMove.CANT_USE_TEXT
+
+
+## `SweetScentNothing`, which `.SweetScent` reaches only after its own
+## `writetext`/`waitbutton`: the miss is a second box, not the only one.
+func _sweet_scent_refusal(_reason: StringName, user: String) -> String:
+	return Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_SWEET_SCENT, user) \
+		+ Gen2TextStream.PAGE_BREAK + Gen2WorldFieldMove.SWEET_SCENT_NOTHING_TEXT
 
 
 ## `FieldMoveFailed`, shared by every field move with no text of its own: Fly's
@@ -6367,15 +6372,13 @@ func _sweet_scent_refusal(_reason: StringName) -> String:
 ## `AskRockSmashScript`'s `_MaySmashText` belongs to the other path, where the
 ## runner owns it, and Headbutt is gated on `CheckPartyMove` and the tile alone.
 func _field_move_refused(_reason: StringName) -> String:
-	return "Can't use that here."
+	return Gen2WorldFieldMove.CANT_USE_TEXT
 
 
 ## .TryStrength's only refusal is CheckBadge's, since it checks nothing else;
 ## anything past it is this project's own guard, not a cartridge branch.
 func _strength_refusal(reason: StringName) -> String:
-	if reason == &"badge_required":
-		return "Sorry! A new BADGE is required."
-	return "Can't use that here."
+	return _badge_or_generic(reason)
 
 
 ## `GiveTakePartyMonItem`'s two answers. TAKE is a bag transaction and says so in
@@ -6523,10 +6526,8 @@ func _show_field_move_text(text: String, blink_cursor: bool = true) -> void:
 
 
 ## The acknowledge that closes a field-move message. A staged move commits here
-## rather than when it was resolved, because Script_Cut only reaches
-## CutDownTreeOrGrass after UseCutText and UsedSurfScript only reaches
-## SurfStartStep after its waitbutton. A refusal has nothing staged and just
-## closes.
+## rather than when it was resolved: Script_Cut reaches CutDownTreeOrGrass only
+## after UseCutText, and UsedSurfScript SurfStartStep only after its waitbutton.
 func _acknowledge_field_move_text() -> void:
 	## A text longer than the box is several `waitbutton`s, so a press with a page
 	## still behind it spends itself on the box rather than on the move. A
@@ -6581,10 +6582,9 @@ func _acknowledge_field_move_text() -> void:
 	_refresh_labels()
 
 
-## Each commit reports its own audio, below. Strength is the one that plays
-## nothing: Script_UsedStrength has no PlaySFX, because SFX_STRENGTH belongs to
-## the boulder that moves later rather than to the flag being set, and neither
-## does Flash. All redraw anyway, since the party overlay closed over the map.
+## Each commit reports its own audio. Strength plays nothing: SFX_STRENGTH
+## belongs to the boulder that moves later, not to the flag being set. All redraw
+## anyway, since the party overlay closed over the map.
 func _commit_field_move(applied: Dictionary, label: String) -> void:
 	if bool(applied.get("ok", false)):
 		match StringName(applied.get("kind", &"")):
@@ -6597,10 +6597,9 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 			&"waterfall_applied":
 				_play_sfx(SFX_WATERFALL)
 			&"flash_used":
-				# BlindingFlash has no sound of its own: it fades to white,
-				# swaps the palette set and fades back. The palette is the whole
-				# of what changed, so the renderer is told the new row rather
-				# than just asked to redraw.
+				# The palette is the whole of what BlindingFlash changed, so the
+				# renderer is told the new row rather than asked to redraw.
+				_play_sfx(SFX_FLASH)
 				if _renderer != null:
 					_renderer.set_time_of_day(_render_time_of_day())
 				if _animation != null:
@@ -6640,13 +6639,12 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 	_refresh_labels()
 
 
-## HeadbuttScript after ShakeHeadbuttTree: TreeMonEncounter either sets
-## wScriptVar and reaches startbattle, or falls to .no_battle, which is
-## HeadbuttNothingText and a waitbutton. The tree is unchanged either way.
+## HeadbuttScript after ShakeHeadbuttTree: TreeMonEncounter either reaches
+## startbattle or falls to `.no_battle`. The tree is unchanged either way.
 func _finish_headbutt(applied: Dictionary) -> void:
 	var encounter: Variant = applied.get("encounter", {})
 	if not encounter is Dictionary or (encounter as Dictionary).is_empty():
-		_show_field_move_text("Nope. Nothing…")
+		_show_field_move_text(Gen2WorldFieldMove.HEADBUTT_NOTHING_TEXT)
 		return
 	_refresh_labels()
 	_start_battle_request({
@@ -6657,8 +6655,7 @@ func _finish_headbutt(applied: Dictionary) -> void:
 
 
 ## RockSmashScript after the rock is gone: RockMonEncounter either reaches
-## startbattle or the script ends. Unlike Headbutt there is no nothing-text,
-## because `.done` is a bare `end`.
+## startbattle or `.done`, a bare `end` with no nothing-text.
 func _finish_rock_smash(applied: Dictionary) -> void:
 	var encounter: Variant = applied.get("encounter", {})
 	if not encounter is Dictionary or (encounter as Dictionary).is_empty():
@@ -7285,39 +7282,29 @@ func _spawn_grass_rustles() -> void:
 		_renderer.refresh()
 
 
-## The yes half of an Ask*Script. Each move's own request is what decides
-## whether anything happens, exactly as in the submenu path; the difference is
-## that a refusal here is silent, because AskCutScript's `.CheckMap` failure
-## falls straight to `closetext` with no text of its own.
+## The yes half of an Ask*Script, running the same request the submenu does. A
+## refusal is silent here: AskCutScript's `.CheckMap` falls to `closetext`.
 func _use_prompted_field_move(move: int, slot: int) -> void:
 	if _world == null:
 		return
-	var requested: Dictionary = {}
-	var label: String = ""
-	match move:
-		Gen2WorldFieldMove.MOVE_CUT:
-			requested = _world.cut_request()
-			label = "used CUT!"
-		Gen2WorldFieldMove.MOVE_SURF:
-			requested = _world.surf_request(_party_species(slot))
-			label = "used SURF!"
-		Gen2WorldFieldMove.MOVE_WHIRLPOOL:
-			requested = _world.whirlpool_request()
-			label = "used WHIRLPOOL!"
-		Gen2WorldFieldMove.MOVE_WATERFALL:
-			requested = _world.waterfall_request()
-			label = "used WATERFALL!"
-		Gen2WorldFieldMove.MOVE_HEADBUTT:
-			requested = _world.headbutt_request()
-			label = "did a HEADBUTT!"
-	if not bool(requested.get("ok", false)):
+	var asks: Dictionary = {
+		Gen2WorldFieldMove.MOVE_CUT: _world.cut_request,
+		Gen2WorldFieldMove.MOVE_SURF: _world.surf_request.bind(_party_species(slot)),
+		Gen2WorldFieldMove.MOVE_WHIRLPOOL: _world.whirlpool_request,
+		Gen2WorldFieldMove.MOVE_WATERFALL: _world.waterfall_request,
+		Gen2WorldFieldMove.MOVE_HEADBUTT: _world.headbutt_request,
+	}
+	if not asks.has(move):
 		return
-	_show_field_move_text("%s %s" % [_prompted_field_move_name(slot), label])
+	if not bool(((asks[move] as Callable).call() as Dictionary).get("ok", false)):
+		return
+	_show_field_move_text(
+		Gen2WorldFieldMove.used_text(move, _prompted_field_move_name(slot))
+	)
 
 
-## GetPartyNickname, which every one of these scripts calls before its own text.
-## A move used from its HM rather than from a party member has no nickname to
-## read, so the line says who did use it: `<PLAYER> used CUT!`.
+## GetPartyNickname, which every one of these scripts calls before its text. A
+## move used from its HM has no nickname, so the line names the player instead.
 func _prompted_field_move_name(slot: int) -> String:
 	if slot < 0:
 		return _player_display_name()
@@ -7328,9 +7315,8 @@ func _prompted_field_move_name(slot: int) -> String:
 	return _mon_display_name(member as Gen2SaveMon) if member is Gen2SaveMon else "#MON"
 
 
-## `PlaceString`'s own `<PLAYER>`, which is `wPlayerName`. A world with no save
-## selected is a screenshot tool or a test and says PLAYER, the same fallback
-## the start menu's STATUS row takes.
+## `PlaceString`'s `<PLAYER>`, which is `wPlayerName`. With no save selected it
+## says PLAYER, the fallback the start menu's STATUS row takes.
 func _player_display_name() -> String:
 	var player: String = _world.player_name() if _world != null else ""
 	return player if not player.is_empty() else "PLAYER"

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -415,16 +415,17 @@ const STRENGTH_OW_ALREADY_ACTIVE: int = 2
 ## that shows them is reached only through `callasm`, which has no runner; see
 ## _stage_strength_boulder().
 const STRENGTH_ASK_TEXT: String = \
-	"A #MON may be\nable to move this.\n\nWant to use\nSTRENGTH?"
+	"A #MON may be\nable to move this." + Gen2TextStream.PAGE_BREAK \
+	+ "Want to use\nSTRENGTH?"
 const STRENGTH_MAY_MOVE_TEXT: String = "A #MON may be\nable to move this."
 const STRENGTH_BOULDERS_MOVE_TEXT: String = "Boulders may now\nbe moved!"
 ## data/text/common_2.asm again, for AskRockSmashScript. `HasRockSmash` answers
 ## 1 when CheckPartyMove fails, which is the `ifequal 1, .no` that reaches
 ## _MaySmashText; anything else asks.
 const ROCK_SMASH_ASK_TEXT: String = \
-	"This rock looks\nbreakable.\n\nWant to use ROCK\nSMASH?"
+	"This rock looks\nbreakable." + Gen2TextStream.PAGE_BREAK \
+	+ "Want to use ROCK\nSMASH?"
 const ROCK_SMASH_MAY_SMASH_TEXT: String = "Maybe a #MON\ncan break this."
-const ROCK_SMASH_USED_TEXT: String = "%s used\nROCK SMASH!"
 ## Script_earthquake's operand in RockSmashScript, kept because the runner
 ## reports the request rather than shaking anything.
 const ROCK_SMASH_EARTHQUAKE: int = 84
@@ -436,17 +437,21 @@ const SFX_STRENGTH: int = 0x1B
 ## reaches. Synthesized rather than decoded for the reason AskStrengthScript's
 ## are: each is reached through `CallScript` on a link-time address, so there is
 ## no pointer in the pins to follow. All five are byte identical between them.
-const CUT_ASK_TEXT: String = "This tree can be\nCUT!\n\nWant to use CUT?"
+const CUT_ASK_TEXT: String = "This tree can be\nCUT!" \
+	+ Gen2TextStream.PAGE_BREAK + "Want to use CUT?"
 const CUT_CAN_TEXT: String = "This tree can be\nCUT!"
 const SURF_ASK_TEXT: String = "The water is calm.\nWant to SURF?"
 const WHIRLPOOL_ASK_TEXT: String = \
-	"A whirlpool is in\nthe way.\n\nWant to use\nWHIRLPOOL?"
+	"A whirlpool is in\nthe way." + Gen2TextStream.PAGE_BREAK \
+	+ "Want to use\nWHIRLPOOL?"
 const WHIRLPOOL_MAY_PASS_TEXT: String = \
-	"It's a vicious\nwhirlpool!\n\nA #MON may be\nable to pass it."
+	"It's a vicious\nwhirlpool!" + Gen2TextStream.PAGE_BREAK \
+	+ "A #MON may be\nable to pass it."
 const WATERFALL_ASK_TEXT: String = "Do you want to use\nWATERFALL?"
 const WATERFALL_HUGE_TEXT: String = "Wow, it's a huge\nwaterfall."
 const HEADBUTT_ASK_TEXT: String = \
-	"A #MON could be\nin this tree.\n\nWant to HEADBUTT\nit?"
+	"A #MON could be\nin this tree." + Gen2TextStream.PAGE_BREAK \
+	+ "Want to HEADBUTT\nit?"
 ## A field-move prompt has no source address to push a frame at, since
 ## CallScript's operand is a link-time one the pins do not resolve. The bare
 ## `end` frame still has to sit in the CPU's switchable window for _push_frame,
@@ -516,8 +521,9 @@ const EVENT_PLAYERS_HOUSE_2F_CONSOLE: int = 1857
 const EVENT_PLAYERS_HOUSE_2F_DOLL_1: int = 1858
 const EVENT_PLAYERS_HOUSE_2F_DOLL_2: int = 1859
 const EVENT_PLAYERS_HOUSE_2F_BIG_DOLL: int = 1860
-## `engine/events/unown_walls.asm`'s two reading chambers. Crystal's alone: the
-## other two walls open from a scene script rather than a special.
+## `engine/events/unown_walls.asm`'s two `special` chambers. Crystal's alone: the
+## other two are farcalled from field-move code rather than reached by a script,
+## so they live with the moves that open them (Gen2WorldAPI.unown_wall_event).
 const EVENT_WALL_OPENED_IN_HO_OH_CHAMBER: int = 806
 const EVENT_WALL_OPENED_IN_OMANYTE_CHAMBER: int = 808
 
@@ -6488,7 +6494,9 @@ func _stage_strength_used(slot: int) -> Dictionary:
 	var name: String = _field_move_user_name(slot)
 	_pending = {
 		"type": &"text",
-		"text": "%s used\nSTRENGTH!" % name,
+		"text": Gen2WorldFieldMove.used_text(
+			Gen2WorldFieldMove.MOVE_STRENGTH, name
+		),
 		"internal_text": true,
 		"special": &"strength_used",
 		"name": name,
@@ -6614,7 +6622,7 @@ func _stage_rock_smash_used(slot: int) -> Dictionary:
 	var name: String = _field_move_user_name(slot)
 	_pending = {
 		"type": &"text",
-		"text": ROCK_SMASH_USED_TEXT % name,
+		"text": Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_ROCK_SMASH, name),
 		"internal_text": true,
 		"special": &"rock_smash_used",
 		"source": _request.duplicate(true),

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 23,
+	"api_version": 24,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage, a page of its own with a second row that opens it, and a banner over the map raised when the run's progress moves."
 }

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 21,
+	"api_version": 23,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage, a page of its own with a second row that opens it, and a banner over the map raised when the run's progress moves."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 23,
+	"api_version": 24,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 21,
+	"api_version": 23,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -324,6 +324,11 @@ func test_choosing_cut_shows_the_message_and_defers_the_block_change() -> void:
 	assert_null(_world_screen._party_host)
 	assert_true(_world_screen._field_move_text)
 	assert_eq(_shown_text(), "TESTMON used CUT!")
+	## `_UseCutText`'s own `line`: the move name is the second row whether or not
+	## the nickname is short enough for both to fit on one.
+	assert_eq(_world_screen._text_box.text_lines(), PackedStringArray([
+		"TESTMON used", "CUT!",
+	]))
 	# Script_Cut writes the block only after UseCutText.
 	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
 	assert_false(world.can_walk_to(TREE_CELL))
@@ -1291,6 +1296,9 @@ func test_facing_a_cut_tree_with_only_the_hm_asks_and_cuts() -> void:
 	world.run_event_queue(true)
 	_world_screen._show_script_results(world.choose_script_input(0))
 	assert_eq(_shown_text(), "PLAYER used CUT!")
+	assert_eq(_world_screen._text_box.text_lines(), PackedStringArray([
+		"PLAYER used", "CUT!",
+	]), "the A-press path says the same words as the submenu")
 	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE)
 	_world_screen._acknowledge_field_move_text()
 	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE_CUT)
@@ -1333,3 +1341,42 @@ func test_the_moves_row_appears_only_with_an_offer_and_runs_the_move() -> void:
 	assert_eq(_shown_text(), "PLAYER used CUT!")
 	_world_screen._acknowledge_field_move_text()
 	assert_eq(world.block_at(TREE_BLOCK.x, TREE_BLOCK.y), BLOCK_TREE_CUT)
+
+
+## `.SweetScent` writes its own line and waits for a button before it rolls, so a
+## miss is two boxes: "used SWEET SCENT!" and then `_SweetScentNothingText`.
+## The fixture's floor is not a tile `CanEncounterWildMon` accepts, which is the
+## miss the source's `iffalse SweetScentNothing` takes.
+func test_a_sweet_scent_that_finds_nothing_still_says_it_was_used() -> void:
+	await _open_world(true, Gen2WorldFieldMove.MOVE_SWEET_SCENT)
+	var party: Gen2PartyScreen = await _open_party()
+	party.handle_button(Gen2Button.A)
+	party.handle_button(Gen2Button.A)
+	await get_tree().process_frame
+
+	assert_true(_world_screen._field_move_text)
+	assert_eq(_world_screen._text_box.text_lines(), PackedStringArray([
+		"TESTMON used", "SWEET SCENT!", "Looks like there's", "nothing here…",
+	]))
+	## Two boxes rather than one: the `waitbutton` between the two `writetext`s.
+	## A press while a page is still printing is spent on the printing, so each
+	## box is waited out the way a player waits for it.
+	assert_true(_world_screen._text_box.has_pages_left())
+	_world_screen._text_box.finish()
+	_world_screen._acknowledge_field_move_text()
+	assert_true(_world_screen._field_move_text, "the miss is still up")
+	assert_false(_world_screen._text_box.has_pages_left())
+	_world_screen._text_box.finish()
+	_world_screen._acknowledge_field_move_text()
+	assert_false(_world_screen._field_move_text)
+
+
+## `Script_UseFlash` writes `_BlindingFlashText` and calls no GetPartyNickname,
+## so Flash is the one field move whose line names nobody.
+func test_the_flash_line_is_the_blinding_flash_text() -> void:
+	await _open_world(true, Gen2WorldFieldMove.MOVE_FLASH, Gen2WorldFieldMove.BADGE_ZEPHYR)
+	var rows: Dictionary = _world_screen._field_move_rows(0, "TESTMON")
+	assert_eq(
+		String((rows[Gen2WorldFieldMove.MOVE_FLASH] as Array)[2]),
+		"A blinding FLASH\nlights the area!"
+	)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37882
+const MAX_COMMENT_LINES: int = 37881
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -256,3 +256,23 @@ func test_a_page_break_blinks_even_when_the_text_runs_on() -> void:
 	assert_true(box.advance())
 	assert_false(box.has_pages_left())
 	assert_false(box.cursor_visible(), "and the last page does not")
+
+
+## `Paragraph` clears the box and starts at the top line, which is what
+## [constant Gen2TextStream.PAGE_BREAK] means here. A blank line spells the same
+## `para` in a source string and does not: it fills the top row and pushes the
+## text onto the bottom one, so a hand-written text says `para` with the marker.
+func test_a_blank_line_is_not_a_page_break() -> void:
+	var text: String = "This tree can be\nCUT!"
+	assert_eq(
+		Gen2TextLayout.lay_out(text + Gen2TextStream.PAGE_BREAK + "Want to use CUT?", 18, 2),
+		[
+			PackedStringArray(["This tree can be", "CUT!"]),
+			PackedStringArray(["Want to use CUT?"]),
+		]
+	)
+	assert_eq(
+		Gen2TextLayout.lay_out(text + "\n\nWant to use CUT?", 18, 2)[1],
+		PackedStringArray(["", "Want to use CUT?"]),
+		"a blank line is a line"
+	)

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -86,6 +86,15 @@ const HEADBUTT_STAND_CELL: Vector2i = Vector2i(0, 2)
 const ENVIRONMENT_TOWN: int = 1
 const ENVIRONMENT_DUNGEON: int = 7
 
+## The two Ruins of Alph chambers whose walls a field move opens, at their own
+## Crystal group and numbers so `unown_wall_event` recognises them. Both are
+## DUNGEON and neither is dark, which is what makes the Aerodactyl room the one
+## place Flash works on a lit map.
+const RUINS_GROUP: int = Gen2WorldAPI.RUINS_OF_ALPH_GROUP
+const KABUTO_CHAMBER: int = Gen2WorldAPI.RUINS_OF_ALPH_KABUTO_CHAMBER
+const AERODACTYL_CHAMBER: int = Gen2WorldAPI.RUINS_OF_ALPH_AERODACTYL_CHAMBER
+const ESCAPE_KABUTO_DOOR: Vector2i = Vector2i(1, 3)
+
 var _directory: String = ""
 
 
@@ -134,6 +143,8 @@ func _write_cache() -> void:
 		_map(ESCAPE_TOWN, TILESET_CUTTABLE, 0, ENVIRONMENT_TOWN),
 		_map(ESCAPE_CAVE, TILESET_NO_ENTRY, 0, ENVIRONMENT_CAVE),
 		_map(ESCAPE_POKECENTER, TILESET_POKECENTER, 0, ENVIRONMENT_INDOOR),
+		_map(KABUTO_CHAMBER, TILESET_NO_ENTRY, 0, ENVIRONMENT_DUNGEON, RUINS_GROUP),
+		_map(AERODACTYL_CHAMBER, TILESET_NO_ENTRY, 0, ENVIRONMENT_DUNGEON, RUINS_GROUP),
 	])
 	# `SpawnPoints`, with the town as the one spawn this cache carries and the
 	# Pokemon Center standing in for SPAWN_NEW_BARK, which is the row a
@@ -261,7 +272,9 @@ func _tileset(number: int) -> Dictionary:
 	}
 
 
-func _map(number: int, tileset: int, palette: int = 0, environment: int = 0) -> Dictionary:
+func _map(
+	number: int, tileset: int, palette: int = 0, environment: int = 0, group: int = 1
+) -> Dictionary:
 	var blocks: Array = []
 	for index: int in 16:
 		blocks.append(BLOCK_FLOOR)
@@ -315,16 +328,23 @@ func _map(number: int, tileset: int, palette: int = 0, environment: int = 0) -> 
 				"x": ESCAPE_CENTRE_DOOR.x, "y": ESCAPE_CENTRE_DOOR.y, "destination": 1,
 				"map_group": 1, "map_number": ESCAPE_POKECENTER,
 			},
+			{
+				"x": ESCAPE_KABUTO_DOOR.x, "y": ESCAPE_KABUTO_DOOR.y, "destination": 1,
+				"map_group": RUINS_GROUP, "map_number": KABUTO_CHAMBER,
+			},
 		]
-	elif number in [ESCAPE_CAVE, ESCAPE_POKECENTER]:
+		collision[ESCAPE_KABUTO_DOOR.y * 8 + ESCAPE_KABUTO_DOOR.x] = COLL_PIT
+	elif group == RUINS_GROUP or number in [ESCAPE_CAVE, ESCAPE_POKECENTER]:
 		collision[ESCAPE_INSIDE_DOOR.y * 8 + ESCAPE_INSIDE_DOOR.x] = COLL_PIT
 		warps = [{
 			"x": ESCAPE_INSIDE_DOOR.x, "y": ESCAPE_INSIDE_DOOR.y,
 			"destination": 1 if number == ESCAPE_CAVE else 2,
 			"map_group": 1, "map_number": ESCAPE_TOWN,
 		}]
+		if group == RUINS_GROUP:
+			warps[0]["destination"] = 3
 	return {
-		"group": 1,
+		"group": group,
 		"number": number,
 		"tileset": tileset,
 		"palette": palette,
@@ -1065,20 +1085,37 @@ func test_a_map_reload_restores_the_whirlpool_and_drops_a_staged_request() -> vo
 	assert_true(world.pending_whirlpool().is_empty())
 
 
-func test_the_whirlpool_traps_a_player_until_it_is_removed() -> void:
-	# .CheckTile answers before .TrySurf, so the cell is enterable but not
-	# leavable: Script_ForcedMovement only spins the player around.
+## `.CheckTile` answers before `.TrySurf`, so the cell is entered and then
+## `Script_ForcedMovement` runs: `step_dig 16`, a `turn_in` back the way the
+## player came, another `step_dig 16` and a `turn_head`. `turn_in` reaches
+## `TurningStep` and `InitStep`, so the whirlpool spits the player out rather
+## than holding them; the fall's cell is still not somewhere they can stay.
+func test_the_whirlpool_spits_the_player_back_out_the_way_they_came() -> void:
 	var world: Gen2WorldAPI = _whirlpool_world()
-	assert_true(bool(world.move_result(Vector2i.DOWN).get("ok", false)))
+	var entered: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_true(bool(entered.get("ok", false)))
 	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_DOWN)
+	while world.player_step_in_progress():
+		world.advance_player_step_pass()
 
 	var spun: Dictionary = world.move_result(Vector2i.DOWN)
 	assert_eq(spun["kind"], &"forced_turn")
-	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+	assert_eq(spun["from_cell"], WHIRLPOOL_CELL)
+	assert_eq(world.player_cell, WHIRLPOOL_STAND_CELL, "one cell back the way in")
 	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
-	assert_eq(world.move_result(Vector2i.UP)["kind"], &"forced_turn")
-	assert_eq(world.player_facing, Gen2WorldSprite.FACING_DOWN)
-	assert_eq(world.player_cell, WHIRLPOOL_CELL)
+	## 16 + 8 + 16, and the whole run spins: `step_dig` is STEP_TYPE_SLEEP with
+	## OBJECT_ACTION_SPIN and `turn_in` is TurningStep's.
+	assert_eq(int(spun["passes"]), Gen2WorldAPI.FORCED_TURN_SLEEP_PASSES * 2 + 8)
+	assert_true(world.player_step_in_progress())
+	assert_true(
+		Gen2WorldMovement.SPINNING_KINDS.has(world.player_step_kind()),
+		String(world.player_step_kind())
+	)
+	for _spent: int in int(spun["passes"]):
+		world.advance_player_step_pass()
+	assert_false(world.player_step_in_progress())
+	assert_eq(world.player_cell, WHIRLPOOL_STAND_CELL)
 
 	# Removing it from the neighbouring cell frees it.
 	world.player_cell = WHIRLPOOL_STAND_CELL
@@ -1228,10 +1265,11 @@ func test_the_waterfall_climb_spins_the_player_counterclockwise() -> void:
 			seen.append(world.player_drawn_facing())
 	for index: int in seen.size():
 		assert_eq(seen[index], wanted[(index / 4) % 4], "pass %d" % index)
-	## The logical facing never moved, so the climb still ends facing up, and the
-	## drawing goes back to it the moment the run drains.
-	assert_eq(world.player_facing, Gen2WorldSprite.FACING_UP)
-	assert_eq(world.player_drawn_facing(), Gen2WorldSprite.FACING_UP)
+	## The spin writes OBJECT_DIRECTION, which is `wPlayerDirection`, and nothing
+	## after the script puts it back, so the climb ends a quarter turn per cell
+	## round from DOWN: three steps here, so LEFT.
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_LEFT)
+	assert_eq(world.player_drawn_facing(), Gen2WorldSprite.FACING_LEFT)
 
 
 ## The landing re-derives the player state the way a warp does, so a climb that
@@ -1270,14 +1308,18 @@ func test_a_map_change_clears_a_pending_waterfall() -> void:
 
 ## Flash. `.CheckUseFlash` checks the badge and then the map's own palette byte,
 ## and nothing else: it is the one field move that never looks at a tile.
-func _flash_world(with_badge: bool = true, map_number: int = 3) -> Gen2WorldAPI:
+func _flash_world(
+	with_badge: bool = true, map_number: int = 3, group: int = 1
+) -> Gen2WorldAPI:
 	var data: GameData = GameData.open_directory(_directory)
 	var state := Gen2WorldState.new()
 	if with_badge:
 		state.set_engine_flag(Gen2WorldState.badge_flag(
 			Gen2WorldFieldMove.BADGE_ZEPHYR, Gen2WorldState.is_crystal_profile(data)
 		))
-	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, map_number, Vector2i(1, 1), state)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, group, map_number, Vector2i(1, 1), state
+	)
 	_knowing_party(world, Gen2WorldFieldMove.MOVE_FLASH)
 	return world
 
@@ -1980,3 +2022,159 @@ func test_a_post_champion_slot_continues_at_new_bark() -> void:
 		data, Gen2WorldSnapshot.from_dict(encoded)
 	)
 	assert_eq(legacy.map_id(), world.map_id())
+
+
+## `engine/events/unown_walls.asm`. `SpecialAerodactylChamber` and
+## `SpecialKabutoChamber` each compare the map attributes pointer, so the answer
+## is the map and nothing else.
+func test_the_unown_wall_chambers_answer_only_on_their_own_map() -> void:
+	var chamber: Gen2WorldAPI = _flash_world(true, AERODACTYL_CHAMBER, RUINS_GROUP)
+	assert_eq(
+		chamber.unown_wall_event(Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER),
+		Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER
+	)
+	assert_eq(
+		chamber.unown_wall_event(Gen2WorldAPI.EVENT_WALL_OPENED_IN_KABUTO_CHAMBER), -1,
+		"the other chamber's wall is another map's"
+	)
+
+	var elsewhere: Gen2WorldAPI = _flash_world()
+	assert_eq(
+		elsewhere.unown_wall_event(Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER), -1
+	)
+
+
+## `.CheckUseFlash` asks the chamber before it reads `wTimeOfDayPalset`, so the
+## Aerodactyl room is the one lit map Flash works on, and the wall opens for the
+## asking rather than for the light.
+func test_flash_opens_the_aerodactyl_wall_on_a_map_that_is_not_dark() -> void:
+	var world: Gen2WorldAPI = _flash_world(true, AERODACTYL_CHAMBER, RUINS_GROUP)
+	assert_false(Gen2WorldPalette.is_dark(world.current_map.palette))
+
+	var staged: Dictionary = world.flash_request()
+	assert_true(bool(staged.get("ok", false)), String(staged.get("reason", "")))
+	assert_eq(
+		int(staged["wall_event"]), Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER
+	)
+	assert_false(world.state.is_event_flag_active(
+		Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER
+	), "the flag waits for the text, as BlindingFlash does")
+
+	var used: Dictionary = world.complete_flash()
+	assert_true(bool(used.get("ok", false)))
+	assert_true(world.state.is_event_flag_active(
+		Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER
+	))
+	assert_true(world.state.used_flash(), "BlindingFlash still sets its own flag")
+
+
+## Everywhere else the darkness is still the whole test, and no wall opens.
+func test_flash_on_a_lit_map_outside_the_chamber_is_still_refused() -> void:
+	var world: Gen2WorldAPI = _flash_world(true, 1)
+	var refused: Dictionary = world.flash_request()
+	assert_false(bool(refused.get("ok", true)))
+	assert_eq(refused["reason"], &"not_dark")
+
+	var dark: Gen2WorldAPI = _flash_world()
+	var used: Dictionary = dark.complete_flash() if bool(
+		dark.flash_request().get("ok", false)
+	) else {}
+	assert_eq(int(used.get("wall_event", 0)), -1, "no wall on an ordinary cave")
+
+
+## `EscapeRopeOrDig`'s `.escaperope` farcalls `SpecialKabutoChamber` inside
+## `.DoDig`, so the flag is written while the chamber is still the loaded map.
+func test_an_escape_rope_opens_the_kabuto_wall_and_dig_does_not() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	world.player_cell = ESCAPE_KABUTO_DOOR
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_eq(world.map_id(), Vector2i(RUINS_GROUP, KABUTO_CHAMBER))
+
+	var roped: Dictionary = world.escape_rope_request()
+	assert_true(bool(roped.get("ok", false)), String(roped.get("reason", "")))
+	assert_eq(int(roped["wall_event"]), Gen2WorldAPI.EVENT_WALL_OPENED_IN_KABUTO_CHAMBER)
+	assert_true(world.state.is_event_flag_active(
+		Gen2WorldAPI.EVENT_WALL_OPENED_IN_KABUTO_CHAMBER
+	))
+
+	## `.DoDig`'s Dig branch skips the farcall, so digging out leaves it shut.
+	var digger: Gen2WorldAPI = _escape_world()
+	digger.player_cell = ESCAPE_KABUTO_DOOR
+	digger.try_warp()
+	assert_true(bool(digger.dig_request().get("ok", false)))
+	assert_false(digger.state.is_event_flag_active(
+		Gen2WorldAPI.EVENT_WALL_OPENED_IN_KABUTO_CHAMBER
+	))
+
+
+## `.ResetSurfingOrBikingState`: the bike goes away on the three environments it
+## names and stays on every other, which is why a cave may be ridden through.
+func test_a_map_load_puts_the_bike_away_indoors_and_keeps_it_in_a_cave() -> void:
+	for row: Array in [
+		[ESCAPE_CAVE, Gen2WorldAPI.MOVEMENT_BIKE],
+		[ESCAPE_POKECENTER, Gen2WorldAPI.MOVEMENT_WALK],
+	]:
+		var world: Gen2WorldAPI = _escape_world()
+		assert_true(bool(world.bike_request().get("ok", false)))
+		world.player_cell = ESCAPE_CAVE_DOOR if int(row[0]) == ESCAPE_CAVE \
+			else ESCAPE_CENTRE_DOOR
+		assert_true(bool(world.try_warp().get("ok", false)))
+		assert_eq(world.movement_mode, StringName(row[1]), "map %d" % int(row[0]))
+	## A DUNGEON is the third, and the Kabuto chamber is one.
+	var dungeon: Gen2WorldAPI = _escape_world()
+	assert_true(bool(dungeon.bike_request().get("ok", false)))
+	dungeon.player_cell = ESCAPE_KABUTO_DOOR
+	dungeon.try_warp()
+	assert_eq(dungeon.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	assert_eq(dungeon.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
+
+
+## `.CheckForcedBiking` runs before both other branches, and `.TrySurf` and
+## `TrySurfOW` read the same flag: Route 16 and Route 17 are the two maps that
+## set it, and neither getting off nor surfing off is allowed while it is up.
+func test_always_on_bike_forces_the_bike_back_and_refuses_surf() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	world.state.set_engine_flag(Gen2WorldState.always_on_bike_flag(world.data), true)
+	assert_true(world.always_on_bike())
+
+	assert_eq(world.surf_request()["reason"], &"cannot_surf")
+	assert_false(world._surf_prompt_applies(WATER_CELL))
+
+	## `.CheckForcedBiking` runs first, so a map load puts the bike back on.
+	var forced: Gen2WorldAPI = _escape_world()
+	forced.state.set_engine_flag(
+		Gen2WorldState.always_on_bike_flag(forced.data), true
+	)
+	forced.player_cell = ESCAPE_CAVE_DOOR
+	assert_true(bool(forced.try_warp().get("ok", false)))
+	assert_eq(forced.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
+	assert_eq(forced.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER_BIKE)
+	## `.TryBike` reads `.CheckEnvironment` first and only then the flag, so the
+	## refusal is the flag's on a map the bike may be ridden on at all.
+	forced.player_cell = Vector2i(4, 4)
+	assert_eq(forced.bike_request()["reason"], &"always_on_bike")
+	## The forced branch runs before `.ResetSurfingOrBikingState`, so even an
+	## indoor map keeps the bike on while the flag is up.
+	forced.player_cell = ESCAPE_INSIDE_DOOR
+	assert_true(bool(forced.try_warp().get("ok", false)))
+	forced.player_cell = ESCAPE_CENTRE_DOOR
+	assert_true(bool(forced.try_warp().get("ok", false)))
+	assert_eq(forced.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
+
+
+## data/text/common_2.asm: every one of these is `text_ram` and a `line`, so a
+## nickname short enough to fit one line still prints two.
+func test_every_used_line_carries_the_source_break() -> void:
+	for move: int in Gen2WorldFieldMove.USED_TEXTS:
+		var said: String = Gen2WorldFieldMove.used_text(move, "AB")
+		assert_true(said.contains("\n"), "move $%02x: %s" % [move, said])
+		assert_false(said.contains("%s"), "move $%02x kept its marker" % move)
+	## `_BlindingFlashText` and `_TeleportReturnText` name nobody at all.
+	assert_eq(
+		Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_FLASH, "AB"),
+		"A blinding FLASH\nlights the area!"
+	)
+	assert_eq(
+		Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_CUT, "AB"), "AB used\nCUT!"
+	)
+	assert_eq(Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_FLY, "AB"), "")

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -2178,3 +2178,52 @@ func test_every_used_line_carries_the_source_break() -> void:
 		Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_CUT, "AB"), "AB used\nCUT!"
 	)
 	assert_eq(Gen2WorldFieldMove.used_text(Gen2WorldFieldMove.MOVE_FLY, "AB"), "")
+
+
+## `player_step_span()` against `player_step_offset_cells()` over the whole
+## climb: the two say the same thing, so a renderer can move to the newer one
+## without its drawing shifting. Moving `from` to `to` by `progress` is the
+## offset's own answer, cell for cell.
+func test_the_step_span_is_the_offset_taken_apart_step_by_step() -> void:
+	var world: Gen2WorldAPI = _waterfall_world()
+	assert_true(bool(world.waterfall_request().get("ok", false)))
+	var applied: Dictionary = world.complete_waterfall()
+	var seen: Array[Vector2i] = []
+	for _spent: int in int(applied["passes"]):
+		var span: Dictionary = world.player_step_span()
+		assert_false(span.is_empty())
+		assert_eq(span["kind"], &"turn_waterfall")
+		assert_eq((span["to"] as Vector2i) - (span["from"] as Vector2i), Vector2i.UP)
+		var walked: Vector2 = Vector2(span["from"] as Vector2i).lerp(
+			Vector2(span["to"] as Vector2i), float(span["progress"])
+		)
+		assert_almost_eq(
+			walked, Vector2(world.player_cell) + world.player_step_offset_cells(),
+			Vector2(0.001, 0.001)
+		)
+		if not seen.has(span["from"] as Vector2i):
+			seen.append(span["from"] as Vector2i)
+		world.advance_player_step_pass()
+	## One entry per step of the climb, in order, from the fall's foot up.
+	assert_eq(seen.size(), int(applied["steps"]))
+	assert_eq(seen[0], WATERFALL_STAND_CELL)
+	assert_eq(seen[seen.size() - 1] + Vector2i.UP, WATERFALL_LANDING_CELL)
+	assert_true(world.player_step_span().is_empty(), "empty once the run drains")
+
+
+## The same seam on an object, and the case the offset cannot answer: a stream
+## that turns sums to one vector, so which two cells the step in flight runs
+## between is unrecoverable from it.
+func test_an_object_step_span_survives_a_stream_that_turns() -> void:
+	var object := Gen2WorldObject.new()
+	object.cell = Vector2i(4, 4)
+	object.queue_step(Vector2i.RIGHT, 8, false, Vector2i.RIGHT)
+	object.queue_step(Vector2i.UP, 8, false, Vector2i.UP)
+	var first: Dictionary = object.step_span()
+	assert_eq(first["from"], Vector2i(3, 5))
+	assert_eq(first["to"], Vector2i(4, 5))
+	for _spent: int in 8:
+		object.tick_step()
+	var second: Dictionary = object.step_span()
+	assert_eq(second["from"], Vector2i(4, 5))
+	assert_eq(second["to"], Vector2i(4, 4))

--- a/tools/checks/unown_walls.gd
+++ b/tools/checks/unown_walls.gd
@@ -1,0 +1,161 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Verifies the two Ruins of Alph walls a field move opens, against freshly
+## imported real caches. `FlashFunction` farcalls `SpecialAerodactylChamber` and
+## `EscapeRopeOrDig` farcalls `SpecialKabutoChamber`, so neither is a `special`
+## `tools/checks/specials.gd` can see. The flags are Crystal's alone, so the same
+## two maps must answer nothing on Gold and Silver.
+
+
+## constants/map_constants.asm, DUNGEONS group. Both sit at the same number in
+## all three pins: the group's eight-map shift starts after them.
+const RUINS_GROUP: int = Gen2WorldAPI.RUINS_OF_ALPH_GROUP
+const KABUTO_CHAMBER: int = Gen2WorldAPI.RUINS_OF_ALPH_KABUTO_CHAMBER
+const AERODACTYL_CHAMBER: int = Gen2WorldAPI.RUINS_OF_ALPH_AERODACTYL_CHAMBER
+## `map_const`'s own two operands, and `data/maps/maps.asm`'s tileset column.
+const CHAMBER_BLOCKS := Vector2i(4, 5)
+const TILESET_RUINS_CRYSTAL: int = 0x1A
+const TILESET_RUINS_GOLD_SILVER: int = 0x17
+
+const WALLS: Dictionary = {
+	Gen2WorldAPI.EVENT_WALL_OPENED_IN_KABUTO_CHAMBER: KABUTO_CHAMBER,
+	Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER: AERODACTYL_CHAMBER,
+}
+
+## `.DoDig` refuses on a zero `wDigWarpNumber` byte, so the rope needs one
+## recorded. Which warp it is decides nothing about the wall.
+const DIG_WARP: Dictionary = {"warp": 1, "map_group": 3, "map_number": 22}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	_r.each_game(func() -> void:
+		_verify_chambers()
+		_sweep_maps()
+		_verify_flash()
+		_verify_escape_rope()
+	)
+
+
+## Both rooms are DUNGEON and neither is dark, which is why the Aerodactyl
+## branch has to run before the palette test: a Flash gated on darkness alone
+## could never open that wall.
+func _verify_chambers() -> void:
+	for number: int in [KABUTO_CHAMBER, AERODACTYL_CHAMBER]:
+		var map: Gen2WorldMap = _r.data.world_map(RUINS_GROUP, number)
+		if not _r.check(map != null, "map %d/%d is missing." % [RUINS_GROUP, number]):
+			continue
+		_r.check(
+			map.environment == Gen2WorldAPI.ENVIRONMENT_DUNGEON,
+			"map %d/%d environment is %d, not DUNGEON." % [
+				RUINS_GROUP, number, map.environment,
+			]
+		)
+		_r.check(
+			not Gen2WorldPalette.is_dark(map.palette),
+			"map %d/%d is dark, so Flash would reach it anyway." % [RUINS_GROUP, number]
+		)
+		_r.check(
+			map.tileset == (
+				TILESET_RUINS_CRYSTAL if _r.crystal else TILESET_RUINS_GOLD_SILVER
+			),
+			"map %d/%d tileset is %d." % [RUINS_GROUP, number, map.tileset]
+		)
+		_r.check(
+			Vector2i(map.width_blocks, map.height_blocks) == CHAMBER_BLOCKS,
+			"map %d/%d is %dx%d blocks, not %s." % [
+				RUINS_GROUP, number, map.width_blocks, map.height_blocks, CHAMBER_BLOCKS,
+			]
+		)
+
+
+## The corpus half: each wall answers on exactly one of the cartridge's maps,
+## and on none at all outside Crystal.
+func _sweep_maps() -> void:
+	var wanted: int = 1 if _r.crystal else 0
+	for event: int in WALLS:
+		var answered: Array[String] = []
+		for map: Gen2WorldMap in _r.data.world_maps():
+			var world: Gen2WorldAPI = _r.open_world(map.group, map.number, Vector2i.ZERO)
+			if world == null:
+				continue
+			if world.unown_wall_event(event) == event:
+				answered.append("%d/%d" % [map.group, map.number])
+		_r.check(
+			answered.size() == wanted,
+			"event %d answers on %d maps (%s), not %d." % [
+				event, answered.size(), ", ".join(answered), wanted,
+			]
+		)
+		if wanted == 1 and answered.size() == 1:
+			_r.check(
+				answered[0] == "%d/%d" % [RUINS_GROUP, int(WALLS[event])],
+				"event %d answers on %s." % [event, answered[0]]
+			)
+	_r.note("%d maps swept for the two farcalled walls." % _r.data.world_maps().size())
+
+
+## `.CheckUseFlash`: badge, then `SpecialAerodactylChamber`, then the palette, so
+## the chamber succeeds on a lit map where every other room is refused.
+func _verify_flash() -> void:
+	var state := Gen2WorldState.new()
+	state.set_engine_flag(
+		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_ZEPHYR, _r.crystal)
+	)
+	var world: Gen2WorldAPI = _r.open_world(
+		RUINS_GROUP, AERODACTYL_CHAMBER, Vector2i.ZERO, state
+	)
+	if world == null:
+		return
+	_r.field_move_party(world)
+	var staged: Dictionary = world.flash_request()
+	if not _r.crystal:
+		_r.check(
+			StringName(staged.get("reason", &"")) == &"not_dark",
+			"Flash is not refused in the chamber: %s" % staged
+		)
+		return
+	if not _r.check(
+		bool(staged.get("ok", false)), "Flash refused in the chamber: %s" % staged
+	):
+		return
+	world.complete_flash()
+	_r.check(
+		world.state.is_event_flag_active(
+			Gen2WorldAPI.EVENT_WALL_OPENED_IN_AERODACTYL_CHAMBER
+		),
+		"Flash left the Aerodactyl wall shut."
+	)
+	_r.note("Flash opened the Aerodactyl wall on a map that is not dark.")
+
+
+## `.escaperope`'s farcall, and the Dig branch that skips it.
+func _verify_escape_rope() -> void:
+	for digging: bool in [false, true]:
+		var world: Gen2WorldAPI = _r.open_world(
+			RUINS_GROUP, KABUTO_CHAMBER, Vector2i.ZERO
+		)
+		if world == null:
+			return
+		_r.field_move_party(world)
+		world.dig_warp = DIG_WARP.duplicate()
+		var answer: Dictionary = world.dig_request() if digging \
+			else world.escape_rope_request()
+		if not _r.check(
+			bool(answer.get("ok", false)),
+			"%s refused in the chamber: %s" % ["Dig" if digging else "the rope", answer]
+		):
+			continue
+		var opened: bool = world.state.is_event_flag_active(
+			Gen2WorldAPI.EVENT_WALL_OPENED_IN_KABUTO_CHAMBER
+		)
+		_r.check(
+			opened == (_r.crystal and not digging),
+			"the Kabuto wall is %s after %s." % [
+				"open" if opened else "shut", "Dig" if digging else "the rope",
+			]
+		)
+	if _r.crystal:
+		_r.note("an escape rope opened the Kabuto wall and Dig did not.")

--- a/tools/checks/unown_walls.gd.uid
+++ b/tools/checks/unown_walls.gd.uid
@@ -1,0 +1,1 @@
+uid://d1j1xve52eb26

--- a/tools/checks/whirlpool.gd
+++ b/tools/checks/whirlpool.gd
@@ -158,22 +158,28 @@ func _verify_dragons_den(game_id: StringName, data: GameData, crystal: bool) -> 
 	)
 
 	# .CheckSurfable reads the permission with TALK masked off, so the whirlpool
-	# is water and a surfing player swims onto it. .CheckTile then traps them:
-	# Script_ForcedMovement only spins the player around.
+	# is water and a surfing player swims onto it. Script_ForcedMovement then
+	# spins them and, through turn_in's own InitStep, walks them back out.
 	_r.check(
 		bool(world.move_result(Vector2i.DOWN).get("ok", false))
 			and world.player_cell == DEN_CELL,
 		"%s: Dragon's Den whirlpool refused a surfing step onto it." % game_id
 	)
+	while world.player_step_in_progress():
+		world.advance_player_step_pass()
 	var spun: Dictionary = world.move_result(Vector2i.DOWN)
 	_r.check(
 		StringName(spun.get("kind", &"")) == &"forced_turn"
-			and world.player_cell == DEN_CELL
-			and world.player_facing == Gen2WorldSprite.FACING_UP,
-		"%s: Dragon's Den whirlpool did not spin the player in place: %s." % [
+			and world.player_cell == approach
+			and world.player_facing == Gen2WorldSprite.FACING_UP
+			and int(spun.get("passes", 0))
+				== Gen2WorldAPI.FORCED_TURN_SLEEP_PASSES * 2 + Gen2WorldAPI.STEP_PASSES_WALK,
+		"%s: Dragon's Den whirlpool did not spit the player back out: %s." % [
 			game_id, JSON.stringify(spun),
 		]
 	)
+	while world.player_step_in_progress():
+		world.advance_player_step_pass()
 
 	world.player_cell = approach
 	world.player_facing = Gen2WorldSprite.FACING_DOWN

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -16,7 +16,7 @@ const CHECKS: String = "res://tools/checks"
 const GROUPS: Dictionary = {
 	&"field_moves": [
 		&"cut", &"surf", &"whirlpool", &"strength", &"waterfall", &"headbutt",
-		&"rock_smash", &"field_move_prompts",
+		&"rock_smash", &"field_move_prompts", &"unown_walls",
 	],
 	&"terrain": [
 		&"ledge_hops", &"ice_slides", &"side_walls", &"drawn_blocks", &"story_map_ids",


### PR DESCRIPTION
Six things were wrong against the source, and the two ways into a field move disagreed with each other.

**Two Ruins of Alph walls could not be opened.** `FlashFunction` farcalls `SpecialAerodactylChamber` and `EscapeRopeOrDig`'s escape-rope branch farcalls `SpecialKabutoChamber`, so neither is a `special` that `tools/checks/specials.gd` can see and neither was built. `.CheckUseFlash` asks the chamber before it reads the palette, so Flash works in the Aerodactyl Chamber whatever the light; that room is `PALETTE_DAY`, so a Flash gated on darkness alone refused it forever. Dig skips the farcall and still leaves the Kabuto wall shut. Ho-Oh's and Omanyte's walls are `special` commands and were already built.

**Surfing onto a whirlpool was permanent.** `Script_ForcedMovement`'s `turn_in` reaches `TurningStep` and so `InitStep`, which moves a cell: the whirlpool spins the player and walks them back out over 40 passes rather than holding them where they stood. `step_dig` is `STEP_TYPE_SLEEP` with `OBJECT_ACTION_SPIN`, so it joins `SPINNING_KINDS`, and the frame poll drains a forced turn the way `.CheckTile` does rather than waiting for a press.

**Flash said a line neither cartridge has.** `Script_UseFlash` writes `_BlindingFlashText`, "A blinding FLASH / lights the area!", and its `text_asm` plays `SFX_FLASH`, which nothing here played. Sweet Scent showed its miss with no "used SWEET SCENT!" in front of it, though `.SweetScent` writes and waits before it rolls.

**Every "used" line lost its break** in two of the three places that say one, so a nickname short enough for both halves printed one row where the cartridge prints two. All three now read `Gen2WorldFieldMove.USED_TEXTS`, and the seven refusals are constants beside them. Six ask texts spelled `para` as a blank line, which fills the top row instead of clearing the box; `Gen2TextStream.PAGE_BREAK` is what `Gen2TextLayout` reads, and a new case pins the difference.

**A bike was never put away.** `CheckUpdatePlayerSprite`'s other two branches had no counterpart: `.ResetSurfingOrBikingState` dismounts on an indoor, dungeon or environment-5 map, and `.CheckForcedBiking` forces the bike back on where Route 16 and Route 17 set their flag. That flag also refuses Surf, on the menu path and the A-press path alike.

**A waterfall climb ends where the spin left it.** `SetFacingCounterclockwiseSpin` writes `OBJECT_DIRECTION`, which is `wPlayerDirection` itself, and nothing after the script restores it: `step_end` leaves `STEP_TYPE_FROM_MOVEMENT`, and the next poll's `movement_step_sleep` sets `OBJECT_ACTION_STAND`, whose `SetFacingCurrent` reads the direction back.

`tools/checks/unown_walls.gd` sweeps both walls over every map on all three cartridges and pins that both rooms are DUNGEON and neither is dark.

`Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span()` say which two cells the step in flight runs between: `{from, to, progress, kind}`. `player_step_offset_cells()` sums the whole remaining run into one vector, so what it hands back is a fractional cell: a view that folds a run of cells into height reads the fold as a step in that one number, and the sum cannot be taken apart again once a stream turns. Moving `from` to `to` by `progress` is what the offset already answers, cell for cell, so nothing already drawn shifts.

`API_VERSION` is 24: 22 for the four seams that landed with no number of their own, 23 and 24 for this branch's. `docs/MODS.md` now lists what every version added, which is what a mod needs in order to say the seam it draws from is there.

The comment ceiling drops to 37881.

| Check | Result |
|---|---|
| `gut_cmdln.gd -gdir=res://tests -ginclude_subdirs` | 4040 of 4040, 165 scripts |
| `validate.gd -- all` | exit 0, 82 topics on all three cartridges |
| `--warning-scan` | 0 warnings in 599 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no refusal in any leg |
