### PR TITLE
The reset chord answers everywhere, and the slot counts it

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,13 @@ the game knows which one you used.
 | A | `Z`, Space | Bottom face button |
 | B | `X`, Escape | Right face button |
 | START | Enter | Start |
-| SELECT | Backspace, Shift | Back |
+| SELECT | Backspace, Tab | Back |
+
+A, B, START and SELECT together is the console's own reset, from anywhere: the
+opening, a menu, a battle or the map. It returns to the save screen without
+writing anything, so what you get back is your last SAVE, and the slot counts
+how many times you have done it. The count is on the save page under Mode, which
+is what a shiny hunt is measured in. The first reset asks before it happens.
 
 Keys bind by physical position, so WASD stays under the same four fingers on a
 layout that spells them differently; settings shows each binding as the key

--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -27,17 +27,17 @@ var pending_new_game_label: String = ""
 ## read back out of the installation's settings once the intro is over.
 var pending_new_game_challenge: StringName = Gen2Rules.CHALLENGE_VANILLA
 
+## This port's title screen, where a console reset lands and CONTINUE is.
+const SAVE_SCENE: String = "res://game/save/save_screen.tscn"
+
 ## The autoload, cached after the first lookup.
 static var _instance: Gen2GameRuntime = null
 
 
-## The live runtime, or null outside a scene tree that has one.
-##
-## Named relative to the root rather than as `/root/GameRuntime`, and reached
-## through this rather than through the `GameRuntime` global, for the reason
-## [method Gen2InputRuntime.instance] gives: a script handed to `-s` compiles
-## before the autoloads exist, so a screen naming the global by identifier fails
-## to compile at all and takes every tool that loads it down with it.
+## The live runtime, or null outside a scene tree that has one. Named relative
+## to the root rather than as `/root/GameRuntime`, and reached through this
+## rather than the `GameRuntime` global, for the reason
+## [method Gen2InputRuntime.instance] gives.
 static func instance() -> Gen2GameRuntime:
 	if _instance == null:
 		var loop: SceneTree = Engine.get_main_loop() as SceneTree
@@ -109,6 +109,57 @@ func _ready() -> void:
 	apply_display_options(Gen2OptionsStore.current())
 	_attach_second_screen()
 	load_mods()
+	_watch_reset_chord.call_deferred()
+
+
+## Deferred because the input runtime readies behind this one. Refused outside a
+## player's launch, where a tier pressing four buttons would lose its own scene.
+func _watch_reset_chord() -> void:
+	var input: Gen2InputRuntime = Gen2InputRuntime.instance()
+	if input == null or not is_player_launch():
+		return
+	if not input.reset_chord_pressed.is_connected(_on_reset_chord):
+		input.reset_chord_pressed.connect(_on_reset_chord)
+
+
+## `home/init.asm` wires the four buttons to the console rather than to a
+## routine, so no screen may decline one. Owning the chord here rather than in
+## the overworld makes that true of the opening and of a battle too.
+func _on_reset_chord() -> void:
+	var loop: SceneTree = Engine.get_main_loop() as SceneTree
+	if loop == null or claims_soft_reset(loop.current_scene):
+		return
+	soft_reset()
+
+
+## Whether the screen that is up has taken the chord for itself. Most have
+## nothing to say about it and leave the reset here.
+static func claims_soft_reset(scene: Node) -> bool:
+	return scene != null and scene.has_method(&"claim_soft_reset") \
+		and bool(scene.call(&"claim_soft_reset"))
+
+
+## Nothing of the run is written: what is on disk is what the last SAVE put
+## there, which is the point of the shortcut. The count is the one exception.
+func soft_reset() -> void:
+	count_soft_reset()
+	var loop: SceneTree = Engine.get_main_loop() as SceneTree
+	if loop != null:
+		loop.change_scene_to_file.call_deferred(SAVE_SCENE)
+
+
+## The open slot's reset count, raised by one in the file and in the shared save
+## object, or -1 with no slot open.
+func count_soft_reset() -> int:
+	var save: Gen2SaveData = selected_save_or_null()
+	if save == null:
+		return -1
+	var counted: int = Gen2SaveStore.bump_reset_count(
+		save.game_id, save.rom_sha1, save.slot
+	)
+	if counted >= 0:
+		save.reset_count = counted
+	return counted
 
 
 ## Brings the lower display up for the whole process rather than for the world: a
@@ -178,12 +229,10 @@ static func apply_display_options(options: Gen2Options) -> void:
 
 
 ## Discovers and runs every mod under [constant Gen2ModHost.ROOT], returning the
-## ids that loaded. The directory is created when it is absent so a player has
-## somewhere to put one without being told the path.
-##
-## [param game_id] is the cartridge a mod's `games` declaration is checked
-## against. Empty at boot, because the launcher lists what is installed before a
-## cartridge is chosen and an unrestricted list is the honest answer there.
+## ids that loaded. The directory is created when absent, so a player has
+## somewhere to put one without being told the path. [param game_id] is what a
+## mod's `games` declaration is checked against, and is empty at boot: the
+## launcher lists what is installed before a cartridge is chosen.
 func load_mods(game_id: StringName = &"") -> Array:
 	if not DirAccess.dir_exists_absolute(Gen2ModHost.ROOT):
 		DirAccess.make_dir_recursive_absolute(Gen2ModHost.ROOT)
@@ -211,14 +260,10 @@ func load_mods(game_id: StringName = &"") -> Array:
 	return _loaded_mods
 
 
-## Whether this process runs the mods it finds.
-##
-## A headless run or one driving a `-s` tool script is a check, a test tier or a
-## screenshot, and a mod that swaps the renderer or shuffles a table changes what
-## those measure without saying so anywhere in their output. Such a run discovers
-## mods, so a list is still right, and loads none unless `--mods` is passed. A
-## player's own launch is neither, so what they switched on in the launcher is
-## what runs.
+## Whether this process runs the mods it finds. A headless or `-s` run is a
+## check, a tier or a screenshot, and a mod that swaps the renderer changes what
+## those measure without saying so: it discovers mods and loads none unless
+## `--mods` is passed. A player's launch runs what the launcher switched on.
 static func mods_are_allowed() -> bool:
 	var args: PackedStringArray = OS.get_cmdline_args()
 	if args.has("--mods") or OS.get_cmdline_user_args().has("--mods"):
@@ -253,12 +298,9 @@ func select_game(game_id: StringName) -> bool:
 
 
 ## Reloads the mods a cartridge is entitled to, when the cartridge changes.
-##
-## Every mod's entry script runs again against a fresh host, because a `games`
-## declaration decides what a mod may register at all and a registration made for
-## the previous cartridge would outlive it. Reached only from
-## [method select_game], which the launcher calls on Play and after an import,
-## not while the player walks along the shelf.
+## Every entry script runs again against a fresh host, because a `games`
+## declaration decides what a mod may register and a registration made for the
+## previous cartridge would outlive it. Only [method select_game] reaches it.
 func _retarget_mods(game_id: StringName) -> void:
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	if host.target_game() == game_id:

--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -129,6 +129,7 @@ runs, since every version so far has only added.
 | 25 | `Gen2WorldAPI.party_with_player()` and `party_holder()`, and a visible encounter walking to the next cell |
 | 26 | A run button, and a scale on every experience award |
 | 27 | SMOOTH SCROLL reaching a span, an actor's pose and a walking wild, and `span` on an actor entry |
+| 28 | `height_offset_pixels` on an actor's drawn row, and `Gen2WorldAPI.jump_offset_for()` |
 
 ## Installing
 
@@ -1178,6 +1179,15 @@ Each entry of `sprites()` names cartridge art and nothing else:
 | `emote` | Optional. `Gen2WorldActors.EMOTE_SHOCK` through `EMOTE_GRASS_RUSTLE`, drawn two rows above the sprite as `SpawnEmote` puts one over a map object. It is state, not an edge: up for as long as the entry keeps asking. An index outside the twelve is no emote |
 | `span` | Optional `{from, to, progress, kind}`, the shape `Gen2WorldObject.step_span()` answers: the two cells this pose runs between. A view whose plan is a grid reads `position_cells` and ignores it; one that folds plan into height puts both ends through its own geometry, which a fractional cell cannot do across a fold. A span missing an end is dropped rather than drawn |
 
+`sprites()` answers one key more than a mod sends. `height_offset_pixels` is the
+hop's second axis, in world pixels and positive upward: zero unless the entry's
+`span` names one of `Gen2WorldAPI.JUMP_STEP_KINDS`, and otherwise the entry
+`UpdateJumpPosition`'s table is on at that span's `progress`. It is what makes an
+actor taking a ledge arc over it rather than slide through it, and a 3D view
+stands its card on it the way it stands the player's on
+`player_height_offset_pixels()`. There is no key to send for it: the span already
+says everything.
+
 The host resolves the strip, the palette, the time of day and the icon's two-frame
 animation, so a mod never composes pixels. An entry naming art the cache does not
 carry is dropped.
@@ -1669,7 +1679,9 @@ is drawn, in world pixels and positive upward, which is `UpdateJumpPosition`'s
 step, and on the frame the hop completes. Only a ledge hop and the three
 `jump_step` commands raise it, each covering two cells. Presentation only: the
 cell, the collision, the triggers and the snapshot are at the landing cell for the
-whole arc.
+whole arc. `Gen2WorldAPI.jump_offset_for(progress)` is that table read directly,
+for a caller holding a span's `progress` rather than a spent-and-total pair;
+`jump_offset_at(spent, total)` spends it.
 
 Not covered: the teleport, skyfall and dig step types. `teleport_from`,
 `teleport_to`, `skyfall` and `step_dig` reach the caller as a

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -745,3 +745,8 @@ func _print_allowlist() -> void:
 		lines.append("  %-8s %s" % [RomRegistry.title_for(id), RomRegistry.sha1_for(id)])
 	print("pokerecomp supported cartridges:")
 	print("\n".join(lines))
+
+
+## A reset lands here: nothing is behind the chord left to reset.
+func claim_soft_reset() -> bool:
+	return true

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -13,7 +13,7 @@ const FILENAME: String = "mod.json"
 ## number that says the seam is there: `docs/MODS.md` lists what each version
 ## added. An optional field a mod may send and an older host may drop is
 ## deliberately not a bump.
-const API_VERSION: int = 27
+const API_VERSION: int = 28
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -46,9 +46,7 @@ var party: Array = []
 ## Contest runs. The cartridge leaves them in `wPartyMon` and drops
 ## `wPartyCount` to 1; this project moves them here, so nothing that walks the
 ## party has to know about the mask. `ContestReturnMons` puts them back. Like
-## `mailbox` this defaults rather than versioning: an empty list is the truth
-## about a slot written before the mask existed and about every slot outside a
-## contest.
+## `mailbox` it defaults rather than versioning.
 var contest_stashed_party: Array = []
 var boxes: Array = []
 var world: Gen2WorldSnapshot = null
@@ -112,6 +110,10 @@ var mystery_gift: Dictionary = Gen2MysteryGift.default_section()
 ## dictionary is the truth about every other slot and about every slot written
 ## before the challenge existed. See [Gen2Nuzlocke].
 var nuzlocke: Dictionary = {}
+## How many times the run has been soft reset, which the cartridge has nowhere
+## to put. Written by [method Gen2SaveStore.bump_reset_count] alone, never
+## through this object, which holds the walk the reset throws away.
+var reset_count: int = 0
 
 
 func _init() -> void:
@@ -156,6 +158,7 @@ func to_dict() -> Dictionary:
 		"link_record": link_record.duplicate(true),
 		"mystery_gift": mystery_gift.duplicate(true),
 		"nuzlocke": nuzlocke.duplicate(true),
+		"reset_count": reset_count,
 		"box_names": box_names.duplicate(),
 		"mailbox": _mailbox_dicts(),
 		"world": world.to_dict() if world != null else {},
@@ -205,6 +208,7 @@ static func _read_header(out: Gen2SaveData, source: Dictionary) -> void:
 	out.link_record = Gen2LinkSession.normalize_record(source.get("link_record", {}))
 	out.mystery_gift = Gen2MysteryGift.normalize(source.get("mystery_gift", {}))
 	out.nuzlocke = Gen2Nuzlocke.normalize(source.get("nuzlocke", {}))
+	out.reset_count = maxi(int(source.get("reset_count", 0)), 0)
 
 
 static func _read_lists(out: Gen2SaveData, source: Dictionary) -> void:
@@ -289,8 +293,8 @@ static func _read_run(out: Gen2SaveData, source: Dictionary) -> void:
 ## slot label, 3 no player trainer ID (which migrates to zero rather than being
 ## invented, since a rolled ID would change an existing save's headbutt
 ## encounters), 4 neither gender nor a play timer, and 5 no per-mod namespace. The
-## `run` block joined version 6 after it shipped and is not a version of its own:
-## it defaults to nothing, which is the truth about a slot written before it.
+## The `run` block and the reset count joined version 6 after it shipped and are
+## not versions of their own: each defaults to nothing.
 static func migrate_dict(raw: Variant) -> Dictionary:
 	if not raw is Dictionary:
 		return {"ok": false, "message": "save data is not an object"}

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -102,10 +102,9 @@ func open_new_slot() -> bool:
 ## Starts a new game in the selected slot by running the cartridge's own intro.
 ## Nothing is written here: `NewGame` reaches `InitializeWorld` only after
 ## `PlayerProfileSetup` and `OakSpeech` have returned, so the slot is staged on
-## [GameRuntime] and [Gen2IntroScreen] writes it once the trainer has a name and a
-## gender, and abandoning the intro leaves no file behind. [param label] is the
-## save file's decorative name, optional; [param challenge] overrides the form's
-## own pick, which is what a test and a driver use.
+## [GameRuntime] and [Gen2IntroScreen] writes it once the trainer has a name and
+## a gender. [param label] is the file's decorative name and [param challenge]
+## overrides the form's own pick, which is what a driver uses.
 func create_new_game(label: String = "", challenge: StringName = &"") -> bool:
 	if _data == null:
 		_set_status(&"error", "New game unavailable.", "No imported cartridge cache is selected.")
@@ -368,6 +367,8 @@ func _refresh_details() -> void:
 	if save != null:
 		body.add_child(Gen2LauncherUI.muted(_palette, "Player: %s" % save.player_name))
 		body.add_child(Gen2LauncherUI.muted(_palette, "Mode: %s" % _challenge_title(save)))
+		## What a shiny hunt costs, and a number the cartridge could not keep.
+		body.add_child(Gen2LauncherUI.muted(_palette, "Resets: %d" % save.reset_count))
 		var over: bool = Gen2Nuzlocke.run_over(save.nuzlocke)
 		var save_actions: HFlowContainer = Gen2LauncherUI.actions()
 		body.add_child(save_actions)
@@ -918,3 +919,8 @@ func _set_status(kind: StringName, title: String, detail: String) -> void:
 		Gen2LauncherAudio.play(&"error")
 	if _shell != null:
 		_shell.toast().show_message(kind, title, detail)
+
+
+## A reset lands here: nothing is behind the chord left to reset.
+func claim_soft_reset() -> bool:
+	return true

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -310,13 +310,11 @@ static func create_development_save(data: GameData, slot: int) -> Gen2SaveData:
 
 
 ## Creates the source-shaped Crystal new-game save. Crystal initializes an empty
-## party before the player reaches Elm's Lab, and the imported GIVEPOKE script
-## creates the first party member later. The optional fourth argument remains
-## accepted for callers from the earlier development launcher but is deliberately
-## ignored, so a new save cannot skip the story handoff. [param random] rolls
-## wPlayerID, the one roll in this project that is an identity rather than a game
-## event, so an absent generator randomizes here instead of being refused; pass
-## one when a run has to reproduce itself, since GetTreeScore reads the result.
+## party before Elm's Lab and the imported GIVEPOKE script creates the first
+## member later; the fourth argument is accepted and ignored, so a new save
+## cannot skip the story handoff. [param random] rolls wPlayerID, the one roll
+## here that is an identity rather than a game event, so an absent generator
+## randomizes rather than being refused; pass one for a reproducible run.
 static func create_new_game(
 	data: GameData, slot: int, player_name: String, _starter_species: int = -1,
 	random: RandomNumberGenerator = null
@@ -370,6 +368,47 @@ static func delete_slot(game_id: StringName, rom_sha1: String, slot: int) -> boo
 		if FileAccess.file_exists(path) and DirAccess.remove_absolute(path) == OK:
 			removed = true
 	return removed
+
+
+## Adds one to the soft-reset count in a slot file and returns the new total, or
+## -1 when neither copy can be read. Patched into the document rather than
+## written through a [Gen2SaveData], which would persist the discarded walk.
+static func bump_reset_count(game_id: StringName, rom_sha1: String, slot: int) -> int:
+	if not _valid_slot(slot):
+		return -1
+	var primary: String = path_for(game_id, rom_sha1, slot)
+	var backup: String = backup_path_for(game_id, rom_sha1, slot)
+	var document: Dictionary = _read_document(primary)
+	if not bool(document.get("ok", false)):
+		document = _read_document(backup)
+	if not bool(document.get("ok", false)):
+		return -1
+	var body: Dictionary = document["data"]
+	var counted: int = maxi(int(body.get("reset_count", 0)), 0) + 1
+	body["reset_count"] = counted
+	var text: String = _wrap(JSON.stringify(body, "\t"))
+	if not bool(_write_file(primary, text).get("ok", false)):
+		return -1
+	_write_file(backup, text)
+	return counted
+
+
+## One slot copy as the object it stores, unvalidated and unmigrated.
+static func _read_document(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {"ok": false}
+	var file: FileAccess = FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {"ok": false}
+	var text: String = file.get_as_text()
+	file.close()
+	var container: Dictionary = _unwrap(text)
+	if not bool(container["ok"]):
+		return {"ok": false}
+	var parser := JSON.new()
+	if parser.parse(String(container["payload"])) != OK or parser.data is not Dictionary:
+		return {"ok": false}
+	return {"ok": true, "data": parser.data as Dictionary}
 
 
 static func _write_file(target: String, document: String) -> Dictionary:

--- a/game/world/world_actors.gd
+++ b/game/world/world_actors.gd
@@ -109,11 +109,10 @@ func refresh_pose() -> bool:
 
 ## A press of A that no cartridge object, background event or tile branch
 ## answered, offered to the actors in registration order; the first answering true
-## consumes it. [param cell] is the player's faced cell and [param facing] the
-## player's own, so an actor tests its own pose and the host never has to invent
-## an occupancy notion for a sprite that occupies nothing. Offered ONLY after
-## [method Gen2WorldAPI.interact] answered nothing, so no cartridge interaction
-## can be shadowed by a mod.
+## consumes it. [param cell] is the player's faced cell and [param facing] their
+## own, so an actor tests its own pose and the host invents no occupancy for a
+## sprite that occupies nothing. Offered ONLY after
+## [method Gen2WorldAPI.interact] answered nothing, so nothing is shadowed.
 func interact(cell: Vector2i, facing: int) -> bool:
 	for actor: Object in _actors:
 		if not actor.has_method(ACTOR_INTERACT_METHOD):
@@ -163,10 +162,10 @@ func _resolve_request(entry: Variant) -> Dictionary:
 	return {}
 
 
-## { sprite, facing, frame, position_cells, span, colors, emote }, sorted by the row
-## stood on and then by registration order, the way the map's own objects are.
-## `colors` is empty for everything but a visible encounter, and `emote` is
-## [constant EMOTE_NONE] unless the entry asked for one.
+## { sprite, facing, frame, position_cells, span, height_offset_pixels, colors,
+## emote }, sorted by the row stood on and then by registration order, the way
+## the map's own objects are. `colors` is empty but for a visible encounter, and
+## `emote` is [constant EMOTE_NONE] unless one was asked for.
 func sprites() -> Array:
 	return _sprites
 
@@ -210,6 +209,7 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 		int(row.get("facing", Gen2WorldSprite.FACING_DOWN)),
 		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
 	)
+	var span: Dictionary = _resolved_span(row)
 	return {
 		"sprite": sprite,
 		"facing": facing,
@@ -222,7 +222,10 @@ func _resolve(entry: Variant, order: int) -> Dictionary:
 		# that does not read this draws the ordinary palette and is not wrong.
 		"colors": row.get("colors", PackedColorArray()),
 		# `step_span`'s own shape, or empty: a fractional cell cuts across a fold.
-		"span": _resolved_span(row),
+		"span": span,
+		# The hop's second axis, so a view that folds plan into height stands a
+		# card on the arc rather than on the ground under it.
+		"height_offset_pixels": _span_height_offset_pixels(span),
 		# `SpawnEmote`'s bubble, two rows above the sprite. State rather than an
 		# edge: it is up for as long as the entry keeps asking, so the mod owns
 		# the duration and the host owns the pixels.
@@ -244,6 +247,14 @@ static func _resolved_span(row: Dictionary) -> Dictionary:
 		"progress": clampf(float(entry.get("progress", 0.0)), 0.0, 1.0),
 		"kind": StringName(entry.get("kind", &"step")),
 	}
+
+
+## [method Gen2WorldObject.height_offset_pixels] for an actor, off the span it
+## already carries: zero unless its kind is a hop.
+static func _span_height_offset_pixels(span: Dictionary) -> float:
+	if not Gen2WorldAPI.JUMP_STEP_KINDS.has(span.get("kind", &"")):
+		return 0.0
+	return float(-Gen2WorldAPI.jump_offset_for(float(span["progress"])))
 
 
 ## An out-of-range index is no emote rather than a wrong sheet, the way art the

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -852,9 +852,7 @@ func player_step_in_progress() -> bool:
 
 
 ## `UpdateJumpPosition`'s `.y_offsets`: the pixel a jumping sprite is drawn above
-## its own cell, one entry per frame of the hop. The accumulator the source
-## indexes it with is stepped by the step vector and halved, which over a hop's
-## two STEP_WALK halves is one entry a frame.
+## its own cell, one entry per frame of the hop.
 const JUMP_OFFSETS: Array[int] = [
 	-4, -6, -8, -10, -11, -12, -12, -12, -11, -10, -9, -8, -6, -4, 0, 0,
 ]
@@ -869,16 +867,20 @@ func player_jump_offset() -> int:
 	return jump_offset_at(spent, _player_step_passes_total)
 
 
-## The table entry a jump of [param total] frames is on after [param spent] of
-## them. `UpdateJumpPosition` indexes it with an accumulator stepped by the step
-## vector and halved, so a hop covering two cells in 16 frames advances one entry
-## a frame and every other duration covers the same table at its own rate: the
+## The table entry a hop is on [param progress] of the way through its flight.
+## `UpdateJumpPosition` indexes it with an accumulator stepped by the step vector
+## and halved, so every duration covers the same table at its own rate: the
 ## proportion is the accumulator.
+static func jump_offset_for(progress: float) -> int:
+	var index: int = floori(clampf(progress, 0.0, 1.0) * float(JUMP_OFFSETS.size()))
+	return JUMP_OFFSETS[clampi(index, 0, JUMP_OFFSETS.size() - 1)]
+
+
+## The same for a caller holding the passes rather than the proportion.
 static func jump_offset_at(spent: int, total: int) -> int:
 	if total <= 0:
 		return 0
-	var index: int = spent * JUMP_OFFSETS.size() / total
-	return JUMP_OFFSETS[clampi(index, 0, JUMP_OFFSETS.size() - 1)]
+	return jump_offset_for(float(spent) / float(total))
 
 
 ## How far above the ground the player is drawn this frame, in world pixels and

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -142,14 +142,11 @@ func set_fade(order: int, white_fill: bool = false) -> void:
 	queue_redraw()
 
 
-## Repaints the tiles the last animation frame rewrote.
-##
-## The sequence touches one or two of a tileset's tiles per frame, so recolouring
-## the whole strip was almost all of the frame's cost. A palette command is the
-## exception and recolours every tile drawn with that row, but it is still a
-## repaint of the strips already cached rather than a rebuild of them: the
-## graphics, the roof and the quads are all unchanged, and only the colours a
-## tile is written through are not.
+## Repaints the tiles the last animation frame rewrote. The sequence touches one
+## or two of a tileset's tiles per frame, so recolouring the whole strip was
+## almost all of the frame's cost. A palette command recolours every tile drawn
+## with that row and is still a repaint rather than a rebuild: the graphics, the
+## roof and the quads are unchanged, and only the colours are not.
 func refresh_animation() -> void:
 	if _animation == null or _atlas == null:
 		_rebuild_atlas()
@@ -392,10 +389,9 @@ func _palette_tables(palettes: Array) -> Array:
 ## [param cells] is [method Gen2BattleTransition.cells], [param tiles] the two
 ## tiles `LoadBattleTransitionGFX` loads as index buffers, and [param palette] the
 ## four colours the whole map is flooded with while a trainer's ball is up. An
-## empty palette is the wild branch, which floods nothing: its black tile is colour
-## 3 of whatever palette the cell was already drawn in, and every overworld
-## palette's colour 3 is the same (7,7,7), so both kinds of wedge come out the same
-## dark grey. [param order] is the flash's `wBGP`, applied to the background alone.
+## empty palette is the wild branch, which floods nothing: its black tile is
+## colour 3 of whatever palette the cell was drawn in, and every overworld
+## palette's colour 3 is (7,7,7). [param order] is the flash's `wBGP`.
 func set_transition(
 	cells: PackedByteArray, tiles: PackedByteArray, palette: PackedColorArray,
 	sprites: int = Gen2BattleTransition.SPRITES_ALL, opponent: int = -1,
@@ -559,14 +555,12 @@ func _subpixel_steps() -> int:
 	return maxi(1, int(surface.canvas_transform.get_scale().x))
 
 
-## Lays the map quads out under this frame's camera.
-##
-## The order is the order the cartridge's own buffer would be read in if it had
-## one this wide: the border block under everything, then each connected map
-## furthest first, then `wOverworldMapBlocks` itself over the top. That last one
-## is what keeps the three-block margin byte for byte the cartridge's -- a
-## connection strip stops at the `length` the macro stored, and a neighbour map
-## drawn whole does not -- so nothing a 20x18 screen can reach changes.
+## Lays the map quads out under this frame's camera, in the order the cartridge's
+## own buffer would be read in if it had one this wide: the border block under
+## everything, then each connected map furthest first, then `wOverworldMapBlocks`
+## over the top. That last one keeps the three-block margin byte for byte the
+## cartridge's, since a connection strip stops at the `length` the macro stored
+## and a neighbour map drawn whole does not.
 func _sync_map_layers() -> void:
 	if _world == null or _world.current_map == null or _world.current_tileset == null \
 		or _atlas == null:
@@ -958,9 +952,12 @@ func _draw_actor(sprite: Dictionary, camera_pixels: Vector2) -> void:
 	)
 	if texture == null:
 		return
-	draw_texture(texture, pixel)
+	# The same sprite offset an object's `jump_step` takes, so an actor on a
+	# ledge arcs over it rather than sliding through it.
+	var jump := Vector2(0, -float(sprite.get("height_offset_pixels", 0.0)))
+	draw_texture(texture, pixel + jump)
 	if _in_grass(Vector2i(roundi(cell_position.x), roundi(cell_position.y))):
-		_draw_grass_over(pixel, _background_camera())
+		_draw_grass_over(pixel + jump, _background_camera())
 	## The same bubble a map object's `showemote` puts up, over an actor that
 	## asked for one. Drawn after the grass, as an object's is: `SpawnEmote` is
 	## its own OAM and stands over the tuft rather than behind it.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -18,6 +18,8 @@ const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 ## This port's boot menu, where a cartridge taken out goes.
 const LAUNCHER_SCENE: String = "res://game/main/main.tscn"
 const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
+## Where `JUMP_OFFSETS` is at its highest, for [method preview_pet_actor_arc].
+const PREVIEW_ARC_TOP_PROGRESS: float = 0.4
 ## How far into a view switch's close [method preview_view_cover] photographs:
 ## part way down the scatter, where the wipe is readable and the screen is not
 ## yet black.
@@ -3262,6 +3264,19 @@ func preview_pet_actor() -> void:
 	_refresh_labels()
 
 
+## The same actor mid-ledge, photographing `height_offset_pixels` in the picture.
+func preview_pet_actor_arc() -> void:
+	if _world == null or _actors == null or _renderer == null:
+		return
+	_world.player_facing = Gen2WorldSprite.FACING_UP
+	var pet := PreviewPet.new(_world)
+	pet.jump_progress = PREVIEW_ARC_TOP_PROGRESS
+	_actors.set_actors([pet])
+	_actors.refresh_pose()
+	_script_prompt = "Debug actor arc preview"
+	_refresh_labels()
+
+
 ## What a mod's actor is, in the fewest lines that exercise the optional half.
 class PreviewPet extends RefCounted:
 	const CYNDAQUIL: int = 155
@@ -3269,6 +3284,8 @@ class PreviewPet extends RefCounted:
 	var _world: Gen2WorldAPI = null
 	var _petted: bool = false
 	var _cried: bool = false
+	## Below zero stands; at or above it the entry carries a `jump_step` span.
+	var jump_progress: float = -1.0
 
 	func _init(world: Gen2WorldAPI) -> void:
 		_world = world
@@ -3287,6 +3304,11 @@ class PreviewPet extends RefCounted:
 		}
 		if _petted:
 			entry["emote"] = Gen2WorldActors.EMOTE_HEART
+		if jump_progress >= 0.0:
+			entry["span"] = {
+				"from": _cell() + Vector2i.DOWN, "to": _cell() + Vector2i.UP,
+				"progress": jump_progress, "kind": Gen2WorldAPI.STEP_KIND_HOP,
+			}
 		return [entry]
 
 	func interact(cell: Vector2i, _facing: int) -> bool:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -15,11 +15,8 @@ const FLOWER_MAIL: int = 0xB6
 const SERVICE_SCENE: PackedScene = preload("res://game/world/world_service_screen.tscn")
 const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_screen.tscn")
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
-## The launcher is this port's boot menu and the save screen is its title
-## screen, so a cartridge taken out goes to the first and a console reset to the
-## second, where CONTINUE is.
+## This port's boot menu, where a cartridge taken out goes.
 const LAUNCHER_SCENE: String = "res://game/main/main.tscn"
-const SAVE_SCENE: String = "res://game/save/save_screen.tscn"
 const AUDIO_PLAYER_SCRIPT := preload("res://game/audio/gen2_audio_player.gd")
 ## How far into a view switch's close [method preview_view_cover] photographs:
 ## part way down the scatter, where the wipe is readable and the screen is not
@@ -353,8 +350,6 @@ func _ready() -> void:
 	_data = _injected_data if _injected_data != null else _selected_runtime_data()
 	_build_world()
 	var input: Gen2InputRuntime = Gen2InputRuntime.instance()
-	if input != null and not input.reset_chord_pressed.is_connected(_on_reset_chord):
-		input.reset_chord_pressed.connect(_on_reset_chord)
 	if input != null and not input.back_requested.is_connected(_on_back_requested):
 		input.back_requested.connect(_on_back_requested)
 
@@ -1925,15 +1920,17 @@ func _end_nuzlocke_run(save: Gen2SaveData) -> void:
 	## lists what the run caught and what it lost, and it will not open this one
 	## again.
 	if is_inside_tree():
-		get_tree().change_scene_to_file.call_deferred(SAVE_SCENE)
+		get_tree().change_scene_to_file.call_deferred(Gen2GameRuntime.SAVE_SCENE)
 
 
-## `Reset`, which on hardware is the four buttons wired straight to the console
-## and nothing the game may decline. Nothing is written: what is on disk is what
-## the last SAVE put there, which is the whole point of the shortcut.
+## `Reset`, the four buttons wired straight to the console. What one costs is
+## [Gen2GameRuntime]'s, which answers the chord for every screen.
 func _soft_reset() -> void:
-	if is_inside_tree():
-		get_tree().change_scene_to_file.call_deferred(SAVE_SCENE)
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	if runtime != null:
+		runtime.soft_reset()
+	elif is_inside_tree():
+		get_tree().change_scene_to_file.call_deferred(Gen2GameRuntime.SAVE_SCENE)
 
 
 ## Offered as a B, which backs out of whatever owns the screen. Nothing on a
@@ -1943,21 +1940,18 @@ func _on_back_requested() -> void:
 		press_button(Gen2Button.START)
 
 
-## The reset chord, from anywhere the world is up. The first one ever asks first,
-## over the pause menu's own box, so a player who hit four buttons by accident
-## does not lose the walk between here and their last save; after that answer it
-## resets where it is pressed. A fight or an overlay owning the screen has no
-## room for the question, so the first chord there is refused and the second,
-## once the question has been answered on the map, is not.
-func _on_reset_chord() -> void:
-	if _world == null:
-		return
-	if Gen2OptionsStore.current().soft_reset_acknowledged:
-		_soft_reset()
-		return
+## The first chord ever asks over the pause menu's own box, so four buttons hit
+## by accident do not cost the walk since the last save. Only that one is
+## claimed, and only where there is room for the box: a fight owns the screen,
+## and a chord there resets rather than being swallowed.
+func claim_soft_reset() -> bool:
+	if _world == null or Gen2OptionsStore.current().soft_reset_acknowledged:
+		return false
+	var before: Gen2StartMenuScreen = _start_menu_host
 	_open_start_menu_host(func(host: Gen2StartMenuScreen) -> void:
 		host.ask_soft_reset()
 	)
+	return _start_menu_host != null and _start_menu_host != before
 
 
 ## One player event's lines put up in order, the tail run once the last has been

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 27,
+	"api_version": 28,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage, a page of its own with a second row that opens it, and a banner over the map raised when the run's progress moves."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 27,
+	"api_version": 28,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/integration/test_input_runtime.gd
+++ b/tests/integration/test_input_runtime.gd
@@ -2,6 +2,8 @@ extends GutTest
 
 ## The live scheme and the active device, driven the way the game drives them.
 
+const Fixture := preload("res://tests/unit/battle_fixture.gd")
+
 var _runtime: Gen2InputRuntime = null
 
 
@@ -261,3 +263,82 @@ func test_the_back_notification_is_reported_as_a_signal() -> void:
 		ProjectSettings.get_setting("application/config/quit_on_go_back", true),
 		"the engine must not quit before a screen has answered",
 	)
+
+
+## The chord is the console's, so it belongs to the process rather than to the
+## overworld. It used to be connected in the world screen alone, which left the
+## opening, the launcher and every menu over the map with no answer to it at
+## all, and a battle, where a shiny hunter presses it, swallowing the first one.
+func test_the_chord_is_owned_by_the_runtime_for_every_screen() -> void:
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	assert_eq(
+		_runtime.reset_chord_pressed.is_connected(runtime._on_reset_chord),
+		Gen2GameRuntime.is_player_launch(),
+		"one owner, and it is not a screen; a tier is not a player"
+	)
+	assert_false(
+		Gen2GameRuntime.claims_soft_reset(null),
+		"no scene is not a screen that took the chord"
+	)
+	var plain := Node.new()
+	assert_false(
+		Gen2GameRuntime.claims_soft_reset(plain),
+		"a screen with nothing to say leaves the reset to the runtime"
+	)
+	plain.free()
+	## The launcher's own answer: a reset lands on the title screen, so a chord
+	## pressed on the boot menu has nothing behind it to reset.
+	var claiming := Control.new()
+	claiming.set_script(preload("res://game/main/main.gd"))
+	assert_true(Gen2GameRuntime.claims_soft_reset(claiming))
+	claiming.free()
+
+
+## What a shiny hunt is measured in. The count has to reach the file, because
+## the reset it counts takes the process with it, and it has to reach the shared
+## save object too, so the page drawn next says the same number.
+func test_a_reset_counts_against_the_open_slot_and_reaches_the_file() -> void:
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	var game: StringName = runtime.selected_game_id
+	var slot: int = runtime.selected_save_slot
+	var directory: String = RomCache.directory_for(&"resettest", "0123456789abcdef")
+	var data: GameData = Fixture.build(directory)
+	var mon: Gen2BattleMon = Gen2BattleMon.create(
+		data, Fixture.PIKACHU, 20, [Fixture.TACKLE], Gen2BattleMon.PERFECT_DVS
+	)
+	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
+		data.id, data.sha1, 0, Gen2Party.create([mon]), "RED"
+	)
+	assert_true(Gen2SaveStore.save(save, data)["ok"])
+	## Primed rather than selected: the fixture cache is not a cartridge the
+	## registry knows, and what is under test is the count rather than the load.
+	runtime.selected_game_id = data.id
+	runtime.selected_save_slot = 0
+	runtime._save = save
+	runtime._save_key = "%s:%d" % [data.id, 0]
+
+	assert_eq(runtime.count_soft_reset(), 1, "the first reset of the hunt")
+	assert_eq(save.reset_count, 1, "and the page reads it")
+	var reloaded: Dictionary = Gen2SaveStore.load_result(data.id, data.sha1, 0, data)
+	assert_eq((reloaded["save"] as Gen2SaveData).reset_count, 1, "the file has it")
+
+	runtime.selected_game_id = game
+	runtime.selected_save_slot = slot
+	runtime.reload_selected_save()
+	for copy: String in [
+		Gen2SaveStore.path_for(data.id, data.sha1, 0),
+		Gen2SaveStore.backup_path_for(data.id, data.sha1, 0),
+	]:
+		DirAccess.remove_absolute(copy)
+	DirAccess.remove_absolute(Gen2SaveStore.directory_for(data.id, data.sha1))
+	RomCache.clear(directory)
+
+
+## Nothing to count against is answered rather than invented: a development run
+## with no slot open still resets, it just records nothing.
+func test_a_reset_with_no_slot_counts_nothing() -> void:
+	var runtime: Gen2GameRuntime = Gen2GameRuntime.instance()
+	var slot: int = runtime.selected_save_slot
+	runtime.selected_save_slot = -1
+	assert_eq(runtime.count_soft_reset(), -1)
+	runtime.selected_save_slot = slot

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -196,7 +196,7 @@ func test_the_reset_question_is_asked_once_and_answered_either_way() -> void:
 	Gen2OptionsStore.save(options)
 
 	await _open_world()
-	_world_screen._on_reset_chord()
+	assert_true(_world_screen.claim_soft_reset(), "the chord is claimed to ask")
 	await get_tree().process_frame
 	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
 	assert_not_null(host, "the chord opened the menu to ask")
@@ -212,6 +212,29 @@ func test_the_reset_question_is_asked_once_and_answered_either_way() -> void:
 	assert_true(
 		Gen2OptionsStore.current().soft_reset_acknowledged,
 		"and is never asked again"
+	)
+	assert_false(
+		_world_screen.claim_soft_reset(),
+		"an answered chord is the runtime's to carry out"
+	)
+
+
+## The chord a shiny hunter actually presses is the one inside a battle, and the
+## screen there has no room for the question. It used to be swallowed with
+## nothing said, so the first four buttons of a hunt did nothing at all.
+func test_a_chord_with_no_room_for_the_question_is_left_to_the_runtime() -> void:
+	Gen2OptionsStore.use_test_path()
+	var options: Gen2Options = Gen2OptionsStore.current()
+	options.soft_reset_acknowledged = false
+	Gen2OptionsStore.save(options)
+
+	await _open_world()
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	assert_not_null(_world_screen._start_menu_host, "something owns the screen")
+	assert_false(
+		_world_screen.claim_soft_reset(),
+		"no room to ask, so the reset happens rather than nothing"
 	)
 
 

--- a/tests/unit/test_save_slots.gd
+++ b/tests/unit/test_save_slots.gd
@@ -219,3 +219,38 @@ func test_a_save_from_a_later_format_is_refused_rather_than_guessed_at() -> void
 	raw["format_version"] = Gen2SaveData.FORMAT_VERSION + 1
 
 	assert_false(Gen2SaveData.migrate_dict(raw)["ok"])
+
+
+## The count survives the reset because it is patched into the file rather than
+## written through the save the reset is throwing away. Everything else in the
+## document has to come back unchanged, so the round trip through JSON is
+## asserted rather than assumed.
+func test_the_reset_count_is_patched_into_the_slot_and_nothing_else_moves() -> void:
+	var save: Gen2SaveData = _write_slot(0)
+	var before: Dictionary = save.to_dict()
+
+	assert_eq(Gen2SaveStore.bump_reset_count(_data.id, _data.sha1, 0), 1)
+	assert_eq(Gen2SaveStore.bump_reset_count(_data.id, _data.sha1, 0), 2)
+
+	var reloaded: Gen2SaveData = Gen2SaveStore.load_result(
+		_data.id, _data.sha1, 0, _data
+	)["save"]
+	assert_eq(reloaded.reset_count, 2)
+	before["reset_count"] = 2
+	assert_eq(reloaded.to_dict(), before, "the rest of the slot is untouched")
+
+
+## The backup carries the same number, so a slot recovered from it does not
+## forget the hunt.
+func test_the_backup_copy_is_counted_too() -> void:
+	_write_slot(0)
+	Gen2SaveStore.bump_reset_count(_data.id, _data.sha1, 0)
+	DirAccess.remove_absolute(Gen2SaveStore.path_for(_data.id, _data.sha1, 0))
+	var recovered: Dictionary = Gen2SaveStore.load_result(_data.id, _data.sha1, 0, _data)
+	assert_true(recovered["ok"], String(recovered["message"]))
+	assert_eq((recovered["save"] as Gen2SaveData).reset_count, 1)
+
+
+func test_counting_an_empty_slot_refuses_rather_than_writing_one() -> void:
+	assert_eq(Gen2SaveStore.bump_reset_count(_data.id, _data.sha1, 3), -1)
+	assert_false(Gen2SaveStore.exists(_data.id, _data.sha1, 3))

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1200,6 +1200,20 @@ func test_a_ledge_hop_lifts_the_sprite_and_an_ordinary_step_does_not() -> void:
 	assert_eq(highest, 12.0, "the top of .y_offsets, above the ground")
 	assert_eq(lifted.player_height_offset_pixels(), 0.0, "and back down on landing")
 
+	## Every reader since SMOOTH SCROLL holds a progress rather than a
+	## spent-and-total pair, and the two spellings have to answer the same entry
+	## at every duration the source hops at.
+	for total: int in [Gen2WorldAPI.STEP_PASSES_HOP, 8, 12, 16, 32]:
+		for spent: int in total + 1:
+			assert_eq(
+				Gen2WorldAPI.jump_offset_at(spent, total),
+				Gen2WorldAPI.jump_offset_for(float(spent) / float(total)),
+				"%d of %d" % [spent, total]
+			)
+	assert_eq(Gen2WorldAPI.jump_offset_at(1, 0), 0, "a hop of no passes is flat")
+	assert_eq(Gen2WorldAPI.jump_offset_for(-1.0), Gen2WorldAPI.JUMP_OFFSETS[0])
+	assert_eq(Gen2WorldAPI.jump_offset_for(2.0), Gen2WorldAPI.JUMP_OFFSETS[-1])
+
 	var walker: Gen2WorldAPI = _world(Vector2i(5, 11))
 	assert_true(bool(walker.move_result(Vector2i.UP).get("ok", false)))
 	assert_eq(walker.player_jump_offset(), 0)

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -273,6 +273,55 @@ func test_an_actor_entry_carries_a_span_and_a_broken_one_is_dropped() -> void:
 	RomCache.clear(ActorFixture.directory())
 
 
+## An actor taking a ledge arcs over it, off the same table a map object's
+## `jump_step` is on. Drawn flat, the follower slid through the ledge in 2D and
+## down the face in 3D, because nothing answered a height for it.
+func test_an_actor_on_a_jump_span_is_lifted_by_the_source_table() -> void:
+	var world: Gen2WorldAPI = _actor_world()
+	var actor := TestActor.new()
+	var actors := Gen2WorldActors.new()
+	actors.set_actors([actor])
+	actors.set_world(world)
+
+	var highest: float = 0.0
+	for step: int in 17:
+		var progress: float = float(step) / 16.0
+		actor.out = [{
+			"icon": 1, "position_cells": Vector2(4, 4),
+			"span": {
+				"from": Vector2i(4, 5), "to": Vector2i(4, 3),
+				"progress": progress, "kind": &"jump_step",
+			},
+		}]
+		actors.refresh_pose()
+		var lift: float = float(actors.sprites()[0]["height_offset_pixels"])
+		assert_eq(
+			lift, float(-Gen2WorldAPI.jump_offset_for(progress)),
+			"the entry the table is on at %f" % progress
+		)
+		highest = maxf(highest, lift)
+	assert_eq(highest, 12.0, "`.y_offsets` tops out twelve pixels up")
+	assert_eq(
+		float(actors.sprites()[0]["height_offset_pixels"]), 0.0,
+		"and back on the ground where it lands"
+	)
+
+	## Every other kind is flat, including the one a span defaults to.
+	for kind: Variant in [&"step", &"turn", null]:
+		var span: Dictionary = {"from": Vector2i(4, 5), "to": Vector2i(4, 4), "progress": 0.5}
+		if kind != null:
+			span["kind"] = kind
+		actor.out = [{"icon": 1, "position_cells": Vector2(4, 4), "span": span}]
+		actors.refresh_pose()
+		assert_eq(float(actors.sprites()[0]["height_offset_pixels"]), 0.0, str(kind))
+
+	## An entry with no span at all still answers the key rather than nothing.
+	actor.out = [{"icon": 1, "position_cells": Vector2(4, 4)}]
+	actors.refresh_pose()
+	assert_eq(float(actors.sprites()[0]["height_offset_pixels"]), 0.0, "no span, no lift")
+	RomCache.clear(ActorFixture.directory())
+
+
 ## `.Frameset_PartyMon`: two sets of eight, nine passes each.
 func test_an_icon_actor_steps_the_strips_two_frames_at_the_framesets_rate() -> void:
 	var world: Gen2WorldAPI = _actor_world()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -25,6 +25,7 @@ const KIND_HELP: Dictionary = {
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
+	&"pet_actor_arc": "cell: the same actor mid-ledge, at the top of the arc its span names",
 	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
 	&"script_fade": "special, frames: one of the five fade specials over the map",
 	&"door": "door mat: .CheckWarp's carpet, standing on an interior door's mat",


### PR DESCRIPTION
Two things: the reset chord, and the arc a mod's actor was missing.

## The reset chord answers everywhere, and the slot counts it

A + B + START + SELECT was connected in the overworld screen alone, and the first chord ever had to open the pause menu to ask before it would reset. A fight, an overlay or a script owns that screen and the box could not be drawn, so the chord was swallowed with nothing said. That is exactly where a shiny hunter presses it. Every screen that is not the overworld had no answer to the chord at all: the opening, the launcher and the save screen ignored it.

The chord now belongs to `Gen2GameRuntime`, which answers it for whatever scene is up. A screen with something of its own to do about it says so from `claim_soft_reset`: the overworld claims the first chord only where there is room for the question, and the launcher and the save screen claim it because a reset already lands there. Everything else resets the way the console does. Nothing changed about which buttons produce the chord, so a keyboard, a controller and four fingers on the on-screen pad all reach it.

`Gen2SaveData.reset_count` records how many resets a slot has spent, and the save page shows it under Mode. It is patched into the slot file by `Gen2SaveStore.bump_reset_count` rather than written through the in-memory save, which still holds the walk the reset is throwing away, so a reset persists the count and nothing else.

README's SELECT row said Shift; the binding is Tab.

## An actor arcs on the span it already names

The mods repository asked for this one. An actor entry may carry a span whose kind is a jump, and nothing drew it as one: `Gen2WorldActors._resolve` answered no height and `_draw_actor` added none, where `_draw_row_entries` gives a map object `height_offset_pixels()` two lines above. A follower taking the ledge the player just hopped crossed the two cells flat, through the ledge in 2D and down the face in 3D.

The drawn row now carries `height_offset_pixels`, read off the span's own `kind` and `progress`, and `_draw_actor` lifts the picture by it. Exposing it on the row rather than only drawing it is the half a 3D view needs: it already takes a height per card and had nothing to pass. No new entry key, since the span says everything.

`Gen2WorldAPI.jump_offset_for(progress)` is `UpdateJumpPosition`'s table read directly, for the readers holding a progress rather than a spent-and-total pair since SMOOTH SCROLL; `jump_offset_at(spent, total)` spends it. Mod API 28, and `preview_world.gd`'s new `pet_actor_arc` photographs the arc.

## Checks

| Check | Result |
|---|---|
| Unit tier | 3486 passing |
| Scene tier | 4080 passing, 8 new cases |
| Warning scan | 0 warnings in 601 scripts |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 6 steps each, 0 failures |
| Screenshots | `pet_actor` beside `pet_actor_arc`, and the save page's Resets line |