### PR TITLE
Walk player_movement, naming_screen and decorations

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3193,6 +3193,10 @@ func _open_capture_nickname() -> bool:
 		## A Nuzlocke nicknames every catch, so the question is not asked.
 		_rules().is_nuzlocke()
 	)
+	## `.Pokemon`'s icon and sign, off the DVs the battle already rolled.
+	host.set_species(
+		_enemy, _battle.enemy.dvs if _battle != null else -1
+	)
 	host.named.connect(_on_capture_named)
 	host.closed.connect(_on_capture_nickname_closed)
 	host.z_index = 30

--- a/game/render/naming_screen_page.gd
+++ b/game/render/naming_screen_page.gd
@@ -49,6 +49,11 @@ const ENTRY_AT_MAIL: Vector2i = Vector2i(2, 2)
 const MAIL_ICON_AT: Vector2i = Vector2i(1, 1)
 ## The first `.Frameset_PartyMon` entry, four tiles of the eight loaded.
 const MAIL_ICON_TILES: int = 4
+## `depixel 4, 4, 4, 0` less shadow OAM's own (8, 16) origin, which is not the
+## tile grid, so it is kept in pixels.
+const PROMPT_ICON_AT: Vector2i = Vector2i(24, 20)
+## `.Pokemon`'s `hlcoord 1, 2`: a tilemap write, not an object.
+const GENDER_AT: Vector2i = Vector2i(1, 2)
 ## The cursor steps two tiles per column and two per row, so a keyboard cell is
 ## two tiles wide even where its character is one.
 const CELL: int = 2
@@ -117,7 +122,10 @@ func ready() -> bool:
 
 ## The whole 160x144 page as palette indices, for [param screen] as it stands
 ## and the prompt printed above the entry.
-func draw(screen: Gen2NamingScreen, prompt: String) -> PackedByteArray:
+func draw(
+	screen: Gen2NamingScreen, prompt: String,
+	icon: PackedByteArray = PackedByteArray(), gender: int = 0
+) -> PackedByteArray:
 	var map: PackedInt32Array = PackedInt32Array()
 	map.resize(COLUMNS * ROWS)
 	map.fill(BORDER_TILE)
@@ -130,12 +138,16 @@ func draw(screen: Gen2NamingScreen, prompt: String) -> PackedByteArray:
 	## entry is what says whose mail is being written.
 	if not screen.is_mail:
 		_string(map, prompt, PROMPT_AT)
+		if gender != 0:
+			_put(map, GENDER_AT, gender)
 	_entry(map, screen)
 	_keyboard(map, screen)
 
 	var indices: PackedByteArray = _compose(map)
 	if screen.is_mail:
 		_mail_icon(indices)
+	else:
+		_prompt_icon(indices, icon)
 	_cursor(indices, screen)
 	return indices
 
@@ -153,6 +165,25 @@ func _mail_icon(indices: PackedByteArray) -> void:
 		_blit(
 			indices, _icon_tiles, quadrant, MAIL_ICON_AT, false, false, true,
 			Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
+		)
+
+
+## `.Frameset_RedWalk`'s first entry over the caller's strip. Its three later
+## entries need a frame pump this screen has not got, as the blinking cursor
+## does.
+func _prompt_icon(indices: PackedByteArray, icon: PackedByteArray) -> void:
+	if icon.size() < MAIL_ICON_TILES * TILE * TILE:
+		return
+	var width: int = icon.size() / TILE
+	for quadrant: int in MAIL_ICON_TILES:
+		var cell := PackedByteArray()
+		cell.resize(TILE * TILE)
+		for y: int in TILE:
+			for x: int in TILE:
+				cell[y * TILE + x] = icon[y * width + quadrant * TILE + x]
+		_blit(
+			indices, {0: cell}, 0, Vector2i.ZERO, false, false, true,
+			PROMPT_ICON_AT + Vector2i((quadrant & 1) * TILE, (quadrant >> 1) * TILE)
 		)
 
 

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -266,6 +266,11 @@ func _open_naming() -> void:
 		_ending = Gen2NameRater.ENDING_SAME_NAME
 		_end_named(_nickname)
 		return
+	## `.Pokemon`'s `LoadMenuMonIcon` and `farcall GetGender`, off the row itself.
+	_naming.set_species_icon(
+		_data, mon.species,
+		Gen2NamingScreenScreen.gender_sign(_data, mon.species, mon.dvs)
+	)
 	_text_box.visible = false
 	_naming.closed.connect(_on_named)
 	add_child(_naming)

--- a/game/world/naming_screen_screen.gd
+++ b/game/world/naming_screen_screen.gd
@@ -12,25 +12,51 @@ extends Control
 ## nothing else, so a caller that never sees this signal has no name to take.
 signal closed(name: String)
 
-## `wNamingScreenType`'s three that a screen here opens. All three are the
-## player's keyboard; NAME_MON and NAME_BOX differ only in the length cap behind
-## them.
+## `wNamingScreenType`'s three that a screen here opens, all the player's
+## keyboard; NAME_MON and NAME_BOX differ only in the length cap.
 const KIND_PLAYER: StringName = &"player"
 const KIND_MON: StringName = &"mon"
 const KIND_BOX: StringName = &"box"
 ## `_ComposeMailMessage`, which is not a `wNamingScreenType` at all: its own
-## routine with its own keyboard. A caller that opens this one reads the raw
-## buffer off [method model] rather than the `closed` argument, since a mail
-## message is two fixed-width lines and a break rather than a name.
+## routine with its own keyboard. A caller reads the raw buffer off
+## [method model] rather than the `closed` argument, a mail message being two
+## fixed-width lines and a break rather than a name.
 const KIND_MAIL: StringName = &"mail"
+
+## `data/sprites/sprites.asm`'s rows for the labels `.Rival`, `.Mom` and `.Box`
+## name. The three indices are the same in both pins.
+const SPRITE_RIVAL: int = 0x04
+const SPRITE_MOM: int = 0x0C
+const SPRITE_POKE_BALL: int = 0x54
+
+## `'♂'` and `'♀'` at `.Pokemon`'s `hlcoord 1, 2`; `GetGender`'s carry writes
+## nothing, which is zero here.
+const MALE_SIGN: int = 0xEF
+const FEMALE_SIGN: int = 0xF5
+
+
+## `farcall GetGender` for a Pokemon whose DVs are known.
+static func gender_sign(data: GameData, species: int, dvs: int) -> int:
+	if data == null or dvs < 0:
+		return 0
+	match Gen2BattleMon.gender_for(data, species, dvs):
+		Gen2BattleMon.GENDER_MALE:
+			return MALE_SIGN
+		Gen2BattleMon.GENDER_FEMALE:
+			return FEMALE_SIGN
+	return 0
 
 var _screen: Gen2NamingScreen = null
 var _page: Gen2NamingScreenPage = null
 var _prompt: String = ""
 var _background: TextureRect = null
+## The strip `NamingScreenJumptable`'s row loads into `vTiles0 tile $00`, and
+## `.Pokemon`'s `♂`/`♀`/nothing. See [method set_icon].
+var _icon: PackedByteArray = PackedByteArray()
+var _gender: int = 0
 
 ## The four colours the screen is drawn through, index 0 the field and 3 the
-## ink. Empty is the ordinary black-on-white; the intro sets it because
+## ink. Empty is black-on-white; the intro sets it because
 ## `RotateThreePalettesRight` fades this screen out before `ClearTilemap`.
 var palette: PackedColorArray = PackedColorArray():
 	set(value):
@@ -83,6 +109,27 @@ func model() -> Gen2NamingScreen:
 	return _screen
 
 
+## `NamingScreenJumptable`'s icon, which every row but `.Friend` spawns and is
+## what those rows differ in. [param gender] is `.Pokemon`'s sign, or zero.
+func set_icon(strip: PackedByteArray, gender: int = 0) -> void:
+	_icon = strip
+	_gender = gender
+	_refresh()
+
+
+## `.Pokemon`'s icon and sign by species, and the other rows' by sprite number.
+func set_species_icon(data: GameData, species: int, gender: int = 0) -> void:
+	if data == null:
+		return
+	set_icon(data.species_icon_indices(species), gender)
+
+
+func set_sprite_icon(data: GameData, sprite_number: int) -> void:
+	if data == null:
+		return
+	set_icon(data.overworld_sprite_indices(sprite_number))
+
+
 ## `NamingScreenJoypadLoop`'s `.ReadButtons`, in its own order: A, then B, then
 ## START, then SELECT. The d-pad is `NamingScreen_AnimateCursor`'s own read and
 ## is not in that list, so it never ends the screen.
@@ -111,7 +158,7 @@ func handle_button(button: int) -> bool:
 func _refresh() -> void:
 	if _background == null or _page == null or _screen == null:
 		return
-	var indices: PackedByteArray = _page.draw(_screen, _prompt)
+	var indices: PackedByteArray = _page.draw(_screen, _prompt, _icon, _gender)
 	Gen2PicImage.show(_background, Gen2PicImage.from_indices(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, _colors()
 	))

--- a/game/world/nickname_prompt_screen.gd
+++ b/game/world/nickname_prompt_screen.gd
@@ -25,6 +25,10 @@ enum Phase {
 var _data: GameData = null
 ## `wStringBuffer1`, which is the species name until the player replaces it.
 var _species_name: String = ""
+## `wCurPartySpecies` and `GetGender`'s answer for the row `.Pokemon` draws
+## from; a caller naming by species name alone has no icon.
+var _species: int = 0
+var _gender_sign: int = 0
 ## `_WasSentToBillsPCText`/`_BallSentToPCText` when the Pokemon landed in the
 ## box, empty otherwise. A format, because both read the name buffer the naming
 ## screen has just written rather than the species name the question asked with.
@@ -59,6 +63,12 @@ func set_context(
 	_forced = forced
 	_question = question if not question.is_empty() \
 		else Gen2WorldPartyHost.caught_nickname_question(species_name)
+
+
+## `.Pokemon`'s icon. [param dvs] is `GetGender`'s input; -1 leaves the sign off.
+func set_species(species: int, dvs: int = -1) -> void:
+	_species = species
+	_gender_sign = Gen2NamingScreenScreen.gender_sign(_data, species, dvs)
 
 
 func _ready() -> void:
@@ -210,6 +220,8 @@ func _answer_question(yes: bool) -> void:
 		_naming = null
 		_after_question()
 		return
+	if _species > 0:
+		_naming.set_species_icon(_data, _species, _gender_sign)
 	_text_box.visible = false
 	_naming.closed.connect(_on_named)
 	add_child(_naming)

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -409,6 +409,10 @@ func _open_naming() -> void:
 		_naming = null
 		_enter_next_beat()
 		return
+	## `.Player`'s `GetPlayerIcon`, which is the sprite the gender screen picked.
+	_naming.set_sprite_icon(
+		_data, Gen2WorldSprite.player_normal_sprite(_gender == Gen2SaveData.GENDER_FEMALE)
+	)
 	_naming.closed.connect(_on_named)
 	add_child(_naming)
 	_hide_speech(true)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -991,6 +991,8 @@ func player_walk_frame() -> int:
 	## drawing even though OBJECT_STEP_FRAME itself retains its counter.
 	if _player_step_passes_remaining <= 0 or _player_step_direction == Vector2i.ZERO:
 		return 0
+	if _player_step_kind in Gen2WorldMovement.SLIDING_KINDS:
+		return 0
 	return (_player_step_frame >> 2) & 3
 
 
@@ -1096,7 +1098,8 @@ func advance_player_step_pass() -> bool:
 		return false
 	if _player_step_kind in Gen2WorldMovement.SPINNING_KINDS:
 		_player_spin_frame = Gen2WorldMovement.spin_advance(_player_spin_frame)
-	_player_step_frame = (_player_step_frame + 1) & 0x0F
+	if not _player_step_kind in Gen2WorldMovement.SLIDING_KINDS:
+		_player_step_frame = (_player_step_frame + 1) & 0x0F
 	_player_step_passes_remaining -= 1
 	if _player_step_passes_remaining <= 0:
 		_start_next_player_step()
@@ -5998,9 +6001,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 			## `CountStep`, so the step that leaves a map costs no repel step;
 			## try_connection() owns the facing and the step's own frames.
 			return transition
-		## `.NotMoving`, which reaches `._WalkInPlace`.
-		_stand_in_place()
-		return {"ok": false, "kind": &"move", "reason": &"map_edge"}
+		return _refused_move(direction, &"map_edge")
 	if forced_walk:
 		return _forced_step(direction, destination)
 	if not can_walk_to(destination, direction):
@@ -6015,8 +6016,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 			return hop
 		if not pushed.is_empty():
 			return pushed
-		_stand_in_place()
-		return {"ok": false, "kind": &"move", "reason": &"blocked"}
+		return _refused_move(direction, &"blocked")
 	var from_map: Vector2i = map_id()
 	var from_cell: Vector2i = player_cell
 	## .TrySurf's .ExitWater: .GetOutOfWater restores PLAYER_NORMAL and the walking
@@ -6032,13 +6032,19 @@ func move_result(direction: Vector2i) -> Dictionary:
 		kind = &"exit_water"
 	elif movement_mode == MOVEMENT_SURF:
 		kind = &"water_move"
+	## `.TryStep` reads `wPlayerTileCollision`, the cell being left, and its ice
+	## branch sits in front of `.BikeCheck`.
+	var kind_of_step: StringName = STEP_KIND_WALK
+	var passes: int = _step_frames_for_movement()
+	if Gen2WorldCollision.is_ice(collision_code_at(from_cell)):
+		kind_of_step = &"fast_slide_step"
+		passes = STEP_PASSES_FAST
 	player_cell = destination
 	player_facing = facing_for_direction(direction)
 	count_step()
-	var passes: int = _step_frames_for_movement()
 	_advance_followers(-1, from_cell, passes)
 	_do_step(direction)
-	_start_player_step(direction, passes)
+	_start_player_step(direction, passes, false, kind_of_step)
 	return {
 		"ok": true,
 		"kind": kind,
@@ -6047,6 +6053,19 @@ func move_result(direction: Vector2i) -> Dictionary:
 		"to_map": from_map,
 		"to_cell": player_cell,
 	}
+
+
+## `.NotMoving`: `._WalkInPlace` clears the turning byte and `.BumpSound` plays
+## SFX_BUMP, unless `.CheckWarp` raised `wWalkingIntoEdgeWarp`, which it does
+## whenever the standing cell carries the carpet naming the pressed direction,
+## warp or no warp. `.Surf` never runs `.CheckWarp`.
+func _refused_move(direction: Vector2i, reason: StringName) -> Dictionary:
+	_stand_in_place()
+	var into_carpet: bool = movement_mode != MOVEMENT_SURF \
+		and Gen2WorldCollision.directional_warp_direction(
+			collision_code_at(player_cell)
+		) == direction
+	return {"ok": false, "kind": &"move", "reason": reason, "bump": not into_carpet}
 
 
 ## `.DoStep`'s own tail: the walking direction is stored as `$80 | direction`
@@ -6078,18 +6097,13 @@ func standing_on_ice() -> bool:
 	return Gen2WorldCollision.is_ice(collision_code_at(player_cell))
 
 
-## `.CheckForced`, then `.GetAction`. The forced bit is OR'd into `wCurInput`
-## rather than replacing it, so a held direction and the slide's own can both be
-## set and `.GetAction`'s own test order decides between them: down, up, left,
-## right. [param held] is Vector2i.ZERO when nothing is held.
+## `.CheckForced`, then `.GetAction`. `and PAD_BUTTONS` drops the whole d-pad
+## before the slide's own direction is OR'd in, so a held key reaches
+## `.GetAction` on no frame of a slide.
 func effective_input_direction(held: Vector2i) -> Vector2i:
 	if not standing_on_ice():
 		return held
-	var forced: Vector2i = TURNING_DIRECTION_ORDER[_player_turning_direction & 3]
-	for candidate: Vector2i in TURNING_DIRECTION_ORDER:
-		if candidate == held or candidate == forced:
-			return candidate
-	return held
+	return TURNING_DIRECTION_ORDER[_player_turning_direction & 3]
 
 
 ## .CheckTile for the cell the player stands on: whether the tile overrides input,

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -258,8 +258,12 @@ static func category_rows(
 	var header: int = _header_of(data, slot)
 	if header >= 0:
 		out.append({"deco": header, "name": decoration_name(data, header)})
-	if out.size() < CATEGORY_MENU_HEIGHT:
-		out.append({"deco": 0, "name": decoration_name(data, 0)})
+	## `FindOwnedDecosInCategory` appends CANCEL before anything counts the rows
+	## and `.beyond_eight` takes it back off, so six owned rows are eight and
+	## lose it.
+	out.append({"deco": 0, "name": decoration_name(data, 0)})
+	if out.size() >= CATEGORY_MENU_HEIGHT:
+		out.pop_back()
 	return out
 
 

--- a/game/world/world_movement.gd
+++ b/game/world/world_movement.gd
@@ -17,6 +17,14 @@ const SPINNING_KINDS: Array[StringName] = [
 	&"turn_away", &"turn_in", &"turn_waterfall", &"step_dig",
 ]
 
+## The three commands reaching `SlideStep`, with `DoPlayerMovement.TryStep`'s
+## `STEP_ICE`. `SlideStep` sets OBJECT_ACTION_STAND, whose `SetFacingStandAction`
+## advances the walk frame only while the drawn one is odd; every duration is a
+## multiple of four, so a slide holds frame 0.
+const SLIDING_KINDS: Array[StringName] = [
+	&"slow_slide_step", &"slide_step", &"fast_slide_step",
+]
+
 ## `CounterclockwiseSpinAction`'s `.facings`.
 const SPIN_FACINGS: Array[int] = [
 	Gen2WorldSprite.FACING_DOWN, Gen2WorldSprite.FACING_RIGHT,

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -464,7 +464,9 @@ func tick_step() -> bool:
 		return false
 	if step_kind in Gen2WorldMovement.SPINNING_KINDS:
 		spin_frame = Gen2WorldMovement.spin_advance(spin_frame)
-	if step_direction != Vector2i.ZERO or weird_tree:
+	if step_kind in Gen2WorldMovement.SLIDING_KINDS:
+		frame = 0
+	elif step_direction != Vector2i.ZERO or weird_tree:
 		advance_walk_frame()
 	step_passes_remaining -= 1
 	if step_passes_remaining <= 0:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -28,6 +28,9 @@ const PREVIEW_COVER_FRAMES: int = 10
 ## starts. Played directly rather than through _handle_audio_request(), which
 ## expects a runtime request to acknowledge; a hop is movement, not a script.
 const SFX_JUMP_OVER_LEDGE: int = 0x16
+## constants/sfx_constants.asm's SFX_BUMP, which `.NotMoving` plays for a poll
+## that pressed a direction and committed nothing.
+const SFX_BUMP: int = 0x24
 ## constants/sfx_constants.asm's SFX_PLACE_PUZZLE_PIECE_DOWN, played by
 ## OWCutAnimation before its sprite animation. The animation itself is not
 ## rendered here; the sound is. Not SFX_CUT, which is $38 and is the battle
@@ -1204,8 +1207,7 @@ func _advance_held_direction() -> void:
 		return
 	## `.CheckForced` sits in front of `.GetAction` in all three of
 	## `.TranslateIntoMovement`'s branches, so a player standing on ice keeps
-	## walking with nothing held at all and a held direction is only obeyed when
-	## `.GetAction` tests it before the slide's own.
+	## walking with nothing held and obeys nothing that is.
 	var held: Vector2i = Vector2i.ZERO if direction == Gen2Button.NONE \
 		else Gen2Button.vector(direction)
 	var walking: Vector2i = _world.effective_input_direction(held)
@@ -1662,6 +1664,8 @@ func move_player(direction: Vector2i) -> bool:
 			if _renderer != null:
 				_renderer.refresh()
 			_refresh_labels()
+		else:
+			_play_bump_sfx(movement)
 		return false
 	## A whirlpool spins the player rather than moving them, so nothing a completed
 	## step owes applies: no warp, no encounter, no repel step.
@@ -1678,6 +1682,16 @@ func move_player(direction: Vector2i) -> bool:
 		_refresh_labels()
 		return true
 	return _after_player_move(movement)
+
+
+## `.BumpSound` opens on `CheckSFX` and returns on carry, so a refusal during
+## any effect is silent.
+func _play_bump_sfx(movement: Dictionary) -> void:
+	if not bool(movement.get("bump", false)):
+		return
+	if _audio_player == null or _audio_player.effect_playing():
+		return
+	_play_sfx(SFX_BUMP)
 
 
 ## What a step owes the rest of the screen on the frame it starts: the sounds
@@ -2099,6 +2113,7 @@ func _open_gift_nickname(request: Dictionary) -> bool:
 		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT if destination == &"box" else "",
 		"", _nuzlocke_names_everything()
 	)
+	host.set_species(species)
 	_nickname_answer = species_name
 	host.named.connect(_on_gift_named)
 	host.closed.connect(_on_gift_nickname_closed)
@@ -2133,6 +2148,7 @@ func _open_contest_nickname(_request: Dictionary = {}) -> bool:
 		return false
 	var host := Gen2NicknamePromptScreen.new()
 	host.set_context(_data, species_name, "", "", _nuzlocke_names_everything())
+	host.set_species(int(caught.get("species", 0)), int(caught.get("dvs", -1)))
 	_nickname_answer = species_name
 	host.named.connect(_on_gift_named)
 	host.closed.connect(_on_gift_nickname_closed)
@@ -4086,6 +4102,7 @@ func preview_gift_nickname(species: int = 0, boxed: bool = false) -> void:
 		_data, species_name,
 		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT if boxed else ""
 	)
+	host.set_species(chosen)
 	_nickname_answer = species_name
 	_nickname_preview = true
 	host.named.connect(_on_gift_named)
@@ -7375,6 +7392,9 @@ func _open_rival_name(_request: Dictionary) -> bool:
 		_data, Gen2NamingScreenScreen.PROMPT_RIVAL, Gen2NamingScreenScreen.KIND_PLAYER
 	):
 		return false
+	## `.Rival`'s own `RivalSpriteGFX`, which is why the rival's naming screen
+	## does not show the player.
+	host.set_sprite_icon(_data, Gen2NamingScreenScreen.SPRITE_RIVAL)
 	host.closed.connect(_on_rival_named)
 	host.z_index = 30
 	_rival_name_host = host

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -1209,12 +1209,11 @@ func _resume_party_selection(_choice: int) -> Dictionary:
 	return _waiting_result()
 
 
-## describedecoration is a local script in the cartridge. Its text must be
-## acknowledged before the one decoration that needs a host, the town map, calls
-## OverworldTownMap, which preserves the source's
-## opentext/waitbutton/special/closetext/end order.
+## describedecoration is a `ScriptJump`, so its script replaces the caller and
+## its own `end` ends the run: text, `special OverworldTownMap`, then over.
 func _resume_special_after_text(_choice: int) -> Dictionary:
 	var decoration_special: int = int(_pending.get("special_after_text", -1))
+	var finish: bool = bool(_pending.get("finish_after_special", false))
 	_pending = {}
 	_finish_after_pending = false
 	var special_result: Dictionary = _execute_special(decoration_special)
@@ -1222,7 +1221,10 @@ func _resume_special_after_text(_choice: int) -> Dictionary:
 		return _fail(
 			StringName(special_result.get("reason", &"special_failed")), special_result
 		)
-	return _waiting_result() if _pending else advance()
+	if _pending:
+		_finish_after_pending = finish
+		return _waiting_result()
+	return _complete() if finish else advance()
 
 
 ## The five Ask*Scripts TryTileCollisionEvent reaches, all one shape: opentext,
@@ -3929,24 +3931,25 @@ func _stage_decoration_description(description: int) -> Dictionary:
 				DECO_TOWN_MAP:
 					_stage_internal_text("It's the TOWN MAP.", false)
 					_pending["special_after_text"] = SPECIAL_OVERWORLD_TOWN_MAP
+					_pending["finish_after_special"] = true
 					return {"ok": true}
 				DECO_PIKACHU_POSTER:
-					return _stage_internal_text("It's a poster of a\ncute PIKACHU.", false)
+					return _stage_internal_text("It's a poster of a\ncute PIKACHU.", true)
 				DECO_CLEFAIRY_POSTER:
-					return _stage_internal_text("It's a poster of a\ncute CLEFAIRY.", false)
+					return _stage_internal_text("It's a poster of a\ncute CLEFAIRY.", true)
 				DECO_JIGGLYPUFF_POSTER:
-					return _stage_internal_text("It's a poster of a\ncute JIGGLYPUFF.", false)
+					return _stage_internal_text("It's a poster of a\ncute JIGGLYPUFF.", true)
 				_:
 					## `DecorationDesc_NullPoster` is an `end` and prints nothing.
-					return {"ok": true}
+					return _complete()
 		DECODESC_BIG_DOLL:
-			return _stage_internal_text("A giant doll! It's\nfluffy and cuddly.", false)
+			return _stage_internal_text("A giant doll! It's\nfluffy and cuddly.", true)
 		DECODESC_LEFT_DOLL, DECODESC_RIGHT_DOLL, DECODESC_CONSOLE:
 			## `DecorationDesc_OrnamentOrConsole` names whatever stands in that
 			## slot; the box is one text with the name written into it.
 			return _stage_internal_text("It's an adorable\n%s." % Gen2WorldDecoration.decoration_name(
 				data, state.maptile_decoration(DECODESC_SLOTS[description]) if state != null else 0
-			), false)
+			), true)
 	return _fail(&"invalid_decoration_description", {"description": description})
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -1974,6 +1974,8 @@ func _open_box_naming() -> void:
 		_status = "The naming keyboard is not in this cache."
 		_render_rows()
 		return
+	## `.Box`'s `PokeBallSpriteGFX`, the one row whose icon is not a walker.
+	host.set_sprite_icon(_data, Gen2NamingScreenScreen.SPRITE_POKE_BALL)
 	_naming = host
 	_set_overlay_open(true)
 	host.z_index = 5

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37868
+const MAX_COMMENT_LINES: int = 37786
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -7104,21 +7104,61 @@ func test_ice_forces_nothing_once_the_player_has_stood_still() -> void:
 	assert_eq(world.effective_input_direction(Vector2i.LEFT), Vector2i.LEFT)
 
 
-## `.CheckForced` ORs its bit into wCurInput rather than replacing it, so both
-## directions are set and `.GetAction`'s own test order decides: down, up, left,
-## right. A held DOWN therefore beats a slide running right, and a held UP does
-## not beat a slide running down.
-func test_a_held_direction_beats_the_slide_only_in_getactions_order() -> void:
+## `.CheckForced`'s `and PAD_BUTTONS` drops the whole d-pad before it ORs the
+## slide's own direction in, so no held key reaches `.GetAction` while a slide is
+## running: the four presses and nothing held all answer the same way.
+func test_a_held_direction_never_beats_the_slide() -> void:
 	var world: Gen2WorldAPI = _world(Vector2i(1, 1))
 	world.player_facing = world.facing_for_direction(Vector2i.RIGHT)
 	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
 	_finish_step(world)
-	assert_eq(world.effective_input_direction(Vector2i.DOWN), Vector2i.DOWN)
-	assert_eq(world.effective_input_direction(Vector2i.UP), Vector2i.UP)
-	assert_eq(world.effective_input_direction(Vector2i.LEFT), Vector2i.LEFT)
-	# Right against right is still right, and nothing held is the slide's own.
-	assert_eq(world.effective_input_direction(Vector2i.RIGHT), Vector2i.RIGHT)
-	assert_eq(world.effective_input_direction(Vector2i.ZERO), Vector2i.RIGHT)
+	for held: Vector2i in [
+		Vector2i.DOWN, Vector2i.UP, Vector2i.LEFT, Vector2i.RIGHT, Vector2i.ZERO
+	]:
+		assert_eq(world.effective_input_direction(held), Vector2i.RIGHT, str(held))
+
+
+## `.TryStep` reads the tile the player is standing on and its `.ice` branch
+## sits in front of `.BikeCheck`, so a step off an ice cell is `STEP_ICE`. That
+## is `fast_slide_step`, `StepVectors`' four-pass row, and `SlideStep` sets
+## OBJECT_ACTION_STAND, so the drawing holds frame 0 for the whole slide.
+func test_a_slide_step_is_the_fast_row_and_does_not_animate() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(1, 1))
+	world.player_facing = world.facing_for_direction(Vector2i.RIGHT)
+	# The first step is onto the ice from a walking tile: eight passes and the
+	# ordinary walk cycle.
+	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	var walking: int = 0
+	while world.player_step_in_progress():
+		walking += 1
+		world.advance_player_step_pass()
+	assert_eq(walking, Gen2WorldAPI.STEP_PASSES_WALK)
+
+	assert_true(world.standing_on_ice())
+	assert_true(bool(world.player_input_move(Vector2i.RIGHT).get("ok", false)))
+	var sliding: int = 0
+	while world.player_step_in_progress():
+		assert_eq(world.player_walk_frame(), 0)
+		sliding += 1
+		world.advance_player_step_pass()
+	assert_eq(sliding, Gen2WorldAPI.STEP_PASSES_FAST)
+
+
+## `.NotMoving` reaches `.BumpSound` for every refused press with a direction,
+## and `.CheckWarp` raises `wWalkingIntoEdgeWarp` first when the player stands on
+## the carpet naming that direction, which is what keeps a door silent.
+func test_a_refused_step_reports_the_bump_unless_it_is_an_edge_warp() -> void:
+	var world: Gen2WorldAPI = _world(Vector2i(8, 6))
+	var blocked: Dictionary = world.move_result(Vector2i.RIGHT)
+	assert_false(bool(blocked.get("ok", false)))
+	assert_true(bool(blocked.get("bump", false)), JSON.stringify(blocked))
+
+	# The carpet at (13,4) faces UP and the cell above it is the wall an
+	# interior door always has, so the step is refused and stays silent.
+	var carpet: Gen2WorldAPI = _world(Vector2i(13, 4))
+	var quiet: Dictionary = carpet.move_result(Vector2i.UP)
+	assert_false(bool(quiet.get("ok", false)))
+	assert_false(bool(quiet.get("bump", false)), JSON.stringify(quiet))
 
 
 ## `.CheckTurning`'s first test is wPlayerTurningDirection, so the tap-to-turn

--- a/tools/checks/backup_warp.gd
+++ b/tools/checks/backup_warp.gd
@@ -4,7 +4,6 @@ extends RefCounted
 ## cartridges: `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`, which
 ## `SavePlayerData` copies into `sCurMapData` and which two unrelated routines both
 ## read. Expected values come from the pinned pokecrystal and pokegold sources.
-##
 ## The finding the topic carries: a `warp_event` whose destination is -1 names no
 ## warp and no map of its own, and this port read the placeholder beside it, so the
 ## stairs out of every Pokemon Center's second floor led nowhere.

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -307,7 +307,6 @@ func _verify_the_entrance(game_id: StringName, data: GameData) -> void:
 
 ## `DoBattleTransition` on a real cache: the two tiles it wipes with, the palette
 ## it floods the map with, and all four animations run to the end.
-##
 ## The tiles are content whose value is known independently, which is what checks
 ## the address: one of them is solid colour 3 and the other is the chequered
 ## square, and no other pair of tiles in the dump is that.
@@ -530,7 +529,6 @@ func _verify_substitute_pic(game_id: StringName, data: GameData) -> void:
 
 ## Every animation played through [Gen2BattleAnimPlayer], which is the script
 ## plus the object pool, the tile window and the shadow OAM.
-##
 ## Nothing here asserts what an animation looks like; what it pins is that all
 ## 278 spawn, step and retire their objects inside the cartridge's own limits,
 ## and it prints the inventory of what is still to build.

--- a/tools/checks/cerulean.gd
+++ b/tools/checks/cerulean.gd
@@ -691,7 +691,6 @@ func _crossings(
 ## Ledge hops included, mirroring `tools/preview_world_story.gd`'s
 ## _reachable_step(): a region drawn without them would claim walls that a real
 ## walk can cross, which is exactly the mistake these counts are here to catch.
-##
 ## [param closed] cells are treated as unwalkable, which is how an unavoidable
 ## cell is proved: shut it and see what stops being reachable.
 func _region(

--- a/tools/checks/crystal_route30_trainer.gd
+++ b/tools/checks/crystal_route30_trainer.gd
@@ -4,7 +4,6 @@ var _r: RefCounted = null
 
 ## Verifies the first Route 30 trainer against a freshly imported Crystal cache.
 ## The expected record comes from the pinned pokecrystal Route30 map source.
-##
 ##   Godot --headless --path . -s res://tools/validate.gd -- crystal_route30_trainer
 
 const MAP_GROUP: int = 26

--- a/tools/checks/decorations.gd
+++ b/tools/checks/decorations.gd
@@ -204,3 +204,26 @@ func _verify_categories(data: GameData) -> void:
 				slot, int(headers.get(slot, 0)),
 			]
 		)
+	_verify_menu_trim(data)
+
+
+## `PopulateDecoCategoryMenu`'s `cp 8`, counted on the list with PUT IT AWAY and
+## CANCEL already on it: six owned rows make eight and lose the last.
+func _verify_menu_trim(data: GameData) -> void:
+	var ornaments: Array = EXPECTED_CATEGORIES[Gen2WorldDecoration.SLOT_LEFT_ORNAMENT]
+	for owned: int in range(1, ornaments.size() + 1):
+		var state := Gen2WorldState.new()
+		for index: int in owned:
+			Gen2WorldDecoration.set_owned(data, state, int(ornaments[index]))
+		var rows: Array = Gen2WorldDecoration.category_rows(
+			data, state, Gen2WorldDecoration.SLOT_LEFT_ORNAMENT
+		)
+		var cancels: bool = owned + 2 < Gen2WorldDecoration.CATEGORY_MENU_HEIGHT
+		_r.check(
+			rows.size() == owned + (2 if cancels else 1),
+			"%d owned ornaments gave %d rows" % [owned, rows.size()]
+		)
+		_r.check(
+			(int(rows[rows.size() - 1]["deco"]) == 0) == cancels,
+			"%d owned ornaments got CANCEL wrong" % owned
+		)

--- a/tools/checks/elite_four.gd
+++ b/tools/checks/elite_four.gd
@@ -86,7 +86,6 @@ func run(r: RefCounted) -> void:
 
 
 ## The one door in, and the prepare callback that resets the leg.
-##
 ## This is the one map here worth entering: `MAPCALLBACK_NEWMAP` is what
 ## `IndigoPlateauPokecenter1FPrepareElite4Callback` hangs off, and it is a
 ## reset, so it is checked by setting every flag it clears beforehand.
@@ -244,7 +243,6 @@ func _verify_hall_of_fame(data: GameData, game_id: StringName) -> void:
 ## The two block changes a room turns on, checked as reachability rather than as
 ## collision bytes: the entrance scene has to cut the arrival warp off, and the
 ## boss has to open a door that was solid before them.
-##
 ## [param seal] and [param door] are source walk cells, which a `changeblock`
 ## takes; a block spans 2x2 of them, so the block index is the cell halved.
 func _verify_doors(

--- a/tools/checks/gold_route30_trainer.gd
+++ b/tools/checks/gold_route30_trainer.gd
@@ -7,7 +7,6 @@ var _r: RefCounted = null
 ## Gold and Silver share one command profile
 ## (Gen2WorldScriptRunner._crystal_commands() returns false for both), so this
 ## also covers Silver's opcode layout for this flow.
-##
 ##   Godot --headless --path . -s res://tools/validate.gd -- gold_route30_trainer
 
 const MAP_GROUP: int = 26

--- a/tools/checks/ice_slides.gd
+++ b/tools/checks/ice_slides.gd
@@ -4,12 +4,13 @@ var _r: RefCounted = null
 
 ## Sweeps every ice cell on every map of all three cartridges through the slide
 ## `DoPlayerMovement.CheckForced` and `CheckStandingOnIce` produce, rather than
-## sampling the Ice Path. The expected shapes come from the pinned
-## player_movement.asm, identical in both: a step onto ice leaves
-## `wPlayerTurningDirection` set, the next poll ORs that direction back into
-## `wCurInput`, and the run ends at the first refused step. Two invariants are what
-## a broken slide trips: it has to terminate, which it only does because a refusal
-## clears the byte, and with nothing held it has to keep the one direction.
+## sampling the Ice Path. A step onto ice leaves `wPlayerTurningDirection` set and
+## the next poll rebuilds `wCurInput` as `(input and PAD_BUTTONS) or forced`.
+
+## Three invariants are what a broken slide trips: it has to terminate, which it
+## only does because a refusal clears the byte; it has to keep the one direction
+## against every held key as well as against none, the d-pad being masked off; and
+## each of its steps is `STEP_ICE`, the fast row, rather than a walk.
 
 ## A slide can be no longer than the map, so anything past this is a loop.
 const RUN_CEILING: int = 512
@@ -83,10 +84,12 @@ func _run_one(
 	]
 	if not bool(world.player_input_move(direction).get("ok", false)):
 		return false
+	## The first step is off the ice cell this run starts on, so it is already a
+	## slide even though nothing has been held yet.
+	if not _drain_step(world, where, true):
+		return false
 	var steps: int = 0
 	while world.standing_on_ice():
-		if not _drain_step(world, where):
-			return false
 		## `.CheckForced` with nothing held at all, which is the whole point of
 		## the routine: the slide supplies its own direction.
 		var forced: Vector2i = world.effective_input_direction(Vector2i.ZERO)
@@ -94,6 +97,14 @@ func _run_one(
 			where, str(forced)
 		]):
 			return false
+		for held: Vector2i in [
+			Vector2i.DOWN, Vector2i.UP, Vector2i.LEFT, Vector2i.RIGHT
+		]:
+			if not _r.check(
+				world.effective_input_direction(held) == direction,
+				"%s: a held %s steered the slide." % [where, str(held)]
+			):
+				return false
 		steps += 1
 		if not _r.check(steps < RUN_CEILING, "%s: the slide never ended." % where):
 			return false
@@ -104,14 +115,27 @@ func _run_one(
 				not world.standing_on_ice(),
 				"%s: a refused step left the slide running." % where
 			)
+		if not _drain_step(world, where, true):
+			return false
 	return true
 
 
-func _drain_step(world: Gen2WorldAPI, where: String) -> bool:
+func _drain_step(world: Gen2WorldAPI, where: String, sliding: bool) -> bool:
 	var passes: int = 0
 	while world.player_step_in_progress():
+		if sliding and not _r.check(
+			world.player_walk_frame() == 0,
+			"%s: a slide advanced its walk frame." % where
+		):
+			return false
 		world.advance_player_step_pass()
 		passes += 1
 		if not _r.check(passes < PASS_CEILING, "%s: a step never finished." % where):
 			return false
+	## `STEP_ICE` is `fast_slide_step`, the four-pass row: half a walk.
+	if sliding and not _r.check(
+		passes == Gen2WorldAPI.STEP_PASSES_FAST,
+		"%s: a slide step spent %d passes." % [where, passes]
+	):
+		return false
 	return true

--- a/tools/checks/lavender.gd
+++ b/tools/checks/lavender.gd
@@ -369,7 +369,6 @@ func _crossings(
 ## Ledge hops included, the way `tools/preview_world_story.gd`'s own
 ## _reachable_step() walks: Route 8 is the map where leaving them out would claim
 ## a wall of three bikers the eastbound walk never meets.
-##
 ## [param closed] cells are treated as unwalkable, which is how an unavoidable
 ## cell is proved: shut it and see what stops being reachable.
 func _region(

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -283,7 +283,6 @@ func _check_roofs(pin: String) -> void:
 ## Every (map group, tileset) pair the corpus really draws: the strip a map is
 ## given must hold that group's own roof at tiles $0A..$12 and its tileset's own
 ## tiles everywhere else.
-##
 ## The roof itself is compared against the pin's `gfx/tilesets/roofs/*.png`
 ## rather than against the cache, so a wrong offset or a wrong run is caught by
 ## the source and not by a second reading of the same bytes. rgbgfx maps the

--- a/tools/checks/opening_lane.gd
+++ b/tools/checks/opening_lane.gd
@@ -5,7 +5,6 @@ var _r: RefCounted = null
 ## Validates the cache records required by the first playable lane. This is a
 ## read-only cache audit: it never opens a ROM and never treats a missing
 ## opening record as a presentation fallback.
-##
 ##   Godot --headless --path . -s res://tools/validate.gd -- opening_lane
 
 ## Longer than the whole boot: Crystal's movie is 2,340 frames and Gold and
@@ -147,7 +146,6 @@ func _audit_audio_records(data: GameData, audio_counts: Dictionary) -> Array[Str
 	return out
 
 ## What the title screen puts around itself in a window that is not 10:9.
-##
 ## `LoadTitleScreenTilemap` writes all thirty-two columns of the BG map and the
 ## hardware shows twenty, so the surround is the twelve the screen never reached,
 ## repeated. Two things would break it and neither is visible in a 160x144

--- a/tools/checks/phone.gd
+++ b/tools/checks/phone.gd
@@ -75,7 +75,6 @@ func _contacts(game_id: StringName, data: GameData) -> void:
 
 
 ## `MomTriesToBuySomething`'s whole block against `data/items/mom_phone.asm`.
-##
 ## The two tables are pinned here rather than read off the cache, so a wrong
 ## address fails on content: the ladder's ten triggers and costs, the five she
 ## picks between, and which of each is a doll. Both scripts have to reach Mom's

--- a/tools/checks/screen_palettes.gd
+++ b/tools/checks/screen_palettes.gd
@@ -58,7 +58,6 @@ const HP_FRACTIONS: Array[float] = [1.0, 0.3, 0.05]
 ## bytes on. Every screen in [constant SHINY_LAYOUTS] asks for one or the other,
 ## so a species whose shiny entry never reached the cache would draw its ordinary
 ## colours on all five however carefully each one asked.
-##
 ## Swept rather than sampled: the pair is per species and the importer reads them
 ## from one table, so one missing entry is the whole failure mode.
 func _verify_shiny_palettes() -> void:

--- a/tools/checks/scripted_scenes.gd
+++ b/tools/checks/scripted_scenes.gd
@@ -3,7 +3,6 @@ extends RefCounted
 ## Conversations driven from the imported map events on every cartridge profile:
 ## two long movement scenes a hardware frame at a time, and every object whose
 ## script opens on `faceplayer`.
-##
 ##   Godot --headless --path . -s res://tools/validate.gd -- scripted_scenes
 
 const CHERRYGROVE_CITY := Vector2i(26, 3)

--- a/tools/checks/second_screen.gd
+++ b/tools/checks/second_screen.gd
@@ -41,7 +41,6 @@ func run(r: RefCounted) -> void:
 
 
 ## Every tab any gate can open has the page renderer that tab is built from.
-##
 ## A tab whose page refuses would be a row on the panel that opens a black
 ## rectangle, which is worse than the tab not being there.
 func _verify_pages(game_id: StringName, data: GameData) -> void:

--- a/tools/checks/slots.gd
+++ b/tools/checks/slots.gd
@@ -167,7 +167,6 @@ func _verify_text(game_id: StringName, data: GameData) -> void:
 
 
 ## Whole spins on a pinned seed, every bet and both machines.
-##
 ## What is asserted is the source's own arithmetic rather than a pinned outcome:
 ## the coins the bet took, the payout the match is worth, the reels standing on
 ## symbols their own strips carry, and a match that is really lined up on one of

--- a/tools/checks/specials.gd
+++ b/tools/checks/specials.gd
@@ -18,7 +18,6 @@ const EXPECTED_DEFERRED: Dictionary = {
 	## to a modern platform. The cable club's own sixteen rows have left this
 	## list with the Battle Tower's seven, `DisplayLinkRecord`, which sat in the
 	## link block without being link play, and Mystery Gift's three.
-	##
 	## The bank a routine sits in decides nothing: `GiveOddEgg` and
 	## `AskRememberPassword` sat here for being mobile neighbours, and both are
 	## reached by an ordinary NPC. Read the call sites before adding a row.
@@ -190,7 +189,6 @@ func _verify_slow_cry(data: GameData) -> void:
 ## dumps: each has to decode to something, and every `text_ram` marker left in
 ## one has to name an address the cache can fill. An unresolved marker is what a
 ## wrong pin looks like from the screen that prints the box.
-##
 ## A run the cartridge does not ship is checked to be absent rather than empty:
 ## Gold and Silver's `SpecialsPointers` is short enough that no script of theirs
 ## can reach the Poke Seer, Buena or her prize counter.

--- a/tools/checks/tmhm.gd
+++ b/tools/checks/tmhm.gd
@@ -76,7 +76,6 @@ func run(r: RefCounted) -> void:
 
 
 ## home/hm_moves.asm's IsHMMove against the cartridge's own HM rows.
-##
 ## The two lists are separate in the source and could drift: IsHMMove is a
 ## hand-written array, TMHMMoves rows 51 to 57 are the items. ForgetMove reads
 ## the first, so this checks they name the same seven moves in each real cache,

--- a/tools/checks/world_scripts.gd
+++ b/tools/checks/world_scripts.gd
@@ -37,7 +37,6 @@ var _r: RefCounted = null
 ## Reports how far the cached overworld script and text resources can be read.
 ## This tool only reads the derived user cache. It never writes cartridge data
 ## into the project.
-##
 ##   Godot --headless --path . -s res://tools/validate.gd -- world_scripts
 
 

--- a/tools/dump_tables.gd
+++ b/tools/dump_tables.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Prints the decoded text tables out of the cache, headlessly.
-##
 ##   Godot --headless --path . -s res://tools/dump_tables.gd -- <game> [table]
-##
 ## The written counterpart of the contact sheet: a bad offset in a name table
 ## produces plausible words rather than an error, so the check is reading the
 ## output. <game> is a registry id; [table] is species, moves, items, types,
@@ -156,7 +154,6 @@ func _dump(directory: String, table: String) -> void:
 
 
 ## Every species' level-up moves, in the cartridge's order rather than sorted.
-##
 ## Reading them is the check the runtime one cannot be: the levels and move
 ## numbers are in range whatever a wrong offset does, but a learnset that reads
 ## Tackle at 1 and Growl at 4 for Bulbasaur is right and one that does not is not.
@@ -378,7 +375,6 @@ func _name_at(names: Array, number: int) -> String:
 
 
 ## The chart as a grid, attacker down the side and defender across the top.
-##
 ## Nobody checks a list of 110 rows; a grid gets checked, because the published
 ## table has the same shape and a wrong cell stands out. Only the seventeen real
 ## types are shown: the padding numbers between the two groups have names but no

--- a/tools/generate_launcher_sfx.gd
+++ b/tools/generate_launcher_sfx.gd
@@ -1,10 +1,8 @@
 extends SceneTree
 
 ## Renders the launcher's sound effects to `assets/launcher/sfx/*.wav`.
-##
 ## The sounds are synthesised rather than sampled so the repository carries no
 ## third-party audio. Run after changing any recipe below:
-##
 ##     Godot --headless -s res://tools/generate_launcher_sfx.gd
 
 const OUTPUT_DIR: String = "res://assets/launcher/sfx"

--- a/tools/import_rom.gd
+++ b/tools/import_rom.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Imports a cartridge into the user:// cache, headlessly.
-##
 ##   Godot --headless --path . -s res://tools/import_rom.gd -- [file-or-dir ...]
-##
 ## Defaults to res://roms. Exits 0 only if every candidate imported. Add
 ## --verify to stop after the layout check without writing a cache.
 

--- a/tools/lib/check_run.gd
+++ b/tools/lib/check_run.gd
@@ -2,7 +2,6 @@ extends RefCounted
 
 ## The harness every `tools/validate.gd` topic shares: the three cartridges, the
 ## failure list, and the world helpers a map check needs.
-##
 ## A topic is a script under `tools/checks/` with `func run(r) -> void`. It
 ## reports through [method check] and prints its own census lines with
 ## [method note]; the runner owns the exit code.

--- a/tools/lib/tool_path.gd
+++ b/tools/lib/tool_path.gd
@@ -39,7 +39,6 @@ static func refusal(path: String) -> String:
 
 
 ## The picture a preview tool is about to write, or null with the reason printed.
-##
 ## `--headless` has no viewport texture, so `get_image()` answers null there and
 ## a tool run that way otherwise calls `save_png` on it once a frame until
 ## `godot.sh`'s wall clock cap. Every tool here is a windowed run; this is what

--- a/tools/make_nro_icon.gd
+++ b/tools/make_nro_icon.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Writes the 256x256 JPEG an NRO carries, out of the repository's own PNG.
-##
 ##     Godot --headless --path . -s res://tools/make_nro_icon.gd -- <out.jpg>
-##
 ## `elf2nro --icon=` takes a JPEG of exactly that size and nothing else, and the
 ## repository's icon is a 1024 PNG, so one is made from the other at package time
 ## rather than the same picture being committed twice. Godot does it rather than

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -5,7 +5,6 @@ extends SceneTree
 ## queue walked to the animation it wants, and a counted number of frames spent
 ## inside it. The flags and the `catch`, `0`, `miss` and frame-range forms are
 ## documented below.
-##
 ##   Godot --path . -s res://tools/preview_battle_anim.gd -- \
 ##       <game> <output.png> <move> <side> <frames> [scene_off] [matchup=<enemy>,<player>]
 
@@ -206,7 +205,6 @@ func _prefix() -> String:
 
 
 ## One hardware frame of the opening, with the press a person would make.
-##
 ## `WildPokemonAppearedText`, `WantsToBattleText` and the `cont` inside
 ## `BattleText_EnemySentOut` all wait on a button; this counts
 ## [constant PRESS_AFTER] frames of the line standing finished and then presses,

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -4,7 +4,6 @@ extends SceneTree
 ## `BattleMenu`'s own four rows and the `MoveSelectionScreen` behind FIGHT,
 ## `OfferSwitch`'s yes/no box over the field, `AskUseNextPokemon`'s box in the same
 ## place, and the party list they open. The stages are [constant MENU_STAGES] and [constant WORLD_STAGES].
-##
 ##   Godot --path . -s res://tools/preview_battle_switch.gd -- \
 ##       crystal /tmp/s.png [stage] [presses] [passes]
 

--- a/tools/preview_clickable.gd
+++ b/tools/preview_clickable.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Checks that every button a launcher screen shows can actually be pressed.
-##
 ##   Godot --path . -s res://tools/preview_clickable.gd
-##
 ## Not headless and not a `tools/checks/` topic: it reads `root` and
 ## `gui_get_hovered_control()`, so it needs a real window. A button drawn in the
 ## right place is still dead if something transparent is sitting on top of it, and

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -6,7 +6,6 @@ extends SceneTree
 ## permission come from the same two sources the runtime reads, so a wall drawn
 ## without a red square is a real disagreement rather than a rendering offset.
 ## Objects are not drawn: this is the map's own answer.
-##
 ##   Godot --headless --path . -s res://tools/preview_collision.gd -- crystal 26 2 /tmp/route31.png
 
 const SCALE: int = 3

--- a/tools/preview_controls.gd
+++ b/tools/preview_controls.gd
@@ -2,9 +2,7 @@ extends SceneTree
 
 ## Captures the overworld with the on-screen controller shown, in whichever
 ## orientation the window is given.
-##
 ##   Godot --path . --resolution 480x960 -s res://tools/preview_controls.gd -- <out.png> [mod]
-##
 ## A `mod` argument registers two controls of a mod's own and switches their
 ## on-screen buttons on. The controller is forced on for the capture, since `auto`
 ## would correctly hide it on a desktop; the options file is never written.

--- a/tools/preview_credits.gd
+++ b/tools/preview_credits.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Captures the credits against a real imported cache, one source frame at a time.
-##
 ##   Godot --headless --path . -s res://tools/preview_credits.gd -- crystal /tmp/c.png [frame] [live]
-##
 ## [frame] is how many source frames to spend before the shot; a `CREDITS_WAIT` tick
 ## is thirteen frames, several separated by `;` write one file each, and a frame
 ## suffixed `b` holds B down for it. `live` drives the production world screen's own

--- a/tools/preview_fishing.gd
+++ b/tools/preview_fishing.gd
@@ -3,7 +3,6 @@ extends SceneTree
 ## Captures the production fishing cast screen. With only an output path it uses
 ## the deterministic integration fixture; pass a real imported cache and map to
 ## capture authentic map art instead.
-##
 ##   Godot --path . -s res://tools/preview_fishing.gd -- /tmp/fishing.png
 ##   Godot --path . -s res://tools/preview_fishing.gd -- /tmp/fishing.png silver 2 5
 

--- a/tools/preview_gs_intro.gd
+++ b/tools/preview_gs_intro.gd
@@ -2,9 +2,7 @@ extends SceneTree
 
 ## Captures Gold and Silver's intro movie against a real imported cache, one source
 ## frame at a time.
-##
 ##   Godot --headless --path . -s res://tools/preview_gs_intro.gd -- gold /tmp/i.png [frame;frame]
-##
 ## [frame] is how many source frames to spend before the shot; several separated by
 ## `;` write one file each, numbered. With no frame list the tool runs the whole
 ## movie and prints the frame each scene starts on, which is what pins the budgets.

--- a/tools/preview_hall_of_fame.gd
+++ b/tools/preview_hall_of_fame.gd
@@ -3,9 +3,7 @@ extends SceneTree
 ## Captures the production Hall of Fame overlay against a real imported cache,
 ## which is what makes it worth looking at: the panel draws a real front pic, the
 ## real font and the real text-box frame.
-##
 ##   Godot --path . -s res://tools/preview_hall_of_fame.gd -- crystal /tmp/hof.png [page]
-##
 ## A fourth argument of `shiny` makes the lead shiny. [page] is how many times to
 ## advance, so 0 is the first party member and the last pages are the player's own.
 

--- a/tools/preview_intro.gd
+++ b/tools/preview_intro.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Captures the new-game opening screens against a real cache.
-##
 ##   Godot --path . -s res://tools/preview_intro.gd -- <game> <out.png> [what] [steps] [WxH]
-##
 ## `what` is `copyright`, `presents`, `title`, `gender`, `clock`, `speech` or
 ## `shrink`; `steps` is how many source frames to run first, several separated by
 ## commas writing one file each. `WxH` photographs the opening in a real window

--- a/tools/preview_intro_movie.gd
+++ b/tools/preview_intro_movie.gd
@@ -2,9 +2,7 @@ extends SceneTree
 
 ## Captures the intro movie against a real imported cache, one source frame at a
 ## time.
-##
 ##   Godot --headless --path . -s res://tools/preview_intro_movie.gd -- crystal /tmp/i.png [frame;frame]
-##
 ## [frame] is how many source frames to spend before the shot; several separated by
 ## `;` write one file each, numbered. With no frame list the tool runs the whole
 ## movie and prints the frame each scene starts on, which is what pins the budgets.

--- a/tools/preview_launcher.gd
+++ b/tools/preview_launcher.gd
@@ -2,11 +2,9 @@ extends SceneTree
 
 ## Photographs the launcher in one appearance, at one window size, with a chosen
 ## set of cartridges present.
-##
 ##   Godot --path . -s res://tools/preview_launcher.gd -- <out.png> [light|dark] \
 ##       [width] [height] [page] [empty|mixed|full|stale] [view] [mod id] [scroll] \
 ##       [focus index] [fade step] [insets]
-##
 ## Every argument is documented at the parse below. Opens a real window.
 
 const STATES: Dictionary = {

--- a/tools/preview_mail.gd
+++ b/tools/preview_mail.gd
@@ -4,9 +4,7 @@ extends SceneTree
 ## one screen in this project drawn through four cartridge colours rather than a
 ## white-to-black pair, and every one is a different VRAM window over the same 1bpp
 ## run, so the picture is what says a transcription is right.
-##
 ##   Godot --headless --path . -s res://tools/preview_mail.gd -- crystal /tmp/mail.png [type]
-##
 ## [type] is a `MailGFXPointers` index, 0 to 9, or `all` for a contact sheet.
 
 const COLUMNS: int = 5

--- a/tools/preview_mom_scene.gd
+++ b/tools/preview_mom_scene.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## `MeetMomRightScript` through the world screen, frame by frame.
-##
 ##   Godot --headless --path . -s res://tools/preview_mom_scene.gd -- <game> [png] [frame]
-##
 ## The story walker proves the script's results, never that the presentation runs,
 ## and a run that moves a checkpoint exits non-zero. Crystal triggers on the coord
 ## events at (8,4) and (9,4), Gold and Silver `sdefer` it from the map entry, and

--- a/tools/preview_mystery_gift.gd
+++ b/tools/preview_mystery_gift.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Captures the Mystery Gift screen against a real imported cache.
-##
 ##   Godot --headless --path . -s res://tools/preview_mystery_gift.gd -- <game> <out.png> [box]
-##
 ## [box] is `prompt` or one of `DoMysteryGift`'s eight outcome names, or `all` for a
 ## contact sheet, which is the default. The frame is the one picture that differs
 ## between the two cartridges for a reason: Crystal builds it out of one run and two

--- a/tools/preview_naming_screen.gd
+++ b/tools/preview_naming_screen.gd
@@ -3,14 +3,15 @@ extends SceneTree
 ## Captures the naming screen against a real imported cache, which is what makes it
 ## worth looking at: the keyboard, the border, the two entry markers and the cursor
 ## bracket are all cartridge graphics rather than stand-ins.
-##
 ##   Godot --path . -s res://tools/preview_naming_screen.gd -- crystal /tmp/name.png [presses]
-##
-## A `mail` argument opens `_ComposeMailMessage`, a `rival` one NAME_RIVAL.
-## [presses] is a button script: `r`, `l`, `u`, `d`, `a`, `b`, `s` and `c`.
+
+## A `mail` argument opens `_ComposeMailMessage`, a `rival` one NAME_RIVAL and a
+## `mon` one NAME_MON. [presses] is a button script: `r`, `l`, `u`, `d`, `a`, `b`, `s` and `c`.
 
 const WINDOW_SIZE := Vector2i(1152, 648)
 const SETTLE_FRAMES: int = 8
+## CYNDAQUIL, whose menu icon and gender sign are both worth looking at.
+const PREVIEW_SPECIES: int = 155
 
 const BUTTONS: Dictionary = {
 	"u": Gen2Button.UP,
@@ -48,22 +49,38 @@ func _initialize() -> void:
 	root.set_content_scale_size(WINDOW_SIZE)
 	root.size = WINDOW_SIZE
 	var mail: bool = args.has("mail")
+	var mon: bool = args.has("mon")
 	var prompt: String = Gen2NamingScreenScreen.PROMPT_RIVAL if args.has("rival") \
 		else Gen2NamingScreenScreen.PROMPT_PLAYER
+	if mon:
+		prompt = Gen2WorldPartyHost.nickname_prompt(
+			String(data.species(PREVIEW_SPECIES).get("name", ""))
+		)
+	var kind: StringName = Gen2NamingScreenScreen.KIND_PLAYER
+	if mail:
+		kind = Gen2NamingScreenScreen.KIND_MAIL
+	elif mon:
+		kind = Gen2NamingScreenScreen.KIND_MON
 	_screen = Gen2NamingScreenScreen.new()
-	if not _screen.open(
-		data, "" if mail else prompt,
-		Gen2NamingScreenScreen.KIND_MAIL if mail else Gen2NamingScreenScreen.KIND_PLAYER
-	):
+	if not _screen.open(data, "" if mail else prompt, kind):
 		push_error("The %s cache carries no naming screen data." % args[0])
 		quit(1)
 		return
+	## The icon is the caller's on every screen but mail.
+	if mon:
+		_screen.set_species_icon(
+			data, PREVIEW_SPECIES, Gen2NamingScreenScreen.MALE_SIGN
+		)
+	elif args.has("rival"):
+		_screen.set_sprite_icon(data, Gen2NamingScreenScreen.SPRITE_RIVAL)
+	elif not mail:
+		_screen.set_sprite_icon(data, Gen2WorldSprite.SPRITE_PLAYER)
 	_screen.scale = Vector2(4, 4)
 	root.add_child(_screen)
 	current_scene = _screen
 
 	var presses: String = args[2] \
-		if args.size() > 2 and args[2] not in ["mail", "rival"] else ""
+		if args.size() > 2 and args[2] not in ["mail", "rival", "mon"] else ""
 	for key: String in presses:
 		if BUTTONS.has(key):
 			_screen.handle_button(int(BUTTONS[key]))

--- a/tools/preview_oak_speech.gd
+++ b/tools/preview_oak_speech.gd
@@ -2,9 +2,7 @@ extends SceneTree
 
 ## Captures Oak's speech against a real imported cache: the real trainer-class
 ## pic, the real Wooper front pic, the real font and the real text-box frame.
-##
 ##   Godot --path . -s res://tools/preview_oak_speech.gd -- crystal /tmp/oak.png [advance|choices|player]
-##
 ## [advance] is how many A presses to make before the capture, so 0 is the first
 ## page of `_OakText1` and enough of them reaches the naming screen.
 

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -1,10 +1,8 @@
 extends SceneTree
 
 ## Captures the pack against a real imported cache.
-##
 ##   Godot --headless --path . -s res://tools/preview_pack.gd -- \
 ##       crystal /tmp/pack.png [items|balls|key|tmhm|use|give] [presses] [female]
-##
 ## The world behind it is a new game holding enough of each pocket to scroll, with a
 ## development party so `use` and `give` reach `.Party`'s own list. [presses] is a
 ## `u,d,l,r,a,b,s` list driven into the real screen before the shot.

--- a/tools/preview_party.gd
+++ b/tools/preview_party.gd
@@ -1,10 +1,8 @@
 extends SceneTree
 
 ## The window-resolution save overlays against a real cache. Opens a window.
-##
 ##   Godot --path . -s res://tools/preview_party.gd -- <game> <out.png> \
 ##       [party|give|box|pack|select|stats] [presses] [shiny] [max]
-##
 ## The PC's pic and the stats page draw a shiny lead and the party menu's icons do
 ## not, the cartridge's own answer; `max` puts the lead at level 100, the one
 ## level `PrintLevel` drops the `<LV>` glyph for.

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Renders an imported pic atlas or tile sheet to a PNG so it can be looked at.
-##
 ##   Godot --headless --path . -s res://tools/preview_pics.gd -- <game> <out.png> [what] [--shiny]
-##
 ## The cache stores colour indices rather than pixels, with a palette applied at
 ## draw time so shiny is free; this applies one, which is the only way to tell a
 ## correct decode from a plausible wrong one. The font comes out folded to sixteen
@@ -150,7 +148,6 @@ func _render(
 
 
 ## One palette per cell of an atlas, in slot order.
-##
 ## The three kinds of atlas are indexed differently: a species atlas by species,
 ## the trainer atlas by class, and Unown's by letter form, all twenty-six of
 ## which are the one species and so share its colours.

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -1,10 +1,8 @@
 extends SceneTree
 
 ## Captures the Pokedex against a real imported cache.
-##
 ##   Godot --headless --path . -s res://tools/preview_pokedex.gd -- \
 ##       crystal /tmp/dex.png [list|entry|option|search|results|unown] [presses]
-##
 ## The world behind it is a new game with every species seen and every second one
 ## caught, which puts a full listing, both row states and a real entry on screen at
 ## once. `f<n>` in [presses] spends n hardware frames, which catches the arrow blink.
@@ -98,7 +96,6 @@ func _initialize() -> void:
 ## A world whose dex is filled far enough to draw every row state: seen up to
 ## [constant SEEN], caught on every second one, and the Unown dex unlocked so the
 ## OPTION screen offers its fourth row.
-##
 ## [constant UNSEEN] is left out so one row is the not-seen one, which is the
 ## only row that draws `LoadQuestionMarkPic`'s picture.
 static func _state() -> Gen2WorldState:

--- a/tools/preview_prof_oaks_pc.gd
+++ b/tools/preview_prof_oaks_pc.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Prints Prof Oak's PC against a real imported cache.
-##
 ##   Godot --headless --path . -s res://tools/preview_prof_oaks_pc.gd -- crystal [caught]
-##
 ## Without `caught` it walks every threshold `FindOakRating` bands into, which is
 ## the whole table and the boundary either side of each row. With one it prints
 ## the three pages `ProfOaksPCBoot` shows for that many owned, with the seen

--- a/tools/preview_saves.gd
+++ b/tools/preview_saves.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Photographs a window-resolution save-section screen for a cached cartridge.
-##
 ##   Godot --path . -s res://tools/preview_saves.gd -- <out.png> [light|dark] [WxH] [page] [game]
-##
 ## [page] is `saves`, `new`, `party`, `boxes`, `boxes_move` or `editor`; [game]
 ## picks a cartridge rather than the first cached one. The size is an argument
 ## rather than a constant: a phone portrait and a desktop window are one command

--- a/tools/preview_second_screen.gd
+++ b/tools/preview_second_screen.gd
@@ -1,10 +1,8 @@
 extends SceneTree
 
 ## Photographs the lower display against a real cache.
-##
 ##   Godot --path . -s res://tools/preview_second_screen.gd -- \
 ##       <game> <out.png> [tab] [progress] [panel] [theme]
-##
 ## `progress` is the only thing that decides which tabs exist: `start`, `starter`,
 ## `gear` or `full`. `panel` is a lower display's own `WIDTHxHEIGHT`, defaulting to
 ## the AYN Thor's 1240x1080. The picture is the canvas itself, one pixel per pixel.

--- a/tools/preview_title.gd
+++ b/tools/preview_title.gd
@@ -2,9 +2,7 @@ extends SceneTree
 
 ## Captures the title screen against a real imported cache, one source frame at a
 ## time.
-##
 ##   Godot --headless --path . -s res://tools/preview_title.gd -- crystal /tmp/t.png [frame]
-##
 ## [frame] is how many source frames to spend before the shot, so Crystal's
 ## twenty-eight-frame entrance, its Suicune cycle and Gold's bird can each be looked
 ## at where they are. Several separated by `;` write one file each, numbered.

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -1,10 +1,8 @@
 extends SceneTree
 
 ## Captures the region map against a real imported cache.
-##
 ##   Godot --headless --path . -s res://tools/preview_town_map.gd -- \
 ##       crystal /tmp/map.png [landmark] [card|clock|phone|radio|area:<species>|fly[:all]] [presses]
-##
 ## [landmark] is `TownMap_GetCurrentLandmark`'s answer, which picks the region and
 ## where the player icon stands. `hof` widens the Kanto window, `sel`/`rel` press and
 ## release the dex area's held SELECT, and `f<n>` spends n frames for the nest blink.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -3,7 +3,6 @@ extends SceneTree
 ## Renders one imported map's expanded 4x4-tile blocks to a PNG, or photographs
 ## the real screen on that map. `live help` prints [constant KIND_HELP], which is
 ## every kind and what its two numbers mean.
-##
 ##   Godot --headless --path . -s res://tools/preview_world.gd -- gold 1 1 /tmp/w.png
 ##   Godot --path . -s res://tools/preview_world.gd -- crystal 26 2 /tmp/out.png \
 ##       live [kind] [x y] [WxH] [touch] [framed] [zoom=<n>] [view=<mod id>]

--- a/tools/preview_world_services.gd
+++ b/tools/preview_world_services.gd
@@ -5,7 +5,6 @@ extends SceneTree
 ## mode's second box is photographed. The modes are `apricorn`, `town_map`,
 ## `pokegear`, `trainer_card`, `oak_pc`, `pc`, `decoration`, `hall_of_fame`,
 ## `battle_tower_room` and `unown_dex`; with none the mart is drawn.
-##
 ##   Godot --path . -s res://tools/preview_world_services.gd -- /tmp/pc.png pc a,down,a
 
 const WINDOW_SIZE := Vector2i(1152, 648)

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -2,10 +2,8 @@ extends SceneTree
 
 ## Exercises map-entry callbacks and one facing interaction from an imported
 ## cartridge cache without opening the ROM at runtime.
-##
 ##   Godot --headless --path . -s res://tools/preview_world_story.gd -- \
 ##     crystal 3 19 3 5 1 37,1744 home story
-##
 ## The optional seventh argument is a comma-separated event flag list. `home`
 ## follows the bedroom stair warp out; `story` drives the Mom and New Bark events.
 
@@ -207,7 +205,6 @@ const ROUTE_27_LANDFALL: Vector2i = Vector2i(18, 10)
 
 ## Tohjo Falls, west to east (`maps/TohjoFalls.asm`, `maps/Route27.asm`). The
 ## two mouths are Route 27 cells; everything between them is inside the cave.
-##
 ## The west door lands on (13,15) in an eight-cell pocket whose only water is to
 ## the left, so the surf starts on (10,14). The climb's foot is (8,12), directly
 ## below the four-cell `COLL_WATERFALL` column at x 8, and the descent's top is
@@ -622,7 +619,6 @@ const EVENT_FOUGHT_SNORLAX: int = 1872
 const EVENT_VERMILION_CITY_SNORLAX: int = 1904
 
 ## Diglett's Cave, the one door into west Kanto (`maps/DiglettsCave.asm`).
-##
 ## Three walkable regions, not one tunnel, so it is crossed by warps: the
 ## Vermilion entrance sits in a 14-cell room whose only ladder is (5,31); that
 ## lands on (17,33) in the 99-cell middle, which reaches the second ladder on
@@ -3335,7 +3331,6 @@ func _radio_tower_path(
 
 
 ## The card-key shutter on Radio Tower 3F and the Rocket boss on 5F.
-##
 ## `CardKeySlotScript` is a BGEVENT_UP at (14,2), so it is read by facing up
 ## from (14,3). It changeblocks the shutter open and sets
 ## EVENT_USED_THE_CARD_KEY_IN_THE_RADIO_TOWER, which is what
@@ -3529,7 +3524,6 @@ func _goldenrod_underground_card_key(
 
 
 ## Goldenrod City to the fake director on Radio Tower 5F, and back out.
-##
 ## The climb is one shaft: 1F (15,0), 2F (0,0), 3F (7,0), 4F (0,0). 2F's stairs
 ## are behind the Black Belt on (0,1), whom `RadioTowerRocketsScript` already
 ## hid, and 3F's other staircase at (17,0) is behind the card-key shutter, which
@@ -4449,7 +4443,6 @@ func _ride_waterfall_down(
 
 
 ## Route 26's heal house and the Victory Road Gate badge check.
-##
 ## The gate is not walked with _gate_leg(): that helper reaches the far warp
 ## with _warp_step(), which assigns the cell rather than walking to it, and the
 ## badge check is a coord event at (10,11) that only a real walk can meet.
@@ -4511,7 +4504,6 @@ func _victory_road_gate_leg(
 
 
 ## Victory Road and Route 23 to the Indigo Plateau Pokemon Center.
-##
 ## Victory Road is a warp maze, not one floor: the gate's entrance region
 ## reaches only the ladder at (1,49), whose pair lands on (1,35) in a second
 ## region, whose ladder at (13,31) lands on (13,17) in the third. Only that
@@ -4684,7 +4676,6 @@ func _elite_four_leg(
 ## sets SCENE_LANCESROOM_APPROACH_LANCE, which arms the coord events on (4,5)
 ## and (5,5), and stepping onto one runs the approach, the battle and the whole
 ## champion scene through to `warpfacing UP, HALL_OF_FAME, 4, 13`.
-##
 ## The cell is stepped onto rather than walked to, the way the Plateau rival
 ## coord event is: a resolving walk would re-dispatch it until it ran out of
 ## attempts.
@@ -4744,7 +4735,6 @@ func _lances_room_leg(
 ## so SCENE_HALLOFFAME_ENTER usually runs inside the champion drain and this
 ## step's own dispatch finds nothing left. [param carried] is that drain's count
 ## of the one event this leg exists to reach.
-##
 ## `halloffame` is a presentation boundary: it commits ENGINE_HALL_OF_FAME and
 ## emits `hall_of_fame_requested`, which no screen answers yet.
 func _hall_of_fame_leg(
@@ -4919,7 +4909,6 @@ func _ss_aqua_crossing(
 
 ## New Bark Town back to Olivine City, the way the route first walked it, in
 ## reverse where it overlaps and forward where it does not.
-##
 ## Two of the joins are gate buildings rather than map connections: Route 31's
 ## west edge is wall on every row, so `Route31VioletGate` is the only way into
 ## Violet City, and Ecruteak's west exit is `Route38EcruteakGate`.
@@ -4967,7 +4956,6 @@ func _walk_west_to_olivine(
 
 
 ## Elm's lab, for the ticket he only offers once the Elite Four is beaten.
-##
 ## `ProfElmScript` reads `EVENT_BEAT_ELITE_FOUR` before anything else it could
 ## give, so this is the first thing he answers with now
 ## (`maps/ElmsLab.asm`'s ElmGiveTicketScript).
@@ -5001,7 +4989,6 @@ func _elm_ss_ticket(
 
 
 ## The worried grandpa on 1F, which is where the walked route stops.
-##
 ## `WorriedGrandpaSceneLeft` is a coord event on the pair below the ship's
 ## entrance and it retires itself with `setscene SCENE_FASTSHIP1F_NOOP`, so it is
 ## stepped onto once rather than walked to.
@@ -5055,7 +5042,6 @@ func _ss_aqua_interior(
 
 
 ## B1F's on-duty sailor, who is the only thing that reveals the lazy one.
-##
 ## `FastShipB1FSailorScript` reaches its `clearevent
 ## EVENT_FAST_SHIP_CABINS_NNW_NNE_NE_SAILOR` only with FIRST_TIME, LAZY_SAILOR
 ## and INFORMED all clear, which is exactly the outbound first trip. Stepping
@@ -5115,7 +5101,6 @@ func _ss_aqua_b1f_sailor(
 
 
 ## The lazy sailor in the NE cabin, whose own script stands the B1F pair down.
-##
 ## `FastShipLazySailorScript` is a trainer battle inside an OBJECTTYPE_SCRIPT
 ## object, and its tail is what matters here: `setevent
 ## EVENT_FAST_SHIP_LAZY_SAILOR` and `setmapscene FAST_SHIP_B1F,
@@ -5152,7 +5137,6 @@ func _ss_aqua_lazy_sailor(
 
 ## West past the stood-down sailors to the captain's cabin, and the docking the
 ## granddaughter's scene runs.
-##
 ## With the scene retired the coord events are inert, so the sailor left standing
 ## on (31,6) leaves (30,6) open and B1F's west stairs are reachable. The
 ## granddaughter's own scene is the way back east: it walks the player through
@@ -5197,7 +5181,6 @@ func _ss_aqua_granddaughter(
 
 
 ## The Vermilion Port dock to the Thunder Badge, the route's first Kanto leg.
-##
 ## Nothing gates it. `VermilionGym_MapScripts` declares neither a scene nor a
 ## callback, so the gym is open from the door and Surge answers as soon as he is
 ## faced; `VermilionGymSurgeScript` is his own `checkflag ENGINE_THUNDERBADGE`,
@@ -5268,7 +5251,6 @@ func _thunder_badge_path(
 
 
 ## Vermilion Gym to the Marsh Badge, by way of Route 6 and Saffron City.
-##
 ## The gym exit reloads the city, so the yard's tree has grown back and is cut a
 ## second time from the inside. Saffron is then a gate crossing rather than a
 ## connection, and its own gym is a warp maze: nine rooms with no doors between
@@ -5327,7 +5309,6 @@ func _marsh_badge_path(
 
 
 ## The warp maze, then Sabrina.
-##
 ## Every pad is one half of a bidirectional pair, so a wrong one is recoverable
 ## rather than fatal, but only warp 17 reaches Sabrina's room at all. The walk
 ## between pads is ordinary: within a room the floor is open, and the BFS treats
@@ -5385,7 +5366,6 @@ func _saffron_gym_leg(
 
 
 ## Saffron Gym to the Rainbow Badge, by way of Route 7 and Celadon City.
-##
 ## The maze is walked back out pad for pad, since every pad is one half of a
 ## bidirectional pair. Saffron's west edge is a connection into Route 7 the way
 ## its south one is into Route 6, and carries no more traffic: the crossing is
@@ -5454,7 +5434,6 @@ func _rainbow_badge_path(
 
 
 ## The yard's tree, then Erika.
-##
 ## Cutting (28,35) is what joins the city to the gym yard at all. The walk to
 ## Erika crosses three sight lines it cannot route around, so the trainers the
 ## walk resolves are reported with her.
@@ -5578,7 +5557,6 @@ func _cerulean_approach_path(
 
 
 ## Cerulean City through the errand the Cascade Badge waits on.
-##
 ## The first Kanto badge whose gate is an errand rather than a cell, and the
 ## errand runs in the order the cartridge forces: the Power Plant manager arms
 ## the gym, the gym's grunt arms Route 24 and Route 25, Route 24's grunt names
@@ -6246,7 +6224,6 @@ func _pewter_leg(
 
 ## Vermilion's Snorlax, which is the only thing between the walked route and
 ## west Kanto.
-##
 ## Tuning is the whole interaction: `SnorlaxAwake` compares `wMapMusic` against
 ## the Poke Flute channel and takes its false branch otherwise, so the dial is
 ## moved to 20.0 and the Pokegear closed before it is talked to. The card the
@@ -6533,7 +6510,6 @@ func _seafoam_gym_leg(
 
 
 ## Seafoam Gym back up the coast to Viridian Gym and the Earth Badge.
-##
 ## The way back is the way down reversed, water included: Route 20's east shore,
 ## Cinnabar, Route 21 and Pallet's own pond, then three connections north. The
 ## gym at the end has no puzzle and no trainer in it. Both its objects carry
@@ -7159,7 +7135,6 @@ func _cerulean_machine_part(
 
 
 ## Runs the coord event on [param cell], whichever way the walk gets there.
-##
 ## Open work item 15: a resolving walk aimed at a live coord event re-dispatches
 ## its own target and never settles, so the target is [param approach] and the
 ## last step is a plain move_result(). But the walk to that approach can cross
@@ -7372,7 +7347,6 @@ func _talk_to_on_water(
 ## The lighthouse floors reached by ladder on the way up and by hole on the way
 ## down, from Olivine City's door back to it. [param phase] is "first" for
 ## Jasmine's SecretPotion errand and "cure" for the visit that carries it.
-##
 ## The climb is not the obvious one: 4F's ladder at (3,5) reaches the half of 5F
 ## that cannot see the 6F stairs at (9,15), so the route drops back to 3F
 ## through the hole at 4F (9,3) and climbs the other shaft.
@@ -7458,7 +7432,6 @@ func _lighthouse_shaft(
 
 ## maps/OlivineCafe.asm's sailor at (4,3), who hands over HM04 behind
 ## EVENT_GOT_HM04_STRENGTH. The cafe is Olivine City warp 7 at (7,21).
-##
 ## The HM is then taught through Gen2WorldPartyHost.teach_tm_hm(), the same
 ## transaction the pack's own USE reaches, so the route learns STRENGTH the way a
 ## player does rather than writing a move slot behind the game's back.

--- a/tools/profile.gd
+++ b/tools/profile.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## What a drawn frame costs, per screen, in milliseconds.
-##
 ##   Godot --path . -s res://tools/profile.gd -- [subject ...] [game] [frames]
-##
 ## Neither a check nor a preview can say what sixty frames cost, which is the only
 ## question that decides whether a weaker machine holds its frame rate. A real
 ## window, vsync off and no frame cap, with every subject driven by counted

--- a/tools/record_clip.gd
+++ b/tools/record_clip.gd
@@ -5,7 +5,6 @@ extends SceneTree
 ## so the world spends exactly one hardware frame per recorded frame. Nothing here
 ## steps the screen by hand for that reason: the game runs its ordinary `_process`,
 ## mods included, and only the buttons are scripted. [constant USAGE] is every key.
-##
 ##   Godot --path . --mods --write-movie /tmp/clip.avi --fixed-fps 60 \
 ##     -s res://tools/record_clip.gd -- <game> <group> <map> [key=value ...]
 
@@ -955,7 +954,6 @@ func _perform(action: String) -> void:
 ## The wild a provider has put on the map nearest the player, met the way walking
 ## onto it meets it. Faces the player at it first, since a clip of an encounter
 ## is a clip of the thing on screen.
-##
 ## Not the same as `wild-`: that one invents a battle and the entry standing on
 ## the map is not part of it, so its Pokemon is still there afterwards however
 ## the fight ended.

--- a/tools/render_audio.gd
+++ b/tools/render_audio.gd
@@ -6,7 +6,6 @@ extends SceneTree
 ## same registers in the same order on the same frames. Kinds are `music`, `sfx`,
 ## `cry` and `mon_cry`; the id is the record index, the species for `mon_cry`, or
 ## `all` to sweep the table into `<prefix>_<index>`.
-##
 ##   ... -s res://tools/render_audio.gd -- crystal music 1 600 /tmp/out
 
 

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -334,7 +334,6 @@ func _run(
 
 ## The compared artefact: the world snapshot the save would carry, the play timer
 ## beside it, the frame both are read at, and the party.
-##
 ## The party is what a battle changes, the snapshot carrying none of it: HP, level,
 ## experience, moves and PP are the whole outcome of a fight, so a route that
 ## fights is only proved replayable by comparing them.

--- a/tools/screenshot.gd
+++ b/tools/screenshot.gd
@@ -2,9 +2,7 @@ extends SceneTree
 
 ## Renders a scene and writes it to a PNG, so UI work can be checked without a
 ## human having to press Play and describe what they see.
-##
 ##   Godot --path . -s res://tools/screenshot.gd -- <scene> <output.png> [frames] [method] [times]
-##
 ## The optional method/times pair calls a no-argument method on the scene root
 ## before capturing, which is how a screen is photographed mid-interaction. Opens a
 ## real window for a moment: rendering needs a display.

--- a/tools/trace_world_story.gd
+++ b/tools/trace_world_story.gd
@@ -2,7 +2,6 @@ extends SceneTree
 
 ## Prints the imported map event pointers and bounded script command streams for
 ## story tracing. This reads the derived cache only and never opens a cartridge.
-##
 ##   Godot --headless --path . -s res://tools/trace_world_story.gd -- \
 ##     crystal 24 4 24 5 24 1
 

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -5,7 +5,6 @@ extends SceneTree
 ## pokegold sources and are named in each topic's own file. A topic is a script
 ## under `tools/checks/` with `func run(r) -> void`, found by its file name; add one
 ## there rather than writing another entry point.
-##
 ##   Godot --headless --path . -s res://tools/validate.gd -- all cut surf
 
 const CheckRun := preload("res://tools/lib/check_run.gd")

--- a/tools/verify_rom.gd
+++ b/tools/verify_rom.gd
@@ -1,9 +1,7 @@
 extends SceneTree
 
 ## Runs the import gate against a real cartridge without adding one to the repo.
-##
 ##   Godot --headless --path . -s res://tools/verify_rom.gd -- [file-or-dir ...]
-##
 ## Defaults to res://roms, the gitignored drop folder; absolute host paths work
 ## too. Exits 0 only if every candidate verified as a supported cartridge.
 


### PR DESCRIPTION
Seven defects across three source files a built screen already reached: `engine/overworld/player_movement.asm`, `engine/menus/naming_screen.asm` and `engine/overworld/decorations.asm`, 3,900 lines.

## Fixed

`DoPlayerMovement.CheckForced` rebuilds `wCurInput` as `(input and PAD_BUTTONS) or forced`, and `PAD_BUTTONS` is `%0000_1111`, so the whole d-pad is dropped and a held key reaches `.GetAction` on no frame of an ice slide. This port read the `or` without the mask in front of it and let a held DOWN steer a slide running right.

`.BumpSound` was on no path, so every refused step in the game was silent, on land, on water and on ice. `.CheckWarp` raises `wWalkingIntoEdgeWarp` whenever the standing cell carries the carpet naming the pressed direction, warp or no warp, which is what keeps an interior door quiet; `.Surf` never runs `.CheckWarp`, so a refused paddle bumps on every tile.

`.TryStep` reads `wPlayerTileCollision`, the cell being left, and its ice branch sits in front of `.BikeCheck`, so a step off ice is `STEP_ICE`: `fast_slide_step`, `StepVectors`' four-pass row rather than a walk's eight.

`SlideStep` sets OBJECT_ACTION_STAND where `NormalStep` sets OBJECT_ACTION_STEP, and `SetFacingStandAction` advances the walk frame only while the drawn one is odd. Every step duration is a multiple of four, so a slide holds frame 0; this port walked the sprite through it.

`NamingScreenJumptable`'s icon was on no row: `.Pokemon`'s `LoadMenuMonIcon` for the species, `.Player`, `.Rival` and `.Mom`'s overworld sprite, `.Box`'s Poke Ball, all spawned at `depixel 4, 4, 4, 0`, plus `.Pokemon`'s `farcall GetGender` sign at `hlcoord 1, 2`.

`PopulateDecoCategoryMenu`'s `cp 8` counts the list `FindOwnedDecosInCategory` has already appended PUT IT AWAY and CANCEL to, so six owned rows make eight and `.beyond_eight` writes -1 over CANCEL. This port tested the owned rows alone and kept CANCEL at six, which the ornament category reaches.

`describedecoration` is a `ScriptJump`, so the description script replaces the caller and its own `end` ends the run. Its five uses are consecutive labels in `PlayersHouse2F.asm` with no `end` between them, so talking to the left doll printed the right doll's box, the big doll's and the console's after it.

## Checks

`tools/checks/ice_slides.gd` now sweeps four invariants over every ice cell of all three cartridges rather than the direction alone: the slide terminates, it ignores every held key as well as none, each step spends four passes, and the drawing holds frame 0. 779 cells and 2,701 slides on Crystal, 775 and 2,670 on Gold and on Silver.

`tools/checks/decorations.gd` sweeps the category menu from one owned ornament to twenty-three on all three cartridges, and goes red on the old rule at six.

`tools/preview_naming_screen.gd` takes a `mon` argument, so the species icon and the gender sign are photographable.

| Gate | Result |
|---|---|
| GUT unit tier | 3,541 tests, 0 failures |
| `tools/validate.gd -- all` | 83 topics, 0 failures, exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | complete, no failed leg |
| `addons/warning_scan` | 0 warnings in 608 scripts |

## Also

The comment ceiling pays for the new source facts out of `tools/`: a blank `##` between two comment lines is a paragraph break carrying no fact, and 124 of them are gone. `MAX_COMMENT_LINES` drops from 37,868 to 37,786.

`.CheckWarp`'s documented `$3E` bug is unreachable: only `.NotMoving` reads `wWalkingIntoEdgeWarp` and it branches to `.Standing` on STANDING before it gets there, so no bump was owed either way.
