### PR TITLE
Five defects from a walk of battle move effects and Pokerus

### DIFF
--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -276,7 +276,6 @@ func registered_bank_count() -> int:
 
 
 
-## `_InitSound`.
 func init_sound() -> void:
 	music_off()
 	apu.write(0xFF24, 0)
@@ -325,7 +324,6 @@ func music_off() -> void:
 	music_playing = false
 
 
-## `_PlayMusic`.
 func play_music(record: Dictionary) -> bool:
 	if not register_record(record):
 		return false
@@ -480,7 +478,6 @@ func any_channel_active() -> bool:
 
 
 
-## `_UpdateSound`.
 func update_sound() -> void:
 	if not music_playing:
 		return

--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -271,7 +271,6 @@ static func run(
 	return true
 
 
-## `BattleBGEffects_IncAnonJumptableIndex`.
 static func _inc(effect: Gen2BattleAnimBgEffect) -> void:
 	effect.jumptable_index = (effect.jumptable_index + 1) & 0xFF
 

--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -171,7 +171,6 @@ static func run(
 		return false
 	(FUNCTIONS[object.function] as Callable).call(player, player.data(), object)
 	return true
-## `BattleAnim_IncAnonJumptableIndex`.
 static func _inc(object: Gen2BattleAnimObject) -> void:
 	object.jumptable_index = (object.jumptable_index + 1) & 0xFF
 

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -515,8 +515,10 @@ const GENDER_FEMALE: StringName = &"female"
 const GENDER_NONE: StringName = &"genderless"
 
 
+## `CheckOppositeGender` reads the party struct and `wEnemyBackupDVs` behind a
+## Transform, which is why the copied identity is not asked.
 func gender() -> StringName:
-	return gender_for(data, species, dvs)
+	return gender_for(data, persistent_species(), persistent_dvs())
 
 
 ## The same answer for a Pokémon that is not in a battle, so the Hall of Fame's

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -873,7 +873,8 @@ static func _pay_day(turn: Gen2Turn) -> void:
 static func _transform(turn: Gen2Turn) -> void:
 	turn.attacker().last_move_used = 0 # ClearLastMove opens the source routine.
 	turn.attacker().last_counter_move = 0
-	if not turn.attacker().transform_into(turn.defender()):
+	if _is_hidden(turn.defender().substatus) \
+		or not turn.attacker().transform_into(turn.defender()):
 		turn.emit(Gen2Battle.MOVE_FAILED)
 		turn.end()
 		return
@@ -1183,7 +1184,8 @@ static func _mimic(turn: Gen2Turn) -> void:
 	_clear_last_move_for_call(turn)
 	var copied: int = turn.defender().last_counter_move
 	var slot: int = turn.attacker().moves.find(Gen2MoveEffect.MIMIC_MOVE)
-	if copied == 0 or copied == Gen2Damage.STRUGGLE or slot < 0 \
+	if _is_hidden(turn.defender().substatus) \
+		or copied == 0 or copied == Gen2Damage.STRUGGLE or slot < 0 \
 		or turn.attacker().moves.has(copied) or turn.data().move(copied).is_empty():
 		_fail_called_move(turn)
 		return
@@ -2476,7 +2478,9 @@ static func _attract(turn: Gen2Turn) -> void:
 
 	var user_gender: StringName = attacker.gender()
 	var target_gender: StringName = defender.gender()
-	if user_gender == Gen2BattleMon.GENDER_NONE or target_gender == Gen2BattleMon.GENDER_NONE \
+	if _is_hidden(defender.substatus) \
+		or user_gender == Gen2BattleMon.GENDER_NONE \
+		or target_gender == Gen2BattleMon.GENDER_NONE \
 		or user_gender == target_gender:
 		turn.emit(Gen2Battle.MOVE_FAILED)
 		return
@@ -3189,7 +3193,13 @@ static func _beat_up(turn: Gen2Turn) -> void:
 		turn.skip_to = BUILD_OPPONENT_RAGE
 		return
 	var member: Gen2BattleMon = party.at(index)
-	if member.is_fainted() or member.status != Gen2Status.NONE:
+	# `.got_mon`'s `cp [hl]` puts `wCurBattleMon` against the low byte of the
+	# member's HP rather than its slot, so a member whose HP ends in the active
+	# slot's number is asked for the Pokemon that is out. `cp b` reads the slot.
+	var status: int = member.status
+	if turn.side == Gen2Battle.PLAYER and (member.hp & 0xFF) == party.active:
+		status = party.active_mon().status
+	if member.is_fainted() or status != Gen2Status.NONE:
 		turn.skip_to = BUILD_OPPONENT_RAGE
 		return
 
@@ -3565,10 +3575,17 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 	if not turn.battle.mon(side).can_change_stage(stat_key, amount):
 		return
 
+	if not targets_user and _computer_stat_down_misses(turn):
+		return
+
 	if not targets_user and _substitute_refuses(turn):
 		return
 
 	if turn.failed_chance:
+		return
+
+	# `CheckHiddenOpponent`: a target part way through Fly or Dig is not there.
+	if not targets_user and _is_hidden(turn.battle.mon(side).substatus):
 		return
 
 	turn.stat_moved = turn.battle.mon(side).change_stage(stat_key, amount)
@@ -3583,6 +3600,19 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 		# other half, taking a raised doll off the picture, is undone by the
 		# `raisesub` two commands later in every list that reaches here.
 		turn.emit(Gen2Battle.MINIMIZED, {"side": side})
+
+
+## `BattleCommand_StatDown`'s `.ComputerMiss`: an enemy lowering one of the
+## player's stats fails a quarter of the time, exempting Lock-On and
+## `EFFECT_ACCURACY_DOWN_HIT`. It sits behind `.CantLower`, which never rolls.
+static func _computer_stat_down_misses(turn: Gen2Turn) -> bool:
+	if turn.side != Gen2Battle.ENEMY:
+		return false
+	if Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.LOCK_ON):
+		return false
+	if turn.effect() == Gen2MoveEffect.ACCURACY_DOWN_HIT:
+		return false
+	return turn.rng().randi_range(0, 0xFF) < 64
 
 
 ## Minimize's move number, which is the whole of what `MinimizeDropSub` compares

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -1791,6 +1791,9 @@ const ACCURACY_DOWN: int = STAT_DOWN_BASE + 5
 const SP_DEF_UP_2: int = STAT_UP_2_BASE + 4
 const SPEED_DOWN_HIT: int = STAT_DOWN_HIT_BASE + 2
 
+## The one member of that run `.ComputerMiss` lets past.
+const ACCURACY_DOWN_HIT: int = STAT_DOWN_HIT_BASE + 5
+
 ## `EFFECT_UNUSED_2B`, `EFFECT_DEFROST_OPPONENT` and `EFFECT_PRIORITY_HIT`. The
 ## first two are on no move in either pin and are here because `AI_Smart` has a
 ## handler for each; a mod naming one on its own move reaches them.

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -60,7 +60,6 @@ func set_data(data: GameData) -> void:
 		_refresh()
 
 
-## Selects a project slot by number.
 func select_slot(slot: int) -> bool:
 	if slot < 0 or slot >= Gen2SaveStore.MAX_SLOTS:
 		return false

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -1087,7 +1087,6 @@ func _spawn(object: StringName, at: Vector2i) -> Dictionary:
 	return actor
 
 
-## `ReinitSpriteAnimFrame`: a new frameset, back at its first entry.
 func _reinit_frameset(actor: Dictionary, frameset: StringName) -> void:
 	actor["frameset"] = frameset
 	actor["frame"] = -1

--- a/game/world/link_session.gd
+++ b/game/world/link_session.gd
@@ -170,7 +170,6 @@ func wait_for_other_player_to_exit(transport: Gen2LinkTransport) -> void:
 	reset_serial_registers(transport)
 
 
-## `Link_ResetSerialRegistersAfterLinkClosure`.
 func reset_serial_registers(transport: Gen2LinkTransport) -> void:
 	connection_status = CONNECTION_NOT_ESTABLISHED
 	if transport != null:

--- a/game/world/slot_machine.gd
+++ b/game/world/slot_machine.gd
@@ -245,7 +245,6 @@ static func create(
 	return machine
 
 
-## `Random`, one byte.
 func _random() -> int:
 	return _rng.randi() & 0xFF if _rng != null else 0
 

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -263,7 +263,6 @@ static func grown_level(data: GameData, mon: Gen2SaveMon) -> int:
 	)
 
 
-## `GetPriceToRetrieveBreedmon`.
 static func price_to_retrieve(growth: int) -> int:
 	return RETRIEVE_BASE_PRICE + RETRIEVE_PRICE_PER_LEVEL * maxi(0, growth)
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -153,6 +153,11 @@ const MANIA_OT_NAME: String = "MANIA"
 const SHUCKIE_NICKNAME: String = "SHUCKIE"
 const SHUCKIE_LEVEL: int = 15
 const SHUCKIE_HAPPY_THRESHOLD: int = 150
+
+## `.TrySpreadPokerus`'s two rolls: `cp 33 percent + 1` and `cp 50 percent + 1`,
+## which are 84 + 1 and 127 + 1 under the macro's integer division.
+const POKERUS_SPREAD_ROLL: int = 85
+const POKERUS_FORWARD_ROLL: int = 128
 ## `constants/script_constants.asm`'s own five.
 const SHUCKIE_WRONG_MON: int = 0
 const SHUCKIE_REFUSED: int = 1
@@ -2625,7 +2630,7 @@ static func _give_pokerus(
 static func _try_spread_pokerus(
 	save: Gen2SaveData, carrier: int, random: RandomNumberGenerator
 ) -> Dictionary:
-	if _random_byte(random) >= 85:
+	if _random_byte(random) >= POKERUS_SPREAD_ROLL:
 		return {}
 	var count: int = save.party.size()
 	if count <= 1:
@@ -2633,7 +2638,8 @@ static func _try_spread_pokerus(
 	var strain_source: int = save.party[carrier].pokerus
 	## `ld a, b / cp 2 / jr c`: b is how many party members are left including
 	## the carrier, so a carrier in the last slot can only walk backwards.
-	var forwards: bool = carrier < count - 1 and _random_byte(random) >= 129
+	var forwards: bool = carrier < count - 1 \
+		and _random_byte(random) >= POKERUS_FORWARD_ROLL
 	var step: int = 1 if forwards else -1
 	var index: int = carrier
 	while true:

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -250,6 +250,27 @@ func test_the_female_share_of_the_dv_domain_is_the_ratio_the_species_is_named_fo
 	assert_eq(Gen2BattleMon.gender_for(_data, Fixture.BULBASAUR, 0), &"female")
 
 
+## `CheckOppositeGender` reads the player's own party struct and, for the enemy,
+## `wTempEnemyMonSpecies` with `wEnemyBackupDVs`, so a Transform never moves the
+## answer even though it has overwritten the battle struct's species and DVs.
+func test_gender_reads_the_identity_from_before_a_transform() -> void:
+	var male: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.BULBASAUR, 50, [], Gen2Stats.pack_dvs(15, 0, 15, 0)
+	)
+	var female: Gen2BattleMon = Gen2BattleMon.create(
+		_data, Fixture.BULBASAUR, 50, [], Gen2Stats.pack_dvs(0, 0, 0, 0)
+	)
+	assert_eq(male.gender(), &"male")
+	assert_eq(female.gender(), &"female")
+
+	assert_true(male.transform_into(female))
+	assert_eq(male.dvs, female.dvs, "the battle struct did take the copied DVs")
+	assert_eq(male.gender(), &"male", "and the gender is still the party struct's")
+
+	male.restore_transform()
+	assert_eq(male.gender(), &"male")
+
+
 func test_gender_is_none_for_a_genderless_species() -> void:
 	# Every species this fixture does not name outright reads a gender ratio of
 	# 255, the cartridge's own "genderless" marker.

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -4215,6 +4215,117 @@ func test_beat_up_skips_a_fainted_or_statused_member() -> void:
 		"one member landed a hit, so `beatupfailtext` says nothing")
 
 
+## `CheckHiddenOpponent`, which Attract, Mimic and Transform each spend and which
+## nothing here had: a target part way through Fly or Dig is not there to reach.
+func test_the_three_copying_moves_refuse_a_target_out_of_sight() -> void:
+	for flag: int in [Gen2Substatus.FLYING, Gen2Substatus.UNDERGROUND]:
+		var battle: Gen2Battle = Gen2Battle.create(
+			_data,
+			Gen2BattleMon.create(
+				_data, Fixture.BULBASAUR, 50, [Fixture.ATTRACT_MOVE, Fixture.MIMIC],
+				Gen2Stats.pack_dvs(0, 0, 0, 0)
+			),
+			Gen2BattleMon.create(
+				_data, Fixture.BULBASAUR, 50, [Fixture.TACKLE], Gen2Stats.pack_dvs(15, 0, 15, 0)
+			),
+			_rng
+		)
+		battle.enemy.substatus |= flag
+		battle.enemy.last_counter_move = Fixture.TACKLE
+
+		var attract: Gen2Turn = _turn(battle, Fixture.ATTRACT_MOVE)
+		Gen2EffectCommands.run(Gen2EffectCommands.ATTRACT, attract)
+		assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.ATTRACTED))
+
+		var mimic: Gen2Turn = _turn(battle, Fixture.MIMIC)
+		Gen2EffectCommands.run(Gen2EffectCommands.MIMIC, mimic)
+		assert_false(battle.player.moves.has(Fixture.TACKLE), "nothing was copied")
+
+		var transform: Gen2Turn = _turn(battle, Fixture.TRANSFORM)
+		Gen2EffectCommands.run(Gen2EffectCommands.TRANSFORM, transform)
+		assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.TRANSFORMED))
+
+
+## `BattleCommand_StatDown`'s `.ComputerMiss`: an enemy lowering a player stat
+## fails a quarter of the time, and the player's own drop never rolls.
+func test_an_enemy_stat_drop_misses_a_quarter_of_the_time() -> void:
+	var misses: int = 0
+	for seed_value: int in 200:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed_value
+		var turn: Gen2Turn = _run_enemy_move(battle, Fixture.GROWL)
+		if battle.player.stages.get("attack", 0) == 0:
+			misses += 1
+			assert_false(turn.stat_moved)
+	assert_gt(misses, 20, "a quarter of 200")
+	assert_lt(misses, 80, "and not all of them")
+
+	for seed_value: int in 40:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed_value
+		_run_move(battle, Fixture.GROWL)
+		assert_eq(int(battle.enemy.stages.get("attack", 0)), -1,
+			"the player's own drop never rolls")
+
+
+## Lock-On on the target exempts the drop, the bit sitting on whoever was aimed
+## at rather than on whoever used Lock-On. The command is run on its own because
+## `checkhit` stands in front of it in every stat-down list and `.LockOn` clears
+## the bit as it reads it, so the exemption is unreachable through a whole move.
+func test_lock_on_exempts_an_enemy_stat_drop_from_the_quarter() -> void:
+	for seed_value: int in 40:
+		var battle: Gen2Battle = _battle()
+		battle.rng.seed = seed_value
+		battle.player.substatus |= Gen2Substatus.LOCK_ON
+		var turn: Gen2Turn = Gen2Turn.create(
+			battle, Gen2Battle.ENEMY, 0, Fixture.GROWL, _data.move(Fixture.GROWL), []
+		)
+		Gen2EffectCommands.run(Gen2EffectCommands.ATTACK_DOWN, turn)
+		assert_true(turn.stat_moved, "seed_value %d" % seed_value)
+
+
+## The same gate `CheckHiddenOpponent` puts in front of the write.
+func test_an_enemy_stat_drop_refuses_a_target_out_of_sight() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.substatus |= Gen2Substatus.LOCK_ON | Gen2Substatus.UNDERGROUND
+	_run_enemy_move(battle, Fixture.GROWL)
+	assert_eq(int(battle.player.stages.get("attack", 0)), 0)
+
+
+## `.got_mon`'s `cp [hl]`: the player's side compares `wCurBattleMon` against the
+## member's HP low byte, so a bench member whose HP ends in the active slot's own
+## number is asked for the active Pokemon's status. Slot 0 is out, so HP 256 on
+## the bench member reads Pikachu's byte and swings while paralyzed.
+func test_beat_up_reads_the_active_status_when_the_hp_low_byte_matches() -> void:
+	var battle: Gen2Battle = _beat_up_battle()
+	var party: Gen2Party = battle.party(Gen2Battle.PLAYER)
+	assert_eq(party.active, 0)
+	party.at(1).status = Gen2Status.PARALYSIS
+	party.at(1).hp = 0x100
+	party.at(2).hp = 0x105
+	party.at(2).status = Gen2Status.PARALYSIS
+	var turn: Gen2Turn = _run_move(battle, Fixture.BEAT_UP)
+
+	var swings: Array = _of_type(turn.events, Gen2Battle.BEAT_UP_ATTACK)
+	assert_eq(swings.size(), 2, "slot 2's own byte is read and refuses it")
+	assert_eq(int(swings[0]["index"]), 0)
+	assert_eq(int(swings[1]["index"]), 1, "paralyzed, and asked for slot 0's byte")
+
+
+## The same bench member with the active Pokemon statused: the borrowed byte
+## refuses a member that is perfectly healthy.
+func test_beat_up_refuses_a_healthy_member_when_the_active_one_is_statused() -> void:
+	var battle: Gen2Battle = _beat_up_battle()
+	var party: Gen2Party = battle.party(Gen2Battle.PLAYER)
+	party.at(0).status = Gen2Status.BURN
+	party.at(1).hp = 0x100
+	var turn: Gen2Turn = _run_move(battle, Fixture.BEAT_UP)
+
+	var swings: Array = _of_type(turn.events, Gen2Battle.BEAT_UP_ATTACK)
+	assert_eq(swings.size(), 1, "slot 0 is refused by its own byte, slot 1 by slot 0's")
+	assert_eq(int(swings[0]["index"]), 2)
+
+
 func test_beat_up_says_it_failed_when_no_member_could_swing() -> void:
 	var battle: Gen2Battle = _beat_up_battle()
 	for index: int in 3:

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -947,6 +947,13 @@ func test_the_pokerus_tick_floors_the_days_and_keeps_the_strain() -> void:
 	assert_false(Gen2WorldPartyHost.apply_pokerus_tick(_save, 1), "nothing left to spend")
 
 
+## `.TrySpreadPokerus`'s two `cp`s, both macro results with a byte added: the
+## direction roll is `50 percent + 1`, which is 128 rather than 129.
+func test_the_two_pokerus_spread_rolls_are_the_macro_values() -> void:
+	assert_eq(Gen2WorldPartyHost.POKERUS_SPREAD_ROLL, 33 * 0xFF / 100 + 1)
+	assert_eq(Gen2WorldPartyHost.POKERUS_FORWARD_ROLL, 50 * 0xFF / 100 + 1)
+
+
 ## `.randomPokerusLoop` and `.infectMon`, the two pieces of arithmetic a reading
 ## gets wrong: both durations come off the STRAIN nibble, not off the byte.
 func test_the_two_pokerus_bytes_are_the_source_arithmetic() -> void:

--- a/tools/checks/card_flip.gd
+++ b/tools/checks/card_flip.gd
@@ -230,7 +230,6 @@ func _bet_ready(seed_value: int) -> Gen2CardFlip:
 	return null
 
 
-## The cache against a second reading of the dump: the walk found the records.
 func _verify_section(game_id: StringName, data: GameData) -> void:
 	var rom: RomFile = RomFile.open_verified("res://roms/%s.gbc" % game_id)
 	if not _r.check(rom != null, "%s: roms/%s.gbc is unreadable." % [game_id, game_id]):

--- a/tools/checks/slots.gd
+++ b/tools/checks/slots.gd
@@ -117,7 +117,6 @@ func _verify_reel3_rolls() -> void:
 			return
 
 
-## The cache against a second reading of the dump: the walk found the records.
 func _verify_section(game_id: StringName, data: GameData) -> void:
 	var rom: RomFile = RomFile.open_verified("res://roms/%s.gbc" % game_id)
 	if not _r.check(rom != null, "%s: roms/%s.gbc is unreadable." % [game_id, game_id]):


### PR DESCRIPTION
`CheckHiddenOpponent` is `SUBSTATUS_FLYING | SUBSTATUS_UNDERGROUND` on the target and eight routines spend it. Attract, Mimic, Transform and `BattleCommand_StatDown` did not have it here, so all four reached a target part way through Fly or Dig.

`BattleCommand_StatDown`'s `.ComputerMiss` was not modelled at all: an enemy lowering one of the player's stats fails on `cp 25 percent + 1`, exempting a target carrying `SUBSTATUS_LOCK_ON` and `EFFECT_ACCURACY_DOWN_HIT`. The roll sits behind `.CantLower`, so a stat already at its floor never spends it. The Lock-On arm is unreachable through a whole move: every stat-down list runs `checkhit` first and `.LockOn` clears the bit as it reads it, which is why the test runs the command on its own.

`CheckOppositeGender` reads the player's party struct and, for the enemy, `wTempEnemyMonSpecies` with `wEnemyBackupDVs`, so Attract is settled on the identity each side came into the battle with. `Gen2BattleMon.gender()` read the live battle struct and so moved with a Transform; it reads `persistent_species()` and the new `persistent_dvs()` now. Attract and `AI_Redundant.Attract` are its only callers.

Beat Up's `.got_mon` puts `wCurBattleMon` against the low byte of the member's HP rather than against `c`, its slot, so a bench member whose HP ends in the active slot's own number is asked for `wBattleMonStatus` instead of its own byte. `.enemy_got_mon`'s `cp b` reads the slot and is right.

`.TrySpreadPokerus`'s direction roll is `cp 50 percent + 1`, which is 128 rather than 129. Both of its thresholds are named constants now, pinned against the macro arithmetic.

Ten comment lines that restated the line below them are gone, which is what keeps the total at the recorded ceiling.

| Check | Result |
|---|---|
| GUT unit tier | 3,590 tests, all pass, 8 new |
| `tools/validate.gd -- all` | 84 topics pass, exit 0 |
| Editor analyser | 0 warnings in 614 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | byte-identical to `main` |
| `tools/release.sh --gates` | pass, comments 37,777 of 37,777 |