### PR TITLE
Import the Generation 1 map colour, overworld sprites and wild encounters

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -662,6 +662,17 @@ func world_fishing_group(group: int) -> Dictionary:
 	)
 
 
+## Generation 1's `SuperRodData` index: the one-based fishing group a map is
+## named by, or zero for a map no row names, which is `ReadSuperRodData`'s own
+## "no fish on this map". [method world_fishing_group] reads the group itself.
+func world_fishing_map(map_number: int) -> int:
+	var fishing: Variant = _encounters().get("fishing", {})
+	if not fishing is Dictionary:
+		return 0
+	var maps: Variant = (fishing as Dictionary).get("maps", {})
+	return int((maps as Dictionary).get(str(map_number), 0)) if maps is Dictionary else 0
+
+
 ## The twenty-two day/night fishing substitutions used by entries whose
 ## species byte is zero in the cartridge stream.
 func world_fishing_time_groups() -> Array:

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -88,6 +88,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_dex_entries,
 	_verify_trainer_names,
 	_verify_palettes,
+	_verify_wild_constants,
 	_verify_pic_pointers,
 	_verify_font,
 	_verify_text_box,
@@ -245,6 +246,28 @@ static func _verify_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
 		colors.append(rom.u16le(at + slot * PokePalette.COLOR_BYTES))
 	if colors != FIRST_PALETTE_COLORS.get(rom.id, []):
 		return _fail("PAL_GREENMON reads %s." % str(colors))
+	return _ok()
+
+
+## The two wild tables this port keeps as constants rather than importing:
+## `WildMonEncounterSlotChances`, whose second column is the slot it already is,
+## and `GoodRodMons`. Neither is per-map, and reading them back is what says the
+## constants still describe the cartridge.
+static func _verify_wild_constants(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout["wild_chances"])
+	for slot: int in Gen1Layout.WILD_SLOT_CHANCES.size():
+		var row: int = at + slot * Gen1Layout.WILD_CHANCE_SIZE
+		if rom.u8(row) != Gen1Layout.WILD_SLOT_CHANCES[slot] or rom.u8(row + 1) != slot * 2:
+			return _fail("Wild slot %d wins on %d, not %d." % [
+				slot, rom.u8(row), Gen1Layout.WILD_SLOT_CHANCES[slot],
+			])
+	at = int(layout["good_rod"])
+	for slot: int in Gen1Layout.GOOD_ROD_SLOTS.size():
+		var row: Array = Gen1Layout.GOOD_ROD_SLOTS[slot]
+		if rom.u8(at + slot * 2) != int(row[0]) or rom.u8(at + slot * 2 + 1) != int(row[1]):
+			return _fail("GoodRodMons row %d reads level %d, index %d." % [
+				slot, rom.u8(at + slot * 2), rom.u8(at + slot * 2 + 1),
+			])
 	return _ok()
 
 
@@ -461,6 +484,8 @@ func import_rom(
 		"learnset_moves": 0,
 		"maps": 0,
 		"tilesets": 0,
+		"sprites": 0,
+		"encounters": 0,
 		"elapsed_ms": 0,
 	}
 
@@ -535,6 +560,8 @@ func import_rom(
 		"trainer_count": trainers.size(),
 		"map_count": int(world["maps"]),
 		"tileset_count": int(world["tilesets"]),
+		"overworld_sprite_count": int(world["sprites"]),
+		"encounter_count": int(world["encounters"]),
 		"atlases": pics,
 		"tiles": tiles,
 		"complete": true,
@@ -554,13 +581,17 @@ func import_rom(
 	result["learnset_moves"] = _count_of(species, "learnset")
 	result["maps"] = int(world["maps"])
 	result["tilesets"] = int(world["tilesets"])
+	result["sprites"] = int(world["sprites"])
+	result["encounters"] = int(world["encounters"])
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
 	result["message"] = ("%d species, %d moves, %d items, %d type matchups, "
-		+ "%d trainer classes, %d evolutions, %d level-up moves, %d maps and "
-		+ "%d tilesets in %d ms.") % [
+		+ "%d trainer classes, %d evolutions, %d level-up moves, %d maps, "
+		+ "%d tilesets, %d overworld sprites and %d wild encounter tables "
+		+ "in %d ms.") % [
 		species.size(), moves.size(), items.size(), matchups.size(), trainers.size(),
 		result["evolutions"], result["learnset_moves"], result["maps"],
-		result["tilesets"], result["elapsed_ms"],
+		result["tilesets"], result["sprites"], result["encounters"],
+		result["elapsed_ms"],
 	]
 	return result
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -89,6 +89,18 @@ const POINTER_SIZE: int = 2
 ## colours of each, and a DMG reads neither and shows four greys.
 const SUPER_PALETTE_COLORS: int = 4
 const SUPER_PALETTE_BYTES: int = SUPER_PALETTE_COLORS * PokePalette.COLOR_BYTES
+## `NUM_SGB_PALS`: Yellow put Pikachu's Beach's three behind `PAL_GAMEFREAK` and
+## recoloured every row above them.
+const SUPER_PALETTE_COUNT_RED_BLUE: int = 37
+const SUPER_PALETTE_COUNT_YELLOW: int = 40
+const PAL_ROUTE: int = 0x00
+const PAL_PALLET: int = 0x01
+const PAL_GRAYMON: int = 0x19
+const PAL_CAVE: int = 0x23
+
+## `GBPalNormal`'s `rOBP0`, %11010000: an object's colours 1, 2 and 3 take
+## shades 0, 1 and 3, so a sprite never shows the palette's third colour.
+const OBJECT_SHADES: Array[int] = [0, 0, 1, 3]
 
 ## Evolutions by method until a zero byte, then (level, move) pairs until
 ## another; `EVOLVE_ITEM` is the only four-byte row.
@@ -190,6 +202,16 @@ const MAX_OBJECT_EVENTS: int = 16
 ## `warp_event`'s indoor exit: `wLastMap`, the outdoor map the player came from.
 const WARP_TO_LAST_MAP: int = 0xFF
 
+## The map ids `SetPal_Overworld` splits on; only the link rooms are Yellow's.
+const NUM_CITY_MAPS: int = 0x0B
+const FIRST_INDOOR_MAP: int = 0x25
+const CERULEAN_CAVE_2F: int = 0xE2
+const CERULEAN_CAVE_1F: int = 0xE4
+const TRADE_CENTER: int = 0xEF
+const COLOSSEUM: int = 0xF0
+const LORELEIS_ROOM: int = 0xF5
+const BRUNOS_ROOM: int = 0xF6
+
 ## The `tileset` macro: the bank holding both graphics and blocks, the three
 ## pointers, three counter tiles, the grass tile and the animation kind, with
 ## $FF for "none" in all four tile columns.
@@ -223,6 +245,37 @@ const TILESET_BLOCKS_YELLOW: Array[int] = [
 const TILESET_LIST_END: int = 0xFF
 const WATER_TILE: int = 0x14
 
+## The two tilesets `SetPal_Overworld` tests before it looks at the map id.
+const TILESET_CEMETERY: int = 15
+const TILESET_CAVERN: int = 17
+
+## `WildDataPointers`, one `dw` a map id and $FFFF behind the last. A block is
+## its rate byte alone when the rate is zero and `WILDDATA_LENGTH` otherwise,
+## ten (level, species) pairs behind it; grass first, water in the same shape.
+const WILD_SLOT_COUNT: int = 10
+const WILD_DATA_LENGTH: int = 1 + WILD_SLOT_COUNT * 2
+const WILD_POINTERS_END: int = 0xFFFF
+
+## `WildMonEncounterSlotChances`, as the cumulative byte each slot wins on; its
+## second column is the slot doubled, and the ten sum to 256.
+const WILD_CHANCE_SIZE: int = 2
+const WILD_SLOT_CHANCES: Array[int] = [50, 101, 140, 165, 190, 215, 228, 241, 252, 255]
+
+## `GoodRodMons`. The Old Rod has no table: `ItemUseOldRod` carries its one pair
+## as `lb bc, 5, MAGIKARP`, and neither rod reads the map.
+const GOOD_ROD_SLOTS: Array = [[10, 0x9D], [10, 0x47]]
+
+## `SuperRodData`, a map id and a pointer to `count` (level, species) rows that
+## `ReadSuperRodData` picks between by rejecting a two-bit roll. Yellow's
+## `SuperRodFishingSlots` is one row a map, four (species, level) pairs picked by
+## a byte threshold. Both end on $FF where a map id would be.
+const SUPER_ROD_ROW_SIZE: int = 3
+const SUPER_ROD_ROW_SIZE_YELLOW: int = 9
+const SUPER_ROD_SLOTS_YELLOW: int = 4
+const SUPER_ROD_THRESHOLDS_YELLOW: Array[int] = [0x65, 0xB1, 0xE4, 0xFF]
+const SUPER_ROD_MAX_SLOTS: int = 4
+const ROD_LIST_END: int = 0xFF
+
 ## A walk cell's collision tile is the bottom-left of its 2x2 quarter of the
 ## block, the corner Generation 2 also picks. `_GetTileAndCoordsInFrontOfPlayer`
 ## reads (8, 11), (8, 7), (6, 9) and (10, 9) and the player's cell starts at
@@ -230,6 +283,18 @@ const WATER_TILE: int = 0x14
 ## cell a player can stand on, the Pokemon Centers among them.
 const MAP_BLOCK_TILE_WIDTH: int = 4
 const MAP_BLOCK_CELL_WIDTH: int = 2
+
+## `SpriteSheetPointerTable`: a CPU address, the bytes of one half and the bank,
+## with a picture id one past the row. `LoadMapSpriteTilePatterns` reads a row
+## below `FIRST_STILL_SPRITE` twice, the second time $C0 further on, which is the
+## `$80` the walking rows of `SpriteFacingAndAnimationTable` add.
+const SPRITE_RECORD_SIZE: int = 4
+const SPRITE_COUNT_RED_BLUE: int = 72
+const SPRITE_COUNT_YELLOW: int = 82
+const SPRITE_STILL_FIRST_RED_BLUE: int = 0x3D
+const SPRITE_STILL_FIRST_YELLOW: int = 0x47
+const SPRITE_WALKING_TILES: int = 12
+const SPRITE_STILL_TILES: int = 4
 
 ## `NUM_TRAINERS`, the trainer classes rather than the individual trainers.
 const TRAINER_CLASS_COUNT: int = 47
@@ -284,6 +349,11 @@ const RED_BLUE: Dictionary = {
 	"map_songs": 0x0C04D,
 	"tilesets": 0x0C7BE,
 	"water_tilesets": 0x0E8E0,
+	"overworld_sprites": 0x17B27,
+	"wild_data": 0x0CEEB,
+	"wild_chances": 0x13918,
+	"good_rod": 0x0E27F,
+	"super_rod": 0x0E919,
 	## `_IsTilePassable` and the lists it walks share a bank, and the pointer in
 	## a tileset row names no bank of its own. Red and Blue keep both in home.
 	"tileset_collision_bank": 0x00,
@@ -323,6 +393,12 @@ const YELLOW: Dictionary = {
 	"map_songs": 0xFC000,
 	"tilesets": 0x0C558,
 	"water_tilesets": 0x0E834,
+	"overworld_sprites": 0x142A9,
+	"wild_data": 0x0CB95,
+	"wild_chances": 0x138E2,
+	"good_rod": 0x0E12C,
+	## Yellow's is a flat slot table rather than an index into groups.
+	"super_rod": 0xF5EDA,
 	"tileset_collision_bank": 0x01,
 }
 
@@ -402,6 +478,36 @@ static func super_palette_offset(layout: Dictionary, palette: int) -> int:
 	return int(layout["super_palettes"]) + palette * SUPER_PALETTE_BYTES
 
 
+## `SetPal_Overworld`: the `SuperPalettes` row a map's four colours come from.
+## The two tilesets answer before the map id is read at all. A city's row is its
+## map id plus one and every route shares [constant PAL_ROUTE]; an indoor map no
+## branch names takes `wLastMap`'s, which is [param last_map].
+static func overworld_palette(
+	id: StringName, map_id: int, tileset: int, last_map: int = -1
+) -> int:
+	if tileset == TILESET_CEMETERY:
+		return PAL_GRAYMON
+	if tileset == TILESET_CAVERN:
+		return PAL_CAVE
+	if map_id < FIRST_INDOOR_MAP:
+		return _town_palette(map_id)
+	if map_id >= CERULEAN_CAVE_2F and map_id <= CERULEAN_CAVE_1F:
+		return PAL_CAVE
+	if map_id == BRUNOS_ROOM:
+		return PAL_CAVE
+	if map_id == LORELEIS_ROOM:
+		return PAL_PALLET
+	if id == RomRegistry.YELLOW and (map_id == TRADE_CENTER or map_id == COLOSSEUM):
+		return PAL_GRAYMON
+	return _town_palette(last_map)
+
+
+## `.townOrRoute` and the `inc a` behind it: every id past the last city answers
+## [constant PAL_ROUTE], the routine's own `ld a, PAL_ROUTE - 1`.
+static func _town_palette(map_id: int) -> int:
+	return map_id + 1 if map_id >= 0 and map_id < NUM_CITY_MAPS else PAL_ROUTE
+
+
 ## Resolves one row of a near-pointer table whose bank the layout records.
 static func pointer_target(rom: RomFile, layout: Dictionary, key: String, row: int) -> int:
 	var table: int = int(layout[key])
@@ -433,6 +539,26 @@ static func tileset_count(id: StringName) -> int:
 	return TILESET_COUNT_YELLOW if id == RomRegistry.YELLOW else TILESET_COUNT_RED_BLUE
 
 
+## `NUM_SPRITES`. Yellow added ten walking sprites in front of the still ones.
+static func sprite_count(id: StringName) -> int:
+	return SPRITE_COUNT_YELLOW if id == RomRegistry.YELLOW else SPRITE_COUNT_RED_BLUE
+
+
+static func super_palette_count(id: StringName) -> int:
+	return SUPER_PALETTE_COUNT_YELLOW if id == RomRegistry.YELLOW \
+		else SUPER_PALETTE_COUNT_RED_BLUE
+
+
+## `FIRST_STILL_SPRITE`, the picture id from which a sheet is four tiles.
+static func first_still_sprite(id: StringName) -> int:
+	return SPRITE_STILL_FIRST_YELLOW if id == RomRegistry.YELLOW \
+		else SPRITE_STILL_FIRST_RED_BLUE
+
+
+static func sprite_offset(layout: Dictionary, number: int) -> int:
+	return int(layout["overworld_sprites"]) + (number - 1) * SPRITE_RECORD_SIZE
+
+
 ## Blocks per tileset, in `Tilesets` order.
 static func tileset_blocks(id: StringName) -> Array[int]:
 	return TILESET_BLOCKS_YELLOW if id == RomRegistry.YELLOW else TILESET_BLOCKS_RED_BLUE
@@ -462,6 +588,11 @@ static func tileset_offset(layout: Dictionary, number: int) -> int:
 
 static func map_song_offset(layout: Dictionary, map_id: int) -> int:
 	return int(layout["map_songs"]) + map_id * MAP_SONG_SIZE
+
+
+## Whether the Super Rod is read as Yellow's flat slot table.
+static func flat_super_rod(id: StringName) -> bool:
+	return id == RomRegistry.YELLOW
 
 
 ## Which of a block's sixteen tiles decides one walk cell.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1,11 +1,11 @@
 class_name Gen1WorldImporter
 extends RefCounted
 
-## Decodes every Generation 1 map and tileset into the shared world sections of
-## the cache, the counterpart of [Gen2WorldImporter]. A map is named by one flat
-## id, so a record's group is zero and its number is that id. A script is machine
-## code here rather than an interpreted command stream, so the header's script
-## and text pointers are kept as addresses and nothing follows them.
+## Decodes every Generation 1 map, tileset, SGB palette, overworld sprite and
+## wild encounter table into the shared world sections of the cache, the
+## counterpart of [Gen2WorldImporter]. A map is named by one flat id, so a
+## record's group is zero and its number is that id. A script is machine code
+## here, so the header's script and text pointers are kept as addresses.
 
 const LIST_END: int = Gen1Layout.TILESET_LIST_END
 
@@ -25,19 +25,35 @@ static func import_to_cache(
 		return result
 
 	var tilesets: Array = result["tilesets"]
-	if not RomCache.write_json(RomCache.world_maps_path(directory), result["maps"]):
-		return _error("Could not write overworld map data.")
-	if not RomCache.write_json(RomCache.world_tilesets_path(directory), tilesets):
-		return _error("Could not write overworld tileset data.")
+	var sprites: Array = result["sprites"]
+	var sections: Dictionary = {
+		RomCache.world_maps_path(directory): result["maps"],
+		RomCache.world_tilesets_path(directory): tilesets,
+		RomCache.world_palettes_path(directory): result["palettes"],
+		RomCache.overworld_sprites_path(directory): sprites,
+		RomCache.world_encounters_path(directory): result["encounters"],
+	}
+	for path: String in sections:
+		if not RomCache.write_json(path, sections[path]):
+			return _error("Could not write %s." % path.get_file())
 	var graphics: Dictionary = result["graphics"]
 	for number: int in graphics:
 		if not RomCache.write_indices(RomCache.world_tile_path(directory, number), graphics[number]):
 			return _error("Could not write overworld tileset %d." % number)
+	var sheets: Dictionary = result["sprite_graphics"]
+	for number: int in sheets:
+		if not RomCache.write_indices(
+			RomCache.overworld_sprite_path(directory, number), sheets[number]
+		):
+			return _error("Could not write overworld sprite %d." % number)
 
 	return {
 		"ok": true,
 		"maps": (result["maps"] as Array).size(),
 		"tilesets": tilesets.size(),
+		"sprites": sprites.size(),
+		"encounters": (result["encounters"]["grass"] as Dictionary).size()
+			+ (result["encounters"]["water"] as Dictionary).size(),
 	}
 
 
@@ -47,6 +63,15 @@ static func read_world(
 ) -> Dictionary:
 	if layout.is_empty():
 		return _error("No layout for %s." % rom.id)
+	var palettes: Dictionary = _read_palettes(rom, layout)
+	if not bool(palettes["ok"]):
+		return palettes
+	var sprites: Dictionary = _read_sprites(rom, layout)
+	if not bool(sprites["ok"]):
+		return sprites
+	var encounters: Dictionary = _read_encounters(rom, layout)
+	if not bool(encounters["ok"]):
+		return encounters
 	var water: PackedByteArray = _read_list(rom, int(layout["water_tilesets"]))
 	var tilesets: Array = []
 	var graphics: Dictionary = {}
@@ -77,7 +102,16 @@ static func read_world(
 		if on_progress.is_valid():
 			on_progress.call("maps", maps.size(), map_count - Gen1Layout.UNUSED_MAPS.size())
 
-	return {"ok": true, "maps": maps, "tilesets": tilesets, "graphics": graphics}
+	return {
+		"ok": true,
+		"maps": maps,
+		"tilesets": tilesets,
+		"graphics": graphics,
+		"palettes": palettes["palettes"],
+		"sprites": sprites["sprites"],
+		"sprite_graphics": sprites["graphics"],
+		"encounters": encounters["encounters"],
+	}
 
 
 static func _error(message: String) -> Dictionary:
@@ -91,6 +125,180 @@ static func _read_list(rom: RomFile, at: int, limit: int = 256) -> PackedByteArr
 		out.append(rom.u8(at))
 		at += 1
 	return out
+
+
+## `WildDataPointers` and the rod tables behind it. Grass and water take the
+## shared sections' shape under group zero; fishing keeps the Super Rod's index.
+static func _read_encounters(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var table: int = int(layout["wild_data"])
+	var count: int = Gen1Layout.map_count(rom.id)
+	if rom.u16le(table + count * Gen1Layout.POINTER_SIZE) != Gen1Layout.WILD_POINTERS_END:
+		return _error("WildDataPointers does not end behind map %d." % (count - 1))
+	var bank: int = RomFile.bank_of(table)
+	var grass: Dictionary = {}
+	var water: Dictionary = {}
+	for map_id: int in count:
+		var at: int = RomFile.linear(
+			bank, rom.u16le(table + map_id * Gen1Layout.POINTER_SIZE)
+		)
+		var block: Dictionary = _read_wild_block(rom, at, map_id)
+		if not bool(block["ok"]):
+			return block
+		if not (block["row"] as Dictionary).is_empty():
+			grass["0:%d" % map_id] = block["row"]
+		block = _read_wild_block(rom, int(block["at"]), map_id)
+		if not bool(block["ok"]):
+			return block
+		if not (block["row"] as Dictionary).is_empty():
+			water["0:%d" % map_id] = block["row"]
+
+	var fishing: Dictionary = _read_super_rod(rom, layout)
+	if not bool(fishing["ok"]):
+		return fishing
+	return {"ok": true, "encounters": {
+		"grass": grass, "water": water, "fishing": fishing["fishing"],
+	}}
+
+
+## One `def_grass_wildmons` or `def_water_wildmons` block: a rate byte, and ten
+## (level, species) pairs behind it unless the rate is zero, which ends it.
+static func _read_wild_block(rom: RomFile, at: int, map_id: int) -> Dictionary:
+	if not rom.in_bounds(at):
+		return _error("Map %d's wild data is outside the ROM." % map_id)
+	var rate: int = rom.u8(at)
+	if rate == 0:
+		return {"ok": true, "row": {}, "at": at + 1}
+	if not rom.in_bounds(at, Gen1Layout.WILD_DATA_LENGTH):
+		return _error("Map %d's wild slots are outside the ROM." % map_id)
+	var slots: Array = []
+	for slot: int in Gen1Layout.WILD_SLOT_COUNT:
+		var row: int = at + 1 + slot * 2
+		var species: int = rom.u8(row + 1)
+		if species < 1 or species > Gen1Layout.INDEX_COUNT:
+			return _error("Map %d's wild slot %d names index %d." % [map_id, slot, species])
+		slots.append({"level": rom.u8(row), "species": species})
+	return {
+		"ok": true,
+		"row": {"map": "0:%d" % map_id, "rate": rate, "slots": slots},
+		"at": at + Gen1Layout.WILD_DATA_LENGTH,
+	}
+
+
+## `SuperRodData`'s map index, or Yellow's `SuperRodFishingSlots`, whose row is
+## its own group. An entry is the group [method GameData.world_fishing_map] reads.
+static func _read_super_rod(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout["super_rod"])
+	var bank: int = RomFile.bank_of(at)
+	var flat: bool = Gen1Layout.flat_super_rod(rom.id)
+	var stride: int = Gen1Layout.SUPER_ROD_ROW_SIZE_YELLOW if flat \
+		else Gen1Layout.SUPER_ROD_ROW_SIZE
+	var maps: Dictionary = {}
+	var groups: Array = []
+	var seen: Dictionary = {}
+	while rom.in_bounds(at, stride) and rom.u8(at) != Gen1Layout.ROD_LIST_END:
+		var map_id: int = rom.u8(at)
+		if not Gen1Layout.is_real_map(map_id) or map_id >= Gen1Layout.map_count(rom.id):
+			return _error("The Super Rod names map %d." % map_id)
+		var key: int = at + 1 if flat else RomFile.linear(bank, rom.u16le(at + 1))
+		if not seen.has(key):
+			var group: Dictionary = _read_rod_group(rom, key, flat, map_id)
+			if not bool(group["ok"]):
+				return group
+			groups.append(group["group"])
+			seen[key] = groups.size()
+		maps[str(map_id)] = int(seen[key])
+		at += stride
+	if maps.is_empty():
+		return _error("The Super Rod table is empty.")
+	return {"ok": true, "fishing": {"maps": maps, "groups": groups}}
+
+
+## One group: a count and that many (level, species) rows, or Yellow's four
+## (species, level) rows with the byte `GenerateRandomFishingEncounter` reads.
+static func _read_rod_group(
+	rom: RomFile, at: int, flat: bool, map_id: int
+) -> Dictionary:
+	var count: int = Gen1Layout.SUPER_ROD_SLOTS_YELLOW if flat else rom.u8(at)
+	if count < 1 or count > Gen1Layout.SUPER_ROD_MAX_SLOTS:
+		return _error("Map %d's fishing group holds %d slots." % [map_id, count])
+	var first: int = at if flat else at + 1
+	if not rom.in_bounds(first, count * 2):
+		return _error("Map %d's fishing group is outside the ROM." % map_id)
+	var slots: Array = []
+	for slot: int in count:
+		var row: int = first + slot * 2
+		var species: int = rom.u8(row + 1 if not flat else row)
+		if species < 1 or species > Gen1Layout.INDEX_COUNT:
+			return _error("Map %d's fishing slot %d names index %d." % [map_id, slot, species])
+		var entry: Dictionary = {
+			"level": rom.u8(row if not flat else row + 1), "species": species,
+		}
+		if flat:
+			entry["threshold"] = Gen1Layout.SUPER_ROD_THRESHOLDS_YELLOW[slot]
+		slots.append(entry)
+	return {"ok": true, "group": {"slots": slots}}
+
+
+## `SuperPalettes`. `SetPal_Overworld` names one row a map and the
+## `BlkPacket_WholeScreen` behind it gives that row art and objects alike.
+static func _read_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var count: int = Gen1Layout.super_palette_count(rom.id)
+	var at: int = int(layout["super_palettes"])
+	if not rom.in_bounds(at, count * Gen1Layout.SUPER_PALETTE_BYTES):
+		return _error("SuperPalettes is outside the ROM.")
+	var out: Array = []
+	for row: int in count:
+		var colors: Array = []
+		for slot: int in Gen1Layout.SUPER_PALETTE_COLORS:
+			var packed: int = rom.u16le(
+				Gen1Layout.super_palette_offset(layout, row) + slot * PokePalette.COLOR_BYTES
+			)
+			if (packed & 0x8000) != 0:
+				return _error("SuperPalettes row %d has bit 15 set." % row)
+			colors.append(packed)
+		out.append(colors)
+	return {"ok": true, "palettes": out}
+
+
+## `SpriteSheetPointerTable` and the strips behind it. A walking sprite's row
+## names half its graphics and `LoadMapSpriteTilePatterns` copies that many
+## bytes twice, which `GetUsedSprite` also does: [Gen2WorldSprite] reads both.
+static func _read_sprites(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var count: int = Gen1Layout.sprite_count(rom.id)
+	var still_first: int = Gen1Layout.first_still_sprite(rom.id)
+	var sprites: Array = []
+	var graphics: Dictionary = {}
+	for number: int in range(1, count + 1):
+		var at: int = Gen1Layout.sprite_offset(layout, number)
+		if not rom.in_bounds(at, Gen1Layout.SPRITE_RECORD_SIZE):
+			return _error("Sprite %d's record is outside the ROM." % number)
+		var address: int = rom.u16le(at)
+		if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
+			return _error("Sprite %d names CPU address $%04X." % [number, address])
+		var still: bool = number >= still_first
+		var half: int = Gen1Layout.SPRITE_STILL_TILES if still \
+			else Gen1Layout.SPRITE_WALKING_TILES
+		if rom.u8(at + 2) != half * PokeTiles.TILE_BYTES:
+			return _error("Sprite %d is %d bytes, wanted %d." % [
+				number, rom.u8(at + 2), half * PokeTiles.TILE_BYTES,
+			])
+		var tiles: int = half if still else half * 2
+		var raw: PackedByteArray = rom.slice(
+			RomFile.linear(rom.u8(at + 3), address), tiles * PokeTiles.TILE_BYTES
+		)
+		if raw.size() != tiles * PokeTiles.TILE_BYTES:
+			return _error("Sprite %d's graphics are truncated." % number)
+		graphics[number] = PokeTiles.decode_2bpp_strip(raw, 0, tiles)
+		sprites.append({
+			"number": number,
+			"address": address,
+			"bank": rom.u8(at + 3),
+			"bytes": tiles * PokeTiles.TILE_BYTES,
+			"tiles": tiles,
+			"type": Gen2WorldSprite.TYPE_STILL if still else Gen2WorldSprite.TYPE_WALKING,
+			"palette": 0,
+		})
+	return {"ok": true, "sprites": sprites, "graphics": graphics}
 
 
 ## One row of `Tilesets`, its blockset, its graphics and the list of tiles

--- a/game/import/palette.gd
+++ b/game/import/palette.gd
@@ -47,6 +47,17 @@ static func monochrome() -> PackedColorArray:
 	]))
 
 
+## One palette read through a Game Boy shade register, [param shades] holding
+## the shade each colour index selects. `rBGP` is %11100100 wherever a map is
+## drawn, which is the identity and gives the palette back unchanged; an object
+## register is not, and its index 0 is transparent whatever shade it names.
+static func through_shades(colors: PackedColorArray, shades: Array[int]) -> PackedColorArray:
+	var out := PackedColorArray()
+	for shade: int in shades:
+		out.append(colors[shade] if shade >= 0 and shade < colors.size() else Color.MAGENTA)
+	return out
+
+
 ## Reads one species' entry as { normal, shiny }, each a two-colour array.
 static func decode_entry(data: PackedByteArray, offset: int) -> Dictionary:
 	return {

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 104
+const FORMAT_VERSION: int = 105
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -985,7 +985,7 @@ static func _reverse_byte(value: int) -> int:
 
 static func verify_landmarks(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var count: int = Gen2Layout.landmark_count(layout)
-	var bank: int = Gen2Layout.bank_of(Gen2Layout.landmark_offset(layout, 0))
+	var bank: int = RomFile.bank_of(Gen2Layout.landmark_offset(layout, 0))
 	if not rom.in_bounds(
 		Gen2Layout.landmark_offset(layout, 0), count * Gen2Layout.LANDMARK_RECORD_SIZE
 	):
@@ -993,7 +993,7 @@ static func verify_landmarks(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for index: int in count:
 		var record: int = Gen2Layout.landmark_offset(layout, index)
 		var at: int = Gen2Layout.landmark_name_offset(rom, layout, index)
-		if Gen2Layout.bank_of(at) != bank:
+		if RomFile.bank_of(at) != bank:
 			return {
 				"ok": false,
 				"message": "Landmark %d's name pointer leaves bank $%02X." % [index, bank],
@@ -1031,7 +1031,7 @@ static func verify_oak_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
 		table, Gen2Layout.OAK_RATING_COUNT * Gen2Layout.OAK_RATING_SIZE
 	):
 		return {"ok": false, "message": "The Oak rating table is outside the cartridge."}
-	var bank: int = Gen2Layout.bank_of(table)
+	var bank: int = RomFile.bank_of(table)
 	var previous: int = -1
 	for index: int in Gen2Layout.OAK_RATING_COUNT:
 		var row: int = Gen2Layout.oak_rating_offset(layout, index)
@@ -1044,7 +1044,7 @@ static func verify_oak_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
 				],
 			}
 		previous = threshold
-		if Gen2Layout.bank_of(RomFile.linear(bank, rom.u16le(row + 3))) != bank:
+		if RomFile.bank_of(RomFile.linear(bank, rom.u16le(row + 3))) != bank:
 			return {
 				"ok": false,
 				"message": "Oak rating %d's text leaves bank $%02X." % [index, bank],
@@ -2147,7 +2147,7 @@ static func _verify_credits_strings(
 	var bank: int = int(entry["strings_bank"])
 	for index: int in int(entry["string_count"]):
 		var at: int = Gen2Layout.credits_string_offset(rom, layout, index)
-		if Gen2Layout.bank_of(at) != bank:
+		if RomFile.bank_of(at) != bank:
 			return {"ok": false, "message": "Credits string %d leaves bank $%02X." % [index, bank]}
 		if read_credits_string(rom, layout, index).is_empty():
 			return {"ok": false, "message": "Credits string %d has no terminator." % index}
@@ -3373,7 +3373,7 @@ static func read_evos_attacks(rom: RomFile, layout: Dictionary, species: int) ->
 	var address: int = rom.u16le(table)
 	if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
 		return {}
-	var at: int = RomFile.linear(Gen2Layout.bank_of(table), address)
+	var at: int = RomFile.linear(RomFile.bank_of(table), address)
 
 	var evolutions: Array = []
 	while rom.in_bounds(at) and rom.u8(at) != Gen2Layout.EVOS_ATTACKS_END:
@@ -3429,7 +3429,7 @@ static func read_egg_moves(rom: RomFile, layout: Dictionary, species: int) -> Di
 	var address: int = rom.u16le(table)
 	if address < RomFile.BANK_SIZE or address >= RomFile.BANK_SIZE * 2:
 		return {}
-	var bank: int = Gen2Layout.bank_of(table)
+	var bank: int = RomFile.bank_of(table)
 	var at: int = RomFile.linear(bank, address)
 	var bank_end: int = mini((bank + 1) * RomFile.BANK_SIZE, rom.size())
 	var moves: Array[int] = []
@@ -4275,7 +4275,7 @@ static func _trainer_palette_check(
 static func read_trainer_parties(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var count: int = Gen2Layout.trainer_class_count(layout)
 	var table: int = int(layout["trainer_parties"])
-	var bank: int = Gen2Layout.bank_of(table)
+	var bank: int = RomFile.bank_of(table)
 
 	var pointers: Array = []
 	for trainer_class: int in range(1, count + 1):
@@ -4593,7 +4593,7 @@ static func verify_trainer_dvs(rom: RomFile, layout: Dictionary) -> Dictionary:
 static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> String:
 	var table: int = Gen2Layout.type_name_pointer_offset(layout, type_number)
 	var address: int = rom.u16le(table)
-	var offset: int = RomFile.linear(Gen2Layout.bank_of(table), address)
+	var offset: int = RomFile.linear(RomFile.bank_of(table), address)
 	return Gen2Text.decode(rom.bytes(), offset, Gen2Layout.MAX_NAME_LENGTH)
 
 
@@ -6163,7 +6163,7 @@ func _import_oak_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
 			# `rating` stores the sfx as a word, though every id is a byte.
 			"sfx": rom.u16le(row + 1),
 			"text": read_oak_text(
-				rom, layout, RomFile.linear(Gen2Layout.bank_of(row), rom.u16le(row + 3))
+				rom, layout, RomFile.linear(RomFile.bank_of(row), rom.u16le(row + 3))
 			),
 		})
 	out["ratings"] = rows

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -3736,7 +3736,7 @@ static func map_group_pointer_offset(layout: Dictionary, group: int) -> int:
 
 
 static func map_record_offset(layout: Dictionary, group_pointer: int, number: int) -> int:
-	return RomFile.linear(bank_of(int(layout["map_group_pointers"])), group_pointer) \
+	return RomFile.linear(RomFile.bank_of(int(layout["map_group_pointers"])), group_pointer) \
 		+ (number - 1) * MAP_RECORD_SIZE
 
 
@@ -3799,8 +3799,8 @@ static func trainer_palette_offset(layout: Dictionary, trainer_class: int) -> in
 
 
 ## Where a trainer class's own pointer sits in the trainer party table. The
-## pointer itself still has to be resolved through [method bank_of] on this
-## offset and [method RomFile.linear], the same as [method evos_attacks_pointer_offset].
+## pointer itself still has to be resolved through [method RomFile.bank_of] on
+## this offset and [method RomFile.linear], as [method evos_attacks_pointer_offset] is.
 static func trainer_party_pointer_offset(layout: Dictionary, trainer_class: int) -> int:
 	return int(layout["trainer_parties"]) + (trainer_class - 1) * TRAINER_PARTY_POINTER_SIZE
 
@@ -3836,7 +3836,7 @@ static func move_data_offset(layout: Dictionary, move: int) -> int:
 
 ## One species' entry in the combined evolution and level-up move table. The
 ## pointer is two bytes and the entry it names is in the pointer table's own
-## bank, so [method bank_of] on the table itself resolves it.
+## bank, so [method RomFile.bank_of] on the table itself resolves it.
 static func evos_attacks_pointer_offset(layout: Dictionary, species: int) -> int:
 	return int(layout["evos_attacks"]) + (species - 1) * EVOS_ATTACKS_POINTER_SIZE
 
@@ -3886,7 +3886,7 @@ static func oak_text_stub_offset(rom: RomFile, layout: Dictionary, name: String)
 	if not rom.in_bounds(table, OAK_RATING_SIZE) or not OAK_TEXT_STUBS.has(name):
 		return -1
 	var first: int = rom.u16le(table + 3) + int(OAK_TEXT_STUBS[name]) * OAK_TEXT_STUB_SIZE
-	return RomFile.linear(bank_of(table), first)
+	return RomFile.linear(RomFile.bank_of(table), first)
 
 
 ## Where the word for Unown form [param form] starts, form 1 being A.
@@ -3898,7 +3898,7 @@ static func unown_word_offset(rom: RomFile, layout: Dictionary, form: int) -> in
 	if not rom.in_bounds(table, UNOWN_WORD_ENTRIES * UNOWN_WORD_POINTER_SIZE):
 		return -1
 	var pointer: int = rom.u16le(table + form * UNOWN_WORD_POINTER_SIZE)
-	return RomFile.linear(bank_of(table), pointer)
+	return RomFile.linear(RomFile.bank_of(table), pointer)
 
 
 ## The letter [param code] spells under the `unown` charmap, or an empty string
@@ -4082,7 +4082,7 @@ static func landmark_name_offset(rom: RomFile, layout: Dictionary, index: int) -
 	var record: int = landmark_offset(layout, index)
 	if not rom.in_bounds(record, LANDMARK_RECORD_SIZE):
 		return -1
-	return RomFile.linear(bank_of(record), rom.u16le(record + 2))
+	return RomFile.linear(RomFile.bank_of(record), rom.u16le(record + 2))
 
 
 static func font_offset(layout: Dictionary) -> int:
@@ -4107,10 +4107,3 @@ static func stats_tiles_offset(layout: Dictionary) -> int:
 ## Frames are stored back to back in selection order, six tiles of 1bpp each.
 static func frame_offset(layout: Dictionary, frame: int) -> int:
 	return int(layout["frames"]) + frame * FRAME_TILES * PokeTiles.TILE_1BPP_BYTES
-
-
-## The bank a dump offset falls in, for resolving a pointer that carries an
-## address but no bank number of its own.
-static func bank_of(offset: int) -> int:
-	@warning_ignore("integer_division")
-	return offset / RomFile.BANK_SIZE

--- a/game/import/world_encounter_importer.gd
+++ b/game/import/world_encounter_importer.gd
@@ -162,10 +162,6 @@ static func read_world_encounters(rom: RomFile, layout: Dictionary) -> Dictionar
 			"roaming": roam_result["roaming"],
 			"treemons": treemon_result["treemons"],
 			"bug_contest": contest_result["bug_contest"],
-			"probabilities": {
-				"grass": Gen2Layout.WILD_GRASS_PROBABILITIES,
-				"water": Gen2Layout.WILD_WATER_PROBABILITIES,
-			},
 		},
 		"counts": {
 			"grass": grass.size(),
@@ -590,7 +586,7 @@ static func read_treemons(
 	var set_count: int = int(configured.get("treemon_set_count", -1))
 	if pointer_offset < 0 or set_count < 1:
 		return _error("Treemon set layout is incomplete.")
-	var bank: int = Gen2Layout.bank_of(pointer_offset)
+	var bank: int = RomFile.bank_of(pointer_offset)
 
 	var tree_maps: Dictionary = _read_treemon_maps(rom, layout, configured, "tree")
 	if not bool(tree_maps.get("ok", false)):

--- a/game/import/world_importer.gd
+++ b/game/import/world_importer.gd
@@ -499,7 +499,7 @@ static func _check_icon_pointers(rom: RomFile, layout: Dictionary) -> Dictionary
 	var base: int = int(layout["overworld_icons"])
 	for index: int in Gen2Layout.ICON_POINTER_COUNT:
 		var address: int = rom.u16le(table + index * Gen2Layout.ICON_POINTER_SIZE)
-		var expected: int = RomFile.linear(Gen2Layout.bank_of(base), address)
+		var expected: int = RomFile.linear(RomFile.bank_of(base), address)
 		var wanted: int = base + maxi(index - 1, 0) * Gen2Layout.MON_ICON_BYTES
 		if not _valid_cpu_address(address) or expected != wanted:
 			return _error(

--- a/game/import/world_services_importer.gd
+++ b/game/import/world_services_importer.gd
@@ -130,7 +130,7 @@ static func read_services(
 
 static func _read_marts(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var table: int = int(layout["mart_table"])
-	var bank: int = Gen2Layout.bank_of(table)
+	var bank: int = RomFile.bank_of(table)
 	if not rom.in_bounds(table, Gen2Layout.MART_COUNT * Gen2Layout.MART_POINTER_SIZE):
 		return _error("Mart pointer table is outside the cartridge.")
 

--- a/game/rom/rom_file.gd
+++ b/game/rom/rom_file.gd
@@ -55,6 +55,13 @@ static func linear(bank: int, address: int) -> int:
 	return bank * BANK_SIZE + (address & 0x3FFF)
 
 
+## The other way: the bank a dump offset falls in, for resolving a pointer that
+## carries an address but no bank number of its own.
+static func bank_of(offset: int) -> int:
+	@warning_ignore("integer_division")
+	return offset / BANK_SIZE
+
+
 func size() -> int:
 	return _bytes.size()
 

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -183,6 +183,41 @@ const ENVIRONMENT_TOWN: int = 1
 const ENVIRONMENT_ROUTE: int = 2
 
 
+## Generation 1's answer to [method tile_palettes]. There are no eight slots:
+## `SetPal_Overworld` names one `SuperPalettes` row and the
+## `BlkPacket_WholeScreen` behind it gives that row every attribute block, so
+## the whole screen draws in the same four colours. [param last_map] is
+## `wLastMap`, which only an indoor map the routine does not name reads.
+static func gen1_tile_palettes(
+	data: GameData,
+	map: Gen2WorldMap,
+	tileset: Gen2WorldTileset,
+	last_map: int = -1,
+	fade_order: int = FADE_IDENTITY,
+) -> Array:
+	var colors: PackedColorArray = fade_palette(gen1_map_colors(data, map, last_map), fade_order)
+	var out: Array = []
+	out.resize(tileset.tile_count)
+	out.fill(colors)
+	return out
+
+
+## The four colours one Generation 1 map draws in.
+static func gen1_map_colors(
+	data: GameData, map: Gen2WorldMap, last_map: int = -1
+) -> PackedColorArray:
+	return data.world_palette(
+		Gen1Layout.overworld_palette(data.id, map.number, map.tileset, last_map)
+	)
+
+
+## The same four through `GBPalNormal`'s `rOBP0`, which is what every object on
+## a Generation 1 map is drawn with. Colour 0 is the object's transparent index,
+## so a sprite never shows the map's own background colour.
+static func gen1_object_colors(colors: PackedColorArray) -> PackedColorArray:
+	return PokePalette.through_shades(colors, Gen1Layout.OBJECT_SHADES)
+
+
 ## One palette per tile of [param tileset], in tile order.
 ##
 ## Every tile of the strip shares eight palette slots, so the eight are resolved

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -366,10 +366,6 @@ static func _write_world(cache_directory: String, crystal_commands: bool = true)
 			}],
 			"time_groups": [],
 		},
-		"probabilities": {
-			"grass": Gen2Layout.WILD_GRASS_PROBABILITIES,
-			"water": Gen2Layout.WILD_WATER_PROBABILITIES,
-		},
 	})
 
 	# These two scripts are stored at the object's/coord event's own address,

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -16,7 +16,7 @@ const REQUIRED_KEYS: Array[String] = [
 	"type_names_bank", "type_effects", "item_names", "item_prices", "tmhm_moves",
 	"mon_palettes", "super_palettes", "trainer_names", "evos_moves", "evos_moves_bank",
 	"cries", "font", "text_box", "map_headers", "map_header_banks", "map_songs",
-	"tilesets", "water_tilesets", "tileset_collision_bank",
+	"tilesets", "water_tilesets", "tileset_collision_bank", "overworld_sprites",
 ]
 
 
@@ -263,3 +263,119 @@ func test_the_object_row_widths_match_the_macro() -> void:
 		Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT - 1, 0xFA,
 		"the last TM is item $FA"
 	)
+
+
+## `SetPal_Overworld`, branch by branch. A city's row is its map id plus one, so
+## the eleven of them run PAL_PALLET to PAL_SAFFRON in map order.
+func test_a_city_takes_its_own_row_and_a_route_takes_pal_route() -> void:
+	for map_id: int in Gen1Layout.NUM_CITY_MAPS:
+		assert_eq(
+			Gen1Layout.overworld_palette(RomRegistry.RED, map_id, 0), map_id + 1,
+			"city $%02X" % map_id
+		)
+	assert_eq(Gen1Layout.overworld_palette(RomRegistry.RED, 0x0C, 0), Gen1Layout.PAL_ROUTE)
+	assert_eq(
+		Gen1Layout.overworld_palette(RomRegistry.RED, Gen1Layout.FIRST_INDOOR_MAP - 1, 0),
+		Gen1Layout.PAL_ROUTE, "the last route id"
+	)
+
+
+func test_the_two_tilesets_answer_before_the_map_id() -> void:
+	for id: StringName in RomRegistry.ids_of_generation(RomRegistry.GEN1):
+		assert_eq(
+			Gen1Layout.overworld_palette(id, 0x00, Gen1Layout.TILESET_CEMETERY),
+			Gen1Layout.PAL_GRAYMON, "%s: Pallet Town's own id loses to CEMETERY" % id
+		)
+		assert_eq(
+			Gen1Layout.overworld_palette(id, 0x00, Gen1Layout.TILESET_CAVERN),
+			Gen1Layout.PAL_CAVE, "%s: and to CAVERN" % id
+		)
+
+
+func test_an_indoor_map_reads_the_map_it_was_entered_from() -> void:
+	# OAKS_LAB out of Pallet Town, then out of Route 1.
+	assert_eq(Gen1Layout.overworld_palette(RomRegistry.RED, 0x28, 0, 0x00), Gen1Layout.PAL_PALLET)
+	assert_eq(Gen1Layout.overworld_palette(RomRegistry.RED, 0x28, 0, 0x0C), Gen1Layout.PAL_ROUTE)
+	# `wLastMap` is unset before the first warp, which the routine reads as a
+	# map past the last city.
+	assert_eq(Gen1Layout.overworld_palette(RomRegistry.RED, 0x28, 0), Gen1Layout.PAL_ROUTE)
+
+
+func test_the_named_indoor_branches_ignore_the_last_map() -> void:
+	var named: Dictionary = {
+		Gen1Layout.CERULEAN_CAVE_2F: Gen1Layout.PAL_CAVE,
+		0xE3: Gen1Layout.PAL_CAVE,
+		Gen1Layout.CERULEAN_CAVE_1F: Gen1Layout.PAL_CAVE,
+		Gen1Layout.BRUNOS_ROOM: Gen1Layout.PAL_CAVE,
+		Gen1Layout.LORELEIS_ROOM: Gen1Layout.PAL_PALLET,
+	}
+	for map_id: int in named:
+		for last_map: int in [-1, 0x00, 0x0C]:
+			assert_eq(
+				Gen1Layout.overworld_palette(RomRegistry.RED, map_id, 0, last_map),
+				int(named[map_id]), "$%02X out of %d" % [map_id, last_map]
+			)
+	# One past `CERULEAN_CAVE_1F` is back on `wLastMap`.
+	assert_eq(
+		Gen1Layout.overworld_palette(RomRegistry.RED, Gen1Layout.CERULEAN_CAVE_1F + 1, 0, 0x00),
+		Gen1Layout.PAL_PALLET
+	)
+
+
+func test_only_yellow_names_the_two_link_rooms() -> void:
+	for map_id: int in [Gen1Layout.TRADE_CENTER, Gen1Layout.COLOSSEUM]:
+		assert_eq(
+			Gen1Layout.overworld_palette(RomRegistry.YELLOW, map_id, 0, 0x00),
+			Gen1Layout.PAL_GRAYMON, "yellow $%02X" % map_id
+		)
+		assert_eq(
+			Gen1Layout.overworld_palette(RomRegistry.RED, map_id, 0, 0x00),
+			Gen1Layout.PAL_PALLET, "red $%02X falls through to wLastMap" % map_id
+		)
+
+
+func test_every_palette_row_is_inside_the_table() -> void:
+	for id: StringName in RomRegistry.ids_of_generation(RomRegistry.GEN1):
+		var layout: Dictionary = Gen1Layout.for_id(id)
+		var count: int = Gen1Layout.super_palette_count(id)
+		assert_lt(
+			Gen1Layout.super_palette_offset(layout, count) - 1, GEN1_ROM_SIZE,
+			"%s SuperPalettes" % id
+		)
+		for map_id: int in Gen1Layout.map_count(id):
+			for tileset: int in Gen1Layout.tileset_count(id):
+				assert_between(
+					Gen1Layout.overworld_palette(id, map_id, tileset, 0x00), 0, count - 1,
+					"%s map $%02X tileset %d" % [id, map_id, tileset]
+				)
+
+
+## `GBPalNormal` writes %11010000, so an object's three drawn indices take
+## shades 0, 1 and 3 and never the palette's third colour.
+func test_the_object_register_skips_the_third_colour() -> void:
+	assert_eq(Gen1Layout.OBJECT_SHADES, [0, 0, 1, 3] as Array[int])
+	var colors := PackedColorArray([Color.RED, Color.GREEN, Color.BLUE, Color.BLACK])
+	assert_eq(
+		PokePalette.through_shades(colors, Gen1Layout.OBJECT_SHADES),
+		PackedColorArray([Color.RED, Color.RED, Color.GREEN, Color.BLACK])
+	)
+
+
+func test_every_sprite_row_is_inside_the_table() -> void:
+	for id: StringName in RomRegistry.ids_of_generation(RomRegistry.GEN1):
+		var layout: Dictionary = Gen1Layout.for_id(id)
+		assert_eq(
+			Gen1Layout.sprite_offset(layout, 1), int(layout["overworld_sprites"]),
+			"%s: picture id 1 is the first row" % id
+		)
+		assert_lt(
+			Gen1Layout.sprite_offset(layout, Gen1Layout.sprite_count(id))
+				+ Gen1Layout.SPRITE_RECORD_SIZE,
+			GEN1_ROM_SIZE, "%s SpriteSheetPointerTable" % id
+		)
+		# Twelve still sprites end every table, and the ten Yellow added are
+		# walking ones in front of them.
+		assert_eq(
+			Gen1Layout.sprite_count(id) - Gen1Layout.first_still_sprite(id) + 1, 12,
+			"%s still sprites" % id
+		)

--- a/tests/unit/test_rom_importer.gd
+++ b/tests/unit/test_rom_importer.gd
@@ -389,7 +389,7 @@ func _trainer_party_classes() -> Array:
 ## real cartridge does for the one class with no party of its own.
 func _write_trainer_parties(data: PackedByteArray, classes: Array) -> void:
 	var table: int = int(_layout["trainer_parties"])
-	var bank: int = Gen2Layout.bank_of(table)
+	var bank: int = RomFile.bank_of(table)
 	var at: int = table + classes.size() * Gen2Layout.TRAINER_PARTY_POINTER_SIZE
 
 	for i: int in classes.size():
@@ -412,7 +412,7 @@ func _write_trainer_parties(data: PackedByteArray, classes: Array) -> void:
 			data[at] = Gen2Layout.TRAINER_PARTY_END
 			at += 1
 
-	assert(Gen2Layout.bank_of(at) == bank, "the filler table overran its own bank")
+	assert(RomFile.bank_of(at) == bank, "the filler table overran its own bank")
 
 
 func test_a_plausible_trainer_party_table_verifies() -> void:
@@ -539,7 +539,7 @@ func test_a_trainer_party_pointer_table_with_no_terminator_anywhere_fails() -> v
 	var last_pointer: int = int(_layout["trainer_parties"]) \
 		+ (count - 1) * Gen2Layout.TRAINER_PARTY_POINTER_SIZE
 	var address: int = data[last_pointer] | (data[last_pointer + 1] << 8)
-	var bank: int = Gen2Layout.bank_of(int(_layout["trainer_parties"]))
+	var bank: int = RomFile.bank_of(int(_layout["trainer_parties"]))
 	var at: int = RomFile.linear(bank, address)
 	for i: int in RomFile.BANK_SIZE - (at % RomFile.BANK_SIZE):
 		data[at + i] = 0x41
@@ -1302,7 +1302,7 @@ func test_an_egg_move_list_with_no_terminator_fails() -> void:
 	var data: PackedByteArray = _egg_move_dump()
 	var at: int = int(_layout["egg_move_pointers"]) \
 		+ Gen2Layout.SPECIES_COUNT * Gen2Layout.EGG_MOVE_POINTER_SIZE
-	var bank_end: int = (Gen2Layout.bank_of(at) + 1) * RomFile.BANK_SIZE
+	var bank_end: int = (RomFile.bank_of(at) + 1) * RomFile.BANK_SIZE
 	for i: int in bank_end - at:
 		data[at + i] = 1
 	assert_false(RomImporter.verify_egg_moves(_rom(data), _layout)["ok"])

--- a/tests/unit/test_rom_layout.gd
+++ b/tests/unit/test_rom_layout.gd
@@ -223,7 +223,7 @@ func test_a_type_pointer_resolves_against_its_own_bank() -> void:
 	for id: StringName in RomRegistry.ids_of_generation(RomRegistry.GEN2):
 		var layout: Dictionary = Gen2Layout.for_id(id)
 		var table: int = Gen2Layout.type_name_pointer_offset(layout, 0)
-		var bank: int = Gen2Layout.bank_of(table)
+		var bank: int = RomFile.bank_of(table)
 		assert_eq(RomFile.linear(bank, 0x4000 + (table & 0x3FFF)), table)
 
 

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,10 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 411 lines of the 38156 here, and Generation 1's maps added 21 more to the
-## shared map, tileset, palette and preview code. The tree has no restatement
-## left to pay for them with, which three sweeps for it have now said.
-const MAX_COMMENT_LINES: int = 38156
+## are 451 lines of the 38254 here, and Generation 1's colour, sprites and wild
+## tables added 38 more to the shared palette, encounter and preview code. The
+## tree has no restatement left to pay for them with, which four sweeps for it
+## have now said.
+const MAX_COMMENT_LINES: int = 38254
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -314,10 +314,6 @@ func _write_cache(game_id: String = "testworld") -> void:
 			],
 			"mons": [{"species": 0xF3, "level": 40, "map_group": 1, "map_number": 2}],
 		},
-		"probabilities": {
-			"grass": Gen2Layout.WILD_GRASS_PROBABILITIES,
-			"water": Gen2Layout.WILD_WATER_PROBABILITIES,
-		},
 	})
 	RomCache.write_json(RomCache.world_scripts_path(_directory), {
 		"48:6000": [0x33, 7, 0, 0x4C, 0x00, 0x70, 0x91],

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -1,10 +1,10 @@
 extends RefCounted
 
-## Every Generation 1 map and tileset in the cache, swept on Red, Blue and
-## Yellow. The counts come from pret's own `data/maps` and `gfx/blocksets`, and
-## the structural rules are the map macros' own assertions: a sign's text id
-## sits above the object ids, an object's inside them, and every warp and
-## connection names a map that exists.
+## Every Generation 1 map, tileset, SGB palette and overworld sprite in the
+## cache, swept on Red, Blue and Yellow. The counts come from pret's own
+## `data/maps`, `gfx/blocksets` and `data/sprites`, and the structural rules are
+## the map macros' own assertions: a sign's text id sits above the object ids,
+## an object's inside them, and every warp and connection names a real map.
 
 ## Real maps of the flat table's 248 or 249 ids, and the tilesets behind them.
 const MAP_COUNTS: Dictionary = {&"red": 226, &"blue": 226, &"yellow": 227}
@@ -66,6 +66,43 @@ const POWER_PLANT_WILD: Dictionary = {0x06: 6, 0x8D: 2, 0x4B: 1}
 ## the elevator's own script rewrites the destination before either is taken.
 const SILPH_CO_ELEVATOR: int = 236
 
+## `NUM_SGB_PALS`, and `PAL_ROUTE`'s own four, the row every route draws in.
+const PALETTE_COUNTS: Dictionary = {&"red": 37, &"blue": 37, &"yellow": 40}
+const ROUTE_COLORS: Dictionary = {
+	&"red": [0x7FBF, 0x2F95, 0x7F54, 0x0843],
+	&"blue": [0x7FBF, 0x2F95, 0x7F54, 0x0843],
+	&"yellow": [0x7BFF, 0x4F57, 0x7F77, 0x18C6],
+}
+
+## Every branch of `SetPal_Overworld`, as map id, `wLastMap` and the row wanted.
+## The ids are the same in all three; only the link rooms answer differently.
+const PINNED_PALETTES: Array = [
+	[0x00, -1, 0x01], [0x0A, -1, 0x0B], [0x0C, -1, 0x00],
+	[0x28, 0x00, 0x01], [0x28, 0x0C, 0x00],
+	[0x3B, -1, 0x23], [0x8F, -1, 0x19], [0xF7, -1, 0x19],
+	[0xE2, -1, 0x23], [0xE4, -1, 0x23], [0xF5, -1, 0x01], [0xF6, -1, 0x23],
+]
+const LINK_ROOMS: Array[int] = [0xEF, 0xF0]
+
+## What the corpus lands on with no `wLastMap`: eleven cities one each, Lorelei's
+## room beside Pallet Town's, twenty caves, the Tower and Agatha grey, and the
+## rest the route row. Yellow's extra grey pair is the link rooms.
+const PALETTE_CENSUS: Dictionary = {
+	&"red": {0: 186, 1: 2, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1,
+		11: 1, 25: 8, 35: 20},
+	&"blue": {0: 186, 1: 2, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1,
+		11: 1, 25: 8, 35: 20},
+	&"yellow": {0: 185, 1: 2, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1, 9: 1, 10: 1,
+		11: 1, 25: 10, 35: 20},
+}
+
+## `NUM_SPRITES` and `FIRST_STILL_SPRITE`, with `SpriteSheetPointerTable`'s
+## first row: `RedSprite`, $C0 bytes in bank $05.
+const SPRITE_COUNTS: Dictionary = {&"red": 72, &"blue": 72, &"yellow": 82}
+const SPRITE_STILL_FIRST: Dictionary = {&"red": 0x3D, &"blue": 0x3D, &"yellow": 0x47}
+const PLAYER_SPRITE: Array = [0x4180, 0x05]
+const PLAYER_SPRITE_YELLOW: Array = [0x4571, 0x05]
+
 var _r: RefCounted = null
 var _maps: Dictionary = {}
 
@@ -85,6 +122,8 @@ func _one_game() -> void:
 	_geometry()
 	_events()
 	_wild_objects()
+	_palettes()
+	_sprites()
 
 
 func _counts() -> void:
@@ -277,6 +316,113 @@ static func _is_item(item: int) -> bool:
 		return true
 	return item >= Gen1Layout.HM_FIRST_ITEM \
 		and item < Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT
+
+
+## `SuperPalettes` and the row `SetPal_Overworld` hands each map.
+func _palettes() -> void:
+	var wanted: int = int(PALETTE_COUNTS[_r.game_id])
+	var last: PackedColorArray = _r.data.world_palette(wanted - 1)
+	if not _r.check(
+		_r.data.world_palette(wanted).is_empty() and last.size() == 4,
+		"the cache holds %d SGB palettes, wanted %d." % [_palette_count(), wanted]
+	):
+		return
+	var route: Array = []
+	for color: Color in _r.data.world_palette(Gen1Layout.PAL_ROUTE):
+		route.append(_packed(color))
+	_r.check(route == ROUTE_COLORS[_r.game_id], "PAL_ROUTE reads %s." % [route])
+
+	for row: Array in PINNED_PALETTES:
+		_pinned_palette(int(row[0]), int(row[1]), int(row[2]))
+	# Yellow gives the two link rooms `PAL_GRAYMON` by name; Red and Blue have
+	# the same two maps and let them fall through to `wLastMap`.
+	var link: int = Gen1Layout.PAL_GRAYMON if _r.game_id == RomRegistry.YELLOW \
+		else Gen1Layout.PAL_PALLET
+	for map_id: int in LINK_ROOMS:
+		_pinned_palette(map_id, 0x00, link)
+
+	var census: Dictionary = {}
+	for map: Gen2WorldMap in _maps.values():
+		var palette: int = Gen1Layout.overworld_palette(_r.game_id, map.number, map.tileset)
+		if not _r.check(palette >= 0 and palette < wanted,
+			"map %d draws in SGB palette %d." % [map.number, palette]):
+			continue
+		census[palette] = int(census.get(palette, 0)) + 1
+	var pinned: Dictionary = PALETTE_CENSUS[_r.game_id]
+	for palette: int in pinned:
+		_r.check(int(census.get(palette, 0)) == int(pinned[palette]),
+			"%d maps draw in SGB palette %d, pinned %d." % [
+				int(census.get(palette, 0)), palette, int(pinned[palette]),
+			])
+	_r.check(census.size() == pinned.size(), "the corpus lands on %d palettes, pinned %d." % [
+		census.size(), pinned.size(),
+	])
+	_r.note("gen1 map palettes %s" % census)
+
+
+func _pinned_palette(map_id: int, last_map: int, wanted: int) -> void:
+	var map: Gen2WorldMap = _maps.get(map_id, null)
+	if not _r.check(map != null, "map $%02X is missing." % map_id):
+		return
+	var got: int = Gen1Layout.overworld_palette(_r.game_id, map_id, map.tileset, last_map)
+	_r.check(got == wanted, "map $%02X out of map %d draws in palette %d, wanted %d." % [
+		map_id, last_map, got, wanted,
+	])
+
+
+## How many rows the cache really holds, for the message when the count is wrong.
+func _palette_count() -> int:
+	var out: int = 0
+	while not _r.data.world_palette(out).is_empty():
+		out += 1
+	return out
+
+
+static func _packed(color: Color) -> int:
+	return int(round(color.r * 31.0)) | (int(round(color.g * 31.0)) << 5) \
+		| (int(round(color.b * 31.0)) << 10)
+
+
+## `SpriteSheetPointerTable`'s strips, and the picture id every object names.
+func _sprites() -> void:
+	var wanted: int = int(SPRITE_COUNTS[_r.game_id])
+	var still_first: int = int(SPRITE_STILL_FIRST[_r.game_id])
+	if not _r.check(_r.data.overworld_sprite_count() == wanted,
+		"the cache holds %d overworld sprites, wanted %d." % [
+			_r.data.overworld_sprite_count(), wanted,
+		]):
+		return
+	var player: Array = PLAYER_SPRITE_YELLOW if _r.game_id == RomRegistry.YELLOW \
+		else PLAYER_SPRITE
+	var red: Gen2WorldSprite = _r.data.overworld_sprite(1)
+	_r.check(red.address == int(player[0]) and red.bank == int(player[1]),
+		"RedSprite reads $%02X:$%04X." % [red.bank, red.address])
+
+	var census: Dictionary = {"walking": 0, "still": 0}
+	for number: int in range(1, wanted + 1):
+		var sprite: Gen2WorldSprite = _r.data.overworld_sprite(number)
+		if not _r.check(sprite != null, "sprite %d is missing." % number):
+			continue
+		var still: bool = number >= still_first
+		var tiles: int = Gen1Layout.SPRITE_STILL_TILES if still \
+			else Gen1Layout.SPRITE_WALKING_TILES * 2
+		census["still" if still else "walking"] += 1
+		_r.check(sprite.tiles == tiles and sprite.is_walking() != still,
+			"sprite %d holds %d tiles as type %d, wanted %d." % [
+				number, sprite.tiles, sprite.sprite_type, tiles,
+			])
+		_r.check(
+			_r.data.overworld_sprite_indices(number).size() == tiles * PokeTiles.TILE_PIXELS,
+			"sprite %d's strip is the wrong size." % number
+		)
+	_r.check(census == {"walking": still_first - 1, "still": wanted - still_first + 1},
+		"the sheets read %s." % [census])
+
+	for map: Gen2WorldMap in _maps.values():
+		for object: Dictionary in map.events["objects"] as Array:
+			var picture: int = int(object["sprite"])
+			_r.check(picture >= 1 and picture <= wanted,
+				"map %d has an object drawn with picture id %d." % [map.number, picture])
 
 
 func _wild_objects() -> void:

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -44,10 +44,155 @@ func run(r: RefCounted) -> void:
 		_verify_magikarp_filter()
 		_verify_roaming_walk()
 	)
+	_r.each_game_of(RomRegistry.GEN1, _verify_gen1_tables)
 
 
 ## `UpdateRoamMons` passes per starting map, enough to measure the graph.
 const ROAM_WALK_UPDATES: int = 400
+
+
+## Generation 1's `WildDataPointers` and `SuperRodData`: what the corpus holds
+## and the rows read end to end off pret's `data/wild`. Nothing rolls on it yet.
+const GEN1_CENSUS: Dictionary = {
+	&"red": {"grass": 55, "water": 3, "fishing_maps": 33, "fishing_groups": 10},
+	&"blue": {"grass": 55, "water": 3, "fishing_maps": 33, "fishing_groups": 10},
+	&"yellow": {"grass": 55, "water": 8, "fishing_maps": 31, "fishing_groups": 31},
+}
+
+## `Route1.asm`: rate 25 and ten slots of PIDGEY and RATTATA, by internal index.
+const GEN1_ROUTE_1: int = 0x0C
+const GEN1_ROUTE_1_RATE: int = 25
+const GEN1_ROUTE_1_SLOTS: Array = [
+	[3, 0x24], [3, 0xA5], [3, 0xA5], [2, 0xA5], [2, 0x24],
+	[3, 0x24], [3, 0x24], [4, 0xA5], [4, 0x24], [5, 0x24],
+]
+
+## `SeaRoutes.asm`, the water block Routes 19 and 20 share: rate 5 over ten
+## TENTACOOL, and no grass at all. Yellow gives the pair its own block.
+const GEN1_SEA_ROUTES: Array[int] = [0x1E, 0x1F]
+const GEN1_SEA_RATE: int = 5
+const GEN1_SEA_SPECIES: int = 0x18
+
+## `SuperRodData`'s first row, `.Group1`, and Yellow's own first row, which is
+## four slots with a threshold each rather than a uniform pick.
+const GEN1_ROD_MAP: int = 0x00
+const GEN1_ROD_SLOTS: Array = [[15, 0x18], [15, 0x47]]
+const GEN1_ROD_SLOTS_YELLOW: Array = [[10, 0x1B], [10, 0x18], [5, 0x1B], [20, 0x18]]
+
+
+## Every Generation 1 encounter table in the cache, on all three cartridges.
+func _verify_gen1_tables() -> void:
+	var census: Dictionary = {"grass": 0, "water": 0, "fishing_maps": 0, "fishing_groups": 0}
+	var maps: Array = _r.data.world_maps()
+	for map: Gen2WorldMap in maps:
+		for method: StringName in [&"grass", &"water"] as Array[StringName]:
+			var row: Dictionary = _r.data.world_encounter(method, 0, map.number)
+			if row.is_empty():
+				continue
+			census[String(method)] += 1
+			_gen1_slots(map.number, String(method), row)
+		if _r.data.world_fishing_map(map.number) > 0:
+			census["fishing_maps"] += 1
+	while not _r.data.world_fishing_group(census["fishing_groups"] + 1).is_empty():
+		census["fishing_groups"] += 1
+
+	var pinned: Dictionary = GEN1_CENSUS[_r.game_id]
+	for key: String in pinned:
+		_r.check(census[key] == int(pinned[key]), "the corpus holds %d %s tables, pinned %d." % [
+			census[key], key, int(pinned[key]),
+		])
+	_gen1_route_1()
+	_gen1_sea_routes()
+	_gen1_super_rod()
+	_r.note("gen1 encounters %s" % census)
+
+
+## One block's own rules: a rate a roll can hit, and ten slots naming a real
+## internal index. An empty block is never written, so every row here is live.
+func _gen1_slots(map_id: int, method: String, row: Dictionary) -> void:
+	var rate: int = int(row.get("rate", 0))
+	var slots: Array = row.get("slots", [])
+	_r.check(rate >= 1 and rate <= 255 and slots.size() == Gen1Layout.WILD_SLOT_COUNT,
+		"map %d's %s block reads rate %d over %d slots." % [
+			map_id, method, rate, slots.size(),
+		])
+	for slot: Dictionary in slots:
+		_r.check(
+			int(slot["species"]) >= 1 and int(slot["species"]) <= Gen1Layout.INDEX_COUNT
+			and int(slot["level"]) >= 1 and int(slot["level"]) <= 100,
+			"map %d's %s block holds level %d of index %d." % [
+				map_id, method, int(slot["level"]), int(slot["species"]),
+			]
+		)
+
+
+func _gen1_route_1() -> void:
+	var row: Dictionary = _r.data.world_encounter(&"grass", 0, GEN1_ROUTE_1)
+	if not _r.check(not row.is_empty(), "Route 1 has no grass table."):
+		return
+	_r.check(int(row["rate"]) == GEN1_ROUTE_1_RATE,
+		"Route 1's grass rate is %d." % int(row["rate"]))
+	# Yellow reshuffled Route 1's levels, so only Red and Blue are pinned whole.
+	if _r.game_id == RomRegistry.YELLOW:
+		return
+	_r.check(_gen1_rows(row["slots"]) == GEN1_ROUTE_1_SLOTS,
+		"Route 1's grass slots read %s." % [_gen1_rows(row["slots"])])
+
+
+## The one water block two maps share, which says a pointer is read twice.
+func _gen1_sea_routes() -> void:
+	var rows: Array = []
+	for map_id: int in GEN1_SEA_ROUTES:
+		var row: Dictionary = _r.data.world_encounter(&"surf", 0, map_id)
+		if not _r.check(not row.is_empty(), "map $%02X has no water table." % map_id):
+			return
+		rows.append(row)
+	_r.check(rows[0]["slots"] == rows[1]["slots"],
+		"Routes 19 and 20 no longer share one water block.")
+	for map_id: int in GEN1_SEA_ROUTES:
+		_r.check(_r.data.world_encounter(&"grass", 0, map_id).is_empty(),
+			"map $%02X has a grass table." % map_id)
+	if _r.game_id == RomRegistry.YELLOW:
+		return
+	_r.check(int(rows[0]["rate"]) == GEN1_SEA_RATE,
+		"the sea routes' water rate is %d." % int(rows[0]["rate"]))
+	for slot: Dictionary in rows[0]["slots"] as Array:
+		_r.check(int(slot["species"]) == GEN1_SEA_SPECIES,
+			"a sea route slot names index %d." % int(slot["species"]))
+
+
+## Pallet Town's group, and that every map the table names resolves to slots.
+func _gen1_super_rod() -> void:
+	var group: int = _r.data.world_fishing_map(GEN1_ROD_MAP)
+	if not _r.check(group > 0, "Pallet Town has no fishing group."):
+		return
+	var wanted: Array = GEN1_ROD_SLOTS_YELLOW if _r.game_id == RomRegistry.YELLOW \
+		else GEN1_ROD_SLOTS
+	var slots: Array = _r.data.world_fishing_group(group).get("slots", [])
+	_r.check(_gen1_rows(slots) == wanted, "Pallet Town's rod slots read %s." % [
+		_gen1_rows(slots),
+	])
+	# Yellow's four slots are picked by a byte threshold; Red and Blue reject a
+	# two-bit roll until it is under the group's own count, so no row carries one.
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var named: int = _r.data.world_fishing_map(map.number)
+		if named == 0:
+			continue
+		var rows: Array = _r.data.world_fishing_group(named).get("slots", [])
+		_r.check(rows.size() >= 1 and rows.size() <= Gen1Layout.SUPER_ROD_MAX_SLOTS,
+			"map %d fishes over %d slots." % [map.number, rows.size()])
+		for slot: Dictionary in rows:
+			_r.check(
+				slot.has("threshold") == (_r.game_id == RomRegistry.YELLOW),
+				"map %d's rod slot carries the wrong pick." % map.number
+			)
+
+
+static func _gen1_rows(slots: Array) -> Array:
+	var out: Array = []
+	for slot: Dictionary in slots:
+		out.append([int(slot["level"]), int(slot["species"])])
+	return out
 
 
 ## `UpdateRoamMons` and `JumpRoamMon` over the whole of `RoamMaps` on each

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -7,10 +7,13 @@ extends SceneTree
 ## without a red square is a real disagreement rather than a rendering offset.
 ## Objects are not drawn: this is the map's own answer.
 
-## Generation 1 is named by one flat map id and draws in the four Game Boy greys,
-## its colours being a Super Game Boy packet built from that id.
+## Generation 1 is named by one flat map id, and its four colours are the Super
+## Game Boy packet `SetPal_Overworld` builds from it. An indoor map the routine
+## does not name reads `wLastMap`, which no map carries, so a third argument
+## supplies it and a run without one draws `PAL_ROUTE`.
 ##   Godot --headless --path . -s res://tools/preview_collision.gd -- crystal 26 2 /tmp/route31.png
 ##   Godot --headless --path . -s res://tools/preview_collision.gd -- red 0 /tmp/pallet.png
+##   Godot --headless --path . -s res://tools/preview_collision.gd -- red 40 0 /tmp/oaks_lab.png
 
 const SCALE: int = 3
 const WALL_TINT: Color = Color(1.0, 0.0, 0.0, 0.75)
@@ -23,7 +26,8 @@ const CHECKER: int = 4
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
 	if args.size() < 3:
-		push_error("Usage: -s tools/preview_collision.gd -- <game> [group] <number> <output.png>")
+		push_error("Usage: -s tools/preview_collision.gd -- <game> [group] <number> <output.png>"
+			+ " (Generation 1: <game> <number> [last map] <output.png>)")
 		quit(1)
 		return
 	var out_path: String = args[args.size() - 1]
@@ -35,9 +39,12 @@ func _initialize() -> void:
 		push_error("No cache for %s. Import roms/%s first." % [args[0], args[0]])
 		quit(1)
 		return
-	# A three-argument call is Generation 1's group 0.
-	var group: int = int(args[1]) if args.size() > 3 else 0
-	var number: int = int(args[args.size() - 2])
+	# Generation 1 is one flat map id, so its optional third argument is
+	# `wLastMap` where Generation 2's second is the map group.
+	var flat: bool = data.generation == RomRegistry.GEN1 or args.size() <= 3
+	var group: int = 0 if flat else int(args[1])
+	var number: int = int(args[1]) if flat else int(args[2])
+	var last_map: int = int(args[2]) if flat and args.size() > 3 else -1
 
 	var map: Gen2WorldMap = data.world_map(group, number)
 	var tileset: Gen2WorldTileset = data.world_tileset(map.tileset) if map != null else null
@@ -46,7 +53,7 @@ func _initialize() -> void:
 		quit(1)
 		return
 
-	var image: Image = _draw_map(data, map, tileset)
+	var image: Image = _draw_map(data, map, tileset, last_map)
 	_tint_permissions(image, map, tileset, data.generation)
 	image.resize(image.get_width() * SCALE, image.get_height() * SCALE, Image.INTERPOLATE_NEAREST)
 	if image.save_png(out_path) != OK:
@@ -59,9 +66,11 @@ func _initialize() -> void:
 	quit(0)
 
 
-func _draw_map(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Image:
+func _draw_map(
+	data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset, last_map: int
+) -> Image:
 	var indices: PackedByteArray = data.map_tile_indices(map, tileset)
-	var palettes: Array = _tile_palettes(data, map, tileset)
+	var palettes: Array = _tile_palettes(data, map, tileset, last_map)
 	var strip_width: int = tileset.tile_count * PokeTiles.TILE_WIDTH
 	var image := Image.create(
 		map.collision_width * CELL_PIXELS, map.collision_height * CELL_PIXELS,
@@ -92,15 +101,12 @@ func _draw_map(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> 
 	return image
 
 
-## One palette per tile of the strip; Generation 1 assigns none, so all four
-## greys.
-func _tile_palettes(data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
+## One palette per tile of the strip.
+func _tile_palettes(
+	data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset, last_map: int
+) -> Array:
 	if data.generation == RomRegistry.GEN1:
-		var greys: PackedColorArray = PokePalette.monochrome()
-		var out: Array = []
-		out.resize(tileset.tile_count)
-		out.fill(greys)
-		return out
+		return Gen2WorldPalette.gen1_tile_palettes(data, map, tileset, last_map)
 	return Gen2WorldPalette.tile_palettes(
 		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1
 	)

--- a/tools/preview_overworld_sprites.gd
+++ b/tools/preview_overworld_sprites.gd
@@ -1,13 +1,13 @@
 extends SceneTree
 
-## Draws every overworld sprite a cache holds as one contact sheet, so a human can
-## see at a glance whether the strip was read at the right offset and the frames
-## composed the right way round. Each sprite is a four-by-four block: the four
-## facings across and the four `Facings` frames down, so a correct walking sprite
-## reads as two poses alternating with the right column mirroring the left. A big
-## object draws as a scramble, which is a known gap:
-## [method Gen2WorldSprite.image_for] only knows the four-tile layout, not the
-## sixteen-tile 32x32 one.
+## Draws every overworld sprite a cache holds as one contact sheet, so a human
+## can see whether the strip was read at the right offset and the frames composed
+## the right way round. Each sprite is a four-by-four block: the four facings
+## across and the four `Facings` frames down, so a correct walking sprite reads
+## as two poses alternating with the right column mirroring the left. A big
+## object draws as a scramble: [method Gen2WorldSprite.image_for] knows only the
+## four-tile layout. Generation 1's sheets read the same way, its
+## `SpriteFacingAndAnimationTable` using the same order and the same $80 offset.
 
 const CELL: int = 16
 const COLUMNS: int = 8
@@ -34,7 +34,12 @@ func _initialize() -> void:
 		return
 
 	var count: int = data.overworld_sprite_count()
-	var rows: int = ceili(float(count) / float(COLUMNS)) + 1
+	# Generation 1 draws nothing over an object, so it takes no effects row.
+	var effects: Array[String] = []
+	if data.generation != RomRegistry.GEN1:
+		effects.append_array(Gen2Layout.EMOTE_NAMES)
+		effects.append("headbutt_tree")
+	var rows: int = ceili(float(count) / float(COLUMNS)) + (1 if not effects.is_empty() else 0)
 	var sheet := Image.create(COLUMNS * TILE_W, rows * TILE_H, false, Image.FORMAT_RGBA8)
 	sheet.fill(BACKGROUND)
 	for number: int in range(1, count + 1):
@@ -42,9 +47,7 @@ func _initialize() -> void:
 		if sprite == null:
 			continue
 		var indices: PackedByteArray = data.overworld_sprite_indices(number)
-		var palette: PackedColorArray = data.overworld_sprite_palette(
-			sprite.default_palette, Gen2WorldPalette.TIME_DAY
-		)
+		var palette: PackedColorArray = _sprite_palette(data, sprite)
 		var at := Vector2i(
 			((number - 1) % COLUMNS) * TILE_W + 1,
 			((number - 1) / COLUMNS) * TILE_H + 1
@@ -62,7 +65,7 @@ func _initialize() -> void:
 	## facings and no frames: a wrong offset shows up as noise here.
 	var effects_top: int = (rows - 1) * TILE_H + 1
 	var at_x: int = 1
-	for name: String in Gen2Layout.EMOTE_NAMES + ["headbutt_tree"] as Array[String]:
+	for name: String in effects:
 		var effect: Dictionary = data.overworld_effect(name)
 		if effect.is_empty():
 			continue
@@ -94,3 +97,11 @@ func _initialize() -> void:
 		args[0], count, COLUMNS,
 	])
 	quit(0)
+
+
+## A Generation 1 sprite carries no palette: `SetPal_Overworld` gives the screen
+## one `SuperPalettes` row and `rOBP0` remaps it, so the sheet shows a route's.
+func _sprite_palette(data: GameData, sprite: Gen2WorldSprite) -> PackedColorArray:
+	if data.generation == RomRegistry.GEN1:
+		return Gen2WorldPalette.gen1_object_colors(data.world_palette(Gen1Layout.PAL_ROUTE))
+	return data.overworld_sprite_palette(sprite.default_palette, Gen2WorldPalette.TIME_DAY)


### PR DESCRIPTION
## Added

`SetPal_Overworld` lands in `Gen1Layout.overworld_palette`: the CEMETERY and CAVERN tilesets answer before the map id is read, a city's row is its own id plus one, everything past the last city shares `PAL_ROUTE`, and the four named indoor branches sit in front of `wLastMap`. Yellow names the Trade Center and the Colosseum where Red and Blue let both fall through.

`SuperPalettes` is imported whole, 37 rows or Yellow's 40, and `Gen2WorldPalette.gen1_tile_palettes` hands one of them to every tile the way `BlkPacket_WholeScreen` does. An object on the map wears the same four through `GBPalNormal`'s `rOBP0`, %11010000, so a sprite never shows the palette's third colour.

`SpriteSheetPointerTable`'s 72 sheets, or Yellow's 82, decode into the shared overworld sprite section. `LoadMapSpriteTilePatterns` reads a walking row twice, the second time $C0 further on, which is the shape `GetUsedSprite` already reads, so `Gen2WorldSprite` draws either generation's strip with no branch in it.

`WildDataPointers` gives 55 grass tables on every cartridge, 3 water on Red and Blue and 8 on Yellow. `SuperRodData`'s map index resolves to 10 groups picked by rejecting a two-bit roll; Yellow's `SuperRodFishingSlots` is 31 rows of four slots picked by a byte threshold. `WildMonEncounterSlotChances` and `GoodRodMons` stay constants and are read back off the cartridge at import.

`tools/preview_collision.gd` draws a Generation 1 map in its own colours and takes `wLastMap` as a third argument. `tools/preview_overworld_sprites.gd` draws either generation's sheets. `gen1_maps` pins every branch of the palette routine plus the corpus census, and `wild_encounters` sweeps the Generation 1 tables beside the Generation 2 ones.

## Changed

`bank_of` moves from `Gen2Layout` to `RomFile`, beside `linear`: the bank an offset falls in is a property of the dump rather than of one generation's layout. 22 call sites follow it.

Cache format 105. All six cartridges re-import and report `Layout verified.`

## Removed

The `probabilities` section leaves `world_encounters.json`. It was a copy of `Gen2Layout.WILD_GRASS_PROBABILITIES` and `WILD_WATER_PROBABILITIES` that nothing ever read back.

## Verified

| Run | Result |
|---|---|
| `gut` unit and scene tiers | 4303 tests, 0 failures |
| `validate.gd -- all` | 70 topics, 0 failures |
| Editor analyser | 0 warnings in 626 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | `ok`, 16 badges each |
| Import | 6/6, `Layout verified.` on each |