### PR TITLE
Read a Generation 1 NPC's own machine code

### DIFF
--- a/game/battle/battle_anim_bg_effects.gd
+++ b/game/battle/battle_anim_bg_effects.gd
@@ -5,7 +5,7 @@ extends RefCounted
 ## (engine/battle_anims/bg_effects.asm): the screen shakes, the scanline
 ## deformations, the palette fades and the tilemap edits. Five run at once.
 ##
-## **An effect id is profile-local and is never normalised.** pokegold ships no
+## An effect id is profile-local and is never normalised: pokegold ships no
 ## `BATTLE_BG_EFFECT_BODY_SLAM`, so every id from $25 on names a different effect
 ## in the two games; both jumptables are kept whole and dispatch is by name. The
 ## Color branch is taken wherever the source asks `hCGB`, as everywhere else here.

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -554,11 +554,32 @@ const TRAINER_HEADER_AT: Dictionary = {
 }
 const TRAINER_HEADER_END: int = 0xFF
 const TRAINER_RANGE_SHIFT: int = 4
-## `text_asm`, `ld hl, nn`, then either `call TalkToTrainer` or a `jr` onto one.
-const TRAINER_TEXT_ASM: int = 0x08
-const TRAINER_TEXT_LD_HL: int = 0x21
-const TRAINER_TEXT_CALL: int = 0xCD
-const TRAINER_TEXT_JR: int = 0x18
+## `TX_ASM`, and the opcodes a row behind it is read with. Any opcode not here
+## ends the path [method Gen1WorldImporter.decode_script] is walking.
+const TEXT_ASM: int = 0x08
+const SCRIPT_LD_HL: int = 0x21
+const SCRIPT_LD_A: int = 0x3E
+const SCRIPT_LD_A_MEM: int = 0xFA
+const SCRIPT_LD_MEM_A: int = 0xEA
+const SCRIPT_AND_A: int = 0xA7
+const SCRIPT_PREFIX: int = 0xCB
+const SCRIPT_JR: int = 0x18
+const SCRIPT_JP: int = 0xC3
+const SCRIPT_RET: int = 0xC9
+const SCRIPT_CALL: int = 0xCD
+## Each key is a conditional `jr` or `jp`, the value whether it is taken when
+## the tested bit was set.
+const SCRIPT_BRANCHES: Dictionary = {0x20: true, 0xC2: true, 0x28: false, 0xCA: false}
+const SCRIPT_SHORT_SIZE: int = 2
+const SCRIPT_LONG_SIZE: int = 3
+## The `CB` prefix's three rows, the low three bits naming the operand.
+const SCRIPT_BIT_BASE: int = 0x40
+const SCRIPT_RES_BASE: int = 0x80
+const SCRIPT_SET_BASE: int = 0xC0
+const SCRIPT_OPERAND_A: int = 7
+const SCRIPT_OPERAND_HL: int = 6
+## `flag_array NUM_EVENTS`: 2,560 events on all three cartridges.
+const EVENT_FLAG_BYTES: int = 320
 ## `MAX_WARP_EVENTS`, `MAX_BG_EVENTS` and `MAX_OBJECT_EVENTS`.
 const MAX_WARP_EVENTS: int = 32
 const MAX_SIGN_EVENTS: int = 16
@@ -737,6 +758,14 @@ const RED_BLUE: Dictionary = {
 	"talk_to_trainer": 0x31CC,
 	"print_text": 0x3C49,
 	"event_flags": 0xD747,
+	## The rest of what `decode_script` reads; a row calling anything else is not.
+	"text_script_end": 0x24D7,
+	"yes_no_choice": 0x35EC,
+	"disable_waiting": 0x30B6,
+	"play_cry": 0x13D0,
+	"wait_for_sound": 0x3748,
+	"do_not_wait": 0xCC3C,
+	"current_menu_item": 0xCC26,
 	## `DisplayPokemartDialogue`'s own greeting and the head of the two facility
 	## text runs [constant MART_TEXT_AT] and its neighbour walk. Every offset
 	## here is `pokered.sym`'s, which builds both dumps.
@@ -812,6 +841,13 @@ const YELLOW: Dictionary = {
 	"talk_to_trainer": 0x3168,
 	"print_text": 0x3C36,
 	"event_flags": 0xD746,
+	"text_script_end": 0x23D2,
+	"yes_no_choice": 0x35EF,
+	"disable_waiting": 0x2FDE,
+	"play_cry": 0x118B,
+	"wait_for_sound": 0x373E,
+	"do_not_wait": 0xCC3C,
+	"current_menu_item": 0xCC26,
 	"mart_greeting": 0x02938,
 	"mart_text": 0x06B91,
 	"pokecenter_text": 0x06ED0,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -786,6 +786,10 @@ static func _read_text(
 	if header >= 0:
 		row["trainer"] = _read_trainer_header(rom, layout, bank, header)
 		return row
+	if int(row["command"]) == Gen1Layout.TEXT_ASM:
+		var script: Array = decode_script(rom, layout, bank, at + 1)
+		if not script.is_empty():
+			row["script"] = script
 	row["text"] = String(decoded["text"])
 	row["prompt"] = bool(decoded.get("prompt", false))
 	return row
@@ -795,18 +799,245 @@ static func _read_text(
 ## [param target], or -1 for any other machine code. `TalkToTrainer` is 322 of
 ## the corpus's 626 such rows; a map sharing one landing `jr`s onto it.
 static func _asm_operand(rom: RomFile, bank: int, at: int, target: int) -> int:
-	if rom.u8(at) != Gen1Layout.TRAINER_TEXT_ASM \
-		or rom.u8(at + 1) != Gen1Layout.TRAINER_TEXT_LD_HL:
+	if rom.u8(at) != Gen1Layout.TEXT_ASM \
+		or rom.u8(at + 1) != Gen1Layout.SCRIPT_LD_HL:
 		return -1
 	var landing: int = at + 4
-	if rom.u8(landing) == Gen1Layout.TRAINER_TEXT_JR:
+	if rom.u8(landing) == Gen1Layout.SCRIPT_JR:
 		## `jr` counts from the byte after its own operand.
 		var hop: int = rom.u8(landing + 1)
 		landing += 2 + (hop - 0x100 if hop > 0x7F else hop)
-	if rom.u8(landing) != Gen1Layout.TRAINER_TEXT_CALL \
+	if rom.u8(landing) != Gen1Layout.SCRIPT_CALL \
 		or rom.u16le(landing + 1) != target:
 		return -1
 	return Gen1Layout.banked(bank, rom.u16le(at + 2))
+
+
+## What one walk may read, how deep its branches may nest, and the two answers
+## [method _script_step] gives that are not an address.
+const SCRIPT_BUDGET: int = 512
+const SCRIPT_DEPTH: int = 8
+const SCRIPT_END: int = -2
+const SCRIPT_UNREAD: int = -1
+## What a `jr z` is testing: an event flag by index, or the YES/NO answer.
+const SCRIPT_TESTS_CHOICE: int = -1
+const SCRIPT_TESTS_NOTHING: int = -2
+
+
+## One `text_asm` row's machine code, as the boxes it prints and the branches
+## choosing between them. Only the routines the layout names are read, and a
+## path reaching anything else is dropped whole rather than kept as a prefix
+## that stops mid-interaction.
+static func decode_script(
+	rom: RomFile, layout: Dictionary, bank: int, at: int
+) -> Array:
+	var walked: Variant = _walk_script(
+		{"rom": rom, "layout": layout, "bank": bank, "budget": [SCRIPT_BUDGET]},
+		at, {}, 0
+	)
+	return walked as Array if walked is Array else []
+
+
+## One straight run and the branch that ends it, or null for a path that does
+## not reach `TextScriptEnd`.
+static func _walk_script(
+	ctx: Dictionary, pc: int, state: Dictionary, depth: int
+) -> Variant:
+	if depth > SCRIPT_DEPTH:
+		return null
+	var out: Array = []
+	var budget: Array = ctx["budget"]
+	while budget[0] > 0:
+		budget[0] -= 1
+		var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
+		if Gen1Layout.SCRIPT_BRANCHES.has(op):
+			return _script_branch(ctx, op, pc, state, depth, out)
+		var next: int = _script_step(ctx, pc, state, out)
+		if next == SCRIPT_END:
+			return _script_ended(state, out)
+		if next == SCRIPT_UNREAD:
+			return null
+		pc = next
+	return null
+
+
+## `AfterDisplayingTextID` reads `wDoNotWaitForButtonPress...` once the row is
+## done, so the flag belongs to the last box and not to each.
+static func _script_ended(state: Dictionary, out: Array) -> Array:
+	if bool(state.get("no_press", false)) and not out.is_empty() \
+		and String((out[-1] as Dictionary)["op"]) == "text":
+		(out[-1] as Dictionary)["press"] = false
+	return out
+
+
+## One instruction: the next address, [constant SCRIPT_END] or SCRIPT_UNREAD.
+static func _script_step(
+	ctx: Dictionary, pc: int, state: Dictionary, out: Array
+) -> int:
+	var rom: RomFile = ctx["rom"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
+	match rom.u8(at):
+		Gen1Layout.SCRIPT_LD_HL:
+			state["hl"] = rom.u16le(at + 1)
+			return pc + Gen1Layout.SCRIPT_LONG_SIZE
+		Gen1Layout.SCRIPT_LD_A:
+			state["a"] = rom.u8(at + 1)
+			state.erase("source")
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+		Gen1Layout.SCRIPT_LD_A_MEM:
+			state["source"] = rom.u16le(at + 1)
+			state.erase("a")
+			return pc + Gen1Layout.SCRIPT_LONG_SIZE
+		Gen1Layout.SCRIPT_LD_MEM_A:
+			return pc + Gen1Layout.SCRIPT_LONG_SIZE \
+				if _script_stored(ctx, rom.u16le(at + 1), state) else SCRIPT_UNREAD
+		Gen1Layout.SCRIPT_AND_A:
+			state["tests"] = _script_tests(ctx, state, -1)
+			return pc + 1
+		Gen1Layout.SCRIPT_PREFIX:
+			return _script_prefix(ctx, pc, state, out)
+		Gen1Layout.SCRIPT_JR:
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE + _script_hop(rom.u8(at + 1))
+		Gen1Layout.SCRIPT_JP:
+			return SCRIPT_END if rom.u16le(at + 1) == int(
+				(ctx["layout"] as Dictionary)["text_script_end"]
+			) else SCRIPT_UNREAD
+		Gen1Layout.SCRIPT_RET:
+			return SCRIPT_END
+		Gen1Layout.SCRIPT_CALL:
+			return _script_call(ctx, pc, rom.u16le(at + 1), state, out)
+	return SCRIPT_UNREAD
+
+
+static func _script_hop(operand: int) -> int:
+	return operand - 0x100 if operand > 0x7F else operand
+
+
+## The one memory write read here: `DisableWaitingAfterTextDisplay` by hand.
+static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> bool:
+	if address != int((ctx["layout"] as Dictionary)["do_not_wait"]) \
+		or int(state.get("a", 0)) != 1:
+		return false
+	state["no_press"] = true
+	return true
+
+
+## What the flags hold. [param bit] is -1 for `and a`, which only asks whether
+## the whole byte is zero and so names no flag.
+static func _script_tests(ctx: Dictionary, state: Dictionary, bit: int) -> int:
+	var layout: Dictionary = ctx["layout"]
+	var source: int = int(state.get("source", -1))
+	if source == int(layout["current_menu_item"]):
+		return SCRIPT_TESTS_CHOICE
+	var flag: int = _script_flag(ctx, source, bit)
+	return flag if bit >= 0 and flag >= 0 else SCRIPT_TESTS_NOTHING
+
+
+## An address in `wEventFlags` and a bit as one flag index, the way
+## [method _read_trainer_header] counts one.
+static func _script_flag(ctx: Dictionary, address: int, bit: int) -> int:
+	var base: int = int((ctx["layout"] as Dictionary)["event_flags"])
+	if address < base or address >= base + Gen1Layout.EVENT_FLAG_BYTES:
+		return -1
+	return (address - base) * 8 + bit
+
+
+## `bit b, a` names the flag a branch tests; `set`/`res b, [hl]` writes one.
+static func _script_prefix(
+	ctx: Dictionary, pc: int, state: Dictionary, out: Array
+) -> int:
+	var code: int = (ctx["rom"] as RomFile).u8(
+		Gen1Layout.banked(int(ctx["bank"]), pc) + 1
+	)
+	var bit: int = (code >> 3) & 7
+	var operand: int = code & 7
+	if operand == Gen1Layout.SCRIPT_OPERAND_A \
+		and code >= Gen1Layout.SCRIPT_BIT_BASE and code < Gen1Layout.SCRIPT_RES_BASE:
+		state["tests"] = _script_tests(ctx, state, bit)
+		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+	if operand != Gen1Layout.SCRIPT_OPERAND_HL or code < Gen1Layout.SCRIPT_RES_BASE:
+		return SCRIPT_UNREAD
+	var flag: int = _script_flag(ctx, int(state.get("hl", -1)), bit)
+	if flag < 0:
+		return SCRIPT_UNREAD
+	out.append({"op": "flag", "flag": flag, "set": code >= Gen1Layout.SCRIPT_SET_BASE})
+	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+
+
+## The routines a row may call. No audio driver here, so a cry and the wait
+## behind it spend nothing and the walk carries on past them.
+static func _script_call(
+	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array
+) -> int:
+	var layout: Dictionary = ctx["layout"]
+	var next: int = pc + Gen1Layout.SCRIPT_LONG_SIZE
+	## A routine returns with flags of its own, so a `jr z` behind a call is
+	## reading them rather than whatever set them before it.
+	state.erase("tests")
+	if target == int(layout["print_text"]):
+		var box: Dictionary = _script_box(ctx, int(state.get("hl", 0)))
+		if box.is_empty():
+			return SCRIPT_UNREAD
+		out.append(box)
+		return next
+	if target == int(layout["text_script_end"]):
+		return SCRIPT_END
+	if target == int(layout["disable_waiting"]):
+		state["no_press"] = true
+		return next
+	if target == int(layout["yes_no_choice"]):
+		state["source"] = int(layout["current_menu_item"])
+		state.erase("a")
+		return next
+	if target == int(layout["play_cry"]) or target == int(layout["wait_for_sound"]):
+		return next
+	return SCRIPT_UNREAD
+
+
+## One `PrintText` box, empty when the pointer does not decode to a string.
+static func _script_box(ctx: Dictionary, pointer: int) -> Dictionary:
+	var decoded: Dictionary = Gen1Text.decode_stream(
+		ctx["rom"], Gen1Layout.banked(int(ctx["bank"]), pointer)
+	)
+	if not bool(decoded.get("ok", false)) or String(decoded["text"]).is_empty():
+		return {}
+	return {"op": "text", "text": String(decoded["text"])}
+
+
+## A conditional, walked both ways. A side reaching machine code this decoder
+## does not read becomes an `unknown` node, so an interaction taking that side
+## says nothing at all, as an undecoded row does.
+static func _script_branch(
+	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
+) -> Variant:
+	var tests: int = int(state.get("tests", SCRIPT_TESTS_NOTHING))
+	if tests == SCRIPT_TESTS_NOTHING:
+		return null
+	var rom: RomFile = ctx["rom"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
+	var short: bool = op < Gen1Layout.SCRIPT_JP
+	var size: int = Gen1Layout.SCRIPT_SHORT_SIZE if short else Gen1Layout.SCRIPT_LONG_SIZE
+	var jumped: int = pc + size + _script_hop(rom.u8(at + 1)) if short else rom.u16le(at + 1)
+	var branches: Array = [
+		_walk_script(ctx, jumped, state.duplicate(), depth + 1),
+		_walk_script(ctx, pc + size, state.duplicate(), depth + 1),
+	]
+	if not bool(Gen1Layout.SCRIPT_BRANCHES[op]):
+		branches.reverse()
+	if branches[0] == null and branches[1] == null:
+		return null
+	out.append(_script_node(tests, branches))
+	return out
+
+
+## `wCurrentMenuItem` is 0 for YES, so the branch taken when it is not zero is
+## NO. An event flag reads the other way about: the taken side is the set one.
+static func _script_node(tests: int, branches: Array) -> Dictionary:
+	var taken: Array = branches[0] if branches[0] != null else [{"op": "unknown"}]
+	var fell: Array = branches[1] if branches[1] != null else [{"op": "unknown"}]
+	if tests == SCRIPT_TESTS_CHOICE:
+		return {"op": "choice", "no": taken, "yes": fell}
+	return {"op": "branch", "flag": tests, "then": taken, "else": fell}
 
 
 ## One `trainer` row. `TrainerFlagAction` counts the bit off the address two

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 110
+const FORMAT_VERSION: int = 111
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -4,7 +4,7 @@ extends RefCounted
 ## The Pokedex's own tile screens (engine/pokedex/pokedex.asm). [Gen2Pokedex] owns
 ## the listing, the cursor and the mode; this is the picture. Every layout is one
 ## of the source's `Pokedex_Draw*BG` routines read as tile writes. Three sheets
-## share the dex's VRAM numbering: `$00` to `$30` is the font **inverted**, since
+## share the dex's VRAM numbering: `$00` to `$30` is the font inverted, since
 ## `Pokedex_LoadInvertedFont` XORs every byte and the whole screen is light on
 ## dark; `$31` to `$6a` is `PokedexLZ`; `$6b` up is `LoadFontsExtra`, inverted by
 ## the same pass. The main screen is not a plain grid: its listing is in the

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3724,15 +3724,81 @@ func _gen1_interact() -> Array:
 	if _gen1_steps.is_empty():
 		_gen1_steps = _gen1_facility_steps(row, text_id)
 	if _gen1_steps.is_empty():
-		var text: String = Gen2TextStream.fill_names(String(row.get("text", "")), {
-			"player": _player_name if not _player_name.is_empty() \
-				else Gen2WorldScriptRunner.UNNAMED,
-			"rival": gen1_rival_name,
-		})
+		_gen1_steps = _gen1_script_steps(row)
+	if _gen1_steps.is_empty():
+		var text: String = _gen1_filled_text(String(row.get("text", "")))
 		if text.is_empty():
 			return []
 		_gen1_steps = [{"type": &"text", "text": text}]
 	return _gen1_result()
+
+
+func _gen1_filled_text(text: String) -> String:
+	return Gen2TextStream.fill_names(text, {
+		"player": _player_name if not _player_name.is_empty() \
+			else Gen2WorldScriptRunner.UNNAMED,
+		"rival": gen1_rival_name,
+	})
+
+
+## The boxes a `text_asm` row prints, with its branches resolved against the
+## save. A taken side the importer did not read answers nothing at all, the way
+## an undecoded row does.
+func _gen1_script_steps(row: Dictionary) -> Array:
+	var nodes: Variant = row.get("script", [])
+	if not nodes is Array or (nodes as Array).is_empty():
+		return []
+	var steps: Array = []
+	return steps if _gen1_resolve_script(nodes as Array, steps) else []
+
+
+func _gen1_resolve_script(nodes: Array, steps: Array) -> bool:
+	for node: Dictionary in nodes:
+		match String(node.get("op", "")):
+			"text":
+				steps.append(_gen1_script_box(node))
+			"flag":
+				steps.append({
+					"type": &"flag",
+					"flag": int(node["flag"]),
+					"set": bool(node["set"]),
+				})
+			"branch":
+				var side: String = "then" if event_flag_active(int(node["flag"])) else "else"
+				if not _gen1_resolve_script(node[side] as Array, steps):
+					return false
+			"choice":
+				return _gen1_script_choice(node, steps)
+			_:
+				return false
+	return true
+
+
+## `YesNoChoice` stands behind the box that asked, so the question is the last
+## box printed.
+func _gen1_script_choice(node: Dictionary, steps: Array) -> bool:
+	if steps.is_empty() \
+		or StringName((steps[-1] as Dictionary).get("type", &"")) != &"text":
+		return false
+	var question: Dictionary = steps.pop_back()
+	var yes: Array = []
+	var no: Array = []
+	if not _gen1_resolve_script(node["yes"] as Array, yes) \
+		or not _gen1_resolve_script(node["no"] as Array, no):
+		return false
+	steps.append({
+		"type": &"choice", "text": String(question["text"]), "yes": yes, "no": no,
+	})
+	return true
+
+
+func _gen1_script_box(node: Dictionary) -> Dictionary:
+	var step: Dictionary = {
+		"type": &"text", "text": _gen1_filled_text(String(node.get("text", ""))),
+	}
+	if not bool(node.get("press", true)):
+		step["press"] = false
+	return step
 
 
 ## `DisplayTextID`'s own dispatch, which reads the first byte of the text a
@@ -4136,8 +4202,13 @@ func _gen1_step(type: StringName) -> Dictionary:
 	return step if StringName(step.get("type", &"")) == type else {}
 
 
-## The result the head step is waiting on, empty once the list is spent.
+## The result the head step is waiting on, empty once the list is spent. An
+## event flag a row writes takes no turn of its own and is spent on the way past.
 func _gen1_result() -> Array:
+	while not _gen1_steps.is_empty() \
+		and StringName((_gen1_steps[0] as Dictionary)["type"]) == &"flag":
+		var written: Dictionary = _gen1_steps.pop_front()
+		state.set_event_flag(int(written["flag"]), bool(written["set"]))
 	if _gen1_steps.is_empty():
 		return []
 	var step: Dictionary = _gen1_steps[0]
@@ -4156,11 +4227,15 @@ func _gen1_result() -> Array:
 			"event": (step["values"] as Dictionary).duplicate(true),
 			"events": (step.get("events", []) as Array).duplicate(true),
 		}]
-	## `AfterDisplayingTextID` ends every box on `WaitForTextScrollButtonPress`,
-	## whatever the string's last byte said.
+	## `AfterDisplayingTextID` ends every box on `WaitForTextScrollButtonPress`
+	## unless the row set `wDoNotWaitForButtonPress...` before its last one.
 	return [{
 		"ok": true, "status": &"waiting",
-		"event": {"type": &"text", "text": String(step["text"]), "prompt": true},
+		"event": {
+			"type": &"text",
+			"text": String(step["text"]),
+			"prompt": bool(step.get("press", true)),
+		},
 	}]
 
 
@@ -4250,6 +4325,11 @@ func pending_script_input() -> Dictionary:
 			"choices": Gen2WorldMenu.YES_NO_KEYS.duplicate(),
 			"text": String(step.get("text", "")),
 		}
+	## A box owing no press is spent by [method Gen2WorldScreen.advance_frame]
+	## rather than by one, and this is what it reads to find it.
+	var box: Dictionary = _gen1_step(&"text")
+	if not box.is_empty():
+		return {"type": &"text", "text": String(box["text"])}
 	return _active_script.pending_input() if _active_script != null else {}
 
 

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -1,0 +1,197 @@
+extends GutTest
+
+## [method Gen1WorldImporter.decode_script], the machine code behind a
+## `text_asm` row read as the boxes it prints. Real rows are swept on all three
+## cartridges by `tools/checks/gen1_maps.gd`; what is built here is the shapes
+## that corpus does not hold, above all the ones that have to answer nothing.
+
+const LAYOUT: Dictionary = {
+	"print_text": 0x0100,
+	"text_script_end": 0x0110,
+	"yes_no_choice": 0x0120,
+	"disable_waiting": 0x0130,
+	"play_cry": 0x0140,
+	"wait_for_sound": 0x0150,
+	"do_not_wait": 0xCC3C,
+	"current_menu_item": 0xCC26,
+	"event_flags": 0xD747,
+	"talk_to_trainer": 0x0160,
+}
+const AT: int = 0x1000
+const HELLO: int = 0x1800
+const BYE: int = 0x1810
+const UNREAD_CALL: int = 0x0200
+
+
+func _rom(program: Array, strings: Dictionary = {}) -> RomFile:
+	var data: PackedByteArray = PackedByteArray()
+	data.resize(RomFile.BANK_SIZE)
+	for offset: int in program.size():
+		data[AT + offset] = int(program[offset])
+	for address: int in strings:
+		## `TX_START`, the literal, and `<DONE>`: what a `text_far` target holds.
+		var text: PackedByteArray = Gen1Text.encode(String(strings[address]))
+		data[int(address)] = Gen1Text.TEXT_START
+		for offset: int in text.size():
+			data[int(address) + 1 + offset] = text[offset]
+		data[int(address) + 1 + text.size()] = Gen2TextStream.CHAR_DONE
+	return RomFile.from_bytes(data)
+
+
+func _boxes(text: String = "HI", second: String = "BYE") -> Dictionary:
+	return {HELLO: text, BYE: second}
+
+
+## `ld hl, nn`, low byte first.
+func _load_hl(address: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_HL, address & 0xFF, address >> 8]
+
+
+func _call(address: int) -> Array:
+	return [Gen1Layout.SCRIPT_CALL, address & 0xFF, address >> 8]
+
+
+func _print(address: int) -> Array:
+	return _load_hl(address) + _call(int(LAYOUT["print_text"]))
+
+
+func _decode(program: Array, strings: Dictionary = {}) -> Array:
+	return Gen1WorldImporter.decode_script(_rom(program, strings), LAYOUT, 0, AT)
+
+
+func test_a_row_that_prints_one_box_decodes_to_it() -> void:
+	var script: Array = _decode(
+		_print(HELLO) + _call(int(LAYOUT["text_script_end"])), _boxes()
+	)
+	assert_eq(script, [{"op": "text", "text": "HI"}])
+
+
+func test_a_jump_to_the_end_ends_the_row() -> void:
+	var script: Array = _decode(
+		_print(HELLO)
+			+ [Gen1Layout.SCRIPT_JP, LAYOUT["text_script_end"] & 0xFF,
+				int(LAYOUT["text_script_end"]) >> 8],
+		_boxes()
+	)
+	assert_eq(script.size(), 1)
+
+
+func test_a_call_this_decoder_does_not_read_answers_nothing() -> void:
+	# Not a prefix: a row that would go on to give an item has to say nothing at
+	# all rather than open with its first line and stop.
+	assert_eq(_decode(_print(HELLO) + _call(UNREAD_CALL), _boxes()), [])
+
+
+func test_a_cry_and_its_wait_are_walked_past() -> void:
+	var script: Array = _decode(
+		_call(int(LAYOUT["play_cry"])) + _call(int(LAYOUT["wait_for_sound"]))
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{"op": "text", "text": "HI"}])
+
+
+## `CheckEvent`: `ld a, [wEventFlags + n]` then `bit b, a`.
+func _check_event(flag: int) -> Array:
+	var address: int = int(LAYOUT["event_flags"]) + flag / 8
+	return [
+		Gen1Layout.SCRIPT_LD_A_MEM, address & 0xFF, address >> 8,
+		Gen1Layout.SCRIPT_PREFIX,
+		Gen1Layout.SCRIPT_BIT_BASE + (flag % 8) * 8 + Gen1Layout.SCRIPT_OPERAND_A,
+	]
+
+
+func test_an_event_branch_keeps_the_flag_and_both_sides() -> void:
+	## `jr nz` hops over what runs when the flag is clear, so that side is laid
+	## out first and the one the branch is taken to follows it.
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_check_event(37) + [0x20, clear.size()] + clear
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "branch", "flag": 37,
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "text", "text": "BYE"}],
+	}])
+
+
+func test_a_branch_side_this_decoder_cannot_read_is_marked_rather_than_dropped() -> void:
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_check_event(37) + [0x20, clear.size()] + clear + _call(UNREAD_CALL),
+		_boxes()
+	)
+	if not assert_eq(script.size(), 1, "the branch is the whole row"):
+		return
+	assert_eq((script[0] as Dictionary)["then"], [{"op": "unknown"}])
+	assert_eq((script[0] as Dictionary)["else"], [{"op": "text", "text": "BYE"}])
+
+
+func test_a_branch_with_neither_side_readable_answers_nothing() -> void:
+	var clear: Array = _call(UNREAD_CALL)
+	assert_eq(_decode(
+		_check_event(37) + [0x20, clear.size()] + clear + _call(UNREAD_CALL), _boxes()
+	), [])
+
+
+## `YesNoChoice` writes `wCurrentMenuItem`, which is zero for YES.
+func test_the_zero_side_of_a_yes_no_is_yes() -> void:
+	var menu: int = int(LAYOUT["current_menu_item"])
+	var yes: Array = _print(HELLO) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_call(int(LAYOUT["yes_no_choice"]))
+			+ [Gen1Layout.SCRIPT_LD_A_MEM, menu & 0xFF, menu >> 8, Gen1Layout.SCRIPT_AND_A]
+			+ [0x20, yes.size()] + yes
+			+ _print(BYE) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "choice",
+		"no": [{"op": "text", "text": "BYE"}],
+		"yes": [{"op": "text", "text": "HI"}],
+	}])
+
+
+func test_a_flag_write_becomes_its_own_node() -> void:
+	var address: int = int(LAYOUT["event_flags"]) + 5
+	var script: Array = _decode(
+		_load_hl(address)
+			+ [Gen1Layout.SCRIPT_PREFIX,
+				Gen1Layout.SCRIPT_SET_BASE + 3 * 8 + Gen1Layout.SCRIPT_OPERAND_HL]
+			+ _call(int(LAYOUT["text_script_end"]))
+	)
+	assert_eq(script, [{"op": "flag", "flag": 43, "set": true}])
+
+
+func test_a_flag_write_outside_the_event_array_answers_nothing() -> void:
+	assert_eq(_decode(
+		_load_hl(0xC000)
+			+ [Gen1Layout.SCRIPT_PREFIX,
+				Gen1Layout.SCRIPT_SET_BASE + Gen1Layout.SCRIPT_OPERAND_HL]
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [])
+
+
+## `AfterDisplayingTextID` reads the flag once, after the row is done, so it
+## belongs to the last box rather than to every box printed behind it.
+func test_the_no_press_flag_lands_on_the_last_box_only() -> void:
+	var script: Array = _decode(
+		_call(int(LAYOUT["disable_waiting"])) + _print(HELLO) + _print(BYE)
+			+ _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [
+		{"op": "text", "text": "HI"},
+		{"op": "text", "text": "BYE", "press": false},
+	])
+
+
+func test_a_row_that_never_ends_answers_nothing() -> void:
+	# `jr -2` is its own address, which is what the budget is for.
+	assert_eq(_decode([Gen1Layout.SCRIPT_JR, 0xFE]), [])
+
+
+func test_a_box_that_does_not_decode_answers_nothing() -> void:
+	assert_eq(_decode(_print(HELLO) + _call(int(LAYOUT["text_script_end"]))), [])

--- a/tests/unit/test_gen1_script.gd.uid
+++ b/tests/unit/test_gen1_script.gd.uid
@@ -1,0 +1,1 @@
+uid://dqvgrweraj1q3

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 968 lines of the 39453 here, and Generation 1 has added 779 more to the
+## are 1022 lines of the 39516 here, and Generation 1 has added 787 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 140 the transition, the split effect routines and
-## `BlkPacket_Battle`. Eight sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39453
+## `BlkPacket_Battle`. Nine sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39516
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -128,6 +128,23 @@ const MART_ITEMS: Dictionary = {&"red": 97, &"blue": 97, &"yellow": 98}
 ## `_MtMoonPokecenterClipboardText`, the corpus's one empty box.
 const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
+## The `text_asm` rows read as a script, and the nodes under them.
+const SCRIPT_CENSUS: Dictionary = {
+	&"red": {"rows": 91, "text": 126, "branch": 71, "choice": 6, "flag": 5, "unknown": 46},
+	&"blue": {"rows": 91, "text": 126, "branch": 71, "choice": 6, "flag": 5, "unknown": 46},
+	&"yellow": {"rows": 74, "text": 101, "branch": 63, "choice": 5, "flag": 1, "unknown": 44},
+}
+
+## The pin on which way a `wCurrentMenuItem` branch reads.
+const LAVENDER_TOWN: int = 4
+const GHOST_GIRL_TEXT: int = 1
+const GHOST_GIRL_BOXES: Array[String] = [
+	"Do you believe in\nGHOSTs?",
+	"Really? So there\nare believers...",
+	"Hahaha, I guess\nnot." + Gen2TextStream.PAGE_BREAK + "That white hand\non your shoulder,"
+		+ Gen2TextStream.SCROLL_BREAK + "it's not real.",
+]
+
 ## `NUM_SPRITES` and `FIRST_STILL_SPRITE`, with `SpriteSheetPointerTable`'s
 ## first row: `RedSprite`, $C0 bytes in bank $05.
 const SPRITE_COUNTS: Dictionary = {&"red": 72, &"blue": 72, &"yellow": 82}
@@ -291,7 +308,65 @@ func _texts() -> void:
 	_r.check(empty == int(EMPTY_TEXTS[_r.game_id]),
 		"%d texts decoded to nothing, pinned %d." % [empty, int(EMPTY_TEXTS[_r.game_id])])
 	_r.note("gen1 texts %s" % [census])
+	_scripts(font)
 	_marts()
+
+
+## Every `text_asm` row the importer read as a script. What is pinned is not the
+## count alone but the shape: a branch's flag has to be one `wEventFlags` holds,
+## every box has to draw, and the ghost girl has to keep both her answers.
+func _scripts(font: Gen2Font) -> void:
+	var census: Dictionary = {"rows": 0, "text": 0, "branch": 0, "choice": 0,
+		"flag": 0, "unknown": 0}
+	var wrong: Array[String] = []
+	for map: Gen2WorldMap in _maps.values():
+		for row: Dictionary in map.texts:
+			var script: Array = row.get("script", [])
+			if script.is_empty():
+				continue
+			census["rows"] = int(census["rows"]) + 1
+			_walk_script(font, script, census, wrong, map.number)
+	_r.check(wrong.is_empty(), "script nodes are wrong: %s." % [wrong])
+	_r.check(census == SCRIPT_CENSUS[_r.game_id], "the row scripts read %s." % [census])
+	_r.note("gen1 scripts %s" % [census])
+	_ghost_girl()
+
+
+func _walk_script(
+	font: Gen2Font, nodes: Array, census: Dictionary, wrong: Array[String], number: int
+) -> void:
+	for node: Dictionary in nodes:
+		var op: String = String(node["op"])
+		census[op] = int(census.get(op, 0)) + 1
+		if op == "text" and not _drawn(font, String(node["text"]).replace("\n", "")) \
+			and wrong.size() < 4:
+			wrong.append("map %d draws a blank tile" % number)
+		if op == "flag" or op == "branch":
+			var flag: int = int(node["flag"])
+			if (flag < 0 or flag >= Gen1Layout.EVENT_FLAG_BYTES * 8) and wrong.size() < 4:
+				wrong.append("map %d names flag %d" % [number, flag])
+		for side: String in ["then", "else", "yes", "no"]:
+			if node.has(side):
+				_walk_script(font, node[side] as Array, census, wrong, number)
+
+
+## `LavenderTownLittleGirlText`: the question, then `wCurrentMenuItem` zero for
+## YES. Its `ld hl` between `and a` and the `jr nz` is why a branch is decoded
+## off the flags rather than off the instruction in front of it.
+func _ghost_girl() -> void:
+	var map: Gen2WorldMap = _maps.get(LAVENDER_TOWN)
+	if not _r.check(map != null, "Lavender Town is missing."):
+		return
+	var script: Array = map.text_at(GHOST_GIRL_TEXT).get("script", [])
+	if not _r.check(script.size() == 2, "the ghost girl has %d nodes." % script.size()):
+		return
+	var choice: Dictionary = script[1]
+	var read: Array[String] = [
+		String((script[0] as Dictionary).get("text", "")),
+		String(((choice.get("yes", []) as Array)[0] as Dictionary).get("text", "")),
+		String(((choice.get("no", []) as Array)[0] as Dictionary).get("text", "")),
+	]
+	_r.check(read == GHOST_GIRL_BOXES, "the ghost girl says %s." % [read])
 
 
 ## Every `script_mart` row's inline inventory: `LoadItemList` reads the count out

--- a/tools/checks/gen1_trainers.gd
+++ b/tools/checks/gen1_trainers.gd
@@ -177,7 +177,7 @@ func _the_headers() -> void:
 	var census: Dictionary = {"text_asm": 0, "headers": 0, "trainers": 0, "wilds": 0}
 	for map: Gen2WorldMap in _r.data.world_maps():
 		for row: Dictionary in map.texts:
-			if int(row.get("command", 0)) == Gen1Layout.TRAINER_TEXT_ASM:
+			if int(row.get("command", 0)) == Gen1Layout.TEXT_ASM:
 				census["text_asm"] += 1
 			if row.has("trainer"):
 				census["headers"] += 1

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -95,6 +95,30 @@ const PRIZE_MENUS: Dictionary = {
 	],
 }
 
+## Three `text_asm` rows driven on the world, since a decoded script is only
+## worth the box it puts up. `BikeShopYoungsterText` turns on EVENT_GOT_BICYCLE,
+## `LavenderTownLittleGirlText` asks and branches on the answer, and
+## `CeladonGameCornerText5` is half machine code: while EVENT_GOT_10_COINS is
+## clear it gives coins instead of speaking, and says nothing here.
+const BIKE_SHOP: int = 66
+const BIKE_YOUNGSTER := Vector2i(1, 4)
+const BIKE_FLAG: int = 192
+const BIKE_BOXES: Array[String] = ["These BIKEs are", "Wow. Your BIKE is"]
+const LAVENDER_TOWN: int = 4
+const GHOST_GIRL := Vector2i(15, 10)
+const GHOST_ANSWERS: Array[String] = ["Really? So there", "Hahaha, I guess"]
+const GAME_CORNER: int = 135
+const GAME_CORNER_GAMBLER := Vector2i(5, 12)
+const GAME_CORNER_FLAG: int = 442
+const GAME_CORNER_BOX: String = "Wins seem to come"
+
+## Yellow's `CeruleanBadgeHouse` melanie, the corpus's one box that owes no
+## press: `DisableWaitingAfterTextDisplay` runs before her last `PrintText`.
+const MELANIE_MAP: int = 63
+const MELANIE_CELL := Vector2i(3, 2)
+const MELANIE_FLAG: int = 168
+const MELANIE_BOX: String = "Is BULBASAUR"
+
 var _r: RefCounted = null
 
 
@@ -108,6 +132,7 @@ func _one_game() -> void:
 	_check_ledges()
 	_check_last_map_round_trip()
 	_check_text_boxes()
+	_check_scripted_npcs()
 	_check_the_nurse_heals()
 	_check_the_cable_club()
 	_check_the_vending_machine()
@@ -315,6 +340,71 @@ func _box_text(world: Gen2WorldAPI) -> String:
 	if results.is_empty():
 		return ""
 	return String((results[0].get("event", {}) as Dictionary).get("text", ""))
+
+
+## A decoded `text_asm` row driven on the world, both ways about its own flag.
+func _check_scripted_npcs() -> void:
+	for set_flag: bool in [false, true]:
+		var read: String = _scripted_box(
+			BIKE_SHOP, BIKE_YOUNGSTER, BIKE_FLAG if set_flag else 0
+		)
+		_r.check(read.begins_with(BIKE_BOXES[1 if set_flag else 0]),
+			"the bike shop said %s with the bicycle flag %s." % [read, set_flag])
+	var silent: String = _scripted_box(GAME_CORNER, GAME_CORNER_GAMBLER, 0)
+	_r.check(silent.is_empty(), "the half-read row said %s." % [silent])
+	var spoken: String = _scripted_box(
+		GAME_CORNER, GAME_CORNER_GAMBLER, GAME_CORNER_FLAG
+	)
+	_r.check(spoken.begins_with(GAME_CORNER_BOX), "its other side said %s." % [spoken])
+	_check_the_ghost_girl()
+	if _r.game_id == RomRegistry.YELLOW:
+		_check_a_box_owing_no_press()
+
+
+## The string one interaction opens with, or "" when it opened no box at all.
+## [param flag] is an event flag to set first, or 0 for none.
+func _scripted_box(map: int, cell: Vector2i, flag: int) -> String:
+	var world: Gen2WorldAPI = _r.open_world(0, map, cell)
+	if world == null:
+		return ""
+	if flag > 0:
+		world.set_event_flag(flag)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	return _box_text(world)
+
+
+## `YesNoChoice` answered both ways, which is the routing rather than the
+## strings `tools/checks/gen1_maps.gd` already pins.
+func _check_the_ghost_girl() -> void:
+	for answer: int in [0, 1]:
+		var world: Gen2WorldAPI = _r.open_world(0, LAVENDER_TOWN, GHOST_GIRL)
+		if world == null:
+			return
+		world.player_facing = Gen2WorldSprite.FACING_UP
+		world.interact()
+		var asked: Dictionary = world.pending_script_input()
+		if not _r.check(StringName(asked.get("type", &"")) == &"choice",
+			"the ghost girl asked %s." % [asked]):
+			return
+		var said: String = _event_text(world.choose_script_input(answer))
+		_r.check(said.begins_with(GHOST_ANSWERS[answer]),
+			"answering %d said %s." % [answer, said])
+
+
+## `wDoNotWaitForButtonPressAfterDisplayingText`, which is one box in the corpus.
+func _check_a_box_owing_no_press() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, MELANIE_MAP, MELANIE_CELL)
+	if world == null:
+		return
+	world.set_event_flag(MELANIE_FLAG)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var results: Array = world.interact()
+	if not _r.check(not results.is_empty(), "Melanie said nothing."):
+		return
+	var event: Dictionary = results[0].get("event", {})
+	_r.check(String(event.get("text", "")).begins_with(MELANIE_BOX),
+		"Melanie said %s." % [event.get("text", "")])
+	_r.check(not bool(event.get("prompt", true)), "her box still owes a press.")
 
 
 ## `CableClubNPC` from both sides of `EVENT_GOT_POKEDEX`, each with its own

--- a/tools/checks/tile_anims.gd
+++ b/tools/checks/tile_anims.gd
@@ -7,7 +7,7 @@ var _r: RefCounted = null
 ## from the addresses `Gen2Layout`'s `world_animation_functions` names. What a
 ## reading of them costs is which command ticks `wTileAnimationTimer`:
 ## `StandingTileFrame8` and `StandingTileFrame` do, and so does
-## `ScrollTileRightLeft`, which is the **only** tick the cave, dark cave and ice
+## `ScrollTileRightLeft`, which is the one tick the cave, dark cave and ice
 ## path lists have. A timer that never moves leaves those three maps with a still
 ## water palette and a tile scrolling one way for ever.
 


### PR DESCRIPTION
A `text_asm` row behind a sign or an NPC is Game Boy code rather than a text pointer, so 304 rows on Red and Blue and 358 on Yellow said nothing at all. `Gen1WorldImporter.decode_script` walks that code and keeps the boxes it prints.

## Added

- `decode_script` reads `ld hl` with `call PrintText`, `CheckEvent`'s `ld a, [wEventFlags + n]` and `bit b, a` behind a `jr z` or `jr nz`, `YesNoChoice` through `wCurrentMenuItem`, `set` and `res b, [hl]`, and `DisableWaitingAfterTextDisplay`. Any other opcode or call ends that path, and a path not reaching `TextScriptEnd` is dropped whole instead of kept as a prefix, so a branch whose taken side would give an item says nothing at all, the way an undecoded row does. A call clears the flags, since a routine returns with its own.
- 91 rows on Red and Blue and 74 on Yellow decode, to 126 and 101 boxes over 71 and 63 event branches and 6 and 5 YES/NO questions; 46 and 44 branch sides stay unread.
- `Gen2WorldAPI._gen1_script_steps` resolves the tree against the save, and an event flag a row writes is spent on the way past the step list.
- `tools/checks/gen1_maps.gd` sweeps the corpus and pins `LavenderTownLittleGirlText`'s own two answers; `gen1_walk.gd` drives the Bike Shop youngster from both sides of EVENT_GOT_BICYCLE, answers the ghost girl both ways, and reads the corpus's one box owing no press. Both go red when the branch or the answer is flipped.
- `tests/unit/test_gen1_script.gd`, thirteen cases over built bytes, most of them shapes that have to answer nothing.

## Changed

- `pending_script_input` answers a Generation 1 box owing no press, so frames rather than a button close it.
- The cache format is bumped to 111. Every cartridge wants re-importing.

## Verified

| Run | Result |
|---|---|
| `validate.gd -- all` | 85 topics pass on six cartridges |
| GUT, whole tier | 4387 tests, 172 scripts, all pass |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| `--warning-scan` | 0 warnings in 632 scripts |
| Re-import | 6/6, `Layout verified.` on each |