### PR TITLE
A wild Magikarp measured before it reaches the grass

### DIFF
--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1777,7 +1777,7 @@ func _treemon_encounter(cell: Vector2i, random: RandomNumberGenerator) -> Dictio
 	var asleep: bool = Gen2WorldTreemon.starts_asleep(
 		species, data.asleep_treemons(object_time_of_day)
 	)
-	return {
+	return _stamp_encounter({
 		"kind": &"wild_encounter_requested",
 		"method": Gen2WorldEncounter.METHOD_HEADBUTT,
 		"source": Gen2WorldEncounter.SOURCE_TREE,
@@ -1799,7 +1799,19 @@ func _treemon_encounter(cell: Vector2i, random: RandomNumberGenerator) -> Dictio
 			"battle_type": Gen2Battle.BATTLETYPE_TREE,
 			"asleep": asleep,
 		},
-	}
+	})
+
+
+## `wMapGroup`, `wMapNumber` and `wPlayerID`, read by `LoadEnemyMon`'s DV roll.
+func _stamp_encounter(request: Dictionary) -> Dictionary:
+	var values: Variant = request.get("values", null)
+	if not values is Dictionary:
+		return request
+	var stamped: Dictionary = values as Dictionary
+	stamped["map_group"] = current_map.group if current_map != null else -1
+	stamped["map_number"] = current_map.number if current_map != null else -1
+	stamped["player_id"] = _player_id
+	return request
 
 
 static func _headbutt_failure(reason: StringName) -> Dictionary:
@@ -1895,7 +1907,7 @@ func _rock_encounter(random: RandomNumberGenerator) -> Dictionary:
 		return {}
 	var species: int = int(resolved["species"])
 	var level: int = int(resolved["level"])
-	return {
+	return _stamp_encounter({
 		"kind": &"wild_encounter_requested",
 		"method": Gen2WorldEncounter.METHOD_ROCK_SMASH,
 		"source": Gen2WorldEncounter.SOURCE_ROCK,
@@ -1908,7 +1920,7 @@ func _rock_encounter(random: RandomNumberGenerator) -> Dictionary:
 		"encounter_roll": int(resolved["encounter_roll"]),
 		"slot_roll": int(resolved["slot_roll"]),
 		"values": {"kind": &"wild", "pokemon": species, "level": level},
-	}
+	})
 
 
 static func _rock_smash_failure(reason: StringName) -> Dictionary:
@@ -2347,6 +2359,7 @@ func encounter_request(
 	if resolved.is_empty():
 		return {}
 	resolved["map"] = map_id()
+	_stamp_encounter(resolved)
 	resolved["cell"] = player_cell
 	resolved["fish_group"] = current_map.fish_group
 	resolved["movement"] = movement_mode
@@ -2376,6 +2389,7 @@ func _fishing_request(
 	if fishing.is_empty():
 		return {}
 	fishing["map"] = map_id()
+	_stamp_encounter(fishing)
 	fishing["cell"] = player_cell
 	fishing["fish_group"] = int(context["fish_group"])
 	fishing["selected_fish_group"] = int(context["selected_fish_group"])
@@ -2406,6 +2420,7 @@ func _bug_contest_request(
 	if contest.is_empty():
 		return {}
 	contest["map"] = map_id()
+	_stamp_encounter(contest)
 	contest["cell"] = player_cell
 	contest["movement"] = movement_mode
 	return contest

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -11,6 +11,19 @@ const OUTCOME_CAUGHT: StringName = &"caught"
 const OUTCOME_RAN: StringName = &"ran"
 const OUTCOME_CANCELLED: StringName = &"cancelled"
 
+## `CheckMagikarpArea`'s two `cp`s, the same numbers in both pins.
+const GROUP_LAKE_OF_RAGE: int = 9
+const MAP_LAKE_OF_RAGE: int = 6
+## `HIGH(1536)`, `LOW(1616)`, `LOW(1600)` and `HIGH(1024)`, all read against a
+## length in feet and inches: the unit-conversion entry in the bug docs.
+const MAGIKARP_HUGE_FEET: int = 6
+const MAGIKARP_HUGE_INCHES: int = 80
+const MAGIKARP_LARGE_INCHES: int = 64
+const MAGIKARP_FLOOR_FEET: int = 4
+const MAGIKARP_HUGE_SKIP: int = 12
+const MAGIKARP_LARGE_SKIP: int = 50
+const MAGIKARP_FLOOR_SKIP: int = 100
+
 
 static func prepare(
 	data: GameData,
@@ -187,12 +200,9 @@ static func credit_earnings(state: Gen2WorldState, money: Dictionary) -> void:
 
 ## `LoadEnemyMon`'s `.InitDVs` for a wild, which decides whether the Pokemon in
 ## the grass is shiny, has a bad stat or answers a different Hidden Power. Rolled
-## here rather than in each of the nine callers: this is the one place a wild is
-## built, and [param generator] is the battle's own. Three cases keep an answer of
-## their own, in the source's order: a request already carrying `dvs` keeps it,
-## which is what leaves a player the Pokemon they walked up to;
-## BATTLETYPE_FORCESHINY writes [constant Gen2Stats.SHINY_DVS]; and a wild UNOWN
-## rerolls until its letter is one the Ruins of Alph puzzle has unlocked.
+## here rather than in each of the nine callers, on the battle's own generator.
+## Two cases keep an answer of their own, in the source's order: a request
+## carrying `dvs` keeps it, and BATTLETYPE_FORCESHINY writes the shiny word.
 static func wild_dvs(
 	values: Dictionary, battle_type: int, species: int, generator: RandomNumberGenerator
 ) -> int:
@@ -207,38 +217,63 @@ static func wild_dvs(
 		"map_group": int(values.get("map_group", -1)),
 		"map_number": int(values.get("map_number", -1)),
 	})
-	## -1 is what an unstamped request means, and is every caller that is not the
-	## world screen: no gate, which is how a preview tool or a test keeps the
+	## -1 is an unstamped request: no gate, so a preview tool or a test keeps the
 	## letter it rolled.
 	var unlocked: int = int(values.get("unlocked_unowns", -1))
-	var word: int = _roll_dvs(generator, species, unlocked)
+	var word: int = _roll_dvs(generator, species, unlocked, values)
 	## The charm's extra rolls sit past the source, which takes one: the first
 	## shiny is kept and otherwise the last stands, so 0 and 1 are both vanilla.
 	for _extra: int in maxi(0, rolls - 1):
 		if Gen2Stats.is_shiny(word):
 			break
-		word = _roll_dvs(generator, species, unlocked)
+		word = _roll_dvs(generator, species, unlocked, values)
 	return word
 
 
-## Two `BattleRandom` bytes, high byte first, rerolled while the letter they give a
-## wild Unown is locked, which is `CheckUnownLetter`'s `jr c, .GenerateDVs`.
-## Unbounded the way the source's is, and safe for the same reason: the mask is
-## narrowed to the four real sets first and every one of them holds letters, so any
-## mask left standing is one a roll reaches. A mask of nothing is the save that has
-## solved no puzzle, and there `ChooseWildEncounter` refuses a wild Unown outright,
-## so a caller reaching here with one has already left the cartridge's own path.
+## Two `BattleRandom` bytes, high byte first, rerolled while `CheckUnownLetter`
+## or the Magikarp filters refuse them. Unbounded the way the source's is, and
+## safe for the same reason: the mask is narrowed to the four real sets, every
+## one holds letters, and a wild Unown is refused outright on an empty mask.
 static func _roll_dvs(
-	generator: RandomNumberGenerator, species: int, unlocked_unowns: int
+	generator: RandomNumberGenerator, species: int, unlocked_unowns: int,
+	values: Dictionary = {}
 ) -> int:
 	var gated: bool = species == RomLayout.UNOWN_SPECIES and unlocked_unowns > 0
 	var mask: int = unlocked_unowns & ((1 << Gen2WorldState.UNOWN_LETTER_SETS.size()) - 1)
 	while true:
 		var word: int = (generator.randi_range(0, 255) << 8) | generator.randi_range(0, 255)
-		if not gated or mask == 0 \
-			or Gen2WorldState.unown_letter_unlocked(Gen2Stats.unown_letter(word), mask):
+		if gated and mask != 0 \
+			and not Gen2WorldState.unown_letter_unlocked(Gen2Stats.unown_letter(word), mask):
+			continue
+		if _magikarp_accepted(word, species, generator, values):
 			return word
 	return 0
+
+
+## `LoadEnemyMon.Magikarp` and `.CheckMagikarpArea`, which make a very long wild
+## Magikarp rarer and a short one rarer still. False is `jr .GenerateDVs`.
+static func _magikarp_accepted(
+	dvs: int, species: int, generator: RandomNumberGenerator, values: Dictionary
+) -> bool:
+	if species != Gen2WorldPartyHost.SPECIES_MAGIKARP:
+		return true
+	var length: Vector2i = Gen2WorldPartyHost.magikarp_length(
+		PackedByteArray([(dvs >> 8) & 0xFF, dvs & 0xFF]),
+		int(values.get("player_id", 0))
+	)
+	if length.x == MAGIKARP_HUGE_FEET \
+		and generator.randi_range(0, 255) >= MAGIKARP_HUGE_SKIP:
+		if length.y >= MAGIKARP_HUGE_INCHES:
+			return false
+		if generator.randi_range(0, 255) >= MAGIKARP_LARGE_SKIP \
+			and length.y >= MAGIKARP_LARGE_INCHES:
+			return false
+	if int(values.get("map_group", -1)) == GROUP_LAKE_OF_RAGE \
+		or int(values.get("map_number", -1)) == MAP_LAKE_OF_RAGE:
+		return true
+	if generator.randi_range(0, 255) < MAGIKARP_FLOOR_SKIP:
+		return true
+	return length.x >= MAGIKARP_FLOOR_FEET
 
 
 ## `PlayBattleMusic`'s track, off the request alone.

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -2,13 +2,11 @@ class_name Gen2WorldDayCare
 extends RefCounted
 
 ## `engine/events/daycare.asm` and `engine/pokemon/breeding.asm`, the rules half.
-## The two Day-Care slots are world state rather than party members: the cartridge
-## keeps them in `wBreedMon1` and `wBreedMon2`, boxmon structs beside the flag byte
-## that says whether each is occupied. This answers what the three routines ask of
-## that state and nothing else. What a reading gets wrong is which parent a field
-## comes from: `wBreedMotherOrNonDitto` is set once in `DayCare_InitBreeding` and
-## then read by four routines that each pick a different side of it, so it is
-## computed once here as [method mother_or_non_ditto] and passed down.
+## The two slots are world state rather than party members: `wBreedMon1` and
+## `wBreedMon2` are boxmon structs beside the flag byte saying each is occupied.
+## `wBreedMotherOrNonDitto` is set once in `DayCare_InitBreeding` and then read by
+## four routines picking different sides of it, so it is computed once here as
+## [method mother_or_non_ditto].
 
 ## `wDayCareMan`'s four bits (constants/ram_constants.asm).
 const MAN_HAS_MON: int = 1 << 0

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -304,6 +304,48 @@ func test_a_wild_unown_only_takes_an_unlocked_letter() -> void:
 	assert_gt(ungated.size(), 3, "an ungated roll reaches past one set")
 
 
+## `LoadEnemyMon.CheckMagikarpArea` floors a wild Magikarp's length outside Lake
+## of Rage: three rolls in five reroll anything under four feet. Inside the group
+## the filter is skipped, so the same seed keeps its short ones.
+func test_a_wild_magikarp_is_floored_outside_lake_of_rage() -> void:
+	assert_lt(
+		_short_magikarp({"map_group": 5, "map_number": 3}),
+		_short_magikarp({
+			"map_group": Gen2WorldBattleAdapter.GROUP_LAKE_OF_RAGE, "map_number": 6,
+		}),
+		"the floor drops short Magikarp only outside the lake"
+	)
+	## The pair of `cp`s is an OR, so a map numbered 6 in any group skips it too.
+	assert_eq(
+		_short_magikarp({"map_group": 5, "map_number": Gen2WorldBattleAdapter.MAP_LAKE_OF_RAGE}),
+		_short_magikarp({
+			"map_group": Gen2WorldBattleAdapter.GROUP_LAKE_OF_RAGE, "map_number": 6,
+		}),
+		"map number 6 skips the floor in every group"
+	)
+
+
+## How many of 200 rolled wild Magikarp came out under four feet, off one seeded
+## generator so each map answers the same sequence.
+func _short_magikarp(values: Dictionary) -> int:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 1234
+	var request: Dictionary = values.duplicate()
+	request["player_id"] = 0x1234
+	var short: int = 0
+	for _wild: int in 200:
+		var word: int = Gen2WorldBattleAdapter.wild_dvs(
+			request, Gen2Battle.BATTLETYPE_NORMAL,
+			Gen2WorldPartyHost.SPECIES_MAGIKARP, generator
+		)
+		var length: Vector2i = Gen2WorldPartyHost.magikarp_length(
+			PackedByteArray([(word >> 8) & 0xFF, word & 0xFF]), 0x1234
+		)
+		if length.x < Gen2WorldBattleAdapter.MAGIKARP_FLOOR_FEET:
+			short += 1
+	return short
+
+
 ## How many of [param count] rolled wilds came out shiny, off one seeded
 ## generator so the two halves of the test above draw the same sequence.
 func _shiny_wilds(count: int) -> int:

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -40,6 +40,7 @@ func run(r: RefCounted) -> void:
 		_census()
 		_verify_wild_patch_indices()
 		_verify_rolled_dvs()
+		_verify_magikarp_filter()
 		_verify_roaming_walk()
 	)
 
@@ -207,6 +208,98 @@ func _verify_rolled_dvs() -> void:
 			seen.size() == allowed.size(),
 			"set %d reached %d of its %d letters." % [set_index, seen.size(), allowed.size()]
 		)
+
+
+## `LoadEnemyMon.CheckMagikarpArea` over every map that can produce a Magikarp:
+## the request has to carry the map the filter reads, and the floor has to drop
+## short Magikarp everywhere but the group and map number the two `cp`s name.
+func _verify_magikarp_filter() -> void:
+	var maps: Array = _magikarp_maps()
+	if not _r.check(not maps.is_empty(), "no map holds a wild MAGIKARP."):
+		return
+	var skipped: Array = []
+	var unstamped: int = 0
+	for pair: Vector2i in maps:
+		var world: Gen2WorldAPI = _r.open_world(pair.x, pair.y, Vector2i.ZERO)
+		if world == null:
+			continue
+		world.set_player_id(0x1234)
+		world.state.set_wild_encounter_cooldown(0)
+		var request: Dictionary = world.encounter_request(
+			RandomNumberGenerator.new(), true, Gen2WorldEncounter.METHOD_SURF
+		)
+		var values: Variant = request.get("values", null)
+		if not values is Dictionary:
+			continue
+		var carried: Dictionary = values as Dictionary
+		if int(carried.get("map_group", -1)) != pair.x \
+			or int(carried.get("map_number", -1)) != pair.y \
+			or int(carried.get("player_id", -1)) != 0x1234:
+			unstamped += 1
+			continue
+		if _short_magikarp_share(carried) != _short_magikarp_share({}):
+			skipped.append(pair)
+	_r.check(unstamped == 0, "%d wild requests carried no map." % unstamped)
+	for pair: Vector2i in skipped:
+		_r.check(
+			pair.x == Gen2WorldBattleAdapter.GROUP_LAKE_OF_RAGE \
+				or pair.y == Gen2WorldBattleAdapter.MAP_LAKE_OF_RAGE,
+			"map %d/%d skipped the Magikarp floor." % [pair.x, pair.y]
+		)
+	_r.check(
+		_short_magikarp_share({"map_group": 5, "map_number": 3}) \
+			< _short_magikarp_share({
+				"map_group": Gen2WorldBattleAdapter.GROUP_LAKE_OF_RAGE, "map_number": 6,
+			}),
+		"the floor dropped no short Magikarp outside the lake."
+	)
+	_r.note("Magikarp floor: %d maps, %d of them skipping it." % [
+		maps.size(), skipped.size(),
+	])
+
+
+func _magikarp_maps() -> Array:
+	var out: Array = []
+	for region: String in ["johto", "kanto"]:
+		for row: Dictionary in _r.data.world_encounter_region_rows(&"surf", region):
+			if not _holds_magikarp(row):
+				continue
+			var pair: PackedStringArray = String(row.get("map", "")).split(":")
+			if pair.size() == 2:
+				out.append(Vector2i(int(pair[0]), int(pair[1])))
+	return out
+
+
+static func _holds_magikarp(row: Dictionary) -> bool:
+	for key: Variant in row:
+		var slots: Variant = row[key]
+		if not slots is Array:
+			continue
+		for slot: Variant in slots as Array:
+			if slot is Dictionary \
+				and int((slot as Dictionary).get("species", 0)) \
+					== Gen2WorldPartyHost.SPECIES_MAGIKARP:
+				return true
+	return false
+
+
+func _short_magikarp_share(values: Dictionary) -> int:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 20260912
+	var request: Dictionary = values.duplicate()
+	request["player_id"] = 0x1234
+	var short: int = 0
+	for _wild: int in 256:
+		var word: int = Gen2WorldBattleAdapter.wild_dvs(
+			request, Gen2Battle.BATTLETYPE_NORMAL,
+			Gen2WorldPartyHost.SPECIES_MAGIKARP, generator
+		)
+		var length: Vector2i = Gen2WorldPartyHost.magikarp_length(
+			PackedByteArray([(word >> 8) & 0xFF, word & 0xFF]), 0x1234
+		)
+		if length.x < Gen2WorldBattleAdapter.MAGIKARP_FLOOR_FEET:
+			short += 1
+	return short
 
 
 ## One wild built through the whole adapter, so the sweep measures the path a


### PR DESCRIPTION
`LoadEnemyMon` runs two filters over a rolled Magikarp's length and neither was built, so every wild Magikarp kept the first DV word it drew. `CalcMagikarpLength` existed for the Guru's tape measure and nothing read it while a wild was being made.

`Gen2WorldBattleAdapter._magikarp_accepted` is the seam, inside the same reroll loop `CheckUnownLetter` uses, and it spends the three `Random` bytes the source spends. The limits are compared against feet and inches while they are written as millimetres, which is the unit-conversion entry in the bug docs: `HIGH(1024)` is four feet where the routine wanted three.

The filter reads `wMapGroup`, `wMapNumber` and `wPlayerID`, and none of the five `wild_encounter_requested` sites carried them. `Gen2WorldAPI._stamp_encounter` fills them once, which also gives the mod host's `shiny_roll_count` and the battle screen's caught event the map they had been reading as -1.

| Check | Result |
|---|---|
| `gut` unit tier | 3564 tests, 66054 asserts, all pass |
| `validate.gd -- all` | 84 topics pass |
| `wild_encounters` Magikarp topic | 8 maps per cartridge, 2 of them skipping the floor |
| Warning scan | 0 warnings in 609 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | byte-identical to `main` |