### PR TITLE
Import the Generation 1 maps and tilesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ godot --headless --path . -s res://tools/verify_rom.gd
 
 Matching uses SHA-1, never filenames. Unknown hashes are refused because an
 uncharacterised bank layout could produce corrupt assets. The three Generation 1
-cartridges import their species, move, type, item and trainer tables; the
-launcher seats one and does not offer Play until its world is built.
+cartridges import their species, move, type, item and trainer tables and every
+map and tileset; the launcher seats one and does not offer Play until its world
+is built.
 
 | Game | SHA-1 |
 |---|---|
@@ -364,7 +365,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, and every picture their sprite codec decodes |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, and all 226 or 227 maps with their tilesets |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -91,6 +91,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_pic_pointers,
 	_verify_font,
 	_verify_text_box,
+	_verify_world,
 ]
 
 
@@ -311,6 +312,13 @@ static func _verify_text_box(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return _ok()
 
 
+## Every map and tileset decodes, which is the world layout's own check: a wrong
+## table reaches a tileset number, a map size or a block index the cartridge
+## cannot hold.
+static func _verify_world(rom: RomFile, _layout: Dictionary) -> Dictionary:
+	return Gen1WorldImporter.verify_layout(rom)
+
+
 ## One tile as eight row masks, a set bit per lit pixel; the 2bpp sheet folds
 ## its two planes together.
 static func _font_rows(rom: RomFile, layout: Dictionary, code: int) -> Array[int]:
@@ -451,6 +459,8 @@ func import_rom(
 		"trainers": 0,
 		"evolutions": 0,
 		"learnset_moves": 0,
+		"maps": 0,
+		"tilesets": 0,
 		"elapsed_ms": 0,
 	}
 
@@ -492,6 +502,11 @@ func import_rom(
 		result["message"] = "Could not write the font."
 		return result
 	await _breathe(yield_ms)
+	var world: Dictionary = Gen1WorldImporter.import_to_cache(rom, layout, directory, on_progress)
+	if not bool(world["ok"]):
+		result["message"] = String(world["message"])
+		return result
+	await _breathe(yield_ms)
 
 	var sections: Dictionary = {
 		RomCache.species_path(directory): species,
@@ -518,6 +533,8 @@ func import_rom(
 		"type_count": types.size(),
 		"matchup_count": matchups.size(),
 		"trainer_count": trainers.size(),
+		"map_count": int(world["maps"]),
+		"tileset_count": int(world["tilesets"]),
 		"atlases": pics,
 		"tiles": tiles,
 		"complete": true,
@@ -535,11 +552,15 @@ func import_rom(
 	result["trainers"] = trainers.size()
 	result["evolutions"] = _count_of(species, "evolutions")
 	result["learnset_moves"] = _count_of(species, "learnset")
+	result["maps"] = int(world["maps"])
+	result["tilesets"] = int(world["tilesets"])
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
 	result["message"] = ("%d species, %d moves, %d items, %d type matchups, "
-		+ "%d trainer classes, %d evolutions and %d level-up moves in %d ms.") % [
+		+ "%d trainer classes, %d evolutions, %d level-up moves, %d maps and "
+		+ "%d tilesets in %d ms.") % [
 		species.size(), moves.size(), items.size(), matchups.size(), trainers.size(),
-		result["evolutions"], result["learnset_moves"], result["elapsed_ms"],
+		result["evolutions"], result["learnset_moves"], result["maps"],
+		result["tilesets"], result["elapsed_ms"],
 	]
 	return result
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -71,9 +71,11 @@ const ITEM_COUNT: int = 83
 const ITEM_PRICE_SIZE: int = 3
 
 ## `NUM_TMS` and `NUM_HMS`: `TechnicalMachines` is one move number per row and
-## the HMs follow the TMs in the same table.
+## the HMs follow the TMs. As items they sit above the named ones, `HM01` at $C4.
 const TM_COUNT: int = 50
 const HM_COUNT: int = 5
+const HM_FIRST_ITEM: int = 0xC4
+const TM_FIRST_ITEM: int = HM_FIRST_ITEM + HM_COUNT
 
 ## A `PokedexEntry`: category, feet, inches, weight in tenths of a pound, then
 ## `text_far`'s $17 with a `dab` pointer to the description.
@@ -131,6 +133,104 @@ const SPACE_CODE: int = 0x7F
 const FRAME_VERTICAL_CODE: int = 0x7C
 const FRAME_VERTICAL_ROW: int = 0b00101000
 
+## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
+## it. `SwitchToMapRomBank` selects that bank once, which is what puts a map's
+## blocks, objects, text and script in the bank its header sits in.
+const MAP_COUNT_RED_BLUE: int = 248
+const MAP_COUNT_YELLOW: int = 249
+
+## `map_header`: tileset, height, width, the blocks, text and script pointers,
+## then the connection byte; `end_map_header` puts the object pointer behind
+## whatever connection records were emitted.
+const MAP_HEADER_SIZE: int = 10
+const MAP_CONNECTION_RECORD_SIZE: int = 11
+const MAP_OBJECT_POINTER_SIZE: int = 2
+const MAP_CONNECTION_FLAG_EAST: int = 1
+const MAP_CONNECTION_FLAG_WEST: int = 2
+const MAP_CONNECTION_FLAG_SOUTH: int = 4
+const MAP_CONNECTION_FLAG_NORTH: int = 8
+
+## `map_constants.asm`'s largest map.
+const MAP_MAX_WIDTH_BLOCKS: int = 50
+const MAP_MAX_HEIGHT_BLOCKS: int = 72
+
+## The 22 ids `map_header_pointers.asm` marks UNUSED, the same 22 in all three.
+## Their `dw` repeats a real header while their bank byte is a $01, $11 or $1D
+## placeholder naming a different one, so the pair decodes to noise.
+const UNUSED_MAPS: Array[int] = [
+	0x0B, 0x69, 0x6A, 0x6B, 0x6D, 0x6E, 0x6F, 0x70, 0x72, 0x73, 0x74, 0x75,
+	0xCC, 0xCD, 0xCE, 0xE7, 0xED, 0xEE, 0xF1, 0xF2, 0xF3, 0xF4,
+]
+
+## `MapSongBanks`: the map's music id and the bank that music lives in.
+const MAP_SONG_SIZE: int = 2
+
+## `<Map>_Object`: a border block, a counted list each of warps, signs and
+## objects, then one `warp_to` a warp that names only WRAM.
+const WARP_EVENT_SIZE: int = 4
+const SIGN_EVENT_SIZE: int = 3
+const OBJECT_EVENT_SIZE: int = 6
+const WARP_TO_SIZE: int = 4
+## `object_event` writes coordinates four higher, as Generation 2 does.
+const OBJECT_COORD_BIAS: int = 4
+## `TRAINER | text` and `ITEM | text`, each carrying extra bytes behind the row;
+## `LoadMapHeader`'s `.loadSpriteLoop` masks the byte with $3F for the text id.
+const OBJECT_TRAINER_FLAG: int = 0x40
+const OBJECT_ITEM_FLAG: int = 0x80
+const OBJECT_TEXT_MASK: int = 0x3F
+const OBJECT_TRAINER_BYTES: int = 2
+const OBJECT_ITEM_BYTES: int = 1
+## `InitBattleEnemyParameters`' `cp OPP_ID_OFFSET`: the extra byte is this plus
+## a trainer class, or below it a species, and the next its number or level.
+const OPPONENT_ID_OFFSET: int = 200
+## `MAX_WARP_EVENTS`, `MAX_BG_EVENTS` and `MAX_OBJECT_EVENTS`.
+const MAX_WARP_EVENTS: int = 32
+const MAX_SIGN_EVENTS: int = 16
+const MAX_OBJECT_EVENTS: int = 16
+## `warp_event`'s indoor exit: `wLastMap`, the outdoor map the player came from.
+const WARP_TO_LAST_MAP: int = 0xFF
+
+## The `tileset` macro: the bank holding both graphics and blocks, the three
+## pointers, three counter tiles, the grass tile and the animation kind, with
+## $FF for "none" in all four tile columns.
+const TILESET_RECORD_SIZE: int = 12
+const TILESET_COUNT_RED_BLUE: int = 24
+const TILESET_COUNT_YELLOW: int = 25
+const TILESET_COUNTER_TILES: int = 3
+const TILESET_NO_TILE: int = 0xFF
+## `MAP_TILESET_SIZE`: `LoadTilesetTilePatternData` copies this many tiles to
+## `vTileset` whatever the tileset holds, so a short one's tail is whatever
+## follows it in the bank.
+const TILESET_TILE_COUNT: int = 96
+const TILESET_BLOCK_TILES: int = MAP_BLOCK_TILE_WIDTH * MAP_BLOCK_TILE_WIDTH
+
+## Blocks per tileset, in table order. Nothing in the cartridge records it:
+## `<Tileset>_Block` is an INCBIN whose length only the assembler knew. Read off
+## the pinned checkouts' `.bst` files, and bracketed at import by the blocks the
+## maps use and by where the next tileset's graphics start.
+const TILESET_BLOCKS_RED_BLUE: Array[int] = [
+	128, 19, 37, 128, 19, 116, 37, 116, 35, 128, 128, 17,
+	128, 62, 23, 110, 58, 128, 79, 72, 58, 36, 128, 73,
+]
+## Yellow gave the Mart and Pokemon Center three more and added the Beach House.
+const TILESET_BLOCKS_YELLOW: Array[int] = [
+	128, 19, 40, 128, 19, 116, 40, 116, 35, 128, 128, 17,
+	128, 62, 23, 110, 58, 128, 79, 72, 58, 36, 128, 73, 20,
+]
+
+## `WaterTilesets`, a $FF-terminated list, and the tile
+## `IsNextTileShoreOrWater` calls water on one of them.
+const TILESET_LIST_END: int = 0xFF
+const WATER_TILE: int = 0x14
+
+## A walk cell's collision tile is the bottom-left of its 2x2 quarter of the
+## block, the corner Generation 2 also picks. `_GetTileAndCoordsInFrontOfPlayer`
+## reads (8, 11), (8, 7), (6, 9) and (10, 9) and the player's cell starts at
+## screen (8, 8); reading them as top-left leaves 53 of Red's 226 maps with no
+## cell a player can stand on, the Pokemon Centers among them.
+const MAP_BLOCK_TILE_WIDTH: int = 4
+const MAP_BLOCK_CELL_WIDTH: int = 2
+
 ## `NUM_TRAINERS`, the trainer classes rather than the individual trainers.
 const TRAINER_CLASS_COUNT: int = 47
 
@@ -179,6 +279,14 @@ const RED_BLUE: Dictionary = {
 	"text_box": 0x12288,
 	"pic_player_back": 0x33E0A,
 	"pic_old_man_back": 0x33E9A,
+	"map_headers": 0x001AE,
+	"map_header_banks": 0x0C23D,
+	"map_songs": 0x0C04D,
+	"tilesets": 0x0C7BE,
+	"water_tilesets": 0x0E8E0,
+	## `_IsTilePassable` and the lists it walks share a bank, and the pointer in
+	## a tileset row names no bank of its own. Red and Blue keep both in home.
+	"tileset_collision_bank": 0x00,
 }
 
 const YELLOW: Dictionary = {
@@ -210,6 +318,12 @@ const YELLOW: Dictionary = {
 	## Yellow moved both back pics out of "Pics 4" and into their own bank.
 	"pic_player_back": 0xF43B1,
 	"pic_old_man_back": 0xF4441,
+	"map_headers": 0xFC1F2,
+	"map_header_banks": 0xFC3E4,
+	"map_songs": 0xFC000,
+	"tilesets": 0x0C558,
+	"water_tilesets": 0x0E834,
+	"tileset_collision_bank": 0x01,
 }
 
 
@@ -307,3 +421,50 @@ static func pic_bank(layout: Dictionary, index: int) -> int:
 		if index < PIC_BANK_THRESHOLDS[step]:
 			return PIC_BANKS[step]
 	return PIC_BANKS[PIC_BANKS.size() - 1]
+
+
+## How many map ids the flat table holds. Yellow added the Summer Beach House
+## behind Agatha's room.
+static func map_count(id: StringName) -> int:
+	return MAP_COUNT_YELLOW if id == RomRegistry.YELLOW else MAP_COUNT_RED_BLUE
+
+
+static func tileset_count(id: StringName) -> int:
+	return TILESET_COUNT_YELLOW if id == RomRegistry.YELLOW else TILESET_COUNT_RED_BLUE
+
+
+## Blocks per tileset, in `Tilesets` order.
+static func tileset_blocks(id: StringName) -> Array[int]:
+	return TILESET_BLOCKS_YELLOW if id == RomRegistry.YELLOW else TILESET_BLOCKS_RED_BLUE
+
+
+## Whether a map id decodes to a header at all: see [constant UNUSED_MAPS].
+static func is_real_map(map_id: int) -> bool:
+	return not UNUSED_MAPS.has(map_id)
+
+
+## Where one map's header sits, through `MapHeaderBanks` and `MapHeaderPointers`
+## together. Everything the header points at is in the same bank.
+static func map_header_offset(rom: RomFile, layout: Dictionary, map_id: int) -> int:
+	return RomFile.linear(
+		map_bank(rom, layout, map_id),
+		rom.u16le(int(layout["map_headers"]) + map_id * POINTER_SIZE)
+	)
+
+
+static func map_bank(rom: RomFile, layout: Dictionary, map_id: int) -> int:
+	return rom.u8(int(layout["map_header_banks"]) + map_id)
+
+
+static func tileset_offset(layout: Dictionary, number: int) -> int:
+	return int(layout["tilesets"]) + number * TILESET_RECORD_SIZE
+
+
+static func map_song_offset(layout: Dictionary, map_id: int) -> int:
+	return int(layout["map_songs"]) + map_id * MAP_SONG_SIZE
+
+
+## Which of a block's sixteen tiles decides one walk cell.
+static func cell_tile_index(cell_x: int, cell_y: int) -> int:
+	return (cell_y * MAP_BLOCK_CELL_WIDTH + 1) * MAP_BLOCK_TILE_WIDTH \
+		+ cell_x * MAP_BLOCK_CELL_WIDTH

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1,0 +1,462 @@
+class_name Gen1WorldImporter
+extends RefCounted
+
+## Decodes every Generation 1 map and tileset into the shared world sections of
+## the cache, the counterpart of [Gen2WorldImporter]. A map is named by one flat
+## id, so a record's group is zero and its number is that id. A script is machine
+## code here rather than an interpreted command stream, so the header's script
+## and text pointers are kept as addresses and nothing follows them.
+
+const LIST_END: int = Gen1Layout.TILESET_LIST_END
+
+
+static func verify_layout(rom: RomFile) -> Dictionary:
+	var result: Dictionary = read_world(rom, Gen1Layout.for_id(rom.id))
+	if not bool(result.get("ok", false)):
+		return {"ok": false, "message": String(result.get("message", "World data failed validation."))}
+	return {"ok": true, "message": ""}
+
+
+static func import_to_cache(
+	rom: RomFile, layout: Dictionary, directory: String, on_progress: Callable = Callable()
+) -> Dictionary:
+	var result: Dictionary = read_world(rom, layout, on_progress)
+	if not bool(result.get("ok", false)):
+		return result
+
+	var tilesets: Array = result["tilesets"]
+	if not RomCache.write_json(RomCache.world_maps_path(directory), result["maps"]):
+		return _error("Could not write overworld map data.")
+	if not RomCache.write_json(RomCache.world_tilesets_path(directory), tilesets):
+		return _error("Could not write overworld tileset data.")
+	var graphics: Dictionary = result["graphics"]
+	for number: int in graphics:
+		if not RomCache.write_indices(RomCache.world_tile_path(directory, number), graphics[number]):
+			return _error("Could not write overworld tileset %d." % number)
+
+	return {
+		"ok": true,
+		"maps": (result["maps"] as Array).size(),
+		"tilesets": tilesets.size(),
+	}
+
+
+## Every map and tileset, or the first thing that did not decode.
+static func read_world(
+	rom: RomFile, layout: Dictionary, on_progress: Callable = Callable()
+) -> Dictionary:
+	if layout.is_empty():
+		return _error("No layout for %s." % rom.id)
+	var water: PackedByteArray = _read_list(rom, int(layout["water_tilesets"]))
+	var tilesets: Array = []
+	var graphics: Dictionary = {}
+	var count: int = Gen1Layout.tileset_count(rom.id)
+	for number: int in count:
+		var tileset: Dictionary = _read_tileset(rom, layout, number, water)
+		if not bool(tileset.get("ok", false)):
+			return tileset
+		graphics[number] = tileset["pixels"]
+		tileset.erase("pixels")
+		tileset.erase("ok")
+		tilesets.append(tileset)
+
+	var overlap: Dictionary = _verify_block_counts(rom, layout, count)
+	if not bool(overlap["ok"]):
+		return overlap
+
+	var maps: Array = []
+	var map_count: int = Gen1Layout.map_count(rom.id)
+	for map_id: int in map_count:
+		if not Gen1Layout.is_real_map(map_id):
+			continue
+		var map: Dictionary = _read_map(rom, layout, tilesets, map_id)
+		if not bool(map.get("ok", false)):
+			return map
+		map.erase("ok")
+		maps.append(map)
+		if on_progress.is_valid():
+			on_progress.call("maps", maps.size(), map_count - Gen1Layout.UNUSED_MAPS.size())
+
+	return {"ok": true, "maps": maps, "tilesets": tilesets, "graphics": graphics}
+
+
+static func _error(message: String) -> Dictionary:
+	return {"ok": false, "message": message}
+
+
+## A $FF-terminated run of bytes, as `IsInArray` walks one.
+static func _read_list(rom: RomFile, at: int, limit: int = 256) -> PackedByteArray:
+	var out := PackedByteArray()
+	while out.size() < limit and rom.in_bounds(at) and rom.u8(at) != LIST_END:
+		out.append(rom.u8(at))
+		at += 1
+	return out
+
+
+## One row of `Tilesets`, its blockset, its graphics and the list of tiles
+## `_IsTilePassable` walks. The blockset's length is the one thing no cartridge
+## byte records; see [constant Gen1Layout.TILESET_BLOCKS_RED_BLUE].
+static func _read_tileset(
+	rom: RomFile, layout: Dictionary, number: int, water: PackedByteArray
+) -> Dictionary:
+	var table: int = Gen1Layout.tileset_offset(layout, number)
+	if not rom.in_bounds(table, Gen1Layout.TILESET_RECORD_SIZE):
+		return _error("Tileset %d record is outside the ROM." % number)
+
+	var bank: int = rom.u8(table)
+	var block_address: int = rom.u16le(table + 1)
+	var graphics_address: int = rom.u16le(table + 3)
+	var gap: int = block_address - graphics_address
+	if gap <= 0 or gap > Gen1Layout.TILESET_TILE_COUNT * PokeTiles.TILE_BYTES:
+		return _error("Tileset %d keeps %d bytes between its graphics and its blocks." % [
+			number, gap,
+		])
+
+	var block_count: int = Gen1Layout.tileset_blocks(rom.id)[number]
+	var meta_size: int = block_count * Gen1Layout.TILESET_BLOCK_TILES
+	var meta_at: int = RomFile.linear(bank, block_address)
+	if meta_at + meta_size > _bank_end(bank):
+		return _error("Tileset %d's %d blocks run past bank $%02X." % [number, block_count, bank])
+	var meta: PackedByteArray = rom.slice(meta_at, meta_size)
+	if meta.size() != meta_size:
+		return _error("Tileset %d's blocks are outside the ROM." % number)
+
+	var passable: PackedByteArray = _read_list(
+		rom, RomFile.linear(int(layout["tileset_collision_bank"]), rom.u16le(table + 5))
+	)
+	if passable.is_empty():
+		return _error("Tileset %d has no passable tiles." % number)
+
+	return {
+		"ok": true,
+		"number": number,
+		"block_count": block_count,
+		"tile_count": Gen1Layout.TILESET_TILE_COUNT,
+		"meta": Array(meta),
+		"passable_tiles": Array(passable),
+		"counter_tiles": Array(rom.slice(table + 7, Gen1Layout.TILESET_COUNTER_TILES)),
+		"grass_tile": rom.u8(table + 10),
+		"animation": rom.u8(table + 11),
+		"water": water.has(number),
+		"pixels": _tileset_strip(rom, bank, graphics_address),
+	}
+
+
+## The other end of the pinned block counts: the assembler lays each tileset's
+## graphics behind the last one's blocks, so a pin one block too long runs into
+## the next row's graphics.
+static func _verify_block_counts(rom: RomFile, layout: Dictionary, count: int) -> Dictionary:
+	var rows: Array = []
+	for number: int in count:
+		var table: int = Gen1Layout.tileset_offset(layout, number)
+		rows.append([rom.u8(table), rom.u16le(table + 1), rom.u16le(table + 3)])
+	var blocks: Array[int] = Gen1Layout.tileset_blocks(rom.id)
+	for number: int in count:
+		var row: Array = rows[number]
+		var start: int = RomFile.linear(int(row[0]), int(row[1]))
+		var limit: int = _bank_end(int(row[0]))
+		for other: Array in rows:
+			var graphics: int = RomFile.linear(int(other[0]), int(other[2]))
+			if int(other[0]) == int(row[0]) and graphics > start:
+				limit = mini(limit, graphics)
+		var end: int = start + blocks[number] * Gen1Layout.TILESET_BLOCK_TILES
+		if end > limit:
+			return _error("Tileset %d's %d blocks reach $%05X, past $%05X." % [
+				number, blocks[number], end, limit,
+			])
+	return {"ok": true}
+
+
+## The 96 tiles `LoadTilesetTilePatternData` copies to VRAM, blockset tail and
+## all. Where that would run off the end of the bank the strip is left blank:
+## the cartridge is reading past its own window and no block names a tile there.
+static func _tileset_strip(rom: RomFile, bank: int, graphics_address: int) -> PackedByteArray:
+	var at: int = RomFile.linear(bank, graphics_address)
+	var wanted: int = Gen1Layout.TILESET_TILE_COUNT * PokeTiles.TILE_BYTES
+	var graphics: PackedByteArray = rom.slice(at, mini(wanted, _bank_end(bank) - at))
+	graphics.resize(wanted)
+	return PokeTiles.decode_2bpp_strip(graphics, 0, Gen1Layout.TILESET_TILE_COUNT)
+
+
+static func _bank_end(bank: int) -> int:
+	return (bank + 1) * RomFile.BANK_SIZE
+
+
+static func _bit_count(value: int) -> int:
+	var out: int = 0
+	while value != 0:
+		out += value & 1
+		value >>= 1
+	return out
+
+
+## One map header, the blocks it draws and the object block behind it.
+static func _read_map(
+	rom: RomFile, layout: Dictionary, tilesets: Array, map_id: int
+) -> Dictionary:
+	var bank: int = Gen1Layout.map_bank(rom, layout, map_id)
+	var header: int = Gen1Layout.map_header_offset(rom, layout, map_id)
+	if not rom.in_bounds(header, Gen1Layout.MAP_HEADER_SIZE):
+		return _error("Map %d's header is outside the ROM." % map_id)
+
+	var tileset_number: int = rom.u8(header)
+	if tileset_number >= tilesets.size():
+		return _error("Map %d references tileset %d." % [map_id, tileset_number])
+	var tileset: Dictionary = tilesets[tileset_number]
+	var block_count: int = int(tileset["block_count"])
+
+	var height: int = rom.u8(header + 1)
+	var width: int = rom.u8(header + 2)
+	if width <= 0 or width > Gen1Layout.MAP_MAX_WIDTH_BLOCKS \
+		or height <= 0 or height > Gen1Layout.MAP_MAX_HEIGHT_BLOCKS:
+		return _error("Map %d is %dx%d blocks." % [map_id, width, height])
+
+	var blocks: PackedByteArray = rom.slice(
+		RomFile.linear(bank, rom.u16le(header + 3)), width * height
+	)
+	if blocks.size() != width * height:
+		return _error("Map %d's block data is outside the ROM." % map_id)
+	for block: int in blocks:
+		if block >= block_count:
+			return _error("Map %d uses block %d in a %d-block tileset." % [
+				map_id, block, block_count,
+			])
+
+	var connection_flags: int = rom.u8(header + 9)
+	if (connection_flags & 0xF0) != 0:
+		return _error("Map %d has undefined connection flags $%02X." % [map_id, connection_flags])
+	var connection_count: int = _bit_count(connection_flags)
+	var object_address: int = header + Gen1Layout.MAP_HEADER_SIZE \
+		+ connection_count * Gen1Layout.MAP_CONNECTION_RECORD_SIZE
+	if not rom.in_bounds(object_address, Gen1Layout.MAP_OBJECT_POINTER_SIZE):
+		return _error("Map %d's connection records run past the ROM." % map_id)
+	var connections: Array = _read_connections(
+		rom, header + Gen1Layout.MAP_HEADER_SIZE, connection_flags
+	)
+
+	var events: Dictionary = _read_events(
+		rom, bank, rom.u16le(object_address), map_id, width, height, block_count
+	)
+	if not bool(events.get("ok", false)):
+		return events
+
+	return {
+		"ok": true,
+		"group": 0,
+		"number": map_id,
+		"tileset": tileset_number,
+		"music": rom.u8(Gen1Layout.map_song_offset(layout, map_id)),
+		"border_block": events["border_block"],
+		"width_blocks": width,
+		"height_blocks": height,
+		"blocks": Array(blocks),
+		"collision": _collision_grid(tileset, blocks, width, height),
+		"collision_width": width * Gen1Layout.MAP_BLOCK_CELL_WIDTH,
+		"collision_height": height * Gen1Layout.MAP_BLOCK_CELL_WIDTH,
+		"connection_flags": connection_flags,
+		"connections": connections,
+		"scripts": {
+			"bank": bank,
+			"address": rom.u16le(header + 7),
+			"text_address": rom.u16le(header + 5),
+			"scenes": [],
+			"callbacks": [],
+		},
+		"events": {
+			"bank": bank,
+			"address": rom.u16le(object_address),
+			"warps": events["warps"],
+			"coord_events": [],
+			"bg_events": events["bg_events"],
+			"objects": events["objects"],
+		},
+	}
+
+
+## The tile every walk cell's passability is decided by; Generation 2's grid
+## holds a permission byte in the same place.
+static func _collision_grid(
+	tileset: Dictionary, blocks: PackedByteArray, width: int, height: int
+) -> Array:
+	var meta: Array = tileset["meta"]
+	var out: Array = []
+	for cell_y: int in height * Gen1Layout.MAP_BLOCK_CELL_WIDTH:
+		for cell_x: int in width * Gen1Layout.MAP_BLOCK_CELL_WIDTH:
+			var block: int = blocks[(cell_y >> 1) * width + (cell_x >> 1)]
+			out.append(int(meta[
+				block * Gen1Layout.TILESET_BLOCK_TILES
+				+ Gen1Layout.cell_tile_index(cell_x & 1, cell_y & 1)
+			]))
+	return out
+
+
+## Connection records come north, south, west then east, whichever bits are set,
+## and the caller has bounded the run. `.checkNorthMap` writes the y alignment
+## into `wYCoord` and adds the x one to `wXCoord`, so the pair is an unsigned
+## coordinate and a signed addend rather than Generation 2's two offsets.
+static func _read_connections(rom: RomFile, at: int, connection_flags: int) -> Array:
+	var directions: Array = [
+		["north", Gen1Layout.MAP_CONNECTION_FLAG_NORTH],
+		["south", Gen1Layout.MAP_CONNECTION_FLAG_SOUTH],
+		["west", Gen1Layout.MAP_CONNECTION_FLAG_WEST],
+		["east", Gen1Layout.MAP_CONNECTION_FLAG_EAST],
+	]
+	var out: Array = []
+	for direction: Array in directions:
+		if (connection_flags & int(direction[1])) == 0:
+			continue
+		out.append({
+			"direction": String(direction[0]),
+			"map_group": 0,
+			"map_number": rom.u8(at),
+			"target_block_pointer": rom.u16le(at + 1),
+			"map_pointer": rom.u16le(at + 3),
+			"length": rom.u8(at + 5),
+			"target_width_blocks": rom.u8(at + 6),
+			"y_alignment": rom.u8(at + 7),
+			"x_alignment": rom.u8(at + 8),
+			"window_pointer": rom.u16le(at + 9),
+		})
+		at += Gen1Layout.MAP_CONNECTION_RECORD_SIZE
+	return out
+
+
+## `<Map>_Object`: the border block, then warps, signs and objects, each a count
+## and its rows.
+static func _read_events(
+	rom: RomFile, bank: int, address: int, map_id: int, width: int, height: int, block_count: int
+) -> Dictionary:
+	var at: int = RomFile.linear(bank, address)
+	if not rom.in_bounds(at):
+		return _error("Map %d's object block is outside the ROM." % map_id)
+	var border_block: int = rom.u8(at)
+	if border_block != Gen1Layout.TILESET_NO_TILE and border_block >= block_count:
+		return _error("Map %d's border block is %d in a %d-block tileset." % [
+			map_id, border_block, block_count,
+		])
+	at += 1
+
+	var cell_width: int = width * Gen1Layout.MAP_BLOCK_CELL_WIDTH
+	var cell_height: int = height * Gen1Layout.MAP_BLOCK_CELL_WIDTH
+	var warps: Dictionary = _read_warps(rom, at, map_id, cell_width, cell_height)
+	if not bool(warps.get("ok", false)):
+		return warps
+	var signs: Dictionary = _read_signs(rom, int(warps["at"]), map_id, cell_width, cell_height)
+	if not bool(signs.get("ok", false)):
+		return signs
+	var objects: Dictionary = _read_objects(rom, int(signs["at"]), map_id)
+	if not bool(objects.get("ok", false)):
+		return objects
+	# The block ends in one `warp_to` a warp, which names only WRAM.
+	var end: int = int(objects["at"]) \
+		+ (warps["events"] as Array).size() * Gen1Layout.WARP_TO_SIZE
+	if end > _bank_end(bank):
+		return _error("Map %d's object block runs past bank $%02X." % [map_id, bank])
+
+	return {
+		"ok": true,
+		"border_block": border_block,
+		"warps": warps["events"],
+		"bg_events": signs["events"],
+		"objects": objects["events"],
+	}
+
+
+static func _read_warps(
+	rom: RomFile, at: int, map_id: int, cell_width: int, cell_height: int
+) -> Dictionary:
+	var count: int = rom.u8(at)
+	at += 1
+	if count > Gen1Layout.MAX_WARP_EVENTS:
+		return _error("Map %d has %d warps." % [map_id, count])
+	var out: Array = []
+	for _row: int in count:
+		if not rom.in_bounds(at, Gen1Layout.WARP_EVENT_SIZE):
+			return _error("Map %d's warps are truncated." % map_id)
+		var y: int = rom.u8(at)
+		var x: int = rom.u8(at + 1)
+		if x >= cell_width or y >= cell_height:
+			return _error("Map %d has a warp at %d,%d outside its %dx%d cells." % [
+				map_id, x, y, cell_width, cell_height,
+			])
+		out.append({
+			"x": x,
+			"y": y,
+			"destination": rom.u8(at + 2),
+			"map_group": 0,
+			"map_number": rom.u8(at + 3),
+		})
+		at += Gen1Layout.WARP_EVENT_SIZE
+	return {"ok": true, "events": out, "at": at}
+
+
+## A sign is Generation 2's background event with a text id where that one keeps
+## a script pointer.
+static func _read_signs(
+	rom: RomFile, at: int, map_id: int, cell_width: int, cell_height: int
+) -> Dictionary:
+	var count: int = rom.u8(at)
+	at += 1
+	if count > Gen1Layout.MAX_SIGN_EVENTS:
+		return _error("Map %d has %d signs." % [map_id, count])
+	var out: Array = []
+	for _row: int in count:
+		if not rom.in_bounds(at, Gen1Layout.SIGN_EVENT_SIZE):
+			return _error("Map %d's signs are truncated." % map_id)
+		var y: int = rom.u8(at)
+		var x: int = rom.u8(at + 1)
+		if x >= cell_width or y >= cell_height:
+			return _error("Map %d has a sign at %d,%d outside its %dx%d cells." % [
+				map_id, x, y, cell_width, cell_height,
+			])
+		out.append({"x": x, "y": y, "type": 0, "script": 0, "text": rom.u8(at + 2)})
+		at += Gen1Layout.SIGN_EVENT_SIZE
+	return {"ok": true, "events": out, "at": at}
+
+
+## An object's coordinates may sit in the runtime's own border padding, so unlike
+## a warp or a sign they are not bounded by the map. The TRAINER bit covers a
+## standing wild Pokemon too; [constant Gen1Layout.OPPONENT_ID_OFFSET] splits them.
+static func _read_objects(rom: RomFile, at: int, map_id: int) -> Dictionary:
+	var count: int = rom.u8(at)
+	at += 1
+	if count > Gen1Layout.MAX_OBJECT_EVENTS:
+		return _error("Map %d has %d objects." % [map_id, count])
+	var out: Array = []
+	for _row: int in count:
+		if not rom.in_bounds(at, Gen1Layout.OBJECT_EVENT_SIZE):
+			return _error("Map %d's objects are truncated." % map_id)
+		var text: int = rom.u8(at + 5)
+		var object: Dictionary = {
+			"sprite": rom.u8(at),
+			"y": rom.u8(at + 1) - Gen1Layout.OBJECT_COORD_BIAS,
+			"x": rom.u8(at + 2) - Gen1Layout.OBJECT_COORD_BIAS,
+			"movement": rom.u8(at + 3),
+			"range": rom.u8(at + 4),
+			"text": text & Gen1Layout.OBJECT_TEXT_MASK,
+		}
+		at += Gen1Layout.OBJECT_EVENT_SIZE
+		var extra: int = _object_extra_bytes(text)
+		if not rom.in_bounds(at, extra):
+			return _error("Map %d's objects are truncated." % map_id)
+		if (text & Gen1Layout.OBJECT_TRAINER_FLAG) != 0:
+			var opponent: int = rom.u8(at)
+			if opponent >= Gen1Layout.OPPONENT_ID_OFFSET:
+				object["trainer_class"] = opponent - Gen1Layout.OPPONENT_ID_OFFSET
+				object["trainer_number"] = rom.u8(at + 1)
+			else:
+				object["species"] = opponent
+				object["level"] = rom.u8(at + 1)
+		elif (text & Gen1Layout.OBJECT_ITEM_FLAG) != 0:
+			object["item"] = rom.u8(at)
+		at += extra
+		out.append(object)
+	return {"ok": true, "events": out, "at": at}
+
+
+static func _object_extra_bytes(text: int) -> int:
+	if (text & Gen1Layout.OBJECT_TRAINER_FLAG) != 0:
+		return Gen1Layout.OBJECT_TRAINER_BYTES
+	if (text & Gen1Layout.OBJECT_ITEM_FLAG) != 0:
+		return Gen1Layout.OBJECT_ITEM_BYTES
+	return 0

--- a/game/gen1/gen1_world_importer.gd.uid
+++ b/game/gen1/gen1_world_importer.gd.uid
@@ -1,0 +1,1 @@
+uid://cwqb50vd0ipwv

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -40,6 +40,13 @@ static func pic_palette(middle: PackedColorArray) -> PackedColorArray:
 	return out
 
 
+## The four shades a Game Boy shows where nothing has applied a palette.
+static func monochrome() -> PackedColorArray:
+	return pic_palette(PackedColorArray([
+		Color(0.66, 0.66, 0.66), Color(0.33, 0.33, 0.33),
+	]))
+
+
 ## Reads one species' entry as { normal, shiny }, each a two-colour array.
 static func decode_entry(data: PackedByteArray, offset: int) -> Dictionary:
 	return {

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 103
+const FORMAT_VERSION: int = 104
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -1,9 +1,12 @@
 class_name Gen2WorldMap
 extends RefCounted
 
-## Node-free map data decoded from a Generation 2 map header and event block.
-## Coordinates are row-major, with y increasing from the top as on the
-## cartridge. Collision values are the raw cartridge permissions, not booleans.
+## Node-free map data decoded from either generation's map header and event
+## block. Coordinates are row-major, y increasing from the top as on the
+## cartridge, and Generation 1's one flat map id is [member number] under
+## [member group] 0. Collision values are the raw byte the cartridge tests: a
+## permission byte in Generation 2, and the tile the cell draws in Generation 1,
+## which [method Gen2WorldTileset.tile_passable] answers for.
 
 var group: int = 0
 var number: int = 0
@@ -105,12 +108,15 @@ static func _connection_rows(value: Array) -> Array:
 	var out: Array = []
 	for raw: Dictionary in value:
 		var connection: Dictionary = raw.duplicate(true)
+		# Generation 2 records two offsets where Generation 1 records two
+		# alignments, so a connection carries four of these six.
 		for field: String in [
 			"map_group", "map_number", "length", "target_width_blocks",
-			"x_offset", "y_offset", "target_block_pointer", "map_pointer",
-			"window_pointer",
+			"x_offset", "y_offset", "x_alignment", "y_alignment",
+			"target_block_pointer", "map_pointer", "window_pointer",
 		]:
-			connection[field] = int(raw.get(field, 0))
+			if raw.has(field):
+				connection[field] = int(raw[field])
 		out.append(connection)
 	return out
 
@@ -124,10 +130,15 @@ static func _events_from_cache(value: Variant) -> Dictionary:
 		"address": int(event_values.get("address", 0)),
 		"warps": _event_rows(event_values.get("warps", []), ["x", "y", "destination", "map_group", "map_number"]),
 		"coord_events": _event_rows(event_values.get("coord_events", []), ["scene", "x", "y", "script"]),
-		"bg_events": _event_rows(event_values.get("bg_events", []), ["x", "y", "type", "script"]),
+		"bg_events": _event_rows(
+			event_values.get("bg_events", []), ["x", "y", "type", "script", "text"]
+		),
+		# The last seven are Generation 1's, whose events carry a text id where
+		# Generation 2's carry a script pointer.
 		"objects": _event_rows(event_values.get("objects", []), [
 			"sprite", "x", "y", "movement", "x_radius", "y_radius", "hour_1", "hour_2",
 			"palette", "object_type", "sight_range", "script", "event_flag",
+			"range", "text", "trainer_class", "trainer_number", "species", "level", "item",
 		]),
 	}
 
@@ -138,7 +149,9 @@ static func _event_rows(value: Variant, integer_fields: Array[String]) -> Array:
 	var out: Array = []
 	for raw: Dictionary in value as Array:
 		var event: Dictionary = raw.duplicate(true)
+		# An absent field stays absent: an object names a trainer or an item.
 		for field: String in integer_fields:
-			event[field] = int(raw.get(field, 0))
+			if raw.has(field):
+				event[field] = int(raw[field])
 		out.append(event)
 	return out

--- a/game/world/world_tileset.gd
+++ b/game/world/world_tileset.gd
@@ -15,6 +15,13 @@ var tile_count: int = Gen2Layout.TILESET_TILE_COUNT
 ## command list stays an Array, because its entries are records.
 var meta: PackedByteArray = PackedByteArray()
 var collision: PackedByteArray = PackedByteArray()
+## Generation 1 leaves [member collision] empty: `_IsTilePassable` walks a list
+## of tile numbers, and the four columns beside it are its `tileset` macro's.
+var passable_tiles: PackedByteArray = PackedByteArray()
+var counter_tiles: PackedByteArray = PackedByteArray()
+var grass_tile: int = Gen1Layout.TILESET_NO_TILE
+var animation: int = 0
+var water: bool = false
 var animation_pointer: int = 0
 var palette_map_pointer: int = 0
 var palette_map: PackedByteArray = PackedByteArray()
@@ -28,6 +35,11 @@ static func from_cache(value: Dictionary) -> Gen2WorldTileset:
 	out.tile_count = int(value.get("tile_count", Gen2Layout.TILESET_TILE_COUNT))
 	out.meta = RomCache.packed_bytes(value.get("meta", []))
 	out.collision = RomCache.packed_bytes(value.get("collision", []))
+	out.passable_tiles = RomCache.packed_bytes(value.get("passable_tiles", []))
+	out.counter_tiles = RomCache.packed_bytes(value.get("counter_tiles", []))
+	out.grass_tile = int(value.get("grass_tile", Gen1Layout.TILESET_NO_TILE))
+	out.animation = int(value.get("animation", 0))
+	out.water = bool(value.get("water", false))
 	out.animation_pointer = int(value.get("animation_pointer", 0))
 	out.palette_map_pointer = int(value.get("palette_map_pointer", 0))
 	out.palette_map = RomCache.packed_bytes(value.get("palette_map", []))
@@ -48,6 +60,12 @@ func tile_index(block: int, tile: int) -> int:
 		return 0
 	var index: int = meta[at]
 	return index if index < tile_count else 0
+
+
+## Whether a walk cell drawing this tile can be stepped on, Generation 1's
+## question where Generation 2 reads a permission byte.
+func tile_passable(tile: int) -> bool:
+	return passable_tiles.has(tile)
 
 
 func collision_index(block: int, cell_x: int, cell_y: int) -> int:

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -15,7 +15,8 @@ const REQUIRED_KEYS: Array[String] = [
 	"dex_entries", "dex_entries_bank", "moves", "move_names", "type_names",
 	"type_names_bank", "type_effects", "item_names", "item_prices", "tmhm_moves",
 	"mon_palettes", "super_palettes", "trainer_names", "evos_moves", "evos_moves_bank",
-	"cries", "font", "text_box",
+	"cries", "font", "text_box", "map_headers", "map_header_banks", "map_songs",
+	"tilesets", "water_tilesets", "tileset_collision_bank",
 ]
 
 
@@ -215,3 +216,50 @@ func test_the_text_box_carries_its_own_border_and_space() -> void:
 		"the border's column is inside TextBoxGraphics"
 	)
 	assert_between(Gen1Layout.FRAME_VERTICAL_ROW, 1, 0xFF)
+
+
+func test_the_map_and_tileset_counts_split_by_profile() -> void:
+	assert_eq(Gen1Layout.map_count(RomRegistry.RED), Gen1Layout.MAP_COUNT_RED_BLUE)
+	assert_eq(Gen1Layout.map_count(RomRegistry.BLUE), Gen1Layout.MAP_COUNT_RED_BLUE)
+	# Yellow's Summer Beach House is the extra map, and its Beach House the
+	# extra tileset.
+	assert_eq(Gen1Layout.map_count(RomRegistry.YELLOW), Gen1Layout.MAP_COUNT_RED_BLUE + 1)
+	assert_eq(Gen1Layout.tileset_count(RomRegistry.YELLOW), Gen1Layout.TILESET_COUNT_RED_BLUE + 1)
+	for id: StringName in RomRegistry.ids_of_generation(RomRegistry.GEN1):
+		assert_eq(
+			Gen1Layout.tileset_blocks(id).size(), Gen1Layout.tileset_count(id),
+			"%s pins a block count for every tileset" % id
+		)
+		for blocks: int in Gen1Layout.tileset_blocks(id):
+			assert_between(blocks, 1, 128, "%s block count" % id)
+
+
+func test_the_unused_maps_are_inside_the_table_and_in_order() -> void:
+	var sorted: Array[int] = Gen1Layout.UNUSED_MAPS.duplicate()
+	sorted.sort()
+	assert_eq(sorted, Gen1Layout.UNUSED_MAPS)
+	for map_id: int in Gen1Layout.UNUSED_MAPS:
+		assert_false(Gen1Layout.is_real_map(map_id), "$%02X is unused" % map_id)
+		assert_lt(map_id, Gen1Layout.MAP_COUNT_RED_BLUE, "$%02X is inside the table" % map_id)
+	assert_true(Gen1Layout.is_real_map(0), "Pallet Town is a real map")
+
+
+## The corner `_GetTileAndCoordsInFrontOfPlayer` reads: the bottom-left tile of
+## each 2x2 quarter of the block, which is rows 1 and 3 of the sixteen.
+func test_a_walk_cell_reads_its_bottom_left_tile() -> void:
+	assert_eq(Gen1Layout.cell_tile_index(0, 0), 4)
+	assert_eq(Gen1Layout.cell_tile_index(1, 0), 6)
+	assert_eq(Gen1Layout.cell_tile_index(0, 1), 12)
+	assert_eq(Gen1Layout.cell_tile_index(1, 1), 14)
+
+
+func test_the_object_row_widths_match_the_macro() -> void:
+	assert_eq(
+		Gen1Layout.OBJECT_TRAINER_FLAG | Gen1Layout.OBJECT_ITEM_FLAG, 0xC0,
+		"TRAINER and ITEM are the top two bits of the text byte"
+	)
+	assert_eq(Gen1Layout.TILESET_BLOCK_TILES, 16)
+	assert_eq(
+		Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT - 1, 0xFA,
+		"the last TM is item $FA"
+	)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,9 +17,10 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 286 lines of the 38030 here. The tree has no restatement left to pay for
-## them with, which three sweeps for it have now said.
-const MAX_COMMENT_LINES: int = 38030
+## are 411 lines of the 38156 here, and Generation 1's maps added 21 more to the
+## shared map, tileset, palette and preview code. The tree has no restatement
+## left to pay for them with, which three sweeps for it have now said.
+const MAX_COMMENT_LINES: int = 38156
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -1,0 +1,291 @@
+extends RefCounted
+
+## Every Generation 1 map and tileset in the cache, swept on Red, Blue and
+## Yellow. The counts come from pret's own `data/maps` and `gfx/blocksets`, and
+## the structural rules are the map macros' own assertions: a sign's text id
+## sits above the object ids, an object's inside them, and every warp and
+## connection names a map that exists.
+
+## Real maps of the flat table's 248 or 249 ids, and the tilesets behind them.
+const MAP_COUNTS: Dictionary = {&"red": 226, &"blue": 226, &"yellow": 227}
+const TILESET_COUNTS: Dictionary = {&"red": 24, &"blue": 24, &"yellow": 25}
+
+## What the corpus holds, which is what says a record's stride is right: a wrong
+## one drifts long before the last map.
+const CENSUS: Dictionary = {
+	&"red": {"warps": 813, "signs": 202, "objects": 924, "connections": 78,
+		"items": 106, "trainers": 334},
+	&"blue": {"warps": 813, "signs": 202, "objects": 924, "connections": 78,
+		"items": 106, "trainers": 334},
+	&"yellow": {"warps": 817, "signs": 204, "objects": 949, "connections": 78,
+		"items": 111, "trainers": 329},
+}
+
+## `PalletTown.asm` and `PalletTown.blk` whole, the one map pinned end to end.
+const PALLET_TOWN: int = 0
+const PALLET_BLOCKS: Array[int] = [
+	0x52, 0x4F, 0x52, 0x52, 0x4F, 0x0B, 0x50, 0x52, 0x52, 0x50,
+	0x4E, 0x01, 0x38, 0x39, 0x01, 0x01, 0x38, 0x39, 0x01, 0x4D,
+	0x4E, 0x08, 0x3C, 0x3D, 0x01, 0x08, 0x3C, 0x3D, 0x01, 0x4D,
+	0x4E, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x4D,
+	0x4E, 0x01, 0x77, 0x56, 0x01, 0x0C, 0x0D, 0x0E, 0x01, 0x4D,
+	0x4E, 0x01, 0x74, 0x74, 0x01, 0x10, 0x3A, 0x00, 0x01, 0x4D,
+	0x4E, 0x01, 0x01, 0x01, 0x01, 0x77, 0x56, 0x77, 0x31, 0x4D,
+	0x4E, 0x0A, 0x1D, 0x1E, 0x31, 0x74, 0x74, 0x0A, 0x31, 0x4D,
+	0x50, 0x0A, 0x65, 0x64, 0x61, 0x61, 0x61, 0x61, 0x61, 0x4F,
+]
+const PALLET_WIDTH: int = 10
+const PALLET_HEIGHT: int = 9
+const PALLET_BORDER: int = 0x0B
+const PALLET_MUSIC: int = 186
+## Red's house, Blue's house and Oak's lab, by destination map and warp index.
+const PALLET_WARPS: Array = [[5, 5, 37, 0], [13, 5, 39, 0], [12, 11, 40, 1]]
+const PALLET_SIGNS: Array = [[13, 13, 4], [7, 9, 5], [3, 5, 6], [11, 5, 7]]
+## Route 1 to the north and Route 21 to the south, both ten blocks wide.
+const PALLET_CONNECTIONS: Array = [["north", 12, 35], ["south", 32, 0]]
+
+## `Tilesets`' first row: `Overworld_Coll`, the grass tile and
+## TILEANIM_WATER_FLOWER. The blockset is what every town and route draws from.
+const OVERWORLD_TILESET: int = 0
+const OVERWORLD_BLOCKS: int = 128
+const OVERWORLD_GRASS: int = 0x52
+const OVERWORLD_ANIMATION: int = 2
+const OVERWORLD_PASSABLE: Array[int] = [
+	0x00, 0x10, 0x1B, 0x20, 0x21, 0x23, 0x2C, 0x2D, 0x2E, 0x30,
+	0x31, 0x33, 0x39, 0x3C, 0x3E, 0x52, 0x54, 0x58, 0x5B,
+]
+
+## The Power Plant's Voltorbs, Electrodes and Zapdos: an object with the TRAINER
+## bit and a byte below `OPP_ID_OFFSET`, which is the only shape a wild one
+## takes: six Voltorbs, two Electrodes and Zapdos. Internal indexes, not dex
+## numbers.
+const POWER_PLANT: int = 83
+const POWER_PLANT_WILD: Dictionary = {0x06: 6, 0x8D: 2, 0x4B: 1}
+
+## `SilphCoElevator_Object`'s two warps name UNUSED_MAP_ED, which has no header:
+## the elevator's own script rewrites the destination before either is taken.
+const SILPH_CO_ELEVATOR: int = 236
+
+var _r: RefCounted = null
+var _maps: Dictionary = {}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	_maps = {}
+	for map: Gen2WorldMap in _r.data.world_maps():
+		_maps[map.number] = map
+	_counts()
+	_tilesets()
+	_pallet_town()
+	_geometry()
+	_events()
+	_wild_objects()
+
+
+func _counts() -> void:
+	var wanted: int = int(MAP_COUNTS[_r.game_id])
+	if not _r.check(_maps.size() == wanted, "the cache holds %d maps, wanted %d." % [
+		_maps.size(), wanted,
+	]):
+		return
+	for map_id: int in Gen1Layout.UNUSED_MAPS:
+		_r.check(not _maps.has(map_id), "unused map $%02X decoded to a record." % map_id)
+	var census: Dictionary = {"warps": 0, "signs": 0, "objects": 0, "connections": 0,
+		"items": 0, "trainers": 0}
+	for map: Gen2WorldMap in _maps.values():
+		census["warps"] += (map.events["warps"] as Array).size()
+		census["signs"] += (map.events["bg_events"] as Array).size()
+		census["connections"] += map.connections.size()
+		for object: Dictionary in map.events["objects"] as Array:
+			census["objects"] += 1
+			census["items"] += 1 if object.has("item") else 0
+			census["trainers"] += 1 if object.has("trainer_class") else 0
+	var pinned: Dictionary = CENSUS[_r.game_id]
+	for key: String in pinned:
+		_r.check(census[key] == int(pinned[key]), "the corpus holds %d %s, pinned %d." % [
+			census[key], key, int(pinned[key]),
+		])
+	_r.note("gen1 maps %s" % census)
+
+
+func _tilesets() -> void:
+	var wanted: int = int(TILESET_COUNTS[_r.game_id])
+	if not _r.check(_r.data.world_tileset_count() == wanted,
+		"the cache holds %d tilesets, wanted %d." % [_r.data.world_tileset_count(), wanted]):
+		return
+	var blocks: Array[int] = Gen1Layout.tileset_blocks(_r.game_id)
+	for number: int in wanted:
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(number)
+		if not _r.check(tileset != null, "tileset %d is missing." % number):
+			continue
+		_r.check(tileset.block_count == blocks[number],
+			"tileset %d holds %d blocks, pinned %d." % [number, tileset.block_count, blocks[number]])
+		_r.check(
+			tileset.meta.size() == tileset.block_count * Gen1Layout.TILESET_BLOCK_TILES,
+			"tileset %d's blockset is %d bytes for %d blocks." % [
+				number, tileset.meta.size(), tileset.block_count,
+			]
+		)
+		_r.check(tileset.tile_count == Gen1Layout.TILESET_TILE_COUNT,
+			"tileset %d loads %d tiles, wanted %d." % [
+				number, tileset.tile_count, Gen1Layout.TILESET_TILE_COUNT,
+			])
+		_r.check(not tileset.passable_tiles.is_empty(),
+			"tileset %d lists no passable tile." % number)
+		_r.check(
+			_r.data.world_tileset_indices(number).size()
+			== tileset.tile_count * PokeTiles.TILE_PIXELS,
+			"tileset %d's graphics strip is the wrong size." % number
+		)
+	var overworld: Gen2WorldTileset = _r.data.world_tileset(OVERWORLD_TILESET)
+	_r.check(overworld.block_count == OVERWORLD_BLOCKS and overworld.grass_tile == OVERWORLD_GRASS
+		and overworld.animation == OVERWORLD_ANIMATION and overworld.water,
+		"the overworld tileset reads %d blocks, grass $%02X, animation %d, water %s." % [
+			overworld.block_count, overworld.grass_tile, overworld.animation, overworld.water,
+		])
+	_r.check(Array(overworld.passable_tiles) == OVERWORLD_PASSABLE,
+		"Overworld_Coll reads %s." % [Array(overworld.passable_tiles)])
+
+
+func _pallet_town() -> void:
+	var map: Gen2WorldMap = _maps.get(PALLET_TOWN, null)
+	if not _r.check(map != null, "Pallet Town is missing."):
+		return
+	_r.check(
+		map.width_blocks == PALLET_WIDTH and map.height_blocks == PALLET_HEIGHT
+		and map.tileset == OVERWORLD_TILESET and map.border_block == PALLET_BORDER
+		and map.music == PALLET_MUSIC,
+		"Pallet Town reads %dx%d, tileset %d, border $%02X, music %d." % [
+			map.width_blocks, map.height_blocks, map.tileset, map.border_block, map.music,
+		]
+	)
+	_r.check(Array(map.blocks) == PALLET_BLOCKS, "Pallet Town's blocks differ from PalletTown.blk.")
+	_r.check(_rows(map.events["warps"], ["x", "y", "map_number", "destination"]) == PALLET_WARPS,
+		"Pallet Town's warps read %s." % [_rows(map.events["warps"], ["x", "y", "map_number", "destination"])])
+	_r.check(_rows(map.events["bg_events"], ["x", "y", "text"]) == PALLET_SIGNS,
+		"Pallet Town's signs read %s." % [_rows(map.events["bg_events"], ["x", "y", "text"])])
+	_r.check(
+		_rows(map.connections, ["direction", "map_number", "y_alignment"]) == PALLET_CONNECTIONS,
+		"Pallet Town's connections read %s." % [
+			_rows(map.connections, ["direction", "map_number", "y_alignment"]),
+		]
+	)
+
+
+static func _rows(events: Array, fields: Array) -> Array:
+	var out: Array = []
+	for event: Dictionary in events:
+		var row: Array = []
+		for field: String in fields:
+			row.append(event[field])
+		out.append(row)
+	return out
+
+
+## Every map's own shape, and that a player has somewhere to stand on it.
+func _geometry() -> void:
+	for map: Gen2WorldMap in _maps.values():
+		var cells: int = map.width_blocks * map.height_blocks * 4
+		if not _r.check(
+			map.blocks.size() == map.width_blocks * map.height_blocks
+			and map.collision.size() == cells,
+			"map %d is %dx%d blocks with %d blocks and %d cells." % [
+				map.number, map.width_blocks, map.height_blocks,
+				map.blocks.size(), map.collision.size(),
+			]
+		):
+			continue
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+		if not _r.check(tileset != null, "map %d names tileset %d." % [map.number, map.tileset]):
+			continue
+		var walkable: int = 0
+		for code: int in map.collision:
+			walkable += 1 if tileset.tile_passable(code) else 0
+		_r.check(walkable > 0, "map %d has no cell a player can stand on." % map.number)
+
+
+## The map macros' own assertions, plus the tables an event points into.
+func _events() -> void:
+	for map: Gen2WorldMap in _maps.values():
+		var objects: Array = map.events["objects"]
+		for warp: Dictionary in map.events["warps"] as Array:
+			var destination: int = int(warp["map_number"])
+			if destination == Gen1Layout.WARP_TO_LAST_MAP:
+				continue
+			if map.number == SILPH_CO_ELEVATOR:
+				_r.check(not Gen1Layout.is_real_map(destination),
+					"the Silph Co elevator now warps to map %d." % destination)
+				continue
+			var target: Gen2WorldMap = _maps.get(destination, null)
+			if not _r.check(target != null, "map %d warps to map %d, which has no header." % [
+				map.number, destination,
+			]):
+				continue
+			_r.check(int(warp["destination"]) < (target.events["warps"] as Array).size(),
+				"map %d warps to map %d's warp %d, which it does not have." % [
+					map.number, destination, int(warp["destination"]),
+				])
+		for connection: Dictionary in map.connections:
+			var neighbour: Gen2WorldMap = _maps.get(int(connection["map_number"]), null)
+			if not _r.check(neighbour != null, "map %d connects %s to map %d, which has no header." % [
+				map.number, connection["direction"], int(connection["map_number"]),
+			]):
+				continue
+			_r.check(int(connection["target_width_blocks"]) == neighbour.width_blocks,
+				"map %d's %s connection calls map %d %d blocks wide, and it is %d." % [
+					map.number, connection["direction"], neighbour.number,
+					int(connection["target_width_blocks"]), neighbour.width_blocks,
+				])
+		for board: Dictionary in map.events["bg_events"] as Array:
+			_r.check(int(board["text"]) > objects.size(),
+				"map %d has a sign with text id %d over %d objects." % [
+					map.number, int(board["text"]), objects.size(),
+				])
+		for object: Dictionary in objects:
+			_object(map, object, objects.size())
+
+
+func _object(map: Gen2WorldMap, object: Dictionary, object_count: int) -> void:
+	var text: int = int(object["text"])
+	_r.check(text >= 1 and text <= object_count,
+		"map %d has an object with text id %d over %d objects." % [map.number, text, object_count])
+	if object.has("trainer_class"):
+		var trainer_class: int = int(object["trainer_class"])
+		_r.check(trainer_class >= 1 and trainer_class <= _r.data.trainer_count(),
+			"map %d has a trainer of class %d." % [map.number, trainer_class])
+	if object.has("species"):
+		var species: int = int(object["species"])
+		_r.check(species >= 1 and species <= Gen1Layout.INDEX_COUNT,
+			"map %d has a wild object of species index %d." % [map.number, species])
+	if object.has("item"):
+		_r.check(_is_item(int(object["item"])),
+			"map %d has an item ball holding item %d." % [map.number, int(object["item"])])
+
+
+## An item id an item ball can hold: a named item, or one of the machines above
+## them. Blue's house carries two zeroes, which the cartridge never reads: both
+## objects are people whose event only sets the ITEM bit.
+static func _is_item(item: int) -> bool:
+	if item == 0:
+		return true
+	if item <= Gen1Layout.ITEM_COUNT:
+		return true
+	return item >= Gen1Layout.HM_FIRST_ITEM \
+		and item < Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT
+
+
+func _wild_objects() -> void:
+	var map: Gen2WorldMap = _maps.get(POWER_PLANT, null)
+	if not _r.check(map != null, "the Power Plant is missing."):
+		return
+	var species: Dictionary = {}
+	for object: Dictionary in map.events["objects"] as Array:
+		if object.has("species"):
+			species[int(object["species"])] = int(species.get(int(object["species"]), 0)) + 1
+	_r.check(species == POWER_PLANT_WILD,
+		"the Power Plant's standing wild objects read %s." % [species])

--- a/tools/checks/gen1_maps.gd.uid
+++ b/tools/checks/gen1_maps.gd.uid
@@ -1,0 +1,1 @@
+uid://datjrn33bguuy

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -6,46 +6,67 @@ extends SceneTree
 ## permission come from the same two sources the runtime reads, so a wall drawn
 ## without a red square is a real disagreement rather than a rendering offset.
 ## Objects are not drawn: this is the map's own answer.
+
+## Generation 1 is named by one flat map id and draws in the four Game Boy greys,
+## its colours being a Super Game Boy packet built from that id.
 ##   Godot --headless --path . -s res://tools/preview_collision.gd -- crystal 26 2 /tmp/route31.png
+##   Godot --headless --path . -s res://tools/preview_collision.gd -- red 0 /tmp/pallet.png
 
 const SCALE: int = 3
 const WALL_TINT: Color = Color(1.0, 0.0, 0.0, 0.75)
 const WATER_TINT: Color = Color(0.1, 0.3, 1.0, 0.35)
+const CELL_PIXELS: int = Gen2Layout.MAP_BLOCK_CELL_WIDTH * PokeTiles.TILE_WIDTH
+## The checker square, so the art underneath stays readable.
+const CHECKER: int = 4
 
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
-	if args.size() < 4:
-		push_error("Usage: -s tools/preview_collision.gd -- <game> <group> <number> <output.png>")
+	if args.size() < 3:
+		push_error("Usage: -s tools/preview_collision.gd -- <game> [group] <number> <output.png>")
 		quit(1)
 		return
-	if PokeToolPath.refuses(args[3]):
+	var out_path: String = args[args.size() - 1]
+	if PokeToolPath.refuses(out_path):
 		quit(2)
 		return
 	var data: GameData = GameData.open(StringName(args[0]))
 	if data == null:
-		push_error("No cache for %s. Import roms/%s.gbc first." % [args[0], args[0]])
+		push_error("No cache for %s. Import roms/%s first." % [args[0], args[0]])
 		quit(1)
 		return
-	var group: int = int(args[1])
-	var number: int = int(args[2])
-	var world: Gen2WorldAPI = Gen2WorldAPI.open(data, group, number, Vector2i.ZERO)
-	if world == null:
+	# A three-argument call is Generation 1's group 0.
+	var group: int = int(args[1]) if args.size() > 3 else 0
+	var number: int = int(args[args.size() - 2])
+
+	var map: Gen2WorldMap = data.world_map(group, number)
+	var tileset: Gen2WorldTileset = data.world_tileset(map.tileset) if map != null else null
+	if map == null or tileset == null:
 		push_error("No map %d/%d in %s." % [group, number, args[0]])
 		quit(1)
 		return
 
-	var map: Gen2WorldMap = world.current_map
-	var tileset: Gen2WorldTileset = world.current_tileset
+	var image: Image = _draw_map(data, map, tileset)
+	_tint_permissions(image, map, tileset, data.generation)
+	image.resize(image.get_width() * SCALE, image.get_height() * SCALE, Image.INTERPOLATE_NEAREST)
+	if image.save_png(out_path) != OK:
+		push_error("Could not write %s" % out_path)
+		quit(1)
+		return
+	print("%s map %d/%d: %d by %d cells." % [
+		args[0], group, number, map.collision_width, map.collision_height,
+	])
+	quit(0)
+
+
+func _draw_map(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Image:
 	var indices: PackedByteArray = data.map_tile_indices(map, tileset)
-	var palettes: Array = Gen2WorldPalette.tile_palettes(
-		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1
-	)
+	var palettes: Array = _tile_palettes(data, map, tileset)
 	var strip_width: int = tileset.tile_count * PokeTiles.TILE_WIDTH
 	var image := Image.create(
-		map.collision_width * 16, map.collision_height * 16, false, Image.FORMAT_RGBA8
+		map.collision_width * CELL_PIXELS, map.collision_height * CELL_PIXELS,
+		false, Image.FORMAT_RGBA8
 	)
-
 	for tile_y: int in map.height_blocks * Gen2Layout.MAP_BLOCK_TILE_WIDTH:
 		for tile_x: int in map.width_blocks * Gen2Layout.MAP_BLOCK_TILE_WIDTH:
 			@warning_ignore("integer_division")
@@ -53,42 +74,65 @@ func _initialize() -> void:
 				tile_x / Gen2Layout.MAP_BLOCK_TILE_WIDTH, tile_y / Gen2Layout.MAP_BLOCK_TILE_WIDTH
 			)
 			var tile: int = tileset.tile_index(
-				block, (tile_y % 4) * Gen2Layout.MAP_BLOCK_TILE_WIDTH + (tile_x % 4)
+				block,
+				(tile_y % Gen2Layout.MAP_BLOCK_TILE_WIDTH) * Gen2Layout.MAP_BLOCK_TILE_WIDTH
+				+ (tile_x % Gen2Layout.MAP_BLOCK_TILE_WIDTH)
 			)
 			var palette: PackedColorArray = palettes[tile] if tile < palettes.size() \
 				else PackedColorArray()
 			for y: int in PokeTiles.TILE_HEIGHT:
 				for x: int in PokeTiles.TILE_WIDTH:
-					var index: int = int(indices[y * strip_width + tile * 8 + x])
+					var index: int = int(
+						indices[y * strip_width + tile * PokeTiles.TILE_WIDTH + x]
+					)
 					image.set_pixel(
-						tile_x * 8 + x, tile_y * 8 + y,
+						tile_x * PokeTiles.TILE_WIDTH + x, tile_y * PokeTiles.TILE_HEIGHT + y,
 						palette[index] if index < palette.size() else Color.MAGENTA
 					)
+	return image
 
+
+## One palette per tile of the strip; Generation 1 assigns none, so all four
+## greys.
+func _tile_palettes(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
+	if data.generation == RomRegistry.GEN1:
+		var greys: PackedColorArray = PokePalette.monochrome()
+		var out: Array = []
+		out.resize(tileset.tile_count)
+		out.fill(greys)
+		return out
+	return Gen2WorldPalette.tile_palettes(
+		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1
+	)
+
+
+func _tint_permissions(
+	image: Image, map: Gen2WorldMap, tileset: Gen2WorldTileset, generation: int
+) -> void:
 	for cell_y: int in map.collision_height:
 		for cell_x: int in map.collision_width:
-			var permission: int = world.collision_permission_at(Vector2i(cell_x, cell_y))
-			var tint := Color(0, 0, 0, 0)
-			if permission == Gen2WorldCollision.WALL_TILE:
-				tint = WALL_TINT
-			elif permission == Gen2WorldCollision.WATER_TILE:
-				tint = WATER_TINT
+			var code: int = map.collision_at(cell_x, cell_y)
+			var tint: Color = _tint_for(code, tileset, generation)
 			if tint.a == 0.0:
 				continue
-			for y: int in 16:
-				for x: int in 16:
-					# A four-pixel checker, so the art underneath stays readable.
-					if ((x >> 2) + (y >> 2)) % 2 != 0:
+			for y: int in CELL_PIXELS:
+				for x: int in CELL_PIXELS:
+					if ((x / CHECKER) + (y / CHECKER)) % 2 != 0:
 						continue
-					var at := Vector2i(cell_x * 16 + x, cell_y * 16 + y)
+					var at := Vector2i(cell_x * CELL_PIXELS + x, cell_y * CELL_PIXELS + y)
 					image.set_pixel(at.x, at.y, image.get_pixel(at.x, at.y).lerp(tint, tint.a))
 
-	image.resize(image.get_width() * SCALE, image.get_height() * SCALE, Image.INTERPOLATE_NEAREST)
-	if image.save_png(args[3]) != OK:
-		push_error("Could not write %s" % args[3])
-		quit(1)
-		return
-	print("%s map %d/%d: %d by %d cells." % [
-		args[0], group, number, map.collision_width, map.collision_height,
-	])
-	quit(0)
+
+## `_IsTilePassable` walks the tileset's list and `IsNextTileShoreOrWater` calls
+## one tile water on a tileset that has any.
+func _tint_for(code: int, tileset: Gen2WorldTileset, generation: int) -> Color:
+	if generation == RomRegistry.GEN1:
+		if tileset.water and code == Gen1Layout.WATER_TILE:
+			return WATER_TINT
+		return Color(0, 0, 0, 0) if tileset.tile_passable(code) else WALL_TINT
+	var permission: int = Gen2WorldCollision.permission_for(code)
+	if permission == Gen2WorldCollision.WALL_TILE:
+		return WALL_TINT
+	if permission == Gen2WorldCollision.WATER_TILE:
+		return WATER_TINT
+	return Color(0, 0, 0, 0)

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -120,9 +120,7 @@ func _render_sheet(directory: String, sheet: Dictionary, name: String) -> Image:
 
 	return Gen2PicImage.from_indices(
 		folded, width, rows * PokeTiles.TILE_HEIGHT,
-		PokePalette.pic_palette(PackedColorArray([
-			Color(0.66, 0.66, 0.66), Color(0.33, 0.33, 0.33),
-		]))
+		PokePalette.monochrome()
 	)
 
 
@@ -191,9 +189,7 @@ static func _palette_of(packed: Variant) -> PackedColorArray:
 			out.append(PokePalette.from_packed(int(value)))
 		return out
 	if colors.size() < 2:
-		return PokePalette.pic_palette(PackedColorArray([
-			Color(0.66, 0.66, 0.66), Color(0.33, 0.33, 0.33),
-		]))
+		return PokePalette.monochrome()
 	return PokePalette.pic_palette(PackedColorArray([
 		PokePalette.from_packed(int(colors[0])),
 		PokePalette.from_packed(int(colors[1])),

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,7 +44,7 @@ const GROUPS: Dictionary = {
 		&"battle_tower", &"npc_trade",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
-	&"gen1": [&"gen1_tables", &"gen1_pics"],
+	&"gen1": [&"gen1_tables", &"gen1_pics", &"gen1_maps"],
 }
 
 


### PR DESCRIPTION
`Gen1WorldImporter` decodes every map header, block map, connection, warp, sign and object of Red, Blue and Yellow into the shared world sections of the cache, with the 24 or 25 tilesets behind them: blocksets, the 96 tiles `LoadTilesetTilePatternData` copies to VRAM, and the passable-tile list `_IsTilePassable` walks.

| Cartridge | Maps | Tilesets | Warps | Signs | Objects | Connections |
|---|---|---|---|---|---|---|
| Red | 226 | 24 | 813 | 202 | 924 | 78 |
| Blue | 226 | 24 | 813 | 202 | 924 | 78 |
| Yellow | 227 | 25 | 817 | 204 | 949 | 78 |

A map is named by one flat id, so its record's group is 0 and its number is that id. Its collision grid holds the tile the cell draws rather than a permission byte, which `Gen2WorldTileset.tile_passable` answers for. The 22 ids `map_header_pointers.asm` marks UNUSED have no header of their own and get no record.

The tile that decides a walk cell is the bottom-left of its quarter of the block, the corner Generation 2 also picks. Taking the top-left leaves 53 of Red's 226 maps with no cell a player can stand on, and 504 of 813 warp cells draw a tile from their tileset's own warp or door list against 411, 286 and 178 for the other three corners.

A blockset's length is the one thing no cartridge byte records, so the counts are pinned from the pinned checkouts' `.bst` files and bracketed at import from both sides: below by the blocks the maps really use, above by where the next tileset's graphics start in the same bank.

`tools/preview_collision.gd` draws either generation now, from the cache rather than through `Gen2WorldAPI`, and takes a flat map id for Generation 1. `tools/checks/gen1_maps.gd` sweeps all three cartridges: the counts, Pallet Town end to end, every warp and connection resolving, the map macros' own text-id assertions, and every map having a cell a player can stand on.

Fixed on the way: a connection or event record kept only the fields the reader listed, so a Generation 1 sign's text id arrived as a float; a field the record does not carry now stays absent instead of defaulting to zero.

The cache format moves to 104. All six cartridges re-import and report `layout: Layout verified.`

Green: 4295 tests over 171 scripts, `tools/validate.gd -- all` across 87 topics, `replay_world.gd` 33 routes with 0 failures, the three-profile story walk, 0 analyser warnings over 626 scripts, and the release gates.