### PR TITLE
Catch, heal and shop on Generation 1

### DIFF
--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -1878,6 +1878,8 @@ const NEW_DEX_DATA_TEXT: String = "%s's data\nwas newly added to\nthe #DEX."
 const BALL_BLOCKED_TEXT: String = "The trainer\nblocked the BALL!"
 const BALL_DONT_BE_A_THIEF_TEXT: String = "Don't be a thief!"
 const BALL_BOX_FULL_TEXT: String = "The #MON BOX\nis full. That\ncan't be used now."
+## `_BoxFullCannotThrowBallText`, `BoxFullCannotThrowBall`'s own words.
+const GEN1_BALL_BOX_FULL_TEXT: String = "The #MON BOX\nis full! Can't%suse that item!"
 ## `anim_if_param_equal NO_ITEM`, `BattleAnim_ThrowPokeBall`'s own first branch
 ## and the one `UseBallInTrainerBattle` sets `wBattleAnimParam` to.
 const ANIM_PARAM_NO_ITEM: int = 0
@@ -1888,6 +1890,20 @@ const BREAK_FREE_TEXT: Array[String] = [
 	"Aargh!\nAlmost had it!",
 	"Shoot! It was so\nclose too!",
 ]
+
+## `ItemUseBallText01` to `...04`, which `ItemUseBall` picks off
+## `wPokeBallAnimData` rather than off a wobble count: a ball that rocks no times
+## at all is a miss here and a break-out there.
+const GEN1_BREAK_FREE_TEXT: Array[String] = [
+	"You missed the\n#MON!",
+	"Darn! The #MON\nbroke free!",
+	"Aww! It appeared\nto be caught!",
+	"Shoot! It was so\nclose too!",
+]
+
+## `Text_GotchaMonWasCaught` and `_ItemUseBallText05`.
+const CAUGHT_TEXT: String = "Gotcha! %s was caught!"
+const GEN1_CAUGHT_TEXT: String = "All right! %s was\ncaught!"
 
 ## `SendOutMonText`'s four texts, in [constant Gen2Battle.SEND_OUT_GO]'s order.
 const SEND_OUT_LINES: Array[String] = [
@@ -3191,7 +3207,7 @@ func complete_capture(result: Dictionary) -> Dictionary:
 		_capture_result.clear()
 		_capture_spent_turn = {}
 		show_message(
-			BALL_BOX_FULL_TEXT if StringName(result.get("reason", &"")) == &"storage_full"
+			_ball_box_full_text() if StringName(result.get("reason", &"")) == &"storage_full"
 			else "The capture could not be completed."
 		)
 		if _capture_origin == &"pack" and not _pack_rows.is_empty():
@@ -3213,7 +3229,10 @@ func complete_capture(result: Dictionary) -> Dictionary:
 	var wobbles: int = clampi(int(result.get("wobbles", 0)), 0, 3)
 	var caught: bool = bool(result.get("caught", false))
 	if caught:
-		_capture_messages.append("Gotcha! %s was caught!" % _name_of(_enemy))
+		_capture_messages.append(
+			(GEN1_CAUGHT_TEXT if _generation() == RomRegistry.GEN1 else CAUGHT_TEXT)
+			% _name_of(_enemy)
+		)
 		## `.catch_bug_contest_mon` runs after `Text_GotchaMonWasCaught`, and
 		## `BugContest_SetCaughtContestMon`'s `.firstcatch` says a second line.
 		## A catch that has one to replace says `DisplayAlreadyCaughtText`
@@ -3224,9 +3243,18 @@ func complete_capture(result: Dictionary) -> Dictionary:
 		_capture_terminal = true
 		_capture_caught_event = _caught_event(result)
 	else:
-		_capture_messages.append(BREAK_FREE_TEXT[wobbles])
+		_capture_messages.append(
+			GEN1_BREAK_FREE_TEXT[wobbles] if _generation() == RomRegistry.GEN1
+			else BREAK_FREE_TEXT[wobbles]
+		)
 	_begin_capture_animation(result_ball, wobbles, caught)
 	return result
+
+
+func _ball_box_full_text() -> String:
+	if _generation() != RomRegistry.GEN1:
+		return BALL_BOX_FULL_TEXT
+	return GEN1_BALL_BOX_FULL_TEXT % Gen2TextStream.SCROLL_BREAK
 
 
 ## `PokeBallEffect`'s own `PlayBattleAnim` on `ANIM_THROW_POKE_BALL`: the throw,
@@ -3348,6 +3376,10 @@ func _item_name(item: int) -> String:
 ## the click are the animation behind this line, and the next thing said is
 ## already the outcome.
 func _item_used_text(item: int) -> String:
+	if _generation() == RomRegistry.GEN1:
+		## `_ItemUseText001` and `_ItemUseText002` with the name between them:
+		## one line, no "the", and an exclamation where Crystal has a stop.
+		return "%s used %s!" % [_player_label(), _item_name(item)]
 	return "%s used the\n%s." % [_player_label(), _item_name(item)]
 
 
@@ -3398,17 +3430,24 @@ func _open_capture_nickname() -> bool:
 	## keyboard on screen halfway through "Gotcha! X was caught!".
 	if _box != null and (_box.is_revealing() or _box.has_pages_left()):
 		return true
+	var destination: Dictionary = _capture_result.get("destination", {})
+	var boxed: bool = StringName(destination.get("destination", &"")) == &"box"
+	## `AskName` is reached from inside `AddPartyMon`, so Generation 1 names only
+	## the catch that joins the party and answers a boxed one with the transfer
+	## line alone.
+	if boxed and _generation() == RomRegistry.GEN1:
+		_capture_nickname_asked = true
+		show_message(Gen2WorldPartyHost.sent_to_box_text(species_name, RomRegistry.GEN1))
+		return true
 	_capture_nickname_asked = true
 	_capture_nickname = species_name
 	var host := Gen2NicknamePromptScreen.new()
 	## `.SendToPC` prints `BallSentToPCText` behind the naming and the party
 	## branch prints nothing, which is the one difference between the two.
-	var destination: Dictionary = _capture_result.get("destination", {})
 	host.set_context(
 		_data, species_name,
-		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT \
-			if StringName(destination.get("destination", &"")) == &"box" else "",
-		Gen2WorldPartyHost.capture_nickname_question(species_name),
+		Gen2WorldPartyHost.SENT_TO_BOX_FORMAT if boxed else "",
+		Gen2WorldPartyHost.capture_nickname_question(species_name, _generation()),
 		## A Nuzlocke nicknames every catch, so the question is not asked.
 		_rules().is_nuzlocke()
 	)

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -97,6 +97,7 @@ var _day_care_text: Dictionary = {}
 var _special_text: Dictionary = {}
 var _special_text_ram: Dictionary = {}
 var _vending: Array = []
+var _prizes: Array = []
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 var _world_maps: Array = []
@@ -214,6 +215,7 @@ const MANIFEST_ARRAYS: Dictionary = {
 	"gender_screen_palette": "_gender_screen_palette",
 	"copyright_string": "_copyright_string",
 	"vending": "_vending",
+	"prizes": "_prizes",
 	"copyright_palette": "_copyright_palette",
 	"text_bg_palette": "_text_bg_palette",
 	"odd_eggs": "_odd_eggs",
@@ -1828,6 +1830,12 @@ func special_text(run: String, name: String) -> String:
 ## The WRAM address a `text_ram` in one of those boxes names, by the name
 ## `Gen2Layout`'s own `special_text_ram` gives it, or -1 on a cartridge that
 ## ships no such buffer.
+## `PrizeDifferentMenuPtrs`' three menus, each `{tms, rows}` with a row's item,
+## cost and the level a prize Pokemon arrives at. Empty outside Generation 1.
+func prize_menus() -> Array:
+	return _prizes.duplicate(true)
+
+
 ## `VendingPrices` as `{item, price}`, empty outside Generation 1.
 func vending_rows() -> Array:
 	return _vending.duplicate(true)

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -96,6 +96,7 @@ var _move_deleter_text: Dictionary = {}
 var _day_care_text: Dictionary = {}
 var _special_text: Dictionary = {}
 var _special_text_ram: Dictionary = {}
+var _vending: Array = []
 var _battle_object_palettes: Dictionary = {}
 var _indices: Dictionary = {}
 var _world_maps: Array = []
@@ -212,6 +213,7 @@ const MANIFEST_ARRAYS: Dictionary = {
 	"pc_palette": "_pc_palette",
 	"gender_screen_palette": "_gender_screen_palette",
 	"copyright_string": "_copyright_string",
+	"vending": "_vending",
 	"copyright_palette": "_copyright_palette",
 	"text_bg_palette": "_text_bg_palette",
 	"odd_eggs": "_odd_eggs",
@@ -1826,6 +1828,11 @@ func special_text(run: String, name: String) -> String:
 ## The WRAM address a `text_ram` in one of those boxes names, by the name
 ## `Gen2Layout`'s own `special_text_ram` gives it, or -1 on a cartridge that
 ## ships no such buffer.
+## `VendingPrices` as `{item, price}`, empty outside Generation 1.
+func vending_rows() -> Array:
+	return _vending.duplicate(true)
+
+
 func special_text_ram(name: String) -> int:
 	return int(_special_text_ram.get(name, -1))
 

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -147,6 +147,7 @@ const BATTLE_TILE_SHEETS: Dictionary = {
 ## under `mart_text` instead, because the shop screen already reads that.
 const FACILITY_TEXT_RUNS: Dictionary = {
 	"pokecenter": ["pokecenter_text", Gen1Layout.POKECENTER_TEXT_AT],
+	"cable_club": ["cable_club_text", Gen1Layout.CABLE_CLUB_TEXT_AT],
 }
 
 

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -149,6 +149,8 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"pokecenter": ["pokecenter_text", Gen1Layout.POKECENTER_TEXT_AT],
 	"cable_club": ["cable_club_text", Gen1Layout.CABLE_CLUB_TEXT_AT],
 	"vending": ["vending_text", Gen1Layout.VENDING_TEXT_AT],
+	"prizes": ["prize_text", Gen1Layout.PRIZE_TEXT_AT],
+	"prizes_2": ["prize_text_2", Gen1Layout.PRIZE_TEXT_2_AT],
 }
 
 
@@ -697,6 +699,7 @@ func import_rom(
 		"mart_text": _import_mart_text(rom, layout),
 		"special_text": _import_facility_text(rom, layout),
 		"vending": _import_vending(rom, layout, items),
+		"prizes": _import_prizes(rom, layout),
 		"complete": true,
 	}
 	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
@@ -923,6 +926,45 @@ func _vending_names_agree(drawn: PackedStringArray, rows: Array, items: Array) -
 	return true
 
 
+## `PrizeDifferentMenuPtrs` and the two lists behind each of its three rows.
+## The Pokemon menus hold internal indexes and are converted here, the TM menu's
+## being item numbers already; a prize Pokemon's level is
+## `PrizeMonLevelDictionary`'s, keyed by dex number.
+func _import_prizes(rom: RomFile, layout: Dictionary) -> Array:
+	var table: int = int(layout.get("prize_menus", 0))
+	@warning_ignore("integer_division")
+	var bank: int = table / RomFile.BANK_SIZE
+	var levels: Dictionary = {}
+	var at: int = int(layout.get("prize_mon_levels", 0))
+	for row: int in Gen1Layout.PRIZE_MON_LEVELS:
+		var entry: int = at + row * Gen1Layout.PRIZE_MON_LEVEL_SIZE
+		levels[Gen1Layout.dex_of_index(rom, layout, rom.u8(entry))] = rom.u8(entry + 1)
+	var out: Array = []
+	for menu: int in Gen1Layout.PRIZE_MENUS:
+		var pair: int = table + menu * Gen1Layout.PRIZE_POINTER_PAIR
+		var tms: bool = menu == Gen1Layout.PRIZE_TM_MENU
+		var entries: int = Gen1Layout.banked(bank, rom.u16le(pair))
+		var costs: int = Gen1Layout.banked(bank, rom.u16le(pair + 2))
+		## Both lists end in the `@` the source writes, which is what says the
+		## pointer pair was read at the right stride.
+		if rom.u8(entries + Gen1Layout.PRIZE_ROWS) != Gen1Text.TERMINATOR \
+			or rom.u8(costs + Gen1Layout.PRIZE_ROWS * Gen1Layout.PRIZE_COST_SIZE) \
+				!= Gen1Text.TERMINATOR:
+			return []
+		var rows: Array = []
+		for row: int in Gen1Layout.PRIZE_ROWS:
+			var value: int = rom.u8(entries + row)
+			var number: int = value if tms else Gen1Layout.dex_of_index(rom, layout, value)
+			rows.append({
+				"item": number,
+				"cost": _bcd3(rom, costs + row * Gen1Layout.PRIZE_COST_SIZE,
+					Gen1Layout.PRIZE_COST_SIZE),
+				"level": int(levels.get(number, 0)) if not tms else 0,
+			})
+		out.append({"tms": tms, "rows": rows})
+	return out
+
+
 ## The other two runs, in [method GameData.special_text]'s run/slot shape.
 func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var out: Dictionary = {}
@@ -1011,9 +1053,9 @@ static func _item_price(rom: RomFile, layout: Dictionary, item: int) -> int:
 
 
 ## `bcd3`, which is how both a price and a trainer's reward money are stored.
-static func _bcd3(rom: RomFile, at: int) -> int:
+static func _bcd3(rom: RomFile, at: int, size: int = Gen1Layout.ITEM_PRICE_SIZE) -> int:
 	var out: int = 0
-	for byte: int in Gen1Layout.ITEM_PRICE_SIZE:
+	for byte: int in size:
 		var packed: int = rom.u8(at + byte)
 		out = out * 100 + (packed >> 4) * 10 + (packed & 0x0F)
 	return out

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -148,6 +148,7 @@ const BATTLE_TILE_SHEETS: Dictionary = {
 const FACILITY_TEXT_RUNS: Dictionary = {
 	"pokecenter": ["pokecenter_text", Gen1Layout.POKECENTER_TEXT_AT],
 	"cable_club": ["cable_club_text", Gen1Layout.CABLE_CLUB_TEXT_AT],
+	"vending": ["vending_text", Gen1Layout.VENDING_TEXT_AT],
 }
 
 
@@ -695,6 +696,7 @@ func import_rom(
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"mart_text": _import_mart_text(rom, layout),
 		"special_text": _import_facility_text(rom, layout),
+		"vending": _import_vending(rom, layout, items),
 		"complete": true,
 	}
 	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
@@ -889,6 +891,36 @@ func _import_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 			layout, "mart_text", Gen1Layout.MART_TEXT_AT, name
 		))
 	return out
+
+
+## `VendingPrices`' three rows, checked against the hand-written `DrinkText`
+## beside them: a moved offset sells something the cartridge never stocked.
+func _import_vending(rom: RomFile, layout: Dictionary, items: Array) -> Array:
+	var head: int = int(layout.get("vending_text", 0))
+	## One `PlaceString` with `<NEXT>` between its rows, which [method
+	## Gen1Text.decode] keeps as the token rather than as a break.
+	var drawn: PackedStringArray = Gen1Text.decode(
+		rom.bytes(), head + Gen1Layout.VENDING_DRINKS_AT, Gen1Layout.VENDING_DRINKS_LENGTH
+	).split(Gen1Text.CONTROL_CHARACTERS[Gen1Text.NEXT_LINE])
+	var out: Array = []
+	for row: int in Gen1Layout.VENDING_ROWS:
+		var at: int = head + Gen1Layout.VENDING_PRICES_AT + row * Gen1Layout.VENDING_ROW_SIZE
+		out.append({"item": rom.u8(at), "price": _bcd3(rom, at + 1)})
+	return out if _vending_names_agree(drawn, out, items) else []
+
+
+## `DrinkText` is written by hand rather than read off `ItemNames`, so an offset
+## that has moved shows up as a machine selling something else.
+func _vending_names_agree(drawn: PackedStringArray, rows: Array, items: Array) -> bool:
+	if drawn.size() != Gen1Layout.VENDING_ROWS + 1 \
+		or drawn[Gen1Layout.VENDING_ROWS] != Gen1Layout.VENDING_CANCEL:
+		return false
+	for row: int in Gen1Layout.VENDING_ROWS:
+		var number: int = int((rows[row] as Dictionary)["item"])
+		if number < 1 or number > items.size() \
+			or drawn[row] != String((items[number - 1] as Dictionary).get("name", "")):
+			return false
+	return true
 
 
 ## The other two runs, in [method GameData.special_text]'s run/slot shape.

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -375,6 +375,18 @@ const TEXT_SCRIPT_IDS: Dictionary = {
 }
 const TEXT_SCRIPT_MART: int = 0xFE
 const TEXT_SCRIPT_POKECENTER_NURSE: int = 0xFF
+const TEXT_SCRIPT_CABLE_CLUB: int = 0xF6
+
+## `CableClubNPC`'s stubs by the delta from the first. Only the three a port
+## with no cable reaches are named; the rest want a link partner.
+const CABLE_CLUB_TEXT_AT: Dictionary = {
+	"area_reserved": 0x00, "welcome": 0x05, "making_preparations": 0x1F,
+}
+
+## `ld c, 60 / call DelayFrames` before the preparations line, and
+## `wLinkTimeoutCounter`, one frame a pass of `.establishConnectionLoop`.
+const CABLE_CLUB_PREPARING_FRAMES: int = 60
+const CABLE_CLUB_TIMEOUT_FRAMES: int = 90
 
 ## `script_mart` writes its inventory into the text pointer itself: the $FE,
 ## a count, that many item ids, and a $FF nothing reads. `LoadItemList` copies
@@ -629,6 +641,7 @@ const RED_BLUE: Dictionary = {
 	"mart_greeting": 0x02A55,
 	"mart_text": 0x06E0C,
 	"pokecenter_text": 0x0705D,
+	"cable_club_text": 0x072B3,
 	"font": 0x11A80,
 	"text_box": 0x12288,
 	"battle_font": 0x11EA0,
@@ -689,6 +702,7 @@ const YELLOW: Dictionary = {
 	"mart_greeting": 0x02938,
 	"mart_text": 0x06B91,
 	"pokecenter_text": 0x06ED0,
+	"cable_club_text": 0x07188,
 	"font": 0x10600,
 	"text_box": 0x10E18,
 	"battle_font": 0x10A20,

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -376,6 +376,22 @@ const TEXT_SCRIPT_IDS: Dictionary = {
 const TEXT_SCRIPT_MART: int = 0xFE
 const TEXT_SCRIPT_POKECENTER_NURSE: int = 0xFF
 const TEXT_SCRIPT_CABLE_CLUB: int = 0xF6
+const TEXT_SCRIPT_VENDING_MACHINE: int = 0xF5
+
+## `engine/events/vending_machine.asm` from `VendingMachineText1`: the greeting,
+## the two strings the box draws, `VendingPrices` and the four stubs behind them,
+## at the same deltas on all three cartridges.
+const VENDING_TEXT_AT: Dictionary = {
+	"greeting": 0x00, "no_money": 0x3A, "here_you_go": 0x3F,
+	"bag_full": 0x44, "not_thirsty": 0x49,
+}
+const VENDING_DRINKS_AT: int = 0x05
+const VENDING_DRINKS_LENGTH: int = 0x25
+const VENDING_CANCEL: String = "CANCEL"
+const VENDING_PRICES_AT: int = 0x67
+const VENDING_ROWS: int = 3
+## `vend_item`: one item byte and a `bcd3` price.
+const VENDING_ROW_SIZE: int = 4
 
 ## `CableClubNPC`'s stubs by the delta from the first. Only the three a port
 ## with no cable reaches are named; the rest want a link partner.
@@ -642,6 +658,7 @@ const RED_BLUE: Dictionary = {
 	"mart_text": 0x06E0C,
 	"pokecenter_text": 0x0705D,
 	"cable_club_text": 0x072B3,
+	"vending_text": 0x74F99,
 	"font": 0x11A80,
 	"text_box": 0x12288,
 	"battle_font": 0x11EA0,
@@ -703,6 +720,7 @@ const YELLOW: Dictionary = {
 	"mart_text": 0x06B91,
 	"pokecenter_text": 0x06ED0,
 	"cable_club_text": 0x07188,
+	"vending_text": 0x747DE,
 	"font": 0x10600,
 	"text_box": 0x10E18,
 	"battle_font": 0x10A20,
@@ -734,10 +752,21 @@ const YELLOW: Dictionary = {
 }
 
 
+## Bank $1D holds the 668 symbols that move between Red and Blue: everything in
+## it sits one byte later on Blue.
+const BLUE_ONLY: Dictionary = {
+	"vending_text": 0x74F9A,
+}
+
+static var _blue: Dictionary = RED_BLUE.merged(BLUE_ONLY, true)
+
+
 static func for_id(id: StringName) -> Dictionary:
 	match id:
-		RomRegistry.RED, RomRegistry.BLUE:
+		RomRegistry.RED:
 			return RED_BLUE
+		RomRegistry.BLUE:
+			return _blue
 		RomRegistry.YELLOW:
 			return YELLOW
 	return {}

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -377,6 +377,32 @@ const TEXT_SCRIPT_MART: int = 0xFE
 const TEXT_SCRIPT_POKECENTER_NURSE: int = 0xFF
 const TEXT_SCRIPT_CABLE_CLUB: int = 0xF6
 const TEXT_SCRIPT_VENDING_MACHINE: int = 0xF5
+const TEXT_SCRIPT_PRIZE_VENDOR: int = 0xF7
+
+## `IsItemInBag COIN_CASE`, which `CeladonPrizeMenu` opens on.
+const ITEM_COIN_CASE: int = 0x45
+
+## `CeladonPrizeMenu`'s two stub runs, which are not one: the unreferenced
+## `HereYouGoText` between them moves on Yellow.
+const PRIZE_TEXT_AT: Dictionary = {
+	"require_coin_case": 0x00, "exchange": 0x06, "which_prize": 0x0B,
+}
+const PRIZE_TEXT_2_AT: Dictionary = {
+	"so_you_want": 0x00, "need_more_coins": 0x05, "bag_full": 0x0B,
+	"oh_fine_then": 0x11,
+}
+
+## `PrizeDifferentMenuPtrs`: three `(entries, cost)` pairs, each list three long
+## and `@` terminated, a cost being a `bcd2`. `.putMonName`'s own `cp 2` is what
+## makes the third menu TMs and the two in front of it Pokemon.
+const PRIZE_MENUS: int = 3
+const PRIZE_ROWS: int = 3
+const PRIZE_TM_MENU: int = 2
+const PRIZE_COST_SIZE: int = 2
+const PRIZE_POINTER_PAIR: int = 4
+## `PrizeMonLevelDictionary`, the two Pokemon menus' six rows.
+const PRIZE_MON_LEVELS: int = 6
+const PRIZE_MON_LEVEL_SIZE: int = 2
 
 ## `engine/events/vending_machine.asm` from `VendingMachineText1`: the greeting,
 ## the two strings the box draws, `VendingPrices` and the four stubs behind them,
@@ -659,6 +685,10 @@ const RED_BLUE: Dictionary = {
 	"pokecenter_text": 0x0705D,
 	"cable_club_text": 0x072B3,
 	"vending_text": 0x74F99,
+	"prize_text": 0x5277E,
+	"prize_text_2": 0x52960,
+	"prize_menus": 0x52843,
+	"prize_mon_levels": 0x5298A,
 	"font": 0x11A80,
 	"text_box": 0x12288,
 	"battle_font": 0x11EA0,
@@ -721,6 +751,10 @@ const YELLOW: Dictionary = {
 	"pokecenter_text": 0x06ED0,
 	"cable_club_text": 0x07188,
 	"vending_text": 0x747DE,
+	"prize_text": 0x526DF,
+	"prize_text_2": 0x528C0,
+	"prize_menus": 0x527AE,
+	"prize_mon_levels": 0x528EA,
 	"font": 0x10600,
 	"text_box": 0x10E18,
 	"battle_font": 0x10A20,

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -291,10 +291,31 @@ const ANIM_ID_ULTRATOSS: int = 0xC6
 const ANIM_ID_SHAKE_SCREEN: int = 0xC7
 const ANIM_ID_HIDEPIC: int = 0xC8
 
-## The three ball items `TossBallAnimation` picks a throw off.
+## `ItemUsePtrTable`'s five `ItemUseBall` rows, which `TossBallAnimation` also
+## picks a throw off.
+const ITEM_MASTER_BALL: int = 0x01
 const ITEM_ULTRA_BALL: int = 0x02
 const ITEM_GREAT_BALL: int = 0x03
 const ITEM_POKE_BALL: int = 0x04
+const ITEM_SAFARI_BALL: int = 0x08
+
+## `ItemUseBall`'s three per-ball numbers: the ceiling Rand1 is rerolled above,
+## `BallFactor` and `BallFactor2`. SAFARI_BALL takes the fall-through below.
+const BALL_ROLL: Dictionary = {
+	ITEM_POKE_BALL: [255, 12, 255],
+	ITEM_GREAT_BALL: [200, 8, 200],
+	ITEM_ULTRA_BALL: [150, 12, 150],
+}
+const BALL_ROLL_OTHER: Array[int] = [150, 12, 150]
+
+## `.checkForAilments` takes the first off Rand1 and `.addAilmentValue` adds the
+## second to the shakes, each [any other status, frozen or asleep].
+const BALL_STATUS_SUBTRACT: Array[int] = [12, 25]
+const BALL_STATUS_ADD: Array[int] = [5, 10]
+
+## `.setAnimData`'s ladder over Z: under ten the ball misses, and each threshold
+## passed is one more rock.
+const BALL_SHAKE_THRESHOLDS: Array[int] = [10, 30, 70]
 
 ## What pins the two sheets: the edge under both panels is two solid rows in
 ## the middle of six blank ones, and the empty bar is a rule top and bottom.
@@ -315,6 +336,35 @@ const FRAME_FIRST_CODE: int = 0x79
 const FRAME_LAST_CODE: int = 0x7E
 const FRAME_VERTICAL_CODE: int = FRAME_FIRST_CODE + Gen2Layout.FRAME_VERTICAL
 const FRAME_VERTICAL_ROW: int = 0b00101000
+
+## `PokeCenterFlashingMonitorAndHealBall`: the monitor and one ball.
+## `AnimateHealingMachine` copies three tiles where the sheet is two, so the
+## third is `PokeCenterOAMData` read as pixels at $7e, which nothing draws.
+const HEAL_MACHINE_TILES: int = 2
+const HEAL_MACHINE_VTILE: int = 0x7C
+const HEAL_MACHINE_BYTES: Array[int] = [
+	0x00, 0x00, 0x00, 0x00, 0x7E, 0x00, 0x7E, 0x00,
+	0x7E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C, 0x12, 0x1E,
+	0x21, 0x3F, 0x33, 0x2D, 0x1E, 0x12, 0x0C, 0x0C,
+]
+
+## `PokeCenterOAMData`'s seven rows as the cartridge stores them: y, x, tile and
+## whether the attribute byte flips it. Yellow sets a Game Boy Color palette in
+## that byte too, so only bit 5 is read.
+const HEAL_MACHINE_OAM_SIZE: int = 4
+const HEAL_MACHINE_OAM: Array = [
+	[0x24, 0x34, 0x7C, false],
+	[0x2B, 0x30, 0x7D, false], [0x2B, 0x38, 0x7D, true],
+	[0x30, 0x30, 0x7D, false], [0x30, 0x38, 0x7D, true],
+	[0x35, 0x30, 0x7D, false], [0x35, 0x38, 0x7D, true],
+]
+const HEAL_MACHINE_OAM_XFLIP: int = 0x20
+
+## `rOBP1` as `AnimateHealingMachine` writes it, and the same byte once
+## `FlashSprite8Times` has xored $28 into it: two shades swap places where
+## Crystal rotates all four.
+const HEAL_MACHINE_SHADES: Array = [[0, 0, 2, 3], [0, 2, 0, 3]]
 
 ## `TX_SCRIPT_*`: a text pointer standing at one of these opens a facility
 ## rather than a box, `DisplayTextID` dispatching before it prints.
@@ -592,6 +642,7 @@ const RED_BLUE: Dictionary = {
 	"tilesets": 0x0C7BE,
 	"water_tilesets": 0x0E8E0,
 	"overworld_sprites": 0x17B27,
+	"heal_machine_gfx": 0x704B7,
 	"wild_data": 0x0CEEB,
 	"wild_chances": 0x13918,
 	"good_rod": 0x0E27F,
@@ -652,6 +703,7 @@ const YELLOW: Dictionary = {
 	"tilesets": 0x0C558,
 	"water_tilesets": 0x0E834,
 	"overworld_sprites": 0x142A9,
+	"heal_machine_gfx": 0x7050B,
 	"wild_data": 0x0CB95,
 	"wild_chances": 0x138E2,
 	"good_rod": 0x0E12C,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -36,6 +36,12 @@ static func import_to_cache(
 	for path: String in sections:
 		if not RomCache.write_json(path, sections[path]):
 			return _error("Could not write %s." % path.get_file())
+	if not RomCache.write_section(
+		RomCache.overworld_effects_path(directory),
+		RomCache.blob_path(RomCache.overworld_effects_path(directory)),
+		result["effects"]
+	):
+		return _error("Could not write overworld effect sprites.")
 	var graphics: Dictionary = result["graphics"]
 	for number: int in graphics:
 		if not RomCache.write_indices(RomCache.world_tile_path(directory, number), graphics[number]):
@@ -72,6 +78,9 @@ static func read_world(
 	var encounters: Dictionary = _read_encounters(rom, layout)
 	if not bool(encounters["ok"]):
 		return encounters
+	var effects: Dictionary = _read_overworld_effects(rom, layout)
+	if not bool(effects["ok"]):
+		return effects
 	var water: PackedByteArray = _read_list(rom, int(layout["water_tilesets"]))
 	var tilesets: Array = []
 	var graphics: Dictionary = {}
@@ -111,7 +120,40 @@ static func read_world(
 		"sprites": sprites["sprites"],
 		"sprite_graphics": sprites["graphics"],
 		"encounters": encounters["encounters"],
+		"effects": effects["effects"],
 	}
+
+
+## `PokeCenterFlashingMonitorAndHealBall` and `PokeCenterOAMData` behind it, the
+## one effect Generation 1 draws over the map. Both are checked against the bytes
+## the pinned sources build, so a moved offset is refused rather than decoded.
+static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout.get("heal_machine_gfx", -1))
+	var bytes: int = Gen1Layout.HEAL_MACHINE_TILES * PokeTiles.TILE_BYTES
+	var oam: int = Gen1Layout.HEAL_MACHINE_OAM.size() * Gen1Layout.HEAL_MACHINE_OAM_SIZE
+	if at < 0 or not rom.in_bounds(at, bytes + oam):
+		return _error("The heal machine graphics are outside the cartridge.")
+	if rom.slice(at, bytes) != PackedByteArray(Gen1Layout.HEAL_MACHINE_BYTES):
+		return _error("The heal machine sheet is not the monitor and its ball.")
+	for row: int in Gen1Layout.HEAL_MACHINE_OAM.size():
+		var entry: int = at + bytes + row * Gen1Layout.HEAL_MACHINE_OAM_SIZE
+		var pinned: Array = Gen1Layout.HEAL_MACHINE_OAM[row]
+		## The attribute byte carries a Game Boy Color palette on Yellow and not
+		## on Red or Blue, so only the flip is compared.
+		var flipped: bool = (rom.u8(entry + 3) & Gen1Layout.HEAL_MACHINE_OAM_XFLIP) != 0
+		if [rom.u8(entry), rom.u8(entry + 1), rom.u8(entry + 2), flipped] != pinned:
+			return _error("Heal machine OAM row %d is not %s." % [row, pinned])
+	var pixels: PackedByteArray = PokeTiles.decode_2bpp_strip(
+		rom.slice(at, bytes), 0, Gen1Layout.HEAL_MACHINE_TILES
+	)
+	if pixels.size() != Gen1Layout.HEAL_MACHINE_TILES * PokeTiles.TILE_PIXELS:
+		return _error("The heal machine graphics did not decode.")
+	return {"ok": true, "effects": [{
+		"name": "heal_machine",
+		"tiles": Gen1Layout.HEAL_MACHINE_TILES,
+		"vtile": Gen1Layout.HEAL_MACHINE_VTILE,
+		"bytes": Array(pixels),
+	}]}
 
 
 static func _error(message: String) -> Dictionary:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 108
+const FORMAT_VERSION: int = 109
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -371,6 +371,65 @@ func render_gen1_vending(state: Dictionary) -> Image:
 	return image
 
 
+## `CeladonPrizeMenu`'s box: `TextBoxBorder hlcoord 0, 2` at eight by sixteen,
+## with `PrintPrizePrice`'s COIN panel where the shop puts its money. A cost is
+## `PrintBCDNumber`'s two bytes with leading zeroes, so always four digits.
+const GEN1_PRIZE_AT: Vector2i = Vector2i(0, 2)
+const GEN1_PRIZE_SIZE: Vector2i = Vector2i(18, 10)
+const GEN1_PRIZE_NAME_AT: Vector2i = Vector2i(2, 4)
+const GEN1_PRIZE_COST_AT: Vector2i = Vector2i(13, 5)
+const GEN1_PRIZE_CURSOR_COLUMN: int = 1
+const GEN1_PRIZE_DIGITS: int = 4
+const GEN1_COIN_LABEL: String = "COIN"
+const GEN1_COIN_LABEL_AT: Vector2i = Vector2i(12, 0)
+const GEN1_COIN_AT: Vector2i = Vector2i(13, 1)
+const GEN1_NO_THANKS: String = "NO THANKS"
+
+
+func render_gen1_prizes(state: Dictionary) -> Image:
+	if font == null:
+		return null
+	var image := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	_blit_gen1_coins(image, int(state.get("coins", 0)))
+	var indices: PackedByteArray = _panel(GEN1_PRIZE_SIZE)
+	var width: int = GEN1_PRIZE_SIZE.x * TILE
+	font.draw_box(frame_style, indices, width, 0, 0, GEN1_PRIZE_SIZE.x, GEN1_PRIZE_SIZE.y)
+	var rows: Array = state.get("rows", [])
+	var name_at: Vector2i = GEN1_PRIZE_NAME_AT - GEN1_PRIZE_AT
+	var cost_at: Vector2i = GEN1_PRIZE_COST_AT - GEN1_PRIZE_AT
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		var step := Vector2i(0, index * ROW_STEP)
+		_text(indices, width, String(row.get("name", "")), name_at + step)
+		_text(indices, width, String.num_int64(
+			maxi(int(row.get("cost", 0)), 0)
+		).lpad(GEN1_PRIZE_DIGITS, "0"), cost_at + step)
+	_text(indices, width, GEN1_NO_THANKS, name_at + Vector2i(0, rows.size() * ROW_STEP))
+	var cursor: int = int(state.get("cursor", -1))
+	if cursor >= 0 and cursor <= rows.size():
+		_code(indices, width, CURSOR_CODE, Vector2i(
+			GEN1_PRIZE_CURSOR_COLUMN - GEN1_PRIZE_AT.x, name_at.y + cursor * ROW_STEP
+		))
+	_blit_panel(image, indices, GEN1_PRIZE_SIZE, GEN1_PRIZE_AT)
+	return image
+
+
+## `PrintPrizePrice`: the money box's corners with COIN on the border row.
+func _blit_gen1_coins(image: Image, coins: int) -> void:
+	var indices: PackedByteArray = _panel(MONEY_SIZE)
+	var width: int = MONEY_SIZE.x * TILE
+	font.draw_box(frame_style, indices, width, 0, 0, MONEY_SIZE.x, MONEY_SIZE.y)
+	_text(indices, width, GEN1_COIN_LABEL, GEN1_COIN_LABEL_AT - MONEY_AT)
+	_text(
+		indices, width,
+		String.num_int64(maxi(coins, 0)).lpad(GEN1_PRIZE_DIGITS, "0"),
+		GEN1_COIN_AT - MONEY_AT
+	)
+	_blit_panel(image, indices, MONEY_SIZE, MONEY_AT)
+
+
 static func _panel(size: Vector2i) -> PackedByteArray:
 	var out := PackedByteArray()
 	out.resize(size.x * TILE * size.y * TILE)

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -329,6 +329,48 @@ func _blit_gen1_list(image: Image, state: Dictionary) -> void:
 	_blit_panel(image, indices, GEN1_LIST_SIZE, GEN1_LIST_AT)
 
 
+## `VendingMachineMenu`'s box: `TextBoxBorder hlcoord 0, 3` at eight by twelve,
+## `DrinkText` on the menu's rows and `DrinkPriceText` on the rows between them,
+## placed rather than right aligned, which is what fits a price in a box six
+## columns narrower than the shop's. Beside it is `BuyMenu`'s own `MONEY_BOX`.
+const GEN1_VENDING_AT: Vector2i = Vector2i(0, 3)
+const GEN1_VENDING_SIZE: Vector2i = Vector2i(14, 10)
+const GEN1_VENDING_NAME_AT: Vector2i = Vector2i(2, 5)
+const GEN1_VENDING_PRICE_AT: Vector2i = Vector2i(9, 6)
+const GEN1_VENDING_CURSOR_COLUMN: int = 1
+
+
+func render_gen1_vending(state: Dictionary) -> Image:
+	if font == null:
+		return null
+	var image := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	_blit_gen1_money(image, int(state.get("money", 0)))
+	var indices: PackedByteArray = _panel(GEN1_VENDING_SIZE)
+	var width: int = GEN1_VENDING_SIZE.x * TILE
+	font.draw_box(
+		frame_style, indices, width, 0, 0, GEN1_VENDING_SIZE.x, GEN1_VENDING_SIZE.y
+	)
+	var rows: Array = state.get("rows", [])
+	var name_at: Vector2i = GEN1_VENDING_NAME_AT - GEN1_VENDING_AT
+	var price_at: Vector2i = GEN1_VENDING_PRICE_AT - GEN1_VENDING_AT
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		var step := Vector2i(0, index * ROW_STEP)
+		_text(indices, width, String(row.get("name", "")), name_at + step)
+		_text(indices, width, "¥%d" % int(row.get("price", 0)), price_at + step)
+	_text(indices, width, CANCEL, name_at + Vector2i(0, rows.size() * ROW_STEP))
+	var cursor: int = int(state.get("cursor", -1))
+	if cursor >= 0 and cursor <= rows.size():
+		_code(indices, width, CURSOR_CODE, Vector2i(
+			GEN1_VENDING_CURSOR_COLUMN - GEN1_VENDING_AT.x,
+			name_at.y + cursor * ROW_STEP
+		))
+	_blit_panel(image, indices, GEN1_VENDING_SIZE, GEN1_VENDING_AT)
+	return image
+
+
 static func _panel(size: Vector2i) -> PackedByteArray:
 	var out := PackedByteArray()
 	out.resize(size.x * TILE * size.y * TILE)

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3653,6 +3653,7 @@ var _gen1_last_map: int = -1
 ## The [method GameData.special_text] run `DisplayPokemonCenterDialogue_`'s own
 ## boxes are imported under.
 const GEN1_POKECENTER_RUN: String = "pokecenter"
+const GEN1_CABLE_CLUB_RUN: String = "cable_club"
 
 ## `wRivalName`, which no Generation 1 save model holds yet.
 var gen1_rival_name: String = Gen2WorldScriptRunner.UNNAMED
@@ -3728,7 +3729,27 @@ func _gen1_facility_steps(row: Dictionary) -> Array:
 			return _gen1_mart_steps(row)
 		Gen1Layout.TEXT_SCRIPT_POKECENTER_NURSE:
 			return _gen1_nurse_steps()
+		Gen1Layout.TEXT_SCRIPT_CABLE_CLUB:
+			return _gen1_cable_club_steps()
 	return []
+
+
+## `CableClubNPC`. Without the Pokedex it is the welcome, sixty frames and
+## `CableClubNPCMakingPreparationsText`; with it, `.establishConnectionLoop`
+## spends `wLinkTimeoutCounter` on a partner that is not there and lands on
+## `.failedToEstablishConnection`. Nothing past that has a caller.
+func _gen1_cable_club_steps() -> Array:
+	var linked: bool = state != null \
+		and state.is_engine_flag_active(Gen2WorldState.ENGINE_POKEDEX)
+	return [
+		_gen1_facility_box(GEN1_CABLE_CLUB_RUN, "welcome"),
+		_gen1_wait_step(&"cable_club_wait", Gen1Layout.CABLE_CLUB_TIMEOUT_FRAMES \
+			if linked else Gen1Layout.CABLE_CLUB_PREPARING_FRAMES),
+		_gen1_facility_box(
+			GEN1_CABLE_CLUB_RUN,
+			"area_reserved" if linked else "making_preparations"
+		),
+	]
 
 
 ## `MartDialog`'s counter is the whole of a Generation 1 shop, so the request
@@ -3776,24 +3797,46 @@ func _gen1_nurse_steps() -> Array:
 ## the sound each ball is placed with plays nothing.
 func _gen1_heal_machine_step() -> Dictionary:
 	var balls: int = int(_party_summary.get("count", 0))
-	return {"type": &"wait", "values": {
+	var frames: int = balls * Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES \
+		+ Gen2WorldEffects.HEAL_MACHINE_FLASHES \
+		* Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL
+	return _gen1_wait_step(&"heal_machine_anim", frames, {
+		"machine_type": 0, "balls": balls, "sounds": [],
+	})
+
+
+## A counted wait, with the `presentation_special_applied` event a screen would
+## start it from when [param presentation] names one.
+func _gen1_wait_step(
+	kind: StringName, frames: int, presentation: Dictionary = {}
+) -> Dictionary:
+	var step: Dictionary = {"type": &"wait", "values": {
 		"type": &"wait",
 		"wait": Gen2WorldScriptRunner.WAIT_FRAMES,
-		"kind": &"heal_machine_anim",
-		"machine_type": 0,
-		"balls": balls,
-		"frames": balls * Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES
-			+ Gen2WorldEffects.HEAL_MACHINE_FLASHES
-			* Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL,
+		"kind": kind,
+		"frames": frames,
 	}}
+	if not presentation.is_empty():
+		var event: Dictionary = presentation.duplicate(true)
+		event["type"] = &"presentation_special_applied"
+		event["kind"] = kind
+		step["events"] = [event]
+	return step
 
 
 func _gen1_pokecenter_box(name: String) -> Dictionary:
-	return {"type": &"text", "text": _gen1_pokecenter_text(name)}
+	return _gen1_facility_box(GEN1_POKECENTER_RUN, name)
 
 
 func _gen1_pokecenter_text(name: String) -> String:
 	return data.special_text(GEN1_POKECENTER_RUN, name) if data != null else ""
+
+
+func _gen1_facility_box(run: String, name: String) -> Dictionary:
+	return {
+		"type": &"text",
+		"text": data.special_text(run, name) if data != null else "",
+	}
 
 
 func _gen1_text_id_at(cell: Vector2i, kind: StringName) -> int:
@@ -3969,17 +4012,12 @@ func _gen1_result() -> Array:
 		}]
 	if type == &"choice":
 		return [{"ok": true, "status": &"waiting", "event": {"type": &"choice"}}]
+	## A counted wait and whatever it starts on the frame it opens on.
 	if type == &"wait":
-		var values: Dictionary = step["values"]
 		return [{
-			"ok": true, "status": &"waiting", "event": values.duplicate(true),
-			"events": [{
-				"type": &"presentation_special_applied",
-				"kind": StringName(values["kind"]),
-				"machine_type": int(values["machine_type"]),
-				"balls": int(values["balls"]),
-				"sounds": [],
-			}],
+			"ok": true, "status": &"waiting",
+			"event": (step["values"] as Dictionary).duplicate(true),
+			"events": (step.get("events", []) as Array).duplicate(true),
 		}]
 	## `AfterDisplayingTextID` ends every box on `WaitForTextScrollButtonPress`,
 	## whatever the string's last byte said.

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3731,7 +3731,20 @@ func _gen1_facility_steps(row: Dictionary) -> Array:
 			return _gen1_nurse_steps()
 		Gen1Layout.TEXT_SCRIPT_CABLE_CLUB:
 			return _gen1_cable_club_steps()
+		Gen1Layout.TEXT_SCRIPT_VENDING_MACHINE:
+			return _gen1_vending_steps()
 	return []
+
+
+## `VendingMachineMenu`, whose list is `VendingPrices` rather than a shelf and
+## whose greeting is the box the menu stands over.
+func _gen1_vending_steps() -> Array:
+	var rows: Array = data.vending_rows() if data != null else []
+	if rows.is_empty():
+		return []
+	return [{"type": &"request", "values": {
+		"kind": &"vending_requested", "values": {"rows": rows},
+	}}]
 
 
 ## `CableClubNPC`. Without the Pokedex it is the welcome, sixty frames and

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3708,7 +3708,7 @@ func _gen1_interact() -> Array:
 	if text_id <= 0:
 		text_id = _gen1_text_id_at(object_facing_cell(), &"objects")
 	var row: Dictionary = current_map.text_at(text_id)
-	_gen1_steps = _gen1_facility_steps(row)
+	_gen1_steps = _gen1_facility_steps(row, text_id)
 	if _gen1_steps.is_empty():
 		var text: String = Gen2TextStream.fill_names(String(row.get("text", "")), {
 			"player": _player_name if not _player_name.is_empty() \
@@ -3723,7 +3723,7 @@ func _gen1_interact() -> Array:
 
 ## `DisplayTextID`'s own dispatch, which reads the first byte of the text a
 ## pointer stands at: a `TX_SCRIPT_*` id runs a routine and prints nothing.
-func _gen1_facility_steps(row: Dictionary) -> Array:
+func _gen1_facility_steps(row: Dictionary, text_id: int = 0) -> Array:
 	match int(row.get("command", 0)):
 		Gen1Layout.TEXT_SCRIPT_MART:
 			return _gen1_mart_steps(row)
@@ -3733,7 +3733,39 @@ func _gen1_facility_steps(row: Dictionary) -> Array:
 			return _gen1_cable_club_steps()
 		Gen1Layout.TEXT_SCRIPT_VENDING_MACHINE:
 			return _gen1_vending_steps()
+		Gen1Layout.TEXT_SCRIPT_PRIZE_VENDOR:
+			return _gen1_prize_steps(text_id)
 	return []
+
+
+## `GetPrizeMenuId` subtracts `TEXT_GAMECORNERPRIZEROOM_PRIZE_VENDOR_1` from the
+## id that opened it, so a vendor's list is their place among the map's own
+## prize rows.
+func _gen1_prize_steps(text_id: int) -> Array:
+	var menus: Array = data.prize_menus() if data != null else []
+	var first: int = _gen1_first_prize_text()
+	var menu: int = text_id - first
+	if first <= 0 or menu < 0 or menu >= menus.size():
+		return []
+	var chosen: Dictionary = menus[menu]
+	return [{"type": &"request", "values": {
+		"kind": &"prize_requested",
+		"values": {
+			"menu": menu,
+			"tms": bool(chosen.get("tms", false)),
+			"rows": (chosen.get("rows", []) as Array).duplicate(true),
+		},
+	}}]
+
+
+func _gen1_first_prize_text() -> int:
+	if current_map == null:
+		return 0
+	for index: int in current_map.texts.size():
+		if int((current_map.texts[index] as Dictionary).get("command", 0)) \
+			== Gen1Layout.TEXT_SCRIPT_PRIZE_VENDOR:
+			return index + 1
+	return 0
 
 
 ## `VendingMachineMenu`, whose list is `VendingPrices` rather than a shelf and

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3763,11 +3763,29 @@ func _gen1_nurse_steps() -> Array:
 				{"type": &"request", "values": {
 					"kind": &"party_heal_requested", "values": {},
 				}},
+				_gen1_heal_machine_step(),
 				_gen1_pokecenter_box("fighting_fit"),
 			] + farewell,
 			"no": farewell,
 		},
 	]
+
+
+## `farcall AnimateHealingMachine`, the step behind `predef HealParty`, which the
+## dialogue waits out before its last two lines. No Generation 1 audio driver, so
+## the sound each ball is placed with plays nothing.
+func _gen1_heal_machine_step() -> Dictionary:
+	var balls: int = int(_party_summary.get("count", 0))
+	return {"type": &"wait", "values": {
+		"type": &"wait",
+		"wait": Gen2WorldScriptRunner.WAIT_FRAMES,
+		"kind": &"heal_machine_anim",
+		"machine_type": 0,
+		"balls": balls,
+		"frames": balls * Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES
+			+ Gen2WorldEffects.HEAL_MACHINE_FLASHES
+			* Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL,
+	}}
 
 
 func _gen1_pokecenter_box(name: String) -> Dictionary:
@@ -3951,6 +3969,18 @@ func _gen1_result() -> Array:
 		}]
 	if type == &"choice":
 		return [{"ok": true, "status": &"waiting", "event": {"type": &"choice"}}]
+	if type == &"wait":
+		var values: Dictionary = step["values"]
+		return [{
+			"ok": true, "status": &"waiting", "event": values.duplicate(true),
+			"events": [{
+				"type": &"presentation_special_applied",
+				"kind": StringName(values["kind"]),
+				"machine_type": int(values["machine_type"]),
+				"balls": int(values["balls"]),
+				"sounds": [],
+			}],
+		}]
 	## `AfterDisplayingTextID` ends every box on `WaitForTextScrollButtonPress`,
 	## whatever the string's last byte said.
 	return [{
@@ -4040,6 +4070,9 @@ func pending_script_input() -> Dictionary:
 ## [method pending_runtime_request] because no host answers it: only frames do,
 ## through [method advance_script_wait].
 func pending_script_wait() -> Dictionary:
+	var step: Dictionary = _gen1_step(&"wait")
+	if not step.is_empty():
+		return (step["values"] as Dictionary).duplicate(true)
 	return _active_script.pending_wait() if _active_script != null else {}
 
 
@@ -6122,6 +6155,8 @@ func _complete_script_wait() -> Array:
 	## `WaitScript` and `WaitScriptMovement` both run `UnfreezeAllObjects` the
 	## frame their wait ends, before they hand the script back to `SCRIPT_READ`.
 	unfreeze_all_objects()
+	if not _gen1_step(&"wait").is_empty():
+		return _gen1_advance(-1)
 	if _active_script == null:
 		return []
 	var advanced: Dictionary = _active_script.complete_wait()

--- a/game/world/world_effects.gd
+++ b/game/world/world_effects.gd
@@ -53,6 +53,24 @@ const HEAL_MACHINE_HOF_BALLS: Array = [
 	[Vector2i(65, 41), 1, false],
 	[Vector2i(85, 41), 1, false],
 ]
+## `PokeCenterOAMData` in the same shape. `AnimateHealingMachine` places the
+## monitor before its party loop, so the first row is the machine itself, and
+## its counts are Crystal's to the frame.
+static func gen1_heal_machine_oam() -> Array:
+	var out: Array = []
+	for row: Array in Gen1Layout.HEAL_MACHINE_OAM:
+		out.append([
+			Vector2i(int(row[1]) - OAM_X_ORIGIN, int(row[0]) - OAM_Y_ORIGIN),
+			int(row[2]) - Gen1Layout.HEAL_MACHINE_VTILE,
+			bool(row[3]),
+		])
+	return out
+
+
+## Where a hardware object counts from.
+const OAM_X_ORIGIN: int = 8
+const OAM_Y_ORIGIN: int = 16
+
 ## `.PlaceHealingMachineTile`'s `bcpixel 2, 4`, added to every entry of the table
 ## on Elm's Lab alone; the other two machine types add nothing.
 const HEAL_MACHINE_ELMS_LAB_OFFSET := Vector2i(16, 32)
@@ -63,6 +81,9 @@ const HEAL_MACHINE_HALL_OF_FAME: int = 2
 const HEAL_MACHINE_BALL_FRAMES: int = 30
 const HEAL_MACHINE_FLASH_INTERVAL: int = 10
 const HEAL_MACHINE_FLASHES: int = 8
+## A palette of the sprite's own rather than one of the map's: `.LoadPalettes`
+## in Crystal and `rOBP1` in Generation 1.
+const HEAL_MACHINE_PALETTE: int = -1
 
 const FLY_FROM_FRAMES: int = 128
 const FLY_TO_FRAMES: int = 64
@@ -275,7 +296,9 @@ func start_boulder_dust(object_index: int, cell: Vector2i, direction: Vector2i, 
 ##
 ## [param balls] is `wPartyCount`; the source returns before writing anything
 ## when it is zero.
-func start_heal_machine(machine_type: int, balls: int) -> void:
+func start_heal_machine(
+	machine_type: int, balls: int, generation: int = RomRegistry.GEN2
+) -> void:
 	if balls <= 0:
 		return
 	_sprites.append({
@@ -283,12 +306,13 @@ func start_heal_machine(machine_type: int, balls: int) -> void:
 		"cell": Vector2i.ZERO,
 		"object_index": -1,
 		"screen": true,
-		"palette": -1,
+		"palette": HEAL_MACHINE_PALETTE,
 		"frame": 0,
 		"duration": balls * HEAL_MACHINE_BALL_FRAMES
 			+ HEAL_MACHINE_FLASHES * HEAL_MACHINE_FLASH_INTERVAL,
 		"machine_type": clampi(machine_type, 0, HEAL_MACHINE_HALL_OF_FAME),
 		"balls": mini(balls, HEAL_MACHINE_BALLS.size()),
+		"generation": generation,
 	})
 
 
@@ -514,32 +538,7 @@ func _tiles_for(sprite: Dictionary) -> Array:
 				{"offset": at + Vector2i(8, 0), "tile": 0, "flip_x": true},
 			]
 		SPRITE_HEAL_MACHINE:
-			## One ball a party member, thirty frames apart, and the machine's
-			## own two tiles under them for every type but the Hall of Fame.
-			## Nothing is taken away again: the flashes run over the finished
-			## picture.
-			var machine_type: int = int(sprite["machine_type"])
-			var shown: int = clampi(
-				int(float(frame) / float(HEAL_MACHINE_BALL_FRAMES)) + 1,
-				0, int(sprite["balls"])
-			)
-			var entries: Array = []
-			if machine_type != HEAL_MACHINE_HALL_OF_FAME:
-				entries.append_array(HEAL_MACHINE_BAR)
-				entries.append_array(HEAL_MACHINE_BALLS.slice(0, shown))
-			else:
-				entries.append_array(HEAL_MACHINE_HOF_BALLS.slice(0, shown))
-			var shift := Vector2i.ZERO
-			if machine_type == HEAL_MACHINE_ELMS_LAB:
-				shift = HEAL_MACHINE_ELMS_LAB_OFFSET
-			var machine: Array = []
-			for entry: Array in entries:
-				machine.append({
-					"offset": (entry[0] as Vector2i) + shift,
-					"tile": int(entry[1]),
-					"flip_x": bool(entry[2]),
-				})
-			return machine
+			return _heal_machine_tiles(sprite, frame)
 		SPRITE_BOULDER_DUST:
 			## `SetFacingBoulderDust` swaps FACING_BOULDER_DUST_1 and _2 on bit 1
 			## of the step frame, and each draws its one tile four times in a
@@ -637,6 +636,38 @@ func _fly_leaf_tile(spawned: int, age: int) -> Dictionary:
 		"tile": 0,
 		"flip_x": false,
 	}
+
+
+## One ball a party member, thirty frames apart, over the machine's own tiles.
+## Nothing is taken away again: the flashes run over the finished picture.
+## Generation 1 has one machine and one table, so no machine type reaches it and
+## none of them may move it.
+func _heal_machine_tiles(sprite: Dictionary, frame: int) -> Array:
+	var machine_type: int = int(sprite["machine_type"])
+	var gen1: bool = int(sprite.get("generation", RomRegistry.GEN2)) == RomRegistry.GEN1
+	var shown: int = clampi(
+		int(float(frame) / float(HEAL_MACHINE_BALL_FRAMES)) + 1, 0, int(sprite["balls"])
+	)
+	var entries: Array = []
+	if gen1:
+		var oam: Array = gen1_heal_machine_oam()
+		entries.append(oam[0])
+		entries.append_array(oam.slice(1, shown + 1))
+	elif machine_type != HEAL_MACHINE_HALL_OF_FAME:
+		entries.append_array(HEAL_MACHINE_BAR)
+		entries.append_array(HEAL_MACHINE_BALLS.slice(0, shown))
+	else:
+		entries.append_array(HEAL_MACHINE_HOF_BALLS.slice(0, shown))
+	var shift: Vector2i = HEAL_MACHINE_ELMS_LAB_OFFSET \
+		if machine_type == HEAL_MACHINE_ELMS_LAB and not gen1 else Vector2i.ZERO
+	var machine: Array = []
+	for entry: Array in entries:
+		machine.append({
+			"offset": (entry[0] as Vector2i) + shift,
+			"tile": int(entry[1]),
+			"flip_x": bool(entry[2]),
+		})
+	return machine
 
 
 ## `.FlashPalettes` rotates the four colours of the palette left by one and

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -72,8 +72,10 @@ static func complete_runtime_request(
 		return {"ok": true, "handled": true, "results": world.complete_runtime_request(result)}
 	## None of the three reads cartridge data: the landmark, the dial's amount and
 	## whether `TryQuickSave` wrote are the whole answer.
+	## The vending machine joins them: the request carries `VendingPrices` itself.
 	if kind in [
 		&"town_map_requested", &"mom_bank_dial_requested", &"quick_save_requested",
+		&"vending_requested",
 	]:
 		return {
 			"ok": true,

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -72,10 +72,10 @@ static func complete_runtime_request(
 		return {"ok": true, "handled": true, "results": world.complete_runtime_request(result)}
 	## None of the three reads cartridge data: the landmark, the dial's amount and
 	## whether `TryQuickSave` wrote are the whole answer.
-	## The vending machine joins them: the request carries `VendingPrices` itself.
+	## The two Generation 1 counters join them: each request carries its own list.
 	if kind in [
 		&"town_map_requested", &"mom_bank_dial_requested", &"quick_save_requested",
-		&"vending_requested",
+		&"vending_requested", &"prize_requested",
 	]:
 		return {
 			"ok": true,

--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -156,6 +156,38 @@ static func purchase(
 	}
 
 
+## `VendingMachineMenu`'s purchase: `HasEnoughMoney` refuses first, then
+## `GiveItem`, at the machine's price rather than `ItemPrices`'. The refusal
+## reasons are the shop's, so a caller can pick its box off them.
+static func vend(
+	world: Gen2WorldAPI, save: Gen2SaveData, row: Dictionary, persist: bool = true
+) -> Dictionary:
+	if world == null or world.data == null or world.state == null:
+		return _failure(&"missing_world", {})
+	var item: int = int(row.get("item", 0))
+	var price: int = int(row.get("price", 0))
+	var balance: int = world.state.money(MONEY_ACCOUNT)
+	if price > balance:
+		return _failure(&"insufficient_money", {"item": item, "price": price})
+	var owned: int = world.state.item_quantity(item)
+	if owned + 1 > MAX_ITEM_STACK:
+		return _failure(&"item_stack_full", {"item": item, "owned": owned})
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var applied: Dictionary = world.state.apply_changes({}, {}, {
+		"items": {item: owned + 1},
+		"money": {MONEY_ACCOUNT: balance - price},
+	})
+	if not bool(applied.get("ok", false)):
+		return _failure(&"purchase_state_failed", applied)
+	var committed: Dictionary = Gen2WorldTransaction.run(world, save, before, persist)
+	if not bool(committed.get("ok", false)):
+		return committed
+	return {
+		"ok": true, "item": item, "price": price, "balance": balance - price,
+		"name": world.data.item_name(item),
+	}
+
+
 static func _purchase_refusal(
 	world: Gen2WorldAPI, mart: Dictionary, item: int, quantity: int
 ) -> Dictionary:

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1525,6 +1525,43 @@ static func _apply_party_request(
 	return {"ok": false, "reason": &"unsupported_party_request"}
 
 
+## `GivePokemon`, which the prize counter reaches with `GetPrizeMonLevel`'s
+## level: everything `givepoke` does with no script behind it. Neither the party
+## nor the box having room writes nothing, which is what `.giveMon`'s `ret nc`
+## leaves the coins on.
+static func give_pokemon(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	species: int,
+	level: int,
+	persist: bool = true,
+	random: RandomNumberGenerator = null
+) -> Dictionary:
+	if world == null or save == null or world.data == null:
+		return _failure(&"missing_world", {})
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	var candidate: Gen2SaveData = opened["candidate"]
+	var generator: RandomNumberGenerator = random if random != null else RandomNumberGenerator.new()
+	if random == null:
+		generator.randomize()
+	var applied: Dictionary = _apply_pokemon_request(world, candidate, {
+		"kind": &"pokemon_requested",
+		"values": {"pokemon": species, "level": level},
+	}, {}, generator)
+	if not bool(applied.get("ok", false)) or not bool(applied.get("accepted", true)):
+		return _failure(StringName(applied.get("reason", &"storage_full")), applied)
+	var before: Gen2WorldSnapshot = world.snapshot()
+	_register_caught(world, int(applied.get("register_caught", 0)))
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	return {"ok": true, "species": species, "level": level}
+
+
 ## `Script_givepoke` and `Script_giveegg`.
 static func _apply_pokemon_request(
 	world: Gen2WorldAPI,

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -189,6 +189,15 @@ const CAPTURE_BALLS: Array[int] = [
 	ITEM_FRIEND_BALL, ITEM_MOON_BALL, ITEM_LOVE_BALL,
 ]
 
+## `ItemUsePtrTable`'s own rows, whose numbering is not Crystal's: POKE_BALL is
+## 4 there and 5 here, and SAFARI_BALL is reachable where Crystal's number for it
+## collides with MOON_STONE.
+const GEN1_CAPTURE_BALLS: Array[int] = [
+	Gen1Layout.ITEM_POKE_BALL, Gen1Layout.ITEM_GREAT_BALL,
+	Gen1Layout.ITEM_ULTRA_BALL, Gen1Layout.ITEM_MASTER_BALL,
+	Gen1Layout.ITEM_SAFARI_BALL,
+]
+
 ## `HeavyBallMultiplier.WeightsTable`: the high byte of the converted weight the
 ## row applies below, and what it adds to the catch rate there. The `.lightmon`
 ## branch in front of it takes 20 off below `HIGH(1024)`.
@@ -229,8 +238,9 @@ const WOBBLE_PROBABILITIES: Array = [
 
 ## Returns the ball items whose capture effects are implemented by this host.
 ## The order follows the ordinary ball pocket order used by the source menu.
-static func capture_ball_items() -> Array[int]:
-	return CAPTURE_BALLS.duplicate()
+static func capture_ball_items(generation: int = RomRegistry.GEN2) -> Array[int]:
+	return GEN1_CAPTURE_BALLS.duplicate() if generation == RomRegistry.GEN1 \
+		else CAPTURE_BALLS.duplicate()
 
 
 ## Returns owned supported balls without making the battle scene aware of world
@@ -239,10 +249,14 @@ static func owned_capture_balls(world: Gen2WorldAPI) -> Array[int]:
 	var out: Array[int] = []
 	if world == null or world.state == null:
 		return out
-	for ball: int in CAPTURE_BALLS:
+	for ball: int in capture_ball_items(_generation(world.data)):
 		if world.state.item_quantity(ball) > 0:
 			out.append(ball)
 	return out
+
+
+static func _generation(data: GameData) -> int:
+	return data.generation if data != null else RomRegistry.GEN2
 
 
 static func complete_runtime_request(
@@ -968,7 +982,15 @@ static func caught_nickname_question(species_name: String) -> String:
 ## `_AskGiveNicknameText`, which is `PokeBallEffect`'s own question and not
 ## `GiveANickname_YesNo`'s: a caught Pokemon is asked about by name alone, where
 ## a received one is [method caught_nickname_question]'s longer line.
-static func capture_nickname_question(species_name: String) -> String:
+## `_DoYouWantToNicknameText` is Generation 1's, asked by `AskName` from inside
+## `AddPartyMon` and so never asked of a catch that goes to the box.
+static func capture_nickname_question(
+	species_name: String, generation: int = RomRegistry.GEN2
+) -> String:
+	if generation == RomRegistry.GEN1:
+		return "Do you want to\ngive a nickname%sto %s?" % [
+			Gen2TextStream.SCROLL_BREAK, species_name,
+		]
 	return "Give a nickname to\n%s?" % species_name
 
 
@@ -980,7 +1002,16 @@ static func capture_nickname_question(species_name: String) -> String:
 const SENT_TO_BOX_FORMAT: String = "%s was\nsent to BILL's PC."
 
 
-static func sent_to_box_text(species_name: String) -> String:
+## `_ItemUseBallText08` for Generation 1. `EVENT_MET_BILL` picks
+## `_ItemUseBallText07` and its BILL's PC over it; no Generation 1 event model
+## holds that flag, so what is said is the routine's own clear-flag answer.
+static func sent_to_box_text(
+	species_name: String, generation: int = RomRegistry.GEN2
+) -> String:
+	if generation == RomRegistry.GEN1:
+		return "%s was\ntransferred to%ssomeone's PC!" % [
+			species_name, Gen2TextStream.SCROLL_BREAK,
+		]
 	return SENT_TO_BOX_FORMAT % species_name
 
 
@@ -1275,9 +1306,13 @@ static func _capture_refusal(
 	var definition: Dictionary = world.data.item(ball)
 	if definition.is_empty():
 		return _failure(&"unknown_ball", {"ball": ball})
-	if int(definition.get("pocket", 0)) != Gen2Layout.ITEM_POCKET_BALL:
+	var generation: int = _generation(world.data)
+	## Generation 1 has one bag rather than four pockets, so the ball list below
+	## is the whole test there: `ItemUsePtrTable` is what says an item is a ball.
+	if generation != RomRegistry.GEN1 \
+		and int(definition.get("pocket", 0)) != Gen2Layout.ITEM_POCKET_BALL:
 		return _failure(&"item_is_not_a_ball", {"ball": ball})
-	if ball not in CAPTURE_BALLS:
+	if ball not in capture_ball_items(generation):
 		return _failure(&"unsupported_ball_effect", {"ball": ball})
 	if world.state == null or world.state.item_quantity(ball) <= 0:
 		return _failure(&"insufficient_ball_quantity", {"ball": ball})
@@ -2204,6 +2239,8 @@ static func _capture_outcome(
 ) -> Dictionary:
 	if ball == ITEM_MASTER_BALL or battle_type == Gen2Battle.BATTLETYPE_TUTORIAL:
 		return {"caught": true, "catch_rate": 255, "wobbles": 3}
+	if _generation(data) == RomRegistry.GEN1:
+		return _gen1_capture_outcome(data, wild, ball, random)
 	var max_hp: int = maxi(wild.max_hp(), 1)
 	var final_rate: int = final_catch_rate(data, ball, {
 		"base_rate": clampi(int(data.species(wild.species).get("catch_rate", 0)), 1, 255),
@@ -2226,12 +2263,103 @@ static func _capture_outcome(
 	}
 
 
+## `ItemUseBall`, which settles no catch rate at all. `.setAnimData`'s $10, the
+## ball that cannot be thrown at a ghost, has no caller: nothing puts a Pokemon
+## Tower ghost on the screen. The Safari Zone's branch spends `wNumSafariBalls`
+## rather than the bag and changes nothing else.
+static func _gen1_capture_outcome(
+	data: GameData, wild: Gen2BattleMon, ball: int, random: RandomNumberGenerator
+) -> Dictionary:
+	var max_hp: int = maxi(wild.max_hp(), 1)
+	return gen1_ball_outcome(ball, {
+		"catch_rate": int(data.species(wild.species).get("catch_rate", 0)),
+		"max_hp": max_hp,
+		"current_hp": clampi(wild.hp, 0, max_hp),
+		"status": wild.status,
+	}, Callable(random, "randi_range").bind(0, 0xFF))
+
+
+## Everything `ItemUseBall` decides, split out from the throw the way [method
+## final_catch_rate] is: [param rolls] is `call Random` and [param case] the WRAM
+## bytes, so the oracle's `battle/gen1_catch.py` can put the same row to a dump.
+static func gen1_ball_outcome(
+	ball: int, case: Dictionary, rolls: Callable
+) -> Dictionary:
+	var row: Array = Gen1Layout.BALL_ROLL.get(ball, Gen1Layout.BALL_ROLL_OTHER)
+	var catch_rate: int = int(case["catch_rate"])
+	var status: int = int(case.get("status", Gen2Status.NONE))
+	var roll: int = _gen1_first_roll(int(row[0]), rolls)
+	var penalty: int = _gen1_status_term(status, Gen1Layout.BALL_STATUS_SUBTRACT)
+	if roll < penalty:
+		return {"caught": true, "catch_rate": catch_rate, "wobbles": 3}
+	roll -= penalty
+	var health: int = _gen1_health_term(
+		int(case["max_hp"]), int(case["current_hp"]), int(row[1])
+	)
+	var capped: int = mini(health, 0xFF)
+	## Rand2 is rolled only where the cartridge rolls it: a rate under Rand1 and
+	## a W over 255 each answer in front of it.
+	if catch_rate >= roll and (health > 0xFF or int(rolls.call()) <= capped):
+		return {"caught": true, "catch_rate": catch_rate, "wobbles": 3}
+	return {
+		"caught": false,
+		"catch_rate": catch_rate,
+		"wobbles": _gen1_shakes(status, catch_rate, capped, int(row[2])),
+	}
+
+
+## `.loop`: Rand1 is rerolled until it is at or under the ball's ceiling, which
+## is the whole of what makes a Great Ball better than a Poke Ball here.
+static func _gen1_first_roll(ceiling: int, rolls: Callable) -> int:
+	var roll: int = int(rolls.call())
+	while roll > ceiling:
+		roll = int(rolls.call())
+	return roll
+
+
+## `.checkForAilments` and `.addAilmentValue` read the byte the same way:
+## [param terms] is [any status, frozen or asleep].
+static func _gen1_status_term(status: int, terms: Array[int]) -> int:
+	if status == Gen2Status.NONE:
+		return 0
+	return terms[1] if Gen2Status.has(status, Gen2Status.FREEZE) \
+		or Gen2Status.is_asleep(status) else terms[0]
+
+
+## W, floored twice and uncapped: `.skip3` clamps only the byte the shakes read.
+static func _gen1_health_term(max_hp: int, current_hp: int, factor: int) -> int:
+	var quarter: int = maxi(current_hp >> 2, 1)
+	@warning_ignore("integer_division")
+	var scaled: int = maxi(max_hp, 1) * 0xFF / factor
+	@warning_ignore("integer_division")
+	var out: int = scaled / quarter
+	return out
+
+
+## `.failedToCapture`: Y off the ball's second factor, Z out of X and Y, then the
+## ladder. A Y above 255 cannot happen, the largest being `255 * 100 / 150`.
+static func _gen1_shakes(status: int, catch_rate: int, x: int, factor: int) -> int:
+	@warning_ignore("integer_division")
+	var y: int = catch_rate * 100 / factor
+	if y > 0xFF:
+		return 3
+	@warning_ignore("integer_division")
+	var scaled: int = x * y / 0xFF
+	var z: int = scaled + _gen1_status_term(status, Gen1Layout.BALL_STATUS_ADD)
+	var shakes: int = 0
+	for threshold: int in Gen1Layout.BALL_SHAKE_THRESHOLDS:
+		if z < threshold:
+			return shakes
+		shakes += 1
+	return shakes
+
+
 ## `wFinalCatchRate`: everything `PokeBallEffect` settles between `ld a,
 ## [wEnemyMonCatchRate]` and the `call Random` that reads the answer. Split out
-## from the throw because the cartridge can be asked the same question directly:
-## Running those instructions on a real dump
-## for a grid of cases, and [param case] is that grid's own row. The keys are
-## the bytes the routine reads, named for the WRAM labels it reads them from.
+## from the throw because the cartridge can be asked the same question directly,
+## which the oracle's `battle/catch_rate.py` does for a grid of cases; [param
+## case] is one row of that grid, keyed by the WRAM labels the routine reads its
+## bytes from.
 static func final_catch_rate(data: GameData, ball: int, case: Dictionary) -> int:
 	var catch_rate: int = _ball_multiplier(data, ball, int(case["base_rate"]), case)
 	## `.skip_or_return_from_ball_fn`'s own `cp LEVEL_BALL`: a Level Ball jumps

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -926,9 +926,13 @@ func _sprite_palette(palette: int) -> PackedColorArray:
 func _overworld_sprite_colors(palette: int) -> PackedColorArray:
 	if _world.data.generation != RomRegistry.GEN1:
 		return _world.data.overworld_sprite_palette(palette, _time_of_day)
-	return Gen2WorldPalette.gen1_object_colors(Gen2WorldPalette.gen1_map_colors(
+	return Gen2WorldPalette.gen1_object_colors(_gen1_map_colors())
+
+
+func _gen1_map_colors() -> PackedColorArray:
+	return Gen2WorldPalette.gen1_map_colors(
 		_world.data, _world.current_map, _world.gen1_last_map()
-	))
+	)
 
 
 func _actor_texture(
@@ -1359,6 +1363,14 @@ func _draw_fly_mon(sprite: Dictionary, anchor: Vector2) -> void:
 func _effect_palette(sheet: Dictionary, palette_index: int, rotation_step: int) -> PackedColorArray:
 	var own: PackedColorArray = sheet.get("colors", PackedColorArray())
 	if own.is_empty():
+		## Generation 1's machine wears `rOBP1`, which `FlashSprite8Times` xors
+		## $28 into: two shades of the map's own four trade places where
+		## Crystal's four rotate.
+		if palette_index == Gen2WorldEffects.HEAL_MACHINE_PALETTE \
+			and _world.data.generation == RomRegistry.GEN1:
+			var shades: Array[int] = []
+			shades.assign(Gen1Layout.HEAL_MACHINE_SHADES[rotation_step & 1])
+			return PokePalette.through_shades(_gen1_map_colors(), shades)
 		return _overworld_sprite_colors(palette_index)
 	var rotated := PackedColorArray()
 	for slot: int in own.size():

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3277,7 +3277,10 @@ func preview_effect_sprites(kind: StringName = &"effects") -> void:
 		## the colours can be read off.
 		if _effects != null:
 			var balls: int = Gen2WorldEffects.HEAL_MACHINE_BALLS.size()
-			_effects.start_heal_machine(Gen2WorldEffects.HEAL_MACHINE_ELMS_LAB, balls)
+			_effects.start_heal_machine(
+				Gen2WorldEffects.HEAL_MACHINE_ELMS_LAB, balls,
+				_data.generation if _data != null else RomRegistry.GEN2
+			)
 			for _frame: int in balls * Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES - 1:
 				_effects.advance_frame()
 		_script_prompt = "Debug heal machine preview"
@@ -8529,7 +8532,8 @@ func _start_heal_machine_sounds(event: Dictionary) -> void:
 	_start_sound_schedule((event.get("sounds", []) as Array).duplicate(true))
 	if _effects != null:
 		_effects.start_heal_machine(
-			int(event.get("machine_type", 0)), int(event.get("balls", 0))
+			int(event.get("machine_type", 0)), int(event.get("balls", 0)),
+			_data.generation if _data != null else RomRegistry.GEN2
 		)
 	_advance_sound_schedule()
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -7385,7 +7385,7 @@ const REQUEST_OPENERS: Dictionary = {
 const SERVICE_HOST_REQUESTS: Array[StringName] = [
 	&"mart_requested", &"phone_call_requested", &"special_phone_call_requested",
 	&"town_map_requested", &"apricorn_selection_requested", &"pc_requested",
-	&"mom_bank_dial_requested", &"elevator_requested",
+	&"mom_bank_dial_requested", &"elevator_requested", &"vending_requested",
 ]
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -7386,6 +7386,7 @@ const SERVICE_HOST_REQUESTS: Array[StringName] = [
 	&"mart_requested", &"phone_call_requested", &"special_phone_call_requested",
 	&"town_map_requested", &"apricorn_selection_requested", &"pc_requested",
 	&"mom_bank_dial_requested", &"elevator_requested", &"vending_requested",
+	&"prize_requested",
 ]
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -25,6 +25,7 @@ enum MODE {
 	PC_OAK_ASK,
 	PC_SAVE,
 	ELEVATOR,
+	VENDING,
 }
 
 ## `ElevatorFloorNames`, in `FLOOR_*` order (constants/script_constants.asm).
@@ -336,6 +337,9 @@ func open_pending(
 	if StringName(request.get("kind", &"")) == &"mom_bank_dial_requested":
 		_open_mom_bank(request.get("values", {}))
 		return true
+	if StringName(request.get("kind", &"")) == &"vending_requested":
+		_open_vending((request.get("values", {}) as Dictionary).get("rows", []))
+		return true
 	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world, request)
 	if not bool(resolved.get("ok", false)):
 		_show_error("Service unavailable: %s" % String(resolved.get("reason", "unknown")))
@@ -418,6 +422,9 @@ func handle_button(button: int) -> bool:
 		return true
 	if _mode == MODE.ELEVATOR:
 		_press_elevator(button)
+		return true
+	if _mode == MODE.VENDING:
+		_press_vending(button)
 		return true
 	if _mode == MODE.MART:
 		_press_mart(button)
@@ -628,6 +635,102 @@ func _open_menu(input: Dictionary) -> void:
 	_render_rows()
 
 
+## `VendingMachineMenu`. The greeting stands in its own box while the list is up,
+## and the routine returns after one drink: the box the choice lands in is the
+## last thing the machine says.
+const GEN1_VENDING_RUN: String = "vending"
+
+var _vending_rows: Array = []
+var _vending_said: String = ""
+
+
+func _open_vending(rows: Array) -> void:
+	_mode = MODE.VENDING
+	_vending_rows = rows.duplicate(true)
+	_vending_said = ""
+	_cursor = 0
+	_set_overlay_open(true)
+	_open_map_overlay_view()
+	_render_vending()
+
+
+## `HandleMenuInput` watches A and B with no wrapping, and B answers the way the
+## CANCEL row does.
+func _press_vending(button: int) -> void:
+	if not _vending_said.is_empty():
+		if button in [PokeButton.A, PokeButton.B]:
+			_finish_runtime({"ok": true, "script_value": 0})
+		return
+	if button == PokeButton.UP or button == PokeButton.DOWN:
+		_cursor = clampi(
+			_cursor + (-1 if button == PokeButton.UP else 1), 0, _vending_rows.size()
+		)
+		_render_vending()
+		return
+	if button != PokeButton.A and button != PokeButton.B:
+		return
+	if button == PokeButton.B or _cursor >= _vending_rows.size():
+		_vending_said = _vending_text("not_thirsty")
+		_render_vending()
+		return
+	var bought: Dictionary = Gen2WorldMartHost.vend(
+		_world, _save, _vending_rows[_cursor], _persist
+	)
+	_vending_said = _vending_bought_text(bought)
+	_render_vending()
+
+
+## `.enoughMoney`'s three landings: `VendingMachineText5` names the drink,
+## `...Text4` is `HasEnoughMoney`'s refusal and `...Text6` `GiveItem`'s.
+func _vending_bought_text(bought: Dictionary) -> String:
+	if not bool(bought.get("ok", false)):
+		return _vending_text("no_money") \
+			if StringName(bought.get("reason", &"")) == &"insufficient_money" \
+			else _vending_text("bag_full")
+	return Gen2TextStream.fill_marker(
+		_vending_text("here_you_go"), Gen2TextStream.RAM_MARKER,
+		String(bought.get("name", ""))
+	)
+
+
+func _vending_text(slot: String) -> String:
+	return _data.special_text(GEN1_VENDING_RUN, slot) if _data != null else ""
+
+
+func _render_vending() -> void:
+	if _mart_view == null or _data == null:
+		return
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _service_page == null or _mart_page == null:
+		return
+	var image: Image = _service_page.render(
+		"", "", [], -1,
+		_vending_said if not _vending_said.is_empty() else _vending_text("greeting")
+	)
+	var overlay: Image = _mart_page.render_gen1_vending({
+		"money": _world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
+		"rows": _vending_named_rows(),
+		"cursor": _cursor,
+	})
+	if image != null and overlay != null:
+		image.blend_rect(overlay, Rect2i(Vector2i.ZERO, overlay.get_size()), Vector2i.ZERO)
+	Gen2PicImage.show(_mart_view, image)
+
+
+## `DrinkText`, which the import has already checked against `ItemNames`.
+func _vending_named_rows() -> Array:
+	var out: Array = []
+	for row: Dictionary in _vending_rows:
+		out.append({
+			"name": _data.item_name(int(row.get("item", 0))),
+			"price": int(row.get("price", 0)),
+		})
+	return out
+
+
 ## The shop. `MartDialog` opens on the map: `MENU_BACKUP_TILES` on the welcome
 ## box and on `MenuHeader_BuySell`, and no `BuyMenu` screen until BUY is chosen.
 func _open_mart(mart: Dictionary) -> void:
@@ -642,14 +745,7 @@ func _open_mart(mart: Dictionary) -> void:
 	_mart_message = PackedStringArray()
 	_cursor = 0
 	_set_overlay_open(true)
-	if _mart_view == null and _service_hardware != null:
-		_mart_view = TextureRect.new()
-		_mart_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
-		_mart_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
-		_mart_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
-		## After the panel's own view, which is [method Gen2Screen.display]'s
-		## z-order: the menu behind the shop is hidden anyway.
-		_service_hardware.display(_mart_view)
+	_open_map_overlay_view()
 	_refresh_mart_sell_entries()
 	## `.HowMayIHelpYou` hands the loop to `.TopMenu`; every other shop type
 	## prints its intro through `MartTextbox`, which waits before `BuyMenu`.
@@ -1104,6 +1200,18 @@ func _sell_mart_selection() -> void:
 		}),
 		MART_SELL if not _mart_sell_entries.is_empty() else MART_TOP
 	)
+
+
+## The view every counter standing over the map draws into, after the panel's
+## own: the menu behind a counter is hidden anyway.
+func _open_map_overlay_view() -> void:
+	if _mart_view != null or _service_hardware == null:
+		return
+	_mart_view = TextureRect.new()
+	_mart_view.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	_mart_view.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
+	_mart_view.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_service_hardware.display(_mart_view)
 
 
 func _close_mart() -> void:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -25,7 +25,7 @@ enum MODE {
 	PC_OAK_ASK,
 	PC_SAVE,
 	ELEVATOR,
-	VENDING,
+	VENDING, PRIZE,
 }
 
 ## `ElevatorFloorNames`, in `FLOOR_*` order (constants/script_constants.asm).
@@ -340,6 +340,9 @@ func open_pending(
 	if StringName(request.get("kind", &"")) == &"vending_requested":
 		_open_vending((request.get("values", {}) as Dictionary).get("rows", []))
 		return true
+	if StringName(request.get("kind", &"")) == &"prize_requested":
+		_open_prizes(request.get("values", {}))
+		return true
 	var resolved: Dictionary = Gen2WorldHost.resolve_runtime_request(_world, request)
 	if not bool(resolved.get("ok", false)):
 		_show_error("Service unavailable: %s" % String(resolved.get("reason", "unknown")))
@@ -425,6 +428,9 @@ func handle_button(button: int) -> bool:
 		return true
 	if _mode == MODE.VENDING:
 		_press_vending(button)
+		return true
+	if _mode == MODE.PRIZE:
+		_press_prize(button)
 		return true
 	if _mode == MODE.MART:
 		_press_mart(button)
@@ -729,6 +735,158 @@ func _vending_named_rows() -> Array:
 			"price": int(row.get("price", 0)),
 		})
 	return out
+
+
+const GEN1_PRIZE_RUN: String = "prizes"
+const GEN1_PRIZE_RUN_2: String = "prizes_2"
+
+## `CeladonPrizeMenu`: the coin case, the list, `SoYouWantPrizeText`'s YES/NO and
+## one prize. `.noChoice` says nothing, which is what B and NO THANKS reach.
+var _prize_rows: Array = []
+var _prize_tms: bool = false
+var _prize_said: String = ""
+var _prize_asking: bool = false
+var _prize_confirm: int = 0
+
+
+func _open_prizes(values: Dictionary) -> void:
+	_mode = MODE.PRIZE
+	_prize_rows = (values.get("rows", []) as Array).duplicate(true)
+	_prize_tms = bool(values.get("tms", false))
+	_prize_said = ""
+	_prize_asking = false
+	_prize_confirm = 0
+	_cursor = 0
+	_set_overlay_open(true)
+	_open_map_overlay_view()
+	## `IsItemInBag COIN_CASE`, and the only box a player without one is shown.
+	if _world.state.item_quantity(Gen1Layout.ITEM_COIN_CASE) <= 0:
+		_prize_said = _prize_text("require_coin_case")
+	_render_prizes()
+
+
+func _press_prize(button: int) -> void:
+	if not _prize_said.is_empty():
+		if button in [PokeButton.A, PokeButton.B]:
+			_finish_runtime({"ok": true, "script_value": 0})
+		return
+	if _prize_asking:
+		_press_prize_confirm(button)
+		return
+	if button == PokeButton.UP or button == PokeButton.DOWN:
+		_cursor = clampi(
+			_cursor + (-1 if button == PokeButton.UP else 1), 0, _prize_rows.size()
+		)
+		_render_prizes()
+		return
+	if button == PokeButton.B or _cursor >= _prize_rows.size():
+		if button in [PokeButton.A, PokeButton.B]:
+			_finish_runtime({"ok": true, "script_value": 0})
+		return
+	if button != PokeButton.A:
+		return
+	_prize_asking = true
+	_prize_confirm = 0
+	_render_prizes()
+
+
+## `SoYouWantPrizeText`'s `YesNoChoice`. NO is `.printOhFineThen`.
+func _press_prize_confirm(button: int) -> void:
+	match button:
+		PokeButton.UP, PokeButton.DOWN:
+			_prize_confirm = 1 - _prize_confirm
+		PokeButton.B:
+			_prize_asking = false
+			_prize_said = _prize_text("oh_fine_then", GEN1_PRIZE_RUN_2)
+		PokeButton.A:
+			_prize_asking = false
+			if _prize_confirm == 1:
+				_prize_said = _prize_text("oh_fine_then", GEN1_PRIZE_RUN_2)
+			else:
+				_prize_said = _buy_prize(_prize_rows[_cursor])
+				## `HandlePrizeChoice` falls into `.noChoice` and the routine
+				## returns, so a prize that was handed over says nothing at all.
+				if _prize_said.is_empty():
+					_finish_runtime({"ok": true, "script_value": 0})
+					return
+		_:
+			return
+	_render_prizes()
+
+
+## `HasEnoughCoins` first, then `GiveItem` or `GivePokemon`; no room leaves the
+## coins alone.
+func _buy_prize(row: Dictionary) -> String:
+	var cost: int = int(row.get("cost", 0))
+	if _world.state.coins() < cost:
+		return _prize_text("need_more_coins", GEN1_PRIZE_RUN_2)
+	var number: int = int(row.get("item", 0))
+	if _prize_tms:
+		var owned: int = _world.state.item_quantity(number)
+		if owned + 1 > Gen2WorldMartHost.MAX_ITEM_STACK:
+			return _prize_text("bag_full", GEN1_PRIZE_RUN_2)
+		_world.state.apply_changes({}, {}, {"items": {number: owned + 1}})
+	elif not bool(Gen2WorldPartyHost.give_pokemon(
+		_world, _save, number, int(row.get("level", 1)), _persist
+	).get("ok", false)):
+		return ""
+	Gen2WorldInventory.new(_data, _world.state).change_coins(-cost)
+	return ""
+
+
+func _prize_text(slot: String, run: String = GEN1_PRIZE_RUN) -> String:
+	return _data.special_text(run, slot) if _data != null else ""
+
+
+func _render_prizes() -> void:
+	if _mart_view == null or _data == null:
+		return
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _service_page == null or _mart_page == null:
+		return
+	var image: Image = _service_page.render("", "", [], -1, _prize_box_text())
+	var overlay: Image = _mart_page.render_gen1_prizes({
+		"coins": _world.state.coins(),
+		"rows": _prize_named_rows(),
+		"cursor": _cursor,
+	})
+	if image != null and overlay != null:
+		image.blend_rect(overlay, Rect2i(Vector2i.ZERO, overlay.get_size()), Vector2i.ZERO)
+	## `YesNoChoice` opens over the list rather than under it.
+	if _prize_asking and image != null:
+		_blend_mart_menu(image, Gen2MenuBox.yes_no(), ["YES", "NO"], _prize_confirm)
+	Gen2PicImage.show(_mart_view, image)
+
+
+## `ExchangeCoinsForPrizesText` is printed with the delay off and `WhichPrizeText`
+## over it in the same frame, so the box standing under the list is the question.
+func _prize_box_text() -> String:
+	if not _prize_said.is_empty():
+		return _prize_said
+	if _prize_asking:
+		return Gen2TextStream.fill_marker(
+			_prize_text("so_you_want", GEN1_PRIZE_RUN_2), Gen2TextStream.RAM_MARKER,
+			_prize_name(_prize_rows[_cursor])
+		)
+	return _prize_text("which_prize")
+
+
+func _prize_named_rows() -> Array:
+	var out: Array = []
+	for row: Dictionary in _prize_rows:
+		out.append({"name": _prize_name(row), "cost": int(row.get("cost", 0))})
+	return out
+
+
+## `.putMonName`'s `cp 2`: the third list is `GetItemName`'s and the two in front
+## of it are `GetMonName`'s.
+func _prize_name(row: Dictionary) -> String:
+	var number: int = int(row.get("item", 0))
+	return _data.item_name(number) if _prize_tms \
+		else String(_data.species(number).get("name", ""))
 
 
 ## The shop. `MartDialog` opens on the map: `MENU_BACKUP_TILES` on the welcome

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -31,10 +31,18 @@ func test_a_gen2_game_has_none() -> void:
 	assert_true(Gen1Layout.for_id(&"emerald").is_empty())
 
 
-func test_red_and_blue_share_one_table() -> void:
-	# The two are one source built twice and every table this layout names is at
-	# the same offset in both; only bank $1D's map scripts move.
-	assert_eq(Gen1Layout.for_id(RomRegistry.RED), Gen1Layout.for_id(RomRegistry.BLUE))
+func test_red_and_blue_share_every_table_but_bank_1d() -> void:
+	# The two are one source built twice, so every table sits at the same offset
+	# in both. Bank $1D is the exception: its 668 symbols are the map scripts,
+	# and everything in it is one byte later on Blue.
+	var red: Dictionary = Gen1Layout.for_id(RomRegistry.RED)
+	var blue: Dictionary = Gen1Layout.for_id(RomRegistry.BLUE)
+	assert_eq(red.size(), blue.size())
+	for key: String in red:
+		if Gen1Layout.BLUE_ONLY.has(key):
+			assert_eq(int(blue[key]), int(red[key]) + 1, "%s moved by more than a byte" % key)
+			continue
+		assert_eq(blue[key], red[key], key)
 
 
 func test_every_layout_is_complete_and_inside_the_cartridge() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 859 lines of the 39248 here, and Generation 1 has added 683 more to the
+## are 876 lines of the 39286 here, and Generation 1 has added 704 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 121 the transition, the split effect routines and
 ## `BlkPacket_Battle`. Seven sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39248
+const MAX_COMMENT_LINES: int = 39286
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 851 lines of the 39231 here, and Generation 1 has added 674 more to the
+## are 859 lines of the 39248 here, and Generation 1 has added 683 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 121 the transition, the split effect routines and
 ## `BlkPacket_Battle`. Seven sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39231
+const MAX_COMMENT_LINES: int = 39248
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 876 lines of the 39286 here, and Generation 1 has added 704 more to the
+## are 894 lines of the 39332 here, and Generation 1 has added 732 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 121 the transition, the split effect routines and
 ## `BlkPacket_Battle`. Seven sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39286
+const MAX_COMMENT_LINES: int = 39332
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 774 lines of the 39112 here, and Generation 1 has added 632 more to the
+## are 851 lines of the 39231 here, and Generation 1 has added 674 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 121 the transition, the split effect routines and
-## `BlkPacket_Battle`. Six sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39112
+## `BlkPacket_Battle`. Seven sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39231
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_effects.gd
+++ b/tests/unit/test_world_effects.gd
@@ -464,6 +464,27 @@ func test_the_heal_machine_rotates_its_palette_once_the_balls_are_placed() -> vo
 	)
 
 
+## `AnimateHealingMachine` places the monitor before its own party loop and has
+## one table and one position: no machine type moves it, and the six balls are
+## `PokeCenterOAMData`'s two mirrored columns rather than Crystal's.
+func test_generation_one_places_its_own_machine_and_takes_no_shift() -> void:
+	var effects := Gen2WorldEffects.new()
+	effects.start_heal_machine(
+		Gen2WorldEffects.HEAL_MACHINE_ELMS_LAB, 2, RomRegistry.GEN1
+	)
+	var oam: Array = Gen2WorldEffects.gen1_heal_machine_oam()
+	var tiles: Array = effects.sprites()[0]["tiles"]
+	assert_eq(tiles.size(), 2, "The monitor and the first ball.")
+	assert_eq(tiles[0]["offset"], (oam[0] as Array)[0], "Elm's Lab does not move it.")
+	assert_eq(tiles[1]["offset"], (oam[1] as Array)[0])
+	assert_false(bool(tiles[1]["flip_x"]))
+	for _frame: int in Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES:
+		effects.advance_frame()
+	tiles = effects.sprites()[0]["tiles"]
+	assert_eq(tiles.size(), 3, "The second ball, thirty frames behind the first.")
+	assert_true(bool(tiles[2]["flip_x"]), "The right column is the left one mirrored.")
+
+
 ## `ld a, [wPartyCount] / and a / ret z`: an empty party draws nothing at all.
 func test_the_heal_machine_draws_nothing_for_an_empty_party() -> void:
 	var effects := Gen2WorldEffects.new()

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1435,6 +1435,30 @@ func test_generation_one_says_its_own_catch_lines() -> void:
 	)
 
 
+## `GivePokemon`, which the Game Corner's prize counter reaches with a species
+## and `GetPrizeMonLevel`'s level. A full party boxes it; neither having room
+## writes nothing, which is what leaves the coins alone.
+func test_a_prize_pokemon_joins_the_party_and_a_full_one_goes_to_a_box() -> void:
+	var given: Dictionary = Gen2WorldPartyHost.give_pokemon(
+		_world, _save, 25, 9, false, _random
+	)
+	assert_true(bool(given.get("ok", false)), JSON.stringify(given))
+	assert_eq(_save.party.size(), 3)
+	assert_eq(_save.party[2].species, 25)
+	assert_eq(_save.party[2].level, 9)
+	while _save.party.size() < Gen2SaveData.MAX_PARTY:
+		_save.party.append(Gen2SaveMon.from_dict(_save.party[0].to_dict()))
+	assert_true(bool(Gen2WorldPartyHost.give_pokemon(
+		_world, _save, 25, 9, false, _random
+	).get("ok", false)), "a full party boxes it")
+	assert_eq(_save.party.size(), Gen2SaveData.MAX_PARTY)
+	assert_eq(
+		StringName(Gen2WorldPartyHost.give_pokemon(
+			_world, _save, 0, 9, false, _random
+		).get("reason", &"")), &"unknown_species"
+	)
+
+
 ## `SendMonIntoBox` writes `sBoxCount`, which is the open box and no other, and
 ## `ShiftBoxMon` puts what it wrote at the head of it. A full open box refuses
 ## the throw with the other thirteen still empty, which is

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1339,6 +1339,102 @@ func test_every_ball_kurt_makes_can_be_thrown() -> void:
 		assert_eq(_world.state.item_quantity(ball), 0, "and the ball was spent")
 
 
+## Generation 1 numbers its bag its own way, so the balls a battle offers are
+## `ItemUsePtrTable`'s rows rather than Crystal's: read off the Crystal list, the
+## number that is POKE_BALL there is a TOWN MAP here and the ball itself is not
+## offered at all.
+func test_generation_one_offers_the_cartridges_own_ball_numbers() -> void:
+	_world.state.apply_changes({}, {}, {"items": {0x01: 1, 0x04: 1, 0x05: 1}})
+	assert_eq(
+		Gen2WorldPartyHost.owned_capture_balls(_world), [0x05, 0x04, 0x01] as Array[int]
+	)
+	_data.generation = RomRegistry.GEN1
+	assert_eq(
+		Gen2WorldPartyHost.owned_capture_balls(_world), [0x04, 0x01, 0x08] as Array[int],
+		"POKE_BALL is 4, the 5 beside it is a TOWN MAP, and 8 is the SAFARI_BALL"
+	)
+
+
+## `ItemUseBall` has one bag rather than four pockets, so nothing an item row
+## says about a pocket may refuse a Generation 1 throw. The seam is what
+## `ItemUsePtrTable` says instead, and the cache carries no pocket at all.
+func test_a_generation_one_throw_reads_no_pocket() -> void:
+	_data.generation = RomRegistry.GEN1
+	_world.state.apply_changes({}, {}, {"items": {0x04: 1}})
+	var wild: Gen2BattleMon = Gen2BattleMon.create(
+		_data, 25, 5, _data.moves_at_level(25, 5), 0x1234
+	)
+	var thrown: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x04, _random, 42, false
+	)
+	assert_true(bool(thrown.get("ok", false)), JSON.stringify(thrown))
+	assert_eq(_world.state.item_quantity(0x04), 0, "and the ball was spent")
+	var refused: Dictionary = Gen2WorldPartyHost.capture_wild(
+		_world, _save, wild, 0x05, _random, 42, false
+	)
+	assert_eq(
+		StringName(refused.get("reason", &"")), &"unsupported_ball_effect",
+		"the TOWN MAP has no ItemUseBall row"
+	)
+
+
+## `.loop` rerolls anything over the ball's own ceiling, which is the whole of
+## what a Great Ball buys before the arithmetic starts. A roll it refuses costs
+## nothing but the number.
+func test_a_great_ball_rerolls_a_number_over_two_hundred() -> void:
+	var case: Dictionary = {
+		"catch_rate": 45, "max_hp": 100, "current_hp": 100, "status": 0,
+	}
+	assert_eq(
+		_gen1_throw(0x03, case, [255, 201, 60, 255]),
+		_gen1_throw(0x03, case, [60, 255]),
+		"the two refused rolls change nothing"
+	)
+	assert_ne(
+		_gen1_throw(0x04, case, [255, 255]), _gen1_throw(0x03, case, [255, 255]),
+		"and a Poke Ball keeps the 255 a Great Ball throws away"
+	)
+
+
+## `.checkForAilments` subtracts before it compares, so a roll under the status
+## term is caught with no arithmetic at all: 25 asleep or frozen, 12 otherwise.
+func test_a_sleeping_wild_is_caught_outright_below_the_status_term() -> void:
+	var case: Dictionary = {
+		"catch_rate": 1, "max_hp": 100, "current_hp": 100,
+		"status": Gen2Status.SLEEP_MASK & 3,
+	}
+	assert_true(bool(_gen1_throw(0x04, case, [24, 255])["caught"]))
+	assert_false(bool(_gen1_throw(0x04, case, [25, 255])["caught"]))
+	case["status"] = Gen2Status.POISON
+	assert_true(bool(_gen1_throw(0x04, case, [11, 255])["caught"]))
+	assert_false(bool(_gen1_throw(0x04, case, [12, 255])["caught"]))
+
+
+func _gen1_throw(ball: int, case: Dictionary, rolls: Array) -> Dictionary:
+	var queue: Array = rolls.duplicate()
+	return Gen2WorldPartyHost.gen1_ball_outcome(
+		ball, case,
+		func() -> int: return int(queue.pop_front()) if not queue.is_empty() else 0
+	)
+
+
+## `_DoYouWantToNicknameText` and `_ItemUseBallText08`, which are their own
+## words. The Generation 1 box line is the one `EVENT_MET_BILL` has not replaced,
+## no Generation 1 event model holding that flag.
+func test_generation_one_says_its_own_catch_lines() -> void:
+	assert_string_contains(
+		Gen2WorldPartyHost.capture_nickname_question("PIKACHU", RomRegistry.GEN1),
+		"Do you want to"
+	)
+	assert_string_contains(
+		Gen2WorldPartyHost.sent_to_box_text("PIKACHU", RomRegistry.GEN1),
+		"someone's PC!"
+	)
+	assert_string_contains(
+		Gen2WorldPartyHost.sent_to_box_text("PIKACHU"), "BILL's PC."
+	)
+
+
 ## `SendMonIntoBox` writes `sBoxCount`, which is the open box and no other, and
 ## `ShiftBoxMon` puts what it wrote at the head of it. A full open box refuses
 ## the throw with the other thirteen still empty, which is

--- a/tools/checks/gen1_catch.gd
+++ b/tools/checks/gen1_catch.gd
@@ -1,0 +1,230 @@
+extends RefCounted
+
+## `ItemUseBall` on Red, Blue and Yellow, against what the cartridges themselves
+## answered. The throw is a pure function of five WRAM bytes and the two numbers
+## `call Random` gives it, so the oracle's `battle/gen1_catch.py` drives the
+## routine on a real dump and prints the `wPokeBallAnimData` it wrote;
+## [method _oracle_sweep] prints the same 2,312 lines. All three cartridges
+## answer identically. The corpus sweep beside it runs every species' imported
+## catch rate through every ball.
+
+## `ItemUsePtrTable`'s ball rows and what `ItemNames` calls them.
+const BALL_NAMES: Dictionary = {
+	0x01: "MASTER BALL", 0x02: "ULTRA BALL", 0x03: "GREAT BALL",
+	0x04: "POKé BALL", 0x08: "SAFARI BALL",
+}
+
+## What Crystal's numbering reads as on a Generation 1 cache.
+const GEN2_NUMBERING_READS: Dictionary = {
+	Gen2WorldPartyHost.ITEM_POKE_BALL: "TOWN MAP",
+	Gen2WorldPartyHost.ITEM_GREAT_BALL: "POKé BALL",
+}
+
+## `wPokeBallAnimData`: the high nybble is how many of `.PokeBallAnimations`
+## play, the low nybble the rocks. $43 is `.canUseBall`'s preset, which the
+## captured path never writes over.
+const ANIM_CAUGHT: int = 0x43
+const ANIM_MISSED: int = 0x20
+const ANIM_SHOOK_BASE: int = 0x60
+
+## The oracle's case list in its own order, so the two files diff line for line.
+## A Rand1 over the ball's ceiling would spend a third `Random`.
+const ORACLE_BALLS: Array[int] = [0x04, 0x03, 0x02, 0x08]
+const ORACLE_CEILINGS: Dictionary = {0x04: 255, 0x03: 200, 0x02: 150, 0x08: 150}
+const ORACLE_ROLLS: Array[int] = [
+	0, 1, 11, 12, 24, 25, 60, 100, 149, 150, 199, 200, 254, 255,
+]
+const ORACLE_RATES: Array[int] = [1, 3, 25, 45, 90, 120, 190, 255]
+const ORACLE_SECOND: Array[int] = [0, 63, 128, 255]
+const ORACLE_HEALTH: Array = [
+	[1, 1], [3, 1], [4, 4], [4, 1], [20, 20], [20, 10], [20, 1],
+	[85, 85], [85, 43], [85, 1], [86, 86], [86, 1], [100, 100], [100, 50],
+	[255, 255], [255, 128], [255, 1], [341, 341], [341, 1],
+	[342, 342], [342, 1], [400, 400], [400, 1], [703, 703], [703, 1],
+	[999, 999], [999, 500], [999, 1],
+]
+const ORACLE_STATUSES: Array[int] = [0, 1, 3, 7, 8, 16, 32, 64]
+const ORACLE_HEAD: String = "ball rate maxhp curhp status rand1 rand2 -> animdata"
+
+## SHA-1 of the file the oracle writes, which all three cartridges produce byte
+## for byte. Re-earn it with `venv/bin/python battle/gen1_catch.py red <out>`
+## rather than by copying whatever this prints.
+const ORACLE_DIGEST: String = "f339a8a5578a88520ad742ad69a43d04bb855daf"
+
+## What each pinned row proves, and the byte the cartridge wrote.
+## [ball, rate, max HP, current HP, status, Rand1, Rand2] -> `wPokeBallAnimData`.
+const PINNED: Array = [
+	# `.loop`'s ceilings: 255, 200 and the 150 an Ultra or a Safari Ball takes.
+	[[0x04, 255, 100, 50, 0, 255, 0], ANIM_CAUGHT],
+	[[0x03, 255, 100, 50, 0, 200, 0], ANIM_CAUGHT],
+	[[0x02, 255, 100, 50, 0, 150, 0], ANIM_CAUGHT],
+	[[0x08, 255, 100, 50, 0, 150, 0], ANIM_CAUGHT],
+	# A roll under the status term is caught outright: 25 asleep, 12 poisoned.
+	[[0x04, 45, 100, 100, 3, 24, 255], ANIM_CAUGHT],
+	[[0x04, 45, 100, 100, 3, 25, 255], ANIM_SHOOK_BASE + 1],
+	[[0x04, 45, 100, 100, 8, 11, 255], ANIM_CAUGHT],
+	[[0x04, 45, 100, 100, 8, 12, 255], ANIM_SHOOK_BASE + 1],
+	[[0x04, 190, 100, 100, 32, 0, 255], ANIM_CAUGHT],
+	# `.addAilmentValue` moves the same throw off the bottom of the ladder.
+	[[0x04, 45, 100, 100, 0, 12, 255], ANIM_MISSED],
+	[[0x04, 190, 100, 100, 0, 0, 255], ANIM_SHOOK_BASE + 1],
+	# W over 255 is caught with no second roll: one HP floors to `ld c, $1`.
+	[[0x04, 255, 999, 1, 0, 60, 0], ANIM_CAUGHT],
+	[[0x03, 255, 100, 50, 0, 60, 255], ANIM_CAUGHT],
+	# BallFactor2 is 255 and 200, one more rock out of a Great Ball at every rung.
+	[[0x04, 25, 100, 50, 0, 60, 255], ANIM_MISSED],
+	[[0x03, 25, 100, 50, 0, 60, 255], ANIM_SHOOK_BASE + 1],
+	[[0x04, 190, 100, 50, 0, 199, 255], ANIM_SHOOK_BASE + 2],
+	[[0x03, 190, 100, 50, 0, 199, 255], ANIM_SHOOK_BASE + 3],
+	# 342 max HP locks Crystal up; nothing here truncates the divisor.
+	[[0x04, 255, 342, 342, 0, 60, 255], ANIM_SHOOK_BASE + 2],
+	[[0x04, 255, 999, 999, 0, 60, 255], ANIM_SHOOK_BASE + 2],
+]
+
+## The only two catch rates Yellow rewrote, by dex number.
+const CATCH_RATES: Dictionary = {
+	&"yellow": {148: 27, 149: 9},
+	&"red": {148: 45, 149: 45},
+	&"blue": {148: 45, 149: 45},
+}
+
+## One roll pair per outcome the ladder can reach.
+const CORPUS_ROLLS: Array = [[0, 255], [60, 255], [100, 128], [150, 0]]
+
+## SHA-1 of every species against every ball, one digest per cartridge.
+const CORPUS_DIGESTS: Dictionary = {
+	&"red": "7dabad4cd44540ae2b3b80a2c08e097141db9dc8",
+	&"blue": "7dabad4cd44540ae2b3b80a2c08e097141db9dc8",
+	&"yellow": "4259edebdc2384733103eaaf123b570f16af3b16",
+}
+
+const SPECIES_COUNT: int = 151
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	_the_balls_are_the_cartridge_s()
+	for row: Array in PINNED:
+		_verify(row[0] as Array, int(row[1]))
+	_oracle_sweep()
+	_corpus_sweep()
+
+
+## The five numbers `ItemUsePtrTable` gives an `ItemUseBall` row.
+func _the_balls_are_the_cartridge_s() -> void:
+	var offered: Array[int] = Gen2WorldPartyHost.capture_ball_items(RomRegistry.GEN1)
+	_r.check(
+		offered.size() == BALL_NAMES.size(),
+		"%d balls are offered, %d have an ItemUseBall row." % [
+			offered.size(), BALL_NAMES.size(),
+		]
+	)
+	for ball: int in BALL_NAMES:
+		_r.check(ball in offered, "ball %d is not offered." % ball)
+		var name: String = String(_r.data.item(ball).get("name", ""))
+		_r.check(
+			name == String(BALL_NAMES[ball]),
+			"item %d is %s, the cartridge calls it %s." % [ball, name, BALL_NAMES[ball]]
+		)
+	for ball: int in GEN2_NUMBERING_READS:
+		var name: String = String(_r.data.item(ball).get("name", ""))
+		_r.check(
+			name == String(GEN2_NUMBERING_READS[ball]),
+			"Crystal's %d reads as %s here, not %s." % [
+				ball, name, GEN2_NUMBERING_READS[ball],
+			]
+		)
+
+
+## Hashed whole, header included, so the digest is the cartridge file's own.
+func _oracle_sweep() -> void:
+	var lines: PackedStringArray = PackedStringArray([ORACLE_HEAD])
+	for ball: int in ORACLE_BALLS:
+		for rate: int in ORACLE_RATES:
+			for first: int in ORACLE_ROLLS:
+				if first > int(ORACLE_CEILINGS[ball]):
+					continue
+				for second: int in ORACLE_SECOND:
+					lines.append(_line([ball, rate, 100, 50, 0, first, second]))
+	for ball: int in [0x04, 0x03]:
+		for pair: Array in ORACLE_HEALTH:
+			for rate: int in [3, 45, 255]:
+				for second: int in [0, 128, 255]:
+					lines.append(_line([
+						ball, rate, int(pair[0]), int(pair[1]), 0, 60, second,
+					]))
+	for status: int in ORACLE_STATUSES:
+		for rate: int in [3, 45, 190]:
+			for first: int in [0, 11, 12, 24, 25, 100, 255]:
+				for second: int in [0, 255]:
+					lines.append(_line([0x04, rate, 100, 100, status, first, second]))
+	var digest: String = ("\n".join(lines) + "\n").sha1_text()
+	if digest != ORACLE_DIGEST:
+		_r.fail("the %d-case oracle sweep is %s, the cartridge %s." % [
+			lines.size() - 1, digest, ORACLE_DIGEST,
+		])
+
+
+## Every species' own catch rate through every ball: the oracle above names its
+## rate directly and reads no base stats column.
+func _corpus_sweep() -> void:
+	var lines: PackedStringArray = PackedStringArray()
+	var rewritten: Dictionary = CATCH_RATES.get(_r.game_id, {})
+	for species: int in range(1, SPECIES_COUNT + 1):
+		var rate: int = int(_r.data.species(species).get("catch_rate", -1))
+		if rate < 0:
+			_r.fail("species %d carries no catch rate." % species)
+			return
+		if rewritten.has(species):
+			_r.check(rate == int(rewritten[species]), "species %d catches at %d, not %d." % [
+				species, rate, rewritten[species],
+			])
+		for ball: int in Gen2WorldPartyHost.capture_ball_items(RomRegistry.GEN1):
+			for pair: Array in CORPUS_ROLLS:
+				lines.append("%d %s" % [species, _line([
+					ball, rate, 100, 50, 0, int(pair[0]), int(pair[1]),
+				])])
+	var digest: String = ("\n".join(lines) + "\n").sha1_text()
+	var expected: String = String(CORPUS_DIGESTS.get(_r.game_id, ""))
+	if expected.is_empty():
+		_r.fail("no pinned corpus digest. It answered %s." % digest)
+		return
+	if digest != expected:
+		_r.fail("the %d-case corpus sweep is %s, pinned %s." % [
+			lines.size(), digest, expected,
+		])
+
+
+func _verify(case: Array, expected: int) -> void:
+	var answered: int = _anim_data(case)
+	if answered != expected:
+		_r.check(false, "%s answered $%02X, the cartridge $%02X." % [
+			str(case), answered, expected,
+		])
+
+
+func _line(case: Array) -> String:
+	return "%s -> %d" % [
+		" ".join(case.map(func(v: int) -> String: return str(v))), _anim_data(case),
+	]
+
+
+## The byte the cartridge writes, out of what this port answers instead.
+func _anim_data(case: Array) -> int:
+	var queue: Array = [int(case[5]), int(case[6])]
+	var outcome: Dictionary = Gen2WorldPartyHost.gen1_ball_outcome(int(case[0]), {
+		"catch_rate": int(case[1]),
+		"max_hp": int(case[2]),
+		"current_hp": int(case[3]),
+		"status": int(case[4]),
+	}, func() -> int: return int(queue.pop_front()) if not queue.is_empty() else 0)
+	if bool(outcome["caught"]):
+		return ANIM_CAUGHT
+	var rocks: int = int(outcome["wobbles"])
+	return ANIM_SHOOK_BASE + rocks if rocks > 0 else ANIM_MISSED

--- a/tools/checks/gen1_catch.gd.uid
+++ b/tools/checks/gen1_catch.gd.uid
@@ -1,0 +1,1 @@
+uid://c3eequpinagcp

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -72,6 +72,29 @@ const VENDING_MACHINES: int = 3
 const VENDING_PRICES: Array = [[0x3C, 200], [0x3D, 300], [0x3E, 350]]
 const VENDING_PURSE: int = 1000
 
+## `GameCornerPrizeRoom_Object`'s three vendors, read from below, and
+## `PrizeDifferentMenuPtrs`' lists as [name, cost, level]. All three cartridges
+## stock a different set of Pokemon and the same three TMs.
+const PRIZE_ROOM: int = 137
+const PRIZE_VENDORS: Array = [Vector2i(2, 3), Vector2i(4, 3), Vector2i(6, 3)]
+const PRIZE_MENUS: Dictionary = {
+	&"red": [
+		[["ABRA", 180, 9], ["CLEFAIRY", 500, 8], ["NIDORINA", 1200, 17]],
+		[["DRATINI", 2800, 18], ["SCYTHER", 5500, 25], ["PORYGON", 9999, 26]],
+		[["TM23", 3300, 0], ["TM15", 5500, 0], ["TM50", 7700, 0]],
+	],
+	&"blue": [
+		[["ABRA", 120, 6], ["CLEFAIRY", 750, 12], ["NIDORINO", 1200, 17]],
+		[["PINSIR", 2500, 20], ["DRATINI", 4600, 24], ["PORYGON", 6500, 18]],
+		[["TM23", 3300, 0], ["TM15", 5500, 0], ["TM50", 7700, 0]],
+	],
+	&"yellow": [
+		[["ABRA", 230, 15], ["VULPIX", 1000, 18], ["WIGGLYTUFF", 2680, 22]],
+		[["SCYTHER", 6500, 30], ["PINSIR", 6500, 30], ["PORYGON", 9999, 26]],
+		[["TM23", 3300, 0], ["TM15", 5500, 0], ["TM50", 7700, 0]],
+	],
+}
+
 var _r: RefCounted = null
 
 
@@ -88,6 +111,7 @@ func _one_game() -> void:
 	_check_the_nurse_heals()
 	_check_the_cable_club()
 	_check_the_vending_machine()
+	_check_the_prize_counter()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -392,3 +416,45 @@ func _check_the_vending_machine() -> void:
 	)
 	world.complete_runtime_request({"ok": true})
 	_r.check(not world.script_busy(), "the machine never closed.")
+
+
+## `PrizeDifferentMenuPtrs`' three lists with `PrizeMonLevelDictionary`'s level
+## on every Pokemon row, and the vendor whose place picks each one.
+func _check_the_prize_counter() -> void:
+	var pinned: Array = PRIZE_MENUS[_r.game_id]
+	var menus: Array = _r.data.prize_menus()
+	if not _r.check(menus.size() == pinned.size(), "%d prize menus." % menus.size()):
+		return
+	for index: int in pinned.size():
+		var menu: Dictionary = menus[index]
+		_r.check(
+			bool(menu["tms"]) == (index == Gen1Layout.PRIZE_TM_MENU),
+			"menu %d is the wrong kind." % index
+		)
+		var rows: Array = menu["rows"]
+		for row: int in (pinned[index] as Array).size():
+			var want: Array = (pinned[index] as Array)[row]
+			var got: Dictionary = rows[row]
+			var name: String = _r.data.item_name(int(got["item"])) if bool(menu["tms"]) \
+				else String(_r.data.species(int(got["item"])).get("name", ""))
+			_r.check(
+				[name, int(got["cost"]), int(got["level"])] == want,
+				"prize %d/%d is %s, pinned %s." % [
+					index, row, [name, int(got["cost"]), int(got["level"])], want,
+				]
+			)
+	for index: int in PRIZE_VENDORS.size():
+		var world: Gen2WorldAPI = _r.open_world(0, PRIZE_ROOM, PRIZE_VENDORS[index])
+		if world == null:
+			return
+		world.player_facing = Gen2WorldSprite.FACING_UP
+		if not _r.check(not world.interact().is_empty(), "vendor %d said nothing." % index):
+			continue
+		var values: Dictionary = world.pending_runtime_request().get("values", {})
+		_r.check(
+			int(values.get("menu", -1)) == index
+				and (values.get("rows", []) as Array).size() == Gen1Layout.PRIZE_ROWS,
+			"vendor %d opened menu %s." % [index, values.get("menu", -1)]
+		)
+		world.complete_runtime_request({"ok": true})
+		_r.check(not world.script_busy(), "vendor %d never closed." % index)

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -64,6 +64,14 @@ const NURSE_PARTY: int = 4
 const CABLE_CLUB_COUNTER := Vector2i(11, 3)
 const CABLE_CLUB_ROWS: int = 12
 
+## `CeladonMartRoof_Object`'s three `bg_event` machines, read from below.
+const CELADON_MART_ROOF: int = 126
+const VENDING_MACHINE := Vector2i(10, 2)
+const VENDING_MACHINES: int = 3
+## `VendingPrices`: FRESH_WATER, SODA_POP and LEMONADE at 200, 300 and 350.
+const VENDING_PRICES: Array = [[0x3C, 200], [0x3D, 300], [0x3E, 350]]
+const VENDING_PURSE: int = 1000
+
 var _r: RefCounted = null
 
 
@@ -79,6 +87,7 @@ func _one_game() -> void:
 	_check_text_boxes()
 	_check_the_nurse_heals()
 	_check_the_cable_club()
+	_check_the_vending_machine()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -328,3 +337,58 @@ func _walk_the_receptionist(dex: bool, frames: int, said: String) -> void:
 
 func _event_text(results: Array) -> String:
 	return String((results[0].get("event", {}) as Dictionary).get("text", ""))
+
+
+## `VendingMachineMenu`'s three `VendingPrices` rows and the purchase
+## `HasEnoughMoney` gates. The box drawn is the screen's.
+func _check_the_vending_machine() -> void:
+	var machines: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		for row: Dictionary in map.texts:
+			machines += 1 if int(row["command"]) \
+				== Gen1Layout.TEXT_SCRIPT_VENDING_MACHINE else 0
+	_r.check(machines == VENDING_MACHINES, "%d machines stand on the map." % machines)
+	var rows: Array = _r.data.vending_rows()
+	for index: int in VENDING_PRICES.size():
+		var pinned: Array = VENDING_PRICES[index]
+		var row: Dictionary = rows[index] if index < rows.size() else {}
+		_r.check(
+			int(row.get("item", 0)) == int(pinned[0])
+				and int(row.get("price", 0)) == int(pinned[1]),
+			"machine row %d is %s." % [index, row]
+		)
+	var world: Gen2WorldAPI = _r.open_world(0, CELADON_MART_ROOF, VENDING_MACHINE)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if not _r.check(not world.interact().is_empty(), "the machine offered nothing."):
+		return
+	var request: Dictionary = world.pending_runtime_request()
+	_r.check(
+		StringName(request.get("kind", &"")) == &"vending_requested"
+			and (request.get("values", {}).get("rows", []) as Array).size() == rows.size(),
+		"the machine asked for %s." % [request.get("kind", &"nothing")]
+	)
+	world.state.apply_changes({}, {}, {
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_PURSE},
+	})
+	var drink: Dictionary = rows[0]
+	var bought: Dictionary = Gen2WorldMartHost.vend(world, null, drink, false)
+	_r.check(bool(bought.get("ok", false)), "the first drink refused: %s." % [bought])
+	_r.check(
+		world.state.item_quantity(int(drink["item"])) == 1
+			and world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT)
+				== VENDING_PURSE - int(drink["price"]),
+		"the drink cost %d." % [VENDING_PURSE - world.state.money(
+			Gen2WorldMartHost.MONEY_ACCOUNT
+		)]
+	)
+	## `HasEnoughMoney` refuses before `GiveItem` does.
+	world.state.apply_changes({}, {}, {"money": {Gen2WorldMartHost.MONEY_ACCOUNT: 0}})
+	_r.check(
+		StringName(Gen2WorldMartHost.vend(world, null, drink, false).get("reason", &""))
+			== &"insufficient_money",
+		"an empty purse bought a drink."
+	)
+	world.complete_runtime_request({"ok": true})
+	_r.check(not world.script_busy(), "the machine never closed.")

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -59,6 +59,11 @@ const VIRIDIAN_POKECENTER: int = 41
 const NURSE_COUNTER := Vector2i(3, 3)
 const NURSE_PARTY: int = 4
 
+## `SPRITE_LINK_RECEPTIONIST` at 11,2, faced from the cell below her, and the 12
+## rows the corpus stands at `TX_SCRIPT_CABLE_CLUB`.
+const CABLE_CLUB_COUNTER := Vector2i(11, 3)
+const CABLE_CLUB_ROWS: int = 12
+
 var _r: RefCounted = null
 
 
@@ -73,6 +78,7 @@ func _one_game() -> void:
 	_check_last_map_round_trip()
 	_check_text_boxes()
 	_check_the_nurse_heals()
+	_check_the_cable_club()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -105,10 +111,10 @@ func _check_the_nurse_heals() -> void:
 		* Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL
 	_r.check(
 		StringName(wait.get("kind", &"")) == &"heal_machine_anim"
-			and int(wait.get("balls", 0)) == NURSE_PARTY
 			and int(wait.get("frames", 0)) == frames,
 		"the heal machine waited on %s." % [wait]
 	)
+	_r.check(world.party_holder() == &"heal_machine", "the machine held no party.")
 	var spent: int = 0
 	while not world.pending_script_wait().is_empty() and spent <= frames:
 		world.advance_script_wait_frame()
@@ -275,4 +281,50 @@ func _box_text(world: Gen2WorldAPI) -> String:
 	var results: Array = world.interact()
 	if results.is_empty():
 		return ""
+	return String((results[0].get("event", {}) as Dictionary).get("text", ""))
+
+
+## `CableClubNPC` from both sides of `EVENT_GOT_POKEDEX`, each with its own
+## count of frames.
+func _check_the_cable_club() -> void:
+	var rows: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		for row: Dictionary in map.texts:
+			rows += 1 if int(row["command"]) == Gen1Layout.TEXT_SCRIPT_CABLE_CLUB else 0
+	_r.check(rows == CABLE_CLUB_ROWS, "%d receptionists stand on a TX_SCRIPT row." % rows)
+	_walk_the_receptionist(false, Gen1Layout.CABLE_CLUB_PREPARING_FRAMES, "making_preparations")
+	_walk_the_receptionist(true, Gen1Layout.CABLE_CLUB_TIMEOUT_FRAMES, "area_reserved")
+
+
+func _walk_the_receptionist(dex: bool, frames: int, said: String) -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, VIRIDIAN_POKECENTER, CABLE_CLUB_COUNTER)
+	if world == null:
+		return
+	world.state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, dex)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var opened: Array = world.interact()
+	if not _r.check(not opened.is_empty(), "the receptionist said nothing."):
+		return
+	_r.check(
+		_event_text(opened) == _r.data.special_text("cable_club", "welcome"),
+		"the receptionist opened with %s." % [_event_text(opened)]
+	)
+	world.run_event_queue(true)
+	var wait: Dictionary = world.pending_script_wait()
+	_r.check(int(wait.get("frames", 0)) == frames, "she waited %s frames." % [wait.get("frames", 0)])
+	var spent: int = 0
+	while not world.pending_script_wait().is_empty() and spent <= frames:
+		var landed: Array = world.advance_script_wait_frame()
+		spent += 1
+		if not landed.is_empty():
+			_r.check(
+				_event_text(landed) == _r.data.special_text("cable_club", said),
+				"she finished with %s." % [_event_text(landed)]
+			)
+	_r.check(spent == frames, "she waited %d frames rather than %d." % [spent, frames])
+	world.run_event_queue(true)
+	_r.check(not world.script_busy(), "the receptionist never finished.")
+
+
+func _event_text(results: Array) -> String:
 	return String((results[0].get("event", {}) as Dictionary).get("text", ""))

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -53,6 +53,12 @@ const VIRIDIAN_MART: int = 42
 const MART_COUNTER := Vector2i(2, 5)
 const MART_CLERK := Vector2i(0, 5)
 
+## `ViridianPokecenter_Object`'s nurse, reached over her counter from the cell
+## two below her, and the party she is handed.
+const VIRIDIAN_POKECENTER: int = 41
+const NURSE_COUNTER := Vector2i(3, 3)
+const NURSE_PARTY: int = 4
+
 var _r: RefCounted = null
 
 
@@ -66,6 +72,53 @@ func _one_game() -> void:
 	_check_ledges()
 	_check_last_map_round_trip()
 	_check_text_boxes()
+	_check_the_nurse_heals()
+
+
+## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
+## counted wait rather than a box, so what proves it is there is the world
+## standing in one for its own frames.
+func _check_the_nurse_heals() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, VIRIDIAN_POKECENTER, NURSE_COUNTER)
+	if world == null:
+		return
+	world.set_party_summary(NURSE_PARTY, false)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if not _r.check(not world.interact().is_empty(), "the nurse said nothing."):
+		return
+	## The welcome, then the YES/NO, then the line in front of the heal.
+	world.run_event_queue(true)
+	if not _r.check(world.script_input_waiting(), "the nurse asked nothing."):
+		return
+	world.choose_script_input(0)
+	world.run_event_queue(true)
+	var request: Dictionary = world.pending_runtime_request()
+	if not _r.check(
+		StringName(request.get("kind", &"")) == &"party_heal_requested",
+		"the nurse asked for %s." % [request.get("kind", &"nothing")]
+	):
+		return
+	world.complete_runtime_request({"ok": true})
+	var wait: Dictionary = world.pending_script_wait()
+	var frames: int = NURSE_PARTY * Gen2WorldEffects.HEAL_MACHINE_BALL_FRAMES \
+		+ Gen2WorldEffects.HEAL_MACHINE_FLASHES \
+		* Gen2WorldEffects.HEAL_MACHINE_FLASH_INTERVAL
+	_r.check(
+		StringName(wait.get("kind", &"")) == &"heal_machine_anim"
+			and int(wait.get("balls", 0)) == NURSE_PARTY
+			and int(wait.get("frames", 0)) == frames,
+		"the heal machine waited on %s." % [wait]
+	)
+	var spent: int = 0
+	while not world.pending_script_wait().is_empty() and spent <= frames:
+		world.advance_script_wait_frame()
+		spent += 1
+	_r.check(spent == frames, "the machine ran for %d frames, not %d." % [spent, frames])
+	## `PokemonFightingFitText` and `PokemonCenterFarewellText` behind it.
+	_r.check(world.script_busy(), "nothing was said once the machine had stopped.")
+	world.run_event_queue(true)
+	world.run_event_queue(true)
+	_r.check(not world.script_busy(), "the nurse never finished.")
 
 
 ## Every warp on every map: its destination resolves, it fires from some facing,

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -31,17 +31,52 @@ const HEAL_MACHINE_COLORS: Array[int] = [0x7FFF, 0x2A7F, 0x04FF, 0x0000]
 var _first: Dictionary = {}
 
 
+## The one sheet Generation 1 draws over the map. It wears `rOBP1` rather than a
+## palette of its own, and its monitor is three rows of $7E where Crystal's is two.
+const GEN1_EXPECTED: Array = [["heal_machine", 2, 0x7C]]
+
+## `PokeCenterOAMData` read back to the pixel each object reaches the screen at:
+## the monitor, then six balls in two mirrored columns five rows apart.
+const GEN1_OAM: Array = [
+	[Vector2i(44, 20), 0, false],
+	[Vector2i(40, 27), 1, false], [Vector2i(48, 27), 1, true],
+	[Vector2i(40, 32), 1, false], [Vector2i(48, 32), 1, true],
+	[Vector2i(40, 37), 1, false], [Vector2i(48, 37), 1, true],
+]
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	_first = {}
 	_r.each_game(_check_game)
+	_first = {}
+	_r.each_game_of(RomRegistry.GEN1, _check_gen1_game)
+
+
+## The same sheet checks, plus the OAM table and the two `rOBP1` bytes.
+func _check_gen1_game() -> void:
+	_check_sheets(GEN1_EXPECTED)
+	_r.check(
+		Gen2WorldEffects.gen1_heal_machine_oam() == GEN1_OAM,
+		"the heal machine OAM is %s." % [Gen2WorldEffects.gen1_heal_machine_oam()]
+	)
+	## `ld a, $e0 / ldh [rOBP1]` and `ld d, $28 / call FlashSprite8Times`: the
+	## xor swaps the two inner shades and leaves the ends alone.
+	_r.check(
+		Gen1Layout.HEAL_MACHINE_SHADES == [[0, 0, 2, 3], [0, 2, 0, 3]],
+		"the heal machine shades are %s." % [Gen1Layout.HEAL_MACHINE_SHADES]
+	)
 
 
 func _check_game() -> void:
-	var lit: int = 0
 	var expected: Array = EXPECTED.duplicate()
 	if Gen2WorldState.is_crystal_profile(_r.data):
 		expected.append_array(CRYSTAL_ONLY)
+	_check_sheets(expected)
+
+
+func _check_sheets(expected: Array) -> void:
+	var lit: int = 0
 	for row: Array in expected:
 		var name: String = String(row[0])
 		var sheet: Dictionary = _r.data.overworld_effect(name)
@@ -80,7 +115,7 @@ func _check_game() -> void:
 		else:
 			_first[name] = indices
 		var colors: PackedColorArray = sheet.get("colors", PackedColorArray())
-		if name == "heal_machine":
+		if name == "heal_machine" and _r.data.generation == RomRegistry.GEN2:
 			if _r.check(
 				colors.size() == HEAL_MACHINE_COLORS.size(),
 				"the heal machine carries %d colours, not four." % colors.size()

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -455,7 +455,9 @@ func _process(_delta: float) -> bool:
 		_choose_view()
 	if _frames == 2:
 		_stage_kind()
-		if not _bare and _kind not in SELF_DRIVEN_KINDS:
+		## `bare` takes the readout off and nothing else: skipping these caught
+		## a staged box on the frame it opened, which is an empty box.
+		if _kind not in SELF_DRIVEN_KINDS:
 			for _frame: int in int(STAGED_FRAMES_BY_KIND.get(_kind, STAGED_FRAMES)):
 				_screen.advance_frame()
 	if _frames < 18:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -29,6 +29,7 @@ const KIND_HELP: Dictionary = {
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
+	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
@@ -157,7 +158,7 @@ const STAGED_FRAMES: int = 2
 ## `sign` spends the whole reveal: no press finishes a page early.
 const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
-	&"nurse": BOX_REVEAL_FRAMES,
+	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -401,6 +402,7 @@ const STAGERS: Dictionary = {
 	&"pokepic": &"_stage_pokepic",
 	&"sign": &"_stage_sign",
 	&"nurse": &"_stage_nurse",
+	&"vending": &"_stage_vending",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -921,6 +923,29 @@ func _stage_nurse() -> void:
 		for _frame: int in BOX_REVEAL_FRAMES:
 			_screen.advance_frame()
 		_screen.press_button(PokeButton.A)
+
+
+## The machine, faced from the cell below it, with money for any of its rows.
+func _stage_vending() -> void:
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world != null:
+		world.state.apply_changes({}, {}, {
+			"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY},
+		})
+	_screen.press_button(PokeButton.UP)
+	for _frame: int in TEXT_SETTLE_FRAMES:
+		_screen.advance_frame()
+	_screen.interact()
+	for _step: int in maxi(_cell.y, 0):
+		_screen.press_button(PokeButton.DOWN)
+	for _press: int in maxi(_cell.x, 0):
+		for _frame: int in BOX_REVEAL_FRAMES:
+			_screen.advance_frame()
+		_screen.press_button(PokeButton.A)
+
+
+## Enough for every row of `VendingPrices` and not enough to widen the money box.
+const VENDING_MONEY: int = 1000
 
 
 ## `_UnownPrinter`'s browser: the first number is the slot, where 26 is the vacant

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -412,6 +412,10 @@ const STAGERS: Dictionary = {
 }
 
 
+## The kinds `preview_effect_sprites` answers by name.
+const EFFECT_SPRITE_KINDS: Array[StringName] = [&"cut", &"fly", &"heal_machine"]
+
+
 ## Puts the screen in the state the picture wants. Called once, on the frame the
 ## screen is ready.
 func _stage_kind() -> void:
@@ -431,7 +435,10 @@ func _stage_kind() -> void:
 		if String(_kind).ends_with("_use") or String(_kind).ends_with("_question"):
 			_screen.call(SCREEN_DRIVER % _kind)
 		return
-	if not _bare:
+	## The fall-through stages a pile of debug sprites and an emote, which a bare
+	## capture does not want; the three kinds named ahead of it are pictures of
+	## their own, and skipping those photographed an empty map.
+	if _kind in EFFECT_SPRITE_KINDS or not _bare:
 		_screen.preview_effect_sprites(_kind)
 
 

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -30,6 +30,7 @@ const KIND_HELP: Dictionary = {
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
+	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
@@ -159,6 +160,7 @@ const STAGED_FRAMES: int = 2
 const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
+	&"prizes": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -403,6 +405,7 @@ const STAGERS: Dictionary = {
 	&"sign": &"_stage_sign",
 	&"nurse": &"_stage_nurse",
 	&"vending": &"_stage_vending",
+	&"prizes": &"_stage_prizes",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -927,11 +930,21 @@ func _stage_nurse() -> void:
 
 ## The machine, faced from the cell below it, with money for any of its rows.
 func _stage_vending() -> void:
+	_stage_counter({"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY}})
+
+
+## The prize counter, with the COIN CASE it opens on and coins for any row.
+func _stage_prizes() -> void:
+	_stage_counter({
+		"items": {Gen1Layout.ITEM_COIN_CASE: 1}, "coins": Gen2WorldInventory.MAX_COINS,
+	})
+
+
+## A counter faced from the cell below it: presses, then rows down first.
+func _stage_counter(purse: Dictionary) -> void:
 	var world: Gen2WorldAPI = _screen.get("_world")
 	if world != null:
-		world.state.apply_changes({}, {}, {
-			"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY},
-		})
+		world.state.apply_changes({}, {}, purse)
 	_screen.press_button(PokeButton.UP)
 	for _frame: int in TEXT_SETTLE_FRAMES:
 		_screen.advance_frame()

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -46,7 +46,7 @@ const GROUPS: Dictionary = {
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 	&"gen1": [
 		&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle",
-		&"gen1_battle_anims",
+		&"gen1_battle_anims", &"gen1_catch",
 	],
 }
 


### PR DESCRIPTION
## Added
A ball thrown on Red, Blue or Yellow. `ItemUseBall` settles no catch rate at all, so `Gen2WorldPartyHost.gen1_ball_outcome` is the routine itself: Rand1 against the ball's own ceiling, the status subtraction, the health term W, the catch rate compare, Rand2, then `.setAnimData`'s ladder for the rocks.
`AnimateHealingMachine` behind the nurse's heal, out of the one Generation 1 `overworld_effects` record: the monitor at (44, 20), six balls in two mirrored columns from (40, 27), and `FlashSprite8Times` xoring $28 into `rOBP1`.
`CableClubNPC`, on both sides of `EVENT_GOT_POKEDEX`: the preparations line and its sixty frames, or `wLinkTimeoutCounter`'s ninety and the area-reserved line behind it.
`VendingMachineMenu`, selling `VendingPrices`' three drinks over the map with each price on the row below its drink.
`CeladonPrizeMenu`, whose three vendors show one of `PrizeDifferentMenuPtrs`' lists each, picked by their own place among the map's prize rows.
`Gen2WorldPartyHost.give_pokemon`, which is `givepoke` with no script behind it.
`tools/checks/gen1_catch.gd`, whose 2,312-case digest is the file a real cartridge writes, byte for byte on all three.
`tools/preview_world.gd`'s `vending` and `prizes` kinds.

## Changed
`Gen1Layout` carries a Blue row for anything read out of bank $1D, where the 668 symbols that move between Red and Blue live.
A Generation 1 facility step may be a counted wait carrying its own presentation event.
Cache format 109.

## Fixed
The balls a Generation 1 battle offered were Crystal's numbering, so the selector listed a TOWN MAP and not the POKe BALL beside it, and a throw was refused on a pocket byte a Generation 1 item has none of.
Elm's Lab's `bcpixel 2, 4` moved a healing machine that has one position.
`bare` skipped `preview_world.gd`'s staged settle frames and its `cut`, `fly` and `heal_machine` staging, so a bare capture of either was a picture of an empty box or an empty map.
