### PR TITLE
Decode Generation 1 sprites into the shared cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,14 +364,14 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, and every picture their sprite codec decodes |
 
 The rest are previews and dumps, each driving a real screen or table:
 
 | Tool | Does |
 |---|---|
 | `dump_tables.gd <game> <table>` | Prints a decoded table: `species`, `moves`, `items`, `types`, `matchups`, `trainers`, `learnsets`, `egg_moves`, `evolutions`, `growth` or `all` |
-| `preview_pics.gd <game> <png> [kind]` | Contact sheet of `front`, `trainers`, `font` or `frames` |
+| `preview_pics.gd <game> <png> [kind]` | Contact sheet of `front`, `back`, `trainers`, `player_back`, `font` or `frames`, in either generation |
 | `preview_*.gd` | One per screen: the intro, title, credits, Hall of Fame, region map, party, marts, mail, fishing, battle switch and animations, overworld sprites and collision |
 | `preview_world_story.gd` | Map entry callbacks, event-flag visibility, facing interactions and the whole story route |
 | `replay_world.gd [game ...] [frames]` | Records `(frame, button)` from a real run and replays it into a fresh world; the same seed and log must reach the same snapshot, party and battle outcome byte for byte, at 30 fps and at 144. One route fights: a wild battle is spent from the world's own pump and steered through its own funnel |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -324,7 +324,7 @@ the suite.
 |---|---|
 | Cyclomatic complexity of one function | 20 |
 | Lines in one comment block | 8 |
-| Comment lines under `game/`, `tools/` and `autoload/` | the number recorded in the test, which goes down except for a generation the tree did not carry before |
+| Comment lines under `game/`, `tools/` and `autoload/` | the number recorded in the test, which goes down except while a generation the tree did not carry is being brought in |
 
 Complexity counts `if`, `elif`, `while`, `for`, `and`, `or`, an inline `if` and
 one per `match` arm. Over the ceiling, the remedy is a lookup table, a guard

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1586,14 +1586,22 @@ func _build_matchups(rows: Array) -> void:
 			_foresight_matchups[key] = true
 
 
-## The four colours a species is drawn with, in index order. The cache stores
-## the cartridge's own 15-bit pair; white and black are implied.
+## The four colours a species is drawn with, in index order.
 func palette(number: int, shiny: bool = false) -> PackedColorArray:
 	var entry: Dictionary = species(number)
 	if entry.is_empty():
 		return PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 
-	var stored: Array = entry["palette"]["shiny" if shiny else "normal"]
+	var entry_palette: Dictionary = entry["palette"]
+	# Generation 1's `SuperPalettes` row is all four colours and has no shiny
+	# half; Generation 2 stores only the two that sit between white and black.
+	if entry_palette.has("colors"):
+		var colors: PackedColorArray = PackedColorArray()
+		for packed: Variant in entry_palette["colors"] as Array:
+			colors.append(PokePalette.from_packed(int(packed)))
+		return colors
+
+	var stored: Array = entry_palette["shiny" if shiny else "normal"]
 	return PokePalette.pic_palette(PackedColorArray([
 		PokePalette.from_packed(int(stored[0])),
 		PokePalette.from_packed(int(stored[1])),
@@ -2708,8 +2716,12 @@ func battle_transition_palette(dark: bool = false) -> PackedColorArray:
 	return out
 
 
+## The kinds are the generation's own: Chris, Kris and the Dude in Generation 2,
+## the player and the old man in Generation 1.
 func player_backpic(kind: String) -> Dictionary:
-	var slot: int = Gen2Layout.PLAYER_BACKPICS.find(kind)
+	var kinds: Array[String] = Gen1Layout.PLAYER_BACKPICS if generation == RomRegistry.GEN1 \
+		else Gen2Layout.PLAYER_BACKPICS
+	var slot: int = kinds.find(kind)
 	if slot < 0:
 		return {}
 	var cell: int = int(atlas("player_back").get("cell", 0))

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -413,6 +413,11 @@ func import_rom(
 	var tmhm_moves: Array = _import_tmhm_moves(rom, layout)
 	var trainers: Array = _import_trainers(rom, layout)
 	await _breathe(yield_ms)
+	var pics: Dictionary = _import_pics(rom, layout, species, on_progress)
+	if pics.is_empty():
+		result["message"] = "Could not decode every picture."
+		return result
+	await _breathe(yield_ms)
 
 	var sections: Dictionary = {
 		RomCache.species_path(directory): species,
@@ -439,6 +444,7 @@ func import_rom(
 		"type_count": types.size(),
 		"matchup_count": matchups.size(),
 		"trainer_count": trainers.size(),
+		"atlases": pics,
 		"complete": true,
 	}
 	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
@@ -515,8 +521,9 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 			"evolutions": evos_moves["evolutions"],
 			"learnset": evos_moves["learnset"],
 			# Width in the high nybble, height in the low one, in tiles.
-			"front_tiles": [dimensions & 0x0F, dimensions >> 4],
-			"pics": {
+			"front_tiles": [dimensions >> 4, dimensions & 0x0F],
+			# Not `pics`, which is the key a mod's own artwork arrives under.
+			"pic_offsets": {
 				"front": _pic_offset(rom, layout, stats + Gen1Layout.BASE_FRONT_PIC, index),
 				"back": _pic_offset(rom, layout, stats + Gen1Layout.BASE_BACK_PIC, index),
 			},
@@ -630,12 +637,13 @@ func _import_items(rom: RomFile, layout: Dictionary) -> Array:
 		out.append({
 			"number": item,
 			"name": names[item - 1],
-			"price": _bcd_price(rom, Gen1Layout.item_price_offset(layout, item)),
+			"price": _bcd3(rom, Gen1Layout.item_price_offset(layout, item)),
 		})
 	return out
 
 
-static func _bcd_price(rom: RomFile, at: int) -> int:
+## `bcd3`, which is how both a price and a trainer's reward money are stored.
+static func _bcd3(rom: RomFile, at: int) -> int:
 	var out: int = 0
 	for byte: int in Gen1Layout.ITEM_PRICE_SIZE:
 		var packed: int = rom.u8(at + byte)
@@ -659,5 +667,85 @@ func _import_trainers(rom: RomFile, layout: Dictionary) -> Array:
 	)
 	var out: Array = []
 	for trainer_class: int in range(1, Gen1Layout.TRAINER_CLASS_COUNT + 1):
-		out.append({"number": trainer_class, "name": names[trainer_class - 1]})
+		var row: int = int(layout["trainer_pics"]) \
+			+ (trainer_class - 1) * Gen1Layout.TRAINER_PIC_SIZE
+		out.append({
+			"number": trainer_class,
+			"name": names[trainer_class - 1],
+			# `GetTrainerInformation`: times the last enemy's level.
+			"base_money": _bcd3(rom, row + Gen1Layout.POINTER_SIZE),
+		})
 	return out
+
+
+## Every picture the cartridge draws, through [Gen1SpriteCodec]: the pics
+## `BaseStats` names, `TrainerPicAndMoneyPointers`' 47, and the two back ones.
+func _import_pics(
+	rom: RomFile, layout: Dictionary, species: Array, on_progress: Callable
+) -> Dictionary:
+	var codec := Gen1SpriteCodec.new()
+	var front: Dictionary = PokeTiles.new_atlas(
+		Gen1Layout.FRONTPIC_MAX_TILES, Gen1Layout.SPECIES_COUNT
+	)
+	var back: Dictionary = PokeTiles.new_atlas(
+		Gen1Layout.BACKPIC_TILES, Gen1Layout.SPECIES_COUNT
+	)
+	for entry: Dictionary in species:
+		var slot: int = int(entry["number"]) - 1
+		var offsets: Dictionary = entry["pic_offsets"]
+		_decode_pic(codec, rom, int(offsets["front"]), front, slot)
+		_decode_pic(codec, rom, int(offsets["back"]), back, slot)
+		if on_progress.is_valid():
+			on_progress.call("pics", slot + 1, Gen1Layout.SPECIES_COUNT)
+
+	var trainers: Dictionary = PokeTiles.new_atlas(
+		Gen1Layout.TRAINER_PIC_TILES, Gen1Layout.TRAINER_CLASS_COUNT
+	)
+	for trainer_class: int in range(1, Gen1Layout.TRAINER_CLASS_COUNT + 1):
+		_decode_pic(
+			codec, rom, Gen1Layout.trainer_pic_offset(rom, layout, trainer_class),
+			trainers, trainer_class - 1
+		)
+
+	var player_back: Dictionary = PokeTiles.new_atlas(
+		Gen1Layout.BACKPIC_TILES, Gen1Layout.PLAYER_BACKPICS.size()
+	)
+	for slot: int in Gen1Layout.PLAYER_BACKPICS.size():
+		_decode_pic(
+			codec, rom, int(layout["pic_%s_back" % Gen1Layout.PLAYER_BACKPICS[slot]]),
+			player_back, slot
+		)
+
+	# A wrong offset decodes nothing, so an atlas short of a cell is a bad pin.
+	var wanted: Dictionary = {
+		"front": Gen1Layout.SPECIES_COUNT, "back": Gen1Layout.SPECIES_COUNT,
+		"trainers": Gen1Layout.TRAINER_CLASS_COUNT,
+		"player_back": Gen1Layout.PLAYER_BACKPICS.size(),
+	}
+	var atlases: Dictionary = {
+		"front": front, "back": back, "trainers": trainers, "player_back": player_back,
+	}
+	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
+	var out: Dictionary = {}
+	for name: String in atlases:
+		var atlas: Dictionary = atlases[name]
+		if int(atlas["decoded"]) != int(wanted[name]):
+			return {}
+		if not RomCache.write_indices(RomCache.pic_path(directory, name), atlas["pixels"]):
+			return {}
+		out[name] = PokeTiles.atlas_record(atlas)
+	return out
+
+
+func _decode_pic(
+	codec: Gen1SpriteCodec, rom: RomFile, start: int, atlas: Dictionary, slot: int
+) -> bool:
+	if start < 0:
+		return false
+	var raw: PackedByteArray = codec.decompress(rom.bytes(), start)
+	if codec.failed:
+		return false
+	PokeTiles.blit_pic(
+		PokeTiles.decode_pic(raw, codec.columns, codec.rows), codec.columns, atlas, slot
+	)
+	return true

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -75,9 +75,6 @@ const ITEM_PRICE_SIZE: int = 3
 const TM_COUNT: int = 50
 const HM_COUNT: int = 5
 
-## `NUM_TRAINERS`, the trainer classes rather than the individual trainers.
-const TRAINER_CLASS_COUNT: int = 47
-
 ## A `PokedexEntry`: category, feet, inches, weight in tenths of a pound, then
 ## `text_far`'s $17 with a `dab` pointer to the description.
 const DEX_TEXT_FAR: int = 0x17
@@ -115,6 +112,24 @@ const PIC_INDEX_MEW: int = 0x15
 const PIC_INDEX_FOSSIL_KABUTOPS: int = 0xB6
 const PIC_BANK_FOSSIL_KABUTOPS: int = 0x0B
 
+## `NUM_TRAINERS`, the trainer classes rather than the individual trainers.
+const TRAINER_CLASS_COUNT: int = 47
+
+## `TrainerPicAndMoneyPointers`: a near pointer and the class's base reward
+## money as three packed-decimal bytes. Every trainer picture is in the one bank
+## the layout records, and `ChiefPic` and `ScientistPic` are the same address.
+const TRAINER_PIC_SIZE: int = 5
+
+## Sides in tiles: `_LoadTrainerPic`'s `ld a, $77`, the widest front pic, and
+## every back pic, which `ScaleSpriteByTwo` doubles before a battle draws it.
+const TRAINER_PIC_TILES: int = 7
+const FRONTPIC_MAX_TILES: int = 7
+const BACKPIC_TILES: int = 4
+
+## `GetTrainerBackpic`'s counterpart, in the `player_back` atlas's slot order:
+## the player, and the old man who borrows the screen for the catching tutorial.
+const PLAYER_BACKPICS: Array[String] = ["player", "old_man"]
+
 const RED_BLUE: Dictionary = {
 	"species_names": 0x1C21E,
 	"base_stats": 0x383DE,
@@ -139,6 +154,10 @@ const RED_BLUE: Dictionary = {
 	"evos_moves": 0x3B05C,
 	"evos_moves_bank": 0x0E,
 	"cries": 0x39446,
+	"trainer_pics": 0x39914,
+	"trainer_pics_bank": 0x13,
+	"pic_player_back": 0x33E0A,
+	"pic_old_man_back": 0x33E9A,
 }
 
 const YELLOW: Dictionary = {
@@ -163,6 +182,11 @@ const YELLOW: Dictionary = {
 	"evos_moves": 0x3B1E5,
 	"evos_moves_bank": 0x0E,
 	"cries": 0x39462,
+	"trainer_pics": 0x39893,
+	"trainer_pics_bank": 0x13,
+	## Yellow moved both back pics out of "Pics 4" and into their own bank.
+	"pic_player_back": 0xF43B1,
+	"pic_old_man_back": 0xF4441,
 }
 
 
@@ -213,6 +237,12 @@ static func item_price_offset(layout: Dictionary, item: int) -> int:
 
 static func cry_offset(layout: Dictionary, index: int) -> int:
 	return int(layout["cries"]) + (index - 1) * CRY_SIZE
+
+
+## The pic behind one row of `TrainerPicAndMoneyPointers`.
+static func trainer_pic_offset(rom: RomFile, layout: Dictionary, trainer_class: int) -> int:
+	var row: int = int(layout["trainer_pics"]) + (trainer_class - 1) * TRAINER_PIC_SIZE
+	return RomFile.linear(int(layout["trainer_pics_bank"]), rom.u16le(row))
 
 
 ## `NUM_POKEMON + 1` rows in dex order with MISSINGNO's first, so the dex number

--- a/game/gen1/gen1_sprite_codec.gd
+++ b/game/gen1/gen1_sprite_codec.gd
@@ -1,0 +1,226 @@
+class_name Gen1SpriteCodec
+extends RefCounted
+
+## `UncompressSpriteData`, Generation 1's sprite format, which is not the
+## [Gen2Lz] every other graphic in either generation uses. A stream opens on the
+## picture's size in tiles and a bit naming which buffer takes the first chunk,
+## then two run-length coded chunks of 2-bit groups with `wSpriteUnpackMode`
+## between them. A chunk is written down each tile column four times over,
+## filling bit pairs 7-6, then 5-4, 3-2 and 1-0, so four passes touch every
+## output byte; the two finished chunks are the picture's two bit planes.
+
+## `SPRITEBUFFERSIZE` is 7 by 7 tiles.
+const MAX_TILES: int = 7
+const PASSES: int = 4
+## Mode 1 delta-decodes the first chunk and exclusive-ors it into the second;
+## mode 2 delta-decodes both first.
+const MODE_DELTA: int = 0
+const MODE_XOR: int = 1
+const MODE_DELTA_XOR: int = 2
+## `LengthEncodingOffsetList` has sixteen rows.
+const MAX_RUN_BITS: int = 16
+
+## `DecodeNybble0Table` and `DecodeNybble1Table`, flattened so the nybble being
+## decoded is the row. Which table is the last decoded nybble's bit 0, or its
+## bit 3 when the picture is being mirrored.
+const FROM_0: Array[int] = [0x0, 0x1, 0x3, 0x2, 0x7, 0x6, 0x4, 0x5,
+	0xF, 0xE, 0xC, 0xD, 0x8, 0x9, 0xB, 0xA]
+const FROM_1: Array[int] = [0xF, 0xE, 0xC, 0xD, 0x8, 0x9, 0xB, 0xA,
+	0x0, 0x1, 0x3, 0x2, 0x7, 0x6, 0x4, 0x5]
+const FLIPPED_FROM_0: Array[int] = [0x0, 0x8, 0xC, 0x4, 0xE, 0x6, 0x2, 0xA,
+	0xF, 0x7, 0x3, 0xB, 0x1, 0x9, 0xD, 0x5]
+const FLIPPED_FROM_1: Array[int] = [0xF, 0x7, 0x3, 0xB, 0x1, 0x9, 0xD, 0x5,
+	0x0, 0x8, 0xC, 0x4, 0xE, 0x6, 0x2, 0xA]
+## `NybbleReverseTable`.
+const REVERSED: Array[int] = [0x0, 0x8, 0x4, 0xC, 0x2, 0xA, 0x6, 0xE,
+	0x1, 0x9, 0x5, 0xD, 0x3, 0xB, 0x7, 0xF]
+
+## Set by a run off the end of the cartridge, or a size no buffer can hold.
+var failed: bool = false
+## The last picture's size in tiles, from the first byte of its own stream.
+var columns: int = 0
+var rows: int = 0
+var consumed: int = 0
+
+var _data: PackedByteArray = PackedByteArray()
+var _pos: int = 0
+var _bit: int = 0
+
+
+## Decompresses the pic at [param offset] into the column-major 2bpp tiles
+## [method PokeTiles.decode_pic] takes, or nothing at all on failure.
+## [param flipped] is `wSpriteFlipped`, which mirrors the pixels inside each
+## tile column and leaves the columns for `CopyUncompressedPicToHL` to reverse.
+func decompress(data: PackedByteArray, offset: int, flipped: bool = false) -> PackedByteArray:
+	failed = false
+	columns = 0
+	rows = 0
+	consumed = 0
+	_data = data
+	_pos = offset
+	_bit = 0
+
+	var size: int = _read_byte()
+	columns = size >> 4
+	rows = size & 0x0F
+	if failed or columns < 1 or rows < 1 or columns > MAX_TILES or rows > MAX_TILES:
+		failed = true
+		return PackedByteArray()
+
+	var second_first: bool = _read_bit() == 1
+	var planes: Array[PackedByteArray] = [_new_plane(), _new_plane()]
+	var first: int = 1 if second_first else 0
+	_read_chunk(planes[first])
+	var mode: int = _read_mode()
+	_read_chunk(planes[1 - first])
+	consumed = _pos - offset + (1 if _bit > 0 else 0)
+	if failed:
+		return PackedByteArray()
+
+	_unpack(planes, first, mode, flipped)
+	return _merge(planes, flipped)
+
+
+func _new_plane() -> PackedByteArray:
+	var plane: PackedByteArray = PackedByteArray()
+	plane.resize(columns * rows * PokeTiles.TILE_1BPP_BYTES)
+	return plane
+
+
+func _read_byte() -> int:
+	if _pos < 0 or _pos >= _data.size():
+		failed = true
+		return 0
+	var value: int = _data[_pos]
+	_pos += 1
+	return value
+
+
+func _read_bit() -> int:
+	if _pos < 0 or _pos >= _data.size():
+		failed = true
+		return 0
+	var value: int = (_data[_pos] >> (7 - _bit)) & 1
+	_bit += 1
+	if _bit == 8:
+		_bit = 0
+		_pos += 1
+	return value
+
+
+## One bit for mode 0, two for the others.
+func _read_mode() -> int:
+	if _read_bit() == 0:
+		return MODE_DELTA
+	return MODE_XOR + _read_bit()
+
+
+## The cartridge stops the moment the last pair is placed, which is how a run
+## of zeros longer than the picture ends the chunk.
+func _read_chunk(plane: PackedByteArray) -> void:
+	var stride: int = rows * PokeTiles.TILE_1BPP_BYTES
+	var pairs: PackedByteArray = _read_pairs(columns * stride * PASSES)
+	var at: int = 0
+	for column: int in columns:
+		for pass_number: int in PASSES:
+			var shift: int = (PASSES - 1 - pass_number) * 2
+			var base: int = column * stride
+			for row: int in stride:
+				plane[base + row] |= pairs[at] << shift
+				at += 1
+
+
+func _read_pairs(total: int) -> PackedByteArray:
+	var pairs: PackedByteArray = PackedByteArray()
+	pairs.resize(total)
+	var at: int = 0
+	var zeros: bool = _read_bit() == 0
+	while at < total and not failed:
+		if zeros:
+			at = mini(total, at + _read_run_length())
+			zeros = false
+			continue
+		var value: int = _read_bit() << 1
+		value |= _read_bit()
+		if value == 0:
+			zeros = true
+			continue
+		pairs[at] = value
+		at += 1
+	return pairs
+
+
+## How many zero pairs follow: leading ones count the number's bits, and
+## `LengthEncodingOffsetList` adds `2^bits - 1` so each length has one encoding.
+func _read_run_length() -> int:
+	var bits: int = 1
+	while _read_bit() == 1:
+		bits += 1
+		if bits > MAX_RUN_BITS:
+			failed = true
+			return 0
+	var value: int = 0
+	for _step: int in bits:
+		value = (value << 1) | _read_bit()
+	return value + (1 << bits) - 1
+
+
+func _unpack(planes: Array[PackedByteArray], first: int, mode: int, flipped: bool) -> void:
+	if mode == MODE_DELTA:
+		_delta(planes[0], flipped)
+		_delta(planes[1], flipped)
+		return
+	# A chunk that is not delta-decoded carries a mirrored picture's bits in
+	# cartridge order, so `XorSpriteChunks` reverses its nybbles first.
+	if mode == MODE_DELTA_XOR:
+		_delta(planes[1 - first], false)
+	_delta(planes[first], flipped)
+	if flipped:
+		_reverse_nybbles(planes[1 - first])
+	_xor_into(planes[1 - first], planes[first])
+
+
+## `SpriteDifferentialDecode`: a set bit toggles the running pixel value and a
+## clear one keeps it, along each pixel row, restarting at every row.
+func _delta(plane: PackedByteArray, flipped: bool) -> void:
+	var stride: int = rows * PokeTiles.TILE_1BPP_BYTES
+	var from_0: Array[int] = FLIPPED_FROM_0 if flipped else FROM_0
+	var from_1: Array[int] = FLIPPED_FROM_1 if flipped else FROM_1
+	var carry: int = 8 if flipped else 1
+	for row: int in stride:
+		var last: int = 0
+		for column: int in columns:
+			var at: int = column * stride + row
+			var byte: int = plane[at]
+			var high: int = (from_1 if (last & carry) != 0 else from_0)[byte >> 4]
+			var low: int = (from_1 if (high & carry) != 0 else from_0)[byte & 0x0F]
+			plane[at] = (high << 4) | low
+			last = low
+
+
+static func _reverse_nybbles(plane: PackedByteArray) -> void:
+	for at: int in plane.size():
+		var byte: int = plane[at]
+		plane[at] = (REVERSED[byte >> 4] << 4) | REVERSED[byte & 0x0F]
+
+
+static func _xor_into(plane: PackedByteArray, source: PackedByteArray) -> void:
+	for at: int in plane.size():
+		plane[at] ^= source[at]
+
+
+## `InterlaceMergeSpriteBuffers`: buffer 1 is the low bit plane and buffer 2 the
+## high one. A mirrored picture ends on the nybble swap that turns each already
+## reversed pair into a reversed byte.
+func _merge(planes: Array[PackedByteArray], flipped: bool) -> PackedByteArray:
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(columns * rows * PokeTiles.TILE_BYTES)
+	for at: int in planes[0].size():
+		var low: int = planes[0][at]
+		var high: int = planes[1][at]
+		if flipped:
+			low = ((low & 0x0F) << 4) | (low >> 4)
+			high = ((high & 0x0F) << 4) | (high >> 4)
+		out[at * 2] = low
+		out[at * 2 + 1] = high
+	return out

--- a/game/gen1/gen1_sprite_codec.gd.uid
+++ b/game/gen1/gen1_sprite_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://blrfn6hcaws0w

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -8,11 +8,6 @@ extends RefCounted
 ## plausible garbage rather than an error and garbage in the cache is
 ## indistinguishable from real data later.
 
-## Atlas cells are the largest pic of their kind so a renderer can index them
-## arithmetically; smaller pics sit in the top-left of their cell and record
-## their real size.
-const ATLAS_COLUMNS: int = 16
-
 ## Falkner is trainer class 1 in all three games, and the class in the middle is
 ## a walk check on a table whose entries are terminated rather than padded. The
 ## class that ends the table differs between games and lives in [Gen2Layout].
@@ -7527,24 +7522,34 @@ func _read_egg_palette(rom: RomFile, layout: Dictionary) -> Dictionary:
 func _import_pics(
 	rom: RomFile, layout: Dictionary, species: Array, on_progress: Callable
 ) -> Dictionary:
-	var front: Dictionary = _new_atlas(Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.SPECIES_COUNT)
-	var back: Dictionary = _new_atlas(Gen2Layout.BACKPIC_TILES, Gen2Layout.SPECIES_COUNT)
-	var unown_front: Dictionary = _new_atlas(Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.UNOWN_FORMS)
+	var front: Dictionary = PokeTiles.new_atlas(
+		Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.SPECIES_COUNT
+	)
+	var back: Dictionary = PokeTiles.new_atlas(
+		Gen2Layout.BACKPIC_TILES, Gen2Layout.SPECIES_COUNT
+	)
+	var unown_front: Dictionary = PokeTiles.new_atlas(
+		Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.UNOWN_FORMS
+	)
 	# `GetAnimatedEnemyFrontpic` loads the tiles past the pic's own `w * h` out
 	# of the same decompressed run, into VRAM behind the padded 7x7 block. They
 	# are frames, not a picture, so they get an atlas rather than a slot in the
 	# one beside them.
 	var animated: bool = not Gen2Layout.pic_anim(layout).is_empty()
-	var front_anim: Dictionary = _new_atlas(Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.SPECIES_COUNT)
-	var unown_front_anim: Dictionary = _new_atlas(
+	var front_anim: Dictionary = PokeTiles.new_atlas(
+		Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.SPECIES_COUNT
+	)
+	var unown_front_anim: Dictionary = PokeTiles.new_atlas(
 		Gen2Layout.FRONTPIC_MAX_TILES, Gen2Layout.UNOWN_FORMS
 	)
-	var unown_back: Dictionary = _new_atlas(Gen2Layout.BACKPIC_TILES, Gen2Layout.UNOWN_FORMS)
+	var unown_back: Dictionary = PokeTiles.new_atlas(
+		Gen2Layout.BACKPIC_TILES, Gen2Layout.UNOWN_FORMS
+	)
 	# `EggPic` is entry EGG of `PokemonPicPointers`, past the 251 species and the
 	# unused slot between them, and `GetEggFrontpic` loads it the way any other
 	# front pic is loaded. It gets an atlas of its own because there is no
 	# species record to hang it on: EGG is a party species, not a Pokemon.
-	var egg_front: Dictionary = _new_atlas(Gen2Layout.FRONTPIC_MAX_TILES, 1)
+	var egg_front: Dictionary = PokeTiles.new_atlas(Gen2Layout.FRONTPIC_MAX_TILES, 1)
 	var egg_side: int = Gen2Layout.EGG_PIC_TILES
 	## Gold and Silver's table stops at NUM_POKEMON, so `_GetFrontpic` answers
 	## EGG with `ld hl, EggPic` and the pic is at an address like a back pic.
@@ -7561,10 +7566,12 @@ func _import_pics(
 			egg_side, egg_side, egg_front, 0
 		)
 	var trainer_classes: int = Gen2Layout.trainer_class_count(layout)
-	var trainers: Dictionary = _new_atlas(Gen2Layout.TRAINER_PIC_TILES, trainer_classes)
+	var trainers: Dictionary = PokeTiles.new_atlas(
+		Gen2Layout.TRAINER_PIC_TILES, trainer_classes
+	)
 	# `GetTrainerBackpic`'s three, which are the player standing on the field
 	# before a Pokemon is sent out rather than anybody's front pic.
-	var player_back: Dictionary = _new_atlas(
+	var player_back: Dictionary = PokeTiles.new_atlas(
 		Gen2Layout.PLAYER_BACKPIC_TILES, Gen2Layout.PLAYER_BACKPICS.size()
 	)
 	var backpics: Dictionary = layout.get("player_backpic", {}) as Dictionary
@@ -7661,26 +7668,8 @@ func _import_pics(
 		var atlas: Dictionary = atlases[name]
 		if not RomCache.write_indices(RomCache.pic_path(directory, name), atlas["pixels"]):
 			return {}
-		written[name] = {
-			"width": atlas["width"],
-			"height": atlas["height"],
-			"cell": atlas["cell"],
-			"columns": ATLAS_COLUMNS,
-			"decoded": atlas["decoded"],
-		}
+		written[name] = PokeTiles.atlas_record(atlas)
 	return written
-
-
-func _new_atlas(cell_tiles: int, cells: int) -> Dictionary:
-	var cell: int = cell_tiles * PokeTiles.TILE_WIDTH
-	var rows: int = ceili(float(cells) / ATLAS_COLUMNS)
-	var width: int = ATLAS_COLUMNS * cell
-	var height: int = rows * cell
-	var pixels: PackedByteArray = PackedByteArray()
-	pixels.resize(width * height)
-	return {
-		"pixels": pixels, "width": width, "height": height, "cell": cell, "decoded": 0,
-	}
 
 
 ## The same as [method _decode_into] for a pic the cartridge stores at an
@@ -7739,16 +7728,9 @@ func _blit_pic(
 	raw: PackedByteArray, columns: int, rows: int, atlas: Dictionary, slot: int,
 	skip_tiles: int = 0
 ) -> void:
-	var pixels: PackedByteArray = PokeTiles.decode_pic(
+	PokeTiles.blit_pic(PokeTiles.decode_pic(
 		raw.slice(skip_tiles * PokeTiles.TILE_BYTES) if skip_tiles > 0 else raw, columns, rows
-	)
-	var cell: int = atlas["cell"]
-	PokeTiles.blit(
-		pixels, columns * PokeTiles.TILE_WIDTH,
-		atlas["pixels"], atlas["width"],
-		(slot % ATLAS_COLUMNS) * cell, floori(float(slot) / float(ATLAS_COLUMNS)) * cell
-	)
-	atlas["decoded"] = int(atlas["decoded"]) + 1
+	), columns, atlas, slot)
 
 
 ## `AnimateFrontpic`'s tables: one record per species and one per Unown letter,

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -14,6 +14,8 @@ const TILE_PIXELS: int = 64
 const TILE_BYTES: int = 16
 ## Bytes of 1bpp data per tile: one row per byte, with no second plane.
 const TILE_1BPP_BYTES: int = 8
+## Sixteen cells to an atlas row.
+const ATLAS_COLUMNS: int = 16
 ## The index a set 1bpp pixel decodes to. The hardware widens 1bpp graphics by
 ## copying the byte into both planes, so a lit pixel is index 3 and the rest is
 ## index 0: text is black on white, and the two middle colours never appear.
@@ -127,9 +129,37 @@ static func decode_pic(data: PackedByteArray, columns: int, rows: int) -> Packed
 	return out
 
 
-## Copies an index buffer into a larger one. Pics are stored in fixed-size atlas
-## cells so the renderer can index them arithmetically, and a 5x5 pic has to
-## land in a 7x7 cell somewhere.
+## Cells are the largest pic that goes in them, so a renderer finds one by
+## arithmetic and a smaller pic sits in the top-left of its own.
+static func new_atlas(cell_tiles: int, cells: int) -> Dictionary:
+	var cell: int = cell_tiles * TILE_WIDTH
+	var width: int = ATLAS_COLUMNS * cell
+	var pixels: PackedByteArray = PackedByteArray()
+	var height: int = ceili(float(cells) / ATLAS_COLUMNS) * cell
+	pixels.resize(width * height)
+	return {"pixels": pixels, "width": width, "height": height, "cell": cell, "decoded": 0}
+
+
+static func blit_pic(
+	pixels: PackedByteArray, columns: int, atlas: Dictionary, slot: int
+) -> void:
+	var cell: int = atlas["cell"]
+	blit(
+		pixels, columns * TILE_WIDTH, atlas["pixels"], atlas["width"],
+		(slot % ATLAS_COLUMNS) * cell, floori(float(slot) / float(ATLAS_COLUMNS)) * cell
+	)
+	atlas["decoded"] = int(atlas["decoded"]) + 1
+
+
+## What the manifest keeps about an atlas once its pixels are in their own file.
+static func atlas_record(atlas: Dictionary) -> Dictionary:
+	return {
+		"width": atlas["width"], "height": atlas["height"], "cell": atlas["cell"],
+		"columns": ATLAS_COLUMNS, "decoded": atlas["decoded"],
+	}
+
+
+## Copies an index buffer into a larger one.
 static func blit(
 	source: PackedByteArray,
 	source_width: int,

--- a/tests/unit/test_export_presets.gd
+++ b/tests/unit/test_export_presets.gd
@@ -343,7 +343,7 @@ func test_no_published_file_names_something_only_this_machine_has() -> void:
 	var offenders: Array[String] = []
 	for path: String in paths:
 		var text: String = FileAccess.get_file_as_string(path)
-		for name: String in LOCAL_ONLY:
-			if text.contains(name):
-				offenders.append("%s names %s" % [path, name])
+		for local: String in LOCAL_ONLY:
+			if text.contains(local):
+				offenders.append("%s names %s" % [path, local])
 	assert_eq(offenders, [] as Array[String], "\n".join(offenders))

--- a/tests/unit/test_gen1_sprite_codec.gd
+++ b/tests/unit/test_gen1_sprite_codec.gd
@@ -1,0 +1,185 @@
+extends GutTest
+
+## `UncompressSpriteData` on streams built here, so the shape of the format is
+## pinned without a cartridge. Every real picture is checked against pret's own
+## PNGs by `tools/checks/gen1_pics.gd`.
+
+## One tile square, which is one 8-byte plane and 32 bit pairs a chunk.
+const ONE_TILE: int = 0x11
+const PAIRS: int = 32
+## Four passes of the pair 01 fill a byte with $55, and the differential decode
+## turns that into $66.
+const LITERAL_ONES: int = 0x66
+const LITERAL_TWOS: int = 0xAA
+
+
+## Writes a bit stream the way the cartridge reads one: most significant bit of
+## each byte first.
+class Bits extends RefCounted:
+	var bytes: PackedByteArray = PackedByteArray()
+	var _bit: int = 0
+
+	func byte(value: int) -> void:
+		put(value, 8)
+
+	func put(value: int, count: int) -> void:
+		for step: int in count:
+			var one: int = (value >> (count - 1 - step)) & 1
+			if _bit == 0:
+				bytes.append(0)
+			bytes[bytes.size() - 1] |= one << (7 - _bit)
+			_bit = (_bit + 1) % 8
+
+	## A chunk of literal pairs, none of them zero.
+	func literals(values: Array[int]) -> void:
+		put(1, 1)
+		for value: int in values:
+			put(value, 2)
+
+	## A chunk that opens on a run of [param count] zero pairs, which is as many
+	## as the picture needs.
+	func zeros(count: int) -> void:
+		put(0, 1)
+		var width: int = 1
+		while count > (1 << (width + 1)) - 2:
+			width += 1
+		# `width - 1` ones, then the zero that ends the count, then the number.
+		put(((1 << (width - 1)) - 1) << 1, width)
+		put(count - (1 << width) + 1, width)
+
+
+func _repeat(value: int, count: int) -> Array[int]:
+	var out: Array[int] = []
+	for _step: int in count:
+		out.append(value)
+	return out
+
+
+func _cycle(count: int) -> Array[int]:
+	var out: Array[int] = []
+	for step: int in count:
+		out.append(1 + step % 3)
+	return out
+
+
+## A whole one-tile stream: the size byte, the buffer bit, both chunks and the
+## unpack mode between them.
+func _one_tile(second_first: bool, mode: int, a: Array[int], b: Array[int]) -> PackedByteArray:
+	var bits := Bits.new()
+	bits.byte(ONE_TILE)
+	bits.put(1 if second_first else 0, 1)
+	bits.literals(a)
+	if mode == Gen1SpriteCodec.MODE_DELTA:
+		bits.put(0, 1)
+	else:
+		bits.put(mode + 1, 2)
+	bits.literals(b)
+	return bits.bytes
+
+
+func test_the_first_byte_is_the_picture_size() -> void:
+	var bits := Bits.new()
+	bits.byte(0x53)
+	bits.put(0, 1)
+	bits.zeros(5 * 3 * 8 * 4)
+	bits.put(0, 1)
+	bits.zeros(5 * 3 * 8 * 4)
+	var codec := Gen1SpriteCodec.new()
+	var out: PackedByteArray = codec.decompress(bits.bytes, 0)
+	assert_false(codec.failed, "a whole stream decodes")
+	assert_eq(codec.columns, 5, "the high nybble is the width in tiles")
+	assert_eq(codec.rows, 3, "the low nybble is the height in tiles")
+	assert_eq(out.size(), 5 * 3 * PokeTiles.TILE_BYTES, "one 2bpp tile per tile")
+
+
+func test_a_run_of_zeros_fills_the_picture() -> void:
+	var bits := Bits.new()
+	bits.byte(ONE_TILE)
+	bits.put(0, 1)
+	bits.zeros(PAIRS)
+	bits.put(0, 1)
+	bits.zeros(PAIRS)
+	var codec := Gen1SpriteCodec.new()
+	var out: PackedByteArray = codec.decompress(bits.bytes, 0)
+	assert_false(codec.failed, "a run of zeros is a picture")
+	assert_eq(out.count(0), PokeTiles.TILE_BYTES, "every byte is blank")
+
+
+func test_literal_pairs_are_differentially_decoded() -> void:
+	var codec := Gen1SpriteCodec.new()
+	var out: PackedByteArray = codec.decompress(
+		_one_tile(false, Gen1SpriteCodec.MODE_DELTA, _repeat(1, PAIRS), _repeat(1, PAIRS)), 0
+	)
+	assert_false(codec.failed, "both chunks decode")
+	assert_eq(out.count(LITERAL_ONES), PokeTiles.TILE_BYTES, "both planes carry $66")
+
+
+func test_mode_one_exclusive_ors_the_first_chunk_into_the_second() -> void:
+	var codec := Gen1SpriteCodec.new()
+	var out: PackedByteArray = codec.decompress(
+		_one_tile(false, Gen1SpriteCodec.MODE_XOR, _repeat(1, PAIRS), _repeat(2, PAIRS)), 0
+	)
+	assert_false(codec.failed, "mode 1 decodes")
+	assert_eq(out[0], LITERAL_ONES, "the low plane is the delta-decoded chunk")
+	assert_eq(out[1], LITERAL_TWOS ^ LITERAL_ONES, "the high plane is the other one, xored")
+
+
+func test_the_buffer_bit_swaps_which_plane_the_first_chunk_lands_in() -> void:
+	var codec := Gen1SpriteCodec.new()
+	var out: PackedByteArray = codec.decompress(
+		_one_tile(true, Gen1SpriteCodec.MODE_XOR, _repeat(1, PAIRS), _repeat(2, PAIRS)), 0
+	)
+	assert_false(codec.failed, "the second buffer decodes")
+	assert_eq(out[0], LITERAL_TWOS ^ LITERAL_ONES, "the xored chunk is the low plane now")
+	assert_eq(out[1], LITERAL_ONES, "and the delta-decoded one is the high plane")
+
+
+func test_a_flipped_picture_mirrors_the_pixels_inside_each_tile_column() -> void:
+	var stream: PackedByteArray = _one_tile(
+		false, Gen1SpriteCodec.MODE_DELTA, _cycle(PAIRS), _cycle(PAIRS)
+	)
+	var codec := Gen1SpriteCodec.new()
+	var plain: PackedByteArray = PokeTiles.decode_pic(codec.decompress(stream, 0), 1, 1)
+	var mirrored: PackedByteArray = PokeTiles.decode_pic(codec.decompress(stream, 0, true), 1, 1)
+	assert_false(codec.failed, "a mirrored picture decodes")
+	var wanted: PackedByteArray = PackedByteArray()
+	for row: int in PokeTiles.TILE_HEIGHT:
+		for column: int in PokeTiles.TILE_WIDTH:
+			wanted.append(plain[row * PokeTiles.TILE_WIDTH + 7 - column])
+	assert_eq(mirrored, wanted, "every row is reversed")
+
+
+func test_consumed_counts_the_bytes_the_stream_used() -> void:
+	var stream: PackedByteArray = _one_tile(
+		false, Gen1SpriteCodec.MODE_DELTA, _repeat(1, PAIRS), _repeat(1, PAIRS)
+	)
+	var codec := Gen1SpriteCodec.new()
+	codec.decompress(stream, 0)
+	assert_eq(codec.consumed, stream.size(), "the whole stream was read")
+
+
+func test_a_stream_outside_the_cartridge_fails() -> void:
+	var codec := Gen1SpriteCodec.new()
+	var stream: PackedByteArray = _one_tile(
+		false, Gen1SpriteCodec.MODE_DELTA, _repeat(1, PAIRS), _repeat(1, PAIRS)
+	)
+	assert_eq(codec.decompress(stream, -1).size(), 0, "a negative offset decodes nothing")
+	assert_true(codec.failed, "and says so")
+	assert_eq(codec.decompress(stream, stream.size()).size(), 0, "so does one past the end")
+	assert_true(codec.failed, "and says so")
+	assert_eq(codec.decompress(stream.slice(0, 4), 0).size(), 0, "a truncated stream fails")
+	assert_true(codec.failed, "and says so")
+
+
+func test_a_size_no_sprite_buffer_can_hold_fails() -> void:
+	var codec := Gen1SpriteCodec.new()
+	var bits := Bits.new()
+	bits.byte(0x88)
+	bits.put(0, 1)
+	bits.zeros(PAIRS)
+	assert_eq(codec.decompress(bits.bytes, 0).size(), 0, "an 8x8 picture is refused")
+	assert_true(codec.failed, "and says so")
+	bits = Bits.new()
+	bits.byte(0x00)
+	assert_eq(codec.decompress(bits.bytes, 0).size(), 0, "and so is an empty one")
+	assert_true(codec.failed, "and says so")

--- a/tests/unit/test_gen1_sprite_codec.gd.uid
+++ b/tests/unit/test_gen1_sprite_codec.gd.uid
@@ -1,0 +1,1 @@
+uid://dejqiokqsf85e

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -14,11 +14,12 @@ static var PROJECT: String = ProjectSettings.globalize_path("res://")
 const MAX_COMPLEXITY: int = 20
 const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
-## it whenever a pass leaves room. It moves up only for a generation the tree
-## did not carry before, and then by what that generation's own files cost:
-## `game/gen1` and `game/rom/rom_import.gd` are 166 lines of the 37930 here, and
-## the tree has no restatement left to pay for them with.
-const MAX_COMMENT_LINES: int = 37930
+## it whenever a pass leaves room. It moves up only while a generation the tree
+## did not carry is being brought in, and then by what that generation's own
+## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
+## are 256 lines of the 38001 here. The tree has no restatement left to pay for
+## them with, which two sweeps for it have now said.
+const MAX_COMMENT_LINES: int = 38001
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_pics.gd
+++ b/tools/checks/gen1_pics.gd
@@ -1,0 +1,199 @@
+extends RefCounted
+
+## Every picture [Gen1SpriteCodec] decodes, swept on Red, Blue and Yellow: 151
+## front pics, 151 back pics, 47 trainer classes and two battle back pics. The
+## digests come from a run in which all 906 species pics, all 141 trainer pics
+## and all six back pics matched the PNGs under a pinned checkout's
+## `gfx/pokemon` and `gfx/trainers` pixel for pixel, those being what the
+## cartridge's own `.pic` files are built from. Re-earn them against those
+## rather than by copying whatever this prints.
+
+const SPECIES_COUNT: int = 151
+const TRAINER_COUNT: int = 47
+## The only three front sizes in the corpus.
+const FRONT_SIDES: Array[int] = [5, 6, 7]
+const BACK_SIDE: int = 4
+const TRAINER_SIDE: int = 7
+
+## SHA-1 of each atlas's own index buffer. Red and Blue share every picture,
+## and Yellow redrew all 151 front pics and six trainer ones, Brock, Misty,
+## Erika and the rival's three, but no back pic at all.
+const DIGESTS: Dictionary = {
+	&"red": {
+		"front": "672ba02e2d98a787fb619e11e77fba45a379a47b",
+		"back": "a8976278a8c8294f285a25a993a44f2f6012b127",
+		"trainers": "1bdca25cb1bf6de93811f597481f0bda00079cf6",
+		"player_back": "6c2830e479cf877b20bd10f6c94324bb5c3e425d",
+	},
+	&"blue": {
+		"front": "672ba02e2d98a787fb619e11e77fba45a379a47b",
+		"back": "a8976278a8c8294f285a25a993a44f2f6012b127",
+		"trainers": "1bdca25cb1bf6de93811f597481f0bda00079cf6",
+		"player_back": "6c2830e479cf877b20bd10f6c94324bb5c3e425d",
+	},
+	&"yellow": {
+		"front": "d6e50eed9888dbe7787b1a1952403eab5bd133b6",
+		"back": "a8976278a8c8294f285a25a993a44f2f6012b127",
+		"trainers": "6b0fe80efffb9a8223a9646b1df42cfa592fd0f4",
+		"player_back": "6c2830e479cf877b20bd10f6c94324bb5c3e425d",
+	},
+}
+
+## `TrainerPicAndMoneyPointers`' money column, first row, last row and the two
+## the cartridge caps: money received is this times the last enemy's level.
+const PINNED_MONEY: Dictionary = {1: 1500, 26: 9900, 47: 9900}
+const MIN_MONEY: int = 500
+const MAX_MONEY: int = 9900
+
+## `ChiefPic:` falls through to `ScientistPic`, so rows 27 and 28 are one picture.
+const SHARED_PIC_ROWS: Array[int] = [27, 28]
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	_atlas("front", SPECIES_COUNT, FRONT_SIDES[FRONT_SIDES.size() - 1])
+	_atlas("back", SPECIES_COUNT, BACK_SIDE)
+	_atlas("trainers", TRAINER_COUNT, TRAINER_SIDE)
+	_atlas("player_back", Gen1Layout.PLAYER_BACKPICS.size(), BACK_SIDE)
+	_species_pics()
+	_trainer_pics()
+	_player_pics()
+	_digests()
+
+
+## One atlas's metadata: the cell is the largest picture of its kind, and every
+## slot decoded.
+func _atlas(name: String, cells: int, side: int) -> void:
+	var atlas: Dictionary = _r.data.atlas(name)
+	if not _r.check(not atlas.is_empty(), "the cache carries no %s atlas." % name):
+		return
+	_r.check(
+		int(atlas["cell"]) == side * PokeTiles.TILE_WIDTH,
+		"the %s atlas has %d-pixel cells, wanted %d." % [
+			name, int(atlas["cell"]), side * PokeTiles.TILE_WIDTH,
+		]
+	)
+	_r.check(int(atlas["decoded"]) == cells, "the %s atlas decoded %d of %d cells." % [
+		name, int(atlas["decoded"]), cells,
+	])
+
+
+## Every species, both pictures. A front pic is square, its ink fills its own
+## box, and the rest of the 7x7 cell stays blank: a decoder that read the size
+## nybbles the wrong way round draws inside the cell but outside the box.
+func _species_pics() -> void:
+	var sides: Dictionary = {}
+	for dex: int in range(1, SPECIES_COUNT + 1):
+		var pic: Dictionary = _r.data.species_pic(dex)
+		var tiles: Array = (_r.data.species(dex))["front_tiles"]
+		var side: int = int(tiles[0])
+		sides[side] = int(sides.get(side, 0)) + 1
+		_r.check(
+			int(tiles[1]) == side and FRONT_SIDES.has(side),
+			"species %d is %s tiles, which is no front pic size." % [dex, tiles]
+		)
+		_r.check(
+			int(pic.get("width", 0)) == side * PokeTiles.TILE_WIDTH,
+			"species %d's front cell is %d wide, wanted %d." % [
+				dex, int(pic.get("width", 0)), side * PokeTiles.TILE_WIDTH,
+			]
+		)
+		_inked("front", dex, pic)
+		_blank_outside(dex, side)
+		_inked("back", dex, _r.data.species_pic(dex, true))
+	_r.note("gen1 pics %s front sizes, %d species" % [sides, SPECIES_COUNT])
+
+
+func _trainer_pics() -> void:
+	var shared: Array[PackedByteArray] = []
+	for trainer_class: int in range(1, TRAINER_COUNT + 1):
+		var entry: Dictionary = _r.data.trainer(trainer_class)
+		var money: int = int(entry.get("base_money", 0))
+		var pinned: int = int(PINNED_MONEY.get(trainer_class, 0))
+		if pinned > 0:
+			_r.check(money == pinned, "trainer class %d pays %d, pinned %d." % [
+				trainer_class, money, pinned,
+			])
+		_r.check(money >= MIN_MONEY and money <= MAX_MONEY,
+			"trainer class %d pays %d, outside the table's own range." % [trainer_class, money])
+		var cell: Dictionary = _cell("trainers", trainer_class - 1)
+		_r.check(_ink(cell), "trainer class %d draws a blank picture." % trainer_class)
+		if SHARED_PIC_ROWS.has(trainer_class):
+			shared.append(cell.get("indices", PackedByteArray()))
+	_r.check(
+		shared.size() == SHARED_PIC_ROWS.size() and shared[0] == shared[1],
+		"the Chief and the Scientist are not the one picture ChiefPic falls into."
+	)
+
+
+func _player_pics() -> void:
+	var drawn: Array[PackedByteArray] = []
+	for slot: int in Gen1Layout.PLAYER_BACKPICS.size():
+		var cell: Dictionary = _cell("player_back", slot)
+		_r.check(_ink(cell), "the %s back pic is blank." % Gen1Layout.PLAYER_BACKPICS[slot])
+		drawn.append(cell.get("indices", PackedByteArray()))
+	_r.check(drawn[0] != drawn[1], "the player and the old man share a back pic.")
+
+
+func _inked(name: String, dex: int, pic: Dictionary) -> void:
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		_r.data.atlas_indices(name), _r.data.atlas(name), pic
+	)
+	_r.check(_ink(cell), "species %d draws a blank %s pic." % [dex, name])
+
+
+## The cell past the picture's own box, which nothing may draw in.
+func _blank_outside(dex: int, side: int) -> void:
+	var cell: Dictionary = _cell("front", dex - 1)
+	var width: int = int(cell.get("width", 0))
+	var indices: PackedByteArray = cell.get("indices", PackedByteArray())
+	var edge: int = side * PokeTiles.TILE_WIDTH
+	for y: int in int(cell.get("height", 0)):
+		for x: int in width:
+			if (x < edge and y < edge) or indices[y * width + x] == 0:
+				continue
+			_r.fail("species %d draws at %d,%d, outside its %d-tile box." % [dex, x, y, side])
+			return
+
+
+## A whole atlas cell, the picture and the blank around it.
+func _cell(name: String, slot: int) -> Dictionary:
+	return Gen2PicImage.atlas_cell(
+		_r.data.atlas_indices(name), _r.data.atlas(name), {"slot": slot}
+	)
+
+
+static func _ink(cell: Dictionary) -> bool:
+	var indices: Variant = cell.get("indices", null)
+	if not indices is PackedByteArray:
+		return false
+	for index: int in indices as PackedByteArray:
+		if index != 0:
+			return true
+	return false
+
+
+static func _sha1(data: PackedByteArray) -> String:
+	var context := HashingContext.new()
+	context.start(HashingContext.HASH_SHA1)
+	context.update(data)
+	return context.finish().hex_encode()
+
+
+func _digests() -> void:
+	var pinned: Dictionary = DIGESTS.get(_r.game_id, {}) as Dictionary
+	for name: String in ["front", "back", "trainers", "player_back"]:
+		var digest: String = _sha1(_r.data.atlas_indices(name))
+		var expected: String = String(pinned.get(name, ""))
+		if expected.is_empty():
+			_r.fail("no pinned digest for the %s atlas. It answered %s." % [name, digest])
+			continue
+		_r.check(digest == expected, "the %s atlas is %s, pinned %s." % [
+			name, digest, expected,
+		])

--- a/tools/checks/gen1_pics.gd.uid
+++ b/tools/checks/gen1_pics.gd.uid
@@ -1,0 +1,1 @@
+uid://bpde1x1dhljtm

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -109,7 +109,7 @@ func _one_species(dex: int, entry: Dictionary) -> void:
 		_r.check(_is_real_type(int(type)), "%s carries type $%02X" % [name, type])
 	_r.check(int(entry["catch_rate"]) > 0, "%s has no catch rate" % name)
 	_r.check(int(entry["base_exp"]) > 0, "%s has no base experience" % name)
-	_r.check(int(entry["pics"]["front"]) > 0 and int(entry["pics"]["back"]) > 0,
+	_r.check(int(entry["pic_offsets"]["front"]) > 0 and int(entry["pic_offsets"]["back"]) > 0,
 		"%s has an unreachable pic" % name)
 	_dex_entry(name, entry["dex"])
 	_learnset(name, entry["learnset"])

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -7,7 +7,9 @@ extends SceneTree
 ## correct decode from a plausible wrong one. The font comes out folded to sixteen
 ## tiles a row, the shape the charmap describes.
 
-const ATLASES: PackedStringArray = ["front", "back", "unown_front", "unown_back", "trainers"]
+const ATLASES: PackedStringArray = [
+	"front", "back", "unown_front", "unown_back", "trainers", "player_back",
+]
 const SHEETS: PackedStringArray = [
 	"font", "frames", "battle_font", "enemy_hud", "player_hud", "exp_bar",
 ]
@@ -148,19 +150,23 @@ func _render(
 
 
 ## One palette per cell of an atlas, in slot order.
-## The three kinds of atlas are indexed differently: a species atlas by species,
-## the trainer atlas by class, and Unown's by letter form, all twenty-six of
-## which are the one species and so share its colours.
+## The kinds of atlas are indexed differently: a species atlas by species, the
+## trainer atlas by class, and Unown's by letter form, all twenty-six of which
+## are the one species and so share its colours. A Generation 1 cartridge names
+## no colours for a trainer or a back pic, so those come out in Game Boy greys.
 func _palettes(directory: String, name: String, shiny: bool) -> Array:
 	var out: Array = []
+	var key: String = "shiny" if shiny else "normal"
+
+	if name == "player_back":
+		return [_palette_of([])]
 
 	if name == "trainers":
 		for entry: Dictionary in RomCache.read_json(RomCache.trainers_path(directory)):
-			out.append(_palette_of(entry["palette"]))
+			out.append(_palette_of(entry.get("palette", [])))
 		return out
 
 	var species: Array = RomCache.read_json(RomCache.species_path(directory))
-	var key: String = "shiny" if shiny else "normal"
 	if name.begins_with("unown"):
 		var unown: Dictionary = species[Gen2Layout.UNOWN_SPECIES - 1]
 		for form: int in Gen2Layout.UNOWN_FORMS:
@@ -168,12 +174,23 @@ func _palettes(directory: String, name: String, shiny: bool) -> Array:
 		return out
 
 	for entry: Dictionary in species:
-		out.append(_palette_of(entry["palette"][key]))
+		var palette: Dictionary = entry["palette"]
+		out.append(_palette_of(palette.get("colors", palette.get(key, []))))
 	return out
 
 
-func _palette_of(packed: Array) -> PackedColorArray:
+static func _palette_of(packed: Variant) -> PackedColorArray:
+	var colors: Array = packed as Array if packed is Array else []
+	if colors.size() >= PokePalette.COLORS_PER_PIC:
+		var out: PackedColorArray = PackedColorArray()
+		for value: Variant in colors:
+			out.append(PokePalette.from_packed(int(value)))
+		return out
+	if colors.size() < 2:
+		return PokePalette.pic_palette(PackedColorArray([
+			Color(0.66, 0.66, 0.66), Color(0.33, 0.33, 0.33),
+		]))
 	return PokePalette.pic_palette(PackedColorArray([
-		PokePalette.from_packed(int(packed[0])),
-		PokePalette.from_packed(int(packed[1])),
+		PokePalette.from_packed(int(colors[0])),
+		PokePalette.from_packed(int(colors[1])),
 	]))

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,7 +44,7 @@ const GROUPS: Dictionary = {
 		&"battle_tower", &"npc_trade",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
-	&"gen1": [&"gen1_tables"],
+	&"gen1": [&"gen1_tables", &"gen1_pics"],
 }
 
 


### PR DESCRIPTION
`Gen1SpriteCodec` is `UncompressSpriteData`, Generation 1's own sprite format: two run-length coded chunks of 2-bit groups written four passes down each tile column, a differential pass along each pixel row, and three unpack modes that combine the chunks into the picture's two bit planes. `wSpriteFlipped` mirrors the pixels inside each tile column and leaves the columns for `CopyUncompressedPicToHL` to reverse.

`Gen1Importer` decodes the 151 front pics, the 151 back pics, the 47 rows of `TrainerPicAndMoneyPointers` and the player's and the old man's back pics of each cartridge into atlases, and reads each trainer class's base reward money out of the same table. An atlas short of a cell fails the import rather than writing a hole.

## Proof

| Check | Result |
|---|---|
| Species and trainer pics against pret's PNGs | 906 + 141 + 6 exact on Red, Blue and Yellow |
| Mirrored decode against the per-column mirror | 906 of 906 |
| `tools/validate.gd -- all` | 86 topics pass, `gen1_pics` new |
| GUT, `tests/unit` | 3675 pass |
| GUT, whole tree | 4286 pass |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | exit 0 each |
| Editor analyser | 0 warnings in 624 scripts |

## Also

- `PokeTiles` owns atlas construction; `RomImporter` had the only copy of it.
- `GameData.palette` and `GameData.player_backpic` answer for both generations: Generation 1's `SuperPalettes` row is four colours and has no shiny half.
- A Generation 1 species entry keeps its pic addresses under `pic_offsets`; `pics` is the key a mod's own artwork arrives under.
- `front_tiles` was `[height, width]`, against the order `species_pic` reads it in. Invisible while every Generation 1 front pic is square, wrong the moment one is not.
- `tests/unit/test_export_presets.gd` shadowed `Node.name` in a loop.

`tools/preview_pics.gd` now draws `back` and `player_back` as well, in either generation.