### PR TITLE
Open the three Generation 1 PCs

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -1568,8 +1568,22 @@ func type_count() -> int:
 ## this passes the number to the overlay untouched rather than through
 ## [method _content]'s one-based subtraction.
 func type_name(number: int) -> String:
-	return String(_overlaid(Gen2ContentOverlay.KIND_TYPE, number, _entry(_types, number))
+	return String(_overlaid(Gen2ContentOverlay.KIND_TYPE, number, _type_row(number))
 		.get("name", ""))
+
+
+## The row a type number names. Generation 1's numbering skips $09 to $13 and
+## the cache holds only the types that exist, so a row answers for its own
+## `number` rather than for its place in the array; Crystal's run is dense and
+## takes the first test.
+func _type_row(number: int) -> Dictionary:
+	var row: Dictionary = _entry(_types, number)
+	if int(row.get("number", -1)) == number:
+		return row
+	for candidate: Variant in _types:
+		if int((candidate as Dictionary).get("number", -1)) == number:
+			return candidate
+	return {}
 
 
 ## Which stat pair a type attacks and defends with. The cartridge's answer is

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -134,6 +134,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_battle_tiles,
 	_verify_battle_anims,
 	_verify_facility_text,
+	_verify_dex_ratings,
 	_verify_world,
 ]
 
@@ -171,6 +172,14 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"coin_case": ["coin_case_text", Gen1Layout.COIN_CASE_TEXT_AT],
 	"party_menu": ["party_menu_text", Gen1Layout.PARTY_MENU_TEXT_AT],
 	"toss": ["toss_text", Gen1Layout.TOSS_TEXT_AT],
+	"pc": ["pc_text", Gen1Layout.PC_TEXT_AT],
+	"players_pc": ["players_pc_text", Gen1Layout.PLAYERS_PC_TEXT_AT],
+	"bills_pc": ["bills_pc_text", Gen1Layout.BILLS_PC_TEXT_AT],
+	"bills_pc_2": ["bills_pc_release_text", Gen1Layout.BILLS_PC_RELEASE_TEXT_AT],
+	"oaks_pc": ["oaks_pc_text", Gen1Layout.OAKS_PC_TEXT_AT],
+	"hof_pc": ["hof_pc_text", Gen1Layout.HOF_PC_TEXT_AT],
+	"change_box": ["change_box_text", Gen1Layout.CHANGE_BOX_TEXT_AT],
+	"choose_box": ["choose_box_text", Gen1Layout.CHOOSE_BOX_TEXT_AT],
 }
 
 
@@ -488,6 +497,26 @@ static func _verify_facility_text(rom: RomFile, layout: Dictionary) -> Dictionar
 	return _ok()
 
 
+## `DexRatingsTable`'s thresholds run 10 to `NUM_POKEMON + 1` in tens, so a
+## table that has slipped is off on its first row.
+static func _verify_dex_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var table: int = int(layout["dex_ratings"])
+	if facility_text(rom, table + Gen1Layout.DEX_COMPLETION_TEXT_AT).is_empty():
+		return _fail("DexCompletionText does not decode.")
+	for index: int in Gen1Layout.DEX_RATING_ROWS:
+		var row: int = table + index * Gen1Layout.DEX_RATING_ROW_SIZE
+		var wanted: int = Gen1Layout.DEX_RATING_STEP * (index + 1)
+		if index == Gen1Layout.DEX_RATING_ROWS - 1:
+			wanted = Gen1Layout.SPECIES_COUNT + 1
+		if rom.u8(row) != wanted:
+			return _fail("DexRatingsTable row %d reads %d." % [index, rom.u8(row)])
+		if facility_text(
+			rom, Gen1Layout.banked(RomFile.bank_of(table), rom.u16le(row + 1))
+		).is_empty():
+			return _fail("DexRatingsTable row %d has no text." % index)
+	return _ok()
+
+
 static func _verify_world(rom: RomFile, _layout: Dictionary) -> Dictionary:
 	return Gen1WorldImporter.verify_layout(rom)
 
@@ -760,6 +789,7 @@ func import_rom(
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"mart_text": _import_mart_text(rom, layout),
 		"special_text": _import_facility_text(rom, layout),
+		"oak_ratings": _import_dex_ratings(rom, layout),
 		"vending": _import_vending(rom, layout, items),
 		"prizes": _import_prizes(rom, layout),
 		"complete": true,
@@ -1041,6 +1071,26 @@ func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 		out[run] = boxes
 	out["npc_trade"] = _import_trade_text(rom, layout)
 	return out
+
+
+## `DexRatingsTable` with `DexCompletionText` in front of it, in the section
+## `GameData.oak_ratings` reads. `PlayPokedexRatingSfx` picks its effect off a
+## table of its own rather than off the row, and no Generation 1 audio is
+## imported, so a row carries no `sfx`.
+func _import_dex_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var table: int = int(layout["dex_ratings"])
+	var bank: int = RomFile.bank_of(table)
+	var rows: Array = []
+	for index: int in Gen1Layout.DEX_RATING_ROWS:
+		var row: int = table + index * Gen1Layout.DEX_RATING_ROW_SIZE
+		rows.append({
+			"threshold": rom.u8(row),
+			"text": facility_text(rom, Gen1Layout.banked(bank, rom.u16le(row + 1))),
+		})
+	return {
+		"counts": facility_text(rom, table + Gen1Layout.DEX_COMPLETION_TEXT_AT),
+		"ratings": rows,
+	}
 
 
 ## `InGameTradeTextPointers`' three tables of five and the two boxes the swap
@@ -1352,6 +1402,18 @@ func _import_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"tiles": Gen1Layout.FONT_EXTRA_TILES,
 			"first_code": Gen1Layout.FONT_EXTRA_FIRST_CODE,
 			"bits": 2,
+		},
+		"battle_balls": {
+			"offset": int(layout["ball_tiles"]),
+			"tiles": Gen1Layout.BALL_TILES,
+			"first_code": 0,
+			"bits": 2,
+		},
+		"stats_p": {
+			"offset": int(layout["stats_p"]),
+			"tiles": Gen1Layout.STATS_P_TILES,
+			"first_code": Gen1Layout.STATS_P_CODE,
+			"bits": 1,
 		},
 	}
 	for sheet: String in BATTLE_TILE_SHEETS:

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -192,6 +192,9 @@ static func move_power(number: int, power: int) -> int:
 ## $62 as 2bpp, `BattleHudTiles1` at $6d and `BattleHudTiles2` with
 ## `BattleHudTiles3` contiguous behind it at $73, both doubled from 1bpp.
 const BATTLE_FONT_TILES: int = 30
+## `PTile`, the bold P `StatusScreen2` copies to $72 for "PP".
+const STATS_P_TILES: int = 1
+const STATS_P_CODE: int = 0x72
 const BATTLE_FONT_FIRST_CODE: int = 0x62
 const BATTLE_HUD_1_TILES: int = 3
 const BATTLE_HUD_1_FIRST_CODE: int = 0x6D
@@ -492,6 +495,9 @@ const TEXT_SCRIPT_POKECENTER_NURSE: int = 0xFF
 const TEXT_SCRIPT_CABLE_CLUB: int = 0xF6
 const TEXT_SCRIPT_VENDING_MACHINE: int = 0xF5
 const TEXT_SCRIPT_PRIZE_VENDOR: int = 0xF7
+const TEXT_SCRIPT_POKECENTER_PC: int = 0xF9
+const TEXT_SCRIPT_PLAYERS_PC: int = 0xFC
+const TEXT_SCRIPT_BILLS_PC: int = 0xFD
 
 
 ## `CeladonPrizeMenu`'s two stub runs, which are not one: the unreferenced
@@ -586,6 +592,65 @@ const PARTY_MENU_TEXT_AT: Dictionary = {
 const TOSS_TEXT_AT: Dictionary = {
 	"threw_away": 0x00, "ok_to_toss": 0x05, "too_important": 0x0A,
 }
+
+## `engine/menus/pc.asm`'s four, which `ActivatePC` prints around the machine's
+## own top menu.
+const PC_TEXT_AT: Dictionary = {
+	"turned_on": 0x00, "accessed_bills": 0x05, "accessed_someones": 0x0A,
+	"accessed_mine": 0x0F,
+}
+
+## `engine/menus/players_pc.asm`'s fourteen in file order: `PlayerPC` reached
+## from a text script has no generic PC in front of it, so it prints its own
+## boot line.
+const PLAYERS_PC_TEXT_AT: Dictionary = {
+	"turned_on": 0x00, "what_do_you_want": 0x05, "what_to_deposit": 0x0A,
+	"deposit_how_many": 0x0F, "item_was_stored": 0x14, "nothing_to_deposit": 0x19,
+	"no_room_to_store": 0x1E, "what_to_withdraw": 0x23, "withdraw_how_many": 0x28,
+	"withdrew_item": 0x2D, "nothing_stored": 0x32, "cant_carry_more": 0x37,
+	"what_to_toss": 0x3C, "toss_how_many": 0x41,
+}
+
+## `engine/pokemon/bills_pc.asm`'s stubs, in two runs: Yellow puts an extra one
+## between `CantTakeMonText` and `ReleaseWhichMonText`.
+const BILLS_PC_TEXT_AT: Dictionary = {
+	"switch_on": 0x00, "what": 0x05, "mon_was_stored": 0x0F,
+	"cant_deposit_last": 0x14, "box_full": 0x19, "mon_is_taken_out": 0x1E,
+	"no_mon": 0x23, "cant_take_mon": 0x28,
+}
+const BILLS_PC_RELEASE_TEXT_AT: Dictionary = {
+	"once_released": 0x00, "mon_was_released": 0x05,
+}
+
+## `engine/menus/oaks_pc.asm`'s three, the second spending a `text_waitbutton`.
+const OAKS_PC_TEXT_AT: Dictionary = {
+	"get_rated": 0x00, "closed": 0x05, "accessed": 0x0B,
+}
+## `engine/menus/league_pc.asm`'s one.
+const HOF_PC_TEXT_AT: Dictionary = {"accessed": 0x00}
+
+## `ChangeBox`'s two, pinned apart because Yellow's own boxes move the second.
+const CHANGE_BOX_TEXT_AT: Dictionary = {"warning": 0x00}
+const CHOOSE_BOX_TEXT_AT: Dictionary = {"choose": 0x00}
+
+## `DexRatingsTable`: `dbw threshold, text`, the walk stopping at the first row
+## the owned count is under, with `DexCompletionText`'s stub right behind it.
+const DEX_RATING_ROWS: int = 16
+const DEX_RATING_ROW_SIZE: int = 3
+const DEX_RATING_STEP: int = 10
+
+## `PokeballTileGraphics`' four; only the ball itself is drawn here.
+const BALL_TILES: int = 4
+const DEX_COMPLETION_TEXT_AT: int = -TEXT_FAR_STUB_BYTES
+
+## `NUM_BOXES` and `MONS_PER_BOX`, which `BOX_NUM_MASK` bounds `wCurrentBoxNum`
+## to.
+const BOX_COUNT: int = 12
+const BOX_CAPACITY: int = 20
+
+## `EVENT_MET_BILL`, which puts BILL's PC on the machine's top menu where
+## SOMEONE's PC otherwise stands. Counted off `constants/event_constants.asm`.
+const EVENT_MET_BILL: int = 1360
 
 ## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
 ## it. `SwitchToMapRomBank` selects that bank once, which is what puts a map's
@@ -1135,6 +1200,15 @@ const RED_BLUE: Dictionary = {
 	"pokecenter_text": 0x0705D,
 	"cable_club_text": 0x072B3,
 	"vending_text": 0x74F99,
+	"pc_text": 0x17F23,
+	"players_pc_text": 0x07B22,
+	"bills_pc_text": 0x217E9,
+	"bills_pc_release_text": 0x2181B,
+	"oaks_pc_text": 0x1E93B,
+	"hof_pc_text": 0x76683,
+	"change_box_text": 0x73909,
+	"choose_box_text": 0x739D4,
+	"dex_ratings": 0x441D1,
 	"prize_text": 0x5277E,
 	"prize_text_2": 0x52960,
 	"prize_menus": 0x52843,
@@ -1155,6 +1229,8 @@ const RED_BLUE: Dictionary = {
 	"mon_icons": 0x717C0,
 	"mon_icon_species": 0x7190D,
 	"heal_machine_gfx": 0x704B7,
+	"ball_tiles": 0x3A97E,
+	"stats_p": 0x12ADC,
 	"shock_emote_gfx": 0x17CBD,
 	"wild_data": 0x0CEEB,
 	"wild_chances": 0x13918,
@@ -1292,6 +1368,15 @@ const YELLOW: Dictionary = {
 	"pokecenter_text": 0x06ED0,
 	"cable_club_text": 0x07188,
 	"vending_text": 0x747DE,
+	"pc_text": 0x17DA7,
+	"players_pc_text": 0x079C9,
+	"bills_pc_text": 0x21826,
+	"bills_pc_release_text": 0x2185D,
+	"oaks_pc_text": 0x1E2D4,
+	"hof_pc_text": 0x75F02,
+	"change_box_text": 0x73C52,
+	"choose_box_text": 0x73D10,
+	"dex_ratings": 0x441D1,
 	"prize_text": 0x526DF,
 	"prize_text_2": 0x528C0,
 	"prize_menus": 0x527AE,
@@ -1313,6 +1398,8 @@ const YELLOW: Dictionary = {
 	"mon_icons": 0x7184D,
 	"mon_icon_species": 0x719BA,
 	"heal_machine_gfx": 0x7050B,
+	"ball_tiles": 0x3AA28,
+	"stats_p": 0x11682,
 	"shock_emote_gfx": 0x411E5,
 	"wild_data": 0x0CB95,
 	"wild_chances": 0x138E2,
@@ -1364,6 +1451,7 @@ const BLUE_ONLY: Dictionary = {
 	"hidden_coins": 0x7679A,
 	"hidden_item_coords": 0x766B9,
 	"hidden_coin_coords": 0x76823,
+	"hof_pc_text": 0x76684,
 }
 
 static var _blue: Dictionary = RED_BLUE.merged(BLUE_ONLY, true)

--- a/game/import/text_codec.gd
+++ b/game/import/text_codec.gd
@@ -29,8 +29,10 @@ const BATTLE_EXTRA_LAST_CODE: int = 0x78
 ## What that run says. The rest is the HP bar's fill levels and the HUD borders,
 ## graphics rather than characters, so a code in the run and not here has none:
 ## falling back would decode $75 as an ellipsis when the tile is part of a bar.
+## `PrintLevel`'s own byte, the same code in both generations.
+const LEVEL_CODE: int = 0x6E
 const BATTLE_EXTRA_CHARACTERS: Dictionary = {
-	0x6E: "<LV>",
+	LEVEL_CODE: "<LV>",
 	0x70: "<DO>",
 	0x71: "◀",
 	0x72: "『",

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -82,6 +82,22 @@ const GEN1_FONT_EXTRA_AT: int = 0x60
 const GEN1_BATTLE_FONT_AT: int = 0x62
 const GEN1_HUD_1_AT: int = 0x6D
 const GEN1_HUD_2_AT: int = 0x73
+## Where `StatusScreen` puts them instead, and the cap it closes a bar with:
+## `wHPBarType` 1 is $6d and the party menu's 2 the tile below.
+const GEN1_STATS_HUD_2_AT: int = 0x78
+const GEN1_STATS_HUD_3_AT: int = 0x76
+## `BattleHudTiles3` is three tiles into the run `BattleHudTiles2` opens.
+const GEN1_HUD_3_STRIP_AT: int = 3
+const GEN1_STATS_HP_BAR_END: int = 0x6D
+## `DrawLineBox`'s four tiles.
+const GEN1_LINE_VERTICAL: int = 0x78
+const GEN1_LINE_CORNER: int = 0x77
+const GEN1_LINE_HORIZONTAL: int = 0x76
+const GEN1_LINE_ARROW: int = 0x6F
+## Three battle-extra glyphs the status screen places as bytes.
+const GEN1_ID: int = 0x73
+const GEN1_NUMERO: int = 0x74
+const GEN1_TO: int = 0x70
 
 ## Read through the instance so one panel-drawing routine serves both.
 var hp_label: int = HP_LABEL
@@ -157,6 +173,42 @@ static func _gen1_page(data: GameData) -> Gen2BattleTiles:
 			continue
 		if out._copy(
 			data.tile_indices(String(sheet[0])), int(meta.get("width", 0)), int(sheet[1])
+		):
+			loaded += 1
+	return out if loaded == sheets.size() else null
+
+
+## `StatusScreen`'s own page, which scatters the two HUD sheets a battle copies
+## whole: `BattleHudTiles2` to $78 and `BattleHudTiles3` to $76, leaving $73 to
+## $75 as the battle-extra font's, with `PTile`'s bold P at $72.
+static func gen1_stats_page(data: GameData) -> Gen2BattleTiles:
+	var out := Gen2BattleTiles.new()
+	out._first = GEN1_FIRST_TILE
+	out._last = LAST_TILE
+	out._width = (LAST_TILE - GEN1_FIRST_TILE + 1) * TILE
+	out._tiles.resize(out._width * TILE)
+	out.hp_label = GEN1_HP_LABEL
+	out.hp_label_end = GEN1_HP_LABEL_END
+	out.hp_bar_empty = GEN1_HP_BAR_EMPTY
+	out.hp_bar_full = GEN1_HP_BAR_FULL
+	out.hp_bar_end = GEN1_STATS_HP_BAR_END
+	out.enemy_side = GEN1_ENEMY_SIDE
+	var sheets: Array = [
+		["font_extra", GEN1_FONT_EXTRA_AT, 0, -1],
+		["battle_font", GEN1_BATTLE_FONT_AT, 0, -1],
+		["battle_hud_1", GEN1_HUD_1_AT, 0, -1],
+		["stats_p", Gen1Layout.STATS_P_CODE, 0, 1],
+		["battle_hud_2", GEN1_STATS_HUD_2_AT, 0, 1],
+		["battle_hud_2", GEN1_STATS_HUD_3_AT, GEN1_HUD_3_STRIP_AT, 2],
+	]
+	var loaded: int = 0
+	for sheet: Array in sheets:
+		var meta: Dictionary = data.tile_sheet(String(sheet[0]))
+		if meta.is_empty():
+			continue
+		if out._copy(
+			data.tile_indices(String(sheet[0])), int(meta.get("width", 0)),
+			int(sheet[1]), int(sheet[2]), int(sheet[3])
 		):
 			loaded += 1
 	return out if loaded == sheets.size() else null

--- a/game/render/font.gd
+++ b/game/render/font.gd
@@ -29,6 +29,11 @@ var _frame_stride: int = Gen2Layout.FRAME_TILES
 var _battle_extra: PackedByteArray = PackedByteArray()
 var _battle_extra_width: int = 0
 var _battle_extra_tiles: int = 0
+## The run `_LoadFontsBattleExtra` replaces, which is where that strip lands
+## rather than where its first tile is: $60 on Crystal and $62 on Generation 1,
+## whose `LoadHpBarAndStatusTilePatterns` copies to `vChars2 tile $62`.
+var _battle_extra_first_code: int = Gen2Layout.BATTLE_FONT_FIRST_CODE
+var _battle_extra_last_code: int = Gen2Text.BATTLE_EXTRA_LAST_CODE
 
 ## `FontExtra`, which `_LoadFontsExtra1` parks under the main font's own $80
 ## floor: the ellipsis, the two quotes, the middle dot and `<COLON>` all draw
@@ -102,6 +107,9 @@ func _take_gen1_frames() -> void:
 	_frame_stride = 0
 	_extra_loaded_first = _extra_first_code
 	_extra_loaded_last = Gen1Layout.FRAME_LAST_CODE
+	_battle_extra_first_code = Gen1Layout.BATTLE_FONT_FIRST_CODE
+	_battle_extra_last_code = Gen1Layout.BATTLE_FONT_FIRST_CODE \
+		+ Gen1Layout.BATTLE_FONT_TILES - 1
 
 
 func is_usable() -> bool:
@@ -131,9 +139,8 @@ func draw_code(
 	font: StringName = Gen2Text.FONT_MAIN
 ) -> void:
 	if font == Gen2Text.FONT_BATTLE_EXTRA \
-		and code >= Gen2Text.BATTLE_EXTRA_FIRST_CODE \
-		and code <= Gen2Text.BATTLE_EXTRA_LAST_CODE:
-		var within: int = code - Gen2Layout.BATTLE_FONT_FIRST_CODE
+		and code >= _battle_extra_first_code and code <= _battle_extra_last_code:
+		var within: int = code - _battle_extra_first_code
 		if within < 0 or within >= _battle_extra_tiles:
 			return
 		blit_slot(_battle_extra, _battle_extra_width, within, into, into_width, at_x, at_y)

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -336,8 +336,9 @@ func _blit_gen1_money(image: Image, money: int) -> void:
 	_blit_panel(image, indices, MONEY_SIZE, MONEY_AT)
 
 
-## `wPrintItemPrices` is the one place the two callers of
-## `PrintListMenuEntries` differ, so a row carries a `price` or a `quantity`.
+## `wPrintItemPrices` is where the two priced callers of `PrintListMenuEntries`
+## differ, so a row carries a `price` or a `quantity`; `PCPOKEMONLISTMENU`
+## prints `PrintLevel` in the quantity's own cells.
 func _blit_gen1_list(image: Image, state: Dictionary) -> void:
 	var indices: PackedByteArray = _panel(GEN1_LIST_SIZE)
 	var width: int = GEN1_LIST_SIZE.x * TILE
@@ -360,6 +361,11 @@ func _blit_gen1_list(image: Image, state: Dictionary) -> void:
 				indices, width, "×%s" % String.num_int64(
 					maxi(int(row["quantity"]), 0)
 				).lpad(GEN1_COUNT_DIGITS),
+				Vector2i(GEN1_COUNT_COLUMN - GEN1_LIST_AT.x, at.y + 1)
+			)
+		elif row.has("level"):
+			_level(
+				indices, width, int(row["level"]),
 				Vector2i(GEN1_COUNT_COLUMN - GEN1_LIST_AT.x, at.y + 1)
 			)
 	var cursor_column: int = GEN1_CURSOR_COLUMN - GEN1_LIST_AT.x
@@ -513,6 +519,19 @@ func _blit_gen1_coins(image: Image, coins: int) -> void:
 		GEN1_COIN_AT - MONEY_AT
 	)
 	_blit_panel(image, indices, MONEY_SIZE, MONEY_AT)
+
+
+## `PrintLevel`'s `<LV>` and the number beside it, three digits writing over
+## the glyph. The tile is `font_battle_extra`'s, which `BillsPC_` loads first.
+func _level(indices: PackedByteArray, width: int, level: int, at: Vector2i) -> void:
+	var column: int = at.x
+	if Gen2Font.level_glyph_shown(level):
+		font.draw_code(
+			Gen2Text.LEVEL_CODE, indices, width, at.x * TILE, at.y * TILE,
+			Gen2Text.FONT_BATTLE_EXTRA
+		)
+		column += 1
+	_text(indices, width, String.num_int64(maxi(level, 0)), Vector2i(column, at.y))
 
 
 static func _panel(size: Vector2i) -> PackedByteArray:

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -178,11 +178,16 @@ const EGG_MESSAGES: Array[String] = [
 var font: Gen2Font = null
 var tiles: Gen2BattleTiles = null
 var hud: Gen2BattleHud = null
+## Whether this is `StatusScreen`'s two pages rather than `StatsScreenMain`'s
+## three, which is a different tile page and a different layout.
+var gen1: bool = false
 
 
 static func from_data(data: GameData) -> Gen2StatsScreenPage:
 	var glyphs: Gen2Font = Gen2Font.from_data(data)
-	var page_tiles: Gen2BattleTiles = Gen2BattleTiles.stats_page(data)
+	var one: bool = data != null and data.generation == RomRegistry.GEN1
+	var page_tiles: Gen2BattleTiles = Gen2BattleTiles.gen1_stats_page(data) if one \
+		else Gen2BattleTiles.stats_page(data)
 	var panels: Gen2BattleHud = Gen2BattleHud.from_data(data)
 	if glyphs == null or page_tiles == null or panels == null:
 		return null
@@ -190,12 +195,19 @@ static func from_data(data: GameData) -> Gen2StatsScreenPage:
 	out.font = glyphs
 	out.tiles = page_tiles
 	out.hud = panels
+	out.gen1 = one
 	return out
 
 
 ## Where the screen puts the front pic, in pixels, and how wide the cell is.
 static func pic_position() -> Vector2i:
 	return PIC_AT * TILE
+
+
+## The same corner for the page that is open: `LoadFlippedFrontSpriteByMonIndex`
+## draws Generation 1's a column right of Crystal's.
+func pic_at() -> Vector2i:
+	return (GEN1_PIC_AT if gen1 else PIC_AT) * TILE
 
 
 static func pic_size() -> int:
@@ -245,6 +257,28 @@ static func pic_image(
 	return Gen2PicImage.x_flipped(art) if pic_mirrored(
 		int(snapshot.get("species", 0)), bool(snapshot.get("egg", false))
 	) else art
+
+
+## `StatsScreenInit`'s whole screen: the page with its front pic composed on
+## top, which has a palette of its own and so is blended rather than written
+## into the page's own index buffer. Null when [param page] has nothing to draw.
+static func compose(
+	page: Gen2StatsScreenPage, data: GameData, stats: Gen2MonStatsScreen
+) -> Image:
+	if page == null or stats == null:
+		return null
+	var snapshot: Dictionary = stats.snapshot()
+	var image: Image = page.render(snapshot, data)
+	if image == null or int(snapshot.get("species", 0)) <= 0:
+		return image
+	var art: Image = pic_image(data, snapshot, stats)
+	if art == null:
+		return image
+	image.blit_rect(
+		art, Rect2i(Vector2i.ZERO, art.get_size()),
+		page.pic_at() + pic_origin(art.get_size(), snapshot)
+	)
+	return image
 
 
 ## Where that picture sits: the animation fills the cell, so only a still one is
@@ -318,6 +352,9 @@ func draw(page: Dictionary) -> PackedByteArray:
 	indices.resize(COLUMNS * TILE * ROWS * TILE)
 	if font == null:
 		return indices
+	if gen1:
+		_draw_gen1(page, indices)
+		return indices
 	if bool(page.get("egg", false)):
 		_draw_egg(page, indices)
 		return indices
@@ -373,6 +410,8 @@ static func attributes(count: int = NUM_PAGES) -> PackedInt32Array:
 func render(page: Dictionary, data: GameData) -> Image:
 	var indices: PackedByteArray = draw(page)
 	var width: int = COLUMNS * TILE
+	if gen1:
+		return _render_gen1(page, indices, data)
 	if data == null:
 		return Gen2PicImage.from_indices(
 			indices, width, ROWS * TILE,
@@ -695,3 +734,242 @@ func _text(into: PackedByteArray, width: int, text: String, at: Vector2i) -> voi
 
 func _code(into: PackedByteArray, width: int, code: int, at: Vector2i) -> void:
 	font.draw_code(code, into, width, at.x * TILE, at.y * TILE, FONT)
+
+
+## `StatusScreen` and `StatusScreen2` (`engine/pokemon/status_screen.asm`): two
+## pages, one press each, on a screen never cleared between them. The picture
+## and the first rule survive the turn; the second page clears the block under
+## the name and covers the lower half.
+const GEN1_PAGES: int = 2
+const GEN1_PIC_AT: Vector2i = Vector2i(1, 0)
+## `DrawLineBox hlcoord 19, 1 / lb bc, 6, 10` and `hlcoord 19, 9 / lb bc, 8, 6`
+## as a corner, the rows down and the cells back.
+const GEN1_NAME_RULE: Array = [Vector2i(19, 1), 6, 10]
+const GEN1_OT_RULE: Array = [Vector2i(19, 9), 8, 6]
+## `ld de, -6 / add hl, de`, six cells left of where the first rule ended.
+const GEN1_NUMERO_AT: Vector2i = Vector2i(1, 7)
+const GEN1_NAME_AT: Vector2i = Vector2i(9, 1)
+const GEN1_LEVEL_AT: Vector2i = Vector2i(14, 2)
+const GEN1_HP_BAR_AT: Vector2i = Vector2i(11, 3)
+const GEN1_HP_NUMBERS_AT: Vector2i = Vector2i(12, 4)
+const GEN1_STATUS_LABEL_AT: Vector2i = Vector2i(9, 6)
+const GEN1_STATUS_AT: Vector2i = Vector2i(16, 6)
+const GEN1_DEX_NUMBER_AT: Vector2i = Vector2i(3, 7)
+const GEN1_LABELS_AT: Vector2i = Vector2i(10, 9)
+const GEN1_TYPES_AT: Vector2i = Vector2i(11, 10)
+const GEN1_ID_AT: Vector2i = Vector2i(12, 14)
+const GEN1_OT_AT: Vector2i = Vector2i(12, 16)
+const GEN1_ID_DIGITS: int = 5
+## `PrintStatsBox`' `STATUS_SCREEN_STATS_BOX` branch: `hlcoord 0, 8 / ld b, 8 /
+## ld c, 8`, each number one row down and five columns right of its name.
+const GEN1_STATS_BOX_AT: Vector2i = Vector2i(0, 8)
+const GEN1_STATS_BOX_SIZE: Vector2i = Vector2i(10, 10)
+const GEN1_STATS_NAMES_AT: Vector2i = Vector2i(1, 9)
+const GEN1_STATS_NUMBERS_AT: Vector2i = Vector2i(6, 10)
+## `.StatsText` and its four `wLoadedMon*` words, Special being the one stat
+## this generation has.
+const GEN1_STAT_NAMES: Array[String] = ["ATTACK", "DEFENSE", "SPEED", "SPECIAL"]
+const GEN1_STAT_KEYS: Array[String] = ["attack", "defense", "speed", "sp_attack"]
+## `TypesIDNoOTText`'s four rows, `<NEXT>` dropping two rows apiece.
+const GEN1_TYPE1_LABEL: String = "TYPE1/"
+const GEN1_TYPE2_LABEL: String = "TYPE2/"
+const GEN1_OT_LABEL: String = "OT/"
+const GEN1_STATUS_LABEL: String = "STATUS/"
+const GEN1_OK_STRING: String = "OK"
+## `StatusScreen2`'s own clear, divider and move box.
+const GEN1_CLEAR_AT: Vector2i = Vector2i(9, 2)
+const GEN1_CLEAR_SIZE: Vector2i = Vector2i(10, 5)
+const GEN1_DIVIDER_AT: Vector2i = Vector2i(19, 3)
+const GEN1_MOVE_BOX_AT: Vector2i = Vector2i(0, 8)
+const GEN1_MOVE_BOX_SIZE: Vector2i = Vector2i(20, 10)
+const GEN1_MOVES_AT: Vector2i = Vector2i(2, 9)
+const GEN1_PP_LABEL_AT: Vector2i = Vector2i(11, 10)
+const GEN1_PP_AT: Vector2i = Vector2i(14, 10)
+const GEN1_PP_DASH: String = "--"
+const GEN1_EXP_LABELS_AT: Vector2i = Vector2i(9, 3)
+const GEN1_EXP_LABELS: Array[String] = ["EXP POINTS", "LEVEL UP"]
+const GEN1_EXP_AT: Vector2i = Vector2i(12, 4)
+const GEN1_EXP_TO_NEXT_AT: Vector2i = Vector2i(7, 6)
+const GEN1_TO_AT: Vector2i = Vector2i(14, 6)
+const GEN1_NEXT_LEVEL_AT: Vector2i = Vector2i(16, 6)
+const GEN1_EXP_DIGITS: int = 7
+## `<NEXT>`'s own two rows, which every list on this screen steps by.
+const GEN1_ROW_STEP: int = 2
+
+
+## What survives the turn: the picture, the first rule and the dex number. The
+## name does not, `StatusScreen_ClearName` replacing the nickname with
+## `GetMonName`'s species name.
+func _draw_gen1(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	var moves: bool = int(page.get("page", PINK_PAGE)) > PINK_PAGE
+	_gen1_rule(into, width, GEN1_NAME_RULE)
+	_tile(into, width, Gen2BattleTiles.GEN1_NUMERO, GEN1_NUMERO_AT)
+	_text(into, width, ".", GEN1_NUMERO_AT + Vector2i(1, 0))
+	## PRINTNUM_LEADINGZEROES, so a two-digit dex number keeps its column.
+	_text(
+		into, width, "%0*d" % [DEX_DIGITS, int(page.get("dex_number", 0))],
+		GEN1_DEX_NUMBER_AT
+	)
+	_text(into, width, String(
+		page.get("species_name", "") if moves else page.get("nickname", "")
+	), GEN1_NAME_AT)
+	if moves:
+		_draw_gen1_moves(page, into)
+		return
+	_draw_gen1_stats(page, into)
+
+
+## `StatusScreen`'s own half, down to `PrintStatsBox`.
+func _draw_gen1_stats(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_gen1_rule(into, width, GEN1_OT_RULE)
+	draw_level(into, width, GEN1_LEVEL_AT, int(page.get("level", 0)))
+	var hp: int = int(page.get("hp", 0))
+	var max_hp: int = int(page.get("max_hp", 0))
+	hud.draw_bar_frame(into, width, GEN1_HP_BAR_AT, tiles.hp_bar_end)
+	hud.draw_hp_bar(into, width, GEN1_HP_BAR_AT, hp, max_hp)
+	_text(
+		into, width, "%s/%s" % [str(hp).lpad(HP_DIGITS), str(max_hp).lpad(HP_DIGITS)],
+		GEN1_HP_NUMBERS_AT
+	)
+	_text(into, width, GEN1_STATUS_LABEL, GEN1_STATUS_LABEL_AT)
+	var status: String = _status_string(page)
+	_text(
+		into, width, GEN1_OK_STRING if status == OK_STRING else status, GEN1_STATUS_AT
+	)
+	var types: Array = page.get("types", [])
+	_text(into, width, GEN1_TYPE1_LABEL, GEN1_LABELS_AT)
+	_text(into, width, String(types[0]) if not types.is_empty() else "", GEN1_TYPES_AT)
+	## `EraseType2Text` blanks the second label outright when both types match.
+	if types.size() > 1:
+		_text(into, width, GEN1_TYPE2_LABEL, GEN1_LABELS_AT + Vector2i(0, GEN1_ROW_STEP))
+		_text(
+			into, width, String(types[1]), GEN1_TYPES_AT + Vector2i(0, GEN1_ROW_STEP)
+		)
+	var id_label: Vector2i = GEN1_LABELS_AT + Vector2i(0, GEN1_ROW_STEP * 2)
+	_tile(into, width, Gen2BattleTiles.GEN1_ID, id_label)
+	_tile(into, width, Gen2BattleTiles.GEN1_NUMERO, id_label + Vector2i(1, 0))
+	_text(into, width, "/", id_label + Vector2i(2, 0))
+	_text(into, width, GEN1_OT_LABEL, GEN1_LABELS_AT + Vector2i(0, GEN1_ROW_STEP * 3))
+	_text(
+		into, width, "%0*d" % [GEN1_ID_DIGITS, int(page.get("ot_id", 0))], GEN1_ID_AT
+	)
+	_text(into, width, String(page.get("ot_name", "")), GEN1_OT_AT)
+	font.draw_box(
+		0, into, width, GEN1_STATS_BOX_AT.x * TILE, GEN1_STATS_BOX_AT.y * TILE,
+		GEN1_STATS_BOX_SIZE.x, GEN1_STATS_BOX_SIZE.y
+	)
+	var stats: Dictionary = page.get("stats", {})
+	for index: int in GEN1_STAT_NAMES.size():
+		var step := Vector2i(0, index * GEN1_ROW_STEP)
+		_text(into, width, GEN1_STAT_NAMES[index], GEN1_STATS_NAMES_AT + step)
+		_text(
+			into, width,
+			str(int(stats.get(GEN1_STAT_KEYS[index], 0))).lpad(STAT_DIGITS),
+			GEN1_STATS_NUMBERS_AT + step
+		)
+
+
+## `StatusScreen2`: the moves and PP, and the experience block.
+func _draw_gen1_moves(page: Dictionary, into: PackedByteArray) -> void:
+	var width: int = COLUMNS * TILE
+	_tile(into, width, Gen2BattleTiles.GEN1_LINE_VERTICAL, GEN1_DIVIDER_AT)
+	for index: int in GEN1_EXP_LABELS.size():
+		_text(
+			into, width, GEN1_EXP_LABELS[index],
+			GEN1_EXP_LABELS_AT + Vector2i(0, index * GEN1_ROW_STEP)
+		)
+	_text(into, width, str(int(page.get("exp", 0))).lpad(GEN1_EXP_DIGITS), GEN1_EXP_AT)
+	_text(
+		into, width, str(int(page.get("exp_to_next", 0))).lpad(GEN1_EXP_DIGITS),
+		GEN1_EXP_TO_NEXT_AT
+	)
+	_tile(into, width, Gen2BattleTiles.GEN1_TO, GEN1_TO_AT)
+	draw_level(into, width, GEN1_NEXT_LEVEL_AT, int(page.get("next_level", 0)))
+	font.draw_box(
+		0, into, width, GEN1_MOVE_BOX_AT.x * TILE, GEN1_MOVE_BOX_AT.y * TILE,
+		GEN1_MOVE_BOX_SIZE.x, GEN1_MOVE_BOX_SIZE.y
+	)
+	var moves: Array = page.get("moves", [])
+	for slot: int in MAX_MOVES:
+		var step := Vector2i(0, slot * GEN1_ROW_STEP)
+		if slot >= moves.size():
+			## `StatusScreen_PrintPP`'s second run fills the rest with dashes.
+			_text(into, width, GEN1_PP_DASH, GEN1_PP_LABEL_AT + step)
+			continue
+		var move: Dictionary = moves[slot]
+		_text(into, width, String(move.get("name", "")), GEN1_MOVES_AT + step)
+		for column: int in 2:
+			_tile(
+				into, width, Gen1Layout.STATS_P_CODE,
+				GEN1_PP_LABEL_AT + step + Vector2i(column, 0)
+			)
+		_text(into, width, "%s/%s" % [
+			str(int(move.get("pp", 0))).lpad(PP_DIGITS),
+			str(int(move.get("max_pp", 0))).lpad(PP_DIGITS),
+		], GEN1_PP_AT + step)
+
+
+## `DrawLineBox`: `│` down, the `┘` that closes it, `─` back, a half arrow.
+func _gen1_rule(into: PackedByteArray, width: int, rule: Array) -> void:
+	var at: Vector2i = rule[0]
+	var rows: int = int(rule[1])
+	var columns: int = int(rule[2])
+	for row: int in rows:
+		_tile(into, width, Gen2BattleTiles.GEN1_LINE_VERTICAL, at + Vector2i(0, row))
+	var corner: Vector2i = at + Vector2i(0, rows)
+	_tile(into, width, Gen2BattleTiles.GEN1_LINE_CORNER, corner)
+	for column: int in columns:
+		_tile(
+			into, width, Gen2BattleTiles.GEN1_LINE_HORIZONTAL,
+			corner - Vector2i(column + 1, 0)
+		)
+	_tile(
+		into, width, Gen2BattleTiles.GEN1_LINE_ARROW, corner - Vector2i(columns + 1, 0)
+	)
+
+
+func _tile(into: PackedByteArray, width: int, tile: int, at: Vector2i) -> void:
+	tiles.draw(tile, into, width, at.x * TILE, at.y * TILE)
+
+
+## The page in two colours, with the HP bar blended in `GetHealthBarColor`'s
+## answer the way the party menu blends its six.
+func _render_gen1(page: Dictionary, indices: PackedByteArray, data: GameData) -> Image:
+	var width: int = COLUMNS * TILE
+	var height: int = ROWS * TILE
+	var mono: PackedColorArray = PokePalette.pic_palette(
+		PackedColorArray([Color.WHITE, Color.BLACK])
+	)
+	var pixels: PackedInt32Array = Gen2PicImage.canvas_from_indices(
+		indices, width, height, mono
+	)
+	if data != null and int(page.get("page", PINK_PAGE)) == PINK_PAGE:
+		_blend_gen1_bar(pixels, page, data)
+	return Gen2PicImage.canvas_image(pixels, width, height)
+
+
+func _blend_gen1_bar(
+	pixels: PackedInt32Array, page: Dictionary, data: GameData
+) -> void:
+	var width: int = COLUMNS * TILE
+	var buffer := PackedByteArray()
+	buffer.resize(width * TILE)
+	var hp: int = int(page.get("hp", 0))
+	var max_hp: int = int(page.get("max_hp", 0))
+	hud.draw_hp_bar(buffer, width, Vector2i(GEN1_HP_BAR_AT.x, 0), hp, max_hp)
+	var lit: int = Gen2BattleHud.bar_pixels(
+		hp, max_hp, Gen2BattleHud.HP_BAR_TILES * TILE
+	)
+	var table: PackedInt32Array = Gen2PicImage.lookup(
+		data.bar_palette(GameData.hp_bar_palette_name(lit)), true
+	)
+	var left: int = (GEN1_HP_BAR_AT.x + 2) * TILE
+	for y: int in TILE:
+		var from: int = y * width
+		var to: int = (GEN1_HP_BAR_AT.y * TILE + y) * width
+		for x: int in range(left, left + Gen2BattleHud.HP_BAR_TILES * TILE):
+			var value: int = buffer[from + x]
+			if value != 0:
+				pixels[to + x] = table[value]

--- a/game/render/world_service_page.gd
+++ b/game/render/world_service_page.gd
@@ -9,13 +9,32 @@ const MESSAGE_BOX := Rect2i(0, 12, 20, 6)
 
 var font: Gen2Font = null
 var menu: Gen2MenuPage = null
+## `PokeballTileGraphics`' first tile, which `BillsPCMenu` copies to `$78` and
+## `DisplayChangeBoxMenu` puts beside a box that is not empty. Null on a cache
+## with no such sheet, which is every Generation 2 one.
+var ball: Image = null
 
 
 static func from_data(data: GameData) -> Gen2WorldServicePage:
 	var out := Gen2WorldServicePage.new()
 	out.font = Gen2Font.from_data(data)
 	out.menu = Gen2MenuPage.from_data(data)
+	out.ball = _ball_tile(data)
 	return out if out.font != null and out.menu != null else null
+
+
+static func _ball_tile(data: GameData) -> Image:
+	var sheet: Dictionary = data.tile_sheet("battle_balls")
+	var indices: PackedByteArray = data.tile_indices("battle_balls")
+	if sheet.is_empty() or indices.is_empty():
+		return null
+	var strip: Image = Gen2PicImage.from_indices(
+		indices, int(sheet.get("width", 0)), PokeTiles.TILE_HEIGHT,
+		PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
+	)
+	return null if strip == null else strip.get_region(
+		Rect2i(0, 0, PokeTiles.TILE_WIDTH, PokeTiles.TILE_HEIGHT)
+	)
 
 
 ## `MenuTextbox` over the map: every box here carries `MENU_BACKUP_TILES`, so the
@@ -24,16 +43,17 @@ static func from_data(data: GameData) -> Gen2WorldServicePage:
 ## [param note] is the box beside the list, `{rect, lines}` with each line
 ## `{text, at}` from its own corner. [param message_box] is
 ## [constant MESSAGE_BOX] everywhere but `_ChangeBox`'s `hlcoord 0, 14`.
+## [param marks] is a screen cell per pokeball tile drawn over the menu.
 func render(title: String, prompt: String, rows: Array, cursor: int,
 		message: String = "", box: Gen2MenuBox = null,
-		note: Dictionary = {}, message_box: Rect2i = MESSAGE_BOX) -> Image:
+		note: Dictionary = {}, message_box: Rect2i = MESSAGE_BOX,
+		marks: Array = []) -> Image:
 	var image := Image.create_empty(
 		Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 	)
-	if not rows.is_empty() and box != null:
-		_blit(image, menu.render(box, rows, cursor), box.border_position())
-	if not note.is_empty():
-		_draw_note(image, note)
+	var over: bool = box != null and box.over_textbox
+	if not over:
+		_draw_menu(image, rows, cursor, box, marks)
 	var words: String = message if not message.is_empty() else prompt
 	if words.is_empty():
 		words = title
@@ -54,8 +74,23 @@ func render(title: String, prompt: String, rows: Array, cursor: int,
 		image.blit_rect(
 			part, Rect2i(Vector2i.ZERO, part.get_size()), message_box.position * TILE
 		)
+	## Behind the speech box on the cartridge is above it here: `BillsPCMenu`
+	## draws `WhatText` and then puts its BOX No. panel over the box's own right
+	## half, and no other note here touches one.
+	if over:
+		_draw_menu(image, rows, cursor, box, marks)
+	if not note.is_empty():
+		_draw_note(image, note)
 	return image
 
+
+func _draw_menu(
+	image: Image, rows: Array, cursor: int, box: Gen2MenuBox, marks: Array
+) -> void:
+	if not rows.is_empty() and box != null:
+		_blit(image, menu.render(box, rows, cursor), box.border_position())
+	for at: Vector2i in marks:
+		_blit(image, ball, at)
 
 
 func _draw_note(image: Image, note: Dictionary) -> void:
@@ -75,6 +110,7 @@ func _draw_note(image: Image, note: Dictionary) -> void:
 		PokePalette.pic_palette(PackedColorArray([Color.WHITE, Color.BLACK]))
 	)
 	image.blit_rect(part, Rect2i(Vector2i.ZERO, part.get_size()), rect.position * TILE)
+
 
 func _blit(into: Image, part: Image, at: Vector2i) -> void:
 	if part != null:

--- a/game/save/box_screen.gd
+++ b/game/save/box_screen.gd
@@ -236,7 +236,7 @@ func deposit_selected_party() -> bool:
 		_refresh()
 		return false
 	var mon: Gen2SaveMon = _save.party[_selected_party_index]
-	var mon_name: String = _display_name(mon)
+	var mon_name: String = Gen2SaveMon.display_name(mon, _data)
 	var result: Dictionary = Gen2SaveStorage.deposit_party_to_box(
 		_save, _data, _selected_party_index, _box_index, -1, _persist
 	)
@@ -258,7 +258,7 @@ func withdraw_selected_box() -> bool:
 		return false
 	var box: Gen2SaveBox = _save.boxes[_box_index] if _box_index < _save.boxes.size() else null
 	var mon: Gen2SaveMon = box.slots[_selected_box_slot] as Gen2SaveMon if box != null else null
-	var mon_name: String = _display_name(mon)
+	var mon_name: String = Gen2SaveMon.display_name(mon, _data)
 	var result: Dictionary = Gen2SaveStorage.withdraw_box_to_party(
 		_save, _data, _box_index, _selected_box_slot, _persist
 	)
@@ -278,7 +278,7 @@ func release_selected() -> bool:
 	if _save == null:
 		return false
 	var mon: Gen2SaveMon = _selected_mon()
-	var mon_name: String = _display_name(mon)
+	var mon_name: String = Gen2SaveMon.display_name(mon, _data)
 	var result: Dictionary = Gen2SaveStorage.release_party_member(
 		_save, _data, _selected_party_index, _persist
 	) if _loaded == LOADED_PARTY else Gen2SaveStorage.release_box_slot(
@@ -540,7 +540,8 @@ func rows() -> Array:
 	for entry: Array in _entries():
 		var mon: Gen2SaveMon = entry[1]
 		out.append({
-			"name": _display_name(mon), "index": int(entry[0]), "cancel": false,
+			"name": Gen2SaveMon.display_name(mon, _data),
+			"index": int(entry[0]), "cancel": false,
 		})
 	out.append({"name": Gen2PCBoxPage.CANCEL, "index": -1, "cancel": true})
 	return out
@@ -845,17 +846,9 @@ func _mon_snapshot(box: int, slot: int, mon: Gen2SaveMon) -> Dictionary:
 		return {"empty": true, "box": box, "slot": slot}
 	return {
 		"empty": false, "box": box, "slot": slot,
-		"name": _display_name(mon), "species": mon.species, "level": mon.level,
+		"name": Gen2SaveMon.display_name(mon, _data),
+		"species": mon.species, "level": mon.level,
 	}
-
-
-func _display_name(mon: Gen2SaveMon) -> String:
-	if mon == null:
-		return ""
-	if not mon.nickname.is_empty():
-		return mon.nickname
-	return String(_data.species(mon.species).get("name", "UNKNOWN")) if _data != null \
-		else "UNKNOWN"
 
 
 func _press_up() -> void:

--- a/game/save/mon_stats_screen.gd
+++ b/game/save/mon_stats_screen.gd
@@ -108,6 +108,17 @@ func cursor() -> int:
 
 ## `StatsScreen_JoypadAction`. Returns whether the button was used.
 func handle_button(button: int) -> bool:
+	## `StatusScreen` and `StatusScreen2` each end in
+	## `WaitForTextScrollButtonPress`, which reads A and B and nothing else: one
+	## press turns to the second page and the next returns.
+	if _gen1():
+		if button != PokeButton.A and button != PokeButton.B:
+			return false
+		if _page == _last_page():
+			closed.emit()
+			return true
+		_turn_page(1)
+		return true
 	## `EggStatsJoypad` masks the joypad down to `PAD_DOWN | PAD_UP | PAD_A |
 	## PAD_B` before it reaches the same action, and answers A with the exit
 	## rather than with a page: an egg has no pages to turn.
@@ -142,16 +153,25 @@ func handle_button(button: int) -> bool:
 ## `.d_right` and `.d_left`: the pages wrap in both directions, and a page change
 ## reloads the lower half without reloading the Pokémon.
 func _turn_page(delta: int) -> void:
-	_page = wrapi(
-		_page - PINK_PAGE + delta, 0, Gen2StatsScreenPage.page_count()
-	) + PINK_PAGE
+	_page = wrapi(_page - PINK_PAGE + delta, 0, _page_count()) + PINK_PAGE
+
+
+func _gen1() -> bool:
+	return _data != null and _data.generation == RomRegistry.GEN1
+
+
+## `StatusScreen` and `StatusScreen2` are the whole of Generation 1's screen,
+## and no mod page is registered against them.
+func _page_count() -> int:
+	return Gen2StatsScreenPage.GEN1_PAGES if _gen1() \
+		else Gen2StatsScreenPage.page_count()
 
 
 ## `.d_right`'s wrap point, which is the blue page until a mod registers one past
 ## it (see [method Gen2ModHost.register_stats_page]). A is the exit on this page
 ## and a page turn everywhere else, so both follow the count rather than BLUE.
 func _last_page() -> int:
-	return PINK_PAGE + Gen2StatsScreenPage.page_count() - 1
+	return PINK_PAGE + _page_count() - 1
 
 
 ## `.d_up` and `.d_down`: neither wraps, and the row the party menu is left on

--- a/game/save/party_screen.gd
+++ b/game/save/party_screen.gd
@@ -449,14 +449,14 @@ func _confirm_submenu(entry: Dictionary) -> void:
 				"kind": &"field_move",
 				"move": move,
 				"slot": _member_cursor,
-				"name": _display_name(_save.party[_member_cursor]),
+				"name": Gen2SaveMon.display_name(_save.party[_member_cursor], _data),
 			})
 		&"mon_item":
 			action_chosen.emit({
 				"kind": &"mon_item",
 				"option": StringName(entry.get("option", &"")),
 				"slot": _member_cursor,
-				"name": _display_name(_save.party[_member_cursor]),
+				"name": Gen2SaveMon.display_name(_save.party[_member_cursor], _data),
 			})
 		&"mon_mail":
 			## `.done` answers 3, which `.choosemenu` takes back to the list.
@@ -467,7 +467,7 @@ func _confirm_submenu(entry: Dictionary) -> void:
 				"kind": &"mon_mail",
 				"option": StringName(entry.get("option", &"")),
 				"slot": _member_cursor,
-				"name": _display_name(_save.party[_member_cursor]),
+				"name": Gen2SaveMon.display_name(_save.party[_member_cursor], _data),
 			})
 		&"mod_party_action":
 			## The handler is the mod's, and the slot is the only thing it is
@@ -478,7 +478,7 @@ func _confirm_submenu(entry: Dictionary) -> void:
 				"kind": &"mod_party_action",
 				"mod": StringName(entry.get("mod", &"")),
 				"slot": _member_cursor,
-				"name": _display_name(_save.party[_member_cursor]),
+				"name": Gen2SaveMon.display_name(_save.party[_member_cursor], _data),
 			})
 		&"option":
 			_confirm_option(StringName(entry.get("option", &"")))
@@ -618,8 +618,8 @@ func _choose_heal_target() -> void:
 		"move": _heal_move,
 		"slot": _heal_user,
 		"target_slot": _member_cursor,
-		"name": _display_name(_save.party[_heal_user]),
-		"target_name": _display_name(target),
+		"name": Gen2SaveMon.display_name(_save.party[_heal_user], _data),
+		"target_name": Gen2SaveMon.display_name(target, _data),
 	}
 	_heal_user = -1
 	_heal_move = 0
@@ -834,7 +834,7 @@ func _rows() -> Array:
 			"index": index,
 			"species": mon.species,
 			"item": mon.item,
-			"name": _display_name(mon),
+			"name": Gen2SaveMon.display_name(mon, _data),
 			"level": mon.level,
 			"hp": mon.hp,
 			"max_hp": 0 if mon.is_egg else _max_hp(mon),
@@ -915,10 +915,7 @@ func _render_stats() -> void:
 		_stats_page = Gen2StatsScreenPage.from_data(_data)
 	if _stats_page == null:
 		return
-	var snapshot: Dictionary = _stats.snapshot()
-	var image: Image = _stats_page.render(snapshot, _data)
-	_blend_stats_pic(image, snapshot)
-	Gen2PicImage.show(_view, image)
+	Gen2PicImage.show(_view, Gen2StatsScreenPage.compose(_stats_page, _data, _stats))
 
 
 ## `MoveScreenLoop`'s own screen, which steps its one mon icon per frame the way
@@ -929,20 +926,6 @@ func _render_moves() -> void:
 	if _moves_page == null:
 		return
 	Gen2PicImage.show(_view, _moves_page.render(_moves.snapshot(), _data))
-
-
-## `PrepMonFrontpic`'s own seven-tile cell on `hlcoord 0, 0`, which mirrors the
-## picture and bottom-aligns a smaller one against the far column.
-func _blend_stats_pic(image: Image, snapshot: Dictionary) -> void:
-	var species: int = int(snapshot.get("species", 0))
-	if species <= 0:
-		return
-	var art: Image = Gen2StatsScreenPage.pic_image(_data, snapshot, _stats)
-	if art == null:
-		return
-	image.blit_rect(art, Rect2i(Vector2i.ZERO, art.get_size()), Vector2i(
-		Gen2StatsScreenPage.pic_position()
-	) + Gen2StatsScreenPage.pic_origin(art.get_size(), snapshot))
 
 
 ## `.GetTopCoord` for the mon's own submenu, and the fixed box whichever of
@@ -1130,7 +1113,7 @@ func _member_card(index: int) -> Control:
 	var summary: VBoxContainer = Gen2LauncherUI.column(Gen2LauncherUI.GAP_XS)
 	summary.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	content.add_child(summary)
-	summary.add_child(Gen2LauncherUI.title(_palette, _display_name(mon)))
+	summary.add_child(Gen2LauncherUI.title(_palette, Gen2SaveMon.display_name(mon, _data)))
 	## Level and HP wrap onto their own line on a narrow page rather than
 	## widening the card past the window.
 	var facts: HFlowContainer = Gen2LauncherUI.actions(Gen2LauncherUI.GAP_MD)
@@ -1148,7 +1131,7 @@ func _member_snapshot(index: int, mon: Gen2SaveMon) -> Dictionary:
 	return {
 		"empty": false,
 		"index": index,
-		"name": _display_name(mon),
+		"name": Gen2SaveMon.display_name(mon, _data),
 		"species": mon.species,
 		"level": mon.level,
 		"hp": mon.hp,
@@ -1160,10 +1143,6 @@ func _member_snapshot(index: int, mon: Gen2SaveMon) -> Dictionary:
 func _max_hp(mon: Gen2SaveMon) -> int:
 	var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
 	return battle_mon.max_hp() if battle_mon != null else 0
-
-
-func _display_name(mon: Gen2SaveMon) -> String:
-	return mon.nickname if not mon.nickname.is_empty() else _species_name(mon.species)
 
 
 func _species_name(species: int) -> String:

--- a/game/save/save_mon.gd
+++ b/game/save/save_mon.gd
@@ -11,6 +11,8 @@ extends RefCounted
 const MAX_MOVES: int = Gen2BattleMon.MAX_MOVES
 const MAX_EXP: int = Gen2Experience.MAX_EXP
 const STAT_EXP_KEYS: Array = ["hp", "attack", "defense", "speed", "special"]
+## What a member with neither a nickname nor a species row is called.
+const UNNAMED: String = "UNKNOWN"
 
 var species: int = 0
 var item: int = 0
@@ -42,6 +44,17 @@ var is_egg: bool = false
 ## `sPartyMail`'s own entry for this member, or null when the held item is not
 ## mail. Kept on the record rather than on the party slot; see [Gen2SaveMail].
 var mail: Gen2SaveMail = null
+
+
+## `GetNickname`: the species name for a member that was never given one.
+static func display_name(mon: Gen2SaveMon, data: GameData) -> String:
+	if mon == null:
+		return ""
+	if not mon.nickname.is_empty():
+		return mon.nickname
+	if data == null:
+		return UNNAMED
+	return String(data.species(mon.species).get("name", UNNAMED))
 
 
 func to_dict() -> Dictionary:

--- a/game/save/save_screen.gd
+++ b/game/save/save_screen.gd
@@ -645,7 +645,7 @@ func _add_party_summary(body: VBoxContainer, save: Gen2SaveData) -> void:
 		var mon: Gen2SaveMon = save.party[index]
 		var battle_mon: Gen2BattleMon = Gen2SaveBattleAdapter.to_battle_mon(_data, mon)
 		column.add_child(Gen2LauncherUI.body(
-			_palette, "%d. %s" % [index + 1, _display_name(mon)]
+			_palette, "%d. %s" % [index + 1, Gen2SaveMon.display_name(mon, _data)]
 		))
 		column.add_child(Gen2LauncherUI.muted(_palette, "Lv.%d   HP %d/%d   %s" % [
 			mon.level, mon.hp, battle_mon.max_hp(), _status_name(mon.status)
@@ -892,18 +892,6 @@ func _slot_state_color(row: Dictionary) -> Color:
 	if not row["valid"] or bool(row.get("run_over", false)):
 		return _palette.error
 	return _palette.success
-
-
-func _display_name(mon: Gen2SaveMon) -> String:
-	if mon.nickname.is_empty():
-		return _species_name(mon.species)
-	return mon.nickname
-
-
-func _species_name(species: int) -> String:
-	if _data == null:
-		return "UNKNOWN"
-	return String(_data.species(species).get("name", "UNKNOWN"))
 
 
 func _status_name(status: int) -> String:

--- a/game/world/menu_box.gd
+++ b/game/world/menu_box.gd
@@ -48,6 +48,10 @@ var scroll: int = 0
 ## The frame a caller drew before the menu, `ScrollingMenu` drawing none. Empty
 ## is every other menu, whose frame is its own corners.
 var frame: Rect2i = Rect2i()
+## Whether the routine drew this box after its own `PrintText`, so it stands
+## over the speech box rather than under it. `DisplayDepositWithdrawMenu` is the
+## one that overlaps; every other menu here clears the bottom six rows.
+var over_textbox: bool = false
 ## `BattleTowerRoomMenu_UpdatePickLevelMenu`, the one menu in the game that
 ## shows a single row between two arrows instead of a list under a cursor. Both
 ## are the `▼` of `String_119d07`, placed at `hlcoord 13, 8` and `hlcoord 13,

--- a/game/world/name_rater_screen.gd
+++ b/game/world/name_rater_screen.gd
@@ -242,7 +242,7 @@ func _on_selected(party_index: int) -> void:
 		return
 	_party_index = party_index
 	var mon: Gen2SaveMon = _save.party[party_index] as Gen2SaveMon
-	_nickname = _display_name(mon)
+	_nickname = Gen2SaveMon.display_name(mon, _data)
 	var ending: StringName = Gen2NameRater.ending_for(mon, _player_name, _player_id)
 	if ending != &"":
 		_end(ending)
@@ -307,14 +307,6 @@ func _end(ending: StringName) -> void:
 		_party_index, _nickname, _filled(String(ending), _nickname)
 	)
 	closed.emit()
-
-
-func _display_name(mon: Gen2SaveMon) -> String:
-	if mon == null:
-		return ""
-	if not mon.nickname.is_empty():
-		return mon.nickname
-	return String(_data.species(mon.species).get("name", ""))
 
 
 func _draw_yes_no() -> void:

--- a/game/world/prof_oaks_pc.gd
+++ b/game/world/prof_oaks_pc.gd
@@ -49,19 +49,32 @@ static func rate(data: GameData, state: Gen2WorldState) -> Dictionary:
 
 ## `FindOakRating`: the first row whose threshold the caught count does not
 ## exceed. The table's last row is every species, so the walk always lands.
+## Generation 1's `DisplayDexRating` compares the other way, `cp b / jr c`
+## against `jr nc`, so its rows match under the threshold rather than at it.
 static func rating_for(data: GameData, caught: int) -> Dictionary:
+	var under: bool = data != null and data.generation == RomRegistry.GEN1
 	for row: Variant in data.oak_ratings():
-		if caught <= int((row as Dictionary).get("threshold", -1)):
+		var threshold: int = int((row as Dictionary).get("threshold", -1))
+		if caught < threshold if under else caught <= threshold:
 			return row
 	return {}
 
 
 ## `_OakPCText3` with `.UpdateRatingBuffers`' two numbers in the `text_ram` slots
-## it left for them.
+## it left for them. Generation 1's `_DexCompletionText` reads the same two
+## counts with `text_decimal` instead, so its slots are number markers and
+## `PrintNumber` right-aligns them in [constant COUNT_DIGITS] cells where
+## `PRINTNUM_LEFTALIGN` does not.
 static func counts_text(data: GameData, seen: int, caught: int) -> String:
 	var text: String = data.oak_pc_text("counts")
 	for value: int in [seen, caught]:
-		text = Gen2TextStream.fill_marker(
-			text, Gen2TextStream.RAM_MARKER, String.num_int64(value)
-		)
+		var digits: String = String.num_int64(value)
+		var number: int = text.find(Gen2TextStream.NUMBER_MARKER)
+		var ram: int = text.find(Gen2TextStream.RAM_MARKER)
+		if number >= 0 and (ram < 0 or number < ram):
+			text = Gen2TextStream.fill_marker(
+				text, Gen2TextStream.NUMBER_MARKER, digits.lpad(COUNT_DIGITS)
+			)
+			continue
+		text = Gen2TextStream.fill_marker(text, Gen2TextStream.RAM_MARKER, digits)
 	return text

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3665,6 +3665,15 @@ const GEN1_PICK_UP_RUN: String = "pick_up_item"
 ## `InGameTradeTextPointers`' fifteen and the two boxes the swap prints, which
 ## both generations' trades read under one run name.
 const GEN1_TRADE_RUN: String = "npc_trade"
+## `TextScript_PokemonCenterPC`, `TextScript_ItemStoragePC` and
+## `TextScript_BillsPC`, each a machine, the run its own boxes were imported
+## under and the boot line it opens with. `BIT_USING_GENERIC_PC` is clear on all
+## three, which is what makes every one of them print that line.
+const GEN1_PC_MACHINES: Dictionary = {
+	Gen1Layout.TEXT_SCRIPT_POKECENTER_PC: [&"gen1_pokemon_center", "pc", "turned_on"],
+	Gen1Layout.TEXT_SCRIPT_PLAYERS_PC: [&"gen1_players_pc", "players_pc", "turned_on"],
+	Gen1Layout.TEXT_SCRIPT_BILLS_PC: [&"gen1_bills_pc", "bills_pc", "switch_on"],
+}
 ## `EndTrainerBattle`'s `cp LOST_BATTLE`, which a catch also passes.
 const GEN1_TRAINER_BEATEN: Array[StringName] = [
 	Gen2WorldBattleAdapter.OUTCOME_WON, Gen2WorldBattleAdapter.OUTCOME_CAUGHT,
@@ -3793,14 +3802,16 @@ func _gen1_sign_or_sprite() -> Array:
 	if _gen1_steps.is_empty():
 		_gen1_steps = _gen1_script_steps(row, event)
 	if _gen1_steps.is_empty():
-		var text: String = _gen1_filled_text(String(row.get("text", "")))
+		var text: String = gen1_filled_text(String(row.get("text", "")))
 		if text.is_empty():
 			return []
 		_gen1_steps = [{"type": &"text", "text": text}]
 	return _gen1_result()
 
 
-func _gen1_filled_text(text: String) -> String:
+## The print-time names still standing in an imported Generation 1 box, which
+## is every box the world or a screen hosting one of its facilities prints.
+func gen1_filled_text(text: String) -> String:
 	return Gen2TextStream.fill_names(text, {
 		"player": _player_name if not _player_name.is_empty() \
 			else Gen2WorldScriptRunner.UNNAMED,
@@ -3962,7 +3973,7 @@ func _gen1_node_map_text(node: Dictionary, steps: Array, run: Dictionary) -> boo
 	var nodes: Variant = row.get("script", [])
 	if nodes is Array and not (nodes as Array).is_empty():
 		return _gen1_resolve_script(nodes as Array, steps, run)
-	var text: String = _gen1_filled_text(String(row.get("text", "")))
+	var text: String = gen1_filled_text(String(row.get("text", "")))
 	if text.is_empty():
 		return false
 	steps.append({"type": &"text", "text": text})
@@ -4085,7 +4096,7 @@ func _gen1_pick_up_item(_node: Dictionary, steps: Array, run: Dictionary) -> boo
 	steps.append({"type": &"toggle", "index": toggle, "hidden": true})
 	var box: Dictionary = _gen1_facility_box(GEN1_PICK_UP_RUN, "found")
 	box["text"] = Gen2TextStream.fill_all_markers(
-		_gen1_filled_text(String(box["text"])), Gen2TextStream.RAM_MARKER,
+		String(box["text"]), Gen2TextStream.RAM_MARKER,
 		data.item_name(item) if data != null else ""
 	)
 	box["press"] = false
@@ -4173,7 +4184,7 @@ func _gen1_trade_run_box(record: Dictionary, name: String) -> Dictionary:
 func _gen1_trade_text(record: Dictionary, name: String) -> String:
 	if data == null or name.is_empty():
 		return ""
-	var text: String = _gen1_filled_text(data.special_text(GEN1_TRADE_RUN, name))
+	var text: String = gen1_filled_text(data.special_text(GEN1_TRADE_RUN, name))
 	for row: Array in [
 		[Gen1Layout.TRADE_GIVE_NAME, int(record.get("requested_species", 0))],
 		[Gen1Layout.TRADE_RECEIVE_NAME, int(record.get("offered_species", 0))],
@@ -4227,7 +4238,7 @@ func _gen1_run_copy(run: Dictionary) -> Dictionary:
 
 
 func _gen1_script_box(node: Dictionary, named: String) -> Dictionary:
-	var text: String = _gen1_filled_text(String(node.get("text", "")))
+	var text: String = gen1_filled_text(String(node.get("text", "")))
 	if not named.is_empty():
 		text = Gen2TextStream.fill_all_markers(
 			text, Gen2TextStream.RAM_MARKER, named
@@ -4241,7 +4252,10 @@ func _gen1_script_box(node: Dictionary, named: String) -> Dictionary:
 ## `DisplayTextID`'s own dispatch, which reads the first byte of the text a
 ## pointer stands at: a `TX_SCRIPT_*` id runs a routine and prints nothing.
 func _gen1_facility_steps(row: Dictionary, text_id: int = 0) -> Array:
-	match int(row.get("command", 0)):
+	var command: int = int(row.get("command", 0))
+	if GEN1_PC_MACHINES.has(command):
+		return _gen1_pc_steps(GEN1_PC_MACHINES[command] as Array)
+	match command:
 		Gen1Layout.TEXT_SCRIPT_MART:
 			return _gen1_mart_steps(row)
 		Gen1Layout.TEXT_SCRIPT_POKECENTER_NURSE:
@@ -4253,6 +4267,15 @@ func _gen1_facility_steps(row: Dictionary, text_id: int = 0) -> Array:
 		Gen1Layout.TEXT_SCRIPT_PRIZE_VENDOR:
 			return _gen1_prize_steps(text_id)
 	return []
+
+
+func _gen1_pc_steps(machine: Array) -> Array:
+	return [
+		_gen1_facility_box(String(machine[1]), String(machine[2])),
+		{"type": &"request", "values": {
+			"kind": &"pc_requested", "values": {"mode": StringName(machine[0])},
+		}},
+	]
 
 
 ## `GetPrizeMenuId` subtracts `TEXT_GAMECORNERPRIZEROOM_PRIZE_VENDOR_1` from the
@@ -4397,7 +4420,9 @@ func _gen1_pokecenter_text(name: String) -> String:
 func _gen1_facility_box(run: String, name: String) -> Dictionary:
 	return {
 		"type": &"text",
-		"text": data.special_text(run, name) if data != null else "",
+		"text": gen1_filled_text(
+			data.special_text(run, name)
+		) if data != null else "",
 	}
 
 

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -20,6 +20,15 @@ const UNATTENDED_REQUESTS: Array[StringName] = [
 	&"contest_mon_requested", &"dratini_moveset_requested",
 ]
 
+## Which machine a `pc_requested` names. `PokemonCenterPC` and
+## `_PlayersHousePC` are Crystal's two; Generation 1's three are the
+## `TX_SCRIPT_*` ids `ActivatePC`, `PlayerPC` and `BillsPC_` stand behind, which
+## the top menu can reach each other from.
+const PC_MODES: Array[StringName] = [
+	&"pokemon_center", &"players_house",
+	&"gen1_pokemon_center", &"gen1_players_pc", &"gen1_bills_pc",
+]
+
 
 static func complete_runtime_request(
 	world: Gen2WorldAPI,
@@ -279,7 +288,7 @@ static func _resolve_data_request(world: Gen2WorldAPI, request: Dictionary) -> D
 			## the world already holds, so the only thing to resolve is which of
 			## the two the script asked for.
 			var pc_mode: StringName = StringName(values.get("mode", &"pokemon_center"))
-			if pc_mode not in [&"pokemon_center", &"players_house"]:
+			if pc_mode not in PC_MODES:
 				return {"ok": false, "reason": &"unsupported_pc_mode"}
 			return {"ok": true, "data": {"pc": {"mode": pc_mode}}}
 		&"audio_requested":

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -415,3 +415,128 @@ static func _commit(
 	var out: Dictionary = answer.duplicate()
 	out["ok"] = true
 	return out
+
+
+## `PCMainMenu`'s rows, in the order `DisplayPCMainMenu` prints them.
+const GEN1_PC_BILLS: int = 0
+const GEN1_PC_PLAYERS: int = 1
+const GEN1_PC_OAKS: int = 2
+const GEN1_PC_LEAGUE: int = 3
+const GEN1_PC_LOG_OFF: int = 4
+## `PlayersPCMenuEntries` and `BillsPCMenuText`, inline the way
+## [constant BILLS_PC_ROWS] is.
+const GEN1_PLAYERS_PC_WITHDRAW: int = 0
+const GEN1_PLAYERS_PC_DEPOSIT: int = 1
+const GEN1_PLAYERS_PC_TOSS: int = 2
+const GEN1_PLAYERS_PC_ROWS: Array[String] = [
+	"WITHDRAW ITEM", "DEPOSIT ITEM", "TOSS ITEM", "LOG OFF",
+]
+const GEN1_BILLS_PC_WITHDRAW: int = 0
+const GEN1_BILLS_PC_DEPOSIT: int = 1
+const GEN1_BILLS_PC_RELEASE: int = 2
+const GEN1_BILLS_PC_CHANGE_BOX: int = 3
+const GEN1_BILLS_PC_SEE_YA: int = 4
+const GEN1_BILLS_PC_ROWS: Array[String] = [
+	"WITHDRAW <PKMN>", "DEPOSIT <PKMN>", "RELEASE <PKMN>", "CHANGE BOX", "SEE YA!",
+]
+## `DisplayDepositWithdrawMenu`'s three, its first row named by the parent.
+const GEN1_MON_ACTION_MOVE: int = 0
+const GEN1_MON_ACTION_STATS: int = 1
+const GEN1_MON_ACTION_CANCEL: int = 2
+## `BoxNames`, five cells either way: "BOX 9" has a space and "BOX10" not.
+const GEN1_BOX_LABEL: String = "BOX%s"
+const GEN1_BOX_DIGITS: int = 2
+
+
+## `DisplayPCMainMenu`'s list, `wNumHoFTeams` being the induction flag here
+## the way [method top_menu_list] reads it.
+static func gen1_top_menu(state: Gen2WorldState, player_name: String) -> Array:
+	var pokedex: bool = state != null \
+		and state.is_engine_flag_active(Gen2WorldState.ENGINE_POKEDEX)
+	var league: bool = state != null and state.hall_of_fame()
+	var rows: Array[int] = [GEN1_PC_BILLS, GEN1_PC_PLAYERS]
+	if pokedex:
+		rows.append(GEN1_PC_OAKS)
+		if league:
+			rows.append(GEN1_PC_LEAGUE)
+	rows.append(GEN1_PC_LOG_OFF)
+	var met_bill: bool = state != null \
+		and state.is_event_flag_active(Gen1Layout.EVENT_MET_BILL)
+	var named: String = player_name if not player_name.is_empty() else "PLAYER"
+	var labels: Dictionary = {
+		GEN1_PC_BILLS: "BILL's PC" if met_bill else "SOMEONE's PC",
+		GEN1_PC_PLAYERS: "%s's PC" % named,
+		GEN1_PC_OAKS: "PROF.OAK's PC",
+		GEN1_PC_LEAGUE: "<PKMN>LEAGUE",
+		GEN1_PC_LOG_OFF: "LOG OFF",
+	}
+	var out: Array = []
+	for row: int in rows:
+		out.append({"row": row, "name": String(labels[row])})
+	return out
+
+
+static func gen1_players_pc_menu() -> Array:
+	return _gen1_rows(GEN1_PLAYERS_PC_ROWS)
+
+
+static func gen1_bills_pc_menu() -> Array:
+	return _gen1_rows(GEN1_BILLS_PC_ROWS)
+
+
+## `DisplayChangeBoxMenu`'s twelve, each carrying what
+## `GetMonCountsForAllBoxes` found in it.
+static func gen1_box_menu(save: Gen2SaveData) -> Array:
+	var out: Array = []
+	for box: int in Gen1Layout.BOX_COUNT:
+		out.append({
+			"row": box,
+			"name": GEN1_BOX_LABEL % String.num_int64(box + 1).lpad(GEN1_BOX_DIGITS),
+			"occupied": gen1_box_count(save, box) > 0,
+		})
+	return out
+
+
+static func _gen1_rows(names: Array[String]) -> Array:
+	var out: Array = []
+	for row: int in names.size():
+		out.append({"row": row, "name": names[row]})
+	return out
+
+
+## One box's members: `wBoxCount` counts a packed run, which the occupied
+## slots read in order are.
+static func gen1_box_entries(save: Gen2SaveData, box: int) -> Array:
+	var out: Array = []
+	if save == null or box < 0 or box >= save.boxes.size():
+		return out
+	var record: Gen2SaveBox = save.boxes[box]
+	if record == null:
+		return out
+	for slot: int in record.slots.size():
+		var mon: Gen2SaveMon = record.slots[slot]
+		if mon != null:
+			out.append({"slot": slot, "mon": mon})
+	return out
+
+
+static func gen1_box_count(save: Gen2SaveData, box: int) -> int:
+	return gen1_box_entries(save, box).size()
+
+
+## The three routines' own refusals, in the order each asks them.
+static func gen1_bills_pc_refusal(save: Gen2SaveData, row: int, box: int) -> StringName:
+	var party: int = save.party.size() if save != null else 0
+	var stored: int = gen1_box_count(save, box)
+	match row:
+		GEN1_BILLS_PC_DEPOSIT:
+			if party <= 1:
+				return &"cant_deposit_last"
+			return &"box_full" if stored >= Gen1Layout.BOX_CAPACITY else &""
+		GEN1_BILLS_PC_WITHDRAW:
+			if stored == 0:
+				return &"no_mon"
+			return &"cant_take_mon" if party >= Gen2SaveData.MAX_PARTY else &""
+		GEN1_BILLS_PC_RELEASE:
+			return &"no_mon" if stored == 0 else &""
+	return &""

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3836,6 +3836,9 @@ func preview_diploma(printing: bool = false, page: int = 1) -> void:
 ## reaches: every PC on a preview map is a script's, and the machine wants a
 ## party before it opens at all.
 func preview_bills_pc() -> void:
+	if _data != null and _data.generation == RomRegistry.GEN1:
+		_preview_pc(&"gen1_bills_pc")
+		return
 	if _world == null or _data == null or _service_host != null:
 		return
 	var save: Gen2SaveData = _embedded_party_save()
@@ -3863,11 +3866,27 @@ func preview_pokemon_center_pc() -> void:
 	## `_embedded_party_save` builds a development save when nothing is injected,
 	## so the seeded one has to be the save the host is then handed.
 	_injected_save = save
-	_preview_pc(&"pokemon_center")
+	_preview_pc(_pc_preview_mode(&"pokemon_center_pc", &"pokemon_center"))
 
 
 func preview_players_pc() -> void:
-	_preview_pc(&"players_house")
+	_preview_pc(_pc_preview_mode(&"players_pc", &"players_house"))
+
+
+## The same three drivers open Generation 1's own machines, whose cells no
+## preview map carries either: `TextScript_BillsPC`, `TextScript_ItemStoragePC`
+## and `TextScript_PokemonCenterPC`.
+const GEN1_PC_MODES: Dictionary = {
+	&"bills_pc": &"gen1_bills_pc",
+	&"players_pc": &"gen1_players_pc",
+	&"pokemon_center_pc": &"gen1_pokemon_center",
+}
+
+
+func _pc_preview_mode(driver: StringName, gen2: StringName) -> StringName:
+	if _data == null or _data.generation != RomRegistry.GEN1:
+		return gen2
+	return StringName(GEN1_PC_MODES[driver])
 
 
 func preview_mailbox() -> void:
@@ -7846,7 +7865,9 @@ func _prompted_field_move_name(slot: int) -> String:
 	if save == null or slot >= save.party.size():
 		return "#MON"
 	var member: Variant = save.party[slot]
-	return _mon_display_name(member as Gen2SaveMon) if member is Gen2SaveMon else "#MON"
+	if not member is Gen2SaveMon:
+		return "#MON"
+	return Gen2SaveMon.display_name(member as Gen2SaveMon, _data)
 
 
 ## `PlaceString`'s `<PLAYER>`, which is `wPlayerName`. With no save selected it
@@ -8097,7 +8118,7 @@ func _on_party_selection_made(party_index: int) -> void:
 				## `wPartySpecies` holds EGG for an egg slot, which is the byte
 				## `HaircutOrGrooming` compares against.
 				"species": Gen2WorldScriptRunner.SPECIES_EGG if mon.is_egg else mon.species,
-				"nickname": _mon_display_name(mon),
+				"nickname": Gen2SaveMon.display_name(mon, _data),
 				"species_name": String(_data.species(mon.species).get("name", "")),
 				## What the three deferred routines read off the row they were
 				## handed: MON_DVS, MON_OT_ID, the OT name, MON_HAPPINESS and
@@ -8680,7 +8701,7 @@ func _refresh_party_summary() -> void:
 				if move != 0:
 					mon_moves.append(move)
 			moves.append(mon_moves)
-			names.append(_mon_display_name(mon))
+			names.append(Gen2SaveMon.display_name(mon, _data))
 			eggs.append(mon.is_egg)
 			fainted.append(mon.hp <= 0)
 	## The three party facts the Bug Contest's own scripts ask about, which are
@@ -8784,14 +8805,6 @@ func _owned_species(save: Gen2SaveData) -> Array:
 		owned.append(int(key))
 	owned.sort()
 	return owned
-
-
-## GetPartyNickname's answer for one slot, following the party screen's own rule:
-## the stored nickname, or the species name when the save carries none.
-func _mon_display_name(mon: Gen2SaveMon) -> String:
-	if not mon.nickname.is_empty():
-		return mon.nickname
-	return String(_data.species(mon.species).get("name", "")) if _data != null else ""
 
 
 func _refresh_labels() -> void:

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -24,6 +24,7 @@ enum MODE {
 	PC_MAILBOX, PC_MAIL_SUBMENU, PC_MAIL_CONFIRM,
 	PC_OAK_ASK,
 	PC_SAVE,
+	PC_MON_LIST, PC_MON_ACTION, PC_ASK, PC_ITEM_QUANTITY,
 	ELEVATOR,
 	VENDING, PRIZE,
 }
@@ -128,7 +129,7 @@ var _persist: bool = false
 ## The save sequence while one is up, and what to do once it has finished.
 var _save_prompt: Gen2SavePrompt = null
 var _save_after: StringName = &""
-var _save_clock := Gen2WorldAnimation.FrameClock.new()
+var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 var _request: Dictionary = {}
 var _resolved: Dictionary = {}
 var _mode: int = -1
@@ -226,7 +227,7 @@ const PC_ROW_MODES: Array = [
 	MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST, MODE.PC_BOX_SUBMENU,
 	MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE,
 	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK,
-	MODE.PC_SAVE,
+	MODE.PC_SAVE, MODE.PC_MON_ACTION, MODE.PC_ASK,
 ]
 ## The `db rows` byte of every scrolling menu here, which is how much of its list
 ## a window shows. `wMenuScrollPosition` is one value, the way it is one address
@@ -243,7 +244,7 @@ const SCROLLING_ROWS: Dictionary = {
 const NO_WRAP_MODES: Array = [
 	MODE.PC_BOXES, MODE.PC_BOX_LIST, MODE.PC_BOX_SUBMENU, MODE.PC_ITEM_LIST,
 	MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK,
-	MODE.PC_DECO_SIDE,
+	MODE.PC_DECO_SIDE, MODE.PC_MON_LIST,
 ]
 var _pc_scroll: int = 0
 ## `wCurBox`, which CHANGE BOX writes and both lists read. The save's, so the box
@@ -257,6 +258,25 @@ var _bills_pc_cursor: int = 0
 ## Whether the menu on screen is the host's own question rather than a script's.
 ## See [method open_prompt].
 var _host_prompt: bool = false
+
+## Whether a Generation 1 machine is open, and `BIT_USING_GENERIC_PC`: whether
+## `ActivatePC`'s top menu stands behind it.
+var _gen1_pc: bool = false
+var _gen1_generic: bool = false
+## `wParentMenuItem`: the BILL'S PC row whose list is open, the list, and
+## `wPartyAndBillsPCSavedMenuItem`.
+var _gen1_bills_row: int = -1
+var _gen1_mon_entries: Array = []
+var _gen1_mon_cursor: int = 0
+## Which `YesNoChoice` is up, and `DisplayChooseQuantityMenu`'s dial with it.
+var _gen1_ask: StringName = &""
+var _gen1_ask_over: int = -1
+## `wParentMenuItem` for the item PC, which reopens on the row it was left on.
+var _gen1_items_cursor: int = 0
+var _gen1_quantity: Gen2WorldQuantityPrompt = null
+## `StatsScreenInit` from `.viewStats`, the page BILL'S PC opens over the map.
+var _stats: Gen2MonStatsScreen = null
+var _stats_page: Gen2StatsScreenPage = null
 
 ## The screen every layer here is drawn in: the one the opener handed over, so
 ## the menu box stands on the map's own 160x144 rather than beside it.
@@ -416,41 +436,40 @@ func _open_pokegear(
 
 
 ## Parent screens route buttons here so the service overlay owns input while open.
+## The modes that read the joypad themselves and own every button while open.
+const MODE_PRESS_HANDLERS: Dictionary = {
+	MODE.APRICORN: &"_press_apricorns",
+	MODE.ELEVATOR: &"_press_elevator",
+	MODE.VENDING: &"_press_vending",
+	MODE.PRIZE: &"_press_prize",
+	MODE.MART: &"_press_mart",
+	MODE.MOM_BANK: &"_press_mom_bank",
+	MODE.PC_ITEM_QUANTITY: &"_press_gen1_quantity",
+}
+
+## The overlays that own all 160x144, in the order a press is offered them.
+const OVERLAY_MEMBERS: Array[StringName] = [
+	&"_naming", &"_hof", &"_boxes", &"_mail_reader", &"_mail_party",
+]
+
+
 func handle_button(button: int) -> bool:
 	if not is_active():
 		return false
-	if _mode == MODE.APRICORN:
-		_press_apricorns(button)
-		return true
-	if _mode == MODE.ELEVATOR:
-		_press_elevator(button)
-		return true
-	if _mode == MODE.VENDING:
-		_press_vending(button)
-		return true
-	if _mode == MODE.PRIZE:
-		_press_prize(button)
-		return true
-	if _mode == MODE.MART:
-		_press_mart(button)
-		return true
-	if _mode == MODE.MOM_BANK:
-		_press_mom_bank(button)
+	if MODE_PRESS_HANDLERS.has(_mode):
+		call(MODE_PRESS_HANDLERS[_mode], button)
 		return true
 	if _mode == MODE.CARD and _pokegear != null:
 		return _pokegear.handle_button(button)
-	## The box screen owns all 160x144 while BILL'S PC is open, the way the
-	## region map does, so the buttons are its own.
-	if _naming != null:
-		return _naming.handle_button(button)
-	if _hof != null:
-		return _hof.handle_button(button)
-	if _boxes != null:
-		return _boxes.handle_button(button)
-	if _mail_reader != null:
-		return _mail_reader.handle_button(button)
-	if _mail_party != null:
-		return _mail_party.handle_button(button)
+	if _stats != null:
+		_stats.handle_button(button)
+		if _stats != null:
+			_render_stats()
+		return true
+	for member: StringName in OVERLAY_MEMBERS:
+		var overlay: Object = get(member)
+		if overlay != null:
+			return bool(overlay.call(&"handle_button", button))
 	if PokeButton.is_direction(button):
 		_move_direction(PokeButton.vector(button))
 		return true
@@ -470,8 +489,10 @@ func handle_button(button: int) -> bool:
 ## `SwitchItemsInBag` over `wPCItems`. A deposit is `DepositSellPack`, whose
 ## joypad handler has no SELECT in it.
 func _press_pc_item_select() -> bool:
-	if _mode != MODE.PC_ITEM_LIST \
-		or _pc_action == Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM:
+	if _mode != MODE.PC_ITEM_LIST:
+		return false
+	## `DepositSellPack` has no SELECT; every `ITEMLISTMENU` has one.
+	if not _gen1_pc and _pc_action == Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM:
 		return false
 	_apply_pc_switch_press()
 	return true
@@ -485,7 +506,7 @@ func _apply_pc_switch_press() -> void:
 	var answer: Dictionary = Gen2WorldPack.switch_items(order, _pc_switch, _cursor)
 	var next_order: Array = answer["order"]
 	if next_order != order and _world != null:
-		Gen2WorldBagHost.reorder(_world, _save, next_order, true)
+		Gen2WorldBagHost.reorder(_world, _save, next_order, not _pc_list_is_bag())
 		_refresh_pc_entries()
 		## `PC_PlaySwapItemsSound`, which is the pack's own pair of effects.
 		sfx_requested.emit(SFX_SWITCH_POKEMON, true)
@@ -1603,11 +1624,17 @@ func _finish_mom_bank(amount: int) -> void:
 ## for sixteen frames in every thirty-two: only a crossing of that is redrawn.
 func _process(delta: float) -> void:
 	if _save_prompt != null:
-		for _frame: int in _save_clock.tick(delta):
+		for _frame: int in _frame_clock.tick(delta):
 			_save_prompt.frame()
 			_advance_save_prompt()
 			if _save_prompt == null:
 				return
+		return
+	if _stats != null:
+		## `StatsScreen_WaitAnim`, the picture's own loop while the page is up.
+		for _pic_frame: int in _frame_clock.tick(delta):
+			_stats.advance_animation()
+		_render_stats()
 		return
 	if _mode != MODE.MOM_BANK or _mom_dial == null:
 		return
@@ -1700,6 +1727,12 @@ func open_pc_machine(
 	if _world == null or _data == null:
 		_show_error("The PC has no world or cartridge cache.")
 		return false
+	if String(mode).begins_with("gen1_"):
+		## They refuse nothing, and each zeroes `wParentMenuItem` on the way in.
+		_gen1_items_cursor = 0
+		_bills_pc_cursor = 0
+		_open_gen1_pc(mode)
+		return true
 	## `PC_CheckPartyForPokemon`, which answers with its own sound and shuts down
 	## again. `_PlayersHousePC` never asks it: the bedroom's PC is items and mail.
 	if mode != &"players_house" and not Gen2WorldPC.can_open(_save):
@@ -1725,6 +1758,9 @@ func _leave_bills_pc() -> void:
 ## asked for the bedroom's. `PC_CheckPartyForPokemon` is the one refusal either
 ## has before it opens.
 func _open_pc(mode: StringName) -> void:
+	if _gen1_pc or String(mode).begins_with("gen1_"):
+		_open_gen1_pc(mode)
+		return
 	_pc_house = mode == &"players_house"
 	if not _pc_house and not Gen2WorldPC.can_open(_save):
 		_finish_runtime({"ok": true, "script_value": 0, "cancelled": true})
@@ -1788,15 +1824,24 @@ func _open_pc_item_list(action: int) -> void:
 	_render_rows()
 
 
+## The list a chosen row reads: the bag for a deposit and the PC otherwise.
+func _pc_list_is_bag() -> bool:
+	return _pc_action == (Gen2WorldPC.GEN1_PLAYERS_PC_DEPOSIT if _gen1_pc \
+		else Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM)
+
+
 func _refresh_pc_entries() -> void:
-	_pc_entries = Gen2WorldPC.bag_entries(_data, _world.state) \
-		if _pc_action == Gen2WorldPC.PLAYERSPCITEM_DEPOSIT_ITEM \
+	_pc_entries = Gen2WorldPC.bag_entries(_data, _world.state) if _pc_list_is_bag() \
 		else Gen2WorldPC.pc_entries(_data, _world.state)
-	_cursor = mini(_cursor, maxi(0, _pc_entries.size() - 1))
+	## `.printCancelMenuItem` is a row of Generation 1's list and not Crystal's.
+	_cursor = mini(_cursor, maxi(0, _pc_entries.size() - (0 if _gen1_pc else 1)))
 	_refresh_pc_counts()
 
 
 func _refresh_pc_counts() -> void:
+	if _gen1_pc:
+		## `PlayerPCMenu` prints its question and no count.
+		return
 	_status = "PC %d/%d stacks" % [
 		_world.state.pc_items().size(), Gen2WorldPack.MAX_PC_ITEMS,
 	]
@@ -1806,6 +1851,8 @@ func _confirm_pc_row() -> void:
 	if _cursor < 0 or _cursor >= _pc_rows.size():
 		return
 	var handlers: Dictionary = {
+		MODE.PC_MON_ACTION: _confirm_gen1_mon_action,
+		MODE.PC_ASK: _confirm_gen1_ask,
 		MODE.PC_BOX_LIST: _confirm_box_list_row,
 		MODE.PC_BOX_SUBMENU: _confirm_box_submenu,
 		MODE.PC_BOXES: _confirm_bills_pc_row,
@@ -1818,6 +1865,14 @@ func _confirm_pc_row() -> void:
 		MODE.PC_OAK_ASK: _confirm_oak_ask,
 		MODE.PC: _confirm_pc_menu_row,
 	}
+	if _gen1_pc:
+		handlers.merge({
+			MODE.PC_OAK_ASK: _confirm_gen1_oak,
+			MODE.PC: _confirm_gen1_top_row,
+			MODE.PC_ITEMS: _confirm_gen1_items_row,
+			MODE.PC_BOXES: _confirm_gen1_bills_row,
+			MODE.PC_BOX_LIST: _confirm_gen1_box_row,
+		}, true)
 	var handler: Callable = handlers.get(_mode, _confirm_player_pc_row)
 	handler.call(int(_pc_rows[_cursor].get("row", -1)))
 
@@ -2103,7 +2158,7 @@ func _open_save_prompt(kind: Gen2SavePrompt.Kind, after: StringName) -> void:
 	_save_prompt = Gen2SavePrompt.open(
 		kind, _save.player_name if _save != null else "", _write_service_save
 	)
-	_save_clock.reset()
+	_frame_clock.reset()
 	set_process(true)
 	_render_save_prompt()
 
@@ -2187,11 +2242,30 @@ func _advance_save_prompt() -> void:
 ## A run of the PC's own boxes, acknowledged one at a time.
 func _open_pc_text(pages: Array, after: StringName, label: String) -> void:
 	_mode = MODE.PC_TEXT
-	_pc_pages = pages.duplicate()
+	_pc_pages = _paged(pages)
 	_pc_after = after
 	_cursor = 0
 	_pc_label = label
 	_show_pc_page()
+
+
+## `PrintText` holds a `<PARA>` and a `<CONT>` for their own press, so a box
+## carrying either is that many pages here.
+func _paged(pages: Array) -> Array:
+	var box: Rect2i = Gen2WorldServicePage.MESSAGE_BOX
+	@warning_ignore("integer_division")
+	var rows: int = (box.size.y - 2) / 2
+	var out: Array = []
+	for page: Variant in pages:
+		var text: String = String(page)
+		if text.is_empty():
+			out.append(text)
+			continue
+		for lines: PackedStringArray in Gen2TextLayout.lay_out(
+			text, box.size.x - 2, rows
+		):
+			out.append("\n".join(lines))
+	return out
 
 
 func _show_pc_page() -> void:
@@ -2212,19 +2286,513 @@ func _advance_pc_text() -> void:
 		## `ProfOaksPCBoot` waits *behind* its sound, not in front of it.
 		sfx_requested.emit(_pc_sfx, false)
 	_pc_sfx = -1
-	if _pc_after == &"close":
-		_finish_runtime({"ok": true, "script_value": 0})
-		return
-	if _pc_after == &"decoration":
-		_open_decorations()
-		return
-	if _pc_after == &"bills_pc":
-		_open_bills_pc_menu()
-		return
-	if _pc_after == &"oak_closed":
-		_open_oak_closed()
+	if PC_TEXT_LANDINGS.has(_pc_after):
+		call(PC_TEXT_LANDINGS[_pc_after])
 		return
 	_open_pc(&"pokemon_center")
+
+
+## Where a run of boxes lands. Anything unnamed goes back to the top menu.
+const PC_TEXT_LANDINGS: Dictionary = {
+	&"close": &"_leave_gen1_machine",
+	&"decoration": &"_open_decorations",
+	&"bills_pc": &"_open_bills_pc_menu",
+	&"oak_closed": &"_open_oak_closed",
+	&"gen1_items": &"_open_gen1_items",
+	&"gen1_bills": &"_open_gen1_bills",
+	&"gen1_item_list": &"_reopen_gen1_item_list",
+	&"gen1_mon_list": &"_reopen_gen1_mon_list",
+	&"gen1_oak_ask": &"_open_gen1_oak_ask",
+	&"gen1_oak_closed": &"_close_gen1_oak",
+	&"gen1_league": &"_open_gen1_league",
+	&"gen1_top": &"_open_gen1_top",
+}
+
+
+## `ActivatePC`, `PlayerPC` and `BillsPC_` over the map. The first can open the
+## other two, which is `BIT_USING_GENERIC_PC`.
+func _open_gen1_pc(mode: StringName) -> void:
+	_gen1_pc = true
+	## `ReloadMainMenu` returns every row of the top menu to it.
+	_gen1_generic = mode != &"gen1_players_pc" and mode != &"gen1_bills_pc"
+	match mode:
+		&"gen1_players_pc":
+			_open_gen1_items()
+		&"gen1_bills_pc":
+			_open_gen1_bills()
+		_:
+			_open_gen1_top()
+
+
+## `DisplayPCMainMenu`, whose box is as tall as the rows it offers.
+func _open_gen1_top() -> void:
+	_mode = MODE.PC
+	_cursor = 0
+	_pc_rows = Gen2WorldPC.gen1_top_menu(
+		_world.state, _save.player_name if _save != null else ""
+	)
+	_gen1_quiet()
+	_render_rows()
+
+
+func _confirm_gen1_top_row(row: int) -> void:
+	match row:
+		Gen2WorldPC.GEN1_PC_BILLS:
+			var met: bool = _world.state.is_event_flag_active(Gen1Layout.EVENT_MET_BILL)
+			_open_gen1_box_text(
+				"pc", "accessed_bills" if met else "accessed_someones", &"gen1_bills"
+			)
+		Gen2WorldPC.GEN1_PC_PLAYERS:
+			_open_gen1_box_text("pc", "accessed_mine", &"gen1_items")
+		Gen2WorldPC.GEN1_PC_OAKS:
+			_open_gen1_box_text("oaks_pc", "accessed", &"gen1_oak_ask")
+		Gen2WorldPC.GEN1_PC_LEAGUE:
+			_open_gen1_box_text("hof_pc", "accessed", &"gen1_league")
+		_:
+			_leave_gen1_machine()
+
+
+## `LogOff`, and `ExitPlayerPC` and `ExitBillsPC` with no top menu behind them.
+func _leave_gen1_machine() -> void:
+	_finish_runtime({"ok": true, "script_value": 0})
+
+
+func _cancel_gen1_machine() -> void:
+	if _gen1_generic:
+		_open_gen1_top()
+		return
+	_leave_gen1_machine()
+
+
+## `PlayerPCMenu`, which opens on `wParentMenuItem` and leaves on LOG OFF or B.
+func _open_gen1_items() -> void:
+	_mode = MODE.PC_ITEMS
+	_cursor = _gen1_items_cursor
+	_pc_action = -1
+	_pc_switch = -1
+	_pc_rows = Gen2WorldPC.gen1_players_pc_menu()
+	_gen1_quiet()
+	_summary = _gen1_box("players_pc", "what_do_you_want")
+	_render_rows()
+
+
+## The question each of `PlayerPC`'s three rows prints, and its empty line.
+const GEN1_ITEM_ACTIONS: Dictionary = {
+	Gen2WorldPC.GEN1_PLAYERS_PC_WITHDRAW: ["what_to_withdraw", "nothing_stored"],
+	Gen2WorldPC.GEN1_PLAYERS_PC_DEPOSIT: ["what_to_deposit", "nothing_to_deposit"],
+	Gen2WorldPC.GEN1_PLAYERS_PC_TOSS: ["what_to_toss", "nothing_stored"],
+}
+
+
+func _confirm_gen1_items_row(row: int) -> void:
+	_gen1_items_cursor = _cursor
+	if not GEN1_ITEM_ACTIONS.has(row):
+		_cancel_gen1_machine()
+		return
+	_pc_action = row
+	_pc_switch = -1
+	_cursor = 0
+	_pc_scroll = 0
+	_pc_quantity = 1
+	_refresh_pc_entries()
+	var names: Array = GEN1_ITEM_ACTIONS[row]
+	if _pc_entries.is_empty():
+		_open_gen1_box_text("players_pc", String(names[1]), &"gen1_items")
+		return
+	_mode = MODE.PC_ITEM_LIST
+	_gen1_quiet()
+	_summary = _gen1_box("players_pc", String(names[0]))
+	_render_rows()
+
+
+## `jp .loop`, back onto the list a transaction's box was printed over.
+func _reopen_gen1_item_list() -> void:
+	_confirm_gen1_items_row(_pc_action)
+
+
+## `IsKeyItem_`, an HM included: a stack asks how many and a toss refuses one.
+func _confirm_gen1_item() -> void:
+	if _cursor >= _pc_entries.size():
+		_open_gen1_items()
+		return
+	_pc_quantity = 1
+	var item: int = int((_pc_entries[_cursor] as Dictionary).get("item", 0))
+	if not Gen2WorldPack.can_toss(_data, item):
+		if _pc_action == Gen2WorldPC.GEN1_PLAYERS_PC_TOSS:
+			_open_gen1_box_text("toss", "too_important", &"gen1_item_list")
+			return
+		_apply_gen1_item()
+		return
+	_gen1_quantity = Gen2WorldQuantityPrompt.open(
+		int((_pc_entries[_cursor] as Dictionary).get("quantity", 1)), RomRegistry.GEN1
+	)
+	_mode = MODE.PC_ITEM_QUANTITY
+	_summary = _gen1_box("players_pc", String(GEN1_QUANTITY_BOXES[_pc_action]))
+	_render_rows()
+
+
+## The three boxes printed in front of `DisplayChooseQuantityMenu`.
+const GEN1_QUANTITY_BOXES: Dictionary = {
+	Gen2WorldPC.GEN1_PLAYERS_PC_WITHDRAW: "withdraw_how_many",
+	Gen2WorldPC.GEN1_PLAYERS_PC_DEPOSIT: "deposit_how_many",
+	Gen2WorldPC.GEN1_PLAYERS_PC_TOSS: "toss_how_many",
+}
+
+
+func _press_gen1_quantity(button: int) -> void:
+	if _gen1_quantity == null:
+		return
+	match _gen1_quantity.press(button):
+		Gen2WorldQuantityPrompt.CONFIRMED:
+			_pc_quantity = _gen1_quantity.value
+			if _pc_action == Gen2WorldPC.GEN1_PLAYERS_PC_TOSS:
+				## `TossItem_` asks `IsItOKToTossItemText` over the list first.
+				_open_gen1_ask(&"toss", Gen2TextStream.fill_marker(
+					_gen1_box("toss", "ok_to_toss"), Gen2TextStream.RAM_MARKER,
+					String(_pc_entries[_cursor].get("name", ""))
+				))
+				return
+			_apply_gen1_item()
+		Gen2WorldQuantityPrompt.CANCELLED:
+			_reopen_gen1_item_list()
+		_:
+			_render_rows()
+
+
+## The three transactions and the box each answers with.
+func _apply_gen1_item() -> void:
+	var item: int = int((_pc_entries[_cursor] as Dictionary).get("item", 0))
+	var applied: Dictionary = _gen1_item_transaction(item)
+	if not bool(applied.get("ok", false)):
+		_open_gen1_box_text(
+			"players_pc", GEN1_ITEM_REFUSALS.get(_pc_action, "no_room_to_store"),
+			&"gen1_item_list"
+		)
+		return
+	_refresh_pc_entries()
+	if _pc_action == Gen2WorldPC.GEN1_PLAYERS_PC_TOSS:
+		_open_gen1_text(
+			[_filled(_data.special_text("toss", "threw_away"), applied)], &"gen1_item_list"
+		)
+		return
+	_open_gen1_text([_filled(_gen1_box(
+		"players_pc",
+		"withdrew_item" if _pc_action == Gen2WorldPC.GEN1_PLAYERS_PC_WITHDRAW
+		else "item_was_stored"
+	), applied)], &"gen1_item_list")
+
+
+## `CantCarryMoreText` and `NoRoomToStoreText`, `AddItemToInventory`'s two.
+const GEN1_ITEM_REFUSALS: Dictionary = {
+	Gen2WorldPC.GEN1_PLAYERS_PC_WITHDRAW: "cant_carry_more",
+	Gen2WorldPC.GEN1_PLAYERS_PC_DEPOSIT: "no_room_to_store",
+	Gen2WorldPC.GEN1_PLAYERS_PC_TOSS: "no_room_to_store",
+}
+
+
+func _gen1_item_transaction(item: int) -> Dictionary:
+	match _pc_action:
+		Gen2WorldPC.GEN1_PLAYERS_PC_WITHDRAW:
+			return Gen2WorldPC.withdraw(_world, _save, item, _pc_quantity, _persist)
+		Gen2WorldPC.GEN1_PLAYERS_PC_DEPOSIT:
+			return Gen2WorldPC.deposit(_world, _save, item, _pc_quantity, _persist)
+	return Gen2WorldPC.toss(_world, _save, item, _pc_quantity, _persist)
+
+
+## `BillsPCMenu`, with `BoxNoPCText`'s own panel under it.
+func _open_gen1_bills() -> void:
+	_mode = MODE.PC_BOXES
+	_cursor = _bills_pc_cursor
+	_pc_rows = Gen2WorldPC.gen1_bills_pc_menu()
+	_gen1_quiet()
+	_summary = _gen1_box("bills_pc", "what")
+	_render_rows()
+
+
+func _confirm_gen1_bills_row(row: int) -> void:
+	_bills_pc_cursor = _cursor
+	if row == Gen2WorldPC.GEN1_BILLS_PC_SEE_YA:
+		_cancel_gen1_machine()
+		return
+	if row == Gen2WorldPC.GEN1_BILLS_PC_CHANGE_BOX:
+		_open_gen1_ask(&"change_box", _gen1_box("change_box", "warning"))
+		return
+	var refusal: StringName = Gen2WorldPC.gen1_bills_pc_refusal(_save, row, _box_index)
+	if refusal != &"":
+		_open_gen1_box_text("bills_pc", String(refusal), &"gen1_bills")
+		return
+	_open_gen1_mon_list(row)
+
+
+## `DisplayMonListMenu` over `wPartyCount` for a deposit and `wBoxCount` for
+## the other two: a name and `PrintLevel` beside it.
+func _open_gen1_mon_list(row: int) -> void:
+	_gen1_bills_row = row
+	_mode = MODE.PC_MON_LIST
+	_cursor = 0
+	_pc_scroll = 0
+	_refresh_gen1_mon_entries()
+	_gen1_mon_box()
+	_render_rows()
+
+
+func _refresh_gen1_mon_entries() -> void:
+	_gen1_mon_entries = []
+	if _gen1_bills_row == Gen2WorldPC.GEN1_BILLS_PC_DEPOSIT:
+		for slot: int in (_save.party.size() if _save != null else 0):
+			_gen1_mon_entries.append({"slot": slot, "mon": _save.party[slot]})
+	else:
+		_gen1_mon_entries = Gen2WorldPC.gen1_box_entries(_save, _box_index)
+	_cursor = mini(_cursor, _gen1_mon_entries.size())
+
+
+func _reopen_gen1_mon_list() -> void:
+	_mode = MODE.PC_MON_LIST
+	_refresh_gen1_mon_entries()
+	_gen1_mon_box()
+	_render_rows()
+
+
+## `PrintListMenuEntries` clears only `hlcoord 5, 3`: `WhatText` stays.
+func _gen1_mon_box() -> void:
+	_gen1_quiet()
+	_summary = _gen1_box("bills_pc", "what")
+
+
+func _confirm_gen1_mon_row() -> void:
+	if _cursor >= _gen1_mon_entries.size():
+		_open_gen1_bills()
+		return
+	if _gen1_bills_row == Gen2WorldPC.GEN1_BILLS_PC_RELEASE:
+		_open_gen1_ask(
+			&"release", _gen1_filled_mon("bills_pc_2", "once_released", 1)
+		)
+		return
+	_mode = MODE.PC_MON_ACTION
+	_pc_rows = [
+		{"row": Gen2WorldPC.GEN1_MON_ACTION_MOVE, "name": "DEPOSIT" \
+			if _gen1_bills_row == Gen2WorldPC.GEN1_BILLS_PC_DEPOSIT else "WITHDRAW"},
+		{"row": Gen2WorldPC.GEN1_MON_ACTION_STATS, "name": "STATS"},
+		{"row": Gen2WorldPC.GEN1_MON_ACTION_CANCEL, "name": "CANCEL"},
+	]
+	_gen1_mon_cursor = _cursor
+	_cursor = 0
+	_gen1_mon_box()
+	_render_rows()
+
+
+func _confirm_gen1_mon_action(row: int) -> void:
+	match row:
+		Gen2WorldPC.GEN1_MON_ACTION_MOVE:
+			_apply_gen1_mon_move()
+		Gen2WorldPC.GEN1_MON_ACTION_STATS:
+			_open_gen1_mon_stats()
+		_:
+			_reopen_gen1_mon_list()
+
+
+## `MoveMon` and `RemovePokemon`, which is [Gen2SaveStorage]'s own move.
+func _apply_gen1_mon_move() -> void:
+	var entry: Dictionary = _gen1_mon_entries[_gen1_mon_cursor]
+	var mon: Gen2SaveMon = entry["mon"]
+	var deposit: bool = _gen1_bills_row == Gen2WorldPC.GEN1_BILLS_PC_DEPOSIT
+	var applied: Dictionary = Gen2SaveStorage.deposit_party_to_box(
+		_save, _data, int(entry["slot"]), _box_index, -1, _persist
+	) if deposit else Gen2SaveStorage.withdraw_box_to_party(
+		_save, _data, _box_index, int(entry["slot"]), _persist
+	)
+	if not bool(applied.get("ok", false)):
+		_open_gen1_box_text(
+			"bills_pc", "box_full" if deposit else "cant_take_mon", &"gen1_bills"
+		)
+		return
+	_cursor = _gen1_mon_cursor
+	cry_requested.emit(mon.species if mon != null else 0)
+	_open_gen1_text([_gen1_mon_text(
+		"bills_pc", "mon_was_stored" if deposit else "mon_is_taken_out", mon
+	)], &"gen1_mon_list")
+
+
+## `.viewStats`' two `StatusScreen` predefs, the party list's own pages.
+func _open_gen1_mon_stats() -> void:
+	var mons: Array = []
+	for entry: Dictionary in _gen1_mon_entries:
+		mons.append(entry["mon"])
+	if _data == null or mons.is_empty():
+		return
+	_stats = Gen2MonStatsScreen.create(_data, mons, _gen1_mon_cursor)
+	_stats.closed.connect(_close_gen1_mon_stats)
+	_stats.cry_requested.connect(cry_requested.emit)
+	_stats.announce()
+	_frame_clock.reset()
+	set_process(true)
+	_render_stats()
+
+
+## `wPartyAndBillsPCSavedMenuItem`: back to the submenu on the row it left.
+func _close_gen1_mon_stats() -> void:
+	_gen1_mon_cursor = _stats.cursor() if _stats != null else _gen1_mon_cursor
+	_stats = null
+	set_process(false)
+	_cursor = 0
+	_mode = MODE.PC_MON_ACTION
+	_render_rows()
+
+
+## `StatsScreenInit`'s screen, composed the way the party menu composes it.
+func _render_stats() -> void:
+	if _stats_page == null:
+		_stats_page = Gen2StatsScreenPage.from_data(_data)
+	if _stats_page == null or _stats == null:
+		return
+	var image: Image = Gen2StatsScreenPage.compose(_stats_page, _data, _stats)
+	if image != null:
+		Gen2PicImage.show(_service_view, image)
+		_service_drawn = true
+		_apply_layer_visibility()
+
+
+## What YES and NO do, by the routine that asked. B is NO's own answer.
+const GEN1_ASK_YES: Dictionary = {
+	&"change_box": &"_open_gen1_box_list",
+	&"release": &"_apply_gen1_release",
+	&"toss": &"_apply_gen1_item",
+}
+const GEN1_ASK_NO: Dictionary = {
+	&"change_box": &"_open_gen1_bills",
+	&"release": &"_reopen_gen1_mon_list",
+	&"toss": &"_reopen_gen1_item_list",
+}
+
+
+## `BillsPCRelease`'s `YesNoChoice`, `ChangeBox`'s and `TossItem_`'s.
+func _open_gen1_ask(kind: StringName, question: String) -> void:
+	_gen1_ask = kind
+	_gen1_ask_over = _mode
+	_mode = MODE.PC_ASK
+	_cursor = 0
+	_pc_rows = [{"row": 0, "name": "YES"}, {"row": 1, "name": "NO"}]
+	_gen1_quiet()
+	_summary = question
+	_render_rows()
+
+
+func _confirm_gen1_ask(row: int) -> void:
+	var landings: Dictionary = GEN1_ASK_YES if row == 0 else GEN1_ASK_NO
+	call(landings.get(_gen1_ask, &"_open_gen1_bills"))
+
+
+func _refuse_gen1_ask() -> void:
+	_confirm_gen1_ask(1)
+
+
+func _apply_gen1_release() -> void:
+	var entry: Dictionary = {}
+	if _cursor < _gen1_mon_entries.size():
+		entry = _gen1_mon_entries[_cursor]
+	var mon: Gen2SaveMon = entry.get("mon", null) as Gen2SaveMon
+	var applied: Dictionary = Gen2SaveStorage.release_box_slot(
+		_save, _data, _box_index, int(entry.get("slot", -1)), _persist
+	)
+	if not bool(applied.get("ok", false)):
+		_open_gen1_box_text("bills_pc", "no_mon", &"gen1_bills")
+		return
+	cry_requested.emit(mon.species if mon != null else 0)
+	_open_gen1_text(
+		[_gen1_mon_text("bills_pc_2", "mon_was_released", mon)], &"gen1_mon_list"
+	)
+
+
+## `DisplayChangeBoxMenu`: twelve names one row apart, a pokeball beside each
+## box that holds something, and `BoxNoText`'s panel.
+func _open_gen1_box_list() -> void:
+	_mode = MODE.PC_BOX_LIST
+	_pc_rows = Gen2WorldPC.gen1_box_menu(_save)
+	_cursor = _box_index
+	_pc_scroll = 0
+	_gen1_quiet()
+	_summary = _gen1_box("choose_box", "choose")
+	_render_rows()
+
+
+## `ChangeBox` writes `wCurrentBoxNum` and saves the game behind it.
+func _confirm_gen1_box_row(row: int) -> void:
+	_box_index = clampi(row, 0, Gen1Layout.BOX_COUNT - 1)
+	if _save != null:
+		_save.current_box = _box_index
+	_open_gen1_bills()
+
+
+## `OpenOaksPC`: the greeting, the question, and `ClosedOaksPCText` either way.
+func _open_gen1_oak_ask() -> void:
+	_mode = MODE.PC_OAK_ASK
+	_cursor = 0
+	_pc_rows = [{"row": 0, "name": "YES"}, {"row": 1, "name": "NO"}]
+	_gen1_quiet()
+	_summary = _gen1_box("oaks_pc", "get_rated")
+	_render_rows()
+
+
+func _confirm_gen1_oak(row: int) -> void:
+	if row != 0:
+		_close_gen1_oak()
+		return
+	## `DisplayDexRating`: `DexCompletionText` and the row the count lands on.
+	var rated: Dictionary = Gen2ProfOaksPC.rate(_data, _world.state)
+	_open_gen1_text(rated.get("pages", []) as Array, &"gen1_oak_closed")
+
+
+func _close_gen1_oak() -> void:
+	_open_gen1_box_text("oaks_pc", "closed", &"gen1_top")
+
+
+## `PKMNLeaguePC`; the save model keeps its teams as records, so an empty
+## list is the row answering with nothing.
+func _open_gen1_league() -> void:
+	_open_hall_of_fame(0)
+
+
+func _gen1_box(run: String, slot: String) -> String:
+	return _world.gen1_filled_text(_data.special_text(run, slot)) if _data != null else ""
+
+
+## A nickname in every `text_ram` slot, and `MonWasStoredText`'s box number.
+func _gen1_mon_text(run: String, slot: String, mon: Gen2SaveMon) -> String:
+	var text: String = _gen1_filled_mon(run, slot, 2 if slot == "mon_is_taken_out" \
+		or slot == "mon_was_released" else 1, mon)
+	if slot != "mon_was_stored":
+		return text
+	return Gen2TextStream.fill_marker(
+		text, Gen2TextStream.RAM_MARKER, String.num_int64(_box_index + 1)
+	)
+
+
+func _gen1_filled_mon(
+	run: String, slot: String, slots: int, mon: Gen2SaveMon = null
+) -> String:
+	var chosen: Gen2SaveMon = mon
+	if chosen == null and _cursor < _gen1_mon_entries.size():
+		chosen = (_gen1_mon_entries[_cursor] as Dictionary).get("mon", null) as Gen2SaveMon
+	var nickname: String = Gen2SaveMon.display_name(chosen, _data)
+	var text: String = _gen1_box(run, slot)
+	for _slot: int in slots:
+		text = Gen2TextStream.fill_marker(text, Gen2TextStream.RAM_MARKER, nickname)
+	return text
+
+
+## The lines a menu with no box of its own has to clear before it draws.
+func _gen1_quiet() -> void:
+	_title = ""
+	_summary = ""
+	_status = ""
+
+
+func _open_gen1_box_text(run: String, slot: String, after: StringName) -> void:
+	_open_gen1_text([_gen1_box(run, slot)], after)
+
+
+func _open_gen1_text(pages: Array, after: StringName) -> void:
+	_open_pc_text(pages, after, "")
 
 
 ## `_BillsPC`, the top menu the two lists and the box picker sit behind.
@@ -2853,9 +3421,9 @@ func _move_cursor(delta: int) -> void:
 	if rows > 0:
 		_pc_scroll = clampi(_pc_scroll, _cursor - rows + 1, _cursor)
 		_pc_scroll = clampi(_pc_scroll, 0, maxi(0, count - rows))
-	if _mode == MODE.PC_BOX_LIST:
+	if _mode == MODE.PC_BOX_LIST and not _gen1_pc:
 		## `BillsPC_PrintBoxCountAndCapacity` runs per row rather than per
-		## choice.
+		## choice, where `DisplayChangeBoxMenu` counts every box once up front.
 		_refresh_box_counts()
 	_render_rows()
 
@@ -2869,6 +3437,13 @@ func _scrolling_rows() -> int:
 		if _menu == null or _menu.rows >= _menu.options.size():
 			return 0
 		return _menu.rows
+	if _gen1_pc:
+		if _mode == MODE.PC_ITEM_LIST or _mode == MODE.PC_MON_LIST:
+			## `ld b, 4` names against `wMaxMenuItem` 2: the fourth is a look ahead.
+			return Gen2MartPage.GEN1_CURSOR_ROWS
+		## `DisplayChangeBoxMenu` draws all twelve names and scrolls none.
+		if _mode == MODE.PC_BOX_LIST:
+			return 0
 	return int(SCROLLING_ROWS.get(_mode, 0))
 
 
@@ -2881,7 +3456,7 @@ func _move_direction(direction: Vector2i) -> void:
 			_cursor = _menu.selected_index()
 			_render_rows()
 		return
-	if _mode == MODE.PC_ITEM_LIST and direction.x != 0:
+	if _mode == MODE.PC_ITEM_LIST and direction.x != 0 and not _gen1_pc:
 		_change_pc_quantity(direction.x)
 		return
 	if direction.x != 0:
@@ -2891,12 +3466,14 @@ func _move_direction(direction: Vector2i) -> void:
 
 
 func _confirm() -> void:
-	if _mode in [
-		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
-		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
-		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK,
-	]:
+	if _mode == MODE.PC_SAVE:
+		_press_save_prompt(true)
+		return
+	if PC_ROW_MODES.has(_mode):
 		_confirm_pc_row()
+		return
+	if _mode == MODE.PC_MON_LIST:
+		_confirm_gen1_mon_row()
 		return
 	if _mode == MODE.PC_ITEM_LIST:
 		## `.moving_stuff_around` reads A before anything else, so the A that
@@ -2904,10 +3481,10 @@ func _confirm() -> void:
 		if _pc_switch >= 0:
 			_apply_pc_switch_press()
 			return
+		if _gen1_pc:
+			_confirm_gen1_item()
+			return
 		_confirm_pc_item()
-		return
-	if _mode == MODE.PC_SAVE:
-		_press_save_prompt(true)
 		return
 	if _mode == MODE.PC_TEXT:
 		_advance_pc_text()
@@ -2940,13 +3517,32 @@ const CANCEL_HANDLERS: Dictionary = {
 	MODE.PC_DECO_SIDE: &"_cancel_deco_side",
 	MODE.PC_SAVE: &"_refuse_save_prompt",
 	MODE.PC_TEXT: &"_advance_pc_text",
+	MODE.PC_MON_LIST: &"_open_gen1_bills",
+	MODE.PC_MON_ACTION: &"_reopen_gen1_mon_list",
+	MODE.PC_ITEM_QUANTITY: &"_reopen_gen1_item_list",
+	MODE.PC_ASK: &"_refuse_gen1_ask",
 	MODE.MENU: &"_finish_input_cancelled",
 	MODE.PHONE: &"_cancel_phone",
 	MODE.TOWN_MAP: &"_cancel_town_map",
 }
 
 
+## Generation 1's own B: a machine opened from the top menu steps back to it
+## and one opened from a text script leaves.
+const GEN1_CANCEL_HANDLERS: Dictionary = {
+	MODE.PC: &"_leave_gen1_machine",
+	MODE.PC_ITEMS: &"_cancel_gen1_machine",
+	MODE.PC_BOXES: &"_cancel_gen1_machine",
+	MODE.PC_ITEM_LIST: &"_open_gen1_items",
+	MODE.PC_BOX_LIST: &"_open_gen1_bills",
+	MODE.PC_OAK_ASK: &"_close_gen1_oak",
+}
+
+
 func _cancel() -> void:
+	if _gen1_pc and GEN1_CANCEL_HANDLERS.has(_mode):
+		call(GEN1_CANCEL_HANDLERS[_mode])
+		return
 	if CANCEL_HANDLERS.has(_mode):
 		call(CANCEL_HANDLERS[_mode])
 
@@ -3028,6 +3624,8 @@ func _finish(results: Array) -> void:
 		results.append_array(_extra_results)
 		_extra_results = []
 	_mode = -1
+	_gen1_pc = false
+	_gen1_quantity = null
 	_close_mart()
 	completed.emit(results)
 
@@ -3035,6 +3633,9 @@ func _finish(results: Array) -> void:
 ## The rows this mode is offering, which is all [method _render_service_page]
 ## needs: there is no second list to keep in step with it any more.
 func _render_rows(override: Array = []) -> void:
+	if _gen1_pc and GEN1_LIST_MODES.has(_gen1_list_mode()):
+		_render_gen1_list()
+		return
 	if _is_single_row() and override.is_empty():
 		## One value at a time, the way the dial and the room menu each show it.
 		override = [_choices[clampi(_cursor, 0, _choices.size() - 1)]] if not _choices.is_empty() \
@@ -3055,6 +3656,71 @@ func _render_rows(override: Array = []) -> void:
 		_render_service_page(values.slice(_pc_scroll, _pc_scroll + rows), _cursor - _pc_scroll)
 		return
 	_render_service_page(values)
+
+
+## The modes drawn as `DisplayListMenuID`'s `LIST_MENU_BOX` over the map, with
+## the last box printed under it and the quantity dial over it.
+const GEN1_LIST_MODES: Array = [
+	MODE.PC_ITEM_LIST, MODE.PC_MON_LIST, MODE.PC_ITEM_QUANTITY,
+]
+
+
+## The list a `YesNoChoice` is standing over, or the open mode when none is.
+func _gen1_list_mode() -> int:
+	return _gen1_ask_over if _mode == MODE.PC_ASK else _mode
+
+
+func _render_gen1_list() -> void:
+	if _service_page == null:
+		_service_page = Gen2WorldServicePage.from_data(_data)
+	if _mart_page == null:
+		_mart_page = Gen2MartPage.from_data(_data)
+	if _service_page == null or _mart_page == null or _service_view == null:
+		return
+	var asking: bool = _mode == MODE.PC_ASK
+	if not asking:
+		var rows: int = Gen2MartPage.GEN1_CURSOR_ROWS
+		_pc_scroll = clampi(_pc_scroll, _cursor - rows + 1, _cursor)
+		_pc_scroll = clampi(_pc_scroll, 0, maxi(0, _option_count() - rows))
+	var image: Image = _mart_page.render_gen1_pack({
+		"rows": _gen1_list_rows(),
+		"cursor": -1 if asking else _cursor - _pc_scroll,
+		"quantity": _gen1_quantity.value \
+			if _mode == MODE.PC_ITEM_QUANTITY and _gen1_quantity != null else -1,
+	})
+	var over: Image = _service_page.render(
+		"", "", _pc_rows if asking else [], _cursor, _summary,
+		_service_box() if asking else null
+	)
+	if image != null and over != null:
+		image.blend_rect(over, Rect2i(Vector2i.ZERO, over.get_size()), Vector2i.ZERO)
+	if image != null:
+		Gen2PicImage.show(_service_view, image)
+	_service_drawn = image != null
+	_apply_layer_visibility()
+
+
+## `PrintListMenuEntries`' four names, with a count or `PrintLevel` under each.
+func _gen1_list_rows() -> Array:
+	if _gen1_list_mode() != MODE.PC_MON_LIST:
+		return Gen2WorldPack.list_rows(
+			_data, Gen1Layout.BAG_POCKET, _pc_entries, _pc_scroll, true,
+			Gen2MartPage.GEN1_LIST_HEIGHT
+		)
+	var out: Array = []
+	for offset: int in Gen2MartPage.GEN1_LIST_HEIGHT:
+		var index: int = _pc_scroll + offset
+		if index > _gen1_mon_entries.size():
+			break
+		if index == _gen1_mon_entries.size():
+			out.append({"cancel": true})
+			break
+		var mon: Gen2SaveMon = (_gen1_mon_entries[index] as Dictionary)["mon"]
+		out.append({
+			"name": Gen2SaveMon.display_name(mon, _data),
+			"level": mon.level if mon != null else 0,
+		})
+	return out
 
 
 ## `PhoneCall`'s ringing box and `PC_DisplayText`'s plain `MenuTextbox` print
@@ -3089,7 +3755,7 @@ func _render_service_page(values: Array, cursor: int = -1) -> void:
 		else _dial_image() if _is_dial() else _service_page.render(
 		"" if quiet else _title, "" if quiet else _summary, labels,
 		_cursor if cursor < 0 else cursor, "" if quiet else _status,
-		_service_box(), _service_note(), _message_box()
+		_service_box(), _service_note(), _message_box(), _gen1_box_marks()
 	)
 	if image != null:
 		Gen2PicImage.show(_service_view, image)
@@ -3106,6 +3772,8 @@ func _message_box() -> Rect2i:
 
 ## `Elevator_GetCurrentFloorText`'s `hlcoord 0, 0 / ld b, 4 / ld c, 8`.
 func _service_note() -> Dictionary:
+	if _gen1_pc and (_mode == MODE.PC_BOXES or _mode == MODE.PC_BOX_LIST):
+		return _gen1_box_note()
 	if _mode == MODE.PC_BOX_LIST:
 		return _box_count_note()
 	if _mode != MODE.ELEVATOR:
@@ -3121,6 +3789,30 @@ func _service_note() -> Dictionary:
 			"at": Vector2i(4, 4),
 		},
 	]}
+
+
+## `BoxNoPCText`'s panel: `hlcoord 9, 14` under BILL'S PC's menu and
+## `hlcoord 0, 0` beside the box picker, each `lb bc, 2, 9` with the label two
+## rows in and the number eight columns past it.
+func _gen1_box_note() -> Dictionary:
+	var at: Vector2i = Vector2i(0, 0) if _mode == MODE.PC_BOX_LIST else Vector2i(9, 14)
+	return {"rect": Rect2i(at, Vector2i(11, 4)), "lines": [
+		{"text": "BOX No.", "at": Vector2i(1, 2)},
+		{"text": String.num_int64(_box_index + 1), "at": Vector2i(9, 2)},
+	]}
+
+
+## `DisplayChangeBoxMenu`'s pokeball, on every box that holds something.
+func _gen1_box_marks() -> Array:
+	if _mode != MODE.PC_BOX_LIST or not _gen1_pc:
+		return []
+	var out: Array = []
+	for index: int in _pc_rows.size():
+		if bool((_pc_rows[index] as Dictionary).get("occupied", false)):
+			out.append(Vector2i(
+				GEN1_BOX_LIST_BALL_COLUMN, GEN1_BOX_LIST_BOX.position.y + 1 + index
+			))
+	return out
 
 
 ## `BillsPC_PrintBoxCountAndCapacity`'s `hlcoord 11, 7 / lb bc, 5, 7`.
@@ -3173,63 +3865,140 @@ func _dial_image() -> Image:
 
 ## The `menu_coords` box this mode's own list sits in. `null` draws no box,
 ## which is what MODE.MENU falls back to before a menu is loaded.
+## `TextBoxBorder hlcoord 0, 0` with each menu's own height, as the corners
+## `menu_coords` would name: every one of them places its strings at (2,2) with
+## the cursor on column 1. The top menu's height is the rows it offers.
+const GEN1_PC_BOXES: Dictionary = {
+	MODE.PC_ITEMS: Rect2i(0, 0, 15, 9),
+	MODE.PC_BOXES: Rect2i(0, 0, 13, 11),
+	## `DisplayDepositWithdrawMenu`'s `hlcoord 9, 10 / lb bc, 6, 9`.
+	MODE.PC_MON_ACTION: Rect2i(9, 10, 19, 17),
+}
+const GEN1_PC_TOP_BOTTOM: Dictionary = {3: 7, 4: 9, 5: 11}
+## `DisplayChangeBoxMenu`'s `hlcoord 11, 0 / lb bc, 12, 7`, whose names are one
+## row apart: `BIT_DOUBLE_SPACED_MENU` names the bit that is set for a
+## single-row step, and `HandleMenuInput` steps two rows when it is clear.
+const GEN1_BOX_LIST_BOX := Rect2i(11, 0, 19, 13)
+const GEN1_BOX_LIST_BALL_COLUMN: int = 18
+
+
+func _gen1_pc_box() -> Gen2MenuBox:
+	if _mode == MODE.PC_BOX_LIST:
+		var list: Gen2MenuBox = Gen2MenuBox.from_coords(
+			GEN1_BOX_LIST_BOX.position.x, GEN1_BOX_LIST_BOX.position.y,
+			GEN1_BOX_LIST_BOX.end.x, GEN1_BOX_LIST_BOX.end.y,
+			Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+		)
+		list.row_step = 1
+		return list
+	var corners: Rect2i = GEN1_PC_BOXES.get(_mode, Rect2i(
+		0, 0, 15, int(GEN1_PC_TOP_BOTTOM.get(_pc_rows.size(), 9))
+	))
+	var menu_box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		corners.position.x, corners.position.y, corners.end.x, corners.end.y,
+		Gen2MenuBox.STATICMENU_CURSOR
+	)
+	## `DisplayDepositWithdrawMenu` is drawn after `WhatText`, over the speech
+	## box's own right half.
+	menu_box.over_textbox = _mode == MODE.PC_MON_ACTION
+	return menu_box
+
+
+## The box each mode's menu is drawn in, by the method that answers for it.
+## Every one of them is a `menu_coords` and nothing else, which is why they are
+## a table rather than forty arms.
+const SERVICE_BOXES: Dictionary = {
+	MODE.MENU: &"_scripted_menu_box",
+	MODE.PC: &"_pc_top_box",
+	MODE.PC_ITEMS: &"_pc_top_box",
+	MODE.PC_BOXES: &"_pc_top_box",
+	MODE.PC_DECO: &"_deco_category_box",
+	MODE.PC_DECO_LIST: &"_deco_list_box",
+	MODE.PC_DECO_SIDE: &"_deco_side_box",
+	MODE.ELEVATOR: &"_elevator_box",
+	MODE.PC_MAILBOX: &"_mailbox_box",
+	MODE.PC_MAIL_SUBMENU: &"_mail_submenu_box",
+	MODE.PC_MAIL_CONFIRM: &"_yes_no_box",
+	MODE.PC_OAK_ASK: &"_yes_no_box",
+	MODE.PC_ASK: &"_yes_no_box",
+	MODE.PC_SAVE: &"_save_prompt_box",
+	MODE.PC_BOX_LIST: &"_pc_box_list_box",
+	MODE.PC_BOX_SUBMENU: &"_box_submenu_box",
+	MODE.PC_ITEM_LIST: &"_pc_item_list_box",
+	MODE.APRICORN: &"_apricorn_box",
+}
+## The Generation 1 machines' own menus, which are `TextBoxBorder`s at
+## coordinates of their own rather than any of the above.
+const GEN1_PC_BOX_MODES: Array = [
+	MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_MON_ACTION, MODE.PC_BOX_LIST,
+]
+
+
 func _service_box() -> Gen2MenuBox:
-	match _mode:
-		MODE.MENU:
-			if _menu == null or _menu.kind == &"spinner":
-				return null
-			var menu_box: Gen2MenuBox = _menu.box()
-			menu_box.scroll = _pc_scroll
-			return menu_box
-		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES:
-			return _pc_top_box()
-		MODE.PC_DECO_LIST:
-			return _deco_list_box()
-		MODE.ELEVATOR:
-			## `Elevator_MenuHeader`'s `menu_coords 12, 1, 18, 9`, whose fourth
-			## floor only fits without the top row of spacing.
-			var elevator_box: Gen2MenuBox = Gen2MenuBox.from_coords(
-				12, 1, 18, 9,
-				Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
-			)
-			elevator_box.scrolling_arrows = true
-			elevator_box.scroll = _elevator_scroll
-			return elevator_box
-		MODE.PC_MAILBOX:
-			## `.TopMenuHeader`'s `menu_coords 8, 1, SCREEN_WIDTH - 2, 10`.
-			return _scrolling_box(Gen2MenuBox.from_coords(
-				8, 1, 18, 10,
-				Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
-			))
-		MODE.PC_MAIL_SUBMENU:
-			## `.SubMenuHeader`'s `menu_coords 0, 0, 13, 9`.
-			return Gen2MenuBox.from_coords(0, 0, 13, 9, Gen2MenuBox.STATICMENU_CURSOR)
-		MODE.PC_MAIL_CONFIRM, MODE.PC_OAK_ASK:
-			## `YesNoBox`, which `.PutInPack` and `ProfOaksPC` open over theirs.
-			return Gen2MenuBox.yes_no()
-		MODE.PC_SAVE:
-			## The same `YesNoBox`, and nothing at all on the timed steps: they
-			## are a box with no question on it.
-			return Gen2MenuBox.yes_no() if _pc_rows.size() == 2 else null
-		MODE.PC_DECO:
-			return _deco_category_box()
-		MODE.PC_DECO_SIDE:
-			return _deco_side_box()
-		MODE.PC_BOX_LIST:
-			return _pc_box_list_box()
-		MODE.PC_BOX_SUBMENU:
-			## `.MenuHeader`'s `menu_coords 11, 4, SCREEN_WIDTH - 1, 13`, raised
-			## two rows: the change-box screen it is drawn over on the cartridge
-			## has its own words at rows 14 to 17, and this panel's box is at 11,
-			## which the source's corner would put QUIT behind.
-			return Gen2MenuBox.from_coords(11, 2, 19, 11, Gen2MenuBox.STATICMENU_CURSOR)
-		MODE.PC_ITEM_LIST:
-			return _pc_item_list_box()
-		MODE.APRICORN:
-			return _apricorn_quantity_box() if _apricorns != null \
-				and _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY \
-				else _apricorn_select_box()
-	return null
+	if _gen1_pc and GEN1_PC_BOX_MODES.has(_mode):
+		return _gen1_pc_box()
+	if not SERVICE_BOXES.has(_mode):
+		return null
+	return call(SERVICE_BOXES[_mode]) as Gen2MenuBox
+
+
+func _scripted_menu_box() -> Gen2MenuBox:
+	if _menu == null or _menu.kind == &"spinner":
+		return null
+	var menu_box: Gen2MenuBox = _menu.box()
+	menu_box.scroll = _pc_scroll
+	return menu_box
+
+
+## `Elevator_MenuHeader`'s `menu_coords 12, 1, 18, 9`, whose fourth floor only
+## fits without the top row of spacing.
+func _elevator_box() -> Gen2MenuBox:
+	var box: Gen2MenuBox = Gen2MenuBox.from_coords(
+		12, 1, 18, 9,
+		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+	)
+	box.scrolling_arrows = true
+	box.scroll = _elevator_scroll
+	return box
+
+
+## `.TopMenuHeader`'s `menu_coords 8, 1, SCREEN_WIDTH - 2, 10`.
+func _mailbox_box() -> Gen2MenuBox:
+	return _scrolling_box(Gen2MenuBox.from_coords(
+		8, 1, 18, 10,
+		Gen2MenuBox.STATICMENU_CURSOR | Gen2MenuBox.STATICMENU_NO_TOP_SPACING
+	))
+
+
+## `.SubMenuHeader`'s `menu_coords 0, 0, 13, 9`.
+func _mail_submenu_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(0, 0, 13, 9, Gen2MenuBox.STATICMENU_CURSOR)
+
+
+## `YesNoBox`, which `.PutInPack`, `ProfOaksPC` and both of Generation 1's
+## questions open over their own.
+func _yes_no_box() -> Gen2MenuBox:
+	return Gen2MenuBox.yes_no()
+
+
+## The same `YesNoBox`, and nothing at all on the timed steps: they are a box
+## with no question on it.
+func _save_prompt_box() -> Gen2MenuBox:
+	return Gen2MenuBox.yes_no() if _pc_rows.size() == 2 else null
+
+
+## `.MenuHeader`'s `menu_coords 11, 4, SCREEN_WIDTH - 1, 13`, raised two rows:
+## the change-box screen it is drawn over on the cartridge has its own words at
+## rows 14 to 17, and this panel's box is at 11, which the source's corner would
+## put QUIT behind.
+func _box_submenu_box() -> Gen2MenuBox:
+	return Gen2MenuBox.from_coords(11, 2, 19, 11, Gen2MenuBox.STATICMENU_CURSOR)
+
+
+func _apricorn_box() -> Gen2MenuBox:
+	return _apricorn_quantity_box() if _apricorns != null \
+		and _apricorns.phase == Gen2WorldApricorn.SELECT_QUANTITY \
+		else _apricorn_select_box()
 
 
 ## `PokemonCenterPC.TopMenu` and `PlayersPCMenuData` share this `menu_coords`.
@@ -3307,15 +4076,13 @@ func _apricorn_quantity_box() -> Gen2MenuBox:
 func _option_count() -> int:
 	if _mode == MODE.MENU:
 		return _menu.options.size() if _menu != null else _choices.size()
-	if _mode in [
-		MODE.PC, MODE.PC_ITEMS, MODE.PC_BOXES, MODE.PC_BOX_LIST,
-		MODE.PC_DECO, MODE.PC_DECO_LIST, MODE.PC_DECO_SIDE, MODE.PC_BOX_SUBMENU,
-		MODE.PC_MAILBOX, MODE.PC_MAIL_SUBMENU, MODE.PC_MAIL_CONFIRM, MODE.PC_SAVE,
-		MODE.PC_OAK_ASK,
-	]:
+	if PC_ROW_MODES.has(_mode):
 		return _pc_rows.size()
+	if _mode == MODE.PC_MON_LIST:
+		## `.printCancelMenuItem`, the row every `DisplayListMenuID` ends on.
+		return _gen1_mon_entries.size() + 1
 	if _mode == MODE.PC_ITEM_LIST:
-		return maxi(1, _pc_entries.size())
+		return _pc_entries.size() + 1 if _gen1_pc else maxi(1, _pc_entries.size())
 	return 1
 
 

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1`, `game/rom/rom_import.gd` and `tools/checks/gen1_*`
-## are 1372 lines of the 40160 here, and Generation 1 has added 1101 more to the
-## shared battle, world, palette, text, save and renderer code: 150 the battle
-## animation engine, 140 the transition, 85 the party menu, 40 the bag in a
-## battle, 33 the hidden objects, 18 the trades. Fourteen sweeps paid nothing.
-const MAX_COMMENT_LINES: int = 40160
+## files cost: `game/gen1` and its neighbours are 1395 lines of the 40379 here,
+## and Generation 1 has added 1292 more to the shared battle, world, palette,
+## text, save and renderer code: 150 the battle animation engine, 140 the
+## transition, 108 the three PCs, 85 the party menu, 42 the status screen, 40
+## the bag in a battle, 33 the hidden objects. Fifteen sweeps paid nothing.
+const MAX_COMMENT_LINES: int = 40379
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -292,6 +292,14 @@ func _types() -> void:
 	_r.check(data.type_count() == TYPE_COUNT, "%d types, expected %d" % [
 		data.type_count(), TYPE_COUNT
 	])
+	## The numbering skips $09 to $13, so a cache holding only the types that
+	## exist cannot be read by position: every real number answers with a name.
+	for type: int in Gen1Layout.TYPE_COUNT:
+		if not _is_real_type(type):
+			continue
+		_r.check(
+			not data.type_name(type).is_empty(), "type $%02X has no name." % type
+		)
 	var matchups: int = 0
 	for attacker: int in Gen1Layout.TYPE_COUNT:
 		for defender: int in Gen1Layout.TYPE_COUNT:

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -214,6 +214,16 @@ const VIRIDIAN_CITY: int = 0x01
 const HIDDEN_POTION_CELL := Vector2i(14, 4)
 const HIDDEN_POTION: int = 0x14
 
+## `OpenPokemonCenterPC` at VIRIDIAN_POKECENTER's own cell and `OpenRedsPC` at
+## the bedroom's: the two hidden events a `TX_SCRIPT_*` PC stands behind, faced
+## from the cell below each.
+const POKECENTER_PC_CELL := Vector2i(13, 3)
+const REDS_PC_CELL := Vector2i(0, 1)
+const PC_MACHINES: Array = [
+	[VIRIDIAN_POKECENTER, POKECENTER_PC_CELL, &"gen1_pokemon_center", "pc"],
+	[REDS_HOUSE_2F, REDS_PC_CELL, &"gen1_players_pc", "players_pc"],
+]
+
 ## `MapBadgeFlags`' Pewter row and its two statues, with the two names
 ## `PewterGym_Script.LoadNames` hands `LoadGymLeaderAndCityName`.
 const PEWTER_GYM: int = 0x36
@@ -257,6 +267,7 @@ func _one_game() -> void:
 	_check_the_magikarp_salesman()
 	_check_the_coin_clerks()
 	_check_a_hidden_object()
+	_check_a_pc_opens()
 	_check_a_hidden_item()
 	_check_a_gym_statue()
 	_check_a_bench_guy()
@@ -1129,6 +1140,49 @@ func _check_a_hidden_object() -> void:
 		var box: String = _box_text(world)
 		_r.check(box.begins_with(SNES_BOX % Gen2WorldScriptRunner.UNNAMED),
 			"the SNES said %s facing %s." % [box, step])
+
+
+## `TextScript_PokemonCenterPC` and `TextScript_ItemStoragePC`: each prints the
+## machine's own boot line and then hands the world a `pc_requested`.
+## `OpenPokemonCenterPC`'s `cp SPRITE_FACING_UP` is what refuses the machine to a
+## player standing beside it.
+func _check_a_pc_opens() -> void:
+	for machine: Array in PC_MACHINES:
+		var world: Gen2WorldAPI = _facing_up(
+			int(machine[0]), Vector2i(machine[1]) + Vector2i.DOWN
+		)
+		if world == null:
+			return
+		var boot: String = world.gen1_filled_text(
+			_r.data.special_text(String(machine[3]), "turned_on")
+		)
+		var said: String = _box_text(world)
+		_r.check(not boot.is_empty() and said.begins_with(boot.split("\n")[0]),
+			"the %s PC opened with %s." % [machine[2], said])
+		world.run_event_queue(true)
+		var request: Dictionary = world.pending_runtime_request()
+		_r.check(
+			StringName(request.get("kind", &"")) == &"pc_requested"
+				and StringName(
+					(request.get("values", {}) as Dictionary).get("mode", &"")
+				) == StringName(machine[2]),
+			"the machine asked for %s." % [request]
+		)
+	_check_the_pc_refuses_a_player_beside_it()
+
+
+func _check_the_pc_refuses_a_player_beside_it() -> void:
+	var world: Gen2WorldAPI = _r.open_world(
+		0, VIRIDIAN_POKECENTER, POKECENTER_PC_CELL + Vector2i.LEFT
+	)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	world.interact()
+	_r.check(
+		world.pending_runtime_request().is_empty(),
+		"the Pokemon Center PC opened from beside it."
+	)
 
 
 ## `HiddenItems`: the receipt names the item `GetItemName` fetched before the

--- a/tools/checks/pc.gd
+++ b/tools/checks/pc.gd
@@ -2,8 +2,8 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies Bill's PC's own graphics and its screen against freshly imported real
-## caches, over every species rather than a sampled one. Expected values come from
+## Verifies Bill's PC's graphics and its screen against freshly imported real
+## caches over every species, and Generation 1's three machines beside them. Expected values come from
 ## `engine/pokemon/bills_pc.asm`: `BillsPC_InitGFX`'s two runs, `_CGB_BillsPC`'s
 ## palettes, `BillsPC_UpdateSelectionCursor`'s ring and `PCMonInfo`'s left column.
 ## The sweep is over species because that column is the one thing whose width is
@@ -40,6 +40,32 @@ const GOLD_OAM: Array = [
 const OAM_X_BIAS: int = 8
 const OAM_Y_BIAS: int = 16
 
+## Every slot of the runs Generation 1's own machines print from.
+const GEN1_TEXT_RUNS: Dictionary = {
+	"pc": ["turned_on", "accessed_bills", "accessed_someones", "accessed_mine"],
+	"players_pc": [
+		"turned_on", "what_do_you_want", "what_to_deposit", "deposit_how_many",
+		"item_was_stored", "nothing_to_deposit", "no_room_to_store",
+		"what_to_withdraw", "withdraw_how_many", "withdrew_item", "nothing_stored",
+		"cant_carry_more", "what_to_toss", "toss_how_many",
+	],
+	"bills_pc": [
+		"switch_on", "what", "mon_was_stored", "cant_deposit_last", "box_full",
+		"mon_is_taken_out", "no_mon", "cant_take_mon",
+	],
+	"bills_pc_2": ["once_released", "mon_was_released"],
+	"oaks_pc": ["get_rated", "closed", "accessed"],
+	"hof_pc": ["accessed"],
+	"change_box": ["warning"],
+	"choose_box": ["choose"],
+}
+## `DisplayPCMainMenu` before the Pokedex, after it, and once `wNumHoFTeams` is
+## not zero.
+const GEN1_TOP_MENU_ROWS: Array[int] = [3, 4, 5]
+## A box with nothing in it refuses a withdrawal and a release and takes a
+## deposit, the development save's party being six.
+const GEN1_EMPTY_BOX_REFUSALS: Array[StringName] = [&"", &"no_mon", &"no_mon"]
+
 
 func run(r: RefCounted) -> void:
 	_r = r
@@ -51,6 +77,85 @@ func run(r: RefCounted) -> void:
 		_verify_graphics(game_id, data)
 		_verify_cursor(game_id, Gen2PCBoxPage.from_data(data))
 		_verify_info_column(game_id, data)
+	r.each_game_of(RomRegistry.GEN1, _verify_gen1)
+
+
+## Generation 1's three machines: every box `ActivatePC`, `PlayerPC`, `BillsPC_`,
+## `OpenOaksPC` and `ChangeBox` print, `DexRatingsTable` whole, and the menus
+## and refusals the three read.
+func _verify_gen1() -> void:
+	var data: GameData = _r.data
+	for run_name: String in GEN1_TEXT_RUNS:
+		for slot: String in GEN1_TEXT_RUNS[run_name] as Array:
+			_r.check(not data.special_text(run_name, slot).is_empty(),
+				"%s's %s box is empty." % [run_name, slot])
+	_verify_gen1_ratings(data)
+	_verify_gen1_menus(data)
+	_r.check(Gen2StatsScreenPage.from_data(data) != null,
+		"StatusScreen has no tile page.")
+
+
+## `DexRatingsTable`, and `DisplayDexRating`'s `cp b / jr c`: a row answers for
+## the counts under its own threshold, so 9 owned takes the first row and 10
+## takes the second.
+func _verify_gen1_ratings(data: GameData) -> void:
+	var rows: Array = data.oak_ratings()
+	if not _r.check(rows.size() == Gen1Layout.DEX_RATING_ROWS,
+		"%d rating rows." % rows.size()):
+		return
+	for index: int in rows.size():
+		var row: Dictionary = rows[index]
+		_r.check(not String(row.get("text", "")).is_empty(),
+			"rating row %d has no text." % index)
+	for caught: int in [0, 9, 10, 149, 151]:
+		var wanted: int = 0
+		for index: int in rows.size():
+			if caught < int((rows[index] as Dictionary)["threshold"]):
+				wanted = index
+				break
+		_r.check(
+			Gen2ProfOaksPC.rating_for(data, caught) == rows[wanted],
+			"%d owned did not land on row %d." % [caught, wanted]
+		)
+	_r.check(not data.oak_pc_text("counts").is_empty(),
+		"DexCompletionText is empty.")
+
+
+## `DisplayPCMainMenu`'s list, which grows with the Pokedex and again with
+## `wNumHoFTeams`, and `BillsPCDeposit`, `BillsPCWithdraw` and `BillsPCRelease`'s
+## own refusals.
+func _verify_gen1_menus(data: GameData) -> void:
+	var state := Gen2WorldState.new()
+	var rows: Array[int] = []
+	for open_dex: bool in [false, true]:
+		state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, open_dex)
+		rows.append(Gen2WorldPC.gen1_top_menu(state, "RED").size())
+	state.set_hall_of_fame(true)
+	rows.append(Gen2WorldPC.gen1_top_menu(state, "RED").size())
+	_r.check(rows == GEN1_TOP_MENU_ROWS,
+		"the machine's menu reads %s." % [rows])
+	var items: int = Gen2WorldPC.gen1_players_pc_menu().size()
+	var boxes: int = Gen2WorldPC.gen1_bills_pc_menu().size()
+	_r.check(
+		items == Gen2WorldPC.GEN1_PLAYERS_PC_ROWS.size()
+			and boxes == Gen2WorldPC.GEN1_BILLS_PC_ROWS.size(),
+		"the item menu reads %d rows and the box menu %d." % [items, boxes]
+	)
+	_r.check(
+		Gen2WorldPC.gen1_box_menu(null).size() == Gen1Layout.BOX_COUNT,
+		"the box picker is not twelve rows."
+	)
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(data, 0)
+	if not _r.check(save != null, "no development save."):
+		return
+	var refusals: Array[StringName] = []
+	for row: int in [
+		Gen2WorldPC.GEN1_BILLS_PC_DEPOSIT, Gen2WorldPC.GEN1_BILLS_PC_WITHDRAW,
+		Gen2WorldPC.GEN1_BILLS_PC_RELEASE,
+	]:
+		refusals.append(Gen2WorldPC.gen1_bills_pc_refusal(save, row, 0))
+	_r.check(refusals == GEN1_EMPTY_BOX_REFUSALS,
+		"an empty box refused with %s." % [refusals])
 
 
 ## `BillsPC_InitGFX`'s two sheets and the palette `_CGB_BillsPC` loads over the

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -62,9 +62,9 @@ const KIND_HELP: Dictionary = {
 	&"gift_nickname": "presses, species: GiveANickname_YesNo. 1 the question, 2 the WasSentToBillsPCText behind NO; add 1000 for the box branch",
 	&"unown_printer": "slot, page: _UnownPrinter's browser. Slot 26 is the vacant one; page 1 is what A sends to a printer that is not there",
 	&"diploma": "loop, page: _Diploma's page. 1 stands _PrintDiploma's connection error over it; page 2 needs a printer that answered",
-	&"bills_pc": "rows down, A presses: _BillsPC's top menu and the lists behind it",
-	&"players_pc": "rows down, A presses: the bedroom's item PC",
-	&"pokemon_center_pc": "rows down, A presses: the Pokemon Center's machine",
+	&"bills_pc": "rows down, A presses: _BillsPC's top menu and the lists behind it, or BillsPC_ on a Generation 1 cartridge. @d,0 is a second run of rows down, spent before the last press",
+	&"players_pc": "rows down, A presses: the bedroom's item PC, or PlayerPC on a Generation 1 cartridge",
+	&"pokemon_center_pc": "rows down, A presses: the Pokemon Center's machine, or ActivatePC on a Generation 1 cartridge",
 	&"mom_bank": "wallet, balance, both in hundreds: Mom_WithdrawDepositMenuJoypad's dial. Add 1000 for the WITHDRAW header",
 	&"move_tutor": "presses: special MoveTutor. 0 is ChooseMonToLearnTMHM's list, not a box",
 	&"day_care": "presses, routine: 0 the man, 1 the lady, 2 the man outside, 3 and 4 the two signs",
@@ -1179,13 +1179,22 @@ func _generation() -> int:
 	return data.generation if data != null else RomRegistry.GEN2
 
 
+## `@d,0` is a second run of DOWN presses, spent before the last A: a Generation
+## 1 machine's menus are two deep and one number cannot reach both.
 func _stage_pc() -> void:
 	_screen.call(SCREEN_DRIVER % _kind)
-	for _down: int in maxi(_cell.x, 0):
-		_screen.press_button(PokeButton.DOWN)
-		_screen.advance_frame()
-	for _press: int in maxi(_cell.y, 0):
+	var presses: int = maxi(_cell.y, 0)
+	_press_rows(maxi(_cell.x, 0))
+	for press: int in presses:
+		if press == presses - 1:
+			_press_rows(maxi(_kind_cell.x, 0))
 		_screen.press_button(PokeButton.A)
+		_screen.advance_frame()
+
+
+func _press_rows(rows: int) -> void:
+	for _down: int in rows:
+		_screen.press_button(PokeButton.DOWN)
 		_screen.advance_frame()
 
 


### PR DESCRIPTION
`TextScript_PokemonCenterPC`, `TextScript_ItemStoragePC` and `TextScript_BillsPC` are the last three `TX_SCRIPT_*` ids `DisplayTextID` dispatches. The 21 hidden-object rows on Red and Blue and 17 on Yellow that stand at one now open a machine over the map.

## Added

- `ActivatePC`'s top menu, whose list grows with the Pokedex and again with `wNumHoFTeams`. `BIT_USING_GENERIC_PC` decides both a machine's own boot line and whether its B steps back to the top menu or leaves.
- `PlayerPC`: `DisplayListMenuID`'s framed list with `DisplayChooseQuantityMenu`'s dial over it, `TossItem_`'s key-item refusal and its question behind TOSS, and `AddItemToInventory`'s two refusals.
- `BillsPC_`: the same list over `wPartyCount` or `wBoxCount`, `DisplayDepositWithdrawMenu` over the speech box, `ChangeBox`'s twelve names with a pokeball beside each box that holds something, and the save's own atomic moves behind DEPOSIT, WITHDRAW and RELEASE.
- `OpenOaksPC`, which prints `DexRatingsTable`'s row for the owned count. `DisplayDexRating`'s `cp b / jr c` matches under a threshold where `FindOakRating` matches at it.
- `StatusScreen` and `StatusScreen2` beside Crystal's three pages, on a tile page that scatters `BattleHudTiles2` to $78 and `BattleHudTiles3` to $76 where a battle copies both to $73, with `PTile`'s bold P at $72.
- `tools/checks/pc.gd` sweeps every imported box, the sixteen rating rows and the three menus on all three cartridges. `gen1_walk.gd` opens the Pokemon Center's machine and the bedroom's and is refused from beside one.

## Fixed

- The party menu's STATS row opened nothing on a Generation 1 cartridge: `Gen2BattleTiles.stats_page` reads four sheets no such cache holds, so the page was never built.
- Every Generation 1 special type read as nameless. `GameData.type_name` indexed the cached rows by position where the numbering skips $09 to $13.
- A `<PARA>` or a `<CONT>` inside a PC box was dropped with the rest of its tail rather than held for its own press.
- `Gen2Font.draw_code` took the battle-extra strip's slot from Crystal's $60 on a cartridge whose own load lands at $62.

## Changed

- Five copies of one nickname rule are now `Gen2SaveMon.display_name`, and `_service_box` and `handle_button` are lookup tables rather than forty arms.