### PR TITLE
Read a Generation 1 sign and meet a wild on its grass

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ godot --headless --path . -s res://tools/verify_rom.gd
 
 Matching uses SHA-1, never filenames. Unknown hashes are refused because an
 uncharacterised bank layout could produce corrupt assets. The three Generation 1
-cartridges import their species, move, type, item and trainer tables and every
-map and tileset; the launcher seats one and does not offer Play until its world
-is built.
+cartridges import their species, move, type, item and trainer tables, every map
+and tileset, and every map text; the launcher seats one and does not offer Play
+until its battle engine is built.
 
 | Game | SHA-1 |
 |---|---|
@@ -365,7 +365,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, and all 226 or 227 maps with their tilesets |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, and the text box and wild encounter a map reads |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -142,8 +142,20 @@ const FONT_EXTRA_FIRST_CODE: int = 0x60
 const FONT_INK_RUNS: Array = [[0x80, 0xBF], [0xE0, 0xFF]]
 const FONT_BLANK_RUNS: Array = [[0xC0, 0xDF]]
 const SPACE_CODE: int = 0x7F
-const FRAME_VERTICAL_CODE: int = 0x7C
+## `TextBoxBorder` prints `┌─┐│└┘`, the six codes `charmap.asm` puts at $79.
+## Generation 2 spells them the same way in a table of eight frames.
+const FRAME_FIRST_CODE: int = 0x79
+const FRAME_LAST_CODE: int = 0x7E
+const FRAME_VERTICAL_CODE: int = FRAME_FIRST_CODE + Gen2Layout.FRAME_VERTICAL
 const FRAME_VERTICAL_ROW: int = 0b00101000
+
+## `TX_SCRIPT_*`: a text pointer standing at one of these opens a facility
+## rather than a box, `DisplayTextID` dispatching before it prints.
+const TEXT_SCRIPT_IDS: Dictionary = {
+	0xF5: "vending machine", 0xF6: "cable club receptionist", 0xF7: "prize vendor",
+	0xF9: "Pokemon Center PC", 0xFC: "the player's PC", 0xFD: "Bill's PC",
+	0xFE: "mart", 0xFF: "Pokemon Center nurse",
+}
 
 ## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
 ## it. `SwitchToMapRomBank` selects that bank once, which is what puts a map's
@@ -259,6 +271,7 @@ const TILESET_CEMETERY: int = 15
 const TILESET_CAVERN: int = 17
 const TILESET_OVERWORLD: int = 0
 const TILESET_PLATEAU: int = 23
+const TILESET_FOREST: int = 3
 const TILESET_SHIP: int = 13
 const TILESET_SHIP_PORT: int = 14
 
@@ -627,3 +640,10 @@ static func flat_super_rod(id: StringName) -> bool:
 static func cell_tile_index(cell_x: int, cell_y: int) -> int:
 	return (cell_y * MAP_BLOCK_CELL_WIDTH + 1) * MAP_BLOCK_TILE_WIDTH \
 		+ cell_x * MAP_BLOCK_CELL_WIDTH
+
+
+## `TryDoWildEncounter` reads `hlcoord 9, 9` where everything else reads
+## `hlcoord 8, 9`: the bottom right tile of the quarter block the player stands
+## in rather than its bottom left, which is why a left shore rolls on grass.
+static func cell_encounter_tile_index(cell_x: int, cell_y: int) -> int:
+	return cell_tile_index(cell_x, cell_y) + 1

--- a/game/gen1/gen1_text.gd
+++ b/game/gen1/gen1_text.gd
@@ -69,7 +69,29 @@ const EXTRA_CHARACTERS: Dictionary = {
 	0xF0: "¥", 0xF1: "×", 0xF2: ".", 0xF3: "/", 0xF4: ",", 0xF5: "♀",
 }
 
+## `font_extra.png`, which `LoadTextBoxTilePatterns` parks at $60. Ordinary text
+## prints the ellipsis, the quotes and the dot, so those encode as well as decode.
+const FONT_EXTRA_CHARACTERS: Dictionary = {
+	0x60: "<BOLD_A>", 0x61: "<BOLD_B>", 0x62: "<BOLD_C>", 0x63: "<BOLD_D>",
+	0x64: "<BOLD_E>", 0x65: "<BOLD_F>", 0x66: "<BOLD_G>", 0x67: "<BOLD_H>",
+	0x68: "<BOLD_I>", 0x69: "<BOLD_V>", 0x6A: "<BOLD_S>", 0x6B: "<BOLD_L>",
+	0x6C: "<BOLD_M>", 0x6D: "<COLON>", 0x6E: "\u3043", 0x6F: "\u3045",
+	0x70: "\u2018", 0x71: "\u2019", 0x72: "\u201c", 0x73: "\u201d",
+	0x74: "\u00b7", 0x75: "\u2026", 0x76: "\u3041", 0x77: "\u3047",
+	0x78: "\u3049",
+	0x79: "\u250c", 0x7A: "\u2500", 0x7B: "\u2510",
+	0x7C: "\u2502", 0x7D: "\u2514", 0x7E: "\u2518",
+}
+
+const ELLIPSIS_CODE: int = 0x75
+
+## `PlacePKMN`'s text is `db "<PK><MN>@"`: two narrow tiles, never six letters.
+const WORD_TILES: Dictionary = {
+	"<PKMN>": [0xE1, 0xE2],
+}
+
 ## The longest sequence one tile stands for: a ligature is two characters.
+## [constant WORD_TILES]' spelling is longer and is matched ahead of this run.
 const MAX_LIGATURE: int = 2
 
 static var _table: Dictionary = {}
@@ -149,6 +171,16 @@ static func encode(text: String) -> PackedByteArray:
 	var at: int = 0
 	while at < text.length():
 		var taken: int = 0
+		for spelling: String in WORD_TILES:
+			if text.substr(at, spelling.length()) != spelling:
+				continue
+			for code: int in WORD_TILES[spelling] as Array:
+				out.append(code)
+			taken = spelling.length()
+			break
+		if taken > 0:
+			at += taken
+			continue
 		# Longest first, so "'s" wins over a "'" with no "s" code after it.
 		for length: int in range(mini(MAX_LIGATURE, text.length() - at), 0, -1):
 			var candidate: String = text.substr(at, length)
@@ -186,6 +218,7 @@ static func _characters() -> Dictionary:
 		table[0xF6 + i] = char("0".unicode_at(0) + i)
 	table[SPACE] = " "
 	table.merge(EXTRA_CHARACTERS)
+	table.merge(FONT_EXTRA_CHARACTERS)
 	table.merge(CONTROL_CHARACTERS)
 	_table = table
 	return _table
@@ -203,5 +236,11 @@ static func _encodings() -> Dictionary:
 		var glyph: String = _characters()[byte]
 		if not codes.has(glyph):
 			codes[glyph] = byte
+	# The $60 run is below FIRST_PRINTABLE and still drawn. A bracketed name in it
+	# stays decode-only, being wider than one window of the loop above.
+	for byte: int in FONT_EXTRA_CHARACTERS:
+		var extra: String = FONT_EXTRA_CHARACTERS[byte]
+		if extra.length() <= MAX_LIGATURE and not codes.has(extra):
+			codes[extra] = byte
 	_codes = codes
 	return _codes

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -5,7 +5,7 @@ extends RefCounted
 ## wild encounter table into the shared world sections of the cache, the
 ## counterpart of [Gen2WorldImporter]. A map is named by one flat id, so a
 ## record's group is zero and its number is that id. A script is machine code
-## here, so the header's script and text pointers are kept as addresses.
+## here, so the header keeps its address and its text pointer is followed.
 
 const LIST_END: int = Gen1Layout.TILESET_LIST_END
 
@@ -466,10 +466,10 @@ static func _read_map(
 		"scripts": {
 			"bank": bank,
 			"address": rom.u16le(header + 7),
-			"text_address": rom.u16le(header + 5),
 			"scenes": [],
 			"callbacks": [],
 		},
+		"texts": _read_texts(rom, bank, rom.u16le(header + 5), events),
 		"events": {
 			"bank": bank,
 			"address": rom.u16le(object_address),
@@ -660,6 +660,50 @@ static func _read_objects(rom: RomFile, at: int, map_id: int) -> Dictionary:
 		at += extra
 		out.append(object)
 	return {"ok": true, "events": out, "at": at}
+
+
+## `<Map>_TextPointers`, which `DisplayTextID` indexes with a text id. A row is
+## machine code; only `text_far` and `text_start` are a text, and the rest keep
+## the byte naming them. The table has no end, so the map's own events bound it.
+static func _read_texts(rom: RomFile, bank: int, address: int, events: Dictionary) -> Array:
+	var table: int = _banked(bank, address)
+	var out: Array = []
+	for id: int in _highest_text_id(events):
+		out.append(_read_text(rom, bank, rom.u16le(table + id * 2)))
+	return out
+
+
+static func _read_text(rom: RomFile, bank: int, pointer: int) -> Dictionary:
+	var at: int = _banked(bank, pointer)
+	var command: int = rom.u8(at)
+	var row: Dictionary = {"command": command, "text": ""}
+	if command != Gen1Text.TEXT_FAR and command != Gen1Text.TEXT_START:
+		return row
+	var decoded: Dictionary = Gen2TextStream.decode(rom.bytes(), at, {
+		"generation": RomRegistry.GEN1,
+		"far": func(far_bank: int, far_address: int) -> PackedByteArray:
+			var start: int = _banked(far_bank, far_address)
+			return rom.slice(start, _bank_end(RomFile.bank_of(start)) - start),
+	})
+	if not bool(decoded.get("ok", false)):
+		row["reason"] = String(decoded.get("reason", "invalid_text"))
+		return row
+	row["text"] = String(decoded["text"])
+	row["prompt"] = bool(decoded.get("prompt", false))
+	return row
+
+
+static func _highest_text_id(events: Dictionary) -> int:
+	var highest: int = 0
+	for kind: String in ["bg_events", "objects"]:
+		for event: Dictionary in events.get(kind, []) as Array:
+			highest = maxi(highest, int(event.get("text", 0)))
+	return highest
+
+
+## A `dw` inside a banked map: below $4000 is home, whatever bank is switched in.
+static func _banked(bank: int, address: int) -> int:
+	return RomFile.linear(0 if address < RomFile.BANK_SIZE else bank, address)
 
 
 static func _object_extra_bytes(text: int) -> int:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 105
+const FORMAT_VERSION: int = 106
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -44,11 +44,19 @@ const NUMBER_MARKER: String = "<NUM_"
 ## `TextSFX`: the seven command bytes that play an effect and `WaitSFX`.
 const TX_SOUND: Array[int] = [0x0B, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13]
 
+## Generation 1's `TextCommands` agree as far as `TX_PAUSE` and then part: $14 to
+## $16 are three more cries where Crystal has the buffer, the weekday and TX_FAR.
+const GEN1_TX_SOUND: Array[int] = [
+	0x0B, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+]
+const GEN1_TX_FAR: int = 0x17
+
 ## `CheckDict` entries that are not characters.
 const CHAR_NULL: int = 0x00
 const CHAR_BSP: int = 0x1F
 const CHAR_LF: int = 0x22
 const CHAR_WBR: int = 0x25
+const CHAR_PAGE: int = 0x49
 const CHAR_CONT_RAW: int = 0x4B
 const CHAR_SCROLL: int = 0x4C
 const CHAR_NEXT: int = 0x4E
@@ -77,6 +85,38 @@ const WEEKDAYS: Array[String] = [
 	"SUN", "MON", "TUES", "WEDNES", "THURS", "FRI", "SATUR",
 ]
 
+## What a character does to the laid-out string instead of drawing itself.
+## Anything not here is a glyph or a name.
+const BREAKS: Dictionary = {
+	CHAR_LF: "\n", CHAR_NEXT: "\n", CHAR_LINE: "\n",
+	CHAR_PARA: PAGE_BREAK,
+	CHAR_CONT: SCROLL_BREAK, CHAR_CONT_RAW: SCROLL_BREAK,
+	CHAR_SCROLL: SCROLL_NOWAIT_BREAK,
+	CHAR_WBR: "", CHAR_BSP: " ", CHAR_DEXEND: ".",
+}
+
+## Generation 1's, whose `PlaceNextChar` has no `<LF>`, `<BSP>` or `<WBR>` and
+## reaches `PageChar` on the $49 Crystal spends on `<MOM>`.
+const GEN1_BREAKS: Dictionary = {
+	CHAR_PAGE: "\n", CHAR_NEXT: "\n", CHAR_LINE: "\n",
+	CHAR_PARA: PAGE_BREAK,
+	CHAR_CONT: SCROLL_BREAK, CHAR_CONT_RAW: SCROLL_BREAK,
+	CHAR_SCROLL: SCROLL_NOWAIT_BREAK,
+	CHAR_DEXEND: ".",
+}
+
+## `CheckDict`'s `print_name` entries: the [param context] key each code reads.
+const NAMES: Dictionary = {
+	CHAR_PLAY_G: "player", 0x52: "player", 0x53: "rival", 0x49: "mom",
+	0x38: "red", 0x39: "green", 0x3F: "enemy", 0x59: "target", 0x5A: "user",
+}
+
+## Generation 1's four; its other `print_name` entries spell whole words rather
+## than reading RAM, so [Gen1Text] answers them.
+const GEN1_NAMES: Dictionary = {
+	0x52: "player", 0x53: "rival", 0x59: "target", 0x5A: "user",
+}
+
 
 ## Runs a text from [param offset] to its terminator.
 ##
@@ -96,6 +136,9 @@ static func decode(
 static func _run(
 	data: PackedByteArray, offset: int, context: Dictionary, depth: int
 ) -> Dictionary:
+	var gen1: bool = is_gen1(context)
+	var far_command: int = GEN1_TX_FAR if gen1 else TX_FAR
+	var sounds: Array[int] = GEN1_TX_SOUND if gen1 else TX_SOUND
 	var out: String = ""
 	var at: int = offset
 	var prompt: bool = false
@@ -116,40 +159,45 @@ static func _run(
 					"prompt": bool(placed.get("prompt", false)),
 				}
 			continue
-		if command in TX_SOUND:
+		if command in sounds:
 			# The effect plays and `WaitSFX` holds the printer; nothing is drawn.
 			continue
-		match command:
-			TX_FAR:
-				if not _has(data, at, 3):
-					return _truncated(out, &"truncated_text_far")
-				var far_address: int = data[at] | (data[at + 1] << 8)
-				var far_bank: int = int(data[at + 2])
-				at += 3
-				var far: Dictionary = _far(context, far_bank, far_address, depth)
-				out += String(far.get("text", ""))
-				if not bool(far.get("ok", false)):
-					return {"ok": false, "reason": far.get("reason", &"invalid_far_text"), "text": out}
-				return {
-					"ok": true, "text": out, "bytes": at,
-					"prompt": bool(far.get("prompt", false)),
-				}
-			TX_START_ASM:
-				# `jp hl` into code. Nothing after it can be read as text.
-				return {"ok": true, "text": out, "bytes": at, "prompt": prompt}
-			_:
-				var step: Dictionary = _step_command(data, at, context, command)
-				if step.has("reason"):
-					return _truncated(out, StringName(step["reason"]))
-				if step.is_empty():
-					return {
-						"ok": false, "reason": &"unknown_text_command",
-						"text": out, "command": command,
-					}
-				out += String(step.get("text", ""))
-				at = int(step["at"])
-				prompt = prompt or bool(step.get("prompt", false))
+		if command == far_command:
+			return _far_command(data, at, context, depth, out)
+		if command == TX_START_ASM:
+			# `jp hl` into code. Nothing after it can be read as text.
+			return {"ok": true, "text": out, "bytes": at, "prompt": prompt}
+		var step: Dictionary = _step_command(data, at, context, command)
+		if step.has("reason"):
+			return _truncated(out, StringName(step["reason"]))
+		if step.is_empty():
+			return {
+				"ok": false, "reason": &"unknown_text_command",
+				"text": out, "command": command,
+			}
+		out += String(step.get("text", ""))
+		at = int(step["at"])
+		prompt = prompt or bool(step.get("prompt", false))
 	return {"ok": false, "reason": &"missing_text_terminator", "text": out}
+
+
+## `TextCommand_FAR`'s three operands and the text they name, which ends the
+## text the command appears in either way.
+static func _far_command(
+	data: PackedByteArray, at: int, context: Dictionary, depth: int, out: String
+) -> Dictionary:
+	if not _has(data, at, 3):
+		return _truncated(out, &"truncated_text_far")
+	var far: Dictionary = _far(
+		context, int(data[at + 2]), data[at] | (data[at + 1] << 8), depth
+	)
+	var text: String = out + String(far.get("text", ""))
+	if not bool(far.get("ok", false)):
+		return {"ok": false, "reason": far.get("reason", &"invalid_far_text"), "text": text}
+	return {
+		"ok": true, "text": text, "bytes": at + 3,
+		"prompt": bool(far.get("prompt", false)),
+	}
 
 
 ## A `reason` means the operands ran off the end; empty means another opcode.
@@ -192,12 +240,18 @@ static func _step_command(
 				"text": _decimal_string(context, data[at] | (data[at + 1] << 8)),
 				"at": at + 3,
 			}
-		TX_BCD, TX_MOVE:
-			# Three bytes of operand each, and each prints from live RAM this
-			# project does not model. Skipped rather than drawn wrong.
+		TX_BCD:
+			# `dw address, db flags`, printed from live RAM this project does not
+			# model. Skipped rather than drawn wrong.
 			if not _has(data, at, 3):
 				return {"reason": &"truncated_text_command"}
 			return {"at": at + 3}
+		TX_MOVE:
+			# `dw address` alone, and it prints nothing. Reading a third byte here
+			# slid every command behind it.
+			if not _has(data, at, 2):
+				return {"reason": &"truncated_text_command"}
+			return {"at": at + 2}
 		TX_BOX:
 			if not _has(data, at, 4):
 				return {"reason": &"truncated_text_command"}
@@ -207,71 +261,58 @@ static func _step_command(
 
 ## `PlaceString`/`CheckDict`: characters until the `@` that ends the literal.
 static func _place(data: PackedByteArray, offset: int, context: Dictionary) -> Dictionary:
+	var gen1: bool = is_gen1(context)
+	var breaks: Dictionary = GEN1_BREAKS if gen1 else BREAKS
 	var out: String = ""
 	var at: int = offset
 	while at < data.size():
 		var byte: int = int(data[at])
 		at += 1
-		match byte:
-			TX_END:
-				return {"text": out, "at": at, "ended": false}
-			CHAR_DONE:
-				return {"text": out, "at": at, "ended": true, "prompt": false}
-			CHAR_PROMPT:
-				# `PromptText` waits for a press and falls through to `DoneText`.
-				return {"text": out, "at": at, "ended": true, "prompt": true}
-			CHAR_NULL:
-				# `NullChar` prints a debugging error string. Treated as an end
-				# rather than reproduced.
-				return {"text": out, "at": at, "ended": true, "prompt": false}
-			CHAR_LINE, CHAR_NEXT, CHAR_LF:
-				out += "\n"
-			CHAR_PARA:
-				out += PAGE_BREAK
-			CHAR_CONT, CHAR_CONT_RAW:
-				out += SCROLL_BREAK
-			CHAR_SCROLL:
-				out += SCROLL_NOWAIT_BREAK
-			CHAR_WBR:
-				pass
-			CHAR_BSP:
-				out += " "
-			CHAR_DEXEND:
-				out += "."
-			_:
-				out += _dict(byte, context)
+		if byte == TX_END:
+			return {"text": out, "at": at, "ended": false}
+		# `NullChar` prints a debugging error string, so it ends the text rather
+		# than being reproduced.
+		if byte == CHAR_DONE or byte == CHAR_NULL:
+			return {"text": out, "at": at, "ended": true, "prompt": false}
+		if byte == CHAR_PROMPT:
+			return {"text": out, "at": at, "ended": true, "prompt": true}
+		if breaks.has(byte):
+			out += String(breaks[byte])
+			continue
+		out += _dict(byte, context, gen1)
 	# Off the end of the data with no `@`, `<DONE>` or `<PROMPT>`: the text
 	# is truncated, which is a wrong offset rather than a finished string.
 	return {"text": out, "at": at, "truncated": true}
 
 
-## The `print_name` half of `CheckDict`. Everything else is a glyph.
-static func _dict(byte: int, context: Dictionary) -> String:
-	match byte:
-		CHAR_PLAY_G, 0x52:
-			# `PlaceGenderedPlayerName` places `wPlayerName`, the same string
-			# `PrintPlayerName` does; the honorific is the Japanese build's.
-			return _name(context, "player", "<PLAYER>")
-		0x53:
-			return _name(context, "rival", "<RIVAL>")
-		0x49:
-			return _name(context, "mom", "<MOM>")
-		0x38:
-			return _name(context, "red", "<RED>")
-		0x39:
-			return _name(context, "green", "<GREEN>")
-		0x3F:
-			return _name(context, "enemy", "<ENEMY>")
-		0x59:
-			return _name(context, "target", "<TARGET>")
-		0x5A:
-			return _name(context, "user", "<USER>")
-	return Gen2Text.character(byte)
+## The `print_name` half of `CheckDict`; everything else is a glyph the
+## generation's own codec answers. `PlaceGenderedPlayerName` places `wPlayerName`.
+static func _dict(byte: int, context: Dictionary, gen1: bool) -> String:
+	var names: Dictionary = GEN1_NAMES if gen1 else NAMES
+	if names.has(byte):
+		var key: String = String(names[byte])
+		return _name(context, key, "<%s>" % key.to_upper())
+	return Gen1Text.character(byte) if gen1 else Gen2Text.character(byte)
+
+
+## Whether [param context] names a Generation 1 cartridge; absent is Generation 2.
+static func is_gen1(context: Dictionary) -> bool:
+	return int(context.get("generation", RomRegistry.GEN2)) == RomRegistry.GEN1
 
 
 static func _name(context: Dictionary, key: String, fallback: String) -> String:
 	var value: String = String(context.get(key, ""))
 	return value if not value.is_empty() else fallback
+
+
+## The print-time names still standing as markers, keyed as [constant NAMES]
+## values are. Generation 1's texts are decoded at import, with no save to read
+## a name out of.
+static func fill_names(text: String, names: Dictionary) -> String:
+	var out: String = text
+	for key: String in names:
+		out = out.replace("<%s>" % key.to_upper(), String(names[key]))
+	return out
 
 
 ## Replaces the first marker of [param prefix] in [param text] with

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -21,6 +21,10 @@ var _frames: PackedByteArray = PackedByteArray()
 var _frame_width: int = 0
 var _frame_first_code: int = Gen2Layout.FRAME_FIRST_CODE
 var _frame_tiles: int = 0
+## Where the border starts in the strip holding it, and how far one frame is from
+## the next. A zero stride is one border answering every frame style.
+var _frame_slot: int = 0
+var _frame_stride: int = Gen2Layout.FRAME_TILES
 
 var _battle_extra: PackedByteArray = PackedByteArray()
 var _battle_extra_width: int = 0
@@ -32,6 +36,11 @@ var _battle_extra_tiles: int = 0
 var _extra: PackedByteArray = PackedByteArray()
 var _extra_width: int = 0
 var _extra_tiles: int = 0
+var _extra_first_code: int = Gen2Layout.FONT_EXTRA_FIRST_CODE
+var _extra_loaded_first: int = Gen2Layout.FONT_EXTRA_LOADED_FIRST
+var _extra_loaded_last: int = Gen2Layout.FONT_EXTRA_LOADED_LAST
+
+var _generation: int = RomRegistry.GEN2
 
 
 ## `PrintLevel`'s `cp 100`, "distinct from MAX_LEVEL": three digits overwrite the
@@ -73,8 +82,26 @@ static func from_data(data: GameData) -> Gen2Font:
 	out._extra = data.tile_indices("font_extra")
 	out._extra_width = int(extra.get("width", 0))
 	out._extra_tiles = int(extra.get("tiles", 0))
+	out._extra_first_code = int(extra.get("first_code", Gen2Layout.FONT_EXTRA_FIRST_CODE))
+
+	out._generation = data.generation
+	if out._generation == RomRegistry.GEN1:
+		out._take_gen1_frames()
 
 	return out if out.is_usable() else null
+
+
+## Generation 1 has no `frames` sheet: `LoadTextBoxTilePatterns` copies
+## `TextBoxGraphics` to $60 and `TextBoxBorder` prints `┌─┐│└┘` out of it at $79.
+func _take_gen1_frames() -> void:
+	_frames = _extra
+	_frame_width = _extra_width
+	_frame_tiles = _extra_tiles
+	_frame_first_code = Gen1Layout.FRAME_FIRST_CODE
+	_frame_slot = Gen1Layout.FRAME_FIRST_CODE - _extra_first_code
+	_frame_stride = 0
+	_extra_loaded_first = _extra_first_code
+	_extra_loaded_last = Gen1Layout.FRAME_LAST_CODE
 
 
 func is_usable() -> bool:
@@ -82,10 +109,10 @@ func is_usable() -> bool:
 
 
 func frame_count() -> int:
-	if Gen2Layout.FRAME_TILES <= 0:
-		return 0
+	if _frame_stride <= 0:
+		return 1 if _frame_tiles > 0 else 0
 	@warning_ignore("integer_division")
-	return _frame_tiles / Gen2Layout.FRAME_TILES
+	return _frame_tiles / _frame_stride
 
 
 func has_battle_extra() -> bool:
@@ -113,9 +140,8 @@ func draw_code(
 		return
 	# `_LoadFontsExtra1`'s own run, which is under the main font everywhere the
 	# battle's strip is not: a code below the font's $80 draws from FontExtra.
-	if code >= Gen2Layout.FONT_EXTRA_LOADED_FIRST \
-		and code <= Gen2Layout.FONT_EXTRA_LOADED_LAST:
-		var extra_slot: int = code - Gen2Layout.FONT_EXTRA_FIRST_CODE
+	if code >= _extra_loaded_first and code <= _extra_loaded_last:
+		var extra_slot: int = code - _extra_first_code
 		if extra_slot < _extra_tiles:
 			blit_slot(_extra, _extra_width, extra_slot, into, into_width, at_x, at_y)
 		return
@@ -137,7 +163,7 @@ func draw_text(
 	text: String, into: PackedByteArray, into_width: int, at_x: int, at_y: int,
 	font: StringName = Gen2Text.FONT_MAIN, max_tiles: int = -1
 ) -> int:
-	var codes: PackedByteArray = fit(text, max_tiles, font)
+	var codes: PackedByteArray = fit(text, max_tiles, font, _generation)
 	for i: int in codes.size():
 		draw_code(codes[i], into, into_width, at_x + i * TILE, at_y, font)
 	return codes.size()
@@ -147,18 +173,27 @@ func draw_text(
 ## ellipsis where anything was dropped. Negative is no bound. Exposed so a
 ## caller that measures before it draws asks the same question once.
 static func fit(
-	text: String, max_tiles: int, font: StringName = Gen2Text.FONT_MAIN
+	text: String, max_tiles: int, font: StringName = Gen2Text.FONT_MAIN,
+	generation: int = RomRegistry.GEN2
 ) -> PackedByteArray:
-	var codes: PackedByteArray = Gen2Text.encode(text, font)
+	var codes: PackedByteArray = Gen1Text.encode(text) \
+		if generation == RomRegistry.GEN1 else Gen2Text.encode(text, font)
 	if max_tiles < 0 or codes.size() <= max_tiles:
 		return codes
 	if max_tiles <= 0:
 		return PackedByteArray()
-	if font == Gen2Text.FONT_BATTLE_EXTRA:
+	if font == Gen2Text.FONT_BATTLE_EXTRA and generation != RomRegistry.GEN1:
 		return codes.slice(0, max_tiles)
 	var out: PackedByteArray = codes.slice(0, max_tiles - 1)
 	out.append(Gen2Text.ELLIPSIS_CODE)
 	return out
+
+
+## The codes [param text] draws as under this font, for a caller composing its
+## own row of tiles: Generation 1 keeps `'s` at $bd and Crystal at $d4, which is
+## a blank tile in the other's `FontGraphics`.
+func encode(text: String, font: StringName = Gen2Text.FONT_MAIN) -> PackedByteArray:
+	return fit(text, -1, font, _generation)
 
 
 ## Draws one tile of one text box border. [param code] is a box-drawing code
@@ -170,7 +205,7 @@ func draw_frame_code(
 	var within: int = code - _frame_first_code
 	if within < 0 or within >= Gen2Layout.FRAME_TILES:
 		return
-	var slot: int = frame * Gen2Layout.FRAME_TILES + within
+	var slot: int = _frame_slot + frame * _frame_stride + within
 	if frame < 0 or slot >= _frame_tiles:
 		return
 	blit_slot(_frames, _frame_width, slot, into, into_width, at_x, at_y)

--- a/game/render/text_box.gd
+++ b/game/render/text_box.gd
@@ -393,7 +393,7 @@ func _start_page() -> void:
 	var already: int = 0
 	if _page < _pages.size():
 		for line: String in _pages[_page]["lines"]:
-			var codes: PackedByteArray = Gen2Text.encode(line)
+			var codes: PackedByteArray = _encode(line)
 			if _lines.size() < carried:
 				already += codes.size()
 			_lines.append(codes)
@@ -405,6 +405,11 @@ func _start_page() -> void:
 	if reveal_speed <= 0.0:
 		_shown = float(_tiles_on_page)
 	_redraw()
+
+
+## The codes one line draws as. A box with no font still paginates.
+func _encode(line: String) -> PackedByteArray:
+	return font.encode(line) if font != null else Gen2Text.encode(line)
 
 
 func _redraw() -> void:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -1266,9 +1266,18 @@ func facing_direction() -> Vector2i:
 func object_facing_cell() -> Vector2i:
 	var direction: Vector2i = _direction_for_facing(player_facing)
 	var faced: Vector2i = player_cell + direction
-	if Gen2WorldCollision.is_counter(gen2_code_at(faced)):
+	if _counter_ahead(faced):
 		return faced + direction
 	return faced
+
+
+## `.extendRangeOverCounter`'s list: the tileset's own three
+## `wTilesetTalkingOverTiles` in Generation 1, a collision code in Generation 2.
+func _counter_ahead(cell: Vector2i) -> bool:
+	if not _gen1:
+		return Gen2WorldCollision.is_counter(gen2_code_at(cell))
+	return current_tileset != null \
+		and current_tileset.counter_tiles.has(_gen1_tile_drawn_at(cell))
 
 
 func fishing_request(
@@ -2198,6 +2207,8 @@ func can_encounter_wild_mon() -> bool:
 func can_encounter_wild_mon_at(cell: Vector2i) -> bool:
 	if state.wild_encounters_off():
 		return false
+	if _gen1:
+		return _gen1_encounter_rate_at(cell) > 0
 	var code: int = gen2_code_at(cell)
 	var environment: int = current_map.environment if current_map != null else 0
 	if environment != ENVIRONMENT_CAVE and environment != ENVIRONMENT_DUNGEON \
@@ -2224,12 +2235,27 @@ func visible_encounter_cells() -> Dictionary:
 			var cell := Vector2i(x, y)
 			if not can_encounter_wild_mon_at(cell):
 				continue
-			var permission: int = collision_permission_at(cell)
-			if permission == Gen2WorldCollision.WATER_TILE:
-				out[Gen2WorldEncounter.METHOD_SURF].append(Vector2(cell))
-			elif permission == Gen2WorldCollision.LAND_TILE:
-				out[Gen2WorldEncounter.METHOD_GRASS].append(Vector2(cell))
+			var terrain: StringName = _terrain_method(cell)
+			if out.has(terrain):
+				out[terrain].append(Vector2(cell))
 	return out
+
+
+## The table a step on [param cell] rolls on, empty for a cell that stands on
+## neither. `.gotWildEncounterType` reads the bottom left tile of the quarter
+## block in Generation 1; Generation 2 reads the standing permission itself.
+func _terrain_method(cell: Vector2i) -> StringName:
+	var permission: int = collision_permission_at(cell)
+	if permission != Gen2WorldCollision.WATER_TILE \
+		and permission != Gen2WorldCollision.LAND_TILE:
+		return &""
+	if _gen1:
+		return Gen2WorldEncounter.METHOD_SURF \
+			if _gen1_tile_drawn_at(cell) == Gen1Layout.WATER_TILE \
+			else Gen2WorldEncounter.METHOD_GRASS
+	return Gen2WorldEncounter.METHOD_SURF \
+		if permission == Gen2WorldCollision.WATER_TILE \
+		else Gen2WorldEncounter.METHOD_GRASS
 
 
 ## `wildoff`. The only thing that empties [method visible_encounter_cells] while
@@ -2284,7 +2310,9 @@ func active_encounter_tables() -> Dictionary:
 			continue
 		out[method] = {
 			"source": source,
-			"slots": Gen2WorldEncounter.active_slots(record, method, object_time_of_day),
+			"slots": Gen2WorldEncounter.active_slots(
+				record, method, object_time_of_day, _gen1
+			),
 		}
 	return out
 
@@ -2314,12 +2342,8 @@ func encounter_request(
 			return {}
 		if not can_encounter_wild_mon():
 			return {}
-	var permission: int = collision_permission_at(player_cell)
-	var terrain_method: StringName = method
-	if terrain_method == &"auto" and permission == Gen2WorldCollision.WATER_TILE:
-		terrain_method = Gen2WorldEncounter.METHOD_SURF
-	elif terrain_method == &"auto" and permission == Gen2WorldCollision.LAND_TILE:
-		terrain_method = Gen2WorldEncounter.METHOD_GRASS
+	var terrain_method: StringName = _terrain_method(player_cell) \
+		if method == &"auto" else method
 	if terrain_method not in [Gen2WorldEncounter.METHOD_GRASS, Gen2WorldEncounter.METHOD_SURF]:
 		return {}
 	## `RandomEncounter`'s Bug Contest branch, which replaces the map's own
@@ -2328,7 +2352,7 @@ func encounter_request(
 		return _bug_contest_request(random, force_encounter, lead_level, cleanse_tag)
 	var source: StringName = Gen2WorldEncounter.SOURCE_NORMAL
 	var record: Dictionary = data.world_encounter(terrain_method, current_map.group, current_map.number)
-	if state.swarm_active_on(current_map.group, current_map.number):
+	if not _gen1 and state.swarm_active_on(current_map.group, current_map.number):
 		var swarm_method: StringName = &"swarm_grass" if terrain_method == Gen2WorldEncounter.METHOD_GRASS else &"swarm_water"
 		var swarm_record: Dictionary = data.world_encounter(
 			swarm_method, current_map.group, current_map.number
@@ -2339,13 +2363,19 @@ func encounter_request(
 	var resolved: Dictionary = Gen2WorldEncounter.resolve(
 		record, terrain_method, object_time_of_day, random, force_encounter, {
 			"source": source,
-			"roaming_mons": state.roaming_mons(),
+			## `.RoamMon1` is Generation 2's; nothing roams Kanto in Generation 1,
+			## and an empty list would still spend the draw the walk reads.
+			"roaming_mons": [] if _gen1 else state.roaming_mons(),
 			"map_group": current_map.group,
 			"map_number": current_map.number,
 			"repel_steps": state.repel_steps(),
 			"lead_level": lead_level,
-			"map_music": state.map_music(),
-			"cleanse_tag": cleanse_tag,
+			## Generation 1 has neither `ApplyMusicEffectOnEncounterRate` nor a
+			## Cleanse Tag, and its own music ids overlap the three that routine
+			## reads, so both are Generation 2's alone.
+			"map_music": 0 if _gen1 else state.map_music(),
+			"cleanse_tag": cleanse_tag and not _gen1,
+			"generation": data.generation,
 			## `ChooseWildEncounter`'s own `ld a, [wUnlockedUnowns] / and a`, and
 			## the guard that keeps `CheckUnownLetter`'s reroll answerable: on a
 			## save that has solved no Ruins of Alph puzzle there is no letter to
@@ -3620,6 +3650,11 @@ var _gen1: bool = false
 ## `wLastMap`, the outdoor map a [constant Gen1Layout.WARP_TO_LAST_MAP] warp
 ## comes back out to. Generation 2 has no such warp and never writes it.
 var _gen1_last_map: int = -1
+## `wRivalName`, which no Generation 1 save model holds yet.
+var gen1_rival_name: String = Gen2WorldScriptRunner.UNNAMED
+## `DisplayTextID` holds `HandleMap` until its press, and there is no script
+## here to hold the world instead.
+var _gen1_text_open: bool = false
 
 
 ## The raw cartridge permission byte at a walk cell.
@@ -3654,6 +3689,40 @@ func collision_code_at(cell: Vector2i) -> int:
 ## `SetPal_Overworld` names no branch of its own. -1 until a warp writes it.
 func gen1_last_map() -> int:
 	return _gen1_last_map
+
+
+## `IsSpriteOrSignInFrontOfPlayer`: a sign on the faced cell answers first and
+## returns, and only then is a sprite looked for. A Generation 1 script is
+## machine code this port does not run, so a box is the whole of an interaction.
+func _gen1_interact() -> Array:
+	if current_map == null:
+		return []
+	var text_id: int = _gen1_text_id_at(facing_cell(), &"bg_events")
+	if text_id <= 0:
+		text_id = _gen1_text_id_at(object_facing_cell(), &"objects")
+	var row: Dictionary = current_map.text_at(text_id)
+	var text: String = Gen2TextStream.fill_names(String(row.get("text", "")), {
+		"player": _player_name if not _player_name.is_empty() \
+			else Gen2WorldScriptRunner.UNNAMED,
+		"rival": gen1_rival_name,
+	})
+	if text.is_empty():
+		return []
+	_gen1_text_open = true
+	## `AfterDisplayingTextID` ends every one of these on
+	## `WaitForTextScrollButtonPress`, whatever the string's last byte said.
+	return [{
+		"ok": true,
+		"status": &"waiting",
+		"event": {"type": &"text", "text": text, "prompt": true},
+	}]
+
+
+func _gen1_text_id_at(cell: Vector2i, kind: StringName) -> int:
+	for event: Dictionary in _active_events_at(cell):
+		if event.get("kind", &"") == kind and int(event.get("text", 0)) > 0:
+			return int(event["text"])
+	return 0
 
 
 ## A Generation 2 collision code at [param cell], or -1 on a Generation 1 map,
@@ -3787,14 +3856,14 @@ func dispatch_sight_events() -> Array:
 
 
 func script_input_waiting() -> bool:
-	return _active_script != null and _active_script.is_waiting()
+	return _gen1_text_open or (_active_script != null and _active_script.is_waiting())
 
 
 ## True while a script holds the world, either running or still queued. A host
 ## that drives ambient motion checks this so a script keeps sole ownership of
 ## the objects it may be moving.
 func script_busy() -> bool:
-	return _active_script != null or not _script_queue.is_empty()
+	return _gen1_text_open or _active_script != null or not _script_queue.is_empty()
 
 
 ## Whether the script holding the world is one that stops the map around it.
@@ -3912,8 +3981,10 @@ func load_object_masks() -> void:
 ## This is the explicit interaction boundary for NPCs, signs and item-like
 ## objects. It never executes a hidden object or invents a fallback action.
 func interact() -> Array:
-	if _active_script != null or not _script_queue.is_empty():
+	if _active_script != null or not _script_queue.is_empty() or _gen1_text_open:
 		return run_event_queue(false)
+	if _gen1:
+		return _gen1_interact()
 	var target: Vector2i = facing_cell()
 	var events: Array = []
 	## TryObjectEvent runs before TryBGEvent in the cartridge event loop. Keep
@@ -4032,6 +4103,11 @@ func _tile_collision_script_request(cell: Vector2i) -> Dictionary:
 ## script. Completed results retain the source event so a screen can react to
 ## them without reaching into the runner.
 func run_event_queue(acknowledge: bool = false, choice: int = -1) -> Array:
+	## `AfterDisplayingTextID` waits for the press and `CloseTextDisplay` returns
+	## to `HandleMap`, with no script behind it to resume.
+	if _gen1_text_open:
+		_gen1_text_open = not acknowledge
+		return []
 	var results: Array = []
 	var accept: bool = acknowledge
 	var selected_choice: int = choice
@@ -5248,6 +5324,55 @@ func edge_warp_ready(direction: Vector2i) -> bool:
 ## `LoadTileBlockMap` fills the three blocks past every edge with the map's own
 ## border block, so `_GetTileAndCoordsInFrontOfPlayer` reads that rather than
 ## nothing at the edge. -1 stays -1 where the border block is the $FF naming none.
+## `TryDoWildEncounter`'s own gate, which reads the tile a cell draws rather than
+## a permission byte: `wGrassTile` takes the grass rate, $14 the water rate, and
+## an indoor map takes the grass rate anywhere but Viridian Forest and the Safari
+## Zone. Zero is a cell no wild can be met on.
+func _gen1_encounter_rate_at(cell: Vector2i) -> int:
+	if current_map == null or current_tileset == null or data == null:
+		return 0
+	## `IsPlayerJustOutsideMap`, which compares each coordinate with the map's own
+	## dimension doubled: exactly one cell past the bottom or right edge, and
+	## nothing on the other two sides.
+	if cell.x == current_map.collision_width or cell.y == current_map.collision_height:
+		return 0
+	var standing: int = _gen1_tile_drawn_at(cell)
+	if Gen2WorldCollision.gen1_is_warp_tile(current_map.tileset, standing) \
+		or Gen2WorldCollision.gen1_is_door_tile(current_map.tileset, standing):
+		return 0
+	var tile: int = _gen1_encounter_tile_at(cell)
+	if tile == current_tileset.grass_tile:
+		return _gen1_encounter_rate(Gen2WorldEncounter.METHOD_GRASS)
+	if tile == Gen1Layout.WATER_TILE:
+		return _gen1_encounter_rate(Gen2WorldEncounter.METHOD_SURF)
+	if current_map.number < Gen1Layout.FIRST_INDOOR_MAP \
+		or current_map.tileset == Gen1Layout.TILESET_FOREST:
+		return 0
+	return _gen1_encounter_rate(Gen2WorldEncounter.METHOD_GRASS)
+
+
+func _gen1_encounter_rate(method: StringName) -> int:
+	return int(data.world_encounter(
+		method, current_map.group, current_map.number
+	).get("rate", 0))
+
+
+## The bottom right tile of the quarter block [param cell] is, which only
+## `TryDoWildEncounter` reads. Off the map that is the border block's, as it is
+## for the bottom left the grid holds.
+func _gen1_encounter_tile_at(cell: Vector2i) -> int:
+	if current_map == null or current_tileset == null:
+		return -1
+	var block: int = current_map.border_block if collision_code_at(cell) < 0 \
+		else block_at(cell.x >> 1, cell.y >> 1)
+	if block >= current_tileset.block_count:
+		return -1
+	return current_tileset.tile_index(block, Gen1Layout.cell_encounter_tile_index(
+		posmod(cell.x, Gen2Layout.MAP_BLOCK_CELL_WIDTH),
+		posmod(cell.y, Gen2Layout.MAP_BLOCK_CELL_WIDTH)
+	))
+
+
 func _gen1_tile_drawn_at(cell: Vector2i) -> int:
 	var code: int = collision_code_at(cell)
 	if code >= 0 or current_map == null or current_tileset == null \
@@ -6570,6 +6695,7 @@ func _apply_map(
 		target_map.group, target_map.number, target_map.tileset, target_cell,
 	])
 	_record_escape_points(target_map, from_warp)
+	_gen1_text_open = false
 	## `WarpFound2`'s `CheckIfInOutsideMap`: leaving a town or a route records it,
 	## and that is the map a `LAST_MAP` warp comes back out to.
 	if _gen1 and current_map != null and Gen1Layout.is_outside_tileset(current_map.tileset):

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -44,7 +44,8 @@ static func resolve(
 	if random == null:
 		generator.randomize()
 
-	var rate: int = _rate(record, method, time_of_day)
+	var gen1: bool = int(options.get("generation", RomRegistry.GEN2)) == RomRegistry.GEN1
+	var rate: int = _rate(record, method, time_of_day, gen1)
 	rate = apply_music_effect(rate, int(options.get("map_music", 0)))
 	if bool(options.get("cleanse_tag", false)):
 		rate >>= 1
@@ -85,7 +86,7 @@ static func resolve(
 				values["dvs"] = int(roaming.get("dvs", 0))
 			return roamer
 
-	var mon: Dictionary = _wild_mon(record, method, time_of_day, generator, options)
+	var mon: Dictionary = _wild_mon(record, method, time_of_day, generator, options, gen1)
 	if mon.is_empty():
 		return {}
 	var level: int = int(mon["level"])
@@ -101,10 +102,10 @@ static func resolve(
 ## `ChooseWildEncounter`: the drawn slot, with `.surfmon`'s variance spent.
 static func _wild_mon(
 	record: Dictionary, method: StringName, time_of_day: int,
-	generator: RandomNumberGenerator, options: Dictionary
+	generator: RandomNumberGenerator, options: Dictionary, gen1: bool = false
 ) -> Dictionary:
-	var slots: Array = _slots(record, method, time_of_day)
-	var slot: int = _choose_slot(generator, method)
+	var slots: Array = _slots(record, method, time_of_day, gen1)
+	var slot: int = _choose_slot(generator, method, gen1)
 	if slot < 0 or slot >= slots.size():
 		return {}
 	var selected: Variant = slots[slot]
@@ -112,7 +113,8 @@ static func _wild_mon(
 		return {}
 	var species: int = int((selected as Dictionary).get("species", 0))
 	var level: int = int((selected as Dictionary).get("level", 0))
-	if species < 1 or species > Gen2Layout.SPECIES_COUNT or level < 1 or level > Gen2Layout.MAX_LEVEL:
+	var highest: int = Gen1Layout.INDEX_COUNT if gen1 else Gen2Layout.SPECIES_COUNT
+	if species < 1 or species > highest or level < 1 or level > Gen2Layout.MAX_LEVEL:
 		return {}
 	## The last test, after `ValidateTempWildMonSpecies` and on the drawn slot
 	## rather than the table: a wild UNOWN is refused outright while
@@ -120,7 +122,9 @@ static func _wild_mon(
 	if species == Gen2Layout.UNOWN_SPECIES and int(options.get("unlocked_unowns", -1)) == 0:
 		return {}
 	var level_roll: int = -1
-	if method == METHOD_SURF:
+	## `.surfmon`'s variance is Generation 2's: a Generation 1 water slot carries
+	## its own level and `TryDoWildEncounter` reads it unchanged.
+	if method == METHOD_SURF and not gen1:
 		level_roll = generator.randi_range(0, 255)
 		level = mini(level + _surf_level_bonus(level_roll), Gen2Layout.MAX_LEVEL)
 	return {"slot": slot, "species": species, "level": level, "level_roll": level_roll}
@@ -309,8 +313,11 @@ static func _append_nest(out: Array, data: GameData, map_key: String) -> void:
 		out.append(map.location)
 
 
-static func _rate(record: Dictionary, method: StringName, time_of_day: int) -> int:
-	if method == METHOD_SURF:
+static func _rate(
+	record: Dictionary, method: StringName, time_of_day: int, gen1: bool = false
+) -> int:
+	## One `def_grass_wildmons` rate byte a block, with no time of day behind it.
+	if gen1 or method == METHOD_SURF:
 		return int(record.get("rate", 0))
 	var rates: Variant = record.get("rates", [])
 	if not rates is Array or (rates as Array).is_empty():
@@ -335,11 +342,13 @@ static func apply_music_effect(rate: int, map_music: int) -> int:
 	return rate
 
 
-static func _slots(record: Dictionary, method: StringName, time_of_day: int) -> Array:
+static func _slots(
+	record: Dictionary, method: StringName, time_of_day: int, gen1: bool = false
+) -> Array:
 	var value: Variant = record.get("slots", [])
 	if not value is Array:
 		return []
-	if method == METHOD_SURF:
+	if gen1 or method == METHOD_SURF:
 		return value as Array
 	var index: int = mini(2, maxi(0, time_of_day))
 	return (value as Array)[index] if index < (value as Array).size() and (value as Array)[index] is Array else []
@@ -349,9 +358,11 @@ static func _slots(record: Dictionary, method: StringName, time_of_day: int) -> 
 ## `{species, min_level, max_level}`. A cartridge table names one level per slot,
 ## so the bounds are equal; the shape is the Bug Contest's, whose rows are a
 ## range. See [method Gen2WorldAPI.active_encounter_tables].
-static func active_slots(record: Dictionary, method: StringName, time_of_day: int) -> Array:
+static func active_slots(
+	record: Dictionary, method: StringName, time_of_day: int, gen1: bool = false
+) -> Array:
 	var out: Array = []
-	for slot: Variant in _slots(record, method, time_of_day):
+	for slot: Variant in _slots(record, method, time_of_day, gen1):
 		if not slot is Dictionary:
 			continue
 		var level: int = int((slot as Dictionary).get("level", 0))
@@ -363,7 +374,18 @@ static func active_slots(record: Dictionary, method: StringName, time_of_day: in
 	return out
 
 
-static func _choose_slot(random: RandomNumberGenerator, method: StringName) -> int:
+static func _choose_slot(
+	random: RandomNumberGenerator, method: StringName, gen1: bool = false
+) -> int:
+	## `.determineEncounterSlot`: one byte of the generator against
+	## `WildMonEncounterSlotChances`' cumulative column, which sums to 256, so
+	## there is nothing to reject and grass and water draw from one table.
+	if gen1:
+		var roll: int = random.randi_range(0, 255)
+		for slot: int in Gen1Layout.WILD_SLOT_CHANCES.size():
+			if roll <= Gen1Layout.WILD_SLOT_CHANCES[slot]:
+				return slot
+		return -1
 	var probabilities: Array[int] = (
 		Gen2Layout.WILD_WATER_PROBABILITIES if method == METHOD_SURF
 		else Gen2Layout.WILD_GRASS_PROBABILITIES

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -32,6 +32,9 @@ var connection_flags: int = 0
 var connections: Array = []
 var scripts: Dictionary = {}
 var events: Dictionary = {}
+## `<Map>_TextPointers` decoded, one row a text id from 1 up. Generation 1 only:
+## a Generation 2 map's text is inside the script its event names.
+var texts: Array = []
 
 
 static func from_cache(value: Dictionary) -> Gen2WorldMap:
@@ -62,7 +65,15 @@ static func from_cache(value: Dictionary) -> Gen2WorldMap:
 		out.connections = []
 	out.scripts = _scripts_from_cache(value.get("scripts", {}))
 	out.events = _events_from_cache(value.get("events", {}))
+	out.texts = _text_rows(value.get("texts", []))
 	return out
+
+
+## The text one id names. Ids count from one, as `DisplayTextID`'s `dec a` says.
+func text_at(id: int) -> Dictionary:
+	if id < 1 or id > texts.size():
+		return {}
+	return texts[id - 1]
 
 
 func block_at(block_x: int, block_y: int) -> int:
@@ -89,6 +100,17 @@ static func _scripts_from_cache(value: Variant) -> Dictionary:
 		"scenes": _script_pointer_rows(script_values.get("scenes", [])),
 		"callbacks": _script_pointer_rows(script_values.get("callbacks", [])),
 	}
+
+
+static func _text_rows(value: Variant) -> Array:
+	if not value is Array:
+		return []
+	var out: Array = []
+	for raw: Dictionary in value as Array:
+		var row: Dictionary = raw.duplicate(true)
+		row["command"] = int(raw.get("command", 0))
+		out.append(row)
+	return out
 
 
 static func _script_pointer_rows(value: Variant) -> Array:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4937,6 +4937,16 @@ func _handle_fishing_result(result: Dictionary) -> void:
 func _start_battle_request(request: Dictionary) -> void:
 	if _battle_host != null or _battle_transition != null or _data == null:
 		return
+	## No Generation 1 battle engine: its species are internal indexes and its
+	## stats a different formula, so the request is reported rather than fought.
+	## `RomRegistry`'s `playable` flag is what keeps a player off this path.
+	if _data.generation == RomRegistry.GEN1:
+		_script_prompt = "Wild %d, level %d" % [
+			int((request.get("values", {}) as Dictionary).get("pokemon", 0)),
+			int((request.get("values", {}) as Dictionary).get("level", 0)),
+		]
+		_refresh_labels()
+		return
 	_play_battle_music(request)
 	_battle_transition_request = request.duplicate(true)
 	_battle_transition = _build_battle_transition(request)

--- a/game/world/world_script_runner.gd
+++ b/game/world/world_script_runner.gd
@@ -119,7 +119,7 @@ var _text_buffers: Dictionary = {}
 ## Magikarp record holder's name and the Poke Seer's five. Keyed by address so
 ## they reach `TextCommand_RAM` through the same map the string buffers do.
 var _text_ram: Dictionary = {}
-var _rival_name: String = "???"
+var _rival_name: String = UNNAMED
 ## wPlayerName, mirrored from the selected save the way Gen2WorldAPI mirrors
 ## wPlayerID. `<PLAYER>` is a `CheckDict` entry, so a text carrying one cannot
 ## be printed without it; empty leaves the marker visible rather than inventing
@@ -138,6 +138,9 @@ var _random := RandomNumberGenerator.new()
 var _cur_party_species: int = 0
 ## Which balance window `engine/menus/menu_2.asm` left standing, empty for none.
 var _money_window: StringName = &""
+
+## What `<RIVAL>` prints before a rival has been named, in either generation.
+const UNNAMED: String = "???"
 
 const PIKACHU: int = 25
 const PIKACHU_DEBUG_LEVEL: int = 5

--- a/tests/integration/world_trainer_fixture.gd
+++ b/tests/integration/world_trainer_fixture.gd
@@ -1037,12 +1037,13 @@ static func _write_battle_graphics(cache_directory: String, manifest: Dictionary
 		"mail_gfx": [Gen2Layout.MAIL_GFX_TILES, PokeTiles.INK],
 		"mail_icon": [Gen2Layout.MAIL_ICON_TILES, 2],
 	}
-	## The font and the frames are the two sheets addressed by character code
-	## rather than by slot, so both need their real first code. A frames sheet
+	## The font, the frames and `FontExtra` are the sheets addressed by character
+	## code rather than by slot, so each needs its real first code. A frames sheet
 	## left on 0 draws nothing at all, since every box-drawing code is then past
 	## the end of the strip.
 	var first_codes: Dictionary = {
 		"font": Gen2Layout.FONT_FIRST_CODE,
+		"font_extra": Gen2Layout.FONT_EXTRA_FIRST_CODE,
 		"frames": Gen2Layout.FRAME_FIRST_CODE,
 		"copyright": Gen2Layout.COPYRIGHT_FIRST_CODE,
 		"up_arrow": Gen2Text.UP_ARROW_CODE,

--- a/tests/unit/test_font.gd
+++ b/tests/unit/test_font.gd
@@ -17,6 +17,7 @@ const FONT_EXTRA_INK: int = 1
 
 var _directory: String = ""
 var _font: Gen2Font = null
+var _gen1_directory: String = ""
 
 
 func before_each() -> void:
@@ -29,6 +30,48 @@ func before_each() -> void:
 
 func after_each() -> void:
 	RomCache.clear(_directory)
+	if not _gen1_directory.is_empty():
+		RomCache.clear(_gen1_directory)
+		_gen1_directory = ""
+
+
+## A Generation 1 cache: `TextBoxGraphics` and no `frames` sheet, which is where
+## that generation keeps its one border. Its ink says which strip a pixel came
+## from, the way the sheets above do.
+func _gen1_font() -> Gen2Font:
+	_gen1_directory = RomCache.directory_for(&"fontgame1", "0123456789abcdef")
+	RomCache.clear(_gen1_directory)
+	RomCache.prepare(_gen1_directory)
+
+	var glyphs: PackedByteArray = PackedByteArray()
+	glyphs.resize(WIDTH * Gen2Font.TILE)
+	glyphs.fill(PokeTiles.INK)
+	RomCache.write_indices(RomCache.tile_path(_gen1_directory, "font"), glyphs)
+
+	var extra: PackedByteArray = PackedByteArray()
+	extra.resize(FONT_EXTRA_WIDTH * Gen2Font.TILE)
+	extra.fill(FONT_EXTRA_INK)
+	RomCache.write_indices(RomCache.tile_path(_gen1_directory, "font_extra"), extra)
+
+	RomCache.write_json(RomCache.manifest_path(_gen1_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "fontgame1",
+		"sha1": "0123456789abcdef",
+		"complete": true,
+		"generation": RomRegistry.GEN1,
+		"tiles": {
+			"font": {
+				"width": WIDTH, "height": Gen2Font.TILE,
+				"tiles": SHEET_TILES, "first_code": Gen1Layout.FONT_FIRST_CODE,
+			},
+			"font_extra": {
+				"width": FONT_EXTRA_WIDTH, "height": Gen2Font.TILE,
+				"tiles": Gen1Layout.FONT_EXTRA_TILES,
+				"first_code": Gen1Layout.FONT_EXTRA_FIRST_CODE,
+			},
+		},
+	})
+	return Gen2Font.from_data(GameData.open_directory(_gen1_directory))
 
 
 ## Three solid glyphs and one frame of six solid border tiles.
@@ -266,3 +309,34 @@ func test_drawing_stops_at_the_bound_and_marks_it() -> void:
 	var into: PackedByteArray = _canvas(4)
 	assert_eq(_font.draw_text("AAAA", into, 4 * Gen2Font.TILE, 0, 0, Gen2Text.FONT_MAIN, 2), 2)
 	assert_eq(into[Gen2Font.TILE * 2], 0, "nothing past the bound")
+
+
+func test_generation_1_draws_its_border_out_of_the_text_box_sheet() -> void:
+	# `LoadTextBoxTilePatterns` is the whole of that generation's border: the six
+	# tiles sit inside `TextBoxGraphics` at $79 and there is no `frames` sheet.
+	var font: Gen2Font = _gen1_font()
+	assert_not_null(font)
+	assert_eq(font.frame_count(), 1)
+	var into: PackedByteArray = _canvas(4)
+	font.draw_box(0, into, 2 * Gen2Font.TILE, 0, 0, 2, 2)
+	assert_eq(into[0], FONT_EXTRA_INK, "the corner comes off the text box sheet")
+
+
+func test_generation_1_answers_every_frame_style_with_its_one_border() -> void:
+	# The options screen offers eight; only Generation 2 has eight to offer.
+	var font: Gen2Font = _gen1_font()
+	var first: PackedByteArray = _canvas(1)
+	var last: PackedByteArray = _canvas(1)
+	font.draw_frame_code(0, Gen1Layout.FRAME_FIRST_CODE, first, Gen2Font.TILE, 0, 0)
+	font.draw_frame_code(
+		Gen2Layout.FRAME_COUNT - 1, Gen1Layout.FRAME_FIRST_CODE, last, Gen2Font.TILE, 0, 0
+	)
+	assert_eq(first, last)
+	assert_eq(first.count(FONT_EXTRA_INK), first.size())
+
+
+func test_generation_1_encodes_through_its_own_codec() -> void:
+	# $d4 is Crystal's `\u0027s` and a blank tile in `FontGraphics`, so a box
+	# encoded by the wrong codec prints a hole.
+	assert_eq(_gen1_font().encode("'s"), Gen1Text.encode("'s"))
+	assert_eq(_font.encode("'s"), Gen2Text.encode("'s"))

--- a/tests/unit/test_gen1_text.gd
+++ b/tests/unit/test_gen1_text.gd
@@ -70,3 +70,31 @@ func test_a_dex_description_ends_on_dexend_and_breaks_on_its_line_codes() -> voi
 func test_decoding_stops_at_the_end_of_the_buffer() -> void:
 	assert_eq(Gen1Text.decode(_bytes([0x80]), 0, 40), "A")
 	assert_eq(Gen1Text.decode(PackedByteArray(), 0, 40), "")
+
+
+## `font_extra.png`, which `LoadTextBoxTilePatterns` parks at $60 and which the
+## charmap maps as characters: the ellipsis is written as itself in source text,
+## so a text carrying one has to encode back to the tile that draws it.
+func test_the_text_box_sheet_is_characters_as_well_as_a_border() -> void:
+	assert_eq(Gen1Text.character(Gen1Text.ELLIPSIS_CODE), "\u2026")
+	assert_eq(Gen1Text.character(0x72), "\u201c")
+	assert_eq(Gen1Text.character(Gen1Layout.FRAME_FIRST_CODE), "\u250c")
+	assert_eq(Gen1Text.encode("\u2026"), _bytes([Gen1Text.ELLIPSIS_CODE]))
+
+
+## A name too long to be one tile stays decode-only, the way `<PLAYER>` does:
+## [method encode] matches two characters at a time.
+func test_an_unused_bold_letter_does_not_encode() -> void:
+	assert_eq(Gen1Text.character(0x60), "<BOLD_A>")
+	assert_eq(Gen1Text.encode("<BOLD_A>").size(), 8, "eight characters, not one tile")
+
+
+## `PlacePKMN`'s text is `db "<PK><MN>@"`: two narrow tiles, never six letters.
+func test_pkmn_places_its_own_two_tiles() -> void:
+	assert_eq(Gen1Text.encode("<PKMN>"), _bytes([0xE1, 0xE2]))
+
+
+## `PlacePOKe` prints four characters for `#`, all of which the font draws, so
+## the word needs no pair of its own.
+func test_poke_is_four_letters() -> void:
+	assert_eq(Gen1Text.encode(Gen1Text.character(0x54)).size(), 4)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 480 lines of the 38360 here, and Generation 1's colour, sprites, wild
-## tables and walk added 114 more to the shared collision, palette, world and
-## renderer code, most of that the six tables `CheckTilePassable` stands in for.
-## Four sweeps have said the tree has no restatement left to pay with.
-const MAX_COMMENT_LINES: int = 38360
+## are 520 lines of the 38480 here, and Generation 1's colour, sprites, wild
+## tables, walk, text box and encounter roll added 201 more to the shared
+## collision, palette, world, encounter, text and renderer code. Four sweeps
+## have said the tree has no restatement left to pay with.
+const MAX_COMMENT_LINES: int = 38480
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_text_stream.gd
+++ b/tests/unit/test_text_stream.gd
@@ -150,3 +150,62 @@ func test_the_two_scrolls_that_wait_for_nothing_are_their_own_break() -> void:
 	assert_true(command["ok"])
 	assert_eq(command["text"], "A" + Gen2TextStream.SCROLL_NOWAIT_BREAK + "B")
 	assert_false(bool(command["prompt"]))
+
+
+## `macros/scripts/text.asm` in pokered: the first eleven commands agree with
+## Crystal's and then part. `TX_FAR` is $17 there, $14 to $16 are three more
+## cries, and a reader that took Crystal's $16 for the far pointer read a cry as
+## one and walked into whatever followed it.
+func test_generation_1_reads_its_own_command_set() -> void:
+	var far: PackedByteArray = PackedByteArray([0x00, 0x82, 0x57])
+	var decoded: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x00, 0x80, 0x50, 0x14, 0x15, 0x16, 0x17, 0x00, 0x40, 0x03]),
+		0,
+		{
+			"generation": RomRegistry.GEN1,
+			"far": func(bank: int, address: int) -> PackedByteArray:
+				return far if bank == 3 and address == 0x4000 else PackedByteArray(),
+		}
+	)
+	assert_true(decoded["ok"])
+	assert_eq(decoded["text"], "AC", "the three cries draw nothing and $17 is the far pointer")
+
+
+## `PlaceNextChar`'s dictionary is not `CheckDict`'s: $49 is `PageChar` there and
+## `<MOM>` in Crystal, and Generation 1 has no `<LF>`, `<BSP>` or `<WBR>`.
+func test_generation_1_breaks_its_line_on_page_where_crystal_names_mom() -> void:
+	var bytes: PackedByteArray = PackedByteArray([0x00, 0x80, 0x49, 0x81, 0x57])
+	assert_eq(
+		Gen2TextStream.decode(bytes, 0, {"generation": RomRegistry.GEN1})["text"], "A\nB"
+	)
+	assert_eq(Gen2TextStream.decode(bytes, 0, {"mom": "MUM"})["text"], "AMUMB")
+
+
+## `PlacePKMN` places two narrow tiles and `PlacePOKe` four letters, so the two
+## dictionary entries are not spellings. Generation 1 keeps the ligatures and the
+## accented e in a different run from Crystal's.
+func test_generation_1_takes_its_glyphs_from_its_own_codec() -> void:
+	var decoded: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x00, 0xBD, 0xBA, 0x4A, 0x57]), 0,
+		{"generation": RomRegistry.GEN1}
+	)
+	assert_eq(decoded["text"], "'sé<PKMN>")
+
+
+## `text_move` is `db TX_MOVE` and `dw \1`: two operand bytes, not three. Taking
+## a third slid every command behind it by one.
+func test_a_cursor_move_consumes_two_operand_bytes() -> void:
+	var decoded: Dictionary = Gen2TextStream.decode(
+		PackedByteArray([0x03, 0x00, 0xC5, 0x00, 0x80, 0x57])
+	)
+	assert_true(decoded["ok"])
+	assert_eq(decoded["text"], "A")
+
+
+## The print-time names a text decoded before a save existed still carries, which
+## is every Generation 1 map text.
+func test_a_marker_left_by_a_decode_is_filled_by_name() -> void:
+	assert_eq(
+		Gen2TextStream.fill_names("<PLAYER> met <RIVAL>", {"player": "RED", "rival": "BLUE"}),
+		"RED met BLUE"
+	)

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -96,6 +96,19 @@ const PALETTE_CENSUS: Dictionary = {
 		11: 1, 25: 10, 35: 20},
 }
 
+## Every row of `<Map>_TextPointers` the maps' signs and objects reach, by the
+## byte that opens it. Yellow's six bare `text_end`s are Jessie and James, whose
+## two ids share one on three maps.
+const TEXT_CENSUS: Dictionary = {
+	&"red": {0x08: 626, 0x17: 456, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"blue": {0x08: 626, 0x17: 456, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"yellow": {0x08: 675, 0x17: 429, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3,
+		0xFE: 14, 0xFF: 12},
+}
+
+## `_MtMoonPokecenterClipboardText`, the corpus's one empty box.
+const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
+
 ## `NUM_SPRITES` and `FIRST_STILL_SPRITE`, with `SpriteSheetPointerTable`'s
 ## first row: `RedSprite`, $C0 bytes in bank $05.
 const SPRITE_COUNTS: Dictionary = {&"red": 72, &"blue": 72, &"yellow": 82}
@@ -121,6 +134,7 @@ func _one_game() -> void:
 	_pallet_town()
 	_geometry()
 	_events()
+	_texts()
 	_wild_objects()
 	_palettes()
 	_sprites()
@@ -214,6 +228,59 @@ func _pallet_town() -> void:
 			_rows(map.connections, ["direction", "map_number", "y_alignment"]),
 		]
 	)
+	## `text/PalletTown.asm` as pret writes it: the town sign's `cont` is a
+	## scroll and the two house signs keep the names a print fills in.
+	var pinned: Array[String] = [
+		"OAK POKéMON\nRESEARCH LAB",
+		"PALLET TOWN\nShades of your%sjourney await!" % Gen2TextStream.SCROLL_BREAK,
+		"<PLAYER>'s house ",
+		"<RIVAL>'s house ",
+	]
+	for index: int in pinned.size():
+		var text: String = String(map.text_at(index + 4).get("text", ""))
+		_r.check(text == pinned[index], "Pallet Town's text %d reads %s." % [index + 4, text])
+
+
+## Every decoded text in the corpus: what each row opens with, and that every
+## character of a box draws a tile. `FontGraphics` is blank from $c0 to $df, so a
+## code from the wrong generation's codec is a hole rather than a wrong letter.
+func _texts() -> void:
+	var font: Gen2Font = Gen2Font.from_data(_r.data)
+	if not _r.check(font != null, "the cache has no font."):
+		return
+	var census: Dictionary = {}
+	var empty: int = 0
+	var blank: Array[String] = []
+	for map: Gen2WorldMap in _maps.values():
+		for row: Dictionary in map.texts:
+			var command: int = int(row["command"])
+			census[command] = int(census.get(command, 0)) + 1
+			var text: String = String(row.get("text", ""))
+			if text.is_empty():
+				empty += 1 if command in [Gen1Text.TEXT_FAR, Gen1Text.TEXT_START] else 0
+				continue
+			for line: String in text.split("\n"):
+				if not _drawn(font, line) and blank.size() < 4:
+					blank.append("map %d: %s" % [map.number, line])
+	_r.check(blank.is_empty(), "texts draw a blank tile: %s." % [blank])
+	_r.check(census == TEXT_CENSUS[_r.game_id], "the text rows read %s." % [census])
+	_r.check(empty == int(EMPTY_TEXTS[_r.game_id]),
+		"%d texts decoded to nothing, pinned %d." % [empty, int(EMPTY_TEXTS[_r.game_id])])
+	_r.note("gen1 texts %s" % [census])
+
+
+## Whether every code [param line] encodes to has ink behind it.
+static func _drawn(font: Gen2Font, line: String) -> bool:
+	for code: int in font.encode(line):
+		if code == Gen1Text.SPACE \
+			or (code >= Gen1Layout.FONT_EXTRA_FIRST_CODE and code <= Gen1Layout.FRAME_LAST_CODE):
+			continue
+		var inked: bool = false
+		for ink: Array in Gen1Layout.FONT_INK_RUNS:
+			inked = inked or (code >= int(ink[0]) and code <= int(ink[1]))
+		if not inked:
+			return false
+	return true
 
 
 static func _rows(events: Array, fields: Array) -> Array:

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -41,6 +41,18 @@ const REDS_HOUSE_1F: int = 37
 const PALLET_DOOR := Vector2i(5, 5)
 const REDS_HOUSE_MAT := Vector2i(2, 7)
 
+## `PalletTown_Object`'s third `bg_event` and its second `object_event`, each
+## read from the cell below it.
+const PALLET_HOUSE_SIGN := Vector2i(3, 6)
+const PALLET_GIRL := Vector2i(3, 9)
+const PALLET_GIRL_TEXT: String = "I'm raising\nPOKéMON too!"
+
+## `ViridianMart_Object`'s clerk, who stands at 0,5 behind the counter at 1,5.
+## `.extendRangeOverCounter` is what lets the player at 2,5 reach them.
+const VIRIDIAN_MART: int = 42
+const MART_COUNTER := Vector2i(2, 5)
+const MART_CLERK := Vector2i(0, 5)
+
 var _r: RefCounted = null
 
 
@@ -53,6 +65,7 @@ func _one_game() -> void:
 	_check_warps()
 	_check_ledges()
 	_check_last_map_round_trip()
+	_check_text_boxes()
 
 
 ## Every warp on every map: its destination resolves, it fires from some facing,
@@ -174,3 +187,39 @@ func _check_last_map_round_trip() -> void:
 		return
 	_r.check(world.map_id() == Vector2i(0, PALLET_TOWN) and world.player_cell == PALLET_DOOR,
 		"the way back led to %s %s." % [world.map_id(), world.player_cell])
+
+
+## `DisplayTextID` driven through the world: the box carries the map's own string
+## with `<PLAYER>` filled and the press closing it leaves nothing waiting. The
+## mart counter is `.extendRangeOverCounter`, whose reach is two cells.
+func _check_text_boxes() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, PALLET_TOWN, PALLET_HOUSE_SIGN)
+	if world == null:
+		return
+	world.set_player_name("RED")
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var read: String = _box_text(world)
+	_r.check(read == "RED's house ", "the house sign read %s." % [read])
+	_r.check(world.script_input_waiting(), "the house sign left nothing waiting.")
+	world.run_event_queue(true)
+	_r.check(not world.script_input_waiting(), "the press left the box open.")
+
+	world.player_cell = PALLET_GIRL
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var girl: String = _box_text(world)
+	_r.check(girl.begins_with(PALLET_GIRL_TEXT), "the girl said %s." % [girl])
+
+	var mart: Gen2WorldAPI = _r.open_world(0, VIRIDIAN_MART, MART_COUNTER)
+	if mart == null:
+		return
+	mart.player_facing = Gen2WorldSprite.FACING_LEFT
+	_r.check(mart.object_facing_cell() == MART_CLERK,
+		"the mart counter reaches %s." % [mart.object_facing_cell()])
+
+
+## The string one interaction puts in a box, or "" when it opened none.
+func _box_text(world: Gen2WorldAPI) -> String:
+	var results: Array = world.interact()
+	if results.is_empty():
+		return ""
+	return String((results[0].get("event", {}) as Dictionary).get("text", ""))

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -52,12 +52,30 @@ const ROAM_WALK_UPDATES: int = 400
 
 
 ## Generation 1's `WildDataPointers` and `SuperRodData`: what the corpus holds
-## and the rows read end to end off pret's `data/wild`. Nothing rolls on it yet.
+## and the rows read end to end off pret's `data/wild`.
 const GEN1_CENSUS: Dictionary = {
 	&"red": {"grass": 55, "water": 3, "fishing_maps": 33, "fishing_groups": 10},
 	&"blue": {"grass": 55, "water": 3, "fishing_maps": 33, "fishing_groups": 10},
 	&"yellow": {"grass": 55, "water": 8, "fishing_maps": 31, "fishing_groups": 31},
 }
+
+## What `TryDoWildEncounter`'s gate offers across the corpus: encounter cells,
+## how many of them read the water table, the maps holding one, and the left
+## shores among them.
+const GEN1_CELL_CENSUS: Dictionary = {
+	&"red": [17875, 3624, 57, 34],
+	&"blue": [17875, 3624, 57, 34],
+	&"yellow": [19317, 5172, 57, 38],
+}
+
+## Viridian Forest's FOREST tileset is the one indoor map that does not roll off
+## its own grass; Mt Moon's cave floor is the one that does.
+const GEN1_INDOOR_BRANCH: Array = [[0x33, false], [0x3B, true]]
+
+## Enough steps for a 1-in-256 slot and a rate of 25/256 to both show.
+const GEN1_ROLL_STEPS: int = 8000
+const GEN1_ROLL_SEED: int = 7
+const GEN1_ROLL_TOLERANCE: float = 0.01
 
 ## `Route1.asm`: rate 25 and ten slots of PIDGEY and RATTATA, by internal index.
 const GEN1_ROUTE_1: int = 0x0C
@@ -104,7 +122,120 @@ func _verify_gen1_tables() -> void:
 	_gen1_route_1()
 	_gen1_sea_routes()
 	_gen1_super_rod()
+	_gen1_cells()
+	_gen1_rolls()
 	_r.note("gen1 encounters %s" % census)
+
+
+## `TryDoWildEncounter`'s gate over the whole corpus. The census is the point:
+## a cave floor rolls everywhere and a route rolls only on `wGrassTile`, so one
+## number says both branches are live. A left shore is a half block whose bottom
+## right tile is water and whose bottom left is not, which gates on the water
+## rate and then reads the grass table.
+func _gen1_cells() -> void:
+	var pinned: Array = GEN1_CELL_CENSUS[_r.game_id]
+	var cells: int = 0
+	var surf: int = 0
+	var maps: int = 0
+	var shores: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var world: Gen2WorldAPI = _r.open_world(0, map.number, Vector2i.ZERO)
+		if world == null:
+			continue
+		var found: Dictionary = world.visible_encounter_cells()
+		var here: int = found[Gen2WorldEncounter.METHOD_GRASS].size() \
+			+ found[Gen2WorldEncounter.METHOD_SURF].size()
+		cells += here
+		surf += found[Gen2WorldEncounter.METHOD_SURF].size()
+		maps += 1 if here > 0 else 0
+		shores += _gen1_left_shores(world)
+	_r.check([cells, surf, maps, shores] == pinned,
+		"the corpus offers %s, pinned %s." % [[cells, surf, maps, shores], pinned])
+	_r.note("gen1 encounter cells %d, %d of them surf, on %d maps" % [cells, surf, maps])
+
+
+func _gen1_left_shores(world: Gen2WorldAPI) -> int:
+	var out: int = 0
+	var size: Vector2i = world.map_size_cells()
+	for y: int in size.y:
+		for x: int in size.x:
+			var cell := Vector2i(x, y)
+			if world.can_encounter_wild_mon_at(cell) \
+				and world._gen1_encounter_tile_at(cell) == Gen1Layout.WATER_TILE \
+				and world._gen1_tile_drawn_at(cell) != Gen1Layout.WATER_TILE:
+				out += 1
+	return out
+
+
+## Route 1 walked: `.CanEncounter`'s rate against the generator's first byte and
+## `.determineEncounterSlot`'s against its second. Every drawn row is one of the
+## map's ten, every slot is reachable, and the hit share lands on the rate.
+func _gen1_rolls() -> void:
+	var row: Dictionary = _r.data.world_encounter(&"grass", 0, GEN1_ROUTE_1)
+	var world: Gen2WorldAPI = _r.open_world(0, GEN1_ROUTE_1, Vector2i.ZERO)
+	if world == null or row.is_empty():
+		return
+	var grass: PackedVector2Array = world.visible_encounter_cells()[
+		Gen2WorldEncounter.METHOD_GRASS
+	]
+	if not _r.check(not grass.is_empty(), "Route 1 offers no grass cell."):
+		return
+	world.player_cell = Vector2i(grass[0])
+	var generator := RandomNumberGenerator.new()
+	generator.seed = GEN1_ROLL_SEED
+	var met: int = 0
+	var slots: Dictionary = {}
+	for _step: int in GEN1_ROLL_STEPS:
+		var wild: Dictionary = world.encounter_request(generator)
+		if wild.is_empty():
+			continue
+		met += 1
+		slots[int(wild["slot"])] = true
+		var slot: Dictionary = (row["slots"] as Array)[int(wild["slot"])]
+		_r.check(
+			int(wild["pokemon"]) == int(slot["species"]) and int(wild["level"]) == int(slot["level"]),
+			"slot %d gave index %d level %d." % [
+				int(wild["slot"]), int(wild["pokemon"]), int(wild["level"]),
+			]
+		)
+	_r.check(slots.size() == Gen1Layout.WILD_SLOT_COUNT,
+		"%d of the ten slots were drawn." % slots.size())
+	var share: float = float(met) / float(GEN1_ROLL_STEPS)
+	var wanted: float = float(row["rate"]) / 256.0
+	_r.check(absf(share - wanted) < GEN1_ROLL_TOLERANCE,
+		"Route 1 met %d of %d steps, a rate of %.3f against %.3f." % [
+			met, GEN1_ROLL_STEPS, share, wanted,
+		])
+	_gen1_indoor_branch()
+	_r.note("gen1 Route 1 met %d of %d steps" % [met, GEN1_ROLL_STEPS])
+
+
+## The branch behind the two tile tests: an indoor map rolls on any tile, and
+## Viridian Forest and the Safari Zone are the tileset it does not.
+func _gen1_indoor_branch() -> void:
+	for row: Array in GEN1_INDOOR_BRANCH:
+		var world: Gen2WorldAPI = _r.open_world(0, int(row[0]), Vector2i.ZERO)
+		if world == null:
+			continue
+		var off_grass: Vector2i = _gen1_bare_floor(world)
+		if not _r.check(off_grass.x >= 0, "map %d has no cell off its grass tile." % row[0]):
+			continue
+		_r.check(world.can_encounter_wild_mon_at(off_grass) == bool(row[1]),
+			"map %d answers %s off its grass tile at %s." % [
+				row[0], world.can_encounter_wild_mon_at(off_grass), off_grass,
+			])
+
+
+## The first walkable cell whose own encounter tile is not the tileset's grass.
+func _gen1_bare_floor(world: Gen2WorldAPI) -> Vector2i:
+	var size: Vector2i = world.map_size_cells()
+	for y: int in size.y:
+		for x: int in size.x:
+			var cell := Vector2i(x, y)
+			if world.collision_permission_at(cell) == Gen2WorldCollision.LAND_TILE \
+				and world._gen1_encounter_tile_at(cell) != world.current_tileset.grass_tile:
+				return cell
+	return Vector2i(-1, -1)
 
 
 ## One block's own rules: a rate a roll can hit, and ten slots naming a real

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -26,6 +26,7 @@ const KIND_HELP: Dictionary = {
 	&"mart": "cell in front of the counter: BuyMenu",
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
+	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"magnet_train": "frames, direction: special MagnetTrain, that many frames in. Direction 1 rides to Goldenrod",
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
@@ -144,7 +145,8 @@ const TEXT_SETTLE_FRAMES: int = 20
 ## instead: Cut's tree stands three frames before it splits, and the waterfall
 ## climb runs four passes a cell, so 26 lands a few cells up.
 const STAGED_FRAMES: int = 2
-const STAGED_FRAMES_BY_KIND: Dictionary = {&"cut": 12, &"waterfall_use": 26}
+## `sign` spends the whole reveal: no press finishes a page early.
+const STAGED_FRAMES_BY_KIND: Dictionary = {&"cut": 12, &"waterfall_use": 26, &"sign": 120}
 
 const PREVIEW_BATTLE_SPECIES: int = 16 ## `preview_battle_request`'s PIDGEY.
 
@@ -370,6 +372,7 @@ const STAGERS: Dictionary = {
 	&"mod_notice": &"_stage_mod_notice",
 	&"mod_page": &"_stage_mod_page",
 	&"pokepic": &"_stage_pokepic",
+	&"sign": &"_stage_sign",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -848,6 +851,12 @@ func _stage_mod_page() -> void:
 
 func _stage_pokepic() -> void:
 	_screen.preview_pokepic(POKEPIC_SPECIES)
+
+
+## `DisplayTextID`'s box, read by facing the cell above the `x y` argument.
+func _stage_sign() -> void:
+	_screen.press_button(PokeButton.UP)
+	_screen.interact()
 
 
 ## `_UnownPrinter`'s browser: the first number is the slot, where 26 is the vacant


### PR DESCRIPTION
## Added
A Generation 1 sign or NPC opens a text box. `Gen1WorldImporter` follows every map's `<Map>_TextPointers` as far as its own signs and objects reach: 456 rows decode to a text on Red and Blue, 429 on Yellow, and the rest keep the byte naming a mart, a nurse, a PC, a vending machine or a `text_asm` script. `Gen2WorldAPI.interact` answers `IsSpriteOrSignInFrontOfPlayer` with them, the sign first and only then a sprite, at twice the range over a counter tile.

A step on Generation 1 grass meets a wild. `TryDoWildEncounter` gates on the tile the cell draws rather than on a permission byte: `wGrassTile` takes the grass rate, $14 the water rate, and an indoor map takes the grass rate anywhere but Viridian Forest and the Safari Zone. `Gen2WorldEncounter` rolls the block's rate byte and `WildMonEncounterSlotChances`' cumulative column.

`tools/preview_world.gd` gains a `sign` kind that photographs the box.

## Changed
`Gen2Font` carries the generation its cache was written by. Generation 1's one border sits inside `TextBoxGraphics` at $79 where Generation 2 has a `frames` sheet of eight, and a string is now encoded by the codec that will draw it.

`Gen2TextStream` reads either command set: `TX_FAR` is $17 in Generation 1 with three more cries at $14 to $16, and `PlaceNextChar` breaks its line on the $49 `CheckDict` spends on `<MOM>`.

`RomCache.FORMAT_VERSION` is 106. Every dump needs importing again.

## Fixed
A Generation 1 box drawn through Crystal's codec had holes in it: `'s` is $bd on one cartridge and $d4 on the other, which `FontGraphics` leaves blank.

`text_move` consumed three operand bytes where the macro emits two, sliding every text command behind one.

`object_facing_cell` read a Generation 2 collision code for the counter, so a Generation 1 clerk behind one was out of reach.

The integration fixture wrote `first_code` 0 for its `FontExtra` strip, which is addressed by character code like the font and the frames.

## Measurements
| Check | Red | Blue | Yellow |
|---|---|---|---|
| Text rows read | 1126 | 1126 | 1154 |
| Of them a text | 456 | 456 | 429 |
| Encounter cells | 17875 | 17875 | 19317 |
| Of them water | 3624 | 3624 | 5172 |
| Left shores | 34 | 34 | 38 |

Route 1 meets 811 wilds in 8000 steps against a rate of 25/256, drawing all ten slots.

`tools/validate.gd -- all` passes, 4326 GUT tests pass over the whole tier, the editor analyser reports 0 warnings over 627 scripts, and the three-profile story walk reaches the Hall of Fame on each.