### PR TITLE
Open a bystander's share of an experience award to mods

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -33,7 +33,7 @@ user://mods/<id>/
 | `id` | Lowercase `[a-z0-9][a-z0-9_-]*`. Addresses the directory and the registry keys |
 | `name` | Shown to the player |
 | `version` | The mod's own version. Strict `major.minor.patch` |
-| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is 27 and a host accepts 1 to 27. [Contract versions](#contract-versions) says what each added |
+| `api_version` | The oldest host this mod runs on, not a number to keep current: raise it when the mod starts using a newer seam. `Gen2ModManifest.API_VERSION` is the number [Contract versions](#contract-versions) ends on, and a host accepts 1 to that. [Contract versions](#contract-versions) says what each added |
 | `entry` | A `.gd` path inside the mod directory, or inside the pack when there is one |
 | `pack` | Optional `.pck` or `.zip` beside `mod.json`, holding the mod's files |
 | `description` | Optional |
@@ -130,6 +130,7 @@ runs, since every version so far has only added.
 | 26 | A run button, and a scale on every experience award |
 | 27 | SMOOTH SCROLL reaching a span, an actor's pose and a walking wild, and `span` on an actor entry |
 | 28 | `height_offset_pixels` on an actor's drawn row, and `Gen2WorldAPI.jump_offset_for()` |
+| 29 | `register_experience_bystanders()`, and `bystander` on an `exp_gained` event |
 
 ## Installing
 
@@ -1022,6 +1023,45 @@ the rest. Three things it does not do: stat experience is the cartridge's own EV
 gain and is not scaled; the product truncates the way every division in
 `Gen2Experience` does, with a non-zero award floored at 1 so a 0.5x run still
 levels; and the result is clamped to `Gen2Experience.MAX_EXP`.
+
+## Paying a Pokemon that never fought
+
+`register_experience_bystanders(manifest, provider)` answers what a living party
+member paid by neither cartridge pass receives, as a fraction of a participant's
+own award. 0.0 is the cartridge and is what an unregistered host does; 0.5 is
+Gen 6's Exp. Share and 1.0 is Gen 8's.
+
+```gdscript
+class Multi:
+	func experience_bystander_share(context: Dictionary) -> float:
+		return 0.5 if not (context["exp_share_holders"] as Array).is_empty() else 0.0
+```
+
+The context carries what the split would otherwise have to be guessed at:
+
+| Field | Is |
+|---|---|
+| `participants` | Party indices the first pass paid |
+| `exp_share_holders` | Party indices the second pass paid |
+| `living` | Every unfainted party index |
+| `is_trainer_battle` | Whether the award already carries the trainer bonus |
+
+Registered with the manifest `register()` was handed, and **exclusive**: the
+second registration is refused with `duplicate_experience_bystanders` whoever
+makes it. A share is not a product the way a scale is, and multiplying two mods'
+fractions would let load order decide what a party is paid.
+
+Three things the host does around it. A claimed share above zero **suppresses the
+cartridge halving**, since neither later generation halves and enabling the
+feature would otherwise cut the fighter's award. A bystander is paid **once and
+last**, after both passes, with the participant pass's award scaled and floored
+at 1 the way every scaled award is. Its stat experience is the participant pass's
+block unchanged: a bystander's EVs are the cartridge's hidden gain rather than a
+rate. The `exp_gained` event carries `bystander` beside `exp_share`, so a line
+printed for a Pokemon that never fought is told from either pass.
+
+`award_win_experience()` and `award_capture_experience()` both run the same pass,
+so a skipped fight and a capture split the same way.
 
 ## Annotating the battle
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2238,21 +2238,63 @@ func _award_experience(events: Array) -> void:
 func _give_experience_for(defeated: Gen2BattleMon, events: Array) -> void:
 	var participants: Array = (_participants[PLAYER] as Dictionary).keys()
 	var holders: Array = _exp_share_holders()
-	var halved: bool = not holders.is_empty()
+	var living: Array = _living_party_indices()
+	## Neither later generation halves, so a claimed share suppresses the halving.
+	var share: float = Gen2ModHost.experience_bystander_share({
+		"participants": participants.duplicate(),
+		"exp_share_holders": holders.duplicate(),
+		"living": living.duplicate(),
+		"is_trainer_battle": is_trainer_battle,
+	})
+	var halved: bool = not holders.is_empty() and share <= 0.0
 
-	_award_share(defeated, participants, halved, false, events)
+	var award: int = _award_share(defeated, participants, halved, false, events)
 	_award_share(defeated, holders, halved, true, events)
+	_award_bystanders(defeated, participants, holders, living, halved, share, award, events)
 
 	_participants[PLAYER] = {party(PLAYER).active: true}
 
 
+## Every living index neither pass paid, at [param share] of [param award]. Its
+## stat experience is the participant pass's block unchanged.
+func _award_bystanders(
+	defeated: Gen2BattleMon, participants: Array, holders: Array, living: Array,
+	halved: bool, share: float, award: int, events: Array
+) -> void:
+	if share <= 0.0 or award <= 0 or participants.is_empty():
+		return
+	var block: Dictionary = Gen2Experience.shared_block(
+		defeated.base_stat_exp_shape(), defeated.base_exp(), halved, participants.size()
+	)
+	var scaled: int = clampi(maxi(int(float(award) * share), 1), 0, Gen2Experience.MAX_EXP)
+	for index: int in living:
+		if participants.has(index) or holders.has(index):
+			continue
+		var learner: Gen2BattleMon = party(PLAYER).at(int(index))
+		if learner == null:
+			continue
+		_give_experience_to(
+			learner, int(index), scaled, block["stats"], false, events, true
+		)
+
+
+func _living_party_indices() -> Array:
+	var out: Array = []
+	var party_side: Gen2Party = party(PLAYER)
+	for index: int in party_side.size():
+		var member: Gen2BattleMon = party_side.at(index)
+		if member != null and not member.is_fainted():
+			out.append(index)
+	return out
+
+
 ## One of the two passes: the block divided among [param recipients], then handed
-## to each of them that is still standing.
+## to each of them that is still standing. Answers what one recipient was paid.
 func _award_share(
 	defeated: Gen2BattleMon, recipients: Array, halved: bool, by_exp_share: bool, events: Array
-) -> void:
+) -> int:
 	if recipients.is_empty():
-		return
+		return 0
 	var block: Dictionary = Gen2Experience.shared_block(
 		defeated.base_stat_exp_shape(), defeated.base_exp(), halved, recipients.size()
 	)
@@ -2264,6 +2306,7 @@ func _award_share(
 		var learner: Gen2BattleMon = party(PLAYER).at(int(index))
 		if learner != null and not learner.is_fainted():
 			_give_experience_to(learner, int(index), award, stat_gains, by_exp_share, events)
+	return award
 
 
 ## The one place a registered experience scale is applied, so everything a player
@@ -2476,7 +2519,7 @@ func _exp_share_holders() -> Array:
 
 func _give_experience_to(
 	learner: Gen2BattleMon, index: int, award: int, stat_gains: Dictionary,
-	by_exp_share: bool, events: Array
+	by_exp_share: bool, events: Array, bystander: bool = false
 ) -> void:
 	learner.gain_exp(award)
 	events.append({
@@ -2485,6 +2528,8 @@ func _give_experience_to(
 		# Which pass this came from. The cartridge prints one line either way; this
 		# tells a Pokémon in both passes from one awarded twice otherwise.
 		"exp_share": by_exp_share,
+		# Neither pass: a BYSTANDER SHARE paid a Pokemon that never fought.
+		"bystander": bystander,
 	})
 
 	learner.gain_stat_exp(stat_gains)

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -151,6 +151,9 @@ const BATTLE_INFO_METHODS: Array[String] = ["annotate_battle"]
 const SHINY_ROLLS_METHODS: Array[String] = ["shiny_rolls"]
 const RUN_BUTTON_METHODS: Array[String] = ["runs_while_held"]
 const EXPERIENCE_SCALE_METHODS: Array[String] = ["experience_scale"]
+const EXPERIENCE_BYSTANDER_METHODS: Array[String] = ["experience_bystander_share"]
+
+const MAX_BYSTANDER_SHARE: float = 1.0
 
 ## A scale is a mod's number and the range is the host's, as with the rolls above.
 const MIN_EXPERIENCE_SCALE: float = 0.1
@@ -258,6 +261,8 @@ var _battle_info: Dictionary = {}
 var _shiny_rolls: Dictionary = {}
 var _run_buttons: Dictionary = {}
 var _experience_scales: Dictionary = {}
+## The one BYSTANDER SHARE policy, exclusive for [member _event_mutators]' reason.
+var _experience_bystanders: Dictionary = {}
 var _battle_renderers: Dictionary = {}
 ## The one id the player's view is chosen by, read from [Gen2ModState] when the
 ## host is built and written back whenever it changes. It is a bare id and may
@@ -728,14 +733,10 @@ static func allows_item_field_move(move: int) -> bool:
 	return false
 
 
-## Registers a REPEL RENEWAL provider under [param id]: which owned Repel to
-## offer when an active one runs out on a step.
-##
-## [param provider] is a [RefCounted] answering
-## [constant REPEL_PROVIDER_METHODS]: `repel_to_use(inventory)` is handed a
-## read-only `{item: quantity}` copy of the bag and answers one item number, or
-## 0 for none. Which of the three to prefer is the mod's; the prompt, the
-## transaction, the step count and the encounter ordering are the host's.
+## Registers a REPEL RENEWAL provider under [param id]: `repel_to_use(inventory)`
+## is handed a read-only copy of the bag and answers which owned Repel to offer
+## when an active one runs out, or 0. Which of the three to prefer is the mod's;
+## the prompt, the transaction, the step count and the ordering are the host's.
 func register_repel_renewal(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(_repel_renewals, REPEL_PROVIDER_METHODS, id, provider)
 
@@ -786,12 +787,9 @@ static func shiny_roll_count(context: Dictionary) -> int:
 
 
 ## Registers a CATCH EXPERIENCE policy for [param manifest]'s own run: whether a
-## successful wild capture awards the caught Pokemon's experience. Save bound, so
-## [param manifest] is the capability the way it is for
-## [method register_save_lifecycle] and a manifest this host did not discover
-## registers nothing. [param provider] answers `awards_catch_experience()`, read
-## every capture rather than once, so a mod that switched its own option off
-## mid-run is off from the next throw.
+## successful wild capture awards the caught Pokemon's experience. Save bound the
+## way [method register_save_lifecycle] is, and `awards_catch_experience()` is
+## read every capture rather than once. See `docs/MODS.md`.
 func register_catch_experience(manifest: Gen2ModManifest, provider: Object) -> Dictionary:
 	if not _owns_manifest(manifest):
 		return {"ok": false, "reason": &"unknown_mod_save_owner"}
@@ -864,13 +862,43 @@ static func experience_scale() -> float:
 	return clampf(scale, MIN_EXPERIENCE_SCALE, MAX_EXPERIENCE_SCALE)
 
 
+## Registers the one BYSTANDER SHARE policy, save bound the way
+## [method register_experience_scale] is. See `docs/MODS.md`.
+func register_experience_bystanders(manifest: Gen2ModManifest, provider: Object) -> Dictionary:
+	if not _owns_manifest(manifest):
+		return {"ok": false, "reason": &"unknown_mod_save_owner"}
+	if not _experience_bystanders.is_empty() and not _experience_bystanders.has(manifest.id):
+		return {
+			"ok": false, "reason": &"duplicate_experience_bystanders",
+			"detail": "%s: claimed by %s" % [manifest.id, _experience_bystanders.keys()[0]],
+		}
+	return _register_provider(
+		_experience_bystanders, EXPERIENCE_BYSTANDER_METHODS, manifest.id, provider
+	)
+
+
+func experience_bystander_ids() -> Array:
+	return _experience_bystanders.keys()
+
+
+## A fraction of a participant's award; 0.0 is the cartridge, and so is anything
+## that is not a number. Static and null-safe as [method experience_scale] is.
+static func experience_bystander_share(context: Dictionary) -> float:
+	if _instance == null or _instance._experience_bystanders.is_empty():
+		return 0.0
+	var provider: Object = _instance._experience_bystanders.values()[0]
+	var answered: float = float(
+		provider.call("experience_bystander_share", context.duplicate(true))
+	)
+	if not is_finite(answered):
+		return 0.0
+	return clampf(answered, 0.0, MAX_BYSTANDER_SHARE)
+
+
 ## Registers a BATTLE INFORMATION provider under [param id]: read-only annotations
 ## drawn on the hardware interface over whichever battle renderer is selected.
-## [param provider] answers `annotate_battle(snapshot)` with an array of
-## placements on the 20x18 tile grid, each `{"at": Vector2i}` plus either a `text`
-## string or a `tile` of 8x8 pixel indices. The snapshot is
-## [method Gen2BattleScreen.info_snapshot], so a provider computes nothing the
-## host already knows.
+## `annotate_battle(snapshot)` answers placements on the 20x18 tile grid off
+## [method Gen2BattleScreen.info_snapshot]. See `docs/MODS.md`.
 func register_battle_info(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(_battle_info, BATTLE_INFO_METHODS, id, provider)
 

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -13,7 +13,7 @@ const FILENAME: String = "mod.json"
 ## number that says the seam is there: `docs/MODS.md` lists what each version
 ## added. An optional field a mod may send and an older host may drop is
 ## deliberately not a bump.
-const API_VERSION: int = 28
+const API_VERSION: int = 29
 ## The oldest contract this host still answers. See [constant API_VERSION].
 const MIN_API_VERSION: int = 1
 ## Ids address directories and registry keys, so they stay to a plain lowercase

--- a/mods/examples/new_content/mod.json
+++ b/mods/examples/new_content/mod.json
@@ -2,7 +2,7 @@
 	"id": "new_content",
 	"name": "New Content Example",
 	"version": "1.0.0",
-	"api_version": 28,
+	"api_version": 29,
 	"entry": "mod.gd",
 	"description": "Adds a type and two matchups, a species with its own art, a move and its effect, an item with a pocket and a mart shelf, a named control axis, a fourth page on the stats screen and a visible wild population that reads the run's rules; rebalances two cartridge rows, watches both event channels and rewrites how a world text is shown. The reference for everything a mod can register that is not a renderer. Registers the six read-only policies that change how the game is played: an alternate field-move source, Repel renewal, experience for a capture, how many times a wild's DVs are rolled, battle annotations and a start-menu row that opens the host's own storage, a page of its own with a second row that opens it, and a banner over the map raised when the run's progress moves."
 }

--- a/mods/examples/voxel_preview/mod.json
+++ b/mods/examples/voxel_preview/mod.json
@@ -2,7 +2,7 @@
 	"id": "voxel_preview",
 	"name": "Voxel Preview",
 	"version": "1.0.0",
-	"api_version": 28,
+	"api_version": 29,
 	"entry": "mod.gd",
 	"games": ["gold", "silver", "crystal"],
 	"description": "Draws the same map as extruded geometry at the window's own resolution. Press V in the overworld to switch between this and the Game Boy Color view."

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -1892,6 +1892,7 @@ func test_the_provider_registrations_share_one_set_of_rules() -> void:
 	for register: Callable in [
 		func(p: Object) -> Dictionary: return host.register_catch_experience(stranger, p),
 		func(p: Object) -> Dictionary: return host.register_experience_scale(stranger, p),
+		func(p: Object) -> Dictionary: return host.register_experience_bystanders(stranger, p),
 	]:
 		assert_eq(StringName(register.call(same.new())["reason"]), &"unknown_mod_save_owner")
 
@@ -2038,6 +2039,147 @@ func experience_scale() -> float:
 	assert_eq(Gen2ModHost.experience_scale(), Gen2ModHost.MAX_EXPERIENCE_SCALE)
 	provider.set("value", 0.001)
 	assert_eq(Gen2ModHost.experience_scale(), Gen2ModHost.MIN_EXPERIENCE_SCALE)
+
+
+## A share is claimed exclusively, clamped to the host's ceiling, and answers the
+## cartridge for anything that is not a number.
+func test_a_bystander_share_is_exclusive_and_held_inside_the_hosts_range() -> void:
+	Gen2ModHost.reset()
+	assert_eq(Gen2ModHost.experience_bystander_share({}), 0.0, "no host at all")
+
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var policy := GDScript.new()
+	policy.source_code = """extends RefCounted
+var value: float = 0.5
+var seen: Dictionary = {}
+func experience_bystander_share(context: Dictionary) -> float:
+	seen = context
+	return value
+"""
+	policy.reload()
+	var provider: Object = policy.new()
+	assert_true(bool(host.register_experience_bystanders(manifest, provider).get("ok", false)))
+	assert_eq(host.experience_bystander_ids(), [manifest.id])
+	assert_eq(Gen2ModHost.experience_bystander_share({"living": [0, 1]}), 0.5)
+	assert_eq((provider.get("seen") as Dictionary)["living"], [0, 1])
+
+	var second := Gen2ModManifest.new()
+	second.id = &"other"
+	host._manifests[second.id] = second
+	assert_eq(
+		StringName(host.register_experience_bystanders(second, policy.new())["reason"]),
+		&"duplicate_experience_bystanders",
+		"two fractions have no join that does not depend on load order"
+	)
+
+	for refused: float in [NAN, INF, -INF]:
+		provider.set("value", refused)
+		assert_eq(Gen2ModHost.experience_bystander_share({}), 0.0, "not a number")
+	provider.set("value", -1.0)
+	assert_eq(Gen2ModHost.experience_bystander_share({}), 0.0)
+	provider.set("value", 4.0)
+	assert_eq(
+		Gen2ModHost.experience_bystander_share({}), Gen2ModHost.MAX_BYSTANDER_SHARE,
+		"nothing is paid more than a fighter"
+	)
+
+
+## The later generations' split: a bystander is paid a fraction of the fighter's
+## own award, once and last, and a claimed share suppresses the cartridge halving
+## so turning it on never cuts the fighter.
+func test_a_registered_bystander_share_pays_the_rest_of_the_party() -> void:
+	Gen2ModHost.reset()
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	var manifest: Gen2ModManifest = _loaded_manifest()
+	var policy := GDScript.new()
+	policy.source_code = """extends RefCounted
+var value: float = 0.0
+func experience_bystander_share(_context: Dictionary) -> float:
+	return value
+"""
+	policy.reload()
+	var provider: Object = policy.new()
+	assert_true(bool(host.register_experience_bystanders(manifest, provider).get("ok", false)))
+
+	var directory: String = RomCache.directory_for(&"modbystandertest", "0123456789abcdef")
+	var data: GameData = BattleFixture.build(directory)
+	var awards: Dictionary = {}
+	var flags: Dictionary = {}
+	var stat_gains: Dictionary = {}
+	for share: float in [0.0, 0.5, 1.0]:
+		provider.set("value", share)
+		var rng := RandomNumberGenerator.new()
+		rng.seed = 12345
+		var bench: Gen2BattleMon = Gen2BattleMon.create(
+			data, BattleFixture.PIKACHU, 5, [BattleFixture.THUNDERBOLT]
+		)
+		var battle: Gen2Battle = Gen2Battle.create_parties(
+			data,
+			Gen2Party.create([
+				Gen2BattleMon.create(
+					data, BattleFixture.PIKACHU, 5, [BattleFixture.THUNDERBOLT]
+				),
+				bench,
+			]),
+			Gen2Party.of(Gen2BattleMon.create(
+				data, BattleFixture.BULBASAUR, 5, [BattleFixture.TACKLE]
+			)),
+			rng, true
+		)
+		var paid: Dictionary = {}
+		for event: Dictionary in battle.award_win_experience():
+			if StringName(event["type"]) == Gen2Battle.EXP_GAINED:
+				paid[int(event["index"])] = int(event["amount"])
+				flags[share] = bool(event.get("bystander", false)) if int(event["index"]) == 1 \
+					else flags.get(share, false)
+			elif StringName(event["type"]) == Gen2Battle.STAT_EXP_GAINED \
+				and int(event["index"]) == 1:
+				stat_gains[share] = event["gains"]
+		awards[share] = paid
+	assert_eq(awards[0.0], {0: 67}, "the cartridge pays the fighter alone")
+	assert_eq(awards[0.5], {0: 67, 1: 33}, "Gen 6's half, floored the way a scale is")
+	assert_eq(awards[1.0], {0: 67, 1: 67}, "Gen 8 pays the whole party in full")
+	assert_true(bool(flags[1.0]), "a line for a Pokemon that never fought")
+	assert_false(flags[0.0], "nothing is a bystander at the cartridge's own share")
+	assert_eq(
+		stat_gains[1.0], stat_gains.get(0.5, stat_gains[1.0]),
+		"a bystander's EVs are the cartridge's hidden gain, not a rate"
+	)
+
+	## With a living Exp. Share holder the cartridge halves the block before both
+	## passes. A claimed share suppresses that, or turning the feature on would
+	## cut the award of the Pokemon that did the fighting.
+	var held: Dictionary = {}
+	for share: float in [0.0, 1.0]:
+		provider.set("value", share)
+		var rng := RandomNumberGenerator.new()
+		rng.seed = 12345
+		var holder: Gen2BattleMon = Gen2BattleMon.create(
+			data, BattleFixture.PIKACHU, 5, [BattleFixture.THUNDERBOLT]
+		)
+		holder.item = Gen2Experience.EXP_SHARE_ITEM
+		var battle: Gen2Battle = Gen2Battle.create_parties(
+			data,
+			Gen2Party.create([
+				Gen2BattleMon.create(
+					data, BattleFixture.PIKACHU, 5, [BattleFixture.THUNDERBOLT]
+				),
+				holder,
+			]),
+			Gen2Party.of(Gen2BattleMon.create(
+				data, BattleFixture.BULBASAUR, 5, [BattleFixture.TACKLE]
+			)),
+			rng, true
+		)
+		var paid: Dictionary = {}
+		for event: Dictionary in battle.award_win_experience():
+			if StringName(event["type"]) == Gen2Battle.EXP_GAINED:
+				paid[int(event["index"])] = paid.get(int(event["index"]), 0) + int(event["amount"])
+		held[share] = paid
+	assert_eq(held[0.0], {0: 33, 1: 33}, "the cartridge halves the block for both passes")
+	assert_eq(held[1.0], {0: 67, 1: 67}, "a claimed share never cuts the fighter")
+	RomCache.clear(directory)
 
 
 ## The one seam is the award itself, so every figure a player sees moves with it.

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37877
+const MAX_COMMENT_LINES: int = 37876
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than


### PR DESCRIPTION
`Gen2Battle`'s two cartridge passes pay the participants and the Exp. Share holders, and nothing outside them could reach who is paid: `register_experience_scale` moves what an award is worth, never who gets one. A mod wanting the later generations' split had to reimplement the block arithmetic, the level ups, the moves offered and the evolutions.

`register_experience_bystanders(manifest, provider)` answers one fraction of a participant's own award for every living party member neither pass paid. 0.0 is the cartridge, 0.5 is Gen 6's Exp. Share, 1.0 is Gen 8's. The context carries `participants`, `exp_share_holders`, `living` and `is_trainer_battle`.

Claimed exclusively, the way an event mutator is: a share is not a product like a scale, and multiplying two mods' fractions would let load order decide what a party is paid. The second registration is refused with `duplicate_experience_bystanders`.

Three things around it that only the engine can do:

- a claimed share **suppresses the cartridge halving**, since neither later generation halves and turning the feature on would otherwise cut the fighter;
- a bystander is paid **once and last**, with the participant pass's award scaled and floored at 1 the way every scaled award is;
- its stat experience is that pass's block unchanged, an EV gain rather than a rate.

`exp_gained` carries `bystander` beside `exp_share`. `award_win_experience()` and `award_capture_experience()` both run the same pass, so a skipped fight and a capture split the same way.

Measured on the host's own fixture, a level 5 party against a level 5 Bulbasaur in a trainer battle:

| Share | Fighter | Bench |
|---|---|---|
| 0.0 | 67 | not paid |
| 0.5 | 67 | 33 |
| 1.0 | 67 | 67 |
| 0.0, bench holds an Exp. Share | 33 | 33 |
| 1.0, bench holds an Exp. Share | 67 | 67 |

`API_VERSION` is 29. One stale line fixed on the way: the manifest table in `docs/MODS.md` said 27 while the contract table below it said 28, so the number is now written once and read from that table.

| Check | Result |
|---|---|
| `gut` unit tier | 3505 tests, 64768 asserts, all passing |
| `tools/validate.gd -- all` | 82 topics, exit 0 |
| Warning scan | 0 warnings in 605 scripts |
| Boot smoke test, with mods | exit 0 |
| Comment budget | 37876, lowered by one: the new prose is paid for by compressing three registration docs that `docs/MODS.md` already states in full |