### PR TITLE
Open the Generation 1 region map

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -2565,6 +2565,34 @@ func town_map_palette(slot: int, female: bool = false) -> PackedColorArray:
 	return colors
 
 
+## `TownMapOrder`, the map ids `DisplayTownMap`'s cursor walks. Empty on a
+## Generation 2 cache, whose cursor walks a landmark window instead.
+func town_map_order() -> PackedInt32Array:
+	var stored: Variant = _town_map.get("order", [])
+	var out := PackedInt32Array()
+	if not stored is Array:
+		return out
+	for entry: Variant in stored as Array:
+		out.append(int(entry))
+	return out
+
+
+## `FlyWarpDataPtr`'s row for [param map]: `{ x, y }`, the tile `.usedFlyWarp`
+## puts the player on. Empty for a map no row names, which is what
+## `.flyWarpDataPtrLoop` never returning from means for a bad destination.
+func gen1_fly_warp(map: int) -> Dictionary:
+	var stored: Variant = _town_map.get("fly_warps", [])
+	if not stored is Array:
+		return {}
+	for row: Variant in stored as Array:
+		if row is Dictionary and int((row as Dictionary).get("map", -1)) == map:
+			return {
+				"x": int((row as Dictionary).get("x", 0)),
+				"y": int((row as Dictionary).get("y", 0)),
+			}
+	return {}
+
+
 func landmark_count() -> int:
 	var stored: Variant = _town_map.get("landmarks", [])
 	return (stored as Array).size() if stored is Array else 0
@@ -2580,7 +2608,12 @@ func landmark(index: int) -> Dictionary:
 	var codes := PackedByteArray()
 	for code: Variant in row.get("codes", []) as Array:
 		codes.append(int(code))
-	return {"x": int(row.get("x", 0)), "y": int(row.get("y", 0)), "codes": codes}
+	return {
+		"x": int(row.get("x", 0)), "y": int(row.get("y", 0)), "codes": codes,
+		## `LoadTownMapEntry`'s own packed pair, which only Generation 1 stores
+		## and only `DisplayWildLocations`' Cerulean Cave test reads.
+		"packed": int(row.get("packed", -1)),
+	}
 
 
 ## A landmark's name as text. `<BSP>` reads as the space it is everywhere but the
@@ -2591,7 +2624,8 @@ func landmark_name(index: int) -> String:
 		return ""
 	var out: String = ""
 	for code: int in entry.get("codes", PackedByteArray()) as PackedByteArray:
-		out += Gen2Text.character(code)
+		out += Gen1Text.character(code) if generation == RomRegistry.GEN1 \
+			else Gen2Text.character(code)
 	return out
 
 

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -89,6 +89,9 @@ const MAX_ANIM_ROWS: int = 64
 
 ## A runaway guard for the terminated name tables, longer than any entry.
 const MAX_NAME_LENGTH: int = 20
+## `data/maps/names.asm`: the longest is `SEAFOAM ISLANDS`, and a run past this
+## means the entry table's own pointer is wrong.
+const MAX_LANDMARK_LENGTH: int = 24
 ## `PokedexEntry` descriptions run to two pages of three lines.
 const MAX_DEX_TEXT: int = 256
 ## An `EvosMoves` record cannot outrun this; the longest learnset is well under.
@@ -797,6 +800,7 @@ func import_rom(
 		"oak_ratings": _import_dex_ratings(rom, layout),
 		"vending": _import_vending(rom, layout, items),
 		"prizes": _import_prizes(rom, layout),
+		"town_map": _import_town_map(rom, layout),
 		"complete": true,
 	}
 	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
@@ -937,6 +941,90 @@ static func _import_bar_palettes(rom: RomFile, layout: Dictionary) -> Dictionary
 		for slot: int in Gen1Layout.SUPER_PALETTE_COLORS:
 			colors.append(rom.u16le(at + slot * PokePalette.COLOR_BYTES))
 		out[name] = colors
+	return out
+
+
+## `_TownMap`'s whole screen: `CompressedMap`'s runs, `PalPacket_TownMap`'s own
+## four colours, `TownMapOrder` and one landmark a map id, so the cursor walk and
+## every icon read the same table [Gen2TownMapPage] draws Crystal's regions from.
+static func _import_town_map(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var palette: int = Gen1Layout.super_palette_offset(layout, Gen1Layout.PAL_TOWNMAP)
+	var colors: Array = []
+	for slot: int in Gen1Layout.SUPER_PALETTE_COLORS:
+		colors.append(rom.u16le(palette + slot * PokePalette.COLOR_BYTES))
+	var order: Array = []
+	for row: int in Gen1Layout.TOWN_MAP_ORDER_COUNT:
+		order.append(rom.u8(int(layout["town_map_order"]) + row))
+	return {
+		"kanto": _town_map_cells(rom, int(layout["town_map_rle"])),
+		"palettes": colors,
+		"order": order,
+		"landmarks": _town_map_landmarks(rom, layout),
+		"fly_warps": _town_map_fly_warps(rom, layout),
+	}
+
+
+## `FlyWarpDataPtr` with the record behind each row, which `.usedFlyWarp` copies
+## the last four bytes of onto the player: the tile, then the two sub-block bits
+## the tile's own low bits already say.
+static func _town_map_fly_warps(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout["fly_warps"])
+	var bank: int = RomFile.bank_of(at)
+	var out: Array = []
+	for row: int in Gen1Layout.FLY_WARP_COUNT:
+		var record: int = RomFile.linear(
+			bank, rom.u16le(at + row * Gen1Layout.FLY_WARP_ROW_SIZE + 2)
+		) + Gen1Layout.FLY_WARP_RECORD_AT
+		out.append({
+			"map": rom.u8(at + row * Gen1Layout.FLY_WARP_ROW_SIZE),
+			"y": rom.u8(record),
+			"x": rom.u8(record + 1),
+		})
+	return out
+
+
+## `.nextTile`: each byte is a tile nybble over [constant
+## Gen1Layout.WORLD_MAP_FIRST_CODE] and a count, and a zero byte ends the screen.
+static func _town_map_cells(rom: RomFile, at: int) -> Array:
+	var out: Array = []
+	while rom.u8(at) != 0 and out.size() < Gen1Layout.WORLD_MAP_CELLS:
+		var byte: int = rom.u8(at)
+		for _run: int in byte & 0x0F:
+			out.append(Gen1Layout.WORLD_MAP_FIRST_CODE + ((byte >> 4) & 0x0F))
+		at += 1
+	return out
+
+
+## `LoadTownMapEntry` for every map id, flattened: the icon centre in screen
+## pixels and the name `PlaceString` copies out of the row's own pointer.
+static func _town_map_landmarks(rom: RomFile, layout: Dictionary) -> Array:
+	var external: int = int(layout["external_map_entries"])
+	var internal: int = int(layout["internal_map_entries"])
+	var out: Array = []
+	for map: int in Gen1Layout.map_count(rom.id):
+		var row: int = external + map * Gen1Layout.EXTERNAL_MAP_ENTRY_SIZE
+		if map >= Gen1Layout.FIRST_INDOOR_MAP:
+			row = internal
+			while rom.u8(row) <= map:
+				row += Gen1Layout.INTERNAL_MAP_ENTRY_SIZE
+			row += 1
+		var packed: int = rom.u8(row)
+		var name: String = Gen1Text.decode(
+			rom.bytes(),
+			RomFile.linear(RomFile.bank_of(external), rom.u16le(row + 1)),
+			MAX_LANDMARK_LENGTH
+		)
+		var codes: Array = []
+		for code: int in Gen1Text.encode(name):
+			codes.append(code)
+		out.append({
+			"x": (packed & 0x0F) * PokeTiles.TILE_WIDTH
+				+ Gen1Layout.TOWN_MAP_ICON_CENTRE.x,
+			"y": (packed >> 4) * PokeTiles.TILE_HEIGHT
+				+ Gen1Layout.TOWN_MAP_ICON_CENTRE.y,
+			"packed": packed,
+			"codes": codes,
+		})
 	return out
 
 
@@ -1473,6 +1561,30 @@ func _import_tiles(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"tiles": Gen1Layout.BADGE_FACE_TILES,
 			"first_code": Gen1Layout.BADGE_FACE_CODE,
 			"bits": 2,
+		},
+		"world_map": {
+			"offset": int(layout["world_map_tiles"]),
+			"tiles": Gen1Layout.WORLD_MAP_TILES,
+			"first_code": Gen1Layout.WORLD_MAP_FIRST_CODE,
+			"bits": 2,
+		},
+		"town_map_cursor": {
+			"offset": int(layout["town_map_cursor"]),
+			"tiles": Gen1Layout.TOWN_MAP_CURSOR_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"town_map_nest": {
+			"offset": int(layout["town_map_nest"]),
+			"tiles": Gen1Layout.TOWN_MAP_NEST_TILES,
+			"first_code": 0,
+			"bits": 1,
+		},
+		"town_map_arrow": {
+			"offset": int(layout["town_map_arrow"]),
+			"tiles": Gen1Layout.TOWN_MAP_ARROW_TILES,
+			"first_code": Gen1Text.ARROW_UP,
+			"bits": 1,
 		},
 		"stats_p": {
 			"offset": int(layout["stats_p"]),

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -667,6 +667,57 @@ const POKEDEX_TILES: int = 18
 const POKEDEX_FIRST_CODE: int = 0x60
 const POKEDEX_BALL_CODE: int = 0x72
 
+## `LoadTownMap`: `WorldMapTileGraphics` at `vChars2 tile $60` over the text box
+## sheet, and `CompressedMap`'s runs, each byte a tile nybble from that base and
+## a count, filling the whole screen.
+const WORLD_MAP_TILES: int = 16
+const WORLD_MAP_FIRST_CODE: int = 0x60
+const WORLD_MAP_CELLS: int = 360
+## `TownMapCursor`, `MonNestIcon`, `TownMapUpArrow` and the `BirdSprite` frames
+## `LoadTownMap_Fly` copies over the cursor, all at `vSprites tile $04`.
+const TOWN_MAP_CURSOR_TILES: int = 4
+const TOWN_MAP_NEST_TILES: int = 1
+const TOWN_MAP_ARROW_TILES: int = 1
+const TOWN_MAP_BIRD_TILES: int = 12
+## `PalPacket_TownMap` under a `BlkPacket_WholeScreen`, so one row colours every
+## cell of the screen.
+const PAL_TOWNMAP: int = 0x0C
+## `TownMapOrder`, the ids `DisplayTownMap`'s own cursor walks.
+const TOWN_MAP_ORDER_COUNT: int = 47
+## `LoadTownMapEntry`: a map under this indexes `ExternalMapEntries` by itself,
+## and one above it takes the first `InternalMapEntries` row whose group byte is
+## greater. Both rows pack y in the high nybble and x in the low one.
+const EXTERNAL_MAP_ENTRY_SIZE: int = 3
+const INTERNAL_MAP_ENTRY_SIZE: int = 4
+## `MarkTownVisitedAndLoadToggleableObjects` sets a bit for any map under this,
+## and `BuildFlyLocationsList` walks the [constant NUM_CITY_MAPS] under that.
+const FIRST_ROUTE_MAP: int = 0x0C
+## `TownMapCoordsToOAMCoords` gives (x * 8 + 24, y * 8 + 24) and
+## `WriteTownMapSpriteOAM` takes 4 off x and, the borrow out of x costing one of
+## the two, 3 off y. Stored is the 16x16 icon's own centre.
+const TOWN_MAP_ICON_CENTRE: Vector2i = Vector2i(20, 13)
+## `.nestloop` writes that pair with no adjustment, so its 8x8 icon hangs a
+## pixel below the centre the borrow gave the bigger one.
+const TOWN_MAP_NEST_ORIGIN: Vector2i = Vector2i(4, 5)
+## `DisplayWildLocations`' `cp $19`: the packed coordinates Cerulean Cave's own
+## entry carries, and the one place a nest icon is never drawn.
+const TOWN_MAP_SKIP_COORDS: int = 0x19
+## `TownMapSpriteBlinkingAnimation` counts to 25 and hides every object but the
+## player's, then to 50 and shows them again.
+const TOWN_MAP_BLINK_FRAMES: int = 25
+## `FlyWarpDataPtr`: thirteen `db map, 0 / dw` rows, each pointing at a
+## `fly_warp` whose third and fourth bytes are the tile the player lands on.
+const FLY_WARP_COUNT: int = 13
+const FLY_WARP_ROW_SIZE: int = 4
+const FLY_WARP_RECORD_AT: int = 2
+## `wBeatGymFlags`' own bit for the badge `.fly` asks for.
+const THUNDERBADGE: int = 2
+
+## `NOT_VISITED`, which `BuildFlyLocationsList` writes for a town the player has
+## not been to, and `.townMapFlyLoop`'s own `ld c, 15` between two draws.
+const TOWN_MAP_NOT_VISITED: int = 0xFE
+const TOWN_MAP_FLY_DELAY: int = 15
+
 ## `DrawTrainerInfo`'s own four sheets and where each lands. `BlankLeaderNames`
 ## runs straight on into `CircleTile`, which is why its `$17` is one longer than
 ## the file: `$76` is the circle "●BADGES●" is written with, and the sixteen
@@ -944,9 +995,13 @@ const ENGINE_FLAG_BYTES: Dictionary = {
 	"status_flags_4": 1,
 	"obtained_hidden_items": HIDDEN_ITEM_FLAG_BYTES,
 	"obtained_hidden_coins": HIDDEN_COIN_FLAG_BYTES,
+	"town_visited": TOWN_VISITED_FLAG_BYTES,
 }
 const ENGINE_FLAG_FIRST: int = 256
 const ENGINE_FLAG_BITS: int = 8
+## `flag_array NUM_CITY_MAPS`, rounded up to the two bytes the array occupies.
+const TOWN_VISITED_FLAG_BYTES: int = 2
+
 ## `BAG_ITEM_CAPACITY`: one list of slots, not four pockets.
 const BAG_ITEM_CAPACITY: int = 20
 ## The one type byte every Generation 1 item wears, so the shared pack draws the
@@ -1310,6 +1365,21 @@ const RED_BLUE: Dictionary = {
 	"font": 0x11A80,
 	"text_box": 0x12288,
 	"pokedex_tiles": 0x12488,
+	## The region map's own sheet, its run-length screen, the three object tiles
+	## and the twelve `BirdSprite` frames the fly map draws instead of a cursor.
+	"world_map_tiles": 0x125A8,
+	"town_map_rle": 0x71100,
+	"town_map_order": 0x70F11,
+	"town_map_cursor": 0x70F40,
+	"town_map_nest": 0x716BE,
+	"town_map_arrow": 0x71093,
+	"town_map_bird": 0x14D80,
+	"external_map_entries": 0x71313,
+	"internal_map_entries": 0x71382,
+	"town_visited": 0xD70B,
+	"display_town_map": 0x70E3E,
+	"town_map_text": 0x0FC12,
+	"fly_warps": 0x06448,
 	"battle_font": 0x11EA0,
 	"battle_hud_1": 0x12080,
 	"battle_hud_2": 0x12098,
@@ -1500,6 +1570,19 @@ const YELLOW: Dictionary = {
 	"font": 0x10600,
 	"text_box": 0x10E18,
 	"pokedex_tiles": 0x11018,
+	"world_map_tiles": 0x11138,
+	"town_map_rle": 0x7118A,
+	"town_map_order": 0x70F95,
+	"town_map_cursor": 0x70FC4,
+	"town_map_nest": 0x7174B,
+	"town_map_arrow": 0x7111E,
+	"town_map_bird": 0x15171,
+	"external_map_entries": 0x7139C,
+	"internal_map_entries": 0x7140B,
+	"town_visited": 0xD70A,
+	"display_town_map": 0x70EB4,
+	"town_map_text": 0x0FAA0,
+	"fly_warps": 0x061BC,
 	"battle_font": 0x10A20,
 	"battle_hud_1": 0x10C00,
 	"battle_hud_2": 0x10C18,

--- a/game/gen1/gen1_text.gd
+++ b/game/gen1/gen1_text.gd
@@ -85,6 +85,11 @@ const FONT_EXTRA_CHARACTERS: Dictionary = {
 
 const ELLIPSIS_CODE: int = 0x75
 
+## `charmap "▲", $ed`. `LoadTownMap_Fly` copies `TownMapUpArrow` over the tile
+## the menu cursor is drawn from, so one code is both while that screen is up.
+const ARROW_UP: int = 0xED
+const ARROW_DOWN: int = 0xEE
+
 ## `PlacePKMN`'s text is `db "<PK><MN>@"`: two narrow tiles, never six letters.
 const WORD_TILES: Dictionary = {
 	"<PKMN>": [0xE1, 0xE2],

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -1994,6 +1994,10 @@ static func _script_far(
 	var layout: Dictionary = ctx["layout"]
 	var bank: int = int(state.get("b", -1))
 	var target: int = int(state.get("hl", -1))
+	if bank >= 0 and target >= 0 \
+		and RomFile.linear(bank, target) == int(layout.get("display_town_map", -1)):
+		out.append({"op": "town_map"})
+		return next
 	if bank != int(layout["remove_item_bank"]) or target != int(layout["remove_item"]):
 		return _script_routine_call(ctx, bank, target, state, out, next, depth)
 	if int(state.get("remove", 0)) < 1:
@@ -2306,6 +2310,12 @@ static func _script_text_row(
 		out.append({"op": "text", "text": String(decoded["text"])})
 	var code: int = _text_code_at(decoded)
 	if code < 0:
+		return true
+	## The third row the world owns whole. `TownMapText`'s own code clears
+	## `BIT_NO_TEXT_DELAY` and pushes a return address behind `CloseTextDisplay`,
+	## and none of that is the screen it opens.
+	if at == int((ctx["layout"] as Dictionary).get("town_map_text", -1)):
+		out.append({"op": "town_map"})
 		return true
 	var walked: Variant = _walk_script(ctx, code, state, depth + 1)
 	if not walked is Array:

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 119
+const FORMAT_VERSION: int = 120
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/render/town_map_page.gd
+++ b/game/render/town_map_page.gd
@@ -146,6 +146,26 @@ const NAME_BREAK_CODES: Array[int] = [0x1F, 0x25]
 ## `PAL_TOWNMAP_CITY`, the one slot `FemalePokegearPals` changes.
 const CITY_PALETTE: int = 3
 
+## Generation 1 draws one screen out of `CompressedMap` and prints over it.
+## `DisplayTownMap` puts the cursor's name at (1,0), and `.townMapLoop` clears
+## the row first where the screen it opened on did not.
+const GEN1_NAME_AT: Vector2i = Vector2i(1, 0)
+## `LoadTownMap_Fly`: `ToText` in the corner, fifteen cells cleared for the name
+## at (3,0), and the two arrows the loop rewrites after its own `DelayFrames`.
+const GEN1_FLY_TO: String = "To"
+const GEN1_FLY_NAME_AT: Vector2i = Vector2i(3, 0)
+const GEN1_FLY_CLEAR_COLUMNS: int = 15
+const GEN1_FLY_ARROWS: Array[Vector2i] = [Vector2i(18, 0), Vector2i(19, 0)]
+const GEN1_FLY_ARROW_CODES: Array[int] = [Gen1Text.ARROW_UP, Gen1Text.ARROW_DOWN]
+## `DisplayWildLocations`' own box when nothing matched, which is the whole of
+## what the AREA row shows for a species with no wild table.
+const GEN1_UNKNOWN_BOX_AT: Vector2i = Vector2i(1, 7)
+const GEN1_UNKNOWN_BOX_SIZE: Vector2i = Vector2i(17, 4)
+const GEN1_UNKNOWN_AT: Vector2i = Vector2i(2, 9)
+const GEN1_UNKNOWN_TEXT: String = " AREA UNKNOWN"
+## `WaitForTextScrollButtonPress`' own arrow, which the nest screen waits under.
+const GEN1_NEST_ARROW_AT: Vector2i = Vector2i(18, 16)
+
 var font: Gen2Font = null
 ## Which text-box border the player chose, for the box a card draws under itself.
 ## The region map screens have no box and never read it.
@@ -156,6 +176,7 @@ var _cards: Dictionary = {}
 ## `FlyMapLabelBorderGFX`, which the fly map loads over the first six Pokegear
 ## tiles, so it is a second window rather than more of the first.
 var _fly_tiles: Dictionary = {}
+var _gen1: bool = false
 
 
 ## [param data] supplies the glyphs and both graphics sheets; a cache without
@@ -167,6 +188,9 @@ static func from_data(data: GameData) -> Gen2TownMapPage:
 	var out := Gen2TownMapPage.new()
 	out.font = glyphs
 	out.frame_style = Gen2OptionsStore.current().textbox_frame
+	out._gen1 = data.generation == RomRegistry.GEN1
+	if out._gen1:
+		return out._load_gen1(data)
 	out._load_sheet(
 		data, "town_map", TOWN_MAP_FIRST_TILE, Gen2Layout.TOWN_MAP_TILES, out._tiles
 	)
@@ -184,8 +208,27 @@ static func from_data(data: GameData) -> Gen2TownMapPage:
 	return out
 
 
+## `LoadTownMap` copies `WorldMapTileGraphics` over the text box sheet at $60
+## and the fly map puts `TownMapUpArrow` over the cursor tile the font draws at
+## `▲`, so the second is a window over the first rather than beside it.
+func _load_gen1(data: GameData) -> Gen2TownMapPage:
+	_load_sheet(
+		data, "world_map", Gen1Layout.WORLD_MAP_FIRST_CODE,
+		Gen1Layout.WORLD_MAP_TILES, _tiles
+	)
+	_load_sheet(
+		data, "town_map_arrow", Gen1Text.ARROW_UP,
+		Gen1Layout.TOWN_MAP_ARROW_TILES, _fly_tiles
+	)
+	return self
+
+
 func ready() -> bool:
-	return font != null and _tiles.size() >= Gen2Layout.TOWN_MAP_TILES + Gen2Layout.POKEGEAR_TILES
+	if font == null:
+		return false
+	if _gen1:
+		return _tiles.size() >= Gen1Layout.WORLD_MAP_TILES
+	return _tiles.size() >= Gen2Layout.TOWN_MAP_TILES + Gen2Layout.POKEGEAR_TILES
 
 
 ## [param window] is which VRAM window the strip lands in: the shared one, or the
@@ -239,6 +282,53 @@ func tilemap(
 			_draw_town_map_frame(map)
 			_draw_name(map, name_codes)
 	return map
+
+
+## `DisplayTownMap`, `LoadTownMap_Nest` and `LoadTownMap_Fly` over the one screen
+## `LoadTownMap` draws. [param options] is what each loop blanked before it
+## printed: `row_cleared` is `.townMapLoop`'s own `ClearScreenArea`, which the
+## screen it opened on never ran, `arrow_hidden` the arrow the last press left
+## blank for fifteen frames, and `area_unknown` the box a species with no wild
+## table gets instead of icons.
+func gen1_tilemap(
+	region: PackedByteArray,
+	name_codes: PackedByteArray,
+	screen: StringName = Gen2TownMap.SCREEN_TOWN_MAP,
+	options: Dictionary = {},
+) -> PackedInt32Array:
+	var map := PackedInt32Array()
+	map.resize(COLUMNS * ROWS)
+	map.fill(BLANK_TILE)
+	for cell: int in mini(region.size(), map.size()):
+		map[cell] = region[cell]
+	if screen == Gen2TownMap.SCREEN_FLY:
+		_draw_gen1_fly(map, name_codes, int(options.get("arrow_hidden", -1)))
+		return map
+	if bool(options.get("row_cleared", false)):
+		for column: int in COLUMNS:
+			_put(map, Vector2i(column, 0), BLANK_TILE)
+	_draw_codes(map, GEN1_NAME_AT, name_codes)
+	if screen != Gen2TownMap.SCREEN_DEX_AREA:
+		return map
+	_put(map, GEN1_NEST_ARROW_AT, Gen1Text.ARROW_DOWN)
+	if bool(options.get("area_unknown", false)):
+		_draw_box(map, GEN1_UNKNOWN_BOX_AT, GEN1_UNKNOWN_BOX_SIZE)
+		_draw_string(map, GEN1_UNKNOWN_AT, GEN1_UNKNOWN_TEXT)
+	return map
+
+
+func _draw_gen1_fly(
+	map: PackedInt32Array, name_codes: PackedByteArray, hidden: int
+) -> void:
+	_draw_string(map, Vector2i.ZERO, GEN1_FLY_TO)
+	for column: int in GEN1_FLY_CLEAR_COLUMNS:
+		_put(map, GEN1_FLY_NAME_AT + Vector2i(column, 0), BLANK_TILE)
+	_draw_codes(map, GEN1_FLY_NAME_AT, name_codes)
+	for index: int in GEN1_FLY_ARROWS.size():
+		_put(
+			map, GEN1_FLY_ARROWS[index],
+			BLANK_TILE if index == hidden else GEN1_FLY_ARROW_CODES[index]
+		)
 
 
 func cards_ready() -> bool:
@@ -394,8 +484,12 @@ func _draw_box(map: PackedInt32Array, at: Vector2i, size: Vector2i) -> void:
 
 
 func _draw_string(map: PackedInt32Array, at: Vector2i, text: String) -> void:
+	_draw_codes(map, at, font.encode(text))
+
+
+func _draw_codes(map: PackedInt32Array, at: Vector2i, codes: PackedByteArray) -> void:
 	var cell: Vector2i = at
-	for code: int in Gen2Text.encode(text):
+	for code: int in codes:
 		_put(map, cell, code)
 		cell.x += 1
 
@@ -421,10 +515,7 @@ func _draw_fly_bubble(map: PackedInt32Array, name_codes: PackedByteArray) -> voi
 	for corner: Array in FLY_BUBBLE_CORNERS:
 		_put(map, corner[0] as Vector2i, int(corner[1]))
 	_draw_string(map, FLY_BUBBLE_WHERE_AT, FLY_BUBBLE_WHERE)
-	var at: Vector2i = FLY_BUBBLE_NAME_AT
-	for code: int in name_codes:
-		_put(map, at, code)
-		at.x += 1
+	_draw_codes(map, FLY_BUBBLE_NAME_AT, name_codes)
 	_put(map, FLY_BUBBLE_ARROW_AT, FLY_BUBBLE_ARROW_TILE)
 
 
@@ -441,10 +532,7 @@ func _draw_nest_header(map: PackedInt32Array, header_codes: PackedByteArray) -> 
 	for column: int in COLUMNS:
 		_put(map, Vector2i(column, 0), BLANK_TILE)
 	_draw_bar(map, NEST_BAR_ROW)
-	var at: Vector2i = NEST_HEADER_AT
-	for code: int in header_codes:
-		_put(map, at, code)
-		at.x += 1
+	_draw_codes(map, NEST_HEADER_AT, header_codes)
 
 
 ## `Pokegear_FinishTilemap`, which runs after the name is placed and so blanks

--- a/game/world/pokedex_screen.gd
+++ b/game/world/pokedex_screen.gd
@@ -310,19 +310,10 @@ func _open_area() -> void:
 	if _area != null:
 		return
 	var species: int = _dex.selected_species()
-	var roaming: Array = _world.state.roaming_mons()
-	var nests: Array = []
-	for region: int in Gen2TownMap.REGION_NAMES.size():
-		nests.append(Gen2WorldEncounter.nests(
-			_data, species, Gen2TownMap.region_name(region), roaming
-		))
 	var host := Gen2TownMapScreen.new()
 	host.z_index = 10
 	add_child(host)
-	if not host.open_dex_area(
-		_data, species, nests, _world.landmark_backup(), _world.state.hall_of_fame(),
-		_world.player_female(), _world.map_time_of_day()
-	):
+	if not _open_area_screen(host, species):
 		Gen2Screen.drop(host)
 		return
 	host.closed.connect(_on_area_closed)
@@ -330,10 +321,35 @@ func _open_area() -> void:
 	_mode = Mode.AREA
 
 
+## `predef LoadTownMap_Nest` on a Generation 1 cartridge, whose nests are one
+## list of map ids and whose header is the species itself.
+func _open_area_screen(host: Gen2TownMapScreen, species: int) -> bool:
+	if _gen1:
+		return host.open_gen1_dex_area(
+			_data, species, Gen2WorldEncounter.gen1_nests(_data, species),
+			_world.landmark_backup()
+		)
+	var roaming: Array = _world.state.roaming_mons()
+	var nests: Array = []
+	for region: int in Gen2TownMap.REGION_NAMES.size():
+		nests.append(Gen2WorldEncounter.nests(
+			_data, species, Gen2TownMap.region_name(region), roaming
+		))
+	return host.open_dex_area(
+		_data, species, nests, _world.landmark_backup(), _world.state.hall_of_fame(),
+		_world.player_female(), _world.map_time_of_day()
+	)
+
+
 func _on_area_closed() -> void:
 	if _area != null:
 		Gen2Screen.drop(_area)
 		_area = null
+	if _gen1:
+		## `.choseArea` leaves `b = 0`, which is `.exitSideMenu`'s own way back
+		## to the listing rather than to the entry page.
+		_open_list_mode()
+		return
 	## `.Area` redisplays the entry it left, cursor and page included.
 	_mode = Mode.ENTRY
 	_refresh()
@@ -436,9 +452,7 @@ func _handle_gen1_side(button: int) -> bool:
 
 
 ## What each row leaves `b` as: DATA and AREA answer 0 and redraw the listing,
-## QUIT answers 1 and closes the dex, and CRY stays in the menu. AREA is
-## `predef LoadTownMap_Nest`, whose nest table nothing imports, so it draws
-## nothing and lands on the listing its own `b = 0` goes to.
+## QUIT answers 1 and closes the dex, and CRY stays in the menu.
 func _gen1_side_action() -> void:
 	match _side_cursor:
 		Gen2Pokedex.GEN1_SIDE_DATA:
@@ -447,7 +461,7 @@ func _gen1_side_action() -> void:
 		Gen2Pokedex.GEN1_SIDE_CRY:
 			cry_requested.emit(_dex.selected_species())
 		Gen2Pokedex.GEN1_SIDE_AREA:
-			_open_list_mode()
+			_open_area()
 		Gen2Pokedex.GEN1_SIDE_QUIT:
 			closed.emit()
 
@@ -676,6 +690,10 @@ func render() -> Image:
 		return Image.create_empty(
 			Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8
 		)
+	## `LoadTownMap` clears the screen and draws the region map over it, so the
+	## AREA row is the whole picture rather than a layer on the listing.
+	if _mode == Mode.AREA and _area != null:
+		return _area.render()
 	if _gen1:
 		return _render_gen1()
 	## `Pokedex_BlinkArrowCursor`'s own off phase, and the same answer on every

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1508,13 +1508,16 @@ func _confirm_gen1_use(item: int) -> void:
 
 
 ## The `.Current` rows that are neither `UnusableItem` nor battle-only.
-## `ItemUsePokedex` is a predef the world owns, `ItemUseCoinCase` prints over
-## the pack, and `ItemUseOaksParcel` is the one refusal with a text of its own.
+## `ItemUsePokedex` and `ItemUseTownMap` are screens the world owns,
+## `ItemUseCoinCase` prints over the pack, and `ItemUseOaksParcel` is the one
+## refusal with a text of its own.
 ## The rest land on `ItemUseNotTime`, the box `.Oak` prints.
 func _confirm_gen1_current(item: int) -> void:
 	match item:
 		Gen1Layout.ITEM_POKEDEX:
 			action_chosen.emit(Gen2WorldStartMenu.ITEM_POKEDEX, &"")
+		Gen1Layout.ITEM_TOWN_MAP:
+			action_chosen.emit(Gen2WorldStartMenu.ITEM_TOWN_MAP, &"")
 		Gen1Layout.ITEM_COIN_CASE:
 			_show_pack_result(_coin_case_text(), true)
 		Gen1Layout.ITEM_OAKS_PARCEL:

--- a/game/world/town_map.gd
+++ b/game/world/town_map.gd
@@ -46,6 +46,19 @@ var hall_of_fame: bool = false
 var visited_flypoints: Array[int] = []
 var _first: int = JOHTO_LANDMARK
 var _last: int = JOHTO_LANDMARK
+## Generation 1 walks tables rather than a landmark window: `TownMapOrder` on
+## the map itself and `wFlyLocationsList` on the fly map, whose unvisited towns
+## stand at [constant Gen1Layout.TOWN_MAP_NOT_VISITED].
+var gen1: bool = false
+var rows: PackedInt32Array = PackedInt32Array()
+## `wWhichTownMapLocation`, which `.enterLoop` leaves at zero while the cursor
+## stands on `wCurMap`, so the first UP press walks to the second row.
+var row_index: int = 0
+## Whether `.townMapLoop`'s own `ClearScreenArea` has run, which the screen each
+## of the three opened on skipped.
+var row_cleared: bool = false
+## Which of the two fly arrows the last press blanked, and -1 before any.
+var arrow_hidden: int = -1
 
 
 ## `FlyMap`, opened on the region the player is in with the cursor on its default
@@ -71,6 +84,31 @@ static func fly(
 		out._first = 0
 		out._last = Gen2Layout.KANTO_FLYPOINT - 1
 		out.cursor = 0
+	return out
+
+
+## `DisplayTownMap`. [param map] is `wCurMap`, which `.enterLoop` draws the
+## cursor on before the loop proper, and [param order] is `TownMapOrder`.
+static func create_gen1(
+	map: int, order: PackedInt32Array, on_screen: StringName = SCREEN_TOWN_MAP
+) -> Gen2TownMap:
+	var out := Gen2TownMap.new()
+	out.gen1 = true
+	out.crystal = false
+	out.screen = on_screen
+	out.rows = order
+	out.player_landmark = map
+	out.cursor = map
+	return out
+
+
+## `LoadTownMap_Fly` over `BuildFlyLocationsList`'s answer: one entry a town, the
+## map id where it was visited and `NOT_VISITED` where it was not. The list opens
+## on its first row whether or not that town was visited, which is the source's
+## own `ld hl, wFlyLocationsList`.
+static func fly_gen1(map: int, towns: PackedInt32Array) -> Gen2TownMap:
+	var out: Gen2TownMap = create_gen1(map, towns, SCREEN_FLY)
+	out.cursor = towns[0] if towns.size() > 0 else map
 	return out
 
 
@@ -115,6 +153,8 @@ func _shift(landmark: int) -> int:
 ## `_TownMap` picks by number alone, so the Fast Ship shows Kanto there;
 ## `InitPokegearTilemap.Map` tests it first and shows Johto.
 func region() -> int:
+	if gen1:
+		return REGION_KANTO
 	if screen == SCREEN_DEX_AREA:
 		return cursor
 	# `.NoKanto` is what puts a player standing in Kanto on Johto's map.
@@ -133,6 +173,8 @@ static func region_name(region_id: int) -> String:
 
 ## `.CheckPlayerLocation`: whether the dex area draws the player icon at all.
 func player_in_region() -> bool:
+	if gen1:
+		return true
 	var player: int = REGION_KANTO if Gen2WorldRadio.is_kanto_landmark(
 		player_landmark, crystal
 	) else REGION_JOHTO
@@ -152,6 +194,8 @@ func last_landmark() -> int:
 ## `.right` Kanto, the second only past the Hall of Fame, and each returns
 ## without redrawing when that region is already up.
 func press(button: int) -> bool:
+	if gen1:
+		return _press_gen1(button)
 	if screen == SCREEN_DEX_AREA:
 		match button:
 			PokeButton.LEFT:
@@ -175,6 +219,32 @@ func press(button: int) -> bool:
 			_skip_unvisited(-1)
 			return true
 	return false
+
+
+## `.pressedUp` and `.pressedDown` on both Generation 1 screens. The map's own
+## walk wraps through `TownMapOrder`; the fly map's skips an unvisited town and
+## wraps down through them too, where `.wrapToStartOfList` does not.
+func _press_gen1(button: int) -> bool:
+	var step: int = 1 if button == PokeButton.UP else -1
+	if button != PokeButton.UP and button != PokeButton.DOWN:
+		return false
+	row_cleared = true
+	arrow_hidden = 0 if step > 0 else 1
+	if rows.is_empty():
+		return true
+	row_index = wrapi(row_index + step, 0, rows.size())
+	if screen == SCREEN_FLY:
+		_skip_unvisited_gen1(step)
+	cursor = rows[row_index]
+	return true
+
+
+## `cp NOT_VISITED / jr z`, which walks on in the direction the press went.
+## `.wrapToStartOfList` skips the test, so an unvisited first town is landed on;
+## the first town is always visited, so nothing here has to guard against it.
+func _skip_unvisited_gen1(step: int) -> void:
+	while rows[row_index] == Gen1Layout.TOWN_MAP_NOT_VISITED and row_index > 0:
+		row_index = wrapi(row_index + step, 0, rows.size())
 
 
 ## `.ScrollNext` and `.ScrollPrev`'s loop, wrapping the way one press does. The

--- a/game/world/town_map_screen.gd
+++ b/game/world/town_map_screen.gd
@@ -51,6 +51,13 @@ const NEST_ORIGIN: int = 4
 const NEST_BLINK_FRAMES: int = 0x10
 ## `.String_SNest`, printed straight after `GetPokemonName`'s answer.
 const NEST_HEADER_SUFFIX: String = "'S NEST"
+## `MonsNestText`, whose `'s` is the one tile the Generation 1 charmap gives it.
+const GEN1_NEST_HEADER_SUFFIX: String = "'s NEST"
+## `TownMapCursor` and `MonNestIcon`, both at `vSprites tile $04`, and
+## `SPRITE_BIRD`, which `LoadTownMap_Fly` copies over the same four tiles.
+const GEN1_CURSOR_SHEET: String = "town_map_cursor"
+const GEN1_NEST_SHEET: String = "town_map_nest"
+const GEN1_BIRD_SPRITE: int = 0x09
 
 ## What the shadow OAM currently holds, which is a state rather than a redraw:
 ## the blink only writes it every sixteenth frame, so releasing SELECT leaves the
@@ -84,6 +91,13 @@ var _nests: Array = []
 var _oam: StringName = OAM_NESTS
 var _select_held: bool = false
 var _nest_icons: Array[TextureRect] = []
+var _gen1: bool = false
+## `DisplayWildLocations`' answer, which Generation 1 holds as one list of map
+## ids rather than a landmark list per region.
+var _gen1_nests: Array = []
+## Which frame the fly map's last press landed on, so its `ld c, 15` between the
+## blank and the two arrows is spent rather than assumed.
+var _gen1_pressed_at: int = -1
 var _frame_clock := Gen2WorldAnimation.FrameClock.new()
 
 
@@ -119,12 +133,15 @@ func open(
 		# with an empty rectangle over its own menu.
 		visible = false
 		return false
-	_map = Gen2TownMap.create(
-		landmark, Gen2WorldState.is_crystal_profile(_data), hall_of_fame, screen
-	)
+	_gen1 = _data.generation == RomRegistry.GEN1
+	_map = Gen2TownMap.create_gen1(landmark, _data.town_map_order(), screen) if _gen1 \
+		else Gen2TownMap.create(
+			landmark, Gen2WorldState.is_crystal_profile(_data), hall_of_fame, screen
+		)
 	if screen != Gen2TownMap.SCREEN_DEX_AREA:
 		_species = 0
 		_nests = []
+		_gen1_nests = []
 		for icon: TextureRect in _nest_icons:
 			icon.visible = false
 	_cards = cards.duplicate()
@@ -136,6 +153,32 @@ func open(
 	_select_held = false
 	_open = true
 	visible = true
+	if is_inside_tree() and _background != null:
+		_refresh()
+	return true
+
+
+## `LoadTownMap_Nest`. [param nests] is `DisplayWildLocations`' own list of map
+## ids, already deduplicated, and [param at_map] is `wCurMap`, where the player
+## icon stands beside them.
+func open_gen1_dex_area(
+	data: GameData, species: int, nests: Array, at_map: int
+) -> bool:
+	_species = species
+	_gen1_nests = nests.duplicate()
+	_nests = []
+	return open(data, at_map, false, Gen2TownMap.SCREEN_DEX_AREA)
+
+
+## `LoadTownMap_Fly` over `BuildFlyLocationsList`. [param towns] is one entry a
+## town: its map id, or `NOT_VISITED`. The answer is taken with
+## [method chosen_spawn], which is the map id `.pressedA` writes to
+## `wDestinationMap` and -1 for the B press that writes none.
+func open_gen1_fly(data: GameData, at_map: int, towns: PackedInt32Array) -> bool:
+	_chosen_spawn = -1
+	if not open(data, at_map, false, Gen2TownMap.SCREEN_FLY):
+		return false
+	_map = Gen2TownMap.fly_gen1(at_map, towns)
 	if is_inside_tree() and _background != null:
 		_refresh()
 	return true
@@ -204,7 +247,7 @@ func map() -> Gen2TownMap:
 func cursor_landmark() -> int:
 	if _map == null:
 		return 0
-	if _map.screen != Gen2TownMap.SCREEN_FLY:
+	if _gen1 or _map.screen != Gen2TownMap.SCREEN_FLY:
 		return _map.cursor
 	var row: Dictionary = _data.flypoint(_map.cursor) if _data != null else {}
 	return int(row.get("landmark", 0))
@@ -223,16 +266,19 @@ func handle_button(button: int) -> bool:
 	if not _open or _map == null:
 		return false
 	if button == PokeButton.A and _map.screen == Gen2TownMap.SCREEN_FLY:
-		# `.pressedA` reads the flypoint's own spawn out of `Flypoints + 1`.
+		# `.pressedA` reads the flypoint's own spawn out of `Flypoints + 1`,
+		# where Generation 1 writes the map id the list itself holds.
 		var row: Dictionary = _data.flypoint(_map.cursor) if _data != null else {}
-		_chosen_spawn = int(row.get("spawn", -1)) if not row.is_empty() else -1
+		_chosen_spawn = _map.cursor if _gen1 \
+			else (int(row.get("spawn", -1)) if not row.is_empty() else -1)
 		close()
 		return true
 	if button == PokeButton.B \
 		or (button == PokeButton.A and _map.screen == Gen2TownMap.SCREEN_DEX_AREA):
 		close()
 		return true
-	if button == PokeButton.SELECT and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
+	if button == PokeButton.SELECT and not _gen1 \
+		and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
 		_select_held = true
 		_apply_select()
 		return true
@@ -240,6 +286,7 @@ func handle_button(button: int) -> bool:
 		# `.left` and `.right` write the new region's icons at once rather than
 		# waiting for the blink.
 		_oam = OAM_NESTS
+		_gen1_pressed_at = _frames
 		_refresh()
 	return true
 
@@ -268,11 +315,36 @@ func close() -> void:
 ## icon it draws instead is `GetPlayerIcon`'s standing frame, not a walk.
 func advance_frame() -> void:
 	_frames += 1
+	if _gen1:
+		_advance_gen1()
+		return
 	if _map != null and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
 		_advance_dex_area()
 		return
 	if _frames % WALK_FRAME_LENGTH == 0:
 		_refresh_player_icon()
+
+
+## `TownMapSpriteBlinkingAnimation`, which the map's own input loop and
+## `WaitForTextScrollButtonPress` both run: 25 frames shown and 25 hidden. The
+## fly map's loop calls neither, and the player icon is above the range the
+## routine hides either way.
+func _advance_gen1() -> void:
+	if _map == null:
+		return
+	if _map.screen == Gen2TownMap.SCREEN_FLY:
+		if _map.arrow_hidden >= 0 \
+			and _frames - _gen1_pressed_at >= Gen1Layout.TOWN_MAP_FLY_DELAY:
+			_map.arrow_hidden = -1
+			_refresh()
+		return
+	var blinked: StringName = OAM_CLEARED \
+		if _frames % (Gen1Layout.TOWN_MAP_BLINK_FRAMES * 2) \
+			>= Gen1Layout.TOWN_MAP_BLINK_FRAMES else OAM_NESTS
+	if blinked == _oam:
+		return
+	_oam = blinked
+	_refresh_objects()
 
 
 func _advance_dex_area() -> void:
@@ -297,6 +369,14 @@ func _apply_select() -> void:
 func render() -> Image:
 	var out: Image = _background_image()
 	if _map == null:
+		return out
+	if _gen1:
+		for object: Array in _gen1_objects():
+			out.blend_rect(
+				object[0] as Image,
+				Rect2i(Vector2i.ZERO, (object[0] as Image).get_size()),
+				object[1] as Vector2i
+			)
 		return out
 	if _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
 		return _render_dex_area(out)
@@ -350,6 +430,10 @@ func shadow_oam() -> StringName:
 
 ## The landmarks the region on screen holds the species at, which is the list
 ## `.GetAndPlaceNest` last loaded.
+func nest_count() -> int:
+	return _gen1_drawn_nests().size() if _gen1 else current_nests().size()
+
+
 func current_nests() -> Array:
 	if _map == null or _map.region() >= _nests.size():
 		return []
@@ -396,7 +480,7 @@ func _refresh() -> void:
 		Gen2PicImage.show(_background, _background_image())
 		_background.size = Vector2(Gen2Screen.WIDTH, Gen2Screen.HEIGHT)
 	_refresh_arrow()
-	if _map != null and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
+	if _map != null and (_gen1 or _map.screen == Gen2TownMap.SCREEN_DEX_AREA):
 		_refresh_objects()
 		return
 	_refresh_player_icon()
@@ -405,8 +489,48 @@ func _refresh() -> void:
 
 ## The dex area's shadow OAM, which holds one of three things whole rather than
 ## a per-object position.
+## Every object the Generation 1 screen has up this frame, in shadow-OAM order
+## so the player's icon draws over what blinks under it: the nest set or the
+## cursor first, then the bird, then the player, who no blink ever hides.
+func _gen1_objects() -> Array:
+	var out: Array = []
+	if _map.screen == Gen2TownMap.SCREEN_DEX_AREA and _oam != OAM_CLEARED:
+		var nest: Image = _gen1_nest_image()
+		for nested: int in _gen1_drawn_nests():
+			out.append([nest, _gen1_nest_position(nested)])
+	elif _map.screen == Gen2TownMap.SCREEN_FLY:
+		out.append([_gen1_bird_image(), _icon_position(_map.cursor)])
+	elif _oam != OAM_CLEARED:
+		out.append([_cursor_image(), _icon_position(_map.cursor)])
+	out.append([_player_image(), _icon_position(_map.player_landmark)])
+	return out
+
+
+## `.loop`'s own two refusals, and what `.exitLoop`'s `ld a, l / and a` counts:
+## a zero, which is both a duplicate the list cleared and PALLET_TOWN's own id,
+## and Cerulean Cave, named by the coordinates its entry carries.
+func _gen1_drawn_nests() -> Array:
+	var out: Array = []
+	for nested: int in _gen1_nests:
+		var entry: Dictionary = _data.landmark(nested)
+		if nested == 0 or entry.is_empty() \
+			or int(entry.get("packed", -1)) == Gen1Layout.TOWN_MAP_SKIP_COORDS:
+			continue
+		out.append(nested)
+	return out
+
+
+func _gen1_nest_position(at_map: int) -> Vector2i:
+	var entry: Dictionary = _data.landmark(at_map)
+	return Vector2i(int(entry.get("x", 0)), int(entry.get("y", 0))) \
+		- Gen1Layout.TOWN_MAP_NEST_ORIGIN
+
+
 func _refresh_objects() -> void:
 	if _cursor_icon == null or _player_icon == null:
+		return
+	if _gen1:
+		_refresh_gen1_objects()
 		return
 	_cursor_icon.visible = false
 	_player_icon.visible = _oam == OAM_PLAYER and _map != null \
@@ -426,6 +550,26 @@ func _refresh_objects() -> void:
 			continue
 		node.position = Vector2(_nest_position(landmark))
 		Gen2PicImage.show(node, icon)
+
+
+## [method _gen1_objects] over the nodes this screen keeps, the last of which is
+## always the player.
+func _refresh_gen1_objects() -> void:
+	var objects: Array = _gen1_objects()
+	var player: Array = objects.pop_back()
+	_player_icon.visible = true
+	_player_icon.position = Vector2(player[1] as Vector2i)
+	Gen2PicImage.show(_player_icon, player[0] as Image)
+	_cursor_icon.visible = false
+	while _nest_icons.size() < objects.size():
+		_nest_icons.append(_sprite())
+	for index: int in _nest_icons.size():
+		var node: TextureRect = _nest_icons[index]
+		node.visible = index < objects.size()
+		if not node.visible:
+			continue
+		node.position = Vector2((objects[index] as Array)[1] as Vector2i)
+		Gen2PicImage.show(node, (objects[index] as Array)[0] as Image)
 
 
 ## Up only on the Pokegear's own card: `OverworldTownMap`, the fly map and the
@@ -450,9 +594,20 @@ func _background_image() -> Image:
 	if _page == null or _map == null or _data == null:
 		return Image.create(Gen2Screen.WIDTH, Gen2Screen.HEIGHT, false, Image.FORMAT_RGBA8)
 	var codes: PackedByteArray = _header_codes()
+	var region: PackedByteArray = _data.town_map_region(
+		Gen2TownMap.region_name(_map.region())
+	)
+	if _gen1:
+		return _page.image(_data, _page.gen1_tilemap(
+			region, codes, _map.screen, {
+				"row_cleared": _map.row_cleared,
+				"arrow_hidden": _map.arrow_hidden,
+				"area_unknown": _map.screen == Gen2TownMap.SCREEN_DEX_AREA \
+					and _gen1_drawn_nests().is_empty(),
+			}
+		), false, _map.screen)
 	return _page.image(_data, _page.tilemap(
-		_data.town_map_region(Gen2TownMap.region_name(_map.region())),
-		codes, _map.screen, _cards
+		region, codes, _map.screen, _cards
 	), _female, _map.screen)
 
 
@@ -462,6 +617,10 @@ func _header_codes() -> PackedByteArray:
 	if _map.screen != Gen2TownMap.SCREEN_DEX_AREA:
 		return _data.landmark(cursor_landmark()).get("codes", PackedByteArray())
 	var species_name: String = String(_data.species(_species).get("name", ""))
+	if _gen1:
+		var gen1: PackedByteArray = Gen1Text.encode(species_name)
+		gen1.append_array(Gen1Text.encode(GEN1_NEST_HEADER_SUFFIX))
+		return gen1
 	var out: PackedByteArray = Gen2Text.encode(species_name)
 	out.append_array(Gen2Text.encode(NEST_HEADER_SUFFIX))
 	return out
@@ -477,7 +636,21 @@ func _refresh_cursor() -> void:
 
 
 func _cursor_image() -> Image:
+	if _gen1:
+		return _icon_from(GEN1_CURSOR_SHEET, 0)
 	return _icon_from("pokegear_sprites", CURSOR_TILE)
+
+
+## `MonNestIcon`, one 1bpp tile `FarCopyDataDouble` doubles into the same four
+## the cursor was copied over.
+func _gen1_nest_image() -> Image:
+	return _tile_image(GEN1_NEST_SHEET, NEST_TILE)
+
+
+## `SPRITE_BIRD`, whose first four tiles `LoadTownMap_Fly` copies to the cursor's
+## own `vSprites tile $04` and draws with the same OAM writer.
+func _gen1_bird_image() -> Image:
+	return _overworld_icon(GEN1_BIRD_SPRITE)
 
 
 ## One 16x16 object out of a tile strip, as the four tiles from [param first].
@@ -517,10 +690,12 @@ func _refresh_player_icon() -> void:
 
 
 func _player_image() -> Image:
-	var blank := Image.create(ICON_SIZE, ICON_SIZE, false, Image.FORMAT_RGBA8)
-	blank.fill(Color(0, 0, 0, 0))
 	if _data == null:
-		return blank
+		return _blank_icon()
+	if _gen1:
+		# `DrawPlayerOrBirdSprite` writes the four tiles once, so no icon on any
+		# of the three Generation 1 screens walks.
+		return _overworld_icon(Gen2WorldSprite.player_normal_sprite(false))
 	@warning_ignore("integer_division")
 	var step: int = (_frames / WALK_FRAME_LENGTH) % WALK_FRAMES.size()
 	if _map != null and _map.screen == Gen2TownMap.SCREEN_DEX_AREA:
@@ -529,16 +704,24 @@ func _player_image() -> Image:
 		step = 0
 	if _map != null and _map.player_landmark == Gen2WorldRadio.fast_ship_landmark(_map.crystal):
 		return _fast_ship_image(step)
-	var number: int = Gen2WorldSprite.player_normal_sprite(_female)
+	return _overworld_icon(
+		Gen2WorldSprite.player_normal_sprite(_female), WALK_FRAMES[step]
+	)
+
+
+func _blank_icon() -> Image:
+	var blank := Image.create(ICON_SIZE, ICON_SIZE, false, Image.FORMAT_RGBA8)
+	blank.fill(Color(0, 0, 0, 0))
+	return blank
+
+
+func _overworld_icon(number: int, frame: int = 0) -> Image:
 	var sprite: Gen2WorldSprite = _data.overworld_sprite(number)
 	if sprite == null:
-		return blank
+		return _blank_icon()
 	return Gen2WorldSprite.image_for(
-		sprite,
-		_data.overworld_sprite_indices(number),
-		_player_palette(),
-		Gen2WorldSprite.FACING_DOWN,
-		WALK_FRAMES[step],
+		sprite, _data.overworld_sprite_indices(number), _player_palette(),
+		Gen2WorldSprite.FACING_DOWN, frame,
 	)
 
 
@@ -554,7 +737,11 @@ func _fast_ship_image(step: int) -> Image:
 ## `PokedexNestIconGFX`, drawn with the same object palette every other icon on
 ## these screens takes.
 func _nest_image() -> Image:
-	var tiles: PackedByteArray = _data.tile_indices("dex_nest_icon") if _data != null \
+	return _tile_image("dex_nest_icon", NEST_TILE)
+
+
+func _tile_image(sheet: String, tile: int) -> Image:
+	var tiles: PackedByteArray = _data.tile_indices(sheet) if _data != null \
 		else PackedByteArray()
 	var palette: PackedColorArray = _object_palette()
 	var out: PackedInt32Array = Gen2PicImage.canvas(NEST_ICON_SIZE, NEST_ICON_SIZE)
@@ -563,7 +750,7 @@ func _nest_image() -> Image:
 	@warning_ignore("integer_division")
 	Gen2PicImage.blit_tile(
 		out, NEST_ICON_SIZE, NEST_ICON_SIZE, tiles,
-		tiles.size() / PokeTiles.TILE_PIXELS, NEST_TILE, 0, 0,
+		tiles.size() / PokeTiles.TILE_PIXELS, tile, 0, 0,
 		Gen2PicImage.lookup(palette), false, false, 0
 	)
 	return Gen2PicImage.canvas_image(out, NEST_ICON_SIZE, NEST_ICON_SIZE)
@@ -580,6 +767,12 @@ func _nest_position(landmark: int) -> Vector2i:
 func _object_palette(slot: int = OBJECT_PALETTE) -> PackedColorArray:
 	if _data == null:
 		return PackedColorArray()
+	if _gen1:
+		# `GBPalNormal`'s `rOBP0` over the one row `PalPacket_TownMap` names, so
+		# an icon wears the map's own colours and colour 0 is transparent.
+		return Gen2WorldPalette.gen1_object_colors(
+			_data.world_palette(Gen1Layout.PAL_TOWNMAP)
+		)
 	return _data.overworld_sprite_palette(slot, _time_of_day)
 
 

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -488,6 +488,7 @@ func _init(
 	inventory = Gen2WorldInventory.new(data, state)
 	state.ensure_roaming_mons(data.world_roaming_mons())
 	current_map = map
+	_gen1_mark_town_visited()
 	_map_placements = {}
 	_connected_objects = []
 	block_revision += 1
@@ -519,6 +520,10 @@ func landmark() -> int:
 ## on every visit. `SetCaughtData` tests POKECENTER_2F by name rather than the
 ## landmark, and the two agree everywhere a caught mon can be made.
 func landmark_backup() -> int:
+	## `LoadTownMapEntry` takes `wCurMap` itself, so a Generation 1 map is its own
+	## landmark and the four routines below need no backup to reach one.
+	if data != null and data.generation == RomRegistry.GEN1:
+		return current_map.number if current_map != null else 0
 	var here: int = landmark()
 	if here != Gen2WorldRadio.LANDMARK_SPECIAL or backup_warp.is_empty() or data == null:
 		return here
@@ -3722,6 +3727,7 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"player_coord": &"_gen1_node_player_coord",
 	"walk": &"_gen1_node_walk",
 	"day_care": &"_gen1_node_day_care",
+	"town_map": &"_gen1_node_town_map",
 }
 
 
@@ -4028,6 +4034,15 @@ func _gen1_node_walk(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
 	steps.append({
 		"type": &"walk", "direction": int(node["direction"]), "steps": int(node["steps"]),
 	})
+	return true
+
+
+## `farcall DisplayTownMap`, which the bookshelf poster and the TOWN MAP item
+## both reach. The screen is the whole of the step: it takes B and leaves.
+func _gen1_node_town_map(_node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"request", "values": {
+		"kind": &"town_map_requested", "values": {"landmark": landmark_backup()},
+	}})
 	return true
 
 
@@ -7996,6 +8011,7 @@ func _apply_map(
 	state.clear_flash_if_outdoors(target_map.environment)
 	_command_queue_slots = _empty_command_queue_slots()
 	current_map = target_map
+	_gen1_mark_town_visited()
 	_map_placements = {}
 	_connected_objects = []
 	block_revision += 1
@@ -8168,11 +8184,74 @@ func warp_to_spawn(index: int, entry: int = MAP_ENTRY_WARP) -> Dictionary:
 ## `FlyFunction`'s `.TryFly`: the badge and the map, which is everything it can
 ## refuse on before the region map is drawn. The choice itself belongs to
 ## whoever draws that map; [method warp_to_spawn] is what answers it.
+## `MarkTownVisitedAndLoadToggleableObjects`' own first half: any map under
+## `FIRST_ROUTE_MAP` marks its bit, which is the list the fly map walks.
+func _gen1_mark_town_visited() -> void:
+	if not _gen1 or state == null or current_map == null \
+		or current_map.number >= Gen1Layout.FIRST_ROUTE_MAP:
+		return
+	state.set_engine_flag(
+		Gen1Layout.engine_flag_base("town_visited") + current_map.number, true
+	)
+
+
+## `BuildFlyLocationsList`: one entry a town, its own map id where the bit is set
+## and `NOT_VISITED` where it is not.
+func gen1_visited_towns() -> PackedInt32Array:
+	var out := PackedInt32Array()
+	var base: int = Gen1Layout.engine_flag_base("town_visited")
+	for town: int in Gen1Layout.NUM_CITY_MAPS:
+		out.append(
+			town if state != null and state.is_engine_flag_active(base + town)
+			else Gen1Layout.TOWN_MAP_NOT_VISITED
+		)
+	return out
+
+
+## `.fly`: the THUNDERBADGE, then `CheckIfInOutsideMap` rather than a map
+## environment, and `wFlyLocationsList` in place of the visited flypoints.
+func _gen1_fly_request() -> Dictionary:
+	if not state.is_engine_flag_active(Gen2WorldState.BADGE_ENGINE_FLAGS[
+		Gen2WorldState.KANTO_BADGE_FIRST + Gen1Layout.THUNDERBADGE
+	]):
+		return _fly_failure(&"badge_required")
+	if not Gen1Layout.is_outside_tileset(current_map.tileset):
+		return _fly_failure(&"indoors")
+	return {
+		"ok": true,
+		"kind": &"fly_requested",
+		"move": Gen2WorldFieldMove.MOVE_FLY,
+		"towns": gen1_visited_towns(),
+	}
+
+
+## `.usedFlyWarp`: the destination's own `FlyWarpDataPtr` record, which is a tile
+## on a map the overworld tileset always draws.
+func gen1_fly_to(map: int) -> Dictionary:
+	var landing: Dictionary = data.gen1_fly_warp(map) if data != null else {}
+	var target_map: Gen2WorldMap = data.world_map(0, map) if not landing.is_empty() else null
+	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
+		if target_map != null else null
+	if target_map == null or target_tileset == null:
+		return {"ok": false, "kind": &"fly_warp", "reason": &"missing_map"}
+	var from_map: Vector2i = map_id()
+	_apply_map(
+		target_map, target_tileset,
+		Vector2i(int(landing["x"]), int(landing["y"])), false, 0, MAP_ENTRY_FLY
+	)
+	return {
+		"ok": true, "kind": &"fly_warp", "from_map": from_map,
+		"to_map": map_id(), "to_cell": player_cell,
+	}
+
+
 func fly_request() -> Dictionary:
 	if current_map == null:
 		return _fly_failure(&"missing_map")
 	if field_move_source(Gen2WorldFieldMove.MOVE_FLY).is_empty():
 		return _fly_failure(&"move_not_known")
+	if _gen1:
+		return _gen1_fly_request()
 	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
 		Gen2WorldFieldMove.BADGE_STORM, Gen2WorldState.is_crystal_profile(data)
 	)):

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -283,6 +283,23 @@ static func nests(
 	return out
 
 
+## `FindWildLocationsOfMon` with `ZeroOutDuplicatesInList` behind it: the maps
+## whose grass or water table holds the species, in `WildDataPointers`' own
+## order and once each. The duplicate pass writes a zero, which is PALLET_TOWN's
+## id, so `DisplayWildLocations` refuses that map its icon.
+static func gen1_nests(data: GameData, species: int) -> Array:
+	var out: Array = []
+	if data == null or species < 1:
+		return out
+	for map: int in Gen1Layout.map_count(data.id):
+		for method: StringName in [METHOD_GRASS, &"water"]:
+			if out.has(map):
+				continue
+			if _holds_species(data.world_encounter(method, 0, map), species):
+				out.append(map)
+	return out
+
+
 ## `.SearchMapForMon` over every slot the record carries: `NUM_GRASSMON * 3`
 ## walks the three times of day as one run, and water's own three follow.
 static func _holds_species(row: Dictionary, species: int) -> bool:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -6240,6 +6240,7 @@ func _on_start_menu_action(kind: StringName, id: StringName = &"") -> void:
 	_reopen_start_menu = kind in [
 		Gen2WorldStartMenu.ITEM_POKEMON, Gen2WorldStartMenu.ITEM_POKEGEAR,
 		Gen2WorldStartMenu.ITEM_PLAYER, Gen2WorldStartMenu.ITEM_POKEDEX,
+		Gen2WorldStartMenu.ITEM_TOWN_MAP,
 		Gen2ModHost.START_ACTION_OPEN_BILLS_PC,
 		Gen2ModHost.START_ACTION_OPEN_MOD_PAGE,
 	]
@@ -6256,6 +6257,8 @@ func _on_start_menu_action(kind: StringName, id: StringName = &"") -> void:
 			_open_trainer_card()
 		Gen2WorldStartMenu.ITEM_POKEDEX:
 			_open_pokedex()
+		Gen2WorldStartMenu.ITEM_TOWN_MAP:
+			_open_town_map_overlay()
 		Gen2WorldStartMenu.ITEM_QUIT:
 			## `StartMenu_Quit`'s `FarQueueScript
 			## BugCatchingContestReturnToGateScript` and the 4 it returns, which
@@ -7231,34 +7234,64 @@ func _open_service_overlay(kind: StringName) -> void:
 	_refresh_labels()
 
 
-## `_FlyMap` as its own overlay, and the warp its answer asks for. A cancel
-## leaves the player where they were, which is what `.illegal` does with the
-## `-1` a B press writes.
-func _open_fly_map(request: Dictionary) -> void:
-	if _service_host != null or _world == null or _data == null:
-		return
-	var host: Gen2WorldServiceScreen = SERVICE_SCENE.instantiate() as Gen2WorldServiceScreen
+## `ItemUseTownMap`: the same overlay the poster opens, with nothing behind it
+## to answer. `.ItemMenuLoop` returns to the bag; the menu the row was chosen
+## from is what reopens here, the way the bag's own POKéDEX row does.
+func _open_town_map_overlay() -> void:
+	var host: Gen2WorldServiceScreen = _service_overlay()
 	if host == null:
-		_script_prompt = "Region map scene unavailable"
-		_refresh_labels()
 		return
-	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	host.z_index = 20
-	host.set_screen(_screen)
-	add_child(host)
-	var save: Gen2SaveData = _injected_save if _injected_save != null \
-		else _selected_runtime_save()
-	if not host.open_fly_map(_world, _data, save, request):
+	if not host.open_town_map(_world, _data, _overlay_save()):
 		Gen2Screen.drop(host)
 		_script_prompt = "Region map unavailable"
 		_refresh_labels()
 		return
+	_adopt_service_overlay(host, "Town map open")
+
+
+## `_FlyMap` as its own overlay, and the warp its answer asks for. A cancel
+## leaves the player where they were, which is what `.illegal` does with the
+## `-1` a B press writes.
+func _open_fly_map(request: Dictionary) -> void:
+	var host: Gen2WorldServiceScreen = _service_overlay()
+	if host == null:
+		return
+	if not host.open_fly_map(_world, _data, _overlay_save(), request):
+		Gen2Screen.drop(host)
+		_script_prompt = "Region map unavailable"
+		_refresh_labels()
+		return
+	_adopt_service_overlay(host, "Fly: choose a town")
+
+
+## The service host the two region-map overlays are drawn in, added and sized but
+## not yet opened. Null when one is already up or the scene will not load.
+func _service_overlay() -> Gen2WorldServiceScreen:
+	if _service_host != null or _world == null or _data == null:
+		return null
+	var host: Gen2WorldServiceScreen = SERVICE_SCENE.instantiate() as Gen2WorldServiceScreen
+	if host == null:
+		_script_prompt = "Region map scene unavailable"
+		_refresh_labels()
+		return null
+	host.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	host.z_index = 20
+	host.set_screen(_screen)
+	add_child(host)
+	return host
+
+
+func _overlay_save() -> Gen2SaveData:
+	return _injected_save if _injected_save != null else _selected_runtime_save()
+
+
+func _adopt_service_overlay(host: Gen2WorldServiceScreen, prompt: String) -> void:
 	host.save_action = persist_world_snapshot
 	host.completed.connect(_on_service_completed)
 	host.sfx_requested.connect(_play_sfx)
 	host.cry_requested.connect(_play_species_cry)
 	_service_host = host
-	_script_prompt = "Fly: choose a town"
+	_script_prompt = prompt
 	_refresh_labels()
 
 
@@ -7342,8 +7375,11 @@ func _advance_fly() -> void:
 		return
 	var spawn: int = int(_pending_fly["spawn"])
 	## `newloadmap MAPSETUP_FLY`, whose setup script opens on `JumpRoamMons`: a
-	## flight scatters the beasts rather than stepping them.
-	var warped: Dictionary = _world.warp_to_spawn(spawn, Gen2WorldAPI.MAP_ENTRY_FLY)
+	## flight scatters the beasts rather than stepping them. Generation 1's own
+	## answer is the destination map, which `.usedFlyWarp` lands on directly.
+	var warped: Dictionary = _world.gen1_fly_to(spawn) \
+		if _data != null and _data.generation == RomRegistry.GEN1 \
+		else _world.warp_to_spawn(spawn, Gen2WorldAPI.MAP_ENTRY_FLY)
 	if not bool(warped.get("ok", false)):
 		_finish_fly()
 		return

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -3317,6 +3317,21 @@ func _close_card() -> void:
 	_pokegear = null
 
 
+## `ItemUseTownMap`, the poster read out of the bag: the same screen with no
+## runtime request behind it, so closing it answers nothing and the host reopens
+## whatever it came from.
+func open_town_map(world: Gen2WorldAPI, data: GameData, save: Gen2SaveData) -> bool:
+	_world = world
+	_data = data
+	_save = save
+	_persist = false
+	if _world == null or _data == null:
+		_show_error("The region map has no world or cartridge cache.")
+		return false
+	_open_town_map(false)
+	return _town_map != null
+
+
 ## `_FlyMap` opened as an overlay of its own: the region map with the flypoint
 ## cursor, and nothing of the Pokegear around it.
 ##
@@ -3342,6 +3357,13 @@ func open_fly_map(
 	_town_map.set_screen(_service_hardware)
 	add_child(_town_map)
 	_town_map.closed.connect(_on_town_map_closed)
+	if _data.generation == RomRegistry.GEN1:
+		var towns := PackedInt32Array()
+		for town: Variant in request.get("towns", []):
+			towns.append(int(town))
+		if not _town_map.open_gen1_fly(_data, _world.landmark_backup(), towns):
+			_on_town_map_closed()
+		return true
 	var visited: Array[int] = []
 	for index: Variant in request.get("visited", []):
 		visited.append(int(index))
@@ -3373,7 +3395,9 @@ func _open_town_map(from_request: bool) -> void:
 	# The Pokegear's own MAP card when the Pokegear opened it, `_TownMap`'s
 	# corner box when `OverworldTownMap` did.
 	var owned: Array = Gen2PokegearScreen.owned_card_ids(_world.state)
-	var screen: StringName = Gen2TownMap.SCREEN_TOWN_MAP if from_request \
+	# Generation 1 has no Pokegear, so `_TownMap`'s own screen is every caller's.
+	var screen: StringName = Gen2TownMap.SCREEN_TOWN_MAP \
+		if from_request or _data.generation == RomRegistry.GEN1 \
 		else Gen2TownMap.SCREEN_POKEGEAR_CARD
 	var opened: bool = _town_map.open(
 		_data,

--- a/game/world/world_start_menu.gd
+++ b/game/world/world_start_menu.gd
@@ -19,6 +19,9 @@ const ENGINE_POKEGEAR: int = 4
 const ENGINE_POKEDEX: int = 11
 
 const ITEM_POKEDEX: StringName = &"pokedex"
+## `ItemUseTownMap`, which is a bag row rather than a start menu one: Generation
+## 1 has no Pokegear, so the poster in the pack is the only way to the map.
+const ITEM_TOWN_MAP: StringName = &"town_map"
 const ITEM_POKEMON: StringName = &"pokemon"
 const ITEM_PACK: StringName = &"pack"
 const ITEM_POKEGEAR: StringName = &"pokegear"

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1494 lines of it, and
-## Generation 1 has added 1604 more to the shared code: 150 the battle animation
-## engine, 140 the transition, 130 the Pokedex, 108 the three PCs, 95 the
-## trainer card, 85 the party menu, 42 the status screen, 40 the bag in a
-## battle, 20 the map callbacks, 9 the scripted walk, 66 the Day-Care.
-const MAX_COMMENT_LINES: int = 40768
+## files cost: `game/gen1` and its neighbours are 1535 lines of it, and
+## Generation 1 has added 1762 more to the shared code: 152 the region map, 150
+## the battle animation engine, 140 the transition, 130 the Pokedex, 108 the
+## three PCs, 95 the trainer card, 85 the party menu, 66 the Day-Care, 42 the
+## status screen, 40 the bag in a battle, 29 the map callbacks and the walk.
+const MAX_COMMENT_LINES: int = 40967
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_town_map.gd
+++ b/tests/unit/test_town_map.gd
@@ -1,8 +1,14 @@
 extends GutTest
 
-## `_TownMap`'s region choice and cursor walk, which is all of the region map
-## that is not pixels. The page and the imported art are covered by
+## `_TownMap`'s region choice and cursor walk, and `DisplayTownMap`'s own walk
+## over `TownMapOrder` beside it, which is all of the region map that is not
+## pixels. The page and the imported art are covered by
 ## `tools/preview_town_map.gd` against a real cache.
+
+## `TownMapOrder`'s own head: PALLET_TOWN, ROUTE_1, VIRIDIAN_CITY, ROUTE_2.
+const GEN1_ORDER: Array[int] = [0, 12, 1, 13]
+## OAKS_LAB, which is an indoor map standing on Pallet Town's own point.
+const GEN1_OAKS_LAB: int = 40
 
 
 func test_johto_window_is_the_whole_region_and_the_cursor_wraps() -> void:
@@ -162,3 +168,52 @@ func test_a_fly_map_with_nothing_visited_holds_its_default() -> void:
 	for press: int in [PokeButton.UP, PokeButton.DOWN, PokeButton.UP]:
 		map.press(press)
 		assert_eq(map.cursor, 0)
+
+
+func test_the_generation_1_map_opens_on_wcurmap_with_the_order_still_at_zero() -> void:
+	## `.enterLoop` draws the cursor on `wCurMap` while `wWhichTownMapLocation`
+	## is zero, so the first UP press walks to the order's second row.
+	var map := Gen2TownMap.create_gen1(GEN1_OAKS_LAB, PackedInt32Array(GEN1_ORDER))
+	assert_eq(map.region(), Gen2TownMap.REGION_KANTO)
+	assert_eq(map.cursor, GEN1_OAKS_LAB)
+	assert_eq(map.player_landmark, GEN1_OAKS_LAB)
+	assert_false(map.row_cleared)
+
+	map.press(PokeButton.UP)
+	assert_eq(map.cursor, GEN1_ORDER[1])
+	assert_true(map.row_cleared)
+	assert_eq(map.arrow_hidden, 0)
+
+
+func test_the_generation_1_cursor_wraps_both_ways_round_the_order() -> void:
+	var map := Gen2TownMap.create_gen1(0, PackedInt32Array(GEN1_ORDER))
+	map.press(PokeButton.DOWN)
+	assert_eq(map.cursor, GEN1_ORDER[GEN1_ORDER.size() - 1])
+	assert_eq(map.arrow_hidden, 1)
+	map.press(PokeButton.UP)
+	assert_eq(map.cursor, GEN1_ORDER[0])
+	## Neither LEFT nor A moves it: `.inputLoop` watches four buttons and the
+	## d-pad's other axis is not among them.
+	assert_false(map.press(PokeButton.LEFT))
+	assert_eq(map.cursor, GEN1_ORDER[0])
+
+
+func test_the_generation_1_fly_walk_skips_a_town_that_was_not_visited() -> void:
+	## `BuildFlyLocationsList` with Pallet, Pewter and Cerulean visited.
+	var towns := PackedInt32Array([
+		0, Gen1Layout.TOWN_MAP_NOT_VISITED, 2, 3,
+		Gen1Layout.TOWN_MAP_NOT_VISITED, Gen1Layout.TOWN_MAP_NOT_VISITED,
+	])
+	var map := Gen2TownMap.fly_gen1(0, towns)
+	assert_eq(map.cursor, 0)
+	map.press(PokeButton.UP)
+	assert_eq(map.cursor, 2)
+	map.press(PokeButton.UP)
+	assert_eq(map.cursor, 3)
+	## `.wrapToStartOfList` skips the unvisited test, and the first town is the
+	## one the source leaves reachable regardless.
+	map.press(PokeButton.UP)
+	assert_eq(map.cursor, 0)
+	## `.pressedDown` keeps skipping through the wrap, where UP does not.
+	map.press(PokeButton.DOWN)
+	assert_eq(map.cursor, 3)

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -181,10 +181,9 @@ const HIDDEN_CENSUS: Dictionary = {
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
 		"map_text": 5, "choice": 3, "unknown": 2, "dex_count": 1},
 }
-## Of `BookshelfTileIDs`' 17 rows, all but two decode: `TownMapText` ends in
-## `DisplayTownMap`, a screen this port has not imported, and the Indigo Plateau
+## Of `BookshelfTileIDs`' 17 rows, all but one decode: the Indigo Plateau
 ## statues read `wXCoord` for which of their two boxes they answer with.
-const BOOKSHELF_COUNTS: Dictionary = {&"red": 15, &"blue": 15, &"yellow": 15}
+const BOOKSHELF_COUNTS: Dictionary = {&"red": 16, &"blue": 16, &"yellow": 16}
 const CARD_KEY_FLOORS: int = 10
 ## `gated` is every map whose script opens on `wCurrentMapScriptFlags` and
 ## `read` the ones whose body decodes whole; `blocks` counts the

--- a/tools/checks/gen1_pics.gd
+++ b/tools/checks/gen1_pics.gd
@@ -52,13 +52,11 @@ const MAX_MONEY: int = 9900
 ## `ChiefPic:` falls through to `ScientistPic`, so rows 27 and 28 are one picture.
 const SHARED_PIC_ROWS: Array[int] = [27, 28]
 
-## SHA-1 of each tile strip. All three cartridges hold the one font and the one
-## text box; re-earn these against `gfx/font/font.png` and `font_extra.png`.
 ## SHA-1 of each tile strip. All three cartridges hold the same five; re-earn
 ## these against `gfx/font/font.png`, `font_extra.png`, `font_battle_extra.png`,
-## `gfx/battle/battle_hud_*.png`, `gfx/pokedex/pokedex.png` and the trainer
-## card's own three. `BlankLeaderNames` runs on into `CircleTile`, so its digest
-## is over both files.
+## `gfx/battle/battle_hud_*.png`, `gfx/pokedex/pokedex.png`, `gfx/town_map`'s
+## own four and the trainer card's three. `BlankLeaderNames` runs on into
+## `CircleTile`, so its digest is over both files.
 const SHEET_DIGESTS: Dictionary = {
 	"font": "8146fe98bbbd27f9d67509e3da62044b44785a3a",
 	"font_extra": "ca0735bbbf8d2ce178a3f06a8d95ac6395dc8f7e",
@@ -69,6 +67,10 @@ const SHEET_DIGESTS: Dictionary = {
 	"trainer_card_box": "4cbd04d3a6bc75710d26612068ed8ed71b1262b8",
 	"trainer_card_names": "b308184b958a914e70f6f034a28a13fe06b43b24",
 	"badge_numbers": "b2a864c62c1d5c5e50e372fa83b704178e41fcf0",
+	"world_map": "0777b341fe67d856c28a89bd2a64a0ef2cd1e001",
+	"town_map_cursor": "9ac3640b61003d3d45528ec1c599f9f885685261",
+	"town_map_nest": "c3b5073e7202abe208484e48ca065b2c3f393e49",
+	"town_map_arrow": "baf477ca6150473ffce09097a62a86f6b6cbdaf7",
 }
 ## `gfx/trainer_card/badges.2bpp` is the one card sheet the two pins disagree
 ## on: Yellow redrew Brock's and Misty's faces and left both their badges and

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -57,6 +57,18 @@ const PALLET_HOUSE_SIGN := Vector2i(3, 6)
 const PALLET_GIRL := Vector2i(3, 9)
 const PALLET_GIRL_TEXT: String = "I'm raising\nPOKéMON too!"
 
+## Blue's house and the poster on its wall, which is the one bookshelf row that
+## opens a screen. `_TownMapText` is what its own box says.
+const BLUES_HOUSE: int = 39
+const TOWN_MAP_POSTER_TILE: int = 0x3D
+## `text_promptbutton` behind the string, which is the page break the stream
+## keeps rather than a second box.
+const TOWN_MAP_POSTER_BOX: String = "A TOWN MAP." + Gen2TextStream.PAGE_BREAK
+## A party that knows FLY, and `FlyWarpDataPtr.ViridianCity`'s own tile.
+const FLY_SPECIES: Array[int] = [16]
+const FLY_MOVES: Array = [[Gen2WorldFieldMove.MOVE_FLY, 0, 0, 0]]
+const VIRIDIAN_FLY_CELL := Vector2i(23, 26)
+
 ## `ViridianMart_Object`'s clerk, who stands at 0,5 behind the counter at 1,5.
 ## `.extendRangeOverCounter` is what lets the player at 2,5 reach them.
 const VIRIDIAN_MART: int = 42
@@ -314,6 +326,8 @@ func _one_game() -> void:
 	_check_a_bookshelf()
 	_check_a_card_key_door()
 	_check_the_day_care()
+	_check_the_town_map_poster()
+	_check_flying()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -1656,6 +1670,67 @@ func _check_a_bookshelf() -> void:
 	if beside != null:
 		beside.player_facing = Gen2WorldSprite.FACING_RIGHT
 		_r.check(beside.interact().is_empty(), "the shelf answered from the side.")
+
+
+## `bookshelf_tile HOUSE, $3D, TownMapText`: the poster in Blue's house, whose
+## box is followed by the region map rather than by another line.
+func _check_the_town_map_poster() -> void:
+	var shelf: Vector2i = _tile_cell(BLUES_HOUSE, [TOWN_MAP_POSTER_TILE])
+	if not _r.check(shelf.x >= 0, "no town map poster tile is in Blue's house."):
+		return
+	var world: Gen2WorldAPI = _facing_up(BLUES_HOUSE, shelf + Vector2i.DOWN)
+	if world == null:
+		return
+	var box: String = _box_text(world)
+	if not _r.check(box == TOWN_MAP_POSTER_BOX, "the poster said %s." % [box]):
+		return
+	world.run_event_queue(true)
+	var request: Dictionary = world.pending_runtime_request()
+	_r.check(
+		StringName(request.get("kind", &"")) == &"town_map_requested",
+		"the poster asked for %s." % [request.get("kind", &"nothing")]
+	)
+
+
+## `.fly`: the THUNDERBADGE, `CheckIfInOutsideMap`, and `.usedFlyWarp` landing
+## the player on the destination's own `FlyWarpDataPtr` tile.
+func _check_flying() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, PALLET_TOWN, PALLET_DOOR)
+	if world == null:
+		return
+	world.set_party_summary(1, false, FLY_SPECIES, FLY_MOVES)
+	_r.check(
+		StringName(world.fly_request().get("reason", &"")) == &"badge_required",
+		"flying was allowed with no THUNDERBADGE."
+	)
+	world.state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
+		Gen2WorldState.KANTO_BADGE_FIRST + Gen1Layout.THUNDERBADGE
+	], true)
+	var request: Dictionary = world.fly_request()
+	if not _r.check(bool(request.get("ok", false)), "flying was refused outdoors."):
+		return
+	var towns: Array = request.get("towns", [])
+	_r.check(
+		towns.size() == Gen1Layout.NUM_CITY_MAPS and int(towns[0]) == PALLET_TOWN
+			and int(towns[1]) == Gen1Layout.TOWN_MAP_NOT_VISITED,
+		"the fly list read %s." % [towns]
+	)
+	var landed: Dictionary = world.gen1_fly_to(VIRIDIAN_CITY)
+	_r.check(
+		bool(landed.get("ok", false)) and world.player_cell == VIRIDIAN_FLY_CELL,
+		"flying to Viridian landed on %s." % [world.player_cell]
+	)
+	var indoors: Gen2WorldAPI = _r.open_world(0, REDS_HOUSE_1F, REDS_HOUSE_MAT)
+	if indoors == null:
+		return
+	indoors.set_party_summary(1, false, FLY_SPECIES, FLY_MOVES)
+	indoors.state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
+		Gen2WorldState.KANTO_BADGE_FIRST + Gen1Layout.THUNDERBADGE
+	], true)
+	_r.check(
+		StringName(indoors.fly_request().get("reason", &"")) == &"indoors",
+		"flying was allowed out of a house."
+	)
 
 
 ## The first cell of [param map] drawing a tile `BookshelfTileIDs` names.

--- a/tools/checks/town_map.gd
+++ b/tools/checks/town_map.gd
@@ -54,6 +54,27 @@ const CARD_TEXTS: Dictionary = {
 const SHADOW_OAM_SPRITES: int = 40
 
 
+## `LoadTownMapEntry` end to end: the external table's own first row, the first
+## indoor map, the last one Silph Co.'s group covers, and Cerulean Cave, whose
+## packed pair `DisplayWildLocations` refuses a nest icon by.
+const GEN1_PALLET_TOWN: int = 0
+const GEN1_LANDMARK_PINS: Array[Array] = [
+	[0x00, "PALLET TOWN", 0xB2], [0x25, "PALLET TOWN", 0xB2],
+	[0xEB, "SILPH CO.", 0x5A], [0xE4, "CERULEAN CAVE", 0x19],
+]
+## The places `TownMapOrder`'s 47 rows stand on: MT_MOON_1F and ROUTE_4 share
+## Mt. Moon's own entry, which is why the walk shows one fewer.
+const GEN1_ORDER_PLACES: int = 47
+## `FindWildLocationsOfMon` on the two ends: PIKACHU stands in the Viridian
+## Forest and the Power Plant, and in no wild table at all on Yellow, which hands
+## one over instead; MEW is nowhere on any of the three.
+const GEN1_NEST_PINS: Dictionary = {
+	&"red": [[25, 2], [151, 0]],
+	&"blue": [[25, 2], [151, 0]],
+	&"yellow": [[25, 0], [151, 0]],
+}
+
+
 func run(r: RefCounted) -> void:
 	_r = r
 	for game_id: StringName in _r.GAME_IDS:
@@ -70,6 +91,207 @@ func run(r: RefCounted) -> void:
 		_verify_nests(game_id, _data, crystal)
 		_verify_flypoints(game_id, _data)
 		_verify_cards(game_id, _data)
+	_r.each_game_of(RomRegistry.GEN1, _one_gen1_game)
+
+
+## `LoadTownMap` and the three screens over it, on Red, Blue and Yellow. What
+## only a real cache can say is that `CompressedMap`'s runs fill the screen out
+## of the sixteen tiles it has, that `LoadTownMapEntry` resolves every map id
+## either table names, and that `FindWildLocationsOfMon` finds the species the
+## cartridge's own wild tables hold.
+func _one_gen1_game() -> void:
+	_gen1_region()
+	_gen1_landmarks()
+	_gen1_cursor_walk()
+	_gen1_fly_walk()
+	_gen1_nests()
+	_gen1_screens()
+
+
+func _gen1_region() -> void:
+	var cells: PackedByteArray = _r.data.town_map_region(
+		Gen2TownMap.region_name(Gen2TownMap.REGION_KANTO)
+	)
+	if not _r.check(
+		cells.size() == Gen1Layout.WORLD_MAP_CELLS,
+		"the region map decoded to %d cells." % cells.size()
+	):
+		return
+	var outside: int = 0
+	for cell: int in cells:
+		if cell < Gen1Layout.WORLD_MAP_FIRST_CODE 			or cell >= Gen1Layout.WORLD_MAP_FIRST_CODE + Gen1Layout.WORLD_MAP_TILES:
+			outside += 1
+	_r.check(outside == 0, "%d cells name a tile the sheet has not." % outside)
+	_r.check(
+		_r.data.town_map_palette(0).size() == PokePalette.COLORS_PER_PIC,
+		"PAL_TOWNMAP decoded to %d colours." % _r.data.town_map_palette(0).size()
+	)
+
+
+## Every map id `LoadTownMapEntry` answers for, and the four rows pinned by hand:
+## the external table's first, the internal walk's own first row above
+## `FIRST_INDOOR_MAP`, the deepest indoor map, and Cerulean Cave, whose packed
+## coordinates are what `DisplayWildLocations` refuses an icon by.
+func _gen1_landmarks() -> void:
+	var count: int = Gen1Layout.map_count(_r.data.id)
+	_r.check(
+		_r.data.landmark_count() == count,
+		"%d landmark rows for %d maps." % [_r.data.landmark_count(), count]
+	)
+	var offscreen: int = 0
+	var unnamed: int = 0
+	for map: int in count:
+		var entry: Dictionary = _r.data.landmark(map)
+		if _r.data.landmark_name(map).is_empty():
+			unnamed += 1
+		var at := Vector2i(int(entry.get("x", -1)), int(entry.get("y", -1)))
+		if at.x < 0 or at.y < 0 or at.x >= Gen2Screen.WIDTH or at.y >= Gen2Screen.HEIGHT:
+			offscreen += 1
+	_r.check(unnamed == 0, "%d map ids resolved to no name." % unnamed)
+	_r.check(offscreen == 0, "%d landmark points fall off the screen." % offscreen)
+	for pin: Array in GEN1_LANDMARK_PINS:
+		var entry: Dictionary = _r.data.landmark(int(pin[0]))
+		var name: String = _r.data.landmark_name(int(pin[0]))
+		_r.check(
+			name == String(pin[1]) and int(entry.get("packed", -1)) == int(pin[2]),
+			"map %d is %s at $%02x." % [int(pin[0]), name, int(entry.get("packed", -1))]
+		)
+
+
+## `.pressedUp` and `.pressedDown` over `TownMapOrder`: 47 presses come back to
+## the row the walk started on, and every row names a map the cache has.
+func _gen1_cursor_walk() -> void:
+	var order: PackedInt32Array = _r.data.town_map_order()
+	if not _r.check(
+		order.size() == Gen1Layout.TOWN_MAP_ORDER_COUNT,
+		"TownMapOrder decoded to %d rows." % order.size()
+	):
+		return
+	var missing: int = 0
+	for map: int in order:
+		if _r.data.world_map(0, map) == null:
+			missing += 1
+	_r.check(missing == 0, "%d order rows name a map the cache has not." % missing)
+	var walk: Gen2TownMap = Gen2TownMap.create_gen1(GEN1_PALLET_TOWN, order)
+	_r.check(
+		walk.cursor == GEN1_PALLET_TOWN and not walk.row_cleared,
+		"the map opened on %d rather than wCurMap." % walk.cursor
+	)
+	var seen: Dictionary = {}
+	for _press: int in order.size():
+		walk.press(PokeButton.UP)
+		seen[walk.cursor] = true
+	_r.check(
+		walk.row_index == 0 and walk.cursor == order[0],
+		"%d presses ended on row %d." % [order.size(), walk.row_index]
+	)
+	_r.check(
+		seen.size() == GEN1_ORDER_PLACES,
+		"the walk showed %d places of %d." % [seen.size(), GEN1_ORDER_PLACES]
+	)
+	walk.press(PokeButton.DOWN)
+	_r.check(
+		walk.row_index == order.size() - 1,
+		"one DOWN press from the first row landed on %d." % walk.row_index
+	)
+
+
+## `BuildFlyLocationsList` and the walk over it: with Pallet Town alone visited
+## every press stays there, and with all eleven the walk is a ring.
+func _gen1_fly_walk() -> void:
+	var lone := PackedInt32Array()
+	var every := PackedInt32Array()
+	for town: int in Gen1Layout.NUM_CITY_MAPS:
+		lone.append(town if town == 0 else Gen1Layout.TOWN_MAP_NOT_VISITED)
+		every.append(town)
+	var alone: Gen2TownMap = Gen2TownMap.fly_gen1(GEN1_PALLET_TOWN, lone)
+	alone.press(PokeButton.UP)
+	_r.check(alone.cursor == 0, "an unvisited walk reached map %d." % alone.cursor)
+	alone.press(PokeButton.DOWN)
+	_r.check(alone.cursor == 0, "an unvisited walk fell to map %d." % alone.cursor)
+	var full: Gen2TownMap = Gen2TownMap.fly_gen1(GEN1_PALLET_TOWN, every)
+	var seen: Dictionary = {}
+	for _press: int in Gen1Layout.NUM_CITY_MAPS:
+		full.press(PokeButton.UP)
+		seen[full.cursor] = true
+	_r.check(
+		seen.size() == Gen1Layout.NUM_CITY_MAPS and full.cursor == 0,
+		"the fly walk showed %d towns and ended on %d." % [seen.size(), full.cursor]
+	)
+	var landings: int = 0
+	for map: int in Gen1Layout.map_count(_r.data.id):
+		var landing: Dictionary = _r.data.gen1_fly_warp(map)
+		if landing.is_empty():
+			continue
+		landings += 1
+		var record: Gen2WorldMap = _r.data.world_map(0, map)
+		_r.check(
+			record != null and int(landing["x"]) < record.collision_width
+				and int(landing["y"]) < record.collision_height,
+			"map %d lands a flight at %s." % [map, landing]
+		)
+	_r.check(
+		landings == Gen1Layout.FLY_WARP_COUNT,
+		"FlyWarpDataPtr decoded to %d rows." % landings
+	)
+
+
+## `FindWildLocationsOfMon` over all 151 species: every map it names holds the
+## species in its own grass or water table, and no map is named twice.
+func _gen1_nests() -> void:
+	var wrong: int = 0
+	var total: int = 0
+	for species: int in range(1, Gen1Layout.SPECIES_COUNT + 1):
+		var nests: Array = Gen2WorldEncounter.gen1_nests(_r.data, species)
+		total += nests.size()
+		var seen: Dictionary = {}
+		for map: int in nests:
+			if seen.has(map) or not _gen1_map_holds(map, species):
+				wrong += 1
+			seen[map] = true
+	_r.check(wrong == 0, "%d nests name a map with no such wild slot." % wrong)
+	_r.note("gen1 nests %s: %d over 151 species" % [_r.game_id, total])
+	for pin: Array in GEN1_NEST_PINS[_r.game_id] as Array:
+		var found: int = Gen2WorldEncounter.gen1_nests(_r.data, int(pin[0])).size()
+		_r.check(found == int(pin[1]), "species %d has %d nests." % [int(pin[0]), found])
+
+
+func _gen1_map_holds(map: int, species: int) -> bool:
+	for method: StringName in [Gen2WorldEncounter.METHOD_GRASS, &"water"]:
+		for slot: Variant in _r.data.world_encounter(method, 0, map).get("slots", []) as Array:
+			if slot is Dictionary and int((slot as Dictionary).get("species", 0)) == species:
+				return true
+	return false
+
+
+## The three screens drawn: `DisplayTownMap` on the map the player stands on,
+## `LoadTownMap_Nest` for a species with no wild table, which is the AREA UNKNOWN
+## box, and `LoadTownMap_Fly`. The blink is what the cursor answers to.
+func _gen1_screens() -> void:
+	var host := Gen2TownMapScreen.new()
+	if not _r.check(host.open(_r.data, GEN1_PALLET_TOWN), "the map would not open."):
+		host.free()
+		return
+	var shown: int = host.render().get_used_rect().size.y
+	for _frame: int in Gen1Layout.TOWN_MAP_BLINK_FRAMES:
+		host.advance_frame()
+	_r.check(
+		host.shadow_oam() == Gen2TownMapScreen.OAM_CLEARED,
+		"the cursor was still up after %d frames." % Gen1Layout.TOWN_MAP_BLINK_FRAMES
+	)
+	_r.check(shown > 0, "the map drew an empty screen.")
+	_r.check(
+		host.open_gen1_dex_area(_r.data, Gen1Layout.SPECIES_COUNT, [], GEN1_PALLET_TOWN)
+			and host.nest_count() == 0,
+		"MEW's AREA screen drew a nest."
+	)
+	var towns := PackedInt32Array()
+	for town: int in Gen1Layout.NUM_CITY_MAPS:
+		towns.append(town)
+	_r.check(host.open_gen1_fly(_r.data, GEN1_PALLET_TOWN, towns), "the fly map would not open.")
+	host.handle_button(PokeButton.A)
+	_r.check(host.chosen_spawn() == 0, "A on the fly map chose %d." % host.chosen_spawn())
+	host.free()
 
 
 ## `Flypoints` and `SpawnPoints` against the cache they were imported beside: every

--- a/tools/preview_pokedex.gd
+++ b/tools/preview_pokedex.gd
@@ -51,6 +51,8 @@ const GEN1_ROUTES: Dictionary = {
 	"unseen": "d,d,d",
 	"side": "a",
 	"entry": "a,a",
+	# `.choseArea`, which is the side menu's third row.
+	"area": "a,d,d,a",
 }
 
 

--- a/tools/preview_town_map.gd
+++ b/tools/preview_town_map.gd
@@ -4,8 +4,9 @@ extends SceneTree
 ##   Godot --headless --path . -s res://tools/preview_town_map.gd -- \
 ##       crystal /tmp/map.png [landmark] [card|clock|phone|radio|area:<species>|fly[:all]] [presses]
 ## [landmark] is `TownMap_GetCurrentLandmark`'s answer, which picks the region and
-## where the player icon stands. `hof` widens the Kanto window, `sel`/`rel` press and
-## release the dex area's held SELECT, and `f<n>` spends n frames for the nest blink.
+## where the player icon stands, and a map id on a Generation 1 cache. `hof` widens
+## the Kanto window, `sel`/`rel` press and release the dex area's held SELECT, and
+## `f<n>` spends n frames for the nest blink.
 
 ## Where a card preview's world stands, which is what its clock, dial and contact
 ## list are read from.
@@ -71,8 +72,14 @@ func _initialize() -> void:
 	if species > 0:
 		print("Wrote %s: %s'S NEST, region %s, %d nests, player at landmark %d %s" % [
 			args[1], data.species(species).get("name", "?"), region,
-			host.current_nests().size(), landmark,
+			host.nest_count(), landmark,
 			data.landmark_name(landmark).replace(" ", "_"),
+		])
+	elif data.generation == RomRegistry.GEN1:
+		print("Wrote %s: map %d, cursor %d %s, row %d of %d" % [
+			args[1], landmark, host.cursor_landmark(),
+			host.cursor_name().replace(" ", "_"),
+			host.map().row_index, host.map().rows.size(),
 		])
 	else:
 		print("Wrote %s: landmark %d, region %s, cursor %d %s, window %d..%d" % [
@@ -115,6 +122,8 @@ func _open(
 	host: Gen2TownMapScreen, data: GameData, species: int, landmark: int,
 	hall_of_fame: bool, mode: String
 ) -> bool:
+	if data.generation == RomRegistry.GEN1:
+		return _open_gen1(host, data, species, landmark, mode)
 	if mode.begins_with("fly"):
 		var visited: Array[int] = []
 		if mode == "fly:all":
@@ -140,6 +149,27 @@ func _open(
 		Gen2TownMap.SCREEN_POKEGEAR_CARD if mode == "card" else Gen2TownMap.SCREEN_TOWN_MAP,
 		[&"map", &"phone", &"radio"] as Array,
 	)
+
+
+## Generation 1's three screens, where the landmark argument is a map id.
+## `fly` visits Pallet Town alone, so the walk shows every other town skipped;
+## `fly:all` visits them all.
+func _open_gen1(
+	host: Gen2TownMapScreen, data: GameData, species: int, landmark: int, mode: String
+) -> bool:
+	if mode.begins_with("fly"):
+		var towns := PackedInt32Array()
+		for town: int in Gen1Layout.NUM_CITY_MAPS:
+			towns.append(
+				town if town == 0 or mode == "fly:all"
+				else Gen1Layout.TOWN_MAP_NOT_VISITED
+			)
+		return host.open_gen1_fly(data, landmark, towns)
+	if species > 0:
+		return host.open_gen1_dex_area(
+			data, species, Gen2WorldEncounter.gen1_nests(data, species), landmark
+		)
+	return host.open(data, landmark)
 
 
 ## The Pokegear's other three cards, driven the way the service host drives them:


### PR DESCRIPTION
`LoadTownMap` draws one screen out of `CompressedMap`'s run-length rows over `WorldMapTileGraphics`' sixteen tiles at $60, coloured by `PalPacket_TownMap` under a `BlkPacket_WholeScreen`, so every cell wears the same four. `LoadTownMapEntry` is flattened at import into one landmark a map id: below `FIRST_INDOOR_MAP` the external table is indexed directly and above it the internal one is walked to the first row whose group byte is greater, which is why every indoor map of Pallet Town stands on Pallet Town's point.

`TownMapCursor`, `MonNestIcon` and `SPRITE_BIRD` all stand at `vSprites tile $04`, and the player's own overworld sheet at tile 0. `TownMapSpriteBlinkingAnimation` hides 36 of the 40 shadow-OAM sprites for 25 frames of every 50, so the cursor and the nests blink and the player, who sits above that range, does not.

`DisplayTownMap` opens on `wCurMap` while `wWhichTownMapLocation` still stands at zero, so the first UP press walks to `TownMapOrder`'s second row and the first DOWN to its last. `LoadTownMap_Nest` is `FindWildLocationsOfMon` with `ZeroOutDuplicatesInList` behind it, and `DisplayWildLocations` refuses an icon to a zero, which is both a cleared duplicate and PALLET_TOWN's own id, and to Cerulean Cave, named by the packed coordinates its entry carries; a species with no icon gets the AREA UNKNOWN box. `LoadTownMap_Fly` walks `BuildFlyLocationsList`'s eleven towns, skipping an unvisited one in the direction pressed, and `.wrapToStartOfList` skips that test.

Four callers reach it: `TownMapText`, the poster on the HOUSE tileset's $3D bookshelf; `ItemUseTownMap` from the bag; the Pokedex's AREA row; and `.fly`, gated on the THUNDERBADGE and `CheckIfInOutsideMap`, whose answer is a map id `.usedFlyWarp` lands on through `FlyWarpDataPtr`'s thirteen rows. `MarkTownVisitedAndLoadToggleableObjects`' own first half is a `town_visited` engine-flag run, set on entering any map under `FIRST_ROUTE_MAP`.

## Fixed on the way

- The bag's TOWN MAP row answered with `ItemUseNotTime`'s OAK refusal.
- The Pokedex's AREA row drew nothing and landed straight back on the listing.
- `bookshelf_tile HOUSE, $3D, TownMapText` decoded to no nodes and was dropped, so `gen1_maps.gd`'s bookshelf census read 15 of 17 rows; it reads 16 now, and the comment that named the missing screen is gone.
- `Gen2TownMapPage._draw_string` encoded through `Gen2Text` rather than through the page's own font, so a Generation 1 string would have taken Crystal's codes.
- The same per-code loop was written out three times in that file and is one helper now.
- `world_screen.gd`'s two region-map overlays shared eleven lines of host setup; they share one helper now.

## Measurements

| Run | Result |
|---|---|
| `gut` unit tier | 3861 tests, 0 failures |
| `gut` whole tree | 4479 tests, 0 failures |
| `validate.gd -- all` | every topic passes |
| `--warning-scan` | 0 warnings in 634 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | no failed step |
| Import, six cartridges | `Layout verified.` on each |

The cache format moves to 120: the manifest carries the region map, the landmark table, `TownMapOrder` and `FlyWarpDataPtr` beside four new tile sheets, so every cartridge is re-imported.