### PR TITLE
Let the new dex entry take the press that closes it

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3150,6 +3150,11 @@ func _is_bug_contest_battle() -> bool:
 	return _battle != null and _battle.battle_type == Gen2Battle.BATTLETYPE_CONTEST
 
 
+## The screen the fight draws on, for an overlay the world opens over it.
+func hardware_screen() -> Gen2Screen:
+	return _screen
+
+
 func _capture_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "reason": reason}
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1347,10 +1347,6 @@ func press_button(button: int) -> bool:
 	return _handle_button(button)
 
 
-## Routes one button to whatever owns the screen, and reports whether anything
-## took it. A pause that owns the world swallows every button rather than
-## refusing the ones it has no use for, which is what keeps a stray press from
-## reaching the map behind it.
 ## The overlays that own the whole screen, in the order a press is offered them.
 ## Each runs with the map loop suspended behind it, by `givepoke`, `opentext` or
 ## a `special` of its own, and owns every button until its own exit.
@@ -1400,8 +1396,12 @@ func _handle_button(button: int) -> bool:
 	## First, because a battle hides the map entirely and owns every button while
 	## it does. The fight takes it through this funnel rather than reading events
 	## of its own, so a press inside a battle is recorded once, by the world, and
-	## a replayed log reaches the fight (`tools/replay_world.gd`).
-	if _battle_host != null:
+	## a replayed log reaches the fight (`tools/replay_world.gd`). An overlay the
+	## fight opened stands in front of it and takes the press: unconditional here,
+	## `NewPokedexEntry`'s page never saw its B and a first catch of a species
+	## froze with the entry on screen.
+	if _battle_host != null and not _any_host_open(OVERLAY_HOSTS) \
+		and not _any_host_open(ANSWERING_HOSTS):
 		_battle_host.press_button(button)
 		return true
 	if _input_locked():
@@ -4662,9 +4662,34 @@ func preview_catch_nickname() -> bool:
 	return false
 
 
-## Enough for the battle's own opening, the throw and the shakes, each of which
-## is a box printing at the OPTION screen's own speed.
+## Enough for the battle's own opening, the throw and the shakes, each a box
+## printing at the OPTION screen's own speed.
 const CATCH_NICKNAME_FRAMES: int = 1200
+
+
+func preview_catch_dex() -> bool:
+	if _world == null or _world.state == null:
+		return false
+	_world.state.set_engine_flag(Gen2WorldStartMenu.ENGINE_POKEDEX, true)
+	preview_capture()
+	settle_battle_transition()
+	for _frame: int in CATCH_NICKNAME_FRAMES:
+		if _battle_host == null:
+			return false
+		if _preview_throw_master_ball():
+			break
+		_battle_host.advance_hardware_frame()
+	for _frame: int in CATCH_NICKNAME_FRAMES:
+		if _pokedex_host != null:
+			_script_prompt = "New dex entry"
+			_refresh_labels()
+			return true
+		if _battle_host == null:
+			return false
+		_battle_host.finish()
+		_battle_host.advance()
+		_battle_host.advance_hardware_frame()
+	return false
 
 
 ## Public screenshot driver for a resolved imported wild encounter. It uses the
@@ -5111,9 +5136,8 @@ func _on_capture_requested(ball: int) -> void:
 	_refresh_labels()
 
 
-## `NewPokedexEntry` behind `Text_GotchaMonWasCaught`: the page stands over the
-## battle, and the battle waits for it. The world opens it because the world owns
-## the dex; a cache with no entry for the species answers straight away.
+## `NewPokedexEntry` behind `Text_GotchaMonWasCaught`, which the battle waits
+## for. A cache with no entry for the species answers straight away.
 func _on_battle_dex_entry_requested(species: int) -> void:
 	if _battle_host == null:
 		return
@@ -5121,8 +5145,6 @@ func _on_battle_dex_entry_requested(species: int) -> void:
 		_battle_host.complete_dex_entry()
 
 
-## `UseDisposableItem` inside a battle: the effect has already landed on the
-## party the battle owns, so all the world does is take the row down by one.
 ## `InitNickname` behind `PokeBallEffect`'s own `YesNoBox`. The battle screen
 ## owns the question and the keyboard, because the routine runs inside the
 ## fight; the row it names is on the save this screen handed the catch.
@@ -5140,6 +5162,8 @@ func _apply_capture_nickname(capture: Dictionary) -> void:
 		_script_prompt = "Nickname refused: %s" % String(named.get("reason", "unknown"))
 
 
+## `UseDisposableItem` inside a battle: the effect has already landed on the
+## party the battle owns, so all the world does is take the row down by one.
 func _on_battle_item_used(item: int, _target: int) -> void:
 	if _world == null or _world.inventory == null:
 		return
@@ -7735,11 +7759,15 @@ func _open_pokedex_entry(request: Dictionary) -> bool:
 	if species <= 0:
 		return false
 	var host := Gen2PokedexScreen.new()
+	## The fight that asked for the page draws on a screen of its own: given the
+	## world's, the page is drawn under the battle and nobody can see it.
+	host.set_screen(
+		_battle_host.hardware_screen() if _battle_host != null else _screen
+	)
 	if not host.open_entry(_data, _world, species):
 		host.free()
 		return false
 	host.z_index = 10
-	host.set_screen(_screen)
 	add_child(host)
 	host.closed.connect(_on_pokedex_entry_closed)
 	host.cry_requested.connect(_on_pokedex_cry_requested)

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -2139,6 +2139,54 @@ func test_a_first_catch_says_its_dex_line_and_asks_for_the_page() -> void:
 	assert_eq(asked.size(), 1, "and the page was asked for once")
 
 
+## `NewPokedexEntry` stands in front of the fight that asked for it, so the B
+## that closes the page has to reach the page. Routed to the battle, that press
+## was swallowed by a fight already waiting on the page and neither ever moved:
+## a first catch of a species froze with the entry on screen.
+func test_the_new_dex_page_takes_the_press_that_closes_it() -> void:
+	await _open_world()
+	_world_screen._world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, true)
+	assert_true(bool(_world_screen._world.state.apply_changes(
+		{}, {}, {"items": {Gen2WorldPartyHost.ITEM_MASTER_BALL: 1}}
+	).get("ok", false)))
+	_world_screen.preview_wild_encounter()
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	var host: Gen2BattleScreen = _battle_host()
+	assert_not_null(host)
+	assert_true(host.begin_capture()["ok"])
+	assert_true(host.select_capture_ball(
+		host.available_capture_balls().find(Gen2WorldPartyHost.ITEM_MASTER_BALL)
+	)["ok"])
+	assert_true(host.throw_capture_ball()["ok"])
+	_settle_frames(host)
+	for _frame: int in 1200:
+		if _world_screen.get("_pokedex_host") != null:
+			break
+		_world_screen.press_button(Gen2Button.A)
+		_world_screen.advance_frame()
+	var page: Gen2PokedexScreen = _world_screen.get("_pokedex_host")
+	assert_not_null(page, "the page opened over the fight")
+	assert_eq(
+		page.get("_screen"), host.hardware_screen(),
+		"and drew on the fight's own screen rather than under it"
+	)
+
+	_world_screen.press_button(Gen2Button.B)
+	assert_null(_world_screen.get("_pokedex_host"), "and the page took the press")
+	for _frame: int in 1200:
+		if host.get("_capture_nickname_host") != null:
+			break
+		_world_screen.press_button(Gen2Button.A)
+		_world_screen.advance_frame()
+	assert_not_null(
+		host.get("_capture_nickname_host"),
+		"the catch runs on to `AskGiveNicknameText` behind the page"
+	)
+	await get_tree().process_frame
+
+
 ## A species already in the dex adds no data and opens no page.
 func test_a_catch_of_a_known_species_says_no_dex_line() -> void:
 	await _open_world()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -16,6 +16,7 @@ const KIND_HELP: Dictionary = {
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
 	&"battle": "cell: the wild fight preview_battle_request starts, settled past its transition",
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
+	&"catch_dex": "none: NewPokedexEntry's page, over the fight the catch that opened it is still in",
 	&"cut": "cell: OWCutAnimation's two halves and the jump shadow",
 	&"tile_anim": "frames: the map that many AnimateTileset frames in",
 	&"unown_wall": "cell: DisplayUnownWords' box. Group 3 maps 23 to 26 say HO-OH, ESCAPE, WATER, LIGHT",
@@ -317,7 +318,7 @@ const SELF_DRIVEN_KINDS: Array[StringName] = [
 	&"catch_tutorial",
 	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 	&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
-	&"catch_nickname", &"mom_bank", &"bills_pc", &"players_pc",
+	&"catch_nickname", &"catch_dex", &"mom_bank", &"bills_pc", &"players_pc",
 	&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page",
 	&"reset_question", &"launcher_question",
 ]


### PR DESCRIPTION
A catch of a species the dex has not seen opens `NewPokedexEntry` over the fight. Two things put that page out of the player's reach.

`_handle_button` handed every press to the battle host before it offered one to any world overlay, so the page never saw the B that closes it, and the catch waiting behind the page never ran on. The game froze with the entry on screen, its Pokemon already committed to the save: a force quit came back standing on the encounter cell with the catch in the party. The battle takes a press now only while no world overlay stands in front of it.

The page was drawn under the battle as well. The fight owns a `Gen2Screen` of its own and `_open_pokedex_entry` handed the page the world's, which sits behind it; the page is given the battle's now, the way the catch's own nickname prompt already was.

`tools/preview_world.gd` grows a `catch_dex` kind that drives a real cartridge to the page, and `test_world_trainer_battle.gd` covers the press and the screen the page draws on.

| Check | Result |
|---|---|
| GUT, both tiers | 4146 of 4146 |
| Editor analyser | 0 warnings in 608 scripts |
| `validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | byte identical to main |
| Comment budget | 37786 of 37786 |