### PR TITLE
Three ItemEffects rows the pack had no branch for

### DIFF
--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -2999,18 +2999,12 @@ const CRYSTAL: Dictionary = {
 		"landmarks": 0x1CA8C3,
 		"landmark_count": LANDMARK_COUNT,
 	},
-	# See the Gold and Silver block above; the table is byte identical and only
-	# its address moves.
+	# Every row from here to `mom_phone` is the Gold and Silver block above with a
+	# moved address; `mom_phone`'s two scripts also move their `end` opcode.
 	"oak_ratings": 0x2667F,
-	# See the Gold and Silver block above; the run is byte identical and only its
-	# address moves.
 	"pokecenter_pc": 0x155FA,
 	"decorations": 0x26A4F,
-	# See the Gold and Silver block above; the table is byte identical and only
-	# its address moves.
 	"decoration_ids": 0x26F2B,
-	# See the Gold and Silver block above; only the address and the `end` opcode
-	# in the two scripts move.
 	"mom_phone": 0xFD0FD,
 	# See the Gold and Silver block above; the words are byte identical and only
 	# their address moves.

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -22,7 +22,6 @@ const OAM_ORIGIN := Vector2i(8, 16)
 ## which only the fire cutscene loads a second sheet into.
 const HIGH_TILE: int = 0x80
 
-## `wShadowOAM`, which is forty `SPRITEOAMSTRUCT`s and no more.
 const SHADOW_OAM_SPRITES: int = 40
 
 ## `dbsprite`'s attribute byte.

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -26,7 +26,6 @@ const OAM_ORIGIN := Vector2i(8, 16)
 ## from the one at `vTiles1`.
 const HIGH_TILE: int = 0x80
 
-## `wShadowOAM`, which is forty `SPRITEOAMSTRUCT`s and no more.
 const SHADOW_OAM_SPRITES: int = 40
 
 ## `dbsprite`'s attribute byte.

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -134,7 +134,6 @@ const FRAMESET_RESTART: StringName = &"restart"
 ## `B_OAM_XFLIP` on a frameset entry, which flips each tile where it stands.
 const FLIP_X: int = 1
 
-## `wShadowOAM`, which is forty `SPRITEOAMSTRUCT`s and no more.
 const SHADOW_OAM_SPRITES: int = 40
 ## How many of those each OAM set takes, which is the `db` count each
 ## `.OAMData_*` opens with. The geometry is [Gen2GoldSilverIntroPage]'s; only the
@@ -253,8 +252,7 @@ var _actors: Array[Dictionary] = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}]
 var _anim_count: int = 0
 ## `wShadowOAM`, written by the sprite pass alone. See [method sprites].
 var _shadow: Array[Dictionary] = []
-## Frames a scene spends inside `DelayFrames`, during which neither the
-## jumptable nor `PlaySpriteAnimations` runs.
+## Frames spent inside `DelayFrames`; see [Gen2IntroMovie].
 var _delay: int = 0
 var _frame: int = 0
 var _events: Array[Dictionary] = []
@@ -278,8 +276,7 @@ static func create(
 	return out
 
 
-## Whether [param data] carries the art the movie draws. A cache without it is
-## the caller's cue to skip the phase rather than to run it blank.
+## [method Gen2IntroMovie.available] for the Gold and Silver movie.
 static func available(data: GameData) -> bool:
 	return data != null and data.has_gs_intro()
 
@@ -1371,8 +1368,7 @@ func _sprite_starter(actor: Dictionary, first: int, second: int) -> void:
 	actor["x_offset"] = _cosine_at(cosine, 0x90)
 
 
-## `GetSpriteAnimFrame` and the end of a frameset. Returns false when the struct
-## is deleted.
+## `GetSpriteAnimFrame`; false once the struct is deleted.
 func _advance_actor(actor: Dictionary) -> bool:
 	var frameset: Dictionary = FRAMESETS[StringName(actor["frameset"])]
 	var frames: Array = frameset["frames"]

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -118,6 +118,8 @@ const RESET_ASK_LINES: Array[String] = [
 const RESTORE_PP_WHICH_MOVE: String = "Restore the PP of\nwhich move?"
 const PP_RESTORED: String = "PP was restored."
 const PP_UP_UNSUPPORTED: String = "PP UP has no effect\nin this port yet."
+## `_RepelUsedEarlierIsStillInEffectText`, printed instead of spending the item.
+const REPEL_STILL_IN_EFFECT: String = "The REPEL used\nearlier is still\nin effect."
 
 const SAVE_SAVING_FRAMES: int = Gen2SavePrompt.SAVING_FRAMES
 const SAVE_WRITE_FRAMES: int = Gen2SavePrompt.WRITE_FRAMES
@@ -1830,6 +1832,8 @@ func _use_refusal(reason: StringName, item: int) -> String:
 			return "You have none of those."
 		&"pp_up_unsupported":
 			return PP_UP_UNSUPPORTED
+		&"repel_still_in_effect":
+			return REPEL_STILL_IN_EFFECT
 	return "Can't use that here: %s" % String(reason)
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -63,7 +63,6 @@ const FRIEND_BALL_HAPPINESS: int = 200
 ## The Bug Contest's own ball. It is never in the bag: `wParkBallsRemaining` is
 ## what holds it and `BattleMenu_Pack`'s contest branch loads it by name.
 const ITEM_PARK_BALL: int = 0xB1
-## `ConvertBerriesToBerryJuice`'s own three constants.
 ## `StatExpItemPointerOffsets`: the five vitamins and the stat experience each
 ## one raises. `MON_HP_EXP` and its four neighbours are words and the offsets
 ## name the high byte, so `VitaminEffect` reads and writes that byte alone: it
@@ -113,7 +112,7 @@ const HAPPINESS_PROBABILITIES: Dictionary = {
 const STRING_BUFFER_1: Dictionary = {true: 0xD073, false: 0xCF6B}
 const HAPPINESS_TABLE_OVERRUN_OPCODE: int = 0x21
 
-## `RareCandyEffect` and `RestorePPEffect`'s own five. PP UP is the sixth and
+## `RareCandyEffect` and `RestorePPEffect`'s own six. PP UP is the seventh and
 ## has no branch: `ApplyPPUp` raises a ceiling the save model does not carry, so
 ## the pack refuses it and says why (see `use_item`).
 const ITEM_RARE_CANDY: int = 0x20
@@ -122,11 +121,15 @@ const ITEM_ETHER: int = 0x3F
 const ITEM_MAX_ETHER: int = 0x40
 const ITEM_ELIXER: int = 0x41
 const ITEM_MAX_ELIXER: int = 0x15
-## `RestorePP.restore_some`'s own `ld c, 10`, and `.restore_all`, which the two
-## MAX rows take.
-const PP_RESTORE_STEP: int = 10
+const ITEM_MYSTERYBERRY: int = 0x96
+## `RestorePP.restore_some`'s `ld c, 10`, with `cp MYSTERYBERRY` taking the
+## `ld c, 5` in front of it; the two MAX rows take `.restore_all` instead.
+const PP_RESTORE_STEPS: Dictionary = {
+	ITEM_ETHER: 10, ITEM_ELIXER: 10, ITEM_MYSTERYBERRY: 5,
+}
+## Whether the item walks all four slots, which only the two ELIXERs do.
 const PP_RESTORE_ITEMS: Dictionary = {
-	ITEM_ETHER: false, ITEM_MAX_ETHER: false,
+	ITEM_ETHER: false, ITEM_MAX_ETHER: false, ITEM_MYSTERYBERRY: false,
 	ITEM_ELIXER: true, ITEM_MAX_ELIXER: true,
 }
 const PP_RESTORE_MAX_ITEMS: Array[int] = [ITEM_MAX_ETHER, ITEM_MAX_ELIXER]
@@ -621,7 +624,8 @@ static func use_item(
 		return _failure(StringName(opened["reason"]), opened.get("details", {}))
 	var candidate: Gen2SaveData = opened["candidate"]
 	var effect: Dictionary = _apply_item_effect(
-		world.data, candidate, item, party_index, move_slot, world.map_time_of_day()
+		world.data, candidate, item, party_index, move_slot,
+		world.map_time_of_day(), world.repel_steps()
 	)
 	if not bool(effect.get("ok", false)):
 		return _failure(StringName(effect.get("reason", &"item_has_no_effect")), effect)
@@ -1784,12 +1788,16 @@ static func trade_gender_matches(
 
 static func _apply_item_effect(
 	data: GameData, save: Gen2SaveData, item: int, party_index: int,
-	move_slot: int = -1, time_of_day: int = -1
+	move_slot: int = -1, time_of_day: int = -1, repel_steps: int = 0
 ) -> Dictionary:
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
 		return {"ok": false, "reason": &"unknown_item", "item": item}
 	if REPEL_STEPS.has(item):
+		## `UseRepel`'s `ld a, [wRepelEffect] / and a / jp nz, PrintText`: the
+		## line is said and `UseDisposableItem` never reached.
+		if repel_steps > 0:
+			return {"ok": false, "reason": &"repel_still_in_effect", "item": item}
 		return {"ok": true, "effect": &"repel", "repel_steps": REPEL_STEPS[item]}
 	if item == Gen2WorldPack.ITEM_SACRED_ASH:
 		return _apply_sacred_ash(data, save)
@@ -1841,12 +1849,17 @@ static func _apply_revive(data: GameData, mon: Gen2SaveMon, item: int) -> Dictio
 static func _apply_heal(
 	data: GameData, mon: Gen2SaveMon, definition: Dictionary, item: int
 ) -> Dictionary:
+	## `IsMonFainted` stands in front of `ItemRestoreHP`, `UseStatusHealer` and
+	## `FullRestoreEffect` alike, and a faint clears no status byte, so an
+	## ANTIDOTE is refused on a fainted PSN row rather than curing it.
+	if mon.hp <= 0:
+		return {"ok": false, "reason": &"item_has_no_effect"}
 	var max_hp: int = _max_hp(data, mon)
 	var status_mask: int = int(definition.get("status_mask", 0))
 	var heal_amount: int = int(definition.get("heal_amount", 0))
 	var cleared: int = mon.status & status_mask
 	var healed: int = 0
-	if heal_amount > 0 and mon.hp > 0:
+	if heal_amount > 0:
 		var target_hp: int = max_hp if heal_amount >= Gen2Stats.MAX_STAT_VALUE else mini(
 			max_hp, mon.hp + heal_amount
 		)
@@ -1922,9 +1935,9 @@ static func _apply_rare_candy(
 
 
 ## `RestorePPEffect`: MAX ETHER and MAX ELIXER fill a move, ETHER and ELIXER add
-## ten, and the two ELIXERs walk all four slots where the two ETHERs need the
-## slot `MoveSelectionScreen` chose. A move already at its ceiling is
-## `.dont_restore`, and nothing restored at all is `WontHaveAnyEffectMessage`.
+## ten, MYSTERYBERRY five, and the two ELIXERs walk all four slots where the
+## other three need the slot `MoveSelectionScreen` chose. A move already at its
+## ceiling is `.dont_restore`, and nothing restored is `WontHaveAnyEffectMessage`.
 static func _apply_pp_restore(
 	data: GameData, mon: Gen2SaveMon, item: int, move_slot: int
 ) -> Dictionary:
@@ -1943,7 +1956,8 @@ static func _apply_pp_restore(
 		var current: int = int(mon.pp[slot])
 		if current >= maximum:
 			continue
-		var next: int = maximum if full else mini(maximum, current + PP_RESTORE_STEP)
+		var step: int = int(PP_RESTORE_STEPS.get(item, 0))
+		var next: int = maximum if full else mini(maximum, current + step)
 		restored += next - current
 		mon.pp[slot] = next
 	if restored <= 0:

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -602,7 +602,9 @@ func test_the_pp_restorers_fill_one_move_or_all_four() -> void:
 		_world, _save, Gen2WorldPartyHost.ITEM_ETHER, 0, false, 0
 	)
 	assert_true(bool(ether["ok"]), JSON.stringify(ether))
-	assert_eq(_save.party[0].pp[0], mini(maximum, Gen2WorldPartyHost.PP_RESTORE_STEP))
+	assert_eq(_save.party[0].pp[0], mini(
+		maximum, int(Gen2WorldPartyHost.PP_RESTORE_STEPS[Gen2WorldPartyHost.ITEM_ETHER])
+	))
 
 	var maxed: Dictionary = Gen2WorldPartyHost.use_item(
 		_world, _save, Gen2WorldPartyHost.ITEM_MAX_ETHER, 0, false, 0
@@ -618,6 +620,69 @@ func test_the_pp_restorers_fill_one_move_or_all_four() -> void:
 	assert_false(bool(refused["ok"]))
 	assert_eq(StringName(refused["reason"]), &"item_has_no_effect")
 	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_ELIXER), 1)
+
+
+## `RestorePP`'s `cp MYSTERYBERRY / ld c, 5`: the only PP restorer on five, and
+## the one `ItemEffects` row easy to miss because the item's own pocket row reads
+## as a berry. It takes the same one-slot path as an ETHER.
+func test_a_mysteryberry_restores_five_pp_to_the_chosen_move() -> void:
+	_world.state.apply_changes({}, {}, {"items": {
+		Gen2WorldPartyHost.ITEM_MYSTERYBERRY: 2,
+	}})
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.moves = [1, 0, 0, 0]
+	mon.pp = [0, 0, 0, 0]
+
+	var asked: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_MYSTERYBERRY, 0, false
+	)
+	assert_eq(StringName(asked["reason"]), &"move_slot_required")
+
+	var used: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_MYSTERYBERRY, 0, false, 0
+	)
+	assert_true(bool(used["ok"]), JSON.stringify(used))
+	assert_eq(_save.party[0].pp[0], mini(int(_data.move(1).get("pp", 0)), 5))
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_MYSTERYBERRY), 1)
+
+
+## `UseRepel`'s own `ld a, [wRepelEffect] / and a`: the line is printed in place
+## of `UseDisposableItem`, so a second Repel is neither spent nor stacked.
+func test_a_repel_over_a_live_one_is_refused_and_kept() -> void:
+	_world.state.apply_changes({}, {}, {"items": {
+		Gen2WorldPartyHost.ITEM_REPEL: 1, Gen2WorldPartyHost.ITEM_MAX_REPEL: 1,
+	}})
+
+	var first: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_REPEL, -1, false
+	)
+	assert_true(bool(first["ok"]), JSON.stringify(first))
+	assert_eq(_world.repel_steps(), 100)
+
+	var second: Dictionary = Gen2WorldPartyHost.use_item(
+		_world, _save, Gen2WorldPartyHost.ITEM_MAX_REPEL, -1, false
+	)
+	assert_false(bool(second["ok"]))
+	assert_eq(StringName(second["reason"]), &"repel_still_in_effect")
+	assert_eq(_world.repel_steps(), 100)
+	assert_eq(_world.state.item_quantity(Gen2WorldPartyHost.ITEM_MAX_REPEL), 1)
+
+
+## `IsMonFainted` in front of `ItemRestoreHP`, `UseStatusHealer` and
+## `FullRestoreEffect`. Nothing clears a party member's status byte when it
+## faints, so the reachable case is a member poisoned to zero.
+func test_a_status_healer_is_refused_on_a_fainted_member() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x09: 1}})
+	var mon: Gen2SaveMon = _save.party[0]
+	mon.hp = 0
+	mon.status = Gen2Status.POISON
+
+	var result: Dictionary = Gen2WorldPartyHost.use_item(_world, _save, 0x09, 0, false)
+
+	assert_false(bool(result["ok"]))
+	assert_eq(StringName(result["reason"]), &"item_has_no_effect")
+	assert_eq(_save.party[0].status, Gen2Status.POISON)
+	assert_eq(_world.state.item_quantity(0x09), 1)
 
 
 ## PP UP raises `PP_UP_MASK`, which [Gen2SaveMon] does not carry: the pack says

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -59,6 +59,9 @@ const REGISTERABLE_KEY_ITEMS: Dictionary = {
 ## the item list never reaches.
 const ITEM_ROWS: int = 255
 const NO_DEPOSIT_ROWS: Array[int] = [1, 2, 3]
+## The TM and HM rows, whose ITEMMENU_PARTY nibble is `TeachTMHM` rather than an
+## `ItemEffects` entry.
+const TM_HM_PARTY_ROWS: int = 57
 
 ## What fits between the text box's own borders: `Textbox`'s interior is 18
 ## columns and `PrintItemDescription` is handed the cell one in from the left.
@@ -77,6 +80,7 @@ func run(r: RefCounted) -> void:
 		_verify_field_effects(game_id, data)
 		_verify_deposit_rule(game_id, data)
 		_verify_key_item_effects(game_id, data)
+		_verify_party_item_effects(game_id, data)
 		_verify_screen(game_id, data)
 		_verify_descriptions(game_id, data)
 
@@ -239,6 +243,60 @@ func _verify_deposit_rule(game_id: StringName, data: GameData) -> void:
 			game_id, refused.size(), ", ".join(refused.slice(0, 6)),
 		]
 	)
+
+
+## `ItemEffects` over every ITEMMENU_PARTY row of a real cache. A row
+## `_apply_item_effect` has no branch for answers "It won't have any effect"
+## where the cartridge does something; MYSTERYBERRY was one.
+func _verify_party_item_effects(game_id: StringName, data: GameData) -> void:
+	var unhandled: Array[String] = []
+	var covered: int = 0
+	var machines: int = 0
+	for number: int in range(1, ITEM_ROWS + 1):
+		var definition: Dictionary = data.item(number)
+		if definition.is_empty():
+			continue
+		if Gen2WorldPack.field_use_kind(data, number) != Gen2WorldPack.ITEMMENU_PARTY:
+			continue
+		if int(definition.get("pocket", 0)) == Gen2WorldPack.TYPE_TM_HM:
+			machines += 1
+			continue
+		if _party_effect_branch(number, definition):
+			covered += 1
+			continue
+		unhandled.append("$%02X (%s)" % [number, data.item_name(number)])
+	_r.check(
+		unhandled.is_empty(),
+		"%s: %d of %d party-menu items reach no effect branch: %s" % [
+			game_id, unhandled.size(), covered + unhandled.size(),
+			", ".join(unhandled.slice(0, 6)),
+		]
+	)
+	_r.check(
+		machines == TM_HM_PARTY_ROWS,
+		"%s: %d TM/HM party rows, expected %d" % [game_id, machines, TM_HM_PARTY_ROWS]
+	)
+	print("%s: %d party-menu item effects, %d TM/HM rows beside them." % [
+		game_id, covered, machines,
+	])
+
+
+## The branches `_apply_item_effect` picks between, read off the host's own
+## tables, so a table that loses a row takes this check red with it.
+func _party_effect_branch(item: int, definition: Dictionary) -> bool:
+	if item == Gen2WorldPartyHost.ITEM_RARE_CANDY or item == Gen2WorldPartyHost.ITEM_PP_UP:
+		return true
+	if Gen2WorldPartyHost.PP_RESTORE_ITEMS.has(item):
+		return true
+	if Gen2WorldPartyHost.VITAMINS.has(item):
+		return true
+	if item in Gen2WorldPartyHost.REVIVE_ITEMS:
+		return true
+	if item in Gen2Evolution.STONE_ITEMS \
+		or int((definition.get("evolution", {}) as Dictionary).get("method", 0)) != 0:
+		return true
+	return int(definition.get("heal_amount", 0)) > 0 \
+		or int(definition.get("status_mask", 0)) != 0
 
 
 ## The three key items whose effect is a `farsjump` at a named map script, each

--- a/tools/preview_gs_intro.gd
+++ b/tools/preview_gs_intro.gd
@@ -67,8 +67,7 @@ func _initialize() -> void:
 	quit(0)
 
 
-## The whole movie, printing the frame each scene starts on and every sound it
-## asks for. This is the budget the boot cinema spends.
+## The whole movie, the way `tools/preview_intro_movie.gd` reports Crystal's.
 func _report(movie: Gen2GoldSilverIntro) -> void:
 	var scene: int = movie.scene()
 	print("scene 0 starts at frame 0")


### PR DESCRIPTION
MYSTERYBERRY is a `RestorePPEffect` entry, and `RestorePP`'s `cp MYSTERYBERRY / ld c, 5` is the only PP restore on five. It was in no table here, so its USE fell through to the healing branch and answered "It won't have any effect".

`UseRepel`'s `ld a, [wRepelEffect] / and a / jp nz, PrintText` never reaches `UseDisposableItem`, so a Repel used over a live one is refused and kept. The port restarted the counter and spent the item.

`IsMonFainted` stands in front of `ItemRestoreHP`, `UseStatusHealer` and `FullRestoreEffect` alike, and nothing clears a party member's status byte when it faints, so an ANTIDOTE on a member poisoned to zero is refused rather than curing it.

`tools/checks/pack.gd` sweeps every ITEMMENU_PARTY row of all three caches against the branches `_apply_item_effect` picks between: 49 rows plus 57 TM/HM on each. Removing MYSTERYBERRY from the table takes the topic red naming that row.

Beside them, four statements of one fact reduced to one: `SHADOW_OAM_SPRITES`' docstring, the four "see the block above" rows in `rom_layout.gd`, and three docstrings `gold_silver_intro.gd` repeated from `intro_movie.gd`.

| Check | Result |
|---|---|
| GUT unit tier | 3,580 tests, 68,452 asserts, all pass |
| `validate.gd -- all` | exit 0, 84 topics |
| Editor analyser | 0 warnings in 614 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | unchanged from main |
| Comment ceiling | 37,777 of 37,777 |