### PR TITLE
Use an item on a Generation 1 Pokemon

### DIFF
--- a/game/battle/evolution.gd
+++ b/game/battle/evolution.gd
@@ -9,6 +9,15 @@ const HAPPINESS_TO_EVOLVE: int = 220
 const EVERSTONE: int = 70
 ## Item effects.asm dispatches every one of these through EvoStoneEffect.
 const STONE_ITEMS: Array[int] = [8, 0x16, 0x17, 0x18, 0x22, 0xA9]
+
+
+## The same rows on either cartridge. Generation 1 numbers its items the other
+## way up and shares only $22 with the run above, where it is a Water Stone and
+## a Sun Stone respectively.
+static func stone_items(data: GameData) -> Array[int]:
+	if data != null and data.generation == RomRegistry.GEN1:
+		return Gen1Layout.STONE_ITEMS
+	return STONE_ITEMS
 ## A trade evolution's parameter when it asks for no held item: `inc a / jr z`.
 const TRADE_NO_ITEM: int = 0xFF
 

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -323,7 +323,7 @@ func field_hm_items() -> Array[int]:
 		var item: int = Gen2Layout.item_for_tmhm_number(number + 1, count)
 		if not Gen2WorldTMHM.is_hm(item, _data.generation):
 			continue
-		if Gen2WorldFieldMove.is_field_move(_data.tmhm_move(number + 1)):
+		if Gen2WorldFieldMove.is_field_move(_data.tmhm_move(number + 1), _data):
 			out.append(item)
 	_field_hms = out
 	return out
@@ -347,7 +347,7 @@ func move_for_hm_item(item: int) -> int:
 	if _data == null or not Gen2WorldTMHM.is_hm(item, _data.generation):
 		return 0
 	var move: int = Gen2WorldTMHM.move_for_item(_data, item)
-	return move if Gen2WorldFieldMove.is_field_move(move) else 0
+	return move if Gen2WorldFieldMove.is_field_move(move, _data) else 0
 
 
 ## Every item some check in this catalog hands over, as a set. An item outside it

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -168,6 +168,8 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"prizes_2": ["prize_text_2", Gen1Layout.PRIZE_TEXT_2_AT],
 	"pick_up_item": ["found_item_text", Gen1Layout.PICK_UP_TEXT_AT],
 	"item_use": ["item_use_text", Gen1Layout.ITEM_USE_TEXT_AT],
+	"coin_case": ["coin_case_text", Gen1Layout.COIN_CASE_TEXT_AT],
+	"party_menu": ["party_menu_text", Gen1Layout.PARTY_MENU_TEXT_AT],
 	"toss": ["toss_text", Gen1Layout.TOSS_TEXT_AT],
 }
 
@@ -620,21 +622,22 @@ static func read_evos_moves(rom: RomFile, layout: Dictionary, index: int) -> Dic
 	return {"evolutions": evolutions, "learnset": learnset}
 
 
-## The evolved species is stored as an internal index and the cache speaks dex
-## numbers, so it is translated here rather than by every reader.
+## Written in [method GameData.evolutions]' own words, the evolved species
+## translated from its internal index. An `EVOLVE_ITEM` row carries a minimum
+## level between its item and its species and every shipped row sets it to 1; a
+## trade asks for no held item, so its parameter is the `$FF` `.trade` reads.
 static func _evolution_row(
 	rom: RomFile, layout: Dictionary, at: int, method: int, size: int
 ) -> Dictionary:
 	var target: int = rom.u8(at + size - 1)
-	var row: Dictionary = {"method": method, "species": Gen1Layout.dex_of_index(rom, layout, target)}
-	if method == Gen1Layout.EVOLVE_LEVEL:
-		row["level"] = rom.u8(at + 1)
-	elif method == Gen1Layout.EVOLVE_ITEM:
-		row["item"] = rom.u8(at + 1)
-		row["level"] = rom.u8(at + 2)
-	else:
-		row["level"] = rom.u8(at + 1)
-	return row
+	var parameter: int = rom.u8(at + 1)
+	if method == Gen1Layout.EVOLVE_TRADE:
+		parameter = Gen2Evolution.TRADE_NO_ITEM
+	return {
+		"method": method,
+		"parameter": parameter,
+		"target": Gen1Layout.dex_of_index(rom, layout, target),
+	}
 
 
 ## Reads the cartridge into its cache. Answers the same { ok, message, ... }
@@ -1083,14 +1086,21 @@ func _import_items(rom: RomFile, layout: Dictionary) -> Array:
 	## between the two runs are the ones no `item_constants.asm` row names.
 	var out: Array = []
 	for item: int in range(1, Gen1Layout.TM_FIRST_ITEM + Gen1Layout.TM_COUNT):
-		out.append({
+		var row: Dictionary = {
 			"number": item,
 			"name": _item_name(names, item),
 			"price": _item_price(rom, layout, item),
 			"pocket": Gen1Layout.BAG_POCKET,
 			"permissions": _item_permissions(rom, layout, item),
 			"field_menu": _item_field_menu(item, party_use, close_use),
-		})
+		}
+		## `ItemUseMedicine` branches on the item number rather than reading a
+		## table, so the two amounts are `Gen1Layout`'s and land the same way.
+		if Gen1Layout.ITEM_HEAL_AMOUNTS.has(item):
+			row["heal_amount"] = int(Gen1Layout.ITEM_HEAL_AMOUNTS[item])
+		if Gen1Layout.ITEM_STATUS_MASKS.has(item):
+			row["status_mask"] = int(Gen1Layout.ITEM_STATUS_MASKS[item])
+		out.append(row)
 	return out
 
 
@@ -1111,7 +1121,11 @@ static func _item_permissions(rom: RomFile, layout: Dictionary, item: int) -> in
 ## `StartMenu_Item`'s own ladder as the nibble [Gen2WorldPack] branches on: the
 ## Bicycle and `UsableItems_CloseMenu` quit the menu, an HM, a TM and
 ## `UsableItems_PartyMenu` open the party list, the rest leave the list standing.
+## A row `UseItem` refuses outside a battle answers before any of them, which is
+## what keeps the four X stats off the party list they are listed on.
 static func _item_field_menu(item: int, party_use: Dictionary, close_use: Dictionary) -> int:
+	if Gen1Layout.ITEM_BATTLE_ONLY.has(item):
+		return Gen2Layout.ITEMMENU_NOUSE
 	if item == Gen1Layout.ITEM_BICYCLE or close_use.has(item):
 		return Gen2Layout.ITEMMENU_CLOSE
 	if Gen1Layout.machine_number(item) > 0 or party_use.has(item):

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -100,6 +100,9 @@ const SUPER_PALETTE_COUNT_YELLOW: int = 40
 const PAL_ROUTE: int = 0x00
 const PAL_PALLET: int = 0x01
 const PAL_GRAYMON: int = 0x19
+## `PalPacket_PartyMenu`'s first row, which `BlkPacket_PartyMenu` gives the two
+## columns the party menu's icons stand in and nothing else.
+const PAL_MEWMON: int = 0x10
 const PAL_CAVE: int = 0x23
 ## The three rows `GetHealthBarColor` picks between, under the names
 ## [method GameData.bar_palette] takes them by. Generation 1 has no exp bar.
@@ -306,9 +309,62 @@ const ITEM_ESCAPE_ROPE: int = 0x1D
 ## `IsItemInBag COIN_CASE`, which `CeladonPrizeMenu` opens on.
 const ITEM_COIN_CASE: int = 0x45
 const ITEM_ITEMFINDER: int = 0x47
+const ITEM_TOWN_MAP: int = 0x05
+const ITEM_POKEDEX: int = 0x09
+const ITEM_MOON_STONE: int = 0x0A
+const ITEM_FULL_RESTORE: int = 0x10
+const ITEM_REVIVE: int = 0x35
+const ITEM_MAX_REVIVE: int = 0x36
+const ITEM_RARE_CANDY: int = 0x28
+const ITEM_OAKS_PARCEL: int = 0x46
+const ITEM_PP_UP: int = 0x4F
 const ITEM_OLD_ROD: int = 0x4C
 const ITEM_GOOD_ROD: int = 0x4D
 const ITEM_SUPER_ROD: int = 0x4E
+
+## `ItemUseEvoStone`'s five rows of `ItemUsePtrTable`. Crystal numbers its own
+## six differently, and [method Gen2Evolution.stone_items] is the one seam that
+## tells the two apart.
+const STONE_ITEMS: Array[int] = [ITEM_MOON_STONE, 0x20, 0x21, 0x22, 0x2F]
+
+## `.addHealAmount`'s ladder, with `.setCurrentHPToMaxHp`'s own `cp HYPER_POTION`
+## in front of it: FULL_RESTORE and MAX_POTION are set to the maximum whatever
+## the byte said, which is what a heal past [constant Gen2Stats.MAX_STAT_VALUE]
+## means to [method Gen2WorldPartyHost.use_item].
+const ITEM_HEAL_AMOUNTS: Dictionary = {
+	ITEM_FULL_RESTORE: 999, 0x11: 999, 0x12: 200, 0x13: 50, 0x14: 20,
+	0x3C: 50, 0x3D: 60, 0x3E: 80,
+}
+## `.cureStatusAilment`'s own five and the `$ff` its fall-through carries, which
+## FULL_HEAL takes and which `.doneHealingPartyHP` gives FULL_RESTORE too.
+const ITEM_STATUS_MASKS: Dictionary = {
+	0x0B: Gen2Status.POISON, 0x0C: Gen2Status.BURN, 0x0D: Gen2Status.FREEZE,
+	0x0E: Gen2Status.SLEEP_MASK, 0x0F: Gen2Status.PARALYSIS,
+	ITEM_FULL_RESTORE: Gen2Status.ANY, 0x34: Gen2Status.ANY,
+}
+## `.useVitamin`'s `sub HP_UP`, doubled onto `MON_HP_EXP`: the five stat
+## experience words in the party struct's own order.
+const ITEM_VITAMINS: Dictionary = {
+	0x23: "hp", 0x24: "attack", 0x25: "defense", 0x26: "speed", 0x27: "special",
+}
+## The `ItemUsePtrTable` rows that open on `ld a, [wIsInBattle]` and answer
+## `ItemUseNotTime` outside one. The four X stats are in `UsableItems_PartyMenu`
+## and still never open it: `.useItem_partyMenu` calls `UseItem` first and gets
+## `wActionResultOrTookBattleTurn` back as 2.
+const ITEM_BATTLE_ONLY: Array[int] = [
+	ITEM_MASTER_BALL, ITEM_ULTRA_BALL, ITEM_GREAT_BALL, ITEM_POKE_BALL,
+	ITEM_SAFARI_BALL, 0x15, 0x16, 0x2E, 0x33, 0x37, 0x3A,
+	0x41, 0x42, 0x43, 0x44,
+]
+
+## `ItemUseRepel`, `ItemUseSuperRepel` and `ItemUseMaxRepel`'s own `ld b`.
+const ITEM_REPEL_STEPS: Dictionary = {0x1E: 100, 0x38: 200, 0x39: 250}
+## `.restorePP`'s `add 10` and the `MAX_ETHER` that skips it, with `.useElixir`
+## walking all four slots by decrementing the item twice. The value is whether
+## the whole moveset is restored, which is what [Gen2WorldPartyHost] reads.
+const ITEM_PP_RESTORE: Dictionary = {0x50: false, 0x51: false, 0x52: true, 0x53: true}
+const ITEM_PP_RESTORE_MAX: Array[int] = [0x51, 0x53]
+const ITEM_PP_RESTORE_STEPS: Dictionary = {0x50: 10, 0x52: 10}
 
 ## `ItemUseBall`'s three per-ball numbers: the ceiling Rand1 is rerolled above,
 ## `BallFactor` and `BallFactor2`. SAFARI_BALL takes the fall-through below.
@@ -486,6 +542,13 @@ const POKECENTER_TEXT_AT: Dictionary = {
 const ITEM_USE_TEXT_AT: Dictionary = {
 	"not_time": 0x00, "not_yours": 0x05, "no_effect": 0x0A,
 }
+## `CoinCaseNumCoinsText`, a run of one: `ItemUseCoinCase` is the only reader.
+const COIN_CASE_TEXT_AT: Dictionary = {"coins": 0x00}
+## `PartyMenuMessagePointers`' own five, in the order the table names them.
+## The sixth row points at `PartyMenuItemUseText` again.
+const PARTY_MENU_TEXT_AT: Dictionary = {
+	"normal": 0x00, "item_use": 0x05, "battle": 0x0A, "use_tm": 0x0F, "swap": 0x14,
+}
 const TOSS_TEXT_AT: Dictionary = {
 	"threw_away": 0x00, "ok_to_toss": 0x05, "too_important": 0x0A,
 }
@@ -607,7 +670,7 @@ const SCRIPT_CARRY_BRANCHES: Dictionary = {0x38: true, 0xDA: true, 0x30: false, 
 const SCRIPT_CALLS: Array[String] = [
 	"print_text", "text_script_end", "disable_waiting", "yes_no_choice",
 	"give_item", "is_item_in_bag", "bankswitch", "play_cry", "wait_for_sound",
-	"predef",
+	"predef", "display_pokedex", "give_pokemon",
 ]
 const SCRIPT_SHORT_SIZE: int = 2
 const SCRIPT_LONG_SIZE: int = 3
@@ -757,6 +820,28 @@ const SPRITE_STILL_FIRST_YELLOW: int = 0x47
 const SPRITE_WALKING_TILES: int = 12
 const SPRITE_STILL_TILES: int = 4
 
+## `MonPartySpritePointers`, the table `LoadMonPartySpriteGfx` walks: a CPU
+## address, the tiles to copy, the bank, and the `vSprites` address they land
+## at. An icon owns four tiles at `ICON << 2` and four more `ICONOFFSET` above
+## them, which are its two animation frames.
+const MON_ICON_HEADER_SIZE: int = 6
+const MON_ICON_HEADER_COUNT_RED_BLUE: int = 28
+const MON_ICON_HEADER_COUNT_YELLOW: int = 30
+const MON_ICON_FRAME_TILES: int = 4
+const MON_ICON_FRAME_OFFSET: int = 0x40
+## `vSprites`, which a header's destination is an address inside.
+const MON_ICON_VRAM_AT: int = 0x8000
+## `MonPartyData` holds one `ICON_*` nybble per dex number, the odd number in
+## the high half. Zero is `ICON_MON`, so a cache row is the nybble plus one:
+## [method GameData.mon_menu_icon] reads zero as no icon at all.
+const MON_ICON_NYBBLES: int = 16
+const MON_ICON_VRAM_TILES: int = MON_ICON_FRAME_OFFSET + MON_ICON_NYBBLES * MON_ICON_FRAME_TILES
+## `AnimatePartyMon`'s `.editCoords` pair, which shake a pixel down where every
+## other icon swaps frame, so the two carry the same picture twice.
+const MON_ICON_BALL: int = 0x01
+const MON_ICON_HELIX: int = 0x02
+const MON_ICON_SHAKING: Array[int] = [MON_ICON_BALL, MON_ICON_HELIX]
+
 ## `NUM_TRAINERS`, the trainer classes rather than the individual trainers.
 const TRAINER_CLASS_COUNT: int = 47
 
@@ -800,6 +885,8 @@ const RED_BLUE: Dictionary = {
 	"usable_items_party": 0x13434,
 	"usable_items_close": 0x13459,
 	"item_use_text": 0x0E5C0,
+	"coin_case_text": 0x0E247,
+	"party_menu_text": 0x12E7F,
 	"toss_text": 0x0E755,
 	"tmhm_moves": 0x13773,
 	"mon_palettes": 0x725C8,
@@ -822,6 +909,8 @@ const RED_BLUE: Dictionary = {
 	"yes_no_choice": 0x35EC,
 	"disable_waiting": 0x30B6,
 	"play_cry": 0x13D0,
+	"display_pokedex": 0x0349B,
+	"give_pokemon": 0x03E48,
 	"wait_for_sound": 0x3748,
 	"give_item": 0x3E2E,
 	"is_item_in_bag": 0x3493,
@@ -866,6 +955,8 @@ const RED_BLUE: Dictionary = {
 	"tilesets": 0x0C7BE,
 	"water_tilesets": 0x0E8E0,
 	"overworld_sprites": 0x17B27,
+	"mon_icons": 0x717C0,
+	"mon_icon_species": 0x7190D,
 	"heal_machine_gfx": 0x704B7,
 	"shock_emote_gfx": 0x17CBD,
 	"wild_data": 0x0CEEB,
@@ -906,6 +997,8 @@ const YELLOW: Dictionary = {
 	"usable_items_party": 0x11FDE,
 	"usable_items_close": 0x12003,
 	"item_use_text": 0x0E4FF,
+	"coin_case_text": 0x0E0F4,
+	"party_menu_text": 0x11A38,
 	"toss_text": 0x0E699,
 	"tmhm_moves": 0x1232D,
 	"mon_palettes": 0x72921,
@@ -925,6 +1018,8 @@ const YELLOW: Dictionary = {
 	"yes_no_choice": 0x35EF,
 	"disable_waiting": 0x2FDE,
 	"play_cry": 0x118B,
+	"display_pokedex": 0x0347D,
+	"give_pokemon": 0x03E59,
 	"wait_for_sound": 0x373E,
 	"give_item": 0x3E3F,
 	"is_item_in_bag": 0x3422,
@@ -966,6 +1061,8 @@ const YELLOW: Dictionary = {
 	"tilesets": 0x0C558,
 	"water_tilesets": 0x0E834,
 	"overworld_sprites": 0x142A9,
+	"mon_icons": 0x7184D,
+	"mon_icon_species": 0x719BA,
 	"heal_machine_gfx": 0x7050B,
 	"shock_emote_gfx": 0x411E5,
 	"wild_data": 0x0CB95,
@@ -1226,6 +1323,20 @@ static func sprite_count(id: StringName) -> int:
 static func super_palette_count(id: StringName) -> int:
 	return SUPER_PALETTE_COUNT_YELLOW if id == RomRegistry.YELLOW \
 		else SUPER_PALETTE_COUNT_RED_BLUE
+
+
+## Which of a frame's four tiles its OAM writer reads.
+## `WriteSymmetricMonPartySpriteOAM` reads tiles 0 and 2 and draws each twice,
+## X-flipping the second; the helix has no symmetry and reads all four.
+static func mon_icon_tiles_read(icon: int) -> Array[int]:
+	return [0, 1, 2, 3] if icon == MON_ICON_HELIX else [0, 2]
+
+
+## How many `MonPartySpritePointers` rows `LoadMonPartySpriteGfx` copies.
+## Yellow added Pikachu's own icon and its second frame.
+static func mon_icon_header_count(id: StringName) -> int:
+	return MON_ICON_HEADER_COUNT_YELLOW if id == RomRegistry.YELLOW \
+		else MON_ICON_HEADER_COUNT_RED_BLUE
 
 
 ## `FIRST_STILL_SPRITE`, the picture id from which a sheet is four tiles.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -9,6 +9,10 @@ extends RefCounted
 
 const LIST_END: int = Gen1Layout.TILESET_LIST_END
 
+## The two gifts whose carry the branch behind them reads: `AddItemToInventory`'s
+## and `_GivePokemon`'s.
+const GIFT_OPS: Array[String] = ["give_item", "give_pokemon"]
+
 
 static func verify_layout(rom: RomFile) -> Dictionary:
 	var result: Dictionary = read_world(rom, Gen1Layout.for_id(rom.id))
@@ -52,12 +56,23 @@ static func import_to_cache(
 			RomCache.overworld_sprite_path(directory, number), sheets[number]
 		):
 			return _error("Could not write overworld sprite %d." % number)
+	var icons: Dictionary = result["icons"]
+	for number: int in icons:
+		if not RomCache.write_indices(
+			RomCache.overworld_icon_path(directory, number), icons[number]
+		):
+			return _error("Could not write party menu icon %d." % number)
+	if not RomCache.write_indices(
+		RomCache.mon_menu_icons_path(directory), result["icon_species"]
+	):
+		return _error("Could not write the species icon table.")
 
 	return {
 		"ok": true,
 		"maps": (result["maps"] as Array).size(),
 		"tilesets": tilesets.size(),
 		"sprites": sprites.size(),
+		"icons": (result["icons"] as Dictionary).size(),
 		"encounters": (result["encounters"]["grass"] as Dictionary).size()
 			+ (result["encounters"]["water"] as Dictionary).size(),
 	}
@@ -81,6 +96,9 @@ static func read_world(
 	var effects: Dictionary = _read_overworld_effects(rom, layout)
 	if not bool(effects["ok"]):
 		return effects
+	var icons: Dictionary = _read_mon_icons(rom, layout)
+	if not bool(icons["ok"]):
+		return icons
 	var water: PackedByteArray = _read_list(rom, int(layout["water_tilesets"]))
 	var tilesets: Array = []
 	var graphics: Dictionary = {}
@@ -121,7 +139,96 @@ static func read_world(
 		"sprite_graphics": sprites["graphics"],
 		"encounters": encounters["encounters"],
 		"effects": effects["effects"],
+		"icons": icons["icons"],
+		"icon_species": icons["icon_species"],
 	}
+
+
+## `LoadMonPartySpriteGfx` over `MonPartySpritePointers`: every row copied into
+## one tile strip, then read back out as each icon's two four-tile frames.
+## `MonPartyData` names one icon per dex number, two nybbles to a byte with the
+## odd number in the high half, and the cache numbers species by dex number.
+static func _read_mon_icons(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var bank := PackedByteArray()
+	var width: int = Gen1Layout.MON_ICON_VRAM_TILES * PokeTiles.TILE_WIDTH
+	bank.resize(width * PokeTiles.TILE_HEIGHT)
+	var filled: PackedByteArray = PackedByteArray()
+	filled.resize(Gen1Layout.MON_ICON_VRAM_TILES)
+	var at: int = int(layout["mon_icons"])
+	for row: int in Gen1Layout.mon_icon_header_count(rom.id):
+		var header: int = at + row * Gen1Layout.MON_ICON_HEADER_SIZE
+		if not rom.in_bounds(header, Gen1Layout.MON_ICON_HEADER_SIZE):
+			return _error("Icon header %d is outside the ROM." % row)
+		var tiles: int = rom.u8(header + 2)
+		var source: int = RomFile.linear(rom.u8(header + 3), rom.u16le(header))
+		@warning_ignore("integer_division")
+		var first: int = (rom.u16le(header + 4) - Gen1Layout.MON_ICON_VRAM_AT) \
+			/ PokeTiles.TILE_BYTES
+		if first < 0 or first + tiles > Gen1Layout.MON_ICON_VRAM_TILES:
+			return _error("Icon header %d lands outside the icon strip." % row)
+		var raw: PackedByteArray = rom.slice(source, tiles * PokeTiles.TILE_BYTES)
+		if raw.size() != tiles * PokeTiles.TILE_BYTES:
+			return _error("Icon header %d's graphics are truncated." % row)
+		var pixels: PackedByteArray = PokeTiles.decode_2bpp_strip(raw, 0, tiles)
+		for tile: int in tiles:
+			_copy_icon_tile(pixels, tiles, tile, bank, width, first + tile)
+			filled[first + tile] = 1
+	return _slice_mon_icons(rom, layout, bank, filled)
+
+
+## One 8x8 tile from one strip into another, both being one row of tiles wide.
+static func _copy_icon_tile(
+	from: PackedByteArray, from_tiles: int, from_tile: int,
+	into: PackedByteArray, into_width: int, into_tile: int
+) -> void:
+	var from_width: int = from_tiles * PokeTiles.TILE_WIDTH
+	for row: int in PokeTiles.TILE_HEIGHT:
+		var read: int = row * from_width + from_tile * PokeTiles.TILE_WIDTH
+		var write: int = row * into_width + into_tile * PokeTiles.TILE_WIDTH
+		for column: int in PokeTiles.TILE_WIDTH:
+			into[write + column] = from[read + column]
+
+
+## The strip split back into icons, and the species table beside it. An icon is
+## kept only when both of its frames carry the tiles its own OAM writer reads,
+## which is what leaves the nybbles no cartridge names out of the cache.
+static func _slice_mon_icons(
+	rom: RomFile, layout: Dictionary, bank: PackedByteArray, filled: PackedByteArray
+) -> Dictionary:
+	var frame: int = Gen1Layout.MON_ICON_FRAME_TILES
+	var icons: Dictionary = {}
+	for icon: int in Gen1Layout.MON_ICON_NYBBLES:
+		var first: int = icon * frame
+		var second: int = Gen1Layout.MON_ICON_FRAME_OFFSET + first
+		var whole: bool = true
+		for tile: int in Gen1Layout.mon_icon_tiles_read(icon):
+			whole = whole and filled[first + tile] != 0 and filled[second + tile] != 0
+		if not whole:
+			continue
+		var strip := PackedByteArray()
+		strip.resize(frame * 2 * PokeTiles.TILE_WIDTH * PokeTiles.TILE_HEIGHT)
+		for tile: int in frame:
+			_copy_icon_tile(
+				bank, Gen1Layout.MON_ICON_VRAM_TILES, first + tile,
+				strip, frame * 2 * PokeTiles.TILE_WIDTH, tile
+			)
+			_copy_icon_tile(
+				bank, Gen1Layout.MON_ICON_VRAM_TILES, second + tile,
+				strip, frame * 2 * PokeTiles.TILE_WIDTH, frame + tile
+			)
+		icons[icon + 1] = strip
+
+	var species: PackedByteArray = PackedByteArray()
+	species.resize(Gen1Layout.SPECIES_COUNT)
+	var table: int = int(layout["mon_icon_species"])
+	for dex: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
+		@warning_ignore("integer_division")
+		var byte: int = rom.u8(table + (dex - 1) / 2)
+		var icon: int = (byte >> 4) if dex % 2 == 1 else (byte & 0x0F)
+		if not icons.has(icon + 1):
+			return _error("Dex number %d is drawn with icon %d." % [dex, icon])
+		species[dex - 1] = icon + 1
+	return {"ok": true, "icons": icons, "icon_species": species}
 
 
 ## `PokeCenterFlashingMonitorAndHealBall` with `PokeCenterOAMData` behind it, and
@@ -1052,6 +1159,10 @@ static func _script_call(
 			return _script_far(layout, state, out, next)
 		"predef":
 			return _script_predef(ctx, state, out, next)
+		"display_pokedex":
+			return _script_pokedex(ctx, state, out, next)
+		"give_pokemon":
+			return _script_gift_pokemon(ctx, state, out, next)
 		"play_cry", "wait_for_sound":
 			return next
 	return SCRIPT_UNREAD
@@ -1062,6 +1173,40 @@ static func _script_routine(layout: Dictionary, target: int) -> String:
 		if int(layout.get(name, -1)) == target:
 			return name
 	return ""
+
+
+## `DisplayPokedex` writes `a` to `wPokedexNum` and opens that page, which is the
+## eight Safari Zone signs. The register holds an internal index and the cache
+## speaks dex numbers, so it is translated the way an evolution's target is.
+static func _script_pokedex(
+	ctx: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	if not state.has("a"):
+		return SCRIPT_UNREAD
+	var dex: int = Gen1Layout.dex_of_index(ctx["rom"], ctx["layout"], int(state["a"]))
+	if dex < 1:
+		return SCRIPT_UNREAD
+	out.append({"op": "pokedex", "species": dex})
+	state.erase("a")
+	return next
+
+
+## `GivePokemon` reads the species in b and the level in c and answers in carry,
+## which `_GivePokemon` clears only when the party and the box are both full.
+## The register holds an internal index; the cache speaks dex numbers.
+static func _script_gift_pokemon(
+	ctx: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	if not state.has("b") or not state.has("c") or int(state["c"]) < 1:
+		return SCRIPT_UNREAD
+	var dex: int = Gen1Layout.dex_of_index(ctx["rom"], ctx["layout"], int(state["b"]))
+	if dex < 1:
+		return SCRIPT_UNREAD
+	out.append({"op": "give_pokemon", "species": dex, "level": int(state["c"])})
+	state.erase("b")
+	state.erase("c")
+	state["tests"] = SCRIPT_TESTS_CARRY
+	return next
 
 
 ## `GiveItem` reads the item in b and the count in c, answers in carry, drops bc.
@@ -1186,7 +1331,7 @@ static func _script_node(
 
 ## The carry belongs to the gift in front of it, so both sides fold onto it.
 static func _script_receipt(out: Array, taken: Array, fell: Array) -> Variant:
-	if out.is_empty() or String((out[-1] as Dictionary)["op"]) != "give_item":
+	if out.is_empty() or String((out[-1] as Dictionary)["op"]) not in GIFT_OPS:
 		return null
 	var gift: Dictionary = out.pop_back()
 	gift["ok"] = taken

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 113
+const FORMAT_VERSION: int = 114
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/party_menu_page.gd
+++ b/game/render/party_menu_page.gd
@@ -93,6 +93,30 @@ const ICON_ITEM_TILE: int = Gen2Layout.HELD_ITEM_ICON_ITEM
 const ICON_MAIL_TILE: int = Gen2Layout.HELD_ITEM_ICON_MAIL
 const ICON_ITEM_QUADRANT: int = 2
 
+## Generation 1's own columns and first rows, from `DrawPartyMenu_`: the
+## nickname at `hlcoord 3, 0`, `PrintLevel` ten columns on and
+## `PrintStatusCondition` fourteen, with `DrawHPBar` a row below at
+## `hlcoord 4, 1` and `DrawHP2`'s fraction nine columns past the bar's own left
+## end. `ErasePartyMenuCursors` walks `hlcoord 0, 1` two rows at a time, so the
+## arrow stands beside the bar rather than the nickname, and there is no CANCEL
+## row: `PartyMenuInit` stops the list at `wPartyCount - 1` and B is the way out.
+const GEN1_NICKNAME: Vector2i = Vector2i(3, 0)
+const GEN1_LEVEL: Vector2i = Vector2i(13, 0)
+const GEN1_STATUS: Vector2i = Vector2i(17, 0)
+const GEN1_HP_BAR: Vector2i = Vector2i(4, 1)
+const GEN1_HP_DIGITS: Vector2i = Vector2i(13, 1)
+const GEN1_CURSOR_ROW: int = 1
+## `MESSAGE_BOX` in `data/text_boxes.asm` and `PrintText`'s own `bccoord 1, 14`.
+const GEN1_TEXTBOX: Vector2i = Vector2i(0, 12)
+const GEN1_TEXTBOX_ROWS: int = 6
+const GEN1_PROMPT: Vector2i = Vector2i(1, 14)
+## `WriteMonPartySpriteOAM`: X is `$10` flat and Y the slot shifted four with
+## `$10` added, and both name the block's top-left rather than a centre.
+const GEN1_ICON_AT: Vector2i = Vector2i(0x10, 0x10)
+## `PartyMonSpeeds` with `wOnSGB` set, the V-blanks one frame lasts on a green,
+## yellow and red bar. Crystal's row is added to a duration; this one is it.
+const GEN1_ICON_SPEEDS: Array[int] = [5, 16, 32]
+
 ## `PlaceStatusString`'s three-letter strings, in the order
 ## `PlaceNonFaintStatus` tests them. FNT comes first because
 ## `PlaceStatusString` checks the health before it ever looks at the byte.
@@ -105,6 +129,25 @@ const FAINTED_STRING: String = "FNT"
 var font: Gen2Font = null
 var hud: Gen2BattleHud = null
 var data: GameData = null
+
+## Read through the instance so one drawing routine serves both generations,
+## the way [Gen2BattleTiles] carries its own tile numbers.
+var gen1: bool = false
+var nickname_at: Vector2i = NICKNAME
+var hp_bar_at: Vector2i = HP_BAR
+var hp_digits_at: Vector2i = HP_DIGITS
+var level_at: Vector2i = LEVEL
+var status_at: Vector2i = STATUS
+var quality_at: Vector2i = QUALITY
+var cursor_row: int = NICKNAME.y
+var textbox_at: Vector2i = TEXTBOX
+var textbox_rows: int = TEXTBOX_ROWS
+var prompt_at: Vector2i = PROMPT
+
+## `wAnimCounter` and the `wCurrentMenuItem` its reset is keyed on, which
+## Generation 1 keeps for the whole menu rather than one per icon.
+var _gen1_counter: int = 0
+var _gen1_cursor: int = -1
 
 ## One sprite anim struct per member, in party order:
 ## `{icon, item, speed, frame, duration, var1, x, y_offset}`. Empty until
@@ -135,7 +178,26 @@ static func from_data(source: GameData) -> Gen2PartyMenuPage:
 	out.hud = panels
 	out.data = source
 	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	if source.generation == RomRegistry.GEN1:
+		out._use_gen1_layout()
 	return out
+
+
+func _use_gen1_layout() -> void:
+	gen1 = true
+	nickname_at = GEN1_NICKNAME
+	hp_bar_at = GEN1_HP_BAR
+	hp_digits_at = GEN1_HP_DIGITS
+	level_at = GEN1_LEVEL
+	status_at = GEN1_STATUS
+	## `.teachMoveMenu` and `.evolutionStoneMenu` both print at the nickname's
+	## own `SCREEN_WIDTH + 9`, which is where `PlacePartyMonTMHMCompatibility`
+	## prints too.
+	quality_at = GEN1_NICKNAME + QUALITY - NICKNAME
+	cursor_row = GEN1_CURSOR_ROW
+	textbox_at = GEN1_TEXTBOX
+	textbox_rows = GEN1_TEXTBOX_ROWS
+	prompt_at = GEN1_PROMPT
 
 
 ## The whole screen, with the arrow on [param cursor] counting CANCEL as the row
@@ -156,15 +218,15 @@ func render(
 
 	for index: int in rows.size():
 		_draw_member(page, width, index, rows[index], quality)
-	if cancel:
+	if cancel and not gen1:
 		font.draw_text(
 			Gen2BattleSwitchMenu.cancel_label(), page, width,
-			CANCEL_COLUMN * TILE, (NICKNAME.y + rows.size() * ROW_STEP) * TILE
+			CANCEL_COLUMN * TILE, (nickname_at.y + rows.size() * ROW_STEP) * TILE
 		)
 	if held >= 0 and held < rows.size():
 		font.draw_code(
 			HELD_CODE, page, width,
-			CURSOR_COLUMN * TILE, (NICKNAME.y + held * ROW_STEP) * TILE
+			CURSOR_COLUMN * TILE, (cursor_row + held * ROW_STEP) * TILE
 		)
 	_draw_cursor(page, width, cursor)
 	_draw_prompt(page, width, prompt)
@@ -189,10 +251,40 @@ func render(
 func advance(rows: Array, cursor: int) -> void:
 	if _icons.size() != rows.size():
 		reset(rows)
+	if gen1:
+		_advance_gen1(cursor)
+		return
 	for index: int in _icons.size():
 		var icon: Dictionary = _icons[index]
 		_step_icon_sequence(icon, index == cursor)
 		_step_icon_frame(icon)
+
+
+## `AnimatePartyMon` behind `GetAnimationSpeed`: one counter for the whole menu,
+## which `HandleMenuInput_` zeroes every time it redraws the cursor, and only
+## the chosen row moved. `.resetSprites` puts every icon back on its first frame
+## at zero and `.animateSprite` swaps the chosen one at the speed its bar colour
+## names, so the counter runs to twice that. A ball or a helix takes
+## `.editCoords` and shakes a pixel down where the rest change tile.
+func _advance_gen1(cursor: int) -> void:
+	if cursor != _gen1_cursor:
+		_gen1_cursor = cursor
+		_gen1_counter = 0
+	for icon: Dictionary in _icons:
+		icon["frame"] = 0
+		icon["y_offset"] = 0
+	if cursor < 0 or cursor >= _icons.size():
+		return
+	var chosen: Dictionary = _icons[cursor]
+	var speed: int = GEN1_ICON_SPEEDS[int(chosen["speed"])]
+	var shown: int = _gen1_counter
+	_gen1_counter = 0 if shown + 1 >= speed * 2 else shown + 1
+	if shown < speed:
+		return
+	if bool(chosen["shakes"]):
+		chosen["y_offset"] = 1
+	else:
+		chosen["frame"] = 1
 
 
 ## `InitPartyMenuGFX`: one struct per member, spawned in party order. FRAME
@@ -210,6 +302,9 @@ func reset(rows: Array) -> void:
 		## green one, rather than a stale byte no save can reproduce.
 		if bool(member.get("egg", false)):
 			speed = 0
+		var icon: int = data.mon_menu_icon(
+			int(member.get("species", 0)), bool(member.get("egg", false))
+		) if data != null else 0
 		_icons.append({
 			## The strip is asked for by species rather than by icon number, so a
 			## mod species drawing indices of its own animates with the rest.
@@ -219,12 +314,16 @@ func reset(rows: Array) -> void:
 			"item": int(member.get("item", 0)) != 0,
 			"mail": Gen2HeldItem.is_mail(int(member.get("item", 0))),
 			"speed": speed,
-			"frame": -1,
+			"shakes": gen1 and Gen1Layout.MON_ICON_SHAKING.has(icon - 1),
+			"symmetric": gen1 and icon - 1 != Gen1Layout.MON_ICON_HELIX,
+			"frame": -1 if not gen1 else 0,
 			"duration": 0,
 			"var1": 0,
 			"x": ICON_X,
 			"y_offset": 0,
 		})
+	_gen1_counter = 0
+	_gen1_cursor = -1
 
 
 ## What the icons would draw right now, so a host caching its layer knows when
@@ -268,7 +367,7 @@ func _step_icon_frame(icon: Dictionary) -> void:
 func _blend_icons(pixels: PackedInt32Array, count: int) -> void:
 	if data == null or _icons.is_empty():
 		return
-	var colors: PackedColorArray = data.party_menu_icon_palette()
+	var colors: PackedColorArray = _icon_palette()
 	if colors.size() != PokePalette.COLORS_PER_PIC:
 		return
 	var held: PackedByteArray = data.held_item_icon_indices()
@@ -281,35 +380,64 @@ func _blend_icons(pixels: PackedInt32Array, count: int) -> void:
 		var strip: PackedByteArray = icon["strip"]
 		if strip.is_empty():
 			continue
-		var at := Vector2i(
-			int(icon["x"]) - ICON_TILE - OAM_ORIGIN.x,
-			ICON_FIRST_Y + index * ICON_ROW_STEP + int(icon["y_offset"])
-				- ICON_TILE - OAM_ORIGIN.y
-		)
+		var at: Vector2i = _icon_corner(icon, index)
 		var first: int = int(icon["frame"]) * ICON_FRAME_TILES
 		for quadrant: int in ICON_FRAME_TILES:
 			var source: PackedByteArray = strip
 			var tile: int = first + quadrant
-			if quadrant == ICON_ITEM_QUADRANT and bool(icon["item"]) and not held.is_empty():
+			var flip: bool = false
+			if gen1:
+				## `WriteSymmetricMonPartySpriteOAM` writes each row's one tile
+				## twice, the second time X-flipped; the helix's own writer walks
+				## all four in raster order.
+				flip = bool(icon["symmetric"]) and quadrant % 2 == 1
+				tile = first + (quadrant & 2) if bool(icon["symmetric"]) else tile
+			elif quadrant == ICON_ITEM_QUADRANT and bool(icon["item"]) and not held.is_empty():
 				source = held
 				tile = ICON_MAIL_TILE if bool(icon["mail"]) else ICON_ITEM_TILE
 			blend_tile(
 				pixels, source, tile, colors,
-				at + Vector2i((quadrant & 1) * ICON_TILE, (quadrant >> 1) * ICON_TILE)
+				at + Vector2i((quadrant & 1) * ICON_TILE, (quadrant >> 1) * ICON_TILE), flip
 			)
+
+
+## `PartyMenuOBPals` on Crystal. Generation 1 has no object palette table: the
+## icons stand in the two columns `BlkPacket_PartyMenu` gives PAL_MEWMON, read
+## through `GBPalNormal`'s own `rOBP0`.
+func _icon_palette() -> PackedColorArray:
+	if not gen1:
+		return data.party_menu_icon_palette()
+	return Gen2WorldPalette.gen1_object_colors(
+		data.world_palette(Gen1Layout.PAL_MEWMON)
+	)
+
+
+## The block's top-left on screen. Generation 1's OAM coordinates are the
+## corner itself; Crystal's name the middle of `.OAMData_RedWalk`'s four tiles,
+## which sit a tile up and left of it.
+func _icon_corner(icon: Dictionary, index: int) -> Vector2i:
+	if gen1:
+		return Vector2i(
+			GEN1_ICON_AT.x, GEN1_ICON_AT.y + index * ICON_ROW_STEP + int(icon["y_offset"])
+		) - OAM_ORIGIN
+	return Vector2i(
+		int(icon["x"]) - ICON_TILE - OAM_ORIGIN.x,
+		ICON_FIRST_Y + index * ICON_ROW_STEP + int(icon["y_offset"])
+			- ICON_TILE - OAM_ORIGIN.y
+	)
 
 
 ## One 8x8 tile of an index strip, clipped to the screen. Static and public
 ## because the move screen composes the same icon over its own page.
 static func blend_tile(
 	pixels: PackedInt32Array, strip: PackedByteArray, tile: int,
-	colors: PackedColorArray, at: Vector2i
+	colors: PackedColorArray, at: Vector2i, flip_x: bool = false
 ) -> void:
 	@warning_ignore("integer_division")
 	var tiles: int = strip.size() / PokeTiles.TILE_PIXELS
 	Gen2PicImage.blit_tile(
 		pixels, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, strip, tiles, tile,
-		at.x, at.y, Gen2PicImage.lookup(colors), false, false, 0
+		at.x, at.y, Gen2PicImage.lookup(colors), flip_x, false, 0
 	)
 
 
@@ -323,7 +451,7 @@ func _draw_member(
 
 	font.draw_text(
 		String(row.get("name", "")), page, width,
-		NICKNAME.x * TILE, (NICKNAME.y + step) * TILE
+		nickname_at.x * TILE, (nickname_at.y + step) * TILE
 	)
 	## Every quality below `PlacePartyNicknames` opens its loop with
 	## `PartyMenuCheckEgg` and steps past the row, so an egg is a nickname and
@@ -334,22 +462,21 @@ func _draw_member(
 	if quality:
 		font.draw_text(
 			String(row.get("quality", "")), page, width,
-			QUALITY.x * TILE, (QUALITY.y + step) * TILE
+			quality_at.x * TILE, (quality_at.y + step) * TILE
 		)
 	else:
 		font.draw_text(
 			"%s/%s" % [
 				str(hp).lpad(HP_NUMBER_DIGITS), str(max_hp).lpad(HP_NUMBER_DIGITS),
 			],
-			page, width, HP_DIGITS.x * TILE, (HP_DIGITS.y + step) * TILE
+			page, width, hp_digits_at.x * TILE, (hp_digits_at.y + step) * TILE
 		)
 		hud.draw_bar_frame(
-			page, width, Vector2i(HP_BAR.x, HP_BAR.y + step),
-			Gen2BattleTiles.HP_BAR_END
+			page, width, Vector2i(hp_bar_at.x, hp_bar_at.y + step), hud.tiles.hp_bar_end
 		)
-	hud.draw_level(page, width, Vector2i(LEVEL.x, LEVEL.y + step), int(row.get("level", 0)))
+	hud.draw_level(page, width, Vector2i(level_at.x, level_at.y + step), int(row.get("level", 0)))
 	font.draw_text(
-		_status_string(row), page, width, STATUS.x * TILE, (STATUS.y + step) * TILE
+		_status_string(row), page, width, status_at.x * TILE, (status_at.y + step) * TILE
 	)
 
 
@@ -367,8 +494,8 @@ func _blend_bar(pixels: PackedInt32Array, index: int, row: Dictionary) -> void:
 	buffer.resize(width * TILE)
 	var hp: int = int(row.get("hp", 0))
 	var max_hp: int = int(row.get("max_hp", 0))
-	var top: int = HP_BAR.y + index * ROW_STEP
-	hud.draw_hp_bar(buffer, width, Vector2i(HP_BAR.x, 0), hp, max_hp)
+	var top: int = hp_bar_at.y + index * ROW_STEP
+	hud.draw_hp_bar(buffer, width, Vector2i(hp_bar_at.x, 0), hp, max_hp)
 
 	var lit: int = Gen2BattleHud.bar_pixels(
 		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE
@@ -376,7 +503,7 @@ func _blend_bar(pixels: PackedInt32Array, index: int, row: Dictionary) -> void:
 	var table: PackedInt32Array = Gen2PicImage.lookup(
 		data.bar_palette(GameData.hp_bar_palette_name(lit)), true
 	)
-	var left: int = (HP_BAR.x + 2) * TILE
+	var left: int = (hp_bar_at.x + 2) * TILE
 	for y: int in TILE:
 		var from: int = y * width
 		var to: int = (top * TILE + y) * width
@@ -402,13 +529,20 @@ func _draw_cursor(page: PackedByteArray, width: int, cursor: int) -> void:
 		return
 	font.draw_code(
 		Gen2MenuPage.CURSOR_CODE, page, width,
-		CURSOR_COLUMN * TILE, (NICKNAME.y + cursor * ROW_STEP) * TILE
+		CURSOR_COLUMN * TILE, (cursor_row + cursor * ROW_STEP) * TILE
 	)
 
 
 func _draw_prompt(page: PackedByteArray, width: int, prompt: String) -> void:
 	font.draw_box(
-		frame_style, page, width, TEXTBOX.x * TILE, TEXTBOX.y * TILE,
-		TEXTBOX_COLUMNS, TEXTBOX_ROWS
+		frame_style, page, width, textbox_at.x * TILE, textbox_at.y * TILE,
+		TEXTBOX_COLUMNS, textbox_rows
 	)
-	font.draw_text(prompt, page, width, PROMPT.x * TILE, PROMPT.y * TILE)
+	## `PlacePartyMenuText`'s string is one line and every `PartyMenuMessagePointers`
+	## box is two, so a break is a row two down, which is where `<LINE>` lands.
+	var line: int = 0
+	for row: String in prompt.split("\n", false):
+		font.draw_text(
+			row, page, width, prompt_at.x * TILE, (prompt_at.y + line * ROW_STEP) * TILE
+		)
+		line += 1

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -96,6 +96,9 @@ const MESSAGE_NO_EFFECT: String = "It won't have any effect."
 ## `MonSubmenu.MenuHeader`'s `menu_coords 6, 0, SCREEN_WIDTH - 1,
 ## SCREEN_HEIGHT - 1` with `.GetTopCoord`'s own top:
 ## `1 + bottom - 2 * (count + 1)`, so the box grows upward from the bottom row.
+## `DisplayFieldMoveMonMenu`'s `ld [hl], 12` and its `hlcoord 11, 11`.
+const GEN1_SUBMENU_COLUMN: int = 12
+const GEN1_SUBMENU_TOP: int = 11
 const SUBMENU_LEFT: int = 6
 const SUBMENU_RIGHT: int = 19
 const SUBMENU_BOTTOM: int = 17
@@ -270,7 +273,7 @@ static func submenu_items_for(
 		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
 		return items
 	for move: int in mon.moves:
-		if move == 0 or not Gen2WorldFieldMove.is_field_move(move):
+		if move == 0 or not Gen2WorldFieldMove.is_field_move(move, data):
 			continue
 		items.append({
 			"kind": &"field_move",
@@ -281,6 +284,11 @@ static func submenu_items_for(
 	## `SwitchPartyMons` makes its own `cp 2` refusal rather than being greyed
 	## out, so the row is offered whatever the party holds.
 	items.append(_option_entry(OPTION_SWITCH, "SWITCH"))
+	## `PokemonMenuEntries` is those two and CANCEL: Generation 1 reorders no
+	## moveset from here and its party carries nothing to give or take.
+	if data != null and data.generation == RomRegistry.GEN1:
+		items.append(_option_entry(OPTION_CANCEL, "CANCEL"))
+		return items
 	items.append(_option_entry(OPTION_MOVE, "MOVE"))
 	## `GetMonSubmenuItems`: `ItemIsMail` decides between the two rows, so a
 	## member holding mail has no ITEM row at all.
@@ -846,8 +854,19 @@ func _prompt() -> String:
 	if _selecting:
 		return _select_prompt
 	if _switch_from >= 0:
-		return PROMPT_MOVE_TO_WHERE
-	return PROMPT_USE_ON_WHICH if _heal_user >= 0 else PROMPT_CHOOSE
+		return prompt_text(_data, &"swap", PROMPT_MOVE_TO_WHERE)
+	return prompt_text(_data, &"item_use", PROMPT_USE_ON_WHICH) if _heal_user >= 0 \
+		else prompt_text(_data, &"normal", PROMPT_CHOOSE)
+
+
+## `PartyMenuStrings` on Crystal and `PartyMenuMessagePointers` on Generation 1,
+## whose boxes are imported: the constants here spell POKéMON with the `#` only
+## Crystal's charmap has a glyph for, so a Generation 1 font drew "?MON".
+static func prompt_text(data: GameData, row: StringName, crystal: String) -> String:
+	if data == null or data.generation != RomRegistry.GEN1:
+		return crystal
+	var text: String = data.special_text("party_menu", String(row))
+	return text if not text.is_empty() else crystal
 
 
 func _render_hardware() -> void:
@@ -932,6 +951,8 @@ func _submenu_box() -> Gen2MenuBox:
 			_fixed_menu_box.position.x, _fixed_menu_box.position.y,
 			_fixed_menu_box.end.x, _fixed_menu_box.end.y, Gen2MenuBox.STATICMENU_CURSOR
 		)
+	if _data != null and _data.generation == RomRegistry.GEN1:
+		return gen1_mon_menu_box(_submenu_items)
 	return mon_menu_box(_submenu_items.size())
 
 
@@ -943,6 +964,33 @@ static func mon_menu_box(count: int) -> Gen2MenuBox:
 	return Gen2MenuBox.from_coords(
 		SUBMENU_LEFT, SUBMENU_BOTTOM + 1 - 2 * (maxi(count, 0) + 1),
 		SUBMENU_RIGHT, SUBMENU_BOTTOM, Gen2MenuBox.STATICMENU_CURSOR
+	)
+
+
+## `DisplayFieldMoveMonMenu`. `wFieldMovesLeftmostXCoord` drops to the smallest
+## `FieldMoveDisplayData` column the member's moves name, so a box holding
+## STRENGTH is two columns wider and one holding SOFTBOILED four. Each field
+## move raises the top two rows, with one more for the blank row above the first
+## name that a box with no field move never spends: that one opens on
+## `hlcoord 11, 11` and its first row is the next, `STATICMENU_NO_TOP_SPACING`.
+static func gen1_mon_menu_box(items: Array) -> Gen2MenuBox:
+	var moves: int = 0
+	var left: int = GEN1_SUBMENU_COLUMN
+	for entry: Dictionary in items:
+		if StringName(entry.get("kind", &"")) != &"field_move":
+			continue
+		moves += 1
+		left = mini(left, int(Gen2WorldFieldMove.GEN1_FIELD_MOVES.get(
+			int(entry.get("move", 0)), GEN1_SUBMENU_COLUMN
+		)))
+	if moves == 0:
+		return Gen2MenuBox.from_coords(
+			GEN1_SUBMENU_COLUMN - 1, GEN1_SUBMENU_TOP, SUBMENU_RIGHT, SUBMENU_BOTTOM,
+			Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+		)
+	return Gen2MenuBox.from_coords(
+		left - 1, GEN1_SUBMENU_TOP - 1 - 2 * moves, SUBMENU_RIGHT, SUBMENU_BOTTOM,
+		Gen2MenuBox.STATICMENU_CURSOR
 	)
 
 

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -147,8 +147,10 @@ const TEXT_TOO_IMPORTANT: String = "too_important"
 ## The same four boxes on Generation 1, which keeps them in
 ## `engine/items/item_effects.asm` rather than in a pack of its own.
 ## `AskQuantityThrowAwayText` has no counterpart: the dial opens over no question.
+const TEXT_COIN_CASE: String = "coin_case"
 const GEN1_PACK_TEXTS: Dictionary = {
 	TEXT_OAK: ["item_use", "not_time"],
+	TEXT_COIN_CASE: ["coin_case", "coins"],
 	TEXT_TOSS_ASK_QUANTITY: ["toss", "ok_to_toss"],
 	TEXT_TOSS_THREW: ["toss", "threw_away"],
 	TEXT_TOO_IMPORTANT: ["toss", "too_important"],
@@ -542,10 +544,13 @@ func _move_wrapped(step: int, at: StringName, rows: int, render: StringName) -> 
 
 ## `InitPartyMenuWithCancel`: CANCEL is the row after the last member and the
 ## cursor wraps around it, which is `w2DMenuNumRows` being the party count plus
-## one.
+## one. Generation 1's `PartyMenuInit` stops at `wPartyCount - 1` instead and
+## leaves B as the only way out, so its list is the members and nothing else.
 func _target_rows() -> int:
 	var targets: Array = _party_targets()
-	return 0 if targets.is_empty() else targets.size() + 1
+	if targets.is_empty():
+		return 0
+	return targets.size() if _gen1_pack() else targets.size() + 1
 
 
 ## w2DMenuNumCols is 1, so only vertical input moves the move list.
@@ -1479,14 +1484,50 @@ func _confirm_use() -> void:
 			_show_pack_result(_pack_text(TEXT_OAK), false)
 
 
-## `UseItem`'s jumptable on Generation 1. Neither `DisplayPartyMenu` nor the
-## `ItemUse*` routine behind it is built, so `.Party` and `.Current` answer
-## `ItemUseNotTime` the way a `.Field` row with no effect does.
+## `UseItem_`'s jumptable on Generation 1, reached through the same three menu
+## answers `StartMenu_Item` picks between. `cp HM01` stands in front of the
+## table, so every machine is `ItemUseTMHM` rather than an `ItemEffects` row.
 func _confirm_gen1_use(item: int) -> void:
-	if Gen2WorldPack.field_use_kind(_data, item) == Gen2WorldPack.ITEMMENU_CLOSE:
-		_use_field_item(item)
-		return
-	_show_pack_result(_pack_text(TEXT_OAK), false)
+	match Gen2WorldPack.field_use_kind(_data, item):
+		Gen2WorldPack.ITEMMENU_CLOSE:
+			_use_field_item(item)
+		Gen2WorldPack.ITEMMENU_PARTY:
+			if Gen2WorldTMHM.is_tm_hm(item, RomRegistry.GEN1):
+				_open_teach_mode(item)
+				return
+			if _party_targets().is_empty():
+				## `ItemUseMedicine`'s own `.emptyParty`, which no other
+				## `.Party` routine has: the rest open the menu on nothing.
+				_show_pack_result(_pack_text(TEXT_NO_MON), false)
+				return
+			_open_target_mode()
+		Gen2WorldPack.ITEMMENU_CURRENT:
+			_confirm_gen1_current(item)
+		_:
+			_show_pack_result(_pack_text(TEXT_OAK), false)
+
+
+## The `.Current` rows that are neither `UnusableItem` nor battle-only.
+## `ItemUsePokedex` is a predef the world owns, `ItemUseCoinCase` prints over
+## the pack, and `ItemUseOaksParcel` is the one refusal with a text of its own.
+## The rest land on `ItemUseNotTime`, the box `.Oak` prints.
+func _confirm_gen1_current(item: int) -> void:
+	match item:
+		Gen1Layout.ITEM_POKEDEX:
+			action_chosen.emit(Gen2WorldStartMenu.ITEM_POKEDEX, &"")
+		Gen1Layout.ITEM_COIN_CASE:
+			_show_pack_result(_coin_case_text(), true)
+		Gen1Layout.ITEM_OAKS_PARCEL:
+			_show_pack_result(
+				_data.special_text("item_use", "not_yours"), false
+			)
+		_:
+			## `ItemUseRepel` and its two siblings are the only other rows with
+			## an effect out of battle, and the effect table is what says so.
+			if Gen2WorldPartyHost.item_effects(_data)["repel"].has(item):
+				_use_selected_item(-1)
+				return
+			_show_pack_result(_pack_text(TEXT_OAK), false)
 
 
 ## `.Field`: `DoItemEffect` and then `wItemEffectSucceeded`. The effects that run
@@ -1618,6 +1659,12 @@ func _target_quality_text(mon: Gen2SaveMon) -> String:
 ## PARTYMENUACTION_GIVE_ITEM, and the PARTYMENUACTION_HEALING_ITEM every
 ## `.Party` item effect writes.
 func _target_prompt() -> String:
+	## `PartyMenuMessagePointers` on Generation 1, picked by the
+	## `wPartyMenuTypeOrMessageID` each entrance writes: `ItemUseTMHM`'s
+	## TMHM_PARTY_MENU and the USE_ITEM_PARTY_MENU every medicine writes. There
+	## is no GIVE there, the bag holding nothing a Pokemon can carry.
+	if _gen1_pack():
+		return _data.special_text("party_menu", "use_tm" if _teaching else "item_use")
 	if _teaching:
 		return Gen2PartyScreen.PROMPT_TEACH_WHICH
 	return Gen2PartyScreen.PROMPT_TO_WHICH if _giving \
@@ -1821,7 +1868,7 @@ func _teach_refusal(reason: StringName, party_index: int) -> String:
 
 func _open_target_mode() -> void:
 	_mode = Mode.PACK_TARGET
-	_target_cursor = clampi(_target_cursor, 0, _party_targets().size())
+	_target_cursor = clampi(_target_cursor, 0, _target_rows() - 1)
 	## `InitPartyMenuGFX` respawns one icon struct per member every time the list
 	## is opened, which is what puts the icons on the page at all.
 	if _party_menu_page() != null:
@@ -1835,10 +1882,6 @@ func _open_target_mode() -> void:
 
 
 func _render_targets() -> void:
-	## The panel fallback carries the same CANCEL row the hardware page draws, so
-	## the cursor means one thing whichever of the two is up.
-	var rows: Array = _party_targets()
-	rows.append({"cancel": true})
 	_render_hardware()
 
 
@@ -1951,7 +1994,9 @@ func _use_refusal(reason: StringName, item: int) -> String:
 		return _pack_text(TEXT_OAK)
 	match reason:
 		&"item_has_no_effect":
-			return "It won't have any effect."
+			## `ItemUseNoEffect`'s box, which Generation 1's cache carries.
+			return _data.special_text("item_use", "no_effect") if _gen1_pack() \
+				else "It won't have any effect."
 		&"insufficient_item_quantity":
 			return "You have none of those."
 		&"pp_up_unsupported":
@@ -2072,7 +2117,8 @@ func _press_toss_quantity(button: int) -> bool:
 ## `TextCommands` and the cartridge executes whatever follows, which is
 ## `docs/bugs_and_glitches.md`'s own Coin Case entry. Those two keep the wording.
 func _coin_case_text() -> String:
-	var text: String = _data.menu_text("coin_case") if _data != null else ""
+	var text: String = _pack_text(TEXT_COIN_CASE) if _gen1_pack() \
+		else (_data.menu_text("coin_case") if _data != null else "")
 	if text.is_empty():
 		return "Coins:\n%4d" % _coins()
 	return Gen2TextStream.fill_marker(
@@ -2573,7 +2619,7 @@ func _target_quality() -> StringName:
 		return &"tmhm"
 	return &"evo_stone" if int(_selected_item().get(
 		"item", 0
-	)) in Gen2Evolution.STONE_ITEMS else &""
+	)) in Gen2Evolution.stone_items(_data) else &""
 
 
 func _mod_rows_image() -> Image:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3792,6 +3792,16 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 			"pick_up_item":
 				if not _gen1_pick_up_item(steps, run):
 					return false
+			"give_pokemon":
+				if not _gen1_resolve_gift_pokemon(node, steps, run):
+					return false
+			"pokedex":
+				## `_DisplayPokedex` opens on one entry and the page the world
+				## already has for `pokedex_entry_requested` is that same one.
+				steps.append({"type": &"request", "values": {
+					"kind": &"pokedex_entry_requested",
+					"values": {"species": int(node["species"])},
+				}})
 			"choice":
 				return _gen1_script_choice(node, steps, run)
 			_:
@@ -3803,6 +3813,27 @@ func _gen1_resolve_side(
 	node: Dictionary, taken: bool, steps: Array, run: Dictionary
 ) -> bool:
 	return _gen1_resolve_script(node["then" if taken else "else"] as Array, steps, run)
+
+
+## `_GivePokemon`, whose carry the caller's own `jr nc` reads: the party first,
+## the box behind it, and no room at all is the one answer that clears it. Only
+## the screen holding the save knows which, so both sides are resolved here and
+## the request carries them until it comes back.
+func _gen1_resolve_gift_pokemon(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var step: Dictionary = {"type": &"request", "values": {
+		"kind": &"pokemon_requested",
+		"values": {"pokemon": int(node["species"]), "level": int(node["level"])},
+	}}
+	if node.has("ok"):
+		var taken: Array = []
+		var full: Array = []
+		if not _gen1_resolve_script(node["ok"] as Array, taken, _gen1_run_copy(run)) \
+			or not _gen1_resolve_script(node["full"] as Array, full, _gen1_run_copy(run)):
+			return false
+		step["ok"] = taken
+		step["full"] = full
+	steps.append(step)
+	return true
 
 
 ## `AddItemToInventory` and its carry; only a gift that landed is named.
@@ -4356,6 +4387,11 @@ func _gen1_advance(choice: int, result: Dictionary = {}) -> Array:
 	if StringName(step.get("type", &"")) == &"choice":
 		var branch: Array = step.get("yes" if choice == 0 else "no", [])
 		_gen1_steps = branch.duplicate(true) + _gen1_steps
+	elif step.has("ok"):
+		## `accepted` is the carry `_GivePokemon` answers in.
+		_gen1_steps = (step[
+			"ok" if bool(result.get("accepted", false)) else "full"
+		] as Array).duplicate(true) + _gen1_steps
 	_gen1_battle_won(step, result)
 	return _gen1_result()
 

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -80,6 +80,14 @@ const FIELD_MOVES: Array[int] = [
 	MOVE_FLY, MOVE_SOFTBOILED, MOVE_MILK_DRINK,
 ]
 
+## `FieldMoveDisplayData` (`data/moves/field_moves.asm`), the whole of
+## `GetMonFieldMoves`: the move, and the column `DisplayFieldMoveMonMenu` starts
+## its name one past. `ANIM_B4`'s row is the unused one and names no move.
+const GEN1_FIELD_MOVES: Dictionary = {
+	MOVE_CUT: 0x0C, MOVE_FLY: 0x0C, MOVE_SURF: 0x0C, MOVE_STRENGTH: 0x0A,
+	MOVE_FLASH: 0x0C, MOVE_DIG: 0x0C, MOVE_TELEPORT: 0x0A, MOVE_SOFTBOILED: 0x08,
+}
+
 ## engine/overworld/tile_events.asm's CheckCutCollision, entry for entry: the
 ## four grass codes are LAND_TILE and cuttable, so this is not the permission.
 const CUTTABLE_COLLISIONS: Array[int] = [
@@ -190,7 +198,9 @@ static func move_boulders_text(user: String) -> String:
 	return MOVE_BOULDERS_TEXT % user
 
 
-static func is_field_move(move: int) -> bool:
+static func is_field_move(move: int, data: GameData = null) -> bool:
+	if data != null and data.generation == RomRegistry.GEN1:
+		return GEN1_FIELD_MOVES.has(move)
 	return FIELD_MOVES.has(move)
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1870,24 +1870,26 @@ static func _apply_item_effect(
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
 		return {"ok": false, "reason": &"unknown_item", "item": item}
-	if REPEL_STEPS.has(item):
+	var effects: Dictionary = item_effects(data)
+	var repels: Dictionary = effects["repel"]
+	if repels.has(item):
 		## `UseRepel`'s `ld a, [wRepelEffect] / and a / jp nz, PrintText`: the
 		## line is said and `UseDisposableItem` never reached.
 		if repel_steps > 0:
 			return {"ok": false, "reason": &"repel_still_in_effect", "item": item}
-		return {"ok": true, "effect": &"repel", "repel_steps": REPEL_STEPS[item]}
-	if item == Gen2WorldPack.ITEM_SACRED_ASH:
+		return {"ok": true, "effect": &"repel", "repel_steps": int(repels[item])}
+	if item == int(effects["sacred_ash"]):
 		return _apply_sacred_ash(data, save)
 	if party_index < 0 or party_index >= save.party.size():
 		return {"ok": false, "reason": &"party_member_required"}
 	var mon: Gen2SaveMon = save.party[party_index]
 	if mon == null or mon.is_egg:
 		return {"ok": false, "reason": &"invalid_party_member"}
-	if item == ITEM_RARE_CANDY:
+	if item == int(effects["rare_candy"]):
 		return _apply_rare_candy(data, mon, time_of_day)
-	if PP_RESTORE_ITEMS.has(item):
-		return _apply_pp_restore(data, mon, item, move_slot)
-	if item == ITEM_PP_UP:
+	if (effects["pp_restore"] as Dictionary).has(item):
+		return _apply_pp_restore(data, mon, item, move_slot, effects)
+	if item == int(effects["pp_up"]):
 		## `ApplyPPUp` raises `PP_UP_MASK`, the top two bits of a move's own PP
 		## byte, which [Gen2SaveMon] does not keep: its `pp` is the current value
 		## alone and every `max_pp` in the game is the move's base. Building this
@@ -1896,11 +1898,12 @@ static func _apply_item_effect(
 	var evolution: Dictionary = _apply_item_evolution(data, mon, item)
 	if not evolution.is_empty():
 		return evolution
-	var vitamin: Dictionary = _apply_vitamin(data, mon, item)
+	var vitamin: Dictionary = _apply_vitamin(data, mon, item, effects["vitamin"])
 	if not vitamin.is_empty():
 		return vitamin
-	if REVIVE_ITEMS.has(item):
-		return _apply_revive(data, mon, item)
+	var revives: Dictionary = effects["revive"]
+	if revives.has(item):
+		return _apply_revive(data, mon, item, bool(revives[item]))
 	return _apply_heal(data, mon, definition, item)
 
 
@@ -1909,15 +1912,63 @@ const REPEL_STEPS: Dictionary = {
 	ITEM_REPEL: 100, ITEM_SUPER_REPEL: 200, ITEM_MAX_REPEL: 250,
 }
 ## `RevivePokemon`'s own `cp REVIVE / jr z, .revive_half_hp`: REVIVE is the only
-## half, so MAX_REVIVE and REVIVAL_HERB both reach `ReviveFullHP`.
-const REVIVE_ITEMS: Array[int] = [ITEM_REVIVE, ITEM_MAX_REVIVE, ITEM_REVIVAL_HERB]
+## half, so MAX_REVIVE and REVIVAL_HERB both reach `ReviveFullHP`. Generation 1
+## has the pair and no herb, and `.setCurrentHPToHalfMaxHP` is the same split.
+const REVIVE_ITEMS: Dictionary = {
+	ITEM_REVIVE: true, ITEM_MAX_REVIVE: false, ITEM_REVIVAL_HERB: false,
+}
+const GEN1_REVIVE_ITEMS: Dictionary = {
+	Gen1Layout.ITEM_REVIVE: true, Gen1Layout.ITEM_MAX_REVIVE: false,
+}
+
+## Every table `_apply_item_effect` branches on, by generation. The two
+## cartridges share no item number, so each branch reads through
+## [method item_effects]: Crystal's numbering on a Generation 1 map is what once
+## had Red's bag hold a Dire Hit the world reported as an Old Rod.
+const ITEM_EFFECT_TABLES: Dictionary = {
+	RomRegistry.GEN2: {
+		"repel": REPEL_STEPS,
+		"revive": REVIVE_ITEMS,
+		"vitamin": VITAMINS,
+		"pp_restore": PP_RESTORE_ITEMS,
+		"pp_max": PP_RESTORE_MAX_ITEMS,
+		"pp_steps": PP_RESTORE_STEPS,
+		"rare_candy": ITEM_RARE_CANDY,
+		"pp_up": ITEM_PP_UP,
+		"sacred_ash": Gen2WorldPack.ITEM_SACRED_ASH,
+	},
+	RomRegistry.GEN1: {
+		"repel": Gen1Layout.ITEM_REPEL_STEPS,
+		"revive": GEN1_REVIVE_ITEMS,
+		"vitamin": Gen1Layout.ITEM_VITAMINS,
+		"pp_restore": Gen1Layout.ITEM_PP_RESTORE,
+		"pp_max": Gen1Layout.ITEM_PP_RESTORE_MAX,
+		"pp_steps": Gen1Layout.ITEM_PP_RESTORE_STEPS,
+		"rare_candy": Gen1Layout.ITEM_RARE_CANDY,
+		"pp_up": Gen1Layout.ITEM_PP_UP,
+		## `SacredAshEffect` is Crystal's; nothing in Generation 1 revives a
+		## party, and item 0 is the empty bag slot.
+		"sacred_ash": 0,
+	},
+}
 
 
-static func _apply_revive(data: GameData, mon: Gen2SaveMon, item: int) -> Dictionary:
+## The row of [constant ITEM_EFFECT_TABLES] a cache reads through. Public so
+## `tools/checks/pack.gd` sweeps the same branches `_apply_item_effect` picks.
+static func item_effects(data: GameData) -> Dictionary:
+	return ITEM_EFFECT_TABLES[
+		RomRegistry.GEN1 if data != null and data.generation == RomRegistry.GEN1
+		else RomRegistry.GEN2
+	]
+
+
+static func _apply_revive(
+	data: GameData, mon: Gen2SaveMon, item: int, half: bool
+) -> Dictionary:
 	if mon.hp > 0:
 		return {"ok": false, "reason": &"item_has_no_effect"}
 	var max_hp: int = _max_hp(data, mon)
-	mon.hp = maxi(max_hp / 2, 1) if item == ITEM_REVIVE else max_hp
+	mon.hp = maxi(max_hp / 2, 1) if half else max_hp
 	return _with_bitterness(
 		data, mon, item, {"ok": true, "effect": &"revive", "healed": mon.hp}
 	)
@@ -2016,12 +2067,12 @@ static func _apply_rare_candy(
 ## other three need the slot `MoveSelectionScreen` chose. A move already at its
 ## ceiling is `.dont_restore`, and nothing restored is `WontHaveAnyEffectMessage`.
 static func _apply_pp_restore(
-	data: GameData, mon: Gen2SaveMon, item: int, move_slot: int
+	data: GameData, mon: Gen2SaveMon, item: int, move_slot: int, effects: Dictionary
 ) -> Dictionary:
-	var all_moves: bool = bool(PP_RESTORE_ITEMS[item])
+	var all_moves: bool = bool((effects["pp_restore"] as Dictionary)[item])
 	if not all_moves and (move_slot < 0 or move_slot >= Gen2SaveMon.MAX_MOVES):
 		return {"ok": false, "reason": &"move_slot_required", "item": item}
-	var full: bool = item in PP_RESTORE_MAX_ITEMS
+	var full: bool = item in (effects["pp_max"] as Array)
 	var restored: int = 0
 	for slot: int in Gen2SaveMon.MAX_MOVES:
 		if not all_moves and slot != move_slot:
@@ -2033,7 +2084,7 @@ static func _apply_pp_restore(
 		var current: int = int(mon.pp[slot])
 		if current >= maximum:
 			continue
-		var step: int = int(PP_RESTORE_STEPS.get(item, 0))
+		var step: int = int((effects["pp_steps"] as Dictionary).get(item, 0))
 		var next: int = maximum if full else mini(maximum, current + step)
 		restored += next - current
 		mon.pp[slot] = next
@@ -2047,10 +2098,12 @@ static func _apply_pp_restore(
 ## stats below it and nothing else, so an HP UP raises the maximum and heals
 ## nothing; here every one of those is derived from the stat experience, which
 ## leaves the raise and the happiness row as the whole effect.
-static func _apply_vitamin(data: GameData, mon: Gen2SaveMon, item: int) -> Dictionary:
-	if not VITAMINS.has(item):
+static func _apply_vitamin(
+	data: GameData, mon: Gen2SaveMon, item: int, vitamins: Dictionary
+) -> Dictionary:
+	if not vitamins.has(item):
 		return {}
-	var stat: String = VITAMINS[item]
+	var stat: String = vitamins[item]
 	var raised: int = int(mon.stat_exp.get(stat, 0))
 	if raised >= VITAMIN_CAP:
 		return {"ok": false, "reason": &"item_has_no_effect"}
@@ -2112,7 +2165,7 @@ static func _apply_sacred_ash(data: GameData, save: Gen2SaveData) -> Dictionary:
 static func _apply_item_evolution(data: GameData, mon: Gen2SaveMon, item: int) -> Dictionary:
 	var declared: Dictionary = data.item(item).get("evolution", {}) as Dictionary
 	var method: int = int(declared.get("method", 0))
-	if method == 0 and item not in Gen2Evolution.STONE_ITEMS:
+	if method == 0 and item not in Gen2Evolution.stone_items(data):
 		return {}
 	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(data, mon)
 	if battle_mon == null:

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -2321,6 +2321,13 @@ const GEN1_TOSS_TEXT: Dictionary = {
 const GEN1_ITEM_USE_TEXT: Dictionary = {
 	"not_time": "OAK: <PLAYER>!\nThis isn't the\ntime to use that!",
 }
+## `PartyMenuMessagePointers`' USE_ITEM_PARTY_MENU row, which every
+## `ItemUseMedicine` writes before `DisplayPartyMenu`.
+const GEN1_PARTY_MENU_TEXT: Dictionary = {
+	"item_use": "Use item on which\nPOKéMON?",
+}
+## `UnusableItem`, a `.Current` row with no effect at all.
+const GEN1_NUGGET: int = 0x31
 
 
 ## The fixture's items in Generation 1 shape: one bag pocket, nothing
@@ -2337,6 +2344,10 @@ func _open_gen1_world() -> void:
 			GEN1_POTION:
 				raw["name"] = "POTION"
 				raw["field_menu"] = Gen2WorldPack.ITEMMENU_PARTY
+				## `.addHealAmount`'s `ld b, 20` for a POTION.
+				raw["heal_amount"] = 15
+			GEN1_NUGGET:
+				raw["name"] = "NUGGET"
 			GEN1_BICYCLE:
 				raw["name"] = "BICYCLE"
 				raw["permissions"] = Gen2WorldPack.CANT_SELECT | Gen2WorldPack.CANT_TOSS
@@ -2349,13 +2360,14 @@ func _open_gen1_world() -> void:
 	var manifest: Dictionary = RomCache.read_manifest(Fixture.directory())
 	manifest["special_text"] = {
 		"toss": GEN1_TOSS_TEXT, "item_use": GEN1_ITEM_USE_TEXT,
+		"party_menu": GEN1_PARTY_MENU_TEXT,
 	}
 	RomCache.write_json(RomCache.manifest_path(Fixture.directory()), manifest)
 	_data = GameData.open_directory(Fixture.directory())
 	_data.generation = RomRegistry.GEN1
 	await _open_world()
 	_world_screen._world.state.apply_changes({}, {}, {"items": {
-		GEN1_BICYCLE: 1, GEN1_POTION: 3, GEN1_OLD_ROD: 1,
+		GEN1_BICYCLE: 1, GEN1_POTION: 3, GEN1_OLD_ROD: 1, GEN1_NUGGET: 1,
 	}})
 
 
@@ -2376,7 +2388,7 @@ func test_a_generation_1_bag_lists_one_pocket_and_offers_use_and_toss() -> void:
 	var host: Gen2StartMenuScreen = await _gen1_pack()
 	assert_eq((host.get("_pack_pockets") as Array).size(), 1)
 	var rows: Array = host.call("_current_pocket_items")
-	assert_eq(rows.size(), 4)
+	assert_eq(rows.size(), 5)
 	host.handle_button(PokeButton.A)
 	var actions: Array = []
 	for entry: Dictionary in host.get("_item_actions"):
@@ -2415,13 +2427,35 @@ func test_the_generation_1_bicycle_opens_no_submenu() -> void:
 	assert_ne(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_ITEM)
 
 
-## `.useItem_partyMenu` opens `DisplayPartyMenu`, which this port has no
-## Generation 1 screen for, so a USE that would reach it says `ItemUseNotTime`
-## rather than opening Generation 2's party list over a Generation 1 map.
+## `.useItem_partyMenu` opens `DisplayPartyMenu`, and `ItemUseMedicine` applies
+## to the row chosen there. The list has no CANCEL: `PartyMenuInit` stops at
+## `wPartyCount - 1` and B is the only way back out.
+func test_a_generation_1_use_opens_the_party_list_and_heals_the_row_chosen() -> void:
+	await _open_gen1_world()
+	var save: Gen2SaveData = _world_screen.get("_injected_save")
+	(save.party[0] as Gen2SaveMon).hp = maxi((save.party[0] as Gen2SaveMon).hp - 15, 1)
+	var before: int = (save.party[0] as Gen2SaveMon).hp
+	var host: Gen2StartMenuScreen = await _gen1_pack()
+	assert_true(bool(host.call("_select_pack_item", GEN1_POTION)))
+	_choose_action(host, Gen2WorldPack.ACTION_USE)
+	await get_tree().process_frame
+	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_TARGET)
+	assert_eq(int(host.call("_target_rows")), save.party.size())
+	assert_eq(String(host.call("_target_prompt")), GEN1_PARTY_MENU_TEXT["item_use"])
+	assert_eq((save.party[0] as Gen2SaveMon).hp, before, "nothing until a row is chosen")
+
+	host.handle_button(PokeButton.A)
+	await get_tree().process_frame
+	assert_eq((save.party[0] as Gen2SaveMon).hp, before + 15)
+	assert_eq(_world_screen._world.state.item_quantity(GEN1_POTION), 2)
+
+
+## `UseItem_`'s jumptable answers `.Oak` for every row with no effect out of a
+## battle, which is `ItemUseNotTime`'s own box.
 func test_a_generation_1_use_that_reaches_no_effect_says_oaks_line() -> void:
 	await _open_gen1_world()
 	var host: Gen2StartMenuScreen = await _gen1_pack()
-	assert_true(bool(host.call("_select_pack_item", GEN1_POTION)))
+	assert_true(bool(host.call("_select_pack_item", GEN1_NUGGET)))
 	_choose_action(host, Gen2WorldPack.ACTION_USE)
 	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)

--- a/tests/unit/test_save_screen.gd
+++ b/tests/unit/test_save_screen.gd
@@ -906,6 +906,53 @@ func test_the_move_screen_refuses_to_change_pokemon_while_a_move_is_held() -> vo
 	assert_eq(screen.cursor(), 1)
 
 
+## `PokemonMenuEntries` and `GetMonFieldMoves` in front of it: Generation 1's
+## submenu is the member's own field moves and then those three, with no MOVE
+## row and no ITEM row at all.
+func test_a_generation_1_member_is_offered_its_field_moves_stats_switch_and_cancel() -> void:
+	var gen1: GameData = Fixture.build(
+		RomCache.directory_for(&"gen1screentest", "0123456789abcdef"),
+		"testgame", RomRegistry.GEN1
+	)
+	var mon := Gen2SaveMon.new()
+	mon.species = Fixture.BULBASAUR
+	mon.moves = [
+		Gen2WorldFieldMove.MOVE_CUT, Fixture.TACKLE,
+		Gen2WorldFieldMove.MOVE_STRENGTH, 0,
+	]
+	var labels: Array = []
+	for row: Dictionary in Gen2PartyScreen.submenu_items_for(gen1, mon):
+		labels.append(String(row.get("label", "")))
+	assert_eq(labels.slice(2), ["STATS", "SWITCH", "CANCEL"])
+	assert_eq(labels.size(), 5)
+	RomCache.clear(RomCache.directory_for(&"gen1screentest", "0123456789abcdef"))
+
+
+## `DisplayFieldMoveMonMenu`: `hlcoord 11, 11` with no field move at all, and
+## every one after that raising the top two rows and widening the box to the
+## smallest `FieldMoveDisplayData` column its moves name. STRENGTH's is $0A.
+func test_the_generation_1_submenu_box_grows_with_the_field_moves_in_it() -> void:
+	var bare: Gen2MenuBox = Gen2PartyScreen.gen1_mon_menu_box([])
+	assert_eq(Vector2i(bare.left, bare.top), Vector2i(11, 11))
+	assert_eq(bare.item_position(0), Vector2i(13, 12))
+	assert_eq(bare.cursor_position(0), Vector2i(12, 12))
+
+	var cut: Gen2MenuBox = Gen2PartyScreen.gen1_mon_menu_box([
+		{"kind": &"field_move", "move": Gen2WorldFieldMove.MOVE_CUT},
+	])
+	assert_eq(Vector2i(cut.left, cut.top), Vector2i(11, 8))
+	assert_eq(cut.item_position(0), Vector2i(13, 10))
+
+	var strength: Gen2MenuBox = Gen2PartyScreen.gen1_mon_menu_box([
+		{"kind": &"field_move", "move": Gen2WorldFieldMove.MOVE_CUT},
+		{"kind": &"field_move", "move": Gen2WorldFieldMove.MOVE_STRENGTH},
+	])
+	assert_eq(Vector2i(strength.left, strength.top), Vector2i(9, 6))
+	assert_eq(strength.item_position(0), Vector2i(11, 8))
+	## Four rows of two, the last landing on the interior's own bottom row.
+	assert_eq(strength.item_position(4), Vector2i(11, 16))
+
+
 ## `ManagePokemonMoves`' own `cp EGG`, and `MonMenuOptions`' egg row set, which
 ## offers STATS and SWITCH and nothing else.
 func test_an_egg_is_offered_stats_and_switch_and_no_move_row() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 1108 lines of the 39699 here, and Generation 1 has added 903 more to the
-## shared battle, world, palette, text, save and renderer code, 150 of them the
-## battle animation engine and 140 the transition, the split effect routines and
-## `BlkPacket_Battle`. Eleven sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39699
+## are 1182 lines of the 39881 here, and Generation 1 has added 1000 more to the
+## shared battle, world, palette, text, save and renderer code: 150 the battle
+## animation engine, 140 the transition and the split effects, 85 the party
+## menu with its icons. Twelve sweeps found no restatement to pay with.
+const MAX_COMMENT_LINES: int = 39881
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,20 +130,24 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 198, "text": 199, "branch": 74, "choice": 7, "flag": 25,
-		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 36,
-		"pick_up_item": 104, "toggle_object": 4},
-	&"blue": {"rows": 198, "text": 199, "branch": 74, "choice": 7, "flag": 25,
-		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 36,
-		"pick_up_item": 104, "toggle_object": 4},
-	&"yellow": {"rows": 185, "text": 158, "branch": 66, "choice": 6, "flag": 15,
-		"give_item": 17, "has_item": 7, "take_item": 3, "unknown": 39,
-		"pick_up_item": 108, "toggle_object": 1},
+	&"red": {"rows": 204, "text": 206, "branch": 74, "choice": 7, "flag": 25,
+		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 34,
+		"pick_up_item": 104, "toggle_object": 5, "pokedex": 7, "give_pokemon": 1},
+	&"blue": {"rows": 204, "text": 206, "branch": 74, "choice": 7, "flag": 25,
+		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 34,
+		"pick_up_item": 104, "toggle_object": 5, "pokedex": 7, "give_pokemon": 1},
+	&"yellow": {"rows": 191, "text": 165, "branch": 66, "choice": 6, "flag": 15,
+		"give_item": 17, "has_item": 7, "take_item": 3, "unknown": 37,
+		"pick_up_item": 108, "toggle_object": 2, "pokedex": 7, "give_pokemon": 1},
 }
 ## Three `predef HideObject` rows reach no node: `MtMoonB2F`'s two fossils and
 ## `PokemonTower7F`'s Mr. Fuji each write `wCurMapScript` behind it, which is a
-## map script index and means nothing without an interpreter, and
-## `CeladonMansionRoofHouse`'s Eevee is a `GivePokemon`.
+## map script index and means nothing without an interpreter. The eighth
+## `call DisplayPokedex` in the source is `SilphCo11FPorygonText`, which no map
+## text row names and which the disassembly marks unreferenced. The other four
+## `call GivePokemon` rows are reached past machine code this decoder does not
+## read: the Fighting Dojo's two through `CheckEitherEventSet`, the Magikarp
+## salesman's through `HasEnoughMoney` and the Lapras through `wStatusFlags4`.
 
 ## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
 ## and how many start ON. Three rows name an object their map has not got.
@@ -336,7 +340,8 @@ func _texts() -> void:
 ## every box has to draw, and the ghost girl has to keep both her answers.
 func _scripts(font: Gen2Font) -> void:
 	var census: Dictionary = {"rows": 0, "text": 0, "branch": 0, "choice": 0,
-		"flag": 0, "give_item": 0, "has_item": 0, "take_item": 0, "unknown": 0}
+		"flag": 0, "give_item": 0, "has_item": 0, "take_item": 0, "unknown": 0,
+		"pokedex": 0, "give_pokemon": 0}
 	var wrong: Array[String] = []
 	for map: Gen2WorldMap in _maps.values():
 		for row: Dictionary in map.texts:

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -62,18 +62,23 @@ const PINNED_EFFECTS: Dictionary = {
 ## What `StartMenu_Item`'s three tables come to over the whole 250-row table:
 ## `KeyItemFlags`' own 31 rows with the five HMs behind `IsItemHM`, the Bicycle
 ## and `UsableItems_CloseMenu` quitting the menu, and `UsableItems_PartyMenu`
-## with all 55 machines opening the party list. Identical on all three.
+## with all 55 machines opening the party list. The 15 rows `UseItem` refuses
+## outside a battle answer in front of all three, four of them X stats that are
+## on the party list and never open it. Identical on all three cartridges.
 const KEY_ITEM_COUNT: int = 36
 const FIELD_MENU_CENSUS: Dictionary = {
+	Gen2Layout.ITEMMENU_NOUSE: 15,
 	Gen2Layout.ITEMMENU_CLOSE: 7,
-	Gen2Layout.ITEMMENU_PARTY: 91,
-	Gen2Layout.ITEMMENU_CURRENT: 152,
+	Gen2Layout.ITEMMENU_PARTY: 87,
+	Gen2Layout.ITEMMENU_CURRENT: 141,
 }
 ## One row of each shape: the item, its field menu and whether `IsKeyItem` says
 ## yes. The Town Map and the Poke Ball are both `call UseItem` rows, one of them
-## a key item and one not.
+## a key item and one not, and `ItemUseBall`'s own `ld a, [wIsInBattle]` is why
+## only one of the two does anything on a map.
 const PINNED_ITEM_ATTRIBUTES: Dictionary = {
-	0x04: [Gen2Layout.ITEMMENU_CURRENT, false],
+	0x04: [Gen2Layout.ITEMMENU_NOUSE, false],
+	0x41: [Gen2Layout.ITEMMENU_NOUSE, false],
 	0x05: [Gen2Layout.ITEMMENU_CURRENT, true],
 	0x06: [Gen2Layout.ITEMMENU_CLOSE, true],
 	0x14: [Gen2Layout.ITEMMENU_PARTY, false],
@@ -199,12 +204,18 @@ func _evolutions(name: String, evolutions: Array) -> void:
 	for row: Dictionary in evolutions:
 		var method: int = int(row["method"])
 		_r.check(Gen1Layout.EVOLVE_SIZES.has(method), "%s evolves by method %d" % [name, method])
-		var species: int = int(row["species"])
+		var species: int = int(row["target"])
 		_r.check(species >= 1 and species <= SPECIES_COUNT,
 			"%s evolves into species %d" % [name, species])
+		var parameter: int = int(row["parameter"])
 		if method == Gen1Layout.EVOLVE_ITEM:
-			var item: int = int(row["item"])
-			_r.check(item >= 1 and item <= ITEM_COUNT, "%s evolves with item %d" % [name, item])
+			_r.check(parameter >= 1 and parameter <= ITEM_COUNT,
+				"%s evolves with item %d" % [name, parameter])
+			_r.check(Gen1Layout.STONE_ITEMS.has(parameter),
+				"%s evolves with item %d, which is no stone" % [name, parameter])
+		elif method == Gen1Layout.EVOLVE_TRADE:
+			_r.check(parameter == Gen2Evolution.TRADE_NO_ITEM,
+				"%s trades holding item %d" % [name, parameter])
 
 
 func _moves() -> void:

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -146,6 +146,14 @@ const MUSEUM_AMBER_OBJECT: int = 4
 const OLD_AMBER: int = 0x1F
 const MUSEUM_GIFT_BOX: String = "Take this to a\nPOKéMON LAB"
 
+## `CeladonMansionRoofHouseEeveePokeballText`: `lb bc, EEVEE, 25` and the
+## `jr nc` behind `GivePokemon`, which hides the ball only when the gift landed.
+const EEVEE_HOUSE: int = 0x84
+const EEVEE_BALL_CELL := Vector2i(4, 3)
+const EEVEE_BALL_OBJECT: int = 1
+const EEVEE_DEX: int = 133
+const EEVEE_LEVEL: int = 25
+
 ## Yellow's `CeruleanBadgeHouse` melanie, the corpus's one box that owes no
 ## press: `DisableWaitingAfterTextDisplay` runs before her last `PrintText`.
 const MELANIE_MAP: int = 63
@@ -172,6 +180,7 @@ func _one_game() -> void:
 	_check_an_object_starts_hidden()
 	if _r.game_id != RomRegistry.YELLOW:
 		_check_a_script_hides_an_object()
+	_check_a_script_gives_a_pokemon()
 	_check_the_nurse_heals()
 	_check_the_cable_club()
 	_check_the_vending_machine()
@@ -495,6 +504,40 @@ func _check_a_script_hides_an_object() -> void:
 		"the museum scientist said %s." % [said])
 	_r.check(world.state.item_quantity(OLD_AMBER) == 1, "the OLD AMBER never landed.")
 	_r.check(not _object_active(world, MUSEUM_AMBER_OBJECT), "the OLD AMBER is still drawn.")
+
+
+## The corpus's one `call GivePokemon` a text row reaches: the request the world
+## raises, and the two sides of the caller's own `jr nc`. Both are walked on the
+## same map, since only the answer differs.
+func _check_a_script_gives_a_pokemon() -> void:
+	for accepted: bool in [true, false]:
+		var world: Gen2WorldAPI = _facing_up(EEVEE_HOUSE, EEVEE_BALL_CELL + Vector2i.DOWN)
+		if world == null:
+			return
+		var results: Array = world.interact()
+		var request: Dictionary = _runtime_request(results)
+		_r.check(
+			StringName(request.get("kind", &"")) == &"pokemon_requested"
+			and int((request.get("values", {}) as Dictionary).get("pokemon", 0)) == EEVEE_DEX
+			and int((request.get("values", {}) as Dictionary).get("level", 0)) == EEVEE_LEVEL,
+			"the EEVEE ball raised %s." % [request]
+		)
+		world.complete_runtime_request({"ok": true, "accepted": accepted})
+		_r.check(
+			_object_active(world, EEVEE_BALL_OBJECT) != accepted,
+			"the EEVEE ball is %sdrawn after a gift that was %saccepted." % [
+				"" if accepted else "still ", "" if accepted else "not ",
+			]
+		)
+
+
+## The request the first waiting result of [param results] carries, or empty.
+func _runtime_request(results: Array) -> Dictionary:
+	for row: Dictionary in results:
+		var event: Dictionary = row.get("event", {})
+		if StringName(event.get("type", &"")) == &"runtime_request":
+			return event.get("request", {})
+	return {}
 
 
 func _facing_up(map: int, cell: Vector2i) -> Gen2WorldAPI:

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -60,8 +60,10 @@ const REGISTERABLE_KEY_ITEMS: Dictionary = {
 const ITEM_ROWS: int = 255
 const NO_DEPOSIT_ROWS: Array[int] = [1, 2, 3]
 ## The TM and HM rows, whose ITEMMENU_PARTY nibble is `TeachTMHM` rather than an
-## `ItemEffects` entry.
+## `ItemEffects` entry. Generation 1 has fifty and five and no dummy row inside
+## them, and `StartMenu_Item`'s `cp HM01` is what sends all of them there.
 const TM_HM_PARTY_ROWS: int = 57
+const GEN1_TM_HM_PARTY_ROWS: int = Gen1Layout.TM_COUNT + Gen1Layout.HM_COUNT
 
 ## What fits between the text box's own borders: `Textbox`'s interior is 18
 ## columns and `PrintItemDescription` is handed the cell one in from the left.
@@ -80,9 +82,14 @@ func run(r: RefCounted) -> void:
 		_verify_field_effects(game_id, data)
 		_verify_deposit_rule(game_id, data)
 		_verify_key_item_effects(game_id, data)
-		_verify_party_item_effects(game_id, data)
+		_verify_party_item_effects(game_id, data, TM_HM_PARTY_ROWS)
 		_verify_screen(game_id, data)
 		_verify_descriptions(game_id, data)
+	## `UseItem`'s jumptable is the same three answers on Generation 1, and the
+	## pack that reads it is this one, so its `.Party` rows are swept here too.
+	_r.each_game_of(RomRegistry.GEN1, func() -> void:
+		_verify_party_item_effects(_r.game_id, _r.data, GEN1_TM_HM_PARTY_ROWS)
+	)
 
 
 ## `CheckSelectableItem` over the real rows. The eight named key items are the
@@ -248,7 +255,9 @@ func _verify_deposit_rule(game_id: StringName, data: GameData) -> void:
 ## `ItemEffects` over every ITEMMENU_PARTY row of a real cache. A row
 ## `_apply_item_effect` has no branch for answers "It won't have any effect"
 ## where the cartridge does something; MYSTERYBERRY was one.
-func _verify_party_item_effects(game_id: StringName, data: GameData) -> void:
+func _verify_party_item_effects(
+	game_id: StringName, data: GameData, machine_rows: int
+) -> void:
 	var unhandled: Array[String] = []
 	var covered: int = 0
 	var machines: int = 0
@@ -258,10 +267,10 @@ func _verify_party_item_effects(game_id: StringName, data: GameData) -> void:
 			continue
 		if Gen2WorldPack.field_use_kind(data, number) != Gen2WorldPack.ITEMMENU_PARTY:
 			continue
-		if int(definition.get("pocket", 0)) == Gen2WorldPack.TYPE_TM_HM:
+		if Gen2WorldTMHM.is_tm_hm(number, data.generation):
 			machines += 1
 			continue
-		if _party_effect_branch(number, definition):
+		if _party_effect_branch(number, definition, data):
 			covered += 1
 			continue
 		unhandled.append("$%02X (%s)" % [number, data.item_name(number)])
@@ -273,8 +282,8 @@ func _verify_party_item_effects(game_id: StringName, data: GameData) -> void:
 		]
 	)
 	_r.check(
-		machines == TM_HM_PARTY_ROWS,
-		"%s: %d TM/HM party rows, expected %d" % [game_id, machines, TM_HM_PARTY_ROWS]
+		machines == machine_rows,
+		"%s: %d TM/HM party rows, expected %d" % [game_id, machines, machine_rows]
 	)
 	print("%s: %d party-menu item effects, %d TM/HM rows beside them." % [
 		game_id, covered, machines,
@@ -282,17 +291,16 @@ func _verify_party_item_effects(game_id: StringName, data: GameData) -> void:
 
 
 ## The branches `_apply_item_effect` picks between, read off the host's own
-## tables, so a table that loses a row takes this check red with it.
-func _party_effect_branch(item: int, definition: Dictionary) -> bool:
-	if item == Gen2WorldPartyHost.ITEM_RARE_CANDY or item == Gen2WorldPartyHost.ITEM_PP_UP:
+## tables, so a table that loses a row takes this check red with it. Both
+## generations are swept through the same seam they run through.
+func _party_effect_branch(item: int, definition: Dictionary, data: GameData) -> bool:
+	var effects: Dictionary = Gen2WorldPartyHost.item_effects(data)
+	if item == int(effects["rare_candy"]) or item == int(effects["pp_up"]):
 		return true
-	if Gen2WorldPartyHost.PP_RESTORE_ITEMS.has(item):
-		return true
-	if Gen2WorldPartyHost.VITAMINS.has(item):
-		return true
-	if item in Gen2WorldPartyHost.REVIVE_ITEMS:
-		return true
-	if item in Gen2Evolution.STONE_ITEMS \
+	for key: String in ["pp_restore", "vitamin", "revive"]:
+		if (effects[key] as Dictionary).has(item):
+			return true
+	if item in Gen2Evolution.stone_items(data) \
 		or int((definition.get("evolution", {}) as Dictionary).get("method", 0)) != 0:
 		return true
 	return int(definition.get("heal_amount", 0)) > 0 \

--- a/tools/checks/party_icons.gd
+++ b/tools/checks/party_icons.gd
@@ -11,6 +11,24 @@ var _r: RefCounted = null
 ## range, that the first and last species are the shapes the source names, and that
 ## the three cartridges agree entry for entry.
 
+## Generation 1's own run: `MonPartyData` holds a nybble per dex number and the
+## cache stores it one higher, `ICON_MON` being zero. `MonPartySpritePointers`
+## loads a trade bubble beside the party shapes and no dex number names it, so
+## it is the one strip the table leaves out.
+const GEN1_SPECIES: int = Gen1Layout.SPECIES_COUNT
+const GEN1_TRADE_BUBBLE: int = 0x0E + 1
+## `data/pokemon/menu_icons.asm`'s ends: Bulbasaur is `ICON_GRASS` and Mew
+## `ICON_MON`. Pikachu is Yellow's own `ICON_PIKACHU`, the shape it added, where
+## Red and Blue draw it as `ICON_FAIRY`.
+const GEN1_BULBASAUR_ICON: int = 0x07 + 1
+const GEN1_MEW_ICON: int = 0x00 + 1
+const GEN1_PIKACHU: int = 25
+const GEN1_PIKACHU_ICON: int = 0x0A + 1
+const GEN1_FAIRY_ICON: int = 0x03 + 1
+## `constants/icon_constants.asm`'s run from `ICON_MON` to `ICON_QUADRUPED`,
+## every one of which a dex number names. Yellow's eleventh is Pikachu's own.
+const GEN1_SHAPES: int = 10
+
 ## `constants/icon_constants.asm`, the entries the census names.
 const ICON_BULBASAUR: int = 22
 const ICON_HUMANSHAPE: int = 14
@@ -28,6 +46,77 @@ func run(r: RefCounted) -> void:
 	_r = r
 	_first_table = PackedByteArray()
 	_r.each_game(_check_game)
+	_r.each_game_of(RomRegistry.GEN1, _check_gen1_game)
+
+
+## The same sweep on Generation 1, whose icons come out of
+## `MonPartySpritePointers` rather than one sheet.
+func _check_gen1_game() -> void:
+	var table: PackedByteArray = _r.data.mon_menu_icon_table()
+	if not _r.check(
+		table.size() == GEN1_SPECIES,
+		"MonPartyData holds %d entries, not %d." % [table.size(), GEN1_SPECIES]
+	):
+		return
+	_r.check(
+		_r.data.mon_menu_icon(1) == GEN1_BULBASAUR_ICON,
+		"BULBASAUR draws icon %d." % _r.data.mon_menu_icon(1)
+	)
+	_r.check(
+		_r.data.mon_menu_icon(GEN1_SPECIES) == GEN1_MEW_ICON,
+		"MEW draws icon %d." % _r.data.mon_menu_icon(GEN1_SPECIES)
+	)
+	var pikachu: int = GEN1_PIKACHU_ICON if _r.game_id == RomRegistry.YELLOW \
+		else GEN1_FAIRY_ICON
+	_r.check(
+		_r.data.mon_menu_icon(GEN1_PIKACHU) == pikachu,
+		"PIKACHU draws icon %d, not %d." % [
+			_r.data.mon_menu_icon(GEN1_PIKACHU), pikachu,
+		]
+	)
+	var used: Dictionary = {}
+	for dex: int in range(1, GEN1_SPECIES + 1):
+		used[_r.data.mon_menu_icon(dex)] = true
+	var lit: int = 0
+	for icon: int in used:
+		lit += _gen1_icon_pixels(int(icon))
+	## The trade bubble is loaded beside them and no party row names it, so it
+	## is checked here rather than left as the one strip nothing reads.
+	_gen1_icon_pixels(GEN1_TRADE_BUBBLE)
+	var shapes: int = GEN1_SHAPES + (1 if _r.game_id == RomRegistry.YELLOW else 0)
+	_r.check(
+		used.size() == shapes,
+		"%d of the %d shapes a party menu loads are used." % [used.size(), shapes]
+	)
+	_r.note("party icons: %d dex numbers over %d shapes, %d drawn pixels." % [
+		GEN1_SPECIES, used.size(), lit,
+	])
+
+
+## One Generation 1 shape: eight tiles, both frames drawn, and the two of them
+## different, which is what `AnimatePartyMon` swaps between.
+func _gen1_icon_pixels(icon: int) -> int:
+	var strip: PackedByteArray = _r.data.overworld_icon_indices(icon)
+	var frame: int = Gen1Layout.MON_ICON_FRAME_TILES * PokeTiles.TILE_WIDTH
+	if not _r.check(
+		strip.size() == Gen1Layout.MON_ICON_FRAME_TILES * 2 * PokeTiles.TILE_PIXELS,
+		"icon %d decoded %d pixels." % [icon, strip.size()]
+	):
+		return 0
+	var drawn: int = 0
+	var same: bool = true
+	for row: int in PokeTiles.TILE_HEIGHT:
+		for column: int in frame:
+			var first: int = strip[row * frame * 2 + column]
+			var second: int = strip[row * frame * 2 + frame + column]
+			drawn += (1 if first != 0 else 0) + (1 if second != 0 else 0)
+			same = same and first == second
+	_r.check(drawn > 0, "icon %d is blank." % icon)
+	## The ball and the helix share their two frames: `.editCoords` shakes them
+	## a pixel down instead of loading a second one.
+	if not Gen1Layout.MON_ICON_SHAKING.has(icon - 1):
+		_r.check(not same, "icon %d draws the same picture twice." % icon)
+	return drawn
 
 
 func _check_game() -> void:

--- a/tools/preview_pack.gd
+++ b/tools/preview_pack.gd
@@ -9,6 +9,8 @@ extends SceneTree
 
 const NEW_BARK_GROUP: int = 24
 const NEW_BARK_MAP: int = 7
+## Generation 1 names a map by one flat id, and Pallet Town is 0.
+const PALLET_TOWN: Vector2i = Vector2i(0, 0)
 
 const BUTTONS: Dictionary = {
 	"u": PokeButton.UP, "d": PokeButton.DOWN,
@@ -34,8 +36,15 @@ const ROUTES: Dictionary = {
 const ITEMS: Dictionary = {
 	1: 1, 4: 12, 5: 30,
 	17: 3, 18: 2, 19: 1, 20: 5, 21: 9, 22: 4,
-	7: 1, 70: 1,
+	0x07: 1, 70: 1,
 	0xBF: 1, 0xF3: 1,
+}
+## The same bag in `item_constants.asm`'s Generation 1 numbering, which shares
+## no number with the run above.
+const GEN1_ITEMS: Dictionary = {
+	0x14: 5, 0x0B: 2, 0x0C: 1, 0x0D: 1, 0x0F: 1,
+	0x10: 1, 0x35: 1, 0x0A: 1, 0x28: 2,
+	0x06: 1, 0x45: 1, 0xC9: 1,
 }
 
 
@@ -45,6 +54,20 @@ const ITEMS: Dictionary = {
 func _process(_delta: float) -> bool:
 	_capture()
 	return true
+
+
+## The bag each generation's own numbering fills, on the map its cartridge opens
+## on: Pallet Town is map 0 where New Bark Town is group 24's seventh.
+func _open_world(data: GameData, female: bool) -> Gen2WorldAPI:
+	var gen1: bool = data.generation == RomRegistry.GEN1
+	var at := PALLET_TOWN if gen1 else Vector2i(NEW_BARK_GROUP, NEW_BARK_MAP)
+	var world: Gen2WorldAPI = Gen2WorldAPI.open(
+		data, at.x, at.y, Vector2i.ZERO,
+		Gen2WorldState.new({}, {}, GEN1_ITEMS if gen1 else ITEMS, {})
+	)
+	if female:
+		world.set_player_gender(true)
+	return world
 
 
 func _capture() -> void:
@@ -70,13 +93,7 @@ func _capture() -> void:
 	if args.size() > 3 and not args[3].is_empty():
 		tokens = "%s,%s" % [tokens, args[3]] if not tokens.is_empty() else args[3]
 
-	var world: Gen2WorldAPI = Gen2WorldAPI.open(
-		data, NEW_BARK_GROUP, NEW_BARK_MAP, Vector2i.ZERO,
-		Gen2WorldState.new({}, {}, ITEMS, {})
-	)
-	if args.size() > 4 and args[4] == "female":
-		world.set_player_gender(true)
-
+	var world: Gen2WorldAPI = _open_world(data, args.size() > 4 and args[4] == "female")
 	var host := Gen2StartMenuScreen.new()
 	root.add_child(host)
 	## No slot on disk, so nothing this photographs is written anywhere.


### PR DESCRIPTION
`DisplayPartyMenu` is `Gen2PartyMenuPage`'s own Generation 1 layout: the nickname at `hlcoord 3, 0` with `PrintLevel` ten columns on and `PrintStatusCondition` fourteen, `DrawHPBar` and `DrawHP2`'s fraction a row below, `ErasePartyMenuCursors`' arrow beside the bar, `MESSAGE_BOX` under all six, and no CANCEL row: `PartyMenuInit` stops at `wPartyCount - 1` and B is the way out.

`Gen1WorldImporter` reads `MonPartySpritePointers` the way `LoadMonPartySpriteGfx` does and splits the strip back into each icon's two four-tile frames, with `MonPartyData`'s nybble per dex number naming one. `WriteSymmetricMonPartySpriteOAM` reads a frame's tiles 0 and 2 and draws each twice, X-flipping the second; only the helix reads all four. `AnimatePartyMon` is one counter for the whole menu at `PartyMonSpeeds`' pace, moving the chosen row alone, and the ball and the helix shake a pixel down where the rest change tile.

`ITEM_EFFECT_TABLES` is the seam every branch of `_apply_item_effect` reads through, because the two cartridges share no item number. `ItemUsePtrTable`'s fifteen battle-only rows answer NOUSE in the field, which keeps the four X stats off the party list `UsableItems_PartyMenu` puts them on.

An `EvosMoves` row had carried `species` and `item` where `GameData.evolutions` asks for `target` and `parameter`, so all 72 rows answered zero and nothing evolved at all.

## Added
- `DisplayPartyMenu` on Generation 1, with `PokemonMenuEntries`' submenu sized by `DisplayFieldMoveMonMenu` from the leftmost column the member's `FieldMoveDisplayData` moves name.
- `MonPartySpritePointers` and `MonPartyData` imported: 10 icon shapes on Red and Blue, 11 on Yellow, drawn in `PalPacket_PartyMenu`'s PAL_MEWMON through `GBPalNormal`'s `rOBP0`.
- `.addHealAmount`'s eight amounts and `.cureStatusAilment`'s seven masks on the item table, with the vitamins, the revives, the PP restores, RARE CANDY and PP UP read by role.
- `.Current`'s `ItemUsePokedex`, `ItemUseCoinCase` and `ItemUseOaksParcel`; everything else is `ItemUseNotTime`.
- `call DisplayPokedex` on 7 rows and `call GivePokemon` on Celadon Mansion's Eevee, whose carry is the `accepted` a `pokemon_requested` comes back with.
- `PartyMenuMessagePointers`' five prompts and `CoinCaseNumCoinsText` imported.
- `tools/checks/pack.gd` sweeps every `.Party` row of both generations for an effect branch; `party_icons.gd` sweeps every dex number's icon on all three cartridges.

## Fixed
- Every Generation 1 evolution: `_evolution_row` wrote keys no reader asks for.
- The four X stats opened Generation 2's party list over a Generation 1 map instead of `ItemUseNotTime`.
- The party page drew Crystal's `$6B` bar cap on a Generation 1 cache, where `DrawHPBar` writes `$6C`.
- `Gen2PartyScreen`'s prompts spelled POKéMON with the `#` only Crystal's charmap has a glyph for, so a Generation 1 font drew "?MON".