### PR TITLE
Two Game Corner branches read the wrong way round

### DIFF
--- a/game/world/card_flip.gd
+++ b/game/world/card_flip.gd
@@ -75,9 +75,7 @@ const FLASHES: int = 3
 const PAYOUT_FRAMES: int = 2
 
 ## The two boxes that end in `prompt` rather than `done`, which is the only
-## thing that reaches `LoadBlinkingCursor`. `.TabulateTheResult` waits with
-## `WaitPressAorB_BlinkCursor` on a box that loaded none, and the routine's own
-## comment says so: no arrow blinks over "Yeah!" or "Darn…".
+## thing that reaches `LoadBlinkingCursor`: no arrow blinks over "Yeah!".
 const PROMPT_TEXTS: Array[String] = ["not_enough_coins", "shuffled"]
 
 ## `CardFlip_InitTilemap`'s `ld a, $29`, which is the green felt.
@@ -110,25 +108,20 @@ const FACE_UP_TILEMAP: Array[int] = [
 	0x1D, 0x1E, 0x1E, 0x1E, 0x1F,
 ]
 ## `.Deck`'s second column, the top-left tile of each Pokemon's three by three
-## picture. Its first column is the level as a character and is the digit for
-## the card's own level, so it is not a table here.
+## picture. Its first column is the level's own digit.
 const CARD_PIC_TILES: Array[int] = [0x4E, 0x57, 0x69, 0x60]
-## Where the level and the picture land inside the card, off the two `add hl`
-## in `CardFlip_DisplayCardFaceUp`: `3 + SCREEN_WIDTH` and `SCREEN_HEIGHT` on
-## top of it, which lands one column in and two rows down.
+## `CardFlip_DisplayCardFaceUp`'s two `add hl`: `3 + SCREEN_WIDTH`, then
+## `SCREEN_HEIGHT` on top of it.
 const CARD_LEVEL_AT: Vector2i = Vector2i(3, 1)
 const CARD_PIC_AT: Vector2i = Vector2i(1, 2)
 const CARD_PIC_SIZE: int = 3
 
 ## `CardFlip_BlankDiscardedCardSlot`'s six branches, by level: the row the pair
-## of tiles starts on and the two tiles for a live pair, with `$3d` replacing
-## whichever of them is the discarded half's own. The column is `13 + 2 * mon`
-## in every branch.
+## of tiles starts on. The column is `13 + 2 * mon` in every branch.
 const DISCARD_COLUMN: int = 13
 const DISCARD_ROWS: Array[int] = [3, 4, 6, 7, 9, 10]
 ## (top tile, bottom tile, which of the two `$3d` replaces when the paired card
-## is already discarded). `.Level1`, `.Level3` and `.Level5` mark the bottom and
-## the even levels the top, which is the half of the cell each owns.
+## is already discarded). Each level owns one half of the cell it shares.
 const DISCARD_TILES: Array[Array] = [
 	[0x36, 0x37, 1],
 	[0x3B, 0x3A, 0],
@@ -471,7 +464,9 @@ func _toggle_pass() -> void:
 func _flash_pass() -> void:
 	if _flash_left > 0:
 		_flash_left -= 1
-		_border_at = -1 if _flash_left % 2 == 1 else _which_card
+		## `press_a` spent the first of the six half-steps lit, so `.loop2`'s
+		## last is dark.
+		_border_at = -1 if _flash_left % 2 == 0 else _which_card
 		_delay = TOGGLE_FRAMES
 		return
 	_border_at = -1
@@ -574,8 +569,8 @@ func _cursor_down() -> bool:
 	return true
 
 
-## `.left_to_number_gp`, which every leftward step out of the Pokemon rows ends
-## on whichever column it started in.
+## `.left_to_number_gp`, one fixed cell whichever Pokemon column the step
+## started in.
 func _to_number_group() -> bool:
 	_cursor = Vector2i(COLUMN_NUMBER, ROW_FIRST_NUMBER)
 	return true

--- a/game/world/slot_machine.gd
+++ b/game/world/slot_machine.gd
@@ -95,8 +95,8 @@ const MUSIC_GAME_CORNER: int = 0x12
 ## `SlotsAction_BetAndStart`'s own `ld a, 32`, and `SlotsAction_FlashIfWin`'s 16.
 const START_DELAY: int = 32
 const FLASH_FRAMES: int = 16
-## `Slots_WaitSFX`, which is sixteen frames rather than a wait, and
-## `Slots_AskPlayAgain`'s own sixty behind the ran-out-of-coins line.
+## `Slots_WaitSFX`, sixteen frames rather than a wait, and
+## `Slots_AskPlayAgain`'s sixty behind the ran-out-of-coins line.
 const WAIT_SFX_FRAMES: int = 16
 const RAN_OUT_FRAMES: int = 60
 ## `REEL_MANIP_COUNTER`'s own 4, one per reel.
@@ -105,10 +105,8 @@ const MANIP_COUNTER: int = 4
 const STOP_DELAY: int = 3
 
 ## `Slots_InitBias.Normal` and `.Lucky`: (threshold, symbol), walked until the
-## rolled byte is at or below a threshold. The thresholds are `percent`, which
-## is `x * $ff / 100` and so 2 for one percent, plus the source's own `+ 1` and
-## `- 1` where it has them; they are written out because rgbasm evaluates them
-## and GDScript will not call a function inside a constant.
+## rolled byte is at or below a threshold. A threshold is `percent`, which is
+## `x * $ff / 100`, plus the source's own `+ 1` and `- 1` where it has them.
 const BIAS_NORMAL: Array[Array] = [
 	[1, SLOTS_SEVEN],     # 1 percent - 1
 	[3, SLOTS_POKEBALL],  # 1 percent + 1
@@ -128,8 +126,8 @@ const BIAS_LUCKY: Array[Array] = [
 	[255, SLOTS_NO_BIAS], # 100 percent
 ]
 
-## `Slots_UpdateReelPositionAndOAM`: the first row's own y and the step down the
-## reel, in pixels, and how many objects one reel writes.
+## `Slots_UpdateReelPositionAndOAM`: the first row's y, the step down the reel
+## in pixels, and how many objects one reel writes.
 const REEL_TOP_Y: int = 10 * 8
 const REEL_ROW_STEP: int = 2 * 8
 const REEL_OBJECTS: int = 8
@@ -207,9 +205,8 @@ var _resume: StringName = &""
 var _stall: int = 0
 ## `WaitSFX`, which the host answers off its own driver.
 var _waiting_sfx: bool = false
-## The steps of an action that outlive the pass it started on: the `WaitSFX`,
-## `PlaySFX` and `PrintText` run a routine ends in, in the routine's own order.
-## A `wait` step holds the whole loop until the host says the channels are free.
+## The steps of an action that outlive the pass it started on, in the routine's
+## own order. A `wait` step holds the loop until the channels are free.
 var _script: Array = []
 ## The `PlaySFX`, `PrintText` and palette writes of this pass, for the host.
 var _events: Array = []
@@ -455,6 +452,8 @@ func _run_action() -> void:
 				return
 			_index += 1
 			_delay = FLASH_FRAMES
+			## `.GotIt` falls into `SlotsAction_FlashScreen`.
+			_flash_screen()
 		SLOTS_FLASH_SCREEN:
 			_flash_screen()
 		SLOTS_GIVE_EARNED_COINS:
@@ -471,8 +470,7 @@ func _run_action() -> void:
 		SLOTS_PAYOUT_ANIM:
 			_payout_anim()
 		SLOTS_RESTART_OR_QUIT:
-			## `Slots_DeilluminateBetLights` and then the wait, which is where
-			## the lights go out and the board stands still.
+			## `Slots_DeilluminateBetLights`, then the wait.
 			_bet = 0
 			_prompt = Prompt.PRESS
 			_prompt_name = &"restart"
@@ -574,13 +572,18 @@ func _reel1_has_seven() -> bool:
 	return false
 
 
-## `Slots_StopReel3`'s four-way roll, whose odds depend on whether the first two
-## reels stopped on matching sevens and on whether the spin is biased to seven.
+## `Slots_StopReel3`: the roll only happens once the first two reels have
+## stopped on matching sevens.
 func _stop_reel3_action() -> int:
 	if not _first_two_matching or not _first_two_sevens:
 		return REEL_ACTION_STOP_REEL3
-	if _bias != SLOTS_SEVEN:
-		var roll: int = _random()
+	return reel3_action(_bias, _random())
+
+
+## `.biased` is reached by `and a / jr nz`, so a bias of SLOTS_SEVEN is the zero
+## that falls through and Chansey is reachable from that block alone.
+static func reel3_action(symbol: int, roll: int) -> int:
+	if symbol == SLOTS_SEVEN:
 		if roll >= _percent(71) - 1:
 			return REEL_ACTION_STOP_REEL3
 		if roll >= _percent(47) + 1:
@@ -588,10 +591,9 @@ func _stop_reel3_action() -> int:
 		if roll >= _percent(24) - 1:
 			return REEL_ACTION_INIT_GOLEM
 		return REEL_ACTION_INIT_CHANSEY
-	var biased: int = _random()
-	if biased >= _percent(63):
+	if roll >= _percent(63):
 		return REEL_ACTION_STOP_REEL3
-	if biased >= _percent(31) + 1:
+	if roll >= _percent(31) + 1:
 		return REEL_ACTION_START_SLOW_ADVANCE_REEL3
 	return REEL_ACTION_INIT_GOLEM
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -10,6 +10,8 @@ const TEXT: Color = Color("#f4f7fb")
 const MUTED: Color = Color("#9eacc0")
 const BATTLE_SCENE: PackedScene = preload("res://game/battle/battle_screen.tscn")
 const FLOWER_MAIL: int = 0xB6
+## `CheckOwnMon`'s `rept NAME_LENGTH_JAPANESE - 2` plus the comparison behind it.
+const OT_NAME_COMPARED: int = 5
 
 const SERVICE_SCENE: PackedScene = preload("res://game/world/world_service_screen.tscn")
 const START_MENU_SCENE: PackedScene = preload("res://game/world/start_menu_screen.tscn")
@@ -8590,7 +8592,7 @@ func _refresh_party_summary() -> void:
 			if (int(mon.pokerus) & 0x0F) != 0:
 				has_pokerus = true
 			happiness.append(int(mon.happiness))
-			own_ot.append(_is_own_mon(save, mon))
+			own_ot.append(int(mon.ot_id) == int(save.player_id))
 			held_items.append(int(mon.item))
 			levels.append(int(mon.level))
 			id_numbers.append(int(mon.ot_id))
@@ -8621,8 +8623,9 @@ func _refresh_party_summary() -> void:
 			## offers to hand a POKé BALL over.
 			"box_free_space": save.box_free_space(),
 			## Per slot, for the two specials that read a happiness byte or an
-			## OT: `GetFirstPokemonHappiness` and
-			## `FindPartyMonThatSpeciesYourTrainerID`.
+			## ID: `GetFirstPokemonHappiness` and
+			## `_FindPartyMonThatSpeciesYourTrainerID`, which tests `wPlayerID`
+			## alone and never the OT name.
 			"happiness": happiness,
 			"own_ot": own_ot,
 			## `CheckOwnMonAnywhere`'s answer for every species at once: a mon in
@@ -8646,11 +8649,13 @@ func _refresh_party_summary() -> void:
 	)
 
 
-## `CheckOwnMon`'s three tests: the species is the caller's question, and what is
-## left is the player's own ID and OT name.
-func _is_own_mon(save: Gen2SaveData, mon: Gen2SaveMon) -> bool:
+## `CheckOwnMon`'s three tests: the species is the caller's question, the ID is
+## `wPlayerID`, and `rept NAME_LENGTH_JAPANESE - 2` plus the comparison behind
+## it decides the OT name on its first five letters.
+static func _is_own_mon(save: Gen2SaveData, mon: Gen2SaveMon) -> bool:
 	return int(mon.ot_id) == int(save.player_id) \
-		and mon.original_trainer == save.player_name
+		and mon.original_trainer.left(OT_NAME_COMPARED) \
+			== save.player_name.left(OT_NAME_COMPARED)
 
 
 ## Every box slot's OT ID and species, in box then slot order. One list rather

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -5385,9 +5385,9 @@ func _special_game_corner_prize_mon_check_dex(special: int) -> Dictionary:
 	})
 
 
-## `DoNthMenu` over the five words of today's category, and the answer is whether the
-## row matches the low nibble of `wBuenasPassword`. The category is the high nibble,
-## which is what the radio show drew this morning.
+## `DoNthMenu` over the category's `NUM_PASSWORDS_PER_CATEGORY` words, and the
+## answer is whether the row matches the low nibble of `wBuenasPassword`. The
+## category is the high nibble, which is what the radio show drew this morning.
 func _special_buenas_password(special: int) -> Dictionary:
 	var password: int = _buenas_password()
 	if password < 0:

--- a/tests/unit/test_card_flip.gd
+++ b/tests/unit/test_card_flip.gd
@@ -212,3 +212,25 @@ func test_the_result_box_blinks_no_arrow() -> void:
 	assert_true(_drive_to(game, Prompt.PRESS))
 	assert_eq(game.state(), State.TABULATE_THE_RESULT)
 	assert_false(game.blinking_cursor(), "\"Yeah!\" and \"Darn…\" load no cursor")
+
+
+## `.loop2` is three iterations of border-on then `ClearSprites`, so the six
+## half-steps alternate from lit and the card is revealed over a dark table.
+func test_the_three_flashes_end_dark() -> void:
+	var game: Gen2CardFlip = _table()
+	assert_true(_drive_to(game, Prompt.CHOOSE))
+	game.press_a()
+	var lit: Array[bool] = []
+	for _frame: int in 240:
+		if game.state() != State.CHOOSE_A_CARD:
+			break
+		lit.append(game.border_at() >= 0)
+		_step(game)
+	assert_eq(lit.size(), Gen2CardFlip.FLASHES * 2 * Gen2CardFlip.TOGGLE_FRAMES)
+	for half: int in Gen2CardFlip.FLASHES * 2:
+		var want: bool = half % 2 == 0
+		for frame: int in Gen2CardFlip.TOGGLE_FRAMES:
+			assert_eq(
+				lit[half * Gen2CardFlip.TOGGLE_FRAMES + frame], want,
+				"half-step %d is %s" % [half, "lit" if want else "dark"]
+			)

--- a/tests/unit/test_slot_machine.gd
+++ b/tests/unit/test_slot_machine.gd
@@ -244,3 +244,21 @@ func test_every_window_is_three_symbols_of_the_strip() -> void:
 		assert_eq(window.size(), 3)
 		for symbol: int in window:
 			assert_true(symbol in [0x00, 0x04, 0x08, 0x0C, 0x10, 0x14])
+
+
+## `Slots_StopReel3`'s `and a / jr nz, .biased`: SLOTS_SEVEN is the zero that
+## falls through, so Chansey belongs to the seven bias and to nothing else.
+func test_only_a_seven_bias_can_throw_chansey() -> void:
+	var chansey: int = Gen2SlotMachine.REEL_ACTION_INIT_CHANSEY
+	var seen: Array[int] = []
+	for roll: int in 256:
+		var action: int = Gen2SlotMachine.reel3_action(Gen2SlotMachine.SLOTS_SEVEN, roll)
+		if not seen.has(action):
+			seen.append(action)
+		for other: int in [0x04, 0x08, 0x0C, 0x10, 0x14, Gen2SlotMachine.SLOTS_NO_BIAS]:
+			assert_ne(
+				Gen2SlotMachine.reel3_action(other, roll), chansey,
+				"bias %d roll %d must not reach Chansey" % [other, roll]
+			)
+	assert_true(seen.has(chansey), "a seven bias reaches Chansey below `24 percent - 1`")
+	assert_eq(seen.size(), 4, "the seven block has all four modes in it")

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -761,3 +761,27 @@ func _write_menu_script() -> void:
 		},
 	})
 	_data = GameData.open_directory(Fixture.directory())
+
+
+## `CheckOwnMon`'s OT test walks `NAME_LENGTH_JAPANESE - 2` bytes and compares
+## one more, so a longer name is decided on its first five letters. The
+## terminator is one of the five, so a shorter name still has to match whole.
+func test_an_ot_name_is_own_on_its_first_five_letters() -> void:
+	var player := Gen2SaveData.new()
+	player.player_id = 0x1234
+	player.player_name = "MICHAEL"
+	for row: Array in [
+		["MICHAEL", true], ["MICHASHA", true], ["MICHA", true],
+		["MICH", false], ["MICKEY", false], ["michael", false],
+	]:
+		var mon := Gen2SaveMon.new()
+		mon.ot_id = player.player_id
+		mon.original_trainer = String(row[0])
+		assert_eq(
+			Gen2WorldScreen._is_own_mon(player, mon), bool(row[1]),
+			"OT \"%s\" against MICHAEL" % row[0]
+		)
+	var stranger := Gen2SaveMon.new()
+	stranger.ot_id = 0x1235
+	stranger.original_trainer = player.player_name
+	assert_false(Gen2WorldScreen._is_own_mon(player, stranger), "the ID is tested too")

--- a/tools/checks/slots.gd
+++ b/tools/checks/slots.gd
@@ -34,6 +34,13 @@ const PAYOUTS: Array[int] = [300, 50, 6, 8, 10, 15]
 ## once and two banks index it.
 const SECTION: Dictionary = {"slots_1": 37, "slots_2": 64, "slots_3": 64}
 
+## `Slots_StopReel3`'s two blocks, as (threshold, action) walked in order. The
+## first is the one `and a / jr nz, .biased` falls through on, a bias of
+## SLOTS_SEVEN, and Chansey is in it alone. The thresholds are `71 percent - 1`,
+## `47 percent + 1`, `24 percent - 1`, `63 percent` and `31 percent + 1`.
+const REEL3_SEVEN_BIAS: Array[Array] = [[180, 9], [120, 16], [60, 18], [0, 21]]
+const REEL3_OTHER_BIAS: Array[Array] = [[160, 9], [80, 16], [0, 18]]
+
 ## `Slots_InitBias.Normal` and `.Lucky`, as (threshold, symbol).
 const BIAS_NORMAL: Array[Array] = [
 	[1, 0x00], [3, 0x04], [10, 0x14], [20, 0x10], [40, 0x0C], [48, 0x08], [255, -1],
@@ -87,6 +94,27 @@ func _verify_tables() -> void:
 		Gen2SlotMachine.BIAS_LUCKY == BIAS_LUCKY,
 		"the lucky bias table is not `Slots_InitBias.Lucky`."
 	)
+	_verify_reel3_rolls()
+
+
+## Every byte `Random` can answer, against a second reading of the two blocks.
+func _verify_reel3_rolls() -> void:
+	for symbol: int in [0x00, 0x04, 0x08, 0x0C, 0x10, 0x14, -1]:
+		var rows: Array[Array] = REEL3_SEVEN_BIAS if symbol == 0 else REEL3_OTHER_BIAS
+		for roll: int in 256:
+			var want: int = 0
+			for row: Array in rows:
+				if roll >= int(row[0]):
+					want = int(row[1])
+					break
+			var got: int = Gen2SlotMachine.reel3_action(symbol, roll)
+			if got == want:
+				continue
+			_r.fail(
+				"`Slots_StopReel3` on bias %d roll %d answers %d, not %d."
+				% [symbol, roll, got, want]
+			)
+			return
 
 
 ## The cache against a second reading of the dump: the walk found the records.
@@ -166,11 +194,9 @@ func _verify_text(game_id: StringName, data: GameData) -> void:
 	)
 
 
-## Whole spins on a pinned seed, every bet and both machines.
-## What is asserted is the source's own arithmetic rather than a pinned outcome:
-## the coins the bet took, the payout the match is worth, the reels standing on
-## symbols their own strips carry, and a match that is really lined up on one of
-## the rows the bet paid for.
+## Whole spins on a pinned seed, every bet and both machines, against the
+## source's own arithmetic rather than a pinned outcome: the coins the bet took,
+## the payout the match is worth, and a match really lined up on a paid row.
 func _verify_spins(game_id: StringName, data: GameData) -> void:
 	var spins: int = 0
 	var wins: int = 0


### PR DESCRIPTION
`Slots_StopReel3` splits on `ld a, [wSlotBias] / and a / jr nz, .biased`, and SLOTS_SEVEN is 0, so the block that falls through is the seven-biased one. This port had the two swapped: Chansey stood behind every bias its own comment calls impossible for it and behind none of the seven bias, and 23.4 percent of unbiased seven line-ups turned into a guaranteed 300 coins. The roll is `Gen2SlotMachine.reel3_action` now, swept over all 256 bytes and all seven biases by `tools/checks/slots.gd`.

`SlotsAction_FlashIfWin`'s `.GotIt` falls into `SlotsAction_FlashScreen`, so the win flash spends its first of sixteen frames on the pass that starts it.

`_CardFlip`'s `.loop2` is three iterations of border-then-`ClearSprites`, six half-steps alternating from lit, so the table is dark when the card turns over. The parity here was inverted and the border stood over the reveal.

`CheckOwnMon` compares five letters of the OT name, which `docs/bugs_and_glitches.md` records; `Gen2WorldScreen._is_own_mon` compared the whole string. The same method also filled `own_ot`, which answers `_FindPartyMonThatSpeciesYourTrainerID`, and that routine tests `wPlayerID` alone and never the name. The two tests are separated.

Walked whole for the same pass: `engine/games/slot_machine.asm`, `engine/games/card_flip.asm`, `engine/pokemon/search_owned.asm` with `search_party.asm`, `engine/events/buena.asm` and `engine/math/print_num.asm`. The last two paid nothing but a stale comment.

| Check | Result |
|---|---|
| `gut` unit tier | 3573 tests, 68418 asserts, all pass |
| `validate.gd -- all` | 84 topics pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | unchanged against `main` |
| Warning scan | 0 warnings in 608 scripts |
| `release.sh --gates` | pass, 37779 of 37779 comment lines |