### PR TITLE
Fix battle context rules and traded Pokemon obedience

### DIFF
--- a/addons/warning_scan/plugin.gd
+++ b/addons/warning_scan/plugin.gd
@@ -21,8 +21,7 @@ extends EditorPlugin
 ## Without the flag the plugin does nothing at all, so an ordinary editor session
 ## is untouched by it.
 ##
-## It costs what opening every script in the editor costs: this project's 566
-## take a few minutes and about three gigabytes, because `edit_script` adds a tab
+## A full sweep takes a few minutes and about three gigabytes: `edit_script` adds a tab
 ## per script and the editor exposes no way to close one. Name a directory rather
 ## than sweeping everything when only part of the tree moved.
 

--- a/game/battle/ai.gd
+++ b/game/battle/ai.gd
@@ -20,6 +20,7 @@ class Context extends RefCounted:
 	var atk_turns: int = 0
 	var def_turns: int = 0
 	var weather: int = Gen2Weather.NONE
+	var link_battle: bool = false
 	var attacker_screens: int = Gen2Screens.NONE
 	var defender_screens: int = Gen2Screens.NONE
 	var has_bench: bool = false
@@ -50,7 +51,8 @@ class Context extends RefCounted:
 		p_matchup_score: int = Gen2AISwitch.BASE_SCORE,
 		p_defender_has_bench: bool = false,
 		p_defender_used_moves: Array = [],
-		p_bench_status_mask: int = Gen2Status.NONE
+		p_bench_status_mask: int = Gen2Status.NONE,
+		p_link_battle: bool = false
 	) -> Context:
 		var out := Context.new()
 		out.attacker = p_attacker
@@ -67,6 +69,7 @@ class Context extends RefCounted:
 		out.defender_has_bench = p_defender_has_bench
 		out.defender_used_moves.assign(p_defender_used_moves)
 		out.bench_status_mask = p_bench_status_mask
+		out.link_battle = p_link_battle
 		return out
 
 
@@ -254,14 +257,15 @@ static func choose_slot(
 	matchup_score: int = Gen2AISwitch.BASE_SCORE,
 	defender_has_bench: bool = false,
 	defender_used_moves: Array = [],
-	bench_status_mask: int = Gen2Status.NONE
+	bench_status_mask: int = Gen2Status.NONE,
+	link_battle: bool = false
 ) -> int:
 	return _pick_lowest(
 		score_slots(
 			attacker, defender, data, ai_move_weights, rng,
 			attacker_turns_taken, defender_turns_taken, weather,
 			attacker_screens, defender_screens, has_bench, matchup_score,
-			defender_has_bench, defender_used_moves, bench_status_mask
+			defender_has_bench, defender_used_moves, bench_status_mask, link_battle
 		),
 		attacker, rng
 	)
@@ -285,7 +289,8 @@ static func score_slots(
 	matchup_score: int = Gen2AISwitch.BASE_SCORE,
 	defender_has_bench: bool = false,
 	defender_used_moves: Array = [],
-	bench_status_mask: int = Gen2Status.NONE
+	bench_status_mask: int = Gen2Status.NONE,
+	link_battle: bool = false
 ) -> Array:
 	var scores: Array = []
 	for slot: int in Gen2BattleMon.MAX_MOVES:
@@ -294,7 +299,7 @@ static func score_slots(
 	var context := Context.of(
 		attacker, defender, data, rng, attacker_turns_taken, defender_turns_taken,
 		weather, attacker_screens, defender_screens, has_bench, matchup_score,
-		defender_has_bench, defender_used_moves, bench_status_mask
+		defender_has_bench, defender_used_moves, bench_status_mask, link_battle
 	)
 
 	if ai_move_weights & RomLayout.AI_BASIC:
@@ -1439,7 +1444,7 @@ static func _estimate_damage(c: Context, move: Dictionary, constant: bool = true
 		return Gen2Damage.constant_damage(effect, c.attacker, c.defender, move, c.rng)
 	return int(Gen2Damage.calculate_with(
 		c.attacker, c.defender, move, false, Gen2Damage.MAX_VARIATION,
-		Gen2Weather.NONE, c.defender_screens
+		Gen2Weather.NONE, c.defender_screens, false, c.link_battle
 	)["damage"])
 
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -494,9 +494,10 @@ var rules: Gen2Rules = null
 var is_trainer_battle: bool = false
 
 var in_battle_tower: bool = false
+var is_link_battle: bool = false
+var player_id: int = -1
 
-## `wBattleType`, read by running alone so far and set on the world path by a
-## `loadvar VAR_BATTLETYPE` before `startbattle`.
+## `wBattleType`, set by `loadvar VAR_BATTLETYPE` before `startbattle`.
 var battle_type: int = BATTLETYPE_NORMAL
 
 ## Earned player badges as source-order bits. Zero is the battle-safe default
@@ -2832,6 +2833,9 @@ func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 ## once-per-action status gate. A fresh [Gen2Turn] is that clean move-struct copy,
 ## keeping the acting side and the one event stream.
 func run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
+	if turn.ended:
+		return
+	Gen2EffectCommands.check_obedience(turn)
 	var sequence: Array = Gen2MoveEffect.sequence_for(turn.effect())
 	var counter: int = 0
 	while counter < sequence.size():

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -36,6 +36,7 @@ var data: GameData = null
 
 var species: int = 0
 var level: int = 1
+var ot_id: int = -1
 var dvs: int = PERFECT_DVS
 var stat_exp: Dictionary = {}
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -39,6 +39,12 @@ const PARTY_SIZE: int = 2
 ## Keyed by the names [Gen2Status] answers with, so a status the engine grows
 ## later shows up here as a missing key rather than as a wrong sentence.
 const STOPPED_BY: Dictionary = {
+	&"ignored_sleeping": "ignored orders…sleeping!",
+	&"began_to_nap": "began to nap!",
+	&"loafing": "is loafing around!",
+	&"wont_obey": "won't obey!",
+	&"turned_away": "turned away!",
+	&"ignored_orders": "ignored orders!",
 	&"sleep": "is fast asleep!",
 	&"freeze": "is frozen solid!",
 	&"paralysis": "is fully paralyzed!",
@@ -1134,7 +1140,8 @@ func start_world_battle(
 	var crystal: bool = Gen2WorldState.is_crystal_profile(_data)
 	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
 		_data, _stamped_request(request, save, crystal), player_party, _rng,
-		_world_badge_mask(save, crystal, player_badges), _injected_rules
+		_world_badge_mask(save, crystal, player_badges), _injected_rules,
+		save.player_id if save != null else -1
 	)
 	if not bool(prepared.get("ok", false)):
 		_emit_world_battle_failure(
@@ -3413,7 +3420,7 @@ func _enemy_slot() -> int:
 		_battle.screens[Gen2Battle.ENEMY], _battle.screens[Gen2Battle.PLAYER],
 		Gen2AISwitch.has_bench(_battle), Gen2AISwitch.matchup_score(_battle),
 		Gen2AISwitch.has_bench(_battle, Gen2Battle.PLAYER), _battle.player_used_moves,
-		_party_status_mask(Gen2Battle.ENEMY)
+		_party_status_mask(Gen2Battle.ENEMY), _battle.is_link_battle
 	)
 
 

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -65,7 +65,8 @@ static func calculate_with(
 	variation: int,
 	weather: int = Gen2Weather.NONE,
 	defender_screens: int = Gen2Screens.NONE,
-	foresight: bool = false
+	foresight: bool = false,
+	link_battle: bool = false
 ) -> Dictionary:
 	var out: Dictionary = {
 		"damage": 0, "critical": critical, "effectiveness": RomLayout.MATCHUP_EFFECTIVE,
@@ -76,7 +77,7 @@ static func calculate_with(
 
 	var move_type: int = int(move.get("type", RomLayout.TYPE_NORMAL))
 	var stats: Array = damage_stats(
-		attacker, defender, move_type, critical, defender_screens
+		attacker, defender, move_type, critical, defender_screens, link_battle
 	)
 	var damage: int = damage_calc(
 		attacker, int(move.get("power", 0)), int(stats[0]), int(stats[1]),
@@ -105,14 +106,15 @@ static func damage_stats(
 	defender: Gen2BattleMon,
 	move_type: int,
 	critical: bool,
-	defender_screens: int = Gen2Screens.NONE
+	defender_screens: int = Gen2Screens.NONE,
+	link_battle: bool = false
 ) -> Array:
 	if attacker == null or defender == null:
 		return [1, 1]
 	return metal_powder_pair(defender, truncate_stats(
 		_attack_stat(attacker, defender, move_type, critical),
 		_defense_stat(attacker, defender, move_type, critical, defender_screens),
-		Gen2WorldState.is_crystal_profile(attacker.data)
+		Gen2WorldState.is_crystal_profile(attacker.data) and not link_battle
 	))
 
 
@@ -299,13 +301,14 @@ static func roll_variation(rng: RandomNumberGenerator) -> int:
 ## [param screens] is the confused Pokémon's own side's, doubled off exactly as
 ## `PlayerAttackDamage` doubles, so a Reflect halves what confusion takes.
 static func confusion_damage(
-	mon: Gen2BattleMon, rng: RandomNumberGenerator, screens: int = Gen2Screens.NONE
+	mon: Gen2BattleMon, rng: RandomNumberGenerator, screens: int = Gen2Screens.NONE,
+	link_battle: bool = false
 ) -> int:
 	var defense: int = mon.stat("defense")
 	if Gen2Screens.has(screens, Gen2Screens.REFLECT):
 		defense *= Gen2Screens.DEFENCE_MULTIPLIER
 	var truncated: Array = truncate_stats(
-		mon.stat("attack"), defense, Gen2WorldState.is_crystal_profile(mon.data)
+		mon.stat("attack"), defense, Gen2WorldState.is_crystal_profile(mon.data) and not link_battle
 	)
 	var damage: int = base_damage(
 		mon.level, CONFUSION_POWER, int(truncated[0]), int(truncated[1])
@@ -457,7 +460,7 @@ static func psywave_damage(level: int, rng: RandomNumberGenerator) -> int:
 
 
 ## The split is by type, not by move: below Fire is physical and Fire up
-## special, which is why Hyper Beam is special and Bite physical.
+## special, which is why Hyper Beam is physical and Bite special.
 ##
 ## A type past the cartridge's chart is a mod's own and carries the choice on its
 ## row instead, since there is no number to compare it against. Only such a

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -550,8 +550,7 @@ const HEAL_TIMES: Dictionary = {
 ## Wheel and Sacred Fire, by move number.
 const THAWING_MOVES: Array = [172, 221]
 
-## `.fast_asleep`'s own two by number, Snore and Sleep Talk. The second has no
-## effect list yet and is named anyway: the bypass is the sleep check's rule.
+## `.fast_asleep` permits Snore and Sleep Talk through the sleep check.
 const SLEEPING_MOVES: Array = [173, 214]
 
 ## What Encore refuses to lock a target into, by number: Encore itself, which
@@ -900,7 +899,7 @@ static func _damage_stats(turn: Gen2Turn) -> void:
 	var stats: Array = Gen2Damage.damage_stats(
 		turn.attacker(), turn.defender(),
 		int(turn.effective_move().get("type", RomLayout.TYPE_NORMAL)),
-		turn.critical, turn.battle.screens[turn.target]
+		turn.critical, turn.battle.screens[turn.target], turn.battle.is_link_battle
 	)
 	turn.attack_stat = int(stats[0])
 	turn.defense_stat = int(stats[1])
@@ -1809,12 +1808,7 @@ static func _check_status(turn: Gen2Turn) -> void:
 			turn.emit(Gen2Battle.CONFUSED)
 			if Gen2Substatus.rolls_confusion_hit(turn.rng()):
 				_cancel_charge(mon)
-				var dealt: int = mon.take_damage(Gen2Damage.confusion_damage(
-					mon, turn.rng(), turn.battle.screens[turn.side]
-				))
-				turn.emit(Gen2Battle.HURT_ITSELF, {
-					"amount": dealt, "hp": mon.hp, "max_hp": mon.max_hp(),
-				})
+				_hurt_self(turn)
 				turn.end()
 				return
 
@@ -1883,6 +1877,10 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 	if not primary and _substitute_refuses(turn):
 		return
 
+	if _primary_status_misses(turn, flag):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+
 	if Gen2Status.is_afflicted(defender.status):
 		# `BattleCommand_BurnTarget` is the one that does not simply return here:
 		# its `jp nz, Defrost` thaws a frozen target instead.
@@ -1914,7 +1912,7 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 		_animate_current_move(turn)
 
 	if flag == Gen2Status.SLEEP_MASK:
-		defender.status = Gen2Status.roll_sleep(turn.rng())
+		defender.status = Gen2Status.roll_sleep(turn.rng(), turn.battle.in_battle_tower)
 	else:
 		defender.status |= flag
 
@@ -1989,6 +1987,10 @@ static func _toxic_target(turn: Gen2Turn) -> void:
 	# passes that command's own `CheckIfTargetIsPoisonType` on the way in: a
 	# Poison-type is no more badly poisoned than ordinarily poisoned.
 	if _status_type_refuses(turn, Gen2Status.POISON):
+		return
+
+	if _computer_effect_misses(turn):
+		turn.emit(Gen2Battle.MOVE_FAILED)
 		return
 
 	# `.dont_sample_failure`, which is where that command asks about the doll:
@@ -3290,7 +3292,7 @@ static func _heal(turn: Gen2Turn) -> void:
 ## time of day, which is the cartridge's real rule: matching the clock buys
 ## nothing, missing it costs. Then one step up in sun, or one step down in any
 ## other weather, so the worst case is an eighth and the best is the whole bar.
-## Link battles skip the time step; there are none here.
+## Link battles skip the time step.
 static func _timed_heal(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	if attacker.hp >= attacker.max_hp():
@@ -3298,7 +3300,9 @@ static func _timed_heal(turn: Gen2Turn) -> void:
 		return
 
 	var index: int = HEAL_HALF
-	if turn.battle.time_of_day != HEAL_TIMES.get(turn.effect(), Gen2WorldPalette.TIME_DAY):
+	if not turn.battle.is_link_battle and turn.battle.time_of_day != HEAL_TIMES.get(
+		turn.effect(), Gen2WorldPalette.TIME_DAY
+	):
 		index -= 1
 	if Gen2Weather.is_active(turn.battle.weather):
 		index += 1 if turn.battle.weather == Gen2Weather.SUN else -1
@@ -3613,13 +3617,34 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 ## player's stats fails a quarter of the time, exempting Lock-On and
 ## `EFFECT_ACCURACY_DOWN_HIT`. It sits behind `.CantLower`, which never rolls.
 static func _computer_stat_down_misses(turn: Gen2Turn) -> bool:
-	if turn.side != Gen2Battle.ENEMY:
+	if turn.effect() == Gen2MoveEffect.ACCURACY_DOWN_HIT:
+		return false
+	return _computer_effect_misses(turn)
+
+
+static func _computer_effect_misses(turn: Gen2Turn) -> bool:
+	if turn.side != Gen2Battle.ENEMY or turn.battle.is_link_battle or turn.battle.in_battle_tower:
 		return false
 	if Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.LOCK_ON):
 		return false
-	if turn.effect() == Gen2MoveEffect.ACCURACY_DOWN_HIT:
-		return false
 	return turn.rng().randi_range(0, 0xFF) < 64
+
+
+static func _primary_status_misses(turn: Gen2Turn, flag: int) -> bool:
+	if not _status_move_animates(turn, flag):
+		return false
+	var status: int = turn.defender().status
+	match flag:
+		Gen2Status.SLEEP_MASK:
+			if Gen2Status.is_asleep(status) or turn.missed:
+				return false
+		Gen2Status.POISON:
+			if Gen2Status.is_afflicted(status) or _status_type_refuses(turn, flag) or turn.immune:
+				return false
+		Gen2Status.PARALYSIS:
+			if Gen2Status.has(status, flag) or turn.immune:
+				return false
+	return _computer_effect_misses(turn)
 
 
 ## Minimize's move number, which is the whole of what `MinimizeDropSub` compares
@@ -3683,4 +3708,105 @@ static func _stat_fail_text(turn: Gen2Turn) -> void:
 		return
 	turn.emit(Gen2Battle.STAT_CHANGE_FAILED, {
 		"target": turn.stat_target, "stat": turn.stat_key, "by": turn.stat_by,
+	})
+
+
+## `BattleCommand_CheckObedience` runs before every effect list, after CheckTurn.
+static func check_obedience(turn: Gen2Turn) -> void:
+	var battle: Gen2Battle = turn.battle
+	var user: Gen2BattleMon = turn.attacker()
+	if turn.side != Gen2Battle.PLAYER or turn.locked or turn.called or turn.disobeyed:
+		return
+	if battle.is_link_battle or battle.in_battle_tower or battle.player_id < 0:
+		return
+	if user.ot_id < 0 or user.ot_id == battle.player_id:
+		return
+	var limit: int = _obedience_level(battle.player_badge_mask)
+	if user.level <= limit:
+		return
+	var total: int = mini(limit + user.level, 255)
+	if _obedience_roll(turn, total, true) < limit:
+		return
+	if SLEEPING_MOVES.has(turn.move_number) and Gen2Status.is_asleep(user.status):
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"ignored_sleeping"})
+		turn.end()
+		return
+	if _obedience_roll(turn, total, false) < limit:
+		_disobedient_move(turn)
+	else:
+		_disobedient_action(turn, user.level - limit)
+	user.last_move_used = 0
+	user.last_counter_move = 0
+	user.encored_slot = -1
+	user.encore_turns = 0
+	turn.end()
+
+
+static func _obedience_level(badges: int) -> int:
+	for row: Array in [[7, 101], [5, 70], [3, 50], [1, 30]]:
+		if badges & (1 << int(row[0])):
+			return int(row[1])
+	return 10
+
+
+static func _obedience_roll(turn: Gen2Turn, upper: int, swap: bool) -> int:
+	while true:
+		var value: int = turn.rng().randi_range(0, 255)
+		if swap:
+			value = ((value << 4) | (value >> 4)) & 255
+		if value < upper:
+			return value
+	return 0
+
+
+static func _disobedient_move(turn: Gen2Turn) -> void:
+	var user: Gen2BattleMon = turn.attacker()
+	var available: Array[int] = []
+	for slot: int in user.moves.size():
+		if slot != turn.slot and user.can_use(slot):
+			available.append(slot)
+	if user.moves.size() < 2 or user.disabled_slot >= 0 or available.is_empty():
+		_disobedient_idle(turn)
+		return
+	var chosen: int = turn.rng().randi_range(0, 255) & 3
+	while not available.has(chosen):
+		chosen = turn.rng().randi_range(0, 255) & 3
+	var number: int = int(user.moves[chosen])
+	var alternate: Gen2Turn = Gen2Turn.create(
+		turn.battle, turn.side, chosen, number, turn.data().move(number), turn.events
+	)
+	alternate.disobeyed = true
+	turn.battle.run_move_effect(alternate)
+
+
+static func _disobedient_action(turn: Gen2Turn, difference: int) -> void:
+	var value: int = _obedience_roll(turn, 256, true)
+	if value < difference:
+		var sleep: int = 0
+		while sleep == 0:
+			var doubled: int = (turn.rng().randi_range(0, 255) << 1) & 255
+			sleep = (doubled >> 4) & Gen2Status.SLEEP_MASK
+		turn.attacker().status = sleep
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"began_to_nap"})
+	elif value < difference * 2:
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"wont_obey"})
+		_hurt_self(turn)
+	else:
+		_disobedient_idle(turn)
+
+
+static func _disobedient_idle(turn: Gen2Turn) -> void:
+	var reasons: Array[StringName] = [
+		&"loafing", &"wont_obey", &"turned_away", &"ignored_orders",
+	]
+	turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": reasons[turn.rng().randi_range(0, 255) & 3]})
+
+
+static func _hurt_self(turn: Gen2Turn) -> void:
+	var user: Gen2BattleMon = turn.attacker()
+	var dealt: int = user.take_damage(Gen2Damage.confusion_damage(
+		user, turn.rng(), turn.battle.screens[turn.side], turn.battle.is_link_battle
+	))
+	turn.emit(Gen2Battle.HURT_ITSELF, {
+		"amount": dealt, "hp": user.hp, "max_hp": user.max_hp(),
 	})

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -860,8 +860,7 @@ const TRAP_TARGET_SEQUENCE: Array = [
 
 ## The heal family, the same four-step shape as the weather moves: announce,
 ## spend, heal. Neither list rolls accuracy, so the 100% every one of the seven
-## carries is never read. The cartridge's own lists open with `checkobedience`,
-## which this engine does not model and no other list here carries either.
+## carries is never read. `checkobedience` runs before every list.
 const HEAL_SEQUENCE: Array = [
 	Gen2EffectCommands.USED_MOVE_TEXT,
 	Gen2EffectCommands.DO_TURN,

--- a/game/battle/status.gd
+++ b/game/battle/status.gd
@@ -77,9 +77,9 @@ static func tick_sleep(status: int) -> int:
 	return (status & ~SLEEP_MASK) | ((status & SLEEP_MASK) - 1)
 
 
-## How long a Pokémon put to sleep stays asleep.
-static func roll_sleep(rng: RandomNumberGenerator) -> int:
-	return rng.randi_range(MIN_SLEEP, MAX_SLEEP)
+## `BattleCommand_SleepTarget`: the Tower mask limits the initial count to 2..4.
+static func roll_sleep(rng: RandomNumberGenerator, battle_tower: bool = false) -> int:
+	return rng.randi_range(MIN_SLEEP, 4 if battle_tower else MAX_SLEEP)
 
 
 ## Whether a paralysed Pokémon cannot move this turn.

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -60,6 +60,7 @@ var locked: bool = false
 ## Mirror Move or Sleep Talk spends no PP and adds no second turn. Not
 ## [member locked], which is a real continuation.
 var called: bool = false
+var disobeyed: bool = false
 
 ## A called-move command's request to restart at another move's first command,
 ## zero for none. [Gen2Battle] consumes it as soon as the command returns.

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -13,6 +13,7 @@ static func from_battle_mon(mon: Gen2BattleMon) -> Gen2SaveMon:
 	out.item = mon.item
 	out.level = mon.level
 	out.exp = mon.exp
+	out.ot_id = maxi(mon.ot_id, 0)
 	out.dvs = mon.persistent_dvs()
 	out.stat_exp = {}
 	for key: String in Gen2SaveMon.STAT_EXP_KEYS:
@@ -46,6 +47,7 @@ static func to_battle_mon(data: GameData, saved: Gen2SaveMon) -> Gen2BattleMon:
 	if out == null:
 		return null
 	out.exp = saved.exp
+	out.ot_id = saved.ot_id
 	out.status = saved.status
 	out.happiness = saved.happiness
 	out.caught_location = saved.caught_location & Gen2BattleMon.CAUGHT_LOCATION_MASK

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -33,6 +33,7 @@ static func prepare(
 	random: RandomNumberGenerator = null,
 	player_badges: int = 0,
 	battle_rules: Gen2Rules = null,
+	player_id: int = -1,
 ) -> Dictionary:
 	if data == null or player_party == null or player_party.is_wiped():
 		return _failure(&"missing_player_party")
@@ -47,9 +48,7 @@ static func prepare(
 	var trainer_index: int = 0
 	# wBattleType, which a `loadvar VAR_BATTLETYPE` before `startbattle` sets.
 	# Read before the party is built, since `LoadEnemyMon` branches a wild's DVs
-	# on it. Running is the only other thing that reads it so far, and four of
-	# its values are what make Celebi, Suicune and the Rocket trap battles
-	# inescapable.
+	# on it. Four values make Celebi, Suicune and the Rocket traps inescapable.
 	var battle_type: int = int(values.get("battle_type", Gen2Battle.BATTLETYPE_NORMAL))
 	# `BattleRandom`, so a wild's DVs come out of the run's own sequence and a
 	# replay of the same seed meets the same Pokemon.
@@ -103,6 +102,8 @@ static func prepare(
 		return _failure(&"battle_setup_failed")
 	battle.battle_type = battle_type
 	battle.in_battle_tower = kind == &"battle_tower"
+	battle.is_link_battle = kind == &"link_battle"
+	battle.player_id = player_id
 	## `InitEnemyTrainer` belongs to setting the opponent up rather than to
 	## whoever draws the fight, so every host gets the class's two items, its
 	## gym-leader happiness and `ComputeTrainerReward` from one place. Only a

--- a/tests/unit/test_ai.gd
+++ b/tests/unit/test_ai.gd
@@ -1832,3 +1832,18 @@ func test_risky_wants_strictly_more_damage_than_the_bar() -> void:
 	assert_eq(int(_scores(pikachu, charmander, RomLayout.AI_RISKY)[0]), 20, "exactly the bar")
 	charmander.hp = damage - 1
 	assert_eq(int(_scores(pikachu, charmander, RomLayout.AI_RISKY)[0]), 15, "one under it")
+
+
+func test_link_predictions_use_the_same_stat_truncation_as_the_hit() -> void:
+	_data = Fixture.build(_directory, "crystal")
+	var attacker: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.BODY_SLAM_ALWAYS_PARALYZES, Fixture.STATIC_DAMAGE_MOVE])
+	var defender: Gen2BattleMon = _mon(Fixture.CHARMANDER, 50, [Fixture.TACKLE])
+	attacker.stats["attack"] = 100
+	defender.stats["defense"] = 600
+	for linked: bool in [false, true]:
+		var selected: int = Gen2BattleAI.choose_slot(
+			attacker, defender, _data, RomLayout.AI_AGGRESSIVE, _rng,
+			0, 0, Gen2Weather.NONE, Gen2Screens.NONE, Gen2Screens.REFLECT,
+			false, Gen2AISwitch.BASE_SCORE, false, [], Gen2Status.NONE, linked
+		)
+		assert_eq(selected, 0 if linked else 1)

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -601,3 +601,18 @@ func test_damage_calc_takes_a_level_of_its_own() -> void:
 		Gen2Damage.damage_calc(attacker, 10, 55, 30, false, Fixture.DARK, false, -1),
 		Gen2Damage.damage_calc(attacker, 10, 55, 30, false, Fixture.DARK, false, 50)
 	)
+
+
+func test_crystal_link_stats_use_one_shift_for_hits_and_confusion() -> void:
+	_data = Fixture.build(_directory, "crystal")
+	var attacker: Gen2BattleMon = _mon(Fixture.CHARMANDER)
+	var defender: Gen2BattleMon = _mon(Fixture.CHARMANDER)
+	attacker.stats["attack"] = 100
+	defender.stats["defense"] = 600
+	assert_eq(Gen2Damage.damage_stats(attacker, defender, 0, false, Gen2Screens.REFLECT), [6, 75])
+	assert_eq(Gen2Damage.damage_stats(attacker, defender, 0, false, Gen2Screens.REFLECT, true), [25, 44])
+	attacker.stats["defense"] = 600
+	var generator := RandomNumberGenerator.new()
+	generator.seed = 1
+	assert_between(Gen2Damage.confusion_damage(attacker, generator, Gen2Screens.REFLECT), 2, 3)
+	assert_between(Gen2Damage.confusion_damage(attacker, generator, Gen2Screens.REFLECT, true), 10, 12)

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -838,6 +838,8 @@ const ART_SCRATCH: String = "user://cartridge_art_tests"
 
 
 func _clear_art_scratch() -> void:
+	if not DirAccess.dir_exists_absolute(ART_SCRATCH):
+		return
 	var listing: PackedStringArray = DirAccess.get_files_at(ART_SCRATCH)
 	for entry: String in listing:
 		DirAccess.remove_absolute("%s/%s" % [ART_SCRATCH, entry])

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -199,7 +199,7 @@ func test_a_browse_sheet_walks_into_a_directory_and_answers_with_a_file() -> voi
 	var answers: Array[String] = []
 	sheet.chosen.connect(func(path: String) -> void: answers.append(path))
 	sheet.open(host)
-	await wait_frames(2)
+	await wait_process_frames(2)
 	var rows: Array[Button] = _row_buttons(sheet)
 	assert_eq(rows.size(), 1, "the directory is the only row at the top")
 	rows[0].pressed.emit()

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -4846,3 +4846,165 @@ func test_transform_refuses_an_already_transformed_target() -> void:
 	var turn: Gen2Turn = _run_move(battle, Fixture.TRANSFORM)
 	assert_eq(_of_type(turn.events, Gen2Battle.MOVE_FAILED).size(), 1)
 	assert_eq(battle.player.species, Fixture.PIKACHU)
+
+
+func test_link_healing_ignores_time_but_keeps_weather_for_every_heal() -> void:
+	for number: int in [Fixture.MORNING_SUN, Fixture.SYNTHESIS, Fixture.MOONLIGHT]:
+		for time: int in 3:
+			for weather: int in 4:
+				for side: int in 2:
+					var battle: Gen2Battle = _battle()
+					battle.is_link_battle = true
+					battle.time_of_day = time
+					battle.weather = weather
+					battle.mon(side).stats["hp"] = 160
+					battle.mon(side).hp = 1
+					var turn := Gen2Turn.create(battle, side, 0, number, _data.move(number), [])
+					Gen2EffectCommands.run(Gen2EffectCommands.TIMED_HEAL, turn)
+					var amount: int = [80, 40, 160, 40][weather]
+					assert_eq(battle.mon(side).hp, mini(1 + amount, 160))
+
+
+func test_link_and_tower_stat_drops_spend_no_computer_failure_roll() -> void:
+	for mode: int in 2:
+		var battle: Gen2Battle = _battle()
+		battle.is_link_battle = mode == 0
+		battle.in_battle_tower = mode == 1
+		var before: int = battle.rng.state
+		var turn := Gen2Turn.create(battle, Gen2Battle.ENEMY, 0,
+			Fixture.GROWL, _data.move(Fixture.GROWL), [])
+		Gen2EffectCommands.run(Gen2EffectCommands.ATTACK_DOWN, turn)
+		assert_eq(int(battle.player.stages["attack"]), -1)
+		assert_eq(battle.rng.state, before)
+
+
+func test_primary_status_failures_share_the_link_and_tower_exemptions() -> void:
+	for number: int in [Fixture.SLEEP_POWDER, Fixture.POISON_POWDER, Fixture.THUNDER_WAVE, Fixture.TOXIC]:
+		for mode: int in 3:
+			var misses: int = 0
+			for seed_value: int in 100:
+				var battle: Gen2Battle = _battle()
+				battle.is_link_battle = mode == 1
+				battle.in_battle_tower = mode == 2
+				battle.rng.seed = seed_value
+				var turn := Gen2Turn.create(battle, Gen2Battle.ENEMY, 0,
+					number, _data.move(number), [])
+				var commands: Dictionary = {
+					Fixture.SLEEP_POWDER: Gen2EffectCommands.SLEEP_TARGET,
+					Fixture.POISON_POWDER: Gen2EffectCommands.POISON_TARGET,
+					Fixture.THUNDER_WAVE: Gen2EffectCommands.PARALYZE_TARGET,
+					Fixture.TOXIC: Gen2EffectCommands.TOXIC_TARGET,
+				}
+				Gen2EffectCommands.run(commands[number], turn)
+				if battle.player.status == 0:
+					misses += 1
+			if mode == 0:
+				assert_between(misses, 10, 40)
+			else:
+				assert_eq(misses, 0)
+
+
+func test_tower_sleep_is_one_to_three_lost_turns_on_either_side() -> void:
+	for side: int in 2:
+		var seen: Dictionary = {}
+		for seed_value: int in 100:
+			var battle: Gen2Battle = _battle()
+			battle.in_battle_tower = true
+			battle.rng.seed = seed_value
+			var turn := Gen2Turn.create(battle, side, 0, Fixture.SLEEP_POWDER, _data.move(Fixture.SLEEP_POWDER), [])
+			Gen2EffectCommands.run(Gen2EffectCommands.SLEEP_TARGET, turn)
+			var status: int = turn.defender().status
+			assert_between(status, 2, 4)
+			seen[status] = true
+		assert_eq(seen.size(), 3)
+
+
+func test_obedience_exemptions_do_not_draw_randomness() -> void:
+	for reason: String in ["owner", "level", "badges", "link", "tower", "locked", "called", "enemy"]:
+		var battle: Gen2Battle = _battle()
+		battle.player_id = 1
+		battle.player.ot_id = 2
+		battle.enemy.ot_id = 2
+		battle.is_link_battle = reason == "link"
+		battle.in_battle_tower = reason == "tower"
+		if reason == "owner":
+			battle.player.ot_id = 1
+		if reason == "level":
+			battle.player.level = 10
+		if reason == "badges":
+			battle.player_badge_mask = 1 << 3
+		var turn := Gen2Turn.create(battle, Gen2Battle.ENEMY if reason == "enemy" else Gen2Battle.PLAYER,
+			0, Fixture.TACKLE, _data.move(Fixture.TACKLE), [])
+		turn.locked = reason == "locked"
+		turn.called = reason == "called"
+		var before: int = battle.rng.state
+		Gen2EffectCommands.check_obedience(turn)
+		assert_false(turn.ended, reason)
+		assert_eq(battle.rng.state, before, reason)
+
+
+func test_obedience_badge_thresholds_use_only_the_four_source_badges() -> void:
+	for mask: int in 256:
+		var expected: int = 10
+		for row: Array in [[1, 30], [3, 50], [5, 70], [7, 101]]:
+			if mask & (1 << int(row[0])):
+				expected = int(row[1])
+		assert_eq(Gen2EffectCommands._obedience_level(mask), expected)
+
+
+func test_disobedience_reaches_every_outcome_and_clears_encore() -> void:
+	var outcomes: Dictionary = {}
+	for seed_value: int in 300:
+		var battle: Gen2Battle = _battle()
+		battle.player_id = 1
+		battle.player.ot_id = 2
+		battle.player.moves = [Fixture.GROWL, Fixture.SPLASH]
+		battle.player.pp = [20, 20]
+		battle.player.last_move_used = Fixture.TACKLE
+		battle.player.last_counter_move = Fixture.TACKLE
+		battle.player.encored_slot = 0
+		battle.player.encore_turns = 3
+		battle.rng.seed = seed_value
+		var turn: Gen2Turn = _turn(battle, Fixture.GROWL)
+		Gen2EffectCommands.check_obedience(turn)
+		if not turn.ended:
+			outcomes[&"obeyed"] = true
+			continue
+		assert_eq(battle.player.last_move_used, 0)
+		assert_eq(battle.player.last_counter_move, 0)
+		assert_eq(battle.player.encored_slot, -1)
+		assert_eq(battle.player.encore_turns, 0)
+		assert_eq(int(battle.player.pp[0]), 20)
+		for event: Dictionary in turn.events:
+			if event["type"] == Gen2Battle.CANNOT_MOVE:
+				outcomes[event["reason"]] = true
+			if event["type"] == Gen2Battle.HURT_ITSELF:
+				outcomes[&"hurt_self"] = true
+			if event["type"] == Gen2Battle.USED_MOVE:
+				outcomes[&"alternate"] = true
+				assert_eq(int(event["move"]), Fixture.SPLASH)
+				assert_eq(int(battle.player.pp[1]), 19)
+	for outcome: StringName in [&"obeyed", &"began_to_nap", &"hurt_self", &"alternate",
+		&"loafing", &"wont_obey", &"turned_away", &"ignored_orders"]:
+		assert_true(outcomes.has(outcome), String(outcome))
+
+
+func test_a_disobedient_sleeping_move_preserves_encore_and_spends_no_pp() -> void:
+	var seen: bool = false
+	for seed_value: int in 100:
+		var battle: Gen2Battle = _battle()
+		battle.player_id = 1
+		battle.player.ot_id = 2
+		battle.player.status = 3
+		battle.player.encored_slot = 0
+		battle.player.encore_turns = 3
+		battle.rng.seed = seed_value
+		var turn: Gen2Turn = _turn(battle, Fixture.SLEEP_TALK)
+		Gen2EffectCommands.check_obedience(turn)
+		if not turn.ended:
+			continue
+		seen = true
+		assert_eq(turn.events[0]["reason"], &"ignored_sleeping")
+		assert_eq(battle.player.encore_turns, 3)
+		assert_eq(battle.player.status, 3)
+	assert_true(seen)

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -72,10 +72,13 @@ func test_a_battle_party_round_trips_into_persistent_fields() -> void:
 
 func test_a_saved_pokemon_restores_stats_hp_status_exp_and_pp() -> void:
 	var save: Gen2SaveData = _save()
+	save.party[0].ot_id = 1234
 	var restored: Gen2Party = Gen2SaveBattleAdapter.to_battle_party(_data, save)
 	assert_not_null(restored)
 	var original: Gen2BattleMon = _party().at(0)
 	var mon: Gen2BattleMon = restored.at(0)
+	assert_eq(mon.ot_id, 1234)
+	assert_eq(Gen2SaveBattleAdapter.from_battle_mon(mon).ot_id, 1234)
 	assert_eq(mon.species, original.species)
 	assert_eq(mon.level, original.level)
 	assert_eq(mon.dvs, original.dvs)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -1,9 +1,6 @@
 extends GutTest
 
 ## The source budget: how much branching and how much prose the tree is allowed.
-## Both are capped because both track defect count the way line count does, and a
-## ceiling nothing measures is a wish. `CLAUDE.md`'s "The budget" is this table
-## in prose; this file is what fails.
 
 const ROOTS: Array[String] = ["autoload", "game", "mods", "tests", "tools"]
 ## Where the comment total is counted. The tests and the shipped example mods are
@@ -18,7 +15,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37768
+const MAX_COMMENT_LINES: int = 37762
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -88,21 +88,26 @@ func test_wild_request_builds_a_one_mon_enemy_party() -> void:
 	assert_eq((prepared["battle"] as Gen2Battle).enemy.species, SPECIES_TWO)
 
 
-func test_a_battle_tower_request_marks_the_battle_for_its_ai_rules() -> void:
+func test_special_battle_requests_keep_their_context() -> void:
 	var opponent := Gen2SaveMon.new()
 	opponent.species = SPECIES_TWO
 	opponent.level = 5
 	opponent.moves = [TACKLE]
 	opponent.pp = [35]
 	opponent.hp = 10
-	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
-		_data, {"values": {
-			"kind": &"battle_tower", "trainer_class": 1,
-			"enemy_party": [opponent.to_dict()],
-		}}, _player_party(), RandomNumberGenerator.new()
-	)
-	assert_true(bool(prepared["ok"]), String(prepared.get("reason", "")))
-	assert_true((prepared["battle"] as Gen2Battle).in_battle_tower)
+	for kind: StringName in [&"battle_tower", &"link_battle"]:
+		var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(
+			_data, {"values": {
+				"kind": kind, "trainer_class": 1,
+				"enemy_party": [opponent.to_dict()],
+			}}, _player_party(), RandomNumberGenerator.new(), 0, null, 123
+		)
+		assert_true(bool(prepared["ok"]), String(prepared.get("reason", "")))
+		var battle: Gen2Battle = prepared["battle"]
+		assert_eq(battle.in_battle_tower, kind == &"battle_tower")
+		assert_eq(battle.is_link_battle, kind == &"link_battle")
+		assert_eq(battle.player_id, 123)
+
 
 
 ## `LoadEnemyMon.WildItem` spends its item roll before the two DV bytes. Sweep

--- a/tools/checks/move_effects.gd
+++ b/tools/checks/move_effects.gd
@@ -20,9 +20,7 @@ const PINS: Dictionary = {
 ## not as a command of its own; anything not in it and not a name we use is an
 ## unread step and fails.
 const FOLDED: Dictionary = {
-	# `CheckTurn` is called before `DoMove` and `checkobedience` is the first
-	# command of every list; both are the once-per-action gate `Gen2Battle._act`
-	# runs as `checkstatus` in front of the sequence.
+	# `CheckTurn` runs in `_act`; `checkobedience` opens `run_move_effect`.
 	&"checkturn": "",
 	&"checkobedience": "",
 	# Text and pacing. Every one of these prints what the step in front of it
@@ -87,6 +85,7 @@ func run(r: RefCounted) -> void:
 			continue
 		_r.game_id = game_id
 		compared += _compare(pin, data)
+		_check_obedience_corpus(data)
 		_r.game_id = &""
 	if compared == 0:
 		print("no pin was checked out; move_effects compared nothing.")
@@ -229,3 +228,25 @@ func _reference_root() -> String:
 	if override != "":
 		return override
 	return ProjectSettings.globalize_path("res://").path_join(".references")
+
+
+func _check_obedience_corpus(data: GameData) -> void:
+	var checked: int = 0
+	for number: int in range(1, 252):
+		var battle: Gen2Battle = Gen2Battle.create(
+			data, Gen2BattleMon.create(data, 25, 100, [number]),
+			Gen2BattleMon.create(data, 1, 100, [1]), RandomNumberGenerator.new()
+		)
+		battle.player_id = 1
+		battle.player.ot_id = 2
+		for mode: int in 3:
+			battle.is_link_battle = mode == 1
+			battle.in_battle_tower = mode == 2
+			battle.player_badge_mask = 128 if mode == 0 else 0
+			var before: int = battle.rng.state
+			var turn := Gen2Turn.create(battle, 0, 0, number, data.move(number), [])
+			Gen2EffectCommands.check_obedience(turn)
+			_r.check(not turn.ended and battle.rng.state == before,
+				"move %d obedience exemption %d" % [number, mode])
+			checked += 1
+	print("%s: %d move obedience exemptions." % [data.id, checked])

--- a/tools/preview_battle_anim.gd
+++ b/tools/preview_battle_anim.gd
@@ -4,7 +4,7 @@ extends SceneTree
 ## `tools/screenshot.gd` cannot drive: an animation needs a turn taken, an event
 ## queue walked to the animation it wants, and a counted number of frames spent
 ## inside it. The flags and the `catch`, `0`, `miss` and frame-range forms are
-## documented below.
+## documented below; `disobey` captures a traded Pokemon ignoring an order.
 ##   Godot --path . -s res://tools/preview_battle_anim.gd -- \
 ##       <game> <output.png> <move> <side> <frames> [scene_off] [matchup=<enemy>,<player>]
 
@@ -42,6 +42,7 @@ var _last_trace: String = ""
 var _scene_off: bool = false
 var _with_intro: bool = false
 var _miss: bool = false
+var _disobey: bool = false
 var _frames: int = 0
 var _matchup: Vector2i = DEFAULT_MATCHUP
 
@@ -83,6 +84,8 @@ func _initialize() -> void:
 				_with_intro = true
 			"miss":
 				_miss = true
+			"disobey":
+				_disobey = true
 			_:
 				push_error("Unknown flag %s" % flag)
 				quit(1)
@@ -333,6 +336,8 @@ func _drive_miss(battle: Gen2Battle) -> bool:
 
 
 func _drive() -> bool:
+	if _disobey:
+		return _drive_disobedience()
 	if _move == 0:
 		return _drive_entrance()
 	if _move == CATCH_MOVE:
@@ -370,4 +375,37 @@ func _drive() -> bool:
 		_screen.finish()
 		_screen.advance()
 	push_error("No animation on that side in %d steps. %s" % [MAX_STEPS, JSON.stringify(_screen.battle_snapshot())])
+	return false
+
+
+func _drive_disobedience() -> bool:
+	var data: GameData = _screen._data
+	var member: Gen2BattleMon = Gen2BattleMon.create(data, _matchup.y, 100, [_move])
+	member.ot_id = 2
+	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
+		data.id, data.sha1, -1, Gen2Party.create([member]), "PLAYER"
+	)
+	save.player_id = 1
+	if not _screen.start_world_battle({"values": {
+		"kind": &"wild", "pokemon": _matchup.x, "level": 100,
+	}}, save):
+		return false
+	_settle_entrance()
+	_screen.set_random_seed(7)
+	_screen.take_turn_with(0, 0)
+	for _step: int in MAX_STEPS:
+		var message: String = String(_screen.battle_snapshot()["message"])
+		for ending: String in ["nap!", "obey!", "around!", "away!", "orders!"]:
+			if message.ends_with(ending):
+				_screen.finish()
+				print(message)
+				return true
+		if _screen._audio_player != null:
+			_screen._audio_player.stop_all()
+		if _screen.frames_running():
+			_screen.advance_frame()
+			continue
+		_screen.finish()
+		_screen.advance()
+	push_error("The traded Pokemon did not disobey.")
 	return false


### PR DESCRIPTION
Traded Pokémon now obey the cartridge's badge thresholds and disobedience outcomes. Original Trainer IDs survive the save-to-battle conversion, and every move passes the obedience check before spending PP. Link and Battle Tower battles bypass that check.

- Preserve encounter mode through timed healing, stat-drop failure rolls, damage calculations and move scoring. Crystal link battles use the cartridge's single-pass stat truncation, including confusion damage.
- Restore the ordinary enemy failure roll for primary status moves and the Battle Tower's shorter sleep duration.
- Fix missing-directory cleanup and a deprecated frame wait in launcher tests, remove stale comments, and lower the comment ceiling.

Validation: 4,228 full-suite tests passed; the final move-scoring and script-loading checks passed 130 tests; 33 replay routes and all three story walks passed before and after; the full real-cache sweep passed, including 2,259 move obedience exemptions. Cartridge execution matched 684 healing/stat-truncation cases and 1,500 obedience decisions. The editor analysed 614 scripts with zero warnings. The live battle preview displays the refusal before consuming move PP.
