### PR TITLE
Six defects from a walk of the move effects and the status cures

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1907,8 +1907,9 @@ func _residual_leech_seed(side: int, events: Array) -> void:
 		note_faint(side, events)
 
 
-## Nothing here asks whether the sufferer is still asleep, because waking is what
-## clears the flag.
+## Nothing here asks whether the sufferer is still asleep: `.woke_up`,
+## `BattleCommand_HealBell`, `HealStatus` and `UseHeldStatusHealingItem` each clear
+## the flag. `AI_HealStatus` is the one that does not, a pret-recorded bug.
 func _residual_nightmare(side: int, events: Array) -> void:
 	var current: Gen2BattleMon = mon(side)
 	if not Gen2Substatus.has(current.substatus, Gen2Substatus.NIGHTMARE):
@@ -2173,10 +2174,11 @@ func use_status_berry(side: int, events: Array) -> bool:
 	if not Gen2HeldItem.heals_status(_held_effect(holder), holder.status):
 		return false
 
-	# The status byte alone: `UseHeldStatusHealingItem` never touches
-	# `SUBSTATUS_TOXIC`, so a cured Pokémon keeps the flag that ramps its next
-	# poison, and [member Gen2BattleMon.toxic_counter] is that flag.
+	# `UseHeldStatusHealingItem` follows the cleared byte with `res
+	# SUBSTATUS_TOXIC` and `res SUBSTATUS_NIGHTMARE`, both of which it was holding.
 	holder.status = Gen2Status.NONE
+	holder.toxic_counter = 0
+	holder.substatus &= ~Gen2Substatus.NIGHTMARE
 	var used: int = holder.item
 	holder.item = 0
 	events.append({"type": RECOVERED_USING_ITEM, "side": side, "item": used})
@@ -2466,6 +2468,8 @@ func _apply_party_item(
 	if cured != 0:
 		target.status = Gen2Status.NONE
 		target.toxic_counter = 0
+		if active: # `HealStatus` runs behind `IsItemUsedOnBattleMon`.
+			target.substatus &= ~Gen2Substatus.NIGHTMARE
 	var unconfused: bool = mask == 0xFF and active \
 		and Gen2Substatus.has(target.substatus, Gen2Substatus.CONFUSED)
 	if unconfused:

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -683,6 +683,13 @@ func replace_move(slot: int, move: int) -> bool:
 		return false
 	moves[slot] = move
 	pp[slot] = int(data.move(move).get("pp", 0))
+	# `BattleCommand_Sketch` writes the party struct with no transform test.
+	if not transform_original.is_empty():
+		var backup_moves: Array = transform_original["moves"]
+		var backup_pp: Array = transform_original["pp"]
+		if slot < backup_moves.size():
+			backup_moves[slot] = move
+			backup_pp[slot] = pp[slot]
 	return true
 
 

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -59,7 +59,6 @@ const FALSE_SWIPE: StringName = &"falseswipe"
 ## lists carry no `stab`. A fixed number has no effectiveness to announce.
 const RESET_TYPE_MATCHUP: StringName = &"resettypematchup"
 
-## Heal Bell, which clears the status of every Pokémon in the user's party.
 const HEAL_BELL: StringName = &"healbell"
 
 ## Snore, which fails unless its user is asleep.
@@ -360,7 +359,6 @@ const FORCE_SWITCH: StringName = &"forceswitch"
 ## Baton Pass, which switches the side that used it and hands everything over.
 const BATON_PASS: StringName = &"batonpass"
 
-## Teleport, which takes its own user out of a wild battle and ends it as a draw.
 const TELEPORT: StringName = &"teleport"
 
 ## Foresight and Lock On, the two flags one side leaves on the other for the
@@ -369,16 +367,12 @@ const TELEPORT: StringName = &"teleport"
 const FORESIGHT: StringName = &"foresight"
 const LOCK_ON: StringName = &"lockon"
 
-## Spite, which takes two to five PP off the slot holding the target's last move.
 const SPITE: StringName = &"spite"
 
-## Pain Split, which writes the average of the two Pokémon's health into both.
 const PAIN_SPLIT: StringName = &"painsplit"
 
-## Thief, which moves the target's held item onto a thief carrying none.
 const THIEF: StringName = &"thief"
 
-## Pursuit, which doubles the finished figure against a side that is leaving.
 const PURSUIT: StringName = &"pursuit"
 
 ## Beat Up: one pass of its loop, and the line behind the loop that says nothing
@@ -1093,14 +1087,15 @@ static func _reset_type_matchup(turn: Gen2Turn) -> void:
 ## the one on the field included. The source zeroes all six bytes whether or not a
 ## slot holds anything, so a shorter party is the same thing. Its trailing
 ## `CalcPlayerStats` has no counterpart, a burn and a paralysis being applied when
-## a stat is read ([method Gen2BattleMon.stat]), and its `res SUBSTATUS_NIGHTMARE`
-## none either, no move here giving one.
+## a stat is read ([method Gen2BattleMon.stat]). Its opening `res
+## SUBSTATUS_NIGHTMARE` is the ringer's own, reached through Sleep Talk.
 static func _heal_bell(turn: Gen2Turn) -> void:
 	for mon: Gen2BattleMon in turn.battle.party(turn.side).mons:
 		if mon == null:
 			continue
 		mon.status = Gen2Status.NONE
 		mon.toxic_counter = 0
+	turn.attacker().substatus &= ~Gen2Substatus.NIGHTMARE
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.BELL_CHIMED)
 
@@ -1183,7 +1178,7 @@ static func _mirror_move(turn: Gen2Turn) -> void:
 static func _mimic(turn: Gen2Turn) -> void:
 	_clear_last_move_for_call(turn)
 	var copied: int = turn.defender().last_counter_move
-	var slot: int = turn.attacker().moves.find(Gen2MoveEffect.MIMIC_MOVE)
+	var slot: int = _last_slot_holding(turn.attacker(), Gen2MoveEffect.MIMIC_MOVE)
 	if _is_hidden(turn.defender().substatus) \
 		or copied == 0 or copied == Gen2Damage.STRUGGLE or slot < 0 \
 		or turn.attacker().moves.has(copied) or turn.data().move(copied).is_empty():
@@ -1194,6 +1189,12 @@ static func _mimic(turn: Gen2Turn) -> void:
 		return
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.MIMIC_LEARNED, {"move": copied, "slot": slot})
+
+
+## `.find_sketch` and `.find_mimic` walk backwards, so a Smeargle carrying four
+## SKETCHes spends the fourth.
+static func _last_slot_holding(mon: Gen2BattleMon, move_number: int) -> int:
+	return mon.moves.rfind(move_number)
 
 
 ## `BattleCommand_Metronome`: byte rejection over the 251 moves, then the
@@ -1257,13 +1258,16 @@ static func _sleep_talk(turn: Gen2Turn) -> void:
 	_fail_called_move(turn)
 
 
-## `BattleCommand_Sketch`: Mimic's validation plus the target's Substitute
-## refusal, then a permanent replacement carrying the copied move's base PP.
+## `BattleCommand_Sketch`: Mimic's validation plus a doll and a `SUBSTATUS5_OPP`
+## transform on the target, then a permanent replacement at the copy's base PP. A
+## transformed *user* is allowed, which is `docs/bugs_and_glitches.md`'s entry.
 static func _sketch(turn: Gen2Turn) -> void:
 	_clear_last_move_for_call(turn)
 	var copied: int = turn.defender().last_counter_move
-	var slot: int = turn.attacker().moves.find(Gen2MoveEffect.SKETCH_MOVE)
-	if _substitute_refuses(turn) or copied == 0 or copied == Gen2Damage.STRUGGLE \
+	var slot: int = _last_slot_holding(turn.attacker(), Gen2MoveEffect.SKETCH_MOVE)
+	if _substitute_refuses(turn) \
+		or Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.TRANSFORMED) \
+		or copied == 0 or copied == Gen2Damage.STRUGGLE \
 		or slot < 0 or turn.attacker().moves.has(copied) \
 		or turn.data().move(copied).is_empty():
 		_fail_called_move(turn)
@@ -1766,6 +1770,9 @@ static func _check_status(turn: Gen2Turn) -> void:
 				turn.end()
 				return
 		else:
+			# `.woke_up` clears `SUBSTATUS_NIGHTMARE`, which has no gate of its
+			# own: left standing it costs an awake Pokemon a quarter a turn.
+			mon.substatus &= ~Gen2Substatus.NIGHTMARE
 			turn.emit(Gen2Battle.WOKE_UP)
 
 	if Gen2Status.has(mon.status, Gen2Status.FREEZE):

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -737,6 +737,21 @@ func test_waking_up_does_not_cost_the_turn() -> void:
 	assert_eq(battle.player.status, Gen2Status.NONE)
 
 
+## `.woke_up` ends with `res SUBSTATUS_NIGHTMARE, [hl]`. Without it the quarter
+## keeps being taken off a Pokemon that is awake, every turn, until it switches.
+func test_waking_up_ends_the_nightmare() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.status = 1
+	battle.player.substatus |= Gen2Substatus.NIGHTMARE
+	var events: Array = battle.take_turn(0, 0)
+	assert_eq(_of_type(events, Gen2Battle.WOKE_UP).size(), 1)
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.NIGHTMARE))
+	assert_eq(_of_type(events, Gen2Battle.HURT_BY_NIGHTMARE).size(), 0)
+
+
 func test_a_frozen_pokemon_does_not_move() -> void:
 	var battle: Gen2Battle = _battle(
 		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
@@ -2693,6 +2708,25 @@ func test_a_status_berry_answers_the_moment_the_status_lands() -> void:
 	)
 	# And the enemy still got its move: the berry costs nothing.
 	assert_eq(_of_type(events, Gen2Battle.USED_MOVE).size(), 2)
+
+
+## `UseHeldStatusHealingItem` follows the cleared byte with `res SUBSTATUS_TOXIC`
+## and `res SUBSTATUS_NIGHTMARE`, both of which the byte was carrying.
+func test_a_status_berry_takes_the_toxic_ramp_and_the_nightmare_with_it() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.GROWL]),
+		_mon(Fixture.CHARMANDER, 50, [Fixture.GROWL])
+	)
+	var holder: Gen2BattleMon = battle.mon(Gen2Battle.ENEMY)
+	holder.item = Fixture.MIRACLEBERRY
+	holder.status = Gen2Status.POISON
+	holder.toxic_counter = 4
+	holder.substatus |= Gen2Substatus.NIGHTMARE
+
+	battle.take_actions(Gen2Battle.use_move(0), Gen2Battle.use_move(0))
+	assert_eq(holder.status, Gen2Status.NONE)
+	assert_eq(holder.toxic_counter, 0)
+	assert_false(Gen2Substatus.has(holder.substatus, Gen2Substatus.NIGHTMARE))
 
 
 ## A berry that answers for one status says nothing about another.

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -2386,6 +2386,20 @@ func test_heal_bell_clears_the_toxic_ramp_with_the_poison() -> void:
 	assert_eq(battle.player.toxic_counter, 0)
 
 
+## `res SUBSTATUS_NIGHTMARE, [hl]` opens the routine, on the ringer's own
+## substatus. Sleep Talk is the way in: a Pokemon having a nightmare is asleep.
+func test_heal_bell_clears_the_ringers_nightmare() -> void:
+	var battle: Gen2Battle = _party_battle()
+	battle.player.status = 3
+	battle.player.substatus |= Gen2Substatus.NIGHTMARE
+	# Rung through Sleep Talk, so the command is run where a sleeping user
+	# reaches it rather than through the turn that would refuse the move.
+	var turn: Gen2Turn = _turn(battle, Fixture.HEAL_BELL)
+	Gen2EffectCommands.run(Gen2EffectCommands.HEAL_BELL, turn)
+	assert_eq(battle.player.status, Gen2Status.NONE)
+	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.NIGHTMARE))
+
+
 func test_snore_fails_awake_and_lands_asleep() -> void:
 	var awake: Gen2Battle = _battle()
 	var awake_turn: Gen2Turn = _run_move(awake, Fixture.SNORE)
@@ -4530,6 +4544,33 @@ func test_sketch_is_refused_by_the_targets_substitute() -> void:
 	battle.player.pp = [1]
 	battle.enemy.last_counter_move = Fixture.TACKLE
 	battle.enemy.substatus = Gen2Substatus.SUBSTITUTE
+	var turn: Gen2Turn = _turn(battle, Fixture.SKETCH)
+	Gen2EffectCommands.run(Gen2EffectCommands.SKETCH, turn)
+	assert_eq(battle.player.moves[0], Fixture.SKETCH)
+	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
+
+
+## `.find_sketch` and `.find_mimic` walk the slots backwards, so a Smeargle
+## carrying four SKETCHes spends the fourth and keeps the first three.
+func test_sketch_replaces_the_last_sketch_slot() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.moves = [Fixture.SKETCH, Fixture.SKETCH]
+	battle.player.pp = [1, 1]
+	battle.enemy.last_counter_move = Fixture.TACKLE
+	var turn: Gen2Turn = _turn(battle, Fixture.SKETCH)
+	Gen2EffectCommands.run(Gen2EffectCommands.SKETCH, turn)
+	assert_eq(battle.player.moves[0], Fixture.SKETCH)
+	assert_eq(battle.player.moves[1], Fixture.TACKLE)
+
+
+## `bit SUBSTATUS_TRANSFORMED, [hl]` on `SUBSTATUS5_OPP`: the copy is refused,
+## not the copier.
+func test_sketch_is_refused_by_a_transformed_target() -> void:
+	var battle: Gen2Battle = _battle()
+	battle.player.moves = [Fixture.SKETCH]
+	battle.player.pp = [1]
+	battle.enemy.last_counter_move = Fixture.TACKLE
+	battle.enemy.substatus = Gen2Substatus.TRANSFORMED
 	var turn: Gen2Turn = _turn(battle, Fixture.SKETCH)
 	Gen2EffectCommands.run(Gen2EffectCommands.SKETCH, turn)
 	assert_eq(battle.player.moves[0], Fixture.SKETCH)


### PR DESCRIPTION
Standing programme: read `engine/battle/move_effects/` whole (the last 39 unwalked files), plus nine `engine/events/` files and eleven overworld, party and trainer ones. Six defects, three of them one seam.

## Fixed

Every way out of a sleep or a status byte clears `SUBSTATUS_NIGHTMARE` behind it, and the two item paths clear `SUBSTATUS_TOXIC` as well. Three paths here cleared neither: `CheckPlayerTurn`'s `.woke_up`, `UseHeldStatusHealingItem`'s held berry, and `HealStatus` under a bag item on the Pokemon that is out. A nightmare survived every cure and went on taking a quarter of the maximum a turn off an awake Pokemon until it switched. `BattleCommand_HealBell` opens `res SUBSTATUS_NIGHTMARE, [hl]` on the ringer's own substatus, reached through Sleep Talk, and that was missing too. `AI_HealStatus` really does leave the flag standing and is unchanged.

`.find_sketch` and `.find_mimic` walk the four slots backwards with `ld a, [hld]`, so the last slot holding the move is the one replaced. Both handlers took the first. Smeargle relearns SKETCH every ten levels and can carry four.

`BattleCommand_Sketch` refuses a target carrying `SUBSTATUS_TRANSFORMED` (`SUBSTATUS5_OPP`), and had no such check.

`BattleCommand_Sketch` writes the battle struct and then the party struct through `UserPartyAttr`, with no transform test between them, so a transformed user keeps the sketched move once the copy is dropped. `Gen2BattleMon.replace_move` writes the backup too now.

## Verified

Unit tier 3595 tests, 68630 asserts, green, five new cases. `validate.gd -- all` green on all three cartridges. Warning scan: 0 warnings in 614 scripts. Release gates pass, comment total unchanged at the ceiling.