### PR TITLE
Object zero, the gender comparison, and the rival's name

### DIFF
--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -370,18 +370,6 @@ static func _deform_screen(
 		progress = (progress + offset) & 0xFF
 
 
-## `InitSurfWaves`: the 64-entry wave the Surf effect then rotates past the
-## window one entry a frame.
-static func _init_surf_waves(
-	player: Gen2BattleAnimPlayer, amplitude: int, offset: int
-) -> void:
-	var background: Gen2BattleAnimBackground = player.background()
-	var progress: int = 0
-	for index: int in Gen2BattleAnimBackground.SURF_WAVE_LENGTH:
-		background.surf_wave[index] = _sine(player, progress, amplitude)
-		progress = (progress + offset) & 0xFF
-
-
 ## `DeformWater`: a wave that grows outwards from one line in both directions,
 ## stopping at whichever end of the window it reaches first.
 static func _deform_water(

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -499,11 +499,13 @@ func persistent_dvs() -> int:
 	return int(transform_original.get("dvs", dvs))
 
 
-## `GetGender`'s answer, from the species ratio and this Pokémon's Attack and
-## Speed DVs: the cartridge folds the Attack DV into a byte's high nibble and the
-## Speed DV into its low, then compares against the ratio. Ratio 0 is always male
-## and 254 always female with no comparison at all, 255 is genderless, and
-## otherwise below the ratio is male, so a higher ratio means likelier female.
+## `GetGender`, which folds the Attack DV into a byte's high nibble and the Speed
+## DV into its low and compares that against the species ratio. Ratio 0 is always
+## male, 254 always female and 255 genderless, with no comparison at all.
+## Otherwise `cp b` puts the ratio against the byte and `jr c` takes male, so a
+## byte ABOVE the ratio is male and one equal to it is female; the source's own
+## comment there reads the other way round. `ratio + 1` values of 256 are female,
+## which is the percentage each GENDER_F* constant is named for.
 const GENDER_F0: int = 0
 const GENDER_F100: int = 254
 const GENDER_UNKNOWN: int = 255
@@ -531,7 +533,7 @@ static func gender_for(data_source: GameData, species_number: int, mon_dvs: int)
 		return GENDER_FEMALE
 
 	var combined: int = (Gen2Stats.attack_dv(mon_dvs) << 4) | Gen2Stats.speed_dv(mon_dvs)
-	return GENDER_MALE if combined < ratio else GENDER_FEMALE
+	return GENDER_MALE if combined > ratio else GENDER_FEMALE
 
 
 ## The two type numbers, which are the same number twice for a single-type

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -286,13 +286,6 @@ static func _read_mart_list_at(rom: RomFile, offset: int) -> Dictionary:
 	return {"ok": true, "items": items}
 
 
-static func _read_price_mart(rom: RomFile, bank: int, address: int, name: String) -> Dictionary:
-	if not _valid_cpu_address(address):
-		return _error("%s mart has an invalid CPU address." % name)
-	var offset: int = RomFile.linear(bank, address)
-	return _read_price_mart_at(rom, offset, name)
-
-
 static func _read_price_mart_at(rom: RomFile, offset: int, name: String) -> Dictionary:
 	if not rom.in_bounds(offset):
 		return _error("%s mart is outside the cartridge." % name)

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -39,10 +39,12 @@ var palette: PackedColorArray = PackedColorArray():
 
 
 
-## `.PlayerNameString`'s "YOUR NAME?" is the caller's, since the same screen
-## names a Pokemon, the rival and Mom under its own prompt. Answers false when
-## the cache carried no keyboards, which the caller reports rather than opening
-## a screen with nothing on it.
+## `NamingScreenJumptable`'s own strings. One keyboard names a Pokemon, the
+## player and the rival; only the line over it differs, so it is the caller's.
+const PROMPT_PLAYER: String = "YOUR NAME?"
+const PROMPT_RIVAL: String = "RIVAL'S NAME?"
+
+
 func open(data: GameData, prompt: String, kind: StringName = KIND_PLAYER) -> bool:
 	_prompt = prompt
 	_page = Gen2NamingScreenPage.from_data(data)

--- a/game/world/oak_speech.gd
+++ b/game/world/oak_speech.gd
@@ -48,9 +48,6 @@ const SHRINK_CLEAR_AT: Vector2i = Vector2i(6, 5)
 ## 4`, x `9 * 8`; hardware OAM counts from (-8, -16).
 const SHRINK_SPRITE_AT: Vector2i = Vector2i(64, 60)
 
-## `.PlayerNameString`, printed above the naming screen's entry.
-const NAME_PROMPT: String = "YOUR NAME?"
-
 ## `home/string.asm`'s InitName substitutes these for a blank entry.
 const DEFAULT_MALE: String = "CHRIS"
 const DEFAULT_FEMALE: String = "KRIS"

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -404,7 +404,7 @@ func _on_name_choice(chosen: String) -> void:
 
 func _open_naming() -> void:
 	_naming = Gen2NamingScreenScreen.new()
-	if not _naming.open(_data, Gen2OakSpeech.NAME_PROMPT):
+	if not _naming.open(_data, Gen2NamingScreenScreen.PROMPT_PLAYER):
 		_naming.free()
 		_naming = null
 		_enter_next_beat()

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -188,6 +188,9 @@ var current_tileset: Gen2WorldTileset = null
 var player_cell: Vector2i = Vector2i.ZERO
 var player_facing: int = Gen2WorldSprite.FACING_DOWN
 var objects: Array = []
+## Object zero: `showemote`'s bubble and `disappear`'s deletion, the two things
+## the object commands write onto the player beyond the fields above.
+var _player_object: Gen2WorldObject = Gen2WorldObject.new()
 var object_hour: int = 6
 var object_time_of_day: int = Gen2WorldPalette.TIME_MORNING
 var world_day: int = 0
@@ -2864,12 +2867,26 @@ func advance_frame_counter() -> int:
 	return frame_number
 
 
-## One hardware frame of every object's emote countdown.
+## One hardware frame of every object's emote countdown, the player's included.
 func advance_emotes_frame() -> bool:
-	var changed: bool = false
+	var changed: bool = _player_object.tick_emote()
 	for object: Gen2WorldObject in objects:
 		changed = object.tick_emote() or changed
 	return changed
+
+
+func player_emote() -> int:
+	return _player_object.emote_id if _player_object.emote_visible \
+		else Gen2WorldActors.EMOTE_NONE
+
+
+func set_player_emote(emote_id: int, visible: bool, duration: int = 0) -> void:
+	_player_object.set_emote(emote_id, visible, duration)
+
+
+## False while `disappear PLAYER` holds: `DeleteObjectStruct` on object zero.
+func player_visible() -> bool:
+	return not _player_object.deleted
 
 
 ## The grass rustles `NormalStep` spawned this frame, taken once. `ShakeGrass` runs
@@ -4465,8 +4482,9 @@ func _script_player_facing(event: Dictionary) -> Array:
 
 
 func _script_write_object_position(event: Dictionary) -> Array:
-	var index: int = int(event.get("object_index", -1))
-	if not _event_names_loaded_object(event, index):
+	var index: int = int(event.get("object_index", Gen2WorldObject.NONE_INDEX))
+	if index == Gen2WorldObject.PLAYER_INDEX \
+		or not _event_names_loaded_object(event, index):
 		return [{"type": &"object_change_failed", "reason": &"invalid_object"}]
 	var key: String = _object_key(
 		int(event.get("map_group", -1)), int(event.get("map_number", -1)), index
@@ -4575,29 +4593,37 @@ func _script_object_stop_follow(_event: Dictionary) -> Array:
 
 
 func _script_player_face_object(event: Dictionary) -> Array:
-	var target: int = int(event.get("target_index", -1))
-	if _event_names_loaded_object(event, target):
+	var target: int = int(event.get("target_index", Gen2WorldObject.NONE_INDEX))
+	if target >= 0 and _event_names_loaded_object(event, target):
 		player_facing = _facing_toward(
 			player_cell, (objects[target] as Gen2WorldObject).cell
 		)
 	return []
 
 
-## Whether [param event] names the loaded map and an object on it. Every event
-## that edits one is refused rather than applied to whatever is at that index on
-## another map.
+## Whether [param event] names the loaded map and an actor on it: an object in
+## range, or the player. An event that edits one is refused rather than applied
+## to whatever sits at that index on another map.
 func _event_names_loaded_object(event: Dictionary, index: int) -> bool:
-	return current_map != null \
-		and int(event.get("map_group", -1)) == current_map.group \
-		and int(event.get("map_number", -1)) == current_map.number \
-		and index >= 0 and index < objects.size()
+	if current_map == null \
+		or int(event.get("map_group", -1)) != current_map.group \
+		or int(event.get("map_number", -1)) != current_map.number:
+		return false
+	return index == Gen2WorldObject.PLAYER_INDEX \
+		or (index >= 0 and index < objects.size())
+
+
+func _object_record(index: int) -> Gen2WorldObject:
+	if index == Gen2WorldObject.PLAYER_INDEX:
+		return _player_object
+	return objects[index] if index >= 0 and index < objects.size() else null
 
 
 func _apply_local_object_event(type: StringName, event: Dictionary) -> Array:
-	var index: int = int(event.get("object_index", -1))
+	var index: int = int(event.get("object_index", Gen2WorldObject.NONE_INDEX))
 	if not _event_names_loaded_object(event, index):
 		return [{"type": &"object_change_failed", "reason": &"invalid_object"}]
-	var object: Gen2WorldObject = objects[index]
+	var object: Gen2WorldObject = _object_record(index)
 	match type:
 		&"object_deleted":
 			object.deleted = true
@@ -4621,7 +4647,9 @@ func _apply_local_object_event(type: StringName, event: Dictionary) -> Array:
 func _apply_object_override(type: StringName, event: Dictionary) -> bool:
 	var map_group: int = int(event.get("map_group", -1))
 	var map_number: int = int(event.get("map_number", -1))
-	var index: int = int(event.get("object_index", -1))
+	var index: int = int(event.get("object_index", Gen2WorldObject.NONE_INDEX))
+	if index == Gen2WorldObject.PLAYER_INDEX:
+		return _apply_player_override(type, event)
 	if index < 0:
 		return false
 	var key: String = _object_key(map_group, map_number, index)
@@ -4657,6 +4685,34 @@ func _apply_object_override(type: StringName, event: Dictionary) -> bool:
 					(objects[target] as Gen2WorldObject).cell
 				)
 	return true
+
+
+## The same writes against object zero. Nothing is recorded for the next object
+## load, and `ApplyEventActionAppearDisappear` finds the player's event flag is
+## -1, so `disappear PLAYER` has no flag half either.
+func _apply_player_override(type: StringName, event: Dictionary) -> bool:
+	if not _event_names_loaded_object(event, Gen2WorldObject.PLAYER_INDEX):
+		return false
+	match type:
+		&"object_visibility":
+			_player_object.deleted = not bool(event.get("active", false))
+		&"object_position":
+			var cell: Variant = event.get("cell", Vector2i.ZERO)
+			if not cell is Vector2i:
+				return false
+			player_cell = cell
+		&"object_facing":
+			player_facing = clampi(
+				int(event.get("facing", Gen2WorldSprite.FACING_DOWN)),
+				Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
+			)
+		&"object_face_object":
+			var target: int = int(event.get("target_index", Gen2WorldObject.NONE_INDEX))
+			if target >= 0 and target < objects.size():
+				player_facing = _facing_toward(
+					player_cell, (objects[target] as Gen2WorldObject).cell
+				)
+	return false
 
 
 func _apply_object_movement(event: Dictionary) -> Array:
@@ -5645,8 +5701,10 @@ func _start_object_follow(event: Dictionary) -> void:
 	var map_number: int = int(event.get("map_number", -1))
 	if map_group != current_map.group or map_number != current_map.number:
 		return
-	var follower_index: int = int(event.get("object_index", -2))
-	var leader_index: int = int(event.get("target_index", -2))
+	var follower_index: int = int(
+		event.get("object_index", Gen2WorldObject.NONE_INDEX)
+	)
+	var leader_index: int = int(event.get("target_index", Gen2WorldObject.NONE_INDEX))
 	if not _follow_object_is_visible(leader_index):
 		return
 	_object_followers.clear()
@@ -5675,7 +5733,7 @@ func _start_object_follow(event: Dictionary) -> void:
 
 func _follow_object_is_visible(object_index: int) -> bool:
 	if object_index < 0:
-		return object_index == -1
+		return object_index == Gen2WorldObject.PLAYER_INDEX and player_visible()
 	if object_index >= objects.size():
 		return false
 	var object: Gen2WorldObject = objects[object_index]
@@ -5756,20 +5814,20 @@ func _step_follower(
 	# The leader's own step duration, not the slower wandering one:
 	# QueueFollowerFirstStep queues `movement_step` and the queue after it holds
 	# the leader's own command bytes. A running player leaves a follower on the
-	# walk row a cell behind every step.
+	# walk row a cell behind every step. The facing rides that queued step, since
+	# a whole stream queues in one call and MovementFunction_Follow turns a
+	# follower as each step begins rather than all at once.
 	if follower == null:
 		player_cell = destination
-		player_facing = facing_for_direction(direction)
-		_queue_player_step(direction, passes)
+		_queue_player_step(direction, passes, false, direction)
 		return
 	follower.cell = destination
-	follower.apply_direction(direction)
-	follower.queue_step(direction, passes)
+	follower.queue_step(direction, passes, false, direction)
 	var override_key: String = _object_key(
 		current_map.group, current_map.number, follower_index
 	)
 	_object_position_overrides[override_key] = follower.cell
-	_object_facing_overrides[override_key] = follower.facing
+	_object_facing_overrides[override_key] = facing_for_direction(direction)
 
 
 ## Moves one cell or enters a neighboring map when the step leaves a connected map
@@ -7125,6 +7183,9 @@ func connected_map_objects() -> Array:
 ## rather than on the way into it. See Gen2WorldObject.carry_presentation_from().
 func _load_objects(carry_presentation: bool = false) -> void:
 	var previous: Array = objects if carry_presentation else []
+	## `ReadObjectEvents` clears every object struct, object zero included.
+	if not carry_presentation:
+		_player_object = Gen2WorldObject.new()
 	objects = []
 	if current_map == null or data == null:
 		return

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -7,20 +7,17 @@ extends RefCounted
 ## pending with a specific reason rather than being guessed or acknowledged as
 ## if the subsystem had run.
 
-## The requests the host settles out of the save alone. `special HealParty`,
-## `giveegg` and a `givepoke` that names an OT each run to completion inside the
-## command that asked for them and the script runs straight on, so a screen
-## completes one where it is staged rather than waiting for a press.
-## `pokemon_requested` is here for those and no further: `GivePoke`'s `.wildmon`
-## branch reaches `GiveANickname_YesNo`, so a screen that can draw one intercepts
-## the request in front of this list and a driver that cannot settles it here with
-## the species name, which is what NO answers.
+## The requests the host settles out of the save alone: `special HealParty`,
+## `giveegg`, `GiveDratini` and a `givepoke` that names an OT each run to
+## completion inside the command that asked, so a screen completes one where it
+## is staged rather than waiting for a press. `pokemon_requested` is here for
+## those and no further: `GivePoke`'s `.wildmon` branch reaches
+## `GiveANickname_YesNo`, so a screen that can draw one intercepts it in front of
+## this list and a driver that cannot settles it with the species name, which is
+## what NO answers.
 const UNATTENDED_REQUESTS: Array[StringName] = [
 	&"party_heal_requested", &"pokemon_requested", &"trade_requested",
-	&"contest_mon_requested",
-	## `GiveDratini` draws nothing at all: it rewrites four move slots in a row
-	## the party already holds and the script runs straight on.
-	&"dratini_moveset_requested",
+	&"contest_mon_requested", &"dratini_moveset_requested",
 ]
 
 
@@ -67,16 +64,14 @@ static func complete_runtime_request(
 			"request": request.duplicate(true),
 			"results": resumed,
 		}
-	## `_DisplayLinkRecord` draws a page over a save field and writes nothing, and
-	## a room console with no cable has nothing to exchange: both run to
-	## completion where they are staged. A screen that can draw either intercepts
-	## the request in front of this.
+	## `_DisplayLinkRecord` writes nothing and a room console with no cable has
+	## nothing to exchange, so both run to completion where they are staged. A
+	## screen that can draw either intercepts in front of this.
 	if kind in [&"battle_requested", &"swarm_requested",
 		&"link_record_requested", &"link_room_requested"]:
 		return {"ok": true, "handled": true, "results": world.complete_runtime_request(result)}
-	## None of the three reads cartridge data of its own: the region map's
-	## landmark, the bank dial's amount and whether `TryQuickSave` wrote are the
-	## whole answer, and the runner owns what is done with it.
+	## None of the three reads cartridge data: the landmark, the dial's amount and
+	## whether `TryQuickSave` wrote are the whole answer.
 	if kind in [
 		&"town_map_requested", &"mom_bank_dial_requested", &"quick_save_requested",
 	]:

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -42,6 +42,11 @@ const MOVEMENT_BIGDOLL: int = 0x21
 ## "big doll height".
 const BIG_OBJECT_SIZE: int = 2
 
+## What an object index names. Object zero is the player, which every object
+## command may name, so NONE_INDEX rather than PLAYER_INDEX is the refusal.
+const PLAYER_INDEX: int = -1
+const NONE_INDEX: int = -2
+
 const OBJECTTYPE_SCRIPT: int = 0
 const OBJECTTYPE_ITEMBALL: int = 1
 const OBJECTTYPE_TRAINER: int = 2

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -307,10 +307,6 @@ func flood_palette() -> PackedColorArray:
 	)
 
 
-func _tile_palettes() -> Array:
-	return _tile_palettes_for(_world.current_map, _world.current_tileset)
-
-
 ## The palettes the current map's tile strip was coloured with, which
 ## [method _atlas_for] already resolved and kept.
 func _current_palettes() -> Array:
@@ -849,12 +845,17 @@ func _draw_player(background: Vector2) -> Vector2:
 		_world.player_sprite(), _world.player_palette(), _world.player_drawn_facing(),
 		_world.player_walk_frame()
 	)
+	if not _world.player_visible():
+		## `disappear PLAYER` takes object zero out of OAM.
+		return player
 	if player_texture != null:
 		draw_texture(player_texture, player + jump)
 		if _in_grass(_world.player_cell):
 			_draw_grass_over(player + jump, background)
 		if _world.fishing_busy():
 			_draw_fishing_rod(player + jump)
+		if _world.player_emote() != Gen2WorldActors.EMOTE_NONE:
+			_draw_emote(_world.player_emote(), player + jump)
 	else:
 		var marker := Rect2(Vector2(player.x, player.y), Vector2(16, 16))
 		draw_rect(marker, PLAYER_COLOR, false, 1.0)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -187,6 +187,7 @@ var _nickname_answer: String = ""
 var _nickname_preview: bool = false
 ## `special NameRater`'s screen and the save whose party row it may rename.
 var _name_rater_host: Gen2NameRaterScreen = null
+var _rival_name_host: Gen2NamingScreenScreen = null
 var _name_rater_save: Gen2SaveData = null
 ## `special MoveDeletion`'s screen. It needs no save of its own beside it: the
 ## moves and their PP belong to the save it was handed and it writes them itself.
@@ -1217,6 +1218,7 @@ const FULLSCREEN_HOSTS: Array[StringName] = [
 	&"_hatch_host",
 	&"_nickname_host",
 	&"_name_rater_host",
+	&"_rival_name_host",
 	&"_move_deleter_host",
 	&"_move_tutor_host",
 	&"_day_care_host",
@@ -1331,41 +1333,27 @@ func press_button(button: int) -> bool:
 ## refusing the ones it has no use for, which is what keeps a stray press from
 ## reaching the map behind it.
 ## The overlays that own the whole screen, in the order a press is offered them.
+## Each runs with the map loop suspended behind it, by `givepoke`, `opentext` or
+## a `special` of its own, and owns every button until its own exit.
 const OVERLAY_HOSTS: Array[StringName] = [
-	## In front of every other overlay: `EvolveAfterBattle` runs with the map
-	## loop suspended, and the pack path reaches it with the pack still open
-	## behind it, so its B is the animation's cancel rather than the pack's back.
+	## In front of every other overlay: the pack path reaches `EvolveAfterBattle`
+	## with the pack still open behind it, so its B is the animation's cancel
+	## rather than the pack's back.
 	&"_evolution_host",
 	## `TradeAnimation` stands over whatever ran the trade, the trade room's own
 	## screen included, and answers no button.
 	&"_trade_anim_host",
-	## The same rule for `OverworldHatchEgg`, which `PlayerEvents` runs with the
-	## map loop suspended in exactly the same place.
 	&"_hatch_host",
-	## `GivePoke` runs inside `givepoke`, with the map loop suspended behind the
-	## script the same way, and its own naming screen is reached through it.
 	&"_nickname_host",
-	## `special NameRater` runs inside `opentext`, so the map loop is suspended
-	## behind it the same way and its own two screens are reached through it.
 	&"_name_rater_host",
-	## `special MoveTutor` and `special MoveDeletion`, the same shape again.
+	&"_rival_name_host",
 	&"_move_tutor_host",
 	&"_move_deleter_host",
-	## The Day-Care's five, one screen with the same shape again.
 	&"_day_care_host",
-	## `special UnownPrinter`, which owns the whole screen until B off its list.
 	&"_unown_printer_host",
-	## `special Diploma`, which owns the whole screen until a button, and
-	## `special PrintDiploma`, which owns it until B.
 	&"_diploma_host",
-	## `special UnownPuzzle`, which owns the whole screen until START or the
-	## last piece.
 	&"_unown_puzzle_host",
-	## `special SlotMachine`, which owns the whole screen until the player says
-	## no to another game or runs out of coins.
 	&"_slot_machine_host",
-	## `special CardFlip`, the Game Corner's other machine, which owns the screen
-	## on the same terms.
 	&"_card_flip_host",
 	## Before the PC and the party overlay because the Hall of Fame is the one
 	## overlay a script opens with nothing behind it: there is no map to go back
@@ -3187,6 +3175,7 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 		if nearest == null or object.cell.distance_squared_to(_world.player_cell) \
 			< nearest.cell.distance_squared_to(_world.player_cell):
 			nearest = object
+	_world.set_player_emote(0, true)
 	if nearest == null:
 		_script_prompt = "No visible object for the emote"
 	else:
@@ -7072,19 +7061,18 @@ const REQUEST_OPENERS: Dictionary = {
 	&"move_tutor_requested": [&"_open_move_tutor", &"continue", {}],
 	&"day_care_requested": [&"_open_day_care", &"continue", {}],
 	&"pokedex_entry_requested": [&"_open_pokedex_entry", &"continue", {}],
-	## A cartridge whose cache has no slots or card flip art gives the coins back
-	## untouched rather than stopping the script.
+	## No slots or card flip art gives the coins back rather than stopping.
 	&"slot_machine_requested": [&"_open_slot_machine", &"coins", {}],
 	&"card_flip_requested": [&"_open_card_flip", &"coins", {}],
-	## `ret z` on an empty dex, and the same answer for a cache with no glyphs or
-	## no diploma art: the script runs straight on and writes nothing either.
+	## `ret z` on an empty dex, and the same for a cache with no glyphs or art.
 	&"unown_printer_requested": [&"_open_unown_printer", &"values", {"ok": true}],
 	&"diploma_requested": [&"_open_diploma", &"values", {"ok": true}],
-	## A cache with no puzzle art answers an unsolved board, which is the
-	## `iftrue` the map takes either way.
+	## No puzzle art answers an unsolved board, the `iftrue` the map takes anyway.
 	&"unown_puzzle_requested": [
 		&"_open_unown_puzzle", &"values", {"ok": true, "script_value": 0},
 	],
+	## A cache with no keyboards answers blank, which `InitName` reads as SILVER.
+	&"rival_name_requested": [&"_open_rival_name", &"values", {"ok": true}],
 	&"pokemon_requested": [&"_open_gift_nickname", &"prompt", {}],
 	&"contest_mon_requested": [&"_open_contest_nickname", &"prompt", {}],
 }
@@ -7310,6 +7298,37 @@ func _open_requested_page(kind: StringName, request: Dictionary) -> StringName:
 
 func _open_link_record(_request: Dictionary) -> bool:
 	return _open_link_screen(Gen2LinkScreen.MODE_RECORD)
+
+
+func _open_rival_name(_request: Dictionary) -> bool:
+	if _rival_name_host != null or _world == null or _data == null:
+		return false
+	var host := Gen2NamingScreenScreen.new()
+	if not host.open(
+		_data, Gen2NamingScreenScreen.PROMPT_RIVAL, Gen2NamingScreenScreen.KIND_PLAYER
+	):
+		return false
+	host.closed.connect(_on_rival_named)
+	host.z_index = 30
+	_rival_name_host = host
+	_screen.display(host)
+	_script_prompt = "Rival's name"
+	_refresh_labels()
+	return true
+
+
+func _on_rival_named(entered: String) -> void:
+	var host: Gen2NamingScreenScreen = _rival_name_host
+	_rival_name_host = null
+	if host != null:
+		Gen2Screen.drop(host)
+	if _renderer != null:
+		_renderer.refresh()
+	if _world != null:
+		_show_script_results(
+			_world.complete_runtime_request({"ok": true, "name": entered})
+		)
+	_refresh_labels()
 
 
 func _request_trainer_approach(request: Dictionary) -> StringName:

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -570,10 +570,6 @@ static func is_promptbutton(opcode: int, crystal_commands: bool = true) -> bool:
 	return opcode == PROMPTBUTTON if crystal_commands else opcode == 0x54
 
 
-static func is_faceplayer(opcode: int, crystal_commands: bool = true) -> bool:
-	return opcode == FACEPLAYER if crystal_commands else opcode == GOLD_FACEPLAYER
-
-
 static func is_text_jump(opcode: int, crystal_commands: bool = true) -> bool:
 	return opcode in [FARJUMPTEXT, JUMPTEXT] if crystal_commands else opcode in [0x51, 0x52]
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -67,7 +67,7 @@ var _last_text: Dictionary = {}
 ## so the question a choice answers is the last text the script wrote; without it
 ## a host has nothing but the command's own name to print.
 var _standing_text: String = ""
-var _last_talked_object_index: int = -1
+var _last_talked_object_index: int = Gen2WorldObject.NONE_INDEX
 var _last_item: int = 0
 var _staged_warp: Dictionary = {}
 var _script_value: int = 0
@@ -489,6 +489,9 @@ const FRUIT_TREE_OBTAINED_TEXT: String = "Hey! It's\n%s!\nObtained\n%s!"
 const FRUIT_TREE_FULL_TEXT: String = "Hey! It's\n%s!\nBut the PACK is\nfull…"
 ## The `disappear LAST_TALKED` operand (constants/map_object_constants.asm).
 const LAST_TALKED: int = 0xFE
+## PLAYER and the first `object_const_def` id.
+const PLAYER_OBJECT_ID: int = 0
+const FIRST_MAP_OBJECT_ID: int = 2
 ## wBattleResult, which startbattle copies into wScriptVar
 ## (constants/battle_constants.asm).
 const BATTLE_RESULT_WIN: int = 0
@@ -671,7 +674,9 @@ static func begin(
 	else:
 		runner._random.randomize()
 	runner._reset_phone_receive_timer = bool(request.get("reset_receive_timer", false))
-	runner._last_talked_object_index = int(request.get("object_index", -1))
+	runner._last_talked_object_index = int(
+		request.get("object_index", Gen2WorldObject.NONE_INDEX)
+	)
 	runner._last_item = int(request.get("item", 0))
 	runner.player_name = String(request.get("player_name", ""))
 	var bank: int = int(request.get("bank", 0))
@@ -1262,7 +1267,11 @@ func _stage_yes_or_no(tag: StringName, values: Dictionary) -> Dictionary:
 
 
 ## What answers each runtime request the host has finished, as the handler that
-## reads it. The key is the pending request's own kind.
+## reads it. The key is the pending request's own kind. `_complete_plain_request`
+## puts the host's answer in wScriptVar and runs on, and for most of these that
+## answer is nothing: the routine drew a page, held for a button and wrote
+## nothing a script reads, and the map's own `waitbutton` presses what it left
+## standing. The five that do answer a value say so beside them.
 const COMPLETION_HANDLERS: Dictionary = {
 	&"catch_tutorial_requested": &"_complete_catch_tutorial",
 	&"swarm_requested": &"_complete_swarm",
@@ -1286,8 +1295,6 @@ const COMPLETION_HANDLERS: Dictionary = {
 	## `BugContestJudging` answers with the placing, which the results script
 	## reads out of wScriptVar exactly as the marts and the PC do.
 	&"bug_contest_judging_requested": &"_complete_plain_request",
-	## Neither routine writes anything a script reads: each returns and the
-	## map's own `waitbutton` presses the text it left standing.
 	&"name_rater_requested": &"_complete_plain_request",
 	&"move_deleter_requested": &"_complete_plain_request",
 	## `MoveTutor` answers FALSE when the move was learned and -1 when the
@@ -1299,25 +1306,17 @@ const COMPLETION_HANDLERS: Dictionary = {
 	## `CheckPartyFullAfterContest`'s own three answers, which
 	## `BugContestResults_DidNotLeaveMons` branches on twice.
 	&"contest_mon_requested": &"_complete_plain_request",
-	## `PlayRadio` holds until A or B and writes nothing; the station it
-	## opened is the request's own.
+	## `PlayRadio` opens the request's own station.
 	&"map_radio_requested": &"_complete_plain_request",
 	## `NewPokedexEntry` behind `GameCornerPrizeMonCheckDex`'s dex writes,
 	## which are staged here rather than in the screen.
 	&"pokedex_entry_requested": &"_complete_plain_request",
-	## `GiveDratini` rewrites four move slots and answers nothing: every one
-	## of its scripts runs straight on.
 	&"dratini_moveset_requested": &"_complete_plain_request",
-	## `_Diploma`, `_PrintDiploma` and `_UnownPrinter` write nothing either:
-	## the page stands until a button and the script runs on behind it.
 	&"diploma_requested": &"_complete_plain_request",
 	&"unown_printer_requested": &"_complete_plain_request",
 	## `TryQuickSave` answers TRUE for a save that was written and FALSE for
 	## one that was not, which is the branch both of its sites read.
 	&"quick_save_requested": &"_complete_plain_request",
-	## `_DisplayLinkRecord` draws one page and holds for a button, and the
-	## three link rooms' own consoles run their exchange and come back to a
-	## `newloadmap`. Neither writes anything the script reads.
 	&"link_record_requested": &"_complete_plain_request",
 	&"link_room_requested": &"_complete_plain_request",
 	&"rival_name_requested": &"_complete_rival_name",
@@ -1813,9 +1812,11 @@ func complete_wait() -> Dictionary:
 		return {
 			"ok": false, "status": &"failed", "reason": &"script_wait_not_pending",
 		}
-	var hide_emote_object: int = int(_pending.get("hide_emote_object", -1))
+	var hide_emote_object: int = int(
+		_pending.get("hide_emote_object", Gen2WorldObject.NONE_INDEX)
+	)
 	_pending = {}
-	if hide_emote_object >= 0:
+	if hide_emote_object != Gen2WorldObject.NONE_INDEX:
 		_emit_object_event(&"object_emote", {
 			"object_index": hide_emote_object,
 			"emote_id": _loaded_emote,
@@ -1953,8 +1954,6 @@ const COMMAND_HANDLERS: Dictionary = {
 	Gen2WorldScript.GIVEEGG: &"_command_givepoke",
 	Gen2WorldScript.GIVEPOKEMAIL: &"_command_givepokemail",
 	Gen2WorldScript.CHECKPOKEMAIL: &"_command_checkpokemail",
-	Gen2WorldScript.GOLD_FACEPLAYER: &"_command_gold_faceplayer",
-	Gen2WorldScript.FACEPLAYER: &"_command_gold_faceplayer",
 }
 
 ## The two commands with nothing behind them yet: `getnum` reads a number into
@@ -2531,10 +2530,6 @@ func _command_checkpokemail(_opcode: int, command: Dictionary, _bank: int) -> Di
 	return _check_poke_mail(command)
 
 
-func _command_gold_faceplayer(opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
-	if Gen2WorldScript.is_faceplayer(opcode, _crystal_commands()):
-		pass
-	return {"ok": true}
 ## A command whose numbers a mod may have moved, substituted before it runs.
 ##
 ## The site is addressed by the byte it sits at, `frame.address + offset`, which
@@ -3199,30 +3194,33 @@ func _command_battletowertext(_source_opcode: int, command: Dictionary, _bank: i
 	return _stage_battle_tower_text(int(command.get("value", 1)))
 
 
+func _apply_movement(object_index: int, address: int) -> Dictionary:
+	var walks_player: bool = object_index == Gen2WorldObject.PLAYER_INDEX
+	var values: Dictionary = {
+		"bank": int(_request.get("bank", 0)), "address": address,
+	}
+	if not walks_player:
+		values["object_index"] = object_index
+	_emit_object_event(
+		&"player_movement_requested" if walks_player else &"object_movement_requested",
+		values
+	)
+	return _stage_movement_wait({"object_index": object_index})
+
+
 func _execute_object_command(source_opcode: int, command: Dictionary) -> Dictionary:
 	match source_opcode:
 		0x67:
 			_last_talked_object_index = _object_index_from_id(int(command["object_id"]))
 		0x68:
-			var movement_event_type: StringName = &"player_movement_requested" \
-				if int(command.get("object_id", 0)) == 0 else &"object_movement_requested"
-			var movement_values: Dictionary = {
-				"bank": int(_request.get("bank", 0)),
-				"address": int(command.get("address", 0)),
-			}
-			var moved_index: int = -1
-			if movement_event_type == &"object_movement_requested":
-				moved_index = _object_index_from_id(int(command.get("object_id", 0)))
-				movement_values["object_index"] = moved_index
-			_emit_object_event(movement_event_type, movement_values)
-			return _stage_movement_wait({"object_index": moved_index})
+			return _apply_movement(
+				_object_index_from_id(int(command.get("object_id", 0))),
+				int(command.get("address", 0))
+			)
 		0x69:
-			_emit_object_event(&"object_movement_requested", {
-				"object_index": _last_talked_object_index,
-				"bank": int(_request.get("bank", 0)),
-				"address": int(command.get("address", 0)),
-			})
-			return _stage_movement_wait({"object_index": _last_talked_object_index})
+			return _apply_movement(
+				_last_talked_object_index, int(command.get("address", 0))
+			)
 		0x6A:
 			_face_player()
 		0x6B:
@@ -6275,13 +6273,13 @@ func _emit_runtime_event(kind: StringName, values: Dictionary) -> void:
 func _object_index_from_id(object_id: int) -> int:
 	if object_id in [0xFE, 0xFF]:
 		return _last_talked_object_index
-	if object_id == 0:
-		return -1
-	if object_id <= 0:
-		return -1
+	if object_id == PLAYER_OBJECT_ID:
+		return Gen2WorldObject.PLAYER_INDEX
+	if object_id < FIRST_MAP_OBJECT_ID:
+		return Gen2WorldObject.NONE_INDEX
 	# object_const_def starts map-object constants at 2. The cache omits the
 	# player object, so source id 2 is array index zero.
-	return object_id - 2
+	return object_id - FIRST_MAP_OBJECT_ID
 
 
 func _emit_object_event(event_type: StringName, values: Dictionary) -> void:

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -226,25 +226,28 @@ func test_badge_stat_boosts_are_active_battle_values_and_clear_cleanly() -> void
 
 ## Attract's "opposite gender" rule reads [method Gen2BattleMon.gender], which
 ## `GetGender` works out from the species ratio and the Attack and Speed DVs
-## combined into one byte, not a coin flip. Bulbasaur is 12.5% female (ratio 31);
-## Pikachu is an even 50/50 (ratio 127), which is why it checks the boundary,
-## since a combined value equal to the ratio reads female.
-func test_gender_reads_the_combined_dv_byte_against_the_species_ratio() -> void:
-	var mostly_male := func(attack: int, speed: int) -> Gen2BattleMon:
-		var dvs: int = Gen2Stats.pack_dvs(attack, 0, speed, 0)
-		return Gen2BattleMon.create(_data, Fixture.BULBASAUR, 50, [], dvs)
+## combined into one byte, not a coin flip. Counted over the whole 256-value
+## domain rather than sampled at the boundary: a sampled pair can be read
+## backwards, but the female share cannot, because each GENDER_F* constant is
+## named for the share it produces. Bulbasaur's ratio 31 is 32 of 256 and
+## Pikachu's 127 is 128 of 256, which is the 12.5% and the 50% they are named
+## for. A combined value equal to the ratio is female, so the count is ratio + 1.
+func test_the_female_share_of_the_dv_domain_is_the_ratio_the_species_is_named_for() -> void:
+	for species: int in [Fixture.BULBASAUR, Fixture.PIKACHU]:
+		var ratio: int = int(_data.species(species).get("gender_ratio", 255))
+		var female: int = 0
+		for attack: int in 16:
+			for speed: int in 16:
+				var dvs: int = Gen2Stats.pack_dvs(attack, 0, speed, 0)
+				if Gen2BattleMon.gender_for(_data, species, dvs) == &"female":
+					female += 1
+		assert_eq(female, ratio + 1, "species %d, ratio %d" % [species, ratio])
 
-	assert_eq(mostly_male.call(0, 0).gender(), &"male")
-	assert_eq(mostly_male.call(15, 15).gender(), &"female")
-
-	var even_odds := func(attack: int, speed: int) -> Gen2BattleMon:
-		var dvs: int = Gen2Stats.pack_dvs(attack, 0, speed, 0)
-		return Gen2BattleMon.create(_data, Fixture.PIKACHU, 50, [], dvs)
-
-	# 126 is one under Pikachu's own ratio of 127; 127 is the ratio itself, and
-	# the cartridge reads a value equal to the ratio as female, not male.
-	assert_eq(even_odds.call(7, 14).gender(), &"male")
-	assert_eq(even_odds.call(7, 15).gender(), &"female")
+	# The two ends of the domain, so the count above cannot pass on an inverted
+	# comparison that happens to answer the same total.
+	var perfect: int = Gen2Stats.pack_dvs(15, 0, 15, 0)
+	assert_eq(Gen2BattleMon.gender_for(_data, Fixture.BULBASAUR, perfect), &"male")
+	assert_eq(Gen2BattleMon.gender_for(_data, Fixture.BULBASAUR, 0), &"female")
 
 
 func test_gender_is_none_for_a_genderless_species() -> void:

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4219,6 +4219,71 @@ func test_object_visibility_override_survives_a_map_change() -> void:
 	assert_false(world.objects[0].active)
 
 
+## Object zero is the player, and `GetScriptObject` hands it to every object
+## command exactly as it hands over an NPC. Each row here is a real operand in
+## the corpus, counted by `tools/checks/world_scripts.gd`, and each was a silent
+## no-op while the runner answered "no object" for PLAYER: the cells were right,
+## so nothing that measured cells could see it. Raw Crystal opcodes, and PLAYER
+## is operand 0.
+func test_turnobject_on_the_player_turns_the_player() -> void:
+	var world: Gen2WorldAPI = _object_script_world([
+		0x76, 0, Gen2WorldSprite.FACING_RIGHT, Gen2WorldScript.END,
+	])
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_DOWN)
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_RIGHT)
+
+
+## `showemote EMOTE_SHOCK, PLAYER, 15` is the "!" over the player's own head, and
+## it is 49 of the corpus's `showemote` sites.
+func test_showemote_on_the_player_puts_the_bubble_over_the_player() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x75, 1, 0, 2, Gen2WorldScript.END])
+	assert_eq(world.dispatch_script_events()[0]["status"], &"waiting")
+	assert_eq(world.player_emote(), 1)
+	assert_false((world.objects[0] as Gen2WorldObject).emote_visible,
+		"the bubble belongs to the player, not to whatever sits at index zero")
+
+	for _frame: int in 3:
+		assert_true(world.advance_script_wait_frame().is_empty())
+	assert_eq(world.player_emote(), 1, "still up while the pause runs")
+	assert_eq(_final_status(world.advance_script_wait_frame()), &"complete")
+	assert_eq(world.player_emote(), Gen2WorldActors.EMOTE_NONE)
+
+
+## `faceobject PLAYER, LAST_TALKED` opens `SeenByTrainerScript`, so this is every
+## trainer who spots the player as well as the two receptionists who name an
+## object outright.
+func test_faceobject_on_the_player_turns_the_player_toward_the_object() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x6C, 0, 2, Gen2WorldScript.END])
+	assert_eq(world.player_cell, Vector2i(7, 6))
+	assert_eq((world.objects[0] as Gen2WorldObject).cell, Vector2i(5, 6))
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_eq(world.player_facing, Gen2WorldSprite.FACING_LEFT)
+
+
+## `disappear PLAYER` is `DeleteObjectStruct` on object zero, which takes the
+## player out of OAM. Lance's room is the corpus's one site, and the player is
+## gone from it while Mary runs about.
+func test_disappear_on_the_player_takes_the_player_out_of_the_drawing() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x6E, 0, Gen2WorldScript.END])
+	assert_true(world.player_visible())
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_false(world.player_visible())
+	assert_true((world.objects[0] as Gen2WorldObject).active,
+		"and no map object is deleted in its place")
+
+
+## A map load rebuilds every object struct, object zero included, so neither of
+## the two above outlives the map it ran on.
+func test_the_player_record_is_rebuilt_by_a_map_load() -> void:
+	var world: Gen2WorldAPI = _object_script_world([0x6E, 0, Gen2WorldScript.END])
+	assert_eq(world.dispatch_script_events()[0]["status"], &"complete")
+	assert_false(world.player_visible())
+	world.player_cell = Vector2i(6, 6)
+	assert_true(world.try_warp()["ok"])
+	assert_true(world.player_visible())
+
+
 ## Opens map 1/1 standing on the coordinate event at (7, 6) with
 ## [param script_bytes] behind it, so a test can drive one object command.
 func _object_script_world(script_bytes: Array) -> Gen2WorldAPI:

--- a/tests/unit/test_world_day_care.gd
+++ b/tests/unit/test_world_day_care.gd
@@ -21,10 +21,10 @@ const DITTO: int = Fixture.DITTO
 
 ## Two DV words giving opposite genders at GENDER_F50, whose Defense DVs and
 ## Special low bits differ so `.CheckDVs` does not refuse the pair. The Attack
-## and Speed nibbles are what `GetGender` reads: `$0` is male at a 127 ratio and
-## `$F` is female.
-const MALE_DVS: int = 0x0A05
-const FEMALE_DVS: int = 0xF3FE
+## and Speed nibbles are what `GetGender` reads: `$FF` is above a 127 ratio and
+## so male, `$00` is below it and so female.
+const MALE_DVS: int = 0xF3FE
+const FEMALE_DVS: int = 0x0A05
 
 const CACHE_ID: StringName = &"daycaretest"
 const CACHE_SHA1: String = "0123456789abcdef"

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -30,6 +30,30 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory())
 
 
+## Every runtime request the runner can stage has to reach something that draws
+## it, and the four tables below are the whole set of answers there are. Without
+## this, `special NameRival` staged a request nothing opened, so the policeman
+## asked the question and [Gen2WorldHost]'s default answered SILVER for the
+## player. A kind that genuinely has nothing to draw belongs in
+## [constant Gen2WorldHost.UNATTENDED_REQUESTS] with the reason beside it.
+func test_every_runtime_request_kind_reaches_a_screen_or_is_named_unattended() -> void:
+	var answered: Dictionary = {}
+	for kind: StringName in Gen2WorldScreen.REQUEST_HANDLERS:
+		answered[kind] = true
+	for kind: StringName in Gen2WorldScreen.REQUEST_OPENERS:
+		answered[kind] = true
+	for kind: StringName in Gen2WorldScreen.SERVICE_HOST_REQUESTS:
+		answered[kind] = true
+	for kind: StringName in Gen2WorldHost.UNATTENDED_REQUESTS:
+		answered[kind] = true
+	var unanswered: Array[StringName] = []
+	for kind: StringName in Gen2WorldScriptRunner.COMPLETION_HANDLERS:
+		if not answered.has(kind):
+			unanswered.append(kind)
+	assert_eq(unanswered, [] as Array[StringName],
+		"these staged requests reach no screen and are not named unattended")
+
+
 func test_mart_entries_use_imported_items_and_prices() -> void:
 	var mart: Dictionary = _data.world_mart(0)
 	var entries: Array = Gen2WorldMartHost.entries(_data, mart)

--- a/tools/checks/scripted_scenes.gd
+++ b/tools/checks/scripted_scenes.gd
@@ -22,6 +22,17 @@ const GUIDE_FOLLOWER_WAYPOINTS: Array[Vector2i] = [
 	Vector2i(10, 6), Vector2i(24, 11), Vector2i(24, 11),
 ]
 const GUIDE_MOVEMENT_FRAMES: Array[int] = [32, 48, 56, 64, 152, 16]
+## Which way the player looks at the box after each stream: the follow's own
+## answer, then `turnobject PLAYER` UP, UP, LEFT and RIGHT. Stream 6 has no box
+## behind it, and pokegold ships Crystal's guide script.
+const NO_TEXT_AFTER: int = -1
+const GUIDE_PLAYER_FACINGS: Array[int] = [
+	Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_UP,
+	Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_LEFT,
+	Gen2WorldSprite.FACING_RIGHT, NO_TEXT_AFTER,
+]
+## `turnobject CHERRYGROVECITY_GRAMPS, LEFT`, the object half of it.
+const GUIDE_GIFT_FACING: int = Gen2WorldSprite.FACING_LEFT
 const DUDE_MOVEMENT_FRAMES: Array[Array] = [[48, 48], [40, 40]]
 
 var _r: RefCounted = null
@@ -70,9 +81,22 @@ func _check_guide(game_id: StringName, data: GameData) -> void:
 			"%s: Guide Gent movement %d left the player at %s, expected %s." % [
 				game_id, index + 1, row.get("player"), GUIDE_FOLLOWER_WAYPOINTS[index],
 			])
+		_r.check(int(row.get("facing", -1)) == GUIDE_PLAYER_FACINGS[index],
+			"%s: Guide Gent movement %d ended with the player facing %d, expected %d." % [
+				game_id, index + 1, int(row.get("facing", -1)),
+				GUIDE_PLAYER_FACINGS[index],
+			])
 	_r.check(not (world.objects[GUIDE_OBJECT] as Gen2WorldObject).active,
 		"%s: Guide Gent did not disappear at his door." % game_id)
-	print("%s: Guide Gent %d movement frames" % [game_id, int(run_result.get("movement_frames", 0))])
+	if movements.size() == GUIDE_PLAYER_FACINGS.size():
+		_r.check(int((movements[4] as Dictionary).get("leader_facing", -1)) == GUIDE_GIFT_FACING,
+			"%s: Guide Gent faces %d for the gift, expected %d." % [
+				game_id, int((movements[4] as Dictionary).get("leader_facing", -1)),
+				GUIDE_GIFT_FACING,
+			])
+	print("%s: Guide Gent %d movement frames" % [
+		game_id, int(run_result.get("movement_frames", 0)),
+	])
 
 
 func _check_tutorial(game_id: StringName, data: GameData, trigger_index: int) -> void:
@@ -155,6 +179,12 @@ func _drain(world: Gen2WorldAPI, initial: Array, tracked_object: int) -> Diction
 		var input: Dictionary = world.pending_script_input()
 		var input_type: StringName = StringName(input.get("type", &""))
 		if input_type in [&"text", &"button"]:
+			## What the `turnobject` before this box left. A dropped turn moves
+			## nobody, so the waypoints above cannot see one.
+			if not movements.is_empty() and not (movements[-1] as Dictionary).has("facing"):
+				(movements[-1] as Dictionary)["facing"] = world.player_facing
+				(movements[-1] as Dictionary)["leader_facing"] = \
+					(world.objects[tracked_object] as Gen2WorldObject).facing
 			results = world.run_event_queue(true)
 			continue
 		if input_type in [&"choice", &"menu"]:

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -7,6 +7,20 @@ extends RefCounted
 ## parse failures and the unwired `0415` marker below come from too.
 const NOT_A_TEXT: Array[String] = ["96:4081"]
 
+## constants/map_object_constants.asm's PLAYER.
+const PLAYER_OBJECT_ID: int = 0
+
+## The commands the corpus points at PLAYER. Each writes the player's own struct
+## on hardware and is a silent no-op if the runtime drops object zero, and the
+## cells come out the same either way, so nothing that measures cells sees one.
+## All but two are proved in `tests/unit/test_world_api.gd`; `follow` is the
+## Cherrygrove guide in `scripted_scenes.gd`, and `follownotexact`, unused by
+## either pin, shares `follow`'s match arm. One unlisted here is unproved.
+const PLAYER_OPERAND_COMMANDS: Array[String] = [
+	"applymovement", "faceobject", "follow", "follownotexact",
+	"turnobject", "showemote", "disappear",
+]
+
 var _r: RefCounted = null
 
 ## Reports how far the cached overworld script and text resources can be read.
@@ -49,6 +63,7 @@ func _validate(game_id: StringName) -> bool:
 	var failure_reasons: Dictionary = {}
 	var failure_opcodes: Dictionary = {}
 	var command_names: Dictionary = {}
+	var player_operands: Dictionary = {}
 	for raw_key: Variant in (scripts_value as Dictionary):
 		# Read through GameData rather than off the JSON: the cache stores byte
 		# runs as spans into a blob, and this checks the path the runtime uses.
@@ -72,12 +87,18 @@ func _validate(game_id: StringName) -> bool:
 				break
 			var name: String = String(command.get("name", ""))
 			command_names[name] = int(command_names.get(name, 0)) + 1
+			_tally_object_operands(command, name, player_operands)
 			command_count += 1
 			steps += 1
 			offset += int(command["width"])
 			if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal_commands):
 				walk_end_count += 1
 				break
+
+	var unproved: Dictionary = {}
+	for name: String in player_operands:
+		if not PLAYER_OPERAND_COMMANDS.has(name):
+			unproved[name] = player_operands[name]
 
 	var invalid_text: int = 0
 	var invalid_text_reasons: Dictionary = {}
@@ -116,10 +137,24 @@ func _validate(game_id: StringName) -> bool:
 	print("  invalid_text_reasons=%s" % invalid_text_reasons)
 	print("  invalid_text_samples=%s" % JSON.stringify(invalid_text_samples))
 	print("  commands=%s" % command_names)
+	print("  player_operands=%s" % player_operands)
+	if not unproved.is_empty():
+		print("FAIL %s: %s name PLAYER and nothing proves the runtime reaches them" % [
+			game_id, unproved,
+		])
 	_print_ram_markers(data, ram_addresses, number_markers)
 	print("  raw_byte_markers=%s" % raw_bytes)
 	_print_standard_table(game_id)
-	return raw_bytes.is_empty()
+	return raw_bytes.is_empty() and unproved.is_empty()
+
+
+## Both operand keys are read, so `follow <NPC>, PLAYER` counts once.
+func _tally_object_operands(command: Dictionary, name: String, tally: Dictionary) -> void:
+	for key: String in ["object_id", "object_id_2"]:
+		if int(command.get(key, -1)) != PLAYER_OBJECT_ID:
+			continue
+		tally[name] = int(tally.get(name, 0)) + 1
+		return
 
 
 ## Resolves one "bank:address" cache key through the runtime accessor.

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -23,6 +23,16 @@ const CHECKPOINTS: Dictionary = {
 	&"silver": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2039},
 }
 
+## Who looks at whom while the text is up: Crystal's `turnobject PLAYER, LEFT`
+## and Mom's `turn_head RIGHT` against pokegold's walk downstairs and her own
+## `turnobject ..., UP`. The cells read the same whether those ran or not.
+const FACINGS_AT_TEXT: Dictionary = {
+	&"crystal": {&"player": Gen2WorldSprite.FACING_LEFT, &"mom": Gen2WorldSprite.FACING_RIGHT},
+	&"gold": {&"player": Gen2WorldSprite.FACING_DOWN, &"mom": Gen2WorldSprite.FACING_UP},
+	&"silver": {&"player": Gen2WorldSprite.FACING_DOWN, &"mom": Gen2WorldSprite.FACING_UP},
+}
+const FACING_NAMES: Array[String] = ["down", "up", "left", "right"]
+
 ## Both pieces are `channel_count 3` on all three profiles, so a fourth music
 ## channel on is the town still playing under `playmusic MUSIC_MOM`.
 const MUSIC_CHANNELS: int = 3
@@ -106,6 +116,8 @@ func _sample() -> Dictionary:
 		"player": world.player_cell,
 		"mom": mom.cell if mom != null else Vector2i(-1, -1),
 		"mom_offset": mom.step_offset_cells() if mom != null else Vector2.ZERO,
+		"player_facing": world.player_drawn_facing(),
+		"mom_facing": mom.facing if mom != null else -1,
 		"emote": mom != null and mom.emote_visible,
 		"text": _screen._text_box != null and _screen._text_box.visible,
 		"channels": _screen._audio_player.audio_status()["active_channels"],
@@ -160,9 +172,33 @@ func _checkpoints_hold() -> bool:
 		if at != want:
 			printerr("%s %s first appears on frame %d, not %d" % [_game, name, at, want])
 			held = false
+	held = _facings_hold() and held
 	held = _channels_hold() and held
 	print("%s checkpoints %s" % [_game, "hold" if held else "MOVED"])
 	return held
+
+
+func _facings_hold() -> bool:
+	var expected: Dictionary = FACINGS_AT_TEXT.get(_game, {})
+	var at: int = _first_frame(&"text")
+	if expected.is_empty() or at < 0 or at >= _trace.size():
+		return true
+	var row: Dictionary = _trace[at]
+	var held: bool = true
+	for who: StringName in expected:
+		var facing: int = int(row["%s_facing" % who])
+		var want: int = int(expected[who])
+		if facing == want:
+			continue
+		printerr("%s %s faces %s at the text, not %s" % [
+			_game, who, _facing_name(facing), _facing_name(want),
+		])
+		held = false
+	return held
+
+
+func _facing_name(facing: int) -> String:
+	return FACING_NAMES[facing] if facing >= 0 and facing < FACING_NAMES.size() else "?"
 
 
 func _channels_hold() -> bool:
@@ -204,11 +240,12 @@ func _report() -> void:
 			continue
 		last = without
 		changes += 1
-		print("f%4d  script %s  input %s  player %s  mom %s%s%s  text %s  chan %s  %s" % [
+		print("f%4d  script %s  input %s  player %s %s  mom %s %s%s%s  text %s  chan %s  %s" % [
 			row["frame"],
 			"busy" if row["script_busy"] else "idle",
 			"wait" if row["waiting_input"] else "-   ",
-			row["player"], row["mom"],
+			row["player"], _facing_name(int(row["player_facing"])),
+			row["mom"], _facing_name(int(row["mom_facing"])),
 			" stepping" if row["mom_offset"] != Vector2.ZERO else "",
 			" emote" if row["emote"] else "",
 			"up" if row["text"] else "-",

--- a/tools/preview_naming_screen.gd
+++ b/tools/preview_naming_screen.gd
@@ -6,7 +6,7 @@ extends SceneTree
 ##
 ##   Godot --path . -s res://tools/preview_naming_screen.gd -- crystal /tmp/name.png [presses]
 ##
-## A `mail` argument after the presses opens `_ComposeMailMessage` instead.
+## A `mail` argument opens `_ComposeMailMessage`, a `rival` one NAME_RIVAL.
 ## [presses] is a button script: `r`, `l`, `u`, `d`, `a`, `b`, `s` and `c`.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
@@ -48,9 +48,11 @@ func _initialize() -> void:
 	root.set_content_scale_size(WINDOW_SIZE)
 	root.size = WINDOW_SIZE
 	var mail: bool = args.has("mail")
+	var prompt: String = Gen2NamingScreenScreen.PROMPT_RIVAL if args.has("rival") \
+		else Gen2NamingScreenScreen.PROMPT_PLAYER
 	_screen = Gen2NamingScreenScreen.new()
 	if not _screen.open(
-		data, "" if mail else "YOUR NAME?",
+		data, "" if mail else prompt,
 		Gen2NamingScreenScreen.KIND_MAIL if mail else Gen2NamingScreenScreen.KIND_PLAYER
 	):
 		push_error("The %s cache carries no naming screen data." % args[0])
@@ -60,7 +62,8 @@ func _initialize() -> void:
 	root.add_child(_screen)
 	current_scene = _screen
 
-	var presses: String = args[2] if args.size() > 2 and args[2] != "mail" else ""
+	var presses: String = args[2] \
+		if args.size() > 2 and args[2] not in ["mail", "rival"] else ""
 	for key: String in presses:
 		if BUTTONS.has(key):
 			_screen.handle_button(int(BUTTONS[key]))


### PR DESCRIPTION
Four reported defects, each fixed at the seam every occurrence goes through rather than at the case that was named.

## The save editor always gave a female Pokemon

`GetGender` folds the Attack DV into a byte's high nibble and the Speed DV into its low, then runs `cp b` against the species ratio and takes `jr c` for male. A byte above the ratio is male; one equal to it is female. The port implemented the source's own comment over that branch, which reads the other way round, so the comparison was inverted.

Perfect DVs give a combined byte of 255, which is above every ratio, so every perfect-DV Pokemon read female: the save editor's, a Hall of Fame panel's, a box row's, the stats screen's glyph, both Day-Care parents, an egg's gender roll, Attract, and the in-game trades that require one.

The test that covered it sampled two DV pairs and was written from the same misreading, so it passed. It now counts the whole 256-value domain. The female share has to be `ratio + 1` of 256, which is exactly the percentage each `GENDER_F*` constant is named for: 32 of 256 for Bulbasaur's 12.5%, 128 of 256 for Pikachu's 50%. A share cannot be written backwards the way a sampled pair can.

## The old man faced you the wrong way, and Mum did not turn

`GetScriptObject` hands object zero, which is the player, to every object command. The runner resolved PLAYER to -1 and an invalid id to -1 as well, and every applier downstream refused -1, so the whole class was dropped:

| Command with a PLAYER operand | Gold sites | Crystal sites |
|---|---|---|
| `turnobject` | 138 | 187 |
| `applymovement` | 101 | 140 |
| `showemote` | 38 | 54 |
| `follow` | 17 | 25 |
| `disappear` | 2 | 2 |
| `faceobject` | 0 | 1 |

`applymovement`, `follow` and `faceobject` had their own PLAYER branches already. `turnobject`, `showemote` and `disappear` had none, so the player never turned, the "!" bubble never appeared over their head, and `disappear PLAYER` left them standing in Lance's room while Mary ran about.

The two answers are now separate named constants on `Gen2WorldObject`. The world API resolves object zero to a record of the player's own, which carries what those commands write beyond the cell, facing and sprite it already had. A map load rebuilds it exactly as `ReadObjectEvents` clears every other object struct.

Second cause, same cutscene: a follower's facing was written when the stream was queued rather than when each step began. A whole stream queues in one call, so the Cherrygrove guide turned the player to the last leg of the walk on the frame he set off and dragged them around facing that way. The facing rides the queued step now, which is what an object's own `queue_step` has always done and what `MovementFunction_Follow` does on hardware.

## The policeman would not let you type a name

`special NameRival` staged a runtime request that no screen opened, so it fell through to the host, whose default is what `InitName` puts in for a blank entry: SILVER. It opens the naming screen under `NAME_RIVAL`'s prompt now.

## What would have found each, and what will find the next one

The four defects are four blind spots, and each is now closed by something that sweeps rather than samples.

**Measure the facing, not just the cell.** `tools/checks/scripted_scenes.gd` already drove the whole Cherrygrove tour and `tools/preview_mom_scene.gd` already traced the Mom scene frame by frame. Both measured where everyone ended up, and a cell reads the same whether a `turnobject` ran or was dropped. Both now pin who is looking at whom when each box goes up, on all three cartridges. Run against the old code, they name the defect on the first try.

**Census the corpus, then require a proof per row.** `tools/checks/world_scripts.gd` already walked every cached script on all three profiles. It now counts every object command the corpus points at PLAYER and fails on one that nothing has proved the runtime reaches. The list is short and each row names where it is proved, so a command that turns up unlisted is a real gap rather than a warning.

**Sweep the domain instead of the boundary.** A sampled pair can be written from the same misreading as the code it checks. Anything whose ceiling, share or count is named by a constant should be counted over its whole domain, because the name is the thing that cannot be inverted.

**Ask the structural question about every entry, not the one in front of you.** A test now asserts that every runtime request the runner can stage reaches a screen, a service host or `Gen2WorldHost.UNATTENDED_REQUESTS`. `rival_name_requested` was the only gap; the next one fails the suite instead of shipping.

## Met on the way

Three unreferenced functions, a dead `faceplayer` handler `_execute_object_command` had already answered, an unused profile predicate behind it, a redundant branch in the object id resolver, a Day-Care fixture whose two DV words were named from the inverted rule, and several comment blocks restating what their own table doc said.

## Proving it

| Check | Result |
|---|---|
| Unit tier | 3513 tests, 0 failures |
| Full tier with scenes | 4111 tests, 0 failures |
| `validate.gd -- all` | 82 topics pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 16 badges each, 292 to 295 steps |
| Editor analyser | 0 warnings in 607 scripts |
| Boot smoke test | exit 0 |
| Comment budget | 37875 of 37875 |