### PR TITLE
A machine with no coins in front of it stays shut

### DIFF
--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -493,7 +493,7 @@ func _blackout_refusal() -> String:
 		return ""
 	if rows().size() < BLACKOUT_ROWS:
 		return PROMPT_LAST_MON
-	if _all_others_fainted():
+	if _save.others_all_fainted(_cursor + _scroll):
 		return PROMPT_NO_USABLE
 	# `wBillsPC_MonHasMail`, which `BillsPC_PrintMonInfo` writes for the row the
 	# cursor stands on rather than for a stored selection.
@@ -501,20 +501,6 @@ func _blackout_refusal() -> String:
 	if mon != null and not mon.is_egg and Gen2HeldItem.is_mail(mon.item):
 		return PROMPT_REMOVE_MAIL
 	return ""
-
-
-## `CheckCurPartyMonFainted`: whether every party member but the chosen one has
-## no HP left. `wCurPartyMon` is `wBillsPC_CursorPosition` plus the scroll, so
-## the one left out is the row under the cursor.
-func _all_others_fainted() -> bool:
-	var chosen: int = _cursor + _scroll
-	for index: int in _save.party.size():
-		if index == chosen:
-			continue
-		var mon: Gen2SaveMon = _save.party[index]
-		if mon != null and mon.hp > 0:
-			return false
-	return true
 
 
 ## `BillsPC_StatsScreen`, `StatsScreenInit` over this screen. `_StatsScreenDPad`

--- a/game/save/save_data.gd
+++ b/game/save/save_data.gd
@@ -347,6 +347,25 @@ func deposit_box_slot() -> Dictionary:
 	return {"ok": true, "box": box_index, "slot": empty_slot}
 
 
+## `CheckCurPartyMonFainted`: carry when every slot but [param party_index]
+## reads zero HP. `DayCare_GiveEgg` zeroes an egg's, so an egg is fainted here.
+func others_all_fainted(party_index: int) -> bool:
+	for index: int in party.size():
+		if index == party_index:
+			continue
+		var other: Gen2SaveMon = party[index] as Gen2SaveMon
+		if other != null and other.hp > 0:
+			return false
+	return true
+
+
+func party_fainted_flags() -> Array:
+	var out: Array = []
+	for member: Variant in party:
+		out.append(member is Gen2SaveMon and (member as Gen2SaveMon).hp <= 0)
+	return out
+
+
 ## `_GetVarAction`'s `.BoxFreeSpace`, which is `MONS_PER_BOX - [sBoxCount]` on
 ## the open box alone. A full one answers 0, which is the same refusal the
 ## source's zero gives every script that reads the var.

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -444,7 +444,7 @@ static func deposit_refusal(save: Gen2SaveData, party_index: int) -> String:
 		return TEXT_CANT_BREED_EGG
 	## `CheckCurPartyMonFainted`, which refuses the *last* healthy member rather
 	## than a fainted one: a fainted member may be deposited if another can walk.
-	if _last_healthy(save, party_index):
+	if save.others_all_fainted(party_index):
 		return TEXT_LAST_ALIVE_MON
 	if Gen2HeldItem.is_mail(mon.item):
 		return TEXT_REMOVE_MAIL
@@ -563,18 +563,6 @@ static func _can_learn_tm_hm(data: GameData, species: int, number: int) -> bool:
 	if index >= (flags as Array).size():
 		return false
 	return int((flags as Array)[index]) & (1 << (bit & 7)) != 0
-
-
-## `CheckCurPartyMonFainted`, which is `.OutOfUsableMons` when no *other* member
-## can still walk.
-static func _last_healthy(save: Gen2SaveData, party_index: int) -> bool:
-	for index: int in save.party.size():
-		if index == party_index:
-			continue
-		var other: Gen2SaveMon = save.party[index] as Gen2SaveMon
-		if other != null and not other.is_egg and other.hp > 0:
-			return false
-	return true
 
 
 ## `.day_care_lady`'s three `inc [hl]`: one point of experience, with the high

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -367,6 +367,18 @@ const ITEM_ESCAPE_ROPE: int = 0x13
 ## prints its count inside the pack and closes nothing, so it has no field
 ## effect and the screen answers it where the other CURRENT rows are answered.
 const ITEM_COIN_CASE: int = 0x36
+## `CheckCoinsAndCoinCase`, which `SlotMachine` and `CardFlip` run first: an
+## empty purse is refused before the Coin Case is looked for.
+const NO_COINS_TEXT: String = "You have no coins."
+const NO_COIN_CASE_TEXT: String = "You don't have a\nCOIN CASE."
+
+
+static func coin_game_refusal(state: Gen2WorldState) -> String:
+	if state == null or state.coins() <= 0:
+		return NO_COINS_TEXT
+	return "" if state.item_quantity(ITEM_COIN_CASE) > 0 else NO_COIN_CASE_TEXT
+
+
 ## `BlueCardEffect`, the Coin Case's twin: `MenuTextboxWaitButton` over the
 ## balance. Crystal's alone, because Buena is.
 const ITEM_BLUE_CARD: int = 0x74

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -22,17 +22,21 @@ const PALETTE_NITE: int = 2
 const PALETTE_MORN: int = 3
 const PALETTE_DARK: int = 4
 
-## `.BrightnessLevels`, one row per [constant PALETTE_AUTO] and its four
-## neighbours, read by the clock's own time of day. The cartridge packs each row
-## into a byte two bits at a time and `GetTimePalette` picks the pair back out;
-## the byte is not kept here because nothing else reads it.
+## `.BrightnessLevels`, read by the clock's own time of day; `GetTimePalette`
+## picks each row's pair out of a packed byte. `ReplaceTimeOfDayPals` indexes it
+## with `maskbits NUM_MAP_PALETTES`, `and %111`, so the three rows past
+## `PALETTE_DARK` repeat `PALETTE_AUTO`'s.
 const BRIGHTNESS_LEVELS: Array = [
 	[TIME_MORNING, TIME_DAY, TIME_NIGHT, TIME_DARK],
 	[TIME_DAY, TIME_DAY, TIME_DAY, TIME_DAY],
 	[TIME_NIGHT, TIME_NIGHT, TIME_NIGHT, TIME_NIGHT],
 	[TIME_MORNING, TIME_MORNING, TIME_MORNING, TIME_MORNING],
 	[TIME_DARK, TIME_DARK, TIME_DARK, TIME_DARK],
+	[TIME_MORNING, TIME_DAY, TIME_NIGHT, TIME_DARK],
+	[TIME_MORNING, TIME_DAY, TIME_NIGHT, TIME_DARK],
+	[TIME_MORNING, TIME_DAY, TIME_NIGHT, TIME_DARK],
 ]
+const PALETTE_MASK: int = 0x07
 
 
 ## Which of the four palette rows a map draws with right now.
@@ -46,7 +50,7 @@ static func map_time_of_day(
 ) -> int:
 	if map_palette == PALETTE_DARK:
 		return TIME_NIGHT if used_flash else TIME_DARK
-	var row: Array = BRIGHTNESS_LEVELS[clampi(map_palette, 0, BRIGHTNESS_LEVELS.size() - 1)]
+	var row: Array = BRIGHTNESS_LEVELS[map_palette & PALETTE_MASK]
 	return int(row[clampi(clock_time_of_day, 0, row.size() - 1)])
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2425,6 +2425,8 @@ func _on_unown_puzzle_closed(solved: bool) -> void:
 func _open_slot_machine(request: Dictionary) -> bool:
 	if _slot_machine_host != null or _world == null or _data == null:
 		return false
+	if _refuse_coin_game(request):
+		return false
 	var values: Dictionary = request.get("values", {})
 	var host := Gen2SlotMachineScreen.new()
 	## The bias, the reel manipulation and both streak rolls come off the
@@ -2464,11 +2466,31 @@ func _on_slot_machine_closed(coins: int) -> void:
 	}))
 
 
+## `CheckCoinsAndCoinCase`'s `scf`. The guard is the special's, so a request
+## without one is a preview naming its own balance.
+func _refuse_coin_game(request: Dictionary) -> bool:
+	if not (request.get("values", {}) as Dictionary).has("special"):
+		return false
+	var line: String = Gen2WorldPack.coin_game_refusal(_world.state)
+	if line.is_empty():
+		return false
+	if _text_box != null and _text_box.font != null:
+		_apply_text_box_options()
+		_text_awaits_press = false
+		_text_box.show_text(line, false)
+		_text_box.visible = true
+	_script_prompt = line
+	_refresh_labels()
+	return true
+
+
 ## `special CardFlip`. Its objects are drawn in `wOBPals1` palette 0, which
 ## `CardFlip_InitAttrPals` never writes, so the map's own `PAL_OW_RED` is handed
 ## over with the request.
 func _open_card_flip(request: Dictionary) -> bool:
 	if _card_flip_host != null or _world == null or _data == null:
+		return false
+	if _refuse_coin_game(request):
 		return false
 	var values: Dictionary = request.get("values", {})
 	var host := Gen2CardFlipScreen.new()
@@ -7965,12 +7987,8 @@ func _on_party_selection_made(party_index: int) -> void:
 		_refresh_labels()
 		return
 	var result: Dictionary = {"ok": true, "party_index": -1}
-	## `CheckCurPartyMonFainted` walks `wPartyMon1HP` for every slot but the
-	## chosen one, so the whole column travels with the row that was picked.
-	var party_fainted: Array = []
-	if save != null:
-		for member: Variant in save.party:
-			party_fainted.append(member is Gen2SaveMon and (member as Gen2SaveMon).hp <= 0)
+	## The whole column travels with the row that was picked.
+	var party_fainted: Array = save.party_fainted_flags() if save != null else []
 	if save != null and party_index >= 0 and party_index < save.party.size():
 		var mon: Gen2SaveMon = save.party[party_index] as Gen2SaveMon
 		if mon != null:

--- a/tests/unit/test_world_day_care.gd
+++ b/tests/unit/test_world_day_care.gd
@@ -249,6 +249,9 @@ func test_an_egg_and_the_last_healthy_member_are_each_refused() -> void:
 	var save: Gen2SaveData = Gen2SaveData.new()
 	var egg: Gen2SaveMon = _mon(CUBONE)
 	egg.is_egg = true
+	# `DayCare_GiveEgg` zeroes MON_HP after `CalcMonStats`, which is what makes
+	# `CheckCurPartyMonFainted` count an egg as fainted.
+	egg.hp = 0
 	save.party = [egg, _mon(HOOTHOOT)]
 	assert_eq(
 		Gen2WorldDayCare.deposit_refusal(save, 0),

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -2318,3 +2318,21 @@ func test_an_object_step_span_survives_a_stream_that_turns() -> void:
 			walked, Vector2(object.cell) + object.step_offset_cells(fraction),
 			Vector2(0.001, 0.001), str(fraction)
 		)
+
+
+## `ReplaceTimeOfDayPals` masks with `maskbits NUM_MAP_PALETTES` rather than
+## clamping, so a map header past PALETTE_DARK reads one of the three repeats of
+## PALETTE_AUTO's row instead of the cave's.
+func test_a_map_palette_past_the_last_one_wraps_onto_auto() -> void:
+	for palette: int in [5, 6, 7, 13]:
+		assert_eq(
+			Gen2WorldPalette.map_time_of_day(palette, Gen2WorldPalette.TIME_DAY),
+			Gen2WorldPalette.TIME_DAY,
+			"palette %d" % palette
+		)
+	assert_eq(
+		Gen2WorldPalette.map_time_of_day(
+			Gen2WorldPalette.PALETTE_DARK, Gen2WorldPalette.TIME_DAY
+		),
+		Gen2WorldPalette.TIME_DARK
+	)

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -434,3 +434,18 @@ func test_an_order_that_is_not_a_permutation_is_refused() -> void:
 		{"ok": false, "reason": &"invalid_item_order"}
 	)
 	assert_eq(state.items().keys(), [ITEM_ANTIDOTE, ITEM_POTION])
+
+
+## `CheckCoinsAndCoinCase`: no coins is answered before the Coin Case is looked
+## for, and the Game Corner's two games share the one guard.
+func test_a_coin_game_names_the_first_thing_missing() -> void:
+	var broke := Gen2WorldState.new({}, {}, {Gen2WorldPack.ITEM_COIN_CASE: 1})
+	assert_eq(Gen2WorldPack.coin_game_refusal(broke), Gen2WorldPack.NO_COINS_TEXT)
+	var caseless := Gen2WorldState.new({}, {}, {ITEM_POTION: 1})
+	caseless.apply_changes({}, {}, {"coins": 50})
+	assert_eq(
+		Gen2WorldPack.coin_game_refusal(caseless), Gen2WorldPack.NO_COIN_CASE_TEXT
+	)
+	var playable := Gen2WorldState.new({}, {}, {Gen2WorldPack.ITEM_COIN_CASE: 1})
+	playable.apply_changes({}, {}, {"coins": 1})
+	assert_eq(Gen2WorldPack.coin_game_refusal(playable), "")


### PR DESCRIPTION
Programme 2's walk over eight source files a built screen calls into: `specials.asm`, `timeofday_pals.asm`, `bills_pc_top.asm`, `mail.asm`, `judging.asm`, `read_trainer_party.asm`, `load_pics.asm` and `magnet_train.asm`. Three paid.

## Fixed
- `CheckCoinsAndCoinCase` stands in front of both Game Corner games and neither asked it, so a player who had spent every coin opened the machine anyway. `wCoins` is tested before the bag, so no coins is answered ahead of a missing Coin Case; `Gen2WorldPack.coin_game_refusal` is that order and both openers ask it.
- `ReplaceTimeOfDayPals` indexes `.BrightnessLevels` with `maskbits NUM_MAP_PALETTES`, `and %111` over eight rows whose last three repeat `PALETTE_AUTO`'s. This clamped to `PALETTE_DARK`, so a map header nibble of 5, 6 or 7 drew as a cave.
- `CheckCurPartyMonFainted` had three copies here and they disagreed about eggs. It reads `wPartyMon1HP` and nothing else, and `DayCare_GiveEgg` zeroes MON_HP after `CalcMonStats`, so an egg is fainted for it; the day care was excluding eggs by hand and its own test built one with HP. One `Gen2SaveData.others_all_fainted` now answers the day care, the box list and `checkpokemail`.

## Checked
| Check | Result |
|---|---|
| GUT unit tier | 3562 tests, 66049 asserts, 0 failures |
| Editor analyser | 0 warnings in 609 scripts |
| `validate.gd -- all` | 84 topics pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 150/149/149 steps, identical to `main` |
| Release gates | pass, comments 37779 of 37779 |