### PR TITLE
Walk the player out of Museum 1F

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -779,6 +779,9 @@ const SCRIPT_HIGH_BIT: int = 7
 const SCRIPT_AND_N: int = 0xE6
 const SCRIPT_LD_C: int = 0x0E
 const SCRIPT_LD_B_A: int = 0x47
+const SCRIPT_COORD_SOURCES: Array[String] = ["player_y", "player_x"]
+## `PAD_DOWN` down to `PAD_RIGHT`, bits 7 to 4, as `Gen2WorldAPI`'s directions.
+const PAD_DIRECTIONS: Dictionary = {0x80: 0, 0x40: 1, 0x20: 2, 0x10: 3}
 const SCRIPT_PREFIX: int = 0xCB
 const SCRIPT_JR: int = 0x18
 const SCRIPT_JP: int = 0xC3
@@ -818,6 +821,7 @@ const SCRIPT_CALLS: Array[String] = [
 	"predef", "display_pokedex", "give_pokemon", "wait_for_button",
 	"auto_textbox_on", "auto_textbox_off", "has_enough_money", "display_text_box",
 	"has_enough_coins", "print_predef_text", "display_text_id", "count_set_bits",
+	"start_simulating_joypad", "update_sprites", "play_sound", "play_sound_wait",
 ]
 ## Routines named by a full ROM offset, the same address in another bank being another routine.
 const SCRIPT_BANKED_CALLS: Array[String] = ["coin_box"]
@@ -825,7 +829,8 @@ const SCRIPT_BANKED_CALLS: Array[String] = ["coin_box"]
 ## every box, and `wAutoTextBoxDrawingControl` has no counterpart.
 const SCRIPT_SILENT_CALLS: Array[String] = [
 	"play_cry", "wait_for_sound", "wait_for_button",
-	"auto_textbox_on", "auto_textbox_off", "count_set_bits",
+	"auto_textbox_on", "auto_textbox_off", "count_set_bits", "update_sprites",
+	"play_sound", "play_sound_wait",
 ]
 const SCRIPT_CONDITIONAL_CALLS: Array[int] = [0xC4, 0xCC, 0xD4, 0xDC]
 ## `cp n` and the two conditional `ret`s behind it, whose value is the side
@@ -1310,6 +1315,15 @@ const RED_BLUE: Dictionary = {
 	"tile_map": 0xC3A0,
 	"cur_map_tileset": 0xD367,
 	"num_set_bits": 0xD11E,
+	"player_y": 0xD361,
+	"player_x": 0xD362,
+	## `StartSimulatingJoypadStates` and its buffer: one entry per walking step.
+	"update_sprites": 0x2429,
+	"play_sound": 0x23B1,
+	"play_sound_wait": 0x3740,
+	"start_simulating_joypad": 0x3486,
+	"simulated_joypad_index": 0xCD38,
+	"simulated_joypad_end": 0xCCD3,
 	"obtained_hidden_items": 0xD6F0,
 	"obtained_hidden_coins": 0xD6FE,
 	## `_IsTilePassable` and the lists it walks share a bank, and the pointer in
@@ -1480,6 +1494,14 @@ const YELLOW: Dictionary = {
 	"tile_map": 0xC3A0,
 	"cur_map_tileset": 0xD366,
 	"num_set_bits": 0xD11D,
+	"player_y": 0xD360,
+	"player_x": 0xD361,
+	"update_sprites": 0x231C,
+	"play_sound": 0x2238,
+	"play_sound_wait": 0x3736,
+	"start_simulating_joypad": 0x3415,
+	"simulated_joypad_index": 0xCD38,
+	"simulated_joypad_end": 0xCCD3,
 	"obtained_hidden_items": 0xD6EF,
 	"obtained_hidden_coins": 0xD6FD,
 	"tileset_collision_bank": 0x01,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1413,6 +1413,7 @@ const SCRIPT_TESTS_DEX: int = -8
 ## which is how a bookshelf tells a sculpture apart.
 const SCRIPT_TESTS_TILESET: int = -9
 const SCRIPT_TESTS_TILE: int = -10
+const SCRIPT_TESTS_COORD: int = -11
 ## What `push af` saves and `pop af` puts back, which is how
 ## `CheckEventAfterBranchReuseA` still reads the event byte a block write
 ## clobbered.
@@ -1711,11 +1712,27 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 	if address == int(layout["joy_held"]) \
 		or address == int(layout["auto_text_box_control"]):
 		return true
+	if _script_joypad_stored(layout, address, state):
+		return true
 	if _script_bcd_stored(ctx, address, state):
 		return true
 	if address != int(layout["item_to_remove"]) or int(state.get("a", 0)) < 1:
 		return false
 	state["remove"] = int(state["a"])
+	return true
+
+
+static func _script_joypad_stored(
+	layout: Dictionary, address: int, state: Dictionary
+) -> bool:
+	if not state.has("a"):
+		return false
+	if address == int(layout["simulated_joypad_index"]):
+		state["walk_steps"] = int(state["a"])
+		return true
+	if address != int(layout["simulated_joypad_end"]):
+		return false
+	state["walk_pad"] = int(state["a"])
 	return true
 
 
@@ -1848,10 +1865,27 @@ static func _script_call(
 			return _script_predef_text(ctx, state, out, next, depth)
 		"display_text_id":
 			return _script_map_text(state, out, next)
+		"start_simulating_joypad":
+			return _script_walk(state, out, next)
 	if _script_banked_routine(layout, int(ctx["bank"]), target) == "coin_box":
 		out.append({"op": "coin_box"})
 		return next
 	return _script_routine_call(ctx, int(ctx["bank"]), target, state, out, next, depth)
+
+
+## `StartSimulatingJoypadStates`, whose buffer is one walking step per entry.
+static func _script_walk(state: Dictionary, out: Array, next: int) -> int:
+	var pad: int = int(state.get("walk_pad", 0))
+	if not Gen1Layout.PAD_DIRECTIONS.has(pad) or int(state.get("walk_steps", 0)) < 1:
+		return SCRIPT_UNREAD
+	out.append({
+		"op": "walk",
+		"direction": int(Gen1Layout.PAD_DIRECTIONS[pad]),
+		"steps": int(state["walk_steps"]),
+	})
+	state.erase("walk_pad")
+	state.erase("walk_steps")
+	return next
 
 
 ## A `call` to a routine the layout does not name, walked in [param bank] and
@@ -2193,13 +2227,18 @@ static func _script_ret_branch(
 
 
 ## `cp n` against the faced direction, the species count `CountSetBits` left,
-## the map's tileset or one screen position; anything else ends the path.
+## the map's tileset, one screen position or where the player stands; anything
+## else ends the path.
 static func _script_compared(
 	ctx: Dictionary, pc: int, state: Dictionary, value: int
 ) -> int:
 	var layout: Dictionary = ctx["layout"]
 	var source: int = int(state.get("source", -1))
 	var next: int = pc + Gen1Layout.SCRIPT_SHORT_SIZE
+	## `cp $0` where every other row spends `and a`, YES being 0 either way.
+	if source == int(layout["current_menu_item"]) and value == 0:
+		_script_test_bit(ctx, state, -1)
+		return next
 	if source == int(layout["facing_direction"]):
 		state["facing"] = value
 		_script_tested(state, SCRIPT_TESTS_FACING)
@@ -2213,6 +2252,13 @@ static func _script_compared(
 		state["screen"] = screen
 		state["tile"] = value
 		_script_tested(state, SCRIPT_TESTS_TILE)
+		return next
+	for axis: int in Gen1Layout.SCRIPT_COORD_SOURCES.size():
+		if source != int(layout[Gen1Layout.SCRIPT_COORD_SOURCES[axis]]):
+			continue
+		state["axis"] = axis
+		state["coord"] = value
+		_script_tested(state, SCRIPT_TESTS_COORD)
 		return next
 	if source != int(layout["num_set_bits"]):
 		return SCRIPT_UNREAD
@@ -2327,6 +2373,9 @@ static func _script_node(
 		SCRIPT_TESTS_TILE:
 			return {"op": "screen_tile", "screen": int(state["screen"]),
 				"tile": int(state["tile"]), "then": fell, "else": taken}
+		SCRIPT_TESTS_COORD:
+			return {"op": "player_coord", "axis": int(state["axis"]),
+				"value": int(state["coord"]), "then": fell, "else": taken}
 	var branch: Dictionary = {
 		"op": "branch", "flag": int(tests), "then": taken, "else": fell,
 	}

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3719,6 +3719,8 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"map_text": &"_gen1_node_map_text",
 	"facility": &"_gen1_node_facility",
 	"replace_block": &"_gen1_node_replace_block",
+	"player_coord": &"_gen1_node_player_coord",
+	"walk": &"_gen1_node_walk",
 }
 
 
@@ -4013,6 +4015,19 @@ func _gen1_node_screen_tile(node: Dictionary, steps: Array, run: Dictionary) -> 
 			== int(node["tile"]),
 		steps, run
 	)
+
+
+func _gen1_node_player_coord(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	var axis: int = int(node["axis"])
+	var standing: int = player_cell.y if axis == 0 else player_cell.x
+	return _gen1_resolve_side(node, standing == int(node["value"]), steps, run)
+
+
+func _gen1_node_walk(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({
+		"type": &"walk", "direction": int(node["direction"]), "steps": int(node["steps"]),
+	})
+	return true
 
 
 ## `GetItemName` into `wStringBuffer`, which names a hidden item's receipt
@@ -4806,6 +4821,11 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 		&"toggle":
 			gen1_toggle_object(int(step["index"]), bool(step["hidden"]))
 			return true
+		&"walk":
+			events.append_array(_gen1_walk_player(
+				_movement_direction(int(step["direction"])), int(step["steps"])
+			))
+			return true
 		&"npc_trade":
 			state.apply_changes({}, {}, {"npc_trades": {int(step["trade_id"]): true}})
 			return true
@@ -4857,6 +4877,23 @@ func _gen1_battle_won(step: Dictionary, result: Dictionary) -> void:
 
 ## `ShowObject` and `HideObject`: one `wToggleableObjectFlags` bit by global
 ## index, and `UpdateSprites` behind it.
+## `CollisionCheckOnLand` skips every test while `wSimulatedJoypadStatesIndex`
+## stands, so only the map bounds refuse. The row ends before the walk is drawn.
+func _gen1_walk_player(direction: Vector2i, steps: int) -> Array:
+	var generated: Array = []
+	for _step: int in steps:
+		var destination: Vector2i = player_cell + direction
+		if not _cell_in_bounds(destination):
+			_queue_player_step(Vector2i.ZERO, 0, false, direction, STEP_KIND_WALK)
+			generated.append({
+				"type": &"movement_blocked", "player": true, "cell": destination,
+			})
+			break
+		player_cell = destination
+		_queue_player_step(direction, STEP_PASSES_WALK, false, direction, STEP_KIND_WALK)
+	return generated
+
+
 func gen1_toggle_object(index: int, hidden: bool) -> void:
 	if index < 0 or state == null or data == null:
 		return

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -3065,7 +3065,8 @@ func _party_holds_cleanse_tag() -> bool:
 func interact() -> bool:
 	if _world == null or _overlay_open() \
 		or _field_move_text or not _oak_pc_pages.is_empty() \
-		or _world.phone_ring_active() or _world.fishing_busy():
+		or _world.phone_ring_active() or _world.fishing_busy() \
+		or _world.scripted_movement_in_progress():
 		return false
 	var results: Array = _world.interact()
 	if results.is_empty():

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -652,7 +652,6 @@ static func _map(source: Dictionary, key: String) -> Dictionary:
 	return value if value is Dictionary else {}
 
 
-## The same for a list.
 static func _list(source: Dictionary, key: String) -> Array:
 	var value: Variant = source.get(key, [])
 	return value if value is Array else []

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -61,6 +61,14 @@ const LAYOUT: Dictionary = {
 	"num_set_bits": 0xD11E,
 	"cur_map_tileset": 0xD367,
 	"tile_map": 0xC3A0,
+	"player_y": 0xD361,
+	"player_x": 0xD362,
+	"update_sprites": 0x02D0,
+	"play_sound": 0x02E0,
+	"play_sound_wait": 0x02F0,
+	"start_simulating_joypad": 0x0320,
+	"simulated_joypad_index": 0xCD38,
+	"simulated_joypad_end": 0xCCD3,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
 const PREDEFS: Dictionary = {

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,15 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1486 lines of the 40468 here,
-## and Generation 1 has added 1312 more to the shared battle, world, palette,
+## files cost: `game/gen1` and its neighbours are 1486 lines of the 40477 here,
+## and Generation 1 has added 1321 more to the shared battle, world, palette,
 ## text, save and renderer code: 150 the battle animation engine, 140 the
 ## transition, 108 the three PCs, 85 the party menu, 42 the status screen, 40
-## the bag in a battle, 20 the map callbacks. Fifteen sweeps paid nothing.
-
-## The map callbacks are the one subsystem since: no Silph Co. floor carries a
-## card key door until its own load callback puts that block back.
-const MAX_COMMENT_LINES: int = 40468
+## the bag in a battle, 20 the map callbacks, 9 the scripted walk.
+const MAX_COMMENT_LINES: int = 40477
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,30 +130,32 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 250, "text": 289, "branch": 108, "choice": 13, "flag": 41,
+	&"red": {"rows": 253, "text": 309, "branch": 111, "choice": 17, "flag": 43,
 		"give_item": 25, "has_item": 15, "take_item": 3, "unknown": 55,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
-		"trade": 9, "has_money": 2, "spend_money": 2, "money_box": 2,
-		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2},
-	&"blue": {"rows": 250, "text": 289, "branch": 108, "choice": 13, "flag": 41,
+		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
+		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
+		"player_coord": 4, "walk": 2, "replace_block": 1},
+	&"blue": {"rows": 253, "text": 309, "branch": 111, "choice": 17, "flag": 43,
 		"give_item": 25, "has_item": 15, "take_item": 3, "unknown": 55,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
-		"trade": 9, "has_money": 2, "spend_money": 2, "money_box": 2,
-		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2},
-	&"yellow": {"rows": 296, "text": 327, "branch": 103, "choice": 14, "flag": 35,
+		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
+		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
+		"player_coord": 4, "walk": 2, "replace_block": 1},
+	&"yellow": {"rows": 299, "text": 347, "branch": 106, "choice": 18, "flag": 37,
 		"give_item": 24, "has_item": 12, "take_item": 3, "unknown": 59,
 		"pick_up_item": 108, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
-		"trade": 7, "has_money": 2, "spend_money": 2, "money_box": 2,
-		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 6},
+		"trade": 7, "has_money": 3, "spend_money": 3, "money_box": 4,
+		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 6,
+		"player_coord": 4, "walk": 2, "replace_block": 1},
 }
 ## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
 ## which no map text row names and the disassembly marks unreferenced. The
 ## `trade` rows are the eight `predef DoInGameTradeDialogue` sites plus
 ## `CinnabarLabTradeRoom`'s second, whose `jr` shares the first one's tail;
 ## Yellow ships neither trade house. The coin rows are the Game Corner's four
-## clerks. Museum 1F and the Safari Zone gate spend their money behind
-## `StartSimulatingJoypadStates`, which walks the player and which this port
-## has no counterpart for, so those two paths stay unread.
+## clerks. The Safari Zone gate takes its 500 from a row only that map's own
+## per-frame script names, so no event reaches it and it is not imported.
 
 ## `ToggleableObjectStates` as the corpus carries it: the objects a row lands on
 ## and how many start ON. Three rows name an object their map has not got.

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -74,15 +74,28 @@ const NURSE_PARTY: int = 4
 const CABLE_CLUB_COUNTER := Vector2i(11, 3)
 const CABLE_CLUB_ROWS: int = 12
 
-## `MtMoonPokecenter_Object`'s fourth object, the one row of the corpus that
-## spends money: `HasEnoughMoney`, `GivePokemon` and `SubBCDPredef` behind it,
-## with MONEY_BOX standing over the map for the question.
+## `MtMoonPokecenter_Object`'s fourth object: `HasEnoughMoney`, `GivePokemon`
+## and `SubBCDPredef` behind it, with MONEY_BOX standing over the map for the
+## question. Museum 1F's scientist is the corpus's other spender.
 const MT_MOON_POKECENTER: int = 0x44
 const MAGIKARP_SELLER := Vector2i(10, 6)
 const MAGIKARP_PRICE: int = 500
 const MAGIKARP_DEX: int = 129
 const MAGIKARP_LEVEL: int = 5
 const MAGIKARP_PURSE: int = 600
+
+## `Museum1F_Object`'s first object, at 12,4: the cell the player stands on
+## picks his line, and a refusal walks them one cell down.
+const MUSEUM_COUNTER := Vector2i(11, 4)
+const MUSEUM_TICKET: int = 50
+const MUSEUM_TICKET_FLAG: int = 104
+const MUSEUM_OFFER: String = "It's ¥50 for a"
+const MUSEUM_REFUSED: String = "Come again!"
+const MUSEUM_BOUGHT: String = "Right, ¥50!"
+const MUSEUM_BEHIND_COUNTER := Vector2i(13, 4)
+const MUSEUM_BACK_WAY: String = "You can't sneak"
+const MUSEUM_BELOW_COUNTER := Vector2i(12, 5)
+const MUSEUM_OTHER_SIDE: String = "Please go to the"
 
 ## `CeladonMartRoof_Object`'s three `bg_event` machines, read from below.
 const CELADON_MART_ROOF: int = 126
@@ -275,6 +288,7 @@ func _one_game() -> void:
 	_check_the_prize_counter()
 	_check_a_trade()
 	_check_the_magikarp_salesman()
+	_check_the_museum_ticket()
 	_check_the_coin_clerks()
 	_check_a_hidden_object()
 	_check_a_pc_opens()
@@ -926,6 +940,75 @@ func _check_the_magikarp_salesman() -> void:
 	_r.note("gen1 walk the MAGIKARP salesman with %d and with %d" % [
 		MAGIKARP_PURSE, MAGIKARP_PRICE - 1,
 	])
+
+
+## `Museum1FScientist1Text`, the corpus's one `StartSimulatingJoypadStates`: a
+## refusal is proved by the player standing a cell lower, mid-step.
+func _check_the_museum_ticket() -> void:
+	var world: Gen2WorldAPI = _museum_offer()
+	if world == null:
+		return
+	var refused: Array = world.choose_script_input(1)
+	_r.check(_event_text(refused).begins_with(MUSEUM_REFUSED),
+		"the refusal said %s." % [_event_text(refused)])
+	var walked: Array = world.run_event_queue(true)
+	_r.check(
+		world.player_cell == MUSEUM_COUNTER + Vector2i.DOWN
+			and world.scripted_movement_in_progress(),
+		"the refusal left the player at %s." % [world.player_cell]
+	)
+	_r.check(world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == MUSEUM_TICKET,
+		"a refused ticket cost %s." % [walked])
+	world = _museum_offer()
+	if world == null:
+		return
+	_r.check(_event_text(world.choose_script_input(0)).begins_with(MUSEUM_BOUGHT),
+		"the ticket was not sold.")
+	world.run_event_queue(true)
+	_r.check(
+		world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == 0
+			and world.state.is_event_flag_active(MUSEUM_TICKET_FLAG)
+			and world.player_cell == MUSEUM_COUNTER,
+		"the sale left %d and flag %s." % [
+			world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT),
+			world.state.is_event_flag_active(MUSEUM_TICKET_FLAG),
+		]
+	)
+	_check_the_museum_counter()
+	_r.note("gen1 walk the MUSEUM ticket bought and refused")
+
+
+func _check_the_museum_counter() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, MUSEUM_1F, MUSEUM_BEHIND_COUNTER)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	world.interact()
+	var back: String = String(world.pending_script_input().get("text", ""))
+	_r.check(back.begins_with(MUSEUM_BACK_WAY), "the back way said %s." % [back])
+	world = _r.open_world(0, MUSEUM_1F, MUSEUM_BELOW_COUNTER)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var side: String = _box_text(world)
+	_r.check(side.begins_with(MUSEUM_OTHER_SIDE), "the near side said %s." % [side])
+
+
+func _museum_offer() -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(0, MUSEUM_1F, MUSEUM_COUNTER)
+	if world == null:
+		return null
+	world.player_facing = Gen2WorldSprite.FACING_RIGHT
+	world.state.apply_changes({}, {}, {
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: MUSEUM_TICKET},
+	})
+	var window: Dictionary = _first_event(world.interact(), &"money_window_opened")
+	_r.check(int(window.get("money", -1)) == MUSEUM_TICKET,
+		"the ticket drew %s over the map." % [window])
+	return world if _r.check(
+		String(world.pending_script_input().get("text", "")).begins_with(MUSEUM_OFFER),
+		"the ticket asked %s." % [world.pending_script_input()]
+	) else null
 
 
 ## The row up to its YES/NO, which the offer itself is the question of, with

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -36,6 +36,7 @@ const KIND_HELP: Dictionary = {
 	&"prizes": "presses, rows down: CeladonPrizeMenu, read the same way. 0 the list, 1 SoYouWantPrizeText's YES/NO, 2 the box YES lands in",
 	&"trade": "presses: DoInGameTradeDialogue, faced up from the cell below the trader. 0 the offer and its YES/NO, 1 the party list YES opens",
 	&"deal": "presses: the MAGIKARP salesman, faced right from the cell beside him with the money box DisplayTextBoxID drew over the map",
+	&"ticket": "presses: Museum 1F's scientist, faced right from 11,4 with the fare exactly. 0 the offer, `2 1` the walk StartSimulatingJoypadStates makes of a refusal",
 	&"coins": "presses: GameCornerClerk1Text, faced up from the cell below her with GameCornerDrawCoinBox's own box over the map. 0 the offer and its YES/NO, 1 the box YES lands in",
 	&"card_key_door": "presses: PrintCardKeyText on a Silph Co. door, faced up from the cell below it with the CARD KEY owned. 0 CardKeySuccessText's first page, 1 its second, 2 the door those two presses opened",
 	&"trade_animation": "frames, half: TradeAnimation over the map, that many frames into the half named",
@@ -195,6 +196,7 @@ const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
 	&"prizes": BOX_REVEAL_FRAMES, &"trade": BOX_REVEAL_FRAMES,
 	&"coins": BOX_REVEAL_FRAMES, &"deal": BOX_REVEAL_FRAMES,
+	&"ticket": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -452,6 +454,7 @@ const STAGERS: Dictionary = {
 	&"prizes": &"_stage_prizes",
 	&"trade": &"_stage_trade",
 	&"deal": &"_stage_deal",
+	&"ticket": &"_stage_ticket",
 	&"coins": &"_stage_coins",
 	&"card_key_door": &"_stage_card_key_door",
 	&"unown_printer": &"_stage_unown_printer",
@@ -1076,6 +1079,10 @@ func _stage_deal() -> void:
 	)
 
 
+func _stage_ticket() -> void:
+	_stage_counter({"money": {Gen2WorldMartHost.MONEY_ACCOUNT: MUSEUM_FARE}}, PokeButton.RIGHT)
+
+
 func _stage_coins() -> void:
 	_stage_counter({
 		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY},
@@ -1111,6 +1118,7 @@ func _stage_counter(purse: Dictionary, facing: int = PokeButton.UP) -> void:
 
 ## Enough for every row of `VendingPrices` and not enough to widen the money box.
 const VENDING_MONEY: int = 1000
+const MUSEUM_FARE: int = 50
 
 
 ## `_UnownPrinter`'s browser: the first number is the slot, where 26 is the vacant


### PR DESCRIPTION
`StartSimulatingJoypadStates`' buffer holds one walking step per entry and `CollisionCheckOnLand` refuses no step while `wSimulatedJoypadStatesIndex` stands, so a `walk` node is a direction and a count. `Gen1Layout.PAD_DIRECTIONS` maps the pad bit onto the DOWN, UP, LEFT, RIGHT order `Gen2WorldAPI` already counts a direction in, and the step queues the walk the way an `applymovement` does.

Museum 1F's scientist is the corpus's one caller. `cp` against `wYCoord` and `wXCoord` picks which of his three lines opens, and `.not_right_of_scientist` compares the y still in `a` rather than the x below it.

Two routines that spend nothing in this port unlocked with him: `PlaySound` and `PlaySoundWaitForCurrent`. That is the ticket's own purchase, and the Game Corner poster, which sets EVENT_FOUND_ROCKET_HIDEOUT and writes block $43 at (8, 2) to open the stairs. `cp $0` against `wCurrentMenuItem` is how Museum 1F and Pewter City's second super nerd read a YES where every other row spends `and a`.

| Corpus | Before | After |
|---|---|---|
| `text_asm` rows read, Red and Blue | 250 | 253 |
| `text_asm` rows read, Yellow | 296 | 299 |
| Nodes read as `unknown` | 55 / 59 | 55 / 59 |

The Safari Zone gate's 500 is not behind this seam: it stands on a row only that map's own per-frame script names, so no event reaches it and no importer reads it. `SafariZoneEntranceAutoWalk`'s `FillMemory` form has no caller for the same reason and is not built.

A press is refused while a scripted walk is being drawn, which is `OverworldLoopLessDelay` reading BIT_SCRIPTED_MOVEMENT_STATE; that applies to both generations.

`gen1_walk.gd` buys the ticket, is refused into the walk and reads the scientist from all three sides on all three cartridges. GUT is 3839 green, `validate.gd -- all` is 93 topics green, the analyser is 0 warnings in 634 scripts, `replay_world.gd` is 33 routes with 0 failures, and the story walk is clean on all three profiles.