### PR TITLE
Stop the AltStore feed pull request from asking for approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    # The AltStore feed pull request is opened by `github-actions[bot]`, and a
+    # `pull_request` run from a bot author is held for manual approval and
+    # expires unapproved: five of the last nine releases left a red `ci` run
+    # nobody could have read, and one was approved by hand. A pull request whose
+    # only changed file is listed here creates no run at all. Nothing is lost.
+    # `test_export_presets.gd` compares `source.json` against the iOS preset, so
+    # any change that would make the feed disagree with the preset is already
+    # red on the ordinary pull request that makes it.
+    paths-ignore: [".github/altstore/source.json"]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
The `ci` run on [#503](https://github.com/Decryptu/pokerecomp/pull/503) failed with `This workflow run required approval but was not approved before it expired`. It is not a one-off: a `pull_request` run whose author is `github-actions[bot]` is held for manual approval, and the feed pull request is opened by the release workflow.

| Feed pull request | `ci` |
|---|---|
| altstore-0.1.20 | failure, expired unapproved |
| altstore-0.1.19 | success on attempt 2, approved by hand |
| altstore-0.1.18 | failure, then a re-run by Decryptu |
| altstore-0.1.17 | failure |
| altstore-0.1.16 | failure |
| altstore-0.1.15 | success on attempt 2 |
| altstore-0.1.14 | failure |

## Fixed

`.github/workflows/ci.yml`'s `pull_request` trigger takes `paths-ignore: [".github/altstore/source.json"]`. The feed pull request changes that file and nothing else, so no run is created and there is nothing to approve. A pull request that touches the feed alongside anything else still runs.

## Notes

No gate is lost. `tests/unit/test_export_presets.gd` reads `source.json` and compares its bundle identifier, minimum iOS version, app-level version and per-version download URLs against `export_presets.cfg` and the release tags, so a change that would make the feed disagree with the preset goes red on the ordinary pull request that makes it, before any release exists.

The 0.1.20 feed that landed unchecked is correct: `-gselect=test_export_presets` passes against it on `main`, 15 tests and 153 asserts.

The `Protect main` ruleset carries no required status checks, which is why the merge went through with the run red.

| Gate | Result |
|---|---|
| GUT unit tier | 3,545 tests, 0 failures, 65,419 asserts |
| `tools/release.sh --gates` | pass, 4 sections, version 0.1.20 everywhere, 37,785 of 37,786 comment lines |