### PR TITLE
Say what a save is doing everywhere but the START menu

### DIFF
--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -1,13 +1,12 @@
 class_name Gen2HallOfFamePage
 extends RefCounted
 
-## One Hall of Fame induction panel, on the tile grid the hardware uses. Positions
-## are `engine/events/halloffame.asm`'s own: DisplayHOFMon's two text boxes, its
-## frontpic at (6,5) and every field row it prints, plus
-## HOF_AnimatePlayerPic's name box for the player's page. `halloffame.asm:298`
-## calls `LoadFontsBattleExtra` first, so the panel prints with the battle-extra
-## strip over $60 to $78. Node-free; the Pokemon's own pic is not in that buffer,
-## having its own palette, and is composed over the page by the screen.
+## One Hall of Fame induction panel, on the tile grid the hardware uses.
+## Positions are `engine/events/halloffame.asm`'s own: `DisplayHOFMon`'s two text
+## boxes, its frontpic at (6,5) and every field row, plus
+## `HOF_AnimatePlayerPic`'s name box. `LoadFontsBattleExtra` runs first, so the
+## panel prints with the battle-extra strip over $60 to $78. Node-free: the pic
+## has its own palette and is composed over the page by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -18,11 +17,10 @@ const MON_TOP_BOX: Rect2i = Rect2i(0, 0, 20, 5)
 const MON_BOTTOM_BOX: Rect2i = Rect2i(0, 12, 20, 6)
 const CAPTION: Vector2i = Vector2i(1, 2)
 const CAPTION_TEXT: String = "New Hall of Famer!"
-## `_HallOfFamePC.DisplayMonAndStrings` draws this caption instead: `.TimeFamer`
-## at `hlcoord 1, 2` and then `PrintNum` `lb bc, 1, 3` over `hlcoord 2, 2`, so
-## the count is right-aligned in three columns and the words start at column 5.
-## `.HOFMaster` is its unreachable sibling: `cp HOF_MASTER_COUNT + 1` needs 201
-## and `wHallOfFameCount` stops at 200 (`docs/bugs_and_glitches.md`).
+## `_HallOfFamePC.DisplayMonAndStrings` draws this instead: `PrintNum`'s
+## `lb bc, 1, 3` over `hlcoord 2, 2`, so the count is right-aligned in three
+## columns and the words start at column 5. `.HOFMaster` is unreachable: it needs
+## 201 and `wHallOfFameCount` stops at 200 (`docs/bugs_and_glitches.md`).
 const FAMER_TEXT: String = "-Time Famer"
 const FAMER_COUNT: Vector2i = Vector2i(2, 2)
 const FAMER_DIGITS: int = 3
@@ -72,6 +70,8 @@ const TEXT_AT: Vector2i = Vector2i(1, 14)
 const TEXT_COLUMNS: int = MON_BOTTOM_BOX.size.x - 2
 const TEXT_ROWS: int = 2
 const TEXT_LINE_SPACING: int = 2
+## `PrintText`'s own `hlcoord 1, 14` again, over a cleared screen.
+const SAVING_AT: Vector2i = Vector2i(1, 14)
 
 ## `Textbox` draws with wTextboxFrame, which the in-game OPTION menu's FRAME row
 ## and the launcher's settings both write, so the panel is drawn in whichever
@@ -98,7 +98,10 @@ func draw(page: Dictionary) -> PackedByteArray:
 	indices.resize(COLUMNS * TILE * ROWS * TILE)
 	if font == null:
 		return indices
-	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_PLAYER:
+	var kind: StringName = StringName(page.get("kind", &""))
+	if kind == Gen2HallOfFame.PAGE_SAVING:
+		_draw_saving(page, indices)
+	elif kind == Gen2HallOfFame.PAGE_PLAYER:
 		_draw_player(page, indices)
 	else:
 		_draw_mon(page, indices)
@@ -146,10 +149,8 @@ func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:
 	_text(indices, width, "%0*d" % [OT_DIGITS, int(page.get("ot_id", 0))], OT_NUMBER)
 
 
-## The player's page is the name box and the empty bottom one. The source also
-## slides in the player's own pic and prints the trainer ID and PLAY TIME beneath
-## the name; the project imports no player pic and its save model carries neither
-## number, so nothing stands in for them.
+## The name box and the empty bottom one. The source also slides in the player's
+## pic and prints the trainer ID and PLAY TIME, none of which this project has.
 func _draw_player(page: Dictionary, indices: PackedByteArray) -> void:
 	var width: int = COLUMNS * TILE
 	_box(indices, width, PLAYER_BOX)
@@ -160,6 +161,16 @@ func _draw_player(page: Dictionary, indices: PackedByteArray) -> void:
 		_text(
 			indices, width, String(lines[index]),
 			TEXT_AT + Vector2i(0, index * TEXT_LINE_SPACING)
+		)
+
+
+## `InitDisplayForHallOfFame`: no box, since it prints into a cleared tilemap.
+func _draw_saving(page: Dictionary, indices: PackedByteArray) -> void:
+	var lines: Array = page.get("lines", [])
+	for index: int in lines.size():
+		_text(
+			indices, COLUMNS * TILE, String(lines[index]),
+			SAVING_AT + Vector2i(0, index * TEXT_LINE_SPACING)
 		)
 
 

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -1,28 +1,26 @@
 class_name Gen2BoxScreen
 extends Control
 
-## Bill's PC's two lists, on the hardware's own grid. [Gen2PCBoxPage] is the
-## picture and `engine/pokemon/bills_pc.asm` is the model. `_DepositPKMN` and
-## `_WithdrawPKMN` are this one screen with a different list loaded, and
-## `_BillsPC`'s own top menu is the panel's, which is what opens this in either
-## mode. A on a row opens the submenu both jumptables reach: the transfer, STATS,
-## RELEASE and CANCEL. Left and right do nothing, because the only routine that
-## reads them is `MoveMonWithoutMail_DPad` and that screen is not built.
+## Bill's PC's three lists, on the hardware's own grid. [Gen2PCBoxPage] is the
+## picture and `engine/pokemon/bills_pc.asm` is the model. `_DepositPKMN`,
+## `_WithdrawPKMN` and `_MovePKMNWithoutMail` are this one screen with a
+## different list loaded, opened from the panel's own top menu. A on a row opens
+## the submenu each jumptable reaches; left and right belong to
+## `MoveMonWithoutMail_DPad` alone.
 
 signal closed(result: Dictionary)
 ## `PlayMonCry2` from the stats screen this one can open, played by whoever owns
 ## the audio player: nothing here reaches [Gen2AudioPlayer].
 signal cry_requested(species: int)
+## `MoveMonWOMail_InsertMon_SaveGame`'s `SFX_SAVE`, played by the driver's owner.
+signal sfx_requested(index: int, waited: bool)
 
-## The PC is drawn in hardware pixels and the panel it is opened from is ordinary
-## UI at window resolution, so the screen carries a [Gen2Screen] of its own, the
-## way [Gen2TownMapScreen] does.
+## The PC is drawn in hardware pixels and the panel it opens from is ordinary UI,
+## so the screen carries a [Gen2Screen] of its own the way the region map does.
 
-## `PCString_*` and `.PartyPKMN`. All of them are engine strings inside
-## `bills_pc.asm` that no script points at, so nothing imports them and they are
-## the host's, like the contest judging lines. "PKMN" is the two tiles `<PK>` and
-## `<MN>`, which is what [method Gen2Text.encode] makes of it; "#" is the POKé
-## ligature and has no tile in either font.
+## `PCString_*` and `.PartyPKMN`, engine strings inside `bills_pc.asm` that no
+## script points at, so they are the host's the way the contest lines are. "PKMN"
+## is the two tiles `<PK>` and `<MN>` and "#" is the POKé ligature.
 const PROMPT_CHOOSE: String = "Choose a PKMN."
 const PROMPT_WHATS_UP: String = "What's up?"
 const PROMPT_RELEASE: String = "Release PKMN?"
@@ -103,6 +101,10 @@ var _scroll: int = 0
 ## The line the bottom box carries, which is `PCString_ChooseaPKMN` until a
 ## transfer answers.
 var _prompt: String = PROMPT_CHOOSE
+## `MovePKMNWithoutMail_InsertMon`'s two waits, and the clock that spends them.
+var _saving_frames: int = 0
+var _saving_saved: bool = false
+var _saving_clock := Gen2WorldAnimation.FrameClock.new()
 ## `_DepositPKMN` or `_WithdrawPKMN`, and the submenu, the release yes/no and
 ## the stats screen either of them can put over the listing.
 var _mode: int = MODE_DEPOSIT
@@ -319,6 +321,9 @@ func _refusal(result: Dictionary, fallback: String) -> String:
 ## A takes the row the cursor stands on and B leaves. Left and right belong to
 ## MOVE PKMN W/O MAIL alone and do nothing here.
 func handle_button(button: int) -> bool:
+	if _saving_frames > 0:
+		## Two `DelayFrames`, which read no joypad.
+		return true
 	if _stats != null:
 		return _stats.handle_button(button)
 	if _release_open:
@@ -590,8 +595,6 @@ func _sprite() -> TextureRect:
 	return node
 
 
-## The cursor's row is the selection whether or not there is anything to draw
-## it with: a cache carrying no font still stores and withdraws.
 ## Drawing only. The selection is [method _sync_selection]'s, so a caller that
 ## picked a slot by hand keeps it and a cache carrying no font still draws
 ## nothing without losing one.
@@ -778,9 +781,7 @@ func _refresh_pic(mon: Gen2SaveMon) -> void:
 	var image: Image = Gen2PicImage.from_atlas(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic,
 		## `_CGB_BillsPC` reaches `GetMonNormalOrShinyPalettePointer`, so the
-		## selected Pokemon is drawn shiny here the way it is on its own stats
-		## page. The headless page beside this one already asked; the live node
-		## did not, which is the same screen answering two ways.
+		## selection is drawn shiny here the way it is on its own stats page.
 		_data.palette(mon.species, Gen2Stats.is_shiny(mon.dvs))
 	)
 	Gen2PicImage.show(_pic, image)
@@ -924,8 +925,9 @@ func _begin_move() -> void:
 
 
 ## `.a_button_2`: `BillsPC_CheckSpaceInDestination` and then
-## `MovePKMNWithoutMail_InsertMon`, which puts the Pokemon where the cursor
-## stands and shifts everything behind it down.
+## `MovePKMNWithoutMail_InsertMon`, which puts up a box for twenty frames, moves
+## the Pokemon and saves behind it. The move lands in front of the box here
+## rather than behind it, which the box itself covers.
 func _insert_moved_mon() -> void:
 	var result: Dictionary = Gen2SaveStorage.move_mon(
 		_save, _data, _move_from_loaded, _move_from_index, _loaded,
@@ -939,7 +941,42 @@ func _insert_moved_mon() -> void:
 		) == &"no_room_in_destination" else _refusal(result, PROMPT_NO_ROOM)
 		_refresh()
 		return
-	_end_move()
+	_prompt = Gen2SavePrompt.SAVING_LEAVE_ON
+	_saving_frames = Gen2SavePrompt.LEAVE_ON_FRAMES
+	_saving_saved = false
+	set_process(true)
+	_refresh()
+
+
+## `MoveMonWOMail_InsertMon_SaveGame`'s `SFX_SAVE` and twenty-four frames, with
+## the box still up: the save runs behind it.
+func _saved_moved_mon() -> void:
+	sfx_requested.emit(Gen2SavePrompt.SFX_SAVE, true)
+	_saving_frames = Gen2SavePrompt.INSERT_SAVED_FRAMES
+	_saving_saved = true
+
+
+## The two waits, one hardware frame at a time. Public so a test owns its own.
+func advance_saving_frames(count: int) -> void:
+	for _step: int in count:
+		if _saving_frames <= 0:
+			return
+		_saving_frames -= 1
+		if _saving_frames > 0:
+			continue
+		if _saving_saved:
+			set_process(false)
+			_saving_saved = false
+			_end_move()
+		else:
+			_saved_moved_mon()
+
+
+func _process(delta: float) -> void:
+	if _saving_frames <= 0:
+		set_process(false)
+		return
+	advance_saving_frames(_saving_clock.tick(delta))
 
 
 ## `.Cancel` and `.b_button_2` alike: the first pass again, on the list the

--- a/game/save/save_prompt.gd
+++ b/game/save/save_prompt.gd
@@ -1,0 +1,205 @@
+class_name Gen2SavePrompt
+extends RefCounted
+
+## Every save `engine/menus/save.asm` performs, as the one sequence they share:
+## an optional question, `AskOverwriteSaveFile`, `SavingDontTurnOffThePower` and
+## `SavedTheGame`. Node free, with the write injected. [enum Kind] is only the
+## question in front, `Link_SaveGame` (whose caller is `TryQuickSave`) asking
+## none of its own.
+enum Kind { MENU, CHANGE_BOX, MOVE_MON, LINK }
+
+## `ASK` and `OVERWRITE` read a yes/no, `SAVING` and `SAVED` read no joypad at
+## all, and `FAILED` is this port's own step.
+enum Step { ASK, OVERWRITE, SAVING, SAVED, FAILED, REFUSED, DONE }
+
+## The texts, out of `data/text/common_3.asm` on Crystal and `common_2.asm` on
+## Gold and Silver, which no importer reads and which this project authors beside
+## its other engine text. Verbatim, one entry a line, so a box scrolls where
+## `_ContText` scrolls. `AnotherSaveFileText` is `AlreadyASaveFileText`'s sibling
+## for another player's file, and `CompareLoadedAndSavedPlayerID` cannot reach it
+## here: a world is always played from the slot it was started in.
+const ASK_LINES: Array[String] = [
+	"Would you like to", "save the game?",
+]
+const CHANGE_BOX_LINES: Array[String] = [
+	"When you change a", "#MON BOX, data", "will be saved. OK?",
+]
+const MOVE_MON_LINES: Array[String] = [
+	"Each time you move", "a #MON, data", "will be saved. OK?",
+]
+const OVERWRITE_LINES: Array[String] = [
+	"There is already a", "save file. Is it", "OK to overwrite?",
+]
+const SAVING_LINES: Array[String] = [
+	"SAVING… DON'T TURN", "OFF THE POWER.",
+]
+## `_SavedTheGameText`, whose `<PLAYER>` is filled from the save.
+const SAVED_LINES: Array[String] = [
+	"%s saved", "the game.",
+]
+## `MovePKMNWithoutMail_InsertMon`'s own one-row box, a `PlaceString` rather than
+## a text, and the `_PCMonHoldingMailText` `BillsPC_MovePKMNMenu` refuses the
+## whole row with.
+const SAVING_LEAVE_ON: String = "Saving… Leave ON!"
+const MON_HOLDING_MAIL_LINES: Array[String] = [
+	"There is a #MON", "holding MAIL.", "Please remove the", "MAIL.",
+]
+const QUESTIONS: Array[Array] = [ASK_LINES, CHANGE_BOX_LINES, MOVE_MON_LINES, []]
+
+## `SavingDontTurnOffThePower`'s own `ld c, 16`, then `SavedTheGame`'s 32 before
+## the words and 30 after them; `MovePKMNWithoutMail_InsertMon`'s 20 and
+## `MoveMonWOMail_InsertMon_SaveGame`'s 24; and `SFX_SAVE`, hexadecimal the way
+## constants/sfx_constants.asm counts.
+const SAVING_FRAMES: int = 16
+const WRITE_FRAMES: int = 32
+const DONE_FRAMES: int = 30
+const LEAVE_ON_FRAMES: int = 20
+const INSERT_SAVED_FRAMES: int = 24
+const SFX_SAVE: int = 0x25
+
+## `InitDisplayForHallOfFame`'s `_SavingRecordText` and the `ld c, 100`
+## `HallOfFame_FadeOutMusic` spends behind it. Not this sequence: `HallOfFame`
+## saves further down and says nothing there.
+const SAVING_RECORD_LINES: Array[String] = [
+	"SAVING RECORD…", "DON'T TURN OFF!",
+]
+const SAVING_RECORD_FRAMES: int = 100
+
+var step: Step = Step.ASK
+## The box's lines and the one it has scrolled to, and the yes/no's cursor: 0 is
+## YES, 1 is NO, and below zero is a box with no question on it yet.
+var lines: Array[String] = []
+var line: int = 0
+var cursor: int = -1
+var frames: int = 0
+var result: Dictionary = {}
+
+var _kind: Kind = Kind.MENU
+var _player_name: String = ""
+var _write: Callable = Callable()
+
+
+## [param write] takes no arguments and answers an "ok" key, with a "reason"
+## behind a false one.
+static func open(kind: Kind, player_name: String, write: Callable) -> Gen2SavePrompt:
+	var prompt := Gen2SavePrompt.new()
+	prompt._kind = kind
+	prompt._player_name = player_name
+	prompt._write = write
+	if QUESTIONS[int(kind)].is_empty():
+		prompt._enter(Step.OVERWRITE)
+	else:
+		prompt._enter(Step.ASK)
+	return prompt
+
+
+## Waiting on a button rather than on its own frames.
+func reads_joypad() -> bool:
+	return step in [Step.ASK, Step.OVERWRITE, Step.FAILED]
+
+
+func finished() -> bool:
+	return step in [Step.REFUSED, Step.DONE]
+
+
+## Stopped on a NO, which is the carry both `.refused` branches set.
+func refused() -> bool:
+	return step == Step.REFUSED
+
+
+## A on the box. A three-line text is prompted past once before its last line,
+## which is `_ContText`'s own `PromptButton`, and [param yes] is ignored there.
+func confirm(yes: bool) -> void:
+	if cursor < 0 and step in [Step.ASK, Step.OVERWRITE]:
+		line = 1
+		cursor = 0
+		return
+	match step:
+		Step.ASK:
+			_enter(Step.OVERWRITE if yes else Step.REFUSED)
+		Step.OVERWRITE:
+			_enter(Step.SAVING if yes else Step.REFUSED)
+		## A write that failed did not happen, so it ends the way a NO does.
+		Step.FAILED:
+			_enter(Step.REFUSED)
+		_:
+			pass
+
+
+## B, which is `YesNoBox`'s NO and `PromptButton`'s other button.
+func cancel() -> void:
+	confirm(false)
+
+
+## One hardware frame of the two timed steps.
+func frame() -> void:
+	if reads_joypad() or finished():
+		return
+	frames += 1
+	match step:
+		Step.SAVING:
+			if frames == SAVING_FRAMES:
+				_run_write()
+			elif frames == SAVING_FRAMES + WRITE_FRAMES:
+				_show_result()
+		## Exactly, not past: a host freed a frame later would otherwise be told
+		## the sequence ended again on every frame in between.
+		Step.SAVED:
+			if frames == DONE_FRAMES:
+				_enter(Step.DONE)
+
+
+func frames_elapsed(count: int) -> void:
+	for _step: int in count:
+		frame()
+
+
+## The frame the write lands on, where `ChangeBoxSaveGame` switches its box.
+func writing_now() -> bool:
+	return step == Step.SAVING and frames == SAVING_FRAMES
+
+
+## The frame `SavedTheGame` asks for `SFX_SAVE` through `WaitPlaySFX`.
+func sfx_owed() -> bool:
+	return step == Step.SAVED and frames == 0
+
+
+func _open_question(text: Array) -> void:
+	lines.assign(text)
+	cursor = -1 if text.size() > 2 else 0
+
+
+func _enter(next: Step) -> void:
+	step = next
+	frames = 0
+	line = 0
+	match next:
+		Step.ASK:
+			_open_question(QUESTIONS[int(_kind)])
+		Step.OVERWRITE:
+			_open_question(OVERWRITE_LINES)
+		Step.SAVING:
+			lines.assign(SAVING_LINES)
+			cursor = -1
+		Step.SAVED:
+			lines.assign([SAVED_LINES[0] % _player_name, SAVED_LINES[1]])
+			cursor = -1
+		Step.FAILED:
+			lines.assign([
+				"Save failed:", String(result.get("reason", "unknown")),
+			])
+			cursor = 0
+		_:
+			lines.clear()
+			cursor = -1
+
+
+func _run_write() -> void:
+	result = _write.call() if _write.is_valid() \
+		else {"ok": false, "reason": &"no_save_action"}
+
+
+## `SavedTheGame`'s words. The failure line is this project's own: the cartridge
+## has no such path, its write being to SRAM it has already checked.
+func _show_result() -> void:
+	_enter(Step.SAVED if bool(result.get("ok", false)) else Step.FAILED)

--- a/game/save/save_prompt.gd.uid
+++ b/game/save/save_prompt.gd.uid
@@ -1,0 +1,1 @@
+uid://j8mm38krn7s8

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -2,19 +2,18 @@ class_name Gen2HallOfFame
 extends RefCounted
 
 ## The induction sequence `halloffame` asks for, as pages a screen can draw.
-## `AnimateHallOfFame` walks the party built by `GetHallOfFameParty`, showing one
-## panel per Pokemon and then the player's own, so the order and the contents are
-## that routine's. `HOF_AnimatePlayerPic` ends on `farcall ProfOaksPCRating`,
-## whose two texts print into the empty box that panel opens, so the player's
-## panel is answered once per box. The player's panel wants a trainer ID and PLAY
-## TIME the save model has neither of, so those lines are absent rather than drawn
-## as zeros.
+## `AnimateHallOfFame` walks the party `GetHallOfFameParty` built, one panel per
+## Pokemon and then the player's, which `HOF_AnimatePlayerPic` answers once per
+## box `ProfOaksPCRating` prints into it. That panel's trainer ID and PLAY TIME
+## are absent rather than zeros: the save model carries neither.
 
 ## GetHallOfFameParty's own cap: it copies at most a full party and stops on the
 ## -1 terminator.
 const MAX_MONS: int = 6
 
 const PAGE_MON: StringName = &"mon"
+## `InitDisplayForHallOfFame`'s record box, in front of the panels.
+const PAGE_SAVING: StringName = &"saving"
 const PAGE_PLAYER: StringName = &"player"
 
 ## `sHallOfFame`'s own thirty records and `HOF_MASTER_COUNT`, which is where
@@ -25,9 +24,9 @@ const MASTER_COUNT: int = 200
 const MAX_NICKNAME: int = 10
 
 
-## The pages, in AnimateHallOfFame's order: every non-egg party member, then the
-## player. An empty or egg-only party still answers the player's page, matching
-## LoadHOFTeam's carry falling straight through to HOF_AnimatePlayerPic.
+## The pages, in `HallOfFame`'s order: the record box, then every non-egg party
+## member, then the player. An empty or egg-only party still answers the player's
+## page, matching `LoadHOFTeam`'s carry falling through to `HOF_AnimatePlayerPic`.
 ##
 ## [param state] is what `Rate` counts; without it, or without the rating table,
 ## the player's page is the bare panel the source never stops on.
@@ -37,14 +36,17 @@ static func pages(
 	var out: Array = []
 	if data == null or save == null:
 		return out
+	out.append({"kind": PAGE_SAVING, "lines": Gen2SavePrompt.SAVING_RECORD_LINES})
+	var inducted_mons: int = 0
 	for mon: Gen2SaveMon in save.party:
-		if out.size() >= MAX_MONS:
+		if inducted_mons >= MAX_MONS:
 			break
 		## GetHallOfFameParty skips EGG without consuming a slot, so an egg is
 		## not inducted and does not shorten the list either.
 		if mon.is_egg:
 			continue
 		out.append(_mon_page(data, mon))
+		inducted_mons += 1
 	out.append_array(_player_pages(data, save, state))
 	return out
 

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -2,19 +2,16 @@ class_name Gen2HallOfFameScreen
 extends Control
 
 ## The screen behind `halloffame`, embedded in the overworld the way the PC and
-## the mart overlays are. `HallOfFame` saves, walks the party one panel at a time
-## and then shows the player's own with `ProfOaksPCRating` printed into it. What
-## is here is that walk, advanced by A; the credits, the two pic slides and the
-## palette rotations are not. `_HallOfFamePC` reuses the same walk over a stored
-## record. The source pauses 60 frames per panel and moves on by itself; this
-## waits for a key instead, since there is no animation to watch yet and a timer
-## would only be a delay.
+## the mart overlays are: the record box, then `AnimateHallOfFame`'s walk over
+## the party and the player's own panel, advanced by A. The two pic slides and
+## the palette rotations are not here, and the source's 60 frames a panel are a
+## key press instead, there being no animation to watch. `_HallOfFamePC` reuses
+## the same walk over a stored record.
 
 signal closed()
 
 ## `ProfOaksPCRating`'s `PlayMusic MUSIC_NONE` and `PlaySFX`, which reach the
-## overworld's own player rather than one of this screen's: the same way the
-## Pokedex asks for a cry.
+## overworld's own player the way the Pokedex's cry does.
 signal rating_reached(sfx: int)
 
 const BACKDROP: Color = Color.WHITE
@@ -32,6 +29,9 @@ var _index: int = 0
 var _page_renderer: Gen2HallOfFamePage = null
 var _background: TextureRect = null
 var _pic: TextureRect = null
+## `HallOfFame_FadeOutMusic`'s `ld c, 100` behind the record box, and its clock.
+var _saving_frames: int = 0
+var _saving_clock := Gen2WorldAnimation.FrameClock.new()
 
 
 ## [param pages] is [method Gen2HallOfFame.pages]. An empty list closes at once
@@ -72,6 +72,9 @@ func current_page() -> Dictionary:
 ## [member cancelled] says afterwards, and START skips the rest of this team.
 ## `AnimateHallOfFame` reads neither, so an induction ignores them.
 func handle_button(button: int) -> bool:
+	if _saving_frames > 0:
+		## `HallOfFame_FadeOutMusic` ends on `DelayFrames`, which reads nothing.
+		return true
 	if button == Gen2Button.A:
 		advance()
 		return true
@@ -112,10 +115,29 @@ func _build() -> void:
 	add_child(_background)
 
 
+## Hardware frames of the record box. Public so a test owns its own.
+func advance_saving_frames(count: int) -> void:
+	for _step: int in count:
+		if _saving_frames <= 0:
+			return
+		_saving_frames -= 1
+		if _saving_frames <= 0:
+			set_process(false)
+			advance()
+
+
+func _process(delta: float) -> void:
+	advance_saving_frames(_saving_clock.tick(delta))
+
+
 func _refresh() -> void:
 	var page: Dictionary = current_page()
 	if page.is_empty() or _background == null:
 		return
+	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_SAVING:
+		_saving_frames = Gen2SavePrompt.SAVING_RECORD_FRAMES
+		_saving_clock.reset()
+		set_process(true)
 	if page.has("sfx"):
 		rating_reached.emit(int(page["sfx"]))
 	var indices: PackedByteArray = _page_renderer.draw(page)

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -4,22 +4,18 @@ extends Control
 ## The overworld pause menu (engine/menus/start_menu.asm). The list, `_Option`,
 ## `SaveMenu` and every box the pack opens are the cartridge's own screens through
 ## [Gen2StartMenuPage] and [Gen2PackPage], drawn into whichever [Gen2Screen] the
-## host hands over; a caller that hands over none keeps the window-resolution
-## panel below. Pokedex, Pokemon and Pokegear are screens the world already owns,
-## so this only reports the choice through [signal action_chosen]. Pack and Save
-## live here as internal modes.
+## host hands over; a caller handing over none keeps the panel below. Pokedex,
+## Pokemon and Pokegear are the world's, so this only reports the choice.
 
-## Emitted for an available entry this screen does not own itself
-## (Pokedex, Pokemon, Pokegear, Player); the caller opens the matching screen.
-## [param id] is the registering mod's own id where the row is a mod's and the
-## action needs to know whose it is, and is empty for every cartridge row.
+## An available entry this screen does not own (Pokedex, Pokemon, Pokegear,
+## Player); the caller opens it. [param id] is the registering mod's where the
+## row is a mod's, and empty for every cartridge row.
 signal action_chosen(kind: StringName, id: StringName)
 ## Emitted on Exit or cancel from the top-level list.
 signal closed
 ## `.Field`'s PACKSTATE_QUITRUNSCRIPT: an ITEMMENU_CLOSE item whose effect
-## succeeded, so the pack quits and the overworld runs what the effect queued.
-## The payload is the resolved effect, because the screen hosting the world is
-## the one that can cast a rod or draw a warp.
+## succeeded, so the pack quits and the overworld runs what it queued. The
+## payload is the resolved effect: only the world's host can cast a rod.
 signal field_item_used(request: Dictionary)
 
 ## `EvoStoneEffect`'s own `EvolvePokemon`: the pack has already written the party
@@ -44,6 +40,17 @@ enum Mode {
 	SAVE_FAILED, QUIT_ASK, LAUNCHER_ASK, RESET_ASK, OPTIONS, MODS, MOD_OPTIONS,
 	FIELD_MOVES,
 }
+
+## The prompt's step as one of this screen's modes, so its box is drawn the way
+## every other question here is.
+const SAVE_PROMPT_MODES: Dictionary = {
+	Gen2SavePrompt.Step.ASK: Mode.SAVE_ASK,
+	Gen2SavePrompt.Step.OVERWRITE: Mode.SAVE_OVERWRITE,
+	Gen2SavePrompt.Step.SAVING: Mode.SAVE_SAVING,
+	Gen2SavePrompt.Step.SAVED: Mode.SAVE_SAVED,
+	Gen2SavePrompt.Step.FAILED: Mode.SAVE_FAILED,
+}
+
 
 ## The two-row boxes, by the cursor each toggles and the method that repaints it.
 const TOGGLE_MODES: Dictionary = {
@@ -84,16 +91,9 @@ const CONFIRM_HANDLERS: Dictionary = {
 	Mode.FIELD_MOVES: &"_confirm_field_move",
 }
 
-## `SaveMenu`'s four texts, out of `data/text/common_3.asm` on Crystal and
-## `common_2.asm` on Gold and Silver, which no importer reads and which this
-## project authors beside its other engine text. Verbatim, one entry a line, so
-## the box scrolls where `_ContText` scrolls.
-const SAVE_ASK_LINES: Array[String] = [
-	"Would you like to", "save the game?",
-]
-## `AlreadyASaveFileText`. `AnotherSaveFileText` is its sibling for a save file
-## belonging to another player, and `CompareLoadedAndSavedPlayerID` cannot
-## reach it here: a world is always played from the slot it was started in.
+## `SaveMenu`'s question. The words and the frames are [Gen2SavePrompt]'s: every
+## save runs one routine, and only the question in front of it differs.
+const SAVE_ASK_LINES: Array[String] = Gen2SavePrompt.ASK_LINES
 ## `_StartMenuContestEndText`, which `StartMenu_Quit` asks over the same
 ## `YesNoMenuHeader` box the save question uses. Authored here beside the save
 ## texts for the same reason: no importer reads either.
@@ -112,34 +112,16 @@ const LAUNCHER_ASK_LINES: Array[String] = [
 const RESET_ASK_LINES: Array[String] = [
 	"You pressed the", "RESET buttons.", "Reset the game?",
 ]
-const SAVE_OVERWRITE_LINES: Array[String] = [
-	"There is already a", "save file. Is it", "OK to overwrite?",
-]
-const SAVE_SAVING_LINES: Array[String] = [
-	"SAVING… DON'T TURN", "OFF THE POWER.",
-]
-## `_SavedTheGameText`, whose `<PLAYER>` is filled from the save.
-## `RestoreThePPOfWhichMoveText`, `PPRestoredText` and the refusal the pack owes
-## PP UP, whose ceiling the save model does not carry. The first two are
-## `text_far` stubs in `data/text/common_2.asm` that no script reaches, so they
-## are this screen's the way the save boxes below are; the third is this port's
-## own words, because the cartridge has no such refusal.
+## `RestoreThePPOfWhichMoveText` and `PPRestoredText`, `text_far` stubs no script
+## reaches, so they are this screen's the way the questions above are. The third
+## is this port's own words: the save model carries no PP UP ceiling.
 const RESTORE_PP_WHICH_MOVE: String = "Restore the PP of\nwhich move?"
 const PP_RESTORED: String = "PP was restored."
 const PP_UP_UNSUPPORTED: String = "PP UP has no effect\nin this port yet."
 
-const SAVE_SAVED_LINES: Array[String] = [
-	"%s saved", "the game.",
-]
-
-## `SavingDontTurnOffThePower`'s own `ld c, 16`, then `SavedTheGame`'s 32 before
-## the words and 30 after them.
-const SAVE_SAVING_FRAMES: int = 16
-const SAVE_WRITE_FRAMES: int = 32
-const SAVE_DONE_FRAMES: int = 30
-## `ld de, SFX_SAVE` (constants/sfx_constants.asm; the comment column there is
-## hex).
-const SFX_SAVE: int = 0x25
+const SAVE_SAVING_FRAMES: int = Gen2SavePrompt.SAVING_FRAMES
+const SAVE_WRITE_FRAMES: int = Gen2SavePrompt.WRITE_FRAMES
+const SAVE_DONE_FRAMES: int = Gen2SavePrompt.DONE_FRAMES
 
 ## `SwitchItemsInBag`' own two, both hexadecimal the way the constants file
 ## counts: `.place_insert` asks for SFX_SWITCH_POKEMON twice through
@@ -168,11 +150,10 @@ const TEXT_FALLBACKS: Dictionary = {
 }
 
 
-## The pack's submenus, all `MENU_BACKUP_TILES` boxes over the pack's own screen.
-##
+## The pack's submenus, `MENU_BACKUP_TILES` boxes over the pack's own screen.
 ## `MenuHeader_UsableKeyItem` and its five siblings differ only in where the box
-## starts: `menu_coords 13, y, SCREEN_WIDTH - 1, TEXTBOX_Y - 1` with y chosen so
-## the rows end on the text box, which is `TEXTBOX_Y - 1 - 2 * items`.
+## starts: `menu_coords 13, y, SCREEN_WIDTH - 1, TEXTBOX_Y - 1`, y being
+## `TEXTBOX_Y - 1 - 2 * items` so the rows end on the text box.
 const ITEM_MENU_LEFT: int = 13
 const ITEM_MENU_RIGHT: int = 19
 const ITEM_MENU_BOTTOM: int = 11
@@ -281,7 +262,8 @@ var _save_line: int = 0
 var _save_cursor: int = -1
 var _save_frames: int = 0
 var _save_clock := Gen2WorldAnimation.FrameClock.new()
-var _save_result: Dictionary = {}
+## `SaveMenu`'s own sequence while one is up, and null the rest of the time.
+var _save_prompt: Gen2SavePrompt = null
 
 var _options_menu: Gen2WorldOptionsMenu = null
 
@@ -336,14 +318,9 @@ func _ready() -> void:
 		entry.call()
 
 
-## `save_action` is called with no arguments and must return a Dictionary
-## shaped like Gen2WorldScreen.persist_world_snapshot()'s result (an "ok" key,
-## with "reason" on failure). Kept as a Callable so this screen does not need
-## to know how a snapshot is written or where saves live.
-##
-## Mirrors Gen2BoxScreen.set_context(): open() may be called before or after this
-## node enters the tree, so opening the list defers to _ready() until it is in
-## one, and runs immediately here otherwise.
+## `save_action` takes no arguments and answers an "ok" key, with a "reason"
+## behind a false one: a Callable, so this screen does not know where saves live.
+## Called before or after the node enters the tree, the way the box screen is.
 func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_cursor: int = 0) -> bool:
 	_world = world
 	_data = data
@@ -357,12 +334,10 @@ func open(world: Gen2WorldAPI, data: GameData, save_action: Callable, previous_c
 
 
 ## The save the pack's USE applies to, and whether that write reaches disk.
-## Optional: without it the pack still lists items and refuses to use one, which
-## is what a screenshot tool driving an injected world gets.
-##
-## Passed rather than wrapped in a Callable the way `save_action` is, because
-## using an item is a Gen2WorldPartyHost transaction over this same save, not a
-## world-snapshot write only the world screen knows how to do.
+## Without it the pack lists items and refuses to use one, which is what a
+## screenshot tool driving an injected world gets. Passed rather than wrapped the
+## way `save_action` is: USE is a [Gen2WorldPartyHost] transaction over this same
+## save, not a snapshot write only the world screen can do.
 func set_party_context(save: Gen2SaveData, persist: bool = true) -> void:
 	_pack_save = save
 	_pack_persist = persist
@@ -761,6 +736,7 @@ func _contest_status() -> Dictionary:
 
 
 func _open_list_mode() -> void:
+	_save_prompt = null
 	_mode = Mode.LIST
 	## The row the menu reopens on is the one it was left on, which may be past
 	## the window a previous open left behind.
@@ -823,14 +799,11 @@ func _open_mods_mode() -> void:
 	_render_mods()
 
 
-## The rows the MODS entry shows: the host's own VIEW row where the player has
-## more than one view to choose from, then one row per mod that registered a
-## setting. The view is the host's and not any mod's: `Gen2ModHost` holds one
-## selection for both surfaces, persists it and draws it on the launcher's mod
-## page, and a mod registering a VIEW button of its own would be a private copy of
-## that state, six of them for six mods. This is the same list on the surface a
-## player is already changing what a mod does from, which is the only place a
-## shipped build has: `V` is behind [method Gen2DebugKeys.enabled].
+## The rows MODS shows: the host's own VIEW row where there is more than one view
+## to choose from, then one row per mod that registered a setting. The view is
+## the host's rather than any mod's, since `Gen2ModHost` holds one selection for
+## both surfaces; `V` is behind [method Gen2DebugKeys.enabled], so this is the
+## only place a shipped build can change it.
 func _mod_rows() -> Array:
 	var rows: Array = []
 	if Gen2ModHost.instance().view_ids().size() > 1:
@@ -2053,14 +2026,45 @@ func _render_pack_result() -> void:
 
 ## `SaveMenu`'s first question. `LoadStandardMenuHeader` and
 ## `DisplaySaveInfoOnSave` put the info box up before it, and both stay up for
-## every mode below.
+## every mode below. [Gen2SavePrompt] is the sequence; this draws its box.
 func _open_save_confirm_mode() -> void:
-	_enter_save_mode(Mode.SAVE_ASK, SAVE_ASK_LINES, 0)
+	_save_prompt = Gen2SavePrompt.open(
+		Gen2SavePrompt.Kind.MENU,
+		_pack_save.player_name if _pack_save != null else "",
+		_save_action
+	)
+	_sync_save_prompt()
+
+
+func _sync_save_prompt() -> void:
+	if _save_prompt == null:
+		return
+	if _save_prompt.refused():
+		## `.refused`'s carry, which `StartMenu_Save` answers with 0.
+		_save_prompt = null
+		_open_list_mode()
+		return
+	if _save_prompt.finished():
+		## `StartMenu_Save`'s `ld a, 1`, `StartMenu`'s exit and not `.Reopen`.
+		_save_prompt = null
+		closed.emit()
+		return
+	if _save_prompt.sfx_owed():
+		## `SavedTheGame` reaches it through `WaitPlaySFX`; the wait behind it is
+		## not spent, for the reason the intro cry's is not.
+		sfx_requested.emit(Gen2SavePrompt.SFX_SAVE, true)
+	_mode = SAVE_PROMPT_MODES[_save_prompt.step]
+	_save_lines = _save_prompt.lines.duplicate()
+	_save_line = _save_prompt.line
+	_save_cursor = _save_prompt.cursor
+	_save_frames = _save_prompt.frames
+	_render_save()
 
 
 ## The yes/no's own cursor, `YesNoMenuHeader`'s `db 1` default, and the words
 ## the box holds. [param cursor_index] below zero is a mode with no box at all.
 func _enter_save_mode(mode: Mode, lines: Array, cursor_index: int) -> void:
+	_save_prompt = null
 	_mode = mode
 	_save_lines = lines.duplicate()
 	_save_line = 0
@@ -2105,35 +2109,23 @@ func _confirm_save() -> void:
 				closed.emit()
 			else:
 				soft_reset_confirmed.emit()
-		Mode.SAVE_ASK:
-			if _save_cursor == 1:
-				_open_list_mode()
-			else:
-				_enter_save_mode(Mode.SAVE_OVERWRITE, SAVE_OVERWRITE_LINES, -1)
-		Mode.SAVE_OVERWRITE:
-			## `_ContText`'s own `PromptButton` before the third line, which
-			## `AlreadyASaveFileText` is the only one of these texts to carry.
-			if _save_cursor < 0:
-				_save_line = 1
-				_save_cursor = 0
-				_render_save()
-			elif _save_cursor == 1:
-				_open_list_mode()
-			else:
-				_enter_save_mode(Mode.SAVE_SAVING, SAVE_SAVING_LINES, -1)
-		## The two timed modes read no button, since `SavingDontTurnOffThePower`
-		## zeroes the joypad bytes before it prints.
-		Mode.SAVE_SAVING, Mode.SAVE_SAVED:
-			pass
+		## `SavingDontTurnOffThePower` zeroes the joypad bytes before it prints,
+		## and the prompt refuses a button on both timed steps.
+		Mode.SAVE_ASK, Mode.SAVE_OVERWRITE, Mode.SAVE_SAVING, Mode.SAVE_SAVED, \
 		Mode.SAVE_FAILED:
-			_open_list_mode()
+			if _save_prompt != null:
+				_save_prompt.confirm(_save_cursor == 0)
+				_sync_save_prompt()
 
 
 ## B is `YesNoBox`'s no wherever a question is up, and `PromptButton`'s other
 ## button while the text still has a line to come. The two timed modes read no
 ## joypad at all.
 func _cancel_save() -> void:
-	if _save_cursor < 0 and _mode in [Mode.SAVE_OVERWRITE, Mode.RESET_ASK]:
+	if _save_prompt != null:
+		_save_prompt.cancel()
+		_sync_save_prompt()
+	elif _save_cursor < 0 and _mode == Mode.RESET_ASK:
 		_confirm_save()
 	elif _mode == Mode.RESET_ASK:
 		## B is `YesNoBox`'s NO, and the menu was opened for the question alone.
@@ -2164,22 +2156,10 @@ func ask_soft_reset() -> void:
 ## One hardware frame of the two timed modes. Public so a test or a preview owns
 ## its own frames rather than sampling a screen mid-flight.
 func advance_save_frame() -> void:
-	if _mode != Mode.SAVE_SAVING and _mode != Mode.SAVE_SAVED:
+	if _save_prompt == null:
 		return
-	_save_frames += 1
-	match _mode:
-		Mode.SAVE_SAVING:
-			if _save_frames == SAVE_SAVING_FRAMES:
-				_write_save()
-			elif _save_frames == SAVE_SAVING_FRAMES + SAVE_WRITE_FRAMES:
-				_show_save_result()
-		## Exactly, not past: the host is freed a frame later and this would
-		## otherwise emit again on every frame in between.
-		Mode.SAVE_SAVED:
-			if _save_frames == SAVE_DONE_FRAMES:
-				## `StartMenu_Save`'s `ld a, 1`, which is `StartMenu`'s exit
-				## rather than its `.Reopen`.
-				closed.emit()
+	_save_prompt.frame()
+	_sync_save_prompt()
 
 
 func advance_save_frames(count: int) -> void:
@@ -2198,29 +2178,6 @@ func _process(delta: float) -> void:
 		return
 	for _frame: int in _save_clock.tick(delta):
 		advance_save_frame()
-
-
-func _write_save() -> void:
-	_save_result = _save_action.call() if _save_action.is_valid() \
-		else {"ok": false, "reason": &"no_save_action"}
-
-
-## `SavedTheGame`'s words and `SFX_SAVE` behind them. A refused write is this
-## project's own line: the cartridge has no failure path, because its write is
-## to SRAM it has already checked.
-func _show_save_result() -> void:
-	if not bool(_save_result.get("ok", false)):
-		_enter_save_mode(Mode.SAVE_FAILED, [
-			"Save failed:", String(_save_result.get("reason", "unknown")),
-		], 0)
-		return
-	var player_name: String = _pack_save.player_name if _pack_save != null else ""
-	_enter_save_mode(Mode.SAVE_SAVED, [
-		SAVE_SAVED_LINES[0] % player_name, SAVE_SAVED_LINES[1],
-	], -1)
-	## `WaitSFX` after it is not spent, for the reason the intro cry's is not.
-	## `SavedTheGame` reaches SFX_SAVE through `WaitPlaySFX`.
-	sfx_requested.emit(SFX_SAVE, true)
 
 
 ## `DisplaySaveInfoOnSave`'s four rows: the same fields [Gen2TrainerCard]'s

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -67,18 +67,19 @@ static func complete_runtime_request(
 			"request": request.duplicate(true),
 			"results": resumed,
 		}
-	## `_DisplayLinkRecord` draws a page over a save field and writes nothing,
-	## and a room console with no cable on the other end has nothing to exchange:
-	## both run to completion where they are staged, the way the unattended
-	## requests above do. A screen that can draw either intercepts the request in
-	## front of this.
+	## `_DisplayLinkRecord` draws a page over a save field and writes nothing, and
+	## a room console with no cable has nothing to exchange: both run to
+	## completion where they are staged. A screen that can draw either intercepts
+	## the request in front of this.
 	if kind in [&"battle_requested", &"swarm_requested",
 		&"link_record_requested", &"link_room_requested"]:
 		return {"ok": true, "handled": true, "results": world.complete_runtime_request(result)}
-	## Neither reads cartridge data of its own: the region map's landmark and the
-	## bank dial's amount are the whole answer, and the runner owns what is done
-	## with it.
-	if kind in [&"town_map_requested", &"mom_bank_dial_requested"]:
+	## None of the three reads cartridge data of its own: the region map's
+	## landmark, the bank dial's amount and whether `TryQuickSave` wrote are the
+	## whole answer, and the runner owns what is done with it.
+	if kind in [
+		&"town_map_requested", &"mom_bank_dial_requested", &"quick_save_requested",
+	]:
 		return {
 			"ok": true,
 			"handled": true,

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -3,12 +3,9 @@ extends RefCounted
 
 ## `engine/events/pokecenter_pc.asm`: the Pokemon Center's top menu, the item PC
 ## behind its `<PLAYER>'S PC` row, and the two transactions that move a stack
-## between the bag and `wPCItems`. Scene-free like the other world hosts: the rows
-## and their per-state lists are the source's own tables, a host draws whichever
-## list is returned, and the commit boundary is [Gen2WorldTransaction]. Every row
-## of both lists is built, MAIL BOX being `_PlayerMailBoxMenu` over the save's own
-## mailbox, DECORATION [Gen2WorldDecoration]'s and HALL OF FAME [Gen2HallOfFame]'s
-## viewer.
+## between the bag and `wPCItems`. Scene-free like the other world hosts, with
+## [Gen2WorldTransaction] the commit boundary. MAIL BOX is `_PlayerMailBoxMenu`,
+## DECORATION [Gen2WorldDecoration]'s and HALL OF FAME [Gen2HallOfFame]'s.
 
 ## `PokemonCenterPC.Jumptable` indexes.
 const PCPCITEM_PLAYERS_PC: int = 0
@@ -81,8 +78,8 @@ const MAILBOX_EGG: String = "An EGG can't hold\nany MAIL."
 const MAILBOX_MOVED: String = "The MAIL was moved\nfrom the MAILBOX."
 
 ## The top menu behind BILL'S PC, as `{row, name}` in the source's own order.
-## Every row of it is built: MOVE PKMN W/O MAIL is [Gen2BoxScreen]'s `MODE_MOVE`,
-## which is `_MovePKMNWithoutMail`'s own two joypad passes over the same listing.
+## MOVE PKMN W/O MAIL is [Gen2BoxScreen]'s `MODE_MOVE`, `_MovePKMNWithoutMail`'s
+## own two joypad passes over the same listing.
 static func bills_pc_menu() -> Array:
 	var out: Array = []
 	for row: int in BILLS_PC_ROWS.size():
@@ -156,10 +153,20 @@ static func can_open(save: Gen2SaveData) -> bool:
 	return save != null and not save.party.is_empty()
 
 
-## The bag as rows a deposit list can draw, and the PC as rows a withdraw or
-## toss list can. Both keep the order the map holds, which is the order the
-## items were received: `wPCItems` is a packed array `ReceiveItemFromPC` appends
-## to, and `SwitchItemsInBag` is the only thing that reorders one.
+## `IsAnyMonHoldingMail`, which refuses the whole of MOVE PKMN W/O MAIL. It walks
+## the party alone, so a boxed Pokemon holding mail does not stop it.
+static func any_party_mon_holds_mail(save: Gen2SaveData) -> bool:
+	if save == null:
+		return false
+	for mon: Gen2SaveMon in save.party:
+		if mon != null and Gen2HeldItem.is_mail(mon.item):
+			return true
+	return false
+
+
+## The bag as rows a deposit list can draw, and the PC as rows a withdraw or toss
+## list can. Both keep the received order: `wPCItems` is a packed array
+## `ReceiveItemFromPC` appends to and `SwitchItemsInBag` alone reorders.
 static func bag_entries(data: GameData, state: Gen2WorldState) -> Array:
 	return _entries(data, state.items() if state != null else {})
 
@@ -188,10 +195,9 @@ static func _entries(data: GameData, owned: Dictionary) -> Array:
 	return out
 
 
-## `PlayerDepositItemMenu`: the stack leaves `wNumItems` and arrives in
-## `wNumPCItems`. The source refuses an item whose `CheckItemMenu` attribute is
-## one of the three `.no_toss` rows, which is what keeps a key item out of the
-## PC.
+## `PlayerDepositItemMenu`: the stack leaves `wNumItems` for `wNumPCItems`. An
+## item whose `CheckItemMenu` attribute is one of the three `.no_toss` rows is
+## refused, which is what keeps a key item out of the PC.
 static func deposit(
 	world: Gen2WorldAPI, save: Gen2SaveData, item: int, quantity: int = 1,
 	persist: bool = true
@@ -258,10 +264,9 @@ static func _transfer(
 		return Gen2WorldTransaction.failure(&"item_stack_full", {
 			"item": item, "quantity": quantity, "owned": destination,
 		})
-	## `ReceiveItem` fails on a full destination list before anything is taken
-	## from the source, which is what `.PackFull` and `.NoRoomInPC` report. The
-	## bag's own check is per pocket, so it goes through the pack's; the PC is
-	## one flat list of fifty.
+	## `ReceiveItem` fails on a full destination before anything leaves the
+	## source, which `.PackFull` and `.NoRoomInPC` report. The bag's check is per
+	## pocket and goes through the pack's; the PC is one flat list of fifty.
 	if to_pc:
 		if destination == 0 and world.state.pc_items().size() >= Gen2WorldPack.MAX_PC_ITEMS:
 			return Gen2WorldTransaction.failure(&"pc_full", {"item": item})
@@ -353,10 +358,9 @@ static func mailbox_to_pack(
 	}
 
 
-## `.AttachMail`, once `PartyMenuSelect` has picked a member. The two refusals
-## in front of it are the caller's, because both print and go back to the same
-## list: an egg cannot hold mail and a member already holding an item is not
-## asked to swap.
+## `.AttachMail`, once `PartyMenuSelect` has picked a member. Its two refusals
+## are the caller's, both printing and going back to the same list: an egg cannot
+## hold mail, and a member already holding an item is not asked to swap.
 static func mailbox_attach(
 	world: Gen2WorldAPI, save: Gen2SaveData, index: int, slot: int,
 	persist: bool = true

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3638,6 +3638,7 @@ func _preview_pc(mode: StringName) -> void:
 	if not host.open_pc_machine(_world, _data, save, false, mode):
 		Gen2Screen.drop(host)
 		return
+	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
@@ -3662,6 +3663,7 @@ func preview_mom_bank(mode: StringName, saved: int, held: int) -> void:
 	if not host.open_mom_bank(_world, _data, mode, saved, held):
 		Gen2Screen.drop(host)
 		return
+	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
@@ -5489,6 +5491,7 @@ func _open_service_host() -> void:
 		_script_prompt = "Service request unavailable"
 		_refresh_labels()
 		return
+	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
@@ -6706,6 +6709,7 @@ func _open_host_prompt(text: String) -> bool:
 	if not host.open_prompt(_world, _data, save, _injected_save == null, text):
 		Gen2Screen.drop(host)
 		return false
+	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
@@ -6742,6 +6746,7 @@ func _open_service_overlay(kind: StringName) -> void:
 		_script_prompt = "%s unavailable" % label
 		_refresh_labels()
 		return
+	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
@@ -6772,6 +6777,7 @@ func _open_fly_map(request: Dictionary) -> void:
 		_script_prompt = "Region map unavailable"
 		_refresh_labels()
 		return
+	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
@@ -7182,16 +7188,41 @@ func _request_bug_contest_judging(_request: Dictionary) -> StringName:
 	return &"return"
 
 
-## `TryQuickSave` writes the save where it stands and answers TRUE; a write that
-## fails answers FALSE, which is the same "no" the source gives a player who
-## declines.
+## `TryQuickSave`, which is `Link_SaveGame`: the overwrite question, the SAVING
+## box and `SavedTheGame`, on the service screen where BILL'S PC's already are. A
+## driver with no scene behind it still writes rather than hanging.
 func _request_quick_save(_request: Dictionary) -> StringName:
+	if _service_host == null and _open_quick_save_screen():
+		return &"break"
 	var written: Dictionary = persist_world_snapshot()
 	_show_script_results(_world.complete_runtime_request({
 		"ok": true,
 		"script_value": 1 if bool(written.get("ok", false)) else 0,
 	}))
 	return &"return"
+
+
+func _open_quick_save_screen() -> bool:
+	var host: Gen2WorldServiceScreen = SERVICE_SCENE.instantiate() as Gen2WorldServiceScreen
+	if host == null:
+		return false
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	host.set_screen(_screen)
+	add_child(host)
+	var save: Gen2SaveData = _injected_save if _injected_save != null \
+		else _selected_runtime_save()
+	host.save_action = persist_world_snapshot
+	if not host.open_quick_save(_world, _data, save, _injected_save == null):
+		Gen2Screen.drop(host)
+		return false
+	host.completed.connect(_on_service_completed)
+	host.sfx_requested.connect(_play_sfx)
+	host.cry_requested.connect(_play_species_cry)
+	_service_host = host
+	_script_prompt = "Saving"
+	_refresh_labels()
+	return true
 
 
 func _request_swarm(request: Dictionary) -> StringName:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -6,18 +6,13 @@ extends Control
 ## hosts and API.
 
 signal completed(results: Array)
-## The sound this screen asks for, played by whoever owns the driver. Nothing here
-## reaches [Gen2AudioPlayer]: the world screen owns the one player a map's music
-## and its effects share, so a second surface asking for a sound goes through it.
-## [Gen2WorldAudioHost] is an inspection probe that renders no samples and must
-## never stand in for it. [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent in
-## front of the sound by hand: the cartridge holds there until the four effect
-## channels are free, so the request can never be the one `PlaySFX`'s priority gate
-## refuses. The wait itself is not spent.
+## The sound this screen asks for, played by whoever owns the driver: the world
+## screen owns the one player a map's music and its effects share, and
+## [Gen2WorldAudioHost] is an inspection probe that must never stand in for it.
+## [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent by hand, so the request
+## can never be the one `PlaySFX`'s priority gate refuses; the wait is not spent.
 signal sfx_requested(index: int, waited: bool)
-## `PlayMonCry2` from a screen this one opens, the box screen's stats page today.
-## Passed on for the same reason [signal sfx_requested] is: the world screen owns
-## the one player.
+## `PlayMonCry2` from a screen this one opens, passed on for the same reason.
 signal cry_requested(species: int)
 
 enum MODE {
@@ -27,6 +22,7 @@ enum MODE {
 	PC_DECO, PC_DECO_LIST, PC_DECO_SIDE,
 	PC_BOX_SUBMENU,
 	PC_MAILBOX, PC_MAIL_SUBMENU, PC_MAIL_CONFIRM,
+	PC_SAVE,
 	ELEVATOR,
 }
 
@@ -46,25 +42,22 @@ const BOX_SCENE := preload("res://game/save/box_screen.tscn")
 ## and the move tutor open.
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 
-## `wPokegearRadioMusicPlaying`, which is what `ExitPokegearRadio_HandleMusic`
-## branches on: zero while nothing in this overlay has touched the music, and
-## one of the source's own two values once the radio card has.
+## `wPokegearRadioMusicPlaying`, which `ExitPokegearRadio_HandleMusic` branches
+## on: zero until the radio card has touched the music, then one of its two.
 const RADIO_MUSIC_SILENT: int = 0
 const RADIO_MUSIC_RESTART_MAP: int = 0xFE
 const RADIO_MUSIC_ENTER_MAP: int = 0xFF
 
 const WorldMenu := preload("res://game/world/world_menu.gd")
 
-## `BuyMenuLoop`'s four states: the list `ScrollingMenu` runs, the quantity
-## `SelectQuantityToBuy` asks for, `MartConfirmPurchase`'s yes/no, and a box
-## waiting on `JoyWaitAorB`.
+## `BuyMenuLoop`'s four states: `ScrollingMenu`'s list, `SelectQuantityToBuy`'s
+## quantity, `MartConfirmPurchase`'s yes/no and a box on `JoyWaitAorB`.
 const MART_LIST: StringName = &"list"
 const MART_QUANTITY: StringName = &"quantity"
 const MART_CONFIRM: StringName = &"confirm"
 const MART_MESSAGE: StringName = &"message"
-## `StandardMart`'s own jumptable, which only `MartDialog` runs: the BUY/SELL/QUIT
-## menu and the three states `SellMenu` adds behind its SELL row. The other four
-## shop types open `BuyMenu` and nothing else.
+## `StandardMart`'s jumptable, which only `MartDialog` runs: the BUY/SELL/QUIT
+## menu and the three states behind SELL. The other four shops open `BuyMenu`.
 const MART_TOP: StringName = &"top"
 const MART_SELL: StringName = &"sell"
 const MART_SELL_QUANTITY: StringName = &"sell_quantity"
@@ -73,16 +66,14 @@ const MART_SELL_STAGES: Array[StringName] = [
 	MART_SELL, MART_SELL_QUANTITY, MART_SELL_CONFIRM,
 ]
 ## `MenuHeader_BuySell`'s three rows, inline in `engine/items/mart.asm` and
-## reached by no script, so they are this screen's the way [Gen2WorldPC]'s
-## BILL'S PC rows are.
+## reached by no script, the way [Gen2WorldPC]'s BILL'S PC rows are.
 const MART_TOP_ROWS: Array[String] = ["BUY", "SELL", "QUIT"]
 const MART_TOP_BUY: int = 0
 const MART_TOP_SELL: int = 1
 const MART_TOP_QUIT: int = 2
 ## Which of `GetMartDialogGroup.MartTextFunctionPointers`' groups a variant
-## reads. The rooftop sale takes the standard group, which is why it has no
-## prefix of its own; the bargain shop's `MARTTEXT_HOW_MANY` slot is
-## `BuyMenuLoop` rather than a text, so it asks no quantity.
+## reads. The rooftop sale takes the standard group; the bargain shop's
+## `MARTTEXT_HOW_MANY` slot is `BuyMenuLoop`, so it asks no quantity.
 const MART_TEXT_PREFIX: Dictionary = {
 	&"standard": "", &"bitter": "bitter_", &"bargain": "bargain_",
 	&"pharmacy": "pharmacy_", &"rooftop_mart_1": "", &"rooftop_mart_2": "",
@@ -101,8 +92,7 @@ const SFX_CALL: int = 0x6A
 const SFX_NO_SIGNAL: int = 0x6C
 
 ## `BillsPC_ChangeBoxSubmenu.MenuData`'s four rows, inline in `bills_pc.asm` and
-## reached by no script, so they are this screen's the way the machine's own top
-## menu is.
+## reached by no script, so they are this screen's the way the top menu is.
 const BOX_SUBMENU_SWITCH: int = 0
 const BOX_SUBMENU_NAME: int = 1
 const BOX_SUBMENU_PRINT: int = 2
@@ -119,10 +109,18 @@ const MART_TEXT_ROWS: int = 2
 ## `text_decimal` marker says which of the two numbers it wants.
 const HRAM_FIRST: int = 0xFF00
 
+## The one writer, handed over by whoever opened this screen: the same
+## `SaveGameData` the START menu's SAVE row reaches.
+var save_action: Callable = Callable()
+
 var _world: Gen2WorldAPI = null
 var _data: GameData = null
 var _save: Gen2SaveData = null
 var _persist: bool = false
+## The save sequence while one is up, and what to do once it has finished.
+var _save_prompt: Gen2SavePrompt = null
+var _save_after: StringName = &""
+var _save_clock := Gen2WorldAnimation.FrameClock.new()
 var _request: Dictionary = {}
 var _resolved: Dictionary = {}
 var _mode: int = -1
@@ -217,12 +215,11 @@ const BOX_LIST_ROWS: int = 4
 const PC_ROW_MODES: Array = [
 	MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST, MODE.PC_BOX_SUBMENU,
 	MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
-	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
+	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_SAVE,
 ]
-## The `db rows` byte of every scrolling menu this screen hosts, which is how
-## many of its list a window shows at once. `wMenuScrollPosition` is one value
-## here, the way it is one address on the cartridge: only one of these lists is
-## ever open.
+## The `db rows` byte of every scrolling menu here, which is how much of its list
+## a window shows. `wMenuScrollPosition` is one value, the way it is one address
+## on the cartridge: only one of these lists is ever open.
 const SCROLLING_ROWS: Dictionary = {
 	MODE.PC_BOX_LIST: BOX_LIST_ROWS,
 	## `MailboxPC.TopMenuData`, `.PCItemsMenuData` and
@@ -440,10 +437,9 @@ func handle_button(button: int) -> bool:
 	return false
 
 
-## `PCItemsJoypad`'s `.select_1` and `.a_select_2`, which are one press of
-## `SwitchItemsInBag` over `wPCItems`. Only the two lists that show the PC's own
-## items reach it: a deposit is `DepositSellPack`, whose joypad handler has no
-## SELECT in it.
+## `PCItemsJoypad`'s `.select_1` and `.a_select_2`, one press of
+## `SwitchItemsInBag` over `wPCItems`. A deposit is `DepositSellPack`, whose
+## joypad handler has no SELECT in it.
 func _press_pc_item_select() -> bool:
 	if _mode != MODE.PC_ITEM_LIST \
 		or _pc_action == Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM:
@@ -506,6 +502,22 @@ func open_prompt(
 		return false
 	_host_prompt = true
 	_open_menu({"text": text, "choices": Gen2WorldMenu.YES_NO_KEYS})
+	return true
+
+
+## `TryQuickSave`: no question of its own, so it opens on the overwrite one and
+## answers the script with whether it wrote.
+func open_quick_save(
+	world: Gen2WorldAPI, data: GameData, save: Gen2SaveData, persist: bool
+) -> bool:
+	_world = world
+	_data = data
+	_save = save
+	_persist = persist
+	if _world == null or _data == null:
+		_show_error("A quick save has no world or cartridge cache.")
+		return false
+	_open_save_prompt(Gen2SavePrompt.Kind.LINK, &"quick_save")
 	return true
 
 
@@ -1180,12 +1192,8 @@ func _finish_apricorns() -> void:
 
 ## `Mom_SetUpDepositMenu` and `Mom_SetUpWithdrawMenu` over
 ## `Mom_WithdrawDepositMenuJoypad`. The model owns the amount and the cursor;
-## this owns the box and the blink.
-##
-## `Mom_Wait10Frames` stands between the box and the joypad so a press that
-## opened it cannot be read as a press on it. The world screen spends the press
-## that reaches here, so those ten frames are not held: what they are for is
-## already true.
+## this owns the box and the blink. `Mom_Wait10Frames` is not held: the world
+## screen already spends the press that opened the box.
 func _open_mom_bank(values: Dictionary) -> void:
 	_mode = MODE.MOM_BANK
 	_mom_dial = Gen2WorldMoneyDial.open(
@@ -1219,9 +1227,16 @@ func _finish_mom_bank(amount: int) -> void:
 	_finish_runtime({"ok": true, "amount": amount})
 
 
-## The digit under the cursor is drawn for sixteen frames in every thirty-two,
-## so only a crossing of the half period is redrawn.
-func _process(_delta: float) -> void:
+## The save sequence's frames, and the money dial's cursor, whose digit is drawn
+## for sixteen frames in every thirty-two: only a crossing of that is redrawn.
+func _process(delta: float) -> void:
+	if _save_prompt != null:
+		for _frame: int in _save_clock.tick(delta):
+			_save_prompt.frame()
+			_advance_save_prompt()
+			if _save_prompt == null:
+				return
+		return
 	if _mode != MODE.MOM_BANK or _mom_dial == null:
 		return
 	var was_up: bool = _mom_cursor_up()
@@ -1444,7 +1459,18 @@ func _confirm_bills_pc_row(row: int) -> void:
 		Gen2WorldPC.BILLSPCITEM_CHANGE_BOX:
 			_open_box_list()
 		Gen2WorldPC.BILLSPCITEM_MOVE_WITHOUT_MAIL:
-			_open_boxes(Gen2BoxScreen.MODE_MOVE)
+			## `BillsPC_MovePKMNMenu`, whose two halves are the mail refusal
+			## and `StartMoveMonWOMail_SaveGame`.
+			if Gen2WorldPC.any_party_mon_holds_mail(_save):
+				_open_pc_text(
+					[
+						"\n".join(Gen2SavePrompt.MON_HOLDING_MAIL_LINES.slice(0, 2)),
+						"\n".join(Gen2SavePrompt.MON_HOLDING_MAIL_LINES.slice(2, 4)),
+					],
+					&"bills_pc", "BILL's PC"
+				)
+			else:
+				_open_save_prompt(Gen2SavePrompt.Kind.MOVE_MON, &"move_mons")
 		Gen2WorldPC.BILLSPCITEM_SEE_YA:
 			_leave_bills_pc()
 
@@ -1665,6 +1691,94 @@ func _leave_decorations() -> void:
 	_finish_runtime({"ok": true, "script_value": 0})
 
 
+## `ChangeBoxSaveGame` and `StartMoveMonWOMail_SaveGame`, which [Gen2SavePrompt]
+## owns; this draws the box it is holding and spends its frames.
+func _open_save_prompt(kind: Gen2SavePrompt.Kind, after: StringName) -> void:
+	_save_after = after
+	_save_prompt = Gen2SavePrompt.open(
+		kind, _save.player_name if _save != null else "", _write_service_save
+	)
+	_save_clock.reset()
+	set_process(true)
+	_render_save_prompt()
+
+
+## `SaveGameData`, which the opener hands over. A screen driven with no writer
+## behind it answers the same success without touching a file, the way a
+## transaction with `persist` off does.
+func _write_service_save() -> Dictionary:
+	if not save_action.is_valid():
+		return {"ok": true, "kind": &"not_persisted"}
+	return save_action.call()
+
+
+## Hardware frames of the save sequence. Public so a test owns its own.
+func advance_save_frames(count: int) -> void:
+	for _step: int in count:
+		if _save_prompt == null:
+			return
+		_save_prompt.frame()
+		_advance_save_prompt()
+
+
+## A on the box is YES where the cursor stands on it, and B is `YesNoBox`'s NO.
+func _press_save_prompt(accepted: bool) -> void:
+	if _save_prompt == null:
+		return
+	if accepted:
+		_save_prompt.confirm(_cursor == 0)
+	else:
+		_save_prompt.cancel()
+	_advance_save_prompt()
+
+
+func _render_save_prompt() -> void:
+	if _save_prompt == null:
+		return
+	_mode = MODE.PC_SAVE
+	_cursor = maxi(_save_prompt.cursor, 0)
+	_pc_rows = [{"row": 0, "name": "YES"}, {"row": 1, "name": "NO"}] \
+		if _save_prompt.cursor >= 0 else []
+	_summary = "\n".join(_save_prompt.lines.slice(_save_prompt.line))
+	_status = ""
+	_render_rows()
+
+
+## A, B and a frame all sync the same way: the prompt decides what its step
+## reads.
+func _advance_save_prompt() -> void:
+	if _save_prompt == null:
+		return
+	if _save_prompt.writing_now() and _save_after == &"change_box":
+		## `ChangeBoxSaveGame` puts `wCurBox` between the two halves, so the
+		## write switches the box rather than the answer.
+		_box_index = _box_submenu_index
+		if _save != null:
+			_save.current_box = _box_index
+	if _save_prompt.sfx_owed():
+		sfx_requested.emit(Gen2SavePrompt.SFX_SAVE, true)
+	if not _save_prompt.finished():
+		_render_save_prompt()
+		return
+	var refused: bool = _save_prompt.refused()
+	var after: StringName = _save_after
+	_save_prompt = null
+	_save_after = &""
+	set_process(false)
+	if after == &"quick_save":
+		## TRUE for a save that was written, FALSE for one that was not.
+		_finish_runtime({"ok": true, "script_value": 0 if refused else 1})
+		return
+	if after == &"change_box":
+		_open_box_list()
+		return
+	if refused:
+		## `.refused`'s carry, which `BillsPC_MovePKMNMenu` takes to `.quit`.
+		_open_bills_pc_menu()
+		return
+	_open_boxes(Gen2BoxScreen.MODE_MOVE)
+
+
 ## A run of the PC's own boxes, acknowledged one at a time.
 func _open_pc_text(pages: Array, after: StringName, label: String) -> void:
 	_mode = MODE.PC_TEXT
@@ -1698,6 +1812,9 @@ func _advance_pc_text() -> void:
 		return
 	if _pc_after == &"decoration":
 		_open_decorations()
+		return
+	if _pc_after == &"bills_pc":
+		_open_bills_pc_menu()
 		return
 	_open_pc(&"pokemon_center")
 
@@ -1759,13 +1876,13 @@ func _open_box_submenu(index: int) -> void:
 func _confirm_box_submenu(row: int) -> void:
 	match row:
 		BOX_SUBMENU_SWITCH:
-			## `.Switch`: `wCurBox` and nothing else, and the box it is already
-			## on is a `ret z` rather than a second save.
-			if _box_submenu_index != _box_index:
-				_box_index = _box_submenu_index
-				if _save != null:
-					_save.current_box = _box_index
-			_open_box_list()
+			## `.Switch`: the box it is already on is a `ret z` rather than a
+			## save, and any other one is `ChangeBoxSaveGame`, which asks before
+			## it writes and puts `wCurBox` between its two halves.
+			if _box_submenu_index == _box_index:
+				_open_box_list()
+			else:
+				_open_save_prompt(Gen2SavePrompt.Kind.CHANGE_BOX, &"change_box")
 		BOX_SUBMENU_NAME:
 			_open_box_naming()
 		BOX_SUBMENU_PRINT:
@@ -1987,6 +2104,7 @@ func _open_boxes(mode: int) -> void:
 	add_child(host)
 	host.set_context(_data, _save, _persist, true, mode, _box_index)
 	host.cry_requested.connect(_on_boxes_cry)
+	host.sfx_requested.connect(sfx_requested.emit)
 	host.closed.connect(_on_boxes_closed)
 
 
@@ -2374,6 +2492,9 @@ func _confirm() -> void:
 			return
 		_confirm_pc_item()
 		return
+	if _mode == MODE.PC_SAVE:
+		_press_save_prompt(true)
+		return
 	if _mode == MODE.PC_TEXT:
 		_advance_pc_text()
 		return
@@ -2387,53 +2508,72 @@ func _confirm() -> void:
 		_finish_runtime({"ok": true, "script_value": 1})
 
 
+## B, by mode. `.cancel`, `.shutdown` and `VerticalMenu`'s carry are one thing:
+## back to the list the mode was opened from, and out off the top menu.
+const CANCEL_HANDLERS: Dictionary = {
+	MODE.PC_BOXES: &"_leave_bills_pc",
+	MODE.PC_BOX_LIST: &"_open_bills_pc_menu",
+	MODE.PC_BOX_SUBMENU: &"_open_box_list",
+	MODE.PC: &"_shut_down_pc",
+	MODE.PC_ITEMS: &"_cancel_pc_items",
+	MODE.PC_ITEM_LIST: &"_cancel_pc_item_list",
+	MODE.PC_MAILBOX: &"_open_pc_items",
+	MODE.PC_MAIL_SUBMENU: &"_open_mailbox",
+	MODE.PC_MAIL_CONFIRM: &"_refuse_mail_to_pack",
+	MODE.PC_DECO: &"_leave_decorations",
+	MODE.PC_DECO_LIST: &"_open_decorations",
+	MODE.PC_DECO_SIDE: &"_cancel_deco_side",
+	MODE.PC_SAVE: &"_refuse_save_prompt",
+	MODE.PC_TEXT: &"_advance_pc_text",
+	MODE.MENU: &"_finish_input_cancelled",
+	MODE.PHONE: &"_cancel_phone",
+	MODE.TOWN_MAP: &"_cancel_town_map",
+}
+
+
 func _cancel() -> void:
-	if _mode == MODE.PC_BOXES:
-		## `.cancel`: B off the top menu is the same way out SEE YA! is.
-		_leave_bills_pc()
-	elif _mode == MODE.PC_BOX_LIST:
-		_open_bills_pc_menu()
-	elif _mode == MODE.PC_BOX_SUBMENU:
-		## `VerticalMenu`'s carry, which `.ret c` takes back to `.loop`.
-		_open_box_list()
-	elif _mode == MODE.PC:
-		## `.shutdown`: B off the top menu is the same shut-down TURN OFF is.
+	if CANCEL_HANDLERS.has(_mode):
+		call(CANCEL_HANDLERS[_mode])
+
+
+func _shut_down_pc() -> void:
+	_finish_runtime({"ok": true, "script_value": 0})
+
+
+func _cancel_pc_items() -> void:
+	if _pc_house:
 		_finish_runtime({"ok": true, "script_value": 0})
-	elif _mode == MODE.PC_ITEMS:
-		if _pc_house:
-			_finish_runtime({"ok": true, "script_value": 0})
-		else:
-			_open_pc(&"pokemon_center")
-	elif _mode == MODE.PC_ITEM_LIST:
-		## `.b_2`: the mark is dropped and the list stays up.
-		if _pc_switch >= 0:
-			_pc_switch = -1
-			_render_rows()
-			return
-		_open_pc_items()
-	elif _mode == MODE.PC_MAILBOX:
-		## `ScrollingMenu`'s PAD_B, which is `.exit` and the way back to the
-		## menu `_PlayerMailBoxMenu` was called from.
-		_open_pc_items()
-	elif _mode == MODE.PC_MAIL_SUBMENU:
-		## `VerticalMenu`'s carry, which `.subexit` takes back to `.loop`.
-		_open_mailbox()
-	elif _mode == MODE.PC_MAIL_CONFIRM:
-		_confirm_mail_to_pack(false)
-	elif _mode == MODE.PC_DECO:
-		_leave_decorations()
-	elif _mode == MODE.PC_DECO_LIST:
-		_open_decorations()
-	elif _mode == MODE.PC_DECO_SIDE:
-		_open_decoration_category(_deco_slot)
-	elif _mode == MODE.PC_TEXT:
-		## Both `PromptButton` answers advance the box; neither leaves early.
-		_advance_pc_text()
-	elif _mode == MODE.MENU:
-		_finish_input_cancelled()
-	elif _mode == MODE.PHONE:
-		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
-	elif _mode == MODE.TOWN_MAP and _town_map != null:
+	else:
+		_open_pc(&"pokemon_center")
+
+
+## `.b_2`: the mark is dropped and the list stays up.
+func _cancel_pc_item_list() -> void:
+	if _pc_switch >= 0:
+		_pc_switch = -1
+		_render_rows()
+		return
+	_open_pc_items()
+
+
+func _refuse_mail_to_pack() -> void:
+	_confirm_mail_to_pack(false)
+
+
+func _refuse_save_prompt() -> void:
+	_press_save_prompt(false)
+
+
+func _cancel_deco_side() -> void:
+	_open_decoration_category(_deco_slot)
+
+
+func _cancel_phone() -> void:
+	_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
+
+
+func _cancel_town_map() -> void:
+	if _town_map != null:
 		_town_map.close()
 
 
@@ -2575,7 +2715,7 @@ func _box_count_note() -> Dictionary:
 
 
 ## An overlay owns all 160x144 while it is up: the mart, box storage, a Pokegear
-## card and the region map are each a screen rather than a box over this one.
+## card and the region map are screens rather than boxes over this one.
 func _set_overlay_open(open: bool) -> void:
 	_overlay_open = open
 	_apply_layer_visibility()
@@ -2650,6 +2790,10 @@ func _service_box() -> Gen2MenuBox:
 		MODE.PC_MAIL_CONFIRM:
 			## `YesNoBox`'s own box, which `.PutInPack` opens over its question.
 			return Gen2MenuBox.yes_no()
+		MODE.PC_SAVE:
+			## The same `YesNoBox`, and nothing at all on the timed steps: they
+			## are a box with no question on it.
+			return Gen2MenuBox.yes_no() if _pc_rows.size() == 2 else null
 		MODE.PC_DECO:
 			return _deco_category_box()
 		MODE.PC_DECO_SIDE:
@@ -2749,7 +2893,7 @@ func _option_count() -> int:
 	if _mode in [
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
 		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
-		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
+		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_SAVE,
 	]:
 		return _pc_rows.size()
 	if _mode == MODE.PC_ITEM_LIST:

--- a/tests/integration/test_world_credits_screen.gd
+++ b/tests/integration/test_world_credits_screen.gd
@@ -174,6 +174,11 @@ func test_the_hall_of_fame_runs_into_unskippable_credits() -> void:
 	await _open_world()
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
+	## `InitDisplayForHallOfFame`'s record box reads no joypad and moves on after
+	## a hundred frames of its own.
+	_world_screen._hall_of_fame_host.advance_saving_frames(
+		Gen2SavePrompt.SAVING_RECORD_FRAMES
+	)
 	while _world_screen._hall_of_fame_host != null:
 		_world_screen._hall_of_fame_host.handle_button(Gen2Button.A)
 	await get_tree().process_frame

--- a/tests/integration/test_world_hall_of_fame_screen.gd
+++ b/tests/integration/test_world_hall_of_fame_screen.gd
@@ -57,6 +57,11 @@ func test_the_overlay_opens_with_one_page_per_party_member_and_the_player() -> v
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
 	assert_not_null(_host())
+	## `InitDisplayForHallOfFame`'s record box stands in front of the panels and
+	## moves on by itself after a hundred frames.
+	assert_eq(_host().remaining(), 1 + 2 + RATING_PAGES)
+	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_SAVING)
+	_spend_record_box()
 	assert_eq(_host().remaining(), 2 + RATING_PAGES)
 	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_MON)
 
@@ -77,6 +82,7 @@ func test_a_key_walks_the_pages_and_the_last_one_closes_the_overlay() -> void:
 	await _open_world(1)
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
+	_spend_record_box()
 	assert_eq(_host().remaining(), 1 + RATING_PAGES)
 
 	_host().handle_button(Gen2Button.A)
@@ -101,6 +107,7 @@ func test_an_unrelated_key_does_not_advance_a_page() -> void:
 	await _open_world(2)
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
+	_spend_record_box()
 	var before: int = _host().remaining()
 	assert_false(_host().handle_button(Gen2Button.B))
 	assert_eq(_host().remaining(), before)
@@ -150,7 +157,21 @@ func test_the_halloffame_command_opens_the_overlay() -> void:
 
 
 ## The panels are answered one at a time; a test that only wants the overlay
-## closed does not care how many there were.
+## closed does not care how many there were. The record box in front of them
+## reads no joypad, so its frames are spent first.
 func _advance_to_the_end() -> void:
+	if StringName(_host().current_page()["kind"]) == Gen2HallOfFame.PAGE_SAVING:
+		_spend_record_box()
 	while _world_screen._hall_of_fame_host != null:
 		_host().handle_button(Gen2Button.A)
+
+
+## `HallOfFame_FadeOutMusic`'s `ld c, 100` behind `InitDisplayForHallOfFame`.
+func _spend_record_box() -> void:
+	assert_eq(
+		StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_SAVING
+	)
+	var before: int = _host().remaining()
+	assert_true(_host().handle_button(Gen2Button.A), "the box reads no joypad")
+	assert_eq(_host().remaining(), before, "and does not advance on one")
+	_host().advance_saving_frames(Gen2SavePrompt.SAVING_RECORD_FRAMES)

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -123,6 +123,52 @@ func test_players_house_pc_opens_the_item_pc_and_resumes_the_waiting_script() ->
 	assert_false(_world_screen._world.script_input_waiting())
 
 
+## `special TryQuickSave`, which the cable club and the Battle Tower both ask for
+## before they start. `Link_SaveGame` has no question of its own, so the box that
+## opens is `AskOverwriteSaveFile`'s; writing with nothing on screen was the
+## defect.
+func test_try_quick_save_asks_before_it_writes_and_answers_the_script() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts["48:6195"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_TRY_QUICK_SAVE, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	_data = GameData.open_directory(Fixture.directory())
+	await _open_world()
+	_world_screen._world.current_map.events["coord_events"][0]["script"] = 0x6195
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(Vector2i(7, 6))
+	)
+	await get_tree().process_frame
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_not_null(host)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_SAVE)
+	_world_screen._injected_save.world = null
+	assert_eq(host._save_prompt.lines, Gen2SavePrompt.OVERWRITE_LINES)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._save_prompt.step, Gen2SavePrompt.Step.SAVING)
+	host.advance_save_frames(
+		Gen2SavePrompt.SAVING_FRAMES + Gen2SavePrompt.WRITE_FRAMES
+		+ Gen2SavePrompt.DONE_FRAMES
+	)
+	await get_tree().process_frame
+	assert_null(_world_screen._service_host)
+	assert_not_null(_world_screen._injected_save.world, "the write landed")
+
+
+## Both questions taken with YES, and every frame the two boxes behind them own.
+func _answer_save_prompt(host: Gen2WorldServiceScreen) -> void:
+	for _press: int in 4:
+		host.handle_button(Gen2Button.A)
+	host.advance_save_frames(
+		Gen2SavePrompt.SAVING_FRAMES + Gen2SavePrompt.WRITE_FRAMES
+		+ Gen2SavePrompt.DONE_FRAMES
+	)
+
+
 ## `BillsPC_ChangeBoxSubmenu`: SWITCH writes `wCurBox`, NAME opens the keyboard
 ## over `sBoxNames`, and PRINT answers `GetBoxCount` before it reaches the
 ## printer that is not there.
@@ -136,11 +182,13 @@ func test_change_box_switches_names_and_prints_a_box() -> void:
 	host.handle_button(Gen2Button.A)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
 
-	## The second box, then SWITCH.
+	## The second box, then SWITCH, which is `ChangeBoxSaveGame`: the question,
+	## the overwrite question and the save behind them.
 	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_SUBMENU)
 	host.handle_button(Gen2Button.A)
+	_answer_save_prompt(host)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
 	assert_eq(host._box_index, 1)
 	assert_eq(host._save.current_box, 1)
@@ -210,6 +258,74 @@ func test_pokemon_center_pc_opens_the_top_menu_and_bills_pc_behind_it() -> void:
 	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	await _finish_pokemon_center_pc(host)
+
+
+## `.Switch`: `ChangeBoxSaveGame` asks, saves behind its own box, and puts
+## `wCurBox` between the two halves. Silently switching the box was the defect.
+func test_change_box_asks_and_saves_before_the_box_moves() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_SUBMENU)
+	host.handle_button(Gen2Button.A)
+
+	## Three lines, so the question is prompted past before the yes/no is on it.
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_SAVE)
+	assert_eq(host._save_prompt.lines, Gen2SavePrompt.CHANGE_BOX_LINES)
+	assert_eq(host._save_prompt.cursor, -1)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._save_prompt.cursor, 0)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._save_prompt.lines, Gen2SavePrompt.OVERWRITE_LINES)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._save_prompt.step, Gen2SavePrompt.Step.SAVING)
+	assert_eq(int(host._save.current_box), 0, "not until the write")
+
+	host.advance_save_frames(Gen2SavePrompt.SAVING_FRAMES)
+	assert_eq(int(host._save.current_box), 1, "`wCurBox` sits between the halves")
+	host.advance_save_frames(
+		Gen2SavePrompt.WRITE_FRAMES + Gen2SavePrompt.DONE_FRAMES
+	)
+	assert_null(host._save_prompt)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
+
+
+## `BillsPC_MovePKMNMenu`: `IsAnyMonHoldingMail` refuses the row outright, and
+## `StartMoveMonWOMail_SaveGame` is what stands in front of the listing.
+func test_move_without_mail_refuses_a_party_holding_mail_and_saves_otherwise() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	host.handle_button(Gen2Button.A)
+	(host._save.party[0] as Gen2SaveMon).item = Gen2HeldItem.MAIL_ITEMS[0]
+	for _step: int in 3:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_TEXT)
+	assert_string_contains(host._summary, "holding MAIL")
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
+
+	## Without the mail the row asks its own question, and a NO is `.refused`'s
+	## carry: back to the machine's menu with no listing opened.
+	(host._save.party[0] as Gen2SaveMon).item = 0
+	for _step: int in 3:
+		host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._save_prompt.lines, Gen2SavePrompt.MOVE_MON_LINES)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_null(host._save_prompt)
+	assert_null(host._boxes)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
 
 
 ## `special PokemonCenterPC` from a coord event, which is how every test above

--- a/tests/unit/test_hall_of_fame.gd
+++ b/tests/unit/test_hall_of_fame.gd
@@ -8,6 +8,9 @@ const TILE: int = Gen2Font.TILE
 
 ## `Rate`'s two texts, one box each at the fixture's short lengths.
 const RATING_PAGES: int = 2
+## `InitDisplayForHallOfFame`'s record box, which `HallOfFame_FadeOutMusic` puts
+## up in front of the whole induction.
+const SAVING_PAGES: int = 1
 
 var _data: GameData = null
 
@@ -36,28 +39,29 @@ func _save(species_list: Array, eggs: Array = []) -> Gen2SaveData:
 
 func test_pages_follow_the_party_and_end_with_the_player() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4]))
-	assert_eq(pages.size(), 2 + RATING_PAGES)
-	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_MON)
+	assert_eq(pages.size(), SAVING_PAGES + 2 + RATING_PAGES)
+	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_SAVING)
+	assert_eq(StringName(pages[1]["kind"]), Gen2HallOfFame.PAGE_MON)
 	## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS`, which the Hall of Fame asks for and
 	## which reaches `GetMonNormalOrShinyPalettePointer`: a shiny is inducted in
 	## its own colours, the same DV word the letter beside it comes from.
-	assert_false(bool(pages[0]["shiny"]), "the fixture's party is not shiny")
+	assert_false(bool(pages[1]["shiny"]), "the fixture's party is not shiny")
 
 	var shiny_save: Gen2SaveData = _save([1, 4])
 	shiny_save.party[0].dvs = Gen2Stats.SHINY_DVS
 	var shiny_pages: Array = Gen2HallOfFame.pages(_data, shiny_save)
-	assert_true(bool(shiny_pages[0]["shiny"]))
-	assert_false(bool(shiny_pages[1]["shiny"]), "and only the one that is")
+	assert_true(bool(shiny_pages[1]["shiny"]))
+	assert_false(bool(shiny_pages[2]["shiny"]), "and only the one that is")
 	## The stored records take the same road: an induction is written and read
 	## back, so a shiny in the viewer is drawn shiny however long ago it won.
 	var stored: Array = Gen2HallOfFame.inducted([], shiny_save)
 	var replayed: Array = Gen2HallOfFame.record_pages(_data, stored[0])
 	assert_true(bool(replayed[0]["shiny"]), "the stored record kept it")
-	assert_eq(int(pages[0]["species"]), 1)
-	assert_eq(int(pages[0]["dex_number"]), 1)
-	assert_eq(int(pages[1]["species"]), 4)
-	assert_eq(StringName(pages[2]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
-	assert_eq(String(pages[2]["player_name"]), "ASH")
+	assert_eq(int(pages[1]["species"]), 1)
+	assert_eq(int(pages[1]["dex_number"]), 1)
+	assert_eq(int(pages[2]["species"]), 4)
+	assert_eq(StringName(pages[3]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_eq(String(pages[3]["player_name"]), "ASH")
 
 
 ## `HOF_AnimatePlayerPic` ends on `farcall ProfOaksPCRating`, so the player's
@@ -65,8 +69,8 @@ func test_pages_follow_the_party_and_end_with_the_player() -> void:
 ## picked plays on the last of them.
 func test_the_player_panel_carries_the_oak_rating() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
-	var counts: Dictionary = pages[1]
-	var rating: Dictionary = pages[2]
+	var counts: Dictionary = pages[2]
+	var rating: Dictionary = pages[3]
 	assert_eq(StringName(counts["kind"]), Gen2HallOfFame.PAGE_PLAYER)
 	assert_eq(StringName(rating["kind"]), Gen2HallOfFame.PAGE_PLAYER)
 	assert_string_contains(String((counts["lines"] as Array)[0]), "SEEN")
@@ -82,46 +86,46 @@ func test_a_cache_without_the_ratings_shows_the_bare_panel() -> void:
 	RomCache.write_json(RomCache.manifest_path(Fixture.directory()), manifest)
 	var data: GameData = GameData.open_directory(Fixture.directory())
 	var pages: Array = Gen2HallOfFame.pages(data, _save([1]))
-	assert_eq(pages.size(), 2)
-	assert_false(pages[1].has("lines"))
+	assert_eq(pages.size(), SAVING_PAGES + 2)
+	assert_false(pages[2].has("lines"))
 
 
 ## GetHallOfFameParty skips EGG without consuming a slot, so the egg is neither
 ## inducted nor counted against the six.
 func test_an_egg_is_skipped_and_the_player_page_still_follows() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4, 7], [1]))
-	assert_eq(pages.size(), 2 + RATING_PAGES)
-	assert_eq(int(pages[0]["species"]), 1)
-	assert_eq(int(pages[1]["species"]), 7)
-	assert_eq(StringName(pages[2]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_eq(pages.size(), SAVING_PAGES + 2 + RATING_PAGES)
+	assert_eq(int(pages[1]["species"]), 1)
+	assert_eq(int(pages[2]["species"]), 7)
+	assert_eq(StringName(pages[3]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
 
 
 ## LoadHOFTeam's carry falls straight through to HOF_AnimatePlayerPic, so a
 ## party with nothing to induct still reaches the player's own panel.
 func test_a_party_of_only_eggs_answers_the_player_page_alone() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 4], [0, 1]))
-	assert_eq(pages.size(), RATING_PAGES)
-	assert_eq(StringName(pages[0]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_eq(pages.size(), SAVING_PAGES + RATING_PAGES)
+	assert_eq(StringName(pages[1]["kind"]), Gen2HallOfFame.PAGE_PLAYER)
 
 
 ## DisplayHOFMon prints the species name and the nickname in two places, so a
 ## mon that was never renamed shows the same word twice rather than a blank.
 func test_an_unnamed_mon_takes_its_species_name_as_its_nickname() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
-	assert_eq(String(pages[0]["nickname"]), String(pages[0]["species_name"]))
-	assert_false(String(pages[0]["species_name"]).is_empty())
+	assert_eq(String(pages[1]["nickname"]), String(pages[1]["species_name"]))
+	assert_false(String(pages[1]["species_name"]).is_empty())
 
 
 func test_a_nickname_is_kept() -> void:
 	var save: Gen2SaveData = _save([1])
 	(save.party[0] as Gen2SaveMon).nickname = "SPARKY"
 	var pages: Array = Gen2HallOfFame.pages(_data, save)
-	assert_eq(String(pages[0]["nickname"]), "SPARKY")
+	assert_eq(String(pages[1]["nickname"]), "SPARKY")
 
 
 func test_pages_stop_at_a_full_party() -> void:
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1, 2, 3, 4, 5, 6, 7]))
-	assert_eq(pages.size(), Gen2HallOfFame.MAX_MONS + RATING_PAGES)
+	assert_eq(pages.size(), SAVING_PAGES + Gen2HallOfFame.MAX_MONS + RATING_PAGES)
 
 
 func test_a_missing_cache_or_save_answers_nothing() -> void:
@@ -135,7 +139,7 @@ func test_a_mon_panel_draws_both_boxes_on_a_full_screen_buffer() -> void:
 	var page_renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(_data)
 	assert_not_null(page_renderer)
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
-	var indices: PackedByteArray = page_renderer.draw(pages[0])
+	var indices: PackedByteArray = page_renderer.draw(pages[1])
 	assert_eq(indices.size(), Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
 	assert_true(_has_ink(indices, Gen2HallOfFamePage.MON_TOP_BOX))
 	assert_true(_has_ink(indices, Gen2HallOfFamePage.MON_BOTTOM_BOX))
@@ -146,7 +150,7 @@ func test_a_mon_panel_draws_both_boxes_on_a_full_screen_buffer() -> void:
 func test_the_player_panel_draws_its_name_box_and_the_rating_box() -> void:
 	var page_renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(_data)
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
-	var indices: PackedByteArray = page_renderer.draw(pages[1])
+	var indices: PackedByteArray = page_renderer.draw(pages[2])
 	assert_eq(indices.size(), Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
 	assert_true(_has_ink(indices, Gen2HallOfFamePage.PLAYER_BOX))
 	assert_true(_has_ink(indices, Gen2HallOfFamePage.MON_BOTTOM_BOX))
@@ -195,7 +199,7 @@ func test_the_dex_row_draws_two_label_tiles_and_leaves_column_six_blank() -> voi
 	var page_renderer: Gen2HallOfFamePage = Gen2HallOfFamePage.from_data(_data)
 	assert_not_null(page_renderer)
 	var pages: Array = Gen2HallOfFame.pages(_data, _save([1]))
-	var indices: PackedByteArray = page_renderer.draw(pages[0])
+	var indices: PackedByteArray = page_renderer.draw(pages[1])
 	# The fixture fills each sheet with an index of its own, so a drawn pixel
 	# says which strip it came from: 1 is battle_font, 3 is the main font.
 	assert_eq(_index_at(indices, Vector2i(1, 13)), 1, "№ comes off the battle strip")

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -379,6 +379,74 @@ func test_the_party_list_refuses_a_transfer_that_would_leave_nobody_standing() -
 
 ## `_MovePKMNWithoutMail`: left and right load another list, the submenu drops
 ## RELEASE, and the second A puts the Pokemon where the insert cursor stands.
+## `engine/menus/save.asm`'s one sequence, which every save in the game runs:
+## the routine's own question, `AskOverwriteSaveFile`, the SAVING box and
+## `SavedTheGame`. Only `SaveMenu`'s half of it was built.
+func test_the_save_sequence_asks_twice_and_then_spends_its_frames() -> void:
+	var written: Array = []
+	var prompt: Gen2SavePrompt = Gen2SavePrompt.open(
+		Gen2SavePrompt.Kind.CHANGE_BOX, "RED",
+		func() -> Dictionary:
+			written.append(true)
+			return {"ok": true}
+	)
+	## A three-line question carries no cursor until it has been prompted past.
+	assert_eq(prompt.lines, Gen2SavePrompt.CHANGE_BOX_LINES)
+	assert_eq(prompt.cursor, -1)
+	prompt.confirm(true)
+	assert_eq(prompt.cursor, 0)
+	prompt.confirm(true)
+	assert_eq(prompt.lines, Gen2SavePrompt.OVERWRITE_LINES)
+	prompt.confirm(true)
+	prompt.confirm(true)
+	assert_eq(prompt.step, Gen2SavePrompt.Step.SAVING)
+
+	prompt.frames_elapsed(Gen2SavePrompt.SAVING_FRAMES - 1)
+	assert_eq(written.size(), 0, "the box is up for sixteen frames first")
+	prompt.frames_elapsed(1)
+	assert_eq(written.size(), 1)
+	assert_true(prompt.writing_now())
+	prompt.frames_elapsed(Gen2SavePrompt.WRITE_FRAMES)
+	assert_eq(prompt.step, Gen2SavePrompt.Step.SAVED)
+	assert_true(prompt.sfx_owed())
+	assert_eq(prompt.lines[0], "RED saved")
+	prompt.frames_elapsed(Gen2SavePrompt.DONE_FRAMES)
+	assert_true(prompt.finished())
+	assert_false(prompt.refused())
+
+
+## `.refused`'s carry, and `Link_SaveGame`, whose caller `TryQuickSave` asks no
+## question of its own.
+func test_a_no_refuses_and_the_link_save_opens_on_the_overwrite_question() -> void:
+	var refused: Gen2SavePrompt = Gen2SavePrompt.open(
+		Gen2SavePrompt.Kind.MOVE_MON, "RED", Callable()
+	)
+	refused.confirm(true)
+	refused.cancel()
+	assert_true(refused.finished())
+	assert_true(refused.refused())
+
+	var quick: Gen2SavePrompt = Gen2SavePrompt.open(
+		Gen2SavePrompt.Kind.LINK, "RED", func() -> Dictionary:
+			return {"ok": false, "reason": &"disk_full"}
+	)
+	assert_eq(quick.step, Gen2SavePrompt.Step.OVERWRITE)
+	quick.confirm(true)
+	quick.confirm(true)
+	quick.frames_elapsed(Gen2SavePrompt.SAVING_FRAMES + Gen2SavePrompt.WRITE_FRAMES)
+	## A write that failed is this port's own step, and it ends as a NO does.
+	assert_eq(quick.step, Gen2SavePrompt.Step.FAILED)
+	assert_string_contains(quick.lines[1], "disk_full")
+	quick.confirm(true)
+	assert_true(quick.refused())
+
+
+func _spend_insert_frames() -> void:
+	_box_screen.advance_saving_frames(
+		Gen2SavePrompt.LEAVE_ON_FRAMES + Gen2SavePrompt.INSERT_SAVED_FRAMES
+	)
+
+
 func test_move_without_mail_reorders_a_list_and_moves_between_two() -> void:
 	var save: Gen2SaveData = _save_with_two()
 	var third: Gen2BattleMon = Gen2BattleMon.create(
@@ -405,6 +473,14 @@ func test_move_without_mail_reorders_a_list_and_moves_between_two() -> void:
 	_box_screen.handle_button(Gen2Button.UP)
 	_box_screen.handle_button(Gen2Button.UP)
 	_box_screen.handle_button(Gen2Button.A)
+	## `MovePKMNWithoutMail_InsertMon`'s twenty frames and the twenty-four
+	## `MoveMonWOMail_InsertMon_SaveGame` spends behind `SFX_SAVE`, which read no
+	## joypad: the list only comes back once both are spent.
+	assert_eq(
+		String(_box_screen.box_snapshot()["prompt"]), Gen2SavePrompt.SAVING_LEAVE_ON
+	)
+	assert_true(_box_screen.handle_button(Gen2Button.B))
+	_spend_insert_frames()
 	assert_eq(String((save.party[0] as Gen2SaveMon).nickname), "THIRD")
 	assert_eq(save.party.size(), 3)
 
@@ -419,6 +495,7 @@ func test_move_without_mail_reorders_a_list_and_moves_between_two() -> void:
 	_box_screen.handle_button(Gen2Button.A)
 	_box_screen.handle_button(Gen2Button.RIGHT)
 	_box_screen.handle_button(Gen2Button.A)
+	_spend_insert_frames()
 	assert_eq(save.party.size(), 2)
 	assert_not_null(save.boxes[0].slots[0])
 	assert_eq(String((save.boxes[0].slots[0] as Gen2SaveMon).nickname), "THIRD")


### PR DESCRIPTION
Every save in `engine/menus/save.asm` is one sequence: the routine's own question, `AskOverwriteSaveFile`, `SavingDontTurnOffThePower` and `SavedTheGame`. Four routines are that sequence with a different question in front of it, and only `SaveMenu`'s was built. `Gen2SavePrompt` is now that sequence, and the START menu runs it too, so the words and the frame counts have one home instead of being copied.

## What the other three did before

| Routine | Before | Now |
|---|---|---|
| `ChangeBoxSaveGame` | CHANGE BOX switched boxes silently | Asks "When you change a #MON BOX, data will be saved. OK?", writes behind its own box, and puts `wCurBox` between the two halves |
| `BillsPC_MovePKMNMenu` | MOVE PKMN W/O MAIL opened the listing with nothing in front of it | `IsAnyMonHoldingMail` refuses the row outright when a party member holds mail; otherwise `StartMoveMonWOMail_SaveGame` asks and saves first |
| `TryQuickSave` | The cable club and the Battle Tower saved with nothing on screen | `Link_SaveGame`'s overwrite question, box and confirmation |

Beside them, `MovePKMNWithoutMail_InsertMon`'s own box: "Saving… Leave ON!" for twenty frames, then `SFX_SAVE` and twenty-four more, neither of them reading a button.

## The Hall of Fame's first screen

`InitDisplayForHallOfFame` was absent, and it is the first thing an induction draws: SAVING RECORD… over a cleared screen, no box, for the hundred frames `HallOfFame_FadeOutMusic` spends on it.

A quick-save request now completes the way the region map's and the bank dial's do: it reads no cartridge data, and the runner owns the answer.

## Met on the way

- `bills_pc.asm`'s three lists were described as two in `box_screen.gd`, with left and right called dead. MOVE PKMN W/O MAIL is built and reads both.
- `world_service_screen.gd`'s B chain had grown past the complexity ceiling. It is a lookup table now.

## Proof

| Check | Result |
|---|---|
| GUT, whole tree | 4045 of 4045, 175 s |
| Editor analyser | 0 warnings in 600 scripts |
| `tools/validate.gd -- all` | exit 0 |