### PR TITLE
Match battle effect damage and turn state to cartridge behavior

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2417,7 +2417,7 @@ func award_capture_experience() -> Array:
 ## whether or not it changed anything, `AI_TryItem` clearing the slot the moment a
 ## check said yes. What the cartridge clears beside it is
 ## [method _reset_action_counters]'s work and
-## [method reset_damage_taken]'s; Bide and Rage do not exist here yet.
+## [method reset_damage_taken]'s.
 func _use_trainer_item(side: int, item: int, events: Array) -> void:
 	if item == 0:
 		return

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -280,14 +280,6 @@ func set_badge_boosts(mask: int) -> void:
 		badge_stat_boosts["defense"] = true
 	if mask & (1 << 6):
 		badge_stat_boosts["sp_attack"] = true
-		# The source intends Glacier to raise both Special stats, but its
-		# second check uses the value left in A by the Special Attack boost.
-		# That makes the Special Defense boost appear only for unboosted
-		# Special Attack values 206..432 or 661 and above.
-		var unboosted_special: int = int(stats.get("sp_attack", 0))
-		if (unboosted_special >= 206 and unboosted_special <= 432) \
-			or unboosted_special >= 661:
-			badge_stat_boosts["sp_defense"] = true
 
 	badge_type_boost_mask = 0
 	var boosted_types: Array[int] = [
@@ -309,10 +301,14 @@ func clear_badge_boosts() -> void:
 
 
 func _badge_boosted(value: int, key: String) -> int:
+	if key == "sp_defense" and badge_stat_boosts.has("sp_attack"):
+		var special: int = Gen2Stats.apply_stage(int(stats.get("sp_attack", 0)), stage("sp_attack"))
+		if (special >= 206 and special <= 432) or special >= 661:
+			return mini(value + value / 8, Gen2Stats.MAX_STAT_VALUE)
 	if not badge_stat_boosts.has(key):
 		return value
 	@warning_ignore("integer_division")
-	return mini(value + maxi(value / 8, 1), Gen2Stats.MAX_STAT_VALUE)
+	return mini(value + value / 8, Gen2Stats.MAX_STAT_VALUE)
 
 
 func _stat(
@@ -328,11 +324,11 @@ func _stat(
 ## on the copy the stages did, which is why a critical hit reading
 ## [method unmodified_stat] is free of the burn as well as the stages.
 func stat(key: String) -> int:
-	var value: int = _badge_boosted(int(stats.get(key, 0)), key)
+	var value: int = int(stats.get(key, 0))
 	if not STAGED_STATS.has(key):
 		return value
 
-	var out: int = Gen2Stats.apply_stage(value, int(stages.get(key, 0)))
+	var out: int = _badge_boosted(Gen2Stats.apply_stage(value, int(stages.get(key, 0))), key)
 	if key == "attack" and Gen2Status.has(status, Gen2Status.BURN):
 		out = Gen2Status.apply_burn(out)
 	elif key == "speed" and Gen2Status.has(status, Gen2Status.PARALYSIS):
@@ -343,7 +339,7 @@ func stat(key: String) -> int:
 ## A stat with no stage applied, which is what a critical hit uses when the
 ## stages would work against the attacker.
 func unmodified_stat(key: String) -> int:
-	return _badge_boosted(int(stats.get(key, 0)), key)
+	return int(stats.get(key, 0))
 
 
 func stage(key: String) -> int:
@@ -354,29 +350,30 @@ func stage(key: String) -> int:
 ## `BattleCommand_StatUp` and `..._StatDown` both settle "already at the end" on
 ## the way in, ahead of the checks that refuse for another reason.
 func can_change_stage(key: String, by: int) -> bool:
+	return stage_has_room(key, by) and not _stat_at_limit(key, by)
+
+
+func stage_has_room(key: String, by: int) -> bool:
 	if not STAGED_STATS.has(key) and not STAGED_ODDS.has(key):
 		return false
-	var before: int = int(stages.get(key, 0))
-	var after: int = clampi(before + by, Gen2Stats.MIN_STAGE, Gen2Stats.MAX_STAGE)
-	if after == before:
-		return false
-	# RaiseStat moves the stage, recalculates, then puts the stage back and fails
-	# when the real stat has reached MAX_STAT_VALUE.
-	if by > 0 and STAGED_STATS.has(key) \
-			and Gen2Stats.apply_stage(int(stats.get(key, 0)), after) >= Gen2Stats.MAX_STAT_VALUE:
-		return false
-	return true
+	return clampi(stage(key) + by, Gen2Stats.MIN_STAGE, Gen2Stats.MAX_STAGE) != stage(key)
 
 
-## Moves a stage, and answers whether it actually moved: at the top or the bottom
-## the cartridge says so rather than silently doing nothing.
+func _stat_at_limit(key: String, by: int) -> bool:
+	if not STAGED_STATS.has(key):
+		return false
+	return stat(key) == (Gen2Stats.MAX_STAT_VALUE if by > 0 else 1)
+
+
+## RaiseStat and TryLowerStat inspect the old stat after writing the new stage;
+## failure rolls back one stage even when the command requested two.
 func change_stage(key: String, by: int) -> bool:
-	if not can_change_stage(key, by):
+	if not stage_has_room(key, by):
 		return false
-	var before: int = int(stages.get(key, 0))
-	var after: int = clampi(before + by, Gen2Stats.MIN_STAGE, Gen2Stats.MAX_STAGE)
-	stages[key] = after
-	return after != before
+	var limited: bool = _stat_at_limit(key, by)
+	var after: int = clampi(stage(key) + by, Gen2Stats.MIN_STAGE, Gen2Stats.MAX_STAGE)
+	stages[key] = after - signi(by) if limited else after
+	return not limited
 
 
 func reset_stages() -> void:

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -204,11 +204,7 @@ static func stab_damage(
 		@warning_ignore("integer_division")
 		worked = worked * STAB_NUMERATOR / STAB_DENOMINATOR
 
-	var applied: Array = []
-	for defending_type: int in defending:
-		if applied.has(defending_type):
-			continue
-		applied.append(defending_type)
+	for defending_type: int in data.ordered_defending_types(move_type, defending):
 		var multiplier: int = data.type_matchup(move_type, defending_type, foresight)
 		if multiplier == RomLayout.MATCHUP_NO_EFFECT:
 			out["immune"] = true
@@ -267,20 +263,23 @@ static func apply_variation(damage: int, variation: int) -> int:
 ## `BattleCommand_Critical`'s roll, at the level below.
 static func roll_critical(
 	move: Dictionary, rng: RandomNumberGenerator, focus_energy: bool = false,
-	scope_lens: bool = false
+	scope_lens: bool = false, species: int = 0, item: int = 0
 ) -> bool:
 	if int(move.get("power", 0)) <= 0:
 		return false
 	return rng.randi_range(0, 255) < CRITICAL_CHANCES[
-		critical_level(int(move.get("number", 0)), focus_energy, scope_lens)
+		critical_level(int(move.get("number", 0)), focus_energy, scope_lens, species, item)
 	]
 
 
 ## Two for a high-critical move, one for Focus Energy, one for the Scope Lens,
 ## in `BattleCommand_Critical`'s own order.
 static func critical_level(
-	move_number: int, focus_energy: bool = false, scope_lens: bool = false
+	move_number: int, focus_energy: bool = false, scope_lens: bool = false,
+	species: int = 0, item: int = 0
 ) -> int:
+	if (species == 113 and item == 0x1E) or (species == 83 and item == 0x69):
+		return 2 # BattleCommand_Critical jumps straight to .Tally for these pairs.
 	var level: int = 0
 	if HIGH_CRITICAL_MOVES.has(move_number):
 		level += 2
@@ -295,14 +294,11 @@ static func roll_variation(rng: RandomNumberGenerator) -> int:
 	return rng.randi_range(MIN_VARIATION, MAX_VARIATION)
 
 
-## `HitSelfInConfusion`: the Pokémon's own Attack against its own Defense, stages
-## and burn read as a physical hit would, and no STAB, matchup or critical.
-##
-## [param screens] is the confused Pokémon's own side's, doubled off exactly as
-## `PlayerAttackDamage` doubles, so a Reflect halves what confusion takes.
+## `HitSelfInConfusion` reaches DamageCalc with the selected move's type and
+## effect intact. It never calls DamageVariation or consumes a random byte.
 static func confusion_damage(
-	mon: Gen2BattleMon, rng: RandomNumberGenerator, screens: int = Gen2Screens.NONE,
-	link_battle: bool = false
+	mon: Gen2BattleMon, screens: int = Gen2Screens.NONE,
+	link_battle: bool = false, move: Dictionary = {}
 ) -> int:
 	var defense: int = mon.stat("defense")
 	if Gen2Screens.has(screens, Gen2Screens.REFLECT):
@@ -310,11 +306,11 @@ static func confusion_damage(
 	var truncated: Array = truncate_stats(
 		mon.stat("attack"), defense, Gen2WorldState.is_crystal_profile(mon.data) and not link_battle
 	)
-	var damage: int = base_damage(
-		mon.level, CONFUSION_POWER, int(truncated[0]), int(truncated[1])
+	return damage_calc(
+		mon, CONFUSION_POWER, int(truncated[0]), int(truncated[1]),
+		int(move.get("effect", -1)) == Gen2MoveEffect.SELFDESTRUCT,
+		int(move.get("type", RomLayout.TYPE_NORMAL))
 	)
-	damage = mini(damage, DAMAGE_CAP) + MIN_DAMAGE
-	return apply_variation(damage, roll_variation(rng))
 
 
 ## `MagnitudePower` (`data/moves/magnitude_power.asm`), as [threshold, power,
@@ -480,7 +476,7 @@ static func _attack_stat(
 	var key: String = "attack" if physical else "sp_attack"
 	var out: int = attacker.unmodified_stat(key) \
 		if _ignores_stages(attacker, defender, move_type, critical) else attacker.stat(key)
-	if Gen2HeldItem.doubles_attack(attacker.species, attacker.item, physical):
+	if Gen2HeldItem.doubles_attack(attacker.persistent_species(), attacker.item, physical):
 		out *= 2
 	return out
 
@@ -511,7 +507,7 @@ static func _defense_stat(
 ## is `docs/bugs_and_glitches.md`'s Metal Powder entry. Turning
 ## `metal_powder_overflow` off keeps the boosted defence at the byte instead.
 static func metal_powder_pair(defender: Gen2BattleMon, pair: Array) -> Array:
-	if defender == null or not Gen2HeldItem.boosts_defence(defender.species, defender.item):
+	if defender == null or not Gen2HeldItem.boosts_defence(defender.persistent_species(), defender.item):
 		return pair
 	var attack: int = int(pair[0])
 	var boosted: int = Gen2HeldItem.metal_powder_defence(int(pair[1]))

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -214,7 +214,7 @@ const TOXIC_TARGET: StringName = &"toxictarget"
 const FLINCH_TARGET: StringName = &"flinchtarget"
 const CONFUSE_TARGET: StringName = &"confusetarget"
 
-## Heals the attacker for half of what the hit calculated: the Absorb family, and
+## Heals the attacker for half of the damage taken: the Absorb family, and
 ## Dream Eater behind its own rule inside [constant CHECK_HIT].
 const DRAIN_TARGET: StringName = &"draintarget"
 
@@ -761,7 +761,7 @@ static func _do_turn(turn: Gen2Turn) -> void:
 
 	# "If we've gotten this far, this counts as a turn", ahead of the Struggle
 	# check, so Struggle counts even though it spends nothing.
-	turn.attacker().turns_taken += 1
+	turn.attacker().turns_taken = (turn.attacker().turns_taken + 1) & 0xFF
 
 	if turn.slot >= 0 and turn.move_number != Gen2Damage.STRUGGLE:
 		turn.attacker().spend_pp(turn.slot)
@@ -780,6 +780,7 @@ static func _store_energy(turn: Gen2Turn) -> void:
 		return
 	user.substatus &= ~Gen2Substatus.BIDE
 	turn.bide_release = true
+	turn.skip_to = UNLEASH_ENERGY
 	turn.damage = mini(user.bide_damage * 2, 0xFFFF)
 	user.bide_damage = 0
 	turn.emit(Gen2Battle.BIDE_UNLEASHED)
@@ -889,7 +890,8 @@ static func _critical(turn: Gen2Turn) -> void:
 	turn.critical = Gen2Damage.roll_critical(
 		turn.effective_move(), turn.rng(),
 		Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY),
-		Gen2HeldItem.effect_of(turn.data(), attacker.item) == Gen2HeldItem.CRITICAL_UP
+		Gen2HeldItem.effect_of(turn.data(), attacker.item) == Gen2HeldItem.CRITICAL_UP,
+		attacker.species, attacker.item
 	)
 
 
@@ -1545,6 +1547,7 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 		return
 
 	turn.dealt = defender.take_damage(turn.damage)
+	turn.damage = turn.dealt # DoPlayerDamage and DoEnemyDamage replace wCurDamage on underflow.
 	# `wCriticalHit` at 2 is the one-hit line rather than the critical one, which
 	# is the only thing that tells an OHKO's own hit apart from any other.
 	turn.emit(Gen2Battle.OHKO if turn.one_hit_ko else Gen2Battle.HIT, {
@@ -1674,15 +1677,8 @@ static func _doubles_minimize_damage(turn: Gen2Turn) -> bool:
 	return turn.defender().minimized
 
 
-## A quarter of [member Gen2Turn.damage], the calculated number, at least one, and
-## never [member Gen2Turn.dealt]. `BattleCommand_Recoil` reads the same uncapped
-## `wCurDamage` [constant Gen2EffectCommands.DRAIN_TARGET] reads, so a move
-## calculating fifty against a target with three HP left costs a quarter of
-## fifty.
+## BattleCommand_Recoil takes at least one, even after a doll clears wCurDamage.
 static func _recoil(turn: Gen2Turn) -> void:
-	if turn.damage <= 0:
-		return
-
 	var attacker: Gen2BattleMon = turn.attacker()
 	@warning_ignore("integer_division")
 	var taken: int = attacker.take_damage(maxi(turn.damage / RECOIL_DIVISOR, 1))
@@ -1727,7 +1723,8 @@ static func _destiny_bond_takes_user(turn: Gen2Turn) -> void:
 
 ## `CantMove` cancels Bide, a two-turn move, Rollout or rampage, and makes a Fly
 ## or Dig user visible again, so a flinch cannot leave it untouchable.
-static func _cancel_charge(mon: Gen2BattleMon) -> void:
+static func _cant_move(mon: Gen2BattleMon) -> void:
+	mon.fury_cutter_count = 0
 	mon.substatus &= ~(Gen2Substatus.CHARGING | Gen2Substatus.FLYING | Gen2Substatus.UNDERGROUND)
 	mon.charged_move = 0
 	mon.substatus &= ~(Gen2Substatus.ROLLOUT | Gen2Substatus.RAMPAGING)
@@ -1739,53 +1736,56 @@ static func _cancel_charge(mon: Gen2BattleMon) -> void:
 	mon.bide_move = 0
 
 
-## The cartridge's own order: recharge, sleep, freeze, flinch, Disable's
-## countdown, confusion, Attract's roll, a belt-and-braces refusal for a Pokémon
-## still locked into the disabled move, then paralysis. A frozen Pokémon is never
-## asked about paralysis, the status byte saying one thing at a time.
-##
-## Waking up does not cost the turn: the counter runs out, the wake is printed and
-## the remaining checks continue, which is Generation 2's rule and not
-## Generation 1's. Confusion and Disable expire the same way.
-static func _check_status(turn: Gen2Turn) -> void:
+static func _check_sleep(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
-
-	if Gen2Substatus.has(mon.substatus, Gen2Substatus.RECHARGING):
-		_cancel_charge(mon)
-		mon.substatus &= ~Gen2Substatus.RECHARGING
-		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"recharge"})
-		turn.end()
-		return
-
 	if Gen2Status.is_asleep(mon.status):
 		mon.status = Gen2Status.tick_sleep(mon.status)
 		if Gen2Status.is_asleep(mon.status):
-			_cancel_charge(mon)
 			turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"sleep"})
 			# `.fast_asleep` prints its line and only then looks at the move:
 			# Snore and Sleep Talk are used through a sleep, so the text stands
 			# and `CantMove` is what they skip.
 			if not SLEEPING_MOVES.has(turn.move_number):
+				_cant_move(mon)
 				turn.end()
 				return
 		else:
 			# `.woke_up` clears `SUBSTATUS_NIGHTMARE`, which has no gate of its
 			# own: left standing it costs an awake Pokemon a quarter a turn.
+			_cant_move(mon)
+			turn.locked = false
 			mon.substatus &= ~Gen2Substatus.NIGHTMARE
 			turn.emit(Gen2Battle.WOKE_UP)
+
+
+## CheckTurn checks recharge, sleep, freeze, flinch, Disable, confusion, Attract,
+## the disabled move, then paralysis.
+static func _check_status(turn: Gen2Turn) -> void:
+	var mon: Gen2BattleMon = turn.attacker()
+
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.RECHARGING):
+		_cant_move(mon)
+		mon.substatus &= ~Gen2Substatus.RECHARGING
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"recharge"})
+		turn.end()
+		return
+
+	_check_sleep(turn)
+	if turn.ended:
+		return
 
 	if Gen2Status.has(mon.status, Gen2Status.FREEZE):
 		# Flame Wheel and Sacred Fire are the only moves used through a freeze.
 		# `CheckPlayerTurn` clears no bit, so the thaw is the `defrost` step in
 		# their own list, behind `applydamage`: a miss leaves the user frozen.
 		if not THAWING_MOVES.has(turn.move_number):
-			_cancel_charge(mon)
+			_cant_move(mon)
 			turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"freeze"})
 			turn.end()
 			return
 
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.FLINCHED):
-		_cancel_charge(mon)
+		_cant_move(mon)
 		mon.substatus &= ~Gen2Substatus.FLINCHED
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"flinch"})
 		turn.end()
@@ -1807,14 +1807,15 @@ static func _check_status(turn: Gen2Turn) -> void:
 		else:
 			turn.emit(Gen2Battle.CONFUSED)
 			if Gen2Substatus.rolls_confusion_hit(turn.rng()):
-				_cancel_charge(mon)
+				mon.substatus &= ~Gen2Substatus.IN_LOOP
 				_hurt_self(turn)
+				_cant_move(mon)
 				turn.end()
 				return
 
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.ATTRACTED) \
 		and Gen2Substatus.rolls_attract_immobile(turn.rng()):
-		_cancel_charge(mon)
+		_cant_move(mon)
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"attract"})
 		turn.end()
 		return
@@ -1824,14 +1825,14 @@ static func _check_status(turn: Gen2Turn) -> void:
 	# still names the slot asked for, so comparing slots would refuse it too.
 	if mon.disabled_slot >= 0 and mon.disabled_slot < mon.moves.size() \
 		and turn.move_number == int(mon.moves[mon.disabled_slot]):
-		_cancel_charge(mon)
+		_cant_move(mon)
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"disabled"})
 		turn.end()
 		return
 
 	if Gen2Status.has(mon.status, Gen2Status.PARALYSIS) \
 		and Gen2Status.rolls_full_paralysis(turn.rng()):
-		_cancel_charge(mon)
+		_cant_move(mon)
 		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"paralysis"})
 		turn.end()
 
@@ -1934,12 +1935,21 @@ static func _status_target(turn: Gen2Turn, flag: int) -> void:
 	# for the end of the turn.
 	turn.battle.use_status_berry(turn.target, turn.events)
 
+	_status_interrupts(turn, flag)
+
+
+static func _status_interrupts(turn: Gen2Turn, flag: int) -> void:
+	var defender: Gen2BattleMon = turn.defender()
 	# `BattleCommand_FreezeTarget`'s tail, behind the berry as the source puts it
 	# behind `UseHeldStatusHealingItem`'s `ret nz`: a freeze a berry already cured
 	# never sets the flag, so it stops no thaw.
 	if flag == Gen2Status.FREEZE \
 		and Gen2Status.has(defender.status, Gen2Status.FREEZE):
+		_cant_move(defender)
+		defender.substatus &= ~Gen2Substatus.RECHARGING
 		turn.battle.mark_just_got_frozen(turn.target)
+	if flag == Gen2Status.SLEEP_MASK and Gen2Status.is_asleep(defender.status):
+		_cant_move(defender)
 
 
 ## Whether the target's type refuses this status, which two of the five ask.
@@ -2023,9 +2033,12 @@ static func _flinch_target(turn: Gen2Turn) -> void:
 		return
 
 	var defender: Gen2BattleMon = turn.defender()
-	if defender.is_fainted():
+	if defender.is_fainted() or Gen2Status.is_asleep(defender.status) \
+		or Gen2Status.has(defender.status, Gen2Status.FREEZE):
 		return
-
+	if turn.battle.opponent_went_first(turn.side):
+		return
+	defender.substatus &= ~Gen2Substatus.RECHARGING
 	defender.substatus |= Gen2Substatus.FLINCHED
 
 
@@ -2073,9 +2086,7 @@ static func _confuse_target(turn: Gen2Turn) -> void:
 	turn.battle.use_confusion_berry(turn.target, turn.events)
 
 
-## Heals the attacker for half of what the hit calculated, at least one: half of
-## [member Gen2Turn.damage] rather than [member Gen2Turn.dealt], the uncapped
-## figure, so fifty against a target with three left heals twenty-five.
+## SapHealth reads wCurDamage after DoPlayerDamage or DoEnemyDamage clamps it.
 static func _drain_target(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
 	@warning_ignore("integer_division")
@@ -2136,16 +2147,12 @@ static func _ohko(turn: Gen2Turn) -> void:
 		turn.end()
 		return
 
-	var accuracy: int = clampi(
+	turn.accuracy = clampi(
 		int(turn.move.get("accuracy", 0)) + (attacker.level - defender.level) * OHKO_LEVEL_BONUS,
 		0, Gen2Accuracy.ALWAYS_HITS
 	)
-	var chance: int = Gen2Accuracy.chance(
-		accuracy, attacker.stage("accuracy"), defender.stage("evasion")
-	)
-	if not Gen2Accuracy.rolls_hit(turn.rng(), chance):
-		turn.emit(Gen2Battle.MISSED, {"target": turn.target})
-		turn.end()
+	_check_hit(turn)
+	if turn.missed:
 		return
 
 	# `ld a, $ff / ld [hli], a / ld [hl], a` over `wCurDamage`, and `wCriticalHit`
@@ -2274,6 +2281,8 @@ static func _rollout_check(turn: Gen2Turn) -> void:
 	var mon: Gen2BattleMon = turn.attacker()
 	if not Gen2Substatus.has(mon.substatus, Gen2Substatus.ROLLOUT):
 		mon.rollout_count = 0
+	else:
+		turn.skip_to = DO_TURN
 
 
 ## `BattleCommand_RolloutPower`, both halves of Rollout: the count and the
@@ -3556,6 +3565,7 @@ static func _kings_rock(turn: Gen2Turn) -> void:
 	):
 		return
 
+	turn.defender().substatus &= ~Gen2Substatus.RECHARGING
 	turn.defender().substatus |= Gen2Substatus.FLINCHED
 
 
@@ -3583,7 +3593,7 @@ static func _stat_change(command: StringName, turn: Gen2Turn) -> void:
 		turn.stat_mist_blocked = true
 		return
 
-	if not turn.battle.mon(side).can_change_stage(stat_key, amount):
+	if not turn.battle.mon(side).stage_has_room(stat_key, amount):
 		return
 
 	if not targets_user and _computer_stat_down_misses(turn):
@@ -3805,7 +3815,7 @@ static func _disobedient_idle(turn: Gen2Turn) -> void:
 static func _hurt_self(turn: Gen2Turn) -> void:
 	var user: Gen2BattleMon = turn.attacker()
 	var dealt: int = user.take_damage(Gen2Damage.confusion_damage(
-		user, turn.rng(), turn.battle.screens[turn.side], turn.battle.is_link_battle
+		user, turn.battle.screens[turn.side], turn.battle.is_link_battle, turn.effective_move()
 	))
 	turn.emit(Gen2Battle.HURT_ITSELF, {
 		"amount": dealt, "hp": user.hp, "max_hp": user.max_hp(),

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1490,6 +1490,20 @@ func mod_type_numbers() -> Array[int]:
 	return _overlay.defined_numbers(Gen2ContentOverlay.KIND_TYPE)
 
 
+## BattleCommand_Stab walks TypeMatchups in table order, not the species' slots.
+func ordered_defending_types(attacking: int, defending: Array) -> Array:
+	var out: Array = []
+	var keys: Array = _matchups.keys()
+	for key: int in keys:
+		for kind: int in defending:
+			if key == Gen2ContentOverlay.matchup_number(attacking, kind) and not out.has(kind):
+				out.append(kind)
+	for kind: int in defending:
+		if not out.has(kind):
+			out.append(kind)
+	return out
+
+
 ## How effective [param attacking] is against [param defending], in tenths: 0 an
 ## immunity, 5 a resistance, 20 a weakness, 10 otherwise. Tenths because that is
 ## what the cartridge stores and what the damage formula divides by, truncating
@@ -1531,11 +1545,7 @@ func _matchup_row(key: int) -> Dictionary:
 ## damage. A single-type Pokemon carries its type in both slots and repeats skip.
 func type_effectiveness(attacking: int, defending: Array, foresight: bool = false) -> int:
 	var out: int = RomLayout.MATCHUP_EFFECTIVE
-	var applied: Array = []
-	for defending_type: int in defending:
-		if applied.has(defending_type):
-			continue
-		applied.append(defending_type)
+	for defending_type: int in ordered_defending_types(attacking, defending):
 		@warning_ignore("integer_division")
 		out = out * type_matchup(attacking, defending_type, foresight) \
 			/ RomLayout.MATCHUP_EFFECTIVE

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -131,12 +131,14 @@ func test_a_stage_at_the_end_of_its_range_reports_that_it_did_not_move() -> void
 	assert_eq(mon.stage("attack"), Gen2Stats.MAX_STAGE)
 
 
-func test_a_stage_that_would_leave_the_real_stat_at_999_is_put_back() -> void:
+func test_a_stat_can_reach_999_and_only_the_next_raise_fails() -> void:
 	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
 	mon.stats["attack"] = 800
-	assert_false(mon.can_change_stage("attack", 1))
+	assert_true(mon.can_change_stage("attack", 1))
+	assert_true(mon.change_stage("attack", 1))
+	assert_eq(mon.stat("attack"), 999)
 	assert_false(mon.change_stage("attack", 1))
-	assert_eq(mon.stage("attack"), 0)
+	assert_eq(mon.stage("attack"), 1)
 
 
 func test_hp_has_no_stage() -> void:
@@ -216,7 +218,8 @@ func test_badge_stat_boosts_are_active_battle_values_and_clear_cleanly() -> void
 	assert_gt(mon.stat("attack"), attack)
 	assert_gt(mon.stat("defense"), defense)
 	assert_gt(mon.stat("speed"), speed)
-	assert_gt(mon.unmodified_stat("sp_attack"), special)
+	assert_gt(mon.stat("sp_attack"), special)
+	assert_eq(mon.unmodified_stat("sp_attack"), special)
 	assert_eq(mon.unmodified_stat("sp_defense"), special_defense)
 	assert_false(mon.badge_stat_boosts.has("sp_defense"))
 	mon.clear_badge_boosts()
@@ -358,3 +361,27 @@ func test_rolled_dvs_stay_inside_a_nibble_each() -> void:
 		assert_between(Gen2Stats.attack_dv(dvs), 0, Gen2Stats.MAX_DV)
 		assert_between(Gen2Stats.special_dv(dvs), 0, Gen2Stats.MAX_DV)
 		assert_eq(dvs & ~0xFFFF, 0)
+
+
+func test_stat_limit_refusals_roll_back_only_one_of_two_requested_stages() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.stats.attack = 999
+	assert_false(mon.change_stage("attack", 2))
+	assert_eq(mon.stage("attack"), 1)
+	mon.stats.defense = 1
+	assert_false(mon.change_stage("defense", -2))
+	assert_eq(mon.stage("defense"), -1)
+
+
+func test_badges_follow_stage_rounding_and_glacier_reads_the_staged_special_attack() -> void:
+	var mon: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	mon.stats.attack = 7
+	mon.stats.sp_attack = 150
+	mon.stats.sp_defense = 100
+	mon.set_badge_boosts(0x41)
+	mon.stages.attack = 1
+	assert_eq(mon.stat("attack"), 11)
+	assert_eq(mon.unmodified_stat("attack"), 7)
+	assert_eq(mon.stat("sp_defense"), 100)
+	mon.stages.sp_attack = 1
+	assert_eq(mon.stat("sp_defense"), 112)

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -612,7 +612,39 @@ func test_crystal_link_stats_use_one_shift_for_hits_and_confusion() -> void:
 	assert_eq(Gen2Damage.damage_stats(attacker, defender, 0, false, Gen2Screens.REFLECT), [6, 75])
 	assert_eq(Gen2Damage.damage_stats(attacker, defender, 0, false, Gen2Screens.REFLECT, true), [25, 44])
 	attacker.stats["defense"] = 600
-	var generator := RandomNumberGenerator.new()
-	generator.seed = 1
-	assert_between(Gen2Damage.confusion_damage(attacker, generator, Gen2Screens.REFLECT), 2, 3)
-	assert_between(Gen2Damage.confusion_damage(attacker, generator, Gen2Screens.REFLECT, true), 10, 12)
+	assert_eq(Gen2Damage.confusion_damage(attacker, Gen2Screens.REFLECT), 3)
+	assert_eq(Gen2Damage.confusion_damage(attacker, Gen2Screens.REFLECT, true), 12)
+
+
+func test_lucky_punch_and_stick_replace_the_other_critical_bonuses() -> void:
+	for pair: Array in [[113, 30], [83, 105]]:
+		for move: int in [Fixture.TACKLE, Fixture.SLASH]:
+			assert_eq(Gen2Damage.critical_level(move, true, false, pair[0], pair[1]), 2)
+			assert_eq(Gen2Damage.critical_level(move, true, false, 1, pair[1]), Gen2Damage.critical_level(move, true))
+
+
+func test_confusion_uses_the_selected_moves_item_boost_and_selfdestruct_effect() -> void:
+	var mon: Gen2BattleMon = _mon(Fixture.PIKACHU)
+	mon.stats.attack = 100
+	mon.stats.defense = 100
+	mon.item = Fixture.MAGNET
+	assert_eq(Gen2Damage.confusion_damage(mon, 0, false, {"type": 23}), 20)
+	assert_eq(Gen2Damage.confusion_damage(mon, 0, false, {"type": 20}), 19)
+	assert_eq(Gen2Damage.confusion_damage(mon, 0, false, {"type": 23, "effect": Gen2MoveEffect.SELFDESTRUCT}), 40)
+
+
+func test_species_items_read_the_persistent_species_through_transform() -> void:
+	for pair: Array in [[Fixture.CUBONE, Fixture.THICK_CLUB, 0], [Fixture.PIKACHU, Fixture.LIGHT_BALL, 20]]:
+		var user: Gen2BattleMon = _mon(pair[0])
+		var target: Gen2BattleMon = _mon(Fixture.GEODUDE)
+		user.item = pair[1]
+		assert_true(user.transform_into(target))
+		user.stats.attack = 100
+		user.stats.sp_attack = 100
+		target.stats.defense = 100
+		target.stats.sp_defense = 100
+		assert_eq(Gen2Damage.damage_stats(user, target, pair[2], false), [200, 100])
+	var ditto: Gen2BattleMon = _mon(Fixture.DITTO)
+	ditto.item = Fixture.METAL_POWDER
+	assert_true(ditto.transform_into(_mon(Fixture.PIKACHU)))
+	assert_eq(Gen2Damage.metal_powder_pair(ditto, [100, 100]), [100, 150])

--- a/tests/unit/test_move_effect.gd
+++ b/tests/unit/test_move_effect.gd
@@ -402,12 +402,7 @@ func test_an_ordinary_move_spends_its_slot() -> void:
 	assert_eq(int(battle.player.pp[0]), before - 1)
 
 
-## A quarter of [member Gen2Turn.damage], the number the formula calculated,
-## never [member Gen2Turn.dealt], the number that actually came off a target
-## with less left than that: the real cartridge's own recoil reads the same
-## uncapped figure drain does. A target with 3 HP left against a hit worth 20
-## costs the attacker a quarter of 20, not a quarter of 3.
-func test_recoil_is_a_quarter_of_what_the_formula_calculated_and_never_nothing() -> void:
+func test_recoil_reads_the_damage_word_and_takes_at_least_one() -> void:
 	var battle: Gen2Battle = _battle()
 	var turn: Gen2Turn = _turn(battle)
 	turn.damage = 20
@@ -422,10 +417,10 @@ func test_recoil_is_a_quarter_of_what_the_formula_calculated_and_never_nothing()
 	assert_eq(int(_first(second.events, Gen2Battle.RECOIL)["amount"]), 1)
 
 
-func test_a_move_that_dealt_nothing_costs_nothing_in_recoil() -> void:
+func test_recoil_takes_one_even_after_a_substitute_clears_damage() -> void:
 	var turn: Gen2Turn = _turn(_battle())
 	Gen2EffectCommands.run(Gen2EffectCommands.RECOIL, turn)
-	assert_eq(turn.events.size(), 0)
+	assert_eq(int(_first(turn.events, Gen2Battle.RECOIL)["amount"]), 1)
 
 
 func test_flinch_hit_is_the_secondary_shape_with_flinch_target_in_it() -> void:
@@ -969,9 +964,7 @@ func test_the_two_drain_lists_differ_only_in_the_kings_rock_step() -> void:
 	)
 
 
-func test_drain_heals_half_of_what_was_calculated_not_what_was_taken() -> void:
-	# A target with three hit points left takes three, but the drain reads the
-	# uncapped fifty the formula worked out, the cartridge's own quirk.
+func test_drain_heals_half_the_hp_taken_after_the_damage_word_is_clamped() -> void:
 	var battle: Gen2Battle = _battle()
 	battle.enemy.hp = 3
 	battle.player.hp = 1
@@ -981,7 +974,7 @@ func test_drain_heals_half_of_what_was_calculated_not_what_was_taken() -> void:
 	assert_eq(turn.dealt, 3, "clamped to what was left to take")
 
 	Gen2EffectCommands.run(Gen2EffectCommands.DRAIN_TARGET, turn)
-	assert_eq(int(_first(turn.events, Gen2Battle.DRAINED)["amount"]), 25, "half of fifty, not of three")
+	assert_eq(int(_first(turn.events, Gen2Battle.DRAINED)["amount"]), 1, "half of the three HP taken")
 	assert_eq(_first(turn.events, Gen2Battle.DRAINED)["from"], turn.target)
 
 
@@ -1075,7 +1068,7 @@ func test_psywave_stays_inside_its_own_range() -> void:
 
 func test_ohko_rolls_its_own_accuracy_and_leaves_the_damage_to_applydamage() -> void:
 	# `OHKOHit` carries no `checkhit`: the command calls it itself, so the three
-	# moves are the one place a locked-on flying target is still out of reach.
+	# moves pass the same gates as every other hit.
 	# It carries no `damagestats` or `damagecalc` either, the damage being $FFFF.
 	var sequence: Array = Gen2MoveEffect.sequence_for(Gen2MoveEffect.OHKO)
 	assert_true(sequence.has(Gen2EffectCommands.OHKO))
@@ -1652,11 +1645,12 @@ func test_kings_rock_flinches_out_of_its_own_parameter() -> void:
 	var flinched: int = 0
 	for seed_value: int in 256:
 		battle.rng.seed = seed_value
-		battle.enemy.substatus = Gen2Substatus.NONE
+		battle.enemy.substatus = Gen2Substatus.RECHARGING
 		var turn: Gen2Turn = _turn(battle, Fixture.TACKLE)
 		Gen2EffectCommands.run(Gen2EffectCommands.KINGS_ROCK, turn)
 		if Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.FLINCHED):
 			flinched += 1
+			assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.RECHARGING))
 
 	assert_between(flinched, 10, 60, "roughly thirty in 256 across 256 seeds")
 
@@ -3903,17 +3897,16 @@ func test_a_locked_on_flying_target_is_still_missed_by_the_ground_moves() -> voi
 	assert_false(_run_move(battle, Fixture.TACKLE).missed)
 
 
-## Fissure's own list has no `checkhit`, so the flag it is named against is
-## neither read nor spent by it.
-func test_fissure_never_reaches_the_lock_on_read() -> void:
+## OHKO calls CheckHit internally, including its Lock-On read.
+func test_fissure_reaches_the_lock_on_read_inside_ohko() -> void:
 	assert_false(
 		Gen2MoveEffect.sequence_for(Gen2MoveEffect.OHKO).has(Gen2EffectCommands.CHECK_HIT),
-		"`OHKOHit` rolls its own accuracy instead"
+		"the command calls CheckHit internally"
 	)
 	var battle: Gen2Battle = _battle()
 	battle.enemy.substatus |= Gen2Substatus.LOCK_ON
 	_run_move(battle, Fixture.FISSURE)
-	assert_true(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON))
+	assert_false(Gen2Substatus.has(battle.enemy.substatus, Gen2Substatus.LOCK_ON))
 
 
 ## `.Protect` is asked before `.LockOn`, so a Protect turns a locked-on move away
@@ -5008,3 +5001,148 @@ func test_a_disobedient_sleeping_move_preserves_encore_and_spends_no_pp() -> voi
 		assert_eq(battle.player.encore_turns, 3)
 		assert_eq(battle.player.status, 3)
 	assert_true(seen)
+
+
+func test_every_turn_refusal_clears_fury_cutter_and_move_locks() -> void:
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		for reason: String in ["recharge", "sleep", "freeze", "flinch", "confusion", "attract", "disabled", "paralysis"]:
+			var refused: bool = false
+			for seed_value: int in 32:
+				var battle: Gen2Battle = _battle()
+				battle.rng.seed = seed_value
+				var mon: Gen2BattleMon = battle.mon(side)
+				_arm_move_locks(mon)
+				match reason:
+					"recharge": mon.substatus |= Gen2Substatus.RECHARGING
+					"sleep": mon.status = 3
+					"freeze": mon.status = Gen2Status.FREEZE
+					"flinch": mon.substatus |= Gen2Substatus.FLINCHED
+					"confusion":
+						mon.substatus |= Gen2Substatus.CONFUSED | Gen2Substatus.IN_LOOP
+						mon.confusion_turns = 3
+					"attract": mon.substatus |= Gen2Substatus.ATTRACTED
+					"disabled":
+						mon.disabled_slot = 0
+						mon.disable_turns = 3
+					"paralysis": mon.status = Gen2Status.PARALYSIS
+				var turn := Gen2Turn.create(battle, side, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), [])
+				Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+				if not turn.ended:
+					continue
+				refused = true
+				_assert_move_locks_clear(mon)
+				if reason == "confusion":
+					assert_false(Gen2Substatus.has(mon.substatus, Gen2Substatus.IN_LOOP))
+				break
+			assert_true(refused, reason)
+
+
+func _arm_move_locks(mon: Gen2BattleMon) -> void:
+	mon.fury_cutter_count = 4
+	mon.charged_move = Fixture.TACKLE
+	mon.rampage_move = Fixture.TACKLE
+	mon.bide_move = Fixture.TACKLE
+	mon.substatus |= Gen2Substatus.CHARGING | Gen2Substatus.RAMPAGING | Gen2Substatus.BIDE | Gen2Substatus.ROLLOUT
+
+
+func _assert_move_locks_clear(mon: Gen2BattleMon) -> void:
+	assert_eq(mon.fury_cutter_count, 0)
+	assert_eq(mon.charged_move, 0)
+	assert_eq(mon.rampage_move, 0)
+	assert_eq(mon.bide_move, 0)
+	assert_eq(mon.substatus & (Gen2Substatus.CHARGING | Gen2Substatus.RAMPAGING | Gen2Substatus.BIDE | Gen2Substatus.ROLLOUT), 0)
+
+
+func test_waking_clears_locks_but_sleeping_moves_skip_the_reset() -> void:
+	for number: int in [Fixture.TACKLE, Fixture.SNORE, Fixture.SLEEP_TALK]:
+		var turn: Gen2Turn = _turn(_battle(), number)
+		_arm_move_locks(turn.attacker())
+		turn.locked = true
+		turn.attacker().status = 1
+		Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+		_assert_move_locks_clear(turn.attacker())
+		assert_false(turn.locked)
+		assert_false(turn.ended)
+		if number == Fixture.TACKLE:
+			continue
+		_arm_move_locks(turn.attacker())
+		turn.attacker().status = 3
+		Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+		assert_eq(turn.attacker().fury_cutter_count, 4)
+		assert_false(turn.ended)
+
+
+func test_sleep_and_freeze_cancel_locks_only_when_a_berry_did_not_cure_them() -> void:
+	for command: StringName in [Gen2EffectCommands.SLEEP_TARGET, Gen2EffectCommands.FREEZE_TARGET]:
+		for berry: int in [0, Fixture.MIRACLEBERRY]:
+			var turn: Gen2Turn = _turn(_battle(), Fixture.SLEEP_POWDER)
+			_arm_move_locks(turn.defender())
+			turn.defender().substatus |= Gen2Substatus.RECHARGING
+			turn.defender().item = berry
+			Gen2EffectCommands.run(command, turn)
+			if berry != 0:
+				assert_eq(turn.defender().fury_cutter_count, 4)
+				assert_true(Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.RECHARGING))
+				continue
+			_assert_move_locks_clear(turn.defender())
+			assert_eq(Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.RECHARGING), command == Gen2EffectCommands.SLEEP_TARGET)
+
+
+func test_flinching_clears_recharge_and_refuses_sleep_freeze_and_a_finished_turn() -> void:
+	for status: int in [Gen2Status.NONE, 3, Gen2Status.FREEZE]:
+		var turn: Gen2Turn = _turn(_battle())
+		turn.defender().status = status
+		turn.defender().substatus |= Gen2Substatus.RECHARGING
+		Gen2EffectCommands.run(Gen2EffectCommands.FLINCH_TARGET, turn)
+		assert_eq(Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.FLINCHED), status == 0)
+		assert_eq(Gen2Substatus.has(turn.defender().substatus, Gen2Substatus.RECHARGING), status != 0)
+	var late: Gen2Turn = _turn(_battle())
+	late.side = Gen2Battle.ENEMY
+	late.target = Gen2Battle.PLAYER
+	Gen2EffectCommands.run(Gen2EffectCommands.FLINCH_TARGET, late)
+	assert_false(Gen2Substatus.has(late.defender().substatus, Gen2Substatus.FLINCHED))
+
+
+func test_ohko_obeys_immunity_protect_hidden_targets_and_x_accuracy() -> void:
+	for gate: int in [Gen2Substatus.PROTECT, Gen2Substatus.FLYING, Gen2Substatus.UNDERGROUND]:
+		var turn: Gen2Turn = _turn(_battle(), Fixture.OHKO_MOVE)
+		turn.defender().substatus = gate
+		turn.attacker().substatus |= Gen2Substatus.X_ACCURACY
+		Gen2EffectCommands.run(Gen2EffectCommands.OHKO, turn)
+		assert_true(turn.missed)
+		assert_eq(turn.damage, 0)
+	var immune: Gen2Turn = _turn(_battle(), Fixture.OHKO_MOVE)
+	immune.immune = true
+	Gen2EffectCommands.run(Gen2EffectCommands.OHKO, immune)
+	assert_true(immune.missed)
+	var aimed: Gen2Turn = _turn(_battle(), Fixture.OHKO_MOVE)
+	aimed.attacker().substatus |= Gen2Substatus.X_ACCURACY
+	aimed.move = aimed.move.duplicate()
+	aimed.move.accuracy = 0
+	Gen2EffectCommands.run(Gen2EffectCommands.OHKO, aimed)
+	assert_eq(aimed.damage, 65535)
+
+
+func test_confusion_damage_consumes_no_random_draw_after_the_hit_decision() -> void:
+	var turn: Gen2Turn = _turn(_battle())
+	var expected := RandomNumberGenerator.new()
+	expected.seed = 12345
+	expected.randi_range(0, 255)
+	turn.attacker().substatus = Gen2Substatus.CONFUSED
+	turn.attacker().confusion_turns = 3
+	Gen2EffectCommands.run(Gen2EffectCommands.CHECK_STATUS, turn)
+	assert_true(turn.ended)
+	assert_eq(turn.rng().state, expected.state)
+
+
+func test_lethal_damage_is_recorded_before_it_is_clamped_for_recoil() -> void:
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		var battle: Gen2Battle = _battle()
+		var turn := Gen2Turn.create(battle, side, 0, Fixture.TACKLE, _data.move(Fixture.TACKLE), [])
+		turn.defender().hp = 3
+		turn.damage = 50
+		Gen2EffectCommands.run(Gen2EffectCommands.APPLY_DAMAGE, turn)
+		assert_eq(turn.damage, 3)
+		assert_eq(int(battle.last_damage_taken(turn.target).damage), 50)
+		Gen2EffectCommands.run(Gen2EffectCommands.RECOIL, turn)
+		assert_eq(int(_first(turn.events, Gen2Battle.RECOIL).amount), 1)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -15,7 +15,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37762
+const MAX_COMMENT_LINES: int = 37742
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/move_effects.gd
+++ b/tools/checks/move_effects.gd
@@ -86,6 +86,8 @@ func run(r: RefCounted) -> void:
 		_r.game_id = game_id
 		compared += _compare(pin, data)
 		_check_obedience_corpus(data)
+		_check_damage_matchup_corpus(data)
+		_check_critical_item_corpus(data)
 		_r.game_id = &""
 	if compared == 0:
 		print("no pin was checked out; move_effects compared nothing.")
@@ -250,3 +252,47 @@ func _check_obedience_corpus(data: GameData) -> void:
 				"move %d obedience exemption %d" % [number, mode])
 			checked += 1
 	print("%s: %d move obedience exemptions." % [data.id, checked])
+
+
+func _check_damage_matchup_corpus(data: GameData) -> void:
+	var rows: Array = JSON.parse_string(FileAccess.get_file_as_string(RomCache.matchups_path(data.directory)))
+	var user: Gen2BattleMon = Gen2BattleMon.create(data, 25, 50)
+	user.battle_types.assign([6, 6])
+	var checked: int = 0
+	for kind: int in [0, 1, 2, 3, 4, 5, 7, 8, 9, 20, 21, 22, 23, 24, 25, 26, 27]:
+		for species: int in range(1, 252):
+			var target: Gen2BattleMon = Gen2BattleMon.create(data, species, 50)
+			var expected: int = 13
+			for row: Dictionary in rows:
+				if int(row.attacker) != kind or not target.types().has(int(row.defender)):
+					continue
+				if int(row.multiplier) == 0:
+					expected = 0
+				elif expected > 0:
+					expected = maxi(expected * int(row.multiplier) / 10, 1)
+			var got: Dictionary = Gen2Damage.stab_damage(user, target, {"number": 33, "type": kind}, 13)
+			_r.check(int(got.damage) == expected, "type %d against species %d: %d, expected %d" % [kind, species, got.damage, expected])
+			checked += 1
+	print("%s: %d damage matchups in cartridge table order." % [data.id, checked])
+
+
+func _check_critical_item_corpus(data: GameData) -> void:
+	var checked: int = 0
+	for species: int in [83, 113]:
+		var item: int = 105 if species == 83 else 30
+		var battle: Gen2Battle = Gen2Battle.create(data, Gen2BattleMon.create(data, species, 50), Gen2BattleMon.create(data, 1, 50), RandomNumberGenerator.new())
+		battle.player.item = item
+		battle.player.substatus |= Gen2Substatus.FOCUS_ENERGY
+		for number: int in range(1, 252):
+			for seed_value: int in [1, 2, 3, 4]:
+				battle.rng.seed = seed_value
+				var expected_rng := RandomNumberGenerator.new()
+				expected_rng.seed = seed_value
+				var expected: bool = false
+				if int(data.move(number).power) > 0:
+					expected = expected_rng.randi_range(0, 255) < 64
+				var turn := Gen2Turn.create(battle, 0, 0, number, data.move(number), [])
+				Gen2EffectCommands.run(Gen2EffectCommands.CRITICAL, turn)
+				_r.check(turn.critical == expected and battle.rng.state == expected_rng.state, "species %d critical item, move %d, seed %d" % [species, number, seed_value])
+				checked += 1
+	print("%s: %d species-item critical decisions." % [data.id, checked])

--- a/tools/replay_world.gd
+++ b/tools/replay_world.gd
@@ -6,8 +6,8 @@ extends SceneTree
 ## [Gen2WorldSnapshot] JSON plus the play timer, which either matches byte for byte
 ## or does not. Four runs per route from the same seed and log: record, replay, and
 ## the same log driven by `_process` at 30 and 144 fps, which is what says the pump
-## rather than the host spends frames. The corpus is twenty-seven generated walks,
-## one scripted errand and one wild battle, the battle being the seam this closes.
+## rather than the host spends frames. Each of the three profiles runs nine
+## generated walks, one scripted errand and one wild battle: thirty-three routes.
 
 const GAMES: Array[StringName] = [&"gold", &"silver", &"crystal"]
 ## Twenty seconds of hardware frames: long enough for several walks, a script
@@ -298,8 +298,6 @@ func _run(
 	var battles: int = 0
 	if adaptive:
 		battles = _drive(screen, frames)
-	elif host_fps <= 0.0:
-		screen.advance_frames(frames)
 	elif host_fps <= 0.0:
 		screen.advance_frames(frames)
 	else:


### PR DESCRIPTION
Battle effects disagreed with cartridge behavior at shared damage and turn-state boundaries. For example, a hit calculating 50 damage against 3 HP healed 25 HP with a draining move; the cartridge clamps the damage word first and heals 1 HP.

- Apply the HP clamp after Counter and Bide record damage, preserve recoil's one-point minimum, and follow cartridge type-table rounding order.
- Correct stage limits, badge ordering, critical stat bypass, Lucky Punch and Stick, and species-item behavior after Transform.
- Route one-hit knockout moves through the shared hit checks and preserve the selected move's modifiers during confusion damage without an extra random draw.
- Reset interrupted move state consistently, honor sleep and flinch exceptions, and correct Bide/Rollout command skipping and the byte-sized turn counter.
- Add regressions and full move/species corpora, remove a dead replay branch, correct stale comments, and lower the comment ceiling.

Validation:

| Check | Result |
|---|---|
| Unit and integration suite | 4,241 tests pass; final affected test file also passes |
| Direct cartridge comparisons | 22,539 cases match across Gold, Silver and Crystal |
| Added matchup and critical-item corpus | 18,825 cases pass; reversed type order produces 399 failures |
| Full validation | All 84 topics pass |
| Replay | 33 routes, zero failures before and after |
| Full story walks | All three profiles complete with 16 badges before and after |
| Editor analysis | Zero warnings in 614 scripts |
| Boot and release gates | Normal boot, mod boot and release gates pass |
