### PR TITLE
Animate a Generation 1 move on the battle screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, and the text box, shop inventory and wild encounter a map reads |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, and all 202 or 203 battle animations |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/battle/battle_anim_data.gd
+++ b/game/battle/battle_anim_data.gd
@@ -1,21 +1,32 @@
 class_name Gen2BattleAnimData
 extends RefCounted
 
-## The five imported battle animation tables, read the way the cartridge reads
-## them. [Gen2BattleAnimImporter] caches each table as a whole region because
-## every pointer inside one is bank-local; this resolves them, an address minus
-## the region's base being an index into its bytes, which is what `add hl, de`
-## does with the bank paged in.
+## The imported battle animation tables, read the way the cartridge reads them.
+## An importer caches a table as a whole region because every pointer inside one
+## is bank-local; this resolves them, an address minus the region's base being an
+## index into its bytes, which is what `add hl, de` does with the bank paged in.
+## Crystal gives each table a region; Generation 1 interleaves all four through
+## bank $1E, so it caches one and [method gen1_pointer] takes the table.
 
 ## `BattleAnimObjects` row fields, in the order `InitBattleAnimation` copies them.
 const OBJECT_FIELDS: Array[StringName] = [
 	&"flags", &"y_fix", &"frameset", &"function", &"palette", &"gfx",
 ]
 
+## Crystal's four regions, one table each.
+const GEN2_REGIONS: Array[StringName] = [&"scripts", &"objects", &"framesets", &"oam_sets"]
+## Generation 1's one, whose four tables are interleaved inside it.
+const GEN1_REGION: StringName = &"anims"
+## Where three of them stand in it; `AttackAnimationPointers` is its base.
+const GEN1_TABLES: Array[StringName] = [&"subanims", &"frame_blocks", &"base_coords"]
+
 var _regions: Dictionary = {}
 var _gfx: Array = []
 var _sine: PackedByteArray = PackedByteArray()
 var _profile: StringName = &"crystal"
+var _tables: Dictionary = {}
+var _special_effects: PackedInt32Array = PackedInt32Array()
+var _falling_deltas: PackedInt32Array = PackedInt32Array()
 
 
 ## Built from a cache. Returns null when the cache carries no animation layer,
@@ -23,8 +34,9 @@ var _profile: StringName = &"crystal"
 static func from_game_data(data: GameData) -> Gen2BattleAnimData:
 	if data == null:
 		return null
+	var is_gen1: bool = data.generation == RomRegistry.GEN1
 	var regions: Dictionary = {}
-	for name: StringName in [&"scripts", &"objects", &"framesets", &"oam_sets"]:
+	for name: StringName in ([GEN1_REGION] if is_gen1 else GEN2_REGIONS):
 		var region_data: Dictionary = data.battle_anim_region(name)
 		if region_data.is_empty():
 			return null
@@ -32,7 +44,15 @@ static func from_game_data(data: GameData) -> Gen2BattleAnimData:
 	var sheets: Array = []
 	for index: int in data.battle_anim_gfx_count():
 		sheets.append(data.battle_anim_gfx(index))
-	return create(regions, sheets, data.battle_anim_sine(), data.id)
+	if not is_gen1:
+		return create(regions, sheets, data.battle_anim_sine(), data.id)
+	var tables: Dictionary = {}
+	for name: StringName in GEN1_TABLES:
+		tables[name] = data.battle_anim_table(name)
+	return create_gen1(
+		regions[GEN1_REGION], sheets, tables,
+		data.battle_anim_special_effects(), data.battle_anim_falling_deltas(), data.id
+	)
 
 
 static func create(
@@ -44,6 +64,20 @@ static func create(
 	out._gfx = sheets
 	out._sine = sine
 	out._profile = profile_name
+	return out
+
+
+## The Generation 1 layer: one region, the three table addresses inside it, and
+## the two flat tables the engine reads beside them.
+static func create_gen1(
+	anims: Dictionary, sheets: Array, tables: Dictionary,
+	effects: PackedInt32Array, deltas: PackedInt32Array,
+	profile_name: StringName = &"red"
+) -> Gen2BattleAnimData:
+	var out: Gen2BattleAnimData = create({GEN1_REGION: anims}, sheets, PackedByteArray(), profile_name)
+	out._tables = tables
+	out._special_effects = effects
+	out._falling_deltas = deltas
 	return out
 
 
@@ -62,6 +96,77 @@ func sine_word(index: int) -> int:
 	if at < 0 or at + 2 > _sine.size():
 		return 0
 	return _sine[at] | (_sine[at + 1] << 8)
+
+
+## Whether this is the Generation 1 layer, which is what a reader parts on
+## rather than the profile name.
+func gen1() -> bool:
+	return _regions.has(GEN1_REGION)
+
+
+func gen1_pointer(table: StringName, index: int) -> int:
+	var at: int = int(_tables.get(table, -1))
+	return -1 if at < 0 else word_at(GEN1_REGION, at + index * Gen1Layout.POINTER_SIZE)
+
+
+## One `FrameBlockBaseCoords` row as the y and x `DrawFrameBlock` adds.
+func gen1_base_coord(index: int) -> Vector2i:
+	var at: int = int(_tables.get(&"base_coords", -1))
+	if at < 0 or index < 0 or index >= Gen1Layout.BASE_COORD_COUNT:
+		return Vector2i.ZERO
+	at += index * Gen1Layout.BASE_COORD_SIZE
+	return Vector2i(byte_at(GEN1_REGION, at + 1), byte_at(GEN1_REGION, at))
+
+
+## One `FrameBlockPointers` entry as the `dbsprite` rows behind its count byte,
+## each [code]{ y, x, tile, attributes }[/code]. `FRAMEBLOCK_00` holds none, and
+## `FrameBlock62` counts fifteen where sixteen are written, so its last is never
+## drawn: the count byte is what the cartridge reads and what this reads.
+func gen1_frame_block(index: int) -> Array:
+	var address: int = gen1_pointer(&"frame_blocks", index)
+	if address < 0 or index < 0 or index >= Gen1Layout.FRAME_BLOCK_COUNT:
+		return []
+	var out: Array = []
+	for sprite: int in byte_at(GEN1_REGION, address):
+		var at: int = address + 1 + sprite * Gen1Layout.FRAME_BLOCK_SPRITE_SIZE
+		out.append({
+			"y": byte_at(GEN1_REGION, at),
+			"x": byte_at(GEN1_REGION, at + 1),
+			"tile": byte_at(GEN1_REGION, at + 2),
+			"attributes": byte_at(GEN1_REGION, at + 3),
+		})
+	return out
+
+
+## One `SubanimationPointers` entry as [code]{ kind, rows }[/code] in
+## `PlaySubanimation`'s own order. `kind` is the header's `SUBANIMTYPE_*`, which
+## `LoadSubanimation` turns into a transform against whose turn it is.
+func gen1_subanim(index: int) -> Dictionary:
+	var address: int = gen1_pointer(&"subanims", index)
+	if address < 0 or index < 0 or index >= Gen1Layout.SUBANIM_COUNT:
+		return {}
+	var header: int = byte_at(GEN1_REGION, address)
+	var rows: Array = []
+	for row: int in header & Gen1Layout.SUBANIM_COUNT_MASK:
+		var at: int = address + 1 + row * Gen1Layout.SUBANIM_ROW_SIZE
+		rows.append({
+			"frame_block": byte_at(GEN1_REGION, at),
+			"base_coord": byte_at(GEN1_REGION, at + 1),
+			"mode": byte_at(GEN1_REGION, at + 2),
+		})
+	return {"kind": header >> Gen1Layout.SUBANIM_TYPE_SHIFT, "rows": rows}
+
+
+## One `FallingObjects_DeltaXs` entry, which the two objects that walk off the
+## nine-byte table read out of the routine behind it.
+func gen1_falling_delta(index: int) -> int:
+	return _falling_deltas[index] if index >= 0 and index < _falling_deltas.size() else 0
+
+
+## Whether `SpecialEffectPointers` names [param id]. An animation byte at or
+## above `FIRST_SE_ID` that it does not name would run off the table's end.
+func gen1_has_special_effect(id: int) -> bool:
+	return _special_effects.has(id)
 
 
 func region(name: StringName) -> Dictionary:

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -56,6 +56,21 @@ const AFTER_ANIM_ENEMY_STAT_DOWN: int = 0x110 - BATTLE_AFTERANIMS
 const AFTER_ANIM_PLAYER_DAMAGE: int = 0x112 - BATTLE_AFTERANIMS
 const AFTER_ANIM_WOBBLE: int = 0x113 - BATTLE_AFTERANIMS
 
+## A guard on the steps one frame may take: only `FRAMEBLOCKMODE_02` takes none.
+const GEN1_MAX_STEPS: int = 64
+
+## `DrawFrameBlock`'s exception: GROWL keeps the sprite buffer between blocks,
+## because `DoGrowlSpecialEffects` is what doubles the note and clears up.
+const GEN1_GROWL: int = 0x2D
+
+## `SUBANIMTYPE_HVFLIP` compares the whole byte, so anything but a bare flip,
+## an OBP1 bit included, comes out with no flags at all.
+const GEN1_HVFLIP_FLAGS: Dictionary = {
+	0x00: Gen2BattleAnimObject.OAM_YFLIP | Gen2BattleAnimObject.OAM_XFLIP,
+	Gen2BattleAnimObject.OAM_XFLIP: Gen2BattleAnimObject.OAM_YFLIP,
+	Gen2BattleAnimObject.OAM_YFLIP: Gen2BattleAnimObject.OAM_XFLIP,
+}
+
 ## The status animations `PlayOpponentBattleAnim` plays on the target, past
 ## `wFXAnimID`'s low byte and so reached by `BattleAnimRunScript`'s `.not_move`.
 ## Only these five of the block are named, the rest having no caller: `ANIM_SLP`
@@ -88,6 +103,20 @@ var _unimplemented: Dictionary = {}
 var _bg_effects: Array[Gen2BattleAnimBgEffect] = []
 ## The video state the bg effects and `BattleAnimFunc_Surf` share.
 var _background: Gen2BattleAnimBackground = null
+
+## Generation 1's own state; see [method create_gen1].
+var _gen1: bool = false
+var _gen1_at: int = 0
+var _gen1_done: bool = false
+var _gen1_delay: int = 0
+var _gen1_transform: int = Gen1Layout.SUBANIMTYPE_NORMAL
+var _gen1_rows: Array = []
+var _gen1_row: int = 0
+var _gen1_mode: int = -1
+var _gen1_write: int = 0
+var _gen1_block: int = 0
+var _gen1_steps: Array = []
+var _gen1_wait: int = 0
 
 ## `wCurItem`, read by `GetBallAnimPal` to colour a thrown ball. Nothing else
 ## asks, and a non-ball falls out of `BallColors` on its own terminator.
@@ -128,6 +157,33 @@ static func create(
 	player._script = Gen2BattleAnimScript.create(
 		region["data"], int(region["address"]), address, param, wobbles
 	)
+	return player
+
+
+## `PlayAnimation`: `battle_anim` rows, each a special effect or a subanimation
+## of frame blocks drawn straight into `wShadowOAM`. There is no `param` and no
+## wobble list, and a row's sound byte is dropped for want of an audio driver.
+static func create_gen1(
+	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool = false
+) -> Gen2BattleAnimPlayer:
+	if anim_data == null or not anim_data.gen1():
+		return null
+	var address: int = anim_data.pointer(Gen2BattleAnimData.GEN1_REGION, index)
+	if address < 0:
+		return null
+
+	var player := Gen2BattleAnimPlayer.new()
+	player._data = anim_data
+	player._anim_index = index
+	player._enemy_turn = on_enemy_turn
+	player._gen1 = true
+	player._gen1_at = address
+	player._objects.resize(MAX_OBJECTS)
+	player._tile_dict.resize(TILE_DICT_ENTRIES)
+	player._bg_effects.resize(MAX_BG_EFFECTS)
+	for slot: int in MAX_BG_EFFECTS:
+		player._bg_effects[slot] = Gen2BattleAnimBgEffect.new()
+	player._background = Gen2BattleAnimBackground.new()
 	return player
 
 
@@ -188,11 +244,11 @@ func set_first_object_y_offset(value: int) -> void:
 
 
 func finished() -> bool:
-	return _script.finished()
+	return _gen1_done if _gen1 else _script.finished()
 
 
 func failed() -> bool:
-	return _script.failed()
+	return false if _gen1 else _script.failed()
 
 
 ## The sprites the last frame put in `wShadowOAM`, each
@@ -229,15 +285,15 @@ func objects() -> Array:
 
 
 ## What this animation asked for and did not get, as
-## [code]{ "bg_effects": [id, ...], "functions": [id, ...] }[/code], each id
-## once. Empty when the animation ran whole.
+## [code]{ "bg_effects": [id, ...], "functions": [id, ...], "gen1_effects":
+## [id, ...] }[/code], each id once. Empty lists when the animation ran whole.
 func unimplemented() -> Dictionary:
-	var out: Dictionary = {"bg_effects": [], "functions": []}
+	var out: Dictionary = {"bg_effects": [], "functions": [], "gen1_effects": []}
 	for key: String in _unimplemented:
 		var parts: PackedStringArray = key.split(":")
 		(out[parts[0]] as Array).append(int(parts[1]))
-	(out["bg_effects"] as Array).sort()
-	(out["functions"] as Array).sort()
+	for kind: String in out:
+		(out[kind] as Array).sort()
 	return out
 
 
@@ -250,6 +306,8 @@ func advance_frame() -> bool:
 	if finished():
 		_finish()
 		return false
+	if _gen1:
+		return _gen1_frame()
 
 	_run_commands()
 	_execute_bg_effects()
@@ -510,3 +568,817 @@ func _finish() -> void:
 
 func _note(kind: StringName, id: int) -> void:
 	_unimplemented["%s:%d" % [kind, id]] = true
+
+
+## One frame of `PlayAnimation`: every `DelayFrames` is a countdown here, and a
+## `FRAMEBLOCKMODE_02` row takes none, so several can build one picture.
+func _gen1_frame() -> bool:
+	_frame_commands = []
+	if _gen1_wait <= 0:
+		for _step: int in GEN1_MAX_STEPS:
+			if _gen1_done or _gen1_wait > 0:
+				break
+			_gen1_step()
+	_gen1_wait = maxi(_gen1_wait - 1, 0)
+	if finished():
+		_finish()
+	return true
+
+
+func _gen1_step() -> void:
+	if not _gen1_steps.is_empty():
+		_gen1_effect_step()
+	elif _gen1_mode >= 0 or _gen1_row < _gen1_rows.size():
+		_gen1_subanim_step()
+	else:
+		_gen1_read_row()
+
+
+## One `battle_anim` row; $FF is the terminator before it is an effect id.
+func _gen1_read_row() -> void:
+	var byte: int = _gen1_byte(_gen1_at)
+	if byte == Gen1Layout.ANIM_END:
+		_gen1_done = true
+		return
+	if byte >= Gen1Layout.ANIM_FIRST_SE_ID:
+		_gen1_at += Gen1Layout.ANIM_SE_SIZE
+		_gen1_begin_effect(byte)
+		return
+	_gen1_delay = byte & Gen1Layout.ANIM_DELAY_MASK
+	var subanim: int = _gen1_byte(_gen1_at + 2)
+	_gen1_at += Gen1Layout.ANIM_SUBANIM_SIZE
+	_gen1_load_tileset(byte >> Gen1Layout.ANIM_TILESET_SHIFT)
+	_gen1_begin_subanim(subanim)
+
+
+## `LoadMoveAnimationTiles`: one sheet at `vSprites tile $31`, which every frame
+## block tile is counted from, so the window is the sheet itself.
+func _gen1_load_tileset(tileset: int) -> void:
+	var row: Dictionary = _data.gfx(tileset)
+	if row.is_empty():
+		return
+	_tiles = []
+	_tiles.resize(int(row["tiles"]))
+	for tile: int in _tiles.size():
+		_tiles[tile] = {"gfx": tileset, "tile": tile}
+
+
+## `LoadSubanimation`: the transform the header's type answers against whose
+## turn it is. `SUBANIMTYPE_REVERSE` walks the rows backwards instead.
+func _gen1_begin_subanim(index: int) -> void:
+	var subanim: Dictionary = _data.gen1_subanim(index)
+	var kind: int = int(subanim.get("kind", Gen1Layout.SUBANIMTYPE_NORMAL))
+	if kind == Gen1Layout.SUBANIMTYPE_ENEMY:
+		_gen1_transform = Gen1Layout.SUBANIMTYPE_NORMAL if _enemy_turn \
+			else Gen1Layout.SUBANIMTYPE_HFLIP
+	else:
+		_gen1_transform = kind if _enemy_turn else Gen1Layout.SUBANIMTYPE_NORMAL
+
+	_gen1_rows = subanim.get("rows", [])
+	if _gen1_transform == Gen1Layout.SUBANIMTYPE_REVERSE:
+		_gen1_rows.reverse()
+	_gen1_row = 0
+	_gen1_mode = -1
+	# `PlaySubanimation` rewinds without clearing, so a shorter block leaves
+	# the tail of a longer one.
+	_gen1_write = 0
+
+
+func _gen1_subanim_step() -> void:
+	if _gen1_mode >= 0:
+		var counter: int = _gen1_rows.size() - _gen1_row + 1
+		_gen1_end_block()
+		_gen1_steps = _gen1_block_effect_steps(counter)
+		if not _gen1_steps.is_empty():
+			return
+	if _gen1_row >= _gen1_rows.size():
+		_gen1_rows = []
+		return
+	var row: Dictionary = _gen1_rows[_gen1_row]
+	_gen1_row += 1
+	_gen1_block = _gen1_write
+	_gen1_draw_block(int(row["frame_block"]), int(row["base_coord"]))
+	_gen1_mode = int(row["mode"])
+	_gen1_wait = 0 if _gen1_mode == Gen1Layout.FRAMEBLOCKMODE_KEEP_NO_DELAY \
+		else _gen1_delay
+
+
+## After `DrawFrameBlock`'s delay: `FRAMEBLOCKMODE_04` rewinds so the next block
+## lands on this one, and GROWL keeps the buffer while rewinding to the top.
+func _gen1_end_block() -> void:
+	var mode: int = _gen1_mode
+	_gen1_mode = -1
+	if mode == Gen1Layout.FRAMEBLOCKMODE_KEEP_NO_DELAY \
+			or mode == Gen1Layout.FRAMEBLOCKMODE_KEEP:
+		return
+	if mode == Gen1Layout.FRAMEBLOCKMODE_HOLD:
+		_gen1_write = _gen1_block
+		return
+	if _anim_index != GEN1_GROWL:
+		_sprites = []
+	_gen1_write = 0
+
+
+## One frame block into `wShadowOAM`: every sum is a byte, every tile plus `$31`.
+func _gen1_draw_block(frame_block: int, base_coord: int) -> void:
+	var base: Vector2i = _data.gen1_base_coord(base_coord)
+	for sprite: Dictionary in _data.gen1_frame_block(frame_block):
+		if _gen1_write >= MAX_SPRITES:
+			return
+		var placed: Dictionary = _gen1_place(sprite, base)
+		_sprites.resize(maxi(_sprites.size(), _gen1_write + 1))
+		_sprites[_gen1_write] = placed
+		_gen1_write += 1
+
+
+## `DrawFrameBlock`'s four branches over `wSubAnimTransform`.
+func _gen1_place(sprite: Dictionary, base: Vector2i) -> Dictionary:
+	var y: int = base.y + int(sprite["y"])
+	var x: int = base.x + int(sprite["x"])
+	var flags: int = int(sprite["attributes"])
+	match _gen1_transform:
+		Gen1Layout.SUBANIMTYPE_HVFLIP:
+			y = Gen1Layout.ANIM_FLIP_Y - y
+			x = Gen1Layout.ANIM_FLIP_X - x
+			flags = GEN1_HVFLIP_FLAGS.get(flags, 0)
+		Gen1Layout.SUBANIMTYPE_HFLIP:
+			y += Gen1Layout.ANIM_HFLIP_DROP
+			x = Gen1Layout.ANIM_FLIP_X - x
+			flags ^= Gen2BattleAnimObject.OAM_XFLIP
+		Gen1Layout.SUBANIMTYPE_COORDFLIP:
+			y = Gen1Layout.ANIM_FLIP_Y - base.y + int(sprite["y"])
+			x = Gen1Layout.ANIM_FLIP_X - base.x + int(sprite["x"])
+	return {
+		"y": y & 0xFF,
+		"x": x & 0xFF,
+		"tile": (int(sprite["tile"]) + Gen1Layout.ANIM_BASE_TILE) & 0xFF,
+		"attributes": flags & 0xFF,
+	}
+
+
+func _gen1_byte(address: int) -> int:
+	return _data.byte_at(Gen2BattleAnimData.GEN1_REGION, address)
+
+
+## `DoSpecialEffect`: the routine `SpecialEffectPointers` names, as a list of
+## [code]{ frames, ... }[/code] steps whose other keys are [constant
+## GEN1_EFFECT_KEYS]. An id with no list is reported and costs no frames.
+func _gen1_begin_effect(id: int) -> void:
+	_gen1_steps = _gen1_effect_steps(id)
+	if _gen1_steps.is_empty():
+		_note(&"gen1_effects", id)
+
+
+func _gen1_effect_step() -> void:
+	var step: Dictionary = _gen1_steps.pop_front()
+	for key: StringName in GEN1_EFFECT_KEYS:
+		if step.has(key):
+			_gen1_apply(key, step[key])
+	_gen1_wait = int(step.get(&"frames", 0))
+
+
+## One step's effect. `visible`, `shift` and `scale` name a side the way
+## `CallWithTurnFlipped` does: whether it is the animation's actor.
+func _gen1_apply(key: StringName, value: Variant) -> void:
+	match key:
+		&"bgp":
+			_background.bgp = int(value)
+			_background.request_pals()
+		&"scx":
+			_background.scx = int(value) & 0xFF
+		&"scy":
+			_background.scy = int(value) & 0xFF
+		&"end_subanim":
+			_gen1_row = _gen1_rows.size()
+		&"copy_sprites":
+			_gen1_copy_sprites(int(value))
+		&"visible":
+			var side: Array = value
+			_background.report_battler(_gen1_side(bool(side[0])), bool(side[1]))
+		&"shift":
+			var moved: Array = value
+			_background.battler_shift[_gen1_side(bool(moved[0]))] = moved[1] as Vector2
+		&"scale":
+			var sized: Array = value
+			_background.battler_scale[_gen1_side(bool(sized[0]))] = float(sized[1])
+		&"substitute":
+			_gen1_command(Gen2BattleAnimScript.RAISE_SUB)
+		&"minimize":
+			# `anim_minimizeopp` puts the dot on `hBattleTurn`'s own picture.
+			_gen1_command(Gen2BattleAnimScript.MINIMIZE_OPP)
+		&"wavy":
+			_gen1_wavy_screen(int(value))
+		&"rows":
+			_gen1_shake_rows(int(value))
+		&"tileset":
+			_gen1_load_tileset(int(value))
+		&"sprites":
+			_sprites = (value as Array).duplicate()
+			_gen1_write = _sprites.size()
+
+
+func _gen1_side(flipped: bool) -> bool:
+	return _enemy_turn if flipped else not _enemy_turn
+
+
+func _gen1_command(name: StringName) -> void:
+	_frame_commands.append({"name": name, "byte": 0, "operands": []})
+
+
+## `WavyScreenLineOffsets` under `rSCX`, rotated one entry a frame. A phase
+## below zero puts the scanline table back.
+func _gen1_wavy_screen(phase: int) -> void:
+	if phase < 0:
+		_background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_OFF
+		_background.set_ly_overrides(0)
+		return
+	_background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCX
+	for line: int in Gen2BattleAnimBackground.SCREEN_LINES:
+		var at: int = (line + phase) % GEN1_WAVY_OFFSETS.size()
+		_background.ly_overrides_backup[line] = GEN1_WAVY_OFFSETS[at] & 0xFF
+	_background.push_ly_overrides()
+
+
+## `CallWithTurnFlipped`: five routines are another one run on the other side.
+const GEN1_EFFECT_FLIPPED: Dictionary = {
+	0xDB: 0xF4,  # SE_SLIDE_ENEMY_MON_OFF -> SE_SLIDE_MON_OFF
+	0xDC: 0xDD,  # SE_SHOW_ENEMY_MON_PIC -> SE_SHOW_MON_PIC
+	0xDE: 0xF3,  # SE_BLINK_ENEMY_MON -> SE_BLINK_MON
+	0xDF: 0xEF,  # SE_HIDE_ENEMY_MON_PIC -> SE_HIDE_MON_PIC
+	0xE0: 0xF5,  # SE_FLASH_ENEMY_MON_PIC -> SE_FLASH_MON_PIC
+}
+
+## `SetAnimationBGPalette`'s four callers and the Super Game Boy byte each loads.
+const GEN1_EFFECT_BGP: Dictionary = {
+	0xFD: 0x6F,  # SE_DARK_SCREEN_PALETTE
+	0xFC: 0xE4,  # SE_RESET_SCREEN_PALETTE
+	0xF9: 0xF4,  # SE_DARKEN_MON_PALETTE
+	0xF0: 0x90,  # SE_LIGHT_SCREEN_PALETTE
+}
+
+## The routines that walk a picture off its square, as
+## [code][steps, pixels, frames, horizontal, hide][/code]. A horizontal slide
+## goes towards the edge the picture stands against.
+const GEN1_EFFECT_SLIDES: Dictionary = {
+	0xF7: [7, 8, 2, false, false],  # SE_SLIDE_MON_UP
+	GEN1_SE_SLIDE_MON_DOWN: [7, 8, 3, false, true],
+	0xF4: [8, 8, 3, true, true],    # SE_SLIDE_MON_OFF
+	0xE5: [4, 8, 4, true, false],   # SE_SLIDE_MON_HALF_OFF
+	0xE9: [2, 8, 8, false, true],   # SE_SLIDE_MON_DOWN_AND_HIDE
+}
+
+const GEN1_SE_SLIDE_MON_DOWN: int = 0xF6
+const GEN1_SE_DARK_SCREEN_FLASH: int = 0xFE
+const GEN1_SE_SHAKE_SCREEN: int = 0xFB
+const GEN1_SE_FLASH_SCREEN_LONG: int = 0xF8
+const GEN1_SE_FLASH_MON_PIC: int = 0xF5
+const GEN1_SE_BLINK_MON: int = 0xF3
+const GEN1_SE_MOVE_MON_HORIZONTALLY: int = 0xF2
+const GEN1_SE_RESET_MON_POSITION: int = 0xF1
+const GEN1_SE_HIDE_MON_PIC: int = 0xEF
+const GEN1_SE_SQUISH_MON_PIC: int = 0xEE
+const GEN1_SE_MINIMIZE_MON: int = 0xEA
+const GEN1_SE_DELAY_ANIMATION_10: int = 0xE1
+const GEN1_SE_SHOW_MON_PIC: int = 0xDD
+const GEN1_SE_SHAKE_BACK_AND_FORTH: int = 0xDA
+const GEN1_SE_SUBSTITUTE_MON: int = 0xD9
+const GEN1_SE_WAVY_SCREEN: int = 0xD8
+
+## What one step of an effect may write. `frames` is every step's own duration.
+const GEN1_EFFECT_KEYS: Array[StringName] = [
+	&"tileset", &"bgp", &"scx", &"scy", &"visible", &"shift", &"scale",
+	&"substitute", &"minimize", &"wavy", &"rows", &"sprites", &"copy_sprites",
+	&"end_subanim",
+]
+
+## `%00011011`, `AnimationFlashScreen`'s inverted palette, and the white it
+## follows it with. Two frames each, then the palette that was there.
+const GEN1_FLASH_INVERTED: int = 0x1B
+const GEN1_FLASH_FRAMES: int = 2
+
+## `FlashScreenLongSGB`, the twelve `rBGP` bytes `AnimationFlashScreenLong`
+## cycles three times. `FlashScreenLongDelay` spends 2 frames on the first cycle
+## and 1 on the other two.
+const GEN1_FLASH_LONG_PALETTES: Array[int] = [
+	0x2F, 0x3F, 0xFF, 0x3F, 0x2F, 0x1B, 0x06, 0x01, 0x00, 0x01, 0x06, 0x1B,
+]
+const GEN1_FLASH_LONG_FRAMES: Array[int] = [2, 1, 1]
+
+## `PredefShakeScreenHorizontally` with `b = 8`: the window out by the count for
+## five frames and back for four, the count dropping. `rWX` right is scroll left.
+const GEN1_SHAKE_AMPLITUDE: int = 8
+const GEN1_SHAKE_OUT_FRAMES: int = 5
+const GEN1_SHAKE_BACK_FRAMES: int = 4
+const GEN1_SHAKE_ONE_OUT: int = 4
+const GEN1_SHAKE_ONE_BACK: int = 3
+
+## `AnimationBlinkMon`: six times off and on, five frames each.
+const GEN1_BLINK_CYCLES: int = 6
+const GEN1_BLINK_FRAMES: int = 5
+
+## `AnimationShakeBackAndForth`: sixteen times a tile each way, three frames a
+## side, and the picture cleared rather than drawn back.
+const GEN1_SHAKE_MON_CYCLES: int = 0x10
+const GEN1_SHAKE_MON_FRAMES: int = 3
+
+## `AnimationSquishMonPic`: four passes of a squeeze each way, three frames each,
+## then hidden. The squeeze is horizontal and `battler_scale` is one number for a
+## square, so it is drawn as a shrink.
+const GEN1_SQUISH_PASSES: int = 4
+const GEN1_SQUISH_FRAMES: int = 3
+
+## `AnimationMoveMonHorizontally`: one tile towards the other side, three frames.
+const GEN1_MOVE_FRAMES: int = 3
+
+const GEN1_DELAY_FRAMES: int = 10
+
+## `WavyScreenLineOffsets`, rotated one entry per frame for 255 of them.
+const GEN1_WAVY_OFFSETS: Array[int] = [
+	0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 1, 1, 1,
+	0, 0, 0, 0, 0, -1, -1, -1, -2, -2, -2, -2, -2, -1, -1, -1,
+]
+const GEN1_WAVY_FRAMES: int = 0xFF
+
+const GEN1_TILE: int = 8
+
+## `AnimationIdSpecialEffects`' flashing rows, as how often each flashes.
+const GEN1_FLASH_EVERY_FOUR: int = 4
+const GEN1_BLOCK_FLASH: Dictionary = {
+	0x05: 1,  # MEGA_PUNCH
+	0x0C: 1,  # GUILLOTINE
+	0x19: 1,  # MEGA_KICK
+	0x1D: 1,  # HEADBUTT
+	0x32: 1,  # DISABLE
+	0x3D: 1,  # BUBBLEBEAM
+	0x73: 1,  # REFLECT
+	0x93: 1,  # SPORE
+	0x3F: GEN1_FLASH_EVERY_FOUR,  # HYPER_BEAM
+	0x55: 8,  # THUNDERBOLT
+}
+const GEN1_TAIL_WHIP: int = 0x27
+const GEN1_BLIZZARD: int = 0x3B
+const GEN1_SELFDESTRUCT: int = 0x78
+const GEN1_EXPLOSION: int = 0x99
+const GEN1_ROCK_SLIDE: int = 0x9D
+
+const GEN1_TAIL_WHIP_FRAMES: int = 20
+const GEN1_GROWL_NOTE_SPRITES: int = 4
+const GEN1_BLIZZARD_FLASHES: Array[int] = [13, 9, 5, 1]
+const GEN1_ROCK_SLIDE_QUIET: int = 12
+const GEN1_ROCK_SLIDE_SHAKE: int = 8
+## `PredefShakeScreenHorizontally` and `..._Vertically` with `b = 1`.
+
+const GEN1_SE_WATER_DROPLETS: int = 0xFA
+const GEN1_SE_SHOOT_BALLS_UPWARD: int = 0xED
+const GEN1_SE_SHOOT_MANY_BALLS_UPWARD: int = 0xEC
+const GEN1_SE_BOUNCE_UP_AND_DOWN: int = 0xEB
+const GEN1_SE_TRANSFORM_MON: int = 0xE8
+const GEN1_SE_LEAVES_FALLING: int = 0xE7
+const GEN1_SE_PETALS_FALLING: int = 0xE6
+const GEN1_SE_SHAKE_ENEMY_HUD: int = 0xE4
+const GEN1_SE_SHAKE_ENEMY_HUD_2: int = 0xE3
+const GEN1_SE_SPIRAL_BALLS_INWARD: int = 0xE2
+
+## What the object routines write into OAM: a window tile id already.
+const GEN1_BALL_TILE: int = 0x7A
+const GEN1_DROPLET_TILE: int = 0x71
+const GEN1_LEAF_TILE: int = 0x37
+
+## `SpiralBallAnimationCoordinates` as `(x, y)`: three rows hold the three balls
+## and the window walks one row every five frames.
+const GEN1_SPIRAL_COORDS: Array[Vector2i] = [
+	Vector2i(0x28, 0x38), Vector2i(0x18, 0x40), Vector2i(0x10, 0x50),
+	Vector2i(0x18, 0x60), Vector2i(0x28, 0x68), Vector2i(0x38, 0x60),
+	Vector2i(0x40, 0x50), Vector2i(0x38, 0x40), Vector2i(0x28, 0x40),
+	Vector2i(0x1E, 0x46), Vector2i(0x18, 0x50), Vector2i(0x1E, 0x5B),
+	Vector2i(0x28, 0x60), Vector2i(0x32, 0x5B), Vector2i(0x38, 0x50),
+	Vector2i(0x32, 0x46), Vector2i(0x28, 0x48), Vector2i(0x20, 0x50),
+	Vector2i(0x28, 0x58), Vector2i(0x30, 0x50), Vector2i(0x28, 0x50),
+]
+const GEN1_SPIRAL_BALLS: int = 3
+const GEN1_SPIRAL_FRAMES: int = 5
+## `wSpiralBallsBaseX` and `..._BaseY` on the enemy's turn; the player's are 0.
+const GEN1_SPIRAL_ENEMY_BASE: Vector2i = Vector2i(80, -40)
+
+## `_AnimationShootBallsUpward`, by whether the square is the player's.
+const GEN1_PILLAR_BASE: Dictionary = {true: Vector2i(5 * 8, 6 * 8), false: Vector2i(16 * 8, 0)}
+const GEN1_PILLAR_BALLS: int = 5
+const GEN1_BALL_RISE: int = 4
+
+## `UpwardBallsAnimXCoordinates*`, the row they stand on and a pillar's balls.
+const GEN1_MANY_PILLAR_X: Dictionary = {
+	true: [0x10, 0x40, 0x28, 0x18, 0x38, 0x30],
+	false: [0x60, 0x90, 0x78, 0x68, 0x88, 0x80],
+}
+const GEN1_MANY_PILLAR_Y: Dictionary = {true: 0x50, false: 0x28}
+const GEN1_MANY_PILLAR_BALLS: int = 4
+
+## `FallingObjects_InitialXCoords` and `..._InitialMovementData`, laid out for
+## twenty whether three or twenty fall. The deltas themselves are imported.
+const GEN1_FALLING_X: Array[int] = [
+	0x38, 0x40, 0x50, 0x60, 0x70, 0x88, 0x90, 0x56, 0x67, 0x4A,
+	0x77, 0x84, 0x98, 0x32, 0x22, 0x5C, 0x6C, 0x7D, 0x8E, 0x99,
+]
+const GEN1_FALLING_MOVEMENT: Array[int] = [
+	0x00, 0x84, 0x06, 0x81, 0x02, 0x88, 0x01, 0x83, 0x05, 0x89,
+	0x09, 0x80, 0x07, 0x87, 0x03, 0x82, 0x04, 0x85, 0x08, 0x86,
+]
+const GEN1_FALLING_FRAMES: int = 3
+## Where an object leaves the screen, parks, and ends the effect by reaching.
+const GEN1_FALLING_LIMIT: int = 112
+const GEN1_FALLING_OFF: int = 144 + 16
+const GEN1_FALLING_END: int = 104
+const GEN1_PETALS: int = 20
+const GEN1_LEAVES: int = 3
+
+## `_AnimationWaterDroplets`: an x off the left edge, stepping 27 and wrapping
+## by 168, walked down sixteen rows at a time.
+const GEN1_DROPLET_FIRST_X: int = -16
+const GEN1_DROPLET_STEP: int = 27
+const GEN1_DROPLET_WRAP_X: int = 144
+const GEN1_DROPLET_SPAN: int = 168
+const GEN1_DROPLET_ROWS: Array[int] = [16, 24]
+const GEN1_DROPLET_ROW_STEP: int = 16
+const GEN1_DROPLET_LAST_ROW: int = 112
+const GEN1_DROPLET_PASSES: int = 32
+
+const GEN1_BOUNCE_CYCLES: int = 5
+
+## `ShakeEnemyHUD_ShakeBG`'s `lb de, 2, 8` and where its window opens.
+const GEN1_HUD_SHAKE_AMPLITUDE: int = 2
+const GEN1_HUD_SHAKE_CYCLES: int = 8
+const GEN1_HUD_SHAKE_FRAMES: int = 2
+const GEN1_HUD_SHAKE_LINES: int = 7 * 8
+
+
+## The frames one `SpecialEffectPointers` routine spends: a palette byte or a
+## walk off a square out of the tables above, and the rest named here.
+func _gen1_effect_steps(id: int) -> Array:
+	var flipped: bool = GEN1_EFFECT_FLIPPED.has(id)
+	var effect: int = int(GEN1_EFFECT_FLIPPED[id]) if flipped else id
+	if GEN1_EFFECT_BGP.has(effect):
+		return [{&"bgp": int(GEN1_EFFECT_BGP[effect])}]
+	if GEN1_EFFECT_SLIDES.has(effect):
+		return _gen1_slide_steps(GEN1_EFFECT_SLIDES[effect], flipped)
+	match effect:
+		GEN1_SE_DARK_SCREEN_FLASH:
+			return [
+				{&"frames": GEN1_FLASH_FRAMES, &"bgp": GEN1_FLASH_INVERTED},
+				{&"frames": GEN1_FLASH_FRAMES, &"bgp": 0},
+				{&"bgp": _background.bgp},
+			]
+		GEN1_SE_FLASH_SCREEN_LONG:
+			return _gen1_flash_long_steps()
+		GEN1_SE_SHAKE_SCREEN:
+			return _gen1_shake_screen_steps()
+		GEN1_SE_DELAY_ANIMATION_10:
+			return [{&"frames": GEN1_DELAY_FRAMES}]
+		GEN1_SE_WAVY_SCREEN:
+			return _gen1_wavy_steps()
+		GEN1_SE_SPIRAL_BALLS_INWARD:
+			return _gen1_spiral_steps(flipped)
+		GEN1_SE_SHOOT_BALLS_UPWARD:
+			return _gen1_upward_steps(flipped, false)
+		GEN1_SE_SHOOT_MANY_BALLS_UPWARD:
+			return _gen1_upward_steps(flipped, true)
+		GEN1_SE_PETALS_FALLING:
+			return _gen1_falling_steps(GEN1_DROPLET_TILE, GEN1_PETALS)
+		GEN1_SE_LEAVES_FALLING:
+			return _gen1_falling_steps(GEN1_LEAF_TILE, GEN1_LEAVES)
+		GEN1_SE_WATER_DROPLETS:
+			return _gen1_droplet_steps()
+		GEN1_SE_SHAKE_ENEMY_HUD, GEN1_SE_SHAKE_ENEMY_HUD_2:
+			return _gen1_hud_shake_steps()
+	return _gen1_mon_effect_steps(effect, flipped)
+
+
+## The routines that only move, hide or show one square's picture.
+## `SE_FLASH_MON_PIC` and `SE_TRANSFORM_MON` are `ChangeMonPic` with a species
+## the square already shows by then, so both redraw rather than being a gap.
+func _gen1_mon_effect_steps(effect: int, flipped: bool) -> Array:
+	match effect:
+		GEN1_SE_HIDE_MON_PIC:
+			return [{&"visible": [flipped, false]}]
+		GEN1_SE_SHOW_MON_PIC, GEN1_SE_FLASH_MON_PIC, GEN1_SE_TRANSFORM_MON:
+			return [{&"visible": [flipped, true]}]
+		GEN1_SE_BOUNCE_UP_AND_DOWN:
+			return _gen1_bounce_steps(flipped)
+		GEN1_SE_RESET_MON_POSITION:
+			return [{&"visible": [flipped, true], &"shift": [flipped, Vector2.ZERO]}]
+		GEN1_SE_MOVE_MON_HORIZONTALLY:
+			return [{
+				&"frames": GEN1_MOVE_FRAMES,
+				&"shift": [flipped, Vector2(-_gen1_edge(flipped) * GEN1_TILE, 0.0)],
+			}]
+		GEN1_SE_BLINK_MON:
+			return _gen1_blink_steps(flipped)
+		GEN1_SE_SHAKE_BACK_AND_FORTH:
+			return _gen1_shake_mon_steps(flipped)
+		GEN1_SE_SQUISH_MON_PIC:
+			return _gen1_squish_steps(flipped)
+		GEN1_SE_MINIMIZE_MON:
+			return [{&"minimize": true}]
+		GEN1_SE_SUBSTITUTE_MON:
+			return [{&"substitute": true}]
+	return []
+
+
+## Which edge a picture leaves by: the back pic's left, the front pic's right.
+func _gen1_edge(flipped: bool) -> float:
+	return -1.0 if _gen1_side(flipped) else 1.0
+
+
+func _gen1_slide_steps(slide: Array, flipped: bool) -> Array:
+	var horizontal: bool = bool(slide[3])
+	var step: float = float(int(slide[1])) * (_gen1_edge(flipped) if horizontal else 1.0)
+	var out: Array = []
+	for index: int in int(slide[0]):
+		var moved: float = step * float(index + 1)
+		out.append({
+			&"frames": int(slide[2]),
+			&"shift": [flipped, Vector2(moved, 0.0) if horizontal else Vector2(0.0, moved)],
+		})
+	if bool(slide[4]):
+		out.append({&"visible": [flipped, false]})
+	return out
+
+
+func _gen1_flash_long_steps() -> Array:
+	var out: Array = []
+	for cycle: int in GEN1_FLASH_LONG_FRAMES.size():
+		for value: int in GEN1_FLASH_LONG_PALETTES:
+			out.append({&"frames": GEN1_FLASH_LONG_FRAMES[cycle], &"bgp": value})
+	out.append({&"bgp": Gen2BattleAnimBackground.PALETTE_IDENTITY})
+	return out
+
+
+func _gen1_shake_screen_steps() -> Array:
+	var out: Array = []
+	for amplitude: int in range(GEN1_SHAKE_AMPLITUDE, 0, -1):
+		out.append({&"frames": GEN1_SHAKE_OUT_FRAMES, &"scx": -amplitude})
+		out.append({&"frames": GEN1_SHAKE_BACK_FRAMES, &"scx": 0})
+	return out
+
+
+func _gen1_blink_steps(flipped: bool) -> Array:
+	var out: Array = []
+	for _cycle: int in GEN1_BLINK_CYCLES:
+		out.append({&"frames": GEN1_BLINK_FRAMES, &"visible": [flipped, false]})
+		out.append({&"frames": GEN1_BLINK_FRAMES, &"visible": [flipped, true]})
+	return out
+
+
+func _gen1_shake_mon_steps(flipped: bool) -> Array:
+	var out: Array = []
+	for _cycle: int in GEN1_SHAKE_MON_CYCLES:
+		for side: int in [-GEN1_TILE, GEN1_TILE]:
+			out.append({
+				&"frames": GEN1_SHAKE_MON_FRAMES,
+				&"shift": [flipped, Vector2(float(side), 0.0)],
+			})
+	out.append({&"visible": [flipped, false], &"shift": [flipped, Vector2.ZERO]})
+	return out
+
+
+func _gen1_squish_steps(flipped: bool) -> Array:
+	var out: Array = []
+	var passes: int = GEN1_SQUISH_PASSES * 2
+	for index: int in passes:
+		out.append({
+			&"frames": GEN1_SQUISH_FRAMES,
+			&"scale": [flipped, float(passes - index - 1) / float(passes)],
+		})
+	out.append({&"visible": [flipped, false], &"scale": [flipped, 1.0]})
+	return out
+
+
+func _gen1_wavy_steps() -> Array:
+	var out: Array = []
+	for frame: int in GEN1_WAVY_FRAMES:
+		out.append({&"frames": 1, &"wavy": frame})
+	out.append({&"wavy": -1})
+	return out
+
+
+## `ShakeEnemyHUD_ShakeBG`: `hSCX` over the rows above the window, so only the
+## enemy panel and its picture move. The back pic is OAM there and stays still,
+## where here it is background and its top two rows shake with them.
+func _gen1_shake_rows(offset: int) -> void:
+	_background.lcdc_pointer = Gen2BattleAnimBackground.LCDC_SCX
+	for line: int in Gen2BattleAnimBackground.SCREEN_LINES:
+		_background.ly_overrides_backup[line] = \
+			offset & 0xFF if line < GEN1_HUD_SHAKE_LINES else 0
+	_background.push_ly_overrides()
+
+
+## `AnimationSpiralBallsInward`: three balls along the coordinates, then a frame
+## more of them, a clear and a flash.
+func _gen1_spiral_steps(flipped: bool) -> Array:
+	var base: Vector2i = Vector2i.ZERO if _gen1_side(flipped) \
+		else GEN1_SPIRAL_ENEMY_BASE
+	var out: Array = [{&"tileset": 0}]
+	var pairs: int = GEN1_SPIRAL_COORDS.size()
+	for step: int in pairs - GEN1_SPIRAL_BALLS + 1:
+		out.append({
+			&"frames": GEN1_SPIRAL_FRAMES,
+			&"sprites": _gen1_balls(base, step, GEN1_SPIRAL_BALLS),
+		})
+	out.append({&"frames": 1, &"sprites": _gen1_balls(base, pairs - 2, 2) \
+		+ [_gen1_ball(base, pairs - 1)]})
+	out.append({&"sprites": []})
+	out.append_array(_gen1_effect_steps(GEN1_SE_DARK_SCREEN_FLASH))
+	return out
+
+
+func _gen1_balls(base: Vector2i, from: int, count: int) -> Array:
+	var out: Array = []
+	for index: int in count:
+		out.append(_gen1_ball(base, from + index))
+	return out
+
+
+func _gen1_ball(base: Vector2i, index: int) -> Dictionary:
+	var at: Vector2i = GEN1_SPIRAL_COORDS[mini(index, GEN1_SPIRAL_COORDS.size() - 1)]
+	return {
+		"y": (base.y + at.y) & 0xFF, "x": (base.x + at.x) & 0xFF,
+		"tile": GEN1_BALL_TILE, "attributes": 0,
+	}
+
+
+## `_AnimationShootBallsUpward`: balls rising four pixels a frame, each taken
+## off as it reaches the top.
+func _gen1_pillar_steps(base: Vector2i, balls: int) -> Array:
+	var out: Array = []
+	var rows: Array[int] = []
+	for index: int in balls:
+		rows.append((base.y + GEN1_TILE * (index + 1)) & 0xFF)
+	out.append({&"frames": 1, &"sprites": _gen1_pillar(base.x, rows)})
+	var live: int = balls
+	while live > 0:
+		for index: int in balls:
+			if rows[index] == ((base.y + GEN1_TILE) & 0xFF):
+				rows[index] = 0
+				live -= 1
+			elif rows[index] != 0:
+				rows[index] = (rows[index] - GEN1_BALL_RISE) & 0xFF
+		out.append({&"frames": 1, &"sprites": _gen1_pillar(base.x, rows)})
+	return out
+
+
+func _gen1_pillar(x: int, rows: Array[int]) -> Array:
+	var out: Array = []
+	for row: int in rows:
+		out.append({"y": row, "x": x, "tile": GEN1_BALL_TILE, "attributes": 0})
+	return out
+
+
+func _gen1_upward_steps(flipped: bool, many: bool) -> Array:
+	var player: bool = _gen1_side(flipped)
+	var out: Array = [{&"tileset": 0}]
+	if not many:
+		var base: Vector2i = GEN1_PILLAR_BASE[player]
+		out.append_array(_gen1_pillar_steps(base, GEN1_PILLAR_BALLS))
+	else:
+		var y: int = GEN1_MANY_PILLAR_Y[player]
+		for x: int in GEN1_MANY_PILLAR_X[player]:
+			out.append_array(_gen1_pillar_steps(Vector2i(x, y), GEN1_MANY_PILLAR_BALLS))
+	out.append({&"frames": 1})
+	out.append({&"sprites": []})
+	return out
+
+
+## `AnimationFallingObjects`: objects down two pixels every three frames,
+## drifting through `FallingObjects_DeltaXs`, until the first reaches 104.
+func _gen1_falling_steps(tile: int, count: int) -> Array:
+	var out: Array = [{&"tileset": 1}]
+	var rows: Array[int] = []
+	var columns: Array[int] = []
+	var movement: Array[int] = []
+	for index: int in count:
+		rows.append(0 if index == 0 else GEN1_TILE * (index + 1))
+		columns.append(GEN1_FALLING_X[index])
+		movement.append(GEN1_FALLING_MOVEMENT[index])
+	var frame: Array = []
+	while rows[0] != GEN1_FALLING_END:
+		frame = []
+		for index: int in count:
+			movement[index] = _gen1_next_movement(movement[index])
+			var step: int = _data.gen1_falling_delta(movement[index] & 0x7F)
+			var left: bool = (movement[index] & 0x80) != 0
+			rows[index] = rows[index] + 2 if rows[index] + 2 < GEN1_FALLING_LIMIT \
+				else GEN1_FALLING_OFF
+			columns[index] = (columns[index] - step if left else columns[index] + step) & 0xFF
+			frame.append({
+				"y": rows[index], "x": columns[index], "tile": tile,
+				"attributes": Gen2BattleAnimObject.OAM_XFLIP if left else 0,
+			})
+		out.append({&"frames": GEN1_FALLING_FRAMES, &"sprites": frame})
+	return out
+
+
+## `FallingObjects_UpdateMovementByte`: the list's end turns the object round.
+func _gen1_next_movement(byte: int) -> int:
+	var next: int = (byte + 1) & 0xFF
+	if (next & 0x7F) != Gen1Layout.FALLING_DELTA_TABLE:
+		return next
+	return (next & 0x80) ^ 0x80
+
+
+## `AnimationWaterDropletsEverywhere`: a drizzle whose x carries between passes,
+## shown a frame and cleared a frame, sixty-four times over.
+func _gen1_droplet_steps() -> Array:
+	var out: Array = [{&"tileset": 0}]
+	var x: int = GEN1_DROPLET_FIRST_X
+	for _pass: int in GEN1_DROPLET_PASSES:
+		for y: int in GEN1_DROPLET_ROWS:
+			var grid: Array = []
+			var row: int = y
+			while true:
+				x = (x + GEN1_DROPLET_STEP) & 0xFF
+				grid.append({
+					"y": row, "x": x, "tile": GEN1_DROPLET_TILE, "attributes": 0,
+				})
+				if x < GEN1_DROPLET_WRAP_X:
+					continue
+				x = (x - GEN1_DROPLET_SPAN) & 0xFF
+				row += GEN1_DROPLET_ROW_STEP
+				if row >= GEN1_DROPLET_LAST_ROW:
+					break
+			out.append({&"frames": 1, &"sprites": grid})
+			out.append({&"frames": 1, &"sprites": []})
+	return out
+
+
+## `AnimationBoundUpAndDown`: five slides down, the picture back after them.
+func _gen1_bounce_steps(flipped: bool) -> Array:
+	var out: Array = []
+	for _cycle: int in GEN1_BOUNCE_CYCLES:
+		out.append_array(_gen1_slide_steps(GEN1_EFFECT_SLIDES[GEN1_SE_SLIDE_MON_DOWN], flipped))
+	out.append({&"visible": [flipped, true], &"shift": [flipped, Vector2.ZERO]})
+	return out
+
+
+func _gen1_hud_shake_steps() -> Array:
+	var out: Array = []
+	for _cycle: int in GEN1_HUD_SHAKE_CYCLES:
+		out.append({&"frames": GEN1_HUD_SHAKE_FRAMES, &"rows": GEN1_HUD_SHAKE_AMPLITUDE})
+		out.append({&"frames": GEN1_HUD_SHAKE_FRAMES, &"rows": -GEN1_HUD_SHAKE_AMPLITUDE})
+	out.append({&"rows": 0})
+	return out
+
+
+## `DoSpecialEffectByAnimationId`, after every frame block of the twenty-five
+## `AnimationIdSpecialEffects` names. [param counter] is `wSubAnimCounter`, which
+## opens at the row count. The trade and ball rows wait for a caller.
+func _gen1_block_effect_steps(counter: int) -> Array:
+	var id: int = _anim_index + 1
+	if GEN1_BLOCK_FLASH.has(id):
+		return _gen1_flash_when(counter % int(GEN1_BLOCK_FLASH[id]) == 0)
+	match id:
+		GEN1_TAIL_WHIP:
+			return [{&"frames": GEN1_TAIL_WHIP_FRAMES, &"end_subanim": true}]
+		GEN1_GROWL:
+			# The note doubles into the four slots behind it, which is why
+			# `DrawFrameBlock` keeps GROWL's buffer between blocks.
+			if counter > 1:
+				return [{&"copy_sprites": GEN1_GROWL_NOTE_SPRITES}]
+			return [{&"frames": 1}, {&"sprites": []}]
+		GEN1_BLIZZARD:
+			return _gen1_flash_when(GEN1_BLIZZARD_FLASHES.has(counter))
+		GEN1_SELFDESTRUCT, GEN1_EXPLOSION:
+			if counter == 1:
+				return [{&"visible": [false, false]}]
+			return _gen1_flash_when(counter % GEN1_FLASH_EVERY_FOUR == 0)
+		GEN1_ROCK_SLIDE:
+			return _gen1_rock_slide_steps(counter)
+	return []
+
+
+func _gen1_flash_when(condition: bool) -> Array:
+	return _gen1_effect_steps(GEN1_SE_DARK_SCREEN_FLASH) if condition else []
+
+
+## `DoRockSlideSpecialEffects`: quiet above eleven, a pixel each way to eight,
+## a flash on the last block.
+func _gen1_rock_slide_steps(counter: int) -> Array:
+	if counter >= GEN1_ROCK_SLIDE_QUIET:
+		return []
+	if counter >= GEN1_ROCK_SLIDE_SHAKE:
+		return [
+			{&"frames": GEN1_SHAKE_ONE_OUT, &"scx": -1},
+			{&"frames": 1, &"scx": -1},
+			{&"frames": GEN1_SHAKE_ONE_OUT, &"scx": 0},
+			{&"frames": GEN1_SHAKE_ONE_BACK, &"scy": -1},
+			{&"frames": GEN1_SHAKE_ONE_BACK, &"scy": 0},
+		]
+	return _gen1_flash_when(counter == 1)
+
+
+## `DoGrowlSpecialEffects`' `CopyData`: the note over the four slots behind it.
+func _gen1_copy_sprites(count: int) -> void:
+	for index: int in count:
+		if index >= _sprites.size():
+			return
+		var at: int = count + index
+		_sprites.resize(maxi(_sprites.size(), at + 1))
+		_sprites[at] = (_sprites[index] as Dictionary).duplicate()

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -599,15 +599,17 @@ func _battler_palette(species: int, slot: int, shiny: bool) -> PackedColorArray:
 ## between.
 func gen1_screen_palette(slot: int) -> PackedColorArray:
 	var player: bool = slot == GEN1_PAL_PLAYER_BAR or slot == GEN1_PAL_PLAYER_MON
-	if slot == GEN1_PAL_PLAYER_MON or slot == GEN1_PAL_ENEMY_MON:
-		return _data.palette(
-			int(_view.get("player_species" if player else "enemy_species", 0)),
-			bool(_view.get("player_shiny" if player else "enemy_shiny", false))
-		)
-	return _hp_palette(
+	var base: PackedColorArray = _data.palette(
+		int(_view.get("player_species" if player else "enemy_species", 0)),
+		bool(_view.get("player_shiny" if player else "enemy_shiny", false))
+	) if slot == GEN1_PAL_PLAYER_MON or slot == GEN1_PAL_ENEMY_MON else _hp_palette(
 		int(_view.get("player_hp" if player else "enemy_hp", 0)),
 		int(_view.get("player_max_hp" if player else "enemy_max_hp", 0))
 	)
+	# `rBGP` is one byte for the whole screen where the Color hardware has a map
+	# per palette, so every block takes slot 0's. It is what
+	# `SetAnimationBGPalette` and `AnimationFlashScreen` darken the screen with.
+	return _remap(base, _palette_map("bg_palette_maps", 0))
 
 
 ## `_CGB_BattleGrayscale`'s palette while the view says the battle is still in
@@ -814,11 +816,12 @@ func _blit_sprite(into: Image, sprite: Dictionary, backpic: bool = false) -> voi
 	if pixels.is_empty():
 		return
 	var attributes: int = int(sprite.get("attributes", 0))
-	var palette: PackedColorArray = _object_palette(attributes & OAM_PALETTE)
+	var palette: PackedColorArray = _gen1_object_palette(attributes) if _gen1() \
+		else _object_palette(attributes & OAM_PALETTE)
 	var grayscale: PackedColorArray = _grayscale()
 	if not grayscale.is_empty():
 		palette = grayscale
-	else:
+	elif not _gen1():
 		palette = _remap(palette, _palette_map("ob_palette_maps", attributes & OAM_PALETTE))
 	var lookup: Image = Gen2PicImage.from_indices(pixels, TILE, TILE, palette, true)
 	if (attributes & OAM_XFLIP) != 0:
@@ -905,6 +908,17 @@ static func pic_tile(pixels: PackedByteArray, side: int, index: int) -> PackedBy
 		for column: int in TILE:
 			out[row * TILE + column] = pixels[from + column]
 	return out
+
+
+## `SetAnimationPalette` and the `rOBP0` `PlayAnimation` swaps in for the length
+## of a subanimation. Its $F0 reads only colours 0 and 3, which every
+## `SuperPalettes` row shares, so the Super Game Boy block a sprite happens to be
+## over cannot change what it is drawn in; $6C, which the attribute bit picks,
+## reads the two between and takes the square's own.
+func _gen1_object_palette(attributes: int) -> PackedColorArray:
+	var dmg: int = Gen1Layout.ANIM_OBP1 \
+		if (attributes & Gen1Layout.ANIM_OAM_OBP1) != 0 else Gen1Layout.ANIM_OBP0
+	return _remap(gen1_screen_palette(GEN1_PAL_PLAYER_MON), dmg)
 
 
 ## `PAL_BATTLE_OB_*`. Slots 0 and 1 are the two battlers' own rather than

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1992,6 +1992,7 @@ func _begin_animation(event: Dictionary) -> void:
 	var index: int = int(event.get("index", 0))
 	var after: int = int(event.get("after_anim", 0))
 	var is_move: bool = index < ANIM_MOVE_LIMIT
+	var gen1: bool = _anim_data != null and _anim_data.gen1()
 
 	# `PlayFXAnimID`'s own `ld c, 3 / call DelayFrames`, then `_PlayBattleAnim`'s
 	# six, `BattleAnimAssignPals`/`..._RequestPals` and one more. The two pal
@@ -2003,11 +2004,15 @@ func _begin_animation(event: Dictionary) -> void:
 
 	if is_move:
 		if Gen2OptionsStore.current().battle_scene:
-			_step(ANIM_CLEAR_HUD, {})
+			# `MoveAnimation` leaves the panels where they are: only Crystal's
+			# `_PlayBattleAnim` takes the acting side's hud off the map first.
+			if not gen1:
+				_step(ANIM_CLEAR_HUD, {})
 			_step(ANIM_SCRIPT, {"index": index})
 			# `xor a / ldh [hSCX] / ldh [hSCY]`, a delay, then the huds.
 			_step(ANIM_DELAY, {"frames": 1})
-			_step(ANIM_RESTORE_HUD, {})
+			if not gen1:
+				_step(ANIM_RESTORE_HUD, {})
 		else:
 			_apply_sub_pic_no_anim(index, int(event.get("param", 0)))
 		if after != 0:
@@ -2026,7 +2031,7 @@ func _begin_animation(event: Dictionary) -> void:
 	_step(ANIM_WAIT_SFX, {})
 	# A send-out draws the picture itself and the ball animation only shows it
 	# arriving, so a cache with no animation layer still owes the square one.
-	if bool(event.get("restore_user_pic", false)) or (not is_move and _anim_data == null):
+	if bool(event.get("restore_user_pic", false)) or (not is_move and _anim_row(index) < 0):
 		_step(ANIM_APPEAR_USER, {})
 	_run_next_anim_step()
 
@@ -2132,18 +2137,50 @@ func _run_next_anim_step() -> void:
 	_push_view()
 
 
+## `AttackAnimationPointers`' rows for the ids the engine names past a move
+## number. Generation 1 numbers those differently from Crystal, and both of the
+## status pairs are picked by which side the animation is playing on.
+const GEN1_ANIM_IDS: Dictionary = {
+	Gen2BattleAnimPlayer.ANIM_CONFUSED: [190, 191],
+	Gen2BattleAnimPlayer.ANIM_BRN: [186, 186],
+	Gen2BattleAnimPlayer.ANIM_PSN: [186, 186],
+	Gen2BattleAnimPlayer.ANIM_PAR: [184, 184],
+}
+
+
+## `wAnimationID` less one, which is what `AttackAnimationPointers` is indexed
+## by. Crystal's own table is indexed by the id itself, so this is the identity
+## there. -1 is an id this cartridge has no row for: `ANIM_SEND_OUT_MON`, the
+## thrown ball and the four after-anims are all their own routines in Generation
+## 1 rather than entries in the table, and `ANIM_FRZ` has no animation at all.
+func _anim_row(index: int) -> int:
+	if _anim_data == null:
+		return -1
+	if not _anim_data.gen1():
+		return index
+	if index < ANIM_MOVE_LIMIT:
+		return index - 1
+	var pair: Variant = GEN1_ANIM_IDS.get(index, null)
+	if not pair is Array:
+		return -1
+	return int((pair as Array)[1 if bool(_anim_event.get("enemy_turn", false)) else 0]) - 1
+
+
 ## `RunBattleAnimScript`, which is `ClearBattleAnims` and then a frame loop. The
 ## tilemap the battle is showing is what the effects edit, so it goes in here
 ## and comes back out at the end. A cache carrying no animation layer answers
 ## with no player, and the step is skipped rather than the whole framing: the
 ## delays and the hud belong to the screen, not to the data.
 func _start_script(index: int) -> bool:
-	if _anim_data == null:
+	var row: int = _anim_row(index)
+	if _anim_data == null or row < 0:
 		return false
 	var wobbles: Array[int] = []
 	wobbles.assign(_anim_event.get("wobbles", []))
-	_anim = Gen2BattleAnimPlayer.create(
-		_anim_data, index, bool(_anim_event.get("enemy_turn", false)),
+	_anim = Gen2BattleAnimPlayer.create_gen1(
+		_anim_data, row, bool(_anim_event.get("enemy_turn", false))
+	) if _anim_data.gen1() else Gen2BattleAnimPlayer.create(
+		_anim_data, row, bool(_anim_event.get("enemy_turn", false)),
 		int(_anim_event.get("param", 0)), wobbles
 	)
 	if _anim == null:

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -817,9 +817,11 @@ func world_encounter_count(method: StringName) -> int:
 
 ## One battle animation region: the cached bytes plus the bank and address the
 ## cartridge holds them at, so an in-bank pointer resolves by subtraction.
-## [param name] is `scripts`, `objects`, `framesets` or `oam_sets`. Answers
-## [code]{ bank, address, count, data }[/code], empty when the section is absent
-## or the name is not one of the four.
+## [param name] is `scripts`, `objects`, `framesets` or `oam_sets` on a
+## Generation 2 cache and the single `anims` on a Generation 1 one, whose four
+## tables share a bank and are reached through [method battle_anim_table].
+## Answers [code]{ bank, address, count, data }[/code], empty when the section is
+## absent or the name is not one the cache holds.
 func battle_anim_region(name: StringName) -> Dictionary:
 	var value: Variant = _battle_anims().get(String(name), null)
 	if not value is Dictionary:
@@ -846,6 +848,39 @@ func battle_anim_address(index: int) -> int:
 	if at + 2 > data.size():
 		return -1
 	return data[at] | (data[at + 1] << 8)
+
+
+## Where one of the Generation 1 animation layer's tables stands inside the
+## `anims` region: `subanims`, `frame_blocks` or `base_coords`. -1 on a
+## Generation 2 cache, which gives each table a region of its own.
+func battle_anim_table(name: StringName) -> int:
+	var value: Variant = _battle_anims().get("tables", null)
+	if not value is Dictionary:
+		return -1
+	return int((value as Dictionary).get(String(name), -1))
+
+
+## `SpecialEffectPointers`' ids, which is every special effect a Generation 1
+## animation may name. Empty on a Generation 2 cache.
+func battle_anim_special_effects() -> PackedInt32Array:
+	var value: Variant = _battle_anims().get("special_effects", null)
+	var out := PackedInt32Array()
+	if value is Array:
+		for effect: Variant in value as Array:
+			out.append(int(effect))
+	return out
+
+
+## `FallingObjects_DeltaXs` and the bytes past it two of Petal Dance's objects
+## read as their own drift; see [constant Gen1Layout.FALLING_DELTA_BYTES]. Empty
+## on a Generation 2 cache.
+func battle_anim_falling_deltas() -> PackedInt32Array:
+	var value: Variant = _battle_anims().get("falling_deltas", null)
+	var out := PackedInt32Array()
+	if value is Array:
+		for byte: Variant in value as Array:
+			out.append(int(byte))
+	return out
 
 
 ## `BattleAnimSineWave` as its own 64 cartridge bytes, or empty when the section

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -37,6 +37,12 @@ const FIRST_DEX_WEIGHT: int = 150
 const FIRST_TM_MOVE: int = 0x05
 const LAST_HM_MOVE: int = 0x94
 
+## `PoundAnim` whole: one subanimation row at tileset 0 and delay 8, POUND's own
+## sound and `SUBANIM_0_STAR_TWICE`, then the terminator.
+const POUND_ANIM: Array[int] = [0x08, 0x00, 0x01, 0xFF]
+## `BASECOORD_00`, the corner every frame block is placed from.
+const FIRST_BASE_COORD: Array[int] = [0x10, 0x68]
+
 ## `TypeEffects`' first row, water beating fire twice over.
 const FIRST_MATCHUP: Array[int] = [0x15, 0x14, 20]
 
@@ -49,6 +55,24 @@ const FIRST_PALETTE_COLORS: Dictionary = {
 	RomRegistry.BLUE: [32703, 17236, 11913, 2115],
 	RomRegistry.YELLOW: [31743, 19352, 16045, 6342],
 }
+
+## Where a bank-local pointer points: every one of them addresses $4000 up.
+const BANK_BASE: int = 0x4000
+
+## The battle animation offsets [method _import_battle_anims] reads, in the one
+## order that lets each be checked against the tables it indexes.
+const ANIM_TABLES: Array[String] = [
+	"special_effects", "frame_blocks", "subanims", "attack_anims", "base_coords",
+	"anim_tilesets", "falling_deltas",
+]
+## Byte position of the tile id in one `dbsprite`, after its y and x offsets.
+const FRAME_BLOCK_TILE: int = 2
+## `SpecialEffectPointers` is 40 rows and its terminator; both dumps agree.
+const MIN_SPECIAL_EFFECTS: int = 32
+const MAX_SPECIAL_EFFECTS: int = 64
+## A runaway guard for one animation's `battle_anim` rows. The longest in any of
+## the three dumps is eleven.
+const MAX_ANIM_ROWS: int = 64
 
 ## A runaway guard for the terminated name tables, longer than any entry.
 const MAX_NAME_LENGTH: int = 20
@@ -93,6 +117,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_font,
 	_verify_text_box,
 	_verify_battle_tiles,
+	_verify_battle_anims,
 	_verify_facility_text,
 	_verify_world,
 ]
@@ -385,6 +410,24 @@ static func _verify_battle_tiles(rom: RomFile, layout: Dictionary) -> Dictionary
 	return _ok()
 
 
+## `PoundAnim` and `FrameBlockBaseCoords`' first row, which pin the two ends of
+## the animation layer: a subanimation entry of the right shape and the flat
+## table the frame blocks are placed by. The walk in [method
+## _import_battle_anims] checks the rest against each other.
+static func _verify_battle_anims(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var anims: int = Gen1Layout.banked(Gen1Layout.ANIM_BANK, int(layout["attack_anims"]))
+	if not rom.in_bounds(anims, Gen1Layout.anim_count(rom.id) * Gen1Layout.POINTER_SIZE):
+		return _fail("AttackAnimationPointers runs past the end of the dump.")
+	var pound: int = Gen1Layout.banked(Gen1Layout.ANIM_BANK, rom.u16le(anims))
+	for index: int in POUND_ANIM.size():
+		if rom.u8(pound + index) != POUND_ANIM[index]:
+			return _fail("AttackAnimationPointers: entry 0 is not POUND's animation.")
+	var coords: int = Gen1Layout.banked(Gen1Layout.ANIM_BANK, int(layout["base_coords"]))
+	if rom.u8(coords) != FIRST_BASE_COORD[0] or rom.u8(coords + 1) != FIRST_BASE_COORD[1]:
+		return _fail("FrameBlockBaseCoords: row 0 is not BASECOORD_00.")
+	return _ok()
+
+
 ## Every map and tileset decodes, which is the world layout's own check: a wrong
 ## table reaches a tileset number, a map size or a block index the cartridge
 ## cannot hold.
@@ -603,6 +646,18 @@ func import_rom(
 		result["message"] = String(world["message"])
 		return result
 	await _breathe(yield_ms)
+	var anims: Dictionary = _import_battle_anims(rom, layout, directory)
+	if anims.is_empty():
+		result["message"] = "Could not decode the battle animations."
+		return result
+	if not RomCache.write_section(
+		RomCache.battle_anims_path(directory),
+		RomCache.blob_path(RomCache.battle_anims_path(directory)),
+		anims["section"]
+	):
+		result["message"] = "Could not write the battle animations."
+		return result
+	await _breathe(yield_ms)
 
 	var sections: Dictionary = {
 		RomCache.species_path(directory): species,
@@ -633,6 +688,7 @@ func import_rom(
 		"tileset_count": int(world["tilesets"]),
 		"overworld_sprite_count": int(world["sprites"]),
 		"encounter_count": int(world["encounters"]),
+		"battle_anim_count": int(anims["anims"]),
 		"atlases": pics,
 		"tiles": tiles,
 		"bar_palettes": _import_bar_palettes(rom, layout),
@@ -657,15 +713,18 @@ func import_rom(
 	result["tilesets"] = int(world["tilesets"])
 	result["sprites"] = int(world["sprites"])
 	result["encounters"] = int(world["encounters"])
+	result["battle_anims"] = int(anims["anims"])
+	result["subanim_frames"] = int(anims["subanim_frames"])
+	result["frame_block_sprites"] = int(anims["frame_block_sprites"])
 	result["elapsed_ms"] = Time.get_ticks_msec() - started
 	result["message"] = ("%d species, %d moves, %d items, %d type matchups, "
 		+ "%d trainer classes, %d evolutions, %d level-up moves, %d maps, "
-		+ "%d tilesets, %d overworld sprites and %d wild encounter tables "
-		+ "in %d ms.") % [
+		+ "%d tilesets, %d overworld sprites, %d wild encounter tables and "
+		+ "%d battle animations in %d ms.") % [
 		species.size(), moves.size(), items.size(), matchups.size(), trainers.size(),
 		result["evolutions"], result["learnset_moves"], result["maps"],
 		result["tilesets"], result["sprites"], result["encounters"],
-		result["elapsed_ms"],
+		result["battle_anims"], result["elapsed_ms"],
 	]
 	return result
 
@@ -1067,3 +1126,227 @@ func _decode_pic(
 		PokeTiles.decode_pic(raw, codec.columns, codec.rows), codec.columns, atlas, slot
 	)
 	return true
+
+
+## `AttackAnimationPointers` and the three tables its subanimations reach, plus
+## `MoveAnimationTilesPointers`' sheets. Empty when anything fails to walk, so a
+## wrong offset refuses the import rather than animating noise.
+##
+## The four tables and their data are interleaved through bank $1E, so the cache
+## holds one region spanning all of them and each table is an address inside it.
+func _import_battle_anims(rom: RomFile, layout: Dictionary, directory: String) -> Dictionary:
+	var bank: PackedByteArray = rom.slice(
+		Gen1Layout.ANIM_BANK * RomFile.BANK_SIZE, RomFile.BANK_SIZE
+	)
+	if bank.size() != RomFile.BANK_SIZE:
+		return {}
+
+	var tables: Dictionary = {}
+	for name: String in ANIM_TABLES:
+		tables[name] = BANK_BASE + int(layout[name]) % RomFile.BANK_SIZE
+
+	if not _in_bank(int(tables["falling_deltas"]) + Gen1Layout.FALLING_DELTA_BYTES - 1):
+		return {}
+	var effects: Array = _read_special_effects(bank, int(tables["special_effects"]))
+	var frame_blocks: Dictionary = _walk_frame_blocks(bank, int(tables["frame_blocks"]))
+	var subanims: Dictionary = _walk_subanims(bank, int(tables["subanims"]), frame_blocks)
+	var anims: Dictionary = _walk_anims(
+		bank, int(tables["attack_anims"]), Gen1Layout.anim_count(rom.id), effects
+	)
+	var sheets: Array = _import_anim_tilesets(rom, int(tables["anim_tilesets"]), directory)
+	if effects.is_empty() or frame_blocks.is_empty() or subanims.is_empty() \
+			or anims.is_empty() or sheets.is_empty():
+		return {}
+
+	var spans: Array = [anims, subanims, frame_blocks]
+	var lowest: int = int(tables["attack_anims"])
+	var highest: int = int(tables["base_coords"]) \
+		+ Gen1Layout.BASE_COORD_COUNT * Gen1Layout.BASE_COORD_SIZE
+	for span: Dictionary in spans:
+		lowest = mini(lowest, int(span["lowest"]))
+		highest = maxi(highest, int(span["highest"]))
+
+	return {
+		"section": {
+			"anims": {
+				"bank": Gen1Layout.ANIM_BANK,
+				"address": lowest,
+				"count": Gen1Layout.anim_count(rom.id),
+				"bytes": _bank_bytes(bank, lowest, highest),
+			},
+			"tables": {
+				"subanims": tables["subanims"],
+				"frame_blocks": tables["frame_blocks"],
+				"base_coords": tables["base_coords"],
+			},
+			"special_effects": effects,
+			"falling_deltas": _bank_bytes(
+				bank, int(tables["falling_deltas"]),
+				int(tables["falling_deltas"]) + Gen1Layout.FALLING_DELTA_BYTES
+			),
+			"object_gfx": sheets,
+		},
+		"anims": Gen1Layout.anim_count(rom.id),
+		"subanim_frames": int(subanims["frames"]),
+		"frame_block_sprites": int(frame_blocks["sprites"]),
+	}
+
+
+## `SpecialEffectPointers`, as the ids alone: the addresses beside them are
+## routines this port answers with its own. Empty when the table never ends.
+func _read_special_effects(bank: PackedByteArray, table: int) -> Array:
+	var out: Array = []
+	var at: int = table
+	while out.size() <= MAX_SPECIAL_EFFECTS:
+		var id: int = _bank_u8(bank, at)
+		if id == Gen1Layout.ANIM_END:
+			return out if out.size() >= MIN_SPECIAL_EFFECTS else []
+		if id < Gen1Layout.ANIM_FIRST_SE_ID or out.has(id):
+			return []
+		out.append(id)
+		at += Gen1Layout.SPECIAL_EFFECT_ROW_SIZE
+	return []
+
+
+## `FrameBlockPointers` and every `dbsprite` run behind it. Answers
+## [code]{ lowest, highest, sprites, tiles }[/code], `tiles` being the highest
+## tile id any of them draws, which pins the tileset the sheets have to hold.
+func _walk_frame_blocks(bank: PackedByteArray, table: int) -> Dictionary:
+	var lowest: int = table
+	var highest: int = table + Gen1Layout.FRAME_BLOCK_COUNT * Gen1Layout.POINTER_SIZE
+	var sprites: int = 0
+	var tiles: int = 0
+	for index: int in Gen1Layout.FRAME_BLOCK_COUNT:
+		var address: int = _bank_u16(bank, table + index * Gen1Layout.POINTER_SIZE)
+		if not _in_bank(address):
+			return {}
+		var count: int = _bank_u8(bank, address)
+		var end: int = address + 1 + count * Gen1Layout.FRAME_BLOCK_SPRITE_SIZE
+		if not _in_bank(end - 1):
+			return {}
+		for sprite: int in count:
+			var at: int = address + 1 + sprite * Gen1Layout.FRAME_BLOCK_SPRITE_SIZE
+			tiles = maxi(tiles, _bank_u8(bank, at + FRAME_BLOCK_TILE))
+		sprites += count
+		lowest = mini(lowest, address)
+		highest = maxi(highest, end)
+	return {"lowest": lowest, "highest": highest, "sprites": sprites, "tiles": tiles + 1}
+
+
+## `SubanimationPointers` and the three-byte rows behind each header. Every row
+## is checked against the two tables it indexes, which is what makes a plausible
+## but wrong offset fail here rather than on screen.
+func _walk_subanims(
+	bank: PackedByteArray, table: int, frame_blocks: Dictionary
+) -> Dictionary:
+	if frame_blocks.is_empty():
+		return {}
+	var lowest: int = table
+	var highest: int = table + Gen1Layout.SUBANIM_COUNT * Gen1Layout.POINTER_SIZE
+	var frames: int = 0
+	for index: int in Gen1Layout.SUBANIM_COUNT:
+		var address: int = _bank_u16(bank, table + index * Gen1Layout.POINTER_SIZE)
+		if not _in_bank(address):
+			return {}
+		var header: int = _bank_u8(bank, address)
+		var count: int = header & Gen1Layout.SUBANIM_COUNT_MASK
+		var kind: int = header >> Gen1Layout.SUBANIM_TYPE_SHIFT
+		var end: int = address + 1 + count * Gen1Layout.SUBANIM_ROW_SIZE
+		if count == 0 or kind >= Gen1Layout.SUBANIMTYPE_COUNT or not _in_bank(end - 1):
+			return {}
+		for row: int in count:
+			var at: int = address + 1 + row * Gen1Layout.SUBANIM_ROW_SIZE
+			if _bank_u8(bank, at) >= Gen1Layout.FRAME_BLOCK_COUNT \
+					or _bank_u8(bank, at + 1) >= Gen1Layout.BASE_COORD_COUNT \
+					or _bank_u8(bank, at + 2) >= Gen1Layout.FRAMEBLOCKMODE_COUNT:
+				return {}
+		frames += count
+		lowest = mini(lowest, address)
+		highest = maxi(highest, end)
+	return {"lowest": lowest, "highest": highest, "frames": frames}
+
+
+## `AttackAnimationPointers` and every `battle_anim` row behind it, with each
+## row's subanimation id and special effect id checked against its table.
+func _walk_anims(
+	bank: PackedByteArray, table: int, count: int, effects: Array
+) -> Dictionary:
+	var lowest: int = table
+	var highest: int = table + count * Gen1Layout.POINTER_SIZE
+	for index: int in count:
+		var address: int = _bank_u16(bank, table + index * Gen1Layout.POINTER_SIZE)
+		if not _in_bank(address):
+			return {}
+		var at: int = address
+		var rows: int = 0
+		while true:
+			rows += 1
+			if rows > MAX_ANIM_ROWS or not _in_bank(at):
+				return {}
+			var byte: int = _bank_u8(bank, at)
+			if byte == Gen1Layout.ANIM_END:
+				at += 1
+				break
+			if byte >= Gen1Layout.ANIM_FIRST_SE_ID:
+				if not effects.has(byte):
+					return {}
+				at += Gen1Layout.ANIM_SE_SIZE
+				continue
+			if _bank_u8(bank, at + 2) >= Gen1Layout.SUBANIM_COUNT:
+				return {}
+			at += Gen1Layout.ANIM_SUBANIM_SIZE
+		lowest = mini(lowest, address)
+		highest = maxi(highest, at)
+	return {"lowest": lowest, "highest": highest}
+
+
+## `MoveAnimationTilesPointers`' three rows, decoded as raw 2bpp strips into the
+## same files a Generation 2 `AnimObjGFX` sheet uses. Rows 0 and 2 name the same
+## bytes, the third being the first cut to 64 tiles, so both are written.
+func _import_anim_tilesets(rom: RomFile, table: int, directory: String) -> Array:
+	var out: Array = []
+	for index: int in Gen1Layout.ANIM_TILESET_COUNT:
+		var row: int = Gen1Layout.banked(Gen1Layout.ANIM_BANK, table) \
+			+ index * Gen1Layout.ANIM_TILESET_ROW_SIZE
+		var tiles: int = rom.u8(row + Gen1Layout.ANIM_TILESET_TILES)
+		var address: int = rom.u16le(row + Gen1Layout.ANIM_TILESET_POINTER)
+		var start: int = Gen1Layout.banked(Gen1Layout.ANIM_BANK, address)
+		if tiles <= 0 or not _in_bank(address) \
+				or not rom.in_bounds(start, tiles * PokeTiles.TILE_BYTES):
+			return []
+		if not RomCache.write_indices(
+			RomCache.battle_anim_gfx_path(directory, index),
+			PokeTiles.decode_strip(rom.bytes(), start, tiles, 2)
+		):
+			return []
+		out.append({
+			"tiles": tiles,
+			"bank": Gen1Layout.ANIM_BANK,
+			"address": address,
+			"sheet": true,
+		})
+	return out
+
+
+## The slice of bank $1E between two of its own addresses, as an Array the cache
+## moves into the section blob.
+func _bank_bytes(bank: PackedByteArray, from: int, to: int) -> Array:
+	var slice: PackedByteArray = bank.slice(from - BANK_BASE, to - BANK_BASE)
+	var out: Array = []
+	out.resize(slice.size())
+	for index: int in slice.size():
+		out[index] = slice[index]
+	return out
+
+
+func _bank_u8(bank: PackedByteArray, address: int) -> int:
+	var at: int = address - BANK_BASE
+	return bank[at] if at >= 0 and at < bank.size() else 0
+
+
+func _bank_u16(bank: PackedByteArray, address: int) -> int:
+	return _bank_u8(bank, address) | (_bank_u8(bank, address + 1) << 8)
+
+
+static func _in_bank(address: int) -> bool:
+	return address >= BANK_BASE and address < BANK_BASE + RomFile.BANK_SIZE

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -195,6 +195,89 @@ const BATTLE_HUD_1_FIRST_CODE: int = 0x6D
 const BATTLE_HUD_2_TILES: int = 6
 const BATTLE_HUD_2_FIRST_CODE: int = 0x73
 
+## The battle animation layer, all of it in bank $1E: `AttackAnimationPointers`,
+## `SubanimationPointers`, `FrameBlockPointers` and `FrameBlockBaseCoords` with
+## their data interleaved between them, so the cache holds one region and every
+## table resolves inside it.
+const ANIM_COUNT_RED_BLUE: int = 203
+## Yellow drops `ZigZagScreenAnim`, the one entry past `NUM_ATTACK_ANIMS`.
+const ANIM_COUNT_YELLOW: int = 202
+const SUBANIM_COUNT: int = 86
+const FRAME_BLOCK_COUNT: int = 122
+const BASE_COORD_COUNT: int = 177
+const BASE_COORD_SIZE: int = 2
+const SUBANIM_ROW_SIZE: int = 3
+const FRAME_BLOCK_SPRITE_SIZE: int = 4
+const SPECIAL_EFFECT_ROW_SIZE: int = 3
+
+## One `battle_anim` row. A byte at or above `FIRST_SE_ID` names a special
+## effect and takes a sound after it; anything below is a subanimation's tileset
+## in the top two bits and its frame delay in the low six, then a sound and a
+## subanimation id.
+const ANIM_FIRST_SE_ID: int = 0xC0
+const ANIM_END: int = 0xFF
+## `NO_MOVE - 1`, the sound byte that plays nothing.
+const ANIM_NO_SOUND: int = 0xFF
+const ANIM_DELAY_MASK: int = 0x3F
+const ANIM_TILESET_SHIFT: int = 6
+const ANIM_SE_SIZE: int = 2
+const ANIM_SUBANIM_SIZE: int = 3
+
+## One `subanim` header: the count in the low five bits, the type in the top
+## three.
+const SUBANIM_COUNT_MASK: int = 0x1F
+const SUBANIM_TYPE_SHIFT: int = 5
+const SUBANIMTYPE_NORMAL: int = 0
+const SUBANIMTYPE_HVFLIP: int = 1
+const SUBANIMTYPE_HFLIP: int = 2
+const SUBANIMTYPE_COORDFLIP: int = 3
+const SUBANIMTYPE_REVERSE: int = 4
+const SUBANIMTYPE_ENEMY: int = 5
+const SUBANIMTYPE_COUNT: int = 6
+
+## `FRAMEBLOCKMODE_*`. 02 keeps the sprites and skips the delay, 03 keeps them
+## and takes it, 04 keeps them and does not advance the write position.
+const FRAMEBLOCKMODE_COUNT: int = 5
+const FRAMEBLOCKMODE_KEEP_NO_DELAY: int = 2
+const FRAMEBLOCKMODE_KEEP: int = 3
+const FRAMEBLOCKMODE_HOLD: int = 4
+
+## What `DrawFrameBlock` flips a coordinate about, and the offset
+## `SUBANIMTYPE_HFLIP` translates down by.
+const ANIM_FLIP_Y: int = 136
+const ANIM_FLIP_X: int = 168
+const ANIM_HFLIP_DROP: int = 40
+
+## `FallingObjects_DeltaXs` is nine bytes and `FallingObjects_UpdateMovementByte`
+## only wraps a movement byte that reaches nine, so the two objects
+## `FallingObjects_InitialMovementData` starts at nine walk off the end and read
+## the routine's own machine code as their drift. The byte is masked to seven
+## bits, so 128 is as far as one can reach; the two dumps disagree past the ninth
+## and both are cached.
+const FALLING_DELTA_BYTES: int = 128
+const FALLING_DELTA_TABLE: int = 9
+
+## `MoveAnimationTilesPointers`: three `anim_tileset` rows of a tile count, a
+## bank-local pointer and a padding byte. Tileset 2 is tileset 0 cut short.
+const ANIM_TILESET_COUNT: int = 3
+const ANIM_TILESET_ROW_SIZE: int = 4
+const ANIM_TILESET_TILES: int = 0
+const ANIM_TILESET_POINTER: int = 1
+
+## The bank every table above lives in, and `vSprites tile $31`, which
+## `DrawFrameBlock` adds to a frame block's tile so the id is an index into the
+## loaded tileset.
+const ANIM_BANK: int = 0x1E
+const ANIM_BASE_TILE: int = 0x31
+
+## `SetAnimationPalette` on the Super Game Boy: `rOBP0` while a subanimation
+## draws is `wAnimPalette`, $F0, and `rOBP1` is $6C throughout.
+const ANIM_OBP0: int = 0xF0
+const ANIM_OBP1: int = 0x6C
+## The DMG palette bit of an OAM attribute byte, where Generation 2 keeps a
+## three-bit Game Boy Color palette.
+const ANIM_OAM_OBP1: int = 0x10
+
 ## What pins the two sheets: the edge under both panels is two solid rows in
 ## the middle of six blank ones, and the empty bar is a rule top and bottom.
 const HUD_BOTTOM_CODE: int = 0x76
@@ -495,6 +578,15 @@ const RED_BLUE: Dictionary = {
 	"wild_chances": 0x13918,
 	"good_rod": 0x0E27F,
 	"super_rod": 0x0E919,
+	## `data/battle_anims`, every one of them in bank $1E and reached from
+	## `AttackAnimationPointers`.
+	"attack_anims": 0x7A07D,
+	"subanims": 0x7A76D,
+	"frame_blocks": 0x7AF74,
+	"base_coords": 0x7BC85,
+	"special_effects": 0x790DA,
+	"anim_tilesets": 0x781F2,
+	"falling_deltas": 0x79D0D,
 	## `_IsTilePassable` and the lists it walks share a bank, and the pointer in
 	## a tileset row names no bank of its own. Red and Blue keep both in home.
 	"tileset_collision_bank": 0x00,
@@ -547,6 +639,13 @@ const YELLOW: Dictionary = {
 	"good_rod": 0x0E12C,
 	## Yellow's is a flat slot table rather than an index into groups.
 	"super_rod": 0xF5EDA,
+	"attack_anims": 0x7A22A,
+	"subanims": 0x7A915,
+	"frame_blocks": 0x7B11C,
+	"base_coords": 0x7BE2D,
+	"special_effects": 0x79145,
+	"anim_tilesets": 0x7822B,
+	"falling_deltas": 0x79E96,
 	"tileset_collision_bank": 0x01,
 }
 
@@ -750,6 +849,11 @@ static func warp_wants_carpet(map_id: int, tileset: int) -> bool:
 
 static func tileset_count(id: StringName) -> int:
 	return TILESET_COUNT_YELLOW if id == RomRegistry.YELLOW else TILESET_COUNT_RED_BLUE
+
+
+## How many `AttackAnimationPointers` rows the cartridge holds.
+static func anim_count(id: StringName) -> int:
+	return ANIM_COUNT_YELLOW if id == RomRegistry.YELLOW else ANIM_COUNT_RED_BLUE
 
 
 ## `NUM_SPRITES`. Yellow added ten walking sprites in front of the still ones.

--- a/tests/unit/test_battle_anim_player.gd
+++ b/tests/unit/test_battle_anim_player.gd
@@ -289,7 +289,9 @@ func test_a_callback_or_effect_past_its_table_is_reported() -> void:
 		SPAWN + [0xF0, 0x22, 0x00, 0x00, 0x00] + [0x01] + RET, 2, 0x09
 	)
 	whole.advance_frame()
-	assert_eq(whole.unimplemented(), {"bg_effects": [], "functions": []})
+	assert_eq(
+		whole.unimplemented(), {"bg_effects": [], "functions": [], "gen1_effects": []}
+	)
 
 
 ## An animation the cache does not carry answers null rather than an empty
@@ -297,3 +299,165 @@ func test_a_callback_or_effect_past_its_table_is_reported() -> void:
 func test_an_animation_the_cache_does_not_have_answers_null() -> void:
 	assert_null(Gen2BattleAnimPlayer.create(_data(RET), 1))
 	assert_null(Gen2BattleAnimPlayer.create(null, 0))
+
+
+## `PlayAnimation`'s own layer, built by hand the same way: one animation, one
+## subanimation and one frame block, so `DrawFrameBlock`'s four transforms and
+## `FRAMEBLOCKMODE_*` are checked against the coordinates rather than against a
+## cartridge's own tables.
+const GEN1_ANIMS: int = BASE
+const GEN1_SUBANIMS: int = BASE + 0x40
+const GEN1_BLOCKS: int = BASE + 0x60
+const GEN1_COORDS: int = BASE + 0x80
+## `BASECOORD_00`, which every case below is placed from.
+const GEN1_BASE_Y: int = 0x10
+const GEN1_BASE_X: int = 0x68
+
+
+## One animation playing subanimation 0 at [param delay], whose one row draws
+## frame block 0 at base coordinate 0 in [param mode]. The frame block is one
+## sprite at the corner, so a transform shows as the coordinates alone.
+func _gen1_data(
+	kind: int, mode: int = 0, delay: int = 4, rows: int = 1, attributes: int = 0
+) -> Gen2BattleAnimData:
+	var bytes: Array = []
+	bytes.resize(0x100)
+	bytes.fill(0)
+	var write := func(at: int, values: Array) -> void:
+		for index: int in values.size():
+			bytes[at - BASE + index] = int(values[index]) & 0xFF
+
+	write.call(GEN1_ANIMS, [(GEN1_ANIMS + 2) & 0xFF, (GEN1_ANIMS + 2) >> 8])
+	write.call(GEN1_ANIMS + 2, [delay, Gen1Layout.ANIM_NO_SOUND, 0x00, Gen1Layout.ANIM_END])
+	write.call(GEN1_SUBANIMS, [(GEN1_SUBANIMS + 2) & 0xFF, (GEN1_SUBANIMS + 2) >> 8])
+	var subanim: Array = [(kind << Gen1Layout.SUBANIM_TYPE_SHIFT) | rows]
+	for row: int in rows:
+		subanim.append_array([0x00, 0x00, mode])
+	write.call(GEN1_SUBANIMS + 2, subanim)
+	write.call(GEN1_BLOCKS, [(GEN1_BLOCKS + 2) & 0xFF, (GEN1_BLOCKS + 2) >> 8])
+	write.call(GEN1_BLOCKS + 2, [0x01, 0x00, 0x00, 0x00, attributes])
+	write.call(GEN1_COORDS, [GEN1_BASE_Y, GEN1_BASE_X])
+
+	return Gen2BattleAnimData.create_gen1(
+		{"bank": Gen1Layout.ANIM_BANK, "address": BASE, "count": 1, "data": _bytes(bytes)},
+		[{"tiles": 79, "sheet": true}],
+		{
+			&"subanims": GEN1_SUBANIMS,
+			&"frame_blocks": GEN1_BLOCKS,
+			&"base_coords": GEN1_COORDS,
+		},
+		PackedInt32Array(), PackedInt32Array()
+	)
+
+
+func _gen1_sprite(
+	kind: int, enemy_turn: bool, attributes: int = 0
+) -> Dictionary:
+	var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(
+		_gen1_data(kind, 0, 4, 1, attributes), 0, enemy_turn
+	)
+	player.advance_frame()
+	return (player.sprites() as Array)[0]
+
+
+## `GetSubanimationTransform1`: a subanimation is drawn untransformed on the
+## player's turn whatever its type says, and takes its type on the enemy's.
+func test_a_generation_1_subanimation_is_untransformed_on_the_players_turn() -> void:
+	var sprite: Dictionary = _gen1_sprite(Gen1Layout.SUBANIMTYPE_HVFLIP, false)
+	assert_eq(
+		[sprite["y"], sprite["x"], sprite["tile"]],
+		[GEN1_BASE_Y, GEN1_BASE_X, Gen1Layout.ANIM_BASE_TILE]
+	)
+
+
+## `DrawFrameBlock`'s three coordinate branches, each about its own constant.
+func test_a_generation_1_subanimation_takes_its_transform_on_the_enemys_turn() -> void:
+	var flipped: Dictionary = _gen1_sprite(Gen1Layout.SUBANIMTYPE_HVFLIP, true)
+	assert_eq(
+		[flipped["y"], flipped["x"]],
+		[Gen1Layout.ANIM_FLIP_Y - GEN1_BASE_Y, Gen1Layout.ANIM_FLIP_X - GEN1_BASE_X]
+	)
+	assert_eq(
+		flipped["attributes"],
+		Gen2BattleAnimObject.OAM_YFLIP | Gen2BattleAnimObject.OAM_XFLIP,
+		"a bare frame block flips both ways under SUBANIMTYPE_HVFLIP"
+	)
+
+	var half: Dictionary = _gen1_sprite(Gen1Layout.SUBANIMTYPE_HFLIP, true)
+	assert_eq(
+		[half["y"], half["x"], half["attributes"]],
+		[
+			GEN1_BASE_Y + Gen1Layout.ANIM_HFLIP_DROP,
+			Gen1Layout.ANIM_FLIP_X - GEN1_BASE_X,
+			Gen2BattleAnimObject.OAM_XFLIP,
+		]
+	)
+
+	var coords: Dictionary = _gen1_sprite(Gen1Layout.SUBANIMTYPE_COORDFLIP, true)
+	assert_eq(
+		[coords["y"], coords["x"], coords["attributes"]],
+		[
+			Gen1Layout.ANIM_FLIP_Y - GEN1_BASE_Y,
+			Gen1Layout.ANIM_FLIP_X - GEN1_BASE_X,
+			0,
+		]
+	)
+
+
+## `SUBANIMTYPE_ENEMY` is the one type read the other way round.
+func test_the_enemy_subanimation_type_flips_on_the_players_turn() -> void:
+	var mine: Dictionary = _gen1_sprite(Gen1Layout.SUBANIMTYPE_ENEMY, false)
+	assert_eq(mine["x"], Gen1Layout.ANIM_FLIP_X - GEN1_BASE_X)
+	var theirs: Dictionary = _gen1_sprite(Gen1Layout.SUBANIMTYPE_ENEMY, true)
+	assert_eq(theirs["x"], GEN1_BASE_X)
+
+
+## `SUBANIMTYPE_HVFLIP` compares the whole attribute byte against three
+## constants, so an OBP1 bit falls through to no flags rather than being kept.
+func test_the_hvflip_transform_drops_an_attribute_it_does_not_recognise() -> void:
+	var sprite: Dictionary = _gen1_sprite(
+		Gen1Layout.SUBANIMTYPE_HVFLIP, true, Gen1Layout.ANIM_OAM_OBP1
+	)
+	assert_eq(sprite["attributes"], 0)
+
+
+## The delay is what a frame block is shown for, and `FRAMEBLOCKMODE_00` clears
+## the buffer after it where `FRAMEBLOCKMODE_02` keeps it and takes no delay.
+func test_a_generation_1_frame_block_is_shown_for_its_own_delay() -> void:
+	var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(
+		_gen1_data(Gen1Layout.SUBANIMTYPE_NORMAL, 0, 3, 2), 0
+	)
+	var counts: Array[int] = []
+	for _frame: int in 8:
+		player.advance_frame()
+		counts.append((player.sprites() as Array).size())
+	assert_eq(counts, [1, 1, 1, 1, 1, 1, 0, 0], "three frames a block, two blocks")
+
+	var kept: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(
+		_gen1_data(Gen1Layout.SUBANIMTYPE_NORMAL, Gen1Layout.FRAMEBLOCKMODE_KEEP, 3, 2), 0
+	)
+	var stacked: Array[int] = []
+	for _frame: int in 7:
+		kept.advance_frame()
+		stacked.append((kept.sprites() as Array).size())
+	assert_eq(stacked, [1, 1, 1, 2, 2, 2, 0], "FRAMEBLOCKMODE_03 keeps the buffer")
+
+	var quick: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(
+		_gen1_data(
+			Gen1Layout.SUBANIMTYPE_NORMAL, Gen1Layout.FRAMEBLOCKMODE_KEEP_NO_DELAY, 3, 2
+		), 0
+	)
+	quick.advance_frame()
+	assert_true(
+		quick.finished(), "FRAMEBLOCKMODE_02 takes no delay, so both blocks land at once"
+	)
+
+
+## An animation the cache does not carry answers null on either engine.
+func test_a_generation_1_animation_outside_the_table_answers_null() -> void:
+	assert_null(Gen2BattleAnimPlayer.create_gen1(_gen1_data(0), 1))
+	assert_null(Gen2BattleAnimPlayer.create_gen1(null, 0))
+	assert_null(
+		Gen2BattleAnimPlayer.create_gen1(_data(RET), 0),
+		"a Generation 2 layer has no `anims` region to walk"
+	)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 678 lines of the 38876 here, and Generation 1 has added 482 more to the
-## shared battle, world, palette, text, save and renderer code, 121 of them the
-## battle transition, the four split effect routines and `BlkPacket_Battle`.
-## Five sweeps have found no restatement left to pay with.
-const MAX_COMMENT_LINES: int = 38876
+## are 774 lines of the 39112 here, and Generation 1 has added 632 more to the
+## shared battle, world, palette, text, save and renderer code, 150 of them the
+## battle animation engine and 121 the transition, the split effect routines and
+## `BlkPacket_Battle`. Six sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39112
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_battle_anims.gd
+++ b/tools/checks/gen1_battle_anims.gd
@@ -1,0 +1,282 @@
+extends RefCounted
+
+## Every Generation 1 battle animation, played to its end on Red, Blue and
+## Yellow. What pins the layer is walking all 203 rather than sampling: a table
+## read a byte off still decodes into plausible rows, and only running every one
+## of them through the four tables it indexes fails.
+
+var _r: RefCounted = null
+
+## `assert_table_length` in each pinned data file, shared by both. Only
+## `AttackAnimationPointers` differs: Yellow dropped `ZigZagScreenAnim`.
+const EXPECTED_COUNTS: Dictionary = {
+	&"subanims": Gen1Layout.SUBANIM_COUNT,
+	&"frame_blocks": Gen1Layout.FRAME_BLOCK_COUNT,
+	&"base_coords": Gen1Layout.BASE_COORD_COUNT,
+}
+
+## `SpecialEffectPointers` is 40 rows in both dumps.
+const SPECIAL_EFFECT_COUNT: int = 39
+
+## `FallingObjects_DeltaXs`' nine bytes and what the two objects that walk off
+## the end read behind it. Byte 10 is where the two dumps disagree.
+const FALLING_DELTAS: Array[int] = [0, 1, 3, 5, 7, 9, 11, 13, 15, 0xFA]
+const FALLING_OVERRUN: Dictionary = {&"red": 0x8A, &"blue": 0x8A, &"yellow": 0x89}
+
+## `MoveAnimationTilesPointers`, whose third row is the first cut short.
+const TILESET_TILES: Array[int] = [79, 79, 64]
+
+## `PoundAnim`: tileset 0 at delay 8, POUND's sound and `SUBANIM_0_STAR_TWICE`.
+const POUND_INDEX: int = 0
+const POUND_DELAY: int = 8
+const POUND_SUBANIM: int = 0x01
+
+## `Subanim_0StarTwice`: two `FRAMEBLOCK_01` frames, both `FRAMEBLOCKMODE_00`.
+const POUND_ROWS: Array = [[0x01, 0x0F, 0x00], [0x01, 0x1D, 0x00]]
+## `FrameBlock01` is nine sprites, the first of them the block's own corner.
+const POUND_SPRITES: int = 9
+## Where the first of them lands with `BASECOORD_0F`, which is `$20, $70`: the
+## base coordinate plus the sprite's own zero offsets, and `$31` over its tile.
+const POUND_FIRST_SPRITE: Array[int] = [0x20, 0x70, 0x31 + 0x2C, 0x00]
+
+## `SUBANIMTYPE_ENEMY` reads the other way round: it flips on the player's turn
+## and not on the enemy's. `Subanim_1StarBigMoving` is a plain one beside it.
+const ENEMY_SUBANIM: int = 24
+const HFLIP_SUBANIM: int = 4
+
+## A guard: the longest is `AnimationWavyScreen`'s 255 frames and its framing.
+const MAX_FRAMES: int = 1024
+
+## How many of `SpecialEffectPointers`' ids the corpus names, all of them drawn.
+const IMPLEMENTED_EFFECTS: Dictionary = {&"red": 36, &"blue": 36, &"yellow": 36}
+
+## The whole engine in two numbers: a delay read wrong moves the frames and a
+## transform read wrong moves the sprites. Yellow is one animation short and the
+## same sprites, `ZigZagScreenAnim` being `SE_WAVY_SCREEN` alone.
+const EXPECTED_TOTALS: Dictionary = {
+	&"red": [24828, 141410],
+	&"blue": [24828, 141410],
+	&"yellow": [24316, 141410],
+}
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	var anims: Gen2BattleAnimData = Gen2BattleAnimData.from_game_data(_r.data)
+	if not _r.check(anims != null, "%s: no battle animation layer in the cache." % _r.game_id):
+		return
+	if not _r.check(anims.gen1(), "%s: the animation layer is not Generation 1's." % _r.game_id):
+		return
+	_verify_tables(anims)
+	_verify_pound(anims)
+	_verify_transforms(anims)
+	_play_every_animation(anims)
+
+
+func _verify_tables(anims: Gen2BattleAnimData) -> void:
+	_r.check(
+		anims.count(Gen2BattleAnimData.GEN1_REGION) == Gen1Layout.anim_count(_r.game_id),
+		"%s: AttackAnimationPointers holds %d rows, expected %d." % [
+			_r.game_id, anims.count(Gen2BattleAnimData.GEN1_REGION),
+			Gen1Layout.anim_count(_r.game_id),
+		]
+	)
+	for table: StringName in EXPECTED_COUNTS:
+		_r.check(
+			_r.data.battle_anim_table(table) > 0,
+			"%s: %s is not in the cached region." % [_r.game_id, table]
+		)
+	_r.check(
+		anims.gen1_frame_block(Gen1Layout.FRAME_BLOCK_COUNT - 1).size() > 0
+			and anims.gen1_subanim(Gen1Layout.SUBANIM_COUNT - 1).get("rows", []).size() > 0
+			and anims.gen1_base_coord(Gen1Layout.BASE_COORD_COUNT - 1) != Vector2i.ZERO,
+		"%s: the last row of one of the three tables does not decode." % _r.game_id
+	)
+
+	for index: int in FALLING_DELTAS.size():
+		_r.check(
+			anims.gen1_falling_delta(index) == FALLING_DELTAS[index],
+			"%s: FallingObjects_DeltaXs byte %d is $%02X, expected $%02X." % [
+				_r.game_id, index, anims.gen1_falling_delta(index), FALLING_DELTAS[index],
+			]
+		)
+	_r.check(
+		anims.gen1_falling_delta(FALLING_DELTAS.size())
+			== int(FALLING_OVERRUN[_r.game_id]),
+		"%s: the byte a petal reads past FallingObjects_DeltaXs is $%02X." % [
+			_r.game_id, anims.gen1_falling_delta(FALLING_DELTAS.size()),
+		]
+	)
+
+	var effects: PackedInt32Array = _r.data.battle_anim_special_effects()
+	_r.check(
+		effects.size() == SPECIAL_EFFECT_COUNT,
+		"%s: SpecialEffectPointers holds %d ids, expected %d." % [
+			_r.game_id, effects.size(), SPECIAL_EFFECT_COUNT,
+		]
+	)
+	for index: int in TILESET_TILES.size():
+		var row: Dictionary = anims.gfx(index)
+		_r.check(
+			int(row.get("tiles", 0)) == TILESET_TILES[index],
+			"%s: animation tileset %d holds %d tiles, expected %d." % [
+				_r.game_id, index, int(row.get("tiles", 0)), TILESET_TILES[index],
+			]
+		)
+		_r.check(
+			_r.data.battle_anim_gfx_indices(index).size()
+				== TILESET_TILES[index] * PokeTiles.TILE_WIDTH * PokeTiles.TILE_HEIGHT,
+			"%s: animation tileset %d did not decode to its own pixels." % [_r.game_id, index]
+		)
+
+
+## POUND end to end, down to the first sprite that lands on screen.
+func _verify_pound(anims: Gen2BattleAnimData) -> void:
+	var address: int = anims.pointer(Gen2BattleAnimData.GEN1_REGION, POUND_INDEX)
+	var byte: int = anims.byte_at(Gen2BattleAnimData.GEN1_REGION, address)
+	_r.check(
+		byte == POUND_DELAY and byte >> Gen1Layout.ANIM_TILESET_SHIFT == 0,
+		"%s: POUND's row is $%02X, not tileset 0 at delay %d." % [
+			_r.game_id, byte, POUND_DELAY,
+		]
+	)
+	_r.check(
+		anims.byte_at(Gen2BattleAnimData.GEN1_REGION, address + 2) == POUND_SUBANIM,
+		"%s: POUND does not play SUBANIM_0_STAR_TWICE." % _r.game_id
+	)
+
+	var subanim: Dictionary = anims.gen1_subanim(POUND_SUBANIM)
+	var rows: Array = []
+	for row: Dictionary in subanim.get("rows", []):
+		rows.append([row["frame_block"], row["base_coord"], row["mode"]])
+	_r.check(
+		rows == POUND_ROWS,
+		"%s: SUBANIM_0_STAR_TWICE decoded to %s." % [_r.game_id, rows]
+	)
+	_r.check(
+		int(subanim.get("kind", -1)) == Gen1Layout.SUBANIMTYPE_HFLIP,
+		"%s: SUBANIM_0_STAR_TWICE is type %d, expected SUBANIMTYPE_HFLIP." % [
+			_r.game_id, int(subanim.get("kind", -1)),
+		]
+	)
+	_r.check(
+		anims.gen1_frame_block(int(POUND_ROWS[0][0])).size() == POUND_SPRITES,
+		"%s: FRAMEBLOCK_01 is not %d sprites." % [_r.game_id, POUND_SPRITES]
+	)
+
+	var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(anims, POUND_INDEX)
+	if not _r.check(player != null, "%s: POUND would not start." % _r.game_id):
+		return
+	player.advance_frame()
+	var sprites: Array = player.sprites()
+	if not _r.check(sprites.size() == POUND_SPRITES, "%s: POUND drew %d sprites on its first frame, expected %d." % [_r.game_id, sprites.size(), POUND_SPRITES]):
+		return
+	var first: Dictionary = sprites[0]
+	_r.check(
+		[first["y"], first["x"], first["tile"], first["attributes"]] == POUND_FIRST_SPRITE,
+		"%s: POUND's first sprite is %s, expected %s." % [
+			_r.game_id, [first["y"], first["x"], first["tile"], first["attributes"]],
+			POUND_FIRST_SPRITE,
+		]
+	)
+
+
+## `GetSubanimationTransform1` and `..._2`, the same table read either way.
+func _verify_transforms(anims: Gen2BattleAnimData) -> void:
+	_r.check(
+		int(anims.gen1_subanim(ENEMY_SUBANIM).get("kind", -1))
+			== Gen1Layout.SUBANIMTYPE_ENEMY,
+		"%s: subanimation %d is not SUBANIMTYPE_ENEMY." % [_r.game_id, ENEMY_SUBANIM]
+	)
+	_r.check(
+		int(anims.gen1_subanim(HFLIP_SUBANIM).get("kind", -1))
+			== Gen1Layout.SUBANIMTYPE_HFLIP,
+		"%s: subanimation %d is not SUBANIMTYPE_HFLIP." % [_r.game_id, HFLIP_SUBANIM]
+	)
+
+
+## Every animation on both turns, run to its end.
+func _play_every_animation(anims: Gen2BattleAnimData) -> void:
+	var count: int = Gen1Layout.anim_count(_r.game_id)
+	var frames: int = 0
+	var drawn: int = 0
+	var missing: Dictionary = {}
+	var answered: Dictionary = {}
+	for index: int in count:
+		for enemy_turn: bool in [false, true]:
+			var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(
+				anims, index, enemy_turn
+			)
+			if not _r.check(player != null, "%s: animation %d would not start." % [
+				_r.game_id, index,
+			]):
+				return
+			var spent: int = 0
+			while not player.finished() and spent < MAX_FRAMES:
+				player.advance_frame()
+				drawn += player.sprites().size()
+				spent += 1
+			if not _r.check(spent < MAX_FRAMES, "%s: animation %d never ended." % [
+				_r.game_id, index,
+			]):
+				return
+			frames += spent
+			for id: int in player.unimplemented().get("gen1_effects", []):
+				missing[id] = int(missing.get(id, 0)) + 1
+	for index: int in count:
+		_count_effects(anims, index, missing, answered)
+
+	var totals: Array = EXPECTED_TOTALS[_r.game_id]
+	_r.check(
+		[frames, drawn] == totals,
+		"%s: the corpus ran for %d frames drawing %d sprites, expected %s." % [
+			_r.game_id, frames, drawn, totals,
+		]
+	)
+	_r.check(
+		answered.size() == int(IMPLEMENTED_EFFECTS[_r.game_id]),
+		"%s: %d special effects are drawn, expected %d." % [
+			_r.game_id, answered.size(), int(IMPLEMENTED_EFFECTS[_r.game_id]),
+		]
+	)
+	var names: Array = missing.keys()
+	names.sort()
+	_r.note("%d animations, %d frames, %d sprites, %d special effects drawn, %d not (%s)" % [
+		count, frames, drawn, answered.size(), missing.size(),
+		", ".join(_hex(names)),
+	])
+
+
+## Which special effect ids the corpus names, read off the stream rather than
+## the player, so one no animation reaches is not counted either way.
+func _count_effects(
+	anims: Gen2BattleAnimData, index: int, missing: Dictionary, answered: Dictionary
+) -> void:
+	var at: int = anims.pointer(Gen2BattleAnimData.GEN1_REGION, index)
+	for _row: int in Gen2BattleAnimPlayer.GEN1_MAX_STEPS:
+		var byte: int = anims.byte_at(Gen2BattleAnimData.GEN1_REGION, at)
+		if byte == Gen1Layout.ANIM_END:
+			return
+		if byte < Gen1Layout.ANIM_FIRST_SE_ID:
+			at += Gen1Layout.ANIM_SUBANIM_SIZE
+			continue
+		at += Gen1Layout.ANIM_SE_SIZE
+		_r.check(
+			anims.gen1_has_special_effect(byte),
+			"%s: animation %d names special effect $%02X, which is not in the table." % [
+				_r.game_id, index, byte,
+			]
+		)
+		if not missing.has(byte):
+			answered[byte] = true
+
+
+static func _hex(ids: Array) -> PackedStringArray:
+	var out := PackedStringArray()
+	for id: Variant in ids:
+		out.append("$%02X" % int(id))
+	return out

--- a/tools/checks/gen1_battle_anims.gd.uid
+++ b/tools/checks/gen1_battle_anims.gd.uid
@@ -1,0 +1,1 @@
+uid://dc0n7kwry4aof

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -44,7 +44,10 @@ const GROUPS: Dictionary = {
 		&"battle_tower", &"npc_trade",
 	],
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
-	&"gen1": [&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle"],
+	&"gen1": [
+		&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle",
+		&"gen1_battle_anims",
+	],
 }
 
 


### PR DESCRIPTION
## Added

`Gen1Importer` caches bank $1E's four animation tables as one region: `AttackAnimationPointers` at its base with `SubanimationPointers`, `FrameBlockPointers` and `FrameBlockBaseCoords` addressed inside it, plus `SpecialEffectPointers`' ids, `MoveAnimationTilesPointers`' three sheets as `battle_anim_gfx` strips, and 128 bytes from `FallingObjects_DeltaXs`. Every row is walked against the table it indexes, so a wrong offset refuses the import rather than animating noise.

`Gen2BattleAnimPlayer.create_gen1` is `PlayAnimation`. Every `DelayFrames` is a countdown, so a frame is a wait or the work between two, and a `FRAMEBLOCKMODE_02` row takes none. `DrawFrameBlock`'s four transforms and five modes place a block's `dbsprite` rows in `wShadowOAM` from `$31`, which is the base Crystal counts OAM tiles from as well, so the renderer's window needs no seam.

All 36 of `SpecialEffectPointers`' ids the corpus names spend their own frames, and `AnimationIdSpecialEffects`' per-frame-block routines run beside them.

`tools/checks/gen1_battle_anims.gd` plays all 203 rows on both turns on all three cartridges. `tools/preview_battle_anim.gd` photographs one.

## Changed

The palette an animation is drawn in: `rOBP0` is $F0 for the length of a subanimation and every `SuperPalettes` row shares colours 0 and 3, so an animation sprite is two colours whichever Super Game Boy block it stands over. `rBGP` now reaches a Generation 1 screen through one map where the Color hardware has eight, which is what `SetAnimationBGPalette` and `AnimationFlashScreen` darken it with.

## Fixed

Two of Petal Dance's twenty objects walk off `FallingObjects_DeltaXs` and read `FallingObjects_UpdateMovementByte`'s own machine code as their drift, which the two dumps disagree on. Those bytes are imported rather than held as a constant.

| Cartridge | Animations | Frames | Sprites | Special effects |
|---|---|---|---|---|
| Red | 203 | 24,828 | 141,410 | 36 of 36 |
| Blue | 203 | 24,828 | 141,410 | 36 of 36 |
| Yellow | 202 | 24,316 | 141,410 | 36 of 36 |