### PR TITLE
Walk a Generation 1 map on the world screen

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -201,6 +201,13 @@ const MAX_SIGN_EVENTS: int = 16
 const MAX_OBJECT_EVENTS: int = 16
 ## `warp_event`'s indoor exit: `wLastMap`, the outdoor map the player came from.
 const WARP_TO_LAST_MAP: int = 0xFF
+## `ExtraWarpCheck`'s four named maps, which take the warp-carpet test their own
+## tileset would not give them, and the two the routine answers by hand:
+## SS Anne 3F asks for the map edge instead, and the Bow has one carpet tile.
+const WARP_CARPET_MAPS: Array[int] = [0x52, 0xC7, 0xC8, 0xCA]
+const MAP_SS_ANNE_3F: int = 0x61
+const MAP_SS_ANNE_BOW: int = 0x63
+const SS_ANNE_BOW_WARP_TILE: int = 0x15
 
 ## The map ids `SetPal_Overworld` splits on; only the link rooms are Yellow's.
 const NUM_CITY_MAPS: int = 0x0B
@@ -245,9 +252,15 @@ const TILESET_BLOCKS_YELLOW: Array[int] = [
 const TILESET_LIST_END: int = 0xFF
 const WATER_TILE: int = 0x14
 
-## The two tilesets `SetPal_Overworld` tests before it looks at the map id.
+## The two tilesets `SetPal_Overworld` tests before the map id, the two
+## `CheckIfInOutsideMap` calls a town or a route, and the two beside them that
+## `ExtraWarpCheck` reads a carpet on.
 const TILESET_CEMETERY: int = 15
 const TILESET_CAVERN: int = 17
+const TILESET_OVERWORLD: int = 0
+const TILESET_PLATEAU: int = 23
+const TILESET_SHIP: int = 13
+const TILESET_SHIP_PORT: int = 14
 
 ## `WildDataPointers`, one `dw` a map id and $FFFF behind the last. A block is
 ## its rate byte alone when the rate is zero and `WILDDATA_LENGTH` otherwise,
@@ -533,6 +546,21 @@ static func pic_bank(layout: Dictionary, index: int) -> int:
 ## behind Agatha's room.
 static func map_count(id: StringName) -> int:
 	return MAP_COUNT_YELLOW if id == RomRegistry.YELLOW else MAP_COUNT_RED_BLUE
+
+
+## `CheckIfInOutsideMap`: which maps write `wLastMap` on the way out of them.
+static func is_outside_tileset(tileset: int) -> bool:
+	return tileset == TILESET_OVERWORLD or tileset == TILESET_PLATEAU
+
+
+## `ExtraWarpCheck`: whether a warp the player is not standing on the tile of
+## asks for a carpet in front of them rather than for the edge of the map.
+static func warp_wants_carpet(map_id: int, tileset: int) -> bool:
+	if map_id == MAP_SS_ANNE_3F:
+		return false
+	if WARP_CARPET_MAPS.has(map_id):
+		return true
+	return tileset in [TILESET_OVERWORLD, TILESET_SHIP, TILESET_SHIP_PORT, TILESET_PLATEAU]
 
 
 static func tileset_count(id: StringName) -> int:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -469,6 +469,7 @@ func _init(
 	world_rules: Gen2Rules = null,
 ) -> void:
 	data = game_data
+	_gen1 = data != null and data.generation == RomRegistry.GEN1
 	# Opening a world is the run starting, so its rules become the installed ones:
 	# the statics that read them ([Gen2Experience], [Gen2Damage], [Gen2BattleAI])
 	# take no world object, and one installed set is what keeps them from
@@ -1265,7 +1266,7 @@ func facing_direction() -> Vector2i:
 func object_facing_cell() -> Vector2i:
 	var direction: Vector2i = _direction_for_facing(player_facing)
 	var faced: Vector2i = player_cell + direction
-	if Gen2WorldCollision.is_counter(collision_code_at(faced)):
+	if Gen2WorldCollision.is_counter(gen2_code_at(faced)):
 		return faced + direction
 	return faced
 
@@ -1431,8 +1432,7 @@ func surf_request(species: int = 0) -> Dictionary:
 	var direction: Vector2i = _direction_for_facing(player_facing)
 	# CheckDirection: the standing cell's own permissions must not wall off the
 	# way the player faces.
-	var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
-	if face != 0 and (tile_permissions_at(player_cell) & face) != 0:
+	if _edge_step_blocked(player_cell, collision_code_at(target), direction):
 		return _surf_failure(&"cannot_surf")
 	# CheckFacingObject is Crystal only. pokegold's .TrySurf omits it and carries
 	# the "You can Surf on top of NPCs" bug comment.
@@ -2198,7 +2198,7 @@ func can_encounter_wild_mon() -> bool:
 func can_encounter_wild_mon_at(cell: Vector2i) -> bool:
 	if state.wild_encounters_off():
 		return false
-	var code: int = collision_code_at(cell)
+	var code: int = gen2_code_at(cell)
 	var environment: int = current_map.environment if current_map != null else 0
 	if environment != ENVIRONMENT_CAVE and environment != ENVIRONMENT_DUNGEON \
 		and not Gen2WorldCollision.gates_encounter(code):
@@ -2406,7 +2406,7 @@ func _bug_contest_request(
 ) -> Dictionary:
 	var contest: Dictionary = Gen2WorldBugContest.resolve(
 		data.bug_contest_mons(),
-		Gen2WorldCollision.is_long_grass(collision_code_at(player_cell)),
+		Gen2WorldCollision.is_long_grass(gen2_code_at(player_cell)),
 		random if random != null else RandomNumberGenerator.new(),
 		force_encounter,
 		{
@@ -2974,7 +2974,7 @@ func take_grass_rustles() -> Array:
 	var out: Array = []
 	if _player_step_began:
 		_player_step_began = false
-		if Gen2WorldCollision.is_grass(collision_code_at(player_cell)):
+		if Gen2WorldCollision.is_grass(gen2_code_at(player_cell)):
 			out.append({
 				"object_index": -1,
 				"cell": player_cell,
@@ -2986,7 +2986,7 @@ func take_grass_rustles() -> Array:
 		object.step_began = false
 		if not object.active or object.deleted:
 			continue
-		if not Gen2WorldCollision.is_grass(collision_code_at(object.cell)):
+		if not Gen2WorldCollision.is_grass(gen2_code_at(object.cell)):
 			continue
 		out.append({
 			"object_index": object.index,
@@ -3283,7 +3283,7 @@ func warp_index_at(cell: Vector2i) -> int:
 func stone_queue_script(boulder: Gen2WorldObject) -> Dictionary:
 	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
 		return {}
-	if not Gen2WorldCollision.is_pit_tile(collision_code_at(boulder.cell)):
+	if not Gen2WorldCollision.is_pit_tile(gen2_code_at(boulder.cell)):
 		return {}
 	var warp: int = warp_index_at(boulder.cell)
 	if warp <= 0:
@@ -3614,6 +3614,14 @@ static func _overridden_block_at(
 	return map.block_at(block_x, block_y)
 
 
+## Whether this world is a Generation 1 one, which decides every question below:
+## its collision grid holds the tile a cell draws rather than a permission byte.
+var _gen1: bool = false
+## `wLastMap`, the outdoor map a [constant Gen1Layout.WARP_TO_LAST_MAP] warp
+## comes back out to. Generation 2 has no such warp and never writes it.
+var _gen1_last_map: int = -1
+
+
 ## The raw cartridge permission byte at a walk cell.
 ##
 ## The imported grid already holds the code the tileset gave each cell, so it is
@@ -3630,6 +3638,11 @@ func collision_code_at(cell: Vector2i) -> int:
 	var block: int = block_at(block_x, block_y)
 	if block == current_map.block_at(block_x, block_y):
 		return current_map.collision_at(cell.x, cell.y)
+	if _gen1:
+		return current_tileset.tile_index(block, Gen1Layout.cell_tile_index(
+			cell.x & (Gen2Layout.MAP_BLOCK_CELL_WIDTH - 1),
+			cell.y & (Gen2Layout.MAP_BLOCK_CELL_WIDTH - 1),
+		))
 	return current_tileset.collision_index(
 		block,
 		cell.x & (Gen2Layout.MAP_BLOCK_CELL_WIDTH - 1),
@@ -3637,8 +3650,47 @@ func collision_code_at(cell: Vector2i) -> int:
 	)
 
 
+## `wLastMap`, which a Generation 1 indoor map's four colours are chosen by when
+## `SetPal_Overworld` names no branch of its own. -1 until a warp writes it.
+func gen1_last_map() -> int:
+	return _gen1_last_map
+
+
+## A Generation 2 collision code at [param cell], or -1 on a Generation 1 map,
+## whose grid holds the tile a cell draws instead. Grass, ice, pits, counters,
+## warp carpets and the forced tiles are all families of that code, and -1
+## answers no to every one of them.
+func gen2_code_at(cell: Vector2i) -> int:
+	return -1 if _gen1 else collision_code_at(cell)
+
+
 func collision_permission_at(cell: Vector2i) -> int:
-	return Gen2WorldCollision.permission_for(collision_code_at(cell))
+	return permission_for_code(collision_code_at(cell))
+
+
+## `CollisionPermissionTable`, or Generation 1's `CheckTilePassable` against the
+## tileset of the map the code was read from, which defaults to the loaded one.
+func permission_for_code(code: int, tileset: Gen2WorldTileset = null) -> int:
+	if not _gen1:
+		return Gen2WorldCollision.permission_for(code)
+	return Gen2WorldCollision.gen1_permission(
+		tileset if tileset != null else current_tileset, code
+	)
+
+
+## The leave-side test one step owes: `GetMovementPermissions`' face mask in
+## Generation 2, and `CheckForTilePairCollisions` in Generation 1, which reads
+## the faced tile as well as the one stood on.
+func _edge_step_blocked(from: Vector2i, to_code: int, direction: Vector2i) -> bool:
+	var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
+	if face == 0:
+		return false
+	if not _gen1:
+		return (tile_permissions_at(from) & face) != 0
+	return Gen2WorldCollision.gen1_pair_blocked(
+		current_map.tileset, collision_code_at(from), to_code,
+		movement_mode == MOVEMENT_SURF
+	)
 
 
 ## home/map.asm's GetMovementPermissions for a player standing at [param cell]:
@@ -3944,10 +3996,9 @@ func _surf_prompt_applies(cell: Vector2i) -> bool:
 		return false
 	if collision_permission_at(cell) != Gen2WorldCollision.WATER_TILE:
 		return false
-	var face: int = Gen2WorldCollision.face_mask_for_direction(
-		_direction_for_facing(player_facing)
+	return not _edge_step_blocked(
+		player_cell, collision_code_at(cell), _direction_for_facing(player_facing)
 	)
-	return face == 0 or (tile_permissions_at(player_cell) & face) == 0
 
 
 ## engine/events/std_collision.asm's CheckFacingTileForStdScript. Keyed by the
@@ -3958,7 +4009,7 @@ func _surf_prompt_applies(cell: Vector2i) -> bool:
 func _tile_collision_script_request(cell: Vector2i) -> Dictionary:
 	if current_map == null or data == null:
 		return {}
-	var collision: int = collision_code_at(cell)
+	var collision: int = gen2_code_at(cell)
 	var index: int = Gen2WorldCollision.tile_collision_std_index(
 		collision, Gen2WorldState.is_crystal_profile(data)
 	)
@@ -5170,9 +5221,12 @@ func _apply_script_warp(request: Dictionary) -> Dictionary:
 ## which clears carry on the four warp carpets: landing on one of those warps
 ## nothing, and only [method edge_warp_ready] takes it.
 func warp_pending(cell: Vector2i = player_cell) -> bool:
+	if warp_at(cell).is_empty():
+		return false
+	if _gen1:
+		return _warp_tile_allows(cell)
 	var code: int = collision_code_at(cell)
-	return not warp_at(cell).is_empty() \
-		and Gen2WorldCollision.is_warp_tile(code) \
+	return Gen2WorldCollision.is_warp_tile(code) \
 		and not Gen2WorldCollision.is_directional_warp(code)
 
 
@@ -5181,7 +5235,7 @@ func warp_pending(cell: Vector2i = player_cell) -> bool:
 ## warp. The press takes the warp instead of bumping, which is why an interior
 ## door is stood on first and walked into afterwards.
 func edge_warp_ready(direction: Vector2i) -> bool:
-	var code: int = collision_code_at(player_cell)
+	var code: int = gen2_code_at(player_cell)
 	if Gen2WorldCollision.directional_warp_direction(code) != direction:
 		return false
 	## `ld a, [wPlayerDirection] / rrca / rrca` against wWalkingDirection: the
@@ -5191,6 +5245,55 @@ func edge_warp_ready(direction: Vector2i) -> bool:
 	return not warp_at(player_cell).is_empty()
 
 
+## `LoadTileBlockMap` fills the three blocks past every edge with the map's own
+## border block, so `_GetTileAndCoordsInFrontOfPlayer` reads that rather than
+## nothing at the edge. -1 stays -1 where the border block is the $FF naming none.
+func _gen1_tile_drawn_at(cell: Vector2i) -> int:
+	var code: int = collision_code_at(cell)
+	if code >= 0 or current_map == null or current_tileset == null \
+		or current_map.border_block >= current_tileset.block_count:
+		return code
+	return current_tileset.tile_index(current_map.border_block, Gen1Layout.cell_tile_index(
+		posmod(cell.x, Gen2Layout.MAP_BLOCK_CELL_WIDTH),
+		posmod(cell.y, Gen2Layout.MAP_BLOCK_CELL_WIDTH)
+	))
+
+
+## Where a warp puts the player: the destination's own cell, unless
+## `LoadTilesetHeader`'s gate skips `LoadDestinationWarpPosition` altogether
+## ([constant Gen2WorldCollision.GEN1_DUNGEON_TILESETS]).
+func _warp_landing_cell(
+	target_map: Gen2WorldMap, target_warp: Dictionary, from: Vector2i
+) -> Vector2i:
+	if _gen1 and target_map.tileset == current_map.tileset \
+		and not Gen2WorldCollision.gen1_is_dungeon_tileset(target_map.tileset):
+		return from
+	return Vector2i(int(target_warp["x"]), int(target_warp["y"]))
+
+
+## `CheckWarpCollision` in Generation 2, and `CheckWarpsNoCollision`'s own pair
+## of tests in Generation 1: a warp fires at once off a warp or a door tile, and
+## otherwise wants a carpet or the edge of the map in front of the player, who
+## is still holding the direction that walked them onto it.
+func _warp_tile_allows(cell: Vector2i) -> bool:
+	var standing: int = collision_code_at(cell)
+	if not _gen1:
+		return Gen2WorldCollision.is_warp_tile(standing)
+	var tileset: int = current_map.tileset
+	if Gen2WorldCollision.gen1_is_warp_tile(tileset, standing) \
+		or Gen2WorldCollision.gen1_is_door_tile(tileset, standing):
+		return true
+	var direction: Vector2i = _direction_for_facing(player_facing)
+	var ahead: Vector2i = cell + direction
+	if current_map.number == Gen1Layout.MAP_SS_ANNE_BOW:
+		return _gen1_tile_drawn_at(ahead) == Gen1Layout.SS_ANNE_BOW_WARP_TILE
+	## `IsPlayerFacingEdgeOfMap` compares the player's own coordinate against the
+	## map, where the carpet test reads the drawn tile and so sees the border.
+	if not Gen1Layout.warp_wants_carpet(current_map.number, tileset):
+		return collision_code_at(ahead) < 0
+	return Gen2WorldCollision.gen1_is_warp_carpet(direction, _gen1_tile_drawn_at(ahead))
+
+
 func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	var source_warp: Dictionary = warp_at(cell)
 	if source_warp.is_empty():
@@ -5198,10 +5301,14 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	## CheckWarpCollision gates every warp on the tile's own code, so a
 	## warp_event sitting on ordinary floor never fires. Burned Tower B1F's
 	## (10,8) is one, and the walk to the beasts crosses it.
-	if not Gen2WorldCollision.is_warp_tile(collision_code_at(cell)):
+	if not _warp_tile_allows(cell):
 		return {}
 	var target_group: int = int(source_warp.get("map_group", -1))
 	var target_number: int = int(source_warp.get("map_number", -1))
+	## `.goBackOutside`: a Generation 1 indoor warp names `LAST_MAP` rather than a
+	## map of its own, and comes back out to the town or route it was entered from.
+	if _gen1 and target_number == Gen1Layout.WARP_TO_LAST_MAP:
+		target_number = _gen1_last_map
 	var target_map: Gen2WorldMap = data.world_map(target_group, target_number) if data != null else null
 	if target_map == null:
 		return {
@@ -5216,8 +5323,12 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	## warp and no map of its own, and the three bytes at `wBackupWarpNumber` are
 	## read contiguously in its place. The map named beside such a byte is a
 	## placeholder (POKECENTER_2F names itself), so it is replaced too.
-	var destination_index: int = int(source_warp.get("destination", 0)) - 1
-	if int(source_warp.get("destination", 0)) == BACKUP_WARP_DESTINATION:
+	## `warp_event` writes `\4 - 1`, so Generation 1's stored byte already indexes
+	## the destination map's warps where Generation 2's counts from one.
+	var destination_index: int = int(source_warp.get("destination", 0))
+	if not _gen1:
+		destination_index -= 1
+	if not _gen1 and int(source_warp.get("destination", 0)) == BACKUP_WARP_DESTINATION:
 		if backup_warp.is_empty():
 			return {
 				"ok": false,
@@ -5265,7 +5376,7 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	## itself a -1 warp records the warp and the map the player came from, and
 	## that is what walking back out of it spends. Behind the read above, as in
 	## the source, so a -1 warp taken back out of a -1 warp reads the old value.
-	if int(target_warp.get("destination", 0)) == BACKUP_WARP_DESTINATION:
+	if not _gen1 and int(target_warp.get("destination", 0)) == BACKUP_WARP_DESTINATION:
 		var walked: int = warp_index_at(cell)
 		if walked > 0:
 			backup_warp = {
@@ -5275,9 +5386,8 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	# Rope comes back out of. `WarpToNewMapScript`, the pitfall and the magnet
 	# train name DOOR, FALL and TRAIN, which are one setup-script body.
 	_apply_map(
-		target_map, target_tileset,
-		Vector2i(int(target_warp["x"]), int(target_warp["y"])), false,
-		warp_index_at(cell), MAP_ENTRY_DOOR
+		target_map, target_tileset, _warp_landing_cell(target_map, target_warp, cell),
+		false, warp_index_at(cell), MAP_ENTRY_DOOR
 	)
 	return {
 		"ok": true,
@@ -5435,11 +5545,11 @@ func can_walk_to(cell: Vector2i, direction: Vector2i = Vector2i.ZERO) -> bool:
 func _connection_step_allows(
 	target_map: Gen2WorldMap, target_cell: Vector2i, direction: Vector2i
 ) -> bool:
-	var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
-	if face != 0 and (tile_permissions_at(player_cell) & face) != 0:
+	var target_code: int = target_map.collision_at(target_cell.x, target_cell.y)
+	if _edge_step_blocked(player_cell, target_code, direction):
 		return false
-	var permission: int = Gen2WorldCollision.permission_for(
-		target_map.collision_at(target_cell.x, target_cell.y)
+	var permission: int = permission_for_code(
+		target_code, data.world_tileset(target_map.tileset) if data != null else null
 	)
 	if movement_mode == MOVEMENT_SURF:
 		if collision_permission_at(player_cell) == Gen2WorldCollision.WATER_TILE:
@@ -5455,10 +5565,9 @@ func _step_permission_allows(cell: Vector2i, direction: Vector2i) -> bool:
 	if current_map == null or cell.x < 0 or cell.y < 0 \
 		or cell.x >= current_map.collision_width or cell.y >= current_map.collision_height:
 		return false
-	if direction != Vector2i.ZERO:
-		var face: int = Gen2WorldCollision.face_mask_for_direction(direction)
-		if face != 0 and (tile_permissions_at(player_cell) & face) != 0:
-			return false
+	if direction != Vector2i.ZERO \
+		and _edge_step_blocked(player_cell, collision_code_at(cell), direction):
+		return false
 	var permission: int = collision_permission_at(cell)
 	if movement_mode == MOVEMENT_SURF:
 		var current_permission: int = collision_permission_at(player_cell)
@@ -5490,9 +5599,11 @@ func can_object_walk_to(
 	var wanted: int = Gen2WorldCollision.WATER_TILE if moving.is_swimming() \
 		else Gen2WorldCollision.LAND_TILE
 	for checked: Vector2i in checked_cells:
-		if Gen2WorldCollision.permission_for(collision_code_at(checked)) != wanted:
+		if permission_for_code(collision_code_at(checked)) != wanted:
 			return false
-	if direction != Vector2i.ZERO and Gen2WorldCollision.side_wall_step_blocked(
+	# `CheckForTilePairCollisions` is the player's own routine, so a Generation 1
+	# map object has no leave-side rule at all.
+	if not _gen1 and direction != Vector2i.ZERO and Gen2WorldCollision.side_wall_step_blocked(
 		collision_code_at(moving.cell), collision_code_at(cell), direction
 	):
 		return false
@@ -6070,7 +6181,7 @@ func move_result(direction: Vector2i) -> Dictionary:
 	## branch sits in front of `.BikeCheck`.
 	var kind_of_step: StringName = STEP_KIND_WALK
 	var passes: int = _step_frames_for_movement()
-	if Gen2WorldCollision.is_ice(collision_code_at(from_cell)):
+	if Gen2WorldCollision.is_ice(gen2_code_at(from_cell)):
 		kind_of_step = &"fast_slide_step"
 		passes = STEP_PASSES_FAST
 	player_cell = destination
@@ -6097,7 +6208,7 @@ func _refused_move(direction: Vector2i, reason: StringName) -> Dictionary:
 	_stand_in_place()
 	var into_carpet: bool = movement_mode != MOVEMENT_SURF \
 		and Gen2WorldCollision.directional_warp_direction(
-			collision_code_at(player_cell)
+			gen2_code_at(player_cell)
 		) == direction
 	return {"ok": false, "kind": &"move", "reason": reason, "bump": not into_carpet}
 
@@ -6128,7 +6239,7 @@ func note_standing_still() -> void:
 func standing_on_ice() -> bool:
 	if _player_turning_direction == 0 or current_map == null:
 		return false
-	return Gen2WorldCollision.is_ice(collision_code_at(player_cell))
+	return Gen2WorldCollision.is_ice(gen2_code_at(player_cell))
 
 
 ## `.CheckForced`, then `.GetAction`. `and PAD_BUTTONS` drops the whole d-pad
@@ -6145,7 +6256,7 @@ func effective_input_direction(held: Vector2i) -> Vector2i:
 func forced_movement() -> Dictionary:
 	if current_map == null:
 		return {"kind": &"none"}
-	return Gen2WorldCollision.forced_action(collision_code_at(player_cell))
+	return Gen2WorldCollision.forced_action(gen2_code_at(player_cell))
 
 
 ## Whatever the standing tile forces, with no input: the source polls .CheckTile
@@ -6229,7 +6340,7 @@ func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary
 	var boulder: Gen2WorldObject = object_at(destination)
 	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
 		return {}
-	if Gen2WorldCollision.is_pit_tile(collision_code_at(boulder.cell)):
+	if Gen2WorldCollision.is_pit_tile(gen2_code_at(boulder.cell)):
 		return {}
 	var landing: Vector2i = boulder.cell + direction
 	# CanObjectMoveInDirection with the boulder's own flags: WONT_DELETE,
@@ -6285,7 +6396,7 @@ func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary
 func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 	if movement_mode == MOVEMENT_SURF:
 		return {}
-	if not Gen2WorldCollision.allows_hop(collision_code_at(player_cell), direction):
+	if not _allows_hop(direction):
 		return {}
 	var landing: Vector2i = player_cell + direction * 2
 	if landing.x < 0 or landing.y < 0 \
@@ -6308,6 +6419,18 @@ func _try_ledge_hop(direction: Vector2i) -> Dictionary:
 		"to_map": from_map,
 		"to_cell": player_cell,
 	}
+
+
+## `HandleLedges` reads the faced tile as well as the one stood on, and runs in
+## front of the passability check rather than behind it. A ledge tile is never
+## passable, so the step is refused either way and the hop is the same one.
+func _allows_hop(direction: Vector2i) -> bool:
+	if not _gen1:
+		return Gen2WorldCollision.allows_hop(collision_code_at(player_cell), direction)
+	return Gen2WorldCollision.gen1_allows_hop(
+		current_map.tileset, collision_code_at(player_cell),
+		collision_code_at(player_cell + direction), direction
+	)
 
 
 ## Moves exactly one walk cell in a cardinal direction, or two when a ledge
@@ -6447,6 +6570,10 @@ func _apply_map(
 		target_map.group, target_map.number, target_map.tileset, target_cell,
 	])
 	_record_escape_points(target_map, from_warp)
+	## `WarpFound2`'s `CheckIfInOutsideMap`: leaving a town or a route records it,
+	## and that is the map a `LAST_MAP` warp comes back out to.
+	if _gen1 and current_map != null and Gen1Layout.is_outside_tileset(current_map.tileset):
+		_gen1_last_map = current_map.number
 	## `RefreshPlayerSprite` clears `wPlayerTurningDirection`, and every warp and
 	## connection reaches it, so a slide never survives a map change.
 	_stand_in_place()
@@ -6496,7 +6623,7 @@ func _apply_map(
 	# face its automatic downward exit instead of retaining the direction used on
 	# the previous map.
 	if not custom_facing and Gen2WorldCollision.faces_down_on_spawn(
-		collision_code_at(player_cell)
+		gen2_code_at(player_cell)
 	):
 		player_facing = Gen2WorldSprite.FACING_DOWN
 	_apply_map_setup_player_state()

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -479,3 +479,122 @@ static func tile_collision_std_index(collision_code: int, is_crystal: bool) -> i
 	var table: Dictionary = TILE_COLLISION_STD_INDEX_CRYSTAL if is_crystal \
 		else TILE_COLLISION_STD_INDEX_GOLD_SILVER
 	return int(table.get(collision_code, -1))
+
+
+## Generation 1 keeps no permission table. `CheckTilePassable` walks the
+## tileset's own list of walkable tiles and the six tables below are the rest of
+## what one step reads. Every byte is the same in Red, Blue and Yellow but for
+## the two rows Yellow adds, each named where it sits.
+
+## `TilePairCollisionsLand` and `TilePairCollisionsWater`, by tileset: two tiles
+## the player may not cross between, in either order.
+const GEN1_TILE_PAIRS_LAND: Dictionary = {
+	3: [[0x30, 0x2E], [0x52, 0x2E], [0x55, 0x2E], [0x56, 0x2E], [0x20, 0x2E],
+		[0x5E, 0x2E], [0x5F, 0x2E]],
+	17: [[0x20, 0x05], [0x41, 0x05], [0x2A, 0x05], [0x05, 0x21]],
+}
+const GEN1_TILE_PAIRS_WATER: Dictionary = {
+	3: [[0x14, 0x2E], [0x48, 0x2E]],
+	17: [[0x14, 0x05]],
+}
+
+## `LedgeTiles`: the facing, the tile stood on and the ledge tile. Its fourth
+## column is the press the hop needs, which is the facing again in all eight
+## rows. `HandleLedges` returns before reading the table off any tileset but
+## OVERWORLD.
+const GEN1_LEDGES: Array = [
+	[FACE_DOWN, 0x2C, 0x37], [FACE_DOWN, 0x39, 0x36], [FACE_DOWN, 0x39, 0x37],
+	[FACE_LEFT, 0x2C, 0x27], [FACE_LEFT, 0x39, 0x27],
+	[FACE_RIGHT, 0x2C, 0x0D], [FACE_RIGHT, 0x2C, 0x1D], [FACE_RIGHT, 0x39, 0x0D],
+]
+
+## `WarpTileListPointers`, the carpets `IsWarpTileInFrontOfPlayer` accepts, keyed
+## by the facing rather than by the tileset.
+const GEN1_WARP_CARPETS: Dictionary = {
+	FACE_DOWN: [0x01, 0x12, 0x17, 0x3D, 0x04, 0x18, 0x33],
+	FACE_UP: [0x01, 0x5C],
+	FACE_LEFT: [0x1A, 0x4B],
+	FACE_RIGHT: [0x0F, 0x4E],
+}
+
+## `WarpTileIDPointers`: the tiles `IsPlayerStandingOnDoorTileOrWarpTile` calls a
+## warp. A tileset with no row of its own warps from nowhere.
+const GEN1_WARP_TILES: Dictionary = {
+	0: [0x1B, 0x58], 1: [0x1A, 0x1C], 2: [0x5E], 3: [0x5A, 0x5C, 0x3A],
+	4: [0x1A, 0x1C], 5: [0x4A], 6: [0x5E], 7: [0x4A], 8: [0x54, 0x5C, 0x32],
+	9: [0x3B, 0x1A, 0x1C], 10: [0x3B, 0x1A, 0x1C], 11: [0x13],
+	12: [0x3B, 0x1A, 0x1C], 13: [0x37, 0x39, 0x1E, 0x4A], 15: [0x1B, 0x13],
+	16: [0x15, 0x55, 0x04], 17: [0x18, 0x1A, 0x22], 18: [0x1A, 0x1C, 0x38],
+	19: [0x1A, 0x1C, 0x53], 20: [0x34], 22: [0x43, 0x58, 0x20, 0x1B, 0x13],
+	23: [0x1B, 0x3B],
+}
+
+## `DoorTileIDPointers`, which is the other half of that question and the half
+## `PlayMapChangeSound` and the step out of a door read. INTERIOR is Yellow's
+## own row; every other one is in all three.
+const GEN1_DOOR_TILES: Dictionary = {
+	0: [0x1B, 0x58], 2: [0x5E], 3: [0x3A], 8: [0x54], 9: [0x3B], 10: [0x3B],
+	12: [0x3B], 13: [0x1E], 16: [0x04, 0x15], 18: [0x1C, 0x38, 0x1A],
+	19: [0x1A, 0x1C, 0x53], 20: [0x34], 22: [0x43, 0x58, 0x1B], 23: [0x3B, 0x1B],
+}
+
+## `DungeonTilesets`: `LoadTilesetHeader` skips `LoadDestinationWarpPosition`
+## when the map entered keeps the tileset already loaded and that tileset is not
+## one of these. All 162 same-tileset warp pairs the corpus ships are dungeon
+## ones, so only a mod-authored map reaches the other branch.
+const GEN1_DUNGEON_TILESETS: Array[int] = [3, 7, 10, 12, 13, 15, 17, 18, 19, 20, 22]
+
+
+## `CheckTilePassable`, with `IsNextTileShoreOrWater`'s own test in front of it,
+## as the permission a Generation 2 collision code would have answered. Tile $14
+## is water only on a `WaterTilesets` row: elsewhere it is Red's own doormat.
+static func gen1_permission(tileset: Gen2WorldTileset, tile: int) -> int:
+	if tileset == null or tile < 0:
+		return WALL_TILE
+	if tileset.water and tile == Gen1Layout.WATER_TILE:
+		return WATER_TILE
+	return LAND_TILE if tileset.tile_passable(tile) else WALL_TILE
+
+
+## `CheckForTilePairCollisions`: whether the pair of tiles stood on and faced is
+## one the tileset forbids crossing. Surfing reads the second table.
+static func gen1_pair_blocked(
+	tileset_number: int, standing: int, ahead: int, surfing: bool
+) -> bool:
+	var table: Dictionary = GEN1_TILE_PAIRS_WATER if surfing else GEN1_TILE_PAIRS_LAND
+	for pair: Array in table.get(tileset_number, []):
+		if standing == pair[0] and ahead == pair[1]:
+			return true
+		if standing == pair[1] and ahead == pair[0]:
+			return true
+	return false
+
+
+## `HandleLedges`, which runs before the passability check and hops on a match.
+static func gen1_allows_hop(
+	tileset_number: int, standing: int, ahead: int, direction: Vector2i
+) -> bool:
+	if tileset_number != Gen1Layout.TILESET_OVERWORLD:
+		return false
+	var face: int = face_mask_for_direction(direction)
+	for row: Array in GEN1_LEDGES:
+		if row[0] == face and row[1] == standing and row[2] == ahead:
+			return true
+	return false
+
+
+static func gen1_is_warp_tile(tileset_number: int, tile: int) -> bool:
+	return (GEN1_WARP_TILES.get(tileset_number, []) as Array).has(tile)
+
+
+static func gen1_is_door_tile(tileset_number: int, tile: int) -> bool:
+	return (GEN1_DOOR_TILES.get(tileset_number, []) as Array).has(tile)
+
+
+static func gen1_is_warp_carpet(direction: Vector2i, tile: int) -> bool:
+	var face: int = face_mask_for_direction(direction)
+	return (GEN1_WARP_CARPETS.get(face, []) as Array).has(tile)
+
+
+static func gen1_is_dungeon_tileset(tileset_number: int) -> bool:
+	return GEN1_DUNGEON_TILESETS.has(tileset_number)

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -183,7 +183,8 @@ const ENVIRONMENT_TOWN: int = 1
 const ENVIRONMENT_ROUTE: int = 2
 
 
-## Generation 1's answer to [method tile_palettes]. There are no eight slots:
+## What [method tile_palettes] answers on a Generation 1 cartridge. There are no
+## eight slots:
 ## `SetPal_Overworld` names one `SuperPalettes` row and the
 ## `BlkPacket_WholeScreen` behind it gives that row every attribute block, so
 ## the whole screen draws in the same four colours. [param last_map] is
@@ -218,6 +219,19 @@ static func gen1_object_colors(colors: PackedColorArray) -> PackedColorArray:
 	return PokePalette.through_shades(colors, Gen1Layout.OBJECT_SHADES)
 
 
+## `FillWhiteBGColor`, which only the fade out of the map runs: every background
+## palette takes palette 0's own colour 0, so the order that flattens a palette
+## onto it flattens the screen onto one white.
+static func _flood_white(resolved: Array) -> void:
+	if resolved.is_empty():
+		return
+	var white: Color = (resolved[0] as PackedColorArray)[0]
+	for slot: int in range(1, resolved.size()):
+		var palette: PackedColorArray = resolved[slot]
+		palette[0] = white
+		resolved[slot] = palette
+
+
 ## One palette per tile of [param tileset], in tile order.
 ##
 ## Every tile of the strip shares eight palette slots, so the eight are resolved
@@ -233,7 +247,10 @@ static func tile_palettes(
 	cave_color: int = -1,
 	fade_order: int = FADE_IDENTITY,
 	white_fill: bool = false,
+	last_map: int = -1,
 ) -> Array:
+	if data.generation == RomRegistry.GEN1:
+		return gen1_tile_palettes(data, map, tileset, last_map, fade_order)
 	## `LoadMapPals` asks `LoadSpecialMapPalette` first, and its carry skips the
 	## environment and time-of-day pair entirely.
 	var special: Array = data.special_map_palettes(map.tileset, map.environment)
@@ -259,15 +276,8 @@ static func tile_palettes(
 			slot_palette[1] = roof[0]
 			slot_palette[2] = roof[1]
 			resolved[PAL_BG_ROOF] = slot_palette
-	# `FillWhiteBGColor`, which only the fade out of the map runs: every
-	# background palette takes palette 0's own colour 0, so the order that
-	# flattens a palette onto it flattens the screen onto one white.
-	if white_fill and not resolved.is_empty():
-		var white: Color = (resolved[0] as PackedColorArray)[0]
-		for slot: int in range(1, resolved.size()):
-			var palette: PackedColorArray = resolved[slot]
-			palette[0] = white
-			resolved[slot] = palette
+	if white_fill:
+		_flood_white(resolved)
 	if fade_order != FADE_IDENTITY:
 		for slot: int in resolved.size():
 			resolved[slot] = fade_palette(resolved[slot], fade_order)

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -349,6 +349,7 @@ func _tile_palettes_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
 		_animation.cave_palette_color() if _animation != null else -1,
 		_fade_order,
 		_fade_white_fill,
+		_world.gen1_last_map(),
 	)
 	if _transition_order == Gen2BattleTransition.IDENTITY:
 		return rows
@@ -916,7 +917,18 @@ func _sprite_palette(palette: int) -> PackedColorArray:
 	if not _transition_palette.is_empty() \
 		and palette in [Gen2WorldEffects.PAL_OW_TREE, Gen2WorldEffects.PAL_OW_ROCK]:
 		return _transition_palette
-	return _world.data.overworld_sprite_palette(palette, _time_of_day)
+	return _overworld_sprite_colors(palette)
+
+
+## A Generation 1 map has no sprite palettes: `BlkPacket_WholeScreen` gives its
+## objects the four colours the background is drawn in, through `GBPalNormal`'s
+## own `rOBP0`.
+func _overworld_sprite_colors(palette: int) -> PackedColorArray:
+	if _world.data.generation != RomRegistry.GEN1:
+		return _world.data.overworld_sprite_palette(palette, _time_of_day)
+	return Gen2WorldPalette.gen1_object_colors(Gen2WorldPalette.gen1_map_colors(
+		_world.data, _world.current_map, _world.gen1_last_map()
+	))
 
 
 func _actor_texture(
@@ -1026,7 +1038,7 @@ func _draw_emote(emote_id: int, pixel: Vector2) -> void:
 ## front of the object covers its legs.
 func _in_grass(cell: Vector2i) -> bool:
 	return _world != null and _world.current_map != null \
-		and Gen2WorldCollision.is_grass(_world.collision_code_at(cell))
+		and Gen2WorldCollision.is_grass(_world.gen2_code_at(cell))
 
 
 ## Redraws the map over the bottom half of a sprite drawn at [param pixel], with
@@ -1347,7 +1359,7 @@ func _draw_fly_mon(sprite: Dictionary, anchor: Vector2) -> void:
 func _effect_palette(sheet: Dictionary, palette_index: int, rotation_step: int) -> PackedColorArray:
 	var own: PackedColorArray = sheet.get("colors", PackedColorArray())
 	if own.is_empty():
-		return _world.data.overworld_sprite_palette(palette_index, _time_of_day)
+		return _overworld_sprite_colors(palette_index)
 	var rotated := PackedColorArray()
 	for slot: int in own.size():
 		rotated.append(own[(slot + rotation_step) % own.size()])

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 451 lines of the 38254 here, and Generation 1's colour, sprites and wild
-## tables added 38 more to the shared palette, encounter and preview code. The
-## tree has no restatement left to pay for them with, which four sweeps for it
-## have now said.
-const MAX_COMMENT_LINES: int = 38254
+## are 480 lines of the 38360 here, and Generation 1's colour, sprites, wild
+## tables and walk added 114 more to the shared collision, palette, world and
+## renderer code, most of that the six tables `CheckTilePassable` stands in for.
+## Four sweeps have said the tree has no restatement left to pay with.
+const MAX_COMMENT_LINES: int = 38360
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -9761,3 +9761,163 @@ func test_a_cancelled_party_list_prints_the_two_boxes_that_have_one() -> void:
 			}))
 			assert_eq(results[0]["status"], &"waiting")
 			assert_eq(results[0]["event"]["text"], String(row[1 if chosen < 0 else 2]))
+
+
+## A Generation 1 cache: three maps whose collision grid holds the tile each cell
+## draws, which is what `CheckTilePassable` reads. Map 0 is a town with a door
+## tile and a ledge, map 1 the house behind it, whose mat warps back through
+## `LAST_MAP`, and map 2 a FOREST map holding one `TilePairCollisionsLand` pair.
+const GEN1_FLOOR: int = 0x00
+const GEN1_WALL: int = 0x0A
+const GEN1_DOOR: int = 0x1B
+const GEN1_MAT: int = 0x14
+const GEN1_TOWN_CELLS: Array[int] = [
+	0x0A, 0x0A, 0x0A, 0x0A,
+	0x00, 0x1B, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x2C, 0x00, 0x00,
+	0x00, 0x37, 0x00, 0x14,
+	0x00, 0x00, 0x00, 0x00,
+]
+const GEN1_HOUSE_CELLS: Array[int] = [
+	0x0A, 0x0A, 0x0A, 0x0A,
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x14, 0x00, 0x0A,
+]
+const GEN1_FOREST_CELLS: Array[int] = [
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x30, 0x2E, 0x00,
+	0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00,
+]
+
+
+func _gen1_directory() -> String:
+	return RomCache.directory_for(&"testred", "fedcba9876543210")
+
+
+func _write_gen1_cache() -> void:
+	var directory: String = _gen1_directory()
+	RomCache.clear(directory)
+	RomCache.prepare(directory)
+	for path: String in [
+		RomCache.species_path(directory), RomCache.moves_path(directory),
+		RomCache.items_path(directory), RomCache.types_path(directory),
+		RomCache.matchups_path(directory), RomCache.trainers_path(directory),
+	]:
+		RomCache.write_json(path, [])
+	var wall_block: Array = []
+	for _tile: int in 16:
+		wall_block.append(GEN1_WALL)
+	var tilesets: Array = []
+	for number: int in 4:
+		tilesets.append({
+			"number": number, "block_count": 1, "tile_count": 96,
+			"meta": wall_block, "passable_tiles": [GEN1_FLOOR, GEN1_DOOR, 0x2C, 0x30, 0x2E],
+			"counter_tiles": [], "grass_tile": 0xFF, "animation": 0,
+			"water": number == Gen1Layout.TILESET_OVERWORLD,
+		})
+	tilesets[1]["passable_tiles"] = [GEN1_FLOOR, GEN1_MAT]
+	RomCache.write_json(RomCache.world_tilesets_path(directory), tilesets)
+	RomCache.write_json(RomCache.world_maps_path(directory), [
+		_gen1_map(0, Gen1Layout.TILESET_OVERWORLD, 2, 3, GEN1_TOWN_CELLS,
+			[{"x": 1, "y": 1, "destination": 0, "map_group": 0, "map_number": 1}]),
+		_gen1_map(1, 1, 2, 2, GEN1_HOUSE_CELLS, [{
+			"x": 1, "y": 3, "destination": 0, "map_group": 0,
+			"map_number": Gen1Layout.WARP_TO_LAST_MAP,
+		}]),
+		_gen1_map(2, 3, 2, 2, GEN1_FOREST_CELLS, []),
+	])
+	var pixels := PackedByteArray()
+	pixels.resize(96 * PokeTiles.TILE_PIXELS)
+	for number: int in 4:
+		RomCache.write_indices(RomCache.world_tile_path(directory, number), pixels)
+	RomCache.write_json(RomCache.manifest_path(directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "red",
+		"generation": RomRegistry.GEN1,
+		"sha1": "fedcba9876543210",
+		"complete": true,
+	})
+
+
+func _gen1_map(
+	number: int, tileset: int, width: int, height: int, cells: Array[int], warps: Array
+) -> Dictionary:
+	var blocks: Array = []
+	for _block: int in width * height:
+		blocks.append(0)
+	return {
+		"group": 0, "number": number, "tileset": tileset, "border_block": 0,
+		"width_blocks": width, "height_blocks": height, "blocks": blocks,
+		"collision": cells, "collision_width": width * 2, "collision_height": height * 2,
+		"connection_flags": 0, "connections": [],
+		"events": {"warps": warps, "coord_events": [], "bg_events": [], "objects": []},
+	}
+
+
+func _gen1_world(number: int, start: Vector2i) -> Gen2WorldAPI:
+	_write_gen1_cache()
+	return Gen2WorldAPI.open(
+		GameData.open_directory(_gen1_directory()), 0, number, start, Gen2WorldState.new()
+	)
+
+
+## `CheckTilePassable` walks the tileset's own list, so a tile that is not on it
+## walls the cell whatever a Generation 2 permission table would have said of it.
+func test_gen1_walking_reads_the_tilesets_passable_list() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 1))
+	assert_eq(world.collision_permission_at(Vector2i(1, 1)), Gen2WorldCollision.LAND_TILE)
+	assert_eq(world.collision_permission_at(Vector2i(1, 0)), Gen2WorldCollision.WALL_TILE)
+	assert_false(world.move(Vector2i.UP), "the wall row let the player through")
+	assert_true(world.move(Vector2i.DOWN))
+	RomCache.clear(_gen1_directory())
+
+
+## `IsNextTileShoreOrWater`: $14 is water on a `WaterTilesets` row and the mat in
+## front of Red's own door everywhere else.
+func test_gen1_water_needs_a_water_tileset() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(0, 4))
+	assert_eq(world.collision_permission_at(Vector2i(3, 4)), Gen2WorldCollision.WATER_TILE)
+	world = _gen1_world(1, Vector2i(1, 2))
+	assert_eq(world.collision_permission_at(Vector2i(1, 3)), Gen2WorldCollision.LAND_TILE)
+	RomCache.clear(_gen1_directory())
+
+
+## `warp_event` stores its destination already counting from zero, and the way
+## back out names `LAST_MAP` rather than a map of its own.
+func test_gen1_warp_and_the_way_back_through_last_map() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 1))
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_true(bool(world.try_warp().get("ok", false)), "the door refused")
+	assert_eq(world.map_id(), Vector2i(0, 1))
+	assert_eq(world.player_cell, Vector2i(1, 3))
+	assert_eq(world.gen1_last_map(), 0)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(bool(world.try_warp().get("ok", false)), "the mat refused")
+	assert_eq(world.map_id(), Vector2i(0, 0))
+	assert_eq(world.player_cell, Vector2i(1, 1))
+	RomCache.clear(_gen1_directory())
+
+
+## `HandleLedges` reads the faced tile as well as the one stood on, and the hop
+## covers two cells as `wSimulatedJoypadStatesIndex`'s 2 does.
+func test_gen1_ledge_hop_crosses_the_ledge_tile() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 3))
+	var hop: Dictionary = world.move_result(Vector2i.DOWN)
+	assert_eq(StringName(hop.get("kind", &"")), &"ledge_hop")
+	assert_eq(world.player_cell, Vector2i(1, 5))
+	RomCache.clear(_gen1_directory())
+
+
+## `CheckForTilePairCollisions`: two passable FOREST tiles the player may not
+## cross between, refused in either order.
+func test_gen1_tile_pair_collision_blocks_a_step_between_two_passable_tiles() -> void:
+	var world: Gen2WorldAPI = _gen1_world(2, Vector2i(1, 1))
+	assert_eq(world.collision_permission_at(Vector2i(2, 1)), Gen2WorldCollision.LAND_TILE)
+	assert_false(world.move(Vector2i.RIGHT), "the pair let the player across")
+	world = _gen1_world(2, Vector2i(2, 1))
+	assert_false(world.move(Vector2i.LEFT), "the pair let the player back")
+	assert_true(world.move(Vector2i.UP))
+	RomCache.clear(_gen1_directory())

--- a/tests/unit/test_world_collision.gd
+++ b/tests/unit/test_world_collision.gd
@@ -398,3 +398,84 @@ func test_water_and_the_walkable_floor_are_not_grass() -> void:
 		)
 	assert_false(Gen2WorldCollision.is_grass(-1))
 	assert_false(Gen2WorldCollision.is_grass(0x100))
+
+
+## The Generation 1 half, against pokered revision
+## a1a22aaf84d1675bcdbaeb194592379d586d838e, whose six tables Red, Blue and
+## Yellow ship byte for byte but for the two rows named below.
+func _gen1_tileset(number: int, passable: Array, water: bool) -> Gen2WorldTileset:
+	return Gen2WorldTileset.from_cache({
+		"number": number, "block_count": 1, "tile_count": 96,
+		"passable_tiles": passable, "water": water,
+	})
+
+
+func test_gen1_permission_reads_the_tilesets_own_passable_list() -> void:
+	var overworld: Gen2WorldTileset = _gen1_tileset(0, [0x00, 0x1B], true)
+	assert_eq(Gen2WorldCollision.gen1_permission(overworld, 0x00), Gen2WorldCollision.LAND_TILE)
+	assert_eq(Gen2WorldCollision.gen1_permission(overworld, 0x0A), Gen2WorldCollision.WALL_TILE)
+	assert_eq(Gen2WorldCollision.gen1_permission(overworld, -1), Gen2WorldCollision.WALL_TILE)
+	assert_eq(Gen2WorldCollision.gen1_permission(null, 0x00), Gen2WorldCollision.WALL_TILE)
+
+
+## `IsNextTileShoreOrWater` asks `WaterTilesets` before it looks at the tile, so
+## $14 is water on a route and Red's own doormat inside a house.
+func test_gen1_water_tile_needs_a_water_tileset() -> void:
+	assert_eq(
+		Gen2WorldCollision.gen1_permission(_gen1_tileset(0, [0x00], true), 0x14),
+		Gen2WorldCollision.WATER_TILE
+	)
+	assert_eq(
+		Gen2WorldCollision.gen1_permission(_gen1_tileset(1, [0x00, 0x14], false), 0x14),
+		Gen2WorldCollision.LAND_TILE
+	)
+
+
+## `TilePairCollisionsLand` and `TilePairCollisionsWater`: a row forbids crossing
+## in either order, and only on the tileset it names.
+func test_gen1_tile_pairs_block_both_ways_on_their_own_tileset() -> void:
+	assert_true(Gen2WorldCollision.gen1_pair_blocked(3, 0x30, 0x2E, false))
+	assert_true(Gen2WorldCollision.gen1_pair_blocked(3, 0x2E, 0x30, false))
+	assert_false(Gen2WorldCollision.gen1_pair_blocked(0, 0x30, 0x2E, false))
+	assert_false(Gen2WorldCollision.gen1_pair_blocked(3, 0x30, 0x2E, true))
+	assert_true(Gen2WorldCollision.gen1_pair_blocked(3, 0x14, 0x2E, true))
+	assert_true(Gen2WorldCollision.gen1_pair_blocked(17, 0x05, 0x21, false))
+	assert_false(Gen2WorldCollision.gen1_pair_blocked(17, 0x05, 0x22, false))
+
+
+## `HandleLedges` returns before reading the table on any tileset but OVERWORLD,
+## and each row names the tile stood on as well as the ledge.
+func test_gen1_hops_are_the_ledge_table_on_the_overworld_tileset() -> void:
+	assert_true(Gen2WorldCollision.gen1_allows_hop(0, 0x2C, 0x37, Vector2i.DOWN))
+	assert_false(Gen2WorldCollision.gen1_allows_hop(0, 0x2C, 0x37, Vector2i.UP))
+	assert_false(Gen2WorldCollision.gen1_allows_hop(0, 0x2C, 0x36, Vector2i.DOWN))
+	assert_true(Gen2WorldCollision.gen1_allows_hop(0, 0x39, 0x36, Vector2i.DOWN))
+	assert_true(Gen2WorldCollision.gen1_allows_hop(0, 0x2C, 0x27, Vector2i.LEFT))
+	assert_true(Gen2WorldCollision.gen1_allows_hop(0, 0x2C, 0x1D, Vector2i.RIGHT))
+	assert_false(Gen2WorldCollision.gen1_allows_hop(3, 0x2C, 0x37, Vector2i.DOWN))
+	assert_false(Gen2WorldCollision.gen1_allows_hop(0, 0x2C, 0x37, Vector2i.ZERO))
+
+
+## `WarpTileIDPointers`, `DoorTileIDPointers` and `WarpTileListPointers`, each
+## keyed the way its own routine indexes it. INTERIOR's doors are Yellow's row;
+## `SHIP_PORT` and `CLUB` have no warp tiles at all.
+func test_gen1_warp_door_and_carpet_tables_answer_by_their_own_key() -> void:
+	assert_true(Gen2WorldCollision.gen1_is_warp_tile(0, 0x1B))
+	assert_false(Gen2WorldCollision.gen1_is_warp_tile(0, 0x1A))
+	assert_true(Gen2WorldCollision.gen1_is_warp_tile(15, 0x13))
+	assert_false(Gen2WorldCollision.gen1_is_warp_tile(14, 0x1B))
+	assert_true(Gen2WorldCollision.gen1_is_door_tile(16, 0x15))
+	assert_false(Gen2WorldCollision.gen1_is_door_tile(1, 0x1A))
+	assert_true(Gen2WorldCollision.gen1_is_warp_carpet(Vector2i.DOWN, 0x01))
+	assert_false(Gen2WorldCollision.gen1_is_warp_carpet(Vector2i.UP, 0x12))
+	assert_true(Gen2WorldCollision.gen1_is_warp_carpet(Vector2i.LEFT, 0x4B))
+	assert_true(Gen2WorldCollision.gen1_is_warp_carpet(Vector2i.RIGHT, 0x4E))
+
+
+## `DungeonTilesets`, the list `LoadTilesetHeader` walks before it compares the
+## new tileset with the one already loaded.
+func test_gen1_dungeon_tilesets_are_the_source_list() -> void:
+	for number: int in [3, 7, 10, 12, 13, 15, 17, 18, 19, 20, 22]:
+		assert_true(Gen2WorldCollision.gen1_is_dungeon_tileset(number), "tileset %d" % number)
+	for number: int in [0, 1, 2, 14, 21, 23, 24]:
+		assert_false(Gen2WorldCollision.gen1_is_dungeon_tileset(number), "tileset %d" % number)

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -1,0 +1,176 @@
+extends RefCounted
+
+## Every Generation 1 warp and every ledge, swept on Red, Blue and Yellow. A
+## Generation 1 map's collision grid holds the tile a cell draws, so what is
+## proved here is the six tables [Gen2WorldCollision] carries for it: the
+## tileset's passable list decides a step, `WarpTileIDPointers` and
+## `DoorTileIDPointers` decide whether a warp fires, and `LedgeTiles` decides a
+## hop. Each is swept against the imported corpus rather than one sampled map.
+
+## `data/maps/objects`' own totals, and the `LAST_MAP` warps inside them.
+const WARP_CENSUS: Dictionary = {
+	&"red": {"warps": 813, "last_map": 251, "driven": 554, "hops": 758},
+	&"blue": {"warps": 813, "last_map": 251, "driven": 554, "hops": 758},
+	&"yellow": {"warps": 817, "last_map": 253, "driven": 556, "hops": 756},
+}
+
+## `SilphCoElevator_Object`'s two warps name UNUSED_MAP_ED, which has no header;
+## its own script rewrites the destination before either is taken.
+const SILPH_CO_ELEVATOR: int = 236
+
+## The warps no facing can fire, as map id and warp index. Every one is a cell
+## the player arrives on rather than steps onto: three are pret's own
+## `; inaccessible`, four are the upper half of a two-cell gate doorway on
+## Routes 7 and 8, and Rock Tunnel's two are the far cell of each tunnel mouth.
+const ARRIVAL_ONLY: Array = [
+	[6, 8], [18, 0], [18, 2], [19, 0], [19, 2], [82, 1], [82, 3], [181, 4], [235, 2],
+]
+
+## Warps whose cell is not passable, which is the same shape: a gate's second
+## doorway cell, the Seafoam holes that drop onto water, and the Elite Four
+## doors, which are wall until each room's script opens them.
+const UNSTANDABLE_WARPS: Array = [
+	[6, 8], [17, 0], [18, 2], [27, 3], [47, 0], [49, 0], [50, 0], [82, 3],
+	[161, 5], [161, 6], [162, 0], [162, 1], [245, 2], [245, 3],
+]
+
+## Pallet Town's front door and the mat behind it: the round trip a `LAST_MAP`
+## warp is, out through `RedsHouse1F_Object`'s first warp and back.
+const PALLET_TOWN: int = 0
+const REDS_HOUSE_1F: int = 37
+const PALLET_DOOR := Vector2i(5, 5)
+const REDS_HOUSE_MAT := Vector2i(2, 7)
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	_check_warps()
+	_check_ledges()
+	_check_last_map_round_trip()
+
+
+## Every warp on every map: its destination resolves, it fires from some facing,
+## and taking it lands on the destination map's own warp cell.
+func _check_warps() -> void:
+	var pinned: Dictionary = WARP_CENSUS[_r.game_id]
+	var warps: int = 0
+	var last_map: int = 0
+	var driven: int = 0
+	var arrival_only: Array = []
+	var unstandable: Array = []
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+		var rows: Array = map.events.get("warps", [])
+		for index: int in rows.size():
+			var warp: Dictionary = rows[index]
+			var cell := Vector2i(int(warp["x"]), int(warp["y"]))
+			warps += 1
+			if not tileset.tile_passable(map.collision_at(cell.x, cell.y)):
+				unstandable.append([map.number, index])
+			if int(warp["map_number"]) == Gen1Layout.WARP_TO_LAST_MAP:
+				last_map += 1
+			var world: Gen2WorldAPI = _r.open_world(0, map.number, cell)
+			var facing: int = _firing_facing(world, cell)
+			if facing < 0:
+				arrival_only.append([map.number, index])
+				continue
+			## A `LAST_MAP` warp names no map of its own until one is walked out
+			## of, which [method _check_last_map_round_trip] is; the lift's two
+			## name a map with no header at all.
+			if int(warp["map_number"]) == Gen1Layout.WARP_TO_LAST_MAP \
+				or map.number == SILPH_CO_ELEVATOR:
+				continue
+			world.player_facing = facing
+			var taken: Dictionary = world.try_warp()
+			if not _r.check(bool(taken.get("ok", false)),
+				"map %d warp %d: %s" % [map.number, index, taken.get("reason", &"refused")]):
+				continue
+			driven += 1
+			var destination: Dictionary = taken["destination"]
+			_r.check(
+				world.player_cell == Vector2i(int(destination["x"]), int(destination["y"])),
+				"map %d warp %d landed on %s" % [map.number, index, world.player_cell]
+			)
+	_r.check(warps == int(pinned["warps"]), "%d warps, wanted %d" % [warps, pinned["warps"]])
+	_r.check(last_map == int(pinned["last_map"]),
+		"%d LAST_MAP warps, wanted %d" % [last_map, pinned["last_map"]])
+	_r.check(driven == int(pinned["driven"]),
+		"%d warps taken, wanted %d" % [driven, pinned["driven"]])
+	_r.check(arrival_only == ARRIVAL_ONLY, "warps firing from no facing: %s" % [arrival_only])
+	_r.check(unstandable == UNSTANDABLE_WARPS, "warps on an impassable tile: %s" % [unstandable])
+	_r.note("%d warps, %d back to LAST_MAP, %d taken" % [warps, last_map, driven])
+
+
+## The first facing `CheckWarpsNoCollision` would warp from, or -1.
+func _firing_facing(world: Gen2WorldAPI, cell: Vector2i) -> int:
+	if world == null:
+		return -1
+	for facing: int in 4:
+		world.player_facing = facing
+		if world._warp_tile_allows(cell):
+			return facing
+	return -1
+
+
+## `LedgeTiles` against the imported OVERWORLD list: every tile the player hops
+## from is passable and every ledge tile is not, which is what makes the hop the
+## only way across. The corpus count is what says the table reaches real cells.
+func _check_ledges() -> void:
+	var overworld: Gen2WorldTileset = _r.data.world_tileset(Gen1Layout.TILESET_OVERWORLD)
+	if not _r.check(overworld != null, "no OVERWORLD tileset."):
+		return
+	for row: Array in Gen2WorldCollision.GEN1_LEDGES:
+		_r.check(overworld.tile_passable(int(row[1])),
+			"ledge row stands on impassable tile $%02X." % row[1])
+		_r.check(not overworld.tile_passable(int(row[2])),
+			"ledge tile $%02X is passable." % row[2])
+	var hops: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		if map.tileset != Gen1Layout.TILESET_OVERWORLD:
+			continue
+		var world: Gen2WorldAPI = _r.open_world(0, map.number, Vector2i.ZERO)
+		if world == null:
+			continue
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				hops += _hops_at(world, Vector2i(x, y))
+	var wanted: int = int(WARP_CENSUS[_r.game_id]["hops"])
+	_r.check(hops == wanted, "%d ledge hops, wanted %d" % [hops, wanted])
+	_r.note("%d cells offer a ledge hop" % hops)
+
+
+func _hops_at(world: Gen2WorldAPI, cell: Vector2i) -> int:
+	var out: int = 0
+	world.player_cell = cell
+	for direction: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+		if world._allows_hop(direction):
+			out += 1
+	return out
+
+
+## Pallet Town to Red's house and back out through `LAST_MAP`, which is the one
+## warp shape with no map of its own in the record.
+func _check_last_map_round_trip() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, PALLET_TOWN, PALLET_DOOR)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var inside: Dictionary = world.try_warp()
+	if not _r.check(bool(inside.get("ok", false)), "Red's front door refused the warp."):
+		return
+	_r.check(world.map_id() == Vector2i(0, REDS_HOUSE_1F) and world.player_cell == REDS_HOUSE_MAT,
+		"the door led to %s %s." % [world.map_id(), world.player_cell])
+	_r.check(world.gen1_last_map() == PALLET_TOWN,
+		"wLastMap is %d." % world.gen1_last_map())
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	var outside: Dictionary = world.try_warp()
+	if not _r.check(bool(outside.get("ok", false)), "the mat refused the way back."):
+		return
+	_r.check(world.map_id() == Vector2i(0, PALLET_TOWN) and world.player_cell == PALLET_DOOR,
+		"the way back led to %s %s." % [world.map_id(), world.player_cell])

--- a/tools/checks/gen1_walk.gd.uid
+++ b/tools/checks/gen1_walk.gd.uid
@@ -1,0 +1,1 @@
+uid://db32wrbm61ta3

--- a/tools/preview_collision.gd
+++ b/tools/preview_collision.gd
@@ -105,10 +105,9 @@ func _draw_map(
 func _tile_palettes(
 	data: GameData, map: Gen2WorldMap, tileset: Gen2WorldTileset, last_map: int
 ) -> Array:
-	if data.generation == RomRegistry.GEN1:
-		return Gen2WorldPalette.gen1_tile_palettes(data, map, tileset, last_map)
 	return Gen2WorldPalette.tile_palettes(
-		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1
+		data, map, tileset, Gen2WorldPalette.TIME_DAY, -1, -1,
+		Gen2WorldPalette.FADE_IDENTITY, false, last_map
 	)
 
 

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,7 +44,7 @@ const GROUPS: Dictionary = {
 		&"battle_tower", &"npc_trade",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
-	&"gen1": [&"gen1_tables", &"gen1_pics", &"gen1_maps"],
+	&"gen1": [&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk"],
 }
 
 


### PR DESCRIPTION
`Gen2WorldAPI` opens a Generation 1 map and `Gen2WorldRenderer` draws it. Its collision grid holds the tile each cell draws, so `CheckTilePassable` walks the tileset's own passable list where Generation 2 reads `CollisionPermissionTable`, and six tables beside it in `Gen2WorldCollision` answer the rest of what a step asks: `TilePairCollisionsLand` and `...Water`, `LedgeTiles`, `WarpTileIDPointers`, `DoorTileIDPointers`, `WarpTileListPointers` and `DungeonTilesets`.

`Gen2WorldAPI.gen2_code_at` is the one seam every Generation 2 collision-code family reads through and answers -1 on a Generation 1 map, so grass, ice, pits, counters, warp carpets and the forced tiles no longer read a tile as a permission byte. `_edge_step_blocked` is the same for the leave-side test: `GetMovementPermissions`' face mask in Generation 2, `CheckForTilePairCollisions` in Generation 1.

A warp fires off a warp or a door tile, and otherwise wants `ExtraWarpCheck`'s carpet or map edge in front of the player. `warp_event` stores its destination already counting from zero, `LAST_MAP` comes back out to the town or route `WarpFound2` recorded in `wLastMap`, and `LoadTilesetHeader`'s gate decides whether the player moves at all. Tile $14 is water only on a `WaterTilesets` row.

`Gen2WorldPalette.tile_palettes` dispatches on the generation, so the renderer, `preview_collision` and the sweep all take `SetPal_Overworld`'s four colours; the objects on the map take the same four through `rOBP0`. `wLastMap` is the world's now rather than an argument each caller passes in by hand.

## Proving it

| Run | Result |
|---|---|
| `gut_cmdln.gd -gexit` | 3703 tests, 90680 asserts, all pass |
| `validate.gd -- all` | every topic passes, exit 0 |
| `validate.gd -- gen1_walk` | 554 warps taken on Red and Blue, 556 on Yellow, each landing on the destination map's own warp cell |
| `validate.gd -- gen1_walk` | 758 cells offer a ledge hop on Red and Blue, 756 on Yellow |
| `replay_world.gd` | 33 routes, 0 failures |
| story walk, three profiles | 16 badges each, exit 0 |
| `--warning-scan` | 0 warnings in 627 scripts |

`tools/checks/gen1_walk.gd` also pins the nine warps no facing can fire and the fourteen standing on an impassable tile. Both lists are the same on all three cartridges; three of the nine are pret's own `; inaccessible`, the rest are cells the player arrives on rather than steps onto.