### PR TITLE
Spend money on a Generation 1 map

### DIFF
--- a/autoload/game_runtime.gd
+++ b/autoload/game_runtime.gd
@@ -55,7 +55,6 @@ static func data_or_any() -> GameData:
 	return GameData.open_any()
 
 
-## The selected slot's save, or null when there is no runtime or no slot.
 static func selected_save_or_null() -> Gen2SaveData:
 	var runtime: Gen2GameRuntime = instance()
 	if runtime == null or not runtime.has_selected_save_slot():

--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2739,7 +2739,6 @@ static func _is_item(action: Dictionary) -> bool:
 	return StringName(action.get("type", ACTION_MOVE)) == ACTION_ITEM
 
 
-## The event a run attempt produces, carrying whatever branch answered it.
 func _run_event(type: StringName, attempt: Dictionary) -> Dictionary:
 	var out: Dictionary = attempt.duplicate(true)
 	out.erase("outcome")

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -233,7 +233,6 @@ var _bars: Dictionary = {}
 ## `MonFaintedAnimation`s still running, oldest first. A double faint runs two,
 ## one after the other, the way the source's two calls do.
 var _faints: Array[Dictionary] = []
-## The running [Gen2ExpBarAnimation], or null when the exp bar is not filling.
 var _exp_bar: Gen2ExpBarAnimation = null
 ## The running [Gen2BattleIntro], or null once the pics have slid into place.
 var _intro: Gen2BattleIntro = null:

--- a/game/battle/damage.gd
+++ b/game/battle/damage.gd
@@ -378,7 +378,6 @@ const HAPPINESS_DENOMINATOR: int = 25
 const HAPPINESS_MAX: int = 255
 
 
-## The [constant MAGNITUDE_POWER] row a rolled byte lands on.
 static func magnitude_row(roll: int) -> Array:
 	for row: Array in MAGNITUDE_POWER:
 		if int(row[0]) >= roll:

--- a/game/battle/turn.gd
+++ b/game/battle/turn.gd
@@ -19,7 +19,6 @@ var move: Dictionary = {}
 ## The same Array [method Gen2Battle.take_actions] hands its caller back.
 var events: Array = []
 
-## What the damage steps worked out, for the steps after them.
 var damage: int = 0
 var critical: bool = false
 var effectiveness: int = Gen2Layout.MATCHUP_EFFECTIVE

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1384,7 +1384,6 @@ func _load_dex_orders(path: String) -> void:
 		_dex_orders[key] = order
 
 
-## The moves a Pokémon of this species is created knowing at [param level].
 func moves_at_level(number: int, level: int) -> Array:
 	var known: Array = starting_moves(number)
 	Gen2Learnset.fill_moves(learnset(number), known, level)

--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -67,7 +67,6 @@ const VECTOR_FIELDS: Array[String] = ["map"]
 var _data: GameData = null
 ## id to row.
 var _rows: Dictionary = {}
-## kind to the ids under it, in decode order.
 var _by_kind: Dictionary = {}
 ## The commands a site's fields also have to reach, keyed by the byte they sit
 ## at: `bank << 24 | address` to `{id, role}`. A starter's species is its ball's
@@ -342,7 +341,6 @@ func badge_for_hm_item(item: int) -> int:
 	return Gen2WorldFieldMove.badge_for_move(move_for_hm_item(item))
 
 
-## The field move [param item] teaches, or 0 for anything that is not a field HM.
 func move_for_hm_item(item: int) -> int:
 	if _data == null or not Gen2WorldTMHM.is_hm(item, _data.generation):
 		return 0

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -695,6 +695,7 @@ const TRAINER_RANGE_SHIFT: int = 4
 ## ends the path [method Gen1WorldImporter.decode_script] is walking.
 const TEXT_ASM: int = 0x08
 const SCRIPT_LD_HL: int = 0x21
+const SCRIPT_LD_DE: int = 0x11
 const SCRIPT_LD_BC: int = 0x01
 const SCRIPT_LD_B: int = 0x06
 const SCRIPT_LD_A: int = 0x3E
@@ -731,7 +732,7 @@ const SCRIPT_CALLS: Array[String] = [
 	"print_text", "text_script_end", "disable_waiting", "yes_no_choice",
 	"give_item", "is_item_in_bag", "bankswitch", "play_cry", "wait_for_sound",
 	"predef", "display_pokedex", "give_pokemon", "wait_for_button",
-	"auto_textbox_on", "auto_textbox_off",
+	"auto_textbox_on", "auto_textbox_off", "has_enough_money", "display_text_box",
 ]
 ## The routines that spend nothing here: no audio driver, a press already ends
 ## every box, and `wAutoTextBoxDrawingControl` has no counterpart.
@@ -740,8 +741,16 @@ const SCRIPT_SILENT_CALLS: Array[String] = [
 	"auto_textbox_on", "auto_textbox_off",
 ]
 const SCRIPT_CONDITIONAL_CALLS: Array[int] = [0xC4, 0xCC, 0xD4, 0xDC]
+## The two packed-decimal buffers a price is written into, most significant
+## byte first. `wPriceTemp` stands at `wWhichTrade`'s own address.
+const SCRIPT_BCD_BUFFERS: Array[String] = ["money_hram", "which_trade"]
+const MONEY_BYTES: int = 3
+const MONEY_BOX_ID: int = 0x13
 const SCRIPT_SHORT_SIZE: int = 2
 const SCRIPT_LONG_SIZE: int = 3
+## Every conditional `jr` is below this and every conditional `jp` above it, so
+## `jp nz` at $C2 is three bytes where [constant SCRIPT_JP] would call it two.
+const SCRIPT_HOP_LIMIT: int = 0x40
 ## The `CB` prefix's three rows, the low three bits naming the operand.
 const SCRIPT_BIT_BASE: int = 0x40
 const SCRIPT_RES_BASE: int = 0x80
@@ -992,6 +1001,14 @@ const RED_BLUE: Dictionary = {
 	"give_item": 0x3E2E,
 	"is_item_in_bag": 0x3493,
 	"bankswitch": 0x35D6,
+	## `HasEnoughMoney` against `hMoney`, `SubBCDPredef` off `wPlayerMoney` and
+	## the `MONEY_BOX` `DisplayTextBoxID` draws.
+	"has_enough_money": 0x35A6,
+	"display_text_box": 0x30E8,
+	"text_box_id": 0xD125,
+	"money_hram": 0xFF9F,
+	"player_money": 0xD347,
+	"sub_bcd": 0x0F836,
 	"remove_item": 0x7F37,
 	"remove_item_bank": 0x05,
 	"do_not_wait": 0xCC3C,
@@ -1116,6 +1133,12 @@ const YELLOW: Dictionary = {
 	"give_item": 0x3E3F,
 	"is_item_in_bag": 0x3422,
 	"bankswitch": 0x3E84,
+	"has_enough_money": 0x35C3,
+	"display_text_box": 0x3010,
+	"text_box_id": 0xD124,
+	"money_hram": 0xFF9F,
+	"player_money": 0xD346,
+	"sub_bcd": 0x0F6BC,
 	"remove_item": 0x7DBB,
 	"remove_item_bank": 0x05,
 	"do_not_wait": 0xCC3C,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -991,6 +991,7 @@ const SCRIPT_TESTS_CHOICE: int = -1
 const SCRIPT_TESTS_NOTHING: int = -2
 const SCRIPT_TESTS_CARRY: int = -3
 const SCRIPT_TESTS_ITEM: int = -4
+const SCRIPT_TESTS_MONEY: int = -5
 
 
 ## One `text_asm` row's machine code, as the boxes it prints and the branches
@@ -1023,7 +1024,7 @@ static func _walk_script(
 		var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
 		if Gen1Layout.SCRIPT_BRANCHES.has(op) or Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op):
 			return _script_branch(ctx, op, pc, state, depth, out)
-		var next: int = _script_step(ctx, pc, state, out)
+		var next: int = _script_step(ctx, pc, state, out, depth)
 		if next == SCRIPT_END:
 			return _script_ended(state, out)
 		if next == SCRIPT_UNREAD:
@@ -1044,13 +1045,16 @@ static func _script_ended(state: Dictionary, out: Array) -> Array:
 ## One instruction: the next address, [constant SCRIPT_END] or SCRIPT_UNREAD.
 ## The register writes are here and [method _script_flow] has the rest.
 static func _script_step(
-	ctx: Dictionary, pc: int, state: Dictionary, out: Array
+	ctx: Dictionary, pc: int, state: Dictionary, out: Array, depth: int
 ) -> int:
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
 	match rom.u8(at):
 		Gen1Layout.SCRIPT_LD_HL:
 			state["hl"] = rom.u16le(at + 1)
+			return pc + Gen1Layout.SCRIPT_LONG_SIZE
+		Gen1Layout.SCRIPT_LD_DE:
+			state["de"] = rom.u16le(at + 1)
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
 		Gen1Layout.SCRIPT_LD_BC:
 			## `lb bc, ITEM, COUNT`: the high byte is what `GiveItem` reads as b.
@@ -1069,24 +1073,22 @@ static func _script_step(
 			state["b"] = int(state["a"])
 			return pc + 1
 		Gen1Layout.SCRIPT_LD_A:
+			_script_wrote_a(state)
 			state["a"] = rom.u8(at + 1)
-			state.erase("source")
-			state.erase("rotated")
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_XOR_A:
 			## Zero and a Z the `ld a, 0` above does not raise, so whatever a
 			## branch behind it was reading is gone.
+			_script_wrote_a(state)
 			state["a"] = 0
-			state.erase("source")
-			state.erase("rotated")
 			state.erase("tests")
 			return pc + 1
-	return _script_flow(ctx, pc, at, state, out)
+	return _script_flow(ctx, pc, at, state, out, depth)
 
 
 ## What reads memory, tests it or leaves the instruction after this one.
 static func _script_flow(
-	ctx: Dictionary, pc: int, at: int, state: Dictionary, out: Array
+	ctx: Dictionary, pc: int, at: int, state: Dictionary, out: Array, depth: int
 ) -> int:
 	var rom: RomFile = ctx["rom"]
 	match rom.u8(at):
@@ -1102,6 +1104,7 @@ static func _script_flow(
 			) else SCRIPT_UNREAD
 		Gen1Layout.SCRIPT_AND_A:
 			_script_test_bit(ctx, state, -1)
+			state["tests_and_a"] = true
 			return pc + 1
 		Gen1Layout.SCRIPT_RRCA:
 			return _script_rotated(ctx, pc, state, int(state.get("rotated", 0)))
@@ -1116,11 +1119,11 @@ static func _script_flow(
 		Gen1Layout.SCRIPT_JR:
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE + _script_hop(rom.u8(at + 1))
 		Gen1Layout.SCRIPT_JP:
-			return _script_jump(ctx, pc, rom.u16le(at + 1), state, out)
+			return _script_jump(ctx, pc, rom.u16le(at + 1), state, out, depth)
 		Gen1Layout.SCRIPT_RET:
 			return SCRIPT_END
 		Gen1Layout.SCRIPT_CALL:
-			return _script_call(ctx, pc, rom.u16le(at + 1), state, out)
+			return _script_call(ctx, pc, rom.u16le(at + 1), state, out, depth)
 	if Gen1Layout.SCRIPT_CONDITIONAL_CALLS.has(rom.u8(at)):
 		return _script_call_if(ctx, pc, rom.u16le(at + 1), state)
 	return SCRIPT_UNREAD
@@ -1139,7 +1142,7 @@ static func _script_call_if(
 
 ## What a branch is reading, and whether it is reading it out of carry.
 static func _script_untested(state: Dictionary) -> void:
-	for key: String in ["tests", "tests_in_carry", "tests_engine"]:
+	for key: String in ["tests", "tests_in_carry", "tests_engine", "tests_and_a"]:
 		state.erase(key)
 
 
@@ -1149,6 +1152,7 @@ static func _script_tested(
 	state["tests"] = value
 	state["tests_in_carry"] = in_carry
 	state["tests_engine"] = engine
+	state.erase("tests_and_a")
 
 
 ## One rotation of `CheckEvent flag, 1`'s run, or `add a` standing for all eight
@@ -1165,12 +1169,20 @@ static func _script_hop(operand: int) -> int:
 	return operand - 0x100 if operand > 0x7F else operand
 
 
+## Anything that writes `a` leaves `CheckEvent`'s rotation and the answer
+## `and a` gave about the register behind it.
+static func _script_wrote_a(state: Dictionary) -> void:
+	state.erase("source")
+	state.erase("rotated")
+	state.erase("tests_and_a")
+
+
 ## `ld a, [nn]`. `ShowPokedexDataInternal` leaves `wPokedexNum` in
 ## `wCurPartySpecies`, which the Fighting Dojo's two gifts read the species from.
 static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> void:
-	state["source"] = address
+	_script_wrote_a(state)
 	state.erase("a")
-	state.erase("rotated")
+	state["source"] = address
 	if address == int((ctx["layout"] as Dictionary)["cur_party_species"]) \
 		and state.has("species_index"):
 		state["a"] = int(state["species_index"])
@@ -1179,14 +1191,14 @@ static func _script_loaded(ctx: Dictionary, address: int, state: Dictionary) -> 
 ## `jp` reaching `TextScriptEnd`, a routine the layout names, or an address in
 ## the same bank. A tail call returns where the row's own `ret` would.
 static func _script_jump(
-	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array
+	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array, depth: int
 ) -> int:
 	var layout: Dictionary = ctx["layout"]
 	if target == int(layout["text_script_end"]):
 		return SCRIPT_END
 	if _script_routine(layout, target).is_empty():
 		return target
-	return SCRIPT_END if _script_call(ctx, pc, target, state, out) != SCRIPT_UNREAD \
+	return SCRIPT_END if _script_call(ctx, pc, target, state, out, depth) != SCRIPT_UNREAD \
 		else SCRIPT_UNREAD
 
 
@@ -1220,10 +1232,12 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 			return false
 		state["no_press"] = true
 		return true
-	if address == int(layout["which_trade"]):
+	if address == int(layout["text_box_id"]):
 		if not state.has("a"):
 			return false
-		state["trade"] = int(state["a"])
+		state["text_box"] = int(state["a"])
+		return true
+	if _script_bcd_stored(ctx, address, state):
 		return true
 	if address == int(layout["toggleable_index"]):
 		if not state.has("a"):
@@ -1313,7 +1327,7 @@ static func _script_prefix(
 ## The routines a row may call. No audio driver here, so a cry and the wait
 ## behind it spend nothing and the walk carries on past them.
 static func _script_call(
-	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array
+	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array, depth: int
 ) -> int:
 	var layout: Dictionary = ctx["layout"]
 	var next: int = pc + Gen1Layout.SCRIPT_LONG_SIZE
@@ -1344,43 +1358,40 @@ static func _script_call(
 		"is_item_in_bag":
 			return _script_asked(state, next)
 		"bankswitch":
-			return _script_far(layout, state, out, next)
+			return _script_far(ctx, state, out, next, depth)
 		"predef":
 			return _script_predef(ctx, state, out, next)
 		"display_pokedex":
 			return _script_pokedex(ctx, state, out, next)
 		"give_pokemon":
 			return _script_gift_pokemon(ctx, state, out, next)
-	return _script_local_call(ctx, target, state, out, next)
+		"has_enough_money":
+			return _script_money_asked(state, next)
+		"display_text_box":
+			return _script_money_box(state, out, next)
+	return _script_routine_call(ctx, int(ctx["bank"]), target, state, out, next, depth)
 
 
-## A `call` to a routine the layout does not name, which is the map's own:
-## walked here and returned from. `MtMoonB2FReceivedFossilText` is an `ld hl` and
-## a tail `jp PrintText`, so a fossil says nothing without this.
-static func _script_local_call(
-	ctx: Dictionary, target: int, state: Dictionary, out: Array, next: int
+## A `call` to a routine the layout does not name, walked in [param bank] and
+## returned from: `MtMoonB2FReceivedFossilText` is an `ld hl` and a tail
+## `jp PrintText`, and Yellow keeps 22 rows behind a `callfar`.
+static func _script_routine_call(
+	ctx: Dictionary, bank: int, target: int, state: Dictionary, out: Array,
+	next: int, depth: int
 ) -> int:
 	var nesting: Array = ctx["calls"]
-	if nesting[0] >= Gen1Layout.SCRIPT_CALL_DEPTH:
+	if nesting[0] >= Gen1Layout.SCRIPT_CALL_DEPTH or bank < 0 or target < 0:
 		return SCRIPT_UNREAD
 	nesting[0] += 1
-	var pc: int = target
-	var budget: Array = ctx["budget"]
-	var answer: int = SCRIPT_UNREAD
-	while budget[0] > 0:
-		budget[0] -= 1
-		var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
-		## A branch inside one would need a return address per side.
-		if Gen1Layout.SCRIPT_BRANCHES.has(op) or Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op):
-			break
-		pc = _script_step(ctx, pc, state, out)
-		if pc == SCRIPT_UNREAD:
-			break
-		if pc == SCRIPT_END:
-			answer = next
-			break
+	var outer: int = int(ctx["bank"])
+	ctx["bank"] = bank
+	var walked: Variant = _walk_script(ctx, target, state, depth + 1)
+	ctx["bank"] = outer
 	nesting[0] -= 1
-	return answer
+	if not walked is Array:
+		return SCRIPT_UNREAD
+	out.append_array(walked as Array)
+	return next
 
 
 static func _script_routine(layout: Dictionary, target: int) -> String:
@@ -1446,17 +1457,95 @@ static func _script_asked(state: Dictionary, next: int) -> int:
 	return next
 
 
-## `farcall` is `ld b, BANK`, `ld hl, target`, `call Bankswitch`.
+## `farcall` is `ld b, BANK`, `ld hl, target`, `call Bankswitch`, and `callfar`
+## the same two the other way about.
 static func _script_far(
-	layout: Dictionary, state: Dictionary, out: Array, next: int
+	ctx: Dictionary, state: Dictionary, out: Array, next: int, depth: int
 ) -> int:
-	if int(state.get("b", -1)) != int(layout["remove_item_bank"]) \
-		or int(state.get("hl", -1)) != int(layout["remove_item"]) \
-		or int(state.get("remove", 0)) < 1:
+	var layout: Dictionary = ctx["layout"]
+	var bank: int = int(state.get("b", -1))
+	var target: int = int(state.get("hl", -1))
+	if bank != int(layout["remove_item_bank"]) or target != int(layout["remove_item"]):
+		return _script_routine_call(ctx, bank, target, state, out, next, depth)
+	if int(state.get("remove", 0)) < 1:
 		return SCRIPT_UNREAD
 	out.append({"op": "take_item", "item": int(state["remove"])})
 	state.erase("remove")
 	return next
+
+
+## One byte of `hMoney` or `wPriceTemp`, whose first byte is `wWhichTrade`'s
+## own, so a store there is kept as both.
+static func _script_bcd_stored(
+	ctx: Dictionary, address: int, state: Dictionary
+) -> bool:
+	var layout: Dictionary = ctx["layout"]
+	for name: String in Gen1Layout.SCRIPT_BCD_BUFFERS:
+		var base: int = int(layout[name])
+		if address < base or address >= base + Gen1Layout.MONEY_BYTES:
+			continue
+		if not state.has("a"):
+			return false
+		## Duplicated, because a branch's two sides share this state's values.
+		var bytes: Dictionary = (state.get(name, {}) as Dictionary).duplicate()
+		bytes[address - base] = int(state["a"])
+		state[name] = bytes
+		if name == "which_trade" and address == base:
+			state["trade"] = int(state["a"])
+		return true
+	return false
+
+
+## Three packed-decimal bytes as a number, -1 until all three are written.
+static func _script_bcd_value(state: Dictionary, name: String) -> int:
+	var bytes: Dictionary = state.get(name, {})
+	var value: int = 0
+	for index: int in Gen1Layout.MONEY_BYTES:
+		if not bytes.has(index):
+			return -1
+		var byte: int = int(bytes[index])
+		value = value * 100 + (byte >> 4) * 10 + (byte & 0xF)
+	return value
+
+
+## `HasEnoughMoney` compares `hMoney` with the player's own three bytes through
+## `StringCmp`, which sets carry when the player is short.
+static func _script_money_asked(state: Dictionary, next: int) -> int:
+	var price: int = _script_bcd_value(state, Gen1Layout.SCRIPT_BCD_BUFFERS[0])
+	if price < 1:
+		return SCRIPT_UNREAD
+	state["price"] = price
+	_script_tested(state, SCRIPT_TESTS_MONEY, true)
+	return next
+
+
+## `DisplayMoneyBox` draws the balance over the map and returns, and MONEY_BOX
+## is the only `wTextBoxID` a text row writes.
+static func _script_money_box(state: Dictionary, out: Array, next: int) -> int:
+	if int(state.get("text_box", -1)) != Gen1Layout.MONEY_BOX_ID:
+		return SCRIPT_UNREAD
+	out.append({"op": "money_box"})
+	return next
+
+
+## `predef SubBCDPredef` with `wPlayerMoney + 2` in de and three in c.
+static func _script_spend(
+	ctx: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	var layout: Dictionary = ctx["layout"]
+	var last: int = Gen1Layout.MONEY_BYTES - 1
+	if int(state.get("de", -1)) != int(layout["player_money"]) + last \
+		or int(state.get("c", -1)) != Gen1Layout.MONEY_BYTES:
+		return SCRIPT_UNREAD
+	for name: String in Gen1Layout.SCRIPT_BCD_BUFFERS:
+		if int(state.get("hl", -1)) != int(layout[name]) + last:
+			continue
+		var amount: int = _script_bcd_value(state, name)
+		if amount < 1:
+			return SCRIPT_UNREAD
+		out.append({"op": "spend_money", "amount": amount})
+		return next
+	return SCRIPT_UNREAD
 
 
 ## `predef` is `ld a, id` and `call Predef`; `PredefPointers` is the bank and
@@ -1475,6 +1564,8 @@ static func _script_predef(
 	if target == int(layout["pick_up_item"]):
 		out.append({"op": "pick_up_item"})
 		return next
+	if target == int(layout["sub_bcd"]):
+		return _script_spend(ctx, state, out, next)
 	if target == int(layout["in_game_trade"]):
 		if not state.has("trade"):
 			return SCRIPT_UNREAD
@@ -1517,15 +1608,22 @@ static func _script_branch(
 		return null
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
-	var short: bool = op < Gen1Layout.SCRIPT_JP
+	var short: bool = op < Gen1Layout.SCRIPT_HOP_LIMIT
 	var size: int = Gen1Layout.SCRIPT_SHORT_SIZE if short else Gen1Layout.SCRIPT_LONG_SIZE
 	var jumped: int = pc + size + _script_hop(rom.u8(at + 1)) if short else rom.u16le(at + 1)
-	var branches: Array = [
-		_walk_script(ctx, jumped, state.duplicate(), depth + 1),
-		_walk_script(ctx, pc + size, state.duplicate(), depth + 1),
-	]
 	var table: Dictionary = Gen1Layout.SCRIPT_CARRY_BRANCHES if carry \
 		else Gen1Layout.SCRIPT_BRANCHES
+	var jumped_state: Dictionary = state.duplicate()
+	var fell_state: Dictionary = state.duplicate()
+	if bool(state.get("tests_and_a", false)):
+		## `and a` leaves `a` where it was and raises Z only when it is zero, so
+		## the side a `jp nz` does not take knows the register is zero.
+		var zero: Dictionary = fell_state if bool(table[op]) else jumped_state
+		zero["a"] = 0
+	var branches: Array = [
+		_walk_script(ctx, jumped, jumped_state, depth + 1),
+		_walk_script(ctx, pc + size, fell_state, depth + 1),
+	]
 	if not bool(table[op]):
 		branches.reverse()
 	if branches[0] == null and branches[1] == null:
@@ -1556,6 +1654,11 @@ static func _script_node(
 		SCRIPT_TESTS_ITEM:
 			return {"op": "has_item", "item": int(state["asked"]),
 				"then": taken, "else": fell}
+		SCRIPT_TESTS_MONEY:
+			## Carry is set when the player is short, so the taken side of a
+			## `jr c` is the refusal and the other one is the sale.
+			return {"op": "has_money", "price": int(state["price"]),
+				"then": fell, "else": taken}
 	var branch: Dictionary = {
 		"op": "branch", "flag": int(tests), "then": taken, "else": fell,
 	}

--- a/game/import/rom_importer.gd
+++ b/game/import/rom_importer.gd
@@ -4131,7 +4131,6 @@ static func _verify_bar(
 	return {"ok": true, "message": ""}
 
 
-## One tile out of a strip, as its own buffer.
 static func _strip_tile(strip: PackedByteArray, tiles: int, tile: int) -> PackedByteArray:
 	var width: int = tiles * PokeTiles.TILE_WIDTH
 	var out: PackedByteArray = PackedByteArray()
@@ -4589,7 +4588,6 @@ static func verify_trainer_dvs(rom: RomFile, layout: Dictionary) -> Dictionary:
 	return {"ok": true, "message": ""}
 
 
-## Resolves one entry of the type name pointer table.
 static func type_name(rom: RomFile, layout: Dictionary, type_number: int) -> String:
 	var table: int = Gen2Layout.type_name_pointer_offset(layout, type_number)
 	var address: int = rom.u16le(table)

--- a/game/import/rom_layout.gd
+++ b/game/import/rom_layout.gd
@@ -3456,7 +3456,6 @@ const CRYSTAL: Dictionary = {
 }
 
 
-## The layout for a game id, or an empty Dictionary if it is not characterised.
 static func for_id(id: StringName) -> Dictionary:
 	match id:
 		RomRegistry.GOLD:

--- a/game/import/tile_codec.gd
+++ b/game/import/tile_codec.gd
@@ -10,7 +10,6 @@ extends RefCounted
 const TILE_WIDTH: int = 8
 const TILE_HEIGHT: int = 8
 const TILE_PIXELS: int = 64
-## Bytes of 2bpp data per tile.
 const TILE_BYTES: int = 16
 ## Bytes of 1bpp data per tile: one row per byte, with no second plane.
 const TILE_1BPP_BYTES: int = 8

--- a/game/launcher/launcher_theme.gd
+++ b/game/launcher/launcher_theme.gd
@@ -51,7 +51,6 @@ var backdrop_bottom: Color
 ## laid on the page. It is the opposite of the page, so a control is legible
 ## without an outline and a filled one says so from across the room.
 var surface: Color
-## What is written or drawn on [member surface].
 var on_surface: Color
 ## A content card: the same side of the page as the backdrop, because the text
 ## inside one is page text.

--- a/game/mods/mod_art.gd
+++ b/game/mods/mod_art.gd
@@ -114,7 +114,6 @@ static func cache_icon(url: String, bytes: PackedByteArray, directory: String = 
 	return true
 
 
-## The cached icon for [param url], or null when it was never fetched.
 static func cached_icon(url: String, directory: String = CACHE_DIRECTORY) -> Texture2D:
 	return icon_texture(cache_path(url, directory))
 

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -19,7 +19,6 @@ const ROOT: String = "user://mods"
 const WORLD_RENDERER_METHODS: Array[String] = [
 	"set_world", "set_time_of_day", "refresh", "refresh_animation",
 ]
-## The methods a battle renderer has to provide.
 const BATTLE_RENDERER_METHODS: Array[String] = [
 	"set_battle_data", "set_view", "refresh",
 ]
@@ -203,7 +202,6 @@ static var _mounted_packs: Dictionary = {}
 var _manifests: Dictionary = {}
 ## Every mod directory [method discover] saw, refused manifests included.
 var _present: Dictionary = {}
-## Mod id to version for every entry script that ran. See [method loaded_mods].
 var _loaded: Dictionary = {}
 ## Mod id to the entry object `register` was called on, held so it survives the
 ## load. See [method load_mod].
@@ -213,7 +211,6 @@ var _entries: Dictionary = {}
 ## nothing: the launcher runs before Play is pressed.
 var _target_game: StringName = &""
 var _options: Dictionary = {}
-## Mod id to its registered actions. See [method register_action].
 var _actions: Dictionary = {}
 var _world_renderers: Dictionary = {}
 ## Mod id to the world actor it registered. Held for as long as the mod is
@@ -963,7 +960,6 @@ func battle_renderer_label(id: StringName) -> String:
 	return _renderer_label(_battle_renderers, id)
 
 
-## The battle half of the same choice. See [method selected_world_renderer].
 func selected_battle_renderer() -> StringName:
 	return _selected_view if _battle_renderers.has(_selected_view) else BUILT_IN_RENDERER
 

--- a/game/mods/mod_index.gd
+++ b/game/mods/mod_index.gd
@@ -45,7 +45,6 @@ const UP_TO_DATE: StringName = &"up_to_date"
 const INSTALLED_IS_NEWER: StringName = &"installed_is_newer"
 ## Either side is missing a version or carries one nothing can order.
 const UNKNOWN: StringName = &"unknown"
-## Not installed at all, so there is nothing to compare.
 const NOT_INSTALLED: StringName = &"not_installed"
 
 

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -47,7 +47,6 @@ var dependencies: Dictionary = {}
 ## when the launcher gains another generation, since a mod naming the three
 ## Generation II cartridges refuses on a fourth without being edited.
 var games: Array[StringName] = []
-## Absolute path of the directory the manifest was read from.
 var directory: String = ""
 
 

--- a/game/render/battle_hud.gd
+++ b/game/render/battle_hud.gd
@@ -31,7 +31,6 @@ const PLAYER_HP: Vector2i = Vector2i(11, 10)
 const PLAYER_EXP: Vector2i = Vector2i(10, 11)
 const PLAYER_EDGE: Vector2i = Vector2i(18, 10)
 
-## How many tiles of edge run along the bottom of a panel.
 const EDGE_TILES: int = 8
 
 ## Both HP numbers are printed three columns wide, right-aligned, with a slash

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -54,7 +54,6 @@ const EXP_BAR_FIRST_PARTIAL: int = 0x55
 ## the stats screen eight, and this one is `DrawEnemyHUDBorder`'s ball.
 const CAUGHT_BALL: int = 0x5D
 
-## The level symbol, printed before a number.
 const LEVEL: int = 0x6E
 
 ## The enemy's HUD hangs from a side on its left; the player's from one on its

--- a/game/render/intro_movie_page.gd
+++ b/game/render/intro_movie_page.gd
@@ -217,7 +217,6 @@ func draw(movie: Gen2IntroMovie) -> Image:
 	return Gen2PicImage.canvas_image(pixels, WIDTH, HEIGHT)
 
 
-## [method Gen2GoldSilverIntroPage.shadow_oam]'s buffer for this movie.
 func shadow_oam(movie: Gen2IntroMovie) -> Array[Dictionary]:
 	var out: Array[Dictionary] = []
 	if movie == null:

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -213,6 +213,10 @@ static func balance_window(
 			page._text(indices, width, "COIN", BALANCES_COIN_LABEL_AT)
 			page._text(indices, width, coin_string(coins), BALANCES_COIN_AT)
 		_:
+			## `DisplayMoneyBox` writes MONEY into the box's own top border,
+			## where `PlaceMoneyTopRight` draws the balance alone.
+			if data.generation == RomRegistry.GEN1:
+				page._text(indices, width, GEN1_MONEY_LABEL, GEN1_MONEY_LABEL_AT)
 			page._text(indices, width, money_string(money), MONEY_TEXT_AT)
 	var image: Image = Gen2PicImage.from_indices(
 		indices, width, Gen2Screen.HEIGHT,

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -199,7 +199,6 @@ const ARROW_LEFT: int = 0x3D
 const ARROW_RIGHT: int = 0x3E
 
 var font: Gen2Font = null
-## The dex sheet and the footprint strip, each as the cache's own index buffer.
 var _sheet: PackedByteArray = PackedByteArray()
 var _footprints: PackedByteArray = PackedByteArray()
 var _unown_font: PackedByteArray = PackedByteArray()

--- a/game/render/second_screen.gd
+++ b/game/render/second_screen.gd
@@ -97,11 +97,9 @@ var _idle: Control = null
 ## built it. Kept so a rebuild is skipped when the answer would be the same node.
 var _page: Node = null
 var _page_kind: StringName = &""
-## The tab row's icons, one [TextureRect] per tab, rebuilt with the tab set.
 var _icons: Array[TextureRect] = []
 ## What [method _gate] answered when the row was last built.
 var _gate_read: String = ""
-## The cartridge's glyphs, for the frame around the tab row.
 var _glyphs: Gen2Font = null
 
 

--- a/game/render/second_screen_host.gd
+++ b/game/render/second_screen_host.gd
@@ -51,7 +51,6 @@ var _view: Gen2SecondScreen = null
 var _plugin: Object = null
 var _window: Window = null
 var _since_present: float = 0.0
-## Frames a still page is still owed. See [constant PANEL_SETTLE_FRAMES].
 var _settle: int = PANEL_SETTLE_FRAMES
 
 

--- a/game/rom/rom_registry.gd
+++ b/game/rom/rom_registry.gd
@@ -86,7 +86,6 @@ static func lookup(sha1: String) -> Dictionary:
 	return BY_SHA1.get(sha1.to_lower(), {})
 
 
-## The registry row for a game id, or an empty Dictionary if the id is not ours.
 static func row_for(id: StringName) -> Dictionary:
 	for sha1: String in BY_SHA1:
 		if BY_SHA1[sha1]["id"] == id:
@@ -128,7 +127,6 @@ static func ids_of_generation(generation: int) -> Array[StringName]:
 	return out
 
 
-## The dump size a given cartridge must have, or 0 for an id we do not know.
 static func size_for(id: StringName) -> int:
 	return int(SIZES.get(generation_for(id), 0))
 

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -164,7 +164,6 @@ var _menu_page: Gen2MenuPage = null
 ## A refusal standing in the menu's own bottom box, which the next A or B
 ## clears. See [constant MESSAGE_NOT_ENOUGH_HP].
 var _message: String = ""
-## Whether this is being read rather than driven. See [method set_read_only].
 var _read_only: bool = false
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 ## `OpenPartyStats`' own screen, standing over the whole party menu while it is

--- a/game/world/oak_speech_screen.gd
+++ b/game/world/oak_speech_screen.gd
@@ -118,7 +118,6 @@ func _process(delta: float) -> void:
 	advance_frames(_frame_clock.tick(delta))
 
 
-## [method Gen2ClockSetScreen.advance_frames] over this screen's own state.
 func advance_frames(count: int) -> void:
 	for _frame: int in count:
 		if _text_box != null:

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -97,7 +97,6 @@ var _message: String = ""
 ## `wDexArrowCursorBlinkCounter`, and the leftover of a hardware frame this
 ## screen has not counted yet.
 var _blink: int = 0
-## Whether this is being read rather than driven. See [method set_read_only].
 var _read_only: bool = false
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 

--- a/game/world/pokegear_screen.gd
+++ b/game/world/pokegear_screen.gd
@@ -104,7 +104,6 @@ var _submenu_cursor: int = 0
 var _asking_delete: bool = false
 var _yes_no_cursor: int = 0
 
-## The screen this is drawn in, and the 160x144 layer inside it.
 var _screen: Gen2Screen = null
 var _field: Control = null
 var _background: TextureRect = null

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3677,6 +3677,25 @@ var gen1_rival_name: String = Gen2WorldScriptRunner.UNNAMED
 ## a frame wait, or a facility request waiting for its host. A plain text is one
 ## box; `DisplayPokemonCenterDialogue_` is five of them around a choice.
 var _gen1_steps: Array = []
+var _gen1_money_window: bool = false
+const GEN1_WAITING_STEPS: Array[StringName] = [&"request", &"choice", &"wait"]
+## What each node [method Gen1WorldImporter.decode_script] wrote becomes. False
+## drops the whole interaction, the way an undecoded row does.
+const GEN1_SCRIPT_NODES: Dictionary = {
+	"text": &"_gen1_node_text",
+	"flag": &"_gen1_node_flag",
+	"branch": &"_gen1_node_branch",
+	"has_item": &"_gen1_node_has_item",
+	"has_money": &"_gen1_node_has_money",
+	"spend_money": &"_gen1_node_spend_money",
+	"money_box": &"_gen1_node_money_box",
+	"give_item": &"_gen1_resolve_gift",
+	"take_item": &"_gen1_take_item",
+	"toggle_object": &"_gen1_node_toggle",
+	"pick_up_item": &"_gen1_pick_up_item",
+	"give_pokemon": &"_gen1_resolve_gift_pokemon",
+	"pokedex": &"_gen1_node_pokedex",
+}
 
 
 ## The raw cartridge permission byte at a walk cell.
@@ -3754,62 +3773,89 @@ func _gen1_script_steps(row: Dictionary, event: Dictionary = {}) -> Array:
 	var steps: Array = []
 	return steps if _gen1_resolve_script(nodes as Array, steps, {
 		"bag": state.items() if state != null else {}, "named": "", "object": event,
+		"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
 	}) else []
 
 
 ## [param run] is the bag the row is walked against, carrying what its own gifts
 ## have already put in it, and the name `CopyToStringBuffer` last wrote.
 func _gen1_resolve_script(nodes: Array, steps: Array, run: Dictionary) -> bool:
-	var bag: Dictionary = run["bag"]
 	for node: Dictionary in nodes:
-		match String(node.get("op", "")):
-			"text":
-				steps.append(_gen1_script_box(node, String(run["named"])))
-			"flag":
-				steps.append({
-					"type": &"flag",
-					"flag": int(node["flag"]),
-					"set": bool(node["set"]),
-					"engine": bool(node.get("engine", false)),
-				})
-			"branch":
-				if not _gen1_resolve_side(node, _gen1_branch_set(node), steps, run):
-					return false
-			"has_item":
-				if not _gen1_resolve_side(
-					node, int(bag.get(int(node["item"]), 0)) > 0, steps, run
-				):
-					return false
-			"give_item":
-				if not _gen1_resolve_gift(node, steps, run):
-					return false
-			"take_item":
-				_gen1_take_item(int(node["item"]), steps, bag)
-			"toggle_object":
-				steps.append({
-					"type": &"toggle",
-					"index": int(node["index"]),
-					"hidden": bool(node["hidden"]),
-				})
-			"pick_up_item":
-				if not _gen1_pick_up_item(steps, run):
-					return false
-			"give_pokemon":
-				if not _gen1_resolve_gift_pokemon(node, steps, run):
-					return false
-			"pokedex":
-				## `_DisplayPokedex` opens on one entry and the page the world
-				## already has for `pokedex_entry_requested` is that same one.
-				steps.append({"type": &"request", "values": {
-					"kind": &"pokedex_entry_requested",
-					"values": {"species": int(node["species"])},
-				}})
-			"trade":
-				return _gen1_trade(int(node["trade_id"]), steps)
-			"choice":
-				return _gen1_script_choice(node, steps, run)
-			_:
-				return false
+		var op: String = String(node.get("op", ""))
+		## Each of the two owns every step behind it, so the row ends there.
+		if op == "trade":
+			return _gen1_trade(int(node["trade_id"]), steps)
+		if op == "choice":
+			return _gen1_script_choice(node, steps, run)
+		if not GEN1_SCRIPT_NODES.has(op):
+			return false
+		if not call(GEN1_SCRIPT_NODES[op], node, steps, run):
+			return false
+	return true
+
+
+func _gen1_node_text(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	steps.append(_gen1_script_box(node, String(run["named"])))
+	return true
+
+
+func _gen1_node_flag(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({
+		"type": &"flag",
+		"flag": int(node["flag"]),
+		"set": bool(node["set"]),
+		"engine": bool(node.get("engine", false)),
+	})
+	return true
+
+
+func _gen1_node_branch(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	return _gen1_resolve_side(node, _gen1_branch_set(node), steps, run)
+
+
+func _gen1_node_has_item(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var bag: Dictionary = run["bag"]
+	return _gen1_resolve_side(
+		node, int(bag.get(int(node["item"]), 0)) > 0, steps, run
+	)
+
+
+func _gen1_node_has_money(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	return _gen1_resolve_side(
+		node, int(run["money"]) >= int(node["price"]), steps, run
+	)
+
+
+## `SubBCD` over `wPlayerMoney`, whose `.fill` writes zeroes across a balance it
+## borrowed past.
+func _gen1_node_spend_money(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var left: int = maxi(int(run["money"]) - int(node["amount"]), 0)
+	run["money"] = left
+	steps.append({"type": &"money", "amount": left})
+	return true
+
+
+func _gen1_node_money_box(_node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"money_box"})
+	return true
+
+
+func _gen1_node_toggle(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({
+		"type": &"toggle",
+		"index": int(node["index"]),
+		"hidden": bool(node["hidden"]),
+	})
+	return true
+
+
+## `_DisplayPokedex` opens on one entry and the page the world already has for
+## `pokedex_entry_requested` is that same one.
+func _gen1_node_pokedex(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"request", "values": {
+		"kind": &"pokedex_entry_requested",
+		"values": {"species": int(node["species"])},
+	}})
 	return true
 
 
@@ -3874,7 +3920,7 @@ func _gen1_resolve_gift(node: Dictionary, steps: Array, run: Dictionary) -> bool
 ## `PickUpItem`: the object's own item, `HideObject` on it, and the receipt
 ## behind `wDoNotWaitForButtonPress`. Its own `ret z` says nothing at all for an
 ## item object outside `ToggleableObjectStates`.
-func _gen1_pick_up_item(steps: Array, run: Dictionary) -> bool:
+func _gen1_pick_up_item(_node: Dictionary, steps: Array, run: Dictionary) -> bool:
 	var object: Dictionary = run.get("object", {})
 	var item: int = int(object.get("item", 0))
 	var toggle: int = int(object.get("toggle_index", -1))
@@ -3898,15 +3944,18 @@ func _gen1_pick_up_item(steps: Array, run: Dictionary) -> bool:
 	return true
 
 
-func _gen1_take_item(item: int, steps: Array, bag: Dictionary) -> void:
+func _gen1_take_item(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var bag: Dictionary = run["bag"]
+	var item: int = int(node["item"])
 	var left: int = int(bag.get(item, 0)) - 1
 	if left < 0:
-		return
+		return true
 	if left == 0:
 		bag.erase(item)
 	else:
 		bag[item] = left
 	steps.append({"type": &"items", "items": {item: left}})
+	return true
 
 
 ## `DoInGameTradeDialogue` over the row's own `wWhichTrade`:
@@ -3990,10 +4039,11 @@ func _gen1_trade_text(record: Dictionary, name: String) -> String:
 ## `YesNoChoice` stands behind the box that asked, so the question is the last
 ## box printed.
 func _gen1_script_choice(node: Dictionary, steps: Array, run: Dictionary) -> bool:
-	if steps.is_empty() \
-		or StringName((steps[-1] as Dictionary).get("type", &"")) != &"text":
+	var asked: int = _gen1_last_box(steps)
+	if asked < 0:
 		return false
-	var question: Dictionary = steps.pop_back()
+	var question: Dictionary = steps[asked]
+	steps.remove_at(asked)
 	var yes: Array = []
 	var no: Array = []
 	if not _gen1_resolve_script(node["yes"] as Array, yes, _gen1_run_copy(run)) \
@@ -4005,11 +4055,24 @@ func _gen1_script_choice(node: Dictionary, steps: Array, run: Dictionary) -> boo
 	return true
 
 
+## The box a YES/NO opens under, which nothing written between the two takes
+## the place of.
+func _gen1_last_box(steps: Array) -> int:
+	for index: int in range(steps.size() - 1, -1, -1):
+		var type: StringName = StringName((steps[index] as Dictionary)["type"])
+		if type == &"text":
+			return index
+		if GEN1_WAITING_STEPS.has(type):
+			return -1
+	return -1
+
+
 func _gen1_run_copy(run: Dictionary) -> Dictionary:
 	return {
 		"bag": (run["bag"] as Dictionary).duplicate(),
 		"named": run["named"],
 		"object": run.get("object", {}),
+		"money": run.get("money", 0),
 	}
 
 
@@ -4428,42 +4491,74 @@ func _gen1_step(type: StringName) -> Dictionary:
 
 
 ## The result the head step is waiting on, empty once the list is spent. What a
-## row writes takes no turn of its own and is spent on the way past.
+## row writes takes no turn of its own and is spent on the way past, and the
+## balance window one of those draws rides on the result behind it.
 func _gen1_result() -> Array:
-	while not _gen1_steps.is_empty() and _gen1_written(_gen1_steps[0]):
+	var events: Array = []
+	while not _gen1_steps.is_empty() and _gen1_written(_gen1_steps[0], events):
 		_gen1_steps.pop_front()
 	if _gen1_steps.is_empty():
-		return []
-	var step: Dictionary = _gen1_steps[0]
+		_gen1_close_money_window(events)
+		return [] if events.is_empty() \
+			else [{"ok": true, "status": &"done", "events": events}]
+	var result: Dictionary = _gen1_waiting_result(_gen1_steps[0])
+	result["events"] = events + (result.get("events", []) as Array)
+	return [result]
+
+
+## `AfterDisplayingTextID` redraws the map behind the row, which takes a balance
+## window down the way `closetext`'s redraw takes Generation 2's.
+func _gen1_close_money_window(events: Array) -> void:
+	if not _gen1_money_window:
+		return
+	_gen1_money_window = false
+	events.append({"type": &"money_window_closed"})
+
+
+func _gen1_waiting_result(step: Dictionary) -> Dictionary:
 	var type: StringName = StringName(step["type"])
 	if type == &"request":
-		return [{
+		return {
 			"ok": true, "status": &"waiting",
 			"event": {"type": &"runtime_request", "request": step["values"]},
-		}]
+		}
 	if type == &"choice":
-		return [{"ok": true, "status": &"waiting", "event": {"type": &"choice"}}]
+		return {"ok": true, "status": &"waiting", "event": {"type": &"choice"}}
 	## A counted wait and whatever it starts on the frame it opens on.
 	if type == &"wait":
-		return [{
+		return {
 			"ok": true, "status": &"waiting",
 			"event": (step["values"] as Dictionary).duplicate(true),
 			"events": (step.get("events", []) as Array).duplicate(true),
-		}]
+		}
 	## `AfterDisplayingTextID` ends every box on `WaitForTextScrollButtonPress`
 	## unless the row set `wDoNotWaitForButtonPress...` before its last one.
-	return [{
+	return {
 		"ok": true, "status": &"waiting",
 		"event": {
 			"type": &"text",
 			"text": String(step["text"]),
 			"prompt": bool(step.get("press", true)),
 		},
-	}]
+	}
 
 
-func _gen1_written(step: Dictionary) -> bool:
+func _gen1_written(step: Dictionary, events: Array) -> bool:
 	match StringName(step["type"]):
+		&"money":
+			state.apply_changes({}, {}, {
+				"money": {Gen2WorldMartHost.MONEY_ACCOUNT: int(step["amount"])},
+			})
+			return true
+		&"money_box":
+			_gen1_money_window = true
+			events.append({
+				"type": &"money_window_opened",
+				"kind": &"money_top_right",
+				"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
+				"coins": state.coins() if state != null else 0,
+			})
+			return true
 		&"flag":
 			if bool(step.get("engine", false)):
 				state.set_engine_flag(int(step["flag"]), bool(step["set"]))
@@ -7399,6 +7494,7 @@ func _apply_map(
 	])
 	_record_escape_points(target_map, from_warp)
 	_gen1_steps = []
+	_gen1_money_window = false
 	## `WarpFound2`'s `CheckIfInOutsideMap`: leaving a town or a route records it,
 	## and that is the map a `LAST_MAP` warp comes back out to.
 	if _gen1 and current_map != null and Gen1Layout.is_outside_tileset(current_map.tileset):

--- a/game/world/world_decoration.gd
+++ b/game/world/world_decoration.gd
@@ -171,7 +171,6 @@ static func slot_of(data: GameData, deco: int) -> StringName:
 	return StringName((pair as Array)[0]) if pair is Array else &""
 
 
-## Whether a row is its category's PUT IT AWAY header rather than a decoration.
 static func is_put_away(data: GameData, deco: int) -> bool:
 	var action: int = int(data.decoration(deco).get("action", ACTION_NOTHING)) \
 		if data != null else ACTION_NOTHING

--- a/game/world/world_encounters.gd
+++ b/game/world/world_encounters.gd
@@ -575,7 +575,6 @@ static func glow_palette(
 	return out
 
 
-## Which method's eligible list [param cell] is in, empty when neither.
 func _eligible_method(cell: Vector2i) -> StringName:
 	var eligible: Dictionary = _context.get("eligible", {})
 	for method: Variant in eligible:

--- a/game/world/world_radio.gd
+++ b/game/world/world_radio.gd
@@ -124,7 +124,6 @@ static func knob_values() -> Array[int]:
 	return values
 
 
-## The frequency the dial shows for a stored knob value.
 static func frequency_for(knob: int) -> float:
 	return (knob + 2) / 4.0
 
@@ -141,7 +140,6 @@ static func raw_channel(channel: int, crystal: bool = true) -> int:
 	return -1 if channel == BUENAS_PASSWORD else channel - 1
 
 
-## A Crystal landmark index on the active profile.
 static func profile_landmark(landmark: int, crystal: bool = true) -> int:
 	if crystal or landmark < LANDMARK_BATTLE_TOWER:
 		return landmark

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -279,7 +279,6 @@ var _text_awaits_press: bool = true
 ## first when it does not.
 var _field_move_text_waits: bool = true
 var _field_move_text_frames: int = 0
-## How many presses [method preview_text_scroll] will spend looking for one.
 const PREVIEW_TEXT_PRESSES: int = 8
 ## `ProfOaksPCBoot`'s three texts, one page at a time, and the sfx `Rate` leaves
 ## for it to play once the last of them is up.
@@ -7409,7 +7408,6 @@ const REQUEST_OPENERS: Dictionary = {
 	&"contest_mon_requested": [&"_open_contest_nickname", &"prompt", {}],
 }
 
-## Requests the service host draws, all on one screen.
 const SERVICE_HOST_REQUESTS: Array[StringName] = [
 	&"mart_requested", &"phone_call_requested", &"special_phone_call_requested",
 	&"town_map_requested", &"apricorn_selection_requested", &"pc_requested",

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -1024,7 +1024,6 @@ func _mart_row_count() -> int:
 	return rows + 1 if rows < Gen2MartPage.LIST_HEIGHT else Gen2MartPage.LIST_HEIGHT
 
 
-## Rows drawn, which is [method _mart_row_count] plus the look-ahead row.
 func _mart_drawn_rows() -> int:
 	if _gen1_mart():
 		return mini(Gen2MartPage.GEN1_LIST_HEIGHT, _mart_list().size() + 1 - _mart_scroll)

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -37,9 +37,15 @@ const LAYOUT: Dictionary = {
 	"wait_for_button": 0x01B0,
 	"auto_textbox_on": 0x01C0,
 	"auto_textbox_off": 0x01D0,
+	"has_enough_money": 0x01E0,
+	"display_text_box": 0x01F0,
+	"text_box_id": 0xD125,
+	"money_hram": 0xFF9F,
+	"player_money": 0xD347,
+	"sub_bcd": 0x0250,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
-const PREDEFS: Dictionary = {1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240}
+const PREDEFS: Dictionary = {1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240, 5: 0x0250}
 const AT: int = 0x1000
 const HELLO: int = 0x1800
 const BYE: int = 0x1810
@@ -348,11 +354,26 @@ func test_a_far_call_to_remove_an_item_becomes_its_own_node() -> void:
 	assert_eq(script, [{"op": "take_item", "item": 0x40}])
 
 
-func test_a_far_call_to_anything_else_answers_nothing() -> void:
+## `callfar` is the same three the other way about, and the routine it names is
+## walked in the bank `b` carries. Yellow keeps 22 rows behind one.
+func test_a_far_call_to_a_routine_is_walked_and_returned_from() -> void:
+	var routine: int = AT + 0x40
+	var program: Array = _load_hl(routine) + [Gen1Layout.SCRIPT_LD_B, 0]
+	program += _call(int(LAYOUT["bankswitch"])) + _print(BYE) \
+		+ _call(int(LAYOUT["text_script_end"]))
+	while program.size() < 0x40:
+		program.append(0)
+	program.append_array(_print(HELLO) + [Gen1Layout.SCRIPT_RET])
+	assert_eq(_decode(program, _boxes()), [
+		{"op": "text", "text": "HI"}, {"op": "text", "text": "BYE"},
+	])
+
+
+func test_a_far_call_to_machine_code_this_decoder_cannot_read_answers_nothing() -> void:
 	assert_eq(_decode(
 		[Gen1Layout.SCRIPT_LD_A, 0x40, Gen1Layout.SCRIPT_LDH_MEM_A, 0xDB,
 			Gen1Layout.SCRIPT_LD_B, 0x05]
-			+ _load_hl(0x4000) + _call(int(LAYOUT["bankswitch"]))
+			+ _load_hl(UNREAD_CALL) + _call(int(LAYOUT["bankswitch"]))
 			+ _call(int(LAYOUT["text_script_end"]))
 	), [])
 
@@ -481,3 +502,126 @@ func test_a_conditional_call_to_anything_else_answers_nothing() -> void:
 			int(LAYOUT["print_text"]) >> 8]
 			+ _call(int(LAYOUT["text_script_end"]))
 	), [])
+
+
+## `ldh [hMoney + n], a`, most significant byte first.
+func _money(price: Array) -> Array:
+	var out: Array = []
+	for index: int in price.size():
+		out += [Gen1Layout.SCRIPT_LD_A, int(price[index]),
+			Gen1Layout.SCRIPT_LDH_MEM_A, (int(LAYOUT["money_hram"]) + index) & 0xFF]
+	return out
+
+
+## `HasEnoughMoney` sets carry when the player is short, so the `jr nc` behind it
+## hops to the sale and the price is the one the row wrote into `hMoney`.
+func test_a_money_test_keeps_the_price_and_both_sides() -> void:
+	var short: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_money([0x00, 0x05, 0x00]) + _call(int(LAYOUT["has_enough_money"]))
+			+ [0x30, short.size()] + short
+			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "has_money", "price": 500,
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "text", "text": "BYE"}],
+	}])
+
+
+func test_a_money_test_with_no_price_written_answers_nothing() -> void:
+	assert_eq(_decode(
+		_money([0x00, 0x05]) + _call(int(LAYOUT["has_enough_money"]))
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [])
+
+
+## `wPriceTemp` stands at `wWhichTrade`'s own address, so the predef behind the
+## three stores is what says a price was meant.
+func _spend(price: Array) -> Array:
+	var at: int = int(LAYOUT["which_trade"])
+	var out: Array = []
+	for index: int in price.size():
+		out += [Gen1Layout.SCRIPT_LD_A, int(price[index]), Gen1Layout.SCRIPT_LD_MEM_A,
+			(at + index) & 0xFF, (at + index) >> 8]
+	var money: int = int(LAYOUT["player_money"]) + Gen1Layout.MONEY_BYTES - 1
+	return out + _load_hl(at + Gen1Layout.MONEY_BYTES - 1) \
+		+ [Gen1Layout.SCRIPT_LD_DE, money & 0xFF, money >> 8,
+			Gen1Layout.SCRIPT_LD_C, Gen1Layout.MONEY_BYTES] \
+		+ _predef(5)
+
+
+func test_the_subtraction_predef_becomes_the_price_it_takes() -> void:
+	assert_eq(
+		_decode(_spend([0x00, 0x05, 0x00]) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "spend_money", "amount": 500}]
+	)
+
+
+## `ld a, MONEY_BOX`, `ld [wTextBoxID], a` and `call DisplayTextBoxID`.
+func _text_box(id: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_A, id, Gen1Layout.SCRIPT_LD_MEM_A,
+		int(LAYOUT["text_box_id"]) & 0xFF, int(LAYOUT["text_box_id"]) >> 8] \
+		+ _call(int(LAYOUT["display_text_box"]))
+
+
+func test_the_money_box_becomes_its_own_node() -> void:
+	assert_eq(
+		_decode(_text_box(Gen1Layout.MONEY_BOX_ID)
+			+ _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "money_box"}]
+	)
+
+
+## Every other id names a menu this port hands nothing to.
+func test_any_other_text_box_answers_nothing() -> void:
+	assert_eq(
+		_decode(_text_box(Gen1Layout.MONEY_BOX_ID + 1)
+			+ _call(int(LAYOUT["text_script_end"]))),
+		[]
+	)
+
+
+## `jp nz` is three bytes where the conditional `jr`s are two. Read as two, its
+## fall-through lands inside its own operand and the row says nothing.
+func test_a_long_conditional_jump_is_three_bytes() -> void:
+	var clear: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var set_side: Array = _print(HELLO) + _call(int(LAYOUT["text_script_end"]))
+	var head: Array = _check_event(37)
+	var target: int = AT + head.size() + Gen1Layout.SCRIPT_LONG_SIZE + clear.size()
+	assert_eq(_decode(
+		head + [0xC2, target & 0xFF, target >> 8] + clear + set_side, _boxes()
+	), [{
+		"op": "branch", "flag": 37,
+		"then": [{"op": "text", "text": "HI"}],
+		"else": [{"op": "text", "text": "BYE"}],
+	}])
+
+
+## `and a` raises Z only when `a` is zero, so the side a `jp nz` does not take
+## knows the register: the salesman writes `hMoney` out of it.
+func test_the_zero_side_of_and_a_knows_the_register() -> void:
+	var no: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+	var yes: Array = [Gen1Layout.SCRIPT_LDH_MEM_A, int(LAYOUT["money_hram"]) & 0xFF,
+		Gen1Layout.SCRIPT_LDH_MEM_A, (int(LAYOUT["money_hram"]) + 2) & 0xFF,
+		Gen1Layout.SCRIPT_LD_A, 0x05,
+		Gen1Layout.SCRIPT_LDH_MEM_A, (int(LAYOUT["money_hram"]) + 1) & 0xFF]
+	yes += _call(int(LAYOUT["has_enough_money"])) + [0x30, no.size()] + no \
+		+ _print(HELLO) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = _decode(
+		_call(int(LAYOUT["yes_no_choice"]))
+			+ [Gen1Layout.SCRIPT_LD_A_MEM, int(LAYOUT["current_menu_item"]) & 0xFF,
+				int(LAYOUT["current_menu_item"]) >> 8, Gen1Layout.SCRIPT_AND_A]
+			+ [0x20, yes.size()] + yes + no,
+		_boxes()
+	)
+	assert_eq(script, [{
+		"op": "choice",
+		"yes": [{
+			"op": "has_money", "price": 500,
+			"then": [{"op": "text", "text": "HI"}],
+			"else": [{"op": "text", "text": "BYE"}],
+		}],
+		"no": [{"op": "text", "text": "BYE"}],
+	}])

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -21,7 +21,7 @@ const MAX_COMMENT_BLOCK: int = 8
 ## shared battle, world, palette, text, save and renderer code: 150 the battle
 ## animation engine, 140 the transition and the split effects, 85 the party
 ## menu, 40 the bag in a battle, 18 the trades. Fourteen sweeps paid nothing.
-const MAX_COMMENT_LINES: int = 40025
+const MAX_COMMENT_LINES: int = 40024
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,25 +130,27 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 225, "text": 235, "branch": 84, "choice": 10, "flag": 35,
-		"give_item": 23, "has_item": 9, "take_item": 3, "unknown": 35,
-		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 4,
-		"trade": 9},
-	&"blue": {"rows": 225, "text": 235, "branch": 84, "choice": 10, "flag": 35,
-		"give_item": 23, "has_item": 9, "take_item": 3, "unknown": 35,
-		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 4,
-		"trade": 9},
-	&"yellow": {"rows": 207, "text": 188, "branch": 74, "choice": 8, "flag": 25,
-		"give_item": 18, "has_item": 9, "take_item": 3, "unknown": 36,
-		"pick_up_item": 108, "toggle_object": 9, "pokedex": 9, "give_pokemon": 4,
-		"trade": 7},
+	&"red": {"rows": 235, "text": 252, "branch": 95, "choice": 11, "flag": 37,
+		"give_item": 24, "has_item": 9, "take_item": 3, "unknown": 43,
+		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
+		"trade": 9, "has_money": 1, "spend_money": 1, "money_box": 2},
+	&"blue": {"rows": 235, "text": 252, "branch": 95, "choice": 11, "flag": 37,
+		"give_item": 24, "has_item": 9, "take_item": 3, "unknown": 43,
+		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
+		"trade": 9, "has_money": 1, "spend_money": 1, "money_box": 2},
+	&"yellow": {"rows": 279, "text": 294, "branch": 97, "choice": 12, "flag": 32,
+		"give_item": 24, "has_item": 9, "take_item": 3, "unknown": 47,
+		"pick_up_item": 108, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
+		"trade": 7, "has_money": 1, "spend_money": 1, "money_box": 2},
 }
 ## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
 ## which no map text row names and which the disassembly marks unreferenced. The
 ## `trade` rows are the eight `predef DoInGameTradeDialogue` sites plus
 ## `CinnabarLabTradeRoom`'s second, whose `jr` shares the first one's tail;
-## Yellow ships neither trade house. The last `call GivePokemon` row the decoder
-## does not reach is the Magikarp salesman's, behind `HasEnoughMoney`.
+## Yellow ships neither trade house. The money rows are the Magikarp salesman's
+## alone: Museum 1F and the Safari Zone gate spend theirs behind
+## `StartSimulatingJoypadStates`, which walks the player and which this port
+## has no counterpart for, so those paths stay unread.
 
 ## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
 ## and how many start ON. Three rows name an object their map has not got.

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -64,6 +64,16 @@ const NURSE_PARTY: int = 4
 const CABLE_CLUB_COUNTER := Vector2i(11, 3)
 const CABLE_CLUB_ROWS: int = 12
 
+## `MtMoonPokecenter_Object`'s fourth object, the one row of the corpus that
+## spends money: `HasEnoughMoney`, `GivePokemon` and `SubBCDPredef` behind it,
+## with MONEY_BOX standing over the map for the question.
+const MT_MOON_POKECENTER: int = 0x44
+const MAGIKARP_SELLER := Vector2i(10, 6)
+const MAGIKARP_PRICE: int = 500
+const MAGIKARP_DEX: int = 129
+const MAGIKARP_LEVEL: int = 5
+const MAGIKARP_PURSE: int = 600
+
 ## `CeladonMartRoof_Object`'s three `bg_event` machines, read from below.
 const CELADON_MART_ROOF: int = 126
 const VENDING_MACHINE := Vector2i(10, 2)
@@ -208,6 +218,7 @@ func _one_game() -> void:
 	_check_the_vending_machine()
 	_check_the_prize_counter()
 	_check_a_trade()
+	_check_the_magikarp_salesman()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -757,6 +768,75 @@ func _check_the_vending_machine() -> void:
 	)
 	world.complete_runtime_request({"ok": true})
 	_r.check(not world.script_busy(), "the machine never closed.")
+
+
+## The salesman with the money and without it, and the refusal a bought
+## MAGIKARP leaves behind.
+func _check_the_magikarp_salesman() -> void:
+	var world: Gen2WorldAPI = _magikarp_offer(MAGIKARP_PRICE - 1)
+	if world == null:
+		return
+	var refused: Array = world.choose_script_input(0)
+	_r.check(
+		_runtime_request(refused).is_empty()
+			and world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == MAGIKARP_PRICE - 1,
+		"a short purse bought a MAGIKARP: %s." % [refused]
+	)
+	world = _magikarp_offer(MAGIKARP_PURSE)
+	if world == null:
+		return
+	var offer: String = String(world.pending_script_input().get("text", ""))
+	var request: Dictionary = _runtime_request(world.choose_script_input(0))
+	var values: Dictionary = request.get("values", {})
+	_r.check(
+		StringName(request.get("kind", &"")) == &"pokemon_requested"
+			and int(values.get("pokemon", 0)) == MAGIKARP_DEX
+			and int(values.get("level", 0)) == MAGIKARP_LEVEL,
+		"the salesman raised %s." % [request]
+	)
+	world.complete_runtime_request({"ok": true, "accepted": true})
+	_r.check(
+		world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == MAGIKARP_PURSE - MAGIKARP_PRICE,
+		"the MAGIKARP cost %d." % [
+			MAGIKARP_PURSE - world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
+		]
+	)
+	var again: String = _event_text(world.interact())
+	_r.check(not again.is_empty() and again != offer,
+		"a bought MAGIKARP was offered again: %s." % [again])
+	_r.note("gen1 walk the MAGIKARP salesman with %d and with %d" % [
+		MAGIKARP_PURSE, MAGIKARP_PRICE - 1,
+	])
+
+
+## The row up to its YES/NO, which the offer itself is the question of, with
+## the balance window checked on the way.
+func _magikarp_offer(purse: int) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(
+		0, MT_MOON_POKECENTER, MAGIKARP_SELLER + Vector2i.LEFT
+	)
+	if world == null:
+		return null
+	world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	world.state.apply_changes({}, {}, {
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: purse},
+	})
+	var results: Array = world.interact()
+	var window: Dictionary = _first_event(results, &"money_window_opened")
+	_r.check(int(window.get("money", -1)) == purse,
+		"the deal drew %s over the map." % [window])
+	return world if _r.check(
+		not String(world.pending_script_input().get("text", "")).is_empty(),
+		"the deal asked nothing: %s." % [results]
+	) else null
+
+
+func _first_event(results: Array, type: StringName) -> Dictionary:
+	for row: Dictionary in results:
+		for event: Dictionary in row.get("events", []) as Array:
+			if StringName(event.get("type", &"")) == type:
+				return event
+	return {}
 
 
 ## `PrizeDifferentMenuPtrs`' three lists with `PrizeMonLevelDictionary`'s level

--- a/tools/lib/check_run.gd
+++ b/tools/lib/check_run.gd
@@ -97,7 +97,6 @@ func region(world: Gen2WorldAPI, from: Vector2i) -> Dictionary:
 	return seen
 
 
-## Gives [param world] the party every field-move check assumes.
 func field_move_party(world: Gen2WorldAPI) -> void:
 	world.set_party_summary(
 		FIELD_MOVE_PARTY_SIZE, false, [1] as Array[int],

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -35,6 +35,7 @@ const KIND_HELP: Dictionary = {
 	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
 	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
 	&"trade": "presses: DoInGameTradeDialogue, faced up from the cell below the trader. 0 the offer and its YES/NO, 1 the party list YES opens",
+	&"deal": "presses: the MAGIKARP salesman, faced right from the cell beside him with the money box DisplayTextBoxID drew over the map",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
@@ -446,6 +447,7 @@ const STAGERS: Dictionary = {
 	&"vending": &"_stage_vending",
 	&"prizes": &"_stage_prizes",
 	&"trade": &"_stage_trade",
+	&"deal": &"_stage_deal",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -1062,12 +1064,18 @@ func _stage_trade() -> void:
 	_stage_counter({})
 
 
-## A counter faced from the cell below it: presses, then rows down first.
-func _stage_counter(purse: Dictionary) -> void:
+func _stage_deal() -> void:
+	_stage_counter(
+		{"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY}}, PokeButton.RIGHT
+	)
+
+
+## A counter faced the way [param facing] says: presses, then rows down first.
+func _stage_counter(purse: Dictionary, facing: int = PokeButton.UP) -> void:
 	var world: Gen2WorldAPI = _screen.get("_world")
 	if world != null:
 		world.state.apply_changes({}, {}, purse)
-	_screen.press_button(PokeButton.UP)
+	_screen.press_button(facing)
 	for _frame: int in TEXT_SETTLE_FRAMES:
 		_screen.advance_frame()
 	_screen.interact()

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -5902,7 +5902,6 @@ func _saffron_vermilion_walk(
 	return {"ok": true}
 
 
-## The Pokemon Fan Club, where the doll is.
 func _fan_club_doll(
 	world: Gen2WorldAPI,
 	save: Gen2SaveData,
@@ -9203,7 +9202,6 @@ func _walk_connection_resolving(
 	return {"ok": false, "reason": "connection walk did not settle", "encounters": runs}
 
 
-## The _walk_to_story_cell() counterpart of _walk_connection_resolving().
 func _walk_cell_resolving(
 	world: Gen2WorldAPI,
 	target: Vector2i,


### PR DESCRIPTION
`HasEnoughMoney`, `predef SubBCDPredef` and MONEY_BOX are one seam. `Gen1Layout.SCRIPT_BCD_BUFFERS` is `hMoney` and `wPriceTemp`, whose first byte stands at `wWhichTrade`'s own address, so the routine behind a store is what says which was meant. `Gen2MartPage.balance_window` draws `DisplayMoneyBox`'s MONEY label into the box's own top border, where `PlaceMoneyTopRight` draws the balance alone, and `_gen1_last_box` lets a `YesNoChoice` open under the box a balance window was drawn over rather than under the window.

`Bankswitch` is a general far call: the routine `b` and `hl` name is walked in its own bank and returned from, which is where Yellow keeps 22 of its rows, and a `call` to the map's own routine is read through the same seam, branches included.

Two things the walk had wrong. `jp nz` at $C2 was read as two bytes, so its fall-through landed inside its own operand and every row holding one said nothing; `Gen1Layout.SCRIPT_HOP_LIMIT` is where a `jr` stops and a `jp` begins. And `and a` raises Z only when `a` is zero, so the side a `jp nz` does not take knows the register, which is what `hMoney` is written out of.

| Census | Red and Blue | Yellow |
|---|---|---|
| `text_asm` rows read | 225 to 235 | 207 to 279 |
| boxes | 235 to 252 | 188 to 294 |
| event branches | 84 to 95 | 74 to 97 |
| `has_money`, `spend_money`, `money_box` | 1, 1, 2 | 1, 1, 2 |

`tools/checks/gen1_walk.gd` buys the Magikarp salesman's MAGIKARP with 600 and is refused with 499, and `tools/preview_world.gd -- red 0 68 <out.png> live deal@9,6` photographs the offer under the box. Museum 1F and the Safari Zone gate spend their money behind `StartSimulatingJoypadStates`, which walks the player and which this port has no counterpart for, so those paths stay unread.

Twenty-two comments that restated the name of the function or constant below them are gone, and the recorded ceiling drops to 40,024.

GUT 4440/4440, `tools/validate.gd -- all` 92 topics, the warning scan 0 in 632 scripts, `replay_world.gd` 33 routes and the three-profile story walk all pass.