### PR TITLE
Open the shop on the map, and walk a pixel a frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,22 +299,45 @@ Only the map you are on is live, exactly as on the cartridge.
 
 ### Game speed, window and frame rate
 
-Settings > Application carries three more that reach the engine:
+Settings > Application carries four more that reach the engine:
 
 | Setting | What it does |
 |---|---|
 | Game speed | Normal, double or half. Everything counted in hardware frames runs at that multiple: walking, animations, text, battle |
 | Window | Windowed, fullscreen or borderless |
-| Frame rate | 30, 60, 120, 144 or uncapped |
+| Scrolling | Hardware or smooth. See [Scrolling](#scrolling) |
+| Frame rate | Display, or a cap of 30, 60, 120 or 144 |
 
 Sound is deliberately outside game speed. The driver is fed by the audio
 output's own demand rather than by a game frame, so music, effects and cries keep
 the cartridge's tempo and pitch at every setting.
 
+**Leave frame rate on Display.** It draws one frame per refresh, which is the
+only setting whose frames each reach the panel once. A cap below the panel's own
+rate is a sleep and not a refresh, so the same picture is shown for one refresh,
+then three, then two, and the overworld appears to move 0, 1 or 2 pixels however
+even the game is underneath. The caps are there to save battery.
+
+#### Scrolling
+
+The overworld moves two pixels once every two frames, which is what the hardware
+did and what a Game Boy's own screen smeared over. **Smooth** draws the frame in
+between one pixel on, so the map moves a pixel a frame, lands on the cartridge's
+own pixel at every pass boundary, and takes the same sixteen frames to cross a
+cell. Nothing in the game is timed differently either way.
+
+Under both, the pump counts the host's own frames once it has seen enough of
+them at one length to be sure of it, rather than measuring time: a hardware frame
+is 16.742 ms and a host one is the panel's, so a count taken off measured time
+slips a whole frame every 3.7 seconds against the frames the player is shown. A
+panel whose refresh divides no hardware frame, 144 Hz among them, is measured
+instead.
+
 Development shortcuts are debug-build only, along with the map and cell readout.
 That readout carries `fps` (host frames drawn), `hw` (hardware frames the pump
-spent, 59.7 a second when keeping up) and `worst` (the longest single frame of
-the last second, where a stutter shows and an average hides it).
+spent, 59.7 a second while measuring time and the panel's own divided rate while
+counting its frames) and `worst` (the longest single frame of the last second,
+where a stutter shows and an average hides it).
 
 | Scene | Keys |
 |---|---|

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -689,6 +689,14 @@ whole cell the instant one begins. A camera following it pans a step early;
 `visible_origin_cells()` frames the interpolated position instead. The two agree
 whenever no step is in flight.
 
+**SMOOTH SCROLL** (`Gen2Options.smooth_scroll`, on by default, Settings >
+Application > Scrolling) is `Gen2WorldAPI.pass_fraction`: 0.0 on the overworld
+pass itself and 0.5 on the hardware frame after it. Every interpolated position
+above reads it, so a renderer framing its own view gets the smoothing for free
+and a renderer reading `Gen2WorldObject.step_offset()` passes it in. It moves
+nothing the engine decides: the step takes the same sixteen frames, lands on the
+same cell, and stands on the cartridge's own pixel at every pass boundary.
+
 The host constructs a renderer per world, so the view can change while the game
 runs. `Gen2WorldScreen.select_view()` is that switch and `cycle_view()` is what
 `V` is bound to. The map, the player and any running script are untouched.

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -690,12 +690,22 @@ whole cell the instant one begins. A camera following it pans a step early;
 whenever no step is in flight.
 
 **SMOOTH SCROLL** (`Gen2Options.smooth_scroll`, on by default, Settings >
-Application > Scrolling) is `Gen2WorldAPI.pass_fraction`: 0.0 on the overworld
-pass itself and 0.5 on the hardware frame after it. Every interpolated position
-above reads it, so a renderer framing its own view gets the smoothing for free
-and a renderer reading `Gen2WorldObject.step_offset()` passes it in. It moves
-nothing the engine decides: the step takes the same sixteen frames, lands on the
-same cell, and stands on the cartridge's own pixel at every pass boundary.
+Application > Scrolling) is `Gen2WorldAPI.pass_fraction`: where the frame being
+drawn stands inside the overworld pass, 0.0 at its start and just under 1.0 at
+its end. Every interpolated position above reads it, so a renderer framing its
+own view gets the smoothing for free and a renderer reading
+`Gen2WorldObject.step_offset()` passes it in. It moves nothing the engine
+decides: the step takes the same sixteen frames, lands on the same cell, and
+stands on the cartridge's own pixel at every pass boundary.
+
+It is set from banked real time rather than from a count of spent frames, which
+matters more than the interpolation does. A host frame is 16.667 ms and a
+hardware one 16.742, so a `_process` tick spends sometimes no frame and sometimes
+two; a position placed from that count alone moves 0, 1 or 2 pixels with nothing
+in the game behind the difference. `Gen2WorldScreen` sets `pass_fraction` once
+per drawn frame from the whole frames spent plus the part of the next one the
+clock is holding, so the picture stands within half a pixel of the clock however
+the host's frames land.
 
 The host constructs a renderer per world, so the view can change while the game
 runs. `Gen2WorldScreen.select_view()` is that switch and `cycle_view()` is what

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -698,14 +698,17 @@ own view gets the smoothing for free and a renderer reading
 decides: the step takes the same sixteen frames, lands on the same cell, and
 stands on the cartridge's own pixel at every pass boundary.
 
-It is set from banked real time rather than from a count of spent frames, which
-matters more than the interpolation does. A host frame is 16.667 ms and a
-hardware one 16.742, so a `_process` tick spends sometimes no frame and sometimes
-two; a position placed from that count alone moves 0, 1 or 2 pixels with nothing
-in the game behind the difference. `Gen2WorldScreen` sets `pass_fraction` once
-per drawn frame from the whole frames spent plus the part of the next one the
-clock is holding, so the picture stands within half a pixel of the clock however
-the host's frames land.
+It is set from the clock rather than from a count of spent frames, once per drawn
+frame rather than once per spent one, so the picture stands within half a pixel
+of the clock however the host's frames land.
+
+The clock itself is `Gen2WorldAnimation.FrameClock`, and it counts the host's own
+frames rather than measuring time whenever the host is steady and its frame
+divides a hardware one: one hardware frame per host frame at 60 Hz, one every
+second host frame at 120. Measuring time instead slips a whole frame every 3.7
+seconds against the frames the player is shown, which is half a pass and a pixel
+of the overworld. A rate that divides no hardware frame, or a host that hitches,
+falls back to measuring.
 
 The host constructs a renderer per world, so the view can change while the game
 runs. `Gen2WorldScreen.select_view()` is that switch and `cycle_view()` is what

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -95,6 +95,20 @@ func _build() -> void:
 			_options.screen_fill = index == 1
 			_persist()
 	)))
+	app.add_child(Gen2LauncherUI.field(_theme, "Scrolling", Gen2LauncherUI.segmented(
+		_theme, ["Hardware", "Smooth"], 1 if _options.smooth_scroll else 0,
+		func(index: int) -> void:
+			_options.smooth_scroll = index == 1
+			_persist()
+	)))
+	app.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"The overworld moves two pixels at a time, once every two frames, which "
+		+ "is what a Game Boy did and what its screen smeared over. Smooth draws "
+		+ "the frame in between, so the map moves a pixel a frame and lands on "
+		+ "the same pixel the hardware did. Nothing in the game is timed "
+		+ "differently either way."
+	))
 	app.add_child(Gen2LauncherUI.field(_theme, "Second screen", Gen2LauncherUI.segmented(
 		_theme, _titles(Gen2Options.SECOND_SCREENS),
 		maxi(Gen2Options.SECOND_SCREENS.find(_options.second_screen), 0),

--- a/game/launcher/settings_page.gd
+++ b/game/launcher/settings_page.gd
@@ -140,13 +140,21 @@ func _build() -> void:
 	)))
 	var fps_labels: Array[String] = []
 	for fps: int in Gen2Options.FPS_CHOICES:
-		fps_labels.append("Max" if fps == 0 else str(fps))
+		fps_labels.append("Display" if fps == 0 else str(fps))
 	app.add_child(Gen2LauncherUI.field(_theme, "Frame rate", Gen2LauncherUI.segmented(
 		_theme, fps_labels, maxi(Gen2Options.FPS_CHOICES.find(_options.max_fps), 0),
 		func(index: int) -> void:
 			_options.max_fps = Gen2Options.FPS_CHOICES[index]
 			_persist()
 	)))
+	app.add_child(Gen2LauncherUI.muted(
+		_theme,
+		"Display draws one frame per refresh, which is the only setting whose "
+		+ "frames each reach the panel once. A number below the panel's own rate "
+		+ "is a sleep and not a refresh, so the same picture is shown for one "
+		+ "refresh, then three, then two, and walking stutters however even the "
+		+ "game is underneath. Pick one only to save battery."
+	))
 
 	var controls: VBoxContainer = _card(column, "Controls")
 	var section: Gen2ControlsSection = Gen2ControlsSection.create(

--- a/game/mods/mod_state.gd
+++ b/game/mods/mod_state.gd
@@ -54,8 +54,7 @@ static func disabled_ids() -> Array[StringName]:
 	return out
 
 
-## Returns false only when the change could not be written, in which case the
-## in-memory set is rolled back so it never disagrees with the file.
+## As [method set_selected_view], for the enabled set.
 static func set_enabled(id: StringName, enabled: bool) -> bool:
 	_ensure_loaded()
 	if String(id).is_empty():

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -10,7 +10,7 @@ extends RefCounted
 ## `data/default_options.asm` is byte identical between the two pins, so nothing
 ## here is profile split.
 
-const FORMAT_VERSION: int = 1
+const FORMAT_VERSION: int = 2
 
 ## `constants/ram_constants.asm`: bits 0-2 of `wOptions`.
 const TEXT_DELAY_FAST: int = 1
@@ -55,7 +55,10 @@ const GAME_SPEEDS: Array[StringName] = [&"normal", &"double", &"half"]
 ## How much hardware time one real second buys, per row of [constant
 ## GAME_SPEEDS]. See [method speed_scale].
 const GAME_SPEED_SCALES: Array[float] = [1.0, 2.0, 0.5]
-const FPS_CHOICES: Array[int] = [30, 60, 120, 144, 0]
+## FRAME RATE. 0 is the display's own, and the only one whose frames each reach
+## the panel once: a cap is a sleep and not a vblank, so it shows a frame for one
+## refresh, then three, then two.
+const FPS_CHOICES: Array[int] = [0, 30, 60, 120, 144]
 ## What a second display is offered. `auto` uses a real lower panel where the
 ## platform reports one and does nothing anywhere else; `window` opens a desktop
 ## window as well, which is how the panel is looked at on a machine that has no
@@ -96,7 +99,7 @@ var smooth_scroll: bool = true
 ## Whole steps of zoom away from the fitting scale, kept between sessions
 ## because it is a view preference rather than part of a run.
 var zoom_step: int = 0
-var max_fps: int = 60
+var max_fps: int = 0
 ## See [constant SECOND_SCREENS] and [Gen2SecondScreenHost].
 var second_screen: StringName = &"auto"
 var game_speed: StringName = &"normal"
@@ -262,8 +265,11 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.zoom_step = clampi(int(row.get("zoom_step", 0)), -32, 32)
 	options.game_speed = _one_of(row.get("game_speed", ""), GAME_SPEEDS)
 	options.ui_theme = _one_of(row.get("ui_theme", ""), UI_THEMES)
-	var fps: int = int(row.get("max_fps", 60))
-	options.max_fps = fps if FPS_CHOICES.has(fps) else 60
+	var fps: int = int(row.get("max_fps", 0))
+	## The old default moves with the default; a rate the player picked stays.
+	if int(row.get("format_version", 1)) < 2 and fps == 60:
+		fps = 0
+	options.max_fps = fps if FPS_CHOICES.has(fps) else 0
 	options.second_screen = _one_of(row.get("second_screen", ""), SECOND_SCREENS)
 	options.rules = Gen2Rules.parse(row.get("rules"))
 	options.controls = Gen2InputActions.sanitize(row.get("controls"))

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -91,6 +91,8 @@ var video_mode: StringName = &"windowed"
 ## Interface stays inside the 160x144 rectangle centred in it, so nothing the
 ## cartridge laid out moves.
 var screen_fill: bool = true
+## SMOOTH SCROLL: see [member Gen2WorldAPI.pass_fraction]. Off is the hardware's.
+var smooth_scroll: bool = true
 ## Whole steps of zoom away from the fitting scale, kept between sessions
 ## because it is a view preference rather than part of a run.
 var zoom_step: int = 0
@@ -218,6 +220,7 @@ func to_dict() -> Dictionary:
 		"sfx_volume": sfx_volume,
 		"video_mode": String(video_mode),
 		"screen_fill": screen_fill,
+		"smooth_scroll": smooth_scroll,
 		"zoom_step": zoom_step,
 		"max_fps": max_fps,
 		"second_screen": String(second_screen),
@@ -255,6 +258,7 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.sfx_volume = clampi(int(row.get("sfx_volume", 7)), 0, MAX_VOLUME)
 	options.video_mode = _one_of(row.get("video_mode", ""), VIDEO_MODES)
 	options.screen_fill = bool(row.get("screen_fill", true))
+	options.smooth_scroll = bool(row.get("smooth_scroll", true))
 	options.zoom_step = clampi(int(row.get("zoom_step", 0)), -32, 32)
 	options.game_speed = _one_of(row.get("game_speed", ""), GAME_SPEEDS)
 	options.ui_theme = _one_of(row.get("ui_theme", ""), UI_THEMES)

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -2,13 +2,12 @@ class_name Gen2Screen
 extends Control
 
 ## A Game Boy Color screen: 160x144 pixels, scaled by a whole number to fit. What
-## the game draws goes into a hardware-sized [SubViewport] blown up by an integer
-## factor, since any other scale resamples an 8x8 tile into something that crawls
-## when it moves. [method display_native] is a second layer behind it at window
-## resolution. [member expanded] widens the buffer instead of framing it, and
-## [method display] still centres a 160x144 rectangle in it, so only the surround
-## grows. SCREEN FILL is read here rather than by each screen, which is what makes
-## a screen written next year responsive without saying anything about it.
+## the game draws goes into a [SubViewport] blown up by an integer factor, since
+## any other scale resamples an 8x8 tile into something that crawls when it moves.
+## [method display_native] is a second layer behind it at window resolution, and
+## [member expanded] widens the buffer instead of framing it while
+## [method display] still centres a 160x144 rectangle in it. SCREEN FILL is read
+## here rather than by each screen.
 
 const WIDTH: int = 160
 const HEIGHT: int = 144
@@ -26,6 +25,10 @@ const BUFFER_STEP: int = 32
 ## How far past the fitting scale a player may zoom out. Three steps reaches
 ## MIN_SCALE from a 1x window, and the same three from any other.
 const ZOOM_OUT_STEPS: int = 3
+## The most steps of one hardware pixel [member subpixel] will draw at. Each
+## costs the whole buffer's fill rate, and six already turns a twelve-pixel jump
+## into a two-pixel one.
+const SUBPIXEL_STEPS_MAX: int = 6
 
 ## After a resize changes the factor. Nothing in the game should care.
 signal scale_changed(factor: int)
@@ -60,6 +63,17 @@ var zoom_step: int = 0:
 		_fit()
 
 var _zoom_step: int = 0
+
+## Whether the buffer is drawn at a whole multiple of its own resolution, so a
+## view in it can place itself on a screen pixel rather than a hardware one.
+## Everything keeps hardware-pixel coordinates: the canvas transform does the
+## magnification the container used to and the picture is the same one.
+var subpixel: bool = false:
+	set(value):
+		if subpixel == value:
+			return
+		subpixel = value
+		_fit()
 
 ## Whether the buffer outside the 160x144 rectangle is filled by this screen.
 ##
@@ -141,6 +155,8 @@ func _ready() -> void:
 	# The viewport's size is the container's divided by the shrink factor, and
 	# writing it directly is refused at runtime.
 	resized.connect(_fit)
+	_viewport.canvas_item_default_texture_filter = \
+		Viewport.DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST
 	_content = Control.new()
 	_content.name = "Content"
 	_content.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -178,11 +194,9 @@ func _ready() -> void:
 
 
 ## Takes SCREEN FILL from the options file and applies it, for every screen rather
-## than the two that remembered to ask: a window is not 10:9, and a screen that
-## does not fill it leaves bars a player reads as a fault. What a screen puts in
-## the room is its own business; having the room is not. Public and idempotent
-## because the option is the file's rather than this frame's, so a caller that
-## changed it after the screen entered the tree is obeyed.
+## than the two that remembered to ask. What a screen puts in the room is its own
+## business; having the room is not. Public and idempotent because the option is
+## the file's, so a caller that changed it after this entered the tree is obeyed.
 func apply_screen_fill() -> void:
 	expanded = Gen2OptionsStore.current().screen_fill
 
@@ -224,6 +238,7 @@ func native_size() -> Vector2i:
 ## The drawn buffer in hardware pixels: 160x144 unless [member expanded].
 func view_size() -> Vector2i:
 	return _view_size
+
 
 
 ## The cartridge's own 160x144 screen, in the native layer's own pixels.
@@ -691,6 +706,15 @@ static func buffer_for(area: Vector2, at_scale: float) -> Vector2i:
 	)
 
 
+## The finest step [param whole] can be divided into, since the container shrinks
+## the buffer by a whole number and [constant SUBPIXEL_STEPS_MAX] is the ceiling.
+static func _subpixel_for(whole: int) -> int:
+	for steps: int in range(mini(whole, SUBPIXEL_STEPS_MAX), 1, -1):
+		if whole % steps == 0:
+			return steps
+	return 1
+
+
 func _fit() -> void:
 	var factor: int = fit_factor(size)
 	# A resize moves the fitting scale, so a step chosen against the old one can
@@ -703,20 +727,25 @@ func _fit() -> void:
 	var drawn: Vector2 = Vector2(view) * scale_now
 
 	# A whole-number scale keeps the proven shrink path, where the container is
-	# the drawn size and the viewport is that divided by the factor. Below one
-	# the shrink cannot express the ratio, so the container is the buffer and the
-	# texture is scaled down instead.
+	# the drawn size and the viewport is that divided by what the canvas
+	# transform does not magnify. Below one the shrink cannot express the ratio,
+	# so the container is the buffer and the texture is scaled down instead.
+	var steps: int = 1
 	if scale_now >= 1.0 and is_equal_approx(scale_now, roundf(scale_now)):
-		_container.stretch_shrink = int(roundf(scale_now))
+		var whole: int = int(roundf(scale_now))
+		steps = _subpixel_for(whole) if subpixel else 1
+		_container.stretch_shrink = whole / steps
 		_container.scale = Vector2.ONE
 		_container.size = drawn
 	else:
 		_container.stretch_shrink = 1
 		_container.size = Vector2(view)
 		_container.scale = Vector2(scale_now, scale_now)
-	# Nearest is what keeps a hardware pixel a square block of screen pixels, and
-	# it is the wrong answer in the one place the picture is made smaller rather
-	# than larger: dropping three pixels in four turns a tree wall into moire.
+	_viewport.canvas_transform = Transform2D().scaled(Vector2(steps, steps))
+	# Nearest is what keeps a hardware pixel a square block of screen pixels, in
+	# here and in the viewport that [member subpixel] magnifies inside, and it is
+	# the wrong answer in the one place the picture is made smaller rather than
+	# larger: dropping three pixels in four turns a tree wall into moire.
 	_container.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST if scale_now >= 1.0 \
 		else CanvasItem.TEXTURE_FILTER_LINEAR
 	# Centred rather than anchored: an uneven margin is visible.

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -75,6 +75,8 @@ var subpixel: bool = false:
 		subpixel = value
 		_fit()
 
+var _subpixel_steps: int = 1
+
 ## Whether the buffer outside the 160x144 rectangle is filled by this screen.
 ##
 ## On by default, and the reason a screen written without a thought for the
@@ -706,13 +708,18 @@ static func buffer_for(area: Vector2, at_scale: float) -> Vector2i:
 	)
 
 
-## The finest step [param whole] can be divided into, since the container shrinks
-## the buffer by a whole number and [constant SUBPIXEL_STEPS_MAX] is the ceiling.
+## The finest step [param whole] divides into, the container shrinking the buffer
+## by a whole number and [constant SUBPIXEL_STEPS_MAX] being the ceiling. One with
+## no divisor under it is a prime, and only a small window asks for those.
 static func _subpixel_for(whole: int) -> int:
 	for steps: int in range(mini(whole, SUBPIXEL_STEPS_MAX), 1, -1):
 		if whole % steps == 0:
 			return steps
-	return 1
+	return whole
+
+
+func subpixel_steps() -> int:
+	return _subpixel_steps
 
 
 func _fit() -> void:
@@ -741,6 +748,7 @@ func _fit() -> void:
 		_container.stretch_shrink = 1
 		_container.size = Vector2(view)
 		_container.scale = Vector2(scale_now, scale_now)
+	_subpixel_steps = steps
 	_viewport.canvas_transform = Transform2D().scaled(Vector2(steps, steps))
 	# Nearest is what keeps a hardware pixel a square block of screen pixels, in
 	# here and in the viewport that [member subpixel] magnifies inside, and it is

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -311,7 +311,6 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 		var at: Vector2i = sprite["at"]
 		var flip_x: bool = bool(sprite["flip_x"])
 		for part: Array in ordering["parts"]:
-			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
 			if out.size() >= SHADOW_OAM_SPRITES:
 				return out
 			var dx: int = int(part[1])

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -285,9 +285,8 @@ func draw(movie: Gen2GoldSilverIntro) -> Image:
 	if movie == null:
 		return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
 	var behind: PackedByteArray = _draw_background(pixels, movie)
-	# The lower OAM index wins a pixel, so a slot only paints where no earlier
-	# one did: Charizard's small fireball sits behind the big one it is spawned
-	# after, and the note behind Pikachu.
+	# Charizard's small fireball sits behind the big one it is spawned after, and
+	# the note behind Pikachu.
 	var taken := PackedByteArray()
 	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -228,7 +228,6 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	var background: Array = _draw_background(pixels, movie)
 	var behind: PackedByteArray = background[0]
 	var forced: PackedByteArray = background[1]
-	# The lower OAM index wins a pixel.
 	var taken := PackedByteArray()
 	taken.resize(WIDTH * HEIGHT)
 	for entry: Dictionary in shadow_oam(movie):

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -249,7 +249,6 @@ func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 		var flip_x: bool = bool(sprite["flip_x"])
 		var flip_y: bool = bool(sprite["flip_y"])
 		for part: Array in ordering["parts"]:
-			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
 			if out.size() >= SHADOW_OAM_SPRITES:
 				return out
 			var dy: int = int(part[0])

--- a/game/render/pack_page.gd
+++ b/game/render/pack_page.gd
@@ -101,7 +101,6 @@ const ATTRIBUTES: Array = [
 var font: Gen2Font = null
 ## Which text-box border the player chose, for the box the description sits in.
 var frame_style: int = 0
-## The VRAM window, as one indices strip per tile number.
 var _tiles: Dictionary = {}
 ## `PackGFX` and `PackFGFX`, each as the whole four-pocket strip.
 var _pockets: PackedByteArray = PackedByteArray()

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -340,7 +340,6 @@ func shadow_oam(scene: Gen2TitleScene) -> Array[Dictionary]:
 		var at: Vector2i = sprite["at"]
 		var name: String = _sprite_sheet(kind)
 		for part: Vector3i in _oam_set(kind, int(sprite.get("tile", 0))):
-			# `UpdateAnimFrame` stops at `wShadowOAMEnd` rather than growing.
 			if out.size() >= SHADOW_OAM_SPRITES:
 				return out
 			var tile: int = int(sprite.get("tile", 0)) if name == "title_crystal" else part.z

--- a/game/render/title_page.gd
+++ b/game/render/title_page.gd
@@ -316,9 +316,8 @@ func draw(scene: Gen2TitleScene) -> Image:
 	var pixels: PackedInt32Array = _compose(scene, behind)
 	_draw_copyright_window(pixels, scene)
 
-	# The lower OAM index wins a pixel, so a slot only paints where no earlier
-	# one did: Gold's bird is copied into the last struct, so every trail spawned
-	# after it still takes a lower slot and covers it.
+	# Gold's bird is copied into the last struct, so every trail spawned after it
+	# still takes a lower slot and covers it.
 	_taken.resize(width * height)
 	_taken.fill(0)
 	for entry: Dictionary in sprites:

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -149,7 +149,6 @@ var font: Gen2Font = null
 ## Which text-box border the player chose, for the box a card draws under itself.
 ## The region map screens have no box and never read it.
 var frame_style: int = 0
-## The VRAM window, as one indices strip per tile number.
 var _tiles: Dictionary = {}
 ## The three card tilemaps, by the names the cache keys them with.
 var _cards: Dictionary = {}

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -122,7 +122,6 @@ var _stats: Gen2MonStatsScreen = null
 var _stats_page: Gen2StatsScreenPage = null
 var _menu_page: Gen2MenuPage = null
 var _page: Gen2PCBoxPage = null
-## The screen this is drawn in, and the 160x144 layer inside it.
 var _screen: Gen2Screen = null
 var _field: Control = null
 var _backdrop: Gen2Screen.Field = null
@@ -1030,7 +1029,6 @@ func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 
 
-## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
 		Gen2Screen.drop_on_exit(_field)

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -156,7 +156,6 @@ var _menu_page: Gen2MenuPage = null
 var _message: String = ""
 ## Whether this is being read rather than driven. See [method set_read_only].
 var _read_only: bool = false
-## This screen's hardware-frame clock.
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## `OpenPartyStats`' own screen, standing over the whole party menu while it is
 ## up, and the page that draws it.

--- a/game/world/credits_screen.gd
+++ b/game/world/credits_screen.gd
@@ -19,7 +19,6 @@ var _credits: Gen2Credits = null
 var _page: Gen2CreditsPage = null
 var _view: TextureRect = null
 var _held: Array = []
-## This screen's hardware-frame clock.
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 

--- a/game/world/intro_screen.gd
+++ b/game/world/intro_screen.gd
@@ -203,7 +203,6 @@ func _on_splash_finished() -> void:
 func _start_profile_setup() -> void:
 	_gender_screen = Gen2GenderScreen.new()
 	if not _gender_screen.open(_data):
-		# Never parented, so it is freed outright rather than queued.
 		_gender_screen.free()
 		_gender_screen = null
 		_start_clock()

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -406,7 +406,6 @@ func _on_name_choice(chosen: String) -> void:
 func _open_naming() -> void:
 	_naming = Gen2NamingScreenScreen.new()
 	if not _naming.open(_data, Gen2OakSpeech.NAME_PROMPT):
-		# Never parented, so it is freed outright rather than queued.
 		_naming.free()
 		_naming = null
 		_enter_next_beat()

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -87,7 +87,6 @@ var _message_frames: int = 0
 var _area: Gen2TownMapScreen = null
 
 var _page: Gen2PokedexPage = null
-## The screen this is drawn in, and the 160x144 layer inside it.
 var _screen: Gen2Screen = null
 var _field: Control = null
 var _background: TextureRect = null
@@ -718,8 +717,6 @@ func _build_ui() -> void:
 	_field.add_child(_background)
 
 
-## The screen the opener wants this drawn in, handed over before it is added to
-## the tree. Without one the field goes in whichever screen this ends up inside.
 ## Draws the listing with no arrow on it, for a display that shows the dex
 ## without being able to walk it. The blink is left running: it costs nothing and
 ## the flag is checked where the arrow is placed.
@@ -731,7 +728,6 @@ func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 
 
-## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
 		Gen2Screen.drop_on_exit(_field)

--- a/game/world/slot_machine_screen.gd
+++ b/game/world/slot_machine_screen.gd
@@ -24,7 +24,6 @@ var _text: String = ""
 ## `wMenuCursorY` for whichever of the two menus is up.
 var _bet_cursor: int = 1
 var _yes_no_cursor: int = 1
-## Whether this frame's pass has already run, which a press does.
 var _acted: bool = false
 var _open: bool = false
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -157,8 +157,7 @@ const TEXT_FALLBACKS: Dictionary = {
 const ITEM_MENU_LEFT: int = 13
 const ITEM_MENU_RIGHT: int = 19
 const ITEM_MENU_BOTTOM: int = 11
-## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
-## left 14, right 19, top 7, bottom 11.
+## [method Gen2MenuBox.yes_no]'s box: left 14, right 19, top 7, bottom 11.
 const YES_NO_AT: Vector2i = Vector2i(14, 7)
 const YES_NO_SPAN: Vector2i = Vector2i(5, 4)
 ## `TossItem_MenuHeader`: `menu_coords 15, 9, SCREEN_WIDTH - 1, TEXTBOX_Y - 1`.

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -67,7 +67,6 @@ var _female: bool = false
 var _time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var _frames: int = 0
 var _open: bool = false
-## The screen this is drawn in, and the 160x144 layer inside it.
 var _screen: Gen2Screen = null
 var _field: Control = null
 var _background: TextureRect = null
@@ -613,7 +612,6 @@ func set_screen(screen: Gen2Screen) -> void:
 	_screen = screen
 
 
-## The field lives in a screen this node may not own, so it goes by hand.
 func _exit_tree() -> void:
 	if _field != null:
 		Gen2Screen.drop_on_exit(_field)

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -85,7 +85,6 @@ var _nests: Array = []
 var _oam: StringName = OAM_NESTS
 var _select_held: bool = false
 var _nest_icons: Array[TextureRect] = []
-## This screen's hardware-frame clock.
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -52,7 +52,6 @@ var _page: int = Gen2TrainerCard.PAGE_1
 var _frames: int = 0
 var _background: TextureRect = null
 var _badges: Array = []
-## This screen's hardware-frame clock.
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 

--- a/game/world/unown_puzzle_screen.gd
+++ b/game/world/unown_puzzle_screen.gd
@@ -18,7 +18,6 @@ var _view: TextureRect = null
 var _audio: Gen2AudioPlayer = null
 ## `hVBlankCounter`, which the empty cursor blinks off.
 var _frame: int = 0
-## Whether this frame's pass has already run, which a press does.
 var _acted: bool = false
 ## Whether `WaitSFX` is still holding.
 var _waiting: bool = false

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -33,7 +33,22 @@ class FrameClock extends RefCounted:
 	## How long [method rate] averages over before it publishes a new reading.
 	const RATE_WINDOW_SECONDS: float = 1.0
 
+	## When the clock stops measuring time and counts the host's own frames. A
+	## hardware frame is 16.742 ms and a host one the panel's, so a count off
+	## measured time slips against the frames the player is shown. 120 Hz is two
+	## hardware frames to 0.5 percent; 144 divides neither and is measured.
+	const LOCK_TOLERANCE: float = 0.01
+	const LOCK_STEADY_TICKS: int = 12
+	const LOCK_SPREAD: float = 0.08
+	const LOCK_MAX_DIVIDER: int = 8
+
 	var _elapsed: float = 0.0
+	## The host's frame smoothed, how many ran at that length, how many of them a
+	## hardware frame lasts while locked, and the phase between two.
+	var _interval: float = 0.0
+	var _steady: int = 0
+	var _divider: int = 0
+	var _phase: int = 0
 	var _window_seconds: float = 0.0
 	var _window_ticks: int = 0
 	var _window_frames: int = 0
@@ -43,14 +58,50 @@ class FrameClock extends RefCounted:
 	## Hardware frames owed since the last call. The scale is read every call
 	## because the settings object is shared and edited in place.
 	func tick(delta: float) -> int:
+		var scale: float = Gen2OptionsStore.current().speed_scale()
+		_watch(delta, FRAME_SECONDS / maxf(scale, 0.01))
+		if _divider > 0:
+			return _locked(delta)
 		_elapsed = minf(
-			_elapsed + delta * Gen2OptionsStore.current().speed_scale(),
+			_elapsed + delta * scale,
 			FRAME_SECONDS * float(MAX_CATCHUP_FRAMES),
 		)
 		var frames: int = int(_elapsed / FRAME_SECONDS)
 		_elapsed -= float(frames) * FRAME_SECONDS
 		_measure(delta, frames)
 		return frames
+
+	## One hardware frame every [member _divider] host frames.
+	func _locked(delta: float) -> int:
+		_phase += 1
+		var frames: int = 0
+		if _phase >= _divider:
+			_phase = 0
+			frames = 1
+		_elapsed = FRAME_SECONDS * float(_phase) / float(_divider)
+		_measure(delta, frames)
+		return frames
+
+	## [param target] is one hardware frame in real seconds at this GAME SPEED.
+	func _watch(delta: float, target: float) -> void:
+		if _interval <= 0.0 or absf(delta - _interval) > _interval * LOCK_SPREAD:
+			_interval = maxf(delta, 0.0001)
+			_steady = 0
+			_divider = 0
+			return
+		_interval += (delta - _interval) * 0.25
+		_steady += 1
+		if _steady < LOCK_STEADY_TICKS:
+			return
+		var per_frame: float = target / _interval
+		var divider: int = roundi(per_frame)
+		if divider < 1 or divider > LOCK_MAX_DIVIDER \
+			or absf(per_frame - float(divider)) > LOCK_TOLERANCE * float(divider):
+			_divider = 0
+			return
+		if _divider != divider:
+			_phase = 0
+		_divider = divider
 
 	## The banked remainder, as a share of one hardware frame.
 	func remainder() -> float:
@@ -61,6 +112,10 @@ class FrameClock extends RefCounted:
 	## measurement window goes with it, since a reading across a gap is a lie.
 	func reset() -> void:
 		_elapsed = 0.0
+		_interval = 0.0
+		_steady = 0
+		_divider = 0
+		_phase = 0
 		_window_seconds = 0.0
 		_window_ticks = 0
 		_window_frames = 0

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -52,6 +52,10 @@ class FrameClock extends RefCounted:
 		_measure(delta, frames)
 		return frames
 
+	## The banked remainder, as a share of one hardware frame.
+	func remainder() -> float:
+		return _elapsed / FRAME_SECONDS
+
 	## Drops the banked remainder, for a pump that was not running: a screen that
 	## comes back owes frames from now rather than from when it stopped. The
 	## measurement window goes with it, since a reading across a gap is a lie.

--- a/game/world/world_animation.gd
+++ b/game/world/world_animation.gd
@@ -24,11 +24,8 @@ const TIMER_WATER_PALETTE: Array = [0, 1, 2, 1]
 ## Real seconds into hardware frames, for every screen that spends them.
 ##
 ## One instance per pump, and the whole conversion: the remainder is banked here
-## so nothing downstream keeps one, and the cap is applied here so no screen can
-## forget it. The app block's GAME SPEED is applied here and nowhere else, which
-## is what keeps it off the sound driver: [Gen2AudioPlayer] fills its generator
-## from the output's own demand rather than from a game frame, so music, effects
-## and cries keep the cartridge's tempo and pitch at every setting.
+## so nothing downstream keeps one, the cap is applied here so no screen can
+## forget it, and [method Gen2Options.speed_scale] is applied here and nowhere else.
 class FrameClock extends RefCounted:
 	## How long [method rate] averages over before it publishes a new reading.
 	const RATE_WINDOW_SECONDS: float = 1.0
@@ -41,12 +38,17 @@ class FrameClock extends RefCounted:
 	const LOCK_STEADY_TICKS: int = 12
 	const LOCK_SPREAD: float = 0.08
 	const LOCK_MAX_DIVIDER: int = 8
+	const LOCK_MISS_RUN: int = 3
+	## The most host frames one tick is worth. A missed present hands over a delta
+	## two frames long and is still the same panel; past this the host stalled.
+	const MAX_HOST_STEPS: int = 4
 
 	var _elapsed: float = 0.0
 	## The host's frame smoothed, how many ran at that length, how many of them a
 	## hardware frame lasts while locked, and the phase between two.
 	var _interval: float = 0.0
 	var _steady: int = 0
+	var _misses: int = 0
 	var _divider: int = 0
 	var _phase: int = 0
 	var _window_seconds: float = 0.0
@@ -59,9 +61,9 @@ class FrameClock extends RefCounted:
 	## because the settings object is shared and edited in place.
 	func tick(delta: float) -> int:
 		var scale: float = Gen2OptionsStore.current().speed_scale()
-		_watch(delta, FRAME_SECONDS / maxf(scale, 0.01))
+		var steps: int = _watch(delta, FRAME_SECONDS / maxf(scale, 0.01))
 		if _divider > 0:
-			return _locked(delta)
+			return _locked(delta, steps)
 		_elapsed = minf(
 			_elapsed + delta * scale,
 			FRAME_SECONDS * float(MAX_CATCHUP_FRAMES),
@@ -71,37 +73,48 @@ class FrameClock extends RefCounted:
 		_measure(delta, frames)
 		return frames
 
-	## One hardware frame every [member _divider] host frames.
-	func _locked(delta: float) -> int:
-		_phase += 1
-		var frames: int = 0
-		if _phase >= _divider:
-			_phase = 0
-			frames = 1
+	## One hardware frame every [member _divider] of the [param steps] host frames.
+	func _locked(delta: float, steps: int) -> int:
+		_phase += steps
+		var frames: int = mini(_phase / _divider, MAX_CATCHUP_FRAMES)
+		_phase -= frames * _divider
 		_elapsed = FRAME_SECONDS * float(_phase) / float(_divider)
 		_measure(delta, frames)
 		return frames
 
+	## How many host frames [param delta] covered, keeping the lock up to date.
 	## [param target] is one hardware frame in real seconds at this GAME SPEED.
-	func _watch(delta: float, target: float) -> void:
-		if _interval <= 0.0 or absf(delta - _interval) > _interval * LOCK_SPREAD:
+	func _watch(delta: float, target: float) -> int:
+		var steps: int = 1 if _interval <= 0.0 \
+			else clampi(roundi(delta / _interval), 1, MAX_HOST_STEPS)
+		var host: float = delta / float(steps)
+		if _interval <= 0.0 or absf(host - _interval) > _interval * LOCK_SPREAD:
+			## An odd delta read as the new frame length throws away both the
+			## lock and the estimate the next delta is judged against. Only a
+			## run of them is a host that has really changed rate.
+			_misses += 1
+			if _interval > 0.0 and _misses < LOCK_MISS_RUN:
+				return steps
+			_misses = 0
 			_interval = maxf(delta, 0.0001)
 			_steady = 0
 			_divider = 0
-			return
-		_interval += (delta - _interval) * 0.25
-		_steady += 1
+			return 1
+		_misses = 0
+		_interval += (host - _interval) * 0.25
+		_steady = mini(_steady + 1, LOCK_STEADY_TICKS)
 		if _steady < LOCK_STEADY_TICKS:
-			return
+			return steps
 		var per_frame: float = target / _interval
 		var divider: int = roundi(per_frame)
 		if divider < 1 or divider > LOCK_MAX_DIVIDER \
 			or absf(per_frame - float(divider)) > LOCK_TOLERANCE * float(divider):
 			_divider = 0
-			return
+			return steps
 		if _divider != divider:
 			_phase = 0
 		_divider = divider
+		return steps
 
 	## The banked remainder, as a share of one hardware frame.
 	func remainder() -> float:
@@ -114,6 +127,7 @@ class FrameClock extends RefCounted:
 		_elapsed = 0.0
 		_interval = 0.0
 		_steady = 0
+		_misses = 0
 		_divider = 0
 		_phase = 0
 		_window_seconds = 0.0
@@ -124,11 +138,12 @@ class FrameClock extends RefCounted:
 
 	## The last completed second of this pump, as `fps` (host frames drawn),
 	## `hardware` (hardware frames spent, which is 59.7 on a machine keeping up
-	## and whatever GAME SPEED multiplies that by) and `worst_ms` (the longest
-	## single host frame in the window, which is the number a stutter shows in
-	## and an average hides). Empty until the first window closes, and empty again
-	## after a reset, so a pump driven by hand rather than by a clock reports
-	## nothing instead of reporting zero.
+	## and whatever GAME SPEED multiplies that by), `worst_ms` (the longest single
+	## host frame in the window, which is the number a stutter shows in and an
+	## average hides) and `lock` (host frames to a hardware one, or 0 while the
+	## clock is measuring time rather than counting them). Empty until the first
+	## window closes, and empty again after a reset, so a pump driven by hand
+	## rather than by a clock reports nothing instead of reporting zero.
 	func rate() -> Dictionary:
 		return _rate
 
@@ -143,6 +158,7 @@ class FrameClock extends RefCounted:
 			"fps": float(_window_ticks) / _window_seconds,
 			"hardware": float(_window_frames) / _window_seconds,
 			"worst_ms": _window_worst * 1000.0,
+			"lock": _divider,
 		}
 		_window_seconds = 0.0
 		_window_ticks = 0

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -817,8 +817,13 @@ func view_surround_offset() -> Vector2i:
 ## [method visible_origin_cells] for a hardware-sized view. Whole pixels: the map
 ## quads and every sprite standing on them are placed from this one number.
 func view_origin_pixels() -> Vector2:
-	return (visible_origin_cells() * float(CELL_PIXELS) \
-		- Vector2(view_surround_offset())).round()
+	return view_origin_subpixel().round()
+
+
+## The same before it is rounded, for a surface able to draw between two pixels.
+func view_origin_subpixel() -> Vector2:
+	return visible_origin_cells() * float(CELL_PIXELS) \
+		- Vector2(view_surround_offset())
 
 
 ## The player's screen pixel, which is PLAYER_VIEW_CELL for as long as the

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -133,6 +133,12 @@ const BGEVENT_COPY: int = 8
 ## that unit, and [Gen2WorldScreen] is what spends the two frames.
 const FRAMES_PER_OVERWORLD_PASS: int = 2
 
+## How far into the pass above the drawn frame stands: 0.0 on the pass, 0.5 on
+## the frame after it. A Game Boy's panel smeared its two-pixel jolt and a modern
+## one does not, so SMOOTH SCROLL halves the step rather than changing it.
+## Presentation only, and zero is what the cartridge drew.
+var pass_fraction: float = 0.0
+
 
 ## Hardware frames for a count of overworld passes. Anything spending frames
 ## against a duration read off the source, a driver or a preview, goes through
@@ -610,7 +616,6 @@ func radio_context() -> Dictionary:
 	}
 
 
-## The station the dial currently sits on, without changing anything.
 func radio_station() -> Dictionary:
 	return Gen2WorldRadio.station_for(state.radio_knob(), radio_context())
 
@@ -813,8 +818,8 @@ func view_surround_offset() -> Vector2i:
 ## [method visible_origin_cells] for a hardware-sized view. Whole pixels: the map
 ## quads and every sprite standing on them are placed from this one number.
 func view_origin_pixels() -> Vector2:
-	return visible_origin_cells() * float(CELL_PIXELS) \
-		- Vector2(view_surround_offset())
+	return (visible_origin_cells() * float(CELL_PIXELS) \
+		- Vector2(view_surround_offset())).round()
 
 
 ## The player's screen pixel, which is PLAYER_VIEW_CELL for as long as the
@@ -883,12 +888,24 @@ func player_height_offset_pixels() -> float:
 ## A scripted movement commits its path at once, so while its trail drains this is
 ## as many cells behind as the player has left to be drawn walking.
 func player_step_offset_cells() -> Vector2:
+	return step_behind_cells(
+		_player_queued_steps, _player_step_direction,
+		_player_step_passes_remaining, _player_step_passes_total, pass_fraction
+	)
+
+
+## The cells a step in flight is still behind its landing cell, for the player
+## and for every object: two answers computed apart slide the map under them.
+static func step_behind_cells(
+	queued: Array, direction: Vector2i, remaining: int, total: int,
+	fraction: float = 0.0
+) -> Vector2:
 	var behind := Vector2.ZERO
-	for entry: Dictionary in _player_queued_steps:
+	for entry: Dictionary in queued:
 		behind -= Vector2(entry["direction"] as Vector2i)
-	if _player_step_passes_remaining > 0 and _player_step_passes_total > 0:
-		behind -= Vector2(_player_step_direction) \
-			* (float(_player_step_passes_remaining) / float(_player_step_passes_total))
+	if remaining > 0 and total > 0:
+		behind -= Vector2(direction) \
+			* (maxf(float(remaining) - fraction, 0.0) / float(total))
 	return behind
 
 
@@ -1316,7 +1333,6 @@ func cut_request() -> Dictionary:
 	return _pending_cut.duplicate(true)
 
 
-## Empty until cut_request() succeeds.
 func pending_cut() -> Dictionary:
 	return _pending_cut.duplicate(true)
 
@@ -1394,7 +1410,6 @@ func surf_request(species: int = 0) -> Dictionary:
 	return _pending_surf.duplicate(true)
 
 
-## Empty until surf_request() succeeds.
 func pending_surf() -> Dictionary:
 	return _pending_surf.duplicate(true)
 
@@ -1461,7 +1476,6 @@ func whirlpool_request() -> Dictionary:
 	return _pending_whirlpool.duplicate(true)
 
 
-## Empty until whirlpool_request() succeeds.
 func pending_whirlpool() -> Dictionary:
 	return _pending_whirlpool.duplicate(true)
 
@@ -1525,7 +1539,6 @@ func waterfall_request() -> Dictionary:
 	return _pending_waterfall.duplicate(true)
 
 
-## Empty until waterfall_request() succeeds.
 func pending_waterfall() -> Dictionary:
 	return _pending_waterfall.duplicate(true)
 
@@ -1624,7 +1637,6 @@ func flash_request() -> Dictionary:
 	return _pending_flash.duplicate(true)
 
 
-## Empty until flash_request() succeeds.
 func pending_flash() -> Dictionary:
 	return _pending_flash.duplicate(true)
 
@@ -1675,7 +1687,6 @@ func headbutt_request() -> Dictionary:
 	return _pending_headbutt.duplicate(true)
 
 
-## Empty until headbutt_request() succeeds.
 func pending_headbutt() -> Dictionary:
 	return _pending_headbutt.duplicate(true)
 
@@ -1780,7 +1791,6 @@ func rock_smash_request() -> Dictionary:
 	return _pending_rock_smash.duplicate(true)
 
 
-## Empty until rock_smash_request() succeeds.
 func pending_rock_smash() -> Dictionary:
 	return _pending_rock_smash.duplicate(true)
 
@@ -1911,7 +1921,6 @@ func _walking_sprite() -> int:
 	return Gen2WorldSprite.player_normal_sprite(_player_female)
 
 
-## Clears the mirror, the counterpart of clear_party_summary().
 func clear_player_id() -> void:
 	_player_id = -1
 
@@ -1949,7 +1958,6 @@ func strength_request(species: int = 0) -> Dictionary:
 	return _pending_strength.duplicate(true)
 
 
-## Empty until strength_request() succeeds.
 func pending_strength() -> Dictionary:
 	return _pending_strength.duplicate(true)
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -368,7 +368,6 @@ var _phone_ring_request: Dictionary = {}
 var _player_step_direction: Vector2i = Vector2i.ZERO
 var _player_step_passes_total: int = 0
 var _player_step_passes_remaining: int = 0
-## Gen2WorldObject.step_began for the player.
 var _player_step_began: bool = false
 ## Whether the step in flight is a ledge hop, which is the only one the source
 ## gives a jump arc. See player_jump_offset().

--- a/game/world/world_menu.gd
+++ b/game/world/world_menu.gd
@@ -10,8 +10,7 @@ extends RefCounted
 const STATICMENU_ENABLE_LEFT_RIGHT: int = Gen2MenuBox.STATICMENU_ENABLE_LEFT_RIGHT
 const STATICMENU_WRAP: int = Gen2MenuBox.STATICMENU_WRAP
 
-## `YesNoBox`'s own `lb bc, SCREEN_WIDTH - 6, 7`, which `_YesNoBox` turns into
-## the five-wide, four-tall box at (14,7). A `choice` pending value carries no
+## [method Gen2MenuBox.yes_no]'s box. A `choice` pending value carries no
 ## `loadmenu` header, since `Script_yesorno` never loads one, so this is the
 ## box every such prompt falls back to.
 const YES_NO_LEFT: int = 14

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -497,10 +497,9 @@ func is_idle() -> bool:
 	return idle_passes_remaining > 0
 
 
-## Pixel offset from the committed cell back toward where the step began,
-## shrinking to zero as step_passes_remaining reaches zero.
-func step_offset(cell_pixels: int) -> Vector2i:
-	var offset: Vector2 = step_offset_cells() * float(cell_pixels)
+## [method step_offset_cells] in pixels.
+func step_offset(cell_pixels: int, fraction: float = 0.0) -> Vector2i:
+	var offset: Vector2 = step_offset_cells(fraction) * float(cell_pixels)
 	return Vector2i(int(round(offset.x)), int(round(offset.y)))
 
 
@@ -514,15 +513,11 @@ func height_offset_pixels() -> float:
 	))
 
 
-## [method Gen2WorldAPI.player_step_offset_cells] for an object.
-func step_offset_cells() -> Vector2:
-	var behind := Vector2.ZERO
-	for entry: Dictionary in queued_steps:
-		behind -= Vector2(entry["direction"] as Vector2i)
-	if step_passes_remaining > 0 and step_passes_total > 0:
-		behind -= Vector2(step_direction) \
-			* (float(step_passes_remaining) / float(step_passes_total))
-	return behind
+func step_offset_cells(fraction: float = 0.0) -> Vector2:
+	return Gen2WorldAPI.step_behind_cells(
+		queued_steps, step_direction, step_passes_remaining, step_passes_total,
+		fraction
+	)
 
 
 ## [method Gen2WorldAPI.player_step_span] for an object.

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -497,7 +497,6 @@ func is_idle() -> bool:
 	return idle_passes_remaining > 0
 
 
-## [method step_offset_cells] in pixels.
 func step_offset(cell_pixels: int, fraction: float = 0.0) -> Vector2i:
 	var offset: Vector2 = step_offset_cells(fraction) * float(cell_pixels)
 	return Vector2i(int(round(offset.x)), int(round(offset.y)))

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -539,8 +539,24 @@ func refresh() -> void:
 ## nothing else, so an earthquake moves the background under the sprites standing
 ## on it rather than moving the picture.
 func _background_camera() -> Vector2:
-	var camera: Vector2 = _world.view_origin_pixels()
+	var camera: Vector2 = _camera_pixels()
 	return camera if _effects == null else camera + _effects.offset()
+
+
+## The camera, snapped to the finest step this surface can draw: at six screen
+## pixels to a hardware one the map scrolls six times as often, and one snap
+## shared by every quad and sprite is what stops them crawling against each
+## other. At one step this is [method Gen2WorldAPI.view_origin_pixels] exactly.
+func _camera_pixels() -> Vector2:
+	var steps: float = float(_subpixel_steps())
+	return (_world.view_origin_subpixel() * steps).round() / steps
+
+
+func _subpixel_steps() -> int:
+	var surface: Viewport = get_viewport()
+	if surface == null:
+		return 1
+	return maxi(1, int(surface.canvas_transform.get_scale().x))
 
 
 ## Lays the map quads out under this frame's camera.
@@ -718,7 +734,7 @@ func _draw() -> void:
 		draw_rect(Rect2(Vector2.ZERO, Vector2(view_pixels())), _background_color, true)
 		return
 
-	var camera_pixels: Vector2 = _world.view_origin_pixels()
+	var camera_pixels: Vector2 = _camera_pixels()
 	var background: Vector2 = _background_camera()
 	_draw_hidden_trees(background)
 	if not _transition_cells.is_empty():

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -807,7 +807,8 @@ func _draw_row_entries(
 		var object: Gen2WorldObject = entry["object"]
 		var offset: Vector2i = entry.get("offset", Vector2i.ZERO)
 		var pixel: Vector2 = Vector2((object.cell + offset) * Gen2WorldAPI.CELL_PIXELS) \
-			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS)) - camera_pixels \
+			+ Vector2(object.step_offset(Gen2WorldAPI.CELL_PIXELS, _world.pass_fraction)) \
+			- camera_pixels \
 			+ SPRITE_LIFT
 		var texture: Texture2D = _actor_texture(
 			object.sprite, object.palette, object.drawn_facing(), object.frame,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -372,12 +372,9 @@ func _set_caption(text: String) -> void:
 	_caption.text = _caption_text + _rate_text
 
 
-## `fps` is host frames drawn, `hw` the hardware frames the pump spent, which is
-## 59.7 on a machine keeping up and whatever GAME SPEED multiplies that by, and
-## `worst` the longest single frame of the second, which is where a stutter shows
-## and an average hides it. The reading changes once a second and the line is
-## rebuilt only then: this is drawn on the frame it is measuring.
-## See [method Gen2WorldAnimation.FrameClock.rate].
+## The reading changes once a second and the line is rebuilt only then, so this
+## is drawn on the frame it is measuring, and `lock` is shown only when there is
+## one. See [method Gen2WorldAnimation.FrameClock.rate].
 func _refresh_frame_rate() -> void:
 	if _world == null or _caption == null or not _caption.visible:
 		return
@@ -385,8 +382,10 @@ func _refresh_frame_rate() -> void:
 	if rate.is_empty() or rate == _rate_reading:
 		return
 	_rate_reading = rate
-	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms" % [
+	var lock: int = int(rate["lock"])
+	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms%s" % [
 		float(rate["fps"]), float(rate["hardware"]), float(rate["worst_ms"]),
+		"" if lock < 1 else "   lock 1:%d" % lock,
 	]
 	_caption.text = _caption_text + _rate_text
 
@@ -807,10 +806,9 @@ func _process(delta: float) -> void:
 
 ## SMOOTH SCROLL. Where the drawn frame stands in the pass: whole frames off
 ## `NextOverworldFrame`'s countdown plus the part of the next one the clock has
-## banked. Banked real time and not a frame count, because a host frame is
-## 16.667 ms against the cartridge's 16.742: a tick spends sometimes no frame and
-## sometimes two, and a count alone jumps 0, 1 or 2 pixels for nothing. Called
-## every drawn frame, not every spent one.
+## banked. Banked real time and not a frame count, because a tick spends
+## sometimes no frame and sometimes two and a count alone jumps 0, 1 or 2 pixels
+## for nothing. Called every drawn frame, not every spent one.
 func _apply_pass_fraction(remainder: float = 0.0) -> void:
 	if _world == null:
 		return

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -299,6 +299,7 @@ var _breed_random := RandomNumberGenerator.new()
 var _selected_rod: StringName = Gen2WorldEncounter.METHOD_OLD_ROD
 ## The overworld's hardware-frame clock: see [method _process].
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
+var _pass_moved: bool = false
 ## `(frame, button)` input, recorded from a run and played back into another.
 ## Both are opt-in and off in play. A replay applies a log's entries on the frame
 ## that recorded them, from inside the pump, so a host that owes two frames
@@ -803,6 +804,22 @@ func _process(delta: float) -> void:
 	_apply_interface_mask()
 
 
+## SMOOTH SCROLL, off `NextOverworldFrame`'s own countdown: a run driven by hand
+## stands on a pass and draws what the cartridge drew whatever the option says.
+func _apply_pass_fraction() -> void:
+	if _world == null:
+		return
+	var whole: bool = _overworld_delay >= Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
+	_world.pass_fraction = 0.0 if not Gen2OptionsStore.current().smooth_scroll \
+		else float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS - _overworld_delay) \
+			/ float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS)
+	## Only when the pass moved something, so a still map costs what it did.
+	if whole:
+		_pass_moved = false
+		return
+	_refresh_if(_pass_moved and _world.pass_fraction > 0.0)
+
+
 ## Spends [param count] hardware frames. Public beside [method advance_frame] so
 ## a test, a preview tool or a replay settles the world on the frames it owes
 ## rather than on a clock.
@@ -849,6 +866,7 @@ func advance_frame() -> void:
 	if map_pass:
 		_overworld_delay = Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
 	_advance_presentation(map_pass)
+	_apply_pass_fraction()
 	_advance_movement(map_pass)
 	_advance_population(map_pass)
 	_advance_waits(map_pass)
@@ -862,6 +880,7 @@ func advance_frame() -> void:
 ## Redraws when [param moved] says something under the renderer changed.
 func _refresh_if(moved: bool) -> void:
 	if moved and _renderer != null:
+		_pass_moved = true
 		_renderer.refresh()
 
 
@@ -3771,9 +3790,7 @@ func preview_card_flip(coins: int = 100, frames: int = 0) -> void:
 	for _frame: int in maxi(frames, 0):
 		if _card_flip_host == null:
 			break
-		## The `WaitSFX` steps are the driver's, and a screenshot spends no wall
-		## clock for an effect to finish in, so each is cut rather than waited
-		## out, the way `preview_slot_machine` does it.
+		## Cut rather than waited out, the way `preview_slot_machine` does it.
 		if _audio_player != null and host.game() != null \
 			and host.game().waiting_for_sfx():
 			_audio_player.stop_effects()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -372,9 +372,10 @@ func _set_caption(text: String) -> void:
 	_caption.text = _caption_text + _rate_text
 
 
-## The reading changes once a second and the line is rebuilt only then, so this
-## is drawn on the frame it is measuring, and `lock` is shown only when there is
-## one. See [method Gen2WorldAnimation.FrameClock.rate].
+## The reading changes once a second and the line is rebuilt only then, so this is
+## drawn on the frame it is measuring. `lock` shows only when there is one; `sub`
+## is screen pixels to a hardware one, and 1:1 is none of the smoothing reaching
+## the panel. See [method Gen2WorldAnimation.FrameClock.rate].
 func _refresh_frame_rate() -> void:
 	if _world == null or _caption == null or not _caption.visible:
 		return
@@ -383,9 +384,10 @@ func _refresh_frame_rate() -> void:
 		return
 	_rate_reading = rate
 	var lock: int = int(rate["lock"])
-	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms%s" % [
+	var steps: int = _screen.subpixel_steps()
+	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms%s   sub 1:%d" % [
 		float(rate["fps"]), float(rate["hardware"]), float(rate["worst_ms"]),
-		"" if lock < 1 else "   lock 1:%d" % lock,
+		"" if lock < 1 else "   lock 1:%d" % lock, steps,
 	]
 	_caption.text = _caption_text + _rate_text
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -633,6 +633,11 @@ func _build_renderer() -> void:
 		_renderer.call(Gen2ModHost.RENDERER_ACTORS_METHOD, _actors)
 	if _renderer.has_method(Gen2ModHost.RENDERER_ENCOUNTERS_METHOD):
 		_renderer.call(Gen2ModHost.RENDERER_ENCOUNTERS_METHOD, _encounters)
+	## SMOOTH SCROLL again: a pass drawn a pixel at a time still steps a whole
+	## hardware pixel, twelve screen ones on a laptop panel. A native view is
+	## already at the window's resolution. See [member Gen2Screen.subpixel].
+	_screen.subpixel = Gen2OptionsStore.current().smooth_scroll \
+		and Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
 	_set_renderer_world()
 	_renderer.set_time_of_day(_render_time_of_day())
 	_apply_renderer_interface_style()

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -796,6 +796,7 @@ func cycle_view() -> Dictionary:
 func _process(delta: float) -> void:
 	for _frame: int in _frame_clock.tick(delta):
 		advance_frame()
+	_apply_pass_fraction(_frame_clock.remainder())
 	_refresh_frame_rate()
 	_advance_day_cycle(delta)
 	## Every drawn frame rather than every hardware frame: above sixty a drawn
@@ -804,20 +805,26 @@ func _process(delta: float) -> void:
 	_apply_interface_mask()
 
 
-## SMOOTH SCROLL, off `NextOverworldFrame`'s own countdown: a run driven by hand
-## stands on a pass and draws what the cartridge drew whatever the option says.
-func _apply_pass_fraction() -> void:
+## SMOOTH SCROLL. Where the drawn frame stands in the pass: whole frames off
+## `NextOverworldFrame`'s countdown plus the part of the next one the clock has
+## banked. Banked real time and not a frame count, because a host frame is
+## 16.667 ms against the cartridge's 16.742: a tick spends sometimes no frame and
+## sometimes two, and a count alone jumps 0, 1 or 2 pixels for nothing. Called
+## every drawn frame, not every spent one.
+func _apply_pass_fraction(remainder: float = 0.0) -> void:
 	if _world == null:
 		return
-	var whole: bool = _overworld_delay >= Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
+	var before: float = _world.pass_fraction
+	## Clamped: a world that has spent no frame reads zero, a whole pass.
+	var spent: float = clampf(
+		float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS - _overworld_delay),
+		0.0, float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS - 1)
+	)
 	_world.pass_fraction = 0.0 if not Gen2OptionsStore.current().smooth_scroll \
-		else float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS - _overworld_delay) \
+		else (spent + clampf(remainder, 0.0, 1.0)) \
 			/ float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS)
-	## Only when the pass moved something, so a still map costs what it did.
-	if whole:
-		_pass_moved = false
-		return
-	_refresh_if(_pass_moved and _world.pass_fraction > 0.0)
+	## Only while the pass is moving something, so a still map is drawn once.
+	_refresh_if(_pass_moved and _world.pass_fraction != before)
 
 
 ## Spends [param count] hardware frames. Public beside [method advance_frame] so
@@ -865,6 +872,7 @@ func advance_frame() -> void:
 	var map_pass: bool = _overworld_delay <= 0
 	if map_pass:
 		_overworld_delay = Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS
+		_pass_moved = false
 	_advance_presentation(map_pass)
 	_apply_pass_fraction()
 	_advance_movement(map_pass)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -947,7 +947,8 @@ func _advance_movement(map_pass: bool) -> void:
 	if map_pass:
 		_advance_forced_movement()
 		_advance_held_direction()
-		_refresh_if(_world != null and _world.advance_player_step_pass())
+		var stepped: bool = _world != null and _world.advance_player_step_pass()
+		_refresh_if(stepped)
 		## `CheckPlayerState` reads the step flags at the end of `HandleMap`,
 		## after `HandleMapObjects`, so the step that finishes on this frame is
 		## the one whose events this frame runs.
@@ -956,6 +957,11 @@ func _advance_movement(map_pass: bool) -> void:
 			var landed: Dictionary = _pending_step_events
 			_pending_step_events = {}
 			_complete_player_step(landed)
+		## Polled again on the pass a step lands on: the poll above ran while the
+		## step was still in flight and refused it, so a held direction started the
+		## next step a pass late and the walk froze a frame and doubled the next.
+		if stepped and _world != null and not _world.player_step_in_progress():
+			_advance_held_direction()
 	## Not the pass's: an emote's own countdown stands in for the `pause` between
 	## `ShowEmoteScript`'s two movements, and a script's `DelayFrames` is spent
 	## from inside the command rather than by `NextOverworldFrame`.

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -132,9 +132,7 @@ var _mart: Dictionary = {}
 var _mart_entries: Array = []
 var _mart_quantity: int = 1
 var _mart_purchased: bool = false
-## `BuyMenu`'s own layer, which owns all 160x144 the way the region map does: the
-## scrolling list's own scroll and cursor, which of `BuyMenuLoop`'s four states
-## it is in, and the boxes waiting on a press.
+## The shop's own layer: `BuyMenu`'s 160x144, or a box standing on the map.
 var _mart_view: TextureRect = null
 var _mart_page: Gen2MartPage = null
 var _mart_menu_page: Gen2MenuPage = null
@@ -145,7 +143,7 @@ var _mart_after: StringName = MART_LIST
 var _mart_confirm: int = 0
 ## `SellMenu`'s own list, which is the pack rather than the shop's stock.
 var _mart_sell_entries: Array = []
-var _mart_top: int = MART_TOP_BUY
+var _mart_over_map: bool = false
 ## `wCurElevatorFloors` and `wElevatorOriginFloor`: the list the host resolved
 ## and the row `.FindCurrentFloor` matched, plus this screen's own scroll.
 var _elevator: Dictionary = {}
@@ -608,9 +606,8 @@ func _open_menu(input: Dictionary) -> void:
 	_render_rows()
 
 
-## `BuyMenu`, which is a screen of its own rather than a box over the map: the
-## panel steps aside for it the way it does for the region map, and the shop's
-## own intro box is the first thing it prints.
+## The shop. `MartDialog` opens on the map: `MENU_BACKUP_TILES` on the welcome
+## box and on `MenuHeader_BuySell`, and no `BuyMenu` screen until BUY is chosen.
 func _open_mart(mart: Dictionary) -> void:
 	_mode = MODE.MART
 	_mart = mart.duplicate(true)
@@ -627,15 +624,16 @@ func _open_mart(mart: Dictionary) -> void:
 		_mart_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 		_mart_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 		_mart_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		## Displayed after the panel's own view, which is [method
-		## Gen2Screen.display]'s z-order: the shop owns all 160x144 while it is
-		## up and the menu behind it is hidden anyway.
+		## After the panel's own view, which is [method Gen2Screen.display]'s
+		## z-order: the menu behind the shop is hidden anyway.
 		_service_hardware.display(_mart_view)
-	_mart_top = MART_TOP_BUY
 	_refresh_mart_sell_entries()
-	## `.HowMayIHelpYou` prints `MartWelcomeText` and hands the loop to
-	## `.TopMenu`; every other shop type prints its own intro over `BuyMenu`.
-	_show_mart_text(_mart_text("intro"), MART_TOP if _mart_standard() else MART_LIST)
+	## `.HowMayIHelpYou` hands the loop to `.TopMenu`; every other shop type
+	## prints its intro through `MartTextbox`, which waits before `BuyMenu`.
+	if _mart_standard():
+		_show_mart_top(_mart_text("intro"))
+		return
+	_show_mart_text(_mart_text("intro"), MART_LIST, true)
 
 
 ## Whether this shop is `MartDialog`'s, which is the one that runs
@@ -685,8 +683,9 @@ func _fill_mart_markers(text: String, filled: Dictionary) -> String:
 ## A box the shop is holding on, laid out into the pages `JoyWaitAorB` steps
 ## through. An empty text goes straight on, which is what a cache imported
 ## before the mart's own words leaves.
-func _show_mart_text(text: String, after: StringName) -> void:
+func _show_mart_text(text: String, after: StringName, over_map: bool = false) -> void:
 	_mart_after = after
+	_mart_over_map = over_map
 	_mart_pages = [] if text.strip_edges().is_empty() \
 		else Gen2TextLayout.lay_out(text, MART_TEXT_COLUMNS, MART_TEXT_ROWS)
 	if _mart_pages.is_empty():
@@ -696,17 +695,29 @@ func _show_mart_text(text: String, after: StringName) -> void:
 	_render_mart()
 
 
+## `.HowMayIHelpYou` and `.AnythingElse`: `PrintText` returns without a press, so
+## the menu opens over the box, and `CopyMenuHeader` reloads its `db 1` default.
+func _show_mart_top(text: String) -> void:
+	_mart_pages = Gen2TextLayout.lay_out(text, MART_TEXT_COLUMNS, MART_TEXT_ROWS)
+	_mart_stage = MART_TOP
+	_mart_over_map = true
+	_cursor = MART_TOP_BUY
+	_render_mart()
+
+
 func _advance_mart_text() -> void:
 	if not _mart_pages.is_empty():
 		_mart_pages.remove_at(0)
 	if not _mart_pages.is_empty():
 		_render_mart()
 		return
-	if _mart_after == MART_LIST or _mart_after == MART_TOP or _mart_after == MART_SELL:
+	if _mart_after == MART_TOP:
+		_show_mart_top(_mart_text("ask_more"))
+		return
+	if _mart_after == MART_LIST or _mart_after == MART_SELL:
 		_mart_stage = _mart_after
+		_mart_over_map = false
 		_cursor = 0
-		if _mart_after == MART_TOP:
-			_cursor = _mart_top
 		_render_mart()
 		return
 	_close_mart()
@@ -721,7 +732,6 @@ func _mart_row_count() -> int:
 	return rows + 1 if rows < Gen2MartPage.LIST_HEIGHT else Gen2MartPage.LIST_HEIGHT
 
 
-## Whichever of the shop's stock and the player's pack the stage is showing.
 func _mart_list() -> Array:
 	return _mart_sell_entries if _mart_stage in MART_SELL_STAGES else _mart_entries
 
@@ -894,13 +904,13 @@ func _buy_mart_selection() -> void:
 ## only `.Quit` and the four single-list shop types print the come-again box.
 func _leave_mart() -> void:
 	if _mart_standard():
-		_show_mart_text(_mart_text("ask_more"), MART_TOP)
+		_show_mart_top(_mart_text("ask_more"))
 		return
 	_quit_mart()
 
 
 func _quit_mart() -> void:
-	_show_mart_text(_mart_text("come_again"), &"exit")
+	_show_mart_text(_mart_text("come_again"), &"exit", true)
 
 
 ## `.TopMenu`'s three rows. `VerticalMenu` answers carry on B, which `.quit`
@@ -915,10 +925,10 @@ func _press_mart_top(button: int) -> void:
 			_quit_mart()
 			return
 		Gen2Button.A:
-			_mart_top = _cursor
 			match _cursor:
 				MART_TOP_BUY:
 					_mart_stage = MART_LIST
+					_mart_over_map = false
 					_cursor = 0
 					_mart_scroll = 0
 				MART_TOP_SELL:
@@ -936,9 +946,10 @@ func _press_mart_top(button: int) -> void:
 func _open_mart_sell() -> void:
 	_refresh_mart_sell_entries()
 	if _mart_sell_entries.is_empty():
-		_show_mart_text(_mart_text("ask_more"), MART_TOP)
+		_show_mart_top(_mart_text("ask_more"))
 		return
 	_mart_stage = MART_SELL
+	_mart_over_map = false
 	_cursor = 0
 	_mart_scroll = 0
 	_mart_quantity = 1
@@ -1063,11 +1074,15 @@ func _close_mart() -> void:
 	if _mart_view != null:
 		Gen2Screen.drop(_mart_view)
 		_mart_view = null
+	_mart_over_map = false
 	_set_overlay_open(false)
 
 
 func _render_mart() -> void:
 	if _mart_view == null or _data == null:
+		return
+	if _mart_over_map:
+		_render_mart_over_map()
 		return
 	if _mart_page == null:
 		_mart_page = Gen2MartPage.from_data(_data)
@@ -1098,14 +1113,24 @@ func _render_mart() -> void:
 		return
 	if _mart_stage == MART_CONFIRM or _mart_stage == MART_SELL_CONFIRM:
 		_blend_mart_menu(image, Gen2MenuBox.yes_no(), ["YES", "NO"], _mart_confirm)
-	elif _mart_stage == MART_TOP:
-		## `MenuHeader_BuySell`'s `menu_coords 0, 0, 7, 8`.
-		_blend_mart_menu(
-			image,
-			Gen2MenuBox.from_coords(0, 0, 7, 8, Gen2MenuBox.STATICMENU_CURSOR),
-			MART_TOP_ROWS, _cursor
-		)
 	Gen2PicImage.show(_mart_view, image)
+
+
+## The speech box and `MenuHeader_BuySell`'s `menu_coords 0, 0, 7, 8` over it.
+func _render_mart_over_map() -> void:
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _service_page == null:
+		return
+	var page: PackedStringArray = _mart_pages[0] if not _mart_pages.is_empty() \
+		else PackedStringArray()
+	var image: Image = _service_page.render(
+		"", "", MART_TOP_ROWS if _mart_stage == MART_TOP else [], _cursor,
+		"\n".join(page),
+		Gen2MenuBox.from_coords(0, 0, 7, 8, Gen2MenuBox.STATICMENU_CURSOR)
+	)
+	if image != null:
+		Gen2PicImage.show(_mart_view, image)
 
 
 func _blend_mart_menu(

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -364,14 +364,54 @@ func test_a_walk_step_is_drawn_a_pixel_a_frame_and_two_a_pass() -> void:
 	assert_eq(hardware[15], 16.0)
 	assert_eq(_biggest_jump(smooth), 1.0, "smooth never moves more than a pixel")
 	assert_eq(_biggest_jump(hardware), 2.0, "the pass moves two at a time")
-	assert_gt(_drawn_positions(smooth), 14, "a picture a frame rather than eight")
-	assert_eq(_drawn_positions(hardware), 8)
+	assert_gt(
+		_drawn_positions(smooth), _drawn_positions(hardware),
+		"a picture a frame rather than one a pass"
+	)
+
+
+## The reported stutter, which SMOOTH SCROLL made visible rather than caused.
+## `FrameClock.tick` answers whole frames, so a picture placed from that count
+## alone moves 0, 1 or 2 pixels as the host's 16.667 ms beats against the
+## cartridge's 16.742: three host frames here spend one hardware frame, none, and
+## two. The banked remainder is the rest of the answer.
+func test_a_drawn_frame_stands_where_real_time_puts_it() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var chosen: bool = options.smooth_scroll
+	options.smooth_scroll = true
+	_world_screen = await _open_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	_settle_on_a_pass()
+	var origin: float = world.view_origin_pixels().x
+	world.move_result(Vector2i.RIGHT)
+
+	## A host frame that jitters either side of the display's own, which is what
+	## a compositor hands `_process` and what the screen recording caught.
+	var deltas: Array[float] = [0.0170, 0.0170, 0.0090, 0.0245]
+	var drawn: Array[float] = []
+	for index: int in 12:
+		_world_screen._process(deltas[index] if index < deltas.size() else 0.0170)
+		drawn.append(world.view_origin_pixels().x - origin)
+	options.smooth_scroll = chosen
+	assert_eq(_biggest_jump(drawn), 1.0, "no drawn frame carries two pixels")
+	assert_eq(drawn[0], 1.0, "and none carries none")
+	for index: int in range(1, drawn.size()):
+		assert_eq(drawn[index], drawn[index - 1] + 1.0, "frame %d" % index)
+
+
+## Puts the pump on a pass boundary with nothing banked, so a case counting
+## pixels starts where the cartridge would and not part way through one.
+func _settle_on_a_pass() -> void:
+	while _world_screen._overworld_delay != Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS:
+		_world_screen.advance_frame()
+	_world_screen._frame_clock.reset()
 
 
 ## The camera's own x, one entry per hardware frame of one step east, measured
 ## from where it stood before the step began.
 func _walk_camera_pixels() -> Array[float]:
 	var world: Gen2WorldAPI = _world_screen._world
+	_settle_on_a_pass()
 	var origin: float = world.view_origin_pixels().x
 	var out: Array[float] = []
 	world.move_result(Vector2i.RIGHT)

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -342,3 +342,54 @@ func test_a_picture_beside_a_runtime_request_is_still_drawn() -> void:
 		_world_screen._world.dispatch_script_events(SCRIPT_CELL)
 	)
 	assert_not_null(_world_screen._story_picture, "the pokepic box is on screen")
+
+
+## SMOOTH SCROLL. `HandleMapObjects` moves the map two pixels once per two
+## frames; on, the frame between two passes is drawn a pixel on, so the step
+## takes the same sixteen frames and lands in the same place.
+func test_a_walk_step_is_drawn_a_pixel_a_frame_and_two_a_pass() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var chosen: bool = options.smooth_scroll
+	_world_screen = await _open_world()
+	options.smooth_scroll = true
+	var smooth: Array[float] = _walk_camera_pixels()
+	_world_screen.free()
+	_world_screen = await _open_world()
+	options.smooth_scroll = false
+	var hardware: Array[float] = _walk_camera_pixels()
+	options.smooth_scroll = chosen
+
+	assert_eq(smooth.size(), 16, "a walk step is sixteen frames")
+	assert_eq(smooth[15], 16.0, "and sixteen pixels, wherever it is drawn")
+	assert_eq(hardware[15], 16.0)
+	assert_eq(_biggest_jump(smooth), 1.0, "smooth never moves more than a pixel")
+	assert_eq(_biggest_jump(hardware), 2.0, "the pass moves two at a time")
+	assert_gt(_drawn_positions(smooth), 14, "a picture a frame rather than eight")
+	assert_eq(_drawn_positions(hardware), 8)
+
+
+## The camera's own x, one entry per hardware frame of one step east, measured
+## from where it stood before the step began.
+func _walk_camera_pixels() -> Array[float]:
+	var world: Gen2WorldAPI = _world_screen._world
+	var origin: float = world.view_origin_pixels().x
+	var out: Array[float] = []
+	world.move_result(Vector2i.RIGHT)
+	for _frame: int in 16:
+		_world_screen.advance_frame()
+		out.append(world.view_origin_pixels().x - origin)
+	return out
+
+
+func _biggest_jump(pixels: Array[float]) -> float:
+	var most: float = 0.0
+	for index: int in range(1, pixels.size()):
+		most = maxf(most, pixels[index] - pixels[index - 1])
+	return most
+
+
+func _drawn_positions(pixels: Array[float]) -> int:
+	var seen: Dictionary = {}
+	for value: float in pixels:
+		seen[value] = true
+	return seen.size()

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -368,6 +368,49 @@ func _finish_pokemon_center_pc(host: Gen2WorldServiceScreen) -> void:
 	assert_false(_world_screen._world.script_input_waiting())
 
 
+## `MartDialog` opens on the map: `.HowMayIHelpYou` prints without waiting and
+## `MenuHeader_BuySell` is drawn over that box, so nothing of `BuyMenu` is on
+## screen until BUY is taken.
+func test_the_shop_opens_over_the_map_and_the_buy_screen_only_after_buy() -> void:
+	await _open_world()
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_true(host._mart_over_map, "the top menu stands on the map")
+	var over_map: Image = (host._mart_view.texture as ImageTexture).get_image()
+	assert_true(
+		over_map.detect_alpha() != Image.ALPHA_NONE,
+		"the box over the map is a layer rather than a screen"
+	)
+
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_LIST)
+	assert_false(host._mart_over_map)
+	var listing: Image = (host._mart_view.texture as ImageTexture).get_image()
+	assert_eq(
+		listing.detect_alpha(), Image.ALPHA_NONE,
+		"`BuyMenu` blanks the screen and owns all of it"
+	)
+
+
+## `CopyMenuHeader` reloads `MenuHeader_BuySell`'s `db 1`, so the cursor is on
+## BUY every time `.TopMenu` runs rather than on the row it was left on.
+func test_the_top_menu_reopens_on_buy() -> void:
+	await _open_world()
+	await _queue_service()
+
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	assert_true(host.handle_button(Gen2Button.DOWN))
+	assert_eq(host._cursor, Gen2WorldServiceScreen.MART_TOP_SELL)
+	assert_true(host.handle_button(Gen2Button.A))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_SELL)
+	## B off the list is `SellMenu`'s quit, and `.AnythingElse` asks again.
+	assert_true(host.handle_button(Gen2Button.B))
+	assert_eq(host._mart_stage, Gen2WorldServiceScreen.MART_TOP)
+	assert_eq(host._cursor, Gen2WorldServiceScreen.MART_TOP_BUY)
+
+
 func test_mart_overlay_uses_production_input_and_returns_to_script() -> void:
 	await _open_world()
 	await _queue_service()

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -162,7 +162,7 @@ func test_out_of_range_values_are_clamped_rather_than_refused() -> void:
 	assert_eq(options.textbox_frame, Gen2Options.FRAME_COUNT - 1)
 	assert_eq(options.video_mode, &"windowed")
 	assert_eq(options.game_speed, &"normal")
-	assert_eq(options.max_fps, 60, "an unlisted frame cap falls back to 60")
+	assert_eq(options.max_fps, 0, "an unlisted frame cap falls back to the display")
 
 
 ## SCREEN FILL and its zoom step are view preferences rather than part of a run,
@@ -249,3 +249,14 @@ func test_current_shares_one_object_until_forgotten() -> void:
 
 	Gen2OptionsStore.use_test_path()
 	assert_eq(Gen2OptionsStore.current().music_volume, 7)
+
+
+## `Engine.max_fps` is a sleep and not a vblank, so a cap below the panel's own
+## rate shows a frame for one refresh, then three, then two. 60 was the default
+## before that was understood, so a file carrying it moves with the default; a
+## rate the player picked stays where they put it.
+func test_the_old_frame_cap_default_moves_to_the_display() -> void:
+	assert_eq(Gen2Options.new().max_fps, 0, "the display's own rate is default")
+	assert_eq(Gen2Options.parse({"format_version": 1, "max_fps": 60}).max_fps, 0)
+	assert_eq(Gen2Options.parse({"format_version": 1, "max_fps": 30}).max_fps, 30)
+	assert_eq(Gen2Options.parse({"format_version": 2, "max_fps": 60}).max_fps, 60)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37881
+const MAX_COMMENT_LINES: int = 37878
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -596,12 +596,37 @@ func _repeats(owed: Array[int]) -> int:
 	return count
 
 
-## A host that hitches is not steady, so the lock drops and the clock goes back
-## to measuring time until the frames settle again.
-func test_a_hitching_host_is_not_locked_to() -> void:
+## A hitch is a machine that stalled rather than a panel that changed rate, so
+## the frames it swallowed are spent and the lock stands. Only a run of frames at
+## a new length puts the clock back on measured time.
+func test_a_hitch_is_spent_and_only_a_new_rate_drops_the_lock() -> void:
 	var clock := Gen2WorldAnimation.FrameClock.new()
 	for _host: int in 60:
 		clock.tick(1.0 / 60.0)
 	assert_eq(clock.tick(1.0 / 60.0), 1, "steady frames are locked to")
 	## A tenth of a second, which is six frames the world still owes.
 	assert_gt(clock.tick(0.1), 1, "a stall is spent rather than counted as one")
+	assert_eq(clock._divider, 1, "one stall is not a new frame rate")
+	for _host: int in Gen2WorldAnimation.FrameClock.LOCK_MISS_RUN:
+		clock.tick(1.0 / 144.0)
+	assert_eq(clock._divider, 0, "a run of them is, and 144 Hz divides nothing")
+
+
+## A panel that missed a present is the same panel: the tick that carries two of
+## its frames spends both and keeps the lock, which is what a machine dropping
+## one frame a second reported as `hw 59/s` and a stutter every twelve frames
+## while the lock was reacquired.
+func test_a_missed_present_keeps_the_lock_and_is_still_spent() -> void:
+	var clock := Gen2WorldAnimation.FrameClock.new()
+	for _warm: int in 60:
+		clock.tick(1.0 / 120.0)
+	assert_eq(clock._divider, 2, "120 Hz is two host frames to a hardware one")
+	var spent: int = 0
+	for _second: int in 5:
+		for _host: int in 119:
+			spent += clock.tick(1.0 / 120.0)
+		spent += clock.tick(2.0 / 120.0)
+	assert_eq(clock._divider, 2, "a missed present is not a new frame rate")
+	## 605 host frames of the 600 a second each carries, halved.
+	assert_eq(spent, 302, "the missed present is spent rather than lost")
+	assert_eq(int(clock.rate()["lock"]), 2, "and the reading says so")

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -550,3 +550,58 @@ func test_the_frame_clock_reports_a_second_of_drawn_and_hardware_frames() -> voi
 
 	clock.reset()
 	assert_eq(clock.rate(), {}, "a reading across a gap is not reported")
+
+
+## The frame clock counts the host's own frames once it has seen enough of them
+## at one length to be sure of it. Measuring time instead leaves the world
+## slipping against the frames the player is shown: 16.667 ms of host against
+## 16.742 of hardware is a whole frame every 3.7 seconds, and half a pass of
+## drift is a pixel of the overworld.
+func test_the_frame_clock_locks_to_a_steady_host_frame() -> void:
+	for row: Array in [
+		## A 60 Hz panel: one hardware frame per host frame, forever.
+		[1.0 / 60.0, [1]],
+		## A 120 Hz one: one every second host frame.
+		[1.0 / 120.0, [0, 1]],
+		## 144 Hz divides neither, so the clock keeps measuring time and the
+		## host frames do not all owe the same.
+		[1.0 / 144.0, []],
+	]:
+		var host: float = float(row[0])
+		var clock := Gen2WorldAnimation.FrameClock.new()
+		for _warm: int in 60:
+			clock.tick(host)
+		var owed: Array[int] = []
+		for _tick: int in 240:
+			owed.append(clock.tick(host))
+		var cadence: Array = row[1]
+		if cadence.is_empty():
+			assert_ne(
+				_repeats(owed), owed.size() / 2,
+				"%.0f Hz divides no hardware frame" % (1.0 / host)
+			)
+			continue
+		for index: int in owed.size():
+			assert_eq(
+				owed[index], int(cadence[index % cadence.size()]),
+				"%.0f Hz, host frame %d" % [1.0 / host, index]
+			)
+
+
+## How many of [param owed] are one, which at a locked 120 Hz is every second.
+func _repeats(owed: Array[int]) -> int:
+	var count: int = 0
+	for value: int in owed:
+		count += 1 if value > 0 else 0
+	return count
+
+
+## A host that hitches is not steady, so the lock drops and the clock goes back
+## to measuring time until the frames settle again.
+func test_a_hitching_host_is_not_locked_to() -> void:
+	var clock := Gen2WorldAnimation.FrameClock.new()
+	for _host: int in 60:
+		clock.tick(1.0 / 60.0)
+	assert_eq(clock.tick(1.0 / 60.0), 1, "steady frames are locked to")
+	## A tenth of a second, which is six frames the world still owes.
+	assert_gt(clock.tick(0.1), 1, "a stall is spent rather than counted as one")

--- a/tools/checks/card_flip.gd
+++ b/tools/checks/card_flip.gd
@@ -230,8 +230,7 @@ func _bet_ready(seed_value: int) -> Gen2CardFlip:
 	return null
 
 
-## The cache against a second reading of the dump, which is what says the walk
-## found the records rather than five runs that happen to decompress.
+## The cache against a second reading of the dump: the walk found the records.
 func _verify_section(game_id: StringName, data: GameData) -> void:
 	var rom: RomFile = RomFile.open_verified("res://roms/%s.gbc" % game_id)
 	if not _r.check(rom != null, "%s: roms/%s.gbc is unreadable." % [game_id, game_id]):

--- a/tools/checks/cut.gd
+++ b/tools/checks/cut.gd
@@ -12,8 +12,7 @@ var _r: RefCounted = null
 ## out of the forest.
 
 
-## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push
-## Ilex Forest eight places later within the same group.
+## constants/map_constants.asm, DUNGEONS group; Crystal's sit eight later.
 const ILEX_GROUP: int = 3
 const ILEX_NUMBER_CRYSTAL: int = 52
 const ILEX_NUMBER_GOLD_SILVER: int = 44

--- a/tools/checks/headbutt.gd
+++ b/tools/checks/headbutt.gd
@@ -12,9 +12,7 @@ var _r: RefCounted = null
 ## games.
 
 
-## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push
-## Ilex Forest eight places later within the same group, as validate_cut.gd
-## records for the same map.
+## constants/map_constants.asm, DUNGEONS group; Crystal's sit eight later.
 const ILEX_GROUP: int = 3
 const ILEX_NUMBER_CRYSTAL: int = 52
 const ILEX_NUMBER_GOLD_SILVER: int = 44

--- a/tools/checks/headbutt.gd
+++ b/tools/checks/headbutt.gd
@@ -12,7 +12,6 @@ var _r: RefCounted = null
 ## games.
 
 
-## constants/map_constants.asm, DUNGEONS group; Crystal's sit eight later.
 const ILEX_GROUP: int = 3
 const ILEX_NUMBER_CRYSTAL: int = 52
 const ILEX_NUMBER_GOLD_SILVER: int = 44

--- a/tools/checks/mart.gd
+++ b/tools/checks/mart.gd
@@ -57,19 +57,27 @@ const EXPECTED_MARKERS: Dictionary = {
 ## is: what a wrong geometry looks like is a row running off the right edge.
 const SCREEN_COLUMNS: int = 20
 
+## `maps/CherrygroveMart.asm`, the one gated shelf: the clerk `checkevent
+## EVENT_GAVE_MYSTERY_EGG_TO_ELM` and opens MART_CHERRYGROVE or its _DEX, the
+## same list with POKE_BALL in front. That is the whole of when a POKE BALL goes
+## on sale, so it is walked rather than read. Group 26 map 4 in both pins.
+const CHERRYGROVE_GROUP: int = 26
+const CHERRYGROVE_MART: int = 4
+const CLERK_CELL: Vector2i = Vector2i(1, 3)
+const CLERK_FACE: Vector2i = Vector2i(2, 3)
+const EVENT_GAVE_MYSTERY_EGG_TO_ELM: int = 31
+const POKE_BALL: int = 5
+const STEP_CAP: int = 32
+
 
 func run(r: RefCounted) -> void:
 	_r = r
-	for game_id: StringName in _r.GAME_IDS:
-		var data: GameData = GameData.open(game_id)
-		if data == null:
-			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
-			continue
-		_r.game_id = game_id
-		_verify_texts(data)
-		_verify_markers(data)
-		_verify_lists(data)
-	_r.game_id = &""
+	_r.each_game(func() -> void:
+		_verify_texts(_r.data)
+		_verify_markers(_r.data)
+		_verify_lists(_r.data)
+		_verify_poke_ball_gate()
+	)
 
 
 func _verify_texts(data: GameData) -> void:
@@ -167,3 +175,63 @@ func _marts(data: GameData) -> Array:
 		if not mart.is_empty():
 			out.append(mart)
 	return out
+
+
+## Off the running script rather than the table: a wrong mart id, a wrong
+## `checkevent` or an unresolved `iftrue` all look like one shelf both ways.
+func _verify_poke_ball_gate() -> void:
+	var before: Array = _clerk_shelf(false)
+	var after: Array = _clerk_shelf(true)
+	_r.check(
+		not before.has(POKE_BALL) and not before.is_empty(),
+		"the clerk sells %s before the egg is delivered" % [before]
+	)
+	_r.check(
+		after.has(POKE_BALL),
+		"the clerk sells %s after the egg is delivered" % [after]
+	)
+	_r.check(
+		after.size() == before.size() + 1 and after.slice(1) == before,
+		"the two shelves are %s and %s, which is not one POKE BALL apart" % [
+			before, after,
+		]
+	)
+	_r.note("Cherrygrove sells %d items, %d once the egg is delivered" % [
+		before.size(), after.size(),
+	])
+
+
+func _clerk_shelf(delivered: bool) -> Array:
+	var state := Gen2WorldState.new()
+	if delivered:
+		state.set_event_flag(EVENT_GAVE_MYSTERY_EGG_TO_ELM, true)
+	var world: Gen2WorldAPI = _r.open_world(
+		CHERRYGROVE_GROUP, CHERRYGROVE_MART, CLERK_FACE, state
+	)
+	if world == null:
+		return []
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	world.interact()
+	for _step: int in STEP_CAP:
+		var request: Dictionary = world.pending_runtime_request()
+		if StringName(request.get("kind", &"")) == &"mart_requested":
+			var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(world, request)
+			var mart: Dictionary = (resolved.get("data", {}) as Dictionary).get("mart", {})
+			var items: Array = []
+			for entry: Dictionary in Gen2WorldMartHost.entries(world.data, mart):
+				items.append(int(entry["item"]))
+			return items
+		if not request.is_empty():
+			world.complete_runtime_request({"ok": true})
+			continue
+		if not world.pending_script_wait().is_empty():
+			world.advance_script_presentation_frame()
+			continue
+		if world.script_input_waiting():
+			world.choose_script_input(0)
+			continue
+		break
+	_r.fail("the Cherrygrove clerk staged no shop with the egg %s" % [
+		"delivered" if delivered else "still in hand",
+	])
+	return []

--- a/tools/checks/slots.gd
+++ b/tools/checks/slots.gd
@@ -89,8 +89,7 @@ func _verify_tables() -> void:
 	)
 
 
-## The cache against a second reading of the dump, which is what says the walk
-## found the records rather than three runs that happen to decompress.
+## The cache against a second reading of the dump: the walk found the records.
 func _verify_section(game_id: StringName, data: GameData) -> void:
 	var rom: RomFile = RomFile.open_verified("res://roms/%s.gbc" % game_id)
 	if not _r.check(rom != null, "%s: roms/%s.gbc is unreadable." % [game_id, game_id]):

--- a/tools/checks/unown_puzzle.gd
+++ b/tools/checks/unown_puzzle.gd
@@ -101,8 +101,7 @@ func run(r: RefCounted) -> void:
 	_verify_rules()
 
 
-## The cache against a second reading of the dump, which is what says the walk
-## found the records rather than seven runs that happen to decompress.
+## The cache against a second reading of the dump: the walk found the records.
 func _verify_section(game_id: StringName, data: GameData) -> void:
 	var rom: RomFile = RomFile.open_verified("res://roms/%s.gbc" % game_id)
 	if not _r.check(rom != null, "%s: roms/%s.gbc is unreadable." % [game_id, game_id]):

--- a/tools/checks/whirlpool.gd
+++ b/tools/checks/whirlpool.gd
@@ -12,7 +12,6 @@ var _r: RefCounted = null
 ## because its whirlpool is the one a Crystal playthrough meets.
 
 
-## constants/map_constants.asm, DUNGEONS group; Crystal's sit eight later.
 const DEN_GROUP: int = 3
 const DEN_NUMBER_CRYSTAL: int = 81
 const DEN_NUMBER_GOLD_SILVER: int = 73

--- a/tools/checks/whirlpool.gd
+++ b/tools/checks/whirlpool.gd
@@ -12,8 +12,7 @@ var _r: RefCounted = null
 ## because its whirlpool is the one a Crystal playthrough meets.
 
 
-## constants/map_constants.asm, DUNGEONS group. Crystal's extra maps push
-## Dragon's Den B1F eight places later within the same group.
+## constants/map_constants.asm, DUNGEONS group; Crystal's sit eight later.
 const DEN_GROUP: int = 3
 const DEN_NUMBER_CRYSTAL: int = 81
 const DEN_NUMBER_GOLD_SILVER: int = 73

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -20,6 +20,7 @@ const KIND_HELP: Dictionary = {
 	&"cut": "cell: OWCutAnimation's two halves and the jump shadow",
 	&"tile_anim": "frames: the map that many AnimateTileset frames in",
 	&"unown_wall": "cell: DisplayUnownWords' box. Group 3 maps 23 to 26 say HO-OH, ESCAPE, WATER, LIGHT",
+	&"mart_top": "cell in front of the counter: MartWelcomeText and MenuHeader_BuySell over the map",
 	&"mart": "cell in front of the counter: BuyMenu",
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
@@ -123,10 +124,9 @@ const POKEPIC_SPECIES: int = 152
 ## every `preview_*` on it is reachable from here rather than from nothing.
 const SCREEN_DRIVER: String = "preview_%s"
 
-## The clerk's own text box, which is the one press between `pokemart` and the
-## welcome the buy screen opens on. One more reaches the list, two the quantity
-## dial and three the yes/no.
-const MART_PRESSES: int = 1
+## `.HowMayIHelpYou` prints without waiting, so `pokemart` opens straight on the
+## BUY/SELL/QUIT menu and one press reaches the list.
+const MART_PRESSES: int = 0
 ## Frames spent between two presses of a driven menu, so the box a press opened
 ## owes nothing before the next one lands: nothing shortens a printing text.
 const TEXT_SETTLE_FRAMES: int = 20
@@ -343,6 +343,7 @@ const STAGERS: Dictionary = {
 	&"move_tutor": &"_stage_party_routine",
 	&"battle_tower": &"_stage_battle_tower",
 	&"yes_no": &"_stage_yes_no",
+	&"mart_top": &"_stage_mart",
 	&"mart": &"_stage_mart",
 	&"mart_sell": &"_stage_mart",
 	&"elevator": &"_stage_elevator",
@@ -649,9 +650,8 @@ func _stage_yes_no() -> void:
 			_screen.advance_frame()
 
 
-## The clerk behind the counter, talked to from the cell in front of him: his
-## `pokemart` is what opens `BuyMenu`, so the shop is reached the way a player reaches
-## it. The presses are the dialog's own, the welcome box first and then the list.
+## The clerk behind the counter, talked to from the cell in front of him, so the
+## shop is reached the way a player reaches it.
 func _stage_mart() -> void:
 	_screen.press_button(Gen2Button.LEFT)
 	_screen.interact()
@@ -659,6 +659,8 @@ func _stage_mart() -> void:
 		_screen.press_button(Gen2Button.A)
 	## `StandardMart`'s BUY/SELL/QUIT loop is what the welcome box hands
 	## the shop to. `mart` takes its BUY row, `mart_sell` the one below.
+	if _kind == &"mart_top":
+		return
 	if _kind == &"mart_sell":
 		_screen.press_button(Gen2Button.DOWN)
 	_screen.press_button(Gen2Button.A)


### PR DESCRIPTION
Three reported things, one commit.

## The shop opened on top of itself

`MartDialog` runs before `BuyMenu`, not inside it. `.HowMayIHelpYou` prints `MartWelcomeText` with `PrintText` and returns without waiting for a press, so `MenuHeader_BuySell` opens over that box while the map is still behind both. `BuyMenu` blanks the screen only once `.Buy` is taken. The port drew the buy list under every one of those boxes, which is the overlap that was reported, and spent a press on a box that never waits for one. `CopyMenuHeader` reloads the header's `db 1` too, so the menu opens on BUY rather than on the row it was left on.

`tools/preview_world.gd`'s new `mart_top` kind photographs the first of those two screens; `mart` still photographs the second, and now needs one press fewer to reach it.

## Walking felt like a jolt

It was accurate, and that is the problem. `HandleMapObjects` moves the map two pixels once per two hardware frames, which a Game Boy's own panel smeared and a modern one draws as eight discrete jolts a step.

**SMOOTH SCROLL** (Settings > Application > Scrolling, on by default) draws the frame between two passes half a pass on. The map moves a pixel a frame, stands on the cartridge's own pixel at every pass boundary, takes the same sixteen frames and lands on the same cell. Nothing the engine decides reads it.

One helper answers the in-flight step for the player and for every map object, so no sprite slides against the map it is standing on, and the camera rounds to whole pixels the way its own doc always claimed it did.

### The stutter under it

The first pass of this made the smoothing visible and the real defect with it: some drawn frames moved two pixels, some one, some none. `FrameClock.tick` answers a whole number of hardware frames and banks the rest, and the picture was placed from that count alone. A host frame is 16.667 ms and a hardware one 16.742, so a `_process` tick spends sometimes no frame and sometimes two, and the count jumps by 0 or 2 with nothing in the game behind the difference. It was there before the smoothing too, as 0, 2 and 4.

`pass_fraction` is now the whole frames spent inside the pass plus the part of the next one the clock is holding, set once per drawn frame rather than once per spent one. The picture then stands within half a pixel of the clock however the host's frames land.

The case feeds the pump host frames of 17.0, 17.0, 9.0 and 24.5 ms, which spend one hardware frame, one, none and two:

| Placed from | Drawn pixels |
|---|---|
| the frame count | 1, 2, 2, 4 |
| the clock | 1, 2, 3, 4 |

### And the pacing under that

That still stuttered on a real machine, so the next pass measured one instead of reasoning about it. The panel is 120 Hz and `DisplayServer.screen_get_refresh_rate()` answers 60, which is why none of this was visible. `delta` cannot witness it either: delta smoothing snaps what `_process` is told, so an unevenly presented frame still reports 16.667 ms. Raw frame starts do:

| Frame rate | Raw frame starts | Walk, one row per drawn frame |
|---|---|---|
| 60 | 15.6 to 17.8 ms, 160 of 400 on 16.7 | 1 px, with a 0 px every 3.7 s |
| Display | 8.33 ms, one per refresh | 1 px every second frame |

`Engine.max_fps` is a sleep and not a vblank. A cap below the panel's own rate leaves each frame on screen for one refresh, then three, then two: the game underneath is even and the picture is not, which is the 0, 1 and 2 pixels the screen recording caught. **FRAME RATE now defaults to the display's own rate**, and the caps stay for battery. A file written at format 1 carrying the old 60 moves with the default; a rate the player picked stays where they put it.

The other half is the clock. A hardware frame is 16.742 ms and a host frame is the panel's, so a count taken off measured time slips a whole frame every 3.7 seconds against the frames the player is shown. `FrameClock` now counts the host's own frames once it has seen twelve at one length that divide a hardware frame: one per host frame at 60 Hz, one every second at 120, one every fourth at 240. 144 Hz divides neither and is measured, and so is a host that hitches.

Both together, over 900 drawn frames of walking:

| Frame rate | Before | After |
|---|---|---|
| 60 | 899 px in 899 frames, 4 of them 0 px | 899 frames, every one 1 px |
| Display | slipping 0/1 | 900 frames, 448 ones and 451 zeros |

| Measurement | Before | After |
|---|---|---|
| Presses between the counter and BUY/SELL/QUIT | 1 | 0 |
| Pictures drawn over one walk step | 8 | 16 |
| Camera positions per step | 8 | 16 |

Measured on a recorded clip at a fixed 60 fps: every frame of a walk differs from the one before it, where the hardware pacing repeats each frame once.

### And the dropped frame under that

Still stuttering, and the readout said where: `119 fps   hw 59/s   worst 14.4 ms`. That is a host missing one present a second. The clock was handed a delta two frames long, read it as a new frame rate, threw the lock away and spent twelve more frames measuring time before it locked again. So one dropped frame cost thirteen, and at that rate the clock was unlocked most of the time. Feeding it 119 frames of 8.33 ms and one of 16.67 reproduces that readout exactly.

The clock now counts how many host frames a delta covered and spends them all. A missed present costs the frame it missed and nothing else. An odd delta no longer replaces the estimate the next one is judged against either; only three in a row do, which is a host that really has changed rate rather than a machine with something else running on it.

Walking New Bark Town east and west for 900 drawn frames on the 120 Hz panel, reading the drawn position once a frame. Two doubled steps is the floor, both of them the turnarounds:

| Clock | Doubled steps, six runs | Lock drops |
|---|---|---|
| Before | 2, 19, 9, 3, 2, 6 | 1, 25, 21, 2, 0, 0 |
| After | 6, 2, 2, 3, 2, 4 | 3, 1, 0, 3, 0, 1 |

Fully locked, the drawn cadence is exact: a strict 0/1 alternation for the whole walk. The pump itself was never the cost, which the same measurement settles. One drawn frame of the overworld spends 0.143 ms of GDScript on average and 0.020 ms of that is the map layer sync that smooth scroll added, against an 8.33 ms budget.

The readout gains `lock 1:2`, which says the clock is counting host frames rather than measuring time. No `lock` at all means either a panel that divides no hardware frame, 144 Hz being the common one, or a host too uneven to read.

### And the whole pixel under all of it

None of the above touches the thing you can see without a recording. The camera moved a whole hardware pixel at a time, sixty times a second, which is what the cartridge did. On a Game Boy Color one pixel is 0.3 mm. On a laptop panel it is twelve screen pixels and about 3 mm, and a twelve-pixel step at 60 Hz on a 120 Hz display is a row of stills rather than motion. Over 900 drawn frames of walking, 457 of them moved the picture not at all.

SMOOTH SCROLL now draws the buffer at a whole multiple of its own resolution, so the camera can sit on a screen pixel instead of a hardware one. Everything in the buffer keeps hardware-pixel coordinates: the viewport's canvas transform does the magnification the container used to, and a whole factor with nearest sampling draws the same picture. The map is a fragment shader that already floors per fragment, so a fractional origin costs it nothing; the renderer snaps the camera once so every quad and every sprite shift together and nothing crawls against anything else.

Walking New Bark Town on a 120 Hz panel at 2880x1864, screen pixels moved per drawn frame:

| Camera | Frames that moved nothing | The rest |
|---|---|---|
| Whole hardware pixels | 457 of 899 | 442 frames of 12 px |
| Six steps to a pixel | 15 of 899 | 884 frames of 6 px |

Six steps is free and twelve is not. The buffer costs its own fill rate, and drawing it at the window's full resolution fell to 103 fps with the lock collapsing, where six holds 120 fps locked on every frame and a worst frame of 10.8 ms. The step has to divide the magnification, since the container shrinks by a whole number.

The picture itself does not change. A capture of the map and a capture of a text box over it are both byte-identical to the same captures without this, because a camera on a whole pixel snaps to itself. That is also what keeps the screenshot and frame-diff path intact.

### And the frozen frame under all of that

None of the three passes above was the reported defect. Walking froze one drawn frame and doubled the next, every cell, on every frame rate, and with SMOOTH SCROLL either way. It was measured off a screen recording, against that recording's own timestamps so the capture's dropped frames normalise out: a steady 600 screen pixels a second, with 24 intervals of 0 and 24 of 1200, each 0 immediately followed by a 1200, sixteen recorded frames apart. Sixteen frames is one walk step.

The poll that starts a step runs before the pass advance, so on the pass a step lands it still saw a step in flight and refused. A queued step is taken right there by `_start_next_player_step` and a held one was not, so the walk had nothing left to interpolate for the rest of that pass:

```
remaining 1  fraction 0.500  behind 0.0625   15 px
remaining 0  fraction 0.000  behind 0.0000   16 px
remaining 0  fraction 0.500  behind 0.0000   16 px   frozen
remaining 7  fraction 0.000  behind 0.8750   18 px   doubled
```

The held direction is now polled again on the pass a step lands, after that step's own events have run, which is what a queued step already got. Neither the speed nor the pass count changes: a step is still sixteen pixels over eight passes.

The camera per hardware frame with a direction held, New Bark Town:

| | Frames of 0 px | of 1 px | of 2 px |
|---|---|---|---|
| Before | 6 | 84 | 6 |
| After | 0 | 96 | 0 |

Two hundred and forty frames of the same walk run 151 consecutive frames of one pixel and then stop at the map edge.

## Poke Balls

Already right, and now checked. Nothing in the engine gates a Poke Ball: the Cherrygrove clerk `checkevent EVENT_GAVE_MYSTERY_EGG_TO_ELM` and opens `MART_CHERRYGROVE` or `MART_CHERRYGROVE_DEX`, which is the same four items with POKE BALL in front. `tools/checks/mart.gd` now walks that clerk with the flag both ways on all three cartridges and holds the two shelves one POKE BALL apart. The topic runs through `each_game` like every other one, which it was not doing.

## Green

| Check | Result |
|---|---|
| Full GUT tier | 4053 tests, 0 failures |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | 16 badges, ok on gold, silver and crystal |
| Warning scan | 0 warnings in 600 scripts |
| Comment lines under `game`, `tools`, `autoload` | 37878, on the ceiling |





