### PR TITLE
SMOOTH SCROLL reaches a span, a mod actor and a walking wild

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -33,7 +33,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version. Strict `major.minor.patch` |
-| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 26 and a host accepts 1 to 26. [Contract versions](#contract-versions) says what each added |
+| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 27 and a host accepts 1 to 27. [Contract versions](#contract-versions) says what each added |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -128,6 +128,7 @@ runs, since every version so far has only added.
 | 24 | `Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span()` |
 | 25 | `Gen2WorldAPI.party_with_player()` and `party_holder()`, and a visible encounter walking to the next cell |
 | 26 | A run button, and a scale on every experience award |
+| 27 | SMOOTH SCROLL reaching a span, an actor's pose and a walking wild, and `span` on an actor entry |
 
 ## Installing
 
@@ -1175,10 +1176,17 @@ Each entry of `sprites()` names cartridge art and nothing else:
 | `position_cells` | Where to draw it, in fractional walk cells |
 | `colors` | Optional. Four colours instead of the map's sprite palette. What a visible encounter wears, so a shiny one is shiny before the battle starts |
 | `emote` | Optional. `Gen2WorldActors.EMOTE_SHOCK` through `EMOTE_GRASS_RUSTLE`, drawn two rows above the sprite as `SpawnEmote` puts one over a map object. It is state, not an edge: up for as long as the entry keeps asking. An index outside the twelve is no emote |
+| `span` | Optional `{from, to, progress, kind}`, the shape `Gen2WorldObject.step_span()` answers: the two cells this pose runs between. A view whose plan is a grid reads `position_cells` and ignores it; one that folds plan into height puts both ends through its own geometry, which a fractional cell cannot do across a fold. A span missing an end is dropped rather than drawn |
 
 The host resolves the strip, the palette, the time of day and the icon's two-frame
 animation, so a mod never composes pixels. An entry naming art the cache does not
 carry is dropped.
+
+A pose is read once a DRAWN frame, not once a hardware one, so an actor standing
+on `player_step_offset_cells()` or on `pass_fraction` slides with SMOOTH SCROLL
+rather than jumping a whole hardware pixel every other frame. `advance_frame()` is
+still the hardware clock's and is where an actor's own state moves; `sprites()` is
+asked again afterwards, so it must stay a read.
 
 An actor's sprite is presentation. It occupies no cell, blocks nothing, nobody
 talks to it, no trainer sees it and it is in no snapshot. Actors are sorted into
@@ -1639,11 +1647,14 @@ answer carries `steps` and `passes`, and the surfer stays a surfer until the las
 step lands them ashore. A renderer that draws a fall as a vertical wall reads the
 offset as height.
 
-`Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span()` say which two
-cells the step in flight runs between: `{from, to, progress, kind}`, and `{}` while
+`Gen2WorldAPI.player_step_span()` and `Gen2WorldObject.step_span(fraction)` say
+which two cells the step in flight runs between: `{from, to, progress, kind}`, and `{}` while
 nothing steps. Moving `from` to `to` by `progress` is exactly what the offset
 above answers, so the two never disagree; the span is the one to read when the
-plan a renderer draws is not a plain grid. A view that folds a run of plan into
+plan a renderer draws is not a plain grid. `player_step_span()` spends the world's
+own `pass_fraction`, and an object's takes it as the same argument
+`step_offset_cells()` does, so SMOOTH SCROLL reaches whichever of the two a view
+reads. A view that folds a run of plan into
 height, or lifts or ramps it, puts `from` and `to` through its own geometry and
 moves between the two answers, which stays continuous where a fractional cell
 cannot: the fractional cell is one number and the fold is a step in it. The offset

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1825,8 +1825,7 @@ func _reset_action_counters(side: int, effect: int) -> void:
 		actor.rage_count = 0
 
 
-## Both sides use a move slot, which is the common case and the whole of a battle
-## that has one Pokémon a side.
+## Both sides use a move slot, which is the common case.
 func take_turn(player_slot: int, enemy_slot: int) -> Array:
 	return take_actions(use_move(player_slot), use_move(enemy_slot))
 

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -155,8 +155,6 @@ func anim_index() -> int:
 	return _anim_index
 
 
-## The video state the background effects write: scanline tables, screen scroll,
-## palette remaps and the tilemap.
 func background() -> Gen2BattleAnimBackground:
 	return _background
 
@@ -226,8 +224,7 @@ func tiles() -> Array:
 	return _tiles
 
 
-## The commands the last [method advance_frame] ran, each
-## [code]{ name, byte, operands }[/code] as [Gen2BattleAnimScript] reports them.
+## Each [code]{ name, byte, operands }[/code], as the script reports them.
 func frame_commands() -> Array:
 	return _frame_commands
 

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -213,7 +213,6 @@ func delay() -> int:
 	return _delay
 
 
-## Where the next byte will be read from, as the cartridge addresses it.
 func address() -> int:
 	return _address
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1317,7 +1317,6 @@ func _update_low_health_alarm() -> void:
 	_audio_player.set_low_health_alarm(GameData.hp_bar_palette_name(lit) == "hp_red")
 
 
-## Whether any bar is still moving, which is what holds the next message back.
 func bars_animating() -> bool:
 	return not _bars.is_empty() or _exp_bar != null
 

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -13,7 +13,7 @@ const FILENAME: String = "mod.json"
 ## number that says the seam is there: `docs/MODS.md` lists what each version
 ## added. An optional field a mod may send and an older host may drop is
 ## deliberately not a bump.
-const API_VERSION: int = 26
+const API_VERSION: int = 27
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/world/link_transport.gd
+++ b/game/world/link_transport.gd
@@ -47,7 +47,6 @@ const GENERATION_1: int = 1
 const GENERATION_2: int = 2
 
 
-## Whether a peer is on the other end at all. Everything else asks this first.
 func connected() -> bool:
 	return not peer.is_empty()
 

--- a/game/world/slot_machine.gd
+++ b/game/world/slot_machine.gd
@@ -302,7 +302,6 @@ func finished() -> bool:
 	return (_index & (1 << SLOTS_END_LOOP_F)) != 0
 
 
-## What the host is being asked for this frame, and by which box.
 func prompt() -> int:
 	return _prompt
 

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -3,8 +3,8 @@ extends RefCounted
 
 ## The sprites a mod puts in the world, driven and resolved by the host: a mod
 ## wanting a follower or a marker registers an actor rather than a whole renderer,
-## and the screen drives it with one `advance_frame` per world frame and one
-## `sprites()` read after it. PRESENTATION and nothing else: an actor's sprite
+## and the screen drives it with one `advance_frame` per world frame and a
+## `sprites()` read per DRAWN one. PRESENTATION and nothing else: an actor's sprite
 ## occupies no cell, blocks nothing, is talked to by nobody, is seen by no trainer
 ## and is in no snapshot, which is why it is a layer of its own rather than a map
 ## object. A mod names cartridge art and never composes pixels, the strip, palette
@@ -94,6 +94,14 @@ func advance_frame() -> bool:
 	_frame += 1
 	for actor: Object in _actors:
 		actor.call("advance_frame")
+	return refresh_pose()
+
+
+## The pose again at the fraction the drawn frame stands at: [method
+## advance_frame] is the hardware clock's and this is the panel's.
+func refresh_pose() -> bool:
+	if not has_actors():
+		return false
 	var before: Array = _sprites
 	_collect()
 	return _changed(before, _sprites)
@@ -119,9 +127,8 @@ func interact(cell: Vector2i, facing: int) -> bool:
 
 
 ## An actor's one-shot outbox, drained once a world frame and emptied by the
-## drain. A pose belongs in [method sprites], which is a read asked once a frame
-## however many times the screen redraws; an edge belongs here, asked for once
-## and spent once.
+## drain. A pose belongs in [method sprites], which is a read; an edge belongs
+## here, asked for once and spent once.
 ##
 ## Every entry is validated against [constant REQUEST_KINDS] here, so the screen
 ## is handed requests it can spend rather than whatever a mod wrote.
@@ -156,7 +163,7 @@ func _resolve_request(entry: Variant) -> Dictionary:
 	return {}
 
 
-## { sprite, facing, frame, position_cells, colors, emote }, sorted by the row
+## { sprite, facing, frame, position_cells, span, colors, emote }, sorted by the row
 ## stood on and then by registration order, the way the map's own objects are.
 ## `colors` is empty for everything but a visible encounter, and `emote` is
 ## [constant EMOTE_NONE] unless the entry asked for one.
@@ -214,10 +221,28 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 		# only way a shiny one is a shiny one before the battle starts. A view
 		# that does not read this draws the ordinary palette and is not wrong.
 		"colors": row.get("colors", PackedColorArray()),
+		# `step_span`'s own shape, or empty: a fractional cell cuts across a fold.
+		"span": _resolved_span(row),
 		# `SpawnEmote`'s bubble, two rows above the sprite. State rather than an
 		# edge: it is up for as long as the entry keeps asking, so the mod owns
 		# the duration and the host owns the pixels.
 		"emote": _resolve_emote(row),
+	}
+
+
+## A span missing an end is no span rather than a wrong one.
+static func _resolved_span(row: Dictionary) -> Dictionary:
+	var span: Variant = row.get("span", null)
+	if span is not Dictionary:
+		return {}
+	var entry: Dictionary = span
+	if not entry.has("from") or not entry.has("to"):
+		return {}
+	return {
+		"from": Vector2i(entry["from"]),
+		"to": Vector2i(entry["to"]),
+		"progress": clampf(float(entry.get("progress", 0.0)), 0.0, 1.0),
+		"kind": StringName(entry.get("kind", &"step")),
 	}
 
 
@@ -257,6 +282,7 @@ func _changed(before: Array, after: Array) -> bool:
 		var was: Dictionary = before[index]
 		var now: Dictionary = after[index]
 		if was["position_cells"] != now["position_cells"] \
+			or was["span"] != now["span"] \
 			or int(was["facing"]) != int(now["facing"]) \
 			or int(was["frame"]) != int(now["frame"]) \
 			or int(was["emote"]) != int(now["emote"]) \

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -901,6 +901,14 @@ func player_step_offset_cells() -> Vector2:
 	)
 
 
+## How far into its own run the step in flight is. The one place the fraction is
+## spent, so a span and an offset taken apart cannot disagree by half a pass.
+static func step_progress(remaining: int, total: int, fraction: float = 0.0) -> float:
+	if remaining <= 0 or total <= 0:
+		return 0.0
+	return 1.0 - maxf(float(remaining) - fraction, 0.0) / float(total)
+
+
 ## The cells a step in flight is still behind its landing cell, for the player
 ## and for every object: two answers computed apart slide the map under them.
 static func step_behind_cells(
@@ -931,8 +939,9 @@ func player_step_span() -> Dictionary:
 	return {
 		"from": landing - _player_step_direction,
 		"to": landing,
-		"progress": 1.0 - float(_player_step_passes_remaining) \
-			/ float(_player_step_passes_total),
+		"progress": step_progress(
+			_player_step_passes_remaining, _player_step_passes_total, pass_fraction
+		),
 		"kind": _player_step_kind,
 	}
 

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -154,6 +154,7 @@ func actor_entries() -> Array:
 	var out: Array = []
 	if _world == null or _world.data == null:
 		return out
+	_refresh_step_spans()
 	for entry: Dictionary in _entries:
 		var icon: int = _world.data.mon_menu_icon(int(entry["species"]))
 		if icon <= 0:
@@ -162,6 +163,8 @@ func actor_entries() -> Array:
 			"icon": icon,
 			"facing": int(entry["facing"]),
 			"position_cells": Vector2(entry["cell"]) + step_offset(entry),
+			# The same walk as two cells. See [method Gen2WorldActors.sprites].
+			"span": entry.get("step_span", {}),
 			# `GetMonNormalOrShinyPalettePointer`: the species' own four colours,
 			# which is what makes a shiny one visible before the battle starts,
 			# walked toward an entry's own light when it asked for one.
@@ -422,13 +425,27 @@ func _step_entry(entry: Dictionary, raw: Dictionary) -> void:
 		entry["facing"] = _world.facing_for_direction(direction)
 	if not _steps.has(id):
 		return
-	var step: Dictionary = _steps[id]
-	entry["step_span"] = {
+	entry["step_span"] = _span_for(_steps[id])
+
+
+## Built where it is read: a span held from the pass jumps beside a sliding player.
+func _span_for(step: Dictionary) -> Dictionary:
+	return {
 		"from": step["from"],
 		"to": step["to"],
-		"progress": 1.0 - float(step["remaining"]) / float(STEP_PASSES),
+		"progress": Gen2WorldAPI.step_progress(
+			int(step["remaining"]), STEP_PASSES,
+			_world.pass_fraction if _world != null else 0.0
+		),
 		"kind": &"step",
 	}
+
+
+func _refresh_step_spans() -> void:
+	for entry: Dictionary in _entries:
+		var step: Variant = _steps.get(StringName(entry["id"]), null)
+		if step is Dictionary:
+			entry["step_span"] = _span_for(step as Dictionary)
 
 
 ## The target has to be eligible for the SAME method: an entry keeps its

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -519,8 +519,9 @@ func step_offset_cells(fraction: float = 0.0) -> Vector2:
 	)
 
 
-## [method Gen2WorldAPI.player_step_span] for an object.
-func step_span() -> Dictionary:
+## [method Gen2WorldAPI.player_step_span] for an object, at the fraction
+## [method step_offset_cells] takes, so the two cannot disagree.
+func step_span(fraction: float = 0.0) -> Dictionary:
 	if step_passes_remaining <= 0 or step_passes_total <= 0:
 		return {}
 	var ahead := Vector2i.ZERO
@@ -530,6 +531,8 @@ func step_span() -> Dictionary:
 	return {
 		"from": landing - step_direction,
 		"to": landing,
-		"progress": 1.0 - float(step_passes_remaining) / float(step_passes_total),
+		"progress": Gen2WorldAPI.step_progress(
+			step_passes_remaining, step_passes_total, fraction
+		),
 		"kind": step_kind,
 	}

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -377,8 +377,9 @@ func _set_caption(text: String) -> void:
 
 ## The reading changes once a second and the line is rebuilt only then, so this is
 ## drawn on the frame it is measuring. `lock` shows only when there is one; `sub`
-## is screen pixels to a hardware one, and 1:1 is none of the smoothing reaching
-## the panel. See [method Gen2WorldAnimation.FrameClock.rate].
+## is screen pixels to a hardware one, `1:1` none of the smoothing reaching the
+## panel, and `native` a view drawing at the window's own resolution, which needs
+## none. See [method Gen2WorldAnimation.FrameClock.rate].
 func _refresh_frame_rate() -> void:
 	if _world == null or _caption == null or not _caption.visible:
 		return
@@ -387,10 +388,11 @@ func _refresh_frame_rate() -> void:
 		return
 	_rate_reading = rate
 	var lock: int = int(rate["lock"])
-	var steps: int = _screen.subpixel_steps()
-	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms%s   sub 1:%d" % [
+	var native: bool = not Gen2ModHost.renderer_uses_hardware_viewport(_renderer)
+	_rate_text = "   %.0f fps   hw %.0f/s   worst %.1f ms%s   sub %s" % [
 		float(rate["fps"]), float(rate["hardware"]), float(rate["worst_ms"]),
-		"" if lock < 1 else "   lock 1:%d" % lock, steps,
+		"" if lock < 1 else "   lock 1:%d" % lock,
+		"native" if native else "1:%d" % _screen.subpixel_steps(),
 	]
 	_caption.text = _caption_text + _rate_text
 
@@ -832,7 +834,13 @@ func _apply_pass_fraction(remainder: float = 0.0) -> void:
 		else (spent + clampf(remainder, 0.0, 1.0)) \
 			/ float(Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS)
 	## Only while the pass is moving something, so a still map is drawn once.
-	_refresh_if(_pass_moved and _world.pass_fraction != before)
+	if not _pass_moved or _world.pass_fraction == before:
+		return
+	## A mod actor's pose is the panel's frame, or it judders against the player.
+	## Not while one is being spent: `advance_frame` takes that one itself.
+	if not _spending_frame and _actors != null:
+		_actors.refresh_pose()
+	_refresh_if(true)
 
 
 ## Spends [param count] hardware frames. Public beside [method advance_frame] so

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -750,7 +750,6 @@ func link_transport() -> Gen2LinkTransport:
 	return _link_transport
 
 
-## The live Mystery Gift section, edited in place the way the tower's record is.
 func mystery_gift() -> Dictionary:
 	return _mystery_gift
 

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 26,
+	"api_version": 27,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage, a page of its own with a second row that opens it, and a banner over the map raised when the run's progress moves."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 26,
+	"api_version": 27,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -25,6 +25,7 @@ func after_each() -> void:
 		_world_screen.free()
 		_world_screen = null
 	RomCache.clear(Fixture.directory())
+	Gen2ModHost.reset()
 
 
 ## `_ContText`'s two `TextScroll` steps, which the box spends on its own frames.
@@ -367,6 +368,63 @@ func test_a_walk_step_is_drawn_a_pixel_a_frame_and_two_a_pass() -> void:
 	assert_gt(
 		_drawn_positions(smooth), _drawn_positions(hardware),
 		"a picture a frame rather than one a pass"
+	)
+
+
+## An actor standing on the fraction, which is what a follower reading the
+## player's own offset is.
+const SLIDING_ACTOR_SOURCE: String = """extends RefCounted
+
+var world = null
+
+func set_world(value) -> void:
+	world = value
+
+func advance_frame() -> void:
+	pass
+
+func sprites() -> Array:
+	var at: float = 3.0 + (0.0 if world == null else world.pass_fraction)
+	return [{"icon": 1, "position_cells": Vector2(at, 4)}]
+"""
+
+
+## SMOOTH SCROLL reaches a mod actor. Its pose used to be taken once a hardware
+## frame, so a follower stood still for a drawn frame and moved a whole hardware
+## pixel on the next while the player beside it slid a sixth of one.
+func test_a_mod_actors_pose_moves_on_every_drawn_frame() -> void:
+	var script := GDScript.new()
+	script.source_code = SLIDING_ACTOR_SOURCE
+	script.reload()
+	assert_true(
+		Gen2ModHost.instance().register_world_actor(&"slider", script.new())["ok"]
+	)
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var chosen: bool = options.smooth_scroll
+	options.smooth_scroll = true
+	_world_screen = await _open_world()
+	_settle_on_a_pass()
+	_world_screen._world.move_result(Vector2i.RIGHT)
+
+	## Half a hardware frame each, so most of these spend none at all: those are
+	## the drawn frames the pose used to be held through.
+	var drawn: Array[Vector2] = []
+	for _frame: int in 8:
+		_world_screen._process(FRAME * 0.5)
+		drawn.append(Vector2(
+			float(_world_screen._world.frame_number),
+			(_world_screen._actors.sprites()[0]["position_cells"] as Vector2).x
+		))
+	options.smooth_scroll = chosen
+
+	var moved_without_a_frame: int = 0
+	for index: int in range(1, drawn.size()):
+		if drawn[index].x == drawn[index - 1].x \
+			and not is_equal_approx(drawn[index].y, drawn[index - 1].y):
+			moved_without_a_frame += 1
+	assert_gt(
+		moved_without_a_frame, 0,
+		"the pose is read again on a drawn frame that spent no hardware one"
 	)
 
 

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -7789,6 +7789,21 @@ func test_a_visible_encounter_walks_to_the_next_cell() -> void:
 		Vector2(from) + Vector2(direction) * 0.5
 	)
 
+	## SMOOTH SCROLL reaches the wild as well: the drawn frame stands part way
+	## into the pass, and the sprite is read there rather than where the pass
+	## left it. The row a view draws carries the same walk as a span.
+	world.pass_fraction = 0.5
+	var walked: float = Gen2WorldAPI.step_progress(
+		Gen2WorldEncounters.STEP_PASSES / 2, Gen2WorldEncounters.STEP_PASSES, 0.5
+	)
+	var drawn: Dictionary = driver.actor_entries()[0]
+	assert_almost_eq(
+		Vector2(drawn["position_cells"]),
+		Vector2(from) + Vector2(direction) * walked, Vector2(0.0001, 0.0001)
+	)
+	assert_almost_eq(float((drawn["span"] as Dictionary)["progress"]), walked, 0.0001)
+	world.pass_fraction = 0.0
+
 	## It lands on the target, and stays there while the provider keeps naming
 	## the cell it stepped off.
 	for _tick: int in Gen2WorldEncounters.STEP_PASSES / 2:

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -221,6 +221,58 @@ func test_an_actors_entry_is_resolved_to_the_sprite_the_map_objects_use() -> voi
 	RomCache.clear(ActorFixture.directory())
 
 
+## SMOOTH SCROLL reaches an actor. Its pose is read again on the drawn frame, not
+## once a hardware frame: an actor standing on the player's own offset answers
+## differently at every fraction, and one held for the whole hardware frame stands
+## still for a frame and jumps a whole pixel on the next beside a sliding player.
+func test_an_actor_pose_is_taken_again_on_a_drawn_frame() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{"icon": 1, "position_cells": Vector2(0, 0)}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	var reads: int = actor.reads
+
+	actor.out = [{"icon": 1, "position_cells": Vector2(0, 0.5)}]
+	assert_true(actors.refresh_pose(), "the pose moved without a hardware frame")
+	assert_eq(actors.sprites()[0]["position_cells"], Vector2(0, 0.5))
+	assert_gt(actor.reads, reads, "and the mod was asked again")
+	assert_eq(actor.frames, 0, "no hardware frame was spent for it")
+	assert_false(actors.refresh_pose(), "a pose that has not moved is not a redraw")
+	RomCache.clear(ActorFixture.directory())
+
+
+## The two cells a pose runs between, for a view whose plan is not a plain grid:
+## a fractional `position_cells` cuts across a fold and a span does not. A span
+## that is not one is dropped rather than drawn at a cell nothing asked for.
+func test_an_actor_entry_carries_a_span_and_a_broken_one_is_dropped() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	actor.out = [{
+		"icon": 1, "position_cells": Vector2(4, 4.5),
+		"span": {"from": Vector2i(4, 5), "to": Vector2i(4, 4), "progress": 0.5},
+	}]
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+	var span: Dictionary = actors.sprites()[0]["span"]
+	assert_eq(span["from"], Vector2i(4, 5))
+	assert_eq(span["to"], Vector2i(4, 4))
+	assert_almost_eq(float(span["progress"]), 0.5, 0.0001)
+	assert_eq(StringName(span["kind"]), &"step", "a span that names no kind is a step")
+
+	for broken: Variant in [
+		null, "span", {"to": Vector2i(4, 4)}, {"from": Vector2i(4, 5)},
+	]:
+		actor.out = [{"icon": 1, "position_cells": Vector2(4, 4), "span": broken}]
+		actors.refresh_pose()
+		assert_true(
+			(actors.sprites()[0]["span"] as Dictionary).is_empty(), str(broken)
+		)
+	RomCache.clear(ActorFixture.directory())
+
+
 ## `.Frameset_PartyMon`: two sets of eight, nine passes each.
 func test_an_icon_actor_steps_the_strips_two_frames_at_the_framesets_rate() -> void:
 	var world: Gen2WorldAPI = _actor_world()

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -2184,31 +2184,36 @@ func test_every_used_line_carries_the_source_break() -> void:
 ## climb: the two say the same thing, so a renderer can move to the newer one
 ## without its drawing shifting. Moving `from` to `to` by `progress` is the
 ## offset's own answer, cell for cell.
+## Walked at three fractions, not at the pass boundary alone: SMOOTH SCROLL puts
+## the drawn frame part way into a pass, and a span that ignored it disagreed
+## with the offset by half a pass on every frame between two.
 func test_the_step_span_is_the_offset_taken_apart_step_by_step() -> void:
-	var world: Gen2WorldAPI = _waterfall_world()
-	assert_true(bool(world.waterfall_request().get("ok", false)))
-	var applied: Dictionary = world.complete_waterfall()
-	var seen: Array[Vector2i] = []
-	for _spent: int in int(applied["passes"]):
-		var span: Dictionary = world.player_step_span()
-		assert_false(span.is_empty())
-		assert_eq(span["kind"], &"turn_waterfall")
-		assert_eq((span["to"] as Vector2i) - (span["from"] as Vector2i), Vector2i.UP)
-		var walked: Vector2 = Vector2(span["from"] as Vector2i).lerp(
-			Vector2(span["to"] as Vector2i), float(span["progress"])
-		)
-		assert_almost_eq(
-			walked, Vector2(world.player_cell) + world.player_step_offset_cells(),
-			Vector2(0.001, 0.001)
-		)
-		if not seen.has(span["from"] as Vector2i):
-			seen.append(span["from"] as Vector2i)
-		world.advance_player_step_pass()
-	## One entry per step of the climb, in order, from the fall's foot up.
-	assert_eq(seen.size(), int(applied["steps"]))
-	assert_eq(seen[0], WATERFALL_STAND_CELL)
-	assert_eq(seen[seen.size() - 1] + Vector2i.UP, WATERFALL_LANDING_CELL)
-	assert_true(world.player_step_span().is_empty(), "empty once the run drains")
+	for fraction: float in [0.0, 0.5, 0.75]:
+		var world: Gen2WorldAPI = _waterfall_world()
+		world.pass_fraction = fraction
+		assert_true(bool(world.waterfall_request().get("ok", false)))
+		var applied: Dictionary = world.complete_waterfall()
+		var seen: Array[Vector2i] = []
+		for _spent: int in int(applied["passes"]):
+			var span: Dictionary = world.player_step_span()
+			assert_false(span.is_empty())
+			assert_eq(span["kind"], &"turn_waterfall")
+			assert_eq((span["to"] as Vector2i) - (span["from"] as Vector2i), Vector2i.UP)
+			var walked: Vector2 = Vector2(span["from"] as Vector2i).lerp(
+				Vector2(span["to"] as Vector2i), float(span["progress"])
+			)
+			assert_almost_eq(
+				walked, Vector2(world.player_cell) + world.player_step_offset_cells(),
+				Vector2(0.001, 0.001), str(fraction)
+			)
+			if not seen.has(span["from"] as Vector2i):
+				seen.append(span["from"] as Vector2i)
+			world.advance_player_step_pass()
+		## One entry per step of the climb, in order, from the fall's foot up.
+		assert_eq(seen.size(), int(applied["steps"]))
+		assert_eq(seen[0], WATERFALL_STAND_CELL)
+		assert_eq(seen[seen.size() - 1] + Vector2i.UP, WATERFALL_LANDING_CELL)
+		assert_true(world.player_step_span().is_empty(), "empty once the run drains")
 
 
 ## The same seam on an object, and the case the offset cannot answer: a stream
@@ -2227,3 +2232,15 @@ func test_an_object_step_span_survives_a_stream_that_turns() -> void:
 	var second: Dictionary = object.step_span()
 	assert_eq(second["from"], Vector2i(4, 5))
 	assert_eq(second["to"], Vector2i(4, 4))
+
+	## And an object's span takes the fraction its own offset takes, so a view
+	## reading either one of them is moved by SMOOTH SCROLL.
+	for fraction: float in [0.0, 0.5, 0.75]:
+		var span: Dictionary = object.step_span(fraction)
+		var walked: Vector2 = Vector2(span["from"] as Vector2i).lerp(
+			Vector2(span["to"] as Vector2i), float(span["progress"])
+		)
+		assert_almost_eq(
+			walked, Vector2(object.cell) + object.step_offset_cells(fraction),
+			Vector2(0.001, 0.001), str(fraction)
+		)

--- a/tools/checks/unown_puzzle.gd
+++ b/tools/checks/unown_puzzle.gd
@@ -232,7 +232,6 @@ func _strip_at(x: int, y: int, side: int) -> int:
 	return (y % TILE) * side * side * TILE + tile * TILE + x % TILE
 
 
-## Which border tile, if any, a piece-local tile takes.
 func _border_for(local: int) -> int:
 	return BORDERED.find(local)
 

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -8260,7 +8260,6 @@ func _events_at_cells(world: Gen2WorldAPI, targets: Array) -> Dictionary:
 	return {"events": [], "cell": Vector2i(-1, -1)}
 
 
-## The failure a leg answers with when a step refuses.
 func _leg_failed(path: Array, label: String, result: Dictionary) -> Dictionary:
 	return {"ok": false, "path": path, "reason": "%s: %s" % [label, result.get("reason", "")]}
 


### PR DESCRIPTION
Both requests in the mods repository's handoff, and the third case the same seam serves.

**A span that carries the pass fraction.** `pass_fraction` reached `player_step_offset_cells()` and `Gen2WorldObject.step_offset_cells()` and reached neither span, whose `progress` was `1.0 - remaining / total`: a whole pass. A view whose plan is not a plain grid has to read the span, which is what the span exists for, so SMOOTH SCROLL reached the 2D view and no view that folds plan into height. `Gen2WorldAPI.step_progress(remaining, total, fraction)` is the one place the fraction is spent now; `player_step_span()` hands its own down and `Gen2WorldObject.step_span(fraction)` takes the argument its offset already took. Nothing already drawn shifts: a pass boundary is a fraction of zero. `test_the_step_span_is_the_offset_taken_apart_step_by_step` walks the climb at 0.0, 0.5 and 0.75, and an object walks its own stream at the same three; put the whole-pass expression back and the first fails by 0.125 of a cell on every frame between two passes.

**A walking wild was the same bug.** `Gen2WorldEncounters` built its own span with the same arithmetic, on the pass that moved it, so a visible encounter jumped beside a sliding player in both views. It is built where it is read now, at the fraction the drawn frame stands at.

**A mod actor's pose, once a drawn frame.** `_collect()` ran from `advance_frame()` alone, so a follower reading the player's own offset stood still for a drawn frame and moved a whole hardware pixel on the next, beside a player the same option moves a sixth of one. `Gen2WorldActors.refresh_pose()` is that read, and `Gen2WorldScreen._apply_pass_fraction` takes it on the drawn frame the fraction moved on and not while a hardware frame is being spent, which `advance_frame` already owns. The test drives `_process` at half a hardware frame each and asserts the pose moved between two drawn frames that spent no frame at all; without the call it moves on none of them.

**A span on an actor entry.** `_resolve` rebuilt the row and dropped what it did not name. An entry may carry an optional `span` in `step_span`'s own shape now, validated and carried into the drawn row; one missing an end is dropped rather than drawn at a cell nothing asked for. A visible encounter's row carries the same span, so the two are one read for a view. The 2D view reads `position_cells` and ignores it.

**The readout.** `sub 1:1` under a native view said none of the smoothing was reaching a panel it was reaching at the window's own resolution. It says `native` for that case.

`api_version` is 27 and `docs/MODS.md` carries the row, the `span` key and the drawn-frame pose rule. Comment lines stay at the ceiling: a dozen docs that only restated the name of the function under them are gone.

Green: 4072 tests, `validate.gd -- all` 82 PASS, the editor analyser 0 warnings over 601 scripts.