### PR TITLE
Three defects from a walk of the overworld sprite and HUD routines

### DIFF
--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -577,16 +577,19 @@ func _draw_panels() -> void:
 	var enemy_hud: bool = bool(_view.get("enemy_hud_visible", true))
 	var player_hud: bool = bool(_view.get("player_hud_visible", true))
 	var border: Array = _view.get("trainer_hud_border", []) as Array
+	var enemy_caught: bool = bool(_view.get("enemy_caught", false))
 
 	# The player's panel prints its own HP numbers, so it moves with the bar; the
 	# enemy's does not, which is why both sit in one layer keyed on all of it.
 	if _layer_changed(&"panels", [
 		enemy_name, enemy_level, player_name, player_level, player_hp, player_max_hp,
-		enemy_hud, player_hud, border, raster,
+		enemy_hud, player_hud, border, enemy_caught, raster,
 	]):
 		var panels: PackedByteArray = _new_buffer()
 		if enemy_hud:
-			_hud.draw_enemy(panels, Gen2Screen.WIDTH, enemy_name, enemy_level)
+			_hud.draw_enemy(
+				panels, Gen2Screen.WIDTH, enemy_name, enemy_level, enemy_caught
+			)
 		if player_hud:
 			_hud.draw_player(
 				panels, Gen2Screen.WIDTH, player_name, player_level, player_hp, player_max_hp

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1700,9 +1700,8 @@ func _begin_slide(side: int) -> void:
 	})
 
 
-## `BattleStart_TrainerHuds`: the player's party balls always, the opponent's as
-## well when there is a trainer behind them, each six sprites hanging under a
-## border of four tile kinds.
+## `BattleStart_TrainerHuds`: the player's party balls always, the opponent's
+## when a trainer is behind them, six sprites under a border of four tile kinds.
 func _build_trainer_huds() -> void:
 	_hud_balls = []
 	_hud_border = []
@@ -1712,9 +1711,8 @@ func _build_trainer_huds() -> void:
 
 
 ## One side of it. `LoadTrainerHudOAM` walks six slots from
-## [constant HUD_BALL_AT] in [constant HUD_BALL_STEP]'s direction, taking the
-## tile `StageBallTilesData` staged for each, and `PlaceHUDBorderTiles` draws the
-## frame from a corner outwards in the same direction.
+## [constant HUD_BALL_AT] in [constant HUD_BALL_STEP]'s direction, and
+## `PlaceHUDBorderTiles` draws the frame from a corner outwards the same way.
 func _add_trainer_hud(side: int) -> void:
 	var player_side: bool = side == Gen2Battle.PLAYER
 	var at: Vector2i = HUD_BALL_AT[player_side]
@@ -6068,6 +6066,9 @@ func _push_view() -> void:
 			and _anim_hud_hidden != Gen2Battle.ENEMY,
 		"player_hud_visible": _player_hud_visible \
 			and _anim_hud_hidden != Gen2Battle.PLAYER,
+		## `DrawEnemyHUDBorder`'s last line, which leaves on `wBattleMode`: only
+		## a wild battle marks a species the Pokedex already holds.
+		"enemy_caught": _enemy_caught_before and _enemy_trainer_class == 0,
 		## `BattleStart_TrainerHuds`' party balls and the frame they hang in.
 		"trainer_hud_balls": _hud_balls,
 		"trainer_hud_border": _hud_border,

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -1,13 +1,10 @@
 class_name Gen2BattleHud
 extends RefCounted
 
-## The two status panels a battle draws, on the tile grid the hardware uses. The
-## enemy's hangs from a side on its left at the top, the player's from a side on
-## its right below the middle; neither is a box, but an edge and two corners with
-## the contents printed inside, which is why both come from the HUD sheets. The
-## player's also carries HP as numbers and an exp bar along its bottom edge, and
-## the enemy's has neither because the player is not supposed to know either
-## number. Node-free: it writes indices into a buffer.
+## The two status panels a battle draws, on the tile grid the hardware uses.
+## Neither is a box but an edge and two corners with the contents printed inside,
+## which is why both come from the HUD sheets. Only the player's carries HP as
+## numbers and an exp bar. Node-free: it writes indices into a buffer.
 
 const TILE: int = Gen2Font.TILE
 
@@ -20,6 +17,8 @@ const EXP_BAR_TILES: int = 8
 
 ## The enemy's panel: name, then level, then the bar and the edge under it.
 const ENEMY_NAME: Vector2i = Vector2i(1, 0)
+## `DrawEnemyHUDBorder`'s `hlcoord 1, 1`, under the name's first letter.
+const ENEMY_CAUGHT: Vector2i = Vector2i(1, 1)
 const ENEMY_LEVEL: Vector2i = Vector2i(6, 1)
 const ENEMY_BAR: Vector2i = Vector2i(2, 2)
 const ENEMY_EDGE: Vector2i = Vector2i(1, 2)
@@ -78,16 +77,20 @@ static func bar_pixels(current: int, maximum: int, length: int) -> int:
 
 
 ## The enemy's panel except for the bar's fill: the name, the level, the "HP:"
-## label, the cap that closes the bar and the edge under it.
-##
-## The fill is drawn separately as the one thing on the panel that is not black
-## on white. The hardware gives every tile its own palette; this layers instead,
-## which comes to the same picture and keeps the palette choice where the colour
-## is.
+## label, the cap that closes the bar and the edge under it. [param caught] is
+## `DrawEnemyHUDBorder`'s ball, drawn on a wild battle whose species the Pokedex
+## already has caught. The fill is a layer of its own as the one thing on the
+## panel that is not black on white, which keeps the palette choice where the
+## colour is.
 func draw_enemy(
-	into: PackedByteArray, width: int, name: String, level: int
+	into: PackedByteArray, width: int, name: String, level: int, caught: bool = false
 ) -> void:
 	font.draw_text(name, into, width, ENEMY_NAME.x * TILE, ENEMY_NAME.y * TILE)
+	if caught:
+		tiles.draw(
+			Gen2BattleTiles.CAUGHT_BALL, into, width,
+			ENEMY_CAUGHT.x * TILE, ENEMY_CAUGHT.y * TILE
+		)
 	draw_level(into, width, ENEMY_LEVEL, level)
 	draw_bar_frame(into, width, ENEMY_BAR, Gen2BattleTiles.HP_BAR_END)
 
@@ -150,14 +153,12 @@ func draw_hp_bar(
 		)
 
 
-## The exp bar, whose ends are the HP bar's own tiles and whose partial fills are
-## the only thing its own sheet is for. [param pixels] is `PlaceExpBar`'s own `b`:
-## a pixel count and never a ratio, `CalcExpBar` having already divided and rounded
-## it. `PlaceExpBar` starts at `hlcoord 17, 11` and writes with `ld [hld], a`, so
-## the full tiles land at the right-hand end and the run walks left, and unlike
-## `DrawBattleHPBar` it lays no empty template and writes $62 for every tile the
-## fill did not reach. [param at] is the bar's left-hand tile, the HUD's own
-## everywhere but the stats screen, where `LoadPinkPage` fills it in at (11,16).
+## The exp bar, whose ends are the HP bar's own tiles. [param pixels] is
+## `PlaceExpBar`'s `b`: a pixel count and never a ratio, `CalcExpBar` having
+## divided already. It starts at `hlcoord 17, 11` and writes with `ld [hld], a`,
+## so the run walks left from the right-hand end, and writes $62 for every tile
+## the fill did not reach. [param at] is the bar's left-hand tile, the HUD's own
+## everywhere but the stats screen's (11,16).
 func draw_exp_bar(
 	into: PackedByteArray, width: int, pixels: int, at: Vector2i = PLAYER_EXP
 ) -> void:
@@ -176,8 +177,8 @@ func draw_exp_bar(
 		tiles.draw(number, into, width, (right - tile) * TILE, top)
 
 
-## The level symbol and the number, left-aligned after it, which is how a level
-## is written everywhere in these games until the number needs three digits.
+## The level symbol and the number after it, which is how a level is written
+## everywhere in these games until the number needs three digits.
 func draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> void:
 	var column: int = at.x
 	if Gen2Font.level_glyph_shown(level):

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -50,6 +50,9 @@ const HP_BAR_END: int = 0x6B
 ## The seven partial fills of the exp bar. Its empty and full tiles are the HP
 ## bar's own: only the middle of it is drawn from a sheet of its own.
 const EXP_BAR_FIRST_PARTIAL: int = 0x55
+## `ExpBarGFX`' ninth tile, no part of the bar: a battle loads nine at $55 and
+## the stats screen eight, and this one is `DrawEnemyHUDBorder`'s ball.
+const CAUGHT_BALL: int = 0x5D
 
 ## The level symbol, printed before a number.
 const LEVEL: int = 0x6E

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -4914,9 +4914,8 @@ func _movement_effect(
 			return false
 		&"tree_shake":
 			## `Movement_tree_shake` shakes the object, not the screen: the
-			## stream sleeps 24 frames while OBJECT_ACTION_WEIRD_TREE cycles
-			## its drawing. The event stays for a host that plays a sound
-			## over it; nothing else is asked of it.
+			## stream sleeps 24 frames while OBJECT_ACTION_WEIRD_TREE cycles its
+			## drawing. The event is there for a host that sounds it.
 			object.queue_tree_shake(TREE_SHAKE_FRAMES)
 			generated.append({
 				"type": &"tree_shake_requested",

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -219,8 +219,8 @@ const COLL_UP_RIGHT_WALL: int = 0xB6
 const COLL_UP_LEFT_WALL: int = 0xB7
 
 ## .MovementPermissionsData, indexed by a wall or buoy code's low three bits:
-## which of the standing tile's edges it walls off, in FACE_* terms. Numerically
-## identical to LEDGE_FACE_MASK, and two tables in the source as well.
+## which of the standing tile's edges it walls off. Numerically LEDGE_FACE_MASK,
+## and two tables in the source as well.
 const SIDE_WALL_FACE_MASK: Array[int] = [
 	FACE_RIGHT,               # COLL_RIGHT_WALL/BUOY
 	FACE_LEFT,                # COLL_LEFT_WALL/BUOY
@@ -245,17 +245,24 @@ static func side_wall_face_mask(collision_code: int) -> int:
 	return SIDE_WALL_FACE_MASK[collision_code & 0x07]
 
 
+## `CanObjectLeaveTile`'s answer per code. It means to index `.dir_masks` by
+## wWalkingDirection, but the `ld a, [hl]` that would read it is missing, so it
+## indexes by `GetSideWallDirectionMask`'s own mask ANDed with 3 and tests the
+## mask against that entry: four codes refuse every step and four allow it.
+const SIDE_WALL_LEAVE_BLOCKED: Array[bool] = [
+	false, false, true, false, false, true, true, true,
+]
+
+
 ## engine/overworld/npc_movement.asm's CanObjectLeaveTile (on [param from_code])
-## and WillObjectBumpIntoTile (on [param to_code]). Both index a differently
-## bit-packed table, GetSideWallDirectionMask's, keyed by wWalkingDirection
-## rather than wFacingDirection, and produce the identical per-code result, so
-## the FACE_* table is reused instead of encoding the rule twice. Both games ship
-## npc_movement.asm byte identical, hence no profile argument here.
+## and WillObjectBumpIntoTile (on [param to_code]); only the second reads the
+## direction. Both pins ship the file byte identical, hence no profile argument.
 static func side_wall_step_blocked(from_code: int, to_code: int, direction: Vector2i) -> bool:
 	var forward_face: int = face_mask_for_direction(direction)
 	if forward_face == 0:
 		return false
-	if (side_wall_face_mask(from_code) & forward_face) != 0:
+	if side_wall_face_mask(from_code) != 0 \
+		and SIDE_WALL_LEAVE_BLOCKED[from_code & 0x07]:
 		return true
 	return (side_wall_face_mask(to_code) & face_mask_for_direction(-direction)) != 0
 

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -666,10 +666,6 @@ const PARTY_SELECTION_CANCEL_BOX: Dictionary = {
 	&"photo_studio": ["photo_studio", "no_photo"],
 }
 
-## `CelebiShrineEvent`'s own loop: `ld a, 160` into wFrameCounter and
-## `ld c, 2 / call DelayFrames` per pass, so the cutscene stands for twice its
-## own counter. There is no sprite-anim layer outside the intro, so what it owes
-## a script is the wait and the battle type it leaves behind.
 ## `engine/events/poke_seer.asm`'s own readings.
 const SEER_UNKNOWN: String = "Unknown"
 const SEER_TIMES: Array[String] = ["Morning", "Day", "Night"]
@@ -686,8 +682,12 @@ const SEER_ADVICE: Array = [
 	[89, "mighty"], [100, "impressed"], [255, "more_care"],
 ]
 
+## `CelebiShrineEvent`: `ld a, 160` into wFrameCounter, two frames a pass, and
+## one `DelayFrame` in front. `CelebiEvent_CountDown` reads the counter before
+## it decrements, so the pass that reads zero is spent too.
 const CELEBI_SHRINE_PASSES: int = 160
 const CELEBI_SHRINE_FRAMES_PER_PASS: int = 2
+const CELEBI_SHRINE_ENTRY_FRAMES: int = 1
 const VARIABLE_SPRITE_BASE: int = 0xF0
 
 
@@ -5165,9 +5165,8 @@ func _special_check_caught_celebi(_special: int) -> Dictionary:
 	return {"ok": true}
 
 
-## The whole routine is a sprite-anim cutscene and a battle type. There is no
-## sprite-anim layer outside the intro, so what it owes a script is the wait its own
-## loop spends and the type the fight behind it starts with.
+## A sprite-anim cutscene and a battle type. There is no sprite-anim layer
+## outside the intro, so what it owes a script is the wait and the type.
 func _special_celebi_shrine_event(special: int) -> Dictionary:
 	_loaded_battle_type = Gen2Battle.BATTLETYPE_CELEBI
 	if not _battle_setup.is_empty():
@@ -5176,7 +5175,8 @@ func _special_celebi_shrine_event(special: int) -> Dictionary:
 		"special": special, "kind": &"celebi_shrine",
 	})
 	return _stage_frame_wait(
-		CELEBI_SHRINE_PASSES * CELEBI_SHRINE_FRAMES_PER_PASS,
+		CELEBI_SHRINE_ENTRY_FRAMES
+			+ (CELEBI_SHRINE_PASSES + 1) * CELEBI_SHRINE_FRAMES_PER_PASS,
 		{"special": special, "kind": &"celebi_shrine"}
 	)
 

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -198,6 +198,36 @@ func test_the_hud_draws_its_panels_where_the_hardware_puts_them() -> void:
 	assert_eq(_ink_in_row(screen, 5), 0, "nothing between the two panels")
 
 
+## `DrawEnemyHUDBorder`'s tail: a wild battle whose species the Pokedex already
+## holds carries `ExpBarGFX`' ninth tile under the enemy's name, and nothing else
+## on the panel moves.
+func test_a_caught_species_marks_the_enemy_panel_with_a_ball() -> void:
+	_write_cache()
+	var hud: Gen2BattleHud = Gen2BattleHud.from_data(_data())
+
+	var plain: PackedByteArray = PackedByteArray()
+	plain.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_enemy(plain, Gen2Screen.WIDTH, "PIDGEY", 5)
+
+	var caught: PackedByteArray = PackedByteArray()
+	caught.resize(Gen2Screen.WIDTH * Gen2Screen.HEIGHT)
+	hud.draw_enemy(caught, Gen2Screen.WIDTH, "PIDGEY", 5, true)
+
+	## Row 1 already carries the level, so the ball is the difference between
+	## the two panels rather than everything drawn on the row.
+	assert_eq(
+		_ink_in_row(caught, Gen2BattleHud.ENEMY_CAUGHT.y)
+			- _ink_in_row(plain, Gen2BattleHud.ENEMY_CAUGHT.y),
+		Gen2Font.TILE * Gen2Font.TILE,
+		"one tile of ball"
+	)
+	assert_eq(
+		_ink_in_row(caught, Gen2BattleHud.ENEMY_NAME.y),
+		_ink_in_row(plain, Gen2BattleHud.ENEMY_NAME.y),
+		"the name row is untouched"
+	)
+
+
 func test_the_hp_bar_fill_is_drawn_apart_from_the_panel() -> void:
 	# The fill is the only part of a panel that is not black on white, so it is
 	# a layer of its own and the panel must not draw it.

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -4008,6 +4008,26 @@ func test_heal_machine_anim_special_emits_presentation_event_without_state_chang
 	)
 
 
+## `CelebiShrineEvent` holds the script for its own loop: one `DelayFrame` on
+## the way in and two frames a pass, and `CelebiEvent_CountDown` reads its
+## counter before decrementing, so the pass that reads zero is spent as well.
+func test_the_celebi_shrine_event_waits_for_the_loop_it_runs() -> void:
+	var scripts: Dictionary = RomCache.read_json(RomCache.world_scripts_path(_directory))
+	scripts["48:6360"] = [
+		Gen2WorldScript.SPECIAL, Gen2WorldScriptRunner.SPECIAL_CELEBI_SHRINE_EVENT, 0,
+		Gen2WorldScript.END,
+	]
+	RomCache.write_json(RomCache.world_scripts_path(_directory), scripts)
+	var data: GameData = GameData.open_directory(_directory)
+	var runner := Gen2WorldScriptRunner.begin(data, Gen2WorldState.new(), {
+		"kind": &"test", "bank": 48, "script": 0x6360,
+	})
+	var result: Dictionary = runner.advance()
+	assert_eq(result["status"], &"waiting", JSON.stringify(result))
+	assert_eq(StringName(result["event"]["kind"]), &"celebi_shrine")
+	assert_eq(int(result["event"]["frames"]), 323, JSON.stringify(result))
+
+
 ## `.HallOfFame`'s sequence is the only one that differs: two effects around
 ## `.FlashPalettes8Times` where the other two start `MUSIC_HEAL` under it.
 func test_heal_machine_sounds_follow_the_sequence_the_machine_type_selects() -> void:

--- a/tests/unit/test_world_collision.gd
+++ b/tests/unit/test_world_collision.gd
@@ -209,21 +209,33 @@ func test_tile_permissions_gold_silver_enter_rule_always_sets_face_down() -> voi
 
 
 ## engine/overworld/npc_movement.asm's CanObjectLeaveTile and
-## WillObjectBumpIntoTile, byte-identical between both pinned repositories.
+## WillObjectBumpIntoTile, byte-identical between both pinned repositories. The
+## leave half never reads the walking direction, so it answers per code alone.
 func test_side_wall_step_blocked_matches_the_leave_and_enter_rules() -> void:
 	var open_code: int = 0x00
-	# Leaving a RIGHT_WALL tile moving RIGHT is blocked (leave rule).
-	assert_true(Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, Vector2i.RIGHT))
-	# Leaving the same tile moving LEFT, UP or DOWN is not.
-	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, Vector2i.LEFT))
-	assert_false(Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, Vector2i.UP))
-	# Entering a LEFT_WALL tile from the west (moving RIGHT) is blocked
-	# (enter rule: the destination's own mask contains FACE_LEFT, the
-	# opposite of RIGHT).
+	# Leaving a RIGHT_WALL tile is allowed in every direction, RIGHT included:
+	# `GetSideWallDirectionMask` returns RIGHT_MASK, and RIGHT_MASK & 3 indexes
+	# the entry RIGHT_MASK does not share a bit with.
+	for direction: Vector2i in [Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN]:
+		assert_false(
+			Gen2WorldCollision.side_wall_step_blocked(0xB0, open_code, direction),
+			"a right wall lets an object leave"
+		)
+	# An UP_WALL tile refuses every one of them, and so do the three corner
+	# codes whose mask carries DOWN_MASK or lands on LEFT_MASK.
+	for code: int in [0xB2, 0xB5, 0xB6, 0xB7]:
+		for direction: Vector2i in [Vector2i.RIGHT, Vector2i.LEFT, Vector2i.UP, Vector2i.DOWN]:
+			assert_true(
+				Gen2WorldCollision.side_wall_step_blocked(code, open_code, direction),
+				"code %02x holds an object where it stands" % code
+			)
+	# Entering a LEFT_WALL tile from the west (moving RIGHT) is blocked: the
+	# destination's own mask contains FACE_LEFT, the opposite of RIGHT. That
+	# half does read the direction.
 	assert_true(Gen2WorldCollision.side_wall_step_blocked(open_code, 0xB1, Vector2i.RIGHT))
 	assert_false(Gen2WorldCollision.side_wall_step_blocked(open_code, 0xB1, Vector2i.LEFT))
-	# A RIGHT_WALL/LEFT_WALL pair blocks crossing in both directions even
-	# though both tiles are plain LAND_TILE permission.
+	# A RIGHT_WALL/LEFT_WALL pair still blocks crossing in both directions,
+	# through the enter rule alone.
 	assert_true(Gen2WorldCollision.side_wall_step_blocked(0xB0, 0xB1, Vector2i.RIGHT))
 	assert_true(Gen2WorldCollision.side_wall_step_blocked(0xB1, 0xB0, Vector2i.LEFT))
 	# A zero or diagonal direction never blocks.

--- a/tools/checks/side_walls.gd
+++ b/tools/checks/side_walls.gd
@@ -40,6 +40,13 @@ const EXPECTED_CENSUS: Dictionary = {
 }
 
 
+## Map objects standing on a side-wall cell, from the same caches.
+const EXPECTED_OBJECT_CENSUS: Dictionary = {
+	&"crystal": {0xB2: 2},
+	&"gold": {0xB2: 5},
+}
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	for game_id: StringName in [&"crystal", &"gold"]:
@@ -49,6 +56,7 @@ func run(r: RefCounted) -> void:
 			continue
 		_verify_codes(game_id)
 		_verify_census(game_id, data)
+		_verify_object_census(game_id, data)
 	_verify_celadon_mansion_roof()
 
 
@@ -109,6 +117,30 @@ func _verify_census(game_id: StringName, data: GameData) -> void:
 			false,
 			"%s: $%02X has %d cells with no expected count; census is stale." % [
 				game_id, code, int(counts[code]),
+			]
+		)
+
+
+## `CanObjectLeaveTile` never reads the walking direction, so an object on a $b2
+## cell cannot step at all. Seven objects stand on one across the two pins, every
+## one a standing or still movement type.
+func _verify_object_census(game_id: StringName, data: GameData) -> void:
+	var counts: Dictionary = {}
+	for map: Gen2WorldMap in data.world_maps():
+		for event: Dictionary in map.events.get("objects", []) as Array:
+			var cell := Vector2i(int(event.get("x", 0)), int(event.get("y", 0)))
+			if cell.x < 0 or cell.y < 0 or cell.x >= map.collision_width \
+				or cell.y >= map.collision_height:
+				continue
+			var code: int = int(map.collision[cell.y * map.collision_width + cell.x])
+			if code >= 0xB0 and code <= 0xCF:
+				counts[code] = int(counts.get(code, 0)) + 1
+	var expected: Dictionary = EXPECTED_OBJECT_CENSUS[game_id]
+	for code: int in EXPECTED_FACE_MASK:
+		_r.check(
+			int(counts.get(code, 0)) == int(expected.get(code, 0)),
+			"%s: %d map objects stand on $%02X, expected %d." % [
+				game_id, int(counts.get(code, 0)), code, int(expected.get(code, 0)),
 			]
 		)
 

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -14,7 +14,8 @@ extends SceneTree
 ## which is the pack's USE on that item.
 const KIND_HELP: Dictionary = {
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
-	&"battle": "cell: the wild fight preview_battle_request starts, settled past its transition",
+	&"battle": "frames: the wild fight preview_battle_request starts, settled past its transition",
+	&"battle_caught": "frames: the same fight against a species the dex already holds",
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
 	&"catch_dex": "none: NewPokedexEntry's page, over the fight the catch that opened it is still in",
 	&"cut": "cell: OWCutAnimation's two halves and the jump shadow",
@@ -144,6 +145,8 @@ const TEXT_SETTLE_FRAMES: int = 20
 ## climb runs four passes a cell, so 26 lands a few cells up.
 const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_BY_KIND: Dictionary = {&"cut": 12, &"waterfall_use": 26}
+
+const PREVIEW_BATTLE_SPECIES: int = 16 ## `preview_battle_request`'s PIDGEY.
 
 var _screen: Gen2WorldScreen = null
 var _output_path: String = ""
@@ -317,7 +320,8 @@ func _settle_mon_special(host_property: String) -> void:
 ## stages a sprite and then spends the frames it needs.
 const SELF_DRIVEN_KINDS: Array[StringName] = [
 	&"warp", &"door", &"map_name_sign", &"ledge", &"heal_machine", &"fly",
-	&"battle", &"battle_transition", &"level_evolution", &"egg_hatch",
+	&"battle", &"battle_caught", &"battle_transition", &"level_evolution",
+	&"egg_hatch",
 	&"catch_tutorial",
 	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 	&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
@@ -333,6 +337,7 @@ const SELF_DRIVEN_KINDS: Array[StringName] = [
 const STAGERS: Dictionary = {
 	&"unown_wall": &"_stage_unown_wall",
 	&"battle": &"_stage_battle",
+	&"battle_caught": &"_stage_battle",
 	&"catch_tutorial": &"_stage_catch_tutorial",
 	&"battle_transition": &"_stage_battle_transition",
 	&"script_fade": &"_stage_script_fade",
@@ -449,12 +454,20 @@ func _stage_unown_wall() -> void:
 	_screen.press_button(Gen2Button.A)
 
 
-## Past the transition and into the fight it opens, which is the one picture a battle
-## renderer staged on the map draws.
+## Past the transition and into the fight it opens. `battle_caught` marks the
+## species caught first and answers the appearance line, since the panel
+## `DrawEnemyHUDBorder`'s ball rides on is only up past it.
 func _stage_battle() -> void:
+	var frames: int = maxi(_cell.x, STAGED_FRAMES)
+	var caught: bool = _kind == &"battle_caught"
+	if caught:
+		_screen.world().state.set_species_caught(PREVIEW_BATTLE_SPECIES)
 	_screen.preview_battle_request()
 	_screen.settle_battle_transition()
-	_screen.advance_frames(STAGED_FRAMES)
+	_screen.advance_frames(frames)
+	for _press: int in (3 if caught else 0):
+		_screen.press_button(Gen2Button.A)
+		_screen.advance_frames(frames)
 
 
 ## `CatchTutorial`, played by `DudeAutoInputs` rather than by anybody. The first


### PR DESCRIPTION
## Fixed

`CanObjectLeaveTile` never reads wWalkingDirection. The `ld a, [hl]` before its `maskbits` is missing, so the routine indexes `.dir_masks` with `GetSideWallDirectionMask`'s own mask instead of the direction: $b2, $b5, $b6 and $b7 refuse every step an object standing on them takes, and $b0, $b1, $b3 and $b4 allow every one. `Gen2WorldCollision.side_wall_step_blocked` asked the direction on both halves; only the enter half reads it. `tools/checks/side_walls.gd` pins the seven map objects across the two pins that stand on such a cell, every one a standing or still movement type.

`DrawEnemyHUDBorder`'s caught marker. A wild battle whose species the Pokedex already holds carries `ExpBarGFX`' ninth tile at `hlcoord 1, 1`, which is why a battle loads nine tiles at $55 and the stats screen eight. `Gen2BattleHud.draw_enemy` draws it, off the dex context the battle screen already carried for `PokeBallEffect`.

`CelebiShrineEvent` holds a script for 323 frames, not 320: one `DelayFrame` before the loop, and `CelebiEvent_CountDown` reads its counter before decrementing, so the pass that reads zero is spent too.

## Changed

`tools/preview_world.gd` takes a `battle_caught` kind, which marks the species caught and answers the appearance line so the marker is on screen. Its two numbers are frames now rather than a cell, which is what `battle` was already spending them as.

The Celebi comment block that had drifted onto the Seer constants is back on its own.

## Proving it

| Check | Result |
|---|---|
| GUT unit tier | 3582 tests, 0 failures |
| `tools/validate.gd -- all` | no FAIL lines |
| `replay_world.gd` | 33 routes, 0 failures |
| warning scan | 0 warnings in 614 scripts |
| `tools/release.sh --gates` | pass, comments 37777 of 37777 |