### PR TITLE
Gate a release before the tag rather than after seven builds

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Refuses a push that CI would refuse, in under a second.
+#
+# Both of the last release's failures were of this shape: a comment line over
+# the recorded ceiling, and an editing note whose closing marker an edit had
+# taken with it. Each cost a full CI run to learn, and the second cost seven
+# builds. `tools/release.sh --gates` is the same set of checks the release
+# itself runs, so there is one definition of them.
+#
+# Enabled per-clone (hooks are not cloned) with:
+#   git config core.hooksPath .githooks
+
+set -e
+
+root=$(git rev-parse --show-toplevel)
+
+if [ -x "$root/tools/release.sh" ]; then
+	"$root/tools/release.sh" --gates || {
+		echo "" >&2
+		echo "pre-push: fix the above, or push with --no-verify if you mean it." >&2
+		exit 1
+	}
+fi
+
+# `CLAUDE.md` forbids naming a tool, an assistant or a company anywhere in the
+# history. A commit that does cannot be edited once it is on a protected branch.
+range=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo "origin/main")
+found=$(git log --format='%an <%ae>%n%B' "$range..HEAD" 2>/dev/null \
+	| grep -niE 'generated with|co-authored' || true)
+if [ -n "$found" ]; then
+	echo "pre-push: the commits carry an attribution trailer:" >&2
+	echo "$found" | sed 's/^/    /' >&2
+	exit 1
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,16 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      # Here rather than only in `publish`, which is seven builds and a quarter
+      # of an hour later. A body that renders to nothing is a one-line edit to
+      # fix and there is no reason to pay for the templates first.
+      - name: The release notes render to a body
+        run: |
+          set -euo pipefail
+          notes="$(sed '/^<!--/,/-->$/d' .github/release-notes.md | sed '/./,$!d')"
+          grep -q '^## ' <<<"$notes" \
+            || { echo "::error::release notes rendered no sections"; exit 1; }
+
   templates:
     needs: version
     uses: ./.github/workflows/export-templates.yml

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ download the new file and replace the old one. Saves live elsewhere and survive.
 
 ## Getting started
 
-You need Godot 4.8 or newer. Enable the commit guard once per clone:
+You need Godot 4.8 or newer. Enable the hooks once per clone. The commit one
+refuses cartridge data; the push one runs the checks CI runs that need no engine.
 
 ```bash
 git config core.hooksPath .githooks

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,6 +18,12 @@ sprites, text, maps or audio. Three layers enforce it:
 `roms/.gdignore` keeps Godot from importing or exporting that directory while
 tools still read it with `FileAccess`. Do not delete it.
 
+`.githooks/pre-push` runs `tools/release.sh --gates`, which is every check CI
+makes that needs no engine: the release notes render to a body with sections,
+the version agrees across its four files, and the comment total is under the
+ceiling `tests/unit/test_source_budget.gd` records. It takes under a second and
+the same hooks path enables it.
+
 ## Map
 
 | Path | Owns |

--- a/tests/unit/test_export_presets.gd
+++ b/tests/unit/test_export_presets.gd
@@ -7,6 +7,7 @@ extends GutTest
 
 const PRESETS: String = "res://export_presets.cfg"
 const ALTSTORE_SOURCE: String = "res://.github/altstore/source.json"
+const RELEASE_NOTES: String = "res://.github/release-notes.md"
 
 ## Preset names `.github/workflows/release.yml` exports by. Renaming one in the
 ## editor would leave the workflow asking for a preset that is not there, and
@@ -245,3 +246,58 @@ func test_the_altstore_source_describes_the_ios_preset() -> void:
 		assert_string_contains(String(version["downloadURL"]),
 			"/releases/download/v%s/" % version["version"], "the download is that release's own")
 		assert_gt(int(version["size"]), 0, "%s carries its byte count" % version["version"])
+
+
+## `.github/workflows/release.yml`'s own `sed '/^<!--/,/-->$/d'`, which is what
+## the published body is. The editing note names `## Added` in its own prose, so
+## a rewrite that starts from the first one in the file lands inside the note and
+## takes its closing marker with it; the range then runs to the end and the whole
+## file renders as nothing. 0.1.17 published an empty body that way and 0.1.18
+## spent a seven-target build finding out, so the contract is a test now.
+static func _rendered_notes() -> PackedStringArray:
+	var out := PackedStringArray()
+	var dropping: bool = false
+	for line: String in FileAccess.get_file_as_string(RELEASE_NOTES).split("\n"):
+		if dropping:
+			dropping = not line.strip_edges().ends_with("-->")
+			continue
+		if line.begins_with("<!--"):
+			dropping = not line.strip_edges().ends_with("-->")
+			continue
+		out.append(line)
+	while out.size() > 0 and out[0].strip_edges().is_empty():
+		out.remove_at(0)
+	return out
+
+
+func test_the_release_notes_render_to_a_body_that_opens_on_a_section() -> void:
+	var body: PackedStringArray = _rendered_notes()
+	assert_gt(body.size(), 0, "the release notes render to nothing")
+	if body.size() > 0:
+		assert_true(body[0].begins_with("## "), "the body opens on %s" % body[0])
+	var sections: int = 0
+	for line: String in body:
+		if line.begins_with("## "):
+			sections += 1
+	assert_gt(sections, 0, "the body carries no section")
+
+
+func test_the_release_notes_editing_note_is_opened_once_and_closed() -> void:
+	var opens: int = 0
+	var closes: int = 0
+	for line: String in FileAccess.get_file_as_string(RELEASE_NOTES).split("\n"):
+		if line.begins_with("<!--"):
+			opens += 1
+		if line.strip_edges().ends_with("-->"):
+			closes += 1
+	assert_eq(opens, 1, "one editing note")
+	assert_eq(closes, opens, "every editing note is closed")
+
+
+## The one punctuation `CLAUDE.md` forbids outright, checked where a body is
+## written rather than left to a reader.
+func test_the_release_notes_carry_no_em_dash() -> void:
+	assert_false(
+		FileAccess.get_file_as_string(RELEASE_NOTES).contains(char(0x2014)),
+		"the release notes carry an em dash"
+	)

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# The release, start to finish, and the gates in front of it.
+#
+#   tools/release.sh --gates          every check, changing nothing
+#   tools/release.sh 0.1.19           the same checks, then the version bump
+#
+# The version lives in four files and `tests/unit/test_export_presets.gd` holds
+# three of them to the fourth, so a hand edit that misses one fails a pull
+# request. Everything below fails before a tag exists instead, because a tag
+# costs seven builds and a quarter of an hour to tell you the same thing.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+fail() { echo "release: $1" >&2; exit 1; }
+
+android_code() {
+	local IFS=.
+	# shellcheck disable=SC2086
+	set -- $1
+	echo $(( $1 * 10000 + $2 * 100 + $3 ))
+}
+
+notes_render() {
+	sed '/^<!--/,/-->$/d' .github/release-notes.md | sed '/./,$!d'
+}
+
+# What `.github/workflows/release.yml` publishes as the body. An edit that
+# rewrites the top section from the first `## Added` in the file lands inside
+# the editing note, which names that heading in its own prose, and takes the
+# closing marker with it: the range then runs to the end and the body is empty.
+gate_notes() {
+	local opens closes body
+	opens=$(grep -c '^<!--' .github/release-notes.md || true)
+	closes=$(grep -c -- '-->$' .github/release-notes.md || true)
+	[ "$opens" = "1" ] || fail "release-notes.md opens $opens editing notes, expected 1"
+	[ "$closes" = "$opens" ] || fail "release-notes.md leaves an editing note unclosed"
+	body="$(notes_render)"
+	[ -n "$body" ] || fail "release-notes.md renders to nothing"
+	grep -q '^## ' <<<"$body" || fail "the rendered body carries no section"
+	head -1 <<<"$body" | grep -q '^## ' \
+		|| fail "the rendered body opens on prose rather than a section"
+	# The escape, not the character, so this line does not match itself.
+	! grep -q "$(printf '\u2014')" .github/release-notes.md \
+		|| fail "release-notes.md carries an em dash"
+	echo "  notes: $(grep -c '^## ' <<<"$body") sections, $(wc -l <<<"$body" | tr -d ' ') lines"
+}
+
+# The four places, against each other. `version/code` is
+# `major * 10000 + minor * 100 + patch`, which is what
+# `test_the_android_version_code_derives_from_the_app_version` holds it to: the
+# installer refuses a code below the one already on the device.
+gate_version() {
+	local declared project code
+	declared=$(sed -n 's/^const VERSION: String = "\(.*\)"$/\1/p' game/main/app_version.gd)
+	[ -n "$declared" ] || fail "game/main/app_version.gd states no version"
+	project=$(sed -n 's/^config\/version="\(.*\)"$/\1/p' project.godot)
+	[ "$project" = "$declared" ] || fail "project.godot says $project, not $declared"
+	for key in application/short_version application/version version/name; do
+		while read -r value; do
+			[ "$value" = "$declared" ] || fail "export_presets.cfg $key says $value, not $declared"
+		done < <(sed -n "s|^${key}=\"\(.*\)\"$|\1|p" export_presets.cfg)
+	done
+	code=$(sed -n 's/^version\/code=\(.*\)$/\1/p' export_presets.cfg)
+	[ "$code" = "$(android_code "$declared")" ] \
+		|| fail "export_presets.cfg version/code is $code, not $(android_code "$declared")"
+	echo "  version: $declared everywhere, android code $code"
+}
+
+# Comment lines under the three roots `tests/unit/test_source_budget.gd` counts,
+# against the ceiling it records. The same number, reached without the engine,
+# so a push cannot spend a CI run learning it.
+gate_comments() {
+	local ceiling total
+	ceiling=$(sed -n 's/^const MAX_COMMENT_LINES: int = \([0-9]*\)$/\1/p' \
+		tests/unit/test_source_budget.gd)
+	total=$(find autoload game tools -name '*.gd' -print0 \
+		| xargs -0 awk '{ s=$0; sub(/^[ \t]+/, "", s); if (substr(s, 1, 1) == "#") n++ }
+			END { print n + 0 }')
+	[ "$total" -le "$ceiling" ] \
+		|| fail "$total comment lines under autoload, game, tools, ceiling $ceiling"
+	echo "  comments: $total of $ceiling"
+}
+
+gate_tree() {
+	git diff --quiet && git diff --cached --quiet \
+		|| fail "the tree is dirty; commit or stash first"
+}
+
+gates() {
+	echo "release gates:"
+	gate_notes
+	gate_version
+	gate_comments
+}
+
+if [ "${1:-}" = "--gates" ]; then
+	gates
+	echo "release: gates pass"
+	exit 0
+fi
+
+version="${1:-}"
+[ -n "$version" ] || fail "usage: tools/release.sh --gates | tools/release.sh <version>"
+grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' <<<"$version" || fail "version must be X.Y.Z"
+gate_tree
+[ "$(git rev-parse --abbrev-ref HEAD)" != "main" ] \
+	|| fail "branch first: main takes nothing but a pull request"
+
+last="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [ -n "$last" ] && git diff --quiet "$last" -- .github/release-notes.md; then
+	fail "release-notes.md is unchanged since $last; rewrite its top section first"
+fi
+
+sed -i.bak "s/^const VERSION: String = \".*\"$/const VERSION: String = \"$version\"/" \
+	game/main/app_version.gd
+sed -i.bak "s|^config/version=\".*\"$|config/version=\"$version\"|" project.godot
+sed -i.bak \
+	-e "s|^application/short_version=\".*\"$|application/short_version=\"$version\"|" \
+	-e "s|^application/version=\".*\"$|application/version=\"$version\"|" \
+	-e "s|^version/name=\".*\"$|version/name=\"$version\"|" \
+	-e "s|^version/code=.*$|version/code=$(android_code "$version")|" \
+	export_presets.cfg
+rm -f game/main/app_version.gd.bak project.godot.bak export_presets.cfg.bak
+
+gates
+cat <<NEXT
+
+release: $version written to the four places. What is left:
+
+  git commit -am "Release $version"
+  git push -u origin <branch> && gh pr create --title "Release $version" --body ...
+  # merge it, then from main:
+  git checkout main && git pull
+  git tag v$version && git push origin v$version
+
+The workflow builds the seven targets, publishes them with sha256sums.txt,
+announces the release and opens the AltStore pull request itself. Do not run
+tools/altstore_source.sh by hand and do not open a second one.
+NEXT


### PR DESCRIPTION
0.1.18 took thirteen workflow runs. Two failures caused all of it, and the tree knew the answer to both before either push.

## Fixed

- The release notes render to nothing when the editing note above the top section loses its closing marker, which an edit that rewrites from the first `## Added` in the file does, because the note names that heading in its own prose. The only check for it ran in `publish`, after the seven builds and about fifteen minutes. It runs in the `version` job now, thirty seconds in.

## Added

- `tools/release.sh`. `--gates` is every check that needs no engine, in under a second: the rendered body, the four version places against each other with Android's `version/code` at `major * 10000 + minor * 100 + patch`, and the comment total against the ceiling `tests/unit/test_source_budget.gd` records. Given a version it also refuses a dirty tree, refuses `main`, refuses release notes unchanged since the last tag, writes the four places, and prints what is left to do.
- `.githooks/pre-push`, which runs those gates and refuses an attribution trailer. A comment line over the ceiling costs a second rather than a CI run. Hooks are not cloned, so `git config core.hooksPath .githooks` enables both it and the existing commit guard; the README and `docs/CONTRIBUTING.md` say so.
- Three cases in `tests/unit/test_export_presets.gd`, the file that already owns everything a release is published from: the notes carry one editing note and it is closed, they render to a body that opens on a section, and they carry no em dash. Breaking the closing marker on purpose fails all three.

## Proving it

| Check | Result |
|---|---|
| GUT, both tiers | 4,134 tests, all passing |
| Editor analyser | 0 warnings in 608 scripts |
| `tools/release.sh --gates` | passes, and fails on a truncated note, an em dash, a mismatched version and an over-budget comment |
| `tools/release.sh 0.1.19` in a scratch worktree | refuses a dirty tree, refuses unchanged notes, then writes all four places and leaves `test_export_presets` green |
