### PR TITLE
Take a Generation 1 gift into the bag

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -558,18 +558,27 @@ const TRAINER_RANGE_SHIFT: int = 4
 ## ends the path [method Gen1WorldImporter.decode_script] is walking.
 const TEXT_ASM: int = 0x08
 const SCRIPT_LD_HL: int = 0x21
+const SCRIPT_LD_BC: int = 0x01
+const SCRIPT_LD_B: int = 0x06
 const SCRIPT_LD_A: int = 0x3E
 const SCRIPT_LD_A_MEM: int = 0xFA
 const SCRIPT_LD_MEM_A: int = 0xEA
+const SCRIPT_LDH_MEM_A: int = 0xE0
 const SCRIPT_AND_A: int = 0xA7
 const SCRIPT_PREFIX: int = 0xCB
 const SCRIPT_JR: int = 0x18
 const SCRIPT_JP: int = 0xC3
 const SCRIPT_RET: int = 0xC9
 const SCRIPT_CALL: int = 0xCD
+const SCRIPT_HRAM_BASE: int = 0xFF00
 ## Each key is a conditional `jr` or `jp`, the value whether it is taken when
-## the tested bit was set.
+## the tested bit was set; the carry rows read the flag a routine answers in.
 const SCRIPT_BRANCHES: Dictionary = {0x20: true, 0xC2: true, 0x28: false, 0xCA: false}
+const SCRIPT_CARRY_BRANCHES: Dictionary = {0x38: true, 0xDA: true, 0x30: false, 0xD2: false}
+const SCRIPT_CALLS: Array[String] = [
+	"print_text", "text_script_end", "disable_waiting", "yes_no_choice",
+	"give_item", "is_item_in_bag", "bankswitch", "play_cry", "wait_for_sound",
+]
 const SCRIPT_SHORT_SIZE: int = 2
 const SCRIPT_LONG_SIZE: int = 3
 ## The `CB` prefix's three rows, the low three bits naming the operand.
@@ -580,6 +589,8 @@ const SCRIPT_OPERAND_A: int = 7
 const SCRIPT_OPERAND_HL: int = 6
 ## `flag_array NUM_EVENTS`: 2,560 events on all three cartridges.
 const EVENT_FLAG_BYTES: int = 320
+## `BAG_ITEM_CAPACITY`: one list of slots, not four pockets.
+const BAG_ITEM_CAPACITY: int = 20
 ## `MAX_WARP_EVENTS`, `MAX_BG_EVENTS` and `MAX_OBJECT_EVENTS`.
 const MAX_WARP_EVENTS: int = 32
 const MAX_SIGN_EVENTS: int = 16
@@ -764,8 +775,14 @@ const RED_BLUE: Dictionary = {
 	"disable_waiting": 0x30B6,
 	"play_cry": 0x13D0,
 	"wait_for_sound": 0x3748,
+	"give_item": 0x3E2E,
+	"is_item_in_bag": 0x3493,
+	"bankswitch": 0x35D6,
+	"remove_item": 0x7F37,
+	"remove_item_bank": 0x05,
 	"do_not_wait": 0xCC3C,
 	"current_menu_item": 0xCC26,
+	"item_to_remove": 0xFFDB,
 	## `DisplayPokemartDialogue`'s own greeting and the head of the two facility
 	## text runs [constant MART_TEXT_AT] and its neighbour walk. Every offset
 	## here is `pokered.sym`'s, which builds both dumps.
@@ -846,8 +863,14 @@ const YELLOW: Dictionary = {
 	"disable_waiting": 0x2FDE,
 	"play_cry": 0x118B,
 	"wait_for_sound": 0x373E,
+	"give_item": 0x3E3F,
+	"is_item_in_bag": 0x3422,
+	"bankswitch": 0x3E84,
+	"remove_item": 0x7DBB,
+	"remove_item_bank": 0x05,
 	"do_not_wait": 0xCC3C,
 	"current_menu_item": 0xCC26,
+	"item_to_remove": 0xFFDB,
 	"mart_greeting": 0x02938,
 	"mart_text": 0x06B91,
 	"pokecenter_text": 0x06ED0,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -819,15 +819,16 @@ const SCRIPT_BUDGET: int = 512
 const SCRIPT_DEPTH: int = 8
 const SCRIPT_END: int = -2
 const SCRIPT_UNREAD: int = -1
-## What a `jr z` is testing: an event flag by index, or the YES/NO answer.
+## What a branch is testing: an event flag by index, or one of these.
 const SCRIPT_TESTS_CHOICE: int = -1
 const SCRIPT_TESTS_NOTHING: int = -2
+const SCRIPT_TESTS_CARRY: int = -3
+const SCRIPT_TESTS_ITEM: int = -4
 
 
 ## One `text_asm` row's machine code, as the boxes it prints and the branches
 ## choosing between them. Only the routines the layout names are read, and a
-## path reaching anything else is dropped whole rather than kept as a prefix
-## that stops mid-interaction.
+## path reaching anything else is dropped whole rather than kept as a prefix.
 static func decode_script(
 	rom: RomFile, layout: Dictionary, bank: int, at: int
 ) -> Array:
@@ -850,7 +851,7 @@ static func _walk_script(
 	while budget[0] > 0:
 		budget[0] -= 1
 		var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
-		if Gen1Layout.SCRIPT_BRANCHES.has(op):
+		if Gen1Layout.SCRIPT_BRANCHES.has(op) or Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op):
 			return _script_branch(ctx, op, pc, state, depth, out)
 		var next: int = _script_step(ctx, pc, state, out)
 		if next == SCRIPT_END:
@@ -880,6 +881,14 @@ static func _script_step(
 		Gen1Layout.SCRIPT_LD_HL:
 			state["hl"] = rom.u16le(at + 1)
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
+		Gen1Layout.SCRIPT_LD_BC:
+			## `lb bc, ITEM, COUNT`: the high byte is what `GiveItem` reads as b.
+			state["b"] = rom.u8(at + 2)
+			state["c"] = rom.u8(at + 1)
+			return pc + Gen1Layout.SCRIPT_LONG_SIZE
+		Gen1Layout.SCRIPT_LD_B:
+			state["b"] = rom.u8(at + 1)
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_LD_A:
 			state["a"] = rom.u8(at + 1)
 			state.erase("source")
@@ -891,6 +900,10 @@ static func _script_step(
 		Gen1Layout.SCRIPT_LD_MEM_A:
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE \
 				if _script_stored(ctx, rom.u16le(at + 1), state) else SCRIPT_UNREAD
+		Gen1Layout.SCRIPT_LDH_MEM_A:
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE if _script_stored(
+				ctx, Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(at + 1), state
+			) else SCRIPT_UNREAD
 		Gen1Layout.SCRIPT_AND_A:
 			state["tests"] = _script_tests(ctx, state, -1)
 			return pc + 1
@@ -913,12 +926,17 @@ static func _script_hop(operand: int) -> int:
 	return operand - 0x100 if operand > 0x7F else operand
 
 
-## The one memory write read here: `DisableWaitingAfterTextDisplay` by hand.
+## `DisableWaitingAfterTextDisplay` by hand, and `RemoveItemByID`'s own item.
 static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> bool:
-	if address != int((ctx["layout"] as Dictionary)["do_not_wait"]) \
-		or int(state.get("a", 0)) != 1:
+	var layout: Dictionary = ctx["layout"]
+	if address == int(layout["do_not_wait"]):
+		if int(state.get("a", 0)) != 1:
+			return false
+		state["no_press"] = true
+		return true
+	if address != int(layout["item_to_remove"]) or int(state.get("a", 0)) < 1:
 		return false
-	state["no_press"] = true
+	state["remove"] = int(state["a"])
 	return true
 
 
@@ -974,24 +992,72 @@ static func _script_call(
 	## A routine returns with flags of its own, so a `jr z` behind a call is
 	## reading them rather than whatever set them before it.
 	state.erase("tests")
-	if target == int(layout["print_text"]):
-		var box: Dictionary = _script_box(ctx, int(state.get("hl", 0)))
-		if box.is_empty():
-			return SCRIPT_UNREAD
-		out.append(box)
-		return next
-	if target == int(layout["text_script_end"]):
-		return SCRIPT_END
-	if target == int(layout["disable_waiting"]):
-		state["no_press"] = true
-		return next
-	if target == int(layout["yes_no_choice"]):
-		state["source"] = int(layout["current_menu_item"])
-		state.erase("a")
-		return next
-	if target == int(layout["play_cry"]) or target == int(layout["wait_for_sound"]):
-		return next
+	match _script_routine(layout, target):
+		"print_text":
+			var box: Dictionary = _script_box(ctx, int(state.get("hl", 0)))
+			if box.is_empty():
+				return SCRIPT_UNREAD
+			out.append(box)
+			return next
+		"text_script_end":
+			return SCRIPT_END
+		"disable_waiting":
+			state["no_press"] = true
+			return next
+		"yes_no_choice":
+			state["source"] = int(layout["current_menu_item"])
+			state.erase("a")
+			return next
+		"give_item":
+			return _script_gift(state, out, next)
+		"is_item_in_bag":
+			return _script_asked(state, next)
+		"bankswitch":
+			return _script_far(layout, state, out, next)
+		"play_cry", "wait_for_sound":
+			return next
 	return SCRIPT_UNREAD
+
+
+static func _script_routine(layout: Dictionary, target: int) -> String:
+	for name: String in Gen1Layout.SCRIPT_CALLS:
+		if int(layout.get(name, -1)) == target:
+			return name
+	return ""
+
+
+## `GiveItem` reads the item in b and the count in c, answers in carry, drops bc.
+static func _script_gift(state: Dictionary, out: Array, next: int) -> int:
+	if not state.has("b") or not state.has("c") or int(state["c"]) < 1:
+		return SCRIPT_UNREAD
+	out.append({"op": "give_item", "item": int(state["b"]), "count": int(state["c"])})
+	state.erase("b")
+	state.erase("c")
+	state["tests"] = SCRIPT_TESTS_CARRY
+	return next
+
+
+## `IsItemInBag` reads b and sets zero when the bag does not hold it.
+static func _script_asked(state: Dictionary, next: int) -> int:
+	if not state.has("b"):
+		return SCRIPT_UNREAD
+	state["asked"] = int(state["b"])
+	state.erase("b")
+	state["tests"] = SCRIPT_TESTS_ITEM
+	return next
+
+
+## `farcall` is `ld b, BANK`, `ld hl, target`, `call Bankswitch`.
+static func _script_far(
+	layout: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	if int(state.get("b", -1)) != int(layout["remove_item_bank"]) \
+		or int(state.get("hl", -1)) != int(layout["remove_item"]) \
+		or int(state.get("remove", 0)) < 1:
+		return SCRIPT_UNREAD
+	out.append({"op": "take_item", "item": int(state["remove"])})
+	state.erase("remove")
+	return next
 
 
 ## One `PrintText` box, empty when the pointer does not decode to a string.
@@ -1011,7 +1077,8 @@ static func _script_branch(
 	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
 ) -> Variant:
 	var tests: int = int(state.get("tests", SCRIPT_TESTS_NOTHING))
-	if tests == SCRIPT_TESTS_NOTHING:
+	var carry: bool = Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op)
+	if tests == SCRIPT_TESTS_NOTHING or carry != (tests == SCRIPT_TESTS_CARRY):
 		return null
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
@@ -1022,22 +1089,46 @@ static func _script_branch(
 		_walk_script(ctx, jumped, state.duplicate(), depth + 1),
 		_walk_script(ctx, pc + size, state.duplicate(), depth + 1),
 	]
-	if not bool(Gen1Layout.SCRIPT_BRANCHES[op]):
+	var table: Dictionary = Gen1Layout.SCRIPT_CARRY_BRANCHES if carry \
+		else Gen1Layout.SCRIPT_BRANCHES
+	if not bool(table[op]):
 		branches.reverse()
 	if branches[0] == null and branches[1] == null:
 		return null
-	out.append(_script_node(tests, branches))
+	var node: Variant = _script_node(tests, branches, state, out)
+	if node == null:
+		return null
+	out.append(node)
 	return out
 
 
 ## `wCurrentMenuItem` is 0 for YES, so the branch taken when it is not zero is
-## NO. An event flag reads the other way about: the taken side is the set one.
-static func _script_node(tests: int, branches: Array) -> Dictionary:
+## NO. Every other test reads the other way about: the taken side is the set
+## one, a set carry or an item the bag holds.
+static func _script_node(
+	tests: int, branches: Array, state: Dictionary, out: Array
+) -> Variant:
 	var taken: Array = branches[0] if branches[0] != null else [{"op": "unknown"}]
 	var fell: Array = branches[1] if branches[1] != null else [{"op": "unknown"}]
-	if tests == SCRIPT_TESTS_CHOICE:
-		return {"op": "choice", "no": taken, "yes": fell}
+	match tests:
+		SCRIPT_TESTS_CHOICE:
+			return {"op": "choice", "no": taken, "yes": fell}
+		SCRIPT_TESTS_CARRY:
+			return _script_receipt(out, taken, fell)
+		SCRIPT_TESTS_ITEM:
+			return {"op": "has_item", "item": int(state["asked"]),
+				"then": taken, "else": fell}
 	return {"op": "branch", "flag": tests, "then": taken, "else": fell}
+
+
+## The carry belongs to the gift in front of it, so both sides fold onto it.
+static func _script_receipt(out: Array, taken: Array, fell: Array) -> Variant:
+	if out.is_empty() or String((out[-1] as Dictionary)["op"]) != "give_item":
+		return null
+	var gift: Dictionary = out.pop_back()
+	gift["ok"] = taken
+	gift["full"] = fell
+	return gift
 
 
 ## One `trainer` row. `TrainerFlagAction` counts the bit off the address two

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3710,8 +3710,7 @@ func gen1_last_map() -> int:
 
 
 ## `IsSpriteOrSignInFrontOfPlayer`: a sign on the faced cell answers first and
-## returns, and only then is a sprite looked for. A Generation 1 script is
-## machine code this port does not run, so a box is the whole of an interaction.
+## returns, and only then is a sprite looked for.
 func _gen1_interact() -> Array:
 	if current_map == null:
 		return []
@@ -3749,14 +3748,19 @@ func _gen1_script_steps(row: Dictionary) -> Array:
 	if not nodes is Array or (nodes as Array).is_empty():
 		return []
 	var steps: Array = []
-	return steps if _gen1_resolve_script(nodes as Array, steps) else []
+	return steps if _gen1_resolve_script(nodes as Array, steps, {
+		"bag": state.items() if state != null else {}, "named": "",
+	}) else []
 
 
-func _gen1_resolve_script(nodes: Array, steps: Array) -> bool:
+## [param run] is the bag the row is walked against, carrying what its own gifts
+## have already put in it, and the name `CopyToStringBuffer` last wrote.
+func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
+	var bag: Dictionary = run["bag"]
 	for node: Dictionary in nodes:
 		match String(node.get("op", "")):
 			"text":
-				steps.append(_gen1_script_box(node))
+				steps.append(_gen1_script_box(node, String(run["named"])))
 			"flag":
 				steps.append({
 					"type": &"flag",
@@ -3764,27 +3768,72 @@ func _gen1_resolve_script(nodes: Array, steps: Array) -> bool:
 					"set": bool(node["set"]),
 				})
 			"branch":
-				var side: String = "then" if event_flag_active(int(node["flag"])) else "else"
-				if not _gen1_resolve_script(node[side] as Array, steps):
+				if not _gen1_resolve_side(
+					node, event_flag_active(int(node["flag"])), steps, run
+				):
 					return false
+			"has_item":
+				if not _gen1_resolve_side(
+					node, int(bag.get(int(node["item"]), 0)) > 0, steps, run
+				):
+					return false
+			"give_item":
+				if not _gen1_resolve_gift(node, steps, run):
+					return false
+			"take_item":
+				_gen1_take_item(int(node["item"]), steps, bag)
 			"choice":
-				return _gen1_script_choice(node, steps)
+				return _gen1_script_choice(node, steps, run)
 			_:
 				return false
 	return true
 
 
+func _gen1_resolve_side(
+	node: Dictionary, taken: bool, steps: Array, run: Dictionary
+) -> bool:
+	return _gen1_resolve_script(node["then" if taken else "else"] as Array, steps, run)
+
+
+## `AddItemToInventory` and its carry; only a gift that landed is named.
+func _gen1_resolve_gift(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var item: int = int(node["item"])
+	var bag: Dictionary = run["bag"]
+	var room: Dictionary = Gen2WorldPack.receive_check(
+		data, bag, item, int(node["count"])
+	)
+	var taken: bool = bool(room.get("ok", false))
+	if taken:
+		bag[item] = int(room["quantity"])
+		run["named"] = data.item_name(item) if data != null else ""
+		steps.append({"type": &"items", "items": {item: int(room["quantity"])}})
+	if not node.has("ok"):
+		return true
+	return _gen1_resolve_script(node["ok" if taken else "full"] as Array, steps, run)
+
+
+func _gen1_take_item(item: int, steps: Array, bag: Dictionary) -> void:
+	var left: int = int(bag.get(item, 0)) - 1
+	if left < 0:
+		return
+	if left == 0:
+		bag.erase(item)
+	else:
+		bag[item] = left
+	steps.append({"type": &"items", "items": {item: left}})
+
+
 ## `YesNoChoice` stands behind the box that asked, so the question is the last
 ## box printed.
-func _gen1_script_choice(node: Dictionary, steps: Array) -> bool:
+func _gen1_script_choice(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	if steps.is_empty() \
 		or StringName((steps[-1] as Dictionary).get("type", &"")) != &"text":
 		return false
 	var question: Dictionary = steps.pop_back()
 	var yes: Array = []
 	var no: Array = []
-	if not _gen1_resolve_script(node["yes"] as Array, yes) \
-		or not _gen1_resolve_script(node["no"] as Array, no):
+	if not _gen1_resolve_script(node["yes"] as Array, yes, _gen1_run_copy(run)) \
+		or not _gen1_resolve_script(node["no"] as Array, no, _gen1_run_copy(run)):
 		return false
 	steps.append({
 		"type": &"choice", "text": String(question["text"]), "yes": yes, "no": no,
@@ -3792,10 +3841,17 @@ func _gen1_script_choice(node: Dictionary, steps: Array) -> bool:
 	return true
 
 
-func _gen1_script_box(node: Dictionary) -> Dictionary:
-	var step: Dictionary = {
-		"type": &"text", "text": _gen1_filled_text(String(node.get("text", ""))),
-	}
+func _gen1_run_copy(run: Dictionary) -> Dictionary:
+	return {"bag": (run["bag"] as Dictionary).duplicate(), "named": run["named"]}
+
+
+func _gen1_script_box(node: Dictionary, named: String) -> Dictionary:
+	var text: String = _gen1_filled_text(String(node.get("text", "")))
+	if not named.is_empty():
+		text = Gen2TextStream.fill_all_markers(
+			text, Gen2TextStream.RAM_MARKER, named
+		)
+	var step: Dictionary = {"type": &"text", "text": text}
 	if not bool(node.get("press", true)):
 		step["press"] = false
 	return step
@@ -4202,13 +4258,11 @@ func _gen1_step(type: StringName) -> Dictionary:
 	return step if StringName(step.get("type", &"")) == type else {}
 
 
-## The result the head step is waiting on, empty once the list is spent. An
-## event flag a row writes takes no turn of its own and is spent on the way past.
+## The result the head step is waiting on, empty once the list is spent. What a
+## row writes takes no turn of its own and is spent on the way past.
 func _gen1_result() -> Array:
-	while not _gen1_steps.is_empty() \
-		and StringName((_gen1_steps[0] as Dictionary)["type"]) == &"flag":
-		var written: Dictionary = _gen1_steps.pop_front()
-		state.set_event_flag(int(written["flag"]), bool(written["set"]))
+	while not _gen1_steps.is_empty() and _gen1_written(_gen1_steps[0]):
+		_gen1_steps.pop_front()
 	if _gen1_steps.is_empty():
 		return []
 	var step: Dictionary = _gen1_steps[0]
@@ -4237,6 +4291,17 @@ func _gen1_result() -> Array:
 			"prompt": bool(step.get("press", true)),
 		},
 	}]
+
+
+func _gen1_written(step: Dictionary) -> bool:
+	match StringName(step["type"]):
+		&"flag":
+			state.set_event_flag(int(step["flag"]), bool(step["set"]))
+			return true
+		&"items":
+			state.apply_changes({}, {}, {"items": step["items"]})
+			return true
+	return false
 
 
 ## Spends the head step and answers with whatever the next one waits on.

--- a/game/world/world_mart_host.gd
+++ b/game/world/world_mart_host.gd
@@ -6,7 +6,6 @@ extends RefCounted
 ## writeback for one purchase off `BuyMenu` or one sale off `SellMenu`.
 
 const MONEY_ACCOUNT: int = 0
-const MAX_ITEM_STACK: int = 99
 
 const MARTTYPE_STANDARD: int = 0
 const MARTTYPE_BITTER: int = 1
@@ -16,12 +15,10 @@ const MARTTYPE_ROOFTOP: int = 4
 
 
 ## Resolves the source pokemart dialog before the UI is opened. Standard,
-## bitter and pharmacy shops use the indexed pointer; bargain and rooftop
-## shops use their imported priced records.
-##
-## [param inline_items] stands in for the indexed record when the inventory
-## travels with the request: a catalog site's shelf, and every Generation 1
-## counter, whose list `script_mart` writes into the text pointer.
+## bitter and pharmacy shops use the indexed pointer; bargain and rooftop shops
+## their imported priced records. [param inline_items] stands in for the indexed
+## record when the inventory travels with the request, which every Generation 1
+## counter does: `script_mart` writes its list into the text pointer.
 static func resolve_mart(
 	data: GameData, dialog_id: int, mart_id: int, rooftop_after_hall: bool = false,
 	world_state: Gen2WorldState = null, inline_items: Array = []
@@ -157,8 +154,7 @@ static func purchase(
 
 
 ## `VendingMachineMenu`'s purchase: `HasEnoughMoney` refuses first, then
-## `GiveItem`, at the machine's price rather than `ItemPrices`'. The refusal
-## reasons are the shop's, so a caller can pick its box off them.
+## `GiveItem`, at the machine's price rather than `ItemPrices`'.
 static func vend(
 	world: Gen2WorldAPI, save: Gen2SaveData, row: Dictionary, persist: bool = true
 ) -> Dictionary:
@@ -170,11 +166,14 @@ static func vend(
 	if price > balance:
 		return _failure(&"insufficient_money", {"item": item, "price": price})
 	var owned: int = world.state.item_quantity(item)
-	if owned + 1 > MAX_ITEM_STACK:
-		return _failure(&"item_stack_full", {"item": item, "owned": owned})
+	var room: Dictionary = Gen2WorldPack.receive_check(
+		world.data, world.state.items(), item, 1
+	)
+	if not bool(room.get("ok", false)):
+		return _failure(StringName(room["reason"]), {"item": item, "owned": owned})
 	var before: Gen2WorldSnapshot = world.snapshot()
 	var applied: Dictionary = world.state.apply_changes({}, {}, {
-		"items": {item: owned + 1},
+		"items": {item: int(room["quantity"])},
 		"money": {MONEY_ACCOUNT: balance - price},
 	})
 	if not bool(applied.get("ok", false)):
@@ -212,7 +211,6 @@ static func _purchase_refusal(
 	var price: int = int(selected.get("price", 0))
 	var total: int = price * quantity
 	var owned: int = world.state.item_quantity(item)
-	var next_quantity: int = owned + quantity
 	## `BuyMenuLoop` runs `CompareMoney` before `ReceiveItem`: price refuses first.
 	var balance: int = world.state.money(MONEY_ACCOUNT)
 	if total < 0 or total > balance:
@@ -220,11 +218,16 @@ static func _purchase_refusal(
 			"item": item, "price": price, "quantity": quantity,
 			"total": total, "balance": balance,
 		})
-	if next_quantity > MAX_ITEM_STACK:
-		return _failure(&"item_stack_full", {
+	## `.insufficient_bag_space`: `ReceiveItem` refuses a full pocket too.
+	var room: Dictionary = Gen2WorldPack.receive_check(
+		world.data, world.state.items(), item, quantity
+	)
+	if not bool(room.get("ok", false)):
+		return _failure(StringName(room["reason"]), {
 			"item": item, "quantity": quantity, "owned": owned,
-			"maximum": MAX_ITEM_STACK,
+			"maximum": Gen2WorldPack.MAX_ITEM_STACK,
 		})
+	var next_quantity: int = int(room["quantity"])
 	return {
 		"ok": true,
 		"is_bargain": is_bargain,

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -1,14 +1,12 @@
 class_name Gen2WorldPack
 extends RefCounted
 
-## Scene-free grouping of owned items into the cartridge's four pack pockets.
-## [Gen2WorldState] stores items as a flat item-to-quantity map and this is
-## presentation only. Classification uses the item type byte GameData imports under
-## the confusingly-named `pocket` field, which is what decides a real item's
-## pocket. The save remains flat, so one item cannot be split into two 99-count
-## stacks like the source's packed pocket arrays can. Pockets registered on
-## [Gen2ModHost] follow the four source ones, and the item submenu below is
-## `engine/items/pack.asm`'s own header selection.
+## Scene-free grouping of owned items into the cartridge's four pack pockets,
+## and the one answer to whether the bag can take another. [Gen2WorldState]
+## stores items flat, so one item cannot be split into two 99-count stacks the
+## way the source's packed pocket arrays can. Classification is the item type
+## byte GameData imports under the confusingly-named `pocket` field; a pocket
+## registered on [Gen2ModHost] follows the four source ones.
 
 const TYPE_ITEM: int = 1
 const TYPE_KEY_ITEM: int = 2
@@ -43,11 +41,9 @@ const SOURCE_POCKET_NAMES: Dictionary = {
 	TYPE_TM_HM: "TM POCKET",
 }
 
-## `ITEMATTR_PERMISSIONS` bits and the field-menu nibble `CheckItemMenu` returns,
-## named here in this file's own terms but valued from the import layer, so the
-## numbers stay defined once. A set permission bit is what the item *cannot* do,
-## which is why the source's own branch labels around
-## `.ItemBallsKey_LoadSubmenu` read backwards.
+## `ITEMATTR_PERMISSIONS` bits and the field-menu nibble `CheckItemMenu` returns.
+## A set permission bit is what the item *cannot* do, which is why the source's
+## own branch labels around `.ItemBallsKey_LoadSubmenu` read backwards.
 const CANT_SELECT: int = Gen2Layout.ITEM_ATTRIBUTE_CANT_SELECT
 const CANT_TOSS: int = Gen2Layout.ITEM_ATTRIBUTE_CANT_TOSS
 const ITEMMENU_NOUSE: int = Gen2Layout.ITEMMENU_NOUSE
@@ -153,10 +149,7 @@ static func source_pocket_name(data: GameData, item: int) -> String:
 ## The five rows `ScrollingMenu_UpdateDisplay` writes, out of one pocket's own
 ## items and the CANCEL row after them. The TM/HM pocket is
 ## `TMHM_DisplayPocketItems`, which prints the TM number and the move it teaches
-## rather than the item's name. Here rather than in the screen that scrolls them,
-## because the pack listing is drawn on more than one screen and only one of them
-## owns a cursor. [param cancel] is the row that closes the pack: a screen that
-## cannot be closed asks for the listing without it.
+## rather than the item's name. [param cancel] is the row that closes the pack.
 static func list_rows(
 	data: GameData, pocket_type: int, items: Array, scroll: int = 0,
 	cancel: bool = true
@@ -461,10 +454,8 @@ static func pocket_capacity(pocket_type: int) -> int:
 
 
 ## Mirrors ReceiveItem's all-or-nothing result for the flat save model. Existing
-## stacks may grow up to MAX_ITEM_STACK; a new item also consumes one pocket
-## entry. TM/HM and unclassified fixture rows have no count limit here because
-## the source routes TMs through their separate numbered table and mods may add
-## their own pocket types.
+## stacks may grow up to MAX_ITEM_STACK; a new item also takes one pocket entry.
+## A Generation 2 TM/HM row and a mod's own pocket have no entry limit here.
 static func receive_check(
 	data: GameData, owned: Dictionary, item: int, quantity: int
 ) -> Dictionary:
@@ -476,16 +467,24 @@ static func receive_check(
 	if current + quantity > MAX_ITEM_STACK:
 		return {"ok": false, "reason": &"item_stack_full", "available": MAX_ITEM_STACK - current}
 	var pocket: int = pocket_for(data, item)
-	var capacity: int = pocket_capacity(pocket)
-	if current == 0 and capacity > 0:
-		var entries: int = 0
-		for raw_item: Variant in owned:
-			if int(owned[raw_item]) <= 0 or pocket_for(data, int(raw_item)) != pocket:
-				continue
-			entries += 1
-		if entries >= capacity:
-			return {"ok": false, "reason": &"pocket_full", "pocket": pocket}
+	var capacity: int = pocket_capacity(pocket) if data.generation != RomRegistry.GEN1 \
+		else Gen1Layout.BAG_ITEM_CAPACITY
+	if current == 0 and capacity > 0 and _pocket_entries(data, owned, pocket) >= capacity:
+		return {"ok": false, "reason": &"pocket_full", "pocket": pocket}
 	return {"ok": true, "quantity": current + quantity}
+
+
+## How many slots [param pocket] stands in; Generation 1's whole bag is one.
+static func _pocket_entries(data: GameData, owned: Dictionary, pocket: int) -> int:
+	var gen1: bool = data.generation == RomRegistry.GEN1
+	var entries: int = 0
+	for raw_item: Variant in owned:
+		if int(owned[raw_item]) <= 0:
+			continue
+		if not gen1 and pocket_for(data, int(raw_item)) != pocket:
+			continue
+		entries += 1
+	return entries
 
 
 ## `GiveTakePartyMonItem`'s own wording (`data/text/common_2.asm`), shared by the

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -822,10 +822,12 @@ func _buy_prize(row: Dictionary) -> String:
 		return _prize_text("need_more_coins", GEN1_PRIZE_RUN_2)
 	var number: int = int(row.get("item", 0))
 	if _prize_tms:
-		var owned: int = _world.state.item_quantity(number)
-		if owned + 1 > Gen2WorldMartHost.MAX_ITEM_STACK:
+		var room: Dictionary = Gen2WorldPack.receive_check(
+			_data, _world.state.items(), number, 1
+		)
+		if not bool(room.get("ok", false)):
 			return _prize_text("bag_full", GEN1_PRIZE_RUN_2)
-		_world.state.apply_changes({}, {}, {"items": {number: owned + 1}})
+		_world.state.apply_changes({}, {}, {"items": {number: int(room["quantity"])}})
 	elif not bool(Gen2WorldPartyHost.give_pokemon(
 		_world, _save, number, int(row.get("level", 1)), _persist
 	).get("ok", false)):
@@ -1120,7 +1122,7 @@ func _move_mart_cursor(delta: int) -> void:
 ## against `wItemQuantity`, which `StandardMartAskPurchaseQuantity` sets to the
 ## whole stack rather than to what the money or the pack allows.
 func _press_mart_quantity(button: int) -> void:
-	var maximum: int = Gen2WorldMartHost.MAX_ITEM_STACK
+	var maximum: int = Gen2WorldPack.MAX_ITEM_STACK
 	match button:
 		PokeButton.UP, PokeButton.DOWN, PokeButton.LEFT, PokeButton.RIGHT:
 			_mart_quantity = Gen2WorldQuantityPrompt.stepped(
@@ -1175,7 +1177,7 @@ func _buy_mart_selection() -> void:
 		var reason: StringName = StringName(purchase.get("reason", &""))
 		var slot: String = {
 			&"insufficient_money": "no_money", &"item_stack_full": "pack_full",
-			&"bargain_item_sold_out": "sold_out",
+			&"pocket_full": "pack_full", &"bargain_item_sold_out": "sold_out",
 		}.get(reason, "")
 		if slot.is_empty():
 			_status = "Purchase failed: %s" % String(reason)
@@ -1929,12 +1931,11 @@ func _confirm_pc_item() -> void:
 		_:
 			applied = Gen2WorldPC.toss(_world, _save, item, _pc_quantity, _persist)
 	if not bool(applied.get("ok", false)):
-		## `.PackFull` and `.NoRoomInPC` are the two the source has a box for;
-		## everything else is a refusal it never reaches.
+		## `.PackFull` and `.NoRoomInPC` are the two the source has a box for.
 		var reason: StringName = StringName(applied.get("reason", &""))
 		_status = {
 			&"pc_full": "no_room_deposit", &"pack_full": "no_room_withdraw",
-			&"item_stack_full": "no_room_withdraw",
+			&"item_stack_full": "no_room_withdraw", &"pocket_full": "no_room_withdraw",
 		}.get(reason, "")
 		_status = _data.pokecenter_pc_text(_status) if not _status.is_empty() \
 			else "Refused: %s" % String(reason)

--- a/tests/integration/test_world_service_screen.gd
+++ b/tests/integration/test_world_service_screen.gd
@@ -576,7 +576,7 @@ func test_mart_overlay_purchases_the_selected_quantity() -> void:
 	assert_true(host.handle_button(PokeButton.LEFT))
 	assert_eq(host._mart_quantity, 1)
 	assert_true(host.handle_button(PokeButton.DOWN))
-	assert_eq(host._mart_quantity, Gen2WorldMartHost.MAX_ITEM_STACK)
+	assert_eq(host._mart_quantity, Gen2WorldPack.MAX_ITEM_STACK)
 	assert_true(host.handle_button(PokeButton.UP))
 	assert_eq(host._mart_quantity, 1)
 	assert_true(host.handle_button(PokeButton.UP))

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -16,6 +16,12 @@ const LAYOUT: Dictionary = {
 	"current_menu_item": 0xCC26,
 	"event_flags": 0xD747,
 	"talk_to_trainer": 0x0160,
+	"give_item": 0x0170,
+	"is_item_in_bag": 0x0180,
+	"bankswitch": 0x0190,
+	"remove_item": 0x7F37,
+	"remove_item_bank": 0x05,
+	"item_to_remove": 0xFFDB,
 }
 const AT: int = 0x1000
 const HELLO: int = 0x1800
@@ -195,3 +201,85 @@ func test_a_row_that_never_ends_answers_nothing() -> void:
 
 func test_a_box_that_does_not_decode_answers_nothing() -> void:
 	assert_eq(_decode(_print(HELLO) + _call(int(LAYOUT["text_script_end"]))), [])
+
+
+## `lb bc, ITEM, COUNT` then `call GiveItem`, with `jr nc` onto the refusal.
+func _give(item: int, count: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_BC, count, item] + _call(int(LAYOUT["give_item"]))
+
+
+func test_a_gift_folds_both_sides_of_its_carry_onto_one_node() -> void:
+	## `jr nc` hops over the receipt onto the refusal, so the taken side is the
+	## bag that had no room and the one laid out first is the gift that landed.
+	var received: Array = _print(HELLO) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_give(0xF1, 1) + [0x30, received.size()] + received
+			+ _print(BYE) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "give_item", "item": 0xF1, "count": 1,
+		"ok": [{"op": "text", "text": "HI"}],
+		"full": [{"op": "text", "text": "BYE"}],
+	}])
+
+
+func test_a_gift_with_no_item_loaded_answers_nothing() -> void:
+	assert_eq(_decode(
+		_call(int(LAYOUT["give_item"])) + _call(int(LAYOUT["text_script_end"]))
+	), [])
+
+
+func test_a_carry_branch_behind_a_flag_test_answers_nothing() -> void:
+	# `jr nc` reads the flag a routine returned in, which `bit b, a` never wrote.
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	assert_eq(_decode(
+		_check_event(37) + [0x30, clear.size()] + clear
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	), [])
+
+
+func test_a_zero_branch_behind_a_gift_answers_nothing() -> void:
+	var full: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	assert_eq(_decode(
+		_give(0xF1, 1) + [0x20, full.size()] + full
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	), [])
+
+
+## `ld b, ITEM` then `call IsItemInBag`, which sets zero when the bag has none.
+func test_an_item_test_keeps_the_item_and_both_sides() -> void:
+	var missing: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		[Gen1Layout.SCRIPT_LD_B, 0x45] + _call(int(LAYOUT["is_item_in_bag"]))
+			+ [0x20, missing.size()] + missing
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "has_item", "item": 0x45,
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "text", "text": "BYE"}],
+	}])
+
+
+## `ldh [hItemToRemoveID], a` then `farcall RemoveItemByID`.
+func test_a_far_call_to_remove_an_item_becomes_its_own_node() -> void:
+	var script: Array = _decode(
+		[Gen1Layout.SCRIPT_LD_A, 0x40, Gen1Layout.SCRIPT_LDH_MEM_A, 0xDB,
+			Gen1Layout.SCRIPT_LD_B, 0x05]
+			+ _load_hl(0x7F37) + _call(int(LAYOUT["bankswitch"]))
+			+ _call(int(LAYOUT["text_script_end"]))
+	)
+	assert_eq(script, [{"op": "take_item", "item": 0x40}])
+
+
+func test_a_far_call_to_anything_else_answers_nothing() -> void:
+	assert_eq(_decode(
+		[Gen1Layout.SCRIPT_LD_A, 0x40, Gen1Layout.SCRIPT_LDH_MEM_A, 0xDB,
+			Gen1Layout.SCRIPT_LD_B, 0x05]
+			+ _load_hl(0x4000) + _call(int(LAYOUT["bankswitch"]))
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [])

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -170,6 +170,24 @@ func test_receive_check_enforces_stack_and_pocket_capacity() -> void:
 	assert_eq(pocket_full["reason"], &"pocket_full")
 
 
+## Generation 1 has one bag of BAG_ITEM_CAPACITY slots and no item type byte, so
+## every item counts against the same capacity rather than falling through it.
+func test_receive_check_counts_a_generation_1_bag_as_one_pocket() -> void:
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	data.generation = RomRegistry.GEN1
+	var owned: Dictionary = {}
+	for item: int in range(2, Gen1Layout.BAG_ITEM_CAPACITY + 2):
+		owned[item] = 1
+	var full: Dictionary = Gen2WorldPack.receive_check(data, owned, ITEM_POTION, 1)
+	assert_false(full["ok"])
+	assert_eq(full["reason"], &"pocket_full")
+	owned.erase(2)
+	assert_true(bool(Gen2WorldPack.receive_check(data, owned, ITEM_POTION, 1)["ok"]))
+	assert_true(bool(Gen2WorldPack.receive_check(
+		data, {ITEM_POTION: 1}, ITEM_POTION, 1
+	)["ok"]), "a stack already held takes no new slot")
+
+
 ## engine/items/pack.asm's .ItemBallsKey_LoadSubmenu picks between six headers on
 ## two inverted permission bits and the field-menu nibble. POTION is CANT_SELECT
 ## with a usable field menu, so it reaches MenuHeader_UsableItem.

--- a/tests/unit/test_world_service_hosts.gd
+++ b/tests/unit/test_world_service_hosts.gd
@@ -283,7 +283,7 @@ func test_mart_purchase_refuses_crossing_the_source_item_stack_limit() -> void:
 	_world.state.apply_changes({}, {}, {"money": {0: 999999}})
 	var before: Dictionary = _world.snapshot().to_dict()
 	var result: Dictionary = Gen2WorldMartHost.purchase(
-		_world, _save, mart, 7, Gen2WorldMartHost.MAX_ITEM_STACK, false
+		_world, _save, mart, 7, Gen2WorldPack.MAX_ITEM_STACK, false
 	)
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"item_stack_full")
@@ -295,7 +295,7 @@ func test_mart_purchase_refuses_crossing_the_source_item_stack_limit() -> void:
 func test_mart_purchase_refuses_on_money_before_the_stack_limit() -> void:
 	var mart: Dictionary = _data.world_mart(0)
 	var result: Dictionary = Gen2WorldMartHost.purchase(
-		_world, _save, mart, 7, Gen2WorldMartHost.MAX_ITEM_STACK, false
+		_world, _save, mart, 7, Gen2WorldPack.MAX_ITEM_STACK, false
 	)
 	assert_false(result["ok"])
 	assert_eq(result["reason"], &"insufficient_money")

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,9 +130,12 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 91, "text": 126, "branch": 71, "choice": 6, "flag": 5, "unknown": 46},
-	&"blue": {"rows": 91, "text": 126, "branch": 71, "choice": 6, "flag": 5, "unknown": 46},
-	&"yellow": {"rows": 74, "text": 101, "branch": 63, "choice": 5, "flag": 1, "unknown": 44},
+	&"red": {"rows": 94, "text": 195, "branch": 74, "choice": 7, "flag": 22,
+		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 39},
+	&"blue": {"rows": 94, "text": 195, "branch": 74, "choice": 7, "flag": 22,
+		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 39},
+	&"yellow": {"rows": 77, "text": 157, "branch": 66, "choice": 6, "flag": 14,
+		"give_item": 17, "has_item": 7, "take_item": 3, "unknown": 40},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -317,7 +320,7 @@ func _texts() -> void:
 ## every box has to draw, and the ghost girl has to keep both her answers.
 func _scripts(font: Gen2Font) -> void:
 	var census: Dictionary = {"rows": 0, "text": 0, "branch": 0, "choice": 0,
-		"flag": 0, "unknown": 0}
+		"flag": 0, "give_item": 0, "has_item": 0, "take_item": 0, "unknown": 0}
 	var wrong: Array[String] = []
 	for map: Gen2WorldMap in _maps.values():
 		for row: Dictionary in map.texts:
@@ -345,7 +348,10 @@ func _walk_script(
 			var flag: int = int(node["flag"])
 			if (flag < 0 or flag >= Gen1Layout.EVENT_FLAG_BYTES * 8) and wrong.size() < 4:
 				wrong.append("map %d names flag %d" % [number, flag])
-		for side: String in ["then", "else", "yes", "no"]:
+		if op == "give_item" or op == "has_item" or op == "take_item":
+			_r.check(not _r.data.item_name(int(node["item"])).is_empty(),
+				"map %d names item %d, which has no name." % [number, int(node["item"])])
+		for side: String in ["then", "else", "yes", "no", "ok", "full"]:
 			if node.has(side):
 				_walk_script(font, node[side] as Array, census, wrong, number)
 

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -98,8 +98,8 @@ const PRIZE_MENUS: Dictionary = {
 ## Three `text_asm` rows driven on the world, since a decoded script is only
 ## worth the box it puts up. `BikeShopYoungsterText` turns on EVENT_GOT_BICYCLE,
 ## `LavenderTownLittleGirlText` asks and branches on the answer, and
-## `CeladonGameCornerText5` is half machine code: while EVENT_GOT_10_COINS is
-## clear it gives coins instead of speaking, and says nothing here.
+## `GameCornerFishingGuruText` reaches `Has9990Coins` only with the COIN CASE in
+## the bag, so the row speaks without one and says nothing at all with it.
 const BIKE_SHOP: int = 66
 const BIKE_YOUNGSTER := Vector2i(1, 4)
 const BIKE_FLAG: int = 192
@@ -111,6 +111,19 @@ const GAME_CORNER: int = 135
 const GAME_CORNER_GAMBLER := Vector2i(5, 12)
 const GAME_CORNER_FLAG: int = 442
 const GAME_CORNER_BOX: String = "Wins seem to come"
+const GAME_CORNER_ASKED: String = "Kid, do you want"
+const COIN_CASE: int = 0x45
+
+## Celadon City's TM41, whose receipt box names the item out of the buffer
+## `CopyToStringBuffer` fills only when the bag took it.
+const CELADON_CITY: int = 6
+const TM41_CELL := Vector2i(22, 17)
+const TM41_ITEM: int = 241
+const TM41_NAME: String = "TM41"
+const TM41_FLAG: int = 384
+const GIFT_OPENING: String = "Hello, there!"
+const GIFT_KNOWN: String = "TM41 teaches"
+const GIFT_REFUSED: String = "Oh, your pack is"
 
 ## Yellow's `CeruleanBadgeHouse` melanie, the corpus's one box that owes no
 ## press: `DisableWaitingAfterTextDisplay` runs before her last `PrintText`.
@@ -133,6 +146,7 @@ func _one_game() -> void:
 	_check_last_map_round_trip()
 	_check_text_boxes()
 	_check_scripted_npcs()
+	_check_a_gift()
 	_check_the_nurse_heals()
 	_check_the_cable_club()
 	_check_the_vending_machine()
@@ -350,7 +364,12 @@ func _check_scripted_npcs() -> void:
 		)
 		_r.check(read.begins_with(BIKE_BOXES[1 if set_flag else 0]),
 			"the bike shop said %s with the bicycle flag %s." % [read, set_flag])
-	var silent: String = _scripted_box(GAME_CORNER, GAME_CORNER_GAMBLER, 0)
+	var asked: String = _scripted_box(GAME_CORNER, GAME_CORNER_GAMBLER, 0)
+	_r.check(asked.begins_with(GAME_CORNER_ASKED),
+		"the guru said %s with no COIN CASE." % [asked])
+	var silent: String = _scripted_box(
+		GAME_CORNER, GAME_CORNER_GAMBLER, 0, {COIN_CASE: 1}
+	)
 	_r.check(silent.is_empty(), "the half-read row said %s." % [silent])
 	var spoken: String = _scripted_box(
 		GAME_CORNER, GAME_CORNER_GAMBLER, GAME_CORNER_FLAG
@@ -361,14 +380,59 @@ func _check_scripted_npcs() -> void:
 		_check_a_box_owing_no_press()
 
 
+## `GiveItem` both ways: the bag takes the gift, or it stands in every slot.
+func _check_a_gift() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, CELADON_CITY, TM41_CELL)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var said: Array[String] = _spoken(world)
+	_r.check(said.size() == 2 and said[0].begins_with(GIFT_OPENING)
+		and said[1].contains(TM41_NAME), "the gift said %s." % [said])
+	_r.check(world.state.item_quantity(TM41_ITEM) == 1,
+		"the bag holds %d TM41." % world.state.item_quantity(TM41_ITEM))
+	_r.check(world.event_flag_active(TM41_FLAG), "the gift left its flag clear.")
+	var again: Array[String] = _spoken(world)
+	_r.check(again.size() == 1 and again[0].begins_with(GIFT_KNOWN),
+		"talked to again he said %s." % [again])
+	_check_a_gift_refused()
+
+
+func _check_a_gift_refused() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, CELADON_CITY, TM41_CELL)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var stock: Dictionary = {}
+	for slot: int in Gen1Layout.BAG_ITEM_CAPACITY:
+		stock[slot + 1] = 1
+	world.state.apply_changes({}, {}, {"items": stock})
+	var said: Array[String] = _spoken(world)
+	_r.check(said.size() == 2 and said[1].begins_with(GIFT_REFUSED),
+		"a full bag said %s." % [said])
+	_r.check(world.state.item_quantity(TM41_ITEM) == 0, "a full bag took the gift.")
+	_r.check(not world.event_flag_active(TM41_FLAG), "a refused gift set its flag.")
+
+
+func _spoken(world: Gen2WorldAPI) -> Array[String]:
+	var said: Array[String] = []
+	var results: Array = world.interact()
+	while not results.is_empty() and said.size() < Gen1Layout.MAX_OBJECT_EVENTS:
+		said.append(_event_text(results))
+		results = world.run_event_queue(true)
+	return said
+
+
 ## The string one interaction opens with, or "" when it opened no box at all.
 ## [param flag] is an event flag to set first, or 0 for none.
-func _scripted_box(map: int, cell: Vector2i, flag: int) -> String:
+func _scripted_box(map: int, cell: Vector2i, flag: int, owned: Dictionary = {}) -> String:
 	var world: Gen2WorldAPI = _r.open_world(0, map, cell)
 	if world == null:
 		return ""
 	if flag > 0:
 		world.set_event_flag(flag)
+	if not owned.is_empty():
+		world.state.apply_changes({}, {}, {"items": owned})
 	world.player_facing = Gen2WorldSprite.FACING_UP
 	return _box_text(world)
 

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -28,6 +28,7 @@ const KIND_HELP: Dictionary = {
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
 	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
+	&"gift": "presses: a `GiveItem` row, faced up from the cell after the @. 0 is the offer's first page, 4 the receipt box a bag with room earns",
 	&"trainer": "presses, frames: TalkToTrainer on the map's first trainer, faced from the cell below. 0 the before-battle box, 1 the fight the press behind it opens; a second number stops that many frames into the transition instead",
 	&"sight": "frames, 0: CheckFightingMapTrainers on the map's first trainer who sees, walked into from the far end of its own line. 40 stands in the shock bubble, 120 in the walk-up, 400 in the before-battle box",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
@@ -161,6 +162,7 @@ const STAGED_FRAMES: int = 2
 ## `sign` spends the whole reveal: no press finishes a page early.
 const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
+	&"gift": BOX_REVEAL_FRAMES,
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
 	&"prizes": BOX_REVEAL_FRAMES,
 }
@@ -405,6 +407,7 @@ const STAGERS: Dictionary = {
 	&"mod_page": &"_stage_mod_page",
 	&"pokepic": &"_stage_pokepic",
 	&"sign": &"_stage_sign",
+	&"gift": &"_stage_gift",
 	&"trainer": &"_stage_trainer",
 	&"sight": &"_stage_sight",
 	&"nurse": &"_stage_nurse",
@@ -958,6 +961,14 @@ func _stage_sight() -> void:
 func _stage_sign() -> void:
 	_screen.press_button(PokeButton.UP)
 	_screen.interact()
+
+
+func _stage_gift() -> void:
+	_stage_sign()
+	for _press: int in maxi(_cell.x, 0):
+		for _frame: int in BOX_REVEAL_FRAMES:
+			_screen.advance_frame()
+		_screen.press_button(PokeButton.A)
 
 
 ## The nurse, reached over her counter from the cell below it, which is the


### PR DESCRIPTION
`Gen1WorldImporter.decode_script` reads `GiveItem`, `IsItemInBag` and `RemoveItemByID`. A gift is `lb bc, ITEM, COUNT` and the carry `AddItemToInventory` answers in, folded onto one node carrying the boxes each way; a `farcall` is `ld b, BANK`, `ld hl`, `call Bankswitch`, which is how the item in `hItemToRemoveID` is read. Only a gift that landed reaches `GetItemName`, so the receipt box's `wStringBuffer` marker is filled on that side and nowhere else.

`Gen2WorldPack.receive_check` is now the one answer to whether the bag can take another, and Generation 1's whole bag is one pocket of `BAG_ITEM_CAPACITY`. The mart, the vending machine and the prize counter ask it instead of comparing against the stack ceiling themselves, which is `ReceiveItem`'s `.insufficient_bag_space` and which Generation 2's own counter had never refused; the item PC's withdrawal reports it with `.PackFull` rather than as a bare reason.

`GameCornerFishingGuruText` reads now too: without the COIN CASE it says its two boxes, and with one it reaches `Has9990Coins` and still says nothing.

| Corpus | Red and Blue | Yellow |
|---|---|---|
| Rows decoded | 91 to 94 | 74 to 77 |
| Boxes | 126 to 195 | 101 to 157 |
| Event branches | 71 to 74 | 63 to 66 |
| Flag writes | 5 to 22 | 1 to 14 |
| `give_item` / `has_item` / `take_item` | 22 / 7 / 3 | 17 / 7 / 3 |
| Branch sides still unread | 46 to 39 | 44 to 40 |

## Proving it

| Check | Result |
|---|---|
| `gut_cmdln` unit tier | 3,784 tests, all pass |
| `gut_cmdln` whole tier | 4,395 tests, all pass |
| `validate.gd -- all` | 92 topics, exit 0 |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| `--warning-scan` | 0 warnings in 632 scripts |
| `release.sh --gates` | pass, comments 39516 of 39516 |

`gen1_walk.gd` takes Celadon City's TM41 with room in the bag and against a bag standing in all twenty slots; `gen1_maps.gd` pins the census above and checks every item a node names has a name. `preview_world.gd`'s new `gift` kind photographs the receipt: `-- red 0 6 <out.png> live gift@22,17 4 0`.

Seven of the 22 gifts end their success side in `predef HideObject`, which wants `MapHSPointers` and a toggleable-object flag array of its own, so those rows still say nothing on the side that would give.