### PR TITLE
Answer the map's music and the field-move boxes the way the source does

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1655,12 +1655,10 @@ func copyright_palette() -> PackedColorArray:
 	return colors
 
 
-## One of the pack's five texts (`oak_no_time`, `no_mon`, `toss_ask`,
-## `toss_ask_quantity`, `toss_threw`) or the six a field item says
-## (`escape_rope`, `itemfinder_nearby`, `itemfinder_nope`, `sacred_ash`,
-## `squirtbottle`, `coin_case`), still carrying [Gen2TextStream]'s markers
-## for the quantity, the player and the item name. Empty on a cache imported before them,
-## which is the caller's cue to use its own wording.
+## One of the pack's own boxes or the ones a field item says, by the name
+## `RomImporter.PACK_TEXT_OPENINGS` gives it, still carrying [Gen2TextStream]'s
+## markers. Empty on a cache imported before it, which is the caller's cue to use
+## its own wording.
 func menu_text(key: String) -> String:
 	return String(_menu_text.get(key, ""))
 

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -2362,8 +2362,7 @@ const INTRO_TEXT_OPENINGS: Dictionary = {
 
 
 ## What each pack text opens with once its `text` macro byte is past. Short
-## anchors, the way the intro texts are anchored.
-## The pack's own five, and the six a field item says. Every one is
+## anchors, the way the intro texts are anchored. Every one is
 ## `data/text/common_*.asm`, which no other importer reads, so each is pinned by
 ## its own opening rather than by a table.
 const PACK_TEXT_OPENINGS: Dictionary = {
@@ -2379,6 +2378,9 @@ const PACK_TEXT_OPENINGS: Dictionary = {
 	## MENU_DESCRIPTION_FIRST does.
 	"sacred_ash": "<PLAYER>'s POKéMON",
 	"squirtbottle": "<PLAYER> sprinkled",
+	"cant_get_off_bike": "You can't get off",
+	"got_on_bike": "<PLAYER> got on the",
+	"got_off_bike": "<PLAYER> got off",
 	"coin_case": "Coins:",
 	"blue_card": "You now have",
 	"sent_trophy_home": "There was a trophy",

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -2214,10 +2214,10 @@ const GOLD_SILVER: Dictionary = {
 	## Nested the way the trainer card is, so the -1 for what Gold and Silver do
 	## not ship stays out of the flat offset checks. `_OakText3` is a bare
 	## `text_promptbutton` and carries no words, so it has no offset here.
-	# `engine/menus/start_menu.asm`'s description run and `data/text/common_2.asm`'s
-	# five pack texts, encoded from the source and matched. Each hits once per
-	# dump except the two refusals, which the cartridge copies elsewhere too; the
-	# offsets below are the common_2 copy beside the toss texts.
+	# `engine/menus/start_menu.asm`'s description run and the `data/text/common_2.asm`
+	# boxes the pack and the field items say, encoded from the source and matched.
+	# Each hits once per dump except the two refusals and the bike's two name lines,
+	# copied elsewhere too; these are the copy beside the toss texts.
 	"menu_text": {
 		"descriptions": 0x12B15,
 		"oak_no_time": 0x1945B2,
@@ -2231,6 +2231,9 @@ const GOLD_SILVER: Dictionary = {
 		"itemfinder_nope": 0x19446D,
 		"sacred_ash": 0x194529,
 		"squirtbottle": 0x1944FF,
+		"cant_get_off_bike": 0x19435E,
+		"got_on_bike": 0x194376,
+		"got_off_bike": 0x19438B,
 		# `_CoinCaseCountText` ends with `done` rather than `text_end` here, so
 		# `DoTextUntilTerminator` indexes `TextCommands` with $57 and runs off
 		# the table: the arbitrary code execution pokegold's own comment names.
@@ -2861,6 +2864,9 @@ const CRYSTAL: Dictionary = {
 		"itemfinder_nope": 0x1C0AA9,
 		"sacred_ash": 0x1C0B65,
 		"squirtbottle": 0x1C0B3B,
+		"cant_get_off_bike": 0x1C099A,
+		"got_on_bike": 0x1C09B2,
+		"got_off_bike": 0x1C09C7,
 		"coin_case": 0x1C5C7B,
 		"blue_card": 0x1C5C5E,
 		"sent_trophy_home": 0x1C5D03,

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1374,6 +1374,8 @@ func _use_field_item(item: int) -> void:
 		## `CantUseItem`, which is the one thing the two jumptables disagree on.
 		_show_pack_result(_use_refusal(&"item_effect_failed", item), false)
 		return
+	## `.CheckIfRegistered`: the Bicycle's two scripts each have a silent copy.
+	request["registered"] = _using_registered
 	field_item_used.emit(request)
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -281,37 +281,22 @@ var block_revision: int = 0
 ## cartridge would have drawn, so the player keeps the place
 ## [constant PLAYER_VIEW_CELL] puts him in and only the surround grows.
 var view_pixels: Vector2i = VIEW_PIXELS
-## A resolved but uncommitted Cut, held between cut_request() and complete_cut()
-## the way Script_Cut holds wCutWhirlpool* across its writetext. Cleared with the
-## block overrides, since the block it names belongs to the loaded map.
+## One resolved but uncommitted field move each, held between its `*_request()`
+## and `complete_*()` the way Script_Cut holds wCutWhirlpool* across its
+## writetext. Every one is cleared with the loaded map, since a request cannot
+## outlive the map it was made on: most name a cell, block or object index that
+## belongs to it, and Strength, Flash and the escapes, which name none, would
+## otherwise refuse every later use with `*_in_progress`.
 var _pending_cut: Dictionary = {}
-## The same for Surf, held between surf_request() and complete_surf() while
-## UsedSurfScript shows its text. The cell it names belongs to the loaded map,
-## so it is cleared beside the Cut request.
 var _pending_surf: Dictionary = {}
-## The same for Whirlpool, which shares the source's wCutWhirlpool* slots with
-## Cut and is cleared beside it for the same reason.
 var _pending_whirlpool: Dictionary = {}
-## The same for Strength, held while Script_UsedStrength shows its text. It names
-## no cell or block, but it is cleared with the others anyway: the source queues
-## Script_StrengthFromMenu and runs it at once, so a request cannot outlive the
-## map it was made on.
 var _pending_strength: Dictionary = {}
-## The same for Waterfall, held while Script_UsedWaterfall shows its text. It
-## names the faced cell, so it is cleared with the loaded map like the rest.
+var _pending_escape: Dictionary = {}
 var _pending_waterfall: Dictionary = {}
-## The same for Flash. It names no cell or block, but it is cleared with the
-## others so a request left unacknowledged across a map load cannot refuse every
-## later Flash with flash_in_progress.
 var _pending_flash: Dictionary = {}
-## The same for Headbutt, held while HeadbuttScript shows UseHeadbuttText. It
-## names the faced tree, so it is cleared with the loaded map like the rest;
-## the encounter behind it is only rolled on the commit, since TreeMonEncounter
-## runs after that text.
+## The encounter behind this one is rolled on the commit, since TreeMonEncounter
+## runs after UseHeadbuttText.
 var _pending_headbutt: Dictionary = {}
-## The same for Rock Smash, held while RockSmashScript shows UseRockSmashText.
-## It names the faced rock's object index, so it is cleared with the loaded map
-## like the rest.
 var _pending_rock_smash: Dictionary = {}
 ## wPlayerID, mirrored from the selected save the way _party_summary mirrors
 ## its party. GetTreeScore is the only reader; -1 means no save has set one,
@@ -587,22 +572,57 @@ func _init_map_name_sign() -> void:
 	_map_name_sign = current
 
 
-## GetMapMusic_MaybeSpecial: SpecialMapMusic answers first, so a surfing player
-## carries MUSIC_SURF across map loads and warps. Its Bug Contest branch has no
-## counterpart here, since no contest timer exists.
+## `GetMapMusic`'s two special header values and what it answers them with, the
+## same numbers on all three cartridges.
+const MUSIC_MAHOGANY_MART: int = 0x64
+const RADIO_TOWER_MUSIC: int = 0x80
+const MUSIC_CHERRYGROVE_CITY: int = 0x26
+const MUSIC_ROCKET_HIDEOUT: int = 0x48
+const MUSIC_BUG_CATCHING_CONTEST_RANKING: int = 0x58
+
+
+## GetMapMusic_MaybeSpecial: SpecialMapMusic answers first, so MUSIC_SURF crosses
+## map loads and the two National Park gates play the ranking piece for a contest.
 func map_music_track() -> int:
 	if movement_mode == MOVEMENT_SURF:
 		return Gen2WorldFieldMove.MUSIC_SURF
-	## `BikeFunction` writes `wMapMusic` itself rather than going through
-	## `SpecialMapMusic`, so the track is the bike's until the player gets off.
+	if _is_national_park_gate() and bug_contest_active():
+		return MUSIC_BUG_CATCHING_CONTEST_RANKING
+	## `BikeFunction` writes `wMapMusic` itself; `SpecialMapMusic`'s own `.bike`
+	## branch is unreferenced.
 	if movement_mode == MOVEMENT_BIKE:
 		return Gen2WorldFieldMove.MUSIC_BICYCLE
-	return current_map.music if current_map != null else Gen2WorldState.MUSIC_NONE
+	return _map_header_music()
 
 
-## PlayMapMusic on map entry. Answers whether the track actually changed, which
-## is both the source's own "do not restart the same piece" rule and what keeps
-## a tuned radio station playing until the player leaves the map.
+func _is_national_park_gate() -> bool:
+	return current_map != null and current_map.group == NATIONAL_PARK_GATE_GROUP \
+		and NATIONAL_PARK_GATE_MAPS.has(current_map.number)
+
+
+## `GetMapMusic`: a raw header is the wrong piece on six maps. The Radio Tower's
+## five carry `RADIO_TOWER_MUSIC | MUSIC_GOLDENROD_CITY`, $BD unmasked.
+func _map_header_music() -> int:
+	if current_map == null:
+		return Gen2WorldState.MUSIC_NONE
+	var header: int = current_map.music
+	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
+	if header == MUSIC_MAHOGANY_MART:
+		return MUSIC_ROCKET_HIDEOUT if state.is_engine_flag_active(
+			Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_ROCKETS_IN_MAHOGANY, crystal)
+		) else MUSIC_CHERRYGROVE_CITY
+	if (header & RADIO_TOWER_MUSIC) == 0:
+		return header
+	if state.is_engine_flag_active(Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER, crystal
+	)):
+		return Gen2WorldRadio.MUSIC_ROCKET_OVERTURE
+	return header & (RADIO_TOWER_MUSIC - 1)
+
+
+## PlayMapMusic, which every map entry and every change of movement mode runs.
+## Answers whether the track actually changed, which is both the source's own "do
+## not restart the same piece" rule and what keeps a tuned station playing.
 func _apply_map_music() -> bool:
 	return state.play_map_music(map_music_track())
 
@@ -1447,6 +1467,7 @@ func complete_surf() -> Dictionary:
 	movement_mode = MOVEMENT_SURF
 	player_sprite_number = int(request["sprite"])
 	player_cell = request["cell"]
+	_apply_map_music()
 	_start_player_step(request["direction"], STEP_PASSES_NPC_WALK, false, &"slow_step")
 	return {
 		"ok": true,
@@ -5940,6 +5961,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 	if exiting_water:
 		movement_mode = MOVEMENT_WALK
 		player_sprite_number = _walking_sprite()
+		_apply_map_music()
 		kind = &"exit_water"
 	elif movement_mode == MOVEMENT_SURF:
 		kind = &"water_move"
@@ -6318,6 +6340,7 @@ func _apply_map(
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
 	_pending_strength.clear()
+	_pending_escape.clear()
 	_pending_waterfall.clear()
 	_pending_headbutt.clear()
 	_pending_rock_smash.clear()
@@ -6584,8 +6607,8 @@ static func _sweet_scent_failure(reason: StringName) -> Dictionary:
 
 ## `TeleportFunction`: the outdoor-only escape to the last Pokemon Center, whose
 ## whole test is the map being outdoors and that spawn being a spawn point. No
-## badge. Applied rather than staged, since everything in `.TeleportScript` but
-## [method _escape_map_tail] is animation this project has no frames for.
+## badge. Staged rather than applied: `.TeleportScript` prints its line on the
+## map being left and spends `pause 60` before `special WarpToSpawnPoint`.
 func teleport_request() -> Dictionary:
 	if current_map == null:
 		return _teleport_failure(&"missing_map")
@@ -6596,15 +6619,7 @@ func teleport_request() -> Dictionary:
 	var spawn: int = spawn_index_of(last_spawn_map)
 	if spawn < 0:
 		return _teleport_failure(&"no_spawn_point")
-	var warped: Dictionary = warp_to_spawn(spawn)
-	if not bool(warped.get("ok", false)):
-		return _teleport_failure(StringName(warped.get("reason", &"missing_spawn")))
-	return {
-		"ok": true,
-		"kind": &"teleport_requested",
-		"move": Gen2WorldFieldMove.MOVE_TELEPORT,
-		"warp": warped,
-	}
+	return _stage_escape(&"teleport_requested", Gen2WorldFieldMove.MOVE_TELEPORT, spawn)
 
 
 static func _teleport_failure(reason: StringName) -> Dictionary:
@@ -6622,15 +6637,7 @@ func dig_request() -> Dictionary:
 	var checked: StringName = _check_can_dig()
 	if checked != &"":
 		return _dig_failure(checked)
-	var warped: Dictionary = warp_to_dig_point()
-	if not bool(warped.get("ok", false)):
-		return _dig_failure(StringName(warped.get("reason", &"no_dig_warp")))
-	return {
-		"ok": true,
-		"kind": &"dig_requested",
-		"move": Gen2WorldFieldMove.MOVE_DIG,
-		"warp": warped,
-	}
+	return _stage_escape(&"dig_requested", Gen2WorldFieldMove.MOVE_DIG, -1)
 
 
 ## `DoPlayerMovement`'s own speed for a committed step: `STEP_BIKE` while riding,
@@ -6647,9 +6654,9 @@ func _step_frames_for_movement() -> int:
 
 
 ## `BikeFunction`'s `.TryBike`: `.CheckEnvironment` first, then the state the
-## player is in. Getting off is refused while `BIKEFLAGS_ALWAYS_ON_BIKE_F` is
-## set, which is `Script_CantGetOffBike`; the two get-on and get-off scripts are
-## the caller's, since both are text and a sprite update.
+## player is in. `BIKEFLAGS_ALWAYS_ON_BIKE_F` queues `Script_CantGetOffBike`
+## rather than refusing, so `.done` answers 1 and the pack closes on its line.
+## The three scripts are the caller's, each being text and a sprite update.
 func bike_request() -> Dictionary:
 	if current_map == null:
 		return _bike_failure(&"missing_map")
@@ -6658,20 +6665,22 @@ func bike_request() -> Dictionary:
 	if movement_mode == MOVEMENT_WALK:
 		movement_mode = MOVEMENT_BIKE
 		player_sprite_number = Gen2WorldSprite.player_bike_sprite(_player_female)
+		_apply_map_music()
 		return {
 			"ok": true, "kind": &"bike_on",
-			"music": Gen2WorldFieldMove.MUSIC_BICYCLE,
+			"music": state.map_music(),
 			"sprite": player_sprite_number,
 		}
 	if movement_mode != MOVEMENT_BIKE:
 		return _bike_failure(&"cannot_use_bike")
 	if always_on_bike():
-		return _bike_failure(&"always_on_bike")
+		return {"ok": true, "kind": &"bike_cant_get_off", "sprite": player_sprite_number}
 	movement_mode = MOVEMENT_WALK
 	player_sprite_number = _walking_sprite()
+	_apply_map_music()
 	return {
 		"ok": true, "kind": &"bike_off",
-		"music": map_music_track(),
+		"music": state.map_music(),
 		"sprite": player_sprite_number,
 	}
 
@@ -6712,15 +6721,40 @@ func escape_rope_request() -> Dictionary:
 	var wall_event: int = unown_wall_event(EVENT_WALL_OPENED_IN_KABUTO_CHAMBER)
 	if wall_event >= 0:
 		state.set_event_flag(wall_event, true)
-	var warped: Dictionary = warp_to_dig_point()
+	var staged: Dictionary = _stage_escape(&"escape_rope_requested", 0, -1)
+	staged["wall_event"] = wall_event
+	_pending_escape["wall_event"] = wall_event
+	return staged
+
+
+## The three escapes print their line on the map they leave: a `waitbutton` or
+## `pause 60` sits behind it and `special WarpToSpawnPoint` behind that.
+## [param spawn] below zero is the recorded dig warp rather than a spawn.
+func _stage_escape(kind: StringName, move_id: int, spawn: int) -> Dictionary:
+	_pending_escape = {"ok": true, "kind": kind, "move": move_id, "spawn": spawn}
+	return _pending_escape.duplicate(true)
+
+
+func pending_escape() -> Dictionary:
+	return _pending_escape.duplicate(true)
+
+
+## The warp the staged escape owes, taken once its line has been acknowledged.
+func complete_escape() -> Dictionary:
+	if _pending_escape.is_empty():
+		return {"ok": false, "kind": &"escape_failed", "reason": &"no_pending_escape"}
+	var staged: Dictionary = _pending_escape
+	_pending_escape = {}
+	var spawn: int = int(staged["spawn"])
+	var warped: Dictionary = warp_to_spawn(spawn) if spawn >= 0 else warp_to_dig_point()
 	if not bool(warped.get("ok", false)):
-		return _escape_rope_failure(StringName(warped.get("reason", &"no_dig_warp")))
-	return {
-		"ok": true,
-		"kind": &"escape_rope_requested",
-		"warp": warped,
-		"wall_event": wall_event,
-	}
+		return {
+			"ok": false, "kind": &"escape_failed",
+			"reason": StringName(warped.get("reason", &"no_dig_warp")),
+		}
+	staged["kind"] = &"escape_applied"
+	staged["warp"] = warped
+	return staged
 
 
 ## `.CheckCanDig`: a cave or a dungeon, and all three bytes of the recorded dig
@@ -7054,6 +7088,7 @@ func reload_current_map() -> Dictionary:
 	_pending_surf.clear()
 	_pending_whirlpool.clear()
 	_pending_strength.clear()
+	_pending_escape.clear()
 	_pending_waterfall.clear()
 	_pending_headbutt.clear()
 	_pending_rock_smash.clear()

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -41,25 +41,19 @@ const BADGE_HIVE: int = 1
 const BADGE_PLAIN: int = 2
 const BADGE_FOG: int = 3
 const BADGE_GLACIER: int = 6
-## `.TryFly`'s own `CheckBadge ENGINE_STORMBADGE`, the sixth badge.
 const BADGE_STORM: int = 5
-## WaterfallFunction's .TryWaterfall: ENGINE_RISINGBADGE.
 const BADGE_RISING: int = 7
-## FlashFunction's .CheckUseFlash: ENGINE_ZEPHYRBADGE, the least of the eight.
 const BADGE_ZEPHYR: int = 0
 
 ## GetSurfType's comparison, constants/pokemon_constants.asm.
 const SPECIES_PIKACHU: int = 0x19
 
-## `SpecialMapMusic` returns this ahead of the map header's while the player is
-## surfing, so it belongs to Surf. `UsedSurfScript` calls no PlaySFX.
+## The two tracks `Gen2WorldAPI.map_music_track` names for a player not walking.
 const MUSIC_SURF: int = 0x21
-## `BikeFunction` writes this to `wMapMusic`, so it survives a map load.
 const MUSIC_BICYCLE: int = 0x13
 
-## Which badge each gated field move asks `CheckBadge` for, as the badge-order
-## index the constants above are. A move that is not here has no badge gate:
-## Headbutt, Rock Smash, Dig, Teleport, Sweet Scent and the two heals.
+## Which badge each gated field move asks `CheckBadge` for. A move that is not
+## here has none: Headbutt, Rock Smash, Dig, Teleport, Sweet Scent and the heals.
 const MOVE_BADGES: Dictionary = {
 	MOVE_CUT: BADGE_HIVE,
 	MOVE_SURF: BADGE_FOG,
@@ -154,8 +148,7 @@ const HM_FIELD_MOVES: Array[int] = [
 
 ## What each move's own script writes, from data/text/common_2.asm, kept here
 ## because the party submenu, the A-press prompt and the script runner all say
-## them. `%s` is `GetPartyNickname`'s buffer and each break is the source's own
-## `line`, which a name short enough to fit one line would otherwise lose.
+## them. `%s` is `GetPartyNickname`'s buffer and each break the source's `line`.
 const USED_TEXTS: Dictionary = {
 	MOVE_CUT: "%s used\nCUT!",
 	MOVE_SURF: "%s used\nSURF!",
@@ -171,6 +164,9 @@ const USED_TEXTS: Dictionary = {
 	MOVE_FLASH: "A blinding FLASH\nlights the area!",
 	MOVE_TELEPORT: "Return to the last\n#MON CENTER.",
 }
+
+## `Script_UsedStrength`'s second box, which both callers of the first reach.
+const MOVE_BOULDERS_TEXT: String = "%s can\nmove boulders."
 
 ## `FieldMoveFailed`'s `_CantUseItemText`, shared by every move with no refusal
 ## of its own, and the five that have one.
@@ -188,6 +184,10 @@ const SWEET_SCENT_NOTHING_TEXT: String = "Looks like there's\nnothing here…"
 static func used_text(move: int, user: String) -> String:
 	var text: String = String(USED_TEXTS.get(move, ""))
 	return text % user if text.contains("%s") else text
+
+
+static func move_boulders_text(user: String) -> String:
+	return MOVE_BOULDERS_TEXT % user
 
 
 static func is_field_move(move: int) -> bool:

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -458,7 +458,8 @@ static func audio_for_request(world: Gen2WorldAPI, request: Dictionary) -> Dicti
 		&"map_music", &"encounter_music":
 			if world.current_map == null:
 				return {}
-			return data.world_audio(&"music", world.current_map.music)
+			## `GetMapMusic_MaybeSpecial`, never the raw header byte.
+			return data.world_audio(&"music", world.map_music_track())
 	return {}
 
 

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -14,9 +14,8 @@ const PCPCITEM_OAKS_PC: int = 2
 const PCPCITEM_HALL_OF_FAME: int = 3
 const PCPCITEM_TURN_OFF: int = 4
 
-## `PokemonCenterPC.WhichPC`, the three lists `.ChooseWhichPCListToUse` picks
-## between: before the Pokedex, after it, and after the Hall of Fame. The lists
-## themselves are imported.
+## `PokemonCenterPC.WhichPC`, the three imported lists `.ChooseWhichPCListToUse`
+## picks between: before the Pokedex, after it, and after the Hall of Fame.
 const PCPC_BEFORE_POKEDEX: int = 0
 const PCPC_BEFORE_HOF: int = 1
 const PCPC_POSTGAME: int = 2
@@ -194,9 +193,9 @@ static func _entries(data: GameData, owned: Dictionary) -> Array:
 	return out
 
 
-## `PlayerDepositItemMenu`: the stack leaves `wNumItems` for `wNumPCItems`. An
-## item whose `CheckItemMenu` attribute is one of the three `.no_toss` rows is
-## refused, which is what keeps a key item out of the PC.
+## `PlayerDepositItemMenu`: the stack leaves `wNumItems` for `wNumPCItems`.
+## `.TryDepositItem` refuses only the three `CheckItemMenu` values no item
+## carries, so a key item goes in at the quantity `_CheckTossableItem` picks.
 static func deposit(
 	world: Gen2WorldAPI, save: Gen2SaveData, item: int, quantity: int = 1,
 	persist: bool = true
@@ -204,8 +203,7 @@ static func deposit(
 	return _transfer(world, save, item, quantity, true, persist)
 
 
-## `PlayerWithdrawItemMenu`, which is the same move the other way and refuses
-## nothing: anything in the PC came out of the bag.
+## `PlayerWithdrawItemMenu`, the same move the other way and refusing nothing.
 static func withdraw(
 	world: Gen2WorldAPI, save: Gen2SaveData, item: int, quantity: int = 1,
 	persist: bool = true
@@ -249,8 +247,6 @@ static func _transfer(
 	var definition: Dictionary = world.data.item(item)
 	if definition.is_empty():
 		return Gen2WorldTransaction.failure(&"unknown_item", {"item": item})
-	if to_pc and not Gen2WorldPack.can_toss(world.data, item):
-		return Gen2WorldTransaction.failure(&"item_cannot_be_deposited", {"item": item})
 	var bag: int = world.state.item_quantity(item)
 	var pc: int = world.state.pc_item_quantity(item)
 	var source: int = bag if to_pc else pc

--- a/game/world/world_radio.gd
+++ b/game/world/world_radio.gd
@@ -28,20 +28,22 @@ const NUM_RADIO_CHANNELS_GOLD_SILVER: int = 10
 ## data/radio/channel_music.asm's RadioChannelSongs, by canonical channel id.
 ## The Gold/Silver table is this one without its Buena's row, so indexing by
 ## channel rather than by position keeps one copy.
-const CHANNEL_SONGS: Array[int] = [
-	29,  # MUSIC_POKEMON_TALK
-	9,   # MUSIC_POKEMON_CENTER
-	1,   # MUSIC_TITLE
-	18,  # MUSIC_GAME_CORNER
-	96,  # MUSIC_BUENAS_PASSWORD, Crystal only
-	21,  # MUSIC_VIRIDIAN_CITY
-	19,  # MUSIC_BICYCLE
-	86,  # MUSIC_ROCKET_OVERTURE
-	64,  # MUSIC_POKE_FLUTE_CHANNEL
-	75,  # MUSIC_RUINS_OF_ALPH_RADIO
-	90,  # MUSIC_LAKE_OF_RAGE_ROCKET_RADIO
-]
+const MUSIC_POKEMON_TALK: int = 29
+const MUSIC_POKEMON_CENTER: int = 9
+const MUSIC_TITLE: int = 1
+const MUSIC_GAME_CORNER: int = 18
+const MUSIC_BUENAS_PASSWORD: int = 96
+const MUSIC_VIRIDIAN_CITY: int = 21
+const MUSIC_ROCKET_OVERTURE: int = 86
 const MUSIC_POKE_FLUTE_CHANNEL: int = 64
+const MUSIC_RUINS_OF_ALPH_RADIO: int = 75
+const MUSIC_LAKE_OF_RAGE_ROCKET_RADIO: int = 90
+const CHANNEL_SONGS: Array[int] = [
+	MUSIC_POKEMON_TALK, MUSIC_POKEMON_CENTER, MUSIC_TITLE, MUSIC_GAME_CORNER,
+	MUSIC_BUENAS_PASSWORD, MUSIC_VIRIDIAN_CITY, Gen2WorldFieldMove.MUSIC_BICYCLE,
+	MUSIC_ROCKET_OVERTURE, MUSIC_POKE_FLUTE_CHANNEL, MUSIC_RUINS_OF_ALPH_RADIO,
+	MUSIC_LAKE_OF_RAGE_ROCKET_RADIO,
+]
 ## constants/music_constants.asm. Neither is a real track: they are the two
 ## sentinels `ExitPokegearRadio_HandleMusic` compares
 ## `wPokegearRadioMusicPlaying` against, which is why a tuned station's own id

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -45,6 +45,13 @@ const SFX_WATERFALL: int = 0x51
 ## constants/sfx_constants.asm's SFX_FLASH, played by `UseFlashTextScript`'s own
 ## `text_asm` rather than by `BlindingFlash`, which fades in silence.
 const SFX_FLASH: int = 0xA9
+const FIELD_MOVE_TEXT_RUNS_ON: Array[int] = [
+	Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.MOVE_FLASH,
+	Gen2WorldFieldMove.MOVE_TELEPORT,
+]
+## `.TeleportScript`'s `pause 60`, two frames a unit, where the other two
+## escapes spend a `waitbutton`.
+const TELEPORT_PAUSE_FRAMES: int = 120
 ## constants/sfx_constants.asm's SFX_SANDSTORM, which is what ShakeHeadbuttTree
 ## plays (engine/events/field_moves.asm). SFX_HEADBUTT is a battle-move effect
 ## and is referenced by nothing in either pin's overworld code.
@@ -252,6 +259,10 @@ var _player_event_after: Callable = Callable()
 ## page ends in `<DONE>` does not: `MapTextbox` prints and returns, and the
 ## press is the `waitbutton` behind the command.
 var _text_awaits_press: bool = true
+## Whether the field-move box up now owes a press, and the frames it spends
+## first when it does not.
+var _field_move_text_waits: bool = true
+var _field_move_text_frames: int = 0
 ## How many presses [method preview_text_scroll] will spend looking for one.
 const PREVIEW_TEXT_PRESSES: int = 8
 ## `ProfOaksPCBoot`'s three texts, one page at a time, and the sfx `Rate` leaves
@@ -1026,6 +1037,7 @@ func _advance_waits(map_pass: bool) -> void:
 	## `_ContText`'s scroll ends on a frame rather than on a press, and the page
 	## it lands on may be the text's last, which is where the script runs on.
 	_continue_if_text_settled()
+	_continue_if_field_move_text_settled()
 	if not _trainer_approach.is_empty():
 		_advance_trainer_approach(map_pass)
 	if _world != null and _world.phone_ring_active():
@@ -6192,22 +6204,10 @@ func _on_field_item_used(request: Dictionary) -> void:
 		return
 	match StringName(request.get("effect", &"")):
 		Gen2WorldPack.FIELD_EFFECT_BICYCLE:
-			## `Script_GetOnBike` and `Script_GetOffBike`, both of which are a
-			## line, a `waitbutton` and `special UpdatePlayerSprite`. The music is
-			## the function's own rather than either script's.
-			var on: bool = StringName(
-				(request.get("bike", {}) as Dictionary).get("kind", &"")
-			) == &"bike_on"
-			var bike_name: String = _data.item_name(int(request.get("item", 0)))
-			_show_field_move_text(
-				"Got on the\n%s." % bike_name if on else "Got off\nthe %s." % bike_name
-			)
-			_play_current_map_music()
-			if _renderer != null:
-				_renderer.refresh()
+			_on_bike_used(request)
+		## Printed on the map being left; the acknowledge takes the warp.
 		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
 			_show_field_move_text(_field_item_text("escape_rope", "Used an\nESCAPE ROPE."))
-			_refresh_after_escape()
 		Gen2WorldPack.FIELD_EFFECT_ROD:
 			var rods: Array[StringName] = _world.available_fishing_rods()
 			select_fishing_rod(rods.find(StringName(request.get("rod", &""))))
@@ -6245,6 +6245,33 @@ func _on_field_item_used(request: Dictionary) -> void:
 					"squirtbottle", "Sprinkled water.\nBut nothing\nhappened…"
 				))
 	_refresh_labels()
+
+
+## `BikeFunction`'s three scripts. Each of the two that say a line has a
+## `_Register` copy with none, so the Bicycle used from SELECT is silent.
+func _on_bike_used(request: Dictionary) -> void:
+	var kind: StringName = StringName(
+		(request.get("bike", {}) as Dictionary).get("kind", &"")
+	)
+	if kind == &"bike_cant_get_off":
+		_show_field_move_text(
+			_field_item_text("cant_get_off_bike", "You can't get off\nhere!")
+		)
+		return
+	if not bool(request.get("registered", false)):
+		var bike_name: String = _data.item_name(int(request.get("item", 0)))
+		var on: bool = kind == &"bike_on"
+		var line: String = _field_item_text(
+			"got_on_bike" if on else "got_off_bike",
+			"<PLAYER> got on the\n%s." % bike_name if on \
+				else "<PLAYER> got off\nthe %s." % bike_name
+		)
+		_show_field_move_text(
+			Gen2TextStream.fill_marker(line, Gen2TextStream.RAM_MARKER, bike_name)
+		)
+	_play_current_map_music()
+	if _renderer != null:
+		_renderer.refresh()
 
 
 ## One of `data/text/common_2.asm`'s field-item lines, with `<PLAYER>` filled
@@ -6373,7 +6400,8 @@ func _field_move_rows(slot: int, user: String) -> Dictionary:
 		],
 		Gen2WorldFieldMove.MOVE_STRENGTH: [
 			_world.strength_request.bind(_party_species(slot)), _strength_refusal,
-			says.call(Gen2WorldFieldMove.MOVE_STRENGTH), Callable(),
+			says.call(Gen2WorldFieldMove.MOVE_STRENGTH),
+			_after_strength.bind(slot, user),
 		],
 		Gen2WorldFieldMove.MOVE_WHIRLPOOL: [
 			_world.whirlpool_request, _whirlpool_refusal,
@@ -6403,13 +6431,14 @@ func _field_move_rows(slot: int, user: String) -> Dictionary:
 			_sweet_scent_refusal.bind(user),
 			says.call(Gen2WorldFieldMove.MOVE_SWEET_SCENT), _after_sweet_scent,
 		],
+		## Both print on the map being left, so the warp is the acknowledge's.
 		Gen2WorldFieldMove.MOVE_DIG: [
 			_world.dig_request, _field_move_refused,
-			says.call(Gen2WorldFieldMove.MOVE_DIG), _after_escape,
+			says.call(Gen2WorldFieldMove.MOVE_DIG), Callable(),
 		],
 		Gen2WorldFieldMove.MOVE_TELEPORT: [
 			_world.teleport_request, _field_move_refused,
-			says.call(Gen2WorldFieldMove.MOVE_TELEPORT), _after_escape,
+			says.call(Gen2WorldFieldMove.MOVE_TELEPORT), Callable(),
 		],
 	}
 
@@ -6431,10 +6460,20 @@ func _run_field_move(action: Dictionary) -> void:
 		)
 		return
 	if not String(row[2]).is_empty():
-		_show_field_move_text(row[2])
+		var runs_on: bool = FIELD_MOVE_TEXT_RUNS_ON.has(move)
+		_show_field_move_text(
+			row[2], not runs_on, not runs_on,
+			TELEPORT_PAUSE_FRAMES if move == Gen2WorldFieldMove.MOVE_TELEPORT else 0
+		)
 	var after: Callable = row[3]
 	if after.is_valid():
 		after.call(answer)
+
+
+## `Script_UsedStrength` past its first box: `cry 0` on `wStrengthSpecies`.
+func _after_strength(_answer: Dictionary, slot: int, user: String) -> void:
+	_play_species_cry(_party_species(slot))
+	_player_event_texts.append(Gen2WorldFieldMove.move_boulders_text(user))
 
 
 func _after_sweet_scent(answer: Dictionary) -> void:
@@ -6444,10 +6483,6 @@ func _after_sweet_scent(answer: Dictionary) -> void:
 		"values": found["values"],
 		"encounter": found.duplicate(true),
 	})
-
-
-func _after_escape(_answer: Dictionary) -> void:
-	_refresh_after_escape()
 
 
 ## GetSurfType reads wPartySpecies at wCurPartyMon; the submenu action carries
@@ -6650,24 +6685,43 @@ func _run_heal_transfer(action: Dictionary) -> void:
 	if not bool(result.get("ok", false)):
 		_show_field_move_text("It won't have any effect.")
 		return
-	## `PARTYMENUTEXT_HEAL_HP`, which is the line every healing item shares.
-	## `ItemActionText` is followed by `JoyWaitAorB`, which loads no cursor, so
-	## the line waits without an arrow the way `ProfOaksPCBoot`'s pages do.
+	## `PARTYMENUTEXT_HEAL_HP`, behind `ItemActionText`'s own `JoyWaitAorB`,
+	## which waits without an arrow the way `ProfOaksPCBoot`'s pages do.
 	_show_field_move_text(
 		"%s\nrecovered health!" % String(action.get("target_name", "")), false
 	)
 
 
 ## [param blink_cursor] is whether the wait behind the line is one of the three
-## routines that call `LoadBlinkingCursor`, not whether it waits at all.
-func _show_field_move_text(text: String, blink_cursor: bool = true) -> void:
+## routines that call `LoadBlinkingCursor`, not whether it waits at all;
+## [param waits] is whether it waits, and [param frames] how many it spends
+## first when it does not.
+func _show_field_move_text(
+	text: String, blink_cursor: bool = true, waits: bool = true, frames: int = 0
+) -> void:
 	_field_move_text = true
+	_field_move_text_waits = waits
+	_field_move_text_frames = frames
 	if _text_box != null and _text_box.font != null:
 		_apply_text_box_options()
 		_text_box.show_text(text, blink_cursor)
 		_text_box.visible = true
-	_script_prompt = "A: continue"
+	_script_prompt = "A: continue" if waits else ""
 	_refresh_labels()
+
+
+## The three used-texts with no press behind them: `_UseStrengthText`, which the
+## `cry 0` and second box follow, `_BlindingFlashText`, whose `text_asm` plays
+## SFX_FLASH and returns a blank, and `_TeleportReturnText` with its `pause 60`.
+func _continue_if_field_move_text_settled() -> void:
+	if not _field_move_text or _field_move_text_waits or _text_box == null:
+		return
+	if _text_box.is_scrolling() or _text_box.has_pages_left():
+		return
+	if _field_move_text_frames > 0:
+		_field_move_text_frames -= 1
+		return
+	_acknowledge_field_move_text()
 
 
 ## The acknowledge that closes a field-move message. A staged move commits here
@@ -6717,6 +6771,9 @@ func _acknowledge_field_move_text() -> void:
 	if not _world.pending_flash().is_empty():
 		_commit_field_move(_world.complete_flash(), "Flash")
 		return
+	if not _world.pending_escape().is_empty():
+		_commit_field_move(_world.complete_escape(), "Escape")
+		return
 	if not _world.pending_headbutt().is_empty():
 		_commit_field_move(_world.complete_headbutt(_encounter_random), "Headbutt")
 		return
@@ -6739,6 +6796,10 @@ func _commit_field_move(applied: Dictionary, label: String) -> void:
 				_play_sfx(SFX_WHIRLPOOL)
 			&"strength_applied":
 				pass
+			## `.UsedDigOrEscapeRopeScript`'s sound, in front of its own warp.
+			&"escape_applied":
+				_play_sfx(SFX_WARP_TO)
+				_refresh_after_escape()
 			&"waterfall_applied":
 				_play_sfx(SFX_WATERFALL)
 			&"flash_used":
@@ -7249,6 +7310,8 @@ func _apply_text_pause(event: Dictionary, flags: Dictionary) -> StringName:
 	# `writetext` whose text ends in `done` reaches none of them, so its last page
 	# carries no arrow and the script runs straight on.
 	_text_awaits_press = bool(event.get("prompt", true))
+	if int(event.get("cry", 0)) > 0:
+		_play_species_cry(int(event["cry"]))
 	if _oak_pc_pages.is_empty():
 		_apply_text_box_options()
 		_text_box.show_text(String(event.get("text", "")), _text_awaits_press)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1033,10 +1033,9 @@ func _resume_pocket_is_full(_choice: int) -> Dictionary:
 	return _waiting_result()
 
 
-## Script_UsedStrength's second writetext, _MoveBoulderText.
 func _resume_strength_used(_choice: int) -> Dictionary:
 	_stage_internal_text(
-		"%s can\nmove boulders." % String(_pending.get("name", "#MON")), true
+		Gen2WorldFieldMove.move_boulders_text(String(_pending.get("name", "#MON"))), true
 	)
 	return _waiting_result()
 
@@ -6488,18 +6487,21 @@ func _field_move_user_name(slot: int) -> String:
 	return String(names[slot]) if slot < names.size() else "#MON"
 
 
-## SetStrengthFlag plus Script_UsedStrength's two texts. The cry and its three
-## frame pause are presentation the runner does not own, so the two writetexts
-## become two pauses back to back, which is what a reader sees either way.
+## SetStrengthFlag plus Script_UsedStrength. `_UseStrengthText` ends in `done`
+## with no `waitbutton` behind it, so its box owes no press, and the `cry 0` is
+## `wStrengthSpecies`. Only `pause 3` is dropped, six frames before the next box.
 func _stage_strength_used(slot: int) -> Dictionary:
 	_staged_engine_flags[Gen2WorldState.strength_active_flag(_crystal_commands())] = true
 	var name: String = _field_move_user_name(slot)
+	var species: Array = _request.get("party", {}).get("species", [])
 	_pending = {
 		"type": &"text",
 		"text": Gen2WorldFieldMove.used_text(
 			Gen2WorldFieldMove.MOVE_STRENGTH, name
 		),
 		"internal_text": true,
+		"prompt": false,
+		"cry": int(species[slot]) if slot >= 0 and slot < species.size() else 0,
 		"special": &"strength_used",
 		"name": name,
 		"source": _request.duplicate(true),

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -1480,6 +1480,8 @@ const ENGINE_SAFARI_ZONE: int = 18
 ## Five entries further down the same run (data/events/engine_flags.asm), so it
 ## shifts on Gold and Silver the way every flag past ENGINE_MOBILE_SYSTEM does.
 const ENGINE_REACHED_GOLDENROD: int = 22
+## The last entry of the same run, which `GetMapMusic` reads in Mahogany Mart.
+const ENGINE_ROCKETS_IN_MAHOGANY: int = 23
 ## `ENGINE_DAILY_BUG_CONTEST`, the once-a-day flag the officer checks.
 const ENGINE_DAILY_BUG_CONTEST: int = 81
 ## `BugCatchingContestantEventFlagTable`, whose ten entries are the same numbers

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -540,8 +540,8 @@ func test_submenu_lists_strength_for_a_mon_that_knows_it() -> void:
 
 
 ## .TryStrength checks the badge and stops, so the entry resolves facing open
-## floor with no boulder in sight, and the flag waits for the acknowledge the way
-## Cut's block change does.
+## floor with no boulder in sight. `Script_UsedStrength` is two boxes, and the
+## flag waits for the second one's acknowledge the way Cut's block change does.
 func test_choosing_strength_shows_the_message_and_defers_the_flag() -> void:
 	await _open_strength_world()
 	var world: Gen2WorldAPI = _world_screen._world
@@ -549,11 +549,14 @@ func test_choosing_strength_shows_the_message_and_defers_the_flag() -> void:
 	var party: Gen2PartyScreen = await _open_party()
 	party.handle_button(Gen2Button.A)
 	party.handle_button(Gen2Button.A)
+	## `_UseStrengthText` ends in `done` with no `waitbutton` behind it, so this
+	## box is up before a frame passes and gone after one.
+	assert_eq(_shown_text(), "TESTMON used STRENGTH!")
 	await get_tree().process_frame
 
 	assert_null(_world_screen._party_host)
 	assert_true(_world_screen._field_move_text)
-	assert_eq(_shown_text(), "TESTMON used STRENGTH!")
+	assert_eq(_shown_text(), "TESTMON can move boulders.")
 	assert_false(world.strength_active())
 
 	_world_screen._acknowledge_field_move_text()

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -275,6 +275,23 @@ func _shown_text() -> String:
 	return " ".join(_world_screen._text_box.text_lines())
 
 
+## Frames [method _settle] will spend. A box that runs on without a press waits
+## for its own scroll first, and how long that takes belongs to the text speed
+## and the length of the message rather than to a constant a test can pin.
+const SETTLE_FRAMES: int = 120
+
+
+## Spends host frames until [param predicate] holds. One `await process_frame`
+## is one frame of the host, not one of the screen, and a loaded runner leaves
+## the two a frame or more apart.
+func _settle(predicate: Callable) -> bool:
+	for _frame: int in SETTLE_FRAMES:
+		if bool(predicate.call()):
+			return true
+		await get_tree().process_frame
+	return bool(predicate.call())
+
+
 func _labels(items: Array) -> Array:
 	var out: Array = []
 	for entry: Dictionary in items:
@@ -549,14 +566,16 @@ func test_choosing_strength_shows_the_message_and_defers_the_flag() -> void:
 	var party: Gen2PartyScreen = await _open_party()
 	party.handle_button(Gen2Button.A)
 	party.handle_button(Gen2Button.A)
-	## `_UseStrengthText` ends in `done` with no `waitbutton` behind it, so this
-	## box is up before a frame passes and gone after one.
+	## `_UseStrengthText` ends in `done` with no `waitbutton` behind it, so the
+	## first box is up before a frame passes and runs on once its own scroll has
+	## settled.
 	assert_eq(_shown_text(), "TESTMON used STRENGTH!")
-	await get_tree().process_frame
+	assert_true(await _settle(func() -> bool:
+		return _shown_text() == "TESTMON can move boulders."
+	), "the second box never arrived")
 
 	assert_null(_world_screen._party_host)
 	assert_true(_world_screen._field_move_text)
-	assert_eq(_shown_text(), "TESTMON can move boulders.")
 	assert_false(world.strength_active())
 
 	_world_screen._acknowledge_field_move_text()

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37875
+const MAX_COMMENT_LINES: int = 37870
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2298,6 +2298,10 @@ func test_boulder_script_asks_and_a_yes_sets_the_flag() -> void:
 
 	var used: Array = world.run_event_queue(true, 0)
 	assert_eq(String(used[0]["event"]["text"]), "CHIKORITA used\nSTRENGTH!")
+	## `_UseStrengthText` ends in `done` with no `waitbutton` behind it, and the
+	## `cry 0` after it names `wStrengthSpecies`.
+	assert_false(bool(used[0]["event"]["prompt"]), "the first box owes no press")
+	assert_eq(int(used[0]["event"]["cry"]), 25, "the fixture party's own species")
 
 	var boulders: Array = world.run_event_queue(true)
 	assert_eq(String(boulders[0]["event"]["text"]), "CHIKORITA can\nmove boulders.")

--- a/tests/unit/test_world_bag_host.gd
+++ b/tests/unit/test_world_bag_host.gd
@@ -139,13 +139,19 @@ func test_a_stack_moves_between_the_bag_and_the_pc_and_back() -> void:
 	assert_eq(_world.state.pc_item_quantity(POTION), 0, "an emptied stack is gone")
 
 
-## `.no_toss` keeps a key item out of the PC, which is the same permission bit
-## TOSS reads.
-func test_a_key_item_cannot_be_deposited() -> void:
+## `.TryDepositItem`'s jumptable is `CheckItemMenu`'s value, not the CANT_TOSS
+## bit: a key item's is `ITEMMENU_CLOSE`, which is one of its four `.tossable`
+## rows, so the PC takes it. `TossItemFromPC` is what refuses it afterwards.
+func test_a_key_item_is_deposited_and_then_cannot_be_tossed() -> void:
 	var result: Dictionary = Gen2WorldPC.deposit(_world, _save, KEY_ITEM, 1, false)
-	assert_false(bool(result["ok"]))
-	assert_eq(result["reason"], &"item_cannot_be_deposited")
-	assert_eq(_world.state.pc_item_quantity(KEY_ITEM), 0)
+	assert_true(bool(result["ok"]), String(result.get("reason", "")))
+	assert_eq(_world.state.pc_item_quantity(KEY_ITEM), 1)
+	assert_eq(_world.state.item_quantity(KEY_ITEM), 0)
+
+	var tossed: Dictionary = Gen2WorldPC.toss(_world, _save, KEY_ITEM, 1, false)
+	assert_false(bool(tossed["ok"]))
+	assert_eq(tossed["reason"], &"item_cannot_be_tossed")
+	assert_eq(_world.state.pc_item_quantity(KEY_ITEM), 1)
 
 
 ## `.NoRoomInPC`: `ReceiveItem` fails before anything leaves the bag, so a full

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1612,6 +1612,10 @@ func test_dig_takes_the_warp_the_cave_was_entered_by() -> void:
 
 	var dug: Dictionary = world.dig_request()
 	assert_true(bool(dug.get("ok", false)), String(dug.get("reason", "")))
+	## `.UsedDigScript` prints on the map being left and warps behind its
+	## `waitbutton`, so the request stages and the acknowledge moves.
+	assert_eq(world.map_id(), Vector2i(1, ESCAPE_CAVE))
+	assert_true(bool(world.complete_escape().get("ok", false)))
 	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
 	assert_eq(world.player_cell, ESCAPE_CAVE_DOOR)
 
@@ -1650,6 +1654,7 @@ func test_an_escape_aborts_a_running_contest_and_clears_both_status_flags() -> v
 	world.player_cell = Vector2i(4, 4)
 
 	assert_true(bool(world.dig_request().get("ok", false)))
+	assert_true(bool(world.complete_escape().get("ok", false)))
 	assert_false(world.state.is_engine_flag_active(timer), "the contest is over")
 	assert_false(world.state.is_engine_flag_active(safari))
 	assert_true(
@@ -1670,6 +1675,7 @@ func test_an_escape_with_no_contest_running_owes_the_party_nothing() -> void:
 	world.try_warp()
 	world.player_cell = Vector2i(4, 4)
 	assert_true(bool(world.escape_rope_request().get("ok", false)))
+	assert_true(bool(world.complete_escape().get("ok", false)))
 	assert_false(world.take_contest_abort())
 	## `Script_AbortBugContest`'s `iffalse .finish` jumps the setflag too.
 	assert_false(world.state.is_engine_flag_active(daily))
@@ -1686,15 +1692,70 @@ func test_the_bike_goes_on_and_off_outdoors_and_carries_its_own_music() -> void:
 	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER_BIKE)
 	assert_eq(world.map_music_track(), Gen2WorldFieldMove.MUSIC_BICYCLE)
 
+	assert_eq(world.state.map_music(), Gen2WorldFieldMove.MUSIC_BICYCLE,
+		"`.GetOnBike` writes `wMapMusic` before it plays it")
+	assert_eq(int(on["music"]), Gen2WorldFieldMove.MUSIC_BICYCLE)
+
 	var off: Dictionary = world.bike_request()
 	assert_true(bool(off.get("ok", false)), String(off.get("reason", "")))
 	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
 	assert_eq(world.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER)
 	assert_ne(world.map_music_track(), Gen2WorldFieldMove.MUSIC_BICYCLE)
+	assert_eq(world.state.map_music(), world.current_map.music,
+		"`Script_GetOffBike`'s `special PlayMapMusic` puts the map's own back")
+
+
+## `SpecialMapMusic`'s surf branch reaches `wMapMusic` through
+## `UsedSurfScript`'s `special PlayMapMusic`, and `.ExitWater` spends another one.
+func test_surfing_puts_the_surf_track_in_wmapmusic_and_landing_takes_it_out() -> void:
+	var world: Gen2WorldAPI = _surf_world()
+	var map_track: int = world.current_map.music
+	assert_true(bool(world.surf_request().get("ok", false)))
+	assert_true(bool(world.complete_surf().get("ok", false)))
+	assert_eq(world.state.map_music(), Gen2WorldFieldMove.MUSIC_SURF)
+
+	_drain_player_step(world)
+	assert_eq(StringName(world.move_result(Vector2i.UP)["kind"]), &"exit_water")
+	assert_eq(world.state.map_music(), map_track)
+
+
+## `GetMapMusic`: the two header values that name a pair of tracks rather than
+## one, and `SpecialMapMusic`'s own contest branch.
+func test_the_two_special_map_headers_and_the_contest_gate_pick_their_own_track() -> void:
+	var world: Gen2WorldAPI = _escape_world()
+	var crystal: bool = Gen2WorldState.is_crystal_profile(world.data)
+	var mahogany: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_ROCKETS_IN_MAHOGANY, crystal
+	)
+	var tower: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER, crystal
+	)
+
+	world.current_map.music = Gen2WorldAPI.MUSIC_MAHOGANY_MART
+	assert_eq(world.map_music_track(), Gen2WorldAPI.MUSIC_CHERRYGROVE_CITY)
+	world.state.set_engine_flag(mahogany, true)
+	assert_eq(world.map_music_track(), Gen2WorldAPI.MUSIC_ROCKET_HIDEOUT)
+
+	## `RadioTower1F`'s own header: the bit plus MUSIC_GOLDENROD_CITY.
+	world.current_map.music = Gen2WorldAPI.RADIO_TOWER_MUSIC | 0x3D
+	assert_eq(world.map_music_track(), 0x3D, "the bit is masked off, not asked for")
+	world.state.set_engine_flag(tower, true)
+	assert_eq(world.map_music_track(), Gen2WorldRadio.MUSIC_ROCKET_OVERTURE)
+
+	world.current_map.music = 0x0A
+	assert_eq(world.map_music_track(), 0x0A, "an ordinary header is itself")
+	world.state.set_engine_flag(
+		Gen2WorldState.engine_flag(Gen2WorldState.ENGINE_BUG_CONTEST_TIMER, crystal), true
+	)
+	assert_eq(world.map_music_track(), 0x0A, "this map is not one of the two gates")
+	world.current_map.group = Gen2WorldAPI.NATIONAL_PARK_GATE_GROUP
+	world.current_map.number = Gen2WorldAPI.NATIONAL_PARK_GATE_MAPS[0]
+	assert_eq(world.map_music_track(), Gen2WorldAPI.MUSIC_BUG_CATCHING_CONTEST_RANKING)
 
 
 ## `.CheckEnvironment` again: a cave is a place to ride and an indoor map is not,
-## and `.GetOffBike` refuses while BIKEFLAGS_ALWAYS_ON_BIKE_F is set.
+## and `.GetOffBike` runs `Script_CantGetOffBike` while BIKEFLAGS_ALWAYS_ON_BIKE_F
+## is set.
 func test_the_bike_is_refused_indoors_and_cannot_be_left_where_it_is_forced() -> void:
 	var indoors: Gen2WorldAPI = _escape_world(ESCAPE_POKECENTER, Vector2i(4, 4))
 	assert_eq(StringName(indoors.bike_request()["reason"]), &"cannot_use_bike")
@@ -1703,7 +1764,9 @@ func test_the_bike_is_refused_indoors_and_cannot_be_left_where_it_is_forced() ->
 	assert_true(bool(cave.bike_request().get("ok", false)), "a cave is rideable")
 
 	cave.state.set_engine_flag(Gen2WorldState.always_on_bike_flag(cave.data), true)
-	assert_eq(StringName(cave.bike_request()["reason"]), &"always_on_bike")
+	var forced_off: Dictionary = cave.bike_request()
+	assert_eq(StringName(forced_off["kind"]), &"bike_cant_get_off")
+	assert_true(bool(forced_off["ok"]), "`.done` answers 1, so the pack closes on the line")
 	assert_eq(cave.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE, "still riding")
 
 
@@ -1739,6 +1802,7 @@ func test_an_escape_rope_takes_the_same_warp_dig_does_and_knows_no_move() -> voi
 
 	var escaped: Dictionary = world.escape_rope_request()
 	assert_true(bool(escaped.get("ok", false)), String(escaped.get("reason", "")))
+	assert_true(bool(world.complete_escape().get("ok", false)))
 	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
 	assert_eq(world.player_cell, ESCAPE_CAVE_DOOR)
 
@@ -1762,6 +1826,7 @@ func test_teleport_returns_to_the_last_pokemon_centre_from_outdoors() -> void:
 
 	var teleported: Dictionary = world.teleport_request()
 	assert_true(bool(teleported.get("ok", false)), String(teleported.get("reason", "")))
+	assert_true(bool(world.complete_escape().get("ok", false)))
 	assert_eq(world.map_id(), Vector2i(1, ESCAPE_TOWN))
 	assert_eq(world.player_cell, SPAWN_CELL)
 
@@ -2152,7 +2217,7 @@ func test_always_on_bike_forces_the_bike_back_and_refuses_surf() -> void:
 	## `.TryBike` reads `.CheckEnvironment` first and only then the flag, so the
 	## refusal is the flag's on a map the bike may be ridden on at all.
 	forced.player_cell = Vector2i(4, 4)
-	assert_eq(forced.bike_request()["reason"], &"always_on_bike")
+	assert_eq(forced.bike_request()["kind"], &"bike_cant_get_off")
 	## The forced branch runs before `.ResetSurfingOrBikingState`, so even an
 	## indoor map keeps the bike on while the flag is up.
 	forced.player_cell = ESCAPE_INSIDE_DOOR

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -6,15 +6,14 @@ var _r: RefCounted = null
 ## caches, over every item row rather than a sampled one. Expected values come from
 ## the pinned sources' `.ItemBallsKey_LoadSubmenu`, which asks `_CheckTossableItem`,
 ## `CheckSelectableItem` and `CheckItemMenu` in that order, `RegisterItem`, and
-## `.GiveItem`. `data/items/attributes.asm` is byte identical between the pins. The
-## point of sweeping all 256 rows is that a permission bit read the wrong way round
-## is invisible on the one item a screen test picks: the bit is set on the item that
-## *cannot* do the thing, so an inverted read offers TOSS on every key item.
+## `.GiveItem`. `data/items/attributes.asm` is byte identical between the pins.
+## All 256 rows are swept because a bit read the wrong way round is invisible on
+## the one item a screen test picks: it is set on the item that *cannot* do the
+## thing, so an inverted read offers TOSS on every key item.
 
 ## The ten rows whose field-menu nibble is ITEMMENU_CLOSE, byte identical
 ## between the pins. The unit tier writes the nibble onto its own fixture, so
-## only a real cache can say which rows actually carry it: the Coin Case reads
-## like one and is ITEMMENU_CURRENT, printing its count inside the pack.
+## only a real cache can say which rows carry it.
 const CLOSE_ITEMS: Dictionary = {
 	0x07: "BICYCLE",
 	0x13: "ESCAPE ROPE",
@@ -59,6 +58,7 @@ const REGISTERABLE_KEY_ITEMS: Dictionary = {
 ## `ItemAttributes` is 256 rows on both pins, the last of which is the terminator
 ## the item list never reaches.
 const ITEM_ROWS: int = 255
+const NO_DEPOSIT_ROWS: Array[int] = [1, 2, 3]
 
 ## What fits between the text box's own borders: `Textbox`'s interior is 18
 ## columns and `PrintItemDescription` is handed the cell one in from the left.
@@ -75,6 +75,7 @@ func run(r: RefCounted) -> void:
 		_verify_registerable(game_id, data)
 		_verify_submenus(game_id, data)
 		_verify_field_effects(game_id, data)
+		_verify_deposit_rule(game_id, data)
 		_verify_key_item_effects(game_id, data)
 		_verify_screen(game_id, data)
 		_verify_descriptions(game_id, data)
@@ -220,6 +221,24 @@ func _verify_field_effects(game_id: StringName, data: GameData) -> void:
 				game_id, number, deco,
 			]
 		)
+
+
+## `.TryDepositItem`'s jumptable, whose rows 1, 2 and 3 are `.no_toss`: no item
+## carries one, so the item PC takes key items too and CANT_TOSS only decides
+## the quantity.
+func _verify_deposit_rule(game_id: StringName, data: GameData) -> void:
+	var refused: Array[String] = []
+	for number: int in range(1, ITEM_ROWS + 1):
+		if data.item(number).is_empty():
+			continue
+		if Gen2WorldPack.field_use_kind(data, number) in NO_DEPOSIT_ROWS:
+			refused.append("$%02X (%s)" % [number, data.item_name(number)])
+	_r.check(
+		refused.is_empty(),
+		"%s: %d rows the item PC would refuse: %s" % [
+			game_id, refused.size(), ", ".join(refused.slice(0, 6)),
+		]
+	)
 
 
 ## The three key items whose effect is a `farsjump` at a named map script, each

--- a/tools/checks/radio.gd
+++ b/tools/checks/radio.gd
@@ -2,14 +2,13 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the Pokegear radio card and the one thing in the overworld that reads
-## what it leaves behind: Vermilion City's Snorlax. Expected values come from the
-## pinned sources' radio tables, `SnorlaxAwake`, the BIG_OBJECT row and
-## maps/VermilionCity.asm. Two findings carry it. The Poke Flute channel is the only
-## way a track other than the map's own reaches `wMapMusic`, because a station's
-## music id is neither of the two sentinels the exit restores on. And the Snorlax is
-## a BIG_OBJECT filling four cells rather than one, which is why SnorlaxAwake's five
-## proximity coordinates are the cells they are.
+## Verifies the Pokegear radio card, everything else that writes `wMapMusic`, and
+## the one thing in the overworld reading what the card leaves behind: Vermilion
+## City's Snorlax. Expected values come from the pinned sources' radio tables,
+## `GetMapMusic`, `SnorlaxAwake`, the BIG_OBJECT row and maps/VermilionCity.asm.
+## The Poke Flute channel is the only station whose track survives the card
+## closing, its id being neither sentinel; and the Snorlax is a BIG_OBJECT filling
+## four cells, which is why SnorlaxAwake's five proximity coordinates are those.
 
 
 ## constants/map_constants.asm.
@@ -26,10 +25,8 @@ const CAVE_MOUTH: Vector2i = Vector2i(34, 7)
 const SNORLAX_CELL: Vector2i = Vector2i(34, 8)
 const SNORLAX_OBJECT: int = 4
 const TALK_FROM: Vector2i = Vector2i(34, 10)
-## One cell fewer than this pin held until 2026-08-10, for the reason
-## `tools/checks/celadon.gd`'s own count records: (26,7) carries a
-## `SPRITE_MACHOP` object, which this build cannot draw and which used to be
-## walked through as well.
+## Walkable city cells. (26,7) is not one: it carries a `SPRITE_MACHOP` object,
+## for the reason `tools/checks/celadon.gd`'s own count records.
 const CITY_CELLS: int = 318
 
 ## engine/events/specials.asm's SnorlaxAwake.ProximityCoords, in source order:
@@ -71,6 +68,8 @@ const SPECIES_SNORLAX: int = 143
 const SNORLAX_LEVEL: int = 50
 const BATTLETYPE_FORCEITEM: int = 10
 
+## MahoganyMart1F and the Radio Tower's five floors, in either pin.
+const SPECIAL_MUSIC_MAPS: int = 6
 ## Long enough for a hundred lines at `PrintRadioLine`'s own 100 frames, which
 ## walks the longest station (Buena's twenty-one segments) several times over.
 const SHOW_FRAMES: int = 12000
@@ -87,6 +86,7 @@ func run(r: RefCounted) -> void:
 		var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
 		_verify_stations(_data, game_id, crystal)
 		_verify_music_records(_data, game_id, crystal)
+		_verify_map_music(_data, game_id, crystal)
 		_verify_shows(_data, game_id, crystal)
 		_verify_big_object_census(_data, game_id)
 		_verify_snorlax(_data, game_id, crystal)
@@ -234,6 +234,74 @@ func _verify_music_records(_data: GameData, game_id: StringName, crystal: bool) 
 			not _data.world_audio(&"music", song).is_empty(),
 			"%s: channel %d wants music record %d, which this cache lacks." % [
 				game_id, channel, song,
+			]
+		)
+
+
+## `GetMapMusic` over the whole corpus: an ordinary header is a track the cache
+## ships and the two that are not answer their own pair.
+func _verify_map_music(_data: GameData, game_id: StringName, crystal: bool) -> void:
+	var special: Array[Gen2WorldMap] = []
+	var missing: Array[String] = []
+	for map: Gen2WorldMap in _data.world_maps():
+		var header: int = map.music
+		if header == Gen2WorldAPI.MUSIC_MAHOGANY_MART \
+			or (header & Gen2WorldAPI.RADIO_TOWER_MUSIC) != 0:
+			special.append(map)
+			continue
+		if _data.world_audio(&"music", header).is_empty():
+			missing.append("%d/%d wants %d" % [map.group, map.number, header])
+	_r.check(
+		missing.is_empty(),
+		"%s: %d maps name a music record this cache lacks: %s" % [
+			game_id, missing.size(), ", ".join(missing.slice(0, 6)),
+		]
+	)
+	_r.check(
+		special.size() == SPECIAL_MUSIC_MAPS,
+		"%s: %d maps carry a special music header, not %d." % [
+			game_id, special.size(), SPECIAL_MUSIC_MAPS,
+		]
+	)
+	for map: Gen2WorldMap in special:
+		_verify_special_music(_data, game_id, crystal, map)
+	_r.note("%s map music: %d headers resolved, %d of them a pair." % [
+		game_id, _data.world_maps().size(), special.size(),
+	])
+
+
+func _verify_special_music(
+	_data: GameData, game_id: StringName, crystal: bool, map: Gen2WorldMap
+) -> void:
+	var mahogany: bool = map.music == Gen2WorldAPI.MUSIC_MAHOGANY_MART
+	var flag: int = Gen2WorldState.engine_flag(
+		Gen2WorldState.ENGINE_ROCKETS_IN_MAHOGANY if mahogany \
+			else Gen2WorldState.ENGINE_ROCKETS_IN_RADIO_TOWER,
+		crystal
+	)
+	var expected: Array[int] = [
+		Gen2WorldAPI.MUSIC_CHERRYGROVE_CITY, Gen2WorldAPI.MUSIC_ROCKET_HIDEOUT,
+	]
+	if not mahogany:
+		expected = [
+			map.music & (Gen2WorldAPI.RADIO_TOWER_MUSIC - 1),
+			Gen2WorldRadio.MUSIC_ROCKET_OVERTURE,
+		]
+	for rockets: int in 2:
+		var state := Gen2WorldState.new()
+		state.set_engine_flag(flag, rockets == 1)
+		var world: Gen2WorldAPI = Gen2WorldAPI.open(
+			_data, map.group, map.number, Vector2i.ZERO, state
+		)
+		if world == null:
+			_r.fail("%s: map %d/%d is missing." % [game_id, map.group, map.number])
+			return
+		_r.check(
+			world.map_music_track() == expected[rockets]
+				and not _data.world_audio(&"music", expected[rockets]).is_empty(),
+			"%s: map %d/%d with rockets=%d answered %d, not record %d." % [
+				game_id, map.group, map.number, rockets,
+				world.map_music_track(), expected[rockets],
 			]
 		)
 


### PR DESCRIPTION
`engine/events/overworld.asm`, `engine/pokemon/mon_menu.asm`, `engine/overworld/select_menu.asm` and `engine/events/pokecenter_pc.asm`, read whole. Eight defects, all of them audible or visible.

## The map's own music

`GetMapMusic` answers two header values with something other than themselves, and neither branch was built. The Radio Tower's five floors carry `RADIO_TOWER_MUSIC | MUSIC_GOLDENROD_CITY`, which unmasked is track $BD; no cartridge ships one, so those maps kept whatever was playing outside. Mahogany Mart's own value is a song id the map music never uses, so it played the Suicune battle theme. `SpecialMapMusic`'s Bug Catching Contest branch was absent as well.

`wMapMusic` is also written by more than a map load. `BikeFunction` writes MUSIC_BICYCLE straight into it, `UsedSurfScript` spends a `special PlayMapMusic` that `SpecialMapMusic` answers with MUSIC_SURF, and `.ExitWater` spends another. None of the three reached the state, so mounting a bike or starting to surf replayed the map's own track and the right piece only turned up on the next map.

`Gen2WorldAPI.map_music_track` is the whole of `GetMapMusic_MaybeSpecial` now, `Gen2WorldHost` asks it instead of reading the header byte, and `tools/checks/radio.gd` sweeps all 368 maps on all three cartridges: an ordinary header has to name a record the cache ships, and the six that are not ordinary have to answer their own pair with the Rockets in and out.

## The Bicycle

`Script_CantGetOffBike` was not built. Route 16 and Route 17 answered with the pack's generic refusal instead of "You can't get off here!", and the pack stayed open where `.done` closes it.

Its other two lines were hardcoded English with no `<PLAYER>` in them. They come out of the cartridge now like every other field-item text, at three new `menu_text` offsets per profile.

`Script_GetOnBike_Register` and `Script_GetOffBike_Register` say nothing at all, so the Bicycle used from SELECT is silent.

## Boxes that owe no press

Three used-texts end in `done` with no `waitbutton` behind them and cost a press each here: `_UseStrengthText`, `_BlindingFlashText`, and `_TeleportReturnText`, whose `pause 60` is spent instead.

`Script_UsedStrength` is two boxes and a cry. Its `cry 0` on `wStrengthSpecies` and its second box were both missing from the party menu's path, and the cry from the boulder script's.

## Where the escapes print

Dig, an Escape Rope and Teleport each print their line on the map being left and warp behind it. All three warped inside the request, so the box went up over the destination. They stage now and `Gen2WorldAPI.complete_escape` takes the warp, which is the shape Surf already had.

## The item PC

`.TryDepositItem` dispatches on `CheckItemMenu`, whose three `.no_toss` rows no item carries, so the item PC takes a key item and `_CheckTossableItem` only decides that its quantity is one. `Gen2WorldPC.deposit` refused one, on the CANT_TOSS bit that belongs to TOSS. `tools/checks/pack.gd` sweeps all 255 rows for it.

## Proof

| Run | Result |
|---|---|
| `gut` unit tier | 3,515 tests, 64,878 asserts, green |
| `gut` full tier | 4,113 tests, 74,535 asserts, green |
| `validate.gd -- all` | 82 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 295/292/292 steps to Red, 16 badges each |
| Editor warning scan | 607 scripts, 0 warnings |
| Re-import | 3/3, `layout: Layout verified.` on each |
