### PR TITLE
Four defects from a walk of the command queue and the elevator

### DIFF
--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -83,8 +83,7 @@ const PROMPT_TEACH_WHICH: String = "Teach which PKMN?"
 ## `SwitchPartyMons`' own `PARTYMENUACTION_MOVE` string, `MoveToWhereString`.
 const PROMPT_MOVE_TO_WHERE: String = "Move to where?"
 
-## `constants/sfx_constants.asm`'s SFX_SWITCH_POKEMON, which
-## `_SwitchPartyMons.ClearSprite` plays once the two rows have traded places.
+## `constants/sfx_constants.asm`'s SFX_SWITCH_POKEMON.
 const SFX_SWITCH_POKEMON: int = 0x20
 
 ## `_PokemonNotEnoughHPText` and `_ItemCantUseOnMonText`, the two refusals the
@@ -644,7 +643,9 @@ func _finish_switch() -> void:
 		var held: Gen2SaveMon = _save.party[from]
 		_save.party[from] = _save.party[_member_cursor]
 		_save.party[_member_cursor] = held
-		## `SwitchPartyMons` is `WaitPlaySFX`.
+		## `.ClearSprite` runs once per row and ends on `WaitPlaySFX`, so the
+		## effect is asked for twice and the second waits the first out.
+		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
 		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
 	_member_cursor = clampi(_member_cursor, 0, _row_count() - 1)
 	## The icons are respawned rather than stepped: `LoadPartyMenuGFX` and

--- a/game/world/move_tutor.gd
+++ b/game/world/move_tutor.gd
@@ -3,11 +3,9 @@ extends RefCounted
 
 ## `MoveTutor` and `CheckCanLearnMoveTutorMove` (`engine/events/move_tutor.asm`),
 ## the rules half. [Gen2MoveTutorScreen] is the routine and
-## [method Gen2WorldPartyHost.teach_tutor_move] owns the transaction.
-##
-## Crystal only: `TMHMMoves` ends at HM07 on both Gold and Silver, so
-## [method move_for_value] answers 0 there and no map script reaches the special
-## anyway.
+## [method Gen2WorldPartyHost.teach_tutor_move] owns the transaction. Crystal
+## only: `TMHMMoves` ends at HM07 on Gold and Silver, so [method move_for_value]
+## answers 0 there and no map script reaches the special anyway.
 
 ## constants/script_constants.asm's MOVETUTOR_* run, which the map's own
 ## `verticalmenu` leaves in wScriptVar. Its fourth row is CANCEL, which the

--- a/game/world/name_rater.gd
+++ b/game/world/name_rater.gd
@@ -1,13 +1,11 @@
 class_name Gen2NameRater
 extends RefCounted
 
-## `engine/events/name_rater.asm`, the rules half. `_NameRater` is a straight line
-## of text, question, party selection, text and naming screen; what needs a reading
-## rather than a screen is which of its five endings a chosen party member reaches,
-## and the three routines beside it that decide the last one.
-## [Gen2NameRaterScreen] is the routine itself, on the overworld's own pump; this
-## holds nothing and answers questions. Every string is the cartridge's, off the
-## ten `text_far` stubs `RomLayout.NAME_RATER_TEXT_ORDER` pins.
+## `engine/events/name_rater.asm`, the rules half: which of `_NameRater`'s five
+## endings a chosen party member reaches, and the three routines beside it that
+## decide the last one. [Gen2NameRaterScreen] is the routine itself, on the
+## overworld's own pump. Every string is the cartridge's, off the ten `text_far`
+## stubs `RomLayout.NAME_RATER_TEXT_ORDER` pins.
 
 ## `MON_NAME_LENGTH - 1`: how many characters a nickname holds before its `@`.
 const NICKNAME_LENGTH: int = 10

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -306,8 +306,8 @@ var _player_name: String = ""
 ## trainer ID is. Crystal only: pokegold ships no KrisStateSprites, so a Gold or
 ## Silver world stays male whatever a caller sets.
 var _player_female: bool = false
-var _command_queues: Dictionary = {}
-var _next_command_queue_id: int = 0
+## wCmdQueue: four fixed entries, empty where the type byte is CMDQUEUE_NULL.
+var _command_queue_slots: Array[Dictionary] = _empty_command_queue_slots()
 var _fishing: Gen2WorldFishing = Gen2WorldFishing.new()
 ## Supplies the roaming jumps performed during map setup. A caller that needs a
 ## reproducible route sets its own generator; otherwise map setup randomizes.
@@ -3220,28 +3220,45 @@ func change_block(block_x: int, block_y: int, block: int) -> Dictionary:
 	}
 
 
-func command_queues() -> Array:
-	var out: Array = []
-	for key: Variant in _command_queues:
-		out.append((_command_queues[key] as Dictionary).duplicate(true))
+static func _empty_command_queue_slots() -> Array[Dictionary]:
+	var out: Array[Dictionary] = []
+	for _slot: int in Gen2WorldScript.CMDQUEUE_CAPACITY:
+		out.append({})
 	return out
 
 
+func command_queues() -> Array:
+	var out: Array = []
+	for queue: Dictionary in _command_queue_slots:
+		if not queue.is_empty():
+			out.append(queue.duplicate(true))
+	return out
+
+
+## The type byte in each of the four slots, CMDQUEUE_NULL for a free one.
+func command_queue_types() -> Array[int]:
+	var out: Array[int] = []
+	for queue: Dictionary in _command_queue_slots:
+		out.append(int(queue.get("type", Gen2WorldScript.CMDQUEUE_NULL)))
+	return out
+
+
+## `WriteCmdQueue`: the lowest free entry, and no write at all when all four hold.
 func apply_command_queue_write(bank: int, address: int) -> Dictionary:
-	var key: String = "%d:%04X" % [bank, address]
-	var queue_id: int = _next_command_queue_id
-	_next_command_queue_id += 1
-	var queue: Dictionary = {"id": queue_id, "bank": bank, "address": address}
-	# The imported payload, so a written queue carries what it does and not only
-	# where it came from. A queue the cartridge has no entry for stays pointer
-	# only, which is what every type but CMDQUEUE_STONETABLE is.
+	var queue: Dictionary = {"bank": bank, "address": address}
+	# A queue the cartridge has no entry for stays pointer only, which is what
+	# every type but CMDQUEUE_STONETABLE is.
 	if data != null:
 		var record: Dictionary = data.world_command_queue(bank, address)
 		if not record.is_empty():
 			queue["type"] = int(record.get("type", 0))
 			queue["rows"] = record.get("rows", [])
-	_command_queues[key] = queue
-	return {"ok": true, "kind": &"command_queue_written", "queue": _command_queues[key]}
+	for slot: int in _command_queue_slots.size():
+		if not _command_queue_slots[slot].is_empty():
+			continue
+		_command_queue_slots[slot] = queue
+		return {"ok": true, "kind": &"command_queue_written", "queue": queue.duplicate(true)}
+	return {"ok": true, "kind": &"command_queue_written", "queue": queue, "written": false}
 
 
 ## The one-based warp index `HandleStoneQueue.check_on_warp` counts, or 0 when
@@ -3259,12 +3276,10 @@ func warp_index_at(cell: Vector2i) -> int:
 
 
 ## `CmdQueue_StoneTable` and `HandleStoneQueue`, as one question: which script does
-## this boulder's cell fire? The source's own order, all five tests. The object
-## must be a Strength boulder, standing on a pit tile, not mid-step, on a warp
-## event, and named by a written CMDQUEUE_STONETABLE row for that warp; any refusal
-## answers an empty Dictionary. The row's object id is an `object_const_def`
-## constant, which starts at 2, so it is compared against the object's own index
-## plus two, the same mapping `applymovement` uses.
+## this boulder's cell fire? The guards below are the source's own order, and any
+## refusal answers an empty Dictionary. The row's object id is an
+## `object_const_def` constant, which starts at 2, so it is compared against the
+## object's own index plus two, the same mapping `applymovement` uses.
 func stone_queue_script(boulder: Gen2WorldObject) -> Dictionary:
 	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
 		return {}
@@ -3274,9 +3289,9 @@ func stone_queue_script(boulder: Gen2WorldObject) -> Dictionary:
 	if warp <= 0:
 		return {}
 	var object_id: int = boulder.index + 2
-	for key: Variant in _command_queues:
-		var queue: Dictionary = _command_queues[key]
-		if int(queue.get("type", 0)) != Gen2WorldScript.CMDQUEUE_STONETABLE:
+	for queue: Dictionary in _command_queue_slots:
+		if int(queue.get("type", Gen2WorldScript.CMDQUEUE_NULL)) \
+			!= Gen2WorldScript.CMDQUEUE_STONETABLE:
 			continue
 		for row: Dictionary in queue.get("rows", []):
 			if int(row.get("warp", -1)) != warp or int(row.get("object", -1)) != object_id:
@@ -3287,14 +3302,18 @@ func stone_queue_script(boulder: Gen2WorldObject) -> Dictionary:
 	return {}
 
 
-func apply_command_queue_delete(queue_id: int) -> Dictionary:
-	for key: Variant in _command_queues:
-		var queue: Dictionary = _command_queues[key]
-		if int(queue.get("id", -1)) != queue_id:
+## `DelCmdQueue`: matched on the type byte, and the first slot carrying it.
+func apply_command_queue_delete(queue_type: int) -> Dictionary:
+	for slot: int in _command_queue_slots.size():
+		if int(_command_queue_slots[slot].get("type", Gen2WorldScript.CMDQUEUE_NULL)) \
+			!= queue_type:
 			continue
-		_command_queues.erase(key)
-		return {"ok": true, "kind": &"command_queue_deleted", "queue_id": queue_id}
-	return {"ok": true, "kind": &"command_queue_deleted", "queue_id": queue_id, "removed": false}
+		_command_queue_slots[slot] = {}
+		return {"ok": true, "kind": &"command_queue_deleted", "queue_type": queue_type}
+	return {
+		"ok": true, "kind": &"command_queue_deleted",
+		"queue_type": queue_type, "removed": false,
+	}
 
 
 ## The expanded graphics tile at a map-space tile coordinate, or -1 outside
@@ -3976,11 +3995,7 @@ func run_event_queue(acknowledge: bool = false, choice: int = -1) -> Array:
 				if _object_masks_pending:
 					load_object_masks()
 				break
-			var request: Dictionary = _script_queue.pop_front()
-			_active_script = Gen2WorldScriptRunner.begin(
-				data, state, request, Callable(self, "_validate_script_warp"),
-				script_random
-			)
+			_active_script = _begin_script(_script_queue.pop_front())
 		var result: Dictionary = _active_script.advance(accept, selected_choice)
 		accept = false
 		selected_choice = -1
@@ -4062,11 +4077,7 @@ func _drain_script_queue() -> Array:
 			_queue_map_scene()
 			if _script_queue.is_empty():
 				break
-		var request: Dictionary = _script_queue.pop_front()
-		_active_script = Gen2WorldScriptRunner.begin(
-			data, state, request, Callable(self, "_validate_script_warp"),
-			script_random
-		)
+		_active_script = _begin_script(_script_queue.pop_front())
 		var next: Dictionary = _active_script.advance()
 		if StringName(next.get("status", &"")) == &"waiting":
 			results.append(_apply_result_events(next))
@@ -4637,6 +4648,15 @@ func _script_wild_encounters(event: Dictionary) -> Array:
 	return [{"type": &"wild_encounters_changed", "enabled": enabled}]
 
 
+## The live wCmdQueue types ride along so both queue commands see the map's four.
+func _begin_script(request: Dictionary) -> Gen2WorldScriptRunner:
+	var runner: Gen2WorldScriptRunner = Gen2WorldScriptRunner.begin(
+		data, state, request, Callable(self, "_validate_script_warp"), script_random
+	)
+	runner.cmd_queue_types = command_queue_types()
+	return runner
+
+
 func _script_queue_write(event: Dictionary) -> Array:
 	return [apply_command_queue_write(
 		int(event.get("bank", 0)), int(event.get("address", 0))
@@ -4644,7 +4664,9 @@ func _script_queue_write(event: Dictionary) -> Array:
 
 
 func _script_queue_delete(event: Dictionary) -> Array:
-	return [apply_command_queue_delete(int(event.get("queue_id", -1)))]
+	return [apply_command_queue_delete(
+		int(event.get("queue_type", Gen2WorldScript.CMDQUEUE_NULL))
+	)]
 
 
 ## `wObjectFollow_Leader` and `wObjectFollow_Follower` are one byte each, so a
@@ -6463,7 +6485,7 @@ func _apply_map(
 	# HandleContinueMap behind it runs ClearCmdQueue over every written queue.
 	state.reset_bike_flags(Gen2WorldState.is_crystal_profile(data))
 	state.clear_flash_if_outdoors(target_map.environment)
-	_command_queues.clear()
+	_command_queue_slots = _empty_command_queue_slots()
 	current_map = target_map
 	_map_placements = {}
 	_connected_objects = []

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -323,15 +323,13 @@ const DIRECTIONAL_WARPS: Dictionary = {
 }
 
 
-## CheckDirectionalWarp: a carpet clears carry, so `CheckWarpTile` refuses it and
-## the step that lands on one takes no warp. Only `DoPlayerMovement.CheckWarp`
+## CheckDirectionalWarp: a carpet clears carry, so only `DoPlayerMovement.CheckWarp`
 ## takes these, and only for the one direction the carpet names.
 static func is_directional_warp(collision_code: int) -> bool:
 	return DIRECTIONAL_WARPS.values().has(collision_code)
 
 
-## Which direction [param collision_code] has to be walked in to warp, or
-## Vector2i.ZERO when it is not a carpet.
+## The direction [param collision_code] warps in, Vector2i.ZERO for no carpet.
 static func directional_warp_direction(collision_code: int) -> Vector2i:
 	for direction: Vector2i in DIRECTIONAL_WARPS:
 		if int(DIRECTIONAL_WARPS[direction]) == collision_code:

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -321,9 +321,9 @@ static func _resolve_elevator(world: Gen2WorldAPI, values: Dictionary) -> Dictio
 			"ok": false,
 			"reason": StringName(floors.get("reason", &"elevator_data_unavailable")),
 		}
-	## `.FindCurrentFloor` walks the list for the row whose map is the
-	## backup warp's, and quits the whole routine when none is: the car
-	## does not know where it is standing, so it does not move.
+	## `.FindCurrentFloor` walks the list for the row whose map is the backup
+	## warp's, and its failure is a `scf` `Script_elevator`'s `ret c` swallows.
+	## So -1 is a ride that does not happen, never a refused request.
 	var rows: Array = floors["floors"]
 	var current: int = -1
 	for index: int in rows.size():
@@ -332,8 +332,6 @@ static func _resolve_elevator(world: Gen2WorldAPI, values: Dictionary) -> Dictio
 			and int(row["map_number"]) == int(world.backup_warp.get("map_number", -1)):
 			current = index
 			break
-	if current < 0:
-		return {"ok": false, "reason": &"elevator_floor_unknown"}
 	return {
 		"ok": true,
 		"data": {"elevator": {"floors": rows, "current": current}},

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -2735,12 +2735,9 @@ static func magikarp_beats_record(length: Vector2i, record: Dictionary) -> bool:
 	return length.y > int(record.get("inches", 0))
 
 
-## `CheckForLuckyNumberWinners`, as one walk over the ID numbers the party
-## mirror carries. [param stored_ids] and [param stored_species] are every box
-## slot in one list, which is what the source's open-box pass plus its
-## `.BoxesLoop` skipping `wCurBox` add up to. Answers `{script_value, species,
-## in_storage}`, where a zero script value is the routine's own "found nothing"
-## and leaves both boxes unprinted.
+## `CheckForLuckyNumberWinners`. [param stored_ids] and [param stored_species] are
+## every box slot in one list, which is the source's open-box pass plus its
+## `.BoxesLoop` skipping `wCurBox`. A zero script value is "found nothing".
 static func lucky_number_match(
 	lucky_id: int, party_ids: Array, party_species: Array, party_eggs: Array,
 	stored_ids: Array, stored_species: Array

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -11,6 +11,9 @@ extends RefCounted
 var data: GameData = null
 var state: Gen2WorldState = null
 var warp_validator: Callable = Callable()
+## wCmdQueue's four type bytes, set by the caller from the live queue and left as
+## this invocation's writes and deletes leave them.
+var cmd_queue_types: Array[int] = []
 
 var _request: Dictionary = {}
 var _frames: Array = []
@@ -2588,13 +2591,13 @@ func _command_setflag(_opcode: int, command: Dictionary, _bank: int) -> Dictiona
 
 func _command_checkflag(_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
 	_script_value = 1 if _engine_flag_active(int(command["flag"])) else 0
+	return {"ok": true}
+
+
 ## `Script_wildon` and `Script_wildoff`, which write
 ## `STATUSFLAGS_NO_WILD_ENCOUNTERS_F` outright rather than through a
 ## staged flag: it is scratch the next map entry does not clear, and the
 ## scripts that turn it off all turn it back on themselves.
-	return {"ok": true}
-
-
 func _command_wildon(_opcode: int, _command: Dictionary, _bank: int) -> Dictionary:
 	_emit_runtime_event(&"wild_encounters_changed", {"enabled": true})
 	return {"ok": true}
@@ -3167,19 +3170,43 @@ func _command_refreshmap(_source_opcode: int, _command: Dictionary, _bank: int) 
 	return {"ok": true}
 
 
+## `Script_writecmdqueue`: `WriteCmdQueue` fills the lowest free entry of four and
+## drops the write when all four are taken, so a full queue is silent.
 func _command_writecmdqueue(_source_opcode: int, command: Dictionary, bank: int) -> Dictionary:
-	_emit_runtime_event(&"command_queue_written", {
-		"bank": bank, "address": int(command.get("address", 0)),
-	})
+	var address: int = int(command.get("address", 0))
+	var slot: int = _cmd_queue_slots().find(Gen2WorldScript.CMDQUEUE_NULL)
+	if slot < 0:
+		return {"ok": true}
+	cmd_queue_types[slot] = _command_queue_type(bank, address)
+	_emit_runtime_event(&"command_queue_written", {"bank": bank, "address": address})
 	return {"ok": true}
 
 
+## `Script_delcmdqueue`, whose operand is the entry's type byte rather than a
+## handle. Its `ret c` runs on the found path, so `wScriptVar` stays FALSE when an
+## entry was deleted and is TRUE only when the type matched nothing.
 func _command_delcmdqueue(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:
-	_script_value = 1
-	_emit_runtime_event(&"command_queue_deleted", {
-		"queue_id": int(command.get("value", -1)),
-	})
+	var queue_type: int = int(command.get("value", Gen2WorldScript.CMDQUEUE_NULL))
+	var slot: int = _cmd_queue_slots().find(queue_type)
+	_script_value = 1 if slot < 0 else 0
+	if slot < 0:
+		return {"ok": true}
+	cmd_queue_types[slot] = Gen2WorldScript.CMDQUEUE_NULL
+	_emit_runtime_event(&"command_queue_deleted", {"queue_type": queue_type})
 	return {"ok": true}
+
+
+func _cmd_queue_slots() -> Array[int]:
+	while cmd_queue_types.size() < Gen2WorldScript.CMDQUEUE_CAPACITY:
+		cmd_queue_types.append(Gen2WorldScript.CMDQUEUE_NULL)
+	return cmd_queue_types
+
+
+func _command_queue_type(bank: int, address: int) -> int:
+	if data == null:
+		return Gen2WorldScript.CMDQUEUE_NULL
+	var record: Dictionary = data.world_command_queue(bank, address)
+	return int(record.get("type", Gen2WorldScript.CMDQUEUE_NULL))
 
 
 func _command_playmusic(_source_opcode: int, command: Dictionary, _bank: int) -> Dictionary:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -535,6 +535,11 @@ func open_quick_save(
 func _open_elevator(elevator: Dictionary) -> void:
 	_mode = MODE.ELEVATOR
 	_elevator = elevator.duplicate(true)
+	if int(_elevator.get("current", -1)) < 0:
+		## `.FindCurrentFloor`'s `jr c, .quit` is in front of
+		## `Elevator_AskWhichFloor`; `completed` is connected after this returns.
+		_finish_runtime.call_deferred({"ok": true})
+		return
 	_elevator_scroll = 0
 	## `ld a, 1` is the header's default option, and `xor a / ld
 	## [wMenuScrollPosition], a` puts the window at the top whatever floor the

--- a/game/world/world_treemon.gd
+++ b/game/world/world_treemon.gd
@@ -2,12 +2,8 @@ class_name Gen2WorldTreemon
 extends RefCounted
 
 ## The headbutt-tree and rock-smash encounter rolls
-## (engine/events/treemons.asm), which share their tables.
-##
-## TreeMonEncounter is four questions: has this map a set, is the set under this
-## profile's limit, does GetTreeMon's score and roll make an encounter, and which
-## row does SelectTreeMon land on. Only the last two are random; the caller
-## resolves the lookups through [GameData]. The generator is required rather than
+## (engine/events/treemons.asm), which share their tables. The caller resolves
+## the lookups through [GameData]; the generator is required rather than
 ## defaulted, so nothing here can roll on an uninjected one.
 
 ## GetTreeScore's three answers (constants/pokemon_data_constants.asm).

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -1914,7 +1914,10 @@ func test_the_party_submenu_switch_row_moves_a_member() -> void:
 	party.handle_button(Gen2Button.A)
 	assert_same(save.party[0], second, "the two traded places")
 	assert_same(save.party[1], first)
-	assert_eq(played, [Gen2PartyScreen.SFX_SWITCH_POKEMON])
+	## `.ClearSprite` runs once per row, so the effect is asked for twice.
+	assert_eq(played, [
+		Gen2PartyScreen.SFX_SWITCH_POKEMON, Gen2PartyScreen.SFX_SWITCH_POKEMON,
+	] as Array[int])
 	assert_eq(int(party.submenu_snapshot()["switch_from"]), -1)
 	assert_eq(party._row_count(), 3, "and CANCEL is back")
 

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37779
+const MAX_COMMENT_LINES: int = 37777
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -1508,6 +1508,58 @@ func test_a_written_command_queue_dies_with_the_map_but_not_with_a_reload() -> v
 	assert_true(world.command_queues().is_empty())
 
 
+## WriteCmdQueue fills the lowest free entry of four and drops the fifth write;
+## DelCmdQueue matches on the type byte and frees the slot for a later write.
+func test_the_command_queue_holds_four_entries_and_deletes_by_type() -> void:
+	var world: Gen2WorldAPI = _stone_table_world([
+		{"warp": STONE_WARP, "object": STONE_OBJECT, "script": STONE_SCRIPT},
+	])
+	for _extra: int in 4:
+		world.apply_command_queue_write(48, 0x6200)
+	assert_eq(world.command_queues().size(), Gen2WorldScript.CMDQUEUE_CAPACITY)
+	for slot_type: int in world.command_queue_types():
+		assert_eq(slot_type, Gen2WorldScript.CMDQUEUE_STONETABLE)
+	var deleted: Dictionary = world.apply_command_queue_delete(
+		Gen2WorldScript.CMDQUEUE_STONETABLE
+	)
+	assert_false(deleted.has("removed"), JSON.stringify(deleted))
+	assert_eq(world.command_queues().size(), Gen2WorldScript.CMDQUEUE_CAPACITY - 1)
+	var missing: Dictionary = world.apply_command_queue_delete(
+		Gen2WorldScript.CMDQUEUE_STONETABLE + 1
+	)
+	assert_false(bool(missing["removed"]), JSON.stringify(missing))
+	# The freed slot is the one the next write takes, which is why the delete is
+	# by slot rather than by a handle.
+	world.apply_command_queue_write(48, 0x6200)
+	assert_eq(world.command_queues().size(), Gen2WorldScript.CMDQUEUE_CAPACITY)
+
+
+## `Script_delcmdqueue`'s operand is a type byte and its `ret c` runs on the found
+## path, so a delete that hits leaves wScriptVar FALSE and one that misses sets
+## it TRUE. The script here sets event 24 only on the found path.
+func test_delcmdqueue_matches_a_type_and_answers_false_when_it_deletes() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6270"] = [
+		0x7E, Gen2WorldScript.CMDQUEUE_STONETABLE,
+		Gen2WorldScript.IFTRUE, 0x79, 0x62,
+		Gen2WorldScript.SETEVENT, 24, 0,
+		Gen2WorldScript.END,
+	]
+	scripts["48:6279"] = [Gen2WorldScript.END]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	for types: Array in [[Gen2WorldScript.CMDQUEUE_STONETABLE, 0, 0, 0], [1, 1, 1, 1]]:
+		var state := Gen2WorldState.new()
+		var runner := Gen2WorldScriptRunner.begin(data, state, {
+			"kind": &"test", "bank": 48, "script": 0x6270,
+		})
+		runner.cmd_queue_types.assign(types)
+		var result: Dictionary = runner.advance()
+		assert_eq(result["status"], &"complete", JSON.stringify(result))
+		var hit: bool = int(types[0]) == Gen2WorldScript.CMDQUEUE_STONETABLE
+		assert_eq(state.is_event_flag_active(24), hit, JSON.stringify(result))
+
+
 ## HandleStoneQueue reads the queue that was written, so a map whose callback
 ## never ran has none and nothing falls.
 func test_no_stone_table_fires_without_a_written_queue() -> void:

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -591,6 +591,62 @@ func _write_services_at(directory: String) -> void:
 	})
 
 
+## `Elevator`'s `.FindCurrentFloor` fails with `scf` when the backup map is on no
+## floor row, and `Script_elevator`'s `ret c` swallows it: the car draws no menu,
+## wScriptVar stays FALSE and the script runs on. It is not a refused request.
+func test_an_elevator_that_cannot_place_itself_leaves_the_script_running() -> void:
+	_set_elevator_script()
+	assert_eq(_world.backup_warp, {})
+	var waiting: Array = _world.dispatch_script_events(Vector2i(7, 6))
+	assert_eq(waiting[0]["status"], &"waiting")
+	assert_eq(_world.pending_runtime_request()["kind"], &"elevator_requested")
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_true(bool(resolved["ok"]), JSON.stringify(resolved))
+	assert_eq(int(resolved["data"]["elevator"]["current"]), -1)
+	var complete: Dictionary = Gen2WorldHost.complete_runtime_request(
+		_world, {"ok": true}, _save, false
+	)
+	assert_eq(complete["results"][0]["status"], &"complete", JSON.stringify(complete))
+
+
+## The same list with the backup warp standing on one of its rows, which is every
+## ordinary ride.
+func test_an_elevator_places_itself_on_the_backup_warps_floor() -> void:
+	_set_elevator_script()
+	_world.backup_warp = {
+		"map_group": Fixture.MAP_GROUP, "map_number": Fixture.MAP_NUMBER, "warp": 1,
+	}
+	_world.dispatch_script_events(Vector2i(7, 6))
+	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world)
+	assert_eq(int(resolved["data"]["elevator"]["current"]), 1)
+
+
+## `elevfloor`'s two rows behind a `Script_elevator` on the fixture's coord event.
+## The first row names a map nothing here stands on; the second is this map.
+func _set_elevator_script() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6300)] = [
+		0x95, 0x10, 0x40, 0x91,
+	]
+	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x4010)] = [
+		2, 4, 4, 21, 5, 5, 3, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, 0xFF,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(Fixture.directory()), scripts)
+	var maps: Array = RomCache.read_json(RomCache.world_maps_path(Fixture.directory()))
+	for raw: Dictionary in maps:
+		if int(raw.get("group", -1)) != Fixture.MAP_GROUP \
+		or int(raw.get("number", -1)) != Fixture.MAP_NUMBER:
+			continue
+		var events: Dictionary = raw.get("events", {})
+		events["coord_events"] = [{"x": 7, "y": 6, "script": 0x6300}]
+		raw["events"] = events
+	RomCache.write_json(RomCache.world_maps_path(Fixture.directory()), maps)
+	_data = GameData.open_directory(Fixture.directory())
+	_world = Gen2WorldAPI.open(
+		_data, Fixture.MAP_GROUP, Fixture.MAP_NUMBER, Vector2i(7, 6), _world.state
+	)
+
+
 func _set_mart_script(dialog_id: int = Gen2WorldMartHost.MARTTYPE_STANDARD) -> void:
 	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(Fixture.directory()))
 	scripts[Gen2WorldScript.pointer_key(Fixture.BANK, 0x6300)] = [0x94, dialog_id, 0x00, 0x40, 0x91]


### PR DESCRIPTION
`delcmdqueue`'s operand is an entry's type byte, not a handle, and `Script_delcmdqueue`'s `ret c` runs on the found path, so wScriptVar is FALSE when an entry was deleted and TRUE only when the type matched nothing. Both were the other way round here.

wCmdQueue is four fixed entries. `WriteCmdQueue.GetNextEmptyEntry` takes the lowest free one, drops the write when all four hold, and a delete frees a slot a later write reuses. The port kept an unbounded dictionary keyed by where each queue was written from, so a second write of the same pointer overwrote the first instead of taking a second entry.

`Elevator`'s `.FindCurrentFloor` quits with a `scf` that `Script_elevator` swallows, leaving the script's own FALSE branch standing and no floor list drawn. A car whose backup map is on no floor row refused the request here and stalled the script.

`_SwitchPartyMons` calls `.ClearSprite` once per row and each ends on `WaitPlaySFX`, so SFX_SWITCH_POKEMON is asked for twice. The party screen asked once; `SwitchItemsInBag` and the move screen already asked twice.

A doc block that had landed inside `_command_checkflag`'s body moves to the function it describes.

| Proof | Result |
|---|---|
| GUT, unit and scene tiers | 4183 of 4183, five new cases |
| `tools/validate.gd -- all` | 84 topics pass, `command_queues` on all three cartridges |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | passes on Crystal, Gold and Silver |
| Editor analyser | 0 warnings in 614 scripts |
| `tools/release.sh --gates` | pass; comment ceiling lowered to 37,777 |