### PR TITLE
Fight a Generation 1 trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ godot --headless --path . -s res://tools/verify_rom.gd
 Matching uses SHA-1, never filenames. Unknown hashes are refused because an
 uncharacterised bank layout could produce corrupt assets. The three Generation 1
 cartridges import their species, move, type, item and trainer tables, every map
-and tileset, and every map text, and a wild fight on one of their maps is fought
-on the battle screen; the launcher seats one and does not offer Play until its
-map scripts are interpreted.
+and tileset, and every map text, and a wild fight, a trainer battle and a
+standing wild Pokemon on one of their maps are all fought on the battle screen;
+the launcher seats one and does not offer Play until its map scripts are
+interpreted.
 
 | Game | SHA-1 |
 |---|---|
@@ -366,7 +367,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, and all 202 or 203 battle animations |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, and all 202 or 203 battle animations |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -782,10 +782,16 @@ func init_enemy_trainer(trainer_class: int, rewarded: bool = true) -> void:
 	_gain_gym_battle_happiness(trainer_class)
 
 
+## `wAmountMoneyWon`, the three packed-decimal bytes
+## `ReadTrainerParty.LastLoop` adds `wTrainerBaseMoney` into once a level, where
+## `ComputeTrainerReward`'s `Multiply` is read two binary ones wide.
+const GEN1_REWARD_CEILING: int = 999999
+
+
 ## `ComputeTrainerReward`, which `ReadTrainerParty` runs once the whole party is
 ## in: `wCurPartyLevel` is still the last member's, so a reward is the class's
 ## base times the level of whoever the trainer sends out last rather than of
-## whoever is strongest. `Multiply`'s product is read two bytes wide.
+## whoever is strongest.
 func _compute_trainer_reward(base_reward: int) -> void:
 	battle_reward = 0
 	if base_reward <= 0:
@@ -796,7 +802,11 @@ func _compute_trainer_reward(base_reward: int) -> void:
 	var last: Gen2BattleMon = mons[mons.size() - 1]
 	if last == null:
 		return
-	battle_reward = (base_reward * last.level) & 0xFFFF
+	var product: int = base_reward * last.level
+	if data != null and data.generation == RomRegistry.GEN1:
+		battle_reward = mini(product, GEN1_REWARD_CEILING)
+		return
+	battle_reward = product & 0xFFFF
 
 
 ## `InitEnemyTrainer`'s `.partyloop`, which runs on the frame the trainer's pic

--- a/game/battle/battle_transition.gd
+++ b/game/battle/battle_transition.gd
@@ -98,18 +98,52 @@ const WEDGES: Dictionary = {
 }
 ## `BattleTransitions`, the jumptable `GetBattleTransitionID_WildOrTrainer`,
 ## `..._CompareLevels` and `..._IsDungeonMap` index with one bit each. Only the
-## four wild rows have a caller: nothing puts a Generation 1 trainer on a map,
-## and `..._Shrink` and `..._Split` move the map's own tiles rather than blacking
-## cells, so they want a screen of them.
+## circles flash; the other six open on the wipe itself.
+## `wBattleTransitionSpiralDirection` is 1 when the lead is stronger, which is
+## the trainer row that spirals inward.
 const GEN1_TRAINER_BIT: int = 1
 const GEN1_STRONGER_BIT: int = 2
 const GEN1_DUNGEON_BIT: int = 4
 const GEN1_SCENES: Dictionary = {
 	0: [&"gen1_init", &"gen1_flash", &"gen1_double_circle"],
+	GEN1_TRAINER_BIT: [&"gen1_init", &"gen1_spiral_in"],
 	GEN1_STRONGER_BIT: [&"gen1_init", &"gen1_flash", &"gen1_circle"],
+	GEN1_TRAINER_BIT | GEN1_STRONGER_BIT: [&"gen1_init", &"gen1_spiral_out"],
 	GEN1_DUNGEON_BIT: [&"gen1_init", &"gen1_stripes"],
+	GEN1_DUNGEON_BIT | GEN1_TRAINER_BIT: [&"gen1_init", &"gen1_shrink"],
 	GEN1_DUNGEON_BIT | GEN1_STRONGER_BIT: [&"gen1_init", &"gen1_stripes"],
+	GEN1_DUNGEON_BIT | GEN1_STRONGER_BIT | GEN1_TRAINER_BIT: [&"gen1_init", &"gen1_split"],
 }
+
+## `BattleTransition_InwardSpiral`: down, right, up and left from `hlcoord 0, 0`.
+const GEN1_SPIRAL_DIRECTIONS: Array[int] = [COLUMNS, 1, -COLUMNS, -1]
+const GEN1_SPIRAL_FIRST_ARM: int = ROWS - 1
+## `wInwardSpiralUpdateScreenCounter`: cells written between two `Delay3`s.
+const GEN1_SPIRAL_TRANSFER: int = 7
+
+## `BattleTransition_Spiral.outwardSpiral`: three `..._OutwardSpiral_` calls a
+## frame from `hlcoord 10, 10`. A probe past `wTileMap` never reads its tile.
+const GEN1_OUTWARD_AT := Vector2i(10, 10)
+const GEN1_OUTWARD_DIRECTION: int = 3
+const GEN1_OUTWARD_FRAMES: int = 120
+const GEN1_OUTWARD_PER_FRAME: int = 3
+## Probe, then the cell kept to, per `wOutwardSpiralCurrentDirection`.
+const GEN1_OUTWARD_STEPS: Array[Vector2i] = [
+	Vector2i(-1, -COLUMNS), Vector2i(COLUMNS, -1),
+	Vector2i(1, COLUMNS), Vector2i(-COLUMNS, 1),
+]
+
+## Both squeezes as their `BattleTransition_CopyTiles` calls.
+const GEN1_SHRINK_ROWS: Array = [[7, 8, -2], [10, 9, 2]]
+const GEN1_SHRINK_COLUMNS: Array = [[8, 9, -2], [11, 10, 2]]
+const GEN1_SPLIT_ROWS: Array = [[16, 17, -2], [1, 0, 2]]
+const GEN1_SPLIT_COLUMNS: Array = [[18, 19, -2], [1, 0, 2]]
+const GEN1_SQUEEZE_PASSES: int = ROWS / 2
+const GEN1_ROW_COPIES: int = 8
+const GEN1_COLUMN_COPIES: int = 9
+## Shrink's `ld c, 6`, which is Split's two `Delay3`s.
+const GEN1_SQUEEZE_STEP_FRAMES: int = 6
+const GEN1_SQUEEZE_END_FRAMES: int = 10
 
 ## `BattleTransition_HalfCircle1` and `...2`, with the Y quadrant their caller
 ## passes folded into [method _draw_wedge]'s own two bits: the first table is
@@ -228,6 +262,13 @@ var _sprites: int = SPRITES_ALL
 ## Which stripe plan is running, and whether this is `BattleTransition`.
 var _gen1_stripes: Array = []
 var _gen1: bool = false
+## `wTileMap` as a squeeze moves it: the cell each one draws, or -1 for black.
+var _gen1_map: PackedInt32Array = PackedInt32Array()
+## Where either spiral has reached, and which way the outward one faces.
+var _gen1_arms: Array = []
+var _gen1_arm: int = 0
+var _gen1_cursor: int = 0
+var _gen1_direction: int = 0
 var _cells: PackedByteArray = PackedByteArray()
 var _sine: PackedByteArray = PackedByteArray()
 var _rng: RandomNumberGenerator = null
@@ -280,7 +321,38 @@ static func create_gen1(index: int) -> Gen2BattleTransition:
 	out._rng = RandomNumberGenerator.new()
 	out._cells = PackedByteArray()
 	out._cells.resize(COLUMNS * ROWS)
+	out._gen1_direction = GEN1_OUTWARD_DIRECTION
+	out._gen1_arms = _gen1_spiral_arms()
+	if out._scene.has(&"gen1_spiral_out"):
+		out._gen1_cursor = GEN1_OUTWARD_AT.y * COLUMNS + GEN1_OUTWARD_AT.x
+	if out._scene.has(&"gen1_shrink") or out._scene.has(&"gen1_split"):
+		out._gen1_map.resize(COLUMNS * ROWS)
+		for cell: int in COLUMNS * ROWS:
+			out._gen1_map[cell] = cell
 	return out
+
+
+## The arms as `(direction, length)`, in the order the calls run.
+static func _gen1_spiral_arms() -> Array:
+	var arms: Array = [[0, GEN1_SPIRAL_FIRST_ARM]]
+	var arm: int = GEN1_SPIRAL_FIRST_ARM + 1
+	while true:
+		arm += 1
+		arms.append([1, arm])
+		arm -= 2
+		arms.append([2, arm])
+		arm += 1
+		arms.append([3, arm])
+		arm -= 2
+		if arm <= 0:
+			return arms
+		arms.append([0, arm])
+	return arms
+
+
+## Which screen cell each cell draws, empty for a transition moving none.
+func source_cells() -> PackedInt32Array:
+	return _gen1_map
 
 
 ## Which scene is running, for a test or a trace: a key of [constant SCENE_STEPS].
@@ -361,6 +433,9 @@ const SCENE_STEPS: Dictionary = {
 	&"gen1_circle": &"_gen1_circle_step",
 	&"gen1_double_circle": &"_gen1_double_circle_step",
 	&"gen1_stripes": &"_gen1_stripes_step",
+	&"gen1_spiral_in": &"_gen1_inward_spiral_step",
+	&"gen1_spiral_out": &"_gen1_outward_spiral_step",
+	&"gen1_shrink": &"_gen1_shrink_step", &"gen1_split": &"_gen1_split_step",
 }
 
 
@@ -559,6 +634,102 @@ func _gen1_stripes_step() -> void:
 			at += run
 	_counter += 1
 	_delay = GEN1_STEP_FRAMES - 1
+
+
+## `BattleTransition_InwardSpiral_`: seven cells, then the `Delay3` they trip.
+func _gen1_inward_spiral_step() -> void:
+	for _cell: int in GEN1_SPIRAL_TRANSFER:
+		while _gen1_arm < _gen1_arms.size() and int((_gen1_arms[_gen1_arm] as Array)[1]) <= 0:
+			_gen1_arm += 1
+		if _gen1_arm >= _gen1_arms.size():
+			_finish()
+			return
+		var arm: Array = _gen1_arms[_gen1_arm]
+		if _gen1_cursor >= 0 and _gen1_cursor < _cells.size():
+			_cells[_gen1_cursor] = CELL_BLACK
+		_gen1_cursor += GEN1_SPIRAL_DIRECTIONS[int(arm[0])]
+		arm[1] = int(arm[1]) - 1
+	_delay = GEN1_STEP_FRAMES - 1
+
+
+## Each direction turns into the cell ninety degrees off it while it is map.
+func _gen1_outward_spiral_step() -> void:
+	if _counter >= GEN1_OUTWARD_FRAMES:
+		_finish()
+		return
+	for _pass: int in GEN1_OUTWARD_PER_FRAME:
+		var steps: Vector2i = GEN1_OUTWARD_STEPS[_gen1_direction]
+		var probe: int = _gen1_cursor + steps.x
+		if _gen1_written(probe):
+			_gen1_cursor += steps.y
+		else:
+			_gen1_cursor = probe
+			_gen1_direction = (_gen1_direction + 1) % GEN1_OUTWARD_STEPS.size()
+		if _gen1_cursor >= 0 and _gen1_cursor < _cells.size():
+			_cells[_gen1_cursor] = CELL_BLACK
+	_counter += 1
+	_delay = 0
+
+
+func _gen1_written(cell: int) -> bool:
+	return cell >= 0 and cell < _cells.size() and int(_cells[cell]) == CELL_BLACK
+
+
+## `BattleTransition_Shrink`: both halves of each axis move toward the middle.
+func _gen1_shrink_step() -> void:
+	_gen1_squeeze(GEN1_SHRINK_ROWS, GEN1_SHRINK_COLUMNS)
+
+
+## `BattleTransition_Split`: the halves move apart and the middle fills.
+func _gen1_split_step() -> void:
+	_gen1_squeeze(GEN1_SPLIT_ROWS, GEN1_SPLIT_COLUMNS)
+
+
+func _gen1_squeeze(rows: Array, columns: Array) -> void:
+	if _counter >= GEN1_SQUEEZE_PASSES:
+		_delay += GEN1_SQUEEZE_END_FRAMES
+		_finish()
+		return
+	for row: Array in rows:
+		_gen1_copy(int(row[0]) * COLUMNS, int(row[1]) * COLUMNS, int(row[2]) * COLUMNS,
+			GEN1_ROW_COPIES, 1, COLUMNS)
+	for column: Array in columns:
+		_gen1_copy(int(column[0]), int(column[1]), int(column[2]),
+			GEN1_COLUMN_COPIES, COLUMNS, ROWS)
+	_gen1_publish()
+	_counter += 1
+	_delay = GEN1_SQUEEZE_STEP_FRAMES - 1
+
+
+## `BattleTransition_CopyTiles1` and `..._CopyTiles2`, one routine with two
+## strides: its `pop hl / pop de` swaps the pointers every pass, and `de` ends
+## on the run to fill.
+func _gen1_copy(
+	source: int, destination: int, offset: int, passes: int, stride: int, length: int
+) -> void:
+	for _pass: int in passes:
+		for cell: int in length:
+			_gen1_write(destination + cell * stride, _gen1_read(source + cell * stride))
+		var next: int = destination + offset
+		destination = source
+		source = next
+	for cell: int in length:
+		_gen1_write(destination + cell * stride, -1)
+
+
+func _gen1_read(cell: int) -> int:
+	return int(_gen1_map[cell]) if cell >= 0 and cell < _gen1_map.size() else -1
+
+
+func _gen1_write(cell: int, value: int) -> void:
+	if cell >= 0 and cell < _gen1_map.size():
+		_gen1_map[cell] = value
+
+
+## The filled cells, so a renderer taking no source map still draws them.
+func _gen1_publish() -> void:
+	for cell: int in _cells.size():
+		_cells[cell] = CELL_BLACK if int(_gen1_map[cell]) < 0 else CELL_NONE
 
 
 ## `.load`: a run of cells blacked out along a row, then a step back and down

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -19,6 +19,9 @@ const FIRST_TYPE_NAME: String = "NORMAL"
 const LAST_TYPE_NAME: String = "DRAGON"
 const FIRST_TRAINER_NAME: String = "YOUNGSTER"
 
+## `YoungsterData`'s first party, the Route 3 pair, as levels and dex numbers.
+const FIRST_TRAINER_PARTY: Array = [[11, 19], [11, 23]]
+
 ## Bulbasaur's whole `BaseStats` row, which says the record size and member
 ## order are both right.
 const FIRST_STATS: Array[int] = [45, 49, 49, 45, 65]
@@ -111,6 +114,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_dex_order,
 	_verify_dex_entries,
 	_verify_trainer_names,
+	_verify_trainer_parties,
 	_verify_palettes,
 	_verify_wild_constants,
 	_verify_pic_pointers,
@@ -498,6 +502,31 @@ static func _verify_trainer_names(rom: RomFile, layout: Dictionary) -> Dictionar
 	)
 	if names.size() != Gen1Layout.TRAINER_CLASS_COUNT or names[0] != FIRST_TRAINER_NAME:
 		return _fail("Trainer names open on '%s'." % (names[0] if not names.is_empty() else ""))
+	return _ok()
+
+
+## Every class points inside the table's own bank, the spans do not go back, and
+## Youngster opens on the pair Route 3 stands the player in front of.
+static func _verify_trainer_parties(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var table: int = int(layout["trainer_parties"])
+	var bank: int = RomFile.bank_of(table)
+	var end: int = int(layout["trainer_parties_end"])
+	var previous: int = table
+	for trainer_class: int in Gen1Layout.TRAINER_CLASS_COUNT:
+		var at: int = Gen1Layout.banked(
+			bank, rom.u16le(table + trainer_class * Gen1Layout.POINTER_SIZE)
+		)
+		if at < previous or at >= end:
+			return _fail("Trainer class %d's party is at $%05X." % [trainer_class + 1, at])
+		previous = at
+	var classes: Array = _read_trainer_parties(rom, layout)
+	if (classes[0] as Array).is_empty() or (classes[-1] as Array).is_empty():
+		return _fail("A trainer class at the end of the table carries no parties.")
+	var read: Array = []
+	for member: Dictionary in ((classes[0] as Array)[0] as Dictionary)["party"]:
+		read.append([int(member["level"]), int(member["species"])])
+	if read != FIRST_TRAINER_PARTY:
+		return _fail("Youngster's first party reads %s." % str(read))
 	return _ok()
 
 
@@ -1075,6 +1104,7 @@ func _import_trainers(rom: RomFile, layout: Dictionary) -> Array:
 		rom.bytes(), int(layout["trainer_names"]), Gen1Layout.TRAINER_CLASS_COUNT,
 		MAX_NAME_LENGTH,
 	)
+	var parties: Array = _read_trainer_parties(rom, layout)
 	var out: Array = []
 	for trainer_class: int in range(1, Gen1Layout.TRAINER_CLASS_COUNT + 1):
 		var row: int = int(layout["trainer_pics"]) \
@@ -1082,9 +1112,58 @@ func _import_trainers(rom: RomFile, layout: Dictionary) -> Array:
 		out.append({
 			"number": trainer_class,
 			"name": names[trainer_class - 1],
-			# `GetTrainerInformation`: times the last enemy's level.
-			"base_money": _bcd3(rom, row + Gen1Layout.POINTER_SIZE),
+			# `ReadTrainerParty.LastLoop` adds it once a level, which is what
+			# `Gen2Battle._compute_trainer_reward` multiplies.
+			"attributes": {
+				"base_reward": _bcd3(rom, row + Gen1Layout.POINTER_SIZE),
+			},
+			"trainers": parties[trainer_class - 1],
 		})
+	return out
+
+
+## `TrainerDataPointers`: one span a class, each a run of parties. A party opens
+## on one level every member shares, or on `$FF` and then a level a member.
+static func _read_trainer_parties(rom: RomFile, layout: Dictionary) -> Array:
+	var table: int = int(layout["trainer_parties"])
+	var bank: int = RomFile.bank_of(table)
+	var starts: Array[int] = []
+	for trainer_class: int in Gen1Layout.TRAINER_CLASS_COUNT:
+		starts.append(Gen1Layout.banked(
+			bank, rom.u16le(table + trainer_class * Gen1Layout.POINTER_SIZE)
+		))
+	starts.append(int(layout["trainer_parties_end"]))
+	var out: Array = []
+	for trainer_class: int in Gen1Layout.TRAINER_CLASS_COUNT:
+		out.append(_read_trainer_class_parties(
+			rom, layout, starts[trainer_class], starts[trainer_class + 1]
+		))
+	return out
+
+
+static func _read_trainer_class_parties(
+	rom: RomFile, layout: Dictionary, start: int, end: int
+) -> Array:
+	var out: Array = []
+	var at: int = start
+	while at < end:
+		var level: int = rom.u8(at)
+		at += 1
+		var party: Array = []
+		while at < end and rom.u8(at) != 0:
+			var member_level: int = level
+			if level == Gen1Layout.TRAINER_PARTY_LEVELS:
+				member_level = rom.u8(at)
+				at += 1
+			party.append({
+				"level": member_level,
+				"species": Gen1Layout.dex_of_index(rom, layout, rom.u8(at)),
+				"item": 0,
+				"moves": [],
+			})
+			at += 1
+		at += 1
+		out.append({"name": "", "type": Gen2Layout.TRAINER_MON_NORMAL, "party": party})
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -509,6 +509,21 @@ const OBJECT_ITEM_BYTES: int = 1
 ## `InitBattleEnemyParameters`' `cp OPP_ID_OFFSET`: the extra byte is this plus
 ## a trainer class, or below it a species, and the next its number or level.
 const OPPONENT_ID_OFFSET: int = 200
+## `trainer`'s twelve bytes, which a `text_asm` row's `ld hl` names: the bit
+## `TrainerFlagAction` counts off the address behind it, the range
+## `CheckSpriteCanSeePlayer` compares in pixels, then three texts and a spare.
+const TRAINER_HEADER_SIZE: int = 12
+const TRAINER_HEADER_AT: Dictionary = {
+	"flag_bit": 0, "range": 1, "flag_address": 2,
+	"before": 4, "after": 6, "end": 8,
+}
+const TRAINER_HEADER_END: int = 0xFF
+const TRAINER_RANGE_SHIFT: int = 4
+## `text_asm`, `ld hl, nn`, then either `call TalkToTrainer` or a `jr` onto one.
+const TRAINER_TEXT_ASM: int = 0x08
+const TRAINER_TEXT_LD_HL: int = 0x21
+const TRAINER_TEXT_CALL: int = 0xCD
+const TRAINER_TEXT_JR: int = 0x18
 ## `MAX_WARP_EVENTS`, `MAX_BG_EVENTS` and `MAX_OBJECT_EVENTS`.
 const MAX_WARP_EVENTS: int = 32
 const MAX_SIGN_EVENTS: int = 16
@@ -639,6 +654,9 @@ const TRAINER_CLASS_COUNT: int = 47
 ## money as three packed-decimal bytes. Every trainer picture is in the one bank
 ## the layout records, and `ChiefPic` and `ScientistPic` are the same address.
 const TRAINER_PIC_SIZE: int = 5
+## `ReadTrainerParty`'s `cp $ff`: a party opening on this stores a level in
+## front of every species instead of one for the whole team.
+const TRAINER_PARTY_LEVELS: int = 0xFF
 
 ## Sides in tiles: `_LoadTrainerPic`'s `ld a, $77`, the widest front pic, and
 ## every back pic, which `ScaleSpriteByTwo` doubles before a battle draws it.
@@ -677,6 +695,13 @@ const RED_BLUE: Dictionary = {
 	"cries": 0x39446,
 	"trainer_pics": 0x39914,
 	"trainer_pics_bank": 0x13,
+	## `TrainerDataPointers` and the `TrainerAI` that bounds the last class.
+	"trainer_parties": 0x39D3B,
+	"trainer_parties_end": 0x3A52E,
+	## What a trainer header is read through, and what one of its texts may be.
+	"talk_to_trainer": 0x31CC,
+	"print_text": 0x3C49,
+	"event_flags": 0xD747,
 	## `DisplayPokemartDialogue`'s own greeting and the head of the two facility
 	## text runs [constant MART_TEXT_AT] and its neighbour walk. Every offset
 	## here is `pokered.sym`'s, which builds both dumps.
@@ -746,6 +771,11 @@ const YELLOW: Dictionary = {
 	"cries": 0x39462,
 	"trainer_pics": 0x39893,
 	"trainer_pics_bank": 0x13,
+	"trainer_parties": 0x39DD1,
+	"trainer_parties_end": 0x3A5B2,
+	"talk_to_trainer": 0x3168,
+	"print_text": 0x3C36,
+	"event_flags": 0xD746,
 	"mart_greeting": 0x02938,
 	"mart_text": 0x06B91,
 	"pokecenter_text": 0x06ED0,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -491,6 +491,9 @@ static func _read_map(
 	if not bool(events.get("ok", false)):
 		return events
 
+	var texts: Array = _read_texts(rom, layout, bank, rom.u16le(header + 5), events)
+	_carry_trainer_headers(events["objects"], texts)
+
 	return {
 		"ok": true,
 		"group": 0,
@@ -512,7 +515,7 @@ static func _read_map(
 			"scenes": [],
 			"callbacks": [],
 		},
-		"texts": _read_texts(rom, bank, rom.u16le(header + 5), events),
+		"texts": texts,
 		"events": {
 			"bank": bank,
 			"address": rom.u16le(object_address),
@@ -708,20 +711,43 @@ static func _read_objects(
 	return {"ok": true, "events": out, "at": at}
 
 
+## The header an object's text row carries, copied onto the object so a flag
+## read reaches it without the text.
+static func _carry_trainer_headers(objects: Array, texts: Array) -> void:
+	for object: Dictionary in objects:
+		var id: int = int(object.get("text", 0))
+		if id < 1 or id > texts.size():
+			continue
+		var header: Variant = (texts[id - 1] as Dictionary).get("trainer", {})
+		if not header is Dictionary or (header as Dictionary).is_empty():
+			continue
+		## `EndTrainerBattle` hides only below `OPP_ID_OFFSET`, by that bit.
+		if not object.has("trainer_class"):
+			object["event_flag"] = int((header as Dictionary)["event_flag"])
+			continue
+		object["object_type"] = Gen2WorldObject.OBJECTTYPE_TRAINER
+		object["sight_range"] = int((header as Dictionary)["sight_range"])
+		object["trainer"] = {"event_flag": int((header as Dictionary)["event_flag"])}
+
+
 ## `<Map>_TextPointers`, which `DisplayTextID` indexes with a text id. A row is
 ## machine code; only `text_far` and `text_start` are a text, and the rest keep
 ## the byte naming them. The table has no end, so the map's own events bound it.
-static func _read_texts(rom: RomFile, bank: int, address: int, events: Dictionary) -> Array:
+static func _read_texts(
+	rom: RomFile, layout: Dictionary, bank: int, address: int, events: Dictionary
+) -> Array:
 	var table: int = Gen1Layout.banked(bank, address)
 	var out: Array = []
 	for id: int in _highest_text_id(events):
-		out.append(_read_text(rom, bank, rom.u16le(table + id * 2)))
+		out.append(_read_text(rom, layout, bank, rom.u16le(table + id * 2)))
 	return out
 
 
 ## A `TX_SCRIPT_*` row keeps its own inventory where it has one, so nothing
 ## downstream has to read the cartridge again to open the shop.
-static func _read_text(rom: RomFile, bank: int, pointer: int) -> Dictionary:
+static func _read_text(
+	rom: RomFile, layout: Dictionary, bank: int, pointer: int
+) -> Dictionary:
 	var at: int = Gen1Layout.banked(bank, pointer)
 	var decoded: Dictionary = Gen1Text.decode_stream(rom, at)
 	var row: Dictionary = {"command": rom.u8(at), "text": ""}
@@ -731,9 +757,62 @@ static func _read_text(rom: RomFile, bank: int, pointer: int) -> Dictionary:
 		elif String(decoded.get("reason", "")) != "text_script":
 			row["reason"] = String(decoded.get("reason", "invalid_text"))
 		return row
+	var header: int = _asm_operand(rom, bank, at, int(layout["talk_to_trainer"]))
+	if header >= 0:
+		row["trainer"] = _read_trainer_header(rom, layout, bank, header)
+		return row
 	row["text"] = String(decoded["text"])
 	row["prompt"] = bool(decoded.get("prompt", false))
 	return row
+
+
+## Where a `text_asm` row's `ld hl` points when the code behind it calls
+## [param target], or -1 for any other machine code. `TalkToTrainer` is 322 of
+## the corpus's 626 such rows; a map sharing one landing `jr`s onto it.
+static func _asm_operand(rom: RomFile, bank: int, at: int, target: int) -> int:
+	if rom.u8(at) != Gen1Layout.TRAINER_TEXT_ASM \
+		or rom.u8(at + 1) != Gen1Layout.TRAINER_TEXT_LD_HL:
+		return -1
+	var landing: int = at + 4
+	if rom.u8(landing) == Gen1Layout.TRAINER_TEXT_JR:
+		## `jr` counts from the byte after its own operand.
+		var hop: int = rom.u8(landing + 1)
+		landing += 2 + (hop - 0x100 if hop > 0x7F else hop)
+	if rom.u8(landing) != Gen1Layout.TRAINER_TEXT_CALL \
+		or rom.u16le(landing + 1) != target:
+		return -1
+	return Gen1Layout.banked(bank, rom.u16le(at + 2))
+
+
+## One `trainer` row. `TrainerFlagAction` counts the bit off the address two
+## bytes in, so the flag is that address's distance from `wEventFlags` in bits
+## plus the stored bit.
+static func _read_trainer_header(
+	rom: RomFile, layout: Dictionary, bank: int, at: int
+) -> Dictionary:
+	var offsets: Dictionary = Gen1Layout.TRAINER_HEADER_AT
+	var flag_address: int = rom.u16le(at + int(offsets["flag_address"]))
+	var out: Dictionary = {
+		"event_flag": (flag_address - int(layout["event_flags"])) * 8
+			+ rom.u8(at + int(offsets["flag_bit"])),
+		"sight_range": rom.u8(at + int(offsets["range"])) >> Gen1Layout.TRAINER_RANGE_SHIFT,
+	}
+	for name: String in ["before", "after", "end"]:
+		out[name] = _read_trainer_text(
+			rom, layout, bank, rom.u16le(at + int(offsets[name]))
+		)
+	return out
+
+
+## One of a header's three texts. `RocketHideoutB4FRocket3AfterBattleText` is
+## the corpus's one that is machine code, and says its `PrintText` operand.
+static func _read_trainer_text(
+	rom: RomFile, layout: Dictionary, bank: int, pointer: int
+) -> String:
+	var at: int = Gen1Layout.banked(bank, pointer)
+	var printed: int = _asm_operand(rom, bank, at, int(layout["print_text"]))
+	var decoded: Dictionary = Gen1Text.decode_stream(rom, at if printed < 0 else printed)
+	return String(decoded["text"]) if bool(decoded.get("ok", false)) else ""
 
 
 ## `script_mart`'s inline list, which `LoadItemList` copies straight out of the

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3654,6 +3654,10 @@ var _gen1_last_map: int = -1
 ## boxes are imported under.
 const GEN1_POKECENTER_RUN: String = "pokecenter"
 const GEN1_CABLE_CLUB_RUN: String = "cable_club"
+## `EndTrainerBattle`'s `cp LOST_BATTLE`, which a catch also passes.
+const GEN1_TRAINER_BEATEN: Array[StringName] = [
+	Gen2WorldBattleAdapter.OUTCOME_WON, Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
+]
 
 ## `wRivalName`, which no Generation 1 save model holds yet.
 var gen1_rival_name: String = Gen2WorldScriptRunner.UNNAMED
@@ -3704,11 +3708,14 @@ func gen1_last_map() -> int:
 func _gen1_interact() -> Array:
 	if current_map == null:
 		return []
-	var text_id: int = _gen1_text_id_at(facing_cell(), &"bg_events")
-	if text_id <= 0:
-		text_id = _gen1_text_id_at(object_facing_cell(), &"objects")
+	var event: Dictionary = _gen1_event_at(facing_cell(), &"bg_events")
+	if event.is_empty():
+		event = _gen1_event_at(object_facing_cell(), &"objects")
+	var text_id: int = int(event.get("text", 0))
 	var row: Dictionary = current_map.text_at(text_id)
-	_gen1_steps = _gen1_facility_steps(row, text_id)
+	_gen1_steps = _gen1_trainer_steps(row, event)
+	if _gen1_steps.is_empty():
+		_gen1_steps = _gen1_facility_steps(row, text_id)
 	if _gen1_steps.is_empty():
 		var text: String = Gen2TextStream.fill_names(String(row.get("text", "")), {
 			"player": _player_name if not _player_name.is_empty() \
@@ -3884,11 +3891,61 @@ func _gen1_facility_box(run: String, name: String) -> Dictionary:
 	}
 
 
-func _gen1_text_id_at(cell: Vector2i, kind: StringName) -> int:
+func _gen1_event_at(cell: Vector2i, kind: StringName) -> Dictionary:
 	for event: Dictionary in _active_events_at(cell):
 		if event.get("kind", &"") == kind and int(event.get("text", 0)) > 0:
-			return int(event["text"])
-	return 0
+			return event
+	return {}
+
+
+## `TalkToTrainer`: the flag first, then the after-battle line or the
+## before-battle one and `StartTrainerBattle`. The same header stands behind the
+## standing wild Pokemon of the Power Plant, Victory Road and the two caves.
+func _gen1_trainer_steps(row: Dictionary, event: Dictionary) -> Array:
+	var raw: Variant = row.get("trainer", {})
+	if not raw is Dictionary or (raw as Dictionary).is_empty():
+		return []
+	var header: Dictionary = raw as Dictionary
+	var flag: int = int(header["event_flag"])
+	if event_flag_active(flag):
+		return [{"type": &"text", "text": String(header["after"])}]
+	return [
+		{"type": &"text", "text": String(header["before"])},
+		{
+			"type": &"request",
+			"values": {
+				"kind": &"battle_requested",
+				"values": _gen1_battle_values(header, event),
+			},
+			"trainer_flag": flag,
+			"object_index": int(event.get("object_index", -1)),
+		},
+	]
+
+
+## `InitBattleEnemyParameters` splits the object's two bytes on `OPP_ID_OFFSET`:
+## above it a trainer class and party, below a species and a level.
+func _gen1_battle_values(header: Dictionary, event: Dictionary) -> Dictionary:
+	if not event.has("trainer_class"):
+		return {
+			"kind": &"wild",
+			"pokemon": int(event.get("species", 0)),
+			"level": int(event.get("level", 0)),
+		}
+	var trainer_class: int = int(event["trainer_class"])
+	var spoken: Dictionary = {"text": "%s: %s" % [
+		data.trainer_name(trainer_class) if data != null else "",
+		String(header["end"]),
+	]}
+	return {
+		"kind": &"trainer",
+		"trainer_group": trainer_class,
+		"trainer_class": trainer_class,
+		"trainer_id": maxi(int(event.get("trainer_number", 1)) - 1, 0),
+		"object_index": int(event.get("object_index", -1)),
+		"win_text": spoken,
+		"loss_text": spoken,
+	}
 
 
 ## A Generation 2 collision code at [param cell], or -1 on a Generation 1 map,
@@ -4074,12 +4131,25 @@ func _gen1_result() -> Array:
 
 ## Spends the head step and answers with whatever the next one waits on.
 ## [param choice] is the row a YES/NO was answered with.
-func _gen1_advance(choice: int) -> Array:
+func _gen1_advance(choice: int, result: Dictionary = {}) -> Array:
 	var step: Dictionary = _gen1_steps.pop_front()
 	if StringName(step.get("type", &"")) == &"choice":
 		var branch: Array = step.get("yes" if choice == 0 else "no", [])
 		_gen1_steps = branch.duplicate(true) + _gen1_steps
+	_gen1_battle_won(step, result)
 	return _gen1_result()
+
+
+## `EndTrainerBattle` flags a beaten opponent, and its `cp OPP_ID_OFFSET` skips
+## `HideObject` for a trainer, so only a standing wild goes off the map.
+func _gen1_battle_won(step: Dictionary, result: Dictionary) -> void:
+	var flag: int = int(step.get("trainer_flag", -1))
+	if flag < 0 or state == null:
+		return
+	if StringName(result.get("outcome", &"")) not in GEN1_TRAINER_BEATEN:
+		return
+	state.set_event_flag(flag)
+	load_object_masks()
 
 
 ## Whether the script holding the world is one that stops the map around it.
@@ -4389,7 +4459,7 @@ func complete_runtime_request(result: Dictionary) -> Array:
 	## `AfterDisplayingTextID` returns to `HandleMap` with nothing behind it, so
 	## a Generation 1 facility walks its own list instead of resuming a script.
 	if not _gen1_step(&"request").is_empty():
-		return _gen1_advance(-1)
+		return _gen1_advance(-1, result)
 	if _active_script == null:
 		return []
 	var results: Array = []

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -72,6 +72,9 @@ func set_world(world: Gen2WorldAPI, animation: Gen2WorldAnimation = null) -> voi
 ## draws them with and the palette it floods the map with, or an empty one when
 ## it floods nothing.
 var _transition_cells: PackedByteArray = PackedByteArray()
+## Which screen cell each cell draws its map tile from, for a squeeze that moves
+## `wTileMap` rather than blacking it out.
+var _transition_sources: PackedInt32Array = PackedInt32Array()
 var _transition_tiles: PackedByteArray = PackedByteArray()
 var _transition_palette: PackedColorArray = PackedColorArray()
 ## Which map objects the transition has left in OAM, and which of them is the
@@ -408,10 +411,12 @@ func _palette_tables(palettes: Array) -> Array:
 func set_transition(
 	cells: PackedByteArray, tiles: PackedByteArray, palette: PackedColorArray,
 	sprites: int = Gen2BattleTransition.SPRITES_ALL, opponent: int = -1,
-	order: int = Gen2BattleTransition.IDENTITY
+	order: int = Gen2BattleTransition.IDENTITY,
+	sources: PackedInt32Array = PackedInt32Array()
 ) -> void:
 	var was: PackedColorArray = _transition_palette
 	var was_order: int = _transition_order
+	_transition_sources = sources
 	_transition_cells = cells
 	_transition_tiles = tiles
 	_transition_palette = palette
@@ -432,6 +437,7 @@ func clear_transition() -> void:
 		return
 	var was_flooding: bool = not _transition_palette.is_empty()
 	_transition_cells = PackedByteArray()
+	_transition_sources = PackedInt32Array()
 	_transition_tiles = PackedByteArray()
 	_transition_palette = PackedColorArray()
 	_transition_sprites = Gen2BattleTransition.SPRITES_ALL
@@ -486,8 +492,12 @@ func _draw_transition(
 		)
 	for y: int in range(maxi(first.y, 0), last.y + 1):
 		for x: int in range(maxi(first.x, 0), last.x + 1):
-			var cell: int = int(_transition_cells[y * Gen2BattleTransition.COLUMNS + x])
-			if cell == Gen2BattleTransition.CELL_NONE:
+			var index: int = y * Gen2BattleTransition.COLUMNS + x
+			var cell: int = int(_transition_cells[index])
+			## A cell the squeeze filled is black whatever it was drawing before.
+			var source: int = -1 if cell == Gen2BattleTransition.CELL_BLACK \
+				else _transition_source(index)
+			if cell == Gen2BattleTransition.CELL_NONE and source < 0:
 				continue
 			var at := Rect2(
 				origin + Vector2(x * PokeTiles.TILE_WIDTH, y * PokeTiles.TILE_HEIGHT),
@@ -495,6 +505,9 @@ func _draw_transition(
 			)
 			var covered: Rect2 = at if not priority else at.intersection(clip)
 			if covered.size.x <= 0.0 or covered.size.y <= 0.0:
+				continue
+			if source >= 0:
+				_draw_moved_tile(screen_tile, source, at, covered)
 				continue
 			var palette: PackedColorArray = flood
 			if palette.is_empty():
@@ -510,6 +523,37 @@ func _draw_transition(
 			draw_texture_rect_region(
 				texture, covered, Rect2(covered.position - at.position, covered.size)
 			)
+
+
+## Where the cell at [param index] takes its map tile from, or -1 for its own.
+func _transition_source(index: int) -> int:
+	if index >= _transition_sources.size():
+		return -1
+	var source: int = int(_transition_sources[index])
+	return -1 if source < 0 or source == index else source
+
+
+## The map tile another screen cell was drawing, painted over this one.
+func _draw_moved_tile(
+	screen_tile: Vector2i, source: int, at: Rect2, covered: Rect2
+) -> void:
+	if _atlas == null:
+		return
+	@warning_ignore("integer_division")
+	var tile: int = _drawn_tile_at(
+		screen_tile.x + source % Gen2BattleTransition.COLUMNS,
+		screen_tile.y + source / Gen2BattleTransition.COLUMNS,
+	)
+	if tile < 0:
+		return
+	draw_texture_rect_region(
+		_atlas,
+		covered,
+		Rect2(
+			Vector2(tile * PokeTiles.TILE_WIDTH, 0) + (covered.position - at.position),
+			covered.size,
+		),
+	)
 
 
 ## `BATTLETRANSITION_SQUARE`, the one tile of the pair that has a pattern in it.
@@ -1140,7 +1184,8 @@ func _transition_wrote(at: Vector2) -> bool:
 		return false
 	var index: int = y * Gen2BattleTransition.COLUMNS + x
 	return index < _transition_cells.size() \
-		and int(_transition_cells[index]) != Gen2BattleTransition.CELL_NONE
+		and (int(_transition_cells[index]) != Gen2BattleTransition.CELL_NONE
+			or _transition_source(index) >= 0)
 
 
 ## The same strip as the atlas with the cartridge's transparent index left out,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4985,13 +4985,20 @@ func _build_battle_transition(request: Dictionary) -> Gen2BattleTransition:
 ## `..._CompareLevels` and `..._IsDungeonMap` over `DungeonMaps1` and
 ## `DungeonMaps2`. The level read is `wCurEnemyLevel`, this battle's own, where
 ## Crystal reads the previous fight's `wEnemyMonLevel`.
+## `wCurEnemyLevel`, which `InitBattleEnemyParameters` writes for a wild battle
+## and not for a trainer one, so the level a trainer transition is picked by is
+## whatever wild the player last met.
+var _gen1_cur_enemy_level: int = 0
+
+
 func _build_gen1_battle_transition(values: Dictionary) -> Gen2BattleTransition:
+	_gen1_cur_enemy_level = int(values.get("level", _gen1_cur_enemy_level))
 	var map_id: int = _world.current_map.number if _world.current_map != null else 0
 	var index: int = 0
 	if int(values.get("trainer_class", 0)) > 0:
 		index |= Gen2BattleTransition.GEN1_TRAINER_BIT
 	if _battle_lead_level() + Gen2BattleTransition.STRONGER_MARGIN \
-		<= int(values.get("level", 0)):
+		<= int(values.get("level", _gen1_cur_enemy_level)):
 		index |= Gen2BattleTransition.GEN1_STRONGER_BIT
 	if Gen1Layout.is_dungeon_map(map_id):
 		index |= Gen2BattleTransition.GEN1_DUNGEON_BIT
@@ -5086,6 +5093,7 @@ func _apply_battle_transition() -> void:
 		## alone, so this is the background's order and not the map fade's:
 		## the sprites standing over the wedges keep their own colours.
 		_battle_transition.palette_order(),
+		_battle_transition.source_cells(),
 	)
 
 

--- a/tests/unit/test_battle_intro.gd
+++ b/tests/unit/test_battle_intro.gd
@@ -524,11 +524,47 @@ func test_a_generation_1_wipe_opens_with_the_battlers_alone() -> void:
 	])
 
 
-## `BattleTransition_Spiral`, `..._Shrink` and `..._Split` are the four trainer
-## rows, and the last two move the map's own tiles rather than blacking cells.
-func test_the_generation_1_trainer_rows_have_no_animation_yet() -> void:
-	for index: int in [1, 3, 5, 7]:
-		assert_null(Gen2BattleTransition.create_gen1(index))
+## `BattleTransition_Spiral`'s two directions, `..._Shrink` and `..._Split`: the
+## four trainer rows, each driven to its own end the same way.
+const GEN1_TRAINER_FRAMES: Dictionary = {1: 163, 3: 130, 5: 74, 7: 74}
+
+
+func test_every_generation_1_trainer_wipe_ends_black_in_its_own_frame_count() -> void:
+	for index: int in GEN1_TRAINER_FRAMES:
+		var ran: Dictionary = _run_gen1_transition(index)
+		assert_eq(int(ran["frames"]), int(GEN1_TRAINER_FRAMES[index]),
+			"row %d spends its own frames" % index)
+		assert_eq(int(ran["black"]),
+			Gen2BattleTransition.COLUMNS * Gen2BattleTransition.ROWS,
+			"BattleTransition_BlackScreen leaves nothing showing")
+		assert_eq(int(ran["order"]), Gen2BattleTransition.GEN1_BLACK_ORDER)
+
+
+## `BattleTransition_CopyTiles1` and `..._CopyTiles2` move `wTileMap` rather than
+## writing the black tile over it, so only the two squeezes answer a source cell
+## for every cell of the screen, and only the halves that moved answer one that
+## is not their own.
+func test_only_the_two_generation_1_squeezes_move_the_map() -> void:
+	for index: int in [1, 3]:
+		assert_true(Gen2BattleTransition.create_gen1(index).source_cells().is_empty(),
+			"row %d blacks cells out" % index)
+	for index: int in [5, 7]:
+		var transition: Gen2BattleTransition = Gen2BattleTransition.create_gen1(index)
+		var seeded: PackedInt32Array = transition.source_cells()
+		assert_eq(seeded.size(), Gen2BattleTransition.COLUMNS * Gen2BattleTransition.ROWS)
+		for cell: int in seeded.size():
+			assert_eq(int(seeded[cell]), cell, "row %d opens on the map itself" % index)
+			break
+		for _step: int in 40:
+			transition.advance_frame()
+		var moved: int = 0
+		var filled: int = 0
+		for cell: int in transition.source_cells().size():
+			var source: int = int(transition.source_cells()[cell])
+			moved += 1 if source >= 0 and source != cell else 0
+			filled += 1 if source < 0 else 0
+		assert_true(moved > 0, "row %d moved the map" % index)
+		assert_true(filled > 0, "row %d filled the edge it moved off" % index)
 
 
 ## `BattleTransition_CircleData1` to `...5` are `.wedge1` to `.wedge5` byte for

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 894 lines of the 39332 here, and Generation 1 has added 732 more to the
+## are 944 lines of the 39422 here, and Generation 1 has added 772 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
-## battle animation engine and 121 the transition, the split effect routines and
-## `BlkPacket_Battle`. Seven sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39332
+## battle animation engine and 140 the transition, the split effect routines and
+## `BlkPacket_Battle`. Eight sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39422
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_pics.gd
+++ b/tools/checks/gen1_pics.gd
@@ -141,8 +141,7 @@ func _species_pics() -> void:
 func _trainer_pics() -> void:
 	var shared: Array[PackedByteArray] = []
 	for trainer_class: int in range(1, TRAINER_COUNT + 1):
-		var entry: Dictionary = _r.data.trainer(trainer_class)
-		var money: int = int(entry.get("base_money", 0))
+		var money: int = int(_r.data.trainer_attributes(trainer_class).get("base_reward", 0))
 		var pinned: int = int(PINNED_MONEY.get(trainer_class, 0))
 		if pinned > 0:
 			_r.check(money == pinned, "trainer class %d pays %d, pinned %d." % [

--- a/tools/checks/gen1_trainers.gd
+++ b/tools/checks/gen1_trainers.gd
@@ -1,0 +1,312 @@
+extends RefCounted
+
+## Every Generation 1 trainer, swept on Red, Blue and Yellow:
+## `TrainerDataPointers`' parties, the `trainer` header each `TalkToTrainer` text
+## row carries, and that routine walked on every object standing on one. The
+## counts come from pret's `data/trainers/parties.asm` and `scripts/`.
+
+## Parties and members of `TrainerDataPointers`.
+const PARTY_CENSUS: Dictionary = {
+	&"red": [391, 994], &"blue": [391, 994], &"yellow": [396, 990],
+}
+const DEEPEST_PARTY: int = 6
+const CLASS_COUNT: int = 47
+
+## `text_asm` rows, the ones reaching `TalkToTrainer`, and the objects naming
+## one: a trainer class above `OPP_ID_OFFSET`, or a standing wild below it.
+const HEADER_CENSUS: Dictionary = {
+	&"red": {"text_asm": 626, "headers": 322, "trainers": 310, "wilds": 12},
+	&"blue": {"text_asm": 626, "headers": 322, "trainers": 310, "wilds": 12},
+	&"yellow": {"text_asm": 675, "headers": 317, "trainers": 305, "wilds": 12},
+}
+
+## `view_range << 4` is a pixel distance, so the stored range is a nibble.
+const MAX_SIGHT_RANGE: int = 5
+
+## `BattleTransitions`' four trainer rows and the frames each runs to black in.
+const TRAINER_TRANSITIONS: Dictionary = {
+	Gen2BattleTransition.GEN1_TRAINER_BIT: 163,
+	Gen2BattleTransition.GEN1_TRAINER_BIT
+		| Gen2BattleTransition.GEN1_STRONGER_BIT: 130,
+	Gen2BattleTransition.GEN1_TRAINER_BIT
+		| Gen2BattleTransition.GEN1_DUNGEON_BIT: 64,
+	Gen2BattleTransition.GEN1_TRAINER_BIT | Gen2BattleTransition.GEN1_STRONGER_BIT
+		| Gen2BattleTransition.GEN1_DUNGEON_BIT: 64,
+}
+const TRANSITION_FRAME_CAP: int = 400
+
+## Route 3's first Youngster: `YoungsterData`'s opening party and the base
+## `pic_money` pays a level of.
+const FIGHT_CLASS: int = 1
+const FIGHT_INDEX: int = 0
+const FIGHT_PARTY: Array = [[11, 19], [11, 23]]
+const FIGHT_BASE_MONEY: int = 1500
+const FIGHT_LEAD: int = 1
+const FIGHT_LEAD_LEVEL: int = 50
+const FIGHT_SEED: int = 20260930
+const FIGHT_TURN_CAP: int = 64
+
+## Where the player stands to talk to an object, and which way that faces.
+const APPROACHES: Array = [
+	[Vector2i.DOWN, Gen2WorldSprite.FACING_UP],
+	[Vector2i.UP, Gen2WorldSprite.FACING_DOWN],
+	[Vector2i.RIGHT, Gen2WorldSprite.FACING_LEFT],
+	[Vector2i.LEFT, Gen2WorldSprite.FACING_RIGHT],
+]
+
+var _r: RefCounted = null
+
+
+func run(r: RefCounted) -> void:
+	_r = r
+	r.each_game_of(RomRegistry.GEN1, _one_game)
+
+
+func _one_game() -> void:
+	_the_party_table()
+	_the_headers()
+	_every_trainer_is_talked_to()
+	_a_trainer_is_beaten()
+	_the_trainer_transitions()
+
+
+## A party is never empty, never over six, and every member is a real species.
+func _the_party_table() -> void:
+	var parties: int = 0
+	var members: int = 0
+	_r.check(_r.data.trainer_count() == CLASS_COUNT,
+		"the cache holds %d trainer classes." % _r.data.trainer_count())
+	for number: int in range(1, _r.data.trainer_count() + 1):
+		var name: String = _r.data.trainer_name(number)
+		for index: int in _r.data.trainer_party_count(number):
+			var party: Array = (_r.data.trainer_party(number, index) as Dictionary)["party"]
+			parties += 1
+			members += party.size()
+			if not _r.check(not party.is_empty() and party.size() <= DEEPEST_PARTY,
+				"%s %d brings %d Pokemon." % [name, index + 1, party.size()]):
+				continue
+			for mon: Dictionary in party:
+				_r.check(int(mon["species"]) >= 1 and int(mon["species"]) <= Gen1Layout.SPECIES_COUNT,
+					"%s %d brings species %d." % [name, index + 1, int(mon["species"])])
+				_r.check(int(mon["level"]) >= 1 and int(mon["level"]) <= Gen2Layout.MAX_LEVEL,
+					"%s %d brings a level %d." % [name, index + 1, int(mon["level"])])
+	var pinned: Array = PARTY_CENSUS[_r.game_id]
+	_r.check([parties, members] == pinned,
+		"the party table reads %d parties and %d members, pinned %s." % [
+			parties, members, str(pinned),
+		])
+	_r.note("gen1 trainers %d parties, %d members" % [parties, members])
+
+
+## Every header the corpus carries, and the object each belongs to: three texts,
+## a range inside its nibble, a flag above zero, and a party that is stored.
+func _the_headers() -> void:
+	var census: Dictionary = {"text_asm": 0, "headers": 0, "trainers": 0, "wilds": 0}
+	for map: Gen2WorldMap in _r.data.world_maps():
+		for row: Dictionary in map.texts:
+			if int(row.get("command", 0)) == Gen1Layout.TRAINER_TEXT_ASM:
+				census["text_asm"] += 1
+			if row.has("trainer"):
+				census["headers"] += 1
+				_one_header(map, row["trainer"])
+		for object: Dictionary in map.events["objects"] as Array:
+			var header: Dictionary = _header_for(map, object)
+			if header.is_empty():
+				continue
+			if object.has("trainer_class"):
+				census["trainers"] += 1
+				_one_trainer_object(map, object)
+			else:
+				census["wilds"] += 1
+				_r.check(int(object.get("event_flag", 0)) == int(header["event_flag"]),
+					"map %d's standing wild wears flag %d." % [
+						map.number, int(object.get("event_flag", 0)),
+					])
+	_r.check(census == HEADER_CENSUS[_r.game_id],
+		"the header census reads %s." % str(census))
+	_r.note("gen1 trainers %d headers on %d text_asm rows" % [
+		int(census["headers"]), int(census["text_asm"]),
+	])
+
+
+func _one_header(map: Gen2WorldMap, header: Dictionary) -> void:
+	_r.check(int(header["event_flag"]) > 0,
+		"map %d has a header on flag %d." % [map.number, int(header["event_flag"])])
+	_r.check(int(header["sight_range"]) <= MAX_SIGHT_RANGE,
+		"map %d has a header seeing %d cells." % [map.number, int(header["sight_range"])])
+	for name: String in ["before", "after", "end"]:
+		_r.check(not String(header[name]).is_empty(),
+			"map %d has a header with no %s text." % [map.number, name])
+
+
+func _one_trainer_object(map: Gen2WorldMap, object: Dictionary) -> void:
+	var trainer_class: int = int(object["trainer_class"])
+	var number: int = int(object["trainer_number"])
+	if not _r.check(trainer_class >= 1 and trainer_class <= CLASS_COUNT,
+		"map %d has trainer class %d." % [map.number, trainer_class]):
+		return
+	_r.check(number >= 1 and number <= _r.data.trainer_party_count(trainer_class),
+		"map %d wants %s %d of %d." % [
+			map.number, _r.data.trainer_name(trainer_class), number,
+			_r.data.trainer_party_count(trainer_class),
+		])
+	_r.check(int(object.get("object_type", 0)) == Gen2WorldObject.OBJECTTYPE_TRAINER,
+		"map %d's trainer is object type %d." % [map.number, int(object.get("object_type", 0))])
+
+
+func _header_for(map: Gen2WorldMap, object: Dictionary) -> Dictionary:
+	var id: int = int(object.get("text", 0))
+	if id < 1 or id > map.texts.size():
+		return {}
+	var row: Dictionary = map.texts[id - 1]
+	return row["trainer"] if row.has("trainer") else {}
+
+
+## `TalkToTrainer` on every object standing on a header: the before-battle line,
+## the fight it names, and the after-battle line once its flag is on.
+func _every_trainer_is_talked_to() -> void:
+	var talked: int = 0
+	var wilds: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var world: Gen2WorldAPI = null
+		for object: Dictionary in map.events["objects"] as Array:
+			var header: Dictionary = _header_for(map, object)
+			if header.is_empty():
+				continue
+			if world == null:
+				world = _r.open_world(0, map.number, Vector2i.ZERO)
+				if world == null:
+					return
+			if not _talk_to(world, map, object, header):
+				continue
+			if object.has("trainer_class"):
+				talked += 1
+			else:
+				wilds += 1
+	var pinned: Dictionary = HEADER_CENSUS[_r.game_id]
+	_r.check(talked == int(pinned["trainers"]) and wilds == int(pinned["wilds"]),
+		"%d trainers and %d standing wilds answered." % [talked, wilds])
+
+
+func _talk_to(
+	world: Gen2WorldAPI, map: Gen2WorldMap, object: Dictionary, header: Dictionary
+) -> bool:
+	var opened: Array = _face(world, object)
+	var where: String = "map %d text %d" % [map.number, int(object.get("text", 0))]
+	if not _r.check(not opened.is_empty(), "%s said nothing." % where):
+		return false
+	if not _r.check(_event_text(opened) == String(header["before"]),
+		"%s opened with %s." % [where, _event_text(opened)]):
+		return false
+	var request: Dictionary = _request_after(world)
+	if not _r.check(_battle_matches(request, object), "%s asked for %s." % [where, str(request)]):
+		return false
+	world.complete_runtime_request({"outcome": Gen2WorldBattleAdapter.OUTCOME_WON})
+	if not _r.check(not world.script_busy(), "%s held the world after its fight." % where):
+		return false
+	if not _r.check(world.event_flag_active(int(header["event_flag"])),
+		"%s left flag %d clear." % [where, int(header["event_flag"])]):
+		return false
+	if not object.has("trainer_class"):
+		return _r.check(_face(world, object).is_empty(), "%s is still on the map." % where)
+	var again: Array = _face(world, object)
+	var answered: bool = _r.check(_event_text(again) == String(header["after"]),
+		"%s finished with %s." % [where, _event_text(again)])
+	world.run_event_queue(true)
+	return answered
+
+
+## The first of the four cells around an object that opens a box. Nothing is
+## walked, so a wall is as good as a path.
+func _face(world: Gen2WorldAPI, object: Dictionary) -> Array:
+	var cell := Vector2i(int(object["x"]), int(object["y"]))
+	for approach: Array in APPROACHES:
+		world.player_cell = cell + (approach[0] as Vector2i)
+		world.player_facing = int(approach[1])
+		var opened: Array = world.interact()
+		if not opened.is_empty():
+			return opened
+	return []
+
+
+## What the box is waiting on, once `AfterDisplayingTextID`'s press is spent.
+func _request_after(world: Gen2WorldAPI) -> Dictionary:
+	world.run_event_queue(true)
+	return world.pending_runtime_request()
+
+
+func _battle_matches(request: Dictionary, object: Dictionary) -> bool:
+	if StringName(request.get("kind", &"")) != &"battle_requested":
+		return false
+	var values: Dictionary = request.get("values", {})
+	if not object.has("trainer_class"):
+		return StringName(values.get("kind", &"")) == &"wild" \
+			and int(values.get("pokemon", 0)) == int(object.get("species", 0)) \
+			and int(values.get("level", 0)) == int(object.get("level", 0))
+	return StringName(values.get("kind", &"")) == &"trainer" \
+		and int(values.get("trainer_group", 0)) == int(object["trainer_class"]) \
+		and int(values.get("trainer_id", -1)) == int(object["trainer_number"]) - 1
+
+
+## That fight run to its last faint: `ReadTrainerParty` brings the stored party
+## and `.LastLoop` pays the class's base once a level of the last member.
+func _a_trainer_is_beaten() -> void:
+	var party: Array = (_r.data.trainer_party(FIGHT_CLASS, FIGHT_INDEX) as Dictionary)["party"]
+	var read: Array = []
+	for mon: Dictionary in party:
+		read.append([int(mon["level"]), int(mon["species"])])
+	if not _r.check(read == FIGHT_PARTY, "%s 1 brings %s." % [
+		_r.data.trainer_name(FIGHT_CLASS), str(read),
+	]):
+		return
+	var enemy: Gen2Party = Gen2TrainerParty.build(_r.data, FIGHT_CLASS, FIGHT_INDEX)
+	var generator := RandomNumberGenerator.new()
+	generator.seed = FIGHT_SEED
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_r.data,
+		Gen2Party.create([Gen2BattleMon.create(
+			_r.data, FIGHT_LEAD, FIGHT_LEAD_LEVEL,
+			_r.data.moves_at_level(FIGHT_LEAD, FIGHT_LEAD_LEVEL)
+		)]),
+		enemy, generator, true, 0
+	)
+	if not _r.check(battle != null, "the trainer fight could not be built."):
+		return
+	battle.init_enemy_trainer(FIGHT_CLASS, true)
+	var owed: int = FIGHT_BASE_MONEY * int(FIGHT_PARTY[-1][0])
+	_r.check(battle.battle_reward == owed,
+		"the fight pays %d, not %d." % [battle.battle_reward, owed])
+	var turns: int = 0
+	while not battle.is_over() and turns < FIGHT_TURN_CAP:
+		if battle.mon(Gen2Battle.ENEMY).is_fainted():
+			## `ReplaceFaintedEnemyMon`, which the screen owns in a real fight.
+			battle.send_out(Gen2Battle.ENEMY, enemy.first_healthy())
+			continue
+		battle.take_turn(0, 0)
+		turns += 1
+	_r.check(battle.winner() == Gen2Battle.PLAYER,
+		"the trainer fight ended on %s after %d turns." % [battle.winner(), turns])
+
+
+## Each of those rows run to `BlackScreen`.
+func _the_trainer_transitions() -> void:
+	for index: int in TRAINER_TRANSITIONS:
+		var transition: Gen2BattleTransition = Gen2BattleTransition.create_gen1(index)
+		if not _r.check(transition != null, "transition %d has no scene." % index):
+			continue
+		var frames: int = 0
+		while not transition.finished() and frames < TRANSITION_FRAME_CAP:
+			transition.advance_frame()
+			frames += 1
+		_r.check(frames == int(TRAINER_TRANSITIONS[index]),
+			"transition %d ran %d frames, pinned %d." % [
+				index, frames, int(TRAINER_TRANSITIONS[index]),
+			])
+		_r.check(transition.palette_order() == Gen2BattleTransition.GEN1_BLACK_ORDER,
+			"transition %d ended on order $%02X." % [index, transition.palette_order()])
+
+
+func _event_text(results: Array) -> String:
+	if results.is_empty():
+		return ""
+	return String((results[0].get("event", {}) as Dictionary).get("text", ""))

--- a/tools/checks/gen1_trainers.gd.uid
+++ b/tools/checks/gen1_trainers.gd.uid
@@ -1,0 +1,1 @@
+uid://b5ykvrihemi8c

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -28,6 +28,7 @@ const KIND_HELP: Dictionary = {
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
+	&"trainer": "presses, frames: TalkToTrainer on the map's first trainer, faced from the cell below. 0 the before-battle box, 1 the fight the press behind it opens; a second number stops that many frames into the transition instead",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
 	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
@@ -403,6 +404,7 @@ const STAGERS: Dictionary = {
 	&"mod_page": &"_stage_mod_page",
 	&"pokepic": &"_stage_pokepic",
 	&"sign": &"_stage_sign",
+	&"trainer": &"_stage_trainer",
 	&"nurse": &"_stage_nurse",
 	&"vending": &"_stage_vending",
 	&"prizes": &"_stage_prizes",
@@ -906,6 +908,32 @@ func _stage_mod_page() -> void:
 
 func _stage_pokepic() -> void:
 	_screen.preview_pokepic(POKEPIC_SPECIES)
+
+
+## `TalkToTrainer` on the first trainer the map carries, stood below and faced.
+## One press opens the fight; a frame count stops inside `BattleTransition`.
+func _stage_trainer() -> void:
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world == null or world.current_map == null:
+		return
+	for object: Gen2WorldObject in world.objects:
+		if object.object_type != Gen2WorldObject.OBJECTTYPE_TRAINER:
+			continue
+		world.player_cell = object.cell + Vector2i.DOWN
+		break
+	_screen.press_button(PokeButton.UP)
+	for _frame: int in TEXT_SETTLE_FRAMES:
+		_screen.advance_frame()
+	_screen.interact()
+	for _frame: int in BOX_REVEAL_FRAMES:
+		_screen.advance_frame()
+	if _cell.x <= 0:
+		return
+	_screen.press_button(PokeButton.A)
+	for _frame: int in maxi(_cell.y, TEXT_SETTLE_FRAMES):
+		_screen.advance_frame()
+	if _cell.y <= 0:
+		_screen.settle_battle_transition()
 
 
 ## `DisplayTextID`'s box, read by facing the cell above the `x y` argument.

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -46,7 +46,7 @@ const GROUPS: Dictionary = {
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 	&"gen1": [
 		&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle",
-		&"gen1_battle_anims", &"gen1_catch",
+		&"gen1_battle_anims", &"gen1_catch", &"gen1_trainers",
 	],
 }
 


### PR DESCRIPTION
## Added
322 of Red and Blue's 626 `text_asm` rows and 317 of Yellow's 675 are `TalkToTrainer`, a fixed byte shape rather than machine code: `text_asm`, `ld hl, <header>`, then a `call` or a `jr` onto a landing that calls. `Gen1WorldImporter._asm_operand` reads that operand and decodes the `trainer` macro's twelve bytes behind it: the event flag, the view range and the before, after and end-battle texts.
`Gen2WorldAPI._gen1_trainer_steps` is `TalkToTrainer` itself. A beaten trainer says its after-battle line; one who has not says its before-battle line and then `StartTrainerBattle`, and `EndTrainerBattle` sets the flag on the way out. 310 objects on Red and Blue and 305 on Yellow stand on a header; the other 12 are the standing wild Pokemon of the Power Plant, Victory Road and the two caves, which share the header and whose flag is their own mask, so a beaten one goes off the map where a beaten trainer stays.
`TrainerDataPointers` is imported: 391 parties and 994 members on Red and Blue, 396 and 990 on Yellow. `pic_money`'s `bcd3` is the `base_reward` `ComputeTrainerReward` multiplies, held to `wAmountMoneyWon`'s three packed-decimal bytes.
`BattleTransitions`' four trainer rows animate: `BattleTransition_Spiral` both ways about, `..._Shrink` and `..._Split`. The two squeezes move `wTileMap` rather than blacking cells, so `Gen2BattleTransition.source_cells` answers which screen cell each cell draws and `Gen2WorldRenderer` paints the map tile from there.
`tools/checks/gen1_trainers.gd` sweeps all three cartridges: every party, every header, and `TalkToTrainer` walked on all 322 or 317 objects that stand on one. `tools/preview_world.gd`'s new `trainer` kind photographs the box, the wipe and the fight.

## Fixed
`RocketHideoutB4FRocket3AfterBattleText` said nothing: it is the corpus's one header text that is itself machine code, printing its own `.Text` before it reveals the LIFT KEY. The `PrintText` operand is read the same way `TalkToTrainer`'s is.