### PR TITLE
A battle picture, Update all, two mod seams, and your own cartridge art

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ A cache is never migrated. An update that changes its format discards the old
 one, and the launcher's manage sheet says so: import the same dump again. Saves
 live under their own root and are not touched.
 
+The same sheet, behind the three dots above the shelf, also swaps a cartridge's
+picture for one of your own: any PNG, WebP or JPEG, scaled to fit the shell
+whatever shape it is, with a way back to the shipped art. It is kept under
+`user://` beside the saves, so an update does not ask for it again.
+
 | Data | Contents |
 |---|---|
 | Species | Names, base stats, types, held items, egg groups, TM/HM flags |

--- a/autoload/input_runtime.gd
+++ b/autoload/input_runtime.gd
@@ -144,7 +144,6 @@ func device() -> StringName:
 	return _device
 
 
-## Whether the on-screen controller should be drawn right now.
 func touch_controls_shown() -> bool:
 	return _touch_shown
 

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -33,7 +33,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version. Strict `major.minor.patch` |
-| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 25 and a host accepts 1 to 25. [Contract versions](#contract-versions) says what each added |
+| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 26 and a host accepts 1 to 26. [Contract versions](#contract-versions) says what each added |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -127,6 +127,7 @@ runs, since every version so far has only added.
 | 23 | `Gen2WorldAPI.unown_wall_event()` and `always_on_bike()`, and `Gen2WorldFieldMove`'s field-move texts |
 | 24 | `Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span()` |
 | 25 | `Gen2WorldAPI.party_with_player()` and `party_holder()`, and a visible encounter walking to the next cell |
+| 26 | A run button, and a scale on every experience award |
 
 ## Installing
 
@@ -972,6 +973,53 @@ The opponent is not pretended to have fainted. Everything is spent between the
 Gotcha line and the nickname prompt.
 
 The catching tutorial and a Bug Contest catch are excluded.
+
+## Running
+
+`register_run_button(id, provider)` walks the player at bike speed while B is
+held. The cartridge has no such branch, so this adds one:
+
+```gdscript
+class Shoes:
+	func runs_while_held() -> bool:
+		return enabled
+```
+
+The provider is the switch and nothing else. Whether B is down, and whether
+running is allowed where the player is standing, are the host's: only a step in
+`MOVEMENT_WALK` moves, since the bike is already fast and surf and every scripted
+stream carry their own duration. It is read on the step rather than once, so a
+setting turned off mid-run is off from the next one.
+
+A step is still one step. Encounter counts, Repel steps, the bike-step counter
+and every tile event stay per step rather than per frame, a follower takes the
+duration the player's step actually took, and an input recording carries the run
+state beside the held direction so a replay reproduces the run.
+
+## Scaling experience
+
+`register_experience_scale(manifest, provider)` multiplies every experience
+award. 1.0 is none:
+
+```gdscript
+class Curve:
+	func experience_scale() -> float:
+		return 2.0
+```
+
+Registered with the manifest `register()` was handed, because the run is what the
+scale belongs to. Two providers compose by MULTIPLICATION, which is the join a
+scale has, and the product is held between `Gen2ModHost.MIN_EXPERIENCE_SCALE` and
+`MAX_EXPERIENCE_SCALE`. A negative, a NAN or an infinity is a provider answering
+nothing rather than a number and is dropped.
+
+The one seam is the award `Gen2Experience.award_for` returns, so the participant
+split, the Exp. Share halving, the level-up loop, the move offers and evolution
+eligibility are all downstream of it, and a skipped fight and a capture scale with
+the rest. Three things it does not do: stat experience is the cartridge's own EV
+gain and is not scaled; the product truncates the way every division in
+`Gen2Experience` does, with a non-zero award floored at 1 so a 0.5x run still
+levels; and the result is clamped to `Gen2Experience.MAX_EXP`.
 
 ## Annotating the battle
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2257,14 +2257,24 @@ func _award_share(
 	var block: Dictionary = Gen2Experience.shared_block(
 		defeated.base_stat_exp_shape(), defeated.base_exp(), halved, recipients.size()
 	)
-	var award: int = Gen2Experience.award_for(
+	var award: int = _scaled_award(Gen2Experience.award_for(
 		defeated.level, int(block["base_exp"]), is_trainer_battle
-	)
+	))
 	var stat_gains: Dictionary = block["stats"]
 	for index: int in recipients:
 		var learner: Gen2BattleMon = party(PLAYER).at(int(index))
 		if learner != null and not learner.is_fainted():
 			_give_experience_to(learner, int(index), award, stat_gains, by_exp_share, events)
+
+
+## The one place a registered experience scale is applied, so everything a player
+## means by 2x is downstream. It truncates the way `Gen2Experience` does, with a
+## non-zero award floored at 1 or a 0.5x run would never level at all.
+func _scaled_award(award: int) -> int:
+	var scale: float = Gen2ModHost.experience_scale()
+	if is_equal_approx(scale, 1.0) or award <= 0:
+		return award
+	return clampi(maxi(int(float(award) * scale), 1), 0, Gen2Experience.MAX_EXP)
 
 
 ## What a won battle owes when nothing simulated the turns that won it: every

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -142,12 +142,10 @@ func enemy_turn() -> bool:
 	return _enemy_turn
 
 
-## The imported tables the callbacks resolve their sine and framesets through.
 func data() -> Gen2BattleAnimData:
 	return _data
 
 
-## Which cartridge this animation came from, which only the bg effect table asks.
 func profile() -> StringName:
 	return _data.profile()
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1363,8 +1363,6 @@ func _init_battle_display() -> void:
 	Gen2BattleScreenMap.clear_intro_box(_bg_map)
 	_intro_message = ""
 	_entrance_stages = []
-	_slides = []
-	_slid_pixels = {Gen2Battle.PLAYER: 0.0, Gen2Battle.ENEMY: 0.0}
 	_frontpic = null
 	_bg_vbank1 = PackedByteArray()
 	_hud_balls = []
@@ -2278,6 +2276,9 @@ func _audio_assets() -> Dictionary:
 func _reseed_bg_map() -> void:
 	_bg_map = Gen2BattleScreenMap.seeded()
 	_faints.clear()
+	## A slide still owed walks the picture this put back off its own square.
+	_slides.clear()
+	_slid_pixels = {Gen2Battle.PLAYER: 0.0, Gen2Battle.ENEMY: 0.0}
 
 
 ## How full the exp bar is, in `PlaceExpBar`'s own pixels. The committed value:
@@ -3593,10 +3594,6 @@ func _confirm_forget_slot() -> void:
 func advance() -> void:
 	if _box == null:
 		return
-	## `BattleIntroSlidingPics` is a run of unconditional `DelayFrame`s with
-	## nothing reading a button, so a press during the slide does nothing at all.
-	if _intro != null:
-		return
 	## The exp bar stopped at a level boundary is under `.LoopLevels`' own
 	## `StdBattleTextbox`, which blocks on a button: this press is that button,
 	## and it lets the loop run on into the next level's fill rather than
@@ -3609,14 +3606,9 @@ func advance() -> void:
 		## releases, the same as the first one.
 		_play_anim_sound(SFX_EXP_BAR)
 		return
-	## A bar the source is still animating has not printed its message yet, so
-	## there is nothing for a press to advance past. Without this the press
-	## would pop the next event and the held line would never be shown.
-	if bars_animating() or fainting():
-		return
-	## An animation is a run of unconditional delays, the way the intro is, so a
-	## press during one reaches nothing.
-	if animation_running():
+	## `BattleIntroSlidingPics`, `SlideBattlePicOut` and every other run of frames
+	## this screen counts is delays with nothing reading a button.
+	if frames_running():
 		return
 	if _box.advance():
 		return

--- a/game/data/content_overlay.gd
+++ b/game/data/content_overlay.gd
@@ -297,7 +297,6 @@ func type_is_physical(number: int) -> bool:
 	return number < RomLayout.SPECIAL_TYPES_START
 
 
-## Which mod claimed [param number], for a launcher listing what it will change.
 func owner_of(kind: StringName, number: int) -> StringName:
 	return StringName((_owners.get(kind, {}) as Dictionary).get(number, &""))
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -564,14 +564,12 @@ func world_standard_script(index: int) -> Dictionary:
 	return entry
 
 
-## Raw bounded text bytes indexed by the cartridge's bank and CPU address.
 func world_text(bank: int, address: int) -> PackedByteArray:
 	return _payload_bytes(
 		_text().get(Gen2WorldScript.pointer_key(bank, address), []), _blob("text")
 	)
 
 
-## Raw bounded movement bytes indexed by the script bank and movement pointer.
 func world_movement(bank: int, address: int) -> PackedByteArray:
 	return _payload_bytes(
 		_movements().get(Gen2WorldScript.pointer_key(bank, address), []), _blob("movements")

--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -119,7 +119,6 @@ func _build() -> void:
 	invitation.add_child(_bay_label)
 
 	_art = TextureRect.new()
-	_art.texture = ART.get(game_id, null)
 	_art.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
 	_art.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
 	_art.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -127,7 +126,17 @@ func _build() -> void:
 	_art.material = _side_fade
 	add_child(_art)
 
+	refresh_art()
 	set_imported(false)
+
+
+## The player's own picture, or the shipped shell. The stretch mode above is what
+## contains a picture of any shape inside the shell's box.
+func refresh_art() -> void:
+	if _art == null:
+		return
+	var custom: Texture2D = Gen2CartridgeArt.texture_for(game_id)
+	_art.texture = custom if custom != null else ART.get(game_id, null)
 
 
 ## Hides the download icon and the cartridge's name inside an empty bay, leaving

--- a/game/launcher/cartridge_art.gd
+++ b/game/launcher/cartridge_art.gd
@@ -1,0 +1,151 @@
+class_name Gen2CartridgeArt
+extends RefCounted
+
+## A picture the player put on a cartridge in place of the shipped shell. Under
+## `user://`, beside the saves and for their reason: an update never touches it.
+## What is stored is never the chosen file: it is decoded, measured, shrunk and
+## written back out as a PNG this project encoded.
+
+const ROOT: String = "user://cartridge_art"
+
+## Refused before it is decoded, or read into memory at all.
+const MAX_SOURCE_BYTES: int = 12 * 1024 * 1024
+## Refused rather than shrunk: past this it is a panorama or a decompression bomb.
+const MAX_SOURCE_PIXELS: int = 64 * 1024 * 1024
+## The shipped shells are 1058 by 1201: larger is scaled down once, here, rather
+## than by the renderer on every frame of the carousel.
+const STORED_SIDE: int = 1201
+
+## The extension is the chooser's guess at their own file; these are the file.
+const SIGNATURES: Array = [
+	[[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], &"png"],
+	[[0x52, 0x49, 0x46, 0x46], &"webp"],
+	[[0xFF, 0xD8, 0xFF], &"jpg"],
+]
+
+## Keyed by content, as [Gen2ModArt]'s is: the shelf rebuilds on any change.
+static var _textures: Dictionary = {}
+
+
+static func path_for(game_id: StringName, directory: String = ROOT) -> String:
+	return "%s/%s.png" % [directory, game_id]
+
+
+static func has_custom_art(game_id: StringName, directory: String = ROOT) -> bool:
+	return FileAccess.file_exists(path_for(game_id, directory))
+
+
+## Null when there is none, and when a stored file will not decode: that costs
+## the shipped shell rather than an empty bay.
+static func texture_for(game_id: StringName, directory: String = ROOT) -> Texture2D:
+	var path: String = path_for(game_id, directory)
+	if not FileAccess.file_exists(path):
+		return null
+	var bytes: PackedByteArray = FileAccess.get_file_as_bytes(path)
+	var key: String = _digest(bytes)
+	if _textures.has(key):
+		return _textures[key]
+	var image: Image = _decoded(bytes)
+	if image == null:
+		return null
+	var texture: Texture2D = ImageTexture.create_from_image(image)
+	_textures[key] = texture
+	return texture
+
+
+## Answers `{ok}` or `{ok, reason}` the way an install does.
+static func adopt(
+	game_id: StringName, source: String, directory: String = ROOT
+) -> Dictionary:
+	if String(game_id).is_empty():
+		return {"ok": false, "reason": &"unknown_cartridge"}
+	if not FileAccess.file_exists(source):
+		return {"ok": false, "reason": &"missing_file"}
+	var file: FileAccess = FileAccess.open(source, FileAccess.READ)
+	if file == null:
+		return {"ok": false, "reason": &"unreadable_file"}
+	# Measured before it is read: a file past the ceiling never reaches memory.
+	var size: int = file.get_length()
+	if size > MAX_SOURCE_BYTES:
+		return {"ok": false, "reason": &"file_too_large"}
+	var bytes: PackedByteArray = file.get_buffer(size)
+	var image: Image = _decoded(bytes)
+	if image == null:
+		return {"ok": false, "reason": &"not_an_image"}
+	if image.get_width() * image.get_height() > MAX_SOURCE_PIXELS:
+		return {"ok": false, "reason": &"image_too_large"}
+	return _store(game_id, _fitted(image), directory)
+
+
+## Answers whether there was anything to remove.
+static func revert(game_id: StringName, directory: String = ROOT) -> bool:
+	var path: String = path_for(game_id, directory)
+	if not FileAccess.file_exists(path):
+		return false
+	return DirAccess.remove_absolute(path) == OK
+
+
+## The reasons above as sentences, so every caller refuses in the same words.
+static func refusal_text(reason: StringName) -> String:
+	match reason:
+		&"missing_file", &"unreadable_file":
+			return "That file could not be read."
+		&"file_too_large":
+			return "Cartridge art has to be under %d MB." % (MAX_SOURCE_BYTES / 1024 / 1024)
+		&"not_an_image":
+			return "That is not a PNG, WebP or JPEG image."
+		&"image_too_large":
+			return "That image has too many pixels to be a cartridge label."
+		&"unknown_cartridge":
+			return "No cartridge was chosen."
+	return "That picture could not be used."
+
+
+## Scaled to fit the shell's box, never up: a 32x32 sprite stays 32x32.
+static func _fitted(image: Image) -> Image:
+	var side: int = maxi(image.get_width(), image.get_height())
+	if side <= STORED_SIDE or side <= 0:
+		return image
+	var ratio: float = float(STORED_SIDE) / float(side)
+	image.resize(
+		maxi(1, int(image.get_width() * ratio)), maxi(1, int(image.get_height() * ratio)),
+		Image.INTERPOLATE_LANCZOS
+	)
+	return image
+
+
+static func _store(game_id: StringName, image: Image, directory: String) -> Dictionary:
+	if DirAccess.make_dir_recursive_absolute(directory) != OK \
+			and not DirAccess.dir_exists_absolute(directory):
+		return {"ok": false, "reason": &"unwritable_directory"}
+	image.convert(Image.FORMAT_RGBA8)
+	if image.save_png(path_for(game_id, directory)) != OK:
+		return {"ok": false, "reason": &"unwritable_directory"}
+	return {"ok": true, "id": game_id}
+
+
+static func _decoded(bytes: PackedByteArray) -> Image:
+	if bytes.is_empty() or bytes.size() > MAX_SOURCE_BYTES:
+		return null
+	var image := Image.new()
+	var loaded: int = FAILED
+	for row: Array in SIGNATURES:
+		var magic := PackedByteArray(row[0] as Array)
+		if bytes.slice(0, magic.size()) != magic:
+			continue
+		match StringName(row[1]):
+			&"png":
+				loaded = image.load_png_from_buffer(bytes)
+			&"webp":
+				loaded = image.load_webp_from_buffer(bytes)
+			&"jpg":
+				loaded = image.load_jpg_from_buffer(bytes)
+		break
+	return null if loaded != OK or image.is_empty() else image
+
+
+static func _digest(bytes: PackedByteArray) -> String:
+	var context := HashingContext.new()
+	context.start(HashingContext.HASH_SHA256)
+	context.update(bytes)
+	return context.finish().hex_encode()

--- a/game/launcher/cartridge_art.gd.uid
+++ b/game/launcher/cartridge_art.gd.uid
@@ -1,0 +1,1 @@
+uid://bwhsq62dqtu4i

--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -359,6 +359,5 @@ func _place_all() -> void:
 	layout_changed.emit()
 
 
-## Where cartridge [param index] sits relative to the middle, in slots.
 func _slot(index: int) -> float:
 	return _shortest(float(index) - _scroll)

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -140,7 +140,6 @@ func other_mode() -> StringName:
 	return LIGHT if is_dark() else DARK
 
 
-## The colour the stage is lit in while [param game_id] is selected.
 func tint_for(game_id: StringName) -> Color:
 	return GAME_TINTS.get(game_id, accent)
 

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -44,6 +44,9 @@ var _read_once: Dictionary = {}
 ## count either way.
 var _reading_quietly: bool = false
 var _check_updates_button: Gen2LauncherButton = null
+## Update all is a queue: the page's one request is serialised behind `_busy`.
+var _update_queue: Array = []
+var _updated: int = 0
 var _install_button: Gen2LauncherButton = null
 ## Its own request, because the page's other one is serialised behind `_busy`
 ## and an icon must never make a player wait for a download or a feed.
@@ -105,9 +108,9 @@ func _build() -> void:
 	_check_updates_button = Gen2LauncherButton.icon_only(
 		_theme, &"refresh_square", Gen2LauncherButton.Variant.NEUTRAL, 42.0
 	)
-	_check_updates_button.tooltip_text = "Check all followed sources for mod updates"
-	_check_updates_button.pressed.connect(check_for_updates)
+	_check_updates_button.pressed.connect(_on_update_button)
 	actions.add_child(_check_updates_button)
+	_sync_update_button()
 	_install_button = Gen2LauncherButton.create(
 		_theme, "Install", Gen2LauncherButton.Variant.PRIMARY, &"plus"
 	)
@@ -165,7 +168,9 @@ func _may_fetch_unprompted() -> bool:
 ## project's own index, and without this it would list nothing until the player
 ## thought to press Check for updates.
 func _read_unread_sources() -> void:
-	if _busy or not _check_queue.is_empty() or not _may_fetch_unprompted():
+	if _busy or not _check_queue.is_empty() or not _update_queue.is_empty():
+		return
+	if not _may_fetch_unprompted():
 		return
 	for source: Dictionary in Gen2ModIndex.followed():
 		var feed: String = String(source["feed"])
@@ -175,7 +180,7 @@ func _read_unread_sources() -> void:
 	if _check_queue.is_empty():
 		return
 	_reading_quietly = true
-	_check_updates_button.set_disabled_state(true)
+	_sync_update_button()
 	_check_next_source()
 
 
@@ -189,6 +194,7 @@ func _relist() -> void:
 	)
 	var failures: Array = host.failures()
 	_note.text = "Loaded from %s" % Gen2ModHost.ROOT
+	_sync_update_button()
 
 	if groups.is_empty() and failures.is_empty():
 		_list.add_child(_empty_state())
@@ -425,25 +431,22 @@ func fetch_feed(feed: String) -> void:
 	_fetch_feed(feed)
 
 
-## Reads every followed source one at a time. This only updates cached index
-## metadata: an archive is downloaded exclusively by the separate download
-## button on a mod row after an update is shown.
+## Reads every followed source one at a time, and downloads nothing.
 func check_for_updates() -> void:
-	if _busy or not _check_queue.is_empty():
+	if _busy or not _check_queue.is_empty() or not _update_queue.is_empty():
 		return
 	# Never empty: every build follows this project's own index.
 	for source: Dictionary in Gen2ModIndex.followed():
 		_read_once[String(source["feed"])] = true
 		_check_queue.append(String(source["feed"]))
 	_reading_quietly = false
-	_check_updates_button.set_disabled_state(true)
+	_sync_update_button()
 	_status("Checking mod sources for updates...", _theme.muted)
 	_check_next_source()
 
 
 func _check_next_source() -> void:
 	if _check_queue.is_empty():
-		_check_updates_button.set_disabled_state(false)
 		var quietly: bool = _reading_quietly
 		_reading_quietly = false
 		refresh()
@@ -462,14 +465,73 @@ func _check_next_source() -> void:
 
 
 func available_update_count() -> int:
-	var count: int = 0
+	return update_rows().size()
+
+
+## Every installed mod a source offers a newer version of, and nothing else.
+func update_rows() -> Array:
+	var out: Array = []
 	for group: Dictionary in Gen2ModCatalogue.groups(
 		Gen2ModHost.instance().manifests(), Gen2ModIndex.followed(), _listings
 	):
 		for row: Dictionary in group["rows"] as Array:
-			if StringName(row.get("update", &"")) == Gen2ModIndex.UPDATE_AVAILABLE:
-				count += 1
-	return count
+			if Gen2ModCatalogue.action_for(row) == &"update":
+				out.append(row)
+	return out
+
+
+## The header's one button is two actions: read the sources, or take the updates.
+func _on_update_button() -> void:
+	if available_update_count() > 0:
+		download_all()
+		return
+	check_for_updates()
+
+
+func download_all() -> void:
+	if _busy or not _check_queue.is_empty() or not _update_queue.is_empty():
+		return
+	_update_queue = update_rows()
+	if _update_queue.is_empty():
+		return
+	_updated = 0
+	_sync_update_button()
+	_download_next_update()
+
+
+func _download_next_update() -> void:
+	if _update_queue.is_empty():
+		var count: int = _updated
+		_updated = 0
+		_sync_update_button()
+		_status(
+			"Updated %d mod%s." % [count, "" if count == 1 else "s"] if count > 0
+				else "No mod update could be installed.",
+			_theme.accent if count > 0 else _theme.error,
+		)
+		return
+	download(_update_queue.pop_front() as Dictionary, func(ok: bool) -> void:
+		if ok:
+			_updated += 1
+		_download_next_update()
+	)
+
+
+## Which action the button offers, called wherever a queue or a listing moves.
+func _sync_update_button() -> void:
+	if _check_updates_button == null:
+		return
+	var updates: int = available_update_count()
+	var draining: bool = not _update_queue.is_empty()
+	_check_updates_button.set_disabled_state(
+		_busy or draining or not _check_queue.is_empty()
+	)
+	_check_updates_button.variant = Gen2LauncherButton.Variant.PRIMARY if updates > 0 \
+		else Gen2LauncherButton.Variant.NEUTRAL
+	_check_updates_button.set_glyph(&"download" if updates > 0 else &"refresh_square")
+	_check_updates_button.tooltip_text = "Download and install %d mod update%s" % [
+		updates, "" if updates == 1 else "s",
+	] if updates > 0 else "Check all followed sources for mod updates"
 
 
 func _fetch_feed(feed: String, finished: Callable = Callable()) -> void:
@@ -529,25 +591,37 @@ func _installed_versions() -> Dictionary:
 
 
 ## Downloads and installs one listed row, which is the same press for a mod that
-## is absent, out of date, or being reinstalled.
-func download(row: Dictionary) -> void:
+## is absent, out of date, or reinstalled. [param finished] takes whether it landed.
+func download(row: Dictionary, finished: Callable = Callable()) -> void:
 	if not Gen2ModIndex.is_downloadable(String(row.get("download", ""))):
 		_status("%s has no download in its source." % row.get("name", "That mod"), _theme.error)
+		_settled(finished, false)
 		return
 	_pending = row.duplicate(true)
 	_status("Downloading %s..." % row["name"], _theme.muted)
-	_request(String(row["download"]), func(
+	var started: bool = _request(String(row["download"]), func(
 		result: int, code: int, _headers: PackedStringArray, body: PackedByteArray
 	) -> void:
 		var pending: Dictionary = _pending
 		_pending = {}
 		if pending.is_empty():
+			_settled(finished, false)
 			return
 		if result != HTTPRequest.RESULT_SUCCESS or code != 200:
 			_status("%s could not be downloaded (HTTP %d)." % [pending["name"], code], _theme.error)
+			_settled(finished, false)
 			return
-		install_entry_bytes(pending, body)
+		_settled(finished, bool(install_entry_bytes(pending, body).get("ok", false)))
 	)
+	if not started:
+		_pending = {}
+		_settled(finished, false)
+
+
+## Deferred rather than nested: a batch of ten is otherwise ten frames of stack.
+func _settled(finished: Callable, ok: bool) -> void:
+	if finished.is_valid():
+		finished.call_deferred(ok)
 
 
 ## Installs a downloaded archive for [param row]. Separate from the request

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -22,6 +22,7 @@ var _title_backdrop: Gen2LauncherTitleBackdrop = null
 
 var _file_dialog: Gen2LauncherFilePicker = null
 var _mod_dialog: Gen2LauncherFilePicker = null
+var _art_dialog: Gen2LauncherFilePicker = null
 var _preview_browse_dir: String = ""
 var _update_http: HTTPRequest = null
 
@@ -30,6 +31,8 @@ var _selected_game_id: StringName = &""
 ## The game a re-import is replacing, so a cache is only overwritten by a dump
 ## of the cartridge it already holds.
 var _reimport_game_id: StringName = &""
+## The cartridge whose picture the open art dialog will replace.
+var _art_game_id: StringName = &""
 var _status: Dictionary = {"kind": &"info", "title": "", "detail": ""}
 
 
@@ -100,6 +103,12 @@ func _build_dialogs() -> void:
 
 	_mod_dialog = _picker("Choose a mod .zip", PackedStringArray(["*.zip; Mod archive"]))
 	_mod_dialog.file_selected.connect(func(path: String) -> void: import_mod_path(path))
+
+	_art_dialog = _picker(
+		"Choose cartridge art",
+		PackedStringArray(["*.png, *.webp, *.jpg, *.jpeg; Image"]),
+	)
+	_art_dialog.file_selected.connect(func(path: String) -> void: adopt_cartridge_art(path))
 
 	# Created once and reused. The check only ever runs from the button.
 	_update_http = HTTPRequest.new()
@@ -343,6 +352,26 @@ func _open_manage_sheet(game_id: StringName) -> void:
 		)
 		body.add_child(delete)
 
+	var art: Gen2LauncherButton = Gen2LauncherButton.create(
+		_palette, "Use your own art", Gen2LauncherButton.Variant.NEUTRAL, &"folder"
+	)
+	art.tooltip_text = "Replace this cartridge's picture with an image of your own"
+	art.pressed.connect(func() -> void:
+		_art_game_id = game_id
+		sheet.close()
+		_art_dialog.show_picker(Vector2i(920, 620))
+	)
+	body.add_child(art)
+	if Gen2CartridgeArt.has_custom_art(game_id):
+		var default_art: Gen2LauncherButton = Gen2LauncherButton.create(
+			_palette, "Use the default art", Gen2LauncherButton.Variant.NEUTRAL, &"refresh"
+		)
+		default_art.pressed.connect(func() -> void:
+			sheet.close()
+			revert_cartridge_art(game_id)
+		)
+		body.add_child(default_art)
+
 	var reimport: Gen2LauncherButton = Gen2LauncherButton.create(
 		_palette,
 		"Re-import" if state != RomCache.STATE_MISSING else "Import",
@@ -374,6 +403,45 @@ static func cache_state_text(state: StringName) -> String:
 		RomCache.STATE_INCOMPLETE:
 			return "The last import did not finish. Import the cartridge again."
 	return "No cache exists for this cartridge yet."
+
+
+## Public and separate from the dialog for the reason
+## [method Gen2ModsPage.install_entry_bytes] is: a test needs no OS file dialog.
+func adopt_cartridge_art(path: String) -> Dictionary:
+	var game_id: StringName = _art_game_id
+	_art_game_id = &""
+	var taken: Dictionary = Gen2CartridgeArt.adopt(game_id, path)
+	if not bool(taken.get("ok", false)):
+		_set_status(
+			&"error",
+			"That art was not used.",
+			Gen2CartridgeArt.refusal_text(StringName(taken.get("reason", &""))),
+		)
+		return taken
+	_refresh_cartridge_art(game_id)
+	_set_status(
+		&"success",
+		"%s is wearing your own art." % RomRegistry.title_for(game_id),
+		"Cartridge options has a way back to the default.",
+	)
+	return taken
+
+
+func revert_cartridge_art(game_id: StringName) -> void:
+	if not Gen2CartridgeArt.revert(game_id):
+		return
+	_refresh_cartridge_art(game_id)
+	_set_status(
+		&"info",
+		"%s is wearing its own art again." % RomRegistry.title_for(game_id),
+		"The picture you chose was removed.",
+	)
+
+
+func _refresh_cartridge_art(game_id: StringName) -> void:
+	var seated: Gen2Cartridge = _shelf.cartridge(game_id)
+	if seated != null:
+		seated.refresh_art()
 
 
 func _open_cache_folder(game_id: StringName) -> void:

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -149,6 +149,12 @@ const REPEL_PROVIDER_METHODS: Array[String] = ["repel_to_use"]
 const CATCH_EXPERIENCE_METHODS: Array[String] = ["awards_catch_experience"]
 const BATTLE_INFO_METHODS: Array[String] = ["annotate_battle"]
 const SHINY_ROLLS_METHODS: Array[String] = ["shiny_rolls"]
+const RUN_BUTTON_METHODS: Array[String] = ["runs_while_held"]
+const EXPERIENCE_SCALE_METHODS: Array[String] = ["experience_scale"]
+
+## A scale is a mod's number and the range is the host's, as with the rolls above.
+const MIN_EXPERIENCE_SCALE: float = 0.1
+const MAX_EXPERIENCE_SCALE: float = 10.0
 
 ## The most DV words the host will draw for one wild, whatever a provider asks
 ## for. A roll is cheap, but the count is a mod's number and the ceiling is the
@@ -250,6 +256,8 @@ var _repel_renewals: Dictionary = {}
 var _catch_experience: Dictionary = {}
 var _battle_info: Dictionary = {}
 var _shiny_rolls: Dictionary = {}
+var _run_buttons: Dictionary = {}
+var _experience_scales: Dictionary = {}
 var _battle_renderers: Dictionary = {}
 ## The one id the player's view is chosen by, read from [Gen2ModState] when the
 ## host is built and written back whenever it changes. It is a bare id and may
@@ -686,7 +694,6 @@ func visible_encounter_ids() -> Array:
 	return _visible_encounters.keys()
 
 
-## Every registered provider, in registration order.
 func visible_encounter_providers() -> Array:
 	return _visible_encounters.values()
 
@@ -806,6 +813,55 @@ static func awards_catch_experience() -> bool:
 		if bool(provider.call("awards_catch_experience")):
 			return true
 	return false
+
+
+## Registers a RUN BUTTON policy under [param id]: `runs_while_held()` is the
+## mod's switch and nothing else. Not save bound; see `docs/MODS.md`.
+func register_run_button(id: StringName, provider: Object) -> Dictionary:
+	return _register_provider(_run_buttons, RUN_BUTTON_METHODS, id, provider)
+
+
+func run_button_ids() -> Array:
+	return _run_buttons.keys()
+
+
+## A provider says so and B is down. Static and null-safe for the same reason
+## [method allows_item_field_move] is.
+static func run_button_held() -> bool:
+	if _instance == null or not Gen2Button.held(Gen2Button.B):
+		return false
+	for provider: Object in _instance._run_buttons.values():
+		if bool(provider.call("runs_while_held")):
+			return true
+	return false
+
+
+## Registers an EXPERIENCE SCALE policy for [param manifest]'s own run, save
+## bound for the reason [method register_catch_experience] is.
+func register_experience_scale(manifest: Gen2ModManifest, provider: Object) -> Dictionary:
+	if not _owns_manifest(manifest):
+		return {"ok": false, "reason": &"unknown_mod_save_owner"}
+	return _register_provider(
+		_experience_scales, EXPERIENCE_SCALE_METHODS, manifest.id, provider
+	)
+
+
+func experience_scale_ids() -> Array:
+	return _experience_scales.keys()
+
+
+## Every scale MULTIPLIED together, which is the join a scale has, and clamped. A
+## negative, a NAN or an infinity is not a number and is dropped.
+static func experience_scale() -> float:
+	if _instance == null:
+		return 1.0
+	var scale: float = 1.0
+	for provider: Object in _instance._experience_scales.values():
+		var answered: float = float(provider.call("experience_scale"))
+		if not is_finite(answered) or answered < 0.0:
+			continue
+		scale *= answered
+	return clampf(scale, MIN_EXPERIENCE_SCALE, MAX_EXPERIENCE_SCALE)
 
 
 ## Registers a BATTLE INFORMATION provider under [param id]: read-only annotations
@@ -1146,7 +1202,6 @@ func register_page(id: StringName, entry: Dictionary) -> Dictionary:
 	return {"ok": true, "id": id}
 
 
-## The ids with a page, in registration order.
 func page_ids() -> Array:
 	return _pages.keys()
 

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -13,7 +13,7 @@ const FILENAME: String = "mod.json"
 ## number that says the seam is there: `docs/MODS.md` lists what each version
 ## added. An optional field a mod may send and an older host may drop is
 ## deliberately not a bump.
-const API_VERSION: int = 25
+const API_VERSION: int = 26
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase
@@ -171,7 +171,6 @@ static func _check_art(manifest: Gen2ModManifest) -> Dictionary:
 	return {}
 
 
-## Whether this mod ships its files as a resource pack rather than loose.
 func packed() -> bool:
 	return not pack.is_empty()
 

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -82,7 +82,6 @@ func frame_count() -> int:
 	return _frame_tiles / RomLayout.FRAME_TILES
 
 
-## Whether the battle-extra strip was in the cache this was read from.
 func has_battle_extra() -> bool:
 	return _battle_extra_width > 0 and _battle_extra_tiles > 0
 

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -232,7 +232,6 @@ func display_native(node: Node) -> void:
 	_native.add_child(node)
 
 
-## The native layer's rectangle in window pixels.
 func native_size() -> Vector2i:
 	return Vector2i((Vector2(_view_size) * _draw_scale).round())
 
@@ -548,7 +547,6 @@ func play_view_cover(rebuild: Callable) -> void:
 	set_process(true)
 
 
-## Whether a view switch is still being covered.
 func view_cover_active() -> bool:
 	return _cover != null and _cover.visible
 

--- a/game/render/pc_box_page.gd
+++ b/game/render/pc_box_page.gd
@@ -201,7 +201,6 @@ static func max_cursor_sprites() -> int:
 	return maxi(CURSOR_SPRITES.size(), CURSOR_SPRITES_GOLD.size())
 
 
-## The profile's own OAM table.
 func cursor_set() -> Array:
 	return CURSOR_SPRITES if _profile == RomRegistry.CRYSTAL else CURSOR_SPRITES_GOLD
 

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -235,7 +235,6 @@ func select_tab(kind: StringName) -> bool:
 	return true
 
 
-## The tab the cursor is on, for a host reporting what the panel shows.
 func selected_kind() -> StringName:
 	return _tabs.selected_kind()
 
@@ -249,7 +248,6 @@ func frame() -> Image:
 	return texture.get_image() if texture != null else null
 
 
-## The viewport itself, for a host that can show it directly rather than copy it.
 func viewport() -> SubViewport:
 	return _viewport
 

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -306,7 +306,6 @@ func occupied_rect() -> Rect2i:
 	return Rect2i(Vector2i(position.floor()), Vector2i(size.floor()))
 
 
-## Tiles of text that fit across the interior.
 func text_columns() -> int:
 	return maxi(columns - TEXT_LEFT * 2, 0)
 

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -240,7 +240,6 @@ func tilemap(
 	return map
 
 
-## Whether the three card tilemaps are in the cache this page was built from.
 func cards_ready() -> bool:
 	return _cards.size() == RomLayout.POKEGEAR_CARD_ORDER.size()
 

--- a/game/render/trainer_card_page.gd
+++ b/game/render/trainer_card_page.gd
@@ -158,7 +158,6 @@ static func from_data(
 	return out
 
 
-## Whether the cache carried every sheet this page needs.
 func ready() -> bool:
 	return font != null and not _tiles.is_empty()
 

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -677,7 +677,6 @@ func _close_submenu() -> void:
 	_refresh()
 
 
-## Test and host seam: the submenu as the screen currently shows it.
 func submenu_snapshot() -> Dictionary:
 	return {
 		"open": _submenu_open,

--- a/game/save/save_prompt.gd
+++ b/game/save/save_prompt.gd
@@ -93,7 +93,6 @@ static func open(kind: Kind, player_name: String, write: Callable) -> Gen2SavePr
 	return prompt
 
 
-## Waiting on a button rather than on its own frames.
 func reads_joypad() -> bool:
 	return step in [Step.ASK, Step.OVERWRITE, Step.FAILED]
 

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -169,7 +169,6 @@ func import_sav_path(path: String, slot: int = -1) -> bool:
 	return true
 
 
-## Read-only state used by scene tests and screenshot drivers.
 func save_screen_snapshot() -> Dictionary:
 	return {
 		"game_id": String(_data.id) if _data != null else "",

--- a/game/world/credits.gd
+++ b/game/world/credits.gd
@@ -152,7 +152,6 @@ func banner_block() -> int:
 	return _block
 
 
-## The BG map, which is what is on screen: one tile number per cell.
 func bg_map() -> PackedInt32Array:
 	return _bg_map.duplicate()
 
@@ -205,7 +204,6 @@ func skippable() -> bool:
 	return _skippable
 
 
-## What [Gen2CreditsPage] needs to draw one frame.
 func frame_state() -> Dictionary:
 	return {
 		"map": bg_map(),

--- a/game/world/gender_screen.gd
+++ b/game/world/gender_screen.gd
@@ -65,7 +65,6 @@ func _ready() -> void:
 		_refresh()
 
 
-## The live menu, so a driver can read the cursor without going through a redraw.
 func menu() -> Gen2WorldMenu:
 	return _menu
 

--- a/game/world/intro_movie.gd
+++ b/game/world/intro_movie.gd
@@ -395,12 +395,10 @@ func scroll_x_at(line: int) -> int:
 	return _ly_shown[maxi(line - 1, 0)]
 
 
-## One background palette, as colours a page can draw with.
 func palette(index: int) -> PackedColorArray:
 	return _palette_at(index)
 
 
-## One object palette, which is the same run's second half.
 func object_palette(index: int) -> PackedColorArray:
 	return _palette_at(BG_PALETTES + index)
 
@@ -432,7 +430,6 @@ func tile_overlay() -> Array:
 	return _overlay
 
 
-## The 32x32 BG map and its attribute plane, as the cache holds them.
 func bg_map() -> PackedByteArray:
 	return _data.intro_map(String(_vram.get("map", ""))) if _data != null \
 		else PackedByteArray()

--- a/game/world/intro_presentation.gd
+++ b/game/world/intro_presentation.gd
@@ -155,7 +155,6 @@ func bgp() -> int:
 	return _bgp
 
 
-## Where the player pic sits, in tiles.
 func column() -> int:
 	return _column
 

--- a/game/world/link_screen.gd
+++ b/game/world/link_screen.gd
@@ -112,7 +112,6 @@ func _ready() -> void:
 	_refresh()
 
 
-## Which step is on screen, for the checks and the screenshot tool.
 func step() -> int:
 	return _step
 

--- a/game/world/mod_page_screen.gd
+++ b/game/world/mod_page_screen.gd
@@ -110,7 +110,6 @@ func _scroll_by(delta: int) -> bool:
 	return true
 
 
-## The rows on screen now, which is what a test or a screenshot reads back.
 func visible_rows() -> Array:
 	return _rows.slice(_scroll, _scroll + VISIBLE_ROWS)
 

--- a/game/world/mystery_gift_screen.gd
+++ b/game/world/mystery_gift_screen.gd
@@ -71,7 +71,6 @@ func step() -> STEP:
 	return _step
 
 
-## What the last exchange answered, empty before one has run.
 func result() -> Dictionary:
 	return _result.duplicate()
 

--- a/game/world/mystery_gift_transport.gd
+++ b/game/world/mystery_gift_transport.gd
@@ -24,7 +24,6 @@ var peer: Dictionary = {}
 var role: int = IR_RECEIVER
 
 
-## Whether anybody is in the window at all. Everything else asks this first.
 func connected() -> bool:
 	return not peer.is_empty()
 

--- a/game/world/naming_screen.gd
+++ b/game/world/naming_screen.gd
@@ -174,7 +174,6 @@ func row_count() -> int:
 	return 6 if is_box or is_mail else 5
 
 
-## Which row the case switch, DEL and END sit on.
 func command_row() -> int:
 	return row_count() - 1
 

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -77,7 +77,6 @@ func _ready() -> void:
 		_refresh()
 
 
-## The live model, so a driver can read the entry without going through a redraw.
 func model() -> Gen2NamingScreen:
 	return _screen
 

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -135,7 +135,6 @@ func advance_frames(count: int) -> void:
 			_finish_queue()
 
 
-## Which beat is showing, zero-based, for a driver that wants to step to one.
 func beat_index() -> int:
 	return _index
 

--- a/game/world/slot_machine_screen.gd
+++ b/game/world/slot_machine_screen.gd
@@ -73,7 +73,6 @@ func text() -> String:
 	return _text
 
 
-## What the machine is asking the player for, if anything.
 func prompt() -> int:
 	return _machine.prompt() if _machine != null else Gen2SlotMachine.Prompt.NONE
 

--- a/game/world/splash_screen.gd
+++ b/game/world/splash_screen.gd
@@ -153,7 +153,6 @@ func last_music_request() -> Dictionary:
 	return _last_music.duplicate()
 
 
-## Whether a song is running in the driver right now.
 func music_playing() -> bool:
 	return _audio != null and bool(_audio.audio_status().get("music_active", false))
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -195,6 +195,10 @@ var world_hour: int = 6
 var world_minute: int = 0
 var dst_enabled: bool = false
 var movement_mode: StringName = MOVEMENT_WALK
+## Whether the next committed walk takes bike speed. No cartridge state: the
+## screen polls [method Gen2ModHost.run_button_held] and pushes it in, so a
+## replay reproduces a run rather than reading a live keyboard.
+var run_held: bool = false
 ## `DOWN`, `UP`, `LEFT`, `RIGHT`: the direction constants' own order, which is
 ## both `.FinishFacing`'s row order and `.GetAction`'s test order.
 const TURNING_DIRECTION_ORDER: Array[Vector2i] = [
@@ -642,7 +646,6 @@ func tune_radio(knob: int) -> Dictionary:
 	return tuned
 
 
-## The programme the tuned station is reading, or null on dead air.
 func radio_show() -> Gen2RadioShow:
 	return _radio_show
 
@@ -5676,7 +5679,9 @@ func _follow_object_is_visible(object_index: int) -> bool:
 ## approach do: MovementFunction_Follow is HandleMovementData over the queued
 ## leader commands, so every one of them lands in NormalStep and never reaches
 ## CanObjectMoveInDirection.
-func _advance_followers(leader_index: int, leader_from_cell: Vector2i) -> void:
+func _advance_followers(
+	leader_index: int, leader_from_cell: Vector2i, passes: int = STEP_PASSES_WALK
+) -> void:
 	if current_map == null:
 		return
 	var relations: Array = []
@@ -5695,14 +5700,17 @@ func _advance_followers(leader_index: int, leader_from_cell: Vector2i) -> void:
 	for entry: Dictionary in relations:
 		_step_follower(
 			int(entry["index"]), leader_from_cell,
-			bool((entry["relation"] as Dictionary).get("exact", true))
+			bool((entry["relation"] as Dictionary).get("exact", true)), passes
 		)
 
 
 ## One follower's step toward [param target_cell], which is the cell its leader
 ## has just left. An index below zero is the player, who is the object the
 ## source counts as zero and who is the follower in every `follow <NPC>, PLAYER`.
-func _step_follower(follower_index: int, target_cell: Vector2i, exact: bool) -> void:
+func _step_follower(
+	follower_index: int, target_cell: Vector2i, exact: bool,
+	passes: int = STEP_PASSES_WALK
+) -> void:
 	var follower_cell: Vector2i = player_cell
 	var follower: Gen2WorldObject = null
 	if follower_index >= 0:
@@ -5734,17 +5742,18 @@ func _step_follower(follower_index: int, target_cell: Vector2i, exact: bool) -> 
 	var destination: Vector2i = follower_cell + direction
 	if not _cell_in_bounds(destination):
 		return
-	# The player's own walk duration, not the slower wandering one:
+	# The leader's own step duration, not the slower wandering one:
 	# QueueFollowerFirstStep queues `movement_step` and the queue after it holds
-	# the leader's own command bytes.
+	# the leader's own command bytes. A running player leaves a follower on the
+	# walk row a cell behind every step.
 	if follower == null:
 		player_cell = destination
 		player_facing = facing_for_direction(direction)
-		_queue_player_step(direction, STEP_PASSES_WALK)
+		_queue_player_step(direction, passes)
 		return
 	follower.cell = destination
 	follower.apply_direction(direction)
-	follower.queue_step(direction, STEP_PASSES_WALK)
+	follower.queue_step(direction, passes)
 	var override_key: String = _object_key(
 		current_map.group, current_map.number, follower_index
 	)
@@ -5868,9 +5877,10 @@ func move_result(direction: Vector2i) -> Dictionary:
 	player_cell = destination
 	player_facing = facing_for_direction(direction)
 	count_step()
-	_advance_followers(-1, from_cell)
+	var passes: int = _step_frames_for_movement()
+	_advance_followers(-1, from_cell, passes)
 	_do_step(direction)
-	_start_player_step(direction, _step_frames_for_movement())
+	_start_player_step(direction, passes)
 	return {
 		"ok": true,
 		"kind": kind,
@@ -6558,8 +6568,13 @@ func dig_request() -> Dictionary:
 ## which is `big_step` and so four frames, and `STEP_WALK`'s eight otherwise.
 ## `.BikeCheck`'s downhill branch is not modelled: `BIKEFLAGS_DOWNHILL_F` is set
 ## by nothing in either pin, so no map can ask for the slower non-down step.
+## [member run_held] is the one addition the cartridge has no branch for, and it
+## reaches the walk alone.
 func _step_frames_for_movement() -> int:
-	return STEP_PASSES_FAST if movement_mode == MOVEMENT_BIKE else STEP_PASSES_WALK
+	if movement_mode == MOVEMENT_BIKE:
+		return STEP_PASSES_FAST
+	return STEP_PASSES_FAST if run_held and movement_mode == MOVEMENT_WALK \
+		else STEP_PASSES_WALK
 
 
 ## `BikeFunction`'s `.TryBike`: `.CheckEnvironment` first, then the state the

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -313,7 +313,6 @@ func active() -> bool:
 	return _frame < _duration and _duration > 0
 
 
-## Whether any effect sprite is still on screen.
 func sprites_active() -> bool:
 	return not _sprites.is_empty()
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -311,6 +311,9 @@ var _input_replay: Dictionary = {}
 var _replaying_input: bool = false
 ## What a replay is holding down, in place of the runtime's own poll.
 var _replay_held_direction: int = Gen2Button.NONE
+## Beside the held direction: a hold that changes a step's duration and is not in
+## the log makes every replay taken while running wrong.
+var _replay_running: bool = false
 ## Whether a frame is being spent right now, which is what tells a press
 ## delivered from inside the pump from one that arrived between two frames.
 var _spending_frame: bool = false
@@ -1080,7 +1083,6 @@ func record_input() -> void:
 	_recording_input = true
 
 
-## The recorded `(frame, kind, button)` entries, in the order they were consumed.
 func input_recording() -> Array:
 	return _input_recording.duplicate(true)
 
@@ -1094,9 +1096,12 @@ func replay_input(entries: Array) -> void:
 			continue
 		var entry: Dictionary = raw
 		var frame: int = int(entry.get("frame", 0))
-		var at: Dictionary = _input_replay.get(frame, {"hold": Gen2Button.NONE, "presses": []})
+		var at: Dictionary = _input_replay.get(
+			frame, {"hold": Gen2Button.NONE, "run": false, "presses": []}
+		)
 		if String(entry.get("kind", "")) == "hold":
 			at["hold"] = int(entry.get("button", Gen2Button.NONE))
+			at["run"] = bool(entry.get("run", false))
 		else:
 			(at["presses"] as Array).append(int(entry.get("button", Gen2Button.NONE)))
 		_input_replay[frame] = at
@@ -1106,6 +1111,7 @@ func replay_input(entries: Array) -> void:
 func _apply_replayed_input(frame: int) -> void:
 	var at: Dictionary = _input_replay.get(frame, {})
 	_replay_held_direction = int(at.get("hold", Gen2Button.NONE))
+	_replay_running = bool(at.get("run", false))
 	for button: int in at.get("presses", []) as Array:
 		press_button(button)
 
@@ -1163,9 +1169,14 @@ func _advance_held_direction() -> void:
 	## was held rather than what the world did with it.
 	var direction: int = _replay_held_direction if _replaying_input \
 		else Gen2InputRuntime.instance().held_direction()
+	var running: bool = _replay_running if _replaying_input \
+		else Gen2ModHost.run_button_held()
+	if _world != null:
+		_world.run_held = running
 	if _recording_input and _world != null and direction != Gen2Button.NONE:
 		_input_recording.append({
 			"frame": _world.frame_number, "kind": "hold", "button": direction,
+			"run": running,
 		})
 	if not _objects_may_move() or _world.script_input_waiting() \
 		or _world.player_step_in_progress():

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 25,
+	"api_version": 26,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage, a page of its own with a second row that opens it, and a banner over the map raised when the run's progress moves."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 25,
+	"api_version": 26,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -1054,3 +1054,39 @@ func test_the_scanline_window_reports_the_side_it_is_open_over() -> void:
 	var sunk: Vector2 = sinking.battler_window_offset(false)
 	assert_eq(sunk.x, 0.0, "a vertical window moves nothing sideways")
 	assert_eq(sunk.y, 5.0, "the rows still on screen carry the whole push")
+
+
+## The reported defect: `DoBattle` slides the player's trainer back pic off the
+## square before the first Pokemon is sent out, and a player mashing A through
+## `WildPokemonAppearedText` ran the send-out into that slide. The map was
+## reseeded with the new picture and the remaining steps walked it left, leaving
+## two columns of it beside its own square for the rest of the fight.
+## `SlideBattlePicOut` reads no joypad, so the press reaches nothing.
+func test_a_press_reaches_nothing_while_a_pic_slides_off_its_square() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	var guard: int = 8000
+	while not _battle_screen.sliding() and guard > 0:
+		guard -= 1
+		if not _battle_screen.frames_running():
+			_battle_screen.finish()
+			_battle_screen.advance()
+		_battle_screen.advance_frame()
+	assert_gt(guard, 0, "the opening reaches SlideBattlePicOut")
+
+	var stages: int = _battle_screen._entrance_stages.size()
+	_battle_screen.press_button(Gen2Button.A)
+	assert_true(_battle_screen.sliding(), "the slide is still owed after the press")
+	assert_eq(
+		_battle_screen._entrance_stages.size(), stages,
+		"and nothing behind it ran"
+	)
+
+	# The other half of the same seam: whatever got the screen there, a map with
+	# both pictures put back has nothing left to walk one of them off it.
+	_battle_screen._reseed_bg_map()
+	assert_false(_battle_screen.sliding(), "a reseeded map owes no slide")
+	assert_eq(
+		_battle_screen._bg_map, Gen2BattleScreenMap.seeded(),
+		"both pictures stand on their own squares and nowhere else"
+	)

--- a/tests/integration/test_walk_pacing.gd
+++ b/tests/integration/test_walk_pacing.gd
@@ -339,3 +339,76 @@ func test_a_warp_back_into_the_same_landmark_raises_no_sign() -> void:
 		_world.map_name_sign_pending(), Fixture.HOME_MAP_LANDMARK,
 		"and the house's own landmark is what the sign names"
 	)
+
+
+## `Gen2ModHost.register_run_button`'s whole effect on the pacing: a walk takes
+## the bike's own four passes while the button is held, and nothing else moves.
+## The bike is already fast, and surf and every scripted stream carry their own
+## row.
+func test_running_takes_the_fast_row_and_only_for_a_walk() -> void:
+	assert_eq(_world._step_frames_for_movement(), Gen2WorldAPI.STEP_PASSES_WALK)
+	_world.run_held = true
+	assert_eq(_world._step_frames_for_movement(), Gen2WorldAPI.STEP_PASSES_FAST)
+	for mode: StringName in [Gen2WorldAPI.MOVEMENT_SURF, Gen2WorldAPI.MOVEMENT_BIKE]:
+		_world.movement_mode = mode
+		var passes: int = Gen2WorldAPI.STEP_PASSES_FAST \
+			if mode == Gen2WorldAPI.MOVEMENT_BIKE else Gen2WorldAPI.STEP_PASSES_WALK
+		assert_eq(_world._step_frames_for_movement(), passes, String(mode))
+
+
+## A follower queued on the walk row falls a cell behind a running leader every
+## step, so it takes the duration the player's step actually took.
+func test_a_follower_takes_the_duration_the_leaders_step_took() -> void:
+	_world.player_cell = Vector2i(5, 4)
+	_world._start_object_follow({
+		"map_group": Fixture.MAP_GROUP, "map_number": Fixture.MAP_NUMBER,
+		"object_index": 0, "target_index": -1, "exact": true,
+	})
+	var follower: Gen2WorldObject = _world.objects[0]
+	assert_eq(follower.cell, Vector2i(5, 3), "standing on the cell the player leaves into")
+
+	_world.run_held = true
+	assert_true(bool(_world.move_result(Vector2i(0, 1)).get("ok", false)))
+	assert_eq(follower.cell, Vector2i(5, 4), "it stepped into the vacated cell")
+	assert_eq(
+		follower.step_passes_total, Gen2WorldAPI.STEP_PASSES_FAST,
+		"and over the same four passes the run took"
+	)
+
+
+## The run state goes in the log beside the held direction, or a replay taken
+## while running walks at the wrong speed and lands somewhere else. The provider
+## is registered rather than mocked: the recording is what the pump polled.
+func test_a_recording_carries_the_run_state_and_a_replay_reads_it_back() -> void:
+	Gen2ModHost.reset()
+	var policy := GDScript.new()
+	policy.source_code = "extends RefCounted\nfunc runs_while_held() -> bool:\n\treturn true\n"
+	policy.reload()
+	assert_true(bool(
+		Gen2ModHost.instance().register_run_button(&"shoes", policy.new()).get("ok", false)
+	))
+	_screen = await _screen_at(Fixture.WARP_CELL + Vector2i.DOWN)
+	## Held rather than called: `_advance_held_direction` polls the input runtime,
+	## which is the poll the run state is recorded beside.
+	for button: int in [Gen2Button.B, Gen2Button.LEFT]:
+		Input.action_press(Gen2Button.ACTIONS[button])
+	await get_tree().process_frame
+	_screen.record_input()
+	for _frame: int in _walk_screen_frames():
+		_screen.advance_frame()
+	for button: int in [Gen2Button.B, Gen2Button.LEFT]:
+		Input.action_release(Gen2Button.ACTIONS[button])
+	Gen2ModHost.reset()
+
+	var holds: Array = _screen.input_recording().filter(
+		func(entry: Dictionary) -> bool: return String(entry["kind"]) == "hold"
+	)
+	assert_false(holds.is_empty(), "the pump polled a held direction")
+	for entry: Dictionary in holds:
+		assert_true(bool(entry["run"]), "recorded beside the direction")
+
+	## Replayed with no host and no button down at all, the log is still the run.
+	_screen.replay_input(holds)
+	_screen._apply_replayed_input(int((holds[0] as Dictionary)["frame"]))
+	_screen._advance_held_direction()
+	assert_true(_screen._world.run_held)

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -38,6 +38,9 @@ func after_each() -> void:
 	Gen2ModInstaller.uninstall(VIEW_MOD_ID)
 	for feed: String in PROBE_FEEDS:
 		Gen2ModIndex.unfollow(feed)
+	for game_id: StringName in RomRegistry.ORDER:
+		Gen2CartridgeArt.revert(game_id)
+	_clear_art_scratch()
 
 
 ## The mods page on its own, which is what every mod workflow but the file
@@ -794,3 +797,99 @@ func test_back_closes_what_is_open_before_it_asks_about_quitting() -> void:
 ## The sheets open over the launcher, innermost last.
 func _sheet_count() -> int:
 	return _launcher.find_children("", "Gen2LauncherSheet", true, false).size()
+
+
+## The scratch directory the art store is exercised in, so a run never writes a
+## picture onto one of this machine's own cartridges. The one test that has to
+## use the real root reverts it in `after_each`.
+const ART_SCRATCH: String = "user://cartridge_art_tests"
+
+
+func _clear_art_scratch() -> void:
+	var listing: PackedStringArray = DirAccess.get_files_at(ART_SCRATCH)
+	for entry: String in listing:
+		DirAccess.remove_absolute("%s/%s" % [ART_SCRATCH, entry])
+	DirAccess.remove_absolute(ART_SCRATCH)
+
+
+func _write_image(path: String, width: int, height: int) -> String:
+	var image: Image = Image.create_empty(width, height, false, Image.FORMAT_RGBA8)
+	image.fill(Color.REBECCA_PURPLE)
+	DirAccess.make_dir_recursive_absolute(path.get_base_dir())
+	image.save_png(path)
+	return path
+
+
+## What is stored is a picture this project encoded, not the file that was
+## chosen, and it is never larger than the shell it stands in for.
+func test_chosen_cartridge_art_is_re_encoded_and_fitted_to_the_shell() -> void:
+	var source: String = _write_image("%s/source.png" % ART_SCRATCH, 3000, 1500)
+	assert_false(Gen2CartridgeArt.has_custom_art(&"gold", ART_SCRATCH))
+
+	var taken: Dictionary = Gen2CartridgeArt.adopt(&"gold", source, ART_SCRATCH)
+	assert_true(bool(taken.get("ok", false)), JSON.stringify(taken))
+	assert_true(Gen2CartridgeArt.has_custom_art(&"gold", ART_SCRATCH))
+
+	var texture: Texture2D = Gen2CartridgeArt.texture_for(&"gold", ART_SCRATCH)
+	assert_not_null(texture)
+	assert_eq(texture.get_size().x, float(Gen2CartridgeArt.STORED_SIDE), "the long side")
+	assert_eq(texture.get_size().y, float(Gen2CartridgeArt.STORED_SIDE / 2), "aspect kept")
+
+	## Smaller than the shell is left where it is: a 32x32 sprite is drawn small
+	## rather than smeared over a cartridge.
+	assert_true(bool(Gen2CartridgeArt.adopt(
+		&"gold", _write_image("%s/small.png" % ART_SCRATCH, 32, 48), ART_SCRATCH
+	).get("ok", false)))
+	assert_eq(
+		Gen2CartridgeArt.texture_for(&"gold", ART_SCRATCH).get_size(), Vector2(32, 48),
+		"and the texture is the new picture rather than the cached first one"
+	)
+
+	assert_true(Gen2CartridgeArt.revert(&"gold", ART_SCRATCH))
+	assert_false(Gen2CartridgeArt.has_custom_art(&"gold", ART_SCRATCH))
+	assert_null(Gen2CartridgeArt.texture_for(&"gold", ART_SCRATCH))
+	assert_false(Gen2CartridgeArt.revert(&"gold", ART_SCRATCH), "nothing left to remove")
+
+
+## Every way a chosen file can be refused, each with a sentence rather than an
+## error: the file is the player's own and the launcher has to say why.
+func test_a_file_that_is_not_cartridge_art_is_refused_with_a_reason() -> void:
+	DirAccess.make_dir_recursive_absolute(ART_SCRATCH)
+	var text: String = "%s/notes.txt" % ART_SCRATCH
+	var file: FileAccess = FileAccess.open(text, FileAccess.WRITE)
+	file.store_string("PNG? no.")
+	file.close()
+
+	var rows: Array = [
+		[&"unknown_cartridge", Gen2CartridgeArt.adopt(&"", text, ART_SCRATCH)],
+		[&"missing_file", Gen2CartridgeArt.adopt(&"gold", "%s/nope.png" % ART_SCRATCH, ART_SCRATCH)],
+		[&"not_an_image", Gen2CartridgeArt.adopt(&"gold", text, ART_SCRATCH)],
+	]
+	for row: Array in rows:
+		var answer: Dictionary = row[1]
+		assert_false(bool(answer.get("ok", false)), String(row[0]))
+		assert_eq(StringName(answer["reason"]), StringName(row[0]))
+		assert_false(Gen2CartridgeArt.refusal_text(row[0]).is_empty(), String(row[0]))
+	assert_false(Gen2CartridgeArt.has_custom_art(&"gold", ART_SCRATCH), "and nothing was stored")
+
+
+## The cartridge draws the player's picture where it has one and the shipped
+## shell where it has not, contained inside the shell's own box whatever shape
+## the picture is.
+func test_a_cartridge_wears_the_players_own_art_and_goes_back_to_the_default() -> void:
+	var card: Gen2Cartridge = autofree(
+		Gen2Cartridge.create(Gen2LauncherTheme.active(), &"gold")
+	)
+	var art: TextureRect = card.get("_art")
+	assert_eq(art.stretch_mode, TextureRect.STRETCH_KEEP_ASPECT_CENTERED, "contained, not stretched")
+	assert_eq(art.texture, Gen2Cartridge.ART[&"gold"], "the shipped shell")
+
+	assert_true(bool(Gen2CartridgeArt.adopt(
+		&"gold", _write_image("%s/mine.png" % ART_SCRATCH, 700, 300)
+	).get("ok", false)))
+	card.refresh_art()
+	assert_ne(art.texture, Gen2Cartridge.ART[&"gold"], "the player\'s own")
+
+	Gen2CartridgeArt.revert(&"gold")
+	card.refresh_art()
+	assert_eq(art.texture, Gen2Cartridge.ART[&"gold"])

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -15,6 +15,12 @@ const PROBE_MOD_ID: StringName = &"launcher_probe"
 ## loaded script by path: two mods sharing a directory would have the first
 ## one's entry script run for the second.
 const VIEW_MOD_ID: StringName = &"launcher_view_probe"
+## The sources these tests follow. Unfollowed after each one, or a test that
+## fails part way leaves the next one reading a feed it never added.
+const PROBE_FEEDS: Array[String] = [
+	"https://mods.example.com/update-all.json",
+	"https://mods.example.com/update-queue.json",
+]
 
 
 func after_each() -> void:
@@ -30,6 +36,8 @@ func after_each() -> void:
 	DirAccess.remove_absolute(_view_archive)
 	Gen2ModInstaller.uninstall(PROBE_MOD_ID)
 	Gen2ModInstaller.uninstall(VIEW_MOD_ID)
+	for feed: String in PROBE_FEEDS:
+		Gen2ModIndex.unfollow(feed)
 
 
 ## The mods page on its own, which is what every mod workflow but the file
@@ -362,6 +370,67 @@ func test_a_source_names_the_mods_a_newer_version_is_listed_for() -> void:
 	}))
 	assert_false(page.status_text().contains("can be updated"))
 	Gen2ModIndex.forget_cache(feed)
+
+
+## The header carries one button and it offers whichever of its two actions is
+## worth pressing: read the sources while nothing is known to be out of date, and
+## download every update once something is.
+func test_the_header_button_offers_update_all_once_a_source_lists_one() -> void:
+	_write_probe_mod_zip()
+	assert_true(bool(Gen2ModInstaller.install_zip(_mod_archive).get("ok", false)))
+	Gen2ModHost.reset()
+	Gen2ModHost.instance().discover()
+
+	var feed: String = PROBE_FEEDS[0]
+	assert_true(bool(Gen2ModIndex.follow(feed).get("ok", false)))
+	var page: Gen2ModsPage = _mods_page()
+	var button: Gen2LauncherButton = page._check_updates_button
+	assert_eq(button.get("_glyph"), &"refresh_square", "nothing to update yet")
+
+	page.receive_feed_response(feed, true, JSON.stringify({
+		"schema_version": Gen2ModIndex.SCHEMA_VERSION,
+		"name": "Example",
+		"mods": [{"id": String(PROBE_MOD_ID), "name": "Launcher Probe", "version": "9.9.9",
+			"download": "https://example.com/probe.zip"}],
+	}))
+	assert_eq(page.available_update_count(), 1)
+	assert_eq(button.get("_glyph"), &"download", "the same button is now Update all")
+	assert_eq(button.text, "", "and it is still icon sized for a phone")
+	assert_string_contains(button.tooltip_text, "1 mod update")
+	assert_eq(
+		StringName((page.update_rows()[0] as Dictionary)["id"]), PROBE_MOD_ID,
+		"one press is the installed mods a source has something newer for"
+	)
+
+
+## Update all walks its queue whatever each row answers, and a row whose download
+## never starts is the refusal a single press of that row would give.
+func test_update_all_walks_its_queue_and_reports_what_it_installed() -> void:
+	_write_probe_mod_zip()
+	assert_true(bool(Gen2ModInstaller.install_zip(_mod_archive).get("ok", false)))
+	Gen2ModHost.reset()
+	Gen2ModHost.instance().discover()
+
+	var feed: String = PROBE_FEEDS[1]
+	assert_true(bool(Gen2ModIndex.follow(feed).get("ok", false)))
+	var page: Gen2ModsPage = _mods_page()
+	page.receive_feed_response(feed, true, JSON.stringify({
+		"schema_version": Gen2ModIndex.SCHEMA_VERSION,
+		"name": "Example",
+		"mods": [{"id": String(PROBE_MOD_ID), "name": "Launcher Probe", "version": "9.9.9",
+			"download": "https://example.com/probe.zip"}],
+	}))
+	assert_eq(page.available_update_count(), 1)
+
+	# No test reaches a server, so the transport is taken away: every row then
+	# answers the way one whose download could not be started does.
+	page._http = null
+	page.download_all()
+	for _frame: int in 4:
+		await get_tree().process_frame
+	assert_eq(page._update_queue.size(), 0, "the queue is drained rather than stuck")
+	assert_string_contains(page.status_text(), "No mod update could be installed")
+	assert_false(page._check_updates_button.disabled, "and the button is pressable again")
 
 
 ## A toast with nothing to say occupies nothing: not drawn, and not in the hit

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -5,6 +5,7 @@ extends GutTest
 ## has never seen can reach it.
 
 const ROOT: String = "user://mod_tests"
+const BattleFixture := preload("res://tests/unit/battle_fixture.gd")
 
 var _directory: String = ""
 
@@ -1829,11 +1830,11 @@ func test_a_fetched_icon_is_cached_and_read_back_without_the_network() -> void:
 	assert_not_null(Gen2ModArt.cached_icon(url, directory))
 
 
-## The four object registrations added for the Quality of Life seams all go
-## through one shape, so the rules are checked once rather than four times: a
+## The object registrations added for the Quality of Life seams all go through
+## one shape, so the rules are checked once rather than once per policy: a
 ## RefCounted that is never a Node, every method the host will call, and one
 ## claim per id.
-func test_the_four_provider_registrations_share_one_set_of_rules() -> void:
+func test_the_provider_registrations_share_one_set_of_rules() -> void:
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	var manifest: Gen2ModManifest = _loaded_manifest()
 	var node := Node2D.new()
@@ -1850,6 +1851,9 @@ func test_the_four_provider_registrations_share_one_set_of_rules() -> void:
 		[&"info", Gen2ModHost.BATTLE_INFO_METHODS[0],
 			func(id: StringName, p: Object) -> Dictionary:
 				return host.register_battle_info(id, p)],
+		[&"run", Gen2ModHost.RUN_BUTTON_METHODS[0],
+			func(id: StringName, p: Object) -> Dictionary:
+				return host.register_run_button(id, p)],
 		[manifest.id, Gen2ModHost.CATCH_EXPERIENCE_METHODS[0],
 			func(_id: StringName, p: Object) -> Dictionary:
 				return host.register_catch_experience(manifest, p)],
@@ -1875,6 +1879,7 @@ func test_the_four_provider_registrations_share_one_set_of_rules() -> void:
 	assert_eq(host.field_move_source_ids(), [&"field"])
 	assert_eq(host.repel_renewal_ids(), [&"repel"])
 	assert_eq(host.battle_info_ids(), [&"info"])
+	assert_eq(host.run_button_ids(), [&"run"])
 	assert_eq(host.catch_experience_ids(), [manifest.id])
 
 	## The catch policy is save bound, so a manifest this host never discovered
@@ -1884,10 +1889,11 @@ func test_the_four_provider_registrations_share_one_set_of_rules() -> void:
 	var same := GDScript.new()
 	same.source_code = "extends RefCounted\nfunc awards_catch_experience() -> bool:\n\treturn true\n"
 	same.reload()
-	assert_eq(
-		StringName(host.register_catch_experience(stranger, same.new())["reason"]),
-		&"unknown_mod_save_owner"
-	)
+	for register: Callable in [
+		func(p: Object) -> Dictionary: return host.register_catch_experience(stranger, p),
+		func(p: Object) -> Dictionary: return host.register_experience_scale(stranger, p),
+	]:
+		assert_eq(StringName(register.call(same.new())["reason"]), &"unknown_mod_save_owner")
 
 
 ## The three static answers a game with no mods must reach without building a
@@ -1977,3 +1983,110 @@ func test_a_start_menu_entry_without_a_predicate_is_always_listed() -> void:
 		"label": "ATLAS", "handler": func() -> void: pass,
 	}).get("ok", false)))
 	assert_eq(host.start_menu_entries({"party_count": 0}).size(), 1)
+
+
+## The run button is the mod's switch and the button is the host's, so neither
+## alone runs. `Input.action_press` is what stands in for a held B: the host asks
+## `Gen2Button`, which is the same read the world's own poll makes.
+func test_running_needs_both_a_provider_and_the_button() -> void:
+	Gen2ModHost.reset()
+	assert_false(Gen2ModHost.run_button_held(), "no host at all")
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var policy := GDScript.new()
+	policy.source_code = """extends RefCounted
+var on: bool = true
+func runs_while_held() -> bool:
+	return on
+"""
+	policy.reload()
+	var provider: Object = policy.new()
+	assert_true(bool(host.register_run_button(&"shoes", provider).get("ok", false)))
+	assert_false(Gen2ModHost.run_button_held(), "the button is not down")
+
+	Input.action_press(Gen2Button.ACTIONS[Gen2Button.B])
+	assert_true(Gen2ModHost.run_button_held())
+	provider.set("on", false)
+	assert_false(Gen2ModHost.run_button_held(), "read on the step, not once")
+	Input.action_release(Gen2Button.ACTIONS[Gen2Button.B])
+
+
+## Two scales multiply, an answer that is not a number is dropped rather than
+## carried into the product, and the product is held inside the host's range.
+func test_experience_scales_multiply_and_are_held_inside_the_hosts_range() -> void:
+	Gen2ModHost.reset()
+	assert_eq(Gen2ModHost.experience_scale(), 1.0, "no host at all")
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var policy := GDScript.new()
+	policy.source_code = """extends RefCounted
+var value: float = 2.0
+func experience_scale() -> float:
+	return value
+"""
+	policy.reload()
+	var provider: Object = policy.new()
+	assert_true(bool(host.register_experience_scale(manifest, provider).get("ok", false)))
+	assert_eq(Gen2ModHost.experience_scale(), 2.0)
+
+	for refused: float in [-1.0, NAN, INF]:
+		provider.set("value", refused)
+		assert_eq(Gen2ModHost.experience_scale(), 1.0, "an answer that is not a scale")
+
+	provider.set("value", 1000.0)
+	assert_eq(Gen2ModHost.experience_scale(), Gen2ModHost.MAX_EXPERIENCE_SCALE)
+	provider.set("value", 0.001)
+	assert_eq(Gen2ModHost.experience_scale(), Gen2ModHost.MIN_EXPERIENCE_SCALE)
+
+
+## The one seam is the award itself, so every figure a player sees moves with it.
+## A 0.5x run still levels: the product truncates the way every division in
+## `Gen2Experience` does, and a non-zero award is floored at 1.
+func test_a_registered_scale_moves_the_award_and_leaves_stat_experience_alone() -> void:
+	Gen2ModHost.reset()
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var policy := GDScript.new()
+	policy.source_code = """extends RefCounted
+var value: float = 1.0
+func experience_scale() -> float:
+	return value
+"""
+	policy.reload()
+	var provider: Object = policy.new()
+	assert_true(bool(host.register_experience_scale(manifest, provider).get("ok", false)))
+
+	var directory: String = RomCache.directory_for(&"modexptest", "0123456789abcdef")
+	var data: GameData = BattleFixture.build(directory)
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 12345
+	var awards: Dictionary = {}
+	var stats: Dictionary = {}
+	for scale: float in [1.0, 2.0, 0.5, Gen2ModHost.MIN_EXPERIENCE_SCALE]:
+		provider.set("value", scale)
+		var battle: Gen2Battle = Gen2Battle.create_parties(
+			data,
+			Gen2Party.of(Gen2BattleMon.create(
+				data, BattleFixture.PIKACHU, 5, [BattleFixture.THUNDERBOLT]
+			)),
+			Gen2Party.of(Gen2BattleMon.create(
+				data, BattleFixture.BULBASAUR, 5, [BattleFixture.TACKLE]
+			)),
+			rng, true
+		)
+		var events: Array = battle.award_win_experience()
+		for event: Dictionary in events:
+			if StringName(event["type"]) == Gen2Battle.EXP_GAINED:
+				awards[scale] = int(event["amount"])
+			elif StringName(event["type"]) == Gen2Battle.STAT_EXP_GAINED:
+				stats[scale] = event["gains"]
+	assert_eq(awards[1.0], 67, "the unscaled trainer award")
+	assert_eq(awards[2.0], 134)
+	assert_eq(awards[0.5], 33, "truncated, the way the cartridge divides")
+	assert_eq(awards[Gen2ModHost.MIN_EXPERIENCE_SCALE], 6)
+	assert_eq(
+		stats[2.0], stats[1.0],
+		"stat experience is the cartridge's own EV gain and is not scaled"
+	)
+	RomCache.clear(directory)

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -7,7 +7,7 @@ extends SceneTree
 ## documented below.
 ##
 ##   Godot --path . -s res://tools/preview_battle_anim.gd -- \
-##       <game> <output.png> <move> <side> <frames> [scene_off]
+##       <game> <output.png> <move> <side> <frames> [scene_off] [matchup=<enemy>,<player>]
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 ## Enough frames for the scene to lay out before anything is driven, and enough
@@ -25,6 +25,10 @@ const PRESS_AFTER: int = 40
 ## number, so it cannot collide with one.
 const CATCH_MOVE: int = -1
 
+## `matchup=` is what a picture reported against one pair is shot as.
+const DEFAULT_MATCHUP: Vector2i = Vector2i(16, 155)
+const MATCHUP_LEVEL: int = 20
+
 var _screen: Gen2BattleScreen = null
 var _output_path: String = ""
 var _move: int = 1
@@ -40,6 +44,7 @@ var _scene_off: bool = false
 var _with_intro: bool = false
 var _miss: bool = false
 var _frames: int = 0
+var _matchup: Vector2i = DEFAULT_MATCHUP
 
 
 func _initialize() -> void:
@@ -64,6 +69,14 @@ func _initialize() -> void:
 	else:
 		_frames_in = int(args[4])
 	for flag: String in args.slice(5):
+		if flag.begins_with("matchup="):
+			var pair: PackedStringArray = flag.trim_prefix("matchup=").split(",", false)
+			if pair.size() != 2:
+				push_error("matchup= wants <enemy>,<player>")
+				quit(1)
+				return
+			_matchup = Vector2i(int(pair[0]), int(pair[1]))
+			continue
 		match flag:
 			"scene_off":
 				_scene_off = true
@@ -225,7 +238,7 @@ func _drive_entrance() -> bool:
 	if _side_is_enemy:
 		_screen.show_trainer(1, 0)
 	else:
-		_screen.show_matchup(16, 155, 20, 20)
+		_show_matchup()
 	if _range_lo >= 0:
 		# `InitBattleDisplay` and `BattleIntroSlidingPics` are frames of the
 		# opening like any other; a diff against the cartridge trace wants them
@@ -243,6 +256,10 @@ func _drive_entrance() -> bool:
 			continue
 		_screen.advance_frame()
 	return true
+
+
+func _show_matchup() -> void:
+	_screen.show_matchup(_matchup.x, _matchup.y, MATCHUP_LEVEL, MATCHUP_LEVEL)
 
 
 ## Everything `DoBattle` spends before its first menu, so a turn driven after
@@ -265,7 +282,7 @@ func _settle_entrance() -> void:
 ## Pokemon is caught or gets out, since only `anim_checkpokeball` tells the two
 ## endings apart.
 func _drive_capture() -> bool:
-	_screen.show_matchup(16, 155, 20, 20)
+	_show_matchup()
 	while _screen.intro_running():
 		_screen.advance_frame()
 	_settle_entrance()
@@ -322,7 +339,7 @@ func _drive() -> bool:
 		return _drive_entrance()
 	if _move == CATCH_MOVE:
 		return _drive_capture()
-	_screen.show_matchup(16, 155, 20, 20)
+	_show_matchup()
 	while _screen.intro_running():
 		_screen.advance_frame()
 	_settle_entrance()


### PR DESCRIPTION
Four reports.

**A duplicate of your own Pokemon beside its square.** `DoBattle` slides the player trainer back pic off its square before the first Pokemon is sent out. A press during that slide ran the battle on: the send-out put both pictures back on the tilemap, and the slide steps still owed then walked the new one left, leaving two of its columns at the screen edge for the rest of the fight. Mashing A through "Wild LEDYBA appeared!" is enough, which is why it looked random and why the strip was a different width each time.

`SlideBattlePicOut` reads no joypad, and neither does any other run of frames the screen counts. `advance` stood on three of the five parts of `frames_running` and now stands on all of it, so `SlideBattlePicOut` and `AnimateFrontpic` are covered alongside the intro, the bars, a faint and an animation. A map that has just been reseeded also drops the slide it no longer owes, the way it already dropped a faint.

**Update all.** The mods page header carried one icon button for Check for updates. It is now two actions in one place: it reads the followed sources while nothing is known to be out of date, and turns into Update all once something is, saying how many. One press downloads and installs every listed update in turn, through the same code a single row button uses, so a refusal reads the same either way.

**Two seams the mods repository asked for**, at `api_version` 26.

`register_run_button(id, provider)` walks the player at bike speed while B is held. The provider is the switch and nothing else; whether B is down, and whether running is allowed where the player stands, are the host's, and only a walk moves, since the bike is already fast and surf and every scripted stream carry their own duration. A step is still one step, so encounter counts, Repel steps and every tile event stay per step. The two things that go with it are done: a follower takes the duration the leader's step actually took, and an input recording carries the run state beside the held direction, so a replay taken while running walks at the same speed.

`register_experience_scale(manifest, provider)` multiplies every experience award, save bound the way the catch policy is. Two providers compose by multiplication and the product is clamped. The one seam is the award `Gen2Experience.award_for` returns, so the participant split, the Exp. Share halving, the level-up loop, the move offers and evolution eligibility are all downstream of it, and a skipped fight and a capture scale with the rest. Stat experience is the cartridge's own EV gain and is not scaled, the product truncates the way every division in `Gen2Experience` does with a non-zero award floored at 1, and the result is clamped to `MAX_EXP`.

**Your own cartridge art.** Cartridge options, behind the three dots above the shelf, now takes a picture of your own for a cartridge and gives the shipped shell back. Whatever is chosen is never the file that is kept: it is measured before it is read, decoded by its own magic bytes rather than its extension, refused if it is over 12 MB or decodes to more than 64 megapixels, scaled down to the shell's own 1201 px, and written back out as a PNG this project encoded. It lives under `user://` beside the saves, so an update never asks for it again, and the shell's box contains it whatever shape it is.

`preview_battle_anim.gd` takes `matchup=<enemy>,<player>`, so a picture reported against one pair can be shot as that pair.

Comment lines stay at the ceiling the budget test records. Forty-two doc comments that only restated the name of the function under them are gone.

Green: 4068 tests, `validate.gd -- all` 82 PASS, the editor analyser 0 warnings over 601 scripts.