### PR TITLE
Build the three map-object movement rows nothing answered

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -43,41 +43,32 @@ const TRAINER_SHOCK_EMOTE: int = 0
 ## the operand is `wScriptDelay` and `ShowEmoteScript`'s `pause 0` spends
 ## two frames a unit (`Gen2WorldScriptRunner.PAUSE_FRAMES_PER_UNIT`).
 const TRAINER_SHOCK_FRAMES: int = 60
-## StepVectors' normal-speed row: 2 pixels per frame for 8 frames, the source
-## duration for ordinary player walking (engine/overworld/map_objects.asm). The
-## trainer approach shares it: see advance_trainer_approach_step().
+## StepVectors' normal row: 2 pixels a frame for 8, the player's own walk. The
+## trainer approach shares it; see advance_trainer_approach_step().
 const STEP_PASSES_WALK: int = 8
-## A ledge hop is two chained STEP_WALK-duration cells back to back
-## (engine/overworld/map_objects.asm's StepFunction_PlayerJump: .initjump/
-## .stepjump then .initland/.stepland, each timed by the same InitStep call
-## the ordinary walk uses). OBJECT_JUMP_HEIGHT/UpdateJumpPosition supplies the
-## vertical arc exposed by player_jump_offset() and drawn by the world renderer.
+## A ledge hop is two chained STEP_WALK cells: `StepFunction_PlayerJump`'s
+## .initjump/.stepjump then .initland/.stepland, each timed by the walk's own
+## InitStep. `UpdateJumpPosition` is the arc player_jump_offset() exposes.
 const STEP_PASSES_HOP: int = STEP_PASSES_WALK * 2
-## StepVectors' slow row: 1 pixel per frame for 16 frames. _RandomWalkContinue
-## calls InitStep with a direction of 0 to 3, which indexes that first row, so
-## a wandering object steps at half the player's walking speed.
+## StepVectors' slow row: 1 pixel a frame for 16. _RandomWalkContinue calls
+## InitStep with a direction of 0 to 3, which indexes it.
 const STEP_PASSES_NPC_WALK: int = 16
 ## MovementFunction_Strength calls InitStep with `direction | 0`, so a pushed
 ## boulder indexes that same slow row and slides at a wandering NPC's speed.
 const STEP_PASSES_BOULDER_PUSH: int = STEP_PASSES_NPC_WALK
 ## `Movement_tree_shake`'s own `ld a, 24`, spent as a STEP_TYPE_SLEEP.
 const TREE_SHAKE_FRAMES: int = 24
-## StepVectors' fast row: 4 pixels per frame for 4 frames, which the bike-speed
-## movement commands reach through `STEP_BIKE`.
+## StepVectors' fast row: 4 pixels a frame for 4, reached through `STEP_BIKE`.
 const STEP_PASSES_FAST: int = 4
-## `StepFunction_Turn` (engine/overworld/map_objects.asm): two frames standing,
-## then the new facing is written and two more, so a turn on the spot costs
-## four frames and no cell.
+## `StepFunction_Turn`: two frames standing, the new facing, two more.
 const STEP_PASSES_TURN: int = 4
-## `Script_ForcedMovement`'s own `step_dig 16`, twice per whirlpool.
+## `Script_ForcedMovement`'s `step_dig 16`, twice per whirlpool.
 const FORCED_TURN_SLEEP_PASSES: int = 16
-## How long each scripted step command takes, from the `STEP_*` speed it passes to
-## `InitStep` and that row of `StepVectors`. Every command here reaches `InitStep`
-## and they differ only in the step type set over the top; the turning rows keep
-## the direction the command names, `turn_away` not reversing it. The frames are
-## one cell's, and the three jumping rows cover two, `JumpStep`'s jumptable being
-## `.Jump` then `.Land`. `turn_step` is the one command not here: `TurnStep` never
-## calls `InitStep`, so it is filed with `turn_head` below.
+## How long each scripted step command takes, from the `STEP_*` speed it hands
+## `InitStep` and that row of `StepVectors`. They differ only in the step type
+## set over the top, and the turning rows keep the direction the command names.
+## The frames are one cell's; the three jumping rows cover two. `turn_step` is
+## not here: `TurnStep` never calls `InitStep`, so it sits with `turn_head`.
 const SCRIPTED_STEP_PASSES: Dictionary = {
 	&"slow_step": STEP_PASSES_NPC_WALK,
 	&"step": STEP_PASSES_WALK,
@@ -96,18 +87,23 @@ const STEP_KIND_WALK: StringName = &"step"
 const STEP_KIND_HOP: StringName = &"jump_step"
 const STEP_KIND_TURN: StringName = &"turn"
 
-## The three rows of SCRIPTED_STEP_PASSES that are a hop: two cells, twice the
-## frames, and the arc `UpdateJumpPosition` draws over them.
+## SCRIPTED_STEP_PASSES' three hops: two cells and `UpdateJumpPosition`'s arc.
 const JUMP_STEP_KINDS: Array[StringName] = [
 	&"slow_jump_step", &"jump_step", &"fast_jump_step",
 ]
-## The commands that only change a facing. `TurnHead` writes the direction and
-## stands; `TurnStep` writes it two frames in and stands for two more.
+## The two commands that only change a facing: `TurnHead` writes the direction
+## and stands, `TurnStep` writes it two frames in and stands for two more.
 const SCRIPTED_TURN_KINDS: Array[StringName] = [&"turn_head", &"turn_step"]
 ## RandomStepDuration_Slow and _Fast mask the source random byte before storing
 ## it as the wait preceding the next movement decision.
 const IDLE_MASK_SLOW: int = 0x7F
 const IDLE_MASK_FAST: int = 0x1F
+## `StepFunction_Sleep` decrements before testing, so a rolled 0 wraps to 256.
+const IDLE_PASSES_WRAP: int = 256
+## `IsObjectMovingOffEdgeOfScreen`'s window, relative to the player, who stands
+## four cells into the ten by nine `wXCoord`/`wYCoord` name. Inclusive.
+const OBJECT_SCREEN_MIN: Vector2i = Vector2i(-4, -4)
+const OBJECT_SCREEN_MAX: Vector2i = Vector2i(5, 4)
 
 ## Crystal background event types from script_constants.asm. READ and the four
 ## facing variants point directly at a script. IFSET and IFNOTSET point at a
@@ -5470,23 +5466,26 @@ func can_object_walk_to(
 	return _cells_unoccupied(checked_cells, moving)
 
 
+## `WillObjectBumpIntoSomeoneElse`: `IsNPCAtCoord` over every struct, the
+## player's included, on both pairs. See [method Gen2WorldObject.vacating_cell].
 func _cells_unoccupied(cells: Array[Vector2i], moving: Gen2WorldObject) -> bool:
 	for object: Gen2WorldObject in objects:
 		if object == moving or not object.active or object.deleted:
 			continue
 		for checked: Vector2i in cells:
-			if object.occupies(checked):
+			if object.occupies(checked) or object.vacating_cell() == checked:
 				return false
+	var player_vacating: Vector2i = player_cell - _player_step_direction \
+		if player_step_in_progress() else player_cell
 	for checked: Vector2i in cells:
-		if checked == player_cell:
+		if checked == player_cell or checked == player_vacating:
 			return false
 	return true
 
 
 
-## `WillObjectRemainOnWater` checks the two cells a big object newly occupies,
-## not its already occupied anchor row or column. With no movement direction a
-## caller is asking about the whole footprint, which is the useful public form.
+## `WillObjectRemainOnWater` checks the two cells a big object newly occupies.
+## With no direction a caller is asking about the whole footprint.
 func _object_landing_cells(
 	moving: Gen2WorldObject, destination: Vector2i, direction: Vector2i
 ) -> Array[Vector2i]:
@@ -5515,9 +5514,8 @@ func _object_landing_cells(
 ## slice. Scripted movement is executed by the script runner, while followers
 ## advance after each successful player step.
 ##
-## One movement decision per eligible object per call. A caller wanting the
-## source's pacing uses advance_object_steps_pass(), which spends the step and
-## idle durations this records.
+## One decision per eligible object per call. A caller wanting the source's
+## pacing uses advance_object_steps_pass(), which spends the durations.
 func advance_objects(random: RandomNumberGenerator) -> int:
 	var moved: int = 0
 	for object: Gen2WorldObject in objects:
@@ -5532,41 +5530,68 @@ func advance_objects(random: RandomNumberGenerator) -> int:
 ## a facing or a direction, then records how long the resulting step or wait
 ## lasts. Returns true when the object committed to a new cell.
 func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenerator) -> bool:
-	if object.movement in [
-		Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW, Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST
-	]:
-		# MovementFunction_RandomSpinSlow and _Fast set a facing and go straight
-		# to their own wait; neither ever starts a step.
-		object.facing = random.randi_range(
-			Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT
-		)
-		var spin_mask: int = IDLE_MASK_SLOW \
-			if object.movement == Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW else IDLE_MASK_FAST
-		object.start_idle(random.randi() & spin_mask)
+	if _decide_object_spin(object, random):
 		return false
 	var direction: Vector2i = object.next_direction(random)
 	if direction == Vector2i.ZERO:
 		return false
+	# InitStep writes the facing before CanObjectMoveInDirection is asked, so a
+	# refused step still turns the object.
+	object.apply_direction(direction)
 	var destination: Vector2i = object.cell + direction
 	if not object.can_leave_to(destination) \
+		or not _object_stays_on_screen(destination) \
 		or not can_object_walk_to(destination, object, direction):
 		# _RandomWalkContinue's .new_duration branch: a blocked object keeps its
 		# cell and waits again before trying another direction.
-		object.start_idle(random.randi() & IDLE_MASK_SLOW)
+		object.start_idle(_rolled_idle_passes(random, IDLE_MASK_SLOW))
 		return false
 	object.cell = destination
-	object.apply_direction(direction)
 	object.start_step(direction, STEP_PASSES_NPC_WALK)
 	return true
 
 
+## The four spin templates: pick a facing, wait, never step.
+func _decide_object_spin(object: Gen2WorldObject, random: RandomNumberGenerator) -> bool:
+	if object.movement in Gen2WorldObject.SPIN_NEXT_FACING:
+		var table: Array = Gen2WorldObject.SPIN_NEXT_FACING[object.movement]
+		object.facing = int(table[clampi(object.facing, 0, table.size() - 1)])
+		object.start_idle(Gen2WorldObject.SPIN_HOLD_PASSES)
+		return true
+	if object.movement == Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW:
+		object.facing = random.randi() & 3
+		object.start_idle(_rolled_idle_passes(random, IDLE_MASK_SLOW))
+		return true
+	if object.movement != Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST:
+		return false
+	# MovementFunction_RandomSpinFast turns a repeat into the opposite facing,
+	# `xor %00001100` on the direction being `^ 3` here, so it never stands twice.
+	var rolled: int = random.randi() & 3
+	object.facing = rolled if rolled != object.facing else rolled ^ 3
+	object.start_idle(_rolled_idle_passes(random, IDLE_MASK_FAST))
+	return true
+
+
+## `RandomStepDuration_Slow` and `_Fast`. See [constant IDLE_PASSES_WRAP].
+func _rolled_idle_passes(random: RandomNumberGenerator, mask: int) -> int:
+	var rolled: int = random.randi() & mask
+	return rolled if rolled > 0 else IDLE_PASSES_WRAP
+
+
+## `IsObjectMovingOffEdgeOfScreen`, the refusal beside the movement radius in
+## `CanObjectMoveInDirection`; MOVE_ANYWHERE skips both. Measured: Cherrygrove's
+## teacher settles on the far cell of its band from four columns, not eight.
+func _object_stays_on_screen(destination: Vector2i) -> bool:
+	var offset: Vector2i = destination - player_cell
+	return offset.x >= OBJECT_SCREEN_MIN.x and offset.x <= OBJECT_SCREEN_MAX.x \
+		and offset.y >= OBJECT_SCREEN_MIN.y and offset.y <= OBJECT_SCREEN_MAX.y
+
+
 ## One hardware frame of the data-driven movement templates.
 ##
-## Per frame an object spends one frame of an in-flight step, one frame of its
-## wait, or takes a new decision: the source's STEP_TYPE_CONTINUE_WALK,
-## STEP_TYPE_SLEEP and STEP_TYPE_FROM_MOVEMENT cycle. The cell commits when the
-## step starts, matching InitStep and the player path, and only the presentation
-## offset trails. Returns true when something a renderer draws changed.
+## An object spends a frame of an in-flight step, a frame of its wait, or takes
+## a decision: STEP_TYPE_CONTINUE_WALK, _SLEEP and _FROM_MOVEMENT. The cell
+## commits when the step starts, as InitStep does, and the offset trails.
 func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 	if random == null or objects.is_empty():
 		return false
@@ -5574,9 +5599,8 @@ func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 	for object: Gen2WorldObject in objects:
 		if not object.active or object.deleted:
 			continue
-		# A scripted trail belongs to advance_scripted_steps_pass(), which runs
-		# while a script does. Draining it here as well would walk it at twice
-		# the speed on every frame both drivers run.
+		# A scripted trail belongs to advance_scripted_steps_pass(). Draining it
+		# here too would walk it at twice the speed while both drivers run.
 		if object.scripted_steps:
 			continue
 		# `HandleStepType` returns before every step function while FROZEN_F is
@@ -5584,20 +5608,24 @@ func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 		# no decision. `applymovement` is what freezes the rest of the map.
 		if object.frozen:
 			continue
-		# A step in flight is drained whatever put it there, so a pushed
-		# boulder slides even though its template never decides anything.
-		# StepFunction_StrengthBoulder ends by standing the boulder back up
-		# without rolling a wait, which is why only a template that decides
-		# reaches start_idle below.
+		# A step in flight is drained whatever put it there, so a pushed boulder
+		# slides even though its template decides nothing.
+		# StepFunction_StrengthBoulder rolls no wait, which is why only a
+		# deciding template reaches start_idle below.
 		if object.is_stepping():
 			if object.tick_step():
 				changed = true
 				if not object.is_stepping() and object.movement_advances():
 					# StepFunction_ContinueWalk rolls a new wait the moment
-					# the step duration reaches zero, so a wandering object
-					# pauses between steps instead of walking without
-					# stopping.
-					object.start_idle(random.randi() & IDLE_MASK_SLOW)
+					# the step duration reaches zero.
+					object.start_idle(_rolled_idle_passes(random, IDLE_MASK_SLOW))
+			continue
+		# `MovementFunction_Bouncing` decides nothing and leaves the picture to
+		# OBJECT_ACTION_BOUNCE, which `HandleObjectAction` runs every pass. No
+		# _remember_object_position(): this is a drawing, not a facing.
+		if object.movement == Gen2WorldObject.MOVEMENT_POKEMON:
+			if object.tick_bounce():
+				changed = true
 			continue
 		if not object.movement_advances():
 			continue
@@ -5613,11 +5641,10 @@ func advance_object_steps_pass(random: RandomNumberGenerator) -> bool:
 	return changed
 
 
-## Drains the presentation trail an `applymovement` left on the objects it moved,
-## and nothing else. Separate from [method advance_object_steps_pass] because that
-## one decides movement and a caller stops calling it while a script runs, which
-## is exactly when a scripted stream needs drawing. This decides nothing and
-## writes no cell: every cell the stream names committed when it was applied.
+## Drains the presentation trail an `applymovement` left, and nothing else.
+## Separate from [method advance_object_steps_pass] because a caller stops
+## calling that while a script runs, which is when a stream needs drawing. No
+## cell is written: every one the stream names committed when it was applied.
 ## Below, `FreezeAllOtherObjects`: `ApplyMovement` freezes every object with a
 ## sprite and clears the bit on the one it is about to move, and
 ## `UnfreezeFollowerObject` behind it keeps a `follow` pair walking together.

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -2,9 +2,8 @@ class_name Gen2WorldObject
 extends RefCounted
 
 ## Scene-free state for one map-object event. Script pointers and event flags
-## remain data here. The movement templates implemented in this slice cover
-## the source's standing, fixed-facing, axis-wander and random-wander rows.
-## Scripted movement and follower state are driven by the world event runtime.
+## remain data here; scripted movement and follower state are driven by the
+## world event runtime.
 
 const MOVEMENT_STILL: int = 1
 const MOVEMENT_WANDER: int = 2
@@ -21,20 +20,38 @@ const MOVEMENT_FOLLOW: int = 19
 const MOVEMENT_SCRIPTED: int = 20
 ## SPRITEMOVEDATA_STRENGTH_BOULDER. The constants file's comment column is hex,
 ## hence $19 and not 19, which is SPRITEMOVEDATA_FOLLOWING ($13). A boulder
-## decides nothing, so it is in neither movement_supported() nor
-## movement_advances() and only reacts to a push.
+## decides nothing, so it is in neither set below and only reacts to a push.
 const MOVEMENT_STRENGTH_BOULDER: int = 0x19
 ## SPRITEMOVEDATA_SMASHABLE_ROCK, below the boulder and in neither set for the
-## same reason. Its flags1 are the boulder's minus the palette bit and plus
-## USE_OBP1, so only the movement byte tells the two apart.
+## same reason. It shares the boulder's flags1 and differs in flags2 (USE_OBP1)
+## and palette flags, so the movement byte is what tells the two apart.
 const MOVEMENT_SMASHABLE_ROCK: int = 0x18
 ## SPRITEMOVEDATA_SUDOWOODO, in neither set for the same reason. Route 36's weird
 ## tree is the only object on it and `.CheckCanUseSquirtbottle` the only reader.
 const MOVEMENT_SUDOWOODO: int = 0x17
 const MOVEMENT_SWIM_WANDER: int = 0x24
-## The three rows data/sprites/map_objects.asm gives BIG_OBJECT in their palette
-## flags. Only two objects in either game use one: the player's bedroom big doll
-## and Vermilion City's Snorlax. BIGDOLLASYM is referenced by no map.
+## SPRITEMOVEDATA_POKEMON: `MovementFunction_Bouncing` stands the object still
+## and leaves the drawing to OBJECT_ACTION_BOUNCE. See tick_bounce().
+const MOVEMENT_POKEMON: int = 0x16
+const MOVEMENT_SPINCOUNTERCLOCKWISE: int = 0x1E
+const MOVEMENT_SPINCLOCKWISE: int = 0x1F
+## `_MovementSpinRepeat`'s `ld a, $10`, spent as a STEP_TYPE_SLEEP.
+const SPIN_HOLD_PASSES: int = 16
+## `.facings_counterclockwise` and `.facings_clockwise`, both indexed by the
+## facing the object holds now. Measured against a cartridge.
+const SPIN_NEXT_FACING: Dictionary = {
+	MOVEMENT_SPINCOUNTERCLOCKWISE: [
+		Gen2WorldSprite.FACING_RIGHT, Gen2WorldSprite.FACING_LEFT,
+		Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_UP,
+	],
+	MOVEMENT_SPINCLOCKWISE: [
+		Gen2WorldSprite.FACING_LEFT, Gen2WorldSprite.FACING_RIGHT,
+		Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_DOWN,
+	],
+}
+## The three rows data/sprites/map_objects.asm gives BIG_OBJECT. Two objects in
+## either game use one, the bedroom doll and Vermilion's Snorlax; no map names
+## BIGDOLLASYM.
 const MOVEMENT_BIGDOLLSYM: int = 0x15
 const MOVEMENT_BIGDOLLASYM: int = 0x20
 const MOVEMENT_BIGDOLL: int = 0x21
@@ -69,18 +86,15 @@ var sight_range: int = 0
 var event_script: int = 0
 var event_flag: int = 0
 ## Whether [member event_flag] was set when the table was built.
-## `ReadObjectEvents` reads it at map load and `wMapObjects` carries the answer
-## until the next, so only `appear` and `disappear`, which edit the live struct
-## too, move anything mid-map. Kept across a mid-script object reload.
+## `ReadObjectEvents` reads it at map load, so only `appear` and `disappear`,
+## which edit the live struct too, move anything mid-map.
 var flag_hidden: bool = false
 var trainer_data: Dictionary = {}
 var facing: int = Gen2WorldSprite.FACING_DOWN
-## The `Facings` frame this object is drawn on, 0 to 3: two standing and two
-## walking. Derived from step_frame; see walk_frame().
+## The `Facings` frame, 0 to 3: two standing and two walking. See walk_frame().
 var frame: int = 0
-## OBJECT_STEP_FRAME. `SetFacingStepAction` (engine/overworld/map_object_action.asm)
-## increments it once per hardware frame of a step and masks it to four bits, and
-## the drawn frame is its two high bits, so the drawing changes every four frames.
+## OBJECT_STEP_FRAME. `SetFacingStepAction` increments it once a frame masked to
+## four bits, and the drawn frame is its two high bits.
 var step_frame: int = 0
 ## Which command is walking, and OBJECT_STEP_FRAME's spin use for it.
 var step_kind: StringName = &""
@@ -104,24 +118,19 @@ var step_began: bool = false
 ## OBJECT_ACTION_WEIRD_TREE, while the sleep a `tree_shake` queued runs. See
 ## queue_tree_shake().
 var weird_tree: bool = false
-## The rest of a scripted movement stream, still to be drawn. An applymovement
-## commits every cell of its path at once, so the whole path is behind the
-## committed cell until these drain; each entry is one `{direction, frames}`
-## step of it, in stream order.
+## The rest of a scripted movement stream, still to be drawn: an applymovement
+## commits every cell of its path at once. One `{direction, frames}` an entry.
 var queued_steps: Array = []
-## True while the trail above belongs to a script rather than to the movement
-## templates, which is what tells the two drivers apart:
-## Gen2WorldAPI.advance_object_steps_pass() decides movement and skips a frozen
-## object, advance_scripted_steps_pass() only draws and is not gated at all.
+## True while the trail above belongs to a script, which is what tells the two
+## drivers apart: Gen2WorldAPI.advance_object_steps_pass() decides movement and
+## skips a frozen object, advance_scripted_steps_pass() only draws.
 var scripted_steps: bool = false
 ## OBJECT_FLAGS2 FROZEN_F. `HandleStepType` returns before every step function
-## for a frozen object, so it neither steps, nor spends its wait, nor decides;
-## `FreezeAllOtherObjects` is the only thing in the game that sets it and
-## `ApplyMovement` is its only caller.
+## for a frozen object, so it neither steps, nor waits, nor decides.
+## `FreezeAllOtherObjects` sets it and `ApplyMovement` is its only caller.
 var frozen: bool = false
-## Frames this object waits before its movement template decides again. The
-## source keeps this in OBJECT_STEP_DURATION while the object sits in
-## STEP_TYPE_SLEEP (engine/overworld/map_objects.asm, StepFunction_Sleep).
+## Passes this object waits before its movement template decides again:
+## OBJECT_STEP_DURATION under `StepFunction_Sleep`.
 var idle_passes_remaining: int = 0
 
 
@@ -149,16 +158,14 @@ static func from_event(
 		out.trainer_data = (trainer as Dictionary).duplicate(true)
 	if out.event_flag == 0xFFFF:
 		out.event_flag = -1
-	out.facing = out.initial_facing()
+	out.restore_default_movement()
 	return out
 
 
-## Carries the live presentation of the object this replaces at the same index:
-## its emote, the trail it is still being drawn walking, and whether a movement
-## stream deleted it. The cartridge never rebuilds a struct for the reasons this
-## project rebuilds a record, `ApplyObjectFacing` and the rest writing into the
-## one already there, so without this a `turnobject` between a `showemote` and
-## its `applymovement` empties the trail the script is waiting on.
+## Carries the live presentation of the object this replaces at the same index.
+## The cartridge writes into the struct already there rather than rebuilding it,
+## so without this a `turnobject` between a `showemote` and its `applymovement`
+## empties the trail the script is waiting on.
 func carry_presentation_from(previous: Gen2WorldObject) -> void:
 	if previous == null:
 		return
@@ -177,13 +184,21 @@ func carry_presentation_from(previous: Gen2WorldObject) -> void:
 	deleted = previous.deleted
 
 
+## `ResetObject`: the movement row's own facing, and `_MovementSpinInit`'s first
+## hold on it before `_MovementSpinTurnLeft` reaches the table.
+func restore_default_movement() -> void:
+	facing = initial_facing()
+	idle_passes_remaining = SPIN_HOLD_PASSES if movement in SPIN_NEXT_FACING else 0
+
+
+## data/sprites/map_objects.asm's facing column.
 func initial_facing() -> int:
 	match movement:
 		MOVEMENT_FIXED_UP:
 			return Gen2WorldSprite.FACING_UP
-		MOVEMENT_FIXED_LEFT:
+		MOVEMENT_FIXED_LEFT, MOVEMENT_SPINCOUNTERCLOCKWISE:
 			return Gen2WorldSprite.FACING_LEFT
-		MOVEMENT_FIXED_RIGHT:
+		MOVEMENT_FIXED_RIGHT, MOVEMENT_SPINCLOCKWISE:
 			return Gen2WorldSprite.FACING_RIGHT
 		_:
 			return Gen2WorldSprite.FACING_DOWN
@@ -239,8 +254,7 @@ func big_object_shape() -> int:
 
 
 ## WillObjectIntersectBigObject: a big object fills a two-by-two square anchored
-## on its own cell, so it blocks four cells and can be faced from any of them.
-## Every other object is the single cell IsNPCAtCoord compares against.
+## on its own cell. Every other object is the single cell IsNPCAtCoord takes.
 func occupies(target: Vector2i) -> bool:
 	if not is_big_object():
 		return cell == target
@@ -249,22 +263,43 @@ func occupies(target: Vector2i) -> bool:
 		and offset.y >= 0 and offset.y < BIG_OBJECT_SIZE
 
 
+## OBJECT_LAST_MAP_X/Y, which `CopyCoordsTileToLastCoordsTile` only catches up
+## when a step ends. `IsNPCAtCoord` compares it too, so a cell being walked out
+## of still blocks; `CheckFacingObject` refuses it, so nothing is talked to here.
+func vacating_cell() -> Vector2i:
+	return cell - step_direction if is_stepping() else cell
+
+
 func movement_supported() -> bool:
 	return movement in [
 		MOVEMENT_STILL, MOVEMENT_WANDER, MOVEMENT_SPINRANDOM_SLOW,
 		MOVEMENT_WALK_UP_DOWN, MOVEMENT_WALK_LEFT_RIGHT,
 		MOVEMENT_FIXED_DOWN, MOVEMENT_FIXED_UP, MOVEMENT_FIXED_LEFT,
 		MOVEMENT_FIXED_RIGHT, MOVEMENT_SPINRANDOM_FAST, MOVEMENT_SWIM_WANDER,
+		MOVEMENT_POKEMON, MOVEMENT_SPINCOUNTERCLOCKWISE, MOVEMENT_SPINCLOCKWISE,
 	]
 
 
-## The templates that decide something: the three random-walk and two
-## random-spin rows. Standing and fixed-facing resolve once and never ask again.
+## The templates that decide something: the three random-walk rows and the four
+## spins. Standing and fixed-facing resolve once, and a bounce is an action.
 func movement_advances() -> bool:
 	return movement in [
 		MOVEMENT_WANDER, MOVEMENT_WALK_UP_DOWN, MOVEMENT_WALK_LEFT_RIGHT,
 		MOVEMENT_SWIM_WANDER, MOVEMENT_SPINRANDOM_SLOW, MOVEMENT_SPINRANDOM_FAST,
+		MOVEMENT_SPINCOUNTERCLOCKWISE, MOVEMENT_SPINCLOCKWISE,
 	]
+
+
+## `SetFacingBounce`: OBJECT_STEP_FRAME counts one a pass and its bit 3 picks
+## `Facings`' down row or its up row, an icon's two drawings.
+func tick_bounce() -> bool:
+	step_frame = (step_frame + 1) & 0x0F
+	var wanted: int = Gen2WorldSprite.FACING_UP if (step_frame & 0x08) != 0 \
+		else Gen2WorldSprite.FACING_DOWN
+	if facing == wanted:
+		return false
+	facing = wanted
+	return true
 
 
 ## Exact time-window test from CheckObjectTime in the source runtime. Ranges
@@ -300,6 +335,9 @@ func trainer_flag_active(state: Gen2WorldState) -> bool:
 	return flag >= 0 and state != null and state.is_event_flag_active(flag)
 
 
+## `HasObjectReachedMovementLimit` refuses OBJECT_INIT_X or _Y plus or minus
+## OBJECT_RADIUS, and `.InitRadius` adds one to each nibble on the way in, so the
+## band is the map's own radius either side and inclusive.
 func can_leave_to(destination: Vector2i) -> bool:
 	return destination.x >= initial_cell.x - x_radius \
 		and destination.x <= initial_cell.x + x_radius \

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -25,9 +25,8 @@ const FACING_RIGHT: int = 3
 ## `GetUsedSprite` copies that many twice; see [method frame_tile_offset].
 const WALKING_HALF_TILES: int = 12
 
-## Tiles in one frame of a mon icon. `LoadOverworldMonIcon` asks for eight, which
-## is the two `.Frameset_PartyMon` steps through; see [member
-## animate_icon_frames] for why only an actor gets the second.
+## Tiles in one frame of a mon icon. `LoadOverworldMonIcon` asks for eight, the
+## two `.Frameset_PartyMon` steps through.
 const MON_ICON_FRAME_TILES: int = 4
 
 ## data/sprites/player_sprites.asm's ChrisStateSprites and KrisStateSprites, the
@@ -83,12 +82,9 @@ var tiles: int = 0
 var sprite_type: int = TYPE_STILL
 var default_palette: int = 0
 var icon_number: int = 0
-## Whether a mon icon's two 4-tile frames are both drawn. False for a map
-## object, because the cartridge does not animate one: `GetUsedSprite` copies an
-## icon's eight tiles into `vTiles0` and `vTiles1` both, so the walking rows of
-## `Facings` land on the same picture and the object shows its first frame
-## forever. A mod's world actor is not a map object and asks for the animation
-## the strip carries, which is the two frames `Gen2PartyMenuPage` steps through.
+## Whether `Facings`' walking rows reach the icon's second frame. A map object
+## never asks: only OBJECT_ACTION_BOUNCE animates one, through the up row. A
+## mod's actor is not a map object and steps the strip the party menu steps.
 var animate_icon_frames: bool = false
 
 
@@ -136,8 +132,13 @@ func is_walking() -> bool:
 ## the renderer, and so does frame 3 of down and up.
 func frame_tile_offset(facing: int, frame: int) -> int:
 	if sprite_type == TYPE_MON_ICON:
-		return MON_ICON_FRAME_TILES if animate_icon_frames and is_walking_frame(frame) \
-			and tiles >= MON_ICON_FRAME_TILES * 2 else 0
+		if tiles < MON_ICON_FRAME_TILES * 2:
+			return 0
+		## `Facings`' up row is tiles $04 to $07, an icon's second drawing rather
+		## than another view, which is what `SetFacingBounce` alternates onto.
+		if facing == FACING_UP:
+			return MON_ICON_FRAME_TILES
+		return MON_ICON_FRAME_TILES if animate_icon_frames and is_walking_frame(frame) else 0
 	if tiles <= 4 or sprite_type == TYPE_STILL:
 		return 0
 	var facing_index: int = clampi(facing, FACING_DOWN, FACING_RIGHT)

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -2698,15 +2698,19 @@ func test_snapshot_ignores_transient_player_step() -> void:
 
 ## The fixture's single object stands still. These tests hand it a wandering
 ## template so the data-driven driver has something to decide about.
+## The player stands three cells from the fixture's object, because
+## `IsObjectMovingOffEdgeOfScreen` refuses a step off the ten by nine cells the
+## screen shows and the object sits at (5, 6).
 func _wandering_world(
 	movement: int = Gen2WorldObject.MOVEMENT_WANDER, x_radius: int = 2, y_radius: int = 2,
-	start: Vector2i = Vector2i(12, 10)
+	start: Vector2i = Vector2i(8, 6)
 ) -> Gen2WorldAPI:
 	var world: Gen2WorldAPI = _world(start)
 	var object: Gen2WorldObject = world.objects[0]
 	object.movement = movement
 	object.x_radius = x_radius
 	object.y_radius = y_radius
+	object.restore_default_movement()
 	return world
 
 
@@ -2797,7 +2801,9 @@ func test_a_big_object_checks_both_cells_on_its_new_edge() -> void:
 ## NPCs ignore it, but at these two pins both branches of
 ## CanObjectMoveInDirection reach the same HasObjectReachedMovementLimit.
 func test_a_swim_wander_object_moves_across_its_pond_within_its_radius() -> void:
-	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
+	# The player stands beside the pond so IsObjectMovingOffEdgeOfScreen, the
+	# other refusal in CanObjectMoveInDirection, is not the thing under test.
+	var world: Gen2WorldAPI = _world(Vector2i(10, 8))
 	var object: Gen2WorldObject = world.objects[0]
 	object.cell = Vector2i(11, 11)
 	object.initial_cell = object.cell
@@ -2849,7 +2855,9 @@ func test_blocked_wander_object_keeps_its_cell_and_waits() -> void:
 	random.seed = 77
 	var start: Vector2i = object.cell
 
-	assert_false(world.advance_object_steps_pass(random))
+	# InitStep writes the facing before CanObjectMoveInDirection refuses, so the
+	# driver still reports a drawing change on the frame the step is blocked.
+	assert_true(world.advance_object_steps_pass(random))
 	assert_eq(object.cell, start)
 	assert_false(object.is_stepping())
 	# _RandomWalkContinue's .new_duration branch waits again rather than
@@ -2879,6 +2887,99 @@ func test_wander_object_never_leaves_its_source_radius() -> void:
 	# The same run has to prove the object actually wandered, or a driver that
 	# never moved anything would pass the bound above.
 	assert_gt(visited.size(), 1, "object never moved")
+
+
+## `MovementFunction_SpinCounterclockwise` and `_SpinClockwise`: sixteen passes
+## on the row's own facing, then the next one out of the table, for ever.
+## Measured against a real cartridge at 32 hardware frames a facing.
+func test_fixed_spin_templates_walk_their_own_facing_table() -> void:
+	for movement: int in [
+		Gen2WorldObject.MOVEMENT_SPINCOUNTERCLOCKWISE,
+		Gen2WorldObject.MOVEMENT_SPINCLOCKWISE,
+	]:
+		var world: Gen2WorldAPI = _wandering_world(movement)
+		var object: Gen2WorldObject = world.objects[0]
+		var random := RandomNumberGenerator.new()
+		random.seed = 3
+		var start: Vector2i = object.cell
+		var table: Array = Gen2WorldObject.SPIN_NEXT_FACING[movement]
+
+		assert_eq(object.facing, Gen2WorldSprite.FACING_LEFT \
+			if movement == Gen2WorldObject.MOVEMENT_SPINCOUNTERCLOCKWISE \
+			else Gen2WorldSprite.FACING_RIGHT)
+		for turn: int in 8:
+			var before: int = object.facing
+			_advance_object_frames(world, Gen2WorldObject.SPIN_HOLD_PASSES, random)
+			assert_eq(object.facing, before, "turned early on turn %d" % turn)
+			_advance_object_frames(world, 1, random)
+			assert_eq(object.facing, int(table[before]))
+		assert_eq(object.cell, start)
+		assert_false(object.is_stepping())
+
+
+## `MovementFunction_RandomSpinFast` rerolls a repeat onto the opposite facing,
+## so the drawing changes on every one of its waits.
+func test_the_fast_random_spin_never_repeats_a_facing() -> void:
+	var world: Gen2WorldAPI = _wandering_world(Gen2WorldObject.MOVEMENT_SPINRANDOM_FAST)
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 99
+
+	var facings: Dictionary = {}
+	for _turn: int in 200:
+		var before: int = object.facing
+		while object.tick_idle():
+			pass
+		world.advance_object_steps_pass(random)
+		assert_ne(object.facing, before)
+		facings[object.facing] = true
+	assert_eq(facings.size(), 4, "the reroll must still reach all four facings")
+
+
+## `SetFacingBounce`: eight passes on `Facings`' down row and eight on its up
+## row, which for a mon icon are the icon's two drawings. Measured against a
+## real cartridge at 16 hardware frames a drawing.
+func test_a_bouncing_object_alternates_the_two_icon_rows() -> void:
+	var world: Gen2WorldAPI = _wandering_world(Gen2WorldObject.MOVEMENT_POKEMON)
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 1
+	var start: Vector2i = object.cell
+
+	assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN)
+	for _step: int in 7:
+		world.advance_object_steps_pass(random)
+		assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN)
+	assert_true(world.advance_object_steps_pass(random))
+	assert_eq(object.facing, Gen2WorldSprite.FACING_UP)
+	for _step: int in 7:
+		world.advance_object_steps_pass(random)
+		assert_eq(object.facing, Gen2WorldSprite.FACING_UP)
+	world.advance_object_steps_pass(random)
+	assert_eq(object.facing, Gen2WorldSprite.FACING_DOWN)
+	assert_eq(object.cell, start)
+	assert_false(object.is_stepping())
+
+
+## `IsObjectMovingOffEdgeOfScreen`, the refusal beside the movement radius: an
+## object may not step off the ten by nine cells the screen shows, whatever its
+## radius allows. Measured against a real cartridge.
+func test_an_object_refuses_a_step_off_the_screen() -> void:
+	var world: Gen2WorldAPI = _wandering_world(
+		Gen2WorldObject.MOVEMENT_WALK_LEFT_RIGHT, 3, 0
+	)
+	var object: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 12
+
+	# The object sits at (5, 6) and the player at (8, 6), so the band's left
+	# half is four columns out and the right half is not.
+	var visited: Dictionary = {}
+	for _frame: int in 4000:
+		world.advance_object_steps_pass(random)
+		visited[object.cell.x] = true
+	assert_true(visited.has(4), "the object never reached the near edge")
+	assert_false(visited.has(3), "the object stepped off the screen")
 
 
 func test_spin_templates_turn_without_starting_a_step() -> void:

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -343,12 +343,15 @@ func test_an_icon_actor_steps_the_strips_two_frames_at_the_framesets_rate() -> v
 	RomCache.clear(ActorFixture.directory())
 
 
-## A map object's icon is copied into both VRAM halves, so it shows one frame
-## forever; only an actor asks for the second.
-func test_a_map_objects_icon_never_reaches_the_strips_second_frame() -> void:
+## `Facings`' up row is tiles $04 to $07 whatever the sprite, which for an icon
+## is its second drawing. A map object reaches it by facing up, which is what
+## `SetFacingBounce` alternates, and by nothing else: the walking rows belong to
+## an actor.
+func test_a_map_objects_icon_reaches_the_second_frame_only_by_facing_up() -> void:
 	var sprite: Gen2WorldSprite = Gen2WorldSprite.from_mon_icon(1)
 	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_DOWN, 1), 0)
-	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_UP, 3), 0)
+	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_LEFT, 3), 0)
+	assert_eq(sprite.frame_tile_offset(Gen2WorldSprite.FACING_UP, 0), 4)
 
 
 func test_actor_sprites_are_sorted_by_row_and_read_once_a_frame() -> void:

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -3,13 +3,12 @@ extends RefCounted
 var _r: RefCounted = null
 
 ## The imported map corpus against the pins' own copies of the same bytes. pret
-## assembles to a bit-identical ROM, so the `.blk`, metatile, collision and palette
-## map files are the cartridge's own bytes read a second way. Agreement proves the
-## importer's addressing, stride and fold, which is where an offset read one row out
-## hides; it proves nothing about what the bytes mean, and `drawn_blocks` and
+## assembles to a bit-identical ROM, so the `.blk`, metatile, collision and
+## palette map files are the cartridge's own bytes read a second way. Agreement
+## proves the importer's addressing, stride and fold; `drawn_blocks` and
 ## `side_walls` are the semantic half. Every identity comes from the pin's own
-## tables rather than from a number, because `Tileset0` and `TilesetJohto` are the
-## same record under two labels. A missing checkout skips rather than fails.
+## tables, because `Tileset0` and `TilesetJohto` are one record under two
+## labels. A missing checkout skips rather than fails.
 
 const PINS: Dictionary = {
 	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",
@@ -28,6 +27,30 @@ const ROOF_FILES: Array[String] = [
 
 ## `constants/hardware.inc`: `OAM_BANK1 equ 1 << B_OAM_BANK1`.
 const OAM_BANK1: int = 1 << 3
+
+## Every `SPRITEMOVEDATA_*` an `object_event` in either corpus names, and what
+## answers it here. Transcribed rather than read off `Gen2WorldObject`.
+const MODELLED_MOVEMENT: Dictionary = {
+	"SPRITEMOVEDATA_STILL": "movement_supported",
+	"SPRITEMOVEDATA_WANDER": "movement_advances",
+	"SPRITEMOVEDATA_SPINRANDOM_SLOW": "movement_advances",
+	"SPRITEMOVEDATA_WALK_UP_DOWN": "movement_advances",
+	"SPRITEMOVEDATA_WALK_LEFT_RIGHT": "movement_advances",
+	"SPRITEMOVEDATA_STANDING_DOWN": "movement_supported",
+	"SPRITEMOVEDATA_STANDING_UP": "movement_supported",
+	"SPRITEMOVEDATA_STANDING_LEFT": "movement_supported",
+	"SPRITEMOVEDATA_STANDING_RIGHT": "movement_supported",
+	"SPRITEMOVEDATA_SPINRANDOM_FAST": "movement_advances",
+	"SPRITEMOVEDATA_POKEMON": "tick_bounce",
+	"SPRITEMOVEDATA_SUDOWOODO": "is_sudowoodo",
+	"SPRITEMOVEDATA_SMASHABLE_ROCK": "is_smashable_rock",
+	"SPRITEMOVEDATA_STRENGTH_BOULDER": "is_strength_boulder",
+	"SPRITEMOVEDATA_SPINCOUNTERCLOCKWISE": "movement_advances",
+	"SPRITEMOVEDATA_SPINCLOCKWISE": "movement_advances",
+	"SPRITEMOVEDATA_BIGDOLLSYM": "is_big_object",
+	"SPRITEMOVEDATA_BIGDOLL": "is_big_object",
+	"SPRITEMOVEDATA_SWIM_WANDER": "movement_advances",
+}
 
 var _pins: Dictionary = {}
 var _root: String = ""
@@ -50,6 +73,7 @@ func _check_game() -> void:
 	_check_blocks(pin)
 	_check_tilesets(pin)
 	_check_roofs(pin)
+	_check_object_movement(pin)
 
 
 # --- Map block arrays -------------------------------------------------------
@@ -101,9 +125,8 @@ func _check_blocks(pin: String) -> void:
 
 ## The highest block [param map] names, and a failure when that is past its
 ## tileset's own table. A metatile run's length is only the distance to the next
-## label, so `RomLayout.tileset_block_counts` is the one number here the pins
-## state nowhere: this is what says the imported length covers the corpus, and
-## `TilesetForest`'s 40 is why it is checked rather than assumed.
+## label, so `RomLayout.tileset_block_counts` is the one number the pins state
+## nowhere; `TilesetForest`'s 40 is why it is checked rather than assumed.
 func _check_block_reach(id: String, map: Gen2WorldMap) -> int:
 	var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
 	if tileset == null:
@@ -204,12 +227,10 @@ func _check_palette_reach(number: int, tileset: Gen2WorldTileset) -> void:
 # --- Roofs ------------------------------------------------------------------
 
 
-## `MapGroupRoofs`, `RoofPals` and the strip `LoadMapGroupRoof` writes over.
-##
-## The two tables are compared against the pin's own text, and the strip is
-## checked from the other side: a group that names a roof must change tiles
-## $0A..$12 of every tileset it draws with, since a copy that lands somewhere
-## else or reads the wrong run is silent until someone looks at a town.
+## `MapGroupRoofs`, `RoofPals` and the strip `LoadMapGroupRoof` writes over. The
+## tables are compared against the pin's text and the strip from the other side:
+## a group naming a roof must change tiles $0A..$12 of every tileset it draws
+## with, since a copy landing elsewhere is silent until someone sees a town.
 func _check_roofs(pin: String) -> void:
 	var groups: PackedByteArray = _roof_groups(pin)
 	var palettes: Array = _roof_palettes(pin)
@@ -403,6 +424,72 @@ func _roof_palettes(pin: String) -> Array:
 # --- Comparison -------------------------------------------------------------
 
 
+# --- Object movement rows ---------------------------------------------------
+
+
+## Every `object_event`'s movement byte against the pin's own `maps/*.asm`, and
+## every row the corpus names against what answers it here. The second half is
+## how the two fixed spins and the bouncing icon were found standing still.
+func _check_object_movement(pin: String) -> void:
+	var numbers: Dictionary = _movement_numbers(pin)
+	var attributes: Dictionary = _attributes(pin)
+	var objects: int = 0
+	var used: Dictionary = {}
+	for entry: Dictionary in _map_ids(pin):
+		var id: String = entry["id"]
+		var map: Gen2WorldMap = _r.data.world_map(entry["group"], entry["number"])
+		var label: String = String(attributes.get(id, {}).get("label", ""))
+		if map == null or label == "":
+			continue
+		var rows: Array = map.events.get("objects", [])
+		var pinned: PackedStringArray = _pinned_movement(pin, label)
+		if pinned.size() != rows.size():
+			_report("%s has %d objects, the pin has %d." % [id, rows.size(), pinned.size()])
+			continue
+		for index: int in pinned.size():
+			var name: String = pinned[index]
+			used[name] = true
+			objects += 1
+			var wanted: int = int(numbers.get(name, -1))
+			var ours: int = int((rows[index] as Dictionary).get("movement", -1))
+			if ours != wanted:
+				_report("%s object %d moves on $%02X, the pin says %s ($%02X)." % [
+					id, index, ours, name, wanted
+				])
+	for name: String in used:
+		if not MODELLED_MOVEMENT.has(name):
+			_report("%s is used by the corpus and nothing here answers it." % name)
+	_r.note("objects: %d movement rows compared, %d distinct" % [objects, used.size()])
+	if objects == 0:
+		_report("no object movement row was compared, so the layer proved nothing.")
+
+
+## `const SPRITEMOVEDATA_*`, whose `const_def` opens at zero.
+func _movement_numbers(pin: String) -> Dictionary:
+	return _parsed(pin, &"movement_numbers", func() -> Dictionary:
+		var out: Dictionary = {}
+		var next: int = 0
+		for line: String in _lines(pin.path_join("constants/map_object_constants.asm")):
+			if not line.begins_with("const SPRITEMOVEDATA_"):
+				continue
+			out[line.substr(6).strip_edges()] = next
+			next += 1
+		return out
+	)
+
+
+## Each `object_event`'s fourth operand, in the order the map file writes them.
+func _pinned_movement(pin: String, label: String) -> PackedStringArray:
+	var out: PackedStringArray = []
+	for line: String in _lines(pin.path_join("maps/%s.asm" % label)):
+		if not line.begins_with("object_event"):
+			continue
+		var fields: PackedStringArray = _fields(line)
+		if fields.size() > 3:
+			out.append(fields[3])
+	return out
+
+
 ## Reports the first differing byte of [param ours] against [param pinned] over
 ## [param length] bytes, and a length disagreement as its own failure.
 func _compare(
@@ -431,8 +518,7 @@ func _report(message: String) -> void:
 
 
 ## `constants/map_constants.asm` in order: `newgroup` opens a group and each
-## `map_const` is the next map in it, so this is the same walk that gives
-## `MapGroupPointers` its indices.
+## `map_const` is the next map in it, the walk `MapGroupPointers` is indexed by.
 func _map_ids(pin: String) -> Array:
 	return _parsed(pin, &"map_ids", func() -> Array:
 		var out: Array = []
@@ -470,8 +556,7 @@ func _attributes(pin: String) -> Dictionary:
 	)
 
 
-## `<Label>_Blocks:` to the `.blk` it includes. Several labels can stand over
-## one `INCBIN`, which is how two maps share blockdata.
+## `<Label>_Blocks:` to the `.blk` it includes; several labels can share one.
 func _blockdata(pin: String) -> Dictionary:
 	return _parsed(pin, &"blockdata", func() -> Dictionary:
 		return _includes(pin.path_join("data/maps/blocks.asm"))
@@ -632,8 +717,7 @@ func _parsed(pin: String, key: StringName, body: Callable) -> Variant:
 	return cache[key]
 
 
-## A source file with its comments and indentation gone, so a caller matches on
-## the directive alone.
+## A source file with its comments and indentation gone.
 func _lines(path: String) -> PackedStringArray:
 	var out: PackedStringArray = []
 	var file: FileAccess = FileAccess.open(path, FileAccess.READ)

--- a/tools/checks/surf.gd
+++ b/tools/checks/surf.gd
@@ -285,8 +285,11 @@ func _verify_swimming_objects(game_id: StringName, data: GameData, crystal: bool
 	if swimmers.size() != SWIM_OBJECT_CENSUS:
 		return
 
+	# Three cells north of the Lapras, because `IsObjectMovingOffEdgeOfScreen`
+	# refuses a step off the ten by nine cells the screen shows and the whole
+	# radius has to sit inside that window for the limit to be what is measured.
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(
-		data, UNION_CAVE_GROUP, number, Vector2i.ZERO, Gen2WorldState.new()
+		data, UNION_CAVE_GROUP, number, LAPRAS_CELL + Vector2i(0, -3), Gen2WorldState.new()
 	)
 	if world == null:
 		_r.fail("%s: Union Cave B2F is missing." % game_id)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -7230,9 +7230,8 @@ func _ss_aqua_disembark(
 	return {"ok": true}
 
 
-## _push_boulder_at() for a boulder that may land on a `stonetable` pit: the
-## fall script is queued by the push that commits the cell, and the boulder
-## needs its own slide finished before the next push can reach it.
+## _push_boulder_at() for a boulder that may land on a `stonetable` pit, whose
+## fall script the push that commits the cell queues.
 func _push_boulder_run(
 	world: Gen2WorldAPI,
 	approach: Vector2i,
@@ -7249,13 +7248,11 @@ func _push_boulder_run(
 	)
 	if not bool(fall.get("terminal", true)):
 		return {"ok": false, "reason": "fall script did not finish: %s" % fall.get("reason", "")}
-	_settle_object_steps(world, random)
 	return pushed
 
 
-## Spends hardware frames until no object is mid-step. A pushed boulder slides
-## for STEP_PASSES_BOULDER_PUSH frames and refuses a second push until it stands
-## again, so this has to spend the frames rather than ask for them at once.
+## Spends hardware frames until no object is mid-step, one at a time: a pushed
+## boulder slides for STEP_PASSES_BOULDER_PUSH of them.
 func _settle_object_steps(world: Gen2WorldAPI, random: RandomNumberGenerator) -> void:
 	for _frame: int in OBJECT_STEP_FRAME_BUDGET:
 		var stepping: bool = false
@@ -7609,10 +7606,11 @@ func _storm_badge_leg(
 	return {"ok": true}
 
 
-## Walks to [param approach] and steps into [param direction], which is a push
-## rather than a step because a boulder stands there. DoPlayerMovement.CheckNPC
-## bumps the player on a push, so the step reports blocked and the boulder moving
-## is the success signal.
+## Walks to [param approach] and steps into [param direction], a push rather
+## than a step because a boulder stands there. DoPlayerMovement.CheckNPC bumps
+## the player, so the step reports blocked and the boulder moving is the success
+## signal. Every push starts settled: a sliding boulder holds
+## OBJECT_LAST_MAP_X/Y on the cell it is leaving, which the next push may need.
 func _push_boulder_at(
 	world: Gen2WorldAPI,
 	approach: Vector2i,
@@ -7621,6 +7619,7 @@ func _push_boulder_at(
 	random: RandomNumberGenerator,
 	data: GameData,
 ) -> Dictionary:
+	_settle_object_steps(world, random)
 	var walked: Dictionary = _walk_cell_resolving(world, approach, save, random, data)
 	if not bool(walked.get("ok", false)):
 		return walked


### PR DESCRIPTION
`engine/overworld/map_objects.asm` walked whole, with `map_object_action.asm`, `npc_movement.asm` and `player_object.asm` inside it. Sixty-six objects a cartridge sat on a movement row this port did not model, and four more rules in the same routines were wrong.

## Added

- `SPRITEMOVEDATA_POKEMON`, 48 objects a cartridge. The row stands the object still and leaves `OBJECT_ACTION_BOUNCE` to alternate `Facings`' down row and its up row every eight passes; for a mon icon those are its own two drawings, so every overworld Pokemon was a frozen picture.
- `SPRITEMOVEDATA_SPINCLOCKWISE` and `SPRITEMOVEDATA_SPINCOUNTERCLOCKWISE`, 18 objects on Crystal and 16 on Gold and Silver. Each holds a facing for sixteen passes and takes the next out of `.facings_clockwise` or `.facings_counterclockwise`, and both start on the row's own facing rather than DOWN. Fourteen of them are trainers whose sight line is that facing, so a rotating trainer watched one direction for ever.
- `IsObjectMovingOffEdgeOfScreen`: an object may not step off the ten by nine cells the screen shows, whatever its movement radius allows.
- `tools/checks/map_data.gd` sweeps every `object_event`'s movement byte against the pin's own `maps/*.asm` on all three cartridges, 1,343 rows on Gold and Silver and 1,466 on Crystal, and fails on a row nothing here answers.

## Fixed

- `MovementFunction_RandomSpinFast` rerolls a repeated facing onto the opposite one, so a fast spin never stands twice; this rolled uniformly.
- `InitStep` writes the facing before `CanObjectMoveInDirection` is asked, so a refused step still turns the object.
- `IsNPCAtCoord` compares `OBJECT_LAST_MAP_X/Y` as well as the destination, so a cell being walked out of stays blocked until the step arrives. The player's struct is one of the thirteen it walks.
- `StepFunction_Sleep` decrements before testing, so a rolled step duration of zero is spent as 256 passes rather than none.
- `PrepMonFrontpic`'s neighbour on the sprite side: `Facings`' up row is tiles $04 to $07, which for an icon is its second drawing rather than another view.

## Measured

The bounce, both spin tables and the screen edge come from a real cartridge as well as from the disassembly: 16 hardware frames a drawing, 32 a facing, both tables in order, and Cherrygrove's teacher settles on the far cell of its band with the player four columns away and never reaches it from eight.

`HasObjectReachedMovementLimit` looked like a seventh defect and is not one. `CopyTempObjectToObjectStruct`'s `.InitRadius` adds one to each nibble on the way in, so the band is the map's own radius either side and inclusive, which is what was already here.

## Proof

| Check | Result |
|---|---|
| Unit tier | 3,533 tests, 65,284 asserts, green |
| Scene tier | 4,131 tests, 74,944 asserts, green |
| `tools/validate.gd -- all` | 83 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 16 badges on each, 292/292/295 legs |
| Editor analyser | 0 warnings in 608 scripts |