### PR TITLE
The PC's lists answer the arrows again, and its ring closes

### DIFF
--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -124,7 +124,9 @@ func move_focus(direction: Vector2) -> bool:
 	var current: Control = viewport.gui_get_focus_owner()
 	if current == null or not top.is_ancestor_of(current):
 		refresh()
-		return viewport.gui_get_focus_owner() != null
+		# The ring this guard placed, not one left elsewhere on the page.
+		var landed: Control = viewport.gui_get_focus_owner()
+		return landed != null and top.is_ancestor_of(landed)
 	var best: Control = _toward(current, direction, focusable_controls(top), top == _root)
 	if best == null or best == current:
 		return false

--- a/game/render/pc_box_page.gd
+++ b/game/render/pc_box_page.gd
@@ -4,10 +4,8 @@ extends RefCounted
 ## Bill's PC on the tile grid the hardware uses (`engine/pokemon/bills_pc.asm`).
 ## `Gen2BoxScreen` owns the party, the boxes and what a row may do; this is the
 ## picture, the way [Gen2PackPage] is the pack's. Every position is the source's
-## own: `BillsPC_BoxName`'s header box, `BillsPC_RefreshTextboxes`' listing,
-## `PCMonInfo`'s left column and `BillsPC_PlaceString`'s bottom box. Node-free;
-## the selected Pokemon's pic and the cursor are drawn through palettes of their
-## own and are composed over the page by the screen.
+## own. Node-free; the selected Pokemon's pic and the cursor carry palettes of
+## their own and are composed over the page by the screen.
 
 const TILE: int = Gen2Font.TILE
 const COLUMNS: int = 20
@@ -18,13 +16,11 @@ const ROWS: int = 18
 const NAME_BOX: Rect2i = Rect2i(8, 0, 12, 3)
 const NAME_AT: Vector2i = Vector2i(10, 1)
 
-## `hlcoord 8, 2 / lb bc, 10, 10`, whose top corners are then overwritten with
-## `└` and `┘` so the listing joins the header box above it rather than closing
-## against it.
+## `hlcoord 8, 2 / lb bc, 10, 10`, whose top corners are overwritten with `└` and
+## `┘` so the listing joins the header box rather than closing against it.
 const LIST_BOX: Rect2i = Rect2i(8, 2, 12, 12)
 const LIST_AT: Vector2i = Vector2i(9, 4)
-## `ld a, $5 / ld [wBillsPC_NumMonsOnScreen], a`, and the two rows a nickname
-## steps by.
+## `ld a, $5 / ld [wBillsPC_NumMonsOnScreen], a`, and a nickname's two rows.
 const LIST_HEIGHT: int = 5
 const ROW_SPACING: int = 2
 ## `.CancelString`, the row `CopyBoxmonSpecies` terminates every list with.
@@ -34,9 +30,8 @@ const CANCEL: String = "CANCEL"
 const PROMPT_BOX: Rect2i = Rect2i(0, 15, 20, 3)
 const PROMPT_AT: Vector2i = Vector2i(1, 16)
 
-## `PCMonInfo`'s own column. The pic is seven tiles square at `hlcoord 1, 4`,
-## laid down column by column (`ld [hli], a / add 7`), which is the order
-## `GetMonFrontpic` decompresses into.
+## `PCMonInfo`'s own column. The pic is seven tiles square at `hlcoord 1, 4`, laid
+## down column by column (`ld [hli], a / add 7`), `GetMonFrontpic`'s own order.
 const PIC_AT: Vector2i = Vector2i(1, 4)
 const PIC_TILES: int = 7
 const LEVEL_AT: Vector2i = Vector2i(1, 12)
@@ -44,23 +39,25 @@ const GENDER_AT: Vector2i = Vector2i(5, 12)
 const ITEM_AT: Vector2i = Vector2i(7, 12)
 const SPECIES_AT: Vector2i = Vector2i(1, 14)
 
-## `PrintLevel`'s `<LV>`, and the two markers `BillsPC_InitGFX` copies
-## `PCMailGFX` over: `$5c` for a held mail and `$5d` for any other held item.
-## Everything on the page is printed with the battle-extra strip loaded, which
-## `BillsPC_InitGFX` does before it copies `PCMailGFX` over two of its tiles.
+## `PrintLevel`'s `<LV>`, and the four tiles `BillsPC_InitGFX` copies `PCMailGFX`
+## over the battle-extra strip's own `$5c` to `$5f`: a held mail, any other held
+## item, and the two arrows `BillsPC_MoveMonWOMail_BoxNameAndArrows` puts either
+## side of the box name.
 const FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
 const CODE_LEVEL: int = 0x6E
 const MAIL_CODE: int = 0x5C
 const ITEM_CODE: int = 0x5D
+const ARROW_RIGHT_CODE: int = 0x5E
+const ARROW_LEFT_CODE: int = 0x5F
+const ARROW_LEFT_AT: Vector2i = Vector2i(8, 1)
+const ARROW_RIGHT_AT: Vector2i = Vector2i(19, 1)
 
-## `BillsPC_UpdateSelectionCursor`'s OAM, as (x, y, tile, x flip, y flip) in
-## screen pixels: `dbsprite` is x tile, y tile, x pixel, y pixel, and the
-## hardware's own 8 and 16 pixel bias is taken off here. The whole set moves down
-## sixteen pixels per cursor row, so only the row inside the listing is stored.
-## The two profiles draw different rings out of different sheets: Crystal's
-## twenty-four objects are two tiles flipped into four edges, and Gold and
-## Silver's twenty are six tiles with no flip in them. Reading either set out of
-## the other's sheet draws the side pieces along the top.
+## `BillsPC_UpdateSelectionCursor`'s OAM as (x, y, tile, x flip, y flip) in
+## screen pixels, pinned to the source's own operands by `tools/checks/pc.gd`.
+## The set moves down sixteen pixels a row, so only the first row is stored.
+## Crystal's twenty-four objects are two tiles flipped into four edges; Gold and
+## Silver's twenty are six tiles with no flip. Reading either set out of the
+## other's sheet draws the side pieces along the top.
 const CURSOR_STEP: int = 16
 const CURSOR_SPRITES: Array = [
 	[72, 22, 0, false, false], [80, 22, 0, false, false],
@@ -68,11 +65,11 @@ const CURSOR_SPRITES: Array = [
 	[104, 22, 0, false, false], [112, 22, 0, false, false],
 	[120, 22, 0, false, false], [128, 22, 0, false, false],
 	[136, 22, 0, false, false], [143, 22, 0, false, false],
-	[72, 46, 0, false, true], [80, 46, 0, false, true],
-	[88, 46, 0, false, true], [96, 46, 0, false, true],
-	[104, 46, 0, false, true], [112, 46, 0, false, true],
-	[120, 46, 0, false, true], [128, 46, 0, false, true],
-	[136, 46, 0, false, true], [143, 46, 0, false, true],
+	[72, 41, 0, false, true], [80, 41, 0, false, true],
+	[88, 41, 0, false, true], [96, 41, 0, false, true],
+	[104, 41, 0, false, true], [112, 41, 0, false, true],
+	[120, 41, 0, false, true], [128, 41, 0, false, true],
+	[136, 41, 0, false, true], [143, 41, 0, false, true],
 	[70, 30, 1, false, false], [70, 33, 1, false, true],
 	[145, 30, 1, true, false], [145, 33, 1, true, true],
 ]
@@ -95,7 +92,7 @@ var frame_style: int = 0
 var font: Gen2Font = null
 ## Which cartridge's cursor set the screen draws.
 var _profile: StringName = RomRegistry.CRYSTAL
-## `PCMailGFX`, the two markers a held item is printed as.
+## `PCMailGFX`: the two markers a held item is printed as and the two arrows.
 var _mail: PackedByteArray = PackedByteArray()
 
 
@@ -115,10 +112,9 @@ static func from_data(data: GameData) -> Gen2PCBoxPage:
 
 ## The whole 160x144 page as palette indices.
 ##
-## [param state] is the screen's own: `box_name`, the visible `rows` of at most
-## [constant LIST_HEIGHT] nicknames with `cancel` on the last one, `prompt` for
-## the line the bottom box carries, and `mon` for whatever `PCMonInfo` prints
-## about the row the cursor stands on.
+## [param state] is the screen's own: `box_name`, `arrows` for MOVE PKMN W/O
+## MAIL's own two, the visible `rows` with `cancel` on the last one, `prompt` for
+## the bottom box, and `mon` for what `PCMonInfo` prints beside the cursor.
 func draw(state: Dictionary) -> PackedByteArray:
 	var indices := PackedByteArray()
 	indices.resize(COLUMNS * TILE * ROWS * TILE)
@@ -127,6 +123,9 @@ func draw(state: Dictionary) -> PackedByteArray:
 	var width: int = COLUMNS * TILE
 	_box(indices, width, NAME_BOX)
 	_text(indices, width, String(state.get("box_name", "")), NAME_AT)
+	if bool(state.get("arrows", false)):
+		_marker(indices, width, ARROW_LEFT_CODE, ARROW_LEFT_AT)
+		_marker(indices, width, ARROW_RIGHT_CODE, ARROW_RIGHT_AT)
 	_box(indices, width, LIST_BOX)
 	## The two corners `BillsPC_RefreshTextboxes` writes over the frame it has
 	## just drawn, which is what joins the two boxes into one.
@@ -231,8 +230,8 @@ func _code(indices: PackedByteArray, width: int, code: int, at: Vector2i) -> voi
 	font.draw_code(code, indices, width, at.x * TILE, at.y * TILE, FONT)
 
 
-## One of `PCMailGFX`'s two tiles, which sit where the battle-extra strip's own
-## $5c and $5d would be: the copy is made after `LoadFontsBattleExtra`.
+## One of `PCMailGFX`'s four tiles; the copy is made after
+## `LoadFontsBattleExtra`.
 func _marker(
 	indices: PackedByteArray, width: int, code: int, at: Vector2i
 ) -> void:

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -4,19 +4,15 @@ extends Control
 ## Bill's PC's three lists, on the hardware's own grid. [Gen2PCBoxPage] is the
 ## picture and `engine/pokemon/bills_pc.asm` is the model. `_DepositPKMN`,
 ## `_WithdrawPKMN` and `_MovePKMNWithoutMail` are this one screen with a
-## different list loaded, opened from the panel's own top menu. A on a row opens
-## the submenu each jumptable reaches; left and right belong to
-## `MoveMonWithoutMail_DPad` alone.
+## different list loaded. A on a row opens the submenu each jumptable reaches;
+## left and right belong to `MoveMonWithoutMail_DPad` alone.
 
 signal closed(result: Dictionary)
-## `PlayMonCry2` from the stats screen this one can open, played by whoever owns
-## the audio player: nothing here reaches [Gen2AudioPlayer].
+## `PlayMonCry` on every transfer and from the stats screen, played by whoever
+## owns the audio player: nothing here reaches [Gen2AudioPlayer].
 signal cry_requested(species: int)
 ## `MoveMonWOMail_InsertMon_SaveGame`'s `SFX_SAVE`, played by the driver's owner.
 signal sfx_requested(index: int, waited: bool)
-
-## The PC is drawn in hardware pixels and the panel it opens from is ordinary UI,
-## so the screen carries a [Gen2Screen] of its own the way the region map does.
 
 ## `PCString_*` and `.PartyPKMN`, engine strings inside `bills_pc.asm` that no
 ## script points at, so they are the host's the way the contest lines are. "PKMN"
@@ -35,8 +31,7 @@ const PROMPT_NO_EGGS: String = "No releasing EGGS!"
 const PROMPT_STORED: String = "Stored %s!"
 const PROMPT_GOT: String = "Got %s!"
 ## `ReleasePKMN_ByePKMN` prints `PCString_ReleasedPKMN` for eighty frames and
-## then this one for fifty. Nothing here spends frames, so the line left on the
-## page is the one the source leaves on it.
+## then this one for fifty. Nothing here spends frames, so this is the line left.
 const PROMPT_BYE: String = "Bye, %s!"
 const PARTY_NAME: String = "PARTY PKMN"
 
@@ -46,16 +41,15 @@ const LOADED_PARTY: int = 0
 ## Which of `_BillsPC.Jumptable`'s three list rows opened this screen.
 const MODE_DEPOSIT: int = 0
 const MODE_WITHDRAW: int = 1
-## `_MovePKMNWithoutMail`, which is neither list: left and right load any of the
-## party and the fourteen boxes, and A twice moves a Pokemon from one place in
-## one of them to another place in another.
+## `_MovePKMNWithoutMail`, neither list: left and right load any of the party and
+## the fourteen boxes, and A twice moves a Pokemon from one to another.
 const MODE_MOVE: int = 2
 ## Its two `.Joypad` passes: choosing the Pokemon and choosing where it goes.
 const MOVE_PHASE_CHOOSE: int = 0
 const MOVE_PHASE_INSERT: int = 1
 ## `PCString_MoveToWhere` and `PCString_TheresNoRoom`.
 const PROMPT_MOVE_WHERE: String = "Move to where?"
-const PROMPT_NO_ROOM: String = "There's no room."
+const PROMPT_NO_ROOM: String = "There's no room!"
 ## `.MenuData`'s own three rows, which drop the RELEASE the other two lists have.
 const SUBMENU_ROWS_MOVE: Array[String] = ["MOVE", "STATS", "CANCEL"]
 const SUBMENU_MOVE_STATS: int = 1
@@ -63,8 +57,7 @@ const SUBMENU_MOVE_CANCEL: int = 2
 
 ## `BillsPCDepositMenuHeader` and `BillsPC_Withdraw.MenuHeader`, the same
 ## `menu_coords 9, 4, SCREEN_WIDTH - 1, 13` over the listing, and the yes/no
-## `lb bc, 14, 11` puts under it. `_YesNoBox` adds five and four to the corner it
-## is handed.
+## `lb bc, 14, 11` puts under it; `_YesNoBox` adds five and four to that corner.
 const SUBMENU_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR
 const SUBMENU_AT: Rect2i = Rect2i(9, 4, 10, 9)
 const RELEASE_AT: Vector2i = Vector2i(14, 11)
@@ -79,6 +72,9 @@ const SUBMENU_RELEASE: int = 2
 const SUBMENU_CANCEL: int = 3
 const SUBMENU_ROWS: Array[String] = ["DEPOSIT", "STATS", "RELEASE", "CANCEL"]
 const SUBMENU_ROWS_WITHDRAW: Array[String] = ["WITHDRAW", "STATS", "RELEASE", "CANCEL"]
+
+## Every refusal the screen prints is followed by `WaitPlaySFX SFX_WRONG`.
+const SFX_WRONG: int = 0x19
 
 ## `BillsPC_CheckMail_PreventBlackout`'s own `cp $3` against
 ## `wBillsPC_NumMonsInBox`, which `CopyBoxmonSpecies` leaves one over the party
@@ -239,17 +235,17 @@ func deposit_selected_party() -> bool:
 		_prompt = PROMPT_CHOOSE
 		_refresh()
 		return false
-	var mon_name: String = _display_name(_save.party[_selected_party_index] as Gen2SaveMon)
+	var mon: Gen2SaveMon = _save.party[_selected_party_index]
+	var mon_name: String = _display_name(mon)
 	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(
 		_save, _data, _selected_party_index, _box_index, -1, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_prompt = _refusal(result, PROMPT_BOX_FULL)
-		_refresh()
+		_refuse(_refusal(result, PROMPT_BOX_FULL))
 		return false
 	_prompt = PROMPT_STORED % mon_name
-	_selected_party_index = -1
-	_clamp_cursor()
+	_cry_for(mon)
+	_reset_cursor()
 	_refresh()
 	return true
 
@@ -261,19 +257,17 @@ func withdraw_selected_box() -> bool:
 		_refresh()
 		return false
 	var box: Gen2SaveBox = _save.boxes[_box_index] if _box_index < _save.boxes.size() else null
-	var mon_name: String = _display_name(
-		box.slots[_selected_box_slot] as Gen2SaveMon if box != null else null
-	)
+	var mon: Gen2SaveMon = box.slots[_selected_box_slot] as Gen2SaveMon if box != null else null
+	var mon_name: String = _display_name(mon)
 	var result: Dictionary = Gen2SaveStorage.withdraw_box_to_party(
 		_save, _data, _box_index, _selected_box_slot, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_prompt = _refusal(result, PROMPT_PARTY_FULL)
-		_refresh()
+		_refuse(_refusal(result, PROMPT_PARTY_FULL))
 		return false
 	_prompt = PROMPT_GOT % mon_name
-	_selected_box_slot = -1
-	_clamp_cursor()
+	_cry_for(mon)
+	_reset_cursor()
 	_refresh()
 	return true
 
@@ -291,13 +285,11 @@ func release_selected() -> bool:
 		_save, _data, _box_index, _selected_box_slot, _persist
 	)
 	if not bool(result.get("ok", false)):
-		_prompt = _refusal(result, PROMPT_LAST_MON)
-		_refresh()
+		_refuse(_refusal(result, PROMPT_LAST_MON))
 		return false
 	_prompt = PROMPT_BYE % mon_name
-	_selected_party_index = -1
-	_selected_box_slot = -1
-	_clamp_cursor()
+	_cry_for(mon)
+	_reset_cursor()
 	_refresh()
 	return true
 
@@ -350,14 +342,15 @@ func handle_button(button: int) -> bool:
 	return true
 
 
-## `VerticalMenu` over the listing. Its B is the CANCEL row, which is
-## `BillsPCDepositFuncCancel`: back to the list, nothing done.
+## `VerticalMenu` over the listing. Its B is the CANCEL row,
+## `BillsPCDepositFuncCancel`. Neither this menu nor the yes/no under it carries
+## `STATICMENU_WRAP`, so both stop at their ends.
 func _handle_submenu_button(button: int) -> bool:
 	match button:
 		Gen2Button.UP:
-			_submenu_cursor = wrapi(_submenu_cursor - 1, 0, _submenu_labels().size())
+			_submenu_cursor = maxi(_submenu_cursor - 1, 0)
 		Gen2Button.DOWN:
-			_submenu_cursor = wrapi(_submenu_cursor + 1, 0, _submenu_labels().size())
+			_submenu_cursor = mini(_submenu_cursor + 1, _submenu_labels().size() - 1)
 		Gen2Button.A:
 			_confirm_submenu()
 			return true
@@ -374,9 +367,9 @@ func _handle_submenu_button(button: int) -> bool:
 func _handle_release_button(button: int) -> bool:
 	match button:
 		Gen2Button.UP:
-			_release_cursor = wrapi(_release_cursor - 1, 0, RELEASE_OPTIONS.size())
+			_release_cursor = maxi(_release_cursor - 1, 0)
 		Gen2Button.DOWN:
-			_release_cursor = wrapi(_release_cursor + 1, 0, RELEASE_OPTIONS.size())
+			_release_cursor = mini(_release_cursor + 1, RELEASE_OPTIONS.size() - 1)
 		Gen2Button.A:
 			_release_open = false
 			if _release_cursor == 0:
@@ -427,11 +420,7 @@ func _confirm_submenu() -> void:
 			SUBMENU_TRANSFER:
 				## `.Move`: `BillsPC_CheckMail_PreventBlackout` first, and then
 				## the second joypad pass over whichever list is loaded then.
-				var refusal: String = _blackout_refusal()
-				if not refusal.is_empty():
-					_close_submenu(false)
-					_prompt = refusal
-					_refresh()
+				if _refuse_to_list(_blackout_refusal()):
 					return
 				_close_submenu(false)
 				_begin_move()
@@ -442,13 +431,8 @@ func _confirm_submenu() -> void:
 		return
 	match _submenu_cursor:
 		SUBMENU_TRANSFER:
-			var refusal: String = _blackout_refusal()
-			if not refusal.is_empty():
-				_close_submenu(false)
-				_prompt = refusal
-				_refresh()
+			if _refuse_to_list(_blackout_refusal()):
 				return
-			_close_submenu(false)
 			if _loaded == LOADED_PARTY:
 				deposit_selected_party()
 			else:
@@ -456,23 +440,49 @@ func _confirm_submenu() -> void:
 		SUBMENU_STATS:
 			_open_stats()
 		SUBMENU_RELEASE:
-			var blocked: String = _blackout_refusal()
-			if blocked.is_empty() and _selected_mon() != null \
-					and (_selected_mon() as Gen2SaveMon).is_egg:
-				## `BillsPC_IsMonAnEgg`, which the box side checks on its own and
-				## the party side reaches behind the blackout check.
-				blocked = PROMPT_NO_EGGS
-			if not blocked.is_empty():
-				_close_submenu(false)
-				_prompt = blocked
-				_refresh()
-				return
-			_release_open = true
-			_release_cursor = 0
-			_prompt = PROMPT_RELEASE
-			_refresh()
+			_ask_release()
 		_:
 			_close_submenu()
+
+
+## `BillsPCDepositFuncCancel`, which the three blackout refusals reach: the list
+## again. `.box_full`, `.FailedWithdraw` and `.FailedRelease` return to the
+## submenu instead, which is still up.
+func _refuse_to_list(refusal: String) -> bool:
+	if refusal.is_empty():
+		return false
+	_close_submenu(false)
+	_refuse(refusal)
+	return true
+
+
+## `PlayMonCry` on `wCurPartySpecies`, and `ReleasePKMN_ByePKMN`'s `GetCryIndex`
+## before its own: an egg carries no cry of the Pokemon inside it.
+func _cry_for(mon: Gen2SaveMon) -> void:
+	if mon != null and not mon.is_egg:
+		cry_requested.emit(mon.species)
+
+
+## `BillsPC_PlaceString` and the `WaitPlaySFX` every refusal ends on.
+func _refuse(line: String) -> void:
+	_prompt = line
+	sfx_requested.emit(SFX_WRONG, true)
+	_refresh()
+
+
+## `.release`'s own order: the party's blackout guard, then `BillsPC_IsMonAnEgg`,
+## which the box side checks on its own, and then the yes/no.
+func _ask_release() -> void:
+	if _refuse_to_list(_blackout_refusal()):
+		return
+	var mon: Gen2SaveMon = _selected_mon()
+	if mon != null and mon.is_egg:
+		_refuse(PROMPT_NO_EGGS)
+		return
+	_release_open = true
+	_release_cursor = 0
+	_prompt = PROMPT_RELEASE
+	_refresh()
 
 
 ## `BillsPC_CheckMail_PreventBlackout`, which guards the party list's transfer
@@ -507,21 +517,29 @@ func _all_others_fainted() -> bool:
 	return true
 
 
-## `BillsPC_StatsScreen`, which is `StatsScreenInit` over this screen and hands
-## control back on the way out.
+## `BillsPC_StatsScreen`, `StatsScreenInit` over this screen. `_StatsScreenDPad`
+## walks the loaded list from in there, so it is handed the whole of it.
 func _open_stats() -> void:
-	var mon: Gen2SaveMon = _selected_mon()
-	if mon == null or _data == null:
+	var mons: Array = []
+	for entry: Array in _entries():
+		mons.append(entry[1])
+	var at: int = _cursor + _scroll
+	if at < 0 or at >= mons.size() or _data == null:
 		return
-	_stats = Gen2MonStatsScreen.create(_data, [mon])
+	_stats = Gen2MonStatsScreen.create(_data, mons, at)
 	_stats.closed.connect(_close_stats)
 	_stats.cry_requested.connect(func(species: int) -> void: cry_requested.emit(species))
 	_stats.announce()
 	_refresh()
 
 
-## The submenu is still up behind it, which is where `.stats` returns.
+## `.stats` returns to the submenu, on the row `BillsPC_PressUp` and
+## `BillsPC_PressDown` left the two cursor bytes on.
 func _close_stats() -> void:
+	var at: int = _stats.cursor()
+	_scroll = clampi(_scroll, at - Gen2PCBoxPage.LIST_HEIGHT + 1, at)
+	_cursor = at - _scroll
+	_sync_selection()
 	_stats = null
 	_prompt = PROMPT_WHATS_UP
 	_refresh()
@@ -612,6 +630,7 @@ func _refresh() -> void:
 			visible_rows.append(all_rows[at])
 	var indices: PackedByteArray = _page.draw({
 		"box_name": _box_name(),
+		"arrows": _mode == MODE_MOVE,
 		"rows": visible_rows,
 		"prompt": _prompt,
 		"mon": _mon_state(mon),
@@ -924,9 +943,8 @@ func _begin_move() -> void:
 
 
 ## `.a_button_2`: `BillsPC_CheckSpaceInDestination` and then
-## `MovePKMNWithoutMail_InsertMon`, which puts up a box for twenty frames, moves
-## the Pokemon and saves behind it. The move lands in front of the box here
-## rather than behind it, which the box itself covers.
+## `MovePKMNWithoutMail_InsertMon`, a box for twenty frames with the move and the
+## save behind it. The move lands in front of that box here.
 func _insert_moved_mon() -> void:
 	var result: Dictionary = Gen2SaveStorage.move_mon(
 		_save, _data, _move_from_loaded, _move_from_index, _loaded,
@@ -935,10 +953,9 @@ func _insert_moved_mon() -> void:
 	if not bool(result.get("ok", false)):
 		## `.no_space` steps the jumptable back one, which leaves the insert
 		## cursor where it was with the box's own refusal printed under it.
-		_prompt = PROMPT_NO_ROOM if StringName(
+		_refuse(PROMPT_NO_ROOM if StringName(
 			result.get("reason", &"")
-		) == &"no_room_in_destination" else _refusal(result, PROMPT_NO_ROOM)
-		_refresh()
+		) == &"no_room_in_destination" else _refusal(result, PROMPT_NO_ROOM))
 		return
 	_prompt = Gen2SavePrompt.SAVING_LEAVE_ON
 	_saving_frames = Gen2SavePrompt.LEAVE_ON_FRAMES
@@ -966,7 +983,8 @@ func advance_saving_frames(count: int) -> void:
 		if _saving_saved:
 			set_process(false)
 			_saving_saved = false
-			_end_move()
+			## `.a_button_2` reaches `.Init` without touching the backup.
+			_end_move(false)
 		else:
 			_saved_moved_mon()
 
@@ -978,10 +996,10 @@ func _process(delta: float) -> void:
 	advance_saving_frames(_saving_clock.tick(delta))
 
 
-## `.Cancel` and `.b_button_2` alike: the first pass again, on the list the
-## Pokemon was chosen from.
-func _end_move() -> void:
-	if _move_backup.size() == 3:
+## `.b_button_2`: the first pass again, on the list the Pokemon was chosen from.
+## Only a cancel puts that back.
+func _end_move(restore: bool = true) -> void:
+	if restore and _move_backup.size() == 3:
 		_loaded = int(_move_backup[0])
 		_cursor = int(_move_backup[1])
 		_scroll = int(_move_backup[2])
@@ -993,6 +1011,16 @@ func _end_move() -> void:
 	_prompt = PROMPT_CHOOSE
 	_clamp_cursor()
 	_refresh()
+
+
+## `BillsPCDepositFuncDeposit`, `.withdraw` and both `.release`s end with `xor a`
+## into `wBillsPC_CursorPosition` and `wBillsPC_ScrollPosition`.
+func _reset_cursor() -> void:
+	_cursor = 0
+	_scroll = 0
+	_submenu_open = false
+	_selected_box_slot = -1
+	_selected_party_index = -1
 
 
 ## After a transfer the list is one row shorter, so the cursor comes back inside

--- a/game/save/save_storage.gd
+++ b/game/save/save_storage.gd
@@ -1,12 +1,9 @@
 class_name Gen2SaveStorage
 extends RefCounted
 
-## Atomic party and PC-box transactions for a validated project save.
-##
-## Each operation edits a deep candidate, validates it against the selected
-## cartridge cache, writes it through the save store, and only then updates the
-## shared runtime save object. A failed write or validation therefore leaves
-## both the in-memory and on-disk save untouched.
+## Atomic party and PC-box transactions for a validated project save. Each edits
+## a deep candidate, validates it, writes it through the save store and only then
+## updates the shared save, so a failed write leaves both copies untouched.
 
 
 static func deposit_party_to_box(
@@ -77,11 +74,10 @@ static func withdraw_box_to_party(
 	}, persist)
 
 
-## `RemoveMonFromPartyOrBox` behind `BillsPCDepositFuncRelease` and Bill's PC's
-## own `.release`: the same atomic write the two transfers make, with nothing on
-## the other end of it. Both of the source's refusals are the caller's, since
-## both are boxes it prints before the yes/no: `BillsPC_IsMonAnEgg` and, for the
-## party alone, `BillsPC_CheckMail_PreventBlackout`.
+## `RemoveMonFromPartyOrBox` behind both `.release`s: the same atomic write the
+## transfers make, with nothing on the other end. `BillsPC_IsMonAnEgg` and
+## `BillsPC_CheckMail_PreventBlackout` are the caller's, printed before the
+## yes/no.
 static func release_party_member(
 	save: Gen2SaveData, data: GameData, party_index: int, persist: bool = true
 ) -> Dictionary:
@@ -124,12 +120,9 @@ static func release_box_slot(
 
 ## `MovePKMNWithoutMail_InsertMon`'s four branches in one: the mon leaves
 ## [param from_index] of one list and is inserted at [param to_index] of the
-## other, everything behind it shifting down. A list is the party when it is
-## `Gen2BoxScreen.LOADED_PARTY` and the box before it otherwise, which is
-## `wBillsPC_LoadedBox`'s own numbering.
-##
-## `BillsPC_CheckSpaceInDestination` is the one refusal, and only for a move
-## between two lists: a reorder inside one cannot overflow it.
+## other. A list is the party at `Gen2BoxScreen.LOADED_PARTY` and the box before
+## it otherwise, `wBillsPC_LoadedBox`'s own numbering.
+## `BillsPC_CheckSpaceInDestination` is the one refusal, and only across lists.
 static func move_mon(
 	save: Gen2SaveData,
 	data: GameData,
@@ -154,7 +147,10 @@ static func move_mon(
 	if from_loaded == to_loaded:
 		var reordered: Array = source.duplicate()
 		reordered.remove_at(from_index)
-		reordered.insert(clampi(to_index, 0, reordered.size()), mon)
+		## `.CheckTrivialMove`: the row pointed at has already shifted up by the
+		## one that left, so the insert row loses one when it came from above.
+		var at: int = to_index - 1 if to_index > from_index else to_index
+		reordered.insert(clampi(at, 0, reordered.size()), mon)
 		_write_loaded_list(candidate, from_loaded, reordered)
 	else:
 		var destination: Array = _loaded_list(candidate, to_loaded)

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -60,8 +60,7 @@ const BILLS_PC_NEEDS_POKEMON: String = "You gotta have\n#MON to call!"
 
 ## `MailboxPC.SubMenuData`'s four rows, inline menu strings the way BILL'S PC's
 ## own five are, and the five `text_far` stubs `.PutInPack` and `.AttachMail`
-## print through. Kept here rather than imported for the same reason: nothing
-## points at them, so there is no table to walk.
+## print through. Kept here for the same reason: nothing points at them.
 const MAILBOXITEM_READ: int = 0
 const MAILBOXITEM_PUT_IN_PACK: int = 1
 const MAILBOXITEM_ATTACH: int = 2

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -10,7 +10,7 @@ signal completed(results: Array)
 ## screen owns the one player a map's music and its effects share, and
 ## [Gen2WorldAudioHost] is an inspection probe that must never stand in for it.
 ## [param waited] is `WaitPlaySFX`, or a `WaitSFX` spent by hand, so the request
-## can never be the one `PlaySFX`'s priority gate refuses; the wait is not spent.
+## is never the one `PlaySFX`'s gate refuses; the wait itself is not spent.
 signal sfx_requested(index: int, waited: bool)
 ## `PlayMonCry2` from a screen this one opens, passed on for the same reason.
 signal cry_requested(species: int)
@@ -22,6 +22,7 @@ enum MODE {
 	PC_DECO, PC_DECO_LIST, PC_DECO_SIDE,
 	PC_BOX_SUBMENU,
 	PC_MAILBOX, PC_MAIL_SUBMENU, PC_MAIL_CONFIRM,
+	PC_OAK_ASK,
 	PC_SAVE,
 	ELEVATOR,
 }
@@ -34,12 +35,10 @@ const FLOOR_NAMES: Array[String] = [
 ## `Elevator_MenuData`'s `db 4, 0`: four rows of floors are shown at a time.
 const ELEVATOR_ROWS: int = 4
 
-## `PokemonCenterPC`'s own box storage, which is the one row that opens a screen
-## rather than a list. It is added as a child the way the MAP card adds the
-## region map, so the top menu is still there when the box screen closes.
+## `PokemonCenterPC`'s box storage, added as a child the way MAP adds the map.
 const BOX_SCENE := preload("res://game/save/box_screen.tscn")
-## `.AttachMail`'s own `PartyMenuSelect`, which is the same list the day care
-## and the move tutor open.
+const OAK_PC: String = "PROF.OAK'S PC"
+## `.AttachMail`'s `PartyMenuSelect`, the list the day care also opens.
 const PARTY_SCENE: PackedScene = preload("res://game/save/party_screen.tscn")
 
 ## `wPokegearRadioMusicPlaying`, which `ExitPokegearRadio_HandleMusic` branches
@@ -84,6 +83,10 @@ const SFX_TRANSACTION: int = 0x22
 ## `PC_PlaySwapItemsSound`, which asks for the same effect twice through
 ## `WaitPlaySFX`. Hexadecimal, the way `constants/sfx_constants.asm` counts.
 const SFX_SWITCH_POKEMON: int = 0x20
+## `PC_PlayBootSound`, `PC_PlayShutdownSound` and `PC_PlayChoosePCSound`.
+const SFX_BOOT_PC: int = 0x0D
+const SFX_SHUT_DOWN_PC: int = 0x0E
+const SFX_CHOOSE_PC_OPTION: int = 0x0F
 ## `BillsPC_PlaceEmptyBoxString_SFX`'s own `SFX_WRONG`.
 const SFX_WRONG: int = 0x19
 ## `PokegearPhone_MakePhoneCall`'s own `SFX_CALL`, and the `SFX_NO_SIGNAL`
@@ -213,27 +216,35 @@ const BOX_LIST_ROWS: int = 4
 const PC_ROW_MODES: Array = [
 	MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST, MODE.PC_BOX_SUBMENU,
 	MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
-	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_SAVE,
+	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK,
+	MODE.PC_SAVE,
 ]
 ## The `db rows` byte of every scrolling menu here, which is how much of its list
 ## a window shows. `wMenuScrollPosition` is one value, the way it is one address
 ## on the cartridge: only one of these lists is ever open.
 const SCROLLING_ROWS: Dictionary = {
 	MODE.PC_BOX_LIST: BOX_LIST_ROWS,
-	## `MailboxPC.TopMenuData`, `.PCItemsMenuData` and
-	## `_PlayerDecorationMenu.ScrollingMenuData`.
+	## `.TopMenuData`, `.PCItemsMenuData` and `.ScrollingMenuData`.
 	MODE.PC_MAILBOX: 4,
 	MODE.PC_ITEM_LIST: 4,
 	MODE.PC_DECO_LIST: 8,
 }
+## No `STATICMENU_WRAP`, and every `ScrollingMenu`, whose `_2DMENU_EXIT_UP` and
+## `_DOWN` hand an end to a scroll rather than to the other end of the list.
+const NO_WRAP_MODES: Array = [
+	MODE.PC_BOXES, MODE.PC_BOX_LIST, MODE.PC_BOX_SUBMENU, MODE.PC_ITEM_LIST,
+	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK,
+	MODE.PC_DECO_SIDE,
+]
 var _pc_scroll: int = 0
-## `wCurBox`, which CHANGE BOX writes and both lists read. It is the save's, so
-## the box a deposit lands in outlives the machine being switched off.
+## `wCurBox`, which CHANGE BOX writes and both lists read. The save's, so the box
+## a deposit lands in outlives the machine being switched off.
 var _box_index: int = 0
-## Whether storage was opened without the Pokemon Center machine around it, so
-## its B leaves the host rather than stepping back to a menu. See
-## [method open_bills_pc].
+## Whether storage was opened without the machine around it, so its B leaves the
+## host rather than stepping back to a menu. See [method open_bills_pc].
 var _bills_pc_only: bool = false
+## `.UseBillsPC`'s `push af`/`pop bc` around a row's routine.
+var _bills_pc_cursor: int = 0
 ## Whether the menu on screen is the host's own question rather than a script's.
 ## See [method open_prompt].
 var _host_prompt: bool = false
@@ -480,10 +491,9 @@ func _build_ui() -> void:
 
 
 ## A YES/NO the HOST asks rather than one a script staged: the same
-## `Script_yesorno` box in the same place, answered back to whoever opened this
-## instead of into the script runner. [method completed] carries one
-## `{kind: &"host_choice", choice}` row, choice 0 for YES and 1 for NO, and -1
-## when it was cancelled.
+## `Script_yesorno` box in the same place, answered back to whoever opened this.
+## [method completed] carries one `{kind: &"host_choice", choice}` row, choice 0
+## for YES and 1 for NO, and -1 when it was cancelled.
 func open_prompt(
 	world: Gen2WorldAPI,
 	data: GameData,
@@ -1217,8 +1227,7 @@ func _finish_apricorns() -> void:
 
 ## `Mom_SetUpDepositMenu` and `Mom_SetUpWithdrawMenu` over
 ## `Mom_WithdrawDepositMenuJoypad`. The model owns the amount and the cursor;
-## this owns the box and the blink. `Mom_Wait10Frames` is not held: the world
-## screen already spends the press that opened the box.
+## this owns the box and the blink. `Mom_Wait10Frames` is not held.
 func _open_mom_bank(values: Dictionary) -> void:
 	_mode = MODE.MOM_BANK
 	_mom_dial = Gen2WorldMoneyDial.open(
@@ -1313,9 +1322,8 @@ func open_mom_bank(
 	return true
 
 
-## BILL'S PC on its own, without the machine's top menu in front of it: the
-## opening a registered start-menu action asks for. `PC_CheckPartyForPokemon` is
-## the same refusal the machine has, applied here rather than trusted.
+## BILL'S PC on its own, the opening a registered start-menu action asks for.
+## `PC_CheckPartyForPokemon` is applied here rather than trusted.
 func open_bills_pc(
 	world: Gen2WorldAPI,
 	data: GameData,
@@ -1333,12 +1341,13 @@ func open_bills_pc(
 		_show_error("Storage needs a party.")
 		return false
 	_bills_pc_only = true
+	_bills_pc_cursor = 0
 	_open_bills_pc_menu()
 	return true
 
 
-## `special PokemonCenterPC` and `special PlayersHousePC` without a script in
-## front of them, for the screenshot drivers: no preview map carries either cell.
+## `special PokemonCenterPC` and `special PlayersHousePC` with no script in front
+## of them, for the screenshot drivers: no preview map carries either cell.
 func open_pc_machine(
 	world: Gen2WorldAPI,
 	data: GameData,
@@ -1353,9 +1362,14 @@ func open_pc_machine(
 	if _world == null or _data == null:
 		_show_error("The PC has no world or cartridge cache.")
 		return false
-	if not Gen2WorldPC.can_open(_save):
-		_show_error("The PC needs a party.")
-		return false
+	## `PC_CheckPartyForPokemon`, which answers with its own sound and shuts down
+	## again. `_PlayersHousePC` never asks it: the bedroom's PC is items and mail.
+	if mode != &"players_house" and not Gen2WorldPC.can_open(_save):
+		sfx_requested.emit(SFX_CHOOSE_PC_OPTION, false)
+		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
+		return true
+	## `PC_PlayBootSound`, once per machine rather than per return to its menu.
+	sfx_requested.emit(SFX_BOOT_PC, true)
 	_open_pc(mode)
 	return true
 
@@ -1375,7 +1389,6 @@ func _leave_bills_pc() -> void:
 func _open_pc(mode: StringName) -> void:
 	_pc_house = mode == &"players_house"
 	if not _pc_house and not Gen2WorldPC.can_open(_save):
-		## `.PokecenterPCCantUseText`: the machine answers and shuts down again.
 		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
 		return
 	if _pc_house:
@@ -1420,9 +1433,8 @@ func _open_pc_item_list(action: int) -> void:
 	_refresh_pc_entries()
 	if _pc_entries.is_empty():
 		## `.CheckItemsInBag`'s `.PlayersPCNoItemsText`, which the source prints
-		## for a deposit. The other two open an empty scrolling menu there, which
-		## can only be cancelled, so they are refused with the same box rather
-		## than drawn empty.
+		## for a deposit. The other two would open a list that can only be
+		## cancelled, so they take the same box rather than being drawn empty.
 		_status = _data.pokecenter_pc_text("no_items")
 		_render_rows()
 		return
@@ -1465,6 +1477,7 @@ func _confirm_pc_row() -> void:
 		MODE.PC_MAILBOX: _open_mail_submenu,
 		MODE.PC_MAIL_SUBMENU: _confirm_mail_submenu,
 		MODE.PC_MAIL_CONFIRM: _confirm_mail_row,
+		MODE.PC_OAK_ASK: _confirm_oak_ask,
 		MODE.PC: _confirm_pc_menu_row,
 	}
 	var handler: Callable = handlers.get(_mode, _confirm_player_pc_row)
@@ -1476,6 +1489,7 @@ func _confirm_box_list_row(row: int) -> void:
 
 
 func _confirm_bills_pc_row(row: int) -> void:
+	_bills_pc_cursor = _cursor
 	match row:
 		Gen2WorldPC.BILLSPCITEM_WITHDRAW:
 			_open_boxes(Gen2BoxScreen.MODE_WITHDRAW)
@@ -1525,8 +1539,13 @@ func _confirm_mail_row(row: int) -> void:
 
 
 func _confirm_pc_menu_row(row: int) -> void:
+	## `PC_PlayChoosePCSound`, which every row but TURN OFF opens on.
+	if row != Gen2WorldPC.PCPCITEM_TURN_OFF:
+		sfx_requested.emit(SFX_CHOOSE_PC_OPTION, true)
 	match row:
 		Gen2WorldPC.PCPCITEM_BILLS_PC:
+			## `BillsPC` reaches `_BillsPC` afresh, on its own first row.
+			_bills_pc_cursor = 0
 			_open_bills_pc_menu()
 		Gen2WorldPC.PCPCITEM_PLAYERS_PC:
 			_open_pc_items()
@@ -1546,6 +1565,8 @@ func _confirm_player_pc_row(row: int) -> void:
 		Gen2WorldPC.PLAYERSPCITEM_TOSS_ITEM:
 			_open_pc_item_list(row)
 		Gen2WorldPC.PLAYERSPCITEM_MAIL_BOX:
+			## `MailboxPC` writes `wCurMessageIndex` on the way in.
+			_mail_index = 0
 			_open_mailbox()
 		Gen2WorldPC.PLAYERSPCITEM_DECORATION:
 			_open_decorations()
@@ -1618,12 +1639,31 @@ func _change_pc_quantity(step: int) -> void:
 ## returns to the loop. A cache with no rating table has nothing to print, which
 ## is what an empty boot says.
 func _open_pc_oak() -> void:
-	var boot: Dictionary = Gen2ProfOaksPC.boot(_data, _world.state)
-	if boot.is_empty():
+	if Gen2ProfOaksPC.boot(_data, _world.state).is_empty():
 		_status = "PROF.OAK'S PC needs a cache that carries its ratings."
 		return
+	_mode = MODE.PC_OAK_ASK
+	_cursor = 0
+	_pc_rows = [{"row": 0, "name": "YES"}, {"row": 1, "name": "NO"}]
+	_title = OAK_PC
+	_summary = _data.oak_pc_text("ask")
+	_status = ""
+	_render_rows()
+
+
+## `ProfOaksPCBoot` behind the YES. A NO is the same `.shutdown` B reaches.
+func _confirm_oak_ask(row: int) -> void:
+	if row != 0:
+		_open_oak_closed()
+		return
+	var boot: Dictionary = Gen2ProfOaksPC.boot(_data, _world.state)
 	_pc_sfx = int(boot["sfx"])
-	_open_pc_text(boot["pages"], &"top", "PROF.OAK'S PC")
+	_open_pc_text(boot["pages"], &"oak_closed", OAK_PC)
+
+
+## `.shutdown`'s `_OakPCText4`, which both answers pass through.
+func _open_oak_closed() -> void:
+	_open_pc_text([_data.oak_pc_text("closed")], &"top", OAK_PC)
 
 
 ## `_PlayerDecorationMenu`'s top menu: only a category the player owns something
@@ -1841,6 +1881,9 @@ func _advance_pc_text() -> void:
 	if _pc_after == &"bills_pc":
 		_open_bills_pc_menu()
 		return
+	if _pc_after == &"oak_closed":
+		_open_oak_closed()
+		return
 	_open_pc(&"pokemon_center")
 
 
@@ -1854,7 +1897,7 @@ func _open_bills_pc_menu() -> void:
 		_open_pc_text([Gen2WorldPC.BILLS_PC_NEEDS_POKEMON], &"top", "BILL's PC")
 		return
 	_mode = MODE.PC_BOXES
-	_cursor = 0
+	_cursor = _bills_pc_cursor
 	_box_index = clampi(
 		_save.current_box if _save != null else 0, 0, Gen2SaveData.BOX_COUNT - 1
 	)
@@ -1870,8 +1913,10 @@ func _open_bills_pc_menu() -> void:
 ## Choosing one opens `BillsPC_ChangeBoxSubmenu`.
 func _open_box_list() -> void:
 	_mode = MODE.PC_BOX_LIST
-	_cursor = _box_index
-	_pc_scroll = clampi(_box_index - BOX_LIST_ROWS + 1, 0, Gen2SaveData.BOX_COUNT - BOX_LIST_ROWS)
+	## `.loop` copies the header and zeroes `wMenuScrollPosition` every time
+	## round, so the picker opens on the first box rather than on `wCurBox`.
+	_cursor = 0
+	_pc_scroll = 0
 	_pc_rows = []
 	for index: int in Gen2SaveData.BOX_COUNT:
 		_pc_rows.append({
@@ -1980,9 +2025,8 @@ func _refresh_box_counts() -> void:
 
 
 ## BILL'S PC's own two lists. The panel steps aside for the box screen the way it
-## does for the region map, so the menu is still there when the boxes close.
-## `_PlayerMailBoxMenu`: `InitMail` answers zero when `sMailboxCount` is, and
-## the routine prints `.EmptyMailboxText` instead of opening the list.
+## does for the region map. `_PlayerMailBoxMenu`: `InitMail` answers zero when
+## `sMailboxCount` is, and prints `.EmptyMailboxText` instead of a list.
 func _open_mailbox() -> void:
 	_pc_rows = Gen2WorldPC.mailbox_entries(_save)
 	if _pc_rows.is_empty():
@@ -1993,7 +2037,7 @@ func _open_mailbox() -> void:
 		return
 	_mode = MODE.PC_MAILBOX
 	## `MailboxPC` keeps `wCurMessageIndex` across the submenu, so the list
-	## reopens on the message that was just acted on rather than at the top.
+	## reopens on the message just acted on.
 	_cursor = clampi(_mail_index, 0, _pc_rows.size() - 1)
 	_title = _data.pokecenter_pc_row("mail_box", true)
 	_summary = ""
@@ -2081,8 +2125,10 @@ func _open_mail_attach() -> void:
 	host.mouse_filter = Control.MOUSE_FILTER_STOP
 	host.z_index = 5
 	host.set_screen(_service_hardware)
-	add_child(host)
+	## Before the tree: a screen told it is embedded afterwards has already put
+	## up the focus ring that swallows the arrows this screen routes.
 	host.set_context(_data, _save, true)
+	add_child(host)
 	host.selection_made.connect(_on_mail_attach_selected)
 	host.open_selection()
 
@@ -2126,8 +2172,8 @@ func _open_boxes(mode: int) -> void:
 	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
 	host.z_index = 5
 	host.set_screen(_service_hardware)
-	add_child(host)
 	host.set_context(_data, _save, _persist, true, mode, _box_index)
+	add_child(host)
 	host.cry_requested.connect(_on_boxes_cry)
 	host.sfx_requested.connect(sfx_requested.emit)
 	host.closed.connect(_on_boxes_closed)
@@ -2298,9 +2344,8 @@ func _on_card_switched(direction: int) -> void:
 
 ## `wPokegearRadioMusicPlaying`, for the host that owns the driver:
 ## `ExitPokegearRadio_HandleMusic` restarts the map's music only when the radio
-## card has played something over it, and every other service leaves it alone.
-## The restart lands when this overlay closes rather than when the card does,
-## since the overlay is what the world is waiting on rather than the card.
+## card has played something over it. The restart lands when this overlay closes
+## rather than when the card does: the overlay is what the world waits on.
 func radio_music_playing() -> int:
 	return _radio_music
 
@@ -2455,7 +2500,8 @@ func _move_cursor(delta: int) -> void:
 	var count: int = _option_count()
 	if count <= 0:
 		return
-	_cursor = wrapi(_cursor + delta, 0, count)
+	_cursor = clampi(_cursor + delta, 0, count - 1) if NO_WRAP_MODES.has(_mode) \
+		else wrapi(_cursor + delta, 0, count)
 	if _mode == MODE.PC_ITEM_LIST:
 		_pc_quantity = 1
 	## `ScrollingMenu` keeps the cursor inside its own window and moves the
@@ -2505,7 +2551,7 @@ func _confirm() -> void:
 	if _mode in [
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
 		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
-		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM,
+		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK,
 	]:
 		_confirm_pc_row()
 		return
@@ -2545,6 +2591,7 @@ const CANCEL_HANDLERS: Dictionary = {
 	MODE.PC_MAILBOX: &"_open_pc_items",
 	MODE.PC_MAIL_SUBMENU: &"_open_mailbox",
 	MODE.PC_MAIL_CONFIRM: &"_refuse_mail_to_pack",
+	MODE.PC_OAK_ASK: &"_open_oak_closed",
 	MODE.PC_DECO: &"_leave_decorations",
 	MODE.PC_DECO_LIST: &"_open_decorations",
 	MODE.PC_DECO_SIDE: &"_cancel_deco_side",
@@ -2562,11 +2609,13 @@ func _cancel() -> void:
 
 
 func _shut_down_pc() -> void:
+	sfx_requested.emit(SFX_SHUT_DOWN_PC, true)
 	_finish_runtime({"ok": true, "script_value": 0})
 
 
 func _cancel_pc_items() -> void:
 	if _pc_house:
+		sfx_requested.emit(SFX_SHUT_DOWN_PC, true)
 		_finish_runtime({"ok": true, "script_value": 0})
 	else:
 		_open_pc(&"pokemon_center")
@@ -2812,8 +2861,8 @@ func _service_box() -> Gen2MenuBox:
 		MODE.PC_MAIL_SUBMENU:
 			## `.SubMenuHeader`'s `menu_coords 0, 0, 13, 9`.
 			return Gen2MenuBox.from_coords(0, 0, 13, 9, Gen2MenuBox.STATICMENU_CURSOR)
-		MODE.PC_MAIL_CONFIRM:
-			## `YesNoBox`'s own box, which `.PutInPack` opens over its question.
+		MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK:
+			## `YesNoBox`, which `.PutInPack` and `ProfOaksPC` open over theirs.
 			return Gen2MenuBox.yes_no()
 		MODE.PC_SAVE:
 			## The same `YesNoBox`, and nothing at all on the timed steps: they
@@ -2919,6 +2968,7 @@ func _option_count() -> int:
 		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
 		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
 		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_SAVE,
+		MODE.PC_OAK_ASK,
 	]:
 		return _pc_rows.size()
 	if _mode == MODE.PC_ITEM_LIST:

--- a/tests/integration/test_launcher_focus.gd
+++ b/tests/integration/test_launcher_focus.gd
@@ -281,6 +281,24 @@ func test_nothing_focusable_is_not_an_error() -> void:
 	assert_null(Gen2FocusGuard.first_focusable(root))
 
 
+## A guard with nothing to focus has to let the arrow past. Reporting the ring
+## someone else was holding as its own left every direction press claimed, and
+## the screen routing its own buttons behind the guard never saw one.
+func test_a_guard_with_nothing_to_focus_does_not_claim_a_direction() -> void:
+	var elsewhere := Button.new()
+	add_child_autofree(elsewhere)
+	var root := Control.new()
+	add_child_autofree(root)
+	root.add_child(Label.new())
+	var guard: Gen2FocusGuard = Gen2FocusGuard.attach(root)
+	elsewhere.grab_focus()
+	await get_tree().process_frame
+
+	assert_same(_focus_owner(), elsewhere)
+	assert_false(guard.move_focus(Vector2.DOWN))
+	assert_same(_focus_owner(), elsewhere, "and it is left where it was")
+
+
 ## A modal is where a pad has to be, and where it was has to come back, or
 ## closing a sheet would strand the player with nothing selected.
 func test_a_sheet_takes_the_ring_and_gives_it_back() -> void:

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -192,8 +192,13 @@ func test_change_box_switches_names_and_prints_a_box() -> void:
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOX_LIST)
 	assert_eq(host._box_index, 1)
 	assert_eq(host._save.current_box, 1)
+	## `.loop` copies the header again, so the list comes back on its first row
+	## rather than on the box that was just switched to.
+	assert_eq(host._cursor, 0)
+	assert_eq(host._pc_scroll, 0)
 
 	## PRINT over an empty box is `.EmptyBox` rather than a send.
+	host.handle_button(Gen2Button.DOWN)
 	host.handle_button(Gen2Button.A)
 	for _step: int in 2:
 		host.handle_button(Gen2Button.DOWN)
@@ -314,10 +319,10 @@ func test_move_without_mail_refuses_a_party_holding_mail_and_saves_otherwise() -
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
 
 	## Without the mail the row asks its own question, and a NO is `.refused`'s
-	## carry: back to the machine's menu with no listing opened.
+	## carry: back to the machine's menu with no listing opened. `.UseBillsPC`
+	## puts that menu back on the row it left, so MOVE is under the cursor still.
 	(host._save.party[0] as Gen2SaveMon).item = 0
-	for _step: int in 3:
-		host.handle_button(Gen2Button.DOWN)
+	assert_eq(host._cursor, Gen2WorldPC.BILLSPCITEM_MOVE_WITHOUT_MAIL)
 	host.handle_button(Gen2Button.A)
 	assert_eq(host._save_prompt.lines, Gen2SavePrompt.MOVE_MON_LINES)
 	host.handle_button(Gen2Button.A)
@@ -326,6 +331,101 @@ func test_move_without_mail_refuses_a_party_holding_mail_and_saves_otherwise() -
 	assert_null(host._save_prompt)
 	assert_null(host._boxes)
 	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_BOXES)
+
+
+## `PC_PlayBootSound`, `PC_PlayChoosePCSound` and `PC_PlayShutdownSound`, the
+## three the machine spends on its own: one on the way in, one on every row but
+## TURN OFF, and one on `.shutdown`.
+func test_the_machine_boots_chooses_and_shuts_down_with_its_own_sounds() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	watch_signals(host)
+	assert_true(host.open_pc_machine(
+		host._world, _data, host._save, false, &"pokemon_center"
+	))
+	assert_signal_emitted_with_parameters(
+		host, "sfx_requested", [Gen2WorldServiceScreen.SFX_BOOT_PC, true]
+	)
+	host.handle_button(Gen2Button.A)
+	assert_signal_emitted_with_parameters(
+		host, "sfx_requested", [Gen2WorldServiceScreen.SFX_CHOOSE_PC_OPTION, true]
+	)
+
+	## `.loop` is behind the boot sound, so coming back to it plays nothing.
+	host.handle_button(Gen2Button.B)
+	assert_signal_emit_count(host, "sfx_requested", 2)
+	host.handle_button(Gen2Button.B)
+	assert_signal_emitted_with_parameters(
+		host, "sfx_requested", [Gen2WorldServiceScreen.SFX_SHUT_DOWN_PC, true]
+	)
+	await get_tree().process_frame
+	assert_null(_world_screen._service_host)
+
+
+## `ProfOaksPC`: `_OakPCText1`'s question first, `ProfOaksPCBoot` behind a YES,
+## and `_OakPCText4` on the way out whichever way it was answered. The row used
+## to open on the rating with neither box around it.
+func test_the_oak_pc_row_asks_first_and_closes_with_its_own_line() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	host._world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+	host._open_pc(&"pokemon_center")
+	var rows: Array = []
+	for row: Dictionary in host._pc_rows:
+		rows.append(int(row["row"]))
+	host._cursor = rows.find(Gen2WorldPC.PCPCITEM_OAKS_PC)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_OAK_ASK)
+	assert_eq(host._summary, _data.oak_pc_text("ask"))
+
+	## NO is `.shutdown`: the closing line and nothing rated.
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC_TEXT)
+	assert_eq(host._summary, _data.oak_pc_text("closed"))
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
+
+	## YES rates first, and the same line is still the last box.
+	host._cursor = rows.find(Gen2WorldPC.PCPCITEM_OAKS_PC)
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.A)
+	var boot: Dictionary = Gen2ProfOaksPC.boot(_data, host._world.state)
+	assert_eq(host._summary, String((boot["pages"] as Array)[0]))
+	for _page: int in (boot["pages"] as Array).size():
+		host.handle_button(Gen2Button.A)
+	assert_eq(host._summary, _data.oak_pc_text("closed"))
+	host.handle_button(Gen2Button.A)
+	assert_eq(host._mode, Gen2WorldServiceScreen.MODE.PC)
+
+
+## The reported defect. The box screen owns the whole screen while BILL'S PC is
+## open and the world routes its buttons, so a focus ring put up before
+## `set_context` said it was embedded claimed every direction on the way in and
+## the listing never left its first row.
+func test_the_deposit_list_walks_on_real_presses_with_focus_held_elsewhere() -> void:
+	await _open_pokemon_center_pc()
+	var host: Gen2WorldServiceScreen = _world_screen._service_host
+	host.handle_button(Gen2Button.A)
+	host.handle_button(Gen2Button.DOWN)
+	host.handle_button(Gen2Button.A)
+	var boxes: Gen2BoxScreen = host._boxes
+	assert_not_null(boxes)
+	assert_null(boxes.get_node_or_null(^"FocusGuard"), "the world routes these buttons")
+
+	var elsewhere := Button.new()
+	add_child_autofree(elsewhere)
+	elsewhere.grab_focus()
+	await get_tree().process_frame
+	for step: int in 2:
+		var press := InputEventAction.new()
+		press.action = Gen2Button.action(Gen2Button.DOWN)
+		press.pressed = true
+		get_tree().root.push_input(press)
+		await get_tree().process_frame
+		assert_eq(int(boxes.box_snapshot()["cursor"]), step + 1)
+	boxes.close_embedded()
+	await get_tree().process_frame
 
 
 ## `special PokemonCenterPC` from a coord event, which is how every test above

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -900,3 +900,95 @@ func test_an_egg_is_offered_stats_and_switch_and_no_move_row() -> void:
 	## `EggStatsJoypad` answers A with `.quit` rather than with a page.
 	screen.handle_button(Gen2Button.A)
 	assert_signal_emitted(screen, "closed")
+
+
+## `BillsPCDepositFuncDeposit` ends with `xor a` into both cursor bytes, and
+## `DepositPokemon` plays the stored Pokemon's cry on the way.
+func test_a_deposit_puts_the_cursor_back_on_the_first_row_and_plays_a_cry() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	var third: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.GEODUDE, 12, [Fixture.GROWL]
+	)
+	save.party.append(Gen2SaveBattleAdapter.from_battle_mon(third))
+	await _open_box_screen(save)
+	watch_signals(_box_screen)
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.DOWN)
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+
+	assert_eq(save.party.size(), 2)
+	assert_signal_emitted_with_parameters(_box_screen, "cry_requested", [Fixture.GEODUDE])
+	var snapshot: Dictionary = _box_screen.box_snapshot()
+	assert_eq(int(snapshot["cursor"]), 0)
+	assert_eq(int(snapshot["scroll"]), 0)
+	assert_eq(snapshot["submenu"], [], "the submenu went with the row")
+
+
+## `.box_full` prints and returns to `.Submenu`, which is still on screen; only
+## `BillsPC_CheckMail_PreventBlackout` takes `BillsPCDepositFuncCancel` back to
+## the list. Neither menu carries `STATICMENU_WRAP`.
+func test_a_full_box_refuses_under_the_submenu_which_does_not_wrap() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	for slot: int in Gen2SaveBox.CAPACITY:
+		save.boxes[0].slots[slot] = Gen2SaveBattleAdapter.from_battle_mon(
+			Gen2BattleMon.create(_data, Fixture.GEODUDE, 5, [Fixture.GROWL])
+		)
+	await _open_box_screen(save)
+	watch_signals(_box_screen)
+	_box_screen.handle_button(Gen2Button.A)
+	## Four rows, and up on the first stays on it.
+	_box_screen.handle_button(Gen2Button.UP)
+	assert_eq(int(_box_screen.box_snapshot()["submenu_cursor"]), 0)
+	for _press: int in 6:
+		_box_screen.handle_button(Gen2Button.DOWN)
+	assert_eq(int(_box_screen.box_snapshot()["submenu_cursor"]), 3)
+
+	for _press: int in 3:
+		_box_screen.handle_button(Gen2Button.UP)
+	_box_screen.handle_button(Gen2Button.A)
+	assert_eq(save.party.size(), 2, "nothing left the party")
+	var snapshot: Dictionary = _box_screen.box_snapshot()
+	assert_eq(String(snapshot["prompt"]), Gen2BoxScreen.PROMPT_BOX_FULL)
+	assert_eq(snapshot["submenu"], Gen2BoxScreen.SUBMENU_ROWS)
+	assert_signal_emitted_with_parameters(
+		_box_screen, "sfx_requested", [Gen2BoxScreen.SFX_WRONG, true]
+	)
+
+
+## `.a_button_2` reaches `.Init` without restoring the backup `.b_button_2` puts
+## back, so the first pass resumes on the list the Pokemon was moved into.
+func test_a_finished_move_stays_on_the_list_it_moved_into() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	await _open_box_screen(save, Gen2BoxScreen.MODE_MOVE)
+	_box_screen.handle_button(Gen2Button.LEFT)
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), Gen2BoxScreen.LOADED_PARTY)
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.A)
+	_box_screen.handle_button(Gen2Button.RIGHT)
+	_box_screen.handle_button(Gen2Button.A)
+	_spend_insert_frames()
+
+	assert_eq(save.party.size(), 1)
+	assert_eq(int(_box_screen.box_snapshot()["loaded"]), 1, "the box it went into")
+	assert_eq(String(_box_screen.box_snapshot()["prompt"]), Gen2BoxScreen.PROMPT_CHOOSE)
+
+
+## `.CheckTrivialMove`: the row the insert cursor points at has already shifted
+## up by the one that left, so a move down the same list lands in front of it.
+func test_a_move_down_one_list_lands_in_front_of_the_row_it_points_at() -> void:
+	var save: Gen2SaveData = _save_with_two()
+	for nickname: String in ["THIRD", "FOURTH"]:
+		var extra: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(
+			Gen2BattleMon.create(_data, Fixture.GEODUDE, 12, [Fixture.GROWL])
+		)
+		extra.nickname = nickname
+		save.party.append(extra)
+	var moved: Dictionary = Gen2SaveStorage.move_mon(
+		save, _data, Gen2BoxScreen.LOADED_PARTY, 0, Gen2BoxScreen.LOADED_PARTY, 2, false
+	)
+	assert_true(moved["ok"], String(moved.get("reason", "")))
+	var order: Array[String] = []
+	for mon: Gen2SaveMon in save.party:
+		order.append(mon.nickname)
+	assert_eq(order, ["", "SPARKY", "THIRD", "FOURTH"], "GEODUDE carries no nickname")

--- a/tools/checks/pc.gd
+++ b/tools/checks/pc.gd
@@ -5,11 +5,10 @@ var _r: RefCounted = null
 ## Verifies Bill's PC's own graphics and its screen against freshly imported real
 ## caches, over every species rather than a sampled one. Expected values come from
 ## `engine/pokemon/bills_pc.asm`: `BillsPC_InitGFX`'s two runs, `_CGB_BillsPC`'s
-## palettes, `BillsPC_RefreshTextboxes`' listing and `PCMonInfo`'s left column. The
-## sweep is over species because that column is the one thing on the screen whose
-## width is not fixed: a pic wider than its seven-tile cell, or a name wider than
-## the two boxes `ClearBox` leaves for it, would overrun the listing, and no
-## one-species screenshot says so.
+## palettes, `BillsPC_UpdateSelectionCursor`'s ring and `PCMonInfo`'s left column.
+## The sweep is over species because that column is the one thing whose width is
+## not fixed: a pic wider than its seven-tile cell, or a name wider than the two
+## boxes `ClearBox` leaves for it, would overrun the listing.
 
 ## `BillsPCOrangePalette`, `gfx/pc/orange.pal`, which is the same four colours in
 ## all three dumps.
@@ -17,11 +16,29 @@ const ORANGE: Array[int] = [0x01FF, 0x0197, 0x00EF, 0x0000]
 const SPECIES_COUNT: int = 251
 ## What `PCMonInfo` clears for the pic, the name and the level: eight columns
 ## (`hlcoord 0, 0 / lb bc, 15, 8`) plus the three past them on the name's own row
-## (`hlcoord 8, 14 / lb bc, 1, 3`). The second clear is there for exactly one
-## reason: the longest species name is ten tiles printed from column 1.
+## (`hlcoord 8, 14 / lb bc, 1, 3`), which the ten-tile species names need.
 const INFO_COLUMNS: int = 8
 const NAME_OVERHANG: Vector2i = Vector2i(8, 14)
 const NAME_OVERHANG_COLUMNS: int = 3
+
+## `BillsPC_UpdateSelectionCursor`'s `.OAM`, transcribed from the two
+## disassemblies rather than read back out of the page: repeated `dbsprite` rows
+## folded into `[first x tile, count, y tile, x pixel, y pixel, tile, x, y flip]`.
+## The macro lays down `y tile * 8 + y pixel` and `x tile * 8 + x pixel`.
+const CRYSTAL_OAM: Array = [
+	[10, 9, 4, 0, 6, 0, false, false], [18, 1, 4, 7, 6, 0, false, false],
+	[10, 9, 7, 0, 1, 0, false, true], [18, 1, 7, 7, 1, 0, false, true],
+	[9, 1, 5, 6, 6, 1, false, false], [9, 1, 6, 6, 1, 1, false, true],
+	[19, 1, 5, 1, 6, 1, true, false], [19, 1, 6, 1, 1, 1, true, true],
+]
+const GOLD_OAM: Array = [
+	[9, 1, 5, 7, 1, 0, false, false], [10, 8, 5, 7, 1, 1, false, false],
+	[18, 1, 5, 7, 1, 2, false, false],
+	[9, 1, 6, 7, 1, 3, false, false], [10, 8, 6, 7, 1, 4, false, false],
+	[18, 1, 6, 7, 1, 5, false, false],
+]
+const OAM_X_BIAS: int = 8
+const OAM_Y_BIAS: int = 16
 
 
 func run(r: RefCounted) -> void:
@@ -67,28 +84,37 @@ func _verify_graphics(game_id: StringName, data: GameData) -> void:
 		)
 
 
-## `BillsPC_UpdateSelectionCursor`'s OAM for each of the five rows it can stand
-## on: every object inside the listing box and stepping sixteen pixels a row,
-## which is what says the shadow-OAM bias was taken off once rather than twice.
+## `.OAM` object by object against the disassembly's own operands, and the
+## sixteen pixels a row it steps by, which says the shadow-OAM bias came off once
+## rather than twice. A bottom bar that drifts off its own sides is what this
+## pins: bounds alone still read it as an object inside the listing.
 func _verify_cursor(game_id: StringName, page: Gen2PCBoxPage) -> void:
 	if not _r.check(page != null, "%s: the PC page needs a font." % game_id):
 		return
-	var box: Rect2i = Gen2PCBoxPage.LIST_BOX
-	var left: int = box.position.x * Gen2Font.TILE
-	var right: int = (box.position.x + box.size.x) * Gen2Font.TILE
+	var wanted: Array = _expected_oam(
+		CRYSTAL_OAM if game_id == RomRegistry.CRYSTAL else GOLD_OAM
+	)
+	var drawn: Array = page.cursor_set()
+	if not _r.check(
+		drawn.size() == wanted.size(),
+		"%s: the ring draws %d objects, not the %d `.OAM` lays down." % [
+			game_id, drawn.size(), wanted.size(),
+		]
+	):
+		return
+	for index: int in wanted.size():
+		_r.check(
+			Array(drawn[index]) == Array(wanted[index]),
+			"%s: ring object %d is %s, not `dbsprite`'s %s." % [
+				game_id, index, drawn[index], wanted[index],
+			]
+		)
 	var first: Array = page.cursor_sprites(0, 1)
 	for cursor: int in Gen2PCBoxPage.LIST_HEIGHT:
 		var sprites: Array = page.cursor_sprites(cursor, 1)
-		if not _r.check(
-			sprites.size() == page.cursor_set().size(),
-			"%s: cursor %d draws %d objects, not %d." % [
-				game_id, cursor, sprites.size(), page.cursor_set().size(),
-			]
-		):
-			return
 		for index: int in sprites.size():
-			var at: Vector2i = sprites[index]["position"]
-			var step: int = at.y - Vector2i(first[index]["position"]).y
+			var step: int = Vector2i(sprites[index]["position"]).y \
+				- Vector2i(first[index]["position"]).y
 			_r.check(
 				step == cursor * Gen2PCBoxPage.CURSOR_STEP,
 				"%s: cursor %d object %d sits %d pixels down, not %d." % [
@@ -96,17 +122,23 @@ func _verify_cursor(game_id: StringName, page: Gen2PCBoxPage) -> void:
 					cursor * Gen2PCBoxPage.CURSOR_STEP,
 				]
 			)
-			_r.check(
-				at.x >= left - Gen2Font.TILE and at.x < right \
-					and at.y >= 0 and at.y < Gen2Screen.HEIGHT,
-				"%s: cursor %d object %d is at %s, outside the listing." % [
-					game_id, cursor, index, at,
-				]
-			)
 	_r.check(
 		page.cursor_sprites(0, 0).is_empty(),
 		"%s: a list with nothing in it still draws a cursor." % game_id
 	)
+
+
+## One run list as the page's own `[x, y, tile, flips]` rows.
+func _expected_oam(runs: Array) -> Array:
+	var out: Array = []
+	for row: Array in runs:
+		for step: int in int(row[1]):
+			out.append([
+				(int(row[0]) + step) * Gen2Font.TILE + int(row[3]) - OAM_X_BIAS,
+				int(row[2]) * Gen2Font.TILE + int(row[4]) - OAM_Y_BIAS,
+				int(row[5]), bool(row[6]), bool(row[7]),
+			])
+	return out
 
 
 ## `PCMonInfo`'s column over the whole species run: the pic fits the seven-tile

--- a/tools/preview_saves.gd
+++ b/tools/preview_saves.gd
@@ -2,12 +2,12 @@ extends SceneTree
 
 ## Photographs a window-resolution save-section screen for a cached cartridge.
 ##
-##   Godot --path . -s res://tools/preview_saves.gd -- <out.png> [light|dark] [WxH] [page]
+##   Godot --path . -s res://tools/preview_saves.gd -- <out.png> [light|dark] [WxH] [page] [game]
 ##
-## [page] is `saves`, `new`, `party`, `boxes` or `editor`. They are one command
-## because they are one section and share this harness. The size is what says
-## whether a page is responsive, so it is an argument rather than a constant: a
-## phone portrait and a desktop window are the same command twice.
+## [page] is `saves`, `new`, `party`, `boxes`, `boxes_move` or `editor`; [game]
+## picks a cartridge rather than the first cached one. The size is an argument
+## rather than a constant: a phone portrait and a desktop window are one command
+## twice, and it is what says whether a page is responsive.
 
 var _output: String = ""
 var _frames: int = 0
@@ -36,7 +36,10 @@ func _initialize() -> void:
 	# path does not resolve from outside the running scene, so the runtime is
 	# found on the root by name.
 	var runtime: Node = root.get_node_or_null(NodePath("GameRuntime"))
+	var wanted: StringName = StringName(args[4]) if args.size() > 4 else &""
 	for game_id: StringName in RomRegistry.ORDER:
+		if not wanted.is_empty() and game_id != wanted:
+			continue
 		var data: GameData = GameData.open(game_id)
 		if data != null:
 			runtime.call("select_game", game_id)
@@ -52,6 +55,7 @@ func _initialize() -> void:
 		"new": "res://game/save/save_screen.tscn",
 		"party": "res://game/save/party_screen.tscn",
 		"boxes": "res://game/save/box_screen.tscn",
+		"boxes_move": "res://game/save/box_screen.tscn",
 		"editor": "res://game/save/save_editor_screen.tscn",
 	}
 	if not scenes.has(page):
@@ -59,6 +63,12 @@ func _initialize() -> void:
 		quit(2)
 		return
 	_screen = load(String(scenes[page])).instantiate()
+	if page == "boxes_move":
+		_screen.set_context(
+			Gen2GameRuntime.data_or_any(),
+			Gen2GameRuntime.selected_save_or_null(), false, false,
+			Gen2BoxScreen.MODE_MOVE
+		)
 	root.add_child(_screen)
 	## `_ready` runs on the first frame rather than on `add_child` from here, so
 	## the form is opened once the pane it lives in exists, which is the order a


### PR DESCRIPTION
A player reported that withdrawing and depositing at a PC would not move past the first Pokemon in the list, from the Pokemon Center machine and from the start-menu action alike.

The box screen learns it is embedded from its caller. The Pokemon Center told it after putting it in the tree rather than before, so the screen still believed it was the launcher page and put up a focus ring for a keyboard. The guard behind that ring reported any focus anywhere on the page as its own, and so claimed every direction press before the screen that routes those buttons saw one. Two fixes, either of which closes it: the guard now claims only a direction it actually used, and the two callers that were the wrong way round have been turned around. `tests/integration/test_world_service_screen.gd` drives real presses with focus held elsewhere, and goes red on either regression.

Reading the rest of the machine against `engine/pokemon/bills_pc.asm` and `engine/events/pokecenter_pc.asm` paid for more than the report:

| Now | Source |
|---|---|
| A transfer or a release puts the cursor back on the first row | `BillsPCDepositFuncDeposit`, `.withdraw` and both `.release`s end with `xor a` into both cursor bytes |
| A transfer or a release plays the cry | `DepositPokemon`, `TryWithdrawPokemon`, `ReleasePKMN_ByePKMN` |
| A full box, a full party and an egg print under the submenu, which stays up | `.box_full`, `.FailedWithdraw`, `.FailedRelease` return into `.Submenu` |
| The three blackout refusals close it | `BillsPCDepositFuncCancel` |
| Every refusal sounds | `WaitPlaySFX SFX_WRONG` |
| A finished move stays on the list it moved into | `.a_button_2` never touches the backup `.b_button_2` restores |
| A move down one list lands in front of the row it points at | `.CheckTrivialMove` |
| MOVE PKMN W/O MAIL draws its two arrows | `BillsPC_MoveMonWOMail_BoxNameAndArrows` |
| The stats page opened from the PC walks the list | `_StatsScreenDPad` |
| The submenus and the yes/no stop at their ends | no `STATICMENU_WRAP` on either |
| The box picker opens on its first box | `_ChangeBox.loop` copies the header again |
| The machine's own menu comes back on the row that opened a list | `.UseBillsPC`'s `push af`/`pop bc` |
| PROF.OAK'S PC asks before it rates and says its own line after | `ProfOaksPC`'s `_OakPCText1` and `_OakPCText4`, neither of which had a caller |
| The boot, choose and shutdown sounds play | `PC_PlayBootSound`, `PC_PlayChoosePCSound`, `PC_PlayShutdownSound` |
| The bedroom PC opens with no party | `_PlayersHousePC` never asks `PC_CheckPartyForPokemon` |

Crystal's selection ring was transcribed with its bottom bar five pixels low, so the ring was open at the sides and a loose line floated above the row below it. `dbsprite 10, 7, 0, 1` puts it at 7 * 8 + 1 - 16 = 41. Both profiles' rings are now pinned in `tools/checks/pc.gd` to the disassemblies' own operands, object by object, and that check goes red on the old value.

GUT 4101/4101, `validate.gd -- all` 82 topics green, the warning scan 0 in 605 scripts, `replay_world.gd` 33 routes with no failures, and the three-profile story walk finishes on 16 badges.
