### PR TITLE
Clear the state a map load and a day rollover zero

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -2004,8 +2004,8 @@ func pending_strength() -> Dictionary:
 
 
 ## SetStrengthFlag: the engine flag plus wStrengthSpecies, which is only read
-## back by Script_UsedStrength's own cry. Nothing in the pinned sources ever
-## clears the flag, so this is the one write and it persists for the save.
+## back by Script_UsedStrength's own cry. `ResetBikeFlags` takes it off again on
+## the next map, so a boulder outlives nothing but the map it stands on.
 func complete_strength() -> Dictionary:
 	if _pending_strength.is_empty():
 		return _strength_failure(&"no_pending_strength")
@@ -2022,8 +2022,7 @@ func complete_strength() -> Dictionary:
 	}
 
 
-## Whether BIKEFLAGS_STRENGTH_ACTIVE_F is set, the single condition
-## DoPlayerMovement.CheckStrengthBoulder and TryStrengthOW both read.
+## BIKEFLAGS_STRENGTH_ACTIVE_F, the one condition CheckStrengthBoulder reads.
 func strength_active() -> bool:
 	return state.is_engine_flag_active(
 		Gen2WorldState.strength_active_flag(Gen2WorldState.is_crystal_profile(data))
@@ -6445,9 +6444,12 @@ func _apply_map(
 	# EnterMap's own SetUpFiveStepWildEncounterCooldown, which is why the first
 	# steps out of a door are quiet.
 	state.set_wild_encounter_cooldown(Gen2WorldState.WILD_ENCOUNTER_COOLDOWN_STEPS)
-	# ResetFlashIfOutOfCave, which runs in map setup: stepping out into a route
-	# or a town puts the light out, and a cave to cave doorway does not.
+	# HandleNewMap's own resets: ResetBikeFlags drops a used Strength with the
+	# map, ResetFlashIfOutOfCave puts the light out on a route or a town, and
+	# HandleContinueMap behind it runs ClearCmdQueue over every written queue.
+	state.reset_bike_flags(Gen2WorldState.is_crystal_profile(data))
 	state.clear_flash_if_outdoors(target_map.environment)
+	_command_queues.clear()
 	current_map = target_map
 	_map_placements = {}
 	_connected_objects = []
@@ -6777,8 +6779,7 @@ func always_on_bike() -> bool:
 
 
 ## `.CheckEnvironment`: outdoors, a cave or a gate, and standing on a tile whose
-## permission's low nibble is `FLOOR_TILE`. Water and every wall code fail it, so
-## a surfing player can never be on a bike either.
+## permission's low nibble is `FLOOR_TILE`. Water and every wall code fail it.
 func _can_ride_bike_here() -> bool:
 	if not _is_outdoor(current_map.environment) \
 		and current_map.environment not in [ENVIRONMENT_CAVE, ENVIRONMENT_GATE]:
@@ -7198,6 +7199,10 @@ func reload_current_map() -> Dictionary:
 
 func _on_world_state_changed() -> void:
 	set_object_time(object_hour, object_time_of_day)
+	## RefreshMapSprites runs CheckUpdatePlayerSprite after HandleNewMap's own
+	## callback, and Route 16 and Route 17 set the flag from theirs.
+	if always_on_bike() and movement_mode != MOVEMENT_BIKE:
+		_apply_map_setup_player_state()
 
 
 ## `GetMonSprite` itself: a variable slot resolves through the table and is

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -105,16 +105,15 @@ const ENGINE_KURT_MAKING_BALLS: int = 80
 const ENGINE_ALL_FRUIT_TREES: int = 84
 
 ## wBikeFlags' BIKEFLAGS_STRENGTH_ACTIVE_F, three engine flags ahead of the badge
-## section and so profile split the same way. Nothing in the pinned engine/ or
-## home/ ever clears it: SetStrengthFlag is the only writer, so it persists for
-## the save across maps, warps and snapshots.
+## section and so profile split the same way. `SetStrengthFlag` is its one writer
+## and `ResetBikeFlags` its one clear, so it lives exactly one map load.
 const ENGINE_STRENGTH_ACTIVE: int = 24
 const ENGINE_STRENGTH_ACTIVE_GOLD_SILVER: int = 23
-## The next flag in the same byte: `BIKEFLAGS_ALWAYS_ON_BIKE_F`, which is the
-## whole of `.CantGetOffBike`. `BIKEFLAGS_DOWNHILL_F` follows it and is read by
-## `DoPlayerMovement` alone, which no map ever sets.
+## The next two flags in the same byte: `BIKEFLAGS_ALWAYS_ON_BIKE_F` is the whole
+## of `.CantGetOffBike`, and `BIKEFLAGS_DOWNHILL_F` is Route 17's, unmodelled.
 const ENGINE_ALWAYS_ON_BIKE: int = 25
 const ENGINE_ALWAYS_ON_BIKE_GOLD_SILVER: int = 24
+const ENGINE_DOWNHILL: int = 26
 
 ## wBadges spans wJohtoBadges then wKantoBadges as one contiguous flag_array, and
 ## VAR_BADGES counts both bytes, not Johto alone. These are Crystal indices:
@@ -990,6 +989,20 @@ static func always_on_bike_flag(data: GameData) -> int:
 		else ENGINE_ALWAYS_ON_BIKE_GOLD_SILVER
 
 
+## `ResetBikeFlags` (`home/flag.asm`), which zeroes `wBikeFlags` whole.
+func reset_bike_flags(crystal: bool = true) -> bool:
+	var did_change: bool = false
+	for index: int in [ENGINE_STRENGTH_ACTIVE, ENGINE_ALWAYS_ON_BIKE, ENGINE_DOWNHILL]:
+		var flag: int = engine_flag(index, crystal)
+		if not _engine_flags.has(flag):
+			continue
+		_engine_flags.erase(flag)
+		did_change = true
+	if did_change:
+		changed.emit()
+	return did_change
+
+
 ## Mirrors _GetVarAction's .CountBadges: a popcount over both badge bytes.
 func badge_count(crystal: bool = true) -> int:
 	var count: int = 0
@@ -1010,14 +1023,12 @@ func badge_mask(crystal: bool = true) -> int:
 	return mask
 
 
-## Clears only source daily engine flags; story flags such as Hall of Fame
-## survive the day boundary. `CheckDailyResetTimer` (`engine/overworld/time.asm`)
-## zeroes the whole `wDailyFlags1` byte, so every flag in it goes together.
-## Listed by Crystal index because only the ones this project writes are
-## modelled; add one as soon as something sets it, or it survives the day.
-const DAILY_ENGINE_FLAGS: Array[int] = [
-	ENGINE_KURT_MAKING_BALLS, ENGINE_ALL_FRUIT_TREES,
-	ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED,
+## `CheckDailyResetTimer` (`engine/overworld/time.asm`) zeroes `wDailyFlags1`
+## through `wSwarmFlags` and the three phone runs behind them, so every engine
+## flag in those bytes goes together. Inclusive Crystal index runs, which
+## `engine_flag()` resolves onto Gold and Silver.
+const DAILY_ENGINE_FLAG_RUNS: Array[Vector2i] = [
+	Vector2i(80, 97), Vector2i(101, 158), Vector2i(160, 161),
 ]
 
 
@@ -1025,17 +1036,24 @@ func reset_daily_flags(
 	crystal: bool = true, random: RandomNumberGenerator = null
 ) -> bool:
 	var did_change: bool = false
-	for crystal_index: int in DAILY_ENGINE_FLAGS:
-		var flag: int = engine_flag(crystal_index, crystal)
-		if not _engine_flags.has(flag):
-			continue
-		_engine_flags.erase(flag)
-		did_change = true
-	## `CheckDailyResetTimer` does not only clear the flag bytes: the same
-	## branch steps `wKenjiBreakTimer` and resamples it when it runs out, so a
-	## day passing is what moves the Route 27 sailor's break along.
-	## The same branch is where every day-counted timer this project keeps is
-	## stepped, since a weekday alone cannot say how many days have passed.
+	for run: Vector2i in DAILY_ENGINE_FLAG_RUNS:
+		for crystal_index: int in range(run.x, run.y + 1):
+			var flag: int = engine_flag(crystal_index, crystal)
+			if not _engine_flags.has(flag):
+				continue
+			_engine_flags.erase(flag)
+			did_change = true
+	## Crystal's `_SwarmWildmonCheck` reads `wSwarmFlags` before either map, so
+	## the byte going is what ends a swarm; pokegold's reads the map alone.
+	if crystal:
+		for kind: int in _swarm_maps.size():
+			if _swarm_maps[kind] == Vector2i(-1, -1):
+				continue
+			_swarm_maps[kind] = Vector2i(-1, -1)
+			did_change = true
+	## The same branch steps `wKenjiBreakTimer` and resamples it when it runs
+	## out, and every day-counted timer this project keeps is stepped here too:
+	## a weekday alone cannot say how many days have passed.
 	if _lucky_number_days_left > 0:
 		_lucky_number_days_left -= 1
 		did_change = true

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1494,6 +1494,20 @@ func test_a_boulder_pushed_onto_open_floor_fires_no_stone_table() -> void:
 	assert_false(result["boulder_pushed"].has("fall_script"), JSON.stringify(result))
 
 
+## HandleNewMap falls into HandleContinueMap, whose ClearCmdQueue empties the
+## queue on every map load; MapSetupScript_ReloadMap reaches neither.
+func test_a_written_command_queue_dies_with_the_map_but_not_with_a_reload() -> void:
+	var world: Gen2WorldAPI = _stone_table_world([
+		{"warp": STONE_WARP, "object": STONE_OBJECT, "script": STONE_SCRIPT},
+	])
+	assert_eq(world.command_queues().size(), 1)
+	world.reload_current_map()
+	assert_eq(world.command_queues().size(), 1)
+	world.player_cell = Vector2i(6, 6)
+	assert_true(bool(world.try_warp().get("ok", false)))
+	assert_true(world.command_queues().is_empty())
+
+
 ## HandleStoneQueue reads the queue that was written, so a map whose callback
 ## never ran has none and nothing falls.
 func test_no_stone_table_fires_without_a_written_queue() -> void:
@@ -6039,6 +6053,9 @@ func test_world_snapshot_round_trips_map_player_and_mutable_state() -> void:
 	state.set_hall_of_fame()
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, 1, 1, Vector2i(8, 6), state)
 	world.set_world_clock(2, 7, 12)
+	## The clock crossing a day is CheckDailyResetTimer, which ends a Crystal
+	## swarm, so the one this round trip carries is set after it.
+	world.state.set_swarm_map(Vector2i(1, 1))
 	world.set_daylight_saving_time_enabled(true)
 	world.player_facing = Gen2WorldSprite.FACING_LEFT
 	assert_true(world.set_movement_mode(Gen2WorldAPI.MOVEMENT_SURF)["ok"])

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -535,9 +535,9 @@ func test_complete_strength_sets_the_flag_only_after_the_request() -> void:
 	assert_true(world.pending_strength().is_empty())
 
 
-## Nothing clears the flag, so it has to outlive the map reload and the warp that
-## drop every staged field-move request.
-func test_strength_stays_active_across_a_map_reload_and_a_warp() -> void:
+## MapSetupScript_ReloadMap runs no HandleNewMap, so a reload keeps the flag that
+## the warp behind it drops through ResetBikeFlags.
+func test_strength_survives_a_map_reload_and_ends_at_the_next_warp() -> void:
 	var world: Gen2WorldAPI = _strength_world()
 	assert_true(world.strength_request()["ok"])
 	assert_true(world.complete_strength()["ok"])
@@ -548,7 +548,7 @@ func test_strength_stays_active_across_a_map_reload_and_a_warp() -> void:
 	world.player_cell = SHORE_CELL
 	assert_true(world.try_warp()["ok"])
 	assert_eq(world.map_id(), Vector2i(1, 2))
-	assert_true(world.strength_active())
+	assert_false(world.strength_active())
 
 
 ## A staged request dies with the loaded map beside the other three, because
@@ -2205,13 +2205,16 @@ func test_always_on_bike_forces_the_bike_back_and_refuses_surf() -> void:
 	assert_eq(world.surf_request()["reason"], &"cannot_surf")
 	assert_false(world._surf_prompt_applies(WATER_CELL))
 
-	## `.CheckForcedBiking` runs first, so a map load puts the bike back on.
+	## `ResetBikeFlags` zeroes the byte ahead of HandleNewMap's own callback, so
+	## the two maps that force a bike set the flag again on every load, and
+	## `.CheckForcedBiking` puts the bike back on when they do.
 	var forced: Gen2WorldAPI = _escape_world()
+	forced.player_cell = ESCAPE_CAVE_DOOR
+	assert_true(bool(forced.try_warp().get("ok", false)))
+	assert_false(forced.always_on_bike())
 	forced.state.set_engine_flag(
 		Gen2WorldState.always_on_bike_flag(forced.data), true
 	)
-	forced.player_cell = ESCAPE_CAVE_DOOR
-	assert_true(bool(forced.try_warp().get("ok", false)))
 	assert_eq(forced.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
 	assert_eq(forced.player_sprite_number, Gen2WorldSprite.SPRITE_PLAYER_BIKE)
 	## `.TryBike` reads `.CheckEnvironment` first and only then the flag, so the
@@ -2222,8 +2225,14 @@ func test_always_on_bike_forces_the_bike_back_and_refuses_surf() -> void:
 	## indoor map keeps the bike on while the flag is up.
 	forced.player_cell = ESCAPE_INSIDE_DOOR
 	assert_true(bool(forced.try_warp().get("ok", false)))
+	forced.state.set_engine_flag(
+		Gen2WorldState.always_on_bike_flag(forced.data), true
+	)
 	forced.player_cell = ESCAPE_CENTRE_DOOR
 	assert_true(bool(forced.try_warp().get("ok", false)))
+	forced.state.set_engine_flag(
+		Gen2WorldState.always_on_bike_flag(forced.data), true
+	)
 	assert_eq(forced.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
 
 

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -224,30 +224,68 @@ func test_bargain_merchant_closed_uses_the_gold_silver_flag_when_requested() -> 
 	assert_false(gold_state.bargain_merchant_closed(true))
 
 
-func test_reset_daily_flags_clears_the_matching_profiles_merchant_flag_only() -> void:
-	var gold_state := Gen2WorldState.new()
-	gold_state.set_engine_flag(
-		Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED_GOLD_SILVER
-	)
-	assert_false(gold_state.reset_daily_flags(true))
-	assert_true(gold_state.bargain_merchant_closed(false))
-	assert_true(gold_state.reset_daily_flags(false))
-	assert_false(gold_state.bargain_merchant_closed(false))
-
-
-## CheckDailyResetTimer zeroes the whole wDailyFlags1 byte, so Kurt's flag goes
-## with the merchant's. Without it he never finishes a ball.
-func test_reset_daily_flags_clears_kurts_flag_on_both_profiles() -> void:
+## CheckDailyResetTimer zeroes wDailyFlags1, wDailyFlags2, wSwarmFlags and the
+## three phone runs, so Kurt's ball, the merchant, the Bug Contest, a rematch,
+## a caller's daily item and both swarm bits go together. The four indices
+## between the runs live in other bytes and stand. Without this a phone contact
+## hands over its item once per save rather than once per day.
+func test_reset_daily_flags_clears_every_flag_the_daily_bytes_hold() -> void:
+	var daily: Array[int] = [
+		Gen2WorldState.ENGINE_KURT_MAKING_BALLS,
+		Gen2WorldState.ENGINE_DAILY_BUG_CONTEST,
+		Gen2WorldState.ENGINE_GOLDENROD_UNDERGROUND_MERCHANT_CLOSED,
+		97, 101, 124, 125, 134, 135, 158, 160, 161,
+	]
+	var kept: Array[int] = [98, 99, 100, 159]
 	for crystal: bool in [true, false]:
 		var state := Gen2WorldState.new()
-		var flag: int = Gen2WorldState.engine_flag(
-			Gen2WorldState.ENGINE_KURT_MAKING_BALLS, crystal
-		)
-		state.set_engine_flag(flag)
-		assert_false(state.reset_daily_flags(not crystal))
-		assert_true(state.is_engine_flag_active(flag))
+		for index: int in daily + kept:
+			state.set_engine_flag(Gen2WorldState.engine_flag(index, crystal))
 		assert_true(state.reset_daily_flags(crystal))
-		assert_false(state.is_engine_flag_active(flag))
+		for index: int in daily:
+			assert_false(
+				state.is_engine_flag_active(Gen2WorldState.engine_flag(index, crystal))
+			)
+		for index: int in kept:
+			assert_true(
+				state.is_engine_flag_active(Gen2WorldState.engine_flag(index, crystal))
+			)
+
+
+## ResetBikeFlags zeroes wBikeFlags whole on every HandleNewMap, so a used
+## Strength, an always-on bike and a downhill slope all end with the map.
+func test_reset_bike_flags_clears_the_whole_byte_on_both_profiles() -> void:
+	for crystal: bool in [true, false]:
+		var state := Gen2WorldState.new()
+		var byte: Array[int] = [
+			Gen2WorldState.ENGINE_STRENGTH_ACTIVE,
+			Gen2WorldState.ENGINE_ALWAYS_ON_BIKE,
+			Gen2WorldState.ENGINE_DOWNHILL,
+		]
+		for index: int in byte:
+			state.set_engine_flag(Gen2WorldState.engine_flag(index, crystal))
+		assert_true(state.reset_bike_flags(crystal))
+		assert_false(state.reset_bike_flags(crystal))
+		for index: int in byte:
+			assert_false(
+				state.is_engine_flag_active(Gen2WorldState.engine_flag(index, crystal))
+			)
+
+
+## Crystal's _SwarmWildmonCheck reads wSwarmFlags before either map, so the same
+## reset ends a swarm. pokegold's reads the map alone and its swarm has no end.
+func test_reset_daily_flags_ends_a_crystal_swarm_only() -> void:
+	var crystal_state := Gen2WorldState.new()
+	crystal_state.set_swarm_map(Vector2i(1, 2))
+	crystal_state.set_swarm_map(Vector2i(3, 4), true, 0, Gen2WorldState.SWARM_YANMA)
+	assert_true(crystal_state.reset_daily_flags(true))
+	assert_false(crystal_state.swarm_active_on(1, 2))
+	assert_false(crystal_state.swarm_active_on(3, 4))
+
+	var gold_state := Gen2WorldState.new()
+	gold_state.set_swarm_map(Vector2i(1, 2))
+	assert_false(gold_state.reset_daily_flags(false))
+	assert_true(gold_state.swarm_active_on(1, 2))
 
 
 func test_the_saved_kurt_quantity_survives_a_snapshot_round_trip() -> void:


### PR DESCRIPTION
Three defects, all one seam: state the cartridge zeroes on a boundary and this port carried for the rest of the save. Found walking nine files a built screen already reaches, 5,100 lines, listed at the bottom.

## Fixed

`CheckDailyResetTimer` zeroes `wDailyFlags1`, `wDailyFlags2`, `wSwarmFlags` and the three four-byte runs at `wDailyRematchFlags`, `wDailyPhoneItemFlags` and `wDailyPhoneTimeOfDayFlags`, which is 44 engine flags on Crystal. `reset_daily_flags` cleared three of them, so a phone contact handed over its daily item once per save, a rematch offer never expired, the Bug Contest closed for good after one entry, and Anthony's Dunsparce swarm and Arnie's Yanma swarm never ended.

The two swarms end with the flags on Crystal, because `_SwarmWildmonCheck` reads `wSwarmFlags` before either map there. pokegold's own `_SwarmWildmonCheck` reads the map with no flag in front of it, so a Gold or Silver swarm still has no end.

`ResetBikeFlags` zeroes `wBikeFlags` whole on every `HandleNewMap`, which is every warp, connection, door, fall, teleport, train and fly. A used Strength lasts exactly as long as the map it was used on; this port kept the flag for the save. Route 16 and Route 17 set `BIKEFLAGS_ALWAYS_ON_BIKE_F` back from a `MAPCALLBACK_NEWMAP` callback that runs after the reset, so `CheckUpdatePlayerSprite` is re-derived here when that flag moves.

`HandleNewMap` falls into `HandleContinueMap`, whose `ClearCmdQueue` empties every written queue on the same loads. Nothing here cleared one, so a `CMDQUEUE_STONETABLE` row from an earlier map could still answer `HandleStoneQueue` for a boulder standing on a later one.

`MapSetupScript_ReloadMap` reaches none of the three routines, so a `reloadmap` keeps all of them.

## Notes

pokegold's engine flag table stops at `DAILYFLAGS2_INDIGO_PLATEAU_RIVAL_FIGHT`, 93 entries against Crystal's 162. The rematch, phone and swarm runs are Crystal's alone, so `engine_flag()`'s one-index shift maps them onto Gold and Silver numbers no script there ever names, and no profile split is needed.

`api_version` stays 29 and nothing on the boundary moved.

`AnimateWaterPalette`'s "only update on even ticks" guard is redundant: `and %110` drops the bit it tests, so the colour it would have skipped is the one already standing.

Walked whole and agreeing with what is built: `engine/menus/start_menu.asm`, `engine/items/tmhm.asm`, `engine/rtc/timeset.asm`, `engine/pokemon/mon_stats.asm`, `engine/tilesets/tileset_anims.asm`, `engine/menus/scrolling_menu.asm` and `engine/gfx/mon_icons.asm`. The three defects came out of `engine/overworld/time.asm` and `engine/overworld/warp_connection.asm` with `home/flag.asm`.

## Checks

| Gate | Result |
|---|---|
| GUT unit tier | 3,544 tests, 0 failures, 65,412 asserts |
| `tools/validate.gd -- all` | 0 failures, exit 0 |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | complete, no failed leg |
| `addons/warning_scan` | 0 warnings in 608 scripts |