### PR TITLE
A bay that cannot be played says which kind of empty it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ A few seconds per game. The cache is keyed by game and hash and lives in Godot's
 `user://`, never in the project or an export. `--verify` checks without writing.
 
 A cache is never migrated. An update that changes its format discards the old
-one, and the launcher's manage sheet says so: import the same dump again. Saves
-live under their own root and are not touched.
+one. The shelf marks that cartridge "Update needed", and pressing it says why and
+opens the picker: import the same dump again. Saves live under their own root and
+are not touched.
 
 The same sheet, behind the three dots above the shelf, also swaps a cartridge's
 picture for one of your own: any PNG, WebP or JPEG, scaled to fit the shell

--- a/game/launcher/cartridge.gd
+++ b/game/launcher/cartridge.gd
@@ -17,6 +17,9 @@ const ART: Dictionary = {
 ## The cartridge shells are 1058 by 1201.
 const ASPECT: float = 1058.0 / 1201.0
 
+const BAY_ICON_SIDE: float = 44.0
+const FAR_BAY_ICON_SIDE: float = 26.0
+
 const SIDE_FADE_SHADER: String = """
 shader_type canvas_item;
 
@@ -31,6 +34,8 @@ void fragment() {
 """
 
 var game_id: StringName = &""
+## Which of the three bays this draws.
+var cache_state: StringName = RomCache.STATE_MISSING
 var imported: bool = false
 ## How far the cartridge is from the selected one, which decides its size and
 ## how far back it stands. Set by [Gen2CartridgeStage].
@@ -44,6 +49,7 @@ var _bay_label: Label = null
 ## The icon and the name inside an empty bay, hidden together by
 ## [method set_bay_prompt].
 var _bay_prompt: VBoxContainer = null
+var _bay_note: Label = null
 var _hover: bool = false
 var _side_fade: ShaderMaterial = null
 var _bay_side_fade: ShaderMaterial = null
@@ -109,7 +115,7 @@ func _build() -> void:
 	invitation.offset_top = 0.0
 	invitation.offset_bottom = 0.0
 	_bay.add_child(invitation)
-	_bay_icon = Gen2LauncherIcon.create(&"download", 44.0, _theme.faint)
+	_bay_icon = Gen2LauncherIcon.create(&"download", BAY_ICON_SIDE, _theme.faint)
 	_bay_icon.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
 	invitation.add_child(_bay_icon)
 	_bay_label = Gen2LauncherUI.muted(_theme, RomRegistry.title_for(game_id))
@@ -117,6 +123,10 @@ func _build() -> void:
 	_bay_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_bay_label.autowrap_mode = TextServer.AUTOWRAP_OFF
 	invitation.add_child(_bay_label)
+	_bay_note = Gen2LauncherUI.tag(_theme, "")
+	_bay_note.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_bay_note.add_theme_color_override("font_color", _theme.accent)
+	invitation.add_child(_bay_note)
 
 	_art = TextureRect.new()
 	_art.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
@@ -127,11 +137,10 @@ func _build() -> void:
 	add_child(_art)
 
 	refresh_art()
-	set_imported(false)
+	set_cache_state(RomCache.STATE_MISSING)
 
 
-## The player's own picture, or the shipped shell. The stretch mode above is what
-## contains a picture of any shape inside the shell's box.
+## The player's own picture, or the shipped shell.
 func refresh_art() -> void:
 	if _art == null:
 		return
@@ -139,20 +148,21 @@ func refresh_art() -> void:
 	_art.texture = custom if custom != null else ART.get(game_id, null)
 
 
-## Hides the download icon and the cartridge's name inside an empty bay, leaving
-## the silhouette alone.
-##
-## For a caller that wants the shape rather than the invitation: the lower
-## display draws one to say no game is running, and nothing can be dropped on it.
+## Leaves an empty bay its silhouette alone, for a caller that wants the shape
+## rather than the invitation: the lower display draws one to say no game is
+## running, and nothing can be dropped on it.
 func set_bay_prompt(on: bool) -> void:
 	if _bay_prompt != null:
 		_bay_prompt.visible = on
 
 
-func set_imported(state: bool) -> void:
-	imported = state
-	_art.visible = state
-	_bay.visible = not state
+func set_cache_state(state: StringName, note: String = "") -> void:
+	cache_state = state
+	imported = state == RomCache.STATE_USABLE
+	_art.visible = imported
+	_bay.visible = not imported
+	_bay_note.text = note if not imported and state != RomCache.STATE_MISSING else ""
+	_paint_bay()
 	mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
 	queue_redraw()
 
@@ -161,8 +171,20 @@ func set_imported(state: bool) -> void:
 func set_depth(distance: int) -> void:
 	depth = distance
 	_bay_label.visible = distance == 0
-	_bay_icon.set_glyph(&"download", 44.0 if distance == 0 else 26.0, _theme.faint)
+	_paint_bay()
 	queue_redraw()
+
+
+## One place dresses the bay: its size belongs to the depth pass and its glyph to
+## the cache state, and each repainting alone undid the other.
+func _paint_bay() -> void:
+	var wants_file: bool = not imported and cache_state != RomCache.STATE_MISSING
+	_bay_icon.set_glyph(
+		&"refresh" if wants_file else &"download",
+		BAY_ICON_SIDE if depth == 0 else FAR_BAY_ICON_SIDE,
+		_theme.accent if wants_file else _theme.faint,
+	)
+	_bay_note.visible = wants_file and depth == 0 and not _bay_note.text.is_empty()
 
 
 ## The selected cartridge is untouched. A left neighbour fades from 100% at its
@@ -288,7 +310,7 @@ func play_insert() -> void:
 	if not is_inside_tree():
 		return
 	Gen2LauncherAudio.play(&"insert")
-	set_imported(true)
+	set_cache_state(RomCache.STATE_USABLE)
 	_art.modulate.a = 0.0
 	_hop = -size.y * 0.7
 	_squash = Vector2(1.04, 1.04)
@@ -322,13 +344,13 @@ func play_start() -> void:
 
 func play_eject() -> void:
 	if not is_inside_tree():
-		set_imported(false)
+		set_cache_state(RomCache.STATE_MISSING)
 		return
 	Gen2LauncherAudio.play(&"eject")
 	var tween: Tween = create_tween()
 	tween.tween_property(self, "_hop", -size.y * 0.6, 0.24).set_ease(Tween.EASE_OUT)
 	tween.parallel().tween_property(_art, "modulate:a", 0.0, 0.24)
 	await tween.finished
-	set_imported(false)
+	set_cache_state(RomCache.STATE_MISSING)
 	_hop = 0.0
 	_art.modulate.a = 1.0

--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -131,10 +131,10 @@ func step(direction: int) -> void:
 	select(selected + direction)
 
 
-func set_imported(game_id: StringName, state: bool) -> void:
+func set_cache_state(game_id: StringName, state: StringName, note: String) -> void:
 	var target: Gen2Cartridge = cartridge(game_id)
-	if target != null and target.imported != state:
-		target.set_imported(state)
+	if target != null and target.cache_state != state:
+		target.set_cache_state(state, note)
 
 
 func _on_pressed(index: int) -> void:

--- a/game/launcher/shelf_page.gd
+++ b/game/launcher/shelf_page.gd
@@ -76,9 +76,9 @@ func selected_id() -> StringName:
 	return _stage.selected_id()
 
 
-func set_slot_state(game_id: StringName, imported: bool, detail: String) -> void:
+func set_slot_state(game_id: StringName, state: StringName, detail: String) -> void:
 	_details[game_id] = detail
-	_stage.set_imported(game_id, imported)
+	_stage.set_cache_state(game_id, state, detail)
 	_refresh_action()
 
 
@@ -158,9 +158,11 @@ func _refresh_action() -> void:
 	if card == null:
 		return
 	var title: String = RomRegistry.title_for(id)
-	if card.imported:
+	# Shown for a cache this build cannot read too, which it used to hide over.
+	var known: bool = card.cache_state != RomCache.STATE_MISSING
+	if known:
 		_manage.tooltip_text = "%s options. %s" % [title, _details.get(id, "Ready")]
-	_manage.visible = card.imported
+	_manage.visible = known
 	_sync_stage_inset()
 
 

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -12,6 +12,24 @@ extends Control
 ## the frames cost the import very little, short enough to read as motion.
 const IMPORT_YIELD_MS: int = 80
 
+## Shelf label and sheet sentence per cache state, in the player's words: a cache
+## is never migrated ([constant RomCache.FORMAT_VERSION]) and is asked for again.
+const CACHE_STATE_COPY: Dictionary = {
+	RomCache.STATE_USABLE: ["", "This cartridge is imported and verified."],
+	RomCache.STATE_STALE: [
+		"Update needed",
+		"This version reads cartridges differently. Import your file again to play.",
+	],
+	RomCache.STATE_INCOMPLETE: [
+		"Import unfinished",
+		"The last import stopped early. Import your file again to play.",
+	],
+	RomCache.STATE_MISSING: ["", "No cartridge file has been imported yet."],
+}
+
+## Said beside both lines that ask for a file again, which read as "start again".
+const SAVES_ARE_SAFE: String = "Your saved games are not affected."
+
 var _palette: Gen2LauncherTheme = null
 var _shell: Gen2LauncherShell = null
 var _shelf: Gen2ShelfPage = null
@@ -174,14 +192,20 @@ func _refresh_backdrop() -> void:
 func _refresh_games() -> void:
 	for game_id: StringName in RomRegistry.ORDER:
 		var data: GameData = GameData.open(game_id)
-		_shelf.set_slot_state(game_id, data != null, _cartridge_detail(game_id, data))
+		var state: StringName = cache_state_for(game_id) if data == null \
+			else RomCache.STATE_USABLE
+		_shelf.set_slot_state(game_id, state, _cartridge_detail(game_id, data, state))
 	_shelf.set_busy(_importing)
 	_refresh_backdrop()
 
 
-func _cartridge_detail(game_id: StringName, data: GameData) -> String:
+func cache_state_for(game_id: StringName) -> StringName:
+	return RomCache.state(RomCache.directory_for(game_id, RomRegistry.sha1_for(game_id)))
+
+
+func _cartridge_detail(game_id: StringName, data: GameData, state: StringName) -> String:
 	if data == null:
-		return ""
+		return cache_state_note(state)
 	var slots: Array = Gen2SaveStore.slots_for(game_id, data.sha1, data)
 	var ready_slots: int = 0
 	for row: Dictionary in slots:
@@ -331,6 +355,8 @@ func _open_manage_sheet(game_id: StringName) -> void:
 	)
 	var body: VBoxContainer = sheet.body()
 	body.add_child(Gen2LauncherUI.muted(_palette, cache_state_text(state)))
+	if needs_reimport(state):
+		body.add_child(Gen2LauncherUI.muted(_palette, SAVES_ARE_SAFE))
 	var directory: Label = Gen2LauncherUI.muted(_palette, path)
 	directory.add_theme_color_override("font_color", _palette.faint)
 	body.add_child(directory)
@@ -372,37 +398,57 @@ func _open_manage_sheet(game_id: StringName) -> void:
 		)
 		body.add_child(default_art)
 
-	var reimport: Gen2LauncherButton = Gen2LauncherButton.create(
-		_palette,
-		"Re-import" if state != RomCache.STATE_MISSING else "Import",
-		Gen2LauncherButton.Variant.PRIMARY,
-		&"download",
-	)
-	reimport.pressed.connect(func() -> void:
-		_reimport_game_id = game_id
-		sheet.close()
-		_open_import_dialog()
-	)
-	sheet.add_action(reimport)
+	sheet.add_action(_reimport_action(
+		sheet, game_id, "Re-import" if state != RomCache.STATE_MISSING else "Import"
+	))
 	sheet.open(self)
 
 
-## What the manage sheet says about a cache in [param state]. Takes the state
-## rather than a cartridge so the four sentences can be asserted without a cache
-## on disk to put a build's own cartridges at risk.
-##
-## A cache is never migrated ([constant RomCache.FORMAT_VERSION]), so a build
-## that has moved on says so and asks for the dump again rather than reporting
-## the cartridge as never imported.
+## The manage sheet answers the same states, but it is a workbench.
+func _open_update_sheet(game_id: StringName, state: StringName) -> void:
+	var sheet: Gen2LauncherSheet = Gen2LauncherSheet.create(
+		_palette, RomRegistry.title_for(game_id)
+	)
+	var body: VBoxContainer = sheet.body()
+	var sentence: Label = Gen2LauncherUI.body(_palette, cache_state_text(state))
+	sentence.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	body.add_child(sentence)
+	body.add_child(Gen2LauncherUI.muted(_palette, SAVES_ARE_SAFE))
+	sheet.add_action(_reimport_action(sheet, game_id, "Import again"))
+	sheet.open(self)
+
+
+func _reimport_action(
+	sheet: Gen2LauncherSheet, game_id: StringName, label: String
+) -> Gen2LauncherButton:
+	var button: Gen2LauncherButton = Gen2LauncherButton.create(
+		_palette, label, Gen2LauncherButton.Variant.PRIMARY, &"download"
+	)
+	button.pressed.connect(func() -> void:
+		_reimport_game_id = game_id
+		sheet.close()
+		_show_import_picker()
+	)
+	return button
+
+
+static func cache_state_note(state: StringName) -> String:
+	return _cache_state_copy(state, 0)
+
+
+## Takes a state rather than a cartridge, so the four sentences can be asserted
+## without a cache on disk to put a build's own cartridges at risk.
 static func cache_state_text(state: StringName) -> String:
-	match state:
-		RomCache.STATE_USABLE:
-			return "This cartridge is imported and verified."
-		RomCache.STATE_STALE:
-			return "This cache was written by an older build. Import the cartridge again."
-		RomCache.STATE_INCOMPLETE:
-			return "The last import did not finish. Import the cartridge again."
-	return "No cache exists for this cartridge yet."
+	return _cache_state_copy(state, 1)
+
+
+static func needs_reimport(state: StringName) -> bool:
+	return state == RomCache.STATE_STALE or state == RomCache.STATE_INCOMPLETE
+
+
+static func _cache_state_copy(state: StringName, column: int) -> String:
+	var row: Array = CACHE_STATE_COPY.get(state, ["", ""])
+	return String(row[column])
 
 
 ## Public and separate from the dialog for the reason
@@ -493,6 +539,9 @@ func launcher_snapshot() -> Dictionary:
 		games[String(game_id)] = {
 			"title": RomRegistry.title_for(game_id),
 			"imported": data != null,
+			"cache_state": String(
+				RomCache.STATE_USABLE if data != null else cache_state_for(game_id)
+			),
 			"selected": game_id == _selected_game_id,
 			"save_slots": Gen2SaveStore.slots_for(game_id, data.sha1, data) if data != null else [],
 		}
@@ -521,13 +570,13 @@ func preview_fade_step(step: int) -> void:
 	_shell.preview_fade_step(step)
 
 
-## Preview seam: shows the shelf as if these cartridges were imported, so the
-## empty and full states can be photographed on one machine. Changes nothing on
-## disk and is never called by the launcher itself.
+## Preview seam: every bay photographed on one machine. Nothing on disk moves.
 func preview_slot_states(states: Dictionary) -> void:
 	for game_id: StringName in RomRegistry.ORDER:
-		var imported: bool = bool(states.get(String(game_id), false))
-		_shelf.set_slot_state(game_id, imported, "Ready. 2 saves" if imported else "")
+		var state := StringName(states.get(String(game_id), RomCache.STATE_MISSING))
+		var detail: String = "Ready. 2 saves" if state == RomCache.STATE_USABLE \
+			else cache_state_note(state)
+		_shelf.set_slot_state(game_id, state, detail)
 	_refresh_backdrop()
 
 
@@ -551,6 +600,9 @@ func preview_sheet(view: StringName) -> void:
 		&"manage":
 			select_page(&"shelf")
 			_open_manage_sheet(_shelf.selected_id())
+		&"update":
+			select_page(&"shelf")
+			_open_update_sheet(_shelf.selected_id(), RomCache.STATE_STALE)
 		&"touch":
 			select_page(&"settings")
 			_settings._open_touch_layout()
@@ -601,7 +653,7 @@ func _launch_game(game_id: StringName) -> void:
 		return
 	var data: GameData = GameData.open(game_id)
 	if data == null:
-		_open_import_dialog()
+		_open_import_dialog(game_id)
 		return
 	if not GameRuntime.select_game(game_id):
 		_set_status(
@@ -621,7 +673,19 @@ func _launch_game(game_id: StringName) -> void:
 	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
 
 
-func _open_import_dialog(_game_id: StringName = &"") -> void:
+## A cartridge this build cannot read was imported once; an empty bay was not.
+func _open_import_dialog(game_id: StringName = &"") -> void:
+	if _importing:
+		return
+	var state: StringName = cache_state_for(game_id) if not game_id.is_empty() \
+		else RomCache.STATE_MISSING
+	if needs_reimport(state):
+		_open_update_sheet(game_id, state)
+		return
+	_show_import_picker()
+
+
+func _show_import_picker() -> void:
 	if _importing:
 		return
 	_set_status(

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -594,7 +594,6 @@ func _build_idle() -> Node:
 	## Any id: the silhouette is the same shape for all three and its prompt, which
 	## is the only part that names one, is off.
 	var slot: Gen2Cartridge = Gen2Cartridge.create(skin, RomRegistry.ORDER[0])
-	slot.set_imported(false)
 	## The shape, not the invitation: an empty bay on the shelf asks for a dump
 	## to be dropped on it, and nothing can be dropped on a panel.
 	slot.set_bay_prompt(false)

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -503,7 +503,7 @@ func _find_toast(node: Node) -> Gen2LauncherToast:
 
 ## There is no cache migration by design, so the one thing the launcher owes a
 ## player whose cache a build has outgrown is a sentence saying which of the
-## four states it is in and that the dump is wanted again.
+## four states it is in and that the file is wanted again.
 func test_every_cache_state_says_something_different() -> void:
 	var main := preload("res://game/main/main.gd")
 	var said: Dictionary = {}
@@ -514,12 +514,45 @@ func test_every_cache_state_says_something_different() -> void:
 		var text: String = main.cache_state_text(state)
 		assert_false(text.is_empty(), "%s says nothing" % state)
 		assert_false(said.has(text), "%s repeats another state's line" % state)
+		assert_false(text.to_lower().contains("cache"), "%s says it in cache terms" % state)
 		said[text] = true
 	for state: StringName in [RomCache.STATE_STALE, RomCache.STATE_INCOMPLETE]:
 		assert_true(
-			main.cache_state_text(state).contains("Import the cartridge again"),
-			"%s asks for the dump" % state
+			main.cache_state_text(state).contains("Import your file again"),
+			"%s asks for the file" % state
 		)
+		assert_true(main.needs_reimport(state), "%s is a press worth interrupting" % state)
+		assert_false(main.cache_state_note(state).is_empty(), "%s labels its bay" % state)
+	for state: StringName in [RomCache.STATE_USABLE, RomCache.STATE_MISSING]:
+		assert_false(main.needs_reimport(state), "%s needs no explanation" % state)
+		assert_true(main.cache_state_note(state).is_empty(), "%s labels no bay" % state)
+
+
+## Pressing a cartridge this build cannot read explains itself before the file
+## picker lands on the player: they imported this one already, and an OS dialog
+## with no reason in front of it reads as the game having lost their cartridge.
+func test_a_cartridge_needing_its_file_again_is_explained_first() -> void:
+	await _open_launcher()
+	var main := preload("res://game/main/main.gd")
+	_launcher.call("_open_update_sheet", RomRegistry.GOLD, RomCache.STATE_STALE)
+	await get_tree().process_frame
+
+	assert_eq(_sheet_count(), 1, "the press opened the sentence, not the picker")
+	var text: String = _sheet_text()
+	assert_string_contains(text, main.cache_state_text(RomCache.STATE_STALE))
+	assert_string_contains(text, main.SAVES_ARE_SAFE)
+	assert_string_contains(text, "Import again")
+
+
+## Every label on the open sheet, joined, which is what a player reads on it.
+func _sheet_text() -> String:
+	var parts: PackedStringArray = []
+	for sheet: Node in _launcher.find_children("", "Gen2LauncherSheet", true, false):
+		for label: Node in sheet.find_children("", "Label", true, false):
+			parts.append((label as Label).text)
+		for button: Node in sheet.find_children("", "Gen2LauncherButton", true, false):
+			parts.append((button as Button).text)
+	return "\n".join(parts)
 
 
 ## A mod archive whose entry registers a renderer of each kind, for the view

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -671,7 +671,7 @@ func test_an_icon_button_shrinks_its_actual_rect_without_a_container() -> void:
 func test_landscape_keeps_at_least_two_fifths_of_the_stage_for_the_cartridge() -> void:
 	var page: Gen2ShelfPage = Gen2ShelfPage.create(_light, true)
 	add_child_autofree(page)
-	page.set_slot_state(&"gold", true, "Ready")
+	page.set_slot_state(&"gold", RomCache.STATE_USABLE, "Ready")
 	# The last is short enough that the dock alone asks for more than half the
 	# stage, which is what [constant Gen2CartridgeStage.FURNITURE_MAX_SHARE] caps.
 	var sizes: Array[Vector2] = [
@@ -749,12 +749,39 @@ func test_ejecting_a_cartridge_empties_its_bay() -> void:
 	page.size = Vector2(900, 600)
 	await get_tree().process_frame
 	var card: Gen2Cartridge = page.cartridge(RomRegistry.GOLD)
-	page.set_slot_state(RomRegistry.GOLD, true, "Ready")
+	page.set_slot_state(RomRegistry.GOLD, RomCache.STATE_USABLE, "Ready")
 	assert_true(card.imported)
 
 	await card.play_eject()
 	assert_false(card.imported, "the bay is empty again")
 	assert_almost_eq(card.position.y, card.rest_y(), 0.5, "and back where it stood")
+
+
+## A cache an older build wrote is not an empty bay. The player imported this
+## cartridge once, so a bay identical to one that was never filled sends them
+## looking for a bug instead of at the one line that explains it.
+func test_a_cartridge_needing_its_file_again_does_not_look_unimported() -> void:
+	var page: Gen2ShelfPage = Gen2ShelfPage.create(_light, false)
+	add_child_autofree(page)
+	page.size = Vector2(900, 600)
+	await get_tree().process_frame
+	var card: Gen2Cartridge = page.cartridge(RomRegistry.GOLD)
+
+	page.set_slot_state(RomRegistry.GOLD, RomCache.STATE_MISSING, "")
+	assert_false(card._bay_note.visible, "an empty bay has nothing to add")
+	assert_false(page._manage.visible, "and nothing to manage")
+	var empty_glyph: StringName = card._bay_icon.glyph
+
+	page.set_slot_state(RomRegistry.GOLD, RomCache.STATE_STALE, "Update needed")
+	assert_false(card.imported, "it still cannot be played")
+	assert_true(card._bay_note.visible)
+	assert_eq(card._bay_note.text, "Update needed")
+	assert_ne(card._bay_icon.glyph, empty_glyph, "and it is not the same invitation")
+	assert_true(page._manage.visible, "its folder and its delete are reachable")
+
+	page.set_slot_state(RomRegistry.GOLD, RomCache.STATE_USABLE, "Ready. 2 saves")
+	assert_true(card.imported)
+	assert_false(card._bay_note.visible, "a seated cartridge hides the bay whole")
 
 
 func test_the_toast_says_which_kind_of_message_it_is_showing() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37878
+const MAX_COMMENT_LINES: int = 37877
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -4,15 +4,16 @@ extends SceneTree
 ## set of cartridges present.
 ##
 ##   Godot --path . -s res://tools/preview_launcher.gd -- <out.png> [light|dark] \
-##       [width] [height] [page] [empty|mixed|full] [view] [mod id] [scroll] \
+##       [width] [height] [page] [empty|mixed|full|stale] [view] [mod id] [scroll] \
 ##       [focus index] [fade step] [insets]
 ##
 ## Every argument is documented at the parse below. Opens a real window.
 
 const STATES: Dictionary = {
-	"empty": {"gold": false, "silver": false, "crystal": false},
-	"mixed": {"gold": true, "silver": false, "crystal": false},
-	"full": {"gold": true, "silver": true, "crystal": true},
+	"empty": {"gold": "missing", "silver": "missing", "crystal": "missing"},
+	"mixed": {"gold": "usable", "silver": "missing", "crystal": "missing"},
+	"full": {"gold": "usable", "silver": "usable", "crystal": "usable"},
+	"stale": {"gold": "stale", "silver": "usable", "crystal": "incomplete"},
 }
 
 var _output: String = ""
@@ -86,8 +87,8 @@ func _process(_delta: float) -> bool:
 			# goes, so the ordinary shot below lands in the middle of it, which
 			# is the screen worth photographing.
 			_launcher.import_rom_path(_mod)
-		elif _view in ["manage", "touch", "binding", "browse", "delete_mod", "bugs", "report",
-				"toast", "quit"]:
+		elif _view in ["manage", "update", "touch", "binding", "browse", "delete_mod", "bugs",
+				"report", "toast", "quit"]:
 			_launcher._preview_browse_dir = _mod
 			_launcher.preview_sheet(StringName(_view))
 		elif not _view.is_empty():


### PR DESCRIPTION
A cache is never migrated, so an update that changes its format leaves a cartridge that has to be imported again. The launcher only ever asked whether `GameData.open` answered, so that cartridge looked exactly like one nobody had ever imported: same dark bay, no line under it, and a press that opened the file picker with no reason in front of it.

The shelf now carries the cache state rather than a bool.

| Where | Before | After |
|---|---|---|
| The bay | Identical to never imported | Refresh glyph in the accent colour, and "Update needed" or "Import unfinished" under the name |
| The three dots | Hidden, so the folder and the delete were unreachable for exactly the two states worth reaching them | Shown for any cartridge that has a cache |
| A press | Straight to the OS file picker | One sentence, the note that saves are not affected, and an Import again button |
| The dump chosen next | Any of the three accepted | Checked against the cartridge that was pressed |

The wording lost the word "cache", which named a chore nobody bought the game to do. All four state lines live in one table with the short shelf label beside each sentence, and the manage sheet says the same thing from the same place.

Two things found on the way and fixed here: `set_depth` repainted the bay icon on every layout pass and undid the state's own glyph, so the icon is decided in one place now; and a long sentence in a sheet was clipped, because `Gen2LauncherUI.body` does not wrap.

Unit tier 3499 passing, analyser 0 warnings in 605 scripts, boot smoke clean. Screenshots in the shelf and the sheet, light and dark, desktop and phone.