### PR TITLE
Let a mod the contract left behind be replaced or removed

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -99,7 +99,8 @@ loader and no mod.
 What each `api_version` added. Declare the oldest one that carries every seam the
 mod reaches, and a host refuses a number above its own. Every version up to 29
 only added, so an older number still ran. Version 30 renamed classes, and a host
-carrying it answers 30 alone.
+carrying it answers 30 alone: a copy already installed below that is listed as
+installed but not loaded, and its own page offers to replace or remove it.
 
 | Version | Added |
 |---|---|

--- a/game/launcher/mod_detail_page.gd
+++ b/game/launcher/mod_detail_page.gd
@@ -124,9 +124,10 @@ func _summary(row: Dictionary) -> Control:
 	panel.add_child(column)
 
 	var installed: String = String(row["installed_version"])
-	column.add_child(Gen2LauncherUI.stacked(
-		_theme, "Installed", _value(installed if not installed.is_empty() else "Not installed")
-	))
+	if installed.is_empty():
+		# A copy this host refused has no version to name and is still on disk.
+		installed = "installed, not loaded" if bool(row["present"]) else "Not installed"
+	column.add_child(Gen2LauncherUI.stacked(_theme, "Installed", _value(installed)))
 	var listed: String = String(row["listed_version"])
 	if bool(row["listed"]):
 		column.add_child(Gen2LauncherUI.stacked(
@@ -154,7 +155,7 @@ func _summary(row: Dictionary) -> Control:
 		)
 		get_it.pressed.connect(func() -> void: download_requested.emit(_row))
 		actions.add_child(get_it)
-	if bool(row["installed"]):
+	if bool(row["present"]):
 		var remove: Gen2LauncherButton = Gen2LauncherButton.create(
 			_theme,
 			"Delete" if Gen2ModCatalogue.removal_is_permanent(row) else "Remove",
@@ -200,6 +201,8 @@ static func _download_label(row: Dictionary) -> String:
 			return "Download"
 		&"update":
 			return "Update to %s" % row["listed_version"]
+		&"replace":
+			return "Replace"
 	return "Reinstall"
 
 

--- a/game/launcher/mods_page.gd
+++ b/game/launcher/mods_page.gd
@@ -4,11 +4,9 @@ extends VBoxContainer
 ## The mod manager: a list grouped by where each mod came from, a page per mod,
 ## and a page for the sources the player follows. The model is a package
 ## manager's, so removing a mod a source lists uninstalls it and leaves it listed
-## while removing one that came from a file deletes the only copy there was;
-## [Gen2ModCatalogue] decides both. The list carries only what a list is for, with
-## settings and history on the mod's own page. A change is applied where it is
-## made: the host is reset and every entry script runs again, because nothing here
-## can withdraw one registration on its own.
+## while removing one from a file deletes the only copy; [Gen2ModCatalogue]
+## decides both. A change is applied where it is made: the host is reset and every
+## entry script runs again, nothing here withdrawing one registration on its own.
 
 ## Asks the launcher for its file picker: the page owns no OS dialog.
 signal install_requested
@@ -158,10 +156,9 @@ func refresh() -> void:
 ## Whether the page may reach the network without a player having asked it to.
 ## [method HTTPRequest.request] refuses, loudly, from a node that is not in the
 ## tree, and [method create] builds the whole page before the launcher adds it.
-## The rest is [method Gen2GameRuntime.is_player_launch]: a check, a test tier, a
-## screenshot driver or a replay has nobody to show a listing to and its user:// is
-## usually empty, so every page it builds would fetch the feed and then an icon
-## per row. What a player pressed is not gated here and works in any run.
+## The rest is [method Gen2GameRuntime.is_player_launch]: a check, a test tier or
+## a replay has nobody to show a listing to, so every page it builds would fetch
+## the feed and an icon per row. What a player pressed is not gated here.
 func _may_fetch_unprompted() -> bool:
 	return is_inside_tree() and Gen2GameRuntime.is_player_launch()
 
@@ -192,7 +189,7 @@ func _relist() -> void:
 	Gen2LauncherUI.clear(_list)
 	var host: Gen2ModHost = Gen2ModHost.instance()
 	var groups: Array = Gen2ModCatalogue.groups(
-		host.manifests(), PokeModIndex.followed(), _listings
+		host.manifests(), PokeModIndex.followed(), _listings, host.present_ids()
 	)
 	var failures: Array = host.failures()
 	_note.text = "Loaded from %s" % Gen2ModHost.ROOT
@@ -298,28 +295,26 @@ static func _clipped(label: Label) -> Label:
 
 
 ## What a row can do: download a mod that is not installed, update one a source
-## offers a newer version of, and remove one that is installed. Download and
-## update are the same press, since a source hands over an archive and the
-## installer replaces whatever was there.
+## offers a newer version of, replace a copy this host would not load, and remove
+## whatever is on disk. Download, update and replace are the same press, since a
+## source hands over an archive and the installer replaces what was there.
+##
+## The remove button follows `present` rather than `installed`, or a copy whose
+## manifest was refused has no button that does anything: the download over it is
+## refused by the directory and there is nothing else to press.
 func _action_buttons(row: Dictionary) -> Array[Control]:
 	var out: Array[Control] = []
-	match Gen2ModCatalogue.action_for(row):
-		&"download":
-			var get_it: Gen2LauncherButton = Gen2LauncherButton.icon_only(
-				_theme, &"download", Gen2LauncherButton.Variant.PRIMARY, 40.0
-			)
-			get_it.tooltip_text = "Download %s" % row["name"]
-			get_it.pressed.connect(func() -> void: download(row))
-			out.append(get_it)
-			return out
-		&"update":
-			var update: Gen2LauncherButton = Gen2LauncherButton.icon_only(
-				_theme, &"download", Gen2LauncherButton.Variant.PRIMARY, 40.0
-			)
-			update.size_flags_vertical = Control.SIZE_SHRINK_CENTER
-			update.tooltip_text = "Download and install the available update for %s" % row["name"]
-			update.pressed.connect(func() -> void: download(row))
-			out.append(update)
+	var action: StringName = Gen2ModCatalogue.action_for(row)
+	if action != &"remove" and bool(row["listed"]):
+		var get_it: Gen2LauncherButton = Gen2LauncherButton.icon_only(
+			_theme, &"download", Gen2LauncherButton.Variant.PRIMARY, 40.0
+		)
+		get_it.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+		get_it.tooltip_text = ACTION_TOOLTIPS[action] % row["name"]
+		get_it.pressed.connect(func() -> void: download(row))
+		out.append(get_it)
+	if not bool(row["present"]):
+		return out
 	var remove: Gen2LauncherButton = Gen2LauncherButton.icon_only(
 		_theme, &"trash", Gen2LauncherButton.Variant.DANGER, 40.0
 	)
@@ -327,6 +322,13 @@ func _action_buttons(row: Dictionary) -> Array[Control]:
 	remove.pressed.connect(func() -> void: remove_mod(row))
 	out.append(remove)
 	return out
+
+
+const ACTION_TOOLTIPS: Dictionary = {
+	&"download": "Download %s",
+	&"update": "Download and install the available update for %s",
+	&"replace": "Replace the copy of %s this version cannot load",
+}
 
 
 ## The line under a name: the version in hand, and what a source is offering
@@ -337,7 +339,11 @@ static func _version_line(row: Dictionary) -> String:
 	if not version.is_empty():
 		line += "  %s" % version
 	if not bool(row["installed"]):
-		return "%s  Not installed" % line
+		# A copy on disk the host refused is not the same as nothing installed,
+		# and the refusal card below the list says which one it was.
+		return "%s  %s" % [
+			line, "Installed, not loaded" if bool(row["present"]) else "Not installed"
+		]
 	match StringName(row["update"]):
 		PokeModIndex.UPDATE_AVAILABLE:
 			return "%s  %s available" % [line, row["listed_version"]]
@@ -364,8 +370,9 @@ func _refusal(failure: Dictionary) -> Control:
 ## The row for one id as the catalogue sees it now, or an empty dictionary for a
 ## mod that has since been removed and is listed nowhere.
 func _row_for(id: StringName) -> Dictionary:
+	var host: Gen2ModHost = Gen2ModHost.instance()
 	for group: Dictionary in Gen2ModCatalogue.groups(
-		Gen2ModHost.instance().manifests(), PokeModIndex.followed(), _listings
+		host.manifests(), PokeModIndex.followed(), _listings, host.present_ids()
 	):
 		for row: Dictionary in group["rows"] as Array:
 			if StringName(row["id"]) == id:
@@ -477,13 +484,20 @@ func available_update_count() -> int:
 	return update_rows().size()
 
 
+## What the update button offers: a newer version, and a copy this host would
+## not load that a source can hand over again, which is the one press out of a
+## contract bump.
+const UPDATE_ACTIONS: Array[StringName] = [&"update", &"replace"]
+
+
 func update_rows() -> Array:
 	var out: Array = []
+	var host: Gen2ModHost = Gen2ModHost.instance()
 	for group: Dictionary in Gen2ModCatalogue.groups(
-		Gen2ModHost.instance().manifests(), PokeModIndex.followed(), _listings
+		host.manifests(), PokeModIndex.followed(), _listings, host.present_ids()
 	):
 		for row: Dictionary in group["rows"] as Array:
-			if Gen2ModCatalogue.action_for(row) == &"update":
+			if UPDATE_ACTIONS.has(Gen2ModCatalogue.action_for(row)) and bool(row["listed"]):
 				out.append(row)
 	return out
 
@@ -635,7 +649,7 @@ func _settled(finished: Callable, ok: bool) -> void:
 ## turns out to be another mod is exactly what this refuses.
 func install_entry_bytes(row: Dictionary, body: PackedByteArray) -> Dictionary:
 	var installed: Dictionary = Gen2ModInstaller.install_bytes(
-		body, bool(row.get("installed", false)), StringName(row["id"])
+		body, bool(row.get("present", row.get("installed", false))), StringName(row["id"])
 	)
 	if not bool(installed.get("ok", false)):
 		_status("%s was not installed: %s" % [

--- a/game/mods/mod_catalogue.gd
+++ b/game/mods/mod_catalogue.gd
@@ -18,10 +18,13 @@ const SOURCE_FILE_LABEL: String = "Installed from a file"
 ## anything in it, in the order the player added them, then the file group.
 ##
 ## [param sources] is [method PokeModIndex.followed]'s rows, [param listings] is
-## feed to that feed's entries, and [param manifests] is
-## [method Gen2ModHost.manifests]. A group is
+## feed to that feed's entries, [param manifests] is
+## [method Gen2ModHost.manifests] and [param present] is
+## [method Gen2ModHost.present_ids]. A group is
 ## `{feed, label, rows}`; see [method _row] for a row.
-static func groups(manifests: Array, sources: Array, listings: Dictionary) -> Array:
+static func groups(
+	manifests: Array, sources: Array, listings: Dictionary, present: Dictionary = {}
+) -> Array:
 	var installed: Dictionary = {}
 	for manifest: PokeModManifest in manifests:
 		installed[manifest.id] = manifest
@@ -39,14 +42,22 @@ static func groups(manifests: Array, sources: Array, listings: Dictionary) -> Ar
 			if String(id).is_empty() or claimed.has(id):
 				continue
 			claimed[id] = true
-			rows.append(_row(id, entry as Dictionary, installed.get(id, null), feed, label))
+			rows.append(_row(
+				id, entry as Dictionary, installed.get(id, null), feed, label,
+				present.has(id)
+			))
 		if not rows.is_empty():
 			out.append({"feed": feed, "label": label, "rows": _sorted(rows)})
 
 	var loose: Array = []
 	for id: StringName in installed:
 		if not claimed.has(id):
-			loose.append(_row(id, {}, installed[id], SOURCE_FILE, SOURCE_FILE_LABEL))
+			loose.append(_row(id, {}, installed[id], SOURCE_FILE, SOURCE_FILE_LABEL, true))
+	# A copy no source lists whose manifest was refused: it has no manifest to
+	# read a name or a version off, and it is still a directory to remove.
+	for id: StringName in present:
+		if not claimed.has(id) and not installed.has(id):
+			loose.append(_row(id, {}, null, SOURCE_FILE, SOURCE_FILE_LABEL, true))
 	if not loose.is_empty():
 		out.append({"feed": SOURCE_FILE, "label": SOURCE_FILE_LABEL, "rows": _sorted(loose)})
 	return out
@@ -58,8 +69,11 @@ static func groups(manifests: Array, sources: Array, listings: Dictionary) -> Ar
 ##
 ## `version` is what the row shows: the installed version when there is one,
 ## because that is the copy the player has, and the listed version otherwise.
+## [param present] is whether the mods root holds a directory for it, which is
+## true without a manifest whenever this host refused the one that is there.
 static func _row(
-	id: StringName, entry: Dictionary, manifest: PokeModManifest, feed: String, label: String
+	id: StringName, entry: Dictionary, manifest: PokeModManifest, feed: String,
+	label: String, present: bool
 ) -> Dictionary:
 	var listed_version: String = String(entry.get("version", ""))
 	var installed_version: String = manifest.version if manifest != null else ""
@@ -81,6 +95,7 @@ static func _row(
 		"feed": feed,
 		"source_label": label,
 		"installed": manifest != null,
+		"present": present or manifest != null,
 		"listed": not entry.is_empty(),
 		"enabled": manifest != null and Gen2ModState.is_enabled(id),
 		"update": PokeModIndex.update_state(listed_version, installed_version),
@@ -91,9 +106,15 @@ static func _row(
 ## What the row's own action does, which is the one place the Cydia rule lives:
 ## a listed mod is downloaded, updated or reinstalled, and an installed one is
 ## removed. Removing a listed mod leaves it listed.
+##
+## `replace` is a copy on disk this host would not load, which is what a
+## contract bump leaves behind: the installer refuses a plain download over it,
+## so the press has to say it is replacing what is there.
 static func action_for(row: Dictionary) -> StringName:
-	if not bool(row.get("installed", false)):
+	if not bool(row.get("present", row.get("installed", false))):
 		return &"download"
+	if not bool(row.get("installed", false)):
+		return &"replace"
 	if StringName(row.get("update", PokeModIndex.UNKNOWN)) == PokeModIndex.UPDATE_AVAILABLE:
 		return &"update"
 	return &"remove"

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -66,10 +66,8 @@ const RENDERER_WORLD_CONTEXT_METHOD: String = "set_world_context"
 ## Optional, world renderers only. Offered every input event the world screen did
 ## not use, so a renderer can own camera pitch or first person; answering true
 ## consumes the event. The screen decides first, so a renderer can never take a
-## movement or interaction key: it reads world state and must not write it.
-## Implement this rather than [method Node._input] or
-## [method Node._unhandled_input], which are offered events before the screen
-## decides and so race the gameplay keys instead of taking what is left.
+## movement or interaction key. Implement this rather than [method Node._input]
+## or [method Node._unhandled_input], which race the gameplay keys instead.
 const RENDERER_INPUT_METHOD: String = "handle_world_input"
 ## Optional, battle renderers only. The same seam on the battle side: every event
 ## [Gen2BattleScreen] did not claim, so a renderer composing its own shot can let
@@ -82,11 +80,9 @@ const RENDERER_INPUT_METHOD: String = "handle_world_input"
 const RENDERER_BATTLE_INPUT_METHOD: String = "handle_battle_input"
 ## Optional, both renderer kinds. How opaque the screen draws the field of its own
 ## text box while this renderer is on the native layer, from 0 to 1. The frame's
-## lines and the glyphs are ink and stay opaque, so nothing becomes harder to
-## read. Only honoured for a renderer that answered
+## lines and the glyphs stay opaque. Only honoured for a renderer that answered
 ## [constant RENDERER_SURFACE_METHOD] false: one drawing in hardware pixels paints
-## the background the box sits on, and a hole in the box would show the window
-## behind the screen rather than the map.
+## the background the box sits on, so a hole would show the window behind it.
 const RENDERER_INTERFACE_OPACITY_METHOD: String = "interface_opacity"
 ## Optional, both renderer kinds. Called with the rectangle the screen's text box
 ## covers, in hardware pixels, whenever it changes, and with an empty rectangle
@@ -95,12 +91,10 @@ const RENDERER_INTERFACE_OPACITY_METHOD: String = "interface_opacity"
 const RENDERER_TEXT_BOX_METHOD: String = "set_text_box_rect"
 ## Optional, both renderer kinds. Called when a screen laid out in 160x144 takes
 ## the picture over the view, and again when it gives it back. A renderer drawing
-## in hardware pixels needs nothing, the screen painting its own letterbox inside
-## the hardware viewport; a native-layer renderer is deliberately not covered,
-## since the mask would crop a view that already filled the surface. This is how
-## such a renderer closes its own surround, and `DoBattleTransition` is the case it
-## exists for: twenty by eighteen cells cannot be widened, so the wedge closing
-## over a filled window is a shape only that view can draw.
+## in hardware pixels needs nothing; a native-layer one is deliberately not
+## covered, the mask cropping a view that already filled the surface, so this is
+## how it closes its own surround. `DoBattleTransition` is the case it exists
+## for: the wedge closing over a filled window is a shape only that view draws.
 const RENDERER_INTERFACE_MASK_METHOD: String = "set_interface_masked"
 ## Optional, both renderer kinds, and only meaningful on the native layer. Called
 ## beside [constant RENDERER_RESIZE_METHOD] with the cartridge's own 160x144
@@ -207,6 +201,8 @@ static var _instance: Gen2ModHost = null
 static var _mounted_packs: Dictionary = {}
 
 var _manifests: Dictionary = {}
+## Every mod directory [method discover] saw, refused manifests included.
+var _present: Dictionary = {}
 ## Mod id to version for every entry script that ran. See [method loaded_mods].
 var _loaded: Dictionary = {}
 ## Mod id to the entry object `register` was called on, held so it survives the
@@ -359,9 +355,8 @@ func create_world_renderer() -> Node:
 ## because an actor is a pose and not a view: it must be a [RefCounted], never a
 ## [Node], and must answer [constant Gen2WorldActors.ACTOR_METHODS], a
 ## registration missing one being refused here where the mod's name is in hand.
-## Two more are OPTIONAL and offered only to an actor that defines them, so every
-## actor already written keeps working. What an actor draws is presentation and
-## takes part in nothing else; see `docs/MODS.md` for the entry shape.
+## Two more are OPTIONAL and offered only to an actor that defines them. See
+## `docs/MODS.md` for the entry shape.
 func register_world_actor(id: StringName, actor: Object) -> Dictionary:
 	return _register_provider(
 		_world_actors, Gen2WorldActors.ACTOR_METHODS, id, actor, "actor"
@@ -419,11 +414,9 @@ func requeue_hidden_items(cells: Array[Vector2i]) -> void:
 ## Asks the world screen to hand [param item] over, [param quantity] of it,
 ## through `verbosegiveitem`'s own transaction: the bag write, the fanfare, the
 ## received line, the pocket line and the pack-full branch. A REQUEST and never
-## the act, for the reason [method request_hidden_item] is one, and answering
-## nothing for the same reason. Queued the same way, so one made inside a battle
-## or a warp is spent on the first world frame nothing else owns. An item number
-## the cartridge does not know is refused when the queue is spent, not here.
-## Unlike a hidden item there is no cell, no event flag and no map.
+## the act, for the reason [method request_hidden_item] is one, and queued the
+## same way. An item number the cartridge does not know is refused when the queue
+## is spent, not here. Unlike a hidden item there is no cell, flag or map.
 func request_item_gift(item: int, quantity: int = 1) -> void:
 	if item <= 0 or quantity <= 0:
 		return
@@ -447,12 +440,10 @@ func requeue_item_gifts(gifts: Array[Dictionary]) -> void:
 
 ## One line's worth of the cartridge's own font, printed in the battle's own box
 ## with its own pacing and its own press, after the line being shown when the
-## request was made. Queued and spent in request order, the way the other two ask
-## methods are. Unlike those it is DROPPED where no battle is showing messages
-## rather than held: a line about a moment that has passed is worse than no line.
-## Refused rather than clipped when it does not fit one line of
-## [constant Gen2TextBox.STANDARD_COLUMNS], with the refusal reaching
-## [method failures] under [param id].
+## request was made. Queued and spent in request order like the other two ask
+## methods, but DROPPED where no battle is showing messages rather than held: a
+## line about a moment that has passed is worse than no line. Refused rather than
+## clipped past [constant Gen2TextBox.STANDARD_COLUMNS], into [method failures].
 func request_battle_message(id: StringName, text: String) -> Dictionary:
 	var line: String = text.strip_edges()
 	if String(id).is_empty():
@@ -497,12 +488,10 @@ const MAX_NOTICES: int = 8
 
 ## Asks the world screen to raise a banner over the map: an icon, a title, a line
 ## and a sound. A REQUEST and never the act, the way [method request_hidden_item]
-## is. Drawn as `PlaceMapNameSign` draws the landmark banner, the only thing the
-## cartridge ever puts over a live map, and held rather than dropped while
-## something else owns the world, with [constant Gen2WorldAPI.MAP_NAME_SIGN_PASSES]
-## between two. `title` and `line` are REFUSED rather than clipped, `icon` is the
-## vocabulary an actor's `sprites()` shares, and `sound` is a
-## [constant NOTICE_SOUNDS] name.
+## is. Drawn as `PlaceMapNameSign` draws the landmark banner, and held rather than
+## dropped while something else owns the world, with
+## [constant Gen2WorldAPI.MAP_NAME_SIGN_PASSES] between two. `title` and `line`
+## are REFUSED rather than clipped, `icon` is an actor's `sprites()` vocabulary.
 func request_notice(id: StringName, notice: Dictionary) -> Dictionary:
 	if String(id).is_empty():
 		return {"ok": false, "reason": &"invalid_provider"}
@@ -759,11 +748,9 @@ func repel_renewal_item(bag: Dictionary) -> int:
 ## Registers a SHINY ROLLS provider under [param id]: how many DV words the host
 ## draws for one wild before it settles, which is the later games' charm. The host
 ## keeps the first [method Gen2Stats.is_shiny] accepts and otherwise the last, and
-## clamps to [constant MAX_SHINY_ROLLS]; 0 and 1 both mean the cartridge's own
-## single roll. [code]context[/code] carries the encounter but not the bag, since
-## [method inventory] is live and this would be one snapshot per wild. Two
-## providers COMPOSE ADDITIVELY rather than by registration order: refusing the
-## second would make two charms an install error over a number with an obvious join.
+## clamps to [constant MAX_SHINY_ROLLS]; 0 and 1 both mean one roll.
+## [code]context[/code] carries the encounter but not the bag, [method inventory]
+## being live. Two providers COMPOSE ADDITIVELY rather than by load order.
 func register_shiny_rolls(id: StringName, provider: Object) -> Dictionary:
 	return _register_provider(_shiny_rolls, SHINY_ROLLS_METHODS, id, provider)
 
@@ -909,10 +896,8 @@ func battle_info_ids() -> Array:
 ## Every provider's placements for [param snapshot], validated and with
 ## overlapping ownership refused rather than resolved by load order: a cell a
 ## later provider claims after an earlier one is dropped and reported, so which
-## mod loaded first cannot decide what a player sees. A placement the grid refuses
-## is reported by name too. This runs once a frame over a pure function, so each
-## distinct refusal is recorded once: repeating it sixty times a second would bury
-## every other failure the launcher lists.
+## mod loaded first cannot decide what a player sees. This runs once a frame, so
+## each distinct refusal is recorded once rather than sixty times a second.
 func battle_info_placements(snapshot: Dictionary) -> Array:
 	var out: Array = []
 	var claimed: Dictionary = {}
@@ -1178,10 +1163,8 @@ func party_member_entries(slot: int, in_battle: bool = false) -> Array:
 ## [param entry] carries a `build(page)` Callable taking
 ## [method Gen2MonStatsScreen.snapshot] and answering placements on the screen's
 ## own tile grid, `{"text", "at"}` for a string and `{"divider"}` for a vertical
-## rule. The host writes them with the screen's own font, so a page needs no
-## renderer, node or picture. The ceiling is
-## [constant Gen2StatsScreenPage.MAX_PAGES], past which the indicators reach the
-## front pic.
+## rule, written with the screen's own font. The ceiling is
+## [constant Gen2StatsScreenPage.MAX_PAGES], past which they reach the front pic.
 func register_stats_page(id: StringName, entry: Dictionary) -> Dictionary:
 	if String(id).is_empty():
 		return {"ok": false, "reason": &"invalid_stats_page"}
@@ -1281,11 +1264,10 @@ func menu_entries(menu: StringName) -> Array:
 
 ## The start-menu entries [code]context[/code] leaves visible, in registration order.
 ##
-## An entry that registered no `visible` predicate is always listed, which is
-## every entry written before this existed. One that did is asked with a copy of
-## the context, so deciding whether to appear cannot change the menu being built;
-## answering false leaves the row ABSENT rather than present and refused, which
-## is what the cartridge's own gated rows do. The host applies its own gate after
+## An entry that registered no `visible` predicate is always listed. One that did
+## is asked with a copy of the context, so deciding whether to appear cannot
+## change the menu being built; answering false leaves the row ABSENT rather than
+## refused, as the cartridge's own gated rows are. The host's own gate runs after
 ## the predicate, so a mod cannot show a row the game would refuse.
 func start_menu_entries(context: Dictionary) -> Array:
 	var out: Array = []
@@ -1340,9 +1322,8 @@ func mart_entries(mart: Dictionary) -> Array:
 ## needs a `key`, a `label` and a non-empty `values` array; `labels` names each
 ## rung and defaults to the values themselves, and `default` is the rung used
 ## until the player picks. A toggle is a two-rung ladder and
-## [constant OPTION_NUMBER] takes a range instead. A mod describes a setting rather
-## than drawing one, so the start menu's MODS entry and the launcher's mods page
-## cannot disagree.
+## [constant OPTION_NUMBER] takes a range. A mod describes a setting rather than
+## drawing one, so the MODS entry and the launcher's page cannot disagree.
 func register_option(id: StringName, spec: Dictionary) -> Dictionary:
 	var key: StringName = StringName(spec.get("key", &""))
 	if String(id).is_empty() or String(key).is_empty():
@@ -2103,6 +2084,7 @@ static func _renderer_takes_input(renderer: Node, method: String, event: InputEv
 func discover(root: String = ROOT) -> Array:
 	_manifests = {}
 	_failures = []
+	_present = {}
 	_battle_info_reported = {}
 	var directory: DirAccess = DirAccess.open(root)
 	if directory == null:
@@ -2111,6 +2093,7 @@ func discover(root: String = ROOT) -> Array:
 	var name: String = directory.get_next()
 	while name != "":
 		if directory.current_is_dir() and not name.begins_with("."):
+			_present[StringName(name)] = true
 			var result: Dictionary = PokeModManifest.read("%s/%s" % [root, name])
 			if bool(result.get("ok", false)):
 				var manifest: PokeModManifest = result["manifest"]
@@ -2132,6 +2115,14 @@ func discover(root: String = ROOT) -> Array:
 ## discover would drop the load failures recorded after it.
 func manifests() -> Array:
 	return _manifests.values()
+
+
+## Every directory the last [method discover] walked, which is the question
+## [method Gen2ModInstaller.install_zip] asks before it refuses one as already
+## installed. A copy whose manifest was refused is in here and not in
+## [method manifests], and the launcher has to be able to replace or remove it.
+func present_ids() -> Dictionary:
+	return _present.duplicate()
 
 
 func failures() -> Array:
@@ -2193,10 +2184,9 @@ const SAVE_LIFECYCLE_METHODS: Array[String] = [
 ## rather than an installation. [param manifest] is the object `register()` was
 ## handed and it is the capability: the host keeps it beside the provider, so a
 ## callback reaches [method read_save_data] for its OWN namespace and no other
-## mod's. [param provider] answers [constant SAVE_LIFECYCLE_METHODS]. Ordering is
-## in `docs/MODS.md`; what matters here is that the host drops every lifecycle
-## mod's overlay contributions before a `save_activated` runs, so two slots cannot
-## leak patches into one another.
+## mod's. [param provider] answers [constant SAVE_LIFECYCLE_METHODS]. The host
+## drops every lifecycle mod's overlay contributions before a `save_activated`
+## runs, so two slots cannot leak patches into one another; see `docs/MODS.md`.
 func register_save_lifecycle(manifest: PokeModManifest, provider: Object) -> Dictionary:
 	if not _owns_manifest(manifest):
 		return {"ok": false, "reason": &"unknown_mod_save_owner"}
@@ -2242,10 +2232,9 @@ func created_save(save: Gen2SaveData) -> void:
 ## The save about to be played, or null for a DEVELOPMENT run: one started without
 ## a selected slot, which has no namespace to read and must not be handed an
 ## invented save to write into. Every lifecycle mod's overlay contributions are
-## dropped first, in one pass, so the callbacks that follow all start from the
-## cartridge whatever order they run in. The save's own mod settings are bound
-## before any callback, so a provider reads the values this run was played with;
-## a slot written before that snapshot existed adopts the installation once, here.
+## dropped first, so the callbacks that follow all start from the cartridge. The
+## save's own mod settings are bound before any callback; a slot written before
+## that snapshot existed adopts the installation once, here.
 func activate_save(save: Gen2SaveData) -> void:
 	_clear_save_overlays()
 	if save == null:

--- a/game/mods/mod_installer.gd
+++ b/game/mods/mod_installer.gd
@@ -2,12 +2,11 @@ class_name Gen2ModInstaller
 extends RefCounted
 
 ## Installs a mod from a `.zip` into [constant Gen2ModHost.ROOT]. The only way a
-## mod gets onto disk, whichever way the player found it: a file they picked, a
-## file they dropped on the window, or one downloaded from an index. So a listing
-## buys a mod no trust that picking the same file by hand would not, and there is
-## one place to harden rather than three. Nothing is written until the archive has
-## been opened, its layout resolved and its manifest validated, and a copy that
-## fails part way removes what it wrote.
+## mod gets onto disk, whichever way the player found it: a file they picked, one
+## they dropped on the window, or one downloaded from an index. So a listing buys
+## a mod no trust picking the same file by hand would not. Nothing is written
+## until the archive is opened, its layout resolved and its manifest validated,
+## and a copy that fails part way removes what it wrote.
 
 ## A single mod's uncompressed size. Well above the voxel example and far below
 ## anything that fills a phone, so a hostile or broken archive stops here rather

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -115,10 +115,19 @@ static func from_dictionary(source: Dictionary, folder: String) -> Dictionary:
 static func _check_names(manifest: PokeModManifest, regex: RegEx) -> Dictionary:
 	if regex.search(String(manifest.id)) == null:
 		return _refuse(&"invalid_id", String(manifest.id))
-	if manifest.api_version < MIN_API_VERSION or manifest.api_version > API_VERSION:
+	# Two different fixes, so two different refusals: a mod above this host wants
+	# a newer build of the game, and one below it wants a newer build of itself.
+	if manifest.api_version > API_VERSION:
 		return _refuse(
 			&"unsupported_api_version",
 			"mod declares %d, host provides %d" % [manifest.api_version, API_VERSION]
+		)
+	if manifest.api_version < MIN_API_VERSION:
+		return _refuse(
+			&"mod_is_too_old",
+			"mod declares %d, host answers %d and above" % [
+				manifest.api_version, MIN_API_VERSION
+			]
 		)
 	if not PokeModVersion.valid_version(manifest.version):
 		return _refuse(&"invalid_mod_version", manifest.version)

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -161,7 +161,9 @@ static func text(result: Dictionary) -> String:
 			detail = PokeModManifest.FILENAME
 		&"unsupported_api_version":
 			# The detail already names both versions.
-			return "That mod was built for a different host: %s." % detail
+			return "That mod needs a newer build of the game: %s." % detail
+		&"mod_is_too_old":
+			return "That mod was built for an older build: %s. Download it again." % detail
 		&"unsupported_index_schema":
 			return "That index uses format %s; this build reads %d." % [
 				detail, PokeModIndex.SCHEMA_VERSION,

--- a/tests/unit/test_launcher_ui.gd
+++ b/tests/unit/test_launcher_ui.gd
@@ -300,7 +300,7 @@ func test_mod_update_controls_stay_icon_sized_for_mobile() -> void:
 	assert_eq(check.text, "", "the page-wide check does not widen the mobile header")
 	assert_eq(check.get("_glyph"), &"refresh_all")
 	var actions: Array[Control] = page._action_buttons({
-		"name": "Example", "installed": true,
+		"name": "Example", "installed": true, "present": true, "listed": true,
 		"update": PokeModIndex.UPDATE_AVAILABLE,
 	})
 	var update: Gen2LauncherButton = actions[0] as Gen2LauncherButton
@@ -963,6 +963,8 @@ func test_a_mod_row_fits_a_phone_rather_than_running_off_its_card() -> void:
 		"name": "Listed mod",
 		"version": "1.0.0",
 		"installed": false,
+		"present": false,
+		"listed": true,
 		"enabled": false,
 		"update": PokeModIndex.UNKNOWN,
 	}) as Gen2LauncherCard

--- a/tests/unit/test_mod_registries.gd
+++ b/tests/unit/test_mod_registries.gd
@@ -467,6 +467,7 @@ func test_every_refusal_reason_the_mod_layer_produces_has_player_wording() -> vo
 	# neither used to show as a raw StringName through whichever screen met it.
 	for reason: StringName in [
 		&"not_a_zip", &"unsafe_archive_entry", &"unsupported_api_version",
+		&"mod_is_too_old",
 		&"unsupported_index_schema", &"already_installed", &"duplicate_renderer",
 		&"duplicate_content", &"reserved_effect_command", &"missing_entry_script",
 		&"duplicate_party_menu_entry", &"party_menu_entry_missing_callable",

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -113,14 +113,14 @@ func test_a_manifest_built_for_another_host_is_refused() -> void:
 	_write_manifest(source)
 	assert_eq(PokeModManifest.read(_directory)["reason"], &"unsupported_api_version")
 
-	## An OLDER contract still runs: every bump so far has only added to it, and
-	## refusing one would break every mod already installed.
+	## Below the oldest contract this host answers is a different refusal, since
+	## it is the mod that wants updating rather than the game.
 	source["api_version"] = PokeModManifest.MIN_API_VERSION
 	_write_manifest(source)
 	assert_true(bool(PokeModManifest.read(_directory).get("ok", false)))
 	source["api_version"] = PokeModManifest.MIN_API_VERSION - 1
 	_write_manifest(source)
-	assert_eq(PokeModManifest.read(_directory)["reason"], &"unsupported_api_version")
+	assert_eq(PokeModManifest.read(_directory)["reason"], &"mod_is_too_old")
 
 
 func test_manifest_versions_and_dependency_ranges_are_validated_before_code_runs() -> void:
@@ -1529,6 +1529,54 @@ func test_a_mod_belongs_to_the_source_that_lists_it_and_otherwise_to_the_file_it
 	assert_eq(String(loose["id"]), "handmade")
 	assert_eq(Gen2ModCatalogue.action_for(loose), &"remove")
 	assert_true(Gen2ModCatalogue.removal_is_permanent(loose), "a file is the only copy")
+
+
+## The trap a contract bump leaves behind. A copy whose `mod.json` this host
+## refuses is on disk and not in [method Gen2ModHost.manifests], so a row read
+## off the manifests alone says "Not installed", offers only the download, and
+## that download is refused because the directory is there.
+func test_a_copy_the_host_refused_is_still_a_copy_the_player_can_act_on() -> void:
+	var stale: String = "%s/stale" % ROOT
+	_write_dependency_mod(stale, "stale", "1.0.0")
+	_write("%s/mod.json" % stale, JSON.stringify({
+		"id": "stale", "name": "Stale", "version": "1.0.0",
+		"api_version": PokeModManifest.MIN_API_VERSION - 1, "entry": "mod.gd",
+	}))
+	var host: Gen2ModHost = Gen2ModHost.instance()
+	host.discover(ROOT)
+	assert_eq(host.manifests().size(), 0, "the manifest is refused")
+	assert_true(host.failures().any(func(failure: Dictionary) -> bool:
+		return StringName(failure.get("reason", &"")) == &"mod_is_too_old"
+	), "and refused for the contract it declares")
+	assert_true(host.present_ids().has(&"stale"), "the copy is still on disk")
+
+	var sources: Array = [{"feed": "https://a.example/index.json", "label": "A"}]
+	var groups: Array = Gen2ModCatalogue.groups(
+		host.manifests(), sources,
+		{"https://a.example/index.json": [{
+			"id": &"stale", "name": "Stale", "version": "2.0.0",
+			"download": "https://a.example/stale.zip",
+		}]},
+		host.present_ids()
+	)
+	var row: Dictionary = (groups[0]["rows"] as Array)[0]
+	assert_false(bool(row["installed"]), "no manifest reached the host")
+	assert_true(bool(row["present"]), "a copy is in the mods root")
+	assert_eq(
+		Gen2ModCatalogue.action_for(row), &"replace",
+		"the download replaces the copy rather than being refused by it"
+	)
+	assert_eq(
+		Gen2ModInstaller.install_bytes(
+			PackedByteArray(), bool(row["present"]), StringName(row["id"]), ROOT
+		).get("reason", &""),
+		&"not_a_zip",
+		"the installer got as far as reading the archive rather than refusing the folder"
+	)
+	assert_true(
+		Gen2ModInstaller.uninstall(&"stale", ROOT).get("removed", false),
+		"and the row can be removed instead"
+	)
 
 
 func test_two_sources_listing_one_mod_leave_it_under_the_first() -> void:


### PR DESCRIPTION
Reported: every mod reads as not installed and cannot be downloaded again because it is already installed.

`MIN_API_VERSION` refuses a copy built for an older host, so every mod installed before 0.1.27 stopped parsing. `Gen2ModHost.manifests` is what the launcher reads and a refused copy is not in it: the row said "Not installed", offered only the download, and the installer refused that download because `root/<id>` was there. There was no remove button on such a row either, so nothing on the page did anything and the only way out was the file system.

The two questions were the same fact answered from different places. The installer asks whether the directory exists; `Gen2ModHost.present_ids` is now that same answer off the walk `discover` already does, and a catalogue row carries `present` beside `installed`. A copy on disk this host would not load is `action_for`'s new `replace`: the download goes in as a replacement rather than being refused by the folder, the remove button follows `present` so there is always something to press, and the row says "Installed, not loaded" instead of claiming there is nothing there. The update button counts those rows, so one press reinstalls every mod a contract bump left behind.

A copy no source lists gets a row of its own for the same reason: it had only a refusal card, and no way to remove it from inside the game.

The refusal splits in two, because the fixes are opposite. A mod above this host wants a newer build of the game; one below it wants a newer build of itself, which is `mod_is_too_old` and says to download it again.

Reproduced against the real launcher by putting one installed mod back to `api_version` 29: before, the row was "Not installed" with a download button that refused; after, it is "Installed, not loaded" with a replace button, a remove button, and the header offering the update.

| Run | Result |
|---|---|
| `gut_cmdln.gd -gdir=res://tests -ginclude_subdirs` | 4360 tests, 0 failures |
| `validate.gd -- all` | 90 topics, 0 failures |
| `--warning-scan` over 629 scripts | 0 warnings |
| `--quit-after 30` | clean boot |
| `tools/release.sh --gates` | pass |