### PR TITLE
Two bytes of stale WRAM the battle transition compares

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3918,15 +3918,15 @@ func _finish_world_battle() -> void:
 
 ## What `BattleEnd_HandleRoamMons` reads out of `wEnemyMon` on the way out of a
 ## wild battle: the species it was, the HP it is leaving on and the DVs it was
-## built with. Empty when there is no enemy to read, which is every path that
-## ends before one exists.
+## built with, plus the level `wEnemyMonLevel` keeps past the fight. Empty when
+## there is no enemy to read, which is every path that ends before one exists.
 func _enemy_battler_record() -> Dictionary:
 	if _battle == null:
 		return {}
 	var enemy: Gen2BattleMon = _battle.party(Gen2Battle.ENEMY).active_mon()
 	if enemy == null:
 		return {}
-	return {"species": enemy.species, "hp": enemy.hp, "dvs": enemy.dvs}
+	return {"species": enemy.species, "hp": enemy.hp, "dvs": enemy.dvs, "level": enemy.level}
 
 
 func _finish_world_capture(capture: Dictionary) -> void:

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -471,10 +471,7 @@ func _zoom_step() -> void:
 ## `ClearSprites` empties shadow OAM, and every background palette is filled with
 ## zero, which is what takes whatever the outro left to black.
 func _finish() -> void:
-	## Added rather than assigned: `..._SpinToBlack.end` and
-	## `..._SpeckleToBlack.done` each spend three `DelayFrame`s of their own
-	## before writing `BATTLETRANSITION_FINISH`, and those are the outro's frames
-	## rather than the tail's.
+	## Added rather than assigned: [constant SPIN_END_FRAMES] belongs to the outro.
 	_delay += TAIL_FRAMES
 	_finished = true
 	_sprites = SPRITES_NONE

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -137,6 +137,8 @@ var _script_fade_white: bool = false
 ## it has finished.
 var _battle_transition: Gen2BattleTransition = null
 var _battle_transition_request: Dictionary = {}
+## `wEnemyMonLevel`, which `ClearBattleRAM` zeroes only behind the transition.
+var _last_enemy_level: int = 0
 ## `wLandmarkSignTimer` and the window the sign is drawn in. The map load decides
 ## whether there is a sign (`Gen2WorldAPI.map_name_sign_pending`); the sixty
 ## passes it stands for are spent here, like every other overworld countdown.
@@ -4948,7 +4950,8 @@ func _start_battle_request(request: Dictionary) -> void:
 
 
 ## `StartTrainerBattle_DetermineWhichAnimation`'s two bits, and the ball only a
-## trainer's own transition draws.
+## trainer's own transition draws. What the lead is measured against is the
+## PREVIOUS battle's enemy, which `docs/bugs_and_glitches.md` calls out.
 func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	if _world == null or _data == null:
 		return null
@@ -4964,9 +4967,8 @@ func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	## wavy outro belong to.
 	var cave: bool = environment in Gen2WorldAPI.CAVE_ENVIRONMENTS
 	var lead: int = _battle_lead_level()
-	var opponent: int = int(values.get("level", lead))
 	return Gen2BattleTransition.create(
-		lead + Gen2BattleTransition.STRONGER_MARGIN < opponent,
+		lead + Gen2BattleTransition.STRONGER_MARGIN < _last_enemy_level,
 		cave,
 		int(values.get("trainer_class", 0)) > 0,
 		_render_time_of_day() == Gen2WorldPalette.TIME_DARK,
@@ -4975,13 +4977,16 @@ func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	)
 
 
-## `wBattleMonLevel`, which is the party's own lead rather than the battle's:
-## the transition is picked before `InitBattleMon` has run.
+## `wBattleMonLevel` as `FindFirstAliveMonAndStartBattle` writes it in front of
+## the transition: the first party member with HP left, not the lead.
 func _battle_lead_level() -> int:
 	var save: Gen2SaveData = _injected_save if _injected_save != null \
 		else _selected_runtime_save()
 	if save == null or save.party.is_empty():
 		return 1
+	for mon: Gen2SaveMon in save.party:
+		if mon != null and mon.hp > 0:
+			return int(mon.level)
 	return int((save.party[0] as Gen2SaveMon).level)
 
 
@@ -5294,6 +5299,10 @@ func _on_battle_finished(result: Dictionary) -> void:
 	if _world == null:
 		return
 	_last_battle_outcome = StringName(result.get("outcome", &""))
+	## `wEnemyMon` outlives the fight; the next transition reads its level.
+	var last_enemy: Variant = result.get("enemy", {})
+	if last_enemy is Dictionary and (last_enemy as Dictionary).has("level"):
+		_last_enemy_level = int((last_enemy as Dictionary)["level"])
 	_record_roam_battle(result)
 	if not _link_battle_peer.is_empty():
 		_record_link_battle(result)

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1449,6 +1449,57 @@ func test_the_battle_track_is_chosen_before_the_transition_on_one_driver() -> vo
 	assert_eq(driver.get_parent(), _world_screen)
 
 
+## `FindFirstAliveMonAndStartBattle` writes `wBattleMonLevel` from the first
+## party member with HP left, and `wEnemyMonLevel` still holds the last battle's
+## enemy because `ClearBattleRAM` runs behind the transition. Both are what
+## `StartTrainerBattle_DetermineWhichAnimation` reads.
+func test_the_transition_reads_the_first_alive_mon_and_the_last_enemy() -> void:
+	await _open_world(true)
+	var save: Gen2SaveData = _world_screen._injected_save
+	while save.party.size() < 2:
+		save.party.append(Gen2SaveMon.from_dict((save.party[0] as Gen2SaveMon).to_dict()))
+	var lead: Gen2SaveMon = save.party[0]
+	var second: Gen2SaveMon = save.party[1]
+	lead.level = 50
+	second.level = 5
+
+	_world_screen._last_enemy_level = 0
+	assert_eq(
+		_world_screen._battle_lead_level(), 50, "the lead while it is still standing"
+	)
+	var request: Dictionary = {"values": {"level": 90, "trainer_class": 1}}
+	var first: Gen2BattleTransition = _world_screen._build_battle_transition(request)
+	assert_not_null(first)
+	assert_eq(
+		first.scene(), &"init",
+		"nothing has been fought yet, so the enemy level compared against is zero"
+	)
+	assert_false(_stronger(first), "level 90 in the request never reaches the choice")
+
+	## A fainted lead hands `wBattleMonLevel` to the next slot with HP.
+	lead.hp = 0
+	assert_eq(_world_screen._battle_lead_level(), 5, "the first alive one")
+
+	_world_screen._on_battle_finished({
+		"outcome": Gen2WorldBattleAdapter.OUTCOME_WON,
+		"enemy": {"species": 1, "hp": 0, "dvs": 0, "level": 40},
+	})
+	assert_eq(_world_screen._last_enemy_level, 40, "`wEnemyMon` outlives the fight")
+	assert_true(
+		_stronger(_world_screen._build_battle_transition(request)),
+		"5 + 3 is under the 40 the last battle left behind"
+	)
+
+
+## Which pair of animations a transition took: `TRANS_STRONGER_F` is bit 0 of
+## `StartingPoints`' index, so the two stronger runs are rows 1 and 3.
+func _stronger(transition: Gen2BattleTransition) -> bool:
+	if transition == null:
+		return false
+	return transition._scene == Gen2BattleTransition.SCENES[1] \
+		or transition._scene == Gen2BattleTransition.SCENES[3]
+
+
 ## `StartBattle`: `DoBattleTransition` owns every frame between the encounter
 ## resolving and the battle screen existing, and the map is what it draws over.
 func test_a_battle_runs_its_transition_before_the_overlay_exists() -> void:


### PR DESCRIPTION
Programme 2 again: seven files a built screen calls into, read whole. `engine/battle/battle_transition.asm`, `engine/games/unown_puzzle.asm`, `engine/gfx/pic_animation.asm`, `engine/movie/evolution_animation.asm`, `engine/pokemon/mail_2.asm`, `engine/events/battle_tower/rules.asm` and `engine/link/link_trade.asm`. One paid.

## Fixed

- `StartTrainerBattle_DetermineWhichAnimation` compares `wBattleMonLevel`, which `FindFirstAliveMonAndStartBattle` writes from the first party member with HP left in the instruction before the `predef`. A fainted lead is not the level compared; `_battle_lead_level` read slot one.
- The other side of that comparison is `wEnemyMonLevel`, which is not the opponent: `ClearBattleRAM` runs behind `DoBattleTransition`, so the byte holds the enemy the previous battle ended on, and zero before the session's first. `_last_enemy_level` is that byte now, carried out of the battle screen's own `wEnemyMon` record, which grows the level beside the species, HP and DVs it already reported.

## Checked and already agreeing

`.pals`' thirteen `dc` bytes and the `srl a` that reads the counter before its own `inc`; `.spin_quadrants`' twenty wedges, with `RIGHT_QUADRANT_F` reversing `.loop1` and `.loop2` in opposite directions; `PokeBallTransition` drawn two bytes a row eight columns apart; `calc_sine_wave`'s `ld a, h`; the triangular run the offset steps the counter by; `.BlackOutRandomTile` resampling a tile that is already black. The puzzle's hand-listed cursor edges with cells 30 and 35 jumping across the START>CANCEL box, `ConvertLoadedPuzzlePieces` doubling each source tile into four, and `PuzzlePieceBorderData`'s eight tiles ORed around every piece's centre. `PokeAnim_SetWait` falling through into `PokeAnim_Wait`, `.DoRepeat`'s two `ret`s making `setrepeat n` run the body n times, `PokeAnim_GetDuration`'s `(hl >> 4) + c`, and `.GetTilemap`'s `poke_anim_box` tables. `.AnimationSequence`'s seven passes of 14, 12 down to 2 frames. `CheckPartyValueIsUnique` skipping an egg on either side and a zero on the left. `.UpdateCursor` writing `$1f` again `MON_NAME_LENGTH` cells right so both name columns carry it.

## Proof

| Check | Result |
|---|---|
| GUT, all tiers | 4184 passing, 0 failing, 168 scripts |
| `tools/validate.gd -- all` | exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | unchanged against `main` |
| Warning scan | 0 warnings in 614 scripts |
| `tools/release.sh --gates` | pass, comments 37777 of 37777 |