### PR TITLE
Take a Generation 1 item off the ground

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -126,6 +126,8 @@ var _world_marts: Dictionary = {}
 ## Built on first ask and kept, since the walk behind it is the whole script
 ## corpus. See [method catalog].
 var _catalog: Gen2WorldCatalog = null
+## See [method gen1_toggle_on]. Empty outside Generation 1 and until first read.
+var _gen1_toggle_on: Dictionary = {}
 var _world_phone: Dictionary = {}
 var _world_fruit_trees: Array = []
 var _world_spawns: Dictionary = {}
@@ -315,6 +317,19 @@ func world_map(group: int, number: int) -> Gen2WorldMap:
 
 func world_maps() -> Array:
 	return _maps().duplicate()
+
+
+## `ToggleableObjectStates`' ON column by global index, derived once from the
+## objects carrying one. The three rows reaching no object read as ON, which is
+## what a flag nothing draws from is worth.
+func gen1_toggle_on(index: int) -> bool:
+	if _gen1_toggle_on.is_empty():
+		for map: Gen2WorldMap in _maps():
+			for object: Dictionary in map.events.get("objects", []) as Array:
+				if object.has("toggle_index"):
+					_gen1_toggle_on[int(object["toggle_index"])] = \
+						bool(object.get("toggle_on", true))
+	return bool(_gen1_toggle_on.get(index, true))
 
 
 ## Every imported script's `bank:address` key, sorted, for a caller that has to

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -155,6 +155,7 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"vending": ["vending_text", Gen1Layout.VENDING_TEXT_AT],
 	"prizes": ["prize_text", Gen1Layout.PRIZE_TEXT_AT],
 	"prizes_2": ["prize_text_2", Gen1Layout.PRIZE_TEXT_2_AT],
+	"pick_up_item": ["found_item_text", Gen1Layout.PICK_UP_TEXT_AT],
 }
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -519,6 +519,17 @@ const OBJECT_ITEM_FLAG: int = 0x80
 const OBJECT_TEXT_MASK: int = 0x3F
 const OBJECT_TRAINER_BYTES: int = 2
 const OBJECT_ITEM_BYTES: int = 1
+## `ToggleableObjectStates`: a map id, the object's 1-based id, and ON or OFF.
+## `MarkTownVisitedAndLoadToggleableObjects` reaches a map's run through
+## `ToggleableObjectMapPointers` and ends it on the first row naming another
+## map; a row's distance from the table is the index `HideObject` is given.
+const TOGGLE_STATE_SIZE: int = 3
+const TOGGLE_ON: int = 0x15
+## `add_predef`'s `dba`, indexed by the id the `predef` macro leaves in a.
+const PREDEF_SIZE: int = 3
+## `PickUpItemText`'s two boxes, a `text_far` stub and a `sound_get_item_1` apart.
+const PICK_UP_TEXT_AT: Dictionary = {"found": 0x00, "no_room": 0x06}
+
 ## `object_event`'s two movement bytes as one shared template. Byte 1 is WALK or
 ## STAY; byte 2 is a fixed direction, the axis a random walk keeps to, or
 ## `BOULDER_MOVEMENT_BYTE_2`. A STAY sprite still turns, because `TryWalking`
@@ -578,6 +589,7 @@ const SCRIPT_CARRY_BRANCHES: Dictionary = {0x38: true, 0xDA: true, 0x30: false, 
 const SCRIPT_CALLS: Array[String] = [
 	"print_text", "text_script_end", "disable_waiting", "yes_no_choice",
 	"give_item", "is_item_in_bag", "bankswitch", "play_cry", "wait_for_sound",
+	"predef",
 ]
 const SCRIPT_SHORT_SIZE: int = 2
 const SCRIPT_LONG_SIZE: int = 3
@@ -783,6 +795,16 @@ const RED_BLUE: Dictionary = {
 	"do_not_wait": 0xCC3C,
 	"current_menu_item": 0xCC26,
 	"item_to_remove": 0xFFDB,
+	"toggleable_index": 0xCC4D,
+	## `Predef` and the table it indexes, with the three rows read through it.
+	"predef": 0x3E6D,
+	"predef_pointers": 0x4FE79,
+	"hide_object": 0x0F1D7,
+	"show_object": 0x0F1C8,
+	"pick_up_item": 0x04DE1,
+	"found_item_text": 0x04E26,
+	"toggleable_pointers": 0x0C8F5,
+	"toggleable_states": 0x0CAEA,
 	## `DisplayPokemartDialogue`'s own greeting and the head of the two facility
 	## text runs [constant MART_TEXT_AT] and its neighbour walk. Every offset
 	## here is `pokered.sym`'s, which builds both dumps.
@@ -871,6 +893,15 @@ const YELLOW: Dictionary = {
 	"do_not_wait": 0xCC3C,
 	"current_menu_item": 0xCC26,
 	"item_to_remove": 0xFFDB,
+	"toggleable_index": 0xCC4D,
+	"predef": 0x3EB4,
+	"predef_pointers": 0xF681D,
+	"hide_object": 0x0F053,
+	"show_object": 0x0F044,
+	"pick_up_item": 0x04D55,
+	"found_item_text": 0x04D9A,
+	"toggleable_pointers": 0x0C69B,
+	"toggleable_states": 0x0C892,
 	"mart_greeting": 0x02938,
 	"mart_text": 0x06B91,
 	"pokecenter_text": 0x06ED0,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -517,6 +517,7 @@ static func _read_map(
 
 	var texts: Array = _read_texts(rom, layout, bank, rom.u16le(header + 5), events)
 	_carry_trainer_headers(events["objects"], texts)
+	_carry_toggleable_objects(rom, layout, events["objects"], map_id)
 
 	return {
 		"ok": true,
@@ -744,15 +745,45 @@ static func _carry_trainer_headers(objects: Array, texts: Array) -> void:
 		var header: Variant = (texts[id - 1] as Dictionary).get("trainer", {})
 		if not header is Dictionary or (header as Dictionary).is_empty():
 			continue
-		var flag: int = int((header as Dictionary)["event_flag"])
 		object["object_type"] = Gen2WorldObject.OBJECTTYPE_TRAINER
 		object["sight_range"] = int((header as Dictionary)["sight_range"])
-		## `EndTrainerBattle` hides only below `OPP_ID_OFFSET`, by that bit, and
-		## `CheckForEngagingTrainers` walks both kinds of row alike.
-		if object.has("trainer_class"):
-			object["trainer"] = {"event_flag": flag}
-		else:
-			object["event_flag"] = flag
+		## `CheckForEngagingTrainers` walks a trainer and a standing wild alike,
+		## and so does `TrainerFlagAction`; only `EndTrainerBattle`'s
+		## `predef HideObject` tells the two apart.
+		object["trainer"] = {"event_flag": int((header as Dictionary)["event_flag"])}
+
+
+## `wToggleableObjectList`: the map's own run of `ToggleableObjectStates`. Three
+## rows of the corpus name an object their map does not have.
+static func read_toggleable_rows(rom: RomFile, layout: Dictionary, map_id: int) -> Array:
+	var table: int = int(layout["toggleable_states"])
+	var at: int = Gen1Layout.banked(RomFile.bank_of(table), rom.u16le(
+		int(layout["toggleable_pointers"]) + map_id * Gen1Layout.POINTER_SIZE
+	))
+	@warning_ignore("integer_division")
+	var first: int = (at - table) / Gen1Layout.TOGGLE_STATE_SIZE
+	var out: Array = []
+	while rom.in_bounds(at, Gen1Layout.TOGGLE_STATE_SIZE) and rom.u8(at) == map_id:
+		out.append({
+			"object": rom.u8(at + 1),
+			"index": first + out.size(),
+			"on": rom.u8(at + 2) == Gen1Layout.TOGGLE_ON,
+		})
+		at += Gen1Layout.TOGGLE_STATE_SIZE
+	return out
+
+
+## Each row carried onto its object, so a mask read reaches it without the table.
+static func _carry_toggleable_objects(
+	rom: RomFile, layout: Dictionary, objects: Array, map_id: int
+) -> void:
+	for row: Dictionary in read_toggleable_rows(rom, layout, map_id):
+		var slot: int = int(row["object"]) - 1
+		if slot < 0 or slot >= objects.size():
+			continue
+		var object: Dictionary = objects[slot]
+		object["toggle_index"] = int(row["index"])
+		object["toggle_on"] = bool(row["on"])
 
 
 ## `<Map>_TextPointers`, which `DisplayTextID` indexes with a text id. A row is
@@ -934,6 +965,11 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 			return false
 		state["no_press"] = true
 		return true
+	if address == int(layout["toggleable_index"]):
+		if not state.has("a"):
+			return false
+		state["toggle"] = int(state["a"])
+		return true
 	if address != int(layout["item_to_remove"]) or int(state.get("a", 0)) < 1:
 		return false
 	state["remove"] = int(state["a"])
@@ -1014,6 +1050,8 @@ static func _script_call(
 			return _script_asked(state, next)
 		"bankswitch":
 			return _script_far(layout, state, out, next)
+		"predef":
+			return _script_predef(ctx, state, out, next)
 		"play_cry", "wait_for_sound":
 			return next
 	return SCRIPT_UNREAD
@@ -1057,6 +1095,31 @@ static func _script_far(
 		return SCRIPT_UNREAD
 	out.append({"op": "take_item", "item": int(state["remove"])})
 	state.erase("remove")
+	return next
+
+
+## `predef` is `ld a, id` and `call Predef`; `PredefPointers` is the bank and
+## address that id names. `ShowObject2` shares `ShowObject`'s address, so
+## resolving the address rather than the id reads both.
+static func _script_predef(
+	ctx: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	var layout: Dictionary = ctx["layout"]
+	var id: int = int(state.get("a", -1))
+	if id < 0:
+		return SCRIPT_UNREAD
+	var rom: RomFile = ctx["rom"]
+	var row: int = int(layout["predef_pointers"]) + id * Gen1Layout.PREDEF_SIZE
+	var target: int = Gen1Layout.banked(rom.u8(row), rom.u16le(row + 1))
+	if target == int(layout["pick_up_item"]):
+		out.append({"op": "pick_up_item"})
+		return next
+	var hidden: bool = target == int(layout["hide_object"])
+	if not state.has("toggle") \
+		or (not hidden and target != int(layout["show_object"])):
+		return SCRIPT_UNREAD
+	out.append({"op": "toggle_object", "index": int(state["toggle"]), "hidden": hidden})
+	state.erase("toggle")
 	return next
 
 

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 111
+const FORMAT_VERSION: int = 112
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3661,6 +3661,7 @@ var _gen1_last_map: int = -1
 ## boxes are imported under.
 const GEN1_POKECENTER_RUN: String = "pokecenter"
 const GEN1_CABLE_CLUB_RUN: String = "cable_club"
+const GEN1_PICK_UP_RUN: String = "pick_up_item"
 ## `EndTrainerBattle`'s `cp LOST_BATTLE`, which a catch also passes.
 const GEN1_TRAINER_BEATEN: Array[StringName] = [
 	Gen2WorldBattleAdapter.OUTCOME_WON, Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
@@ -3723,7 +3724,7 @@ func _gen1_interact() -> Array:
 	if _gen1_steps.is_empty():
 		_gen1_steps = _gen1_facility_steps(row, text_id)
 	if _gen1_steps.is_empty():
-		_gen1_steps = _gen1_script_steps(row)
+		_gen1_steps = _gen1_script_steps(row, event)
 	if _gen1_steps.is_empty():
 		var text: String = _gen1_filled_text(String(row.get("text", "")))
 		if text.is_empty():
@@ -3743,13 +3744,13 @@ func _gen1_filled_text(text: String) -> String:
 ## The boxes a `text_asm` row prints, with its branches resolved against the
 ## save. A taken side the importer did not read answers nothing at all, the way
 ## an undecoded row does.
-func _gen1_script_steps(row: Dictionary) -> Array:
+func _gen1_script_steps(row: Dictionary, event: Dictionary = {}) -> Array:
 	var nodes: Variant = row.get("script", [])
 	if not nodes is Array or (nodes as Array).is_empty():
 		return []
 	var steps: Array = []
 	return steps if _gen1_resolve_script(nodes as Array, steps, {
-		"bag": state.items() if state != null else {}, "named": "",
+		"bag": state.items() if state != null else {}, "named": "", "object": event,
 	}) else []
 
 
@@ -3782,6 +3783,15 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 					return false
 			"take_item":
 				_gen1_take_item(int(node["item"]), steps, bag)
+			"toggle_object":
+				steps.append({
+					"type": &"toggle",
+					"index": int(node["index"]),
+					"hidden": bool(node["hidden"]),
+				})
+			"pick_up_item":
+				if not _gen1_pick_up_item(steps, run):
+					return false
 			"choice":
 				return _gen1_script_choice(node, steps, run)
 			_:
@@ -3810,6 +3820,33 @@ func _gen1_resolve_gift(node: Dictionary, steps: Array, run: Dictionary) -> bool
 	if not node.has("ok"):
 		return true
 	return _gen1_resolve_script(node["ok" if taken else "full"] as Array, steps, run)
+
+
+## `PickUpItem`: the object's own item, `HideObject` on it, and the receipt
+## behind `wDoNotWaitForButtonPress`. Its own `ret z` says nothing at all for an
+## item object outside `ToggleableObjectStates`.
+func _gen1_pick_up_item(steps: Array, run: Dictionary) -> bool:
+	var object: Dictionary = run.get("object", {})
+	var item: int = int(object.get("item", 0))
+	var toggle: int = int(object.get("toggle_index", -1))
+	if item < 1 or toggle < 0:
+		return false
+	var bag: Dictionary = run["bag"]
+	var room: Dictionary = Gen2WorldPack.receive_check(data, bag, item, 1)
+	if not bool(room.get("ok", false)):
+		steps.append(_gen1_facility_box(GEN1_PICK_UP_RUN, "no_room"))
+		return true
+	bag[item] = int(room["quantity"])
+	steps.append({"type": &"items", "items": {item: int(room["quantity"])}})
+	steps.append({"type": &"toggle", "index": toggle, "hidden": true})
+	var box: Dictionary = _gen1_facility_box(GEN1_PICK_UP_RUN, "found")
+	box["text"] = Gen2TextStream.fill_all_markers(
+		_gen1_filled_text(String(box["text"])), Gen2TextStream.RAM_MARKER,
+		data.item_name(item) if data != null else ""
+	)
+	box["press"] = false
+	steps.append(box)
+	return true
 
 
 func _gen1_take_item(item: int, steps: Array, bag: Dictionary) -> void:
@@ -3842,7 +3879,11 @@ func _gen1_script_choice(node: Dictionary, steps: Array, run: Dictionary) -> boo
 
 
 func _gen1_run_copy(run: Dictionary) -> Dictionary:
-	return {"bag": (run["bag"] as Dictionary).duplicate(), "named": run["named"]}
+	return {
+		"bag": (run["bag"] as Dictionary).duplicate(),
+		"named": run["named"],
+		"object": run.get("object", {}),
+	}
 
 
 func _gen1_script_box(node: Dictionary, named: String) -> Dictionary:
@@ -4048,6 +4089,7 @@ func _gen1_trainer_steps(row: Dictionary, event: Dictionary) -> Array:
 			},
 			"trainer_flag": flag,
 			"object_index": int(event.get("object_index", -1)),
+			"standing_wild": not event.has("trainer_class"),
 		},
 	]
 
@@ -4301,6 +4343,9 @@ func _gen1_written(step: Dictionary) -> bool:
 		&"items":
 			state.apply_changes({}, {}, {"items": step["items"]})
 			return true
+		&"toggle":
+			gen1_toggle_object(int(step["index"]), bool(step["hidden"]))
+			return true
 	return false
 
 
@@ -4324,7 +4369,24 @@ func _gen1_battle_won(step: Dictionary, result: Dictionary) -> void:
 	if StringName(result.get("outcome", &"")) not in GEN1_TRAINER_BEATEN:
 		return
 	state.set_event_flag(flag)
+	if bool(step.get("standing_wild", false)):
+		gen1_toggle_object(_gen1_toggle_index(int(step.get("object_index", -1))), true)
 	load_object_masks()
+
+
+## `ShowObject` and `HideObject`: one `wToggleableObjectFlags` bit by global
+## index, and `UpdateSprites` behind it.
+func gen1_toggle_object(index: int, hidden: bool) -> void:
+	if index < 0 or state == null or data == null:
+		return
+	state.set_object_toggled(index, hidden == data.gen1_toggle_on(index))
+	load_object_masks()
+
+
+func _gen1_toggle_index(object_index: int) -> int:
+	if object_index < 0 or object_index >= objects.size():
+		return -1
+	return (objects[object_index] as Gen2WorldObject).toggle_index
 
 
 ## Whether the script holding the world is one that stops the map around it.
@@ -4450,7 +4512,7 @@ func dispatch_map_entry() -> Array:
 func load_object_masks() -> void:
 	_object_masks_pending = false
 	for object: Gen2WorldObject in objects:
-		object.flag_hidden = object.event_flag_active(state)
+		object.flag_hidden = object.masked_hidden(state)
 	## `LoadObjectMasks` writes one mask byte an object out of `GetObjectTimeMask`
 	## and `CheckObjectFlag` together, which is what this already is.
 	set_object_time(object_hour, object_time_of_day)
@@ -8086,7 +8148,7 @@ func connected_map_objects() -> Array:
 			var object: Gen2WorldObject = _object_from_event(index, rows[index])
 			if object.sprite == null:
 				continue
-			object.flag_hidden = object.event_flag_active(state)
+			object.flag_hidden = object.masked_hidden(state)
 			object.active = object.visible_at(object_hour, object_time_of_day) \
 				and not object.flag_hidden
 			if not object.active:
@@ -8121,7 +8183,7 @@ func _load_objects(carry_presentation: bool = false) -> void:
 			object.carry_presentation_from(previous[index] as Gen2WorldObject)
 			object.flag_hidden = (previous[index] as Gen2WorldObject).flag_hidden
 		else:
-			object.flag_hidden = object.event_flag_active(state)
+			object.flag_hidden = object.masked_hidden(state)
 		objects.append(object)
 	set_object_time(object_hour, object_time_of_day)
 

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -161,6 +161,7 @@ static func _events_from_cache(value: Variant) -> Dictionary:
 			"sprite", "x", "y", "movement", "x_radius", "y_radius", "hour_1", "hour_2",
 			"palette", "object_type", "sight_range", "script", "event_flag",
 			"text", "trainer_class", "trainer_number", "species", "level", "item",
+			"toggle_index",
 		]),
 	}
 

--- a/game/world/world_object.gd
+++ b/game/world/world_object.gd
@@ -85,6 +85,10 @@ var object_type: int = 0
 var sight_range: int = 0
 var event_script: int = 0
 var event_flag: int = 0
+## This object's `ToggleableObjectStates` row: the global index `HideObject`
+## takes and the ON or OFF it starts at. -1 for an object outside the table.
+var toggle_index: int = -1
+var toggle_on: bool = true
 ## Whether [member event_flag] was set when the table was built.
 ## `ReadObjectEvents` reads it at map load, so only `appear` and `disappear`,
 ## which edit the live struct too, move anything mid-map.
@@ -153,6 +157,8 @@ static func from_event(
 	out.sight_range = int(value.get("sight_range", 0))
 	out.event_script = int(value.get("script", 0))
 	out.event_flag = int(value.get("event_flag", 0))
+	out.toggle_index = int(value.get("toggle_index", -1))
+	out.toggle_on = bool(value.get("toggle_on", true))
 	var trainer: Variant = value.get("trainer", {})
 	if trainer is Dictionary:
 		out.trainer_data = (trainer as Dictionary).duplicate(true)
@@ -328,6 +334,21 @@ func visible_with_state(hour: int, time_of_day: int, state: Gen2WorldState) -> b
 
 func event_flag_active(state: Gen2WorldState) -> bool:
 	return event_flag > 0 and state != null and state.is_event_flag_active(event_flag)
+
+
+## `IsObjectHidden`, which reads `wToggleableObjectFlags` rather than an event
+## flag: the row's own ON or OFF is where the bit starts, and the save carries
+## only the indices a `ShowObject` or a `HideObject` has moved since.
+func toggle_hidden(state: Gen2WorldState) -> bool:
+	if toggle_index < 0 or state == null:
+		return false
+	return toggle_on == state.is_object_toggled(toggle_index)
+
+
+## `LoadObjectMasks`' whole answer: `CheckObjectFlag` on Generation 2 and
+## `IsObjectHidden` on Generation 1, and an object carries only its own.
+func masked_hidden(state: Gen2WorldState) -> bool:
+	return event_flag_active(state) or toggle_hidden(state)
 
 
 func trainer_flag_active(state: Gen2WorldState) -> bool:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -5675,18 +5675,18 @@ func _advance_script_input() -> void:
 	_refresh_labels()
 
 
-## `Script_writetext` is `MapTextbox` and returns as soon as the string is placed,
-## so a text ending in `<DONE>` owes no press of its own and the script runs on the
-## moment its last page is up. The box reaches that page three ways: shown whole,
-## turned to by the press that clears a `<PARA>`, or scrolled into by `_ContText`,
-## and only the first two are a press. The scroll ends on a frame instead, which
-## is why [method advance_frame] asks this as well.
+## `Script_writetext` is `MapTextbox`, which prints its string a letter at a time
+## and returns behind the last one, so a text ending in `<DONE>` owes no press and
+## the script runs on the frame its last page finishes printing. The box reaches
+## that page three ways: printed where it stands, turned to by the press that
+## clears a `<PARA>`, or scrolled into by `_ContText`. Only the middle one is a
+## press, which is why [method advance_frame] asks this as well.
 func _continue_if_text_settled() -> bool:
 	if _text_box == null or not _text_box.visible or _world == null:
 		return false
 	if _text_awaits_press or not _oak_pc_pages.is_empty():
 		return false
-	if _text_box.is_scrolling() or _text_box.has_pages_left():
+	if _text_box.is_revealing() or _text_box.has_pages_left():
 		return false
 	if StringName(_world.pending_script_input().get("type", &"")) != &"text":
 		return false

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -298,6 +298,11 @@ var _picked_fruit_trees: Dictionary = {}
 ## `wTradeFlags`, one bit per `NPC_TRADE_*` index. `TradeFlagAction` is an NPC
 ## trade's whole once-only gate: no map script guards one.
 var _npc_trades: Dictionary = {}
+## `wToggleableObjectFlags`, Generation 1's own. The array is initialised from
+## `ToggleableObjectStates` rather than to zero, so what is kept here is the set
+## of global indices a `ShowObject` or a `HideObject` has since moved away from
+## that row: a state that has run neither is the cartridge's own new game.
+var _toggled_objects: Dictionary = {}
 ## `wRegisteredItem`. `wWhichRegisteredItem`'s pocket and slot number have no
 ## counterpart in the flat item model: `CheckRegisteredItem` uses them to find
 ## the entry again in its packed pocket array and clears both when the item is
@@ -520,6 +525,7 @@ func to_dict() -> Dictionary:
 		"maptile_decorations": _maptile_decorations.duplicate(),
 		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
 		"picked_fruit_trees": _picked_fruit_trees.duplicate(),
+		"toggled_objects": _toggled_objects.duplicate(),
 		"npc_trades": _npc_trades.duplicate(),
 		"registered_item": _registered_item,
 		"day_care_man": _day_care_man,
@@ -570,6 +576,7 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	)
 	_seed_counts(restored._pc_items, _map(source, "pc_items"), 1, -1, Gen2WorldPack.MAX_PC_ITEMS)
 	_seed_flags(restored._picked_fruit_trees, _map(source, "picked_fruit_trees"), 1)
+	_seed_flags(restored._toggled_objects, _map(source, "toggled_objects"), 0)
 	_seed_flags(restored._npc_trades, _map(source, "npc_trades"), 0)
 	restored._swarm_maps[SWARM_YANMA] = _vector_from_value(
 		source.get("yanma_swarm_map", [-1, -1])
@@ -724,6 +731,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_maptile_decorations = restored._maptile_decorations.duplicate()
 	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
 	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
+	_toggled_objects = restored._toggled_objects.duplicate()
 	_npc_trades = restored._npc_trades.duplicate()
 	_registered_item = restored._registered_item
 	_day_care_man = restored._day_care_man
@@ -1667,6 +1675,21 @@ func set_kurt_apricorn_quantity(quantity: int) -> void:
 	if next_quantity == _kurt_apricorn_quantity:
 		return
 	_kurt_apricorn_quantity = next_quantity
+	changed.emit()
+
+
+## Whether that object stands the other way round from its own table row.
+func is_object_toggled(index: int) -> bool:
+	return index >= 0 and bool(_toggled_objects.get(index, false))
+
+
+func set_object_toggled(index: int, toggled: bool) -> void:
+	if index < 0 or is_object_toggled(index) == toggled:
+		return
+	if toggled:
+		_toggled_objects[index] = true
+	else:
+		_toggled_objects.erase(index)
 	changed.emit()
 
 

--- a/tests/integration/test_world_frame_pump.gd
+++ b/tests/integration/test_world_frame_pump.gd
@@ -227,14 +227,36 @@ func _write_scroll_script() -> void:
 
 ## Frames until the box is neither revealing a page nor scrolling into one, so
 ## the press that follows is the one the cartridge charges rather than the one
-## that skips a reveal.
+## that skips a reveal. The box is driven by hand here, so the screen is spent
+## one frame past the settling one: that is the pass `MapTextbox` returns on.
 func _settle_text_box(screen: Gen2WorldScreen) -> void:
 	for _frame: int in 240:
-		if not screen._text_box.is_revealing() and not screen._text_box.is_scrolling():
-			return
+		var settled: bool = not screen._text_box.is_revealing() \
+			and not screen._text_box.is_scrolling()
 		screen.advance_frame()
+		if settled:
+			return
 		screen._text_box.advance_frame()
 		screen._text_box.advance_scroll_frames(1.0)
+
+
+## `MapTextbox` prints its string a letter at a time and returns behind the last
+## one, so the command after a `writetext` is not reached while the page is still
+## revealing. Before this the script ran on the frame the box opened, which put a
+## box owing no press on screen for one frame and no letters in it.
+func test_a_writetext_holds_the_script_while_its_page_is_still_printing() -> void:
+	_write_scroll_script()
+	_world_screen = await _open_world()
+	_world_screen._show_script_results(
+		_world_screen._world.dispatch_script_events(SCRIPT_CELL)
+	)
+	assert_true(_world_screen._text_box.is_revealing())
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"text",
+		"the writetext is still running",
+	)
+	_settle_text_box(_world_screen)
+	assert_false(_world_screen._text_box.is_revealing())
 
 
 ## `_ContText` waits for a press and scrolls; the `<DONE>` behind it owes none,

--- a/tests/integration/test_world_trainer_battle.gd
+++ b/tests/integration/test_world_trainer_battle.gd
@@ -508,10 +508,10 @@ func test_production_world_entry_and_facing_object_story_persist_separate_flags(
 	_world_screen._world.player_cell = Vector2i(4, 3)
 	_world_screen._world.player_facing = Gen2WorldSprite.FACING_RIGHT
 	assert_true(_world_screen.interact())
-	## The `waitbutton` behind the `writetext`, which is what a text ending in
-	## `<DONE>` leaves the script holding on.
+	## `MapTextbox` returns behind the last letter it prints, so the `writetext`
+	## is still running while the page reveals.
 	assert_eq(
-		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"button"
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"text"
 	)
 	assert_false(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_false(_world_screen._world.state.hall_of_fame())
@@ -519,8 +519,12 @@ func test_production_world_entry_and_facing_object_story_persist_separate_flags(
 	## The box reveals at the OPTION menu's TEXT SPEED, and a press cannot shorten
 	## it: `PrintLetterDelay` is all a button reaches while a text is running, and
 	## the most it does there is one letter a frame. So the page is spent in
-	## frames and then one press acknowledges it.
+	## frames, which is where the `waitbutton` behind the `writetext` is reached,
+	## and then one press acknowledges it.
 	_world_screen.advance_frames(_world_screen._text_box.frames_left())
+	assert_eq(
+		StringName(_world_screen._world.pending_script_input().get("type", &"")), &"button"
+	)
 	_world_screen._advance_script_input()
 	assert_true(_world_screen._world.event_flag_active(STORY_EVENT_FLAG))
 	assert_true(_world_screen._world.state.hall_of_fame())

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -22,7 +22,15 @@ const LAYOUT: Dictionary = {
 	"remove_item": 0x7F37,
 	"remove_item_bank": 0x05,
 	"item_to_remove": 0xFFDB,
+	"toggleable_index": 0xCC4D,
+	"predef": 0x01A0,
+	"predef_pointers": 0x0300,
+	"hide_object": 0x0210,
+	"show_object": 0x0220,
+	"pick_up_item": 0x0230,
 }
+## `PredefPointers`' rows, by the id `predef` leaves in a.
+const PREDEFS: Dictionary = {1: 0x0210, 2: 0x0220, 3: 0x0230}
 const AT: int = 0x1000
 const HELLO: int = 0x1800
 const BYE: int = 0x1810
@@ -41,6 +49,10 @@ func _rom(program: Array, strings: Dictionary = {}) -> RomFile:
 		for offset: int in text.size():
 			data[int(address) + 1 + offset] = text[offset]
 		data[int(address) + 1 + text.size()] = Gen2TextStream.CHAR_DONE
+	for id: int in PREDEFS:
+		var row: int = int(LAYOUT["predef_pointers"]) + id * Gen1Layout.PREDEF_SIZE
+		data[row + 1] = int(PREDEFS[id]) & 0xFF
+		data[row + 2] = int(PREDEFS[id]) >> 8
 	return RomFile.from_bytes(data)
 
 
@@ -283,3 +295,41 @@ func test_a_far_call_to_anything_else_answers_nothing() -> void:
 			+ _load_hl(0x4000) + _call(int(LAYOUT["bankswitch"]))
 			+ _call(int(LAYOUT["text_script_end"]))
 	), [])
+
+
+## `ld a, id` and `call Predef`, the whole of the macro.
+func _predef(id: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_A, id] + _call(int(LAYOUT["predef"]))
+
+
+## `ld a, TOGGLE_X` and `ld [wToggleableObjectIndex], a` in front of one.
+func _toggle(index: int, id: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_A, index, Gen1Layout.SCRIPT_LD_MEM_A,
+		int(LAYOUT["toggleable_index"]) & 0xFF,
+		int(LAYOUT["toggleable_index"]) >> 8] + _predef(id)
+
+
+func test_a_predef_hiding_an_object_keeps_its_global_index() -> void:
+	assert_eq(_decode(_toggle(7, 1) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "toggle_object", "index": 7, "hidden": true}])
+
+
+func test_a_predef_showing_an_object_reads_the_other_way() -> void:
+	assert_eq(_decode(_toggle(7, 2) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "toggle_object", "index": 7, "hidden": false}])
+
+
+## `wToggleableObjectIndex` is what the routine reads, so a row that wrote no
+## index is one this decoder cannot say which object goes off the map.
+func test_a_predef_with_no_index_written_answers_nothing() -> void:
+	assert_eq(_decode(_predef(1) + _call(int(LAYOUT["text_script_end"]))), [])
+
+
+## `PickUpItemText` whole: the object's own item is the world's to supply.
+func test_the_pick_up_predef_becomes_its_own_node() -> void:
+	assert_eq(_decode(_predef(3) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "pick_up_item"}])
+
+
+func test_any_other_predef_answers_nothing() -> void:
+	assert_eq(_decode(_predef(0) + _call(int(LAYOUT["text_script_end"]))), [])

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 1022 lines of the 39516 here, and Generation 1 has added 787 more to the
+## are 1066 lines of the 39572 here, and Generation 1 has added 819 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 140 the transition, the split effect routines and
-## `BlkPacket_Battle`. Nine sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39516
+## `BlkPacket_Battle`. Ten sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39572
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_objects.gd
+++ b/tests/unit/test_world_objects.gd
@@ -30,6 +30,38 @@ func test_ff_event_flag_is_the_source_always_visible_sentinel() -> void:
 	assert_true(object.visible_with_state(6, Gen2WorldPalette.TIME_MORNING, state))
 
 
+## `IsObjectHidden`: the toggleable flag starts at the row's own ON or OFF, so
+## the save holds the indices moved away from it rather than the live array.
+func test_a_toggleable_object_starts_where_its_row_stands() -> void:
+	var visible: Gen2WorldObject = Gen2WorldObject.from_event(0, {
+		"toggle_index": 3, "toggle_on": true,
+	})
+	var hidden: Gen2WorldObject = Gen2WorldObject.from_event(1, {
+		"toggle_index": 4, "toggle_on": false,
+	})
+	var state := Gen2WorldState.new()
+	assert_false(visible.masked_hidden(state))
+	assert_true(hidden.masked_hidden(state))
+
+	state.set_object_toggled(3, true)
+	state.set_object_toggled(4, true)
+	assert_true(visible.masked_hidden(state))
+	assert_false(hidden.masked_hidden(state))
+
+
+## An object outside `ToggleableObjectStates` reads its event flag and nothing
+## else, which is every Generation 2 object.
+func test_an_object_with_no_toggle_row_is_masked_by_its_event_flag_alone() -> void:
+	var object: Gen2WorldObject = Gen2WorldObject.from_event(0, {"event_flag": 7})
+	var state := Gen2WorldState.new()
+	assert_eq(object.toggle_index, -1)
+	assert_false(object.masked_hidden(state))
+	state.set_object_toggled(0, true)
+	assert_false(object.masked_hidden(state))
+	state.set_event_flag(7)
+	assert_true(object.masked_hidden(state))
+
+
 func test_hour_ranges_include_endpoints_and_wrap_midnight() -> void:
 	var object: Gen2WorldObject = _object()
 	assert_true(object.visible_at(6, Gen2WorldPalette.TIME_MORNING))

--- a/tests/unit/test_world_state.gd
+++ b/tests/unit/test_world_state.gd
@@ -8,6 +8,20 @@ extends GutTest
 const FLYPOINT_VERMILION: int = 58
 
 
+## `wToggleableObjectFlags` is saved as the indices moved away from their own
+## `ToggleableObjectStates` row, so a state that has moved none writes nothing.
+func test_toggled_objects_round_trip_and_clear() -> void:
+	var state := Gen2WorldState.new()
+	assert_false(state.is_object_toggled(11))
+	state.set_object_toggled(11, true)
+	state.set_object_toggled(12, true)
+	state.set_object_toggled(12, false)
+	var restored := Gen2WorldState.from_dict(state.to_dict())
+	assert_true(restored.is_object_toggled(11))
+	assert_false(restored.is_object_toggled(12))
+	assert_false(restored.is_object_toggled(-1))
+
+
 func test_world_state_round_trips_persistent_overworld_fields() -> void:
 	var state := Gen2WorldState.new(
 		{7: true}, {"1:2": 4}, {3: 8}, {0: 120}, 17, {9: true},

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,12 +130,27 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 94, "text": 195, "branch": 74, "choice": 7, "flag": 22,
-		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 39},
-	&"blue": {"rows": 94, "text": 195, "branch": 74, "choice": 7, "flag": 22,
-		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 39},
-	&"yellow": {"rows": 77, "text": 157, "branch": 66, "choice": 6, "flag": 14,
-		"give_item": 17, "has_item": 7, "take_item": 3, "unknown": 40},
+	&"red": {"rows": 198, "text": 199, "branch": 74, "choice": 7, "flag": 25,
+		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 36,
+		"pick_up_item": 104, "toggle_object": 4},
+	&"blue": {"rows": 198, "text": 199, "branch": 74, "choice": 7, "flag": 25,
+		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 36,
+		"pick_up_item": 104, "toggle_object": 4},
+	&"yellow": {"rows": 185, "text": 158, "branch": 66, "choice": 6, "flag": 15,
+		"give_item": 17, "has_item": 7, "take_item": 3, "unknown": 39,
+		"pick_up_item": 108, "toggle_object": 1},
+}
+## Three `predef HideObject` rows reach no node: `MtMoonB2F`'s two fossils and
+## `PokemonTower7F`'s Mr. Fuji each write `wCurMapScript` behind it, which is a
+## map script index and means nothing without an interpreter, and
+## `CeladonMansionRoofHouse`'s Eevee is a `GivePokemon`.
+
+## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
+## and how many start ON. Three rows name an object their map has not got.
+const TOGGLE_CENSUS: Dictionary = {
+	&"red": {"objects": 226, "on": 194},
+	&"blue": {"objects": 226, "on": 194},
+	&"yellow": {"objects": 233, "on": 195},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -179,6 +194,7 @@ func _one_game() -> void:
 	_r.check(_movements == MOVEMENT_CENSUS[_r.game_id],
 		"the movement census reads %s." % str(_movements))
 	_texts()
+	_toggleables()
 	_wild_objects()
 	_palettes()
 	_sprites()
@@ -625,6 +641,49 @@ func _sprites() -> void:
 			var picture: int = int(object["sprite"])
 			_r.check(picture >= 1 and picture <= wanted,
 				"map %d has an object drawn with picture id %d." % [map.number, picture])
+
+
+## Every object `ShowObject` and `HideObject` can name: one object a global
+## index, and a row under every item and every standing wild.
+func _toggleables() -> void:
+	var indexes: Dictionary = {}
+	var on: int = 0
+	var missing: Array[String] = []
+	var unreachable: Array[String] = []
+	for map: Gen2WorldMap in _maps.values():
+		for object: Dictionary in map.events["objects"] as Array:
+			## `BluesHouse`'s two ITEM rows carry item 0 and a script of their
+			## own; every other item object is picked up by `PickUpItemText`.
+			if int(object.get("item", 0)) > 0 and unreachable.size() < 4 and not _has_op(
+				map.text_at(int(object.get("text", 0))).get("script", []), "pick_up_item"
+			):
+				unreachable.append("map %d item %d" % [map.number, int(object["item"])])
+			if not object.has("toggle_index"):
+				## `PickUpItem` and `EndTrainerBattle` both read
+				## `wToggleableObjectList` with no answer for a miss.
+				if (object.has("item") or object.has("species")) and missing.size() < 4:
+					missing.append("map %d object %d" % [map.number, int(object.get("text", 0))])
+				continue
+			var index: int = int(object["toggle_index"])
+			_r.check(not indexes.has(index), "toggleable index %d is on two objects." % index)
+			indexes[index] = true
+			on += 1 if bool(object.get("toggle_on", true)) else 0
+	_r.check(missing.is_empty(), "no toggleable row reaches %s." % ", ".join(missing))
+	_r.check(unreachable.is_empty(),
+		"no PickUpItem reaches the item on %s." % ", ".join(unreachable))
+	var census: Dictionary = {"objects": indexes.size(), "on": on}
+	_r.check(census == TOGGLE_CENSUS[_r.game_id],
+		"the toggleable objects read %s." % [census])
+	_r.note("gen1 toggleables %s" % [census])
+
+
+static func _has_op(nodes: Variant, op: String) -> bool:
+	if not nodes is Array:
+		return false
+	for node: Dictionary in nodes as Array:
+		if String(node["op"]) == op:
+			return true
+	return false
 
 
 func _wild_objects() -> void:

--- a/tools/checks/gen1_trainers.gd
+++ b/tools/checks/gen1_trainers.gd
@@ -186,23 +186,23 @@ func _the_headers() -> void:
 			var header: Dictionary = _header_for(map, object)
 			if header.is_empty():
 				continue
-			## `CheckForEngagingTrainers` walks one list, so both kinds carry the
-			## type and the range; only the flag's place tells them apart.
+			## Both kinds carry the type, the range and the header's own flag.
 			_r.check(int(object.get("object_type", 0)) == Gen2WorldObject.OBJECTTYPE_TRAINER
-				and int(object.get("sight_range", -1)) == int(header["sight_range"]),
-				"map %d's header row is object type %d seeing %d." % [
+				and int(object.get("sight_range", -1)) == int(header["sight_range"])
+				and int((object.get("trainer", {}) as Dictionary).get("event_flag", 0))
+					== int(header["event_flag"]),
+				"map %d's header row is object type %d seeing %d on flag %d." % [
 					map.number, int(object.get("object_type", 0)),
 					int(object.get("sight_range", -1)),
+					int((object.get("trainer", {}) as Dictionary).get("event_flag", 0)),
 				])
 			if object.has("trainer_class"):
 				census["trainers"] += 1
 				_one_trainer_object(map, object)
 			else:
 				census["wilds"] += 1
-				_r.check(int(object.get("event_flag", 0)) == int(header["event_flag"]),
-					"map %d's standing wild wears flag %d." % [
-						map.number, int(object.get("event_flag", 0)),
-					])
+				_r.check(int(object.get("toggle_index", -1)) >= 0,
+					"map %d's standing wild is outside ToggleableObjectStates." % map.number)
 	_r.check(census == HEADER_CENSUS[_r.game_id],
 		"the header census reads %s." % str(census))
 	_r.note("gen1 trainers %d headers on %d text_asm rows" % [

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -125,6 +125,27 @@ const GIFT_OPENING: String = "Hello, there!"
 const GIFT_KNOWN: String = "TM41 teaches"
 const GIFT_REFUSED: String = "Oh, your pack is"
 
+## Route 4's TM04: an ITEM object on `PickUpItemText` with a toggle row of its own.
+const ROUTE_4: int = 15
+const GROUND_ITEM_CELL := Vector2i(57, 3)
+const GROUND_ITEM_OBJECT: int = 2
+const GROUND_ITEM: int = 0xCC
+const GROUND_ITEM_NAME: String = "TM04"
+const GROUND_ITEM_FOUND: String = "found"
+const GROUND_ITEM_REFUSED: String = "No more room for"
+
+## `TOGGLE_PALLET_TOWN_OAK`, row 0 and one of the 32 that start OFF.
+const PALLET_OAK_CELL := Vector2i(10, 4)
+const PALLET_OAK_OBJECT: int = 0
+
+## `Museum1FScientist2Text`, whose gift ends in `predef HideObject` over the OLD
+## AMBER ball beside it. Yellow reaches that text through a `farcall` instead.
+const MUSEUM_1F: int = 52
+const MUSEUM_SCIENTIST_CELL := Vector2i(15, 2)
+const MUSEUM_AMBER_OBJECT: int = 4
+const OLD_AMBER: int = 0x1F
+const MUSEUM_GIFT_BOX: String = "Take this to a\nPOKéMON LAB"
+
 ## Yellow's `CeruleanBadgeHouse` melanie, the corpus's one box that owes no
 ## press: `DisableWaitingAfterTextDisplay` runs before her last `PrintText`.
 const MELANIE_MAP: int = 63
@@ -147,6 +168,10 @@ func _one_game() -> void:
 	_check_text_boxes()
 	_check_scripted_npcs()
 	_check_a_gift()
+	_check_an_item_is_picked_up()
+	_check_an_object_starts_hidden()
+	if _r.game_id != RomRegistry.YELLOW:
+		_check_a_script_hides_an_object()
 	_check_the_nurse_heals()
 	_check_the_cable_club()
 	_check_the_vending_machine()
@@ -412,6 +437,75 @@ func _check_a_gift_refused() -> void:
 		"a full bag said %s." % [said])
 	_r.check(world.state.item_quantity(TM41_ITEM) == 0, "a full bag took the gift.")
 	_r.check(not world.event_flag_active(TM41_FLAG), "a refused gift set its flag.")
+
+
+## `PickUpItem` both ways: the bag takes the item and `HideObject` takes the ball
+## off the map, or the bag is full and both stay where they were.
+func _check_an_item_is_picked_up() -> void:
+	var world: Gen2WorldAPI = _facing_up(ROUTE_4, GROUND_ITEM_CELL + Vector2i.DOWN)
+	if world == null:
+		return
+	var opened: Array = world.interact()
+	var event: Dictionary = opened[0].get("event", {}) if not opened.is_empty() else {}
+	_r.check(String(event.get("text", "")).contains(GROUND_ITEM_NAME)
+		and String(event.get("text", "")).contains(GROUND_ITEM_FOUND)
+		and not bool(event.get("prompt", true)),
+		"the ground item said %s." % [event])
+	world.run_event_queue(true)
+	_r.check(world.state.item_quantity(GROUND_ITEM) == 1,
+		"the bag holds %d of the ground item." % world.state.item_quantity(GROUND_ITEM))
+	_r.check(not _object_active(world, GROUND_ITEM_OBJECT), "the picked ball is still drawn.")
+	_r.check(world.interact().is_empty(), "the picked ball still answers.")
+
+	world = _facing_up(ROUTE_4, GROUND_ITEM_CELL + Vector2i.DOWN)
+	if world == null:
+		return
+	var stock: Dictionary = {}
+	for slot: int in Gen1Layout.BAG_ITEM_CAPACITY:
+		stock[slot + 1] = 1
+	world.state.apply_changes({}, {}, {"items": stock})
+	_r.check(_box_text(world).begins_with(GROUND_ITEM_REFUSED),
+		"a full bag met the ground item with %s." % _box_text(world))
+	_r.check(world.state.item_quantity(GROUND_ITEM) == 0, "a full bag took the ground item.")
+	_r.check(_object_active(world, GROUND_ITEM_OBJECT), "a refused ball left the map.")
+
+
+## `InitializeToggleableObjectsFlags` writes the OFF rows on a new game, so Oak
+## is in Pallet Town's objects and not on its map until a `ShowObject` runs.
+func _check_an_object_starts_hidden() -> void:
+	var world: Gen2WorldAPI = _facing_up(PALLET_TOWN, PALLET_OAK_CELL + Vector2i.DOWN)
+	if world == null:
+		return
+	var oak: Gen2WorldObject = world.objects[PALLET_OAK_OBJECT]
+	_r.check(oak.toggle_index == 0 and not oak.toggle_on,
+		"Pallet Town's Oak carries toggle %d, on %s." % [oak.toggle_index, oak.toggle_on])
+	_r.check(not oak.active, "Oak is on the map already.")
+	world.gen1_toggle_object(oak.toggle_index, false)
+	_r.check(_object_active(world, PALLET_OAK_OBJECT), "ShowObject left Oak off the map.")
+
+
+## A decoded `predef HideObject`: the OLD AMBER lands and its ball leaves the map.
+func _check_a_script_hides_an_object() -> void:
+	var world: Gen2WorldAPI = _facing_up(MUSEUM_1F, MUSEUM_SCIENTIST_CELL + Vector2i.DOWN)
+	if world == null:
+		return
+	_r.check(_object_active(world, MUSEUM_AMBER_OBJECT), "the OLD AMBER was never drawn.")
+	var said: Array[String] = _spoken(world)
+	_r.check(said.size() == 2 and said[0].contains(MUSEUM_GIFT_BOX),
+		"the museum scientist said %s." % [said])
+	_r.check(world.state.item_quantity(OLD_AMBER) == 1, "the OLD AMBER never landed.")
+	_r.check(not _object_active(world, MUSEUM_AMBER_OBJECT), "the OLD AMBER is still drawn.")
+
+
+func _facing_up(map: int, cell: Vector2i) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(0, map, cell)
+	if world != null:
+		world.player_facing = Gen2WorldSprite.FACING_UP
+	return world
+
+
+func _object_active(world: Gen2WorldAPI, index: int) -> bool:
+	return (world.objects[index] as Gen2WorldObject).active
 
 
 func _spoken(world: Gen2WorldAPI) -> Array[String]:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -27,7 +27,7 @@ const KIND_HELP: Dictionary = {
 	&"mart": "cell in front of the counter: BuyMenu",
 	&"mart_sell": "cell in front of the counter: the SELL row (DepositSellPack)",
 	&"pokepic": "cell: Script_pokepic's box over the map, holding Chikorita",
-	&"sign": "none: DisplayTextID's box, read by facing up from where the player stands",
+	&"sign": "frames: DisplayTextID's box, read by facing up from where the player stands. 0 spends the whole reveal, which is past a box owing no press",
 	&"gift": "presses: a `GiveItem` row, faced up from the cell after the @. 0 is the offer's first page, 4 the receipt box a bag with room earns",
 	&"trainer": "presses, frames: TalkToTrainer on the map's first trainer, faced from the cell below. 0 the before-battle box, 1 the fight the press behind it opens; a second number stops that many frames into the transition instead",
 	&"sight": "frames, 0: CheckFightingMapTrainers on the map's first trainer who sees, walked into from the far end of its own line. 40 stands in the shock bubble, 120 in the walk-up, 400 in the before-battle box",
@@ -470,7 +470,7 @@ func _process(_delta: float) -> bool:
 		## `bare` takes the readout off and nothing else: skipping these caught
 		## a staged box on the frame it opened, which is an empty box.
 		if _kind not in SELF_DRIVEN_KINDS:
-			for _frame: int in int(STAGED_FRAMES_BY_KIND.get(_kind, STAGED_FRAMES)):
+			for _frame: int in _staged_frames():
 				_screen.advance_frame()
 	if _frames < 18:
 		return false
@@ -955,6 +955,13 @@ func _stage_sight() -> void:
 		_screen.press_button(ICE_SLIDE_BUTTONS[object.facing ^ 1])
 		break
 	_screen.advance_frames(maxi(_cell.x, 0))
+
+
+## The whole reveal, or the `x` argument: a box owing no press closes behind it.
+func _staged_frames() -> int:
+	if _kind == &"sign" and _cell.x > 0:
+		return _cell.x
+	return int(STAGED_FRAMES_BY_KIND.get(_kind, STAGED_FRAMES))
 
 
 ## `DisplayTextID`'s box, read by facing the cell above the `x y` argument.


### PR DESCRIPTION
`ToggleableObjectMapPointers` and `ToggleableObjectStates` are imported onto the objects they name: 226 rows on Red and Blue and 233 on Yellow, 32 and 41 of them starting OFF, which is why Oak is in Pallet Town's objects and not on its map. The flag `IsObjectHidden` reads is kept as the set of indices a `ShowObject` or a `HideObject` has moved away from their own row, so a save that has run neither is the cartridge's own new game and there is no seeding pass. `Gen2WorldObject.masked_hidden` is the one seam `LoadObjectMasks` reads through, `CheckObjectFlag` on Generation 2 and `IsObjectHidden` on Generation 1.

`Gen1WorldImporter.decode_script` reads `predef` whole, resolving the id through `PredefPointers` rather than pinning one, so `ShowObject2` needs no row of its own. `PickUpItemText` decodes on 104 rows of Red and Blue and 108 of Yellow, every ITEM object carrying an item; 4 rows on Red and Blue and 1 on Yellow hide or show an object. A beaten standing wild leaves the map through its own toggle bit now rather than through the header flag, which `EndTrainerBattle` sets on both kinds alike.

`MapTextbox` prints its string a letter at a time and returns behind the last one. `Gen2WorldScreen._continue_if_text_settled` had read it as returning where the box opened, so a text owing no press was on screen for one frame with no letters in it, in both generations.

## Checks

| Run | Result |
|---|---|
| `tools/validate.gd -- all` | 92 topics pass |
| GUT, every tier | 4,404 tests, 102,083 asserts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed node |
| Warning scan | 0 warnings in 632 scripts |

`tools/checks/gen1_maps.gd` pins the toggle census and that every item object and every standing wild carries a row; `gen1_walk.gd` picks Route 4's TM04 up with room and against a full bag, reads Pallet Town's hidden Oak and shows him again, and takes the Museum's OLD AMBER out of the ball beside the scientist. Both go red when the mask is broken either way about.