### PR TITLE
Shake the screen on a Generation 1 hit and grow a send-out from its ball

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -1433,8 +1433,10 @@ func entrance_events(side: int, ball: bool = true) -> Array:
 	if ball:
 		out.append(_send_out_animation(enemy_turn, SEND_OUT_ANIM_NORMAL))
 	# `BattleCheckPlayerShininess`/`BattleCheckEnemyShininess`, which read the
-	# live DVs: a Transform has already copied the target's over them.
-	if Gen2Stats.is_shiny(entering.dvs):
+	# live DVs: a Transform has already copied the target's over them. Neither
+	# routine exists on a Generation 1 cartridge, which has no shininess.
+	if data != null and data.generation != RomRegistry.GEN1 \
+			and Gen2Stats.is_shiny(entering.dvs):
 		out.append(_send_out_animation(enemy_turn, SEND_OUT_ANIM_SHINY))
 	# `CheckFaintedFrzSlp`: no cry from a fainted, frozen or sleeping Pokemon.
 	# Crystal's alone: pokegold's `SendOutPlayerMon` and

--- a/game/battle/battle_anim_background.gd
+++ b/game/battle/battle_anim_background.gd
@@ -4,8 +4,7 @@ extends RefCounted
 ## The video state a battle animation's background effects write, and the
 ## primitives they write it with (engine/battle_anims/bg_effects.asm). A bg effect
 ## does not draw: it edits the scanline tables, the screen scroll, the DMG palette
-## bytes and the tilemap the battler's picture sits in. All four are held here, so
-## an effect stays arithmetic the way a motion callback does.
+## bytes and the tilemap the picture sits in, all four held here.
 
 const SCREEN_WIDTH: int = 20
 const SCREEN_HEIGHT: int = 18
@@ -74,11 +73,9 @@ var r_bgp: int = PALETTE_IDENTITY
 var r_obp0: int = PALETTE_IDENTITY
 
 ## Which permutation of its own four colours each palette is drawn with, as the
-## DMG palette byte `CopyPals` was handed.
-##
-## `CopyPals` always reads the pristine `wBGPals2`/`wOBPals2`, never the live
-## copy, so a remap is never compounded and the byte is the whole state. A
-## renderer applies it to whatever colours the battle actually loaded.
+## DMG palette byte `CopyPals` was handed. `CopyPals` always reads the pristine
+## `wBGPals2`/`wOBPals2`, so a remap is never compounded and the byte is the
+## whole state.
 var bg_palette_maps: PackedByteArray = PackedByteArray()
 var ob_palette_maps: PackedByteArray = PackedByteArray()
 
@@ -97,12 +94,11 @@ var bg_map_third: int = 0
 var surf_wave: PackedByteArray = PackedByteArray()
 
 ## What the tilemap effects did to each battler's picture, keyed by `player_side`.
-## `BattleBGEffect_HideMon`, `..._RemoveMon` and `..._RunPicResizeScript` all say
-## it by editing `wTilemap`, and a renderer with no background plane cannot read a
-## shrink or a removal back out of a grid of tile ids. `visible` is whether a
-## picture is on the square at all, `shift` how far `RemoveMon` has pushed it off
-## in pixels, and `scale` the side of the square the resize script last placed
-## over the side of the whole picture.
+## `BattleBGEffect_HideMon`, `..._RemoveMon` and `..._RunPicResizeScript` say it
+## by editing `wTilemap`, which a renderer with no background plane cannot read a
+## shrink or a removal back out of. `visible` is whether a picture is on the
+## square, `shift` how far it has been pushed off in pixels, and `scale` the side
+## of the square last placed over the side of the whole picture.
 var battler_visible: Dictionary = {true: true, false: true}
 var battler_shift: Dictionary = {true: Vector2.ZERO, false: Vector2.ZERO}
 var battler_scale: Dictionary = {true: 1.0, false: 1.0}
@@ -124,10 +120,9 @@ const PLAYER_WINDOW_TOP: int = 0x2D
 ## Tackle, Withdraw, Dig, Psychic, DoubleTeam, AcidArmor, Wobble, Flail,
 ## WaveDeformMon, BounceDown and Vibrate all move a battler by writing scroll
 ## values into it. The mean of the window on the axis `hLCDCPointer` names, less
-## the whole-screen scroll `raster_scx`/`raster_scy` already carry. A scroll of n
-## draws n pixels further left or up, so the offset is its negation, and a row
-## pushed off with `$90` is not part of the mean. WaveDeformMon and Psychic
-## stretch rather than move, where the mean is a summary rather than an answer.
+## the whole-screen scroll `raster_scx`/`raster_scy` already carry, negated
+## because a scroll of n draws n pixels further left or up; a row pushed off with
+## `$90` is not in the mean. WaveDeformMon and Psychic stretch rather than move.
 func battler_window_offset(player_side: bool) -> Vector2:
 	if lcdc_pointer != LCDC_SCX and lcdc_pointer != LCDC_SCY:
 		return Vector2.ZERO

--- a/game/battle/battle_anim_player.gd
+++ b/game/battle/battle_anim_player.gd
@@ -3,10 +3,9 @@ extends RefCounted
 
 ## One battle animation playing: `RunBattleAnimScript`'s frame loop
 ## (engine/battle_anims/anim_commands.asm). [Gen2BattleAnimScript] is the
-## interpreter and [Gen2BattleAnimObject] is one object; this runs the script
-## until it yields, steps every live object and collects what they would put in
-## `wShadowOAM`. [method unimplemented] reports what an animation asked for and
-## did not get.
+## interpreter and [Gen2BattleAnimObject] one object; this runs the script until
+## it yields, steps every live object and collects `wShadowOAM`.
+## [method unimplemented] reports what an animation asked for and did not get.
 
 ## `NUM_BATTLE_ANIM_STRUCTS`: an eleventh object is simply not spawned.
 const MAX_OBJECTS: int = 10
@@ -117,6 +116,10 @@ var _gen1_write: int = 0
 var _gen1_block: int = 0
 var _gen1_steps: Array = []
 var _gen1_wait: int = 0
+## A routine rather than a row: the step list is the whole animation.
+var _gen1_steps_only: bool = false
+## `wNumShakes`, which `DoBallShakeSpecialEffects` counts off.
+var _gen1_shakes: int = 0
 
 ## `wCurItem`, read by `GetBallAnimPal` to colour a thrown ball. Nothing else
 ## asks, and a non-ball falls out of `BallColors` on its own terminator.
@@ -164,26 +167,48 @@ static func create(
 ## of frame blocks drawn straight into `wShadowOAM`. There is no `param` and no
 ## wobble list, and a row's sound byte is dropped for want of an audio driver.
 static func create_gen1(
-	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool = false
+	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool = false,
+	shakes: int = 0
 ) -> Gen2BattleAnimPlayer:
 	if anim_data == null or not anim_data.gen1():
 		return null
 	var address: int = anim_data.pointer(Gen2BattleAnimData.GEN1_REGION, index)
 	if address < 0:
 		return null
+	var player: Gen2BattleAnimPlayer = _seeded_gen1(anim_data, index, on_enemy_turn)
+	player._gen1_at = address
+	player._gen1_shakes = shakes
+	return player
 
+
+## `PlayApplyingAttackAnimation`: the shake or blink a move ends with, out of
+## `AnimationTypePointerTable`. Null for a `wAnimationType` of zero.
+static func create_gen1_applying(
+	anim_data: Gen2BattleAnimData, animation_type: int, on_enemy_turn: bool = false
+) -> Gen2BattleAnimPlayer:
+	if anim_data == null or not anim_data.gen1():
+		return null
+	var player: Gen2BattleAnimPlayer = _seeded_gen1(anim_data, 0, on_enemy_turn)
+	player._gen1_steps_only = true
+	player._gen1_steps = player._gen1_applying_steps(animation_type)
+	return null if player._gen1_steps.is_empty() else player
+
+
+static func _seeded_gen1(
+	anim_data: Gen2BattleAnimData, index: int, on_enemy_turn: bool
+) -> Gen2BattleAnimPlayer:
 	var player := Gen2BattleAnimPlayer.new()
 	player._data = anim_data
 	player._anim_index = index
 	player._enemy_turn = on_enemy_turn
 	player._gen1 = true
-	player._gen1_at = address
 	player._objects.resize(MAX_OBJECTS)
 	player._tile_dict.resize(TILE_DICT_ENTRIES)
 	player._bg_effects.resize(MAX_BG_EFFECTS)
 	for slot: int in MAX_BG_EFFECTS:
 		player._bg_effects[slot] = Gen2BattleAnimBgEffect.new()
 	player._background = Gen2BattleAnimBackground.new()
+	player._background.obp0 = Gen1Layout.ANIM_OBP0
 	return player
 
 
@@ -259,13 +284,11 @@ func sprites() -> Array:
 
 
 ## What each tile of the animation window currently holds, indexed from
-## [constant Gen2BattleAnimObject.BASE_TILE]. An OAM tile id below that base is
-## not an animation tile at all.
-##
-## Two shapes: [code]{ gfx, tile }[/code] is a tile of an imported sheet, and
-## [code]{ battler_tile }[/code] a tile of `vTiles2`, which is where the battle's
-## own two pictures live, in the numbering [Gen2BattleScreenMap] uses. Only
-## `anim_battlergfx_1row` and `..._2row` produce the second.
+## [constant Gen2BattleAnimObject.BASE_TILE]; an OAM tile id below that base is
+## not an animation tile. [code]{ gfx, tile }[/code] is a tile of an imported
+## sheet and [code]{ battler_tile }[/code] one of `vTiles2`, in the numbering
+## [Gen2BattleScreenMap] uses; only `anim_battlergfx_1row` and `..._2row` make
+## the second.
 func tiles() -> Array:
 	return _tiles
 
@@ -299,9 +322,8 @@ func unimplemented() -> Dictionary:
 
 ## One hardware frame of `.playframe`, in its order: the script, the bg effects,
 ## every object, the scanline table and the palettes. `.playframe` skips its own
-## `BattleAnimDelayFrame` while Rollout's bg effect is live, because that effect
-## waits a frame itself, but both paths spend exactly one frame, so a player
-## stepped once per frame has nothing for the check to decide.
+## `BattleAnimDelayFrame` while Rollout's bg effect is live, that effect waiting
+## a frame itself; both paths spend one frame, so nothing here decides.
 func advance_frame() -> bool:
 	if finished():
 		_finish()
@@ -408,10 +430,9 @@ func _load_graphics(operands: Array) -> void:
 
 ## `BattleAnimCmd_BattlerGFX_1Row` and `..._2Row`: one or two rows of each
 ## battler's picture copied into the top of the animation window, so an effect can
-## lift a battler's feet or head off the tilemap and move them as objects.
-## The dict entries are crosswise with what is copied, `PLAYERHEAD` holding the
+## lift a battler's feet or head off the tilemap and move them as objects. The
+## dict entries are crosswise with what is copied, `PLAYERHEAD` holding the
 ## enemy's rows, and the object rows are crossed the same way, so the two cancel.
-## Both crossings are the cartridge's and neither is tidied.
 func _load_battler_graphics(rows: int) -> void:
 	var slot: int = _free_tile_dict_slot()
 	if slot < 0 or slot + 1 >= TILE_DICT_ENTRIES:
@@ -520,9 +541,8 @@ func _execute_bg_effects() -> void:
 ## `BattleAnim_UpdateOAM_All`: every live object stepped and drawn in slot order,
 ## stopping at the first whose sprites would not fit. The slot's index byte is
 ## tested once, at the top of the loop, so an object whose own callback calls
-## `DeinitBattleAnimation` is still drawn once more where it stands. Measured on a
-## cartridge: TACKLE's `anim_incobj 1` frees the target's two rows on the frame it
-## runs and OAM still holds their fourteen sprites.
+## `DeinitBattleAnimation` is still drawn once more. Measured on a cartridge:
+## TACKLE's `anim_incobj 1` frees two rows and OAM still holds their sprites.
 func _update_oam() -> void:
 	_sprites = []
 	for object: Gen2BattleAnimObject in _objects:
@@ -588,6 +608,8 @@ func _gen1_frame() -> bool:
 func _gen1_step() -> void:
 	if not _gen1_steps.is_empty():
 		_gen1_effect_step()
+	elif _gen1_steps_only:
+		_gen1_done = true
 	elif _gen1_mode >= 0 or _gen1_row < _gen1_rows.size():
 		_gen1_subanim_step()
 	else:
@@ -744,6 +766,10 @@ func _gen1_apply(key: StringName, value: Variant) -> void:
 		&"bgp":
 			_background.bgp = int(value)
 			_background.request_pals()
+		&"obp0":
+			_background.obp0 = int(value) & 0xFF
+		&"rewind":
+			_gen1_row = maxi(_gen1_row - int(value), 0)
 		&"scx":
 			_background.scx = int(value) & 0xFF
 		&"scy":
@@ -754,10 +780,16 @@ func _gen1_apply(key: StringName, value: Variant) -> void:
 			_gen1_copy_sprites(int(value))
 		&"visible":
 			var side: Array = value
-			_background.report_battler(_gen1_side(bool(side[0])), bool(side[1]))
+			_gen1_draw_battler(_gen1_side(bool(side[0])), bool(side[1]))
 		&"shift":
 			var moved: Array = value
-			_background.battler_shift[_gen1_side(bool(moved[0]))] = moved[1] as Vector2
+			_gen1_move_battler(_gen1_side(bool(moved[0])), moved[1] as Vector2)
+		&"squish":
+			var squeezed: Array = value
+			Gen2BattleScreenMap.squish_step(
+				_background.bg_map, _gen1_side(bool(squeezed[0])),
+				RomRegistry.GEN1, bool(squeezed[1])
+			)
 		&"scale":
 			var sized: Array = value
 			_background.battler_scale[_gen1_side(bool(sized[0]))] = float(sized[1])
@@ -779,6 +811,44 @@ func _gen1_apply(key: StringName, value: Variant) -> void:
 
 func _gen1_side(flipped: bool) -> bool:
 	return _enemy_turn if flipped else not _enemy_turn
+
+
+## `AnimationHideMonPic` and `AnimationShowMonPic`, which are `ClearScreenArea`
+## and `CopyPicTiles` over the box the picture was last drawn in. The report
+## beside it is what a renderer with no background plane reads.
+func _gen1_draw_battler(player_side: bool, visible: bool) -> void:
+	_gen1_clear_battler(player_side)
+	_background.report_battler(player_side, visible)
+	if visible:
+		Gen2BattleScreenMap.stamp(
+			_background.bg_map, player_side, RomRegistry.GEN1,
+			_gen1_shift_tiles(player_side)
+		)
+
+
+func _gen1_move_battler(player_side: bool, shift: Vector2) -> void:
+	var visible: bool = bool(_background.battler_visible[player_side])
+	_gen1_clear_battler(player_side)
+	_background.battler_shift[player_side] = shift
+	if visible:
+		Gen2BattleScreenMap.stamp(
+			_background.bg_map, player_side, RomRegistry.GEN1,
+			_gen1_shift_tiles(player_side)
+		)
+
+
+func _gen1_clear_battler(player_side: bool) -> void:
+	if bool(_background.battler_visible[player_side]):
+		Gen2BattleScreenMap.clear_battler(
+			_background.bg_map, player_side, RomRegistry.GEN1,
+			_gen1_shift_tiles(player_side)
+		)
+
+
+func _gen1_shift_tiles(player_side: bool) -> Vector2i:
+	return Vector2i(
+		(_background.battler_shift[player_side] as Vector2) / float(GEN1_TILE)
+	)
 
 
 func _gen1_command(name: StringName) -> void:
@@ -818,9 +888,10 @@ const GEN1_EFFECT_BGP: Dictionary = {
 
 ## The routines that walk a picture off its square, as
 ## [code][steps, pixels, frames, horizontal, hide][/code]. A horizontal slide
-## goes towards the edge the picture stands against.
+## goes towards the edge the picture stands against; `_AnimationSlideMonUp`
+## scrolls its box upwards, which is the one negative row.
 const GEN1_EFFECT_SLIDES: Dictionary = {
-	0xF7: [7, 8, 2, false, false],  # SE_SLIDE_MON_UP
+	0xF7: [7, -8, 2, false, false],  # SE_SLIDE_MON_UP
 	GEN1_SE_SLIDE_MON_DOWN: [7, 8, 3, false, true],
 	0xF4: [8, 8, 3, true, true],    # SE_SLIDE_MON_OFF
 	0xE5: [4, 8, 4, true, false],   # SE_SLIDE_MON_HALF_OFF
@@ -846,9 +917,9 @@ const GEN1_SE_WAVY_SCREEN: int = 0xD8
 
 ## What one step of an effect may write. `frames` is every step's own duration.
 const GEN1_EFFECT_KEYS: Array[StringName] = [
-	&"tileset", &"bgp", &"scx", &"scy", &"visible", &"shift", &"scale",
-	&"substitute", &"minimize", &"wavy", &"rows", &"sprites", &"copy_sprites",
-	&"end_subanim",
+	&"tileset", &"bgp", &"obp0", &"scx", &"scy", &"visible", &"shift", &"squish",
+	&"scale", &"substitute", &"minimize", &"wavy", &"rows", &"sprites",
+	&"copy_sprites", &"end_subanim", &"rewind",
 ]
 
 ## `%00011011`, `AnimationFlashScreen`'s inverted palette, and the white it
@@ -864,13 +935,30 @@ const GEN1_FLASH_LONG_PALETTES: Array[int] = [
 ]
 const GEN1_FLASH_LONG_FRAMES: Array[int] = [2, 1, 1]
 
-## `PredefShakeScreenHorizontally` with `b = 8`: the window out by the count for
-## five frames and back for four, the count dropping. `rWX` right is scroll left.
+## `PredefShakeScreenHorizontally` with `b = 8`; `rWX` right is scroll left.
+## `.MutateWX` xors the running offset with the count, so only the first pass
+## opens on the offset and every later one opens on zero.
 const GEN1_SHAKE_AMPLITUDE: int = 8
 const GEN1_SHAKE_OUT_FRAMES: int = 5
 const GEN1_SHAKE_BACK_FRAMES: int = 4
+const GEN1_SHAKE_VERTICAL_FRAMES: int = 3
 const GEN1_SHAKE_ONE_OUT: int = 4
 const GEN1_SHAKE_ONE_BACK: int = 3
+
+## `AnimationTypePointerTable` by `wAnimationType`, as [code][amplitude,
+## vertical][/code]: rows 1 to 3 are the enemy's turn and 4 to 6 the player's.
+const GEN1_APPLYING_SHAKE: Dictionary = {1: [8, true], 2: [8, false], 5: [2, false]}
+## `lb bc, 6, 2` and `lb bc, 3, 2`, the two non-damaging rows.
+const GEN1_APPLYING_SLOW: Dictionary = {3: 6, 6: 3}
+const GEN1_APPLYING_BLINK: int = 4
+const GEN1_SLOW_SHAKE_FRAMES: int = 2
+const GEN1_SLOW_SHAKE_PASSES: int = 2
+
+## `DoBallTossSpecialEffects`' `xor %00111100` on `rOBP0`, and
+## `DoBallShakeSpecialEffects`' four subentries and `ld c, 40`.
+const GEN1_BALL_FLASH: int = 0x3C
+const GEN1_BALL_SHAKE_ENTRIES: int = 4
+const GEN1_BALL_SHAKE_WAIT: int = 40
 
 ## `AnimationBlinkMon`: six times off and on, five frames each.
 const GEN1_BLINK_CYCLES: int = 6
@@ -1030,7 +1118,7 @@ func _gen1_effect_steps(id: int) -> Array:
 		GEN1_SE_FLASH_SCREEN_LONG:
 			return _gen1_flash_long_steps()
 		GEN1_SE_SHAKE_SCREEN:
-			return _gen1_shake_screen_steps()
+			return _gen1_predef_shake_steps(GEN1_SHAKE_AMPLITUDE)
 		GEN1_SE_DELAY_ANIMATION_10:
 			return [{&"frames": GEN1_DELAY_FRAMES}]
 		GEN1_SE_WAVY_SCREEN:
@@ -1112,12 +1200,52 @@ func _gen1_flash_long_steps() -> Array:
 	return out
 
 
-func _gen1_shake_screen_steps() -> Array:
+func _gen1_predef_shake_steps(amplitude: int, vertical: bool = false) -> Array:
+	var key: StringName = &"scy" if vertical else &"scx"
+	var halves: Array = [GEN1_SHAKE_VERTICAL_FRAMES, GEN1_SHAKE_VERTICAL_FRAMES] \
+		if vertical else [GEN1_SHAKE_OUT_FRAMES, GEN1_SHAKE_BACK_FRAMES]
 	var out: Array = []
-	for amplitude: int in range(GEN1_SHAKE_AMPLITUDE, 0, -1):
-		out.append({&"frames": GEN1_SHAKE_OUT_FRAMES, &"scx": -amplitude})
-		out.append({&"frames": GEN1_SHAKE_BACK_FRAMES, &"scx": 0})
+	var value: int = 0
+	for count: int in range(amplitude, 0, -1):
+		for half: int in 2:
+			value ^= count
+			out.append({&"frames": halves[half], key: -value})
+		value = count - 1
+	out.append({key: 0})
 	return out
+
+
+func _gen1_applying_steps(animation_type: int) -> Array:
+	if GEN1_APPLYING_SHAKE.has(animation_type):
+		var row: Array = GEN1_APPLYING_SHAKE[animation_type]
+		return _gen1_predef_shake_steps(int(row[0]), bool(row[1]))
+	if GEN1_APPLYING_SLOW.has(animation_type):
+		return _gen1_slow_shake_steps(int(GEN1_APPLYING_SLOW[animation_type]))
+	if animation_type == GEN1_APPLYING_BLINK:
+		return _gen1_blink_steps(true)
+	return []
+
+
+## `AnimationShakeScreenHorizontallySlow`, whose two `pop bc` put the count back
+## for the return leg: the window out a pixel at a time and back.
+func _gen1_slow_shake_steps(width: int) -> Array:
+	var out: Array = []
+	for _pass: int in GEN1_SLOW_SHAKE_PASSES:
+		for step: int in width * 2:
+			var offset: int = step + 1 if step < width else width * 2 - step - 1
+			out.append({&"frames": GEN1_SLOW_SHAKE_FRAMES, &"scx": -offset})
+	return out
+
+
+## `DoBallShakeSpecialEffects`: two-thirds of a second at the top of a shake,
+## and the last block rewinding four subentries while shakes are left.
+func _gen1_ball_shake_steps(counter: int) -> Array:
+	if counter == GEN1_BALL_SHAKE_ENTRIES:
+		return [{&"frames": GEN1_BALL_SHAKE_WAIT}]
+	if counter > 1:
+		return []
+	_gen1_shakes -= 1
+	return [] if _gen1_shakes <= 0 else [{&"rewind": GEN1_BALL_SHAKE_ENTRIES}]
 
 
 func _gen1_blink_steps(flipped: bool) -> Array:
@@ -1146,6 +1274,7 @@ func _gen1_squish_steps(flipped: bool) -> Array:
 	for index: int in passes:
 		out.append({
 			&"frames": GEN1_SQUISH_FRAMES,
+			&"squish": [flipped, index % 2 == 1],
 			&"scale": [flipped, float(passes - index - 1) / float(passes)],
 		})
 	out.append({&"visible": [flipped, false], &"scale": [flipped, 1.0]})
@@ -1329,7 +1458,8 @@ func _gen1_hud_shake_steps() -> Array:
 
 ## `DoSpecialEffectByAnimationId`, after every frame block of the twenty-five
 ## `AnimationIdSpecialEffects` names. [param counter] is `wSubAnimCounter`, which
-## opens at the row count. The trade and ball rows wait for a caller.
+## opens at the row count. The three trade rows wait for a caller; `POOF_ANIM`'s
+## row is a sound and Generation 1 has no audio driver here.
 func _gen1_block_effect_steps(counter: int) -> Array:
 	var id: int = _anim_index + 1
 	if GEN1_BLOCK_FLASH.has(id):
@@ -1351,6 +1481,13 @@ func _gen1_block_effect_steps(counter: int) -> Array:
 			return _gen1_flash_when(counter % GEN1_FLASH_EVERY_FOUR == 0)
 		GEN1_ROCK_SLIDE:
 			return _gen1_rock_slide_steps(counter)
+		Gen1Layout.ANIM_ID_TOSS, Gen1Layout.ANIM_ID_GREATTOSS, \
+		Gen1Layout.ANIM_ID_ULTRATOSS:
+			if cur_item > Gen1Layout.ITEM_ULTRA_BALL:
+				return []
+			return [{&"obp0": _background.obp0 ^ GEN1_BALL_FLASH}]
+		Gen1Layout.ANIM_ID_SHAKE:
+			return _gen1_ball_shake_steps(counter)
 	return []
 
 

--- a/game/battle/battle_renderer.gd
+++ b/game/battle/battle_renderer.gd
@@ -917,7 +917,8 @@ static func pic_tile(pixels: PackedByteArray, side: int, index: int) -> PackedBy
 ## reads the two between and takes the square's own.
 func _gen1_object_palette(attributes: int) -> PackedColorArray:
 	var dmg: int = Gen1Layout.ANIM_OBP1 \
-		if (attributes & Gen1Layout.ANIM_OAM_OBP1) != 0 else Gen1Layout.ANIM_OBP0
+		if (attributes & Gen1Layout.ANIM_OAM_OBP1) != 0 \
+		else int(_view.get("anim_obp0", Gen1Layout.ANIM_OBP0))
 	return _remap(gen1_screen_palette(GEN1_PAL_PLAYER_MON), dmg)
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -201,12 +201,9 @@ var _renderer_ready: bool = false:
 var _battle: Gen2Battle = null
 var _pending: Array = []
 var _rng := RandomNumberGenerator.new()
-## Whether something else owns the funnel every button arrives through. Set while
-## this screen is an overlay inside the overworld, so a press is recorded once, by
-## the world, and a replayed log reaches the fight: see
-## [method Gen2WorldScreen.press_button] and `tools/replay_world.gd`.
-## Whether the screen that opened this one owns its input and its frames. See
-## [method set_driven].
+## Whether the screen that opened this one owns its input and its frames, so a
+## press is recorded once and a replayed log reaches the fight. See
+## [method set_driven] and `tools/replay_world.gd`.
 var _driven: bool = false
 var _save_slot: int = -1
 var _save_written: bool = false
@@ -551,11 +548,9 @@ func _process(delta: float) -> void:
 	if _box != null:
 		_box.accelerated = PokeButton.text_accelerating()
 	## A screen someone else spends frames for must not also spend them off real
-	## time. The world drives a battle from its own pump
-	## ([method advance_hardware_frame]), so with this clock running as well every
-	## bar drained, every animation ran and the box's own arrow blinked at twice
-	## the source's rate. Same rule, and the same caller, as
-	## [member Gen2TextBox.driven].
+	## time: the world drives a battle from [method advance_hardware_frame], and
+	## with this clock running too every bar, animation and blinking arrow ran at
+	## twice the source's rate. Same rule as [member Gen2TextBox.driven].
 	if _driven:
 		return
 	## The yes/no box appears when the question above it has finished printing,
@@ -563,12 +558,10 @@ func _process(delta: float) -> void:
 	if _switch_stage != &"":
 		_advance_party_icons(delta)
 		_refresh_menu_layer()
-	## The box is on the same hardware clock as everything else the screen draws,
-	## and it keeps counting while nothing else does: a text prints, scrolls and
-	## blinks its arrow whether or not a bar or an animation is running.
-	## [method frames_running] deliberately does not answer for it, since a box
-	## waiting at a page is waiting on a press and a caller draining frames on
-	## that answer would never stop.
+	## The box keeps counting hardware frames while nothing else does, printing,
+	## scrolling and blinking whether or not a bar or an animation is running.
+	## [method frames_running] deliberately does not answer for it: a box waiting
+	## at a page waits on a press, and a caller draining frames would never stop.
 	var running: bool = frames_running()
 	if not running and (_box == null or not _box.visible):
 		_frame_clock.reset()
@@ -613,11 +606,9 @@ func advance_frame() -> bool:
 
 ## What the source does when the frames a command spends run out: it runs on to
 ## the next command. Nothing in `DoMove`'s loop reads a button between an
-## animation, `AnimateHPBar` and `MonFaintedAnimation` and whatever follows them,
-## so the pump continues here rather than standing still until a press.
-##
-## The waits that are real are all a box, and [method _continue_after_messages]
-## owns that test: a message on screen is left alone, and so is a bar holding one.
+## animation, `AnimateHPBar` and `MonFaintedAnimation` and what follows them. The
+## waits that are real are all a box, and [method _continue_after_messages] owns
+## that test: a message on screen is left alone, and so is a bar holding one.
 func _resume_after_frames(was_running: bool) -> void:
 	if not was_running or frames_running():
 		return
@@ -886,22 +877,16 @@ func set_rules(battle_rules: Gen2Rules) -> void:
 
 
 ## Seeds everything this screen decides for itself: the enemy's move choice, its
-## item and switch decisions, and the capture rolls.
-##
-## A battle inside a walk is drawn from the world's own generator, so the seed is
-## part of the run's own chain and a replay reproduces the fight without recording
-## anything about it. A battle with no world seeds itself randomly, which is what
-## a development one should do.
+## item and switch decisions, and the capture rolls. A battle inside a walk is
+## drawn from the world's own generator, so a replay reproduces the fight without
+## recording anything about it; one with no world seeds itself randomly.
 func set_random_seed(value: int) -> void:
 	_rng.seed = value
 
 
-## Hands the input funnel and the frame pump to whoever opened this screen.
-##
-## The world does both while a battle is an overlay on it. One funnel is what
-## makes a recorded log complete, and two would record every press twice or none;
-## one pump is what makes a replay land on the same frame, and two spend every
-## frame twice.
+## Hands the input funnel and the frame pump to whoever opened this screen, which
+## the world does while a battle is an overlay on it. Two funnels record every
+## press twice or none, and two pumps spend every frame twice.
 func set_driven(driven: bool) -> void:
 	_driven = driven
 
@@ -1332,10 +1317,8 @@ func set_hp(enemy: int, enemy_max: int, player: int, player_max: int) -> void:
 
 ## Begins a bar animation from [param from_hp] to the HP now committed for
 ## [param side], which is what an event meaning damage or healing does after it
-## has written the new value.
-##
-## A maximum that moved under the bar is not the same bar draining: a Pokemon
-## coming out gets its bar drawn at once, the way `LoadHPBar` puts one up.
+## has written the new value. A maximum that moved under the bar is not the same
+## bar draining: a Pokemon coming out has it drawn at once, as `LoadHPBar` does.
 func _start_bar(side: int, from_hp: int, from_max: int) -> void:
 	var to_hp: int = _enemy_hp if side == Gen2Battle.ENEMY else _player_hp
 	var max_hp: int = _enemy_max_hp if side == Gen2Battle.ENEMY else _player_max_hp
@@ -1848,6 +1831,10 @@ const ANIM_RESTORE_HUD: StringName = &"restore_hud"
 const ANIM_WAIT_SFX: StringName = &"wait_sfx"
 const ANIM_HIT_SOUND: StringName = &"hit_sound"
 const ANIM_APPEAR_USER: StringName = &"appear_user"
+## `PlayApplyingAttackAnimation` and `AnimateSendingOutMon`, Generation 1's two
+## routines with no row behind them.
+const ANIM_APPLYING: StringName = &"applying"
+const ANIM_SEND_OUT: StringName = &"send_out"
 ## `PlaySFX` on its own, which only the entrance uses: an animation's own sounds
 ## come out of its script.
 const ANIM_SFX: StringName = &"sfx"
@@ -1869,11 +1856,8 @@ var _minimize_pic: Dictionary = {Gen2Battle.PLAYER: false, Gen2Battle.ENEMY: fal
 ## `BattleAnimCmd_Minimize` writes `vTiles0`, which is off screen, and
 ## `..._UpdateActorPic` copies it onto the square 48 frames later. The dot is
 ## already on by then, `BattleCommand_StatUp` having set the byte two commands
-## before the animation, so this only keeps the two halves of the source's own
-## pair together. `BattleAnim_Transform` is the other user of the pair and no
-## list here reaches it: `BattleCommand_Transform` calls `LoadMoveAnim` inline
-## rather than through an `anim` command, and this port's Transform prints
-## without an animation.
+## before, so this only keeps the source's own pair together.
+## `BattleAnim_Transform` is the pair's other user and no list here reaches it.
 var _staged_minimize_pic: bool = false
 
 ## `wFXAnimID` is a word: an id past this is not a move and skips the whole
@@ -2018,20 +2002,29 @@ func _begin_animation(event: Dictionary) -> void:
 		if after != 0:
 			_step(ANIM_WAIT_SFX, {})
 			_step(ANIM_HIT_SOUND, {})
-			_step(ANIM_SCRIPT, {
-				"index": after + Gen2BattleAnimPlayer.BATTLE_AFTERANIMS,
-			})
+			if gen1:
+				_step(ANIM_APPLYING, {"type": _gen1_animation_type(index, after)})
+			else:
+				_step(ANIM_SCRIPT, {
+					"index": after + Gen2BattleAnimPlayer.BATTLE_AFTERANIMS,
+				})
 	else:
 		_step(ANIM_WAIT_SFX, {})
 		_step(ANIM_HIT_SOUND, {})
-		_step(ANIM_SCRIPT, {"index": index})
+		if gen1 and index == Gen2Battle.ANIM_SEND_OUT_MON:
+			_gen1_send_out_steps(bool(event.get("enemy_turn", false)))
+		elif gen1 and index == ANIM_THROW_POKE_BALL:
+			_gen1_toss_ball_steps(event)
+		else:
+			_step(ANIM_SCRIPT, {"index": index})
 
 	# `hBGMapMode = 1`, three delays and `WaitSFX`.
 	_step(ANIM_DELAY, {"frames": 3})
 	_step(ANIM_WAIT_SFX, {})
-	# A send-out draws the picture itself and the ball animation only shows it
-	# arriving, so a cache with no animation layer still owes the square one.
-	if bool(event.get("restore_user_pic", false)) or (not is_move and _anim_row(index) < 0):
+	# A send-out draws the picture itself, so a cache with no animation layer at
+	# all still owes the square one.
+	if bool(event.get("restore_user_pic", false)) \
+			or (index == Gen2Battle.ANIM_SEND_OUT_MON and _anim_data == null):
 		_step(ANIM_APPEAR_USER, {})
 	_run_next_anim_step()
 
@@ -2120,8 +2113,20 @@ func _run_next_anim_step() -> void:
 			ANIM_HIT_SOUND:
 				_play_hit_sound()
 			ANIM_SCRIPT:
-				if _start_script(int(step["index"])):
+				if _start_script(
+					int(step["index"]),
+					bool(step.get("enemy_turn", _anim_event.get("enemy_turn", false))),
+					int(step.get("shakes", 0))
+				):
 					return
+			ANIM_APPLYING:
+				if _start_applying(int(step["type"])):
+					return
+			ANIM_SEND_OUT:
+				_send_out_step(int(step["size"]))
+				_anim_delay = int(step["frames"])
+				_push_view()
+				return
 			ANIM_APPEAR_USER:
 				# `AppearUserLowerSub`, which Fly and Dig reach after the
 				# animation: `LowerSubNoAnim` writes the user's own picture and
@@ -2137,23 +2142,45 @@ func _run_next_anim_step() -> void:
 	_push_view()
 
 
-## `AttackAnimationPointers`' rows for the ids the engine names past a move
-## number. Generation 1 numbers those differently from Crystal, and both of the
-## status pairs are picked by which side the animation is playing on.
+## `AttackAnimationPointers` rows for the ids `PlayOpponentBattleAnim` names past
+## a move number, as [code][on the player, on the enemy][/code]: that event's
+## `enemy_turn` is inverted, so the index is the side it is drawn on.
+## `FreezeBurnParalyzeEffect` plays `ENEMY_HUD_SHAKE_ANIM` on `.burn1`, `.freeze1`
+## and `paralyze1` and nothing on the three the opponent's attack reaches, and
+## `PoisonEffect`'s side-effect branch answers `SHAKE_SCREEN_ANIM` there. A
+## confusion is the move's own animation, so `ANIM_CONFUSED` has no row.
 const GEN1_ANIM_IDS: Dictionary = {
-	Gen2BattleAnimPlayer.ANIM_CONFUSED: [190, 191],
-	Gen2BattleAnimPlayer.ANIM_BRN: [186, 186],
-	Gen2BattleAnimPlayer.ANIM_PSN: [186, 186],
-	Gen2BattleAnimPlayer.ANIM_PAR: [184, 184],
+	Gen2BattleAnimPlayer.ANIM_BRN: [0, Gen1Layout.ANIM_ID_ENEMY_HUD_SHAKE],
+	Gen2BattleAnimPlayer.ANIM_FRZ: [0, Gen1Layout.ANIM_ID_ENEMY_HUD_SHAKE],
+	Gen2BattleAnimPlayer.ANIM_PAR: [0, Gen1Layout.ANIM_ID_ENEMY_HUD_SHAKE],
+	Gen2BattleAnimPlayer.ANIM_PSN: [
+		Gen1Layout.ANIM_ID_SHAKE_SCREEN, Gen1Layout.ANIM_ID_ENEMY_HUD_SHAKE,
+	],
+}
+
+## `wAnimationType`, which `GetPlayerAnimationType`, `GetEnemyAnimationType` and
+## `PlayBattleAnimation2` pick where Crystal picks `wBattleAfterAnim`. The damage
+## rows split on `ld a, [wPlayerMoveEffect] / and a`.
+const GEN1_APPLYING_TYPES: Dictionary = {
+	Gen2BattleAnimPlayer.AFTER_ANIM_ENEMY_DAMAGE: [4, 5],
+	Gen2BattleAnimPlayer.AFTER_ANIM_PLAYER_DAMAGE: [1, 2],
+	Gen2BattleAnimPlayer.AFTER_ANIM_ENEMY_STAT_DOWN: [6, 6],
+	Gen2BattleAnimPlayer.AFTER_ANIM_WOBBLE: [3, 3],
+}
+
+## `TossBallAnimation`'s throw, by `wCurItem`; anything else is `ULTRATOSS_ANIM`.
+const GEN1_TOSS_ANIMS: Dictionary = {
+	Gen1Layout.ITEM_POKE_BALL: Gen1Layout.ANIM_ID_TOSS,
+	Gen1Layout.ITEM_GREAT_BALL: Gen1Layout.ANIM_ID_GREATTOSS,
 }
 
 
 ## `wAnimationID` less one, which is what `AttackAnimationPointers` is indexed
 ## by. Crystal's own table is indexed by the id itself, so this is the identity
 ## there. -1 is an id this cartridge has no row for: `ANIM_SEND_OUT_MON`, the
-## thrown ball and the four after-anims are all their own routines in Generation
-## 1 rather than entries in the table, and `ANIM_FRZ` has no animation at all.
-func _anim_row(index: int) -> int:
+## thrown ball and the four after-anims are each their own routine in Generation
+## 1 rather than an entry in the table.
+func _anim_row(index: int, enemy_turn: bool) -> int:
 	if _anim_data == null:
 		return -1
 	if not _anim_data.gen1():
@@ -2163,7 +2190,78 @@ func _anim_row(index: int) -> int:
 	var pair: Variant = GEN1_ANIM_IDS.get(index, null)
 	if not pair is Array:
 		return -1
-	return int((pair as Array)[1 if bool(_anim_event.get("enemy_turn", false)) else 0]) - 1
+	return int((pair as Array)[1 if enemy_turn else 0]) - 1
+
+
+## `wAnimationType`: which of `AnimationTypePointerTable`'s six routines the move
+## ends with, or zero for none.
+func _gen1_animation_type(index: int, after: int) -> int:
+	var pair: Variant = GEN1_APPLYING_TYPES.get(after, null)
+	if not pair is Array:
+		return 0
+	var effect: int = int(_data.move(index).get("effect", 0)) if _data != null else 0
+	return int((pair as Array)[1 if effect != 0 else 0])
+
+
+## `SendOutMon`'s `POOF_ANIM` and `AnimateSendingOutMon`, which is the whole of
+## `ANIM_SEND_OUT_MON` here. `EnemySendOut` has no poof in front of it.
+func _gen1_send_out_steps(enemy_turn: bool) -> void:
+	if not enemy_turn:
+		# `ld a, $1 / ldh [hWhoseTurn]` ahead of the poof, either side.
+		_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_POOF, "enemy_turn": true})
+	for tiles: int in Gen2BattleScreenMap.SEND_OUT_SIZES:
+		_step(ANIM_SEND_OUT, {
+			"size": tiles,
+			"frames": int(Gen2BattleScreenMap.SEND_OUT_FRAMES[tiles]),
+		})
+
+
+## `TossBallAnimation`: the throw the ball chooses and then `.PokeBallAnimations`
+## for as many entries as `wPokeBallAnimData`'s high nybble names, four on a
+## capture, two on a ball that never opens and six on a break-out; a trainer
+## battle takes `.BlockBall`.
+func _gen1_toss_ball_steps(event: Dictionary) -> void:
+	var wobbles: Array = event.get("wobbles", [])
+	var caught: bool = wobbles.back() == Gen2BattleAnimScript.WOBBLE_CAUGHT \
+		if not wobbles.is_empty() else false
+	var shakes: int = maxi(wobbles.size() - 1, 0)
+	if not _is_wild_battle():
+		_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_TOSS})
+		_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_BLOCKBALL})
+		return
+	_step(ANIM_SCRIPT, {"index": int(
+		GEN1_TOSS_ANIMS.get(int(event.get("cur_item", 0)), Gen1Layout.ANIM_ID_ULTRATOSS)
+	)})
+	_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_POOF})
+	if not caught and shakes <= 0:
+		return
+	_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_HIDEPIC})
+	_step(ANIM_SCRIPT, {
+		"index": Gen1Layout.ANIM_ID_SHAKE, "shakes": maxi(shakes, 1),
+	})
+	if caught:
+		return
+	_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_POOF})
+	_step(ANIM_SCRIPT, {"index": Gen1Layout.ANIM_ID_SHOWPIC})
+
+
+## One step of `AnimateSendingOutMon`, which writes the tilemap rather than
+## running a script. Each block is bottom-centred on the picture's own box, so
+## the size is also the scale the square reports.
+func _send_out_step(tiles: int) -> void:
+	var player_side: bool = not bool(_anim_event.get("enemy_turn", false))
+	var side: int = Gen2Battle.PLAYER if player_side else Gen2Battle.ENEMY
+	var square: int = Gen2BattleScreenMap.player_box_side(_generation()) \
+		if player_side else Gen2BattleScreenMap.ENEMY_SIDE
+	Gen2BattleScreenMap.send_out_step(
+		_bg_map, player_side, _generation(), tiles,
+		1 if _is_wild_battle() else 2
+	)
+	_battler_visible[side] = tiles > 0
+	_battler_scale[side] = float(maxi(tiles, 1)) / float(square)
+	_battler_shift[side] = Vector2(
+		Gen2BattleScreenMap.SEND_OUT_AT[tiles] as Vector2i
+	) * PokeTiles.TILE_WIDTH
 
 
 ## `RunBattleAnimScript`, which is `ClearBattleAnims` and then a frame loop. The
@@ -2171,20 +2269,33 @@ func _anim_row(index: int) -> int:
 ## and comes back out at the end. A cache carrying no animation layer answers
 ## with no player, and the step is skipped rather than the whole framing: the
 ## delays and the hud belong to the screen, not to the data.
-func _start_script(index: int) -> bool:
-	var row: int = _anim_row(index)
+func _start_script(index: int, enemy_turn: bool, shakes: int = 0) -> bool:
+	var row: int = _anim_row(index, enemy_turn)
 	if _anim_data == null or row < 0:
 		return false
 	var wobbles: Array[int] = []
 	wobbles.assign(_anim_event.get("wobbles", []))
-	_anim = Gen2BattleAnimPlayer.create_gen1(
-		_anim_data, row, bool(_anim_event.get("enemy_turn", false))
-	) if _anim_data.gen1() else Gen2BattleAnimPlayer.create(
-		_anim_data, row, bool(_anim_event.get("enemy_turn", false)),
-		int(_anim_event.get("param", 0)), wobbles
+	return _begin_anim_player(
+		Gen2BattleAnimPlayer.create_gen1(_anim_data, row, enemy_turn, shakes) \
+			if _anim_data.gen1() else Gen2BattleAnimPlayer.create(
+				_anim_data, row, enemy_turn,
+				int(_anim_event.get("param", 0)), wobbles
+			)
 	)
-	if _anim == null:
+
+
+func _start_applying(animation_type: int) -> bool:
+	return _begin_anim_player(Gen2BattleAnimPlayer.create_gen1_applying(
+		_anim_data, animation_type, bool(_anim_event.get("enemy_turn", false))
+	))
+
+
+func _begin_anim_player(player: Gen2BattleAnimPlayer) -> bool:
+	if player == null:
 		return false
+	_anim = player
+	# `wCurItem`, which colours a thrown ball and flashes a Master or Ultra one.
+	_anim.cur_item = int(_anim_event.get("cur_item", 0))
 	_anim.background().set_bg_map(_bg_map)
 	_after_anim_frame()
 	return true
@@ -2590,11 +2701,9 @@ func battle_snapshot() -> Dictionary:
 
 ## The plain reading a registered battle-information provider annotates from:
 ## both sides' live stat stages, the weather and what is left of it, who is
-## standing, what is on screen, whether this opponent had been seen in this save,
-## and each move's exact effectiveness against the defender. That effectiveness is
-## [method GameData.type_effectiveness] over [method Gen2BattleMon.types] carrying
-## Foresight's identified state, so a provider never copies the type chart and
-## never rebuilds state from the event stream.
+## standing, what is on screen, whether this opponent had been seen, and each
+## move's effectiveness as [method GameData.type_effectiveness] over
+## [method Gen2BattleMon.types], which carries Foresight's identified state.
 func info_snapshot() -> Dictionary:
 	var player: Gen2BattleMon = _battle.mon(Gen2Battle.PLAYER) if _battle != null else null
 	var enemy: Gen2BattleMon = _battle.mon(Gen2Battle.ENEMY) if _battle != null else null
@@ -2663,11 +2772,9 @@ func _list_state_changed() -> void:
 
 
 ## Rebuilds the layer the frame a modal takes the interface or gives it back.
-##
 ## Every state [method _annotations_visible] reads writes through a setter that
 ## reaches here, so ownership is answered where it changes rather than at each
-## caller that opens a subflow: a modal built next year hides the annotations by
-## being made of the same flags, and nothing has to remember to refresh.
+## caller that opens a subflow.
 func _gate_annotations() -> void:
 	if _annotation_layer == null:
 		return
@@ -2861,9 +2968,8 @@ func use_selected_pack_item() -> Dictionary:
 ## `UseBallInTrainerBattle`, which is where `PokeBallEffect` jumps before it says
 ## anything at all: no ITEM USED line, the throw animation on
 ## `BattleAnim_ThrowPokeBall`'s own NO_ITEM branch, two boxes, and then
-## `UseDisposableItem` spends the ball anyway. The turn goes with it, because
-## `wItemEffectSucceeded` and `wBattlePlayerAction` are one byte and
-## `_DoItemEffect` set it to BATTLEPLAYERACTION_USEITEM on the way in.
+## `UseDisposableItem` spends the ball anyway. The turn goes with it:
+## `wItemEffectSucceeded` and `wBattlePlayerAction` are one byte.
 func _block_ball_in_trainer_battle(ball: int) -> Dictionary:
 	_capture_messages.clear()
 	_capture_messages.append(BALL_BLOCKED_TEXT)
@@ -2871,6 +2977,7 @@ func _block_ball_in_trainer_battle(ball: int) -> Dictionary:
 	_begin_animation({
 		"param": ANIM_PARAM_NO_ITEM,
 		"index": ANIM_THROW_POKE_BALL,
+		"cur_item": ball,
 		"enemy_turn": false,
 	})
 	item_used.emit(ball, -1)
@@ -3125,11 +3232,9 @@ func complete_capture(result: Dictionary) -> Dictionary:
 ## `PokeBallEffect`'s own `PlayBattleAnim` on `ANIM_THROW_POKE_BALL`: the throw,
 ## the poof, the opponent going in, the wobbles and the click or the break free,
 ## one script rather than five. The catch is already resolved when this runs, the
-## way the source resolves it in front of the animation and hands the drawing
-## `wThrownBallWobbleCount` rather than a roll, so the queue is
+## way the source resolves it in front of the animation, so the queue is
 ## `GetPokeBallWobble`'s answers in order. The opponent leaving and coming back
-## are `BATTLE_BG_EFFECT_RETURN_MON` and `..._ENTER_MON` inside the script, which
-## is why nothing here touches the picture.
+## are `BATTLE_BG_EFFECT_RETURN_MON` and `..._ENTER_MON` inside the script.
 func _begin_capture_animation(ball: int, wobbles: int, caught: bool) -> void:
 	if ball <= 0:
 		return
@@ -3145,6 +3250,8 @@ func _begin_capture_animation(ball: int, wobbles: int, caught: bool) -> void:
 		## which is what the `cp POKE_BALL + 1` in front of it decides.
 		"param": mini(ball, Gen2WorldPartyHost.ITEM_POKE_BALL),
 		"index": ANIM_THROW_POKE_BALL,
+		## `GetBallAnimPal` colours the ball off the real number, not the clamp.
+		"cur_item": ball,
 		## `xor a / ldh [hBattleTurn]`: the throw is the player's, so the
 		## script's `BG_EFFECT_TARGET` is the opponent.
 		"enemy_turn": false,
@@ -3371,11 +3478,9 @@ func _close_capture_nickname() -> void:
 
 
 ## `PokeBallEffect` gives no experience of its own: this is what a registered
-## policy adds, and with none registered it answers false and the capture flow
-## above is the one the cartridge has.
-##
-## The catching tutorial and a Bug Contest catch are excluded: neither is an
-## ordinary capture, and the contest's is a score rather than a Pokemon kept.
+## policy adds, and with none registered the capture flow is the cartridge's. The
+## catching tutorial and a Bug Contest catch are excluded, the contest's being a
+## score rather than a Pokemon kept.
 func _spend_capture_experience() -> bool:
 	if _capture_experience_spent or _battle == null or _world_battle_tutorial \
 		or bool(_capture_result.get("contest", false)) \
@@ -3582,11 +3687,8 @@ func _next_healthy(side: int) -> int:
 
 
 ## Opens LearnMove's full-slot branch, or keeps it open. Answered through
-## [method _handle_button], the same way capture ball selection is.
-##
-## Only the player side is ever queued
-## ([method Gen2Battle._offer_moves_learned_at]), so there is one stage rather
-## than one per side.
+## [method _handle_button], as capture ball selection is. Only the player side is
+## ever queued ([method Gen2Battle._offer_moves_learned_at]), so one stage does.
 func _open_move_learn() -> bool:
 	if _battle == null:
 		return false
@@ -3927,12 +4029,10 @@ func _finish_battle() -> void:
 		_finish_world_battle()
 
 
-## The fought party over the live save, with nothing written to disk.
-##
-## A ball is thrown mid-battle and the catch is its own transaction, which
-## builds its candidate from the live save; without this the party that reaches
-## the candidate is the pre-battle one, so the HP and PP spent weakening the
-## wild are given back the moment it is caught.
+## The fought party over the live save, with nothing written to disk. A catch is
+## its own transaction and builds its candidate from the live save; without this
+## the candidate carries the pre-battle party, so the HP and PP spent weakening
+## the wild are given back the moment it is caught.
 func sync_live_party() -> bool:
 	if _source_save == null or _battle == null or _data == null:
 		return false
@@ -4193,12 +4293,9 @@ func _answer_baton_pass() -> bool:
 
 
 ## `BattleMenu`: what the player is asked once the turn before it has finished
-## being shown. `EmptyBattleTextbox` first, so the menu opens over a clear box
-## rather than over the last line of the turn.
-##
-## `CheckPlayerHasUsableMoves` runs inside `MoveSelectionScreen` rather than
-## here, so a Pokemon with nothing left still opens the menu and Struggle is
-## chosen when FIGHT is.
+## being shown, `EmptyBattleTextbox` first so it opens over a clear box.
+## `CheckPlayerHasUsableMoves` runs inside `MoveSelectionScreen` rather than here,
+## so a Pokemon with nothing left still opens the menu and Struggle is chosen.
 func _open_battle_menu() -> void:
 	if _battle == null or _battle.is_over() or not _pending.is_empty():
 		return
@@ -5122,12 +5219,9 @@ func _show_layer_image(layer: TextureRect, image: Image, at: Vector2i) -> void:
 
 
 ## `HandlePlayerMonFaint` and `HandleEnemyMonFaint`'s replacement tail put on
-## screen, and whether any of it had something to do.
-##
-## The three steps are the source's own order: `AskUseNextPokemon`'s wild
-## question, `ForcePlayerMonChoice`'s list, and then the trainer's own entrance,
-## which [method Gen2Battle.replace_fallen] picks and which SHIFT turns into
-## another offer.
+## screen, and whether any of it had something to do. The three steps are the
+## source's order: `AskUseNextPokemon`'s wild question, `ForcePlayerMonChoice`'s
+## list, and the trainer's entrance, which SHIFT turns into another offer.
 func _replace_the_fallen() -> bool:
 	if _battle == null:
 		return false
@@ -5214,10 +5308,8 @@ func _show_next_event() -> void:
 			return
 		## `AnimateHPBar` and `MonFaintedAnimation` both block: the source does
 		## not reach the next command until the bar has emptied and the picture
-		## has sunk. Without this stop, a hit with no line of its own popped the
-		## faint in the same pass and the picture left the field while its own bar
-		## was still draining. [method _resume_after_frames] brings the queue back
-		## when the frames are spent.
+		## has sunk. Without this a hit with no line of its own popped the faint
+		## while its own bar was still draining.
 		if not _bars.is_empty() or fainting():
 			return
 	## The queue ran dry with nothing to print. `DoTurn` does not read a button
@@ -5333,12 +5425,10 @@ func _apply_event_state(event: Dictionary) -> void:
 			_refresh_exp_bar()
 		Gen2Battle.GREW_LEVEL:
 			# The level number in the panel belongs to whoever is on screen, so
-			# it only moves when the index that grew is the one currently
-			# active: a benched participant can level up too, and this screen
-			# has no bench to show it on. The bar itself is not recomputed here:
-			# `.LoopLevels` is inside `AnimateExpBar`, so from the award until
-			# the walk ends the animation owns the bar and [method advance_bars]
-			# commits the real count when it arrives.
+			# it only moves when the index that grew is the active one: a
+			# benched participant levels up with no bench to show it on. The bar
+			# is not recomputed here either, `.LoopLevels` being inside
+			# `AnimateExpBar`, so the animation owns it until the walk ends.
 			if int(event["index"]) == _battle.party(Gen2Battle.PLAYER).active:
 				_player_level = int(event["new_level"])
 				_push_view()
@@ -5832,14 +5922,11 @@ func _unhandled_input(event: InputEvent) -> void:
 		accept_event()
 
 
-## Whether the battle itself is idle enough to pass an event on.
-##
-## The modal input states are the ones that mean something by themselves: the
-## forget-move prompt, a switch's yes/no or list, and ball selection. A draining
-## bar, the opening slide and a move animation are deliberately not on that list.
-## None of them reads input, and a camera that stops answering every time a bar
-## drains is not a camera; the presses they do swallow are swallowed in
-## [method _handle_button], which runs first and never reaches here.
+## Whether the battle itself is idle enough to pass an event on. The modal input
+## states are the ones that mean something by themselves: the forget-move prompt,
+## a switch's yes/no or list, and ball selection. A draining bar, the opening
+## slide and a move animation read no input and are deliberately not on that list;
+## what they do swallow is swallowed in [method _handle_button], which runs first.
 func _renderer_input_free() -> bool:
 	return is_ready() and _forget_stage == &"" and _switch_stage == &"" \
 		and _menu_stage == &"" and not _capture_selecting and not _pack_selecting \
@@ -6082,14 +6169,11 @@ func select_view(id: StringName) -> Dictionary:
 	return result
 
 
-## Says what a view switch did, unless a menu is holding the interface.
-##
-## The acknowledgement is battle text, and the menu layer above it covers the
-## box's right-hand half rather than the whole panel, so a line printed under an
-## open menu leaks its first glyphs out beside the list. The cartridge's own
-## transition cover already says the switch happened; the words are development
-## chrome and are worth less than the menu underneath them staying intact. Said
-## through the same log the refusals use, so nothing is silently dropped.
+## Says what a view switch did, unless a menu is holding the interface: the menu
+## layer covers the box's right-hand half rather than the whole panel, so a line
+## printed under an open list leaks its first glyphs out beside it, and the
+## transition cover already says the switch happened. Said through the same log
+## the refusals use, so nothing is silently dropped.
 func _report_view(message: String) -> void:
 	if _menu_owns_interface():
 		print_verbose(message)
@@ -6191,11 +6275,9 @@ func _push_view() -> void:
 		"raster_scx": _raster_offsets(),
 		"raster_scy": _raster_rows(),
 		## `CopyBackpic` puts the player's back pic on the tilemap before
-		## `InitBattleDisplay` ever reaches the slide, so it is there through it
-		## and comes in with the middle band. Its top three tile rows fall in the
-		## band the enemy scrolls, which is what the eighteen sprites here are
-		## for; `PlaceGraphic` afterwards is what settles the two pixels between
-		## them.
+		## `InitBattleDisplay` reaches the slide, so it comes in with the middle
+		## band. Its top three tile rows fall in the band the enemy scrolls,
+		## which is what the eighteen sprites here are for.
 		"intro_sprites": _intro.sprites() if _intro != null else [],
 		## `GetSGBLayout SCGB_BATTLE_GRAYSCALE` is called where the battle is
 		## entered and `SCGB_BATTLE_COLORS` only after `BattleIntroSlidingPics`,
@@ -6228,6 +6310,8 @@ func _push_view() -> void:
 		"bg_vbank1": _bg_vbank1,
 		"bg_palette_maps": _background_maps(&"bg"),
 		"ob_palette_maps": _background_maps(&"ob"),
+		## `rOBP0`, which only `DoBallTossSpecialEffects` moves off `wAnimPalette`.
+		"anim_obp0": _anim.background().obp0 if _anim != null else Gen1Layout.ANIM_OBP0,
 		"anim_sprites": _anim.sprites() if _anim != null else _kept_sprites,
 		"anim_tiles": _anim.tiles() if _anim != null else _kept_tiles,
 		## Whether both panels are on the map, which is the summary of the two
@@ -6250,11 +6334,9 @@ func _push_view() -> void:
 
 
 ## What is standing on one side's square, whether it is on it, how far it is from
-## resting there and how big it is drawn; `docs/MODS.md` documents the block.
-## Every other battler field says it in the terms the hardware draws it in, so a
-## renderer with no background plane would have to rebuild host state to read a
-## faint, a recall or a deformation. These four are read out of the state the
-## screen already runs rather than simulated again.
+## resting there and how big it is drawn; `docs/MODS.md` documents the block. A
+## renderer with no background plane would otherwise have to rebuild host state to
+## read a faint, a recall or a deformation.
 func battler_side(side: int) -> Dictionary:
 	var player_side: bool = side == Gen2Battle.PLAYER
 	var backpic: String = _player_backpic if player_side else ""
@@ -6323,12 +6405,10 @@ func _raster_rows() -> PackedInt32Array:
 	return _anim_raster(Gen2BattleAnimBackground.LCDC_SCY)
 
 
-## One axis of the animation's scroll, per scanline.
-##
-## The whole-screen `hSCX`/`hSCY` is the base, and the scanline table replaces it
-## on every line while `hLCDCPointer` names that axis' register. A table pointed
-## at `rBGP` reaches nothing here: `UpdatePals` never touches that register on the
-## Color hardware, which is the branch this project builds.
+## One axis of the animation's scroll, per scanline. The whole-screen
+## `hSCX`/`hSCY` is the base and the scanline table replaces it on every line
+## while `hLCDCPointer` names that axis' register. A table pointed at `rBGP`
+## reaches nothing here: `UpdatePals` never touches it on the Color hardware.
 func _anim_raster(register: int) -> PackedInt32Array:
 	var out := PackedInt32Array()
 	if _anim == null:

--- a/game/battle/battle_screen_map.gd
+++ b/game/battle/battle_screen_map.gd
@@ -5,8 +5,7 @@ extends RefCounted
 ## each of the 20x18 cells. An animation does not draw a picture, it edits this
 ## map, and the screen hands it to [Gen2BattleAnimBackground] and takes back
 ## whatever the animation left, which is why a Fly is still gone after its own
-## animation ends. Node-free: a map is data, so what an effect did to one can be
-## asserted headless.
+## animation ends. Node-free, so an effect's work can be asserted headless.
 
 const COLUMNS: int = Gen2BattleAnimBackground.SCREEN_WIDTH
 const ROWS: int = Gen2BattleAnimBackground.SCREEN_HEIGHT
@@ -89,11 +88,9 @@ static func faint_step(map: PackedByteArray, player_side: bool) -> void:
 
 ## `SlideBattlePicOut`, which is not the picture's box either: seven rows from
 ## one above the player's, and the whole of the enemy's, shifted a column at a
-## time until the picture is off the screen.
-##
-## `DoBattle`'s `hlcoord 1, 5 / ld a, 9` walks the player's left and
-## `ResetEnemyBattleVars`' `hlcoord 18, 0 / ld a, 8` walks the enemy's right, and
-## the count is both how many columns are touched and how many steps it takes.
+## time until the picture is off the screen. `DoBattle`'s `hlcoord 1, 5 / ld a, 9`
+## walks the player's left and `ResetEnemyBattleVars`' `hlcoord 18, 0 / ld a, 8`
+## the enemy's right; the count is both the columns touched and the steps.
 const SLIDE_AT: Dictionary = {false: Vector2i(18, 0), true: Vector2i(1, 5)}
 const SLIDE_ROWS: int = 7
 const SLIDE_STEPS: Dictionary = {false: 8, true: 9}
@@ -125,12 +122,9 @@ static func slide_step(map: PackedByteArray, player_side: bool) -> void:
 
 ## `InitBattleDisplay`'s `hlcoord 1, 5 / lb bc, 3, 7 / ClearBox`, which runs
 ## between `CopyBackpic` and the slide and takes the top two tile rows of the
-## player's back pic off the map.
-##
-## It is what makes the slide's eighteen sprites necessary rather than a second
-## copy of the same picture: those rows fall in the band the enemy's own scroll
-## owns, so the background cannot carry them and `.LoadTrainerBackpicAsOAM`
-## does. `PlaceGraphic` puts the whole pic back when the slide returns.
+## player's back pic off the map. It is what makes the slide's eighteen sprites
+## necessary: those rows fall in the band the enemy's own scroll owns, so
+## `.LoadTrainerBackpicAsOAM` carries them and `PlaceGraphic` puts the pic back.
 const INTRO_CLEAR_AT: Vector2i = Vector2i(1, 5)
 const INTRO_CLEAR_COLUMNS: int = 7
 const INTRO_CLEAR_ROWS: int = 3
@@ -154,20 +148,114 @@ static func clear_intro_box(map: PackedByteArray) -> void:
 ## [code]base + column * side + row[/code], the column-major order `.BGSquares`
 ## indexes and `AppearUser` restores.
 static func stamp(
-	map: PackedByteArray, player_side: bool, generation: int = RomRegistry.GEN2
+	map: PackedByteArray, player_side: bool, generation: int = RomRegistry.GEN2,
+	shift: Vector2i = Vector2i.ZERO
+) -> void:
+	if map.size() != COLUMNS * ROWS:
+		return
+	var at: Vector2i = (player_box_at(generation) if player_side else ENEMY_AT) + shift
+	var side: int = player_box_side(generation) if player_side else ENEMY_SIDE
+	var base: int = PLAYER_BASE_TILE if player_side else ENEMY_BASE_TILE
+	for column: int in side:
+		for row: int in side:
+			_write(
+				map, at + Vector2i(column, row), base + column * side + row
+			)
+
+
+## `ClearMonPicFromTileMap`: the seven by seven box, wherever the picture was
+## last drawn.
+static func clear_battler(
+	map: PackedByteArray, player_side: bool, generation: int,
+	shift: Vector2i = Vector2i.ZERO
+) -> void:
+	if map.size() != COLUMNS * ROWS:
+		return
+	var at: Vector2i = (player_box_at(generation) if player_side else ENEMY_AT) + shift
+	var side: int = player_box_side(generation) if player_side else ENEMY_SIDE
+	for column: int in side:
+		for row: int in side:
+			_write(map, at + Vector2i(column, row), BLANK_TILE)
+
+
+## `_AnimationSquishMonPic`: three tiles of each of the box's rows pulled a
+## column inwards, the cell they leave blanked. `AnimCopyRowLeft` runs from four
+## columns into the box and `..._Right` from two.
+const SQUISH_LEFT_AT: int = 4
+const SQUISH_RIGHT_AT: int = 2
+const SQUISH_TILES: int = 3
+
+
+static func squish_step(
+	map: PackedByteArray, player_side: bool, generation: int, to_the_right: bool
 ) -> void:
 	if map.size() != COLUMNS * ROWS:
 		return
 	var at: Vector2i = player_box_at(generation) if player_side else ENEMY_AT
 	var side: int = player_box_side(generation) if player_side else ENEMY_SIDE
+	var step: int = 1 if to_the_right else -1
+	var head: int = at.x + (SQUISH_RIGHT_AT if to_the_right else SQUISH_LEFT_AT)
+	for row: int in side:
+		var y: int = at.y + row
+		var x: int = head
+		for _tile: int in SQUISH_TILES:
+			_write(map, Vector2i(x + step, y), _cell(map, Vector2i(x, y)))
+			x -= step
+		_write(map, Vector2i(x + step, y), BLANK_TILE)
+
+
+static func _cell(map: PackedByteArray, at: Vector2i) -> int:
+	if at.x < 0 or at.x >= COLUMNS or at.y < 0 or at.y >= ROWS:
+		return BLANK_TILE
+	return int(map[at.y * COLUMNS + at.x])
+
+
+## `AnimateSendingOutMon`, which is no `AttackAnimationPointers` row: the ball
+## tile, then `DownscaledMonTiles_3x3` and `..._5x5` over these rows and columns,
+## each block two rows up and a column left of the last.
+const SEND_OUT_ROWS: Dictionary = {3: [0, 3, 6], 5: [0, 1, 3, 5, 6]}
+const SEND_OUT_AT: Dictionary = {
+	0: Vector2i(3, 6), 3: Vector2i(2, 4), 5: Vector2i(1, 2), 7: Vector2i(0, 0),
+}
+const SEND_OUT_SIZES: Array[int] = [0, 3, 5, 7]
+## `Delay3`, `ld c, 4` and `ld c, 5`; the whole picture ends the routine.
+const SEND_OUT_FRAMES: Dictionary = {0: 3, 3: 4, 5: 5, 7: 0}
+
+## `ld b, $4c` with `ld a, [wIsInBattle]` still in `a`: the tile written is $4d
+## in a wild battle and $4e in a trainer's, both of them back pic tiles.
+const SEND_OUT_BALL_TILE: int = 0x4C
+
+
+## One step of it: [param size] 0 is the ball tile and 7 the whole picture.
+static func send_out_step(
+	map: PackedByteArray, player_side: bool, generation: int, size: int,
+	in_battle: int = 1
+) -> void:
+	if map.size() != COLUMNS * ROWS or not SEND_OUT_AT.has(size):
+		return
+	var side: int = player_box_side(generation) if player_side else ENEMY_SIDE
+	var at: Vector2i = (player_box_at(generation) if player_side else ENEMY_AT) \
+		+ (SEND_OUT_AT[size] as Vector2i)
+	if size == 0:
+		_write(map, at, SEND_OUT_BALL_TILE + in_battle)
+		return
+	if size >= side:
+		stamp(map, player_side, generation)
+		return
 	var base: int = PLAYER_BASE_TILE if player_side else ENEMY_BASE_TILE
-	for column: int in side:
-		for row: int in side:
-			var x: int = at.x + column
-			var y: int = at.y + row
-			if x < 0 or x >= COLUMNS or y < 0 or y >= ROWS:
-				continue
-			map[y * COLUMNS + x] = (base + column * side + row) & 0xFF
+	var picked: Array = SEND_OUT_ROWS[size]
+	for column: int in size:
+		for row: int in size:
+			_write(
+				map, at + Vector2i(column, row),
+				base + int(picked[column]) * side + int(picked[row])
+			)
+
+
+static func _write(map: PackedByteArray, at: Vector2i, tile: int) -> void:
+	if at.x < 0 or at.x >= COLUMNS or at.y < 0 or at.y >= ROWS:
+		return
+	map[at.y * COLUMNS + at.x] = tile & 0xFF
 
 
 static func result_trainer_step(map: PackedByteArray, columns: int) -> void:

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -278,6 +278,24 @@ const ANIM_OBP1: int = 0x6C
 ## three-bit Game Boy Color palette.
 const ANIM_OAM_OBP1: int = 0x10
 
+## `constants/move_constants.asm`: moves do double duty as animation ids, and
+## these are the rows past `NUM_ATTACKS` that no move number names.
+const ANIM_ID_SHOWPIC: int = 0xA6
+const ANIM_ID_ENEMY_HUD_SHAKE: int = 0xA9
+const ANIM_ID_TOSS: int = 0xC1
+const ANIM_ID_SHAKE: int = 0xC2
+const ANIM_ID_POOF: int = 0xC3
+const ANIM_ID_BLOCKBALL: int = 0xC4
+const ANIM_ID_GREATTOSS: int = 0xC5
+const ANIM_ID_ULTRATOSS: int = 0xC6
+const ANIM_ID_SHAKE_SCREEN: int = 0xC7
+const ANIM_ID_HIDEPIC: int = 0xC8
+
+## The three ball items `TossBallAnimation` picks a throw off.
+const ITEM_ULTRA_BALL: int = 0x02
+const ITEM_GREAT_BALL: int = 0x03
+const ITEM_POKE_BALL: int = 0x04
+
 ## What pins the two sheets: the edge under both panels is two solid rows in
 ## the middle of six blank ones, and the empty bar is a rule top and bottom.
 const HUD_BOTTOM_CODE: int = 0x76

--- a/tests/unit/test_battle_anim_player.gd
+++ b/tests/unit/test_battle_anim_player.gd
@@ -453,6 +453,57 @@ func test_a_generation_1_frame_block_is_shown_for_its_own_delay() -> void:
 	)
 
 
+## `AnimationTypePointerTable`: what each of the six routines moves and how far
+## it opens. Only the vertical one is on `rWY`, and a type of zero has no row.
+func test_the_applying_attack_animation_moves_by_its_type() -> void:
+	var data: Gen2BattleAnimData = _gen1_data(0)
+	var vertical: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1_applying(data, 1)
+	vertical.advance_frame()
+	assert_eq(
+		[vertical.background().scy, vertical.background().scx], [(-8) & 0xFF, 0]
+	)
+	var light: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1_applying(data, 5)
+	light.advance_frame()
+	assert_eq(light.background().scx, (-2) & 0xFF, "the light shake is `ld b, 2`")
+	var slow: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1_applying(data, 6)
+	slow.advance_frame()
+	assert_eq(slow.background().scx, (-1) & 0xFF, "the slow shake opens a pixel out")
+	assert_null(Gen2BattleAnimPlayer.create_gen1_applying(data, 0))
+	assert_null(Gen2BattleAnimPlayer.create_gen1_applying(_data(RET), 4))
+
+
+## `.MutateWX` xors the running offset with the count, so the first pass opens on
+## the offset and every later one opens on zero and closes on the count.
+func test_the_screen_shake_offsets_follow_the_xor() -> void:
+	var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1_applying(
+		_gen1_data(0), 2
+	)
+	var offsets: Array[int] = []
+	for _frame: int in 18:
+		player.advance_frame()
+		offsets.append(player.background().scx)
+	assert_eq(
+		[offsets[0], offsets[5], offsets[9], offsets[14]],
+		[(-8) & 0xFF, 0, 0, (-7) & 0xFF]
+	)
+
+
+## `AnimationBlinkEnemyMon` is `AnimationBlinkMon` through `CallWithTurnFlipped`,
+## so the picture that goes is the one belonging to whoever is not acting.
+func test_the_blink_after_anim_takes_the_other_sides_picture() -> void:
+	var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1_applying(
+		_gen1_data(0), 4
+	)
+	player.advance_frame()
+	assert_eq(
+		[
+			bool(player.background().battler_visible[true]),
+			bool(player.background().battler_visible[false]),
+		],
+		[true, false]
+	)
+
+
 ## An animation the cache does not carry answers null on either engine.
 func test_a_generation_1_animation_outside_the_table_answers_null() -> void:
 	assert_null(Gen2BattleAnimPlayer.create_gen1(_gen1_data(0), 1))

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -544,3 +544,36 @@ func test_the_two_generations_draw_one_circle() -> void:
 	seen.sort()
 	spin.sort()
 	assert_eq(seen, spin)
+
+
+## `AnimateSendingOutMon`: the ball tile, the two subsamplings and the whole
+## picture, each block two rows up and a column left of the last.
+func test_a_generation_1_send_out_grows_the_picture_onto_its_box() -> void:
+	var map: PackedByteArray = Gen2BattleScreenMap.seeded(RomRegistry.GEN1)
+	map.fill(Gen2BattleScreenMap.BLANK_TILE)
+	var cell := func(at: Vector2i) -> int:
+		return int(map[at.y * Gen2BattleScreenMap.COLUMNS + at.x])
+
+	Gen2BattleScreenMap.send_out_step(map, true, RomRegistry.GEN1, 0, 2)
+	assert_eq(
+		cell.call(Vector2i(4, 11)), Gen2BattleScreenMap.SEND_OUT_BALL_TILE + 2,
+		"`ld a, [wIsInBattle]` is still in `a` when `add b` runs"
+	)
+
+	Gen2BattleScreenMap.send_out_step(map, true, RomRegistry.GEN1, 5)
+	var base: int = Gen2BattleScreenMap.PLAYER_BASE_TILE
+	assert_eq(
+		[cell.call(Vector2i(2, 7)), cell.call(Vector2i(3, 7)), cell.call(Vector2i(2, 8))],
+		[base, base + 7, base + 1],
+		"`DownscaledMonTiles_5x5` picks rows and columns 0, 1, 3, 5 and 6"
+	)
+
+	Gen2BattleScreenMap.send_out_step(map, false, RomRegistry.GEN1, 3)
+	assert_eq(
+		cell.call(Vector2i(14, 4)), Gen2BattleScreenMap.ENEMY_BASE_TILE,
+		"the enemy's blocks count from its own box at (12, 0)"
+	)
+
+	Gen2BattleScreenMap.send_out_step(map, true, RomRegistry.GEN1, 7)
+	assert_eq(cell.call(Vector2i(1, 5)), base)
+	assert_eq(cell.call(Vector2i(7, 11)), base + 6 * 7 + 6)

--- a/tools/checks/gen1_battle_anims.gd
+++ b/tools/checks/gen1_battle_anims.gd
@@ -54,10 +54,29 @@ const IMPLEMENTED_EFFECTS: Dictionary = {&"red": 36, &"blue": 36, &"yellow": 36}
 ## transform read wrong moves the sprites. Yellow is one animation short and the
 ## same sprites, `ZigZagScreenAnim` being `SE_WAVY_SCREEN` alone.
 const EXPECTED_TOTALS: Dictionary = {
-	&"red": [24828, 141410],
-	&"blue": [24828, 141410],
-	&"yellow": [24316, 141410],
+	&"red": [24908, 141730],
+	&"blue": [24908, 141730],
+	&"yellow": [24396, 141730],
 }
+
+## `AnimationTypePointerTable`'s six routines, as the frames each spends: the
+## two `PredefShakeScreen*` amplitudes, `AnimationShakeScreenHorizontallySlow`'s
+## two counts and `AnimationBlinkMon`'s six cycles, each plus the frame the
+## player ends on.
+const APPLYING_FRAMES: Dictionary = {1: 49, 2: 73, 3: 49, 4: 61, 5: 19, 6: 25}
+
+## `SHAKE_ANIM`, and what `DoBallShakeSpecialEffects` adds per extra shake: its
+## own `ld c, 40` and the four subentries behind it, four frames each.
+const BALL_SHAKE_INDEX: int = Gen1Layout.ANIM_ID_SHAKE - 1
+const BALL_SHAKE_STEP: int = 56
+
+## `AnimateSendingOutMon` over the player's box: the ball tile at (4,11), then
+## `DownscaledMonTiles_3x3`'s own first row at (3,9), and the whole picture.
+const SEND_OUT_BALL_AT: Vector2i = Vector2i(4, 11)
+const SEND_OUT_BALL_TILE: int = 0x4D
+const SEND_OUT_SMALL_AT: Vector2i = Vector2i(3, 9)
+const SEND_OUT_SMALL_ROW: Array[int] = [0x31, 0x46, 0x5B]
+const SEND_OUT_WHOLE_AT: Vector2i = Vector2i(1, 5)
 
 
 func run(r: RefCounted) -> void:
@@ -74,7 +93,90 @@ func _one_game() -> void:
 	_verify_tables(anims)
 	_verify_pound(anims)
 	_verify_transforms(anims)
+	_verify_applying(anims)
+	_verify_ball_shake(anims)
+	_verify_send_out()
 	_play_every_animation(anims)
+
+
+## `PlayApplyingAttackAnimation`, which is a routine rather than a row: each of
+## `wAnimationType`'s six answers run to its end, and zero answering none.
+func _verify_applying(anims: Gen2BattleAnimData) -> void:
+	for animation_type: int in APPLYING_FRAMES:
+		var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1_applying(
+			anims, animation_type
+		)
+		if not _r.check(player != null, "%s: animation type %d would not start." % [
+			_r.game_id, animation_type,
+		]):
+			continue
+		var spent: int = 0
+		while not player.finished() and spent < MAX_FRAMES:
+			player.advance_frame()
+			spent += 1
+		_r.check(
+			spent == int(APPLYING_FRAMES[animation_type]),
+			"%s: animation type %d ran for %d frames, expected %d." % [
+				_r.game_id, animation_type, spent, int(APPLYING_FRAMES[animation_type]),
+			]
+		)
+	_r.check(
+		Gen2BattleAnimPlayer.create_gen1_applying(anims, 0) == null,
+		"%s: animation type 0 built a player." % _r.game_id
+	)
+
+
+## `wNumShakes`: the last frame block rewinds four subentries while shakes are
+## left, so a ball that rocks three times is two more shakes long than one.
+func _verify_ball_shake(anims: Gen2BattleAnimData) -> void:
+	var lengths: Array[int] = []
+	for shakes: int in [1, 3]:
+		var player: Gen2BattleAnimPlayer = Gen2BattleAnimPlayer.create_gen1(
+			anims, BALL_SHAKE_INDEX, false, shakes
+		)
+		var spent: int = 0
+		while player != null and not player.finished() and spent < MAX_FRAMES:
+			player.advance_frame()
+			spent += 1
+		lengths.append(spent)
+	_r.check(
+		lengths.size() == 2 and lengths[1] - lengths[0] == BALL_SHAKE_STEP * 2,
+		"%s: three shakes ran %s, expected %d frames more than one." % [
+			_r.game_id, lengths, BALL_SHAKE_STEP * 2,
+		]
+	)
+
+
+## `AnimateSendingOutMon` writes the tilemap rather than running a script.
+func _verify_send_out() -> void:
+	var map: PackedByteArray = Gen2BattleScreenMap.seeded(RomRegistry.GEN1)
+	map.fill(Gen2BattleScreenMap.BLANK_TILE)
+	Gen2BattleScreenMap.send_out_step(map, true, RomRegistry.GEN1, 0)
+	_r.check(
+		_cell(map, SEND_OUT_BALL_AT) == SEND_OUT_BALL_TILE,
+		"%s: the ball tile is $%02X, expected $%02X." % [
+			_r.game_id, _cell(map, SEND_OUT_BALL_AT), SEND_OUT_BALL_TILE,
+		]
+	)
+	Gen2BattleScreenMap.send_out_step(map, true, RomRegistry.GEN1, 3)
+	var row: Array[int] = []
+	for column: int in SEND_OUT_SMALL_ROW.size():
+		row.append(_cell(map, SEND_OUT_SMALL_AT + Vector2i(column, 0)))
+	_r.check(
+		row == SEND_OUT_SMALL_ROW,
+		"%s: the 3x3 block's top row is %s, expected %s." % [
+			_r.game_id, row, SEND_OUT_SMALL_ROW,
+		]
+	)
+	Gen2BattleScreenMap.send_out_step(map, true, RomRegistry.GEN1, 7)
+	_r.check(
+		_cell(map, SEND_OUT_WHOLE_AT) == Gen2BattleScreenMap.PLAYER_BASE_TILE,
+		"%s: the whole picture does not land on the player's own box." % _r.game_id
+	)
+
+
+static func _cell(map: PackedByteArray, at: Vector2i) -> int:
+	return int(map[at.y * Gen2BattleScreenMap.COLUMNS + at.x])
 
 
 func _verify_tables(anims: Gen2BattleAnimData) -> void:


### PR DESCRIPTION
`PlayApplyingAttackAnimation` is `Gen2BattleAnimPlayer.create_gen1_applying`: `AnimationTypePointerTable`'s six rows over four routines, picked by `wAnimationType`, which `Gen2BattleScreen.GEN1_APPLYING_TYPES` maps `wBattleAfterAnim` onto. `GetPlayerAnimationType` and `GetEnemyAnimationType` split on the move's own effect byte and `PlayBattleAnimation2` on whose turn it is. `PredefShakeScreenHorizontally`'s `.MutateWX` xors the running offset with the count, so only the first pass opens on the offset and every later one opens on zero; `AnimationShakeScreen` was drawing the pairs the other way up.

`AnimateSendingOutMon` is `Gen2BattleScreenMap.send_out_step`: the ball tile, `DownscaledMonTiles_3x3`, `..._5x5` and the whole picture, each block two rows up and a column left of the last. That tile is `$4c` plus `wIsInBattle`, since `ld a, [wIsInBattle]` is still in `a` when `add b` runs, so a send-out opens on a scrap of the player's own back pic. `TossBallAnimation` is the throw the ball chooses and `.PokeBallAnimations` behind it, four entries on a capture, two on a ball that never opens and six on a break-out, with `DoBallTossSpecialEffects`' `rOBP0` flash and `DoBallShakeSpecialEffects`' own wait and rewind; a trainer battle takes `.BlockBall`.

`GEN1_ANIM_IDS` was wrong for every status id. `FreezeBurnParalyzeEffect` plays `ENEMY_HUD_SHAKE_ANIM` on `.burn1`, `.freeze1` and `paralyze1` and nothing on the three the opponent's attack reaches, `PoisonEffect`'s side-effect branch answers `SHAKE_SCREEN_ANIM` there, and a confusion is the move's own animation on both cartridges. `ANIM_SEND_OUT_MON` no longer falls through to `AppearUser`, which was stamping a whole picture over a status animation.

Every Generation 1 effect that hides, moves or squishes a picture now edits `wTilemap` the way `AnimationHideMonPic`, `CopyPicTiles` and `_AnimationSquishMonPic` do rather than only reporting it, so a blink, a slide, Teleport's squeeze and Double Team's shake draw. `AnimationSlideMonUp` scrolls its box upwards and was reported moving down. A thrown ball carries `wCurItem` now, which is what `GetBallAnimPal` colours it off on both generations, and a Generation 1 entrance no longer plays the shiny sparkle `BattleCheckPlayerShininess` has no counterpart for.

| Run | Result |
|---|---|
| `gut_cmdln.gd -gdir=res://tests -ginclude_subdirs` | 4363 tests, 0 failures |
| `validate.gd -- all` | 90 topics, 0 failures |
| `--warning-scan` over 629 scripts | 0 warnings |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk on Gold, Silver and Crystal | complete, 0 failures |
| `gen1_battle_anims` corpus | 24,908 frames and 141,730 sprites on Red and Blue, 24,396 and 141,730 on Yellow |