### PR TITLE
Fix Battle Tower trainer policy

### DIFF
--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -189,7 +189,7 @@ static func choose_action(
 		if bool(switch["switch"]):
 			return Gen2Battle.switch_to(int(switch["index"]))
 
-	if not battle.enemy_items.is_empty() \
+	if not battle.in_battle_tower and not battle.enemy_items.is_empty() \
 			and Gen2AIItems.is_highest_level(battle.party(Gen2Battle.ENEMY)):
 		var item: int = Gen2AIItems.choose(
 			battle.mon(Gen2Battle.ENEMY), battle.enemy_items, item_switch_flags,
@@ -199,6 +199,17 @@ static func choose_action(
 			return Gen2Battle.use_item(item)
 
 	return Gen2Battle.use_move(move_slot)
+
+
+static func trainer_policy(data: GameData, trainer_class: int, battle_tower: bool) -> Dictionary:
+	var policy_class: int = 1 if battle_tower else trainer_class
+	if data == null or policy_class <= 0:
+		return {"move_weights": 0, "item_switch": 0}
+	var attributes: Dictionary = data.trainer_attributes(policy_class)
+	return {
+		"move_weights": int(attributes.get("ai_move_weights", 0)),
+		"item_switch": int(attributes.get("ai_item_switch", 0)),
+	}
 
 
 ## The two things that jump straight to `DontSwitch` without stopping the item

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -493,6 +493,8 @@ var rules: Gen2Rules = null
 ## encounter, which is the default, never sets it.
 var is_trainer_battle: bool = false
 
+var in_battle_tower: bool = false
+
 ## `wBattleType`, read by running alone so far and set on the world path by a
 ## `loadvar VAR_BATTLETYPE` before `startbattle`.
 var battle_type: int = BATTLETYPE_NORMAL

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -3402,11 +3402,10 @@ func _random_slot(side: int) -> int:
 func _enemy_slot() -> int:
 	if _enemy_trainer_class == 0:
 		return _random_slot(Gen2Battle.ENEMY)
-	# The class's own imported mask under every challenge but hard, which scores
-	# with every layer rather than inventing a level or a stat.
-	var weights: int = _rules().ai_move_weights(
-		int(_data.trainer_attributes(_enemy_trainer_class).get("ai_move_weights", 0))
+	var policy: Dictionary = Gen2BattleAI.trainer_policy(
+		_data, _enemy_trainer_class, _battle.in_battle_tower
 	)
+	var weights: int = _rules().ai_move_weights(int(policy["move_weights"]))
 	return Gen2BattleAI.choose_slot(
 		_battle.mon(Gen2Battle.ENEMY), _battle.mon(Gen2Battle.PLAYER), _data, weights, _rng,
 		_battle.mon(Gen2Battle.ENEMY).turns_taken, _battle.mon(Gen2Battle.PLAYER).turns_taken,
@@ -3437,11 +3436,10 @@ func _enemy_action() -> Dictionary:
 	var slot: int = _enemy_slot()
 	if _enemy_trainer_class == 0:
 		return Gen2Battle.use_move(slot)
-	## The class's own imported word under every challenge but hard, which moves
-	## each class onto SWITCH_OFTEN.
-	var flags: int = _rules().ai_item_switch(int(
-		_data.trainer_attributes(_enemy_trainer_class).get("ai_item_switch", 0)
-	))
+	var policy: Dictionary = Gen2BattleAI.trainer_policy(
+		_data, _enemy_trainer_class, _battle.in_battle_tower
+	)
+	var flags: int = _rules().ai_item_switch(int(policy["item_switch"]))
 	return Gen2BattleAI.choose_action(_battle, flags, slot, _rng)
 
 

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -102,6 +102,7 @@ static func prepare(
 	if battle == null:
 		return _failure(&"battle_setup_failed")
 	battle.battle_type = battle_type
+	battle.in_battle_tower = kind == &"battle_tower"
 	## `InitEnemyTrainer` belongs to setting the opponent up rather than to
 	## whoever draws the fight, so every host gets the class's two items, its
 	## gym-leader happiness and `ComputeTrainerReward` from one place. Only a

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -30,6 +30,25 @@ func _mon(species: int, level: int, moves: Array) -> Gen2BattleMon:
 	return Gen2BattleMon.create(_data, species, level, moves)
 
 
+func test_battle_tower_ai_uses_one_policy_and_never_an_item() -> void:
+	var falkner: Dictionary = _data.trainer_attributes(1)
+	var sampled_class: int = 2
+	var policy: Dictionary = Gen2BattleAI.trainer_policy(_data, sampled_class, true)
+	assert_eq(int(policy["move_weights"]), int(falkner["ai_move_weights"]))
+	assert_eq(int(policy["item_switch"]), int(falkner["ai_item_switch"]))
+
+	var player: Gen2BattleMon = _mon(Fixture.GEODUDE, 50, [Fixture.TACKLE])
+	var enemy: Gen2BattleMon = _mon(Fixture.PIKACHU, 50, [Fixture.TACKLE])
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data, Gen2Party.of(player), Gen2Party.of(enemy), _rng, true
+	)
+	battle.in_battle_tower = true
+	battle.enemy_items = [Gen2AIItems.FULL_RESTORE]
+	enemy.hp = 1
+	var action: Dictionary = Gen2BattleAI.choose_action(battle, 0, 0, _rng)
+	assert_eq(StringName(action["type"]), Gen2Battle.ACTION_MOVE)
+
+
 func test_types_discourages_a_move_the_defender_is_immune_to() -> void:
 	# Geodude is Rock/Ground, and this fixture's chart has Electric against
 	# Ground at x0: Thunderbolt does nothing, so Types has to prefer Tackle

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -18,7 +18,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37772
+const MAX_COMMENT_LINES: int = 37768
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -88,6 +88,23 @@ func test_wild_request_builds_a_one_mon_enemy_party() -> void:
 	assert_eq((prepared["battle"] as Gen2Battle).enemy.species, SPECIES_TWO)
 
 
+func test_a_battle_tower_request_marks_the_battle_for_its_ai_rules() -> void:
+	var opponent := Gen2SaveMon.new()
+	opponent.species = SPECIES_TWO
+	opponent.level = 5
+	opponent.moves = [TACKLE]
+	opponent.pp = [35]
+	opponent.hp = 10
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+		_data, {"values": {
+			"kind": &"battle_tower", "trainer_class": 1,
+			"enemy_party": [opponent.to_dict()],
+		}}, _player_party(), RandomNumberGenerator.new()
+	)
+	assert_true(bool(prepared["ok"]), String(prepared.get("reason", "")))
+	assert_true((prepared["battle"] as Gen2Battle).in_battle_tower)
+
+
 ## `LoadEnemyMon.WildItem` spends its item roll before the two DV bytes. Sweep
 ## enough seeds to reach all three exits and compare the whole draw order.
 func test_a_wild_rolls_its_species_held_items_before_its_dvs() -> void:


### PR DESCRIPTION
## Fixed

- Use Falkner's move-scoring and switch-policy attributes for every Battle Tower opponent, matching the tower's fixed policy while preserving the sampled trainer's identity.
- Prevent Battle Tower opponents from using trainer-class inventory items.
- Carry the Battle Tower context through world battle preparation and cover the live policy boundary with focused tests.

## Verified

- 3,612 unit tests, 68,826 assertions
- 127 focused trainer-policy tests and 19 world-battle tests
- 0 warnings across 614 analysed scripts
- All real-cache validation topics
- 33 deterministic replay routes, 0 failures
- Gold, Silver and Crystal story walks
- Launcher smoke tests with and without mods
- Release gates and source budget at 37,768 comment lines