### PR TITLE
Open a Silph Co. card key door

### DIFF
--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -181,6 +181,7 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"change_box": ["change_box_text", Gen1Layout.CHANGE_BOX_TEXT_AT],
 	"choose_box": ["choose_box_text", Gen1Layout.CHOOSE_BOX_TEXT_AT],
 }
+const CARD_KEY_TEXT_NAMES: Array[String] = ["card_key_success", "card_key_fail"]
 
 
 static func verify_layout(rom: RomFile) -> Dictionary:
@@ -1070,6 +1071,17 @@ func _import_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 			)
 		out[run] = boxes
 	out["npc_trade"] = _import_trade_text(rom, layout)
+	out["card_key"] = _import_card_key_text(rom, layout)
+	return out
+
+
+## `PrintCardKeyText`'s two boxes. `PrintPredefTextID` reads a row in the bank of
+## the routine that named it, and `SilphCoMapList` stands in that bank.
+func _import_card_key_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var bank: int = RomFile.bank_of(int(layout["silph_map_list"]))
+	var out: Dictionary = {}
+	for name: String in CARD_KEY_TEXT_NAMES:
+		out[name] = Gen1WorldImporter.predef_text(rom, layout, bank, name)
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -316,6 +316,7 @@ const ITEM_ESCAPE_ROPE: int = 0x1D
 ## `IsItemInBag COIN_CASE`, which `CeladonPrizeMenu` opens on.
 const ITEM_COIN_CASE: int = 0x45
 const ITEM_COIN: int = 0x3B
+const ITEM_CARD_KEY: int = 0x30
 const ITEM_ITEMFINDER: int = 0x47
 const ITEM_TOWN_MAP: int = 0x05
 const ITEM_POKEDEX: int = 0x09
@@ -790,6 +791,23 @@ const SCRIPT_HRAM_BASE: int = 0xFF00
 const MAP_SCRIPT_BYTES: int = 0x7A
 ## How deep a `call` to a routine the layout does not name may nest.
 const SCRIPT_CALL_DEPTH: int = 2
+const SCRIPT_PUSH_AF: int = 0xF5
+const SCRIPT_POP_AF: int = 0xF1
+const SCRIPT_STACK_HL: Array[int] = [0xE5, 0xE1]
+## The opcode following a map-load gate, `size` its own length and `target`
+## whether the body is where it branches rather than the byte after it.
+const MAP_LOAD_GATE_BRANCHES: Dictionary = {
+	0xC8: {"size": 1, "target": false},
+	0x28: {"size": 2, "target": false},
+	0x20: {"size": 2, "target": true},
+	0xCA: {"size": 3, "target": false},
+	0xC2: {"size": 3, "target": true},
+	0xCC: {"size": 3, "target": false},
+	0xC4: {"size": 3, "target": true},
+}
+## A `dbmapcoord` list: `db y, x` rows under a terminator.
+const MAP_COORD_END: int = 0xFF
+const MAP_COORD_SIZE: int = 2
 ## Each key is a conditional `jr` or `jp`, the value whether it is taken when
 ## the tested bit was set; the carry rows read the flag a routine answers in.
 const SCRIPT_BRANCHES: Dictionary = {0x20: true, 0xC2: true, 0x28: false, 0xCA: false}
@@ -821,15 +839,27 @@ const TEXT_PREDEF_COUNT: int = 66
 const TEXT_PREDEF_COUNT_YELLOW: int = 68
 const TEXT_PREDEF_SIZE: int = 2
 const TEXT_PREDEFS: Dictionary = {
+	"card_key_success": 0x01, "card_key_fail": 0x02,
 	"gym_statue": 0x0C, "gym_statue_badge": 0x0D, "found_hidden_item": 0x24,
 	"hidden_item_bag_full": 0x25, "found_hidden_coins": 0x2B,
 	"dropped_hidden_coins": 0x2C,
 }
 const TEXT_PREDEFS_YELLOW: Dictionary = {
+	"card_key_success": 0x01, "card_key_fail": 0x02,
 	"gym_statue": 0x0E, "gym_statue_badge": 0x0F, "found_hidden_item": 0x26,
 	"hidden_item_bag_full": 0x27, "found_hidden_coins": 0x2D,
 	"dropped_hidden_coins": 0x2E,
 }
+## `PrintCardKeyText`: a Silph Co. door draws either of two tiles, the top
+## floor's own a third, and the block that opens one is $0E under it and $03
+## there. SILPH_CO_11F is the one floor the routine names by number.
+const CARD_KEY_DOOR_TILES: Array[int] = [0x18, 0x24]
+const CARD_KEY_TOP_FLOOR_TILE: int = 0x5E
+const CARD_KEY_OPEN_BLOCK: int = 0x0E
+const CARD_KEY_TOP_FLOOR_BLOCK: int = 0x03
+const SILPH_CO_TOP_FLOOR: int = 0xEB
+## `SilphCoMapList`, ten floors under a terminator.
+const SILPH_MAP_LIST_MAX: int = 16
 ## The two packed-decimal buffers a price is written into, most significant
 ## byte first. `wPriceTemp` stands at `wWhichTrade`'s own address.
 const SCRIPT_BCD_BUFFERS: Array[String] = ["money_hram", "which_trade"]
@@ -849,6 +879,7 @@ const SCRIPT_HOP_LIMIT: int = 0x40
 const SCRIPT_BIT_BASE: int = 0x40
 const SCRIPT_RES_BASE: int = 0x80
 const SCRIPT_SET_BASE: int = 0xC0
+const SCRIPT_PREFIX_BLOCK: int = 0x40
 const SCRIPT_OPERAND_A: int = 7
 const SCRIPT_OPERAND_HL: int = 6
 ## `flag_array NUM_EVENTS`: 2,560 events on all three cartridges.
@@ -1175,6 +1206,13 @@ const RED_BLUE: Dictionary = {
 	"cur_party_species": 0xCF91,
 	"cur_map_script": 0xDA39,
 	"map_scripts": 0xD5F0,
+	## `ReplaceTileBlock` writes `wNewTileBlockID` at the block `bc` names, and
+	## `SilphCoMapList` is the ten floors `PrintCardKeyText` answers on.
+	"map_script_flags": 0xD126,
+	"new_tile_block": 0xD09F,
+	"replace_tile_block": 0x0EE9E,
+	"card_key_door": 0xD73F,
+	"silph_map_list": 0x526E3,
 	## `DoInGameTradeDialogue`, the trade table it indexes with `wWhichTrade`,
 	## `InGameTradeTextPointers` and the pair of boxes the swap itself prints.
 	"in_game_trade": 0x71AD9,
@@ -1349,6 +1387,11 @@ const YELLOW: Dictionary = {
 	"cur_party_species": 0xCF90,
 	"cur_map_script": 0xDA38,
 	"map_scripts": 0xD5EF,
+	"map_script_flags": 0xD125,
+	"new_tile_block": 0xD09E,
+	"replace_tile_block": 0x0ED1B,
+	"card_key_door": 0xD73E,
+	"silph_map_list": 0x52645,
 	"in_game_trade": 0x71B86,
 	"which_trade": 0xCD3D,
 	"trade_mons": 0x71C1D,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -13,6 +13,15 @@ const LIST_END: int = Gen1Layout.TILESET_LIST_END
 ## and `_GivePokemon`'s.
 const GIFT_OPS: Array[String] = ["give_item", "give_pokemon"]
 
+## The gate's own two prefixed opcodes, and how many `push hl` it may hold a
+## copy of `hl` through.
+const MAP_LOAD_PREFIXES: Array[int] = [
+	Gen1Layout.SCRIPT_BIT_BASE, Gen1Layout.SCRIPT_RES_BASE,
+]
+const MAP_LOAD_HELD_LIMIT: int = 4
+## `ld hl, .GateCoordinates` and the two card key calls behind it.
+const CARD_KEY_PROLOGUE_SIZE: int = 3 * Gen1Layout.SCRIPT_LONG_SIZE
+
 
 static func verify_layout(rom: RomFile) -> Dictionary:
 	var result: Dictionary = read_world(rom, Gen1Layout.for_id(rom.id))
@@ -118,11 +127,14 @@ static func read_world(
 		return overlap
 
 	var maps: Array = []
+	var card_key_floors: PackedByteArray = _read_list(
+		rom, int(layout["silph_map_list"]), Gen1Layout.SILPH_MAP_LIST_MAX
+	)
 	var map_count: int = Gen1Layout.map_count(rom.id)
 	for map_id: int in map_count:
 		if not Gen1Layout.is_real_map(map_id):
 			continue
-		var map: Dictionary = _read_map(rom, layout, tilesets, map_id)
+		var map: Dictionary = _read_map(rom, layout, tilesets, map_id, card_key_floors)
 		if not bool(map.get("ok", false)):
 			return map
 		map.erase("ok")
@@ -619,7 +631,8 @@ static func _bit_count(value: int) -> int:
 
 ## One map header, the blocks it draws and the object block behind it.
 static func _read_map(
-	rom: RomFile, layout: Dictionary, tilesets: Array, map_id: int
+	rom: RomFile, layout: Dictionary, tilesets: Array, map_id: int,
+	card_key_floors: PackedByteArray
 ) -> Dictionary:
 	var bank: int = Gen1Layout.map_bank(rom, layout, map_id)
 	var header: int = Gen1Layout.map_header_offset(rom, layout, map_id)
@@ -670,6 +683,9 @@ static func _read_map(
 	var texts: Array = _read_texts(rom, layout, bank, rom.u16le(header + 5), events)
 	_carry_trainer_headers(events["objects"], texts)
 	_carry_toggleable_objects(rom, layout, events["objects"], map_id)
+	var callback: Dictionary = _read_map_callback(
+		rom, layout, bank, rom.u16le(header + 7), card_key_floors.has(map_id)
+	)
 
 	return {
 		"ok": true,
@@ -690,7 +706,7 @@ static func _read_map(
 			"bank": bank,
 			"address": rom.u16le(header + 7),
 			"scenes": [],
-			"callbacks": [],
+			"callbacks": [] if callback.is_empty() else [callback],
 		},
 		"texts": texts,
 		"events": {
@@ -703,8 +719,130 @@ static func _read_map(
 			"hidden_events": _read_hidden_events(
 				rom, layout, map_id, bank, rom.u16le(header + 7)
 			),
+			"card_key": _card_key_doors(callback),
 		},
 	}
+
+
+## `RunMapScript` runs the whole of a map's script every frame, so the work a map
+## does once is the body behind a `wCurrentMapScriptFlags` bit. That body is
+## decoded the way a `text_asm` row is; the per-frame state machine
+## `CallFunctionInTable` dispatches is not read at all.
+static func _read_map_callback(
+	rom: RomFile, layout: Dictionary, bank: int, script: int, card_key: bool
+) -> Dictionary:
+	var body: int = _map_load_gate(rom, layout, bank, script)
+	if body < 0:
+		return {}
+	var coordinates: Array = _card_key_coordinates(rom, bank, body) if card_key else []
+	if not coordinates.is_empty():
+		body += CARD_KEY_PROLOGUE_SIZE
+	return {"nodes": decode_script(rom, layout, bank, body), "coordinates": coordinates}
+
+
+## The gate is the entry script's own opening or that of the routine its first
+## `call` names, where `AgathaShowOrHideExitBlock` keeps it.
+static func _map_load_gate(rom: RomFile, layout: Dictionary, bank: int, at: int) -> int:
+	var body: int = _map_load_body(rom, layout, bank, at)
+	if body >= 0:
+		return body
+	var entry: int = Gen1Layout.banked(bank, at)
+	if not rom.in_bounds(entry, Gen1Layout.SCRIPT_LONG_SIZE) \
+		or rom.u8(entry) != Gen1Layout.SCRIPT_CALL:
+		return -1
+	return _map_load_body(rom, layout, bank, rom.u16le(entry + 1))
+
+
+## `ld hl, wCurrentMapScriptFlags`, `bit`, `res` and the branch under them. -1
+## when the map opens on anything else.
+static func _map_load_body(rom: RomFile, layout: Dictionary, bank: int, at: int) -> int:
+	var pc: int = at
+	var opening: int = Gen1Layout.banked(bank, pc)
+	if not rom.in_bounds(opening, Gen1Layout.SCRIPT_LONG_SIZE) \
+		or rom.u8(opening) != Gen1Layout.SCRIPT_LD_HL \
+		or rom.u16le(opening + 1) != int(layout["map_script_flags"]):
+		return -1
+	pc += Gen1Layout.SCRIPT_LONG_SIZE
+	for base: int in MAP_LOAD_PREFIXES:
+		if not _map_load_prefixed(rom, bank, pc, base):
+			return -1
+		pc += Gen1Layout.SCRIPT_SHORT_SIZE
+	for held: int in MAP_LOAD_HELD_LIMIT:
+		if not Gen1Layout.SCRIPT_STACK_HL.has(rom.u8(Gen1Layout.banked(bank, pc))):
+			break
+		pc += 1
+	var branch: int = rom.u8(Gen1Layout.banked(bank, pc))
+	if not Gen1Layout.MAP_LOAD_GATE_BRANCHES.has(branch):
+		return -1
+	return _map_load_branch(rom, bank, pc, Gen1Layout.MAP_LOAD_GATE_BRANCHES[branch])
+
+
+static func _map_load_prefixed(rom: RomFile, bank: int, pc: int, base: int) -> bool:
+	var at: int = Gen1Layout.banked(bank, pc)
+	if not rom.in_bounds(at, Gen1Layout.SCRIPT_SHORT_SIZE) \
+		or rom.u8(at) != Gen1Layout.SCRIPT_PREFIX:
+		return false
+	var code: int = rom.u8(at + 1)
+	return code >= base and code < base + Gen1Layout.SCRIPT_PREFIX_BLOCK \
+		and (code & 7) == Gen1Layout.SCRIPT_OPERAND_HL
+
+
+static func _map_load_branch(rom: RomFile, bank: int, pc: int, row: Dictionary) -> int:
+	var size: int = int(row["size"])
+	if not bool(row["target"]):
+		return pc + size
+	var operand: int = Gen1Layout.banked(bank, pc) + 1
+	if size == Gen1Layout.SCRIPT_LONG_SIZE:
+		return rom.u16le(operand)
+	return pc + size + _script_hop(rom.u8(operand))
+
+
+## `SilphCo2F_SetCardKeyDoorYScript` walks the floor's own gate coordinates for
+## the door `PrintCardKeyText` last opened and `<Map>_UnlockedDoorEventScript`
+## turns that index into the door's own flag. Both loop over a table, which this
+## decoder does not, so the pair is read by hand and what the callback is walked
+## for is the blocks behind them.
+static func _card_key_coordinates(rom: RomFile, bank: int, at: int) -> Array:
+	var opening: int = Gen1Layout.banked(bank, at)
+	if not rom.in_bounds(opening, CARD_KEY_PROLOGUE_SIZE) \
+		or rom.u8(opening) != Gen1Layout.SCRIPT_LD_HL:
+		return []
+	for call_index: int in 2:
+		var call_at: int = opening + Gen1Layout.SCRIPT_LONG_SIZE * (call_index + 1)
+		if rom.u8(call_at) != Gen1Layout.SCRIPT_CALL:
+			return []
+	var list: int = Gen1Layout.banked(bank, rom.u16le(opening + 1))
+	var out: Array = []
+	while rom.in_bounds(list, Gen1Layout.MAP_COORD_SIZE) \
+		and rom.u8(list) != Gen1Layout.MAP_COORD_END:
+		out.append({"x": rom.u8(list + 1), "y": rom.u8(list)})
+		list += Gen1Layout.MAP_COORD_SIZE
+	return out
+
+
+## One card key door per gate coordinate: the block the callback puts back while
+## the door's own flag is clear, in the order
+## `<Map>_UnlockedDoorEventScript` numbers them.
+static func _card_key_doors(callback: Dictionary) -> Array:
+	if callback.is_empty() or (callback["coordinates"] as Array).is_empty():
+		return []
+	var doors: Array = []
+	_card_key_walk(callback["nodes"], doors)
+	return doors if doors.size() == (callback["coordinates"] as Array).size() else []
+
+
+static func _card_key_walk(nodes: Array, doors: Array) -> void:
+	for node: Dictionary in nodes:
+		if String(node["op"]) != "branch":
+			continue
+		for blocked: Dictionary in node["else"] as Array:
+			if String(blocked["op"]) != "replace_block":
+				continue
+			doors.append({
+				"x": int(blocked["x"]), "y": int(blocked["y"]),
+				"block": int(blocked["block"]), "flag": int(node["flag"]),
+			})
+		_card_key_walk(node["else"] as Array, doors)
 
 
 ## The tile every walk cell's passability is decided by; Generation 2's grid
@@ -1102,8 +1240,8 @@ static func _hidden_item_nodes(
 	if index < 0:
 		return []
 	var flag: int = Gen1Layout.engine_flag_base("obtained_hidden_items") + index
-	var found: String = _predef_text(rom, layout, bank, "found_hidden_item")
-	var full: String = _predef_text(rom, layout, bank, "hidden_item_bag_full")
+	var found: String = predef_text(rom, layout, bank, "found_hidden_item")
+	var full: String = predef_text(rom, layout, bank, "hidden_item_bag_full")
 	if found.is_empty() or full.is_empty():
 		return []
 	return [{"op": "branch", "flag": flag, "engine": true, "then": [], "else": [
@@ -1126,8 +1264,8 @@ static func _hidden_coin_nodes(
 	if index < 0:
 		return []
 	var flag: int = Gen1Layout.engine_flag_base("obtained_hidden_coins") + index
-	var found: String = _predef_text(rom, layout, bank, "found_hidden_coins")
-	var dropped: String = _predef_text(rom, layout, bank, "dropped_hidden_coins")
+	var found: String = predef_text(rom, layout, bank, "found_hidden_coins")
+	var dropped: String = predef_text(rom, layout, bank, "dropped_hidden_coins")
 	if found.is_empty() or dropped.is_empty():
 		return []
 	return [{"op": "has_item", "item": Gen1Layout.ITEM_COIN_CASE, "else": [], "then": [
@@ -1228,7 +1366,7 @@ static func _predef_pointer(rom: RomFile, layout: Dictionary, id: int) -> int:
 
 
 ## The string one [constant Gen1Layout.TEXT_PREDEFS] row prints.
-static func _predef_text(
+static func predef_text(
 	rom: RomFile, layout: Dictionary, bank: int, name: String
 ) -> String:
 	var decoded: Dictionary = Gen1Text.decode_stream(rom, Gen1Layout.banked(
@@ -1275,6 +1413,20 @@ const SCRIPT_TESTS_DEX: int = -8
 ## which is how a bookshelf tells a sculpture apart.
 const SCRIPT_TESTS_TILESET: int = -9
 const SCRIPT_TESTS_TILE: int = -10
+## What `push af` saves and `pop af` puts back, which is how
+## `CheckEventAfterBranchReuseA` still reads the event byte a block write
+## clobbered.
+const SCRIPT_AF_KEYS: Array[String] = [
+	"a", "source", "rotated", "tests", "tests_in_carry", "tests_engine",
+	"tests_and_a",
+]
+## The four stores a row is read for that are `a` under another name: the box
+## `DisplayTextBoxID` will draw, the row `DisplayTextID` will print, the object
+## a predef will toggle and the block `ReplaceTileBlock` will write.
+const SCRIPT_STORED_REGISTERS: Dictionary = {
+	"text_box_id": "text_box", "text_id_hram": "map_text",
+	"toggleable_index": "toggle", "new_tile_block": "new_block",
+}
 
 
 ## One `text_asm` row's machine code, as the boxes it prints and the branches
@@ -1413,6 +1565,11 @@ static func _script_flow(
 			return SCRIPT_END
 		Gen1Layout.SCRIPT_CALL:
 			return _script_call(ctx, pc, rom.u16le(at + 1), state, out, depth)
+		Gen1Layout.SCRIPT_PUSH_AF:
+			state["af"] = _script_pushed_af(state)
+			return pc + 1
+		Gen1Layout.SCRIPT_POP_AF:
+			return SCRIPT_UNREAD if not state.has("af") else _script_popped_af(state, pc)
 	if Gen1Layout.SCRIPT_CONDITIONAL_CALLS.has(rom.u8(at)):
 		return _script_call_if(ctx, pc, rom.u16le(at + 1), state)
 	return SCRIPT_UNREAD
@@ -1427,6 +1584,24 @@ static func _script_call_if(
 		return SCRIPT_UNREAD
 	_script_untested(state)
 	return pc + Gen1Layout.SCRIPT_LONG_SIZE
+
+
+static func _script_pushed_af(state: Dictionary) -> Dictionary:
+	var saved: Dictionary = {}
+	for key: String in SCRIPT_AF_KEYS:
+		if state.has(key):
+			saved[key] = state[key]
+	return saved
+
+
+static func _script_popped_af(state: Dictionary, pc: int) -> int:
+	var saved: Dictionary = state["af"]
+	for key: String in SCRIPT_AF_KEYS:
+		state.erase(key)
+		if saved.has(key):
+			state[key] = saved[key]
+	state.erase("af")
+	return pc + 1
 
 
 ## What a branch is reading, and whether it is reading it out of carry.
@@ -1524,15 +1699,12 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 			return false
 		state["no_press"] = true
 		return true
-	if address == int(layout["text_box_id"]):
+	for name: String in SCRIPT_STORED_REGISTERS:
+		if address != int(layout[name]):
+			continue
 		if not state.has("a"):
 			return false
-		state["text_box"] = int(state["a"])
-		return true
-	if address == int(layout["text_id_hram"]):
-		if not state.has("a"):
-			return false
-		state["map_text"] = int(state["a"])
+		state[String(SCRIPT_STORED_REGISTERS[name])] = int(state["a"])
 		return true
 	## `Mansion1Script_Switches` blanks the held buttons and `OpenPokemonCenterPC`
 	## turns the automatic box off; this port reads nothing out of either.
@@ -1540,11 +1712,6 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 		or address == int(layout["auto_text_box_control"]):
 		return true
 	if _script_bcd_stored(ctx, address, state):
-		return true
-	if address == int(layout["toggleable_index"]):
-		if not state.has("a"):
-			return false
-		state["toggle"] = int(state["a"])
 		return true
 	if address != int(layout["item_to_remove"]) or int(state.get("a", 0)) < 1:
 		return false
@@ -1931,12 +2098,27 @@ static func _script_predef(
 		out.append({"op": "trade", "trade_id": int(state["trade"])})
 		state.erase("trade")
 		return next
+	if target == int(layout["replace_tile_block"]):
+		return _script_replace_block(state, out, next)
 	var hidden: bool = target == int(layout["hide_object"])
 	if not state.has("toggle") \
 		or (not hidden and target != int(layout["show_object"])):
 		return SCRIPT_UNREAD
 	out.append({"op": "toggle_object", "index": int(state["toggle"]), "hidden": hidden})
 	state.erase("toggle")
+	return next
+
+
+## `ReplaceTileBlock`, which is how a map draws a door, a gate or an exit its
+## own block data has none of.
+static func _script_replace_block(state: Dictionary, out: Array, next: int) -> int:
+	if not state.has("new_block") or not state.has("b") or not state.has("c"):
+		return SCRIPT_UNREAD
+	out.append({
+		"op": "replace_block", "block": int(state["new_block"]),
+		"y": int(state["b"]), "x": int(state["c"]),
+	})
+	state.erase("new_block")
 	return next
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3665,6 +3665,9 @@ const GEN1_PICK_UP_RUN: String = "pick_up_item"
 ## `InGameTradeTextPointers`' fifteen and the two boxes the swap prints, which
 ## both generations' trades read under one run name.
 const GEN1_TRADE_RUN: String = "npc_trade"
+## `CardKeySuccessText` and `CardKeyFailText`, the two `TextPredefs` rows
+## `PrintCardKeyText` prints.
+const GEN1_CARD_KEY_RUN: String = "card_key"
 ## `TextScript_PokemonCenterPC`, `TextScript_ItemStoragePC` and
 ## `TextScript_BillsPC`, each a machine, the run its own boxes were imported
 ## under and the boot line it opens with. `BIT_USING_GENERIC_PC` is clear on all
@@ -3715,6 +3718,7 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"name_item": &"_gen1_node_name_item",
 	"map_text": &"_gen1_node_map_text",
 	"facility": &"_gen1_node_facility",
+	"replace_block": &"_gen1_node_replace_block",
 }
 
 
@@ -3754,16 +3758,18 @@ func gen1_last_map() -> int:
 
 ## `CheckForHiddenEventOrBookshelfOrCardKeyDoor` runs on the A press ahead of
 ## everything, and finding a row spends it even when the routine prints nothing.
-## The card key door is not among them: no Silph Co. floor draws one until its
-## own map callback puts the block there.
+## A card key door is the one thing it finds that does not: `PrintBookshelfText`'s
+## `.noMatch` leaves `hItemAlreadyFound` at $ff, so the door's box opens and the
+## sign and sprite check still runs behind it.
 func _gen1_interact() -> Array:
 	if current_map == null:
 		return []
 	var hidden: Variant = _gen1_hidden_nodes()
-	if hidden == null:
-		return _gen1_sign_or_sprite()
-	_gen1_steps = _gen1_script_steps({"script": hidden})
-	return _gen1_result()
+	if hidden != null:
+		_gen1_steps = _gen1_script_steps({"script": hidden})
+		return _gen1_result()
+	_gen1_steps = _gen1_card_key_steps() + _gen1_sign_or_sprite()
+	return _gen1_result() if not _gen1_steps.is_empty() else []
 
 
 ## `CheckForHiddenEvent`, then `PrintBookshelfText`, or null when neither found
@@ -3796,17 +3802,55 @@ func _gen1_sign_or_sprite() -> Array:
 		event = _gen1_event_at(object_facing_cell(), &"objects")
 	var text_id: int = int(event.get("text", 0))
 	var row: Dictionary = current_map.text_at(text_id)
-	_gen1_steps = _gen1_trainer_steps(row, event)
-	if _gen1_steps.is_empty():
-		_gen1_steps = _gen1_facility_steps(row, text_id)
-	if _gen1_steps.is_empty():
-		_gen1_steps = _gen1_script_steps(row, event)
-	if _gen1_steps.is_empty():
-		var text: String = gen1_filled_text(String(row.get("text", "")))
-		if text.is_empty():
-			return []
-		_gen1_steps = [{"type": &"text", "text": text}]
-	return _gen1_result()
+	var steps: Array = _gen1_trainer_steps(row, event)
+	if steps.is_empty():
+		steps = _gen1_facility_steps(row, text_id)
+	if steps.is_empty():
+		steps = _gen1_script_steps(row, event)
+	if not steps.is_empty():
+		return steps
+	var text: String = gen1_filled_text(String(row.get("text", "")))
+	return [] if text.is_empty() else [{"type": &"text", "text": text}]
+
+
+## `PrintCardKeyText`: the CARD KEY opens the door in front of the player and
+## the world remembers where it stood; without the key there is only a refusal.
+func _gen1_card_key_steps() -> Array:
+	var door: Dictionary = _gen1_card_key_door()
+	if door.is_empty():
+		return []
+	if state == null or int((state.items() as Dictionary).get(
+		Gen1Layout.ITEM_CARD_KEY, 0
+	)) < 1:
+		return [_gen1_card_key_box("card_key_fail")]
+	door["type"] = &"block"
+	door["card_key"] = true
+	return [_gen1_card_key_box("card_key_success"), door]
+
+
+func _gen1_card_key_box(name: String) -> Dictionary:
+	return {
+		"type": &"text",
+		"text": data.special_text(GEN1_CARD_KEY_RUN, name) if data != null else "",
+	}
+
+
+## `GetTileAndCoordsInFrontOfPlayer` against the door tiles, and the block
+## coordinates `srl d` and `srl e` leave.
+func _gen1_card_key_door() -> Dictionary:
+	if (current_map.events["card_key"] as Array).is_empty():
+		return {}
+	var top_floor: bool = current_map.number == Gen1Layout.SILPH_CO_TOP_FLOOR
+	var cell: Vector2i = facing_cell()
+	var tile: int = _gen1_tile_drawn_at(cell)
+	if not Gen1Layout.CARD_KEY_DOOR_TILES.has(tile) \
+		and not (top_floor and tile == Gen1Layout.CARD_KEY_TOP_FLOOR_TILE):
+		return {}
+	return {
+		"x": cell.x >> 1, "y": cell.y >> 1,
+		"block": Gen1Layout.CARD_KEY_TOP_FLOOR_BLOCK if top_floor \
+			else Gen1Layout.CARD_KEY_OPEN_BLOCK,
+	}
 
 
 ## The print-time names still standing in an imported Generation 1 box, which
@@ -3827,11 +3871,16 @@ func _gen1_script_steps(row: Dictionary, event: Dictionary = {}) -> Array:
 	if not nodes is Array or (nodes as Array).is_empty():
 		return []
 	var steps: Array = []
-	return steps if _gen1_resolve_script(nodes as Array, steps, {
+	return steps if _gen1_resolve_script(nodes as Array, steps, _gen1_run(event)) else []
+
+
+## The bag, purse and object a row is walked against.
+func _gen1_run(event: Dictionary) -> Dictionary:
+	return {
 		"bag": state.items() if state != null else {}, "named": "", "object": event,
 		"money": state.money(Gen2WorldMartHost.MONEY_ACCOUNT) if state != null else 0,
 		"coins": state.coins() if state != null else 0,
-	}) else []
+	}
 
 
 ## [param run] is the bag the row is walked against, carrying what its own gifts
@@ -3862,6 +3911,14 @@ func _gen1_node_flag(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
 		"flag": int(node["flag"]),
 		"set": bool(node["set"]),
 		"engine": bool(node.get("engine", false)),
+	})
+	return true
+
+
+func _gen1_node_replace_block(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({
+		"type": &"block", "x": int(node["x"]), "y": int(node["y"]),
+		"block": int(node["block"]),
 	})
 	return true
 
@@ -4752,6 +4809,17 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 		&"npc_trade":
 			state.apply_changes({}, {}, {"npc_trades": {int(step["trade_id"]): true}})
 			return true
+		&"block":
+			## `PrintCardKeyText` writes `wCardKeyDoorY` and its neighbour behind
+			## the box, so the floor's own callback can flag the door next load.
+			if bool(step.get("card_key", false)) and state != null:
+				state.set_card_key_door(Vector2i(int(step["x"]), int(step["y"])))
+			var changed: Dictionary = change_block(
+				int(step["x"]), int(step["y"]), int(step["block"])
+			)
+			if bool(changed.get("ok", false)):
+				events.append(changed)
+			return true
 	return false
 
 
@@ -5513,6 +5581,9 @@ func _object_event_flags() -> Array[int]:
 func _queue_map_callbacks(callback_type: int) -> void:
 	if current_map == null:
 		return
+	if _gen1:
+		_run_gen1_map_callback()
+		return
 	var bank: int = int(current_map.scripts.get("bank", 0))
 	for callback: Dictionary in current_map.scripts.get("callbacks", []):
 		if callback_type >= 0 and int(callback.get("type", -1)) != callback_type:
@@ -5525,6 +5596,38 @@ func _queue_map_callbacks(callback_type: int) -> void:
 			"bank": bank,
 			"script": int(callback.get("script", 0)),
 		})
+
+
+## The body behind a map's `wCurrentMapScriptFlags` bit. Running it again writes
+## the same blocks, so the second call a map entry makes says nothing new.
+func _run_gen1_map_callback() -> void:
+	var callbacks: Array = current_map.scripts.get("callbacks", [])
+	if callbacks.is_empty():
+		return
+	_unlock_gen1_card_key_door()
+	var steps: Array = []
+	if not _gen1_resolve_script(callbacks[0]["nodes"] as Array, steps, _gen1_run({})):
+		return
+	var events: Array = []
+	while not steps.is_empty() and _gen1_written(steps[0], events):
+		steps.pop_front()
+
+
+## `<Map>_SetCardKeyDoorYScript` and `<Map>_UnlockedDoorEventScript`, which run
+## in front of the blocks: the door `PrintCardKeyText` last opened becomes that
+## door's own flag, and the coordinates are cleared on the floor that owns them.
+func _unlock_gen1_card_key_door() -> void:
+	if state == null:
+		return
+	var opened: Vector2i = state.card_key_door()
+	if opened == Gen2WorldState.NO_CARD_KEY_DOOR:
+		return
+	for door: Dictionary in current_map.events["card_key"] as Array:
+		if Vector2i(int(door["x"]), int(door["y"])) != opened:
+			continue
+		state.set_event_flag(int(door["flag"]))
+		state.set_card_key_door(Gen2WorldState.NO_CARD_KEY_DOOR)
+		return
 
 
 func _queue_map_scene() -> void:

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -165,6 +165,10 @@ static func _events_from_cache(value: Variant) -> Dictionary:
 		]),
 		# `CheckForHiddenEvent`'s own rows, Generation 1's alone.
 		"hidden_events": _event_rows(event_values.get("hidden_events", []), ["x", "y"]),
+		# One row per Silph Co. card key door, Generation 1's alone.
+		"card_key": _event_rows(
+			event_values.get("card_key", []), ["x", "y", "block", "flag"]
+		),
 	}
 
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -306,6 +306,12 @@ var _npc_trades: Dictionary = {}
 ## of global indices a `ShowObject` or a `HideObject` has since moved away from
 ## that row: a state that has run neither is the cartridge's own new game.
 var _toggled_objects: Dictionary = {}
+## `wCardKeyDoorY` and its neighbour: the block `PrintCardKeyText` last opened a
+## Silph Co. door at. The floor's own callback turns it into that door's flag on
+## the next load and clears it, so opening a second door on one visit loses the
+## first. Both bytes open at zero, so block (0, 0) is "no door".
+const NO_CARD_KEY_DOOR: Vector2i = Vector2i.ZERO
+var _card_key_door: Vector2i = NO_CARD_KEY_DOOR
 ## `wRegisteredItem`. `wWhichRegisteredItem`'s pocket and slot number have no
 ## counterpart in the flat item model: `CheckRegisteredItem` uses them to find
 ## the entry again in its packed pocket array and clears both when the item is
@@ -529,6 +535,7 @@ func to_dict() -> Dictionary:
 		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
 		"picked_fruit_trees": _picked_fruit_trees.duplicate(),
 		"toggled_objects": _toggled_objects.duplicate(),
+		"card_key_door": [_card_key_door.x, _card_key_door.y],
 		"npc_trades": _npc_trades.duplicate(),
 		"registered_item": _registered_item,
 		"day_care_man": _day_care_man,
@@ -580,6 +587,9 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	_seed_counts(restored._pc_items, _map(source, "pc_items"), 1, -1, Gen2WorldPack.MAX_PC_ITEMS)
 	_seed_flags(restored._picked_fruit_trees, _map(source, "picked_fruit_trees"), 1)
 	_seed_flags(restored._toggled_objects, _map(source, "toggled_objects"), 0)
+	restored._card_key_door = _vector_from_value(
+		source.get("card_key_door", [NO_CARD_KEY_DOOR.x, NO_CARD_KEY_DOOR.y])
+	)
 	_seed_flags(restored._npc_trades, _map(source, "npc_trades"), 0)
 	restored._swarm_maps[SWARM_YANMA] = _vector_from_value(
 		source.get("yanma_swarm_map", [-1, -1])
@@ -735,6 +745,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
 	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
 	_toggled_objects = restored._toggled_objects.duplicate()
+	_card_key_door = restored._card_key_door
 	_npc_trades = restored._npc_trades.duplicate()
 	_registered_item = restored._registered_item
 	_day_care_man = restored._day_care_man
@@ -1678,6 +1689,17 @@ func set_kurt_apricorn_quantity(quantity: int) -> void:
 	if next_quantity == _kurt_apricorn_quantity:
 		return
 	_kurt_apricorn_quantity = next_quantity
+	changed.emit()
+
+
+func card_key_door() -> Vector2i:
+	return _card_key_door
+
+
+func set_card_key_door(cell: Vector2i) -> void:
+	if _card_key_door == cell:
+		return
+	_card_key_door = cell
 	changed.emit()
 
 

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -26,6 +26,9 @@ const LAYOUT: Dictionary = {
 	"cur_party_species": 0xCF91,
 	"cur_map_script": 0xDA39,
 	"map_scripts": 0xD5F0,
+	"map_script_flags": 0xD126,
+	"new_tile_block": 0xD09F,
+	"replace_tile_block": 0x02C0,
 	"predef": 0x01A0,
 	"predef_pointers": 0x0300,
 	"hide_object": 0x0210,
@@ -62,6 +65,7 @@ const LAYOUT: Dictionary = {
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
 const PREDEFS: Dictionary = {
 	1: 0x0210, 2: 0x0220, 3: 0x0230, 4: 0x0240, 5: 0x0250, 6: 0x0270,
+	7: 0x02C0,
 }
 const AT: int = 0x1000
 const HELLO: int = 0x1800
@@ -421,6 +425,60 @@ func test_a_predef_showing_an_object_reads_the_other_way() -> void:
 ## index is one this decoder cannot say which object goes off the map.
 func test_a_predef_with_no_index_written_answers_nothing() -> void:
 	assert_eq(_decode(_predef(1) + _call(int(LAYOUT["text_script_end"]))), [])
+
+
+## `ld a, block`, `ld [wNewTileBlockID], a` and `lb bc, y, x` in front of a
+## `predef ReplaceTileBlock`, which is a map's own load callback whole.
+func _replace_block(block: int, y: int, x: int) -> Array:
+	return [
+		Gen1Layout.SCRIPT_LD_A, block, Gen1Layout.SCRIPT_LD_MEM_A,
+		int(LAYOUT["new_tile_block"]) & 0xFF, int(LAYOUT["new_tile_block"]) >> 8,
+		Gen1Layout.SCRIPT_LD_BC, x, y,
+	] + _predef(7)
+
+
+func test_a_replace_tile_block_predef_becomes_a_block_node() -> void:
+	assert_eq(_decode(_replace_block(0x54, 2, 3) + [Gen1Layout.SCRIPT_RET]),
+		[{"op": "replace_block", "block": 0x54, "y": 2, "x": 3}])
+
+
+## `wNewTileBlockID` is the whole of what the routine writes, so a callback that
+## named no block says nothing rather than writing whatever stood in `a`.
+func test_a_block_predef_with_no_block_written_answers_nothing() -> void:
+	assert_eq(_decode(
+		[Gen1Layout.SCRIPT_LD_BC, 3, 2] + _predef(7) + [Gen1Layout.SCRIPT_RET]
+	), [])
+
+
+## `CheckEventAfterBranchReuseA` reads the event byte the block write left in
+## `a`, which only the `push af` and `pop af` around the write keep.
+func test_push_and_pop_af_carry_the_event_byte_across_a_block_write() -> void:
+	var locked: Array = [Gen1Layout.SCRIPT_PUSH_AF] \
+		+ _replace_block(0x54, 2, 2) + [Gen1Layout.SCRIPT_POP_AF]
+	var script: Array = _decode(
+		_check_event(0) + [0x20, locked.size()] + locked
+			+ [
+				Gen1Layout.SCRIPT_PREFIX,
+				Gen1Layout.SCRIPT_BIT_BASE + 8 + Gen1Layout.SCRIPT_OPERAND_A,
+				0xC0,
+			] + _replace_block(0x54, 5, 2) + [Gen1Layout.SCRIPT_RET]
+	)
+	assert_eq(script, [{
+		"op": "branch", "flag": 0,
+		"then": [{
+			"op": "branch", "flag": 1,
+			"then": [],
+			"else": [{"op": "replace_block", "block": 0x54, "y": 5, "x": 2}],
+		}],
+		"else": [
+			{"op": "replace_block", "block": 0x54, "y": 2, "x": 2},
+			{
+				"op": "branch", "flag": 1,
+				"then": [],
+				"else": [{"op": "replace_block", "block": 0x54, "y": 5, "x": 2}],
+			},
+		],
+	}])
 
 
 ## `PickUpItemText` whole: the object's own item is the world's to supply.

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,15 +16,15 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1395 lines of the 40379 here,
-## and Generation 1 has added 1292 more to the shared battle, world, palette,
+## files cost: `game/gen1` and its neighbours are 1486 lines of the 40468 here,
+## and Generation 1 has added 1312 more to the shared battle, world, palette,
 ## text, save and renderer code: 150 the battle animation engine, 140 the
 ## transition, 108 the three PCs, 85 the party menu, 42 the status screen, 40
-## the bag in a battle, 33 the hidden objects. Fifteen sweeps paid nothing.
+## the bag in a battle, 20 the map callbacks. Fifteen sweeps paid nothing.
 
-## The wording seam is the one subsystem since: `data/text_overlay.gd` and
-## `checks/text.gd` are 17 lines against 5 the accessors they funnelled gave back.
-const MAX_COMMENT_LINES: int = 40391
+## The map callbacks are the one subsystem since: no Silph Co. floor carries a
+## card key door until its own load callback puts that block back.
+const MAX_COMMENT_LINES: int = 40468
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -184,6 +184,14 @@ const HIDDEN_CENSUS: Dictionary = {
 ## statues read `wXCoord` for which of their two boxes they answer with.
 const BOOKSHELF_COUNTS: Dictionary = {&"red": 15, &"blue": 15, &"yellow": 15}
 const CARD_KEY_FLOORS: int = 10
+## `gated` is every map whose script opens on `wCurrentMapScriptFlags` and
+## `read` the ones whose body decodes whole; `blocks` counts the
+## `ReplaceTileBlock` writes on every branch of those bodies.
+const CALLBACK_CENSUS: Dictionary = {
+	&"red": {"gated": 36, "read": 21, "blocks": 79, "doors": 20, "floors": 10},
+	&"blue": {"gated": 36, "read": 21, "blocks": 79, "doors": 20, "floors": 10},
+	&"yellow": {"gated": 34, "read": 20, "blocks": 78, "doors": 20, "floors": 10},
+}
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
 const LAVENDER_TOWN: int = 4
@@ -226,6 +234,7 @@ func _one_game() -> void:
 	_r.check(_movements == MOVEMENT_CENSUS[_r.game_id],
 		"the movement census reads %s." % str(_movements))
 	_texts()
+	_map_callbacks()
 	_hidden_events()
 	_toggleables()
 	_wild_objects()
@@ -383,6 +392,64 @@ func _scripts(font: Gen2Font) -> void:
 	_r.check(census == SCRIPT_CENSUS[_r.game_id], "the row scripts read %s." % [census])
 	_r.note("gen1 scripts %s" % [census])
 	_ghost_girl()
+
+
+func _map_callbacks() -> void:
+	var census: Dictionary = {
+		"gated": 0, "read": 0, "blocks": 0, "doors": 0, "floors": 0,
+	}
+	var wrong: Array[String] = []
+	for map: Gen2WorldMap in _maps.values():
+		var doors: Array = map.events["card_key"] as Array
+		census["floors"] += 1 if not doors.is_empty() else 0
+		census["doors"] += doors.size()
+		var callbacks: Array = map.scripts["callbacks"] as Array
+		if callbacks.is_empty():
+			continue
+		var nodes: Array = callbacks[0]["nodes"] as Array
+		census["gated"] += 1
+		census["read"] += 1 if not nodes.is_empty() else 0
+		census["blocks"] += _blocks_written(nodes)
+		_check_doors(map, callbacks[0], doors, wrong)
+	_r.check(wrong.is_empty(), "card key doors are wrong: %s." % [wrong])
+	_r.check(census == CALLBACK_CENSUS[_r.game_id],
+		"the map callbacks read %s." % [census])
+	_r.note("gen1 map callbacks %s" % [census])
+
+
+func _blocks_written(nodes: Array) -> int:
+	var written: int = 0
+	for node: Dictionary in nodes:
+		written += 1 if String(node["op"]) == "replace_block" else 0
+		for side: String in ["then", "else"]:
+			if node.has(side):
+				written += _blocks_written(node[side] as Array)
+	return written
+
+
+## A floor's doors stand on its own `.GateCoordinates`, each under a flag of its
+## own.
+func _check_doors(
+	map: Gen2WorldMap, callback: Dictionary, doors: Array, wrong: Array[String]
+) -> void:
+	var coordinates: Array = callback["coordinates"] as Array
+	if coordinates.is_empty():
+		return
+	var flags: Dictionary = {}
+	for index: int in doors.size():
+		var door: Dictionary = doors[index]
+		var gate: Dictionary = coordinates[index]
+		if (int(door["x"]) != int(gate["x"]) or int(door["y"]) != int(gate["y"])) \
+			and wrong.size() < 4:
+			wrong.append("map %d door %d stands on %d,%d, not %d,%d" % [
+				map.number, index, int(door["x"]), int(door["y"]),
+				int(gate["x"]), int(gate["y"]),
+			])
+		flags[int(door["flag"])] = true
+	if flags.size() != doors.size() and wrong.size() < 4:
+		wrong.append("map %d has %d doors under %d flags" % [
+			map.number, doors.size(), flags.size(),
+		])
 
 
 func _walk_script(

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -17,6 +17,16 @@ const WARP_CENSUS: Dictionary = {
 ## `SilphCoElevator_Object`'s two warps name UNUSED_MAP_ED, which has no header;
 ## its own script rewrites the destination before either is taken.
 const SILPH_CO_ELEVATOR: int = 236
+## Silph Co. 2F's two card key doors, the block that locks one and the one
+## `PrintCardKeyText` opens it with, and the cell below the first.
+const SILPH_CO_2F: int = 207
+const SILPH_DOOR := Vector2i(2, 2)
+const SILPH_SECOND_DOOR := Vector2i(2, 5)
+const SILPH_DOOR_APPROACH := Vector2i(4, 5)
+const SILPH_LOCKED_BLOCK: int = 0x54
+const SILPH_OPEN_BLOCK: int = 0x0E
+const CARD_KEY_REFUSED: String = "Darn! It needs a"
+const CARD_KEY_OPENED: String = "Bingo!"
 
 ## The warps no facing can fire, as map id and warp index. Every one is a cell
 ## the player arrives on rather than steps onto: three are pret's own
@@ -272,6 +282,7 @@ func _one_game() -> void:
 	_check_a_gym_statue()
 	_check_a_bench_guy()
 	_check_a_bookshelf()
+	_check_a_card_key_door()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -467,6 +478,65 @@ func _check_text_boxes() -> void:
 	mart.player_facing = Gen2WorldSprite.FACING_LEFT
 	_r.check(mart.object_facing_cell() == MART_CLERK,
 		"the mart counter reaches %s." % [mart.object_facing_cell()])
+
+
+## `PrintCardKeyText` on Silph Co. 2F, whose door tile is on the map only
+## because the floor's own callback put the locked block back.
+func _check_a_card_key_door() -> void:
+	var refused: Gen2WorldAPI = _silph_door()
+	if refused == null:
+		return
+	_r.check(refused.block_at(SILPH_DOOR.x, SILPH_DOOR.y) == SILPH_LOCKED_BLOCK,
+		"Silph Co. 2F draws block $%02X on a locked door." % refused.block_at(
+			SILPH_DOOR.x, SILPH_DOOR.y
+		))
+	var darn: String = _box_text(refused)
+	_r.check(darn.begins_with(CARD_KEY_REFUSED), "a door with no CARD KEY said %s." % [darn])
+	_r.check(refused.block_at(SILPH_DOOR.x, SILPH_DOOR.y) == SILPH_LOCKED_BLOCK,
+		"a refused door opened anyway.")
+
+	var world: Gen2WorldAPI = _silph_door()
+	if world == null:
+		return
+	world.state.apply_changes({}, {}, {"items": {Gen1Layout.ITEM_CARD_KEY: 1}})
+	var opened: String = _box_text(world)
+	_r.check(opened.begins_with(CARD_KEY_OPENED), "the CARD KEY said %s." % [opened])
+	world.run_event_queue(true)
+	_r.check(world.block_at(SILPH_DOOR.x, SILPH_DOOR.y) == SILPH_OPEN_BLOCK,
+		"the opened door draws block $%02X." % world.block_at(SILPH_DOOR.x, SILPH_DOOR.y))
+	_r.check(world.state.card_key_door() == SILPH_DOOR,
+		"the door opened at %s was remembered as %s." % [
+			SILPH_DOOR, world.state.card_key_door(),
+		])
+
+	## The floor loaded again: the coordinates become the door's flag and the
+	## callback leaves that one alone.
+	var again: Gen2WorldAPI = _r.open_world(
+		0, SILPH_CO_2F, SILPH_DOOR_APPROACH, world.state
+	)
+	if again == null:
+		return
+	again.dispatch_map_entry()
+	_r.check(again.state.card_key_door() == Gen2WorldState.NO_CARD_KEY_DOOR,
+		"the reloaded floor kept %s." % [again.state.card_key_door()])
+	_r.check(again.block_at(SILPH_DOOR.x, SILPH_DOOR.y) == SILPH_OPEN_BLOCK,
+		"the reloaded floor blocked the opened door with $%02X." % again.block_at(
+			SILPH_DOOR.x, SILPH_DOOR.y
+		))
+	_r.check(again.block_at(SILPH_SECOND_DOOR.x, SILPH_SECOND_DOOR.y) == SILPH_LOCKED_BLOCK,
+		"the floor's other door stands at $%02X." % again.block_at(
+			SILPH_SECOND_DOOR.x, SILPH_SECOND_DOOR.y
+		))
+
+
+## Silph Co. 2F opened and entered, standing under its first door facing it.
+func _silph_door() -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(0, SILPH_CO_2F, SILPH_DOOR_APPROACH)
+	if world == null:
+		return null
+	world.dispatch_map_entry()
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	return world
 
 
 ## The string one interaction puts in a box, or "" when it opened none.

--- a/tools/lib/check_run.gd
+++ b/tools/lib/check_run.gd
@@ -18,6 +18,25 @@ const FIELD_MOVE_PARTY_SIZE: int = 1
 
 var failures: PackedStringArray = []
 
+## Godot ends the function a runtime error happened in and returns to its
+## caller, so a topic that throws goes on to print its own verdict:
+## `gen1_maps` said PASS for every run in which its hidden event census had not
+## run at all. `OS.add_logger` is the only thing in the engine that sees one.
+class RuntimeErrors extends Logger:
+	var seen: PackedStringArray = []
+
+	func _log_error(
+		function: String, file: String, line: int, code: String,
+		rationale: String, _editor_notify: bool, _error_type: int,
+		_backtraces: Array[ScriptBacktrace]
+	) -> void:
+		seen.append("%s:%d in %s(): %s" % [
+			file, line, function, code if rationale.is_empty() else rationale,
+		])
+
+
+var _errors: RuntimeErrors = RuntimeErrors.new()
+
 ## Set per game by [method each_game] so a topic can read them without threading
 ## them through every helper.
 var game_id: StringName = &""
@@ -35,6 +54,17 @@ func check(condition: bool, message: String) -> bool:
 
 func fail(message: String) -> void:
 	check(false, message)
+
+
+func watch() -> void:
+	OS.add_logger(_errors)
+
+
+## Stops, and answers for every error raised while it was watching.
+func unwatch() -> void:
+	OS.remove_logger(_errors)
+	for error: String in _errors.seen:
+		fail("a runtime error stopped a check: %s" % error)
 
 
 ## A census or landmark line. Kept apart from [method fail] so a topic reads the

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -37,6 +37,7 @@ const KIND_HELP: Dictionary = {
 	&"trade": "presses: DoInGameTradeDialogue, faced up from the cell below the trader. 0 the offer and its YES/NO, 1 the party list YES opens",
 	&"deal": "presses: the MAGIKARP salesman, faced right from the cell beside him with the money box DisplayTextBoxID drew over the map",
 	&"coins": "presses: GameCornerClerk1Text, faced up from the cell below her with GameCornerDrawCoinBox's own box over the map. 0 the offer and its YES/NO, 1 the box YES lands in",
+	&"card_key_door": "presses: PrintCardKeyText on a Silph Co. door, faced up from the cell below it with the CARD KEY owned. 0 CardKeySuccessText's first page, 1 its second, 2 the door those two presses opened",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
 	&"level_evolution": "frames: EvolveAfterBattle's screen that many frames in, each box pressed past as it lands",
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
@@ -189,6 +190,7 @@ const STAGED_FRAMES: int = 2
 const BATTLE_MENU_WAIT: int = 6
 const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"cut": 12, &"waterfall_use": 26, &"sign": BOX_REVEAL_FRAMES,
+	&"card_key_door": BOX_REVEAL_FRAMES,
 	&"gift": BOX_REVEAL_FRAMES,
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
 	&"prizes": BOX_REVEAL_FRAMES, &"trade": BOX_REVEAL_FRAMES,
@@ -451,6 +453,7 @@ const STAGERS: Dictionary = {
 	&"trade": &"_stage_trade",
 	&"deal": &"_stage_deal",
 	&"coins": &"_stage_coins",
+	&"card_key_door": &"_stage_card_key_door",
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
@@ -1078,6 +1081,15 @@ func _stage_coins() -> void:
 		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY},
 		"items": {Gen1Layout.ITEM_COIN_CASE: 1},
 	})
+
+
+## `PrintCardKeyText` reads the CARD KEY out of the bag rather than through a
+## pack USE, so the door is a box faced from the cell below it.
+func _stage_card_key_door() -> void:
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world != null:
+		world.state.apply_changes({}, {}, {"items": {Gen1Layout.ITEM_CARD_KEY: 1}})
+	_stage_gift()
 
 
 ## A counter faced the way [param facing] says: presses, then rows down first.

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -73,7 +73,9 @@ func _initialize() -> void:
 			printerr("FAIL %s: the topic script did not load." % name)
 			failed.append(name)
 			continue
+		run.watch()
 		topic.call(&"run", run)
+		run.unwatch()
 		if run.failures.is_empty():
 			print("PASS %s" % name)
 			continue


### PR DESCRIPTION
## Added

A Generation 1 map runs the body behind its own `wCurrentMapScriptFlags` bit when it opens. `RunMapScript` runs the whole of a map's script every frame, so that body is the work a map does once; the per-frame state machine `CallFunctionInTable` dispatches is not read at all. `Gen1WorldImporter._read_map_callback` finds the gate in the entry script or in the routine its first `call` names, and decodes the body with the walker a `text_asm` row is already read by.

`PrintCardKeyText`. The CARD KEY opens a Silph Co. door: `$18` and `$24` with SILPH_CO_11F's own `$5e`, the block replaced with `$0E` under it and `$03` there, and `CardKeySuccessText` and `CardKeyFailText` imported as the two `TextPredefs` rows they are. `PrintBookshelfText`'s `.noMatch` leaves `hItemAlreadyFound` at `$ff`, so the door's box opens and the sign and sprite check still runs behind it.

`Gen2WorldState.card_key_door` is `wCardKeyDoorY` and its neighbour. `<Map>_SetCardKeyDoorYScript` and `<Map>_UnlockedDoorEventScript` both loop over a table, so the pair is read by hand: the door last opened becomes that door's flag on the next load of that floor, and opening two doors in one visit is what loses the first.

`card_key_door` in `tools/preview_world.gd`: `red 0 207 <out.png> live card_key_door@4,5 0 0` photographs the box and `2 0` the door it opened.

## Changed

`ReplaceTileBlock` is a `replace_block` node the shared Generation 1 resolver spends through `change_block`, so a callback's own event flags decide which blocks land. `push af` and `pop af` carry the event byte across the block write that `CheckEventAfterBranchReuseA` reads back, and the four stores that are `a` under another name are one lookup table rather than four `if`s.

## Fixed

A check topic that raised a runtime error still reported PASS. Godot ends the function the error happened in and returns to its caller, so `tools/checks/gen1_maps.gd` read `map.events["card_key"]`, which no importer wrote, and went on to print its verdict with its whole hidden event census unrun. `CheckRun.watch` is an `OS.add_logger` handler and `unwatch` turns every error it saw into a failure of its own; `tools/validate.gd` brackets each topic with the pair.

## Measured

| Check | Result |
|---|---|
| Map-load gates found / bodies decoded | 36 / 21 on Red and Blue, 34 / 20 on Yellow |
| `ReplaceTileBlock` writes decoded | 79 on Red and Blue, 78 on Yellow |
| Card key floors / doors | 10 / 20 on all three |
| `tools/validate.gd -- all` | 93 topics, exit 0 |
| GUT, `tests` with subdirs | 4457 tests, 4457 passing |
| `addons/warning_scan` | 0 warnings in 634 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | every step ok |

The 15 gated maps whose bodies do not decode sit behind a conditional `call` to a routine the walker refuses, which is `_script_call_if`'s own rule rather than this seam's.