### PR TITLE
Divide an HP bar the way the hardware divides it

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1538,10 +1538,10 @@ func _spikes_damage(side: int, events: Array) -> void:
 		note_faint(side, events)
 
 
-## `UpdateUsedMoves`: remembered once, four kept, and a fifth drops the oldest
-## rather than being ignored, which is why it is a queue and not a capped set.
-func _record_used_move(move_number: int) -> void:
-	if move_number == 0 or player_used_moves.has(move_number):
+## `UpdateUsedMoves`, on the player's own side alone: remembered once, four kept,
+## and a fifth drops the oldest rather than being ignored.
+func record_used_move(side: int, move_number: int) -> void:
+	if side != PLAYER or move_number == 0 or player_used_moves.has(move_number):
 		return
 	player_used_moves.append(move_number)
 	if player_used_moves.size() > Gen2BattleMon.MAX_MOVES:
@@ -2757,9 +2757,6 @@ func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 		or Gen2Substatus.has(active_substatus, Gen2Substatus.BIDE)
 	) and move_number != 0
 
-	if side == PLAYER:
-		_record_used_move(move_number)
-
 	# Whether the Pokémon can move at all is asked before the effect is looked up,
 	# which is the cartridge's arrangement: every move goes through it, so no
 	# sequence has to remember to include it.
@@ -2815,8 +2812,6 @@ func run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
 			turn.emit(MOVE_FAILED)
 			turn.end()
 			return
-		if turn.side == PLAYER:
-			_record_used_move(number)
 		var called_turn: Gen2Turn = Gen2Turn.create(
 			self, turn.side, -1, number, called_move, turn.events
 		)

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -5159,6 +5159,8 @@ func _apply_event_state(event: Dictionary) -> void:
 			# `FaintYourPokemon` and `FaintEnemyPokemon` sink the picture before
 			# either prints, so the line waits on the animation.
 			_begin_faint(int(event["side"]))
+		Gen2Battle.MOVE_FORGOTTEN:
+			_play_anim_sound(Gen2MoveForget.SFX_SWITCH_POKEMON)
 		Gen2Battle.SUBSTITUTE_PIC:
 			_set_substitute_pic(int(event["side"]), bool(event["raised"]))
 		Gen2Battle.MINIMIZED:

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -753,6 +753,9 @@ static func _used_move_text(turn: Gen2Turn) -> void:
 	if not turn.called:
 		turn.attacker().last_move_used = turn.move_number
 		turn.attacker().last_counter_move = turn.move_number
+	# `UpdateUsedMoves` runs inside `UsedMoveText`, so a turn that announces
+	# nothing remembers nothing.
+	turn.battle.record_used_move(turn.side, turn.move_number)
 	turn.emit(Gen2Battle.USED_MOVE, {"move": turn.move_number})
 
 

--- a/game/battle/hp_bar_animation.gd
+++ b/game/battle/hp_bar_animation.gd
@@ -3,18 +3,16 @@ extends RefCounted
 
 ## The HP bar draining or filling, one pixel at a time
 ## (engine/battle/anim_hp_bar.asm). The bar arrives before the message that
-## describes the hit, which is the source's order rather than a choice: `NormalHit`
-## runs `applydamage` before `criticaltext`. `_AnimateHPBar` has two branches, keyed
-## on whether the maximum is at least `HP_BAR_LENGTH_PX`; both redraw exactly one
-## pixel per iteration, so both are one pixel per step here, and what differs is
-## only the HP number printed beside the bar, which [method hp] answers.
+## describes the hit: `NormalHit` runs `applydamage` before `criticaltext`.
+## `_AnimateHPBar`'s two branches are keyed on whether the maximum reaches
+## `HP_BAR_LENGTH_PX`; both redraw one pixel per iteration, and what differs is
+## the HP number [method hp] answers.
 
 ## `HP_BAR_LENGTH * TILE_WIDTH`, the bar's full width in pixels.
 const LENGTH_PX: int = Gen2BattleHud.HP_BAR_TILES * Gen2BattleHud.TILE
 
-## `HPBarAnim_BGMapUpdate` waits two frames per redraw, on both the DMG path and
-## the CGB one: a battle bar is `wWhichHPBar` 0 or 1, which takes `.load_0` or
-## `.load_1` into `.finish`'s two `DelayFrame`s.
+## `HPBarAnim_BGMapUpdate` waits two frames per redraw on both paths: a battle bar
+## is `wWhichHPBar` 0 or 1, which takes `.finish`'s two `DelayFrame`s.
 const FRAMES_PER_STEP: int = 2
 
 var _max_hp: int = 0
@@ -24,14 +22,16 @@ var _pixels: int = 0
 var _target_pixels: int = 0
 var _frames: int = 0
 
+var _hp: int = 0
 
-## The animation from [param from_hp] to [param to_hp]. A bar already at its
-## destination is finished on arrival and never ticks.
+
+## A bar already at its destination is finished on arrival and never ticks.
 static func create(from_hp: int, to_hp: int, max_hp: int) -> Gen2HpBarAnimation:
 	var animation := Gen2HpBarAnimation.new()
 	animation._max_hp = max_hp
 	animation._from_hp = from_hp
 	animation._to_hp = to_hp
+	animation._hp = from_hp
 	animation._pixels = Gen2BattleHud.bar_pixels(from_hp, max_hp, LENGTH_PX)
 	animation._target_pixels = Gen2BattleHud.bar_pixels(to_hp, max_hp, LENGTH_PX)
 	return animation
@@ -45,8 +45,7 @@ func pixels() -> int:
 	return _pixels
 
 
-## One hardware frame. Answers whether the bar moved, which is what tells the
-## screen to redraw.
+## One hardware frame. Answers whether the bar moved, so the screen redraws.
 func advance_frame() -> bool:
 	if finished():
 		return false
@@ -55,41 +54,45 @@ func advance_frame() -> bool:
 		return false
 	_frames = 0
 	_pixels += 1 if _target_pixels > _pixels else -1
+	_walk_hp_to_pixels()
 	return true
 
 
+## `LongAnim_UpdateVariables`' own loop: it steps `wCurHPAnimOldHP` one HP at a
+## time until the bar it recomputes draws the pixel count just reached.
+func _walk_hp_to_pixels() -> void:
+	if _max_hp < LENGTH_PX:
+		return
+	var step: int = 1 if _to_hp > _hp else -1
+	while _hp != _to_hp:
+		if Gen2BattleHud.bar_pixels(_hp, _max_hp, LENGTH_PX) == _pixels:
+			return
+		_hp += step
+
+
 ## The HP to print beside the bar while it moves, and the real value once it has
-## arrived.
-##
-## Mid-animation this is the inverse of `ComputeHPBarPixels`, which is what the
-## long branch prints as it steps real HP toward the target. The short branch is
-## `ShortHPBar_CalcPixelFrame`'s own answer instead, whose off-by-one for low HP
-## is switched by `short_hp_bar_number_off_by_one`. Only the number differs,
-## never the bar.
+## arrived. The long branch prints the HP it walked to; the short branch never
+## walks, and answers from `ShortHPBar_CalcPixelFrame` instead.
 func hp() -> int:
 	if finished():
 		return _to_hp
 	if _max_hp <= 0:
 		return 0
-	if _pixels <= 0:
-		return 0
-	if _pixels >= LENGTH_PX:
-		return _max_hp
 	if _max_hp < LENGTH_PX:
 		return _short_bar_hp()
-	@warning_ignore("integer_division")
-	var value: int = _pixels * _max_hp / LENGTH_PX
-	return clampi(maxi(value, 1), 0, _max_hp)
+	return _hp
 
 
-## `ShortHPBar_CalcPixelFrame`, which is how a maximum under the bar's own width
-## recovers an HP number from a pixel count. Its loop subtracts before it tests,
-## so an exact multiple of the width is counted and then rounded up again: one HP
-## too many, which is `docs/bugs_and_glitches.md`'s low-HP off-by-one. pret's fix
-## stops the loop on the zero. The answer is clamped to the two ends of this
-## animation, the routine's own `wCurHPAnimLowHP`/`wCurHPAnimHighHP` comparison,
-## which is why the extra HP is invisible until the drain passes through a multiple.
+## `ShortHPBar_CalcPixelFrame`, which recovers an HP number from a pixel count
+## under a maximum narrower than the bar. Its loop subtracts before it tests, so an
+## exact multiple of the width is counted and then rounded up again: one HP too
+## many, `docs/bugs_and_glitches.md`'s low-HP off-by-one, where pret's fix stops on
+## the zero. `wCurHPAnimLowHP`/`wCurHPAnimHighHP` clamp it to this drain's ends.
 func _short_bar_hp() -> int:
+	if _pixels >= LENGTH_PX:
+		return _max_hp
+	if _pixels <= 0:
+		return 0
 	var total: int = _max_hp * _pixels
 	var counted: int = 0
 	var rest: int = total

--- a/game/data/move_forget.gd
+++ b/game/data/move_forget.gd
@@ -13,6 +13,9 @@ extends RefCounted
 ## How many moves a Pokémon can know at once, NUM_MOVES.
 const MOVE_SLOTS: int = 4
 
+## `Text_1_2_and_Poof`'s own `PlaySFX`, where the text turns into `_MoveForgotText`.
+const SFX_SWITCH_POKEMON: int = 0x20
+
 ## home/hm_moves.asm's `IsHMMove.HMMoves`, in source order. Seven, against the
 ## four [constant Gen2WorldFieldMove.FIELD_MOVES] the overworld acts on:
 ## forgetting is gated on every HM, not on the ones with a field effect here.
@@ -75,7 +78,7 @@ static func did_not_learn_text(mon_name: String, move_name: String) -> String:
 
 
 ## `Text_1_2_and_Poof` then `_MoveForgotText`, as one line where the source
-## shows two: the SFX_SWITCH_POKEMON between them has no route on either screen.
+## shows two. Its caller plays [constant SFX_SWITCH_POKEMON] with it.
 static func forgot_text(mon_name: String, old_move_name: String) -> String:
 	return "1, 2 and… Poof! %s forgot %s. And…" % [mon_name, old_move_name]
 

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -11,6 +11,9 @@ extends RefCounted
 
 const TILE: int = Gen2Font.TILE
 
+## The widest maximum `ComputeHPBarPixels` divides by unshifted.
+const BAR_DIVISOR_MAX: int = 0xFF
+
 ## The HP bar is six tiles of eight pixels; the exp bar is eight.
 const HP_BAR_TILES: int = 6
 const EXP_BAR_TILES: int = 8
@@ -55,15 +58,22 @@ static func from_data(data: GameData) -> Gen2BattleHud:
 
 ## How much of a bar is lit, in pixels.
 ##
-## A Pokémon that is alive never shows an empty bar: the games round down and
-## then put one pixel back, so that fainting is the only thing that empties it.
+## A Pokémon that is alive never shows an empty bar: the games round down and put
+## one pixel back, so fainting is the only thing that empties it.
+## `ComputeHPBarPixels`' divisor is one byte, so a maximum over 255 has product and
+## divisor shifted right two bits first, both shifts truncating.
 static func bar_pixels(current: int, maximum: int, length: int) -> int:
 	if maximum <= 0 or current <= 0:
 		return 0
 	if current >= maximum:
 		return length
+	var product: int = current * length
+	var divisor: int = maximum
+	if maximum > BAR_DIVISOR_MAX:
+		product >>= 2
+		divisor >>= 2
 	@warning_ignore("integer_division")
-	var lit: int = current * length / maximum
+	var lit: int = product / divisor
 	return maxi(lit, 1)
 
 

--- a/game/world/move_tutor_screen.gd
+++ b/game/world/move_tutor_screen.gd
@@ -240,6 +240,7 @@ func _teach(forget_slot: int) -> void:
 				Gen2MoveForget.forgot_text(_mon_name(), _forgotten_name(forget_slot)),
 				learned,
 			]
+			sfx_requested.emit(Gen2MoveForget.SFX_SWITCH_POKEMON, false)
 		_end(Gen2MoveTutor.SCRIPT_VALUE_LEARNED, learned)
 		return
 	var reason: StringName = StringName(result.get("reason", &""))

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1635,6 +1635,7 @@ func _confirm_forget() -> void:
 		)
 		return
 	var target_name: String = _target_name(_forget_party_index)
+	sfx_requested.emit(Gen2MoveForget.SFX_SWITCH_POKEMON, false)
 	_show_pack_result("%s %s" % [
 		Gen2MoveForget.forgot_text(target_name, String(entry.get("name", ""))),
 		Gen2MoveForget.learned_text(target_name, _forget_move_name),

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -127,6 +127,16 @@ const FADE_TO_BLACK_ORDERS: Array[int] = [0xE4, 0xF9, 0xFE, 0xFF]
 const FADE_FROM_BLACK_ORDERS: Array[int] = [0xFF, 0xFE, 0xF9, 0xE4]
 ## `DelayFrames`' own `ld c, 2` inside either loop.
 const FADE_STEP_FRAMES: int = 2
+
+## `LoadPoisonBGPals.cgb` writes `palred 28 + palgreen 21 + palblue 31` over all
+## eight background palettes: `ld c, 4 palettes` is 32 iterations of two bytes.
+const POISON_FLASH_COLOR: int = 28 | (21 << 5) | (31 << 10)
+const POISON_FLASH_FRAMES: int = 4
+
+
+static func poison_flash_palette() -> PackedColorArray:
+	var colour: Color = Gen2Palette.from_packed(POISON_FLASH_COLOR)
+	return PackedColorArray([colour, colour, colour, colour])
 ## `BattleTowerFade` is `FadeOutToWhite`'s four rows with `ld c, 7` instead.
 const BATTLE_TOWER_FADE_STEP_FRAMES: int = 7
 

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -85,6 +85,7 @@ var _transition_opponent: int = -1
 ## their own colours. The map fade is the other shape and goes through
 ## [method set_fade], which is both.
 var _transition_order: int = Gen2BattleTransition.IDENTITY
+var _poison_flash: bool = false
 ## The one patterned tile of the pair, cached rather than drawn pixel by pixel:
 ## the transition is redrawn once for the screen and again over the lower half of
 ## every sprite standing in grass.
@@ -316,7 +317,22 @@ func _current_palettes() -> Array:
 	return entry["palettes"] if not entry.is_empty() else []
 
 
+## `LoadPoisonBGPals` writes `wBGPals2` alone, so the sprites keep their colours.
+func set_poison_flash(on: bool) -> void:
+	if on == _poison_flash:
+		return
+	_poison_flash = on
+	_rebuild_atlas()
+	queue_redraw()
+
+
 func _tile_palettes_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
+	if _poison_flash:
+		var flooded: Array = []
+		var flash: PackedColorArray = Gen2WorldPalette.poison_flash_palette()
+		for _tile: int in tileset.tile_count:
+			flooded.append(flash)
+		return flooded
 	## `StartTrainerBattle_LoadPokeBallGraphics.pal_loop` puts every background
 	## tile on `PAL_BG_TEXT` and fills that one palette, which is why a trainer
 	## transition draws the whole map in four colours.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -125,6 +125,9 @@ var _map_fade: Dictionary = {}
 ## `FadeOutToWhite` holds the screen white until its own `FadeInFromWhite` runs,
 ## so the last row of a finished fade stays applied rather than snapping back.
 var _script_fade: Dictionary = {}
+## `LoadPoisonBGPals`' own `DelayFrames`, and what the poison step owes behind it.
+var _poison_flash_frames: int = 0
+var _poison_flash_after: Callable = Callable()
 var _script_fade_order: int = Gen2WorldPalette.FADE_IDENTITY
 var _script_fade_white: bool = false
 ## `DoBattleTransition` and the battle it is in front of: the encounter is
@@ -946,6 +949,7 @@ func _advance_presentation(map_pass: bool) -> void:
 	## and nothing else runs while `RunMapSetupScript` is spending its own.
 	_advance_map_fade()
 	_advance_script_fade()
+	_advance_poison_flash()
 	## `DoBattleTransition`'s own `.loop`, which owns every frame between the
 	## encounter and the battle screen.
 	_advance_battle_transition()
@@ -1810,11 +1814,10 @@ func _spend_egg_steps() -> void:
 
 
 ## `DoPoisonStep`, which `CountStep` reaches on the pass `wPoisonStepCount`
-## carries to 4 and which resets the counter whether or not anything is
-## poisoned. The party lives on the save, so the walk counts the step and this
-## spends it, the way [method _spend_step_happiness] does for `StepHappiness`.
-## Answers whether it took the screen: a faint is `PLAYEREVENT_WHITEOUT`'s own
-## script, and everything a step still owes waits behind its presses.
+## carries to 4 and which resets the counter whether or not anything is poisoned.
+## The party lives on the save, so the walk counts the step and this spends it.
+## Answers whether it took the screen: everything a step still owes waits behind
+## the presses a faint's own `PLAYEREVENT_WHITEOUT` script asks for.
 func _spend_poison_steps() -> bool:
 	if _world == null or _world.state == null or _data == null:
 		return false
@@ -1827,6 +1830,7 @@ func _spend_poison_steps() -> bool:
 	var pass_result: Dictionary = Gen2WorldPartyHost.apply_poison_step(_data, save)
 	if bool(pass_result.get("sfx", false)):
 		_play_sfx(SFX_POISON)
+		_start_poison_flash()
 	var texts: PackedStringArray = pass_result.get("texts", PackedStringArray())
 	if texts.is_empty():
 		if not PackedInt32Array(pass_result.get("damaged", PackedInt32Array())).is_empty():
@@ -1841,17 +1845,44 @@ func _spend_poison_steps() -> bool:
 		lines.append(Gen2Nuzlocke.death_text(Gen2Nuzlocke.grave_name(_data, lost)))
 	if bool(pass_result.get("whiteout", false)):
 		lines.append_array(_whiteout_texts())
-		_show_player_event(lines, _finish_whiteout)
+		_hold_poison_flash(_show_player_event.bind(lines, _finish_whiteout))
 	else:
 		_persist_after_poison_step(save)
-		_show_player_event(lines, Callable())
+		_hold_poison_flash(_show_player_event.bind(lines, Callable()))
 	return true
 
 
-## The save write the poison pass owes. `DoPoisonStep` writes WRAM and the
-## cartridge commits on the player's own save, but this port keeps the party on
-## disk, so a pass that moved HP is written where it happened; a whiteout writes
-## once at the end of its own script instead.
+## `.PlayPoisonSFX` floods the background and spends four frames of its own.
+func _start_poison_flash() -> void:
+	_poison_flash_frames = Gen2WorldPalette.POISON_FLASH_FRAMES
+	if _renderer != null and _renderer.has_method("set_poison_flash"):
+		_renderer.set_poison_flash(true)
+
+
+func _hold_poison_flash(after: Callable) -> void:
+	if _poison_flash_frames <= 0:
+		after.call()
+		return
+	_poison_flash_after = after
+
+
+func _advance_poison_flash() -> void:
+	if _poison_flash_frames <= 0:
+		return
+	_poison_flash_frames -= 1
+	if _poison_flash_frames > 0:
+		return
+	if _renderer != null and _renderer.has_method("set_poison_flash"):
+		_renderer.set_poison_flash(false)
+	var after: Callable = _poison_flash_after
+	_poison_flash_after = Callable()
+	if after.is_valid():
+		after.call()
+
+
+## The save write the poison pass owes. `DoPoisonStep` writes WRAM, but this port
+## keeps the party on disk, so a pass that moved HP is written where it happened;
+## a whiteout writes once at the end of its own script instead.
 func _persist_after_poison_step(save: Gen2SaveData) -> void:
 	if save == null or _data == null or _injected_save != null:
 		return

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1903,6 +1903,10 @@ func test_the_last_member_fainting_to_poison_opens_the_whiteout() -> void:
 	for _step: int in Gen2WorldState.POISON_STEP_PHASE:
 		state.count_step()
 	assert_true(_world_screen._spend_poison_steps(), "the pass takes the turn")
+	## `.PlayPoisonSFX` floods the background and spends four frames before
+	## `.Script_MonFaintedToPoison` reaches its own `opentext`.
+	assert_false(_world_screen._field_move_text, "the flash comes first")
+	_world_screen.advance_frames(Gen2WorldPalette.POISON_FLASH_FRAMES)
 	assert_true(_world_screen._field_move_text, "the faint owns the box")
 	assert_eq(mon.hp, 0)
 	assert_eq(mon.status, Gen2Status.NONE, "the faint clears the status")
@@ -1960,6 +1964,7 @@ func test_a_nuzlocke_wipe_ends_the_run_instead_of_whiting_out() -> void:
 	assert_true(save.party.is_empty(), "the faint took the row off the party")
 	assert_eq((save.nuzlocke["graveyard"] as Array).size(), 1)
 	assert_eq(String((save.nuzlocke["graveyard"] as Array)[0]["nickname"]), "CYNDER")
+	_world_screen.advance_frames(Gen2WorldPalette.POISON_FLASH_FRAMES)
 	var said: String = ""
 	for _press: int in 200:
 		said += "".join(_world_screen._text_box.text_lines())

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3189,6 +3189,20 @@ func test_the_players_used_moves_are_remembered_once_and_cleared_on_a_switch() -
 	assert_eq(battle.player_used_moves, [] as Array[int], "the list describes the Pokemon")
 
 
+## `UpdateUsedMoves` is called from `UsedMoveText`, so a turn frozen solid never
+## announces a move and never remembers one.
+func test_a_move_that_is_never_announced_is_never_remembered() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])), _rng, true
+	)
+	battle.player.status = Gen2Status.FREEZE
+
+	battle.take_turn(0, 0)
+
+	assert_eq(battle.player_used_moves, [] as Array[int])
+
+
 ## The enemy's own send-out leaves the list alone: it records what the player has
 ## shown, not what it is being shown to.
 func test_an_enemy_switch_leaves_the_used_move_list_alone() -> void:

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -136,6 +136,16 @@ func test_a_pokemon_that_is_alive_never_shows_an_empty_bar() -> void:
 	assert_eq(Gen2BattleHud.bar_pixels(1, 999, 48), 1)
 
 
+## `ComputeHPBarPixels`' divisor is one byte, so a maximum over 255 shifts both
+## product and divisor right two bits, and both shifts truncate: 300 of 401 is
+## 35 exactly and 36 the way the routine divides it.
+func test_a_maximum_over_a_byte_is_divided_the_way_the_routine_divides_it() -> void:
+	assert_eq(Gen2BattleHud.bar_pixels(300, 401, 48), 36)
+	assert_eq(300 * 48 / 401, 35, "and not the exact fraction")
+	assert_eq(Gen2BattleHud.bar_pixels(400, 401, 48), 48, "a nearly full bar still fills")
+	assert_eq(Gen2BattleHud.bar_pixels(128, 256, 48), 24, "an exact half is unchanged")
+
+
 func test_a_bar_is_as_full_as_the_fraction_behind_it() -> void:
 	assert_eq(Gen2BattleHud.bar_pixels(10, 20, 48), 24)
 	assert_eq(Gen2BattleHud.bar_pixels(5, 20, 48), 12)

--- a/tests/unit/test_hp_bar_animation.gd
+++ b/tests/unit/test_hp_bar_animation.gd
@@ -76,6 +76,17 @@ func test_the_printed_hp_follows_the_bar_down() -> void:
 	assert_eq(int(seen[-1]), 0)
 
 
+## `LongAnim_UpdateVariables` steps the real HP one at a time and stops at the
+## first value that redraws the bar, so the number beside a draining bar is the
+## highest HP still on that pixel rather than the lowest.
+func test_the_long_branch_prints_the_hp_it_walked_to() -> void:
+	var animation: Gen2HpBarAnimation = Gen2HpBarAnimation.create(100, 0, 100)
+	animation.advance_frame()
+	animation.advance_frame()
+	assert_eq(animation.pixels(), Gen2HpBarAnimation.LENGTH_PX - 1)
+	assert_eq(animation.hp(), 99, "the first HP that draws 47 pixels of 48")
+
+
 ## The two source branches are keyed on whether the maximum reaches the bar's
 ## own width; both redraw one pixel at a time, so both take the same walk.
 func test_a_small_maximum_still_walks_pixel_by_pixel() -> void:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -532,14 +532,17 @@ func _stage_gift_nickname() -> void:
 		_settle_mon_special("_nickname_host")
 
 
-## `Script_Whiteout`, which no fixture cell reaches: the party is poisoned down to its
-## last point and the pass `CountStep` owes is spent. The first number is how many of
-## its presses to spend, so 0 is the faint line, 1 the first page of `_WhitedOutText`
-## and 3 the map the player wakes up on.
+## `Script_Whiteout`, which no fixture cell reaches: the party is poisoned down to
+## its last point and the pass `CountStep` owes spent. The first number is presses,
+## so 0 is the faint line, 1 the first page of `_WhitedOutText` and 3 the map the
+## player wakes up on. A second number stops that many frames into
+## `.PlayPoisonSFX`'s own four instead, which is the flooded background.
 func _stage_whiteout() -> void:
 	_screen.preview_whiteout()
-	## The box reveals a letter at a time at the OPTION menu's own speed,
-	## so each press is given behind the frames its page costs.
+	if _cell.y > 0:
+		_screen.advance_frames(_cell.y)
+		return
+	## Each press is given behind the frames its own page costs to reveal.
 	for _press: int in maxi(_cell.x, 0) + 1:
 		for _frame: int in 120:
 			_screen.advance_frame()


### PR DESCRIPTION
Eight source files walked whole against the pins, five defects closed.

## Fixed

`ComputeHPBarPixels`' divisor is one byte, so a maximum over 255 has the product and the divisor shifted right two bits before the division, and both shifts truncate. `Gen2BattleHud.bar_pixels` divided exactly, so 300 HP of 401 drew 35 pixels where the routine answers 36. The battle HUD, the party menu, the stats screen and the bar animation all read it. `.reversal`'s own `ldh a, [hProduct + 4]` is `hDivisor` rather than a fifth product byte, since the two share one `UNION`.

`LongAnim_UpdateVariables` steps `wCurHPAnimOldHP` one HP at a time and recomputes the bar, printing the first value that draws the pixel count just reached. This printed `pixels * max / 48` instead, which is the other end of that pixel's HP band: draining 100 of 100 printed 97 where the cartridge prints 99.

`UpdateUsedMoves` is called from inside `UsedMoveText`, so a turn that never announces a move never remembers one. This recorded at the top of the turn, so a frozen or sleeping Pokemon fed the trainer's switch scoring moves it never showed. Recording now happens at the announcement, which also covers a called move without a second call site.

`LoadPoisonBGPals` was not built, so a poison step took HP with no picture. `.PlayPoisonSFX` floods the background with `palred 28 + palgreen 21 + palblue 31` and spends four frames before `.Script_MonFaintedToPoison` reaches its `opentext`. `ld c, 4 palettes` is 32 iterations of two bytes, which is all eight background palettes rather than four, and `wBGPals2` alone, so the sprites standing on the map keep their colours.

`Text_1_2_and_Poof` plays SFX_SWITCH_POKEMON where the line turns into `_MoveForgotText`. All three screens that print it now ask for the sound.

## Checked

Unit and scene tiers green, 4,162 tests. `validate.gd -- all` passes all 84 topics. `replay_world.gd` runs 33 routes with no failures. The three-profile story walk stops on the same leg with the same reason as `main`. The editor analyser reports 0 warnings in 609 scripts.
