### PR TITLE
Open a choice box over the page the text box is still showing

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1806,7 +1806,7 @@ func pokecenter_pc_lists(players: bool = false) -> Array:
 
 
 ## One of the routine's own six texts, by the name
-## `RomLayout.POKECENTER_PC_TEXTS` gives it.
+## `RomLayout.POKECENTER_PC_TEXT_AT` gives it.
 func pokecenter_pc_text(name: String) -> String:
 	var texts: Variant = _pokecenter_pc.get("texts", {})
 	return String((texts as Dictionary).get(name, "")) if texts is Dictionary else ""

--- a/game/render/clock_set_page.gd
+++ b/game/render/clock_set_page.gd
@@ -2,18 +2,15 @@ class_name Gen2ClockSetPage
 extends RefCounted
 
 ## `InitClock` and `SetDayOfWeek` on the hardware tile grid. The two one-tile
-## arrows stand where the source loads its temporary arrow graphics.
-##
-## The speech box is drawn here only for a caller that has no [Gen2TextBox] of
-## its own: `InitClock` reaches every one of its lines through `PrintText`, so
+## arrows stand where the source loads its temporary arrow graphics. The speech
+## box is drawn here only for a caller with no [Gen2TextBox] of its own:
 ## [Gen2ClockSetScreen] passes an empty prompt and puts a real box over this.
 
 const TILE: int = Gen2Font.TILE
 
 ## `.loop`, `.HourIsSet` and `SetDayOfWeek.loop` each place their own `Textbox`,
-## its two arrows and its value, and differ in nothing else. Each row is the box
-## as (left, top, right, bottom), the column both arrows stand in, and where the
-## value is printed; both arrows sit on the box's own border rows.
+## its two arrows and its value, and differ in nothing else: the box as
+## (left, top, right, bottom), the arrows' shared column, and the value's corner.
 const DIALS: Dictionary = {
 	&"hour": {"box": Vector4i(3, 7, 19, 11), "arrow_x": 11, "value": Vector2i(4, 9)},
 	&"minutes": {"box": Vector4i(11, 7, 19, 11), "arrow_x": 15, "value": Vector2i(12, 9)},
@@ -34,12 +31,15 @@ static func from_data(data: GameData) -> Gen2ClockSetPage:
 ## [param kind] is which of [constant DIALS] is drawn, and empty draws none.
 ## `InitClock`'s `.ClearScreen` runs before each `YesNoBox`, so a confirm has
 ## no dial; `SetDayOfWeek` keeps its own up behind the question instead.
+## [param over_map] is the screen behind: `InitClock` runs `ClearTilemap` first
+## and `SetDayOfWeek`, called from a map script, clears nothing at all.
 func render(
 	value: String, prompt: String, confirm_cursor: int, kind: StringName,
-	palette: PackedColorArray = PackedColorArray()
+	palette: PackedColorArray = PackedColorArray(), over_map: bool = false
 ) -> Image:
 	var indices := PackedByteArray()
 	indices.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	var drawn: Array[Rect2i] = []
 	if DIALS.has(kind):
 		var dial: Dictionary = DIALS[kind]
 		var at: Vector4i = dial["box"]
@@ -51,7 +51,9 @@ func render(
 		var arrow_x: int = int(dial["arrow_x"]) * TILE
 		_draw_arrow(indices, arrow_x, (at.y + 1) * TILE, false)
 		_draw_arrow(indices, arrow_x, at.w * TILE, true)
+		drawn.append(Rect2i(at.x, at.y, at.z - at.x + 1, at.w - at.y + 1))
 	if not prompt.is_empty():
+		drawn.append(Rect2i(0, 12, 20, 6))
 		var speech := Gen2MenuBox.from_coords(0, 12, 19, 17, 0)
 		menu.draw(speech, [], -1, indices, Gen2Screen.WIDTH)
 		var pages: Array = Gen2TextLayout.lay_out(prompt, 18, 2)
@@ -65,9 +67,24 @@ func render(
 		var yes_no := Gen2MenuBox.from_coords(14, 7, 19, 11,
 			Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING)
 		menu.draw(yes_no, ["YES", "NO"], confirm_cursor, indices, Gen2Screen.WIDTH)
-	return Gen2PicImage.from_indices(indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
+		drawn.append(Rect2i(14, 7, 6, 5))
+	var image: Image = Gen2PicImage.from_indices(
+		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT,
 		palette if palette.size() == 4 else Gen2Palette.pic_palette(
-			PackedColorArray([Color.WHITE, Color.BLACK])))
+			PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	return _boxes_only(image, drawn) if over_map else image
+
+
+## [param image] with everything outside [param drawn] left transparent.
+static func _boxes_only(image: Image, drawn: Array[Rect2i]) -> Image:
+	var out := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	for rect: Rect2i in drawn:
+		var pixels := Rect2i(rect.position * TILE, rect.size * TILE)
+		out.blit_rect(image, pixels, pixels.position)
+	return out
 
 
 func _draw_arrow(indices: PackedByteArray, x: int, y: int, down: bool) -> void:

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -33,9 +33,7 @@ const CURSOR_CODE: int = 0xEE
 const CURSOR_COLUMN: int = 18
 ## `PromptButton.blink_cursor` reads `hVBlankCounter` and `and 1 << 4`, so the
 ## arrow is up for sixteen frames and the border's own '─' is back for the
-## next sixteen (`home/joypad.asm`). Counted in seconds rather than frames for
-## the reason [member reveal_speed] is a rate: the period is the same either
-## way and this does not assume 60 Hz.
+## next sixteen (`home/joypad.asm`).
 const CURSOR_BLINK_FRAMES: int = 16
 const FRAME_SECONDS: float = Gen2WorldAnimation.FRAME_SECONDS
 
@@ -245,8 +243,7 @@ func text_lines() -> PackedStringArray:
 
 ## Whether a page after this one is still waiting, which is what the blinking
 ## arrow means. A screen putting a menu over the box waits for both this and
-## [method is_revealing] to be false, since the cartridge prints the whole text
-## before it opens one.
+## [method is_revealing] to be false: the cartridge prints the whole text first.
 func has_pages_left() -> bool:
 	return _page + 1 < _pages.size()
 
@@ -262,10 +259,8 @@ func finish() -> void:
 
 ## What a button press does: moves to the next page. Returns false once there is
 ## nothing left, having emitted [signal finished]. A press while the page is still
-## printing is SPENT and does nothing else: the cartridge has no path from a press
-## to the end of a page, `PrintLetterDelay` being the only thing a button reaches
-## while text is running. Completing the page on the press instead let a repeated
-## one tear through a whole text a page per press.
+## printing is SPENT: `PrintLetterDelay` is the only thing a button reaches while
+## text is running, so no press on the cartridge finishes a page early.
 func advance() -> bool:
 	if _pages.is_empty():
 		return false

--- a/game/render/text_layout.gd
+++ b/game/render/text_layout.gd
@@ -2,13 +2,16 @@ class_name Gen2TextLayout
 extends RefCounted
 
 ## Breaking a string into the lines and pages a text box can show. Pure rules, no
-## font and no screen: it counts tiles and returns strings, so a conversation's
-## pagination can be checked without drawing anything. Widths count tiles, never
-## characters: a ligature like "'s" is two characters in one glyph, so
-## [method String.length] overstates a line and wraps it a column early. The
-## cartridges do not wrap at runtime, their text being pre-broken at authoring
-## time, which works when every string is known in advance and does not when a mod
-## adds one or a name runs long.
+## font and no screen, so a conversation's pagination can be checked without
+## drawing anything. Widths count tiles rather than characters, since a ligature
+## like "'s" is two of one and [method String.length] would wrap a column early.
+## The cartridges do not wrap at all, their text being pre-broken at authoring
+## time; a mod's string and a long name are what needs it.
+
+
+## `Textbox`'s inner area: `TEXTBOX_INNERW` wide, and two rows two apart.
+const TEXTBOX_COLUMNS: int = 18
+const TEXTBOX_ROWS: int = 2
 
 
 ## Breaks [param text] into lines of at most [param columns] tiles.
@@ -22,8 +25,8 @@ static func wrap_lines(text: String, columns: int) -> PackedStringArray:
 
 	for paragraph: String in text.split("\n"):
 		var line: String = ""
-		for word: String in paragraph.split(" ", false):
-			var candidate: String = word if line.is_empty() else "%s %s" % [line, word]
+		for word: String in _spaced_words(paragraph):
+			var candidate: String = line + word
 			if Gen2Text.encoded_length(candidate) <= columns:
 				line = candidate
 				continue
@@ -31,6 +34,10 @@ static func wrap_lines(text: String, columns: int) -> PackedStringArray:
 			if not line.is_empty():
 				out.append(line)
 				line = ""
+				word = word.lstrip(" ")
+				if Gen2Text.encoded_length(word) <= columns:
+					line = word
+					continue
 
 			# A word too long for a line of its own is cut rather than allowed to
 			# run off the edge. Nothing in these games is that long, but a mod's
@@ -46,32 +53,23 @@ static func wrap_lines(text: String, columns: int) -> PackedStringArray:
 	return out
 
 
-## Groups lines into pages of at most [param rows], each page being what the box
-## shows before it waits to be advanced.
-static func paginate(lines: PackedStringArray, rows: int) -> Array:
-	var out: Array = []
-	if rows <= 0:
-		return out
-
-	var page: PackedStringArray = PackedStringArray()
-	for line: String in lines:
-		page.append(line)
-		if page.size() == rows:
-			out.append(page)
-			page = PackedStringArray()
-
-	if not page.is_empty():
-		out.append(page)
+## Each word with the spaces in front of it, so a line keeps the padding
+## `PlaceString` prints. Only a wrap drops the spaces it breaks at.
+static func _spaced_words(paragraph: String) -> PackedStringArray:
+	var out: PackedStringArray = PackedStringArray()
+	var trimmed: String = paragraph.rstrip(" ")
+	var at: int = 0
+	while at < trimmed.length():
+		var start: int = at
+		while at < trimmed.length() and trimmed[at] == " ":
+			at += 1
+		while at < trimmed.length() and trimmed[at] != " ":
+			at += 1
+		out.append(trimmed.substr(start, at - start))
 	return out
 
 
-## Both steps at once, honouring the two waits [Gen2TextStream] marks.
-##
-## `Paragraph` clears the box and starts again at the top line, so its page
-## begins empty. `_ContText` scrolls by one line and writes at the bottom, so
-## its page begins with the line that was underneath: with a two-line box that
-## is the previous page's second line, and dropping it loses a line out of every
-## paragraph that runs past two.
+## [method lay_out_pages] with each page's lines alone.
 static func lay_out(text: String, columns: int, rows: int) -> Array:
 	var out: Array = []
 	for page: Dictionary in lay_out_pages(text, columns, rows):
@@ -130,6 +128,17 @@ static func lay_out_pages(text: String, columns: int, rows: int) -> Array:
 	if not page.is_empty():
 		out.append({"lines": page, "enter": enter, "carried": carried})
 	return out
+
+
+## What a box is left holding once [param text] has been printed to its end.
+## `Paragraph` clears it between paragraphs, so a menu opens over the final page.
+static func standing_page(
+	text: String, columns: int = TEXTBOX_COLUMNS, rows: int = TEXTBOX_ROWS
+) -> String:
+	var pages: Array = lay_out_pages(text, columns, rows)
+	if pages.is_empty():
+		return ""
+	return "\n".join(pages[pages.size() - 1]["lines"])
 
 
 ## The longest prefix of [param word] that fits in [param columns] tiles.

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -68,7 +68,8 @@ const CARD_TEXT_AT: Vector2i = Vector2i(1, 14)
 const CARD_TEXT_SPACING: int = 2
 
 ## `.Clock`'s own string, and `Pokegear_UpdateClock`: a 14x5 box cleared at
-## (3,5), `_GearTodayText`'s weekday at (6,6) and `PrintHoursMins` at (6,8).
+## (3,5), `_GearTodayText`'s weekday at (6,6) and [method Gen2WorldClock.reading]
+## at (6,8).
 const CLOCK_SWITCH_TEXT: String = " SWITCH▶"
 const CLOCK_SWITCH_AT: Vector2i = Vector2i(12, 1)
 const CLOCK_CLEAR_AT: Vector2i = Vector2i(3, 5)
@@ -256,20 +257,9 @@ func clock_tilemap(
 		for column: int in CLOCK_CLEAR_COLUMNS:
 			_put(map, CLOCK_CLEAR_AT + Vector2i(column, row), BLANK_TILE)
 	_draw_string(map, CLOCK_DAY_AT, Gen2TextStream.weekday_name(weekday) + "DAY")
-	_draw_string(map, CLOCK_TIME_AT, _clock_reading(hour, minute))
+	_draw_string(map, CLOCK_TIME_AT, Gen2WorldClock.reading(hour, minute))
 	_draw_card_icons(map, owned)
 	return map
-
-
-## `PrintHoursMins`: the hour space-padded to two tiles, the minute with its
-## leading zero, and AM or PM one tile past it. Midnight and noon are both
-## printed as twelve, which is what its two branches do with a zero hour.
-static func _clock_reading(hour: int, minute: int) -> String:
-	var hour24: int = posmod(hour, 24)
-	var reading: int = hour24 % 12
-	if reading == 0:
-		reading = 12
-	return "%2d:%02d %s" % [reading, posmod(minute, 60), "AM" if hour24 < 12 else "PM"]
 
 
 ## `.Radio`: the tuned station's own name under the dial, and whatever

--- a/game/world/clock_set_screen.gd
+++ b/game/world/clock_set_screen.gd
@@ -21,6 +21,10 @@ const DAYS: Array[String] = [
 	" SUNDAY", " MONDAY", " TUESDAY", "WEDNESDAY", "THURSDAY", " FRIDAY", "SATURDAY",
 ]
 
+## `SetDayOfWeek`'s `.loop` draws its own `Textbox` at `hlcoord 0, 12` and prints
+## `.OakTimeWhatDayIsItText` into it, so the dial carries no map text.
+const DAY_QUESTION: String = "What day is it?"
+
 ## `_OakTimeWokeUpText`. `<……>` is `SixDotsCharText`, which is two ellipsis
 ## tiles, so each of the first two lines is twelve.
 const WOKE_UP_TEXT: String = "%s\n%s%sZzz… Hm? Wha…?\nYou woke me up!%sWill you check the\nclock for me?"

--- a/game/world/world_clock.gd
+++ b/game/world/world_clock.gd
@@ -78,6 +78,18 @@ static func catch_up(
 	}
 
 
+## `PrintHoursMins`: the hour space-padded to two tiles, the minute with its
+## leading zero, and AM or PM one tile past the blank `inc hl` steps over.
+static func reading(hour_value: int, minute_value: int) -> String:
+	var hour24: int = posmod(hour_value, HOURS_PER_DAY)
+	var digits: int = hour24 % 12
+	if digits == 0:
+		digits = 12
+	return "%2d:%02d %s" % [
+		digits, posmod(minute_value, MINUTES_PER_HOUR), "AM" if hour24 < 12 else "PM",
+	]
+
+
 func time_of_day() -> int:
 	if hour < MORN_START:
 		return Gen2WorldPalette.TIME_NIGHT

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -5490,9 +5490,8 @@ func _advance_script_input() -> void:
 ## so a text ending in `<DONE>` owes no press of its own and the script runs on the
 ## moment its last page is up. The box reaches that page three ways: shown whole,
 ## turned to by the press that clears a `<PARA>`, or scrolled into by `_ContText`,
-## and only the first two are a press. The scroll ends on a frame, which is why
-## [method advance_frame] asks this as well; without it every `<CONT>`-terminated
-## text cost one press more than the cartridge spends.
+## and only the first two are a press. The scroll ends on a frame instead, which
+## is why [method advance_frame] asks this as well.
 func _continue_if_text_settled() -> bool:
 	if _text_box == null or not _text_box.visible or _world == null:
 		return false
@@ -7312,9 +7311,8 @@ func _apply_text_pause(event: Dictionary, flags: Dictionary) -> StringName:
 		return &"break"
 	if _text_box == null or _text_box.font == null:
 		return &"none"
-	# `LoadBlinkingCursor` is `Paragraph`, `_ContText` and `PromptText`; a
-	# `writetext` whose text ends in `done` reaches none of them, so its last page
-	# carries no arrow and the script runs straight on.
+	# A `writetext` whose text ends in `done` reaches no `LoadBlinkingCursor`, so
+	# its last page carries no arrow and the script runs straight on.
 	_text_awaits_press = bool(event.get("prompt", true))
 	if int(event.get("cry", 0)) > 0:
 		_play_species_cry(int(event["cry"]))

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -886,7 +886,7 @@ func advance(acknowledge: bool = false, choice: int = -1) -> Dictionary:
 ## empty result when it is spent and the command loop takes over.
 func _resume_pending(acknowledge: bool, choice: int) -> Dictionary:
 	if _pending.has("text"):
-		_standing_text = String(_pending["text"])
+		_set_standing_text(String(_pending["text"]))
 	var pending_type: StringName = StringName(_pending.get("type", &""))
 	var request: Dictionary = _pending.get("request", {})
 	if pending_type == &"runtime_request" \
@@ -5262,7 +5262,7 @@ func _special_party_selection(special: int) -> Dictionary:
 		var asked: String = _special_box("photo_studio", "which_mon")
 		if asked.is_empty():
 			return {"ok": false, "reason": &"missing_special_text", "special": special}
-		_standing_text = asked
+		_set_standing_text(asked)
 	return _stage_runtime_request(&"party_selection_requested", {
 		"special": special,
 		"routine": PARTY_SELECTION_ROUTINE_OF[special],
@@ -6084,7 +6084,7 @@ func _stage_day_of_week_menu() -> void:
 		"command": &"set_day_of_week",
 		"options": WEEKDAY_NAMES.duplicate(),
 		"header": {"default": 1, "data_flags": 1 << 5},
-		"text": _standing_text,
+		"text": Gen2ClockSetScreen.DAY_QUESTION,
 		"special": &"set_day_of_week",
 		"source": _request.duplicate(true),
 	}
@@ -6106,10 +6106,13 @@ func _stage_dst_confirmation_text(enabled: bool) -> void:
 	var clock: Dictionary = _request.get("clock", {})
 	var hour: int = clampi(int(clock.get("hour", 0)), 0, 23)
 	var minute: int = clampi(int(clock.get("minute", 0)), 0, 59)
-	var time_text: String = "%02d:%02d" % [hour, minute]
 	_pending = {
 		"type": &"text",
-		"text": "%s%s,\nis that OK?" % [time_text, " DST" if enabled else ""],
+		## `.Text` farcalls `PrintHoursMins` at `decoord 1, 14` and returns
+		## `_DSTIsThatOKText`, which carries on from where the AM or PM ended.
+		"text": "%s%s,\nis that OK?" % [
+			Gen2WorldClock.reading(hour, minute), " DST" if enabled else "",
+		],
 		"special": &"initial_dst_confirmation",
 		"source": _request.duplicate(true),
 	}
@@ -7156,6 +7159,12 @@ func _stage_button(command: Dictionary) -> Dictionary:
 	return {"ok": true}
 
 
+## `Paragraph` clears the box between paragraphs, so a menu opens over the last
+## page of the text rather than over all of it.
+func _set_standing_text(text: String) -> void:
+	_standing_text = Gen2TextLayout.standing_page(text)
+
+
 func _stage_choice(command: Dictionary, choices: Array) -> Dictionary:
 	_pending = {
 		"type": &"choice",
@@ -7183,12 +7192,10 @@ func _show_text(bank: int, address: int, finish_after: bool) -> Dictionary:
 		"text": String(decoded.get("text", "")),
 		"bank": bank,
 		"address": address,
-		## `Script_writetext` is `MapTextbox` and returns: only `<PROMPT>`,
-		## `text_promptbutton` and `text_waitbutton` spend a press inside the
-		## text. A text ending in `<DONE>` therefore owes none of its own, and
-		## the press belongs to the `waitbutton` behind the command.
-		## `JumpTextScript` carries that `waitbutton` itself, which is what
-		## [param finish_after] names.
+		## Only `<PROMPT>`, `text_promptbutton` and `text_waitbutton` spend a
+		## press inside the text, so a text ending in `<DONE>` owes none and the
+		## press belongs to the `waitbutton` behind the command. `JumpTextScript`
+		## carries that one itself, which is what [param finish_after] names.
 		"prompt": finish_after or bool(decoded.get("prompt", false)),
 		"source": _request.duplicate(true),
 	}

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -608,9 +608,8 @@ func _open_menu(input: Dictionary) -> void:
 	_choices = _menu.options.duplicate(true)
 	_cursor = _menu.selected_index()
 	_title = "MENU"
-	## The question the box behind this menu is still showing. A command name is
-	## an internal key, never something the cartridge prints, so it is not a
-	## fallback: an unattached menu says nothing rather than saying "yesorno".
+	## The question the box behind this menu is still showing. An unattached menu
+	## says nothing: a command name is an internal key, never a printed one.
 	_summary = String(input.get("text", ""))
 	_status = ""
 	_render_rows()
@@ -2823,9 +2822,9 @@ func _dial_image() -> Image:
 	if _clock_page == null:
 		return null
 	var day: int = clampi(_cursor, 0, Gen2ClockSetScreen.DAYS.size() - 1)
-	var prompt: String = _summary if not _summary.is_empty() \
-		else "What day is it?"
-	return _clock_page.render(Gen2ClockSetScreen.DAYS[day], prompt, -1, &"day")
+	return _clock_page.render(
+		Gen2ClockSetScreen.DAYS[day], _summary, -1, &"day", PackedColorArray(), true
+	)
 
 
 ## The `menu_coords` box this mode's own list sits in. `null` draws no box,

--- a/tests/unit/test_text_layout.gd
+++ b/tests/unit/test_text_layout.gd
@@ -53,17 +53,6 @@ func test_zero_columns_lays_nothing_out_rather_than_looping() -> void:
 	assert_eq(Gen2TextLayout.wrap_lines("HELLO", 0).size(), 0)
 
 
-func test_pages_hold_as_many_lines_as_the_box_shows() -> void:
-	var lines := PackedStringArray(["a", "b", "c", "d"])
-	assert_eq(Gen2TextLayout.paginate(lines, ROWS).size(), 2)
-
-
-func test_a_part_full_last_page_is_kept() -> void:
-	var pages: Array = Gen2TextLayout.paginate(PackedStringArray(["a", "b", "c"]), ROWS)
-	assert_eq(pages.size(), 2)
-	assert_eq(pages[1], PackedStringArray(["c"]))
-
-
 func test_laying_out_gives_pages_of_lines_that_all_fit() -> void:
 	var text: String = "BULBASAUR used TACKLE! It's not very effective against a GHOST."
 	var pages: Array = Gen2TextLayout.lay_out(text, COLUMNS, ROWS)
@@ -275,4 +264,23 @@ func test_a_blank_line_is_not_a_page_break() -> void:
 		Gen2TextLayout.lay_out(text + "\n\nWant to use CUT?", 18, 2)[1],
 		PackedStringArray(["", "Want to use CUT?"]),
 		"a blank line is a line"
+	)
+
+
+## `Paragraph` clears the box and prints again, so a menu opened over the box
+## stands over the final page. `.WeekdayStrings`' own leading space survives the
+## wrap, since `PlaceString` prints it.
+func test_the_standing_page_is_the_last_one_and_keeps_its_padding() -> void:
+	var text: String = "%sfirst page%ssecond page%s SUNDAY, is it?" % [
+		"", Gen2TextStream.PAGE_BREAK, Gen2TextStream.PAGE_BREAK,
+	]
+	assert_eq(Gen2TextLayout.standing_page(text), " SUNDAY, is it?")
+	assert_eq(Gen2TextLayout.standing_page(""), "")
+	## `_ContText` scrolls rather than clearing, so its page carries the line
+	## that was underneath.
+	assert_eq(
+		Gen2TextLayout.standing_page("one%stwo%sthree" % [
+			Gen2TextStream.PAGE_BREAK, Gen2TextStream.SCROLL_BREAK,
+		]),
+		"two\nthree"
 	)

--- a/tests/unit/test_town_map_page.gd
+++ b/tests/unit/test_town_map_page.gd
@@ -185,10 +185,10 @@ func test_a_card_carries_the_icon_row() -> void:
 ## `PrintHoursMins`: twelve-hour, the hour space-padded and the minute not, and
 ## both midnight and noon printed as twelve.
 func test_the_clock_card_prints_the_source_reading() -> void:
-	assert_eq(Gen2TownMapPage._clock_reading(0, 7), "12:07 AM")
-	assert_eq(Gen2TownMapPage._clock_reading(12, 0), "12:00 PM")
-	assert_eq(Gen2TownMapPage._clock_reading(9, 30), " 9:30 AM")
-	assert_eq(Gen2TownMapPage._clock_reading(23, 59), "11:59 PM")
+	assert_eq(Gen2WorldClock.reading(0, 7), "12:07 AM")
+	assert_eq(Gen2WorldClock.reading(12, 0), "12:00 PM")
+	assert_eq(Gen2WorldClock.reading(9, 30), " 9:30 AM")
+	assert_eq(Gen2WorldClock.reading(23, 59), "11:59 PM")
 	var map: PackedInt32Array = _page.clock_tilemap([], 3, 13, 5, "")
 	assert_eq(_text(map, Gen2TownMapPage.CLOCK_DAY_AT, 9), "WEDNESDAY")
 	assert_eq(_text(map, Gen2TownMapPage.CLOCK_TIME_AT, 8), " 1:05 PM")

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1699,7 +1699,7 @@ func test_gold_profile_specials_normalize_onto_the_crystal_handlers() -> void:
 		"kind": &"test", "bank": 48, "script": 0x6410,
 		"clock": {"day": 1, "hour": 10, "minute": 5},
 	})
-	assert_eq(dst.advance()["event"]["text"], "10:05 DST,\nis that OK?")
+	assert_eq(dst.advance()["event"]["text"], "10:05 AM DST,\nis that OK?")
 	assert_eq(dst.advance(true)["event"]["type"], &"choice")
 	var dst_result: Dictionary = dst.advance(true, 0)
 	assert_eq(dst_result["status"], &"complete", JSON.stringify(dst_result))
@@ -4130,6 +4130,38 @@ func test_a_choice_carries_the_text_the_open_box_is_still_showing() -> void:
 	assert_eq(closed.advance(true)["event"]["text"], "")
 
 
+## `Paragraph` clears the box at every `<PARA>`, so what a several-page text
+## leaves for `YesNoBox` to stand over is its last page. Carrying the whole
+## string put the opening lines of `MomGivesPokegearText` under `SetDayOfWeek`'s
+## dial and of `ComeHomeForDSTText` under the phone question behind it.
+func test_a_choice_over_a_paged_text_carries_that_text_s_last_page_alone() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6644"] = [
+		Gen2WorldScript.WRITETEXT, 0x40, 0x70,
+		Gen2WorldScript.YESORNO,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var text: Dictionary = RomCache.read_json(RomCache.world_text_path(_directory))
+	text["48:7040"] = [
+		Gen2WorldScript.TEXT_START, 0x80, 0x81,
+		Gen2TextStream.CHAR_PARA, 0x82, 0x83,
+		Gen2WorldScript.TEXT_TERMINATOR,
+	]
+	RomCache.write_json(RomCache.world_text_path(_directory), text)
+	var data: GameData = GameData.open_directory(_directory)
+
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6644,
+	})
+	assert_eq(
+		runner.advance()["event"]["text"], "AB%sCD" % Gen2TextStream.PAGE_BREAK
+	)
+	var choice: Dictionary = runner.advance(true)
+	assert_eq(choice["event"]["type"], &"choice")
+	assert_eq(choice["event"]["text"], "CD", JSON.stringify(choice))
+
+
 ## `_GetVarAction.BoxFreeSpace` is `MONS_PER_BOX - [sBoxCount]`. Route 29's
 ## catching tutorial reads it before it hands a POKé BALL over, so an
 ## unsupported variable stops that NPC talking at all.
@@ -4194,7 +4226,7 @@ func test_initial_dst_specials_publish_source_confirmation_text_and_commit_state
 		"clock": {"day": 1, "hour": 10, "minute": 5},
 	})
 	var enabled_text: Dictionary = enabled.advance()
-	assert_eq(enabled_text["event"]["text"], "10:05 DST,\nis that OK?")
+	assert_eq(enabled_text["event"]["text"], "10:05 AM DST,\nis that OK?")
 	var enabled_choice: Dictionary = enabled.advance(true)
 	assert_eq(enabled_choice["event"]["type"], &"choice")
 	var enabled_result: Dictionary = enabled.advance(true, 0)
@@ -4206,7 +4238,7 @@ func test_initial_dst_specials_publish_source_confirmation_text_and_commit_state
 		"clock": {"day": 1, "hour": 10, "minute": 5},
 	})
 	var disabled_text: Dictionary = disabled.advance()
-	assert_eq(disabled_text["event"]["text"], "10:05,\nis that OK?")
+	assert_eq(disabled_text["event"]["text"], "10:05 AM,\nis that OK?")
 	var disabled_choice: Dictionary = disabled.advance(true)
 	assert_eq(disabled_choice["event"]["type"], &"choice")
 	var disabled_result: Dictionary = disabled.advance(true, 0)

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -24,6 +24,10 @@ const PLAYER_OPERAND_COMMANDS: Array[String] = [
 ## The two with no runner on purpose: each names an address absent from the pins.
 const NO_RUNNER: Array[String] = ["callasm", "memcallasm"]
 
+## What draws over the box a `writetext` left standing. `loadmenu` only stores
+## the header.
+const CHOICE_COMMANDS: Array[String] = ["yesorno", "verticalmenu", "2dmenu"]
+
 const PINS: Dictionary = {
 	&"gold": "pokegold", &"silver": "pokegold", &"crystal": "pokecrystal",
 }
@@ -43,6 +47,71 @@ func run(r: RefCounted) -> void:
 		if not _validate(game_id):
 			_r.fail("%s: the cached scripts and text did not read back." % game_id)
 		_check_command_widths(game_id)
+		_check_standing_boxes(game_id)
+
+
+## Every choice and menu in the corpus against the text in front of it:
+## `Paragraph` clears the box at each page break, so the question is the last page.
+func _check_standing_boxes(game_id: StringName) -> void:
+	var data: GameData = GameData.open(game_id)
+	if data == null:
+		return
+	var scripts: Variant = RomCache.read_json(RomCache.world_scripts_path(data.directory))
+	if not scripts is Dictionary:
+		return
+	var sites: int = 0
+	var paged: int = 0
+	var over: Array[String] = []
+	for raw_key: Variant in (scripts as Dictionary):
+		for text_key: String in _choice_questions(data, String(raw_key), game_id == &"crystal"):
+			sites += 1
+			var text: String = _decoded_text(data, text_key)
+			if Gen2TextLayout.lay_out_pages(
+				text, Gen2TextLayout.TEXTBOX_COLUMNS, Gen2TextLayout.TEXTBOX_ROWS
+			).size() > 1:
+				paged += 1
+			var lines: PackedStringArray = Gen2TextLayout.standing_page(text).split("\n")
+			if lines.size() > Gen2TextLayout.TEXTBOX_ROWS:
+				over.append("%s is %d lines" % [text_key, lines.size()])
+	print("  choice_boxes=%d over_one_page=%d" % [sites, paged])
+	for entry: String in over:
+		print("FAIL %s: %s" % [game_id, entry])
+	if not over.is_empty():
+		_r.fail("%s: a standing box does not fit the text box." % game_id)
+
+
+## The text each of [param key]'s choices answers: the last `writetext` in front.
+func _choice_questions(data: GameData, key: String, crystal: bool) -> PackedStringArray:
+	var out := PackedStringArray()
+	var bytes: PackedByteArray = _pointer_bytes(data, key, false)
+	var bank: String = key.split(":")[0]
+	var last: String = ""
+	var offset: int = 0
+	var steps: int = 0
+	while offset < bytes.size() and steps < Gen2WorldScript.MAX_COMMANDS:
+		var command: Dictionary = Gen2WorldScript.command_at(bytes, offset, crystal)
+		if not bool(command.get("ok", false)):
+			break
+		var name: String = String(command.get("name", ""))
+		if name == "writetext":
+			last = "%s:%X" % [bank, int(command["address"])]
+		elif name == "farwritetext":
+			last = "%d:%X" % [int(command["bank"]), int(command["address"])]
+		elif CHOICE_COMMANDS.has(name) and not last.is_empty():
+			out.append(last)
+		steps += 1
+		offset += int(command["width"])
+		if not Gen2WorldScript.continues_after(int(command["opcode"]), crystal):
+			break
+	return out
+
+
+func _decoded_text(data: GameData, key: String) -> String:
+	var decoded: Dictionary = Gen2TextStream.decode(_pointer_bytes(data, key, true), 0, {
+		"far": func(bank: int, address: int) -> PackedByteArray:
+			return data.world_text(bank, address),
+	})
+	return String(decoded.get("text", ""))
 
 
 ## Every command byte's name and width against the pin's own

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -17,10 +17,20 @@ const TRACE_FRAMES: int = 4000
 ## `end` land on. `showemote EMOTE_SHOCK, MOM1, 15` is 30 frames and the walk is
 ## `MomWalksToPlayerMovement`, both counted in overworld passes.
 const CHECKPOINTS: Dictionary = {
-	&"crystal": {&"emote": 17, &"walk": 46, &"text": 77, &"done": 1909},
-	&"gold": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2039},
-	&"silver": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2039},
+	&"crystal": {&"emote": 17, &"walk": 46, &"text": 77, &"done": 1921},
+	&"gold": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2051},
+	&"silver": {&"emote": 17, &"walk": 47, &"text": 143, &"done": 2051},
 }
+
+## The five boxes the scene asks over, in order and the same on all three.
+## `SetDayOfWeek` draws its own; the rest are a `writetext`'s last page.
+const QUESTIONS: Array[String] = [
+	"What day is it?",
+	" SUNDAY, is it?",
+	"Is it Daylight\nSaving Time now?",
+	" 6:00 AM DST,\nis that OK?",
+	"know how to use\nthe PHONE?",
+]
 
 ## Who looks at whom at the text: Crystal's `turnobject PLAYER, LEFT` and Mom's
 ## `turn_head RIGHT` against pokegold's `turnobject ..., UP`.
@@ -121,7 +131,16 @@ func _sample() -> Dictionary:
 		"text": _screen._text_box != null and _screen._text_box.visible,
 		"channels": _screen._audio_player.audio_status()["active_channels"],
 		"prompt": _screen._script_prompt,
+		"asking": _asking(world),
 	}
+
+
+## The question a choice or a menu opens over: the map script's own last page.
+func _asking(world: Gen2WorldAPI) -> String:
+	var pending: Dictionary = world.pending_script_input()
+	if StringName(pending.get("type", &"")) not in [&"choice", &"menu"]:
+		return ""
+	return String(pending.get("text", ""))
 
 
 func _process(_delta: float) -> bool:
@@ -138,6 +157,14 @@ func _process(_delta: float) -> bool:
 	if not _started:
 		_started = true
 		_screen.move_player(Vector2i(0, 1))
+	# Before the press below, so a capture keeps the box that press would answer.
+	if _frames == _capture_frame and not _output_path.is_empty():
+		var image: Image = Gen2ToolPath.capture(root)
+		if image == null:
+			quit(1)
+			return true
+		image.save_png(_output_path)
+		print("Wrote %s at frame %d" % [_output_path, _frames])
 	if not _trace.is_empty() and bool(_trace[-1]["waiting_input"]):
 		# Every question answered YES, the way the other preview drivers do.
 		_screen.press_button(Gen2Button.A)
@@ -148,13 +175,6 @@ func _process(_delta: float) -> bool:
 	if _talk_frame < 0 and _first_frame(&"done") >= 0 and bool(_trace[-1]["text"]):
 		_talk_frame = _frames
 		_talk_facing = int(_trace[-1]["mom_facing"])
-	if _frames == _capture_frame and not _output_path.is_empty():
-		var image: Image = Gen2ToolPath.capture(root)
-		if image == null:
-			quit(1)
-			return true
-		image.save_png(_output_path)
-		print("Wrote %s at frame %d" % [_output_path, _frames])
 	if _frames < maxi(TRACE_FRAMES, _capture_frame):
 		return false
 	_report()
@@ -190,11 +210,22 @@ func _checkpoints_hold() -> bool:
 		if at != want:
 			printerr("%s %s first appears on frame %d, not %d" % [_game, name, at, want])
 			held = false
+	held = _questions_hold() and held
 	held = _facings_hold() and held
 	held = _talk_facing_holds() and held
 	held = _channels_hold() and held
 	print("%s checkpoints %s" % [_game, "hold" if held else "MOVED"])
 	return held
+
+
+func _questions_hold() -> bool:
+	var asked: Array[String] = _questions()
+	if Array(asked) == Array(QUESTIONS):
+		return true
+	printerr("%s asks %s, not %s" % [
+		_game, JSON.stringify(asked), JSON.stringify(QUESTIONS),
+	])
+	return false
 
 
 func _facings_hold() -> bool:
@@ -285,3 +316,23 @@ func _report() -> void:
 			row["prompt"],
 		])
 	print("%d frames, %d changes" % [_trace.size(), changes])
+	for row: Dictionary in _trace:
+		if not String(row["asking"]).is_empty() \
+			and _first_asking(String(row["asking"])) == int(row["frame"]):
+			print("  f%4d asks %s" % [row["frame"], JSON.stringify(row["asking"])])
+
+
+func _first_asking(question: String) -> int:
+	for row: Dictionary in _trace:
+		if String(row["asking"]) == question:
+			return int(row["frame"])
+	return -1
+
+
+func _questions() -> Array[String]:
+	var out: Array[String] = []
+	for row: Dictionary in _trace:
+		var asking: String = String(row["asking"])
+		if not asking.is_empty() and (out.is_empty() or out[out.size() - 1] != asking):
+			out.append(asking)
+	return out


### PR DESCRIPTION
`Paragraph` clears the box at every `<PARA>` and prints the next paragraph, so what a `writetext` leaves for `YesNoBox` or `_2DMenu` to stand over is its last page. The runner carried the whole string and `Gen2WorldServicePage.render` drew page one of it, so `SetDayOfWeek`'s dial opened over "#MON GEAR, or just #GEAR." and the phone question over "Come home to adjust your clock".

## Fixed

- 116 of Crystal's 155 corpus choice boxes, and 92 of Gold and Silver's 122, opened over the wrong lines. `Gen2WorldScriptRunner` now keeps only the standing page, which is the one seam all eight of its choice, menu and dial events read.
- `SetDayOfWeek`'s `.loop` draws its own `Textbox` at `hlcoord 0, 12` and prints `.OakTimeWhatDayIsItText`, so the dial asks "What day is it?" and carries no map text.
- The same routine clears nothing else, unlike `InitClock`'s `ClearTilemap`: the dial and its speech box stand over the overworld rather than a white screen.
- `InitialSetDSTFlag` farcalls `PrintHoursMins`, which is twelve-hour with AM or PM, so the confirmation reads " 6:00 AM DST," and not "06:00 DST,".
- `Gen2TextLayout.wrap_lines` keeps a line's own leading spaces, which `PlaceString` prints: `.WeekdayStrings` centres with one, so the weekday confirmation reads " SUNDAY, is it?".
- Dead `Gen2TextLayout.paginate`, reached by nothing but its own test, deleted; a doc comment naming `RomLayout.POKECENTER_PC_TEXTS`, which does not exist, corrected.

## Changed

- `PrintHoursMins` moves from `Gen2TownMapPage._clock_reading` to `Gen2WorldClock.reading`, read by the Pokegear clock card and the DST box.
- `tools/checks/world_scripts.gd` walks every cached script on all three cartridges, counts the choice boxes and the texts that run past one page, and fails a standing box that does not fit `Textbox`'s two rows.
- `tools/preview_mom_scene.gd` pins the five questions the scene asks, and holds the box on a capture frame so a screenshot shows what a press would answer.

## Proving it

| Check | Result |
|---|---|
| `gut` unit and scene tiers | 4137 tests, 0 failures |
| `validate.gd -- all` | 83 topics pass |
| `replay_world.gd` | 33 routes, 0 failures |
| `preview_mom_scene.gd` | checkpoints hold on crystal, gold and silver |
| `preview_world_story.gd` home story | passes on all three |
| `--warning-scan` | 0 warnings in 608 scripts |
| `release.sh --gates` | pass |