### PR TITLE
See a Generation 1 trainer and be walked up to

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -340,13 +340,26 @@ const FRAME_VERTICAL_ROW: int = 0b00101000
 ## `PokeCenterFlashingMonitorAndHealBall`: the monitor and one ball.
 ## `AnimateHealingMachine` copies three tiles where the sheet is two, so the
 ## third is `PokeCenterOAMData` read as pixels at $7e, which nothing draws.
-const HEAL_MACHINE_TILES: int = 2
 const HEAL_MACHINE_VTILE: int = 0x7C
 const HEAL_MACHINE_BYTES: Array[int] = [
 	0x00, 0x00, 0x00, 0x00, 0x7E, 0x00, 0x7E, 0x00,
 	0x7E, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C, 0x12, 0x1E,
 	0x21, 0x3F, 0x33, 0x2D, 0x1E, 0x12, 0x0C, 0x0C,
+]
+
+## `ShockEmote`, at the $F8 `EmotionBubblesOAMBlock` names. It is the one
+## `EmotionBubbles` row with a caller: `CheckFightingMapTrainers`.
+const SHOCK_EMOTE_VTILE: int = 0xF8
+const SHOCK_EMOTE_BYTES: Array[int] = [
+	0x1F, 0x00, 0x3F, 0x1F, 0x7F, 0x20, 0xFF, 0x41,
+	0xFF, 0x41, 0xFF, 0x41, 0xFF, 0x41, 0xFF, 0x41,
+	0xF8, 0x00, 0xFC, 0xF8, 0xFE, 0x04, 0xFF, 0x82,
+	0xFF, 0x82, 0xFF, 0x82, 0xFF, 0x82, 0xFF, 0x82,
+	0xFF, 0x40, 0xFF, 0x41, 0xFF, 0x41, 0x7F, 0x20,
+	0x3F, 0x1F, 0x1F, 0x00, 0x01, 0x00, 0x01, 0x00,
+	0xFF, 0x02, 0xFF, 0x82, 0xFF, 0x82, 0xFE, 0x04,
+	0xFC, 0xF8, 0xF8, 0xC0, 0xC0, 0x80, 0x80, 0x00,
 ]
 
 ## `PokeCenterOAMData`'s seven rows as the cartridge stores them: y, x, tile and
@@ -506,6 +519,28 @@ const OBJECT_ITEM_FLAG: int = 0x80
 const OBJECT_TEXT_MASK: int = 0x3F
 const OBJECT_TRAINER_BYTES: int = 2
 const OBJECT_ITEM_BYTES: int = 1
+## `object_event`'s two movement bytes as one shared template. Byte 1 is WALK or
+## STAY; byte 2 is a fixed direction, the axis a random walk keeps to, or
+## `BOULDER_MOVEMENT_BYTE_2`. A STAY sprite still turns, because `TryWalking`
+## writes the facing before `CanWalkOntoTile` refuses its step.
+const OBJECT_MOVEMENT_STAY: int = 0xFF
+const OBJECT_STANDING_MOVEMENTS: Dictionary = {
+	0x10: Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER,
+	0xD0: Gen2WorldObject.MOVEMENT_FIXED_DOWN,
+	0xD1: Gen2WorldObject.MOVEMENT_FIXED_UP,
+	0xD2: Gen2WorldObject.MOVEMENT_FIXED_LEFT,
+	0xD3: Gen2WorldObject.MOVEMENT_FIXED_RIGHT,
+}
+const OBJECT_WALKING_MOVEMENTS: Dictionary = {
+	0x01: Gen2WorldObject.MOVEMENT_WALK_UP_DOWN,
+	0x02: Gen2WorldObject.MOVEMENT_WALK_LEFT_RIGHT,
+}
+## `CanWalkOntoTile`'s two displacement counters, $8 apiece at map load and the
+## whole of a wanderer's band. Down and right are never refused, up stops at 0,
+## and the vertical test also stands in front of a sideways step, so an object
+## that walked five cells up can only keep going up.
+const OBJECT_WALK_ORIGIN: int = 8
+const OBJECT_WALK_FLOOR: int = 5
 ## `InitBattleEnemyParameters`' `cp OPP_ID_OFFSET`: the extra byte is this plus
 ## a trainer class, or below it a species, and the next its number or level.
 const OPPONENT_ID_OFFSET: int = 200
@@ -728,6 +763,7 @@ const RED_BLUE: Dictionary = {
 	"water_tilesets": 0x0E8E0,
 	"overworld_sprites": 0x17B27,
 	"heal_machine_gfx": 0x704B7,
+	"shock_emote_gfx": 0x17CBD,
 	"wild_data": 0x0CEEB,
 	"wild_chances": 0x13918,
 	"good_rod": 0x0E27F,
@@ -800,6 +836,7 @@ const YELLOW: Dictionary = {
 	"water_tilesets": 0x0E834,
 	"overworld_sprites": 0x142A9,
 	"heal_machine_gfx": 0x7050B,
+	"shock_emote_gfx": 0x411E5,
 	"wild_data": 0x0CB95,
 	"wild_chances": 0x138E2,
 	"good_rod": 0x0E12C,
@@ -1082,6 +1119,15 @@ static func tileset_offset(layout: Dictionary, number: int) -> int:
 
 static func map_song_offset(layout: Dictionary, map_id: int) -> int:
 	return int(layout["map_songs"]) + map_id * MAP_SONG_SIZE
+
+
+## An unlisted byte 2 leaves the direction to `Random`, standing or walking.
+static func object_movement(byte_1: int, byte_2: int) -> int:
+	if byte_1 == OBJECT_MOVEMENT_STAY:
+		return OBJECT_STANDING_MOVEMENTS.get(
+			byte_2, Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW
+		)
+	return OBJECT_WALKING_MOVEMENTS.get(byte_2, Gen2WorldObject.MOVEMENT_WANDER)
 
 
 ## Whether the Super Rod is read as Yellow's flat slot table.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -124,36 +124,60 @@ static func read_world(
 	}
 
 
-## `PokeCenterFlashingMonitorAndHealBall` and `PokeCenterOAMData` behind it, the
-## one effect Generation 1 draws over the map. Both are checked against the bytes
-## the pinned sources build, so a moved offset is refused rather than decoded.
+## `PokeCenterFlashingMonitorAndHealBall` with `PokeCenterOAMData` behind it, and
+## `ShockEmote`: the two sheets Generation 1 draws over the map.
 static func _read_overworld_effects(rom: RomFile, layout: Dictionary) -> Dictionary:
-	var at: int = int(layout.get("heal_machine_gfx", -1))
-	var bytes: int = Gen1Layout.HEAL_MACHINE_TILES * PokeTiles.TILE_BYTES
-	var oam: int = Gen1Layout.HEAL_MACHINE_OAM.size() * Gen1Layout.HEAL_MACHINE_OAM_SIZE
-	if at < 0 or not rom.in_bounds(at, bytes + oam):
-		return _error("The heal machine graphics are outside the cartridge.")
-	if rom.slice(at, bytes) != PackedByteArray(Gen1Layout.HEAL_MACHINE_BYTES):
-		return _error("The heal machine sheet is not the monitor and its ball.")
+	var machine: Dictionary = _read_pinned_sheet(
+		rom, int(layout.get("heal_machine_gfx", -1)),
+		Gen1Layout.HEAL_MACHINE_BYTES, Gen1Layout.HEAL_MACHINE_VTILE, "heal_machine"
+	)
+	if not bool(machine.get("ok", false)):
+		return machine
+	var oam: Dictionary = _check_heal_machine_oam(
+		rom, int(layout["heal_machine_gfx"]) + Gen1Layout.HEAL_MACHINE_BYTES.size()
+	)
+	if not bool(oam.get("ok", false)):
+		return oam
+	var shock: Dictionary = _read_pinned_sheet(
+		rom, int(layout.get("shock_emote_gfx", -1)),
+		Gen1Layout.SHOCK_EMOTE_BYTES, Gen1Layout.SHOCK_EMOTE_VTILE, "shock"
+	)
+	if not bool(shock.get("ok", false)):
+		return shock
+	return {"ok": true, "effects": [machine["effect"], shock["effect"]]}
+
+
+## One sheet, refused rather than decoded once the pinned bytes have moved.
+static func _read_pinned_sheet(
+	rom: RomFile, at: int, pinned: Array[int], vtile: int, name: String
+) -> Dictionary:
+	if at < 0 or not rom.in_bounds(at, pinned.size()) \
+		or rom.slice(at, pinned.size()) != PackedByteArray(pinned):
+		return _error("The %s sheet is not at $%X." % [name, at])
+	@warning_ignore("integer_division")
+	var tiles: int = pinned.size() / PokeTiles.TILE_BYTES
+	var pixels: PackedByteArray = PokeTiles.decode_2bpp_strip(
+		rom.slice(at, pinned.size()), 0, tiles
+	)
+	if pixels.size() != tiles * PokeTiles.TILE_PIXELS:
+		return _error("The %s sheet did not decode." % name)
+	return {"ok": true, "effect": {
+		"name": name, "tiles": tiles, "vtile": vtile, "bytes": Array(pixels),
+	}}
+
+
+static func _check_heal_machine_oam(rom: RomFile, at: int) -> Dictionary:
 	for row: int in Gen1Layout.HEAL_MACHINE_OAM.size():
-		var entry: int = at + bytes + row * Gen1Layout.HEAL_MACHINE_OAM_SIZE
+		var entry: int = at + row * Gen1Layout.HEAL_MACHINE_OAM_SIZE
 		var pinned: Array = Gen1Layout.HEAL_MACHINE_OAM[row]
+		if not rom.in_bounds(entry, Gen1Layout.HEAL_MACHINE_OAM_SIZE):
+			return _error("Heal machine OAM row %d is outside the cartridge." % row)
 		## The attribute byte carries a Game Boy Color palette on Yellow and not
 		## on Red or Blue, so only the flip is compared.
 		var flipped: bool = (rom.u8(entry + 3) & Gen1Layout.HEAL_MACHINE_OAM_XFLIP) != 0
 		if [rom.u8(entry), rom.u8(entry + 1), rom.u8(entry + 2), flipped] != pinned:
 			return _error("Heal machine OAM row %d is not %s." % [row, pinned])
-	var pixels: PackedByteArray = PokeTiles.decode_2bpp_strip(
-		rom.slice(at, bytes), 0, Gen1Layout.HEAL_MACHINE_TILES
-	)
-	if pixels.size() != Gen1Layout.HEAL_MACHINE_TILES * PokeTiles.TILE_PIXELS:
-		return _error("The heal machine graphics did not decode.")
-	return {"ok": true, "effects": [{
-		"name": "heal_machine",
-		"tiles": Gen1Layout.HEAL_MACHINE_TILES,
-		"vtile": Gen1Layout.HEAL_MACHINE_VTILE,
-		"bytes": Array(pixels),
-	}]}
+	return {"ok": true}
 
 
 static func _error(message: String) -> Dictionary:
@@ -688,8 +712,7 @@ static func _read_objects(
 			"sprite": rom.u8(at),
 			"y": rom.u8(at + 1) - Gen1Layout.OBJECT_COORD_BIAS,
 			"x": rom.u8(at + 2) - Gen1Layout.OBJECT_COORD_BIAS,
-			"movement": rom.u8(at + 3),
-			"range": rom.u8(at + 4),
+			"movement": Gen1Layout.object_movement(rom.u8(at + 3), rom.u8(at + 4)),
 			"text": text & Gen1Layout.OBJECT_TEXT_MASK,
 		}
 		at += Gen1Layout.OBJECT_EVENT_SIZE
@@ -721,13 +744,15 @@ static func _carry_trainer_headers(objects: Array, texts: Array) -> void:
 		var header: Variant = (texts[id - 1] as Dictionary).get("trainer", {})
 		if not header is Dictionary or (header as Dictionary).is_empty():
 			continue
-		## `EndTrainerBattle` hides only below `OPP_ID_OFFSET`, by that bit.
-		if not object.has("trainer_class"):
-			object["event_flag"] = int((header as Dictionary)["event_flag"])
-			continue
+		var flag: int = int((header as Dictionary)["event_flag"])
 		object["object_type"] = Gen2WorldObject.OBJECTTYPE_TRAINER
 		object["sight_range"] = int((header as Dictionary)["sight_range"])
-		object["trainer"] = {"event_flag": int((header as Dictionary)["event_flag"])}
+		## `EndTrainerBattle` hides only below `OPP_ID_OFFSET`, by that bit, and
+		## `CheckForEngagingTrainers` walks both kinds of row alike.
+		if object.has("trainer_class"):
+			object["trainer"] = {"event_flag": flag}
+		else:
+			object["event_flag"] = flag
 
 
 ## `<Map>_TextPointers`, which `DisplayTextID` indexes with a text id. A row is

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 109
+const FORMAT_VERSION: int = 110
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -104,6 +104,13 @@ const IDLE_PASSES_WRAP: int = 256
 ## four cells into the ten by nine `wXCoord`/`wYCoord` name. Inclusive.
 const OBJECT_SCREEN_MIN: Vector2i = Vector2i(-4, -4)
 const OBJECT_SCREEN_MAX: Vector2i = Vector2i(5, 4)
+## A facing as the step it walks, which is also the axis its sight line runs on.
+const SIGHT_STEPS: Dictionary = {
+	Gen2WorldSprite.FACING_DOWN: Vector2i.DOWN,
+	Gen2WorldSprite.FACING_UP: Vector2i.UP,
+	Gen2WorldSprite.FACING_LEFT: Vector2i.LEFT,
+	Gen2WorldSprite.FACING_RIGHT: Vector2i.RIGHT,
+}
 
 ## Crystal background event types from script_constants.asm. READ and the four
 ## facing variants point directly at a script. IFSET and IFNOTSET point at a
@@ -4069,6 +4076,8 @@ func dispatch_script_events(cell: Vector2i = player_cell) -> Array:
 ## cartridge's trainer scan order. A trainer sees only along its facing axis,
 ## and a nonzero event flag prevents the encounter from being queued.
 func dispatch_sight_events() -> Array:
+	if _gen1:
+		return _gen1_sight()
 	if _active_script != null or not _script_queue.is_empty():
 		return run_event_queue(false)
 	var request: Dictionary = _find_sight_request()
@@ -4076,6 +4085,32 @@ func dispatch_sight_events() -> Array:
 		return []
 	_enqueue_script(request)
 	return run_event_queue(false)
+
+
+## `CheckFightingMapTrainers`: the shock bubble and `TrainerWalkUpToPlayer` in
+## front of `DisplayEnemyTrainerTextAndStartBattle`, which is `TalkToTrainer`
+## with BIT_SEEN_BY_TRAINER already set and so opens on the before-battle line.
+func _gen1_sight() -> Array:
+	if _gen1_holding():
+		return []
+	var request: Dictionary = _find_sight_request()
+	if request.is_empty():
+		return []
+	var event: Dictionary = request["event"]
+	var steps: Array = _gen1_trainer_steps(
+		current_map.text_at(int(event.get("text", 0))), event
+	)
+	if steps.is_empty():
+		return []
+	_gen1_steps = [{"type": &"request", "values": {
+		"kind": &"trainer_approach_requested",
+		"values": {
+			"object_index": int(request["object_index"]),
+			"direction": request["direction"],
+			"distance": int(request["distance"]),
+		},
+	}}] + steps
+	return _gen1_result()
 
 
 func script_input_waiting() -> bool:
@@ -6110,7 +6145,7 @@ func _decide_object_movement(object: Gen2WorldObject, random: RandomNumberGenera
 	# refused step still turns the object.
 	object.apply_direction(direction)
 	var destination: Vector2i = object.cell + direction
-	if not object.can_leave_to(destination) \
+	if not _object_may_leave(object, destination, direction) \
 		or not _object_stays_on_screen(destination) \
 		or not can_object_walk_to(destination, object, direction):
 		# _RandomWalkContinue's .new_duration branch: a blocked object keeps its
@@ -6147,6 +6182,23 @@ func _decide_object_spin(object: Gen2WorldObject, random: RandomNumberGenerator)
 func _rolled_idle_passes(random: RandomNumberGenerator, mask: int) -> int:
 	var rolled: int = random.randi() & mask
 	return rolled if rolled > 0 else IDLE_PASSES_WRAP
+
+
+## The movement radius in Generation 2, and in Generation 1 the displacement
+## counters of [constant Gen1Layout.OBJECT_WALK_ORIGIN], which the distance the
+## object has come carries: each accepted step moves both alike.
+func _object_may_leave(
+	object: Gen2WorldObject, destination: Vector2i, direction: Vector2i
+) -> bool:
+	if not _gen1:
+		return object.can_leave_to(destination)
+	var walked: Vector2i = object.cell - object.initial_cell \
+		+ Vector2i(Gen1Layout.OBJECT_WALK_ORIGIN, Gen1Layout.OBJECT_WALK_ORIGIN)
+	if direction.y < 0:
+		return walked.y > 0
+	if walked.y + direction.y < Gen1Layout.OBJECT_WALK_FLOOR:
+		return false
+	return direction.x >= 0 or walked.x > 0
 
 
 ## `IsObjectMovingOffEdgeOfScreen`, the refusal beside the movement radius in
@@ -7948,7 +8000,7 @@ func _find_sight_request() -> Dictionary:
 	for object: Gen2WorldObject in objects:
 		if not object.active \
 			or object.object_type != Gen2WorldObject.OBJECTTYPE_TRAINER \
-			or object.sight_range <= 0 or object.event_script <= 0:
+			or object.sight_range <= 0 or (object.event_script <= 0 and not _gen1):
 			continue
 		if object.event_flag_active(state) or object.trainer_flag_active(state):
 			continue
@@ -7981,21 +8033,12 @@ func _find_sight_request() -> Dictionary:
 
 
 func _sight_distance(object: Gen2WorldObject) -> Dictionary:
+	var step: Vector2i = SIGHT_STEPS.get(object.facing, Vector2i.ZERO)
 	var delta: Vector2i = player_cell - object.cell
-	var direction: Vector2i = Vector2i.ZERO
-	match object.facing:
-		Gen2WorldSprite.FACING_DOWN:
-			if delta.x == 0 and delta.y > 0:
-				direction = Vector2i.DOWN
-		Gen2WorldSprite.FACING_UP:
-			if delta.x == 0 and delta.y < 0:
-				direction = Vector2i.UP
-		Gen2WorldSprite.FACING_LEFT:
-			if delta.y == 0 and delta.x < 0:
-				direction = Vector2i.LEFT
-		Gen2WorldSprite.FACING_RIGHT:
-			if delta.y == 0 and delta.x > 0:
-				direction = Vector2i.RIGHT
-	if direction == Vector2i.ZERO:
+	if step == Vector2i.ZERO \
+		or (delta.x != 0 and step.x == 0) or (delta.y != 0 and step.y == 0):
 		return {}
-	return {"distance": absi(delta.x) + absi(delta.y), "direction": direction}
+	var reach: int = delta.x * step.x + delta.y * step.y
+	if reach <= 0:
+		return {}
+	return {"distance": absi(reach), "direction": step}

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -155,12 +155,12 @@ static func _events_from_cache(value: Variant) -> Dictionary:
 		"bg_events": _event_rows(
 			event_values.get("bg_events", []), ["x", "y", "type", "script", "text"]
 		),
-		# The last seven are Generation 1's, whose events carry a text id where
+		# The last six are Generation 1's, whose events carry a text id where
 		# Generation 2's carry a script pointer.
 		"objects": _event_rows(event_values.get("objects", []), [
 			"sprite", "x", "y", "movement", "x_radius", "y_radius", "hour_1", "hour_2",
 			"palette", "object_type", "sight_range", "script", "event_flag",
-			"range", "text", "trainer_class", "trainer_number", "species", "level", "item",
+			"text", "trainer_class", "trainer_number", "species", "level", "item",
 		]),
 	}
 

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -495,3 +495,21 @@ func test_the_dungeon_list_is_the_one_the_transition_reads() -> void:
 	for map_id: int in [0x00, 0x3A, 0x3E, 0x5E, 0x77, 0x53, 0x9F, 0xA5, 0xC2,
 		0xC5, 0xE9]:
 		assert_false(Gen1Layout.is_dungeon_map(map_id), "map $%02X is not" % map_id)
+
+
+## `object_event`'s two bytes: STAY plus a direction stands fixed, STAY plus
+## anything else turns at random, and WALK picks the axis it wanders on.
+func test_the_two_movement_bytes_decode_to_one_template() -> void:
+	assert_eq(Gen1Layout.object_movement(0xFF, 0xD0), Gen2WorldObject.MOVEMENT_FIXED_DOWN)
+	assert_eq(Gen1Layout.object_movement(0xFF, 0xD1), Gen2WorldObject.MOVEMENT_FIXED_UP)
+	assert_eq(Gen1Layout.object_movement(0xFF, 0xD2), Gen2WorldObject.MOVEMENT_FIXED_LEFT)
+	assert_eq(Gen1Layout.object_movement(0xFF, 0xD3), Gen2WorldObject.MOVEMENT_FIXED_RIGHT)
+	assert_eq(Gen1Layout.object_movement(0xFF, 0x10), Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER)
+	## ANY_DIR and NONE, the two a standing sprite spins on.
+	assert_eq(Gen1Layout.object_movement(0xFF, 0x00), Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW)
+	assert_eq(Gen1Layout.object_movement(0xFF, 0xFF), Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW)
+	assert_eq(Gen1Layout.object_movement(0xFE, 0x00), Gen2WorldObject.MOVEMENT_WANDER)
+	assert_eq(Gen1Layout.object_movement(0xFE, 0x01), Gen2WorldObject.MOVEMENT_WALK_UP_DOWN)
+	assert_eq(Gen1Layout.object_movement(0xFE, 0x02), Gen2WorldObject.MOVEMENT_WALK_LEFT_RIGHT)
+	## A fixed direction only stands a sprite still while byte 1 says STAY.
+	assert_eq(Gen1Layout.object_movement(0xFE, 0xD0), Gen2WorldObject.MOVEMENT_WANDER)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 944 lines of the 39422 here, and Generation 1 has added 772 more to the
+## are 968 lines of the 39453 here, and Generation 1 has added 779 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 140 the transition, the split effect routines and
 ## `BlkPacket_Battle`. Eight sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39422
+const MAX_COMMENT_LINES: int = 39453
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -9828,6 +9828,7 @@ func _write_gen1_cache() -> void:
 			"map_number": Gen1Layout.WARP_TO_LAST_MAP,
 		}]),
 		_gen1_map(2, 3, 2, 2, GEN1_FOREST_CELLS, []),
+		_gen1_wander_map(),
 	])
 	var pixels := PackedByteArray()
 	pixels.resize(96 * PokeTiles.TILE_PIXELS)
@@ -9855,6 +9856,20 @@ func _gen1_map(
 		"connection_flags": 0, "connections": [],
 		"events": {"warps": warps, "coord_events": [], "bg_events": [], "objects": []},
 	}
+
+
+## Map 3: a clear four by twelve floor with one object walking its own column,
+## which is room for the eight cells `CanWalkOntoTile` lets it climb.
+func _gen1_wander_map() -> Dictionary:
+	var cells: Array[int] = []
+	for _cell: int in 4 * 12:
+		cells.append(GEN1_FLOOR)
+	var map: Dictionary = _gen1_map(3, Gen1Layout.TILESET_OVERWORLD, 2, 6, cells, [])
+	(map["events"] as Dictionary)["objects"] = [{
+		"sprite": 1, "x": 1, "y": 9, "text": 1,
+		"movement": Gen2WorldObject.MOVEMENT_WALK_UP_DOWN,
+	}]
+	return map
 
 
 func _gen1_world(number: int, start: Vector2i) -> Gen2WorldAPI:
@@ -9920,4 +9935,24 @@ func test_gen1_tile_pair_collision_blocks_a_step_between_two_passable_tiles() ->
 	world = _gen1_world(2, Vector2i(2, 1))
 	assert_false(world.move(Vector2i.LEFT), "the pair let the player back")
 	assert_true(world.move(Vector2i.UP))
+	RomCache.clear(_gen1_directory())
+
+
+## `CanWalkOntoTile`'s displacement counters: a Generation 1 wanderer climbs at
+## most the eight cells its counter starts on, and the source's own commented
+## bug stops it coming back down once it has climbed five.
+func test_gen1_wanderer_climbs_eight_cells_and_never_comes_back_down() -> void:
+	var world: Gen2WorldAPI = _gen1_world(3, Vector2i(2, 9))
+	var walker: Gen2WorldObject = world.objects[0]
+	var random := RandomNumberGenerator.new()
+	random.seed = 20260905
+	var highest: int = walker.cell.y
+	for _tick: int in 400:
+		world.player_cell = Vector2i(2, walker.cell.y)
+		world.advance_objects(random)
+		highest = mini(highest, walker.cell.y)
+		if highest <= walker.initial_cell.y - 5:
+			assert_true(walker.cell.y <= walker.initial_cell.y - 5, "it walked back down")
+	assert_eq(highest, walker.initial_cell.y - 8, "it stopped short of its counter")
+	assert_eq(walker.cell.y, walker.initial_cell.y - 8, "it left the top of its band")
 	RomCache.clear(_gen1_directory())

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -55,6 +55,21 @@ const OVERWORLD_PASSABLE: Array[int] = [
 	0x31, 0x33, 0x39, 0x3C, 0x3E, 0x52, 0x54, 0x58, 0x5B,
 ]
 
+## Every template `object_event`'s two movement bytes decode to, and how many.
+const MOVEMENTS: Array[int] = [
+	Gen2WorldObject.MOVEMENT_WANDER, Gen2WorldObject.MOVEMENT_WALK_UP_DOWN,
+	Gen2WorldObject.MOVEMENT_WALK_LEFT_RIGHT,
+	Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW,
+	Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER, Gen2WorldObject.MOVEMENT_FIXED_DOWN,
+	Gen2WorldObject.MOVEMENT_FIXED_UP, Gen2WorldObject.MOVEMENT_FIXED_LEFT,
+	Gen2WorldObject.MOVEMENT_FIXED_RIGHT,
+]
+const MOVEMENT_CENSUS: Dictionary = {
+	&"red": [20, 29, 50, 256, 21, 234, 79, 114, 121],
+	&"blue": [20, 29, 50, 256, 21, 234, 79, 114, 121],
+	&"yellow": [19, 28, 49, 260, 21, 252, 85, 114, 121],
+}
+
 ## The Power Plant's Voltorbs, Electrodes and Zapdos: an object with the TRAINER
 ## bit and a byte below `OPP_ID_OFFSET`, which is the only shape a wild one
 ## takes: six Voltorbs, two Electrodes and Zapdos, as the dex numbers the cache
@@ -122,6 +137,7 @@ const PLAYER_SPRITE_YELLOW: Array = [0x4571, 0x05]
 
 var _r: RefCounted = null
 var _maps: Dictionary = {}
+var _movements: Array[int] = []
 
 
 func run(r: RefCounted) -> void:
@@ -137,7 +153,11 @@ func _one_game() -> void:
 	_tilesets()
 	_pallet_town()
 	_geometry()
+	_movements = []
+	_movements.resize(MOVEMENTS.size())
 	_events()
+	_r.check(_movements == MOVEMENT_CENSUS[_r.game_id],
+		"the movement census reads %s." % str(_movements))
 	_texts()
 	_wild_objects()
 	_palettes()
@@ -401,6 +421,10 @@ func _object(map: Gen2WorldMap, object: Dictionary, object_count: int) -> void:
 	if object.has("item"):
 		_r.check(_is_item(int(object["item"])),
 			"map %d has an item ball holding item %d." % [map.number, int(object["item"])])
+	var movement: int = int(object["movement"])
+	var slot: int = MOVEMENTS.find(movement)
+	if _r.check(slot >= 0, "map %d has an object on movement %d." % [map.number, movement]):
+		_movements[slot] += 1
 
 
 ## An item id an item ball can hold: a named item, or one of the machines above

--- a/tools/checks/gen1_trainers.gd
+++ b/tools/checks/gen1_trainers.gd
@@ -23,6 +23,13 @@ const HEADER_CENSUS: Dictionary = {
 ## `view_range << 4` is a pixel distance, so the stored range is a nibble.
 const MAX_SIGHT_RANGE: int = 5
 
+## Sight lines walked, cells engaging their own trainer, and cells behind one.
+const SIGHT_CENSUS: Dictionary = {
+	&"red": {"lines": 295, "cells": 880, "behind": 0},
+	&"blue": {"lines": 295, "cells": 880, "behind": 0},
+	&"yellow": {"lines": 291, "cells": 868, "behind": 0},
+}
+
 ## `BattleTransitions`' four trainer rows and the frames each runs to black in.
 const TRAINER_TRANSITIONS: Dictionary = {
 	Gen2BattleTransition.GEN1_TRAINER_BIT: 163,
@@ -66,8 +73,74 @@ func _one_game() -> void:
 	_the_party_table()
 	_the_headers()
 	_every_trainer_is_talked_to()
+	_every_trainer_sees()
 	_a_trainer_is_beaten()
 	_the_trainer_transitions()
+
+
+## `CheckFightingMapTrainers` walked from every cell of every trainer's own
+## line: inside the range the shock bubble and the walk-up open, and one cell
+## past it or one cell behind, nothing does. `CheckPlayerIsInFrontOfSprite`
+## exempts the Power Plant, but every fake item there carries `view_range` 0,
+## which `CheckSpriteCanSeePlayer` refuses at any distance, so `behind` is 0.
+func _every_trainer_sees() -> void:
+	var census: Dictionary = {"lines": 0, "cells": 0, "behind": 0}
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var rows: Array = map.events["objects"]
+		var world: Gen2WorldAPI = null
+		for index: int in rows.size():
+			if int((rows[index] as Dictionary).get("sight_range", 0)) < 1:
+				continue
+			if world == null:
+				world = _r.open_world(0, map.number, Vector2i.ZERO)
+			if world == null:
+				return
+			_one_sight_line(world, map, index, census)
+	_r.check(census == SIGHT_CENSUS[_r.game_id], "the sight census reads %s." % str(census))
+	_r.note("gen1 trainers %d sight lines over %d cells" % [
+		int(census["lines"]), int(census["cells"]),
+	])
+
+
+func _one_sight_line(
+	world: Gen2WorldAPI, map: Gen2WorldMap, index: int, census: Dictionary
+) -> void:
+	var object: Gen2WorldObject = world.objects[index]
+	var step: Vector2i = Gen2WorldAPI.SIGHT_STEPS[object.facing]
+	var where: String = "map %d object %d" % [map.number, index]
+	census["lines"] += 1
+	for distance: int in range(1, object.sight_range + 1):
+		var engaged: int = _engaged_at(world, object.cell + step * distance)
+		if not _r.check(engaged >= 0 and engaged <= index,
+			"%s saw nobody %d cells ahead." % [where, distance]):
+			continue
+		if engaged < index:
+			continue
+		census["cells"] += 1
+		var path: Array = world.trainer_approach_plan(index, step, distance).get("path", [])
+		_r.check(path.size() == distance - 1 and (path.is_empty() or path[0] == step),
+			"%s walked %s to reach the player %d cells away." % [where, str(path), distance])
+	_r.check(_engaged_at(world, object.cell + step * (object.sight_range + 1)) != index,
+		"%s saw past its own range of %d." % [where, object.sight_range])
+	if _engaged_at(world, object.cell - step) == index:
+		census["behind"] += 1
+
+
+## `dispatch_sight_events` from one cell, answering which object engaged and
+## spending `TalkToTrainer` behind it so the next cell starts on an idle world.
+func _engaged_at(world: Gen2WorldAPI, cell: Vector2i) -> int:
+	world.player_cell = cell
+	var opened: Array = world.dispatch_sight_events()
+	if opened.is_empty():
+		return -1
+	var request: Dictionary = (opened[0].get("event", {}) as Dictionary).get("request", {})
+	world.complete_runtime_request({"ok": true})
+	world.run_event_queue(true)
+	world.complete_runtime_request({})
+	_r.check(not world.script_busy(), "a sighting at %s held the world." % cell)
+	_r.check(StringName(request.get("kind", &"")) == &"trainer_approach_requested",
+		"a sighting at %s opened %s." % [cell, request.get("kind", &"nothing")])
+	return int((request.get("values", {}) as Dictionary).get("object_index", -1))
 
 
 ## A party is never empty, never over six, and every member is a real species.
@@ -113,6 +186,14 @@ func _the_headers() -> void:
 			var header: Dictionary = _header_for(map, object)
 			if header.is_empty():
 				continue
+			## `CheckForEngagingTrainers` walks one list, so both kinds carry the
+			## type and the range; only the flag's place tells them apart.
+			_r.check(int(object.get("object_type", 0)) == Gen2WorldObject.OBJECTTYPE_TRAINER
+				and int(object.get("sight_range", -1)) == int(header["sight_range"]),
+				"map %d's header row is object type %d seeing %d." % [
+					map.number, int(object.get("object_type", 0)),
+					int(object.get("sight_range", -1)),
+				])
 			if object.has("trainer_class"):
 				census["trainers"] += 1
 				_one_trainer_object(map, object)
@@ -150,8 +231,6 @@ func _one_trainer_object(map: Gen2WorldMap, object: Dictionary) -> void:
 			map.number, _r.data.trainer_name(trainer_class), number,
 			_r.data.trainer_party_count(trainer_class),
 		])
-	_r.check(int(object.get("object_type", 0)) == Gen2WorldObject.OBJECTTYPE_TRAINER,
-		"map %d's trainer is object type %d." % [map.number, int(object.get("object_type", 0))])
 
 
 func _header_for(map: Gen2WorldMap, object: Dictionary) -> Dictionary:

--- a/tools/checks/overworld_effects.gd
+++ b/tools/checks/overworld_effects.gd
@@ -31,9 +31,9 @@ const HEAL_MACHINE_COLORS: Array[int] = [0x7FFF, 0x2A7F, 0x04FF, 0x0000]
 var _first: Dictionary = {}
 
 
-## The one sheet Generation 1 draws over the map. It wears `rOBP1` rather than a
-## palette of its own, and its monitor is three rows of $7E where Crystal's is two.
-const GEN1_EXPECTED: Array = [["heal_machine", 2, 0x7C]]
+## The two sheets Generation 1 draws over the map. The machine wears `rOBP1`
+## rather than a palette of its own, and its monitor is three rows of $7E.
+const GEN1_EXPECTED: Array = [["heal_machine", 2, 0x7C], ["shock", 4, 0xF8]]
 
 ## `PokeCenterOAMData` read back to the pixel each object reaches the screen at:
 ## the monitor, then six balls in two mirrored columns five rows apart.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -29,6 +29,7 @@ const KIND_HELP: Dictionary = {
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
 	&"trainer": "presses, frames: TalkToTrainer on the map's first trainer, faced from the cell below. 0 the before-battle box, 1 the fight the press behind it opens; a second number stops that many frames into the transition instead",
+	&"sight": "frames, 0: CheckFightingMapTrainers on the map's first trainer who sees, walked into from the far end of its own line. 40 stands in the shock bubble, 120 in the walk-up, 400 in the before-battle box",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
 	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
@@ -287,7 +288,7 @@ func _build_live(data: GameData, group: int, number: int, cell: Vector2i) -> voi
 		&"battle_transition", &"level_evolution", &"egg_hatch", &"name_rater",
 		&"move_deleter", &"move_tutor", &"day_care", &"unown_puzzle", &"slot_machine",
 		&"card_flip", &"tile_anim", &"ice_slide", &"whiteout", &"gift_nickname",
-		&"magnet_train",
+		&"magnet_train", &"sight",
 	]:
 		_screen.start_cell = cell
 	## Pinned so two captures of the same map are the same picture: the seed the
@@ -359,7 +360,7 @@ const SELF_DRIVEN_KINDS: Array[StringName] = [
 	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 	&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
 	&"catch_nickname", &"catch_dex", &"mom_bank", &"bills_pc", &"players_pc",
-	&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page",
+	&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page", &"sight",
 	&"reset_question", &"launcher_question",
 ]
 
@@ -405,6 +406,7 @@ const STAGERS: Dictionary = {
 	&"pokepic": &"_stage_pokepic",
 	&"sign": &"_stage_sign",
 	&"trainer": &"_stage_trainer",
+	&"sight": &"_stage_sight",
 	&"nurse": &"_stage_nurse",
 	&"vending": &"_stage_vending",
 	&"prizes": &"_stage_prizes",
@@ -934,6 +936,22 @@ func _stage_trainer() -> void:
 		_screen.advance_frame()
 	if _cell.y <= 0:
 		_screen.settle_battle_transition()
+
+
+## `CheckFightingMapTrainers`, walked into from the far end of the line.
+func _stage_sight() -> void:
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world == null:
+		return
+	for object: Gen2WorldObject in world.objects:
+		if object.sight_range < 1:
+			continue
+		var step: Vector2i = Gen2WorldAPI.SIGHT_STEPS[object.facing]
+		world.player_cell = object.cell + step * (object.sight_range + 1)
+		world.player_facing = object.facing ^ 1
+		_screen.press_button(ICE_SLIDE_BUTTONS[object.facing ^ 1])
+		break
+	_screen.advance_frames(maxi(_cell.x, 0))
 
 
 ## `DisplayTextID`'s box, read by facing the cell above the `x y` argument.


### PR DESCRIPTION
A Generation 1 trainer whose line the player steps into puts up the shock bubble, walks over and opens its before-battle line, and the fight behind it is the one talking to that trainer already opened.

`CheckFightingMapTrainers` is reached from the map script table rather than from a text row, and this port runs no script interpreter. Every map whose objects carry a `trainer` header is a map whose script table reaches it, so `Gen2WorldAPI.dispatch_sight_events` walks the map's own objects in the header list's order instead, which is the order `CheckForEngagingTrainers` reads them in.

`TrainerEngage`'s alignment test, `CheckSpriteCanSeePlayer`'s range and `CheckPlayerIsInFrontOfSprite`'s side test are one answer in `_sight_distance`, which now dispatches a facing through a lookup rather than four `match` arms. `EmotionBubbles`' `ShockEmote` is imported beside the heal machine, pinned byte for byte the way that sheet is, and spends the 60 frames its own `DelayFrames` counts. `DisplayEnemyTrainerTextAndStartBattle` is `TalkToTrainer` with `BIT_SEEN_BY_TRAINER` already set, so the step list is the before-battle line and the battle, which `_gen1_trainer_steps` already built.

An object's two movement bytes decode to one shared template at import. Until now a Generation 1 NPC's `movement` was the raw `$FE` or `$FF`, which matches no template, so all 924 objects on Red faced down and none of them moved. `Gen1Layout.object_movement` reads the pair: a STAY sprite is fixed on `$D0` to `$D3`, is a boulder on `$10`, and spins on anything else, because `TryWalking` writes the facing before `CanWalkOntoTile` refuses the step; a WALK sprite takes byte 2 as the axis it wanders on. `CanWalkOntoTile`'s two displacement counters are that wander's only bound and are carried by the distance the object has come, so down and right are free, up stops at eight, and the source's own commented bug stops an object that walked five cells up from ever walking back.

`CheckPlayerIsInFrontOfSprite` names POWER_PLANT and skips its side test there "to get voltorb fake items to work". That branch is unreachable on shipped data: all 27 range-0 headers in the corpus are those fake items, and `CheckSpriteCanSeePlayer` compares `wTrainerEngageDistance` against a pixel distance that is never 0, so a range of 0 refuses at every distance. The sweep's `behind` column is 0 and is what records it.

## Proof

| Check | Red | Blue | Yellow |
|---|---|---|---|
| Sight lines walked | 295 | 295 | 291 |
| Cells engaging their own trainer | 880 | 880 | 868 |
| Cells engaging one from behind | 0 | 0 | 0 |
| Objects on a decoded movement template | 924 | 924 | 949 |

`gen1_trainers.gd` walks every cell of every line, one past each range and one behind each trainer, and checks the approach path is `distance - 1` steps of the trainer's own facing. `gen1_maps.gd` pins the movement census against `data/maps/objects`. `overworld_effects.gd` pins the new sheet. `tools/preview_world.gd -- red 0 14 <out.png> live sight 400 0` photographs a sighting; 40 frames stands in the bubble and 120 in the walk-up.

Unit tier 3763 tests, scene tier 4374, `tools/validate.gd -- all` 92 topics, `replay_world.gd` 33 routes and the three-profile story walk are all green, and the editor analyser reports 0 warnings over 631 scripts. The cache format moves to 110 and all six cartridges re-import with `layout: Layout verified.`

`HEAL_MACHINE_TILES` was dead and is gone; the two sheets now share one pinned-bytes reader.
