### PR TITLE
The trade animation plays, and a cartridge agrees with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ download the new file and replace the old one. Saves live elsewhere and survive.
 >   file you are told your friend is not ready, which is what one Game Boy has
 >   always been told.
 >
-> Missing: the trade animation, and some pixel-level divergences in the opening
-> movies and title screen.
+> Missing: some pixel-level divergences in the opening movies and title screen.
 
 ## Getting started
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -4,7 +4,6 @@ extends RefCounted
 ## A decoded cartridge, read back out of the cache: the importer's counterpart
 ## and the only way the engine sees cartridge content. [RefCounted] and
 ## scene-free, so a battle or menu can run in a test.
-##
 ## JSON has one number type, so every cached number returns as a float and every
 ## comparison against an int quietly fails; coercion happens here, once. Index
 ## buffers and world sections load on first use, because reading them at open()
@@ -84,6 +83,7 @@ var _slots_text: Dictionary = {}
 var _card_flip: Dictionary = {}
 var _card_flip_text: Dictionary = {}
 var _gs_intro: Dictionary = {}
+var _trade_anim: Dictionary = {}
 var _menu_text: Dictionary = {}
 var _mart_text: Dictionary = {}
 var _name_rater_text: Dictionary = {}
@@ -187,6 +187,7 @@ const MANIFEST_DICTIONARIES: Dictionary = {
 	"card_flip": "_card_flip",
 	"card_flip_text": "_card_flip_text",
 	"gs_intro": "_gs_intro",
+	"trade_anim": "_trade_anim",
 	"menu_text": "_menu_text",
 	"mart_text": "_mart_text",
 	"name_rater_text": "_name_rater_text",
@@ -795,7 +796,6 @@ func world_encounter_count(method: StringName) -> int:
 
 ## One battle animation region: the cached bytes plus the bank and address the
 ## cartridge holds them at, so an in-bank pointer resolves by subtraction.
-##
 ## [param name] is `scripts`, `objects`, `framesets` or `oam_sets`. Answers
 ## [code]{ bank, address, count, data }[/code], empty when the section is absent
 ## or the name is not one of the four.
@@ -814,7 +814,6 @@ func battle_anim_region(name: StringName) -> Dictionary:
 
 ## Where one animation's script starts, as the cartridge addresses it, or -1
 ## when the index is outside `BattleAnimations`.
-##
 ## The table is the first bytes of the scripts region, so this reads it rather
 ## than a copy: index 0 is `BattleAnim_Dummy` and the rest are move numbers.
 func battle_anim_address(index: int) -> int:
@@ -1044,7 +1043,6 @@ func overworld_sprite_palette(palette_index: int, time_of_day: int) -> PackedCol
 
 
 ## One of the cartridge's four-colour background palette groups.
-##
 ## Decoded once and kept: there are forty-two groups, they never change, and the
 ## overworld asks for them again every time an animated tile redraws the atlas.
 func world_palette(number: int) -> PackedColorArray:
@@ -1065,7 +1063,6 @@ func world_palette(number: int) -> PackedColorArray:
 ## The three tilesets `home/map.asm` gates `LoadMapGroupRoof` on: "These tilesets
 ## support dynamic per-mapgroup roof tiles." Every other tileset owns tiles
 ## $0A..$12 itself, so writing a roof over them is the map's own art destroyed.
-##
 ## pokegold ships no `TilesetBattleTowerOutside` and its gate is the two Johto
 ## rows alone, which is also why every tileset past index 3 sits one lower
 ## there; the numbers below are each pin's own.
@@ -1138,7 +1135,6 @@ func roof_palette(map_group: int, night: bool) -> PackedColorArray:
 ## a map group's nine roof tiles are copied over `vTiles2 tile $0a`, so they
 ## replace whatever the tileset's own strip holds there. A group with no roof
 ## (`cp -1 / ret z`) is handed its strip back unchanged.
-##
 ## [param roof] is [method map_group_roof]'s answer, passed in rather than a map,
 ## because the overworld's animated strip goes through here on every pass that
 ## rotates a tile and the group is already resolved by then.
@@ -1185,7 +1181,6 @@ func world_animation_asset(name: String) -> PackedByteArray:
 
 
 ## Indexed 2bpp pixels for one tileset's overworld tiles, loaded on demand.
-##
 ## The strip is [constant RomLayout.TILESET_TILE_COUNT] tiles wide and is indexed
 ## by the metatile byte itself, so both graphics blocks are addressable; see that
 ## constant for what sits where.
@@ -1206,7 +1201,6 @@ func species(number: int) -> Dictionary:
 
 ## A species' level-up moves, in the cartridge's own order, as
 ## { level, move } with both coerced back to int.
-##
 ## The order is not sorted and must not be: it decides which four moves a fresh
 ## Pokémon ends up with, and one species' list genuinely is out of order. See
 ## [Gen2Learnset], which is what turns this into an answer.
@@ -1216,7 +1210,6 @@ func learnset(number: int) -> Array:
 
 ## How a species evolves, as { method, parameter, condition, target }. Empty for
 ## the ones that do not.
-##
 ## [code]method[/code] is one of the [code]RomLayout.EVOLVE_*[/code] constants and
 ## decides what [code]parameter[/code] means: a level, an item, a held item or a
 ## time of day. [code]condition[/code] is only ever set by
@@ -1228,7 +1221,6 @@ func evolutions(number: int) -> Array:
 ## The moves a species can inherit from its father, in `EggMovePointers`' own
 ## order. Empty for the 145 or 146 species that inherit none, and for a mod
 ## species that named none.
-##
 ## Move numbers alone: an egg move has no level, unlike a [method learnset] row.
 ## Which of them a hatched Pokémon actually knows is the breeding rule rather
 ## than this table: [method Gen2WorldDayCare.inherits_move] is that rule, and this
@@ -1242,7 +1234,6 @@ func egg_moves(number: int) -> Array[int]:
 
 ## A species' Pokedex entry as { category, height, weight, pages }, or an empty
 ## Dictionary if there is no such number.
-##
 ## [code]height[/code] and [code]weight[/code] are the cartridge's own numbers,
 ## not measurements: see [method RomImporter.read_dex_entry]. [code]pages[/code]
 ## is the two description pages, in order. It goes through [method species] so a
@@ -1420,7 +1411,6 @@ func mail_palette(index: int) -> PackedColorArray:
 
 ## Which `text_buffer` argument a `TX_RAM` address names, or -1 for an address
 ## this cartridge does not use as a string buffer.
-##
 ## `TextCommand_RAM` prints from a raw WRAM pointer while `getstring` and
 ## `verbosegiveitem` fill buffers by number, so a runner that only knows the
 ## numbers cannot answer a `text_ram`. StringBufferPointers is the way across.
@@ -1518,7 +1508,6 @@ func _matchup_row(key: int) -> Dictionary:
 ## How effective [param attacking] is against a defender of one or two types, in
 ## tenths, accumulated the way the cartridge accumulates it: start at ten,
 ## multiply by each matching type in turn, truncate after each.
-##
 ## The number a battle announces, not the one it deals damage with. The hardware
 ## computes them separately and they disagree: a move resisted by both halves of
 ## a dual type reports 2 rather than 2.5. Use [method type_matchup] per type for
@@ -1592,7 +1581,6 @@ func card_palette(slot: int) -> PackedColorArray:
 
 ## One of the eight `PAL_BATTLE_OB_*` object palettes an animation object is
 ## drawn with, whole.
-##
 ## Slots 0 and 1 are the two battlers' own and are not in the table:
 ## `_CGB_BattleScreenLayout` fills them from whoever is on the field, so a caller
 ## passes those two in as [param enemy] and [param player] pairs. Everything from
@@ -1804,7 +1792,6 @@ func pokecenter_pc_row(name: String, players: bool = false) -> String:
 
 ## `.WhichPC`: which rows each of the menu's per-state lists offers, as indices
 ## into the row order above. Empty on a cache imported without them.
-##
 ## JSON numbers come back as floats, so the rows are converted here rather than
 ## at every reader.
 func pokecenter_pc_lists(players: bool = false) -> Array:
@@ -1989,6 +1976,26 @@ func gs_intro_map(name: String) -> PackedByteArray:
 ## for the entries the scenes take out of `PredefPals`.
 func gs_intro_palette(name: String) -> PackedColorArray:
 	var stored: Variant = (_gs_intro.get("palettes", {}) as Dictionary).get(name, [])
+	var colors := PackedColorArray()
+	if not stored is Array:
+		return colors
+	for packed: Variant in stored as Array:
+		colors.append(Gen2Palette.from_packed(int(packed)))
+	return colors
+
+
+## All three cartridges ship the art, so a false here is an old cache.
+func has_trade_anim() -> bool:
+	return not (_trade_anim.get("maps", []) as Array).is_empty()
+
+
+## One of the trade animation's two tilemaps, in tile numbers.
+func trade_anim_tilemap(name: String) -> PackedByteArray:
+	return tile_indices("trade_anim_%s" % name)
+
+
+func trade_anim_palette(name: String) -> PackedColorArray:
+	var stored: Variant = (_trade_anim.get("palettes", {}) as Dictionary).get(name, [])
 	var colors := PackedColorArray()
 	if not stored is Array:
 		return colors
@@ -2719,7 +2726,6 @@ func tile_indices(name: String) -> PackedByteArray:
 
 
 ## Where a species sits in its atlas, and how much of that cell it fills.
-##
 ## Cells are the size of the largest pic of their kind so a slot can be found by
 ## arithmetic; a smaller pic sits in the top-left of its cell and the rest is
 ## blank. Returns { atlas, slot, width, height } in pixels, or an empty
@@ -2777,7 +2783,6 @@ func egg_palette(shiny: bool = false) -> PackedColorArray:
 
 ## A mod's own picture for a numbered row, in [method species_pic]'s shape but
 ## carrying the pixels instead of an atlas cell to crop.
-##
 ## The atlases hold exactly the cartridge's slots, so a defined species or
 ## trainer class has no cell to point at and supplies decoded indices on its own
 ## row instead. [method Gen2PicImage.atlas_cell] takes either, which is what lets
@@ -2820,7 +2825,6 @@ func species_pic_animation(number: int, unown_form: int = 0) -> Dictionary:
 ## `AnimateFrontpic`'s record for a species, or for one of Unown's letters when
 ## [param unown_form] is a letter rather than zero: { height, script, idle,
 ## frames }, the scripts and each frame as a [PackedByteArray].
-##
 ## Empty for Gold and Silver, which have no pic animation at all, and for an egg:
 ## `AnimateMon_CheckIfPokemon` refuses `EGG` before anything is read, so the
 ## cartridge's own egg tables are never reached through here.
@@ -3228,7 +3232,6 @@ func _coerce_service_value(value: Variant, blob: PackedByteArray) -> Variant:
 
 
 ## Resolves one cached byte run, whichever way the cache holds it.
-##
 ## A record carrying a [constant RomCache.PAYLOAD_KEY] is a span into the
 ## section's blob. A bare Array is read inline, which is what a hand-written test
 ## fixture holds. The two never have to be told apart by shape: the key says

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 97
+const FORMAT_VERSION: int = 98
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a
@@ -368,7 +368,6 @@ static func read_json(path: String) -> Variant:
 
 
 ## One cached grid of cartridge bytes, packed on the way out of JSON.
-##
 ## A JSON number returns as a float, and an Array of them costs about twenty-six
 ## resident bytes per cartridge byte. Map block, map collision and tileset lookup
 ## tables are byte grids read once per drawn tile and resident for every map at
@@ -406,7 +405,6 @@ static func write_payload_map(
 
 ## Writes a section whose byte runs are named fields rather than whole values,
 ## as the audio records and the standard-script table are.
-##
 ## Only a [code]bytes[/code] field holding an array is moved. Nothing else is
 ## touched: plenty of cached arrays are small numbers without being cartridge
 ## payloads, and a mart list or an encounter rate must stay an array.

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -162,6 +162,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	verify_slots,
 	verify_printer,
 	verify_link_border,
+	verify_trade_anim,
 	verify_card_flip,
 	verify_credits,
 	verify_menu_text,
@@ -614,7 +615,6 @@ const TITLE_RUN_GAP_MAX: int = 16
 
 
 ## The title screen's art, which is two different screens under one key.
-##
 ## Crystal's three LZ runs and its palettes are one contiguous section in
 ## `engine/movie/title.asm`'s INCBIN order, so each pins the next: a run that
 ## decompresses to the wrong number of tiles, or whose neighbour does not follow
@@ -1259,7 +1259,6 @@ static func verify_day_care_text(rom: RomFile, layout: Dictionary) -> Dictionary
 ## opens on has to be its own. A run the layout gives no offset is skipped
 ## rather than failed, which is what Gold and Silver's three Crystal-only rows
 ## are.
-##
 ## `SPECIAL_TEXT_FIRST_BOX` is the identifying line per run, so a wrong pin is
 ## caught here rather than by a screen printing the wrong routine's box.
 const SPECIAL_TEXT_FIRST_BOX: Dictionary = {
@@ -1270,6 +1269,9 @@ const SPECIAL_TEXT_FIRST_BOX: Dictionary = {
 	"poke_seer": ["see_all", "I see all."],
 	"buena_prize": ["ask_which_prize", "Which prize would"],
 	"mystery_gift": ["canceled", "The link has been"],
+	## Four of the trade's boxes open on a `text_ram` marker whose address
+	## differs by profile, so the anchor is the one that opens on a literal.
+	"trade": ["take_good_care", "Take good care of"],
 }
 
 
@@ -1634,9 +1636,59 @@ static func _aligned(value: int, to: int) -> int:
 	return ((value + to - 1) / to) * to
 
 
+## `TradeAnimation`'s art run, walked whole from its one pinned address: every
+## entry landing on the size its loader asks VRAM for is what says that address
+## is right. {name: PackedByteArray} in `TRADE_ANIM_SECTION` order, or empty.
+static func read_trade_anim_section(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("trade_anim", -1))
+	if at < 0:
+		return {}
+	var lz := Gen2Lz.new()
+	var out: Dictionary = {}
+	for row: Array in RomLayout.TRADE_ANIM_SECTION:
+		var name: String = String(row[0])
+		var kind: String = String(row[1])
+		var wanted: int = int(row[2]) if kind == "map" \
+			else int(row[2]) * Gen2Tiles.TILE_BYTES
+		var raw: PackedByteArray = PackedByteArray()
+		var consumed: int = 0
+		if kind == "lz":
+			raw = lz.decompress(rom.bytes(), at)
+			consumed = lz.consumed
+			if lz.failed:
+				return {}
+		else:
+			if not rom.in_bounds(at, wanted):
+				return {}
+			raw = rom.slice(at, wanted)
+			consumed = wanted
+		if raw.size() != wanted:
+			return {}
+		out[name] = raw
+		at += consumed
+	return out
+
+
+## The walk above is most of the check; what is left is that the two tilemaps
+## name tiles the one sheet behind them holds.
+static func verify_trade_anim(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_trade_anim_section(rom, layout)
+	if section.is_empty():
+		return {"ok": false, "message": "The trade animation section does not walk."}
+	var first: int = RomLayout.TRADE_ANIM_SHEET_FIRST_TILE
+	var last: int = first + RomLayout.TRADE_ANIM_SHEET_TILES - 1
+	for name: String in ["game_boy_tilemap", "link_cable_tilemap"]:
+		for cell: int in (section[name] as PackedByteArray):
+			if cell < first or cell > last:
+				return {
+					"ok": false,
+					"message": "The trade %s names a tile outside its sheet." % name,
+				}
+	return {"ok": true, "message": "The trade animation art verified."}
+
+
 ## The intro movie. The section walk above is most of the check; what is left is
 ## content, and the two palette runs INCLUDEd inside the code rather than in it.
-##
 ## `unown_1.pal` is byte-identical to the first palette of `fade.pal`, which is
 ## the same "two INCLUDEs of one picture check each other" the copyright string
 ## gives the credits: the two are pinned independently, so each confirms the
@@ -1694,7 +1746,6 @@ static func verify_intro_movie(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## `_UnownPuzzle`'s art. The walk is most of the check: seven records whose
 ## lengths are the sizes the routine copies into VRAM, each address the previous
 ## entry's own consumed length, so one wrong pin fails the next entry.
-##
 ## What the walk cannot see is that a puzzle picture is square: the four are
 ## six by six tiles because `ConvertLoadedPuzzlePieces` doubles them into the
 ## twelve-by-twelve grid the sixteen three-by-three pieces are cut from.
@@ -1852,7 +1903,6 @@ static func verify_card_flip(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## `GoldSilverIntro`. The section walk is most of the check; what is left is the
 ## three palette runs outside it and the two metatile maps, which name their own
 ## `.bin` entries and so check the pair.
-##
 ## `predef_pals` is checked against `game_freak_presents.object_palette`, which
 ## this layout pins independently: that offset is `PREDEFPAL_GAMEFREAK_LOGO_OB`,
 ## index 77 of the same table, so each address confirms the other for nothing.
@@ -2342,7 +2392,6 @@ const MENU_DESCRIPTION_LAST: String = "Quit and\nbe judged."
 
 
 ## The start menu's description run and the pack's five texts.
-##
 ## The run is checked by content at both ends and by shape in between: nine
 ## strings, each terminated inside its own bound, which no neighbouring text run
 ## in the bank satisfies with those two at the ends. The five texts are checked
@@ -2626,7 +2675,6 @@ static func read_challenge_menu_rows(rom: RomFile, layout: Dictionary) -> Packed
 ## The whole Battle Tower block: the 70 trainers, the ten level groups of 21
 ## Pokemon as the party-mon structs they are, the two per-class tables, the 120
 ## trainer lines, the level menu's own rows and the challenge menu's three.
-##
 ## Empty on Gold and Silver, which is what [GameData] answers "no tower" from.
 func _import_battle_tower(rom: RomFile, layout: Dictionary) -> Dictionary:
 	if not RomLayout.has_battle_tower(layout):
@@ -2969,7 +3017,6 @@ static func verify_text_bg_palette(rom: RomFile, layout: Dictionary) -> Dictiona
 
 ## `LoadGenderScreenPal` and `LoadGenderScreenLightBlueTile`, whose bytes sit
 ## thirteen apart in the same routine pair.
-##
 ## The palette's eight bytes appear once in the dump, so they pin themselves.
 ## The tile does not: sixteen bytes of one repeated index occur hundreds of
 ## times, so it is checked for being exactly that, on the index the palette's
@@ -3174,7 +3221,6 @@ static func verify_pc(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## Walks the type matchup chart from its offset to the terminator.
-##
 ## Returns an Array of { attacker, defender, multiplier, negated_by_foresight },
 ## empty if the walk ran away without finding an end. Rows after the $FE marker
 ## carry the flag: they stop applying once Foresight identifies the defender,
@@ -3210,7 +3256,6 @@ static func read_matchups(rom: RomFile, layout: Dictionary) -> Array:
 
 
 ## The matchup chart, checked by the shape a chart of exceptions has to have.
-##
 ## No name and no number, but hard to land on by accident: every row is two
 ## sparse type numbers and one of three multipliers, the run must reach $FE then
 ## $FF at exactly the right distance, and both ends are known content. A wrong
@@ -3345,7 +3390,6 @@ static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) ->
 ## One species' inherited move list from EggMovePointers. Returns { moves } on
 ## success, including an empty list, and an empty Dictionary for a malformed
 ## pointer, move id or unterminated list.
-##
 ## The address has no bank byte, so it must name the switchable window and is
 ## resolved against the pointer table's bank. The walk stops at that bank's end,
 ## not merely the dump's end: continuing into the next bank would turn a missing
@@ -3747,7 +3791,6 @@ static func verify_pokedex(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 ## The font carries no name and no number, so it is checked against the one
 ## thing that is known about it independently: the charmap.
-##
 ## The font is indexed by character code, so the letters and digits [Gen2Text]
 ## claims must have ink and the runs it has no character for must be blank. Those
 ## runs sit between the alphabets, so an offset out by one tile drags a blank
@@ -4087,7 +4130,6 @@ static func _ink(pixels: PackedByteArray) -> int:
 
 
 ## The three trainer tables, each checked by what is known about it independently.
-##
 ## Checked together because they are three views of one numbering, so a mistake
 ## shows up as the three disagreeing: names say what a class is, the palette
 ## table has one entry more than the pic table because the player owns the first,
@@ -4599,7 +4641,6 @@ func _import_world_sections(
 
 
 ## Imports [param rom] into its cache directory, replacing whatever was there.
-##
 ## [param on_progress] is called as [code](stage, done, total)[/code] if given.
 ## Returns { ok, message, directory, species, elapsed_ms }.
 ## [param yield_ms] is how often the one long stretch of this hands the main loop
@@ -4816,6 +4857,7 @@ func import_rom(
 		"town_map": _import_town_map(rom, layout),
 		"intro_movie": _import_intro_movie(rom, layout),
 		"gs_intro": _import_gs_intro(rom, layout),
+		"trade_anim": _import_trade_anim(rom, layout),
 		"oak_ratings": _import_oak_ratings(rom, layout),
 		"pokecenter_pc": _import_pokecenter_pc(rom, layout),
 		"decorations": _import_decorations(rom, layout),
@@ -5000,7 +5042,6 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 
 ## The two dex orderings, keyed by the mode that reads each. Empty on any layout
 ## failure, which the caller reports rather than caching a half table.
-##
 ## The third ordering, DEXMODE_OLD, has no table: `.OldMode` counts from 1 to
 ## 251, so storing it would be storing the species range twice.
 func _import_dex_orders(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -5047,7 +5088,6 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 
 ## data/moves/tmhm_moves.asm's TMHMMoves, in TMNUM order. Empty on any layout or
 ## content failure, which the caller reports rather than caching a half table.
-##
 ## Checked rather than trusted: every entry has to be a real move number, the
 ## terminating zero has to be there, and HM01's row has to be CUT. The last is
 ## what actually pins the table, since a nearby run of bytes can pass the first
@@ -5072,7 +5112,6 @@ func _import_tmhm_moves(rom: RomFile, layout: Dictionary) -> Array:
 
 ## data/events/happiness_changes.asm's HappinessChanges, one row of three signed
 ## changes per HAPPINESS_* constant. Empty on any layout or content failure.
-##
 ## Checked rather than trusted: no change is larger than twenty either way, and
 ## the first row has to be `+5, +3, +2`, which is what pins the table. Signed
 ## because `ChangeHappiness` reads the byte as one: its `cp $64` puts everything
@@ -5149,7 +5188,6 @@ func _import_mail_palettes(rom: RomFile, layout: Dictionary) -> Array:
 
 
 ## StringBufferPointers as WRAM addresses, in `text_buffer` argument order.
-##
 ## Stored rather than derived because the addresses move between Gold/Silver and
 ## Crystal, and a `TX_RAM` operand is an address: without the table there is no
 ## way back from `$CFA4` to the buffer a script filled.
@@ -5163,7 +5201,6 @@ func _import_string_buffer_pointers(rom: RomFile, layout: Dictionary) -> Array:
 ## The intro texts, decoded to strings the way species names are, since each is
 ## one whole value rather than a run a script indexes into. `<PLAYER>` stays a
 ## marker: the screen that prints it is the one that knows the name.
-##
 ## A text a profile does not ship is left out rather than stored empty, so a
 ## caller can tell "Gold has no gender screen" from "the text failed to decode".
 func _import_intro_text(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -5494,7 +5531,6 @@ func _import_stats_screen_palettes(rom: RomFile, layout: Dictionary) -> Dictiona
 
 ## The six `BattleObjectPals` an animation object is drawn with, four colours
 ## each rather than a pair, since `_CGB_BattleScreenLayout` copies them in whole.
-##
 ## Slots 0 and 1 are not here and are not table rows: the layout fills them from
 ## the two battlers' own palettes, so an object asking for either is asking for
 ## whoever is on the field.
@@ -5516,7 +5552,6 @@ func _import_battle_object_palettes(rom: RomFile, layout: Dictionary) -> Diction
 ## `_CGB_TrainerCard`'s palettes: its eight background slots, each a trainer
 ## class pair `LoadPalette_White_Col1_Col2_Black` expands, and the badge object
 ## palette it takes from `PredefPals` whole.
-##
 ## Slot 0 is trainer class 0, the player, whose pair sits in the class table but
 ## whose class the pic tables skip, so this is the only place it is read.
 func _import_card_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -5534,7 +5569,6 @@ func _import_card_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## `_CGB_Pokedex`'s three palettes.
-##
 ## `interface` is PREDEFPAL_POKEDEX, the four colours the whole screen is drawn
 ## through; `question_mark` is what an unseen species' Slowpoke picture wears,
 ## which `_CGB_Pokedex` fills the 7x7 pic box with; `cursor` is object palette 7,
@@ -5705,7 +5739,6 @@ func _import_presents_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 ## The credits: `CreditsScript`, every `CreditsStringsPointers` entry as the tile
 ## codes it is, `CreditsPalettes` and `.Frames`' block indices.
-##
 ## The strings stay codes rather than text for the same reason the copyright
 ## screen's does: `CreditsStringsPointers.Copyright` is nothing but tile numbers
 ## into `CopyrightGFX`, which `Credits` loads over $60 the way `Copyright` does.
@@ -5748,7 +5781,6 @@ func _packed_palette(rom: RomFile, at: int, colors: int) -> Array:
 ## The pack screen's data half: `DrawPocketName`'s 5x12 tilemap and the palettes
 ## `_CGB_PackPals` fills the attrmap with. The graphics go through the tile table
 ## with the rest of the strips.
-##
 ## Both palette sets are six palettes, not the eight the copy asks for; the two
 ## past them are read out of whatever follows and no attribute names them.
 func _import_pack(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -5792,7 +5824,6 @@ func _import_copyright_palette(rom: RomFile, layout: Dictionary) -> Array:
 
 ## The intro movie's tile strips and its four BG maps with their attribute
 ## planes, all out of one walk of the section.
-##
 ## A map is a byte run keyed by a name, so it is written the way a strip is and
 ## read back with `GameData.intro_map()`; it is not a sheet and gets no entry in
 ## the manifest's tile table. `Intro_LoadTilemap` copies the top-left 20x18 of
@@ -5828,7 +5859,6 @@ func _import_intro_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## The intro movie's palettes: the five sixteen-palette runs inside the section,
 ## `Intro_Scene24_ApplyPaletteFade`'s eight and `Intro_Scene20_AppearUnown`'s
 ## two, plus the names of the maps written beside the sheets.
-##
 ## The fades `CrystalIntro_UnownFade` and `Intro_FadeUnownWordPals` run through
 ## are `for hue, 32` tables the assembler generates, not cartridge data, so they
 ## are computed in [Gen2IntroMovie] rather than imported.
@@ -5857,6 +5887,52 @@ func _import_intro_movie(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"palettes": palettes, "maps": maps}
 
 
+## The trade's five tile strips and two tilemaps, out of one walk. A tilemap is
+## a cell run rather than pixels, written the way the intro's BG maps are.
+func _import_trade_anim_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var section: Dictionary = read_trade_anim_section(rom, layout)
+	if section.is_empty():
+		return {}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var out: Dictionary = {}
+	for row: Array in RomLayout.TRADE_ANIM_SECTION:
+		var name: String = String(row[0])
+		var path: String = RomCache.tile_path(directory, "trade_anim_%s" % name)
+		if String(row[1]) == "map":
+			if not RomCache.write_indices(path, section[name]):
+				return {}
+			continue
+		var tiles: int = int(row[2])
+		if not RomCache.write_indices(
+			path, Gen2Tiles.decode_2bpp_strip(section[name], 0, tiles)
+		):
+			return {}
+		out["trade_anim_%s" % name] = _strip_sheet_entry(tiles)
+	return out
+
+
+## `_CGB_TradeTube`'s TRADE_TUBE entry, which is every background cell of the
+## tube animation and object palette 7. Its other three are ROUTES, which no
+## cell of a wiped attrmap shows, and object palette 0 is the party menu's.
+func _import_trade_anim(rom: RomFile, layout: Dictionary) -> Dictionary:
+	if read_trade_anim_section(rom, layout).is_empty():
+		return {}
+	var maps: Array = []
+	for row: Array in RomLayout.TRADE_ANIM_SECTION:
+		if String(row[1]) == "map":
+			maps.append(String(row[0]))
+	return {
+		"maps": maps,
+		"palettes": {
+			"tube": _packed_palette(
+				rom,
+				RomLayout.predef_palette_offset(layout, RomLayout.PREDEFPAL_TRADE_TUBE),
+				RomLayout.PREDEF_PALETTE_COLORS
+			),
+		},
+	}
+
+
 ## `GoldSilverIntro`'s seven tile strips. The two `.tilemap`s and two `.bin`s are
 ## metatile data rather than pixels, so they go beside the movie's own entry
 ## through [method _import_gs_intro] rather than into the tile table.
@@ -5881,7 +5957,6 @@ func _import_gs_intro_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## `GoldSilverIntro`'s metatile maps and its palettes.
-##
 ## The four `.tilemap`/`.bin` runs are byte runs keyed by a name, written the way
 ## the Crystal movie's BG maps are and read back with `GameData.gs_intro_map()`.
 ## The palettes are `Intro_LoadMagikarpPalettes`' pair, the shellder and lapras
@@ -5965,7 +6040,6 @@ func _import_shrink_pics(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## The title screen's palettes and, on Gold and Silver, its tilemap. The
 ## graphics themselves go through [method _import_title_sheets] with the rest of
 ## the tile strips.
-##
 ## Crystal's sixteen palettes are one run `_TitleScreen` copies whole into both
 ## buffers; Gold and Silver's are five background and two object palettes that
 ## `GetSGBLayout` and `LoadTitleScreenPals` load separately, so they are kept
@@ -6257,7 +6331,6 @@ func _import_pc_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## `Pokedex_LoadGFX`'s two LZ runs, each as one strip of tiles.
-##
 ## Kept out of the fixed table [method _import_tiles] uses for the same reason
 ## the region map's are: a compressed run has to be decompressed before its tile
 ## count is even known.
@@ -6288,7 +6361,6 @@ func _import_pokedex_sheets(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## The title screen's graphics, each as one strip of tiles.
-##
 ## Every one but the trail is an LZ run, so they cannot go through the fixed
 ## table [method _import_tiles] uses: each is decompressed first and the strip
 ## written from the result. The names are the source's own symbols with the
@@ -6343,7 +6415,6 @@ func _strip_sheet_entry(tiles: int) -> Dictionary:
 ## on its own because thirty-four bytes of code sit between it and the run;
 ## everything from `UnownPuzzleCursorGFX` on is one walk, each address the
 ## previous entry's consumed length, with no alignment between them.
-##
 ## Returns {name: PackedByteArray} in `UNOWN_PUZZLE_SECTION` order plus
 ## `tile_borders`, or an empty Dictionary if any entry does not decompress to
 ## its own size.
@@ -6424,11 +6495,9 @@ func _import_unown_puzzle(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## `_SlotMachine`'s data run, walked whole from `Reel1Tilemap`.
-##
 ## The three reel strips and `SlotsTilemap` are raw bytes and the three graphics
 ## runs are LZ, laid out in that order with nothing between them; every entry
 ## landing on its own size is what says the address is right.
-##
 ## Returns {name: PackedByteArray} in `SLOTS_SECTION` order, or an empty
 ## Dictionary if any entry does not.
 static func read_slots_section(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -6518,7 +6587,6 @@ func _import_slots_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 
 ## `_CardFlip`'s art run, walked whole from `.palettes`.
-##
 ## Returns {name: PackedByteArray} in `CARD_FLIP_SECTION` order plus `tilemap`,
 ## the run's own tail, or an empty Dictionary if any entry does not land on its
 ## size. Unlike the slot machine's the run has no alignment fill between
@@ -6755,7 +6823,6 @@ func _import_card_flip_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## `PlaceDiplomaOnScreen`'s art: `DiplomaGFX` decompressed, and the two whole
 ## screens of tile numbers laid out behind its stream. The art itself is what
 ## says the address is right, since each tilemap has to index inside it.
-##
 ## Returns {tiles, page1, page2}, or an empty Dictionary if any part does not
 ## land on its own size.
 static func read_diploma_section(rom: RomFile, layout: Dictionary) -> Dictionary:
@@ -7331,6 +7398,7 @@ func _import_tiles(rom: RomFile, layout: Dictionary, on_progress: Callable) -> D
 	written.merge(_import_pc_sheets(rom, layout), true)
 	written.merge(_import_intro_sheets(rom, layout), true)
 	written.merge(_import_gs_intro_sheets(rom, layout), true)
+	written.merge(_import_trade_anim_sheets(rom, layout), true)
 	written.merge(_import_unown_puzzle_sheets(rom, layout), true)
 	written.merge(_import_slots_sheets(rom, layout), true)
 	written.merge(_import_card_flip_sheets(rom, layout), true)
@@ -7434,7 +7502,6 @@ func _import_pics(
 	## Gold and Silver's table stops at NUM_POKEMON, so `_GetFrontpic` answers
 	## EGG with `ld hl, EggPic` and the pic is at an address like a back pic.
 	## Their picture is a different one.
-	##
 	## Crystal's run carries two animation frames that nothing reads:
 	## `GetEggFrontpic` is `GetMonFrontpic`, not `GetAnimatedFrontpic`, and
 	## `AnimateMon_CheckIfPokemon` refuses EGG before any script is read.

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -242,7 +242,6 @@ const AUDIO_CRY_COUNT: int = 68
 ## `PokemonCries` (data/pokemon/cries.asm): `mon_cry index, pitch, length` per
 ## species, six bytes a row. 255 rows, not 251: the table pads to `$ff` with four
 ## silent CRY_NIDORAN_M rows the way the pic tables pad.
-##
 ## The table is what makes a cry per species rather than per stream: Ivysaur and
 ## Venusaur both play CRY_BULBASAUR and differ only in these two words.
 const MON_CRY_COUNT: int = 255
@@ -430,7 +429,6 @@ const DEXMODE_UNOWN: int = 3
 ## its evolutions, then a zero byte, then its level-up moves as level and move
 ## pairs, then another zero byte. One pointer answers both questions, which is
 ## why the two are decoded in the same pass rather than as separate tables.
-##
 ## The pointers are two bytes rather than three: the entries sit in the pointer
 ## table's own bank, so there is no bank number to store.
 const EVOS_ATTACKS_POINTER_SIZE: int = 2
@@ -588,7 +586,6 @@ const MAP_ENTRY_SIGN_TILES: int = 14
 
 ## The battle HUD's own graphics, which sit in the same section as the font and
 ## the text box borders and are the rest of what a battle screen draws.
-##
 ## [code]battle_font[/code] is 2bpp and carries "HP:", the HP bar's nine fill
 ## levels and the screen's odds and ends. The two HUD borders are 1bpp, the boxes
 ## a name and level sit in. The exp bar is 2bpp, seven fills and two ends.
@@ -899,7 +896,6 @@ const CARD_PALETTE_CLASSES: Array[int] = [0, 1, 3, 2, 4, 7, 6, 5]
 const CARD_BADGE_PALETTE_COLORS: int = 4
 
 ## The region map (`_TownMap` and `PokegearMap`, engine/pokegear/pokegear.asm).
-##
 ## `Pokegear_LoadGFX` builds one VRAM window for both screens: `TownMapGFX` at
 ## `vTiles2`, `PokegearGFX` at `vTiles2 tile $30` and `PokegearSpritesGFX` at
 ## `vTiles0`, which is where the cursor's tiles come from. All three are LZ runs.
@@ -935,7 +931,6 @@ const FLY_MAP_LABEL_FIRST_TILE: int = POKEGEAR_FIRST_TILE
 ## `RadioTilemapRLE`, `PhoneTilemapRLE` and `ClockTilemapRLE`: the other three
 ## Pokegear cards, one contiguous run in that order directly behind
 ## `PokegearSpritesGFX`, byte identical on all three cartridges.
-##
 ## `Pokegear_LoadTilemapRLE` reads the *tile* first and its run length second,
 ## the opposite way round from the comment above it, and writes from (0,0) until
 ## `-1`. Each card is twelve rows; `Textbox` draws the four below them.
@@ -975,7 +970,6 @@ const TOWN_MAP_PALETTE_COLORS: int = 4
 const TOWN_MAP_PALETTE_FIRST_COLOR: int = 0x53FC
 
 ## The credits (`engine/movie/credits.asm`).
-##
 ## `CreditsScript`'s commands, `const_def -1, -1`: the byte a command is not is a
 ## `CreditsStringsPointers` index.
 const CREDITS_END: int = 0xFF
@@ -1024,7 +1018,6 @@ const CREDITS_SCRIPT_MAX_BYTES: int = 1024
 const CREDITS_STRING_MAX_BYTES: int = 64
 
 ## The intro movie (`CrystalIntro`, engine/movie/intro.asm).
-##
 ## Every graphic, tilemap, attrmap and palette the movie draws is one contiguous
 ## section behind the code, in the INCBIN order below, and each entry starts on a
 ## sixteen-byte boundary from the first. So one pinned offset walks all
@@ -1209,6 +1202,38 @@ const LINK_TRADE_CABLE_ROWS_BYTES: int = 40
 ## `_CGB_Unused0D` is SCGB_DIPLOMA's own layout and its `WipeAttrmap` puts every
 ## cell on palette 0.
 const PREDEFPAL_DIPLOMA: int = 0x1B
+
+## The `lb bc` each `TradeAnim_CopyBoxFromDEtoHL` is given.
+const TRADE_ANIM_GAME_BOY_SIZE: Vector2i = Vector2i(6, 8)
+const TRADE_ANIM_LINK_CABLE_SIZE: Vector2i = Vector2i(12, 3)
+const TRADE_ANIM_GAME_BOY_CELLS: int = 48
+const TRADE_ANIM_LINK_CABLE_CELLS: int = 36
+
+## `TradeAnimation`'s art (engine/movie/trade_animation.asm): nine INCBINs end to
+## end with no alignment, so one pinned address walks the lot, each entry's own
+## length being where the next begins. `game_boy_cable` is `game_boy.2bpp` and
+## `link_cable.2bpp` concatenated by the Makefile. `cable` is two tiles and not
+## the four `LoadTradeBallAndCableGFX` asks for: that request runs on into
+## `bubble`, and nothing draws what it took, the bulge naming only tile one.
+const TRADE_ANIM_SECTION: Array[Array] = [
+	["game_boy_tilemap", "map", TRADE_ANIM_GAME_BOY_CELLS],
+	["link_cable_tilemap", "map", TRADE_ANIM_LINK_CABLE_CELLS],
+	["arrow_right", "raw", 1],
+	["arrow_left", "raw", 1],
+	["cable", "raw", 2],
+	["bubble", "raw", 4],
+	["game_boy_cable", "lz", 49],
+	["ball", "raw", 6],
+	["poof", "raw", 12],
+]
+## `ld de, vTiles2 tile $31`, and what the run decompresses to.
+const TRADE_ANIM_SHEET_FIRST_TILE: int = 0x31
+const TRADE_ANIM_SHEET_TILES: int = 49
+## Character codes whose font tile the layout overwrites with an arrow sheet.
+const TRADE_ANIM_RIGHT_ARROW_CODE: int = 0xED
+const TRADE_ANIM_LEFT_ARROW_CODE: int = 0xEE
+## `PalPacket_TradeTube`'s first entry, and object palette 7 as well.
+const PREDEFPAL_TRADE_TUBE: int = 0x1C
 
 ## `PrinterStatusStringPointers`' eight strings in table order, by the status
 ## each names. `null` is the empty string a status of zero prints, which is what
@@ -1496,7 +1521,6 @@ const NAME_RATER_TEXT_ORDER: Array[String] = [
 ## deferred list print, by run name, then the layout key and the stub names in
 ## the file's own order. One table rather than one accessor per routine: a
 ## routine that gets built adds a row here and needs no importer of its own.
-##
 ## A run whose layout offset is zero is not on the cartridge. `poke_seer`,
 ## `seer_advice` and `buena_prize` are Crystal's alone, and Gold and Silver's
 ## `SpecialsPointers` is short enough that no script of theirs can reach one.
@@ -1564,6 +1588,17 @@ const SPECIAL_TEXT_RUNS: Dictionary = {
 		["link_cant_battle_text", ["cant_battle"]],
 		["link_abnormal_mon_text", ["abnormal_mon"]],
 		["link_ask_trade_text", ["ask_trade"]],
+	],
+	## `TradeAnimation`'s boxes. Five runs because the stubs live inside the four
+	## routines that print them, in the file's order rather than the script's.
+	## `_MonNameSentToText` is left out: it is a `text_start` with nothing in it,
+	## so it imports as an empty string a decode failure cannot be told from.
+	"trade": [
+		["trade_sent_text", ["was_sent"]],
+		["trade_farewell_text", ["bids_farewell", "name_bids_farewell"]],
+		["trade_take_care_text", ["take_good_care"]],
+		["trade_sends_text", ["for_your_mon_sends", "ot_sends"]],
+		["trade_will_trade_text", ["will_trade", "for_your_mon_will_trade"]],
 	],
 	## `DoMysteryGift`'s eight, one contiguous run behind
 	## `.String_PressAToLink_BToCancel`. Every box the routine can end on is
@@ -1705,7 +1740,6 @@ const BATTLE_ANIM_SINE_WAVE: Array[int] = [
 
 ## The eight `PAL_BATTLE_OB_*` object palettes an animation object's palette byte
 ## indexes, and which of them the cartridge stores.
-##
 ## Only six are stored. `_CGB_BattleScreenLayout` (engine/gfx/cgb_layouts.asm)
 ## copies `BattleObjectPals` into `wOBPals1` from slot 2 on, four colours each,
 ## and fills slots 0 and 1 from the two battlers' own two-colour palettes through
@@ -1738,7 +1772,6 @@ const BATTLE_OBJECT_PALETTES: Array = [
 ## or red depending on how much is left, and the exp bar in blue. They are two
 ## colours each like a species' palette, white and black being implied, and they
 ## sit immediately before the species palettes in every game.
-##
 ## The names are the cache's keys, and the order is the cartridge's.
 const BAR_PALETTE_NAMES: Array = ["hp_green", "hp_yellow", "hp_red", "exp"]
 
@@ -1754,7 +1787,6 @@ const BAR_PALETTES: Array = [
 ## the stats screen's three page indicators wear, then the three single colours
 ## `LoadStatsScreenPals` writes over colour 0 of `wBGPals1` palettes 0 and 2, so
 ## the open page tints the whole lower screen and the exp bar's trough.
-##
 ## The two labels are read as one record because the second follows the first
 ## with nothing between it, which is what locates both from one pin.
 const STATS_PAGE_PALETTES: int = 3
@@ -1804,7 +1836,6 @@ const BAR_STEP_PIXELS: int = 2
 ## Trainer classes are numbered from 1; class 0 is the player, who has a palette
 ## in the table but no pic in it. Crystal added one class to the sixty-six Gold
 ## and Silver have, so the count lives in the layout rather than here.
-##
 ## Every trainer pic is this square, unlike a Pokémon's front pic.
 const TRAINER_PIC_TILES: int = 7
 
@@ -1812,7 +1843,6 @@ const TRAINER_PIC_TILES: int = 7
 ## per class, holding the individual trainers. "LEADER" is the class name every
 ## gym leader shares; FALKNER is stored inside class 1's party entry beside the
 ## Pokémon he brings, so a class's identity always means reading two tables.
-##
 ## Two-byte pointers in the pointer table's own bank, like [member evos_attacks]:
 ## the entries share that bank, so there is no bank number to store.
 const TRAINER_PARTY_POINTER_SIZE: int = 2
@@ -2422,6 +2452,10 @@ const GOLD_SILVER: Dictionary = {
 	# `LinkTextboxAtHL` instead. The same address on Gold and on Silver.
 	"link_border": 0x29D5B,
 	"link_trade_tilemaps": -1,
+	# `TradeGameBoyTilemap`, which `TRADE_ANIM_SECTION` walks the run from.
+	# rgblink's own address out of a build byte identical to this dump, and the
+	# same on Gold and on Silver.
+	"trade_anim": 0x29713,
 	# `InitMysteryGiftLayout` at Gold and Silver's own addresses, which is three
 	# art runs rather than Crystal's one: thirty-two tiles of `MysteryGiftGFX`,
 	# `MysteryGiftBackgroundGFX`'s 1bpp question mark and border doubled into
@@ -2615,6 +2649,12 @@ const GOLD_SILVER: Dictionary = {
 		## `wBufferTrademonNickname`, which `_LinkAskTradeForText` names with a
 		## `text_ram` whose address is in the text data itself.
 		"trademon_nickname": 0xCEEF,
+		## `TradeAnimation`'s four `text_ram` buffers: who sent each Pokemon and
+		## what species it is.
+		"player_trademon_species_name": 0xC5D1,
+		"player_trademon_sender_name": 0xC5E7,
+		"ot_trademon_species_name": 0xC602,
+		"ot_trademon_sender_name": 0xC618,
 		## The two names `_MysteryGiftSentText` and `_MysteryGiftSentHomeText`
 		## spell: the partner who sent the gift and the player it came home to.
 		## Gold and Silver's Mystery Gift block sits a page below Crystal's, the
@@ -2629,6 +2669,13 @@ const GOLD_SILVER: Dictionary = {
 	"link_cant_battle_text": 0x289A8,
 	"link_abnormal_mon_text": 0x289BD,
 	"link_ask_trade_text": 0x28D51,
+	## `TradeAnimation`'s five stub blocks, in the file's order and the same on
+	## Gold and on Silver.
+	"trade_sent_text": 0x2958B,
+	"trade_farewell_text": 0x295AB,
+	"trade_take_care_text": 0x295D3,
+	"trade_sends_text": 0x295F3,
+	"trade_will_trade_text": 0x29618,
 	"mystery_gift_text": 0x29F31,
 	"magikarp_measure_text": 0xFBCAD,
 	"magikarp_record_text": 0xFBDEC,
@@ -2998,6 +3045,7 @@ const CRYSTAL: Dictionary = {
 	},
 	"link_border": 0x16CFC1,
 	"link_trade_tilemaps": 0x16D465,
+	"trade_anim": 0x298C7,
 	# `UnownDexATile`, the two 1bpp tiles `_UnownPrinter` requests into the
 	# menu's own A and B glyphs, seven bytes behind `UnownDexVacantString`.
 	"unown_printer_glyphs": 0x16D9C,
@@ -3192,6 +3240,10 @@ const CRYSTAL: Dictionary = {
 		"seer_ot": 0xD02A,
 		"seer_caught_level": 0xD036,
 		"trademon_nickname": 0xD004,
+		"player_trademon_species_name": 0xC6D1,
+		"player_trademon_sender_name": 0xC6E7,
+		"ot_trademon_species_name": 0xC703,
+		"ot_trademon_sender_name": 0xC719,
 		"mystery_gift_partner_name": 0xC903,
 		"mystery_gift_player_name": 0xC953,
 	},
@@ -3202,6 +3254,11 @@ const CRYSTAL: Dictionary = {
 	"link_cant_battle_text": 0x28AAF,
 	"link_abnormal_mon_text": 0x28AC4,
 	"link_ask_trade_text": 0x28EB8,
+	"trade_sent_text": 0x29732,
+	"trade_farewell_text": 0x29752,
+	"trade_take_care_text": 0x2977A,
+	"trade_sends_text": 0x2979A,
+	"trade_will_trade_text": 0x297BF,
 	"mystery_gift_text": 0x1049FD,
 	"magikarp_measure_text": 0xFBBA9,
 	"magikarp_record_text": 0xFBCE8,
@@ -3372,7 +3429,6 @@ static func is_characterised(id: StringName) -> bool:
 
 ## Translates the bank number stored in a pic pointer into the bank the data is
 ## really in.
-##
 ## The tables were written before the pic sections were shuffled between banks
 ## and nobody rebuilt them, so the game repairs each pointer as it loads it.
 ## Reproducing that is not optional: the stored numbers are simply wrong.
@@ -3713,7 +3769,6 @@ static func egg_move_pointer_offset(layout: Dictionary, species: int) -> int:
 
 ## How many bytes one evolution entry occupies. [constant EVOLVE_STAT] carries a
 ## second parameter and so is a byte longer than the rest.
-##
 ## The cartridge never needs this: it skips the evolutions by reading bytes until
 ## it meets the terminator, which works because no byte inside an entry is ever
 ## zero. Something that decodes them rather than skipping them does need it.
@@ -3729,7 +3784,6 @@ static func type_name_pointer_offset(layout: Dictionary, type_number: int) -> in
 
 
 ## Whether a byte is a type number the matchup chart could be talking about.
-##
 ## The type numbers are sparse, and the run between the two groups is padding
 ## that a move's type byte may legitimately hold but that no matchup names. A
 ## walk that has left the table lands in that gap almost immediately, which is
@@ -3756,7 +3810,6 @@ static func oak_text_stub_offset(rom: RomFile, layout: Dictionary, name: String)
 
 
 ## Where the word for Unown form [param form] starts, form 1 being A.
-##
 ## The pointer is bank-local, so the table's own bank is the whole address.
 static func unown_word_offset(rom: RomFile, layout: Dictionary, form: int) -> int:
 	var table: int = int(layout.get("unown_words", -1))

--- a/game/render/trade_animation_page.gd
+++ b/game/render/trade_animation_page.gd
@@ -1,0 +1,397 @@
+class_name Gen2TradeAnimationPage
+extends RefCounted
+
+## `TradeAnimation`'s screen: [Gen2TradeAnimation] owns the two maps, the scroll,
+## the window and the sprite structs, and this turns a tile code into pixels.
+## Three sheets feed one code: the frontpic below the trade sheet's first tile,
+## the sheet's own 49, and the font, its two arrow codes replaced.
+
+const TILE: int = Gen2Tiles.TILE_WIDTH
+const WIDTH: int = Gen2Screen.WIDTH
+const HEIGHT: int = Gen2Screen.HEIGHT
+const MAP_COLUMNS: int = Gen2TradeAnimation.MAP_COLUMNS
+const MAP_ROWS: int = Gen2TradeAnimation.MAP_ROWS
+const PIC_TILES: int = Gen2TradeAnimation.PIC_TILES
+
+const OAM_ORIGIN := Vector2i(8, 16)
+const SHADOW_OAM_SPRITES: int = Gen2TradeAnimation.SHADOW_OAM_SPRITES
+
+const ATTR_PALETTE: int = 0x07
+const ATTR_XFLIP: int = 0x20
+const ATTR_YFLIP: int = 0x40
+const ATTR_PRIORITY: int = 0x80
+
+const OBJECT_FIRST_TILE: int = Gen2TradeAnimation.DICT_DEFAULT_TILE
+
+## What each `vTiles0` load puts where, off `OBJECT_FIRST_TILE`. The bubble's
+## load lands over the ball's, which is why the two never appear together.
+const BALL_SHEETS: Array[Array] = [
+	["ball", 0x00, 6], ["poof", 0x06, 12], ["cable", 0x12, 2],
+]
+const BUBBLE_SHEETS: Array[Array] = [["icon", 0x00, 8], ["bubble", 0x10, 4]]
+
+## The `spriteanimoam` rows the movie names, in [Gen2TradeAnimation]'s order.
+## A part is (dy, dx, tile, attributes), the order `dbsprite` emits.
+const OAM_SETS: Array[Dictionary] = [
+	# 0: TRADE_POKE_BALL_1 (TradePokeBall1, 4)
+	{"vtile": 0x00, "parts": [
+		[-8, -8, 0x00, 0x80], [-8, 0, 0x00, 0xA0], [0, -8, 0x01, 0x80],
+		[0, 0, 0x01, 0xA0],
+	]},
+	# 1: TRADE_POKE_BALL_2 (MagnetTrainRed, 4)
+	{"vtile": 0x02, "parts": [
+		[-8, -8, 0x00, 0x80], [-8, 0, 0x01, 0x80], [0, -8, 0x02, 0x80],
+		[0, 0, 0x03, 0x80],
+	]},
+	# 2: TRADE_POOF_1 (TradePoofBubble, 16)
+	{"vtile": 0x06, "parts": [
+		[-16, -16, 0x00, 0x00], [-16, -8, 0x01, 0x00], [-8, -16, 0x02, 0x00],
+		[-8, -8, 0x03, 0x00], [-16, 0, 0x01, 0x20], [-16, 8, 0x00, 0x20],
+		[-8, 0, 0x03, 0x20], [-8, 8, 0x02, 0x20], [0, -16, 0x02, 0x40],
+		[0, -8, 0x03, 0x40], [8, -16, 0x00, 0x40], [8, -8, 0x01, 0x40],
+		[0, 0, 0x03, 0x60], [0, 8, 0x02, 0x60], [8, 0, 0x01, 0x60],
+		[8, 8, 0x00, 0x60],
+	]},
+	# 3: TRADE_POOF_2 (TradePoofBubble, 16)
+	{"vtile": 0x0A, "parts": [
+		[-16, -16, 0x00, 0x00], [-16, -8, 0x01, 0x00], [-8, -16, 0x02, 0x00],
+		[-8, -8, 0x03, 0x00], [-16, 0, 0x01, 0x20], [-16, 8, 0x00, 0x20],
+		[-8, 0, 0x03, 0x20], [-8, 8, 0x02, 0x20], [0, -16, 0x02, 0x40],
+		[0, -8, 0x03, 0x40], [8, -16, 0x00, 0x40], [8, -8, 0x01, 0x40],
+		[0, 0, 0x03, 0x60], [0, 8, 0x02, 0x60], [8, 0, 0x01, 0x60],
+		[8, 8, 0x00, 0x60],
+	]},
+	# 4: TRADE_POOF_3 (TradePoofBubble, 16)
+	{"vtile": 0x0E, "parts": [
+		[-16, -16, 0x00, 0x00], [-16, -8, 0x01, 0x00], [-8, -16, 0x02, 0x00],
+		[-8, -8, 0x03, 0x00], [-16, 0, 0x01, 0x20], [-16, 8, 0x00, 0x20],
+		[-8, 0, 0x03, 0x20], [-8, 8, 0x02, 0x20], [0, -16, 0x02, 0x40],
+		[0, -8, 0x03, 0x40], [8, -16, 0x00, 0x40], [8, -8, 0x01, 0x40],
+		[0, 0, 0x03, 0x60], [0, 8, 0x02, 0x60], [8, 0, 0x01, 0x60],
+		[8, 8, 0x00, 0x60],
+	]},
+	# 5: TRADE_TUBE_BULGE_1 (TradeTubeBulge, 4)
+	{"vtile": 0x12, "parts": [
+		[-8, -8, 0x00, 0x07], [-8, 0, 0x00, 0x27], [0, -8, 0x00, 0x47],
+		[0, 0, 0x00, 0x67],
+	]},
+	# 6: TRADE_TUBE_BULGE_2 (TradeTubeBulge, 4)
+	{"vtile": 0x13, "parts": [
+		[-8, -8, 0x00, 0x07], [-8, 0, 0x00, 0x27], [0, -8, 0x00, 0x47],
+		[0, 0, 0x00, 0x67],
+	]},
+	# 7: TRADEMON_ICON_1 (RedWalk, 4)
+	{"vtile": 0x00, "parts": [
+		[-8, -8, 0x00, 0x00], [-8, 0, 0x01, 0x00], [0, -8, 0x02, 0x00],
+		[0, 0, 0x03, 0x00],
+	]},
+	# 8: TRADEMON_ICON_2 (RedWalk, 4)
+	{"vtile": 0x04, "parts": [
+		[-8, -8, 0x00, 0x00], [-8, 0, 0x01, 0x00], [0, -8, 0x02, 0x00],
+		[0, 0, 0x03, 0x00],
+	]},
+	# 9: TRADEMON_BUBBLE (TradePoofBubble, 16)
+	{"vtile": 0x10, "parts": [
+		[-16, -16, 0x00, 0x00], [-16, -8, 0x01, 0x00], [-8, -16, 0x02, 0x00],
+		[-8, -8, 0x03, 0x00], [-16, 0, 0x01, 0x20], [-16, 8, 0x00, 0x20],
+		[-8, 0, 0x03, 0x20], [-8, 8, 0x02, 0x20], [0, -16, 0x02, 0x40],
+		[0, -8, 0x03, 0x40], [8, -16, 0x00, 0x40], [8, -8, 0x01, 0x40],
+		[0, 0, 0x03, 0x60], [0, 8, 0x02, 0x60], [8, 0, 0x01, 0x60],
+		[8, 8, 0x00, 0x60],
+	]},
+]
+
+var frame_style: int = 0
+
+var _data: GameData = null
+var _font: Gen2Font = null
+var _sheet: PackedByteArray = PackedByteArray()
+var _arrows: Dictionary = {}
+var _objects: Dictionary = {}
+var _icon_species: int = -1
+var _icon: PackedByteArray = PackedByteArray()
+var _tiles: Dictionary = {}
+
+
+static func from_data(data: GameData) -> Gen2TradeAnimationPage:
+	if data == null or not data.has_trade_anim():
+		return null
+	var page := Gen2TradeAnimationPage.new()
+	page._font = Gen2Font.from_data(data)
+	if page._font == null:
+		return null
+	page._data = data
+	page._sheet = data.tile_indices("trade_anim_game_boy_cable")
+	page._arrows = {
+		RomLayout.TRADE_ANIM_RIGHT_ARROW_CODE: data.tile_indices("trade_anim_arrow_right"),
+		RomLayout.TRADE_ANIM_LEFT_ARROW_CODE: data.tile_indices("trade_anim_arrow_left"),
+	}
+	for name: String in ["ball", "poof", "cable", "bubble"]:
+		page._objects[name] = data.tile_indices("trade_anim_%s" % name)
+	return page
+
+
+func draw(movie: Gen2TradeAnimation) -> Image:
+	var pixels: PackedInt32Array = Gen2PicImage.canvas(WIDTH, HEIGHT)
+	if movie == null:
+		return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
+	_tiles.clear()
+	var behind: PackedByteArray = PackedByteArray()
+	behind.resize(WIDTH * HEIGHT)
+	_draw_background(pixels, movie, behind)
+	_draw_window(pixels, movie, behind)
+	var taken := PackedByteArray()
+	taken.resize(WIDTH * HEIGHT)
+	for entry: Dictionary in shadow_oam(movie):
+		_draw_sprite(pixels, movie, entry, behind, taken)
+	return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
+
+
+## Every live struct expanded into shadow OAM, in struct order, so a trace of it
+## compares to a cartridge's buffer line for line.
+func shadow_oam(movie: Gen2TradeAnimation) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	if movie == null:
+		return out
+	for sprite: Dictionary in movie.sprites():
+		var index: int = int(sprite["set"])
+		if index < 0 or index >= OAM_SETS.size():
+			continue
+		var ordering: Dictionary = OAM_SETS[index]
+		var at: Vector2i = sprite["at"]
+		var flip_x: bool = bool(sprite["flip_x"])
+		for part: Array in ordering["parts"]:
+			if out.size() >= SHADOW_OAM_SPRITES:
+				return out
+			var dx: int = int(part[1])
+			var attrs: int = int(part[3])
+			# `AddOrSubtractX`: a flipped frameset turns a part's own offset into
+			# -8 - offset before it is added.
+			if flip_x:
+				dx = -TILE - dx
+			out.append({
+				"y": (at.y + int(part[0])) & 0xFF,
+				"x": (at.x + dx) & 0xFF,
+				"tile": (int(sprite["vtile"]) + int(ordering["vtile"]) + int(part[2])) & 0xFF,
+				"palette": attrs & ATTR_PALETTE,
+				"flip_x": bool(attrs & ATTR_XFLIP) != flip_x,
+				"flip_y": bool(attrs & ATTR_YFLIP),
+				"priority": bool(attrs & ATTR_PRIORITY),
+			})
+	return out
+
+
+## `vBGMap0` through `hSCX`, a byte, so the sampling wraps. [param behind] is what
+## an `OAM_PRIO` sprite is drawn against.
+func _draw_background(
+	pixels: PackedInt32Array, movie: Gen2TradeAnimation, behind: PackedByteArray
+) -> void:
+	var table: PackedInt32Array = _background_lookup(movie)
+	var map: PackedByteArray = movie.bg_map()
+	var scx: int = movie.scroll_x()
+	for y: int in HEIGHT:
+		@warning_ignore("integer_division")
+		var row: int = (y / TILE) % MAP_ROWS
+		var in_tile_y: int = (y % TILE) * TILE
+		var line: int = y * WIDTH
+		var x: int = 0
+		while x < WIDTH:
+			var map_x: int = (x + scx) & 0xFF
+			var in_tile_x: int = map_x % TILE
+			var run: int = mini(TILE - in_tile_x, WIDTH - x)
+			@warning_ignore("integer_division")
+			var column: int = (map_x / TILE) % MAP_COLUMNS
+			var tile: PackedByteArray = _code_tile(
+				movie, int(map[row * MAP_COLUMNS + column])
+			)
+			for step: int in run:
+				var pixel: int = tile[in_tile_y + in_tile_x + step]
+				behind[line + x + step] = pixel
+				pixels[line + x + step] = table[pixel]
+			x += run
+
+
+func _draw_window(
+	pixels: PackedInt32Array, movie: Gen2TradeAnimation, behind: PackedByteArray
+) -> void:
+	var at: Vector2i = movie.window()
+	var left: int = at.x - 7
+	if at.y >= HEIGHT or left >= WIDTH:
+		return
+	var table: PackedInt32Array = _background_lookup(movie)
+	var map: PackedByteArray = movie.window_map()
+	for y: int in range(maxi(at.y, 0), HEIGHT):
+		var within_y: int = y - at.y
+		@warning_ignore("integer_division")
+		var row: int = within_y / TILE
+		if row >= MAP_ROWS:
+			break
+		var in_tile_y: int = (within_y % TILE) * TILE
+		for x: int in range(maxi(left, 0), WIDTH):
+			var within_x: int = x - left
+			@warning_ignore("integer_division")
+			var column: int = within_x / TILE
+			if column >= MAP_COLUMNS:
+				break
+			var tile: PackedByteArray = _code_tile(
+				movie, int(map[row * MAP_COLUMNS + column])
+			)
+			var pixel: int = tile[in_tile_y + within_x % TILE]
+			behind[y * WIDTH + x] = pixel
+			pixels[y * WIDTH + x] = table[pixel]
+
+
+func _background_lookup(movie: Gen2TradeAnimation) -> PackedInt32Array:
+	var colors: PackedColorArray = _data.trade_anim_palette("tube") \
+		if movie.tube_palette() else movie.frontpic_palette()
+	if colors.size() < Gen2Palette.COLORS_PER_PIC:
+		colors = Gen2Palette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	return Gen2PicImage.lookup(_dmg_ordered(colors, movie.background_palette_index()))
+
+
+static func _dmg_ordered(colors: PackedColorArray, order: int) -> PackedColorArray:
+	var out := PackedColorArray()
+	for index: int in colors.size():
+		out.append(colors[(order >> (index * 2)) & 0x3])
+	return out
+
+
+func _code_tile(movie: Gen2TradeAnimation, code: int) -> PackedByteArray:
+	if _tiles.has(code):
+		return _tiles[code]
+	var tile: PackedByteArray = _build_code_tile(movie, code)
+	_tiles[code] = tile
+	return tile
+
+
+func _build_code_tile(movie: Gen2TradeAnimation, code: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(TILE * TILE)
+	var first: int = RomLayout.TRADE_ANIM_SHEET_FIRST_TILE
+	if code < first:
+		_copy_frontpic_tile(out, movie, code)
+		return out
+	if code < first + RomLayout.TRADE_ANIM_SHEET_TILES:
+		_copy_strip_tile(out, _sheet, code - first)
+		return out
+	if _arrows.has(code):
+		_copy_strip_tile(out, _arrows[code], 0)
+		return out
+	## `Textbox`'s six border codes come off `Frames`, not the font's own run.
+	if code >= RomLayout.FRAME_FIRST_CODE \
+		and code < RomLayout.FRAME_FIRST_CODE + RomLayout.FRAME_TILES:
+		_font.draw_frame_code(frame_style, code, out, TILE, 0, 0)
+		return out
+	_font.draw_code(code, out, TILE, 0, 0, Gen2Text.FONT_BATTLE_EXTRA)
+	return out
+
+
+static func _copy_strip_tile(out: PackedByteArray, strip: PackedByteArray, tile: int) -> void:
+	if strip.is_empty():
+		return
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / TILE
+	if tile < 0 or (tile + 1) * TILE > width:
+		return
+	for row: int in TILE:
+		for column: int in TILE:
+			out[row * TILE + column] = strip[row * width + tile * TILE + column]
+
+
+static func _copy_frontpic_tile(
+	out: PackedByteArray, movie: Gen2TradeAnimation, code: int
+) -> void:
+	var pic: PackedByteArray = movie.frontpic_pixels()
+	var box: PackedByteArray = movie.frontpic_box()
+	var side: int = PIC_TILES * TILE
+	if pic.size() < side * side or code >= box.size():
+		return
+	@warning_ignore("integer_division")
+	var stride: int = pic.size() / side
+	var tile: int = int(box[code])
+	@warning_ignore("integer_division")
+	var at_x: int = (tile / PIC_TILES) * TILE
+	var at_y: int = (tile % PIC_TILES) * TILE
+	if at_x + TILE > stride:
+		return
+	for row: int in TILE:
+		for column: int in TILE:
+			out[row * TILE + column] = pic[(at_y + row) * stride + at_x + column]
+
+
+func _draw_sprite(
+	pixels: PackedInt32Array, movie: Gen2TradeAnimation, entry: Dictionary,
+	behind: PackedByteArray, taken: PackedByteArray
+) -> void:
+	var located: Dictionary = _object_tile(movie, int(entry["tile"]))
+	if located.is_empty():
+		return
+	var colors: PackedColorArray = _object_palette(movie, int(entry["palette"]))
+	if colors.size() < Gen2Palette.COLORS_PER_PIC:
+		return
+	var table: PackedInt32Array = Gen2PicImage.lookup(colors)
+	var at := Vector2i(int(entry["x"]) - OAM_ORIGIN.x, int(entry["y"]) - OAM_ORIGIN.y)
+	var priority: bool = bool(entry["priority"])
+	for row: int in TILE:
+		var y: int = at.y + row
+		if y < 0 or y >= HEIGHT:
+			continue
+		for column: int in TILE:
+			var x: int = at.x + column
+			if x < 0 or x >= WIDTH:
+				continue
+			var pixel: int = _strip_pixel(
+				located["strip"], int(located["tile"]), column, row,
+				bool(entry["flip_x"]), bool(entry["flip_y"])
+			)
+			if pixel == Gen2PicImage.TRANSPARENT_INDEX:
+				continue
+			var offset: int = y * WIDTH + x
+			if taken[offset] != 0:
+				continue
+			taken[offset] = 1
+			if priority and behind[offset] != Gen2PicImage.TRANSPARENT_INDEX:
+				continue
+			pixels[offset] = table[pixel]
+
+
+func _object_palette(movie: Gen2TradeAnimation, palette: int) -> PackedColorArray:
+	if palette == 7:
+		return _data.trade_anim_palette("tube")
+	return _dmg_ordered(
+		_data.party_menu_icon_palette(0), movie.object_palette_index()
+	)
+
+
+func _object_tile(movie: Gen2TradeAnimation, tile: int) -> Dictionary:
+	var bubble: bool = movie.object_sheet() == &"bubble"
+	for row: Array in (BUBBLE_SHEETS if bubble else BALL_SHEETS):
+		var first: int = OBJECT_FIRST_TILE + int(row[1])
+		if tile < first or tile >= first + int(row[2]):
+			continue
+		if String(row[0]) == "icon":
+			return {"strip": _icon_strip(movie), "tile": tile - first}
+		return {"strip": _objects[String(row[0])], "tile": tile - first}
+	return {}
+
+
+func _icon_strip(movie: Gen2TradeAnimation) -> PackedByteArray:
+	var species: int = movie.icon_species()
+	if species != _icon_species:
+		_icon_species = species
+		_icon = _data.species_icon_indices(species, species == Gen2TradeAnimation.EGG)
+	return _icon
+
+
+static func _strip_pixel(
+	strip: PackedByteArray, tile: int, x: int, y: int, flip_x: bool, flip_y: bool
+) -> int:
+	if strip.is_empty():
+		return 0
+	@warning_ignore("integer_division")
+	var width: int = strip.size() / TILE
+	var column: int = tile * TILE + ((TILE - 1 - x) if flip_x else x)
+	var row: int = (TILE - 1 - y) if flip_y else y
+	if column < 0 or column >= width:
+		return 0
+	return strip[row * width + column]

--- a/game/render/trade_animation_page.gd.uid
+++ b/game/render/trade_animation_page.gd.uid
@@ -1,0 +1,1 @@
+uid://cdcqt0mnl8kug

--- a/game/world/trade_animation.gd
+++ b/game/world/trade_animation.gd
@@ -1,0 +1,1294 @@
+class_name Gen2TradeAnimation
+extends RefCounted
+
+## `TradeAnimation` and `TradeAnimationPlayer2` (engine/movie/trade_animation.asm),
+## the movie both a link trade and an `NPCTrade` run. `DoTradeAnimation` is one
+## command a frame and then `PlaySpriteAnimations`, so that is the shape here, and
+## [member _delay] is the frames a command spends inside `DelayFrames` with nothing
+## else running. The screen is a tilemap of character codes, which is what the
+## cartridge writes; [Gen2TradeAnimationPage] draws it.
+
+const MUSIC_EVOLUTION: int = 0x22
+const SFX_POKEBALLS_PLACED_ON_TABLE: int = 0x03
+const SFX_POTION: int = 0x04
+const SFX_GOT_SAFARI_BALLS: int = 0x0C
+const SFX_SWITCH_POKEMON: int = 0x20
+const SFX_BALL_POOF: int = 0x29
+const SFX_GIVE_TRADEMON: int = 0xB7
+const SFX_GET_TRADEMON: int = 0xB8
+
+const COLUMNS: int = 20
+const ROWS: int = 18
+const MAP_COLUMNS: int = 32
+const MAP_ROWS: int = 32
+
+const TILE: int = 8
+const BLANK: int = 0x7F
+const PIC_TILES: int = 7
+const PIC_AT: Vector2i = Vector2i(7, 2)
+
+const EGG: int = 0xFD
+
+const PLAYER_1: int = 0
+const PLAYER_2: int = 1
+
+const CRYSTAL_JUMPTABLE: Array[StringName] = [
+	&"advance", &"show_givemon_data", &"show_getmon_data",
+	&"enter_link_tube_1", &"enter_link_tube_2", &"exit_link_tube",
+	&"tube_to_ot_1", &"tube_to_ot_2", &"tube_to_ot_3", &"tube_to_ot_4",
+	&"tube_to_ot_5", &"tube_to_ot_6", &"tube_to_ot_7", &"tube_to_ot_8",
+	&"tube_to_player_1", &"tube_to_player_2", &"tube_to_player_3",
+	&"tube_to_player_4", &"tube_to_player_5", &"tube_to_player_6",
+	&"tube_to_player_7", &"tube_to_player_8",
+	&"sent_to_ot_text", &"ot_bids_farewell", &"take_care_of_text",
+	&"ot_sends_text_1", &"ot_sends_text_2",
+	&"setup_givemon_scroll", &"do_givemon_scroll", &"frontpic_scroll_start",
+	&"textbox_scroll_start", &"scroll_out_right", &"scroll_out_right_2",
+	&"wait_80", &"wait_40", &"rocking_ball", &"drop_ball", &"wait_anim",
+	&"wait_anim_2", &"poof", &"bulge_through_tube", &"give_trademon_sfx",
+	&"get_trademon_sfx", &"end", &"animate_frontpic", &"wait_96",
+	&"wait_80_if_ot_egg", &"wait_180_if_ot_egg",
+]
+const GOLD_SILVER_JUMPTABLE: Array[StringName] = [
+	&"advance", &"show_givemon_data", &"show_getmon_data",
+	&"enter_link_tube_1", &"enter_link_tube_2", &"exit_link_tube",
+	&"tube_to_ot_1", &"tube_to_ot_2", &"tube_to_ot_3", &"tube_to_ot_4",
+	&"tube_to_ot_5", &"tube_to_ot_6", &"tube_to_ot_7", &"tube_to_ot_8",
+	&"tube_to_player_1", &"tube_to_player_2", &"tube_to_player_3",
+	&"tube_to_player_4", &"tube_to_player_5", &"tube_to_player_6",
+	&"tube_to_player_7", &"tube_to_player_8",
+	&"sent_to_ot_text", &"ot_bids_farewell", &"take_care_of_text",
+	&"ot_sends_text_1", &"ot_sends_text_2",
+	&"setup_givemon_scroll", &"do_givemon_scroll", &"frontpic_scroll_start",
+	&"textbox_scroll_start", &"scroll_out_right", &"scroll_out_right_2",
+	&"wait_80", &"rocking_ball", &"drop_ball", &"wait_anim", &"poof",
+	&"bulge_through_tube", &"give_trademon_sfx", &"get_trademon_sfx", &"end",
+]
+
+const CRYSTAL_SCRIPTS: Array[Array] = [
+	[
+		&"setup_givemon_scroll", &"show_givemon_data", &"do_givemon_scroll",
+		&"wait_80", &"wait_96", &"poof", &"rocking_ball", &"enter_link_tube_1",
+		&"wait_anim", &"bulge_through_tube", &"wait_anim", &"textbox_scroll_start",
+		&"give_trademon_sfx", &"tube_to_ot_1", &"sent_to_ot_text",
+		&"scroll_out_right",
+		&"ot_sends_text_1", &"ot_bids_farewell", &"wait_40", &"scroll_out_right",
+		&"get_trademon_sfx", &"tube_to_player_1", &"enter_link_tube_1",
+		&"drop_ball", &"exit_link_tube", &"wait_anim", &"show_getmon_data",
+		&"poof", &"wait_anim", &"frontpic_scroll_start", &"animate_frontpic",
+		&"wait_80_if_ot_egg", &"textbox_scroll_start", &"take_care_of_text",
+		&"scroll_out_right", &"end",
+	],
+	[
+		&"ot_sends_text_2", &"ot_bids_farewell", &"wait_40", &"scroll_out_right",
+		&"get_trademon_sfx", &"tube_to_ot_1", &"enter_link_tube_1", &"drop_ball",
+		&"exit_link_tube", &"wait_anim", &"show_getmon_data", &"poof",
+		&"wait_anim", &"frontpic_scroll_start", &"animate_frontpic",
+		&"wait_180_if_ot_egg", &"textbox_scroll_start", &"take_care_of_text",
+		&"scroll_out_right",
+		&"setup_givemon_scroll", &"show_givemon_data", &"do_givemon_scroll",
+		&"wait_40", &"poof", &"rocking_ball", &"enter_link_tube_1", &"wait_anim",
+		&"bulge_through_tube", &"wait_anim", &"textbox_scroll_start",
+		&"give_trademon_sfx", &"tube_to_player_1", &"sent_to_ot_text",
+		&"scroll_out_right", &"end",
+	],
+]
+const GOLD_SILVER_SCRIPTS: Array[Array] = [
+	[
+		&"setup_givemon_scroll", &"show_givemon_data", &"do_givemon_scroll",
+		&"wait_80", &"poof", &"rocking_ball", &"enter_link_tube_1", &"wait_anim",
+		&"bulge_through_tube", &"wait_anim", &"textbox_scroll_start",
+		&"give_trademon_sfx", &"tube_to_ot_1", &"sent_to_ot_text",
+		&"scroll_out_right",
+		&"ot_sends_text_1", &"ot_bids_farewell", &"scroll_out_right",
+		&"get_trademon_sfx", &"tube_to_player_1", &"enter_link_tube_1",
+		&"drop_ball", &"exit_link_tube", &"wait_anim", &"show_getmon_data",
+		&"poof", &"wait_anim", &"frontpic_scroll_start", &"wait_80",
+		&"textbox_scroll_start", &"take_care_of_text", &"scroll_out_right",
+		&"end",
+	],
+	[
+		&"ot_sends_text_2", &"ot_bids_farewell", &"scroll_out_right",
+		&"get_trademon_sfx", &"tube_to_ot_1", &"enter_link_tube_1", &"drop_ball",
+		&"exit_link_tube", &"wait_anim", &"show_getmon_data", &"poof",
+		&"wait_anim", &"frontpic_scroll_start", &"wait_80",
+		&"textbox_scroll_start", &"take_care_of_text", &"scroll_out_right",
+		&"setup_givemon_scroll", &"show_givemon_data", &"do_givemon_scroll",
+		&"wait_80", &"poof", &"rocking_ball", &"enter_link_tube_1", &"wait_anim",
+		&"bulge_through_tube", &"wait_anim", &"textbox_scroll_start",
+		&"give_trademon_sfx", &"tube_to_player_1", &"sent_to_ot_text",
+		&"scroll_out_right", &"end",
+	],
+]
+
+const FRAMESET_END: StringName = &"end"
+const FRAMESET_DELETE: StringName = &"delete"
+const FRAMESET_RESTART: StringName = &"restart"
+const FLIP_X: int = 1
+
+const OAM_BALL_1: int = 0
+const OAM_BALL_2: int = 1
+const OAM_POOF_1: int = 2
+const OAM_POOF_2: int = 3
+const OAM_POOF_3: int = 4
+const OAM_BULGE_1: int = 5
+const OAM_BULGE_2: int = 6
+const OAM_ICON_1: int = 7
+const OAM_ICON_2: int = 8
+const OAM_BUBBLE: int = 9
+
+const FRAMESETS: Dictionary = {
+	&"ball": {"frames": [[OAM_BALL_1, 32, 0]], "end": FRAMESET_END},
+	&"ball_wobble": {
+		"frames": [
+			[OAM_BALL_1, 3, 0], [OAM_BALL_2, 3, 0], [OAM_BALL_1, 3, 0],
+			[OAM_BALL_2, 3, FLIP_X],
+		],
+		"end": FRAMESET_RESTART,
+	},
+	&"poof": {
+		"frames": [[OAM_POOF_1, 4, 0], [OAM_POOF_2, 4, 0], [OAM_POOF_3, 4, 0]],
+		"end": FRAMESET_DELETE,
+	},
+	&"bulge": {
+		"frames": [[OAM_BULGE_1, 3, 0], [OAM_BULGE_2, 3, 0]], "end": FRAMESET_RESTART,
+	},
+	&"icon": {
+		"frames": [[OAM_ICON_1, 7, 0], [OAM_ICON_2, 7, 0]], "end": FRAMESET_RESTART,
+	},
+	&"bubble": {"frames": [[OAM_BUBBLE, 32, 0]], "end": FRAMESET_END},
+}
+
+const OBJECTS: Dictionary = {
+	&"ball": {"frameset": &"ball", "func": &"ball"},
+	&"poof": {"frameset": &"poof", "func": &"none"},
+	&"bulge": {"frameset": &"bulge", "func": &"bulge"},
+	&"icon": {"frameset": &"icon", "func": &"in_tube"},
+	&"bubble": {"frameset": &"bubble", "func": &"in_tube"},
+}
+const DICT_DEFAULT_TILE: int = 0x62
+
+const ANIM_STRUCTS: int = 10
+const SHADOW_OAM_SPRITES: int = 40
+const OAM_SET_SIZES: Array[int] = [4, 4, 16, 16, 16, 4, 4, 4, 4, 16]
+
+const TUBE_STATE_0: int = 0
+const TUBE_STATE_1: int = 1
+const TUBE_STATE_2: int = 2
+
+const CABLE_END_LEFT: int = 0x5B
+const CABLE_PLUG: int = 0x5D
+const CABLE_CORNER: int = 0x5F
+const CABLE_STRAIGHT: int = 0x60
+const CABLE_VERTICAL: int = 0x61
+
+const STATS_RULE_ROW: Array[int] = [0x7A, 0x7A, 0x7A, 0x7F, 0x74, 0xE8]
+const STATS_ID_ROW: Array[int] = [0x73, 0x74, 0xE8]
+const GENDER_CODES: Array[int] = [0x7F, 0xEF, 0xF5]
+
+const SPEECH_BOX: Rect2i = Rect2i(0, 12, 20, 6)
+const SPEECH_TEXT_AT: Vector2i = Vector2i(1, 14)
+const BOX_CODES: Array[int] = [0x79, 0x7A, 0x7B, 0x7C, 0x7D, 0x7E]
+const LINK_TIMECAPSULE: int = Gen2LinkTransport.LINK_TIMECAPSULE
+
+var _data: GameData = null
+var _sine: Gen2BattleAnimData = null
+var _player: Dictionary = {}
+var _ot: Dictionary = {}
+var _sender_1: String = ""
+var _sender_2: String = ""
+var _sendmon: int = 0
+var _getmon: int = 0
+
+var _jumptable_names: Array[StringName] = CRYSTAL_JUMPTABLE
+var _commands: Dictionary = {}
+var _script: Array = []
+var _script_at: int = 0
+var _jumptable: int = 0
+var _exit: bool = false
+
+var _counter: int = 0
+var _counter2: int = 0
+var _delay: int = 0
+var _frame: int = 0
+
+var _scx: int = 0
+var _wx: int = 7
+var _wy: int = 0x90
+var _map_target: int = 0
+
+var _tilemap: PackedByteArray = PackedByteArray()
+var _bg_map: PackedByteArray = PackedByteArray()
+var _window_map: PackedByteArray = PackedByteArray()
+
+var _actors: Array[Dictionary] = []
+var _anim_count: int = 0
+var _shadow: Array[Dictionary] = []
+var _object_sheet: StringName = &"ball"
+
+var _pic_pixels: PackedByteArray = PackedByteArray()
+var _pic_palette: PackedColorArray = PackedColorArray()
+## Which tile of it each cell shows: the animation's frames are in bank 1.
+var _pic_box: PackedByteArray = PackedByteArray()
+var _animation: Gen2PicAnimation = null
+var _bgp: int = 0xE4
+var _obp0: int = 0xE4
+var _tube_palette: bool = false
+var _crystal: bool = true
+var _link_mode: int = 0
+var _icon_species: int = 0
+
+var _events: Array[Dictionary] = []
+
+
+## [param context] is [method Gen2WorldPartyHost.trade_animation_context]' two
+## halves. A null [param data] draws nothing; a host asks [method available].
+static func create(
+	data: GameData, sine: Gen2BattleAnimData, context: Dictionary, half: int = PLAYER_1
+) -> Gen2TradeAnimation:
+	var out := Gen2TradeAnimation.new()
+	out._data = data
+	out._sine = sine
+	out._player = (context.get("player", {}) as Dictionary).duplicate(true)
+	out._ot = (context.get("ot", {}) as Dictionary).duplicate(true)
+	out._link_mode = int(context.get("link_mode", 0))
+	out._build(half)
+	return out
+
+
+static func available(data: GameData) -> bool:
+	return data != null and data.has_trade_anim()
+
+
+func _build(half: int) -> void:
+	_crystal = Gen2WorldState.is_crystal_profile(_data)
+	_jumptable_names = CRYSTAL_JUMPTABLE if _crystal else GOLD_SILVER_JUMPTABLE
+	var scripts: Array[Array] = CRYSTAL_SCRIPTS if _crystal else GOLD_SILVER_SCRIPTS
+	_script = scripts[PLAYER_2 if half == PLAYER_2 else PLAYER_1]
+	## `LinkTradeAnim_LoadTradePlayerNames`, whose arguments the second entry
+	## point swaps.
+	var first: Dictionary = _ot if half == PLAYER_2 else _player
+	var second: Dictionary = _player if half == PLAYER_2 else _ot
+	_sender_1 = String(first.get("sender_name", ""))
+	_sender_2 = String(second.get("sender_name", ""))
+	_sendmon = int(first.get("species", 0))
+	_getmon = int(second.get("species", 0))
+	_commands = _command_table()
+	_actors.resize(ANIM_STRUCTS)
+	_tilemap = _blank_run(COLUMNS * ROWS)
+	_bg_map = _blank_run(MAP_COLUMNS * MAP_ROWS)
+	_window_map = _blank_run(MAP_COLUMNS * MAP_ROWS)
+	_emit(&"play_music", {"music": MUSIC_EVOLUTION})
+
+
+static func _blank_run(cells: int) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(cells)
+	out.fill(BLANK)
+	return out
+
+
+func finished() -> bool:
+	return _exit
+
+
+func frame() -> int:
+	return _frame
+
+
+func scroll_x() -> int:
+	return _scx
+
+
+func window() -> Vector2i:
+	return Vector2i(_wx, _wy)
+
+
+func bg_map() -> PackedByteArray:
+	return _bg_map
+
+
+func window_map() -> PackedByteArray:
+	return _window_map
+
+
+func tilemap() -> PackedByteArray:
+	return _tilemap
+
+
+func sprites() -> Array[Dictionary]:
+	return _shadow
+
+
+func object_sheet() -> StringName:
+	return _object_sheet
+
+
+func background_palette_index() -> int:
+	return _bgp
+
+
+func object_palette_index() -> int:
+	return _obp0
+
+
+func icon_species() -> int:
+	return _icon_species
+
+
+func tube_palette() -> bool:
+	return _tube_palette
+
+
+func frontpic_pixels() -> PackedByteArray:
+	return _pic_pixels
+
+
+func frontpic_palette() -> PackedColorArray:
+	return _pic_palette
+
+
+func frontpic_box() -> PackedByteArray:
+	return _pic_box
+
+
+func drain_events() -> Array[Dictionary]:
+	var out: Array[Dictionary] = _events.duplicate(true)
+	_events.clear()
+	return out
+
+
+func advance_frame() -> Array[Dictionary]:
+	if _exit:
+		return drain_events()
+	_frame += 1
+	if _delay > 0:
+		_delay -= 1
+		return drain_events()
+	_run_command()
+	if _exit:
+		return drain_events()
+	_run_sprites()
+	_counter2 = (_counter2 + 1) & 0xFF
+	return drain_events()
+
+
+func settle(limit: int = 20000) -> int:
+	var guard: int = limit
+	while not _exit and guard > 0:
+		advance_frame()
+		guard -= 1
+	return _frame
+
+
+func _run_command() -> void:
+	var name: StringName = _jumptable_names[_jumptable] \
+		if _jumptable >= 0 and _jumptable < _jumptable_names.size() else &"end"
+	(_commands[name] as Callable).call()
+
+
+func _command_table() -> Dictionary:
+	return {
+		&"advance": _cmd_advance,
+		&"show_givemon_data": _cmd_show_givemon_data,
+		&"show_getmon_data": _cmd_show_getmon_data,
+		&"enter_link_tube_1": _cmd_enter_link_tube_1,
+		&"enter_link_tube_2": _cmd_enter_link_tube_2,
+		&"exit_link_tube": _cmd_exit_link_tube,
+		&"tube_to_ot_1": _cmd_tube_to_ot_1,
+		&"tube_to_ot_2": _cmd_tube_to_ot_2,
+		&"tube_to_ot_3": _cmd_tube_to_ot_3,
+		&"tube_to_ot_4": _cmd_tube_to_ot_4,
+		&"tube_to_ot_5": _cmd_tube_wait,
+		&"tube_to_ot_6": _cmd_tube_long_wait,
+		&"tube_to_ot_7": _cmd_tube_wait,
+		&"tube_to_ot_8": _cmd_tube_done,
+		&"tube_to_player_1": _cmd_tube_to_player_1,
+		&"tube_to_player_2": _cmd_tube_wait,
+		&"tube_to_player_3": _cmd_tube_to_player_3,
+		&"tube_to_player_4": _cmd_tube_to_player_4,
+		&"tube_to_player_5": _cmd_tube_to_player_5,
+		&"tube_to_player_6": _cmd_tube_long_wait,
+		&"tube_to_player_7": _cmd_tube_wait,
+		&"tube_to_player_8": _cmd_tube_done,
+		&"sent_to_ot_text": _cmd_sent_to_ot_text,
+		&"ot_bids_farewell": _cmd_ot_bids_farewell,
+		&"take_care_of_text": _cmd_take_care_of_text,
+		&"ot_sends_text_1": _cmd_ot_sends_text_1,
+		&"ot_sends_text_2": _cmd_ot_sends_text_2,
+		&"setup_givemon_scroll": _cmd_setup_givemon_scroll,
+		&"do_givemon_scroll": _cmd_do_givemon_scroll,
+		&"frontpic_scroll_start": _cmd_frontpic_scroll_start,
+		&"textbox_scroll_start": _cmd_textbox_scroll_start,
+		&"scroll_out_right": _cmd_scroll_out_right,
+		&"scroll_out_right_2": _cmd_scroll_out_right_2,
+		&"wait_80": _cmd_wait_80,
+		&"wait_40": _cmd_wait_40,
+		&"wait_96": _cmd_wait_96,
+		&"wait_80_if_ot_egg": _cmd_wait_80_if_ot_egg,
+		&"wait_180_if_ot_egg": _cmd_wait_180_if_ot_egg,
+		&"rocking_ball": _cmd_rocking_ball,
+		&"drop_ball": _cmd_drop_ball,
+		&"wait_anim": _cmd_wait_anim,
+		&"wait_anim_2": _cmd_wait_anim,
+		&"poof": _cmd_poof,
+		&"bulge_through_tube": _cmd_bulge_through_tube,
+		&"give_trademon_sfx": _cmd_give_trademon_sfx,
+		&"get_trademon_sfx": _cmd_get_trademon_sfx,
+		&"animate_frontpic": _cmd_animate_frontpic,
+		&"end": _cmd_end,
+	}
+
+
+func _cmd_advance() -> void:
+	if _script_at >= _script.size():
+		_exit = true
+		return
+	_jumptable = _jumptable_names.find(StringName(_script[_script_at]))
+	_script_at += 1
+
+
+func _increment() -> void:
+	_jumptable += 1
+
+
+func _cmd_end() -> void:
+	_exit = true
+
+
+func _cmd_show_givemon_data() -> void:
+	_show_stats(_player)
+	_show_frontpic(&"player")
+	_emit(&"play_cry", {"species": int(_player.get("species", 0))})
+	_cmd_advance()
+
+
+func _cmd_show_getmon_data() -> void:
+	_show_stats(_ot)
+	_show_frontpic(&"ot")
+	if not _crystal:
+		_emit(&"play_cry", {"species": int(_ot.get("species", 0))})
+	_cmd_advance()
+
+
+func _cmd_animate_frontpic() -> void:
+	if _animation == null:
+		if _data == null or int(_ot.get("species", 0)) == EGG:
+			_cmd_advance()
+			return
+		_show_stats(_ot)
+		_show_frontpic(&"ot")
+		var record: Dictionary = _data.pic_animation(int(_ot.get("species", 0)))
+		if record.is_empty():
+			_cmd_advance()
+			return
+		_animation = Gen2PicAnimation.new(record, Gen2PicAnimation.ANIM_MON_TRADE)
+	if _animation.advance() != &"":
+		_emit(&"play_cry", {"species": int(_ot.get("species", 0))})
+	_pic_box = _animation.box
+	if not _animation.finished():
+		return
+	_animation = null
+	_reset_frontpic_box()
+	_cmd_advance()
+
+
+func _cmd_enter_link_tube_1() -> void:
+	_clear_tilemap()
+	_scx = 0xA0
+	_copy_box(
+		_tilemap_run("link_cable_tilemap"),
+		RomLayout.TRADE_ANIM_LINK_CABLE_SIZE, Vector2i(8, 2)
+	)
+	_wait_bg_map()
+	_tube_palette = true
+	_bgp = 0xE4
+	_obp0 = 0xE4
+	_emit(&"play_sfx", {"sfx": SFX_POTION})
+	_increment()
+	## `call DelayFrame` between the scroll register and the tilemap write.
+	_delay += 1
+
+
+func _cmd_enter_link_tube_2() -> void:
+	if _scx == 0:
+		_delay += 80
+		_cmd_advance()
+		return
+	_scx = (_scx + 4) & 0xFF
+
+
+func _cmd_exit_link_tube() -> void:
+	if _scx == 0xA0:
+		_clear_tilemap()
+		_scx = 0
+		_cmd_advance()
+		return
+	_scx = (_scx - 4) & 0xFF
+
+
+func _cmd_setup_givemon_scroll() -> void:
+	_wx = 0x8F
+	_scx = 0x88
+	_wy = 0x50
+	_cmd_advance()
+
+
+func _cmd_do_givemon_scroll() -> void:
+	if _wx == 7:
+		_scx = 0
+		_cmd_advance()
+		return
+	_wx = (_wx - 4) & 0xFF
+	_scx = (_scx - 4) & 0xFF
+
+
+func _cmd_frontpic_scroll_start() -> void:
+	_wx = 7
+	_wy = 0x50
+	_cmd_advance()
+
+
+func _cmd_textbox_scroll_start() -> void:
+	_wx = 7
+	_wy = 0x90
+	_cmd_advance()
+
+
+func _cmd_scroll_out_right() -> void:
+	_map_target = 1
+	_wait_bg_map()
+	_wx = 7
+	_wy = 0
+	_map_target = 0
+	_clear_tilemap()
+	_increment()
+	_delay += 1
+
+
+func _cmd_scroll_out_right_2() -> void:
+	if _wx < 0xA1:
+		## Gold and Silver's own `inc a / inc a`, against Crystal's `add $4`.
+		_wx += 4 if _crystal else 2
+		return
+	_map_target = 1
+	_wait_bg_map()
+	_wx = 7
+	_wy = 0x90
+	_map_target = 0
+	_cmd_advance()
+
+
+func _cmd_wait_80() -> void:
+	_delay += 80
+	_cmd_advance()
+
+
+func _cmd_wait_40() -> void:
+	_delay += 40
+	_cmd_advance()
+
+
+func _cmd_wait_96() -> void:
+	_delay += 96
+	_cmd_advance()
+
+
+## `IsOTTrademonEgg` advances the script pointer before it looks.
+func _cmd_wait_80_if_ot_egg() -> void:
+	_cmd_advance()
+	if int(_ot.get("species", 0)) == EGG:
+		_delay += 80
+
+
+func _cmd_wait_180_if_ot_egg() -> void:
+	_cmd_advance()
+	if int(_ot.get("species", 0)) == EGG:
+		_delay += 180
+
+
+func _cmd_wait_anim() -> void:
+	if _counter > 0:
+		_counter -= 1
+		return
+	_cmd_advance()
+
+
+func _cmd_give_trademon_sfx() -> void:
+	_cmd_advance()
+	_emit(&"play_sfx", {"sfx": SFX_GIVE_TRADEMON})
+
+
+func _cmd_get_trademon_sfx() -> void:
+	_cmd_advance()
+	_emit(&"play_sfx", {"sfx": SFX_GET_TRADEMON})
+
+
+func _cmd_rocking_ball() -> void:
+	_load_ball_gfx()
+	_spawn(&"ball", Vector2i(88, 84))
+	_cmd_advance()
+	## Gold and Silver rock the ball for twice as long.
+	_counter = 32 if _crystal else 64
+
+
+func _cmd_drop_ball() -> void:
+	_load_ball_gfx()
+	var actor: Dictionary = _spawn(&"ball", Vector2i(88, 84))
+	if not actor.is_empty():
+		actor["jumptable"] = 1
+		actor["y_offset"] = 0xDC
+	_cmd_advance()
+	_counter = 56
+
+
+func _cmd_poof() -> void:
+	_load_ball_gfx()
+	_spawn(&"poof", Vector2i(88, 84))
+	_cmd_advance()
+	_counter = 16
+	_emit(&"play_sfx", {"sfx": SFX_BALL_POOF})
+
+
+func _cmd_bulge_through_tube() -> void:
+	_obp0 = 0xE4
+	_spawn(&"bulge", Vector2i(88, 40))
+	_cmd_advance()
+	_counter = 64 if _crystal else 128
+
+
+func _load_ball_gfx() -> void:
+	_object_sheet = &"ball"
+
+
+func _cmd_tube_to_ot_1() -> void:
+	_place_stats_on_tube(RomLayout.TRADE_ANIM_RIGHT_ARROW_CODE)
+	_icon_species = _sendmon
+	_init_tube_anim(TUBE_STATE_0, Vector2i(88, 44), 0)
+
+
+func _cmd_tube_to_player_1() -> void:
+	_place_stats_on_tube(RomLayout.TRADE_ANIM_LEFT_ARROW_CODE)
+	_icon_species = _getmon
+	_init_tube_anim(TUBE_STATE_2, Vector2i(148, 76), 4)
+
+
+func _init_tube_anim(state: int, at: Vector2i, anim_state: int) -> void:
+	_clear_sprite_anims()
+	for column: int in 12:
+		_bg_map[3 * MAP_COLUMNS + 20 + column] = CABLE_STRAIGHT
+	_tube_anim_tilemap(state)
+	_scx = 0
+	_wx = 7
+	_wy = 0x70
+	_object_sheet = &"bubble"
+	for object: StringName in [&"icon", &"bubble"]:
+		var actor: Dictionary = _spawn(object, at)
+		if not actor.is_empty():
+			actor["jumptable"] = anim_state
+	_wait_bg_map()
+	_tube_palette = true
+	_bgp = 0xE4
+	_obp0 = 0xD0
+	_increment()
+	_counter = 92
+
+
+func _cmd_tube_to_ot_2() -> void:
+	_flash_bg_pals()
+	_scx = (_scx + 2) & 0xFF
+	if _scx != 0x50:
+		return
+	_tube_anim_tilemap(TUBE_STATE_1)
+	_increment()
+
+
+func _cmd_tube_to_ot_3() -> void:
+	_flash_bg_pals()
+	_scx = (_scx + 2) & 0xFF
+	if _scx != 0xA0:
+		return
+	_tube_anim_tilemap(TUBE_STATE_2)
+	_increment()
+
+
+func _cmd_tube_to_ot_4() -> void:
+	_flash_bg_pals()
+	_scx = (_scx + 2) & 0xFF
+	if _scx != 0:
+		return
+	_increment()
+
+
+func _cmd_tube_to_player_3() -> void:
+	_flash_bg_pals()
+	_scx = (_scx - 2) & 0xFF
+	if _scx != 0xB0:
+		return
+	_tube_anim_tilemap(TUBE_STATE_1)
+	_increment()
+
+
+func _cmd_tube_to_player_4() -> void:
+	_flash_bg_pals()
+	_scx = (_scx - 2) & 0xFF
+	if _scx != 0x60:
+		return
+	_tube_anim_tilemap(TUBE_STATE_0)
+	_increment()
+
+
+func _cmd_tube_to_player_5() -> void:
+	_flash_bg_pals()
+	_scx = (_scx - 2) & 0xFF
+	if _scx != 0:
+		return
+	_increment()
+
+
+func _cmd_tube_wait() -> void:
+	_flash_bg_pals()
+	if _counter > 0:
+		_counter -= 1
+		return
+	_increment()
+
+
+func _cmd_tube_long_wait() -> void:
+	_counter = 128
+	_increment()
+
+
+func _cmd_tube_done() -> void:
+	_clear_sprite_anims()
+	_bg_map = _blank_run(MAP_COLUMNS * MAP_ROWS)
+	_window_map = _blank_run(MAP_COLUMNS * MAP_ROWS)
+	_clear_tilemap()
+	_scx = 0
+	_wy = 0x90
+	_object_sheet = &"ball"
+	_wait_bg_map()
+	_tube_palette = false
+	_bgp = 0xE4
+	_obp0 = 0xE4
+	_cmd_advance()
+
+
+func _flash_bg_pals() -> void:
+	if _counter2 & 0x7 != 0:
+		return
+	_bgp ^= 0x3C
+
+
+func _cmd_sent_to_ot_text() -> void:
+	## `LINK_TIMECAPSULE` skips the 189 frames of `_MonNameSentToText`, an empty box.
+	if _link_mode == LINK_TIMECAPSULE:
+		_print_text(_box_text("was_sent"))
+		_delay += 80
+		_cmd_advance()
+		return
+	_print_text([])
+	_delay += 189
+	_print_text(_box_text("was_sent"))
+	_delay += 80 + 128
+	_cmd_advance()
+
+
+func _cmd_ot_bids_farewell() -> void:
+	_print_text(_box_text("bids_farewell"))
+	_delay += 80
+	_print_text(_box_text("name_bids_farewell"))
+	_delay += 80
+	_cmd_advance()
+
+
+func _cmd_take_care_of_text() -> void:
+	_clear_rows(10, 8)
+	_print_text(_box_text("take_good_care"))
+	_delay += 80
+	_cmd_advance()
+
+
+func _cmd_ot_sends_text_1() -> void:
+	_print_text(_box_text("for_your_mon_sends"))
+	_delay += 80
+	_print_text(_box_text("ot_sends"))
+	_delay += 80 + 14
+	_cmd_advance()
+
+
+func _cmd_ot_sends_text_2() -> void:
+	_print_text(_box_text("will_trade"))
+	_delay += 80
+	_print_text(_box_text("for_your_mon_will_trade"))
+	_delay += 80 + 14
+	_cmd_advance()
+
+
+func _box_text(name: String) -> Array:
+	if _data == null:
+		return []
+	var text: String = _data.special_text("trade", name)
+	if text.is_empty():
+		return []
+	for buffer: String in [
+		"player_trademon_species_name", "player_trademon_sender_name",
+		"ot_trademon_species_name", "ot_trademon_sender_name",
+	]:
+		var address: int = _data.special_text_ram(buffer)
+		if address < 0:
+			continue
+		text = text.replace(
+			"%s%04X>" % [Gen2TextStream.RAM_MARKER, address], _buffer_value(buffer)
+		)
+	var pages: Array = Gen2TextLayout.lay_out(
+		text, SPEECH_BOX.size.x - 2, Gen2TextBox.LINE_SPACING
+	)
+	return Array(pages[0]) if not pages.is_empty() else []
+
+
+func _buffer_value(buffer: String) -> String:
+	match buffer:
+		"player_trademon_species_name":
+			return String(_player.get("species_name", ""))
+		"ot_trademon_species_name":
+			return String(_ot.get("species_name", ""))
+		"player_trademon_sender_name":
+			return _sender_1
+		_:
+			return _sender_2
+
+
+func _print_text(lines: Array) -> void:
+	_draw_box(SPEECH_BOX)
+	for line: int in lines.size():
+		_place_string(
+			String(lines[line]),
+			SPEECH_TEXT_AT + Vector2i(0, line * Gen2TextBox.LINE_SPACING)
+		)
+	_wait_bg_map()
+
+
+func _place_stats_on_tube(arrow: int) -> void:
+	_map_target = 1
+	_clear_tilemap()
+	for column: int in COLUMNS:
+		_tilemap[column] = 0x7A
+	_place_string(_sender_1, Vector2i(0, 1))
+	_place_string(_sender_2, Vector2i(COLUMNS - _sender_2.length(), 3))
+	for column: int in 6:
+		_tilemap[2 * COLUMNS + 7 + column] = arrow
+	_wait_bg_map()
+	_map_target = 0
+	_clear_tilemap()
+
+
+func _tube_anim_tilemap(state: int) -> void:
+	_clear_tilemap()
+	if state == TUBE_STATE_1:
+		for column: int in COLUMNS:
+			_tilemap[3 * COLUMNS + column] = CABLE_STRAIGHT
+		_wait_bg_map()
+		return
+	if state == TUBE_STATE_2:
+		_tube_anim_tilemap_two()
+		_wait_bg_map()
+		return
+	_tilemap[3 * COLUMNS + 9] = CABLE_END_LEFT
+	for column: int in 10:
+		_tilemap[3 * COLUMNS + 10 + column] = CABLE_STRAIGHT
+	_copy_box(
+		_tilemap_run("game_boy_tilemap"),
+		RomLayout.TRADE_ANIM_GAME_BOY_SIZE, Vector2i(3, 2)
+	)
+	_wait_bg_map()
+
+
+func _tube_anim_tilemap_two() -> void:
+	for column: int in 0x11:
+		_tilemap[3 * COLUMNS + column] = CABLE_STRAIGHT
+	_tilemap[3 * COLUMNS + 17] = CABLE_PLUG
+	for row: int in 3:
+		_tilemap[(4 + row) * COLUMNS + 17] = CABLE_VERTICAL
+	_tilemap[7 * COLUMNS + 16] = CABLE_CORNER
+	_tilemap[7 * COLUMNS + 17] = CABLE_END_LEFT
+	_copy_box(
+		_tilemap_run("game_boy_tilemap"),
+		RomLayout.TRADE_ANIM_GAME_BOY_SIZE, Vector2i(10, 6)
+	)
+
+
+func _show_stats(side: Dictionary) -> void:
+	_map_target = 1
+	_clear_tilemap()
+	_draw_box(Rect2i(3, 0, 15, 8))
+	if int(side.get("species", 0)) == EGG:
+		_place_string("EGG", Vector2i(4, 2))
+		_place_string("OT/?????", Vector2i(4, 4))
+		_place_codes(STATS_ID_ROW, Vector2i(4, 6))
+		_place_string("?????", Vector2i(4 + STATS_ID_ROW.size(), 6))
+		_wait_bg_map()
+		_map_target = 0
+		return
+	_place_codes(STATS_RULE_ROW, Vector2i(4, 0))
+	_place_string("OT/", Vector2i(4, 4))
+	_place_codes(STATS_ID_ROW, Vector2i(4, 6))
+	_place_string(
+		str(int(side.get("species", 0))).lpad(3, "0"), Vector2i(10, 0)
+	)
+	## Crystal alone writes a space over the cell the number ended on.
+	if _crystal:
+		_tilemap[13] = BLANK
+	_place_string(String(side.get("species_name", "")), Vector2i(4, 2))
+	_place_ot(side)
+	_place_string(str(int(side.get("ot_id", 0))).lpad(5, "0"), Vector2i(7, 6))
+	_wait_bg_map()
+	_map_target = 0
+
+
+func _place_ot(side: Dictionary) -> void:
+	var name: String = String(side.get("ot_name", ""))
+	_place_string(name, Vector2i(7, 4))
+	if not _crystal:
+		return
+	var gender: int = int(side.get("caught_gender", 0))
+	if gender >= GENDER_CODES.size():
+		gender = 0
+	_place_codes([GENDER_CODES[gender]], Vector2i(7 + name.length() + 1, 4))
+
+
+func _show_frontpic(side: StringName) -> void:
+	var record: Dictionary = _ot if side == &"ot" else _player
+	var species: int = int(record.get("species", 0))
+	_pic_pixels = PackedByteArray()
+	_pic_palette = PackedColorArray()
+	var pic: Dictionary = {} if _data == null \
+		else (_data.egg_pic() if species == EGG else _data.species_pic(species))
+	if not pic.is_empty():
+		_pic_pixels = Gen2BattleRenderer.padded_pic(
+			_data, pic, PIC_TILES, true,
+			{} if species == EGG else _data.species_pic_animation(species)
+		)
+		_pic_palette = _data.egg_palette() if species == EGG \
+			else _data.palette(species, bool(record.get("shiny", false)))
+	_clear_tilemap()
+	_reset_frontpic_box()
+	for column: int in PIC_TILES:
+		for row: int in PIC_TILES:
+			_tilemap[(PIC_AT.y + row) * COLUMNS + PIC_AT.x + column] = \
+				column * PIC_TILES + row
+	_wait_bg_map()
+
+
+func _reset_frontpic_box() -> void:
+	_pic_box = PackedByteArray()
+	_pic_box.resize(PIC_TILES * PIC_TILES)
+	for cell: int in _pic_box.size():
+		_pic_box[cell] = cell
+
+
+func _tilemap_run(name: String) -> PackedByteArray:
+	return PackedByteArray() if _data == null else _data.trade_anim_tilemap(name)
+
+
+func _clear_tilemap() -> void:
+	_tilemap.fill(BLANK)
+	_wait_bg_map()
+
+
+func _clear_rows(top: int, rows: int) -> void:
+	for cell: int in rows * COLUMNS:
+		_tilemap[top * COLUMNS + cell] = BLANK
+	_wait_bg_map()
+
+
+## `UpdateBGMap`, into whichever map `hBGMapAddress` names. A third of the rows a
+## frame on the cartridge and all of them here, the standing divergence.
+func _wait_bg_map() -> void:
+	var into: PackedByteArray = _window_map if _map_target == 1 else _bg_map
+	for row: int in ROWS:
+		for column: int in COLUMNS:
+			into[row * MAP_COLUMNS + column] = _tilemap[row * COLUMNS + column]
+
+
+func _draw_box(box: Rect2i) -> void:
+	var codes: Array[int] = BOX_CODES
+	var right: int = box.position.x + box.size.x - 1
+	var bottom: int = box.position.y + box.size.y - 1
+	_write(codes[0], box.position)
+	_write(codes[2], Vector2i(right, box.position.y))
+	_write(codes[4], Vector2i(box.position.x, bottom))
+	_write(codes[5], Vector2i(right, bottom))
+	for column: int in range(box.position.x + 1, right):
+		_write(codes[1], Vector2i(column, box.position.y))
+		_write(codes[1], Vector2i(column, bottom))
+	for row: int in range(box.position.y + 1, bottom):
+		_write(codes[3], Vector2i(box.position.x, row))
+		_write(codes[3], Vector2i(right, row))
+		for column: int in range(box.position.x + 1, right):
+			_write(BLANK, Vector2i(column, row))
+
+
+func _place_string(text: String, at: Vector2i) -> void:
+	_place_codes(Array(Gen2Text.encode(text)), at)
+
+
+func _place_codes(codes: Array, at: Vector2i) -> void:
+	for index: int in codes.size():
+		_write(int(codes[index]), at + Vector2i(index, 0))
+
+
+func _write(code: int, at: Vector2i) -> void:
+	if at.x < 0 or at.x >= COLUMNS or at.y < 0 or at.y >= ROWS:
+		return
+	_tilemap[at.y * COLUMNS + at.x] = code
+
+
+func _copy_box(cells: PackedByteArray, size: Vector2i, at: Vector2i) -> void:
+	if cells.size() < size.x * size.y:
+		return
+	for row: int in size.y:
+		for column: int in size.x:
+			_write(int(cells[row * size.x + column]), at + Vector2i(column, row))
+
+
+func _clear_sprite_anims() -> void:
+	_actors.clear()
+	_actors.resize(ANIM_STRUCTS)
+	_anim_count = 0
+	_shadow = []
+
+
+func _spawn(object: StringName, at: Vector2i) -> Dictionary:
+	var slot: int = -1
+	for index: int in _actors.size():
+		if (_actors[index] as Dictionary).is_empty():
+			slot = index
+			break
+	if slot < 0:
+		return {}
+	_anim_count = (_anim_count + 1) & 0xFF
+	if _anim_count == 0:
+		_anim_count = 1
+	var actor: Dictionary = {
+		"index": _anim_count,
+		"object": object,
+		"frameset": StringName((OBJECTS[object] as Dictionary)["frameset"]),
+		"func": StringName((OBJECTS[object] as Dictionary)["func"]),
+		"vtile": DICT_DEFAULT_TILE,
+		"x": at.x, "y": at.y,
+		"x_offset": 0, "y_offset": 0,
+		"duration": 0, "frame": -1,
+		"jumptable": 0, "var1": 0, "var2": 0,
+	}
+	_actors[slot] = actor
+	return actor
+
+
+func _run_sprites() -> void:
+	for slot: int in _actors.size():
+		if bool((_actors[slot] as Dictionary).get("deinit", false)):
+			_actors[slot] = {}
+	_shadow = []
+	var room: int = SHADOW_OAM_SPRITES
+	for slot: int in _actors.size():
+		var actor: Dictionary = _actors[slot]
+		if actor.is_empty():
+			continue
+		if not _run_sprite_func(actor):
+			actor["deinit"] = true
+		if not _advance_actor(actor):
+			_actors[slot] = {}
+			continue
+		var entry: Array = _actor_frame(actor)
+		if entry.is_empty():
+			continue
+		_shadow.append({
+			"at": Vector2i(
+				(int(actor["x"]) + int(actor["x_offset"])) & 0xFF,
+				(int(actor["y"]) + int(actor["y_offset"])) & 0xFF,
+			),
+			"set": int(entry[0]),
+			"flip_x": bool(int(entry[2]) & FLIP_X),
+			"vtile": int(actor["vtile"]),
+		})
+		room -= OAM_SET_SIZES[int(entry[0])]
+		if room <= 0:
+			return
+
+
+func _run_sprite_func(actor: Dictionary) -> bool:
+	match StringName(actor["func"]):
+		&"ball":
+			return _sprite_ball(actor)
+		&"bulge":
+			return _sprite_bulge(actor)
+		&"in_tube":
+			return _sprite_in_tube(actor)
+	return true
+
+
+func _sprite_ball(actor: Dictionary) -> bool:
+	match int(actor["jumptable"]):
+		0:
+			actor["frameset"] = &"ball_wobble"
+			actor["frame"] = -1
+			actor["duration"] = 0
+			actor["jumptable"] = 2
+			actor["var1"] = 0x20
+		1:
+			actor["jumptable"] = 4
+			actor["var1"] = 0x30
+			actor["var2"] = 0x24
+		2:
+			return _sprite_ball_settle(actor)
+		3:
+			return _sprite_ball_rise(actor)
+		4:
+			return _sprite_ball_bounce(actor)
+		_:
+			return false
+	return true
+
+
+func _sprite_ball_settle(actor: Dictionary) -> bool:
+	if int(actor["var1"]) != 0:
+		actor["var1"] = int(actor["var1"]) - 1
+		return true
+	actor["jumptable"] = 3
+	actor["var1"] = 0x40
+	return _sprite_ball_rise(actor)
+
+
+func _sprite_ball_rise(actor: Dictionary) -> bool:
+	var angle: int = int(actor["var1"])
+	if angle < 48:
+		_emit(&"play_sfx", {"sfx": SFX_GOT_SAFARI_BALLS})
+		return false
+	## `dec [hl]` leaves `a` holding the angle the sine is read at.
+	actor["var1"] = angle - 1
+	actor["y_offset"] = _sine_at(angle, 40)
+	return true
+
+
+func _sprite_ball_bounce(actor: Dictionary) -> bool:
+	if int(actor["var2"]) == 0:
+		actor["y_offset"] = 0
+		actor["jumptable"] = 5
+		return true
+	actor["y_offset"] = _sine_at(int(actor["var1"]), int(actor["var2"]))
+	actor["var1"] = (int(actor["var1"]) + 1) & 0xFF
+	if int(actor["var1"]) & 0x3F != 0:
+		return true
+	actor["var1"] = 0x20
+	actor["var2"] = (int(actor["var2"]) - 0x0C) & 0xFF
+	_emit(&"play_sfx", {"sfx": SFX_SWITCH_POKEMON})
+	return true
+
+
+func _sprite_bulge(actor: Dictionary) -> bool:
+	var x: int = int(actor["x"])
+	## Crystal's `inc [hl]` twice against Gold and Silver's one, which is why
+	## theirs is given twice as long to cross.
+	actor["x"] = (x + (2 if _crystal else 1)) & 0xFF
+	if x >= 0xB0:
+		return false
+	if x & 0x3 != 0:
+		return true
+	_emit(&"play_sfx", {"sfx": SFX_POKEBALLS_PLACED_ON_TABLE})
+	return true
+
+
+func _sprite_in_tube(actor: Dictionary) -> bool:
+	match int(actor["jumptable"]):
+		0:
+			actor["jumptable"] = 1
+			actor["var1"] = 0x80
+			return true
+		1:
+			var timer: int = int(actor["var1"])
+			actor["var1"] = (timer - 1) & 0xFF
+			if timer != 0:
+				return true
+			actor["jumptable"] = 2
+			return _tube_move_right(actor)
+		2:
+			return _tube_move_right(actor)
+		3:
+			return _tube_move_down(actor)
+		4:
+			return _tube_move_up(actor)
+		5:
+			return _tube_move_left(actor)
+	var wait: int = int(actor["var1"])
+	actor["var1"] = (wait - 1) & 0xFF
+	return wait != 0
+
+
+func _tube_move_right(actor: Dictionary) -> bool:
+	if int(actor["x"]) < 0x94:
+		actor["x"] = int(actor["x"]) + 1
+		return true
+	actor["jumptable"] = 3
+	return _tube_move_down(actor)
+
+
+func _tube_move_down(actor: Dictionary) -> bool:
+	if int(actor["y"]) < 0x4C:
+		actor["y"] = int(actor["y"]) + 1
+		return true
+	return false
+
+
+func _tube_move_up(actor: Dictionary) -> bool:
+	if int(actor["y"]) != 0x2C:
+		actor["y"] = int(actor["y"]) - 1
+		return true
+	actor["jumptable"] = 5
+	return _tube_move_left(actor)
+
+
+func _tube_move_left(actor: Dictionary) -> bool:
+	if int(actor["x"]) != 0x58:
+		actor["x"] = int(actor["x"]) - 1
+		return true
+	actor["jumptable"] = 6
+	actor["var1"] = 0x80
+	return true
+
+
+func _advance_actor(actor: Dictionary) -> bool:
+	var frameset: Dictionary = FRAMESETS[StringName(actor["frameset"])]
+	var frames: Array = frameset["frames"]
+	if int(actor["duration"]) > 0:
+		actor["duration"] = int(actor["duration"]) - 1
+		return true
+	var next: int = int(actor["frame"]) + 1
+	if next >= frames.size():
+		match StringName(frameset["end"]):
+			FRAMESET_DELETE:
+				return false
+			FRAMESET_RESTART:
+				next = 0
+			_:
+				next = maxi(frames.size() - 1, 0)
+	actor["frame"] = next
+	actor["duration"] = int((frames[next] as Array)[1])
+	return true
+
+
+func _actor_frame(actor: Dictionary) -> Array:
+	var frames: Array = (FRAMESETS[StringName(actor["frameset"])] as Dictionary)["frames"]
+	var at: int = int(actor["frame"])
+	return frames[at] if at >= 0 and at < frames.size() else []
+
+
+func _sine_at(angle: int, amplitude: int) -> int:
+	return 0 if _sine == null else Gen2BattleAnimFunctions.sine_of(_sine, angle, amplitude)
+
+
+func _emit(type: StringName, values: Dictionary) -> void:
+	var event: Dictionary = values.duplicate()
+	event["type"] = type
+	event["frame"] = _frame
+	_events.append(event)

--- a/game/world/trade_animation.gd.uid
+++ b/game/world/trade_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://0hi3kk1sgat0

--- a/game/world/trade_animation_screen.gd
+++ b/game/world/trade_animation_screen.gd
@@ -1,0 +1,85 @@
+class_name Gen2TradeAnimationScreen
+extends Control
+
+## [Gen2TradeAnimation] with [Gen2TradeAnimationPage] in front of it, for a host
+## that has a screen. The trade itself is already committed when this opens, the
+## way `NPCTrade` calls `DoNPCTrade` before its animation.
+
+signal closed()
+signal cry_requested(species: int)
+signal sfx_requested(index: int)
+signal music_requested(index: int)
+
+const FRAME_CAP: int = 20000
+
+var _movie: Gen2TradeAnimation = null
+var _page: Gen2TradeAnimationPage = null
+var _background: TextureRect = null
+
+
+## [param context] is what [method Gen2TradeAnimation.create] takes.
+func set_context(
+	data: GameData, context: Dictionary, half: int = Gen2TradeAnimation.PLAYER_1
+) -> void:
+	_page = Gen2TradeAnimationPage.from_data(data)
+	_movie = Gen2TradeAnimation.create(
+		data, Gen2BattleAnimData.from_game_data(data), context, half
+	)
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	if _movie == null or _page == null:
+		closed.emit()
+		return
+	_background = TextureRect.new()
+	_background.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_background.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(_background)
+	_forward(_movie.drain_events())
+	_refresh()
+
+
+## `TradeAnimation` reads no joypad, so a press is spent rather than passed on.
+func handle_button(_button: int) -> bool:
+	return true
+
+
+func movie() -> Gen2TradeAnimation:
+	return _movie
+
+
+func advance_frame() -> void:
+	if _movie == null or _movie.finished():
+		return
+	_forward(_movie.advance_frame())
+	_refresh()
+	if _movie.finished():
+		closed.emit()
+
+
+func settle() -> void:
+	if _movie == null:
+		return
+	while not _movie.finished() and _movie.frame() < FRAME_CAP:
+		_forward(_movie.advance_frame())
+	closed.emit()
+
+
+func _forward(events: Array) -> void:
+	for event: Dictionary in events:
+		match StringName(event["type"]):
+			&"play_music":
+				music_requested.emit(int(event["music"]))
+			&"play_sfx":
+				sfx_requested.emit(int(event["sfx"]))
+			&"play_cry":
+				cry_requested.emit(int(event["species"]))
+
+
+func _refresh() -> void:
+	if _background == null:
+		return
+	Gen2PicImage.show(_background, _page.draw(_movie))
+	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)

--- a/game/world/trade_animation_screen.gd.uid
+++ b/game/world/trade_animation_screen.gd.uid
@@ -1,0 +1,1 @@
+uid://2bpw5pcjkwvl

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -2,7 +2,6 @@ class_name Gen2WorldPartyHost
 extends RefCounted
 
 ## Scene-free transactions for party-owned overworld operations.
-##
 ## A script can stage world changes and then pause for a gift, egg or NPC trade.
 ## The host builds a candidate save first, resumes the script, and only writes
 ## the candidate after both sides have succeeded. The six-party limit is
@@ -433,6 +432,46 @@ static func commit_link_trade(
 		"received_slot": save.party.size() - 1,
 		"partner": String(peer.get("name", "")),
 		"evolution": evolution.duplicate(true),
+		"animation": trade_animation_context(
+			world.data, given, received, save.player_name,
+			String(peer.get("name", "")),
+			int(peer.get("link_mode", Gen2LinkSession.LINK_TRADECENTER))
+		),
+	}
+
+
+## What `TradeAnimation` is handed: `wPlayerTrademon*` for the Pokemon leaving
+## and `wOTTrademon*` for the one arriving. The names are the species' own,
+## `TradeAnim_GetNicknamename` calling `GetPokemonName`.
+static func trade_animation_context(
+	data: GameData,
+	given: Gen2SaveMon,
+	received: Gen2SaveMon,
+	sender: String,
+	ot_sender: String,
+	link_mode: int
+) -> Dictionary:
+	return {
+		"player": _trade_animation_half(data, given, sender),
+		"ot": _trade_animation_half(data, received, ot_sender),
+		"link_mode": link_mode,
+	}
+
+
+static func _trade_animation_half(
+	data: GameData, mon: Gen2SaveMon, sender: String
+) -> Dictionary:
+	if mon == null:
+		return {}
+	var species: int = Gen2TradeAnimation.EGG if mon.is_egg else mon.species
+	return {
+		"species": species,
+		"species_name": String(data.species(mon.species).get("name", "")),
+		"sender_name": sender,
+		"ot_name": mon.original_trainer,
+		"ot_id": mon.ot_id,
+		"caught_gender": mon.caught_gender,
+		"shiny": Gen2Stats.is_shiny(mon.dvs),
 	}
 
 
@@ -469,7 +508,6 @@ static func record_link_battle(
 ## `HealParty`'s own walk, without the transaction around it: full HP, no status
 ## and full PP for every party member that is not an egg. Answers how many rows
 ## it moved, or -1 for a row the battle adapter cannot read.
-##
 ## Shared, because the whiteout heals the same party [method heal_party] does and
 ## reaches it from a screen rather than from a `special`.
 static func heal_party_rows(data: GameData, save: Gen2SaveData) -> int:
@@ -848,7 +886,6 @@ static func change_happiness(data: GameData, happiness: int, kind: int) -> int:
 ## `HaircutOrGrooming`'s `Random` walk over one of the three tables: subtract
 ## each threshold in turn and take the row that borrows. [param roll] is the
 ## byte `Random` answered and [param crystal] picks the overrun's own address.
-##
 ## Answers `{"script_value": int, "happiness_kind": int}`. A kind no
 ## `HappinessChanges` row exists for leaves [method change_happiness]'s byte
 ## alone, which is exactly what the cartridge's overrun does with it.
@@ -870,7 +907,6 @@ static func groom_outcome(routine: StringName, roll: int, crystal: bool) -> Dict
 ## member that is not an egg, saturating at 255 rather than wrapping, and
 ## reaching no `HappinessChanges` row at all. The step counter that decides how
 ## often is [method Gen2WorldState.count_step]'s.
-##
 ## Answers the slots that moved, so a caller can persist only when the walk
 ## actually changed something.
 static func apply_step_happiness(save: Gen2SaveData, times: int = 1) -> Array[int]:
@@ -958,7 +994,6 @@ static func gift_destination(save: Gen2SaveData) -> StringName:
 ## front taking one hatch cycle off every egg, and stops on the first egg whose
 ## counter reaches zero, so an egg behind that one keeps its cycle for that
 ## step. Answers the party index of the egg that is ready to hatch, or -1.
-##
 ## The counter lives in the happiness byte, which is what `GiveEgg` wrote and
 ## what `HatchEggs` reads; [method apply_step_happiness] skips eggs for the same
 ## reason.
@@ -1132,7 +1167,6 @@ static func contest_return_mons(save: Gen2SaveData) -> int:
 ## the save/world writeback. A caught mon enters the party when there is room and
 ## otherwise goes to the front of the box the player has open, which is the one
 ## `SendMonIntoBox` deposits into.
-##
 ## [param thrower] is the player's active battler, which LEVEL_BALL and LOVE_BALL
 ## read; see [method _ball_multiplier].
 static func capture_wild(
@@ -1373,7 +1407,6 @@ static func _apply_contest_mon(
 ## party or the box: `NamingScreen` writes into `wPartyMonNicknames` or
 ## `sBoxMonNicknames` rather than into the struct the catch built, so the rename
 ## is its own write and not part of [method capture_wild]'s transaction.
-##
 ## [param destination] is that method's own answer. Nothing is written when the
 ## player kept the species name, which is what NO and an empty entry both leave
 ## in `wStringBuffer1`.
@@ -1611,6 +1644,12 @@ static func _apply_trade_request(
 			"kind": &"trade", "accepted": true, "trade_id": trade_id,
 			"given_species": requested.species,
 			"received_species": received.species,
+			## `DoNPCTrade` fills the trade buffers and `.TradeAnimation` runs
+			## straight off them.
+			"animation": trade_animation_context(
+				world.data, requested, received, candidate.player_name,
+				String(trade.get("ot_name", "")), Gen2LinkSession.LINK_TRADECENTER
+			),
 		},
 	}
 
@@ -1813,7 +1852,6 @@ static func _apply_heal(
 ## `UpdateStatsAfterItem`'s max-HP delta added to the current HP,
 ## `LevelUpHappinessMod`, `LearnLevelMoves` and then `EvolvePokemon` with
 ## `wForceEvolution` clear. `MAX_LEVEL` is `NoEffectMessage` rather than a clamp.
-##
 ## The happiness row is `HAPPINESS_GAINLEVEL` flat: `LevelUpHappinessMod`'s
 ## at-home row compares the caught landmark against the *battle's* landmark, and
 ## a field item is not in one.
@@ -2118,7 +2156,6 @@ static func contest_mon_from(wild: Gen2BattleMon) -> Dictionary:
 
 
 ## `PokeBallEffect`'s roll, from `wEnemyMonCatchRate` down to `wFinalCatchRate`.
-##
 ## [param battle_type] is `wBattleType`: BATTLETYPE_TUTORIAL catches without a
 ## roll, the way a MASTER_BALL does. [param thrower] is the player's active
 ## battler, which LEVEL_BALL reads a level off and LOVE_BALL a species and a
@@ -2157,7 +2194,6 @@ static func _capture_outcome(
 
 ## `wFinalCatchRate`: everything `PokeBallEffect` settles between
 ## `ld a, [wEnemyMonCatchRate]` and the `call Random` that reads the answer.
-##
 ## Split out from the throw because the cartridge can be asked the same question
 ## directly: `.claude/oracle/battle/catch_rate.py` runs those instructions on a
 ## real dump for a grid of cases, and [param case] is that grid's own row. The
@@ -2424,7 +2460,6 @@ static func rename_party_mon(
 ## `HatchEggs` for one party slot: the egg becomes the Pokemon it was carrying.
 ## Everything here is the source's own order, and every one of the seven writes
 ## has a reader in this project, which is why none is left out.
-##
 ## Answers the summary the screen shows, or an empty dictionary when the slot is
 ## not an egg that is ready.
 static func hatch_egg(
@@ -2490,7 +2525,6 @@ static func _failure(reason: StringName, details: Dictionary) -> Dictionary:
 ## `EvolveAfterBattle`. Both halves are gated on
 ## `STATUSFLAGS2_REACHED_GOLDENROD_F`, and both are pure party writes, so the
 ## whole routine is one call the world boundary makes on a battle it won.
-##
 ## Returns what changed, for a caller that wants to say so: an empty dictionary
 ## when neither half did anything.
 static func give_pokerus_and_convert_berries(
@@ -2633,7 +2667,6 @@ static func apply_pokerus_tick(save: Gen2SaveData, days: int) -> bool:
 ## `CalcMagikarpLength`, in feet and inches. [param dvs] is MON_DVS' two bytes
 ## and [param player_id] is wPlayerID, read high byte first the way the routine
 ## reads it.
-##
 ## `.BCLessThanDE`'s `ret c / ret nc` is reproduced rather than fixed: the low
 ## byte is never reached, so the row is chosen on the threshold's high byte
 ## alone, which is what `MagikarpLengths`' own comment says the table really
@@ -2692,7 +2725,6 @@ static func magikarp_beats_record(length: Vector2i, record: Dictionary) -> bool:
 
 ## `CheckForLuckyNumberWinners`, as one walk over the ID numbers the party
 ## mirror carries.
-##
 ## [param stored_ids] and [param stored_species] are every box slot in one list,
 ## which is what the source's open-box pass plus its `.BoxesLoop` skipping
 ## `wCurBox` add up to. Answers `{script_value, species, in_storage}`, where a
@@ -2751,7 +2783,6 @@ static func _lucky_number_score(wanted: String, mon_id: int) -> int:
 
 ## `GiveShuckle`. A level 15 SHUCKLE holding a BERRY, named SHUCKIE under
 ## MANIA's name and ID, with `SetGiftPartyMonCaughtData`'s CAUGHT_BY_UNKNOWN.
-##
 ## `TryAddMonToParty` and nothing else: a full party is `.NotGiven`, which
 ## answers zero and never reaches a box. The daily flag behind it is the
 ## script's own `setflag`, which has already run by here.
@@ -2802,7 +2833,6 @@ static func odd_egg_row(rolled: int, probabilities: Array) -> int:
 ## The Day-Care Man's Odd Egg. `AddMobileMonToParty` appends the row as it
 ## stands, with `wTempOddEggNickname` as the OT and the row's own `dname` as the
 ## nickname, so nothing about it is rolled except which of the fourteen it is.
-##
 ## The party-full refusal is the script's own `readvar VAR_PARTYCOUNT` ahead of
 ## the special, so the routine is never entered with a full party and appending
 ## cannot fail; it is answered here as well because a mod can call the special

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2,7 +2,6 @@ class_name Gen2WorldScreen
 extends Control
 
 ## Cartridge-backed overworld screen.
-##
 ## A validated world snapshot is authoritative. The explicit map and cell are
 ## retained as a development entry point for scene tests and cache inspection.
 
@@ -177,6 +176,9 @@ var _evolution_save: Gen2SaveData = null
 ## `OverworldHatchEgg`'s screen and the save whose party it has already written.
 var _hatch_host: Gen2EggHatchScreen = null
 var _hatch_save: Gen2SaveData = null
+## `TradeAnimation` and the script results it stands in front of.
+var _trade_anim_host: Gen2TradeAnimationScreen = null
+var _trade_anim_results: Array = []
 ## `GiveANickname_YesNo`'s screen, standing between `givepoke` staging the
 ## request and the party host applying it.
 var _nickname_host: Gen2NicknamePromptScreen = null
@@ -588,7 +590,6 @@ func _build_world() -> void:
 
 
 ## Hands this world to the lower display, where the build has one.
-##
 ## The display itself belongs to [Gen2GameRuntime] and is up in the launcher too;
 ## all this screen owns is which world is on it. Handed back on the way out, so
 ## closing a game puts the launcher's own mark back rather than leaving the last
@@ -608,7 +609,6 @@ func _exit_tree() -> void:
 
 ## Builds the view for the selected renderer and attaches it to the layer that
 ## renderer asked for.
-##
 ## Constructed through the mod host, so a registered renderer replaces this view
 ## without the screen knowing what it draws with. A renderer answering the
 ## surface question false gets the screen's rectangle at window resolution
@@ -859,6 +859,7 @@ const FRAME_HOSTS: Array[Array] = [
 	["_battle_host", "advance_hardware_frame"],
 	["_evolution_host", "advance_frame"],
 	["_link_host", "advance_frame"],
+	["_trade_anim_host", "advance_frame"],
 	["_hatch_host", "advance_frame"],
 	["_nickname_host", "advance_frame"],
 	["_name_rater_host", "advance_frame"],
@@ -1163,7 +1164,6 @@ func _advance_forced_movement() -> void:
 
 ## Walking goes on while a direction is held, whatever is holding it: a key, a
 ## stick, a d-pad or a thumb on the on-screen controller.
-##
 ## Polled rather than driven by repeated events, because the rate a held key
 ## repeats at belongs to the operating system and has nothing to do with the
 ## hardware. The poll runs once per hardware frame, which is what the source
@@ -1215,6 +1215,7 @@ const FULLSCREEN_HOSTS: Array[StringName] = [
 	&"_pokedex_host",
 	&"_credits_host",
 	&"_evolution_host",
+	&"_trade_anim_host",
 	&"_hatch_host",
 	&"_nickname_host",
 	&"_name_rater_host",
@@ -1337,6 +1338,9 @@ const OVERLAY_HOSTS: Array[StringName] = [
 	## loop suspended, and the pack path reaches it with the pack still open
 	## behind it, so its B is the animation's cancel rather than the pack's back.
 	&"_evolution_host",
+	## `TradeAnimation` stands over whatever ran the trade, the trade room's own
+	## screen included, and answers no button.
+	&"_trade_anim_host",
 	## The same rule for `OverworldHatchEgg`, which `PlayerEvents` runs with the
 	## map loop suspended in exactly the same place.
 	&"_hatch_host",
@@ -1520,18 +1524,26 @@ func _complete_pending_request(result: Dictionary = {"ok": true}) -> Dictionary:
 
 
 ## A request that spends no press on the cartridge, settled where it is staged.
-## Empty when the host refused it, which leaves the caller its own prompt: a
-## save with no party heals nothing, and that is a reason, not a press.
-func _complete_unattended_request() -> Array:
+## A refusal leaves the caller its own prompt: a save with no party heals
+## nothing, and that is a reason, not a press. An `NPCTrade` that took is the
+## one of these with a movie behind it, and its results wait for it.
+func _settle_unattended_request() -> StringName:
 	var settled: Dictionary = _complete_pending_request()
 	if not bool(settled.get("ok", false)):
 		_script_prompt = "Host unavailable: %s" % String(settled.get("reason", "unknown"))
-		return []
-	return settled.get("results", [])
+		return &"none"
+	var results: Array = settled.get("results", [])
+	if results.is_empty():
+		return &"none"
+	var summary: Dictionary = settled.get("transaction", {})
+	if bool(summary.get("accepted", false)) \
+		and _open_trade_animation(summary.get("animation", {}), results):
+		return &"break"
+	_show_script_results(results)
+	return &"return"
 
 
 ## Zoom, on the keys every map program uses for it and on the wheel.
-##
 ## Only while the map itself has the screen: a text box, a menu or a script is
 ## laid out against the 160x144 rectangle and moving the surface under one is
 ## the player losing their place. A framed screen refuses the step, since there
@@ -1751,7 +1763,6 @@ func _spend_step_happiness() -> void:
 ## `DoEggStep` and the `PLAYEREVENT_HATCH` it raises. The party lives on the
 ## save, so the walk counts the step and this spends it, the way
 ## [method _spend_step_happiness] does for `StepHappiness`.
-##
 ## `HatchEggs` walks the whole party, so every egg the pass left on zero hatches
 ## in one screen rather than one per step.
 func _spend_egg_steps() -> void:
@@ -1779,7 +1790,6 @@ func _spend_egg_steps() -> void:
 ## carries to 4 and which resets the counter whether or not anything is
 ## poisoned. The party lives on the save, so the walk counts the step and this
 ## spends it, the way [method _spend_step_happiness] does for `StepHappiness`.
-##
 ## Answers whether it took the screen: a faint is `PLAYEREVENT_WHITEOUT`'s own
 ## script, and everything a step still owes waits behind its presses.
 func _spend_poison_steps() -> bool:
@@ -1975,7 +1985,6 @@ func _show_player_event(texts: PackedStringArray, after: Callable) -> void:
 ## `DayCareStep`, which `CountStep` reaches on every step that did not hatch an
 ## egg: `jr nz, .hatch` jumps over the `farcall`, and the hatch screen standing
 ## is what says this step was one of those.
-##
 ## The two slots live in the world state rather than on the save, so nothing here
 ## is a save transaction; what it can produce is `DAYCAREMAN_HAS_EGG_F`, which
 ## the man outside the Day-Care reads.
@@ -2009,6 +2018,43 @@ func _open_hatch(hatches: Array, save: Gen2SaveData) -> void:
 	_refresh_labels()
 
 
+## `RunTradeAnimScript`. [param results] are shown when the movie ends. False
+## when the cache carries no trade art, which leaves them to the caller.
+func _open_trade_animation(context: Dictionary, results: Array = []) -> bool:
+	if _trade_anim_host != null or _data == null or context.is_empty():
+		return false
+	var host := Gen2TradeAnimationScreen.new()
+	host.set_context(_data, context)
+	host.closed.connect(_on_trade_animation_closed)
+	host.cry_requested.connect(_play_species_cry)
+	host.sfx_requested.connect(_play_sfx)
+	host.music_requested.connect(_play_evolution_music)
+	host.z_index = 40
+	_trade_anim_results = results.duplicate(true)
+	_trade_anim_host = host
+	_screen.display(host)
+	if _trade_anim_host == null:
+		_trade_anim_results = []
+		return false
+	_script_prompt = "Trading"
+	_refresh_labels()
+	return true
+
+
+func _on_trade_animation_closed() -> void:
+	var host: Gen2TradeAnimationScreen = _trade_anim_host
+	_trade_anim_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	var results: Array = _trade_anim_results
+	_trade_anim_results = []
+	if _renderer != null:
+		_renderer.refresh()
+	_refresh_labels()
+	if not results.is_empty():
+		_show_script_results(results)
+
+
 ## `InitName`, which writes whatever the naming screen left into the row's
 ## nickname. `.nonickname` reaches this too, with the species name.
 func _on_hatch_named(party_index: int, nickname: String) -> void:
@@ -2026,7 +2072,6 @@ func _on_hatch_named(party_index: int, nickname: String) -> void:
 ## of the fourteen, every starter among them. `GiveANickname_YesNo` stands
 ## between `TryAddMonToParty` and the row being named, so the request is left
 ## pending while the screen is up and the party host applies it with the answer.
-##
 ## False when the routine reaches no prompt and the request may be settled where
 ## it was staged: an egg, a gift that names an OT, and the storage that has room
 ## for neither, which is `.FailedToGiveMon`.
@@ -2068,7 +2113,6 @@ func _open_gift_nickname(request: Dictionary) -> bool:
 ## question the gift path asks and reaches no "sent to BILL's PC" line: the box
 ## branch prints nothing and the script's `ContestResults_PartyFullText` is what
 ## BUGCONTEST_BOXED_MON reaches instead.
-##
 ## False when the routine reaches no prompt: nothing was caught, and `.BoxFull`,
 ## which writes nothing and answers BUGCONTEST_BOXED_MON where it stands.
 func _open_contest_nickname(_request: Dictionary = {}) -> bool:
@@ -2683,7 +2727,6 @@ func _after_map_settled() -> bool:
 
 
 ## The renewal offer a Repel running out owes, or false when nothing is owed.
-##
 ## Nothing at all without a registered provider: an unregistered host answers 0
 ## and the step rolls exactly as it always did. The fact is held rather than
 ## consumed on the step it happened, so an offer landing on a step a warp, a
@@ -3028,7 +3071,6 @@ func persist_world_snapshot() -> Dictionary:
 
 ## `GameTimer`, one call per hardware frame. The play timer belongs to the save
 ## rather than to the world, since the cartridge keeps it in wPlayerData.
-##
 ## Two source gates decide whether it counts, and neither is `_overlay_open()`:
 ## a battle, the pack and the start menu all keep counting. `wGameTimerPaused`
 ## is cleared for `Script_halloffame` alone (engine/overworld/scripting.asm:2318)
@@ -3793,7 +3835,6 @@ const SLOT_MACHINE_MENU_FRAME_CAP: int = 16
 
 ## Public screenshot driver and scene-test entry for `special SlotMachine`,
 ## which only the two Game Corners reach and no fixture cell does.
-##
 ## [param coins] is the balance the machine opens with, [param lucky] the
 ## `wScriptVar` the map's own `setval` leaves, and [param frames] how far into
 ## the game to drive: the machine is pressed past its bet menu and then handed
@@ -3843,7 +3884,6 @@ const CARD_FLIP_PROMPT_FRAME_CAP: int = 240
 
 ## Public screenshot driver and scene-test entry for `special CardFlip`, which
 ## only the two Game Corners reach and no fixture cell does.
-##
 ## [param coins] is the balance the table opens with and [param frames] how far
 ## into the game to drive: every `YesNoBox` is answered YES and every
 ## `WaitPressAorB` pressed, so the table deals, toggles and pays without the
@@ -3996,6 +4036,36 @@ func preview_egg_hatch(species: int = 0) -> void:
 	_open_hatch([summary], save)
 
 
+## Public screenshot driver for `TradeAnimation`, which no fixture cell reaches:
+## the movie is opened over the map with no trade behind it, so its close writes
+## nothing. [param frames] is how far in the picture is taken.
+func preview_trade_animation(frames: int = 0, half: int = 0) -> void:
+	if _world == null or _data == null or _trade_anim_host != null:
+		return
+	var save: Gen2SaveData = _embedded_party_save()
+	if save == null or save.party.is_empty():
+		_script_prompt = "Trade preview needs a party"
+		_refresh_labels()
+		return
+	var given: Gen2SaveMon = save.party[0]
+	var received: Gen2SaveMon = save.party[mini(1, save.party.size() - 1)]
+	var context: Dictionary = Gen2WorldPartyHost.trade_animation_context(
+		_data, given, received, save.player_name, "BLUE",
+		Gen2LinkSession.LINK_TRADECENTER
+	)
+	var host := Gen2TradeAnimationScreen.new()
+	host.set_context(_data, context, half)
+	host.closed.connect(_on_trade_animation_closed)
+	host.z_index = 40
+	_trade_anim_host = host
+	_screen.display(host)
+	for _frame: int in maxi(frames, 0):
+		if _trade_anim_host == null:
+			return
+		_trade_anim_host.advance_frame()
+	_refresh_labels()
+
+
 ## Public screenshot driver for `GiveANickname_YesNo`, which no fixture cell
 ## reaches: a `givepoke` is somebody's map script. The prompt is opened over the
 ## map with no request behind it, so its close writes nothing.
@@ -4060,7 +4130,6 @@ func _first_stone_evolution() -> Dictionary:
 ## presentation: it stands the first party member on the first LEVEL evolution
 ## the cache holds and opens the screen on it, which is the one path a stone
 ## cannot reach, since `.pressed_b` lets B cancel this one and not that one.
-##
 ## The party row is left alone. [method _on_evolution_resolved] applies it, the
 ## same way the after-battle pass does, so the preview is that pass rather than
 ## a picture of it.
@@ -4180,7 +4249,6 @@ func preview_mod_views() -> void:
 ## Public screenshot driver for the MOVES entry, which needs a registered
 ## field-move source before it exists at all: one call opens the menu on the row
 ## and a second opens the list of moves the bag can supply.
-##
 ## The provider and the HM are synthetic, exactly as [method preview_pet_actor]'s
 ## actor is; the row, the list and the move behind it are the host's own.
 func preview_field_moves_menu() -> void:
@@ -4380,7 +4448,6 @@ func preview_pack_toss() -> void:
 ## four move slots and grants a TM or HM that member can learn, on an injected
 ## save so nothing persists, then advances one menu step per call: Pack, the
 ## TM/HM, USE, YES, the party member, ForgetMove's ask, and the move list.
-##
 ## The granted item is whichever TM or HM this species can actually learn, since
 ## a development save's first member is whatever the cache holds; a species that
 ## can learn none reports that rather than opening a menu it cannot fill.
@@ -4443,7 +4510,6 @@ func _teachable_tmhm_for(species: int) -> int:
 ## Public screenshot driver for the battle-request host path. It starts the
 ## same request shape emitted by [Gen2WorldScriptRunner], without pretending a
 ## map event was present in the selected development map.
-##
 ## [param battle_type] is `wBattleType`, so
 ## [constant Gen2Battle.BATTLETYPE_FORCESHINY] opens the fight the Lake of Rage
 ## Gyarados is met in.
@@ -5587,7 +5653,6 @@ func _open_service_host() -> void:
 
 ## Opens the induction sequence `halloffame` asks for. Public so the screenshot
 ## tool and the scene tests can reach it without replaying the whole route.
-##
 ## The party is the active save's, so an injected or development save inducts
 ## whatever it is carrying. A cache with no font answers nothing rather than
 ## drawing an empty screen.
@@ -5670,6 +5735,7 @@ func _open_link_screen(screen_mode: int) -> bool:
 		_link_transport(), screen_mode, _injected_save == null
 	)
 	host.closed.connect(_on_link_screen_closed)
+	host.traded.connect(_on_link_traded)
 	_link_host = host
 	_screen.display(host)
 	if _link_host == null:
@@ -5679,6 +5745,11 @@ func _open_link_screen(screen_mode: int) -> bool:
 		else "Trade Center"
 	_refresh_labels()
 	return true
+
+
+## `LinkTrade`'s `.do_trade`, which comes back to the trade screen.
+func _on_link_traded(result: Dictionary) -> void:
+	_open_trade_animation(result.get("animation", {}))
 
 
 func _on_link_screen_closed() -> void:
@@ -5764,7 +5835,6 @@ func _on_hall_of_fame_rating(sfx: int) -> void:
 
 
 ## `Script_credits`, which farcalls `RedCredits` and then ends the script.
-##
 ## [param skippable] is the `wStatusFlags` byte `Credits` is handed: `RedCredits`
 ## passes the live one, which by Red has the Hall of Fame bit in it, while
 ## `HallOfFame` pushes the byte before setting that bit, so the induction's own
@@ -7211,11 +7281,7 @@ func _handle_runtime_request(request: Dictionary) -> StringName:
 		if opened != &"prompt":
 			return opened
 	elif kind in Gen2WorldHost.UNATTENDED_REQUESTS:
-		var settled: Array = _complete_unattended_request()
-		if settled.is_empty():
-			return &"none"
-		_show_script_results(settled)
-		return &"return"
+		return _settle_unattended_request()
 	elif kind in SERVICE_HOST_REQUESTS:
 		_open_service_host()
 		return &"break"
@@ -7731,7 +7797,6 @@ func map_name_sign_passes() -> int:
 ## `InitMapNameSign`'s own decision, raised where the map load leaves it: the
 ## sign is a window over the bottom four rows and the map keeps moving behind it,
 ## which is why a connection crossing shows one without stopping the camera.
-##
 ## Gold and Silver ship neither the routine nor `MapEntryFrameGFX`, so the world
 ## asks for no sign there and the page would answer none either.
 func _raise_map_name_sign() -> void:
@@ -8002,7 +8067,6 @@ func _mod_hidden_items() -> Array:
 ## gate: `verbosegiveitem`'s own transaction through the ordinary script path, so
 ## the fanfare, the box and the pacing are the world screen's exactly as they are
 ## for a give the map itself makes.
-##
 ## One per frame, since the first one's box owns the world until it is pressed
 ## past, and the rest wait in the host's queue.
 func _spend_item_gift_requests() -> void:
@@ -8140,7 +8204,6 @@ func _start_sound_schedule(schedule: Array) -> void:
 
 
 ## One frame of that schedule, spent from the same pump the script's own wait is.
-##
 ## A `wait` entry is `WaitPlaySFX`, and it is a real wait only while the driver
 ## is being serviced: a run with no audio device leaves the channels as the last
 ## sound left them, so `effect_playing()` would answer true for the rest of the

--- a/tests/unit/test_trade_animation.gd
+++ b/tests/unit/test_trade_animation.gd
@@ -1,0 +1,222 @@
+extends GutTest
+
+## `TradeAnimation`'s jumptable, driven without a cache. Every frame count here
+## is the cartridge's own: the commands count in `wFrameCounter` and spend
+## `DelayFrames`, neither of which depends on the art being imported, so both
+## scripts run with no [GameData] at all. `AnimateTrademonFrontpic` is the one
+## command that does depend on it and advances instead. tools/checks/link.gd is
+## what checks the art it draws with.
+
+const FRAME_CAP: int = 20000
+
+## Both scripts with no pic animation behind them. Crystal's halves differ by its
+## `wait_96` against a `wait_40`; Gold and Silver's are the same length, their
+## two halves being the same commands in the other order.
+const CRYSTAL_FRAMES: Array[int] = [2329, 2192]
+const GOLD_SILVER_FRAMES: Array[int] = [2480, 2480]
+
+## `SFX_BALL_POOF` twice, `SFX_POTION` twice, the give and get pair, and the
+## twenty-six clicks the two tube bulges and the two balls between them ask for.
+const SFX_TOTAL: int = 32
+## `SFX_GIVE_TRADEMON` and `SFX_GET_TRADEMON`, one each per half.
+const SFX_GIVE_TRADEMON: int = Gen2TradeAnimation.SFX_GIVE_TRADEMON
+const SFX_GET_TRADEMON: int = Gen2TradeAnimation.SFX_GET_TRADEMON
+
+const GIVEN: int = 152
+const RECEIVED: int = 25
+
+
+func _movie(half: int = 0, given: int = GIVEN, received: int = RECEIVED) -> Gen2TradeAnimation:
+	return Gen2TradeAnimation.create(null, null, {
+		"player": {
+			"species": given, "species_name": "CHIKORITA", "sender_name": "RED",
+			"ot_name": "RED", "ot_id": 12345, "caught_gender": 1,
+		},
+		"ot": {
+			"species": received, "species_name": "PIKACHU", "sender_name": "BLUE",
+			"ot_name": "BLUE", "ot_id": 54321, "caught_gender": 2,
+		},
+		"link_mode": Gen2LinkSession.LINK_TRADECENTER,
+	}, half)
+
+
+func _run(movie: Gen2TradeAnimation) -> Array:
+	var events: Array = []
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		events.append_array(movie.advance_frame())
+	return events
+
+
+## Both halves reach `TradeAnim_End` on the cartridge's own frame.
+func test_both_halves_run_to_the_exit_bit() -> void:
+	for half: int in 2:
+		var movie: Gen2TradeAnimation = _movie(half)
+		_run(movie)
+		assert_true(movie.finished(), "half %d never finished" % half)
+		assert_eq(movie.frame(), CRYSTAL_FRAMES[half], "half %d" % half)
+
+
+## `RunTradeAnimScript` opens on `PlayMusic2 MUSIC_EVOLUTION` and asks for
+## nothing else.
+func test_the_music_is_asked_for_once_and_first() -> void:
+	var movie: Gen2TradeAnimation = _movie()
+	var events: Array = movie.drain_events()
+	events.append_array(_run(movie))
+	var music: Array = []
+	for event: Dictionary in events:
+		if StringName(event["type"]) == &"play_music":
+			music.append(event)
+	assert_eq(music.size(), 1)
+	assert_eq(int(music[0]["music"]), Gen2TradeAnimation.MUSIC_EVOLUTION)
+	assert_eq(int(music[0]["frame"]), 0)
+
+
+## The sounds both halves ask for, and the one pair that says which way a
+## Pokemon is moving: the giving half sends before it receives.
+func test_each_half_asks_for_the_same_sounds_in_its_own_order() -> void:
+	for half: int in 2:
+		var sfx: Array = []
+		for event: Dictionary in _run(_movie(half)):
+			if StringName(event["type"]) == &"play_sfx":
+				sfx.append(int(event["sfx"]))
+		assert_eq(sfx.size(), SFX_TOTAL, "half %d" % half)
+		var sent: int = sfx.find(SFX_GIVE_TRADEMON)
+		var received: int = sfx.find(SFX_GET_TRADEMON)
+		assert_true(
+			sent >= 0 and received >= 0, "half %d is missing a trade sound" % half
+		)
+		assert_eq(sent < received, half == 0, "half %d traded the wrong way" % half)
+
+
+## `TradeAnim_ShowGivemonData`'s cry. With no cache behind it Crystal's
+## `AnimateTrademonFrontpic` never runs, so the offered Pokemon's is the one cry.
+func test_the_offered_pokemon_cries() -> void:
+	var cries: Array = []
+	for event: Dictionary in _run(_movie()):
+		if StringName(event["type"]) == &"play_cry":
+			cries.append(int(event["species"]))
+	assert_eq(cries, [GIVEN])
+
+
+## `IsOTTrademonEgg`, which advances the script pointer before it looks: an egg
+## adds eighty frames to the first half and a hundred and eighty to the second.
+func test_an_egg_partner_adds_its_own_wait() -> void:
+	for half: int in 2:
+		var movie: Gen2TradeAnimation = _movie(half, GIVEN, Gen2TradeAnimation.EGG)
+		_run(movie)
+		assert_eq(
+			movie.frame() - CRYSTAL_FRAMES[half], 80 if half == 0 else 180,
+			"half %d" % half
+		)
+
+
+## `TradeAnim_SentToOTText`'s `LINK_TIMECAPSULE` branch, which prints the one
+## line and leaves rather than standing on an empty box for 189 frames.
+func test_a_time_capsule_trade_skips_the_empty_box() -> void:
+	var movie: Gen2TradeAnimation = Gen2TradeAnimation.create(null, null, {
+		"player": {"species": GIVEN}, "ot": {"species": RECEIVED},
+		"link_mode": Gen2LinkSession.LINK_TIMECAPSULE,
+	})
+	_run(movie)
+	assert_eq(movie.frame(), CRYSTAL_FRAMES[0] - (189 + 128))
+
+
+## `TradeAnim_EnterLinkTube2` and `TradeAnim_ExitLinkTube` walk `hSCX` between
+## `$a0` and zero four pixels at a time, and `TradeAnim_DoGivemonScroll` walks
+## `hWX` down to the seven every other command leaves it on.
+func test_the_scroll_and_the_window_land_where_the_source_leaves_them() -> void:
+	var movie: Gen2TradeAnimation = _movie()
+	var scrolls: Dictionary = {}
+	var windows: Dictionary = {}
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+		scrolls[movie.scroll_x()] = true
+		windows[movie.window().x] = true
+	assert_eq(movie.scroll_x(), 0)
+	assert_eq(movie.window(), Vector2i(7, 0x90))
+	assert_true(scrolls.has(0xA0), "the tube never scrolled in from $a0")
+	assert_true(windows.has(0x8F), "the stats window never opened off screen")
+
+
+## `PlaySpriteAnimations` over `wShadowOAM`: the ball, its poof, the tube bulge
+## and the trademon's icon and bubble all reach the buffer, and none outlives
+## the movie.
+func test_every_sprite_the_movie_spawns_reaches_shadow_oam() -> void:
+	var movie: Gen2TradeAnimation = _movie()
+	var sets: Dictionary = {}
+	var peak: int = 0
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+		peak = maxi(peak, movie.sprites().size())
+		for sprite: Dictionary in movie.sprites():
+			sets[int(sprite["set"])] = true
+	var seen: Array = sets.keys()
+	seen.sort()
+	assert_eq(seen, [
+		Gen2TradeAnimation.OAM_BALL_1, Gen2TradeAnimation.OAM_BALL_2,
+		Gen2TradeAnimation.OAM_POOF_1, Gen2TradeAnimation.OAM_POOF_2,
+		Gen2TradeAnimation.OAM_POOF_3, Gen2TradeAnimation.OAM_BULGE_1,
+		Gen2TradeAnimation.OAM_BULGE_2, Gen2TradeAnimation.OAM_ICON_1,
+		Gen2TradeAnimation.OAM_ICON_2, Gen2TradeAnimation.OAM_BUBBLE,
+	])
+	assert_eq(peak, 2, "more than the icon and its bubble were up at once")
+	assert_eq(movie.sprites().size(), 0, "a sprite outlived the movie")
+
+
+## `TradeAnim_AnimateTrademonInTube`: right to `$94` then down to `$4c` on one
+## leg, up to `$2c` then left to `$58` on the other. Both halves run both legs,
+## so the three corners the two walks share are all reached and `(88, 76)`,
+## which neither turns on, is not.
+func test_the_trademon_crosses_the_tube_both_ways() -> void:
+	for half: int in 2:
+		var movie: Gen2TradeAnimation = _movie(half)
+		var seen: Dictionary = {}
+		while not movie.finished() and movie.frame() < FRAME_CAP:
+			movie.advance_frame()
+			for sprite: Dictionary in movie.sprites():
+				if int(sprite["set"]) in [
+					Gen2TradeAnimation.OAM_ICON_1, Gen2TradeAnimation.OAM_ICON_2,
+				]:
+					seen[sprite["at"]] = true
+		for corner: Vector2i in [
+			Vector2i(0x58, 0x2C), Vector2i(0x94, 0x2C), Vector2i(0x94, 0x4C),
+		]:
+			assert_true(
+				seen.has(corner), "half %d never put the icon on %s" % [half, corner]
+			)
+		assert_false(
+			seen.has(Vector2i(0x58, 0x4C)), "half %d cut a corner" % half
+		)
+
+
+## `wFrameCounter2`'s low three bits, which `TradeAnim_FlashBGPals` gates the
+## tube's own palette flash on: it xors `%00111100` and never lands anywhere
+## else.
+func test_the_tube_flashes_between_two_palette_orders() -> void:
+	var movie: Gen2TradeAnimation = _movie()
+	var orders: Dictionary = {}
+	while not movie.finished() and movie.frame() < FRAME_CAP:
+		movie.advance_frame()
+		orders[movie.background_palette_index()] = true
+	var seen: Array = orders.keys()
+	seen.sort()
+	assert_eq(seen, [0xD8, 0xE4])
+
+
+## Gold and Silver run the same movie with four fewer commands: no `wait_96`, no
+## `wait_40` and no pic animation, so their two halves are the same length.
+func test_gold_and_silver_run_their_own_script() -> void:
+	var data: GameData = GameData.open(&"gold")
+	if data == null:
+		pass_test("no Gold cache; the check topic runs this against all three")
+		return
+	for half: int in 2:
+		var movie: Gen2TradeAnimation = Gen2TradeAnimation.create(
+			data, null, {
+				"player": {"species": GIVEN, "species_name": "CHIKORITA"},
+				"ot": {"species": RECEIVED, "species_name": "PIKACHU"},
+				"link_mode": Gen2LinkSession.LINK_TRADECENTER,
+			}, half
+		)
+		_run(movie)
+		assert_eq(movie.frame(), GOLD_SILVER_FRAMES[half], "half %d" % half)

--- a/tests/unit/test_trade_animation.gd.uid
+++ b/tests/unit/test_trade_animation.gd.uid
@@ -1,0 +1,1 @@
+uid://bbilw4tgei2xo

--- a/tools/checks/link.gd
+++ b/tools/checks/link.gd
@@ -9,6 +9,20 @@ extends RefCounted
 ## and a screen tilemap on Crystal against nine tiles and no tilemap on Gold and
 ## Silver, which is the whole difference between the two trade screens.
 
+## `TradeAnimation` is swept over every species the corpus ships.
+
+## The trade animation's census: the frame each half ends on, the sounds it asks
+## for and the cries.
+const TRADE_ANIM_FRAMES: Dictionary = {
+	&"crystal": [2546, 2409], &"gold": [2480, 2480], &"silver": [2480, 2480],
+}
+const TRADE_ANIM_SFX: int = 32
+const TRADE_ANIM_CRIES: int = 2
+const TRADE_ANIM_GIVEN: int = 152
+const TRADE_ANIM_RECEIVED: int = 25
+## Where the offered Pokemon's picture and its stats are both on screen.
+const TRADE_ANIM_DRAWN_FRAME: int = 180
+
 ## `newgroup CABLE_CLUB`, the same group and numbers in both pins.
 const CABLE_CLUB_GROUP: int = 20
 const POKECENTER_2F: int = 1
@@ -49,6 +63,10 @@ func run(r: RefCounted) -> void:
 	_r.each_game(func() -> void:
 		_verify_border()
 		_verify_texts()
+		_verify_trade_anim_art()
+		_verify_trade_anim_texts()
+		_verify_trade_anim_run()
+		_verify_trade_anim_corpus()
 		_verify_no_cable()
 		_verify_with_peer()
 		_verify_time_capsule_receptionist()
@@ -131,6 +149,172 @@ func _verify_texts() -> void:
 		address > 0 and ask.contains("%s%04X>" % [Gen2TextStream.RAM_MARKER, address]),
 		"ask_trade does not name wBufferTrademonNickname (%04X)" % address
 	)
+
+
+## Every entry of the art run at the size its loader asks VRAM for, and both
+## tilemaps naming tiles the one sheet behind them holds.
+func _verify_trade_anim_art() -> void:
+	var data: GameData = _r.data
+	if not _r.check(data.has_trade_anim(), "no trade animation art in the cache"):
+		return
+	var first: int = RomLayout.TRADE_ANIM_SHEET_FIRST_TILE
+	for row: Array in RomLayout.TRADE_ANIM_SECTION:
+		var name: String = String(row[0])
+		if String(row[1]) == "map":
+			var cells: PackedByteArray = data.trade_anim_tilemap(name)
+			if not _r.check(
+				cells.size() == int(row[2]), "trade %s is %d cells" % [name, cells.size()]
+			):
+				continue
+			for cell: int in cells:
+				if not _r.check(
+					cell >= first and cell < first + RomLayout.TRADE_ANIM_SHEET_TILES,
+					"trade %s names tile $%02x, outside its sheet" % [name, cell]
+				):
+					break
+			continue
+		var strip: PackedByteArray = data.tile_indices("trade_anim_%s" % name)
+		_r.check(
+			strip.size() == int(row[2]) * Gen2Tiles.TILE_WIDTH * Gen2Tiles.TILE_HEIGHT,
+			"trade sheet %s is not %d tiles" % [name, int(row[2])]
+		)
+	_r.check(
+		data.trade_anim_palette("tube").size() == Gen2Palette.COLORS_PER_PIC,
+		"the trade tube palette is not four colours"
+	)
+
+
+## The boxes, each by the `text_ram` it names.
+func _verify_trade_anim_texts() -> void:
+	var data: GameData = _r.data
+	if not _r.check(data.has_special_text("trade"), "no trade text run in the cache"):
+		return
+	for row: Array in [
+		["was_sent", "player_trademon_species_name"],
+		["bids_farewell", "ot_trademon_sender_name"],
+		["name_bids_farewell", "ot_trademon_species_name"],
+		["ot_sends", "ot_trademon_sender_name"],
+		["will_trade", "ot_trademon_sender_name"],
+		["for_your_mon_sends", "player_trademon_sender_name"],
+		["for_your_mon_will_trade", "player_trademon_sender_name"],
+		["take_good_care", "ot_trademon_species_name"],
+	]:
+		var text: String = data.special_text("trade", String(row[0]))
+		var address: int = data.special_text_ram(String(row[1]))
+		_r.check(
+			address > 0 and text.contains(
+				"%s%04X>" % [Gen2TextStream.RAM_MARKER, address]
+			),
+			"trade box %s does not name %s: %s" % [row[0], row[1], text]
+		)
+	_r.check(
+		data.special_text("trade", "take_good_care").begins_with("Take good care of"),
+		"take_good_care reads %s" % data.special_text("trade", "take_good_care")
+	)
+
+
+## Both halves whole: every command, every sprite and every sound.
+func _verify_trade_anim_run() -> void:
+	var expected: Array = TRADE_ANIM_FRAMES[_r.game_id]
+	for half: int in 2:
+		var movie: Gen2TradeAnimation = _trade_anim_movie(
+			TRADE_ANIM_GIVEN, TRADE_ANIM_RECEIVED, half
+		)
+		if not _r.check(movie != null, "the trade animation will not build"):
+			return
+		var sfx: int = 0
+		var cries: int = 0
+		for event: Dictionary in _trade_anim_events(movie):
+			if StringName(event["type"]) == &"play_sfx":
+				sfx += 1
+			elif StringName(event["type"]) == &"play_cry":
+				cries += 1
+		_r.check(movie.finished(), "half %d never set its exit bit" % half)
+		_r.check(
+			movie.frame() == int(expected[half]),
+			"half %d ran %d frames, not %d" % [half, movie.frame(), int(expected[half])]
+		)
+		_r.check(sfx == TRADE_ANIM_SFX, "half %d asked for %d sounds" % [half, sfx])
+		_r.check(cries == TRADE_ANIM_CRIES, "half %d played %d cries" % [half, cries])
+	var page: Gen2TradeAnimationPage = Gen2TradeAnimationPage.from_data(_r.data)
+	if not _r.check(page != null, "the trade animation page will not build"):
+		return
+	var drawn: Gen2TradeAnimation = _trade_anim_movie(
+		TRADE_ANIM_GIVEN, TRADE_ANIM_RECEIVED, 0
+	)
+	for _frame: int in TRADE_ANIM_DRAWN_FRAME:
+		drawn.advance_frame()
+	var image: Image = page.draw(drawn)
+	_r.check(
+		_ink(image) > (image.get_width() * image.get_height()) / 20,
+		"the trade animation drew a near-empty frame at %d" % TRADE_ANIM_DRAWN_FRAME
+	)
+
+
+## Every species the cartridge ships, as far as the frame its picture is up:
+## what this catches is one whose pic the movie cannot draw.
+func _verify_trade_anim_corpus() -> void:
+	var data: GameData = _r.data
+	var page: Gen2TradeAnimationPage = Gen2TradeAnimationPage.from_data(data)
+	if page == null:
+		return
+	for species: int in range(1, data.species_count() + 1):
+		var movie: Gen2TradeAnimation = _trade_anim_movie(species, species, 0)
+		if movie == null:
+			return
+		for _frame: int in 3:
+			movie.advance_frame()
+		if not _r.check(
+			not movie.frontpic_pixels().is_empty(),
+			"species %d reached no frontpic" % species
+		):
+			return
+		if not _r.check(
+			movie.frontpic_palette().size() == Gen2Palette.COLORS_PER_PIC,
+			"species %d drew no frontpic palette" % species
+		):
+			return
+
+
+func _trade_anim_movie(given: int, received: int, half: int) -> Gen2TradeAnimation:
+	var data: GameData = _r.data
+	return Gen2TradeAnimation.create(
+		data, Gen2BattleAnimData.from_game_data(data),
+		{
+			"player": {
+				"species": given,
+				"species_name": String(data.species(given).get("name", "")),
+				"sender_name": "RED", "ot_name": "RED", "ot_id": 12345,
+				"caught_gender": 1,
+			},
+			"ot": {
+				"species": received,
+				"species_name": String(data.species(received).get("name", "")),
+				"sender_name": "BLUE", "ot_name": "BLUE", "ot_id": 54321,
+				"caught_gender": 2,
+			},
+			"link_mode": Gen2LinkSession.LINK_TRADECENTER,
+		},
+		half
+	)
+
+
+func _trade_anim_events(movie: Gen2TradeAnimation) -> Array:
+	var out: Array = []
+	var guard: int = 20000
+	while not movie.finished() and guard > 0:
+		out.append_array(movie.advance_frame())
+		guard -= 1
+	return out
+
+
+static func _ink(image: Image) -> int:
+	var count: int = 0
+	for y: int in image.get_height():
+		for x: int in image.get_width():
+			if image.get_pixel(x, y) != Color.WHITE:
+				count += 1
+	return count
 
 
 ## The path a single console gets, which is the only one a player without a

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -64,6 +64,9 @@ const SPECIAL_TEXT_RAM_NAMES: Array[String] = [
 	## `wMysteryGiftPartnerName` and `wMysteryGiftPlayerName`, the two names
 	## `_MysteryGiftSentText` and `_MysteryGiftSentHomeText` spell.
 	"mystery_gift_partner_name", "mystery_gift_player_name",
+	## `TradeAnimation`'s four.
+	"player_trademon_species_name", "player_trademon_sender_name",
+	"ot_trademon_species_name", "ot_trademon_sender_name",
 ]
 
 const SPECIALS_POINTERS_SIZE: int = 169

--- a/tools/preview_link.gd
+++ b/tools/preview_link.gd
@@ -1,13 +1,13 @@
 extends SceneTree
 
 ## Captures the cable club's two screens against a real imported cache.
-##
 ##   Godot --headless --path . -s res://tools/preview_link.gd -- <game> <out.png> [screen]
-##
 ## [screen] is `trade`, `wait`, `confirm`, `record` or `all`, the default. The trade
 ## screen is the one page whose picture differs between the two cartridges for a
 ## reason rather than by accident, so the same call on the three caches is the whole
 ## comparison. Composed into an [Image], so this runs headless.
+## `anim` draws the movie behind the trade instead, six sampled frames;
+## `anim:<frame>[,<frame>...]` names its own.
 
 const COLUMNS: int = 2
 const SCREENS: Array[String] = ["wait", "trade", "confirm", "record"]
@@ -20,6 +20,10 @@ const PLAYER_PARTY: Array[String] = [
 const PARTNER_PARTY: Array[String] = ["BULBASAUR", "SQUIRTLE", "CHARMANDER"]
 const PLAYER_NAME: String = "GOLD"
 const PARTNER_NAME: String = "KRIS"
+
+const ANIM_PLAYER: int = 152
+const ANIM_PARTNER: int = 25
+const ANIM_FRAMES: Array[int] = [40, 260, 420, 700, 1500, 2100]
 
 
 func _initialize() -> void:
@@ -43,6 +47,9 @@ func _initialize() -> void:
 		return
 
 	var wanted: String = args[2] if args.size() > 2 else "all"
+	if wanted.begins_with("anim"):
+		_capture_animation(data, args[0], args[1], wanted)
+		return
 	var screens: Array[String] = SCREENS.duplicate() if wanted == "all" \
 		else ([wanted] as Array[String])
 	var columns: int = mini(COLUMNS, screens.size())
@@ -114,3 +121,60 @@ func _record() -> Dictionary:
 		record, {"name": "SILVER", "id": 7}, &"losses"
 	)
 	return record
+
+
+func _capture_animation(data: GameData, game: String, path: String, wanted: String) -> void:
+	var page: Gen2TradeAnimationPage = Gen2TradeAnimationPage.from_data(data)
+	var movie: Gen2TradeAnimation = Gen2TradeAnimation.create(
+		data, Gen2BattleAnimData.from_game_data(data), _anim_context(data)
+	)
+	if page == null or movie == null:
+		push_error("The %s cache carries no trade animation art." % game)
+		quit(1)
+		return
+	var frames: Array[int] = ANIM_FRAMES.duplicate()
+	if wanted.contains(":"):
+		frames.clear()
+		for value: String in wanted.split(":")[1].split(","):
+			frames.append(int(value))
+	frames.sort()
+	var columns: int = mini(3, frames.size())
+	@warning_ignore("integer_division")
+	var rows: int = (frames.size() + columns - 1) / columns
+	var sheet: Image = Image.create_empty(
+		columns * Gen2Screen.WIDTH, rows * Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	for index: int in frames.size():
+		while not movie.finished() and movie.frame() < frames[index]:
+			movie.advance_frame()
+		var tile: Image = page.draw(movie)
+		@warning_ignore("integer_division")
+		sheet.blit_rect(tile, Rect2i(Vector2i.ZERO, tile.get_size()), Vector2i(
+			(index % columns) * Gen2Screen.WIDTH, (index / columns) * Gen2Screen.HEIGHT
+		))
+	if sheet.save_png(path) != OK:
+		push_error("Could not write %s" % path)
+		quit(1)
+		return
+	print("Wrote %s (%dx%d), frames %s." % [
+		path, sheet.get_width(), sheet.get_height(), str(frames),
+	])
+	quit(0)
+
+
+func _anim_context(data: GameData) -> Dictionary:
+	return {
+		"player": {
+			"species": ANIM_PLAYER,
+			"species_name": String(data.species(ANIM_PLAYER).get("name", "")),
+			"sender_name": PLAYER_NAME, "ot_name": PLAYER_NAME,
+			"ot_id": 12345, "caught_gender": 1,
+		},
+		"ot": {
+			"species": ANIM_PARTNER,
+			"species_name": String(data.species(ANIM_PARTNER).get("name", "")),
+			"sender_name": PARTNER_NAME, "ot_name": PARTNER_NAME,
+			"ot_id": 54321, "caught_gender": 2,
+		},
+		"link_mode": Gen2LinkSession.LINK_TRADECENTER,
+	}

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -24,6 +24,7 @@ const KIND_HELP: Dictionary = {
 	&"mart": "cell in front of the counter: BuyMenu",
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
+	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
 	&"pet_actor_arc": "cell: the same actor mid-ledge, at the top of the arc its span names",
 	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
@@ -333,6 +334,7 @@ const STAGERS: Dictionary = {
 	&"script_fade": &"_stage_script_fade",
 	&"level_evolution": &"_stage_level_evolution",
 	&"egg_hatch": &"_stage_egg_hatch",
+	&"trade_animation": &"_stage_trade_animation",
 	&"gift_nickname": &"_stage_gift_nickname",
 	&"whiteout": &"_stage_whiteout",
 	&"unown_puzzle": &"_stage_unown_puzzle",
@@ -494,6 +496,10 @@ func _stage_level_evolution() -> void:
 ## five hundred frames of picture, so the first number is how far into it to
 ## photograph and the second is the species inside the egg, 0 for the first the cache
 ## holds.
+func _stage_trade_animation() -> void:
+	_screen.preview_trade_animation(maxi(_cell.x, 0), maxi(_cell.y, 0))
+
+
 func _stage_egg_hatch() -> void:
 	_screen.preview_egg_hatch(maxi(_cell.y, 0))
 	for _frame: int in maxi(_cell.x, 0):

--- a/tools/trace_opening_oam.gd
+++ b/tools/trace_opening_oam.gd
@@ -1,14 +1,13 @@
 extends SceneTree
 
 ## Dumps the opening's shadow OAM, one line per sprite per frame, against a real
-## cache. `phase` is `presents`, `intro`, `gs_intro` or `title`, and the artefact is
-## the one `.claude/verification.md` step 2 asks for: two faithful implementations
-## of `PlaySpriteAnimations` put the same sprites in the same slots on the same
-## frames. A line is `frame slot y x tile`, the OAM bytes as a cartridge's own
-## buffer holds them at the frame boundary. Arguments:
-## `<game> <phase> [out.txt] [frames]`.
+## cache. `phase` is `presents`, `intro`, `gs_intro`, `title` or `trade`, and the
+## artefact is the one `.claude/verification.md` step 2 asks for: two faithful
+## implementations of `PlaySpriteAnimations` put the same sprites in the same
+## slots on the same frames. A line is `frame slot y x tile`, the OAM bytes as a
+## cartridge's buffer holds them. `<game> <phase> [out.txt] [frames]`.
 
-const PHASES: Array[String] = ["presents", "intro", "gs_intro", "title"]
+const PHASES: Array[String] = ["presents", "intro", "gs_intro", "title", "trade"]
 
 ## The title screen runs until its own timeout, which is longer than anything
 ## worth diffing; this is well past `TitleScreenEnd`'s own count.
@@ -59,6 +58,8 @@ func _initialize() -> void:
 			lines = _trace_intro(data)
 		"gs_intro":
 			lines = _trace_gs_intro(data)
+		"trade":
+			lines = _trace_trade(data)
 		_:
 			lines = _trace_title(data)
 	if args.size() > 2:
@@ -159,6 +160,37 @@ func _trace_gs_intro(data: GameData) -> PackedStringArray:
 		if movie.scene() != scene:
 			scene = movie.scene()
 			print("frame %d: scene %d" % [frame, scene])
+		movie.advance_frame()
+		frame += 1
+	print("frame %d: finished" % frame)
+	return out
+
+
+## `TradeAnimation`'s first half, on the pair the oracle puts a cartridge into.
+func _trace_trade(data: GameData) -> PackedStringArray:
+	var page: Gen2TradeAnimationPage = Gen2TradeAnimationPage.from_data(data)
+	if page == null:
+		push_error("%s has no trade animation art." % data.id)
+		return PackedStringArray()
+	var movie: Gen2TradeAnimation = Gen2TradeAnimation.create(
+		data, Gen2BattleAnimData.from_game_data(data), {
+			"player": {
+				"species": 152, "species_name": "CHIKORITA", "sender_name": "RED",
+				"ot_name": "RED", "ot_id": 12345, "caught_gender": 1,
+			},
+			"ot": {
+				"species": 25, "species_name": "PIKACHU", "sender_name": "BLUE",
+				"ot_name": "BLUE", "ot_id": 54321, "caught_gender": 2,
+			},
+			"link_mode": Gen2LinkSession.LINK_TRADECENTER,
+		}
+	)
+	var out := PackedStringArray()
+	var frame: int = 0
+	while not movie.finished() and frame < MOVIE_FRAME_CAP:
+		_append_frame(out, frame, page.shadow_oam(movie))
+		if _shots.has(frame):
+			page.draw(movie).save_png("%s_f%d.png" % [_shot_prefix, frame])
 		movie.advance_frame()
 		frame += 1
 	print("frame %d: finished" % frame)


### PR DESCRIPTION
`TradeAnimation` and `TradeAnimationPlayer2` were the last movie in the source with nothing behind them. The trade itself was already exact; its frames were spent in one line. Both scripts now run, one command a frame the way `DoTradeAnimation` does.

## What plays

The offered Pokemon's stats window slides in over its picture, the ball rocks and rises into the cable, the bulge crosses it, the two players' names stand under the tube with the trademon's own menu icon riding through in a bubble, and the received Pokemon arrives, drops out of its ball and is animated. Every box the routine prints is imported and filled from the four `text_ram` buffers the source names.

Both halves are there: the player who offered first runs `TradeAnimation`, the other `TradeAnimationPlayer2`, which is the same commands in the other order. Gold and Silver run their own script, four commands shorter.

## What it is made of

- `Gen2TradeAnimation` is the state machine: the jumptable, the two scripts, the sprite structs and the tilemap of character codes the cartridge writes.
- `Gen2TradeAnimationPage` turns those codes into pixels. Three sheets feed one code: the frontpic under the trade sheet's first tile, the sheet's own 49, and the font with its two arrow codes replaced.
- `Gen2TradeAnimationScreen` is the host, frame-driven like every other embedded screen.

The art is nine INCBINs laid end to end behind the routine, so one pinned address walks the lot. `cable` is two tiles rather than the four `LoadTradeBallAndCableGFX` asks VRAM for: that request runs on into `bubble`, and nothing draws what it took.

Both a link trade and an `NPCTrade` open it, off one context written where the trade is committed rather than at either call site.

## Proof

Settled against a real cartridge. Nothing a single console can reach runs the movie, so the dump is put into it by hand: the trademon buffers in WRAM and a six-byte stub in SRAM, `ei / call TradeAnimation / jr -2`. The `ei` is the whole trick; without it the first `DelayFrame` halts forever and the screen sits on the splash looking as though the jump never happened.

| Cartridge | Distinct sprite states identical, in order |
|---|---|
| Crystal | 361 of 361 |
| Gold | 405 of 405 |
| Silver | 405 of 405 |

Two defects came out of that, neither of which any pinned number would have caught: the rocking ball read its sine off `VAR1` after the `dec [hl]` rather than before, and Gold and Silver's tube bulge crosses at one pixel a frame against Crystal's two.

Also green: the whole unit tier, all 82 check topics on freshly imported caches of the three cartridges, the editor analyser at zero warnings, the boot smoke test, `replay_world.gd`'s 33 routes, and the story walk to Red on all three profiles.

## Housekeeping

The cache format is bumped, so all three cartridges want re-importing. The comment total is back at its ceiling: the wordless paragraph breaks in the files this touches are gone, which costs no fact.