### PR TITLE
Fall through a Generation 1 dungeon hole and pull an Escape Rope

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -70,6 +70,7 @@ var _text_bg_palette: Array = []
 var _presents_palettes: Dictionary = {}
 var _title: Dictionary = {}
 var _town_map: Dictionary = {}
+var _special_warps: Dictionary = {}
 var _oak_ratings: Dictionary = {}
 var _pokecenter_pc: Dictionary = {}
 var _decorations: Dictionary = {}
@@ -188,6 +189,7 @@ const MANIFEST_DICTIONARIES: Dictionary = {
 	"presents_palettes": "_presents_palettes",
 	"title": "_title",
 	"town_map": "_town_map",
+	"special_warps": "_special_warps",
 	"oak_ratings": "_oak_ratings",
 	"pokecenter_pc": "_pokecenter_pc",
 	"decorations": "_decorations",
@@ -2591,6 +2593,25 @@ func gen1_fly_warp(map: int) -> Dictionary:
 				"y": int((row as Dictionary).get("y", 0)),
 			}
 	return {}
+
+
+## `.dungeonWarpListLoop`: the `DungeonWarpData` tile hole [param warp] falling
+## onto [param map] lands on. Empty for a pair the list does not hold, which is
+## Victory Road 3F's switch alone and which the source walks off the end for.
+func gen1_dungeon_warp(map: int, warp: int) -> Dictionary:
+	for row: Variant in _special_warps.get("dungeon_warps", []) as Array:
+		var entry: Dictionary = row
+		if int(entry.get("map", -1)) == map and int(entry.get("warp", -1)) == warp:
+			return {"x": int(entry.get("x", 0)), "y": int(entry.get("y", 0))}
+	return {}
+
+
+## `EscapeRopeTilesets` or `SafariZoneRestHouses`, each a `db` list to a `-1`.
+func gen1_special_warp_list(name: String) -> PackedInt32Array:
+	var out := PackedInt32Array()
+	for value: Variant in _special_warps.get(name, []) as Array:
+		out.append(int(value))
+	return out
 
 
 func landmark_count() -> int:

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -801,6 +801,7 @@ func import_rom(
 		"vending": _import_vending(rom, layout, items),
 		"prizes": _import_prizes(rom, layout),
 		"town_map": _import_town_map(rom, layout),
+		"special_warps": _import_special_warps(rom, layout),
 		"complete": true,
 	}
 	if not RomCache.write_json(RomCache.manifest_path(directory), manifest):
@@ -1078,6 +1079,36 @@ func _import_mart_text(rom: RomFile, layout: Dictionary) -> Dictionary:
 		out[name] = facility_text(rom, Gen1Layout.facility_text_offset(
 			layout, "mart_text", Gen1Layout.MART_TEXT_AT, name
 		))
+	return out
+
+
+## `LoadSpecialWarpData`'s dungeon warp pair flattened onto one row each, with
+## the two lists `ItemUseEscapeRope` and `SetLastBlackoutMap` walk beside them.
+func _import_special_warps(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout["dungeon_warps"])
+	var rows: Array = []
+	while rom.u8(at) != Gen1Layout.TILESET_LIST_END:
+		rows.append({"map": rom.u8(at), "warp": rom.u8(at + 1)})
+		at += Gen1Layout.DUNGEON_WARP_ROW_SIZE
+	at += 1
+	for index: int in rows.size():
+		var record: int = at + index * Gen1Layout.DUNGEON_WARP_DATA_SIZE \
+			+ Gen1Layout.FLY_WARP_RECORD_AT
+		(rows[index] as Dictionary)["y"] = rom.u8(record)
+		(rows[index] as Dictionary)["x"] = rom.u8(record + 1)
+	return {
+		"dungeon_warps": rows,
+		"escape_rope_tilesets": _byte_list(rom, int(layout["escape_rope_tilesets"])),
+		"rest_houses": _byte_list(rom, int(layout["rest_houses"])),
+	}
+
+
+## A `db`-per-row table ended by the `-1` every one of Generation 1's carries.
+func _byte_list(rom: RomFile, at: int) -> Array:
+	var out: Array = []
+	while rom.u8(at) != Gen1Layout.TILESET_LIST_END:
+		out.append(rom.u8(at))
+		at += 1
 	return out
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -713,6 +713,18 @@ const FLY_WARP_RECORD_AT: int = 2
 ## `wBeatGymFlags`' own bit for the badge `.fly` asks for.
 const THUNDERBADGE: int = 2
 
+## `LoadSpecialWarpData`'s other pair. A `DungeonWarpList` row is a destination
+## map and a hole index; `DungeonWarpData`'s row at the same place is a `fly_warp`.
+const DUNGEON_WARP_ROW_SIZE: int = 2
+const DUNGEON_WARP_DATA_SIZE: int = 6
+## `ItemUseEscapeRope`'s one refusal by map, in front of `EscapeRopeTilesets`.
+const AGATHAS_ROOM: int = 0xF7
+## PALLET_TOWN, which is map 0 and so what a zeroed `wLastBlackoutMap` names.
+const PALLET_TOWN: int = 0x00
+## `PlayMapChangeSound`'s `cp $0b`, the OVERWORLD door tile it parts
+## SFX_GO_INSIDE from SFX_GO_OUTSIDE by on every map.
+const OVERWORLD_DOOR_TILE: int = 0x0B
+
 ## `NOT_VISITED`, which `BuildFlyLocationsList` writes for a town the player has
 ## not been to, and `.townMapFlyLoop`'s own `ld c, 15` between two draws.
 const TOWN_MAP_NOT_VISITED: int = 0xFE
@@ -1380,6 +1392,13 @@ const RED_BLUE: Dictionary = {
 	"display_town_map": 0x70E3E,
 	"town_map_text": 0x0FC12,
 	"fly_warps": 0x06448,
+	## `LoadSpecialWarpData` and `ItemUseEscapeRope`: the dungeon warp tables, the
+	## tilesets a rope may be pulled on and the rest houses that record no map.
+	"dungeon_warps": 0x063BF,
+	"escape_rope_tilesets": 0x0DFFD,
+	"rest_houses": 0x07092,
+	"which_dungeon_warp": 0xD71E,
+	"dungeon_warp_destination": 0xD71D,
 	"battle_font": 0x11EA0,
 	"battle_hud_1": 0x12080,
 	"battle_hud_2": 0x12098,
@@ -1583,6 +1602,11 @@ const YELLOW: Dictionary = {
 	"display_town_map": 0x70EB4,
 	"town_map_text": 0x0FAA0,
 	"fly_warps": 0x061BC,
+	"dungeon_warps": 0x06133,
+	"escape_rope_tilesets": 0x0DE28,
+	"rest_houses": 0x06F0A,
+	"which_dungeon_warp": 0xD71D,
+	"dungeon_warp_destination": 0xD71C,
 	"battle_font": 0x10A20,
 	"battle_hud_1": 0x10C00,
 	"battle_hud_2": 0x10C18,

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -21,6 +21,13 @@ const MAP_LOAD_PREFIXES: Array[int] = [
 const MAP_LOAD_HELD_LIMIT: int = 4
 ## `ld hl, .GateCoordinates` and the two card key calls behind it.
 const CARD_KEY_PROLOGUE_SIZE: int = 3 * Gen1Layout.SCRIPT_LONG_SIZE
+## Where a map header keeps its script pointer.
+const MAP_SCRIPT_AT: int = 7
+## `jr nz, .fellDownHoleTo1F` hops the one `ld a, n` behind it, and how far past
+## the call the pick may sit.
+const DUNGEON_PICK_BRANCH: int = 0x20
+const DUNGEON_PICK_HOP: int = 2
+const DUNGEON_PICK_WINDOW: int = 32
 
 
 static func verify_layout(rom: RomFile) -> Dictionary:
@@ -131,10 +138,13 @@ static func read_world(
 		rom, int(layout["silph_map_list"]), Gen1Layout.SILPH_MAP_LIST_MAX
 	)
 	var map_count: int = Gen1Layout.map_count(rom.id)
+	var script_ends: Dictionary = _script_ends(rom, layout, map_count)
 	for map_id: int in map_count:
 		if not Gen1Layout.is_real_map(map_id):
 			continue
-		var map: Dictionary = _read_map(rom, layout, tilesets, map_id, card_key_floors)
+		var map: Dictionary = _read_map(
+			rom, layout, tilesets, map_id, card_key_floors, int(script_ends[map_id])
+		)
 		if not bool(map.get("ok", false)):
 			return map
 		map.erase("ok")
@@ -632,7 +642,7 @@ static func _bit_count(value: int) -> int:
 ## One map header, the blocks it draws and the object block behind it.
 static func _read_map(
 	rom: RomFile, layout: Dictionary, tilesets: Array, map_id: int,
-	card_key_floors: PackedByteArray
+	card_key_floors: PackedByteArray, script_end: int
 ) -> Dictionary:
 	var bank: int = Gen1Layout.map_bank(rom, layout, map_id)
 	var header: int = Gen1Layout.map_header_offset(rom, layout, map_id)
@@ -684,7 +694,7 @@ static func _read_map(
 	_carry_trainer_headers(events["objects"], texts)
 	_carry_toggleable_objects(rom, layout, events["objects"], map_id)
 	var callback: Dictionary = _read_map_callback(
-		rom, layout, bank, rom.u16le(header + 7), card_key_floors.has(map_id)
+		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), card_key_floors.has(map_id)
 	)
 
 	return {
@@ -704,7 +714,7 @@ static func _read_map(
 		"connections": connections,
 		"scripts": {
 			"bank": bank,
-			"address": rom.u16le(header + 7),
+			"address": rom.u16le(header + MAP_SCRIPT_AT),
 			"scenes": [],
 			"callbacks": [] if callback.is_empty() else [callback],
 		},
@@ -717,11 +727,110 @@ static func _read_map(
 			"bg_events": events["bg_events"],
 			"objects": events["objects"],
 			"hidden_events": _read_hidden_events(
-				rom, layout, map_id, bank, rom.u16le(header + 7)
+				rom, layout, map_id, bank, rom.u16le(header + MAP_SCRIPT_AT)
 			),
 			"card_key": _card_key_doors(callback),
+			"dungeon_holes": _read_dungeon_holes(
+				rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), script_end
+			),
 		},
 	}
+
+
+## Where each map's script stops: the next script start in the same bank, or the
+## bank's end. A map's own tables sit behind its script in the file they share.
+static func _script_ends(rom: RomFile, layout: Dictionary, map_count: int) -> Dictionary:
+	var banks: Dictionary = {}
+	for map_id: int in map_count:
+		if not Gen1Layout.is_real_map(map_id):
+			continue
+		var bank: int = Gen1Layout.map_bank(rom, layout, map_id)
+		var rows: Array = banks.get(bank, [])
+		rows.append([
+			rom.u16le(Gen1Layout.map_header_offset(rom, layout, map_id) + MAP_SCRIPT_AT),
+			map_id,
+		])
+		banks[bank] = rows
+	var out: Dictionary = {}
+	for bank: int in banks:
+		var rows: Array = banks[bank]
+		rows.sort()
+		for index: int in rows.size():
+			out[int((rows[index] as Array)[1])] = 2 * RomFile.BANK_SIZE \
+				if index + 1 == rows.size() else int((rows[index + 1] as Array)[0])
+	return out
+
+
+## `IsPlayerOnDungeonWarp` and the copy Pokemon Mansion 3F keeps of it both open
+## `xor a` / `ld [wWhichDungeonWarp], a`, which is what the `ld hl, <coords>` and
+## the call behind it are found by. The per-frame half of a map script has no
+## interpreter here, so the block is read out of the script's own bytes.
+static func _read_dungeon_holes(
+	rom: RomFile, layout: Dictionary, bank: int, script: int, script_end: int
+) -> Array:
+	for pc: int in range(script, script_end - 2 * Gen1Layout.SCRIPT_LONG_SIZE):
+		var at: int = Gen1Layout.banked(bank, pc)
+		if rom.u8(at) != Gen1Layout.SCRIPT_LD_HL \
+			or rom.u8(at + Gen1Layout.SCRIPT_LONG_SIZE) not in [
+				Gen1Layout.SCRIPT_JP, Gen1Layout.SCRIPT_CALL,
+			]:
+			continue
+		var routine: int = Gen1Layout.banked(
+			bank, rom.u16le(at + Gen1Layout.SCRIPT_LONG_SIZE + 1)
+		)
+		if rom.u8(routine) != Gen1Layout.SCRIPT_XOR_A \
+			or rom.u8(routine + 1) != Gen1Layout.SCRIPT_LD_MEM_A \
+			or rom.u16le(routine + 2) != int(layout["which_dungeon_warp"]):
+			continue
+		return _dungeon_holes(
+			rom, layout, bank, rom.u16le(at + 1), pc, pc + 2 * Gen1Layout.SCRIPT_LONG_SIZE
+		)
+	return []
+
+
+## The `dbmapcoord` list itself, each row carrying the map its own index falls to.
+static func _dungeon_holes(
+	rom: RomFile, layout: Dictionary, bank: int, coords: int, block: int, behind: int
+) -> Array:
+	var maps: Dictionary = _dungeon_destinations(rom, layout, bank, block, behind)
+	var out: Array = []
+	var at: int = Gen1Layout.banked(bank, coords)
+	while rom.u8(at) != Gen1Layout.MAP_COORD_END:
+		var index: int = out.size() + 1
+		out.append({
+			"y": rom.u8(at),
+			"x": rom.u8(at + 1),
+			"destination": int(maps.get(index, maps.get(0, -1))),
+		})
+		at += Gen1Layout.MAP_COORD_SIZE
+	return out
+
+
+## Which map each hole index falls to. Five maps write one in front of the block,
+## which is key 0; Pokemon Mansion 3F picks by index behind the call, which is
+## `.fellDownHoleTo1F`'s `cp n` / `ld a, m1` / `jr nz, +2` / `ld a, m2`.
+static func _dungeon_destinations(
+	rom: RomFile, layout: Dictionary, bank: int, block: int, behind: int
+) -> Dictionary:
+	var store: int = int(layout["dungeon_warp_destination"])
+	var ahead: int = Gen1Layout.banked(bank, block) - Gen1Layout.SCRIPT_LONG_SIZE \
+		- Gen1Layout.SCRIPT_SHORT_SIZE
+	if rom.u8(ahead) == Gen1Layout.SCRIPT_LD_A \
+		and rom.u8(ahead + 2) == Gen1Layout.SCRIPT_LD_MEM_A \
+		and rom.u16le(ahead + 3) == store:
+		return {0: rom.u8(ahead + 1)}
+	for pc: int in range(behind, behind + DUNGEON_PICK_WINDOW):
+		var at: int = Gen1Layout.banked(bank, pc)
+		if rom.u8(at) != Gen1Layout.SCRIPT_CP_N \
+			or rom.u8(at + 2) != Gen1Layout.SCRIPT_LD_A \
+			or rom.u8(at + 4) != DUNGEON_PICK_BRANCH \
+			or rom.u8(at + 5) != DUNGEON_PICK_HOP \
+			or rom.u8(at + 6) != Gen1Layout.SCRIPT_LD_A \
+			or rom.u8(at + 8) != Gen1Layout.SCRIPT_LD_MEM_A \
+			or rom.u16le(at + 9) != store:
+			continue
+		return {0: rom.u8(at + 3), rom.u8(at + 1): rom.u8(at + 7)}
+	return {}
 
 
 ## `RunMapScript` runs the whole of a map's script every frame, so the work a map

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 120
+const FORMAT_VERSION: int = 121
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -453,6 +453,8 @@ static func open_snapshot(
 	out.random_seed = world_snapshot.random_seed
 	out.frame_number = world_snapshot.frame_number
 	out.last_spawn_map = world_snapshot.last_spawn_map
+	out._gen1_last_map = world_snapshot.gen1_last_map
+	out._gen1_last_blackout_map = world_snapshot.gen1_last_blackout_map
 	out.dig_warp = world_snapshot.dig_warp.duplicate()
 	out.backup_warp = world_snapshot.backup_warp.duplicate()
 	## `.SpawnAfterE4` and `.AfterRed`, which stand between `ClockContinue` and
@@ -1465,7 +1467,7 @@ func surf_request(species: int = 0) -> Dictionary:
 		"move": Gen2WorldFieldMove.MOVE_SURF,
 		"cell": target,
 		"direction": direction,
-		"sprite": Gen2WorldFieldMove.surf_sprite(species),
+		"sprite": Gen2WorldFieldMove.surf_sprite(species, _gen1),
 	}
 	return _pending_surf.duplicate(true)
 
@@ -3662,6 +3664,11 @@ var _gen1: bool = false
 ## `wLastMap`, the outdoor map a [constant Gen1Layout.WARP_TO_LAST_MAP] warp
 ## comes back out to. Generation 2 has no such warp and never writes it.
 var _gen1_last_map: int = -1
+## `wLastBlackoutMap`, which `SetLastBlackoutMap` copies `wLastMap` into at the
+## Pokemon Center's YES. A blackout, an Escape Rope, Dig and Teleport all land
+## on its own `FlyWarpDataPtr` tile. A zeroed byte is PALLET_TOWN, which is what
+## a game that has healed nowhere lands on.
+var _gen1_last_blackout_map: int = Gen1Layout.PALLET_TOWN
 ## The [method GameData.special_text] run `DisplayPokemonCenterDialogue_`'s own
 ## boxes are imported under.
 const GEN1_POKECENTER_RUN: String = "pokecenter"
@@ -3763,6 +3770,10 @@ func collision_code_at(cell: Vector2i) -> int:
 ## `SetPal_Overworld` names no branch of its own. -1 until a warp writes it.
 func gen1_last_map() -> int:
 	return _gen1_last_map
+
+
+func gen1_last_blackout_map() -> int:
+	return _gen1_last_blackout_map
 
 
 ## `CheckForHiddenEventOrBookshelfOrCardKeyDoor` runs on the A press ahead of
@@ -4565,6 +4576,7 @@ func _gen1_nurse_steps() -> Array:
 			"type": &"choice",
 			"text": _gen1_pokecenter_text("shall_we_heal"),
 			"yes": [
+				{"type": &"blackout_map"},
 				_gen1_pokecenter_box("need_your_pokemon"),
 				{"type": &"request", "values": {
 					"kind": &"party_heal_requested", "values": {},
@@ -4881,6 +4893,16 @@ func _gen1_result() -> Array:
 	return [result]
 
 
+## `SetLastBlackoutMap`, whose whole body is the rest-house list: healing in one
+## of the Safari Zone's three leaves the map a blackout lands on where it was.
+## -1 is no outdoor map walked out of rather than a map id, and records nothing.
+func _gen1_record_blackout_map() -> void:
+	if current_map == null or data == null or _gen1_last_map < 0 \
+		or data.gen1_special_warp_list("rest_houses").has(current_map.number):
+		return
+	_gen1_last_blackout_map = _gen1_last_map
+
+
 ## `AfterDisplayingTextID` redraws the map behind the row, which takes a balance
 ## window down the way `closetext`'s redraw takes Generation 2's.
 func _gen1_close_money_window(events: Array) -> void:
@@ -4948,6 +4970,9 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 			return true
 		&"toggle":
 			gen1_toggle_object(int(step["index"]), bool(step["hidden"]))
+			return true
+		&"blackout_map":
+			_gen1_record_blackout_map()
 			return true
 		&"walk":
 			events.append_array(_gen1_walk_player(
@@ -7922,7 +7947,7 @@ func _apply_map_setup_player_state() -> void:
 
 func _map_setup_sprite(mode: StringName) -> int:
 	if mode == MOVEMENT_SURF:
-		return Gen2WorldSprite.SPRITE_SURF
+		return Gen2WorldFieldMove.surf_sprite(0, _gen1)
 	if mode == MOVEMENT_BIKE:
 		return Gen2WorldSprite.player_bike_sprite(_player_female)
 	return _walking_sprite()
@@ -8227,7 +8252,7 @@ func _gen1_fly_request() -> Dictionary:
 
 ## `.usedFlyWarp`: the destination's own `FlyWarpDataPtr` record, which is a tile
 ## on a map the overworld tileset always draws.
-func gen1_fly_to(map: int) -> Dictionary:
+func gen1_fly_to(map: int, entry: int = MAP_ENTRY_FLY) -> Dictionary:
 	var landing: Dictionary = data.gen1_fly_warp(map) if data != null else {}
 	var target_map: Gen2WorldMap = data.world_map(0, map) if not landing.is_empty() else null
 	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
@@ -8237,12 +8262,66 @@ func gen1_fly_to(map: int) -> Dictionary:
 	var from_map: Vector2i = map_id()
 	_apply_map(
 		target_map, target_tileset,
-		Vector2i(int(landing["x"]), int(landing["y"])), false, 0, MAP_ENTRY_FLY
+		Vector2i(int(landing["x"]), int(landing["y"])), false, 0, entry
 	)
 	return {
 		"ok": true, "kind": &"fly_warp", "from_map": from_map,
 		"to_map": map_id(), "to_cell": player_cell,
 	}
+
+
+## `IsPlayerOnDungeonWarp`: the hole [param cell] stands on, with the
+## `DungeonWarpData` tile it falls to. `.dungeonWarpListLoop` looks the pair up
+## by the map the floor's script wrote and the hole's one-based index; the pair
+## it does not hold is Victory Road 3F's switch, whose bits that floor clears.
+func gen1_dungeon_hole_at(cell: Vector2i) -> Dictionary:
+	if not _gen1 or current_map == null or data == null:
+		return {}
+	var rows: Array = current_map.events.get("dungeon_holes", [])
+	for index: int in rows.size():
+		var hole: Dictionary = rows[index]
+		if int(hole["x"]) != cell.x or int(hole["y"]) != cell.y:
+			continue
+		var landing: Dictionary = data.gen1_dungeon_warp(
+			int(hole["destination"]), index + 1
+		)
+		if landing.is_empty():
+			return {}
+		return {
+			"map": int(hole["destination"]), "warp": index + 1,
+			"x": int(landing["x"]), "y": int(landing["y"]),
+		}
+	return {}
+
+
+## `HandleFlyWarpOrDungeonWarp` behind the fall: the landing is
+## `DungeonWarpData`'s own record rather than a warp event on either map.
+func gen1_dungeon_fall() -> Dictionary:
+	var hole: Dictionary = gen1_dungeon_hole_at(player_cell)
+	if hole.is_empty():
+		return {}
+	var target_map: Gen2WorldMap = data.world_map(0, int(hole["map"]))
+	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
+		if target_map != null else null
+	if target_map == null or target_tileset == null:
+		return {"ok": false, "kind": &"dungeon_warp", "reason": &"missing_map"}
+	var from_map: Vector2i = map_id()
+	_apply_map(
+		target_map, target_tileset, Vector2i(int(hole["x"]), int(hole["y"])),
+		false, 0, MAP_ENTRY_FALL
+	)
+	return {
+		"ok": true, "kind": &"dungeon_warp", "from_map": from_map,
+		"warp": int(hole["warp"]), "to_map": map_id(), "to_cell": player_cell,
+	}
+
+
+## `PlayMapChangeSound`'s own test: `lda_coord 8, 8`, a row above every other
+## read, against the OVERWORLD door tile, whatever tileset the map wears.
+func gen1_entered_a_door() -> bool:
+	return _gen1 and _gen1_screen_tile(
+		Gen1Layout.SCREEN_PLAYER_COLUMN, Gen1Layout.SCREEN_PLAYER_ROW - 1
+	) == Gen1Layout.OVERWORLD_DOOR_TILE
 
 
 func fly_request() -> Dictionary:
@@ -8324,6 +8403,14 @@ func teleport_request() -> Dictionary:
 		return _teleport_failure(&"missing_map")
 	if party_slot_with_move(Gen2WorldFieldMove.MOVE_TELEPORT) < 0:
 		return _teleport_failure(&"move_not_known")
+	## `.teleport` asks `CheckIfInOutsideMap` and nothing else, so the map being
+	## a spawn point is Generation 2's question alone.
+	if _gen1:
+		if not Gen1Layout.is_outside_tileset(current_map.tileset):
+			return _teleport_failure(&"not_outdoors")
+		return _stage_escape(
+			&"teleport_requested", Gen2WorldFieldMove.MOVE_TELEPORT, -1
+		)
 	if not _is_outdoor(current_map.environment):
 		return _teleport_failure(&"not_outdoors")
 	var spawn: int = spawn_index_of(last_spawn_map)
@@ -8344,7 +8431,7 @@ func dig_request() -> Dictionary:
 		return _dig_failure(&"missing_map")
 	if party_slot_with_move(Gen2WorldFieldMove.MOVE_DIG) < 0:
 		return _dig_failure(&"move_not_known")
-	var checked: StringName = _check_can_dig()
+	var checked: StringName = _gen1_check_escape() if _gen1 else _check_can_dig()
 	if checked != &"":
 		return _dig_failure(checked)
 	return _stage_escape(&"dig_requested", Gen2WorldFieldMove.MOVE_DIG, -1)
@@ -8415,6 +8502,28 @@ static func _bike_failure(reason: StringName) -> Dictionary:
 	return {"ok": false, "kind": &"bike_failed", "reason": reason}
 
 
+## Where a blackout, an Escape Rope, Dig and Teleport all put the player down.
+## Generation 2 reads a spawn point; `LoadSpecialWarpData`'s `.usedEscapeWarp`
+## hands `.usedFlyWarp` `wLastBlackoutMap` instead. `Script_AbortBugContest` has
+## no Generation 1 counterpart, so the tail behind the warp is Generation 2's.
+func warp_to_escape_point(spawn: int, entry: int = MAP_ENTRY_WARP) -> Dictionary:
+	if not _gen1:
+		return warp_to_spawn(spawn, entry)
+	return gen1_fly_to(_gen1_last_blackout_map, entry)
+
+
+## `ItemUseEscapeRope`: no map environment is read at all. Agatha's room is
+## refused by name and `EscapeRopeTilesets` is the rest. `DigFunction` is the
+## same routine under the other type byte and asks exactly this.
+func _gen1_check_escape() -> StringName:
+	if current_map.number == Gen1Layout.AGATHAS_ROOM \
+		or not data.gen1_special_warp_list(
+			"escape_rope_tilesets"
+		).has(current_map.tileset):
+		return &"not_in_a_cave"
+	return &""
+
+
 ## `EscapeRopeFunction`, which is `EscapeRopeOrDig` with the other type byte: the
 ## same `.CheckCanDig` and the same `.DoDig`, without a move to know. The type
 ## only picks which text the queued script says and whether `.FailDig` says
@@ -8422,7 +8531,7 @@ static func _bike_failure(reason: StringName) -> Dictionary:
 func escape_rope_request() -> Dictionary:
 	if current_map == null:
 		return _escape_rope_failure(&"missing_map")
-	var checked: StringName = _check_can_dig()
+	var checked: StringName = _gen1_check_escape() if _gen1 else _check_can_dig()
 	if checked != &"":
 		return _escape_rope_failure(checked)
 	## `.escaperope`'s `farcall SpecialKabutoChamber`, which runs while the
@@ -8457,8 +8566,8 @@ func complete_escape() -> Dictionary:
 	var spawn: int = int(staged["spawn"])
 	## Dig and an Escape Rope both `newloadmap MAPSETUP_DOOR`, which
 	## [method warp_to_dig_point] carries; `.TeleportScript` names its own.
-	var warped: Dictionary = warp_to_spawn(spawn, MAP_ENTRY_TELEPORT) if spawn >= 0 \
-		else warp_to_dig_point()
+	var warped: Dictionary = warp_to_escape_point(spawn, MAP_ENTRY_TELEPORT) \
+		if spawn >= 0 or _gen1 else warp_to_dig_point()
 	if not bool(warped.get("ok", false)):
 		return {
 			"ok": false, "kind": &"escape_failed",

--- a/game/world/world_field_move.gd
+++ b/game/world/world_field_move.gd
@@ -211,7 +211,11 @@ static func is_hm_field_move(move: int) -> bool:
 ## GetSurfType through ChrisStateSprites. The source keeps the Pikachu variant
 ## as its own wPlayerState value and only the sprite differs, so the two lookups
 ## collapse into the one number a renderer needs.
-static func surf_sprite(species: int) -> int:
+## `LoadSurfingPlayerSpriteGraphics` is `SeelSprite` on all three Generation 1
+## cartridges, Yellow's included, and there is no variant of it.
+static func surf_sprite(species: int, gen1: bool = false) -> int:
+	if gen1:
+		return Gen2WorldSprite.SPRITE_SEEL
 	return Gen2WorldSprite.SPRITE_SURFING_PIKACHU if species == SPECIES_PIKACHU \
 		else Gen2WorldSprite.SPRITE_SURF
 

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -169,6 +169,10 @@ static func _events_from_cache(value: Variant) -> Dictionary:
 		"card_key": _event_rows(
 			event_values.get("card_key", []), ["x", "y", "block", "flag"]
 		),
+		# `IsPlayerOnDungeonWarp`'s own coordinate list, Generation 1's alone.
+		"dungeon_holes": _event_rows(
+			event_values.get("dungeon_holes", []), ["x", "y", "destination"]
+		),
 	}
 
 

--- a/game/world/world_party_host.gd
+++ b/game/world/world_party_host.gd
@@ -1215,7 +1215,7 @@ static func whiteout(
 	var before_money: int = world.state.money(0)
 	world.state.apply_changes({}, {}, {"money": {0: before_money >> 1}})
 	var spawn: int = world.whiteout_spawn()
-	var warped: Dictionary = world.warp_to_spawn(spawn)
+	var warped: Dictionary = world.warp_to_escape_point(spawn)
 	if not bool(warped.get("ok", false)):
 		return _failure(StringName(warped.get("reason", &"missing_spawn")), warped)
 	if persist and save != null:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -122,6 +122,8 @@ var _pending_step_events: Dictionary = {}
 ## empty on every other frame. The map swaps between the two stages, which is
 ## where the setup script's own list sits.
 var _map_fade: Dictionary = {}
+## Whether the fade in flight is a Generation 1 dungeon fall rather than a warp.
+var _pending_dungeon_fall: bool = false
 ## The fade one of the five fade specials is inside, `{ orders, white_fill,
 ## step_frames, step, frames }`, and the row it left behind once it is done. A
 ## `FadeOutToWhite` holds the screen white until its own `FadeInFromWhite` runs,
@@ -1776,6 +1778,13 @@ func _complete_player_step(movement: Dictionary) -> bool:
 		_zero_map_name_sign_timer()
 		_start_map_fade()
 		return true
+	## `RunMapScript` sets the dungeon warp bit and `OverworldLoop` reads it
+	## behind `CheckWarpsNoCollision`, so a cell that is both takes the warp.
+	if not _world.gen1_dungeon_hole_at(_world.player_cell).is_empty():
+		_zero_map_name_sign_timer()
+		_pending_dungeon_fall = true
+		_start_map_fade()
+		return true
 	return _after_map_settled()
 
 
@@ -2894,13 +2903,20 @@ func script_fade() -> Dictionary:
 ## `MapSetupScript_Door`'s `FadeOutToWhite` is the first thing the setup script
 ## spends: four palette orders, two frames each, before anything is loaded.
 func _start_map_fade() -> void:
-	_play_sfx(_warp_sfx())
+	var sfx: int = _warp_sfx()
+	if sfx >= 0:
+		_play_sfx(sfx)
 	_map_fade = {"stage": &"out", "step": 0, "frames": Gen2WorldPalette.FADE_STEP_FRAMES}
 	_apply_map_fade_step()
 
 
-## `GetWarpSFX`, off `wPlayerTileCollision`.
+## `GetWarpSFX`, off `wPlayerTileCollision`. Generation 1 has no such table:
+## `PlayMapChangeSound` reads one tile and the fall's own anim plays nothing.
 func _warp_sfx() -> int:
+	if _pending_dungeon_fall:
+		return -1
+	if _data != null and _data.generation == RomRegistry.GEN1:
+		return SFX_ENTER_DOOR if _world.gen1_entered_a_door() else SFX_EXIT_BUILDING
 	match _world.collision_code_at(_world.player_cell):
 		COLL_DOOR:
 			return SFX_ENTER_DOOR
@@ -3017,7 +3033,10 @@ func _clear_script_fade() -> void:
 ## screen at its whitest, and `FadeToMapMusic` is the eight-step fade the new
 ## map's track arrives behind rather than a restart.
 func _swap_warped_map() -> void:
-	var transition: Dictionary = _world.try_warp()
+	var falling: bool = _pending_dungeon_fall
+	_pending_dungeon_fall = false
+	var transition: Dictionary = _world.gen1_dungeon_fall() if falling \
+		else _world.try_warp()
 	if not bool(transition.get("ok", false)):
 		return
 	_clear_script_fade()

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -44,6 +44,11 @@ var frame_number: int = 0
 ## which reads as a game that has entered no Pokemon Center and no cave.
 var last_spawn_map: Vector2i = Vector2i(-1, -1)
 var dig_warp: Dictionary = {}
+## `wLastMap` and `wLastBlackoutMap`, saved player data Generation 1 alone keeps:
+## the outdoor map an indoor one comes back out to, and the one a blackout, an
+## Escape Rope, Dig and Teleport land beside. PALLET_TOWN is the zeroed byte's.
+var gen1_last_map: int = -1
+var gen1_last_blackout_map: int = Gen1Layout.PALLET_TOWN
 ## `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`, which
 ## `SavePlayerData` copies into `sCurMapData` alongside the dig warp: where the
 ## stairs out of a Pokemon Center's second floor lead and whose landmark that
@@ -76,6 +81,8 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.random_seed = world.random_seed
 	out.frame_number = world.frame_number
 	out.last_spawn_map = world.last_spawn_map
+	out.gen1_last_map = world.gen1_last_map()
+	out.gen1_last_blackout_map = world.gen1_last_blackout_map()
 	out.dig_warp = world.dig_warp.duplicate()
 	out.backup_warp = world.backup_warp.duplicate()
 	out.spawn_after_champion = world.spawn_after_champion
@@ -97,6 +104,8 @@ func to_dict() -> Dictionary:
 		"random_seed": random_seed,
 		"frame_number": frame_number,
 		"last_spawn_map": [last_spawn_map.x, last_spawn_map.y],
+		"gen1_last_map": gen1_last_map,
+		"gen1_last_blackout_map": gen1_last_blackout_map,
 		"dig_warp": dig_warp.duplicate(),
 		"backup_warp": backup_warp.duplicate(),
 		"spawn_after_champion": spawn_after_champion,
@@ -132,6 +141,10 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 	out.random_seed = int(source.get("random_seed", 0))
 	out.frame_number = maxi(0, int(source.get("frame_number", 0)))
 	out.last_spawn_map = _vector_from_value(source.get("last_spawn_map", [-1, -1]))
+	out.gen1_last_map = int(source.get("gen1_last_map", -1))
+	out.gen1_last_blackout_map = int(source.get(
+		"gen1_last_blackout_map", Gen1Layout.PALLET_TOWN
+	))
 	out.dig_warp = _warp_from_value(source.get("dig_warp", {}))
 	out.backup_warp = _warp_from_value(source.get("backup_warp", {}))
 	out.spawn_after_champion = clampi(

--- a/game/world/world_sprite.gd
+++ b/game/world/world_sprite.gd
@@ -41,6 +41,9 @@ const SPRITE_PLAYER: int = 0x01
 const SPRITE_PLAYER_BIKE: int = 0x02
 const SPRITE_SURFING_PIKACHU: int = 0x34
 const SPRITE_SURF: int = 0x53
+## `SPRITE_SEEL`, which `LoadSurfingPlayerSpriteGraphics` draws the surfing
+## player with on all three Generation 1 cartridges.
+const SPRITE_SEEL: int = 0x3C
 const SPRITE_KRIS: int = 0x60
 const SPRITE_KRIS_BIKE: int = 0x61
 const SPRITE_POKEMON: int = 0x80

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1` and its neighbours are 1535 lines of it, and
-## Generation 1 has added 1762 more to the shared code: 152 the region map, 150
-## the battle animation engine, 140 the transition, 130 the Pokedex, 108 the
-## three PCs, 95 the trainer card, 85 the party menu, 66 the Day-Care, 42 the
-## status screen, 40 the bag in a battle, 29 the map callbacks and the walk.
-const MAX_COMMENT_LINES: int = 40967
+## Generation 1 has added 1847 more to the shared code: 85 the dungeon warps,
+## 152 the region map, 150 the battle animation engine, 140 the transition, 130
+## the Pokedex, 108 the three PCs, 95 the trainer card, 85 the party menu, 66
+## the Day-Care, 42 the status screen and 40 the bag in a battle.
+const MAX_COMMENT_LINES: int = 41052
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_field_move.gd
+++ b/tests/unit/test_world_field_move.gd
@@ -1846,6 +1846,10 @@ func test_a_snapshot_carries_both_escape_points_and_a_reopened_world_keeps_them(
 	world.try_warp()
 	var snapshot: Gen2WorldSnapshot = Gen2WorldSnapshot.from_world(world)
 	snapshot.last_spawn_map = Vector2i(1, ESCAPE_TOWN)
+	# `wLastMap` and `wLastBlackoutMap` ride beside them, saved player data
+	# Generation 1 alone writes.
+	snapshot.gen1_last_map = ESCAPE_TOWN
+	snapshot.gen1_last_blackout_map = ESCAPE_TOWN
 
 	var reopened: Gen2WorldAPI = Gen2WorldAPI.open_snapshot(
 		GameData.open_directory(_directory),
@@ -1853,14 +1857,20 @@ func test_a_snapshot_carries_both_escape_points_and_a_reopened_world_keeps_them(
 	)
 	assert_eq(reopened.dig_warp, {"warp": 1, "map_group": 1, "map_number": ESCAPE_TOWN})
 	assert_eq(reopened.last_spawn_map, Vector2i(1, ESCAPE_TOWN))
-	# A snapshot written before either existed reads as a game that has entered
-	# neither, which is what their defaults say.
+	assert_eq(reopened.gen1_last_map(), ESCAPE_TOWN)
+	assert_eq(reopened.gen1_last_blackout_map(), ESCAPE_TOWN)
+	# A snapshot written before any of them existed reads as a game that has
+	# entered none, which is what their defaults say.
 	var old: Dictionary = snapshot.to_dict()
 	old.erase("dig_warp")
 	old.erase("last_spawn_map")
+	old.erase("gen1_last_map")
+	old.erase("gen1_last_blackout_map")
 	var older: Gen2WorldSnapshot = Gen2WorldSnapshot.from_dict(old)
 	assert_true(older.dig_warp.is_empty())
 	assert_eq(older.last_spawn_map, Vector2i(-1, -1))
+	assert_eq(older.gen1_last_map, -1)
+	assert_eq(older.gen1_last_blackout_map, Gen1Layout.PALLET_TOWN)
 
 
 ## `SweetScentEncounter`: a wild where one could have been stepped into.

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -211,6 +211,23 @@ const SPRITE_STILL_FIRST: Dictionary = {&"red": 0x3D, &"blue": 0x3D, &"yellow": 
 const PLAYER_SPRITE: Array = [0x4180, 0x05]
 const PLAYER_SPRITE_YELLOW: Array = [0x4571, 0x05]
 
+## Every `IsPlayerOnDungeonWarp` caller of the corpus, source map to its holes:
+## the `dbmapcoord`, the map it drops onto and the `DungeonWarpData` tile it
+## lands on. Victory Road 3F's first row is the boulder switch, which
+## `DungeonWarpList` names no pair for.
+const DUNGEON_HOLES: Dictionary = {
+	192: [[6, 17, 159, 7, 18], [6, 24, 159, 7, 23]],
+	159: [[6, 18, 160, 7, 19], [6, 23, 160, 7, 22]],
+	160: [[6, 19, 161, 7, 18], [6, 22, 161, 7, 19]],
+	161: [[16, 3, 162, 14, 4], [16, 6, 162, 14, 5]],
+	198: [[5, 3, 194, -1, -1], [15, 23, 194, 16, 22]],
+	215: [[14, 16, 165, 14, 16], [14, 17, 165, 14, 16], [14, 19, 214, 14, 18]],
+}
+## `EscapeRopeTilesets` and `SafariZoneRestHouses`, the two lists the rope and
+## `SetLastBlackoutMap` walk.
+const ESCAPE_ROPE_TILESETS: Array[int] = [3, 15, 17, 22, 16]
+const REST_HOUSES: Array[int] = [223, 224, 225]
+
 var _r: RefCounted = null
 var _maps: Dictionary = {}
 var _movements: Array[int] = []
@@ -237,6 +254,7 @@ func _one_game() -> void:
 	_texts()
 	_map_callbacks()
 	_hidden_events()
+	_dungeon_warps()
 	_toggleables()
 	_wild_objects()
 	_palettes()
@@ -267,6 +285,80 @@ func _counts() -> void:
 			census[key], key, int(pinned[key]),
 		])
 	_r.note("gen1 maps %s" % census)
+
+
+## `IsPlayerOnDungeonWarp` over the whole corpus: the six maps that call it and
+## nothing else, each hole answering with the tile `.matchedDungeonWarpID` copies.
+func _dungeon_warps() -> void:
+	_r.check(
+		Array(_r.data.gen1_special_warp_list("escape_rope_tilesets")) == ESCAPE_ROPE_TILESETS,
+		"EscapeRopeTilesets reads %s." % str(_r.data.gen1_special_warp_list("escape_rope_tilesets"))
+	)
+	_r.check(
+		Array(_r.data.gen1_special_warp_list("rest_houses")) == REST_HOUSES,
+		"SafariZoneRestHouses reads %s." % str(_r.data.gen1_special_warp_list("rest_houses"))
+	)
+	var holes: int = 0
+	for map: Gen2WorldMap in _maps.values():
+		var rows: Array = map.events.get("dungeon_holes", [])
+		if not _r.check(
+			rows.is_empty() != DUNGEON_HOLES.has(map.number),
+			"map %d decoded %d dungeon holes." % [map.number, rows.size()]
+		) or rows.is_empty():
+			continue
+		_dungeon_holes_of(map, rows)
+		holes += rows.size()
+	_r.note("gen1 dungeon holes %d over %d maps" % [holes, DUNGEON_HOLES.size()])
+
+
+func _dungeon_holes_of(map: Gen2WorldMap, rows: Array) -> void:
+	var pinned: Array = DUNGEON_HOLES[map.number]
+	if not _r.check(rows.size() == pinned.size(), "map %d holds %d holes, pinned %d." % [
+		map.number, rows.size(), pinned.size(),
+	]):
+		return
+	for index: int in rows.size():
+		var hole: Dictionary = rows[index]
+		var want: Array = pinned[index]
+		var landing: Dictionary = _r.data.gen1_dungeon_warp(
+			int(hole["destination"]), index + 1
+		)
+		_r.check(
+			[int(hole["y"]), int(hole["x"]), int(hole["destination"])] == want.slice(0, 3),
+			"map %d hole %d reads (%d, %d) to map %d." % [
+				map.number, index + 1, int(hole["y"]), int(hole["x"]),
+				int(hole["destination"]),
+			]
+		)
+		var got: Array = [-1, -1] if landing.is_empty() \
+			else [int(landing["y"]), int(landing["x"])]
+		_r.check(got == want.slice(3), "map %d hole %d lands at %s, pinned %s." % [
+			map.number, index + 1, str(got), str(want.slice(3)),
+		])
+		if landing.is_empty():
+			continue
+		_r.check(
+			_dungeon_landing_stands(int(hole["destination"]), landing),
+			"map %d hole %d lands off map %d." % [
+				map.number, index + 1, int(hole["destination"]),
+			]
+		)
+
+
+## Nothing checks the landing cell, so a tile the destination cannot stand on
+## would strand the player. The four Seafoam falls land on `CheckForceBikeOrSurf`'s water.
+func _dungeon_landing_stands(number: int, landing: Dictionary) -> bool:
+	var map: Gen2WorldMap = _maps.get(number, null)
+	if map == null:
+		return false
+	var cell := Vector2i(int(landing["x"]), int(landing["y"]))
+	if cell.x < 0 or cell.y < 0 \
+		or cell.x >= map.collision_width or cell.y >= map.collision_height:
+		return false
+	var tile: int = map.collision_at(cell.x, cell.y)
+	var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+	return tileset != null \
+		and (tileset.tile_passable(tile) or tile == Gen1Layout.WATER_TILE)
 
 
 func _tilesets() -> void:

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -289,6 +289,28 @@ const BENCH_GUY_CELL := Vector2i(0, 4)
 const SNES_BOX: String = "%s is\nplaying the SNES!"
 const MART_SHELF_BOX: String = "Wow! Tons of\nPOKéMON stuff!"
 
+## `Seafoam1HolesCoords`' first hole and the tile below it, with Victory Road
+## 3F's list, whose first row is the switch and carries no pair of its own.
+const SEAFOAM_1F: int = 192
+const SEAFOAM_B1F: int = 159
+const SEAFOAM_HOLE := Vector2i(17, 6)
+const SEAFOAM_LANDING := Vector2i(18, 7)
+## Seafoam B2F's first hole and the water on B3F it drops into.
+const SEAFOAM_B2F: int = 160
+const SEAFOAM_B3F: int = 161
+const SEAFOAM_B2F_HOLE := Vector2i(19, 6)
+const SEAFOAM_B3F_LANDING := Vector2i(18, 7)
+const VICTORY_ROAD_3F: int = 198
+const VICTORY_ROAD_2F: int = 194
+const VICTORY_ROAD_SWITCH := Vector2i(3, 5)
+const VICTORY_ROAD_HOLE := Vector2i(23, 15)
+const VICTORY_ROAD_LANDING := Vector2i(22, 16)
+
+## `FlyWarpDataPtr.PalletTown`, which a zeroed `wLastBlackoutMap` names.
+const PALLET_FLY_CELL := Vector2i(5, 6)
+## `AGATHAS_ROOM`, the one map `ItemUseEscapeRope` refuses by name.
+const AGATHAS_ROOM_CELL := Vector2i(4, 11)
+
 var _r: RefCounted = null
 
 
@@ -328,6 +350,8 @@ func _one_game() -> void:
 	_check_the_day_care()
 	_check_the_town_map_poster()
 	_check_flying()
+	_check_a_dungeon_fall()
+	_check_an_escape_rope()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -1731,6 +1755,123 @@ func _check_flying() -> void:
 		StringName(indoors.fly_request().get("reason", &"")) == &"indoors",
 		"flying was allowed out of a house."
 	)
+
+
+## `IsPlayerOnDungeonWarp` and `HandleFlyWarpOrDungeonWarp` behind it. Victory
+## Road 3F's switch shares the list and is no hole at all.
+func _check_a_dungeon_fall() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, SEAFOAM_1F, SEAFOAM_HOLE)
+	if world == null:
+		return
+	if not _r.check(
+		not world.gen1_dungeon_hole_at(SEAFOAM_HOLE).is_empty(),
+		"Seafoam Islands 1F's first hole is no dungeon warp."
+	):
+		return
+	var fell: Dictionary = world.gen1_dungeon_fall()
+	_r.check(
+		bool(fell.get("ok", false)) and world.map_id() == Vector2i(0, SEAFOAM_B1F)
+			and world.player_cell == SEAFOAM_LANDING,
+		"the fall landed on %s at %s." % [world.map_id(), world.player_cell]
+	)
+	var deeper: Gen2WorldAPI = _r.open_world(0, SEAFOAM_B2F, SEAFOAM_B2F_HOLE)
+	if deeper != null:
+		deeper.gen1_dungeon_fall()
+		_r.check(
+			deeper.map_id() == Vector2i(0, SEAFOAM_B3F)
+				and deeper.player_cell == SEAFOAM_B3F_LANDING
+				and deeper.movement_mode == Gen2WorldAPI.MOVEMENT_SURF
+				and deeper.player_sprite_number == Gen2WorldSprite.SPRITE_SEEL,
+			"the fall into B3F's water left the player %s on sprite %d." % [
+				deeper.movement_mode, deeper.player_sprite_number,
+			]
+		)
+	var road: Gen2WorldAPI = _r.open_world(0, VICTORY_ROAD_3F, VICTORY_ROAD_SWITCH)
+	if road == null:
+		return
+	_r.check(
+		road.gen1_dungeon_hole_at(VICTORY_ROAD_SWITCH).is_empty(),
+		"Victory Road 3F's boulder switch fell through the floor."
+	)
+	road.player_cell = VICTORY_ROAD_HOLE
+	var dropped: Dictionary = road.gen1_dungeon_fall()
+	_r.check(
+		bool(dropped.get("ok", false)) and road.map_id() == Vector2i(0, VICTORY_ROAD_2F)
+			and road.player_cell == VICTORY_ROAD_LANDING,
+		"Victory Road's hole landed on %s at %s." % [road.map_id(), road.player_cell]
+	)
+
+
+## `ItemUseEscapeRope`: refused outdoors and in Agatha's room, taken in a cave,
+## landing on `wLastBlackoutMap`'s own `FlyWarpDataPtr` tile.
+func _check_an_escape_rope() -> void:
+	var outdoors: Gen2WorldAPI = _r.open_world(0, PALLET_TOWN, PALLET_DOOR)
+	if outdoors == null:
+		return
+	_r.check(
+		StringName(outdoors.escape_rope_request().get("reason", &"")) == &"not_in_a_cave",
+		"an Escape Rope was pulled in Pallet Town."
+	)
+	var agatha: Gen2WorldAPI = _r.open_world(
+		0, Gen1Layout.AGATHAS_ROOM, AGATHAS_ROOM_CELL
+	)
+	if agatha != null:
+		_r.check(
+			StringName(agatha.escape_rope_request().get("reason", &"")) == &"not_in_a_cave",
+			"an Escape Rope was pulled in Agatha's room."
+		)
+	var world: Gen2WorldAPI = _r.open_world(0, SEAFOAM_1F, SEAFOAM_HOLE + Vector2i.UP)
+	if world == null:
+		return
+	if not _r.check(
+		bool(world.escape_rope_request().get("ok", false)),
+		"an Escape Rope was refused in the Seafoam Islands."
+	):
+		return
+	var escaped: Dictionary = world.complete_escape()
+	_r.check(
+		bool(escaped.get("ok", false)) and world.map_id() == Vector2i(0, PALLET_TOWN)
+			and world.player_cell == PALLET_FLY_CELL,
+		"the rope landed on %s at %s." % [world.map_id(), world.player_cell]
+	)
+	_check_the_blackout_map_moves()
+
+
+## `SetLastBlackoutMap` reads `wLastMap`, so walking in is what moves it.
+func _check_the_blackout_map_moves() -> void:
+	var city: Gen2WorldAPI = _r.open_world(0, VIRIDIAN_CITY, Vector2i.ZERO)
+	if city == null:
+		return
+	var door: Vector2i = _warp_cell_to(city, VIRIDIAN_POKECENTER)
+	if not _r.check(door.x >= 0, "Viridian City has no Pokemon Center door."):
+		return
+	city.player_cell = door
+	city.player_facing = Gen2WorldSprite.FACING_UP
+	if not _r.check(
+		bool(city.try_warp().get("ok", false)),
+		"the Pokemon Center door did not open."
+	):
+		return
+	city.player_cell = NURSE_COUNTER
+	city.player_facing = Gen2WorldSprite.FACING_UP
+	city.set_party_summary(NURSE_PARTY, false)
+	city.interact()
+	city.run_event_queue(true)
+	city.choose_script_input(0)
+	city.run_event_queue(true)
+	_r.check(
+		city.gen1_last_blackout_map() == VIRIDIAN_CITY,
+		"healing left the blackout map at %d." % city.gen1_last_blackout_map()
+	)
+	_r.note("gen1 blackout map %d" % city.gen1_last_blackout_map())
+
+
+## The cell of [param world]'s own warp onto [param map], or (-1, -1).
+func _warp_cell_to(world: Gen2WorldAPI, map: int) -> Vector2i:
+	for warp: Dictionary in world.current_map.events.get("warps", []) as Array:
+		if int(warp.get("map_number", -1)) == map:
+			return Vector2i(int(warp["x"]), int(warp["y"]))
+	return Vector2i(-1, -1)
 
 
 ## The first cell of [param map] drawing a tile `BookshelfTileIDs` names.

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -53,6 +53,7 @@ const KIND_HELP: Dictionary = {
 	&"pet_actor": "cell: a mod's world actor one cell ahead, pressed with A so it wears a showemote heart",
 	&"pet_actor_arc": "cell: the same actor mid-ledge, at the top of the arc its span names",
 	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
+	&"dungeon_fall": "0 or 1: the step north onto a Generation 1 dungeon hole. 0 is LeaveMapAnim at its whitest, 1 the map DungeonWarpData lands on",
 	&"script_fade": "special, frames: one of the five fade specials over the map",
 	&"door": "door mat: .CheckWarp's carpet, standing on an interior door's mat",
 	&"ice_slide": "direction, frames: DoPlayerMovement.CheckForced's run. Direction is down, up, left, right",
@@ -441,6 +442,7 @@ const STAGERS: Dictionary = {
 	&"mart_sell": &"_stage_mart",
 	&"elevator": &"_stage_elevator",
 	&"warp": &"_stage_warp",
+	&"dungeon_fall": &"_stage_dungeon_fall",
 	&"door": &"_stage_door",
 	&"ledge": &"_stage_ledge",
 	&"ice_slide": &"_stage_ice_slide",
@@ -884,6 +886,25 @@ func _stage_warp() -> void:
 		if StringName(fade.get("stage", &"")) == &"out" \
 			and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
 			break
+
+
+## `HandleFlyWarpOrDungeonWarp`: the step north onto a hole and the fade behind
+## it, whose last order is the frame the destination loads on. A first number of
+## 1 spends the fade in too (`red 0 192 ... dungeon_fall@17,7 1 0`).
+func _stage_dungeon_fall() -> void:
+	for _frame: int in WARP_FRAME_CAP:
+		_screen.move_up()
+		_screen.advance_frame()
+		var fade: Dictionary = _screen.map_fade()
+		if StringName(fade.get("stage", &"")) == &"out" \
+			and int(fade.get("step", 0)) == Gen2WorldPalette.FADE_OUT_ORDERS.size() - 1:
+			break
+	if _cell.x <= 0:
+		return
+	for _frame: int in WARP_FRAME_CAP:
+		if _screen.map_fade().is_empty():
+			break
+		_screen.advance_frame()
 
 
 ## `CheckDirectionalWarp`'s carpet: the step onto an interior door's mat lands and


### PR DESCRIPTION
LoadSpecialWarpData's other two tables are imported beside FlyWarpDataPtr: DungeonWarpList's twelve pairs and the DungeonWarpData record behind each, which is a fly_warp read the same way. IsPlayerOnDungeonWarp is called from the per-frame half of six map scripts, which nothing here interprets, so the block is found inside the script's own bytes: a `ld hl, <coords>` whose call lands on a routine opening `xor a` / `ld [wWhichDungeonWarp], a`, which both that routine and the copy Pokemon Mansion 3F keeps of it do. Five maps write the destination in front of the block and the Mansion picks it by index behind it, `cp 3` naming 2F and everything else 1F.

Thirteen holes on all three cartridges. Victory Road 3F's first coordinate is the boulder switch, which DungeonWarpList names no pair for and which is why nothing falls there. `gen1_dungeon_fall` is HandleFlyWarpOrDungeonWarp, taken on the frame a step lands and behind the warp check, as OverworldLoop reads the two. The four Seafoam falls land on water; LoadSurfingPlayerSpriteGraphics is SeelSprite on all three cartridges, where `surf_sprite` had answered Crystal's own $53 and drawn the missing-sprite marker.

`warp_to_escape_point` is the one seam a blackout, an Escape Rope, Dig and Teleport all land through. Generation 2 reads a spawn point, which a Generation 1 cache holds none of, so all four had failed there. `.usedEscapeWarp` hands `.usedFlyWarp` wLastBlackoutMap instead, which SetLastBlackoutMap copies wLastMap into at the Pokemon Center's YES unless the map is one of SafariZoneRestHouses' three. ItemUseEscapeRope reads no map environment at all, refusing Agatha's room by name and everything outside EscapeRopeTilesets, and `.teleport` asks CheckIfInOutsideMap and no more.

wLastMap and wLastBlackoutMap are saved player data and now ride in the world snapshot, where a reopened save had come back knowing no way out of a building. PlayMapChangeSound compares one tile against the OVERWORLD door rather than reading GetWarpSFX's table, which is a permission byte a Generation 1 collision grid does not hold, and LeaveMapThroughHoleAnim spends no sound at all.

## Proof

| Check | Result |
|---|---|
| `tools/validate.gd -- all` | 93 topics pass, 0 fail |
| Unit and scene GUT tiers | 172 scripts, 4479 tests, 0 failures |
| `tools/replay_world.gd` | 33 routes, 0 failures |
| Three-profile story walk | gold, silver and crystal clean |
| Editor analyser | 0 warnings in 634 scripts |
| Re-import | six cartridges, `layout: Layout verified.` on each |

`gen1_maps.gd` sweeps every hole, its destination and its landing cell on all three cartridges, with EscapeRopeTilesets and SafariZoneRestHouses beside them. `gen1_walk.gd` falls through three holes, is refused a rope outdoors and in Agatha's room, and heals to move the blackout map. `tools/preview_world.gd -- red 0 160 <out.png> live dungeon_fall@19,7 1 0` photographs a fall into Seafoam B3F's water.
