### PR TITLE
Name what a refused mod archive holds

### DIFF
--- a/docs/MODS.md
+++ b/docs/MODS.md
@@ -148,11 +148,14 @@ voxel_preview.zip
     mod.gd
 ```
 
-An archive is refused whole if it has no `mod.json`, holds more than one mod
-folder, declares an `api_version` this host does not answer, or names a path that
-would write outside its own folder. Nothing is written until all of that passes,
-so a refusal leaves what is installed untouched. Reimporting a mod that is present
-asks first, and replacing one removes files the new version dropped.
+An archive is refused whole if it has no `mod.json`, holds more than one folder
+with a `mod.json` in it, declares an `api_version` this host does not answer, or
+names a path that would write outside its own folder. A folder holding no
+manifest is not a mod, so it is neither counted nor extracted; the `__MACOSX`
+tree a macOS zip carries is passed over on both counts. Nothing is written until
+all of that passes, so a refusal leaves what is installed untouched. Reimporting
+a mod that is present asks first, and replacing one removes files the new version
+dropped.
 
 An installed mod loads immediately, without a restart. So does a change to the
 list: switching one on or off, deleting one, or choosing a different cartridge

--- a/game/mods/mod_installer.gd
+++ b/game/mods/mod_installer.gd
@@ -4,37 +4,34 @@ extends RefCounted
 ## Installs a mod from a `.zip` into [constant Gen2ModHost.ROOT]. The only way a
 ## mod gets onto disk, whichever way the player found it: a file they picked, one
 ## they dropped on the window, or one downloaded from an index. So a listing buys
-## a mod no trust picking the same file by hand would not. Nothing is written
-## until the archive is opened, its layout resolved and its manifest validated,
-## and a copy that fails part way removes what it wrote.
+## a mod no trust picking the same file by hand would not.
 
-## A single mod's uncompressed size. Well above the voxel example and far below
-## anything that fills a phone, so a hostile or broken archive stops here rather
-## than at the filesystem.
+## A single mod's uncompressed size. Above the voxel example and far below what
+## fills a phone, so a broken archive stops here rather than at the filesystem.
 const MAX_UNCOMPRESSED_BYTES: int = 64 * 1024 * 1024
 ## Refuses an archive that would take longer to unpack than a player will wait.
 const MAX_ENTRIES: int = 2048
-## Local PK magic. An AppleDouble sidecar or a truncated download is not a zip,
-## and saying so beats an opaque failure from the reader.
+## Local PK magic. A sidecar or a truncated download is not a zip, and saying so
+## beats an opaque failure from the reader.
 const ZIP_MAGIC: Array[int] = [0x50, 0x4B]
+## The tree macOS zips beside what was selected. It belongs to no mod.
+const MACOS_SIDECAR: String = "__MACOSX"
 
 
-## Where a staged download is written before it is opened. [ZIPReader] only
-## takes a path, so bytes from the network become a file first.
+## Where a staged download lands: [ZIPReader] takes a path, so bytes from the
+## network become a file first.
 static func staging_path() -> String:
 	return "user://mod_import_staging.zip"
 
 
-## The prefix inside [param paths] that holds the manifest.
+## The prefix inside [param paths] that holds the manifest, as { ok, prefix }.
 ##
-## Returns { ok, prefix } with an empty prefix when the manifest is at the
-## archive root, or the single top-level directory that holds it. Anything else
-## is refused: two mods in one archive have no obvious winner, and an archive
-## with no manifest is not a mod. Pure, so the layout rule is testable without
-## an archive on disk.
+## Empty when the manifest is at the archive root, else the one top-level folder
+## holding one. A folder holding none is not a mod and does not count, which is
+## what macOS zips beside the mod; two that do are refused. Pure, so the rule is
+## testable without an archive.
 static func locate_root(paths: PackedStringArray) -> Dictionary:
-	var top_directories: Array[String] = []
-	var holds_manifest: Dictionary = {}
+	var holds_manifest: Array[String] = []
 	for path: String in paths:
 		if path == PokeModManifest.FILENAME:
 			return {"ok": true, "prefix": ""}
@@ -42,23 +39,46 @@ static func locate_root(paths: PackedStringArray) -> Dictionary:
 		if separator <= 0:
 			continue
 		var top: String = path.substr(0, separator)
-		var rest: String = path.substr(separator + 1)
-		if not top_directories.has(top):
-			top_directories.append(top)
-		if rest == PokeModManifest.FILENAME:
-			holds_manifest[top] = true
-	if top_directories.size() == 1 and holds_manifest.has(top_directories[0]):
-		return {"ok": true, "prefix": top_directories[0]}
-	if top_directories.size() > 1:
-		return {"ok": false, "reason": &"archive_holds_more_than_one_folder"}
-	return {"ok": false, "reason": &"archive_has_no_manifest"}
+		if path.substr(separator + 1) == PokeModManifest.FILENAME \
+			and not holds_manifest.has(top):
+			holds_manifest.append(top)
+	if holds_manifest.size() == 1:
+		return {"ok": true, "prefix": holds_manifest[0]}
+	if holds_manifest.size() > 1:
+		return {
+			"ok": false,
+			"reason": &"archive_holds_more_than_one_folder",
+			"detail": ", ".join(holds_manifest),
+		}
+	return {
+		"ok": false, "reason": &"archive_has_no_manifest", "detail": _manifests_found(paths)
+	}
+
+
+## The JSON filenames where a manifest would be. A foreign mod carries one under
+## its own name, and saying which beats saying only that mod.json is missing.
+static func _manifests_found(paths: PackedStringArray) -> String:
+	var found: Array[String] = []
+	for path: String in paths:
+		var name: String = path.get_file()
+		if name.ends_with(".json") and path.count("/") <= 1 and not found.has(name):
+			found.append(name)
+	found.sort()
+	return ", ".join(found)
+
+
+## True when [param entry] is part of the mod at [param prefix]; anything else is
+## passed over rather than written.
+static func belongs_to_mod(entry: String, prefix: String) -> bool:
+	if entry.begins_with("%s/" % MACOS_SIDECAR):
+		return false
+	return prefix.is_empty() or entry.begins_with("%s/" % prefix)
 
 
 ## True when [param entry] stays inside the mod directory once [param prefix] is
 ## removed. A zip may name any path it likes, including one that climbs out with
-## `..` or starts at the filesystem root, and extracting that would write
-## wherever it pointed. The manifest's own entry check refuses the same shapes;
-## this refuses them one layer earlier, before anything is read.
+## `..` or starts at the filesystem root. The manifest's own entry check refuses
+## the same shapes; this refuses them earlier, before anything is read.
 static func is_safe_entry(entry: String, prefix: String) -> bool:
 	var relative: String = entry
 	if not prefix.is_empty():
@@ -78,9 +98,9 @@ static func is_safe_entry(entry: String, prefix: String) -> bool:
 ## Installs the archive at [param path].
 ##
 ## [param replace] allows an already-installed id to be overwritten, which an
-## update does and a first install does not. [param expect_id] refuses an
-## archive whose manifest names a different mod, so a download resolved from an
-## index cannot quietly deliver something else.
+## update does and a first install does not. [param expect_id] refuses an archive
+## whose manifest names a different mod, so a download resolved from an index
+## cannot quietly deliver something else.
 static func install_zip(
 	path: String,
 	replace: bool = false,
@@ -103,7 +123,10 @@ static func install_zip(
 	var located: Dictionary = locate_root(entries)
 	if not bool(located.get("ok", false)):
 		reader.close()
-		return _refuse(StringName(located.get("reason", &"archive_has_no_manifest")), path)
+		return _refuse(
+			StringName(located.get("reason", &"archive_has_no_manifest")),
+			String(located.get("detail", "")),
+		)
 	var prefix: String = String(located["prefix"])
 
 	var manifest_entry: String = PokeModManifest.FILENAME
@@ -132,25 +155,16 @@ static func install_zip(
 		reader.close()
 		return _refuse(&"already_installed", String(manifest.id))
 
-	var planned: Array[String] = []
-	var total: int = 0
-	for entry: String in entries:
-		if entry.ends_with("/"):
-			continue
-		if not is_safe_entry(entry, prefix):
-			reader.close()
-			return _refuse(&"unsafe_archive_entry", entry)
-		total += reader.read_file(entry).size()
-		if total > MAX_UNCOMPRESSED_BYTES:
-			reader.close()
-			return _refuse(&"archive_too_large", str(total))
-		planned.append(entry)
+	var plan: Dictionary = _plan(reader, entries, prefix)
+	if not bool(plan.get("ok", false)):
+		reader.close()
+		return plan
+	var planned: Array[String] = plan["planned"]
 	if planned.is_empty():
 		reader.close()
 		return _refuse(&"archive_is_empty", path)
 
-	# Only now is anything written. An existing tree is removed first so a
-	# replaced mod cannot keep a file the new version dropped.
+	# Only now is anything written, the old tree first so no dropped file survives.
 	if existed:
 		_remove_tree(destination)
 	var written: Dictionary = _extract(reader, planned, prefix, destination)
@@ -169,9 +183,24 @@ static func install_zip(
 	}
 
 
+## The members to write, as { ok, planned }.
+static func _plan(reader: ZIPReader, entries: PackedStringArray, prefix: String) -> Dictionary:
+	var planned: Array[String] = []
+	var total: int = 0
+	for entry: String in entries:
+		if entry.ends_with("/") or not belongs_to_mod(entry, prefix):
+			continue
+		if not is_safe_entry(entry, prefix):
+			return _refuse(&"unsafe_archive_entry", entry)
+		total += reader.read_file(entry).size()
+		if total > MAX_UNCOMPRESSED_BYTES:
+			return _refuse(&"archive_too_large", str(total))
+		planned.append(entry)
+	return {"ok": true, "planned": planned}
+
+
 ## Installs [param bytes], staging them where [ZIPReader] can open them. The
-## staging file is removed whatever the outcome, so a failed download leaves
-## nothing behind.
+## staging file is removed whatever the outcome, so a failed download leaves none.
 static func install_bytes(
 	bytes: PackedByteArray,
 	replace: bool = false,
@@ -195,9 +224,8 @@ static func uninstall(id: StringName, root: String = Gen2ModHost.ROOT) -> Dictio
 	if String(id).is_empty():
 		return _refuse(&"invalid_id", String(id))
 	var directory: String = "%s/%s" % [root, id]
-	# Drop any off switch and any stored settings with the mod itself, so
-	# reinstalling it later does not find it silently disabled, or configured, by
-	# a decision about a mod that no longer exists.
+	# Drop any off switch and any stored settings with the mod, so reinstalling it
+	# does not find it silently disabled by a decision about a mod that is gone.
 	Gen2ModState.forget(id)
 	PokeModOptions.forget(id)
 	if not DirAccess.dir_exists_absolute(directory):

--- a/game/mods/mod_manifest.gd
+++ b/game/mods/mod_manifest.gd
@@ -75,7 +75,12 @@ static func from_dictionary(source: Dictionary, folder: String) -> Dictionary:
 	manifest.id = StringName(String(source.get("id", "")))
 	manifest.name = String(source.get("name", String(manifest.id)))
 	manifest.version = String(source.get("version", ""))
-	manifest.api_version = int(source.get("api_version", 0))
+	# A number, never coerced: a manifest naming the field something else read as
+	# 0 and was refused for declaring 0, a number no file held.
+	var raw_api: Variant = source.get("api_version")
+	if not (raw_api is int or raw_api is float):
+		return _refuse(&"missing_api_version", FILENAME)
+	manifest.api_version = int(raw_api)
 	manifest.entry = String(source.get("entry", ""))
 	manifest.pack = String(source.get("pack", ""))
 	manifest.description = String(source.get("description", ""))

--- a/game/mods/mod_refusal.gd
+++ b/game/mods/mod_refusal.gd
@@ -16,7 +16,7 @@ const WORDING: Dictionary = {
 	&"archive_not_found": "%s could not be read.",
 	&"archive_unreadable": "That archive could not be opened.",
 	&"archive_is_empty": "That archive is empty.",
-	&"archive_holds_more_than_one_folder": "The archive must hold a single mod folder.",
+	&"archive_holds_more_than_one_folder": "The archive must hold a single mod folder (%s).",
 	&"archive_too_large": "That archive is too large to be a mod.",
 	&"archive_too_many_entries": "That archive is too large to be a mod.",
 	&"unsafe_archive_entry": "The archive tries to write outside the mod folder (%s).",
@@ -24,6 +24,7 @@ const WORDING: Dictionary = {
 	&"missing_manifest": "The mod has no %s.",
 	&"unreadable_manifest": "The mod's %s could not be read.",
 	&"invalid_manifest": "The mod's %s is not valid JSON.",
+	&"missing_api_version": "The mod's %s names no api_version.",
 	&"invalid_id": "\"%s\" is not a usable mod id.",
 	&"invalid_mod_version": "\"%s\" is not a semantic mod version.",
 	&"invalid_dependencies": "%s's dependencies must be an id-to-range object.",
@@ -155,10 +156,13 @@ static func text(result: Dictionary) -> String:
 		# than the whole path, and a version this build can name itself.
 		&"not_a_zip", &"archive_not_found":
 			detail = detail.get_file()
-		&"archive_has_no_manifest", &"missing_manifest", &"unreadable_manifest", \
-		&"invalid_manifest":
+		&"missing_manifest", &"unreadable_manifest", &"invalid_manifest":
 			# The detail is a path; the filename is what a player recognises.
 			detail = PokeModManifest.FILENAME
+		&"archive_has_no_manifest":
+			if detail.is_empty():
+				return "The archive has no %s." % PokeModManifest.FILENAME
+			return "The archive has no %s; it holds %s." % [PokeModManifest.FILENAME, detail]
 		&"unsupported_api_version":
 			# The detail already names both versions.
 			return "That mod needs a newer build of the game: %s." % detail

--- a/tests/unit/test_mods.gd
+++ b/tests/unit/test_mods.gd
@@ -123,6 +123,22 @@ func test_a_manifest_built_for_another_host_is_refused() -> void:
 	assert_eq(PokeModManifest.read(_directory)["reason"], &"mod_is_too_old")
 
 
+## A manifest naming the field something else read as 0 and was then refused for
+## declaring 0, which named a number no file held.
+func test_a_manifest_declaring_no_api_version_is_refused_by_the_missing_field() -> void:
+	var source: Dictionary = _valid_manifest()
+	source.erase("api_version")
+	source["api"] = 2
+	var missing: Dictionary = PokeModManifest.from_dictionary(source, _directory)
+	assert_eq(missing["reason"], &"missing_api_version")
+	assert_string_contains(PokeModRefusal.text(missing), "api_version")
+
+	source["api_version"] = "thirty"
+	assert_eq(
+		PokeModManifest.from_dictionary(source, _directory)["reason"], &"missing_api_version"
+	)
+
+
 func test_manifest_versions_and_dependency_ranges_are_validated_before_code_runs() -> void:
 	var source: Dictionary = _valid_manifest()
 	source["version"] = "one"
@@ -896,12 +912,61 @@ func test_locate_root_refuses_an_archive_without_exactly_one_mod() -> void:
 	)
 	assert_false(two["ok"])
 	assert_eq(two["reason"], &"archive_holds_more_than_one_folder")
+	assert_eq(two["detail"], "a, b")
 
 	var none: Dictionary = Gen2ModInstaller.locate_root(
 		PackedStringArray(["voxel/renderer.gd"])
 	)
 	assert_false(none["ok"])
 	assert_eq(none["reason"], &"archive_has_no_manifest")
+
+
+## A folder holding no manifest is not a mod, so a sidecar tree beside the mod
+## is not a second one and nothing in it is written.
+func test_locate_root_passes_over_a_folder_that_holds_no_manifest() -> void:
+	assert_eq(Gen2ModInstaller.locate_root(PackedStringArray([
+		"voxel/mod.json", "voxel/mod.gd", "__MACOSX/voxel/._mod.json",
+	]))["prefix"], "voxel")
+	assert_false(Gen2ModInstaller.belongs_to_mod("__MACOSX/voxel/._mod.json", "voxel"))
+	assert_false(Gen2ModInstaller.belongs_to_mod("__MACOSX/._mod.json", ""))
+	assert_true(Gen2ModInstaller.belongs_to_mod("voxel/mod.gd", "voxel"))
+	assert_true(Gen2ModInstaller.belongs_to_mod("extra/notes.txt", ""))
+
+
+## A mod built for another project carries its own manifest under its own name.
+## Saying only "no mod.json" sent one author editing files nothing reads.
+func test_an_archive_with_no_manifest_names_what_it_holds_instead() -> void:
+	var foreign: Dictionary = Gen2ModInstaller.locate_root(PackedStringArray([
+		"fr_crystal/manifest.json", "fr_crystal/main.lua", "fr_crystal/.modkit/pack.json",
+	]))
+	assert_eq(foreign["reason"], &"archive_has_no_manifest")
+	assert_eq(foreign["detail"], "manifest.json")
+	assert_string_contains(PokeModRefusal.text(foreign), "manifest.json")
+	assert_string_contains(PokeModRefusal.text(foreign), PokeModManifest.FILENAME)
+
+	var bare: Dictionary = Gen2ModInstaller.locate_root(PackedStringArray(["voxel/mod.gd"]))
+	assert_eq(String(bare["detail"]), "")
+	assert_eq(PokeModRefusal.text(bare), "The archive has no mod.json.")
+
+
+## The whole chain a mod built for another project takes, since the installer
+## carries the layout refusal's own detail rather than the archive path.
+func test_a_mod_built_for_another_project_is_refused_by_what_it_carries() -> void:
+	var archive: String = "%s/foreign.zip" % ROOT
+	DirAccess.make_dir_recursive_absolute(ROOT)
+	_write_zip(archive, {
+		"fr_crystal/manifest.json": JSON.stringify({
+			"id": "fr_crystal", "name": "French", "version": "1.1.0",
+			"api": 2, "entry": "main.lua", "dependencies": [],
+		}),
+		"fr_crystal/main.lua": "return {}",
+	})
+	var refused: Dictionary = Gen2ModInstaller.install_zip(archive, false, &"", ROOT)
+	assert_eq(refused["reason"], &"archive_has_no_manifest")
+	assert_eq(
+		PokeModRefusal.text(refused), "The archive has no mod.json; it holds manifest.json."
+	)
+	assert_false(DirAccess.dir_exists_absolute("%s/fr_crystal" % ROOT))
 
 
 func test_is_safe_entry_refuses_paths_that_leave_the_mod_directory() -> void:
@@ -913,6 +978,21 @@ func test_is_safe_entry_refuses_paths_that_leave_the_mod_directory() -> void:
 	assert_false(Gen2ModInstaller.is_safe_entry("/etc/passwd", ""))
 	assert_false(Gen2ModInstaller.is_safe_entry("user://evil.gd", ""))
 	assert_false(Gen2ModInstaller.is_safe_entry("other/mod.gd", "voxel"))
+
+
+## The sidecar a macOS zip carries is not extracted, so a mod zipped that way
+## installs with its own files and nothing else.
+func test_installing_a_zip_made_on_macos_passes_over_its_sidecar() -> void:
+	var archive: String = "%s/import.zip" % ROOT
+	DirAccess.make_dir_recursive_absolute(ROOT)
+	var entries: Dictionary = _mod_zip_entries("packaged")
+	entries["__MACOSX/packaged/._mod.json"] = "sidecar"
+	_write_zip(archive, entries)
+
+	var result: Dictionary = Gen2ModInstaller.install_zip(archive, false, &"", ROOT)
+	assert_true(result["ok"], JSON.stringify(result))
+	assert_eq(int(result["files"]), 3)
+	assert_false(DirAccess.dir_exists_absolute("%s/packaged/__MACOSX" % ROOT))
 
 
 func test_installing_a_zip_writes_the_mod_and_the_host_then_loads_it() -> void:


### PR DESCRIPTION
Issue #575 installed a mod built for another project and was told the mod declared an api_version of 0. No file held a 0. The reader had defaulted the field it never found, and the installer had reported "no mod.json" without saying it had found a `manifest.json` sitting where one goes, so the author edited `api`, got the same 0 back, and concluded the host was reading a `.modkit/pack.json` nothing opens.

## Fixed

- `locate_root` carries the JSON filenames sitting where a manifest would be, and `PokeModRefusal` prints them: "The archive has no mod.json; it holds manifest.json."
- A manifest whose `api_version` is absent, or is not a number, is refused as `missing_api_version` rather than coerced to 0 and refused for being too old.
- `archive_holds_more_than_one_folder` names the folders it found.
- `install_zip` passed the archive path as the layout refusal's detail, discarding whatever `locate_root` had to say.
- A top-level folder holding no manifest was counted as a second mod, so a `.zip` made on macOS was refused whole for the `__MACOSX` sidecar beside the mod folder. It holds no `mod.json`, so it is now neither counted nor extracted.

`install_zip`'s planning loop is `_plan`; the extra branch put it at 21 against the ceiling of 20.

## Proving it

| Check | Result |
|---|---|
| `test_mods` | 101 passing, 537 asserts |
| Unit tier | 3832 passing, 92618 asserts |
| `release.sh --gates` | pass, comments 40379 of 40379 |
| Warning scan over `game tools tests autoload mods` | 0 warnings in 632 scripts |

Four cases are pinned: a gen1recomp-shaped archive refused end to end through `install_zip` with its exact message, a manifest declaring `api` rather than `api_version`, a manifest whose `api_version` is a string, and a macOS zip installing its three files with the sidecar left out.