### PR TITLE
Open a Generation 1 shop and Pokemon Center

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, and the text box and wild encounter a map reads |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, and the text box, shop inventory and wild encounter a map reads |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -92,8 +92,16 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_pic_pointers,
 	_verify_font,
 	_verify_text_box,
+	_verify_facility_text,
 	_verify_world,
 ]
+
+## The `text_far` runs a facility's own boxes live in, by the [method
+## GameData.special_text] run name each is stored under. The shop's are stored
+## under `mart_text` instead, because the shop screen already reads that.
+const FACILITY_TEXT_RUNS: Dictionary = {
+	"pokecenter": ["pokecenter_text", Gen1Layout.POKECENTER_TEXT_AT],
+}
 
 
 static func verify_layout(rom: RomFile) -> Dictionary:
@@ -119,7 +127,7 @@ static func _ok() -> Dictionary:
 ## `PokedexOrder` rather than at a fixed row.
 static func _verify_species_names(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var data: PackedByteArray = rom.bytes()
-	var slots: PackedInt32Array = read_index_of_dex(rom, layout)
+	var slots: PackedInt32Array = Gen1Layout.index_of_dex(rom, layout)
 	if slots.size() != Gen1Layout.SPECIES_COUNT + 1:
 		return _fail("PokedexOrder does not name %d species." % Gen1Layout.SPECIES_COUNT)
 	var first: String = Gen1Text.decode_fixed(
@@ -275,7 +283,7 @@ static func _verify_wild_constants(rom: RomFile, layout: Dictionary) -> Dictiona
 ## with the byte the pointer lands on proves the pointer, the bank rule and the
 ## stride for every species at once.
 static func _verify_pic_pointers(rom: RomFile, layout: Dictionary) -> Dictionary:
-	var slots: PackedInt32Array = read_index_of_dex(rom, layout)
+	var slots: PackedInt32Array = Gen1Layout.index_of_dex(rom, layout)
 	for dex: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
 		var stats: int = Gen1Layout.base_stats_offset(layout, dex)
 		var front: int = _pic_offset(rom, layout, stats + Gen1Layout.BASE_FRONT_PIC, slots[dex])
@@ -338,6 +346,23 @@ static func _verify_text_box(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## Every map and tileset decodes, which is the world layout's own check: a wrong
 ## table reaches a tileset number, a map size or a block index the cartridge
 ## cannot hold.
+## Each run is one contiguous block of `text_far` stubs, so a base offset that
+## has slipped shows up as a slot that does not decode at all.
+static func _verify_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var runs: Dictionary = {"mart": ["mart_text", Gen1Layout.MART_TEXT_AT]}
+	runs.merge(FACILITY_TEXT_RUNS)
+	for run: String in runs:
+		var key: String = String((runs[run] as Array)[0])
+		var slots: Dictionary = (runs[run] as Array)[1]
+		for name: String in slots:
+			var at: int = Gen1Layout.facility_text_offset(layout, key, slots, name)
+			if facility_text(rom, at).is_empty():
+				return _fail("%s's %s box does not decode at $%05X." % [run, name, at])
+	if facility_text(rom, int(layout["mart_greeting"])).is_empty():
+		return _fail("PokemartGreetingText does not decode.")
+	return _ok()
+
+
 static func _verify_world(rom: RomFile, _layout: Dictionary) -> Dictionary:
 	return Gen1WorldImporter.verify_layout(rom)
 
@@ -370,17 +395,12 @@ static func _verify_trainer_names(rom: RomFile, layout: Dictionary) -> Dictionar
 	return _ok()
 
 
-## `PokedexOrder` inverted: dex number to internal index, row 0 unused so a dex
-## number indexes it directly.
-static func read_index_of_dex(rom: RomFile, layout: Dictionary) -> PackedInt32Array:
-	var out: PackedInt32Array = PackedInt32Array()
-	out.resize(Gen1Layout.SPECIES_COUNT + 1)
-	var order: int = int(layout["dex_order"])
-	for index: int in range(1, Gen1Layout.INDEX_COUNT + 1):
-		var dex: int = rom.u8(order + index - 1)
-		if dex >= 1 and dex <= Gen1Layout.SPECIES_COUNT:
-			out[dex] = index
-	return out
+## One facility box, already laid out. Empty for a stub that does not decode.
+static func facility_text(rom: RomFile, at: int) -> String:
+	if at < 0:
+		return ""
+	var decoded: Dictionary = Gen1Text.decode_stream(rom, at)
+	return String(decoded["text"]) if bool(decoded.get("ok", false)) else ""
 
 
 static func read_type_name(rom: RomFile, layout: Dictionary, type: int) -> String:
@@ -442,7 +462,7 @@ static func _evolution_row(
 	rom: RomFile, layout: Dictionary, at: int, method: int, size: int
 ) -> Dictionary:
 	var target: int = rom.u8(at + size - 1)
-	var row: Dictionary = {"method": method, "species": dex_of_index(rom, layout, target)}
+	var row: Dictionary = {"method": method, "species": Gen1Layout.dex_of_index(rom, layout, target)}
 	if method == Gen1Layout.EVOLVE_LEVEL:
 		row["level"] = rom.u8(at + 1)
 	elif method == Gen1Layout.EVOLVE_ITEM:
@@ -451,14 +471,6 @@ static func _evolution_row(
 	else:
 		row["level"] = rom.u8(at + 1)
 	return row
-
-
-## `PokedexOrder` read forwards: the dex number an internal index carries, or
-## zero for a slot no species claims.
-static func dex_of_index(rom: RomFile, layout: Dictionary, index: int) -> int:
-	if index < 1 or index > Gen1Layout.INDEX_COUNT:
-		return 0
-	return rom.u8(int(layout["dex_order"]) + index - 1)
 
 
 ## Reads the cartridge into its cache. Answers the same { ok, message, ... }
@@ -564,6 +576,8 @@ func import_rom(
 		"encounter_count": int(world["encounters"]),
 		"atlases": pics,
 		"tiles": tiles,
+		"mart_text": _import_mart_text(rom, layout),
+		"special_text": _import_facility_text(rom, layout),
 		"complete": true,
 	}
 	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
@@ -608,7 +622,7 @@ static func _count_of(species: Array, key: String) -> int:
 ## kept for a reader that needs the cartridge's own numbering.
 func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) -> Array:
 	var data: PackedByteArray = rom.bytes()
-	var slots: PackedInt32Array = read_index_of_dex(rom, layout)
+	var slots: PackedInt32Array = Gen1Layout.index_of_dex(rom, layout)
 	var out: Array = []
 
 	for dex: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
@@ -625,14 +639,16 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 			"name": Gen1Text.decode_fixed(
 				data, Gen1Layout.species_name_offset(layout, index), Gen1Layout.NAME_LENGTH
 			),
-			# One Special stat: the split into Sp. Attack and Sp. Defense is
-			# Generation 2's.
+			# One Special stat: Generation 2 split it, and both halves answer
+			# with it so a base stat reads the same either way.
 			"stats": {
 				"hp": rom.u8(stats + Gen1Layout.BASE_HP),
 				"attack": rom.u8(stats + Gen1Layout.BASE_ATTACK),
 				"defense": rom.u8(stats + Gen1Layout.BASE_DEFENSE),
 				"speed": rom.u8(stats + Gen1Layout.BASE_SPEED),
 				"special": special,
+				"sp_attack": special,
+				"sp_defense": special,
 			},
 			"types": [
 				rom.u8(stats + Gen1Layout.BASE_TYPE_1),
@@ -723,6 +739,33 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 
 ## The 27 rows of `TypeNames` less the $09 to $13 hole, which is filled with
 ## NORMAL and named by nothing.
+## The shop's own boxes under the slot names [Gen2WorldServiceScreen] gives
+## them. `welcome` is `DisplayPokemartDialogue`'s greeting, which sits in home
+## rather than in `engine/events/pokemart.asm`'s run.
+func _import_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {"welcome": facility_text(rom, int(layout["mart_greeting"]))}
+	for name: String in Gen1Layout.MART_TEXT_AT:
+		out[name] = facility_text(rom, Gen1Layout.facility_text_offset(
+			layout, "mart_text", Gen1Layout.MART_TEXT_AT, name
+		))
+	return out
+
+
+## The other two runs, in [method GameData.special_text]'s run/slot shape.
+func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for run: String in FACILITY_TEXT_RUNS:
+		var key: String = String((FACILITY_TEXT_RUNS[run] as Array)[0])
+		var slots: Dictionary = (FACILITY_TEXT_RUNS[run] as Array)[1]
+		var boxes: Dictionary = {}
+		for name: String in slots:
+			boxes[name] = facility_text(
+				rom, Gen1Layout.facility_text_offset(layout, key, slots, name)
+			)
+		out[run] = boxes
+	return out
+
+
 func _import_types(rom: RomFile, layout: Dictionary) -> Array:
 	var out: Array = []
 	for type: int in Gen1Layout.TYPE_COUNT:
@@ -759,14 +802,40 @@ func _import_items(rom: RomFile, layout: Dictionary) -> Array:
 	var names: PackedStringArray = Gen1Text.decode_sequence(
 		rom.bytes(), int(layout["item_names"]), Gen1Layout.ITEM_COUNT, MAX_NAME_LENGTH
 	)
+	## `GetMachineName` spells an HM's or a TM's name from its own number and
+	## `GetMachinePrice` reads a nybble table an HM never reaches, so the two
+	## runs above `ItemNames` are built rather than read. The table is dense
+	## because [method GameData.item] indexes it by number less one; the ids
+	## between the two runs are the ones no `item_constants.asm` row names.
 	var out: Array = []
-	for item: int in range(1, Gen1Layout.ITEM_COUNT + 1):
+	for item: int in range(1, Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT):
 		out.append({
 			"number": item,
-			"name": names[item - 1],
-			"price": _bcd3(rom, Gen1Layout.item_price_offset(layout, item)),
+			"name": _item_name(names, item),
+			"price": _item_price(rom, layout, item),
 		})
 	return out
+
+
+static func _item_name(names: PackedStringArray, item: int) -> String:
+	if item <= Gen1Layout.ITEM_COUNT:
+		return names[item - 1]
+	if item < Gen1Layout.TM_FIRST_ITEM:
+		return "HM%02d" % (item - Gen1Layout.HM_FIRST_ITEM + 1) \
+			if item >= Gen1Layout.HM_FIRST_ITEM else ""
+	return "TM%02d" % (item - Gen1Layout.TM_FIRST_ITEM + 1)
+
+
+static func _item_price(rom: RomFile, layout: Dictionary, item: int) -> int:
+	if item <= Gen1Layout.ITEM_COUNT:
+		return _bcd3(rom, Gen1Layout.item_price_offset(layout, item))
+	if item < Gen1Layout.TM_FIRST_ITEM:
+		return 0
+	var machine: int = item - Gen1Layout.TM_FIRST_ITEM
+	@warning_ignore("integer_division")
+	var packed: int = rom.u8(int(layout["tm_prices"]) + machine / 2)
+	var nybble: int = (packed >> 4) if machine % 2 == 0 else (packed & 0x0F)
+	return nybble * Gen1Layout.MACHINE_PRICE_UNIT
 
 
 ## `bcd3`, which is how both a price and a trainer's reward money are stored.

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -76,6 +76,10 @@ const TM_COUNT: int = 50
 const HM_COUNT: int = 5
 const HM_FIRST_ITEM: int = 0xC4
 const TM_FIRST_ITEM: int = HM_FIRST_ITEM + HM_COUNT
+## `GetMachineName` spells the name rather than reading one, and
+## `GetMachinePrice` takes a nybble of `TechnicalMachinePrices` and multiplies by
+## a thousand. `ret c` above it leaves an HM priceless.
+const MACHINE_PRICE_UNIT: int = 1000
 
 ## A `PokedexEntry`: category, feet, inches, weight in tenths of a pound, then
 ## `text_far`'s $17 with a `dab` pointer to the description.
@@ -155,6 +159,37 @@ const TEXT_SCRIPT_IDS: Dictionary = {
 	0xF5: "vending machine", 0xF6: "cable club receptionist", 0xF7: "prize vendor",
 	0xF9: "Pokemon Center PC", 0xFC: "the player's PC", 0xFD: "Bill's PC",
 	0xFE: "mart", 0xFF: "Pokemon Center nurse",
+}
+const TEXT_SCRIPT_MART: int = 0xFE
+const TEXT_SCRIPT_POKECENTER_NURSE: int = 0xFF
+
+## `script_mart` writes its inventory into the text pointer itself: the $FE,
+## a count, that many item ids, and a $FF nothing reads. `LoadItemList` copies
+## the run into `wItemList`, which is 16 bytes, so a longer count is a bad read.
+const MART_COUNT_AT: int = 1
+const MART_ITEMS_AT: int = 2
+const MART_MAX_ITEMS: int = 14
+
+## A `text_far` stub is `TX_FAR`, a two-byte address, a bank byte and a
+## `text_end`; a `text_pause` in front of one adds a byte, which is what makes
+## the second run below irregular. Each run is contiguous with the same deltas on
+## all three cartridges, so one pinned address apiece is enough.
+const TEXT_FAR_STUB_BYTES: int = 5
+
+## `engine/events/pokemart.asm`'s eleven stubs in file order, under the slot
+## names [Gen2WorldServiceScreen] gives a shop's boxes. The greeting is not among
+## them: `DisplayPokemartDialogue` prints it from home, so it is pinned alone.
+const MART_TEXT_AT: Dictionary = {
+	"buy_intro": 0x00, "final_price": 0x05, "thanks": 0x0A, "no_money": 0x0F,
+	"pack_full": 0x14, "sell_intro": 0x19, "sell_price": 0x1E,
+	"bag_empty": 0x23, "cant_buy": 0x28, "come_again": 0x2D, "ask_more": 0x32,
+}
+
+## `engine/events/pokecenter.asm`'s five, `shall_we_heal` and `farewell` each
+## carrying a `text_pause` ahead of the stub.
+const POKECENTER_TEXT_AT: Dictionary = {
+	"welcome": 0x00, "shall_we_heal": 0x05, "need_your_pokemon": 0x0B,
+	"fighting_fit": 0x10, "farewell": 0x15,
 }
 
 ## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
@@ -357,6 +392,7 @@ const RED_BLUE: Dictionary = {
 	"type_effects": 0x3E474,
 	"item_names": 0x0472B,
 	"item_prices": 0x04608,
+	"tm_prices": 0x7BFA7,
 	"tmhm_moves": 0x13773,
 	"mon_palettes": 0x725C8,
 	"super_palettes": 0x72660,
@@ -366,6 +402,12 @@ const RED_BLUE: Dictionary = {
 	"cries": 0x39446,
 	"trainer_pics": 0x39914,
 	"trainer_pics_bank": 0x13,
+	## `DisplayPokemartDialogue`'s own greeting and the head of the two facility
+	## text runs [constant MART_TEXT_AT] and its neighbour walk. Every offset
+	## here is `pokered.sym`'s, which builds both dumps.
+	"mart_greeting": 0x02A55,
+	"mart_text": 0x06E0C,
+	"pokecenter_text": 0x0705D,
 	"font": 0x11A80,
 	"text_box": 0x12288,
 	"pic_player_back": 0x33E0A,
@@ -400,6 +442,7 @@ const YELLOW: Dictionary = {
 	"type_effects": 0x3E5FA,
 	"item_names": 0x045B7,
 	"item_prices": 0x04494,
+	"tm_prices": 0xF65F5,
 	"tmhm_moves": 0x1232D,
 	"mon_palettes": 0x72921,
 	"super_palettes": 0x729B9,
@@ -409,6 +452,9 @@ const YELLOW: Dictionary = {
 	"cries": 0x39462,
 	"trainer_pics": 0x39893,
 	"trainer_pics_bank": 0x13,
+	"mart_greeting": 0x02938,
+	"mart_text": 0x06B91,
+	"pokecenter_text": 0x06ED0,
 	"font": 0x10600,
 	"text_box": 0x10E18,
 	## Yellow moved both back pics out of "Pics 4" and into their own bank.
@@ -468,6 +514,46 @@ static func base_stats_offset(layout: Dictionary, dex: int) -> int:
 
 static func move_offset(layout: Dictionary, move: int) -> int:
 	return int(layout["moves"]) + (move - 1) * MOVE_DATA_SIZE
+
+
+## `PokedexOrder` inverted: dex number to internal index, row 0 unused so a dex
+## number indexes it directly.
+static func index_of_dex(rom: RomFile, layout: Dictionary) -> PackedInt32Array:
+	var out: PackedInt32Array = PackedInt32Array()
+	out.resize(Gen1Layout.SPECIES_COUNT + 1)
+	var order: int = int(layout["dex_order"])
+	for index: int in range(1, Gen1Layout.INDEX_COUNT + 1):
+		var dex: int = rom.u8(order + index - 1)
+		if dex >= 1 and dex <= Gen1Layout.SPECIES_COUNT:
+			out[dex] = index
+	return out
+
+
+## `PokedexOrder` read forwards: the dex number an internal index carries, or
+## zero for a slot no species claims.
+static func dex_of_index(rom: RomFile, layout: Dictionary, index: int) -> int:
+	if index < 1 or index > Gen1Layout.INDEX_COUNT:
+		return 0
+	return rom.u8(int(layout["dex_order"]) + index - 1)
+
+
+## A `dw` or a `dab` inside a banked cartridge: below $4000 is home, whatever
+## bank is switched in, so a pointer that carries no bank of its own is resolved
+## against the one it was read from only above that line.
+static func banked(bank: int, address: int) -> int:
+	return RomFile.linear(0 if address < RomFile.BANK_SIZE else bank, address)
+
+
+## One facility box's `text_far` stub: the run's own pinned head plus the slot's
+## delta. [param slots] is [constant MART_TEXT_AT] or its neighbour.
+## Answers -1 for a slot the table does not name.
+static func facility_text_offset(
+	layout: Dictionary, run: String, slots: Dictionary, name: String
+) -> int:
+	var at: int = int(layout.get(run, 0))
+	if at <= 0 or not slots.has(name):
+		return -1
+	return at + int(slots[name])
 
 
 static func item_price_offset(layout: Dictionary, item: int) -> int:

--- a/game/gen1/gen1_text.gd
+++ b/game/gen1/gen1_text.gd
@@ -134,6 +134,23 @@ static func decode_sequence(
 	return out
 
 
+## One printed box, as [method Gen2TextStream.decode]'s { ok, text, prompt } and
+## a `reason` when the stream does not decode. `DisplayTextID` dispatches the
+## `TX_SCRIPT_*` ids and hands everything else to `PrintText`, so every other
+## first byte is a text command, `text_asm`'s jump into code included. A far
+## target names no length, so its slice runs to the end of its own bank.
+static func decode_stream(rom: RomFile, at: int) -> Dictionary:
+	var command: int = rom.u8(at)
+	if Gen1Layout.TEXT_SCRIPT_IDS.has(command):
+		return {"ok": false, "reason": "text_script", "command": command}
+	return Gen2TextStream.decode(rom.bytes(), at, {
+		"generation": RomRegistry.GEN1,
+		"far": func(bank: int, address: int) -> PackedByteArray:
+			var start: int = Gen1Layout.banked(bank, address)
+			return rom.slice(start, RomFile.bank_end(RomFile.bank_of(start)) - start),
+	})
+
+
 ## Just past the terminator: a Pokedex entry's height follows its category.
 static func terminated_end(data: PackedByteArray, offset: int, max_length: int) -> int:
 	var end: int = offset

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -141,12 +141,12 @@ static func _read_encounters(rom: RomFile, layout: Dictionary) -> Dictionary:
 		var at: int = RomFile.linear(
 			bank, rom.u16le(table + map_id * Gen1Layout.POINTER_SIZE)
 		)
-		var block: Dictionary = _read_wild_block(rom, at, map_id)
+		var block: Dictionary = _read_wild_block(rom, layout, at, map_id)
 		if not bool(block["ok"]):
 			return block
 		if not (block["row"] as Dictionary).is_empty():
 			grass["0:%d" % map_id] = block["row"]
-		block = _read_wild_block(rom, int(block["at"]), map_id)
+		block = _read_wild_block(rom, layout, int(block["at"]), map_id)
 		if not bool(block["ok"]):
 			return block
 		if not (block["row"] as Dictionary).is_empty():
@@ -162,7 +162,9 @@ static func _read_encounters(rom: RomFile, layout: Dictionary) -> Dictionary:
 
 ## One `def_grass_wildmons` or `def_water_wildmons` block: a rate byte, and ten
 ## (level, species) pairs behind it unless the rate is zero, which ends it.
-static func _read_wild_block(rom: RomFile, at: int, map_id: int) -> Dictionary:
+static func _read_wild_block(
+	rom: RomFile, layout: Dictionary, at: int, map_id: int
+) -> Dictionary:
 	if not rom.in_bounds(at):
 		return _error("Map %d's wild data is outside the ROM." % map_id)
 	var rate: int = rom.u8(at)
@@ -173,10 +175,12 @@ static func _read_wild_block(rom: RomFile, at: int, map_id: int) -> Dictionary:
 	var slots: Array = []
 	for slot: int in Gen1Layout.WILD_SLOT_COUNT:
 		var row: int = at + 1 + slot * 2
-		var species: int = rom.u8(row + 1)
-		if species < 1 or species > Gen1Layout.INDEX_COUNT:
-			return _error("Map %d's wild slot %d names index %d." % [map_id, slot, species])
-		slots.append({"level": rom.u8(row), "species": species})
+		var dex: int = Gen1Layout.dex_of_index(rom, layout, rom.u8(row + 1))
+		if dex < 1:
+			return _error("Map %d's wild slot %d names index %d." % [
+				map_id, slot, rom.u8(row + 1),
+			])
+		slots.append({"level": rom.u8(row), "species": dex})
 	return {
 		"ok": true,
 		"row": {"map": "0:%d" % map_id, "rate": rate, "slots": slots},
@@ -201,7 +205,7 @@ static func _read_super_rod(rom: RomFile, layout: Dictionary) -> Dictionary:
 			return _error("The Super Rod names map %d." % map_id)
 		var key: int = at + 1 if flat else RomFile.linear(bank, rom.u16le(at + 1))
 		if not seen.has(key):
-			var group: Dictionary = _read_rod_group(rom, key, flat, map_id)
+			var group: Dictionary = _read_rod_group(rom, layout, key, flat, map_id)
 			if not bool(group["ok"]):
 				return group
 			groups.append(group["group"])
@@ -216,7 +220,7 @@ static func _read_super_rod(rom: RomFile, layout: Dictionary) -> Dictionary:
 ## One group: a count and that many (level, species) rows, or Yellow's four
 ## (species, level) rows with the byte `GenerateRandomFishingEncounter` reads.
 static func _read_rod_group(
-	rom: RomFile, at: int, flat: bool, map_id: int
+	rom: RomFile, layout: Dictionary, at: int, flat: bool, map_id: int
 ) -> Dictionary:
 	var count: int = Gen1Layout.SUPER_ROD_SLOTS_YELLOW if flat else rom.u8(at)
 	if count < 1 or count > Gen1Layout.SUPER_ROD_MAX_SLOTS:
@@ -228,10 +232,11 @@ static func _read_rod_group(
 	for slot: int in count:
 		var row: int = first + slot * 2
 		var species: int = rom.u8(row + 1 if not flat else row)
-		if species < 1 or species > Gen1Layout.INDEX_COUNT:
+		var dex: int = Gen1Layout.dex_of_index(rom, layout, species)
+		if dex < 1:
 			return _error("Map %d's fishing slot %d names index %d." % [map_id, slot, species])
 		var entry: Dictionary = {
-			"level": rom.u8(row if not flat else row + 1), "species": species,
+			"level": rom.u8(row if not flat else row + 1), "species": dex,
 		}
 		if flat:
 			entry["threshold"] = Gen1Layout.SUPER_ROD_THRESHOLDS_YELLOW[slot]
@@ -323,7 +328,7 @@ static func _read_tileset(
 	var block_count: int = Gen1Layout.tileset_blocks(rom.id)[number]
 	var meta_size: int = block_count * Gen1Layout.TILESET_BLOCK_TILES
 	var meta_at: int = RomFile.linear(bank, block_address)
-	if meta_at + meta_size > _bank_end(bank):
+	if meta_at + meta_size > RomFile.bank_end(bank):
 		return _error("Tileset %d's %d blocks run past bank $%02X." % [number, block_count, bank])
 	var meta: PackedByteArray = rom.slice(meta_at, meta_size)
 	if meta.size() != meta_size:
@@ -362,7 +367,7 @@ static func _verify_block_counts(rom: RomFile, layout: Dictionary, count: int) -
 	for number: int in count:
 		var row: Array = rows[number]
 		var start: int = RomFile.linear(int(row[0]), int(row[1]))
-		var limit: int = _bank_end(int(row[0]))
+		var limit: int = RomFile.bank_end(int(row[0]))
 		for other: Array in rows:
 			var graphics: int = RomFile.linear(int(other[0]), int(other[2]))
 			if int(other[0]) == int(row[0]) and graphics > start:
@@ -381,13 +386,9 @@ static func _verify_block_counts(rom: RomFile, layout: Dictionary, count: int) -
 static func _tileset_strip(rom: RomFile, bank: int, graphics_address: int) -> PackedByteArray:
 	var at: int = RomFile.linear(bank, graphics_address)
 	var wanted: int = Gen1Layout.TILESET_TILE_COUNT * PokeTiles.TILE_BYTES
-	var graphics: PackedByteArray = rom.slice(at, mini(wanted, _bank_end(bank) - at))
+	var graphics: PackedByteArray = rom.slice(at, mini(wanted, RomFile.bank_end(bank) - at))
 	graphics.resize(wanted)
 	return PokeTiles.decode_2bpp_strip(graphics, 0, Gen1Layout.TILESET_TILE_COUNT)
-
-
-static func _bank_end(bank: int) -> int:
-	return (bank + 1) * RomFile.BANK_SIZE
 
 
 static func _bit_count(value: int) -> int:
@@ -443,7 +444,7 @@ static func _read_map(
 	)
 
 	var events: Dictionary = _read_events(
-		rom, bank, rom.u16le(object_address), map_id, width, height, block_count
+		rom, layout, bank, rom.u16le(object_address), map_id, width, height, block_count
 	)
 	if not bool(events.get("ok", false)):
 		return events
@@ -532,7 +533,8 @@ static func _read_connections(rom: RomFile, at: int, connection_flags: int) -> A
 ## `<Map>_Object`: the border block, then warps, signs and objects, each a count
 ## and its rows.
 static func _read_events(
-	rom: RomFile, bank: int, address: int, map_id: int, width: int, height: int, block_count: int
+	rom: RomFile, layout: Dictionary, bank: int, address: int, map_id: int,
+	width: int, height: int, block_count: int
 ) -> Dictionary:
 	var at: int = RomFile.linear(bank, address)
 	if not rom.in_bounds(at):
@@ -552,13 +554,13 @@ static func _read_events(
 	var signs: Dictionary = _read_signs(rom, int(warps["at"]), map_id, cell_width, cell_height)
 	if not bool(signs.get("ok", false)):
 		return signs
-	var objects: Dictionary = _read_objects(rom, int(signs["at"]), map_id)
+	var objects: Dictionary = _read_objects(rom, layout, int(signs["at"]), map_id)
 	if not bool(objects.get("ok", false)):
 		return objects
 	# The block ends in one `warp_to` a warp, which names only WRAM.
 	var end: int = int(objects["at"]) \
 		+ (warps["events"] as Array).size() * Gen1Layout.WARP_TO_SIZE
-	if end > _bank_end(bank):
+	if end > RomFile.bank_end(bank):
 		return _error("Map %d's object block runs past bank $%02X." % [map_id, bank])
 
 	return {
@@ -625,7 +627,9 @@ static func _read_signs(
 ## An object's coordinates may sit in the runtime's own border padding, so unlike
 ## a warp or a sign they are not bounded by the map. The TRAINER bit covers a
 ## standing wild Pokemon too; [constant Gen1Layout.OPPONENT_ID_OFFSET] splits them.
-static func _read_objects(rom: RomFile, at: int, map_id: int) -> Dictionary:
+static func _read_objects(
+	rom: RomFile, layout: Dictionary, at: int, map_id: int
+) -> Dictionary:
 	var count: int = rom.u8(at)
 	at += 1
 	if count > Gen1Layout.MAX_OBJECT_EVENTS:
@@ -653,7 +657,7 @@ static func _read_objects(rom: RomFile, at: int, map_id: int) -> Dictionary:
 				object["trainer_class"] = opponent - Gen1Layout.OPPONENT_ID_OFFSET
 				object["trainer_number"] = rom.u8(at + 1)
 			else:
-				object["species"] = opponent
+				object["species"] = Gen1Layout.dex_of_index(rom, layout, opponent)
 				object["level"] = rom.u8(at + 1)
 		elif (text & Gen1Layout.OBJECT_ITEM_FLAG) != 0:
 			object["item"] = rom.u8(at)
@@ -666,31 +670,43 @@ static func _read_objects(rom: RomFile, at: int, map_id: int) -> Dictionary:
 ## machine code; only `text_far` and `text_start` are a text, and the rest keep
 ## the byte naming them. The table has no end, so the map's own events bound it.
 static func _read_texts(rom: RomFile, bank: int, address: int, events: Dictionary) -> Array:
-	var table: int = _banked(bank, address)
+	var table: int = Gen1Layout.banked(bank, address)
 	var out: Array = []
 	for id: int in _highest_text_id(events):
 		out.append(_read_text(rom, bank, rom.u16le(table + id * 2)))
 	return out
 
 
+## A `TX_SCRIPT_*` row keeps its own inventory where it has one, so nothing
+## downstream has to read the cartridge again to open the shop.
 static func _read_text(rom: RomFile, bank: int, pointer: int) -> Dictionary:
-	var at: int = _banked(bank, pointer)
-	var command: int = rom.u8(at)
-	var row: Dictionary = {"command": command, "text": ""}
-	if command != Gen1Text.TEXT_FAR and command != Gen1Text.TEXT_START:
-		return row
-	var decoded: Dictionary = Gen2TextStream.decode(rom.bytes(), at, {
-		"generation": RomRegistry.GEN1,
-		"far": func(far_bank: int, far_address: int) -> PackedByteArray:
-			var start: int = _banked(far_bank, far_address)
-			return rom.slice(start, _bank_end(RomFile.bank_of(start)) - start),
-	})
+	var at: int = Gen1Layout.banked(bank, pointer)
+	var decoded: Dictionary = Gen1Text.decode_stream(rom, at)
+	var row: Dictionary = {"command": rom.u8(at), "text": ""}
 	if not bool(decoded.get("ok", false)):
-		row["reason"] = String(decoded.get("reason", "invalid_text"))
+		if int(row["command"]) == Gen1Layout.TEXT_SCRIPT_MART:
+			row["items"] = _read_mart_items(rom, at)
+		elif String(decoded.get("reason", "")) != "text_script":
+			row["reason"] = String(decoded.get("reason", "invalid_text"))
 		return row
 	row["text"] = String(decoded["text"])
 	row["prompt"] = bool(decoded.get("prompt", false))
 	return row
+
+
+## `script_mart`'s inline list, which `LoadItemList` copies straight out of the
+## text pointer. A count past `wItemList` is not a shop at all.
+static func _read_mart_items(rom: RomFile, at: int) -> Array:
+	var count: int = rom.u8(at + Gen1Layout.MART_COUNT_AT)
+	if count < 1 or count > Gen1Layout.MART_MAX_ITEMS:
+		return []
+	var out: Array = []
+	for slot: int in count:
+		var item: int = rom.u8(at + Gen1Layout.MART_ITEMS_AT + slot)
+		if item < 1:
+			return []
+		out.append(item)
+	return out
 
 
 static func _highest_text_id(events: Dictionary) -> int:
@@ -699,11 +715,6 @@ static func _highest_text_id(events: Dictionary) -> int:
 		for event: Dictionary in events.get(kind, []) as Array:
 			highest = maxi(highest, int(event.get("text", 0)))
 	return highest
-
-
-## A `dw` inside a banked map: below $4000 is home, whatever bank is switched in.
-static func _banked(bank: int, address: int) -> int:
-	return RomFile.linear(0 if address < RomFile.BANK_SIZE else bank, address)
 
 
 static func _object_extra_bytes(text: int) -> int:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 106
+const FORMAT_VERSION: int = 107
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/text_stream.gd
+++ b/game/import/text_stream.gd
@@ -241,11 +241,15 @@ static func _step_command(
 				"at": at + 3,
 			}
 		TX_BCD:
-			# `dw address, db flags`, printed from live RAM this project does not
-			# model. Skipped rather than drawn wrong.
+			# `dw address, db flags`, a packed-decimal number out of live RAM.
+			# Marked the way TX_DECIMAL is; no Crystal text uses it, and every
+			# Generation 1 one that does is a price.
 			if not _has(data, at, 3):
 				return {"reason": &"truncated_text_command"}
-			return {"at": at + 3}
+			return {
+				"text": _decimal_string(context, data[at] | (data[at + 1] << 8)),
+				"at": at + 3,
+			}
 		TX_MOVE:
 			# `dw address` alone, and it prints nothing. Reading a third byte here
 			# slid every command behind it.

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -93,8 +93,30 @@ const DOWN_ARROW_CODE: int = 0xEE
 
 ## `PRINTNUM_MONEY` with six digits: the `¥` is printed in front of the first
 ## significant digit rather than at the field's left edge, so the whole thing is
-## seven cells right aligned.
+## seven cells right aligned, which is `PrintBCDNumber`'s shape too.
 const MONEY_CELLS: int = 7
+
+## Generation 1's shop stands over the map and frames its list. `MONEY_BOX_TEMPLATE`
+## is (11,0) to (19,2) with "MONEY" on its own top border row, and `LIST_MENU_BOX`
+## (4,2) to (19,12) (`data/text_boxes.asm`).
+const GEN1_MONEY_LABEL: String = "MONEY"
+const GEN1_MONEY_LABEL_AT: Vector2i = Vector2i(13, 0)
+const GEN1_LIST_AT: Vector2i = Vector2i(4, 2)
+const GEN1_LIST_SIZE: Vector2i = Vector2i(16, 11)
+## `PrintListMenuEntries`: `hlcoord 6, 4`, four names two rows apart, each price
+## one row down and five columns right of its name, and the cursor on column 5.
+const GEN1_NAME_AT: Vector2i = Vector2i(6, 4)
+const GEN1_CURSOR_COLUMN: int = 5
+const GEN1_PRICE_COLUMN: int = 11
+## `ld b, 4` names drawn against `wMaxMenuItem` 2, so the fourth row is a look
+## ahead the cursor never reaches.
+const GEN1_LIST_HEIGHT: int = 4
+const GEN1_CURSOR_ROWS: int = 3
+## A name runs to the box's own border: the price sits a row below it.
+const GEN1_NAME_CELLS: int = GEN1_LIST_AT.x + GEN1_LIST_SIZE.x - 1 - GEN1_NAME_AT.x
+## `DisplayChooseQuantityMenu`'s priced branch: `hlcoord 7, 9` with `lb b, 1,
+## c, 11`, the same box Generation 2 draws six rows lower.
+const GEN1_QUANTITY_AT: Vector2i = Vector2i(7, 9)
 
 var font: Gen2Font = null
 ## Which text-box border the player chose, for the three boxes this draws.
@@ -237,6 +259,91 @@ static func bank_window(
 ## `PrintNum` with `lb bc, 2, 4`: four digits, right aligned, no `¥`.
 static func coin_string(coins: int) -> String:
 	return ("%d" % maxi(coins, 0)).lpad(COIN_DIGITS)
+
+
+## `DisplayPokemartDialogue_` draws the money box and `DisplayListMenuID` the
+## list. Transparent everywhere else, so the map and the message box show.
+func render_gen1(state: Dictionary) -> Image:
+	if font == null:
+		return null
+	var image := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	_blit_gen1_money(image, int(state.get("money", 0)))
+	if bool(state.get("listing", false)):
+		_blit_gen1_list(image, state)
+	if int(state.get("quantity", -1)) >= 0:
+		_blit_gen1_quantity(
+			image, int(state["quantity"]), int(state.get("subtotal", 0))
+		)
+	return image
+
+
+func _blit_gen1_quantity(image: Image, quantity: int, subtotal: int) -> void:
+	var indices: PackedByteArray = _panel(QUANTITY_SIZE)
+	var width: int = QUANTITY_SIZE.x * TILE
+	font.draw_box(frame_style, indices, width, 0, 0, QUANTITY_SIZE.x, QUANTITY_SIZE.y)
+	var inset: Vector2i = QUANTITY_TEXT_AT - QUANTITY_AT
+	_text(
+		indices, width,
+		"×%s" % String.num_int64(maxi(quantity, 0)).lpad(QUANTITY_DIGITS, "0"), inset
+	)
+	_text(
+		indices, width, money_string(subtotal),
+		Vector2i(SUBTOTAL_AT.x - QUANTITY_AT.x, inset.y)
+	)
+	_blit_panel(image, indices, QUANTITY_SIZE, GEN1_QUANTITY_AT)
+
+
+func _blit_gen1_money(image: Image, money: int) -> void:
+	var indices: PackedByteArray = _panel(MONEY_SIZE)
+	var width: int = MONEY_SIZE.x * TILE
+	font.draw_box(frame_style, indices, width, 0, 0, MONEY_SIZE.x, MONEY_SIZE.y)
+	_text(indices, width, GEN1_MONEY_LABEL, GEN1_MONEY_LABEL_AT - MONEY_AT)
+	_text(indices, width, money_string(money), MONEY_TEXT_AT - MONEY_AT)
+	_blit_panel(image, indices, MONEY_SIZE, MONEY_AT)
+
+
+func _blit_gen1_list(image: Image, state: Dictionary) -> void:
+	var indices: PackedByteArray = _panel(GEN1_LIST_SIZE)
+	var width: int = GEN1_LIST_SIZE.x * TILE
+	font.draw_box(frame_style, indices, width, 0, 0, GEN1_LIST_SIZE.x, GEN1_LIST_SIZE.y)
+	var rows: Array = state.get("rows", [])
+	for index: int in mini(rows.size(), GEN1_LIST_HEIGHT):
+		var row: Dictionary = rows[index]
+		var at: Vector2i = GEN1_NAME_AT - GEN1_LIST_AT + Vector2i(0, index * ROW_STEP)
+		if bool(row.get("cancel", false)):
+			_text(indices, width, CANCEL, at)
+			continue
+		_text(indices, width, String(row.get("name", "")), at, GEN1_NAME_CELLS)
+		_text(
+			indices, width, money_string(int(row.get("price", 0))),
+			Vector2i(GEN1_PRICE_COLUMN - GEN1_LIST_AT.x, at.y + 1)
+		)
+	var cursor: int = int(state.get("cursor", -1))
+	if cursor >= 0 and cursor < mini(rows.size(), GEN1_CURSOR_ROWS):
+		_code(indices, width, CURSOR_CODE, Vector2i(
+			GEN1_CURSOR_COLUMN - GEN1_LIST_AT.x,
+			GEN1_NAME_AT.y - GEN1_LIST_AT.y + cursor * ROW_STEP
+		))
+	_blit_panel(image, indices, GEN1_LIST_SIZE, GEN1_LIST_AT)
+
+
+static func _panel(size: Vector2i) -> PackedByteArray:
+	var out := PackedByteArray()
+	out.resize(size.x * TILE * size.y * TILE)
+	return out
+
+
+func _blit_panel(
+	image: Image, indices: PackedByteArray, size: Vector2i, at: Vector2i
+) -> void:
+	var part: Image = Gen2PicImage.from_indices(
+		indices, size.x * TILE, size.y * TILE,
+		PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	if part != null:
+		image.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), at * TILE)
 
 
 func _draw_money(indices: PackedByteArray, width: int, money: int) -> void:

--- a/game/rom/rom_file.gd
+++ b/game/rom/rom_file.gd
@@ -62,6 +62,12 @@ static func bank_of(offset: int) -> int:
 	return offset / BANK_SIZE
 
 
+## Just past the last byte of a bank, which is where a run whose length nothing
+## states has to stop: a Generation 1 `text_far` target names no length.
+static func bank_end(bank: int) -> int:
+	return (bank + 1) * BANK_SIZE
+
+
 func size() -> int:
 	return _bytes.size()
 

--- a/game/save/save_store.gd
+++ b/game/save/save_store.gd
@@ -287,11 +287,21 @@ static func import_slot(source_path: String, data: GameData) -> Dictionary:
 
 ## Creates the same deterministic development party the old battle screen used,
 ## but puts it into a real save slot so the screen no longer owns that state.
+## A starter and its first evolution, per generation: Cyndaquil and Quilava are
+## outside a Generation 1 cartridge's 151 species, and a party member that does
+## not exist is a save that cannot be built.
+const DEVELOPMENT_PARTY_GEN2: Array[int] = [155, 156]
+const DEVELOPMENT_PARTY: Dictionary = {
+	RomRegistry.GEN1: [1, 2],
+	RomRegistry.GEN2: DEVELOPMENT_PARTY_GEN2,
+}
+
+
 static func create_development_save(data: GameData, slot: int) -> Gen2SaveData:
 	if data == null or not _valid_slot(slot):
 		return null
 	var members: Array = []
-	for species: int in [155, 156]:
+	for species: int in DEVELOPMENT_PARTY.get(data.generation, DEVELOPMENT_PARTY_GEN2):
 		var mon: Gen2BattleMon = Gen2BattleMon.create(
 			data, species, 5, data.moves_at_level(species, 5)
 		)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3650,11 +3650,17 @@ var _gen1: bool = false
 ## `wLastMap`, the outdoor map a [constant Gen1Layout.WARP_TO_LAST_MAP] warp
 ## comes back out to. Generation 2 has no such warp and never writes it.
 var _gen1_last_map: int = -1
+## The [method GameData.special_text] run `DisplayPokemonCenterDialogue_`'s own
+## boxes are imported under.
+const GEN1_POKECENTER_RUN: String = "pokecenter"
+
 ## `wRivalName`, which no Generation 1 save model holds yet.
 var gen1_rival_name: String = Gen2WorldScriptRunner.UNNAMED
-## `DisplayTextID` holds `HandleMap` until its press, and there is no script
-## here to hold the world instead.
-var _gen1_text_open: bool = false
+## What `DisplayTextID` is holding `HandleMap` with, in order, since there is no
+## script here to hold the world instead: a box waiting for its press, a YES/NO,
+## a frame wait, or a facility request waiting for its host. A plain text is one
+## box; `DisplayPokemonCenterDialogue_` is five of them around a choice.
+var _gen1_steps: Array = []
 
 
 ## The raw cartridge permission byte at a walk cell.
@@ -3701,21 +3707,75 @@ func _gen1_interact() -> Array:
 	if text_id <= 0:
 		text_id = _gen1_text_id_at(object_facing_cell(), &"objects")
 	var row: Dictionary = current_map.text_at(text_id)
-	var text: String = Gen2TextStream.fill_names(String(row.get("text", "")), {
-		"player": _player_name if not _player_name.is_empty() \
-			else Gen2WorldScriptRunner.UNNAMED,
-		"rival": gen1_rival_name,
-	})
-	if text.is_empty():
+	_gen1_steps = _gen1_facility_steps(row)
+	if _gen1_steps.is_empty():
+		var text: String = Gen2TextStream.fill_names(String(row.get("text", "")), {
+			"player": _player_name if not _player_name.is_empty() \
+				else Gen2WorldScriptRunner.UNNAMED,
+			"rival": gen1_rival_name,
+		})
+		if text.is_empty():
+			return []
+		_gen1_steps = [{"type": &"text", "text": text}]
+	return _gen1_result()
+
+
+## `DisplayTextID`'s own dispatch, which reads the first byte of the text a
+## pointer stands at: a `TX_SCRIPT_*` id runs a routine and prints nothing.
+func _gen1_facility_steps(row: Dictionary) -> Array:
+	match int(row.get("command", 0)):
+		Gen1Layout.TEXT_SCRIPT_MART:
+			return _gen1_mart_steps(row)
+		Gen1Layout.TEXT_SCRIPT_POKECENTER_NURSE:
+			return _gen1_nurse_steps()
+	return []
+
+
+## `MartDialog`'s counter is the whole of a Generation 1 shop, so the request
+## carries the inventory `script_mart` wrote behind the id.
+func _gen1_mart_steps(row: Dictionary) -> Array:
+	var items: Variant = row.get("items", [])
+	if not items is Array or (items as Array).is_empty():
 		return []
-	_gen1_text_open = true
-	## `AfterDisplayingTextID` ends every one of these on
-	## `WaitForTextScrollButtonPress`, whatever the string's last byte said.
-	return [{
-		"ok": true,
-		"status": &"waiting",
-		"event": {"type": &"text", "text": text, "prompt": true},
-	}]
+	return [{"type": &"request", "values": {
+		"kind": &"mart_requested",
+		"values": {
+			"dialog": Gen2WorldMartHost.MARTTYPE_STANDARD,
+			"address": 0,
+			"items": (items as Array).duplicate(),
+		},
+	}}]
+
+
+## `DisplayPokemonCenterDialogue_`. `BIT_USED_POKECENTER` only decides whether
+## the question is asked again, and `YesNoChoicePokeCenter` runs either way, so
+## the box is spent every time here rather than the first time only.
+## `SetLastBlackoutMap` is YES's, ahead of the heal.
+func _gen1_nurse_steps() -> Array:
+	var farewell: Array = [_gen1_pokecenter_box("farewell")]
+	return [
+		_gen1_pokecenter_box("welcome"),
+		{
+			"type": &"choice",
+			"text": _gen1_pokecenter_text("shall_we_heal"),
+			"yes": [
+				_gen1_pokecenter_box("need_your_pokemon"),
+				{"type": &"request", "values": {
+					"kind": &"party_heal_requested", "values": {},
+				}},
+				_gen1_pokecenter_box("fighting_fit"),
+			] + farewell,
+			"no": farewell,
+		},
+	]
+
+
+func _gen1_pokecenter_box(name: String) -> Dictionary:
+	return {"type": &"text", "text": _gen1_pokecenter_text(name)}
+
+
+func _gen1_pokecenter_text(name: String) -> String:
+	return data.special_text(GEN1_POKECENTER_RUN, name) if data != null else ""
 
 
 func _gen1_text_id_at(cell: Vector2i, kind: StringName) -> int:
@@ -3856,14 +3916,57 @@ func dispatch_sight_events() -> Array:
 
 
 func script_input_waiting() -> bool:
-	return _gen1_text_open or (_active_script != null and _active_script.is_waiting())
+	return _gen1_holding() or (_active_script != null and _active_script.is_waiting())
 
 
 ## True while a script holds the world, either running or still queued. A host
 ## that drives ambient motion checks this so a script keeps sole ownership of
 ## the objects it may be moving.
 func script_busy() -> bool:
-	return _gen1_text_open or _active_script != null or not _script_queue.is_empty()
+	return _gen1_holding() or _active_script != null or not _script_queue.is_empty()
+
+
+## Whether a Generation 1 interaction is still standing in front of the map.
+func _gen1_holding() -> bool:
+	return not _gen1_steps.is_empty()
+
+
+func _gen1_step(type: StringName) -> Dictionary:
+	if _gen1_steps.is_empty():
+		return {}
+	var step: Dictionary = _gen1_steps[0]
+	return step if StringName(step.get("type", &"")) == type else {}
+
+
+## The result the head step is waiting on, empty once the list is spent.
+func _gen1_result() -> Array:
+	if _gen1_steps.is_empty():
+		return []
+	var step: Dictionary = _gen1_steps[0]
+	var type: StringName = StringName(step["type"])
+	if type == &"request":
+		return [{
+			"ok": true, "status": &"waiting",
+			"event": {"type": &"runtime_request", "request": step["values"]},
+		}]
+	if type == &"choice":
+		return [{"ok": true, "status": &"waiting", "event": {"type": &"choice"}}]
+	## `AfterDisplayingTextID` ends every box on `WaitForTextScrollButtonPress`,
+	## whatever the string's last byte said.
+	return [{
+		"ok": true, "status": &"waiting",
+		"event": {"type": &"text", "text": String(step["text"]), "prompt": true},
+	}]
+
+
+## Spends the head step and answers with whatever the next one waits on.
+## [param choice] is the row a YES/NO was answered with.
+func _gen1_advance(choice: int) -> Array:
+	var step: Dictionary = _gen1_steps.pop_front()
+	if StringName(step.get("type", &"")) == &"choice":
+		var branch: Array = step.get("yes" if choice == 0 else "no", [])
+		_gen1_steps = branch.duplicate(true) + _gen1_steps
+	return _gen1_result()
 
 
 ## Whether the script holding the world is one that stops the map around it.
@@ -3879,6 +3982,9 @@ func script_stops_the_map() -> bool:
 
 
 func pending_runtime_request() -> Dictionary:
+	var step: Dictionary = _gen1_step(&"request")
+	if not step.is_empty():
+		return (step["values"] as Dictionary).duplicate(true)
 	return _active_script.pending_runtime_request() if _active_script != null else {}
 
 
@@ -3919,6 +4025,13 @@ func party_with_player() -> bool:
 
 
 func pending_script_input() -> Dictionary:
+	var step: Dictionary = _gen1_step(&"choice")
+	if not step.is_empty():
+		return {
+			"type": &"choice",
+			"choices": Gen2WorldMenu.YES_NO_KEYS.duplicate(),
+			"text": String(step.get("text", "")),
+		}
 	return _active_script.pending_input() if _active_script != null else {}
 
 
@@ -3981,7 +4094,7 @@ func load_object_masks() -> void:
 ## This is the explicit interaction boundary for NPCs, signs and item-like
 ## objects. It never executes a hidden object or invents a fallback action.
 func interact() -> Array:
-	if _active_script != null or not _script_queue.is_empty() or _gen1_text_open:
+	if _active_script != null or not _script_queue.is_empty() or _gen1_holding():
 		return run_event_queue(false)
 	if _gen1:
 		return _gen1_interact()
@@ -4105,9 +4218,8 @@ func _tile_collision_script_request(cell: Vector2i) -> Dictionary:
 func run_event_queue(acknowledge: bool = false, choice: int = -1) -> Array:
 	## `AfterDisplayingTextID` waits for the press and `CloseTextDisplay` returns
 	## to `HandleMap`, with no script behind it to resume.
-	if _gen1_text_open:
-		_gen1_text_open = not acknowledge
-		return []
+	if _gen1_holding():
+		return _gen1_advance(choice) if acknowledge else []
 	var results: Array = []
 	var accept: bool = acknowledge
 	var selected_choice: int = choice
@@ -4158,6 +4270,10 @@ func cancel_script_input() -> Array:
 ## scene-free script invocation. The world API owns the runner lifecycle, so a
 ## screen never needs to reach into the runner or replace its state.
 func complete_runtime_request(result: Dictionary) -> Array:
+	## `AfterDisplayingTextID` returns to `HandleMap` with nothing behind it, so
+	## a Generation 1 facility walks its own list instead of resuming a script.
+	if not _gen1_step(&"request").is_empty():
+		return _gen1_advance(-1)
 	if _active_script == null:
 		return []
 	var results: Array = []
@@ -6695,7 +6811,7 @@ func _apply_map(
 		target_map.group, target_map.number, target_map.tileset, target_cell,
 	])
 	_record_escape_points(target_map, from_warp)
-	_gen1_text_open = false
+	_gen1_steps = []
 	## `WarpFound2`'s `CheckIfInOutsideMap`: leaving a town or a route records it,
 	## and that is the map a `LAST_MAP` warp comes back out to.
 	if _gen1 and current_map != null and Gen1Layout.is_outside_tileset(current_map.tileset):

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -288,8 +288,11 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 static func _resolve_mart(world: Gen2WorldAPI, values: Dictionary) -> Dictionary:
 	var dialog_id: int = int(values.get("dialog", 0))
 	var mart_id: int = int(values.get("address", 0)) & 0xFF
+	## `{item, price}` is the shape `Gen2WorldMartHost.entries` already reads, so
+	## a shelf travelling with the request charges its own prices.
+	var inline: Array = values["items"] if values.get("items", null) is Array else []
 	var mart_result: Dictionary = Gen2WorldMartHost.resolve_mart(
-		world.data, dialog_id, mart_id, world.state.hall_of_fame(), world.state
+		world.data, dialog_id, mart_id, world.state.hall_of_fame(), world.state, inline
 	)
 	if not bool(mart_result.get("ok", false)):
 		return {
@@ -297,13 +300,6 @@ static func _resolve_mart(world: Gen2WorldAPI, values: Dictionary) -> Dictionary
 			"reason": StringName(mart_result.get("reason", &"mart_data_unavailable")),
 		}
 	var mart: Dictionary = mart_result["mart"]
-	## A catalog site may sell its own shelf. `{item, price}` is the shape
-	## `Gen2WorldMartHost.entries` already reads, so a patched price is
-	## the price the counter charges and nothing else changes.
-	if values.has("items") and values["items"] is Array \
-		and not (values["items"] as Array).is_empty():
-		mart = mart.duplicate(true)
-		mart["items"] = (values["items"] as Array).duplicate(true)
 	return {
 		"ok": true,
 		"data": {"mart": mart, "mart_id": mart_id, "dialog": dialog_id},

--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -18,9 +18,13 @@ const MARTTYPE_ROOFTOP: int = 4
 ## Resolves the source pokemart dialog before the UI is opened. Standard,
 ## bitter and pharmacy shops use the indexed pointer; bargain and rooftop
 ## shops use their imported priced records.
+##
+## [param inline_items] stands in for the indexed record when the inventory
+## travels with the request: a catalog site's shelf, and every Generation 1
+## counter, whose list `script_mart` writes into the text pointer.
 static func resolve_mart(
 	data: GameData, dialog_id: int, mart_id: int, rooftop_after_hall: bool = false,
-	world_state: Gen2WorldState = null
+	world_state: Gen2WorldState = null, inline_items: Array = []
 ) -> Dictionary:
 	if data == null:
 		return _failure(&"missing_data", {})
@@ -50,6 +54,8 @@ static func resolve_mart(
 			label = "ROOFTOP SALE"
 		_:
 			return _failure(&"unsupported_mart_dialog", {"dialog": dialog_id})
+	if not inline_items.is_empty():
+		mart = {"items": inline_items.duplicate(true)}
 	if variant == &"bargain" and world_state != null \
 		and world_state.bargain_merchant_closed(Gen2WorldState.is_crystal_profile(data)):
 		return _failure(&"bargain_mart_closed", {"dialog": dialog_id})

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4937,13 +4937,14 @@ func _handle_fishing_result(result: Dictionary) -> void:
 func _start_battle_request(request: Dictionary) -> void:
 	if _battle_host != null or _battle_transition != null or _data == null:
 		return
-	## No Generation 1 battle engine: its species are internal indexes and its
-	## stats a different formula, so the request is reported rather than fought.
-	## `RomRegistry`'s `playable` flag is what keeps a player off this path.
+	## No Generation 1 battle engine: its move effects are numbered its own way,
+	## so the request is reported rather than fought. `RomRegistry`'s `playable`
+	## flag is what keeps a player off this path.
 	if _data.generation == RomRegistry.GEN1:
-		_script_prompt = "Wild %d, level %d" % [
-			int((request.get("values", {}) as Dictionary).get("pokemon", 0)),
-			int((request.get("values", {}) as Dictionary).get("level", 0)),
+		var wild: Dictionary = request.get("values", {})
+		_script_prompt = "Wild %s, level %d" % [
+			_data.species(int(wild.get("pokemon", 0))).get("name", "?"),
+			int(wild.get("level", 0)),
 		]
 		_refresh_labels()
 		return

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -66,7 +66,11 @@ const MART_SELL_STAGES: Array[StringName] = [
 ]
 ## `MenuHeader_BuySell`'s three rows, inline in `engine/items/mart.asm` and
 ## reached by no script, the way [Gen2WorldPC]'s BILL'S PC rows are.
+## `BuySellQuitText` spells the same three, in a box `data/text_boxes.asm` puts
+## at (0,0) to (10,6) whose first row is the one under the border: the string is
+## placed at (2,1) rather than through `_InitVerticalMenuCursor`.
 const MART_TOP_ROWS: Array[String] = ["BUY", "SELL", "QUIT"]
+const GEN1_TOP_MENU_BOX := Rect2i(0, 0, 10, 6)
 const MART_TOP_BUY: int = 0
 const MART_TOP_SELL: int = 1
 const MART_TOP_QUIT: int = 2
@@ -143,6 +147,10 @@ var _mart_stage: StringName = MART_LIST
 var _mart_scroll: int = 0
 var _mart_pages: Array = []
 var _mart_after: StringName = MART_LIST
+## `SaveScreenTilesToBuffer1`: a Generation 1 shop photographs the screen behind
+## its greeting and restores it under every list, so the last box it printed
+## stays up while the player is choosing.
+var _mart_message: PackedStringArray = PackedStringArray()
 var _mart_confirm: int = 0
 ## `SellMenu`'s own list, which is the pack rather than the shop's stock.
 var _mart_sell_entries: Array = []
@@ -631,6 +639,7 @@ func _open_mart(mart: Dictionary) -> void:
 	_mart_quantity = 1
 	_mart_purchased = false
 	_mart_scroll = 0
+	_mart_message = PackedStringArray()
 	_cursor = 0
 	_set_overlay_open(true)
 	if _mart_view == null and _service_hardware != null:
@@ -702,6 +711,8 @@ func _show_mart_text(text: String, after: StringName, over_map: bool = false) ->
 	_mart_over_map = over_map
 	_mart_pages = [] if text.strip_edges().is_empty() \
 		else Gen2TextLayout.lay_out(text, MART_TEXT_COLUMNS, MART_TEXT_ROWS)
+	if not _mart_pages.is_empty():
+		_mart_message = _mart_pages[0]
 	if _mart_pages.is_empty():
 		_advance_mart_text()
 		return
@@ -713,6 +724,8 @@ func _show_mart_text(text: String, after: StringName, over_map: bool = false) ->
 ## the menu opens over the box, and `CopyMenuHeader` reloads its `db 1` default.
 func _show_mart_top(text: String) -> void:
 	_mart_pages = Gen2TextLayout.lay_out(text, MART_TEXT_COLUMNS, MART_TEXT_ROWS)
+	if not _mart_pages.is_empty():
+		_mart_message = _mart_pages[0]
 	_mart_stage = MART_TOP
 	_mart_over_map = true
 	_cursor = MART_TOP_BUY
@@ -738,12 +751,28 @@ func _advance_mart_text() -> void:
 	_finish_runtime({"ok": true, "script_value": 1 if _mart_purchased else 0})
 
 
+## Whether this shop is a Generation 1 counter.
+func _gen1_mart() -> bool:
+	return _data != null and _data.generation == RomRegistry.GEN1
+
+
 ## `w2DMenuNumRows`: the CANCEL row is only on offer when the whole list fits,
 ## because `ScrollingMenu_InitFlags` adds it to the row count and `.d_down`
-## stops scrolling at `size - height`.
+## stops scrolling at `size - height`. `DisplayListMenuID` instead fixes
+## `wMaxMenuItem` at 2 and prints a fourth name the cursor never reaches, so its
+## CANCEL is always on offer and its list always scrolls.
 func _mart_row_count() -> int:
 	var rows: int = _mart_list().size()
+	if _gen1_mart():
+		return mini(Gen2MartPage.GEN1_CURSOR_ROWS, rows + 1)
 	return rows + 1 if rows < Gen2MartPage.LIST_HEIGHT else Gen2MartPage.LIST_HEIGHT
+
+
+## Rows drawn, which is [method _mart_row_count] plus the look-ahead row.
+func _mart_drawn_rows() -> int:
+	if _gen1_mart():
+		return mini(Gen2MartPage.GEN1_LIST_HEIGHT, _mart_list().size() + 1 - _mart_scroll)
+	return _mart_row_count()
 
 
 func _mart_list() -> Array:
@@ -753,7 +782,7 @@ func _mart_list() -> Array:
 func _mart_rows() -> Array:
 	var entries: Array = _mart_list()
 	var out: Array = []
-	for row: int in _mart_row_count():
+	for row: int in _mart_drawn_rows():
 		var index: int = _mart_scroll + row
 		out.append({"cancel": true} if index >= entries.size() else entries[index])
 	return out
@@ -824,7 +853,9 @@ func _move_mart_cursor(delta: int) -> void:
 		if _mart_scroll > 0:
 			_mart_scroll -= 1
 	elif next >= rows:
-		if _mart_list().size() >= _mart_scroll + Gen2MartPage.LIST_HEIGHT:
+		var reach: int = Gen2MartPage.GEN1_CURSOR_ROWS if _gen1_mart() \
+			else Gen2MartPage.LIST_HEIGHT
+		if _mart_list().size() >= _mart_scroll + reach:
 			_mart_scroll += 1
 	else:
 		_cursor = next
@@ -937,10 +968,10 @@ func _press_mart_top(button: int) -> void:
 		PokeButton.A:
 			match _cursor:
 				MART_TOP_BUY:
-					_mart_stage = MART_LIST
-					_mart_over_map = false
-					_cursor = 0
+					## `PokemartBuyingGreetingText`; Generation 2's `.Buy` says
+					## nothing, and an empty box goes straight through.
 					_mart_scroll = 0
+					_show_mart_text(_mart_text("buy_intro"), MART_LIST, true)
 				MART_TOP_SELL:
 					_open_mart_sell()
 					return
@@ -955,15 +986,14 @@ func _press_mart_top(button: int) -> void:
 ## shop asks again rather than opening an empty list.
 func _open_mart_sell() -> void:
 	_refresh_mart_sell_entries()
-	if _mart_sell_entries.is_empty():
-		_show_mart_top(_mart_text("ask_more"))
-		return
-	_mart_stage = MART_SELL
-	_mart_over_map = false
-	_cursor = 0
 	_mart_scroll = 0
 	_mart_quantity = 1
-	_render_mart()
+	if _mart_sell_entries.is_empty():
+		## `PokemartItemBagEmptyText`, which Generation 2's `SellMenu` has no
+		## box for; both shops ask again behind it.
+		_show_mart_text(_mart_text("bag_empty"), MART_TOP, true)
+		return
+	_show_mart_text(_mart_text("sell_intro"), MART_SELL, true)
 
 
 ## The pack as rows this list can draw, at `GetMartPrice`'s halved price per
@@ -1087,6 +1117,9 @@ func _close_mart() -> void:
 func _render_mart() -> void:
 	if _mart_view == null or _data == null:
 		return
+	if _gen1_mart():
+		_render_gen1_mart()
+		return
 	if _mart_over_map:
 		_render_mart_over_map()
 		return
@@ -1096,7 +1129,6 @@ func _render_mart() -> void:
 		return
 	var page: PackedStringArray = _mart_pages[0] if not _mart_pages.is_empty() \
 		else PackedStringArray()
-	var selling: bool = _mart_stage in MART_SELL_STAGES
 	var listing: bool = _mart_stage == MART_LIST or _mart_stage == MART_SELL
 	var image: Image = _mart_page.render({
 		"money": _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
@@ -1109,17 +1141,61 @@ func _render_mart() -> void:
 		## stage's alone.
 		"quantity": _mart_quantity \
 			if _mart_stage == MART_QUANTITY or _mart_stage == MART_SELL_QUANTITY else -1,
-		## `DisplaySellingPrice` halves the multiplied total, not each unit's
-		## price, so the two subtotals are not the same arithmetic.
-		"subtotal": Gen2WorldMartHost.sell_price(
-			_data, int(_mart_selection().get("item", 0)), _mart_quantity
-		) if selling else int(_mart_selection().get("price", 0)) * _mart_quantity,
+		"subtotal": _mart_subtotal(),
 	})
 	if image == null:
 		return
 	if _mart_stage == MART_CONFIRM or _mart_stage == MART_SELL_CONFIRM:
 		_blend_mart_menu(image, Gen2MenuBox.yes_no(), ["YES", "NO"], _mart_confirm)
 	Gen2PicImage.show(_mart_view, image)
+
+
+## `DisplayPokemartDialogue_` never leaves the map: the money box, the list box
+## and whatever `PrintText` last wrote all stand over it.
+func _render_gen1_mart() -> void:
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _service_page == null or _mart_page == null:
+		return
+	var page: PackedStringArray = _mart_pages[0] if not _mart_pages.is_empty() \
+		else _mart_message
+	var image: Image = _service_page.render(
+		"", "", MART_TOP_ROWS if _mart_stage == MART_TOP else [], _cursor,
+		"\n".join(page),
+		Gen2MenuBox.from_coords(
+			GEN1_TOP_MENU_BOX.position.x, GEN1_TOP_MENU_BOX.position.y,
+			GEN1_TOP_MENU_BOX.end.x, GEN1_TOP_MENU_BOX.end.y,
+			Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+		)
+	)
+	if image == null:
+		return
+	var listing: bool = _mart_stage != MART_TOP and _mart_stage != MART_MESSAGE
+	var overlay: Image = _mart_page.render_gen1({
+		"money": _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
+		"rows": _mart_rows(),
+		"cursor": _cursor if _mart_stage == MART_LIST or _mart_stage == MART_SELL else -1,
+		"listing": listing,
+		"quantity": _mart_quantity \
+			if _mart_stage == MART_QUANTITY or _mart_stage == MART_SELL_QUANTITY else -1,
+		"subtotal": _mart_subtotal(),
+	})
+	if overlay != null:
+		image.blend_rect(overlay, Rect2i(Vector2i.ZERO, overlay.get_size()), Vector2i.ZERO)
+	if _mart_stage == MART_CONFIRM or _mart_stage == MART_SELL_CONFIRM:
+		_blend_mart_menu(image, Gen2MenuBox.yes_no(), ["YES", "NO"], _mart_confirm)
+	Gen2PicImage.show(_mart_view, image)
+
+
+## `DisplaySellingPrice` halves the multiplied total, not each unit's price, so
+## the two subtotals are not the same arithmetic.
+func _mart_subtotal() -> int:
+	var item: int = int(_mart_selection().get("item", 0))
+	if _mart_stage in MART_SELL_STAGES:
+		return Gen2WorldMartHost.sell_price(_data, item, _mart_quantity)
+	return int(_mart_selection().get("price", 0)) * _mart_quantity
 
 
 ## The speech box and `MenuHeader_BuySell`'s `menu_coords 0, 0, 7, 8` over it.

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -17,6 +17,7 @@ const REQUIRED_KEYS: Array[String] = [
 	"mon_palettes", "super_palettes", "trainer_names", "evos_moves", "evos_moves_bank",
 	"cries", "font", "text_box", "map_headers", "map_header_banks", "map_songs",
 	"tilesets", "water_tilesets", "tileset_collision_bank", "overworld_sprites",
+	"tm_prices", "mart_greeting", "mart_text", "pokecenter_text",
 ]
 
 
@@ -379,3 +380,61 @@ func test_every_sprite_row_is_inside_the_table() -> void:
 			Gen1Layout.sprite_count(id) - Gen1Layout.first_still_sprite(id) + 1, 12,
 			"%s still sprites" % id
 		)
+
+
+func test_every_text_script_id_is_named_and_the_two_built_are_among_them() -> void:
+	for code: Variant in Gen1Layout.TEXT_SCRIPT_IDS:
+		assert_between(int(code), 0xF5, 0xFF, "a TX_SCRIPT id is outside the run")
+	assert_true(Gen1Layout.TEXT_SCRIPT_IDS.has(Gen1Layout.TEXT_SCRIPT_MART))
+	assert_true(Gen1Layout.TEXT_SCRIPT_IDS.has(Gen1Layout.TEXT_SCRIPT_POKECENTER_NURSE))
+
+
+## A run of `text_far` stubs steps five bytes; the only wider gaps are the two
+## `text_pause`s `engine/events/pokecenter.asm` puts in front of a stub.
+func test_a_facility_text_run_steps_one_stub_at_a_time() -> void:
+	for slots: Dictionary in [Gen1Layout.MART_TEXT_AT, Gen1Layout.POKECENTER_TEXT_AT]:
+		var previous: int = -Gen1Layout.TEXT_FAR_STUB_BYTES
+		for slot: String in slots:
+			var delta: int = int(slots[slot]) - previous
+			assert_between(delta, Gen1Layout.TEXT_FAR_STUB_BYTES,
+				Gen1Layout.TEXT_FAR_STUB_BYTES + 1, "%s is %d bytes on" % [slot, delta])
+			previous = int(slots[slot])
+
+
+func test_a_facility_text_offset_is_its_run_plus_its_own_delta() -> void:
+	for id: StringName in RomRegistry.ids_of_generation(RomRegistry.GEN1):
+		var layout: Dictionary = Gen1Layout.for_id(id)
+		for slot: String in Gen1Layout.MART_TEXT_AT:
+			assert_eq(
+				Gen1Layout.facility_text_offset(layout, "mart_text", Gen1Layout.MART_TEXT_AT, slot),
+				int(layout["mart_text"]) + int(Gen1Layout.MART_TEXT_AT[slot])
+			)
+		assert_eq(
+			Gen1Layout.facility_text_offset(layout, "mart_text", Gen1Layout.MART_TEXT_AT, "none"),
+			-1, "a slot the table does not name has no offset"
+		)
+
+
+## `_IsTilePassable` and every map pointer below $4000 is home whatever bank is
+## switched in, and everything above it belongs to the bank it was read from.
+func test_a_bankless_pointer_below_the_window_is_home() -> void:
+	assert_eq(Gen1Layout.banked(0x1D, 0x2A55), 0x2A55)
+	assert_eq(Gen1Layout.banked(0x1D, 0x4000), 0x1D * RomFile.BANK_SIZE)
+	assert_eq(Gen1Layout.banked(0x00, 0x7FFF), 0x3FFF)
+
+
+## The two runs are the only items above `ItemNames`, and the gap between them
+## is the ids no `item_constants.asm` row names.
+func test_the_machine_items_sit_above_the_named_ones() -> void:
+	assert_eq(Gen1Layout.TM_FIRST_ITEM, Gen1Layout.HM_FIRST_ITEM + Gen1Layout.HM_COUNT)
+	assert_true(Gen1Layout.HM_FIRST_ITEM > Gen1Layout.ITEM_COUNT)
+	assert_between(
+		Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT - 1, Gen1Layout.TM_FIRST_ITEM, 0xFF
+	)
+
+
+func test_a_mart_inventory_fits_the_buffer_it_is_copied_into() -> void:
+	assert_eq(Gen1Layout.MART_ITEMS_AT, Gen1Layout.MART_COUNT_AT + 1)
+	## `wItemList` is sixteen bytes: the count, the items and a terminator, which
+	## is the whole of what `LoadItemList` copies out of the text pointer.
+	assert_true(1 + Gen1Layout.MART_MAX_ITEMS + 1 <= 16)

--- a/tests/unit/test_mart_page.gd
+++ b/tests/unit/test_mart_page.gd
@@ -115,3 +115,76 @@ func test_the_speech_box_prints_its_lines_two_rows_apart() -> void:
 		_ink(image, Gen2MartPage.TEXT_AT + Vector2i(0, 1)),
 		"the row between them is the box's own spacing"
 	)
+
+
+## `render_gen1` leaves the map showing, so its transparent cells are the test:
+## an untouched pixel has zero alpha rather than the white a full page draws.
+func _drawn(image: Image, tile: Vector2i) -> bool:
+	for row: int in TILE:
+		for column: int in TILE:
+			if image.get_pixel(tile.x * TILE + column, tile.y * TILE + row).a > 0.0:
+				return true
+	return false
+
+
+func _gen1_state(overrides: Dictionary = {}) -> Dictionary:
+	var state: Dictionary = _state({"listing": true, "cursor": 0})
+	state["rows"] = [
+		{"name": "POKé BALL", "price": 200},
+		{"name": "POTION", "price": 300},
+		{"name": "ANTIDOTE", "price": 100},
+		{"cancel": true},
+	]
+	state.merge(overrides, true)
+	return state
+
+
+func test_the_gen1_shop_leaves_the_map_between_its_boxes() -> void:
+	var image: Image = _page.render_gen1(_gen1_state())
+	assert_eq(image.get_size(), Vector2i(Gen2Screen.WIDTH, Gen2Screen.HEIGHT))
+	assert_true(_drawn(image, Gen2MartPage.MONEY_AT), "the money box is drawn")
+	assert_true(_drawn(image, Gen2MartPage.GEN1_LIST_AT), "the list box is drawn")
+	## `MESSAGE_BOX` is `PrintText`'s, not the shop's, and every column left of
+	## `LIST_MENU_BOX` is map.
+	assert_false(_drawn(image, Vector2i(0, 12)), "the message box is not this page's")
+	assert_false(_drawn(image, Gen2MartPage.GEN1_LIST_AT - Vector2i(1, 0)))
+
+
+func test_the_gen1_list_prints_four_names_and_moves_over_three() -> void:
+	var image: Image = _page.render_gen1(_gen1_state())
+	for row: int in Gen2MartPage.GEN1_LIST_HEIGHT:
+		var at: Vector2i = Gen2MartPage.GEN1_NAME_AT \
+			+ Vector2i(0, row * Gen2MartPage.ROW_STEP)
+		assert_true(_drawn(image, at), "row %d's name is drawn" % row)
+	var cursor := Vector2i(Gen2MartPage.GEN1_CURSOR_COLUMN, Gen2MartPage.GEN1_NAME_AT.y)
+	assert_true(_drawn(image, cursor), "the cursor stands on the first row")
+	var last := Vector2i(
+		Gen2MartPage.GEN1_CURSOR_COLUMN,
+		Gen2MartPage.GEN1_NAME_AT.y + Gen2MartPage.GEN1_CURSOR_ROWS * Gen2MartPage.ROW_STEP
+	)
+	assert_false(
+		_ink(image, last), "the fourth row is a look ahead the cursor never reaches"
+	)
+
+
+func test_a_gen1_price_lands_a_row_below_its_name() -> void:
+	var image: Image = _page.render_gen1(_gen1_state())
+	var last_digit := Vector2i(
+		Gen2MartPage.GEN1_PRICE_COLUMN + Gen2MartPage.MONEY_CELLS - 1,
+		Gen2MartPage.GEN1_NAME_AT.y + 1
+	)
+	assert_true(_drawn(image, last_digit), "the price is right aligned under the name")
+	assert_false(
+		_ink(image, Vector2i(last_digit.x, Gen2MartPage.GEN1_NAME_AT.y)),
+		"and never beside it: the name has that row to itself"
+	)
+
+
+func test_the_gen1_quantity_box_stands_where_the_list_can_still_be_seen() -> void:
+	var image: Image = _page.render_gen1(_gen1_state({"quantity": 1, "subtotal": 200}))
+	assert_true(_drawn(image, Gen2MartPage.GEN1_QUANTITY_AT), "its own frame")
+	assert_true(_drawn(image, Gen2MartPage.QUANTITY_TEXT_AT - Gen2MartPage.QUANTITY_AT
+		+ Gen2MartPage.GEN1_QUANTITY_AT), "and the count inside it")
+	assert_false(
+		_drawn(image, Gen2MartPage.QUANTITY_AT), "nothing where Generation 2 draws it"
+	)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 520 lines of the 38480 here, and Generation 1's colour, sprites, wild
-## tables, walk, text box and encounter roll added 201 more to the shared
-## collision, palette, world, encounter, text and renderer code. Four sweeps
-## have said the tree has no restatement left to pay with.
-const MAX_COMMENT_LINES: int = 38480
+## are 580 lines of the 38600 here, and Generation 1's colour, sprites, wild
+## tables, walk, text box, encounter roll, shop and Pokemon Center added 261 more
+## to the shared collision, palette, world, encounter, text, save and renderer
+## code. Four sweeps have said the tree has no restatement left to pay with.
+const MAX_COMMENT_LINES: int = 38600
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -57,10 +57,10 @@ const OVERWORLD_PASSABLE: Array[int] = [
 
 ## The Power Plant's Voltorbs, Electrodes and Zapdos: an object with the TRAINER
 ## bit and a byte below `OPP_ID_OFFSET`, which is the only shape a wild one
-## takes: six Voltorbs, two Electrodes and Zapdos. Internal indexes, not dex
-## numbers.
+## takes: six Voltorbs, two Electrodes and Zapdos, as the dex numbers the cache
+## stores rather than the internal indexes the cartridge writes.
 const POWER_PLANT: int = 83
-const POWER_PLANT_WILD: Dictionary = {0x06: 6, 0x8D: 2, 0x4B: 1}
+const POWER_PLANT_WILD: Dictionary = {100: 6, 101: 2, 145: 1}
 
 ## `SilphCoElevator_Object`'s two warps name UNUSED_MAP_ED, which has no header:
 ## the elevator's own script rewrites the destination before either is taken.
@@ -105,6 +105,10 @@ const TEXT_CENSUS: Dictionary = {
 	&"yellow": {0x08: 675, 0x17: 429, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3,
 		0xFE: 14, 0xFF: 12},
 }
+
+## Rows of `script_mart` across the corpus. Yellow's Celadon 5F clerk sells one
+## more than Red and Blue's.
+const MART_ITEMS: Dictionary = {&"red": 97, &"blue": 97, &"yellow": 98}
 
 ## `_MtMoonPokecenterClipboardText`, the corpus's one empty box.
 const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
@@ -267,6 +271,32 @@ func _texts() -> void:
 	_r.check(empty == int(EMPTY_TEXTS[_r.game_id]),
 		"%d texts decoded to nothing, pinned %d." % [empty, int(EMPTY_TEXTS[_r.game_id])])
 	_r.note("gen1 texts %s" % [census])
+	_marts()
+
+
+## Every `script_mart` row's inline inventory: `LoadItemList` reads the count out
+## of the text pointer itself, so a stride that has slipped shows up as a shelf
+## naming an item the cartridge has no name for.
+func _marts() -> void:
+	var shelves: int = 0
+	var items: int = 0
+	for map: Gen2WorldMap in _maps.values():
+		for row: Dictionary in map.texts:
+			if int(row["command"]) != Gen1Layout.TEXT_SCRIPT_MART:
+				continue
+			var shelf: Array = row.get("items", [])
+			shelves += 1
+			items += shelf.size()
+			if not _r.check(not shelf.is_empty(), "map %d's shop is empty." % map.number):
+				continue
+			for item: Variant in shelf:
+				_r.check(not _r.data.item_name(int(item)).is_empty(),
+					"map %d's shop sells item %d, which has no name." % [map.number, int(item)])
+	_r.check(shelves == int(TEXT_CENSUS[_r.game_id][Gen1Layout.TEXT_SCRIPT_MART]),
+		"%d shops carry an inventory." % shelves)
+	_r.check(items == int(MART_ITEMS[_r.game_id]),
+		"the shops sell %d items, pinned %d." % [items, int(MART_ITEMS[_r.game_id])])
+	_r.note("gen1 shops %d selling %d items" % [shelves, items])
 
 
 ## Whether every code [param line] encodes to has ink behind it.

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -8,7 +8,11 @@ extends RefCounted
 
 const SPECIES_COUNT: int = 151
 const MOVE_COUNT: int = 165
+## `NUM_ITEMS`, and the last row the table carries: `GetMachineName` and
+## `GetMachinePrice` put HM01 at $C4 and TM50 at $FA, so the cache runs that far
+## with the unnamed ids between them empty.
 const ITEM_COUNT: int = 83
+const ITEM_TABLE_COUNT: int = 250
 const TYPE_COUNT: int = 16
 const TRAINER_COUNT: int = 47
 const MATCHUP_COUNT: int = 82
@@ -211,8 +215,8 @@ func _types() -> void:
 
 func _items() -> void:
 	var data: GameData = _r.data
-	if not _r.check(data.item_count() == ITEM_COUNT, "%d items, expected %d" % [
-		data.item_count(), ITEM_COUNT
+	if not _r.check(data.item_count() == ITEM_TABLE_COUNT, "%d items, expected %d" % [
+		data.item_count(), ITEM_TABLE_COUNT
 	]):
 		return
 	for number: int in range(1, ITEM_COUNT + 1):
@@ -221,7 +225,18 @@ func _items() -> void:
 		_r.check(int(item["price"]) >= 0, "item %d is priced %d" % [number, item["price"]])
 	_r.check(String(data.item(1)["name"]) == "MASTER BALL", "item 1 is not the Master Ball")
 	_r.check(int(data.item(4)["price"]) == 200, "a Poke Ball is not 200")
-	_r.note("%d items" % ITEM_COUNT)
+	## `HiddenPrefix` and `TechnicalPrefix` either side of the gap, and
+	## `TechnicalMachinePrices`' first and last nybbles.
+	_r.check(String(data.item(Gen1Layout.HM_FIRST_ITEM)["name"]) == "HM01",
+		"$C4 is not HM01")
+	_r.check(int(data.item(Gen1Layout.HM_FIRST_ITEM)["price"]) == 0, "an HM has a price")
+	_r.check(String(data.item(Gen1Layout.TM_FIRST_ITEM)["name"]) == "TM01",
+		"$C9 is not TM01")
+	_r.check(int(data.item(Gen1Layout.TM_FIRST_ITEM)["price"]) == 3000, "TM01 is not 3000")
+	_r.check(int(data.item(ITEM_TABLE_COUNT)["price"]) == 2000, "TM50 is not 2000")
+	_r.check(String(data.item(Gen1Layout.ITEM_COUNT + 1)["name"]).is_empty(),
+		"$54 has a name")
+	_r.note("%d named items in a table of %d" % [ITEM_COUNT, ITEM_TABLE_COUNT])
 
 
 func _tmhm() -> void:

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -77,25 +77,26 @@ const GEN1_ROLL_STEPS: int = 8000
 const GEN1_ROLL_SEED: int = 7
 const GEN1_ROLL_TOLERANCE: float = 0.01
 
-## `Route1.asm`: rate 25 and ten slots of PIDGEY and RATTATA, by internal index.
+## `Route1.asm`: rate 25 and ten slots of PIDGEY and RATTATA. The cartridge
+## names each by its internal index and the cache stores the dex number.
 const GEN1_ROUTE_1: int = 0x0C
 const GEN1_ROUTE_1_RATE: int = 25
 const GEN1_ROUTE_1_SLOTS: Array = [
-	[3, 0x24], [3, 0xA5], [3, 0xA5], [2, 0xA5], [2, 0x24],
-	[3, 0x24], [3, 0x24], [4, 0xA5], [4, 0x24], [5, 0x24],
+	[3, 16], [3, 19], [3, 19], [2, 19], [2, 16],
+	[3, 16], [3, 16], [4, 19], [4, 16], [5, 16],
 ]
 
 ## `SeaRoutes.asm`, the water block Routes 19 and 20 share: rate 5 over ten
 ## TENTACOOL, and no grass at all. Yellow gives the pair its own block.
 const GEN1_SEA_ROUTES: Array[int] = [0x1E, 0x1F]
 const GEN1_SEA_RATE: int = 5
-const GEN1_SEA_SPECIES: int = 0x18
+const GEN1_SEA_SPECIES: int = 72
 
 ## `SuperRodData`'s first row, `.Group1`, and Yellow's own first row, which is
 ## four slots with a threshold each rather than a uniform pick.
 const GEN1_ROD_MAP: int = 0x00
-const GEN1_ROD_SLOTS: Array = [[15, 0x18], [15, 0x47]]
-const GEN1_ROD_SLOTS_YELLOW: Array = [[10, 0x1B], [10, 0x18], [5, 0x1B], [20, 0x18]]
+const GEN1_ROD_SLOTS: Array = [[15, 72], [15, 60]]
+const GEN1_ROD_SLOTS_YELLOW: Array = [[10, 120], [10, 72], [5, 120], [20, 72]]
 
 
 ## Every Generation 1 encounter table in the cache, on all three cartridges.
@@ -289,7 +290,7 @@ func _gen1_sea_routes() -> void:
 		"the sea routes' water rate is %d." % int(rows[0]["rate"]))
 	for slot: Dictionary in rows[0]["slots"] as Array:
 		_r.check(int(slot["species"]) == GEN1_SEA_SPECIES,
-			"a sea route slot names index %d." % int(slot["species"]))
+			"a sea route slot names species %d." % int(slot["species"]))
 
 
 ## Pallet Town's group, and that every map the table names resolves to slots.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -27,6 +27,7 @@ const KIND_HELP: Dictionary = {
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
+	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"magnet_train": "frames, direction: special MagnetTrain, that many frames in. Direction 1 rides to Goldenrod",
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
@@ -133,8 +134,9 @@ const POKEPIC_SPECIES: int = 152
 const SCREEN_DRIVER: String = "preview_%s"
 
 ## `.HowMayIHelpYou` prints without waiting, so `pokemart` opens straight on the
-## BUY/SELL/QUIT menu and one press reaches the list.
-const MART_PRESSES: int = 0
+## BUY/SELL/QUIT menu and one press reaches the list. `DisplayPokemartDialogue`
+## does wait, and prints again behind the row, which is what this bounds.
+const MART_PRESSES: int = 4
 ## Frames spent between two presses of a driven menu, so the box a press opened
 ## owes nothing before the next one lands: nothing shortens a printing text.
 const TEXT_SETTLE_FRAMES: int = 20
@@ -146,7 +148,12 @@ const TEXT_SETTLE_FRAMES: int = 20
 ## climb runs four passes a cell, so 26 lands a few cells up.
 const STAGED_FRAMES: int = 2
 ## `sign` spends the whole reveal: no press finishes a page early.
-const STAGED_FRAMES_BY_KIND: Dictionary = {&"cut": 12, &"waterfall_use": 26, &"sign": 120}
+const STAGED_FRAMES_BY_KIND: Dictionary = {
+	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
+	&"nurse": BOX_REVEAL_FRAMES,
+}
+## Enough for the longest box in the game to finish revealing.
+const BOX_REVEAL_FRAMES: int = 120
 
 const PREVIEW_BATTLE_SPECIES: int = 16 ## `preview_battle_request`'s PIDGEY.
 
@@ -303,6 +310,19 @@ func _stage_battle_tower_party() -> void:
 	_screen._refresh_party_summary()
 
 
+## A party with something to heal: `HealParty` is a save transaction.
+func _stage_hurt_party() -> void:
+	var save: Gen2SaveData = _screen.active_save()
+	if save == null:
+		save = Gen2SaveStore.create_development_save(_screen._data, 0)
+		_screen.set_save(save)
+	if save == null:
+		return
+	for mon: Gen2SaveMon in save.party:
+		mon.hp = 1
+	_screen._refresh_party_summary()
+
+
 func _settle_mon_special(host_property: String) -> void:
 	for _frame: int in MON_SPECIAL_FRAME_CAP:
 		var routine: Control = _screen.get(host_property)
@@ -373,6 +393,7 @@ const STAGERS: Dictionary = {
 	&"mod_page": &"_stage_mod_page",
 	&"pokepic": &"_stage_pokepic",
 	&"sign": &"_stage_sign",
+	&"nurse": &"_stage_nurse",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -706,8 +727,7 @@ func _stage_npc_trade() -> void:
 func _stage_mart() -> void:
 	_screen.press_button(PokeButton.LEFT)
 	_screen.interact()
-	for _press: int in MART_PRESSES:
-		_screen.press_button(PokeButton.A)
+	_clear_mart_boxes()
 	## `StandardMart`'s BUY/SELL/QUIT loop is what the welcome box hands
 	## the shop to. `mart` takes its BUY row, `mart_sell` the one below.
 	if _kind == &"mart_top":
@@ -715,6 +735,18 @@ func _stage_mart() -> void:
 	if _kind == &"mart_sell":
 		_screen.press_button(PokeButton.DOWN)
 	_screen.press_button(PokeButton.A)
+	_clear_mart_boxes()
+
+
+## Presses through whatever boxes the shop is holding on, so a kind lands on the
+## same stage on either generation.
+func _clear_mart_boxes() -> void:
+	for _press: int in MART_PRESSES:
+		var host: Gen2WorldServiceScreen = _screen.get("_service_host")
+		if host == null or StringName(host.get("_mart_stage")) \
+			!= Gen2WorldServiceScreen.MART_MESSAGE:
+			return
+		_screen.press_button(PokeButton.A)
 
 
 ## The floor panel, read from the cell below it: `bg_event 3, 0`'s own `elevator` is
@@ -857,6 +889,20 @@ func _stage_pokepic() -> void:
 func _stage_sign() -> void:
 	_screen.press_button(PokeButton.UP)
 	_screen.interact()
+
+
+## The nurse, reached over her counter from the cell below it, which is the
+## range `IsSpriteOrSignInFrontOfPlayer` doubles. The number is boxes to press past.
+func _stage_nurse() -> void:
+	_stage_hurt_party()
+	_screen.press_button(PokeButton.UP)
+	for _frame: int in TEXT_SETTLE_FRAMES:
+		_screen.advance_frame()
+	_screen.interact()
+	for _press: int in maxi(_cell.x, 0):
+		for _frame: int in BOX_REVEAL_FRAMES:
+			_screen.advance_frame()
+		_screen.press_button(PokeButton.A)
 
 
 ## `_UnownPrinter`'s browser: the first number is the slot, where 26 is the vacant


### PR DESCRIPTION
`DisplayTextID` reads the first byte of the text a pointer stands at and dispatches the `TX_SCRIPT_*` ids before it prints. 44 rows of the Generation 1 corpus stand at one: 14 `script_mart`, 12 `script_pokecenter_nurse`, 12 cable club receptionists, 3 vending machines and 3 prize vendors. The shop and the Pokemon Center are open; the other three read state a Generation 1 save would hold and are named in the state file.

## Added

`Gen2WorldAPI` holds the routine behind a facility as a list of steps where Generation 2 holds a script: a box, a YES/NO, a host request, and the branch a choice takes. `pending_runtime_request`, `pending_script_input` and `complete_runtime_request` all answer from it, so the world screen and the service host reach a Generation 1 counter through the same calls a script command uses.
`script_mart` writes its inventory into the text pointer itself, so a shop is one `mart_requested` carrying that list. `Gen2WorldMartHost.resolve_mart` takes an inline inventory in place of an indexed record, which is also the shape a catalog site's own shelf already had.
`Gen2WorldServiceScreen` runs `StandardMart`'s BUY/SELL/QUIT loop over it with `PokemartGreetingText` and the eleven boxes behind it. `PokemartBuyingGreetingText`, `PokemonSellingGreetingText` and `PokemartItemBagEmptyText` are three box slots Generation 2 has no counterpart for and answers empty, which goes straight through.
`Gen2MartPage` draws `DisplayListMenuID`'s framed list at (4,2), its money box with `MONEY` on the border row, and `DisplayChooseQuantityMenu`'s dial, all over the map: `BuyMenu` blanks the screen and `DisplayPokemartDialogue_` never leaves it. The list prints four names and moves the cursor over three, which is `ld b, 4` against `wMaxMenuItem` 2.
The nurse is `DisplayPokemonCenterDialogue_` whole: the welcome, `ShallWeHealYourPokemonText` with its YES/NO, `HealParty`, and the two boxes behind it.
`tools/preview_world.gd` gains a `nurse` kind beside its three mart ones.

## Fixed

The item table stopped at `ItemNames`' 83 rows, so the nine TMs the Celadon counter sells had no name and no price. `GetMachineName` spells an HM's or a TM's name from its own number and `GetMachinePrice` reads a nybble of `TechnicalMachinePrices` times a thousand, so the table now runs to TM50 with the ids between the two runs empty.
A wild slot, a fishing slot and a standing wild object carried the cartridge's internal index rather than a dex number. All three convert through `PokedexOrder` at import, which is what the cache already did for an evolution's target.
Base stats carried one `special` and neither `sp_attack` nor `sp_defense`, so anything reading a base stat off a Generation 1 species read zero. Both halves answer with the one Special.
`TX_BCD` dropped its number instead of marking it the way `TX_DECIMAL` does. No Crystal text uses the command and every Generation 1 one that does is a price, so `_PokemartTellBuyPriceText` printed `¥. OK?`.
A row whose text opens with a `text_pause` read as machine code and decoded to nothing. `Gen1Text.decode_stream` is now the one reader for a printed box and takes any text command at the head of a row, since `DisplayTextID` hands everything that is not a `TX_SCRIPT_*` id to `PrintText`.
`Gen2SaveStore.create_development_save` built its party from Cyndaquil and Quilava, which are outside a Generation 1 cartridge's 151 species.
`RomFile.bank_end` and `Gen1Layout.banked` replace the two copies each had in `Gen1WorldImporter`.

## Changed

Cache format 107. All six cartridges re-imported; `layout: Layout verified.` on each.

| Check | Result |
|---|---|
| GUT, `tests` with subdirectories | 4336 pass |
| `tools/validate.gd -- all` | exit 0, no failures |
| `addons/warning_scan` over the tree | 0 warnings in 627 scripts |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | 16 badges, 0 failed steps each |
| `gen1_maps` shop sweep | 14 shops selling 97 items on Red and Blue, 98 on Yellow |
