### PR TITLE
Open a Generation 1 fight with its own wipe

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -140,6 +140,9 @@ const SKETCHED_MOVE: StringName = &"sketched_move"
 ## Conversion and Conversion2 both print `TransformedTypeText` after replacing
 ## both of the user's active type bytes.
 const TYPE_CHANGED: StringName = &"type_changed"
+## `_ConvertedTypeText`: Generation 1's Conversion copies the target's pair
+## rather than picking one, so its line names the target and not a type.
+const TYPE_COPIED: StringName = &"type_copied"
 
 ## Disable locked a slot and later let it go, [code]slot[/code] and
 ## [code]move[/code] being the target's. A Pokémon locked into the disabled move
@@ -293,6 +296,9 @@ const CRASHED: StringName = &"crashed"
 const TRAPPED: StringName = &"trapped"
 const HURT_BY_TRAP: StringName = &"hurt_by_trap"
 const RELEASED_FROM_TRAP: StringName = &"released_from_trap"
+## `AttackContinuesText`, which only Generation 1's trapping moves print: the
+## user repeats the move and the target spends the turn held in place.
+const ATTACK_CONTINUES: StringName = &"attack_continues"
 
 ## Mean Look and Spider Web landed. Set on the user, cleared by any send-out;
 ## a second one from the same user is [constant MOVE_FAILED].
@@ -613,6 +619,11 @@ var _faint_charged: Dictionary = {}
 ## Mirror Coat read after the faster side has acted. Cleared each pair: the
 ## cartridge's `wCurDamage` is move-local, not a history.
 var _last_damage_taken: Dictionary = {PLAYER: {}, ENEMY: {}}
+
+## `wDamage` outliving the move that wrote it. Generation 1's trapping moves are
+## the one reader: `.MultiturnMoveCheck` jumps past the damage calculation, so a
+## continuation deals the first hit's figure again.
+var last_damage_dealt: int = 0
 
 ## `DoMove`'s own artefact: every effect command executed, in the order the read
 ## cycle reached it, skips and loop passes included. Collected only while
@@ -1575,7 +1586,7 @@ func _clear_trapping() -> void:
 ## Whether `TryPlayerSwitch` would refuse the recall: bound, or held by Mean Look
 ## or Spider Web. Player-only, `AI_Switch` making no such check.
 func switch_blocked() -> bool:
-	return mon(PLAYER).trapped_turns > 0 \
+	return mon(PLAYER).trapped_turns > 0 or gen1_trapping_move(ENEMY) != 0 \
 		or Gen2Substatus.has(mon(ENEMY).substatus, Gen2Substatus.CANT_RUN)
 
 
@@ -1998,6 +2009,16 @@ func _tick_weather(events: Array) -> void:
 ## release and costs nothing, which is why three to six rolled turns are two to
 ## five turns of damage.
 func _tick_wrap(events: Array) -> void:
+	## Generation 1 has no `ResidualDamage` entry for a trapping move: the
+	## counter is spent by `.MultiturnMoveCheck` repeating the move instead, and
+	## `CheckNumAttacksLeft` at the end of the whole turn is what lets go. So the
+	## turn the counter empties still holds the target, whichever side moves
+	## first on it.
+	if data != null and data.generation == RomRegistry.GEN1:
+		for side: int in [PLAYER, ENEMY]:
+			if mon(side).trapped_turns <= 0:
+				mon(side).trapping_move = 0
+		return
 	for side: int in [PLAYER, ENEMY]:
 		var current: Gen2BattleMon = mon(side)
 		if current.is_fainted() or current.trapped_turns <= 0:
@@ -2719,8 +2740,20 @@ func move_for(side: int, slot: int) -> int:
 	if Gen2Substatus.has(attacker.substatus, Gen2Substatus.RAMPAGING) \
 		and attacker.rampage_move != 0:
 		return attacker.rampage_move
+	var held: int = gen1_trapping_move(side)
+	if held != 0:
+		return held
 	var chosen_slot: int = effective_slot(side, slot)
 	return int(attacker.moves[chosen_slot]) if attacker.can_use(chosen_slot) else Gen2Damage.STRUGGLE
+
+
+## `USING_TRAPPING_MOVE` read from the user's side: while the opponent is bound,
+## Generation 1 repeats the move that bound it and spends no PP on the repeat.
+## Answers 0 on Generation 2, where a bound target still takes its turn.
+func gen1_trapping_move(side: int) -> int:
+	if data == null or data.generation != RomRegistry.GEN1:
+		return 0
+	return mon(1 - side).trapping_move
 
 
 ## Who goes first, as the two sides in the order they act. A switch is settled
@@ -2822,6 +2855,7 @@ func _act(side: int, slot: int, move_number: int, events: Array) -> void:
 		or Gen2Substatus.has(active_substatus, Gen2Substatus.ROLLOUT)
 		or Gen2Substatus.has(active_substatus, Gen2Substatus.RAMPAGING)
 		or Gen2Substatus.has(active_substatus, Gen2Substatus.BIDE)
+		or gen1_trapping_move(side) == move_number
 	) and move_number != 0
 
 	# Whether the Pokémon can move at all is asked before the effect is looked up,
@@ -2842,7 +2876,9 @@ func run_move_effect(turn: Gen2Turn, depth: int = 0) -> void:
 	if turn.ended:
 		return
 	Gen2EffectCommands.check_obedience(turn)
-	var sequence: Array = Gen2MoveEffect.sequence_for(turn.effect())
+	var sequence: Array = Gen2MoveEffect.sequence_for(
+		turn.effect(), data.generation if data != null else RomRegistry.GEN2
+	)
 	var counter: int = 0
 	while counter < sequence.size():
 		if turn.ended:

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -30,8 +30,19 @@ const OAM_YFLIP: int = 1 << 6
 const OAM_XFLIP: int = 1 << 5
 const OAM_PALETTE: int = 0x07
 
-## The white the hardware fills the battle background with.
+## The white the hardware fills the battle background with; Generation 1 fills it
+## with `SuperPalettes`' own, from [method gen1_screen_palette].
 const BACKGROUND: Color = Color.WHITE
+
+## `BlkPacket_Battle`'s five blocks name one of four Super Game Boy palettes for
+## every cell of a Generation 1 battle and `SetPal_Battle` fills them: 0 and 1
+## are `PAL_GREENBAR` plus each side's HP bar colour, 2 and 3 are
+## `DeterminePaletteID`'s. Block 1 gives rows 12 to 17 palette 2 and everything
+## outside them palette 0.
+const GEN1_PAL_PLAYER_BAR: int = 0
+const GEN1_PAL_ENEMY_BAR: int = 1
+const GEN1_PAL_PLAYER_MON: int = 2
+const GEN1_PAL_ENEMY_MON: int = 3
 
 var _data: GameData = null
 var _hud: Gen2BattleHud = null
@@ -110,7 +121,11 @@ func set_battle_data(data: GameData) -> bool:
 	if _hud == null:
 		return false
 
-	add_child(Gen2Screen.Field.create(BACKGROUND))
+	## Palette 0's colour 0, the same white in all three bar rows.
+	var field: Color = BACKGROUND
+	if data.generation == RomRegistry.GEN1:
+		field = data.bar_palette(GameData.HP_BAR_PALETTE_NAMES[0])[0]
+	add_child(Gen2Screen.Field.create(field))
 
 	_enemy_pic = _new_layer()
 	_player_pic = _new_layer()
@@ -578,6 +593,23 @@ func _battler_palette(species: int, slot: int, shiny: bool) -> PackedColorArray:
 	return _remap(_data.palette(species, shiny), _palette_map("bg_palette_maps", slot))
 
 
+## One of `SetPal_Battle`'s four. Every `SuperPalettes` row shares colour 0 and
+## colour 3, so a 1bpp surface reads the same white and near-black out of
+## whichever block covers it; only the bars and the pictures read the two
+## between.
+func gen1_screen_palette(slot: int) -> PackedColorArray:
+	var player: bool = slot == GEN1_PAL_PLAYER_BAR or slot == GEN1_PAL_PLAYER_MON
+	if slot == GEN1_PAL_PLAYER_MON or slot == GEN1_PAL_ENEMY_MON:
+		return _data.palette(
+			int(_view.get("player_species" if player else "enemy_species", 0)),
+			bool(_view.get("player_shiny" if player else "enemy_shiny", false))
+		)
+	return _hp_palette(
+		int(_view.get("player_hp" if player else "enemy_hp", 0)),
+		int(_view.get("player_max_hp" if player else "enemy_max_hp", 0))
+	)
+
+
 ## `_CGB_BattleGrayscale`'s palette while the view says the battle is still in
 ## it, which is every frame up to `GetSGBLayout SCGB_BATTLE_COLORS`. Empty once
 ## the colours are loaded, which is what every other palette here answers to.
@@ -648,9 +680,12 @@ func _draw_panels() -> void:
 				panels, Gen2Screen.WIDTH, player_name, player_level, player_hp, player_max_hp
 			)
 		_draw_trainer_hud_border(panels, border)
+		## Blocks 3 and 2 name palettes 0 and 1 for the two panels; both are
+		## 1bpp, so one layer serves.
 		_show_layer(
 			_panels, panels,
-			PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+			gen1_screen_palette(GEN1_PAL_PLAYER_BAR) if _gen1()
+			else PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 		)
 
 	if _layer_changed(&"enemy_bar", [enemy_hp, enemy_max_hp, enemy_hud, raster]):

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -52,6 +52,9 @@ const STOPPED_BY: Dictionary = {
 	&"recharge": "must recharge!",
 	&"disabled": "is disabled!",
 	&"attract": "is immobilized by love!",
+	## `_CantMoveText`, Generation 1's alone: the target of a trapping move
+	## spends every turn of it held in place.
+	&"held_in_place": "can't move!",
 }
 
 const INFLICTED: Dictionary = {
@@ -5381,6 +5384,7 @@ const LINES: Dictionary = {
 		&"name:side",
 		&"type:type_number",
 	],
+	Gen2Battle.TYPE_COPIED: ["Converted type to %s's!", &"name:target"],
 	Gen2Battle.DISABLE_INFLICTED: [
 		"%s's %s was disabled!",
 		&"name:target",
@@ -5520,6 +5524,7 @@ const LINE_HANDLERS: Dictionary = {
 	Gen2Battle.WEATHER_CONTINUES: &"_weather_text",
 	Gen2Battle.WEATHER_ENDED: &"_weather_text",
 	Gen2Battle.TRAPPED: &"_trapped_text",
+	Gen2Battle.ATTACK_CONTINUES: &"_attack_continues_text",
 	Gen2Battle.SCREEN_SET: &"_screen_set_text",
 	Gen2Battle.SCREEN_FADED: &"_screen_faded_text",
 	Gen2Battle.FLED: &"_fled_text",
@@ -5603,6 +5608,11 @@ func _cannot_move_text(event: Dictionary) -> String:
 		_battler_name(int(event.get("side", Gen2Battle.PLAYER))),
 		STOPPED_BY.get(event["reason"], "cannot move!"),
 	]
+
+
+## `_AttackContinuesText`, printed by `.MultiturnMoveCheck` in front of the hit.
+func _attack_continues_text(event: Dictionary) -> String:
+	return "%s's\nattack continues!" % _battler_name(int(event["side"]))
 
 
 func _status_inflicted_text(event: Dictionary) -> String:
@@ -6088,6 +6098,19 @@ func _enemy_trainer_name() -> String:
 	return String(_data.trainer_party(_enemy_trainer_class, _enemy_trainer_index).get("name", ""))
 
 
+## `BlkPacket_Battle`'s message box block names palette 2, so the box a
+## Generation 1 battle prints in wears the player's own Pokemon's colours.
+func _push_gen1_text_palette() -> void:
+	if _box == null or _data == null or _data.generation != RomRegistry.GEN1:
+		return
+	## A renderer of a mod's own that does not answer leaves it white and black.
+	if _renderer == null or not _renderer.has_method("gen1_screen_palette"):
+		return
+	_box.palette = _renderer.gen1_screen_palette(
+		Gen2BattleRenderer.GEN1_PAL_PLAYER_MON
+	)
+
+
 ## Pushes the current display values to the renderer. Plain values only, never
 ## the battle engine: a turn resolves at once and is then shown an event at a
 ## time, so what is drawn deliberately lags where the battle has got to.
@@ -6095,6 +6118,7 @@ func _push_view() -> void:
 	_update_low_health_alarm()
 	if not _renderer_ready:
 		return
+	_push_gen1_text_palette()
 	_renderer.set_view({
 		"enemy_species": _enemy, "player_species": _player,
 		"enemy_unown_form": _enemy_unown_form,

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -1,13 +1,14 @@
 class_name Gen2BattleTransition
 extends RefCounted
 
-## `DoBattleTransition` (engine/battle/battle_transition.asm): what the overworld
-## does between the encounter and the battle screen. Four animations, picked by
-## the lead's level against the opponent's and by the environment, three passes of
-## a palette flash, then one of four ways of going black. The jumptable is walked
-## one entry per frame, which is `.loop`'s own `DelayFrame`. Node-free: it answers
-## with a screen of cells, a DMG palette order and a per-scanline offset, so a
-## whole transition can be stepped headless.
+## `DoBattleTransition` (engine/battle/battle_transition.asm) and Generation 1's
+## `BattleTransition` (engine/battle/battle_transitions.asm): what the overworld
+## does between the encounter and the battle screen. Node-free, so a whole one
+## steps headless, answering with a screen of cells, a DMG palette order and a
+## per-scanline offset. Crystal walks a jumptable an entry a frame and
+## Generation 1 is straight-line, but `BattleTransition_CircleData1` to `...5`
+## are [constant WEDGES] byte for byte and the two half-circle tables cover
+## [constant SPIN_QUADRANTS]' twenty positions.
 
 const COLUMNS: int = 20
 const ROWS: int = 18
@@ -95,6 +96,67 @@ const WEDGES: Dictionary = {
 	4: [4, 1, 4, 0, 3, 1, 3, 0, 2, 1, 2, 0, 1, -1],
 	5: [4, 0, 3, 0, 3, 0, 2, 0, 2, 0, 1, 0, 1, 0, 1, -1],
 }
+## `BattleTransitions`, the jumptable `GetBattleTransitionID_WildOrTrainer`,
+## `..._CompareLevels` and `..._IsDungeonMap` index with one bit each. Only the
+## four wild rows have a caller: nothing puts a Generation 1 trainer on a map,
+## and `..._Shrink` and `..._Split` move the map's own tiles rather than blacking
+## cells, so they want a screen of them.
+const GEN1_TRAINER_BIT: int = 1
+const GEN1_STRONGER_BIT: int = 2
+const GEN1_DUNGEON_BIT: int = 4
+const GEN1_SCENES: Dictionary = {
+	0: [&"gen1_init", &"gen1_flash", &"gen1_double_circle"],
+	GEN1_STRONGER_BIT: [&"gen1_init", &"gen1_flash", &"gen1_circle"],
+	GEN1_DUNGEON_BIT: [&"gen1_init", &"gen1_stripes"],
+	GEN1_DUNGEON_BIT | GEN1_STRONGER_BIT: [&"gen1_init", &"gen1_stripes"],
+}
+
+## `BattleTransition_HalfCircle1` and `...2`, with the Y quadrant their caller
+## passes folded into [method _draw_wedge]'s own two bits: the first table is
+## always drawn downward and the second upward.
+const GEN1_HALF_CIRCLE_1: Array = [
+	[UPPER_RIGHT, 1, 18, 6], [UPPER_RIGHT, 2, 19, 3], [UPPER_RIGHT, 3, 18, 0],
+	[UPPER_RIGHT, 4, 14, 0], [UPPER_RIGHT, 5, 10, 0],
+	[UPPER_LEFT, 5, 9, 0], [UPPER_LEFT, 4, 5, 0], [UPPER_LEFT, 3, 1, 0],
+	[UPPER_LEFT, 2, 0, 3], [UPPER_LEFT, 1, 1, 6],
+]
+const GEN1_HALF_CIRCLE_2: Array = [
+	[LOWER_LEFT, 1, 1, 11], [LOWER_LEFT, 2, 0, 14], [LOWER_LEFT, 3, 1, 17],
+	[LOWER_LEFT, 4, 5, 17], [LOWER_LEFT, 5, 9, 17],
+	[LOWER_RIGHT, 5, 10, 17], [LOWER_RIGHT, 4, 14, 17], [LOWER_RIGHT, 3, 18, 17],
+	[LOWER_RIGHT, 2, 19, 14], [LOWER_RIGHT, 1, 18, 11],
+]
+
+## `BattleTransition_HorizontalStripes` and `..._VerticalStripes`: two cursors
+## from opposite corners, each blacking every second cell of its row or column.
+## A row is the step count, where each cursor starts, what a step moves it by,
+## and the run a cursor writes as a step and a count.
+const GEN1_STRIPES_HORIZONTAL: Array = [
+	20, Vector2i(0, 0), Vector2i(1, 0), Vector2i(19, 1), Vector2i(-1, 0),
+	Vector2i(0, 2), 9,
+]
+const GEN1_STRIPES_VERTICAL: Array = [
+	18, Vector2i(0, 0), Vector2i(0, 1), Vector2i(1, 17), Vector2i(0, -1),
+	Vector2i(2, 0), 10,
+]
+
+## `BattleTransition_FlashScreen`'s `ld b, $3` over [constant FLASH_PALETTES]'
+## twelve, two frames each, where Generation 2 walks them as three scenes.
+const GEN1_FLASH_PALETTES: int = 12
+const GEN1_FLASH_FRAMES: int = GEN1_FLASH_PALETTES * 2 * 3
+
+## `BattleTransition_TransferDelay3`, the whole cost of a step of all four: the
+## tiles are written between frames and `Delay3` spends the rest.
+const GEN1_STEP_FRAMES: int = 3
+
+## What `BattleTransition` spends in front of the animation: its caller's
+## `DelayFrame`, then `Delay3`, `DelayFrame` and `Delay3` around the OAM clear.
+const GEN1_LEAD_FRAMES: int = 8
+
+## `BattleTransition_BlackScreen` writes `rBGP`, `rOBP0` and `rOBP1` rather than
+## filling the tilemap, so every colour on screen is drawn as colour 3.
+const GEN1_BLACK_ORDER: int = 0xFF
+
 ## `ld c, 2 / DelayFrames` between wedges, and the three `DelayFrame`s
 ## `.end` spends before it hands to `BATTLETRANSITION_FINISH`.
 ## `StartTrainerBattle_SpeckleToBlack.done` spends the same three; the zoom and
@@ -163,6 +225,9 @@ var _darkness: bool = false
 var _order: int = IDENTITY
 var _ball_drawn: bool = false
 var _sprites: int = SPRITES_ALL
+## Which stripe plan is running, and whether this is `BattleTransition`.
+var _gen1_stripes: Array = []
+var _gen1: bool = false
 var _cells: PackedByteArray = PackedByteArray()
 var _sine: PackedByteArray = PackedByteArray()
 var _rng: RandomNumberGenerator = null
@@ -201,8 +266,24 @@ static func create_outro(rng: RandomNumberGenerator = null) -> Gen2BattleTransit
 	return out
 
 
-## Which scene of the jumptable is running, for a test or a trace: `ball`,
-## `bgmap`, `flash`, `next`, one of the four setups or one of the four outros.
+## `BattleTransition`. [param index] is the three bits the three
+## `GetBattleTransitionID_*` routines set, and a row [constant GEN1_SCENES] does
+## not carry answers null, which is every trainer row.
+static func create_gen1(index: int) -> Gen2BattleTransition:
+	if not GEN1_SCENES.has(index):
+		return null
+	var out := Gen2BattleTransition.new()
+	out._gen1 = true
+	out._scene = GEN1_SCENES[index]
+	out._gen1_stripes = GEN1_STRIPES_VERTICAL if (index & GEN1_STRONGER_BIT) != 0 \
+		else GEN1_STRIPES_HORIZONTAL
+	out._rng = RandomNumberGenerator.new()
+	out._cells = PackedByteArray()
+	out._cells.resize(COLUMNS * ROWS)
+	return out
+
+
+## Which scene is running, for a test or a trace: a key of [constant SCENE_STEPS].
 func scene() -> StringName:
 	if _finished or _step >= _scene.size():
 		return &""
@@ -268,45 +349,58 @@ func advance_frame() -> bool:
 	return true
 
 
+## Which method runs a scene, so a jumptable stays a table.
+const SCENE_STEPS: Dictionary = {
+	&"init": &"_lead_in", &"ball": &"_load_poke_ball_graphics",
+	&"bgmap": &"_begin_bg_map", &"flash": &"_flash", &"next": &"_next",
+	&"wavy_setup": &"_wavy_setup", &"sine": &"_sine_wave_step",
+	&"spin_setup": &"_outro_setup", &"spin": &"_spin_step",
+	&"scatter_setup": &"_scatter_setup", &"scatter": &"_scatter_step",
+	&"zoom": &"_zoom_outro",
+	&"gen1_init": &"_gen1_lead_in", &"gen1_flash": &"_gen1_flash",
+	&"gen1_circle": &"_gen1_circle_step",
+	&"gen1_double_circle": &"_gen1_double_circle_step",
+	&"gen1_stripes": &"_gen1_stripes_step",
+}
+
+
 func _run() -> void:
 	if _step >= _scene.size():
 		_finished = true
 		return
-	match StringName(_scene[_step]):
-		&"init":
-			_delay = LEAD_FRAMES
-			_next()
-		&"ball":
-			_load_poke_ball_graphics()
-		&"bgmap":
-			_counter = 0
-			_next()
-		&"flash":
-			_flash()
-		&"next":
-			_next()
-		&"wavy_setup":
-			_respawn()
-			_counter = 0
-			_sine_offset = 0
-			_next()
-		&"sine":
-			_sine_wave_step()
-		&"spin_setup":
-			_respawn()
-			_counter = 0
-			_next()
-		&"spin":
-			_spin_step()
-		&"scatter_setup":
-			_respawn()
-			_counter = SCATTER_FRAMES
-			_next()
-		&"scatter":
-			_scatter_step()
-		&"zoom":
-			_respawn()
-			_zoom_step()
+	call(SCENE_STEPS[StringName(_scene[_step])])
+
+
+func _lead_in() -> void:
+	_delay = LEAD_FRAMES
+	_next()
+
+
+func _begin_bg_map() -> void:
+	_counter = 0
+	_next()
+
+
+func _wavy_setup() -> void:
+	_outro_setup()
+	_sine_offset = 0
+
+
+func _outro_setup() -> void:
+	_respawn()
+	_counter = 0
+	_next()
+
+
+func _scatter_setup() -> void:
+	_respawn()
+	_counter = SCATTER_FRAMES
+	_next()
+
+
+func _zoom_outro() -> void:
+	_respawn()
+	_zoom_step()
 
 
 ## `RespawnPlayerAndOpponent`, which every one of the four outros opens with:
@@ -398,10 +492,73 @@ func _spin_step() -> void:
 		_delay = SPIN_END_FRAMES
 		_finish()
 		return
-	var entry: Array = SPIN_QUADRANTS[_counter]
-	_draw_wedge(int(entry[0]), int(entry[1]), Vector2i(int(entry[2]), int(entry[3])))
+	_wedge_row(SPIN_QUADRANTS[_counter])
 	_counter += 1
 	_delay = SPIN_STEP_FRAMES
+
+
+## A row of [constant SPIN_QUADRANTS] or of a half-circle table, same columns.
+func _wedge_row(entry: Array) -> void:
+	_draw_wedge(int(entry[0]), int(entry[1]), Vector2i(int(entry[2]), int(entry[3])))
+
+
+## `BattleTransition`'s prologue. Its OAM clear keeps the player's block and the
+## enemy trainer's, which Generation 2 only reaches at its outro.
+func _gen1_lead_in() -> void:
+	_sprites = SPRITES_BATTLERS
+	_delay = GEN1_LEAD_FRAMES
+	_next()
+
+
+## `BattleTransition_FlashScreen_`. Its last write is `dc 3, 2, 1, 0`, so `rBGP`
+## is back at [constant IDENTITY] by the time the wipe starts.
+func _gen1_flash() -> void:
+	@warning_ignore("integer_division")
+	_order = int(FLASH_PALETTES[(_counter / 2) % GEN1_FLASH_PALETTES])
+	_counter += 1
+	if _counter < GEN1_FLASH_FRAMES:
+		return
+	_counter = 0
+	_next()
+
+
+## `BattleTransition_Circle`: `HalfCircle1` whole, then `HalfCircle2`.
+func _gen1_circle_step() -> void:
+	var first: int = GEN1_HALF_CIRCLE_1.size()
+	if _counter >= first + GEN1_HALF_CIRCLE_2.size():
+		_finish()
+		return
+	_wedge_row(GEN1_HALF_CIRCLE_1[_counter] if _counter < first \
+		else GEN1_HALF_CIRCLE_2[_counter - first])
+	_counter += 1
+	_delay = GEN1_STEP_FRAMES - 1
+
+
+## `BattleTransition_DoubleCircle`: the same twenty wedges, a pair a step.
+func _gen1_double_circle_step() -> void:
+	if _counter >= GEN1_HALF_CIRCLE_1.size():
+		_finish()
+		return
+	_wedge_row(GEN1_HALF_CIRCLE_1[_counter])
+	_wedge_row(GEN1_HALF_CIRCLE_2[_counter])
+	_counter += 1
+	_delay = GEN1_STEP_FRAMES - 1
+
+
+## Whichever of the two stripe plans [method create_gen1] seated.
+func _gen1_stripes_step() -> void:
+	if _counter >= int(_gen1_stripes[0]):
+		_finish()
+		return
+	var run: Vector2i = _gen1_stripes[5]
+	for cursor: int in 2:
+		var at: Vector2i = (_gen1_stripes[1 + cursor * 2] as Vector2i) \
+			+ (_gen1_stripes[2 + cursor * 2] as Vector2i) * _counter
+		for _cell: int in int(_gen1_stripes[6]):
+			_write(at.x, at.y, CELL_BLACK)
+			at += run
+	_counter += 1
+	_delay = GEN1_STEP_FRAMES - 1
 
 
 ## `.load`: a run of cells blacked out along a row, then a step back and down
@@ -472,10 +629,12 @@ func _zoom_step() -> void:
 ## zero, which is what takes whatever the outro left to black.
 func _finish() -> void:
 	## Added rather than assigned: [constant SPIN_END_FRAMES] belongs to the outro.
-	_delay += TAIL_FRAMES
+	## Generation 1 adds none: `BattleTransition_BlackScreen` writes three
+	## palette registers and returns.
+	_delay += 0 if _gen1 else TAIL_FRAMES
 	_finished = true
 	_sprites = SPRITES_NONE
-	_order = IDENTITY
+	_order = GEN1_BLACK_ORDER if _gen1 else IDENTITY
 	_cells.fill(CELL_BLACK)
 
 

--- a/game/battle/effect_commands.gd
+++ b/game/battle/effect_commands.gd
@@ -276,6 +276,14 @@ const CURL: StringName = &"curl"
 ## either Pokémon's status byte or [Gen2Substatus].
 const HAZE: StringName = &"haze"
 
+## The four routines Generation 1 keeps under an effect byte whose Crystal
+## command list does something else. [method Gen2MoveEffect.sequence_for] picks
+## between the two by generation.
+const GEN1_HAZE: StringName = &"gen1haze"
+const GEN1_TRAP_TARGET: StringName = &"gen1traptarget"
+const GEN1_CONVERSION: StringName = &"gen1conversion"
+const GEN1_FORCE_SWITCH: StringName = &"gen1forceswitch"
+
 ## Half the user's maximum HP for an Attack straight to the top of its range.
 ## Fails free if it has no more than half, or if Attack is already there.
 const BELLY_DRUM: StringName = &"bellydrum"
@@ -650,6 +658,10 @@ static var HANDLERS: Dictionary = {
 	RAMPAGE: _rampage,
 	CURL: _curl,
 	HAZE: _haze,
+	GEN1_HAZE: _gen1_haze,
+	GEN1_TRAP_TARGET: _gen1_trap_target,
+	GEN1_CONVERSION: _gen1_conversion,
+	GEN1_FORCE_SWITCH: _gen1_force_switch,
 	BELLY_DRUM: _belly_drum,
 	PSYCH_UP: _psych_up,
 	DISABLE: _disable,
@@ -1380,6 +1392,12 @@ static func _check_immune(turn: Gen2Turn) -> void:
 ## `.Missed`'s own tail, which every gate in the hit check shares.
 static func _miss(turn: Gen2Turn, event: StringName = Gen2Battle.MISSED) -> void:
 	turn.missed = true
+	## `MoveHitTest.moveMissed` zeroes `wDamage` and clears
+	## `USING_TRAPPING_MOVE`, so a Wrap that misses binds nothing at all.
+	if turn.battle.gen1_trapping_move(turn.side) != 0:
+		turn.defender().trapped_turns = 0
+		turn.defender().trapping_move = 0
+		turn.battle.last_damage_dealt = 0
 	turn.emit(event, {"target": turn.target})
 	if not CONTINUES_AFTER_MISS.has(turn.effect()):
 		_failure_text(turn)
@@ -1559,6 +1577,7 @@ static func _apply_damage(turn: Gen2Turn) -> void:
 
 	turn.dealt = defender.take_damage(turn.damage)
 	turn.damage = turn.dealt # DoPlayerDamage and DoEnemyDamage replace wCurDamage on underflow.
+	turn.battle.last_damage_dealt = turn.damage
 	# `wCriticalHit` at 2 is the one-hit line rather than the critical one, which
 	# is the only thing that tells an OHKO's own hit apart from any other.
 	turn.emit(Gen2Battle.OHKO if turn.one_hit_ko else Gen2Battle.HIT, {
@@ -1794,6 +1813,20 @@ static func _check_status(turn: Gen2Turn) -> void:
 			turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"freeze"})
 			turn.end()
 			return
+
+	## `.HeldInPlaceCheck` and `HazeEffect_`'s `$ff`, both between the freeze
+	## check and the flinch one, and both Generation 1's alone.
+	if turn.battle.gen1_trapping_move(turn.target) != 0:
+		_cant_move(mon)
+		turn.emit(Gen2Battle.CANNOT_MOVE, {"reason": &"held_in_place"})
+		turn.end()
+		return
+
+	if Gen2Substatus.has(mon.substatus, Gen2Substatus.GEN1_LOST_TURN):
+		_cant_move(mon)
+		mon.substatus &= ~Gen2Substatus.GEN1_LOST_TURN
+		turn.end()
+		return
 
 	if Gen2Substatus.has(mon.substatus, Gen2Substatus.FLINCHED):
 		_cant_move(mon)
@@ -2385,6 +2418,115 @@ static func _haze(turn: Gen2Turn) -> void:
 	turn.battle.mon(Gen2Battle.ENEMY).reset_stages()
 	_animate_current_move(turn)
 	turn.emit(Gen2Battle.STAGES_CLEARED)
+
+
+## `HazeEffect_` (engine/battle/move_effects/haze.asm), a good deal more than
+## Crystal's stage reset. The non-volatile status is cured on the target alone,
+## and a target that was asleep or frozen has `$ff` written over its selected
+## move, so it loses the turn it was about to take.
+static func _gen1_haze(turn: Gen2Turn) -> void:
+	for side: int in [Gen2Battle.PLAYER, Gen2Battle.ENEMY]:
+		_gen1_cure_volatile(turn.battle, side)
+	var defender: Gen2BattleMon = turn.defender()
+	var was_immobile: bool = Gen2Status.has(defender.status, Gen2Status.FREEZE) \
+		or Gen2Status.is_asleep(defender.status)
+	defender.status = Gen2Status.NONE
+	## The write only costs a turn the target has not taken yet: on the next one
+	## its own selection lands over the `$ff`.
+	if was_immobile and not turn.battle.opponent_went_first(turn.side):
+		defender.substatus |= Gen2Substatus.GEN1_LOST_TURN
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.STAGES_CLEARED)
+
+
+## `CureVolatileStatuses` and the stage reset in front of it, for one side: the
+## mask keeps `TRANSFORMED` and drops confusion, X Accuracy, Mist, Focus Energy,
+## Leech Seed, the bad-poison counter and both screens.
+static func _gen1_cure_volatile(battle: Gen2Battle, side: int) -> void:
+	var mon: Gen2BattleMon = battle.mon(side)
+	mon.reset_stages()
+	mon.substatus &= ~(
+		Gen2Substatus.CONFUSED | Gen2Substatus.X_ACCURACY | Gen2Substatus.MIST
+		| Gen2Substatus.FOCUS_ENERGY | Gen2Substatus.LEECH_SEED
+	)
+	mon.confusion_turns = 0
+	mon.toxic_counter = 0
+	mon.disabled_slot = -1
+	mon.disable_turns = 0
+	battle.screens[side] = Gen2Screens.NONE
+	battle.light_screen_turns[side] = 0
+	battle.reflect_turns[side] = 0
+
+
+## `TrappingEffect`. The counter goes on the target, where
+## [member Gen2BattleMon.trapped_turns] already lives, and Generation 1 spends it
+## by repeating the move rather than by bleeding: [method Gen2Battle.move_for]
+## forces the move on the user and [method _check_status] holds the target in
+## place. `.MultiturnMoveCheck` jumps past the damage calculation, the accuracy
+## roll and `DecrementPP`, which is the skip here.
+static func _gen1_trap_target(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if defender.trapping_move != 0:
+		defender.trapped_turns -= 1
+		turn.damage = turn.battle.last_damage_dealt
+		turn.skip_to = DAMAGE_VARIATION
+		turn.emit(Gen2Battle.ATTACK_CONTINUES)
+		return
+
+	## `ClearHyperBeam`: the target owes no recharge even if this misses.
+	defender.substatus &= ~Gen2Substatus.RECHARGING
+	defender.trapped_turns = Gen2Substatus.roll_gen1_trap_turns(turn.rng())
+	defender.trapping_move = turn.move_number
+	turn.emit(Gen2Battle.TRAPPED, {
+		"target": turn.target, "move": turn.move_number, "turns": defender.trapped_turns,
+	})
+
+
+## `ConversionEffect_`: the user takes both of the target's types. Its one
+## refusal is a target that is flying or underground.
+static func _gen1_conversion(turn: Gen2Turn) -> void:
+	var defender: Gen2BattleMon = turn.defender()
+	if _is_hidden(defender.substatus):
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+	var copied: Array = defender.types()
+	if copied.size() < 2:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+	turn.attacker().battle_types = [int(copied[0]), int(copied[1])]
+	_animate_current_move(turn)
+	turn.emit(Gen2Battle.TYPE_COPIED, {"target": turn.target})
+
+
+## `SwitchAndTeleportEffect`, which is Roar, Whirlwind and Teleport in one
+## routine. Against a trainer all three say so and nothing switches; against a
+## wild the battle ends on the same level roll Crystal kept in two commands.
+static func _gen1_force_switch(turn: Gen2Turn) -> void:
+	if turn.battle.is_trainer_battle:
+		turn.emit(Gen2Battle.MOVE_FAILED)
+		return
+	var user_level: int = turn.attacker().level
+	var other_level: int = turn.defender().level
+	if user_level < other_level:
+		var span: int = user_level + other_level + 1
+		if turn.rng().randi_range(0, span - 1) < other_level >> 2:
+			turn.emit(Gen2Battle.MOVE_FAILED)
+			return
+
+	## `.playAnimAndPrintText` reads the move number back for its line: Teleport
+	## takes the user out of the fight and the other two blow the target out.
+	var teleporting: bool = turn.move_number == Gen2MoveEffect.TELEPORT_MOVE
+	turn.battle.force_out(turn.side if teleporting else turn.target)
+	turn.battle.battle_anim_param = FORCE_SWITCH_ANIM_PARAM
+	_animate_current_move(turn)
+	if teleporting:
+		turn.emit(Gen2Battle.FLED_FROM_BATTLE)
+		return
+	turn.emit(
+		Gen2Battle.FLED_IN_FEAR if turn.move_number == Gen2MoveEffect.ROAR_MOVE
+		else Gen2Battle.BLOWN_AWAY,
+		{"target": turn.target}
+	)
 
 
 ## Belly Drum. Fails and costs nothing unless the user has more than half its

--- a/game/battle/move_effect.gd
+++ b/game/battle/move_effect.gd
@@ -244,6 +244,9 @@ const FORCE_SWITCH: int = 28
 ## the move's animation byte against `ROAR`, and every move here animates as
 ## itself, so the number is what tells the pair apart.
 const ROAR_MOVE: int = 46
+## Teleport's, for the same reason: Generation 1 runs all three through
+## `SwitchAndTeleportEffect` and picks its line by move number.
+const TELEPORT_MOVE: int = 100
 
 ## Baton Pass, the one effect whose player half cannot be resolved inside the
 ## turn that started it.
@@ -1592,6 +1595,48 @@ const CONVERSION_2_SEQUENCE: Array = [
 	Gen2EffectCommands.END_MOVE,
 ]
 
+## The four lists Generation 1 reads instead, keyed by the same effect byte.
+## Three are one command swapped; the fourth moves `gen1traptarget` in front of
+## `checkhit`, because `TrappingEffect` is in `SpecialEffectsCont` and runs
+## before `MoveHitTest`, which is what lets a miss undo it.
+const GEN1_SEQUENCES: Dictionary = {
+	HAZE: [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.GEN1_HAZE,
+		Gen2EffectCommands.END_MOVE,
+	],
+	CONVERSION: [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.GEN1_CONVERSION,
+		Gen2EffectCommands.END_MOVE,
+	],
+	FORCE_SWITCH: [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.GEN1_FORCE_SWITCH,
+		Gen2EffectCommands.END_MOVE,
+	],
+	TRAP_TARGET: [
+		Gen2EffectCommands.USED_MOVE_TEXT,
+		Gen2EffectCommands.DO_TURN,
+		Gen2EffectCommands.GEN1_TRAP_TARGET,
+		Gen2EffectCommands.CHECK_HIT,
+		Gen2EffectCommands.CRITICAL,
+		Gen2EffectCommands.DAMAGE_STATS,
+		Gen2EffectCommands.DAMAGE_CALC,
+		Gen2EffectCommands.STAB,
+		Gen2EffectCommands.CHECK_IMMUNE,
+		Gen2EffectCommands.DAMAGE_VARIATION,
+		Gen2EffectCommands.MOVE_ANIM,
+		Gen2EffectCommands.APPLY_DAMAGE,
+		Gen2EffectCommands.CHECK_FAINT,
+		Gen2EffectCommands.BUILD_OPPONENT_RAGE,
+		Gen2EffectCommands.END_MOVE,
+	],
+}
+
 ## Snore: a flinch chance whose own command sits between the roll and the
 ## animation, so a Snore used awake fails before anything is drawn.
 const SNORE_SEQUENCE: Array = [
@@ -2075,9 +2120,12 @@ static func _table() -> Dictionary:
 ## A registered effect wins over the cartridge's, which is what lets a mod
 ## rewrite one as well as add one. [method register_effect] is where that is
 ## refused for the effects the engine relies on reading back off a turn.
-static func sequence_for(effect: int) -> Array:
+## [param generation] picks [constant GEN1_SEQUENCES]' four.
+static func sequence_for(effect: int, generation: int = RomRegistry.GEN2) -> Array:
 	if _registered_sequences.has(effect):
 		return _registered_sequences[effect]
+	if generation == RomRegistry.GEN1 and GEN1_SEQUENCES.has(effect):
+		return GEN1_SEQUENCES[effect]
 	return _table().get(effect, NORMAL_HIT)
 
 

--- a/game/battle/substatus.gd
+++ b/game/battle/substatus.gd
@@ -74,6 +74,10 @@ const TRANSFORMED: int = 1 << 28
 ## arrangement and what `supereffectivelooptext` reads.
 const IN_LOOP: int = 1 << 29
 
+## `HazeEffect_` writing `$ff` over the target's selected move: it loses the turn
+## it was about to take. Generation 1 only, and cleared by the turn it costs.
+const GEN1_LOST_TURN: int = 1 << 30
+
 const NONE: int = 0
 
 ## Rolled the shape [constant Gen2Status.MIN_SLEEP] is, both ends inclusive.
@@ -158,6 +162,17 @@ static func rolls_attract_immobile(rng: RandomNumberGenerator) -> bool:
 
 static func roll_trap_turns(rng: RandomNumberGenerator) -> int:
 	return rng.randi_range(MIN_TRAP_TURNS, MAX_TRAP_TURNS)
+
+
+## `TrappingEffect`'s own roll, which is not a range: two bits, and a second draw
+## of the same two whenever the first is 2 or 3. So one and two continuations are
+## 3/8 each and three and four are 1/8, which is the source's "3/8 chance for 2
+## and 3 attacks, and 1/8 chance for 4 and 5".
+static func roll_gen1_trap_turns(rng: RandomNumberGenerator) -> int:
+	var rolled: int = rng.randi_range(0, 255) & 0b11
+	if rolled >= 2:
+		rolled = rng.randi_range(0, 255) & 0b11
+	return rolled + 1
 
 
 static func trap_damage(max_hp: int) -> int:

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -328,6 +328,14 @@ const COLOSSEUM: int = 0xF0
 const LORELEIS_ROOM: int = 0xF5
 const BRUNOS_ROOM: int = 0xF6
 
+## `GetBattleTransitionID_IsDungeonMap`: `DungeonMaps1`'s four ids and
+## `DungeonMaps2`'s four inclusive ranges. The file's own comment lists the
+## dungeons the pair misses, Victory Road 2F and Diglett's Cave among them.
+const DUNGEON_MAPS: Array[int] = [0x33, 0x52, 0xC0, 0xE8]
+const DUNGEON_MAP_RANGES: Array = [
+	[0x3B, 0x3D], [0x5F, 0x76], [0x8D, 0x97], [0xCF, 0xE4],
+]
+
 ## The `tileset` macro: the bank holding both graphics and blocks, the three
 ## pointers, three counter tiles, the grass tile and the animation kind, with
 ## $FF for "none" in all four tile columns.
@@ -718,6 +726,16 @@ static func map_count(id: StringName) -> int:
 ## `CheckIfInOutsideMap`: which maps write `wLastMap` on the way out of them.
 static func is_outside_tileset(tileset: int) -> bool:
 	return tileset == TILESET_OVERWORLD or tileset == TILESET_PLATEAU
+
+
+## `BIT_DUNGEON_BATTLE_TRANSITION`, which picks the stripes over the circles.
+static func is_dungeon_map(map_id: int) -> bool:
+	if DUNGEON_MAPS.has(map_id):
+		return true
+	for range_pair: Array in DUNGEON_MAP_RANGES:
+		if map_id >= int(range_pair[0]) and map_id <= int(range_pair[1]):
+			return true
+	return false
 
 
 ## `ExtraWarpCheck`: whether a warp the player is not standing on the tile of

--- a/game/render/gen2_screen.gd
+++ b/game/render/gen2_screen.gd
@@ -437,9 +437,13 @@ func _on_backdrop_source_gone() -> void:
 ## setter, so a fade that recolours the field takes the surround with it without
 ## the screen doing the fade knowing this exists.
 class Field extends ColorRect:
+	## Quantised the way a picture beside it is: a 15-bit colour kept as a float
+	## is truncated on its way into an image and rounded on its way through a
+	## ColorRect, so a surround and the screen over it can be a unit apart in one
+	## channel. `SuperPalettes`' own white is one such colour.
 	static func create(of_color: Color) -> Field:
 		var out := Field.new()
-		out.color = of_color
+		out.color = Gen2PicImage.quantized(PackedColorArray([of_color]))[0]
 		out.mouse_filter = Control.MOUSE_FILTER_IGNORE
 		out.size = Vector2(WIDTH, HEIGHT)
 		return out

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4954,12 +4954,9 @@ func _start_battle_request(request: Dictionary) -> void:
 func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	if _world == null or _data == null:
 		return null
-	## `BattleTransition` is Generation 1's own subsystem, drawn out of nothing
-	## but the tilemap: none of its four wipes is built here, so a Generation 1
-	## fight opens where Crystal's animation would start.
-	if _data.generation == RomRegistry.GEN1:
-		return null
 	var values: Dictionary = request.get("values", {})
+	if _data.generation == RomRegistry.GEN1:
+		return _build_gen1_battle_transition(values)
 	if bool(values.get("tutorial", false)):
 		return null
 	## A link battle starts from `LinkCommunications`' own screen rather than
@@ -4981,6 +4978,23 @@ func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 	)
 
 
+## `BattleTransition`'s own three bits: `GetBattleTransitionID_WildOrTrainer`,
+## `..._CompareLevels` and `..._IsDungeonMap` over `DungeonMaps1` and
+## `DungeonMaps2`. The level read is `wCurEnemyLevel`, this battle's own, where
+## Crystal reads the previous fight's `wEnemyMonLevel`.
+func _build_gen1_battle_transition(values: Dictionary) -> Gen2BattleTransition:
+	var map_id: int = _world.current_map.number if _world.current_map != null else 0
+	var index: int = 0
+	if int(values.get("trainer_class", 0)) > 0:
+		index |= Gen2BattleTransition.GEN1_TRAINER_BIT
+	if _battle_lead_level() + Gen2BattleTransition.STRONGER_MARGIN \
+		<= int(values.get("level", 0)):
+		index |= Gen2BattleTransition.GEN1_STRONGER_BIT
+	if Gen1Layout.is_dungeon_map(map_id):
+		index |= Gen2BattleTransition.GEN1_DUNGEON_BIT
+	return Gen2BattleTransition.create_gen1(index)
+
+
 ## `wBattleMonLevel` as `FindFirstAliveMonAndStartBattle` writes it in front of
 ## the transition: the first party member with HP left, not the lead.
 func _battle_lead_level() -> int:
@@ -4996,13 +5010,17 @@ func _battle_lead_level() -> int:
 
 ## `DoBattleTransition` alone, driven to [param frames] frames in, for a
 ## screenshot: the transition over the map it actually runs on, without the
-## battle behind it. [param trainer] is the branch that draws the Poke Ball and
-## floods every background tile with `PAL_BG_TEXT`.
-func preview_battle_transition(frames: int, trainer: bool = false) -> void:
-	_battle_transition = Gen2BattleTransition.create(
-		false, false, trainer, false, _encounter_random,
-		_data.battle_anim_sine() if _data != null else PackedByteArray()
-	)
+## battle behind it. A non-zero [param variant] is the trainer branch, which
+## draws the Poke Ball and floods every background tile with `PAL_BG_TEXT`; on a
+## Generation 1 cartridge it is `BattleTransitions`' own index instead, so any of
+## the four wild rows can be photographed on any map.
+func preview_battle_transition(frames: int, variant: int = 0) -> void:
+	_battle_transition = Gen2BattleTransition.create_gen1(variant) \
+		if _data != null and _data.generation == RomRegistry.GEN1 \
+		else Gen2BattleTransition.create(
+			false, false, variant != 0, false, _encounter_random,
+			_data.battle_anim_sine() if _data != null else PackedByteArray()
+		)
 	_apply_interface_mask()
 	_apply_battle_transition()
 	for _frame: int in maxi(frames, 0):

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -464,3 +464,83 @@ func test_the_generation_one_player_square_is_seven_tiles_of_its_own() -> void:
 	var head: int = Gen2BattleScreenMap.ENEMY_AT.y * Gen2BattleScreenMap.COLUMNS \
 		+ Gen2BattleScreenMap.ENEMY_AT.x
 	assert_eq(int(map[head]), Gen2BattleScreenMap.ENEMY_BASE_TILE)
+
+
+## `BattleTransitions`' four wild rows, each driven to its own end. The counts
+## are the routines' own `Delay3`s: nine frames of prologue, then 72 of
+## `BattleTransition_FlashScreen` for the two circles, then three frames a step
+## and one to go black.
+const GEN1_TRANSITION_FRAMES: Dictionary = {0: 112, 2: 142, 4: 70, 6: 64}
+
+
+func _run_gen1_transition(index: int) -> Dictionary:
+	var transition: Gen2BattleTransition = Gen2BattleTransition.create_gen1(index)
+	var frames: int = 0
+	var orders: Array[int] = []
+	var sprites: Array[int] = []
+	while transition.advance_frame() and frames < 4000:
+		frames += 1
+		if not orders.has(transition.palette_order()):
+			orders.append(transition.palette_order())
+		if not sprites.has(transition.sprites()):
+			sprites.append(transition.sprites())
+	return {
+		"frames": frames, "orders": orders, "sprites": sprites,
+		"black": _count(transition.cells(), Gen2BattleTransition.CELL_BLACK),
+		"squares": _count(transition.cells(), Gen2BattleTransition.CELL_SQUARE),
+		"order": transition.palette_order(),
+	}
+
+
+func test_every_generation_1_wipe_ends_black_in_its_own_frame_count() -> void:
+	for index: int in GEN1_TRANSITION_FRAMES:
+		var ran: Dictionary = _run_gen1_transition(index)
+		assert_eq(int(ran["frames"]), int(GEN1_TRANSITION_FRAMES[index]),
+			"row %d spends its own frames" % index)
+		assert_eq(int(ran["black"]),
+			Gen2BattleTransition.COLUMNS * Gen2BattleTransition.ROWS,
+			"BattleTransition_BlackScreen leaves nothing showing")
+		assert_eq(int(ran["squares"]), 0, "there is no square tile in Generation 1")
+		assert_eq(int(ran["order"]), Gen2BattleTransition.GEN1_BLACK_ORDER)
+
+
+## `BattleTransition_FlashScreen` is called by the two circles and by neither
+## pair of stripes.
+func test_only_the_generation_1_circles_flash_the_screen() -> void:
+	for index: int in [0, 2]:
+		assert_true((_run_gen1_transition(index)["orders"] as Array).has(0x90),
+			"row %d walks BattleTransition_FlashScreenPalettes" % index)
+	for index: int in [4, 6]:
+		assert_eq(Array(_run_gen1_transition(index)["orders"]),
+			[Gen2BattleTransition.IDENTITY, Gen2BattleTransition.GEN1_BLACK_ORDER],
+			"row %d writes rBGP once, at the end" % index)
+
+
+## The OAM clear at the top of `BattleTransition` keeps the player's block and
+## the enemy trainer's, where Generation 2 sheds them only at its outro.
+func test_a_generation_1_wipe_opens_with_the_battlers_alone() -> void:
+	assert_eq(Array(_run_gen1_transition(0)["sprites"]), [
+		Gen2BattleTransition.SPRITES_BATTLERS, Gen2BattleTransition.SPRITES_NONE,
+	])
+
+
+## `BattleTransition_Spiral`, `..._Shrink` and `..._Split` are the four trainer
+## rows, and the last two move the map's own tiles rather than blacking cells.
+func test_the_generation_1_trainer_rows_have_no_animation_yet() -> void:
+	for index: int in [1, 3, 5, 7]:
+		assert_null(Gen2BattleTransition.create_gen1(index))
+
+
+## `BattleTransition_CircleData1` to `...5` are `.wedge1` to `.wedge5` byte for
+## byte, and the two half-circle tables cover `spin_quadrants`' twenty positions.
+func test_the_two_generations_draw_one_circle() -> void:
+	var seen: Array = []
+	for entry: Array in Gen2BattleTransition.GEN1_HALF_CIRCLE_1 \
+		+ Gen2BattleTransition.GEN1_HALF_CIRCLE_2:
+		seen.append([int(entry[0]), int(entry[1]), int(entry[2]), int(entry[3])])
+	var spin: Array = []
+	for entry: Array in Gen2BattleTransition.SPIN_QUADRANTS:
+		spin.append([int(entry[0]), int(entry[1]), int(entry[2]), int(entry[3])])
+	seen.sort()
+	spin.sort()
+	assert_eq(seen, spin)

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -472,3 +472,18 @@ func test_an_effect_byte_the_table_does_not_carry_is_a_normal_hit() -> void:
 	assert_eq(Gen1Layout.move_effect(1, 0x57), 0)
 	assert_eq(Gen1Layout.move_effect(1, -1), 0)
 	assert_eq(Gen1Layout.move_power(1, 40), 40)
+
+
+## `DungeonMaps1`'s four ids and `DungeonMaps2`'s four ranges, with the maps
+## either side of a range and the ones the file says it misses.
+func test_the_dungeon_list_is_the_one_the_transition_reads() -> void:
+	for map_id: int in [0x33, 0x52, 0xC0, 0xE8, 0x3B, 0x3C, 0x3D, 0x5F, 0x76, 0x8D,
+		0x97, 0xCF, 0xE4]:
+		assert_true(Gen1Layout.is_dungeon_map(map_id), "map $%02X is a dungeon" % map_id)
+	## Pallet Town, the ids either side of two ranges, and six of the dungeons
+	## the source's own comment says the list fails to recognise: the Power
+	## Plant, Seafoam Islands B1F, Pokemon Mansion 1F, Victory Road 2F,
+	## Diglett's Cave and Silph Co 9F.
+	for map_id: int in [0x00, 0x3A, 0x3E, 0x5E, 0x77, 0x53, 0x9F, 0xA5, 0xC2,
+		0xC5, 0xE9]:
+		assert_false(Gen1Layout.is_dungeon_map(map_id), "map $%02X is not" % map_id)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 655 lines of the 38732 here, and Generation 1's colour, sprites, wild
-## tables, walk, text box, encounter roll, shop, Pokemon Center and battle added
-## 361 more to the shared battle, collision, palette, world, encounter, text,
-## save and renderer code. Four sweeps found no restatement left to pay with.
-const MAX_COMMENT_LINES: int = 38732
+## are 678 lines of the 38876 here, and Generation 1 has added 482 more to the
+## shared battle, world, palette, text, save and renderer code, 121 of them the
+## battle transition, the four split effect routines and `BlkPacket_Battle`.
+## Five sweeps have found no restatement left to pay with.
+const MAX_COMMENT_LINES: int = 38876
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_battle.gd
+++ b/tools/checks/gen1_battle.gd
@@ -3,8 +3,9 @@ extends RefCounted
 ## A Generation 1 fight, swept on Red, Blue and Yellow: the four moves every one
 ## of the 151 species is created knowing, all 165 moves used once each through
 ## the shared engine, `CriticalHitTest`'s chance over the whole base speed
-## column, and one wild battle fought to a faint. The move sweep is what the
-## effect translation is worth: an effect byte that lands on the wrong list
+## column, one wild battle fought to a faint, and the four routines Generation 1
+## keeps where Crystal's command list does something else. The move sweep is what
+## the effect translation is worth: an effect byte that lands on the wrong list
 ## either throws or stops producing events.
 
 const SPECIES_COUNT: int = 151
@@ -60,6 +61,11 @@ func _one_game() -> void:
 	_critical_chances()
 	_every_move()
 	_a_wild_fight()
+	_haze_clears_more_than_stages()
+	_a_trapping_move_holds_its_target()
+	_the_trap_counter_distribution()
+	_conversion_copies_the_target()
+	_teleport_ends_the_battle()
 
 
 ## `AddPartyMon`'s four base moves and `WriteMonMoves` over them, for every
@@ -184,3 +190,146 @@ static func _distinct(moves: Array) -> bool:
 			return false
 		seen[move] = true
 	return true
+
+
+## The moves that carry the four split effects, and the two types Pidgey has.
+const HAZE_MOVE: int = 114
+const WRAP_MOVE: int = 35
+const CONVERSION_MOVE: int = 160
+const TELEPORT_MOVE: int = 100
+const ROAR_MOVE: int = 46
+## `TYPE_NORMAL` and `TYPE_FLYING` as `type_constants.asm` numbers them.
+const PIDGEY_TYPES: Array[int] = [0, 2]
+
+## How many Wraps to roll for the counter census, and what `TrappingEffect`'s
+## two-bit draw with its reroll is worth over them: one and two continuations
+## 3/8 each, three and four 1/8 each. Compared as shares rather than counts.
+const TRAP_TURN_CAP: int = 8
+const TRAP_ROLLS: int = 4000
+const TRAP_SHARES: Array[float] = [0.375, 0.375, 0.125, 0.125]
+const TRAP_TOLERANCE: float = 0.025
+
+
+## `HazeEffect_`: both sides' stages, both sides' volatile statuses and both
+## screens, and the target's own status byte with them. Crystal's
+## `EFFECT_RESET_STATS` clears the stages and nothing else.
+func _haze_clears_more_than_stages() -> void:
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [HAZE_MOVE], SWEEP_SEED)
+	if not _r.check(battle != null, "no battle could be built for HAZE"):
+		return
+	battle.player.change_stage("attack", 2)
+	battle.enemy.change_stage("defense", -2)
+	battle.enemy.status = Gen2Status.PARALYSIS
+	battle.enemy.substatus |= Gen2Substatus.LEECH_SEED | Gen2Substatus.FOCUS_ENERGY
+	battle.player.substatus |= Gen2Substatus.MIST
+	battle.screens[Gen2Battle.PLAYER] = Gen2Screens.LIGHT_SCREEN
+	battle.take_turn(0, 0)
+	_r.check(battle.player.stage("attack") == 0, "HAZE left the user a stage")
+	_r.check(battle.enemy.stage("defense") == 0, "HAZE left the target a stage")
+	_r.check(battle.enemy.status == Gen2Status.NONE, "HAZE left the target paralysed")
+	_r.check(
+		battle.enemy.substatus & (Gen2Substatus.LEECH_SEED | Gen2Substatus.FOCUS_ENERGY) == 0,
+		"HAZE left the target seeded or pumped"
+	)
+	_r.check(
+		battle.player.substatus & Gen2Substatus.MIST == 0, "HAZE left the user misted"
+	)
+	_r.check(
+		battle.screens[Gen2Battle.PLAYER] == Gen2Screens.NONE, "HAZE left a screen up"
+	)
+
+
+## `TrappingEffect` and `.HeldInPlaceCheck`: the user repeats the move for the
+## rolled number of turns, the target never acts, and every continuation deals
+## the first hit's damage over again. `MoveHitTest.moveMissed` clears the flag,
+## so the run walks until a Wrap actually binds.
+func _a_trapping_move_holds_its_target() -> void:
+	var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [WRAP_MOVE], SWEEP_SEED)
+	if not _r.check(battle != null, "no battle could be built for WRAP"):
+		return
+	var bound: int = 0
+	var first: int = 0
+	for _turn: int in TRAP_TURN_CAP:
+		if battle.enemy.is_fainted() or battle.player.is_fainted():
+			break
+		var before: int = battle.enemy.hp
+		battle.take_turn(0, 0)
+		if battle.enemy.trapping_move == 0:
+			continue
+		bound = battle.enemy.trapped_turns
+		first = before - battle.enemy.hp
+		break
+	if not _r.check(bound > 0 and first > 0, "no WRAP bound its target"):
+		return
+
+	var held: int = 0
+	for _turn: int in bound:
+		var before: int = battle.enemy.hp
+		var events: Array = battle.take_turn(0, 0)
+		_r.check(before - battle.enemy.hp == first, "a continuation dealt %d, not %d" % [
+			before - battle.enemy.hp, first,
+		])
+		for event: Dictionary in events:
+			if StringName(event.get("type", &"")) == Gen2Battle.CANNOT_MOVE \
+				and StringName(event.get("reason", &"")) == &"held_in_place":
+				held += 1
+	_r.check(held == bound, "%d turns held over %d continuations" % [held, bound])
+	_r.check(battle.enemy.trapping_move == 0, "CheckNumAttacksLeft never let go")
+	_r.note("gen1 battle WRAP held its target for %d turns at %d HP" % [bound, first])
+
+
+## The two-bit roll with its reroll, over enough Wraps for the shares to settle.
+func _the_trap_counter_distribution() -> void:
+	var census: Array[int] = [0, 0, 0, 0]
+	var generator := RandomNumberGenerator.new()
+	generator.seed = SWEEP_SEED
+	for _roll: int in TRAP_ROLLS:
+		var turns: int = Gen2Substatus.roll_gen1_trap_turns(generator)
+		if not _r.check(turns >= 1 and turns <= 4, "a trap rolled %d turns" % turns):
+			return
+		census[turns - 1] += 1
+	for index: int in census.size():
+		var share: float = float(census[index]) / float(TRAP_ROLLS)
+		_r.check(
+			absf(share - TRAP_SHARES[index]) < TRAP_TOLERANCE,
+			"%d continuations came up %.3f, expected %.3f" % [
+				index + 1, share, TRAP_SHARES[index],
+			]
+		)
+	_r.note("gen1 battle %d trap rolls read %s" % [TRAP_ROLLS, str(census)])
+
+
+## `ConversionEffect_`: both of the target's types onto the user, where Crystal's
+## own Conversion samples the user's own moves for one.
+func _conversion_copies_the_target() -> void:
+	var battle: Gen2Battle = _fight(
+		SWEEP_LEVEL, SWEEP_LEVEL, [CONVERSION_MOVE], SWEEP_SEED
+	)
+	if not _r.check(battle != null, "no battle could be built for CONVERSION"):
+		return
+	battle.take_turn(0, 0)
+	_r.check(
+		battle.player.types() == Array(PIDGEY_TYPES),
+		"CONVERSION left the user on %s" % str(battle.player.types())
+	)
+
+
+## `SwitchAndTeleportEffect`: one routine for three moves. A wild battle ends
+## whenever the user is at least the target's level, and a trainer battle refuses
+## all three outright.
+func _teleport_ends_the_battle() -> void:
+	for move: int in [TELEPORT_MOVE, ROAR_MOVE]:
+		var battle: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED)
+		if not _r.check(battle != null, "no battle could be built for move %d" % move):
+			return
+		battle.take_turn(0, 0)
+		_r.check(battle.is_over(), "move %d did not end the wild battle" % move)
+
+		var trainer: Gen2Battle = _fight(SWEEP_LEVEL, SWEEP_LEVEL, [move], SWEEP_SEED)
+		trainer.is_trainer_battle = true
+		var events: Array = trainer.take_turn(0, 0)
+		_r.check(not trainer.is_over(), "move %d ended a trainer battle" % move)
+		var failed: bool = false
+		for event: Dictionary in events:
+			failed = failed or StringName(event.get("type", &"")) == Gen2Battle.MOVE_FAILED
+		_r.check(failed, "move %d said nothing against a trainer" % move)

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -14,6 +14,7 @@ extends SceneTree
 ## which is the pack's USE on that item.
 const KIND_HELP: Dictionary = {
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
+	&"battle_transition": "frames, index: DoBattleTransition over the map. 1 is the trainer branch; a Generation 1 cartridge reads BattleTransitions' own index, 0 the double circle, 2 the circle, 4 the horizontal stripes, 6 the vertical",
 	&"battle": "frames: the wild fight preview_battle_request starts, settled past its transition",
 	&"battle_caught": "frames: the same fight against a species the dex already holds",
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
@@ -29,6 +30,12 @@ const KIND_HELP: Dictionary = {
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
+	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
+	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
+	&"whiteout": "presses, frames: Script_Whiteout. 0 the faint line, 1 the first page of _WhitedOutText, 3 the map woken on; a second number stops that many frames into .PlayPoisonSFX instead",
+	&"elevator": "DOWN presses: the floor list bg_event 3's elevator opens, read from the cell below the panel",
+	&"start_menu": "rows down, contest: SetUpMenuItems' list. A second number of 1 runs the Bug Catching Contest and 2 has something caught",
+	&"mailbox": "rows down, A presses: the bedroom PC's MAILBOX",
 	&"magnet_train": "frames, direction: special MagnetTrain, that many frames in. Direction 1 rides to Goldenrod",
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
 	&"pet_actor_arc": "cell: the same actor mid-ledge, at the top of the arc its span names",
@@ -505,9 +512,11 @@ func _stage_catch_tutorial() -> void:
 ## `DoBattleTransition` over the map it runs on. The first of the two numbers is how
 ## many frames into it to photograph rather than a cell, since a transition is two
 ## hundred of them and every one is a different picture; the second is 1 for a
-## trainer's, which is the branch that draws the Poke Ball and floods the map.
+## trainer's, which is the branch that draws the Poke Ball and floods the map, and
+## on a Generation 1 cartridge is `BattleTransitions`' own index: 0 the double
+## circle, 2 the circle, 4 the horizontal stripes and 6 the vertical ones.
 func _stage_battle_transition() -> void:
-	_screen.preview_battle_transition(_cell.x, _cell.y != 0)
+	_screen.preview_battle_transition(_cell.x, _cell.y)
 
 
 ## One of the five fade specials over the map it runs on. The first number is the


### PR DESCRIPTION
`BattleTransition` is the same subsystem an ancestor earlier than `DoBattleTransition`, so one class draws both: `BattleTransition_CircleData1` to `...5` are the wedges Crystal spins byte for byte, the two half-circle tables cover `spin_quadrants`' twenty positions, and `BattleTransition_FlashScreenPalettes` is the same twelve orders. `Gen2BattleTransition.create_gen1` takes the three bits `GetBattleTransitionID_WildOrTrainer`, `..._CompareLevels` and `..._IsDungeonMap` set and answers with the double circle, the circle, the horizontal stripes or the vertical ones.

| Row | Animation | Frames |
|---|---|---|
| %000 | `BattleTransition_DoubleCircle` | 112 |
| %010 | `BattleTransition_Circle` | 142 |
| %100 | `BattleTransition_HorizontalStripes` | 70 |
| %110 | `BattleTransition_VerticalStripes` | 64 |

The level it measures against is `wCurEnemyLevel`, this battle's own, where Crystal reads the previous fight's `wEnemyMonLevel`. `DungeonMaps1`'s four ids and `DungeonMaps2`'s four ranges are `Gen1Layout.is_dungeon_map`, wrong in the same places the file's own comment says they are. The four trainer rows have no caller and two of them want more than a cell grid, since `BattleTransition_Shrink` and `..._Split` move the map's own tiles inward and outward rather than blacking cells.

## Four effect bytes that mean something else

`Gen2MoveEffect.GEN1_SEQUENCES` is what `sequence_for` hands out on a Generation 1 cartridge.

| Effect | Generation 1 | Crystal |
|---|---|---|
| 25 | `HazeEffect_` clears both sides' volatile statuses, Disable and both screens, cures the target's own status byte, and costs it the turn it was about to take if it was asleep or frozen | `EFFECT_RESET_STATS` clears the stages |
| 42 | `TrappingEffect` locks the user into the move and the target out of its turn | `EFFECT_TRAP_TARGET` bleeds the target a sixteenth a turn |
| 30 | `ConversionEffect_` copies both of the target's types | `EFFECT_CONVERSION` samples the user's own moves for one |
| 28 | `SwitchAndTeleportEffect` is Roar, Whirlwind and Teleport in one routine | `EFFECT_FORCE_SWITCH` drags a party member out |

The trap counter is a two-bit draw with a reroll, so one and two continuations come up 3/8 each and three and four 1/8. `.MultiturnMoveCheck` deals the first hit's damage again with no accuracy roll and no PP, `CheckNumAttacksLeft` runs at the end of the whole turn so the release turn still holds the target whichever side moves first on it, and `MoveHitTest.moveMissed` undoes the bind outright.

## The Super Game Boy packet

`BlkPacket_Battle`'s five attribute blocks are what every cell of a Generation 1 battle wears, and `Gen2BattleRenderer.gen1_screen_palette` answers `SetPal_Battle`'s four: `PAL_GREENBAR` plus each side's HP bar colour, and `DeterminePaletteID`'s row for each Pokemon. Block 1 gives rows 12 to 17 palette 2 and everything outside them palette 0, so the message box and the panels take `SuperPalettes`' own white and near-black rather than the engine's pure pair. `Gen2Screen.Field` quantises its colour the way a picture beside it does, since a 15-bit colour is truncated into an image and rounded through a `ColorRect` and the two were a unit apart.

## Proving it

| Check | Result |
|---|---|
| `validate.gd -- all` | 89 topics pass |
| GUT, unit and scene tiers | 4,353 tests, 0 failures |
| `replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | 130 steps, none failed |
| Editor analyser | 0 warnings in 628 scripts |

`tools/checks/gen1_battle.gd` walks all four routines on Red, Blue and Yellow: the statuses and screens Haze clears, one Wrap held to its release with every continuation dealing one figure, 4,000 trap rolls against the 3/8 and 1/8 shares, the pair of types Conversion copies, and both endings of the switch routine. Backing out the generation branch turns that into 25 failures.
