### PR TITLE
Restore wild held item rolls

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -436,6 +436,7 @@ const BERSERK_GENE_CONFUSION_TURNS: int = 256
 ## `wBattleType`. Only the values `TryToRunAwayFromBattle` branches on are named;
 ## everything else reaches the ordinary speed check.
 const BATTLETYPE_NORMAL: int = 0
+const BATTLETYPE_FORCEITEM: int = 1
 const BATTLETYPE_DEBUG: int = 2
 ## The Dude's tutorial, which `PokeBallEffect` catches without a roll.
 const BATTLETYPE_TUTORIAL: int = 3

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -1,9 +1,8 @@
 class_name Gen2WorldBattleAdapter
 extends RefCounted
 
-## Scene-free preparation of the battle requests emitted by the overworld
-## script runner. The battle screen owns presentation and input; this boundary
-## only validates source identifiers and builds the existing battle model.
+## Scene-free preparation of overworld battle requests. The battle screen owns
+## presentation and input; this boundary builds the existing battle model.
 
 const OUTCOME_WON: StringName = &"won"
 const OUTCOME_LOST: StringName = &"lost"
@@ -14,8 +13,8 @@ const OUTCOME_CANCELLED: StringName = &"cancelled"
 ## `CheckMagikarpArea`'s two `cp`s, the same numbers in both pins.
 const GROUP_LAKE_OF_RAGE: int = 9
 const MAP_LAKE_OF_RAGE: int = 6
-## `HIGH(1536)`, `LOW(1616)`, `LOW(1600)` and `HIGH(1024)`, all read against a
-## length in feet and inches: the unit-conversion entry in the bug docs.
+## The four length bytes are read against feet and inches, reproducing the
+## source's unit-conversion bug.
 const MAGIKARP_HUGE_FEET: int = 6
 const MAGIKARP_HUGE_INCHES: int = 80
 const MAGIKARP_LARGE_INCHES: int = 64
@@ -23,6 +22,8 @@ const MAGIKARP_FLOOR_FEET: int = 4
 const MAGIKARP_HUGE_SKIP: int = 12
 const MAGIKARP_LARGE_SKIP: int = 50
 const MAGIKARP_FLOOR_SKIP: int = 100
+const WILD_ITEM_NONE_ROLL: int = 192
+const WILD_ITEM_RARE_ROLL: int = 20
 
 
 static func prepare(
@@ -132,9 +133,11 @@ static func _wild_party(
 		return _failure(&"invalid_wild_species", {"species": species})
 	if level < 1 or level > Gen2Experience.MAX_LEVEL:
 		return _failure(&"invalid_wild_level", {"level": level})
+	var species_data: Dictionary = data.species(species)
+	var held_item: int = _wild_held_item(species_data, battle_type, generator)
 	var wild_mon: Gen2BattleMon = Gen2BattleMon.create(
 		data, species, level, data.moves_at_level(species, level),
-		wild_dvs(values, battle_type, species, generator)
+		wild_dvs(values, battle_type, species, generator), {}, held_item
 	)
 	# LoadEnemyMon's .TreeMon branch: a headbutt encounter whose species is in
 	# CheckSleepingTreeMon's list for the current time of day enters asleep for
@@ -151,6 +154,21 @@ static func _wild_party(
 	if wild_mon != null and int(values.get("hp", 0)) > 0:
 		wild_mon.hp = clampi(int(values["hp"]), 1, wild_mon.max_hp())
 	return {"ok": true, "party": Gen2Party.of(wild_mon)}
+
+
+## `LoadEnemyMon.WildItem`: 75% none, 23% common and 2% rare, before the DV
+## bytes. A force-item encounter takes the common slot without a roll.
+static func _wild_held_item(
+	species_data: Dictionary, battle_type: int, generator: RandomNumberGenerator
+) -> int:
+	var held: Array = species_data.get("held_items", []) as Array
+	var common: int = int(held[0]) if held.size() > 0 else 0
+	if battle_type == Gen2Battle.BATTLETYPE_FORCEITEM:
+		return common
+	if generator.randi_range(0, 255) < WILD_ITEM_NONE_ROLL:
+		return 0
+	var rare: int = int(held[1]) if held.size() > 1 else 0
+	return rare if generator.randi_range(0, 255) < WILD_ITEM_RARE_ROLL else common
 
 
 static func earnings(battle: Gen2Battle, state: Gen2WorldState, won: bool) -> Dictionary:
@@ -279,13 +297,9 @@ static func _magikarp_accepted(
 	return length.x >= MAGIKARP_FLOOR_FEET
 
 
-## `PlayBattleMusic`'s track, off the request alone.
-##
-## `FindFirstAliveMonAndStartBattle` runs `PlayBattleMusic` in front of
-## `DoBattleTransition`, so the piece starts before the fight is built: the
-## world screen asks here when the transition opens and the battle screen asks
-## again for the same track, which the driver continues rather than restarts.
-## Both read the one request, so neither can pick a different piece.
+## `FindFirstAliveMonAndStartBattle` plays this request's track before the
+## transition. The world and battle screens ask for the same track, so the
+## driver continues it across the handoff.
 static func music_for(
 	request: Dictionary, landmark_id: int, day_period: int, crystal: bool = true
 ) -> int:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37774
+const MAX_COMMENT_LINES: int = 37772
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -30,7 +30,7 @@ func _write_cache() -> void:
 			"stats": {"hp": 50, "attack": 50, "defense": 50, "speed": 50,
 				"sp_attack": 50, "sp_defense": 50},
 			"types": [0, 0], "growth_rate": Gen2Experience.GROWTH_MEDIUM_FAST,
-			"base_exp": 50, "gender_ratio": 0,
+			"base_exp": 50, "gender_ratio": 0, "held_items": [0, 0],
 			"learnset": [{"level": 1, "move": TACKLE}],
 		},
 		{
@@ -38,7 +38,7 @@ func _write_cache() -> void:
 			"stats": {"hp": 60, "attack": 60, "defense": 60, "speed": 60,
 				"sp_attack": 60, "sp_defense": 60},
 			"types": [0, 0], "growth_rate": Gen2Experience.GROWTH_MEDIUM_FAST,
-			"base_exp": 60, "gender_ratio": 0,
+			"base_exp": 60, "gender_ratio": 0, "held_items": [17, 18],
 			"learnset": [{"level": 1, "move": TACKLE}],
 		},
 	])
@@ -86,6 +86,59 @@ func test_wild_request_builds_a_one_mon_enemy_party() -> void:
 	assert_false(prepared["trainer_battle"])
 	assert_eq((prepared["enemy_party"] as Gen2Party).size(), 1)
 	assert_eq((prepared["battle"] as Gen2Battle).enemy.species, SPECIES_TWO)
+
+
+## `LoadEnemyMon.WildItem` spends its item roll before the two DV bytes. Sweep
+## enough seeds to reach all three exits and compare the whole draw order.
+func test_a_wild_rolls_its_species_held_items_before_its_dvs() -> void:
+	var seen: Dictionary = {}
+	for seed_value: int in 2048:
+		var expected_rng := RandomNumberGenerator.new()
+		expected_rng.seed = seed_value
+		var first: int = expected_rng.randi_range(0, 255)
+		var expected_item: int = 0
+		if first >= Gen2WorldBattleAdapter.WILD_ITEM_NONE_ROLL:
+			expected_item = 18 \
+				if expected_rng.randi_range(0, 255) < Gen2WorldBattleAdapter.WILD_ITEM_RARE_ROLL \
+				else 17
+		var expected_dvs: int = (
+			expected_rng.randi_range(0, 255) << 8
+		) | expected_rng.randi_range(0, 255)
+
+		var actual_rng := RandomNumberGenerator.new()
+		actual_rng.seed = seed_value
+		var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+			_data, {"values": {"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5}},
+			_player_party(), actual_rng
+		)
+		assert_true(prepared["ok"])
+		var wild: Gen2BattleMon = (prepared["battle"] as Gen2Battle).enemy
+		assert_eq(wild.item, expected_item)
+		assert_eq(wild.dvs, expected_dvs)
+		seen[expected_item] = true
+		if seen.size() == 3:
+			break
+	assert_eq(seen.size(), 3, "none, common and rare all occur")
+
+
+func test_a_force_item_wild_takes_item_one_without_spending_a_roll() -> void:
+	var expected_rng := RandomNumberGenerator.new()
+	expected_rng.seed = 91
+	var expected_dvs: int = (
+		expected_rng.randi_range(0, 255) << 8
+	) | expected_rng.randi_range(0, 255)
+	var actual_rng := RandomNumberGenerator.new()
+	actual_rng.seed = 91
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {
+			"kind": &"wild", "pokemon": SPECIES_TWO, "level": 5,
+			"battle_type": Gen2Battle.BATTLETYPE_FORCEITEM,
+		}}, _player_party(), actual_rng
+	)
+	assert_true(prepared["ok"])
+	var wild: Gen2BattleMon = (prepared["battle"] as Gen2Battle).enemy
+	assert_eq(wild.item, 17)
+	assert_eq(wild.dvs, expected_dvs)
 
 
 func test_battle_request_carries_the_players_badge_mask() -> void:

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -39,6 +39,7 @@ func run(r: RefCounted) -> void:
 		_verify_gate_errand()
 		_census()
 		_verify_wild_patch_indices()
+		_verify_wild_held_items()
 		_verify_rolled_dvs()
 		_verify_magikarp_filter()
 		_verify_roaming_walk()
@@ -134,6 +135,34 @@ const DV_SWEEP_WILDS: int = 4096
 ## for not being UNOWN, whose letter gate is swept separately below.
 const DV_SWEEP_SPECIES: int = 19
 const DV_SWEEP_LEVEL: int = 5
+
+
+## Every species' two base item slots through `LoadEnemyMon.WildItem`.
+func _verify_wild_held_items() -> void:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 20260926
+	var rolled: int = 0
+	for species: int in range(1, RomLayout.SPECIES_COUNT + 1):
+		var row: Dictionary = _r.data.species(species)
+		var held: Array = row.get("held_items", []) as Array
+		if not _r.check(held.size() == 2, "species %d has %d held-item slots." % [species, held.size()]):
+			continue
+		var allowed: Array[int] = [0, int(held[0]), int(held[1])]
+		_r.check(
+			Gen2WorldBattleAdapter._wild_held_item(
+				row, Gen2Battle.BATTLETYPE_FORCEITEM, generator
+			) == int(held[0]),
+			"species %d did not force its first held item." % species
+		)
+		for _sample: int in 32:
+			var item: int = Gen2WorldBattleAdapter._wild_held_item(
+				row, Gen2Battle.BATTLETYPE_NORMAL, generator
+			)
+			_r.check(item in allowed, "species %d rolled item %d." % [species, item])
+			rolled += 1
+	_r.note("wild held items: %d species, %d ordinary rolls" % [
+		RomLayout.SPECIES_COUNT, rolled,
+	])
 
 
 ## `LoadEnemyMon`'s `.InitDVs` against the real caches, where before only a


### PR DESCRIPTION
## Summary

- roll each wild Pokémon’s held item from its species slots before generating DVs
- support forced-item encounters without consuming a random draw
- sweep all 251 species across Gold, Silver, and Crystal caches

## Verification

- 3,609 unit tests
- all real-cache validation topics
- 33 deterministic replay routes at replay, 30 fps, and 144 fps
- full Gold, Silver, and Crystal story walks
- 0 warnings in 614 analyzed scripts
- release gates