### PR TITLE
Restore Battle Tower battle boundaries

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1163,7 +1163,8 @@ func _enemy_entrance(events: Array, offer: bool) -> void:
 ## one, given a started battle, somebody else to send, SET off and the player's
 ## own Pokémon standing. A wild has no trainer to switch.
 func should_offer_switch() -> bool:
-	return is_trainer_battle and not battle_style_set \
+	return is_trainer_battle and not battle_style_set and not in_battle_tower \
+		and not is_link_battle \
 		and party(PLAYER).healthy_count() > 1 and not mon(PLAYER).is_fainted()
 
 
@@ -2431,6 +2432,10 @@ func _use_trainer_item(side: int, item: int, events: Array) -> void:
 	})
 
 
+func allows_bag_items() -> bool:
+	return not in_battle_tower and not is_link_battle
+
+
 ## `DoItemEffect` with `wBattleMode` set, the pack's own USE inside a battle:
 ## applied here rather than in the turn loop, as the cartridge applies it in the
 ## menu and then spends the turn as `BATTLEPLAYERACTION_USEITEM`.
@@ -2440,6 +2445,8 @@ func _use_trainer_item(side: int, item: int, events: Array) -> void:
 func use_bag_item(item: int, target_index: int = -1, move_slot: int = -1) -> Dictionary:
 	if data == null or is_over():
 		return _item_failure(&"battle_not_running")
+	if not allows_bag_items():
+		return _item_failure(&"items_cant_be_used_here")
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
 		return _item_failure(&"unknown_item")

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -636,6 +636,12 @@ func heal(amount: int) -> int:
 	return healed
 
 
+func restore_health() -> void:
+	hp = max_hp()
+	status = Gen2Status.NONE
+	restore_pp()
+
+
 ## PP for a move slot, or zero for a slot that holds nothing.
 func pp_left(slot: int) -> int:
 	return int(pp[slot]) if slot >= 0 and slot < pp.size() else 0

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -215,6 +215,7 @@ var _world_battle_request: Dictionary = {}
 ## battle has none and plays the installed set.
 var _injected_rules: Gen2Rules = null
 var _world_battle_completion_sent: bool = false
+var _world_battle_result_picture_shown: bool = false
 var _world_battle_terminal_text_shown: bool = false
 var _world_battle_recovery_shown: bool = false
 var _world_battle_recovery: Dictionary = {}
@@ -638,6 +639,10 @@ func advance_faint() -> bool:
 	Gen2BattleScreenMap.faint_step(_bg_map, bool(faint["player_side"]))
 	if int(faint["step"]) >= Gen2BattleScreenMap.FAINT_STEPS:
 		_faints.remove_at(0)
+		if bool(faint["player_side"]):
+			_player_hud_visible = false
+		else:
+			_enemy_hud_visible = false
 	_push_view()
 	return true
 
@@ -652,6 +657,8 @@ func advance_slide() -> bool:
 	if _slides.is_empty():
 		return false
 	var slide: Dictionary = _slides[0]
+	if bool(slide.get("incoming", false)):
+		return _advance_result_slide(slide)
 	slide["delay"] = int(slide["delay"]) - 1
 	if int(slide["delay"]) > 0:
 		return true
@@ -665,6 +672,23 @@ func advance_slide() -> bool:
 	)
 	if int(slide["step"]) >= int(Gen2BattleScreenMap.SLIDE_STEPS[player_side]):
 		_slides.remove_at(0)
+	_push_view()
+	return true
+
+
+func _advance_result_slide(slide: Dictionary) -> bool:
+	slide["delay"] = int(slide["delay"]) - 1
+	if int(slide["delay"]) > 0:
+		return true
+	var step: int = int(slide["step"])
+	if step == 6:
+		_slides.remove_at(0)
+		return true
+	step += 1
+	slide["step"] = step
+	slide["delay"] = 44 if step == 6 else 4
+	Gen2BattleScreenMap.result_trainer_step(_bg_map, step)
+	_slid_pixels[Gen2Battle.ENEMY] = float((8 - step) * Gen2Tiles.TILE_WIDTH)
 	_push_view()
 	return true
 
@@ -1002,6 +1026,7 @@ func show_matchup(
 	_world_battle_tutorial = false
 	_world_battle_request = {}
 	_world_battle_completion_sent = false
+	_world_battle_result_picture_shown = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
 	_earnings_computed = {}
@@ -1041,6 +1066,7 @@ func show_trainer(
 	_world_battle_tutorial = false
 	_world_battle_request = {}
 	_world_battle_completion_sent = false
+	_world_battle_result_picture_shown = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
 	_earnings_computed = {}
@@ -1087,6 +1113,7 @@ func show_saved_party(save: Gen2SaveData) -> bool:
 	_world_battle_tutorial = false
 	_world_battle_request = {}
 	_world_battle_completion_sent = false
+	_world_battle_result_picture_shown = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
 	_earnings_computed = {}
@@ -1185,6 +1212,7 @@ func _begin_world_battle(prepared: Dictionary, save: Gen2SaveData) -> void:
 	_world_battle_request = (prepared.get("request", {}) as Dictionary).duplicate(true)
 	_world_battle_tutorial = bool(_world_battle_request.get("tutorial", false))
 	_world_battle_completion_sent = false
+	_world_battle_result_picture_shown = false
 	_world_battle_terminal_text_shown = false
 	_world_battle_recovery_shown = false
 	_earnings_computed = {}
@@ -1362,7 +1390,8 @@ func entrance_running() -> bool:
 func _init_battle_display() -> void:
 	## The engine is scene-free, so `wOptions` is injected here, the one place
 	## every battle passes through.
-	_battle.battle_style_set = Gen2OptionsStore.current().battle_style_set
+	_battle.battle_style_set = _battle.in_battle_tower \
+		or Gen2OptionsStore.current().battle_style_set
 	_battle.battle_scene_on = Gen2OptionsStore.current().battle_scene
 	## `InitBattleDisplay` draws both pics, so the letters start from the party
 	## the same way the species above do; every later change is a send-out.
@@ -1457,7 +1486,7 @@ func _build_entrance() -> void:
 			show_message(text)
 		return
 
-	var trainer: bool = _enemy_trainer_class > 0
+	var trainer: bool = _battle.is_trainer_battle
 	if trainer:
 		_entrance_stages.append({
 			"sfx": SFX_SHINE, "wait_sfx": true, "delay": TRAINER_START_FRAMES,
@@ -1645,7 +1674,7 @@ func _apply_entrance_step(what: StringName) -> void:
 func _enemy_battler_label() -> String:
 	if _data == null:
 		return "Enemy"
-	if _enemy_trainer_class <= 0:
+	if _enemy_trainer_class <= 0 or (_battle != null and _battle.is_link_battle):
 		## `wOTPlayerName`, which the request carries: a link opponent is not in
 		## any trainer table, so there is nothing to look the name up in.
 		var linked: String = String(_world_battle_request.get("trainer_name", ""))
@@ -1712,7 +1741,7 @@ func _build_trainer_huds() -> void:
 	_hud_balls = []
 	_hud_border = []
 	_add_trainer_hud(Gen2Battle.PLAYER)
-	if _enemy_trainer_class > 0:
+	if _battle != null and _battle.is_trainer_battle:
 		_add_trainer_hud(Gen2Battle.ENEMY)
 
 
@@ -2709,6 +2738,10 @@ func battle_pack_items() -> Array[int]:
 func open_battle_pack() -> Dictionary:
 	if _battle == null or _battle.is_over() or not _pending.is_empty():
 		return {"ok": false, "reason": &"battle_events_pending"}
+	_close_battle_menu()
+	if not _battle.allows_bag_items():
+		show_message("Items can't be\nused here.")
+		return {"ok": false, "reason": &"items_cant_be_used_here"}
 	if _pack_rows.is_empty():
 		show_message("You have no items to use!")
 		return {"ok": false, "reason": &"no_usable_items"}
@@ -3360,13 +3393,7 @@ func _hurt(mon: Gen2BattleMon) -> void:
 	_read_hp()
 
 
-## Plays one turn out, and the events come back to be shown one at a time.
-##
-## The player picks at random from what it knows, since no menu exists yet; so
-## does the enemy, unless it is a real trainer ([method show_trainer] rather than
-## [method show_matchup]), where [Gen2BattleAI] scores the choice from that
-## class's AI flags. Random rather than the first slot, so the other three moves
-## are ever seen.
+## Development turn driver: random player move and the opponent's usual policy.
 func take_turn() -> void:
 	if _battle == null or _battle.is_over() or not _pending.is_empty():
 		return
@@ -3819,6 +3846,8 @@ func _finish_battle() -> void:
 	if _world_battle_active and not _battle.has_fled():
 		# A run shows neither a win nor a loss text and blacks nobody out:
 		# `wBattleResult` is DRAW and the party is still standing.
+		if _show_world_battle_result_picture():
+			return
 		if _show_world_battle_terminal_text():
 			return
 		## `.give_money` is the next thing `BattleWon` does once
@@ -3851,6 +3880,8 @@ func _finish_battle() -> void:
 func sync_live_party() -> bool:
 	if _source_save == null or _battle == null or _data == null:
 		return false
+	if _battle.in_battle_tower:
+		return true
 	var fought: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
 		_data.id, _data.sha1, _source_save.slot, _battle.party(Gen2Battle.PLAYER),
 		"", _source_save
@@ -3867,14 +3898,7 @@ func sync_live_party() -> bool:
 func _save_battle_result() -> bool:
 	if _save_slot < 0 or _save_written or _battle == null:
 		return true
-	## `wPartyMon` holds the fighting copy on the cartridge, so damage taken, PP
-	## spent and experience gained belong to the party whatever ended the battle.
-	## A loss is no exception: nothing puts the pre-battle party back, and the
-	## full HP a blacked-out player walks away with is `Script_Whiteout`'s own
-	## `special HealParty` rather than a party that was never written.
-	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_battle_party(
-		_data.id, _data.sha1, _save_slot, _battle.party(Gen2Battle.PLAYER), "", _source_save
-	)
+	var save: Gen2SaveData = Gen2SaveBattleAdapter.from_world_battle(_data, _battle, _source_save)
 	# The world host credits its live state from the completion result below;
 	# mirror the same award into the snapshot being written now so neither the
 	# prize nor the Pay Day money is lost between the battle save and that
@@ -3891,9 +3915,7 @@ func _save_battle_result() -> bool:
 				"message": result.get("message", ""),
 			})
 		return false
-	# from_battle_party() returns a clone; without this, the fought party's HP,
-	# experience and PP reach disk but never the live save the world screen and
-	# the next battle read, so both keep showing the pre-battle party.
+	# Publish the saved candidate to the live world before its next battle.
 	Gen2WorldTransaction.copy_into(_source_save, save)
 	_save_written = true
 	return true
@@ -4014,6 +4036,28 @@ func _show_pay_day_text() -> bool:
 	return true
 
 
+# `BattleWinSlideInEnemyTrainerFrontpic`: six columns at four frames, then 40 frames.
+func _show_world_battle_result_picture() -> bool:
+	if _world_battle_result_picture_shown:
+		return false
+	_world_battle_result_picture_shown = true
+	if not _battle.is_trainer_battle or _battle.is_link_battle:
+		return false
+	if _battle.winner() != Gen2Battle.PLAYER:
+		if not _battle.in_battle_tower and not bool(_world_battle_request.get("can_lose", false)):
+			return false
+		_enemy_hud_visible = false
+		for index: int in 8 * Gen2BattleScreenMap.COLUMNS:
+			_bg_map[index] = Gen2BattleScreenMap.BLANK_TILE
+	_enemy_hud_visible = false
+	_enemy_trainer_pic = _enemy_trainer_class
+	_slid_pixels[Gen2Battle.ENEMY] = 56.0
+	Gen2BattleScreenMap.result_trainer_step(_bg_map, 1)
+	_slides.append({"incoming": true, "step": 1, "delay": 4})
+	_push_view()
+	return true
+
+
 func _show_world_battle_terminal_text() -> bool:
 	if _world_battle_terminal_text_shown:
 		return false
@@ -4025,6 +4069,10 @@ func _show_world_battle_terminal_text() -> bool:
 	if not raw_pointer is Dictionary:
 		return false
 	var pointer: Dictionary = raw_pointer as Dictionary
+	var text: String = String(pointer.get("text", ""))
+	if not text.is_empty():
+		show_message(text)
+		return true
 	var address: int = int(pointer.get("address", 0))
 	if address <= 0:
 		return false
@@ -4036,7 +4084,7 @@ func _show_world_battle_terminal_text() -> bool:
 			"bank": bank, "address": address, "text_kind": key,
 		})
 		return true
-	var text: String = String(decoded.get("text", ""))
+	text = String(decoded.get("text", ""))
 	if text.is_empty():
 		return false
 	show_message(text)
@@ -4166,17 +4214,13 @@ func _choose_battle_menu() -> void:
 			_close_battle_menu()
 			_open_switch_pick(&"player")
 		Gen2BattleMenu.PACK:
-			## `BattleMenu_Pack` opens the whole pack; the only item this screen
-			## can use is a ball, so a wild battle reaches ball selection and a
-			## trainer battle is told what `.UseItem`'s own `wWildMon` test would
-			## have refused anyway. Its `.contest` branch skips the pack outright
-			## and throws the one ball a contest has.
+			# `BattleMenu_Pack.contest` skips the pack and throws a Park Ball.
 			_close_battle_menu()
 			if _is_bug_contest_battle():
 				if bool(begin_capture().get("ok", false)):
 					throw_capture_ball()
 				return
-			if not _pack_rows.is_empty():
+			if not _battle.allows_bag_items() or not _pack_rows.is_empty():
 				open_battle_pack()
 				return
 			## No bag was handed over, which is every battle outside the world
@@ -4566,9 +4610,9 @@ func _show_switch_refusal(text: String) -> void:
 
 ## `PlaceEnemysName`: the opponent's class name, a space, and their own name.
 func _enemy_label() -> String:
-	if _enemy_trainer_class <= 0 or _data == null:
+	if _battle == null or not _battle.is_trainer_battle:
 		return _name_of(_enemy)
-	return "%s %s" % [_data.trainer_name(_enemy_trainer_class), _enemy_trainer_name()]
+	return _enemy_battler_label()
 
 
 ## `<PLAYER>`. A development battle has no save to read a name off, so
@@ -5201,16 +5245,19 @@ func _apply_event_state(event: Dictionary) -> void:
 			# here does. The level is part of that: a trainer's own party is not
 			# all one level the way the invented one used to be.
 			if int(event["side"]) == Gen2Battle.ENEMY:
-				enemy_seen.emit(int(event["species"]), int(event.get("unown_form", 0)))
+				if not _battle.in_battle_tower and not _battle.is_link_battle:
+					enemy_seen.emit(int(event["species"]), int(event.get("unown_form", 0)))
 				_enemy = int(event["species"])
 				_enemy_unown_form = int(event.get("unown_form", 0))
 				_enemy_shiny = bool(event.get("shiny", false))
+				_enemy_hud_visible = true
 				_enemy_level = int(event["level"])
 				set_hp(int(event["hp"]), int(event["max_hp"]), _player_hp, _player_max_hp)
 			else:
 				_player = int(event["species"])
 				_player_unown_form = int(event.get("unown_form", 0))
 				_player_shiny = bool(event.get("shiny", false))
+				_player_hud_visible = true
 				_player_level = int(event["level"])
 				set_hp(_enemy_hp, _enemy_max_hp, int(event["hp"]), int(event["max_hp"]))
 			# A send-out draws a picture through `GetBattleMonBackpic` or
@@ -5691,8 +5738,7 @@ func _read_hp() -> void:
 	)
 
 
-## The cartridge's own controls first, then the development drivers that stand
-## in for a battle menu this screen does not have yet.
+## The battle controls first, then the development drivers.
 func _unhandled_input(event: InputEvent) -> void:
 	if not is_ready() or _driven:
 		return
@@ -6013,14 +6059,14 @@ func cycle_view() -> Dictionary:
 	return select_view(ids[posmod(at + 1, ids.size())])
 
 
-## `wild` or `trainer`, decided the way the battle itself decides it: a trainer
-## class of zero is a wild battle, which is what `wOtherTrainerClass` holds and
-## what `Gen2Battle.trainer_battle` was built from.
 func _battle_kind() -> StringName:
-	return &"trainer" if _enemy_trainer_class > 0 else &"wild"
+	return &"trainer" if _battle != null and _battle.is_trainer_battle else &"wild"
 
 
 func _enemy_trainer_name() -> String:
+	var named: String = String(_world_battle_request.get("trainer_name", ""))
+	if not named.is_empty():
+		return named
 	if _enemy_trainer_class <= 0 or _data == null:
 		return ""
 	return String(_data.trainer_party(_enemy_trainer_class, _enemy_trainer_index).get("name", ""))
@@ -6091,7 +6137,7 @@ func _push_view() -> void:
 			and _anim_hud_hidden != Gen2Battle.PLAYER,
 		## `DrawEnemyHUDBorder`'s last line, which leaves on `wBattleMode`: only
 		## a wild battle marks a species the Pokedex already holds.
-		"enemy_caught": _enemy_caught_before and _enemy_trainer_class == 0,
+		"enemy_caught": _enemy_caught_before and _is_wild_battle(),
 		## `BattleStart_TrainerHuds`' party balls and the frame they hang in.
 		"trainer_hud_balls": _hud_balls,
 		"trainer_hud_border": _hud_border,

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -152,3 +152,9 @@ static func stamp(map: PackedByteArray, player_side: bool) -> void:
 			if x < 0 or x >= COLUMNS or y < 0 or y >= ROWS:
 				continue
 			map[y * COLUMNS + x] = (base + column * side + row) & 0xFF
+
+
+static func result_trainer_step(map: PackedByteArray, columns: int) -> void:
+	for column: int in columns:
+		for row: int in ENEMY_SIDE:
+			map[row * COLUMNS + COLUMNS - columns + column] = column * ENEMY_SIDE + row

--- a/game/input/focus_guard.gd
+++ b/game/input/focus_guard.gd
@@ -166,7 +166,7 @@ func _toward(
 	if make is not Callable:
 		return null
 	var target := (make as Callable).call(current) as Control
-	return target if target != null and target != current and target.is_visible_in_tree() \
+	return target if target != null and target != current and target.is_visible_in_tree() and _focusable(target) \
 		else null
 
 
@@ -291,14 +291,14 @@ static func _takes_focus(control: Control) -> bool:
 
 
 static func _focusable(control: Control) -> bool:
-	return control.focus_mode == Control.FOCUS_ALL and not _is_disabled(control)
+	return control.get_focus_mode_with_override() == Control.FOCUS_ALL and not _is_disabled(control)
 
 
 static func _first_focusable(root: Node, skip_panes: bool) -> Control:
 	for child: Node in root.get_children():
 		var control := child as Control
 		if control != null:
-			if not control.visible or control.is_in_group(ASIDE_GROUP):
+			if not control.is_visible_in_tree() or control.is_in_group(ASIDE_GROUP):
 				continue
 			if _focusable(control) and not (skip_panes and _scroll_with_controls(control)):
 				return control

--- a/game/launcher/launcher_shell.gd
+++ b/game/launcher/launcher_shell.gd
@@ -259,10 +259,17 @@ func select(id: StringName) -> void:
 		if _focus.preferred != null and not Gen2InputDevice.is_pointer(
 			Gen2InputRuntime.instance().device()
 		):
-			_focus.preferred.grab_focus.call_deferred()
+			_focus_page_landing.call_deferred()
 		_focus.refresh.call_deferred()
 	_refresh_hints()
 	page_selected.emit(id)
+
+
+func _focus_page_landing() -> void:
+	var target: Control = _page_landing()
+	if target != null and target.is_visible_in_tree() \
+		and target.get_focus_mode_with_override() == Control.FOCUS_ALL:
+		target.grab_focus()
 
 
 ## The page's own hints, plus the way back every page but the first carries.

--- a/game/save/save_battle_adapter.gd
+++ b/game/save/save_battle_adapter.gd
@@ -112,6 +112,22 @@ static func from_battle_party(
 	return out
 
 
+static func from_world_battle(
+	data: GameData, battle: Gen2Battle, source_save: Gen2SaveData
+) -> Gen2SaveData:
+	if data == null or battle == null or source_save == null:
+		return null
+	if battle.in_battle_tower:
+		# RunBattleTowerTrainer reloads Pokemon data, then heals the restored party.
+		var restored: Gen2SaveData = Gen2SaveData.from_dict(source_save.to_dict())
+		if restored == null or Gen2WorldPartyHost.heal_party_rows(data, restored) < 0:
+			return null
+		return restored
+	return from_battle_party(
+		data.id, data.sha1, source_save.slot, battle.party(Gen2Battle.PLAYER), "", source_save
+	)
+
+
 static func _egg_slots(party: Gen2Party, source_save: Gen2SaveData) -> int:
 	if party == null or party.mons.is_empty() or party.mons.size() > Gen2Party.MAX_SIZE:
 		return -1

--- a/game/save/sram_adapter.gd
+++ b/game/save/sram_adapter.gd
@@ -397,6 +397,16 @@ static func read_party_mon(raw: PackedByteArray, start: int) -> Gen2SaveMon:
 	return mon
 
 
+static func read_party_stats(raw: PackedByteArray, start: int) -> Dictionary:
+	if start < 0 or start + PARTYMON_SIZE > raw.size():
+		return {}
+	var stats: Dictionary = {}
+	var keys: Array[String] = ["hp", "attack", "defense", "speed", "sp_attack", "sp_defense"]
+	for index: int in keys.size():
+		stats[keys[index]] = _read_u16_be(raw, start + 36 + index * 2)
+	return stats
+
+
 ## `NICKNAMED_MON_STRUCT_LENGTH`: the same 48 bytes with the nickname behind
 ## them. That is how a ROM table stores a whole Pokemon no save file ever wrote,
 ## which is `BattleTowerMons`' rows and `OddEggs`' fourteen.

--- a/game/world/battle_tower.gd
+++ b/game/world/battle_tower.gd
@@ -259,12 +259,8 @@ static func _values_are_unique(values: Array, eggs: Array) -> bool:
 
 
 ## `LoadOpponentTrainerAndPokemon`: a trainer this streak has not sampled, and
-## three Pokemon of the chosen level group that share no species or held item with
-## each other or with either of the last two teams. The sampled trainer is written
-## into `sBTTrainers[beaten]` and the two previous-team lists shift, so calling
-## this twice in a row gives two different opponents the way the cartridge's own
-## streak does. Answers { trainer, name, class, mons }, or an empty Dictionary
-## when the cartridge has no tower.
+## three Pokemon sharing no species or item within the team. Species from the
+## last two teams are excluded too. Each mon carries its stored battle stats.
 func load_opponent(data: GameData, random: RandomNumberGenerator) -> Dictionary:
 	if data == null or not data.has_battle_tower():
 		return {}
@@ -277,8 +273,8 @@ func load_opponent(data: GameData, random: RandomNumberGenerator) -> Dictionary:
 	var record: Dictionary = rows[trainer % rows.size()] as Dictionary
 	var mons: Array = _sample_mons(data, random)
 	var sampled: Array = []
-	for mon: Gen2SaveMon in mons:
-		sampled.append(mon.species)
+	for mon: Dictionary in mons:
+		sampled.append(int(mon["species"]))
 	earlier_mons = previous_mons.duplicate()
 	previous_mons = sampled
 	return {
@@ -322,44 +318,49 @@ func _sample_mons(data: GameData, random: RandomNumberGenerator) -> Array:
 	var out: Array = []
 	var group: int = clampi(chosen_group, 1, LEVEL_GROUPS) - 1
 	for _slot: int in PARTY_LENGTH:
-		var chosen: Gen2SaveMon = null
+		var chosen: Dictionary = {}
 		for _attempt: int in RESAMPLE_LIMIT:
 			var roll: int = random.randi() & 0x1F
 			if roll >= NUM_UNIQUE_MON:
 				continue
-			var candidate: Gen2SaveMon = _read_mon(data, group, roll)
-			if candidate == null or not _mon_is_free(candidate, out):
+			var candidate: Dictionary = mon_record(data, group, roll)
+			if candidate.is_empty() or not _mon_is_free(candidate, out):
 				continue
 			chosen = candidate
 			break
-		if chosen == null:
+		if chosen.is_empty():
 			chosen = _first_free_mon(data, group, out)
-		if chosen != null:
+		if not chosen.is_empty():
 			out.append(chosen)
 	return out
 
 
-func _mon_is_free(candidate: Gen2SaveMon, team: Array) -> bool:
-	for mon: Gen2SaveMon in team:
+func _mon_is_free(candidate: Dictionary, team: Array) -> bool:
+	for mon: Dictionary in team:
 		if mon.species == candidate.species or mon.item == candidate.item:
 			return false
 	return not previous_mons.has(candidate.species) \
 		and not earlier_mons.has(candidate.species)
 
 
-func _first_free_mon(data: GameData, group: int, team: Array) -> Gen2SaveMon:
+func _first_free_mon(data: GameData, group: int, team: Array) -> Dictionary:
 	for index: int in NUM_UNIQUE_MON:
-		var candidate: Gen2SaveMon = _read_mon(data, group, index)
-		if candidate != null and _mon_is_free(candidate, team):
+		var candidate: Dictionary = mon_record(data, group, index)
+		if not candidate.is_empty() and _mon_is_free(candidate, team):
 			return candidate
-	return null
+	return {}
 
 
-## One `BattleTowerMons` row, which is the nicknamed-mon struct
-## [method Gen2SramAdapter.read_nicknamed_mon] reads wherever a ROM table stores
-## a whole Pokemon.
-static func _read_mon(data: GameData, group: int, index: int) -> Gen2SaveMon:
-	return Gen2SramAdapter.read_nicknamed_mon(data.battle_tower_mon(group, index), 0)
+## `InitEnemyMon` copies the six stored stats; `ValidateBTParty` is unreferenced.
+static func mon_record(data: GameData, group: int, index: int) -> Dictionary:
+	var raw: PackedByteArray = data.battle_tower_mon(group, index)
+	var saved: Gen2SaveMon = Gen2SramAdapter.read_nicknamed_mon(raw, 0)
+	if saved == null:
+		return {}
+	saved.nickname = String(data.species(saved.species).get("name", ""))
+	var record: Dictionary = saved.to_dict()
+	record["battle_stats"] = Gen2SramAdapter.read_party_stats(raw, 0)
+	return record
 
 
 ## `BattleTowerText`: a male class draws from 25 lines and a female from 15, and
@@ -413,7 +414,7 @@ static func class_sprite(data: GameData, trainer_class: int) -> int:
 	return int(sprites[index])
 
 
-## `BattleTower_RandomlyChooseReward`: one of the six stat boosters, LUCKY_PUNCH
+## `BattleTower_RandomlyChooseReward`: one of the five stat boosters, LUCKY_PUNCH
 ## rerolled because it sits inside the run without being a reward. Stored rather
 ## than handed over, so the item the player gets after seven wins was decided
 ## before the first.

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -4,6 +4,8 @@ extends RefCounted
 ## Scene-free preparation of overworld battle requests. The battle screen owns
 ## presentation and input; this boundary builds the existing battle model.
 
+const LINK_TRAINER_CLASS: int = 12
+
 const OUTCOME_WON: StringName = &"won"
 const OUTCOME_LOST: StringName = &"lost"
 const OUTCOME_CAUGHT: StringName = &"caught"
@@ -35,7 +37,7 @@ static func prepare(
 	battle_rules: Gen2Rules = null,
 	player_id: int = -1,
 ) -> Dictionary:
-	if data == null or player_party == null or player_party.is_wiped():
+	if data == null or player_party == null:
 		return _failure(&"missing_player_party")
 
 	var raw_values: Variant = request.get("values", request)
@@ -43,6 +45,11 @@ static func prepare(
 		return _failure(&"invalid_battle_request")
 	var values: Dictionary = (raw_values as Dictionary).duplicate(true)
 	var kind: StringName = StringName(values.get("kind", &""))
+	if kind == &"battle_tower":
+		for member: Gen2BattleMon in player_party.mons:
+			member.restore_health()
+	if player_party.is_wiped():
+		return _failure(&"missing_player_party")
 	var enemy_party: Gen2Party = null
 	var trainer_class: int = 0
 	var trainer_index: int = 0
@@ -71,21 +78,8 @@ static func prepare(
 					"trainer_class": trainer_class, "trainer_index": trainer_index,
 				})
 		&"battle_tower", &"link_battle":
-			## `ReadBTTrainerParty` copies a whole `wOTPartyMon` block out of the
-			## sampled record rather than building one from a trainer table, so
-			## the party arrives with the request and nothing is rolled here.
-			## A link battle is the same shape one caller further out:
-			## `Link_PrepPartyData_Gen2` sends whole party structs and the other
-			## Game Boy's arrive the same way, with no trainer class behind them.
-			trainer_class = int(values.get("trainer_class", 0))
-			var members: Array = []
-			for raw_mon: Variant in values.get("enemy_party", []) as Array:
-				var saved: Gen2SaveMon = Gen2SaveMon.from_dict(raw_mon)
-				var member: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, saved)
-				if member == null:
-					return _failure(&"invalid_battle_tower_mon", {"mon": raw_mon})
-				members.append(member)
-			enemy_party = Gen2Party.create(members)
+			trainer_class = int(values.get("trainer_class", LINK_TRAINER_CLASS if kind == &"link_battle" else 0))
+			enemy_party = _recorded_party(data, values, kind == &"battle_tower")
 		_:
 			return _failure(&"unsupported_battle_kind", {"kind": kind})
 
@@ -120,8 +114,24 @@ static func prepare(
 		"enemy_party": enemy_party,
 		"trainer_class": trainer_class,
 		"trainer_index": trainer_index,
-		"trainer_battle": kind == &"trainer",
+		"trainer_battle": battle.is_trainer_battle,
 	}
+
+
+static func _recorded_party(data: GameData, values: Dictionary, tower: bool) -> Gen2Party:
+	var members: Array = []
+	for raw_mon: Variant in values.get("enemy_party", []) as Array:
+		if not raw_mon is Dictionary:
+			return null
+		var saved: Gen2SaveMon = Gen2SaveMon.from_dict(raw_mon)
+		var member: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, saved)
+		if member == null:
+			return null
+		if tower and raw_mon.has("battle_stats"):
+			member.stats = (raw_mon["battle_stats"] as Dictionary).duplicate()
+			member.hp = clampi(saved.hp, 0, member.max_hp())
+		members.append(member)
+	return Gen2Party.create(members)
 
 
 ## `LoadEnemyMon` for a wild, on the run's own generator.

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -530,11 +530,11 @@ static func heal_party_rows(data: GameData, save: Gen2SaveData) -> int:
 		var max_hp: int = battle_mon.max_hp()
 		if mon.hp != max_hp or mon.status != Gen2Status.NONE:
 			healed += 1
-		mon.hp = max_hp
-		mon.status = Gen2Status.NONE
+		battle_mon.restore_health()
+		mon.hp = battle_mon.hp
+		mon.status = battle_mon.status
 		for slot: int in Gen2SaveMon.MAX_MOVES:
-			var move_number: int = int(mon.moves[slot])
-			mon.pp[slot] = int(data.move(move_number).get("pp", 0)) if move_number > 0 else 0
+			mon.pp[slot] = battle_mon.pp_left(slot)
 	return healed
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -5401,7 +5401,9 @@ func _finish_battle_exit(result: Dictionary, fought_save: Gen2SaveData) -> void:
 	_reap_nuzlocke_faints(fought_save, Gen2Nuzlocke.CAUSE_BATTLE)
 	## The encounter this fight claimed is over, whatever it came to.
 	_world.nuzlocke_area_open = -1
-	if StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON:
+	if StringName(result.get("outcome", &"")) == Gen2WorldBattleAdapter.OUTCOME_WON \
+		and StringName((result.get("request", {}) as Dictionary).get("kind", &"")) \
+			not in [&"battle_tower", &"link_battle"]:
 		Gen2WorldPartyHost.give_pokerus_and_convert_berries(
 			_data, fought_save, _world, _encounter_random
 		)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -5823,7 +5823,7 @@ func _stage_link_room(special: int) -> Dictionary:
 ## separate rolls in the source and must not repeat here.
 func _battle_tower_random(offset: int) -> RandomNumberGenerator:
 	var random := RandomNumberGenerator.new()
-	random.seed = int(_request.get("battle_tower_seed", randi())) + offset
+	random.seed = (int(_request["battle_tower_seed"]) if _request.has("battle_tower_seed") else randi()) + offset
 	return random
 
 
@@ -5991,14 +5991,11 @@ func _load_battle_tower_opponent() -> Dictionary:
 		return _fail(
 			&"missing_battle_tower_data", {"special": SPECIAL_LOAD_BATTLE_TOWER_OPPONENT}
 		)
-	var mons: Array = []
-	for mon: Gen2SaveMon in opponent["mons"] as Array:
-		mons.append(mon.to_dict())
 	_battle_tower_opponent = {
 		"trainer": int(opponent["trainer"]),
 		"name": String(opponent["name"]),
 		"class": int(opponent["class"]),
-		"mons": mons,
+		"mons": opponent["mons"],
 	}
 	_events.append({
 		"type": &"battle_tower_opponent_loaded",
@@ -6028,14 +6025,22 @@ func _stage_battle_tower_battle() -> Dictionary:
 	return _stage_runtime_request(&"battle_requested", {
 		"kind": &"battle_tower",
 		"special": SPECIAL_BATTLE_TOWER_BATTLE,
-		## `set BATTLE_SHIFT, [hl]` for the length of the fight and
-		## `farcall HealParty` on both sides of it.
-		"force_switch_mode": true,
-		"heal_party": true,
+		"win_text": _battle_tower_result_text(Gen2BattleTower.TEXT_LOSS),
+		"loss_text": _battle_tower_result_text(Gen2BattleTower.TEXT_WIN),
 		"trainer_class": int(_battle_tower_opponent["class"]),
 		"trainer_name": String(_battle_tower_opponent["name"]),
 		"enemy_party": (_battle_tower_opponent["mons"] as Array).duplicate(true),
 	})
+
+
+func _battle_tower_result_text(kind: int) -> Dictionary:
+	var random: RandomNumberGenerator = null
+	if _battle_tower_text_index < 0:
+		random = _battle_tower_random(1 + kind)
+	return _battle_tower().trainer_line(
+		data, int(_battle_tower_opponent["class"]), kind,
+		random, _battle_tower_text_index
+	)
 
 
 ## `battletowertext`, which is `BattleTowerText` for the opponent's own class:
@@ -6044,9 +6049,12 @@ func _stage_battle_tower_battle() -> Dictionary:
 func _stage_battle_tower_text(kind: int) -> Dictionary:
 	if _battle_tower_opponent.is_empty():
 		return _fail(&"missing_battle_tower_opponent", {"kind": kind})
+	var random: RandomNumberGenerator = null
+	if kind == 1 or _battle_tower_text_index < 0:
+		random = _battle_tower_random(1 + kind)
 	var line: Dictionary = _battle_tower().trainer_line(
 		data, int(_battle_tower_opponent["class"]), clampi(kind - 1, 0, 2),
-		_battle_tower_random(1 + kind), _battle_tower_text_index
+		random, _battle_tower_text_index
 	)
 	_battle_tower_text_index = int(line["index"])
 	var text: String = String(line["text"])

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -1090,3 +1090,21 @@ func test_a_press_reaches_nothing_while_a_pic_slides_off_its_square() -> void:
 		_battle_screen._bg_map, Gen2BattleScreenMap.seeded(),
 		"both pictures stand on their own squares and nowhere else"
 	)
+
+
+func test_fainting_hides_each_panel_until_its_replacement_enters() -> void:
+	await _open_battle()
+	_battle_screen.show_matchup(16, 155, 7, 9)
+	_settle_intro()
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		var key: String = "player_hud_visible" if side == Gen2Battle.PLAYER else "enemy_hud_visible"
+		_battle_screen._begin_faint(side)
+		for frame: int in 14:
+			assert_true(bool(_battle_screen._renderer._view[key]))
+			_battle_screen.advance_faint()
+		assert_false(bool(_battle_screen._renderer._view[key]))
+		_battle_screen._apply_event_state({
+			"type": Gen2Battle.SENT_OUT, "side": side, "species": 16,
+			"level": 7, "hp": 30, "max_hp": 30,
+		})
+		assert_true(bool(_battle_screen._renderer._view[key]))

--- a/tests/integration/test_launcher_focus.gd
+++ b/tests/integration/test_launcher_focus.gd
@@ -235,6 +235,10 @@ func test_the_first_focusable_skips_what_cannot_take_focus() -> void:
 	var off := Button.new()
 	off.disabled = true
 	root.add_child(off)
+	var blocked := Control.new()
+	blocked.focus_behavior_recursive = Control.FOCUS_BEHAVIOR_DISABLED
+	root.add_child(blocked)
+	blocked.add_child(Button.new())
 	var wanted := Button.new()
 	root.add_child(wanted)
 

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -1048,7 +1048,7 @@ func test_hp_experience_and_pp_survive_into_the_next_wild_battle() -> void:
 
 
 ## `wPartyMon` is the fighting copy, so a run keeps the damage taken and the PP
-## spent exactly as a win does; only a blackout puts the pre-battle party back.
+## spent exactly as a win does. Tower battles restore the original party.
 ## `_save_battle_result` used to refuse every battle the player did not win, so
 ## a wild encounter walked away from cost nothing.
 func test_running_away_keeps_the_damage_taken_and_the_pp_spent() -> void:
@@ -2401,3 +2401,85 @@ func test_a_thrown_ball_asks_for_the_throw_animation() -> void:
 
 	_settle_frames(host)
 	assert_false(host.animation_running(), "and its frames are spent")
+
+
+func _open_special_battle(kind: StringName) -> Gen2BattleScreen:
+	var host: Gen2BattleScreen = load("res://game/battle/battle_screen.tscn").instantiate()
+	host.set_data(_data)
+	host.set_driven(true)
+	add_child(host)
+	host.set_process(false)
+	var opponent: Gen2SaveMon = Gen2SaveBattleAdapter.from_battle_mon(
+		Gen2BattleMon.create(_data, Fixture.TRAINER_SPECIES, 5, [BattleFixture.TACKLE])
+	)
+	assert_true(host.start_world_battle({"values": {
+		"kind": kind, "trainer_name": "VISITOR",
+		"trainer_class": Fixture.TRAINER_CLASS if kind == &"battle_tower" else 0,
+		"enemy_party": [opponent.to_dict()],
+		"win_text": {"text": "TOWER LOSS"}, "loss_text": {"text": "TOWER WIN"},
+	}}))
+	return host
+
+
+func test_special_battles_show_the_opponent_name_and_refuse_the_pack() -> void:
+	for kind: StringName in [&"battle_tower", &"link_battle"]:
+		var host: Gen2BattleScreen = _open_special_battle(kind)
+		var seen: Array = []
+		host.enemy_seen.connect(func(species: int, form: int) -> void: seen.append([species, form]))
+		_settle_frames(host)
+		var label: String = "LEADER VISITOR" if kind == &"battle_tower" else "VISITOR"
+		assert_eq(host.battle_snapshot()["message"], label + "\nwants to battle!")
+		for _frame: int in 4000:
+			if not host.frames_running() and not host.entrance_running():
+				break
+			host.advance_frame()
+			if not host.frames_running() and host.entrance_running():
+				host.finish()
+				host.advance()
+		host.set_battle_pack([0x12], {0x12: 1})
+		assert_eq(host.open_battle_pack().get("reason"), &"items_cant_be_used_here")
+		assert_eq(host.battle_snapshot()["message"], "Items can't be\nused here.")
+		assert_eq(host.battle_snapshot()["menu_stage"], &"")
+		assert_true(seen.is_empty())
+		assert_eq(host._battle_kind(), &"trainer")
+		if kind == &"battle_tower":
+			assert_true(host._battle.battle_style_set)
+		host.free()
+
+
+func test_tower_victory_and_defeat_print_the_matching_result_line() -> void:
+	for won: bool in [true, false]:
+		var host: Gen2BattleScreen = _open_special_battle(&"battle_tower")
+		if not won:
+			for member: Gen2BattleMon in host._battle.party(Gen2Battle.PLAYER).mons:
+				if member != host._battle.mon(Gen2Battle.PLAYER):
+					member.hp = 0
+		for _hit: int in 12:
+			if won:
+				host.hurt_enemy()
+			else:
+				host.hurt_player()
+		var expected: String = "TOWER LOSS" if won else "TOWER WIN"
+		for _frame: int in 4000:
+			if host.battle_snapshot()["message"] == expected:
+				break
+			host.advance_frame()
+			if not host.frames_running():
+				host.finish()
+				host.advance()
+		assert_eq(host.battle_snapshot()["message"], expected)
+		assert_eq(host.battler_side(Gen2Battle.ENEMY)["kind"], &"trainer")
+		assert_eq(host._slid_pixels[Gen2Battle.ENEMY], 16.0)
+		host.free()
+
+
+func test_result_portrait_spends_sixty_four_frames_before_the_dialogue() -> void:
+	var host: Gen2BattleScreen = _open_special_battle(&"battle_tower")
+	host._battle.enemy.hp = 0
+	assert_true(host._show_world_battle_result_picture())
+	for frame: int in 64:
+		assert_true(host.sliding(), "result picture still owns frame %d" % frame)
+		host.advance_slide()
+	assert_false(host.sliding())
+	assert_false(host._show_world_battle_result_picture())
+	host.free()

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -4669,3 +4669,22 @@ func test_a_berserk_gene_runs_on_the_confusion_count_the_last_pokemon_left() -> 
 	battle.take_actions(Gen2Battle.switch_to(1), Gen2Battle.use_move(0))
 	battle.take_turn(0, 0)
 	assert_eq(battle.player.confusion_turns, 2)
+
+
+func test_tower_and_link_battles_refuse_bag_items_and_free_switches() -> void:
+	for mode: int in 3:
+		var player: Gen2BattleMon = _mon(Fixture.PIKACHU, 20, [Fixture.TACKLE])
+		var bench: Gen2BattleMon = _mon(Fixture.PIKACHU, 20, [Fixture.TACKLE])
+		var enemy: Gen2BattleMon = _mon(Fixture.PIKACHU, 20, [Fixture.TACKLE])
+		var battle: Gen2Battle = Gen2Battle.create_parties(
+			_data, Gen2Party.create([player, bench]), Gen2Party.of(enemy), _rng, true
+		)
+		battle.in_battle_tower = mode == 1
+		battle.is_link_battle = mode == 2
+		player.hp = 1
+		assert_eq(battle.should_offer_switch(), mode == 0)
+		var result: Dictionary = battle.use_bag_item(Fixture.POTION, 0)
+		assert_eq(bool(result["ok"]), mode == 0)
+		if mode > 0:
+			assert_eq(result["reason"], &"items_cant_be_used_here")
+			assert_eq(player.hp, 1)

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -424,3 +424,16 @@ func test_the_sprites_stand_over_the_wedges_until_the_outro_hides_them() -> void
 					sprites, Gen2BattleTransition.SPRITES_ALL,
 					"the flash hides nothing: `RespawnPlayerAndOpponent` is the outro's"
 				)
+
+
+func test_result_trainer_slide_copies_six_column_major_slices() -> void:
+	var map := PackedByteArray()
+	map.resize(20 * 18)
+	map.fill(0x7F)
+	for step: int in range(1, 7):
+		Gen2BattleScreenMap.result_trainer_step(map, step)
+		for column: int in step:
+			for row: int in 7:
+				assert_eq(int(map[row * 20 + 20 - step + column]), column * 7 + row)
+		assert_eq(int(map[20 - step - 1]), 0x7F)
+		assert_eq(int(map[7 * 20]), 0x7F)

--- a/tests/unit/test_link.gd
+++ b/tests/unit/test_link.gd
@@ -320,7 +320,7 @@ func test_a_link_battle_request_builds_the_peers_party() -> void:
 	)
 	assert_true(bool(prepared.get("ok", false)), String(prepared.get("reason", "")))
 	assert_eq((prepared["enemy_party"] as Gen2Party).size(), 1)
-	assert_eq(int(prepared["trainer_class"]), 0)
+	assert_eq(int(prepared["trainer_class"]), 12, "Link Battle uses CAL for the trainer picture")
 
 
 func _world() -> Gen2WorldAPI:

--- a/tests/unit/test_save.gd
+++ b/tests/unit/test_save.gd
@@ -1020,3 +1020,34 @@ func test_a_mystery_gift_block_round_trips_through_the_file() -> void:
 	var restored: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
 	assert_not_null(restored)
 	assert_eq(restored.mystery_gift, save.mystery_gift)
+
+
+func test_tower_exit_restores_the_original_party_and_heals_it() -> void:
+	for tower: bool in [false, true]:
+		var source: Gen2SaveData = _save()
+		var original: Gen2SaveMon = source.party[0]
+		original.nickname = "SPARK"
+		original.item = Fixture.POTION
+		var party: Gen2Party = Gen2SaveBattleAdapter.to_battle_party(_data, source)
+		var battle: Gen2Battle = Gen2Battle.create_parties(
+			_data, party, Gen2Party.of(Gen2BattleMon.create(_data, Fixture.PIKACHU, 20, [Fixture.TACKLE])),
+			RandomNumberGenerator.new(), true
+		)
+		battle.in_battle_tower = tower
+		var fought: Gen2BattleMon = party.at(0)
+		fought.hp = 0
+		fought.item = 0
+		fought.happiness = 1
+		fought.replace_move(0, Fixture.THUNDERBOLT)
+		var written: Gen2SaveData = Gen2SaveBattleAdapter.from_world_battle(_data, battle, source)
+		assert_not_null(written)
+		var restored: Gen2SaveMon = written.party[0]
+		assert_eq(restored.hp, fought.max_hp() if tower else 0)
+		assert_eq(restored.item, original.item if tower else 0)
+		assert_eq(restored.happiness, original.happiness if tower else 1)
+		assert_eq(restored.moves[0], original.moves[0] if tower else Fixture.THUNDERBOLT)
+		assert_eq(restored.nickname, "SPARK")
+		if tower:
+			assert_eq(restored.status, Gen2Status.NONE)
+			assert_eq(restored.pp[0], int(_data.move(original.moves[0])["pp"]))
+		assert_eq(source.party[0], original, "the candidate does not mutate the live save")

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -15,7 +15,7 @@ const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room, and never raise it.
-const MAX_COMMENT_LINES: int = 37742
+const MAX_COMMENT_LINES: int = 37709
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -549,3 +549,26 @@ func test_a_battle_that_was_not_won_pays_nothing() -> void:
 	assert_true(
 		(Gen2WorldBattleAdapter.earnings(battle, null, false)["money"] as Dictionary).is_empty()
 	)
+
+
+func test_tower_preparation_heals_even_a_wiped_party_before_choosing_the_lead() -> void:
+	var party: Gen2Party = _player_party()
+	var lead: Gen2BattleMon = party.at(0)
+	lead.hp = 0
+	lead.status = Gen2Status.POISON
+	lead.pp[0] = 0
+	var enemy: Dictionary = Gen2SaveBattleAdapter.from_battle_mon(_player_party().at(0)).to_dict()
+	enemy["battle_stats"] = {
+		"hp": 40, "attack": 23, "defense": 22, "speed": 21, "sp_attack": 20, "sp_defense": 19,
+	}
+	enemy["hp"] = 40
+	var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(_data, {"values": {
+		"kind": &"battle_tower", "enemy_party": [enemy],
+	}}, party)
+	assert_true(prepared["ok"])
+	assert_eq(lead.hp, lead.max_hp())
+	assert_eq(lead.status, Gen2Status.NONE)
+	assert_eq(lead.pp_left(0), 35)
+	assert_eq((prepared["battle"] as Gen2Battle).enemy.stats, enemy["battle_stats"])
+	assert_eq((prepared["battle"] as Gen2Battle).enemy.hp, 40)
+	assert_true(prepared["trainer_battle"])

--- a/tools/checks/battle_tower.gd
+++ b/tools/checks/battle_tower.gd
@@ -73,8 +73,12 @@ func run(r: RefCounted) -> void:
 		_verify_strings()
 		_verify_class_tables()
 		_verify_sampler()
+		_verify_stored_stats()
+		_verify_result_lines()
 		_verify_rules()
 		_verify_battle_room()
+		_verify_challenge(true)
+		_verify_challenge(false)
 	)
 
 
@@ -148,6 +152,53 @@ func _verify_mons() -> void:
 				first,
 			]
 		)
+
+
+func _verify_stored_stats() -> void:
+	var different: int = 0
+	var keys: Array[String] = ["hp", "attack", "defense", "speed", "sp_attack", "sp_defense"]
+	for group: int in 10:
+		for index: int in 21:
+			var raw: PackedByteArray = _r.data.battle_tower_mon(group, index)
+			var record: Dictionary = Gen2BattleTower.mon_record(_r.data, group, index)
+			var plain: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(
+				_r.data, Gen2SaveMon.from_dict(record)
+			)
+			var prepared: Dictionary = Gen2WorldBattleAdapter.prepare(_r.data, {"values": {
+				"kind": &"battle_tower", "enemy_party": [record],
+			}}, Gen2Party.of(plain))
+			if not _r.check(bool(prepared.get("ok", false)), "Tower row failed to prepare"):
+				return
+			var enemy: Gen2BattleMon = (prepared["battle"] as Gen2Battle).enemy
+			var changed: bool = false
+			for stat: int in 6:
+				var offset: int = 36 + stat * 2
+				var expected: int = (int(raw[offset]) << 8) | int(raw[offset + 1])
+				_r.check(int(enemy.stats[keys[stat]]) == expected,
+					"Tower %d/%d %s differs from its stored stat" % [group, index, keys[stat]])
+				changed = changed or int(plain.stats[keys[stat]]) != expected
+			different += int(changed)
+			_r.check(String(record["nickname"]) == String(_r.data.species(enemy.species)["name"]),
+				"Tower nickname was not replaced by GetPokemonName")
+	_r.check(different == 117, "Tower stored stats differ on %d rows, expected 117" % different)
+	print("crystal tower: 210 stored stat rows, 117 differ from recalculation; 1260 stats checked.")
+
+
+func _verify_result_lines() -> void:
+	var tower := Gen2BattleTower.new()
+	var random := RandomNumberGenerator.new()
+	var texts: Dictionary = _r.data.battle_tower()["texts"]
+	for row: Dictionary in _r.data.battle_tower()["trainers"]:
+		var trainer_class: int = int(row["class"])
+		var gender: String = "female" if Gen2BattleTower.is_class_female(_r.data, trainer_class) else "male"
+		var count: int = 15 if gender == "female" else 25
+		for index: int in count:
+			for kind: int in [1, 2]:
+				var before: int = random.state
+				var line: Dictionary = tower.trainer_line(_r.data, trainer_class, kind, random, index)
+				var expected: String = String(texts[RomLayout.BATTLETOWER_TEXT_KINDS[kind]][gender][index])
+				_r.check(line["text"] == expected and random.state == before,
+					"Tower result text lost the greeting's index")
 
 
 func _verify_strings() -> void:
@@ -253,7 +304,7 @@ func _verify_sampler() -> void:
 			tower.beaten += 1
 			var species: Array = []
 			var items: Array = []
-			for mon: Gen2SaveMon in opponent["mons"] as Array:
+			for mon: Dictionary in opponent["mons"] as Array:
 				_r.check(
 					mon.level == (group + 1) * 10,
 					"group %d drew a level %d opponent" % [group, mon.level]
@@ -346,6 +397,9 @@ func _verify_battle_room() -> void:
 		"the challenge is not in progress by the time the first fight starts"
 	)
 	_r.check(state.battle_tower().beaten == 1, "the first trainer was not counted")
+	for key: String in ["win_text", "loss_text"]:
+		_r.check(not String((values.get(key, {}) as Dictionary).get("text", "")).is_empty(),
+			"the Tower request lost its %s" % key)
 	var greeted: bool = false
 	var sprited: bool = false
 	for result: Dictionary in results:
@@ -408,3 +462,36 @@ func _verify_rules() -> void:
 		) == -1,
 		"the ubers check refused a Lv.70 room, which it never reads"
 	)
+
+
+func _verify_challenge(won: bool) -> void:
+	var state := Gen2WorldState.new()
+	state.battle_tower().chosen_group = 3
+	var world: Gen2WorldAPI = _r.open_world(
+		BATTLE_ROOM_GROUP, BATTLE_ROOM_MAP, BATTLE_ROOM_CELL, state
+	)
+	if world == null:
+		return
+	world.set_party_summary(3, false, [1, 4, 7] as Array[int], [[], [], []],
+		["A", "B", "C"], [false, false, false], {"levels": [30, 30, 30]})
+	world.dispatch_map_entry()
+	var battles: int = 0
+	for _frame: int in BATTLE_ROOM_FRAME_CAP * 8:
+		var request: Dictionary = world.pending_runtime_request()
+		if not request.is_empty():
+			var answer: Dictionary = {"ok": true}
+			if request.get("kind", &"") == &"battle_requested":
+				battles += 1
+				answer["outcome"] = &"won" if won else &"lost"
+			world.complete_runtime_request(answer)
+		elif not world.pending_script_wait().is_empty():
+			world.advance_script_presentation_frame()
+		elif world.script_busy():
+			world.run_event_queue(true, 0)
+		else:
+			break
+	_r.check(battles == (7 if won else 1), "Tower challenge stopped after %d fights" % battles)
+	_r.check(not world.script_busy(), "Tower challenge did not return to reception")
+	var expected: int = Gen2BattleTower.RECEIVED_REWARD if won else Gen2BattleTower.NO_CHALLENGE
+	_r.check(state.battle_tower().challenge_state == expected,
+		"Tower challenge ended in state %d, expected %d" % [state.battle_tower().challenge_state, expected])

--- a/tools/preview_battle_switch.gd
+++ b/tools/preview_battle_switch.gd
@@ -210,6 +210,9 @@ func _informing() -> bool:
 
 
 func _open() -> void:
+	if _stage.begins_with("tower_"):
+		_open_tower_stage()
+		return
 	if _stage == "prize":
 		_open_prize()
 		return
@@ -545,3 +548,39 @@ func _button(name: String) -> int:
 		"r": return Gen2Button.RIGHT
 		"b": return Gen2Button.B
 		_: return Gen2Button.A
+
+
+func _open_tower_stage() -> void:
+	var random := RandomNumberGenerator.new()
+	random.seed = 19
+	var tower := Gen2BattleTower.new()
+	var opponent: Dictionary = tower.load_opponent(_screen._data, random)
+	var result_text: Dictionary = tower.trainer_line(_screen._data, int(opponent["class"]),
+		Gen2BattleTower.TEXT_LOSS, random, 0)
+	_screen.start_world_battle({"values": {
+		"win_text": result_text,
+		"kind": &"battle_tower", "trainer_class": opponent["class"],
+		"trainer_name": opponent["name"], "enemy_party": opponent["mons"],
+	}})
+	if _stage == "tower_intro":
+		_settle()
+		_screen.finish()
+		return
+	_drain_to_menu()
+	if _stage == "tower_result":
+		for member: Gen2BattleMon in _screen._battle.party(Gen2Battle.ENEMY).mons:
+			if member != _screen._battle.enemy:
+				member.hp = 0
+		for _hit: int in 100:
+			_screen.hurt_enemy()
+		for _press: int in 60:
+			_settle()
+			if _screen.battle_snapshot()["message"] == result_text["text"]:
+				_screen.finish()
+				return
+			_screen.finish()
+			_screen.advance()
+		return
+	_screen.set_battle_pack(PACK_ITEMS, PACK_QUANTITIES)
+	_screen.open_battle_pack()
+	_screen.finish()


### PR DESCRIPTION
Battle Tower fights now retain the cartridge's stored opponent stats, heal the player's party before entry, and restore the original party after the fight. Consumed or stolen held items, changed moves and happiness no longer leak out of the Tower.

- Enforce the Tower/link pack and free-switch restrictions, preserve sampled trainer names and result dialogue, and exclude these fights from single-player encounter side effects.
- Restore the trainer portrait before result dialogue with the source's 64-frame slide and hold. Clear fainted status panels until their replacements enter.
- Resolve deferred launcher focus against the current page and respect inherited focus restrictions.
- Remove stale comments and lower the comment ceiling from 37,742 to 37,709.

Validation includes the complete 4,249-test suite, all real-cache checks, replay, story walks on all three profiles, normal and mod-enabled boot, and the whole-tree analyzer. The Tower check covers all 210 records (1,260 stored stats), all trainer result lines, seven wins through the reward, and a first-loss return to reception. Direct cartridge calls agree on all stored stats; 117 records differ from recalculation. Disabling the stat copy makes the corpus check fail. Result and pack screenshots were inspected.
