### PR TITLE
Resume map music after cancelling an Unown print

### DIFF
--- a/game/world/unown_printer_screen.gd
+++ b/game/world/unown_printer_screen.gd
@@ -11,6 +11,7 @@ extends Control
 
 signal closed()
 signal music_requested(index: int)
+signal map_music_requested()
 
 const MUSIC_PRINTER: int = Gen2DiplomaScreen.MUSIC_PRINTER
 const STATUS_CONNECTION_ERROR: String = Gen2DiplomaScreen.STATUS_CONNECTION_ERROR
@@ -65,7 +66,7 @@ func handle_button(button: int) -> bool:
 		## `CheckCancelPrint` reads B alone, and the send never ends on its own.
 		if button == Gen2Button.B:
 			_printing = false
-			music_requested.emit(0)
+			map_music_requested.emit()
 			_refresh()
 		return true
 	match button:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2410,6 +2410,7 @@ func _open_unown_printer(request: Dictionary) -> bool:
 		return false
 	host.closed.connect(_on_unown_printer_closed)
 	host.music_requested.connect(_play_music_track)
+	host.map_music_requested.connect(_play_current_map_music)
 	_unown_printer_host = host
 	_apply_interface_mask()
 	_script_prompt = "Unown printer"

--- a/tests/unit/test_menu_page.gd
+++ b/tests/unit/test_menu_page.gd
@@ -175,6 +175,28 @@ func test_the_pokepic_box_refuses_a_species_the_cache_does_not_hold() -> void:
 	assert_null(Gen2PokepicPage.render(data, BattleFixture.CHARMANDER, null))
 
 
+## `PrintUnownStamp` restarts the map music when B cancels the printer send,
+## then returns to the browser rather than closing it.
+func test_cancelling_an_unown_print_restarts_the_map_music() -> void:
+	var screen := Gen2UnownPrinterScreen.new()
+	add_child_autofree(screen)
+	screen._open = true
+	screen.visible = true
+	var tracks: Array[int] = []
+	var restarts: Array[bool] = []
+	screen.music_requested.connect(func(track: int) -> void: tracks.append(track))
+	screen.map_music_requested.connect(func() -> void: restarts.append(true))
+
+	screen.handle_button(Gen2Button.A)
+	assert_eq(tracks, [Gen2UnownPrinterScreen.MUSIC_PRINTER])
+	assert_true(screen.printing())
+	screen.handle_button(Gen2Button.B)
+
+	assert_eq(restarts.size(), 1)
+	assert_false(screen.printing())
+	assert_true(screen.visible, "the browser stays open after the send is cancelled")
+
+
 ## `PlaceVerticalMenuItems` has no bound and needs none: every cartridge label is
 ## written to fit the box it is placed in. A label a mod registers is not, and
 ## unbounded it was drawn straight through the right-hand border and over


### PR DESCRIPTION
## Summary
- resume the current map track when an Unown printer send is cancelled
- keep the Unown browser open after the cancelled send
- cover the printer-to-map music handoff with a regression test

## Verification
- 3,610 unit tests
- all real-cache validation topics
- 33 replay routes at replay, 30 fps and 144 fps
- full Gold, Silver and Crystal story walks
- 0 warnings in 614 analysed scripts
- release gates