### PR TITLE
Take a Generation 1 in-game trade

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ uncharacterised bank layout could produce corrupt assets. The three Generation 1
 cartridges import their species, move, type, item and trainer tables, every map
 and tileset, and every map text, and a wild fight, a trainer battle and a
 standing wild Pokemon on one of their maps are all fought on the battle screen.
+An NPC's in-game trade is offered, refused and taken.
 The START menu is the cartridge's own list and opens its one-pocket bag; the
 launcher seats one and does not offer Play until its map scripts are
 interpreted.

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -475,6 +475,7 @@ static func _verify_battle_anims(rom: RomFile, layout: Dictionary) -> Dictionary
 static func _verify_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var runs: Dictionary = {"mart": ["mart_text", Gen1Layout.MART_TEXT_AT]}
 	runs.merge(FACILITY_TEXT_RUNS)
+	runs["npc_trade"] = ["npc_trade_cable_text", Gen1Layout.NPC_TRADE_TEXT_AT]
 	for run: String in runs:
 		var key: String = String((runs[run] as Array)[0])
 		var slots: Dictionary = (runs[run] as Array)[1]
@@ -1026,7 +1027,7 @@ func _import_prizes(rom: RomFile, layout: Dictionary) -> Array:
 	return out
 
 
-## The other two runs, in [method GameData.special_text]'s run/slot shape.
+## Every run but the shop's, in [method GameData.special_text]'s run/slot shape.
 func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var out: Dictionary = {}
 	for run: String in FACILITY_TEXT_RUNS:
@@ -1038,6 +1039,28 @@ func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 				rom, Gen1Layout.facility_text_offset(layout, key, slots, name)
 			)
 		out[run] = boxes
+	out["npc_trade"] = _import_trade_text(rom, layout)
+	return out
+
+
+## `InGameTradeTextPointers`' three tables of five and the two boxes the swap
+## prints, in the one run both generations' trades are read from.
+func _import_trade_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in Gen1Layout.NPC_TRADE_TEXT_AT:
+		out[name] = facility_text(rom, Gen1Layout.facility_text_offset(
+			layout, "npc_trade_cable_text", Gen1Layout.NPC_TRADE_TEXT_AT, name
+		))
+	var table: int = int(layout["trade_text_pointers"])
+	var bank: int = RomFile.bank_of(table)
+	for slot: int in Gen2Layout.TRADE_TEXT_ORDER.size():
+		@warning_ignore("integer_division")
+		var set_row: int = table + (slot / Gen2Layout.TRADE_TEXTS_PER_SET) * Gen1Layout.POINTER_SIZE
+		var texts: int = Gen1Layout.banked(bank, rom.u16le(set_row))
+		out[Gen2Layout.TRADE_TEXT_ORDER[slot]] = facility_text(rom, Gen1Layout.banked(
+			bank,
+			rom.u16le(texts + (slot % Gen2Layout.TRADE_TEXTS_PER_SET) * Gen1Layout.POINTER_SIZE)
+		))
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -644,6 +644,18 @@ const PREDEF_SIZE: int = 3
 ## `PickUpItemText`'s two boxes, a `text_far` stub and a `sound_get_item_1` apart.
 const PICK_UP_TEXT_AT: Dictionary = {"found": 0x00, "no_room": 0x06}
 
+## `TradeMons`: `npctrade`'s give and get species, its `TRADE_DIALOGSET_*` and a
+## nickname. `ConnectCableText` and `TradedForText` sit behind the last of
+## `InGameTradeTextPointers`' three tables.
+const TRADE_COUNT: int = 10
+const TRADE_RECORD_SIZE: int = 14
+const TRADE_NAME_LENGTH: int = 11
+const NPC_TRADE_TEXT_AT: Dictionary = {"cable": 0x00, "traded_for": 0x05}
+## `InGameTrade_GetMonName`'s two buffers, which every box of the run names by
+## address: the species the row asks for and the one it offers.
+const TRADE_GIVE_NAME: int = 0xCD13
+const TRADE_RECEIVE_NAME: int = 0xCD1E
+
 ## `object_event`'s two movement bytes as one shared template. Byte 1 is WALK or
 ## STAY; byte 2 is a fixed direction, the axis a random walk keeps to, or
 ## `BOULDER_MOVEMENT_BYTE_2`. A STAY sprite still turns, because `TryWalking`
@@ -690,6 +702,12 @@ const SCRIPT_LD_A_MEM: int = 0xFA
 const SCRIPT_LD_MEM_A: int = 0xEA
 const SCRIPT_LDH_MEM_A: int = 0xE0
 const SCRIPT_AND_A: int = 0xA7
+const SCRIPT_XOR_A: int = 0xAF
+## `CheckEvent flag, 1`: one `rrca` per bit up to the one asked about, or `add a`
+## alone for bit 7, which leaves the answer in carry rather than in Z.
+const SCRIPT_RRCA: int = 0x0F
+const SCRIPT_ADD_A: int = 0x87
+const SCRIPT_HIGH_BIT: int = 7
 const SCRIPT_AND_N: int = 0xE6
 const SCRIPT_LD_C: int = 0x0E
 const SCRIPT_LD_B_A: int = 0x47
@@ -712,8 +730,16 @@ const SCRIPT_CARRY_BRANCHES: Dictionary = {0x38: true, 0xDA: true, 0x30: false, 
 const SCRIPT_CALLS: Array[String] = [
 	"print_text", "text_script_end", "disable_waiting", "yes_no_choice",
 	"give_item", "is_item_in_bag", "bankswitch", "play_cry", "wait_for_sound",
-	"predef", "display_pokedex", "give_pokemon",
+	"predef", "display_pokedex", "give_pokemon", "wait_for_button",
+	"auto_textbox_on", "auto_textbox_off",
 ]
+## The routines that spend nothing here: no audio driver, a press already ends
+## every box, and `wAutoTextBoxDrawingControl` has no counterpart.
+const SCRIPT_SILENT_CALLS: Array[String] = [
+	"play_cry", "wait_for_sound", "wait_for_button",
+	"auto_textbox_on", "auto_textbox_off",
+]
+const SCRIPT_CONDITIONAL_CALLS: Array[int] = [0xC4, 0xCC, 0xD4, 0xDC]
 const SCRIPT_SHORT_SIZE: int = 2
 const SCRIPT_LONG_SIZE: int = 3
 ## The `CB` prefix's three rows, the low three bits naming the operand.
@@ -724,6 +750,11 @@ const SCRIPT_OPERAND_A: int = 7
 const SCRIPT_OPERAND_HL: int = 6
 ## `flag_array NUM_EVENTS`: 2,560 events on all three cartridges.
 const EVENT_FLAG_BYTES: int = 320
+## Generation 1's own saved flag bytes, which Crystal's engine flag table names
+## none of, so the run sits above every Crystal index and one store holds both.
+const ENGINE_FLAG_BYTES: Array[String] = ["status_flags_4"]
+const ENGINE_FLAG_FIRST: int = 256
+const ENGINE_FLAG_BITS: int = 8
 ## `BAG_ITEM_CAPACITY`: one list of slots, not four pockets.
 const BAG_ITEM_CAPACITY: int = 20
 ## The one type byte every Generation 1 item wears, so the shared pack draws the
@@ -946,6 +977,7 @@ const RED_BLUE: Dictionary = {
 	"talk_to_trainer": 0x31CC,
 	"print_text": 0x3C49,
 	"event_flags": 0xD747,
+	"status_flags_4": 0xD72E,
 	## The rest of what `decode_script` reads; a row calling anything else is not.
 	"text_script_end": 0x24D7,
 	"yes_no_choice": 0x35EC,
@@ -954,6 +986,9 @@ const RED_BLUE: Dictionary = {
 	"display_pokedex": 0x0349B,
 	"give_pokemon": 0x03E48,
 	"wait_for_sound": 0x3748,
+	"wait_for_button": 0x3865,
+	"auto_textbox_on": 0x3C3C,
+	"auto_textbox_off": 0x3C3F,
 	"give_item": 0x3E2E,
 	"is_item_in_bag": 0x3493,
 	"bankswitch": 0x35D6,
@@ -966,6 +1001,14 @@ const RED_BLUE: Dictionary = {
 	"cur_party_species": 0xCF91,
 	"cur_map_script": 0xDA39,
 	"map_scripts": 0xD5F0,
+	## `DoInGameTradeDialogue`, the trade table it indexes with `wWhichTrade`,
+	## `InGameTradeTextPointers` and the pair of boxes the swap itself prints.
+	"in_game_trade": 0x71AD9,
+	"which_trade": 0xCD3D,
+	"trade_mons": 0x71B7B,
+	"trade_text_pointers": 0x71D64,
+	"trade_ot_name": 0x71D59,
+	"npc_trade_cable_text": 0x71D88,
 	## `Predef` and the table it indexes, with the three rows read through it.
 	"predef": 0x3E6D,
 	"predef_pointers": 0x4FE79,
@@ -1059,6 +1102,7 @@ const YELLOW: Dictionary = {
 	"talk_to_trainer": 0x3168,
 	"print_text": 0x3C36,
 	"event_flags": 0xD746,
+	"status_flags_4": 0xD72D,
 	"text_script_end": 0x23D2,
 	"yes_no_choice": 0x35EF,
 	"disable_waiting": 0x2FDE,
@@ -1066,6 +1110,9 @@ const YELLOW: Dictionary = {
 	"display_pokedex": 0x0347D,
 	"give_pokemon": 0x03E59,
 	"wait_for_sound": 0x373E,
+	"wait_for_button": 0x3852,
+	"auto_textbox_on": 0x3C29,
+	"auto_textbox_off": 0x3C2C,
 	"give_item": 0x3E3F,
 	"is_item_in_bag": 0x3422,
 	"bankswitch": 0x3E84,
@@ -1078,6 +1125,12 @@ const YELLOW: Dictionary = {
 	"cur_party_species": 0xCF90,
 	"cur_map_script": 0xDA38,
 	"map_scripts": 0xD5EF,
+	"in_game_trade": 0x71B86,
+	"which_trade": 0xCD3D,
+	"trade_mons": 0x71C1D,
+	"trade_text_pointers": 0x71E38,
+	"trade_ot_name": 0x71E2D,
+	"npc_trade_cable_text": 0x71E5C,
 	"predef": 0x3EB4,
 	"predef_pointers": 0xF681D,
 	"hide_object": 0x0F053,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -36,6 +36,7 @@ static func import_to_cache(
 		RomCache.world_palettes_path(directory): result["palettes"],
 		RomCache.overworld_sprites_path(directory): sprites,
 		RomCache.world_encounters_path(directory): result["encounters"],
+		RomCache.world_trades_path(directory): result["trades"],
 	}
 	for path: String in sections:
 		if not RomCache.write_json(path, sections[path]):
@@ -141,7 +142,35 @@ static func read_world(
 		"effects": effects["effects"],
 		"icons": icons["icons"],
 		"icon_species": icons["icon_species"],
+		"trades": read_trades(rom, layout),
 	}
+
+
+## `TradeMons` in the shared `world_trade` shape. A row stores no DVs and no OT
+## id: `AddPartyMon` and `InGameTrade_PrepareTradeData` roll them, which -1 asks
+## for, and the trainer name is the one string every row shares.
+static func read_trades(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout["trade_mons"])
+	var out: Array = []
+	for index: int in Gen1Layout.TRADE_COUNT:
+		var row: int = at + index * Gen1Layout.TRADE_RECORD_SIZE
+		out.append({
+			"trade_id": index,
+			"dialog": rom.u8(row + 2),
+			"requested_species": Gen1Layout.dex_of_index(rom, layout, rom.u8(row)),
+			"offered_species": Gen1Layout.dex_of_index(rom, layout, rom.u8(row + 1)),
+			"nickname": Gen1Text.decode(
+				rom.bytes(), row + 3, Gen1Layout.TRADE_NAME_LENGTH
+			),
+			"dvs": -1,
+			"item": 0,
+			"ot_id": -1,
+			"ot_name": Gen1Text.decode(
+				rom.bytes(), int(layout["trade_ot_name"]), Gen1Layout.TRADE_NAME_LENGTH
+			),
+			"gender": Gen2Layout.TRADE_GENDER_EITHER,
+		})
+	return out
 
 
 ## `LoadMonPartySpriteGfx` over `MonPartySpritePointers`: every row copied into
@@ -1013,6 +1042,7 @@ static func _script_ended(state: Dictionary, out: Array) -> Array:
 
 
 ## One instruction: the next address, [constant SCRIPT_END] or SCRIPT_UNREAD.
+## The register writes are here and [method _script_flow] has the rest.
 static func _script_step(
 	ctx: Dictionary, pc: int, state: Dictionary, out: Array
 ) -> int:
@@ -1041,7 +1071,25 @@ static func _script_step(
 		Gen1Layout.SCRIPT_LD_A:
 			state["a"] = rom.u8(at + 1)
 			state.erase("source")
+			state.erase("rotated")
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+		Gen1Layout.SCRIPT_XOR_A:
+			## Zero and a Z the `ld a, 0` above does not raise, so whatever a
+			## branch behind it was reading is gone.
+			state["a"] = 0
+			state.erase("source")
+			state.erase("rotated")
+			state.erase("tests")
+			return pc + 1
+	return _script_flow(ctx, pc, at, state, out)
+
+
+## What reads memory, tests it or leaves the instruction after this one.
+static func _script_flow(
+	ctx: Dictionary, pc: int, at: int, state: Dictionary, out: Array
+) -> int:
+	var rom: RomFile = ctx["rom"]
+	match rom.u8(at):
 		Gen1Layout.SCRIPT_LD_A_MEM:
 			_script_loaded(ctx, rom.u16le(at + 1), state)
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
@@ -1053,11 +1101,15 @@ static func _script_step(
 				ctx, Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(at + 1), state
 			) else SCRIPT_UNREAD
 		Gen1Layout.SCRIPT_AND_A:
-			state["tests"] = _script_tests(ctx, state, -1)
+			_script_test_bit(ctx, state, -1)
 			return pc + 1
+		Gen1Layout.SCRIPT_RRCA:
+			return _script_rotated(ctx, pc, state, int(state.get("rotated", 0)))
+		Gen1Layout.SCRIPT_ADD_A:
+			return _script_rotated(ctx, pc, state, Gen1Layout.SCRIPT_HIGH_BIT)
 		Gen1Layout.SCRIPT_AND_N:
 			## `CheckEitherEventSet`, whose two flags share a byte and a mask.
-			state["tests"] = _script_mask(ctx, state, rom.u8(at + 1))
+			_script_tested(state, _script_mask(ctx, state, rom.u8(at + 1)))
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_PREFIX:
 			return _script_prefix(ctx, pc, state, out)
@@ -1069,7 +1121,44 @@ static func _script_step(
 			return SCRIPT_END
 		Gen1Layout.SCRIPT_CALL:
 			return _script_call(ctx, pc, rom.u16le(at + 1), state, out)
+	if Gen1Layout.SCRIPT_CONDITIONAL_CALLS.has(rom.u8(at)):
+		return _script_call_if(ctx, pc, rom.u16le(at + 1), state)
 	return SCRIPT_UNREAD
+
+
+## A conditional `call`, which only a routine spending nothing here may be: both
+## sides of `call z, WaitForTextScrollButtonPress` print the same boxes.
+static func _script_call_if(
+	ctx: Dictionary, pc: int, target: int, state: Dictionary
+) -> int:
+	if not _script_routine(ctx["layout"], target) in Gen1Layout.SCRIPT_SILENT_CALLS:
+		return SCRIPT_UNREAD
+	_script_untested(state)
+	return pc + Gen1Layout.SCRIPT_LONG_SIZE
+
+
+## What a branch is reading, and whether it is reading it out of carry.
+static func _script_untested(state: Dictionary) -> void:
+	for key: String in ["tests", "tests_in_carry", "tests_engine"]:
+		state.erase(key)
+
+
+static func _script_tested(
+	state: Dictionary, value: Variant, in_carry: bool = false, engine: bool = false
+) -> void:
+	state["tests"] = value
+	state["tests_in_carry"] = in_carry
+	state["tests_engine"] = engine
+
+
+## One rotation of `CheckEvent flag, 1`'s run, or `add a` standing for all eight
+## of them: the bit that has just landed in carry is the flag being asked about.
+static func _script_rotated(
+	ctx: Dictionary, pc: int, state: Dictionary, rotated: int
+) -> int:
+	state["rotated"] = rotated + 1
+	_script_test_bit(ctx, state, rotated, true)
+	return pc + 1
 
 
 static func _script_hop(operand: int) -> int:
@@ -1081,6 +1170,7 @@ static func _script_hop(operand: int) -> int:
 static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> void:
 	state["source"] = address
 	state.erase("a")
+	state.erase("rotated")
 	if address == int((ctx["layout"] as Dictionary)["cur_party_species"]) \
 		and state.has("species_index"):
 		state["a"] = int(state["species_index"])
@@ -1130,6 +1220,11 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 			return false
 		state["no_press"] = true
 		return true
+	if address == int(layout["which_trade"]):
+		if not state.has("a"):
+			return false
+		state["trade"] = int(state["a"])
+		return true
 	if address == int(layout["toggleable_index"]):
 		if not state.has("a"):
 			return false
@@ -1141,15 +1236,30 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 	return true
 
 
-## What the flags hold. [param bit] is -1 for `and a`, which only asks whether
-## the whole byte is zero and so names no flag.
-static func _script_tests(ctx: Dictionary, state: Dictionary, bit: int) -> int:
+## What the flags hold, as the index and whether it is one of Generation 1's own
+## engine flags rather than a `wEventFlags` bit. [param bit] is -1 for `and a`,
+## which only asks whether the whole byte is zero and so names no flag.
+static func _script_tests(ctx: Dictionary, state: Dictionary, bit: int) -> Array:
 	var layout: Dictionary = ctx["layout"]
 	var source: int = int(state.get("source", -1))
 	if source == int(layout["current_menu_item"]):
-		return SCRIPT_TESTS_CHOICE
-	var flag: int = _script_flag(ctx, source, bit)
-	return flag if bit >= 0 and flag >= 0 else SCRIPT_TESTS_NOTHING
+		return [SCRIPT_TESTS_CHOICE, false]
+	if bit >= 0:
+		var flag: int = _script_flag(ctx, source, bit)
+		if flag >= 0:
+			return [flag, false]
+		var engine: int = _script_engine_flag(ctx, source, bit)
+		if engine >= 0:
+			return [engine, true]
+	return [SCRIPT_TESTS_NOTHING, false]
+
+
+## Reads what a test is asking about into [param state].
+static func _script_test_bit(
+	ctx: Dictionary, state: Dictionary, bit: int, in_carry: bool = false
+) -> void:
+	var tested: Array = _script_tests(ctx, state, bit)
+	_script_tested(state, tested[0], in_carry, bool(tested[1]))
 
 
 ## An address in `wEventFlags` and a bit as one flag index, the way
@@ -1159,6 +1269,16 @@ static func _script_flag(ctx: Dictionary, address: int, bit: int) -> int:
 	if address < base or address >= base + Gen1Layout.EVENT_FLAG_BYTES:
 		return -1
 	return (address - base) * 8 + bit
+
+
+## The same for one of [constant Gen1Layout.ENGINE_FLAG_BYTES], the saved bytes
+## outside `wEventFlags` a row reads.
+static func _script_engine_flag(ctx: Dictionary, address: int, bit: int) -> int:
+	var layout: Dictionary = ctx["layout"]
+	for index: int in Gen1Layout.ENGINE_FLAG_BYTES.size():
+		if address == int(layout.get(Gen1Layout.ENGINE_FLAG_BYTES[index], -1)):
+			return Gen1Layout.ENGINE_FLAG_FIRST + index * Gen1Layout.ENGINE_FLAG_BITS + bit
+	return -1
 
 
 ## `bit b, a` names the flag a branch tests; `set`/`res b, [hl]` writes one.
@@ -1172,14 +1292,21 @@ static func _script_prefix(
 	var operand: int = code & 7
 	if operand == Gen1Layout.SCRIPT_OPERAND_A \
 		and code >= Gen1Layout.SCRIPT_BIT_BASE and code < Gen1Layout.SCRIPT_RES_BASE:
-		state["tests"] = _script_tests(ctx, state, bit)
+		_script_test_bit(ctx, state, bit)
 		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 	if operand != Gen1Layout.SCRIPT_OPERAND_HL or code < Gen1Layout.SCRIPT_RES_BASE:
 		return SCRIPT_UNREAD
-	var flag: int = _script_flag(ctx, int(state.get("hl", -1)), bit)
-	if flag < 0:
+	var written: int = _script_flag(ctx, int(state.get("hl", -1)), bit)
+	var engine: int = _script_engine_flag(ctx, int(state.get("hl", -1)), bit)
+	if written < 0 and engine < 0:
 		return SCRIPT_UNREAD
-	out.append({"op": "flag", "flag": flag, "set": code >= Gen1Layout.SCRIPT_SET_BASE})
+	var node: Dictionary = {
+		"op": "flag", "flag": written if written >= 0 else engine,
+		"set": code >= Gen1Layout.SCRIPT_SET_BASE,
+	}
+	if written < 0:
+		node["engine"] = true
+	out.append(node)
 	return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 
 
@@ -1192,8 +1319,11 @@ static func _script_call(
 	var next: int = pc + Gen1Layout.SCRIPT_LONG_SIZE
 	## A routine returns with flags of its own, so a `jr z` behind a call is
 	## reading them rather than whatever set them before it.
-	state.erase("tests")
-	match _script_routine(layout, target):
+	_script_untested(state)
+	var routine: String = _script_routine(layout, target)
+	if routine in Gen1Layout.SCRIPT_SILENT_CALLS:
+		return next
+	match routine:
 		"print_text":
 			var box: Dictionary = _script_box(ctx, int(state.get("hl", 0)))
 			if box.is_empty():
@@ -1221,8 +1351,6 @@ static func _script_call(
 			return _script_pokedex(ctx, state, out, next)
 		"give_pokemon":
 			return _script_gift_pokemon(ctx, state, out, next)
-		"play_cry", "wait_for_sound":
-			return next
 	return _script_local_call(ctx, target, state, out, next)
 
 
@@ -1293,7 +1421,7 @@ static func _script_gift_pokemon(
 	out.append({"op": "give_pokemon", "species": dex, "level": int(state["c"])})
 	state.erase("b")
 	state.erase("c")
-	state["tests"] = SCRIPT_TESTS_CARRY
+	_script_tested(state, SCRIPT_TESTS_CARRY)
 	return next
 
 
@@ -1304,7 +1432,7 @@ static func _script_gift(state: Dictionary, out: Array, next: int) -> int:
 	out.append({"op": "give_item", "item": int(state["b"]), "count": int(state["c"])})
 	state.erase("b")
 	state.erase("c")
-	state["tests"] = SCRIPT_TESTS_CARRY
+	_script_tested(state, SCRIPT_TESTS_CARRY)
 	return next
 
 
@@ -1314,7 +1442,7 @@ static func _script_asked(state: Dictionary, next: int) -> int:
 		return SCRIPT_UNREAD
 	state["asked"] = int(state["b"])
 	state.erase("b")
-	state["tests"] = SCRIPT_TESTS_ITEM
+	_script_tested(state, SCRIPT_TESTS_ITEM)
 	return next
 
 
@@ -1347,6 +1475,12 @@ static func _script_predef(
 	if target == int(layout["pick_up_item"]):
 		out.append({"op": "pick_up_item"})
 		return next
+	if target == int(layout["in_game_trade"]):
+		if not state.has("trade"):
+			return SCRIPT_UNREAD
+		out.append({"op": "trade", "trade_id": int(state["trade"])})
+		state.erase("trade")
+		return next
 	var hidden: bool = target == int(layout["hide_object"])
 	if not state.has("toggle") \
 		or (not hidden and target != int(layout["show_object"])):
@@ -1377,7 +1511,9 @@ static func _script_branch(
 	if tests is Array:
 		if carry:
 			return null
-	elif int(tests) == SCRIPT_TESTS_NOTHING or carry != (int(tests) == SCRIPT_TESTS_CARRY):
+	elif int(tests) == SCRIPT_TESTS_NOTHING or carry != (
+		int(tests) == SCRIPT_TESTS_CARRY or bool(state.get("tests_in_carry", false))
+	):
 		return null
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
@@ -1420,7 +1556,12 @@ static func _script_node(
 		SCRIPT_TESTS_ITEM:
 			return {"op": "has_item", "item": int(state["asked"]),
 				"then": taken, "else": fell}
-	return {"op": "branch", "flag": int(tests), "then": taken, "else": fell}
+	var branch: Dictionary = {
+		"op": "branch", "flag": int(tests), "then": taken, "else": fell,
+	}
+	if bool(state.get("tests_engine", false)):
+		branch["engine"] = true
+	return branch
 
 
 ## The carry belongs to the gift in front of it, so both sides fold onto it.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 115
+const FORMAT_VERSION: int = 116
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -346,7 +346,9 @@ const TRADE_TEXTS_GOLD_SILVER: Array[String] = [
 ## The two cells in their own run, because only Crystal ships them.
 const TRADE_NEWBIE_TEXTS: Array[String] = ["complete_4", "after_4"]
 ## The stubs' own order in the file, variant-major where `TradeTexts` is
-## dialog-major, which is the order a run of stubs is read at.
+## dialog-major, which is the order a run of stubs is read at. Generation 1's
+## `TradeTextPointers1` to `...3` are laid out the same way.
+const TRADE_TEXTS_PER_SET: int = 5
 const TRADE_TEXT_ORDER: Array[String] = [
 	"intro_1", "cancel_1", "wrong_1", "complete_1", "after_1",
 	"intro_2", "cancel_2", "wrong_2", "complete_2", "after_2",

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -816,8 +816,11 @@ func _moves_page_advance() -> void:
 ## `WritePartyMenuTilemap`'s rows, in [Gen2BattleSwitchMenu]'s own shape plus the
 ## `egg` [Gen2PartyMenuPage] needs, which a battle party never carries.
 ## `PartyMenuQualityPointers`' `.Gender`, both `SelectTradeOrDayCareMon` callers.
+## Generation 1 has no gender byte and `PartyMenuInit` no quality column, so
+## `InGameTrade_DoTrade`'s own list still draws the bar every other menu draws.
 func _gender_column() -> bool:
-	return _selecting and _select_action == ACTION_GIVE_MON
+	return _selecting and _select_action == ACTION_GIVE_MON \
+		and _data != null and _data.generation != RomRegistry.GEN1
 
 
 func _rows() -> Array:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3662,6 +3662,9 @@ var _gen1_last_map: int = -1
 const GEN1_POKECENTER_RUN: String = "pokecenter"
 const GEN1_CABLE_CLUB_RUN: String = "cable_club"
 const GEN1_PICK_UP_RUN: String = "pick_up_item"
+## `InGameTradeTextPointers`' fifteen and the two boxes the swap prints, which
+## both generations' trades read under one run name.
+const GEN1_TRADE_RUN: String = "npc_trade"
 ## `EndTrainerBattle`'s `cp LOST_BATTLE`, which a catch also passes.
 const GEN1_TRAINER_BEATEN: Array[StringName] = [
 	Gen2WorldBattleAdapter.OUTCOME_WON, Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
@@ -3767,6 +3770,7 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 					"type": &"flag",
 					"flag": int(node["flag"]),
 					"set": bool(node["set"]),
+					"engine": bool(node.get("engine", false)),
 				})
 			"branch":
 				if not _gen1_resolve_side(node, _gen1_branch_set(node), steps, run):
@@ -3800,6 +3804,8 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 					"kind": &"pokedex_entry_requested",
 					"values": {"species": int(node["species"])},
 				}})
+			"trade":
+				return _gen1_trade(int(node["trade_id"]), steps)
 			"choice":
 				return _gen1_script_choice(node, steps, run)
 			_:
@@ -3808,8 +3814,11 @@ func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
 
 
 ## `CheckEvent`'s one flag, or `CheckEitherEventSet`'s mask over the flags of
-## one `wEventFlags` byte, which is set when any of them is.
+## one `wEventFlags` byte, which is set when any of them is. A row may read one
+## of Generation 1's own saved bytes instead, which the engine flags hold.
 func _gen1_branch_set(node: Dictionary) -> bool:
+	if bool(node.get("engine", false)):
+		return state != null and state.is_engine_flag_active(int(node["flag"]))
 	if event_flag_active(int(node["flag"])):
 		return true
 	for flag: int in node.get("either", []):
@@ -3898,6 +3907,84 @@ func _gen1_take_item(item: int, steps: Array, bag: Dictionary) -> void:
 	else:
 		bag[item] = left
 	steps.append({"type": &"items", "items": {item: left}})
+
+
+## `DoInGameTradeDialogue` over the row's own `wWhichTrade`:
+## `wCompletedInGameTradeFlags` answers TRADETEXT_AFTER_TRADE alone once the swap
+## has happened, and the offer is a `YesNoChoice` under TRADETEXT_WANNA_TRADE.
+func _gen1_trade(trade_id: int, steps: Array) -> bool:
+	var record: Dictionary = Gen2WorldPartyHost.trade_record(data, {"trade_id": trade_id})
+	if record.is_empty():
+		return false
+	if state != null and state.npc_trade_done(trade_id):
+		steps.append(_gen1_trade_box(record, Gen2WorldScriptRunner.TRADE_DIALOG_AFTER))
+		return true
+	steps.append({
+		"type": &"choice",
+		"text": _gen1_trade_text(record, Gen2Layout.trade_text_name(
+			false, Gen2WorldScriptRunner.TRADE_DIALOG_INTRO, int(record["dialog"])
+		)),
+		"yes": [{
+			"type": &"request",
+			"values": {"kind": &"party_selection_requested", "values": {
+				"routine": &"npc_trade", "trade": {"trade_id": trade_id},
+			}},
+			"trade": trade_id,
+		}],
+		"no": [_gen1_trade_box(record, Gen2WorldScriptRunner.TRADE_DIALOG_CANCEL)],
+	})
+	return true
+
+
+## `InGameTrade_DoTrade` behind `DisplayPartyMenu`: a cancelled list is
+## TRADETEXT_NO_TRADE and a wrong species TRADETEXT_WRONG_MON. The swap sets the
+## flag before `ConnectCableText`, and `TradedForText` follows the movie.
+func _gen1_trade_after_selection(step: Dictionary, result: Dictionary) -> Array:
+	var trade_id: int = int(step["trade"])
+	var record: Dictionary = Gen2WorldPartyHost.trade_record(data, {"trade_id": trade_id})
+	var party_index: int = int(result.get("party_index", -1))
+	if record.is_empty():
+		return []
+	if party_index < 0:
+		return [_gen1_trade_box(record, Gen2WorldScriptRunner.TRADE_DIALOG_CANCEL)]
+	if int(result.get("species", 0)) != int(record["requested_species"]):
+		return [_gen1_trade_box(record, Gen2WorldScriptRunner.TRADE_DIALOG_WRONG)]
+	return [
+		{"type": &"npc_trade", "trade_id": trade_id},
+		_gen1_trade_run_box(record, "cable"),
+		{"type": &"request", "values": {"kind": &"trade_requested", "values": {
+			"trade_id": trade_id, "party_index": party_index,
+		}}},
+		_gen1_trade_run_box(record, "traded_for"),
+		_gen1_trade_box(record, Gen2WorldScriptRunner.TRADE_DIALOG_COMPLETE),
+	]
+
+
+func _gen1_trade_box(record: Dictionary, dialog: int) -> Dictionary:
+	return _gen1_trade_run_box(record, Gen2Layout.trade_text_name(
+		false, dialog, int(record.get("dialog", 0))
+	))
+
+
+func _gen1_trade_run_box(record: Dictionary, name: String) -> Dictionary:
+	return {"type": &"text", "text": _gen1_trade_text(record, name)}
+
+
+## `InGameTrade_GetMonName` twice: the species the row asks for into
+## `wInGameTradeGiveMonName` and the one it offers into its neighbour.
+func _gen1_trade_text(record: Dictionary, name: String) -> String:
+	if data == null or name.is_empty():
+		return ""
+	var text: String = _gen1_filled_text(data.special_text(GEN1_TRADE_RUN, name))
+	for row: Array in [
+		[Gen1Layout.TRADE_GIVE_NAME, int(record.get("requested_species", 0))],
+		[Gen1Layout.TRADE_RECEIVE_NAME, int(record.get("offered_species", 0))],
+	]:
+		text = Gen2TextStream.fill_all_markers(
+			text, "%s%04X>" % [Gen2TextStream.RAM_MARKER, int(row[0])],
+			String(data.species(int(row[1])).get("name", ""))
+		)
+	return text
 
 
 ## `YesNoChoice` stands behind the box that asked, so the question is the last
@@ -4378,13 +4465,19 @@ func _gen1_result() -> Array:
 func _gen1_written(step: Dictionary) -> bool:
 	match StringName(step["type"]):
 		&"flag":
-			state.set_event_flag(int(step["flag"]), bool(step["set"]))
+			if bool(step.get("engine", false)):
+				state.set_engine_flag(int(step["flag"]), bool(step["set"]))
+			else:
+				state.set_event_flag(int(step["flag"]), bool(step["set"]))
 			return true
 		&"items":
 			state.apply_changes({}, {}, {"items": step["items"]})
 			return true
 		&"toggle":
 			gen1_toggle_object(int(step["index"]), bool(step["hidden"]))
+			return true
+		&"npc_trade":
+			state.apply_changes({}, {}, {"npc_trades": {int(step["trade_id"]): true}})
 			return true
 	return false
 
@@ -4396,6 +4489,8 @@ func _gen1_advance(choice: int, result: Dictionary = {}) -> Array:
 	if StringName(step.get("type", &"")) == &"choice":
 		var branch: Array = step.get("yes" if choice == 0 else "no", [])
 		_gen1_steps = branch.duplicate(true) + _gen1_steps
+	elif step.has("trade"):
+		_gen1_steps = _gen1_trade_after_selection(step, result) + _gen1_steps
 	elif step.has("ok"):
 		## `accepted` is the carry `_GivePokemon` answers in.
 		_gen1_steps = (step[

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1707,7 +1707,10 @@ static func _apply_trade_request(
 		return {"ok": false, "reason": &"could_not_create_trade_pokemon"}
 	received.nickname = String(trade.get("nickname", ""))
 	received.original_trainer = String(trade.get("ot_name", ""))
-	received.ot_id = int(trade.get("ot_id", 0))
+	## `InGameTrade_PrepareTradeData`'s `call Random`: Generation 1 keeps no OT
+	## id on a trade row and rolls one, which the row's -1 asks for.
+	var ot_id: int = int(trade.get("ot_id", 0))
+	received.ot_id = random.randi_range(0, 0xFFFF) if ot_id < 0 else ot_id
 	## `SetGiftPartyMonCaughtData` with `b` from the dialog set: `rrc b` puts bit
 	## 0 in CAUGHT_GENDER_MASK, so only a GIRL trader is recorded as female.
 	set_caught_data(

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -8061,7 +8061,7 @@ func _open_party_selection(request: Dictionary = {}) -> bool:
 	host.set_screen(_screen)
 	add_child(host)
 	host.open_selection(
-		Gen2PartyScreen.PROMPT_CHOOSE,
+		Gen2PartyScreen.prompt_text(_data, &"normal", Gen2PartyScreen.PROMPT_CHOOSE),
 		Gen2PartyScreen.ACTION_GIVE_MON \
 			if StringName((request.get("values", {}) as Dictionary).get(
 				"routine", &""

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -31,13 +31,21 @@ const LAYOUT: Dictionary = {
 	"hide_object": 0x0210,
 	"show_object": 0x0220,
 	"pick_up_item": 0x0230,
+	"in_game_trade": 0x0240,
+	"which_trade": 0xCD3D,
+	"status_flags_4": 0xD72E,
+	"wait_for_button": 0x01B0,
+	"auto_textbox_on": 0x01C0,
+	"auto_textbox_off": 0x01D0,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
-const PREDEFS: Dictionary = {1: 0x0210, 2: 0x0220, 3: 0x0230}
+const PREDEFS: Dictionary = {1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240}
 const AT: int = 0x1000
 const HELLO: int = 0x1800
 const BYE: int = 0x1810
 const UNREAD_CALL: int = 0x0200
+## `call z, nn`, one of [constant Gen1Layout.SCRIPT_CONDITIONAL_CALLS]' four.
+const CALL_Z: int = 0xCC
 
 
 func _rom(program: Array, strings: Dictionary = {}) -> RomFile:
@@ -385,3 +393,91 @@ func test_the_pick_up_predef_becomes_its_own_node() -> void:
 
 func test_any_other_predef_answers_nothing() -> void:
 	assert_eq(_decode(_predef(0) + _call(int(LAYOUT["text_script_end"]))), [])
+
+
+## `ld a, TRADE_FOR_x`, `ld [wWhichTrade], a` and `predef DoInGameTradeDialogue`.
+func _trade(row: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_A, row, Gen1Layout.SCRIPT_LD_MEM_A,
+		int(LAYOUT["which_trade"]) & 0xFF,
+		int(LAYOUT["which_trade"]) >> 8] + _predef(4)
+
+
+func test_a_trade_predef_keeps_the_row_it_was_handed() -> void:
+	assert_eq(_decode(_trade(6) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "trade", "trade_id": 6}])
+
+
+func test_a_trade_predef_with_no_row_written_answers_nothing() -> void:
+	assert_eq(_decode(_predef(4) + _call(int(LAYOUT["text_script_end"]))), [])
+
+
+## `Route11Gate2FYoungsterText` opens `xor a ; TRADE_FOR_TERRY`.
+func test_xor_a_writes_the_row_a_load_of_zero_would() -> void:
+	assert_eq(_decode(
+		[Gen1Layout.SCRIPT_XOR_A, Gen1Layout.SCRIPT_LD_MEM_A,
+			int(LAYOUT["which_trade"]) & 0xFF, int(LAYOUT["which_trade"]) >> 8]
+			+ _predef(4) + _call(int(LAYOUT["text_script_end"]))
+	), [{"op": "trade", "trade_id": 0}])
+
+
+## `CheckEvent flag, 1`: one `rrca` per bit up to the one asked about, which a
+## `jr c` behind it reads out of carry rather than out of Z.
+func _check_event_carry(flag: int) -> Array:
+	@warning_ignore("integer_division")
+	var byte: int = int(LAYOUT["event_flags"]) + flag / 8
+	var out: Array = [Gen1Layout.SCRIPT_LD_A_MEM, byte & 0xFF, byte >> 8]
+	for _rotation: int in (flag % 8) + 1:
+		out.append(Gen1Layout.SCRIPT_RRCA)
+	return out
+
+
+func test_a_rotated_event_check_reads_the_flag_out_of_carry() -> void:
+	## `jr c` hops over what runs when the flag is clear, the way `jr nz` does.
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_check_event_carry(11) + [0x38, clear.size()] + clear
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{"op": "branch", "flag": 11,
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "text", "text": "BYE"}]}])
+
+
+## Nothing but the rotation raised carry, so a `jr nz` behind the run is reading
+## a Z the rotation did not write.
+func test_a_zero_branch_behind_a_rotation_answers_nothing() -> void:
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	assert_eq(_decode(
+		_check_event_carry(3) + [0x20, clear.size()] + clear
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])), _boxes()
+	), [])
+
+
+## `ld hl, wStatusFlags4` and `set BIT_GOT_LAPRAS, [hl]`, the one saved byte
+## outside `wEventFlags` a row writes.
+func test_an_engine_flag_is_written_as_its_own_kind() -> void:
+	assert_eq(_decode(
+		_load_hl(int(LAYOUT["status_flags_4"]))
+			+ [Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_SET_BASE + 0x06]
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [{"op": "flag", "flag": Gen1Layout.ENGINE_FLAG_FIRST, "set": true,
+		"engine": true}])
+
+
+## `call z, WaitForTextScrollButtonPress`: the routine spends nothing here, so
+## both sides of it print the same boxes.
+func test_a_conditional_call_to_a_silent_routine_is_walked_past() -> void:
+	assert_eq(_decode(
+		[CALL_Z, int(LAYOUT["wait_for_button"]) & 0xFF,
+			int(LAYOUT["wait_for_button"]) >> 8]
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])), _boxes()
+	), [{"op": "text", "text": "HI"}])
+
+
+func test_a_conditional_call_to_anything_else_answers_nothing() -> void:
+	assert_eq(_decode(
+		[CALL_Z, int(LAYOUT["print_text"]) & 0xFF,
+			int(LAYOUT["print_text"]) >> 8]
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [])

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 1215 lines of the 39953 here, and Generation 1 has added 1050 more to the
+## are 1269 lines of the 40025 here, and Generation 1 has added 1068 more to the
 ## shared battle, world, palette, text, save and renderer code: 150 the battle
-## animation engine, 140 the transition and the split effects, 85 the party menu
-## and 40 the bag inside a battle. Thirteen sweeps found nothing to pay with.
-const MAX_COMMENT_LINES: int = 39953
+## animation engine, 140 the transition and the split effects, 85 the party
+## menu, 40 the bag in a battle, 18 the trades. Fourteen sweeps paid nothing.
+const MAX_COMMENT_LINES: int = 40025
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,21 +130,25 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 211, "text": 224, "branch": 78, "choice": 10, "flag": 33,
-		"give_item": 22, "has_item": 9, "take_item": 3, "unknown": 32,
-		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 3},
-	&"blue": {"rows": 211, "text": 224, "branch": 78, "choice": 10, "flag": 33,
-		"give_item": 22, "has_item": 9, "take_item": 3, "unknown": 32,
-		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 3},
-	&"yellow": {"rows": 197, "text": 179, "branch": 70, "choice": 8, "flag": 23,
-		"give_item": 17, "has_item": 9, "take_item": 3, "unknown": 35,
-		"pick_up_item": 108, "toggle_object": 9, "pokedex": 9, "give_pokemon": 3},
+	&"red": {"rows": 225, "text": 235, "branch": 84, "choice": 10, "flag": 35,
+		"give_item": 23, "has_item": 9, "take_item": 3, "unknown": 35,
+		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 4,
+		"trade": 9},
+	&"blue": {"rows": 225, "text": 235, "branch": 84, "choice": 10, "flag": 35,
+		"give_item": 23, "has_item": 9, "take_item": 3, "unknown": 35,
+		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 4,
+		"trade": 9},
+	&"yellow": {"rows": 207, "text": 188, "branch": 74, "choice": 8, "flag": 25,
+		"give_item": 18, "has_item": 9, "take_item": 3, "unknown": 36,
+		"pick_up_item": 108, "toggle_object": 9, "pokedex": 9, "give_pokemon": 4,
+		"trade": 7},
 }
 ## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
-## which no map text row names and which the disassembly marks unreferenced. Two
-## `call GivePokemon` rows are still reached past machine code this decoder does
-## not read: the Magikarp salesman's through `HasEnoughMoney` and the Lapras
-## through `wStatusFlags4`.
+## which no map text row names and which the disassembly marks unreferenced. The
+## `trade` rows are the eight `predef DoInGameTradeDialogue` sites plus
+## `CinnabarLabTradeRoom`'s second, whose `jr` shares the first one's tail;
+## Yellow ships neither trade house. The last `call GivePokemon` row the decoder
+## does not reach is the Magikarp salesman's, behind `HasEnoughMoney`.
 
 ## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
 ## and how many start ON. Three rows name an object their map has not got.

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -104,6 +104,28 @@ const MULTIPLIERS: Array[int] = [0, 5, 20]
 
 const MAX_LEVEL: int = 100
 
+## `TradeMons` whole, as dex numbers: the give and get species, the
+## `TRADE_DIALOGSET_*` and the nickname of every `npctrade` row, unused rows
+## included. Transcribed from `data/events/trades.asm`.
+const TRADES: Dictionary = {
+	&"red": [
+		[33, 30, 0, "TERRY"], [63, 122, 0, "MARCEL"], [12, 15, 2, "CHIKUCHIKU"],
+		[77, 86, 0, "SAILOR"], [21, 83, 2, "DUX"], [80, 108, 0, "MARC"],
+		[61, 124, 1, "LOLA"], [26, 101, 1, "DORIS"], [48, 114, 2, "CRINKLES"],
+		[32, 29, 2, "SPOT"],
+	],
+	&"yellow": [
+		[108, 51, 0, "GURIO"], [35, 122, 0, "MILES"], [12, 15, 2, "STINGER"],
+		[115, 89, 0, "STICKY"], [151, 151, 2, "BART"], [114, 47, 0, "SPIKE"],
+		[18, 18, 1, "MARTY"], [55, 112, 1, "BUFFY"], [58, 87, 2, "CEZANNE"],
+		[104, 67, 2, "RICKY"],
+	],
+}
+## `InGameTrade_TrainerString`, the one OT name every row shares, and the two
+## values `DoInGameTradeDialogue` rolls rather than storing.
+const TRADE_OT_NAME: String = "TRAINER"
+const TRADE_ROLLED: int = -1
+
 var _r: RefCounted = null
 
 
@@ -120,6 +142,7 @@ func _one_game() -> void:
 	_items()
 	_tmhm()
 	_trainers()
+	_trades()
 
 
 func _species() -> void:
@@ -430,3 +453,28 @@ static func _is_real_type(type: int) -> bool:
 	if type > TYPE_DRAGON:
 		return false
 	return type < TYPE_UNUSED_FIRST or type > TYPE_UNUSED_LAST
+
+
+## `TradeMons` and the `special_text` run behind `InGameTradeTextPointers`: ten
+## rows on all three cartridges, three dialog sets of five boxes each, and the
+## two boxes `InGameTrade_DoTrade` prints around the swap.
+func _trades() -> void:
+	var wanted: Array = TRADES[&"yellow" if _r.game_id == RomRegistry.YELLOW else &"red"]
+	var read: Array = []
+	for index: int in _r.data.world_trade_count():
+		var row: Dictionary = _r.data.world_trade(index)
+		read.append([
+			int(row["requested_species"]), int(row["offered_species"]),
+			int(row["dialog"]), String(row["nickname"]),
+		])
+		_r.check(
+			String(row["ot_name"]) == TRADE_OT_NAME
+			and int(row["dvs"]) == TRADE_ROLLED and int(row["ot_id"]) == TRADE_ROLLED,
+			"trade %d carries %s." % [index, row]
+		)
+	_r.check(read == wanted, "the trade table reads %s." % [read])
+	for name: String in Gen2Layout.TRADE_TEXT_ORDER + Gen1Layout.NPC_TRADE_TEXT_AT.keys():
+		_r.check(
+			not _r.data.special_text("npc_trade", name).is_empty(),
+			"the trade run has no %s box." % name
+		)

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -173,6 +173,15 @@ const MELANIE_CELL := Vector2i(3, 2)
 const MELANIE_FLAG: int = 168
 const MELANIE_BOX: String = "Is BULBASAUR"
 
+## `Route11Gate2FYoungsterText`, whose `wWhichTrade` is row 0 on all three
+## cartridges: `xor a` on Red and Blue and `ld a, TRADE_FOR_GURIO` on Yellow.
+const ROUTE_11_GATE_2F: int = 0x56
+const TRADE_YOUNGSTER := Vector2i(4, 3)
+const TRADE_ROW: int = 0
+## Any species the row does not ask for, which is TRADETEXT_WRONG_MON.
+const TRADE_WRONG_SPECIES: int = 25
+const TRADE_PARTY_SLOT: int = 2
+
 var _r: RefCounted = null
 
 
@@ -198,6 +207,7 @@ func _one_game() -> void:
 	_check_the_cable_club()
 	_check_the_vending_machine()
 	_check_the_prize_counter()
+	_check_a_trade()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -789,3 +799,120 @@ func _check_the_prize_counter() -> void:
 		)
 		world.complete_runtime_request({"ok": true})
 		_r.check(not world.script_busy(), "vendor %d never closed." % index)
+
+
+## `DoInGameTradeDialogue` walked whole: the offer both mon names fill, the
+## refusal, a species the row does not want, the swap and the line the trader has
+## once `wCompletedInGameTradeFlags` holds the bit.
+func _check_a_trade() -> void:
+	var trade: Dictionary = _r.data.world_trade(TRADE_ROW)
+	var wanted: int = int(trade.get("requested_species", 0))
+	var asked: String = _trade_offer()
+	_r.check(
+		asked.contains(String(_r.data.species(wanted).get("name", "")))
+		and asked.contains(String(_r.data.species(
+			int(trade.get("offered_species", 0))
+		).get("name", ""))),
+		"the trader offered %s." % [asked]
+	)
+	for row: Array in [
+		[1, 0, "cancel_", "a refused trade"],
+		[0, 0, "cancel_", "a cancelled list"],
+		[0, TRADE_WRONG_SPECIES, "wrong_", "the wrong species"],
+	]:
+		var said: String = _event_text(_trade_walk(int(row[0]), int(row[1])))
+		_r.check(said == _trade_text(String(row[2])), "%s said %s." % [row[3], said])
+	_walk_the_swap(wanted)
+
+
+## The three boxes behind a list that came back with the row's own species, and
+## the once-only bit the swap sets in front of them.
+func _walk_the_swap(wanted: int) -> void:
+	var world: Gen2WorldAPI = _facing_up(ROUTE_11_GATE_2F, TRADE_YOUNGSTER)
+	if world == null:
+		return
+	world.interact()
+	world.choose_script_input(0)
+	var cable: String = _event_text(world.complete_runtime_request({
+		"ok": true, "party_index": TRADE_PARTY_SLOT, "species": wanted,
+	}))
+	_r.check(
+		world.state.npc_trade_done(TRADE_ROW),
+		"the swap left `wCompletedInGameTradeFlags` clear."
+	)
+	_r.check(
+		cable == _r.data.special_text("npc_trade", "cable"),
+		"the swap opened with %s." % [cable]
+	)
+	var request: Dictionary = _runtime_request(world.run_event_queue(true))
+	if not _r.check(
+		StringName(request.get("kind", &"")) == &"trade_requested"
+		and int((request.get("values", {}) as Dictionary).get("party_index", -1))
+			== TRADE_PARTY_SLOT,
+		"the swap raised %s." % [request]
+	):
+		return
+	var receipt: String = _event_text(
+		world.complete_runtime_request({"ok": true, "accepted": true})
+	)
+	_r.check(
+		receipt == _trade_filled(_r.data.special_text("npc_trade", "traded_for")),
+		"the movie was followed by %s." % [receipt]
+	)
+	var thanks: String = _event_text(world.run_event_queue(true))
+	_r.check(thanks == _trade_text("complete_"), "the trader said %s." % [thanks])
+	world.run_event_queue(true)
+	var again: String = _trade_offer(world)
+	_r.check(again == _trade_text("after_"), "a done trade said %s." % [again])
+	_r.note("gen1 walk one in-game trade, both refusals and a wrong species")
+
+
+## The question the youngster opens with, on a world that may already carry the
+## bit.
+func _trade_offer(world: Gen2WorldAPI = null) -> String:
+	var open: Gen2WorldAPI = world if world != null \
+		else _facing_up(ROUTE_11_GATE_2F, TRADE_YOUNGSTER)
+	if open == null:
+		return ""
+	var results: Array = open.interact()
+	var asked: Dictionary = open.pending_script_input()
+	return String(asked["text"]) if asked.has("text") else _event_text(results)
+
+
+## One walk of the row: [param answer] is the YES/NO row and [param species] the
+## member the party list came back with, or 0 for a list that was cancelled.
+func _trade_walk(answer: int, species: int) -> Array:
+	var world: Gen2WorldAPI = _facing_up(ROUTE_11_GATE_2F, TRADE_YOUNGSTER)
+	if world == null:
+		return []
+	world.interact()
+	var results: Array = world.choose_script_input(answer)
+	if answer != 0:
+		return results
+	return world.complete_runtime_request({
+		"ok": true, "party_index": -1 if species < 1 else TRADE_PARTY_SLOT,
+		"species": species,
+	})
+
+
+## One `TradeTextPointers` cell of row 0's own dialog set, with both mon names
+## already in it.
+func _trade_text(prefix: String) -> String:
+	var trade: Dictionary = _r.data.world_trade(TRADE_ROW)
+	return _trade_filled(_r.data.special_text(
+		"npc_trade", "%s%d" % [prefix, int(trade.get("dialog", 0)) + 1]
+	))
+
+
+func _trade_filled(text: String) -> String:
+	var trade: Dictionary = _r.data.world_trade(TRADE_ROW)
+	var out: String = text
+	for row: Array in [
+		[Gen1Layout.TRADE_GIVE_NAME, int(trade.get("requested_species", 0))],
+		[Gen1Layout.TRADE_RECEIVE_NAME, int(trade.get("offered_species", 0))],
+	]:
+		out = Gen2TextStream.fill_all_markers(
+			out, "%s%04X>" % [Gen2TextStream.RAM_MARKER, int(row[0])],
+			String(_r.data.species(int(row[1])).get("name", ""))
+		)
+	return Gen2TextStream.fill_names(out, {"player": Gen2WorldScriptRunner.UNNAMED})

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -34,6 +34,7 @@ const KIND_HELP: Dictionary = {
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
 	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
+	&"trade": "presses: DoInGameTradeDialogue, faced up from the cell below the trader. 0 the offer and its YES/NO, 1 the party list YES opens",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
@@ -188,7 +189,7 @@ const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
 	&"gift": BOX_REVEAL_FRAMES,
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
-	&"prizes": BOX_REVEAL_FRAMES,
+	&"prizes": BOX_REVEAL_FRAMES, &"trade": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -350,15 +351,22 @@ func _stage_battle_tower_party() -> void:
 
 ## A party with something to heal: `HealParty` is a save transaction.
 func _stage_hurt_party() -> void:
-	var save: Gen2SaveData = _screen.active_save()
-	if save == null:
-		save = Gen2SaveStore.create_development_save(_screen._data, 0)
-		_screen.set_save(save)
+	var save: Gen2SaveData = _stage_party()
 	if save == null:
 		return
 	for mon: Gen2SaveMon in save.party:
 		mon.hp = 1
 	_screen._refresh_party_summary()
+
+
+## The save a list or a heal needs, made if the screen has none.
+func _stage_party() -> Gen2SaveData:
+	var save: Gen2SaveData = _screen.active_save()
+	if save != null:
+		return save
+	save = Gen2SaveStore.create_development_save(_screen._data, 0)
+	_screen.set_save(save)
+	return save
 
 
 func _settle_mon_special(host_property: String) -> void:
@@ -437,6 +445,7 @@ const STAGERS: Dictionary = {
 	&"nurse": &"_stage_nurse",
 	&"vending": &"_stage_vending",
 	&"prizes": &"_stage_prizes",
+	&"trade": &"_stage_trade",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -1045,6 +1054,12 @@ func _stage_prizes() -> void:
 	_stage_counter({
 		"items": {Gen1Layout.ITEM_COIN_CASE: 1}, "coins": Gen2WorldInventory.MAX_COINS,
 	})
+
+
+## The trader, faced the way a counter is, with a party for the list `YES` opens.
+func _stage_trade() -> void:
+	_stage_party()
+	_stage_counter({})
 
 
 ## A counter faced from the cell below it: presses, then rows down first.


### PR DESCRIPTION
`TradeMons` and `InGameTradeTextPointers` are imported into the shared `world_trades` section and the `npc_trade` text run, so one trade record and one text order serve both generations. A Generation 1 row stores no DVs and no OT id; -1 in each asks the host to roll one, which is what `AddPartyMon` and `InGameTrade_PrepareTradeData` do.

`DoInGameTradeDialogue` and `InGameTrade_DoTrade` are a step list on the world: the offer, the refusal, the party list, a species the row does not want, and the swap behind `wCompletedInGameTradeFlags`, which is `Gen2WorldState`'s own `_npc_trades`. Nine rows on Red and Blue and seven on Yellow reach it, the two in `CinnabarLabTradeRoom` sharing one `predef` through a `jr`.

`decode_script` reads four more opcodes: `xor a`, then `rrca` and `add a`, which are `CheckEvent flag, 1` leaving the flag in carry where `bit b, a` leaves it in Z, and the four conditional calls to a routine that spends nothing here. `Gen1Layout.ENGINE_FLAG_BYTES` puts `wStatusFlags4` in the engine flags above every Crystal index, which is what the Silph Co. Lapras is gated on.

| Cartridge | `text_asm` rows | was | boxes | was | trades |
|---|---|---|---|---|---|
| Red, Blue | 225 | 211 | 235 | 224 | 9 |
| Yellow | 207 | 197 | 188 | 179 | 7 |

`SelectTradeOrDayCareMon`'s gender column is Crystal's alone, and the party list's prompt is the cartridge's own where a Generation 1 font had drawn `?MON`.

`tools/checks/gen1_tables.gd` pins all ten rows and all seventeen boxes on the three cartridges, `gen1_walk.gd` drives one trade through both refusals, a wrong species and the swap, `gen1_maps.gd` pins the corpus census, and `tools/preview_world.gd -- red 0 168 <out.png> live trade@1,5 0` photographs the offer. Cache format 116.
