### PR TITLE
Buy coins in the Generation 1 Game Corner

### DIFF
--- a/game/data/world_catalog.gd
+++ b/game/data/world_catalog.gd
@@ -65,7 +65,6 @@ const STRING_NAME_FIELDS: Array[String] = ["kind", "role"]
 const VECTOR_FIELDS: Array[String] = ["map"]
 
 var _data: GameData = null
-## id to row.
 var _rows: Dictionary = {}
 var _by_kind: Dictionary = {}
 ## The commands a site's fields also have to reach, keyed by the byte they sit

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -733,7 +733,10 @@ const SCRIPT_CALLS: Array[String] = [
 	"give_item", "is_item_in_bag", "bankswitch", "play_cry", "wait_for_sound",
 	"predef", "display_pokedex", "give_pokemon", "wait_for_button",
 	"auto_textbox_on", "auto_textbox_off", "has_enough_money", "display_text_box",
+	"has_enough_coins",
 ]
+## Routines named by a full ROM offset, the same address in another bank being another routine.
+const SCRIPT_BANKED_CALLS: Array[String] = ["coin_box"]
 ## The routines that spend nothing here: no audio driver, a press already ends
 ## every box, and `wAutoTextBoxDrawingControl` has no counterpart.
 const SCRIPT_SILENT_CALLS: Array[String] = [
@@ -745,6 +748,11 @@ const SCRIPT_CONDITIONAL_CALLS: Array[int] = [0xC4, 0xCC, 0xD4, 0xDC]
 ## byte first. `wPriceTemp` stands at `wWhichTrade`'s own address.
 const SCRIPT_BCD_BUFFERS: Array[String] = ["money_hram", "which_trade"]
 const MONEY_BYTES: int = 3
+## `hCoins` unions `hMoney`'s last two bytes and `hUnusedCoinsByte` its first, so one buffer
+## holds both, and `AddBCD`'s `.fill` is what ceils a sum that carried out of the two.
+const COIN_BYTES: int = 2
+const COIN_BUFFER_AT: int = 1
+const COIN_CEILING: int = 9999
 const MONEY_BOX_ID: int = 0x13
 const SCRIPT_SHORT_SIZE: int = 2
 const SCRIPT_LONG_SIZE: int = 3
@@ -1009,6 +1017,10 @@ const RED_BLUE: Dictionary = {
 	"money_hram": 0xFF9F,
 	"player_money": 0xD347,
 	"sub_bcd": 0x0F836,
+	"has_enough_coins": 0x35B1,
+	"player_coins": 0xD5A4,
+	"add_bcd": 0x0F81D,
+	"coin_box": 0x48F1E,
 	"remove_item": 0x7F37,
 	"remove_item_bank": 0x05,
 	"do_not_wait": 0xCC3C,
@@ -1139,6 +1151,10 @@ const YELLOW: Dictionary = {
 	"money_hram": 0xFF9F,
 	"player_money": 0xD346,
 	"sub_bcd": 0x0F6BC,
+	"has_enough_coins": 0x35CE,
+	"player_coins": 0xD5A3,
+	"add_bcd": 0x0F6A3,
+	"coin_box": 0x48F42,
 	"remove_item": 0x7DBB,
 	"remove_item_bank": 0x05,
 	"do_not_wait": 0xCC3C,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -992,6 +992,7 @@ const SCRIPT_TESTS_NOTHING: int = -2
 const SCRIPT_TESTS_CARRY: int = -3
 const SCRIPT_TESTS_ITEM: int = -4
 const SCRIPT_TESTS_MONEY: int = -5
+const SCRIPT_TESTS_COINS: int = -6
 
 
 ## One `text_asm` row's machine code, as the boxes it prints and the branches
@@ -1367,8 +1368,13 @@ static func _script_call(
 			return _script_gift_pokemon(ctx, state, out, next)
 		"has_enough_money":
 			return _script_money_asked(state, next)
+		"has_enough_coins":
+			return _script_coins_asked(state, next)
 		"display_text_box":
 			return _script_money_box(state, out, next)
+	if _script_banked_routine(layout, int(ctx["bank"]), target) == "coin_box":
+		out.append({"op": "coin_box"})
+		return next
 	return _script_routine_call(ctx, int(ctx["bank"]), target, state, out, next, depth)
 
 
@@ -1397,6 +1403,14 @@ static func _script_routine_call(
 static func _script_routine(layout: Dictionary, target: int) -> String:
 	for name: String in Gen1Layout.SCRIPT_CALLS:
 		if int(layout.get(name, -1)) == target:
+			return name
+	return ""
+
+
+static func _script_banked_routine(layout: Dictionary, bank: int, target: int) -> String:
+	var at: int = Gen1Layout.banked(bank, target)
+	for name: String in Gen1Layout.SCRIPT_BANKED_CALLS:
+		if int(layout.get(name, -1)) == at:
 			return name
 	return ""
 
@@ -1496,14 +1510,16 @@ static func _script_bcd_stored(
 	return false
 
 
-## Three packed-decimal bytes as a number, -1 until all three are written.
-static func _script_bcd_value(state: Dictionary, name: String) -> int:
+## A run of packed-decimal bytes as a number, -1 until every one is written.
+static func _script_bcd_value(
+	state: Dictionary, name: String, count: int = Gen1Layout.MONEY_BYTES, first: int = 0
+) -> int:
 	var bytes: Dictionary = state.get(name, {})
 	var value: int = 0
-	for index: int in Gen1Layout.MONEY_BYTES:
-		if not bytes.has(index):
+	for index: int in count:
+		if not bytes.has(first + index):
 			return -1
-		var byte: int = int(bytes[index])
+		var byte: int = int(bytes[first + index])
 		value = value * 100 + (byte >> 4) * 10 + (byte & 0xF)
 	return value
 
@@ -1516,6 +1532,20 @@ static func _script_money_asked(state: Dictionary, next: int) -> int:
 		return SCRIPT_UNREAD
 	state["price"] = price
 	_script_tested(state, SCRIPT_TESTS_MONEY, true)
+	return next
+
+
+## `HasEnoughCoins` is `StringCmp` over `hCoins`: `Has9990Coins` behind a `jr nc` is a full coin
+## case, and `GameCornerGentlemanText`'s `jr z` an exact 9990.
+static func _script_coins_asked(state: Dictionary, next: int) -> int:
+	var coins: int = _script_bcd_value(
+		state, Gen1Layout.SCRIPT_BCD_BUFFERS[0],
+		Gen1Layout.COIN_BYTES, Gen1Layout.COIN_BUFFER_AT
+	)
+	if coins < 1:
+		return SCRIPT_UNREAD
+	state["coins"] = coins
+	_script_tested(state, SCRIPT_TESTS_COINS)
 	return next
 
 
@@ -1548,6 +1578,24 @@ static func _script_spend(
 	return SCRIPT_UNREAD
 
 
+## `predef AddBCDPredef` with `wPlayerCoins + 1` in de and two in c; the Day-Care's own sum is not.
+static func _script_add_coins(
+	ctx: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	var layout: Dictionary = ctx["layout"]
+	if int(state.get("de", -1)) != int(layout["player_coins"]) + Gen1Layout.COIN_BYTES - 1 \
+		or int(state.get("c", -1)) != Gen1Layout.COIN_BYTES:
+		return SCRIPT_UNREAD
+	var amount: int = _script_bcd_value(
+		state, Gen1Layout.SCRIPT_BCD_BUFFERS[0],
+		Gen1Layout.COIN_BYTES, Gen1Layout.COIN_BUFFER_AT
+	)
+	if amount < 1:
+		return SCRIPT_UNREAD
+	out.append({"op": "add_coins", "amount": amount})
+	return next
+
+
 ## `predef` is `ld a, id` and `call Predef`; `PredefPointers` is the bank and
 ## address that id names. `ShowObject2` shares `ShowObject`'s address, so
 ## resolving the address rather than the id reads both.
@@ -1566,6 +1614,8 @@ static func _script_predef(
 		return next
 	if target == int(layout["sub_bcd"]):
 		return _script_spend(ctx, state, out, next)
+	if target == int(layout["add_bcd"]):
+		return _script_add_coins(ctx, state, out, next)
 	if target == int(layout["in_game_trade"]):
 		if not state.has("trade"):
 			return SCRIPT_UNREAD
@@ -1599,12 +1649,7 @@ static func _script_branch(
 ) -> Variant:
 	var tests: Variant = state.get("tests", SCRIPT_TESTS_NOTHING)
 	var carry: bool = Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op)
-	if tests is Array:
-		if carry:
-			return null
-	elif int(tests) == SCRIPT_TESTS_NOTHING or carry != (
-		int(tests) == SCRIPT_TESTS_CARRY or bool(state.get("tests_in_carry", false))
-	):
+	if not _script_reads_flag(state, tests, carry):
 		return null
 	var rom: RomFile = ctx["rom"]
 	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
@@ -1628,18 +1673,31 @@ static func _script_branch(
 		branches.reverse()
 	if branches[0] == null and branches[1] == null:
 		return null
-	var node: Variant = _script_node(tests, branches, state, out)
+	var node: Variant = _script_node(tests, branches, state, out, carry)
 	if node == null:
 		return null
 	out.append(node)
 	return out
 
 
+## Whether the flag this branch reads is the one the test left: a flag index is in Z alone.
+static func _script_reads_flag(state: Dictionary, tests: Variant, carry: bool) -> bool:
+	if tests is Array:
+		return not carry
+	if int(tests) == SCRIPT_TESTS_COINS:
+		return true
+	if int(tests) == SCRIPT_TESTS_NOTHING:
+		return false
+	return carry == (
+		int(tests) == SCRIPT_TESTS_CARRY or bool(state.get("tests_in_carry", false))
+	)
+
+
 ## `wCurrentMenuItem` is 0 for YES, so the branch taken when it is not zero is
 ## NO. Every other test reads the other way about: the taken side is the set
 ## one, a set carry or an item the bag holds.
 static func _script_node(
-	tests: Variant, branches: Array, state: Dictionary, out: Array
+	tests: Variant, branches: Array, state: Dictionary, out: Array, carry: bool
 ) -> Variant:
 	var taken: Array = branches[0] if branches[0] != null else [{"op": "unknown"}]
 	var fell: Array = branches[1] if branches[1] != null else [{"op": "unknown"}]
@@ -1658,6 +1716,10 @@ static func _script_node(
 			## Carry is set when the player is short, so the taken side of a
 			## `jr c` is the refusal and the other one is the sale.
 			return {"op": "has_money", "price": int(state["price"]),
+				"then": fell, "else": taken}
+		SCRIPT_TESTS_COINS:
+			return {"op": "has_coins", "coins": int(state["coins"]),
+				"test": "at_least" if carry else "exactly",
 				"then": fell, "else": taken}
 	var branch: Dictionary = {
 		"op": "branch", "flag": int(tests), "then": taken, "else": fell,

--- a/game/mods/mod_host.gd
+++ b/game/mods/mod_host.gd
@@ -420,7 +420,6 @@ func request_item_gift(item: int, quantity: int = 1) -> void:
 	_item_gift_requests.append({"item": item, "quantity": quantity})
 
 
-## Drained by [Gen2WorldScreen], once, on the frame it spends them.
 func take_item_gift_requests() -> Array[Dictionary]:
 	var out: Array[Dictionary] = _item_gift_requests
 	_item_gift_requests = []

--- a/game/render/mail_page.gd
+++ b/game/render/mail_page.gd
@@ -374,7 +374,6 @@ func draw(mail: Gen2SaveMail) -> PackedByteArray:
 	return indices
 
 
-## The tile numbers the last [method draw] loaded, in order.
 func loaded_tiles() -> Array:
 	var out: Array = _vram.keys()
 	out.sort()

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -37,6 +37,14 @@ const BALANCES_MONEY_AT: Vector2i = Vector2i(12, 1)
 const BALANCES_COIN_LABEL_AT: Vector2i = Vector2i(6, 3)
 const BALANCES_COIN_AT: Vector2i = Vector2i(15, 3)
 
+## `GameCornerDrawCoinBox`: `TextBoxBorder` at `hlcoord 11, 0`, `lb bc, 5, 7`.
+const GAME_CORNER_AT: Vector2i = Vector2i(11, 0)
+const GAME_CORNER_SIZE: Vector2i = Vector2i(9, 7)
+const GAME_CORNER_MONEY_LABEL_AT: Vector2i = Vector2i(12, 2)
+const GAME_CORNER_MONEY_AT: Vector2i = Vector2i(12, 3)
+const GAME_CORNER_COIN_LABEL_AT: Vector2i = Vector2i(12, 4)
+const GAME_CORNER_COIN_AT: Vector2i = Vector2i(15, 5)
+
 ## `Mom_ContinueMenuSetup`'s own box and the three rows it prints in.
 ## `hlcoord 13, 6` plus `wMomBankDigitCursorPosition` is the digit the cursor
 ## blanks, which is the amount's first digit column.
@@ -197,6 +205,9 @@ static func balance_window(
 		&"money_and_coins":
 			at = BALANCES_AT
 			box = BALANCES_SIZE
+		&"game_corner":
+			at = GAME_CORNER_AT
+			box = GAME_CORNER_SIZE
 	var width: int = Gen2Screen.WIDTH
 	var indices := PackedByteArray()
 	indices.resize(width * Gen2Screen.HEIGHT)
@@ -212,6 +223,11 @@ static func balance_window(
 			page._text(indices, width, money_string(money), BALANCES_MONEY_AT)
 			page._text(indices, width, "COIN", BALANCES_COIN_LABEL_AT)
 			page._text(indices, width, coin_string(coins), BALANCES_COIN_AT)
+		&"game_corner":
+			page._text(indices, width, GEN1_MONEY_LABEL, GAME_CORNER_MONEY_LABEL_AT)
+			page._text(indices, width, money_string(money), GAME_CORNER_MONEY_AT)
+			page._text(indices, width, "COIN", GAME_CORNER_COIN_LABEL_AT)
+			page._text(indices, width, coin_string(coins), GAME_CORNER_COIN_AT)
 		_:
 			## `DisplayMoneyBox` writes MONEY into the box's own top border,
 			## where `PlaceMoneyTopRight` draws the balance alone.

--- a/game/world/card_flip_screen.gd
+++ b/game/world/card_flip_screen.gd
@@ -144,7 +144,6 @@ func _handle_yes_no_button(button: int) -> void:
 			pass
 
 
-## One pass of the loop and whatever it emitted.
 func _pass() -> void:
 	if not _game.advance() and not _game.waiting_for_sfx():
 		_drain()
@@ -168,7 +167,6 @@ func _drain() -> void:
 				pass
 
 
-## The state the page draws over the table.
 func overlay_state() -> Dictionary:
 	if _game == null:
 		return {}

--- a/game/world/slot_machine_screen.gd
+++ b/game/world/slot_machine_screen.gd
@@ -155,7 +155,6 @@ func _handle_yes_no_button(button: int) -> void:
 			pass
 
 
-## One pass of the loop and whatever it emitted.
 func _pass() -> void:
 	if not _machine.advance() and not _machine.waiting_for_sfx():
 		_drain()
@@ -179,7 +178,6 @@ func _drain() -> void:
 				pass
 
 
-## The state the page draws over the machine.
 func overlay_state() -> Dictionary:
 	if _machine == null:
 		return {}

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3687,8 +3687,11 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"branch": &"_gen1_node_branch",
 	"has_item": &"_gen1_node_has_item",
 	"has_money": &"_gen1_node_has_money",
+	"has_coins": &"_gen1_node_has_coins",
 	"spend_money": &"_gen1_node_spend_money",
+	"add_coins": &"_gen1_node_add_coins",
 	"money_box": &"_gen1_node_money_box",
+	"coin_box": &"_gen1_node_coin_box",
 	"give_item": &"_gen1_resolve_gift",
 	"take_item": &"_gen1_take_item",
 	"toggle_object": &"_gen1_node_toggle",
@@ -3774,6 +3777,7 @@ func _gen1_script_steps(row: Dictionary, event: Dictionary = {}) -> Array:
 	return steps if _gen1_resolve_script(nodes as Array, steps, {
 		"bag": state.items() if state != null else {}, "named": "", "object": event,
 		"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
+		"coins": state.coins() if state != null else 0,
 	}) else []
 
 
@@ -3826,6 +3830,14 @@ func _gen1_node_has_money(node: Dictionary, steps: Array, run: Dictionary) -> bo
 	)
 
 
+func _gen1_node_has_coins(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var coins: int = int(run["coins"])
+	var wanted: int = int(node["coins"])
+	var holds: bool = coins == wanted if String(node["test"]) == "exactly" \
+		else coins >= wanted
+	return _gen1_resolve_side(node, holds, steps, run)
+
+
 ## `SubBCD` over `wPlayerMoney`, whose `.fill` writes zeroes across a balance it
 ## borrowed past.
 func _gen1_node_spend_money(node: Dictionary, steps: Array, run: Dictionary) -> bool:
@@ -3835,8 +3847,22 @@ func _gen1_node_spend_money(node: Dictionary, steps: Array, run: Dictionary) -> 
 	return true
 
 
+func _gen1_node_add_coins(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var held: int = mini(
+		int(run["coins"]) + int(node["amount"]), Gen1Layout.COIN_CEILING
+	)
+	run["coins"] = held
+	steps.append({"type": &"coins", "amount": held})
+	return true
+
+
 func _gen1_node_money_box(_node: Dictionary, steps: Array, _run: Dictionary) -> bool:
-	steps.append({"type": &"money_box"})
+	steps.append({"type": &"money_box", "kind": &"money_top_right"})
+	return true
+
+
+func _gen1_node_coin_box(_node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"money_box", "kind": &"game_corner"})
 	return true
 
 
@@ -4073,6 +4099,7 @@ func _gen1_run_copy(run: Dictionary) -> Dictionary:
 		"named": run["named"],
 		"object": run.get("object", {}),
 		"money": run.get("money", 0),
+		"coins": run.get("coins", 0),
 	}
 
 
@@ -4550,11 +4577,14 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 				"money": {Gen2WorldMartHost.MONEY_ACCOUNT: int(step["amount"])},
 			})
 			return true
+		&"coins":
+			state.apply_changes({}, {}, {"coins": int(step["amount"])})
+			return true
 		&"money_box":
 			_gen1_money_window = true
 			events.append({
 				"type": &"money_window_opened",
-				"kind": &"money_top_right",
+				"kind": StringName(step.get("kind", &"money_top_right")),
 				"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
 				"coins": state.coins() if state != null else 0,
 			})

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -307,7 +307,6 @@ func _exit_tree() -> void:
 	_mart_view = null
 
 
-## Opens the host for whatever pending input the world currently exposes.
 func open_pending(
 	world: Gen2WorldAPI,
 	data: GameData,

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -43,9 +43,15 @@ const LAYOUT: Dictionary = {
 	"money_hram": 0xFF9F,
 	"player_money": 0xD347,
 	"sub_bcd": 0x0250,
+	"has_enough_coins": 0x0260,
+	"player_coins": 0xD5A4,
+	"add_bcd": 0x0270,
+	"coin_box": 0x0280,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
-const PREDEFS: Dictionary = {1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240, 5: 0x0250}
+const PREDEFS: Dictionary = {
+	1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240, 5: 0x0250, 6: 0x0270,
+}
 const AT: int = 0x1000
 const HELLO: int = 0x1800
 const BYE: int = 0x1810
@@ -556,6 +562,78 @@ func test_the_subtraction_predef_becomes_the_price_it_takes() -> void:
 	assert_eq(
 		_decode(_spend([0x00, 0x05, 0x00]) + _call(int(LAYOUT["text_script_end"]))),
 		[{"op": "spend_money", "amount": 500}]
+	)
+
+
+## `ldh [hCoins + n], a`, which is `hMoney`'s last two bytes.
+func _coins(count: Array) -> Array:
+	var out: Array = []
+	var at: int = int(LAYOUT["money_hram"]) + Gen1Layout.COIN_BUFFER_AT
+	for index: int in count.size():
+		out += [Gen1Layout.SCRIPT_LD_A, int(count[index]),
+			Gen1Layout.SCRIPT_LDH_MEM_A, (at + index) & 0xFF]
+	return out
+
+
+## The two flags `HasEnoughCoins` leaves: carry when the player is short, which
+## `jr nc` at $30 reads, and zero when the counts are equal, which `jr z` at $28
+## reads. `GameCornerGentlemanText` is the one row of the corpus that takes the
+## second, so both readings are built here.
+func test_a_coin_test_reads_either_flag() -> void:
+	for row: Array in [[0x30, "at_least"], [0x28, "exactly"]]:
+		var refused: Array = _print(BYE) + _call(int(LAYOUT["text_script_end"]))
+		var script: Array = _decode(
+			_coins([0x99, 0x90]) + _call(int(LAYOUT["has_enough_coins"]))
+				+ [int(row[0]), refused.size()] + refused
+				+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
+			_boxes()
+		)
+		assert_eq(script, [{
+			"op": "has_coins", "coins": 9990, "test": String(row[1]),
+			"then": [{"op": "text", "text": "HI"}],
+			"else": [{"op": "text", "text": "BYE"}],
+		}])
+
+
+func test_a_coin_test_with_one_byte_written_answers_nothing() -> void:
+	assert_eq(_decode(
+		_coins([0x99]) + _call(int(LAYOUT["has_enough_coins"]))
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [])
+
+
+## `AddBCDPredef` with `wPlayerCoins + 1` in de and two in c. The Day-Care sums
+## its own price with the same predef over another buffer, which reads as
+## nothing rather than as coins.
+func _add_coins(count: Array, at: int) -> Array:
+	var coins: int = int(LAYOUT["money_hram"]) + Gen1Layout.COIN_BUFFER_AT
+	return _coins(count) + _load_hl(coins + Gen1Layout.COIN_BYTES - 1) \
+		+ [Gen1Layout.SCRIPT_LD_DE, at & 0xFF, at >> 8,
+			Gen1Layout.SCRIPT_LD_C, Gen1Layout.COIN_BYTES] \
+		+ _predef(6)
+
+
+func test_the_addition_predef_becomes_the_coins_it_gives() -> void:
+	var at: int = int(LAYOUT["player_coins"]) + Gen1Layout.COIN_BYTES - 1
+	assert_eq(
+		_decode(_add_coins([0x00, 0x50], at) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "add_coins", "amount": 50}]
+	)
+
+
+func test_an_addition_onto_another_buffer_answers_nothing() -> void:
+	assert_eq(_decode(
+		_add_coins([0x00, 0x50], int(LAYOUT["player_money"]))
+			+ _call(int(LAYOUT["text_script_end"]))
+	), [])
+
+
+## `GameCornerDrawCoinBox`, which the layout names by its full ROM offset
+## because the same address in another bank is another routine.
+func test_the_coin_box_call_becomes_its_own_node() -> void:
+	assert_eq(
+		_decode(_call(int(LAYOUT["coin_box"])) + _call(int(LAYOUT["text_script_end"]))),
+		[{"op": "coin_box"}]
 	)
 
 

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,27 +130,30 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 235, "text": 252, "branch": 95, "choice": 11, "flag": 37,
-		"give_item": 24, "has_item": 9, "take_item": 3, "unknown": 43,
+	&"red": {"rows": 236, "text": 264, "branch": 95, "choice": 12, "flag": 40,
+		"give_item": 24, "has_item": 10, "take_item": 3, "unknown": 40,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
-		"trade": 9, "has_money": 1, "spend_money": 1, "money_box": 2},
-	&"blue": {"rows": 235, "text": 252, "branch": 95, "choice": 11, "flag": 37,
-		"give_item": 24, "has_item": 9, "take_item": 3, "unknown": 43,
+		"trade": 9, "has_money": 2, "spend_money": 2, "money_box": 2,
+		"has_coins": 4, "add_coins": 4, "coin_box": 2},
+	&"blue": {"rows": 236, "text": 264, "branch": 95, "choice": 12, "flag": 40,
+		"give_item": 24, "has_item": 10, "take_item": 3, "unknown": 40,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
-		"trade": 9, "has_money": 1, "spend_money": 1, "money_box": 2},
-	&"yellow": {"rows": 279, "text": 294, "branch": 97, "choice": 12, "flag": 32,
-		"give_item": 24, "has_item": 9, "take_item": 3, "unknown": 47,
+		"trade": 9, "has_money": 2, "spend_money": 2, "money_box": 2,
+		"has_coins": 4, "add_coins": 4, "coin_box": 2},
+	&"yellow": {"rows": 280, "text": 306, "branch": 97, "choice": 13, "flag": 35,
+		"give_item": 24, "has_item": 10, "take_item": 3, "unknown": 44,
 		"pick_up_item": 108, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
-		"trade": 7, "has_money": 1, "spend_money": 1, "money_box": 2},
+		"trade": 7, "has_money": 2, "spend_money": 2, "money_box": 2,
+		"has_coins": 4, "add_coins": 4, "coin_box": 2},
 }
 ## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
-## which no map text row names and which the disassembly marks unreferenced. The
+## which no map text row names and the disassembly marks unreferenced. The
 ## `trade` rows are the eight `predef DoInGameTradeDialogue` sites plus
 ## `CinnabarLabTradeRoom`'s second, whose `jr` shares the first one's tail;
-## Yellow ships neither trade house. The money rows are the Magikarp salesman's
-## alone: Museum 1F and the Safari Zone gate spend theirs behind
+## Yellow ships neither trade house. The coin rows are the Game Corner's four
+## clerks. Museum 1F and the Safari Zone gate spend their money behind
 ## `StartSimulatingJoypadStates`, which walks the player and which this port
-## has no counterpart for, so those paths stay unread.
+## has no counterpart for, so those two paths stay unread.
 
 ## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
 ## and how many start ON. Three rows name an object their map has not got.

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -109,7 +109,7 @@ const PRIZE_MENUS: Dictionary = {
 ## worth the box it puts up. `BikeShopYoungsterText` turns on EVENT_GOT_BICYCLE,
 ## `LavenderTownLittleGirlText` asks and branches on the answer, and
 ## `GameCornerFishingGuruText` reaches `Has9990Coins` only with the COIN CASE in
-## the bag, so the row speaks without one and says nothing at all with it.
+## the bag, so its own flag decides which of two boxes it opens.
 const BIKE_SHOP: int = 66
 const BIKE_YOUNGSTER := Vector2i(1, 4)
 const BIKE_FLAG: int = 192
@@ -118,11 +118,26 @@ const LAVENDER_TOWN: int = 4
 const GHOST_GIRL := Vector2i(15, 10)
 const GHOST_ANSWERS: Array[String] = ["Really? So there", "Hahaha, I guess"]
 const GAME_CORNER: int = 135
-const GAME_CORNER_GAMBLER := Vector2i(5, 12)
+const GAME_CORNER_GURU := Vector2i(5, 12)
 const GAME_CORNER_FLAG: int = 442
 const GAME_CORNER_BOX: String = "Wins seem to come"
 const GAME_CORNER_ASKED: String = "Kid, do you want"
-const COIN_CASE: int = 0x45
+
+const GAME_CORNER_CLERK := Vector2i(5, 7)
+const COIN_CASE_CEILING: int = 9990
+const COIN_PRICE: int = 1000
+const COINS_BOUGHT: int = 50
+const CLERK_SOLD: String = "Thanks! Here are"
+const CLERK_NO_CASE: String = "You don't have a"
+const CLERK_CASE_FULL: String = "Oops! Your COIN"
+const CLERK_SHORT: String = "You can't afford"
+
+## `GameCornerGentlemanText`, whose `jr z` refuses exactly 9990 and pays more.
+const GAME_CORNER_GENTLEMAN := Vector2i(17, 14)
+const GENTLEMAN_FLAG: int = 443
+const COINS_GIVEN: int = 20
+const GENTLEMAN_PAID: String = "20 coins!"
+const GENTLEMAN_REFUSED: String = "You've got your"
 
 ## Celadon City's TM41, whose receipt box names the item out of the buffer
 ## `CopyToStringBuffer` fills only when the bag took it.
@@ -219,6 +234,7 @@ func _one_game() -> void:
 	_check_the_prize_counter()
 	_check_a_trade()
 	_check_the_magikarp_salesman()
+	_check_the_coin_clerks()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -432,15 +448,11 @@ func _check_scripted_npcs() -> void:
 		)
 		_r.check(read.begins_with(BIKE_BOXES[1 if set_flag else 0]),
 			"the bike shop said %s with the bicycle flag %s." % [read, set_flag])
-	var asked: String = _scripted_box(GAME_CORNER, GAME_CORNER_GAMBLER, 0)
+	var asked: String = _scripted_box(GAME_CORNER, GAME_CORNER_GURU, 0)
 	_r.check(asked.begins_with(GAME_CORNER_ASKED),
 		"the guru said %s with no COIN CASE." % [asked])
-	var silent: String = _scripted_box(
-		GAME_CORNER, GAME_CORNER_GAMBLER, 0, {COIN_CASE: 1}
-	)
-	_r.check(silent.is_empty(), "the half-read row said %s." % [silent])
 	var spoken: String = _scripted_box(
-		GAME_CORNER, GAME_CORNER_GAMBLER, GAME_CORNER_FLAG
+		GAME_CORNER, GAME_CORNER_GURU, GAME_CORNER_FLAG
 	)
 	_r.check(spoken.begins_with(GAME_CORNER_BOX), "its other side said %s." % [spoken])
 	_check_the_ghost_girl()
@@ -829,6 +841,88 @@ func _magikarp_offer(purse: int) -> Gen2WorldAPI:
 		not String(world.pending_script_input().get("text", "")).is_empty(),
 		"the deal asked nothing: %s." % [results]
 	) else null
+
+
+func _check_the_coin_clerks() -> void:
+	var world: Gen2WorldAPI = _clerk_world(COIN_PRICE, 0, 1)
+	if world == null:
+		return
+	var window: Dictionary = _first_event(world.interact(), &"money_window_opened")
+	_r.check(
+		StringName(window.get("kind", &"")) == &"game_corner"
+			and int(window.get("money", -1)) == COIN_PRICE
+			and int(window.get("coins", -1)) == 0,
+		"the clerk drew %s over the map." % [window]
+	)
+	if not _r.check(world.script_input_waiting(), "the clerk asked nothing."):
+		return
+	var said: String = _event_text(world.choose_script_input(0))
+	_r.check(said.begins_with(CLERK_SOLD), "she answered YES with %s." % [said])
+	_r.check(
+		world.state.coins() == COINS_BOUGHT
+			and world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == 0,
+		"%d coins cost %d." % [world.state.coins(), COIN_PRICE - world.state.money(
+			Gen2WorldMartHost.MONEY_ACCOUNT
+		)]
+	)
+	for row: Array in [
+		[COIN_PRICE - 1, 0, 1, CLERK_SHORT], [COIN_PRICE, COIN_CASE_CEILING, 1,
+		CLERK_CASE_FULL], [COIN_PRICE, 0, 0, CLERK_NO_CASE],
+	]:
+		_check_a_refused_clerk(int(row[0]), int(row[1]), int(row[2]), String(row[3]))
+	_check_the_gentleman()
+	_r.note("gen1 walk the coin clerk: %d coins for %d, and three refusals" % [
+		COINS_BOUGHT, COIN_PRICE,
+	])
+
+
+func _check_a_refused_clerk(money: int, coins: int, cases: int, wanted: String) -> void:
+	var world: Gen2WorldAPI = _clerk_world(money, coins, cases)
+	if world == null:
+		return
+	world.interact()
+	if not _r.check(world.script_input_waiting(), "the clerk asked nothing."):
+		return
+	var said: String = _event_text(world.choose_script_input(0))
+	_r.check(said.begins_with(wanted), "with %d, %d coins and %d cases she said %s." % [
+		money, coins, cases, said,
+	])
+	_r.check(world.state.coins() == coins, "a refusal left %d coins." % world.state.coins())
+
+
+func _clerk_world(money: int, coins: int, cases: int) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(0, GAME_CORNER, GAME_CORNER_CLERK)
+	if world == null:
+		return null
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	world.state.apply_changes({}, {}, {
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: money},
+		"coins": coins,
+		"items": {Gen1Layout.ITEM_COIN_CASE: cases},
+	})
+	return world
+
+
+func _check_the_gentleman() -> void:
+	for coins: int in [COIN_CASE_CEILING, COIN_CASE_CEILING + 1]:
+		var world: Gen2WorldAPI = _r.open_world(0, GAME_CORNER, GAME_CORNER_GENTLEMAN)
+		if world == null:
+			return
+		world.player_facing = Gen2WorldSprite.FACING_UP
+		world.state.apply_changes({}, {}, {"coins": coins, "items": {Gen1Layout.ITEM_COIN_CASE: 1}})
+		var said: Array[String] = _spoken(world)
+		var refused: bool = coins == COIN_CASE_CEILING
+		_r.check(
+			said.size() == 2 and (said[1].begins_with(GENTLEMAN_REFUSED) if refused
+				else said[1].ends_with(GENTLEMAN_PAID)),
+			"with %d coins the gentleman said %s." % [coins, said]
+		)
+		_r.check(
+			world.state.coins() == (coins if refused else mini(
+				coins + COINS_GIVEN, Gen1Layout.COIN_CEILING
+			)) and world.event_flag_active(GENTLEMAN_FLAG) != refused,
+			"with %d coins he left %d." % [coins, world.state.coins()]
+		)
 
 
 func _first_event(results: Array, type: StringName) -> Dictionary:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -36,6 +36,7 @@ const KIND_HELP: Dictionary = {
 	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
 	&"trade": "presses: DoInGameTradeDialogue, faced up from the cell below the trader. 0 the offer and its YES/NO, 1 the party list YES opens",
 	&"deal": "presses: the MAGIKARP salesman, faced right from the cell beside him with the money box DisplayTextBoxID drew over the map",
+	&"coins": "presses: GameCornerClerk1Text, faced up from the cell below her with GameCornerDrawCoinBox's own box over the map. 0 the offer and its YES/NO, 1 the box YES lands in",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
@@ -191,6 +192,7 @@ const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"gift": BOX_REVEAL_FRAMES,
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
 	&"prizes": BOX_REVEAL_FRAMES, &"trade": BOX_REVEAL_FRAMES,
+	&"coins": BOX_REVEAL_FRAMES, &"deal": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -448,6 +450,7 @@ const STAGERS: Dictionary = {
 	&"prizes": &"_stage_prizes",
 	&"trade": &"_stage_trade",
 	&"deal": &"_stage_deal",
+	&"coins": &"_stage_coins",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -1068,6 +1071,13 @@ func _stage_deal() -> void:
 	_stage_counter(
 		{"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY}}, PokeButton.RIGHT
 	)
+
+
+func _stage_coins() -> void:
+	_stage_counter({
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY},
+		"items": {Gen1Layout.ITEM_COIN_CASE: 1},
+	})
 
 
 ## A counter faced the way [param facing] says: presses, then rows down first.

--- a/tools/preview_world_story.gd
+++ b/tools/preview_world_story.gd
@@ -784,7 +784,6 @@ const TRAINER_CLASS_RED: int = 63
 ## constants/item_constants.asm.
 const ITEM_MACHINE_PART: int = 0x80
 
-## constants/event_flags.asm, same numbers in both pins.
 const EVENT_FAST_SHIP_HAS_ARRIVED: int = 49
 const EVENT_FAST_SHIP_FOUND_GIRL: int = 50
 const EVENT_FAST_SHIP_LAZY_SAILOR: int = 51


### PR DESCRIPTION
All four Game Corner clerks read now, taking the corpus to 236 decoded `text_asm` rows on Red and Blue and 280 on Yellow.

`hCoins` is a union over `hMoney`'s last two bytes, so one `SCRIPT_BCD_BUFFERS` entry holds a price and a coin count alike. `HasEnoughCoins` is the one test read out of either flag: `Has9990Coins` behind a `jr nc` is the coin case being full, and `GameCornerGentlemanText`'s own `jr z` refuses a case holding exactly 9990 and pays one holding more.

`Gen1Layout.SCRIPT_BANKED_CALLS` names `GameCornerDrawCoinBox` by its full ROM offset, the same address in another bank being another routine, and `Gen2MartPage.balance_window`'s fourth kind is that box: `TextBoxBorder` at `hlcoord 11, 0` with `lb bc, 5, 7`, MONEY and COIN inside it rather than in its border. `predef AddBCDPredef` over `wPlayerCoins` is `add_coins`, ceiled at 9999 by `AddBCD`'s own `.fill`.

| Check | Result |
|---|---|
| `validate.gd -- all` | 92 topics pass |
| GUT unit tier | 3827 tests, 0 failures |
| `--warning-scan` | 0 warnings in 632 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| `release.sh --gates` | comments 40024 of 40024 |

`gen1_walk.gd` buys 50 coins for 1000, is refused for a short purse, a full case and no case at all, and takes the gentleman's 20 at 9991 where 9990 is turned away. `tools/preview_world.gd -- red 0 135 <out.png> live coins@5,7 1` photographs the sale; `deal` now spends the box reveal it had been captured in the middle of.