### PR TITLE
Open the Generation 1 Pokedex and trainer card

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -2898,6 +2898,14 @@ func player_backpic(kind: String) -> Dictionary:
 	return {"atlas": "player_back", "slot": slot, "width": cell, "height": cell}
 
 
+## `RedPicFront`, the one picture Generation 1 keeps outside both pic tables.
+func player_frontpic() -> Dictionary:
+	var cell: int = int(atlas("player_front").get("cell", 0))
+	if cell <= 0:
+		return {}
+	return {"atlas": "player_front", "slot": 0, "width": cell, "height": cell}
+
+
 func trainer_pic(number: int) -> Dictionary:
 	var entry: Dictionary = trainer(number)
 	if entry.is_empty():

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -615,17 +615,17 @@ static func read_dex_entry(rom: RomFile, layout: Dictionary, index: int) -> Dict
 	var feet: int = rom.u8(after)
 	var inches: int = rom.u8(after + 1)
 	var weight: int = rom.u16le(after + 2)
-	var text: String = ""
+	var pages := PackedStringArray()
 	if rom.u8(after + 4) == Gen1Layout.DEX_TEXT_FAR:
 		var target: int = RomFile.linear(rom.u8(after + 7), rom.u16le(after + 5))
-		text = Gen1Text.decode_dex_text(data, target, MAX_DEX_TEXT)
+		pages = Gen1Text.decode_dex_pages(data, target, MAX_DEX_TEXT)
 	return {
 		"category": category,
 		# Feet and inches as one decimal number, the way Generation 2 stores the
 		# same measurement: 204 is 2'04".
 		"height": feet * 100 + inches,
 		"weight": weight,
-		"text": text,
+		"pages": pages,
 	}
 
 
@@ -892,7 +892,7 @@ func _import_species(rom: RomFile, layout: Dictionary, on_progress: Callable) ->
 				"category": entry["category"],
 				"height": entry["height"],
 				"weight": entry["weight"],
-				"pages": [entry["text"]],
+				"pages": Array(entry["pages"] as PackedStringArray),
 			},
 			"palette": _import_palette(rom, layout, dex),
 		})
@@ -1377,14 +1377,22 @@ func _import_pics(
 			player_back, slot
 		)
 
+	## `RedPicFront`, which `DrawTrainerInfo` and Oak's speech draw and which no
+	## `BaseStats` row names, so it is imported beside the back pics rather than
+	## with the species.
+	var player_front: Dictionary = PokeTiles.new_atlas(Gen1Layout.FRONTPIC_MAX_TILES, 1)
+	_decode_pic(codec, rom, int(layout["pic_player_front"]), player_front, 0)
+
 	# A wrong offset decodes nothing, so an atlas short of a cell is a bad pin.
 	var wanted: Dictionary = {
 		"front": Gen1Layout.SPECIES_COUNT, "back": Gen1Layout.SPECIES_COUNT,
 		"trainers": Gen1Layout.TRAINER_CLASS_COUNT,
 		"player_back": Gen1Layout.PLAYER_BACKPICS.size(),
+		"player_front": 1,
 	}
 	var atlases: Dictionary = {
-		"front": front, "back": back, "trainers": trainers, "player_back": player_back,
+		"front": front, "back": back, "trainers": trainers,
+		"player_back": player_back, "player_front": player_front,
 	}
 	var directory: String = RomCache.directory_for(rom.id, rom.sha1)
 	var out: Dictionary = {}
@@ -1419,6 +1427,36 @@ func _import_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"offset": int(layout["ball_tiles"]),
 			"tiles": Gen1Layout.BALL_TILES,
 			"first_code": 0,
+			"bits": 2,
+		},
+		"pokedex_tiles": {
+			"offset": int(layout["pokedex_tiles"]),
+			"tiles": Gen1Layout.POKEDEX_TILES,
+			"first_code": Gen1Layout.POKEDEX_FIRST_CODE,
+			"bits": 2,
+		},
+		"trainer_card_box": {
+			"offset": int(layout["trainer_card_box"]),
+			"tiles": Gen1Layout.TRAINER_CARD_BOX_TILES,
+			"first_code": Gen1Layout.TRAINER_CARD_BOX_CODE,
+			"bits": 2,
+		},
+		"trainer_card_names": {
+			"offset": int(layout["trainer_card_names"]),
+			"tiles": Gen1Layout.TRAINER_CARD_NAME_TILES,
+			"first_code": Gen1Layout.TRAINER_CARD_NAME_CODE,
+			"bits": 2,
+		},
+		"badge_numbers": {
+			"offset": int(layout["badge_numbers"]),
+			"tiles": Gen1Layout.BADGE_NUMBER_TILES,
+			"first_code": Gen1Layout.BADGE_NUMBER_CODE,
+			"bits": 2,
+		},
+		"badge_faces": {
+			"offset": int(layout["badge_faces"]),
+			"tiles": Gen1Layout.BADGE_FACE_TILES,
+			"first_code": Gen1Layout.BADGE_FACE_CODE,
 			"bits": 2,
 		},
 		"stats_p": {

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -103,6 +103,13 @@ const PAL_GRAYMON: int = 0x19
 ## `PalPacket_PartyMenu`'s first row, which `BlkPacket_PartyMenu` gives the two
 ## columns the party menu's icons stand in and nothing else.
 const PAL_MEWMON: int = 0x10
+## `PalPacket_Pokedex`, which is what `BlkPacket_Pokedex` gives every cell of the
+## dex outside the picture box.
+const PAL_BROWNMON: int = 0x15
+## `PalPacket_TrainerCard`'s four, in its own order.
+const PAL_REDMON: int = 0x12
+const PAL_YELLOWMON: int = 0x18
+const PAL_BADGE: int = 0x22
 const PAL_CAVE: int = 0x23
 ## The three rows `GetHealthBarColor` picks between, under the names
 ## [method GameData.bar_palette] takes them by. Generation 1 has no exp bar.
@@ -643,6 +650,37 @@ const DEX_RATING_STEP: int = 10
 ## `PokeballTileGraphics`' four; only the ball itself is drawn here.
 const BALL_TILES: int = 4
 const DEX_COMPLETION_TEXT_AT: int = -TEXT_FAR_STUB_BYTES
+
+## `LoadPokedexTilePatterns`: `PokedexTileGraphics` at `vChars2 tile $60`, over
+## the text box sheet, with `PokeballTileGraphics`' first tile at $72 behind it.
+const POKEDEX_TILES: int = 18
+const POKEDEX_FIRST_CODE: int = 0x60
+const POKEDEX_BALL_CODE: int = 0x72
+
+## `DrawTrainerInfo`'s own four sheets and where each lands. `BlankLeaderNames`
+## runs straight on into `CircleTile`, which is why its `$17` is one longer than
+## the file: `$76` is the circle "●BADGES●" is written with, and the sixteen
+## under it are the leader names the international ROMs erased.
+const TRAINER_CARD_BOX_TILES: int = 9
+const TRAINER_CARD_BOX_CODE: int = 0x77
+## The ninth tile, which goes to `vChars1 tile $57` rather than beside the
+## other eight, and is the card's background.
+const TRAINER_CARD_FILL_CODE: int = 0xD7
+const TRAINER_CARD_NAME_TILES: int = 23
+const TRAINER_CARD_NAME_CODE: int = 0x60
+const TRAINER_CARD_CIRCLE_CODE: int = 0x76
+const BADGE_NUMBER_TILES: int = 8
+const BADGE_NUMBER_CODE: int = 0xD8
+## `GymLeaderFaceAndBadgeTileGraphics`: eight tiles a leader, the face first and
+## its badge four on (`DrawBadges`' own `add 4`).
+const BADGE_FACE_TILES: int = 64
+const BADGE_FACE_CODE: int = 0x20
+const BADGE_FACE_STRIDE: int = 8
+const BADGE_FACE_BADGE_AT: int = 4
+## `TextBoxGraphics` tile 13, which the card copies on its own to `vChars1 tile
+## $56` for the play timer's colon.
+const TRAINER_CARD_COLON_TILE: int = 13
+const TRAINER_CARD_COLON_CODE: int = 0xD6
 
 ## `NUM_BOXES` and `MONS_PER_BOX`, which `BOX_NUM_MASK` bounds `wCurrentBoxNum`
 ## to.
@@ -1258,11 +1296,17 @@ const RED_BLUE: Dictionary = {
 	"prize_mon_levels": 0x5298A,
 	"font": 0x11A80,
 	"text_box": 0x12288,
+	"pokedex_tiles": 0x12488,
 	"battle_font": 0x11EA0,
 	"battle_hud_1": 0x12080,
 	"battle_hud_2": 0x12098,
 	"pic_player_back": 0x33E0A,
 	"pic_old_man_back": 0x33E9A,
+	"pic_player_front": 0x12EDE,
+	"trainer_card_box": 0x2FB98,
+	"trainer_card_names": 0x2FC28,
+	"badge_numbers": 0x2FD98,
+	"badge_faces": 0x0EA9E,
 	"map_headers": 0x001AE,
 	"map_header_banks": 0x0C23D,
 	"map_songs": 0x0C04D,
@@ -1440,12 +1484,18 @@ const YELLOW: Dictionary = {
 	"prize_mon_levels": 0x528EA,
 	"font": 0x10600,
 	"text_box": 0x10E18,
+	"pokedex_tiles": 0x11018,
 	"battle_font": 0x10A20,
 	"battle_hud_1": 0x10C00,
 	"battle_hud_2": 0x10C18,
 	## Yellow moved both back pics out of "Pics 4" and into their own bank.
 	"pic_player_back": 0xF43B1,
 	"pic_old_man_back": 0xF4441,
+	"pic_player_front": 0x11A97,
+	"trainer_card_box": 0xF5C24,
+	"trainer_card_names": 0xF5CB4,
+	"badge_numbers": 0xF5E24,
+	"badge_faces": 0x0E91B,
 	"map_headers": 0xFC1F2,
 	"map_header_banks": 0xFC3E4,
 	"map_songs": 0xFC000,

--- a/game/gen1/gen1_text.gd
+++ b/game/gen1/gen1_text.gd
@@ -159,24 +159,37 @@ static func terminated_end(data: PackedByteArray, offset: int, max_length: int) 
 	return end + 1
 
 
-## A Pokedex description: ends on `<DEXEND>` rather than a terminator, and its
-## `<LINE>` and `<PAGE>` breaks become newlines.
-static func decode_dex_text(data: PackedByteArray, offset: int, max_length: int) -> String:
+## A Pokedex description as the pages it prints. `PageChar` clears the box and
+## starts again at its own corner, so `<PAGE>` parts one page from the next where
+## `<LINE>` and `<NEXT>` only drop a row. `PlaceDexEnd` writes a full stop before
+## it returns, which is why no description carries its own.
+static func decode_dex_pages(
+	data: PackedByteArray, offset: int, max_length: int
+) -> PackedStringArray:
+	var pages := PackedStringArray()
 	var out: String = ""
 	for i: int in max_length:
 		var at: int = offset + i
 		if at < 0 or at >= data.size():
 			break
 		var byte: int = data[at]
-		if byte == DEX_END or byte == TERMINATOR:
+		if byte == DEX_END:
+			out += "."
+			break
+		if byte == TERMINATOR:
 			break
 		if byte == TEXT_START:
 			continue
-		if byte == LINE or byte == NEXT_LINE or byte == PAGE:
+		if byte == PAGE:
+			pages.append(out)
+			out = ""
+			continue
+		if byte == LINE or byte == NEXT_LINE:
 			out += "\n"
 			continue
 		out += character(byte)
-	return out
+	pages.append(out)
+	return pages
 
 
 ## A string to the codes that draw it, one tile each: [method decode]'s inverse

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 117
+const FORMAT_VERSION: int = 118
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/battle_tiles.gd
+++ b/game/render/battle_tiles.gd
@@ -98,6 +98,10 @@ const GEN1_LINE_ARROW: int = 0x6F
 const GEN1_ID: int = 0x73
 const GEN1_NUMERO: int = 0x74
 const GEN1_TO: int = 0x70
+## `'─'`, the listing's own SEEN/OWN divider, and the last tile the Pokedex page
+## carries.
+const GEN1_RULE: int = 0x7A
+const GEN1_POKEDEX_LAST_TILE: int = 0x7F
 
 ## Read through the instance so one panel-drawing routine serves both.
 var hp_label: int = HP_LABEL
@@ -204,6 +208,34 @@ static func gen1_stats_page(data: GameData) -> Gen2BattleTiles:
 	var loaded: int = 0
 	for sheet: Array in sheets:
 		var meta: Dictionary = data.tile_sheet(String(sheet[0]))
+		if meta.is_empty():
+			continue
+		if out._copy(
+			data.tile_indices(String(sheet[0])), int(meta.get("width", 0)),
+			int(sheet[1]), int(sheet[2]), int(sheet[3])
+		):
+			loaded += 1
+	return out if loaded == sheets.size() else null
+
+
+## `LoadPokedexTilePatterns`'s page: `LoadHpBarAndStatusTilePatterns` first, then
+## `PokedexTileGraphics` over its front and `PokeballTileGraphics`' first tile at
+## $72. It runs to $7F rather than the battle's $78 because the listing's own
+## divider is `'─'`, which the two sheets happen to draw identically.
+static func gen1_pokedex_page(data: GameData) -> Gen2BattleTiles:
+	var out := Gen2BattleTiles.new()
+	out._first = GEN1_FIRST_TILE
+	out._last = GEN1_POKEDEX_LAST_TILE
+	out._width = (GEN1_POKEDEX_LAST_TILE - GEN1_FIRST_TILE + 1) * TILE
+	out._tiles.resize(out._width * TILE)
+	var sheets: Array = [
+		["battle_font", GEN1_BATTLE_FONT_AT, 0, -1],
+		["pokedex_tiles", Gen1Layout.POKEDEX_FIRST_CODE, 0, -1],
+		["battle_balls", Gen1Layout.POKEDEX_BALL_CODE, 0, 1],
+	]
+	var loaded: int = 0
+	for sheet: Array in sheets:
+		var meta: Dictionary = data.tile_sheet(String(sheet[0])) if data != null else {}
 		if meta.is_empty():
 			continue
 		if out._copy(

--- a/game/render/mart_page.gd
+++ b/game/render/mart_page.gd
@@ -180,9 +180,11 @@ func render(state: Dictionary) -> Image:
 
 
 ## `PRINTNUM_MONEY`'s own shape: `¥` against the number, the pair right aligned
-## in seven cells. `PrintBCDNumber` lays the prices down the same way.
-static func money_string(amount: int) -> String:
-	return ("¥%d" % maxi(amount, 0)).lpad(MONEY_CELLS)
+## in seven cells. `PrintBCDNumber` lays the prices down the same way, and its
+## own LEFT_ALIGN flag is [param left_align], which drops the padding.
+static func money_string(amount: int, left_align: bool = false) -> String:
+	var text: String = "¥%d" % maxi(amount, 0)
+	return text if left_align else text.lpad(MONEY_CELLS)
 
 
 ## One of the three balance windows as an image and the tile it stands at:

--- a/game/render/pic_image.gd
+++ b/game/render/pic_image.gd
@@ -287,14 +287,18 @@ static func frontpic_pad_rows(height: int) -> int:
 
 ## Where the seven-tile cell leaves a front pic, in pixels: bottom-aligned, one
 ## blank column in, and on the other side of the cell when the picture is
-## mirrored. [param size] is the pic's own pixel size.
-static func frontpic_origin(size: Vector2i, mirrored: bool = false) -> Vector2i:
+## mirrored. [param size] is the pic's own pixel size, and [param generation]
+## picks between `PadFrontpic`'s blank column and `LoadUncompressedSpriteData`'s
+## centring, which is the same split [method frontpic_pad_columns] makes.
+static func frontpic_origin(
+	size: Vector2i, mirrored: bool = false, generation: int = RomRegistry.GEN2
+) -> Vector2i:
 	@warning_ignore("integer_division")
 	var columns: int = size.x / PokeTiles.TILE_WIDTH
 	@warning_ignore("integer_division")
 	var rows: int = size.y / PokeTiles.TILE_WIDTH
 	return Vector2i(
-		frontpic_pad_columns(columns, mirrored), frontpic_pad_rows(rows)
+		frontpic_pad_columns(columns, mirrored, generation), frontpic_pad_rows(rows)
 	) * PokeTiles.TILE_WIDTH
 
 

--- a/game/render/pokedex_page.gd
+++ b/game/render/pokedex_page.gd
@@ -199,6 +199,10 @@ const ARROW_LEFT: int = 0x3D
 const ARROW_RIGHT: int = 0x3E
 
 var font: Gen2Font = null
+## `LoadPokedexTilePatterns`' own page, on a Generation 1 cache alone. Every
+## layout below that reads it is that generation's; a Crystal cache leaves it
+## null and takes none of them.
+var gen1_tiles: Gen2BattleTiles = null
 var _sheet: PackedByteArray = PackedByteArray()
 var _footprints: PackedByteArray = PackedByteArray()
 var _unown_font: PackedByteArray = PackedByteArray()
@@ -223,6 +227,13 @@ static func from_data(data: GameData) -> Gen2PokedexPage:
 		return null
 	var out := Gen2PokedexPage.new()
 	out.font = glyphs
+	if data.generation == RomRegistry.GEN1:
+		out.gen1_tiles = Gen2BattleTiles.gen1_pokedex_page(data)
+		## `BlkPacket_Pokedex` gives every cell outside the picture box palette
+		## 0, which `PalPacket_Pokedex` fills with PAL_BROWNMON; the box itself
+		## is the species' own and is blitted over this.
+		out._palette = data.world_palette(Gen1Layout.PAL_BROWNMON)
+		return out
 	out._sheet = data.tile_indices("pokedex")
 	out._footprints = data.tile_indices("footprints")
 	out._unown_font = data.tile_indices("unown_font")
@@ -235,6 +246,8 @@ static func from_data(data: GameData) -> Gen2PokedexPage:
 
 
 func ready() -> bool:
+	if gen1_tiles != null:
+		return font != null and _palette.size() == PokePalette.COLORS_PER_PIC
 	return font != null and not _sheet.is_empty() and not _footprints.is_empty() \
 		and not _objects.is_empty() and not _question_mark.is_empty() \
 		and _object_palette.size() == PokePalette.COLORS_PER_PIC \
@@ -583,18 +596,24 @@ func image(map: PackedInt32Array, pic: Image = null, pic_at: Vector2i = Vector2i
 
 
 ## `PadFrontpic`, which is what makes every species fill the same seven by seven
-## box: one blank column on the left, the picture sitting on the box's floor, and
-## the rest filled with colour 0. A 5x5 species is padded to 7x7 before the copy,
-## so the box is never the screen's own background showing through.
-static func pad_pic(pic: Image, background: Color) -> Image:
+## box: the picture sitting on the box's floor and the rest filled with colour 0.
+## A 5x5 species is padded to 7x7 before the copy, so the box is never the
+## screen's own background showing through. Generation 1's own
+## `LoadUncompressedSpriteData` centres a narrow pic where `PadFrontpic` lays one
+## blank column in front of it, which is [method Gen2PicImage.frontpic_origin]'s
+## own split.
+static func pad_pic(
+	pic: Image, background: Color, generation: int = RomRegistry.GEN2
+) -> Image:
 	var side: int = PIC_COLUMNS * TILE
 	var out: Image = Image.create_empty(side, side, false, Image.FORMAT_RGBA8)
 	out.fill(background)
 	if pic == null:
 		return out
-	out.blit_rect(pic, Rect2i(Vector2i.ZERO, pic.get_size()), Vector2i(
-		0 if pic.get_width() >= side else TILE, side - pic.get_height()
-	))
+	out.blit_rect(
+		pic, Rect2i(Vector2i.ZERO, pic.get_size()),
+		Gen2PicImage.frontpic_origin(pic.get_size(), false, generation)
+	)
 	return out
 
 
@@ -911,6 +930,16 @@ func _window_number(map: PackedInt32Array, x: int, y: int, value: int) -> void:
 func _blit_tile(
 	into: PackedByteArray, into_width: int, tile: int, at_x: int, at_y: int
 ) -> void:
+	# Generation 1 loads no font of its own here, so nothing on its two screens
+	# is inverted: $60 to $7F is `LoadPokedexTilePatterns`' page and the rest the
+	# ordinary font.
+	if gen1_tiles != null:
+		if tile >= Gen1Layout.POKEDEX_FIRST_CODE \
+			and tile <= Gen2BattleTiles.GEN1_POKEDEX_LAST_TILE:
+			gen1_tiles.draw(tile, into, into_width, at_x, at_y)
+			return
+		font.draw_code(tile, into, into_width, at_x, at_y)
+		return
 	# `Pokedex_LoadUnownFont` lands on top of the sheet, so this run is the
 	# alphabet on the Unown screen and the sheet's own tiles everywhere else.
 	if _unown_letters and tile >= UNOWN_FIRST_CHAR \
@@ -974,3 +1003,228 @@ func _invert(into: PackedByteArray, into_width: int, at_x: int, at_y: int) -> vo
 				continue
 			var at: int = row * into_width + column
 			into[at] = 0 if into[at] == 3 else 3
+
+
+## `ShowPokedexMenu`'s two screens (engine/menus/pokedex.asm) are plain tile
+## grids: no window layer, no objects, and the cursor is a `▶` in the map.
+
+## `.doPokemonListMenu`'s `wTopMenuItemY` and `PlaceMenuCursor`'s double-spaced
+## step. `.printPokemonLoop`'s `ld de, -SCREEN_WIDTH` is what puts the number a
+## row above the name.
+const GEN1_LIST_TOP: int = 3
+const GEN1_ROW_STEP: int = 2
+const GEN1_LIST_CURSOR_X: int = 0
+const GEN1_LIST_NUMBER_X: int = 1
+const GEN1_LIST_BALL_X: int = 3
+const GEN1_LIST_NAME_X: int = 4
+const GEN1_LIST_DIGITS: int = 3
+
+## `HandlePokedexListMenu`'s furniture: the column, the rule and the labels.
+const GEN1_RULE_AT := Vector2i(15, 8)
+const GEN1_RULE_WIDTH: int = 5
+const GEN1_LINE_X: int = 14
+const GEN1_CONTENTS_AT := Vector2i(1, 1)
+const GEN1_SEEN_AT := Vector2i(16, 2)
+const GEN1_OWN_AT := Vector2i(16, 5)
+const GEN1_COUNT_DIGITS: int = 3
+const GEN1_SIDE_MENU_AT := Vector2i(16, 10)
+const GEN1_SIDE_CURSOR_X: int = 15
+
+## `DrawPokedexVerticalLine`, run twice nine rows at a time, the second starting
+## on the first's last row.
+const GEN1_LINE: int = 0x71
+const GEN1_LINE_ALT: int = 0x70
+const GEN1_LINE_HEIGHT: int = 9
+## `.writeTile`'s pokeball, beside every species owned.
+const GEN1_CAUGHT_BALL: int = 0x72
+
+## `ShowPokedexDataInternal`'s border and the divider under the picture.
+const GEN1_ENTRY_TOP_LEFT: int = 0x63
+const GEN1_ENTRY_TOP: int = 0x64
+const GEN1_ENTRY_TOP_RIGHT: int = 0x65
+const GEN1_ENTRY_LEFT: int = 0x66
+const GEN1_ENTRY_RIGHT: int = 0x67
+const GEN1_ENTRY_BOTTOM_LEFT: int = 0x6C
+const GEN1_ENTRY_BOTTOM: int = 0x6F
+const GEN1_ENTRY_BOTTOM_RIGHT: int = 0x6E
+const GEN1_ENTRY_ROWS: int = 16
+## `PokedexDataDividerLine`, verbatim.
+const GEN1_DIVIDER: Array[int] = [
+	0x68, 0x69, 0x6B, 0x69, 0x6B, 0x69, 0x6B, 0x69, 0x6B, 0x6B,
+	0x6B, 0x6B, 0x69, 0x6B, 0x69, 0x6B, 0x69, 0x6B, 0x69, 0x6A,
+]
+const GEN1_DIVIDER_ROW: int = 9
+
+## The entry's own coordinates, each an `hlcoord` of its own.
+const GEN1_ENTRY_PIC_AT := Vector2i(1, 1)
+const GEN1_ENTRY_NAME_AT := Vector2i(9, 2)
+const GEN1_ENTRY_CATEGORY_AT := Vector2i(9, 4)
+const GEN1_ENTRY_HEIGHT_AT := Vector2i(9, 6)
+const GEN1_ENTRY_WEIGHT_AT := Vector2i(9, 8)
+const GEN1_ENTRY_NUMBER_AT := Vector2i(2, 8)
+const GEN1_ENTRY_TEXT_AT := Vector2i(1, 11)
+const GEN1_ENTRY_ARROW_AT := Vector2i(18, 16)
+const GEN1_ENTRY_LINES: int = 3
+## `HeightWeightText`'s two rows, whose `?`s the numbers are printed over.
+const GEN1_HEIGHT_TEXT: String = "HT  ?"
+const GEN1_WEIGHT_TEXT: String = "WT   ???lb"
+const GEN1_FEET_AT: int = 12
+const GEN1_INCHES_AT: int = 15
+const GEN1_WEIGHT_NUMBER_AT: int = 11
+const GEN1_WEIGHT_DIGITS: int = 5
+## Where `.next`'s own shuffle puts the point, and the digit it steps forward.
+const GEN1_WEIGHT_POINT_AT: int = 15
+const GEN1_WEIGHT_TENTH: int = 10
+
+## `'′'` and `'″'` are the dex sheet's first two tiles, not font characters.
+const GEN1_FEET_MARK: int = 0x60
+const GEN1_INCHES_MARK: int = 0x61
+const GEN1_NUMERO: int = 0x74
+const GEN1_DOT: int = 0xF2
+const GEN1_SPACE: int = 0x7F
+const GEN1_CURSOR: int = 0xED
+const GEN1_UNFILLED_CURSOR: int = 0xEC
+const GEN1_DOWN_ARROW: int = 0xEE
+
+
+## `ShowPokedexMenu`'s listing. [param side_cursor] is -1 while the side menu is
+## closed, and the listing's arrow is hollow while it is not, which is
+## `PlaceUnfilledArrowMenuCursor`.
+func gen1_list_map(
+	rows: Array, seen: int, caught: int, cursor: int, side_cursor: int = -1
+) -> PackedInt32Array:
+	var map: PackedInt32Array = gen1_blank_map()
+	_put(map, GEN1_LINE_X, 0, GEN1_LINE)
+	for run: int in 2:
+		for row: int in GEN1_LINE_HEIGHT:
+			_put(
+				map, GEN1_LINE_X, 1 + run * (GEN1_LINE_HEIGHT - 1) + row,
+				GEN1_LINE_ALT if row % 2 == 1 else GEN1_LINE
+			)
+	_fill(map, GEN1_RULE_AT.x, GEN1_RULE_AT.y, GEN1_RULE_WIDTH, Gen2BattleTiles.GEN1_RULE)
+	_gen1_text(map, GEN1_CONTENTS_AT.x, GEN1_CONTENTS_AT.y, "CONTENTS")
+	_gen1_text(map, GEN1_SEEN_AT.x, GEN1_SEEN_AT.y, "SEEN")
+	_gen1_number(map, GEN1_SEEN_AT.x, GEN1_SEEN_AT.y + 1, seen, GEN1_COUNT_DIGITS)
+	_gen1_text(map, GEN1_OWN_AT.x, GEN1_OWN_AT.y, "OWN")
+	_gen1_number(map, GEN1_OWN_AT.x, GEN1_OWN_AT.y + 1, caught, GEN1_COUNT_DIGITS)
+	for index: int in Gen2Pokedex.GEN1_SIDE_ROWS.size():
+		_gen1_text(
+			map, GEN1_SIDE_MENU_AT.x, GEN1_SIDE_MENU_AT.y + index * GEN1_ROW_STEP,
+			Gen2Pokedex.GEN1_SIDE_ROWS[index]
+		)
+	for index: int in rows.size():
+		_gen1_list_row(map, index, rows[index] as Dictionary)
+	if cursor >= 0:
+		_put(
+			map, GEN1_LIST_CURSOR_X, GEN1_LIST_TOP + cursor * GEN1_ROW_STEP,
+			GEN1_UNFILLED_CURSOR if side_cursor >= 0 else GEN1_CURSOR
+		)
+	if side_cursor >= 0:
+		_put(
+			map, GEN1_SIDE_CURSOR_X,
+			GEN1_SIDE_MENU_AT.y + side_cursor * GEN1_ROW_STEP, GEN1_CURSOR
+		)
+	return map
+
+
+func _gen1_list_row(map: PackedInt32Array, index: int, row: Dictionary) -> void:
+	var y: int = GEN1_LIST_TOP + index * GEN1_ROW_STEP
+	_gen1_text(
+		map, GEN1_LIST_NUMBER_X, y - 1,
+		"%0*d" % [GEN1_LIST_DIGITS, int(row.get("number", 0))]
+	)
+	if bool(row.get("caught", false)):
+		_put(map, GEN1_LIST_BALL_X, y, GEN1_CAUGHT_BALL)
+	_gen1_text(map, GEN1_LIST_NAME_X, y, String(row.get("name", "")))
+
+
+## `ShowPokedexDataInternal`. [param entry] is [method GameData.dex_entry]'s own
+## record and [param arrow] `PageChar`'s `▼`, which the first page waits under.
+func gen1_entry_map(
+	number: int, name: String, entry: Dictionary, caught: bool, page: int,
+	arrow: bool
+) -> PackedInt32Array:
+	var map: PackedInt32Array = gen1_blank_map()
+	_fill(map, 0, 0, COLUMNS, GEN1_ENTRY_TOP)
+	_fill(map, 0, ROWS - 1, COLUMNS, GEN1_ENTRY_BOTTOM)
+	_column(map, 0, 1, GEN1_ENTRY_ROWS, GEN1_ENTRY_LEFT)
+	_column(map, COLUMNS - 1, 1, GEN1_ENTRY_ROWS, GEN1_ENTRY_RIGHT)
+	_put(map, 0, 0, GEN1_ENTRY_TOP_LEFT)
+	_put(map, COLUMNS - 1, 0, GEN1_ENTRY_TOP_RIGHT)
+	_put(map, 0, ROWS - 1, GEN1_ENTRY_BOTTOM_LEFT)
+	_put(map, COLUMNS - 1, ROWS - 1, GEN1_ENTRY_BOTTOM_RIGHT)
+	_tiles(map, 0, GEN1_DIVIDER_ROW, GEN1_DIVIDER)
+	_gen1_text(map, GEN1_ENTRY_HEIGHT_AT.x, GEN1_ENTRY_HEIGHT_AT.y, GEN1_HEIGHT_TEXT)
+	_put(map, GEN1_FEET_AT + 2, GEN1_ENTRY_HEIGHT_AT.y, GEN1_FEET_MARK)
+	_gen1_text(map, GEN1_INCHES_AT, GEN1_ENTRY_HEIGHT_AT.y, "??")
+	_put(map, GEN1_INCHES_AT + 2, GEN1_ENTRY_HEIGHT_AT.y, GEN1_INCHES_MARK)
+	_gen1_text(map, GEN1_ENTRY_WEIGHT_AT.x, GEN1_ENTRY_WEIGHT_AT.y, GEN1_WEIGHT_TEXT)
+	_gen1_text(map, GEN1_ENTRY_NAME_AT.x, GEN1_ENTRY_NAME_AT.y, name)
+	_gen1_text(
+		map, GEN1_ENTRY_CATEGORY_AT.x, GEN1_ENTRY_CATEGORY_AT.y,
+		String(entry.get("category", ""))
+	)
+	_put(map, GEN1_ENTRY_NUMBER_AT.x, GEN1_ENTRY_NUMBER_AT.y, GEN1_NUMERO)
+	_put(map, GEN1_ENTRY_NUMBER_AT.x + 1, GEN1_ENTRY_NUMBER_AT.y, GEN1_DOT)
+	_gen1_text(
+		map, GEN1_ENTRY_NUMBER_AT.x + 2, GEN1_ENTRY_NUMBER_AT.y,
+		"%0*d" % [GEN1_LIST_DIGITS, number]
+	)
+	if not caught:
+		return map
+	_gen1_measurements(map, int(entry.get("height", 0)), int(entry.get("weight", 0)))
+	var pages: Array = entry.get("pages", []) as Array
+	_gen1_paragraph(map, String(pages[page]) if page < pages.size() else "")
+	if arrow:
+		_put(map, GEN1_ENTRY_ARROW_AT.x, GEN1_ENTRY_ARROW_AT.y, GEN1_DOWN_ARROW)
+	return map
+
+
+## The two lines the caught check gates: feet and inches over the template's
+## `?`s, then five digits and `.next`'s own shuffle, which steps the last digit
+## one cell on and writes the point behind it.
+func _gen1_measurements(map: PackedInt32Array, height: int, weight: int) -> void:
+	var y: int = GEN1_ENTRY_HEIGHT_AT.y
+	@warning_ignore("integer_division")
+	_gen1_number(map, GEN1_FEET_AT, y, height / 100, 2)
+	_put(map, GEN1_FEET_AT + 2, y, GEN1_FEET_MARK)
+	_gen1_text(map, GEN1_INCHES_AT, y, "%02d" % (height % 100))
+	_put(map, GEN1_INCHES_AT + 2, y, GEN1_INCHES_MARK)
+	var row: int = GEN1_ENTRY_WEIGHT_AT.y
+	_gen1_number(map, GEN1_WEIGHT_NUMBER_AT, row, weight, GEN1_WEIGHT_DIGITS)
+	if weight < GEN1_WEIGHT_TENTH:
+		_gen1_text(map, GEN1_WEIGHT_POINT_AT - 1, row, "0")
+	_put(map, GEN1_WEIGHT_POINT_AT + 1, row, map[row * COLUMNS + GEN1_WEIGHT_POINT_AT])
+	_put(map, GEN1_WEIGHT_POINT_AT, row, GEN1_DOT)
+
+
+## `TextCommandProcessor` from `bccoord 1, 11`, `<NEXT>` dropping two rows.
+func _gen1_paragraph(map: PackedInt32Array, text: String) -> void:
+	var lines: PackedStringArray = text.split("\n")
+	for index: int in mini(lines.size(), GEN1_ENTRY_LINES):
+		_gen1_text(
+			map, GEN1_ENTRY_TEXT_AT.x,
+			GEN1_ENTRY_TEXT_AT.y + index * GEN1_ROW_STEP, lines[index]
+		)
+
+
+## `ClearScreen`, which fills the map with spaces rather than a background tile.
+func gen1_blank_map() -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	map.fill(GEN1_SPACE)
+	return map
+
+
+## `PlaceString` through the other generation's codec.
+func _gen1_text(map: PackedInt32Array, x: int, y: int, text: String) -> void:
+	var codes: PackedByteArray = Gen1Text.encode(text)
+	for index: int in codes.size():
+		_put(map, x + index, y, codes[index])
+
+
+## `PrintNumber` with no leading-zero flag.
+func _gen1_number(
+	map: PackedInt32Array, x: int, y: int, value: int, digits: int
+) -> void:
+	_gen1_text(map, x, y, Gen2Pokedex.print_num(value, digits, digits))

--- a/game/render/stats_screen_page.gd
+++ b/game/render/stats_screen_page.gd
@@ -276,19 +276,23 @@ static func compose(
 		return image
 	image.blit_rect(
 		art, Rect2i(Vector2i.ZERO, art.get_size()),
-		page.pic_at() + pic_origin(art.get_size(), snapshot)
+		page.pic_at() + pic_origin(
+			art.get_size(), snapshot, data.generation if data != null else RomRegistry.GEN2
+		)
 	)
 	return image
 
 
 ## Where that picture sits: the animation fills the cell, so only a still one is
 ## padded.
-static func pic_origin(size: Vector2i, snapshot: Dictionary) -> Vector2i:
+static func pic_origin(
+	size: Vector2i, snapshot: Dictionary, generation: int = RomRegistry.GEN2
+) -> Vector2i:
 	if size.x >= pic_size():
 		return Vector2i.ZERO
 	return Gen2PicImage.frontpic_origin(size, pic_mirrored(
 		int(snapshot.get("species", 0)), bool(snapshot.get("egg", false))
-	))
+	), generation)
 
 
 static func pic_palette(data: GameData, snapshot: Dictionary) -> PackedColorArray:

--- a/game/render/trainer_card_page.gd
+++ b/game/render/trainer_card_page.gd
@@ -138,6 +138,9 @@ const CORNER_AT: Vector2i = Vector2i(18, 1)
 var font: Gen2Font = null
 var crystal: bool = true
 var female: bool = false
+## `StartMenu_TrainerInfo`'s card, which shares nothing with Crystal's three
+## pages but this class's tile window and its own compose.
+var gen1: bool = false
 ## The cartridge's VRAM window, as one indices strip per tile number.
 var _tiles: Dictionary = {}
 
@@ -154,7 +157,11 @@ static func from_data(
 	out.font = glyphs
 	out.crystal = is_crystal
 	out.female = is_female
-	out._load_vram(data, is_female)
+	out.gen1 = data.generation == RomRegistry.GEN1
+	if out.gen1:
+		out._load_gen1_vram(data)
+	else:
+		out._load_vram(data, is_female)
 	return out
 
 
@@ -180,12 +187,17 @@ func load_page_tiles(data: GameData, page: int) -> void:
 	_load_sheet(data, sheet, STATUS_FIRST_TILE, STATUS_TILES)
 
 
-func _load_sheet(data: GameData, name: String, first_tile: int, count: int) -> void:
+## [param from] takes a run out of the middle of a sheet, which only the
+## Generation 1 card's two scattered copies need.
+func _load_sheet(
+	data: GameData, name: String, first_tile: int, count: int, from: int = 0
+) -> void:
 	var indices: PackedByteArray = data.tile_indices(name)
 	if indices.is_empty():
 		return
 	var width: int = indices.size() / TILE
-	for tile: int in count:
+	for offset: int in count:
+		var tile: int = from + offset
 		if (tile + 1) * TILE > width:
 			break
 		var cell := PackedByteArray()
@@ -193,12 +205,14 @@ func _load_sheet(data: GameData, name: String, first_tile: int, count: int) -> v
 		for y: int in TILE:
 			for x: int in TILE:
 				cell[y * TILE + x] = indices[y * width + tile * TILE + x]
-		_tiles[first_tile + tile] = cell
+		_tiles[first_tile + offset] = cell
 
 
 ## The whole 160x144 page as palette indices. [param page] is a `TRAINERCARD*`
 ## page number and [param page] one row of [method Gen2TrainerCard.page].
 func draw(page: Dictionary) -> PackedByteArray:
+	if gen1:
+		return _draw_gen1(page)
 	var map: PackedInt32Array = _blank_map()
 	_draw_border(map, Vector2i.ZERO, TOP_BORDER_ROWS)
 	_draw_border(map, BOTTOM_BORDER_AT, BOTTOM_BORDER_ROWS)
@@ -409,3 +423,258 @@ func _blit(
 	for y: int in TILE:
 		for x: int in TILE:
 			indices[(at.y + y) * width + at.x + x] = cell[y * TILE + x]
+
+
+## `StartMenu_TrainerInfo`'s card (engine/menus/start_sub_menus.asm): one page,
+## `DrawTrainerInfo`'s two boxes and three lines with `DrawBadges`' eight cells.
+
+const GEN1_PAGE: int = 3
+
+## `DisplayPicCenteredOrUpperRight`'s corner and the 7x7 `CopyUncompressedPicToHL`
+## writes from it. Two columns run off the right onto the next row, which is the
+## spill `TrainerInfo_DrawVerticalLine` blanks.
+const GEN1_PIC_AT := Vector2i(15, 1)
+const GEN1_PIC_TILES: int = 7
+## `ld hl, vChars2 tile $07 / ld de, vChars2 tile $00 / ld bc, $1c tiles`: the
+## picture walks one column forward in VRAM, so a tile number draws its neighbour.
+const GEN1_PIC_SHIFT: int = 0x07
+const GEN1_PIC_SHIFTED: int = 0x1C
+const GEN1_SPILL_AT := Vector2i(0, 2)
+const GEN1_SPILL_COLUMNS: int = 2
+const GEN1_SPILL_ROWS: int = 8
+
+## `TrainerInfo_DrawTextBox`'s eight tiles and its two boxes, six rows inside.
+const GEN1_BOX_TOP_LEFT: int = 0x79
+const GEN1_BOX_TOP: int = 0x7A
+const GEN1_BOX_TOP_RIGHT: int = 0x7B
+const GEN1_BOX_LEFT: int = 0x7C
+const GEN1_BOX_RIGHT: int = 0x78
+const GEN1_BOX_BOTTOM_LEFT: int = 0x7D
+const GEN1_BOX_BOTTOM: int = 0x77
+const GEN1_BOX_BOTTOM_RIGHT: int = 0x7E
+const GEN1_BOX_ROWS: int = 6
+const GEN1_TOP_BOX_AT := Vector2i(0, 0)
+const GEN1_TOP_BOX_WIDTH: int = 18
+const GEN1_BOTTOM_BOX_AT := Vector2i(1, 10)
+const GEN1_BOTTOM_BOX_WIDTH: int = 16
+## The two columns beside the lower box, filled with the card's own background.
+const GEN1_SIDE_COLUMNS: Array[int] = [0, COLUMNS - 1]
+const GEN1_SIDE_AT: int = 10
+const GEN1_SIDE_ROWS: int = 8
+
+## `TrainerInfo_NameMoneyTimeText`, whose `next` drops two rows.
+const GEN1_LABELS: Array[String] = ["NAME/", "MONEY/", "TIME/"]
+const GEN1_LABELS_AT := Vector2i(2, 2)
+const GEN1_ROW_STEP: int = 2
+const GEN1_NAME_AT := Vector2i(7, 2)
+const GEN1_MONEY_AT := Vector2i(8, 4)
+const GEN1_TIME_AT := Vector2i(9, 6)
+## `TrainerInfo_BadgesText`'s `db $76,"BADGES",$76`.
+const GEN1_BADGES_LABEL: String = "BADGES"
+const GEN1_BADGES_LABEL_AT := Vector2i(6, 9)
+
+## `DrawBadges`' two `hlcoord`s and four cells each, four columns apart: a number
+## tile, two name tiles beside it and a 2x2 face under those.
+const GEN1_BADGE_ROWS: Array[Vector2i] = [Vector2i(2, 11), Vector2i(2, 14)]
+const GEN1_BADGES_PER_ROW: int = 4
+const GEN1_BADGE_STRIDE: int = 4
+## `.FaceBadgeTiles`, and the `add 4` that swaps a leader's face for the badge.
+const GEN1_FACE_TILES: Array[int] = [
+	0x20, 0x28, 0x30, 0x38, 0x40, 0x48, 0x50, 0x58,
+]
+
+## `BlkPacket_TrainerCard`'s ten blocks as (x1, y1, x2, y2, palette), verbatim.
+## Every other cell takes palette 0. Three of them are the Rainbow badge and
+## none of the three is on it: the cell is (15,12) to (16,13) and the packet
+## colours (16,11), (14,13) and (16,13) instead, which is the cartridge's.
+const GEN1_ATTRIBUTE_BLOCKS: Array[Array] = [
+	[3, 12, 4, 13, 0], [7, 12, 8, 13, 1], [11, 12, 12, 13, 3],
+	[16, 11, 17, 12, 2], [14, 13, 15, 14, 1], [16, 13, 17, 14, 3],
+	[3, 15, 4, 16, 2], [7, 15, 8, 16, 3], [11, 15, 12, 16, 2],
+	[15, 15, 16, 16, 1],
+]
+## `PalPacket_TrainerCard`'s own `SuperPalettes` rows, in packet order.
+const GEN1_PALETTES: Array[int] = [
+	Gen1Layout.PAL_MEWMON, Gen1Layout.PAL_BADGE,
+	Gen1Layout.PAL_REDMON, Gen1Layout.PAL_YELLOWMON,
+]
+
+
+## `DrawTrainerInfo` in write order: the picture, the spill blanked over it, both
+## boxes, the labels, then `DrawBadges`.
+func _draw_gen1(page: Dictionary) -> PackedByteArray:
+	return _compose(gen1_map(page))
+
+
+## The card as tile numbers, which is what a sweep reads: the pixels behind them
+## are the four sheets' own.
+func gen1_map(page: Dictionary) -> PackedInt32Array:
+	var map: PackedInt32Array = _blank_map()
+	for row: int in GEN1_PIC_TILES:
+		for column: int in GEN1_PIC_TILES:
+			_put_wrapped(
+				map, GEN1_PIC_AT.y * COLUMNS + GEN1_PIC_AT.x + column * 1 + row * COLUMNS,
+				column * GEN1_PIC_TILES + row
+			)
+	for column: int in GEN1_SPILL_COLUMNS:
+		for row: int in GEN1_SPILL_ROWS:
+			_put(map, GEN1_SPILL_AT + Vector2i(column, row), BLANK_TILE)
+	_gen1_box(map, GEN1_TOP_BOX_AT, GEN1_TOP_BOX_WIDTH)
+	_gen1_box(map, GEN1_BOTTOM_BOX_AT, GEN1_BOTTOM_BOX_WIDTH)
+	for column: int in GEN1_SIDE_COLUMNS:
+		for row: int in GEN1_SIDE_ROWS:
+			_put(map, Vector2i(column, GEN1_SIDE_AT + row), Gen1Layout.TRAINER_CARD_FILL_CODE)
+	_put(map, GEN1_BADGES_LABEL_AT, Gen1Layout.TRAINER_CARD_CIRCLE_CODE)
+	_gen1_text(map, GEN1_BADGES_LABEL, GEN1_BADGES_LABEL_AT + Vector2i(1, 0))
+	_put(
+		map, GEN1_BADGES_LABEL_AT + Vector2i(GEN1_BADGES_LABEL.length() + 1, 0),
+		Gen1Layout.TRAINER_CARD_CIRCLE_CODE
+	)
+	for index: int in GEN1_LABELS.size():
+		_gen1_text(
+			map, GEN1_LABELS[index], GEN1_LABELS_AT + Vector2i(0, index * GEN1_ROW_STEP)
+		)
+	_gen1_text(map, String(page.get("player_name", "")), GEN1_NAME_AT)
+	## `PrintBCDNumber` with LEFT_ALIGN and the money sign, so the `¥` sits
+	## against the first digit and nothing is padded.
+	_gen1_text(map, Gen2MartPage.money_string(int(page.get("money", 0)), true), GEN1_MONEY_AT)
+	_gen1_time(map, page)
+	_draw_gen1_badges(map, page.get("badges", []) as Array)
+	return map
+
+
+## `PrintNumber` with LEFT_ALIGN, the colon the card copies in, then the minutes.
+func _gen1_time(map: PackedInt32Array, page: Dictionary) -> void:
+	var hours: String = String(page.get("hours", "")).strip_edges()
+	_gen1_text(map, hours, GEN1_TIME_AT)
+	var at: Vector2i = GEN1_TIME_AT + Vector2i(hours.length(), 0)
+	_put(map, at, Gen1Layout.TRAINER_CARD_COLON_CODE)
+	_gen1_text(map, String(page.get("minutes", "")), at + Vector2i(1, 0))
+
+
+## `DrawBadges`: both counters step whether or not their tile is drawn, and an
+## owned badge shows the badge rather than the leader's face and no name.
+func _draw_gen1_badges(map: PackedInt32Array, badges: Array) -> void:
+	var number: int = Gen1Layout.BADGE_NUMBER_CODE
+	var name_tile: int = Gen1Layout.TRAINER_CARD_NAME_CODE
+	for row: int in GEN1_BADGE_ROWS.size():
+		for column: int in GEN1_BADGES_PER_ROW:
+			var index: int = row * GEN1_BADGES_PER_ROW + column
+			var at: Vector2i = GEN1_BADGE_ROWS[row] \
+				+ Vector2i(column * GEN1_BADGE_STRIDE, 0)
+			_put(map, at, number)
+			number += 1
+			var owned: bool = index < badges.size() and bool(badges[index])
+			if not owned:
+				_put(map, at + Vector2i(1, 0), name_tile)
+				_put(map, at + Vector2i(2, 0), name_tile + 1)
+			name_tile += 2
+			var face: int = GEN1_FACE_TILES[index] \
+				+ (Gen1Layout.BADGE_FACE_BADGE_AT if owned else 0)
+			for cell: int in 4:
+				@warning_ignore("integer_division")
+				_put(map, at + Vector2i(1 + cell % 2, 1 + cell / 2), face + cell)
+
+
+## `TrainerInfo_DrawTextBox`, whose width is the inside.
+func _gen1_box(map: PackedInt32Array, at: Vector2i, width: int) -> void:
+	_gen1_edge(map, at, width, GEN1_BOX_TOP_LEFT, GEN1_BOX_TOP, GEN1_BOX_TOP_RIGHT)
+	for row: int in GEN1_BOX_ROWS:
+		_put(map, Vector2i(at.x, at.y + 1 + row), GEN1_BOX_LEFT)
+		_put(map, Vector2i(at.x + width + 1, at.y + 1 + row), GEN1_BOX_RIGHT)
+	_gen1_edge(
+		map, Vector2i(at.x, at.y + GEN1_BOX_ROWS + 1), width,
+		GEN1_BOX_BOTTOM_LEFT, GEN1_BOX_BOTTOM, GEN1_BOX_BOTTOM_RIGHT
+	)
+
+
+func _gen1_edge(
+	map: PackedInt32Array, at: Vector2i, width: int, left: int, middle: int, right: int
+) -> void:
+	_put(map, at, left)
+	for column: int in width:
+		_put(map, at + Vector2i(1 + column, 0), middle)
+	_put(map, at + Vector2i(width + 1, 0), right)
+
+
+## `_CGB_TrainerCard`'s counterpart: `BlkPacket_TrainerCard`'s ten blocks over
+## palette 0.
+func gen1_attributes() -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	for block: Array in GEN1_ATTRIBUTE_BLOCKS:
+		for y: int in range(int(block[1]), int(block[3]) + 1):
+			for x: int in range(int(block[0]), int(block[2]) + 1):
+				if x < COLUMNS and y < ROWS:
+					map[y * COLUMNS + x] = int(block[4])
+	return map
+
+
+## `hlcoord 15, 1`'s own write, which runs past the right edge onto the next row.
+func _put_wrapped(map: PackedInt32Array, cell: int, tile: int) -> void:
+	if cell < 0 or cell >= map.size():
+		return
+	map[cell] = tile
+
+
+func _gen1_text(map: PackedInt32Array, text: String, at: Vector2i) -> void:
+	var codes: PackedByteArray = Gen1Text.encode(text)
+	for index: int in codes.size():
+		_put(map, at + Vector2i(index, 0), codes[index])
+
+
+## The card's own VRAM, in copy order: the picture at $00, the leaders' faces over
+## its tail, the erased names, the box pieces, and the two tiles it drops into the
+## font's window.
+func _load_gen1_vram(data: GameData) -> void:
+	_load_gen1_pic(data)
+	_load_sheet(data, "badge_faces", Gen1Layout.BADGE_FACE_CODE, Gen1Layout.BADGE_FACE_TILES)
+	_load_sheet(
+		data, "trainer_card_names", Gen1Layout.TRAINER_CARD_NAME_CODE,
+		Gen1Layout.TRAINER_CARD_NAME_TILES
+	)
+	_load_sheet(
+		data, "trainer_card_box", Gen1Layout.TRAINER_CARD_BOX_CODE,
+		Gen1Layout.TRAINER_CARD_BOX_TILES - 1
+	)
+	_load_sheet(
+		data, "badge_numbers", Gen1Layout.BADGE_NUMBER_CODE, Gen1Layout.BADGE_NUMBER_TILES
+	)
+	_load_sheet(
+		data, "font_extra", Gen1Layout.TRAINER_CARD_COLON_CODE, 1,
+		Gen1Layout.TRAINER_CARD_COLON_TILE
+	)
+	_load_sheet(
+		data, "trainer_card_box", Gen1Layout.TRAINER_CARD_FILL_CODE, 1,
+		Gen1Layout.TRAINER_CARD_BOX_TILES - 1
+	)
+
+
+## `RedPicFront` cut into the 7x7 block column by column, then walked forward by
+## [constant GEN1_PIC_SHIFT].
+func _load_gen1_pic(data: GameData) -> void:
+	var record: Dictionary = data.player_frontpic()
+	if record.is_empty():
+		return
+	var cell: Dictionary = Gen2PicImage.atlas_cell(
+		data.atlas_indices("player_front"), data.atlas("player_front"), record
+	)
+	if cell.is_empty():
+		return
+	var indices: PackedByteArray = cell["indices"]
+	var width: int = int(cell["width"])
+	var tiles: Array = []
+	for column: int in GEN1_PIC_TILES:
+		for row: int in GEN1_PIC_TILES:
+			var block := PackedByteArray()
+			block.resize(TILE * TILE)
+			for y: int in TILE:
+				for x: int in TILE:
+					block[y * TILE + x] = indices[
+						(row * TILE + y) * width + column * TILE + x
+					]
+			tiles.append(block)
+	for tile: int in tiles.size():
+		var from: int = tile + GEN1_PIC_SHIFT if tile < GEN1_PIC_SHIFTED else tile
+		if from < tiles.size():
+			_tiles[tile] = tiles[from]

--- a/game/world/evolution_screen.gd
+++ b/game/world/evolution_screen.gd
@@ -426,7 +426,9 @@ func _draw_species(species: int) -> void:
 	Gen2PicImage.show(_pic, image)
 	_pic.size = Vector2(image.get_size())
 	_pic.position = Vector2(
-		PIC_AT * TILE + Gen2PicImage.frontpic_origin(image.get_size(), true)
+		PIC_AT * TILE + Gen2PicImage.frontpic_origin(
+			image.get_size(), true, _data.generation
+		)
 	)
 
 

--- a/game/world/pokedex.gd
+++ b/game/world/pokedex.gd
@@ -464,7 +464,8 @@ func step_entry(button: int) -> bool:
 ## The name, the category and the number are printed whether or not the species
 ## has been caught; the caught check sits after them and gates the measurements
 ## and the description. A zero height or weight is left blank rather than printed
-## as a zero, which is `.skip_height` and `.skip_weight`.
+## as a zero, which is `.skip_height` and `.skip_weight`. Generation 1 has
+## neither guard and prints both whatever they hold.
 func entry() -> Dictionary:
 	var species: int = selected_species()
 	var dex: Dictionary = _data.dex_entry(species) if _data != null else {}
@@ -478,8 +479,8 @@ func entry() -> Dictionary:
 		"number": "%03d" % species,
 		"category": String(dex.get("category", "")),
 		"caught": caught,
-		"height": height_text(height) if caught and height != 0 else "",
-		"weight": weight_text(weight) if caught and weight != 0 else "",
+		"height": height_text(height) if caught and (gen1 or height != 0) else "",
+		"weight": weight_text(weight) if caught and (gen1 or weight != 0) else "",
 		"page": page,
 		"text": pages[page] if caught and page < pages.size() else "",
 	}
@@ -684,3 +685,139 @@ func _species_name(species: int) -> String:
 	if _data == null:
 		return ""
 	return String(_data.species(species).get("name", ""))
+
+
+## `ShowPokedexMenu` (engine/menus/pokedex.asm) lists the dex numbers themselves
+## rather than an order table, so a species and its position are one value.
+## `wDexMaxSeenMon` is [member listing_end], the last row Generation 2 keeps
+## there too.
+
+## `ld d, 7`, the rows `.printPokemonLoop` draws, and the `ld a, 6` behind them.
+const GEN1_LISTING_HEIGHT: int = 7
+## `.dashedLine`, drawn in place of the name of a species not yet seen.
+const GEN1_NOT_SEEN_NAME: String = "----------"
+## `PokedexMenuItemsText`, and the `b` each row leaves `HandlePokedexSideMenu`
+## with: DATA and AREA redraw the listing, QUIT closes the dex, and CRY stays.
+const GEN1_SIDE_ROWS: Array[String] = ["DATA", "CRY", "AREA", "QUIT"]
+const GEN1_SIDE_DATA: int = 0
+const GEN1_SIDE_CRY: int = 1
+const GEN1_SIDE_AREA: int = 2
+const GEN1_SIDE_QUIT: int = 3
+
+## Set by [method open_gen1]. Every listing rule below this line is that
+## generation's own, and no Generation 2 screen reads it.
+var gen1: bool = false
+
+
+## `ShowPokedexMenu`'s own open: the scroll and the cursor start at zero and the
+## listing runs to the highest dex number seen.
+static func open_gen1(data: GameData, state: Gen2WorldState) -> Gen2Pokedex:
+	var dex := Gen2Pokedex.new()
+	dex._data = data
+	dex._state = state
+	dex.gen1 = true
+	dex.listing_height = GEN1_LISTING_HEIGHT
+	dex._order = PackedInt32Array()
+	dex._order.resize(Gen1Layout.SPECIES_COUNT)
+	for index: int in Gen1Layout.SPECIES_COUNT:
+		dex._order[index] = index + 1
+	dex.find_gen1_max_seen()
+	return dex
+
+
+## `.maxSeenPokemonLoop`, `wPokedexSeen` walked backwards for the highest bit
+## set. Nothing seen answers zero, where the source runs off the front of the
+## field; the dex is behind `EVENT_GOT_POKEDEX` and never opens empty.
+func find_gen1_max_seen() -> void:
+	listing_end = 0
+	for number: int in range(_order.size(), 0, -1):
+		if _has_seen(number):
+			listing_end = number
+			break
+
+
+## `wMaxMenuItem`: six, or one under the listing when it is shorter than a page.
+func gen1_max_cursor() -> int:
+	return mini(GEN1_LISTING_HEIGHT, listing_end) - 1
+
+
+## `.printPokemonLoop`'s rows: seven, or the whole listing when it is shorter.
+func gen1_rows() -> Array:
+	var out: Array = []
+	for index: int in mini(GEN1_LISTING_HEIGHT, listing_end):
+		var number: int = scroll + index + 1
+		var seen: bool = _has_seen(number)
+		out.append({
+			"number": number,
+			"name": _species_name(number) if seen else GEN1_NOT_SEEN_NAME,
+			"seen": seen,
+			"caught": _has_caught(number),
+			"selected": index == cursor,
+		})
+	return out
+
+
+## `HandleMenuInput` inside `HandlePokedexListMenu`: the shared menu moves the
+## cursor inside the page and reports only the presses that ran off its ends, and
+## the listing scrolls on those. Answers whether anything moved.
+func gen1_move_listing(button: int) -> bool:
+	match button:
+		PokeButton.UP:
+			return _gen1_up()
+		PokeButton.DOWN:
+			return _gen1_down()
+		PokeButton.LEFT:
+			return _gen1_page_up()
+		PokeButton.RIGHT:
+			return _gen1_page_down()
+	return false
+
+
+func _gen1_up() -> bool:
+	if cursor > 0:
+		cursor -= 1
+		return true
+	if scroll == 0:
+		return false
+	scroll -= 1
+	return true
+
+
+## `.checkIfDownPressed`, whose scroll stops at `wDexMaxSeenMon - 7`.
+func _gen1_down() -> bool:
+	if cursor < gen1_max_cursor():
+		cursor += 1
+		return true
+	if listing_end < GEN1_LISTING_HEIGHT or scroll >= listing_end - GEN1_LISTING_HEIGHT:
+		return false
+	scroll += 1
+	return true
+
+
+## `.checkIfLeftPressed`: seven rows up, the borrow landing it on zero. It has no
+## length test, so a listing shorter than a page pages too.
+func _gen1_page_up() -> bool:
+	if scroll == 0:
+		return false
+	scroll = maxi(scroll - GEN1_LISTING_HEIGHT, 0)
+	return true
+
+
+## `.checkIfRightPressed`: seven rows down, clamped to `wDexMaxSeenMon - 6` less
+## one, which is the same landing the down press stops at.
+func _gen1_page_down() -> bool:
+	if listing_end < GEN1_LISTING_HEIGHT:
+		return false
+	var last: int = listing_end - GEN1_LISTING_HEIGHT
+	var next: int = mini(scroll + GEN1_LISTING_HEIGHT, last)
+	if next == scroll:
+		return false
+	scroll = next
+	return true
+
+
+## `ShowPokedexData`, which is entered with a dex number in `wPokedexNum` and no
+## listing behind it: the cursor is put on that number outright.
+func gen1_show(number: int) -> void:
+	scroll = maxi(number - 1, 0)
+	cursor = 0

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -26,7 +26,7 @@ signal cry_requested(species: int)
 ## the way [signal cry_requested] is.
 signal sfx_requested(index: int)
 
-enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA, UNOWN }
+enum Mode { LIST, ENTRY, OPTION, SEARCH, SEARCH_RESULTS, AREA, UNOWN, SIDE }
 
 ## The dex is drawn in hardware pixels and the start menu it opens over is
 ## ordinary UI at window resolution, so it carries a [Gen2Screen] of its own the
@@ -62,6 +62,11 @@ var _dex: Gen2Pokedex = null
 var _world: Gen2WorldAPI = null
 var _data: GameData = null
 var _mode: Mode = Mode.LIST
+## `ShowPokedexMenu` is a listing, a side menu and an entry page and none of the
+## other five states, so every branch below reads this rather than the cache.
+var _gen1: bool = false
+## `HandlePokedexSideMenu`'s `wCurrentMenuItem`, or -1 while that menu is closed.
+var _side_cursor: int = -1
 ## The OPTION screen's own cursor (`wDexArrowCursorPosIndex`), which opens on
 ## the row matching the current mode.
 var _option_cursor: int = 0
@@ -109,12 +114,16 @@ func open(data: GameData, world: Gen2WorldAPI, start_entry: int = 0) -> bool:
 	_world = world
 	if _data == null or _world == null or _world.state == null:
 		return false
-	if _data.dex_order_new().is_empty() or _data.dex_order_alpha().is_empty():
+	## Generation 1 lists the dex numbers themselves, so it needs neither order
+	## table; everything else on this screen is behind [member _gen1].
+	_gen1 = _data.generation == RomRegistry.GEN1
+	if not _gen1 \
+		and (_data.dex_order_new().is_empty() or _data.dex_order_alpha().is_empty()):
 		return false
 	_page = Gen2PokedexPage.from_data(_data)
 	if _page == null or not _page.ready():
 		return false
-	_dex = Gen2Pokedex.open(
+	_dex = Gen2Pokedex.open_gen1(_data, _world.state) if _gen1 else Gen2Pokedex.open(
 		_data, _world.state, _world.state.last_dex_mode(), start_entry
 	)
 	if is_inside_tree() and _background != null:
@@ -128,6 +137,10 @@ func open(data: GameData, world: Gen2WorldAPI, start_entry: int = 0) -> bool:
 func open_entry(data: GameData, world: Gen2WorldAPI, species: int) -> bool:
 	if not open(data, world, species):
 		return false
+	## `ShowPokedexData` is handed a dex number and no listing, so the cursor is
+	## put on it rather than sought through an order table.
+	if _gen1 and _dex != null:
+		_dex.gen1_show(species)
 	if _dex == null or _dex.selected_species() != species:
 		return false
 	_entry_only = true
@@ -172,7 +185,9 @@ func handle_button(button: int) -> bool:
 		return _area.handle_button(button)
 	match _mode:
 		Mode.LIST:
-			return _handle_list(button)
+			return _handle_gen1_list(button) if _gen1 else _handle_list(button)
+		Mode.SIDE:
+			return _handle_gen1_side(button)
 		Mode.ENTRY:
 			return _handle_entry(button)
 		Mode.OPTION:
@@ -222,6 +237,8 @@ func _handle_list(button: int) -> bool:
 ## so A always turns the page rather than moving a cursor along a row whose
 ## other three entries would refuse.
 func _handle_entry(button: int) -> bool:
+	if _gen1:
+		return _handle_gen1_entry(button)
 	if _entry_only:
 		return _handle_new_entry(button)
 	match button:
@@ -379,8 +396,131 @@ func _exit() -> void:
 func _open_list_mode() -> void:
 	_message = ""
 	_mode = Mode.LIST
+	_side_cursor = -1
 	_dex.listing_height = Gen2Pokedex.LISTING_HEIGHT
 	_refresh()
+
+
+## `HandlePokedexListMenu`: B leaves, A opens the side menu, the rest walks.
+func _handle_gen1_list(button: int) -> bool:
+	match button:
+		PokeButton.B:
+			closed.emit()
+			return true
+		PokeButton.A:
+			## `HandlePokedexSideMenu` opens whatever the row is and answers
+			## `b = 2` at once for a species not yet seen, which is back here.
+			if _dex.can_open_entry():
+				_open_gen1_side()
+			return true
+	if _dex.gen1_move_listing(button):
+		_refresh()
+	return PokeButton.is_direction(button)
+
+
+## `HandlePokedexSideMenu`'s own four rows, whose watched keys are A and B.
+func _handle_gen1_side(button: int) -> bool:
+	match button:
+		PokeButton.B:
+			_open_list_mode()
+			return true
+		PokeButton.A:
+			_gen1_side_action()
+			return true
+		PokeButton.UP, PokeButton.DOWN:
+			var next: int = _side_cursor + (1 if button == PokeButton.DOWN else -1)
+			_side_cursor = clampi(next, 0, Gen2Pokedex.GEN1_SIDE_ROWS.size() - 1)
+			_refresh()
+			return true
+	return false
+
+
+## What each row leaves `b` as: DATA and AREA answer 0 and redraw the listing,
+## QUIT answers 1 and closes the dex, and CRY stays in the menu. AREA is
+## `predef LoadTownMap_Nest`, whose nest table nothing imports, so it draws
+## nothing and lands on the listing its own `b = 0` goes to.
+func _gen1_side_action() -> void:
+	match _side_cursor:
+		Gen2Pokedex.GEN1_SIDE_DATA:
+			_dex.open_entry()
+			_open_entry_mode(Mode.LIST)
+		Gen2Pokedex.GEN1_SIDE_CRY:
+			cry_requested.emit(_dex.selected_species())
+		Gen2Pokedex.GEN1_SIDE_AREA:
+			_open_list_mode()
+		Gen2Pokedex.GEN1_SIDE_QUIT:
+			closed.emit()
+
+
+func _open_gen1_side() -> void:
+	_message = ""
+	_mode = Mode.SIDE
+	_side_cursor = 0
+	_refresh()
+
+
+## `ShowPokedexDataInternal` waits on A or B twice: `PageChar`'s
+## `ManualTextScroll` between the description pages and `.waitForButtonPress`
+## behind the second. A species not owned prints no description and waits once.
+func _handle_gen1_entry(button: int) -> bool:
+	if button != PokeButton.A and button != PokeButton.B:
+		return false
+	if _gen1_entry_pages() > 1 and _dex.page == Gen2Pokedex.PAGE_1:
+		_dex.toggle_page()
+		_refresh()
+		return true
+	if _entry_only:
+		closed.emit()
+		return true
+	## `.choseData`'s `b = 0` lands on `.setUpGraphics`, which redraws the
+	## listing and re-enters it with the cursor where the side menu left it.
+	_open_list_mode()
+	return true
+
+
+## How many description pages this entry prints, none of them unless owned.
+func _gen1_entry_pages() -> int:
+	var entry: Dictionary = _dex.entry()
+	if not bool(entry.get("caught", false)):
+		return 0
+	return (_data.dex_entry(_dex.selected_species()).get(
+		"pages", PackedStringArray()
+	) as PackedStringArray).size()
+
+
+## `ShowPokedexMenu`'s listing and `ShowPokedexDataInternal`'s page.
+func _render_gen1() -> Image:
+	if _mode != Mode.ENTRY:
+		return _page.image(_page.gen1_list_map(
+			_dex.gen1_rows(), _dex.seen_count(), _dex.caught_count(),
+			_listing_cursor(), _side_cursor
+		))
+	var species: int = _dex.selected_species()
+	var entry: Dictionary = _dex.entry()
+	var page: int = int(entry["page"])
+	return _page.image(_page.gen1_entry_map(
+		species, String(entry["name"]), _data.dex_entry(species),
+		bool(entry["caught"]), page,
+		_gen1_entry_pages() > 1 and page == Gen2Pokedex.PAGE_1
+	), _gen1_entry_pic(species), Gen2PokedexPage.GEN1_ENTRY_PIC_AT)
+
+
+## `LoadFlippedFrontSpriteByMonIndex`: the front pic mirrored, centred in
+## `LoadUncompressedSpriteData`'s 7x7 block, and drawn through the species' own
+## palette, which is `BlkPacket_Pokedex`'s one block.
+func _gen1_entry_pic(species: int) -> Image:
+	var pic: Dictionary = _data.species_pic(species)
+	var palette: PackedColorArray = _data.palette(species)
+	if pic.is_empty() or palette.size() < PokePalette.COLORS_PER_PIC:
+		return null
+	var art: Image = Gen2PicImage.from_atlas(
+		_data.atlas_indices(pic["atlas"]), _data.atlas(pic["atlas"]), pic, palette
+	)
+	if art == null:
+		return null
+	return Gen2PokedexPage.pad_pic(
+		Gen2PicImage.x_flipped(art), palette[0], RomRegistry.GEN1
+	)
 
 
 func _open_entry_mode(from: Mode = Mode.LIST) -> void:
@@ -536,6 +676,8 @@ func render() -> Image:
 		return Image.create_empty(
 			Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 		)
+	if _gen1:
+		return _render_gen1()
 	## `Pokedex_BlinkArrowCursor`'s own off phase, and the same answer on every
 	## frame for a screen that is being read rather than walked.
 	var cursor: int = -1 if _read_only or _blink >= CURSOR_BLINK_FRAMES else 0
@@ -707,6 +849,9 @@ func advance_frame() -> void:
 			_finish_search()
 		elif _slowpoke_frame() != frame:
 			_refresh()
+		return
+	## `PlaceMenuCursor` writes its `▶` into the map, so nothing there blinks.
+	if _gen1:
 		return
 	_blink = (_blink + 1) % (CURSOR_BLINK_FRAMES * 2)
 	if _blink == 0 or _blink == CURSOR_BLINK_FRAMES:

--- a/game/world/trainer_card.gd
+++ b/game/world/trainer_card.gd
@@ -15,6 +15,8 @@ const PAGE_1: int = Gen2TrainerCardPage.PAGE_1
 const PAGE_2: int = Gen2TrainerCardPage.PAGE_2
 const PAGE_3: int = Gen2TrainerCardPage.PAGE_3
 const PAGES: int = 3
+## `StartMenu_TrainerInfo`, which is one page and no badge pages behind it.
+const GEN1_PAGE: int = Gen2TrainerCardPage.GEN1_PAGE
 
 ## `NUM_JOHTO_BADGES`, which is also the number of Kanto badges and the length of
 ## `TrainerCard_JohtoBadgesOAM`, the one template both badge pages read.
@@ -56,6 +58,17 @@ static func page(
 	}
 
 
+## `DrawTrainerInfo`'s three lines and `DrawBadges`' eight bits.
+## `wObtainedBadges` is the Kanto half of the shared badge order, which is what
+## page 3 already reads.
+static func gen1_page(save: Gen2SaveData, world: Gen2WorldAPI) -> Dictionary:
+	var out: Dictionary = page(save, world, PAGE_3)
+	if out.is_empty():
+		return out
+	out["page"] = GEN1_PAGE
+	return out
+
+
 ## Which of the eight badges a badge page draws, in source badge order.
 ## `TrainerCard_Page2_3_OAMUpdate` walks one bit per badge and skips the clear
 ## ones, so this is that bit array rather than a count.
@@ -80,6 +93,11 @@ static func badges(state: Gen2WorldState, page_number: int, crystal: bool) -> Ar
 ## page 3 is unreachable on the cartridge and is unreachable here.
 static func next_page(page_number: int, button: int) -> Dictionary:
 	match page_number:
+		GEN1_PAGE:
+			## `WaitForTextScrollButtonPress`, which is the whole of the
+			## Generation 1 card's input: A or B and back to the start menu.
+			if button == PokeButton.A:
+				return {"exit": true}
 		PAGE_1:
 			if button == PokeButton.RIGHT or button == PokeButton.A:
 				return {"page": PAGE_2}

--- a/game/world/trainer_card_screen.gd
+++ b/game/world/trainer_card_screen.gd
@@ -71,8 +71,13 @@ func open(data: GameData, world: Gen2WorldAPI, save: Gen2SaveData) -> bool:
 	if _page_renderer == null or not _page_renderer.ready():
 		return false
 	if is_inside_tree() and _background != null:
-		_show_page(Gen2TrainerCard.PAGE_1)
+		_show_page(_first_page())
 	return true
+
+
+## `StartMenu_TrainerInfo` has one page and no jumptable behind it.
+func _first_page() -> int:
+	return Gen2TrainerCard.GEN1_PAGE if _page_renderer.gen1 else Gen2TrainerCard.PAGE_1
 
 
 func _ready() -> void:
@@ -80,7 +85,7 @@ func _ready() -> void:
 	size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_build()
 	if _page_renderer != null:
-		_show_page(Gen2TrainerCard.PAGE_1)
+		_show_page(_first_page())
 
 
 func current_page() -> int:
@@ -103,6 +108,9 @@ func handle_button(button: int) -> bool:
 ## One hardware frame: the badges turn every eight and the colon flips every
 ## thirty-two, both off the counter the source reads rather than off a timer.
 func advance_frame() -> void:
+	## Nothing on `DrawTrainerInfo`'s card moves: its badges are background tiles.
+	if _page_renderer != null and _page_renderer.gen1:
+		return
 	_frames += 1
 	if _frames % BADGE_FRAMES == 0 and _page != Gen2TrainerCard.PAGE_1:
 		_refresh_badges()
@@ -127,7 +135,8 @@ func _build() -> void:
 func _show_page(page: int) -> void:
 	_page = page
 	_frames = 0
-	_page_renderer.load_page_tiles(_data, page)
+	if not _page_renderer.gen1:
+		_page_renderer.load_page_tiles(_data, page)
 	_refresh_page()
 	_refresh_badges()
 
@@ -136,11 +145,15 @@ func _refresh_page() -> void:
 	if _background == null or _page_renderer == null:
 		return
 	var separator: bool = int(_frames / SEPARATOR_FRAMES) % 2 == 0
-	var page: Dictionary = Gen2TrainerCard.page(_save, _world, _page, separator)
+	var page: Dictionary = Gen2TrainerCard.gen1_page(_save, _world) \
+		if _page_renderer.gen1 \
+		else Gen2TrainerCard.page(_save, _world, _page, separator)
 	var indices: PackedByteArray = _page_renderer.draw(page)
-	Gen2PicImage.show(_background,
-		_image_from(indices, _page_renderer.attributes())
-	)
+	Gen2PicImage.show(_background, _image_from(
+		indices,
+		_page_renderer.gen1_attributes() if _page_renderer.gen1
+			else _page_renderer.attributes()
+	))
 	_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 
 
@@ -149,8 +162,13 @@ func _refresh_page() -> void:
 ## is eight palettes at once.
 func _image_from(indices: PackedByteArray, attributes: PackedInt32Array) -> Image:
 	var palettes: Array = []
-	for slot: int in Gen2Layout.CARD_PALETTE_CLASSES.size():
-		palettes.append(_data.card_palette(slot))
+	if _page_renderer.gen1:
+		## `PalPacket_TrainerCard`'s four rows, where Crystal builds eight.
+		for row: int in Gen2TrainerCardPage.GEN1_PALETTES:
+			palettes.append(_data.world_palette(row))
+	else:
+		for slot: int in Gen2Layout.CARD_PALETTE_CLASSES.size():
+			palettes.append(_data.card_palette(slot))
 	return Gen2PicImage.from_attributes(
 		indices, Gen2Screen.WIDTH, Gen2Screen.HEIGHT, attributes,
 		Gen2TrainerCardPage.COLUMNS, palettes
@@ -164,7 +182,9 @@ func _refresh_badges() -> void:
 	for node: Node in _badges:
 		Gen2Screen.drop(node)
 	_badges = []
-	if _page == Gen2TrainerCard.PAGE_1 or _data == null:
+	if _page != Gen2TrainerCard.PAGE_2 and _page != Gen2TrainerCard.PAGE_3:
+		return
+	if _data == null:
 		return
 	var set_badges: Array = Gen2TrainerCard.badges(
 		_world.state if _world != null else null,

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -4490,6 +4490,40 @@ class PreviewRepel extends RefCounted:
 ## Public screenshot driver for `_Option`, which is what the start menu's own
 ## OPTION row opens. One call, since the picture wanted is the settings screen
 ## and not the row that reaches it.
+## Public screenshot driver for `StartMenu_Pokedex`, whose row no map cell
+## reaches. A second call presses A on whatever the dex has up, which is how the
+## Generation 1 side menu and its entry page are reached.
+func preview_pokedex() -> void:
+	if _world == null or _data == null:
+		return
+	if _pokedex_host != null:
+		_pokedex_host.handle_button(PokeButton.A)
+		return
+	if _start_menu_host == null:
+		_injected_save = _embedded_party_save()
+		_open_start_menu()
+	if _start_menu_host == null:
+		return
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_POKEDEX):
+		return
+	_start_menu_host.handle_button(PokeButton.A)
+
+
+## Public screenshot driver for `StartMenu_TrainerInfo`, whose row no map cell
+## reaches.
+func preview_trainer_card() -> void:
+	if _world == null or _data == null or _trainer_card_host != null:
+		return
+	if _start_menu_host == null:
+		_injected_save = _embedded_party_save()
+		_open_start_menu()
+	if _start_menu_host == null:
+		return
+	if not _walk_start_menu_to(Gen2WorldStartMenu.ITEM_PLAYER):
+		return
+	_start_menu_host.handle_button(PokeButton.A)
+
+
 func preview_options() -> void:
 	if _world == null or _data == null:
 		return

--- a/tests/unit/pokedex_fixture.gd
+++ b/tests/unit/pokedex_fixture.gd
@@ -131,3 +131,82 @@ static func _tiles(path: String) -> Dictionary:
 			"bits": 1,
 		}
 	return sheets
+
+
+const GEN1_GAME_ID: StringName = &"pokedexfixturegen1"
+## `PAL_BROWNMON`'s own four colours (data/sgb/sgb_palettes.asm), so a page test
+## reads what `PalPacket_Pokedex` actually draws through.
+const GEN1_BROWNMON: Array = [0x7FBF, 0x3E9C, 0x25D5, 0x0843]
+
+
+static func gen1_directory() -> String:
+	return RomCache.directory_for(GEN1_GAME_ID, SHA1)
+
+
+## The same cache shaped the way `Gen1Importer` writes one: 151 species, no order
+## tables, and the four sheets `LoadPokedexTilePatterns` assembles its page from.
+static func build_gen1() -> GameData:
+	var path: String = gen1_directory()
+	RomCache.clear(path)
+	RomCache.prepare(path)
+	RomCache.write_json(RomCache.species_path(path), _gen1_species())
+	var palettes: Array = []
+	for index: int in Gen1Layout.PAL_BROWNMON + 1:
+		palettes.append(GEN1_BROWNMON)
+	RomCache.write_json(RomCache.world_palettes_path(path), palettes)
+	RomCache.write_json(RomCache.manifest_path(path), {
+		"format_version": RomCache.FORMAT_VERSION,
+		"game_id": String(GEN1_GAME_ID),
+		"sha1": SHA1,
+		"complete": true,
+		"generation": RomRegistry.GEN1,
+		"tiles": _gen1_tiles(path),
+	})
+	return GameData.open_directory(path)
+
+
+## Heights are feet and inches packed the way the importer packs them and weights
+## are tenths of a pound, so a formatting test reads a real measurement.
+static func _gen1_species() -> Array:
+	var out: Array = []
+	for number: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
+		out.append({
+			"number": number,
+			"name": species_name(number),
+			"types": types_for(number),
+			"dex": {
+				"category": "CAT%03d" % number,
+				"height": 100 + number,
+				"weight": number * 10,
+				"pages": ["page one %d" % number, "page two %d." % number],
+			},
+		})
+	return out
+
+
+static func _gen1_tiles(path: String) -> Dictionary:
+	var sheets: Dictionary = {}
+	for entry: Array in [
+		["font", Gen1Layout.FONT_TILES, 3, Gen1Layout.FONT_FIRST_CODE],
+		["font_extra", Gen1Layout.FONT_EXTRA_TILES, 1, Gen1Layout.FONT_EXTRA_FIRST_CODE],
+		[
+			"battle_font", Gen1Layout.BATTLE_FONT_TILES, 2,
+			Gen1Layout.BATTLE_FONT_FIRST_CODE,
+		],
+		["battle_balls", Gen1Layout.BALL_TILES, 1, 0],
+		["pokedex_tiles", Gen1Layout.POKEDEX_TILES, 2, Gen1Layout.POKEDEX_FIRST_CODE],
+	]:
+		var name: String = String(entry[0])
+		var count: int = int(entry[1])
+		var indices := PackedByteArray()
+		indices.resize(count * PokeTiles.TILE_PIXELS)
+		indices.fill(int(entry[2]))
+		RomCache.write_indices(RomCache.tile_path(path, name), indices)
+		sheets[name] = {
+			"width": count * PokeTiles.TILE_WIDTH,
+			"height": PokeTiles.TILE_HEIGHT,
+			"tiles": count,
+			"first_code": int(entry[3]),
+			"bits": 1,
+		}
+	return sheets

--- a/tests/unit/test_gen1_text.gd
+++ b/tests/unit/test_gen1_text.gd
@@ -11,6 +11,13 @@ func _bytes(values: Array) -> PackedByteArray:
 	return out
 
 
+func _strings(values: Array) -> PackedStringArray:
+	var out: PackedStringArray = PackedStringArray()
+	for value: String in values:
+		out.append(value)
+	return out
+
+
 func test_the_letter_runs_decode() -> void:
 	# "RHYDON", the cartridge's own first species name.
 	var data: PackedByteArray = _bytes([0x91, 0x87, 0x98, 0x83, 0x8E, 0x8D, 0x50])
@@ -64,7 +71,16 @@ func test_a_dex_description_ends_on_dexend_and_breaks_on_its_line_codes() -> voi
 	var data: PackedByteArray = _bytes([
 		0x00, 0x80, 0x81, 0x4F, 0x82, 0x83, Gen1Text.DEX_END, 0x84,
 	])
-	assert_eq(Gen1Text.decode_dex_text(data, 0, 32), "AB\nCD")
+	# `PlaceDexEnd` writes the full stop the description itself does not carry.
+	assert_eq(Gen1Text.decode_dex_pages(data, 0, 32), _strings(["AB\nCD."]))
+
+
+func test_a_dex_description_parts_its_two_pages_on_page() -> void:
+	# TX_START, "AB", <PAGE>, "CD", <DEXEND>.
+	var data: PackedByteArray = _bytes([
+		0x00, 0x80, 0x81, Gen1Text.PAGE, 0x82, 0x83, Gen1Text.DEX_END,
+	])
+	assert_eq(Gen1Text.decode_dex_pages(data, 0, 32), _strings(["AB", "CD."]))
 
 
 func test_decoding_stops_at_the_end_of_the_buffer() -> void:

--- a/tests/unit/test_pokedex.gd
+++ b/tests/unit/test_pokedex.gd
@@ -18,6 +18,12 @@ func after_each() -> void:
 	RomCache.clear(Fixture.directory())
 
 
+## The Generation 1 cache is built once and kept: it is 151 species of JSON and
+## no test writes to it.
+func after_all() -> void:
+	RomCache.clear(Fixture.gen1_directory())
+
+
 func _state(seen: Array, caught: Array = []) -> Gen2WorldState:
 	var seen_map: Dictionary = {}
 	for species: int in seen:
@@ -740,3 +746,263 @@ func test_a_picture_fills_its_whole_box() -> void:
 		padded.get_pixel(side - 1, side - 1), Color.RED,
 		"a narrow pic is one column in and sits on the box's floor",
 	)
+
+
+## engine/menus/pokedex.asm: one listing over the dex numbers themselves, a side
+## menu of four rows, and a data page with two description pages behind it.
+
+var _gen1_data: GameData = null
+
+
+func _gen1() -> GameData:
+	if _gen1_data == null:
+		_gen1_data = Fixture.build_gen1()
+	return _gen1_data
+
+
+func _gen1_dex(seen: Array, caught: Array = []) -> Gen2Pokedex:
+	return Gen2Pokedex.open_gen1(_gen1(), _state(seen, caught))
+
+
+func _gen1_page() -> Gen2PokedexPage:
+	var page: Gen2PokedexPage = Gen2PokedexPage.from_data(_gen1())
+	assert_not_null(page, "the fixture carries LoadPokedexTilePatterns' sheets")
+	assert_true(page.ready())
+	return page
+
+
+## `.maxSeenPokemonLoop` walks the seen bits backwards, so `wDexMaxSeenMon` is
+## the highest number seen rather than a count of them.
+func test_the_gen1_listing_runs_to_the_highest_number_seen() -> void:
+	assert_eq(_gen1_dex([4, 40, 12]).listing_end, 40)
+	assert_eq(_gen1_dex([]).listing_end, 0)
+
+
+## `.printPokemonLoop` prints seven rows from the scroll offset whether or not
+## each has been seen, and `.dashedLine` stands in for a name that has not.
+func test_a_gen1_row_is_drawn_seen_or_not_and_carries_a_ball_once_caught() -> void:
+	var rows: Array = _gen1_dex([1, 2, 9], [2]).gen1_rows()
+	assert_eq(rows.size(), Gen2Pokedex.GEN1_LISTING_HEIGHT)
+	assert_eq(int(rows[0]["number"]), 1)
+	assert_eq(String(rows[0]["name"]), Fixture.species_name(1))
+	assert_false(bool(rows[0]["caught"]))
+	assert_true(bool(rows[1]["caught"]), "002 has been caught")
+	assert_eq(
+		String(rows[2]["name"]), Gen2Pokedex.GEN1_NOT_SEEN_NAME,
+		"003 has not been seen"
+	)
+
+
+## A listing shorter than a page draws only what it holds, which is `ld d, a`
+## behind `cp 7`, and `wMaxMenuItem` is one under it.
+func test_a_short_gen1_listing_draws_and_walks_only_its_own_rows() -> void:
+	var dex: Gen2Pokedex = _gen1_dex([3])
+	assert_eq(dex.gen1_rows().size(), 3)
+	assert_eq(dex.gen1_max_cursor(), 2)
+	for _step: int in 4:
+		dex.gen1_move_listing(PokeButton.DOWN)
+	assert_eq(dex.cursor, 2)
+	assert_eq(dex.scroll, 0, "nothing to scroll to")
+
+
+## `HandleMenuInput` moves the cursor inside the page and reports only the press
+## that ran off its end, which is where `.upPressed` and `.checkIfDownPressed`
+## scroll by one.
+func test_the_gen1_cursor_fills_the_page_before_the_listing_scrolls() -> void:
+	var dex: Gen2Pokedex = _gen1_dex([20])
+	for _step: int in Gen2Pokedex.GEN1_LISTING_HEIGHT - 1:
+		assert_true(dex.gen1_move_listing(PokeButton.DOWN))
+	assert_eq(dex.cursor, 6)
+	assert_eq(dex.scroll, 0)
+	assert_true(dex.gen1_move_listing(PokeButton.DOWN))
+	assert_eq(dex.cursor, 6)
+	assert_eq(dex.scroll, 1)
+	## The last row of the listing is `wDexMaxSeenMon`, so the scroll stops seven
+	## short of it.
+	for _step: int in 40:
+		dex.gen1_move_listing(PokeButton.DOWN)
+	assert_eq(dex.scroll, 20 - Gen2Pokedex.GEN1_LISTING_HEIGHT)
+	assert_eq(dex.selected_species(), 20)
+	for _step: int in 40:
+		dex.gen1_move_listing(PokeButton.UP)
+	assert_eq(dex.cursor, 0)
+	assert_eq(dex.scroll, 0)
+
+
+## `.checkIfRightPressed` adds seven and steps back to `wDexMaxSeenMon - 7` when
+## that runs past the end; `.checkIfLeftPressed` subtracts seven and lands on
+## zero on the borrow, with no length test of its own.
+func test_a_gen1_page_moves_seven_rows_and_clamps_to_either_end() -> void:
+	var dex: Gen2Pokedex = _gen1_dex([20])
+	assert_true(dex.gen1_move_listing(PokeButton.RIGHT))
+	assert_eq(dex.scroll, 7)
+	assert_true(dex.gen1_move_listing(PokeButton.RIGHT))
+	assert_eq(dex.scroll, 13, "20 - 7")
+	assert_false(dex.gen1_move_listing(PokeButton.RIGHT))
+	assert_true(dex.gen1_move_listing(PokeButton.LEFT))
+	assert_eq(dex.scroll, 6)
+	assert_true(dex.gen1_move_listing(PokeButton.LEFT))
+	assert_eq(dex.scroll, 0)
+	assert_false(dex.gen1_move_listing(PokeButton.LEFT))
+	assert_false(
+		_gen1_dex([5]).gen1_move_listing(PokeButton.RIGHT),
+		"a listing shorter than a page cannot page"
+	)
+
+
+## `HandlePokedexListMenu` draws the number one row above the name, the ball
+## between them, and `PlaceMenuCursor`'s own double-spaced arrow at column 0.
+func test_the_gen1_listing_stacks_its_number_over_its_name() -> void:
+	var dex: Gen2Pokedex = _gen1_dex([1, 2, 9], [2])
+	var map: PackedInt32Array = _gen1_page().gen1_list_map(
+		dex.gen1_rows(), dex.seen_count(), dex.caught_count(), 1
+	)
+	var top: int = Gen2PokedexPage.GEN1_LIST_TOP
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_LIST_NUMBER_X, top - 1),
+		Gen1Text.encode("0")[0], "001's leading zero"
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_LIST_NAME_X, top), Gen1Text.encode("M")[0]
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_LIST_BALL_X, top + Gen2PokedexPage.GEN1_ROW_STEP),
+		Gen2PokedexPage.GEN1_CAUGHT_BALL, "002 has been caught"
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_LIST_CURSOR_X, top + Gen2PokedexPage.GEN1_ROW_STEP),
+		Gen2PokedexPage.GEN1_CURSOR
+	)
+
+
+## `PlaceUnfilledArrowMenuCursor` opens `HandlePokedexSideMenu`, so the listing's
+## own arrow is hollow for as long as that menu is up.
+func test_the_gen1_side_menu_hollows_the_listing_arrow() -> void:
+	var dex: Gen2Pokedex = _gen1_dex([9])
+	var map: PackedInt32Array = _gen1_page().gen1_list_map(
+		dex.gen1_rows(), dex.seen_count(), dex.caught_count(), 0,
+		Gen2Pokedex.GEN1_SIDE_CRY
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_LIST_CURSOR_X, Gen2PokedexPage.GEN1_LIST_TOP),
+		Gen2PokedexPage.GEN1_UNFILLED_CURSOR
+	)
+	assert_eq(
+		_cell(
+			map, Gen2PokedexPage.GEN1_SIDE_CURSOR_X,
+			Gen2PokedexPage.GEN1_SIDE_MENU_AT.y + Gen2PokedexPage.GEN1_ROW_STEP
+		),
+		Gen2PokedexPage.GEN1_CURSOR
+	)
+
+
+## `ShowPokedexDataInternal` prints the height as feet and inches over
+## `HeightWeightText`'s own `?`s and the weight as five digits with `.next`'s
+## shuffle behind them, and the caught check gates both.
+func test_the_gen1_data_page_prints_its_two_measurements() -> void:
+	var page: Gen2PokedexPage = _gen1_page()
+	var entry: Dictionary = _gen1().dex_entry(4)
+	var map: PackedInt32Array = page.gen1_entry_map(
+		4, Fixture.species_name(4), entry, true, Gen2Pokedex.PAGE_1, true
+	)
+	var row: int = Gen2PokedexPage.GEN1_ENTRY_HEIGHT_AT.y
+	## The fixture's height is 104, which is 1'04".
+	assert_eq(_cell(map, Gen2PokedexPage.GEN1_FEET_AT + 1, row), Gen1Text.encode("1")[0])
+	assert_eq(_cell(map, Gen2PokedexPage.GEN1_FEET_AT + 2, row), Gen2PokedexPage.GEN1_FEET_MARK)
+	assert_eq(_cell(map, Gen2PokedexPage.GEN1_INCHES_AT, row), Gen1Text.encode("0")[0])
+	assert_eq(_cell(map, Gen2PokedexPage.GEN1_INCHES_AT + 1, row), Gen1Text.encode("4")[0])
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_INCHES_AT + 2, row),
+		Gen2PokedexPage.GEN1_INCHES_MARK
+	)
+	## 40 tenths of a pound, which reads "   4.0".
+	var weight_row: int = Gen2PokedexPage.GEN1_ENTRY_WEIGHT_AT.y
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_WEIGHT_POINT_AT - 1, weight_row),
+		Gen1Text.encode("4")[0]
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_WEIGHT_POINT_AT, weight_row),
+		Gen2PokedexPage.GEN1_DOT
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_WEIGHT_POINT_AT + 1, weight_row),
+		Gen1Text.encode("0")[0]
+	)
+
+
+## A weight under one pound has `.next` write the zero the printed field left
+## blank, which is what makes a stored 5 read "   0.5".
+func test_a_gen1_weight_under_a_pound_gets_its_own_leading_zero() -> void:
+	var map: PackedInt32Array = _gen1_page().gen1_entry_map(
+		1, "X", {"category": "CAT", "height": 100, "weight": 5, "pages": ["a"]},
+		true, Gen2Pokedex.PAGE_1, false
+	)
+	var row: int = Gen2PokedexPage.GEN1_ENTRY_WEIGHT_AT.y
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_WEIGHT_POINT_AT - 1, row),
+		Gen1Text.encode("0")[0]
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_WEIGHT_POINT_AT + 1, row),
+		Gen1Text.encode("5")[0]
+	)
+
+
+## `jp z, .waitForButtonPress` skips the height, the weight and the description
+## for a species that has been seen and not owned, so the template's own `?`s
+## stay on screen.
+func test_an_uncaught_gen1_entry_keeps_the_template_and_prints_no_description() -> void:
+	var page: Gen2PokedexPage = _gen1_page()
+	var map: PackedInt32Array = page.gen1_entry_map(
+		4, Fixture.species_name(4), _gen1().dex_entry(4), false, Gen2Pokedex.PAGE_1, false
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_FEET_AT + 1, Gen2PokedexPage.GEN1_ENTRY_HEIGHT_AT.y),
+		Gen1Text.encode("?")[0]
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_ENTRY_TEXT_AT.x, Gen2PokedexPage.GEN1_ENTRY_TEXT_AT.y),
+		Gen2PokedexPage.GEN1_SPACE
+	)
+	## The category and the number are printed in front of that check.
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_ENTRY_CATEGORY_AT.x, Gen2PokedexPage.GEN1_ENTRY_CATEGORY_AT.y),
+		Gen1Text.encode("C")[0]
+	)
+	assert_eq(
+		_cell(map, Gen2PokedexPage.GEN1_ENTRY_NUMBER_AT.x, Gen2PokedexPage.GEN1_ENTRY_NUMBER_AT.y),
+		Gen2PokedexPage.GEN1_NUMERO
+	)
+
+
+## `PageChar` shows its `▼` and waits, so the marker is on the first page and not
+## on the second.
+func test_only_the_first_gen1_description_page_carries_its_arrow() -> void:
+	var page: Gen2PokedexPage = _gen1_page()
+	var entry: Dictionary = _gen1().dex_entry(4)
+	var first: PackedInt32Array = page.gen1_entry_map(
+		4, "X", entry, true, Gen2Pokedex.PAGE_1, true
+	)
+	var second: PackedInt32Array = page.gen1_entry_map(
+		4, "X", entry, true, Gen2Pokedex.PAGE_2, false
+	)
+	var at: Vector2i = Gen2PokedexPage.GEN1_ENTRY_ARROW_AT
+	assert_eq(_cell(first, at.x, at.y), Gen2PokedexPage.GEN1_DOWN_ARROW)
+	assert_eq(_cell(second, at.x, at.y), Gen2PokedexPage.GEN1_SPACE)
+	assert_eq(
+		_cell(second, Gen2PokedexPage.GEN1_ENTRY_TEXT_AT.x, Gen2PokedexPage.GEN1_ENTRY_TEXT_AT.y),
+		Gen1Text.encode("p")[0], "the second page's own first letter"
+	)
+
+
+## `LoadUncompressedSpriteData` centres a pic narrower than the block where
+## `PadFrontpic` lays one blank column in front of it.
+func test_generation_one_centres_a_narrow_picture_in_its_box() -> void:
+	var side: int = Gen2PokedexPage.PIC_COLUMNS * Gen2PokedexPage.TILE
+	var art: Image = Image.create_empty(40, 40, false, Image.FORMAT_RGBA8)
+	art.fill(Color.BLUE)
+	var padded: Image = Gen2PokedexPage.pad_pic(art, Color.RED, RomRegistry.GEN1)
+	assert_eq(padded.get_pixel(0, side - 1), Color.RED, "one blank column each side")
+	assert_eq(padded.get_pixel(Gen2PokedexPage.TILE, side - 1), Color.BLUE)
+	assert_eq(padded.get_pixel(side - 1, side - 1), Color.RED)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1486 lines of the 40477 here,
-## and Generation 1 has added 1321 more to the shared battle, world, palette,
-## text, save and renderer code: 150 the battle animation engine, 140 the
-## transition, 108 the three PCs, 85 the party menu, 42 the status screen, 40
-## the bag in a battle, 20 the map callbacks, 9 the scripted walk.
-const MAX_COMMENT_LINES: int = 40477
+## files cost: `game/gen1` and its neighbours are 1486 lines of it, and
+## Generation 1 has added 1546 more to the shared code: 150 the battle animation
+## engine, 140 the transition, 130 the Pokedex, 108 the three PCs, 95 the
+## trainer card, 85 the party menu, 42 the status screen, 40 the bag in a
+## battle, 20 the map callbacks, 9 the scripted walk.
+const MAX_COMMENT_LINES: int = 40702
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_pics.gd
+++ b/tools/checks/gen1_pics.gd
@@ -17,26 +17,29 @@ const BACK_SIDE: int = 4
 const TRAINER_SIDE: int = 7
 
 ## SHA-1 of each atlas's own index buffer. Red and Blue share every picture,
-## and Yellow redrew all 151 front pics and six trainer ones, Brock, Misty,
-## Erika and the rival's three, but no back pic at all.
+## and Yellow redrew all 151 front pics, six trainer ones (Brock, Misty, Erika
+## and the rival's three) and `RedPicFront`, but no back pic at all.
 const DIGESTS: Dictionary = {
 	&"red": {
 		"front": "672ba02e2d98a787fb619e11e77fba45a379a47b",
 		"back": "a8976278a8c8294f285a25a993a44f2f6012b127",
 		"trainers": "1bdca25cb1bf6de93811f597481f0bda00079cf6",
 		"player_back": "6c2830e479cf877b20bd10f6c94324bb5c3e425d",
+		"player_front": "80b4ea682aa90ca902af3310d93ec9f125d03704",
 	},
 	&"blue": {
 		"front": "672ba02e2d98a787fb619e11e77fba45a379a47b",
 		"back": "a8976278a8c8294f285a25a993a44f2f6012b127",
 		"trainers": "1bdca25cb1bf6de93811f597481f0bda00079cf6",
 		"player_back": "6c2830e479cf877b20bd10f6c94324bb5c3e425d",
+		"player_front": "80b4ea682aa90ca902af3310d93ec9f125d03704",
 	},
 	&"yellow": {
 		"front": "d6e50eed9888dbe7787b1a1952403eab5bd133b6",
 		"back": "a8976278a8c8294f285a25a993a44f2f6012b127",
 		"trainers": "6b0fe80efffb9a8223a9646b1df42cfa592fd0f4",
 		"player_back": "6c2830e479cf877b20bd10f6c94324bb5c3e425d",
+		"player_front": "ec4681e52cb329f5c0466ca02ac05ba3c38a6e3d",
 	},
 }
 
@@ -52,14 +55,28 @@ const SHARED_PIC_ROWS: Array[int] = [27, 28]
 ## SHA-1 of each tile strip. All three cartridges hold the one font and the one
 ## text box; re-earn these against `gfx/font/font.png` and `font_extra.png`.
 ## SHA-1 of each tile strip. All three cartridges hold the same five; re-earn
-## these against `gfx/font/font.png`, `font_extra.png`, `font_battle_extra.png`
-## and `gfx/battle/battle_hud_*.png`.
+## these against `gfx/font/font.png`, `font_extra.png`, `font_battle_extra.png`,
+## `gfx/battle/battle_hud_*.png`, `gfx/pokedex/pokedex.png` and the trainer
+## card's own three. `BlankLeaderNames` runs on into `CircleTile`, so its digest
+## is over both files.
 const SHEET_DIGESTS: Dictionary = {
 	"font": "8146fe98bbbd27f9d67509e3da62044b44785a3a",
 	"font_extra": "ca0735bbbf8d2ce178a3f06a8d95ac6395dc8f7e",
 	"battle_font": "91f966f8c57286416ccec63a798e299417fb16b3",
 	"battle_hud_1": "f3c855d6f6f97f4994d4cd1967a2a205e8adac3d",
 	"battle_hud_2": "cc45fdec1282f49f07f31d80d2919a7b40ae8fce",
+	"pokedex_tiles": "657f5b06e8645c7459631437b11a977324774f4b",
+	"trainer_card_box": "4cbd04d3a6bc75710d26612068ed8ed71b1262b8",
+	"trainer_card_names": "b308184b958a914e70f6f034a28a13fe06b43b24",
+	"badge_numbers": "b2a864c62c1d5c5e50e372fa83b704178e41fcf0",
+}
+## `gfx/trainer_card/badges.2bpp` is the one card sheet the two pins disagree
+## on: Yellow redrew Brock's and Misty's faces and left both their badges and
+## the other six leaders alone.
+const BADGE_FACE_DIGESTS: Dictionary = {
+	&"red": "67f182582e594992337acc7d0c2058a5ee2e3dcd",
+	&"blue": "67f182582e594992337acc7d0c2058a5ee2e3dcd",
+	&"yellow": "48627c15953d84a0da69bab365f442ec5f2d01ac",
 }
 
 ## What the assembled page has to hold once the four sheets have overlapped:
@@ -87,11 +104,13 @@ func _one_game() -> void:
 	_atlas("back", SPECIES_COUNT, BACK_SIDE)
 	_atlas("trainers", TRAINER_COUNT, TRAINER_SIDE)
 	_atlas("player_back", Gen1Layout.PLAYER_BACKPICS.size(), BACK_SIDE)
+	_atlas("player_front", 1, TRAINER_SIDE)
 	_species_pics()
 	_trainer_pics()
 	_player_pics()
 	_sheets()
 	_battle_page()
+	_trainer_card()
 	_digests()
 
 
@@ -166,6 +185,14 @@ func _player_pics() -> void:
 		_r.check(_ink(cell), "the %s back pic is blank." % Gen1Layout.PLAYER_BACKPICS[slot])
 		drawn.append(cell.get("indices", PackedByteArray()))
 	_r.check(drawn[0] != drawn[1], "the player and the old man share a back pic.")
+	var front: Dictionary = _cell("player_front", 0)
+	_r.check(_ink(front), "RedPicFront is blank.")
+	_r.check(
+		_lit_columns(front) == GEN1_CARD_PIC_COLUMNS,
+		"RedPicFront draws in columns %s, so the card's own crop would cut it." % [
+			_lit_columns(front),
+		]
+	)
 
 
 ## The import's own font check seen from the cache side, and addressed the way
@@ -293,7 +320,7 @@ static func _sha1(data: PackedByteArray) -> String:
 
 func _digests() -> void:
 	var pinned: Dictionary = DIGESTS.get(_r.game_id, {}) as Dictionary
-	for name: String in ["front", "back", "trainers", "player_back"]:
+	for name: String in ["front", "back", "trainers", "player_back", "player_front"]:
 		var digest: String = _sha1(_r.data.atlas_indices(name))
 		var expected: String = String(pinned.get(name, ""))
 		if expected.is_empty():
@@ -307,3 +334,88 @@ func _digests() -> void:
 		_r.check(digest == String(SHEET_DIGESTS[name]), "the %s sheet is %s, pinned %s." % [
 			name, digest, SHEET_DIGESTS[name],
 		])
+	var faces: String = _sha1(_r.data.tile_indices("badge_faces"))
+	_r.check(
+		faces == String(BADGE_FACE_DIGESTS.get(_r.game_id, "")),
+		"the badge_faces sheet is %s, pinned %s." % [
+			faces, BADGE_FACE_DIGESTS.get(_r.game_id, ""),
+		]
+	)
+
+
+## Which tile columns of `RedPicFront` carry ink. `DrawTrainerInfo` walks the
+## picture one column forward in VRAM and the card's own boxes then cover the
+## outer column and the bottom row, so only these four are ever on screen.
+const GEN1_CARD_PIC_COLUMNS: Array[int] = [1, 2, 3, 4]
+
+## `DrawTrainerInfo`'s own cells, as (x, y) and the tile each has to hold: the
+## two boxes' corners, the `●BADGES●` circles and the badge numbers.
+const CARD_CELLS: Array[Array] = [
+	[0, 0, Gen2TrainerCardPage.GEN1_BOX_TOP_LEFT],
+	[19, 0, Gen2TrainerCardPage.GEN1_BOX_TOP_RIGHT],
+	[0, 7, Gen2TrainerCardPage.GEN1_BOX_BOTTOM_LEFT],
+	[19, 7, Gen2TrainerCardPage.GEN1_BOX_BOTTOM_RIGHT],
+	[1, 10, Gen2TrainerCardPage.GEN1_BOX_TOP_LEFT],
+	[18, 17, Gen2TrainerCardPage.GEN1_BOX_BOTTOM_RIGHT],
+	[0, 10, Gen1Layout.TRAINER_CARD_FILL_CODE],
+	[19, 17, Gen1Layout.TRAINER_CARD_FILL_CODE],
+	[6, 9, Gen1Layout.TRAINER_CARD_CIRCLE_CODE],
+	[13, 9, Gen1Layout.TRAINER_CARD_CIRCLE_CODE],
+	[2, 11, Gen1Layout.BADGE_NUMBER_CODE],
+	[14, 14, Gen1Layout.BADGE_NUMBER_CODE + 7],
+]
+## How many badges the drawn card is given, so the sweep sees both a badge and a
+## leader's face in one page.
+const CARD_BADGES: int = 3
+
+
+## `StartMenu_TrainerInfo`'s card assembled from the cache and drawn: every tile
+## it names has to be one the four sheets carry, and the badge cells have to
+## turn over at `DrawBadges`' own `add 4`.
+func _trainer_card() -> void:
+	var page: Gen2TrainerCardPage = Gen2TrainerCardPage.from_data(_r.data, false, true)
+	if not _r.check(page != null and page.ready(), "the trainer card page would not build."):
+		return
+	var badges: Array = []
+	for index: int in Gen2TrainerCard.BADGES_PER_PAGE:
+		badges.append(index < CARD_BADGES)
+	var map: PackedInt32Array = page.gen1_map({
+		"player_name": "RED", "money": 3000, "hours": "12", "minutes": "34",
+		"badges": badges,
+	})
+	for cell: Array in CARD_CELLS:
+		var read: int = map[int(cell[1]) * Gen2TrainerCardPage.COLUMNS + int(cell[0])]
+		_r.check(read == int(cell[2]), "the card's %d,%d holds $%02X, wanted $%02X." % [
+			cell[0], cell[1], read, int(cell[2]),
+		])
+	for index: int in Gen2TrainerCard.BADGES_PER_PAGE:
+		var at: Vector2i = Gen2TrainerCardPage.GEN1_BADGE_ROWS[index / 4] \
+			+ Vector2i((index % 4) * Gen2TrainerCardPage.GEN1_BADGE_STRIDE + 1, 1)
+		var wanted: int = Gen2TrainerCardPage.GEN1_FACE_TILES[index] \
+			+ (Gen1Layout.BADGE_FACE_BADGE_AT if index < CARD_BADGES else 0)
+		var read: int = map[at.y * Gen2TrainerCardPage.COLUMNS + at.x]
+		_r.check(read == wanted, "badge %d draws $%02X, wanted $%02X." % [
+			index, read, wanted,
+		])
+	_r.note("trainer card drawn, %d badges of %d" % [
+		CARD_BADGES, Gen2TrainerCard.BADGES_PER_PAGE,
+	])
+
+
+## The tile columns of an atlas cell that carry ink.
+func _lit_columns(cell: Dictionary) -> Array[int]:
+	var out: Array[int] = []
+	var width: int = int(cell.get("width", 0))
+	var indices: PackedByteArray = cell.get("indices", PackedByteArray())
+	@warning_ignore("integer_division")
+	for column: int in width / PokeTiles.TILE_WIDTH:
+		for y: int in int(cell.get("height", 0)):
+			var lit: bool = false
+			for x: int in PokeTiles.TILE_WIDTH:
+				if indices[y * width + column * PokeTiles.TILE_WIDTH + x] != 0:
+					lit = true
+					break
+			if lit:
+				out.append(column)
+				break
+	return out

--- a/tools/checks/gen1_tables.gd
+++ b/tools/checks/gen1_tables.gd
@@ -18,6 +18,8 @@ const TRAINER_COUNT: int = 47
 const MATCHUP_COUNT: int = 82
 const TMHM_COUNT: int = 55
 const EVOLUTION_COUNT: int = 72
+## `page` in every `PokedexEntry` description, which `PageChar` waits on.
+const DEX_PAGES: int = 2
 ## `data/pokemon/evos_moves.asm`: Yellow gave Pikachu and its line more to learn.
 const LEARNSET_MOVES: Dictionary = {&"red": 728, &"blue": 728, &"yellow": 755}
 
@@ -207,9 +209,12 @@ func _dex_entry(name: String, dex: Dictionary) -> void:
 	_r.check(not String(dex["category"]).is_empty(), "%s has no Pokedex category" % name)
 	_r.check(int(dex["height"]) > 0, "%s has no height" % name)
 	_r.check(int(dex["weight"]) > 0, "%s has no weight" % name)
+	## `page` parts every description in two, which is what
+	## `ShowPokedexDataInternal` waits between.
 	var pages: Array = dex["pages"]
-	_r.check(pages.size() == 1 and not String(pages[0]).is_empty(),
-		"%s has no Pokedex description" % name)
+	_r.check(pages.size() == DEX_PAGES, "%s has %d description pages" % [name, pages.size()])
+	for page: Variant in pages:
+		_r.check(not String(page).is_empty(), "%s has an empty description page" % name)
 	# `text_far` is the only way out of an entry, so an undecoded byte left in
 	# the text is a pointer that landed somewhere it should not have.
 	_r.check(not String(pages[0]).contains("<"), "%s's description holds a raw byte" % name)

--- a/tools/checks/pokedex.gd
+++ b/tools/checks/pokedex.gd
@@ -2,13 +2,15 @@ extends RefCounted
 
 var _r: RefCounted = null
 
-## Verifies the Pokedex's own graphics against freshly imported real caches on all
-## three cartridges, against `Pokedex_LoadGFX`'s two LZ runs,
-## `gfx/footprints.asm`'s 16x64-tile grid, `Pokedex_LoadUnownFont` and
-## `_CGB_Pokedex`'s three palettes. The real-cartridge counterpart to
-## tests/unit/test_pokedex.gd. What only a real cache can say is that the runs
-## decompressed to exactly the tiles the source asks for, that all three dumps
-## carry the same art, and that all 251 footprints are pictures rather than blanks.
+## Both generations' Pokedex against freshly imported real caches, the
+## real-cartridge counterpart to tests/unit/test_pokedex.gd. Crystal's own
+## graphics on all three of its dumps: `Pokedex_LoadGFX`'s two LZ runs,
+## `gfx/footprints.asm`'s grid, `Pokedex_LoadUnownFont` and `_CGB_Pokedex`'s
+## three palettes, each decompressed to exactly the tiles the source asks for.
+
+## Generation 1's is `ShowPokedexMenu`, swept on Red, Blue and Yellow: all 151
+## `PokedexEntry` rows, `LoadPokedexTilePatterns`' page, and the listing walked
+## from one end to the other with its data page opened.
 
 ## `Pokedex_LoadGFX` decompresses `PokedexLZ` to `vTiles2 tile $31`, so the sheet
 ## number a layout writes is offset by this and the last one it can name is
@@ -45,6 +47,7 @@ func run(r: RefCounted) -> void:
 		_r.fail("The three dumps do not carry the same Pokedex art: %s" % digests)
 	else:
 		print("  art identical on all three: %s" % [unique.keys()])
+	_r.each_game_of(RomRegistry.GEN1, _check_gen1)
 
 
 ## Answers a digest of the three sheets, or "" when the cache failed a check.
@@ -178,3 +181,148 @@ func _check_entries(data: GameData, game_id: StringName, page: Gen2PokedexPage) 
 		game_id, short_entries.size(), short_entries.slice(0, 8),
 	])
 	return false
+
+
+## `PokedexEntry` rows pinned off data/pokemon/dex_entries.asm, by dex number:
+## category, feet, inches and tenths of a pound. All three cartridges carry the
+## same table.
+const GEN1_ENTRIES: Dictionary = {
+	1: ["SEED", 2, 4, 150],
+	25: ["MOUSE", 1, 4, 130],
+	50: ["MOLE", 0, 8, 20],
+	95: ["ROCK SNAKE", 28, 10, 4630],
+	151: ["NEW SPECIE", 1, 4, 90],
+}
+const GEN1_SPECIES: int = 151
+## `page` parts every description in two and `dex` closes the second with a full
+## stop `PlaceDexEnd` writes rather than the text.
+const GEN1_PAGES: int = 2
+const GEN1_LINES: int = 3
+## The one description in the corpus that ends `@@` rather than on `dex`, so
+## `PlaceDexEnd` never runs and the text carries its own punctuation.
+## `_KoffingDexEntry` on Yellow alone (data/pokemon/dex_text.asm).
+const GEN1_NO_DEXEND: Dictionary = {&"yellow": [109] as Array[int]}
+
+
+## One Generation 1 cartridge: the table, the page and a walk over the listing.
+func _check_gen1() -> void:
+	var data: GameData = _r.data
+	var sheet: Dictionary = data.tile_sheet("pokedex_tiles")
+	if not _r.check(
+		int(sheet.get("tiles", 0)) == Gen1Layout.POKEDEX_TILES,
+		"pokedex_tiles is %d tiles, wanted %d" % [
+			int(sheet.get("tiles", 0)), Gen1Layout.POKEDEX_TILES,
+		]
+	):
+		return
+	var page: Gen2PokedexPage = Gen2PokedexPage.from_data(data)
+	if not _r.check(page != null and page.ready(), "the Pokedex page would not build"):
+		return
+	_check_gen1_entries(data)
+	_check_gen1_listing(data, page)
+
+
+## Every row of `PokedexEntryPointers`, read through the dex numbers the cache
+## speaks: a wrong pointer decodes to something, so the shape of all 151 is what
+## says the table is right.
+func _check_gen1_entries(data: GameData) -> void:
+	var lines: Dictionary = {}
+	var unpunctuated: Array[int] = []
+	var wrong_pages: Array[int] = []
+	for number: int in range(1, GEN1_SPECIES + 1):
+		var entry: Dictionary = data.dex_entry(number)
+		var pages: PackedStringArray = entry.get("pages", PackedStringArray())
+		if String(entry.get("category", "")).is_empty():
+			_r.fail("species %d has no Pokedex category" % number)
+			return
+		if pages.size() != GEN1_PAGES:
+			wrong_pages.append(number)
+			continue
+		if not pages[GEN1_PAGES - 1].ends_with("."):
+			unpunctuated.append(number)
+		for text: String in pages:
+			lines[text.split("\n").size()] = true
+	_r.check(
+		wrong_pages.is_empty(),
+		"%d descriptions are not two pages: %s" % [
+			wrong_pages.size(), wrong_pages.slice(0, 8),
+		]
+	)
+	_r.check(
+		unpunctuated == GEN1_NO_DEXEND.get(_r.game_id, [] as Array[int]),
+		"%d descriptions end without PlaceDexEnd's full stop: %s" % [
+			unpunctuated.size(), unpunctuated.slice(0, 8),
+		]
+	)
+	## `bccoord 1, 11` and `<NEXT>`'s two rows leave room for exactly three.
+	for count: Variant in lines:
+		_r.check(
+			int(count) <= GEN1_LINES,
+			"a description page is %d lines, which does not fit the box" % int(count)
+		)
+	for number: Variant in GEN1_ENTRIES:
+		var wanted: Array = GEN1_ENTRIES[number]
+		var entry: Dictionary = data.dex_entry(int(number))
+		var height: int = int(entry.get("height", 0))
+		var read: Array = [
+			String(entry.get("category", "")),
+			int(height / 100), height % 100, int(entry.get("weight", 0)),
+		]
+		_r.check(read == wanted, "species %d reads %s, wanted %s" % [number, read, wanted])
+	_r.note("151 entries, %d pages each, %s" % [GEN1_PAGES, lines.keys()])
+
+
+## `ShowPokedexMenu` walked end to end: the listing pages down to the last dex
+## number, the side menu opens over it, and DATA draws both description pages.
+func _check_gen1_listing(data: GameData, page: Gen2PokedexPage) -> void:
+	var state := Gen2WorldState.new()
+	for number: int in range(1, GEN1_SPECIES + 1):
+		state.set_species_seen(number)
+		state.set_species_caught(number)
+	var dex: Gen2Pokedex = Gen2Pokedex.open_gen1(data, state)
+	if not _r.check(dex.listing_end == GEN1_SPECIES, "the listing runs to %d" % dex.listing_end):
+		return
+	var steps: int = 0
+	while dex.gen1_move_listing(PokeButton.RIGHT):
+		steps += 1
+		if steps > GEN1_SPECIES:
+			break
+	_r.check(
+		dex.selected_species() == GEN1_SPECIES - Gen2Pokedex.GEN1_LISTING_HEIGHT + 1,
+		"paging to the end left the cursor on %d" % dex.selected_species()
+	)
+	while dex.gen1_move_listing(PokeButton.DOWN):
+		pass
+	_r.check(
+		dex.selected_species() == GEN1_SPECIES,
+		"walking down to the end left the cursor on %d" % dex.selected_species()
+	)
+	var rows: Array = dex.gen1_rows()
+	_r.check(
+		rows.size() == Gen2Pokedex.GEN1_LISTING_HEIGHT
+			and int(rows[rows.size() - 1]["number"]) == GEN1_SPECIES,
+		"the last page ends on %s" % [rows]
+	)
+	var entry: Dictionary = data.dex_entry(GEN1_SPECIES)
+	for description: int in GEN1_PAGES:
+		var map: PackedInt32Array = page.gen1_entry_map(
+			GEN1_SPECIES, String(data.species(GEN1_SPECIES).get("name", "")),
+			entry, true, description, description == 0
+		)
+		var text: PackedStringArray = entry["pages"]
+		_r.check(
+			_gen1_row(map, Gen2PokedexPage.GEN1_ENTRY_TEXT_AT.y)
+				== text[description].split("\n")[0],
+			"the data page's first line is not the description's"
+		)
+	_r.note("listing walked %d pages to species %d" % [steps, dex.selected_species()])
+
+
+## One row of a drawn map back as text, so a check can read what the screen says.
+## The border columns are left out: they are sheet tiles rather than characters.
+func _gen1_row(map: PackedInt32Array, row: int) -> String:
+	var codes := PackedByteArray()
+	var from: int = Gen2PokedexPage.GEN1_ENTRY_TEXT_AT.x
+	for column: int in range(from, Gen2PokedexPage.COLUMNS - 1):
+		codes.append(map[row * Gen2PokedexPage.COLUMNS + column])
+	return Gen1Text.decode(codes, 0, codes.size()).strip_edges()

--- a/tools/preview_pics.gd
+++ b/tools/preview_pics.gd
@@ -9,9 +9,12 @@ extends SceneTree
 
 const ATLASES: PackedStringArray = [
 	"front", "back", "unown_front", "unown_back", "trainers", "player_back",
+	"player_front",
 ]
 const SHEETS: PackedStringArray = [
 	"font", "font_extra", "frames", "battle_font", "enemy_hud", "player_hud", "exp_bar",
+	"pokedex_tiles", "trainer_card_box", "trainer_card_names", "badge_numbers",
+	"badge_faces",
 ]
 
 ## Tiles per row when a strip is folded for viewing.

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -3,16 +3,23 @@ extends SceneTree
 ## Captures the Pokedex against a real imported cache.
 ##   Godot --headless --path . -s res://tools/preview_pokedex.gd -- \
 ##       crystal /tmp/dex.png [list|entry|option|search|results|unown] [presses]
+## A Generation 1 cartridge answers `list`, `side` and `entry` and none of the
+## other four: `ShowPokedexMenu` has no mode, search or Unown screen.
 ## The world behind it is a new game with every species seen and every second one
 ## caught, which puts a full listing, both row states and a real entry on screen at
 ## once. `f<n>` in [presses] spends n hardware frames, which catches the arrow blink.
 
 const NEW_BARK_GROUP: int = 24
 const NEW_BARK_MAP: int = 7
-## How far down the dex the preview's save has been filled.
+## PALLET_TOWN, which a Generation 1 map id names on its own.
+const PALLET_TOWN: int = 0
+## How far down the dex the preview's save has been filled, per generation.
 const SEEN: int = 251
+const GEN1_SEEN: int = 151
 ## The one species left out of it, so the listing has an unseen row to draw.
+## Generation 1 lists by dex number, so the hole has to be past the first page.
 const UNSEEN: int = 1
+const GEN1_UNSEEN: int = 4
 
 const BUTTONS: Dictionary = {
 	"u": PokeButton.UP, "d": PokeButton.DOWN,
@@ -37,6 +44,15 @@ const ROUTES: Dictionary = {
 	"unown": "sel,d,d,d,a",
 }
 
+## `HandlePokedexSideMenu` and `ShowPokedexDataInternal`, the two screens behind
+## Generation 1's listing.
+const GEN1_ROUTES: Dictionary = {
+	"list": "",
+	"unseen": "d,d,d",
+	"side": "a",
+	"entry": "a,a",
+}
+
 
 func _initialize() -> void:
 	var args: PackedStringArray = OS.get_cmdline_user_args()
@@ -56,13 +72,16 @@ func _initialize() -> void:
 		quit(1)
 		return
 
+	var gen1: bool = data.generation == RomRegistry.GEN1
 	var screen: String = args[2] if args.size() > 2 else "list"
-	var tokens: String = String(ROUTES.get(screen, ""))
+	var routes: Dictionary = GEN1_ROUTES if gen1 else ROUTES
+	var tokens: String = String(routes.get(screen, ""))
 	if args.size() > 3:
 		tokens = "%s,%s" % [tokens, args[3]] if not tokens.is_empty() else args[3]
 
 	var world: Gen2WorldAPI = Gen2WorldAPI.open(
-		data, NEW_BARK_GROUP, NEW_BARK_MAP, Vector2i.ZERO, _state()
+		data, 0 if gen1 else NEW_BARK_GROUP, PALLET_TOWN if gen1 else NEW_BARK_MAP,
+		Vector2i.ZERO, _state(gen1)
 	)
 	var host := Gen2PokedexScreen.new()
 	root.add_child(host)
@@ -98,10 +117,12 @@ func _initialize() -> void:
 ## OPTION screen offers its fourth row.
 ## [constant UNSEEN] is left out so one row is the not-seen one, which is the
 ## only row that draws `LoadQuestionMarkPic`'s picture.
-static func _state() -> Gen2WorldState:
+static func _state(gen1: bool = false) -> Gen2WorldState:
 	var state := Gen2WorldState.new({}, {}, {}, {})
-	for species: int in range(1, SEEN + 1):
-		if species == UNSEEN:
+	var last: int = GEN1_SEEN if gen1 else SEEN
+	var hole: int = GEN1_UNSEEN if gen1 else UNSEEN
+	for species: int in range(1, last + 1):
+		if species == hole:
 			continue
 		state.set_species_seen(species)
 		if species % 2 == 0:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -44,6 +44,8 @@ const KIND_HELP: Dictionary = {
 	&"egg_hatch": "frames, slot: OverworldHatchEgg on that party slot, that many frames in",
 	&"whiteout": "presses, frames: Script_Whiteout. 0 the faint line, 1 the first page of _WhitedOutText, 3 the map woken on; a second number stops that many frames into .PlayPoisonSFX instead",
 	&"elevator": "DOWN presses: the floor list bg_event 3's elevator opens, read from the cell below the panel",
+	&"trainer_card": "badges, 0: StartMenu_TrainerInfo's card, with that many of wObtainedBadges' eight set",
+	&"pokedex": "rows down, presses: StartMenu_Pokedex's own listing, then A on the row it left the cursor on",
 	&"start_menu": "rows down, contest: SetUpMenuItems' list. A second number of 1 runs the Bug Catching Contest and 2 has something caught",
 	&"pack": "presses, rows down: the bag opened off the start menu, seeded with one row of each shape. The rows are walked after the first press, so 0 4 scrolls the list, 1 0 is USE/TOSS, 2 1 the TOSS dial and 4 1 the box it ends in",
 	&"mailbox": "rows down, A presses: the bedroom PC's MAILBOX",
@@ -401,7 +403,8 @@ const SELF_DRIVEN_KINDS: Array[StringName] = [
 	&"name_rater", &"move_deleter", &"move_tutor", &"day_care",
 	&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
 	&"catch_nickname", &"catch_dex", &"mom_bank", &"bills_pc", &"players_pc",
-	&"pokemon_center_pc", &"start_menu", &"mod_notice", &"mod_page", &"sight",
+	&"pokemon_center_pc", &"start_menu", &"pokedex", &"trainer_card",
+	&"mod_notice", &"mod_page", &"sight",
 	&"reset_question", &"launcher_question",
 ]
 
@@ -460,6 +463,8 @@ const STAGERS: Dictionary = {
 	&"unown_printer": &"_stage_unown_printer",
 	&"diploma": &"_stage_diploma",
 	&"start_menu": &"_stage_start_menu",
+	&"pokedex": &"_stage_pokedex",
+	&"trainer_card": &"_stage_trainer_card",
 	&"pack": &"_stage_pack",
 	&"bills_pc": &"_stage_pc",
 	&"players_pc": &"_stage_pc",
@@ -1140,6 +1145,30 @@ func _stage_diploma() -> void:
 ## number is how many rows down to walk before the picture, and a second number of 1
 ## or more runs the Bug Catching Contest, which is the list `SetUpMenuItems` drops
 ## PACK from and puts QUIT in SAVE's slot.
+## `StartMenu_Pokedex`. The first number walks the listing down and the second
+## spends A presses on it, so `1 2` is the second row's entry page.
+func _stage_pokedex() -> void:
+	_screen.get("_world").state.set_engine_flag(
+		Gen2WorldStartMenu.ENGINE_POKEDEX, true
+	)
+	_screen.preview_pokedex()
+	for _down: int in maxi(_cell.x, 0):
+		_screen.press_button(PokeButton.DOWN)
+	for _press: int in maxi(_cell.y, 0):
+		_screen.preview_pokedex()
+
+
+## `StartMenu_TrainerInfo`. The first number is how many badges to set, since a
+## development save has none and the card's lower half is what they fill.
+func _stage_trainer_card() -> void:
+	var state: Gen2WorldState = _screen.get("_world").state
+	for badge: int in maxi(_cell.x, 0):
+		state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
+			Gen2WorldState.KANTO_BADGE_FIRST + badge
+		], true)
+	_screen.preview_trainer_card()
+
+
 func _stage_start_menu() -> void:
 	if _cell.y >= 1:
 		var contest_world: Gen2WorldAPI = _screen.get("_world")

--- a/tools/validate.gd
+++ b/tools/validate.gd
@@ -46,7 +46,7 @@ const GROUPS: Dictionary = {
 	&"trainers": [&"crystal_route30_trainer", &"gold_route30_trainer"],
 	&"gen1": [
 		&"gen1_tables", &"gen1_pics", &"gen1_maps", &"gen1_walk", &"gen1_battle",
-		&"gen1_battle_anims", &"gen1_catch", &"gen1_trainers",
+		&"gen1_battle_anims", &"gen1_catch", &"gen1_trainers", &"pokedex",
 	],
 }
 


### PR DESCRIPTION
## Added

`ShowPokedexMenu` on Red, Blue and Yellow: a listing over the dex numbers themselves rather than an order table, `HandlePokedexSideMenu`'s DATA/CRY/AREA/QUIT, and `ShowPokedexDataInternal`'s data page with the front pic `LoadFlippedFrontSpriteByMonIndex` mirrors. `HandleMenuInput` inside `HandlePokedexListMenu` is two rules in one and both are here: the cursor fills the page before the listing scrolls, and left and right page in sevens clamped to `wDexMaxSeenMon - 7`.

`StartMenu_TrainerInfo`, as `Gen2TrainerCardPage`'s fourth page: `TrainerInfo_DrawTextBox`'s two boxes, NAME/MONEY/TIME, and `DrawBadges`' eight cells, each a number tile and a leader's face until `add 4` turns it into the badge. `BlkPacket_TrainerCard`'s ten blocks colour it, three of them the Rainbow badge and none of the three on it.

`RedPicFront`, `PokedexTileGraphics`, `TrainerInfoTextBoxTileGraphics`, `BlankLeaderNames`, `BadgeNumbersTileGraphics` and `GymLeaderFaceAndBadgeTileGraphics` are imported. Yellow redrew `RedPicFront` and Brock's and Misty's faces and left the six other leaders and every badge alone.

`tools/preview_pokedex.gd -- red <out.png> [list|side|entry]` photographs the dex and `tools/preview_world.gd -- red 0 0 <out.png> live trainer_card 3 0` the card. `tools/checks/pokedex.gd` sweeps all 151 `PokedexEntry` rows and walks the listing end to end on all three cartridges; `gen1_pics.gd` pins the four card sheets and `RedPicFront` against the pinned `.2bpp` files.

## Fixed

Every Generation 1 Pokedex description was missing the full stop `PlaceDexEnd` writes and carried its two pages as one joined string, so nothing could show `PageChar`'s second page. Yellow's KOFFING is the one row that ends `@@` and gets no stop.

`Gen2PicImage.frontpic_origin` dropped the generation `frontpic_pad_columns` takes, so a Generation 1 picture narrower than seven tiles was laid one column in where `LoadUncompressedSpriteData` centres it. The status screen and an evolution both drew it that way.

`call DisplayPokedex`'s nine script rows and a catch raised `pokedex_entry_requested` and no screen answered it.

## Changed

Cache format 118: the four trainer card sheets, `PokedexTileGraphics`, `RedPicFront` and the split description pages.