### PR TITLE
Three defects from a walk of the battle animation command interpreter

### DIFF
--- a/game/audio/gen2_audio_player.gd
+++ b/game/audio/gen2_audio_player.gd
@@ -150,7 +150,7 @@ func play_record(
 	request_kind: StringName,
 	assets: Dictionary = {},
 	restart: bool = false,
-	cry_tracks: int = 0,
+	track_mask: int = 0,
 ) -> Dictionary:
 	if request_kind == &"music_fadeout":
 		return {"ok": true, "played": fade_out(int(record.get("fade_time", 0)))}
@@ -180,8 +180,8 @@ func play_record(
 			# `PlayStereoCry` writes wCryTracks and puts 1 in wStereoPanningMask;
 			# `PlayMonCry2` zeroes both. Written per request rather than kept, so
 			# one battler's side cannot leak into the next cry.
-			_engine.cry_tracks = cry_tracks
-			_engine.stereo_panning_mask = 1 if cry_tracks != 0 else 0
+			_engine.cry_tracks = track_mask
+			_engine.stereo_panning_mask = 1 if track_mask != 0 else 0
 			started = _engine.play_cry(record)
 		&"sound", &"sfx", &"waited_sfx":
 			# `WaitPlaySFX` holds until the channels are free, so its sound is
@@ -194,8 +194,9 @@ func play_record(
 		&"stereo_sfx":
 			# `PlayStereoSFX`, which the battle animations reach directly: no
 			# `wCurSFX` gate in front of it, so an animation's own sound lands
-			# whatever is still ringing.
-			started = _engine.play_sfx(record)
+			# whatever is still ringing. `track_mask` is `wStereoPanningMask`.
+			_engine.stereo_panning_mask = track_mask
+			started = _engine.play_stereo_sfx(record)
 		_:
 			started = _engine.play_music(record)
 	if not started:

--- a/game/audio/gen2_audio_render.gd
+++ b/game/audio/gen2_audio_render.gd
@@ -15,6 +15,7 @@ static func render(
 	frames: int,
 	stereo: bool = false,
 	trace: bool = false,
+	panning: int = 0,
 ) -> Dictionary:
 	if record.is_empty():
 		return {"ok": false, "reason": &"audio_data_unavailable"}
@@ -30,6 +31,9 @@ static func render(
 			started = engine.play_cry(record)
 		&"sfx", &"sound":
 			started = engine.play_sfx(record)
+		&"stereo_sfx":
+			engine.stereo_panning_mask = panning
+			started = engine.play_stereo_sfx(record)
 		_:
 			started = engine.play_music(record)
 	if not started:

--- a/game/audio/gen2_sound_engine.gd
+++ b/game/audio/gen2_sound_engine.gd
@@ -420,6 +420,30 @@ func play_sfx(record: Dictionary) -> bool:
 	return true
 
 
+## `PlayStereoSFX`, the one thing `anim_sound` reaches. With stereo off it is
+## [method play_sfx]; with it on the four channels are not cleared first and each
+## one's tracks are narrowed by [member stereo_panning_mask]. `wSFXDuration` and
+## the two channel fields it writes are read nowhere in the driver.
+func play_stereo_sfx(record: Dictionary) -> bool:
+	if not stereo:
+		return play_sfx(record)
+	if not register_record(record):
+		return false
+	music_off()
+	_music_id = int(record.get("index", 0))
+	_music_bank = int(record.get("bank", 0))
+	var address: int = int(record.get("address", 0))
+	var count: int = ((_music_byte(_music_bank, address) >> 6) & 0x03) + 1
+	for _channel: int in count:
+		address = _load_channel(address)
+		var channel: Channel = channels[_cur_channel]
+		channel.sfx = true
+		channel.tracks = _default_tracks(_cur_channel) & stereo_panning_mask
+		channel.channel_on = true
+	music_on()
+	return true
+
+
 ## `_PlayCry`. The record supplies the two `PokemonCries` parameters.
 func play_cry(record: Dictionary) -> bool:
 	if not register_record(record):

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -3,17 +3,14 @@ extends RefCounted
 
 ## One battle animation playing: `RunBattleAnimScript`'s frame loop
 ## (engine/battle_anims/anim_commands.asm). [Gen2BattleAnimScript] is the
-## interpreter and [Gen2BattleAnimObject] is one object; this is what the
-## cartridge does with both once a frame, running the script until it yields,
-## stepping every live object and collecting what they would put in `wShadowOAM`.
-## Scene-free: a frame answers with sprites, a tile window and a palette per
-## sprite. [method unimplemented] reports what an animation asked for and did not
-## get, which cartridge data no longer produces.
+## interpreter and [Gen2BattleAnimObject] is one object; this runs the script
+## until it yields, steps every live object and collects what they would put in
+## `wShadowOAM`. [method unimplemented] reports what an animation asked for and
+## did not get.
 
 ## `NUM_BATTLE_ANIM_STRUCTS`: an eleventh object is simply not spawned.
 const MAX_OBJECTS: int = 10
 
-## Matters only because `BattleAnimCmd_ClearObjs` counts bytes, not objects.
 const OBJECT_STRUCT_BYTES: int = 24
 
 ## `BattleAnimCmd_ClearObjs` clears `$a0` bytes where the ten structs are `$f0`,
@@ -22,8 +19,7 @@ const OBJECT_STRUCT_BYTES: int = 24
 ## the cartridge's own bug (docs/bugs_and_glitches.md), reproduced.
 const CLEAR_OBJS_BYTES: int = 0xA0
 
-## The hardware's forty sprites. An object whose sprites would overrun aborts the
-## whole update, so a busy frame loses the objects after it rather than one.
+## The hardware's forty sprites.
 const MAX_SPRITES: int = 40
 
 ## The five sheets `anim_1gfx` through `anim_5gfx` may have loaded at once.
@@ -45,8 +41,7 @@ const GFX_ENEMYFEET: int = 0x29
 ## `vTiles0`, whose top `BattleAnimCmd_BattlerGFX_*` counts back from.
 const OBJECT_TILES: int = 0x80
 
-## Five background effects at once; a sixth is not queued, as an eleventh object
-## is not spawned.
+## `NUM_BG_EFFECTS`: a sixth is not queued.
 const MAX_BG_EFFECTS: int = Gen2BattleAnimBgEffects.MAX_EFFECTS
 
 ## What `Rollout_FillLYOverridesBackup` and `.playframe` check `wFXAnimID` for.
@@ -86,8 +81,7 @@ var _tiles: Array = []
 var _keep_sprites: bool = false
 var _sprites: Array = []
 ## What the last frame's `RunBattleAnimCommand` ran, for the caller that owns
-## what the interpreter does not: `anim_sound` and `anim_cry` need an audio
-## player, which this layer has none of.
+## what the interpreter does not: `anim_sound` and `anim_cry` need an audio player.
 var _frame_commands: Array = []
 var _unimplemented: Dictionary = {}
 ## `wActiveBGEffects`: five `battle_bg_effect` slots.
@@ -159,8 +153,7 @@ func background() -> Gen2BattleAnimBackground:
 	return _background
 
 
-## The live `wActiveBGEffects` slots, for a caller that wants more than the
-## screen they produced.
+## The live `wActiveBGEffects` slots.
 func bg_effects() -> Array:
 	var out: Array = []
 	for effect: Gen2BattleAnimBgEffect in _bg_effects:
@@ -181,8 +174,7 @@ func bump_object_index() -> void:
 	_last_object_index = (_last_object_index + 1) & 0xFF
 
 
-## `_QueueBattleAnimation`, which a battler-object effect calls with the same
-## four values `anim_obj` supplies.
+## `_QueueBattleAnimation`, with the four values `anim_obj` supplies.
 func queue_object(row: int, x: int, y: int, param: int) -> void:
 	_queue_object([row, x, y, param])
 
@@ -205,9 +197,7 @@ func failed() -> bool:
 
 ## The sprites the last frame put in `wShadowOAM`, each
 ## [code]{ y, x, tile, attributes }[/code] with the cartridge's own byte values.
-##
-## A y or x of zero is off screen, the way it is on hardware: OAM subtracts 16
-## and 8 from what is written.
+## A y or x of zero is off screen: OAM subtracts 16 and 8 from what is written.
 func sprites() -> Array:
 	return _sprites
 
@@ -271,8 +261,7 @@ func advance_frame() -> bool:
 	return true
 
 
-## `RunBattleAnimCommand`, plus the commands that reach past the interpreter into
-## the objects and the tile window.
+## `RunBattleAnimCommand`, plus the commands that reach past the interpreter.
 func _run_commands() -> void:
 	_frame_commands = _script.advance_frame()
 	for command: Dictionary in _frame_commands:
@@ -338,8 +327,7 @@ func _queue_object(operands: Array) -> void:
 		return
 
 
-## `BattleAnimCmd_*GFX`: each named sheet is loaded into the window in turn and
-## recorded in the tile dict, until the window is full.
+## `BattleAnimCmd_*GFX`: each named sheet into the window in turn, until full.
 func _load_graphics(operands: Array) -> void:
 	var next_tile: int = 0
 	var entry: int = 0
@@ -365,8 +353,7 @@ func _load_graphics(operands: Array) -> void:
 ## lift a battler's feet or head off the tilemap and move them as objects.
 ## The dict entries are crosswise with what is copied, `PLAYERHEAD` holding the
 ## enemy's rows, and the object rows are crossed the same way, so the two cancel.
-## Both crossings are the cartridge's and neither is tidied. The window tiles name
-## a tile of `vTiles2` in the numbering [Gen2BattleScreenMap] writes.
+## Both crossings are the cartridge's and neither is tidied.
 func _load_battler_graphics(rows: int) -> void:
 	var slot: int = _free_tile_dict_slot()
 	if slot < 0 or slot + 1 >= TILE_DICT_ENTRIES:
@@ -463,7 +450,7 @@ func _bg_effect_with_id(id: int) -> Gen2BattleAnimBgEffect:
 
 
 ## `_ExecuteBGEffects`: every live slot in order. An id past this profile's own
-## table is reported rather than run, which cartridge data never produces.
+## table is reported rather than run; cartridge data never produces one.
 func _execute_bg_effects() -> void:
 	for effect: Gen2BattleAnimBgEffect in _bg_effects:
 		if not effect.active():
@@ -475,10 +462,9 @@ func _execute_bg_effects() -> void:
 ## `BattleAnim_UpdateOAM_All`: every live object stepped and drawn in slot order,
 ## stopping at the first whose sprites would not fit. The slot's index byte is
 ## tested once, at the top of the loop, so an object whose own callback calls
-## `DeinitBattleAnimation` still reaches `BattleAnimOAMUpdate` and is **drawn one
-## last time where it stands**. Measured against a real cartridge: TACKLE's
-## `anim_incobj 1` frees the target's two rows on the frame it runs and OAM still
-## holds their fourteen sprites for that frame.
+## `DeinitBattleAnimation` is still drawn once more where it stands. Measured on a
+## cartridge: TACKLE's `anim_incobj 1` frees the target's two rows on the frame it
+## runs and OAM still holds their fourteen sprites.
 func _update_oam() -> void:
 	_sprites = []
 	for object: Gen2BattleAnimObject in _objects:
@@ -500,8 +486,7 @@ func _update_oam() -> void:
 
 ## `DoBattleAnimFrame`: the object's own motion callback, in
 ## [Gen2BattleAnimFunctions]. A callback outside the jumptable is reported rather
-## than run, which the importer's own range check makes unreachable from a
-## cartridge and a hand-built object can still ask for.
+## than run; only a hand-built object can reach that.
 func _do_battle_anim_frame(object: Gen2BattleAnimObject) -> void:
 	if not Gen2BattleAnimFunctions.run(self, object):
 		_note(&"functions", object.function)

--- a/game/battle/battle_anim_script.gd
+++ b/game/battle/battle_anim_script.gd
@@ -75,6 +75,13 @@ const COMMANDS: Array[Dictionary] = [
 ## `.RunScript` never reaches the jumptable for one.
 const WAIT: StringName = &"wait"
 
+## `BattleAnimCmd_Sound`'s `.GetPanning`, indexed by `wCryTracks`.
+const SOUND_PANNING: Array[int] = [0xF0, 0x0F, 0xF0, 0x0F]
+
+## `BattleAnimCmd_Cry`'s `.CryData`, `[pitch, length]` added to what `LoadCry`
+## left. Growl's `anim_cry $0` and Roar's `$1` are the only two spent.
+const CRY_DATA: Array = [[0, 0xC0], [0, 0x40], [0, 0], [0, 0]]
+
 const OBJ: StringName = &"obj"
 const SOUND: StringName = &"sound"
 ## The two that write a battler's own picture rather than an animation object:
@@ -196,6 +203,25 @@ static func decode_command(
 		"ok": true, "name": command["name"], "byte": byte, "operands": operands,
 		"size": 1 + count, "target": target,
 	}
+
+
+## `wStereoPanningMask` for one `anim_sound`: its first operand, bit 0 flipped on
+## the enemy's turn, which is what puts a sound on the side it came from. The
+## `wSFXDuration` in the same byte is dropped; nothing in the driver reads it.
+static func sound_panning(byte: int, enemy_turn: bool) -> int:
+	return SOUND_PANNING[(byte ^ (1 if enemy_turn else 0)) & 0x03]
+
+
+## One `anim_cry` operand's `.CryData` row added to the species' record, the way
+## `PlaySlowCry` edits the record `LoadCry` just loaded.
+static func cry_with_offsets(record: Dictionary, byte: int) -> Dictionary:
+	var row: Array = CRY_DATA[byte & 0x03]
+	if record.is_empty() or (int(row[0]) == 0 and int(row[1]) == 0):
+		return record
+	var out: Dictionary = record.duplicate(true)
+	out["cry_pitch"] = (int(record.get("cry_pitch", 0)) + int(row[0])) & 0xFFFF
+	out["cry_length"] = (int(record.get("cry_length", 0)) + int(row[1])) & 0xFFFF
+	return out
 
 
 func finished() -> bool:

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -2057,7 +2057,7 @@ func _run_next_anim_step() -> void:
 						_anim_delay = 1
 						return
 			ANIM_SFX:
-				_play_anim_sound(int(step["sfx"]))
+				_play_sfx(int(step["sfx"]))
 			ANIM_HIT_SOUND:
 				_play_hit_sound()
 			ANIM_SCRIPT:
@@ -2105,9 +2105,10 @@ func _after_anim_frame() -> void:
 	for command: Dictionary in _anim.frame_commands():
 		match StringName(command["name"]):
 			Gen2BattleAnimScript.SOUND:
-				_play_anim_sound(int((command["operands"] as Array)[1]))
+				var sound: Array = command["operands"]
+				_play_anim_sound(int(sound[1]), int(sound[0]))
 			Gen2BattleAnimScript.CRY:
-				_play_anim_cry()
+				_play_anim_cry(int((command["operands"] as Array)[0]))
 			Gen2BattleAnimScript.RAISE_SUB, Gen2BattleAnimScript.DROP_SUB:
 				# `BattleAnimCmd_RaiseSub` and `..._DropSub` write the actor's own
 				# tiles, and the actor is `hBattleTurn`, which is whose animation
@@ -2203,21 +2204,38 @@ func battle_music() -> int:
 	return _battle_music
 
 
-## `BattleAnimCmd_Sound`'s second operand, which is the SFX id `PlayStereoSFX`
-## is given. The first is the track and panning mask, which this project has no
-## stereo field to spend.
-func _play_anim_sound(sfx: int) -> void:
+## `PlaySFX`, which is every effect this screen plays that is not an animation's
+## own. Its `wCurSFX` gate is what stops two of them piling up; [param waited] is
+## a `WaitSFX` the source spends first, which the gate must not then refuse.
+func _play_sfx(sfx: int, waited: bool = false) -> void:
 	if _audio_player == null or _data == null:
 		return
 	var record: Dictionary = _data.world_audio(&"sfx", sfx)
 	if record.is_empty():
 		return
-	_audio_player.play_record(record, &"stereo_sfx", _audio_assets())
+	_audio_player.play_record(
+		record, &"waited_sfx" if waited else &"sound", _audio_assets()
+	)
+
+
+## `BattleAnimCmd_Sound`, the cartridge's one `PlayStereoSFX` caller: the second
+## operand is the SFX id and the first is what it pans by.
+func _play_anim_sound(sfx: int, tracks: int) -> void:
+	if _audio_player == null or _data == null:
+		return
+	var record: Dictionary = _data.world_audio(&"sfx", sfx)
+	if record.is_empty():
+		return
+	_audio_player.play_record(
+		record, &"stereo_sfx", _audio_assets(), false, Gen2BattleAnimScript.sound_panning(
+			tracks, bool(_anim_event.get("enemy_turn", false))
+		)
+	)
 
 
 ## `BattleAnimCmd_Cry`: whichever battler `hBattleTurn` names, at its own
 ## `PokemonCries` pitch and length plus the command's own `.CryData` row.
-func _play_anim_cry() -> void:
+func _play_anim_cry(pitch: int) -> void:
 	if _audio_player == null or _data == null:
 		return
 	var enemy_turn: bool = bool(_anim_event.get("enemy_turn", false))
@@ -2225,13 +2243,13 @@ func _play_anim_cry() -> void:
 	if record.is_empty():
 		return
 	_audio_player.play_record(
-		record, &"cry", _audio_assets(), false, cry_tracks(enemy_turn)
+		Gen2BattleAnimScript.cry_with_offsets(record, pitch), &"cry", _audio_assets(),
+		false, cry_tracks(enemy_turn)
 	)
 
 
 ## `PlayStereoCry` behind an entrance, which names its own species rather than
-## reading whoever is on the field: the event is spent where the source plays it,
-## which is before the panel it came with has been drawn.
+## reading the field: the event is spent before its own panel is drawn.
 func _play_entrance_cry(side: int, species: int) -> void:
 	if _audio_player == null or _data == null:
 		return
@@ -2265,7 +2283,7 @@ func _play_hit_sound() -> void:
 		sfx = SFX_SUPER_EFFECTIVE
 	elif effectiveness < RomLayout.MATCHUP_EFFECTIVE:
 		sfx = SFX_NOT_VERY_EFFECTIVE
-	_play_anim_sound(sfx)
+	_play_sfx(sfx, true)
 
 
 func _audio_assets() -> Dictionary:
@@ -2356,7 +2374,7 @@ func _start_exp_bar(event: Dictionary, from_pixels: int) -> void:
 	## `.PlayExpBarSound` runs before the first `.LoopBarAnimation`, so the sound
 	## leads the fill by its own ten frames.
 	if not _exp_bar.finished():
-		_play_anim_sound(SFX_EXP_BAR)
+		_play_sfx(SFX_EXP_BAR, true)
 	_push_view()
 
 
@@ -3620,7 +3638,7 @@ func advance() -> void:
 		_exp_bar.resume()
 		## The loop reaches `.PlayExpBarSound` again for the segment this press
 		## releases, the same as the first one.
-		_play_anim_sound(SFX_EXP_BAR)
+		_play_sfx(SFX_EXP_BAR, true)
 		return
 	## `BattleIntroSlidingPics`, `SlideBattlePicOut` and every other run of frames
 	## this screen counts is delays with nothing reading a button.
@@ -4472,10 +4490,10 @@ func _answer_switch_pick(button: int) -> void:
 func _resolve_switch(answer: Dictionary) -> void:
 	match StringName(answer.get("result", &"")):
 		Gen2BattleSwitchMenu.CHOSEN:
-			_play_anim_sound(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+			_play_sfx(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
 			_commit_switch(int(answer.get("index", -1)))
 		Gen2BattleSwitchMenu.CANCELLED:
-			_play_anim_sound(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
+			_play_sfx(Gen2BattleSwitchMenu.SFX_READ_TEXT_2)
 			## A target list backed out of leaves the item where it was and
 			## reopens the pack it was chosen from.
 			if _switch_reason == &"item":
@@ -4492,7 +4510,7 @@ func _resolve_switch(answer: Dictionary) -> void:
 			## the list is the same answer as NO.
 			_decline_switch_offer()
 		Gen2BattleSwitchMenu.CANNOT_CANCEL:
-			_play_anim_sound(int(answer.get("sfx", 0)))
+			_play_sfx(int(answer.get("sfx", 0)))
 		_:
 			_show_switch_refusal(String(answer.get("text", "")))
 
@@ -5154,7 +5172,7 @@ func _apply_event_state(event: Dictionary) -> void:
 			# either prints, so the line waits on the animation.
 			_begin_faint(int(event["side"]))
 		Gen2Battle.MOVE_FORGOTTEN:
-			_play_anim_sound(Gen2MoveForget.SFX_SWITCH_POKEMON)
+			_play_sfx(Gen2MoveForget.SFX_SWITCH_POKEMON)
 		Gen2Battle.SUBSTITUTE_PIC:
 			_set_substitute_pic(int(event["side"]), bool(event["raised"]))
 		Gen2Battle.MINIMIZED:
@@ -5222,7 +5240,7 @@ func _apply_event_state(event: Dictionary) -> void:
 			## `SFX_HIT_END_OF_EXP_BAR`, then `WaitSFX`, then the line. Both
 			## paths play it: `.LoopLevels` for whoever is out and
 			## `.skip_exp_bar_animation` for a benched participant.
-			_play_anim_sound(SFX_HIT_END_OF_EXP_BAR)
+			_play_sfx(SFX_HIT_END_OF_EXP_BAR)
 			## `.skip_exp_bar_animation` draws the box once per award, after the
 			## last level it crossed, so a walk of several levels shows the
 			## stats it finished on rather than one box a level.

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -8483,10 +8483,22 @@ func _play_ledge_hop_sfx() -> void:
 ## `BattleAnimCmd_Sound` from a shiny pulse. The interpreter has no audio device,
 ## as it has none in a battle either, so the screen spends what its commands
 ## asked for. A cry is not one of them: the sparkle's script has no `anim_cry`.
+## The pulse plays on the enemy's side, as a battle plays it, so its sound pans
+## there.
 func _play_encounter_sounds() -> void:
+	if _audio_player == null or _data == null:
+		return
 	for command: Dictionary in _encounters.frame_commands():
-		if StringName(command["name"]) == Gen2BattleAnimScript.SOUND:
-			_play_sfx(int((command["operands"] as Array)[1]))
+		if StringName(command["name"]) != Gen2BattleAnimScript.SOUND:
+			continue
+		var operands: Array = command["operands"]
+		var record: Dictionary = _data.world_audio(&"sfx", int(operands[1]))
+		if record.is_empty():
+			continue
+		_audio_player.play_record(
+			record, &"stereo_sfx", _audio_assets(), false,
+			Gen2BattleAnimScript.sound_panning(int(operands[0]), true)
+		)
 
 
 func _start_heal_machine_sounds(event: Dictionary) -> void:

--- a/tests/unit/test_audio_player.gd
+++ b/tests/unit/test_audio_player.gd
@@ -284,3 +284,11 @@ func test_the_sound_option_reaches_the_driver_and_restarts_the_piece() -> void:
 	assert_eq(_player.audio_status()["music_key"], "",
 		"a map with no music is `PlayMusic MUSIC_NONE` twice")
 	options.stereo = was
+
+
+## A `stereo_sfx` request is `PlayStereoSFX`, so the mask it carries is
+## `wStereoPanningMask` rather than a cry's tracks.
+func test_a_stereo_sfx_request_carries_its_panning_mask() -> void:
+	_player._engine.stereo = true
+	assert_true(_player.play_record(_record(2), &"stereo_sfx", {}, false, 0x0F)["played"])
+	assert_eq(_player._engine.stereo_panning_mask, 0x0F)

--- a/tests/unit/test_battle_anim_script.gd
+++ b/tests/unit/test_battle_anim_script.gd
@@ -281,3 +281,29 @@ func test_check_pokeball_answers_the_queue_and_then_a_break_free() -> void:
 		"`.finished` with `wWildMon` zero, which is the escape",
 	)
 	assert_eq(answers.size(), 2, "the caller's own array is not spent")
+
+
+## `BattleAnimCmd_Sound`'s `.GetCryTrack` flips bit 0 of the whole operand on the
+## enemy's turn and only then masks it, so `anim_sound 6, 2` pans left for the
+## player and right for the enemy.
+func test_an_anim_sound_pans_by_its_operand_and_the_turn() -> void:
+	assert_eq(Gen2BattleAnimScript.sound_panning((6 << 2) | 2, false), 0xF0)
+	assert_eq(Gen2BattleAnimScript.sound_panning((6 << 2) | 2, true), 0x0F)
+	assert_eq(Gen2BattleAnimScript.sound_panning((0 << 2) | 1, false), 0x0F)
+	assert_eq(Gen2BattleAnimScript.sound_panning((0 << 2) | 1, true), 0xF0)
+
+
+## `BattleAnimCmd_Cry`'s `.CryData`: Growl lengthens the cry by `$c0` and Roar by
+## `$40`, both added to what `LoadCry` left and both wrapping in sixteen bits.
+func test_an_anim_cry_adds_its_own_row_to_the_species_record() -> void:
+	var record: Dictionary = {"cry_pitch": 0x0100, "cry_length": 0xFFC0}
+	var growl: Dictionary = Gen2BattleAnimScript.cry_with_offsets(record, 0)
+	assert_eq(int(growl["cry_pitch"]), 0x0100)
+	assert_eq(int(growl["cry_length"]), 0x0080, "the length wraps in a word")
+
+	var roar: Dictionary = Gen2BattleAnimScript.cry_with_offsets(record, 1)
+	assert_eq(int(roar["cry_length"]), 0x0000)
+
+	var plain: Dictionary = Gen2BattleAnimScript.cry_with_offsets(record, 2)
+	assert_eq(int(plain["cry_length"]), 0xFFC0, "rows 2 and 3 add nothing")
+	assert_eq(int(Gen2BattleAnimScript.cry_with_offsets(record, 6)["cry_length"]), 0xFFC0)

--- a/tests/unit/test_sound_engine.gd
+++ b/tests/unit/test_sound_engine.gd
@@ -416,3 +416,26 @@ func test_a_fade_can_hand_over_to_the_song_queued_behind_it() -> void:
 	assert_false(engine.channels[0].channel_on)
 	assert_true(engine.channels[1].channel_on)
 	assert_eq(engine.music_fade, 0)
+
+
+## `PlayStereoSFX` is the only routine an `anim_sound` reaches, and with stereo on
+## it narrows each channel by `wStereoPanningMask` instead of leaving it on both
+## outputs. Mono falls through to `_PlaySFX`, which also zeroes `wSFXPriority`.
+func test_a_stereo_sfx_is_panned_by_its_mask() -> void:
+	var stream: Array = [[4, [0xD8, 0x10, 0xB1, 0xD4, 0x1F, 0xFF]]]
+
+	var right: Gen2SoundEngine = _engine()
+	right.stereo = true
+	right.stereo_panning_mask = 0x0F
+	right.sfx_priority = 1
+	assert_true(right.play_stereo_sfx(_record(stream)))
+	assert_eq(_values(_writes(right, 1), NR51)[0], 0x01, "right output only")
+	assert_eq(right.sfx_priority, 1, "`PlayStereoSFX` leaves wSFXPriority alone")
+
+	var mono: Gen2SoundEngine = _engine()
+	mono.stereo = false
+	mono.stereo_panning_mask = 0x0F
+	mono.sfx_priority = 1
+	assert_true(mono.play_stereo_sfx(_record(stream, 0x3C)))
+	assert_eq(_values(_writes(mono, 1), NR51)[0], 0x11, "`_PlaySFX` leaves both")
+	assert_eq(mono.sfx_priority, 0)

--- a/tools/checks/battle_anims.gd
+++ b/tools/checks/battle_anims.gd
@@ -5,11 +5,9 @@ var _r: RefCounted = null
 ## Runs every battle animation out of a freshly imported real cache, on all three
 ## cartridges, and checks the four tables behind them. Expected values come from
 ## the pinned pokecrystal and pokegold sources: BattleAnimations, the three
-## data/battle_anims tables and the interpreter itself. The real-cartridge
-## counterpart to tests/unit/test_battle_anim_script.gd. What pins it is running
-## all 278 to completion rather than spot checking: an operand width that is wrong
-## by one byte still decodes, and only walking every body past every branch makes
-## it fall over.
+## data/battle_anims tables and the interpreter itself. What pins it is running
+## all 278 to completion rather than spot checking: an operand width wrong by one
+## byte still decodes, and only walking every body past every branch fails.
 
 
 ## `assert_table_length` in each pinned data file. All five are shared by the
@@ -71,6 +69,11 @@ const BODY_SLAM_BG_EFFECTS: Dictionary = {
 ## counts sum to this in every dump. Rows 0, 40 and 41 have no sheet.
 const EXPECTED_GFX_SHEETS: int = 39
 const EXPECTED_GFX_TILES: int = 659
+
+## `.GetPanning`'s left answer, and the two `anim_cry` sites in
+## data/moves/animations.asm: Growl's `.CryData` row 0 and Roar's row 1.
+const PANNING_LEFT: int = 0xF0
+const EXPECTED_CRY_ROWS: Array[int] = [0, 1]
 
 ## `NUM_BATTLE_BG_EFFECTS` in each pin, and the id the two lists part company on.
 ## pokegold ships no `BATTLE_BG_EFFECT_BODY_SLAM`, so from here its own list runs
@@ -851,7 +854,7 @@ func _verify_gfx(game_id: StringName, data: GameData) -> void:
 
 
 ## All 278, run to a top-level `anim_ret`. Nothing may fail, and nothing may
-## reach [constant MAX_FRAMES].
+## reach [constant MAX_FRAMES]. Every `anim_sound` is panned both ways.
 func _run_every_animation(game_id: StringName, data: GameData) -> void:
 	var region: Dictionary = data.battle_anim_region(&"scripts")
 	var count: int = int(region["count"])
@@ -859,6 +862,9 @@ func _run_every_animation(game_id: StringName, data: GameData) -> void:
 	var longest: int = 0
 	var longest_index: int = -1
 	var sounds: int = 0
+	var left: int = 0
+	var mirrored: int = 0
+	var cry_rows: Array[int] = []
 	for index: int in count:
 		var script: Gen2BattleAnimScript = _script(data, index)
 		if not _r.check(script != null, "%s: animation %d has no address." % [game_id, index]):
@@ -868,8 +874,17 @@ func _run_every_animation(game_id: StringName, data: GameData) -> void:
 			frames += 1
 			for command: Dictionary in script.advance_frame():
 				commands += 1
-				if command["name"] == Gen2BattleAnimScript.SOUND:
-					sounds += 1
+				var operands: Array = command["operands"]
+				if command["name"] == Gen2BattleAnimScript.CRY:
+					cry_rows.append(int(operands[0]) & 0x03)
+				if command["name"] != Gen2BattleAnimScript.SOUND:
+					continue
+				sounds += 1
+				var player_side: int = Gen2BattleAnimScript.sound_panning(int(operands[0]), false)
+				left += 1 if player_side == PANNING_LEFT else 0
+				mirrored += 1 if Gen2BattleAnimScript.sound_panning(
+					int(operands[0]), true
+				) != player_side else 0
 		_r.check(
 			not script.failed(),
 			"%s: animation %d ran off its region." % [game_id, index]
@@ -883,8 +898,21 @@ func _run_every_animation(game_id: StringName, data: GameData) -> void:
 		if frames > longest:
 			longest = frames
 			longest_index = index
+	_r.check(
+		mirrored == sounds,
+		"%s: %d of %d anim_sound pan to the same side on both turns." % [
+			game_id, sounds - mirrored, sounds,
+		]
+	)
+	_r.check(
+		cry_rows == EXPECTED_CRY_ROWS,
+		"%s: anim_cry rows %s, not the pinned %s." % [game_id, cry_rows, EXPECTED_CRY_ROWS]
+	)
 	print("%s: %d animations ran %d commands, %d of them anim_sound; longest %d frames (%d)." % [
 		game_id, count, commands, sounds, longest, longest_index,
+	])
+	print("%s: on the player's turn %d anim_sound pan left and %d right, each the other way on the enemy's; anim_cry rows %s." % [
+		game_id, left, sounds - left, cry_rows,
 	])
 
 

--- a/tools/render_audio.gd
+++ b/tools/render_audio.gd
@@ -4,15 +4,15 @@ extends SceneTree
 ## writes a WAV plus the per-frame hardware-register trace beside it. The trace is
 ## the parity artefact: any faithful implementation of the same driver writes the
 ## same registers in the same order on the same frames. Kinds are `music`, `sfx`,
-## `cry` and `mon_cry`; the id is the record index, the species for `mon_cry`, or
-## `all` to sweep the table into `<prefix>_<index>`.
+## `stereo_sfx`, `cry` and `mon_cry`; the id is the record index, the species for
+## `mon_cry`, or `all` to sweep. The last argument is `wStereoPanningMask`.
 ##   ... -s res://tools/render_audio.gd -- crystal music 1 600 /tmp/out
 
 
 func _initialize() -> void:
 	var arguments: PackedStringArray = OS.get_cmdline_user_args()
 	if arguments.size() < 5:
-		printerr("usage: render_audio.gd -- <game> <music|sfx|cry> <id|all> <frames> <out-prefix> [stereo]")
+		printerr("usage: render_audio.gd -- <game> <music|sfx|stereo_sfx|cry> <id|all> <frames> <out-prefix> [stereo] [panning]")
 		quit(1)
 		return
 	var game: StringName = StringName(arguments[0])
@@ -23,6 +23,7 @@ func _initialize() -> void:
 		quit(2)
 		return
 	var stereo: bool = arguments.size() > 5 and arguments[5] == "1"
+	var panning: int = int(arguments[6]) if arguments.size() > 6 else 0
 
 	var data: GameData = GameData.open(game)
 	if data == null:
@@ -41,7 +42,9 @@ func _initialize() -> void:
 			if swept.is_empty():
 				break
 			_report(kind, index, swept)
-			if not _render(swept, kind, assets, frames, stereo, "%s_%d" % [prefix, index]):
+			if not _render(
+				swept, kind, assets, frames, stereo, panning, "%s_%d" % [prefix, index]
+			):
 				quit(1)
 				return
 			index += 1
@@ -55,7 +58,7 @@ func _initialize() -> void:
 		quit(1)
 		return
 	_report(kind, int(arguments[2]), entry)
-	if not _render(entry, kind, assets, frames, stereo, prefix):
+	if not _render(entry, kind, assets, frames, stereo, panning, prefix):
 		quit(1)
 		return
 	print("%s.wav: %d frames" % [prefix, frames])
@@ -81,9 +84,11 @@ func _report(kind: StringName, index: int, entry: Dictionary) -> void:
 
 func _render(
 	entry: Dictionary, kind: StringName, assets: Dictionary, frames: int,
-	stereo: bool, prefix: String
+	stereo: bool, panning: int, prefix: String
 ) -> bool:
-	var result: Dictionary = Gen2AudioRender.render(entry, kind, assets, frames, stereo, true)
+	var result: Dictionary = Gen2AudioRender.render(
+		entry, kind, assets, frames, stereo, true, panning
+	)
 	if not bool(result.get("ok", false)):
 		printerr("Render failed: %s" % result.get("reason", "unknown"))
 		return false
@@ -102,6 +107,6 @@ func _render(
 func _table(kind: StringName) -> StringName:
 	if kind == &"cry" or kind == &"cries" or kind == &"mon_cry":
 		return &"cries"
-	if kind == &"sfx" or kind == &"sound":
+	if kind == &"sfx" or kind == &"sound" or kind == &"stereo_sfx":
 		return &"sfx"
 	return &"music"


### PR DESCRIPTION
`engine/battle_anims/anim_commands.asm` walked whole, with `core.asm` inside it. Three defects, all in what the interpreter hands to the audio driver; the interpreter, its objects and its OAM are exact.

## Fixed

- `BattleAnimCmd_Sound`'s first operand was dropped whole. It is `wCryTracks` and, through `.GetPanning`, `wStereoPanningMask`, and `PlayStereoSFX` falls through to `_PlaySFX` only in mono: with stereo on it leaves the four channels uncleared and narrows each one's tracks by that mask. All 1,016 `anim_sound` commands now pan to the side of the field the move was played from, 443 left and 573 right on the player's turn and the mirror on the enemy's.
- `BattleAnimCmd_Cry`'s operand indexes `.CryData`, which adds to `wCryPitch` and `wCryLength` on top of what `LoadCry` left, the way `PlaySlowCry` does. Growl's `anim_cry $0` is `+$c0` of length and Roar's `$1` is `+$40`; both played the plain cry.
- The battle screen routed every effect it plays through the animation's own request kind, so the entrance shine, both exp bar sounds, the hit sound and four menu beeps skipped `PlaySFX`'s `wCurSFX` gate. Split, with the two the source guards with `WaitSFX` marked as such.

## Added

- `Gen2SoundEngine.play_stereo_sfx`, `PlayStereoSFX`'s own path.
- `tools/checks/battle_anims.gd` pans every `anim_sound` both ways and pins both `anim_cry` rows, on all three cartridges.
- `tools/render_audio.gd` takes a `stereo_sfx` kind and a panning mask, so the panning is renderable.

## Not fixed, deliberately

`wSFXDuration`, the other half of that first operand, writes `CHANNEL_FIELD2E`, `..._2F` and `SOUND_UNKN_0F`, and nothing in `audio/engine.asm` reads any of the three.

## Measured

| Check | Result |
|---|---|
| Rendered SFX 49, mask `$f0` | left rms 942, right 0 |
| Rendered SFX 49, mask `$0f` | left rms 0, right 942 |
| Rendered SFX 49, mono | left rms 942, right 942 |
| `anim_sound` swept, per cartridge | 1,016 commands, 443 left / 573 right, every one mirrored on the other turn |
| `anim_cry` swept, per cartridge | rows `[0, 1]`, the two pinned sites |
| GUT unit tier | 3,603 tests, 68,666 asserts, green |
| `tools/validate.gd -- all` | 84 topics pass, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, all three profiles | exit 0 |
| `addons/warning_scan` | 0 warnings in 614 scripts |
| `tools/release.sh --gates` | pass, comments 37,775 of 37,775 |