### PR TITLE
Write the application block in the editor's own order

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -13,9 +13,9 @@ config_version=5
 config/name="pokerecomp"
 config/version="0.1.11"
 run/main_scene="res://game/main/main.tscn"
+config/quit_on_go_back=false
 config/features=PackedStringArray("4.8", "GL Compatibility")
 config/icon="res://app_icon.png"
-config/quit_on_go_back=false
 
 [autoload]
 


### PR DESCRIPTION
The editor rewrites `project.godot` whenever the project is opened, and it writes `config/quit_on_go_back` where it registers it rather than where the file had it.

Nothing but the line order differs: `diff <(git show HEAD:project.godot | sort) <(sort project.godot)` is empty. Leaving it uncommitted put the same diff back in the working tree after every session.