### PR TITLE
A switch for trainer sightings, beside the one for wild encounters

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -7149,7 +7149,7 @@ func _script_block_cell(source_cell: Vector2i) -> Vector2i:
 
 
 func _find_sight_request() -> Dictionary:
-	if current_map == null:
+	if current_map == null or state.trainer_sightings_off():
 		return {}
 	var bank: int = int(current_map.events.get("bank", 0))
 	var rows: Array = current_map.events.get("objects", [])

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -209,6 +209,9 @@ var _pending_day_care_steps: int = 0
 ## `wStatusFlags`' `STATUSFLAGS_NO_WILD_ENCOUNTERS_F`, which `wildoff` sets and
 ## `wildon` clears around a scripted sequence.
 var _wild_encounters_off: bool = false
+## No cartridge byte: a staged run's own switch beside the one above. The
+## trainer still stands, still draws and still talks; only the sighting is gone.
+var _trainer_sightings_off: bool = false
 ## The Bug Catching Contest's own counters. `wParkBallsRemaining` and the clock
 ## reading `StartBugContestTimer` copies to `wBugContestStartTime`; whether a
 ## contest is running at all is `ENGINE_BUG_CONTEST_TIMER`, which is an engine
@@ -483,6 +486,7 @@ func to_dict() -> Dictionary:
 		"poison_step_count": _poison_step_count,
 		"happiness_step_count": _happiness_step_count,
 		"wild_encounters_off": _wild_encounters_off,
+		"trainer_sightings_off": _trainer_sightings_off,
 		"park_balls": _park_balls,
 		"bug_contest_started": _bug_contest_started.duplicate(),
 		"contest_mon": _contest_mon.duplicate(),
@@ -584,6 +588,9 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	restored._poison_step_count = int(source.get("poison_step_count", 0)) & 0xFF
 	restored._happiness_step_count = int(source.get("happiness_step_count", 0)) & 1
 	restored.set_wild_encounters_off(bool(source.get("wild_encounters_off", false)))
+	restored.set_trainer_sightings_off(
+		bool(source.get("trainer_sightings_off", false))
+	)
 	restored.set_park_balls(int(source.get("park_balls", 0)))
 	restored._bug_contest_started = _clock_dict(_map(source, "bug_contest_started"))
 	var caught: Dictionary = _map(source, "contest_mon")
@@ -676,6 +683,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_pending_step_happiness = 0
 	_pending_egg_steps = 0
 	_wild_encounters_off = restored._wild_encounters_off
+	_trainer_sightings_off = restored._trainer_sightings_off
 	_park_balls = restored._park_balls
 	_bug_contest_started = restored._bug_contest_started.duplicate()
 	_contest_mon = restored._contest_mon.duplicate()
@@ -1547,9 +1555,7 @@ func set_contest_second_party_species(species: int) -> void:
 	changed.emit()
 
 
-## Which of the ten contestants are not in this contest, as
-## `{index: true}`, read off the event flags
-## `SelectRandomBugContestContestants` set.
+## `SelectRandomBugContestContestants`' own flags, as `{index: true}`.
 func withdrawn_bug_contestants() -> Dictionary:
 	var out: Dictionary = {}
 	for index: int in Gen2WorldBugContest.NUM_CONTESTANTS:
@@ -1566,6 +1572,17 @@ func set_wild_encounters_off(value: bool) -> void:
 	if _wild_encounters_off == value:
 		return
 	_wild_encounters_off = value
+	changed.emit()
+
+
+func trainer_sightings_off() -> bool:
+	return _trainer_sightings_off
+
+
+func set_trainer_sightings_off(value: bool) -> void:
+	if _trainer_sightings_off == value:
+		return
+	_trainer_sightings_off = value
 	changed.emit()
 
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2443,6 +2443,34 @@ func test_trainer_sight_queues_the_first_facing_trainer_in_range() -> void:
 	assert_true(world.dispatch_sight_events().is_empty())
 
 
+## The switch a staged run asks for, beside `wildoff`'s own: the trainer still
+## stands, still draws and still talks, and only the sighting is gone. Without
+## it a benchmark walking a route is stopped and every frame after it measures a
+## text box.
+func test_trainer_sightings_can_be_switched_off_without_touching_a_flag() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(5, 4))
+	var trainer: Gen2WorldObject = world.objects[0]
+	trainer.object_type = Gen2WorldObject.OBJECTTYPE_TRAINER
+	trainer.sight_range = 3
+	trainer.facing = Gen2WorldSprite.FACING_UP
+
+	world.state.set_trainer_sightings_off(true)
+	assert_true(world.dispatch_sight_events().is_empty())
+	assert_true(trainer.active, "the trainer is still standing there")
+	assert_false(
+		trainer.event_flag_active(world.state),
+		"and its own flag was not set: it has not been beaten"
+	)
+
+	## It rides the snapshot the way `wild_encounters_off` does, so a driver asks
+	## for it in the state it injects rather than at the door.
+	var restored: Gen2WorldState = Gen2WorldState.from_dict(world.state.to_dict())
+	assert_true(restored.trainer_sightings_off())
+
+	world.state.set_trainer_sightings_off(false)
+	assert_eq(world.dispatch_sight_events().size(), 1, "and the sighting comes back")
+
+
 func test_trainer_approach_path_uses_the_source_longer_axis_first() -> void:
 	assert_eq(
 		Gen2WorldAPI.trainer_approach_path(Vector2i(1, 1), Vector2i(4, 3)),


### PR DESCRIPTION
From the mods repository's handoff.

`Gen2WorldState` carried `set_wild_encounters_off` and nothing for the other thing that stops a staged walk. A benchmark or a screenshot driver crossing a route was seen, the sighting script ran, and every frame after it measured or photographed a text box. The workaround there was to read each map object's `trainer_data.event_flag` and set it in the save, which marks the trainer beaten: that reaches past the seam into what a flag means, and changes what any script keyed on that flag does.

`set_trainer_sightings_off(value)` and `trainer_sightings_off()` now sit beside the pair above, persisted in the state dictionary under `trainer_sightings_off` and read with a default of false, so an older save loads and no format moves. `_find_sight_request` answers nothing while it is set.

Nothing else changes. The trainer still stands, still draws, still talks when spoken to, and its own flag is untouched, which the test asserts alongside the switch surviving a `to_dict`/`from_dict` round trip and the sighting coming back when it is cleared.

Comment lines stay at the ceiling.

Green: 4069 tests, `validate.gd -- all` 82 PASS, the editor analyser 0 warnings over 601 scripts.