### PR TITLE
Fly on the wing, and every box a party list stages

### DIFF
--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -47,7 +47,7 @@ var stereo: bool = false:
 var volume_scale: float = 1.0:
 	set(value):
 		volume_scale = maxf(value, 0.0)
-		_apply_volume()
+		_apply_settings()
 
 var _player: AudioStreamPlayer = null
 var _generator: AudioStreamGenerator = null
@@ -58,6 +58,9 @@ var _timeline_updates: int = 0
 var _engine: Gen2SoundEngine = null
 var _apu: Gen2Apu = null
 var _music_key: String = ""
+## What a SOUND change restarts.
+var _music_record: Dictionary = {}
+var _music_assets: Dictionary = {}
 var _buffer: PackedVector2Array = PackedVector2Array()
 ## How much of the generator is kept filled, in driver frames. Raised by an
 ## underrun and never lowered inside a run: a device that stuttered once will do
@@ -94,13 +97,13 @@ func _init() -> void:
 
 func _ready() -> void:
 	stereo = Gen2OptionsStore.current().stereo
-	_apply_volume()
+	_apply_settings()
 	_start_stream()
 	set_process(true)
 
 
 func _process(delta: float) -> void:
-	_apply_volume()
+	_apply_settings()
 	_service_timeline(delta)
 
 
@@ -117,15 +120,19 @@ func _notification(what: int) -> void:
 			_starved_seconds = maxf(_starved_seconds, STALL_SECONDS - RESUME_GRACE_SECONDS)
 
 
-## The app block's two volumes, pushed to the driver's mix rather than to the
-## stream player: music and effects share the four hardware channels, so one
-## level on the output could not tell them apart. Read every frame because the
-## settings object is shared and edited in place, and pushed only when a number
-## actually moves.
-func _apply_volume() -> void:
+## The settings the driver owns. The two volumes reach its mix rather than the
+## stream player, since music and effects share the four hardware channels. Read
+## every frame because the object is shared and edited in place, and pushed only
+## when a value moves; a SOUND change also spends `Options_Sound`'s own
+## `RestartMapMusic`, because `Music_StereoPanning` has already narrowed
+## `channel.tracks` and only a restart widens them again.
+func _apply_settings() -> void:
 	if _engine == null:
 		return
 	var options: Gen2Options = Gen2OptionsStore.current()
+	if options.stereo != stereo:
+		stereo = options.stereo
+		_restart_music()
 	var music: float = float(options.music_volume) / float(Gen2Options.MAX_VOLUME)
 	var sfx: float = float(options.sfx_volume) / float(Gen2Options.MAX_VOLUME)
 	music *= volume_scale
@@ -160,7 +167,7 @@ func play_record(
 		# because `_PlayMusic` only loads the channels the new header names.
 		if int(record.get("index", -1)) == 0:
 			_engine.init_sound()
-			_music_key = ""
+			_forget_music()
 			return {"ok": true, "played": true, "stopped": true}
 		if not restart and key == _music_key:
 			return {"ok": true, "played": false, "continued": true}
@@ -195,6 +202,8 @@ func play_record(
 		return {"ok": false, "played": false, "reason": &"audio_record_unplayable"}
 	if music:
 		_music_key = key
+		_music_record = record
+		_music_assets = assets
 	return {
 		"ok": true,
 		"played": true,
@@ -204,6 +213,18 @@ func play_record(
 		"bank": int(record.get("bank", -1)),
 		"address": int(record.get("address", -1)),
 	}
+
+
+func _forget_music() -> void:
+	_music_key = ""
+	_music_record = {}
+	_music_assets = {}
+
+
+func _restart_music() -> void:
+	if _music_record.is_empty():
+		return
+	play_record(_music_record, &"map_music", _music_assets, true)
 
 
 ## `SFXChannelsOff`, which the Unown sounds spend in front of their own
@@ -219,10 +240,10 @@ func fade_out(frames: int = 0) -> bool:
 		if not _engine.any_channel_active():
 			return false
 		_engine.init_sound()
-		_music_key = ""
+		_forget_music()
 		return true
 	_engine.start_fade(frames)
-	_music_key = ""
+	_forget_music()
 	return true
 
 
@@ -243,12 +264,14 @@ func fade_to(record: Dictionary, frames: int, assets: Dictionary = {}) -> bool:
 	_start_stream()
 	_engine.start_fade(frames, record)
 	_music_key = key
+	_music_record = record
+	_music_assets = assets
 	return true
 
 
 func stop_all() -> void:
 	_engine.init_sound()
-	_music_key = ""
+	_forget_music()
 	if _player != null:
 		_player.stop()
 	_playback = null

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -12,7 +12,6 @@ extends RefCounted
 ## filled with the result's own [code]detail[/code]; a reason wanting anything
 ## else is a branch in [method text].
 const WORDING: Dictionary = {
-	# Choosing and reading the archive.
 	&"not_a_zip": "%s is not a .zip archive.",
 	&"archive_not_found": "%s could not be read.",
 	&"archive_unreadable": "That archive could not be opened.",
@@ -22,7 +21,6 @@ const WORDING: Dictionary = {
 	&"archive_too_many_entries": "That archive is too large to be a mod.",
 	&"unsafe_archive_entry": "The archive tries to write outside the mod folder (%s).",
 
-	# What the manifest says.
 	&"missing_manifest": "The mod has no %s.",
 	&"unreadable_manifest": "The mod's %s could not be read.",
 	&"invalid_manifest": "The mod's %s is not valid JSON.",
@@ -40,13 +38,11 @@ const WORDING: Dictionary = {
 	&"art_escapes_mod": "The mod's icon or thumbnail points outside the mod folder (%s).",
 	&"pack_not_a_resource_pack": "A mod's pack has to be a .pck or .zip (%s).",
 
-	# Writing it into place.
 	&"could_not_create_mod_directory": "The mod folder could not be created.",
 	&"could_not_stage_archive": "The download could not be written to disk.",
 	&"could_not_write_mod_file": "%s could not be written.",
 	&"already_installed": "It is already installed.",
 
-	# Running it.
 	&"missing_mod_pack": "The mod's resource pack %s is missing.",
 	&"mod_pack_unreadable": "The mod's resource pack %s could not be opened.",
 	&"missing_entry_script": "The entry script %s is missing.",
@@ -64,7 +60,6 @@ const WORDING: Dictionary = {
 	&"invalid_mod_save_id": "That mod id cannot own save data.",
 	&"mod_save_too_large": "That mod's save data is larger than 64 KiB.",
 
-	# What it registered.
 	&"invalid_renderer": "A mod registered a renderer with no id or script.",
 	&"renderer_not_instantiable": "%s's renderer could not be created.",
 	&"renderer_not_a_node": "%s's renderer is not a Node.",
@@ -141,7 +136,6 @@ const WORDING: Dictionary = {
 	&"reserved_effect_command": "\"%s\" is one of the engine's own steps.",
 	&"duplicate_move_effect": "Two mods both claimed the same move effect (%s).",
 
-	# Index feeds.
 	&"empty_index_url": "Enter an index address first.",
 	&"index_url_not_https": "An index must be an https address.",
 	&"index_not_json": "That address did not return an index.",

--- a/game/save/save_editor.gd
+++ b/game/save/save_editor.gd
@@ -50,9 +50,6 @@ func commit() -> Dictionary:
 	return result
 
 
-# --- Player -----------------------------------------------------------------
-
-
 func set_player_name(name: String) -> Dictionary:
 	var trimmed: String = name.strip_edges()
 	if trimmed.is_empty():
@@ -69,9 +66,6 @@ func set_label(label: String) -> Dictionary:
 		return _refuse("the slot name is at most %d characters" % Gen2SaveData.MAX_LABEL)
 	save.label = trimmed
 	return _changed()
-
-
-# --- Party ------------------------------------------------------------------
 
 
 ## Creates a member at [param level] of [param species], with the moves that
@@ -104,9 +98,6 @@ func move_party_member(from_index: int, to_index: int) -> Dictionary:
 	save.party.remove_at(from_index)
 	save.party.insert(to_index, mon)
 	return _changed()
-
-
-# --- One Pokemon ------------------------------------------------------------
 
 
 ## Changing species re-runs experience against the new growth curve and
@@ -251,9 +242,6 @@ func max_hp_for(mon: Gen2SaveMon) -> int:
 	)
 
 
-# --- Boxes ------------------------------------------------------------------
-
-
 func box(index: int) -> Gen2SaveBox:
 	if index < 0 or index >= save.boxes.size():
 		return null
@@ -281,9 +269,6 @@ func remove_box_member(box_index: int, slot: int) -> Dictionary:
 		return _refuse("that box slot is empty")
 	target.slots[slot] = null
 	return _changed()
-
-
-# --- World ------------------------------------------------------------------
 
 
 ## The bag, money, flags and dex all live in the world snapshot, so a save
@@ -398,9 +383,6 @@ func set_clock(day: int, hour: int, minute: int) -> Dictionary:
 	save.world.world_hour = clampi(hour, 0, Gen2WorldClock.HOURS_PER_DAY - 1)
 	save.world.world_minute = clampi(minute, 0, Gen2WorldClock.MINUTES_PER_HOUR - 1)
 	return _changed()
-
-
-# --- Internals --------------------------------------------------------------
 
 
 ## Level and experience must agree, so setting either sets both: experience

--- a/game/save/save_editor_screen.gd
+++ b/game/save/save_editor_screen.gd
@@ -129,9 +129,6 @@ func reload_now() -> bool:
 	return true
 
 
-# --- Layout -----------------------------------------------------------------
-
-
 func _build_ui() -> void:
 	_palette = Gen2LauncherTheme.active()
 	theme = _palette.control_theme()
@@ -412,9 +409,6 @@ func _build_dex_tab() -> Control:
 	return page
 
 
-# --- Refresh ----------------------------------------------------------------
-
-
 func _refresh() -> void:
 	if _editor == null:
 		_set_status("No save is open.")
@@ -564,9 +558,6 @@ func _refresh_dex() -> void:
 	numbers.sort()
 	for species: Variant in numbers:
 		_dex_list.add_item("%d %s" % [int(species), _species_name(int(species))])
-
-
-# --- Helpers ----------------------------------------------------------------
 
 
 func _set_badge(index: int, pressed: bool) -> void:

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -24,6 +24,7 @@ const SPRITE_CUT_TREE: StringName = &"cut_tree"
 const SPRITE_CUT_LEAF: StringName = &"cut_grass"
 const SPRITE_SHADOW: StringName = &"shadow"
 const SPRITE_HEAL_MACHINE: StringName = &"heal_machine"
+const SPRITE_FLY_MON: StringName = &"fly_mon"
 
 ## `HealMachineAnim`'s two OAM tables, as (screen pixel, tile, flip). An OAM byte
 ## pair is (y + 16, x + 8), so each `dbsprite` is read back to the pixel the
@@ -63,9 +64,25 @@ const HEAL_MACHINE_BALL_FRAMES: int = 30
 const HEAL_MACHINE_FLASH_INTERVAL: int = 10
 const HEAL_MACHINE_FLASHES: int = 8
 
+const FLY_FROM_FRAMES: int = 128
+const FLY_TO_FRAMES: int = 64
+const FLY_MON_X: int = 80
+const FLY_MON_Y: int = 84
+const FLY_TO_START_Y: int = 252
+const FLY_HOLD_FRAMES: int = 0x40
+const FLY_FROM_SWING_STEP: int = 8
+const FLY_FROM_SWING_MAX: int = 0x40
+const FLY_TO_SWING: int = 11 * 8
+const FLY_TO_SWING_STEP: int = 2
+const FLY_MON_FRAME_LENGTH: int = 9
+const FLY_LEAF_INTERVAL: int = 8
+const FLY_LEAF_SWING: int = 0x40
+const FLY_LEAF_LIMIT: int = 0x100 - 9 * 8
+
 ## constants/sprite_data_constants.asm. Every emote-object spawn names its
 ## palette: PAL_OW_EMOTE for the dust and the emote bubbles, PAL_OW_TREE for the
 ## grass and for `.OAMData_Tree`.
+const PAL_OW_RED: int = 0
 const PAL_OW_EMOTE: int = 5
 const PAL_OW_TREE: int = 6
 const PAL_OW_ROCK: int = 7
@@ -265,6 +282,39 @@ func start_heal_machine(machine_type: int, balls: int) -> void:
 	})
 
 
+## `FlyFromAnim` and `FlyToAnim`, one record whose frame counter drives the icon
+## and every leaf in the air. The two `depixel`s and every offset below are OAM
+## coordinates, which count from (8, 16). `SpriteAnimFunc_FlyFrom` holds until
+## VAR2 reaches $40, then rises two pixels a frame while VAR4 widens the swing to
+## $40; `SpriteAnimFunc_FlyTo` descends two a frame into a swing narrowing by two
+## and stops on the frame its wrapped row matches the departure's.
+## `.Frameset_RedWalk` alternates the icon's two drawings every nine frames and
+## `.SpawnLeaf` puts a leaf at column zero every eight.
+func start_fly(icon: int, arriving: bool) -> void:
+	_sprites.append({
+		"kind": SPRITE_FLY_MON,
+		"cell": Vector2i.ZERO,
+		"object_index": -1,
+		"screen": true,
+		"palette": PAL_OW_RED,
+		"frame": 0,
+		"duration": FLY_TO_FRAMES if arriving else FLY_FROM_FRAMES,
+		"icon": maxi(icon, 0),
+		"arriving": arriving,
+	})
+
+
+## Where `FlyFunction_FrameTimer` reaches `ld de, SFX_FLY`.
+static func fly_sfx_frames(arriving: bool) -> Array[int]:
+	var out: Array[int] = []
+	var counter: int = FLY_TO_FRAMES if arriving else FLY_FROM_FRAMES
+	for frame: int in counter:
+		var left: int = counter - frame
+		if left >= FLY_HOLD_FRAMES and left % 8 == 0:
+			out.append(frame)
+	return out
+
+
 ## The three sprites that are temporary map objects on the cartridge, so their
 ## countdowns are `HandleMap`'s passes rather than screen frames
 ## (Gen2WorldAPI.FRAMES_PER_OVERWORLD_PASS). The other four are a routine's own
@@ -342,6 +392,9 @@ func offset() -> Vector2:
 func sprites() -> Array:
 	var out: Array = []
 	for sprite: Dictionary in _sprites:
+		if StringName(sprite["kind"]) == SPRITE_FLY_MON:
+			out.append_array(_fly_records(sprite))
+			continue
 		out.append({
 			"kind": sprite["kind"],
 			"cell": sprite["cell"],
@@ -493,6 +546,85 @@ func _tiles_for(sprite: Dictionary) -> Array:
 				})
 			return dust
 	return []
+
+
+func _fly_records(sprite: Dictionary) -> Array:
+	var frame: int = int(sprite["frame"])
+	var arriving: bool = bool(sprite["arriving"])
+	var out: Array = [{
+		"kind": SPRITE_FLY_MON,
+		"cell": Vector2i.ZERO,
+		"object_index": -1,
+		"screen": true,
+		"palette": PAL_OW_RED,
+		"rotation": 0,
+		"frame": frame,
+		"icon": int(sprite["icon"]),
+		"tiles": _fly_mon_tiles(arriving, frame),
+	}]
+	for spawned: int in range(0, frame + 1, FLY_LEAF_INTERVAL):
+		var leaf: Dictionary = _fly_leaf_tile(spawned, frame - spawned)
+		if leaf.is_empty():
+			continue
+		out.append({
+			"kind": SPRITE_CUT_LEAF,
+			"cell": Vector2i.ZERO,
+			"object_index": -1,
+			"screen": true,
+			"palette": PAL_OW_TREE,
+			"rotation": 0,
+			"frame": frame - spawned,
+			"tiles": [leaf],
+		})
+	return out
+
+
+func _fly_mon_tiles(arriving: bool, frame: int) -> Array:
+	var at: Vector2i = _fly_mon_pixel(arriving, frame) + Vector2i(-8, -8)
+	var step: int = int(float(frame % (FLY_MON_FRAME_LENGTH * 4)) / float(FLY_MON_FRAME_LENGTH))
+	var tiles: Array = []
+	for index: int in 4:
+		tiles.append({
+			"offset": at + Vector2i((index & 1) * 8, (index >> 1) * 8),
+			"tile": step & 1,
+			"flip_x": step == 3,
+		})
+	return tiles
+
+
+func _fly_mon_pixel(arriving: bool, frame: int) -> Vector2i:
+	var moves: int = _fly_moves(arriving, frame)
+	var swing: int = _fly_swing(arriving, moves)
+	var swung: int = 0 if moves == 0 else _signed(_cosine((moves - 1) & 0xFF, swing))
+	var y: int = FLY_TO_START_Y + 2 * moves if arriving else FLY_MON_Y - 2 * moves
+	return Vector2i(FLY_MON_X + swung - 8, (y & 0xFF) - 16)
+
+
+func _fly_moves(arriving: bool, frame: int) -> int:
+	if arriving:
+		return mini(frame, ((FLY_MON_Y - FLY_TO_START_Y) & 0xFF) / 2)
+	return clampi(frame - FLY_HOLD_FRAMES + 1, 0, FLY_MON_Y / 2)
+
+
+func _fly_swing(arriving: bool, moves: int) -> int:
+	if moves == 0:
+		return 0
+	if arriving:
+		return maxi(FLY_TO_SWING - FLY_TO_SWING_STEP * (moves - 1), 0)
+	return mini(FLY_FROM_SWING_STEP * (moves - 1), FLY_FROM_SWING_MAX)
+
+
+func _fly_leaf_tile(spawned: int, age: int) -> Dictionary:
+	var x: int = 2 * age
+	if x >= FLY_LEAF_LIMIT:
+		return {}
+	var y: int = ((spawned & 0x18) << 1) + 0x40 - age
+	var swung: int = _signed(_cosine(age & 0xFF, FLY_LEAF_SWING))
+	return {
+		"offset": Vector2i(x + swung - 8, y - 16) + CUT_LEAF_OFFSET,
+		"tile": 0,
+		"flip_x": false,
+	}
 
 
 ## `.FlashPalettes` rotates the four colours of the palette left by one and

--- a/game/world/world_options_menu.gd
+++ b/game/world/world_options_menu.gd
@@ -52,11 +52,8 @@ func size() -> int:
 	return ROWS.size()
 
 
-## `OptionsControl`. Its two odd branches, `.CheckMenuAccount` writing
-## OPT_MENU_ACCOUNT back before its own `inc` and `.UpPressed` special-casing
-## OPT_FRAME, each land on exactly the value the plain step would, so this is a
-## plain wrap in both directions. The source's own comments call them
-## unexplained.
+## `OptionsControl`, whose two branches the source's own comments call
+## unexplained each land on the value a plain wrap would.
 func move(delta: int) -> bool:
 	if delta == 0:
 		return false

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -48,6 +48,8 @@ var _background_color: Color = FALLBACK_BACKGROUND
 var _actor_textures: Dictionary = {}
 var _priority_atlas: ImageTexture = null
 var _priority_indices: PackedByteArray = PackedByteArray()
+## `HideSprites`: no map object and no player reaches OAM.
+var sprites_hidden: bool = false
 var _effect_sheets: Dictionary = {}
 var _effect_textures: Dictionary = {}
 ## The palette order the map fades are one step of, and `FillWhiteBGColor`
@@ -736,9 +738,11 @@ func _draw() -> void:
 	## objects left in OAM are the player and, in a scripted battle, whoever
 	## `hLastTalked` names.
 	var battlers_only: bool = _transition_sprites == Gen2BattleTransition.SPRITES_BATTLERS
-	var drawn: Array = _row_entries(battlers_only)
-	_draw_row_entries(drawn, camera_pixels, background, battlers_only)
-	var player: Vector2 = _draw_player(background)
+	var player: Vector2 = Vector2(_world.player_view_pixel()) + SPRITE_LIFT
+	if not sprites_hidden:
+		var drawn: Array = _row_entries(battlers_only)
+		_draw_row_entries(drawn, camera_pixels, background, battlers_only)
+		player = _draw_player(background)
 	if battlers_only:
 		return
 	_draw_free_sprites(camera_pixels, player)
@@ -1246,6 +1250,9 @@ func _draw_effect_sprites(object_index: int, pixel: Vector2) -> void:
 
 
 func _draw_effect_sprite(sprite: Dictionary, anchor: Vector2) -> void:
+	if sprite.has("icon"):
+		_draw_fly_mon(sprite, anchor)
+		return
 	var sheet: Dictionary = _effect_sheet(String(sprite["kind"]))
 	if sheet.is_empty():
 		return
@@ -1258,6 +1265,32 @@ func _draw_effect_sprite(sprite: Dictionary, anchor: Vector2) -> void:
 			anchor + Vector2(tile["offset"] as Vector2i),
 			int(sprite.get("rotation", 0)),
 		)
+
+
+## `.OAMData_RedWalk` names PAL_OW_RED, so the icon wears the player's own
+## overworld palette.
+func _draw_fly_mon(sprite: Dictionary, anchor: Vector2) -> void:
+	var tiles: Array = sprite["tiles"]
+	if tiles.is_empty() or _world == null or _world.data == null:
+		return
+	var icon: Gen2WorldSprite = _world.data.overworld_icon(int(sprite["icon"]))
+	var tile: Dictionary = tiles[0]
+	var facing: int = Gen2WorldSprite.FACING_UP if int(tile["tile"]) == 1 \
+		else Gen2WorldSprite.FACING_DOWN
+	var texture: Texture2D = _actor_texture(
+		icon, 0, facing, 0, Gen2WorldSprite.BIG_SHAPE_NONE,
+		_sprite_palette(int(sprite["palette"]))
+	) if icon != null else null
+	if texture == null:
+		return
+	var at: Vector2 = anchor + Vector2(tile["offset"] as Vector2i)
+	var size := Vector2(texture.get_width(), texture.get_height())
+	if bool(tile["flip_x"]):
+		draw_texture_rect(
+			texture, Rect2(at + Vector2(size.x, 0.0), Vector2(-size.x, size.y)), false
+		)
+		return
+	draw_texture(texture, at)
 
 
 ## A sheet with a `colors` of its own is the heal machine, whose palette

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -73,6 +73,9 @@ const MUSIC_HALL_OF_FAME: int = 20
 ## `wPlayerTileCollision` is.
 const SFX_ENTER_DOOR: int = 0x1F
 const SFX_WARP_TO: int = 0x13
+## `FlyFunction_FrameTimer`'s own sound, and what the fly preview flies on.
+const SFX_FLY: int = 0x18
+const PREVIEW_FLY_SPECIES: int = 155
 const SFX_EXIT_BUILDING: int = 0x23
 const COLL_DOOR: int = 0x71
 const COLL_WARP_PANEL: int = 0x7C
@@ -107,6 +110,8 @@ var _encounters: Gen2WorldEncounters = null
 var _battle_encounter_id: StringName = &""
 ## The headbutt result waiting for ShakeHeadbuttTree's 32 frames to be spent.
 var _pending_headbutt_finish: Dictionary = {}
+## `.FlyScript` while it runs.
+var _pending_fly: Dictionary = {}
 ## The step in flight whose `PlayerEvents` are still owed, empty while none is.
 ## `CheckPlayerState` reads `PLAYERSTEP_STOP_F`, so the warp, the coord events
 ## and the wild roll all belong to the frame the step lands on.
@@ -1029,6 +1034,7 @@ func _advance_population(map_pass: bool) -> void:
 ## What a frame owes something already waiting on it, each behind the trail it
 ## waits for.
 func _advance_waits(map_pass: bool) -> void:
+	_advance_fly()
 	if not _pending_headbutt_finish.is_empty() \
 		and (_effects == null or not _effects.sprites_active()):
 		var headbutt: Dictionary = _pending_headbutt_finish
@@ -3175,6 +3181,16 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 				Gen2WorldAPI.STEP_PASSES_HOP,
 			)
 		_script_prompt = "Debug cut animation preview"
+		_renderer.refresh()
+		_refresh_labels()
+		return
+	if kind == &"fly":
+		## `FlyFromAnim` past its hold, with leaves still crossing the screen.
+		_effects.start_fly(_world.data.mon_menu_icon(PREVIEW_FLY_SPECIES), false)
+		_renderer.sprites_hidden = true
+		for _frame: int in 80:
+			_effects.advance_frame()
+		_script_prompt = "Debug fly animation preview"
 		_renderer.refresh()
 		_refresh_labels()
 		return
@@ -7063,15 +7079,70 @@ func _apply_fly_choice(results: Array) -> bool:
 		if spawn < 0:
 			_refresh_labels()
 			return true
-		## `.FlyScript`'s `newloadmap MAPSETUP_FLY`, whose setup script opens on
-		## `JumpRoamMons`: a flight scatters the beasts rather than stepping them.
-		var warped: Dictionary = _world.warp_to_spawn(
-			spawn, Gen2WorldAPI.MAP_ENTRY_FLY
-		)
-		if bool(warped.get("ok", false)):
-			_refresh_after_escape()
+		_start_fly(spawn)
 		return true
 	return false
+
+
+## `.FlyScript`: `callasm HideSprites`, `FlyFromAnim`, the warp, `FlyToAnim`,
+## then `.ReturnFromFly`'s `RespawnPlayer` and `UpdatePlayerSprite`.
+func _start_fly(spawn: int) -> void:
+	_begin_fly_animation(false, {"spawn": spawn})
+	if _renderer != null:
+		_renderer.sprites_hidden = true
+	_refresh_labels()
+
+
+func _begin_fly_animation(arriving: bool, fields: Dictionary) -> void:
+	_pending_fly = fields.duplicate()
+	_pending_fly["arriving"] = arriving
+	_pending_fly["frame"] = 0
+	_pending_fly["sfx"] = Gen2WorldEffects.fly_sfx_frames(arriving)
+	if _effects != null:
+		_effects.start_fly(_fly_icon(), arriving)
+
+
+## `wTempIconSpecies`, which `FlyFunction_InitGFX` reads off `wCurPartyMon`.
+func _fly_icon() -> int:
+	if _world == null or _data == null:
+		return 0
+	var source: Dictionary = _world.field_move_source(Gen2WorldFieldMove.MOVE_FLY)
+	var slot: int = maxi(int(source.get("slot", 0)), 0)
+	var species: Array = _world.party_summary().get("species", [])
+	if slot >= species.size():
+		return 0
+	return _data.mon_menu_icon(int(species[slot]))
+
+
+func _advance_fly() -> void:
+	if _pending_fly.is_empty():
+		return
+	var frame: int = int(_pending_fly["frame"])
+	if (_pending_fly["sfx"] as Array).has(frame):
+		_play_sfx(SFX_FLY)
+	_pending_fly["frame"] = frame + 1
+	if _effects != null and _effects.sprites_active():
+		return
+	if bool(_pending_fly["arriving"]):
+		_finish_fly()
+		return
+	var spawn: int = int(_pending_fly["spawn"])
+	## `newloadmap MAPSETUP_FLY`, whose setup script opens on `JumpRoamMons`: a
+	## flight scatters the beasts rather than stepping them.
+	var warped: Dictionary = _world.warp_to_spawn(spawn, Gen2WorldAPI.MAP_ENTRY_FLY)
+	if not bool(warped.get("ok", false)):
+		_finish_fly()
+		return
+	_refresh_after_escape()
+	_begin_fly_animation(true, {"spawn": spawn})
+
+
+func _finish_fly() -> void:
+	_pending_fly = {}
+	if _renderer != null:
+		_renderer.sprites_hidden = false
+		_renderer.refresh()
+	_refresh_labels()
 
 
 func _on_service_completed(results: Array) -> void:

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -657,6 +657,12 @@ const PARTY_SELECTION_REFUSAL_OF: Dictionary = {
 	&"check_poke_mail": Gen2WorldPartyHost.POKEMAIL_REFUSED,
 }
 
+## The two `.cancel`s that are a `PrintText` rather than a script value.
+const PARTY_SELECTION_CANCEL_BOX: Dictionary = {
+	&"poke_seer": ["poke_seer", "do_nothing"],
+	&"photo_studio": ["photo_studio", "no_photo"],
+}
+
 ## `CelebiShrineEvent`'s own loop: `ld a, 160` into wFrameCounter and
 ## `ld c, 2 / call DelayFrames` per pass, so the cutscene stands for twice its
 ## own counter. There is no sprite-anim layer outside the intro, so what it owes
@@ -1373,7 +1379,12 @@ func complete_runtime_request(result: Dictionary) -> Dictionary:
 			"ok": false, "status": &"failed", "reason": &"runtime_request_kind_mismatch",
 			"details": {"kind": kind},
 		}
-	return call(COMPLETION_HANDLERS[kind], kind, request, result)
+	var answered: Dictionary = call(COMPLETION_HANDLERS[kind], kind, request, result)
+	## `_stage_*`'s bare `{"ok": true}` reads as the script having finished, which
+	## dropped every box a party-selection handler staged.
+	if not _pending.is_empty() and not answered.has("status"):
+		return _waiting_result()
+	return answered
 
 
 func _complete_catch_tutorial(
@@ -6324,7 +6335,13 @@ func _finish_party_selection(request: Dictionary, result: Dictionary) -> Diction
 		## something other than zero for it, so the refusal is theirs to name.
 		_script_value = int(PARTY_SELECTION_REFUSAL_OF.get(routine, 0))
 		_pending = {}
-		return advance()
+		var cancel: Array = PARTY_SELECTION_CANCEL_BOX.get(routine, [])
+		if cancel.is_empty():
+			return advance()
+		var cancel_box: String = _special_box(String(cancel[0]), String(cancel[1]))
+		if cancel_box.is_empty():
+			return {"ok": false, "reason": &"missing_special_text", "special": special}
+		return _stage_internal_text(cancel_box, false, {"special": special})
 	var species: int = int(result.get("species", 0))
 	_cur_party_species = species
 	if routine == &"bills_grandfather":

--- a/tests/integration/test_world_field_move_screen.gd
+++ b/tests/integration/test_world_field_move_screen.gd
@@ -1408,3 +1408,25 @@ func test_the_flash_line_is_the_blinding_flash_text() -> void:
 		String((rows[Gen2WorldFieldMove.MOVE_FLASH] as Array)[2]),
 		"A blinding FLASH\nlights the area!"
 	)
+
+
+## `.FlyScript`: `HideSprites`, `FlyFromAnim`'s 128 frames, the warp, then
+## `FlyToAnim`'s 64 and `.ReturnFromFly`. The fixture ships no spawn point, so
+## the warp refuses and the run ends there; what this covers is that no frame of
+## either animation is skipped and that the map is not warped under the first.
+func test_the_fly_script_spends_its_animation_before_the_warp() -> void:
+	await _open_world()
+	var world: Gen2WorldAPI = _world_screen._world
+	var was: Vector2i = world.player_cell
+	_world_screen._start_fly(0)
+	assert_true(_world_screen._renderer.sprites_hidden, "callasm HideSprites")
+	assert_true(_world_screen._effects.sprites_active())
+
+	for _frame: int in Gen2WorldEffects.FLY_FROM_FRAMES - 1:
+		_world_screen.advance_frame()
+	assert_false(_world_screen._pending_fly.is_empty(), "still leaving")
+	assert_eq(world.player_cell, was, "the warp is behind the animation")
+
+	_world_screen.advance_frame()
+	assert_true(_world_screen._pending_fly.is_empty())
+	assert_false(_world_screen._renderer.sprites_hidden, "RespawnPlayer")

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -65,7 +65,7 @@ func test_the_app_volumes_and_a_host_scale_reach_the_drivers_mix() -> void:
 	options.sfx_volume = 0
 	# Edited in place while the player runs, which is what the settings slider
 	# does, so the level has to be read rather than taken once at startup.
-	_player._apply_volume()
+	_player._apply_settings()
 	var status: Dictionary = _player.audio_status()
 	assert_almost_eq(float(status["music_gain"]), 1.0, 0.001)
 	assert_almost_eq(float(status["sfx_gain"]), 0.0, 0.001)
@@ -255,3 +255,32 @@ func test_the_low_health_alarm_is_the_danger_bit_and_its_timer() -> void:
 	_player._engine.low_health_alarm |= 12
 	_player.set_low_health_alarm(false)
 	assert_eq(_player._engine.low_health_alarm, 0, "the timer went with it")
+
+
+## `Options_Sound` toggles the STEREO bit and spends `RestartMapMusic` on the
+## change, because `Music_StereoPanning` has already narrowed `channel.tracks`
+## and only a restart widens them again. The option is shared and edited in
+## place, so the player follows it rather than being told.
+func test_the_sound_option_reaches_the_driver_and_restarts_the_piece() -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	var was: bool = options.stereo
+	options.stereo = false
+	_player._apply_settings()
+	assert_false(_player._engine.stereo)
+
+	assert_true(_player.play_record(_record(2), &"map_music")["played"])
+	var key: String = _player.audio_status()["music_key"]
+
+	options.stereo = true
+	_player._apply_settings()
+	assert_true(_player._engine.stereo, "the driver follows the SOUND option live")
+	assert_eq(_player.audio_status()["music_key"], key,
+		"RestartMapMusic starts the same piece again")
+	assert_true(_player.audio_status()["music_active"])
+
+	_player.stop_all()
+	options.stereo = not options.stereo
+	_player._apply_settings()
+	assert_eq(_player.audio_status()["music_key"], "",
+		"a map with no music is `PlayMusic MUSIC_NONE` twice")
+	options.stereo = was

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37781
+const MAX_COMMENT_LINES: int = 37779
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -9667,3 +9667,30 @@ func test_the_trainer_house_reads_the_mystery_gift_flag() -> void:
 		var world: Gen2WorldAPI = _special_world(state)
 		_run_special(world)
 		assert_eq(world.state.is_event_flag_active(31), linked == 1)
+
+
+## `PokeSeer`'s `.cancel` and `PhotoStudio`'s are both a `PrintText` rather than
+## a script value, which is what a cancelled party list owes on those two
+## specials alone. A staged box is a pause, so the answer says so: a completion
+## handler that stages one and reports the plain `{"ok": true}` of `_stage_*`
+## has its box dropped with the script.
+func test_a_cancelled_party_list_prints_the_two_boxes_that_have_one() -> void:
+	for row: Array in [
+		[Gen2WorldScriptRunner.SPECIAL_POKE_SEER, "You did nothing.", "You met KARP at ."],
+		[Gen2WorldScriptRunner.SPECIAL_PHOTO_STUDIO, "No picture?", "Hold still."],
+	]:
+		for chosen: int in [-1, 0]:
+			_write_special_script([
+				Gen2WorldScript.SPECIAL, int(row[0]), 0, Gen2WorldScript.END,
+			])
+			var world: Gen2WorldAPI = _special_world()
+			var results: Array = _run_special(world)
+			while world.pending_runtime_request().is_empty():
+				results = _run_script(world, world.run_event_queue(true))
+			results = _run_script(world, world.complete_runtime_request({
+				"ok": true, "party_index": chosen, "species": 1, "nickname": "KARP",
+				"original_trainer": "RED", "ot_id": 0, "level": 10,
+				"caught_level": 5, "caught_time": 1, "caught_location": 2,
+			}))
+			assert_eq(results[0]["status"], &"waiting")
+			assert_eq(results[0]["event"]["text"], String(row[1 if chosen < 0 else 2]))

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -580,3 +580,66 @@ func test_the_outbox_passes_a_cry_and_drops_everything_else() -> void:
 	assert_eq(int(taken[0]["species"]), 155)
 	assert_eq(actors.take_requests(), [], "The drain empties the outbox.")
 	RomCache.clear(ActorFixture.directory())
+
+
+## `FlyFromAnim` holds the icon on the player's own row for $40 frames and then
+## rises two pixels a frame; `FlyToAnim` descends from four pixels above the
+## screen and stops on the frame its row comes back round to the departure's.
+func test_the_two_flight_animations_run_the_source_rows() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_fly(7, false)
+	var first: Dictionary = effects.sprites()[0]
+	assert_eq(first["kind"], Gen2WorldEffects.SPRITE_FLY_MON)
+	assert_eq(first["icon"], 7)
+	assert_eq((first["tiles"][0] as Dictionary)["offset"], Vector2i(64, 60))
+
+	for _frame: int in Gen2WorldEffects.FLY_HOLD_FRAMES - 1:
+		effects.advance_frame()
+	assert_eq(_fly_offset(effects), Vector2i(64, 60), "nothing moves until VAR2 is $40")
+	effects.advance_frame()
+	assert_eq(_fly_offset(effects), Vector2i(64, 58), "then two pixels a frame")
+
+	for _frame: int in Gen2WorldEffects.FLY_FROM_FRAMES:
+		effects.advance_frame()
+	assert_false(effects.sprites_active(), "128 frames and the sprites are gone")
+
+	effects.start_fly(7, true)
+	assert_eq(_fly_offset(effects), Vector2i(64, 228),
+		"the arrival's own row, which the OAM byte has wrapped")
+	for _frame: int in 44:
+		effects.advance_frame()
+	assert_eq(_fly_offset(effects), Vector2i(64, 60), "and lands where the departure left")
+	effects.advance_frame()
+	assert_eq(_fly_offset(effects), Vector2i(64, 60), "`ret z` stops it there")
+
+
+## `.SpawnLeaf` puts a leaf at column zero every eight frames, at one of four
+## rows, and `SpriteAnimFunc_FlyLeaf` walks it two pixels out and one up.
+func test_a_flight_spawns_one_leaf_every_eight_frames() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_fly(7, false)
+	assert_eq(effects.sprites().size(), 2, "the icon and the first leaf")
+	var leaf: Dictionary = effects.sprites()[1]
+	assert_eq(leaf["kind"], Gen2WorldEffects.SPRITE_CUT_LEAF)
+	assert_eq((leaf["tiles"][0] as Dictionary)["offset"], Vector2i(-12, 44))
+
+	for _frame: int in Gen2WorldEffects.FLY_LEAF_INTERVAL:
+		effects.advance_frame()
+	assert_eq(effects.sprites().size(), 3)
+	assert_eq((effects.sprites()[1]["tiles"][0] as Dictionary)["offset"],
+		Vector2i(4, 36), "two out and one up a frame")
+	assert_eq((effects.sprites()[2]["tiles"][0] as Dictionary)["offset"],
+		Vector2i(-12, 60), "the next row up the `and $18` cycle")
+
+
+## `FlyFunction_FrameTimer` plays SFX_FLY while its counter is still $40 or more
+## and a multiple of eight, which is nine times leaving and once arriving.
+func test_the_flight_sound_follows_the_frame_counter() -> void:
+	assert_eq(Gen2WorldEffects.fly_sfx_frames(false).size(), 9)
+	assert_eq(Gen2WorldEffects.fly_sfx_frames(false)[0], 0)
+	assert_eq(Gen2WorldEffects.fly_sfx_frames(false)[1], 8)
+	assert_eq(Gen2WorldEffects.fly_sfx_frames(true), [0] as Array[int])
+
+
+func _fly_offset(effects: Gen2WorldEffects) -> Vector2i:
+	return (effects.sprites()[0]["tiles"][0] as Dictionary)["offset"]

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -76,9 +76,6 @@ func _check_game() -> void:
 	_check_object_movement(pin)
 
 
-# --- Map block arrays -------------------------------------------------------
-
-
 func _check_blocks(pin: String) -> void:
 	var attributes: Dictionary = _attributes(pin)
 	var blockdata: Dictionary = _blockdata(pin)
@@ -140,9 +137,6 @@ func _check_block_reach(id: String, map: Gen2WorldMap) -> int:
 			id, highest, map.tileset, tileset.block_count
 		])
 	return highest
-
-
-# --- Metatiles, collision and palette maps ----------------------------------
 
 
 func _check_tilesets(pin: String) -> void:
@@ -222,9 +216,6 @@ func _check_palette_reach(number: int, tileset: Gen2WorldTileset) -> void:
 		_report("tileset %d names tile %d, past its %d-byte palette map." % [
 			number, highest, tileset.palette_map.size()
 		])
-
-
-# --- Roofs ------------------------------------------------------------------
 
 
 ## `MapGroupRoofs`, `RoofPals` and the strip `LoadMapGroupRoof` writes over. The
@@ -420,12 +411,6 @@ func _roof_palettes(pin: String) -> Array:
 	)
 
 
-# --- Comparison -------------------------------------------------------------
-
-
-# --- Object movement rows ---------------------------------------------------
-
-
 ## Every `object_event`'s movement byte against the pin's own `maps/*.asm`, and
 ## every row the corpus names against what answers it here. The second half is
 ## how the two fixed spins and the bouncing icon were found standing still.
@@ -513,9 +498,6 @@ func _report(message: String) -> void:
 	printerr("%-8s %s" % [_r.game_id, message])
 
 
-# --- The pinned sources -----------------------------------------------------
-
-
 ## `constants/map_constants.asm` in order: `newgroup` opens a group and each
 ## `map_const` is the next map in it, the walk `MapGroupPointers` is indexed by.
 func _map_ids(pin: String) -> Array:
@@ -580,7 +562,6 @@ func _label_paths(pin: String, relative: String) -> Dictionary:
 	return _parsed(pin, StringName(relative), func() -> Dictionary:
 		return _includes(pin.path_join(relative))
 	)
-
 
 
 ## The tilesets `home/map.asm` gates `LoadMapGroupRoof` on, read off the pin's
@@ -702,9 +683,6 @@ func _includes(path: String) -> Dictionary:
 		elif line.ends_with(":") or line.ends_with("::"):
 			pending.append(line.trim_suffix(":").trim_suffix(":"))
 	return out
-
-
-# --- Files ------------------------------------------------------------------
 
 
 ## One pin's parse of [param key], computed once per run. Every table here is

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -18,6 +18,7 @@ const KIND_HELP: Dictionary = {
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
 	&"catch_dex": "none: NewPokedexEntry's page, over the fight the catch that opened it is still in",
 	&"cut": "cell: OWCutAnimation's two halves and the jump shadow",
+	&"fly": "none: FlyFromAnim 80 frames in, with HideSprites' empty OAM behind it",
 	&"tile_anim": "frames: the map that many AnimateTileset frames in",
 	&"unown_wall": "cell: DisplayUnownWords' box. Group 3 maps 23 to 26 say HO-OH, ESCAPE, WATER, LIGHT",
 	&"mart_top": "cell in front of the counter: MartWelcomeText and MenuHeader_BuySell over the map",
@@ -313,7 +314,7 @@ func _settle_mon_special(host_property: String) -> void:
 ## The kinds that drove themselves to the frame they want. Every other kind
 ## stages a sprite and then spends the frames it needs.
 const SELF_DRIVEN_KINDS: Array[StringName] = [
-	&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine",
+	&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine", &"fly",
 	&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
 	&"catch_tutorial",
 	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",


### PR DESCRIPTION
## Added

`FlyFromAnim` and `FlyToAnim`, which were not built at all: a flight was a silent warp. `Gen2WorldEffects.start_fly` now runs both. `HideSprites` empties the map, the party member's own menu icon holds the player's row for 64 frames and then rises two pixels a frame with a widening cosine swing, the warp lands, and 64 more frames descend from four pixels above the screen onto the row it left. One leaf crosses the screen every eight frames and `FlyFunction_FrameTimer` plays SFX_FLY nine times leaving and once arriving.

`live fly` on `tools/preview_world.gd`, which photographs the departure 80 frames in.

## Fixed

The SOUND option did nothing until the next launch, from either the start menu's OPTION block or the launcher card. `Options_Sound` spends `RestartMapMusic` and the driver reads `wOptions`' STEREO bit live, where `Gen2AudioPlayer` copied it once in `_ready`. It now follows the shared settings object every frame the way it already followed the two volumes, and restarts the piece on a change, because `Music_StereoPanning` has already narrowed `channel.tracks` and only a restart widens them again.

Every box a party-selection special stages on the way back from the list was dropped. A completion handler that stages a pause answers with `_stage_*`'s bare `{"ok": true}`, which `Gen2WorldAPI.complete_runtime_request` read as the script having finished, so it cleared the script and took the Seer's readings, the Photo Studio's boxes and the Magikarp Guru's measurement with it.

A cancelled party list at the Seer and at the Photo Studio printed nothing. `PokeSeer`'s `.cancel` prints `SeerDoNothingText` and `PhotoStudio`'s prints `.NoPhotoText`; every other `SelectMonFromParty` caller answers with a script value alone.

## Changed

`# ---` banners are gone from `save_editor.gd`, `save_editor_screen.gd` and `tools/checks/map_data.gd`, and six section labels from `mod_refusal.gd`. `MAX_COMMENT_LINES` drops to 37,779.