### PR TITLE
Six Crystal tilesets never took their own background palettes

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -814,9 +814,8 @@ func _ready() -> void:
 		_announce()
 
 
-## Supplies a cache-backed data source before the scene enters the tree. The
-## normal launcher path still resolves data from GameRuntime or the first
-## imported cache.
+## Supplies a cache-backed data source before the scene enters the tree; the
+## launcher still resolves its own from GameRuntime.
 func set_data(data: GameData) -> void:
 	_injected_data = data
 

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1061,6 +1061,24 @@ func world_palette(number: int) -> PackedColorArray:
 	return out
 
 
+## `LoadSpecialMapPalette`'s eight, or nothing for a tileset with no set and for
+## the INDOOR Hall of Fame sharing `TILESET_ICE_PATH`.
+func special_map_palettes(tileset: int, environment: int) -> Array:
+	var index: int = RomLayout.SPECIAL_PALETTE_TILESETS.find(tileset)
+	if index < 0:
+		return []
+	if tileset == RomLayout.SPECIAL_PALETTE_ICE_PATH \
+		and (environment & 0x07) == RomLayout.SPECIAL_PALETTE_ENVIRONMENT_INDOOR:
+		return []
+	var base: int = RomLayout.SPECIAL_PALETTE_BASE + index * 8
+	if base + 8 > _palettes().size():
+		return []
+	var out: Array = []
+	for slot: int in 8:
+		out.append(world_palette(base + slot))
+	return out
+
+
 ## The three tilesets `home/map.asm` gates `LoadMapGroupRoof` on: "These tilesets
 ## support dynamic per-mapgroup roof tiles." Every other tileset owns tiles
 ## $0A..$12 itself, so writing a roof over them is the map's own art destroyed.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 100
+const FORMAT_VERSION: int = 101
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -267,6 +267,19 @@ const WORLD_PALETTE_GROUP_BYTES: int = 8
 const WORLD_PALETTE_BYTES: int = WORLD_PALETTE_GROUP_COUNT * WORLD_PALETTE_GROUP_BYTES
 const WORLD_PALETTE_MAP_BYTES: int = 0x70
 
+## `LoadSpecialMapPalette` (engine/tilesets/tileset_palettes.asm): six Crystal
+## tilesets whose eight palettes are fixed, and its carry skips `LoadMapPals`'
+## environment and time-of-day selection whole. Appended to the palette groups.
+const SPECIAL_PALETTE_BASE: int = WORLD_PALETTE_GROUP_COUNT
+const SPECIAL_PALETTE_TILESETS: Array[int] = [0x15, 0x16, 0x1D, 0x05, 0x1B, 0x0D]
+## `.ice_path`'s `cp INDOOR`: the Hall of Fame shares the tileset and is handed back.
+const SPECIAL_PALETTE_ICE_PATH: int = 0x1D
+const SPECIAL_PALETTE_MANSION: int = 0x0D
+const PAL_BG_WATER: int = 3
+const PAL_BG_YELLOW: int = 4
+const PAL_BG_ROOF: int = 6
+const SPECIAL_PALETTE_ENVIRONMENT_INDOOR: int = 3
+
 ## `LoadMapGroupRoof` and `RoofPals`. A map group names one of five nine-tile
 ## roof runs, copied over `vTiles2 tile $0a` on every map load, and `_LoadMapPals`
 ## replaces colours 1 and 2 of `PAL_BG_ROOF` with that group's own pair on a TOWN
@@ -276,7 +289,6 @@ const MAP_GROUP_ROOF_COUNT: int = 27
 const ROOF_COUNT: int = 5
 const ROOF_TILES: int = 9
 const ROOF_TILE_BYTES: int = ROOF_TILES * 16
-const ROOF_PALETTE_BYTES: int = 8
 const ROOF_VRAM_TILE: int = 0x0A
 const WORLD_ANIMATION_BANK: int = 0x3F
 const WORLD_ANIMATION_COMMAND_BYTES: int = 4
@@ -2655,6 +2667,9 @@ const GOLD_SILVER: Dictionary = {
 	"tileset_block_counts": [128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 40],
 	"tileset_palette_bank": 0x02,
 	"world_palette_offset": 0xB75E,
+	## `LoadMapPals` here has no `LoadSpecialMapPalette` in front of it.
+	"special_map_palettes": [],
+	"mansion_palette_yellow": -1,
 	"roof_palettes": 0xB9AE,
 	"map_group_roofs": 0x1C021,
 	"roof_tiles": 0x1C03C,
@@ -3244,6 +3259,10 @@ const CRYSTAL: Dictionary = {
 	"tileset_block_counts": [128, 128, 128, 128, 128, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 40, 64, 64, 64, 64, 64],
 	"tileset_palette_bank": 0x13,
 	"world_palette_offset": 0xB319,
+	## In SPECIAL_PALETTE_TILESETS order. `MansionPalette1` is nine palettes: its
+	## seventh goes over PAL_BG_WATER and its ninth over PAL_BG_ROOF.
+	"special_map_palettes": [0x49501, 0x49550, 0x4959F, 0x495EE, 0x4963D, 0x4967D],
+	"mansion_palette_yellow": 0x496FE,
 	"roof_palettes": 0xB569,
 	"map_group_roofs": 0x1C021,
 	"roof_tiles": 0x1C03C,

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -792,27 +792,62 @@ static func _tileset_strip(raw_graphics: PackedByteArray) -> PackedByteArray:
 
 
 static func _read_world_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
-	var offset: int = int(layout["world_palette_offset"])
-	var bytes: PackedByteArray = rom.slice(offset, RomLayout.WORLD_PALETTE_BYTES)
-	if bytes.size() != RomLayout.WORLD_PALETTE_BYTES:
+	var groups: Array = _read_palette_run(
+		rom, int(layout["world_palette_offset"]), RomLayout.WORLD_PALETTE_GROUP_COUNT
+	)
+	if groups.is_empty():
 		return _error("Overworld palette data is outside the cartridge.")
-
-	var groups: Array = []
-	for group: int in RomLayout.WORLD_PALETTE_GROUP_COUNT:
-		var colors: Array = []
-		for color: int in 4:
-			var at: int = group * RomLayout.WORLD_PALETTE_GROUP_BYTES + color * 2
-			colors.append(int(bytes[at]) | (int(bytes[at + 1]) << 8))
-		groups.append(colors)
+	var special: Variant = _read_special_map_palettes(rom, layout)
+	if special is Dictionary:
+		return special
+	groups.append_array(special as Array)
 	return {"ok": true, "groups": groups}
 
 
-## `LoadMapGroupRoof` and `_LoadMapPals`' own roof branch, as one record.
-##
-## The tiles are a plain 2bpp run of [constant RomLayout.ROOF_COUNT] nine-tile
-## roofs, and the palette pair is read whole rather than split: `RoofPals`' row
-## is morn/day's two colours then nite's two, and which half a map takes is the
-## renderer's question rather than the importer's.
+## `LoadSpecialMapPalette`'s six sets, appended so a renderer reads them the way
+## it reads any other group.
+static func _read_special_map_palettes(rom: RomFile, layout: Dictionary) -> Variant:
+	var offsets: Array = layout.get("special_map_palettes", [])
+	var out: Array = []
+	for index: int in offsets.size():
+		var tileset: int = int(RomLayout.SPECIAL_PALETTE_TILESETS[index])
+		var wanted: int = 9 if tileset == RomLayout.SPECIAL_PALETTE_MANSION else 8
+		var read: Array = _read_palette_run(rom, int(offsets[index]), wanted)
+		if read.is_empty():
+			return _error("A special map palette is outside the cartridge.")
+		if tileset == RomLayout.SPECIAL_PALETTE_MANSION:
+			var yellow: Array = _read_palette_run(
+				rom, int(layout.get("mansion_palette_yellow", 0)), 1
+			)
+			if yellow.is_empty():
+				return _error("The mansion's yellow palette is outside the cartridge.")
+			read[RomLayout.PAL_BG_YELLOW] = yellow[0]
+			read[RomLayout.PAL_BG_WATER] = read[6]
+			read[RomLayout.PAL_BG_ROOF] = read[8]
+			read.resize(8)
+		out.append_array(read)
+	return out
+
+
+static func _read_palette_run(rom: RomFile, offset: int, palettes: int) -> Array:
+	var bytes: PackedByteArray = rom.slice(
+		offset, palettes * RomLayout.WORLD_PALETTE_GROUP_BYTES
+	)
+	if bytes.size() != palettes * RomLayout.WORLD_PALETTE_GROUP_BYTES:
+		return []
+	var out: Array = []
+	for palette: int in palettes:
+		var colors: Array = []
+		for color: int in 4:
+			var at: int = palette * RomLayout.WORLD_PALETTE_GROUP_BYTES + color * 2
+			colors.append(int(bytes[at]) | (int(bytes[at + 1]) << 8))
+		out.append(colors)
+	return out
+
+
+## `LoadMapGroupRoof` and `_LoadMapPals`' roof branch as one record. `RoofPals`'
+## row is morn/day's two colours then nite's two, read whole: which half a map
+## takes is the renderer's question.
 static func _read_world_roofs(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var groups: PackedByteArray = rom.slice(
 		int(layout["map_group_roofs"]), RomLayout.MAP_GROUP_ROOF_COUNT
@@ -823,18 +858,11 @@ static func _read_world_roofs(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var raw: PackedByteArray = rom.slice(int(layout["roof_tiles"]), tile_bytes)
 	if raw.size() != tile_bytes:
 		return _error("The roof tiles are outside the cartridge.")
-	var palette_bytes: int = RomLayout.MAP_GROUP_ROOF_COUNT * RomLayout.ROOF_PALETTE_BYTES
-	var packed: PackedByteArray = rom.slice(int(layout["roof_palettes"]), palette_bytes)
-	if packed.size() != palette_bytes:
+	var palettes: Array = _read_palette_run(
+		rom, int(layout["roof_palettes"]), RomLayout.MAP_GROUP_ROOF_COUNT
+	)
+	if palettes.is_empty():
 		return _error("The roof palettes are outside the cartridge.")
-
-	var palettes: Array = []
-	for group: int in RomLayout.MAP_GROUP_ROOF_COUNT:
-		var colors: Array = []
-		for color: int in 4:
-			var at: int = group * RomLayout.ROOF_PALETTE_BYTES + color * 2
-			colors.append(int(packed[at]) | (int(packed[at + 1]) << 8))
-		palettes.append(colors)
 	var tiles: Array = []
 	for roof: int in RomLayout.ROOF_COUNT:
 		tiles.append(Array(Gen2Tiles.decode_2bpp_strip(

--- a/game/render/game_freak_presents_page.gd
+++ b/game/render/game_freak_presents_page.gd
@@ -126,11 +126,8 @@ func draw(phase: Gen2GameFreakPresents) -> Image:
 	return Gen2PicImage.canvas_image(pixels, width, height)
 
 
-## Every live struct expanded into the shadow OAM the hardware would hold, in
-## struct order, which is the z-order `PlaySpriteAnimations` walks. One entry
-## per drawn tile, `y` and `x` the OAM bytes and `tile` the byte `dbsprite`
-## writes, so a trace of this compares to a cartridge's own buffer line for
-## line. [method draw] blits this same list rather than re-deriving it.
+## Every live struct expanded into the shadow OAM the hardware would hold, one
+## entry per drawn tile, in the z-order `PlaySpriteAnimations` walks.
 func shadow_oam(phase: Gen2GameFreakPresents) -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
 	if phase == null:

--- a/game/render/gold_silver_intro_page.gd
+++ b/game/render/gold_silver_intro_page.gd
@@ -267,10 +267,7 @@ func draw(movie: Gen2GoldSilverIntro) -> Image:
 
 
 ## Every live struct expanded into the shadow OAM the hardware would hold, in
-## struct order, which is the z-order `PlaySpriteAnimations` walks. `y` and `x`
-## are the OAM bytes and `tile` the byte `dbsprite` writes. [method draw] blits
-## this same list rather than re-deriving it, so a trace of it compares to a
-## cartridge's own buffer line for line.
+## the z-order `PlaySpriteAnimations` walks; see `Gen2GameFreakPresentsPage`.
 func shadow_oam(movie: Gen2GoldSilverIntro) -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
 	if movie == null:

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -1,12 +1,8 @@
 class_name Gen2WorldPalette
 extends RefCounted
 
-## Cartridge background palette selection for the overworld.
-##
-## The ROM stores 42 actual colour groups and a separate environment/time table
-## selects eight of them for the hardware's background palette slots. The
-## values below are the table from the map palette loader, kept here as data so
-## the renderer does not silently substitute a modern colour scheme.
+## `LoadMapPals`' background palette selection. The cartridge stores 42 colour
+## groups and an environment and time-of-day table names eight of them.
 
 const TIME_MORNING: int = 0
 const TIME_DAY: int = 1
@@ -203,10 +199,14 @@ static func tile_palettes(
 	fade_order: int = FADE_IDENTITY,
 	white_fill: bool = false,
 ) -> Array:
+	## `LoadMapPals` asks `LoadSpecialMapPalette` first, and its carry skips the
+	## environment and time-of-day pair entirely.
+	var special: Array = data.special_map_palettes(map.tileset, map.environment)
 	var slots: Array = palette_slots(map.environment, time_of_day)
 	var resolved: Array = []
 	for slot: int in slots.size():
-		var base: PackedColorArray = data.world_palette(int(slots[slot]))
+		var base: PackedColorArray = special[slot] if slot < special.size() \
+			else data.world_palette(int(slots[slot]))
 		var palette := PackedColorArray()
 		palette.append_array(base)
 		if slot == 3 and water_color >= 0 and base.size() >= 4:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -432,10 +432,8 @@ func hide_debug_readout() -> void:
 		_hint.visible = false
 
 
-## Supplies a cache-backed data source before the scene enters the tree. The
-## launcher continues to use GameRuntime; this boundary lets scene tests and
-## development tools exercise an explicitly selected cache without mutating
-## global runtime selection.
+## Supplies a cache-backed data source before the scene enters the tree, so a
+## test or a tool can name a cache without moving the runtime's own selection.
 func set_data(data: GameData) -> void:
 	_injected_data = data
 

--- a/tests/unit/test_world_animation.gd
+++ b/tests/unit/test_world_animation.gd
@@ -171,6 +171,10 @@ func _write_cache() -> void:
 	var palettes: Array = []
 	for _group: int in RomLayout.WORLD_PALETTE_GROUP_COUNT:
 		palettes.append([0x7FFF, 0x421F, 0x2108, 0])
+	# `LoadSpecialMapPalette`'s six sets, appended the way the importer appends
+	# them and numbered so a slot says which set and which slot it came from.
+	for index: int in RomLayout.SPECIAL_PALETTE_TILESETS.size() * 8:
+		palettes.append([0x0100 + index, 0x0200 + index, 0x0300 + index, 0x0400 + index])
 	RomCache.write_json(RomCache.world_palettes_path(_directory), palettes)
 
 	var water: Array = []
@@ -514,6 +518,43 @@ func test_roof_colours_replace_two_slots_on_outdoor_maps_only() -> void:
 	assert_eq(Gen2WorldPalette.roof_colors(
 		data, Gen2WorldPalette.ENVIRONMENT_TOWN, Gen2WorldPalette.TIME_DAY, 2
 	)[0], Gen2Palette.from_packed(0x0003))
+
+
+## `LoadMapPals` asks `LoadSpecialMapPalette` first, and the carry it answers
+## with skips the environment and time-of-day selection whole: six Crystal
+## tilesets carry eight fixed palettes, and the clock cannot move any of them.
+func test_six_tilesets_take_a_fixed_palette_set_instead_of_the_time_of_day_row() -> void:
+	var data: GameData = GameData.open_directory(_directory)
+	for index: int in RomLayout.SPECIAL_PALETTE_TILESETS.size():
+		var tileset: int = RomLayout.SPECIAL_PALETTE_TILESETS[index]
+		var fixed: Array = data.special_map_palettes(tileset, 0)
+		assert_eq(fixed.size(), 8, "tileset %d carries eight" % tileset)
+		for slot: int in 8:
+			assert_eq(
+				(fixed[slot] as PackedColorArray)[0],
+				Gen2Palette.from_packed(0x0100 + index * 8 + slot),
+				"tileset %d slot %d" % [tileset, slot]
+			)
+	assert_eq(data.special_map_palettes(0x01, 0).size(), 0, "TILESET_JOHTO has none")
+
+	# `.ice_path`'s own `cp INDOOR`: the Hall of Fame shares the tileset and is
+	# the one map handed back to the ordinary selection.
+	assert_eq(data.special_map_palettes(
+		RomLayout.SPECIAL_PALETTE_ICE_PATH,
+		RomLayout.SPECIAL_PALETTE_ENVIRONMENT_INDOOR
+	).size(), 0)
+
+	var tiles: Gen2WorldTileset = data.world_tileset(UNROOFED_TILESET)
+	var house := Gen2WorldMap.from_cache({"group": 0, "tileset": 0x05, "environment": 3})
+	var plain := Gen2WorldMap.from_cache({"group": 0, "tileset": UNROOFED_TILESET, "environment": 3})
+	var drawn: Array = Gen2WorldPalette.tile_palettes(data, house, tiles)
+	var ordinary: Array = Gen2WorldPalette.tile_palettes(data, plain, tiles)
+	assert_eq(
+		(drawn[0] as PackedColorArray)[0],
+		Gen2Palette.from_packed(0x0100 + 3 * 8),
+		"a house tile takes the house set"
+	)
+	assert_eq((ordinary[0] as PackedColorArray)[0], Gen2Palette.from_packed(0x7FFF))
 
 
 ## The debug readout's frame-rate line, which is what says whether a stutter was

--- a/tools/checks/map_data.gd
+++ b/tools/checks/map_data.gd
@@ -73,6 +73,7 @@ func _check_game() -> void:
 	_check_blocks(pin)
 	_check_tilesets(pin)
 	_check_roofs(pin)
+	_check_special_palettes(pin)
 	_check_object_movement(pin)
 
 
@@ -407,6 +408,87 @@ func _roof_palettes(pin: String) -> Array:
 		var out: Array = []
 		for group: int in packed.size() / 4:
 			out.append(packed.slice(group * 4, group * 4 + 4))
+		return out
+	)
+
+
+## `LoadSpecialMapPalette`'s six sets against the pin's own `.pal` files, with
+## `.ice_path`'s INDOOR exemption. `mansion_2` goes over PAL_BG_YELLOW,
+## `mansion_1`'s seventh over PAL_BG_WATER and its ninth over PAL_BG_ROOF.
+const SPECIAL_PALETTE_FILES: Dictionary = {
+	0x15: "pokecom_center", 0x16: "battle_tower_inside", 0x1D: "ice_path",
+	0x05: "house", 0x1B: "radio_tower", 0x0D: "mansion_1",
+}
+
+
+func _check_special_palettes(pin: String) -> void:
+	var crystal: bool = _r.game_id == &"crystal"
+	var compared: int = 0
+	for tileset: int in RomLayout.SPECIAL_PALETTE_TILESETS:
+		var ours: Array = _r.data.special_map_palettes(tileset, 0)
+		if not crystal:
+			_r.check(
+				ours.is_empty(),
+				"tileset %d has a special palette, which is Crystal's alone." % tileset
+			)
+			continue
+		var pinned: Array = _special_palette(pin, tileset)
+		if pinned.is_empty():
+			_report("the pin carries no palette for tileset %d." % tileset)
+			continue
+		if ours.size() != 8:
+			_report("tileset %d has %d special palettes, 8 expected." % [tileset, ours.size()])
+			continue
+		for slot: int in 8:
+			var colors: PackedColorArray = ours[slot]
+			for color: int in 4:
+				var want: Color = Gen2Palette.from_packed(int((pinned[slot] as Array)[color]))
+				if not colors[color].is_equal_approx(want):
+					_report("tileset %d %s colour %d is %s, the pin says %s." % [
+						tileset, BG_PALETTES[slot], color, colors[color], want,
+					])
+			compared += 1
+	if crystal:
+		_r.check(
+			_r.data.special_map_palettes(
+				RomLayout.SPECIAL_PALETTE_ICE_PATH,
+				RomLayout.SPECIAL_PALETTE_ENVIRONMENT_INDOOR
+			).is_empty(),
+			"the Hall of Fame's INDOOR ice path took the special palette."
+		)
+	_r.note("special map palettes: %d slots compared." % compared)
+
+
+func _special_palette(pin: String, tileset: int) -> Array:
+	var read: Array = _packed_palette(pin, String(SPECIAL_PALETTE_FILES[tileset]))
+	if tileset != RomLayout.SPECIAL_PALETTE_MANSION or read.size() < 9:
+		return read.slice(0, 8) if read.size() >= 8 else []
+	var yellow: Array = _packed_palette(pin, "mansion_2")
+	if yellow.is_empty():
+		return []
+	var out: Array = read.slice(0, 8)
+	out[RomLayout.PAL_BG_YELLOW] = yellow[0]
+	out[RomLayout.PAL_BG_WATER] = read[6]
+	out[RomLayout.PAL_BG_ROOF] = read[8]
+	return out
+
+
+func _packed_palette(pin: String, name: String) -> Array:
+	return _parsed(pin, StringName("special_palette_%s" % name), func() -> Array:
+		var packed: Array = []
+		for line: String in _lines(pin.path_join("gfx/tilesets/%s.pal" % name)):
+			if not line.begins_with("RGB "):
+				continue
+			var fields: PackedStringArray = _fields(line)
+			for index: int in range(0, fields.size() - 2, 3):
+				packed.append(
+					_number(fields[index])
+					| (_number(fields[index + 1]) << 5)
+					| (_number(fields[index + 2]) << 10)
+				)
+		var out: Array = []
+		for palette: int in packed.size() / 4:
+			out.append(packed.slice(palette * 4, palette * 4 + 4))
 		return out
 	)
 


### PR DESCRIPTION
`LoadMapPals` asks `LoadSpecialMapPalette` before anything else, and the carry it answers with skips the environment and time-of-day selection whole. Six tilesets carry eight fixed palettes instead: POKECOM_CENTER, BATTLE_TOWER_INSIDE, ICE_PATH, HOUSE, RADIO_TOWER and MANSION. None was built here, so those maps drew with the indoor or cave row and the Ice Path's floor came out the cave row's green.

## Fixed
- The six sets are imported into the palette groups and read through `Gen2WorldPalette.tile_palettes`, the seam every map's colours go through.
- `LoadMansionPalette`'s three extra writes are folded in at import: `mansion_2` over PAL_BG_YELLOW, `mansion_1`'s seventh over PAL_BG_WATER and its ninth over PAL_BG_ROOF.
- `.ice_path`'s `cp INDOOR` keeps the Hall of Fame, which shares the tileset, on the ordinary selection.

## Added
- `tools/checks/map_data.gd` compares all 48 slots against the pin's own `.pal` files on every cartridge, and checks that Gold and Silver take none: their `LoadMapPals` has no such call in front of it.

## Changed
- Cache format 101, so all three cartridges need importing again.
- Roof and overworld palette decoding share one run reader, which is what `ROOF_PALETTE_BYTES` was for.

Unit tier 3604 passing, `validate.gd -- all` green over 84 topics, warning scan 0 over 608 scripts.