### PR TITLE
Read the three trainer scoring files against the source

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -10,9 +10,8 @@ extends RefCounted
 ## which is an argmin rather than a rule, so [method choose_slot] takes it
 ## directly. Percent chances use the cartridge's `X * 255 / 100` macro.
 
-## Everything one scoring layer is allowed to read, gathered once so a handler
-## takes the fact it needs rather than a thirteenth positional argument.
-## The cartridge reads all of this straight out of WRAM; this is that page.
+## Everything one scoring layer is allowed to read, which the cartridge reads
+## straight out of WRAM.
 class Context extends RefCounted:
 	var attacker: Gen2BattleMon = null
 	var defender: Gen2BattleMon = null
@@ -86,29 +85,21 @@ const STATUS_ONLY_EFFECTS: Array = [
 	Gen2MoveEffect.SLEEP, Gen2MoveEffect.TOXIC, Gen2MoveEffect.POISON, Gen2MoveEffect.PARALYZE,
 ]
 
-## [constant RomLayout.AI_AGGRESSIVE] does not punish a move for dealing less
-## damage than the hardest hitter if losing the mon over it is the point.
-## Effect bytes, not moves: Selfdestruct and Explosion share one, and so do
-## every double and multi-hit move.
+## `RecklessMoves`, exempt from `AI_Aggressive`'s punishment. Effect bytes, not
+## moves: Selfdestruct and Explosion share one, and so does every multi-hit.
 const RECKLESS_EFFECTS: Array = [7, 27, 29, 44] # SELFDESTRUCT, RAMPAGE, MULTI_HIT, DOUBLE_HIT
 
-## [constant RomLayout.AI_RISKY] treats these two as a special case: a move
-## that faints the user (Selfdestruct, Explosion) or skips the damage formula
-## for a guaranteed kill (Horn Drill, Fissure, Guillotine, Sheer Cold) is worth
-## holding back on unless already hurt.
+## `RiskyEffects`: a move that faints the user or skips the formula for a
+## guaranteed kill, held back on unless the user is already hurt.
 const RISKY_EFFECTS: Array = [7, 38] # SELFDESTRUCT, OHKO
 
-## [constant RomLayout.AI_OPPORTUNIST] discourages these particular moves, by
-## number, once its own HP is low: `data/battle/ai/stall_moves.asm` in
-## pokecrystal. Every one of them either does nothing to the opponent's HP or
-## buys time, which is a poor trade when the trade might not come.
+## `data/battle/ai/stall_moves.asm`, by move number: what `AI_Opportunist`
+## discourages once its own HP is low.
 const STALL_MOVE_NUMBERS: Array = [
 	14, 39, 43, 45, 50, 54, 68, 73, 74, 81, 96, 97, 99, 102, 103, 106, 110, 111, 112, 113, 114,
 	115, 116, 117, 133, 144, 150, 151, 159, 160, 164, 172,
 ]
 
-## The screen each of the three screen moves would raise, which is the whole of
-## `AI_Redundant`'s `.LightScreen`, `.Reflect` and `.Safeguard`.
 ## `AI_Redundant`'s rows that are one substatus bit on the target, by the move
 ## effect that would set it.
 const REDUNDANT_TARGET_SUBSTATUS: Dictionary = {
@@ -172,19 +163,15 @@ const USEFUL_MOVE_NUMBERS: Array[int] = [
 ## exempts.
 const SANDSTORM_IMMUNE_TYPES: Array = Gen2Weather.SANDSTORM_EXEMPT_TYPES
 
-## [constant RomLayout.AI_CAUTIOUS] discourages these once it is no longer the
-## first turn, because a move whose value is a residual effect (Leech Seed,
-## Toxic-family status, a screen) has usually already paid for itself or not
-## at all by then: `data/battle/ai/residual_moves.asm` in pokecrystal.
+## `data/battle/ai/residual_moves.asm`, by move number: what `AI_Cautious`
+## discourages once the first turn has passed.
 const RESIDUAL_MOVE_NUMBERS: Array = [54, 73, 77, 78, 86, 116, 117, 139, 144, 160, 164, 191]
 
 
-## What the enemy does with its turn: pull its Pokemon out, reach for an item, or
-## use a move. `AI_SwitchOrTryItem`, which runs before the turn and settles ahead
-## of it: switching is considered first and an item only when it is refused,
-## which is the cartridge's `DontSwitch` fallthrough rather than a separate
-## decision. [param item_switch_flags] is the class's own
-## [constant RomLayout.ATTR_AI_ITEM_SWITCH].
+## `AI_SwitchOrTryItem`: pull the Pokemon out, reach for an item, or use a move.
+## An item is only considered once the switch is refused, which is the
+## cartridge's `DontSwitch` fallthrough. [param item_switch_flags] is the class's
+## own [constant RomLayout.ATTR_AI_ITEM_SWITCH].
 static func choose_action(
 	battle: Gen2Battle, item_switch_flags: int, move_slot: int, rng: RandomNumberGenerator
 ) -> Dictionary:
@@ -236,13 +223,11 @@ static func _locked_in(mon: Gen2BattleMon) -> bool:
 
 
 ## Picks a move slot for [param attacker] against [param defender], scored the
-## way [param ai_move_weights] says to. The two turn counts are `wEnemyTurnsTaken`
-## and `wPlayerTurnsTaken` read before the turn is spent, which is when the
-## cartridge reads them; every handler wants the same thing out of them, whether
-## this is the Pokemon's first turn out. [param has_bench] and
-## [param matchup_score] are `FindAliveEnemyMons` and `CheckPlayerMoveTypeMatchups`
-## supplied rather than read, since this scores a pairing rather than a battle.
-## Always returns a slot in range: an unusable one becomes Struggle.
+## way [param ai_move_weights] says to. The two turn counts are
+## `wEnemyTurnsTaken` and `wPlayerTurnsTaken` read before the turn is spent.
+## [param has_bench] and [param matchup_score] are `FindAliveEnemyMons` and
+## `CheckPlayerMoveTypeMatchups` supplied rather than read, since this scores a
+## pairing rather than a battle.
 static func choose_slot(
 	attacker: Gen2BattleMon,
 	defender: Gen2BattleMon,
@@ -348,6 +333,12 @@ static func _move_at(mon: Gen2BattleMon, data: GameData, slot: int) -> Dictionar
 	return data.move(int(mon.moves[slot]))
 
 
+## The `ld a, [de] / and a / ret z` every scoring loop opens with: an empty slot
+## ends the walk, and PP and Disable are not asked about anywhere in this file.
+static func _is_empty_slot(mon: Gen2BattleMon, slot: int) -> bool:
+	return slot >= mon.moves.size() or int(mon.moves[slot]) == 0
+
+
 static func _effect(move: Dictionary) -> int:
 	return int(move.get("effect", 0))
 
@@ -405,6 +396,12 @@ const AI_79_PERCENT_MINUS_ONE: int = 200
 ## `28 percent - 1`, which is 70, and `AI_Smart_Encore` alone.
 const AI_28_PERCENT_MINUS_ONE: int = 70
 
+## `90 percent + 1`, which is 230: `AI_Cautious`'s own roll.
+const AI_90_PERCENT_PLUS_ONE: int = 230
+
+## `31 percent + 1`, which is 80, and the badly-poisoned arm of the evasion tail.
+const AI_31_PERCENT_PLUS_ONE: int = 80
+
 ## `EncoreMoves`: what the AI thinks is worth locking the player into, by move
 ## number. `AI_Smart_Encore` reads it only for a move it has already decided is
 ## weak against the enemy in front of it.
@@ -424,12 +421,9 @@ static func _skip_80_20(rng: RandomNumberGenerator) -> bool:
 	return rng.randi_range(0, 255) < 50
 
 
-## [constant RomLayout.AI_BASIC]: nothing redundant. A status move against an
-## already-statused target, confusion against a confused one, Disable or Encore
-## against a locked one, Attract against a target in love or of the same or
-## unknown gender, and a second Mist or Focus Energy, which is why those two read
-## the attacker rather than the defender. A standing Substitute reads the attacker
-## for the same reason; Leech Seed, Nightmare and Spikes read the target.
+## [constant RomLayout.AI_BASIC]: nothing redundant. Mist, Focus Energy,
+## Substitute and Mean Look read the attacker's own side, because that is where
+## each of them lands; everything else reads the target's.
 static func _apply_basic(scores: Array, c: Context) -> void:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if not c.attacker.can_use(slot):
@@ -452,7 +446,10 @@ static func _is_redundant(effect: int, c: Context) -> bool:
 	if WEATHER_FOR_EFFECT.has(effect):
 		return c.weather == int(WEATHER_FOR_EFFECT[effect])
 	if STATUS_ONLY_EFFECTS.has(effect):
-		return Gen2Status.is_afflicted(c.defender.status)
+		# `AI_Basic`'s two clauses behind `StatusOnlyEffects`: a target that
+		# already carries a status, and one standing behind its own Safeguard.
+		return Gen2Status.is_afflicted(c.defender.status) \
+			or Gen2Screens.has(c.defender_screens, Gen2Screens.SAFEGUARD)
 	# Four labels on one body: healing a full bar does nothing, whatever the
 	# weather would have made of it.
 	if HEALING_EFFECTS.has(effect):
@@ -806,10 +803,8 @@ static func _smart_stomp(scores: Array, slot: int, c: Context) -> void:
 static func _smart_fly_or_dig(scores: Array, slot: int, c: Context) -> void:
 	if _is_semi_invulnerable(c.defender) and _faster(c.attacker, c.defender):
 		_encourage(scores, slot, 3)
-## `AI_Smart_MirrorMove`: without a remembered player move, a faster AI
-## dismisses Mirror Move because it will act before seeing one. A useful
-## remembered move gets one 50% encouragement and, when the AI is faster, a
-## second 90% encouragement.
+## `AI_Smart_MirrorMove`: a faster AI acts before seeing a move, so with nothing
+## remembered it dismisses this.
 static func _smart_mirror_move(scores: Array, slot: int, c: Context) -> void:
 	var copied: int = c.defender.last_counter_move
 	if copied == 0:
@@ -824,10 +819,8 @@ static func _smart_mirror_move(scores: Array, slot: int, c: Context) -> void:
 		_encourage(scores, slot, 1)
 
 
-## `AI_Smart_Mimic`: wait for a move when slower, dismiss the blind attempt
-## when faster, and only copy above half health. A resisted last move is
-## discouraged; a super-effective or source-listed useful one gets its own 50%
-## encouragement.
+## `AI_Smart_Mimic`: wait for a move when slower, dismiss the blind attempt when
+## faster, and only copy above half health.
 static func _smart_mimic(scores: Array, slot: int, c: Context) -> void:
 	var copied: int = c.defender.last_counter_move
 	if copied == 0:
@@ -856,9 +849,7 @@ static func _smart_mimic(scores: Array, slot: int, c: Context) -> void:
 
 
 ## `AI_Smart_Snore` and `AI_Smart_SleepTalk` are one source body. A sleep count
-## of one wakes before the move and is discouraged; every other value gets the
-## smart layer's encouragement. The basic layer independently discourages the
-## awake case, leaving it a bad choice overall as on the cartridge.
+## of one wakes before the move; every other value is encouraged.
 static func _smart_sleep_talk(scores: Array, slot: int, c: Context) -> void:
 	if (c.attacker.status & Gen2Status.SLEEP_MASK) == 1:
 		_discourage(scores, slot, 3)
@@ -866,12 +857,11 @@ static func _smart_sleep_talk(scores: Array, slot: int, c: Context) -> void:
 		_encourage(scores, slot, 3)
 
 
-## `AI_Smart_Conversion2`'s documented bug: once the player has a remembered
-## move, the smart layer almost always discourages the very response designed
-## for it. The no-last-move branch reads past move zero in the cartridge; this
-## model leaves that undefined lookup neutral rather than inventing ROM bytes.
+## `AI_Smart_Conversion2`'s documented bug: a remembered move almost always
+## discourages the very response designed for it. The no-last-move branch reads
+## past move zero on the cartridge and is left neutral here.
 static func _smart_conversion_2(scores: Array, slot: int, c: Context) -> void:
-	if c.defender.last_counter_move != 0 and not _rolls_under(c.rng, 25):
+	if c.defender.last_move_used != 0 and not _rolls_under(c.rng, 25):
 		_discourage(scores, slot, 1)
 
 
@@ -910,11 +900,9 @@ static func _smart_sandstorm(scores: Array, slot: int, c: Context) -> void:
 		_encourage(scores, slot, 1)
 
 
-## `AI_Smart_RainDance` and `AI_Smart_SunnyDay`, one routine with two type pairs:
-## the weather is a bad idea if it would suit the target and a good one if it
-## would hurt it, and otherwise worth setting only with a move that wants it. The
-## two types are tested in the cartridge's order, so a Water/Fire target under
-## Rain Dance is a Water target.
+## `AI_Smart_RainDance` and `AI_Smart_SunnyDay`, one routine with two type pairs.
+## The two types are tested in the cartridge's order, so a Water/Fire target
+## under Rain Dance is a Water target.
 static func _smart_weather_move(
 	scores: Array, slot: int, c: Context, favours_target: int, disfavours_target: int, wanted_moves: Array
 ) -> void:
@@ -953,12 +941,9 @@ static func _good_weather_type(
 		_encourage(scores, slot, 2)
 
 
-## `AI_Smart_TrapTarget`: pointless against a target already bound, and worth two
-## against one that is losing health anyway or has only just come out, provided
-## the user has enough left to hold it there.
-##
-## The five states it encourages on are Toxic and the four bits
-## `and 1 << SUBSTATUS_IN_LOVE | 1 << SUBSTATUS_ROLLOUT | 1 << SUBSTATUS_IDENTIFIED
+## `AI_Smart_TrapTarget`: pointless against a target already bound. The five
+## states it encourages on are Toxic and the four bits
+## `1 << SUBSTATUS_IN_LOVE | 1 << SUBSTATUS_ROLLOUT | 1 << SUBSTATUS_IDENTIFIED
 ## | 1 << SUBSTATUS_NIGHTMARE` tests in one instruction.
 static func _smart_trap_target(scores: Array, slot: int, c: Context) -> void:
 	var worth_it: bool = c.defender.trapped_turns <= 0 and (
@@ -1004,7 +989,7 @@ static func _smart_reset_stats(scores: Array, slot: int, c: Context) -> void:
 static func _smart_confuse(scores: Array, slot: int, c: Context) -> void:
 	if _above_half(c.defender):
 		return
-	if _roll(c.rng, 90):
+	if not _roll(c.rng, 10):
 		_discourage(scores, slot, 1)
 	if not _above_quarter(c.defender):
 		_discourage(scores, slot, 1)
@@ -1083,11 +1068,9 @@ static func _smart_pain_split(scores: Array, slot: int, c: Context) -> void:
 		_discourage(scores, slot, 1)
 
 
-## `AI_Smart_LockOn`, whose two halves ask opposite questions. With the player
-## already locked on, aiming again is wasted: every inaccurate move the enemy
-## knows is encouraged instead and Lock On itself is dismissed, the walk stopping
-## at the first empty slot. Without it the ladder is health, then speed, then
-## whether the accuracy is actually a problem.
+## `AI_Smart_LockOn`, whose two halves ask opposite questions. Already locked on,
+## every inaccurate move the enemy knows is encouraged and Lock On is dismissed.
+## Without it the ladder is health, then speed, then the accuracy itself.
 static func _smart_lock_on(scores: Array, slot: int, c: Context) -> void:
 	if Gen2Substatus.has(c.defender.substatus, Gen2Substatus.LOCK_ON):
 		for other: int in Gen2BattleMon.MAX_MOVES:
@@ -1152,11 +1135,9 @@ static func _lock_on_has_wanting_move(
 const LOCK_ON_WANTED_ACCURACY: int = 180
 
 
-## `AI_Smart_Spite`: worth it against a move the target is nearly out of, wasted
-## against one it has plenty of.
-##
-## The target has not moved yet in the first branch, so there is nothing to drain
-## and the question is only whether the enemy would get to see a move first.
+## `AI_Smart_Spite`: worth it against a move the target is nearly out of. With
+## nothing remembered there is nothing to drain, so the first branch only asks
+## whether the enemy would get to see a move at all.
 static func _smart_spite(scores: Array, slot: int, c: Context) -> void:
 	var last_move: int = c.defender.last_counter_move
 	if last_move == 0:
@@ -1214,15 +1195,16 @@ static func _smart_foresight(scores: Array, slot: int, c: Context) -> void:
 	_encourage(scores, slot, 2)
 
 
-## `AI_Smart_MeanLook`: the source only wants the trap from above half health,
-## with a live bench, or against a player who is already trapped in a costly
-## state. The Toxic branch is intentionally the cartridge's bug: it encourages
-## Mean Look because the AI's own Pokémon is badly poisoned.
+## `AI_Smart_MeanLook`: the trap wants half health and a player with somewhere
+## to run. The Toxic branch is the cartridge's own bug, encouraging Mean Look
+## because the AI's own Pokémon is badly poisoned.
 static func _smart_mean_look(scores: Array, slot: int, c: Context) -> void:
-	if c.attacker.hp * 2 < c.attacker.max_hp():
-		_discourage(scores, slot)
+	if not _above_half(c.attacker):
+		_discourage(scores, slot, 1)
 		return
-	if not c.has_bench:
+	# `AICheckLastPlayerMon`: the *player's* bench, not the AI's. A trap is only
+	# worth setting on somebody who has somewhere else to be.
+	if not c.defender_has_bench:
 		_discourage(scores, slot)
 		return
 
@@ -1260,10 +1242,7 @@ static func _smart_pursuit(scores: Array, slot: int, c: Context) -> void:
 	_discourage(scores, slot, 1)
 
 
-## `AI_Smart_Protect`: one ladder of tests, first match winning, and the two exits
-## are asymmetric. `.encourage` is an 80% roll and one point off; `.discourage` is
-## a two-point penalty that an 8% roll skips outright, and `.greatly_discourage`
-## adds a point and falls into it, so the worst case is three.
+## `AI_Smart_Protect`: one ladder of tests, first match winning.
 ##
 static func _smart_protect(scores: Array, slot: int, c: Context) -> void:
 	if c.attacker.protect_count != 0:
@@ -1318,11 +1297,9 @@ static func _smart_protect_discourage(
 const PROTECT_DISCOURAGE_SKIP_PERCENT: int = 8
 
 
-## `AI_Smart_Endure`: the same opening test as Protect, then health, then the one
-## reason to want to survive on a single point. Reversal is looked for by effect
-## rather than by move number, which is `AIHasMoveEffect`, and Flail carries the
-## same byte. `.no_reversal` is the other reason: `wEnemySubStatus5`, the flag a
-## Lock On the player used left on the enemy.
+## `AI_Smart_Endure`: Protect's opening test, then health, then the one reason to
+## survive on a single point. Reversal is looked for by effect, so Flail counts
+## too; `.no_reversal` reads the enemy's own Lock On flag.
 static func _smart_endure(scores: Array, slot: int, c: Context) -> void:
 	if c.attacker.protect_count != 0 or _at_max_hp(c.attacker):
 		_discourage(scores, slot, 2)
@@ -1343,11 +1320,6 @@ static func _smart_endure(scores: Array, slot: int, c: Context) -> void:
 
 
 ## `AIHasMoveEffect`: whether this Pokémon knows any move carrying [param effect].
-##
-## An empty slot ends the search rather than being skipped, which is the source's
-## own `and a / jr z, .no`, and PP and Disable are not asked about at all. The
-## first costs nothing on a packed move list and is kept because the list is only
-## packed by convention.
 static func _has_move_effect(mon: Gen2BattleMon, data: GameData, effect: int) -> bool:
 	for slot: int in Gen2BattleMon.MAX_MOVES:
 		if slot >= mon.moves.size() or int(mon.moves[slot]) == 0:
@@ -1418,8 +1390,8 @@ static func _apply_aggressive(scores: Array, c: Context) -> void:
 	var best_slot: int = -1
 	var best_damage: int = -1
 	for slot: int in Gen2BattleMon.MAX_MOVES:
-		if not attacker.can_use(slot):
-			continue
+		if _is_empty_slot(attacker, slot):
+			break
 		var move: Dictionary = _move_at(attacker, data, slot)
 		if _power(move) <= 0:
 			continue
@@ -1428,11 +1400,14 @@ static func _apply_aggressive(scores: Array, c: Context) -> void:
 			best_damage = damage
 			best_slot = slot
 
-	if best_slot == -1 or best_damage <= 0:
+	# `.gotstrongestmove` only refuses on `c` still zero, which is no damaging
+	# move at all. A move the player is immune to has already set `c`, so a
+	# whole moveset that lands for nothing still discourages all but the last.
+	if best_slot == -1:
 		return
 
 	for slot: int in Gen2BattleMon.MAX_MOVES:
-		if slot == best_slot or not attacker.can_use(slot):
+		if slot == best_slot or _is_empty_slot(attacker, slot):
 			continue
 		var move: Dictionary = _move_at(attacker, data, slot)
 		if _power(move) < 2:
@@ -1442,14 +1417,11 @@ static func _apply_aggressive(scores: Array, c: Context) -> void:
 		_discourage(scores, slot, 1)
 
 
-## `AIDamageCalc`: the AI's own damage prediction, which is `EnemyAttackDamage`
-## and `BattleCommand_DamageCalc` themselves rather than an approximation, so it
-## reads the player's screens exactly as a real hit would.
+## `AIDamageCalc`: `EnemyAttackDamage` and `BattleCommand_DamageCalc` themselves,
+## so it reads the player's screens exactly as a real hit would.
 ## [constant Gen2Damage.CONSTANT_DAMAGE_EFFECTS] answers with
-## `BattleCommand_ConstantDamage`'s own number instead; without that branch
-## Seismic Toss, Night Shade and Super Fang are read at power 1. [param constant]
-## is what `AI_Smart_PriorityHit` is missing. Psywave's prediction really rolls,
-## and the roll is spent on the one generator both sides share.
+## `BattleCommand_ConstantDamage`'s own number; [param constant] is the branch
+## `AI_Smart_PriorityHit` is missing.
 static func _estimate_damage(c: Context, move: Dictionary, constant: bool = true) -> int:
 	var effect: int = _effect(move)
 	if constant and Gen2Damage.CONSTANT_DAMAGE_EFFECTS.has(effect):
@@ -1480,30 +1452,39 @@ static func _apply_cautious(scores: Array, c: Context) -> void:
 		var move: Dictionary = _move_at(attacker, data, slot)
 		if not RESIDUAL_MOVE_NUMBERS.has(int(move.get("number", 0))):
 			continue
-		if _roll(rng, 90):
+		if _rolls_under(rng, AI_90_PERCENT_PLUS_ONE):
 			_discourage(scores, slot, 1)
 		elif Gen2Rules.hardware(&"cautious_ai_abandons_remaining_moves"):
 			return
 
 
-## [constant RomLayout.AI_STATUS]: dismiss a status move the defender's typing
-## shrugs off. Toxic and Poison need no poison-type shortcut, since a Poison-type
-## defender against a Poison-type move already reads
-## [constant RomLayout.MATCHUP_NO_EFFECT] out of the real chart.
+## [constant RomLayout.AI_STATUS]: dismiss anything the defender's typing shrugs
+## off. Its comment says status moves; the code reads the four named status
+## effects and then every move that does damage, and passes over the rest.
 static func _apply_status(scores: Array, c: Context) -> void:
 	var attacker: Gen2BattleMon = c.attacker
 	var defender: Gen2BattleMon = c.defender
 	var data: GameData = c.data
 	for slot: int in Gen2BattleMon.MAX_MOVES:
-		if not attacker.can_use(slot):
-			continue
+		if _is_empty_slot(attacker, slot):
+			break
 		var move: Dictionary = _move_at(attacker, data, slot)
 		var effect: int = _effect(move)
-		if not STATUS_ONLY_EFFECTS.has(effect) and _power(move) > 0:
-			continue
+		if effect == Gen2MoveEffect.TOXIC or effect == Gen2MoveEffect.POISON:
+			# `.poisonimmunity` stands in front of the chart, and the chart
+			# cannot answer it: Poison against Poison is resisted rather than
+			# refused, and Steel is the only typing the move itself cannot touch.
+			if defender.types().has(RomLayout.TYPE_POISON):
+				_discourage(scores, slot)
+				continue
+		elif effect != Gen2MoveEffect.SLEEP and effect != Gen2MoveEffect.PARALYZE:
+			# Everything past the four named effects is read only when it does
+			# damage, so this layer dismisses an immune attack and passes over a
+			# status move it has no rule for.
+			if _power(move) <= 0:
+				continue
 
-		var move_type: int = int(move.get("type", RomLayout.TYPE_NORMAL))
-		if data.type_effectiveness(move_type, defender.types()) == RomLayout.MATCHUP_NO_EFFECT:
+		if _matchup(c, move) == RomLayout.MATCHUP_NO_EFFECT:
 			_discourage(scores, slot)
 
 
@@ -1526,10 +1507,10 @@ static func _apply_risky(scores: Array, c: Context) -> void:
 		if RISKY_EFFECTS.has(_effect(move)):
 			if _at_max_hp(attacker):
 				continue
-			if _roll(rng, 79):
+			if _rolls_under(rng, AI_79_PERCENT_MINUS_ONE):
 				continue
 
-		if _estimate_damage(c, move) >= defender.hp:
+		if _estimate_damage(c, move) > defender.hp:
 			_encourage(scores, slot, 5)
 
 
@@ -1593,7 +1574,7 @@ static func _smart_selfdestruct(scores: Array, slot: int, c: Context) -> void:
 ## already made up its mind.
 static func _evasion_tail(scores: Array, slot: int, c: Context) -> void:
 	if _badly_poisoned(c.defender):
-		if not _rolls_under(c.rng, AI_39_PERCENT_PLUS_ONE):
+		if not _rolls_under(c.rng, AI_31_PERCENT_PLUS_ONE):
 			_encourage(scores, slot, 2)
 		return
 	if Gen2Substatus.has(c.defender.substatus, Gen2Substatus.LEECH_SEED):
@@ -1774,9 +1755,8 @@ static func _smart_disable(scores: Array, slot: int, c: Context) -> void:
 	_discourage(scores, slot, 1)
 
 
-## `AI_Smart_Counter` and `AI_Smart_MirrorCoat`, which are one routine reading
-## the other half of the physical/special split: three remembered hits of the
-## right half make it worth the guess, and the last one seen decides a tie.
+## `AI_Smart_Counter` and `AI_Smart_MirrorCoat`, one routine reading either half
+## of the physical/special split.
 static func _smart_counter(scores: Array, slot: int, c: Context, physical: bool) -> void:
 	var seen: int = 0
 	for number: int in c.defender_used_moves:
@@ -1866,9 +1846,7 @@ static func _smart_priority_hit(scores: Array, slot: int, c: Context) -> void:
 		_encourage(scores, slot, 3)
 
 
-## `AI_Smart_Curse`, two routines under one label: a Ghost pays half its own HP
-## and wants the trade to be the last one, and everything else is reading
-## whether an attack raise will be spent.
+## `AI_Smart_Curse`, two routines under one label, split on the user's typing.
 static func _smart_curse(scores: Array, slot: int, c: Context) -> void:
 	if c.attacker.types().has(RomLayout.TYPE_GHOST):
 		_smart_ghost_curse(scores, slot, c)
@@ -1918,8 +1896,7 @@ static func _smart_ghost_curse(scores: Array, slot: int, c: Context) -> void:
 		_encourage(scores, slot, 2)
 
 
-## `AI_Smart_Rollout`: a run that has to survive several turns, so anything that
-## might interrupt it, or any accuracy gap, is a reason to stop.
+## `AI_Smart_Rollout`: anything that might interrupt the run is a reason to stop.
 static func _smart_rollout(scores: Array, slot: int, c: Context) -> void:
 	var risky: bool = Gen2Substatus.has(
 		c.attacker.substatus, Gen2Substatus.ATTRACTED | Gen2Substatus.CONFUSED
@@ -1962,9 +1939,7 @@ static func _smart_attract(scores: Array, slot: int, c: Context) -> void:
 	_encourage(scores, slot, 1)
 
 
-## `AI_Smart_Earthquake` and `AI_Smart_Gust`: the same routine reading Dig or
-## Fly. A player already underground or airborne is punished from in front, and
-## one that has only used the move before is a guess taken from behind.
+## `AI_Smart_Earthquake` and `AI_Smart_Gust`, one routine reading Dig or Fly.
 static func _smart_ground_or_air(
 	scores: Array, slot: int, c: Context, move_number: int, flag: int
 ) -> void:

--- a/game/battle/ai_switch.gd
+++ b/game/battle/ai_switch.gd
@@ -296,14 +296,36 @@ static func _alive_enough_to_switch(battle: Gen2Battle) -> bool:
 
 
 ## `FindEnemyMonsWithAtLeastQuarterMaxHP`, narrowing whoever was passed in.
+##
+## The name is the only quarter in it. `AICheckEnemyQuarterHP` doubles the HP
+## word twice with `sla c / rl b`; this routine writes `srl c / rl b`, so the low
+## byte is halved twice while the high byte is doubled twice and picks up the two
+## bits falling out of it. The comparison is then strictly greater, not the
+## comment's `>=`. Both pins ship it. See [method _shifted_hp].
 static func _at_least_quarter_hp(battle: Gen2Battle, candidates: Array) -> Array:
 	var party: Gen2Party = battle.party(Gen2Battle.ENEMY)
 	var out: Array = []
 	for index: int in candidates:
 		var member: Gen2BattleMon = party.at(int(index))
-		if member != null and member.hp * 4 >= member.max_hp():
+		if member != null and _shifted_hp(member.hp) > member.max_hp():
 			out.append(index)
 	return out
+
+
+## The `srl c / rl b` pair run twice over the HP word, as a number.
+##
+## For a maximum HP under 256 the whole thing comes to "current HP is not a
+## multiple of four": the high byte ends up holding the two bits the low byte
+## dropped, so anything but a multiple of four lands over 255 and clears any
+## maximum a party member can have.
+static func _shifted_hp(hp: int) -> int:
+	var high: int = (hp >> 8) & 0xFF
+	var low: int = hp & 0xFF
+	for _pass: int in 2:
+		var carry: int = low & 1
+		low >>= 1
+		high = ((high << 1) | carry) & 0xFF
+	return high * 256 + low
 
 
 ## `FindEnemyMonsThatResistPlayer`: nobody who would be hit super effectively by

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -385,24 +385,26 @@ func test_basic_discourages_a_second_mean_look_from_the_same_pokemon() -> void:
 		)
 
 
-## `AI_Smart_MeanLook`: a healthy user with a bench wants the trap against a
-## costly target state, while a low-health user or a lone user dismisses it.
+## `AI_Smart_MeanLook`: a healthy user wants the trap against a costly target
+## state, as long as the target has somewhere else to go. `AICheckLastPlayerMon`
+## reads the *player's* bench, and a user below half health is worth one point
+## against rather than the ten a dismissal costs.
 func test_smart_mean_look_reads_health_bench_and_target_state() -> void:
 	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MEAN_LOOK, Fixture.TACKLE])
 	var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
 
 	var lone: Array = [20, 20, 20, 20]
 	Gen2BattleAI._apply_smart(
-		lone, Gen2BattleAI.Context.of(pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.NONE, false, Gen2AISwitch.BASE_SCORE)
+		lone, Gen2BattleAI.Context.of(pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE, false)
 	)
-	assert_eq(int(lone[0]), 30, "a lone user cannot leave behind a Mean Look")
+	assert_eq(int(lone[0]), 30, "a target with nobody behind it has nothing to escape to")
 
 	pikachu.hp = pikachu.max_hp() / 4
 	var hurt: Array = [20, 20, 20, 20]
 	Gen2BattleAI._apply_smart(
-		hurt, Gen2BattleAI.Context.of(pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE)
+		hurt, Gen2BattleAI.Context.of(pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE, true)
 	)
-	assert_eq(int(hurt[0]), 30, "a user below half health should not trap")
+	assert_eq(int(hurt[0]), 21, "a user below half health is discouraged, not dismissed")
 
 	pikachu.hp = pikachu.max_hp()
 	charmander.substatus |= Gen2Substatus.IDENTIFIED
@@ -411,7 +413,7 @@ func test_smart_mean_look_reads_health_bench_and_target_state() -> void:
 		_rng.seed = seed_value
 		var scores: Array = [20, 20, 20, 20]
 		Gen2BattleAI._apply_smart(
-			scores, Gen2BattleAI.Context.of(pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE - 1)
+			scores, Gen2BattleAI.Context.of(pikachu, charmander, _data, _rng, 0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.NONE, true, Gen2AISwitch.BASE_SCORE - 1, true)
 		)
 		wanted[int(scores[0])] = true
 	assert_true(wanted.has(17), "an identified target reaches Mean Look's strong branch")
@@ -1244,7 +1246,7 @@ func test_smart_conversion2_reproduces_the_source_last_move_bug() -> void:
 		Gen2BattleAI.DEFAULT_SCORE,
 		"with no remembered move the fixture's undefined lookup leaves it alone"
 	)
-	geodude.last_counter_move = Fixture.TACKLE
+	geodude.last_move_used = Fixture.TACKLE
 	var spread: Dictionary = _score_spread(pikachu, geodude, RomLayout.AI_SMART, 0)
 	assert_true(spread.has(Gen2BattleAI.DEFAULT_SCORE + 1), "the 90% discouragement")
 	assert_true(spread.has(Gen2BattleAI.DEFAULT_SCORE), "and the 10% that skips it")
@@ -1728,3 +1730,86 @@ func test_smart_rapid_spin_reads_the_enemys_own_side() -> void:
 			seen.append(score)
 	seen.sort()
 	assert_eq(seen, [Gen2BattleAI.DEFAULT_SCORE - 2, Gen2BattleAI.DEFAULT_SCORE])
+
+
+## `AI_Status`'s power gate runs the other way round from its own comment: the
+## four named status effects and every damaging move are read against the chart,
+## and a non-damaging move with no named effect is passed over untouched.
+func test_status_reads_damaging_moves_and_skips_the_rest() -> void:
+	var pikachu: Gen2BattleMon = _mon(
+		Fixture.PIKACHU, 50, [Fixture.THUNDERBOLT, Fixture.THUNDER_WAVE]
+	)
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var scores: Array = _scores(pikachu, geodude, RomLayout.AI_STATUS)
+	assert_eq(int(scores[0]), 30, "an immune damaging move is dismissed")
+	assert_eq(int(scores[1]), 30, "and so is an immune paralysis")
+
+	var trapper: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.MEAN_LOOK])
+	var gastly: Gen2BattleMon = _mon(Fixture.GASTLY, 50, [Fixture.TACKLE])
+	assert_eq(
+		int(_scores(trapper, gastly, RomLayout.AI_STATUS)[0]), 20,
+		"a non-damaging move with no named status effect is passed over"
+	)
+
+
+## `.poisonimmunity` stands in front of the chart, which cannot answer it: Poison
+## against Poison is resisted rather than refused.
+func test_status_dismisses_a_poisoning_move_against_a_poison_type() -> void:
+	var bulbasaur: Gen2BattleMon = _mon(Fixture.BULBASAUR, 50, [Fixture.POISON_POWDER])
+	var gastly: Gen2BattleMon = _mon(Fixture.GASTLY, 50, [Fixture.TACKLE])
+	assert_eq(int(_scores(bulbasaur, gastly, RomLayout.AI_STATUS)[0]), 30)
+
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	assert_eq(
+		int(_scores(bulbasaur, geodude, RomLayout.AI_STATUS)[0]), 20,
+		"a Rock/Ground target is not poison immune, only resistant"
+	)
+
+
+## `AI_Basic`'s second clause behind `StatusOnlyEffects`: a Safeguard the target
+## is standing behind is as good a reason as a status it already carries.
+func test_basic_discourages_a_status_move_behind_safeguard() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.THUNDER_WAVE, Fixture.TACKLE])
+	var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
+	var open: Array = Gen2BattleAI.score_slots(
+		pikachu, charmander, _data, RomLayout.AI_BASIC, _rng
+	)
+	assert_eq(int(open[0]), 20, "nothing in the way of a paralysis")
+
+	var guarded: Array = Gen2BattleAI.score_slots(
+		pikachu, charmander, _data, RomLayout.AI_BASIC, _rng, 0, 0, Gen2Weather.NONE,
+		Gen2Screens.NONE, Gen2Screens.SAFEGUARD
+	)
+	assert_eq(int(guarded[0]), 30, "a Safeguard dismisses it")
+
+
+## `.gotstrongestmove` refuses only on no damaging move at all: the first one
+## sets the winner whatever its damage came to, so a moveset that lands for
+## nothing still has all but one of it discouraged.
+func test_aggressive_still_picks_a_winner_when_every_move_is_immune() -> void:
+	var pikachu: Gen2BattleMon = _mon(
+		Fixture.PIKACHU, 50, [Fixture.THUNDERBOLT, Fixture.THUNDER]
+	)
+	var geodude: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var scores: Array = _scores(pikachu, geodude, RomLayout.AI_AGGRESSIVE)
+	assert_eq(int(scores[0]), 21, "the earlier of two equal answers is punished")
+	assert_eq(int(scores[1]), 20, "and the later one is the winner")
+
+
+## `AI_Risky`'s own comparison is `wBattleMonHP - wCurDamage`, so a hit that
+## exactly matches the bar is not a KO the AI reaches for.
+func test_risky_wants_strictly_more_damage_than_the_bar() -> void:
+	var pikachu: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.THUNDERBOLT])
+	var charmander: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
+	var context: Gen2BattleAI.Context = Gen2BattleAI.Context.of(
+		pikachu, charmander, _data, _rng
+	)
+	var damage: int = Gen2BattleAI._estimate_damage(
+		context, _data.move(Fixture.THUNDERBOLT)
+	)
+	assert_gt(damage, 1, "the fixture's Thunderbolt has to actually hurt")
+
+	charmander.hp = damage
+	assert_eq(int(_scores(pikachu, charmander, RomLayout.AI_RISKY)[0]), 20, "exactly the bar")
+	charmander.hp = damage - 1
+	assert_eq(int(_scores(pikachu, charmander, RomLayout.AI_RISKY)[0]), 15, "one under it")

--- a/tests/unit/test_ai_switch.gd
+++ b/tests/unit/test_ai_switch.gd
@@ -299,3 +299,48 @@ func test_a_perish_count_without_the_flag_changes_nothing() -> void:
 	battle.enemy.perish_count = 1
 
 	assert_eq(int(Gen2AISwitch.evaluate(battle)["tier"]), 0)
+
+
+## `FindEnemyMonsWithAtLeastQuarterMaxHP` writes `srl c / rl b` where every other
+## fraction check writes `sla c / rl b`, so the low byte halves twice while the
+## high byte doubles twice and picks up the two bits it dropped. Under a maximum
+## of 256 that comes to "current HP is not a multiple of four", and the
+## comparison is strictly greater rather than the comment's `>=`.
+func test_the_quarter_hp_scan_is_a_multiple_of_four_test() -> void:
+	for maximum: int in [7, 40, 99, 160, 255]:
+		for hp: int in range(1, maximum + 1):
+			assert_eq(
+				Gen2AISwitch._shifted_hp(hp) > maximum, (hp % 4) != 0,
+				"%d of %d" % [hp, maximum]
+			)
+
+	# A multiple of four is the only value the shift leaves inside a byte, and
+	# even then the quarter it lands on has to clear the whole maximum.
+	assert_eq(Gen2AISwitch._shifted_hp(40), 10)
+	assert_eq(Gen2AISwitch._shifted_hp(41), 522, "bit 0 lands in the high byte")
+	assert_eq(Gen2AISwitch._shifted_hp(42), 266, "and so does bit 1")
+
+
+## The scan is what the perish and no-counter branches shortlist through, so a
+## bench Pokémon whose HP is a multiple of four is dropped from it however
+## healthy it is.
+func test_the_quarter_hp_scan_drops_a_full_bench_pokemon() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.BULBASAUR, [Fixture.TACKLE]),
+		[
+			_mon(Fixture.PIKACHU, [Fixture.GROWL]),
+			_mon(Fixture.HOOTHOOT, [Fixture.EMBER]),
+			_mon(Fixture.CHARMANDER, [Fixture.EMBER]),
+		]
+	)
+	battle.enemy.substatus |= Gen2Substatus.PERISH
+	battle.enemy.perish_count = 1
+	var hoothoot: Gen2BattleMon = battle.party(Gen2Battle.ENEMY).at(1)
+	var charmander: Gen2BattleMon = battle.party(Gen2Battle.ENEMY).at(2)
+	hoothoot.hp = hoothoot.max_hp() - (hoothoot.max_hp() % 4)
+	charmander.hp = charmander.max_hp() - (charmander.max_hp() % 4) - 1
+
+	assert_eq(
+		int(Gen2AISwitch.evaluate(battle)["index"]), 2,
+		"the shortlist skips the Hoothoot sitting on a multiple of four"
+	)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37786
+const MAX_COMMENT_LINES: int = 37781
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/trainer_ai.gd
+++ b/tools/checks/trainer_ai.gd
@@ -1,0 +1,173 @@
+extends RefCounted
+
+var _r: RefCounted = null
+
+## Sweeps the trainer AI over every trainer in all three cartridges: what
+## `AI_Basic`, `AI_Types`, `AI_Status` and `AI_Aggressive` do to a real moveset,
+## and what `FindEnemyMonsWithAtLeastQuarterMaxHP` makes of a real HP bar. Those
+## four layers roll no dice, so every claim below is an equality rather than a
+## distribution.
+##   Godot --headless --path . -s res://tools/validate.gd -- trainer_ai
+
+## The three opponents every party member is scored against, by species. Each
+## one is here for a typing: Gastly is what a Normal or Fighting move cannot
+## touch and what `.poisonimmunity` reads, Magnemite is what a Poison move
+## cannot touch through the chart, and Diglett is what an Electric move cannot.
+const OPPONENTS: Array[int] = [92, 81, 50]
+const OPPONENT_LEVEL: int = 50
+
+## `AIDiscourageMove`'s ten on top of the starting twenty.
+const DISMISSED: int = Gen2BattleAI.DEFAULT_SCORE + Gen2BattleAI.DISCOURAGE_MOVE
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	for game_id: StringName in _r.GAME_IDS:
+		var data: GameData = GameData.open(game_id)
+		if data == null:
+			_r.fail("%s cache is unavailable. Import roms/%s.gbc first." % [game_id, game_id])
+			continue
+		_r.game_id = game_id
+		_sweep(game_id, data)
+	_r.game_id = &""
+
+
+func _sweep(game_id: StringName, data: GameData) -> void:
+	var rng := RandomNumberGenerator.new()
+	rng.seed = 1
+	var opponents: Array = []
+	for species: int in OPPONENTS:
+		var mon: Gen2BattleMon = Gen2BattleMon.create(
+			data, species, OPPONENT_LEVEL, data.moves_at_level(species, OPPONENT_LEVEL),
+			Gen2BattleMon.PERFECT_DVS, {}, 0
+		)
+		if mon == null:
+			_r.fail("%s: species %d could not be built." % [game_id, species])
+			return
+		opponents.append(mon)
+
+	var scored: int = 0
+	var bars: int = 0
+	for trainer_class: int in range(1, data.trainer_count() + 1):
+		for index: int in data.trainer_party_count(trainer_class):
+			var party: Gen2Party = Gen2TrainerParty.build(data, trainer_class, index)
+			if party == null:
+				continue
+			for slot: int in party.size():
+				var member: Gen2BattleMon = party.at(slot)
+				if member == null:
+					continue
+				bars += _check_quarter_rule(game_id, member)
+				for opponent: Gen2BattleMon in opponents:
+					_check_layers(game_id, data, member, opponent, rng)
+					scored += 1
+	print("  %s: %d scorings, %d HP bars." % [game_id, scored, bars])
+
+
+func _check_layers(
+	game_id: StringName, data: GameData, attacker: Gen2BattleMon,
+	defender: Gen2BattleMon, rng: RandomNumberGenerator
+) -> void:
+	var types: Array = _layer(data, attacker, defender, rng, RomLayout.AI_TYPES)
+	var status: Array = _layer(data, attacker, defender, rng, RomLayout.AI_STATUS)
+	var safeguarded: Array = Gen2BattleAI.score_slots(
+		attacker, defender, data, RomLayout.AI_BASIC, rng, 0, 0, Gen2Weather.NONE,
+		Gen2Screens.NONE, Gen2Screens.SAFEGUARD
+	)
+	_check_aggressive(game_id, data, attacker, defender, rng)
+
+	for slot: int in Gen2BattleMon.MAX_MOVES:
+		if slot >= attacker.moves.size() or int(attacker.moves[slot]) == 0:
+			break
+		var move: Dictionary = data.move(int(attacker.moves[slot]))
+		var effect: int = int(move.get("effect", 0))
+		var power: int = int(move.get("power", 0))
+		var immune: bool = data.type_effectiveness(
+			int(move.get("type", RomLayout.TYPE_NORMAL)), defender.types()
+		) == RomLayout.MATCHUP_NO_EFFECT
+
+		if immune:
+			_r.check(
+				int(types[slot]) >= DISMISSED,
+				"%s: AI_Types did not dismiss an immune %s." % [game_id, move.get("name", "?")]
+			)
+
+		var poisoning: bool = effect == Gen2MoveEffect.TOXIC or effect == Gen2MoveEffect.POISON
+		var poison_shortcut: bool = poisoning and defender.types().has(RomLayout.TYPE_POISON)
+		# `.poisonimmunity` falls into `.typeimmunity`, so a Poison move against
+		# anything else is still read by the chart.
+		var read_by_status: bool = poisoning or power > 0 \
+			or effect == Gen2MoveEffect.SLEEP or effect == Gen2MoveEffect.PARALYZE
+		var wanted: int = Gen2BattleAI.DEFAULT_SCORE
+		if poison_shortcut or (read_by_status and immune):
+			wanted = DISMISSED
+		_r.check(
+			int(status[slot]) == wanted,
+			"%s: AI_Status put %s at %d, expected %d." % [
+				game_id, move.get("name", "?"), status[slot], wanted
+			]
+		)
+
+		if Gen2BattleAI.STATUS_ONLY_EFFECTS.has(effect):
+			_r.check(
+				int(safeguarded[slot]) >= DISMISSED,
+				"%s: AI_Basic ignored Safeguard for %s." % [game_id, move.get("name", "?")]
+			)
+
+
+## `AI_Aggressive` picks one winner and punishes the rest, and it does so even
+## when every one of them lands for nothing: `c` is already set by the first
+## damaging move, whatever the damage came to. So a moveset with any damaging
+## move at all leaves exactly one ordinary slot alone.
+func _check_aggressive(
+	game_id: StringName, data: GameData, attacker: Gen2BattleMon,
+	defender: Gen2BattleMon, rng: RandomNumberGenerator
+) -> void:
+	var scores: Array = _layer(data, attacker, defender, rng, RomLayout.AI_AGGRESSIVE)
+	var ordinary: int = 0
+	var untouched: int = 0
+	var damaging: bool = false
+	for slot: int in Gen2BattleMon.MAX_MOVES:
+		if slot >= attacker.moves.size() or int(attacker.moves[slot]) == 0:
+			break
+		var move: Dictionary = data.move(int(attacker.moves[slot]))
+		damaging = damaging or int(move.get("power", 0)) > 0
+		if int(move.get("power", 0)) < 2:
+			continue
+		if Gen2BattleAI.RECKLESS_EFFECTS.has(int(move.get("effect", 0))):
+			continue
+		ordinary += 1
+		if int(scores[slot]) == Gen2BattleAI.DEFAULT_SCORE:
+			untouched += 1
+
+	if not damaging or ordinary == 0:
+		return
+	_r.check(
+		untouched <= 1,
+		"%s: AI_Aggressive left %d of %d ordinary moves alone." % [
+			game_id, untouched, ordinary
+		]
+	)
+
+
+func _layer(
+	data: GameData, attacker: Gen2BattleMon, defender: Gen2BattleMon,
+	rng: RandomNumberGenerator, layer: int
+) -> Array:
+	return Gen2BattleAI.score_slots(attacker, defender, data, layer, rng)
+
+
+## `FindEnemyMonsWithAtLeastQuarterMaxHP` over one real HP bar: below a maximum
+## of 256 its shifted word clears the maximum exactly when the current HP is not
+## a multiple of four, which is the whole of what the scan comes to. Answers 1 so
+## the caller can count the bars it walked.
+func _check_quarter_rule(game_id: StringName, member: Gen2BattleMon) -> int:
+	var maximum: int = member.max_hp()
+	if maximum >= 256:
+		return 0
+	for hp: int in range(1, maximum + 1):
+		var wanted: bool = (hp % 4) != 0
+		if (Gen2AISwitch._shifted_hp(hp) > maximum) != wanted:
+			_r.fail("%s: %d of %d HP disagrees with the shift." % [game_id, hp, maximum])
+			return 1
+	return 1

--- a/tools/checks/trainer_ai.gd.uid
+++ b/tools/checks/trainer_ai.gd.uid
@@ -1,0 +1,1 @@
+uid://ikn242wttt4g


### PR DESCRIPTION
Walked `engine/battle/ai/switch.asm`, `items.asm` and `scoring.asm` whole against both pins: 4,773 lines, ten defects. `tools/checks/trainer_ai.gd` is a new topic that sweeps every trainer in all three cartridges through the four move-scoring layers that roll no dice, 10,656 scorings and 3,548 HP bars.

## Fixed

`FindEnemyMonsWithAtLeastQuarterMaxHP` writes `srl c / rl b` twice where `AICheckEnemyQuarterHP` two files away writes `sla c / rl b`, so the low byte halves twice while the high byte doubles twice and picks up the two bits it dropped, and the comparison is strictly greater rather than the comment's `>=`. Under a maximum of 256 the whole scan comes to "current HP is not a multiple of four". Both pins ship it and pret's bug list does not carry it.

`AI_Status`'s power gate runs the other way round from its own comment. The four named status effects and every move with power are read against the chart; a non-damaging move it has no rule for is passed over. This port read damaging moves as the ones to skip, so the layer dismissed nothing a trainer actually attacks with. It also skipped `.poisonimmunity`, which the chart cannot answer (Poison against Poison is resisted, and Steel is the only typing the move cannot touch), and its matchup call dropped Foresight.

`AI_Basic` has two clauses behind `StatusOnlyEffects`, a status the target already carries and a Safeguard it is standing behind. Only the first was built, so no trainer refused to throw a status into a Safeguard.

`AI_Aggressive`'s `.gotstrongestmove` refuses only on no damaging move at all: `c` is set by the first move with power whatever the damage came to. This port refused on zero damage as well, so a moveset that lands for nothing had all four moves left level instead of all but the last discouraged. Its winner search also skipped moves with no PP, where the layer asks about neither PP nor Disable.

`AI_Smart_MeanLook` was wrong three ways: the below-half-health arm is `inc [hl]` and was a ten-point dismissal, its test is `hp * 2 > max` where this port wrote `<`, and `AICheckLastPlayerMon` reads the player's bench where this port read the enemy's own.

`AI_Smart_Conversion2` reads `wLastPlayerMove`, not `wLastPlayerCounterMove`.

Four thresholds: `AI_Smart_Confuse` skips its penalty 25 times in 256 rather than applying it 229; `AI_Cautious`'s `90 percent + 1` is 230; `AI_Risky`'s `79 percent - 1` is 200, and its KO test is `wBattleMonHP - wCurDamage` with `jr nc`, so a hit that exactly matches the bar is not a KO; the evasion tail's badly-poisoned arm rolls `31 percent + 1`, which is 80.

## Checked and already right

`items.asm` whole, including all nine frequency chances and `AI_HealStatus`'s three documented omissions. `docs/bugs_and_glitches.md`'s "AI might use its base reward value as an item" is unreachable with cartridge data: every one of the eighteen classes carrying a second item has base reward 25 on all three pins. `switch.asm`'s matchup halves, weights and both mask-to-index conversions. In `scoring.asm`, the four HP fraction helpers, `AI_Redundant`'s thirty rows, and the whole of Curse, Protect, Endure, Lock On, Evasion Up, Accuracy Down, Encore, Counter, Mirror Coat, Psych Up, Heal Bell, Rollout, Fury Cutter and the two weather routines.

## Proving it

| Check | Result |
|---|---|
| `gut_cmdln.gd -gexit` | 3,552 tests, 66,001 asserts, green |
| `validate.gd -- all` | 84 topics pass, `trainer_ai` among them |
| `--warning-scan` over `game/battle`, `tools/checks`, `tests/unit` | 0 warnings in 257 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | unchanged from `main` |
| `tools/release.sh --gates` | pass, comments 37,781 of 37,781 |

