### PR TITLE
Three defects from a walk of the battle loop, badges and the quantity dial

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -165,6 +165,9 @@ const RECOVERED_WITH_ITEM: StringName = &"recovered_with_item"
 const RECOVERED_USING_ITEM: StringName = &"recovered_using_item"
 const RESTORED_PP: StringName = &"restored_pp"
 const ITEM_HEALED_CONFUSION: StringName = &"item_healed_confusion"
+## `BattleText_UsersStringBuffer1Activated`, the line a held item says when it
+## works on its own holder. Only the Berserk Gene reaches it with cartridge data.
+const ITEM_ACTIVATED: StringName = &"item_activated"
 
 ## `HungOnText`: a Focus Band held the Pokémon on one hit point. The line names
 ## the item, which is why [code]item[/code] is on it. Endure's own line is
@@ -424,6 +427,11 @@ const PP_ITEM_AMOUNTS: Dictionary = {
 	ITEM_ETHER: 10, ITEM_ELIXER: 10, ITEM_MYSTERYBERRY: 5,
 	ITEM_MAX_ETHER: 0, ITEM_MAX_ELIXER: 0,
 }
+
+## `HandleBerserkGene`'s `BattleCommand_AttackUp2`, and the count it never
+## writes: a zero byte decremented once is 255 more turns after this one.
+const BERSERK_GENE_STAGES: int = 2
+const BERSERK_GENE_CONFUSION_TURNS: int = 256
 
 ## `wBattleType`. Only the values `TryToRunAwayFromBattle` branches on are named;
 ## everything else reaches the ordinary speed check.
@@ -1582,6 +1590,9 @@ func take_actions(player_action: Dictionary, enemy_action: Dictionary) -> Array:
 	if _pending_baton_pass >= 0 or _pending_switch_offer >= 0:
 		return events
 
+	# In front of `BattleMenu`, so it is paid before the refusal below too.
+	_handle_berserk_gene(events)
+
 	# Settled before anything is spent, because `TryPlayerSwitch` runs at menu
 	# time: the refusal jumps back to `BattleMenuPKMN_Loop` with no turn taken.
 	if _is_switch(player_action) and switch_blocked():
@@ -2048,6 +2059,47 @@ func _tick_held_items(events: Array) -> void:
 		use_hp_berry(side, events)
 		use_status_berry(side, events)
 		use_confusion_berry(side, events)
+
+
+## `HandleBerserkGene`, at the top of the loop and before either side has chosen:
+## the holder spends the Gene, is confused, and takes `BattleCommand_AttackUp2`'s
+## two stages. A Pokemon put out mid-turn waits for the next one. No count is
+## written, so the confusion runs on the byte [method Gen2Party.send_out] carried
+## over, and a zero one wraps to 256 (`docs/bugs_and_glitches.md`).
+func _handle_berserk_gene(events: Array) -> void:
+	for side: int in [PLAYER, ENEMY]:
+		var holder: Gen2BattleMon = mon(side)
+		if holder == null or holder.item != Gen2HeldItem.BERSERK_GENE_ITEM:
+			continue
+		var used: int = holder.item
+		holder.item = 0
+		var was_confused: bool = Gen2Substatus.has(
+			holder.substatus, Gen2Substatus.CONFUSED
+		)
+		holder.substatus |= Gen2Substatus.CONFUSED
+		if holder.confusion_turns <= 0:
+			holder.confusion_turns = BERSERK_GENE_CONFUSION_TURNS
+		var by: int = mini(BERSERK_GENE_STAGES, Gen2Stats.MAX_STAGE - holder.stage("attack"))
+		if by > 0:
+			holder.change_stage("attack", by)
+		events.append({"type": ITEM_ACTIVATED, "side": side, "item": used})
+		events.append({
+			"type": STAT_CHANGED if by > 0 else STAT_CHANGE_FAILED,
+			"target": side, "stat": "attack",
+			"by": by if by > 0 else BERSERK_GENE_STAGES,
+		})
+		if was_confused:
+			continue
+		events.append({
+			"type": ANIMATION,
+			"index": Gen2BattleAnimPlayer.ANIM_CONFUSED,
+			"param": battle_anim_param,
+			"after_anim": Gen2BattleAnimPlayer.AFTER_ANIM_NONE,
+			"enemy_turn": side == ENEMY,
+			"effectiveness": RomLayout.MATCHUP_EFFECTIVE,
+			"restore_user_pic": false,
+		})
+		events.append({"type": CONFUSE_INFLICTED, "target": side})
 
 
 ## `HandleDefrost`: each frozen side thaws on its own roll, the only thing making

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -5336,6 +5336,7 @@ const LINES: Dictionary = {
 		&"item:item",
 		&"name:side",
 	],
+	Gen2Battle.ITEM_ACTIVATED: ["%s's %s activated!", &"name:side", &"item:item"],
 	Gen2Battle.ENDURED: ["%s hung on with %s!", &"name:target", &"item:item"],
 	Gen2Battle.PROTECTED_ITSELF: ["%s PROTECTED itself!", &"name:side"],
 	Gen2Battle.PROTECTING_ITSELF: ["%s's PROTECTING itself!", &"name:target"],

--- a/game/battle/held_item.gd
+++ b/game/battle/held_item.gd
@@ -99,6 +99,9 @@ const PIKACHU: int = 25
 const METAL_POWDER_ITEM: int = 35
 const DITTO: int = 132
 
+## `HandleBerserkGene`'s `sub BERSERK_GENE`; its held effect is HELD_NONE.
+const BERSERK_GENE_ITEM: int = 0x98
+
 ## `MailItems` (data/items/mail_items.asm). Pinned rather than read from
 ## [GameData] because the battle engine takes no cache; the table is imported
 ## beside it and `tools/checks/mail.gd` holds the two together on all three

--- a/game/battle/party.gd
+++ b/game/battle/party.gd
@@ -97,8 +97,13 @@ func send_out(index: int) -> bool:
 		return false
 
 	var leaving: Gen2BattleMon = active_mon()
+	## `wPlayerConfuseCount` is written by confusing moves and cleared by no
+	## entrance, so `HandleBerserkGene` reads the byte the last Pokemon left.
+	var confuse_count: int = leaving.confusion_turns if leaving != null else 0
 	if leaving != null:
 		leaving.reset_stages()
 		leaving.reset_volatile()
 	active = index
+	if active_mon() != null:
+		active_mon().confusion_turns = confuse_count
 	return true

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -2019,9 +2019,8 @@ func intro_palette(name: String) -> PackedColorArray:
 	return colors
 
 
-## Whether the cache carries `_UnownPuzzle`'s art, which is the whole of what
-## the screen needs: a cartridge with no pin answers false and the special
-## refuses rather than opening an empty board.
+## Whether the cache carries `_UnownPuzzle`'s art. False refuses the special
+## rather than opening an empty board.
 func has_unown_puzzle() -> bool:
 	return not (_unown_puzzle.get("palette", []) as Array).is_empty()
 
@@ -2133,9 +2132,8 @@ func printer_status_string(name: String) -> String:
 	return String(_printer_strings.get(name, ""))
 
 
-## Whether the cache carries `_SlotMachine`'s art, which is the whole of what
-## the screen needs: a cartridge with no pin answers false and the special
-## refuses rather than opening an empty machine.
+## Whether the cache carries `_SlotMachine`'s art. False refuses the special
+## rather than opening an empty machine.
 func has_slots() -> bool:
 	return not (_slots.get("palettes", []) as Array).is_empty()
 

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -349,8 +349,7 @@ func selected_world_renderer() -> StringName:
 	return _selected_view if _world_renderers.has(_selected_view) else BUILT_IN_RENDERER
 
 
-## A fresh renderer node for the selected world renderer, falling back to the
-## built-in one so a screen always has something to draw with.
+## A fresh node for the selected world renderer, or the built-in one.
 func create_world_renderer() -> Node:
 	return _create(_world_renderers, selected_world_renderer(), Gen2WorldRenderer)
 
@@ -984,8 +983,7 @@ func selected_battle_renderer() -> StringName:
 	return _selected_view if _battle_renderers.has(_selected_view) else BUILT_IN_RENDERER
 
 
-## A fresh renderer node for the selected battle renderer, falling back to the
-## built-in one so a screen always has something to draw with.
+## A fresh node for the selected battle renderer, or the built-in one.
 func create_battle_renderer() -> Node:
 	return _create(_battle_renderers, selected_battle_renderer(), Gen2BattleRenderer)
 

--- a/game/mods/mod_options.gd
+++ b/game/mods/mod_options.gd
@@ -68,8 +68,7 @@ static func snapshot(ids: Array) -> Dictionary:
 	return out
 
 
-## Returns false only when the change could not be written, in which case the
-## in-memory value is rolled back so it never disagrees with the file.
+## False only when the write failed, which rolls the in-memory value back.
 ##
 ## A bound run takes the write instead of the file: the value belongs to the slot
 ## being played, and writing it installation-wide would change every other slot

--- a/game/mods/mod_state.gd
+++ b/game/mods/mod_state.gd
@@ -26,8 +26,7 @@ static func selected_view() -> StringName:
 	return _view
 
 
-## Returns false only when the change could not be written, in which case the
-## in-memory value is rolled back so it never disagrees with the file.
+## False only when the write failed, which rolls the in-memory value back.
 static func set_selected_view(id: StringName) -> bool:
 	_ensure_loaded()
 	if String(id).is_empty():

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -304,10 +304,8 @@ func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 	return out
 
 
-## The BG map, sampled through `hSCX` and the scanline's own `hSCY`. Both are
-## bytes and the map is 256 pixels square, so the sampling wraps rather than
-## clipping. Returns each pixel's own colour index, which is what an `OAM_PRIO`
-## sprite is drawn against.
+## The BG map through `hSCX` and the scanline's `hSCY`, wrapping at 256 the way
+## [method Gen2IntroMoviePage._draw_background] does, and each pixel's index out.
 func _draw_background(
 	pixels: PackedInt32Array, movie: Gen2GoldSilverIntro
 ) -> PackedByteArray:

--- a/game/world/gold_silver_intro.gd
+++ b/game/world/gold_silver_intro.gd
@@ -135,12 +135,8 @@ const FRAMESET_RESTART: StringName = &"restart"
 const FLIP_X: int = 1
 
 const SHADOW_OAM_SPRITES: int = 40
-## How many of those each OAM set takes, which is the `db` count each
-## `.OAMData_*` opens with. The geometry is [Gen2GoldSilverIntroPage]'s; only the
-## count belongs here, because a full buffer stops the sprite pass:
-## `UpdateAnimFrame` returns carry at `wShadowOAMEnd` and
-## `DoNextFrameForAllSprites` answers it with `jr c, .done`, so every struct in a
-## later slot loses its own sequence for that frame as well as its picture.
+## Each `.OAMData_*`'s own `db` count, kept for the reason
+## [constant Gen2IntroMovie.OAM_SET_SIZES] gives.
 const OAM_SET_SIZES: Array[int] = [
 	1, 1, 4, 4, 6, 6, 27, 27, 29, 2, 1, 16, 16, 16, 16, 16, 16, 16, 5, 5, 5, 4,
 	16, 36, 25, 25, 25,
@@ -218,8 +214,7 @@ var _scx: int = 0
 var _scy: int = 0
 var _global_x: int = 0
 var _global_y: int = 0
-## `wLYOverrides` under `hLCDCPointer` = LOW(rSCY): one `hSCY` per scanline. Off
-## when [member _ly_active] is false, which is `hLCDCPointer` zero.
+## `wLYOverrides` under `hLCDCPointer` = LOW(rSCY): one `hSCY` per scanline.
 var _ly: PackedByteArray = PackedByteArray()
 var _ly_active: bool = false
 ## `wLYOverrides2`, the sine the overrides are built from.
@@ -317,11 +312,7 @@ func scroll() -> Vector2i:
 	return Vector2i(_scx, _scy)
 
 
-## The `hSCY` for one scanline, which is `wLYOverrides` while `hLCDCPointer`
-## points at rSCY and plain `hSCY` otherwise. `LCD` fires on `STAT_MODE_0` and
-## writes the entry `rLY` names, so the line after it is the one drawn with it;
-## `VBlank_Cutscene` writes entry zero, which is why the first two lines share
-## it.
+## [method Gen2IntroMovie.scroll_x_at] over rSCY: the same scanline-late read.
 func scroll_y_at(line: int) -> int:
 	if not _ly_active or line < 0 or line >= _ly.size():
 		return _scy
@@ -869,8 +860,7 @@ func _set_palettes(background: PackedInt32Array, objects: PackedInt32Array) -> v
 		_ob_palettes[index] = objects[index]
 
 
-## The cache holds a palette as colours; the reordering above works on the
-## cartridge's packed 15-bit values, so they are read back as those.
+## Read back as the packed 15-bit values the reordering above works on.
 func _packed(name: String) -> PackedInt32Array:
 	var out := PackedInt32Array()
 	if _data == null:
@@ -1401,8 +1391,7 @@ func _actor_frame(actor: Dictionary) -> Array:
 	return frames[at]
 
 
-## `AnimSeqs_Sine`: a = d * sin(a * pi/32), read out of `BattleAnimSineWave`
-## rather than derived, and zero without one.
+## `AnimSeqs_Sine`, out of `BattleAnimSineWave` and zero without one.
 func _sine_at(angle: int, amplitude: int) -> int:
 	if _sine == null:
 		return 0

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -91,9 +91,12 @@ static func prepare(
 
 	if enemy_party == null or enemy_party.is_wiped():
 		return _failure(&"missing_enemy_party")
+	## `BadgeStatBoosts` and `DoBadgeTypeBoosts` both `ret nz` on `wLinkMode` and
+	## on `wInBattleTowerBattle`: no badge bonus outside a single-player fight.
+	var badges: int = 0 if kind in [&"battle_tower", &"link_battle"] else player_badges
 	var battle: Gen2Battle = Gen2Battle.create_parties(
 		data, player_party, enemy_party, generator,
-		kind in [&"trainer", &"battle_tower", &"link_battle"], player_badges, battle_rules
+		kind in [&"trainer", &"battle_tower", &"link_battle"], badges, battle_rules
 	)
 	if battle == null:
 		return _failure(&"battle_setup_failed")

--- a/game/world/world_quantity_prompt.gd
+++ b/game/world/world_quantity_prompt.gd
@@ -29,6 +29,15 @@ static func open(available: int) -> Gen2WorldQuantityPrompt:
 	return prompt
 
 
+## The same dial for a caller that keeps the number itself: the mart's box and
+## the item PC's row are `Toss_Sell_Loop` over their own headers.
+static func stepped(shown: int, button: int, available: int) -> int:
+	var prompt: Gen2WorldQuantityPrompt = open(available)
+	prompt.value = clampi(shown, 1, prompt.maximum)
+	prompt.press(button)
+	return prompt.value
+
+
 func press(button: int) -> StringName:
 	match button:
 		Gen2Button.A:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -837,14 +837,10 @@ func _move_mart_cursor(delta: int) -> void:
 func _press_mart_quantity(button: int) -> void:
 	var maximum: int = Gen2WorldMartHost.MAX_ITEM_STACK
 	match button:
-		Gen2Button.UP:
-			_mart_quantity = 1 if _mart_quantity >= maximum else _mart_quantity + 1
-		Gen2Button.DOWN:
-			_mart_quantity = maximum if _mart_quantity <= 1 else _mart_quantity - 1
-		Gen2Button.RIGHT:
-			_mart_quantity = mini(_mart_quantity + 10, maximum)
-		Gen2Button.LEFT:
-			_mart_quantity = maxi(_mart_quantity - 10, 1)
+		Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT:
+			_mart_quantity = Gen2WorldQuantityPrompt.stepped(
+				_mart_quantity, button, maximum
+			)
 		Gen2Button.B:
 			_mart_stage = MART_LIST
 		Gen2Button.A:
@@ -1017,14 +1013,10 @@ func _press_mart_sell_list(button: int) -> void:
 func _press_mart_sell_quantity(button: int) -> void:
 	var maximum: int = maxi(1, int(_mart_selection().get("quantity", 1)))
 	match button:
-		Gen2Button.UP:
-			_mart_quantity = 1 if _mart_quantity >= maximum else _mart_quantity + 1
-		Gen2Button.DOWN:
-			_mart_quantity = maximum if _mart_quantity <= 1 else _mart_quantity - 1
-		Gen2Button.RIGHT:
-			_mart_quantity = mini(_mart_quantity + 10, maximum)
-		Gen2Button.LEFT:
-			_mart_quantity = maxi(_mart_quantity - 10, 1)
+		Gen2Button.UP, Gen2Button.DOWN, Gen2Button.LEFT, Gen2Button.RIGHT:
+			_mart_quantity = Gen2WorldQuantityPrompt.stepped(
+				_mart_quantity, button, maximum
+			)
 		Gen2Button.B:
 			_mart_stage = MART_SELL
 		Gen2Button.A:
@@ -1631,11 +1623,14 @@ func _filled(text: String, applied: Dictionary) -> String:
 	)
 
 
+## `SelectQuantityToToss`' dial: one either way, and zero wraps to the stack.
 func _change_pc_quantity(step: int) -> void:
 	if _cursor < 0 or _cursor >= _pc_entries.size():
 		return
 	var owned: int = int(_pc_entries[_cursor].get("quantity", 1))
-	_pc_quantity = clampi(_pc_quantity + step, 1, maxi(1, owned))
+	_pc_quantity = Gen2WorldQuantityPrompt.stepped(
+		_pc_quantity, Gen2Button.UP if step > 0 else Gen2Button.DOWN, owned
+	)
 	_render_rows()
 
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -751,9 +751,8 @@ func restore_from_dict(raw: Variant) -> void:
 	changed.emit()
 
 
-## The live Battle Tower record, which callers edit in place: every write to it
-## is a write to SRAM the cartridge would have made straight away, and there is
-## no transaction between the receptionist and the section.
+## The live Battle Tower record, edited in place: every write is one the
+## cartridge would have made to SRAM straight away.
 func battle_tower() -> Gen2BattleTower:
 	return _battle_tower
 

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -1149,7 +1149,7 @@ func test_hyper_beam_locks_the_user_out_the_turn_after_it_connects() -> void:
 	assert_false(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.RECHARGING))
 
 
-func test_switching_out_clears_confusion_and_recharge() -> void:
+func test_switching_out_clears_confusion_and_keeps_its_count() -> void:
 	var battle: Gen2Battle = _party_battle(
 		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])],
 		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
@@ -1159,7 +1159,7 @@ func test_switching_out_clears_confusion_and_recharge() -> void:
 	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
 	var bulbasaur: Gen2BattleMon = battle.player
 	assert_eq(bulbasaur.substatus, Gen2Substatus.NONE)
-	assert_eq(bulbasaur.confusion_turns, 0)
+	assert_eq(bulbasaur.confusion_turns, 4)
 
 
 func test_a_two_turn_move_charges_then_hits_on_the_next() -> void:
@@ -4637,3 +4637,35 @@ func test_a_faint_taken_in_a_turn_costs_happiness() -> void:
 		battle.player.happiness,
 		Gen2WorldPartyHost.change_happiness(_data, before, Gen2Battle.HAPPINESS_FAINTED)
 	)
+
+
+func test_a_berserk_gene_holder_is_confused_and_gains_two_attack_stages() -> void:
+	var battle: Gen2Battle = _battle(
+		_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]),
+		_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	)
+	battle.player.item = Gen2HeldItem.BERSERK_GENE_ITEM
+	var events: Array = battle.take_turn(0, 0)
+	var activated: Dictionary = _first(events, Gen2Battle.ITEM_ACTIVATED)
+	assert_eq(int(activated.get("side", -1)), Gen2Battle.PLAYER)
+	assert_eq(int(activated.get("item", 0)), Gen2HeldItem.BERSERK_GENE_ITEM)
+	assert_eq(battle.player.item, 0)
+	assert_eq(battle.player.stage("attack"), 2)
+	assert_true(Gen2Substatus.has(battle.player.substatus, Gen2Substatus.CONFUSED))
+	# One short of the 256 it was set to: the turn it fired on has already
+	# checked the confusion and spent one.
+	assert_eq(battle.player.confusion_turns, Gen2Battle.BERSERK_GENE_CONFUSION_TURNS - 1)
+	assert_eq(int(_first(events, Gen2Battle.CONFUSE_INFLICTED).get("target", -1)), Gen2Battle.PLAYER)
+
+
+func test_a_berserk_gene_runs_on_the_confusion_count_the_last_pokemon_left() -> void:
+	var battle: Gen2Battle = _party_battle(
+		[_mon(Fixture.PIKACHU, 50, [Fixture.TACKLE]), _mon(Fixture.BULBASAUR, 50, [Fixture.TACKLE])],
+		[_mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])]
+	)
+	battle.player.substatus |= Gen2Substatus.CONFUSED
+	battle.player.confusion_turns = 3
+	battle.party(Gen2Battle.PLAYER).at(1).item = Gen2HeldItem.BERSERK_GENE_ITEM
+	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
+	battle.take_turn(0, 0)
+	assert_eq(battle.player.confusion_turns, 2)

--- a/tests/unit/test_link.gd
+++ b/tests/unit/test_link.gd
@@ -288,6 +288,24 @@ func test_a_link_battle_writes_the_record_it_produced() -> void:
 	assert_eq(int(save.link_record["wins"]), 1)
 
 
+## `BadgeStatBoosts` and `DoBadgeTypeBoosts` both `ret nz` on `wLinkMode`, so a
+## link partner meets an unboosted party however many badges the player has.
+func test_a_link_battle_pays_no_badge_boost() -> void:
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data,
+		{"values": {
+			"kind": &"link_battle", "trainer_name": "BLUE",
+			"enemy_party": [_mon(SPECIES_TWO).to_dict()],
+		}},
+		Gen2WorldBattleAdapter.fallback_party(_data, SPECIES_ONE, 5, 1),
+		RandomNumberGenerator.new(), 0xFFFF
+	)
+	assert_true(bool(prepared.get("ok", false)), String(prepared.get("reason", "")))
+	var battle: Gen2Battle = prepared["battle"]
+	assert_eq(battle.player_badge_mask, 0)
+	assert_eq(battle.player.stat("attack"), int(battle.player.stats["attack"]))
+
+
 ## A link battle is a whole-party exchange with no trainer class behind it,
 ## which is `battle_tower`'s shape one caller further out.
 func test_a_link_battle_request_builds_the_peers_party() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37777
+const MAX_COMMENT_LINES: int = 37775
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_apricorn.gd
+++ b/tests/unit/test_world_apricorn.gd
@@ -151,6 +151,16 @@ func test_the_quantity_dial_wraps_at_both_ends() -> void:
 	assert_eq(prompt.value, 2)
 
 
+## The dial as a step, which the mart's box and the item PC's row take instead
+## of keeping a prompt.
+func test_the_quantity_dial_steps_for_a_caller_that_keeps_the_number() -> void:
+	assert_eq(Gen2WorldQuantityPrompt.stepped(1, Gen2Button.DOWN, 7), 7)
+	assert_eq(Gen2WorldQuantityPrompt.stepped(7, Gen2Button.UP, 7), 1)
+	assert_eq(Gen2WorldQuantityPrompt.stepped(3, Gen2Button.RIGHT, 7), 7)
+	assert_eq(Gen2WorldQuantityPrompt.stepped(5, Gen2Button.LEFT, 7), 1)
+	assert_eq(Gen2WorldQuantityPrompt.stepped(99, Gen2Button.UP, 7), 1)
+
+
 func test_the_quantity_dial_pages_by_ten_and_stops_at_the_ceiling() -> void:
 	var prompt: Gen2WorldQuantityPrompt = Gen2WorldQuantityPrompt.open(25)
 	prompt.press(Gen2Button.RIGHT)


### PR DESCRIPTION
## Fixed

`HandleBerserkGene` had no counterpart here. The Berserk Gene is a hidden item in Cerulean City and Mewtwo's wild held item; its holder spends it at the top of the turn for two Attack stages and a confusion whose count the routine never writes. Built in `Gen2Battle` in front of `BattleMenu`'s own place, with the count carried across a send-out the way `wPlayerConfuseCount` is, so a zero one wraps to 256 turns.

`BadgeStatBoosts` and `DoBadgeTypeBoosts` both `ret nz` on `wLinkMode` and on `wInBattleTowerBattle`. `Gen2WorldBattle` handed the player's badges to a Battle Tower and a link battle alike, so both the stat bonus and the type bonus were paid where hardware pays none.

The item PC's quantity dial clamped where `Toss_Sell_Loop` wraps: down at one is the whole stack, not one. `Gen2WorldQuantityPrompt.stepped` is that dial as a single step, and the mart's two copies of it are gone.

## Changed

Nine repeated comment blocks deduped between the two intro movies, their pages, `game_data`, `mod_host` and `mod_state`. `MAX_COMMENT_LINES` is 37775.

Unit tier 3599 passing, whole tier 4206, `validate.gd -- all` green, `replay_world.gd` 33 routes 0 failures, warning scan 0 in 614 scripts.