### PR TITLE
Refuse a mart purchase on the price before the stack

### DIFF
--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -175,16 +175,17 @@ static func _purchase_refusal(
 	var total: int = price * quantity
 	var owned: int = world.state.item_quantity(item)
 	var next_quantity: int = owned + quantity
-	if next_quantity > MAX_ITEM_STACK:
-		return _failure(&"item_stack_full", {
-			"item": item, "quantity": quantity, "owned": owned,
-			"maximum": MAX_ITEM_STACK,
-		})
+	## `BuyMenuLoop` runs `CompareMoney` before `ReceiveItem`: price refuses first.
 	var balance: int = world.state.money(MONEY_ACCOUNT)
 	if total < 0 or total > balance:
 		return _failure(&"insufficient_money", {
 			"item": item, "price": price, "quantity": quantity,
 			"total": total, "balance": balance,
+		})
+	if next_quantity > MAX_ITEM_STACK:
+		return _failure(&"item_stack_full", {
+			"item": item, "quantity": quantity, "owned": owned,
+			"maximum": MAX_ITEM_STACK,
 		})
 	return {
 		"ok": true,
@@ -212,8 +213,7 @@ static func can_sell(data: GameData, item: int) -> bool:
 	return Gen2WorldPack.can_toss(data, item)
 
 
-## `DisplaySellingPrice`: the whole stack is multiplied and then halved, so the
-## shift is on the total rather than on each unit's price.
+## `DisplaySellingPrice`: the shift is on the multiplied total, not on each unit.
 static func sell_price(data: GameData, item: int, quantity: int = 1) -> int:
 	if data == null or quantity <= 0:
 		return 0

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -254,6 +254,9 @@ func test_bargain_script_keeps_the_source_monday_morning_gate() -> void:
 
 func test_mart_purchase_refuses_crossing_the_source_item_stack_limit() -> void:
 	var mart: Dictionary = _data.world_mart(0)
+	## `BuyMenuLoop` asks `CompareMoney` first, so the stack is only what refuses
+	## once the whole order is affordable.
+	_world.state.apply_changes({}, {}, {"money": {0: 999999}})
 	var before: Dictionary = _world.snapshot().to_dict()
 	var result: Dictionary = Gen2WorldMartHost.purchase(
 		_world, _save, mart, 7, Gen2WorldMartHost.MAX_ITEM_STACK, false
@@ -261,6 +264,17 @@ func test_mart_purchase_refuses_crossing_the_source_item_stack_limit() -> void:
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"item_stack_full")
 	assert_eq(_world.snapshot().to_dict(), before)
+
+
+## `BuyMenuLoop`'s own order: `CompareMoney` runs before `ReceiveItem`, so an
+## order that fails both is refused on the price.
+func test_mart_purchase_refuses_on_money_before_the_stack_limit() -> void:
+	var mart: Dictionary = _data.world_mart(0)
+	var result: Dictionary = Gen2WorldMartHost.purchase(
+		_world, _save, mart, 7, Gen2WorldMartHost.MAX_ITEM_STACK, false
+	)
+	assert_false(result["ok"])
+	assert_eq(result["reason"], &"insufficient_money")
 
 
 func test_phone_summary_uses_imported_contact_and_trainer_class() -> void:


### PR DESCRIPTION
`BuyMenuLoop` runs `CompareMoney` before `ReceiveItem`. `Gen2WorldMartHost` asked the 99 stack first, so an order that was both unaffordable and over the stack said PACK FULL where the cartridge says the price.

Found by reading `engine/items/mart.asm` whole. Six other files a built screen calls into were read the same way and agreed with the port: `engine/pokemon/breeding.asm`, `engine/events/daycare.asm`, `engine/events/happiness_egg.asm`'s `DayCareStep`, `engine/overworld/movement.asm`, `engine/items/pack.asm` and `engine/pokemon/bills_pc.asm`.

| Check | Result |
|---|---|
| `gut` unit tier | 3504 tests, 64749 asserts, all passing |
| `tools/validate.gd -- all` | exit 0 |
| Warning scan | 0 warnings in 605 scripts |
| Boot smoke test | exit 0 |

One case each way is pinned: an affordable order over the stack still says the stack, and an order failing both says the price.