### PR TITLE
Fix Lock-On timing and story replay reliability

### DIFF
--- a/game/battle/battle_anim_functions.gd
+++ b/game/battle/battle_anim_functions.gd
@@ -1636,6 +1636,7 @@ static func _lock_on_mind_reader(
 		object.var1 = 0x28
 		_reinit(object, (object.param & 0xF) + object.frameset)
 		object.param = (object.param & 0xF0) | 0x8
+		return
 	match object.jumptable_index:
 		1:
 			if object.var1 != 0:

--- a/tests/unit/test_battle_anim_functions.gd
+++ b/tests/unit/test_battle_anim_functions.gd
@@ -222,6 +222,23 @@ func test_sky_attack_cycles_the_dmg_object_palette() -> void:
 	assert_eq(_player.background().obp0, 0xA0, "$aa masked by the side's own byte")
 
 
+## `BattleAnimFunc_LockOnMindReader` returns after initializing the object, so
+## its first movement does not happen until the next frame.
+func test_lock_on_holds_its_spawn_position_for_the_first_frame() -> void:
+	var object: Gen2BattleAnimObject = _object(0x3E, 0x84, 0x30, 0x03)
+	_run(object)
+	assert_eq(object.jumptable_index, 1)
+	assert_eq(object.var1, 0x28)
+	assert_eq(object.param, 0x08)
+	assert_eq(object.x_offset, 0)
+	assert_eq(object.y_offset, 0)
+
+	_run(object)
+	assert_eq(object.var1, 0x27)
+	assert_ne(object.x_offset, 0)
+	assert_ne(object.y_offset, 0)
+
+
 ## `BattleAnimFunc_RockSmash` writes the frameset straight into the struct rather
 ## than through `ReinitBattleAnimFrameset`, so the frame it is on is not reset.
 func test_rock_smash_swaps_its_frameset_without_restarting_it() -> void:

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -166,9 +166,7 @@ func test_strength_active_flag_is_profile_split_and_is_not_a_badge() -> void:
 	assert_eq(state.badge_count(false), 0)
 
 
-## Nothing in the pinned engine/ or home/ ever clears BIKEFLAGS_STRENGTH_ACTIVE_F,
-## and engine flags serialize with the world snapshot, so the flag has to outlive
-## a round trip and the map-reload reset that clears temporary event flags.
+## Snapshots and MapSetupScript_ReloadMap do not run a warp's ResetBikeFlags.
 func test_strength_active_flag_survives_round_trip_and_map_reload() -> void:
 	var state := Gen2WorldState.new()
 	state.set_engine_flag(Gen2WorldState.strength_active_flag(true))

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -74,7 +74,7 @@ const HM07_APPROACH: Vector2i = Vector2i(30, 7)
 ## before Goldenrod are stocked in Violet and Dratini's far lower catch rate is
 ## answered with the cheapest ball Blackthorn does stock.
 const POKE_BALLS_BOUGHT: int = 5
-const GREAT_BALLS_BOUGHT: int = 3
+const GREAT_BALLS_BOUGHT: int = 20
 ## Both marts are the standard six-by-four interior: object 1 on (1,3), standing
 ## right behind the counter on (2,3), so the clerk is talked to from (3,3)
 ## facing left.
@@ -3809,13 +3809,26 @@ func _blackthorn_gym_leg(
 	data: GameData,
 	path: Array,
 ) -> Dictionary:
-	if not world.strength_active():
-		return {"ok": false, "path": path, "reason": "Strength is not active"}
 	var to_gym: Dictionary = _warp_chain(
 		world, save, random, data, [Vector2i(18, 11), Vector2i(1, 7)]
 	)
 	if not bool(to_gym.get("ok", false)):
 		return _leg_failed(path, "Blackthorn Gym 2F unreachable", to_gym)
+
+	var asked: Dictionary = _talk_to(
+		world, Vector2i(5, 1), Gen2WorldSprite.FACING_RIGHT, save, random, data
+	)
+	path.append({
+		"step": "blackthorn_gym_ask_strength",
+		"map": _map_value(world),
+		"cell": _cell_value(world),
+		"run": asked.get("run", {}),
+		"strength_active": world.strength_active(),
+	})
+	if not bool(asked.get("ok", false)):
+		return _leg_failed(path, "Blackthorn AskStrengthScript failed", asked)
+	if not world.strength_active():
+		return {"ok": false, "path": path, "reason": "Strength did not become active"}
 
 	for leg: Dictionary in BLACKTHORN_GYM_PUSHES:
 		var pushes: Array = []


### PR DESCRIPTION
## Summary

- preserve the source callback boundary after Lock-On and Mind Reader initialization
- add regression coverage for the first-frame spawn position
- reactivate Strength inside Blackthorn Gym after the door warp resets bike flags
- give the deterministic story route enough Great Balls for Crystal Dratini catches
- correct the related Strength state documentation

## Verification

- 3,607 unit tests passing
- all 278 battle animations validated for Gold, Silver, and Crystal
- 33-route record/replay matrix passing across all profiles
- full Gold, Silver, and Crystal story routes complete through Red
- 0 warnings across 614 analysed scripts
- release gates passing