### PR TITLE
Hall of Fame player panel and the trainer card's dex row

### DIFF
--- a/game/render/hall_of_fame_page.gd
+++ b/game/render/hall_of_fame_page.gd
@@ -17,10 +17,9 @@ const MON_TOP_BOX: Rect2i = Rect2i(0, 0, 20, 5)
 const MON_BOTTOM_BOX: Rect2i = Rect2i(0, 12, 20, 6)
 const CAPTION: Vector2i = Vector2i(1, 2)
 const CAPTION_TEXT: String = "New Hall of Famer!"
-## `_HallOfFamePC.DisplayMonAndStrings` draws this instead: `PrintNum`'s
-## `lb bc, 1, 3` over `hlcoord 2, 2`, so the count is right-aligned in three
-## columns and the words start at column 5. `.HOFMaster` is unreachable: it needs
-## 201 and `wHallOfFameCount` stops at 200 (`docs/bugs_and_glitches.md`).
+## `_HallOfFamePC.DisplayMonAndStrings` draws this instead: `lb bc, 1, 3` over
+## `hlcoord 2, 2`, so the words start at column 5. `.HOFMaster` is unreachable,
+## needing 201 where `wHallOfFameCount` stops at 200.
 const FAMER_TEXT: String = "-Time Famer"
 const FAMER_COUNT: Vector2i = Vector2i(2, 2)
 const FAMER_DIGITS: int = 3
@@ -37,23 +36,24 @@ const DEX_DIGITS: int = 3
 const SPECIES_NAME: Vector2i = Vector2i(7, 13)
 const GENDER: Vector2i = Vector2i(18, 13)
 const NICKNAME_SLASH: Vector2i = Vector2i(8, 14)
-## `PrintLevel` writes `<LV>` and then the number left-aligned beside it. Its
-## three-digit branch backs over the `<LV>`, which no level in these games
-## reaches: 100 is the cap and the branch is `cp 100` on a byte.
+## `PrintLevel` writes `<LV>` and the number left-aligned beside it, its
+## three-digit branch backing over the `<LV>`.
 const LEVEL: Vector2i = Vector2i(1, 16)
 ## `<ID>`, `№`, `/` at `hlcoord 7, 16`, then five digits at `hlcoord 10, 16`.
 const OT_LABEL: Vector2i = Vector2i(7, 16)
 const OT_NUMBER: Vector2i = Vector2i(10, 16)
 const OT_DIGITS: int = 5
 
-## The codes the panel places directly, the way the source does: `ld [hl], '№'`
-## puts a byte down, it does not print a string, and a bracketed marker is not
-## something [method Gen2Text.encode] will produce.
+## The codes the panel places directly: `ld [hl], '№'` puts a byte down, and a
+## bracketed marker is not something [method Gen2Text.encode] will produce.
 const CODE_NUMERO: int = 0x74
 const CODE_DOT: int = 0xF2
 const CODE_ID: int = 0x73
 const CODE_LEVEL: int = 0x6E
 const CODE_SLASH: int = 0xF3
+## `HALLOFFAME_COLON` copies `FontExtra + 13 tiles`, which is `<COLON>` at $6d,
+## over tile $63. Drawn through the main font: the battle-extra strip owns $63.
+const CODE_COLON: int = 0x6D
 
 ## Everything on a panel is printed with the battle-extra strip loaded.
 const FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
@@ -63,6 +63,20 @@ const FONT: StringName = Gen2Text.FONT_BATTLE_EXTRA
 ## into.
 const PLAYER_BOX: Rect2i = Rect2i(0, 2, 11, 10)
 const PLAYER_NAME: Vector2i = Vector2i(2, 4)
+## `HOF_LoadTrainerFrontpic`, then `PlaceGraphic` at `hlcoord 12, 5`.
+const PLAYER_PIC_AT: Vector2i = Vector2i(12, 5)
+## `<ID>`, `№`, `/` at `hlcoord 1, 6`, then five digits at `hlcoord 4, 6`.
+const PLAYER_ID_LABEL: Vector2i = Vector2i(1, 6)
+const PLAYER_ID_NUMBER: Vector2i = Vector2i(4, 6)
+const PLAYER_ID_DIGITS: int = 5
+## `.PlayTime` at `hlcoord 1, 8`, three hour digits at `hlcoord 3, 9`, the
+## `ld [hl], HALLOFFAME_COLON` behind them, and two minute digits.
+const PLAY_TIME_LABEL: Vector2i = Vector2i(1, 8)
+const PLAY_TIME_TEXT: String = "PLAY TIME"
+const PLAY_TIME_HOURS: Vector2i = Vector2i(3, 9)
+const PLAY_TIME_HOUR_DIGITS: int = 3
+const PLAY_TIME_COLON: Vector2i = Vector2i(6, 9)
+const PLAY_TIME_MINUTES: Vector2i = Vector2i(7, 9)
 ## `PrintText`'s own first line (`hlcoord 1, 14`) and the interior it prints
 ## into, which is every text box's: one tile of margin each side and two lines
 ## two rows apart.
@@ -117,6 +131,11 @@ static func pic_size() -> int:
 	return PIC_TILES * TILE
 
 
+## Where the screen puts the player's own front pic, in pixels.
+static func player_pic_position() -> Vector2i:
+	return PLAYER_PIC_AT * TILE
+
+
 func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:
 	var width: int = COLUMNS * TILE
 	_box(indices, width, MON_TOP_BOX)
@@ -153,13 +172,28 @@ func _draw_mon(page: Dictionary, indices: PackedByteArray) -> void:
 	_text(indices, width, "%0*d" % [OT_DIGITS, int(page.get("ot_id", 0))], OT_NUMBER)
 
 
-## The name box and the empty bottom one. The source also slides in the player's
-## pic and prints the trainer ID and PLAY TIME, none of which this project has.
+## `HOF_AnimatePlayerPic`'s two boxes. The picture is the screen's, as a mon
+## panel's is.
 func _draw_player(page: Dictionary, indices: PackedByteArray) -> void:
 	var width: int = COLUMNS * TILE
 	_box(indices, width, PLAYER_BOX)
 	_box(indices, width, MON_BOTTOM_BOX)
 	_text(indices, width, String(page.get("player_name", "")), PLAYER_NAME)
+	_code(indices, width, CODE_ID, PLAYER_ID_LABEL)
+	_code(indices, width, CODE_NUMERO, PLAYER_ID_LABEL + Vector2i(1, 0))
+	_code(indices, width, CODE_SLASH, PLAYER_ID_LABEL + Vector2i(2, 0))
+	_text(indices, width, "%0*d" % [
+		PLAYER_ID_DIGITS, int(page.get("player_id", 0)),
+	], PLAYER_ID_NUMBER)
+	_text(indices, width, PLAY_TIME_TEXT, PLAY_TIME_LABEL)
+	_text(indices, width, "%*d" % [
+		PLAY_TIME_HOUR_DIGITS, int(page.get("hours", 0)),
+	], PLAY_TIME_HOURS)
+	font.draw_code(
+		CODE_COLON, indices, width,
+		PLAY_TIME_COLON.x * TILE, PLAY_TIME_COLON.y * TILE, Gen2Text.FONT_MAIN
+	)
+	_text(indices, width, String(page.get("minutes", "")), PLAY_TIME_MINUTES)
 	var lines: Array = page.get("lines", [])
 	for index: int in lines.size():
 		_text(

--- a/game/render/trainer_card_page.gd
+++ b/game/render/trainer_card_page.gd
@@ -39,10 +39,8 @@ const TOP_BORDER_ROWS: int = 5
 const BOTTOM_BORDER_ROWS: int = 6
 const BOTTOM_BORDER_AT: Vector2i = Vector2i(0, 8)
 
-## `.Name_Money` is one string placed at (2,2), and its `next` macro is
-## `<NEXT>`, which `NextLineChar` moves `SCREEN_WIDTH * 2` by, so its three lines
-## land two rows apart: NAME/ on row 2, the empty line on row 4 where the ID
-## tiles go, and MONEY on row 6.
+## `.Name_Money` is one string at (2,2) whose `next` moves `SCREEN_WIDTH * 2`,
+## so NAME/ is on row 2, the ID tiles' empty line on row 4 and MONEY on row 6.
 const NAME_LABEL_AT: Vector2i = Vector2i(2, 2)
 const MONEY_LABEL_AT: Vector2i = Vector2i(2, 6)
 const NAME_LABEL: String = "NAME/"
@@ -75,6 +73,11 @@ const DEX_LABEL: String = "#DEX"
 const PLAY_TIME_LABEL: String = "PLAY TIME"
 const DEX_COUNT_AT: Vector2i = Vector2i(15, 10)
 const DEX_DIGITS: int = 3
+## `ClearBox` at `hlcoord 1, 9` with `lb bc, 2, 17` when STATUSFLAGS_POKEDEX_F
+## is clear, which takes the whole #DEX row and not only its count.
+const NO_DEX_CLEAR_AT: Vector2i = Vector2i(1, 9)
+const NO_DEX_CLEAR_ROWS: int = 2
+const NO_DEX_CLEAR_COLUMNS: int = 17
 ## `hlcoord 11, 12` for the hours, then `inc hl` past the separator column.
 const HOURS_AT: Vector2i = Vector2i(11, 12)
 const HOURS_DIGITS: int = 4
@@ -94,8 +97,7 @@ const BADGES_LABEL: String = "  BADGES"
 const BADGES_LABEL_GOLD_SILVER: String = "BADGES"
 const BADGES_LABEL_AT: Vector2i = Vector2i(10, 15)
 const BADGES_LABEL_AT_GOLD_SILVER: Vector2i = Vector2i(12, 15)
-## The arrow that ends it. Part of the same string on the cartridge; kept apart
-## here only because it is a character code rather than a letter.
+## The arrow that ends it, a character code rather than a letter.
 const BADGES_ARROW_CODE: int = 0xED
 
 ## Pages 2 and 3: `.BadgesTilemap`'s "BADGES" in card tiles, then the leaders'
@@ -114,13 +116,11 @@ const LEADER_FACE_ROWS: int = 3
 const LEADER_FACE_TILES: int = 10
 const LEADER_STRIDE: int = 4
 
-## `_CGB_TrainerCard`'s attribute map, as `FillBoxCGB` writes it: rows first, then
-## columns. Its palette slots are [constant RomLayout.CARD_PALETTE_CLASSES]' own
-## order, and the leader boxes are filled whatever page is on screen, since the
-## layout runs once in `.InitRAM`. Both gender branches are the source's: the
-## whole card takes the opposite gender's palette and the pic area the player's
-## own, Clair's box is filled only for Kris, and the top-right corner is written
-## twice, the second write being the one that lasts.
+## `_CGB_TrainerCard`'s attribute map in [constant
+## RomLayout.CARD_PALETTE_CLASSES]' order, filled whatever page is on screen
+## since the layout runs once in `.InitRAM`. The card takes the opposite
+## gender's palette and the pic area the player's own, Clair's box is filled
+## only for Kris, and the top-right corner is written twice.
 const ATTRIBUTE_LEADER_BOXES: Array[Dictionary] = [
 	{"at": Vector2i(2, 11), "palette": 1},
 	{"at": Vector2i(6, 11), "palette": 2},
@@ -276,12 +276,19 @@ func _draw_page_1(map: PackedInt32Array, page: Dictionary) -> void:
 	_tilemap(map, STATUS_TILEMAP, STATUS_TILEMAP_AT)
 	_draw_badges_label(map)
 	## `CountSetBits` over wPokedexCaught, three digits and no leading zeros.
-	if bool(page.get("pokedex", false)):
-		_text(map, "%*d" % [DEX_DIGITS, int(page.get("caught", 0))], DEX_COUNT_AT)
+	_text(map, "%*d" % [DEX_DIGITS, int(page.get("caught", 0))], DEX_COUNT_AT)
+	if not bool(page.get("pokedex", false)):
+		_clear_box(map, NO_DEX_CLEAR_AT, NO_DEX_CLEAR_ROWS, NO_DEX_CLEAR_COLUMNS)
 	_text(map, String(page.get("hours", "")), HOURS_AT)
 	_text(map, String(page.get("minutes", "")), MINUTES_AT)
 	if bool(page.get("separator", true)):
 		_put(map, SEPARATOR_AT, SEPARATOR_COLON_TILE)
+
+
+func _clear_box(map: PackedInt32Array, at: Vector2i, rows: int, columns: int) -> void:
+	for row: int in rows:
+		for column: int in columns:
+			_put(map, at + Vector2i(column, row), BLANK_TILE)
 
 
 ## `.Badges` and the arrow that ends it. The string and its column are the one

--- a/game/world/hall_of_fame.gd
+++ b/game/world/hall_of_fame.gd
@@ -4,11 +4,9 @@ extends RefCounted
 ## The induction sequence `halloffame` asks for, as pages a screen can draw.
 ## `AnimateHallOfFame` walks the party `GetHallOfFameParty` built, one panel per
 ## Pokemon and then the player's, which `HOF_AnimatePlayerPic` answers once per
-## box `ProfOaksPCRating` prints into it. That panel's trainer ID and PLAY TIME
-## are absent rather than zeros: the save model carries neither.
+## box `ProfOaksPCRating` prints into it.
 
-## GetHallOfFameParty's own cap: it copies at most a full party and stops on the
-## -1 terminator.
+## `GetHallOfFameParty`'s own cap, and its `-1` terminator.
 const MAX_MONS: int = 6
 
 const PAGE_MON: StringName = &"mon"
@@ -22,6 +20,16 @@ const MAX_RECORDS: int = 30
 const MASTER_COUNT: int = 200
 ## `hof_mon`'s nickname field, which is `MON_NAME_LENGTH - 1`.
 const MAX_NICKNAME: int = 10
+
+## `.DisplayNewHallOfFamer`'s `ld c, 60` behind Crystal's `HOF_AnimateFrontpic`
+## and pokegold's `ld c, 180` behind its bare `PlayMonCry`.
+const PANEL_FRAMES_CRYSTAL: int = 60
+const PANEL_FRAMES_GOLD_SILVER: int = 180
+
+
+static func panel_frames(data: GameData) -> int:
+	return PANEL_FRAMES_CRYSTAL if Gen2WorldState.is_crystal_profile(data) \
+		else PANEL_FRAMES_GOLD_SILVER
 
 
 ## The pages, in `HallOfFame`'s order: the record box, then every non-egg party
@@ -58,7 +66,16 @@ static func pages(
 static func _player_pages(
 	data: GameData, save: Gen2SaveData, state: Gen2WorldState
 ) -> Array:
-	var panel: Dictionary = {"kind": PAGE_PLAYER, "player_name": save.player_name}
+	var time: Gen2GameTime = save.game_time if save.game_time != null else Gen2GameTime.new()
+	var panel: Dictionary = {
+		"kind": PAGE_PLAYER,
+		"player_name": save.player_name,
+		"player_id": save.player_id,
+		"female": save.gender == Gen2SaveData.GENDER_FEMALE,
+		## `lb bc, 2, 3`, one digit narrower than the trainer card's own row.
+		"hours": time.hours,
+		"minutes": time.minutes_text(),
+	}
 	var rating: Dictionary = Gen2ProfOaksPC.rate(data, state)
 	if rating.is_empty():
 		return [panel]
@@ -86,8 +103,8 @@ static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
 	return {
 		"kind": PAGE_MON,
 		"species": mon.species,
-		## Gen 2 species numbers are dex numbers, which is why DisplayHOFMon
-		## prints wCurPartySpecies straight into the №. field.
+		## Gen 2 species numbers are dex numbers, so `DisplayHOFMon` prints
+		## `wCurPartySpecies` straight into the №. field.
 		"dex_number": mon.species,
 		"species_name": species_name,
 		"nickname": nickname,
@@ -98,9 +115,8 @@ static func _mon_page(data: GameData, mon: Gen2SaveMon) -> Dictionary:
 		## `wUnownLetter`: an Unown in the Hall of Fame is its own letter, not A.
 		"unown_form": Gen2Stats.unown_letter(mon.dvs) \
 			if mon.species == RomLayout.UNOWN_SPECIES else 0,
-		## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS`, which is the layout the Hall of
-		## Fame asks for and which reaches `GetMonNormalOrShinyPalettePointer`.
-		## The other fact about the DV word the pic needs, so it rides beside it.
+		## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS` reaches
+		## `GetMonNormalOrShinyPalettePointer`.
 		"shiny": Gen2Stats.is_shiny(mon.dvs),
 	}
 
@@ -176,8 +192,7 @@ static func record_pages(data: GameData, record: Dictionary) -> Array:
 	return out
 
 
-## The stored shape, checked rather than trusted: JSON numbers come back as
-## floats and a hand-edited save can carry anything.
+## The stored shape, checked rather than trusted: a save can carry anything.
 static func parse_records(raw: Variant) -> Array:
 	var out: Array = []
 	if not raw is Array:

--- a/game/world/hall_of_fame_screen.gd
+++ b/game/world/hall_of_fame_screen.gd
@@ -3,15 +3,17 @@ extends Control
 
 ## The screen behind `halloffame`, embedded in the overworld the way the PC and
 ## the mart overlays are: the record box, then `AnimateHallOfFame`'s walk over
-## the party and the player's own panel, advanced by A. The two pic slides and
-## the palette rotations are not here, and the source's 60 frames a panel are a
-## key press instead, there being no animation to watch. `_HallOfFamePC` reuses
-## the same walk over a stored record.
+## the party and the player's own panel. The two pic slides and the palette
+## rotations are not here. An induction reads no joypad over its panels and holds
+## each for [method Gen2HallOfFame.panel_frames]; `_HallOfFamePC` walks the same
+## panels over a stored record and answers A, B and START.
 
 signal closed()
 
-## `ProfOaksPCRating`'s `PlayMusic MUSIC_NONE` and `PlaySFX`, which reach the
-## overworld's own player the way the Pokedex's cry does.
+## `PokeAnim_CryNoWait` inside Crystal's ANIM_MON_HOF, pokegold's `PlayMonCry`.
+signal cry_requested(species: int)
+
+## `ProfOaksPCRating`'s `PlayMusic MUSIC_NONE` and `PlaySFX`.
 signal rating_reached(sfx: int)
 
 const BACKDROP: Color = Color.WHITE
@@ -29,13 +31,12 @@ var _index: int = 0
 var _page_renderer: Gen2HallOfFamePage = null
 var _background: TextureRect = null
 var _pic: TextureRect = null
-## `HallOfFame_FadeOutMusic`'s `ld c, 100` behind the record box, and its clock.
-var _saving_frames: int = 0
-var _saving_clock := Gen2WorldAnimation.FrameClock.new()
+## How long the page on screen holds before moving on by itself, and its clock.
+var _hold_frames: int = 0
+var _hold_clock := Gen2WorldAnimation.FrameClock.new()
 
 
-## [param pages] is [method Gen2HallOfFame.pages]. An empty list closes at once
-## rather than showing a blank screen.
+## [param pages] is [method Gen2HallOfFame.pages]; an empty list closes at once.
 func set_context(data: GameData, pages: Array) -> void:
 	_data = data
 	_pages = pages
@@ -53,8 +54,7 @@ func _ready() -> void:
 	_refresh()
 
 
-## How many pages are left, including the one on screen. Drives the scene tests
-## and the screenshot tool without reaching into the array.
+## How many pages are left, including the one on screen.
 func remaining() -> int:
 	return maxi(_pages.size() - _index, 0)
 
@@ -65,15 +65,12 @@ func current_page() -> Dictionary:
 	return _pages[_index]
 
 
-## A moves on, matching every other text pause in the overworld. There is no way
-## back: the cartridge's panels do not rewind either.
-##
-## `_HallOfFamePC.DisplayTeam` adds two: B leaves the viewer, which is what
-## [member cancelled] says afterwards, and START skips the rest of this team.
-## `AnimateHallOfFame` reads neither, so an induction ignores them.
+## `_HallOfFamePC.DisplayTeam`'s three: A moves on, B leaves the viewer, which
+## is what [member cancelled] says afterwards, and START skips the rest of this
+## team. `AnimateHallOfFame` reads none of them.
 func handle_button(button: int) -> bool:
-	if _saving_frames > 0:
-		## `HallOfFame_FadeOutMusic` ends on `DelayFrames`, which reads nothing.
+	if _hold_frames > 0:
+		## Both holds end on `DelayFrames`, which reads no joypad.
 		return true
 	if button == Gen2Button.A:
 		advance()
@@ -102,8 +99,7 @@ func advance() -> void:
 func _build() -> void:
 	add_child(Gen2Screen.Field.create(BACKDROP))
 
-	## The pic sits under the page so the bottom box's border stays drawn over
-	## it, the way the hardware's window does.
+	## Under the page, so the box borders stay drawn over it.
 	_pic = TextureRect.new()
 	_pic.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	_pic.mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -115,29 +111,31 @@ func _build() -> void:
 	add_child(_background)
 
 
-## Hardware frames of the record box. Public so a test owns its own.
-func advance_saving_frames(count: int) -> void:
+## Hardware frames of whichever page is holding. Public so a test owns its own.
+func advance_hold_frames(count: int) -> void:
 	for _step: int in count:
-		if _saving_frames <= 0:
+		if _hold_frames <= 0:
 			return
-		_saving_frames -= 1
-		if _saving_frames <= 0:
+		_hold_frames -= 1
+		if _hold_frames <= 0:
 			set_process(false)
 			advance()
 
 
 func _process(delta: float) -> void:
-	advance_saving_frames(_saving_clock.tick(delta))
+	advance_hold_frames(_hold_clock.tick(delta))
 
 
 func _refresh() -> void:
 	var page: Dictionary = current_page()
 	if page.is_empty() or _background == null:
 		return
-	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_SAVING:
-		_saving_frames = Gen2SavePrompt.SAVING_RECORD_FRAMES
-		_saving_clock.reset()
-		set_process(true)
+	_hold_frames = _hold_for(page)
+	if _hold_frames > 0:
+		_hold_clock.reset()
+	set_process(_hold_frames > 0)
+	if StringName(page.get("kind", &"")) == Gen2HallOfFame.PAGE_MON:
+		cry_requested.emit(int(page.get("species", 0)))
 	if page.has("sfx"):
 		rating_reached.emit(int(page["sfx"]))
 	var indices: PackedByteArray = _page_renderer.draw(page)
@@ -151,11 +149,28 @@ func _refresh() -> void:
 	_refresh_pic(page)
 
 
+## `.SavingRecordText`'s hundred frames, and an induction's own panel count.
+## The viewer's panels answer the joypad, so they hold for nothing.
+func _hold_for(page: Dictionary) -> int:
+	match StringName(page.get("kind", &"")):
+		Gen2HallOfFame.PAGE_SAVING:
+			return Gen2SavePrompt.SAVING_RECORD_FRAMES
+		Gen2HallOfFame.PAGE_MON:
+			return 0 if viewer else Gen2HallOfFame.panel_frames(_data)
+	return 0
+
+
 func _refresh_pic(page: Dictionary) -> void:
 	if _pic == null:
 		return
 	_pic.texture = null
-	if _data == null or StringName(page.get("kind", &"")) != Gen2HallOfFame.PAGE_MON:
+	if _data == null:
+		return
+	var kind: StringName = StringName(page.get("kind", &""))
+	if kind == Gen2HallOfFame.PAGE_PLAYER:
+		_show_player_pic(bool(page.get("female", false)))
+		return
+	if kind != Gen2HallOfFame.PAGE_MON:
 		return
 	var species: int = int(page.get("species", 0))
 	var unown_form: int = int(page.get("unown_form", 0))
@@ -176,4 +191,23 @@ func _refresh_pic(page: Dictionary) -> void:
 	_pic.position = Vector2(
 		at.x + (cell - image.get_width()) / 2.0,
 		at.y + cell - image.get_height()
+	)
+
+
+## `HOF_LoadTrainerFrontpic` and `PlaceGraphic` at (12,5), the intro's picture.
+func _show_player_pic(female: bool) -> void:
+	var cell: Dictionary = Gen2OakSpeech.player_cell(_data, female)
+	if cell.is_empty():
+		return
+	var image: Image = Gen2PicImage.from_indices(
+		cell["indices"], int(cell["width"]), int(cell["height"]),
+		Gen2OakSpeech.player_palette(_data, female)
+	)
+	Gen2PicImage.show(_pic, image)
+	_pic.size = Vector2(image.get_size())
+	var at: Vector2i = Gen2HallOfFamePage.player_pic_position()
+	_pic.position = Vector2(
+		at.x + Gen2PicImage.frontpic_pad_columns(int(cell["width"]) / Gen2Font.TILE) \
+			* Gen2Font.TILE,
+		at.y + Gen2HallOfFamePage.pic_size() - image.get_height()
 	)

--- a/game/world/oak_speech.gd
+++ b/game/world/oak_speech.gd
@@ -53,6 +53,52 @@ const DEFAULT_MALE: String = "CHRIS"
 const DEFAULT_FEMALE: String = "KRIS"
 
 
+## `DrawIntroPlayerPic` and `HOF_LoadTrainerFrontpic` load the same picture:
+## ChrisPic or KrisPic on Crystal, and CAL's own trainer pic on Gold and Silver,
+## which ship neither. One seam, so the intro and the Hall of Fame cannot drift.
+static func player_cell(data: GameData, female: bool) -> Dictionary:
+	if data == null:
+		return {}
+	if not Gen2WorldState.is_crystal_profile(data):
+		return trainer_cell(data, CAL)
+	var sheet: String = "intro_player_female" if female else "intro_player_male"
+	var strip: PackedByteArray = data.tile_indices(sheet)
+	var tile: int = Gen2Font.TILE
+	var tiles: int = RomLayout.INTRO_PLAYER_PIC_TILES
+	if strip.size() < tiles * tile * tile:
+		return {}
+	var width: int = RomLayout.INTRO_PLAYER_PIC_COLUMNS * tile
+	var indices := PackedByteArray()
+	indices.resize(width * RomLayout.INTRO_PLAYER_PIC_ROWS * tile)
+	var strip_width: int = tiles * tile
+	for row: int in RomLayout.INTRO_PLAYER_PIC_ROWS:
+		for column: int in RomLayout.INTRO_PLAYER_PIC_COLUMNS:
+			var source_tile: int = row * RomLayout.INTRO_PLAYER_PIC_COLUMNS + column
+			for y: int in tile:
+				for x: int in tile:
+					indices[(row * tile + y) * width + column * tile + x] = \
+						strip[y * strip_width + source_tile * tile + x]
+	return {"indices": indices, "width": width, "height": width}
+
+
+## `SCGB_PLAYER_OR_MON_FRONTPIC_PALS` with `wCurPartySpecies` zero.
+static func player_palette(data: GameData, female: bool) -> PackedColorArray:
+	if data == null:
+		return PackedColorArray()
+	if not Gen2WorldState.is_crystal_profile(data):
+		return data.trainer_palette(CAL)
+	return data.card_palette(1 if female else 0)
+
+
+static func trainer_cell(data: GameData, trainer_class: int) -> Dictionary:
+	var pic: Dictionary = data.trainer_pic(trainer_class) if data != null else {}
+	if pic.is_empty():
+		return {}
+	return Gen2PicImage.atlas_cell(
+		data.atlas_indices(pic["atlas"]), data.atlas(pic["atlas"]), pic
+	)
+
+
 ## Source order, each `{ pic, text, key, enter, clears_after }`. `_OakText2` and
 ## `_OakText4` are two `PrintText` calls over one pic and so two beats, while
 ## `_OakText3` is a bare promptbutton and is none. `clears_after` is the

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -470,7 +470,7 @@ func _show_pic(kind: int) -> void:
 	match kind:
 		Gen2OakSpeech.Pic.OAK:
 			palette = _data.trainer_palette(Gen2OakSpeech.POKEMON_PROF)
-			cell = _trainer_cell(Gen2OakSpeech.POKEMON_PROF)
+			cell = Gen2OakSpeech.trainer_cell(_data, Gen2OakSpeech.POKEMON_PROF)
 		Gen2OakSpeech.Pic.MON:
 			# `PrepMonFrontpic` sets wBoxAlignment before `PlaceGraphic`, and
 			# `Intro_PrepTrainerPic` does not, so only this beat is mirrored.
@@ -483,8 +483,9 @@ func _show_pic(kind: int) -> void:
 					cell["indices"], int(cell["width"])
 				)
 		Gen2OakSpeech.Pic.PLAYER:
-			palette = _player_palette()
-			cell = _player_cell()
+			var female: bool = _gender == Gen2SaveData.GENDER_FEMALE
+			palette = Gen2OakSpeech.player_palette(_data, female)
+			cell = Gen2OakSpeech.player_cell(_data, female)
 	if cell.is_empty():
 		return
 	_pic_cell = cell
@@ -508,15 +509,6 @@ func _redraw_pic(colors: PackedColorArray) -> void:
 	))
 
 
-func _trainer_cell(trainer_class: int) -> Dictionary:
-	var pic: Dictionary = _data.trainer_pic(trainer_class)
-	if pic.is_empty():
-		return {}
-	return Gen2PicImage.atlas_cell(
-		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic
-	)
-
-
 func _species_cell(species: int) -> Dictionary:
 	var pic: Dictionary = _data.species_pic(species)
 	if pic.is_empty():
@@ -524,39 +516,6 @@ func _species_cell(species: int) -> Dictionary:
 	return Gen2PicImage.atlas_cell(
 		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic
 	)
-
-
-func _player_palette() -> PackedColorArray:
-	if not Gen2WorldState.is_crystal_profile(_data):
-		return _data.trainer_palette(Gen2OakSpeech.CAL)
-	return _data.card_palette(1 if _gender == Gen2SaveData.GENDER_FEMALE else 0)
-
-
-func _player_cell() -> Dictionary:
-	if not Gen2WorldState.is_crystal_profile(_data):
-		# pokegold NamePlayer and ShrinkPlayer use trainer class CAL.
-		return _trainer_cell(Gen2OakSpeech.CAL)
-	var sheet: String = (
-		"intro_player_female"
-		if _gender == Gen2SaveData.GENDER_FEMALE else "intro_player_male"
-	)
-	var strip: PackedByteArray = _data.tile_indices(sheet)
-	var tiles: int = RomLayout.INTRO_PLAYER_PIC_TILES
-	var tile: int = Gen2Font.TILE
-	if strip.size() < tiles * tile * tile:
-		return {}
-	var width: int = RomLayout.INTRO_PLAYER_PIC_COLUMNS * tile
-	var indices := PackedByteArray()
-	indices.resize(width * RomLayout.INTRO_PLAYER_PIC_ROWS * tile)
-	var strip_width: int = tiles * tile
-	for row: int in RomLayout.INTRO_PLAYER_PIC_ROWS:
-		for column: int in RomLayout.INTRO_PLAYER_PIC_COLUMNS:
-			var source_tile: int = row * RomLayout.INTRO_PLAYER_PIC_COLUMNS + column
-			for y: int in tile:
-				for x: int in tile:
-					indices[(row * tile + y) * width + column * tile + x] = \
-						strip[y * strip_width + source_tile * tile + x]
-	return {"indices": indices, "width": width, "height": width}
 
 
 func _start_audio() -> void:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -5694,6 +5694,7 @@ func open_hall_of_fame() -> void:
 	var host := Gen2HallOfFameScreen.new()
 	host.set_context(_data, pages)
 	host.closed.connect(_on_hall_of_fame_closed)
+	host.cry_requested.connect(_play_species_cry)
 	host.rating_reached.connect(_on_hall_of_fame_rating)
 	_hall_of_fame_host = host
 	_screen.display(host)

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -2209,6 +2209,7 @@ func _open_hall_of_fame(index: int) -> void:
 	_hof_index = index
 	_set_overlay_open(true)
 	host.z_index = 5
+	host.cry_requested.connect(cry_requested.emit)
 	host.closed.connect(_on_hall_of_fame_closed)
 	_service_hardware.display(host)
 

--- a/tests/integration/test_oak_speech.gd
+++ b/tests/integration/test_oak_speech.gd
@@ -80,6 +80,21 @@ func test_the_pics_follow_the_routines_own_order() -> void:
 	assert_eq(int(beats[5]["pic"]), Gen2OakSpeech.Pic.PLAYER)
 
 
+## `DrawIntroPlayerPic` and `HOF_LoadTrainerFrontpic` load the same picture, so
+## the intro and the Hall of Fame read one seam rather than two.
+func test_the_player_picture_is_one_seam_for_the_intro_and_the_hall_of_fame() -> void:
+	var side: int = RomLayout.INTRO_PLAYER_PIC_COLUMNS * Gen2Font.TILE
+	for female: bool in [false, true]:
+		var cell: Dictionary = Gen2OakSpeech.player_cell(_data, female)
+		assert_eq(int(cell["width"]), side)
+		assert_eq(int(cell["height"]), side)
+		assert_eq(
+			int((cell["indices"] as PackedByteArray)[0]), 3 if female else 2,
+			"ChrisPic and KrisPic are different sheets"
+		)
+		assert_false(Gen2OakSpeech.player_palette(_data, female).is_empty())
+
+
 func test_a_cache_without_the_texts_has_no_speech() -> void:
 	RomCache.write_json(RomCache.intro_text_path(Fixture.directory()), {})
 	assert_eq(Gen2OakSpeech.beats(GameData.open_directory(Fixture.directory())), [])

--- a/tests/integration/test_world_credits_screen.gd
+++ b/tests/integration/test_world_credits_screen.gd
@@ -174,13 +174,12 @@ func test_the_hall_of_fame_runs_into_unskippable_credits() -> void:
 	await _open_world()
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
-	## `InitDisplayForHallOfFame`'s record box reads no joypad and moves on after
-	## a hundred frames of its own.
-	_world_screen._hall_of_fame_host.advance_saving_frames(
-		Gen2SavePrompt.SAVING_RECORD_FRAMES
-	)
 	while _world_screen._hall_of_fame_host != null:
-		_world_screen._hall_of_fame_host.handle_button(Gen2Button.A)
+		var host: Gen2HallOfFameScreen = _world_screen._hall_of_fame_host
+		## The record box and every induction panel read no joypad and hold for
+		## their own `DelayFrames`; the rating boxes behind them answer A.
+		if host.handle_button(Gen2Button.A):
+			host.advance_hold_frames(Gen2SavePrompt.SAVING_RECORD_FRAMES)
 	await get_tree().process_frame
 	assert_not_null(_host())
 	assert_false(_host().credits().skippable())

--- a/tests/integration/test_world_hall_of_fame_screen.gd
+++ b/tests/integration/test_world_hall_of_fame_screen.gd
@@ -78,14 +78,17 @@ func test_the_overworld_does_not_move_while_the_overlay_is_open() -> void:
 	assert_eq(_world_screen._world.player_cell, before)
 
 
-func test_a_key_walks_the_pages_and_the_last_one_closes_the_overlay() -> void:
+func test_the_panels_time_out_and_the_last_page_closes_the_overlay() -> void:
 	await _open_world(1)
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
 	_spend_record_box()
 	assert_eq(_host().remaining(), 1 + RATING_PAGES)
 
-	_host().handle_button(Gen2Button.A)
+	## `.DisplayNewHallOfFamer` reads no joypad either: the panel stands for its
+	## own `DelayFrames` and then moves on.
+	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_MON)
+	_host().advance_hold_frames(Gen2HallOfFame.panel_frames(_data))
 	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_PLAYER)
 	assert_eq(_host().remaining(), RATING_PAGES)
 
@@ -102,14 +105,32 @@ func test_a_key_walks_the_pages_and_the_last_one_closes_the_overlay() -> void:
 	assert_true(_world_screen.move_player(Vector2i.DOWN))
 
 
-## A key the panel does not use is refused rather than swallowed as an advance.
-func test_an_unrelated_key_does_not_advance_a_page() -> void:
+## `HOF_AnimatePlayerPic` slides the player's own front pic in beside the name
+## box, so the panel behind the rating is not text alone.
+func test_the_player_panel_draws_the_trainer_pic() -> void:
+	await _open_world(1)
+	_world_screen.open_hall_of_fame()
+	await get_tree().process_frame
+	_spend_record_box()
+	_host().advance_hold_frames(Gen2HallOfFame.panel_frames(_data))
+	assert_eq(StringName(_host().current_page()["kind"]), Gen2HallOfFame.PAGE_PLAYER)
+	assert_not_null(_host()._pic.texture)
+	assert_eq(
+		_host()._pic.position.x,
+		float(Gen2HallOfFamePage.player_pic_position().x),
+		"PlaceGraphic at hlcoord 12, 5"
+	)
+
+
+## An induction's panels read no joypad at all, so neither A nor B moves one on.
+func test_no_key_advances_an_induction_panel() -> void:
 	await _open_world(2)
 	_world_screen.open_hall_of_fame()
 	await get_tree().process_frame
 	_spend_record_box()
 	var before: int = _host().remaining()
-	assert_false(_host().handle_button(Gen2Button.B))
+	assert_true(_host().handle_button(Gen2Button.B))
+	assert_true(_host().handle_button(Gen2Button.A))
 	assert_eq(_host().remaining(), before)
 
 
@@ -156,14 +177,17 @@ func test_the_halloffame_command_opens_the_overlay() -> void:
 	assert_not_null(_world_screen._hall_of_fame_host)
 
 
-## The panels are answered one at a time; a test that only wants the overlay
-## closed does not care how many there were. The record box in front of them
-## reads no joypad, so its frames are spent first.
+## An induction reads no joypad until the player's own panel, so every page in
+## front of that one is spent as frames and the rating boxes as presses.
 func _advance_to_the_end() -> void:
-	if StringName(_host().current_page()["kind"]) == Gen2HallOfFame.PAGE_SAVING:
-		_spend_record_box()
 	while _world_screen._hall_of_fame_host != null:
-		_host().handle_button(Gen2Button.A)
+		match StringName(_host().current_page().get("kind", &"")):
+			Gen2HallOfFame.PAGE_SAVING:
+				_host().advance_hold_frames(Gen2SavePrompt.SAVING_RECORD_FRAMES)
+			Gen2HallOfFame.PAGE_MON:
+				_host().advance_hold_frames(Gen2HallOfFame.panel_frames(_data))
+			_:
+				_host().handle_button(Gen2Button.A)
 
 
 ## `HallOfFame_FadeOutMusic`'s `ld c, 100` behind `InitDisplayForHallOfFame`.
@@ -174,4 +198,4 @@ func _spend_record_box() -> void:
 	var before: int = _host().remaining()
 	assert_true(_host().handle_button(Gen2Button.A), "the box reads no joypad")
 	assert_eq(_host().remaining(), before, "and does not advance on one")
-	_host().advance_saving_frames(Gen2SavePrompt.SAVING_RECORD_FRAMES)
+	_host().advance_hold_frames(Gen2SavePrompt.SAVING_RECORD_FRAMES)

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -962,6 +962,9 @@ static func _write_battle_graphics(cache_directory: String, manifest: Dictionary
 	var sheet_tiles: Dictionary = {
 		"exp_bar": [RomLayout.EXP_BAR_TILES, 2],
 		"battle_font": [RomLayout.BATTLE_FONT_TILES, 1],
+		## `_LoadFontsExtra1`'s strip, on an index of its own so a code the
+		## battle strip also owns says which of the two it was drawn from.
+		"font_extra": [RomLayout.FONT_EXTRA_TILES, 2],
 		"enemy_hud": [RomLayout.ENEMY_HUD_TILES, 2],
 		"player_hud": [RomLayout.PLAYER_HUD_TILES, 3],
 		"font": [RomLayout.FONT_TILES, 3],
@@ -988,6 +991,10 @@ static func _write_battle_graphics(cache_directory: String, manifest: Dictionary
 		## `LoadGenderScreenLightBlueTile`'s one tile, on the index the real one
 		## carries, since the page reads the fill out of it rather than assuming.
 		"gender_screen": [RomLayout.GENDER_SCREEN_TILES, RomLayout.GENDER_SCREEN_FILL_INDEX],
+		## `DrawIntroPlayerPic`'s ChrisPic and KrisPic, which `HOF_LoadTrainerFrontpic`
+		## loads as well. A different index each, so a capture says which was drawn.
+		"intro_player_male": [RomLayout.INTRO_PLAYER_PIC_TILES, 2],
+		"intro_player_female": [RomLayout.INTRO_PLAYER_PIC_TILES, 3],
 		## `ShrinkPlayer`'s two pictures, flat fills like the rest: what a test
 		## checks is when each is drawn, not what is in it.
 		"shrink_1": [RomLayout.SHRINK_PIC_TILES, 2],

--- a/tests/unit/test_hall_of_fame.gd
+++ b/tests/unit/test_hall_of_fame.gd
@@ -156,6 +156,39 @@ func test_the_player_panel_draws_its_name_box_and_the_rating_box() -> void:
 	assert_true(_has_ink(indices, Gen2HallOfFamePage.MON_BOTTOM_BOX))
 
 
+## `HOF_AnimatePlayerPic` prints the trainer ID at `hlcoord 1, 6` and the play
+## timer under `.PlayTime`, both of which the save carries.
+func test_the_player_panel_prints_the_trainer_id_and_the_play_timer() -> void:
+	var save: Gen2SaveData = _save([1])
+	save.player_id = 456
+	save.game_time = Gen2GameTime.create(7, 5, 0, 0)
+	var page: Dictionary = Gen2HallOfFame.pages(_data, save)[2]
+	assert_eq(int(page["player_id"]), 456)
+	assert_eq(int(page["hours"]), 7)
+	assert_eq(String(page["minutes"]), "05")
+	var indices: PackedByteArray = Gen2HallOfFamePage.from_data(_data).draw(page)
+	# The fixture fills each sheet with an index of its own: 1 is battle_font,
+	# 3 the main font, and the colon is the one glyph read from the main strip.
+	assert_eq(_index_at(indices, Gen2HallOfFamePage.PLAYER_ID_LABEL), 1, "<ID>")
+	assert_eq(_index_at(indices, Gen2HallOfFamePage.PLAYER_ID_NUMBER), 3, "the digits")
+	assert_eq(_index_at(indices, Gen2HallOfFamePage.PLAY_TIME_LABEL), 3, "PLAY TIME")
+	assert_eq(
+		_index_at(indices, Gen2HallOfFamePage.PLAY_TIME_COLON), 2,
+		"the colon comes off FontExtra rather than the battle strip"
+	)
+	assert_eq(Gen2Text.character(Gen2HallOfFamePage.CODE_COLON), ":")
+
+
+## `.DisplayNewHallOfFamer`'s `ld c, 60` and pokegold's `ld c, 180`: an induction
+## panel holds for frames rather than for a press.
+func test_the_panel_hold_is_profile_split() -> void:
+	assert_eq(
+		Gen2HallOfFame.panel_frames(_data),
+		Gen2HallOfFame.PANEL_FRAMES_CRYSTAL if Gen2WorldState.is_crystal_profile(_data)
+		else Gen2HallOfFame.PANEL_FRAMES_GOLD_SILVER
+	)
+
+
 ## Any non-zero palette index inside a tile rectangle. Index 0 is the page's
 ## own background, so ink means something was drawn there.
 func _has_ink(indices: PackedByteArray, box: Rect2i) -> bool:

--- a/tests/unit/test_trainer_card_page.gd
+++ b/tests/unit/test_trainer_card_page.gd
@@ -86,15 +86,37 @@ func test_the_blinking_separator_is_the_only_difference_a_frame_makes() -> void:
 	)
 
 
-## The dex row is not printed at all without STATUSFLAGS_POKEDEX_F, which is
-## what the source's own ClearBox leaves behind.
-func test_the_dex_count_is_absent_without_the_pokedex() -> void:
+## Without STATUSFLAGS_POKEDEX_F the source clears `hlcoord 1, 9` over two rows
+## and seventeen columns, which takes the #DEX label as well as its count.
+func test_the_whole_dex_row_is_cleared_without_the_pokedex() -> void:
 	var card: Dictionary = _card()
 	card["pokedex"] = false
-	var changed: Array = _changed_tiles(_page.draw(_card()), _page.draw(card))
+	var without: PackedByteArray = _page.draw(card)
+	var changed: Array = _changed_tiles(_page.draw(_card()), without)
 	assert_false(changed.is_empty())
 	for at: Vector2i in changed:
 		assert_eq(at.y, Gen2TrainerCardPage.DEX_COUNT_AT.y)
+	assert_true(
+		Gen2TrainerCardPage.DEX_LABEL_AT in changed,
+		"the label goes with the count"
+	)
+	var blank: PackedByteArray = _page.draw(card)
+	for row: int in Gen2TrainerCardPage.NO_DEX_CLEAR_ROWS:
+		for column: int in Gen2TrainerCardPage.NO_DEX_CLEAR_COLUMNS:
+			var at: Vector2i = Gen2TrainerCardPage.NO_DEX_CLEAR_AT \
+				+ Vector2i(column, row)
+			assert_true(_tile_is_blank(blank, at), "%s is cleared" % at)
+
+
+## Whether every pixel of a tile is the page's background index.
+func _tile_is_blank(indices: PackedByteArray, at: Vector2i) -> bool:
+	var tile: int = Gen2TrainerCardPage.TILE
+	for y: int in tile:
+		for x: int in tile:
+			var offset: int = (at.y * tile + y) * Gen2Screen.WIDTH + at.x * tile + x
+			if offset < indices.size() and indices[offset] != 0:
+				return false
+	return true
 
 
 ## Page 2 replaces the status box with the leaders' faces, and the top half of


### PR DESCRIPTION
## Fixed

The Hall of Fame's player panel printed neither the trainer ID nor PLAY TIME and drew no picture. `HOF_AnimatePlayerPic` puts `<ID>№/` and five digits at `hlcoord 1, 6`, `.PlayTime` at `hlcoord 1, 8` with a three-digit hour and `HALLOFFAME_COLON` behind it, and `HOF_LoadTrainerFrontpic`'s picture at `hlcoord 12, 5`. That picture is `DrawIntroPlayerPic`'s, ChrisPic or KrisPic on Crystal and CAL's trainer pic on Gold and Silver, so the intro and the Hall of Fame now read one seam.

Every Hall of Fame panel says the Pokemon on it and none did: `PokeAnim_CryNoWait` inside Crystal's ANIM_MON_HOF, pokegold's own `PlayMonCry`. Both the induction and the PC viewer.

`.DisplayNewHallOfFamer` reads no joypad. Crystal holds `ld c, 60` behind the animation and pokegold `ld c, 180` behind the cry, where an induction here waited for A on every panel. `_HallOfFamePC`'s viewer still answers A, B and START.

The trainer card's `#DEX` label stayed on screen for a player without the Pokedex. `TrainerCard_Page1_PrintDexCaught_GameTime` ends on `ClearBox` at `hlcoord 1, 9` over two rows and seventeen columns, which takes the label as well as the count.

## Notes

`engine/events/halloffame.asm`, `engine/menus/trainer_card.asm`, `engine/menus/menu.asm` and `engine/events/std_scripts.asm` were read whole; the last two agree with what is built. Page 3 of the trainer card is unreachable on all three cartridges, both routines that would set `TRAINERCARDSTATE_PAGE3_LOADGFX` being unreferenced.

| Check | Result |
|---|---|
| GUT, unit and scene | 4143 of 4143, 75,051 asserts |
| Editor analyser | 0 warnings in 608 scripts |
| `tools/validate.gd -- all` | 83 topics, 0 failures |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 6 legs each, 0 failures |