### PR TITLE
Decode every script command the corpus uses and spend an earthquake as a movement

### DIFF
--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -514,6 +514,9 @@ func _record_script_site(
 			## `db dialog_id / dw mart_id`, so the dialog is the byte and the
 			## mart index the word behind it.
 			var mart: int = int(command.get("address", 0))
+			## `world_mart` answers an out-of-range index with a default shelf.
+			if mart < 0 or mart >= _data.world_mart_count():
+				return
 			_add(KIND_SHOP, bank, address, offset, {
 				"mart": mart,
 				"dialog": int(command.get("value", 0)),

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4464,7 +4464,6 @@ const SCRIPT_EVENT_HANDLERS: Dictionary = {
 	&"wild_encounters_changed": &"_script_wild_encounters",
 	&"command_queue_written": &"_script_queue_write",
 	&"command_queue_deleted": &"_script_queue_delete",
-	&"earthquake_requested": &"_script_earthquake",
 	&"object_follow": &"_script_object_follow",
 	&"object_stop_follow": &"_script_object_stop_follow",
 	&"player_face_object": &"_script_player_face_object",
@@ -4632,12 +4631,6 @@ func _script_queue_delete(event: Dictionary) -> Array:
 	return [apply_command_queue_delete(int(event.get("queue_id", -1)))]
 
 
-func _script_earthquake(event: Dictionary) -> Array:
-	return [{
-		"type": &"screen_shake_requested", "strength": int(event.get("strength", 0)),
-	}]
-
-
 ## `wObjectFollow_Leader` and `wObjectFollow_Follower` are one byte each, so a
 ## second `follow` replaces the pair rather than adding to it.
 func _script_object_follow(event: Dictionary) -> Array:
@@ -4773,6 +4766,14 @@ func _apply_player_override(type: StringName, event: Dictionary) -> bool:
 	return false
 
 
+func _movement_stream(event: Dictionary) -> PackedByteArray:
+	if event.has("movement"):
+		return PackedByteArray(event["movement"])
+	return data.world_movement(
+		int(event.get("bank", 0)), int(event.get("address", 0))
+	)
+
+
 func _apply_object_movement(event: Dictionary) -> Array:
 	var generated: Array = []
 	var map_group: int = int(event.get("map_group", -1))
@@ -4782,10 +4783,7 @@ func _apply_object_movement(event: Dictionary) -> Array:
 		or object_index < 0 or object_index >= objects.size():
 		generated.append({"type": &"movement_failed", "reason": &"invalid_object"})
 		return generated
-	var raw: PackedByteArray = data.world_movement(
-		int(event.get("bank", 0)), int(event.get("address", 0))
-	)
-	var decoded: Dictionary = Gen2WorldMovement.decode(raw)
+	var decoded: Dictionary = Gen2WorldMovement.decode(_movement_stream(event))
 	if not bool(decoded.get("ok", false)):
 		generated.append({
 			"type": &"movement_failed", "reason": decoded.get("reason", &"invalid_movement"),
@@ -4925,10 +4923,7 @@ func _apply_player_movement(event: Dictionary) -> Array:
 	var map_number: int = int(event.get("map_number", -1))
 	if current_map == null or map_group != current_map.group or map_number != current_map.number:
 		return [{"type": &"movement_failed", "reason": &"invalid_map"}]
-	var raw: PackedByteArray = data.world_movement(
-		int(event.get("bank", 0)), int(event.get("address", 0))
-	)
-	var decoded: Dictionary = Gen2WorldMovement.decode(raw)
+	var decoded: Dictionary = Gen2WorldMovement.decode(_movement_stream(event))
 	if not bool(decoded.get("ok", false)):
 		return [{
 			"type": &"movement_failed", "reason": decoded.get("reason", &"invalid_movement"),

--- a/game/world/world_movement.gd
+++ b/game/world/world_movement.gd
@@ -37,6 +37,12 @@ static func spin_advance(frame: int) -> int:
 static func spin_facing(frame: int) -> int:
 	return SPIN_FACINGS[(frame >> 4) & 3]
 
+
+## `EarthquakeMovement`: `step_shake`'s displacement, its low six bits the sleep.
+static func earthquake_stream(value: int) -> PackedByteArray:
+	return PackedByteArray([0x55, value & 0xFF, 0x46, value & 0x3F, STEP_END])
+
+
 static func decode(data: PackedByteArray) -> Dictionary:
 	if data.is_empty():
 		return {"ok": false, "reason": &"missing_movement"}

--- a/game/world/world_script.gd
+++ b/game/world/world_script.gd
@@ -276,6 +276,7 @@ const COMMAND_WIDTHS: Dictionary = {
 		CLOSETEXT, YESORNO, CLOSEWINDOW, WAITBUTTON, ENDCALLBACK
 	],
 	2: [
+		GETCOINS,
 		SETSCENE, SETVAL, ADDVAL, RANDOM, READVAR, WRITEVAR, CHECKITEM, ADDCELLNUM,
 		DELCELLNUM, CHECKCELLNUM, CHECKTIME, CHECKPOKE, GETNUM, GETCURLANDMARKNAME,
 		REANCHORMAP, WRITEUNUSEDBYTE
@@ -308,9 +309,9 @@ static func _width_of(runs: Dictionary) -> Dictionary:
 			out[opcode] = width
 	return out
 
-## The opcodes Crystal and pokegold give different widths, as [crystal, gold].
+## The opcodes the two profiles give different widths, as [crystal, gold]. A zero
+## falls through to the later table rather than meaning "no command".
 const PROFILE_COMMAND_WIDTHS: Dictionary = {
-	GETCOINS: [3, 2],
 	FARJUMPTEXT: [4, 3],
 	JUMPTEXT: [3, 1],
 	PROMPTBUTTON: [1, 2],
@@ -323,7 +324,9 @@ const PROFILE_COMMAND_WIDTHS: Dictionary = {
 
 static func command_width(opcode: int, crystal_commands: bool = true) -> int:
 	if PROFILE_COMMAND_WIDTHS.has(opcode):
-		return PROFILE_COMMAND_WIDTHS[opcode][0 if crystal_commands else 1]
+		var profile_width: int = PROFILE_COMMAND_WIDTHS[opcode][0 if crystal_commands else 1]
+		if profile_width > 0:
+			return profile_width
 	if WIDTH_OF.has(opcode):
 		return WIDTH_OF[opcode]
 	if crystal_commands:
@@ -359,9 +362,9 @@ static func _later_command_width(opcode: int) -> int:
 			return 1
 		0x5C, 0x5D, 0x69, 0x6B, 0x6C, 0x6F, 0x75, 0x76, 0x7C, 0x7E, 0x83, 0x84, 0x8C, 0x8E, 0x94, 0x97, 0x9B, 0x9D, 0x9E:
 			return 3
-		0x60, 0x61, 0x62, 0x67, 0x6D, 0x6E, 0x72, 0x73, 0x77, 0x78, 0x7D, 0x89, 0x8A, 0x8B, 0x91, 0x95, 0x96, 0x99, 0x9A:
+		0x60, 0x61, 0x62, 0x67, 0x6D, 0x6E, 0x72, 0x73, 0x77, 0x7D, 0x89, 0x8A, 0x8B, 0x91, 0x95, 0x96, 0x99, 0x9A:
 			return 2
-		0x68, 0x71, 0x74, 0x79, 0x80, 0x88, 0x93:
+		0x68, 0x71, 0x74, 0x78, 0x79, 0x80, 0x88, 0x93:
 			return 4
 		0x63:
 			return 5
@@ -662,17 +665,21 @@ const OPERANDS: Dictionary = {
 	GETCOINS: [["string_buffer", OPERAND_U8]],
 }
 
-## The rows Crystal reads differently: the four commands it inserted, which have
-## no pokegold opcode behind them, and `getcoins`, which takes a second buffer.
-## A row here is the whole answer, so nothing else is read.
+## The rows Crystal reads differently: the commands it inserted, which have no
+## pokegold opcode behind them. A row here is the whole answer.
 const CRYSTAL_OPERANDS: Dictionary = {
 	0x9F: [["item", OPERAND_U8], ["variable", OPERAND_U8]],
 	0xA0: [
 		["flag", OPERAND_U8], ["map_group", OPERAND_U8], ["map_number", OPERAND_U8]
 	],
 	0xA4: [["value", OPERAND_U8]],
+	0xA5: [["landmark", OPERAND_U8], ["string_buffer", OPERAND_U8]],
+	0xA6: [["trainer_group", OPERAND_U8], ["string_buffer", OPERAND_U8]],
+	0xA7: [
+		["name_type", OPERAND_U8], ["value", OPERAND_U8],
+		["string_buffer", OPERAND_U8]
+	],
 	0xA8: [["value", OPERAND_U8]],
-	GETCOINS: [["string_buffer", OPERAND_U8], ["string_buffer_2", OPERAND_U8]],
 }
 
 ## The commands past the seam, on pokegold's numbering.

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -136,6 +136,9 @@ var _cur_party_species: int = 0
 ## Which balance window `engine/menus/menu_2.asm` left standing, empty for none.
 var _money_window: StringName = &""
 
+const PIKACHU: int = 25
+const PIKACHU_DEBUG_LEVEL: int = 5
+
 const PHONE_RARE_ROLL_ATTEMPTS: int = 128
 const PHONE_CONTACT_GOT: int = 0
 const PHONE_CONTACTS_FULL: int = 1
@@ -430,9 +433,8 @@ const ROCK_SMASH_ASK_TEXT: String = \
 	"This rock looks\nbreakable." + Gen2TextStream.PAGE_BREAK \
 	+ "Want to use ROCK\nSMASH?"
 const ROCK_SMASH_MAY_SMASH_TEXT: String = "Maybe a #MON\ncan break this."
-## Script_earthquake's operand in RockSmashScript, kept because the runner
-## reports the request rather than shaking anything.
 const ROCK_SMASH_EARTHQUAKE: int = 84
+static var ROCK_SMASH_MOVEMENT: PackedByteArray = PackedByteArray([0x57, 10, 0x47])
 ## constants/sfx_constants.asm, whose comment column is hex. RockSmashScript
 ## plays the boulder's own sound rather than one of its own.
 const SFX_STRENGTH: int = 0x1B
@@ -1665,7 +1667,7 @@ func _complete_plain_request(
 		_stage_trainer_approach()
 	if smash_after_sound:
 		_rock_smash_after_sound = false
-		_stage_rock_smashed()
+		_stage_rock_smash_shake()
 	if not notify_after_sound.is_empty():
 		_item_notify_after_sound = {}
 		_stage_item_notify(
@@ -1880,7 +1882,14 @@ func complete_wait() -> Dictionary:
 	var hide_emote_object: int = int(
 		_pending.get("hide_emote_object", Gen2WorldObject.NONE_INDEX)
 	)
+	var rock_smash_step: int = int(_pending.get("rock_smash_step", 0))
 	_pending = {}
+	if rock_smash_step == 1:
+		_stage_rock_smash_movement()
+		return advance()
+	if rock_smash_step == 2:
+		_stage_rock_smashed()
+		return advance()
 	if hide_emote_object != Gen2WorldObject.NONE_INDEX:
 		_emit_object_event(&"object_emote", {
 			"object_index": hide_emote_object,
@@ -1977,6 +1986,7 @@ const COMMAND_HANDLERS: Dictionary = {
 	Gen2WorldScript.CHECKCELLNUM: &"_command_checkcellnum",
 	Gen2WorldScript.SPECIAL: &"_command_special",
 	Gen2WorldScript.RANDOM: &"_command_random",
+	Gen2WorldScript.XYCOMPARE: &"_command_xycompare",
 	Gen2WorldScript.GIVEITEM: &"_command_giveitem",
 	Gen2WorldScript.TAKEITEM: &"_command_takeitem",
 	Gen2WorldScript.CHECKITEM: &"_command_checkitem",
@@ -2026,6 +2036,27 @@ const COMMAND_HANDLERS: Dictionary = {
 ## no script in either pin prints what they leave.
 const HANDLED_BASE: Array[int] = [
 	Gen2WorldScript.GETNUM, Gen2WorldScript.GETCURLANDMARKNAME,
+]
+
+
+## Whether [method _execute] dispatches [param opcode]; the corpus sweeps it.
+static func handles_opcode(opcode: int, crystal_commands: bool = true) -> bool:
+	if opcode == Gen2WorldScript.FARJUMPTEXT \
+		or (crystal_commands and opcode == Gen2WorldScript.JUMPTEXT) \
+		or Gen2WorldScript.is_waitbutton(opcode, crystal_commands) \
+		or Gen2WorldScript.is_promptbutton(opcode, crystal_commands) \
+		or Gen2WorldScript.is_terminal(opcode, crystal_commands):
+		return true
+	if crystal_commands and (opcode in [0x9F, 0xA8, 0xA9] \
+		or CRYSTAL_NAME_COMMANDS.has(opcode)):
+		return true
+	var source: int = Gen2WorldScript.source_opcode(opcode, crystal_commands)
+	return source in OBJECT_SOURCE_OPCODES or LATER_HANDLERS.has(source) \
+		or COMMAND_HANDLERS.has(opcode) or opcode in HANDLED_BASE
+
+
+const OBJECT_SOURCE_OPCODES: Array[int] = [
+	0x67, 0x68, 0x69, 0x6A, 0x6B, 0x6D, 0x6E, 0x6F, 0x70, 0x71, 0x72, 0x75, 0x76,
 ]
 
 
@@ -2083,6 +2114,11 @@ func _execute_early_command(opcode: int, command: Dictionary, bank: int) -> Dict
 			"frames": int(command.get("value", 0)) * WAIT_FRAMES_PER_UNIT,
 		})
 		return _stage_frame_wait(int(command.get("value", 0)) * WAIT_FRAMES_PER_UNIT)
+	if _crystal_commands() and CRYSTAL_NAME_COMMANDS.has(opcode):
+		return call(CRYSTAL_NAME_COMMANDS[opcode], command)
+	if opcode == 0xA9 and _crystal_commands():
+		_script_value = 1
+		return {"ok": true}
 	if opcode == 0x9F and _crystal_commands():
 		## Crystal inserts verbosegiveitemvar at this raw byte. Normalizing first
 		## turns it into pokegold's swarm command.
@@ -2102,6 +2138,64 @@ func _execute_early_command(opcode: int, command: Dictionary, bank: int) -> Dict
 			return variable_given
 		return _stage_give_item_script(variable_item, variable_name)
 	return {}
+
+
+const CRYSTAL_NAME_COMMANDS: Dictionary = {
+	0xA5: &"_command_getlandmarkname",
+	0xA6: &"_command_gettrainerclassname",
+	0xA7: &"_command_getname",
+}
+
+const NAME_TYPE_MON: int = 1
+const NAME_TYPE_MOVE: int = 2
+const NAME_TYPE_ITEM: int = 4
+const NAME_TYPE_TRAINER: int = 7
+
+
+func _command_getlandmarkname(command: Dictionary) -> Dictionary:
+	var landmark: int = int(command.get("landmark", 0))
+	_set_text_buffer(
+		int(command.get("string_buffer", 0)),
+		data.landmark_name(landmark) if data != null else "",
+		&"landmark_name", {"landmark": landmark}
+	)
+	return {"ok": true}
+
+
+func _command_gettrainerclassname(command: Dictionary) -> Dictionary:
+	return _fill_name_buffer(
+		NAME_TYPE_TRAINER, int(command.get("trainer_group", 0)),
+		int(command.get("string_buffer", 0))
+	)
+
+
+func _command_getname(command: Dictionary) -> Dictionary:
+	return _fill_name_buffer(
+		int(command.get("name_type", 0)), int(command.get("value", 0)),
+		int(command.get("string_buffer", 0))
+	)
+
+
+func _fill_name_buffer(name_type: int, index: int, buffer: int) -> Dictionary:
+	var named: String = ""
+	if data != null:
+		match name_type:
+			NAME_TYPE_MON:
+				named = String(data.species(index).get("name", ""))
+			NAME_TYPE_MOVE:
+				named = String(data.move(index).get("name", ""))
+			NAME_TYPE_ITEM:
+				named = data.item_name(index)
+			NAME_TYPE_TRAINER:
+				named = data.trainer_name(index)
+	_set_text_buffer(
+		buffer, named, &"object_name", {"name_type": name_type, "index": index}
+	)
+	return {"ok": true}
+
+
+func _command_xycompare(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return {"ok": true}
 
 
 func _command_scall(_opcode: int, command: Dictionary, bank: int) -> Dictionary:
@@ -2709,6 +2803,8 @@ const LATER_HANDLERS: Dictionary = {
 	0x56: &"_command_closepokepic",
 	0x57: &"_command_two_d_menu",
 	0x58: &"_command_two_d_menu",
+	0x59: &"_command_loadpikachudata",
+	0x5A: &"_command_randomwildmon",
 	0x5B: &"_command_loadtemptrainer",
 	0x5C: &"_command_loadwildmon",
 	0x5D: &"_command_loadtrainer",
@@ -2743,9 +2839,13 @@ const LATER_HANDLERS: Dictionary = {
 	0x6C: &"_command_variablesprite",
 	0x8A: &"_command_pause",
 	0x8B: &"_command_pause",
-	0x8C: &"_command_sdefer",
+	0x88: &"_command_autoinput",
 	0x89: &"_command_newloadmap",
+	0x8C: &"_command_sdefer",
 	0x8D: &"_command_warpcheck",
+	0x8E: &"_command_stopandsjump",
+	0x91: &"_command_reloadend",
+	0x92: &"_command_endall",
 	0x93: &"_command_pokemart",
 	0x94: &"_command_elevator",
 	0x95: &"_command_trade",
@@ -2794,6 +2894,48 @@ func _command_closepokepic(_source_opcode: int, _command: Dictionary, _bank: int
 
 func _command_two_d_menu(source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
 	return _stage_menu(source_opcode == 0x57, command)
+
+
+func _command_loadpikachudata(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_battle_setup = _new_battle_setup({
+		"kind": &"wild", "pokemon": PIKACHU, "level": PIKACHU_DEBUG_LEVEL,
+	})
+	_emit_runtime_event(&"battle_setup_changed", _battle_setup)
+	return {"ok": true}
+
+
+func _command_randomwildmon(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	return {"ok": true}
+
+
+func _command_autoinput(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
+	_emit_runtime_event(&"auto_input_requested", {
+		"bank": int(command.get("bank", 0)),
+		"address": int(command.get("address", 0)),
+	})
+	return {"ok": true}
+
+
+func _command_stopandsjump(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	var jumped: Dictionary = _replace_frame(bank, int(command.get("address", 0)))
+	if not bool(jumped.get("ok", false)):
+		return jumped
+	return _stage_frame_wait(Gen2WorldAPI.passes_in_frames(1))
+
+
+func _command_reloadend(source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
+	var reloaded: Dictionary = _command_newloadmap(source_opcode, command, bank)
+	if not bool(reloaded.get("ok", false)):
+		return reloaded
+	_frames.pop_back()
+	if _frames.is_empty():
+		return _complete()
+	return {"ok": true}
+
+
+func _command_endall(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
+	_frames.clear()
+	return _complete()
 
 
 func _command_loadtemptrainer(_source_opcode: int, _command: Dictionary, bank: int) -> Dictionary:
@@ -2916,8 +3058,11 @@ func _command_scripttalkafter(_source_opcode: int, _command: Dictionary, bank: i
 
 
 func _command_endifjustbattled(_source_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
-	if _just_battled():
-		_frames.clear()
+	if not _just_battled():
+		return {"ok": true}
+	_frames.pop_back()
+	if _frames.is_empty():
+		return _complete()
 	return {"ok": true}
 
 
@@ -2967,15 +3112,21 @@ func _command_showemote(_source_opcode: int, command: Dictionary, _bank: int) ->
 	)
 
 
-## Script_earthquake is `ScriptCall` on `applymovement PLAYER,
-## wEarthquakeMovementDataBuffer`, whose stream is `step_shake n` then `step_sleep (n
-## & %00111111)`. The shake starts and the movement wait is that sleep, since
-## step_shake itself reaches ContinueReadingMovement without spending a frame.
 func _command_earthquake(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
-	_emit_runtime_event(&"earthquake_requested", {
-		"strength": int(command.get("value", 0)),
+	return _stage_earthquake(int(command.get("value", 0)))
+
+
+## `Script_earthquake` is `ScriptCall` on `applymovement PLAYER,
+## wEarthquakeMovementDataBuffer`; its sleep is in passes like every movement.
+func _stage_earthquake(value: int, values: Dictionary = {}) -> Dictionary:
+	_emit_object_event(&"player_movement_requested", {
+		"bank": int(_request.get("bank", 0)),
+		"movement": Gen2WorldMovement.earthquake_stream(value),
 	})
-	return _stage_frame_wait(int(command.get("value", 0)) & 0x3F)
+	var wait: Dictionary = {"object_index": Gen2WorldObject.PLAYER_INDEX}
+	for key: Variant in values:
+		wait[key] = values[key]
+	return _stage_movement_wait(wait)
 
 
 func _command_changemapblocks(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
@@ -3077,15 +3228,15 @@ func _command_variablesprite(_source_opcode: int, command: Dictionary, _bank: in
 
 
 ## Both write wScriptDelay when their operand is nonzero and reuse whatever is in it
-## when it is zero. `Script_pause` then spends `DelayFrames 2` per unit inside the
-## command; `Script_deactivatefacing` hands the same count to SCRIPT_WAIT, which
-## WaitScript decrements once per frame.
+## when it is zero, and both cost two hardware frames a unit: `Script_pause`
+## spends `DelayFrames 2` inside the command, and SCRIPT_WAIT's own `WaitScript`
+## runs once per overworld pass.
 func _command_pause(source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
 	var delay_operand: int = int(command.get("value", 0))
 	if delay_operand != 0:
 		_script_delay = delay_operand
 	var delay_frames: int = _script_delay * PAUSE_FRAMES_PER_UNIT \
-		if source_opcode == 0x8A else _script_delay
+		if source_opcode == 0x8A else Gen2WorldAPI.passes_in_frames(_script_delay)
 	_emit_runtime_event(&"script_timing_requested", {
 		"kind": &"pause" if source_opcode == 0x8A else &"deactivate_facing",
 		"value": delay_operand,
@@ -6860,14 +7011,23 @@ func _stage_rock_smash_used(slot: int) -> Dictionary:
 	return {"ok": true}
 
 
-## Everything RockSmashScript does after its text: `playsound SFX_STRENGTH`,
-## `earthquake 84`, the rock's one-command movement, `disappear LAST_TALKED` and
-## then RockMonEncounter. The sound and the shake are reported as events like
-## every other presentation request. `readmem wTempWildMonSpecies` and `iffalse
-## .done` test the roll, so a species of zero ends the script and anything else
-## reaches `randomwildmon`, `startbattle` and `reloadmapafterbattle`.
+## RockSmashScript past its sound, a staged wait at a time.
+func _stage_rock_smash_shake() -> Dictionary:
+	return _stage_earthquake(ROCK_SMASH_EARTHQUAKE, {"rock_smash_step": 1})
+
+
+func _stage_rock_smash_movement() -> Dictionary:
+	_emit_object_event(&"object_movement_requested", {
+		"object_index": _last_talked_object_index,
+		"bank": int(_request.get("bank", 0)),
+		"movement": ROCK_SMASH_MOVEMENT,
+	})
+	return _stage_movement_wait({
+		"object_index": _last_talked_object_index, "rock_smash_step": 2,
+	})
+
+
 func _stage_rock_smashed() -> void:
-	_emit_runtime_event(&"earthquake_requested", {"duration": ROCK_SMASH_EARTHQUAKE})
 	## `disappear LAST_TALKED` is DeleteObjectStruct plus
 	## ApplyEventActionAppearDisappear. The delete is reported as
 	## `object_deleted` rather than a visibility override, so a rock with no

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -908,12 +908,17 @@ func test_talking_to_a_rock_asks_and_then_smashes_it() -> void:
 	)
 	# Answered on the world rather than through Gen2WorldHost, which would want
 	# audio data this synthetic cache does not carry.
-	var completed: Array = world.complete_runtime_request({"ok": true})
-	assert_eq(completed[0]["status"], &"complete", JSON.stringify(completed))
+	var shaken: Array = world.complete_runtime_request({"ok": true})
+	assert_eq(shaken[0]["status"], &"waiting", JSON.stringify(shaken))
 	assert_true(
-		_has_event(completed[0]["events"], &"screen_shake_requested"),
-		"earthquake 84 is reported"
+		_has_event(shaken[0]["events"], &"screen_shake_requested"),
+		"earthquake 84 is its own applymovement"
 	)
+	assert_not_null(world.object_at(ROCK_CELL), "the rock stands until the shake ends")
+
+	# The shake's own `step_sleep`, then the rock's `rock_smash 10`.
+	var completed: Array = world.finish_script_waits()
+	assert_eq(completed[0]["status"], &"complete", JSON.stringify(completed))
 	assert_null(world.object_at(ROCK_CELL), "disappear LAST_TALKED took the rock")
 	assert_true(world.can_walk_to(ROCK_CELL))
 
@@ -932,7 +937,8 @@ func test_a_talked_rock_that_rolls_an_encounter_asks_for_a_battle() -> void:
 	world.run_event_queue(true)
 	world.choose_script_input(0)
 	world.run_event_queue(true)
-	var after_sound: Array = world.complete_runtime_request({"ok": true})
+	world.complete_runtime_request({"ok": true})
+	var after_sound: Array = world.finish_script_waits()
 	assert_eq(after_sound[0]["status"], &"waiting", JSON.stringify(after_sound))
 	var request: Dictionary = after_sound[0]["event"]["request"]
 	assert_eq(request["kind"], &"battle_requested")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4913,9 +4913,10 @@ func test_hangup_holds_the_script_for_the_whole_hang_up_sequence() -> void:
 
 
 ## `Script_pause` delays two frames per counted unit inside the command, and
-## `Script_deactivatefacing` hands the same count to SCRIPT_WAIT, which
-## `WaitScript` spends one a frame. Both write wScriptDelay only when their
-## operand is nonzero, which is what makes `pause 0` reuse it.
+## `Script_deactivatefacing` hands the same count to SCRIPT_WAIT, whose
+## `WaitScript` runs once per overworld pass, which is two frames as well. Both
+## write wScriptDelay only when their operand is nonzero, which is what makes
+## `pause 0` reuse it.
 func test_pause_and_deactivatefacing_spend_their_own_frame_counts() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	# pause 3, deactivatefacing 0, end.
@@ -4931,16 +4932,17 @@ func test_pause_and_deactivatefacing_spend_their_own_frame_counts() -> void:
 
 	assert_eq(runner.complete_wait()["status"], &"waiting")
 	assert_eq(
-		runner.pending_wait()["frames"], 3,
-		"a zero operand reuses wScriptDelay, and WaitScript spends one a frame"
+		runner.pending_wait()["frames"], Gen2WorldAPI.passes_in_frames(3),
+		"a zero operand reuses wScriptDelay, and WaitScript spends one a pass"
 	)
 	assert_eq(runner.complete_wait()["status"], &"complete")
 
 
 ## `Script_earthquake` is `ScriptCall` on `applymovement PLAYER,
-## wEarthquakeMovementDataBuffer`, whose stream shakes and then sleeps the low
-## six bits of the operand.
-func test_earthquake_waits_out_the_sleep_its_own_movement_carries() -> void:
+## wEarthquakeMovementDataBuffer`, so it hands the world the same
+## `player_movement_requested` an ordinary `applymovement` does and waits on the
+## movement rather than on a frame count.
+func test_earthquake_applies_its_own_movement_to_the_player() -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
 	scripts["48:6170"] = [0x78, 84, Gen2WorldScript.END]
 	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
@@ -4952,12 +4954,104 @@ func test_earthquake_waits_out_the_sleep_its_own_movement_carries() -> void:
 	var result: Dictionary = runner.advance()
 
 	assert_eq(result["status"], &"waiting")
-	assert_eq(runner.pending_wait()["frames"], 84 & 0x3F)
+	assert_eq(
+		runner.pending_wait().get("wait", &""),
+		Gen2WorldScriptRunner.WAIT_MOVEMENT
+	)
 	assert_true(result["events"].any(func(event: Dictionary) -> bool:
-		return event.get("type", &"") == &"earthquake_requested" \
-			and int(event.get("strength", 0)) == 84
+		return event.get("type", &"") == &"player_movement_requested" \
+			and PackedByteArray(event.get("movement", [])) \
+				== Gen2WorldMovement.earthquake_stream(84)
 	), JSON.stringify(result["events"]))
-	assert_eq(runner.complete_wait()["status"], &"complete")
+
+
+## The whole duration is the stream's `step_sleep`, which is counted in overworld
+## passes like every other movement: `earthquake 84` is twenty passes.
+func test_an_earthquake_holds_the_player_for_its_own_sleep() -> void:
+	RomCache.write_json(RomCache.world_scripts_path(_directory), {
+		"48:6070": [0x78, 84, Gen2WorldScript.END],
+	})
+	var data: GameData = GameData.open_directory(_directory)
+	data.world_map(1, 1).events["coord_events"][0]["script"] = 0x6070
+	var world := Gen2WorldAPI.open(data, 1, 1, Vector2i(7, 6))
+	var results: Array = _run_script(world, world.dispatch_script_events())
+
+	assert_eq(_final_status(results), &"complete")
+	var events: Array = _all_events(results)
+	var shakes: Array = events.filter(func(event: Dictionary) -> bool:
+		return event.get("type", &"") == &"screen_shake_requested"
+	)
+	assert_eq(shakes.size(), 1)
+	assert_eq(int((shakes[0] as Dictionary)["strength"]), 84)
+
+
+## `Script_endall` drops the whole stack; `Script_reloadend` is `newloadmap` and
+## then `Script_end`, which returns to a caller; `Script_stopandsjump` jumps and
+## yields a pass. None of the three had a handler, so each answered
+## `unsupported_runtime_command`.
+func test_the_three_script_enders_dispatch() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# scall .sub, newloadmap 5, end | .sub: reloadend 1
+	scripts["48:6190"] = [0x00, 0xA0, 0x61, 0x8A, 5, Gen2WorldScript.END]
+	scripts["48:61A0"] = [0x92, 1]
+	# The same with endall, which the caller never comes back from.
+	scripts["48:61B0"] = [0x00, 0xC0, 0x61, 0x8A, 5, Gen2WorldScript.END]
+	scripts["48:61C0"] = [0x93]
+	# stopandsjump to a bare end.
+	scripts["48:61D0"] = [0x8F, 0xE0, 0x61]
+	scripts["48:61E0"] = [Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+
+	var reloaded := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6190,
+	})
+	var reload_result: Dictionary = reloaded.advance()
+	assert_eq(reload_result["status"], &"complete")
+	assert_eq(
+		_types_of(reload_result).count(&"map_entry_method_requested"), 2,
+		"reloadend ended its own frame and the caller ran on"
+	)
+
+	var ended := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x61B0,
+	})
+	var end_result: Dictionary = ended.advance()
+	assert_eq(end_result["status"], &"complete")
+	assert_eq(
+		_types_of(end_result).count(&"map_entry_method_requested"), 0,
+		"endall dropped the caller too"
+	)
+
+	var jumped := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x61D0,
+	})
+	var jump_result: Dictionary = jumped.advance()
+	assert_eq(jump_result["status"], &"waiting", JSON.stringify(jump_result))
+	assert_eq(jumped.complete_wait()["status"], &"complete")
+
+
+## `Script_getlandmarkname` and `Script_gettrainerclassname`, Crystal's own two
+## raw bytes. Both had operands nobody decoded and no handler at all, and the
+## phone scripts name them 119 times between them.
+func test_the_crystal_name_commands_fill_their_string_buffers() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	# getlandmarkname STRING_BUFFER_4, 1 | gettrainerclassname STRING_BUFFER_5, 1
+	scripts["48:6200"] = [
+		0xA5, 1, RomLayout.STRING_BUFFER_4,
+		0xA6, 1, RomLayout.STRING_BUFFER_5,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6200,
+	})
+
+	assert_eq(runner.advance()["status"], &"complete")
+	var buffers: Dictionary = runner.text_context().get("buffers", {})
+	assert_eq(String(buffers.get(RomLayout.STRING_BUFFER_4, "")), data.landmark_name(1))
+	assert_eq(String(buffers.get(RomLayout.STRING_BUFFER_5, "")), data.trainer_name(1))
 
 
 ## An event is handed to its caller once. The runner drains its list on every
@@ -4974,12 +5068,12 @@ func test_a_script_hands_each_event_to_its_caller_once() -> void:
 	})
 
 	var shaken: Dictionary = runner.advance()
-	assert_eq(_types_of(shaken).count(&"earthquake_requested"), 1)
+	assert_eq(_types_of(shaken).count(&"player_movement_requested"), 1)
 
 	var paused: Dictionary = runner.complete_wait()
 	assert_eq(paused["status"], &"waiting")
 	assert_eq(
-		_types_of(paused).count(&"earthquake_requested"), 0,
+		_types_of(paused).count(&"player_movement_requested"), 0,
 		"the shake was already delivered"
 	)
 

--- a/tests/unit/test_world_script.gd
+++ b/tests/unit/test_world_script.gd
@@ -39,12 +39,15 @@ func test_command_parser_reads_profile_specific_object_commands() -> void:
 	assert_eq(gold_coins["width"], 2)
 	assert_eq(gold_coins["string_buffer"], 4)
 
+	## Both profiles' `getcoins` macro is `db getcoins_command / db string_buffer`
+	## and `Script_getcoins` ends in one `GetStringBuffer`, so there is no second
+	## buffer on either. Reading one ate the byte after every Crystal `getcoins`.
 	var crystal_coins: Dictionary = Gen2WorldScript.command_at(
-		PackedByteArray([0x3E, 4, 5]), 0, true
+		PackedByteArray([0x3E, 4]), 0, true
 	)
 	assert_true(crystal_coins["ok"])
-	assert_eq(crystal_coins["width"], 3)
-	assert_eq(crystal_coins["string_buffer_2"], 5)
+	assert_eq(crystal_coins["width"], 2)
+	assert_eq(crystal_coins["string_buffer"], 4)
 
 
 func test_crystal_trainer_and_tutorial_commands_use_the_pinned_layout() -> void:

--- a/tools/checks/catalog.gd
+++ b/tools/checks/catalog.gd
@@ -26,9 +26,9 @@ const RED_GYARADOS: int = 130
 ## Per game: total rows, and the count under each kind in
 ## [constant Gen2WorldCatalog.KINDS]' own order.
 const EXPECTED_CENSUS: Dictionary = {
-	&"gold": [465, 3, 9, 15, 8, 9, 352, 16, 53],
-	&"silver": [465, 3, 9, 15, 8, 9, 352, 16, 53],
-	&"crystal": [532, 3, 11, 14, 9, 6, 419, 16, 54],
+	&"gold": [449, 3, 9, 15, 8, 9, 352, 16, 37],
+	&"silver": [449, 3, 9, 15, 8, 9, 352, 16, 37],
+	&"crystal": [516, 3, 11, 14, 9, 6, 419, 16, 38],
 }
 
 ## The legendaries and set pieces every profile has to place, and at what level.

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -21,6 +21,13 @@ const PLAYER_OPERAND_COMMANDS: Array[String] = [
 	"turnobject", "showemote", "disappear",
 ]
 
+## The two with no runner on purpose: each names an address absent from the pins.
+const NO_RUNNER: Array[String] = ["callasm", "memcallasm"]
+
+const PINS: Dictionary = {
+	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",
+}
+
 var _r: RefCounted = null
 
 ## Reports how far the cached overworld script and text resources can be read.
@@ -35,6 +42,72 @@ func run(r: RefCounted) -> void:
 	for game_id: StringName in _r.GAME_IDS:
 		if not _validate(game_id):
 			_r.fail("%s: the cached scripts and text did not read back." % game_id)
+		_check_command_widths(game_id)
+
+
+## Every command byte's name and width against the pin's own
+## `macros/scripts/events.asm`, where a `db` is one byte and a `dw` is two.
+func _check_command_widths(game_id: StringName) -> void:
+	var pin: String = _reference_root().path_join(String(PINS[game_id]))
+	var path: String = pin.path_join("macros/scripts/events.asm")
+	if not FileAccess.file_exists(path):
+		_r.note("%s is not checked out, so no command widths were compared." % pin.get_file())
+		return
+	var crystal: bool = game_id == &"crystal"
+	var compared: int = 0
+	for row: Dictionary in _macro_commands(FileAccess.get_file_as_string(path)):
+		var opcode: int = int(row["opcode"])
+		var name: String = String(row["name"])
+		compared += 1
+		_r.check(
+			Gen2WorldScript.command_width(opcode, crystal) == int(row["width"]) \
+				and String(Gen2WorldScript.command_name(opcode, crystal)) == name,
+			"%s: %s ($%02X) is %s wide and named %s, not %d and %s." % [
+				game_id, name, opcode,
+				Gen2WorldScript.command_width(opcode, crystal),
+				Gen2WorldScript.command_name(opcode, crystal),
+				int(row["width"]), name,
+			]
+		)
+	_r.note("%s: %d command macros compared." % [game_id, compared])
+
+
+## `const <name>_command ; $xx` and its `MACRO`, as { opcode, name, width }. A
+## body that is not plain `db`, `dw` and `map_id` lines branches on its operands
+## and is skipped; the unit tier pins those six.
+func _macro_commands(source: String) -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	var pattern := RegEx.create_from_string(
+		"const (\\w+)_command ; \\$([0-9a-f]{2})\\n(?:EXPORT[^\\n]*\\n)?MACRO \\1\\n([\\s\\S]*?)\\nENDM"
+	)
+	for found: RegExMatch in pattern.search_all(source):
+		var width: int = 0
+		var known: bool = true
+		for raw: String in found.get_string(3).split("\n"):
+			var line: String = raw.strip_edges()
+			if line.is_empty() or line.begins_with(";"):
+				continue
+			elif line.begins_with("db "):
+				width += 1
+			elif line.begins_with("dw ") or line.begins_with("map_id"):
+				width += 2
+			else:
+				known = false
+		if not known:
+			continue
+		out.append({
+			"opcode": found.get_string(2).hex_to_int(),
+			"name": found.get_string(1).lstrip("_"),
+			"width": width,
+		})
+	return out
+
+
+func _reference_root() -> String:
+	var override: String = OS.get_environment("GEN2_REFERENCE_ROOT")
+	if override != "":
+		return override
+	return ProjectSettings.globalize_path("res://").path_join(".references")
 
 
 func _validate(game_id: StringName) -> bool:
@@ -63,6 +136,7 @@ func _validate(game_id: StringName) -> bool:
 	var failure_reasons: Dictionary = {}
 	var failure_opcodes: Dictionary = {}
 	var command_names: Dictionary = {}
+	var unhandled: Dictionary = {}
 	var player_operands: Dictionary = {}
 	for raw_key: Variant in (scripts_value as Dictionary):
 		# Read through GameData rather than off the JSON: the cache stores byte
@@ -87,6 +161,7 @@ func _validate(game_id: StringName) -> bool:
 				break
 			var name: String = String(command.get("name", ""))
 			command_names[name] = int(command_names.get(name, 0)) + 1
+			_tally_unhandled(command, name, crystal_commands, unhandled)
 			_tally_object_operands(command, name, player_operands)
 			command_count += 1
 			steps += 1
@@ -138,14 +213,32 @@ func _validate(game_id: StringName) -> bool:
 	print("  invalid_text_samples=%s" % JSON.stringify(invalid_text_samples))
 	print("  commands=%s" % command_names)
 	print("  player_operands=%s" % player_operands)
-	if not unproved.is_empty():
-		print("FAIL %s: %s name PLAYER and nothing proves the runtime reaches them" % [
-			game_id, unproved,
-		])
+	_report_failure(game_id, unhandled, "have no runtime handler")
+	_report_failure(
+		game_id, unproved, "name PLAYER and nothing proves the runtime reaches them"
+	)
 	_print_ram_markers(data, ram_addresses, number_markers)
 	print("  raw_byte_markers=%s" % raw_bytes)
 	_print_standard_table(game_id)
-	return raw_bytes.is_empty() and unproved.is_empty()
+	return [raw_bytes, unproved, unhandled].all(
+		func(tally: Dictionary) -> bool: return tally.is_empty()
+	)
+
+
+func _report_failure(game_id: StringName, tally: Dictionary, why: String) -> void:
+	if tally.is_empty():
+		return
+	print("FAIL %s: %s %s" % [game_id, tally, why])
+
+
+func _tally_unhandled(
+	command: Dictionary, name: String, crystal_commands: bool, tally: Dictionary
+) -> void:
+	if NO_RUNNER.has(name):
+		return
+	if Gen2WorldScriptRunner.handles_opcode(int(command["opcode"]), crystal_commands):
+		return
+	tally[name] = int(tally.get(name, 0)) + 1
 
 
 ## Both operand keys are read, so `follow <NPC>, PLAYER` counts once.


### PR DESCRIPTION
Programme 2's walk of `engine/overworld/scripting.asm`, `engine/pokedex/pokedex.asm` and `engine/pokegear/radio.asm`. The two screens agree with the source label for label; the script engine paid twenty-two.

Four commands the corpus uses decoded as nothing. `PROFILE_COMMAND_WIDTHS` holds a zero for a byte the other profile owns, and `command_width` read that as "no command here" rather than falling through to the table that already answers it, so `command_at` refused Crystal's `applymovementlasttalked` at $6a and `stopandsjump` at $8f, and pokegold's `faceobject` at $6b and `reloadend` at $91. Crystal's twelve `applymovementlasttalked` sites were the whole of that command.

The rest of the width table was then read against both pins' own `macros/scripts/events.asm`, where a `db` is one byte and a `dw` is two, and it disagreed twice more. `getcoins` is `db getcoins_command / db string_buffer` on both profiles and `Script_getcoins` ends in one `GetStringBuffer`; Crystal's was three bytes wide with a second buffer nothing writes, so all ten of its sites ate the byte after them. `changemapblocks` was two bytes wide where its own operand row already read a bank and an address.

Eleven commands decoded and then answered `unsupported_runtime_command`: `loadpikachudata`, `randomwildmon`, `autoinput`, `stopandsjump`, `reloadend`, `endall`, `xycompare`, and Crystal's `getlandmarkname`, `gettrainerclassname`, `getname` and `checksave`. The phone scripts name the first two Crystal ones 119 times and nothing decoded their operands either, so a call that reached one stopped there.

`Script_earthquake` is `ScriptCall` on `applymovement PLAYER, wEarthquakeMovementDataBuffer` and was a bespoke event and a frame wait instead: it froze no objects, and its `step_sleep` is counted in overworld passes, so every shake ran half as long. It now builds that stream and hands it to the same `player_movement_requested` an ordinary `applymovement` uses, and Rock Smash's own copy goes the same way; the rock smash emitted a `duration` key where the consumer reads `strength`, which is a shake of amplitude zero. `Script_deactivatefacing` hands its count to SCRIPT_WAIT, whose `WaitScript` also runs once per pass, and spent frames. `Script_endifjustbattled` is `jp Script_end`, which pops one frame; this dropped the whole stack.

| Where | Before | After |
|---|---|---|
| Crystal script commands decoded | 29,639 | 29,745 |
| Crystal scripts that stop on a byte no command owns | 164 | 152 |
| Gold and Silver, the same | 134 | 130 |
| `earthquake 84`'s hold, hardware frames | 20 | 40 |
| Gold and Silver catalog shop sites | 53 | 37 |

Fixing the widths moved where a catalog walk runs off a script into text, which is what `_scan_one_script` stops on, and eight more `pokemart`s came out of the tail. Seventeen were already there: `GameData.world_mart` answers an unknown index with its default shelf, so a `pokemart` read out of text became a site selling two Potions on maps with no mart at all, Whirl Island B1F among them. The catalog now refuses a mart the cartridge does not ship, against 35 and 36 real `pokemart` sites in the pins.

`tools/checks/world_scripts.gd` gained both sweeps. It compares all 147 pokegold and 154 pokecrystal command macros against `command_width` and `command_name`, and it runs every command in every cached script on all three cartridges through `Gen2WorldScriptRunner.handles_opcode`, so a command the corpus uses can no longer reach `unsupported_runtime_command`. `callasm` and `memcallasm` are its two named exceptions: each names a link-time address absent from the pins.


