### PR TITLE
Open the Generation 1 START menu and its bag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ Matching uses SHA-1, never filenames. Unknown hashes are refused because an
 uncharacterised bank layout could produce corrupt assets. The three Generation 1
 cartridges import their species, move, type, item and trainer tables, every map
 and tileset, and every map text, and a wild fight, a trainer battle and a
-standing wild Pokemon on one of their maps are all fought on the battle screen;
-the launcher seats one and does not offer Play until its map scripts are
+standing wild Pokemon on one of their maps are all fought on the battle screen.
+The START menu is the cartridge's own list and opens its one-pocket bag; the
+launcher seats one and does not offer Play until its map scripts are
 interpreted.
 
 | Game | SHA-1 |
@@ -367,7 +368,7 @@ or a group, or `all`; with no argument it lists them.
 | `art` | Both intro movies, the credits, the region map, all 278 battle animations, the map name sign |
 | `tables` | TM/HM, naming, world scripts, the opening lane |
 | `trainers` | The Route 30 trainer on each profile |
-| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, and all 202 or 203 battle animations |
+| `gen1` | Red, Blue and Yellow's species, move, type, item and trainer tables, the key-item and usable-item tables behind the bag, every picture their sprite codec decodes, all 226 or 227 maps with their tilesets, the text box, shop inventory and wild encounter a map reads, every trainer and standing wild an object stands on, and all 202 or 203 battle animations |
 
 The rest are previews and dumps, each driving a real screen or table:
 

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -321,7 +321,7 @@ func field_hm_items() -> Array[int]:
 	var count: int = _data.tmhm_moves().size()
 	for number: int in count:
 		var item: int = Gen2Layout.item_for_tmhm_number(number + 1, count)
-		if not Gen2WorldTMHM.is_hm(item):
+		if not Gen2WorldTMHM.is_hm(item, _data.generation):
 			continue
 		if Gen2WorldFieldMove.is_field_move(_data.tmhm_move(number + 1)):
 			out.append(item)
@@ -344,7 +344,7 @@ func badge_for_hm_item(item: int) -> int:
 
 ## The field move [param item] teaches, or 0 for anything that is not a field HM.
 func move_for_hm_item(item: int) -> int:
-	if _data == null or not Gen2WorldTMHM.is_hm(item):
+	if _data == null or not Gen2WorldTMHM.is_hm(item, _data.generation):
 		return 0
 	var move: int = Gen2WorldTMHM.move_for_item(_data, item)
 	return move if Gen2WorldFieldMove.is_field_move(move) else 0

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -36,6 +36,16 @@ const FIRST_DEX_HEIGHT_FEET: int = 2
 const FIRST_DEX_HEIGHT_INCHES: int = 4
 const FIRST_DEX_WEIGHT: int = 150
 
+## `KeyItemFlags`' first byte: the four balls are free and the Town Map, the
+## Bicycle, the Surfboard and the Safari Ball are not.
+const KEY_ITEM_FIRST_BYTE: int = 0xF0
+## The first item and the row count of `UsableItems_PartyMenu` and
+## `UsableItems_CloseMenu`, both identical on all three cartridges.
+const USABLE_ITEM_FIRST: Dictionary = {
+	"usable_items_party": [0x0A, 36],
+	"usable_items_close": [0x1D, 6],
+}
+
 ## `TechnicalMachines`' first and last rows: TM01 is Mega Punch and HM05 is Flash.
 const FIRST_TM_MOVE: int = 0x05
 const LAST_HM_MOVE: int = 0x94
@@ -110,6 +120,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_type_names,
 	_verify_type_effects,
 	_verify_item_names,
+	_verify_item_attributes,
 	_verify_tmhm_moves,
 	_verify_dex_order,
 	_verify_dex_entries,
@@ -156,6 +167,8 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"prizes": ["prize_text", Gen1Layout.PRIZE_TEXT_AT],
 	"prizes_2": ["prize_text_2", Gen1Layout.PRIZE_TEXT_2_AT],
 	"pick_up_item": ["found_item_text", Gen1Layout.PICK_UP_TEXT_AT],
+	"item_use": ["item_use_text", Gen1Layout.ITEM_USE_TEXT_AT],
+	"toss": ["toss_text", Gen1Layout.TOSS_TEXT_AT],
 }
 
 
@@ -271,6 +284,21 @@ static func _verify_item_names(rom: RomFile, layout: Dictionary) -> Dictionary:
 	)
 	if names.size() != Gen1Layout.ITEM_COUNT or names[0] != FIRST_ITEM_NAME:
 		return _fail("Item names open on '%s'." % (names[0] if not names.is_empty() else ""))
+	return _ok()
+
+
+## The three tables `StartMenu_Item` reads an item's own behaviour out of. Each
+## opens on a row a wrong offset would not: the Town Map is the first key item,
+## the party run on the Moon Stone and the closing run on the Escape Rope.
+static func _verify_item_attributes(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var flags: int = int(layout["key_item_flags"])
+	if rom.u8(flags) != KEY_ITEM_FIRST_BYTE:
+		return _fail("KeyItemFlags opens on $%02X." % rom.u8(flags))
+	for key: String in USABLE_ITEM_FIRST:
+		var run: Dictionary = read_usable_items(rom, layout, key)
+		if run.size() != int(USABLE_ITEM_FIRST[key][1]) \
+			or not run.has(int(USABLE_ITEM_FIRST[key][0])):
+			return _fail("%s holds %d rows." % [key, run.size()])
 	return _ok()
 
 
@@ -1046,6 +1074,8 @@ func _import_items(rom: RomFile, layout: Dictionary) -> Array:
 	var names: PackedStringArray = Gen1Text.decode_sequence(
 		rom.bytes(), int(layout["item_names"]), Gen1Layout.ITEM_COUNT, MAX_NAME_LENGTH
 	)
+	var party_use: Dictionary = read_usable_items(rom, layout, "usable_items_party")
+	var close_use: Dictionary = read_usable_items(rom, layout, "usable_items_close")
 	## `GetMachineName` spells an HM's or a TM's name from its own number and
 	## `GetMachinePrice` reads a nybble table an HM never reaches, so the two
 	## runs above `ItemNames` are built rather than read. The table is dense
@@ -1057,8 +1087,49 @@ func _import_items(rom: RomFile, layout: Dictionary) -> Array:
 			"number": item,
 			"name": _item_name(names, item),
 			"price": _item_price(rom, layout, item),
+			"pocket": Gen1Layout.BAG_POCKET,
+			"permissions": _item_permissions(rom, layout, item),
+			"field_menu": _item_field_menu(item, party_use, close_use),
 		})
 	return out
+
+
+## `IsKeyItem_`: `KeyItemFlags` decides everything below HM01 and `IsItemHM`
+## everything above, so an HM is a key item and a TM is not. Nothing registers an
+## item on SELECT there, so `CANT_SELECT` is set on the whole table.
+static func _item_permissions(rom: RomFile, layout: Dictionary, item: int) -> int:
+	var key: bool = Gen1Layout.is_hm_item(item)
+	if item <= Gen1Layout.ITEM_COUNT:
+		var index: int = item - 1
+		@warning_ignore("integer_division")
+		var byte: int = rom.u8(int(layout["key_item_flags"]) + index / 8)
+		key = (byte & (1 << (index % 8))) != 0
+	var permissions: int = Gen2Layout.ITEM_ATTRIBUTE_CANT_SELECT
+	return permissions | (Gen2Layout.ITEM_ATTRIBUTE_CANT_TOSS if key else 0)
+
+
+## `StartMenu_Item`'s own ladder as the nibble [Gen2WorldPack] branches on: the
+## Bicycle and `UsableItems_CloseMenu` quit the menu, an HM, a TM and
+## `UsableItems_PartyMenu` open the party list, the rest leave the list standing.
+static func _item_field_menu(item: int, party_use: Dictionary, close_use: Dictionary) -> int:
+	if item == Gen1Layout.ITEM_BICYCLE or close_use.has(item):
+		return Gen2Layout.ITEMMENU_CLOSE
+	if Gen1Layout.machine_number(item) > 0 or party_use.has(item):
+		return Gen2Layout.ITEMMENU_PARTY
+	return Gen2Layout.ITEMMENU_CURRENT
+
+
+## One `db`-terminated item run as a set. Empty when the run does not end inside
+## [constant Gen1Layout.USABLE_ITEMS_MAX] rows, which is what a wrong offset does.
+static func read_usable_items(rom: RomFile, layout: Dictionary, key: String) -> Dictionary:
+	var at: int = int(layout.get(key, 0))
+	var out: Dictionary = {}
+	for step: int in Gen1Layout.USABLE_ITEMS_MAX:
+		var item: int = rom.u8(at + step)
+		if item == Gen1Layout.USABLE_ITEMS_END:
+			return out
+		out[item] = true
+	return {}
 
 
 static func _item_name(names: PackedStringArray, item: int) -> String:

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -299,6 +299,17 @@ const ITEM_GREAT_BALL: int = 0x03
 const ITEM_POKE_BALL: int = 0x04
 const ITEM_SAFARI_BALL: int = 0x08
 
+## The other `ItemUsePtrTable` rows the pack reaches, by `item_constants.asm`'s
+## own numbering, which is not Crystal's anywhere.
+const ITEM_BICYCLE: int = 0x06
+const ITEM_ESCAPE_ROPE: int = 0x1D
+## `IsItemInBag COIN_CASE`, which `CeladonPrizeMenu` opens on.
+const ITEM_COIN_CASE: int = 0x45
+const ITEM_ITEMFINDER: int = 0x47
+const ITEM_OLD_ROD: int = 0x4C
+const ITEM_GOOD_ROD: int = 0x4D
+const ITEM_SUPER_ROD: int = 0x4E
+
 ## `ItemUseBall`'s three per-ball numbers: the ceiling Rand1 is rerolled above,
 ## `BallFactor` and `BallFactor2`. SAFARI_BALL takes the fall-through below.
 const BALL_ROLL: Dictionary = {
@@ -392,8 +403,6 @@ const TEXT_SCRIPT_CABLE_CLUB: int = 0xF6
 const TEXT_SCRIPT_VENDING_MACHINE: int = 0xF5
 const TEXT_SCRIPT_PRIZE_VENDOR: int = 0xF7
 
-## `IsItemInBag COIN_CASE`, which `CeladonPrizeMenu` opens on.
-const ITEM_COIN_CASE: int = 0x45
 
 ## `CeladonPrizeMenu`'s two stub runs, which are not one: the unreferenced
 ## `HereYouGoText` between them moves on Yellow.
@@ -470,6 +479,15 @@ const MART_TEXT_AT: Dictionary = {
 const POKECENTER_TEXT_AT: Dictionary = {
 	"welcome": 0x00, "shall_we_heal": 0x05, "need_your_pokemon": 0x0B,
 	"fighting_fit": 0x10, "farewell": 0x15,
+}
+
+## `engine/items/item_effects.asm`'s two runs the pack prints from: the three
+## refusals `ItemUseFailed` reaches and `TossItem_`'s own three.
+const ITEM_USE_TEXT_AT: Dictionary = {
+	"not_time": 0x00, "not_yours": 0x05, "no_effect": 0x0A,
+}
+const TOSS_TEXT_AT: Dictionary = {
+	"threw_away": 0x00, "ok_to_toss": 0x05, "too_important": 0x0A,
 }
 
 ## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
@@ -603,6 +621,19 @@ const SCRIPT_OPERAND_HL: int = 6
 const EVENT_FLAG_BYTES: int = 320
 ## `BAG_ITEM_CAPACITY`: one list of slots, not four pockets.
 const BAG_ITEM_CAPACITY: int = 20
+## The one type byte every Generation 1 item wears, so the shared pack draws the
+## bag as the single `DisplayListMenuID` list `engine/menus/start_sub_menus.asm`
+## opens.
+const BAG_POCKET: int = Gen2Layout.ITEM_POCKET_ITEM
+
+## `KeyItemFlags` (`data/items/key_items.asm`): `dbit` writes item `n + 1` into
+## bit `n % 8` of byte `n / 8`, `(NUM_ITEMS + 7) / 8` bytes in all.
+const KEY_ITEM_FLAG_BYTES: int = 11
+## `UsableItems_PartyMenu` and `UsableItems_CloseMenu`, each a run of item
+## numbers ending in `-1`. The guard is the whole item table: a longer run means
+## the offset is wrong.
+const USABLE_ITEMS_END: int = 0xFF
+const USABLE_ITEMS_MAX: int = ITEM_COUNT
 ## `MAX_WARP_EVENTS`, `MAX_BG_EVENTS` and `MAX_OBJECT_EVENTS`.
 const MAX_WARP_EVENTS: int = 32
 const MAX_SIGN_EVENTS: int = 16
@@ -765,6 +796,11 @@ const RED_BLUE: Dictionary = {
 	"item_names": 0x0472B,
 	"item_prices": 0x04608,
 	"tm_prices": 0x7BFA7,
+	"key_item_flags": 0x0E799,
+	"usable_items_party": 0x13434,
+	"usable_items_close": 0x13459,
+	"item_use_text": 0x0E5C0,
+	"toss_text": 0x0E755,
 	"tmhm_moves": 0x13773,
 	"mon_palettes": 0x725C8,
 	"super_palettes": 0x72660,
@@ -866,6 +902,11 @@ const YELLOW: Dictionary = {
 	"item_names": 0x045B7,
 	"item_prices": 0x04494,
 	"tm_prices": 0xF65F5,
+	"key_item_flags": 0x0E6DD,
+	"usable_items_party": 0x11FDE,
+	"usable_items_close": 0x12003,
+	"item_use_text": 0x0E4FF,
+	"toss_text": 0x0E699,
 	"tmhm_moves": 0x1232D,
 	"mon_palettes": 0x72921,
 	"super_palettes": 0x729B9,
@@ -1033,6 +1074,23 @@ static func facility_text_offset(
 	if at <= 0 or not slots.has(name):
 		return -1
 	return at + int(slots[name])
+
+
+## `IsItemHM`, and the TM run that follows the five HMs in the item numbering.
+static func is_hm_item(item: int) -> bool:
+	return item >= HM_FIRST_ITEM and item < TM_FIRST_ITEM
+
+
+static func is_tm_item(item: int) -> bool:
+	return item >= TM_FIRST_ITEM and item < TM_FIRST_ITEM + TM_COUNT
+
+
+## `TechnicalMachines`' own one-based row for [param item], or 0. The item
+## numbering puts the HMs under the TMs and the table has them the other way up.
+static func machine_number(item: int) -> int:
+	if is_tm_item(item):
+		return item - TM_FIRST_ITEM + 1
+	return TM_COUNT + item - HM_FIRST_ITEM + 1 if is_hm_item(item) else 0
 
 
 static func item_price_offset(layout: Dictionary, item: int) -> int:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 112
+const FORMAT_VERSION: int = 113
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -308,6 +308,7 @@ const ITEM_ATTRIBUTE_POCKET: int = 5
 const ITEM_ATTRIBUTE_HELP: int = 6
 ## The item attribute table calls this field a pocket, but its value is the
 ## cartridge's item type: ITEM=1, KEY_ITEM=2, BALL=3, TM_HM=4.
+const ITEM_POCKET_ITEM: int = 1
 const ITEM_POCKET_BALL: int = 3
 const ITEMMENU_NOUSE: int = 0
 const ITEMMENU_CURRENT: int = 4

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -114,9 +114,21 @@ const GEN1_LIST_HEIGHT: int = 4
 const GEN1_CURSOR_ROWS: int = 3
 ## A name runs to the box's own border: the price sits a row below it.
 const GEN1_NAME_CELLS: int = GEN1_LIST_AT.x + GEN1_LIST_SIZE.x - 1 - GEN1_NAME_AT.x
+## `PrintListMenuEntries`' other two writes: a count one row below its own name
+## and eight columns right, and the `▼` in the box's bottom-right corner.
+const GEN1_COUNT_COLUMN: int = GEN1_NAME_AT.x + 8
+const GEN1_COUNT_DIGITS: int = 2
+const GEN1_DOWN_ARROW_AT: Vector2i = Vector2i(18, 11)
+## `HandleItemListSwapping`'s own marker, written over the cursor column of the
+## row SELECT is holding.
+const GEN1_HELD_CODE: int = 0xEC
 ## `DisplayChooseQuantityMenu`'s priced branch: `hlcoord 7, 9` with `lb b, 1,
-## c, 11`, the same box Generation 2 draws six rows lower.
+## c, 11`, the same box Generation 2 draws six rows lower. Its unpriced branch is
+## the same row at `hlcoord 15, 9` with `c, 3`, which is what a TOSS asks in.
 const GEN1_QUANTITY_AT: Vector2i = Vector2i(7, 9)
+const GEN1_COUNT_ONLY_AT: Vector2i = Vector2i(15, 9)
+const GEN1_COUNT_ONLY_SIZE: Vector2i = Vector2i(5, 3)
+const GEN1_COUNT_ONLY_TEXT_AT: Vector2i = Vector2i(16, 10)
 
 var font: Gen2Font = null
 ## Which text-box border the player chose, for the three boxes this draws.
@@ -304,6 +316,8 @@ func _blit_gen1_money(image: Image, money: int) -> void:
 	_blit_panel(image, indices, MONEY_SIZE, MONEY_AT)
 
 
+## `wPrintItemPrices` is the one place the two callers of
+## `PrintListMenuEntries` differ, so a row carries a `price` or a `quantity`.
 func _blit_gen1_list(image: Image, state: Dictionary) -> void:
 	var indices: PackedByteArray = _panel(GEN1_LIST_SIZE)
 	var width: int = GEN1_LIST_SIZE.x * TILE
@@ -316,17 +330,68 @@ func _blit_gen1_list(image: Image, state: Dictionary) -> void:
 			_text(indices, width, CANCEL, at)
 			continue
 		_text(indices, width, String(row.get("name", "")), at, GEN1_NAME_CELLS)
-		_text(
-			indices, width, money_string(int(row.get("price", 0))),
-			Vector2i(GEN1_PRICE_COLUMN - GEN1_LIST_AT.x, at.y + 1)
-		)
+		if row.has("price"):
+			_text(
+				indices, width, money_string(int(row["price"])),
+				Vector2i(GEN1_PRICE_COLUMN - GEN1_LIST_AT.x, at.y + 1)
+			)
+		elif row.has("quantity") and bool(row.get("show_quantity", true)):
+			_text(
+				indices, width, "×%s" % String.num_int64(
+					maxi(int(row["quantity"]), 0)
+				).lpad(GEN1_COUNT_DIGITS),
+				Vector2i(GEN1_COUNT_COLUMN - GEN1_LIST_AT.x, at.y + 1)
+			)
+	var cursor_column: int = GEN1_CURSOR_COLUMN - GEN1_LIST_AT.x
+	var first_row: int = GEN1_NAME_AT.y - GEN1_LIST_AT.y
+	var held: int = int(state.get("held", -1))
+	if held >= 0 and held < mini(rows.size(), GEN1_LIST_HEIGHT):
+		_code(indices, width, GEN1_HELD_CODE, Vector2i(
+			cursor_column, first_row + held * ROW_STEP
+		))
 	var cursor: int = int(state.get("cursor", -1))
 	if cursor >= 0 and cursor < mini(rows.size(), GEN1_CURSOR_ROWS):
 		_code(indices, width, CURSOR_CODE, Vector2i(
-			GEN1_CURSOR_COLUMN - GEN1_LIST_AT.x,
-			GEN1_NAME_AT.y - GEN1_LIST_AT.y + cursor * ROW_STEP
+			cursor_column, first_row + cursor * ROW_STEP
 		))
+	## `.printCancelMenuItem` is a `jp PlaceString`: a pass that reached the
+	## terminator returns without writing the arrow.
+	if rows.size() >= GEN1_LIST_HEIGHT \
+		and not bool((rows[GEN1_LIST_HEIGHT - 1] as Dictionary).get("cancel", false)):
+		_code(indices, width, DOWN_ARROW_CODE, GEN1_DOWN_ARROW_AT - GEN1_LIST_AT)
 	_blit_panel(image, indices, GEN1_LIST_SIZE, GEN1_LIST_AT)
+
+
+## `StartMenu_Item`'s screen: the same `DisplayListMenuID` box the shop opens,
+## with counts where the shop prints prices and no money box over it.
+func render_gen1_pack(state: Dictionary) -> Image:
+	if font == null:
+		return null
+	var image := Image.create_empty(
+		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
+	)
+	if bool(state.get("listing", true)):
+		_blit_gen1_list(image, state)
+	if int(state.get("quantity", -1)) >= 0:
+		_blit_gen1_count(image, int(state["quantity"]))
+	return image
+
+
+## `DisplayChooseQuantityMenu`'s unpriced branch, `InitialQuantityText`'s own
+## `×01` in a box five cells wide.
+func _blit_gen1_count(image: Image, quantity: int) -> void:
+	var indices: PackedByteArray = _panel(GEN1_COUNT_ONLY_SIZE)
+	var width: int = GEN1_COUNT_ONLY_SIZE.x * TILE
+	font.draw_box(
+		frame_style, indices, width, 0, 0,
+		GEN1_COUNT_ONLY_SIZE.x, GEN1_COUNT_ONLY_SIZE.y
+	)
+	_text(
+		indices, width,
+		"×%s" % String.num_int64(maxi(quantity, 0)).lpad(GEN1_COUNT_DIGITS, "0"),
+		GEN1_COUNT_ONLY_TEXT_AT - GEN1_COUNT_ONLY_AT
+	)
+	_blit_panel(image, indices, GEN1_COUNT_ONLY_SIZE, GEN1_COUNT_ONLY_AT)
 
 
 ## `VendingMachineMenu`'s box: `TextBoxBorder hlcoord 0, 3` at eight by twelve,

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -141,6 +141,19 @@ const TEXT_TOSS_ASK: String = "toss_ask"
 const TEXT_TOSS_ASK_QUANTITY: String = "toss_ask_quantity"
 const TEXT_TOSS_THREW: String = "toss_threw"
 
+## `TossItem_`'s refusal. Generation 2 never reaches it: TOSS is not in its
+## submenu for an item `_CheckTossableItem` refuses.
+const TEXT_TOO_IMPORTANT: String = "too_important"
+## The same four boxes on Generation 1, which keeps them in
+## `engine/items/item_effects.asm` rather than in a pack of its own.
+## `AskQuantityThrowAwayText` has no counterpart: the dial opens over no question.
+const GEN1_PACK_TEXTS: Dictionary = {
+	TEXT_OAK: ["item_use", "not_time"],
+	TEXT_TOSS_ASK_QUANTITY: ["toss", "ok_to_toss"],
+	TEXT_TOSS_THREW: ["toss", "threw_away"],
+	TEXT_TOO_IMPORTANT: ["toss", "too_important"],
+}
+
 ## What each reads on a cache imported before the texts were, which is the only
 ## way any of these is ever seen. Verbatim from data/text/common_2.asm.
 const TEXT_FALLBACKS: Dictionary = {
@@ -165,6 +178,10 @@ const YES_NO_SPAN: Vector2i = Vector2i(5, 4)
 ## `TossItem_MenuHeader`: `menu_coords 15, 9, SCREEN_WIDTH - 1, TEXTBOX_Y - 1`.
 const TOSS_QUANTITY_AT: Vector2i = Vector2i(15, 9)
 const TOSS_QUANTITY_TO: Vector2i = Vector2i(19, 11)
+## `USE_TOSS_MENU_TEMPLATE` (`data/text_boxes.asm`), Generation 1's whole item
+## submenu, with `wTopMenuItemX` on column 14 and its two rows one apart.
+const GEN1_ITEM_MENU_AT: Vector2i = Vector2i(13, 10)
+const GEN1_ITEM_MENU_TO: Vector2i = Vector2i(19, 14)
 ## `STATICMENU_CURSOR | STATICMENU_NO_TOP_SPACING`, which every one of them sets.
 const SUBMENU_FLAGS: int = (
 	Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
@@ -198,6 +215,10 @@ var _pack_cursors: Array[int] = [0, 0, 0, 0]
 ## or -1 for `SwitchItemsInBag`' own zero.
 var _pack_switch: int = -1
 var _pack_page: Gen2PackPage = null
+## Generation 1's pack is the shop's own `DisplayListMenuID` box and the
+## overworld's `MenuTextbox` over the map.
+var _mart_page: Gen2MartPage = null
+var _service_page: Gen2WorldServicePage = null
 var _pack_result_ok: bool = false
 ## `PrintText` waits per page, so a result longer than the box's two rows is
 ## pressed through rather than cut off at the frame.
@@ -399,6 +420,10 @@ func _select_pack_item(item: int) -> bool:
 				continue
 			_pack_pocket_index = pocket_index
 			_pack_cursor = index
+			## `wListScrollOffset`: a row past the window draws no cursor.
+			_pack_scroll[pocket_index] = clampi(
+				index - (_pack_cursor_rows() - 1), 0, index
+			)
 			_render_pack()
 			return true
 	return false
@@ -957,6 +982,21 @@ func _open_pack_mode(reset: bool = true) -> void:
 	_render_pack()
 
 
+## `DisplayListMenuID`'s one list rather than `engine/items/pack.asm`'s pockets.
+func _gen1_pack() -> bool:
+	return _data != null and _data.generation == RomRegistry.GEN1
+
+
+## `wMaxMenuItem` against `ScrollingMenu_InitFlags`' own row count.
+func _pack_cursor_rows() -> int:
+	return Gen2MartPage.GEN1_CURSOR_ROWS if _gen1_pack() else Gen2PackPage.LIST_HEIGHT
+
+
+## `PrintListMenuEntries` prints four names against a `wMaxMenuItem` of 2.
+func _pack_drawn_rows() -> int:
+	return Gen2MartPage.GEN1_LIST_HEIGHT if _gen1_pack() else Gen2PackPage.LIST_HEIGHT
+
+
 func _current_pocket() -> Dictionary:
 	if _pack_pockets.is_empty():
 		return {}
@@ -971,7 +1011,8 @@ func _current_pocket_items() -> Array:
 ## `w*PocketCursor` and `w*PocketScrollPosition` on the way out and loads them
 ## again on the way in, so a pocket is where the player left it.
 func _cycle_pocket(delta: int) -> void:
-	if _pack_pockets.is_empty():
+	## Generation 1's list menu watches left and right and answers neither.
+	if _pack_pockets.is_empty() or _gen1_pack():
 		return
 	## `.switching_item` answers left and right with a plain carry, so the pocket
 	## cannot be changed while a row is held.
@@ -992,13 +1033,17 @@ func _cycle_pocket(delta: int) -> void:
 ## past the last item, which is what makes the walk wrap over `size + 1`.
 func _move_pack_cursor(delta: int) -> void:
 	var rows: int = _current_pocket_items().size() + 1
-	_pack_cursor = wrapi(_pack_cursor + signi(delta), 0, rows)
+	var height: int = _pack_cursor_rows()
+	var next: int = _pack_cursor + signi(delta)
+	## `DisplayListMenuID` sets `wMenuWatchMovingOutOfBounds`, so a move past
+	## either end scrolls `wListScrollOffset` and leaves the cursor where it was.
+	_pack_cursor = clampi(next, 0, rows - 1) if _gen1_pack() else wrapi(next, 0, rows)
 	_pack_scroll[_pack_pocket_index] = clampi(
 		clampi(
 			_pack_scroll[_pack_pocket_index],
-			_pack_cursor - (Gen2PackPage.LIST_HEIGHT - 1), _pack_cursor
+			_pack_cursor - (height - 1), _pack_cursor
 		),
-		0, maxi(rows - Gen2PackPage.LIST_HEIGHT, 0)
+		0, maxi(rows - height, 0)
 	)
 	_render_pack()
 
@@ -1019,6 +1064,8 @@ func _pack_rows() -> Array:
 		int(_current_pocket().get("pocket", 0)),
 		_current_pocket_items(),
 		_pack_scroll[_pack_pocket_index],
+		true,
+		_pack_drawn_rows(),
 	)
 
 
@@ -1026,6 +1073,8 @@ func _pack_rows() -> Array:
 ## own description, and the TM/HM pocket the move's; a cursor on CANCEL leaves
 ## the box empty, which is what `TMHM_CheckHoveringOverCancel` does.
 func _pack_image() -> Image:
+	if _gen1_pack():
+		return _gen1_pack_image()
 	if _pack_page == null:
 		_pack_page = Gen2PackPage.from_data(_data)
 	if _pack_page == null:
@@ -1033,6 +1082,37 @@ func _pack_image() -> Image:
 	return _pack_page.image(
 		_data, _pack_map(_pack_description()), _pack_pocket_index, _player_is_female()
 	)
+
+
+## `StartMenu_Item` never leaves the map: the framed list, the box a chosen row
+## opens, `DisplayChooseQuantityMenu`'s dial and whatever `PrintText` last wrote
+## all stand over it. [param quantity] is the dial's number, or -1 for no dial.
+func _gen1_pack_image(actions: Array = [], quantity: int = -1) -> Image:
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _service_page == null or _mart_page == null:
+		return null
+	var scroll: int = _pack_scroll[_pack_pocket_index]
+	var image: Image = _mart_page.render_gen1_pack({
+		"rows": _pack_rows(),
+		"cursor": _pack_cursor - scroll,
+		"held": _pack_switch - scroll if _pack_switch >= 0 else -1,
+		"quantity": quantity,
+	})
+	if image == null:
+		return null
+	var over: Image = _service_page.render(
+		"", "", actions, _item_cursor, box_text(),
+		Gen2MenuBox.from_coords(
+			GEN1_ITEM_MENU_AT.x, GEN1_ITEM_MENU_AT.y,
+			GEN1_ITEM_MENU_TO.x, GEN1_ITEM_MENU_TO.y, SUBMENU_FLAGS
+		)
+	)
+	if over != null:
+		image.blend_rect(over, Rect2i(Vector2i.ZERO, over.get_size()), Vector2i.ZERO)
+	return image
 
 
 ## The pocket listing's own tilemap with [param text] in its description box,
@@ -1049,6 +1129,21 @@ func _pack_map(text: String) -> PackedInt32Array:
 ## The pack's screen with one of its `MENU_BACKUP_TILES` boxes over it.
 ## [param draw_page] writes tiles into the map the pack just built, so the box wears
 ## the attrmap `_CGB_PackPals` left rather than being a layer of its own.
+## `TossItem_`'s `hlcoord 14, 7`, the box `_YesNoBox` opens on Generation 2.
+func _blend_gen1_yes_no(image: Image, cursor_index: int) -> void:
+	if _service_page == null:
+		return
+	var box: Image = _service_page.render(
+		"", "", YES_NO_OPTIONS, cursor_index, "",
+		Gen2MenuBox.from_coords(
+			YES_NO_AT.x, YES_NO_AT.y,
+			YES_NO_AT.x + YES_NO_SPAN.x, YES_NO_AT.y + YES_NO_SPAN.y, SUBMENU_FLAGS
+		)
+	)
+	if box != null:
+		image.blend_rect(box, Rect2i(Vector2i.ZERO, box.get_size()), Vector2i.ZERO)
+
+
 func _pack_overlay(text: String, draw_page: Callable) -> Image:
 	if _pack_page == null:
 		_pack_page = Gen2PackPage.from_data(_data)
@@ -1063,6 +1158,11 @@ func _pack_overlay(text: String, draw_page: Callable) -> Image:
 ## `YesNoBox` over one of the pack's printed questions, which is what every one
 ## of its confirmations is.
 func _pack_yes_no(text: String, cursor_index: int) -> Image:
+	if _gen1_pack():
+		var image: Image = _gen1_pack_image()
+		if image != null:
+			_blend_gen1_yes_no(image, cursor_index)
+		return image
 	return _pack_overlay(_last_page(text), func(map: PackedInt32Array) -> void:
 		_pack_page.draw_menu(
 			map,
@@ -1109,6 +1209,10 @@ func _pack_result_text() -> String:
 
 
 func _pack_description() -> String:
+	## Generation 1 prints under no list: `DisplayListMenuID` has no description
+	## box and `HandleItemListSwapping` marks its held row with `\u25b7` alone.
+	if _gen1_pack():
+		return ""
 	## `.select` prints `AskItemMoveText` over the description and nothing
 	## reprints one until the item is placed.
 	if _pack_switch >= 0:
@@ -1135,6 +1239,13 @@ func _selected_item() -> Dictionary:
 func _open_item_mode() -> void:
 	var item: Dictionary = _selected_item()
 	if item.is_empty():
+		return
+	## `StartMenu_Item`'s `cp BICYCLE / jp z, .useOrTossItem`: the one row that
+	## opens no submenu, because getting on and off is the only thing it does.
+	if _gen1_pack() and int(item.get("item", 0)) == Gen1Layout.ITEM_BICYCLE:
+		_teaching = false
+		_giving = false
+		_confirm_use()
 		return
 	_mode = Mode.PACK_ITEM
 	## Both are answers the party list ahead is still waiting to give. Leaving
@@ -1332,6 +1443,9 @@ func _confirm_use() -> void:
 	if item.is_empty():
 		return
 	var number: int = int(item.get("item", 0))
+	if _gen1_pack():
+		_confirm_gen1_use(number)
+		return
 	## The TM/HM pocket never reaches `UseItem`'s jumptable: engine/items/pack.asm
 	## gives it its own USE, which runs AskTeachTMHM first.
 	if Gen2WorldPack.pocket_for(_data, number) == Gen2WorldPack.TYPE_TM_HM:
@@ -1363,6 +1477,16 @@ func _confirm_use() -> void:
 			_use_field_item(number)
 		_:
 			_show_pack_result(_pack_text(TEXT_OAK), false)
+
+
+## `UseItem`'s jumptable on Generation 1. Neither `DisplayPartyMenu` nor the
+## `ItemUse*` routine behind it is built, so `.Party` and `.Current` answer
+## `ItemUseNotTime` the way a `.Field` row with no effect does.
+func _confirm_gen1_use(item: int) -> void:
+	if Gen2WorldPack.field_use_kind(_data, item) == Gen2WorldPack.ITEMMENU_CLOSE:
+		_use_field_item(item)
+		return
+	_show_pack_result(_pack_text(TEXT_OAK), false)
 
 
 ## `.Field`: `DoItemEffect` and then `wItemEffectSucceeded`. The effects that run
@@ -1403,7 +1527,7 @@ func _resolve_field_item(item: int) -> Dictionary:
 				_world.inventory.change_item_quantity(item, -1)
 			request["warp"] = escaped
 		Gen2WorldPack.FIELD_EFFECT_ROD:
-			var rod: StringName = Gen2WorldInventory.rod_for_item(item)
+			var rod: StringName = Gen2WorldInventory.rod_for_item(item, _data.generation)
 			if not bool(_world.fishing_check(rod).get("ok", false)):
 				return {"ok": false}
 			request["rod"] = rod
@@ -1869,8 +1993,17 @@ func _open_toss_quantity() -> void:
 	var item: Dictionary = _selected_item()
 	if item.is_empty():
 		return
+	var number: int = int(item.get("item", 0))
+	## `USE_TOSS_MENU_TEMPLATE` is one box for every item, so `TossItem_` refuses
+	## a key item and an HM after the row is chosen and past `.skipAskingQuantity`.
+	if not Gen2WorldPack.can_toss(_data, number):
+		_show_pack_result(_pack_text(TEXT_TOO_IMPORTANT), false)
+		return
 	_mode = Mode.PACK_TOSS_QUANTITY
-	_toss_prompt = Gen2WorldQuantityPrompt.open(int(item.get("quantity", 1)))
+	_toss_prompt = Gen2WorldQuantityPrompt.open(
+		int(item.get("quantity", 1)),
+		_data.generation if _data != null else RomRegistry.GEN2
+	)
 	_render_toss_quantity()
 
 
@@ -1995,6 +2128,10 @@ func _coins() -> int:
 ## own line breaks are kept: these boxes are the hardware's now, and a break is
 ## where the cartridge ended the row.
 func _pack_text(key: String) -> String:
+	if _gen1_pack():
+		var run: Array = GEN1_PACK_TEXTS.get(key, [])
+		return "" if run.is_empty() \
+			else _data.special_text(String(run[0]), String(run[1]))
 	var text: String = _data.menu_text(key) if _data != null else ""
 	if text.is_empty():
 		text = String(TEXT_FALLBACKS.get(key, ""))
@@ -2306,10 +2443,13 @@ func box_text() -> String:
 		Mode.PACK_STOP_LEARNING:
 			return Gen2MoveForget.stop_text(_forget_move_name)
 		Mode.PACK_TOSS_CONFIRM:
+			## `IsItOKToTossItemText` names the item and no count, where
+			## `AskQuantityThrowAwayText` prints both.
 			return _fill_item_text(
 				_pack_text(TEXT_TOSS_ASK_QUANTITY),
 				String(_selected_item().get("name", "")),
-				_toss_prompt.value if _toss_prompt != null else 1
+				-1 if _gen1_pack() \
+					else (_toss_prompt.value if _toss_prompt != null else 1)
 			)
 		Mode.PACK_GIVE_SWAP:
 			return _swap_question
@@ -2358,7 +2498,8 @@ func _hardware_image() -> Image:
 		Mode.PACK_FORGET, Mode.PACK_PP_MOVE:
 			return _move_list_image()
 		Mode.PACK_RESULT:
-			return _pack_overlay(box_text(), Callable())
+			return _gen1_pack_image() if _gen1_pack() \
+				else _pack_overlay(box_text(), Callable())
 		Mode.PACK_TARGET:
 			return _target_image()
 		Mode.FIELD_MOVES:
@@ -2384,12 +2525,16 @@ func _item_menu_image() -> Image:
 	var labels: Array = []
 	for entry: Dictionary in _item_actions:
 		labels.append(String(entry.get("label", "")))
+	if _gen1_pack():
+		return _gen1_pack_image(labels)
 	return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
 		_pack_page.draw_menu(map, _item_menu_box(labels.size()), labels, _item_cursor)
 	)
 
 
 func _toss_quantity_image() -> Image:
+	if _gen1_pack():
+		return _gen1_pack_image([], _toss_prompt.value if _toss_prompt != null else 1)
 	return _pack_overlay(box_text(), func(map: PackedInt32Array) -> void:
 		_pack_page.draw_quantity(
 			map,

--- a/game/world/world_inventory.gd
+++ b/game/world/world_inventory.gd
@@ -8,6 +8,13 @@ extends RefCounted
 const ITEM_OLD_ROD: int = 0x3A
 const ITEM_GOOD_ROD: int = 0x3B
 const ITEM_SUPER_ROD: int = 0x3D
+## The same three rods in `item_constants.asm`'s Generation 1 numbering, which
+## shares no number with the run above: $3A is a Dire Hit there.
+const GEN1_RODS: Dictionary = {
+	Gen2WorldEncounter.METHOD_OLD_ROD: Gen1Layout.ITEM_OLD_ROD,
+	Gen2WorldEncounter.METHOD_GOOD_ROD: Gen1Layout.ITEM_GOOD_ROD,
+	Gen2WorldEncounter.METHOD_SUPER_ROD: Gen1Layout.ITEM_SUPER_ROD,
+}
 const MAX_MONEY: int = 999999
 const MAX_COINS: int = 9999
 
@@ -20,7 +27,9 @@ func _init(game_data: GameData, world_state: Gen2WorldState) -> void:
 	state = world_state
 
 
-static func item_for_rod(rod: StringName) -> int:
+static func item_for_rod(rod: StringName, generation: int = RomRegistry.GEN2) -> int:
+	if generation == RomRegistry.GEN1:
+		return int(GEN1_RODS.get(rod, 0))
 	match rod:
 		Gen2WorldEncounter.METHOD_OLD_ROD:
 			return ITEM_OLD_ROD
@@ -31,7 +40,12 @@ static func item_for_rod(rod: StringName) -> int:
 	return 0
 
 
-static func rod_for_item(item: int) -> StringName:
+static func rod_for_item(item: int, generation: int = RomRegistry.GEN2) -> StringName:
+	if generation == RomRegistry.GEN1:
+		for rod: StringName in GEN1_RODS:
+			if int(GEN1_RODS[rod]) == item:
+				return rod
+		return &""
 	match item:
 		ITEM_OLD_ROD:
 			return Gen2WorldEncounter.METHOD_OLD_ROD
@@ -55,7 +69,7 @@ func owned_rods() -> Array[StringName]:
 
 
 func owns_rod(rod: StringName) -> bool:
-	var item: int = item_for_rod(rod)
+	var item: int = item_for_rod(rod, data.generation if data != null else RomRegistry.GEN2)
 	return item > 0 and item_quantity(item) > 0
 
 

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -78,6 +78,10 @@ const SUBMENU_USE_QUIT: Array[StringName] = [ACTION_USE, ACTION_QUIT]
 const SUBMENU_TMHM_USE_GIVE_QUIT: Array[StringName] = [
 	ACTION_USE, ACTION_GIVE, ACTION_QUIT,
 ]
+## `USE_TOSS_MENU_TEMPLATE`, the whole of Generation 1's item submenu: nothing
+## there is held, registered or given away, and `TossItem_` refuses a key item
+## once the row is chosen rather than by leaving TOSS off the box.
+const SUBMENU_USE_TOSS: Array[StringName] = [ACTION_USE, ACTION_TOSS]
 
 const ACTION_LABELS: Dictionary = {
 	ACTION_USE: "USE",
@@ -96,7 +100,7 @@ static func build(data: GameData, state: Gen2WorldState) -> Array:
 	if data == null or state == null:
 		return pockets
 	var owned: Dictionary = state.items()
-	for pocket_type: int in pocket_order():
+	for pocket_type: int in pocket_order(data):
 		var pocket_items: Array = []
 		## The order the map holds, which is the order the items were received:
 		## a cartridge pocket is a packed array `ReceiveItem` appends to, and
@@ -126,9 +130,12 @@ static func build(data: GameData, state: Gen2WorldState) -> Array:
 
 ## The source pocket cycle followed by whatever a mod registered, so a mod pocket
 ## is reached by continuing right past TMs/HMs rather than displacing a
-## cartridge one.
-static func pocket_order() -> Array[int]:
+## cartridge one. Generation 1's bag is one `DisplayListMenuID` list with no
+## pockets at all, so it cycles through nothing.
+static func pocket_order(data: GameData = null) -> Array[int]:
 	var order: Array[int] = POCKET_ORDER.duplicate()
+	if data != null and data.generation == RomRegistry.GEN1:
+		order = [TYPE_ITEM] as Array[int]
 	for entry: Dictionary in Gen2ModHost.instance().menu_entries(Gen2ModHost.MENU_PACK_POCKET):
 		var pocket: int = int(entry.get("pocket", 0))
 		if pocket > 0 and not order.has(pocket):
@@ -152,17 +159,19 @@ static func source_pocket_name(data: GameData, item: int) -> String:
 ## rather than the item's name. [param cancel] is the row that closes the pack.
 static func list_rows(
 	data: GameData, pocket_type: int, items: Array, scroll: int = 0,
-	cancel: bool = true
+	cancel: bool = true, height: int = Gen2PackPage.LIST_HEIGHT
 ) -> Array:
 	var tmhm: bool = pocket_type == TYPE_TM_HM
+	var generation: int = data.generation if data != null else RomRegistry.GEN2
 	var out: Array = []
-	for offset: int in Gen2PackPage.LIST_HEIGHT:
+	for offset: int in height:
 		var index: int = scroll + offset
 		if index > items.size():
 			break
 		if index == items.size():
 			if cancel:
-				out.append({"kind": Gen2PackPage.ROW_CANCEL})
+				## `cancel` is the terminator both pages read.
+				out.append({"kind": Gen2PackPage.ROW_CANCEL, "cancel": true})
 			break
 		var entry: Dictionary = items[index]
 		var item: int = int(entry.get("item", 0))
@@ -175,10 +184,8 @@ static func list_rows(
 			"show_quantity": can_toss(data, item),
 		}
 		if tmhm:
-			var number: int = Gen2Layout.tmhm_number_for_item(
-				item, data.tmhm_moves().size() if data != null else 0
-			)
-			var hm: bool = Gen2WorldTMHM.is_hm(item)
+			var number: int = Gen2WorldTMHM.number_for_item(data, item)
+			var hm: bool = Gen2WorldTMHM.is_hm(item, generation)
 			row["kind"] = Gen2PackPage.ROW_TM
 			row["hm"] = hm
 			row["number"] = number - Gen2Layout.TMHM_TM_COUNT if hm else number
@@ -194,7 +201,7 @@ static func list_rows(
 static func row_description(data: GameData, item: int) -> String:
 	if data == null or item <= 0:
 		return ""
-	if Gen2WorldTMHM.is_tm_hm(item):
+	if Gen2WorldTMHM.is_tm_hm(item, data.generation):
 		return String(data.move(Gen2WorldTMHM.move_for_item(data, item)).get("description", ""))
 	return String(data.item(item).get("description", ""))
 
@@ -288,6 +295,8 @@ static func item_submenu(data: GameData, item: int) -> Array:
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
 		return []
+	if data.generation == RomRegistry.GEN1:
+		return _submenu_entries(SUBMENU_USE_TOSS)
 	var tossable: bool = can_toss(data, item)
 	var selectable: bool = can_select(data, item)
 	# CheckItemMenu tests the nibble against zero, not against ITEMMENU_CURRENT,
@@ -303,6 +312,10 @@ static func item_submenu(data: GameData, item: int) -> Array:
 		actions = SUBMENU_USE_GIVE_TOSS_QUIT if can_use else SUBMENU_GIVE_TOSS_QUIT
 	else:
 		actions = SUBMENU_USE_GIVE_TOSS_SELECT_QUIT if can_use else SUBMENU_GIVE_TOSS_SELECT_QUIT
+	return _submenu_entries(actions)
+
+
+static func _submenu_entries(actions: Array[StringName]) -> Array:
 	var entries: Array = []
 	for action: StringName in actions:
 		entries.append({"action": action, "label": String(ACTION_LABELS.get(action, ""))})
@@ -336,6 +349,10 @@ static func can_select(data: GameData, item: int) -> bool:
 ## item pocket and then whatever `CheckTossableItem` refuses, which is the same
 ## pair of tests that decides GIVE is in the submenu at all.
 static func can_hold(data: GameData, item: int) -> bool:
+	## Generation 1 has no held items: `GiveTakePartyMonItem` and the byte it
+	## would write both arrive with Generation 2.
+	if data == null or data.generation == RomRegistry.GEN1:
+		return false
 	if not can_toss(data, item):
 		return false
 	return pocket_for(data, item) != TYPE_KEY_ITEM
@@ -397,6 +414,17 @@ const FIELD_EFFECTS: Dictionary = {
 	ITEM_SACRED_ASH: FIELD_EFFECT_SACRED_ASH,
 	ITEM_SQUIRTBOTTLE: FIELD_EFFECT_SQUIRTBOTTLE,
 }
+## `StartMenu_Item`'s `.useItem_closeMenu` rows in Generation 1's numbering: the
+## Bicycle and `UsableItems_CloseMenu`. The Poke Flute is the one of those with
+## no effect built here, so it lands on `ItemUseNotTime` like any other.
+const GEN1_FIELD_EFFECTS: Dictionary = {
+	Gen1Layout.ITEM_BICYCLE: FIELD_EFFECT_BICYCLE,
+	Gen1Layout.ITEM_ESCAPE_ROPE: FIELD_EFFECT_ESCAPE_ROPE,
+	Gen1Layout.ITEM_ITEMFINDER: FIELD_EFFECT_ITEMFINDER,
+	Gen1Layout.ITEM_OLD_ROD: FIELD_EFFECT_ROD,
+	Gen1Layout.ITEM_GOOD_ROD: FIELD_EFFECT_ROD,
+	Gen1Layout.ITEM_SUPER_ROD: FIELD_EFFECT_ROD,
+}
 
 
 ## The bag rows `BattlePack` can offer, in the pack's own pocket order: every
@@ -421,6 +449,8 @@ static func battle_items(data: GameData, state: Gen2WorldState) -> Array[int]:
 static func field_effect(data: GameData, item: int) -> StringName:
 	if field_use_kind(data, item) != ITEMMENU_CLOSE:
 		return FIELD_EFFECT_NONE
+	if data.generation == RomRegistry.GEN1:
+		return GEN1_FIELD_EFFECTS.get(item, FIELD_EFFECT_NONE)
 	return FIELD_EFFECTS.get(item, FIELD_EFFECT_NONE)
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -720,7 +720,7 @@ static func teach_tm_hm(
 	var before: Gen2WorldSnapshot = world.snapshot()
 	## `IsHM` returns before both the happiness change and `ConsumeTM`, so an HM
 	## costs nothing and moves nothing; a TM does both, in that order.
-	var consumed: bool = not Gen2WorldTMHM.is_hm(item)
+	var consumed: bool = not Gen2WorldTMHM.is_hm(item, world.data.generation)
 	var happiness: int = learner.happiness
 	if consumed:
 		learner.happiness = change_happiness(

--- a/game/world/world_quantity_prompt.gd
+++ b/game/world/world_quantity_prompt.gd
@@ -20,12 +20,18 @@ const CANCELLED: StringName = &"cancelled"
 var maximum: int = 1
 ## `wItemQuantityChange`, which every caller opens on 1.
 var value: int = 1
+## `DisplayChooseQuantityMenu`'s `.waitForKeyPressLoop` reads A, B, UP and DOWN
+## and nothing else, so Generation 1's dial has no ten-step on left and right.
+var page_steps: bool = true
 
 
-static func open(available: int) -> Gen2WorldQuantityPrompt:
+static func open(
+	available: int, generation: int = RomRegistry.GEN2
+) -> Gen2WorldQuantityPrompt:
 	var prompt := Gen2WorldQuantityPrompt.new()
 	prompt.maximum = maxi(1, available)
 	prompt.value = 1
+	prompt.page_steps = generation != RomRegistry.GEN1
 	return prompt
 
 
@@ -49,9 +55,11 @@ func press(button: int) -> StringName:
 		PokeButton.DOWN:
 			_step_down()
 		PokeButton.LEFT:
-			_page_down()
+			if page_steps:
+				_page_down()
 		PokeButton.RIGHT:
-			_page_up()
+			if page_steps:
+				_page_up()
 	return PENDING
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -519,10 +519,15 @@ func _build_world() -> void:
 			_data, map_group, map_number, start_cell, saveless_state, save_rules
 		)
 	else:
+		## Both by the running cartridge's own numbering: Crystal's Old Rod and
+		## Poke Ball are a Dire Hit and a Town Map on Generation 1.
+		var generation: int = _data.generation
 		var development_state := Gen2WorldState.new(
 			{}, {}, {
-				Gen2WorldInventory.ITEM_OLD_ROD: 1,
-				Gen2WorldPartyHost.ITEM_POKE_BALL: 1,
+				Gen2WorldInventory.item_for_rod(
+					Gen2WorldEncounter.METHOD_OLD_ROD, generation
+				): 1,
+				Gen2WorldPartyHost.capture_ball_items(generation)[0]: 1,
 			}
 		)
 		## `InitDecorations` runs at new game, so a world the screen builds
@@ -3724,6 +3729,21 @@ func preview_pack_use() -> void:
 	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PACK):
 		return
 	_start_menu_host.handle_button(PokeButton.A)
+
+
+## Public screenshot driver for the bag itself, which no map cell opens: the
+## rows are granted on an injected save so nothing persists, and the caller names
+## them because the two generations share no item number.
+func preview_pack(rows: Dictionary) -> void:
+	if _world == null or _data == null or _start_menu_host != null:
+		return
+	_injected_save = _embedded_party_save()
+	_world.state.apply_changes({}, {}, {"items": rows})
+	_open_start_menu()
+	if _start_menu_host == null:
+		return
+	if _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PACK):
+		_start_menu_host.handle_button(PokeButton.A)
 
 
 ## Public screenshot driver for a field evolution, which is the pack's USE on a

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -78,6 +78,23 @@ const SOURCE_ENTRIES: Array[Dictionary] = [
 	{"kind": ITEM_LAUNCHER, "label": "HOME", "available": true, "gate": GATE_NO_CONTEST},
 ]
 
+## `DrawStartMenu` (engine/menus/draw_start_menu.asm), which prints its labels
+## as literal characters rather than through the `#` and `<POKE>` markers
+## Generation 2's charmap holds. Its list has no Pokegear and no contest, and
+## `StartMenu_Pokemon` is drawn whatever `wPartyCount` says: the row itself
+## returns on an empty party. `EVENT_GOT_POKEDEX` is the only gate, read here
+## off the same engine flag [Gen2WorldAPI] holds it in.
+const GEN1_ENTRIES: Array[Dictionary] = [
+	{"kind": ITEM_POKEDEX, "label": "POKéDEX", "available": true, "gate": GATE_POKEDEX},
+	{"kind": ITEM_POKEMON, "label": "POKéMON", "available": true, "gate": &""},
+	{"kind": ITEM_PACK, "label": "ITEM", "available": true, "gate": &""},
+	{"kind": ITEM_PLAYER, "label": "<PLAYER>", "available": true, "gate": &""},
+	{"kind": ITEM_SAVE, "label": "SAVE", "available": true, "gate": &""},
+	{"kind": ITEM_OPTION, "label": "OPTION", "available": true, "gate": &""},
+	{"kind": ITEM_EXIT, "label": "EXIT", "available": true, "gate": &""},
+	{"kind": ITEM_LAUNCHER, "label": "HOME", "available": true, "gate": &""},
+]
+
 ## `.Items`' third column, the one MENU ACCOUNT draws under the list
 ## (`.MenuDesc`), as imported. A mod's entry has none, which is what the empty
 ## answer means, and so does a cache imported before the run was.
@@ -101,6 +118,7 @@ static func build(
 	player_name: String = "",
 	field_moves: bool = false,
 	bug_contest: bool = false,
+	generation: int = RomRegistry.GEN2,
 ) -> Gen2WorldStartMenu:
 	var menu := Gen2WorldStartMenu.new()
 	var passes: Dictionary = {
@@ -110,7 +128,9 @@ static func build(
 		GATE_NO_CONTEST: not bug_contest,
 	}
 	var rows: Array = []
-	for entry: Dictionary in SOURCE_ENTRIES:
+	for entry: Dictionary in (
+		GEN1_ENTRIES if generation == RomRegistry.GEN1 else SOURCE_ENTRIES
+	):
 		var gate: StringName = StringName(entry.get("gate", &""))
 		if not String(gate).is_empty() and not bool(passes.get(gate, false)):
 			continue
@@ -162,6 +182,7 @@ static func from_world(world: Gen2WorldAPI, previous_cursor: int = 0) -> Gen2Wor
 		world.player_name(),
 		not world.item_field_move_offers().is_empty(),
 		world.bug_contest_active(),
+		world.data.generation if world.data != null else RomRegistry.GEN2,
 	)
 	menu.load_descriptions(world.data)
 	return menu

--- a/game/world/world_tmhm.gd
+++ b/game/world/world_tmhm.gd
@@ -25,23 +25,36 @@ const TMHM_FLAG_BYTES: int = Gen2Layout.TMHM_BYTES
 
 
 ## AskTeachTMHM's first test, `cp TM01` before anything else: an item below TM01
-## is not a TM or HM and the prompt never appears.
-static func is_tm_hm(item: int) -> bool:
+## is not a TM or HM and the prompt never appears. Generation 1 numbers the two
+## runs the other way up, five HMs at $C4 with the fifty TMs above them, so the
+## comparison is its own.
+static func is_tm_hm(item: int, generation: int = RomRegistry.GEN2) -> bool:
+	if generation == RomRegistry.GEN1:
+		return Gen1Layout.machine_number(item) > 0
 	return item >= ITEM_TM01 and item <= ITEM_BYTE_MAX
 
 
 ## IsHM, which TeachTMHM asks before ConsumeTM: an HM is never used up.
-static func is_hm(item: int) -> bool:
+static func is_hm(item: int, generation: int = RomRegistry.GEN2) -> bool:
+	if generation == RomRegistry.GEN1:
+		return Gen1Layout.is_hm_item(item)
 	return item >= ITEM_HM01 and item <= ITEM_BYTE_MAX
+
+
+## GetTMHMNumber: the one-based `TMHMMoves` row [param item] names, or 0. The one
+## place either generation's numbering is turned into a row.
+static func number_for_item(data: GameData, item: int) -> int:
+	if data == null:
+		return 0
+	if data.generation == RomRegistry.GEN1:
+		return Gen1Layout.machine_number(item)
+	return Gen2Layout.tmhm_number_for_item(item, data.tmhm_moves().size())
 
 
 ## GetTMHMItemMove: the move [param item] teaches, or 0 when it is not a TM/HM
 ## this cartridge carries.
 static func move_for_item(data: GameData, item: int) -> int:
-	if data == null or not is_tm_hm(item):
-		return 0
-	var number: int = Gen2Layout.tmhm_number_for_item(item, data.tmhm_moves().size())
-	return data.tmhm_move(number)
+	return data.tmhm_move(number_for_item(data, item)) if data != null else 0
 
 
 ## CanLearnTMHMMove: the species' own flag bit for the TM/HM that teaches
@@ -87,13 +100,14 @@ static func teach_prompt(data: GameData, item: int) -> Dictionary:
 	if move <= 0:
 		return {"ok": false, "reason": &"not_a_tm_hm", "item": item}
 	var move_name: String = String(data.move(move).get("name", "MOVE"))
-	var booted: String = "Booted up an HM." if is_hm(item) else "Booted up a TM."
+	var hm: bool = is_hm(item, data.generation)
+	var booted: String = "Booted up an HM." if hm else "Booted up a TM."
 	return {
 		"ok": true,
 		"item": item,
 		"move": move,
 		"move_name": move_name,
-		"hm": is_hm(item),
+		"hm": hm,
 		"text": "%s It contained %s. Teach %s to a #MON?" % [booted, move_name, move_name],
 	}
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -2305,3 +2305,150 @@ func _pocket_items(host: Gen2StartMenuScreen) -> Array:
 	for row: Dictionary in host.call("_current_pocket_items"):
 		out.append(int(row.get("item", 0)))
 	return out
+
+
+## Generation 1's own bag: `pokered`'s item numbers for the Bicycle and the Old
+## Rod, and the two `special_text` runs `TossItem_` and `ItemUseFailed` print
+## from, whose `text_ram` slot the item name fills.
+const GEN1_BICYCLE: int = Gen1Layout.ITEM_BICYCLE
+const GEN1_OLD_ROD: int = Gen1Layout.ITEM_OLD_ROD
+const GEN1_POTION: int = 0x14
+const GEN1_TOSS_TEXT: Dictionary = {
+	"threw_away": "Threw away\n<RAM_D036>.",
+	"ok_to_toss": "Is it OK to toss\n<RAM_CF4B>?",
+	"too_important": "That's too impor-\ntant to toss!",
+}
+const GEN1_ITEM_USE_TEXT: Dictionary = {
+	"not_time": "OAK: <PLAYER>!\nThis isn't the\ntime to use that!",
+}
+
+
+## The fixture's items in Generation 1 shape: one bag pocket, nothing
+## registerable, `KeyItemFlags` on the Bicycle and the Old Rod, and
+## `UsableItems_CloseMenu` on the rod.
+func _open_gen1_world() -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		var number: int = int(raw.get("number", 0))
+		raw["pocket"] = Gen1Layout.BAG_POCKET
+		raw["permissions"] = Gen2WorldPack.CANT_SELECT
+		raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
+		match number:
+			GEN1_POTION:
+				raw["name"] = "POTION"
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
+			GEN1_BICYCLE:
+				raw["name"] = "BICYCLE"
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT | Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+			GEN1_OLD_ROD:
+				raw["name"] = "OLD ROD"
+				raw["permissions"] = Gen2WorldPack.CANT_SELECT | Gen2WorldPack.CANT_TOSS
+				raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	var manifest: Dictionary = RomCache.read_manifest(Fixture.directory())
+	manifest["special_text"] = {
+		"toss": GEN1_TOSS_TEXT, "item_use": GEN1_ITEM_USE_TEXT,
+	}
+	RomCache.write_json(RomCache.manifest_path(Fixture.directory()), manifest)
+	_data = GameData.open_directory(Fixture.directory())
+	_data.generation = RomRegistry.GEN1
+	await _open_world()
+	_world_screen._world.state.apply_changes({}, {}, {"items": {
+		GEN1_BICYCLE: 1, GEN1_POTION: 3, GEN1_OLD_ROD: 1,
+	}})
+
+
+func _gen1_pack() -> Gen2StartMenuScreen:
+	_world_screen._open_start_menu()
+	await get_tree().process_frame
+	var host: Gen2StartMenuScreen = _world_screen._start_menu_host
+	_select(host, Gen2WorldStartMenu.ITEM_PACK)
+	host.handle_button(PokeButton.A)
+	await get_tree().process_frame
+	return host
+
+
+## `StartMenu_Item` opens one list, and `USE_TOSS_MENU_TEMPLATE` is the only
+## submenu behind a row of it.
+func test_a_generation_1_bag_lists_one_pocket_and_offers_use_and_toss() -> void:
+	await _open_gen1_world()
+	var host: Gen2StartMenuScreen = await _gen1_pack()
+	assert_eq((host.get("_pack_pockets") as Array).size(), 1)
+	var rows: Array = host.call("_current_pocket_items")
+	assert_eq(rows.size(), 4)
+	host.handle_button(PokeButton.A)
+	var actions: Array = []
+	for entry: Dictionary in host.get("_item_actions"):
+		actions.append(StringName(entry.get("action", &"")))
+	assert_eq(actions, [Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_TOSS])
+	## Left and right cycle nothing: `DisplayListMenuID` watches both and answers
+	## neither.
+	host.handle_button(PokeButton.B)
+	host.handle_button(PokeButton.RIGHT)
+	assert_eq(int(host.get("_pack_pocket_index")), 0)
+
+
+## `TossItem_` refuses a key item and an HM once the row is chosen, because the
+## submenu box is the same one for every item.
+func test_a_generation_1_key_item_is_refused_at_the_toss() -> void:
+	await _open_gen1_world()
+	var host: Gen2StartMenuScreen = await _gen1_pack()
+	assert_true(bool(host.call("_select_pack_item", GEN1_OLD_ROD)))
+	_choose_action(host, Gen2WorldPack.ACTION_TOSS)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(
+		String(host.get("_pack_result")), String(GEN1_TOSS_TEXT["too_important"])
+	)
+	assert_eq(_world_screen._world.state.item_quantity(GEN1_OLD_ROD), 1)
+
+
+## `cp BICYCLE / jp z, .useOrTossItem`: the one row that opens no submenu, so a
+## single A is its whole USE.
+func test_the_generation_1_bicycle_opens_no_submenu() -> void:
+	await _open_gen1_world()
+	var host: Gen2StartMenuScreen = await _gen1_pack()
+	assert_true(bool(host.call("_select_pack_item", GEN1_BICYCLE)))
+	host.handle_button(PokeButton.A)
+	await get_tree().process_frame
+	assert_ne(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
+
+
+## `.useItem_partyMenu` opens `DisplayPartyMenu`, which this port has no
+## Generation 1 screen for, so a USE that would reach it says `ItemUseNotTime`
+## rather than opening Generation 2's party list over a Generation 1 map.
+func test_a_generation_1_use_that_reaches_no_effect_says_oaks_line() -> void:
+	await _open_gen1_world()
+	var host: Gen2StartMenuScreen = await _gen1_pack()
+	assert_true(bool(host.call("_select_pack_item", GEN1_POTION)))
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
+	assert_eq(
+		String(host.get("_pack_result")), String(GEN1_ITEM_USE_TEXT["not_time"])
+	)
+
+
+## `DisplayChooseQuantityMenu` opens over no question, `IsItOKToTossItemText`
+## names the item and no count, and `ThrewAwayItemText` follows the removal.
+func test_a_generation_1_toss_asks_no_quantity_question_and_removes_the_row() -> void:
+	await _open_gen1_world()
+	var host: Gen2StartMenuScreen = await _gen1_pack()
+	assert_true(bool(host.call("_select_pack_item", GEN1_POTION)))
+	_choose_action(host, Gen2WorldPack.ACTION_TOSS)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TOSS_QUANTITY)
+	assert_eq(host.box_text(), "", "the dial opens over no words at all")
+	## `.waitForKeyPressLoop` reads UP, DOWN, A and B, so left does not page.
+	host.handle_button(PokeButton.LEFT)
+	host.handle_button(PokeButton.UP)
+	assert_eq(int(host.get("_toss_prompt").value), 2)
+	host.handle_button(PokeButton.A)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TOSS_CONFIRM)
+	assert_eq(host.box_text(), "Is it OK to toss\nPOTION?")
+	host.handle_button(PokeButton.A)
+	await get_tree().process_frame
+	assert_eq(String(host.get("_pack_result")), "Threw away\nPOTION.")
+	assert_eq(_world_screen._world.state.item_quantity(GEN1_POTION), 1)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 1066 lines of the 39572 here, and Generation 1 has added 819 more to the
+## are 1108 lines of the 39699 here, and Generation 1 has added 903 more to the
 ## shared battle, world, palette, text, save and renderer code, 150 of them the
 ## battle animation engine and 140 the transition, the split effect routines and
-## `BlkPacket_Battle`. Ten sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39572
+## `BlkPacket_Battle`. Eleven sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39699
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -6951,6 +6951,32 @@ func test_fishing_requires_the_matching_inventory_item() -> void:
 	)["ok"])
 
 
+## `ItemUsePtrTable`'s three rod rows are $4C to $4E, which are a Dire Hit, a
+## Guard Spec and a Max Repel in Crystal's numbering, so a bag read through the
+## wrong run reports a rod nobody owns.
+func test_a_generation_1_rod_is_the_item_its_own_cartridge_numbers() -> void:
+	assert_eq(
+		Gen2WorldInventory.item_for_rod(
+			Gen2WorldEncounter.METHOD_OLD_ROD, RomRegistry.GEN1
+		),
+		Gen1Layout.ITEM_OLD_ROD
+	)
+	assert_eq(
+		Gen2WorldInventory.rod_for_item(Gen1Layout.ITEM_SUPER_ROD, RomRegistry.GEN1),
+		Gen2WorldEncounter.METHOD_SUPER_ROD
+	)
+	assert_eq(
+		Gen2WorldInventory.rod_for_item(
+			Gen2WorldInventory.ITEM_OLD_ROD, RomRegistry.GEN1
+		),
+		&""
+	)
+	assert_eq(
+		Gen2WorldInventory.rod_for_item(Gen2WorldInventory.ITEM_OLD_ROD),
+		Gen2WorldEncounter.METHOD_OLD_ROD
+	)
+
+
 func test_inventory_adapter_changes_items_and_currency_atomically() -> void:
 	var world := _world(Vector2i(8, 6), Gen2WorldState.new())
 	assert_true(world.inventory.set_item_quantity(1, 2)["ok"])

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -462,3 +462,72 @@ func test_a_coin_game_names_the_first_thing_missing() -> void:
 		Gen2WorldPack.coin_game_refusal_line(50, 0), Gen2WorldPack.NO_COIN_CASE_TEXT
 	)
 	assert_eq(Gen2WorldPack.coin_game_refusal_line(1, 1), "")
+
+
+## `StartMenu_Item` opens `DisplayListMenuID` on `wNumBagItems` and nothing else,
+## so there is one pocket, its rows are USE and TOSS, and nothing is held.
+func test_a_generation_1_bag_is_one_pocket_with_a_use_toss_submenu() -> void:
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	data.generation = RomRegistry.GEN1
+	assert_eq(Gen2WorldPack.pocket_order(data), [Gen2WorldPack.TYPE_ITEM] as Array[int])
+	var state := Gen2WorldState.new({}, {}, {ITEM_POTION: 3})
+	var pockets: Array = Gen2WorldPack.build(data, state)
+	assert_eq(pockets.size(), 1)
+	assert_eq(((pockets[0]["items"] as Array)[0] as Dictionary)["item"], ITEM_POTION)
+	var actions: Array = []
+	for entry: Dictionary in Gen2WorldPack.item_submenu(data, ITEM_POTION):
+		actions.append(StringName(entry.get("action", &"")))
+	assert_eq(actions, [Gen2WorldPack.ACTION_USE, Gen2WorldPack.ACTION_TOSS])
+	assert_false(Gen2WorldPack.can_hold(data, ITEM_POTION))
+
+
+## `.useItem_closeMenu`'s rows carry Generation 1's own item numbers, which share
+## none of Crystal's: $06 is a Bicycle there and a Town Map here.
+func test_a_generation_1_field_effect_reads_its_own_item_numbers() -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		raw["pocket"] = Gen1Layout.BAG_POCKET
+		raw["permissions"] = Gen2WorldPack.CANT_SELECT
+		raw["field_menu"] = Gen2WorldPack.ITEMMENU_CURRENT
+		if int(raw.get("number", 0)) == Gen1Layout.ITEM_BICYCLE:
+			raw["field_menu"] = Gen2WorldPack.ITEMMENU_CLOSE
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	data.generation = RomRegistry.GEN1
+	assert_eq(
+		Gen2WorldPack.field_effect(data, Gen1Layout.ITEM_BICYCLE),
+		Gen2WorldPack.FIELD_EFFECT_BICYCLE
+	)
+	assert_eq(
+		Gen2WorldPack.field_effect(data, Gen2WorldPack.ITEM_BICYCLE),
+		Gen2WorldPack.FIELD_EFFECT_NONE
+	)
+
+
+## `PrintListMenuEntries` prints four names and `IsKeyItem` decides which of them
+## carry a count, where `ScrollingMenu_UpdateDisplay` writes five and asks
+## `_CheckTossableItem` for the same thing.
+func test_a_generation_1_listing_is_four_rows_and_hides_a_key_item_count() -> void:
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		raw["pocket"] = Gen1Layout.BAG_POCKET
+		raw["permissions"] = Gen2WorldPack.CANT_SELECT
+		if int(raw.get("number", 0)) == ITEM_BICYCLE:
+			raw["permissions"] = Gen2WorldPack.CANT_SELECT | Gen2WorldPack.CANT_TOSS
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	data.generation = RomRegistry.GEN1
+	var owned: Array = []
+	for item: int in range(1, 7):
+		owned.append({"item": item, "name": "ITEM%d" % item, "quantity": 2})
+	var rows: Array = Gen2WorldPack.list_rows(
+		data, Gen1Layout.BAG_POCKET, owned, 0, true, Gen2MartPage.GEN1_LIST_HEIGHT
+	)
+	assert_eq(rows.size(), Gen2MartPage.GEN1_LIST_HEIGHT)
+	assert_true(bool((rows[0] as Dictionary)["show_quantity"]))
+	assert_false(bool((rows[ITEM_BICYCLE - 1] as Dictionary)["show_quantity"]))
+	var tail: Array = Gen2WorldPack.list_rows(
+		data, Gen1Layout.BAG_POCKET, owned, 4, true, Gen2MartPage.GEN1_LIST_HEIGHT
+	)
+	assert_eq(tail.size(), 3)
+	assert_true(bool((tail[2] as Dictionary).get("cancel", false)))

--- a/tests/unit/test_world_start_menu.gd
+++ b/tests/unit/test_world_start_menu.gd
@@ -399,3 +399,25 @@ func test_a_registered_entry_can_be_absent_rather_than_refused() -> void:
 	assert_false(_kinds(Gen2WorldStartMenu.build(0, false, false)).has(&"pc"))
 	assert_true(_kinds(Gen2WorldStartMenu.build(1, false, false)).has(&"pc"))
 	Gen2ModHost.reset()
+
+
+## `DrawStartMenu`'s own list: no Pokegear, no contest, POKéMON drawn whatever
+## `wPartyCount` says, and only `EVENT_GOT_POKEDEX` gating anything.
+func test_the_generation_1_list_is_draw_start_menus_own() -> void:
+	var menu: Gen2WorldStartMenu = Gen2WorldStartMenu.build(
+		0, false, true, 0, "", false, false, RomRegistry.GEN1
+	)
+	assert_eq(_kinds(menu), [
+		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_PACK,
+		Gen2WorldStartMenu.ITEM_PLAYER, Gen2WorldStartMenu.ITEM_SAVE,
+		Gen2WorldStartMenu.ITEM_OPTION, Gen2WorldStartMenu.ITEM_EXIT,
+		Gen2WorldStartMenu.ITEM_LAUNCHER,
+	])
+	var with_dex: Gen2WorldStartMenu = Gen2WorldStartMenu.build(
+		0, true, false, 0, "", false, false, RomRegistry.GEN1
+	)
+	assert_eq(_kinds(with_dex)[0], Gen2WorldStartMenu.ITEM_POKEDEX)
+	## The labels are the literal characters `db "POKéDEX@"` holds, not the `#`
+	## and `<POKE>` markers Generation 2's charmap draws them with.
+	assert_eq(String((with_dex.items()[0] as Dictionary)["label"]), "POKéDEX")
+	assert_eq(String((with_dex.items()[2] as Dictionary)["label"]), "ITEM")

--- a/tests/unit/test_world_tmhm.gd
+++ b/tests/unit/test_world_tmhm.gd
@@ -213,3 +213,22 @@ func test_teach_prompt_names_the_move_and_distinguishes_a_tm_from_an_hm() -> voi
 	var ordinary: Dictionary = Gen2WorldTMHM.teach_prompt(data, 0x12)
 	assert_false(ordinary["ok"])
 	assert_eq(StringName(ordinary["reason"]), &"not_a_tm_hm")
+
+
+## `GetMachineName` and `GetMachinePrice` put HM01 at $C4 and TM01 at $C9 with no
+## dummy rows between them, and `TechnicalMachines` still lists the fifty TMs
+## first, so an item's own row is the inverse of Crystal's arrangement.
+func test_generation_1_numbers_the_two_runs_the_other_way_up() -> void:
+	var data: GameData = _data()
+	data.generation = RomRegistry.GEN1
+	for pair: Array in [[0xC4, 51], [0xC8, 55], [0xC9, 1], [0xFA, 50]]:
+		assert_eq(
+			Gen2WorldTMHM.number_for_item(data, int(pair[0])), int(pair[1]),
+			"item $%02x" % int(pair[0])
+		)
+	assert_eq(Gen2WorldTMHM.number_for_item(data, 0xC3), 0)
+	assert_eq(Gen2WorldTMHM.number_for_item(data, 0xFB), 0)
+	assert_true(Gen2WorldTMHM.is_hm(0xC8, RomRegistry.GEN1))
+	assert_false(Gen2WorldTMHM.is_hm(0xC9, RomRegistry.GEN1))
+	assert_true(Gen2WorldTMHM.is_tm_hm(0xFA, RomRegistry.GEN1))
+	assert_false(Gen2WorldTMHM.is_tm_hm(0xC3, RomRegistry.GEN1))

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -59,6 +59,29 @@ const PINNED_EFFECTS: Dictionary = {
 	92: [33, 0], 101: [87, 0], 149: [88, 1],
 }
 
+## What `StartMenu_Item`'s three tables come to over the whole 250-row table:
+## `KeyItemFlags`' own 31 rows with the five HMs behind `IsItemHM`, the Bicycle
+## and `UsableItems_CloseMenu` quitting the menu, and `UsableItems_PartyMenu`
+## with all 55 machines opening the party list. Identical on all three.
+const KEY_ITEM_COUNT: int = 36
+const FIELD_MENU_CENSUS: Dictionary = {
+	Gen2Layout.ITEMMENU_CLOSE: 7,
+	Gen2Layout.ITEMMENU_PARTY: 91,
+	Gen2Layout.ITEMMENU_CURRENT: 152,
+}
+## One row of each shape: the item, its field menu and whether `IsKeyItem` says
+## yes. The Town Map and the Poke Ball are both `call UseItem` rows, one of them
+## a key item and one not.
+const PINNED_ITEM_ATTRIBUTES: Dictionary = {
+	0x04: [Gen2Layout.ITEMMENU_CURRENT, false],
+	0x05: [Gen2Layout.ITEMMENU_CURRENT, true],
+	0x06: [Gen2Layout.ITEMMENU_CLOSE, true],
+	0x14: [Gen2Layout.ITEMMENU_PARTY, false],
+	0x4E: [Gen2Layout.ITEMMENU_CLOSE, true],
+	0xC4: [Gen2Layout.ITEMMENU_PARTY, true],
+	0xC9: [Gen2Layout.ITEMMENU_PARTY, false],
+}
+
 ## `TechnicalMachines`: TM01 through TM05, then the five HMs.
 const PINNED_TMS: Array[int] = [5, 13, 14, 18, 25]
 const PINNED_HMS: Array[int] = [15, 19, 57, 70, 148]
@@ -274,7 +297,36 @@ func _items() -> void:
 	_r.check(int(data.item(ITEM_TABLE_COUNT)["price"]) == 2000, "TM50 is not 2000")
 	_r.check(String(data.item(Gen1Layout.ITEM_COUNT + 1)["name"]).is_empty(),
 		"$54 has a name")
+	_item_attributes(data)
 	_r.note("%d named items in a table of %d" % [ITEM_COUNT, ITEM_TABLE_COUNT])
+
+
+## The three tables `StartMenu_Item` reads a row's own behaviour out of, swept
+## over the whole table: one bag pocket, nothing registered on SELECT, and a
+## field menu that is one of the three the ladder can answer.
+func _item_attributes(data: GameData) -> void:
+	var keys: int = 0
+	var census: Dictionary = {}
+	for number: int in range(1, ITEM_TABLE_COUNT + 1):
+		var item: Dictionary = data.item(number)
+		var menu: int = int(item["field_menu"])
+		census[menu] = int(census.get(menu, 0)) + 1
+		if not Gen2WorldPack.can_toss(data, number):
+			keys += 1
+		_r.check(int(item["pocket"]) == Gen1Layout.BAG_POCKET,
+			"item %d is in pocket %d" % [number, item["pocket"]])
+		_r.check(not Gen2WorldPack.can_select(data, number),
+			"item %d can be registered" % number)
+	_r.check(keys == KEY_ITEM_COUNT, "%d key items, expected %d" % [keys, KEY_ITEM_COUNT])
+	_r.check(census == FIELD_MENU_CENSUS, "field menus read %s" % str(census))
+	for number: int in PINNED_ITEM_ATTRIBUTES:
+		var pinned: Array = PINNED_ITEM_ATTRIBUTES[number]
+		_r.check(int(data.item(number)["field_menu"]) == int(pinned[0]),
+			"item %d has field menu %d" % [number, data.item(number)["field_menu"]])
+		_r.check(Gen2WorldPack.can_toss(data, number) != bool(pinned[1]),
+			"item %d is tossable %s" % [number, not bool(pinned[1])])
+	_r.check(Gen2WorldPack.pocket_order(data).size() == 1,
+		"the Generation 1 bag cycles through %d pockets" % Gen2WorldPack.pocket_order(data).size())
 
 
 func _tmhm() -> void:
@@ -294,6 +346,22 @@ func _tmhm() -> void:
 	_r.check(moves.slice(Gen1Layout.TM_COUNT) == PINNED_HMS, "the HMs read %s" % str(
 		moves.slice(Gen1Layout.TM_COUNT)
 	))
+	## `GetMachineName` counts the HMs above the TMs and the item run puts them
+	## below, so every machine must reach its own row through the seam and
+	## nothing else may reach one at all.
+	var reached: Dictionary = {}
+	for number: int in range(1, ITEM_TABLE_COUNT + 1):
+		var row: int = Gen2WorldTMHM.number_for_item(_r.data, number)
+		var machine: bool = number >= Gen1Layout.HM_FIRST_ITEM
+		_r.check(machine == (row > 0), "item %d answers machine row %d" % [number, row])
+		if row > 0:
+			_r.check(not reached.has(row), "two items answer machine row %d" % row)
+			reached[row] = true
+	_r.check(reached.size() == TMHM_COUNT,
+		"%d of %d machines are reached" % [reached.size(), TMHM_COUNT])
+	_r.check(Gen2WorldTMHM.is_hm(Gen1Layout.HM_FIRST_ITEM, RomRegistry.GEN1)
+		and not Gen2WorldTMHM.is_hm(Gen1Layout.TM_FIRST_ITEM, RomRegistry.GEN1),
+		"the HM run does not end at TM01")
 
 
 func _trainers() -> void:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -40,6 +40,7 @@ const KIND_HELP: Dictionary = {
 	&"whiteout": "presses, frames: Script_Whiteout. 0 the faint line, 1 the first page of _WhitedOutText, 3 the map woken on; a second number stops that many frames into .PlayPoisonSFX instead",
 	&"elevator": "DOWN presses: the floor list bg_event 3's elevator opens, read from the cell below the panel",
 	&"start_menu": "rows down, contest: SetUpMenuItems' list. A second number of 1 runs the Bug Catching Contest and 2 has something caught",
+	&"pack": "presses, rows down: the bag opened off the start menu, seeded with one row of each shape. The rows are walked after the first press, so 0 4 scrolls the list, 1 0 is USE/TOSS, 2 1 the TOSS dial and 4 1 the box it ends in",
 	&"mailbox": "rows down, A presses: the bedroom PC's MAILBOX",
 	&"magnet_train": "frames, direction: special MagnetTrain, that many frames in. Direction 1 rides to Goldenrod",
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
@@ -129,6 +130,27 @@ const FIELD_ITEMS: Dictionary = {
 	&"squirtbottle": Gen2WorldPack.ITEM_SQUIRTBOTTLE,
 	&"card_key": Gen2WorldPack.ITEM_CARD_KEY,
 	&"basement_key": Gen2WorldPack.ITEM_BASEMENT_KEY,
+}
+## The three of those Generation 1 ships, under its own numbering. A kind not
+## named here is Crystal's alone and is refused rather than granting whatever
+## item that number happens to be.
+const GEN1_FIELD_ITEMS: Dictionary = {
+	&"field_item": Gen1Layout.ITEM_ITEMFINDER,
+	&"bike": Gen1Layout.ITEM_BICYCLE,
+	&"coin_case": Gen1Layout.ITEM_COIN_CASE,
+}
+
+## One row of each shape the bag draws, by generation: a stack that shows its
+## count, two rows that show none, a machine, and enough rows that the list
+## scrolls past the four `PrintListMenuEntries` prints.
+const PACK_ROWS: Dictionary = {
+	RomRegistry.GEN1: {
+		0x14: 5, 0x0F: 2, 0x05: 1, 0x06: 1, 0x4C: 1, 0xC9: 1,
+	},
+	RomRegistry.GEN2: {
+		Gen2WorldPartyHost.ITEM_POTION: 5, Gen2WorldPartyHost.ITEM_REPEL: 2,
+		Gen2WorldPack.ITEM_BICYCLE: 1,
+	},
 }
 
 ## The three whose effect reads what the player is facing. Each is photographed
@@ -416,6 +438,7 @@ const STAGERS: Dictionary = {
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
+	&"pack": &"_stage_pack",
 	&"bills_pc": &"_stage_pc",
 	&"players_pc": &"_stage_pc",
 	&"mailbox": &"_stage_pc",
@@ -437,7 +460,7 @@ func _stage_kind() -> void:
 	if FIELD_ITEMS.has(_kind):
 		if _kind in FACE_UP_FIRST:
 			_screen.move_up()
-		_screen.preview_field_item(int(FIELD_ITEMS[_kind]))
+		_screen.preview_field_item(int(_field_item_number()))
 		return
 	if _screen.has_method(SCREEN_DRIVER % _kind):
 		## The screen's own `preview_*` drivers, by their name without the
@@ -1074,6 +1097,35 @@ func _stage_start_menu() -> void:
 ## `_BillsPC`, which no preview cell reaches: the first number is how many rows down
 ## the top menu to stand and the second how many A presses to spend from there, so `1
 ## 1` is the DEPOSIT list and `1 2` its submenu on the first party member.
+## `StartMenu_Item`'s own list, which no map cell reaches. The rows are walked
+## down after the first A press, so a first number of 0 scrolls the list itself
+## and anything above it walks the submenu that press opened.
+func _stage_pack() -> void:
+	_screen.preview_pack(PACK_ROWS.get(_generation(), {}))
+	if _cell.x >= 1:
+		_screen.press_button(PokeButton.A)
+		_screen.advance_frame()
+	for _down: int in maxi(_cell.y, 0):
+		_screen.press_button(PokeButton.DOWN)
+		_screen.advance_frame()
+	for _press: int in maxi(_cell.x - 1, 0):
+		_screen.press_button(PokeButton.A)
+		_screen.advance_frame()
+
+
+## The item a field kind grants on this cartridge, or 0 where Generation 1 has
+## no row for it at all.
+func _field_item_number() -> int:
+	if _generation() != RomRegistry.GEN1:
+		return int(FIELD_ITEMS[_kind])
+	return int(GEN1_FIELD_ITEMS.get(_kind, 0))
+
+
+func _generation() -> int:
+	var data: GameData = _screen.get("_data")
+	return data.generation if data != null else RomRegistry.GEN2
+
+
 func _stage_pc() -> void:
 	_screen.call(SCREEN_DRIVER % _kind)
 	for _down: int in maxi(_cell.x, 0):


### PR DESCRIPTION
`DrawStartMenu` has no Pokegear and no contest, draws POKéMON whatever `wPartyCount` says and gates only POKéDEX, and spells its labels as characters where Crystal's charmap has `#` and `<POKE>`, which had drawn ?DEX and ?POKE?… on a Generation 1 font.

`StartMenu_Item` is `DisplayListMenuID` over the map, the box `Gen2MartPage` already draws for the shop: four names two rows apart, `IsKeyItem` deciding which carries a × count, `HandleItemListSwapping`'s ▷ on a held row, and the ▼ `.printCancelMenuItem`'s own `jp` skips whenever the terminator is one of the four. `KeyItemFlags`, `UsableItems_PartyMenu` and `UsableItems_CloseMenu` are imported onto all 250 rows of the item table: 36 key items with the five HMs behind `IsItemHM`, 7 rows that quit the menu and 91 that open the party list. `USE_TOSS_MENU_TEMPLATE` is the submenu for every item, the Bicycle alone opens none, `TossItem_` refuses a key item once the row is chosen, and `DisplayChooseQuantityMenu`'s dial reads UP, DOWN, A and B over no question at all. `DisplayPartyMenu` has no screen here, so a USE that would reach it says `ItemUseNotTime`.

Three item numbers had been Crystal's on a Generation 1 map: `Gen2WorldInventory`'s three rods, `Gen2WorldPack.FIELD_EFFECTS` and the two rows a development world seeds, so Red's bag held a Dire Hit the world reported as an Old Rod. `Gen2WorldTMHM` is the same seam for the machines, which Generation 1 numbers the other way up: five HMs at $C4 under fifty TMs at $C9.

| Proof | Result |
|---|---|
| GUT, unit and scene tiers | 4414 tests, 0 failures |
| `tools/validate.gd -- all` | 92 topics, 0 failures |
| `gen1_tables` on Red, Blue and Yellow | 250 item rows swept: 36 key items, 7 CLOSE, 91 PARTY, 55 machine rows each reached once |
| `tools/import_rom.gd` | 6/6 imported, `layout: Layout verified.` on every cartridge |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | crystal, gold, silver clean |
| `preview_world.gd -- red 0 0 out.png live pack` | the list, USE/TOSS, the dial, the YES/NO and both result boxes |