### PR TITLE
Use an item from the Generation 1 battle bag

### DIFF
--- a/game/battle/ai_items.gd
+++ b/game/battle/ai_items.gd
@@ -5,9 +5,9 @@ extends RefCounted
 ## `AI_TryItem` and the `EnemyUsed*` routines in `engine/battle/ai/items.asm`. A
 ## class carries at most two item numbers (`TRNATTR_ITEM1` and `_ITEM2`, already
 ## in the cache as [method GameData.trainer_attributes]) and its
-## `TRNATTR_AI_ITEM_SWITCH` word decides how freely they are spent. Only the enemy
-## has any of this: the player's pack has no X items and no in-battle healing
-## beyond what [Gen2HeldItem] does on its own.
+## `TRNATTR_AI_ITEM_SWITCH` word decides how freely they are spent. What the
+## player's own pack does with the same items is
+## [method Gen2Battle.use_bag_item]; nothing here is reached from it.
 
 ## The thirteen items the AI knows, at their cartridge numbers.
 const FULL_RESTORE: int = 0x0E

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -404,35 +404,11 @@ const ACTION_SWITCH: StringName = &"switch"
 ## `BattleMenu_Run` runs at menu time, so running is settled before the turn: a
 ## success ends the battle before either side moves and a refusal spends none.
 const ACTION_RUN: StringName = &"run"
-## `AI_TryItem`'s action. It costs the turn and lands before the player's move
-## whatever the speeds say, `AI_SwitchOrTryItem` setting `wEnemyGoesFirst`. Only
-## the enemy uses one; the player's pack is the overworld's.
+## `AI_TryItem`'s action, and `BATTLEPLAYERACTION_USEITEM` on the player's side.
+## The enemy's costs the turn and lands before the player's move whatever the
+## speeds say, `AI_SwitchOrTryItem` setting `wEnemyGoesFirst`; the player's is
+## banked once [method use_bag_item] has already applied the effect.
 const ACTION_ITEM: StringName = &"item"
-
-## The half of `ItemEffects` the cache does not carry: the two revives, the four
-## PP restorers and the doll. Everything else comes off the item's own
-## `status_mask` and `heal_amount`.
-const ITEM_POKE_DOLL: int = 0x25
-const ITEM_REVIVE: int = 0x27
-const ITEM_MAX_REVIVE: int = 0x28
-const ITEM_ETHER: int = 0x3F
-const ITEM_MAX_ETHER: int = 0x40
-const ITEM_ELIXER: int = 0x41
-const ITEM_MAX_ELIXER: int = 0x15
-const ITEM_MYSTERYBERRY: int = 0x96
-const REVIVE_ITEMS: Array[int] = [ITEM_REVIVE, ITEM_MAX_REVIVE]
-const PP_ITEMS: Array[int] = [
-	ITEM_ETHER, ITEM_MAX_ETHER, ITEM_ELIXER, ITEM_MAX_ELIXER, ITEM_MYSTERYBERRY,
-]
-## The three of them that fill one slot, which is what `.loop` asks about; the
-## two Elixers fill every slot and ask nothing.
-const SLOT_PP_ITEMS: Array[int] = [ITEM_ETHER, ITEM_MAX_ETHER, ITEM_MYSTERYBERRY]
-## `RestorePPEffect`'s own amounts: the Max pair fill the slot, and the other
-## three add five (`MYSTERYBERRY` and `ETHER` share it).
-const PP_ITEM_AMOUNTS: Dictionary = {
-	ITEM_ETHER: 10, ITEM_ELIXER: 10, ITEM_MYSTERYBERRY: 5,
-	ITEM_MAX_ETHER: 0, ITEM_MAX_ELIXER: 0,
-}
 
 ## `HandleBerserkGene`'s `BattleCommand_AttackUp2`, and the count it never
 ## writes: a zero byte decremented once is 255 more turns after this one.
@@ -2482,14 +2458,21 @@ func use_bag_item(item: int, target_index: int = -1, move_slot: int = -1) -> Dic
 	var definition: Dictionary = data.item(item)
 	if definition.is_empty():
 		return _item_failure(&"unknown_item")
-	if item == ITEM_POKE_DOLL:
-		## `PokeDollEffect`: `wForcedSwitch` and a DRAW, which is
-		## [method force_out] with nobody blown out by a move.
+	## `ItemUseNotTime`, which only a Generation 1 list ever reaches.
+	if int(definition.get("battle_menu", 0)) == Gen2Layout.ITEMMENU_NOUSE:
+		return _item_failure(&"item_not_usable_here")
+	var roles: Dictionary = Gen2WorldPartyHost.item_effects(data)
+	if item == int(roles["poke_doll"]):
+		## `PokeDollEffect` and `ItemUsePokeDoll` alike: `wForcedSwitch` and a
+		## DRAW, which is [method force_out] with nobody blown out by a move.
 		if is_trainer_battle:
 			return _item_failure(&"item_has_no_effect")
 		force_out(PLAYER)
 		return {"ok": true, "kind": &"fled", "item": item}
-	if Gen2AIItems.X_STATS.has(item) or Gen2AIItems.X_SUBSTATUSES.has(item):
+	if item == int(roles["poke_flute"]):
+		return _play_poke_flute(item)
+	if (roles["x_stat"] as Dictionary).has(item) \
+		or (roles["x_substatus"] as Dictionary).has(item):
 		var applied: Dictionary = _apply_active_item(mon(PLAYER), item)
 		if not bool(applied.get("ok", false)):
 			return _item_failure(StringName(applied.get("reason", &"item_has_no_effect")))
@@ -2512,19 +2495,42 @@ func use_bag_item(item: int, target_index: int = -1, move_slot: int = -1) -> Dic
 	}
 
 
+## `ItemUsePokeFlute`'s in-battle branch: everything asleep on the field and in
+## both parties wakes, `WakeUpEntireParty` reaching the enemy's party only in a
+## trainer battle. The turn is spent either way and the key item is not.
+func _play_poke_flute(item: int) -> Dictionary:
+	var woken: int = 0
+	for side: int in [PLAYER, ENEMY]:
+		if side == ENEMY and not is_trainer_battle:
+			woken += _wake_up(mon(ENEMY))
+			continue
+		for index: int in party(side).size():
+			woken += _wake_up(party(side).at(index))
+	return {"ok": true, "kind": &"poke_flute", "item": item, "woken": woken, "spent": false}
+
+
+func _wake_up(sleeper: Gen2BattleMon) -> int:
+	if sleeper == null or not Gen2Status.is_asleep(sleeper.status):
+		return 0
+	sleeper.status &= ~Gen2Status.SLEEP_MASK
+	return 1
+
+
 ## `XItemEffect`, `GuardSpecEffect` and `DireHitEffect`, on whoever is out rather
 ## than a party member, each refusing a capped stage or a set flag with
 ## `WontHaveAnyEffect_NotUsedMessage`.
 func _apply_active_item(user: Gen2BattleMon, item: int) -> Dictionary:
 	if user == null or user.is_fainted():
 		return {"ok": false, "reason": &"item_has_no_effect"}
-	if Gen2AIItems.X_SUBSTATUSES.has(item):
-		var flag: int = int(Gen2AIItems.X_SUBSTATUSES[item])
+	var roles: Dictionary = Gen2WorldPartyHost.item_effects(data)
+	var substatuses: Dictionary = roles["x_substatus"]
+	if substatuses.has(item):
+		var flag: int = int(substatuses[item])
 		if Gen2Substatus.has(user.substatus, flag):
 			return {"ok": false, "reason": &"item_has_no_effect"}
 		user.substatus |= flag
 		return {"ok": true, "substatus": flag}
-	var stat: String = String(Gen2AIItems.X_STATS[item])
+	var stat: String = String((roles["x_stat"] as Dictionary)[item])
 	if user.stage(stat) >= Gen2Stats.MAX_STAGE:
 		return {"ok": false, "reason": &"item_has_no_effect"}
 	user.change_stage(stat, 1)
@@ -2540,15 +2546,19 @@ func _apply_party_item(
 	target: Gen2BattleMon, item: int, definition: Dictionary,
 	move_slot: int, active: bool
 ) -> Dictionary:
-	if item in REVIVE_ITEMS:
+	var roles: Dictionary = Gen2WorldPartyHost.item_effects(data)
+	var revives: Dictionary = roles["revive"]
+	if revives.has(item):
 		if not target.is_fainted():
 			return {"ok": false, "reason": &"item_has_no_effect"}
-		target.hp = target.max_hp() if item == ITEM_MAX_REVIVE else maxi(target.max_hp() / 2, 1)
+		target.hp = maxi(target.max_hp() / 2, 1) if bool(revives[item]) else target.max_hp()
 		_faint_charged.erase(target.get_instance_id())
 		return {"ok": true, "revived": true, "healed": target.hp}
+	if item == int(roles["confusion_cure"]):
+		return _cure_confusion()
 	if target.is_fainted():
 		return {"ok": false, "reason": &"item_has_no_effect"}
-	if item in PP_ITEMS:
+	if (roles["pp_restore"] as Dictionary).has(item):
 		return _restore_pp(target, item, move_slot)
 	var healed: int = 0
 	var heal_amount: int = int(definition.get("heal_amount", 0))
@@ -2577,12 +2587,33 @@ func _apply_party_item(
 	}
 
 
+## `BitterBerryEffect` reads `wPlayerSubStatus3` rather than the row
+## `UseItem_SelectMon` chose, so whoever is out is unconfused whichever member
+## the list picked.
+func _cure_confusion() -> Dictionary:
+	var user: Gen2BattleMon = mon(PLAYER)
+	if user == null or not Gen2Substatus.has(user.substatus, Gen2Substatus.CONFUSED):
+		return {"ok": false, "reason": &"item_has_no_effect"}
+	user.substatus &= ~Gen2Substatus.CONFUSED
+	user.confusion_turns = 0
+	return {"ok": true, "unconfused": true}
+
+
+## Whether a PP item asks which slot to fill: the two Elixers fill every slot and
+## ask nothing. [method Gen2WorldPartyHost.item_effects] is what tells the two
+## cartridges' item numbers apart, here and in every branch around it.
+static func asks_for_move_slot(item_data: GameData, item: int) -> bool:
+	var rows: Dictionary = Gen2WorldPartyHost.item_effects(item_data)["pp_restore"]
+	return rows.has(item) and not bool(rows[item])
+
+
 ## `RestorePPEffect`: the Elixers fill every slot and the Ethers one, which is
 ## the slot `.loop` asks for. Nothing is spent on a moveset already full.
 func _restore_pp(target: Gen2BattleMon, item: int, move_slot: int) -> Dictionary:
-	var amount: int = PP_ITEM_AMOUNTS.get(item, 0)
+	var roles: Dictionary = Gen2WorldPartyHost.item_effects(data)
+	var amount: int = int((roles["pp_steps"] as Dictionary).get(item, 0))
 	var slots: Array[int] = []
-	if item in [ITEM_ELIXER, ITEM_MAX_ELIXER]:
+	if bool((roles["pp_restore"] as Dictionary)[item]):
 		for slot: int in target.moves.size():
 			slots.append(slot)
 	elif move_slot >= 0 and move_slot < target.moves.size():

--- a/game/battle/battle_menu.gd
+++ b/game/battle/battle_menu.gd
@@ -31,6 +31,9 @@ const MAIN_FLAGS: int = Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_D
 ## `.Text`, in its own order. `<PKMN>` is charmap's $4a, one byte the printer
 ## expands to those four letters, so the four tiles are what is written here.
 const MAIN_OPTIONS: Array[String] = ["FIGHT", "PKMN", "PACK", "RUN"]
+## `BattleMenuText`, the same box in the same order: the bag is spelled ITEM and
+## `<PK><MN>` is two narrow tiles where Crystal's one byte spells four letters.
+const GEN1_MAIN_OPTIONS: Array[String] = ["FIGHT", "<PKMN>", "ITEM", "RUN"]
 
 ## `MoveSelectionScreen`'s own `Textbox` rather than a menu header:
 ## `hlcoord 4, 17 - NUM_MOVES - 1` with `b, 4` and `c, 14`, its list placed from
@@ -99,13 +102,22 @@ static func main_box(contest: bool = false) -> Gen2MenuBox:
 	return box
 
 
-static func main_options(contest: bool = false) -> Array[String]:
-	return CONTEST_OPTIONS.duplicate() if contest else MAIN_OPTIONS.duplicate()
+static func main_options(
+	contest: bool = false, generation: int = RomRegistry.GEN2
+) -> Array[String]:
+	if contest:
+		return CONTEST_OPTIONS.duplicate()
+	return GEN1_MAIN_OPTIONS.duplicate() if generation == RomRegistry.GEN1 \
+		else MAIN_OPTIONS.duplicate()
 
 
-static func move_box() -> Gen2MenuBox:
+## `MoveSelectionMenu`, whose `.regularmenu` box is `hlcoord 4, 12` fourteen
+## wide and so is Crystal's. [param relearn] is `wMoveMenuType` 2, the one
+## `ItemUsePPRestore` opens six rows higher with no PP beside the names.
+static func move_box(relearn: bool = false) -> Gen2MenuBox:
 	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
-		MOVE_LEFT, MOVE_TOP, MOVE_RIGHT, MOVE_BOTTOM, MOVE_FLAGS
+		MOVE_LEFT, MOVE_TOP - (RELEARN_RISE if relearn else 0),
+		MOVE_RIGHT, MOVE_BOTTOM - (RELEARN_RISE if relearn else 0), MOVE_FLAGS
 	)
 	box.row_step = 1
 	return box
@@ -146,6 +158,9 @@ const LIST_RIGHT: int = 19
 const LIST_BOTTOM: int = 11
 const LIST_ROWS: int = 4
 const LIST_FLAGS: int = FORGET_FLAGS
+## How far `.relearnmenu` sits above `.regularmenu`: `hlcoord 4, 7` against
+## `hlcoord 4, 12`.
+const RELEARN_RISE: int = 5
 ## How many columns a row has, from [method Gen2MenuBox.text_start] to the frame
 ## on the right.
 const LIST_TEXT_WIDTH: int = LIST_RIGHT - LIST_LEFT - 2
@@ -170,9 +185,11 @@ static func list_box(scroll: int = 0, more: bool = false) -> Gen2MenuBox:
 
 ## `wMenuScrollPosition` after a cursor move: the window travels the least that
 ## keeps the cursor inside it, which is what `ScrollingMenu`'s own clamp does.
-static func list_scrolled(scroll: int, cursor: int, count: int) -> int:
-	var last: int = maxi(count - LIST_ROWS, 0)
-	return clampi(clampi(scroll, cursor - LIST_ROWS + 1, cursor), 0, last)
+static func list_scrolled(
+	scroll: int, cursor: int, count: int, rows: int = LIST_ROWS
+) -> int:
+	var last: int = maxi(count - rows, 0)
+	return clampi(clampi(scroll, cursor - rows + 1, cursor), 0, last)
 
 
 ## `_2DMenuInterpretJoypad` over the main menu's own two-by-two: a press that

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -502,6 +502,8 @@ var _box: Gen2TextBox = null
 ## `PlaceYesNoBox`'s frame over the field, or the whole party page in place of
 ## it, which is what `SetUpBattlePartyMenu` clearing the screen amounts to.
 var _menu_page: Gen2MenuPage = null
+## `DisplayListMenuID`'s box, which the shop and the START menu bag open too.
+var _mart_page: Gen2MartPage = null
 var _party_page: Gen2PartyMenuPage = null
 var _menu_layer: TextureRect = null
 ## What the layer currently holds, so a per-frame refresh redraws nothing.
@@ -2964,7 +2966,7 @@ func use_selected_pack_item() -> Dictionary:
 	if not _pack_selecting or _battle == null:
 		return {"ok": false, "reason": &"pack_not_open"}
 	var item: int = selected_pack_item()
-	if _data != null and int(_data.item(item).get("pocket", 0)) == Gen2WorldPack.TYPE_BALL:
+	if Gen2WorldPartyHost.is_ball(_data, item):
 		_pack_selecting = false
 		if not _is_wild_battle():
 			return _block_ball_in_trainer_battle(item)
@@ -3052,10 +3054,12 @@ func _use_pack_item(item: int, target: int, move_slot: int = -1) -> Dictionary:
 	if not bool(used.get("ok", false)):
 		## `.Field`'s battle twin: every refused effect is one line and the pack
 		## again, so nothing is spent and the turn is still the player's.
-		show_message("It won't have any effect.")
+		show_message(_item_refusal_text(StringName(used.get("reason", &""))))
 		_pack_selecting = true
 		return used
-	item_used.emit(item, target)
+	## `UseDisposableItem`, which the Poke Flute alone is never handed to.
+	if bool(used.get("spent", true)):
+		item_used.emit(item, target)
 	show_message(_item_used_text(item))
 	if _battle.is_over():
 		## `PokeDollEffect`'s `wForcedSwitch`: the battle is already over, so no
@@ -3369,6 +3373,23 @@ func _item_name(item: int) -> String:
 		return "BALL"
 	var item_name: String = _data.item_name(item)
 	return item_name if not item_name.is_empty() else "BALL %d" % item
+
+
+## `ItemUseNoEffectText`, and `ItemUseNotTimeText` for a row `ItemUsePtrTable`
+## refuses inside a battle, which only a Generation 1 list ever offers.
+func _item_refusal_text(reason: StringName) -> String:
+	if reason != &"item_not_usable_here":
+		return _gen1_item_text("no_effect", "It won't have any effect.")
+	return _gen1_item_text(
+		"not_time", "OAK: <PLAYER>!\nThis isn't the\ntime to use that!"
+	).replace(Gen2WorldPC.PLAYER_MARKER, _player_label())
+
+
+func _gen1_item_text(key: String, fallback: String) -> String:
+	if _data == null or _generation() != RomRegistry.GEN1:
+		return fallback
+	var text: String = _data.special_text("item_use_text", key)
+	return fallback if text.is_empty() else text
 
 
 ## `ItemUsedText`, the one line `PokeBallEffect` and every other battle item
@@ -4762,7 +4783,7 @@ func _commit_switch(index: int) -> void:
 		&"item":
 			## `StatusHealer_Jumptable`'s way back: the pack is where a used item
 			## leaves the player, and where a cancelled one does too.
-			if _pack_item in Gen2Battle.SLOT_PP_ITEMS:
+			if Gen2Battle.asks_for_move_slot(_data, _pack_item):
 				_open_pack_move(_pack_item, index)
 				return
 			_use_pack_item(_pack_item, index)
@@ -5051,7 +5072,7 @@ func _draw_battle_menu() -> void:
 	_show_layer_image(
 		_battle_menu_layer,
 		_menu_page.render(
-			box, Gen2BattleMenu.main_options(contest), _menu_position - 1,
+			box, Gen2BattleMenu.main_options(contest, _generation()), _menu_position - 1,
 			"", 0, extras
 		),
 		box.border_position() * Gen2Font.TILE
@@ -5076,14 +5097,22 @@ func _draw_move_menu() -> void:
 
 ## One of the lists standing in front of the fight, windowed onto
 ## [constant Gen2BattleMenu.LIST_ROWS] rows with the cursor kept inside it.
-func _draw_list_menu(key: StringName, labels: Array, cursor: int) -> void:
+func _draw_list_menu(key: StringName, rows: Array, cursor: int) -> void:
 	_menu_layer.visible = false
-	if _menu_page == null or labels.is_empty():
+	if _menu_page == null or rows.is_empty():
 		return
+	var gen1: bool = _generation() == RomRegistry.GEN1
+	var window: int = Gen2MartPage.GEN1_CURSOR_ROWS if gen1 else Gen2BattleMenu.LIST_ROWS
 	var scroll: int = Gen2BattleMenu.list_scrolled(
-		int(_list_scroll.get(key, 0)), cursor, labels.size()
+		int(_list_scroll.get(key, 0)), cursor, rows.size(), window
 	)
 	_list_scroll[key] = scroll
+	if gen1:
+		_draw_gen1_list_menu(rows, scroll, cursor)
+		return
+	var labels: Array = []
+	for row: Dictionary in rows:
+		labels.append(_list_row(String(row.get("name", "")), String(row.get("tail", ""))))
 	var box: Gen2MenuBox = Gen2BattleMenu.list_box(
 		scroll, labels.size() > Gen2BattleMenu.LIST_ROWS
 	)
@@ -5098,6 +5127,20 @@ func _draw_list_menu(key: StringName, labels: Array, cursor: int) -> void:
 	)
 
 
+## `DisplayListMenuID`'s `LIST_MENU_BOX`, the box the shop and the START menu bag
+## already draw: four names two rows apart over the fight, with `wMaxMenuItem`'s
+## own three cursor rows inside them.
+func _draw_gen1_list_menu(rows: Array, scroll: int, cursor: int) -> void:
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _mart_page == null:
+		return
+	_show_layer_image(_battle_menu_layer, _mart_page.render_gen1_pack({
+		"rows": rows.slice(scroll, scroll + Gen2MartPage.GEN1_LIST_HEIGHT),
+		"cursor": cursor - scroll,
+	}), Vector2i.ZERO)
+
+
 ## A row with [param tail] against the box's right-hand edge, which is where the
 ## pack writes a count and the move list a PP pair.
 static func _list_row(text: String, tail: String) -> String:
@@ -5107,21 +5150,23 @@ static func _list_row(text: String, tail: String) -> String:
 
 ## `Pack`'s own rows for the items a battle can use, with what is left of each.
 func _draw_pack_menu() -> void:
-	var labels: Array = []
+	var rows: Array = []
 	for item: int in _pack_rows:
-		labels.append(
-			_list_row(_item_name(item), "×%d" % int(_pack_quantities.get(item, 1)))
-		)
-	_draw_list_menu(&"pack", labels, _pack_index)
+		rows.append(_count_row(_item_name(item), int(_pack_quantities.get(item, 1))))
+	_draw_list_menu(&"pack", rows, _pack_index)
 
 
 ## The BALL pocket of the same list: what choosing a ball in the pack opens, and
 ## the whole of what a fight with no bag behind it is handed.
 func _draw_capture_menu() -> void:
-	var labels: Array = []
+	var rows: Array = []
 	for ball: int in _capture_balls:
-		labels.append(_list_row(_item_name(ball), "×%d" % _capture_quantity(ball)))
-	_draw_list_menu(&"capture", labels, _capture_ball_index)
+		rows.append(_count_row(_item_name(ball), _capture_quantity(ball)))
+	_draw_list_menu(&"capture", rows, _capture_ball_index)
+
+
+static func _count_row(item_name: String, quantity: int) -> Dictionary:
+	return {"name": item_name, "tail": "×%d" % quantity, "quantity": quantity}
 
 
 ## `ItemSubmenu`'s USE/QUIT box, which stands over the list the row was chosen
@@ -5153,14 +5198,30 @@ func _draw_pack_move_menu() -> void:
 	if mon == null or _data == null:
 		_menu_layer.visible = false
 		return
-	var labels: Array = []
+	## `.relearnmenu` prints the names alone, where `BattleMenu_Pack`'s own list
+	## carries the PP pair.
+	var gen1: bool = _generation() == RomRegistry.GEN1
+	var names: Array = []
 	for raw_slot: int in _pack_move_slots:
 		var record: Dictionary = _data.move(int(mon.moves[raw_slot]))
-		labels.append(_list_row(
+		names.append(String(record.get("name", "")) if gen1 else _list_row(
 			String(record.get("name", "")),
 			"%2d/%2d" % [mon.pp_left(raw_slot), int(record.get("pp", 0))]
 		))
-	_draw_list_menu(&"pack_move", labels, _pack_move_index)
+	if not gen1:
+		_draw_list_menu(
+			&"pack_move",
+			names.map(func(text: String) -> Dictionary: return {"name": text, "tail": ""}),
+			_pack_move_index
+		)
+		return
+	_menu_layer.visible = false
+	var box: Gen2MenuBox = Gen2BattleMenu.move_box(true)
+	_show_layer_image(
+		_battle_menu_layer,
+		_menu_page.render(box, names, _pack_move_index),
+		box.border_position() * Gen2Font.TILE
+	)
 
 
 ## `ForgetMove`'s own frame over the field, or the `YesNoBox` of the two

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -1093,6 +1093,7 @@ func _import_items(rom: RomFile, layout: Dictionary) -> Array:
 			"pocket": Gen1Layout.BAG_POCKET,
 			"permissions": _item_permissions(rom, layout, item),
 			"field_menu": _item_field_menu(item, party_use, close_use),
+			"battle_menu": Gen1Layout.item_battle_menu(item),
 		}
 		## `ItemUseMedicine` branches on the item number rather than reading a
 		## table, so the two amounts are `Gen1Layout`'s and land the same way.

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -295,12 +295,16 @@ const ANIM_ID_SHAKE_SCREEN: int = 0xC7
 const ANIM_ID_HIDEPIC: int = 0xC8
 
 ## `ItemUsePtrTable`'s five `ItemUseBall` rows, which `TossBallAnimation` also
-## picks a throw off.
+## picks a throw off; [constant BALL_ITEMS] gathers them in ball pocket order.
 const ITEM_MASTER_BALL: int = 0x01
 const ITEM_ULTRA_BALL: int = 0x02
 const ITEM_GREAT_BALL: int = 0x03
 const ITEM_POKE_BALL: int = 0x04
 const ITEM_SAFARI_BALL: int = 0x08
+const BALL_ITEMS: Array[int] = [
+	ITEM_POKE_BALL, ITEM_GREAT_BALL, ITEM_ULTRA_BALL, ITEM_MASTER_BALL,
+	ITEM_SAFARI_BALL,
+]
 
 ## The other `ItemUsePtrTable` rows the pack reaches, by `item_constants.asm`'s
 ## own numbering, which is not Crystal's anywhere.
@@ -321,6 +325,20 @@ const ITEM_PP_UP: int = 0x4F
 const ITEM_OLD_ROD: int = 0x4C
 const ITEM_GOOD_ROD: int = 0x4D
 const ITEM_SUPER_ROD: int = 0x4E
+const ITEM_POKE_DOLL: int = 0x33
+const ITEM_POKE_FLUTE: int = 0x49
+
+## `ItemUseXStat`'s `sub X_ATTACK - ATTACK_UP1_EFFECT`, in the move effects' own
+## stat order, with `SPECIAL_STAGE_TWIN` carrying X SPECIAL's other half, and
+## then the three that `set` a bit of `wPlayerBattleStatus2` instead.
+const ITEM_X_STATS: Dictionary = {
+	0x41: "attack", 0x42: "defense", 0x43: "speed", 0x44: "sp_attack",
+}
+const ITEM_X_SUBSTATUSES: Dictionary = {
+	0x2E: Gen2Substatus.X_ACCURACY,
+	0x37: Gen2Substatus.MIST,
+	0x3A: Gen2Substatus.FOCUS_ENERGY,
+}
 
 ## `ItemUseEvoStone`'s five rows of `ItemUsePtrTable`. Crystal numbers its own
 ## six differently, and [method Gen2Evolution.stone_items] is the one seam that
@@ -383,6 +401,21 @@ const BALL_STATUS_ADD: Array[int] = [5, 10]
 ## `.setAnimData`'s ladder over Z: under ten the ball misses, and each threshold
 ## passed is one more rock.
 const BALL_SHAKE_THRESHOLDS: Array[int] = [10, 30, 70]
+
+
+## `ItemUsePtrTable`'s own answer inside a battle, as the nibble [Gen2WorldPack]
+## branches on: `ItemUseMedicine` and `ItemUsePPRestore` open the party list, the
+## balls, X items, Poke Doll and Poke Flute are spent on whoever is out, and
+## every other row jumps to `ItemUseNotTime` there.
+static func item_battle_menu(item: int) -> int:
+	if item in BALL_ITEMS or ITEM_X_STATS.has(item) or ITEM_X_SUBSTATUSES.has(item) \
+		or item == ITEM_POKE_DOLL or item == ITEM_POKE_FLUTE:
+		return Gen2Layout.ITEMMENU_CLOSE
+	if ITEM_HEAL_AMOUNTS.has(item) or ITEM_STATUS_MASKS.has(item) \
+		or ITEM_PP_RESTORE.has(item) or item == ITEM_REVIVE or item == ITEM_MAX_REVIVE:
+		return Gen2Layout.ITEMMENU_PARTY
+	return Gen2Layout.ITEMMENU_NOUSE
+
 
 ## What pins the two sheets: the edge under both panels is two solid rows in
 ## the middle of six blank ones, and the empty bar is a rule top and bottom.
@@ -657,12 +690,21 @@ const SCRIPT_LD_A_MEM: int = 0xFA
 const SCRIPT_LD_MEM_A: int = 0xEA
 const SCRIPT_LDH_MEM_A: int = 0xE0
 const SCRIPT_AND_A: int = 0xA7
+const SCRIPT_AND_N: int = 0xE6
+const SCRIPT_LD_C: int = 0x0E
+const SCRIPT_LD_B_A: int = 0x47
 const SCRIPT_PREFIX: int = 0xCB
 const SCRIPT_JR: int = 0x18
 const SCRIPT_JP: int = 0xC3
 const SCRIPT_RET: int = 0xC9
 const SCRIPT_CALL: int = 0xCD
 const SCRIPT_HRAM_BASE: int = 0xFF00
+## `wGameProgressFlags`' own run of `w<Map>CurScript` bytes, 122 on all three
+## cartridges. A store there or to `wCurMapScript` names a map script index, and
+## this port has no interpreter to hand one to.
+const MAP_SCRIPT_BYTES: int = 0x7A
+## How deep a `call` to a routine the layout does not name may nest.
+const SCRIPT_CALL_DEPTH: int = 2
 ## Each key is a conditional `jr` or `jp`, the value whether it is taken when
 ## the tested bit was set; the carry rows read the flag a routine answers in.
 const SCRIPT_BRANCHES: Dictionary = {0x20: true, 0xC2: true, 0x28: false, 0xCA: false}
@@ -921,6 +963,9 @@ const RED_BLUE: Dictionary = {
 	"current_menu_item": 0xCC26,
 	"item_to_remove": 0xFFDB,
 	"toggleable_index": 0xCC4D,
+	"cur_party_species": 0xCF91,
+	"cur_map_script": 0xDA39,
+	"map_scripts": 0xD5F0,
 	## `Predef` and the table it indexes, with the three rows read through it.
 	"predef": 0x3E6D,
 	"predef_pointers": 0x4FE79,
@@ -1030,6 +1075,9 @@ const YELLOW: Dictionary = {
 	"current_menu_item": 0xCC26,
 	"item_to_remove": 0xFFDB,
 	"toggleable_index": 0xCC4D,
+	"cur_party_species": 0xCF90,
+	"cur_map_script": 0xDA38,
+	"map_scripts": 0xD5EF,
 	"predef": 0x3EB4,
 	"predef_pointers": 0xF681D,
 	"hide_object": 0x0F053,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -971,7 +971,10 @@ static func decode_script(
 	rom: RomFile, layout: Dictionary, bank: int, at: int
 ) -> Array:
 	var walked: Variant = _walk_script(
-		{"rom": rom, "layout": layout, "bank": bank, "budget": [SCRIPT_BUDGET]},
+		{
+			"rom": rom, "layout": layout, "bank": bank,
+			"budget": [SCRIPT_BUDGET], "calls": [0],
+		},
 		at, {}, 0
 	)
 	return walked as Array if walked is Array else []
@@ -1027,13 +1030,20 @@ static func _script_step(
 		Gen1Layout.SCRIPT_LD_B:
 			state["b"] = rom.u8(at + 1)
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+		Gen1Layout.SCRIPT_LD_C:
+			state["c"] = rom.u8(at + 1)
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+		Gen1Layout.SCRIPT_LD_B_A:
+			if not state.has("a"):
+				return SCRIPT_UNREAD
+			state["b"] = int(state["a"])
+			return pc + 1
 		Gen1Layout.SCRIPT_LD_A:
 			state["a"] = rom.u8(at + 1)
 			state.erase("source")
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_LD_A_MEM:
-			state["source"] = rom.u16le(at + 1)
-			state.erase("a")
+			_script_loaded(ctx, rom.u16le(at + 1), state)
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
 		Gen1Layout.SCRIPT_LD_MEM_A:
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE \
@@ -1045,14 +1055,16 @@ static func _script_step(
 		Gen1Layout.SCRIPT_AND_A:
 			state["tests"] = _script_tests(ctx, state, -1)
 			return pc + 1
+		Gen1Layout.SCRIPT_AND_N:
+			## `CheckEitherEventSet`, whose two flags share a byte and a mask.
+			state["tests"] = _script_mask(ctx, state, rom.u8(at + 1))
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_PREFIX:
 			return _script_prefix(ctx, pc, state, out)
 		Gen1Layout.SCRIPT_JR:
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE + _script_hop(rom.u8(at + 1))
 		Gen1Layout.SCRIPT_JP:
-			return SCRIPT_END if rom.u16le(at + 1) == int(
-				(ctx["layout"] as Dictionary)["text_script_end"]
-			) else SCRIPT_UNREAD
+			return _script_jump(ctx, pc, rom.u16le(at + 1), state, out)
 		Gen1Layout.SCRIPT_RET:
 			return SCRIPT_END
 		Gen1Layout.SCRIPT_CALL:
@@ -1064,9 +1076,55 @@ static func _script_hop(operand: int) -> int:
 	return operand - 0x100 if operand > 0x7F else operand
 
 
-## `DisableWaitingAfterTextDisplay` by hand, and `RemoveItemByID`'s own item.
+## `ld a, [nn]`. `ShowPokedexDataInternal` leaves `wPokedexNum` in
+## `wCurPartySpecies`, which the Fighting Dojo's two gifts read the species from.
+static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> void:
+	state["source"] = address
+	state.erase("a")
+	if address == int((ctx["layout"] as Dictionary)["cur_party_species"]) \
+		and state.has("species_index"):
+		state["a"] = int(state["species_index"])
+
+
+## `jp` reaching `TextScriptEnd`, a routine the layout names, or an address in
+## the same bank. A tail call returns where the row's own `ret` would.
+static func _script_jump(
+	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array
+) -> int:
+	var layout: Dictionary = ctx["layout"]
+	if target == int(layout["text_script_end"]):
+		return SCRIPT_END
+	if _script_routine(layout, target).is_empty():
+		return target
+	return SCRIPT_END if _script_call(ctx, pc, target, state, out) != SCRIPT_UNREAD \
+		else SCRIPT_UNREAD
+
+
+## Which flags `and n` is asking about: the bits of the byte `ld a, [wEventFlags
+## + n]` just read, which is what `CheckEitherEventSet` compiles to.
+static func _script_mask(ctx: Dictionary, state: Dictionary, mask: int) -> Variant:
+	var flags: Array[int] = []
+	for bit: int in 8:
+		if mask & (1 << bit) == 0:
+			continue
+		var flag: int = _script_flag(ctx, int(state.get("source", -1)), bit)
+		if flag < 0:
+			return SCRIPT_TESTS_NOTHING
+		flags.append(flag)
+	if flags.is_empty():
+		return SCRIPT_TESTS_NOTHING
+	return flags
+
+
+## `DisableWaitingAfterTextDisplay` by hand, `RemoveItemByID`'s own item, and
+## the map script index a row leaves behind it, which this port has no
+## interpreter to hand to and so stores nowhere.
 static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> bool:
 	var layout: Dictionary = ctx["layout"]
+	var scripts: int = int(layout["map_scripts"])
+	if address == int(layout["cur_map_script"]) \
+		or (address >= scripts and address < scripts + Gen1Layout.MAP_SCRIPT_BYTES):
+		return true
 	if address == int(layout["do_not_wait"]):
 		if int(state.get("a", 0)) != 1:
 			return false
@@ -1165,7 +1223,36 @@ static func _script_call(
 			return _script_gift_pokemon(ctx, state, out, next)
 		"play_cry", "wait_for_sound":
 			return next
-	return SCRIPT_UNREAD
+	return _script_local_call(ctx, target, state, out, next)
+
+
+## A `call` to a routine the layout does not name, which is the map's own:
+## walked here and returned from. `MtMoonB2FReceivedFossilText` is an `ld hl` and
+## a tail `jp PrintText`, so a fossil says nothing without this.
+static func _script_local_call(
+	ctx: Dictionary, target: int, state: Dictionary, out: Array, next: int
+) -> int:
+	var nesting: Array = ctx["calls"]
+	if nesting[0] >= Gen1Layout.SCRIPT_CALL_DEPTH:
+		return SCRIPT_UNREAD
+	nesting[0] += 1
+	var pc: int = target
+	var budget: Array = ctx["budget"]
+	var answer: int = SCRIPT_UNREAD
+	while budget[0] > 0:
+		budget[0] -= 1
+		var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
+		## A branch inside one would need a return address per side.
+		if Gen1Layout.SCRIPT_BRANCHES.has(op) or Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op):
+			break
+		pc = _script_step(ctx, pc, state, out)
+		if pc == SCRIPT_UNREAD:
+			break
+		if pc == SCRIPT_END:
+			answer = next
+			break
+	nesting[0] -= 1
+	return answer
 
 
 static func _script_routine(layout: Dictionary, target: int) -> String:
@@ -1187,6 +1274,7 @@ static func _script_pokedex(
 	if dex < 1:
 		return SCRIPT_UNREAD
 	out.append({"op": "pokedex", "species": dex})
+	state["species_index"] = int(state["a"])
 	state.erase("a")
 	return next
 
@@ -1284,9 +1372,12 @@ static func _script_box(ctx: Dictionary, pointer: int) -> Dictionary:
 static func _script_branch(
 	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
 ) -> Variant:
-	var tests: int = int(state.get("tests", SCRIPT_TESTS_NOTHING))
+	var tests: Variant = state.get("tests", SCRIPT_TESTS_NOTHING)
 	var carry: bool = Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op)
-	if tests == SCRIPT_TESTS_NOTHING or carry != (tests == SCRIPT_TESTS_CARRY):
+	if tests is Array:
+		if carry:
+			return null
+	elif int(tests) == SCRIPT_TESTS_NOTHING or carry != (int(tests) == SCRIPT_TESTS_CARRY):
 		return null
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
@@ -1314,11 +1405,14 @@ static func _script_branch(
 ## NO. Every other test reads the other way about: the taken side is the set
 ## one, a set carry or an item the bag holds.
 static func _script_node(
-	tests: int, branches: Array, state: Dictionary, out: Array
+	tests: Variant, branches: Array, state: Dictionary, out: Array
 ) -> Variant:
 	var taken: Array = branches[0] if branches[0] != null else [{"op": "unknown"}]
 	var fell: Array = branches[1] if branches[1] != null else [{"op": "unknown"}]
-	match tests:
+	if tests is Array:
+		return {"op": "branch", "flag": int((tests as Array)[0]),
+			"either": (tests as Array).slice(1), "then": taken, "else": fell}
+	match int(tests):
 		SCRIPT_TESTS_CHOICE:
 			return {"op": "choice", "no": taken, "yes": fell}
 		SCRIPT_TESTS_CARRY:
@@ -1326,7 +1420,7 @@ static func _script_node(
 		SCRIPT_TESTS_ITEM:
 			return {"op": "has_item", "item": int(state["asked"]),
 				"then": taken, "else": fell}
-	return {"op": "branch", "flag": tests, "then": taken, "else": fell}
+	return {"op": "branch", "flag": int(tests), "then": taken, "else": fell}
 
 
 ## The carry belongs to the gift in front of it, so both sides fold onto it.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 114
+const FORMAT_VERSION: int = 115
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -2174,14 +2174,19 @@ func _coins() -> int:
 ## own line breaks are kept: these boxes are the hardware's now, and a break is
 ## where the cartridge ended the row.
 func _pack_text(key: String) -> String:
+	var text: String = ""
 	if _gen1_pack():
 		var run: Array = GEN1_PACK_TEXTS.get(key, [])
-		return "" if run.is_empty() \
-			else _data.special_text(String(run[0]), String(run[1]))
-	var text: String = _data.menu_text(key) if _data != null else ""
-	if text.is_empty():
-		text = String(TEXT_FALLBACKS.get(key, ""))
-	return text
+		if not run.is_empty():
+			text = _data.special_text(String(run[0]), String(run[1]))
+	else:
+		text = _data.menu_text(key) if _data != null else ""
+		if text.is_empty():
+			text = String(TEXT_FALLBACKS.get(key, ""))
+	return text.replace(
+		Gen2WorldPC.PLAYER_MARKER,
+		_pack_save.player_name if _pack_save != null else ""
+	)
 
 
 ## `Pack_GetItemName` fills wStringBuffer2 and the dial owns wItemQuantityChange,

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3769,9 +3769,7 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 					"set": bool(node["set"]),
 				})
 			"branch":
-				if not _gen1_resolve_side(
-					node, event_flag_active(int(node["flag"])), steps, run
-				):
+				if not _gen1_resolve_side(node, _gen1_branch_set(node), steps, run):
 					return false
 			"has_item":
 				if not _gen1_resolve_side(
@@ -3807,6 +3805,17 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 			_:
 				return false
 	return true
+
+
+## `CheckEvent`'s one flag, or `CheckEitherEventSet`'s mask over the flags of
+## one `wEventFlags` byte, which is set when any of them is.
+func _gen1_branch_set(node: Dictionary) -> bool:
+	if event_flag_active(int(node["flag"])):
+		return true
+	for flag: int in node.get("either", []):
+		if event_flag_active(flag):
+			return true
+	return false
 
 
 func _gen1_resolve_side(

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -429,16 +429,18 @@ const GEN1_FIELD_EFFECTS: Dictionary = {
 
 ## The bag rows `BattlePack` can offer, in the pack's own pocket order: every
 ## owned item whose battle nibble is not ITEMMENU_NOUSE. The balls are in it,
-## because the pack is where a throw is chosen from too.
+## because the pack is where a throw is chosen from too. `DisplayPlayerBag` hands
+## `wNumBagItems` over whole instead, and `ItemUseNotTime` refuses a row there.
 static func battle_items(data: GameData, state: Gen2WorldState) -> Array[int]:
 	var out: Array[int] = []
 	if data == null or state == null:
 		return out
+	var whole: bool = data.generation == RomRegistry.GEN1
 	for pocket: Dictionary in build(data, state):
 		var numbers: Array = pocket.get("items", [])
 		for row: Dictionary in numbers:
 			var item: int = int(row.get("item", 0))
-			if int(data.item(item).get("battle_menu", 0)) != ITEMMENU_NOUSE:
+			if whole or int(data.item(item).get("battle_menu", 0)) != ITEMMENU_NOUSE:
 				out.append(item)
 	return out
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -40,6 +40,8 @@ const ITEM_POTION: int = 0x12
 const ITEM_REVIVE: int = 0x27
 const ITEM_MAX_REVIVE: int = 0x28
 const ITEM_REVIVAL_HERB: int = 0x7C
+## `PokeDollEffect`, the one battle row that is neither a heal nor a stage.
+const ITEM_POKE_DOLL: int = 0x25
 const ITEM_REPEL: int = 0x14
 const ITEM_SUPER_REPEL: int = 0x2A
 const ITEM_MAX_REPEL: int = 0x2B
@@ -134,6 +136,8 @@ const PP_RESTORE_ITEMS: Dictionary = {
 }
 const PP_RESTORE_MAX_ITEMS: Array[int] = [ITEM_MAX_ETHER, ITEM_MAX_ELIXER]
 
+## `BitterBerryEffect`, the one battle row whose whole effect is a substatus.
+const ITEM_BITTER_BERRY: int = 0x53
 const ITEM_BERRY: int = 0xAD
 const ITEM_BERRY_JUICE: int = 0x8B
 const SHUCKLE: int = 0xD5
@@ -189,14 +193,7 @@ const CAPTURE_BALLS: Array[int] = [
 	ITEM_FRIEND_BALL, ITEM_MOON_BALL, ITEM_LOVE_BALL,
 ]
 
-## `ItemUsePtrTable`'s own rows, whose numbering is not Crystal's: POKE_BALL is
-## 4 there and 5 here, and SAFARI_BALL is reachable where Crystal's number for it
-## collides with MOON_STONE.
-const GEN1_CAPTURE_BALLS: Array[int] = [
-	Gen1Layout.ITEM_POKE_BALL, Gen1Layout.ITEM_GREAT_BALL,
-	Gen1Layout.ITEM_ULTRA_BALL, Gen1Layout.ITEM_MASTER_BALL,
-	Gen1Layout.ITEM_SAFARI_BALL,
-]
+const GEN1_CAPTURE_BALLS: Array[int] = Gen1Layout.BALL_ITEMS
 
 ## `HeavyBallMultiplier.WeightsTable`: the high byte of the converted weight the
 ## row applies below, and what it adds to the catch rate there. The `.lightmon`
@@ -241,6 +238,16 @@ const WOBBLE_PROBABILITIES: Array = [
 static func capture_ball_items(generation: int = RomRegistry.GEN2) -> Array[int]:
 	return GEN1_CAPTURE_BALLS.duplicate() if generation == RomRegistry.GEN1 \
 		else CAPTURE_BALLS.duplicate()
+
+
+## Whether a pack row is thrown rather than used: `ItemAttributes`' BALL type,
+## or `ItemUsePtrTable`'s five rows on a bag with no type byte to read.
+static func is_ball(data: GameData, item: int) -> bool:
+	if data == null:
+		return false
+	if _generation(data) == RomRegistry.GEN1:
+		return item in GEN1_CAPTURE_BALLS
+	return Gen2WorldPack.pocket_for(data, item) == Gen2WorldPack.TYPE_BALL
 
 
 ## Returns owned supported balls without making the battle scene aware of world
@@ -1936,6 +1943,13 @@ const ITEM_EFFECT_TABLES: Dictionary = {
 		"rare_candy": ITEM_RARE_CANDY,
 		"pp_up": ITEM_PP_UP,
 		"sacred_ash": Gen2WorldPack.ITEM_SACRED_ASH,
+		"ball": CAPTURE_BALLS,
+		"x_stat": Gen2AIItems.X_STATS,
+		"x_substatus": Gen2AIItems.X_SUBSTATUSES,
+		"poke_doll": ITEM_POKE_DOLL,
+		## Crystal has no flute row a battle reaches; 0 is the empty bag slot.
+		"poke_flute": 0,
+		"confusion_cure": ITEM_BITTER_BERRY,
 	},
 	RomRegistry.GEN1: {
 		"repel": Gen1Layout.ITEM_REPEL_STEPS,
@@ -1949,6 +1963,14 @@ const ITEM_EFFECT_TABLES: Dictionary = {
 		## `SacredAshEffect` is Crystal's; nothing in Generation 1 revives a
 		## party, and item 0 is the empty bag slot.
 		"sacred_ash": 0,
+		"ball": GEN1_CAPTURE_BALLS,
+		"x_stat": Gen1Layout.ITEM_X_STATS,
+		"x_substatus": Gen1Layout.ITEM_X_SUBSTATUSES,
+		"poke_doll": Gen1Layout.ITEM_POKE_DOLL,
+		"poke_flute": Gen1Layout.ITEM_POKE_FLUTE,
+		## Nothing in Generation 1 cures confusion: `.cureStatusAilment` reads
+		## the status byte, and confusion is not in it.
+		"confusion_cure": 0,
 	},
 }
 

--- a/tests/integration/test_world_start_menu_screen.gd
+++ b/tests/integration/test_world_start_menu_screen.gd
@@ -2451,7 +2451,7 @@ func test_a_generation_1_use_opens_the_party_list_and_heals_the_row_chosen() -> 
 
 
 ## `UseItem_`'s jumptable answers `.Oak` for every row with no effect out of a
-## battle, which is `ItemUseNotTime`'s own box.
+## battle, which is `ItemUseNotTime`'s own box, with `wPlayerName` in it.
 func test_a_generation_1_use_that_reaches_no_effect_says_oaks_line() -> void:
 	await _open_gen1_world()
 	var host: Gen2StartMenuScreen = await _gen1_pack()
@@ -2460,7 +2460,10 @@ func test_a_generation_1_use_that_reaches_no_effect_says_oaks_line() -> void:
 	await get_tree().process_frame
 	assert_eq(host.get("_mode"), Gen2StartMenuScreen.Mode.PACK_RESULT)
 	assert_eq(
-		String(host.get("_pack_result")), String(GEN1_ITEM_USE_TEXT["not_time"])
+		String(host.get("_pack_result")),
+		String(GEN1_ITEM_USE_TEXT["not_time"]).replace(
+			Gen2WorldPC.PLAYER_MARKER, (host.get("_pack_save") as Gen2SaveData).player_name
+		)
 	)
 
 

--- a/tests/unit/battle_fixture.gd
+++ b/tests/unit/battle_fixture.gd
@@ -328,6 +328,8 @@ const ETHER: int = 0x3F
 const ELIXER: int = 0x41
 const POKE_BALL: int = 0x05
 const BATTLE_ITEMS: Dictionary = {
+	## Held below too: `BitterBerryEffect` is the only row that is both.
+	BITTER_BERRY: {"battle_menu": 5, "pocket": 1},
 	POTION: {
 		"name": "POTION", "battle_menu": 5, "pocket": 1, "heal_amount": 20,
 		"description": "Restores HP by 20.",

--- a/tests/unit/test_battle.gd
+++ b/tests/unit/test_battle.gd
@@ -3055,6 +3055,31 @@ func test_an_x_item_raises_the_stage_once_and_then_has_no_effect() -> void:
 	)
 
 
+## `BitterBerryEffect` reads `wPlayerSubStatus3`, so the row the party list chose
+## is not the one unconfused: whoever is out is, and nothing else in the bag
+## touches confusion at all.
+func test_a_bitter_berry_unconfuses_whoever_is_out() -> void:
+	var battle: Gen2Battle = Gen2Battle.create_parties(
+		_data,
+		Gen2Party.create([
+			_mon(Fixture.PIKACHU, 20, [Fixture.TACKLE]),
+			_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE]),
+		]),
+		Gen2Party.of(_mon(Fixture.GEODUDE, 20, [Fixture.TACKLE])),
+		_rng
+	)
+	assert_eq(
+		StringName(battle.use_bag_item(Fixture.BITTER_BERRY, 0)["reason"]),
+		&"item_has_no_effect", "nothing is confused yet"
+	)
+	var out: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+	out.substatus |= Gen2Substatus.CONFUSED
+	out.confusion_turns = 3
+	assert_true(bool(battle.use_bag_item(Fixture.BITTER_BERRY, 1).get("ok", false)))
+	assert_false(Gen2Substatus.has(out.substatus, Gen2Substatus.CONFUSED))
+	assert_eq(out.confusion_turns, 0)
+
+
 ## `PokeDollEffect`: a wild battle ends as a DRAW the moment it is used, and a
 ## trainer battle leaves `wItemEffectSucceeded` clear.
 func test_a_poke_doll_ends_a_wild_battle_and_does_nothing_to_a_trainer() -> void:

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -23,6 +23,9 @@ const LAYOUT: Dictionary = {
 	"remove_item_bank": 0x05,
 	"item_to_remove": 0xFFDB,
 	"toggleable_index": 0xCC4D,
+	"cur_party_species": 0xCF91,
+	"cur_map_script": 0xDA39,
+	"map_scripts": 0xD5F0,
 	"predef": 0x01A0,
 	"predef_pointers": 0x0300,
 	"hide_object": 0x0210,
@@ -133,6 +136,55 @@ func test_an_event_branch_keeps_the_flag_and_both_sides() -> void:
 		"then": [{"op": "text", "text": "HI"}],
 		"else": [{"op": "text", "text": "BYE"}],
 	}])
+
+
+## `CheckEitherEventSet`: one `ld a, [wEventFlags + n]` and an `and` whose mask
+## names both flags, so the byte answers for the pair at once.
+func test_either_of_two_flags_in_one_byte_is_one_branch() -> void:
+	var address: int = int(LAYOUT["event_flags"]) + 4
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		[Gen1Layout.SCRIPT_LD_A_MEM, address & 0xFF, address >> 8,
+			Gen1Layout.SCRIPT_AND_N, 0b01000010]
+			+ [0x20, clear.size()] + clear
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "branch", "flag": 33, "either": [38],
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "text", "text": "BYE"}],
+	}])
+
+
+## A `call` to a routine the layout does not name is the map's own:
+## `MtMoonB2FReceivedFossilText` is an `ld hl` and a tail `jp PrintText`.
+func test_a_call_to_the_maps_own_routine_is_walked_and_returned_from() -> void:
+	var routine: int = AT + 0x40
+	var program: Array = _call(routine) + _print(BYE) \
+		+ _call(int(LAYOUT["text_script_end"]))
+	while program.size() < 0x40:
+		program.append(0)
+	program.append_array(
+		_load_hl(HELLO) + [Gen1Layout.SCRIPT_JP,
+			LAYOUT["print_text"] & 0xFF, int(LAYOUT["print_text"]) >> 8]
+	)
+	assert_eq(_decode(program, _boxes()), [
+		{"op": "text", "text": "HI"}, {"op": "text", "text": "BYE"},
+	])
+
+
+## The map script index a row leaves behind it. Nothing here interprets one, so
+## the write is walked past rather than ending the path.
+func test_a_map_script_write_is_walked_past() -> void:
+	var index: int = int(LAYOUT["map_scripts"]) + 0x17
+	var script: Array = _decode(
+		[Gen1Layout.SCRIPT_LD_A, 3, Gen1Layout.SCRIPT_LD_MEM_A,
+			index & 0xFF, index >> 8]
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{"op": "text", "text": "HI"}])
 
 
 func test_a_branch_side_this_decoder_cannot_read_is_marked_rather_than_dropped() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 1182 lines of the 39881 here, and Generation 1 has added 1000 more to the
+## are 1215 lines of the 39953 here, and Generation 1 has added 1050 more to the
 ## shared battle, world, palette, text, save and renderer code: 150 the battle
-## animation engine, 140 the transition and the split effects, 85 the party
-## menu with its icons. Twelve sweeps found no restatement to pay with.
-const MAX_COMMENT_LINES: int = 39881
+## animation engine, 140 the transition and the split effects, 85 the party menu
+## and 40 the bag inside a battle. Thirteen sweeps found nothing to pay with.
+const MAX_COMMENT_LINES: int = 39953
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_pack.gd
+++ b/tests/unit/test_world_pack.gd
@@ -504,6 +504,28 @@ func test_a_generation_1_field_effect_reads_its_own_item_numbers() -> void:
 	)
 
 
+## `BattlePack` filters on the battle nibble, where `DisplayPlayerBag` hands
+## `wNumBagItems` over whole and lets `ItemUseNotTime` refuse a row.
+func test_a_generation_1_battle_list_keeps_the_rows_the_bag_would_refuse() -> void:
+	var owned: Dictionary = {ITEM_POTION: 1, ITEM_UNCLASSIFIED: 1}
+	var state := Gen2WorldState.new({}, {}, owned)
+	var items: Array = RomCache.read_json(RomCache.items_path(Fixture.directory()))
+	for raw: Dictionary in items:
+		match int(raw.get("number", 0)):
+			ITEM_POTION:
+				raw["battle_menu"] = Gen2WorldPack.ITEMMENU_PARTY
+			ITEM_UNCLASSIFIED:
+				raw["pocket"] = Gen2WorldPack.TYPE_ITEM
+	RomCache.write_json(RomCache.items_path(Fixture.directory()), items)
+	var data: GameData = GameData.open_directory(Fixture.directory())
+	assert_eq(Gen2WorldPack.battle_items(data, state), [ITEM_POTION] as Array[int])
+	data.generation = RomRegistry.GEN1
+	assert_eq(
+		Gen2WorldPack.battle_items(data, state),
+		[ITEM_POTION, ITEM_UNCLASSIFIED] as Array[int]
+	)
+
+
 ## `PrintListMenuEntries` prints four names and `IsKeyItem` decides which of them
 ## carry a count, where `ScrollingMenu_UpdateDisplay` writes five and asks
 ## `_CheckTossableItem` for the same thing.

--- a/tests/unit/test_world_party_host.gd
+++ b/tests/unit/test_world_party_host.gd
@@ -1355,6 +1355,17 @@ func test_generation_one_offers_the_cartridges_own_ball_numbers() -> void:
 	)
 
 
+## The pack asks the same question in a battle, where a ball is thrown and every
+## other row is used: `ItemAttributes`' type byte, or `ItemUsePtrTable`'s rows on
+## a bag whose every entry carries the item type.
+func test_which_pack_rows_are_thrown_reads_the_generation() -> void:
+	assert_true(Gen2WorldPartyHost.is_ball(_data, 0x05), "POKE_BALL is a Crystal ball")
+	assert_false(Gen2WorldPartyHost.is_ball(_data, 0x08), "and 8 is a MOON STONE row")
+	_data.generation = RomRegistry.GEN1
+	assert_true(Gen2WorldPartyHost.is_ball(_data, 0x08), "8 is the SAFARI BALL there")
+	assert_false(Gen2WorldPartyHost.is_ball(_data, 0x05), "and 5 is the TOWN MAP")
+
+
 ## `ItemUseBall` has one bag rather than four pockets, so nothing an item row
 ## says about a pocket may refuse a Generation 1 throw. The seam is what
 ## `ItemUsePtrTable` says instead, and the cache carries no pocket at all.

--- a/tools/checks/gen1_battle.gd
+++ b/tools/checks/gen1_battle.gd
@@ -66,6 +66,7 @@ func _one_game() -> void:
 	_the_trap_counter_distribution()
 	_conversion_copies_the_target()
 	_teleport_ends_the_battle()
+	_the_bag_in_a_fight()
 
 
 ## `AddPartyMon`'s four base moves and `WriteMonMoves` over them, for every
@@ -333,3 +334,98 @@ func _teleport_ends_the_battle() -> void:
 		for event: Dictionary in events:
 			failed = failed or StringName(event.get("type", &"")) == Gen2Battle.MOVE_FAILED
 		_r.check(failed, "move %d said nothing against a trainer" % move)
+
+
+## `UseItem` from `DisplayPlayerBag`'s own list, at the cartridge's item numbers:
+## a heal, a status cure, a revive, the two kinds of X item, the doll, the flute,
+## and a row `ItemUsePtrTable` refuses inside a battle.
+const BAG_POTION: int = 0x14
+const BAG_ANTIDOTE: int = 0x0B
+const BAG_REVIVE: int = 0x35
+const BAG_X_ATTACK: int = 0x41
+const BAG_X_SPECIAL: int = 0x44
+const BAG_DIRE_HIT: int = 0x3A
+const BAG_POKE_DOLL: int = 0x33
+const BAG_POKE_FLUTE: int = 0x49
+const BAG_TOWN_MAP: int = 0x05
+
+
+func _the_bag_in_a_fight() -> void:
+	var battle: Gen2Battle = _bag_battle()
+	var member: Gen2BattleMon = battle.party(Gen2Battle.PLAYER).at(1)
+	member.hp = 1
+	member.status = Gen2Status.POISON
+	_bag_check(battle.use_bag_item(BAG_POTION, 1), "POTION")
+	_r.check(member.hp == 21, "a POTION left %d HP, not 21" % member.hp)
+	_bag_check(battle.use_bag_item(BAG_ANTIDOTE, 1), "ANTIDOTE")
+	_r.check(member.status == Gen2Status.NONE, "an ANTIDOTE left status %d" % member.status)
+	member.hp = 0
+	_bag_check(battle.use_bag_item(BAG_REVIVE, 1), "REVIVE")
+	_r.check(member.hp > 0, "a REVIVE left the member fainted")
+
+	var out: Gen2BattleMon = battle.mon(Gen2Battle.PLAYER)
+	_bag_check(battle.use_bag_item(BAG_X_ATTACK), "X ATTACK")
+	_r.check(out.stage("attack") == 1, "X ATTACK left attack at %d" % out.stage("attack"))
+	## One stage byte for the one Special stat, which is what the twin carries.
+	_bag_check(battle.use_bag_item(BAG_X_SPECIAL), "X SPECIAL")
+	_r.check(
+		out.stage("sp_attack") == 1 and out.stage("sp_defense") == 1,
+		"X SPECIAL left %d and %d" % [out.stage("sp_attack"), out.stage("sp_defense")]
+	)
+	_bag_check(battle.use_bag_item(BAG_DIRE_HIT), "DIRE HIT")
+	_r.check(
+		Gen2Substatus.has(out.substatus, Gen2Substatus.FOCUS_ENERGY),
+		"DIRE HIT set no focus energy"
+	)
+	_r.check(
+		StringName(battle.use_bag_item(BAG_TOWN_MAP).get("reason", &"")) \
+			== &"item_not_usable_here",
+		"a TOWN MAP is not refused with ItemUseNotTime"
+	)
+
+	out.status = Gen2Status.SLEEP_MASK
+	battle.party(Gen2Battle.PLAYER).at(1).status = Gen2Status.SLEEP_MASK
+	var flute: Dictionary = battle.use_bag_item(BAG_POKE_FLUTE)
+	_bag_check(flute, "POKE FLUTE")
+	_r.check(int(flute.get("woken", 0)) == 2, "the flute woke %d" % int(flute.get("woken", 0)))
+	_r.check(not bool(flute.get("spent", true)), "the flute was spent")
+
+	_r.check(
+		StringName(_bag_battle(true).use_bag_item(BAG_POKE_DOLL).get("reason", &"")) \
+			== &"item_has_no_effect",
+		"a POKE DOLL is not refused in a trainer battle"
+	)
+	var wild: Gen2Battle = _bag_battle()
+	_bag_check(wild.use_bag_item(BAG_POKE_DOLL), "POKE DOLL")
+	_r.check(wild.is_over(), "a POKE DOLL did not end the wild battle")
+	_r.note("gen1 battle bag: 9 rows used, refused or spent as the table says")
+
+
+func _bag_check(result: Dictionary, name: String) -> void:
+	_r.check(bool(result.get("ok", false)), "%s was refused: %s" % [
+		name, String(result.get("reason", &""))
+	])
+
+
+## Two party members so a benched row can be healed, revived and woken.
+func _bag_battle(trainer: bool = false) -> Gen2Battle:
+	var generator := RandomNumberGenerator.new()
+	generator.seed = SWEEP_SEED
+	return Gen2Battle.create_parties(
+		_r.data,
+		Gen2Party.create([
+			Gen2BattleMon.create(
+				_r.data, SWEEP_PLAYER, SWEEP_LEVEL,
+				_r.data.moves_at_level(SWEEP_PLAYER, SWEEP_LEVEL)
+			),
+			Gen2BattleMon.create(
+				_r.data, SWEEP_ENEMY, SWEEP_LEVEL,
+				_r.data.moves_at_level(SWEEP_ENEMY, SWEEP_LEVEL)
+			),
+		]),
+		Gen2Party.of(Gen2BattleMon.create(
+			_r.data, SWEEP_ENEMY, SWEEP_LEVEL,
+			_r.data.moves_at_level(SWEEP_ENEMY, SWEEP_LEVEL)
+		)),
+		generator, trainer
+	)

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,24 +130,21 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 204, "text": 206, "branch": 74, "choice": 7, "flag": 25,
-		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 34,
-		"pick_up_item": 104, "toggle_object": 5, "pokedex": 7, "give_pokemon": 1},
-	&"blue": {"rows": 204, "text": 206, "branch": 74, "choice": 7, "flag": 25,
-		"give_item": 22, "has_item": 7, "take_item": 3, "unknown": 34,
-		"pick_up_item": 104, "toggle_object": 5, "pokedex": 7, "give_pokemon": 1},
-	&"yellow": {"rows": 191, "text": 165, "branch": 66, "choice": 6, "flag": 15,
-		"give_item": 17, "has_item": 7, "take_item": 3, "unknown": 37,
-		"pick_up_item": 108, "toggle_object": 2, "pokedex": 7, "give_pokemon": 1},
+	&"red": {"rows": 211, "text": 224, "branch": 78, "choice": 10, "flag": 33,
+		"give_item": 22, "has_item": 9, "take_item": 3, "unknown": 32,
+		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 3},
+	&"blue": {"rows": 211, "text": 224, "branch": 78, "choice": 10, "flag": 33,
+		"give_item": 22, "has_item": 9, "take_item": 3, "unknown": 32,
+		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 3},
+	&"yellow": {"rows": 197, "text": 179, "branch": 70, "choice": 8, "flag": 23,
+		"give_item": 17, "has_item": 9, "take_item": 3, "unknown": 35,
+		"pick_up_item": 108, "toggle_object": 9, "pokedex": 9, "give_pokemon": 3},
 }
-## Three `predef HideObject` rows reach no node: `MtMoonB2F`'s two fossils and
-## `PokemonTower7F`'s Mr. Fuji each write `wCurMapScript` behind it, which is a
-## map script index and means nothing without an interpreter. The eighth
-## `call DisplayPokedex` in the source is `SilphCo11FPorygonText`, which no map
-## text row names and which the disassembly marks unreferenced. The other four
-## `call GivePokemon` rows are reached past machine code this decoder does not
-## read: the Fighting Dojo's two through `CheckEitherEventSet`, the Magikarp
-## salesman's through `HasEnoughMoney` and the Lapras through `wStatusFlags4`.
+## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
+## which no map text row names and which the disassembly marks unreferenced. Two
+## `call GivePokemon` rows are still reached past machine code this decoder does
+## not read: the Magikarp salesman's through `HasEnoughMoney` and the Lapras
+## through `wStatusFlags4`.
 
 ## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
 ## and how many start ON. Three rows name an object their map has not got.

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -154,6 +154,18 @@ const EEVEE_BALL_OBJECT: int = 1
 const EEVEE_DEX: int = 133
 const EEVEE_LEVEL: int = 25
 
+## `FightingDojoHitmonleePokeBallText`, whose `CheckEitherEventSet` reads both
+## gift flags out of one `wEventFlags` byte: `DisplayPokedex` and the YES/NO
+## behind it are only reached while neither is set. Identical on all three
+## cartridges, objects and event indices alike.
+const FIGHTING_DOJO: int = 0xB1
+const HITMONLEE_BALL_CELL := Vector2i(4, 1)
+const HITMONLEE_BALL_OBJECT: int = 5
+const HITMONLEE_DEX: int = 106
+const HITMONLEE_LEVEL: int = 30
+const GOT_HITMONCHAN_FLAG: int = 855
+const DOJO_GREEDY_BOX: String = "better not get"
+
 ## Yellow's `CeruleanBadgeHouse` melanie, the corpus's one box that owes no
 ## press: `DisableWaitingAfterTextDisplay` runs before her last `PrintText`.
 const MELANIE_MAP: int = 63
@@ -181,6 +193,7 @@ func _one_game() -> void:
 	if _r.game_id != RomRegistry.YELLOW:
 		_check_a_script_hides_an_object()
 	_check_a_script_gives_a_pokemon()
+	_check_either_event_set()
 	_check_the_nurse_heals()
 	_check_the_cable_club()
 	_check_the_vending_machine()
@@ -529,6 +542,33 @@ func _check_a_script_gives_a_pokemon() -> void:
 				"" if accepted else "still ", "" if accepted else "not ",
 			]
 		)
+
+
+## `CheckEitherEventSet`'s two flags, one `wEventFlags` byte and one mask: the
+## ball opens its Pokedex page and its question while neither is set, and the
+## greedy line once the other ball has been taken.
+func _check_either_event_set() -> void:
+	var world: Gen2WorldAPI = _facing_up(
+		FIGHTING_DOJO, HITMONLEE_BALL_CELL + Vector2i.DOWN
+	)
+	if world == null:
+		return
+	var results: Array = world.interact()
+	var request: Dictionary = _runtime_request(results)
+	_r.check(
+		StringName(request.get("kind", &"")) == &"pokedex_entry_requested"
+		and int((request.get("values", {}) as Dictionary).get("species", 0)) == HITMONLEE_DEX,
+		"the HITMONLEE ball raised %s." % [request]
+	)
+	world = _facing_up(FIGHTING_DOJO, HITMONLEE_BALL_CELL + Vector2i.DOWN)
+	if world == null:
+		return
+	world.state.set_event_flag(GOT_HITMONCHAN_FLAG, true)
+	_r.check(
+		"\n".join(_spoken(world)).to_lower().contains(DOJO_GREEDY_BOX),
+		"the taken ball said %s." % [_spoken(world)]
+	)
+	_r.note("gen1 walk the FIGHTING DOJO ball reads both gift flags at once")
 
 
 ## The request the first waiting result of [param results] carries, or empty.

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -65,6 +65,10 @@ const NO_DEPOSIT_ROWS: Array[int] = [1, 2, 3]
 const TM_HM_PARTY_ROWS: int = 57
 const GEN1_TM_HM_PARTY_ROWS: int = Gen1Layout.TM_COUNT + Gen1Layout.HM_COUNT
 
+## How many rows carry a battle nibble at all, which is what `BattlePack` offers
+## on Generation 2 and what `UseItem` answers for on Generation 1.
+const BATTLE_ITEM_ROWS: Dictionary = {RomRegistry.GEN2: 57, RomRegistry.GEN1: 34}
+
 ## What fits between the text box's own borders: `Textbox`'s interior is 18
 ## columns and `PrintItemDescription` is handed the cell one in from the left.
 const DESCRIPTION_COLUMNS: int = 18
@@ -83,12 +87,14 @@ func run(r: RefCounted) -> void:
 		_verify_deposit_rule(game_id, data)
 		_verify_key_item_effects(game_id, data)
 		_verify_party_item_effects(game_id, data, TM_HM_PARTY_ROWS)
+		_verify_battle_item_effects(game_id, data)
 		_verify_screen(game_id, data)
 		_verify_descriptions(game_id, data)
 	## `UseItem`'s jumptable is the same three answers on Generation 1, and the
 	## pack that reads it is this one, so its `.Party` rows are swept here too.
 	_r.each_game_of(RomRegistry.GEN1, func() -> void:
 		_verify_party_item_effects(_r.game_id, _r.data, GEN1_TM_HM_PARTY_ROWS)
+		_verify_battle_item_effects(_r.game_id, _r.data)
 	)
 
 
@@ -288,6 +294,52 @@ func _verify_party_item_effects(
 	print("%s: %d party-menu item effects, %d TM/HM rows beside them." % [
 		game_id, covered, machines,
 	])
+
+
+## `UseItem` inside a battle over every row of a real cache: the battle nibble
+## each carries against the branch [method Gen2Battle.use_bag_item] picks for it.
+## An offered row with no branch is the bug worth catching, the way MYSTERYBERRY
+## was in the field.
+func _verify_battle_item_effects(game_id: StringName, data: GameData) -> void:
+	var unhandled: Array[String] = []
+	var offered: int = 0
+	for number: int in range(1, ITEM_ROWS + 1):
+		var definition: Dictionary = data.item(number)
+		if definition.is_empty() \
+			or int(definition.get("battle_menu", 0)) == Gen2WorldPack.ITEMMENU_NOUSE:
+			continue
+		offered += 1
+		if not _battle_effect_branch(number, definition, data):
+			unhandled.append("$%02X (%s)" % [number, data.item_name(number)])
+	_r.check(
+		unhandled.is_empty(),
+		"%s: %d of %d battle items reach no effect branch: %s" % [
+			game_id, unhandled.size(), offered, ", ".join(unhandled.slice(0, 6)),
+		]
+	)
+	var expected: int = int(BATTLE_ITEM_ROWS[data.generation])
+	_r.check(
+		offered == expected,
+		"%s: %d rows carry a battle nibble, expected %d" % [game_id, offered, expected]
+	)
+	print("%s: %d battle-menu item effects." % [game_id, offered])
+
+
+## The branches [method Gen2Battle.use_bag_item] picks between, off the same
+## tables it reads, so a table that loses a row takes this check red with it.
+func _battle_effect_branch(item: int, definition: Dictionary, data: GameData) -> bool:
+	if Gen2WorldPartyHost.is_ball(data, item):
+		return true
+	var roles: Dictionary = Gen2WorldPartyHost.item_effects(data)
+	if item == int(roles["poke_doll"]) or item == int(roles["poke_flute"]):
+		return true
+	if item == int(roles["confusion_cure"]):
+		return true
+	for key: String in ["x_stat", "x_substatus", "pp_restore", "revive"]:
+		if (roles[key] as Dictionary).has(item):
+			return true
+	return int(definition.get("heal_amount", 0)) > 0 \
+		or int(definition.get("status_mask", 0)) != 0
 
 
 ## The branches `_apply_item_effect` picks between, read off the host's own

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -15,7 +15,7 @@ extends SceneTree
 const KIND_HELP: Dictionary = {
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
 	&"battle_transition": "frames, index: DoBattleTransition over the map. 1 is the trainer branch; a Generation 1 cartridge reads BattleTransitions' own index, 0 the double circle, 2 the circle, 4 the horizontal stripes, 6 the vertical",
-	&"battle": "frames: the wild fight preview_battle_request starts, settled past its transition",
+	&"battle": "frames, 0: the wild fight preview_battle_request starts, settled past its transition. 1 opens the bag over it",
 	&"battle_caught": "frames: the same fight against a species the dex already holds",
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
 	&"catch_dex": "none: NewPokedexEntry's page, over the fight the catch that opened it is still in",
@@ -182,6 +182,8 @@ const TEXT_SETTLE_FRAMES: int = 20
 ## climb runs four passes a cell, so 26 lands a few cells up.
 const STAGED_FRAMES: int = 2
 ## `sign` spends the whole reveal: no press finishes a page early.
+## How many boxes a battle menu is waited for behind.
+const BATTLE_MENU_WAIT: int = 6
 const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
 	&"gift": BOX_REVEAL_FRAMES,
@@ -543,6 +545,24 @@ func _stage_battle() -> void:
 	for _press: int in (3 if caught else 0):
 		_screen.press_button(PokeButton.A)
 		_screen.advance_frames(frames)
+	if _cell.y == 1:
+		_open_battle_bag(frames)
+
+
+## `BattleMenu`'s ITEM row. The appearance line and the send-out in front of it
+## each owe a press, so A is spent until there is a cursor, and only then is it
+## moved one row down and used.
+func _open_battle_bag(frames: int) -> void:
+	var host: Gen2BattleScreen = _screen.get("_battle_host")
+	for _press: int in BATTLE_MENU_WAIT:
+		if host == null or StringName(host.get("_menu_stage")) == &"main":
+			break
+		_screen.press_button(PokeButton.A)
+		_screen.advance_frames(frames)
+	_screen.press_button(PokeButton.DOWN)
+	_screen.advance_frame()
+	_screen.press_button(PokeButton.A)
+	_screen.advance_frames(frames)
 
 
 ## `CatchTutorial`, played by `DudeAutoInputs` rather than by anybody. The first


### PR DESCRIPTION
## Added

`DisplayPlayerBag` hands `wNumBagItems` over whole, so a Generation 1 fight lists every owned row and `ItemUseNotTime` refuses the ones `ItemUsePtrTable` has no battle answer for. `Gen1Layout.item_battle_menu` is that answer as the nibble the shared pack branches on: 34 rows carry one, 20 opening the party list and 14 spent on whoever is out.
`ItemUsePokeFlute` wakes both parties, and is the one row `UseDisposableItem` never spends.
The list is `DisplayListMenuID`'s own `LIST_MENU_BOX` drawn over the fight, and `.relearnmenu`'s box five rows higher is an Ether's question.
`decode_script` reads `CheckEitherEventSet`'s mask over one `wEventFlags` byte, a `call` to a routine the layout does not name, and the map script index a row leaves in `wCurMapScript` or in `wGameProgressFlags`' 122 `w<Map>CurScript` bytes. 211 rows on Red and Blue and 197 on Yellow decode now against 204 and 191, three of them giving a Pokemon where one did and twelve ending in a `predef HideObject` where five did.
`tools/checks/pack.gd` sweeps every offered row of both generations for an effect branch, `tools/checks/gen1_battle.gd` uses nine of them on all three cartridges, and `tools/checks/gen1_walk.gd` opens the Fighting Dojo's Hitmonlee page and takes its greedy line once the other ball is gone.
`tools/preview_world.gd -- red 0 0 <out.png> live battle 300 1` photographs the bag over a fight.

## Changed

`Gen2WorldPartyHost.item_effects` is the seam `Gen2Battle.use_bag_item` reads through, so the revives, the PP restorers, the X items and the doll land at Generation 1's own numbers where Crystal's had been written into the battle; `is_ball` is the same seam for a throw, the bag having one pocket and no type byte to read.
`BattleMenuText` spells the battle menu's row ITEM, with `<PK><MN>` as its own two tiles, where Crystal draws PACK and four letters.
The cache format is 115: a Generation 1 item row carries a battle nibble.

## Fixed

Crystal's BITTER BERRY reached no effect branch at all. `BitterBerryEffect` is the one battle row whose whole effect is a substatus, and the pack answered "It won't have any effect" where the cartridge unconfuses whoever is out, whichever party member the list picked.
The pack's `ItemUseNotTime` box printed the marker `<PLAYER>` rather than the player's name.
