### PR TITLE
Fight a wild Pokemon on a Generation 1 map

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ godot --headless --path . -s res://tools/verify_rom.gd
 Matching uses SHA-1, never filenames. Unknown hashes are refused because an
 uncharacterised bank layout could produce corrupt assets. The three Generation 1
 cartridges import their species, move, type, item and trainer tables, every map
-and tileset, and every map text; the launcher seats one and does not offer Play
-until its battle engine is built.
+and tileset, and every map text, and a wild fight on one of their maps is fought
+on the battle screen; the launcher seats one and does not offer Play until its
+map scripts are interpreted.
 
 | Game | SHA-1 |
 |---|---|

--- a/game/battle/accuracy.gd
+++ b/game/battle/accuracy.gd
@@ -60,8 +60,13 @@ static func apply_stage(value: int, stage: int) -> int:
 ## Rolls a hit against a chance out of 255.
 ##
 ## A chance of exactly 255 connects without rolling. Rolling would miss one time
-## in 256, and the cartridge goes out of its way not to.
-static func rolls_hit(rng: RandomNumberGenerator, hit_chance: int) -> bool:
-	if hit_chance >= ALWAYS_HITS:
+## in 256, and Crystal goes out of its way not to. [param generation] is
+## `MoveHitTest`, which does not: pret's own comment there says even the highest
+## accuracy is 255 in 256, and Swift is exempt because the routine returns above
+## the roll rather than because 255 is special.
+static func rolls_hit(
+	rng: RandomNumberGenerator, hit_chance: int, generation: int = RomRegistry.GEN2
+) -> bool:
+	if hit_chance >= ALWAYS_HITS and generation != RomRegistry.GEN1:
 		return true
 	return rng.randi_range(0, 255) < hit_chance

--- a/game/battle/battle_mon.gd
+++ b/game/battle/battle_mon.gd
@@ -15,6 +15,11 @@ const MAX_MOVES: int = Gen2Learnset.MOVE_SLOTS
 
 ## The stats a stage can be applied to, in the order the cartridge keeps them.
 const STAGED_STATS: Array = ["attack", "defense", "speed", "sp_attack", "sp_defense"]
+## Generation 1 keeps one Special stat and one stage byte for it, so a change
+## to either half is the same byte moving. The base halves already agree.
+const SPECIAL_STAGE_TWIN: Dictionary = {
+	"sp_attack": "sp_defense", "sp_defense": "sp_attack",
+}
 
 ## Accuracy and evasion are staged like a stat and are not stats: they have their
 ## own multiplier table, and there is no number behind them for a stage to
@@ -373,6 +378,9 @@ func change_stage(key: String, by: int) -> bool:
 	var limited: bool = _stat_at_limit(key, by)
 	var after: int = clampi(stage(key) + by, Gen2Stats.MIN_STAGE, Gen2Stats.MAX_STAGE)
 	stages[key] = after - signi(by) if limited else after
+	if SPECIAL_STAGE_TWIN.has(key) and data != null \
+		and data.generation == RomRegistry.GEN1:
+		stages[String(SPECIAL_STAGE_TWIN[key])] = stages[key]
 	return not limited
 
 

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -162,7 +162,7 @@ func _draw_pics() -> void:
 	# when the square is holding a trainer, which it is until that trainer has
 	# sent something out.
 	var enemy_trainer: int = int(_view.get("enemy_trainer_pic", 0))
-	if enemy_trainer > 0 and not bool(_view.get("grayscale", false)):
+	if enemy_trainer > 0 and not bool(_view.get("grayscale", false)) and not _gen1():
 		enemy_palette = _remap(
 			_data.trainer_palette(enemy_trainer),
 			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_ENEMY)
@@ -189,7 +189,7 @@ func _draw_pics() -> void:
 	# `GetPlayerOrMonPalettePointer`'s `and a / jp nz`: a zero species is the
 	# player standing there, and the palette is the player's own.
 	var backpic: String = String(_view.get("player_backpic", ""))
-	if not backpic.is_empty() and not bool(_view.get("grayscale", false)):
+	if not backpic.is_empty() and not bool(_view.get("grayscale", false)) and not _gen1():
 		player_palette = _remap(
 			_data.player_palette(String(_view.get("player_backpic_palette", "chris"))),
 			_palette_map("bg_palette_maps", Gen2BattleAnimBackground.PAL_BG_PLAYER)
@@ -204,10 +204,19 @@ func _draw_pics() -> void:
 			_player_pic,
 			_pic_layer(
 				map, Gen2BattleScreenMap.PLAYER_BASE_TILE,
-				Gen2BattleScreenMap.PLAYER_SIDE, _player_pixels, vbank1
+				Gen2BattleScreenMap.player_box_side(_data.generation),
+				_player_pixels, vbank1
 			),
 			player_palette
 		)
+
+
+## `BlkPacket_Battle` gives each square one of four Super Game Boy palettes and
+## `SetPal_Battle` fills two of them from `DeterminePaletteID`, which reads a
+## species and nothing else. So a Generation 1 trainer, the player's back pic
+## included, wears the palette of the mon whose square it is standing in.
+func _gen1() -> bool:
+	return _data != null and _data.generation == RomRegistry.GEN1
 
 
 ## `wAttrmap` bit 3 over the screen, which is the VRAM bank each cell's tile
@@ -317,20 +326,56 @@ func _ensure_pixels() -> void:
 	]
 	if player_key != _player_pixels_key:
 		if not String(player_key[3]).is_empty():
-			_player_pixels = padded_pic(_data,
-				_data.player_backpic(String(player_key[3])),
-				Gen2BattleScreenMap.PLAYER_SIDE
-			)
+			_player_pixels = _back_pixels(_data.player_backpic(String(player_key[3])))
 		elif bool(player_key[1]):
 			_player_pixels = _substitute_pic(true)
 		elif bool(player_key[4]):
 			_player_pixels = _minimize_pic(true)
 		else:
-			_player_pixels = padded_pic(_data,
-				_battler_pic(int(player_key[0]), int(player_key[2]), true),
-				Gen2BattleScreenMap.PLAYER_SIDE
+			_player_pixels = _back_pixels(
+				_battler_pic(int(player_key[0]), int(player_key[2]), true)
 			)
 		_player_pixels_key = player_key
+
+
+## The back pic in its own box, which Generation 1 doubles on the way in.
+func _back_pixels(pic: Dictionary) -> PackedByteArray:
+	var side: int = Gen2BattleScreenMap.player_box_side(_data.generation)
+	if _data.generation == RomRegistry.GEN1:
+		return doubled_pic(_data, pic, side)
+	return padded_pic(_data, pic, side)
+
+
+## `ScaleSpriteByTwo`: a 32x32 back pic drawn 56x56. It walks 28 of the 32 rows
+## and takes four pixels from the last column rather than eight, so the last
+## four of each are dropped and what is left is drawn twice each way.
+static func doubled_pic(data: GameData, pic: Dictionary, side: int) -> PackedByteArray:
+	var box: int = side * TILE
+	var out: PackedByteArray = PackedByteArray()
+	out.resize(box * box)
+	if pic.is_empty():
+		return out
+	var atlas_name: String = String(pic.get("atlas", ""))
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		data.atlas_indices(atlas_name), data.atlas(atlas_name), pic
+	)
+	if cell.is_empty():
+		return out
+
+	var indices: PackedByteArray = cell["indices"]
+	var stride: int = int(cell["width"])
+	@warning_ignore("integer_division")
+	var half: int = box / 2
+	var rows: int = mini(half, int(cell["height"]))
+	var columns: int = mini(half, stride)
+	for y: int in rows:
+		for x: int in columns:
+			var value: int = indices[y * stride + x]
+			for down: int in 2:
+				var to: int = (y * 2 + down) * box + x * 2
+				out[to] = value
+				out[to + 1] = value
+	return out
 
 
 ## `_GetFrontpic`'s own branch: Unown is drawn out of `UnownPicPointers` by
@@ -343,17 +388,21 @@ func _battler_pic(species: int, unown_form: int, back: bool) -> Dictionary:
 
 
 func _substitute_pic(player_side: bool) -> PackedByteArray:
-	return substitute_pixels(_data.overworld_sprite_indices(SUBSTITUTE_SPRITE), player_side)
+	return substitute_pixels(
+		_data.overworld_sprite_indices(SUBSTITUTE_SPRITE), player_side, _data.generation
+	)
 
 
 func _minimize_pic(player_side: bool) -> PackedByteArray:
-	return minimize_pixels(_data.tile_indices("minimize"), player_side)
+	return minimize_pixels(_data.tile_indices("minimize"), player_side, _data.generation)
 
 
 ## `GetMinimizePic`: a blank box with `MinimizePic`'s single tile copied into it.
 ## Static for the same reason [method substitute_pixels] is.
-static func minimize_pixels(tile: PackedByteArray, player_side: bool) -> PackedByteArray:
-	var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+static func minimize_pixels(
+	tile: PackedByteArray, player_side: bool, generation: int = RomRegistry.GEN2
+) -> PackedByteArray:
+	var side: int = Gen2BattleScreenMap.player_box_side(generation) if player_side \
 		else Gen2BattleScreenMap.ENEMY_SIDE
 	var box: int = side * TILE
 	var out: PackedByteArray = PackedByteArray()
@@ -375,8 +424,10 @@ static func minimize_pixels(tile: PackedByteArray, player_side: bool) -> PackedB
 ##
 ## Static because it is the whole of the picture and takes no screen: a check
 ## sweeping three caches builds it the same way the renderer does.
-static func substitute_pixels(strip: PackedByteArray, player_side: bool) -> PackedByteArray:
-	var side: int = Gen2BattleScreenMap.PLAYER_SIDE if player_side \
+static func substitute_pixels(
+	strip: PackedByteArray, player_side: bool, generation: int = RomRegistry.GEN2
+) -> PackedByteArray:
+	var side: int = Gen2BattleScreenMap.player_box_side(generation) if player_side \
 		else Gen2BattleScreenMap.ENEMY_SIDE
 	var box: int = side * TILE
 	var out: PackedByteArray = PackedByteArray()
@@ -453,7 +504,9 @@ static func padded_pic(
 	var pad_y: int = 0
 	if front:
 		@warning_ignore("integer_division")
-		pad_x = Gen2PicImage.frontpic_pad_columns(width / TILE) * TILE
+		pad_x = Gen2PicImage.frontpic_pad_columns(
+			width / TILE, false, data.generation
+		) * TILE
 		@warning_ignore("integer_division")
 		pad_y = Gen2PicImage.frontpic_pad_rows(height / TILE) * TILE
 	var strip: int = box + extra
@@ -618,7 +671,9 @@ func _draw_panels() -> void:
 
 	if _layer_changed(&"exp_bar", [exp_pixels, player_hud, raster]):
 		var gained: PackedByteArray = _new_buffer()
-		if player_hud:
+		# Generation 1's panel has no exp bar: the row under the HP numbers is
+		# the border's own edge and nothing else.
+		if player_hud and not _hud.gen1:
 			_hud.draw_exp_bar(gained, Gen2Screen.WIDTH, exp_pixels)
 		_show_layer(_exp_bar, gained, _data.bar_palette(GameData.EXP_BAR_PALETTE))
 
@@ -789,7 +844,7 @@ func _sprite_tile(tile: int) -> PackedByteArray:
 func _battler_tile(vram: int) -> PackedByteArray:
 	var enemy: bool = vram < Gen2BattleScreenMap.PLAYER_BASE_TILE
 	var side: int = Gen2BattleScreenMap.ENEMY_SIDE if enemy \
-		else Gen2BattleScreenMap.PLAYER_SIDE
+		else Gen2BattleScreenMap.player_box_side(_data.generation)
 	var base: int = Gen2BattleScreenMap.ENEMY_BASE_TILE if enemy \
 		else Gen2BattleScreenMap.PLAYER_BASE_TILE
 	return pic_tile(_enemy_pixels if enemy else _player_pixels, side, vram - base)

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -850,6 +850,12 @@ func set_data(data: GameData) -> void:
 	_injected_data = data
 
 
+## Which generation's screen this is, for the two boxes the pictures sit in. A
+## battle that never reached [method set_data] seeds Crystal's map.
+func _generation() -> int:
+	return _data.generation if _data != null else RomRegistry.GEN2
+
+
 ## `CleanUpBattleRAM` zeroes `wLowHealthAlarm`. A driver this screen does not own
 ## outlives it, so the byte is cleared where the screen goes rather than where a
 ## fight ends: every way out of a battle, including a wipe and a failed setup, is
@@ -1433,6 +1439,10 @@ func _init_battle_display() -> void:
 ## `GetTrainerBackpic`'s choice: the Dude for the catching tutorial, and the
 ## player's own picture otherwise.
 func player_backpic_kind() -> String:
+	## `GetTrainerBackPic` has two: the player, and the old man who borrows the
+	## screen for the catching tutorial.
+	if _data != null and _data.generation == RomRegistry.GEN1:
+		return Gen1Layout.PLAYER_BACKPICS[1 if _world_battle_tutorial else 0]
 	if _world_battle_tutorial:
 		return "dude"
 	return "kris" if player_is_female() else "chris"
@@ -1740,6 +1750,10 @@ func _begin_slide(side: int) -> void:
 func _build_trainer_huds() -> void:
 	_hud_balls = []
 	_hud_border = []
+	## Generation 1 draws party balls on the link battle's versus screen and
+	## nowhere else: `SetupPlayerAndEnemyPokeballs` has that one caller.
+	if _data != null and _data.generation == RomRegistry.GEN1:
+		return
 	_add_trainer_hud(Gen2Battle.PLAYER)
 	if _battle != null and _battle.is_trainer_battle:
 		_add_trainer_hud(Gen2Battle.ENEMY)
@@ -2007,7 +2021,9 @@ func _begin_animation(event: Dictionary) -> void:
 	# `hBGMapMode = 1`, three delays and `WaitSFX`.
 	_step(ANIM_DELAY, {"frames": 3})
 	_step(ANIM_WAIT_SFX, {})
-	if bool(event.get("restore_user_pic", false)):
+	# A send-out draws the picture itself and the ball animation only shows it
+	# arriving, so a cache with no animation layer still owes the square one.
+	if bool(event.get("restore_user_pic", false)) or (not is_move and _anim_data == null):
 		_step(ANIM_APPEAR_USER, {})
 	_run_next_anim_step()
 
@@ -2183,7 +2199,7 @@ func _carry_battler_reports() -> void:
 ## `PlaceGraphic` putting a whole picture back on a square, which is the one
 ## thing that undoes every report above.
 func _restamp_battler(player_side: bool) -> void:
-	Gen2BattleScreenMap.stamp(_bg_map, player_side)
+	Gen2BattleScreenMap.stamp(_bg_map, player_side, _generation())
 	var side: int = Gen2Battle.PLAYER if player_side else Gen2Battle.ENEMY
 	_battler_visible[side] = true
 	_battler_scale[side] = 1.0
@@ -2334,7 +2350,7 @@ func _audio_assets() -> Dictionary:
 ## every fresh battle does. `ClearBattleAnims` never touches the map, so a Fly
 ## that took a picture off it leaves it off until something stamps it back.
 func _reseed_bg_map() -> void:
-	_bg_map = Gen2BattleScreenMap.seeded()
+	_bg_map = Gen2BattleScreenMap.seeded(_generation())
 	_faints.clear()
 	## A slide still owed walks the picture this put back off its own square.
 	_slides.clear()

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -18,6 +18,20 @@ const PLAYER_AT: Vector2i = Vector2i(2, 6)
 const ENEMY_SIDE: int = 7
 const PLAYER_SIDE: int = 6
 
+## `LoadMonBackPic`'s `hlcoord 1, 5`, and the seven tiles a side
+## `ScaleSpriteByTwo` doubles a 32x32 back pic up to. Crystal shrank it to 6x6.
+const GEN1_PLAYER_AT: Vector2i = Vector2i(1, 5)
+const GEN1_PLAYER_SIDE: int = 7
+
+
+static func player_box_at(generation: int) -> Vector2i:
+	return GEN1_PLAYER_AT if generation == RomRegistry.GEN1 else PLAYER_AT
+
+
+static func player_box_side(generation: int) -> int:
+	return GEN1_PLAYER_SIDE if generation == RomRegistry.GEN1 else PLAYER_SIDE
+
+
 ## Where each picture's tiles start in VRAM. `AppearUser` names both, `xor a` for
 ## the enemy and `ld a, $31` for the player, and `.BGSquares`' own offsets are
 ## counted from the same two.
@@ -40,12 +54,12 @@ const FAINT_STEP_FRAMES: int = 2
 
 
 ## The map a battle sits at: both pictures whole, blank everywhere else.
-static func seeded() -> PackedByteArray:
+static func seeded(generation: int = RomRegistry.GEN2) -> PackedByteArray:
 	var out: PackedByteArray = PackedByteArray()
 	out.resize(COLUMNS * ROWS)
 	out.fill(BLANK_TILE)
-	stamp(out, false)
-	stamp(out, true)
+	stamp(out, false, generation)
+	stamp(out, true, generation)
 	return out
 
 
@@ -139,11 +153,13 @@ static func clear_intro_box(map: PackedByteArray) -> void:
 ## `PlaceGraphic` over one battler's box: a tile is
 ## [code]base + column * side + row[/code], the column-major order `.BGSquares`
 ## indexes and `AppearUser` restores.
-static func stamp(map: PackedByteArray, player_side: bool) -> void:
+static func stamp(
+	map: PackedByteArray, player_side: bool, generation: int = RomRegistry.GEN2
+) -> void:
 	if map.size() != COLUMNS * ROWS:
 		return
-	var at: Vector2i = PLAYER_AT if player_side else ENEMY_AT
-	var side: int = PLAYER_SIDE if player_side else ENEMY_SIDE
+	var at: Vector2i = player_box_at(generation) if player_side else ENEMY_AT
+	var side: int = player_box_side(generation) if player_side else ENEMY_SIDE
 	var base: int = PLAYER_BASE_TILE if player_side else ENEMY_BASE_TILE
 	for column: int in side:
 		for row: int in side:

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -28,6 +28,9 @@ const CRITICAL_CHANCES: Array = [17, 32, 64, 85, 128, 128, 128]
 
 ## Moves with a raised critical rate, worth two critical levels each.
 const HIGH_CRITICAL_MOVES: Array = [0x02, 0x0D, 0x4B, 0x98, 0xA3, 0xB1, 0xEE]
+## `HighCriticalMoves`, which is four rather than seven: Crystal put Razor Wind
+## on the list beside Aeroblast and Cross Chop, neither of which exists there.
+const GEN1_HIGH_CRITICAL_MOVES: Array = [0x02, 0x4B, 0x98, 0xA3]
 
 ## Focus Energy: a state the attacker is in, not a property of the move.
 const FOCUS_ENERGY_LEVELS: int = 1
@@ -142,8 +145,12 @@ static func damage_calc(
 		@warning_ignore("integer_division")
 		used_defense = maxi(used_defense / 2, 1)
 
+	## `sla e`: a Generation 1 critical runs the whole formula at twice the
+	## level where Crystal doubles the answer it got.
+	var gen1: bool = attacker.data != null and attacker.data.generation == RomRegistry.GEN1
+	var used_level: int = attacker.level if level < 0 else level
 	var damage: int = base_damage(
-		attacker.level if level < 0 else level, power, attack, used_defense
+		used_level * 2 if gen1 and critical else used_level, power, attack, used_defense
 	)
 
 	# Where `PlayerAttackDamage` applies them: after the divide by fifty and
@@ -155,7 +162,7 @@ static func damage_calc(
 			damage, Gen2HeldItem.parameter_of(attacker.data, attacker.item)
 		)
 
-	if critical:
+	if critical and not gen1:
 		damage *= CRITICAL_MULTIPLIER
 	return mini(damage, DAMAGE_CAP) + MIN_DAMAGE
 
@@ -270,6 +277,32 @@ static func roll_critical(
 	return rng.randi_range(0, 255) < CRITICAL_CHANCES[
 		critical_level(int(move.get("number", 0)), focus_energy, scope_lens, species, item)
 	]
+
+
+## `CriticalHitTest`: the chance is the attacker's own base speed rather than a
+## table indexed by a stage count. `BattleRandom` is rotated three bits rather
+## than multiplied, so the roll stays uniform over the byte.
+static func roll_gen1_critical(
+	move: Dictionary, rng: RandomNumberGenerator, focus_energy: bool, base_speed: int
+) -> bool:
+	if int(move.get("power", 0)) <= 0:
+		return false
+	return rng.randi_range(0, STAT_BYTE_MAX) < gen1_critical_chance(
+		base_speed, focus_energy,
+		GEN1_HIGH_CRITICAL_MOVES.has(int(move.get("number", 0)))
+	)
+
+
+## The shifts themselves, out of 256. Focus Energy shifts right where the
+## routine means to shift left, and a left shift caps at 255 rather than wraps.
+static func gen1_critical_chance(
+	base_speed: int, focus_energy: bool, high_critical: bool
+) -> int:
+	var chance: int = base_speed >> 1
+	chance = chance >> 1 if focus_energy else mini(chance << 1, STAT_BYTE_MAX)
+	if not high_critical:
+		return chance >> 1
+	return mini(mini(chance << 1, STAT_BYTE_MAX) << 1, STAT_BYTE_MAX)
 
 
 ## Two for a high-critical move, one for Focus Energy, one for the Scope Lens,
@@ -529,6 +562,10 @@ static func _ignores_stages(
 ) -> bool:
 	if not critical:
 		return false
+	## `GetDamageVarsForPlayerAttack` reloads both base stats on any critical,
+	## and the screen doubling with them.
+	if attacker.data != null and attacker.data.generation == RomRegistry.GEN1:
+		return true
 	if is_physical(move_type):
 		return defender.stage("defense") >= attacker.stage("attack")
 	return defender.stage("sp_defense") >= attacker.stage("sp_attack")

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -887,9 +887,19 @@ static func _transform(turn: Gen2Turn) -> void:
 ## add up to. A powerless move never rolls (`and a / ret z`).
 static func _critical(turn: Gen2Turn) -> void:
 	var attacker: Gen2BattleMon = turn.attacker()
+	var focus_energy: bool = Gen2Substatus.has(
+		attacker.substatus, Gen2Substatus.FOCUS_ENERGY
+	)
+	## `CriticalHitTest` reads `wMonHBaseSpeed`, so Generation 1's chance is the
+	## attacker's species rather than anything the turn has raised.
+	if turn.data() != null and turn.data().generation == RomRegistry.GEN1:
+		turn.critical = Gen2Damage.roll_gen1_critical(
+			turn.effective_move(), turn.rng(), focus_energy,
+			_base_stat(turn, attacker.species, "speed")
+		)
+		return
 	turn.critical = Gen2Damage.roll_critical(
-		turn.effective_move(), turn.rng(),
-		Gen2Substatus.has(attacker.substatus, Gen2Substatus.FOCUS_ENERGY),
+		turn.effective_move(), turn.rng(), focus_energy,
 		Gen2HeldItem.effect_of(turn.data(), attacker.item) == Gen2HeldItem.CRITICAL_UP,
 		attacker.species, attacker.item
 	)
@@ -1456,7 +1466,8 @@ static func _check_hit(turn: Gen2Turn) -> void:
 	if Gen2HeldItem.effect_of(turn.data(), powder.item) == Gen2HeldItem.BRIGHTPOWDER:
 		chance = maxi(chance - Gen2HeldItem.parameter_of(turn.data(), powder.item), 0)
 
-	if Gen2Accuracy.rolls_hit(turn.rng(), chance):
+	var generation: int = turn.data().generation if turn.data() != null else RomRegistry.GEN2
+	if Gen2Accuracy.rolls_hit(turn.rng(), chance, generation):
 		return
 	# `.Miss` keeps the worked-out damage for Jump Kick alone, since
 	# `BattleCommand_FailureText` is about to take an eighth of it off the user.

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1332,7 +1332,19 @@ func _load_dex_orders(path: String) -> void:
 
 ## The moves a Pokémon of this species is created knowing at [param level].
 func moves_at_level(number: int, level: int) -> Array:
-	return Gen2Learnset.moves_at_level(learnset(number), level)
+	var known: Array = starting_moves(number)
+	Gen2Learnset.fill_moves(learnset(number), known, level)
+	return known
+
+
+## `wMonHMoves`: the four moves a Generation 1 base-stats row carries, which
+## `AddPartyMon` writes before `WriteMonMoves` walks the learnset over them.
+## Crystal dropped the column and starts every Pokemon empty.
+func starting_moves(number: int) -> Array:
+	var out: Array = []
+	for known: Variant in species(number).get("starting_moves", []) as Array:
+		out.append(int(known))
+	return out
 
 
 ## The moves a Pokémon of this species is offered on reaching exactly
@@ -1627,6 +1639,13 @@ func bar_palette(name: String) -> PackedColorArray:
 	if not stored is Array or (stored as Array).size() < 2:
 		return PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 
+	# Generation 1 stores a `SuperPalettes` row whole; Crystal stores only the
+	# two colours that sit between white and black.
+	if (stored as Array).size() >= Gen1Layout.SUPER_PALETTE_COLORS:
+		var row := PackedColorArray()
+		for packed: Variant in stored as Array:
+			row.append(PokePalette.from_packed(int(packed)))
+		return row
 	return PokePalette.pic_palette(PackedColorArray([
 		PokePalette.from_packed(int(stored[0])),
 		PokePalette.from_packed(int(stored[1])),

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -92,9 +92,30 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_pic_pointers,
 	_verify_font,
 	_verify_text_box,
+	_verify_battle_tiles,
 	_verify_facility_text,
 	_verify_world,
 ]
+
+## What `LoadHudAndHpBarAndStatusTilePatterns` copies over the text box's own,
+## in load order and under the names [Gen2BattleTiles] assembles a page from.
+const BATTLE_TILE_SHEETS: Dictionary = {
+	"battle_font": {
+		"tiles": Gen1Layout.BATTLE_FONT_TILES,
+		"first_code": Gen1Layout.BATTLE_FONT_FIRST_CODE,
+		"bits": 2,
+	},
+	"battle_hud_1": {
+		"tiles": Gen1Layout.BATTLE_HUD_1_TILES,
+		"first_code": Gen1Layout.BATTLE_HUD_1_FIRST_CODE,
+		"bits": 1,
+	},
+	"battle_hud_2": {
+		"tiles": Gen1Layout.BATTLE_HUD_2_TILES,
+		"first_code": Gen1Layout.BATTLE_HUD_2_FIRST_CODE,
+		"bits": 1,
+	},
+}
 
 ## The `text_far` runs a facility's own boxes live in, by the [method
 ## GameData.special_text] run name each is stored under. The shop's are stored
@@ -343,6 +364,27 @@ static func _verify_text_box(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return _ok()
 
 
+## Those three, pinned on the two shapes nothing beside them repeats:
+## `HpBarAndStatusGraphics`' empty bar and `BattleHudTiles3`'s panel edge.
+static func _verify_battle_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
+	for sheet: String in BATTLE_TILE_SHEETS:
+		var run: Dictionary = BATTLE_TILE_SHEETS[sheet]
+		var bytes: int = PokeTiles.TILE_BYTES if int(run["bits"]) == 2 \
+			else PokeTiles.TILE_1BPP_BYTES
+		if not rom.in_bounds(int(layout[sheet]), int(run["tiles"]) * bytes):
+			return _fail("%s runs past the end of the dump." % sheet)
+
+	if _battle_tile_rows(rom, layout, "battle_font", Gen1Layout.HP_BAR_EMPTY_CODE) \
+		!= Gen1Layout.HP_BAR_EMPTY_ROWS:
+		return _fail("HpBarAndStatusGraphics: $%02X is not the empty bar." % \
+			Gen1Layout.HP_BAR_EMPTY_CODE)
+	if _battle_tile_rows(rom, layout, "battle_hud_2", Gen1Layout.HUD_BOTTOM_CODE) \
+		!= Gen1Layout.HUD_BOTTOM_ROWS:
+		return _fail("BattleHudTiles3: $%02X is not the panel's edge." % \
+			Gen1Layout.HUD_BOTTOM_CODE)
+	return _ok()
+
+
 ## Every map and tileset decodes, which is the world layout's own check: a wrong
 ## table reaches a tileset number, a map size or a block index the cartridge
 ## cannot hold.
@@ -374,6 +416,23 @@ static func _font_rows(rom: RomFile, layout: Dictionary, code: int) -> Array[int
 	var rows: Array[int] = []
 	for row: int in PokeTiles.TILE_1BPP_BYTES:
 		rows.append(rom.u8(at + row))
+	return rows
+
+
+## One tile of one battle sheet, in [method _font_rows]' shape. `FarCopyDataDouble`
+## writes a 1bpp sheet into both planes, so folding them answers either way.
+static func _battle_tile_rows(
+	rom: RomFile, layout: Dictionary, sheet: String, code: int
+) -> Array[int]:
+	var run: Dictionary = BATTLE_TILE_SHEETS[sheet]
+	var wide: bool = int(run["bits"]) == 2
+	var stride: int = PokeTiles.TILE_BYTES if wide else PokeTiles.TILE_1BPP_BYTES
+	var at: int = int(layout[sheet]) + (code - int(run["first_code"])) * stride
+	var rows: Array[int] = []
+	for row: int in PokeTiles.TILE_1BPP_BYTES:
+		rows.append(
+			rom.u8(at + 2 * row) | rom.u8(at + 2 * row + 1) if wide else rom.u8(at + row)
+		)
 	return rows
 
 
@@ -576,6 +635,7 @@ func import_rom(
 		"encounter_count": int(world["encounters"]),
 		"atlases": pics,
 		"tiles": tiles,
+		"bar_palettes": _import_bar_palettes(rom, layout),
 		"mart_text": _import_mart_text(rom, layout),
 		"special_text": _import_facility_text(rom, layout),
 		"complete": true,
@@ -703,6 +763,21 @@ static func _pic_offset(rom: RomFile, layout: Dictionary, at: int, index: int) -
 	return RomFile.linear(Gen1Layout.pic_bank(layout, index), address)
 
 
+## `PAL_GREENBAR` and the two rows behind it, whole: `SetPal_Battle` hands an
+## HP bar a Super Game Boy palette of its own, so a bar here is four colours.
+static func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in Gen1Layout.HP_BAR_PALETTES:
+		var at: int = Gen1Layout.super_palette_offset(
+			layout, int(Gen1Layout.HP_BAR_PALETTES[name])
+		)
+		var colors: Array = []
+		for slot: int in Gen1Layout.SUPER_PALETTE_COLORS:
+			colors.append(rom.u16le(at + slot * PokePalette.COLOR_BYTES))
+		out[name] = colors
+	return out
+
+
 ## The four colours a Super Game Boy or a Game Boy Color draws this species in,
 ## as the cartridge's own packed 15-bit values.
 static func _import_palette(rom: RomFile, layout: Dictionary, dex: int) -> Dictionary:
@@ -722,12 +797,17 @@ func _import_moves(rom: RomFile, layout: Dictionary, on_progress: Callable) -> A
 	for move: int in range(1, Gen1Layout.MOVE_COUNT + 1):
 		var entry: int = Gen1Layout.move_offset(layout, move)
 		# The animation byte is dropped: [method _verify_move_data] has already
-		# spent it proving the stride.
+		# spent it proving the stride. The effect byte is Crystal's own number
+		# by the time it lands, so one battle engine reads either cartridge.
 		out.append({
 			"number": move,
 			"name": names[move - 1],
-			"effect": rom.u8(entry + Gen1Layout.MOVE_EFFECT),
-			"power": rom.u8(entry + Gen1Layout.MOVE_POWER),
+			"effect": Gen1Layout.move_effect(
+				move, rom.u8(entry + Gen1Layout.MOVE_EFFECT)
+			),
+			"power": Gen1Layout.move_power(
+				move, rom.u8(entry + Gen1Layout.MOVE_POWER)
+			),
 			"type": rom.u8(entry + Gen1Layout.MOVE_TYPE),
 			"accuracy": rom.u8(entry + Gen1Layout.MOVE_ACCURACY),
 			"pp": rom.u8(entry + Gen1Layout.MOVE_PP),
@@ -951,6 +1031,10 @@ func _import_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"bits": 2,
 		},
 	}
+	for sheet: String in BATTLE_TILE_SHEETS:
+		var run: Dictionary = (BATTLE_TILE_SHEETS[sheet] as Dictionary).duplicate()
+		run["offset"] = int(layout[sheet])
+		sheets[sheet] = run
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var out: Dictionary = {}
 	for name: String in sheets:

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -101,6 +101,11 @@ const PAL_ROUTE: int = 0x00
 const PAL_PALLET: int = 0x01
 const PAL_GRAYMON: int = 0x19
 const PAL_CAVE: int = 0x23
+## The three rows `GetHealthBarColor` picks between, under the names
+## [method GameData.bar_palette] takes them by. Generation 1 has no exp bar.
+const HP_BAR_PALETTES: Dictionary = {
+	"hp_green": 0x1F, "hp_yellow": 0x20, "hp_red": 0x21,
+}
 
 ## `GBPalNormal`'s `rOBP0`, %11010000: an object's colours 1, 2 and 3 take
 ## shades 0, 1 and 3, so a sprite never shows the palette's third colour.
@@ -139,6 +144,63 @@ const FONT_TILES: int = 128
 const FONT_FIRST_CODE: int = 0x80
 const FONT_EXTRA_TILES: int = 32
 const FONT_EXTRA_FIRST_CODE: int = 0x60
+
+## `MoveEffectPointerTable` in Crystal's own numbering, indexed by the effect
+## byte a move row carries. `SpecialDamageEffect` and `PoisonEffect` each stand
+## for several of Crystal's effects and split by move, which is the pair below.
+const MOVE_EFFECTS: Array[int] = [
+	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, # $00 to $09, which Crystal kept in order
+	10, 11, 12, 13, 15, 16, # the six UP1s, Crystal's SP_DEF_UP splitting them
+	34, 17, # PAY_DAY, SWIFT
+	18, 19, 20, 21, 23, 24, # the six DOWN1s
+	30, 25, 26, 27, 28, 29, 29, 31, # CONVERSION to FLINCH_SIDE_EFFECT1
+	1, 2, 4, 5, 6, 31, # the same six statuses again, always rather than on a roll
+	38, 39, 40, 41, 42, 155, 44, 45, 46, 47, 48, 49, # OHKO to CONFUSION
+	50, 51, 52, 53, 55, 56, # the six UP2s
+	32, 57, # HEAL, TRANSFORM
+	58, 59, 60, 61, 63, 64, # the six DOWN2s
+	35, 65, 66, 67, # LIGHT_SCREEN, REFLECT, POISON, PARALYZE
+	68, 69, 70, 71, # the four drops that ride on a hit
+	0, 0, 0, 0, # $48 to $4B, which `const_skip` leaves without a pointer
+	76, 77, 0, # CONFUSION_SIDE, TWINEEDLE, $4E
+	79, 80, 81, 82, 83, 84, 85, 86, # SUBSTITUTE to DISABLE
+]
+
+## Those two entries split, `ChargeEffect`'s own `cp DIG`, and the two damage
+## constants that come with the first: `SONICBOOM_DAMAGE` and
+## `DRAGON_RAGE_DAMAGE` sit in the routine here and in the power column there.
+const MOVE_EFFECT_BY_MOVE: Dictionary = {
+	49: 41, 69: 87, 82: 41, 91: 155, 92: 33, 101: 87, 149: 88,
+}
+const MOVE_POWER_BY_MOVE: Dictionary = {49: 20, 82: 40}
+
+
+static func move_effect(number: int, effect: int) -> int:
+	if MOVE_EFFECT_BY_MOVE.has(number):
+		return int(MOVE_EFFECT_BY_MOVE[number])
+	return MOVE_EFFECTS[effect] if effect >= 0 and effect < MOVE_EFFECTS.size() else 0
+
+
+static func move_power(number: int, power: int) -> int:
+	return int(MOVE_POWER_BY_MOVE.get(number, power))
+
+
+## What a battle loads over the middle of that box: `HpBarAndStatusGraphics` at
+## $62 as 2bpp, `BattleHudTiles1` at $6d and `BattleHudTiles2` with
+## `BattleHudTiles3` contiguous behind it at $73, both doubled from 1bpp.
+const BATTLE_FONT_TILES: int = 30
+const BATTLE_FONT_FIRST_CODE: int = 0x62
+const BATTLE_HUD_1_TILES: int = 3
+const BATTLE_HUD_1_FIRST_CODE: int = 0x6D
+const BATTLE_HUD_2_TILES: int = 6
+const BATTLE_HUD_2_FIRST_CODE: int = 0x73
+
+## What pins the two sheets: the edge under both panels is two solid rows in
+## the middle of six blank ones, and the empty bar is a rule top and bottom.
+const HUD_BOTTOM_CODE: int = 0x76
+const HUD_BOTTOM_ROWS: Array[int] = [0, 0, 0, 0xFF, 0xFF, 0, 0, 0]
+const HP_BAR_EMPTY_CODE: int = 0x63
+const HP_BAR_EMPTY_ROWS: Array[int] = [0, 0, 0xFF, 0, 0, 0xFF, 0, 0]
 
 ## What checks the two offsets: every code [Gen1Text] draws has ink, the hole
 ## between "'v" and "'" has none, the space is the text box's only blank tile,
@@ -410,6 +472,9 @@ const RED_BLUE: Dictionary = {
 	"pokecenter_text": 0x0705D,
 	"font": 0x11A80,
 	"text_box": 0x12288,
+	"battle_font": 0x11EA0,
+	"battle_hud_1": 0x12080,
+	"battle_hud_2": 0x12098,
 	"pic_player_back": 0x33E0A,
 	"pic_old_man_back": 0x33E9A,
 	"map_headers": 0x001AE,
@@ -457,6 +522,9 @@ const YELLOW: Dictionary = {
 	"pokecenter_text": 0x06ED0,
 	"font": 0x10600,
 	"text_box": 0x10E18,
+	"battle_font": 0x10A20,
+	"battle_hud_1": 0x10C00,
+	"battle_hud_2": 0x10C18,
 	## Yellow moved both back pics out of "Pics 4" and into their own bank.
 	"pic_player_back": 0xF43B1,
 	"pic_old_man_back": 0xF4441,

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 107
+const FORMAT_VERSION: int = 108
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -38,8 +38,14 @@ const EDGE_TILES: int = 8
 ## between them.
 const HP_DIGITS: int = 3
 
+## Two columns left of where Crystal prints the same number.
+const GEN1_ENEMY_LEVEL: Vector2i = Vector2i(4, 1)
+
 var font: Gen2Font = null
 var tiles: Gen2BattleTiles = null
+## Generation 1 has no exp bar and no caught ball, and it centres a short name
+## where Crystal prints every one from the same column.
+var gen1: bool = false
 
 
 ## Reads what it draws with out of a cache, or null if any of it is missing.
@@ -52,7 +58,16 @@ static func from_data(data: GameData) -> Gen2BattleHud:
 	var out := Gen2BattleHud.new()
 	out.font = glyphs
 	out.tiles = page
+	out.gen1 = data.generation == RomRegistry.GEN1
 	return out
+
+
+## `CenterMonName`: a name of one or two letters is printed two columns right of
+## where a longer one starts, and one of three or four a single column right.
+static func name_column(at: int, name: String, centred: bool) -> int:
+	if not centred or name.length() > 4:
+		return at
+	return at + (2 if name.length() <= 2 else 1)
 
 
 ## How much of a bar is lit, in pixels.
@@ -85,19 +100,22 @@ static func bar_pixels(current: int, maximum: int, length: int) -> int:
 func draw_enemy(
 	into: PackedByteArray, width: int, name: String, level: int, caught: bool = false
 ) -> void:
-	font.draw_text(name, into, width, ENEMY_NAME.x * TILE, ENEMY_NAME.y * TILE)
-	if caught:
+	font.draw_text(
+		name, into, width, name_column(ENEMY_NAME.x, name, gen1) * TILE,
+		ENEMY_NAME.y * TILE
+	)
+	if caught and not gen1:
 		tiles.draw(
 			Gen2BattleTiles.CAUGHT_BALL, into, width,
 			ENEMY_CAUGHT.x * TILE, ENEMY_CAUGHT.y * TILE
 		)
-	draw_level(into, width, ENEMY_LEVEL, level)
-	draw_bar_frame(into, width, ENEMY_BAR, Gen2BattleTiles.HP_BAR_END)
+	draw_level(into, width, GEN1_ENEMY_LEVEL if gen1 else ENEMY_LEVEL, level)
+	draw_bar_frame(into, width, ENEMY_BAR, tiles.hp_bar_end)
 
 	# The edge, which starts beside the bar and turns under it.
 	var left: int = ENEMY_EDGE.x * TILE
 	var top: int = ENEMY_EDGE.y * TILE
-	tiles.draw(Gen2BattleTiles.ENEMY_SIDE, into, width, left, top)
+	tiles.draw(tiles.enemy_side, into, width, left, top)
 	tiles.draw(Gen2BattleTiles.ENEMY_CORNER, into, width, left, top + TILE)
 	tiles.draw_run(Gen2BattleTiles.HUD_BOTTOM, EDGE_TILES, into, width, left + TILE, top + TILE)
 	tiles.draw(
@@ -111,9 +129,12 @@ func draw_enemy(
 func draw_player(
 	into: PackedByteArray, width: int, name: String, level: int, hp: int, max_hp: int
 ) -> void:
-	font.draw_text(name, into, width, PLAYER_NAME.x * TILE, PLAYER_NAME.y * TILE)
+	font.draw_text(
+		name, into, width, name_column(PLAYER_NAME.x, name, gen1) * TILE,
+		PLAYER_NAME.y * TILE
+	)
 	draw_level(into, width, PLAYER_LEVEL, level)
-	draw_bar_frame(into, width, PLAYER_BAR, Gen2BattleTiles.HP_BAR_END + 1)
+	draw_bar_frame(into, width, PLAYER_BAR, tiles.hp_bar_end + 1)
 
 	# Right-aligned in a fixed field, as the games print any number in a panel:
 	# the digits line up and the leading spaces draw nothing.
@@ -149,7 +170,7 @@ func draw_hp_bar(
 		if within <= 0:
 			continue
 		tiles.draw(
-			Gen2BattleTiles.HP_BAR_EMPTY + within, into, width, left + tile * TILE, at.y * TILE
+			tiles.hp_bar_empty + within, into, width, left + tile * TILE, at.y * TILE
 		)
 
 
@@ -167,9 +188,9 @@ func draw_exp_bar(
 	var top: int = at.y * TILE
 
 	for tile: int in EXP_BAR_TILES:
-		var number: int = Gen2BattleTiles.HP_BAR_EMPTY
+		var number: int = tiles.hp_bar_empty
 		if remaining >= TILE:
-			number = Gen2BattleTiles.HP_BAR_FULL
+			number = tiles.hp_bar_full
 			remaining -= TILE
 		elif remaining > 0:
 			number = Gen2BattleTiles.EXP_BAR_FIRST_PARTIAL + remaining - 1
@@ -192,9 +213,9 @@ func draw_level(into: PackedByteArray, width: int, at: Vector2i, level: int) -> 
 func draw_bar_frame(into: PackedByteArray, width: int, at: Vector2i, cap: int) -> void:
 	var left: int = at.x * TILE
 	var top: int = at.y * TILE
-	tiles.draw(Gen2BattleTiles.HP_LABEL, into, width, left, top)
-	tiles.draw(Gen2BattleTiles.HP_LABEL + 1, into, width, left + TILE, top)
+	tiles.draw(tiles.hp_label, into, width, left, top)
+	tiles.draw(tiles.hp_label_end, into, width, left + TILE, top)
 	tiles.draw_run(
-		Gen2BattleTiles.HP_BAR_EMPTY, HP_BAR_TILES, into, width, left + 2 * TILE, top
+		tiles.hp_bar_empty, HP_BAR_TILES, into, width, left + 2 * TILE, top
 	)
 	tiles.draw(cap, into, width, left + (2 + HP_BAR_TILES) * TILE, top)

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -67,6 +67,31 @@ const PLAYER_BOTTOM_LEFT: int = 0x6F
 const PLAYER_BOTTOM_RIGHT: int = 0x77
 const HUD_BOTTOM: int = 0x76
 
+## Generation 1's own numbers for the six roles it spells differently. Both
+## panel borders are at the tiles Crystal keeps them at.
+const GEN1_FIRST_TILE: int = 0x60
+const GEN1_HP_LABEL: int = 0x71
+const GEN1_HP_LABEL_END: int = 0x62
+const GEN1_HP_BAR_EMPTY: int = 0x63
+const GEN1_HP_BAR_FULL: int = 0x6B
+const GEN1_HP_BAR_END: int = 0x6C
+const GEN1_ENEMY_SIDE: int = 0x73
+
+## Where its four sheets land: `LoadTextBoxTilePatterns` first and
+## `LoadHudAndHpBarAndStatusTilePatterns` over the middle of it.
+const GEN1_FONT_EXTRA_AT: int = 0x60
+const GEN1_BATTLE_FONT_AT: int = 0x62
+const GEN1_HUD_1_AT: int = 0x6D
+const GEN1_HUD_2_AT: int = 0x73
+
+## Read through the instance so one panel-drawing routine serves both.
+var hp_label: int = HP_LABEL
+var hp_label_end: int = HP_LABEL + 1
+var hp_bar_empty: int = HP_BAR_EMPTY
+var hp_bar_full: int = HP_BAR_FULL
+var hp_bar_end: int = HP_BAR_END
+var enemy_side: int = ENEMY_SIDE
+
 var _tiles: PackedByteArray = PackedByteArray()
 var _width: int = 0
 ## The tile number the strip starts and ends at, which is the one thing a
@@ -79,6 +104,8 @@ var _last: int = LAST_TILE
 static func from_data(data: GameData) -> Gen2BattleTiles:
 	if data == null:
 		return null
+	if data.generation == RomRegistry.GEN1:
+		return _gen1_page(data)
 
 	var out := Gen2BattleTiles.new()
 	out._first = FIRST_TILE
@@ -101,6 +128,38 @@ static func from_data(data: GameData) -> Gen2BattleTiles:
 		if out._copy(data.tile_indices(name), int(meta.get("width", 0)), int(sheet[1])):
 			loaded += 1
 
+	return out if loaded == sheets.size() else null
+
+
+## The page as Generation 1 assembles it: the text box's 32 tiles at $60,
+## `HpBarAndStatusGraphics` over all but the first two, and the HUD sheets over
+## the middle. The border at $79 survives, both sheets drawing it the same way.
+static func _gen1_page(data: GameData) -> Gen2BattleTiles:
+	var out := Gen2BattleTiles.new()
+	out._first = GEN1_FIRST_TILE
+	out._last = LAST_TILE
+	out._width = (LAST_TILE - GEN1_FIRST_TILE + 1) * TILE
+	out._tiles.resize(out._width * TILE)
+	out.hp_label = GEN1_HP_LABEL
+	out.hp_label_end = GEN1_HP_LABEL_END
+	out.hp_bar_empty = GEN1_HP_BAR_EMPTY
+	out.hp_bar_full = GEN1_HP_BAR_FULL
+	out.hp_bar_end = GEN1_HP_BAR_END
+	out.enemy_side = GEN1_ENEMY_SIDE
+
+	var sheets: Array = [
+		["font_extra", GEN1_FONT_EXTRA_AT], ["battle_font", GEN1_BATTLE_FONT_AT],
+		["battle_hud_1", GEN1_HUD_1_AT], ["battle_hud_2", GEN1_HUD_2_AT],
+	]
+	var loaded: int = 0
+	for sheet: Array in sheets:
+		var meta: Dictionary = data.tile_sheet(String(sheet[0]))
+		if meta.is_empty():
+			continue
+		if out._copy(
+			data.tile_indices(String(sheet[0])), int(meta.get("width", 0)), int(sheet[1])
+		):
+			loaded += 1
 	return out if loaded == sheets.size() else null
 
 

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -260,15 +260,19 @@ static func x_flipped(image: Image) -> Image:
 
 ## `PadFrontpic` (engine/gfx/load_pics.asm) fills the 7x7 block a front pic is
 ## placed in, and does not centre a smaller pic: it lays one blank tile column
-## before it and blank rows above it, so the pic is bottom-aligned one column in.
-## This is that left pad, in tiles, for a [param width]-tile-wide pic.
-##
+## before it and blank rows above it. This is that left pad, in tiles.
 ## [param mirrored] is `wBoxAlignment`, which `LoadOrientedFrontpic` reads:
-## reversing the columns leaves the trailing blank on the left instead, which for
-## a 5x5 is one column further in than a 6x6.
-static func frontpic_pad_columns(width: int, mirrored: bool = false) -> int:
+## reversing the columns leaves the trailing blank on the left instead.
+## [param generation] is `LoadUncompressedSpriteData`'s `(8 - w) / 2`, which
+## does centre the pic.
+static func frontpic_pad_columns(
+	width: int, mirrored: bool = false, generation: int = RomRegistry.GEN2
+) -> int:
 	if width >= FRONTPIC_TILES or width <= 0:
 		return 0
+	if generation == RomRegistry.GEN1:
+		@warning_ignore("integer_division")
+		return (FRONTPIC_TILES + 1 - width) / 2
 	return FRONTPIC_TILES - 1 - width if mirrored else 1
 
 

--- a/game/rom/rom_registry.gd
+++ b/game/rom/rom_registry.gd
@@ -26,7 +26,7 @@ const SILVER: StringName = &"silver"
 const CRYSTAL: StringName = &"crystal"
 
 ## sha1 (lowercase hex) -> { id, title, revision, generation, playable }
-## `playable` is false while a generation has an importer but no world to walk:
+## `playable` is false while a generation has an importer but no story to walk:
 ## the launcher seats such a cartridge and reads it, and offers no Play.
 const BY_SHA1: Dictionary = {
 	"ea9bcae617fdf159b045185467ae58b2e4a48b9a": {

--- a/game/world/world_battle.gd
+++ b/game/world/world_battle.gd
@@ -328,11 +328,17 @@ static func music_for(
 	)
 
 
+## [param first_species] of -1 takes the cache's own starter: 155 wrapped into
+## Generation 1's 151 species lands on Charmander.
 static func fallback_party(
-	data: GameData, first_species: int = 155, level: int = 5, size: int = 2
+	data: GameData, first_species: int = -1, level: int = 5, size: int = 2
 ) -> Gen2Party:
 	if data == null or data.species_count() <= 0 or size < 1 or size > Gen2Party.MAX_SIZE:
 		return null
+	if first_species < 0:
+		first_species = int((Gen2SaveStore.DEVELOPMENT_PARTY.get(
+			data.generation, Gen2SaveStore.DEVELOPMENT_PARTY_GEN2
+		) as Array)[0])
 	var members: Array = []
 	for offset: int in size:
 		var species: int = wrapi(first_species + offset, 1, data.species_count() + 1)

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4937,17 +4937,6 @@ func _handle_fishing_result(result: Dictionary) -> void:
 func _start_battle_request(request: Dictionary) -> void:
 	if _battle_host != null or _battle_transition != null or _data == null:
 		return
-	## No Generation 1 battle engine: its move effects are numbered its own way,
-	## so the request is reported rather than fought. `RomRegistry`'s `playable`
-	## flag is what keeps a player off this path.
-	if _data.generation == RomRegistry.GEN1:
-		var wild: Dictionary = request.get("values", {})
-		_script_prompt = "Wild %s, level %d" % [
-			_data.species(int(wild.get("pokemon", 0))).get("name", "?"),
-			int(wild.get("level", 0)),
-		]
-		_refresh_labels()
-		return
 	_play_battle_music(request)
 	_battle_transition_request = request.duplicate(true)
 	_battle_transition = _build_battle_transition(request)
@@ -4964,6 +4953,11 @@ func _start_battle_request(request: Dictionary) -> void:
 ## PREVIOUS battle's enemy, which `docs/bugs_and_glitches.md` calls out.
 func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	if _world == null or _data == null:
+		return null
+	## `BattleTransition` is Generation 1's own subsystem, drawn out of nothing
+	## but the tilemap: none of its four wipes is built here, so a Generation 1
+	## fight opens where Crystal's animation would start.
+	if _data.generation == RomRegistry.GEN1:
 		return null
 	var values: Dictionary = request.get("values", {})
 	if bool(values.get("tutorial", false)):

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -428,8 +428,11 @@ const FORESIGHT_MATCHUPS: Array = [[NORMAL, GHOST, 0], [FIGHTING, GHOST, 0]]
 
 ## Writes a cache at [param directory] and opens it. [param id] is the cartridge
 ## the cache claims to be, which the two profiles are told apart by: everything
-## but `gold` and `silver` is Crystal's own branch.
-static func build(directory: String, id: String = "testgame") -> GameData:
+## but `gold` and `silver` is Crystal's own branch. [param generation] is what a
+## Generation 1 branch reads; the tables themselves are the same either way.
+static func build(
+	directory: String, id: String = "testgame", generation: int = RomRegistry.GEN2
+) -> GameData:
 	RomCache.clear(directory)
 	RomCache.prepare(directory)
 
@@ -448,6 +451,7 @@ static func build(directory: String, id: String = "testgame") -> GameData:
 		"format_version": RomCache.FORMAT_VERSION,
 		"game_id": id,
 		"sha1": "0123456789abcdef",
+		"generation": generation,
 		"complete": true,
 	})
 	return GameData.open_directory(directory)

--- a/tests/unit/test_battle_hud.gd
+++ b/tests/unit/test_battle_hud.gd
@@ -308,3 +308,68 @@ func _ink_in_row(screen: PackedByteArray, row: int) -> int:
 			if screen[y * Gen2Screen.WIDTH + x] != 0:
 				out += 1
 	return out
+
+
+## The same cache written the way a Generation 1 importer writes it: four sheets
+## rather than six, each filled with one index so the page can be read back.
+func _write_gen1_cache() -> void:
+	var sheets: Dictionary = {}
+	var written: Dictionary = {
+		"font_extra": [Gen1Layout.FONT_EXTRA_TILES, Gen1Layout.FONT_EXTRA_FIRST_CODE, 1],
+		"battle_font": [Gen1Layout.BATTLE_FONT_TILES, Gen1Layout.BATTLE_FONT_FIRST_CODE, 2],
+		"battle_hud_1": [Gen1Layout.BATTLE_HUD_1_TILES, Gen1Layout.BATTLE_HUD_1_FIRST_CODE, 3],
+		"battle_hud_2": [Gen1Layout.BATTLE_HUD_2_TILES, Gen1Layout.BATTLE_HUD_2_FIRST_CODE, 1],
+		"font": [Gen1Layout.FONT_TILES, Gen1Layout.FONT_FIRST_CODE, 3],
+	}
+	for row_name: String in written:
+		var row: Array = written[row_name]
+		var indices: PackedByteArray = PackedByteArray()
+		indices.resize(int(row[0]) * PokeTiles.TILE_WIDTH * PokeTiles.TILE_HEIGHT)
+		indices.fill(int(row[2]))
+		RomCache.write_indices(RomCache.tile_path(_directory, row_name), indices)
+		sheets[row_name] = {
+			"width": int(row[0]) * PokeTiles.TILE_WIDTH,
+			"height": PokeTiles.TILE_HEIGHT,
+			"tiles": int(row[0]),
+			"first_code": int(row[1]),
+			"bits": 1,
+		}
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "battletest",
+		"sha1": "0123456789abcdef",
+		"generation": RomRegistry.GEN1,
+		"tiles": sheets,
+		"complete": true,
+	})
+
+
+## `LoadTextBoxTilePatterns` lays the box's 32 tiles at $60 and
+## `LoadHudAndHpBarAndStatusTilePatterns` writes over all but the first two of
+## them, so only $60 and $61 are still the box's own.
+func test_the_generation_one_page_overlaps_the_text_box_sheet() -> void:
+	_write_gen1_cache()
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(_data())
+	assert_not_null(page)
+	assert_eq(_drawn(page, Gen2BattleTiles.GEN1_FONT_EXTRA_AT), 1, "the box keeps $60")
+	assert_eq(_drawn(page, Gen2BattleTiles.GEN1_HP_BAR_EMPTY), 2, "the bar is the battle font's")
+	assert_eq(_drawn(page, Gen2BattleTiles.GEN1_HUD_1_AT), 3, "the first HUD sheet overwrites")
+	assert_eq(_drawn(page, Gen2BattleTiles.GEN1_HUD_2_AT), 1, "so does the second")
+	## The page stops where Crystal's does: the text box border above it is
+	## drawn from the font's own frames rather than from here.
+	assert_eq(_drawn(page, Gen1Layout.FRAME_FIRST_CODE), 0)
+	assert_eq(page.hp_label, Gen2BattleTiles.GEN1_HP_LABEL)
+	assert_eq(page.hp_bar_end, Gen2BattleTiles.GEN1_HP_BAR_END)
+	assert_eq(page.enemy_side, Gen2BattleTiles.GEN1_ENEMY_SIDE)
+	assert_true(Gen2BattleHud.from_data(_data()).gen1)
+
+
+## `CenterMonName`: two spaces for a name of one or two letters, one for three or
+## four, and nothing for anything longer.
+func test_a_short_generation_one_name_is_centred() -> void:
+	for pair: Array in [["A", 2], ["AB", 2], ["ABC", 1], ["ABCD", 1], ["ABCDE", 0]]:
+		assert_eq(
+			Gen2BattleHud.name_column(1, String(pair[0]), true), 1 + int(pair[1]),
+			"%s is centred" % pair[0]
+		)
+		assert_eq(Gen2BattleHud.name_column(1, String(pair[0]), false), 1)

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -437,3 +437,30 @@ func test_result_trainer_slide_copies_six_column_major_slices() -> void:
 				assert_eq(int(map[row * 20 + 20 - step + column]), column * 7 + row)
 		assert_eq(int(map[20 - step - 1]), 0x7F)
 		assert_eq(int(map[7 * 20]), 0x7F)
+
+
+## `LoadMonBackPic`'s square is a whole tile bigger than Crystal's and sits a row
+## and a column further out, and the enemy's is where it always was. The tile
+## numbers are the same run either way: seven times seven is exactly the $31 the
+## player's picture starts at.
+func test_the_generation_one_player_square_is_seven_tiles_of_its_own() -> void:
+	assert_eq(Gen2BattleScreenMap.player_box_at(RomRegistry.GEN1), Vector2i(1, 5))
+	assert_eq(Gen2BattleScreenMap.player_box_side(RomRegistry.GEN1), 7)
+	assert_eq(Gen2BattleScreenMap.player_box_at(RomRegistry.GEN2), Gen2BattleScreenMap.PLAYER_AT)
+	assert_eq(
+		Gen2BattleScreenMap.player_box_side(RomRegistry.GEN2), Gen2BattleScreenMap.PLAYER_SIDE
+	)
+
+	var map: PackedByteArray = Gen2BattleScreenMap.seeded(RomRegistry.GEN1)
+	var at: Vector2i = Gen2BattleScreenMap.player_box_at(RomRegistry.GEN1)
+	for row: int in 7:
+		for column: int in 7:
+			var cell: int = (at.y + row) * Gen2BattleScreenMap.COLUMNS + at.x + column
+			assert_eq(
+				int(map[cell]),
+				Gen2BattleScreenMap.PLAYER_BASE_TILE + column * 7 + row,
+				"the square is column major from $31"
+			)
+	var head: int = Gen2BattleScreenMap.ENEMY_AT.y * Gen2BattleScreenMap.COLUMNS \
+		+ Gen2BattleScreenMap.ENEMY_AT.x
+	assert_eq(int(map[head]), Gen2BattleScreenMap.ENEMY_BASE_TILE)

--- a/tests/unit/test_battle_mon.gd
+++ b/tests/unit/test_battle_mon.gd
@@ -385,3 +385,21 @@ func test_badges_follow_stage_rounding_and_glacier_reads_the_staged_special_atta
 	assert_eq(mon.stat("sp_defense"), 100)
 	mon.stages.sp_attack = 1
 	assert_eq(mon.stat("sp_defense"), 112)
+
+
+## Generation 1 keeps one Special stat and one stage byte for it, so a raise
+## through either half moves both. Crystal's two are independent.
+func test_a_generation_one_special_stage_moves_both_halves() -> void:
+	var data: GameData = Fixture.build(_directory, "testgame", RomRegistry.GEN1)
+	var mon: Gen2BattleMon = Gen2BattleMon.create(data, Fixture.PIKACHU, 50)
+	assert_true(mon.change_stage("sp_attack", 2))
+	assert_eq(mon.stage("sp_attack"), 2)
+	assert_eq(mon.stage("sp_defense"), 2)
+	assert_true(mon.change_stage("sp_defense", -1))
+	assert_eq(mon.stage("sp_attack"), 1)
+	assert_true(mon.change_stage("attack", 1))
+	assert_eq(mon.stage("defense"), 0, "only the Special halves are one byte")
+
+	var crystal: Gen2BattleMon = Gen2BattleMon.create(_data, Fixture.PIKACHU, 50)
+	assert_true(crystal.change_stage("sp_attack", 2))
+	assert_eq(crystal.stage("sp_defense"), 0)

--- a/tests/unit/test_damage.gd
+++ b/tests/unit/test_damage.gd
@@ -648,3 +648,35 @@ func test_species_items_read_the_persistent_species_through_transform() -> void:
 	ditto.item = Fixture.METAL_POWDER
 	assert_true(ditto.transform_into(_mon(Fixture.PIKACHU)))
 	assert_eq(Gen2Damage.metal_powder_pair(ditto, [100, 100]), [100, 150])
+
+
+## `CriticalHitTest`'s shifts, worked out by hand: the base speed halved, then
+## doubled for an ordinary move and halved again, or halved twice under Focus
+## Energy, and a high-critical move worth eight times the first halving.
+func test_the_generation_one_critical_chance_is_the_attackers_base_speed() -> void:
+	assert_eq(Gen2Damage.gen1_critical_chance(0, false, false), 0)
+	assert_eq(Gen2Damage.gen1_critical_chance(40, false, false), 20)
+	assert_eq(Gen2Damage.gen1_critical_chance(40, true, false), 5)
+	assert_eq(Gen2Damage.gen1_critical_chance(40, false, true), 160)
+	## Every left shift caps at the byte rather than wrapping, so a high-critical
+	## move saturates from base speed 64 up and an ordinary one never does.
+	assert_eq(Gen2Damage.gen1_critical_chance(64, false, true), 0xFF)
+	assert_eq(Gen2Damage.gen1_critical_chance(63, false, true), 248)
+	assert_eq(Gen2Damage.gen1_critical_chance(255, false, false), 127)
+	assert_eq(Gen2Damage.gen1_critical_chance(255, true, true), 252)
+
+
+## `MoveHitTest` rolls whatever the accuracy is, so a stored 255 still misses one
+## time in 256. Crystal's `ret z` above the roll is what exempts it.
+func test_a_generation_one_move_can_miss_at_full_accuracy() -> void:
+	var rng := RandomNumberGenerator.new()
+	var misses: int = 0
+	for roll: int in 512:
+		rng.seed = roll
+		if not Gen2Accuracy.rolls_hit(rng, Gen2Accuracy.ALWAYS_HITS, RomRegistry.GEN1):
+			misses += 1
+		assert_true(
+			Gen2Accuracy.rolls_hit(rng, Gen2Accuracy.ALWAYS_HITS),
+			"Crystal never rolls at full accuracy"
+		)
+	assert_true(misses > 0, "a Generation 1 move at full accuracy missed nothing in 512 rolls")

--- a/tests/unit/test_game_data.gd
+++ b/tests/unit/test_game_data.gd
@@ -647,6 +647,21 @@ func test_a_species_knows_what_its_level_says_it_knows() -> void:
 	assert_eq(data.moves_at_level(1, 4), [33, 45])
 
 
+## `AddPartyMon` writes `wMonHMoves` and `WriteMonMoves` walks the learnset over
+## them, so a Generation 1 species knows its base moves before it learns
+## anything. The row is absent on Crystal and the answer is the learnset alone.
+func test_a_generation_one_species_starts_with_its_base_moves() -> void:
+	_write_cache()
+	var rows: Array = RomCache.read_json(RomCache.species_path(_directory)) as Array
+	(rows[0] as Dictionary)["starting_moves"] = [1, 39, 22, 73]
+	RomCache.write_json(RomCache.species_path(_directory), rows)
+	var data: GameData = GameData.open_directory(_directory)
+	assert_eq(data.starting_moves(1), [1, 39, 22, 73])
+	assert_eq(data.moves_at_level(1, 1), [39, 22, 73, 33], "the oldest slot is pushed out")
+	assert_eq(data.moves_at_level(1, 4), [22, 73, 33, 45])
+	assert_eq(data.starting_moves(2), [], "a species with no such row starts empty")
+
+
 ## The dex entry travels on the species, so a number with no species has none.
 func test_a_dex_entry_comes_back_with_its_numbers_coerced() -> void:
 	_write_cache()

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -438,3 +438,37 @@ func test_a_mart_inventory_fits_the_buffer_it_is_copied_into() -> void:
 	## `wItemList` is sixteen bytes: the count, the items and a terminator, which
 	## is the whole of what `LoadItemList` copies out of the text pointer.
 	assert_true(1 + Gen1Layout.MART_MAX_ITEMS + 1 <= 16)
+
+
+## `MoveEffectPointerTable` has an entry for every effect byte but $00, so the
+## translation is one longer than the pointer table.
+func test_the_effect_table_covers_every_effect_byte() -> void:
+	assert_eq(Gen1Layout.MOVE_EFFECTS.size(), 0x57)
+	for effect: int in Gen1Layout.MOVE_EFFECTS.size():
+		assert_between(Gen1Layout.MOVE_EFFECTS[effect], 0, 0x9C, "effect $%02X" % effect)
+
+
+## The three routines that stand for more than one of Crystal's effects, split
+## by the move number the routine itself compares against.
+func test_a_move_that_shares_an_effect_byte_is_split_by_number() -> void:
+	## SONICBOOM and DRAGON_RAGE carry their damage where Crystal keeps it, and
+	## the two level-damage moves keep the power the cartridge gave them.
+	assert_eq(Gen1Layout.move_effect(49, 0x29), 41)
+	assert_eq(Gen1Layout.move_power(49, 1), 20)
+	assert_eq(Gen1Layout.move_effect(82, 0x29), 41)
+	assert_eq(Gen1Layout.move_power(82, 1), 40)
+	assert_eq(Gen1Layout.move_effect(69, 0x29), 87)
+	assert_eq(Gen1Layout.move_power(69, 1), 1)
+	assert_eq(Gen1Layout.move_effect(149, 0x29), 88)
+	## TOXIC alone out of `PoisonEffect`, and DIG alone out of `ChargeEffect`.
+	assert_eq(Gen1Layout.move_effect(92, 0x42), 33)
+	assert_eq(Gen1Layout.move_effect(90, 0x42), 66)
+	assert_eq(Gen1Layout.move_effect(91, 0x27), 155)
+	assert_eq(Gen1Layout.move_effect(13, 0x27), 39)
+
+
+## A byte outside the table reads as an ordinary attack rather than off the end.
+func test_an_effect_byte_the_table_does_not_carry_is_a_normal_hit() -> void:
+	assert_eq(Gen1Layout.move_effect(1, 0x57), 0)
+	assert_eq(Gen1Layout.move_effect(1, -1), 0)
+	assert_eq(Gen1Layout.move_power(1, 40), 40)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 580 lines of the 38600 here, and Generation 1's colour, sprites, wild
-## tables, walk, text box, encounter roll, shop and Pokemon Center added 261 more
-## to the shared collision, palette, world, encounter, text, save and renderer
-## code. Four sweeps have said the tree has no restatement left to pay with.
-const MAX_COMMENT_LINES: int = 38600
+## are 655 lines of the 38732 here, and Generation 1's colour, sprites, wild
+## tables, walk, text box, encounter roll, shop, Pokemon Center and battle added
+## 361 more to the shared battle, collision, palette, world, encounter, text,
+## save and renderer code. Four sweeps found no restatement left to pay with.
+const MAX_COMMENT_LINES: int = 38732
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_battle.gd
+++ b/tests/unit/test_world_battle.gd
@@ -572,3 +572,26 @@ func test_tower_preparation_heals_even_a_wiped_party_before_choosing_the_lead() 
 	assert_eq((prepared["battle"] as Gen2Battle).enemy.stats, enemy["battle_stats"])
 	assert_eq((prepared["battle"] as Gen2Battle).enemy.hp, 40)
 	assert_true(prepared["trainer_battle"])
+
+
+## A fight with no save behind it is furnished from the cache's own starter, and
+## the two generations name different ones. The cache here carries two species,
+## so Crystal's 155 would wrap onto the second of them.
+func test_the_fallback_party_takes_the_generations_own_starter() -> void:
+	var gen2: Gen2Party = Gen2WorldBattleAdapter.fallback_party(_data, -1, 5, 1)
+	assert_not_null(gen2)
+	assert_eq(
+		gen2.active_mon().species,
+		int((Gen2SaveStore.DEVELOPMENT_PARTY_GEN2 as Array)[0]) % _data.species_count()
+	)
+
+	RomCache.write_json(RomCache.manifest_path(_directory), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": "worldbattletest", "sha1": "0123456789abcdef",
+		"generation": RomRegistry.GEN1, "complete": true,
+	})
+	var gen1: Gen2Party = Gen2WorldBattleAdapter.fallback_party(
+		GameData.open_directory(_directory), -1, 5, 1
+	)
+	assert_not_null(gen1)
+	assert_eq(gen1.active_mon().species, SPECIES_ONE)

--- a/tools/checks/gen1_battle.gd
+++ b/tools/checks/gen1_battle.gd
@@ -1,0 +1,186 @@
+extends RefCounted
+
+## A Generation 1 fight, swept on Red, Blue and Yellow: the four moves every one
+## of the 151 species is created knowing, all 165 moves used once each through
+## the shared engine, `CriticalHitTest`'s chance over the whole base speed
+## column, and one wild battle fought to a faint. The move sweep is what the
+## effect translation is worth: an effect byte that lands on the wrong list
+## either throws or stops producing events.
+
+const SPECIES_COUNT: int = 151
+const MOVE_COUNT: int = 165
+const MOVE_SLOTS: int = 4
+
+## The levels the created-knowing sweep asks at: the first, the one a starter is
+## met at, and the three a learnset has usually run out by.
+const SWEEP_LEVELS: Array[int] = [1, 5, 25, 50, 100]
+
+## How many species know one, two, three and four moves at level 1: the base
+## stats column with whatever `WriteMonMoves` finds at level 1 over it. Yellow
+## rewrote 23 learnsets and moves three species along by one.
+const STARTING_MOVE_CENSUS: Dictionary = {
+	&"red": [32, 53, 40, 26], &"blue": [32, 53, 40, 26], &"yellow": [35, 54, 38, 24],
+}
+
+## Bulbasaur against Pidgey, both at a level where every move has something to
+## work with, and the seed the fight is reproducible from.
+const SWEEP_PLAYER: int = 1
+const SWEEP_ENEMY: int = 16
+const SWEEP_LEVEL: int = 50
+const SWEEP_SEED: int = 20260930
+
+## The wild fight: a level five starter against the level three Pidgey Route 1
+## really offers, run to a faint. Pinned so a change to a damage rule shows up
+## as a different number of turns.
+const FIGHT_LEVELS: Array[int] = [5, 3]
+const FIGHT_TURN_CAP: int = 64
+const FIGHT_TURNS: int = 4
+
+## `CriticalHitTest`, spot-checked where the shifts are interesting: no speed at
+## all, a slow one, Persian's 115 already saturating a high-critical move, and
+## the byte's own end. Each row is base speed, then the ordinary chance, the one
+## under Focus Energy, and the one a high-critical move gets.
+const CRITICAL_CHANCES: Array = [
+	[0, 0, 0, 0],
+	[40, 20, 5, 160],
+	[115, 57, 14, 255],
+	[255, 127, 31, 255],
+]
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	_created_knowing()
+	_critical_chances()
+	_every_move()
+	_a_wild_fight()
+
+
+## `AddPartyMon`'s four base moves and `WriteMonMoves` over them, for every
+## species at five levels: never empty, never more than four, never a repeat and
+## never a move the cartridge does not carry.
+func _created_knowing() -> void:
+	var census: Array[int] = [0, 0, 0, 0]
+	for species: int in range(1, SPECIES_COUNT + 1):
+		for level: int in SWEEP_LEVELS:
+			var moves: Array = _r.data.moves_at_level(species, level)
+			var name: String = String(_r.data.species(species).get("name", "?"))
+			if not _r.check(
+				not moves.is_empty() and moves.size() <= MOVE_SLOTS,
+				"%s at level %d knows %d moves" % [name, level, moves.size()]
+			):
+				continue
+			for move: int in moves:
+				_r.check(move >= 1 and move <= MOVE_COUNT, "%s knows move %d" % [name, move])
+			_r.check(_distinct(moves), "%s at level %d knows %s" % [name, level, str(moves)])
+			if level == SWEEP_LEVELS[0]:
+				census[moves.size() - 1] += 1
+	_r.check(Array(census) == (STARTING_MOVE_CENSUS[_r.game_id] as Array),
+		"the level one move census reads %s" % str(census))
+	_r.note("gen1 battle %d species created knowing at %d levels" % [
+		SPECIES_COUNT, SWEEP_LEVELS.size(),
+	])
+
+
+## The chance itself, and the whole base speed column read through it: nothing
+## in the corpus reaches the cap on an ordinary move, and a high-critical move,
+## worth eight times the shift, saturates from base speed 64 up.
+func _critical_chances() -> void:
+	for row: Array in CRITICAL_CHANCES:
+		var speed: int = int(row[0])
+		var read: Array = [
+			speed,
+			Gen2Damage.gen1_critical_chance(speed, false, false),
+			Gen2Damage.gen1_critical_chance(speed, true, false),
+			Gen2Damage.gen1_critical_chance(speed, false, true),
+		]
+		_r.check(read == row, "base speed %d reads %s, expected %s" % [
+			speed, str(read), str(row)
+		])
+
+	var saturated: int = 0
+	for species: int in range(1, SPECIES_COUNT + 1):
+		var speed: int = int(
+			(_r.data.species(species).get("stats", {}) as Dictionary).get("speed", 0)
+		)
+		var ordinary: int = Gen2Damage.gen1_critical_chance(speed, false, false)
+		@warning_ignore("integer_division")
+		_r.check(ordinary == speed / 2, "%d base speed gives %d in 256" % [speed, ordinary])
+		if Gen2Damage.gen1_critical_chance(speed, false, true) == 0xFF:
+			saturated += 1
+	_r.note("gen1 battle %d species saturate a high-critical move" % saturated)
+
+
+## Every move used once through the engine, which is what an effect byte read
+## into the wrong list breaks: the turn either produces nothing or the command
+## list asks for state the move never set.
+func _every_move() -> void:
+	var used: int = 0
+	var damaged: int = 0
+	for move: int in range(1, MOVE_COUNT + 1):
+		var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED + move)
+		if not _r.check(battle != null, "no battle could be built for move %d" % move):
+			return
+		var before: int = battle.enemy.hp
+		var events: Array = battle.take_turn(0, 0)
+		var name: String = String(_r.data.move(move).get("name", "?"))
+		if not _r.check(not events.is_empty(), "%s produced no events" % name):
+			continue
+		used += 1
+		if battle.enemy.hp < before:
+			damaged += 1
+	_r.check(used == MOVE_COUNT, "%d of %d moves ran" % [used, MOVE_COUNT])
+	_r.note("gen1 battle %d moves run, %d took HP off the target" % [used, damaged])
+
+
+## One wild battle to a faint, both sides picking their first move every turn.
+func _a_wild_fight() -> void:
+	var battle: Gen2Battle = _fight(FIGHT_LEVELS[0], FIGHT_LEVELS[1], [], SWEEP_SEED)
+	if not _r.check(battle != null, "no wild fight could be built"):
+		return
+	var turns: int = 0
+	while turns < FIGHT_TURN_CAP:
+		if battle.player.is_fainted() or battle.enemy.is_fainted():
+			break
+		battle.take_turn(0, 0)
+		turns += 1
+	_r.check(turns < FIGHT_TURN_CAP, "the wild fight did not end in %d turns" % FIGHT_TURN_CAP)
+	_r.check(turns == FIGHT_TURNS, "the wild fight took %d turns, pinned %d" % [
+		turns, FIGHT_TURNS,
+	])
+	_r.note("gen1 battle a wild %s went down in %d turns" % [
+		_r.data.species(SWEEP_ENEMY).get("name", "?"), turns,
+	])
+
+
+## [param moves] empty takes whatever the level gives, which is what a wild
+## encounter and a party member both carry.
+func _fight(player_level: int, enemy_level: int, moves: Array, seed_value: int) -> Gen2Battle:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = seed_value
+	var player_moves: Array = moves if not moves.is_empty() \
+		else _r.data.moves_at_level(SWEEP_PLAYER, player_level)
+	return Gen2Battle.create(
+		_r.data,
+		Gen2BattleMon.create(_r.data, SWEEP_PLAYER, player_level, player_moves),
+		Gen2BattleMon.create(
+			_r.data, SWEEP_ENEMY, enemy_level,
+			_r.data.moves_at_level(SWEEP_ENEMY, enemy_level)
+		),
+		generator
+	)
+
+
+static func _distinct(moves: Array) -> bool:
+	var seen: Dictionary = {}
+	for move: int in moves:
+		if seen.has(move):
+			return false
+		seen[move] = true
+	return true

--- a/tools/checks/gen1_battle.gd.uid
+++ b/tools/checks/gen1_battle.gd.uid
@@ -1,0 +1,1 @@
+uid://b0ayhjuokxyaw

--- a/tools/checks/gen1_pics.gd
+++ b/tools/checks/gen1_pics.gd
@@ -51,10 +51,28 @@ const SHARED_PIC_ROWS: Array[int] = [27, 28]
 
 ## SHA-1 of each tile strip. All three cartridges hold the one font and the one
 ## text box; re-earn these against `gfx/font/font.png` and `font_extra.png`.
+## SHA-1 of each tile strip. All three cartridges hold the same five; re-earn
+## these against `gfx/font/font.png`, `font_extra.png`, `font_battle_extra.png`
+## and `gfx/battle/battle_hud_*.png`.
 const SHEET_DIGESTS: Dictionary = {
 	"font": "8146fe98bbbd27f9d67509e3da62044b44785a3a",
 	"font_extra": "ca0735bbbf8d2ce178a3f06a8d95ac6395dc8f7e",
+	"battle_font": "91f966f8c57286416ccec63a798e299417fb16b3",
+	"battle_hud_1": "f3c855d6f6f97f4994d4cd1967a2a205e8adac3d",
+	"battle_hud_2": "cc45fdec1282f49f07f31d80d2919a7b40ae8fce",
 }
+
+## What the assembled page has to hold once the four sheets have overlapped:
+## the empty bar, the panel edge, the level symbol and the two bar caps, by tile
+## number and by whether any pixel of that tile is set.
+const BATTLE_PAGE_TILES: Array[int] = [0x62, 0x63, 0x6B, 0x6C, 0x6D, 0x6E, 0x76, 0x78]
+
+## `ScaleSpriteByTwo` walks 28 of a back pic's 32 rows and takes four pixels
+## from the last column, so a battle never draws past this. Nine back pics are
+## drawn past it and are cut on hardware: eight have a 29th row and Persian has
+## a 29th column.
+const BACK_PIC_KEPT: int = 28
+const CROPPED_BACK_PICS: Array[int] = [20, 26, 40, 51, 53, 58, 77, 125, 137]
 
 var _r: RefCounted = null
 
@@ -73,6 +91,7 @@ func _one_game() -> void:
 	_trainer_pics()
 	_player_pics()
 	_sheets()
+	_battle_page()
 	_digests()
 
 
@@ -172,6 +191,45 @@ func _sheets() -> void:
 	_r.note("gen1 sheets %d font codes drawn, %d text box tiles" % [
 		drawn, Gen1Layout.FONT_EXTRA_TILES,
 	])
+
+
+## The battle's own tile page, assembled the way a battle assembles it, and the
+## crop `ScaleSpriteByTwo` puts every back pic through: the four rows and four
+## columns it drops have to be blank on all 153 of them or a battle is drawing
+## less than the cartridge does.
+func _battle_page() -> void:
+	var page: Gen2BattleTiles = Gen2BattleTiles.from_data(_r.data)
+	if not _r.check(page != null, "the battle tile page does not assemble."):
+		return
+	var blank: PackedByteArray = PackedByteArray()
+	blank.resize(PokeTiles.TILE_WIDTH * PokeTiles.TILE_HEIGHT)
+	for tile: int in BATTLE_PAGE_TILES:
+		var drawn: PackedByteArray = blank.duplicate()
+		page.draw(tile, drawn, PokeTiles.TILE_WIDTH, 0, 0)
+		_r.check(drawn != blank, "battle tile $%02X is blank." % tile)
+
+	var cropped: Array[int] = []
+	for slot: int in SPECIES_COUNT + Gen1Layout.PLAYER_BACKPICS.size():
+		var name: String = "back" if slot < SPECIES_COUNT else "player_back"
+		if _draws_outside_crop(name, slot if slot < SPECIES_COUNT else slot - SPECIES_COUNT):
+			cropped.append(slot + 1)
+	_r.check(cropped == CROPPED_BACK_PICS, "back pics cut by the scaler read %s" % str(cropped))
+	_r.note("gen1 battle page %d tiles, %d back pics cut to %dx%d" % [
+		BATTLE_PAGE_TILES.size(), cropped.size(), BACK_PIC_KEPT, BACK_PIC_KEPT,
+	])
+
+
+func _draws_outside_crop(name: String, slot: int) -> bool:
+	var cell: Dictionary = _cell(name, slot)
+	var width: int = int(cell.get("width", 0))
+	var indices: PackedByteArray = cell.get("indices", PackedByteArray())
+	for y: int in int(cell.get("height", 0)):
+		for x: int in width:
+			if x < BACK_PIC_KEPT and y < BACK_PIC_KEPT:
+				continue
+			if indices[y * width + x] != 0:
+				return true
+	return false
 
 
 ## Whether the tile one character code addresses has any pixel set.

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -40,6 +40,24 @@ const PINNED_MOVES: Dictionary = {
 	1: ["POUND", 0, 40, 0x00, 255, 35],
 	165: ["STRUGGLE", 48, 50, 0x00, 255, 10],
 }
+## `MoveEffectPointerTable` translated ([constant Gen1Layout.MOVE_EFFECTS]),
+## as effect id to how many of the 165 moves land on it. The whole table stands
+## behind this: a row that moves shows up as two counts that disagree.
+const EFFECT_CENSUS: Dictionary = {
+	0: 31, 1: 5, 2: 3, 3: 3, 4: 4, 5: 3, 6: 6, 7: 2, 8: 1, 9: 1, 10: 2, 11: 3,
+	13: 1, 16: 2, 17: 1, 18: 1, 19: 2, 20: 1, 23: 4, 25: 1, 26: 1, 27: 2, 28: 3,
+	29: 7, 30: 1, 31: 7, 32: 3, 33: 1, 34: 1, 35: 1, 38: 3, 39: 4, 40: 1, 41: 2,
+	42: 4, 44: 2, 45: 2, 46: 1, 47: 1, 48: 4, 49: 2, 50: 1, 51: 2, 52: 1, 53: 1,
+	57: 1, 59: 1, 65: 1, 66: 2, 67: 3, 68: 1, 69: 1, 70: 3, 71: 1, 76: 2, 77: 1,
+	79: 1, 80: 1, 81: 1, 82: 1, 83: 1, 84: 1, 85: 1, 86: 1, 87: 2, 88: 1, 155: 2,
+}
+
+## The seven rows `SpecialDamageEffect`, `PoisonEffect` and `ChargeEffect` split
+## by move, and the two the first of them carries its damage in.
+const PINNED_EFFECTS: Dictionary = {
+	49: [41, 20], 69: [87, 1], 82: [41, 40], 91: [155, 100],
+	92: [33, 0], 101: [87, 0], 149: [88, 1],
+}
 
 ## `TechnicalMachines`: TM01 through TM05, then the five HMs.
 const PINNED_TMS: Array[int] = [5, 13, 14, 18, 25]
@@ -189,7 +207,27 @@ func _moves() -> void:
 			_r.check(read == want, "move %d reads %s, expected %s" % [
 				number, str(read), str(want)
 			])
+	_move_effects()
 	_r.note("%d moves" % MOVE_COUNT)
+
+
+## Every move's effect byte in the shared numbering: one the battle engine has a
+## command list for, and the same census on all three cartridges.
+func _move_effects() -> void:
+	var census: Dictionary = {}
+	for number: int in range(1, MOVE_COUNT + 1):
+		var move: Dictionary = _r.data.move(number)
+		var effect: int = int(move["effect"])
+		census[effect] = int(census.get(effect, 0)) + 1
+		var known: bool = effect == Gen2MoveEffect.NORMAL_HIT_EFFECT \
+			or Gen2MoveEffect.is_written(effect)
+		_r.check(known, "%s reads effect %d, which is unwritten" % [move["name"], effect])
+		if PINNED_EFFECTS.has(number):
+			var read: Array = [effect, int(move["power"])]
+			_r.check(read == PINNED_EFFECTS[number], "move %d reads %s, expected %s" % [
+				number, str(read), str(PINNED_EFFECTS[number])
+			])
+	_r.check(census == EFFECT_CENSUS, "the effect census reads %s" % str(census))
 
 
 func _types() -> void:

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,7 +44,7 @@ const GROUPS: Dictionary = {
 		&"battle_tower", &"npc_trade",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
-	&"gen1": [&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk"],
+	&"gen1": [&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle"],
 }
 
 


### PR DESCRIPTION
A wild encounter on Red, Blue or Yellow now opens the battle screen and is fought there. `_start_battle_request` no longer refuses one.

## The data

`Gen1Layout.MOVE_EFFECTS` is `MoveEffectPointerTable` read into Crystal's numbering, applied at import so one engine reads either cartridge. The three routines that stand for several of Crystal's effects split by move number the way the routines do: `SpecialDamageEffect`'s `cp` chain is five effects, `PoisonEffect`'s `cp TOXIC` a sixth, and `ChargeEffect`'s `cp DIG` is what keeps Dig semi-invulnerable while Razor Wind and Solar Beam are not. `SONICBOOM_DAMAGE` and `DRAGON_RAGE_DAMAGE` travel with them into the power column.

`AddPartyMon` writes `wMonHMoves` before `WriteMonMoves` walks the learnset, which is `GameData.starting_moves`. Without it a level five starter knew nothing but Struggle.

## The screen

`Gen2BattleTiles` assembles the page the way video memory holds it: `TextBoxGraphics` at `$60`, `HpBarAndStatusGraphics` over all but its first two tiles, `BattleHudTiles1` at `$6d` and `BattleHudTiles2` with `BattleHudTiles3` behind it at `$73`. `Gen2BattleHud` draws `PlaceEnemyHUDTiles`' and `PlacePlayerHUDTiles`' panels through it, with `CenterMonName` and no exp bar. `Gen2BattleScreenMap`'s player square is `LoadMonBackPic`'s 7x7 at (1,5), and `ScaleSpriteByTwo` fills it by dropping a back pic's last four rows and columns and drawing the rest twice each way. Nine of the corpus's back pics really are cut by that.

`SetPal_Battle` hands the Super Game Boy four palettes and `BlkPacket_Battle` gives each square one, so the player's back pic wears the lead Pokemon's colours and an HP bar takes `PAL_GREENBAR`, `PAL_YELLOWBAR` or `PAL_REDBAR` whole. There are no party balls: `SetupPlayerAndEnemyPokeballs` has one caller and it is the link versus screen.

## The engine

Four rules are Generation 1's own. `CriticalHitTest` reads `wMonHBaseSpeed` rather than a stage count, and Focus Energy shifts it right where the routine means to shift left. A critical runs the whole formula at twice the level with both base stats rather than doubling the answer. The one Special stat has one stage byte. `MoveHitTest` rolls even at a stored 255, which Crystal returns above.

`Gen2WorldBattleAdapter.fallback_party` takes the cache's own starter; 155 wrapped into 151 species was landing on Charmander.

## Proof

Cache format 108, so all six cartridges re-import. `tools/checks/gen1_battle.gd` runs all 165 moves through the engine and fights a wild battle to a faint on all three cartridges; `gen1_pics.gd` sweeps the assembled page and the back pic crop; `gen1_tables.gd` sweeps the effect census.

| Check | Result |
|---|---|
| `validate.gd -- all` | 89 topics, 0 failures |
| GUT, `tests/` with subdirectories | 4347 tests, 0 failures |
| `addons/warning_scan` | 0 warnings in 628 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | 0 failures |
| `--quit-after 30`, with and without `--mods` | boots |