### PR TITLE
Give faceplayer's turn back and spend the Dude's inputs in polls

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -137,11 +137,10 @@ const SCREEN_FADED_TEXT: Dictionary = {
 	Gen2Screens.REFLECT: "%s's REFLECT faded!",
 }
 
-## `CatchTutorial.DudeTutorial`, which puts the player's name back afterwards.
 const DUDE_NAME: String = "DUDE"
 
 ## `CatchTutorial.LoadDudeData`: one POTION, and five POKE BALLs because
-## `ld a, POKE_BALL` writes the quantity byte as well as the item byte.
+## `ld a, POKE_BALL` writes the quantity byte too.
 const DUDE_PACK: Array[int] = [
 	Gen2WorldPartyHost.ITEM_POTION, Gen2WorldPartyHost.ITEM_POKE_BALL,
 ]
@@ -150,9 +149,9 @@ const DUDE_PACK_QUANTITIES: Dictionary = {
 	Gen2WorldPartyHost.ITEM_POKE_BALL: Gen2WorldPartyHost.ITEM_POKE_BALL,
 }
 
-## `DudeAutoInputs`: a button and the byte after it, held for one poll more than
-## its own value, and a battle polls once a hardware frame. Measured through the
-## cartridge's own `GetJoypad`: RIGHT lands on frame 10, DOWN on 1021, A on 2042.
+## `DudeAutoInputs`: a button and the byte after it, held for one `GetJoypad`
+## poll more than its value (`home/joypad.asm`'s `.auto`), which is not a frame.
+## See [constant DUDE_POLLS_PER_FRAME].
 const DUDE_AUTO_INPUT: Dictionary = {
 	&"text": [[Gen2Button.NONE, 0x50], [Gen2Button.A, 0x00]],
 	&"pack": [
@@ -165,6 +164,15 @@ const DUDE_AUTO_INPUT: Dictionary = {
 		[Gen2Button.NONE, 0xFE], [Gen2Button.NONE, 0xFE], [Gen2Button.NONE, 0xFE],
 		[Gen2Button.NONE, 0xFE], [Gen2Button.A, 0x00],
 	],
+}
+
+## Polls one frame of each stage is worth: `.wait_input` spends a `DelayFrame` a
+## pass and `Do2DMenuRTCJoypad.loopRTC` spends none. Measured on a cartridge
+## through Route 29's tutorial, from the `_DudeAutoInput_*` call: A lands on
+## frame 80 of the text stream, DOWN on 29 and A on 53 of the menu's, RIGHT on 51
+## and A on 102 of the pack's.
+const DUDE_POLLS_PER_FRAME: Dictionary = {
+	&"text": 1.0, &"menu": 36.0, &"pack": 0.176,
 }
 
 var _data: GameData = null
@@ -287,6 +295,7 @@ var _auto_input: Array = []
 var _auto_input_index: int = 0
 var _auto_input_delay: int = 0
 var _auto_input_stage: StringName = &""
+var _auto_input_polls: float = 0.0
 ## The bars' and the intro's clock: see [method _process].
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## The same, for the party page's icons. Kept apart because they animate while
@@ -877,6 +886,7 @@ func _stop_auto_input() -> void:
 	_auto_input_index = 0
 	_auto_input_delay = 0
 	_auto_input_stage = &""
+	_auto_input_polls = 0.0
 
 
 ## Which of `_DudeAutoInput_A`, `_RightA` and `_DownA` this poll installs, from
@@ -895,19 +905,27 @@ func _dude_auto_input_stage() -> StringName:
 	return &""
 
 
-## `GetJoypad`'s `.auto` branch, one poll. The tutorial is the only stream here.
+## `GetJoypad`'s `.auto` branch, spent this frame's worth of polls.
 func _tick_auto_input() -> void:
 	if not _world_battle_active or not _world_battle_tutorial:
 		return
 	var stage: StringName = _dude_auto_input_stage()
 	if stage != _auto_input_stage:
 		_auto_input_stage = stage
+		_auto_input_polls = 0.0
 		if stage == &"":
 			_auto_input = []
 		else:
 			_start_auto_input(DUDE_AUTO_INPUT[stage])
 	if _auto_input_index >= _auto_input.size():
 		return
+	_auto_input_polls += float(DUDE_POLLS_PER_FRAME.get(_auto_input_stage, 1.0))
+	while _auto_input_polls >= 1.0 and _auto_input_index < _auto_input.size():
+		_auto_input_polls -= 1.0
+		_spend_auto_input_poll()
+
+
+func _spend_auto_input_poll() -> void:
 	if _auto_input_delay > 0:
 		_auto_input_delay -= 1
 		return

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -5078,8 +5078,9 @@ func _apply_result_events(result: Dictionary) -> Dictionary:
 
 
 func _finish_script_result(result: Dictionary) -> Dictionary:
+	## Before the refusal: the commands in front of the failing one did run.
 	if not bool(result.get("ok", false)):
-		return result
+		return _apply_result_events(result)
 	if result.has("clock"):
 		var clock: Dictionary = result.get("clock", {})
 		set_world_clock(

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -867,7 +867,10 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 		if not bool(outcome.get("ok", true)):
 			return _fail(StringName(outcome.get("reason", &"script_failed")), outcome)
 		if _pending:
-			return _waiting_result()
+			## As below: a command with a waiting result of its own has drained
+			## the events, and a second loses them. `faceplayer` before a `trade`
+			## or a `special BankOfMom` is the visible half.
+			return outcome if outcome.has("status") else _waiting_result()
 		if _completed:
 			## A terminal command returns _complete()'s own result, which has
 			## already drained the events; asking for a second one would hand the

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -12,6 +12,15 @@ const STORY_OBJECT: int = 0x6210
 const STORY_TEXT: int = 0x7200
 const STORY_EVENT_FLAG: int = 8
 
+## `CatchTutorial` from the first frame of the fight to the last, measured on a
+## Crystal cartridge through Route 29's own tutorial: 1,529 hardware frames, of
+## which the battle menu is 53. Reading `DudeAutoInputs`' durations as frames
+## rather than as `GetJoypad` polls made that menu 2,042 on its own, which is
+## half a minute of a fight nobody can play sitting on FIGHT. The ceiling is the
+## cartridge's own count; the guard is what says the stream stalled outright.
+const DUDE_TUTORIAL_FRAMES: int = 1529
+const DUDE_FRAME_GUARD: int = 8000
+
 var _data: GameData = null
 var _world_screen: Gen2WorldScreen = null
 
@@ -588,14 +597,21 @@ func test_the_dude_plays_the_catching_tutorial_and_keeps_nothing() -> void:
 		if _world_screen._active_battle_save != null else 0
 
 	var messages: Array[String] = []
-	var guard: int = 8000
-	while _world_screen._battle_host != null and guard > 0:
-		guard -= 1
+	var throw_frame: int = -1
+	var frames: int = 0
+	while _world_screen._battle_host != null and frames < DUDE_FRAME_GUARD:
+		frames += 1
 		var line: String = String(host.battle_snapshot()["message"])
 		if messages.is_empty() or messages.back() != line:
 			messages.append(line)
+			if throw_frame < 0 and line == "DUDE used the\nPOKE BALL.":
+				throw_frame = frames
 		host.advance_hardware_frame()
-	assert_gt(guard, 0, "the tutorial answers itself: %s" % JSON.stringify(messages))
+	assert_lt(frames, DUDE_FRAME_GUARD, "the tutorial answers itself: %s" % JSON.stringify(messages))
+	print("dude: ball thrown on frame %d, tutorial over on %d" % [throw_frame, frames])
+	assert_between(throw_frame, 1, DUDE_TUTORIAL_FRAMES,
+		"the Dude reached the ball on frame %d" % throw_frame)
+	assert_lt(frames, DUDE_FRAME_GUARD, "the tutorial ran %d frames" % frames)
 	await get_tree().process_frame
 	await get_tree().process_frame
 

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37869
+const MAX_COMMENT_LINES: int = 37868
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/scripted_scenes.gd
+++ b/tools/checks/scripted_scenes.gd
@@ -1,8 +1,8 @@
 extends RefCounted
 
-## Long source-script movements whose leader and player-follower paths cross
-## several turns. Each row is driven from the imported map event, one hardware
-## frame at a time, on every cartridge profile.
+## Conversations driven from the imported map events on every cartridge profile:
+## two long movement scenes a hardware frame at a time, and every object whose
+## script opens on `faceplayer`.
 ##
 ##   Godot --headless --path . -s res://tools/validate.gd -- scripted_scenes
 
@@ -22,18 +22,30 @@ const GUIDE_FOLLOWER_WAYPOINTS: Array[Vector2i] = [
 	Vector2i(10, 6), Vector2i(24, 11), Vector2i(24, 11),
 ]
 const GUIDE_MOVEMENT_FRAMES: Array[int] = [32, 48, 56, 64, 152, 16]
-## Which way the player looks at the box after each stream: the follow's own
-## answer, then `turnobject PLAYER` UP, UP, LEFT and RIGHT. Stream 6 has no box
-## behind it, and pokegold ships Crystal's guide script.
+## Which way the player looks at each box: the follow's own answer, then
+## `turnobject PLAYER` UP, UP, LEFT and RIGHT. Stream 6 has no box behind it.
 const NO_TEXT_AFTER: int = -1
 const GUIDE_PLAYER_FACINGS: Array[int] = [
 	Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_UP,
 	Gen2WorldSprite.FACING_UP, Gen2WorldSprite.FACING_LEFT,
 	Gen2WorldSprite.FACING_RIGHT, NO_TEXT_AFTER,
 ]
-## `turnobject CHERRYGROVECITY_GRAMPS, LEFT`, the object half of it.
 const GUIDE_GIFT_FACING: int = Gen2WorldSprite.FACING_LEFT
 const DUDE_MOVEMENT_FRAMES: Array[Array] = [[48, 48], [40, 40]]
+
+## Both open on `Script_faceplayer`, named rather than numbered because
+## pokegold's is $6A and Crystal's $6B.
+const FACE_PLAYER_COMMANDS: Array[StringName] = [&"faceplayer", &"jumptextfaceplayer"]
+const TALKABLE_OBJECT_TYPES: Array[int] = [
+	Gen2WorldObject.OBJECTTYPE_SCRIPT, Gen2WorldObject.OBJECTTYPE_TRAINER,
+]
+const MOVEMENT_WAIT_FRAMES: int = 256
+const NEIGHBOURS: Dictionary = {
+	Gen2WorldSprite.FACING_UP: [Vector2i(0, 1), Gen2WorldSprite.FACING_DOWN],
+	Gen2WorldSprite.FACING_DOWN: [Vector2i(0, -1), Gen2WorldSprite.FACING_UP],
+	Gen2WorldSprite.FACING_LEFT: [Vector2i(1, 0), Gen2WorldSprite.FACING_RIGHT],
+	Gen2WorldSprite.FACING_RIGHT: [Vector2i(-1, 0), Gen2WorldSprite.FACING_LEFT],
+}
 
 var _r: RefCounted = null
 
@@ -48,6 +60,7 @@ func run(r: RefCounted) -> void:
 		_check_guide(game_id, data)
 		for trigger_index: int in ROUTE_TRIGGERS.size():
 			_check_tutorial(game_id, data, trigger_index)
+		_check_face_player(game_id, data)
 
 
 func _check_guide(game_id: StringName, data: GameData) -> void:
@@ -179,8 +192,8 @@ func _drain(world: Gen2WorldAPI, initial: Array, tracked_object: int) -> Diction
 		var input: Dictionary = world.pending_script_input()
 		var input_type: StringName = StringName(input.get("type", &""))
 		if input_type in [&"text", &"button"]:
-			## What the `turnobject` before this box left. A dropped turn moves
-			## nobody, so the waypoints above cannot see one.
+			## What the `turnobject` before this box left: a dropped turn moves
+			## nobody, so no waypoint above can see one.
 			if not movements.is_empty() and not (movements[-1] as Dictionary).has("facing"):
 				(movements[-1] as Dictionary)["facing"] = world.player_facing
 				(movements[-1] as Dictionary)["leader_facing"] = \
@@ -215,3 +228,81 @@ func _drain(world: Gen2WorldAPI, initial: Array, tracked_object: int) -> Diction
 		if results.is_empty():
 			results = world.run_event_queue(false)
 	return {"ok": false, "reason": "script did not terminate in 512 transitions"}
+
+
+## Every object whose script opens on `faceplayer`, from each side it is
+## reachable from and in a world of its own, since a second press would resume
+## the standing conversation. Nothing else asks whether the turn survives a
+## paused or refused command; the party is there because `readvar VAR_BOXSPACE`,
+## `trade` and `GetFirstPokemonHappiness` read one.
+func _check_face_player(game_id: StringName, data: GameData) -> void:
+	var talked: int = 0
+	var missed: int = 0
+	var wrong: Array[String] = []
+	for map: Gen2WorldMap in data.world_maps():
+		var listed: Gen2WorldAPI = Gen2WorldAPI.open(data, map.group, map.number, Vector2i.ZERO)
+		if listed == null:
+			continue
+		for candidate: Gen2WorldObject in listed.objects:
+			if not _opens_on_face_player(data, listed, candidate):
+				continue
+			for facing: int in NEIGHBOURS:
+				var world: Gen2WorldAPI = Gen2WorldAPI.open(
+					data, map.group, map.number, Vector2i.ZERO
+				)
+				var object: Gen2WorldObject = world.objects[candidate.index]
+				if not _talk_from(world, object, facing):
+					continue
+				talked += 1
+				var turned: int = (world.objects[object.index] as Gen2WorldObject).facing
+				var wanted: int = int((NEIGHBOURS[facing] as Array)[1])
+				if turned == wanted:
+					continue
+				missed += 1
+				if wrong.size() < 8:
+					wrong.append("map %d/%d object %d looking %d, not %d" % [
+						map.group, map.number, object.index, turned, wanted,
+					])
+	for line: String in wrong:
+		_r.check(false, "%s: faceplayer left %s" % [game_id, line])
+	_r.check(missed == 0, "%s: faceplayer missed %d of %d talks." % [game_id, missed, talked])
+	print("%s: faceplayer turned %d of %d talks" % [game_id, talked - missed, talked])
+
+
+func _opens_on_face_player(
+	data: GameData, world: Gen2WorldAPI, object: Gen2WorldObject
+) -> bool:
+	if not object.object_type in TALKABLE_OBJECT_TYPES or object.event_script <= 0:
+		return false
+	var bank: int = int(world.current_map.events.get("bank", 0))
+	var raw: PackedByteArray = data.world_script(bank, object.event_script)
+	if raw.is_empty():
+		return false
+	return Gen2WorldScript.command_name(
+		int(raw[0]), Gen2WorldState.is_crystal_profile(data)
+	) in FACE_PLAYER_COMMANDS
+
+
+## Stands the player on one neighbouring cell looking at [param object] and
+## presses A. False where a wall, an object or a counter rules that side out.
+func _talk_from(world: Gen2WorldAPI, object: Gen2WorldObject, facing: int) -> bool:
+	var cell: Vector2i = object.cell + ((NEIGHBOURS[facing] as Array)[0] as Vector2i)
+	if cell.x < 0 or cell.y < 0 \
+		or cell.x >= world.current_map.collision_width \
+		or cell.y >= world.current_map.collision_height:
+		return false
+	if world.object_at(cell) != null or not world.can_walk_to(cell):
+		return false
+	world.player_cell = cell
+	world.player_facing = facing
+	if world.object_at(world.object_facing_cell()) != object:
+		return false
+	world.set_party_summary(1, false, [155] as Array[int], [[33]], ["CHIKORITA"], [false])
+	world.interact()
+	## The Copycat spins between her two `faceplayer`s.
+	for _frame: int in MOVEMENT_WAIT_FRAMES:
+		if StringName(world.pending_script_wait().get("wait", &"")) \
+			!= Gen2WorldScriptRunner.WAIT_MOVEMENT:
+			break
+		world.advance_script_presentation_frame()
+	return true

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -1,31 +1,29 @@
 extends SceneTree
 
-## Traces `MeetMomRightScript` through the world screen, frame by frame.
+## `MeetMomRightScript` through the world screen, frame by frame.
 ##
 ##   Godot --headless --path . -s res://tools/preview_mom_scene.gd -- <game> [png] [frame]
 ##
 ## The story walker proves the script's results, never that the presentation runs,
 ## and a run that moves a checkpoint exits non-zero. Crystal triggers on the coord
-## events at (8,4) and (9,4); Gold and Silver `sdefer` it from the map entry.
+## events at (8,4) and (9,4), Gold and Silver `sdefer` it from the map entry, and
+## `MomScript` is then talked to from the cell the scene left free.
 
 const WINDOW_SIZE := Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 const FRAME: float = 1.0 / 59.7275
-## Long enough for the whole conversation, which the trace answers as it goes.
 const TRACE_FRAMES: int = 4000
 
 ## The frame the emote, Mom's first drawn step, the text box and the script's own
-## `end` each land on, per profile. Every interval between them is the source's:
-## `showemote EMOTE_SHOCK, MOM1, 15` is 30 frames of emote, and the walk is
-## `MomWalksToPlayerMovement`'s own steps, both counted in overworld passes.
+## `end` land on. `showemote EMOTE_SHOCK, MOM1, 15` is 30 frames and the walk is
+## `MomWalksToPlayerMovement`, both counted in overworld passes.
 const CHECKPOINTS: Dictionary = {
 	&"crystal": {&"emote": 17, &"walk": 46, &"text": 77, &"done": 1909},
 	&"gold": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2039},
 	&"silver": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2039},
 }
 
-## Who looks at whom while the text is up: Crystal's `turnobject PLAYER, LEFT`
-## and Mom's `turn_head RIGHT` against pokegold's walk downstairs and her own
-## `turnobject ..., UP`. The cells read the same whether those ran or not.
+## Who looks at whom at the text: Crystal's `turnobject PLAYER, LEFT` and Mom's
+## `turn_head RIGHT` against pokegold's `turnobject ..., UP`.
 const FACINGS_AT_TEXT: Dictionary = {
 	&"crystal": {&"player": Gen2WorldSprite.FACING_LEFT, &"mom": Gen2WorldSprite.FACING_RIGHT},
 	&"gold": {&"player": Gen2WorldSprite.FACING_DOWN, &"mom": Gen2WorldSprite.FACING_UP},
@@ -33,16 +31,18 @@ const FACINGS_AT_TEXT: Dictionary = {
 }
 const FACING_NAMES: Array[String] = ["down", "up", "left", "right"]
 
-## Both pieces are `channel_count 3` on all three profiles, so a fourth music
-## channel on is the town still playing under `playmusic MUSIC_MOM`.
 const MUSIC_CHANNELS: int = 3
 
-## `constants/map_constants.asm`, and `Gen2WorldSpawn`'s own group.
 const PLAYERS_HOUSE_1F: int = 6
-## `MomWalksToPlayerMovement` starts here, and the player is met at (9,4).
 const MOM_OBJECT: int = 0
 const APPROACH_CELL := Vector2i(9, 3)
 const TRIGGER_CELL := Vector2i(9, 4)
+## Where `MomScript` is talked to once the scene has finished: her walk back
+## leaves her on (7,4) on Crystal and (7,3) on pokegold.
+const TALK_CELLS: Dictionary = {
+	&"crystal": Vector2i(8, 4), &"gold": Vector2i(8, 3), &"silver": Vector2i(8, 3),
+}
+const MOM_FACING_AT_TALK: int = Gen2WorldSprite.FACING_RIGHT
 
 var _game: StringName = &""
 var _screen: Gen2WorldScreen = null
@@ -50,6 +50,8 @@ var _output_path: String = ""
 var _capture_frame: int = TRACE_FRAMES
 var _frames: int = 0
 var _started: bool = false
+var _talk_frame: int = -1
+var _talk_facing: int = -1
 var _trace: Array[Dictionary] = []
 
 
@@ -93,16 +95,13 @@ func _initialize() -> void:
 	save.world = world.snapshot()
 	_screen.set_data(data)
 	_screen.set_save(save)
-	## The trace owns the clock. Without this the screen spends host frames of
-	## its own before the trace starts, and the row an event lands on moves by
-	## one from run to run.
+	## The trace owns the clock: host frames of its own move every row by one.
 	_screen.process_mode = Node.PROCESS_MODE_DISABLED
 	root.add_child(_screen)
 	current_scene = _screen
 
 
-## One row per source frame, so a gap in the presentation is a run of frames
-## with nothing happening rather than a missing event.
+## One row per source frame, so a gap is a run of frames rather than a hole.
 func _sample() -> Dictionary:
 	var world: Gen2WorldAPI = _screen._world
 	var mom: Gen2WorldObject = null
@@ -142,8 +141,13 @@ func _process(_delta: float) -> bool:
 	if not _trace.is_empty() and bool(_trace[-1]["waiting_input"]):
 		# Every question answered YES, the way the other preview drivers do.
 		_screen.press_button(Gen2Button.A)
+	elif not _trace.is_empty() and not bool(_trace[-1]["script_busy"]):
+		_drive_talk()
 	_screen._process(FRAME)
 	_trace.append(_sample())
+	if _talk_frame < 0 and _first_frame(&"done") >= 0 and bool(_trace[-1]["text"]):
+		_talk_frame = _frames
+		_talk_facing = int(_trace[-1]["mom_facing"])
 	if _frames == _capture_frame and not _output_path.is_empty():
 		var image: Image = Gen2ToolPath.capture(root)
 		if image == null:
@@ -158,8 +162,22 @@ func _process(_delta: float) -> bool:
 	return true
 
 
-## The first frame each of the three checkpoints appears on, against the pinned
-## row. Reported as a line per checkpoint so a shift names itself.
+func _drive_talk() -> void:
+	var world: Gen2WorldAPI = _screen._world
+	if _talk_frame >= 0 or _first_frame(&"text") < 0:
+		return
+	var target: Vector2i = TALK_CELLS.get(_game, Vector2i(8, 4))
+	var step := Vector2i(signi(target.x - world.player_cell.x), 0)
+	if step == Vector2i.ZERO:
+		step = Vector2i(0, signi(target.y - world.player_cell.y))
+	if step == Vector2i.ZERO and world.player_facing == Gen2WorldSprite.FACING_LEFT:
+		_screen.press_button(Gen2Button.A)
+		return
+	_screen.move_player(step if step != Vector2i.ZERO else Vector2i(-1, 0))
+
+
+## The first frame each checkpoint appears on, a line each so a shift names
+## itself.
 func _checkpoints_hold() -> bool:
 	var expected: Dictionary = CHECKPOINTS.get(_game, {})
 	if expected.is_empty():
@@ -173,6 +191,7 @@ func _checkpoints_hold() -> bool:
 			printerr("%s %s first appears on frame %d, not %d" % [_game, name, at, want])
 			held = false
 	held = _facings_hold() and held
+	held = _talk_facing_holds() and held
 	held = _channels_hold() and held
 	print("%s checkpoints %s" % [_game, "hold" if held else "MOVED"])
 	return held
@@ -195,6 +214,20 @@ func _facings_hold() -> bool:
 		])
 		held = false
 	return held
+
+
+## `MovementFunction_Standing`'s STEP_TYPE_RESTORE resets once and stands, so a
+## standing object holds what `MomScript`'s own `faceplayer` gives it.
+func _talk_facing_holds() -> bool:
+	if _talk_frame < 0:
+		printerr("%s never got MomScript's own box up" % _game)
+		return false
+	if _talk_facing == MOM_FACING_AT_TALK:
+		return true
+	printerr("%s faceplayer left Mom looking %s, not %s" % [
+		_game, _facing_name(_talk_facing), _facing_name(MOM_FACING_AT_TALK),
+	])
+	return false
 
 
 func _facing_name(facing: int) -> String:
@@ -229,7 +262,6 @@ func _first_frame(name: StringName) -> int:
 	return -1
 
 
-## Prints only where something changed, which is what makes a stall readable.
 func _report() -> void:
 	var last: Dictionary = {}
 	var changes: int = 0

--- a/tools/trace_world_script.gd
+++ b/tools/trace_world_script.gd
@@ -4,28 +4,21 @@ extends SceneTree
 ## order it ran and with the `bank:address` the cartridge would hold for it. The
 ## port half of `.claude/oracle/overworld/trace_script.py`: the line is
 ## `frame bank:addr opcode name`, so a branch taken on the wrong side of a flag
-## shows up as the first differing address. The walk list is the steps taken before
-## A is pressed, a count of zero being a turn on the spot; A is then pressed every
-## fourteenth frame, the cadence the cartridge trace mashes at. Arguments:
-## `<game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>`.
+## shows up as the first differing address. Arguments:
+## `<game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt> [new|dev]`.
+## The walk is untraced setup, `a:<count>` pressing A past a scene script in the
+## way, and the save is the new game the oracle's own checkpoints hold.
 
-## The cartridge trace's own pace: slow enough that a box waiting for a press is
-## not pressed twice.
+## The cartridge trace's own pace: slow enough not to press a box twice.
 const PRESS_EVERY: int = 14
-## A scratch root, so a run cannot reach the owner's own saves: the world is
-## given a save because half the script commands read one, VAR_BOXSPACE and
-## VAR_PARTYCOUNT among them, and a world with none fails the command rather
-## than inventing an empty party.
+## A scratch root, so a run cannot reach the owner's own saves. There is one at
+## all because VAR_BOXSPACE, VAR_PARTYCOUNT and half the rest read a save.
 const SAVE_ROOT: String = "user://trace_world_script_slots"
-## Frames with no script running before a run is called finished.
 const IDLE_FRAMES: int = 90
 
 
-## The runner being drained, held across the frame it finishes on.
 var _runner: Gen2WorldScriptRunner = null
 var _seen: int = 0
-## Set once a conversation has run and ended. One talk is the artefact, and a
-## press into the object it was with starts the same one over.
 var _finished: bool = false
 
 
@@ -37,7 +30,9 @@ func _run() -> void:
 	await process_frame
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 8:
-		push_error("usage: <game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt>")
+		push_error(
+			"usage: <game> <group> <map> <x> <y> <dir:count,...> <frames> <out.txt> [new|dev]"
+		)
 		quit(2)
 		return
 	if Gen2ToolPath.refuses(args[7]):
@@ -51,9 +46,11 @@ func _run() -> void:
 
 	DirAccess.make_dir_recursive_absolute(SAVE_ROOT)
 	Gen2SaveStore.use_root(SAVE_ROOT)
-	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	var development: bool = args.size() > 8 and args[8] == "dev"
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0) if development \
+		else Gen2SaveStore.create_new_game(data, 0, "ASH")
 	if save == null:
-		push_error("no development save")
+		push_error("no save")
 		quit(2)
 		return
 	save.world = null
@@ -77,11 +74,15 @@ func _run() -> void:
 	var lines: PackedStringArray = PackedStringArray(["# frame bank:addr opcode name"])
 	var frame: int = 0
 
-	var walked: int = _walk(screen, lines, args[5], frame)
+	var setup: PackedStringArray = PackedStringArray()
+	var walked: int = _walk(screen, setup, args[5], frame)
 	if walked < 0:
 		quit(2)
 		return
 	frame = walked
+	_runner = null
+	_seen = 0
+	_finished = false
 
 	print("talking from %s facing %d" % [screen._world.player_cell, screen._world.player_facing])
 	frame = _spend(screen, lines, frame, maxi(1, int(args[6])))
@@ -100,10 +101,19 @@ func _walk(
 	for step: String in spec.split(",", false):
 		var parts: PackedStringArray = step.split(":")
 		var button: int = _button_for(parts[0])
-		if button == Gen2Button.NONE:
-			push_error("a walk step is <up|down|left|right>:<count>")
-			return -1
 		var cells: int = int(parts[1]) if parts.size() > 1 else 1
+		if parts[0].to_lower() == "a":
+			for press: int in cells:
+				for spent: int in PRESS_EVERY:
+					if spent == 0:
+						screen.press_button(Gen2Button.A)
+					screen.advance_frame()
+					_collect(screen, lines, frame)
+					frame += 1
+			continue
+		if button == Gen2Button.NONE:
+			push_error("a walk step is <up|down|left|right|a>:<count>")
+			return -1
 		if cells == 0:
 			var turns: int = 0
 			while turns < 16 and screen._world.player_facing != _facing_for(button):
@@ -153,10 +163,8 @@ func _spend(
 	return frame
 
 
-## Drains whatever the runner has executed since the last frame, and drains a
-## runner that finished inside the frame before letting go of it: the commands
-## after the last wait all run on one frame, and a sample that only ever looks
-## at the live runner loses every one of them.
+## Drains what the runner ran since the last frame, and a runner that finished
+## inside it: the commands after the last wait all run on one frame.
 func _collect(screen: Gen2WorldScreen, lines: PackedStringArray, frame: int) -> void:
 	var runner: Gen2WorldScriptRunner = screen._world._active_script
 	if runner != _runner:
@@ -182,8 +190,6 @@ func _drain(lines: PackedStringArray, frame: int) -> void:
 	_seen = trace.size()
 
 
-## The facing a held direction settles on, which is what says a turn on the spot
-## has been taken.
 func _facing_for(button: int) -> int:
 	match button:
 		Gen2Button.UP: return Gen2WorldSprite.FACING_UP


### PR DESCRIPTION
Two reported defects, both a class rather than a case.

## Fixed

`Gen2WorldScriptRunner.advance` threw away every event a command emitted in front of its own pause. A command that answers with `_waiting_result()` has already drained the event list, and the second result built over it is empty, so `faceplayer` before a `trade` or a `special BankOfMom` never reached the object. Mom talks about the Bank of Mom without looking at the player, and so do Tim, Emy and Kim. The `_completed` branch three lines below already guarded the same thing.

`Gen2WorldAPI._finish_script_result` refused a failed script before applying what it had emitted. The commands in front of the failing one did run, `faceplayer` among them.

`DudeAutoInputs`' durations are `GetJoypad` polls, not frames (`home/joypad.asm`'s `.auto`). The catching tutorial spent them one a frame, so the Dude sat on the battle menu for 2,042 frames, which is thirty-four seconds of a fight the player can still press buttons in: it reads as an ordinary wild battle. Measured on a Crystal cartridge by hooking `GetJoypad` and `wAutoInputAddress` through Route 29's own tutorial, the cartridge presses DOWN 29 frames into that stream and A 53, because `Do2DMenuRTCJoypad.loopRTC` has no `DelayFrame` and polls about fifty times a frame while `.wait_input` polls once. `DUDE_POLLS_PER_FRAME` carries the three measured rates.

| Where | Before | After | Cartridge |
|---|---|---|---|
| Ball thrown, frames from the start of the fight | 2,349 | 458 | 1,529 to the whole fight |
| `faceplayer` talks turning, Crystal | 1,945/1,973 | 1,973/1,973 | |
| `faceplayer` talks turning, Gold and Silver | 1,797/1,822 | 1,822/1,822 | |

## Added

`tools/checks/scripted_scenes.gd` sweeps every object in the corpus whose script opens on `faceplayer` or `jumptextfaceplayer`, talked to from each side it is reachable from, in a world of its own each so a second press cannot resume the standing conversation. Eleven maps were missing the turn on Crystal and eight on the other two.

## Changed

`test_the_dude_plays_the_catching_tutorial_and_keeps_nothing` held the fight to an 8,000 frame guard, which the broken stream passed. It holds the throw to the cartridge's own 1,529 now and fails on the old code.

`tools/preview_mom_scene.gd` talks to Mom after the scene and pins the facing her box stands on, per profile: she is left on (7,4) on Crystal and (7,3) on Gold and Silver.

`tools/trace_world_script.gd` opens on a new game rather than a development save, which is the state the cartridge oracle's own checkpoints hold, and takes `a:<count>` walk steps so a trace can start behind a scene script.

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 4,131 tests, all passing |
| `tools/validate.gd -- all` | exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | each reaches Red |
| Editor analyser | 0 warnings in 608 scripts |
| Script trace against the cartridge | the Mom meeting and both Mom conversations command for command |
