### PR TITLE
The Game Corner's refusal owes a press of its own

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -570,6 +570,8 @@ var _pending_switch_offer: int = -1
 ## `wOptions`' BATTLE_SHIFT bit, as the caller's own setting rather than a read
 ## of the options file: the engine is scene-free and takes its rules injected.
 var battle_style_set: bool = false
+## `CheckBattleScene`'s answer, injected the same way and read by `present` alone.
+var battle_scene_on: bool = true
 
 ## Whether `AskUseNextPokemon` was answered for the faint standing. Asked once,
 ## a NO whose run fails falling through to `ForcePlayerMonChoice`.

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1355,10 +1355,10 @@ func entrance_running() -> bool:
 ## it there. Every caller that has just built a battle reaches this, which is the
 ## same order the source uses, `InitBattleDisplay` before `BattleStartMessage`.
 func _init_battle_display() -> void:
-	## `wOptions`' BATTLE_SHIFT bit. The engine takes it injected rather than
-	## reading the options file itself, since it is scene-free; this is the one
-	## place every battle here passes through.
+	## The engine is scene-free, so `wOptions` is injected here, the one place
+	## every battle passes through.
 	_battle.battle_style_set = Gen2OptionsStore.current().battle_style_set
+	_battle.battle_scene_on = Gen2OptionsStore.current().battle_scene
 	## `InitBattleDisplay` draws both pics, so the letters start from the party
 	## the same way the species above do; every later change is a send-out.
 	_enemy_unown_form = Gen2Battle.unown_form_of(_battle.enemy)

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -1011,7 +1011,9 @@ static func _present(turn: Gen2Turn) -> void:
 	_animate_current_move(turn)
 	var target: Gen2BattleMon = turn.defender()
 	if target.hp >= target.max_hp():
-		turn.emit(Gen2Battle.PRESENT_REFUSED, {"target": turn.target})
+		## `.already_fully_healed`'s `jr nc, .do_animation` skips the text.
+		if not turn.battle.battle_scene_on:
+			turn.emit(Gen2Battle.PRESENT_REFUSED, {"target": turn.target})
 		turn.end()
 		return
 

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -367,16 +367,15 @@ const ITEM_ESCAPE_ROPE: int = 0x13
 ## prints its count inside the pack and closes nothing, so it has no field
 ## effect and the screen answers it where the other CURRENT rows are answered.
 const ITEM_COIN_CASE: int = 0x36
-## `CheckCoinsAndCoinCase`, which `SlotMachine` and `CardFlip` run first: an
-## empty purse is refused before the Coin Case is looked for.
+## `CheckCoinsAndCoinCase` tests `wCoins` before the bag.
 const NO_COINS_TEXT: String = "You have no coins."
 const NO_COIN_CASE_TEXT: String = "You don't have a\nCOIN CASE."
 
 
-static func coin_game_refusal(state: Gen2WorldState) -> String:
-	if state == null or state.coins() <= 0:
+static func coin_game_refusal_line(coins: int, coin_cases: int) -> String:
+	if coins <= 0:
 		return NO_COINS_TEXT
-	return "" if state.item_quantity(ITEM_COIN_CASE) > 0 else NO_COIN_CASE_TEXT
+	return "" if coin_cases > 0 else NO_COIN_CASE_TEXT
 
 
 ## `BlueCardEffect`, the Coin Case's twin: `MenuTextboxWaitButton` over the

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2425,8 +2425,6 @@ func _on_unown_puzzle_closed(solved: bool) -> void:
 func _open_slot_machine(request: Dictionary) -> bool:
 	if _slot_machine_host != null or _world == null or _data == null:
 		return false
-	if _refuse_coin_game(request):
-		return false
 	var values: Dictionary = request.get("values", {})
 	var host := Gen2SlotMachineScreen.new()
 	## The bias, the reel manipulation and both streak rolls come off the
@@ -2466,31 +2464,11 @@ func _on_slot_machine_closed(coins: int) -> void:
 	}))
 
 
-## `CheckCoinsAndCoinCase`'s `scf`. The guard is the special's, so a request
-## without one is a preview naming its own balance.
-func _refuse_coin_game(request: Dictionary) -> bool:
-	if not (request.get("values", {}) as Dictionary).has("special"):
-		return false
-	var line: String = Gen2WorldPack.coin_game_refusal(_world.state)
-	if line.is_empty():
-		return false
-	if _text_box != null and _text_box.font != null:
-		_apply_text_box_options()
-		_text_awaits_press = false
-		_text_box.show_text(line, false)
-		_text_box.visible = true
-	_script_prompt = line
-	_refresh_labels()
-	return true
-
-
 ## `special CardFlip`. Its objects are drawn in `wOBPals1` palette 0, which
 ## `CardFlip_InitAttrPals` never writes, so the map's own `PAL_OW_RED` is handed
 ## over with the request.
 func _open_card_flip(request: Dictionary) -> bool:
 	if _card_flip_host != null or _world == null or _data == null:
-		return false
-	if _refuse_coin_game(request):
 		return false
 	var values: Dictionary = request.get("values", {})
 	var host := Gen2CardFlipScreen.new()

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -4994,6 +4994,9 @@ func _special_toggle_decorations_visibility(special: int) -> Dictionary:
 
 
 func _special_slot_machine(special: int) -> Dictionary:
+	var shut: Dictionary = _coin_game_refusal()
+	if not shut.is_empty():
+		return shut
 	return _stage_runtime_request(&"slot_machine_requested", {
 		"special": special,
 		## `Slots_InitBias`' own `ld a, [wScriptVar] / and a`, which is
@@ -5004,10 +5007,32 @@ func _special_slot_machine(special: int) -> Dictionary:
 
 
 func _special_card_flip(special: int) -> Dictionary:
+	var shut: Dictionary = _coin_game_refusal()
+	if not shut.is_empty():
+		return shut
 	return _stage_runtime_request(&"card_flip_requested", {
 		"special": special,
 		"coins": _coins_value(),
 	})
+
+
+## `CheckCoinsAndCoinCase`, which `SlotMachine` and `CardFlip` answer with
+## `ret c`. Both texts end in `prompt`, so the box owes a press of its own.
+func _coin_game_refusal() -> Dictionary:
+	var line: String = Gen2WorldPack.coin_game_refusal_line(
+		_coins_value(), _item_quantity(Gen2WorldPack.ITEM_COIN_CASE)
+	)
+	if line.is_empty():
+		return {}
+	_pending = {
+		"type": &"text",
+		"text": line,
+		"internal_text": true,
+		"prompt": true,
+		"source": _request.duplicate(true),
+	}
+	_finish_after_pending = false
+	return {"ok": true}
 
 
 func _special_unown_puzzle(special: int) -> Dictionary:

--- a/tests/integration/test_world_card_flip.gd
+++ b/tests/integration/test_world_card_flip.gd
@@ -48,7 +48,7 @@ func _write_card_flip_script() -> void:
 	RomCache.write_json(RomCache.world_scripts_path(directory), scripts)
 
 
-func _open_world() -> void:
+func _open_world(carrying_case: bool = true) -> void:
 	var packed: PackedScene = load("res://game/world/world_screen.tscn")
 	_world_screen = packed.instantiate() as Gen2WorldScreen
 	_world_screen.map_group = Fixture.MAP_GROUP
@@ -57,7 +57,12 @@ func _open_world() -> void:
 	## `wCoins` is set where the state is built: nothing writes it outside a
 	## world transaction, which is the boundary the table's own result goes
 	## through when it closes.
-	var state := Gen2WorldState.new({}, {}, {}, {}, COINS)
+	## `CheckCoinsAndCoinCase` stands in front of `StartGameCornerGame` and
+	## asks the bag as well as the balance, so the case is in it.
+	var state := Gen2WorldState.new(
+		{}, {}, {Gen2WorldPack.ITEM_COIN_CASE: 1} if carrying_case else {},
+		{}, COINS if carrying_case else 0
+	)
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(
 		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, state
 	)
@@ -163,3 +168,21 @@ func test_a_played_round_reaches_the_world_state() -> void:
 		_world_screen._world.state.coins(), walked,
 		"the balance the table left must reach the world"
 	)
+
+
+## `CheckCoinsAndCoinCase`'s `scf`, which `CardFlip` answers with `ret c`:
+## `StartGameCornerGame` never runs, `_NoCoinsText` ends in `prompt` and so owes
+## a press of its own, and the map is the player's again once it is spent.
+func test_an_empty_purse_leaves_the_table_shut() -> void:
+	await _open_world(false)
+	_run_script()
+	assert_null(_host(), "no coins must not open the table")
+	assert_true(_world_screen._text_awaits_press, "the line ends in `prompt`")
+	assert_false(_world_screen.move_player(Vector2i.RIGHT), "the box holds the map")
+	for _frame: int in 240:
+		if not _world_screen._world.script_busy():
+			break
+		_world_screen.advance_frame()
+		_world_screen.press_button(Gen2Button.A)
+	assert_false(_world_screen._world.script_busy(), "the press ends the script")
+	assert_true(_world_screen.move_player(Vector2i.RIGHT))

--- a/tests/integration/test_world_slot_machine.gd
+++ b/tests/integration/test_world_slot_machine.gd
@@ -58,7 +58,11 @@ func _open_world() -> void:
 	## `wCoins` is set where the state is built: nothing writes it outside a
 	## world transaction, which is the boundary the machine's own result goes
 	## through when it closes.
-	var state := Gen2WorldState.new({}, {}, {}, {}, COINS)
+	## `CheckCoinsAndCoinCase` stands in front of `StartGameCornerGame` and
+	## asks the bag as well as the balance, so the case is in it.
+	var state := Gen2WorldState.new(
+		{}, {}, {Gen2WorldPack.ITEM_COIN_CASE: 1}, {}, COINS
+	)
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(
 		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, PLAYER_CELL, state
 	)

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -2154,7 +2154,10 @@ func test_presents_fourth_row_heals_the_target_a_quarter() -> void:
 
 
 func test_a_present_to_a_target_at_full_health_is_refused() -> void:
+	# `.already_fully_healed` prints `PresentFailedText` only behind
+	# `jr nc, .do_animation`, so the refusal is said with the scene off.
 	var battle: Gen2Battle = _battle()
+	battle.battle_scene_on = false
 	var found: bool = false
 	for seed_value: int in range(1, 60):
 		_rng.seed = seed_value
@@ -2168,6 +2171,28 @@ func test_a_present_to_a_target_at_full_health_is_refused() -> void:
 		assert_eq(battle.enemy.hp, battle.enemy.max_hp(), "and nothing was healed")
 		break
 	assert_true(found, "the same one roll in five")
+
+
+func test_a_present_refused_with_the_scene_on_says_nothing() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.battle_scene_on = true
+	var reached: bool = false
+	for seed_value: int in range(1, 60):
+		_rng.seed = seed_value
+		battle.enemy.hp = battle.enemy.max_hp()
+		var turn: Gen2Turn = _run_move(battle, Fixture.PRESENT)
+		if not _first(turn.events, Gen2Battle.HP_RESTORED).is_empty():
+			continue
+		if int(turn.power_override) > 0:
+			continue
+		reached = true
+		assert_true(
+			_first(turn.events, Gen2Battle.PRESENT_REFUSED).is_empty(),
+			"the scene being on is what skips the line"
+		)
+		assert_eq(battle.enemy.hp, battle.enemy.max_hp())
+		break
+	assert_true(reached, "the heal row is reached on one roll in five")
 
 
 func test_fury_cutter_doubles_once_per_consecutive_hit_and_stops_at_sixteen() -> void:

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -439,13 +439,8 @@ func test_an_order_that_is_not_a_permutation_is_refused() -> void:
 ## `CheckCoinsAndCoinCase`: no coins is answered before the Coin Case is looked
 ## for, and the Game Corner's two games share the one guard.
 func test_a_coin_game_names_the_first_thing_missing() -> void:
-	var broke := Gen2WorldState.new({}, {}, {Gen2WorldPack.ITEM_COIN_CASE: 1})
-	assert_eq(Gen2WorldPack.coin_game_refusal(broke), Gen2WorldPack.NO_COINS_TEXT)
-	var caseless := Gen2WorldState.new({}, {}, {ITEM_POTION: 1})
-	caseless.apply_changes({}, {}, {"coins": 50})
+	assert_eq(Gen2WorldPack.coin_game_refusal_line(0, 1), Gen2WorldPack.NO_COINS_TEXT)
 	assert_eq(
-		Gen2WorldPack.coin_game_refusal(caseless), Gen2WorldPack.NO_COIN_CASE_TEXT
+		Gen2WorldPack.coin_game_refusal_line(50, 0), Gen2WorldPack.NO_COIN_CASE_TEXT
 	)
-	var playable := Gen2WorldState.new({}, {}, {Gen2WorldPack.ITEM_COIN_CASE: 1})
-	playable.apply_changes({}, {}, {"coins": 1})
-	assert_eq(Gen2WorldPack.coin_game_refusal(playable), "")
+	assert_eq(Gen2WorldPack.coin_game_refusal_line(1, 1), "")


### PR DESCRIPTION
## Fixed

- `CheckCoinsAndCoinCase`'s refusal is staged by `Gen2WorldScriptRunner._coin_game_refusal` rather than painted by `Gen2WorldScreen`. `_NoCoinsText` and `_NoCoinCaseText` both end in `prompt` and the map scripts are `special CardFlip` then `closetext`, so the box owes a press that nothing behind the special spends; the old guard completed the runtime request on the frame it opened the box. Every caller of either special gets the press now, and both integration tiers that were failing carry the Coin Case the cartridge's own scripts need.
- `BattleCommand_Present`'s `.already_fully_healed` reaches `PresentFailedText` only past `jr nc, .do_animation`, so a Present given to a target already at full health says nothing with the battle scene on and prints the line with it off. `Gen2Battle.battle_scene_on` is the injected answer, beside `battle_style_set`.

## Walked

Ten source files a built screen calls into, 1,900 lines, recorded with their verdicts: `move_effects/present.asm`, `specials.asm`, `buy_sell_toss.asm`, `mon_submenu.asm`, `elevator.asm`, `checkforhiddenitems.asm` with `itemfinder.asm`, `haircut.asm`, `fruit_trees.asm`, `battle/misc.asm` and `consume_held_item.asm`.

| Check | Result |
|---|---|
| GUT, whole tree | 166 scripts, 4166 tests, 0 failing |
| Editor analyser | 0 warnings in 609 scripts |
| `tools/validate.gd -- all` | exit 0 |
| `tools/release.sh --gates` | pass, comments 37779 of 37779 |