### PR TITLE
Fishing drew a standing player, and a caught dex page had a button row

### DIFF
--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 101
+const FORMAT_VERSION: int = 102
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -2692,6 +2692,9 @@ const GOLD_SILVER: Dictionary = {
 	## located by their own bytes, which occur once per dump.
 	"heal_machine_gfx": 0x127D5,
 	"heal_machine_palette": 0x12828,
+	## `LoadFishingGFX`'s sheet, and no Kris here to pick a second one.
+	"chris_fish_gfx": 0x50580,
+	"kris_fish_gfx": -1,
 	"mart_table": 0x162FE,
 	"default_mart": 0x16469,
 	"bargain_mart": 0x15EDA,
@@ -3284,6 +3287,9 @@ const CRYSTAL: Dictionary = {
 	"cut_grass_gfx": 0x8C9CC,
 	"heal_machine_gfx": 0x123FC,
 	"heal_machine_palette": 0x12451,
+	## `LoadFishingGFX` picks between the two on `PLAYERGENDER_FEMALE_F`.
+	"chris_fish_gfx": 0xB84F2,
+	"kris_fish_gfx": 0xB8582,
 	"mart_table": 0x160A9,
 	"default_mart": 0x16214,
 	"bargain_mart": 0x15C51,

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -16,10 +16,6 @@ const BGEVENT_IFNOTSET: int = 6
 ## which is [method _collect_conditional_bg_script]'s job.
 const BGEVENT_SCRIPT_TYPES: Array[int] = [0, 1, 2, 3, 4]
 
-## Imports the map table, map attributes, map events, tileset tables, overworld
-## object graphics and addressable overworld tile strips for a verified
-## Generation 2 cartridge.
-##
 ## Follows the official map macros and the runtime collision lookup: map blocks
 ## are 4x4 graphics tiles, walk coordinates 2x2 cells per block, and collision
 ## bytes use x as the low bit and y as the high bit.
@@ -621,6 +617,12 @@ const FIELD_MOVE_SHEETS: Array = [
 	## `HealMachineAnim.LoadGFX`'s two tiles at `vTiles0 tile $7c`: the machine's
 	## own bar and one ball. Both tiles are the signature, since a two-tile sheet
 	## whose first row is blank pins nothing on its own.
+	## `LoadFishingGFX`'s eight tiles: the lower half of standing down, up and
+	## left, which it writes over $02, $06 and $0a, and the rod pair at $fc.
+	["chris_fish", "chris_fish_gfx", 8, 0x02,
+		[0x3F, 0x32, 0x0F, 0x08, 0x17, 0x1F, 0x17, 0x1F]],
+	["kris_fish", "kris_fish_gfx", 8, 0x02,
+		[0x9F, 0xF2, 0x7F, 0x78, 0x1F, 0x1F, 0x17, 0x1F]],
 	["heal_machine", "heal_machine_gfx", 2, 0x7C,
 		[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7E, 0x00,
 		0x7E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -671,6 +673,8 @@ static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Diction
 		var offset: int = int(layout.get(String(sheet[1]), -1))
 		var sheet_tiles: int = int(sheet[2])
 		var signature: Array = sheet[4]
+		if offset == -1: # Kris's sheet, which only Crystal ships.
+			continue
 		if not rom.in_bounds(offset, sheet_tiles * Gen2Tiles.TILE_BYTES):
 			return _error("%s graphics are outside the cartridge." % name)
 		if Array(rom.slice(offset, signature.size())) != signature:

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -395,7 +395,8 @@ func results_window_map(rows: Array) -> PackedInt32Array:
 ## not been caught keeps the placeholder height and weight the background draws,
 ## which is what the source's early `ret z` leaves on screen.
 func entry_map(
-	number: int, name: String, entry: Dictionary, caught: bool, page: int, cursor: int
+	number: int, name: String, entry: Dictionary, caught: bool, page: int, cursor: int,
+	menu_row: bool = true
 ) -> PackedInt32Array:
 	_unown_letters = false
 	var map: PackedInt32Array = blank_map()
@@ -411,7 +412,9 @@ func entry_map(
 	_put(map, 17, 7, HEIGHT_INCHES)
 	_text(map, 9, 9, "WT   ???lb")
 	_put(map, 0, 17, SELECT_OPTION[0])
-	_text(map, 1, 17, " PAGE AREA CRY PRNT")
+	## `_NewPokedexEntry` spaces over the rest of row 17: no button row, no cursor.
+	if menu_row:
+		_text(map, 1, 17, " PAGE AREA CRY PRNT")
 	_place_pic_corner(map, 1, 1)
 
 	_text(map, 9, 3, name)
@@ -438,7 +441,7 @@ func entry_map(
 	var body: String = String(pages[page]) if page < pages.size() else ""
 	_paragraph(map, 2, 11, body)
 	_place_footprint_cells(map)
-	if cursor >= 0 and cursor < Gen2PokedexScreen.ENTRY_BUTTONS.size():
+	if menu_row and cursor >= 0 and cursor < Gen2PokedexScreen.ENTRY_BUTTONS.size():
 		_put(map, ENTRY_CURSOR_COLUMNS[cursor], 17, CURSOR_CODE)
 	return map
 
@@ -748,9 +751,7 @@ func _blit_object(
 ## species' box is drawn with: `LoadQuestionMarkPic` decompresses
 ## `gfx/pokedex/question_mark.2bpp.lz` and copies its 7 * 7 tiles into the pic
 ## slot, column major like every pic and drawn through the dex's own
-## `question_mark` palette. Not `PokedexSlowpokeLZ`, which this used to draw:
-## that is a different asset, five Slowpoke reading a book decompressed to
-## `vTiles0` for the search screen and the listing's objects.
+## `question_mark` palette. `PokedexSlowpokeLZ` is a different asset.
 func unseen_pic() -> Image:
 	if _question_mark.is_empty() or _question_mark_palette.size() != Gen2Palette.COLORS_PER_PIC:
 		return null

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -223,12 +223,10 @@ func _handle_list(button: int) -> bool:
 ## so A always turns the page rather than moving a cursor along a row whose
 ## other three entries would refuse.
 func _handle_entry(button: int) -> bool:
+	if _entry_only:
+		return _handle_new_entry(button)
 	match button:
 		Gen2Button.B:
-			## `NewPokedexEntry` has no listing under it, so B is what closes it.
-			if _entry_only:
-				closed.emit()
-				return true
 			## `wPrevDexEntryJumptableIndex`, which `Pokedex_UpdateMainScreen`
 			## and `Pokedex_UpdateSearchResultsScreen` each write before they
 			## open an entry: B goes back to whichever listing that was, not
@@ -256,6 +254,19 @@ func _handle_entry(button: int) -> bool:
 				_refresh()
 			return true
 	return false
+
+
+## `NewPokedexEntry` runs no jumptable: `WaitPressAorB_BlinkCursor`, page 2, that
+## wait again. A and B are one button and nothing else does anything.
+func _handle_new_entry(button: int) -> bool:
+	if button != Gen2Button.A and button != Gen2Button.B:
+		return false
+	if _dex.page == Gen2Pokedex.PAGE_1:
+		_dex.toggle_page()
+		_refresh()
+		return true
+	closed.emit()
+	return true
 
 
 ## `DexEntryScreen_MenuActionJumptable`. `.Print` needs a printer and does
@@ -603,7 +614,8 @@ func _render_entry_image(cursor: int) -> Image:
 	return _page.image(_page.entry_map(
 		species, String(entry["name"]), _data.dex_entry(species),
 		bool(entry["caught"]), int(entry["page"]),
-		_entry_cursor if cursor == 0 else -1
+		_entry_cursor if cursor == 0 else -1,
+		not _entry_only
 	), _selected_pic())
 
 

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -128,16 +128,26 @@ const CUT_LEAF_RADIUS_BASE: int = 0x0400
 ## `.OAMData_Leaf`'s single `dbsprite -1, -1, 4, 4`.
 const CUT_LEAF_OFFSET := Vector2i(-4, -4)
 
-## The rod tile `FacingFishDown` and its three siblings add to the player's own
-## four, in Gen2WorldSprite's DOWN, UP, LEFT, RIGHT order: offset, which of the
-## two rod tiles, and whether it is mirrored. The player picture itself is the
-## standing one, so the rod is the whole difference.
+## The rod `FacingFishDown` and its three siblings add to the player's own four,
+## in Gen2WorldSprite's DOWN, UP, LEFT, RIGHT order: offset, which tile of the
+## gender's sheet, and whether it is mirrored. Down and up hang $fc, the sides $fd.
 const FISHING_ROD_TILES: Array = [
-	{"offset": Vector2i(0, 16), "tile": 0, "flip_x": false},
-	{"offset": Vector2i(0, -8), "tile": 0, "flip_x": false},
-	{"offset": Vector2i(-8, 5), "tile": 1, "flip_x": true},
-	{"offset": Vector2i(16, 5), "tile": 1, "flip_x": false},
+	{"offset": Vector2i(0, 16), "tile": 6, "flip_x": false},
+	{"offset": Vector2i(0, -8), "tile": 6, "flip_x": false},
+	{"offset": Vector2i(-8, 5), "tile": 7, "flip_x": true},
+	{"offset": Vector2i(16, 5), "tile": 7, "flip_x": false},
 ]
+
+## The other six, written over the player's own $02, $06 and $0a: a fishing player
+## is the standing top half and these, and right mirrors left and swaps its cells.
+const FISHING_BODY_TILES: Array = [
+	[{"tile": 0, "flip_x": false}, {"tile": 1, "flip_x": false}],
+	[{"tile": 2, "flip_x": false}, {"tile": 3, "flip_x": false}],
+	[{"tile": 4, "flip_x": false}, {"tile": 5, "flip_x": false}],
+	[{"tile": 5, "flip_x": true}, {"tile": 4, "flip_x": true}],
+]
+
+const FISHING_SHEETS: Array[String] = ["chris_fish", "kris_fish"]
 
 
 ## `MovementFunction_Shadow`: y offset 14 along the axis the jump is on and 12

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -1,13 +1,11 @@
 class_name Gen2WorldRenderer
 extends Node2D
 
-## Draws the visible map page and the development player marker in hardware
-## pixels. It does not own map state; call [method set_world] when the API changes
-## or [method refresh] after a movement. The surface is the cartridge's 160x144
-## unless the world has been given a larger [member Gen2WorldAPI.view_pixels], in
-## which case the map fills all of it: the connected maps the graph places around
-## this one are drawn as well, on [Gen2WorldMapLayer] quads under the sprites, and
-## the border block fills whatever no map covers.
+## Draws the visible map page in hardware pixels. The surface is the cartridge's
+## 160x144 unless the world has been given a larger
+## [member Gen2WorldAPI.view_pixels], in which case the connected maps the graph
+## places around this one are drawn too, on [Gen2WorldMapLayer] quads under the
+## sprites, and the border block fills whatever no map covers.
 
 const PLAYER_COLOR: Color = Color("#d34a5a")
 const FALLBACK_BACKGROUND: Color = Color("#f5f1d8")
@@ -869,7 +867,8 @@ func _draw_player(background: Vector2) -> Vector2:
 		## `disappear PLAYER` takes object zero out of OAM.
 		return player
 	if player_texture != null:
-		draw_texture(player_texture, player + jump)
+		if not (_world.fishing_busy() and _draw_fishing_body(player_texture, player + jump)):
+			draw_texture(player_texture, player + jump)
 		if _in_grass(_world.player_cell):
 			_draw_grass_over(player + jump, background)
 		if _world.fishing_busy():
@@ -1150,17 +1149,49 @@ func _build_priority_atlas() -> void:
 	)
 
 
-## `FacingFishDown` and its three siblings: the standing player plus one tile of
-## the rod sheet, which is what `Script_FishCastRod`'s `fish_cast_rod` puts up
-## and `PutTheRodAway` takes down.
+func _fishing_sheet() -> Dictionary:
+	var sheet: Dictionary = _effect_sheet(
+		Gen2WorldEffects.FISHING_SHEETS[1 if _world.player_female() else 0]
+	)
+	return sheet if not sheet.is_empty() \
+		else _effect_sheet(Gen2WorldEffects.FISHING_SHEETS[0])
+
+
+## `LoadFishingGFX` replaces the player's own lower half, so the standing picture
+## is drawn to the waist and the sheet's pair finishes it.
+func _draw_fishing_body(player_texture: Texture2D, pixel: Vector2) -> bool:
+	var sheet: Dictionary = _fishing_sheet()
+	if sheet.is_empty():
+		return false
+	var size: Vector2 = player_texture.get_size()
+	var half: float = size.y * 0.5
+	draw_texture_rect_region(
+		player_texture, Rect2(pixel, Vector2(size.x, half)),
+		Rect2(Vector2.ZERO, Vector2(size.x, half))
+	)
+	var facing: int = clampi(
+		_world.player_facing, 0, Gen2WorldEffects.FISHING_BODY_TILES.size() - 1
+	)
+	var pair: Array = Gen2WorldEffects.FISHING_BODY_TILES[facing]
+	for cell: int in pair.size():
+		var tile: Dictionary = pair[cell]
+		_draw_effect_tile(
+			sheet, int(tile["tile"]), _world.player_palette(), bool(tile["flip_x"]),
+			pixel + Vector2(cell * Gen2Tiles.TILE_WIDTH, half)
+		)
+	return true
+
+
+## `FacingFishDown` and its three siblings: one more tile of the same sheet, put
+## up by `Script_FishCastRod`. Part of the facing, so it wears the player's palette.
 func _draw_fishing_rod(pixel: Vector2) -> void:
-	var sheet: Dictionary = _effect_sheet("rod")
+	var sheet: Dictionary = _fishing_sheet()
 	if sheet.is_empty():
 		return
 	var facing: int = clampi(_world.player_facing, 0, Gen2WorldEffects.FISHING_ROD_TILES.size() - 1)
 	var tile: Dictionary = Gen2WorldEffects.FISHING_ROD_TILES[facing]
 	_draw_effect_tile(
-		sheet, int(tile["tile"]), Gen2WorldEffects.PAL_OW_EMOTE, bool(tile["flip_x"]),
+		sheet, int(tile["tile"]), _world.player_palette(), bool(tile["flip_x"]),
 		pixel + Vector2(tile["offset"] as Vector2i),
 	)
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -2229,8 +2229,12 @@ func test_the_new_dex_page_takes_the_press_that_closes_it() -> void:
 		"and drew on the fight's own screen rather than under it"
 	)
 
+	## `NewPokedexEntry` is two `WaitPressAorB_BlinkCursor` waits either side of
+	## page 2, so the first press turns the page and the second closes it.
 	_world_screen.press_button(Gen2Button.B)
-	assert_null(_world_screen.get("_pokedex_host"), "and the page took the press")
+	assert_not_null(_world_screen.get("_pokedex_host"), "the first press is page 2")
+	_world_screen.press_button(Gen2Button.B)
+	assert_null(_world_screen.get("_pokedex_host"), "and the second took the page down")
 	for _frame: int in 1200:
 		if host.get("_capture_nickname_host") != null:
 			break

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -639,6 +639,32 @@ func test_the_entry_screen_prints_its_measurements_only_once_caught() -> void:
 	)
 
 
+## `_NewPokedexEntry` blanks row 17 over `.MenuItems`, so a page a catch opened
+## carries the border tile alone and no cursor.
+func test_a_caught_entry_page_has_no_menu_row() -> void:
+	var page: Gen2PokedexPage = _page()
+	var entry: Dictionary = _data.dex_entry(211)
+	var listed: PackedInt32Array = page.entry_map(
+		211, "MON211", entry, true, Gen2Pokedex.PAGE_1, 0
+	)
+	var caught: PackedInt32Array = page.entry_map(
+		211, "MON211", entry, true, Gen2Pokedex.PAGE_1, 0, false
+	)
+	assert_eq(_cell(listed, 0, 17), Gen2PokedexPage.SELECT_OPTION[0])
+	assert_eq(_cell(caught, 0, 17), Gen2PokedexPage.SELECT_OPTION[0])
+	assert_eq(_cell(listed, 2, 17), Gen2Text.encode("P")[0], "PAGE")
+	assert_eq(_cell(caught, 2, 17), Gen2PokedexPage.CURSOR_BLANK, "blanked")
+	assert_eq(
+		_cell(listed, Gen2PokedexPage.ENTRY_CURSOR_COLUMNS[0], 17),
+		Gen2PokedexPage.CURSOR_CODE,
+	)
+	assert_eq(
+		_cell(caught, Gen2PokedexPage.ENTRY_CURSOR_COLUMNS[0], 17),
+		Gen2PokedexPage.CURSOR_BLANK,
+		"no cursor to blink along a row that is not there",
+	)
+
+
 ## `Pokedex_DrawOptionScreenBG` draws the fourth row only once
 ## `wUnlockedUnownMode` is set, and the box under it carries whichever message
 ## the screen last asked for.

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -648,3 +648,26 @@ func test_the_flight_sound_follows_the_frame_counter() -> void:
 
 func _fly_offset(effects: Gen2WorldEffects) -> Vector2i:
 	return (effects.sprites()[0]["tiles"][0] as Dictionary)["offset"]
+
+
+## `FacingFishDown` and its three siblings, whose eight tiles are the whole of
+## `LoadFishingGFX`'s sheet: $02, $06 and $0a are the lower half of standing down,
+## up and left, and $fc and $fd are the rod. Right mirrors the left pair and swaps
+## the two cells, which is the only place the sheet is read out of order.
+func test_the_fishing_facings_name_their_own_sheet() -> void:
+	var body: Array = Gen2WorldEffects.FISHING_BODY_TILES
+	assert_eq(body.size(), 4)
+	for facing: int in body.size():
+		var pair: Array = body[facing]
+		assert_eq(pair.size(), 2, "one 8x8 cell either side of the waist")
+		for cell: Dictionary in pair:
+			assert_true(int(cell["tile"]) < 6, "the rod pair is not part of the body")
+	assert_eq(int((body[3][0] as Dictionary)["tile"]), 5, "right takes left's second cell")
+	assert_true(bool((body[3][1] as Dictionary)["flip_x"]), "and mirrors both of them")
+
+	var rod: Array = Gen2WorldEffects.FISHING_ROD_TILES
+	assert_eq(int((rod[0] as Dictionary)["tile"]), 6, "$fc hangs below")
+	assert_eq((rod[1] as Dictionary)["offset"], Vector2i(0, -8), "and above")
+	assert_eq(int((rod[2] as Dictionary)["tile"]), 7, "$fd reaches sideways")
+	assert_true(bool((rod[2] as Dictionary)["flip_x"]))
+	assert_false(bool((rod[3] as Dictionary)["flip_x"]))

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -17,8 +17,10 @@ const EXPECTED: Array = [
 	["heart", 4, 0xF8], ["bolt", 4, 0xF8], ["sleep", 4, 0xF8], ["fish", 4, 0xF8],
 	["shadow", 1, 0xFC], ["rod", 2, 0xFC], ["boulder_dust", 2, 0xFE],
 	["grass_rustle", 1, 0xFE], ["headbutt_tree", 8, 0x84], ["cut_tree", 4, 0x84],
-	["cut_grass", 4, 0x80], ["heal_machine", 2, 0x7C],
+	["cut_grass", 4, 0x80], ["heal_machine", 2, 0x7C], ["chris_fish", 8, 0x02],
 ]
+
+const CRYSTAL_ONLY: Array = [["kris_fish", 8, 0x02]]
 
 ## `gfx/overworld/heal_machine.pal`, the one sheet that carries a palette of its
 ## own instead of wearing an overworld one: `RGB 31, 31, 31`, `RGB 31, 19, 10`,
@@ -37,7 +39,10 @@ func run(r: RefCounted) -> void:
 
 func _check_game() -> void:
 	var lit: int = 0
-	for row: Array in EXPECTED:
+	var expected: Array = EXPECTED.duplicate()
+	if Gen2WorldState.is_crystal_profile(_r.data):
+		expected.append_array(CRYSTAL_ONLY)
+	for row: Array in expected:
 		var name: String = String(row[0])
 		var sheet: Dictionary = _r.data.overworld_effect(name)
 		if not _r.check(not sheet.is_empty(), "the %s sheet is not in the cache." % name):
@@ -90,4 +95,4 @@ func _check_game() -> void:
 					)
 		else:
 			_r.check(colors.is_empty(), "%s carries a palette it has no source for." % name)
-	_r.note("overworld effects: %d sheets, %d drawn pixels." % [EXPECTED.size(), lit])
+	_r.note("overworld effects: %d sheets, %d drawn pixels." % [expected.size(), lit])


### PR DESCRIPTION
Two findings from walking `engine/gfx/cgb_layouts.asm`, `engine/events/fishing_gfx.asm`, `engine/pokedex/new_pokedex_entry.asm`, `engine/events/odd_egg.asm`, `engine/events/buena_menu.asm`, `engine/events/bug_contest/display_stats.asm`, `engine/battle/link_result.asm`, `engine/rtc/restart_clock.asm`, `engine/gfx/load_font.asm` and `engine/events/catch_tutorial_input.asm`.

## Fixed

- `LoadFishingGFX` writes eight tiles over the player's own $02, $06 and $0a and the rod pair at $fc, so a fishing player is the standing top half and a fishing lower half. Neither `FishingGFX` nor `KrisFishingGFX` was imported here, so the player kept standing and the rod was drawn from `FishingRodGFX`, which the routine overwrites. Both sheets are imported now, Kris's on Crystal alone, and the rod wears the player's own palette rather than PAL_OW_EMOTE.
- `NewPokedexEntry` is `WaitPressAorB_BlinkCursor`, page 2 and the same wait again, and it spaces over row 17 so the PAGE/AREA/CRY/PRNT row is gone. A page a catch opened was running `Pokedex_UpdateDexEntryScreen` instead: B closed it before page 2 was ever shown, up and down walked to other species, and the button row stood under it with a cursor.

## Changed

- `RomCache.FORMAT_VERSION` 101 to 102 for the two new sheets. All three cartridges re-imported, `layout: Layout verified.` on each.
- `tools/checks/overworld_effects.gd` covers `chris_fish` on all three and `kris_fish` on Crystal, including the byte-identical cross-cartridge comparison.

| Check | Result |
|---|---|
| GUT, unit and scene tiers | 4213 tests, 78474 asserts, 0 failing |
| `tools/validate.gd -- all` | 84 topics PASS |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| `addons/warning_scan` | 0 warnings in 614 scripts |