### PR TITLE
Raise a Pokemon at the Generation 1 Day-Care

### DIFF
--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -483,7 +483,10 @@ static func _verify_battle_anims(rom: RomFile, layout: Dictionary) -> Dictionary
 ## Each run is one contiguous block of `text_far` stubs, so a base offset that
 ## has slipped shows up as a slot that does not decode at all.
 static func _verify_facility_text(rom: RomFile, layout: Dictionary) -> Dictionary:
-	var runs: Dictionary = {"mart": ["mart_text", Gen1Layout.MART_TEXT_AT]}
+	var runs: Dictionary = {
+		"mart": ["mart_text", Gen1Layout.MART_TEXT_AT],
+		"day_care": ["day_care_text", Gen1Layout.DAY_CARE_TEXT_AT],
+	}
 	runs.merge(FACILITY_TEXT_RUNS)
 	runs["npc_trade"] = ["npc_trade_cable_text", Gen1Layout.NPC_TRADE_TEXT_AT]
 	for run: String in runs:
@@ -789,6 +792,7 @@ func import_rom(
 		"tiles": tiles,
 		"bar_palettes": _import_bar_palettes(rom, layout),
 		"mart_text": _import_mart_text(rom, layout),
+		"day_care_text": _import_day_care_text(rom, layout),
 		"special_text": _import_facility_text(rom, layout),
 		"oak_ratings": _import_dex_ratings(rom, layout),
 		"vending": _import_vending(rom, layout, items),
@@ -1055,6 +1059,17 @@ func _import_prizes(rom: RomFile, layout: Dictionary) -> Array:
 				"level": int(levels.get(number, 0)) if not tms else 0,
 			})
 		out.append({"tms": tms, "rows": rows})
+	return out
+
+
+## `DaycareGentlemanText`'s fifteen, in the section both generations' Day-Care
+## boxes are read from.
+func _import_day_care_text(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var out: Dictionary = {}
+	for name: String in Gen1Layout.DAY_CARE_TEXT_AT:
+		out[name] = facility_text(rom, Gen1Layout.facility_text_offset(
+			layout, "day_care_text", Gen1Layout.DAY_CARE_TEXT_AT, name
+		))
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -585,6 +585,16 @@ const POKECENTER_TEXT_AT: Dictionary = {
 	"fighting_fit": 0x10, "farewell": 0x15,
 }
 
+## `DaycareGentlemanText`'s fifteen stubs, at the same deltas on all three.
+## `all_right_then` has no `text_end`, so `come_again` prints as part of it.
+const DAY_CARE_TEXT_AT: Dictionary = {
+	"intro": 0x00, "which_mon": 0x05, "will_look_after": 0x0A,
+	"come_see_me": 0x0F, "has_grown": 0x14, "owe_money": 0x19,
+	"got_mon_back": 0x1E, "needs_more_time": 0x23, "all_right_then": 0x28,
+	"come_again": 0x2C, "no_room": 0x31, "only_one_mon": 0x36,
+	"knows_hm_move": 0x3B, "heres_your_mon": 0x40, "not_enough_money": 0x45,
+}
+
 ## `engine/items/item_effects.asm`'s two runs the pack prints from: the three
 ## refusals `ItemUseFailed` reaches and `TossItem_`'s own three.
 const ITEM_USE_TEXT_AT: Dictionary = {
@@ -1256,6 +1266,9 @@ const RED_BLUE: Dictionary = {
 	"replace_tile_block": 0x0EE9E,
 	"card_key_door": 0xD73F,
 	"silph_map_list": 0x526E3,
+	## `DaycareGentlemanText` and the head of its own stub run.
+	"day_care_script": 0x56254,
+	"day_care_text": 0x5640F,
 	## `DoInGameTradeDialogue`, the trade table it indexes with `wWhichTrade`,
 	## `InGameTradeTextPointers` and the pair of boxes the swap itself prints.
 	"in_game_trade": 0x71AD9,
@@ -1450,6 +1463,8 @@ const YELLOW: Dictionary = {
 	"replace_tile_block": 0x0ED1B,
 	"card_key_door": 0xD73E,
 	"silph_map_list": 0x52645,
+	"day_care_script": 0x56244,
+	"day_care_text": 0x56441,
 	"in_game_trade": 0x71B86,
 	"which_trade": 0xCD3D,
 	"trade_mons": 0x71C1D,
@@ -1670,6 +1685,15 @@ static func machine_number(item: int) -> int:
 	if is_tm_item(item):
 		return item - TM_FIRST_ITEM + 1
 	return TM_COUNT + item - HM_FIRST_ITEM + 1 if is_hm_item(item) else 0
+
+
+## The inverse: the item a one-based `TechnicalMachines` row is carried by.
+static func machine_item(number: int) -> int:
+	if number >= 1 and number <= TM_COUNT:
+		return TM_FIRST_ITEM + number - 1
+	if number > TM_COUNT and number <= TM_COUNT + HM_COUNT:
+		return HM_FIRST_ITEM + number - TM_COUNT - 1
+	return 0
 
 
 static func item_price_offset(layout: Dictionary, item: int) -> int:

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1110,6 +1110,11 @@ static func _read_text(
 	if header >= 0:
 		row["trainer"] = _read_trainer_header(rom, layout, bank, header)
 		return row
+	## The corpus's other row the world owns whole: a party list and `MoveMon`
+	## both ways are no more readable here than `TalkToTrainer` is.
+	if at == int(layout["day_care_script"]):
+		row["script"] = [{"op": "day_care"}]
+		return row
 	row["text"] = String(decoded["text"])
 	row["prompt"] = bool(decoded.get("prompt", false))
 	var code: int = _text_code_at(decoded)

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 118
+const FORMAT_VERSION: int = 119
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3721,6 +3721,7 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"replace_block": &"_gen1_node_replace_block",
 	"player_coord": &"_gen1_node_player_coord",
 	"walk": &"_gen1_node_walk",
+	"day_care": &"_gen1_node_day_care",
 }
 
 
@@ -4188,6 +4189,118 @@ func _gen1_take_item(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 		bag[item] = left
 	steps.append({"type": &"items", "items": {item: left}})
 	return true
+
+
+## `DaycareGentlemanText`, which owns the whole row: the offer and a party list
+## on one side of `wDayCareInUse`, the growth and the price on the other.
+func _gen1_node_day_care(_node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	if data == null or state == null:
+		return false
+	if not state.day_care_has_mon(Gen2WorldDayCare.SLOT_MAN):
+		steps.append(_gen1_day_care_offer())
+		return true
+	return _gen1_day_care_visit(steps)
+
+
+## `.IntroText` under a `YesNoChoice`, with `wPartyCount` tested before the list.
+func _gen1_day_care_offer() -> Dictionary:
+	var taken: Array = [_gen1_day_care_box("only_one_mon")]
+	if int(_party_summary.get("count", 0)) > 1:
+		taken = [
+			_gen1_day_care_box("which_mon"),
+			{
+				"type": &"request",
+				"values": {"kind": &"party_selection_requested", "values": {
+					"routine": &"day_care",
+				}},
+				"day_care": &"deposit",
+			},
+		]
+	return {
+		"type": &"choice",
+		"text": String(_gen1_day_care_box("intro")["text"]),
+		"yes": taken,
+		"no": [_gen1_day_care_box("come_again")],
+	}
+
+
+## `DisplayPartyMenu`'s carry is CANCEL, and `callfar KnowsHMMove` is the whole
+## of what is asked about the row it came back with.
+func _gen1_day_care_after_selection(result: Dictionary) -> Array:
+	var party_index: int = int(result.get("party_index", -1))
+	if party_index < 0:
+		return [_gen1_day_care_box("all_right_then")]
+	if Gen2WorldTMHM.knows_hm_move(data, _gen1_party_moves(party_index)):
+		return [_gen1_day_care_box("knows_hm_move")]
+	return [
+		_gen1_day_care_box("will_look_after", String(result.get("nickname", ""))),
+		_gen1_day_care_request(&"deposit", party_index),
+		_gen1_day_care_box("come_see_me"),
+	]
+
+
+## `.daycareInUse`: the level the slot reached and the price behind it.
+func _gen1_day_care_visit(steps: Array) -> bool:
+	var visit: Dictionary = Gen2WorldDayCare.gen1_visit(state, data)
+	if visit.is_empty():
+		return false
+	var nickname: String = String(visit["nickname"])
+	var growth: int = int(visit["growth"])
+	steps.append(_gen1_day_care_box(
+		"has_grown" if growth > 0 else "needs_more_time", nickname, "%3d" % growth
+	))
+	if int(_party_summary.get("count", 0)) >= Gen2SaveData.MAX_PARTY:
+		steps.append(_gen1_day_care_box("no_room"))
+		return true
+	var price: int = int(visit["price"])
+	steps.append({"type": &"money_box", "kind": &"money_top_right"})
+	steps.append({
+		"type": &"choice",
+		"text": String(_gen1_day_care_box("owe_money", "", str(price))["text"]),
+		"yes": _gen1_day_care_payment(price, nickname),
+		"no": [_gen1_day_care_box("all_right_then")],
+	})
+	return true
+
+
+## `.enoughMoney` pays before it draws the box again, so the receipt stands over
+## the new balance.
+func _gen1_day_care_payment(price: int, nickname: String) -> Array:
+	var purse: int = state.money(Gen2WorldMartHost.MONEY_ACCOUNT)
+	if purse < price:
+		return [_gen1_day_care_box("not_enough_money")]
+	return [
+		{"type": &"money", "amount": purse - price},
+		{"type": &"money_box", "kind": &"money_top_right"},
+		_gen1_day_care_box("heres_your_mon"),
+		_gen1_day_care_request(&"withdraw", -1),
+		_gen1_day_care_box("got_mon_back", nickname),
+	]
+
+
+func _gen1_day_care_request(action: StringName, party_index: int) -> Dictionary:
+	return {"type": &"request", "values": {
+		"kind": &"day_care_mon_requested",
+		"values": {"action": action, "party_index": party_index},
+	}}
+
+
+## One stub with its `text_ram` and its `text_decimal` or `text_bcd` filled,
+## [param number] already spelled the way that command prints it.
+func _gen1_day_care_box(name: String, ram: String = "", number: String = "") -> Dictionary:
+	var text: String = gen1_filled_text(data.day_care_text(name))
+	if not ram.is_empty():
+		text = Gen2TextStream.fill_all_markers(text, Gen2TextStream.RAM_MARKER, ram)
+	if not number.is_empty():
+		text = Gen2TextStream.fill_all_markers(
+			text, Gen2TextStream.NUMBER_MARKER, number
+		)
+	return {"type": &"text", "text": text}
+
+
+func _gen1_party_moves(party_index: int) -> Array:
+	var moves: Array = _party_summary.get("moves", [])
+	return moves[party_index] as Array if party_index < moves.size() else []
 
 
 ## `DoInGameTradeDialogue` over the row's own `wWhichTrade`:
@@ -4852,6 +4965,8 @@ func _gen1_advance(choice: int, result: Dictionary = {}) -> Array:
 		_gen1_steps = branch.duplicate(true) + _gen1_steps
 	elif step.has("trade"):
 		_gen1_steps = _gen1_trade_after_selection(step, result) + _gen1_steps
+	elif step.has("day_care"):
+		_gen1_steps = _gen1_day_care_after_selection(result) + _gen1_steps
 	elif step.has("ok"):
 		## `accepted` is the carry `_GivePokemon` answers in.
 		_gen1_steps = (step[

--- a/game/world/world_day_care.gd
+++ b/game/world/world_day_care.gd
@@ -466,14 +466,12 @@ static func deposit(
 	return true
 
 
-## `RetrieveBreedmon`. The level comes from the experience, `HealPartyMon` fills
-## HP, status and PP, and `FillMoves` teaches whatever the levels between the two
-## carry.
-##
-## The last write is `CalcExpAtLevel`, which puts the experience *back* to the
-## bottom of the level it just reached: that is
-## `docs/bugs_and_glitches.md`'s "Pokemon deposited in the Day-Care might lose
-## experience", and it is reproduced rather than corrected.
+## `RetrieveBreedmon`, and `MoveMon DAYCARE_TO_PARTY` with `.enoughMoney` behind
+## it on Generation 1. The level comes from the experience and HP is filled from
+## the new maximum on both; only Crystal's clears the status byte, refills every
+## PP and writes the experience *back* to the bottom of the level just reached,
+## which is `docs/bugs_and_glitches.md`'s "Pokemon deposited in the Day-Care
+## might lose experience" and is reproduced rather than corrected.
 static func retrieve(
 	state: Gen2WorldState, save: Gen2SaveData, data: GameData, slot: int
 ) -> Dictionary:
@@ -484,19 +482,14 @@ static func retrieve(
 		return {}
 	var previous_level: int = mon.level
 	mon.level = clampi(grown_level(data, mon), previous_level, MAX_LEVEL)
-	Gen2Learnset.fill_moves(
-		data.learnset(mon.species), mon.moves, mon.level, previous_level
-	)
-	var growth_rate: int = int(data.species(mon.species).get("growth_rate", 0))
-	mon.exp = Gen2Experience.total_exp_at(growth_rate, mon.level)
-	mon.status = Gen2Status.NONE
+	if data.generation == RomRegistry.GEN1:
+		gen1_fill_moves(data, mon, previous_level)
+	else:
+		_retrieve_gen2_rows(data, mon, previous_level)
 	mon.hp = Gen2Stats.calculate(
 		int((data.species(mon.species).get("stats", {}) as Dictionary).get("hp", 0)),
 		Gen2Stats.hp_dv(mon.dvs), int(mon.stat_exp.get("hp", 0)), mon.level, true
 	)
-	for index: int in Gen2SaveMon.MAX_MOVES:
-		var move: int = int(mon.moves[index])
-		mon.pp[index] = int(data.move(move).get("pp", 0)) if move > 0 else 0
 	save.party.append(mon)
 	state.set_day_care_mon(slot, null)
 	state.set_day_care_has_mon(slot, false)
@@ -506,6 +499,72 @@ static func retrieve(
 		"level": mon.level,
 		"previous_level": previous_level,
 	}
+
+
+static func _retrieve_gen2_rows(data: GameData, mon: Gen2SaveMon, previous_level: int) -> void:
+	Gen2Learnset.fill_moves(
+		data.learnset(mon.species), mon.moves, mon.level, previous_level
+	)
+	mon.exp = Gen2Experience.total_exp_at(
+		int(data.species(mon.species).get("growth_rate", 0)), mon.level
+	)
+	mon.status = Gen2Status.NONE
+	for index: int in Gen2SaveMon.MAX_MOVES:
+		var move: int = int(mon.moves[index])
+		mon.pp[index] = int(data.move(move).get("pp", 0)) if move > 0 else 0
+
+
+## `IncrementDayCareMonExp`, in front of `ApplyOutOfBattlePoisonDamage`'s own
+## gate: a point for the one slot, with no level test, so MAX_LEVEL keeps counting.
+static func gen1_step(state: Gen2WorldState) -> void:
+	var mon: Gen2SaveMon = state.day_care_mon(SLOT_MAN) if state != null else null
+	if mon == null or not state.day_care_has_mon(SLOT_MAN):
+		return
+	mon.exp = _day_care_exp_after(mon.exp)
+	state.set_day_care_mon(SLOT_MAN, mon)
+
+
+## `.daycareInUse`'s head, and the one write a visit makes whatever the player
+## answers: a slot past MAX_LEVEL has its experience put back down to
+## `CalcExperience MAX_LEVEL`, which `.leaveMonInDayCare` does not undo.
+static func gen1_visit(state: Gen2WorldState, data: GameData) -> Dictionary:
+	var mon: Gen2SaveMon = state.day_care_mon(SLOT_MAN) if state != null else null
+	if mon == null or data == null:
+		return {}
+	var rate: int = int(data.species(mon.species).get("growth_rate", 0))
+	var level: int = clampi(Gen2Experience.level_for_exp(rate, mon.exp), 1, MAX_LEVEL)
+	if level == MAX_LEVEL:
+		mon.exp = Gen2Experience.total_exp_at(rate, MAX_LEVEL)
+		state.set_day_care_mon(SLOT_MAN, mon)
+	var growth: int = maxi(0, level - mon.level)
+	return {
+		"level": level,
+		"growth": growth,
+		"price": price_to_retrieve(growth),
+		"species": mon.species,
+		"nickname": Gen2SaveMon.display_name(mon, data),
+	}
+
+
+## `WriteMonMoves` under `wLearningMovesFromDayCare`: only the levels above
+## [param above] are offered, and the shift runs a second time over the PP, so a
+## displaced slot keeps its own count.
+static func gen1_fill_moves(data: GameData, mon: Gen2SaveMon, above: int) -> void:
+	for entry: Dictionary in data.learnset(mon.species):
+		var at: int = int(entry["level"])
+		if at > mon.level:
+			break
+		var move: int = int(entry["move"])
+		if at <= above or mon.moves.has(move):
+			continue
+		var slot: int = mon.moves.find(0)
+		if slot < 0:
+			for index: int in Gen2SaveMon.MAX_MOVES - 1:
+				mon.moves[index] = mon.moves[index + 1]
+				mon.pp[index] = mon.pp[index + 1]
+			slot = Gen2SaveMon.MAX_MOVES - 1
+		mon.moves[slot] = move
+		mon.pp[slot] = int(data.move(move).get("pp", 0))
 
 
 ## `DayCare_GiveEgg`. The egg the pair built when the counter started is the one

--- a/game/world/world_host.gd
+++ b/game/world/world_host.gd
@@ -8,16 +8,16 @@ extends RefCounted
 ## if the subsystem had run.
 
 ## The requests the host settles out of the save alone: `special HealParty`,
-## `giveegg`, `GiveDratini` and a `givepoke` that names an OT each run to
-## completion inside the command that asked, so a screen completes one where it
-## is staged rather than waiting for a press. `pokemon_requested` is here for
-## those and no further: `GivePoke`'s `.wildmon` branch reaches
-## `GiveANickname_YesNo`, so a screen that can draw one intercepts it in front of
-## this list and a driver that cannot settles it with the species name, which is
-## what NO answers.
+## `giveegg`, `GiveDratini`, a `givepoke` that names an OT and
+## `DaycareGentlemanText`'s two `MoveMon` calls each run to completion inside the
+## command that asked. `pokemon_requested` is here for those and no further:
+## `GivePoke`'s `.wildmon` branch reaches `GiveANickname_YesNo`, so a screen that
+## can draw one intercepts it in front of this list and a driver that cannot
+## settles it with the species name, which is what NO answers.
 const UNATTENDED_REQUESTS: Array[StringName] = [
 	&"party_heal_requested", &"pokemon_requested", &"trade_requested",
 	&"contest_mon_requested", &"dratini_moveset_requested",
+	&"day_care_mon_requested",
 ]
 
 ## Which machine a `pc_requested` names. `PokemonCenterPC` and
@@ -54,6 +54,8 @@ static func complete_runtime_request(
 		)
 	if kind == &"party_heal_requested":
 		return Gen2WorldPartyHost.heal_party(world, save, persist)
+	if kind == &"day_care_mon_requested":
+		return Gen2WorldPartyHost.day_care_mon(world, save, request, persist)
 	if kind == &"apricorn_selection_requested":
 		return Gen2WorldApricornHost.complete_runtime_request(world, result, save, persist)
 	if kind == &"rival_name_requested":

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -559,6 +559,66 @@ static func heal_party_rows(data: GameData, save: Gen2SaveData) -> int:
 	return healed
 
 
+## `MoveMon` both ways for the Generation 1 Day-Care, whose slot is world state
+## and whose party is the save: one transaction, for the reason a trade is.
+static func day_care_mon(
+	world: Gen2WorldAPI,
+	save: Gen2SaveData,
+	request: Dictionary,
+	persist: bool = true,
+) -> Dictionary:
+	if world == null or save == null or world.data == null or world.state == null:
+		return _failure(&"missing_save", request)
+	var opened: Dictionary = Gen2WorldTransaction.begin(world, save)
+	if not bool(opened.get("ok", false)):
+		return _failure(StringName(opened["reason"]), opened.get("details", {}))
+	var candidate: Gen2SaveData = opened["candidate"]
+	## After the snapshot, so a refused write rolls the slot back with the party.
+	var before: Gen2WorldSnapshot = world.snapshot()
+	var values: Dictionary = request.get("values", {})
+	var moved: Dictionary = _move_day_care_mon(world, candidate, values)
+	if not bool(moved.get("ok", false)):
+		Gen2WorldTransaction.restore(world, before)
+		return _failure(StringName(moved.get("reason", &"day_care_move_failed")), request)
+	var resumed: Array = world.complete_runtime_request({"ok": true})
+	if resumed.is_empty() or not bool(resumed[0].get("ok", false)):
+		return _failure(&"runtime_request_failed", {
+			"request": request, "results": resumed,
+		})
+	var committed: Dictionary = Gen2WorldTransaction.commit(
+		world, save, candidate, before, persist
+	)
+	if not bool(committed.get("ok", false)):
+		return _failure(StringName(committed["reason"]), committed.get("details", {}))
+	return {
+		"ok": true,
+		"handled": true,
+		"request": request,
+		"transaction": moved,
+		"results": resumed,
+	}
+
+
+static func _move_day_care_mon(
+	world: Gen2WorldAPI, candidate: Gen2SaveData, values: Dictionary
+) -> Dictionary:
+	if StringName(values.get("action", &"")) == &"deposit":
+		var party_index: int = int(values.get("party_index", -1))
+		if not Gen2WorldDayCare.deposit(
+			world.state, candidate, Gen2WorldDayCare.SLOT_MAN, party_index
+		):
+			return {"ok": false, "reason": &"day_care_deposit_refused"}
+		return {"ok": true, "kind": &"deposit", "party_index": party_index}
+	var taken: Dictionary = Gen2WorldDayCare.retrieve(
+		world.state, candidate, world.data, Gen2WorldDayCare.SLOT_MAN
+	)
+	if taken.is_empty():
+		return {"ok": false, "reason": &"day_care_slot_empty"}
+	taken["ok"] = true
+	taken["kind"] = &"withdraw"
+	return taken
+
+
 ## `Softboiled_MilkDrinkFunction`: a fifth of the user's own maximum health moved
 ## from the user to another party member, as one candidate transaction. Both halves
 ## are the *user's* fifth, `GetOneFifthMaxHP` being called twice with

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -2058,6 +2058,15 @@ func _spend_day_care_steps() -> void:
 	var owed: int = _world.state.take_pending_day_care_steps()
 	if owed <= 0 or _hatch_host != null:
 		return
+	## `IncrementDayCareMonExp` stands in front of `ApplyOutOfBattlePoisonDamage`'s
+	## own gate and behind its `wPartyCount` test, so an empty party counts nothing.
+	if _data.generation == RomRegistry.GEN1:
+		var save: Gen2SaveData = active_save()
+		if save == null or save.party.is_empty():
+			return
+		for _pass: int in owed:
+			Gen2WorldDayCare.gen1_step(_world.state)
+		return
 	for _pass: int in owed:
 		Gen2WorldDayCare.step(_world.state, _data, _breed_random)
 

--- a/game/world/world_tmhm.gd
+++ b/game/world/world_tmhm.gd
@@ -51,6 +51,27 @@ static func number_for_item(data: GameData, item: int) -> int:
 	return Gen2Layout.tmhm_number_for_item(item, data.tmhm_moves().size())
 
 
+## GetNumberedTMHM, the inverse of [method number_for_item].
+static func item_for_number(data: GameData, number: int) -> int:
+	if data == null or number < 1:
+		return 0
+	if data.generation == RomRegistry.GEN1:
+		return Gen1Layout.machine_item(number)
+	return Gen2Layout.item_for_tmhm_number(number, data.tmhm_moves().size())
+
+
+## KnowsHMMove, whose `HMMoveArray` is the HM machines' own moves. The
+## Generation 1 Day-Care is its only caller.
+static func knows_hm_move(data: GameData, moves: Array) -> bool:
+	if data == null:
+		return false
+	for slot: Variant in moves:
+		var number: int = data.tmhm_number_for_move(int(slot))
+		if number > 0 and is_hm(item_for_number(data, number), data.generation):
+			return true
+	return false
+
+
 ## GetTMHMItemMove: the move [param item] teaches, or 0 when it is not a TM/HM
 ## this cartridge carries.
 static func move_for_item(data: GameData, item: int) -> int:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1486 lines of it, and
-## Generation 1 has added 1546 more to the shared code: 150 the battle animation
+## files cost: `game/gen1` and its neighbours are 1494 lines of it, and
+## Generation 1 has added 1604 more to the shared code: 150 the battle animation
 ## engine, 140 the transition, 130 the Pokedex, 108 the three PCs, 95 the
 ## trainer card, 85 the party menu, 42 the status screen, 40 the bag in a
-## battle, 20 the map callbacks, 9 the scripted walk.
-const MAX_COMMENT_LINES: int = 40702
+## battle, 20 the map callbacks, 9 the scripted walk, 66 the Day-Care.
+const MAX_COMMENT_LINES: int = 40768
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_day_care.gd
+++ b/tests/unit/test_world_day_care.gd
@@ -17,6 +17,7 @@ const MAROWAK: int = Fixture.MAROWAK
 const HOOTHOOT: int = Fixture.HOOTHOOT
 const BULBASAUR: int = Fixture.BULBASAUR
 const IVYSAUR: int = 2
+const GEODUDE: int = Fixture.GEODUDE
 const DITTO: int = Fixture.DITTO
 
 ## Two DV words giving opposite genders at GENDER_F50, whose Defense DVs and
@@ -223,6 +224,88 @@ func test_a_retrieved_member_comes_back_at_the_level_its_experience_bought() -> 
 	assert_eq(back.exp, Gen2Experience.total_exp_at(growth_rate, 14))
 	assert_eq(back.status, Gen2Status.NONE)
 	assert_gt(back.hp, 0)
+
+
+## `IncrementDayCareMonExp` has no level test in front of it, which is the whole
+## of what parts it from `DayCareStep`.
+func test_a_generation_one_slot_gains_experience_at_the_level_cap() -> void:
+	var state: Gen2WorldState = _state()
+	var mon: Gen2SaveMon = _mon(CUBONE)
+	mon.level = Gen2WorldDayCare.MAX_LEVEL
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, mon)
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	var before: int = state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp
+	Gen2WorldDayCare.gen1_step(state)
+	assert_eq(state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp, before + 1)
+
+
+func test_an_empty_generation_one_slot_counts_nothing() -> void:
+	var state: Gen2WorldState = _state()
+	Gen2WorldDayCare.gen1_step(state)
+	assert_null(state.day_care_mon(Gen2WorldDayCare.SLOT_MAN))
+
+
+## `.daycareInUse` reads the level off the experience and prices the difference.
+func test_a_generation_one_visit_reads_the_growth_and_the_price() -> void:
+	var state: Gen2WorldState = _state()
+	var mon: Gen2SaveMon = _mon(CUBONE)
+	mon.exp = Gen2Experience.total_exp_at(
+		int(_data.species(CUBONE).get("growth_rate", 0)), 13
+	)
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, mon)
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	var visit: Dictionary = Gen2WorldDayCare.gen1_visit(state, _data)
+	assert_eq(int(visit["level"]), 13)
+	assert_eq(int(visit["growth"]), 3)
+	assert_eq(int(visit["price"]), 400)
+
+
+## The clamp is not undone by `.leaveMonInDayCare`, so it survives a visit that
+## bought nothing.
+func test_a_generation_one_visit_clamps_experience_past_the_level_cap() -> void:
+	var state: Gen2WorldState = _state()
+	var mon: Gen2SaveMon = _mon(CUBONE)
+	mon.exp = Gen2Experience.MAX_EXP
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, mon)
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	assert_eq(
+		int(Gen2WorldDayCare.gen1_visit(state, _data)["level"]),
+		Gen2WorldDayCare.MAX_LEVEL
+	)
+	assert_eq(
+		state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp,
+		Gen2Experience.total_exp_at(
+			int(_data.species(CUBONE).get("growth_rate", 0)),
+			Gen2WorldDayCare.MAX_LEVEL
+		)
+	)
+
+
+## `WriteMonMoves_ShiftMoveData` runs a second time over the PP, so the slot a
+## move is shifted into carries that move's own count and the survivors keep
+## whatever they had left.
+func test_generation_one_learning_shifts_the_pp_with_the_moves() -> void:
+	var mon: Gen2SaveMon = _mon(GEODUDE)
+	var learned: Array = _data.learnset(GEODUDE)
+	var taught: int = int((learned[-1] as Dictionary)["move"])
+	var level: int = int((learned[-1] as Dictionary)["level"])
+	mon.moves = [1, 2, 3, 4]
+	mon.pp = [5, 6, 7, 8]
+	mon.level = level
+	Gen2WorldDayCare.gen1_fill_moves(_data, mon, level - 1)
+	assert_eq(mon.moves, [2, 3, 4, taught])
+	assert_eq(int(mon.pp[0]), 6)
+	assert_eq(int(mon.pp[3]), int(_data.move(taught).get("pp", 0)))
+
+
+## Only the levels above the one the slot went in at are offered.
+func test_generation_one_learning_skips_the_levels_below_the_deposit() -> void:
+	var mon: Gen2SaveMon = _mon(GEODUDE)
+	mon.moves = [0, 0, 0, 0]
+	mon.pp = [0, 0, 0, 0]
+	mon.level = Gen2WorldDayCare.MAX_LEVEL
+	Gen2WorldDayCare.gen1_fill_moves(_data, mon, Gen2WorldDayCare.MAX_LEVEL)
+	assert_eq(mon.moves, [0, 0, 0, 0])
 
 
 func test_a_full_party_cannot_take_a_member_back() -> void:

--- a/tools/checks/day_care.gd
+++ b/tools/checks/day_care.gd
@@ -23,6 +23,13 @@ const TEXT_ANCHORS: Dictionary = {
 ## `DITTO`, the one species compatible with everything that breeds at all.
 const SPECIES_DITTO: int = 132
 
+## The Generation 1 stubs whose own `text_ram` names `wNameBuffer` or
+## `wDayCareMonName`, and the two carrying a `text_decimal` or a `text_bcd`.
+const GEN1_RAM_BOXES: Array[String] = [
+	"will_look_after", "has_grown", "got_mon_back", "needs_more_time",
+]
+const GEN1_NUMBER_BOXES: Array[String] = ["has_grown", "owe_money"]
+
 var _r: RefCounted = null
 
 
@@ -40,7 +47,134 @@ func run(r: RefCounted) -> void:
 		_verify_egg_moves(game_id, data)
 		_verify_fill_moves(game_id, data)
 		_verify_odd_eggs(game_id, data)
+	_r.each_game_of(RomRegistry.GEN1, _one_gen1_game)
 	_r.game_id = &""
+
+
+## Generation 1's own Day-Care: one slot, `IncrementDayCareMonExp` a point a
+## step, and `DaycareGentlemanText` reading the level back off the experience.
+func _one_gen1_game() -> void:
+	_verify_gen1_texts()
+	_verify_gen1_hm_moves()
+	_verify_gen1_growth()
+	_verify_gen1_learning()
+
+
+## The fifteen stubs, each distinct and each carrying the print-time markers its
+## own `text_ram`, `text_decimal` or `text_bcd` writes.
+func _verify_gen1_texts() -> void:
+	var seen: Dictionary = {}
+	for name: String in Gen1Layout.DAY_CARE_TEXT_AT:
+		var text: String = _r.data.day_care_text(name)
+		if not _r.check(not text.is_empty(), "the %s box is empty." % name):
+			continue
+		_r.check(not seen.has(text), "the %s box repeats another." % name)
+		seen[text] = true
+		_r.check(
+			text.contains(Gen2TextStream.RAM_MARKER) == GEN1_RAM_BOXES.has(name),
+			"the %s box reads %s." % [name, text]
+		)
+		_r.check(
+			text.contains(Gen2TextStream.NUMBER_MARKER) == GEN1_NUMBER_BOXES.has(name),
+			"the %s box reads %s." % [name, text]
+		)
+	_r.check(
+		_r.data.day_care_text("all_right_then").to_lower().contains("come again"),
+		"`all_right_then` did not run on into `come_again`."
+	)
+
+
+## `HMMoveArray`: `KnowsHMMove` answers for the five HM machines' moves and for
+## nothing else on the cartridge.
+func _verify_gen1_hm_moves() -> void:
+	var refused: Array[int] = []
+	for move: int in range(1, _r.data.move_count() + 1):
+		if Gen2WorldTMHM.knows_hm_move(_r.data, [move]):
+			refused.append(move)
+	var wanted: Array[int] = []
+	for number: int in range(Gen1Layout.TM_COUNT + 1, Gen1Layout.TM_COUNT + Gen1Layout.HM_COUNT + 1):
+		wanted.append(_r.data.tmhm_move(number))
+	wanted.sort()
+	_r.check(refused == wanted, "the Day-Care refuses moves %s." % [refused])
+	_r.note("gen1 day-care refuses %d HM moves" % refused.size())
+
+
+## Every species at every deposit level: `CalcLevelFromExperience` answers the
+## level the experience bought, the price is a hundred a level plus a hundred,
+## and a slot past MAX_LEVEL has its experience written back down.
+func _verify_gen1_growth() -> void:
+	var state: Gen2WorldState = Gen2WorldState.new()
+	for species: int in range(1, _r.data.species_count() + 1):
+		var rate: int = int(_r.data.species(species).get("growth_rate", 0))
+		for level: int in range(1, Gen2WorldDayCare.MAX_LEVEL):
+			var visit: Dictionary = _gen1_visit(
+				state, species, level, Gen2Experience.total_exp_at(rate, level + 1)
+			)
+			if not _r.check(
+				int(visit.get("growth", -1)) == 1 and int(visit.get("price", 0)) == 200,
+				"%s at level %d grew by %s." % [species, level, visit.get("growth", -1)]
+			):
+				return
+		var top: int = Gen2Experience.total_exp_at(rate, Gen2WorldDayCare.MAX_LEVEL)
+		var clamped: Dictionary = _gen1_visit(state, species, 1, Gen2Experience.MAX_EXP)
+		if not _r.check(
+			int(clamped.get("level", 0)) == Gen2WorldDayCare.MAX_LEVEL
+				and state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp == top,
+			"species %d ran past MAX_LEVEL and kept %s." % [species, clamped]
+		):
+			return
+	_r.note("gen1 day-care growth over %d species" % _r.data.species_count())
+
+
+## `WriteMonMoves` under `wLearningMovesFromDayCare`, for every species and every
+## deposit level: four slots, no move twice, and PP behind every one of them.
+func _verify_gen1_learning() -> void:
+	for species: int in range(1, _r.data.species_count() + 1):
+		var learnset: Array = _r.data.learnset(species)
+		for level: int in range(1, Gen2WorldDayCare.MAX_LEVEL):
+			var mon: Gen2SaveMon = _gen1_slot(species, level)
+			mon.moves = Gen2Learnset.moves_at_level(learnset, level)
+			while mon.moves.size() < Gen2SaveMon.MAX_MOVES:
+				mon.moves.append(0)
+			mon.pp = [1, 1, 1, 1]
+			mon.level = Gen2WorldDayCare.MAX_LEVEL
+			Gen2WorldDayCare.gen1_fill_moves(_r.data, mon, level)
+			if not _r.check(_gen1_moves_sane(mon), "species %d from level %d learned %s with %s." % [
+				species, level, mon.moves, mon.pp,
+			]):
+				return
+	_r.note("gen1 day-care learning over %d species" % _r.data.species_count())
+
+
+func _gen1_moves_sane(mon: Gen2SaveMon) -> bool:
+	var seen: Dictionary = {}
+	for slot: int in Gen2SaveMon.MAX_MOVES:
+		var move: int = int(mon.moves[slot])
+		if move == 0:
+			continue
+		if seen.has(move) or int(mon.pp[slot]) < 1:
+			return false
+		seen[move] = true
+	return mon.moves.size() == Gen2SaveMon.MAX_MOVES
+
+
+func _gen1_visit(
+	state: Gen2WorldState, species: int, level: int, experience: int
+) -> Dictionary:
+	var mon: Gen2SaveMon = _gen1_slot(species, level)
+	mon.exp = experience
+	state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, mon)
+	state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	return Gen2WorldDayCare.gen1_visit(state, _r.data)
+
+
+func _gen1_slot(species: int, level: int) -> Gen2SaveMon:
+	var mon: Gen2SaveMon = Gen2SaveMon.new()
+	mon.species = species
+	mon.level = level
+	mon.moves = [0, 0, 0, 0]
+	mon.pp = [0, 0, 0, 0]
+	return mon
 
 
 ## The Day-Care Man's own gift, Crystal's alone. Every row decodes as the

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,24 +130,24 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 253, "text": 309, "branch": 111, "choice": 17, "flag": 43,
+	&"red": {"rows": 254, "text": 309, "branch": 111, "choice": 17, "flag": 43,
 		"give_item": 25, "has_item": 15, "take_item": 3, "unknown": 55,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
-		"player_coord": 4, "walk": 2, "replace_block": 1},
-	&"blue": {"rows": 253, "text": 309, "branch": 111, "choice": 17, "flag": 43,
+		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
+	&"blue": {"rows": 254, "text": 309, "branch": 111, "choice": 17, "flag": 43,
 		"give_item": 25, "has_item": 15, "take_item": 3, "unknown": 55,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
-		"player_coord": 4, "walk": 2, "replace_block": 1},
-	&"yellow": {"rows": 299, "text": 347, "branch": 106, "choice": 18, "flag": 37,
+		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
+	&"yellow": {"rows": 300, "text": 347, "branch": 106, "choice": 18, "flag": 37,
 		"give_item": 24, "has_item": 12, "take_item": 3, "unknown": 59,
 		"pick_up_item": 108, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 7, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 6,
-		"player_coord": 4, "walk": 2, "replace_block": 1},
+		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
 }
 ## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
 ## which no map text row names and the disassembly marks unreferenced. The

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -74,6 +74,22 @@ const NURSE_PARTY: int = 4
 const CABLE_CLUB_COUNTER := Vector2i(11, 3)
 const CABLE_CLUB_ROWS: int = 12
 
+## `Daycare_Object`'s one object, faced from the cell beside him, and the party
+## the row's `wPartyCount` tests are answered with.
+const DAYCARE: int = 0x48
+const DAYCARE_GENTLEMAN := Vector2i(3, 3)
+const DAYCARE_PARTY: int = 2
+## `SPECIES_PIDGEY` and its own level 5, which the deposited slot is built from,
+## and CUT, the HM move `KnowsHMMove` refuses a member for.
+const DAYCARE_SPECIES: int = 16
+const DAYCARE_LEVEL: int = 5
+const DAYCARE_NICKNAME: String = "BIRD"
+const MOVE_CUT: int = 15
+## `wDayCarePerLevelCost` is $0100 and the loop runs `levels + 1` times.
+const DAYCARE_GROWN_LEVEL: int = 8
+const DAYCARE_PRICE: int = 400
+const DAY_CARE_STEPS: int = 6
+
 ## `MtMoonPokecenter_Object`'s fourth object: `HasEnoughMoney`, `GivePokemon`
 ## and `SubBCDPredef` behind it, with MONEY_BOX standing over the map for the
 ## question. Museum 1F's scientist is the corpus's other spender.
@@ -297,6 +313,7 @@ func _one_game() -> void:
 	_check_a_bench_guy()
 	_check_a_bookshelf()
 	_check_a_card_key_door()
+	_check_the_day_care()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -1280,6 +1297,237 @@ func _trade_filled(text: String) -> String:
 			String(_r.data.species(int(row[1])).get("name", ""))
 		)
 	return Gen2TextStream.fill_names(out, {"player": Gen2WorldScriptRunner.UNNAMED})
+
+
+## `DaycareGentlemanText` walked both ways: the offer, the party list and
+## `MoveMon PARTY_TO_DAYCARE`, then the growth, `HasEnoughMoney` and the way
+## back out. `IncrementDayCareMonExp` is what makes the second half possible.
+func _check_the_day_care() -> void:
+	_check_the_day_care_refuses()
+	var world: Gen2WorldAPI = _day_care_world(0)
+	if world == null:
+		return
+	var save: Gen2SaveData = Gen2SaveStore.create_development_save(_r.data, 0)
+	if not _r.check(save != null, "no development save."):
+		return
+	world.set_party_summary(save.party.size(), false, [] as Array[int], _party_moves(save))
+	world.interact()
+	_r.check(
+		_event_text(world.choose_script_input(0)) == _day_care_text("which_mon"),
+		"the gentleman asked for no member."
+	)
+	world.run_event_queue(true)
+	var deposited: String = Gen2SaveMon.display_name(save.party[0], _r.data)
+	_r.check(
+		_event_text(world.complete_runtime_request({
+			"ok": true, "party_index": 0, "nickname": deposited,
+		})) == _day_care_text("will_look_after", deposited),
+		"the gentleman took it without saying so."
+	)
+	world.run_event_queue(true)
+	_r.check(
+		_event_text(_day_care_move(world, save)) == _day_care_text("come_see_me"),
+		"the deposit ended on nothing."
+	)
+	_r.check(
+		world.state.day_care_has_mon(Gen2WorldDayCare.SLOT_MAN)
+			and save.party.size() == DAYCARE_PARTY - 1,
+		"the deposit left %d in the party." % save.party.size()
+	)
+	_check_the_day_care_counts_steps(world)
+	_check_the_day_care_hands_it_back(save)
+	_check_the_day_care_holds_on()
+	_r.note("gen1 walk the DAYCARE: a deposit, three refusals and a %d withdrawal"
+		% DAYCARE_PRICE)
+
+
+## The two boxes that end the visit where it stands: a full party never reaches
+## the price at all, and a slot that has not grown says so before the question.
+func _check_the_day_care_holds_on() -> void:
+	for row: Array in [
+		[Gen2SaveData.MAX_PARTY, DAYCARE_GROWN_LEVEL, "no_room"],
+		[DAYCARE_PARTY, DAYCARE_LEVEL, "needs_more_time"],
+	]:
+		var world: Gen2WorldAPI = _day_care_world(DAYCARE_PRICE)
+		if world == null:
+			return
+		var mon: Gen2SaveMon = _grown_slot()
+		mon.exp = Gen2Experience.total_exp_at(
+			int(_r.data.species(DAYCARE_SPECIES).get("growth_rate", 0)), int(row[1])
+		)
+		world.state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, mon)
+		world.state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+		world.set_party_summary(int(row[0]), false)
+		var opened: String = _event_text(world.interact())
+		if String(row[2]) == "needs_more_time":
+			_r.check(
+				opened == _day_care_text("needs_more_time", DAYCARE_NICKNAME, "%3d" % 0),
+				"an ungrown slot said %s." % opened
+			)
+			continue
+		var said: String = _event_text(world.run_event_queue(true))
+		_r.check(said == _day_care_text("no_room"), "a full party said %s." % said)
+
+
+## The three refusals in the routine's own order: one member, a member that
+## knows an HM, and a list that came back empty.
+func _check_the_day_care_refuses() -> void:
+	for row: Array in [
+		[1, [], "only_one_mon"], [DAYCARE_PARTY, [MOVE_CUT], "knows_hm_move"],
+		[DAYCARE_PARTY, [], "all_right_then"],
+	]:
+		var world: Gen2WorldAPI = _day_care_world(0)
+		if world == null:
+			return
+		world.set_party_summary(
+			int(row[0]), false, [] as Array[int], [row[1], row[1]]
+		)
+		world.interact()
+		var said: String = _event_text(world.choose_script_input(0))
+		if int(row[0]) > 1:
+			world.run_event_queue(true)
+			said = _event_text(world.complete_runtime_request({
+				"ok": true, "party_index": -1 if String(row[2]) == "all_right_then" else 0,
+			}))
+		_r.check(said == _day_care_text(String(row[2])),
+			"the %s refusal said %s." % [String(row[2]), said])
+	var refused: Gen2WorldAPI = _day_care_world(0)
+	if refused != null:
+		refused.set_party_summary(DAYCARE_PARTY, false)
+		refused.interact()
+		_r.check(
+			_event_text(refused.choose_script_input(1)) == _day_care_text("come_again"),
+			"a refused offer said something else."
+		)
+
+
+## `IncrementDayCareMonExp` runs off `CountStep`'s own counter here, so what
+## proves it is the owed steps turning into experience.
+func _check_the_day_care_counts_steps(world: Gen2WorldAPI) -> void:
+	var before: int = world.state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp
+	for _step: int in DAY_CARE_STEPS:
+		world.state.count_step()
+	for _step: int in world.state.take_pending_day_care_steps():
+		Gen2WorldDayCare.gen1_step(world.state)
+	_r.check(
+		world.state.day_care_mon(Gen2WorldDayCare.SLOT_MAN).exp == before + DAY_CARE_STEPS,
+		"%d steps bought no experience." % DAY_CARE_STEPS
+	)
+
+
+## `.daycareInUse` with a slot that has grown: the box says how many levels, the
+## price is a hundred a level plus a hundred, and a short purse is refused.
+func _check_the_day_care_hands_it_back(save: Gen2SaveData) -> void:
+	var grown: Gen2SaveMon = _grown_slot()
+	for purse: int in [DAYCARE_PRICE - 1, DAYCARE_PRICE]:
+		var world: Gen2WorldAPI = _day_care_world(purse)
+		if world == null:
+			return
+		world.state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, grown)
+		world.state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+		world.set_party_summary(save.party.size(), false)
+		_r.check(
+			_event_text(world.interact()) == _day_care_text(
+				"has_grown", DAYCARE_NICKNAME,
+				"%3d" % (DAYCARE_GROWN_LEVEL - DAYCARE_LEVEL)
+			),
+			"the gentleman did not say how much it had grown."
+		)
+		var asked: Dictionary = world.pending_script_input() 			if not world.run_event_queue(true).is_empty() else {}
+		if not _r.check(
+			String(asked.get("text", "")) == _day_care_text(
+				"owe_money", "", str(DAYCARE_PRICE)
+			),
+			"the price was asked as %s." % [asked.get("text", "")]
+		):
+			return
+		_day_care_payment(world, save, purse, grown)
+
+
+func _day_care_payment(
+	world: Gen2WorldAPI, save: Gen2SaveData, purse: int, grown: Gen2SaveMon
+) -> void:
+	var said: String = _event_text(world.choose_script_input(0))
+	if purse < DAYCARE_PRICE:
+		_r.check(said == _day_care_text("not_enough_money"),
+			"a short purse was answered with %s." % said)
+		return
+	_r.check(said == _day_care_text("heres_your_mon"), "the receipt said %s." % said)
+	var taken: Gen2SaveData = Gen2SaveData.from_dict(save.to_dict())
+	world.run_event_queue(true)
+	var handed: String = _event_text(_day_care_move(world, taken))
+	_r.check(
+		not world.state.day_care_has_mon(Gen2WorldDayCare.SLOT_MAN)
+			and taken.party.size() == save.party.size() + 1
+			and (taken.party[-1] as Gen2SaveMon).level == DAYCARE_GROWN_LEVEL,
+		"the slot came back as %d members." % taken.party.size()
+	)
+	_r.check(
+		world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT) == purse - DAYCARE_PRICE,
+		"the purse stands at %d." % world.state.money(Gen2WorldMartHost.MONEY_ACCOUNT)
+	)
+	_r.check(
+		handed == _day_care_text("got_mon_back", Gen2SaveMon.display_name(grown, _r.data)),
+		"the hand-over said %s." % handed
+	)
+
+
+## The `day_care_mon_requested` the row raises, settled the way the world screen
+## settles it: the party is the save's and the slot is the world's.
+func _day_care_move(world: Gen2WorldAPI, save: Gen2SaveData) -> Array:
+	var request: Dictionary = world.pending_runtime_request()
+	if not _r.check(
+		StringName(request.get("kind", &"")) == &"day_care_mon_requested",
+		"the row raised %s." % [request.get("kind", &"nothing")]
+	):
+		return []
+	var moved: Dictionary = Gen2WorldPartyHost.day_care_mon(world, save, request, false)
+	_r.check(bool(moved.get("ok", false)), "the move failed: %s." % [moved])
+	return moved.get("results", []) as Array
+
+
+func _day_care_world(purse: int) -> Gen2WorldAPI:
+	var world: Gen2WorldAPI = _r.open_world(0, DAYCARE, DAYCARE_GENTLEMAN)
+	if world == null:
+		return null
+	world.player_facing = Gen2WorldSprite.FACING_LEFT
+	world.state.apply_changes({}, {}, {
+		"money": {Gen2WorldMartHost.MONEY_ACCOUNT: purse},
+	})
+	return world
+
+
+## The slot as it stands after enough experience for three levels.
+func _grown_slot() -> Gen2SaveMon:
+	var mon: Gen2SaveMon = Gen2SaveMon.new()
+	mon.species = DAYCARE_SPECIES
+	mon.level = DAYCARE_LEVEL
+	mon.nickname = DAYCARE_NICKNAME
+	mon.moves = [MOVE_CUT, 0, 0, 0]
+	mon.pp = [1, 0, 0, 0]
+	mon.exp = Gen2Experience.total_exp_at(
+		int(_r.data.species(DAYCARE_SPECIES).get("growth_rate", 0)), DAYCARE_GROWN_LEVEL
+	)
+	return mon
+
+
+func _party_moves(save: Gen2SaveData) -> Array:
+	var out: Array = []
+	for mon: Gen2SaveMon in save.party:
+		out.append(mon.moves.duplicate())
+	return out
+
+
+func _day_care_text(name: String, ram: String = "", number: String = "") -> String:
+	var text: String = Gen2TextStream.fill_names(
+		_r.data.day_care_text(name),
+		{"player": Gen2WorldScriptRunner.UNNAMED}
+	)
+	if not ram.is_empty():
+		text = Gen2TextStream.fill_all_markers(text, Gen2TextStream.RAM_MARKER, ram)
+	if not number.is_empty():
+		text = Gen2TextStream.fill_all_markers(text, Gen2TextStream.NUMBER_MARKER, number)
+	return text
 
 
 ## The argument column a hidden event hands its routine is not a facing:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -71,7 +71,7 @@ const KIND_HELP: Dictionary = {
 	&"pokemon_center_pc": "rows down, A presses: the Pokemon Center's machine, or ActivatePC on a Generation 1 cartridge",
 	&"mom_bank": "wallet, balance, both in hundreds: Mom_WithdrawDepositMenuJoypad's dial. Add 1000 for the WITHDRAW header",
 	&"move_tutor": "presses: special MoveTutor. 0 is ChooseMonToLearnTMHM's list, not a box",
-	&"day_care": "presses, routine: 0 the man, 1 the lady, 2 the man outside, 3 and 4 the two signs",
+	&"day_care": "presses, routine: 0 the man, 1 the lady, 2 the man outside, 3 and 4 the two signs. On a Generation 1 cartridge, DaycareGentlemanText faced left from 3,3 on DAYCARE, the second number being wDayCareInUse",
 	&"slot_machine": "frames, bet: special SlotMachine. Bet is 1 to 3, plus 4 for the lucky machine",
 	&"card_flip": "frames, coins in hundreds: special CardFlip",
 	&"unown_puzzle": "frames, picture: special UnownPuzzle. 0 Kabuto, 1 Omanyte, 2 Aerodactyl, 3 Ho-Oh, 4 to 7 solved",
@@ -198,7 +198,7 @@ const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"nurse": BOX_REVEAL_FRAMES, &"vending": BOX_REVEAL_FRAMES,
 	&"prizes": BOX_REVEAL_FRAMES, &"trade": BOX_REVEAL_FRAMES,
 	&"coins": BOX_REVEAL_FRAMES, &"deal": BOX_REVEAL_FRAMES,
-	&"ticket": BOX_REVEAL_FRAMES,
+	&"ticket": BOX_REVEAL_FRAMES, &"day_care": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -741,6 +741,9 @@ func _stage_card_flip() -> void:
 ## presses into the routine to photograph and the second is which routine: 0 the man,
 ## 1 the lady, 2 the man outside, 3 and 4 the two signs.
 func _stage_day_care() -> void:
+	if _screen._data != null and _screen._data.generation == RomRegistry.GEN1:
+		_stage_gen1_day_care()
+		return
 	_screen.preview_day_care(DAY_CARE_ROLES[clampi(
 		_cell.y, 0, DAY_CARE_ROLES.size() - 1
 	)])
@@ -1105,7 +1108,7 @@ func _stage_card_key_door() -> void:
 
 
 ## A counter faced the way [param facing] says: presses, then rows down first.
-func _stage_counter(purse: Dictionary, facing: int = PokeButton.UP) -> void:
+func _stage_counter(purse: Dictionary, facing: int = PokeButton.UP, rows: int = -1) -> void:
 	var world: Gen2WorldAPI = _screen.get("_world")
 	if world != null:
 		world.state.apply_changes({}, {}, purse)
@@ -1113,13 +1116,46 @@ func _stage_counter(purse: Dictionary, facing: int = PokeButton.UP) -> void:
 	for _frame: int in TEXT_SETTLE_FRAMES:
 		_screen.advance_frame()
 	_screen.interact()
-	for _step: int in maxi(_cell.y, 0):
+	for _step: int in maxi(_cell.y if rows < 0 else rows, 0):
 		_screen.press_button(PokeButton.DOWN)
 	for _press: int in maxi(_cell.x, 0):
 		for _frame: int in BOX_REVEAL_FRAMES:
 			_screen.advance_frame()
 		_screen.press_button(PokeButton.A)
 
+
+## `DaycareGentlemanText`, whose second number is `wDayCareInUse`: a seeded slot
+## is what puts the growth, the price and MONEY_BOX on the screen.
+func _stage_gen1_day_care() -> void:
+	_stage_party()
+	var world: Gen2WorldAPI = _screen.get("_world")
+	if world != null and _cell.y >= 1:
+		world.state.set_day_care_mon(Gen2WorldDayCare.SLOT_MAN, _day_care_slot())
+		world.state.set_day_care_has_mon(Gen2WorldDayCare.SLOT_MAN, true)
+	_stage_counter(
+		{"money": {Gen2WorldMartHost.MONEY_ACCOUNT: VENDING_MONEY}},
+		PokeButton.LEFT, 0
+	)
+	for _frame: int in _staged_frames():
+		_screen.advance_frame()
+
+
+## The development party's own lead, three levels on from where it went in.
+func _day_care_slot() -> Gen2SaveMon:
+	var mon: Gen2SaveMon = Gen2SaveMon.new()
+	mon.species = DAY_CARE_SPECIES
+	mon.level = DAY_CARE_LEVEL
+	mon.nickname = ""
+	mon.exp = Gen2Experience.total_exp_at(
+		int(_screen._data.species(DAY_CARE_SPECIES).get("growth_rate", 0)),
+		DAY_CARE_LEVEL + DAY_CARE_GROWTH
+	)
+	return mon
+
+
+const DAY_CARE_SPECIES: int = 1
+const DAY_CARE_LEVEL: int = 5
+const DAY_CARE_GROWTH: int = 3
 
 ## Enough for every row of `VendingPrices` and not enough to widen the money box.
 const VENDING_MONEY: int = 1000


### PR DESCRIPTION
`DaycareGentlemanText` is the corpus's other `text_asm` row the world owns whole, so it is pinned by address the way `TalkToTrainer` is and the world holds its steps instead of a script: `.IntroText` under a `YesNoChoice`, `wPartyCount` tested before `DisplayPartyMenu` opens rather than against what it comes back with, `callfar KnowsHMMove` the whole of what is asked about the row that does come back, and `MoveMon PARTY_TO_DAYCARE` behind `.WillLookAfterMonText`.

`.daycareInUse` reads the level off the experience, prices the difference at a hundred a level plus a hundred and draws MONEY_BOX over the map for the question; `.enoughMoney` pays before it draws that box again, so the receipt stands over the new balance. `IncrementDayCareMonExp` sits in front of `ApplyOutOfBattlePoisonDamage`'s own step gate with no level test, so a slot at MAX_LEVEL keeps counting and the visit that finds it clamps `wDayCareMonExp` to `CalcExperience MAX_LEVEL` whether or not the Pokemon comes out.

The one slot is the existing `wBreedMon1`, so no save format moves. `Gen2WorldDayCare.retrieve` carries both generations now: Crystal's alone clears the status byte, refills every PP and writes the experience back down to the bottom of the level just reached, where Generation 1 keeps all three and shifts the PP along with the moves `WriteMonMoves` teaches under `wLearningMovesFromDayCare`. `KnowsHMMove` has one caller and reads `Gen2WorldTMHM`'s own HM rows rather than a table of its own.

| Check | Result |
|---|---|
| `tools/checks/day_care.gd` | fifteen stubs, 151 species' growth and price at every deposit level, 151 species' learning, five HM moves refused, on Red, Blue and Yellow |
| `tools/checks/gen1_walk.gd` | a deposit, four refusals, six steps into experience and a 400 withdrawal on each cartridge |
| `tools/checks/gen1_maps.gd` | the row census reads 254 scripts on Red and Blue and 300 on Yellow |
| `tools/validate.gd -- all` | 93 topics pass |
| GUT unit tier | 3858 tests, 6 of them new |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Story walk | 6 steps on Crystal, Gold and Silver |
| Warning scan | 0 warnings in 634 scripts |

`tools/preview_world.gd -- red 0 72 <out.png> live day_care@3,3 3 1` photographs the price under the money window.

The cache format moves to 119 for the imported box run; all six cartridges re-import with `layout: Layout verified.`