### PR TITLE
Ride the Generation 1 bicycle down Cycling Road

### DIFF
--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -2606,7 +2606,20 @@ func gen1_dungeon_warp(map: int, warp: int) -> Dictionary:
 	return {}
 
 
-## `EscapeRopeTilesets` or `SafariZoneRestHouses`, each a `db` list to a `-1`.
+## Whether `ForcedBikeOrSurfMaps` holds [param map] at [param cell], which is
+## everything `CheckForceBikeOrSurf` asks of the table: which of the two rides
+## it forces is the map id's own answer.
+func gen1_forces_ride(map: int, cell: Vector2i) -> bool:
+	for row: Variant in _special_warps.get("forced_bike_surf", []) as Array:
+		var entry: Dictionary = row
+		if int(entry.get("map", -1)) == map and int(entry.get("x", -1)) == cell.x \
+			and int(entry.get("y", -1)) == cell.y:
+			return true
+	return false
+
+
+## One of the `db` lists ending in `-1` that `_import_special_warps` reads:
+## `EscapeRopeTilesets`, `SafariZoneRestHouses` or `BikeRidingTilesets`.
 func gen1_special_warp_list(name: String) -> PackedInt32Array:
 	var out := PackedInt32Array()
 	for value: Variant in _special_warps.get(name, []) as Array:

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -138,6 +138,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_battle_anims,
 	_verify_facility_text,
 	_verify_dex_ratings,
+	_verify_bike_data,
 	_verify_world,
 ]
 
@@ -172,6 +173,8 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"prizes_2": ["prize_text_2", Gen1Layout.PRIZE_TEXT_2_AT],
 	"pick_up_item": ["found_item_text", Gen1Layout.PICK_UP_TEXT_AT],
 	"item_use": ["item_use_text", Gen1Layout.ITEM_USE_TEXT_AT],
+	"bicycle": ["bicycle_text", Gen1Layout.BICYCLE_TEXT_AT],
+	"start_menu": ["start_menu_text", Gen1Layout.START_MENU_TEXT_AT],
 	"coin_case": ["coin_case_text", Gen1Layout.COIN_CASE_TEXT_AT],
 	"party_menu": ["party_menu_text", Gen1Layout.PARTY_MENU_TEXT_AT],
 	"toss": ["toss_text", Gen1Layout.TOSS_TEXT_AT],
@@ -501,6 +504,24 @@ static func _verify_facility_text(rom: RomFile, layout: Dictionary) -> Dictionar
 				return _fail("%s's %s box does not decode at $%05X." % [run, name, at])
 	if facility_text(rom, int(layout["mart_greeting"])).is_empty():
 		return _fail("PokemartGreetingText does not decode.")
+	return _ok()
+
+
+## `BikeRidingTilesets`' five rows and `ForcedBikeOrSurfMaps`' eight, each
+## naming something the rest of the cache holds.
+static func _verify_bike_data(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var tilesets: Array = _byte_list(rom, int(layout["bike_riding_tilesets"]))
+	if tilesets.size() != Gen1Layout.BIKE_RIDING_TILESET_COUNT:
+		return _fail("BikeRidingTilesets holds %d rows." % tilesets.size())
+	for number: int in tilesets:
+		if number >= Gen1Layout.tileset_count(rom.id):
+			return _fail("BikeRidingTilesets names tileset %d." % number)
+	var forced: Array = _forced_bike_surf(rom, layout)
+	if forced.size() != Gen1Layout.FORCED_BIKE_SURF_ROWS:
+		return _fail("ForcedBikeOrSurfMaps holds %d rows." % forced.size())
+	for row: Dictionary in forced:
+		if not Gen1Layout.is_real_map(int(row["map"])):
+			return _fail("ForcedBikeOrSurfMaps names map %d." % int(row["map"]))
 	return _ok()
 
 
@@ -1100,11 +1121,24 @@ func _import_special_warps(rom: RomFile, layout: Dictionary) -> Dictionary:
 		"dungeon_warps": rows,
 		"escape_rope_tilesets": _byte_list(rom, int(layout["escape_rope_tilesets"])),
 		"rest_houses": _byte_list(rom, int(layout["rest_houses"])),
+		"bike_riding_tilesets": _byte_list(rom, int(layout["bike_riding_tilesets"])),
+		"forced_bike_surf": _forced_bike_surf(rom, layout),
 	}
 
 
+## `ForcedBikeOrSurfMaps`, whose `db map, y, x` rows `CheckForceBikeOrSurf` walks
+## against the cell the player entered the map on.
+static func _forced_bike_surf(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout["forced_bike_surf"])
+	var out: Array = []
+	while rom.u8(at) != Gen1Layout.TILESET_LIST_END:
+		out.append({"map": rom.u8(at), "y": rom.u8(at + 1), "x": rom.u8(at + 2)})
+		at += Gen1Layout.FORCED_BIKE_SURF_ROW_SIZE
+	return out
+
+
 ## A `db`-per-row table ended by the `-1` every one of Generation 1's carries.
-func _byte_list(rom: RomFile, at: int) -> Array:
+static func _byte_list(rom: RomFile, at: int) -> Array:
 	var out: Array = []
 	while rom.u8(at) != Gen1Layout.TILESET_LIST_END:
 		out.append(rom.u8(at))

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -598,8 +598,15 @@ const DAY_CARE_TEXT_AT: Dictionary = {
 ## `engine/items/item_effects.asm`'s two runs the pack prints from: the three
 ## refusals `ItemUseFailed` reaches and `TossItem_`'s own three.
 const ITEM_USE_TEXT_AT: Dictionary = {
-	"not_time": 0x00, "not_yours": 0x05, "no_effect": 0x0A,
+	"not_time": 0x00, "not_yours": 0x05, "no_effect": 0x0A, "no_cycling": 0x19,
 }
+## `GotOnBicycleText` and `GotOffBicycleText`, pinned away from the run above
+## because Yellow's `DontHavePokemonText` sits between them and it.
+const BICYCLE_TEXT_AT: Dictionary = {"got_on": 0x00, "got_off": 0x0A}
+## `CannotGetOffHereText`, which `.useOrTossItem` prints in front of `UseItem`
+## rather than through `ItemUseFailed`. `CannotUseItemsHereText` above it is the
+## Colosseum's and no screen here reaches it.
+const START_MENU_TEXT_AT: Dictionary = {"cannot_get_off": 0x00}
 ## `CoinCaseNumCoinsText`, a run of one: `ItemUseCoinCase` is the only reader.
 const COIN_CASE_TEXT_AT: Dictionary = {"coins": 0x00}
 ## `PartyMenuMessagePointers`' own five, in the order the table names them.
@@ -724,6 +731,23 @@ const PALLET_TOWN: int = 0x00
 ## `PlayMapChangeSound`'s `cp $0b`, the OVERWORLD door tile it parts
 ## SFX_GO_INSIDE from SFX_GO_OUTSIDE by on every map.
 const OVERWORLD_DOOR_TILE: int = 0x0B
+
+## `IsBikeRidingAllowed`'s two maps by name, in front of `BikeRidingTilesets`.
+const ROUTE_23: int = 0x22
+const INDIGO_PLATEAU: int = 0x09
+const BIKE_ALLOWED_MAPS: Array[int] = [ROUTE_23, INDIGO_PLATEAU]
+## `BikeRidingTilesets`: OVERWORLD, FOREST, UNDERGROUND, SHIP_PORT and CAVERN.
+const BIKE_RIDING_TILESET_COUNT: int = 5
+## `ForcedBikeOrSurfMaps`, whose `force_bike_surf` macro writes `db map, y, x`
+## for arguments given as map, x, y. Route 16's and Route 18's four rows force
+## the bike; Seafoam Islands B3F's and B4F's force surfing instead.
+const FORCED_BIKE_SURF_ROW_SIZE: int = 3
+const FORCED_BIKE_SURF_ROWS: int = 8
+const SEAFOAM_ISLANDS_B3F: int = 0xA1
+const SEAFOAM_ISLANDS_B4F: int = 0xA2
+## `res BIT_ALWAYS_ON_BIKE, [hl]`: bit 5 of `wStatusFlags6`, which only Route 16
+## Gate 1F's and Route 18 Gate 1F's per-frame scripts open with.
+const ALWAYS_ON_BIKE_BIT: int = 5
 
 ## `NOT_VISITED`, which `BuildFlyLocationsList` writes for a town the player has
 ## not been to, and `.townMapFlyLoop`'s own `ld c, 15` between two draws.
@@ -1205,6 +1229,10 @@ const SPRITE_STILL_FIRST_RED_BLUE: int = 0x3D
 const SPRITE_STILL_FIRST_YELLOW: int = 0x47
 const SPRITE_WALKING_TILES: int = 12
 const SPRITE_STILL_TILES: int = 4
+## `RedBikeSprite`, which `LoadBikePlayerSpriteGraphics` loads by address and no
+## row names: the walking strip `INCBIN`'d in front of SPRITE_RED's, so its
+## address is that row's less both halves.
+const SPRITE_BIKE_BYTES: int = SPRITE_WALKING_TILES * 2 * PokeTiles.TILE_BYTES
 
 ## `MonPartySpritePointers`, the table `LoadMonPartySpriteGfx` walks: a CPU
 ## address, the tiles to copy, the bank, and the `vSprites` address they land
@@ -1399,6 +1427,13 @@ const RED_BLUE: Dictionary = {
 	"rest_houses": 0x07092,
 	"which_dungeon_warp": 0xD71E,
 	"dungeon_warp_destination": 0xD71D,
+	## `IsBikeRidingAllowed`'s tileset list, `CheckForceBikeOrSurf`'s coordinate
+	## list and the byte the gate scripts clear a forced ride in.
+	"bike_riding_tilesets": 0x009E2,
+	"forced_bike_surf": 0x0C3E6,
+	"status_flags_6": 0xD732,
+	"bicycle_text": 0x0E5F2,
+	"start_menu_text": 0x1342F,
 	"battle_font": 0x11EA0,
 	"battle_hud_1": 0x12080,
 	"battle_hud_2": 0x12098,
@@ -1607,6 +1642,11 @@ const YELLOW: Dictionary = {
 	"rest_houses": 0x06F0A,
 	"which_dungeon_warp": 0xD71D,
 	"dungeon_warp_destination": 0xD71C,
+	"bike_riding_tilesets": 0x00822,
+	"forced_bike_surf": 0x0C12F,
+	"status_flags_6": 0xD731,
+	"bicycle_text": 0x0E536,
+	"start_menu_text": 0x11FD9,
 	"battle_font": 0x10A20,
 	"battle_hud_1": 0x10C00,
 	"battle_hud_2": 0x10C18,
@@ -1992,6 +2032,11 @@ static func first_still_sprite(id: StringName) -> int:
 
 static func sprite_offset(layout: Dictionary, number: int) -> int:
 	return int(layout["overworld_sprites"]) + (number - 1) * SPRITE_RECORD_SIZE
+
+
+## The picture id [constant SPRITE_BIKE_BYTES]' strip is cached under.
+static func bike_sprite(id: StringName) -> int:
+	return sprite_count(id) + 1
 
 
 ## Blocks per tileset, in `Tilesets` order.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -527,7 +527,40 @@ static func _read_sprites(rom: RomFile, layout: Dictionary) -> Dictionary:
 			"type": Gen2WorldSprite.TYPE_STILL if still else Gen2WorldSprite.TYPE_WALKING,
 			"palette": 0,
 		})
+	var bike: Dictionary = _read_bike_sprite(rom, sprites)
+	if not bool(bike["ok"]):
+		return bike
+	sprites.append(bike["sprite"])
+	graphics[int((bike["sprite"] as Dictionary)["number"])] = bike["pixels"]
 	return {"ok": true, "sprites": sprites, "graphics": graphics}
+
+
+## `RedBikeSprite`, which the table names no row for. See [constant
+## Gen1Layout.SPRITE_BIKE_BYTES] for where it stands and why it is derived.
+static func _read_bike_sprite(rom: RomFile, sprites: Array) -> Dictionary:
+	var player: Dictionary = sprites[Gen2WorldSprite.SPRITE_PLAYER - 1]
+	var address: int = int(player["address"]) - Gen1Layout.SPRITE_BIKE_BYTES
+	if address < RomFile.BANK_SIZE:
+		return _error("RedBikeSprite would start at $%04X." % address)
+	var tiles: int = Gen1Layout.SPRITE_WALKING_TILES * 2
+	var raw: PackedByteArray = rom.slice(
+		RomFile.linear(int(player["bank"]), address), Gen1Layout.SPRITE_BIKE_BYTES
+	)
+	if raw.size() != Gen1Layout.SPRITE_BIKE_BYTES:
+		return _error("RedBikeSprite's graphics are truncated.")
+	return {
+		"ok": true,
+		"pixels": PokeTiles.decode_2bpp_strip(raw, 0, tiles),
+		"sprite": {
+			"number": Gen1Layout.bike_sprite(rom.id),
+			"address": address,
+			"bank": int(player["bank"]),
+			"bytes": Gen1Layout.SPRITE_BIKE_BYTES,
+			"tiles": tiles,
+			"type": Gen2WorldSprite.TYPE_WALKING,
+			"palette": 0,
+		},
+	}
 
 
 ## One row of `Tilesets`, its blockset, its graphics and the list of tiles
@@ -717,6 +750,9 @@ static func _read_map(
 			"address": rom.u16le(header + MAP_SCRIPT_AT),
 			"scenes": [],
 			"callbacks": [] if callback.is_empty() else [callback],
+			"clears_always_on_bike": _clears_always_on_bike(
+				rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT)
+			),
 		},
 		"texts": texts,
 		"events": {
@@ -759,6 +795,24 @@ static func _script_ends(rom: RomFile, layout: Dictionary, map_count: int) -> Di
 			out[int((rows[index] as Array)[1])] = 2 * RomFile.BANK_SIZE \
 				if index + 1 == rows.size() else int((rows[index + 1] as Array)[0])
 	return out
+
+
+## Route 16 Gate 1F's and Route 18 Gate 1F's per-frame scripts open with
+## `ld hl, wStatusFlags6` / `res BIT_ALWAYS_ON_BIKE, [hl]` in front of their own
+## jump table, so a forced ride ends on the frame the gate is entered. Nothing
+## interprets that half of a map script here, so the five bytes are matched.
+static func _clears_always_on_bike(
+	rom: RomFile, layout: Dictionary, bank: int, script: int
+) -> bool:
+	var at: int = Gen1Layout.banked(bank, script)
+	if rom.u8(at) != Gen1Layout.SCRIPT_LD_HL \
+		or rom.u16le(at + 1) != int(layout["status_flags_6"]) \
+		or rom.u8(at + Gen1Layout.SCRIPT_LONG_SIZE) != Gen1Layout.SCRIPT_PREFIX:
+		return false
+	var code: int = rom.u8(at + Gen1Layout.SCRIPT_LONG_SIZE + 1)
+	return code >= Gen1Layout.SCRIPT_RES_BASE and code < Gen1Layout.SCRIPT_SET_BASE \
+		and (code & 7) == Gen1Layout.SCRIPT_OPERAND_HL \
+		and ((code >> 3) & 7) == Gen1Layout.ALWAYS_ON_BIKE_BIT
 
 
 ## `IsPlayerOnDungeonWarp` and the copy Pokemon Mansion 3F keeps of it both open

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 121
+const FORMAT_VERSION: int = 122
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -148,8 +148,20 @@ const TEXT_TOO_IMPORTANT: String = "too_important"
 ## `engine/items/item_effects.asm` rather than in a pack of its own.
 ## `AskQuantityThrowAwayText` has no counterpart: the dial opens over no question.
 const TEXT_COIN_CASE: String = "coin_case"
+## The Bicycle's two Generation 1 refusals: `.useOrTossItem` prints
+## `CannotGetOffHereText` in front of `UseItem`, and `NoCyclingAllowedHere`
+## reaches `ItemUseFailed` with a line of its own where every other way an
+## effect fails says `.Oak`.
+const TEXT_CANNOT_GET_OFF: String = "cannot_get_off"
+const TEXT_NO_CYCLING: String = "no_cycling"
+const GEN1_BIKE_REFUSALS: Dictionary = {
+	&"cannot_get_off": TEXT_CANNOT_GET_OFF,
+	&"no_cycling_here": TEXT_NO_CYCLING,
+}
 const GEN1_PACK_TEXTS: Dictionary = {
 	TEXT_OAK: ["item_use", "not_time"],
+	TEXT_CANNOT_GET_OFF: ["start_menu", "cannot_get_off"],
+	TEXT_NO_CYCLING: ["item_use", "no_cycling"],
 	TEXT_COIN_CASE: ["coin_case", "coins"],
 	TEXT_TOSS_ASK_QUANTITY: ["toss", "ok_to_toss"],
 	TEXT_TOSS_THREW: ["toss", "threw_away"],
@@ -1542,7 +1554,9 @@ func _use_field_item(item: int) -> void:
 	if not bool(request.get("ok", false)):
 		## `.Field` says `.Oak` and `UseRegisteredItem`'s `.Overworld`
 		## `CantUseItem`, which is the one thing the two jumptables disagree on.
-		_show_pack_result(_use_refusal(&"item_effect_failed", item), false)
+		_show_pack_result(_use_refusal(
+			StringName(request.get("reason", &"item_effect_failed")), item
+		), false)
 		return
 	## `.CheckIfRegistered`: the Bicycle's two scripts each have a silent copy.
 	request["registered"] = _using_registered
@@ -1559,7 +1573,7 @@ func _resolve_field_item(item: int) -> Dictionary:
 		Gen2WorldPack.FIELD_EFFECT_BICYCLE:
 			var ridden: Dictionary = _world.bike_request()
 			if not bool(ridden.get("ok", false)):
-				return {"ok": false}
+				return {"ok": false, "reason": ridden.get("reason", &"")}
 			request["bike"] = ridden
 		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
 			var escaped: Dictionary = _world.escape_rope_request()
@@ -1991,6 +2005,8 @@ func _use_summary(item: Dictionary, result: Dictionary) -> String:
 func _use_refusal(reason: StringName, item: int) -> String:
 	if _using_registered:
 		return Gen2WorldPack.cant_use_text()
+	if _gen1_pack() and GEN1_BIKE_REFUSALS.has(reason):
+		return _pack_text(String(GEN1_BIKE_REFUSALS[reason]))
 	## `.Field` reads one byte and says `.Oak` for every way an effect can fail,
 	## so a CLOSE item is answered before the reasons `.Party`'s own effects give.
 	if Gen2WorldPack.field_use_kind(_data, item) == Gen2WorldPack.ITEMMENU_CLOSE:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -6558,6 +6558,16 @@ func warp_pending(cell: Vector2i = player_cell) -> bool:
 		and not Gen2WorldCollision.is_directional_warp(code)
 
 
+## `CheckWarpsCollision`, which `CollisionCheckOnLand`'s own carry reaches: a
+## step blocked while standing on a warp still takes it when `ExtraWarpCheck`
+## passes, and that check alone, where a landed step takes a door tile as well.
+## Generation 1's alone, and the only way out of a map whose exit is a warp at
+## its own edge.
+func blocked_step_warps() -> bool:
+	return _gen1 and current_map != null and not warp_at(player_cell).is_empty() \
+		and _gen1_extra_warp_check(player_cell)
+
+
 ## `DoPlayerMovement.CheckWarp`: the player is standing on the warp carpet that
 ## names [param direction], is already facing that way, and the cell carries a
 ## warp. The press takes the warp instead of bumping, which is why an interior
@@ -6682,16 +6692,24 @@ func _warp_tile_allows(cell: Vector2i) -> bool:
 	if not _gen1:
 		return Gen2WorldCollision.is_warp_tile(standing)
 	var tileset: int = current_map.tileset
+	## `IsPlayerStandingOnDoorTileOrWarpTile`, which `CheckWarpsNoCollision` takes
+	## before `ExtraWarpCheck` is asked at all.
 	if Gen2WorldCollision.gen1_is_warp_tile(tileset, standing) \
 		or Gen2WorldCollision.gen1_is_door_tile(tileset, standing):
 		return true
+	return _gen1_extra_warp_check(cell)
+
+
+## `ExtraWarpCheck`: `IsWarpTileInFrontOfPlayer` on the maps and tilesets it
+## names and `IsPlayerFacingEdgeOfMap` on the rest, which compares the player's
+## own coordinate against the map where the carpet test reads the drawn tile and
+## so sees the border.
+func _gen1_extra_warp_check(cell: Vector2i) -> bool:
 	var direction: Vector2i = _direction_for_facing(player_facing)
 	var ahead: Vector2i = cell + direction
 	if current_map.number == Gen1Layout.MAP_SS_ANNE_BOW:
 		return _gen1_tile_drawn_at(ahead) == Gen1Layout.SS_ANNE_BOW_WARP_TILE
-	## `IsPlayerFacingEdgeOfMap` compares the player's own coordinate against the
-	## map, where the carpet test reads the drawn tile and so sees the border.
-	if not Gen1Layout.warp_wants_carpet(current_map.number, tileset):
+	if not Gen1Layout.warp_wants_carpet(current_map.number, current_map.tileset):
 		return collision_code_at(ahead) < 0
 	return Gen2WorldCollision.gen1_is_warp_carpet(direction, _gen1_tile_drawn_at(ahead))
 
@@ -7949,7 +7967,7 @@ func _map_setup_sprite(mode: StringName) -> int:
 	if mode == MOVEMENT_SURF:
 		return Gen2WorldFieldMove.surf_sprite(0, _gen1)
 	if mode == MOVEMENT_BIKE:
-		return Gen2WorldSprite.player_bike_sprite(_player_female)
+		return _bike_sprite()
 	return _walking_sprite()
 
 
@@ -7962,8 +7980,10 @@ const BIKE_DISMOUNT_ENVIRONMENTS: Array[int] = [
 
 ## `CheckUpdatePlayerSprite`'s three branches in its own order: `.CheckForcedBiking`,
 ## then `.CheckSurfing`, then `.ResetSurfingOrBikingState`.
+## Generation 1's is `LoadPlayerSpriteGraphics`, whose `.ridingBike` asks
+## `IsBikeRidingAllowed` and whose nothing forces a ride.
 func _setup_movement_mode(cell: Vector2i) -> StringName:
-	if state != null and state.is_engine_flag_active(
+	if not _gen1 and state != null and state.is_engine_flag_active(
 		Gen2WorldState.always_on_bike_flag(data)
 	):
 		return MOVEMENT_BIKE
@@ -7972,9 +7992,14 @@ func _setup_movement_mode(cell: Vector2i) -> StringName:
 	if movement_mode == MOVEMENT_SURF:
 		return MOVEMENT_WALK
 	if movement_mode == MOVEMENT_BIKE and current_map != null \
-		and BIKE_DISMOUNT_ENVIRONMENTS.has(current_map.environment):
+		and not _map_setup_keeps_bike():
 		return MOVEMENT_WALK
 	return movement_mode
+
+
+func _map_setup_keeps_bike() -> bool:
+	return _can_ride_bike_here() if _gen1 \
+		else not BIKE_DISMOUNT_ENVIRONMENTS.has(current_map.environment)
 
 
 func _apply_map(
@@ -8032,7 +8057,11 @@ func _apply_map(
 	# HandleNewMap's own resets: ResetBikeFlags drops a used Strength with the
 	# map, ResetFlashIfOutOfCave puts the light out on a route or a town, and
 	# HandleContinueMap behind it runs ClearCmdQueue over every written queue.
-	state.reset_bike_flags(Gen2WorldState.is_crystal_profile(data))
+	# Generation 1 has no such reset: `BIT_ALWAYS_ON_BIKE` outlives a map change
+	# and only the two gate scripts clear it, which is what carries a forced ride
+	# from Route 16 all the way to Route 18.
+	if not _gen1:
+		state.reset_bike_flags(Gen2WorldState.is_crystal_profile(data))
 	state.clear_flash_if_outdoors(target_map.environment)
 	_command_queue_slots = _empty_command_queue_slots()
 	current_map = target_map
@@ -8051,6 +8080,7 @@ func _apply_map(
 	):
 		player_facing = Gen2WorldSprite.FACING_DOWN
 	_apply_map_setup_player_state()
+	_gen1_check_force_bike_or_surf()
 	_clear_player_step()
 	# _load_objects() rebuilds every record, so in-flight object steps end with
 	# the objects that owned them.
@@ -8253,6 +8283,7 @@ func _gen1_fly_request() -> Dictionary:
 ## `.usedFlyWarp`: the destination's own `FlyWarpDataPtr` record, which is a tile
 ## on a map the overworld tileset always draws.
 func gen1_fly_to(map: int, entry: int = MAP_ENTRY_FLY) -> Dictionary:
+	_gen1_leave_map_on_foot()
 	var landing: Dictionary = data.gen1_fly_warp(map) if data != null else {}
 	var target_map: Gen2WorldMap = data.world_map(0, map) if not landing.is_empty() else null
 	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
@@ -8300,6 +8331,7 @@ func gen1_dungeon_fall() -> Dictionary:
 	var hole: Dictionary = gen1_dungeon_hole_at(player_cell)
 	if hole.is_empty():
 		return {}
+	_gen1_leave_map_on_foot()
 	var target_map: Gen2WorldMap = data.world_map(0, int(hole["map"]))
 	var target_tileset: Gen2WorldTileset = data.world_tileset(target_map.tileset) \
 		if target_map != null else null
@@ -8457,21 +8489,45 @@ func _step_frames_for_movement() -> int:
 func bike_request() -> Dictionary:
 	if current_map == null:
 		return _bike_failure(&"missing_map")
+	if _gen1:
+		return _gen1_bike_request()
 	if not _can_ride_bike_here():
 		return _bike_failure(&"cannot_use_bike")
 	if movement_mode == MOVEMENT_WALK:
-		movement_mode = MOVEMENT_BIKE
-		player_sprite_number = Gen2WorldSprite.player_bike_sprite(_player_female)
-		_apply_map_music()
-		return {
-			"ok": true, "kind": &"bike_on",
-			"music": state.map_music(),
-			"sprite": player_sprite_number,
-		}
+		return _mount_bike()
 	if movement_mode != MOVEMENT_BIKE:
 		return _bike_failure(&"cannot_use_bike")
 	if always_on_bike():
 		return {"ok": true, "kind": &"bike_cant_get_off", "sprite": player_sprite_number}
+	return _dismount_bike()
+
+
+## `ItemUseBicycle`, with `.useOrTossItem`'s own refusal in front of it: the item
+## menu tests `BIT_ALWAYS_ON_BIKE` before `UseItem` runs, so the Bicycle is
+## refused on Cycling Road whether or not the player is riding. Getting off asks
+## nothing about the map, and only getting on reaches `IsBikeRidingAllowed`.
+func _gen1_bike_request() -> Dictionary:
+	if always_on_bike():
+		return _bike_failure(&"cannot_get_off")
+	if movement_mode == MOVEMENT_SURF:
+		return _bike_failure(&"cannot_use_bike")
+	if movement_mode == MOVEMENT_BIKE:
+		return _dismount_bike()
+	return _mount_bike() if _can_ride_bike_here() else _bike_failure(&"no_cycling_here")
+
+
+func _mount_bike() -> Dictionary:
+	movement_mode = MOVEMENT_BIKE
+	player_sprite_number = _bike_sprite()
+	_apply_map_music()
+	return {
+		"ok": true, "kind": &"bike_on",
+		"music": state.map_music(),
+		"sprite": player_sprite_number,
+	}
+
+
+func _dismount_bike() -> Dictionary:
 	movement_mode = MOVEMENT_WALK
 	player_sprite_number = _walking_sprite()
 	_apply_map_music()
@@ -8483,15 +8539,62 @@ func bike_request() -> Dictionary:
 
 
 ## `BIKEFLAGS_ALWAYS_ON_BIKE_F`: Route 16 and Route 17 set it, and it refuses
-## both getting off and surfing.
+## both getting off and surfing. Generation 1's `BIT_ALWAYS_ON_BIKE` is the same
+## bit of state under `CheckForceBikeOrSurf` instead.
 func always_on_bike() -> bool:
 	return state != null \
 		and state.is_engine_flag_active(Gen2WorldState.always_on_bike_flag(data))
 
 
+## `CheckForceBikeOrSurf`, which `EnterMap` runs behind the map load. A cell of
+## `ForcedBikeOrSurfMaps` mounts the bike and sets `BIT_ALWAYS_ON_BIKE`, except
+## on the two Seafoam Islands floors, which force surfing and set nothing; the
+## flag already standing returns before the walk. The two gate scripts open by
+## clearing it, which is the only way a forced ride ends.
+func _gen1_check_force_bike_or_surf() -> void:
+	if not _gen1 or current_map == null or state == null:
+		return
+	if current_map.scripts.get("clears_always_on_bike", false):
+		state.set_engine_flag(Gen2WorldState.always_on_bike_flag(data), false)
+		return
+	if always_on_bike() or not data.gen1_forces_ride(current_map.number, player_cell):
+		return
+	if current_map.number in [
+		Gen1Layout.SEAFOAM_ISLANDS_B3F, Gen1Layout.SEAFOAM_ISLANDS_B4F,
+	]:
+		movement_mode = MOVEMENT_SURF
+		player_sprite_number = Gen2WorldFieldMove.surf_sprite(0, true)
+		return
+	state.set_engine_flag(Gen2WorldState.always_on_bike_flag(data), true)
+	movement_mode = MOVEMENT_BIKE
+	player_sprite_number = _bike_sprite()
+
+
+## `HandleFlyWarpOrDungeonWarp`'s own two writes, which a fly, an Escape Rope,
+## Dig, Teleport, a blackout and a dungeon hole all pay: `wWalkBikeSurfState`
+## back to walking and `BIT_ALWAYS_ON_BIKE` clear.
+func _gen1_leave_map_on_foot() -> void:
+	if not _gen1:
+		return
+	movement_mode = MOVEMENT_WALK
+	player_sprite_number = _walking_sprite()
+	state.set_engine_flag(Gen2WorldState.always_on_bike_flag(data), false)
+
+
+## `LoadBikePlayerSpriteGraphics`' own sheet. Generation 1's is `RedBikeSprite`,
+## which the picture table names no row for; see [method Gen1Layout.bike_sprite].
+func _bike_sprite() -> int:
+	return Gen1Layout.bike_sprite(data.id) if _gen1 \
+		else Gen2WorldSprite.player_bike_sprite(_player_female)
+
+
 ## `.CheckEnvironment`: outdoors, a cave or a gate, and standing on a tile whose
 ## permission's low nibble is `FLOOR_TILE`. Water and every wall code fail it.
+## `IsBikeRidingAllowed` asks neither: two map ids, then the map's tileset.
 func _can_ride_bike_here() -> bool:
+	if _gen1:
+		return Gen1Layout.BIKE_ALLOWED_MAPS.has(current_map.number) \
+			or data.gen1_special_warp_list("bike_riding_tilesets").has(current_map.tileset)
 	if not _is_outdoor(current_map.environment) \
 		and current_map.environment not in [ENVIRONMENT_CAVE, ENVIRONMENT_GATE]:
 		return false

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -99,6 +99,9 @@ static func _scripts_from_cache(value: Variant) -> Dictionary:
 		"address": int(script_values.get("address", 0)),
 		"scenes": _script_pointer_rows(script_values.get("scenes", [])),
 		"callbacks": _script_pointer_rows(script_values.get("callbacks", [])),
+		# Whether the per-frame half opens by clearing `BIT_ALWAYS_ON_BIKE`,
+		# which only the two cycling road gates do. Generation 1's alone.
+		"clears_always_on_bike": bool(script_values.get("clears_always_on_bike", false)),
 	}
 
 

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -1686,6 +1686,10 @@ func move_player(direction: Vector2i) -> bool:
 			if _renderer != null:
 				_renderer.refresh()
 			_refresh_labels()
+		elif _world.blocked_step_warps():
+			_zero_map_name_sign_timer()
+			_start_map_fade()
+			return true
 		else:
 			_play_bump_sfx(movement)
 		return false
@@ -4940,8 +4944,13 @@ func preview_field_item(item: int = Gen2WorldPack.ITEM_ITEMFINDER) -> void:
 	if not bool(_start_menu_host.call("_select_pack_item", item)):
 		return
 	# The row's submenu, and then its first action, which for a key item is USE.
+	# `.choseItem`'s `cp BICYCLE / jp z, .useOrTossItem` opens no submenu, so
+	# that one row is used by the first press and the host is gone behind it.
+	var submenu: bool = _data.generation != RomRegistry.GEN1 \
+		or item != Gen1Layout.ITEM_BICYCLE
 	_start_menu_host.handle_button(PokeButton.A)
-	_start_menu_host.handle_button(PokeButton.A)
+	if submenu and _start_menu_host != null:
+		_start_menu_host.handle_button(PokeButton.A)
 	if _text_box != null:
 		# The box reveals a tile at a time off wall-clock delta, and a capture
 		# owning its own frames spends none on that.
@@ -6569,11 +6578,28 @@ func _on_bike_used(request: Dictionary) -> void:
 		_renderer.refresh()
 
 
+## The [method GameData.special_text] runs Generation 1 keeps the same lines in.
+## A key with no row is a Generation 2 effect no Generation 1 item reaches.
+const GEN1_FIELD_ITEM_TEXTS: Dictionary = {
+	"got_on_bike": ["bicycle", "got_on"],
+	"got_off_bike": ["bicycle", "got_off"],
+}
+
+
+func _field_item_line(key: String) -> String:
+	if _data == null:
+		return ""
+	if _data.generation != RomRegistry.GEN1:
+		return _data.menu_text(key)
+	var run: Array = GEN1_FIELD_ITEM_TEXTS.get(key, [])
+	return "" if run.is_empty() else _data.special_text(String(run[0]), String(run[1]))
+
+
 ## One of `data/text/common_2.asm`'s field-item lines, with `<PLAYER>` filled
 ## from the world the way every other text's marker is. [param fallback] is what
 ## a cache imported before these texts were carries instead.
 func _field_item_text(key: String, fallback: String) -> String:
-	var text: String = _data.menu_text(key) if _data != null else ""
+	var text: String = _field_item_line(key)
 	if text.is_empty():
 		return fallback
 	return text.replace(

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1` and its neighbours are 1535 lines of it, and
-## Generation 1 has added 1847 more to the shared code: 85 the dungeon warps,
-## 152 the region map, 150 the battle animation engine, 140 the transition, 130
-## the Pokedex, 108 the three PCs, 95 the trainer card, 85 the party menu, 66
-## the Day-Care, 42 the status screen and 40 the bag in a battle.
-const MAX_COMMENT_LINES: int = 41052
+## Generation 1 has added 1944 more to the shared code: 152 the region map, 150
+## the battle animation engine, 140 the transition, 130 the Pokedex, 108 the
+## three PCs, 95 the trainer card, 97 the bicycle, 85 the party menu, 85 the
+## dungeon warps, 66 the Day-Care, 42 the status screen, 40 the bag in battle.
+const MAX_COMMENT_LINES: int = 41149
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -9849,10 +9849,7 @@ func _write_gen1_cache() -> void:
 	RomCache.write_json(RomCache.world_maps_path(directory), [
 		_gen1_map(0, Gen1Layout.TILESET_OVERWORLD, 2, 3, GEN1_TOWN_CELLS,
 			[{"x": 1, "y": 1, "destination": 0, "map_group": 0, "map_number": 1}]),
-		_gen1_map(1, 1, 2, 2, GEN1_HOUSE_CELLS, [{
-			"x": 1, "y": 3, "destination": 0, "map_group": 0,
-			"map_number": Gen1Layout.WARP_TO_LAST_MAP,
-		}]),
+		_gen1_gate_map(),
 		_gen1_map(2, 3, 2, 2, GEN1_FOREST_CELLS, []),
 		_gen1_wander_map(),
 	])
@@ -9866,6 +9863,13 @@ func _write_gen1_cache() -> void:
 		"generation": RomRegistry.GEN1,
 		"sha1": "fedcba9876543210",
 		"complete": true,
+		## `BikeRidingTilesets` and `ForcedBikeOrSurfMaps`: the town and the
+		## forest are rideable, the house is not, and the town's own warp cell is
+		## the one `CheckForceBikeOrSurf` mounts on.
+		"special_warps": {
+			"bike_riding_tilesets": [Gen1Layout.TILESET_OVERWORLD, 3],
+			"forced_bike_surf": [{"map": 0, "y": 1, "x": 1}],
+		},
 	})
 
 
@@ -9882,6 +9886,17 @@ func _gen1_map(
 		"connection_flags": 0, "connections": [],
 		"events": {"warps": warps, "coord_events": [], "bg_events": [], "objects": []},
 	}
+
+
+## Map 1: the house behind the town's door, standing in for Route 16 Gate 1F as
+## the one map whose script opens by clearing `BIT_ALWAYS_ON_BIKE`.
+func _gen1_gate_map() -> Dictionary:
+	var map: Dictionary = _gen1_map(1, 1, 2, 2, GEN1_HOUSE_CELLS, [{
+		"x": 1, "y": 3, "destination": 0, "map_group": 0,
+		"map_number": Gen1Layout.WARP_TO_LAST_MAP,
+	}])
+	map["scripts"] = {"clears_always_on_bike": true}
+	return map
 
 
 ## Map 3: a clear four by twelve floor with one object walking its own column,
@@ -9903,6 +9918,81 @@ func _gen1_world(number: int, start: Vector2i) -> Gen2WorldAPI:
 	return Gen2WorldAPI.open(
 		GameData.open_directory(_gen1_directory()), 0, number, start, Gen2WorldState.new()
 	)
+
+
+## `IsBikeRidingAllowed` reads the map's tileset and nothing about the cell the
+## player stands on, and `LoadPlayerSpriteGraphics`' `.ridingBike` puts the bike
+## away on a map it refuses.
+func test_gen1_the_bike_reads_the_tileset_the_map_wears() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 2))
+	var mounted: Dictionary = world.bike_request()
+	assert_true(bool(mounted.get("ok", false)), "the town is rideable")
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
+	assert_eq(world.player_sprite_number, Gen1Layout.bike_sprite(&"red"))
+	assert_eq(StringName(mounted["kind"]), &"bike_on")
+
+	world.player_cell = Vector2i(1, 1)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(bool(world.try_warp().get("ok", false)), "the door opened")
+	assert_eq(world.map_id(), Vector2i(0, 1))
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK, "the house is not rideable")
+	assert_eq(
+		StringName(world.bike_request().get("reason", &"")), &"no_cycling_here",
+		"`NoCyclingAllowedHere` rather than `.Oak`"
+	)
+	RomCache.clear(_gen1_directory())
+
+
+## `CheckForceBikeOrSurf` on the cell the gate's door lands on, and the gate
+## script's own `res BIT_ALWAYS_ON_BIKE` on the way back in. `HandleNewMap` has
+## no counterpart here, so nothing else clears the flag between the two.
+func test_gen1_a_forced_ride_outlives_the_map_and_only_the_gate_ends_it() -> void:
+	var world: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 1))
+	var flag: int = Gen2WorldState.always_on_bike_flag(world.data)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(bool(world.try_warp().get("ok", false)), "the door opened")
+	assert_false(world.always_on_bike(), "the gate is not a forced cell")
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(bool(world.try_warp().get("ok", false)), "the mat led back outside")
+	assert_eq(world.player_cell, Vector2i(1, 1))
+	assert_true(world.always_on_bike(), "`ForcedBikeOrSurfMaps` names that cell")
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE)
+	assert_eq(world.player_sprite_number, Gen1Layout.bike_sprite(&"red"))
+
+	var refused: Dictionary = world.bike_request()
+	assert_false(bool(refused.get("ok", false)))
+	assert_eq(StringName(refused["reason"]), &"cannot_get_off")
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_BIKE, "still riding")
+
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(bool(world.try_warp().get("ok", false)), "the door opened again")
+	assert_false(world.state.is_engine_flag_active(flag), "the gate script cleared it")
+	assert_eq(world.movement_mode, Gen2WorldAPI.MOVEMENT_WALK)
+	RomCache.clear(_gen1_directory())
+
+
+## `CheckWarpsCollision`: a step blocked while standing on a warp still takes it
+## when `ExtraWarpCheck` passes, which is what leaves a map through a warp at its
+## own edge. Crystal has no such path.
+func test_gen1_a_blocked_step_on_a_warp_takes_it() -> void:
+	var world: Gen2WorldAPI = _gen1_world(1, Vector2i(1, 3))
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_true(world.blocked_step_warps(), "the mat sits on the map's own edge")
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	assert_false(world.blocked_step_warps(), "`ExtraWarpCheck` fails facing the room")
+	world.player_cell = Vector2i(1, 2)
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	assert_false(world.blocked_step_warps(), "no warp on that cell")
+	RomCache.clear(_gen1_directory())
+
+	## The town's own door tile, which `IsPlayerStandingOnDoorTileOrWarpTile`
+	## takes on a landed step and `ExtraWarpCheck` refuses facing the wall above.
+	var town: Gen2WorldAPI = _gen1_world(0, Vector2i(1, 1))
+	town.player_facing = Gen2WorldSprite.FACING_UP
+	assert_true(town.warp_pending(), "a door tile needs no ExtraWarpCheck")
+	assert_false(town.blocked_step_warps(), "the collision path asks that check alone")
+	RomCache.clear(_gen1_directory())
+	assert_false(_world(Vector2i(8, 6)).blocked_step_warps(), "Generation 2 never does")
 
 
 ## `CheckTilePassable` walks the tileset's own list, so a tile that is not on it

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -210,6 +210,23 @@ const SPRITE_COUNTS: Dictionary = {&"red": 72, &"blue": 72, &"yellow": 82}
 const SPRITE_STILL_FIRST: Dictionary = {&"red": 0x3D, &"blue": 0x3D, &"yellow": 0x47}
 const PLAYER_SPRITE: Array = [0x4180, 0x05]
 const PLAYER_SPRITE_YELLOW: Array = [0x4571, 0x05]
+## `RedBikeSprite`, which no row of that table names: the walking strip
+## `INCBIN`'d in front of `RedSprite`'s, cached one picture id past the last.
+const BIKE_SPRITE_BYTES: int = 0x180
+
+## `BikeRidingTilesets` and `ForcedBikeOrSurfMaps` as map to its cells. Route
+## 16's and Route 18's four force the bike, Seafoam Islands B3F's and B4F's
+## force surfing, and `IsBikeRidingAllowed` answers yes on 63 real maps of every
+## cartridge, counted from pret's own `data/maps/headers`.
+const BIKE_RIDING_TILESETS: Array[int] = [0, 3, 11, 14, 17]
+const FORCED_RIDES: Dictionary = {
+	27: [[17, 10], [17, 11]], 29: [[33, 8], [33, 9]],
+	161: [[18, 7], [19, 7]], 162: [[4, 14], [5, 14]],
+}
+const BIKE_ALLOWED_MAPS: int = 63
+## Route 16 Gate 1F and Route 18 Gate 1F, the only two scripts opening on
+## `res BIT_ALWAYS_ON_BIKE, [hl]`.
+const BIKE_GATE_MAPS: Array[int] = [186, 190]
 
 ## Every `IsPlayerOnDungeonWarp` caller of the corpus, source map to its holes:
 ## the `dbmapcoord`, the map it drops onto and the `DungeonWarpData` tile it
@@ -255,6 +272,7 @@ func _one_game() -> void:
 	_map_callbacks()
 	_hidden_events()
 	_dungeon_warps()
+	_bike()
 	_toggleables()
 	_wild_objects()
 	_palettes()
@@ -848,9 +866,9 @@ static func _packed(color: Color) -> int:
 func _sprites() -> void:
 	var wanted: int = int(SPRITE_COUNTS[_r.game_id])
 	var still_first: int = int(SPRITE_STILL_FIRST[_r.game_id])
-	if not _r.check(_r.data.overworld_sprite_count() == wanted,
+	if not _r.check(_r.data.overworld_sprite_count() == wanted + 1,
 		"the cache holds %d overworld sprites, wanted %d." % [
-			_r.data.overworld_sprite_count(), wanted,
+			_r.data.overworld_sprite_count(), wanted + 1,
 		]):
 		return
 	var player: Array = PLAYER_SPRITE_YELLOW if _r.game_id == RomRegistry.YELLOW \
@@ -858,6 +876,20 @@ func _sprites() -> void:
 	var red: Gen2WorldSprite = _r.data.overworld_sprite(1)
 	_r.check(red.address == int(player[0]) and red.bank == int(player[1]),
 		"RedSprite reads $%02X:$%04X." % [red.bank, red.address])
+	var bike: Gen2WorldSprite = _r.data.overworld_sprite(
+		Gen1Layout.bike_sprite(_r.game_id)
+	)
+	_r.check(bike != null and bike.bank == red.bank \
+		and bike.address == red.address - BIKE_SPRITE_BYTES \
+		and bike.tiles == Gen1Layout.SPRITE_WALKING_TILES * 2 and bike.is_walking(),
+		"RedBikeSprite reads $%02X:$%04X over %d tiles." % [
+			bike.bank, bike.address, bike.tiles,
+		])
+	_r.check(
+		_r.data.overworld_sprite_indices(Gen1Layout.bike_sprite(_r.game_id)).size()
+			== Gen1Layout.SPRITE_WALKING_TILES * 2 * PokeTiles.TILE_PIXELS,
+		"RedBikeSprite's strip is the wrong size."
+	)
 
 	var census: Dictionary = {"walking": 0, "still": 0}
 	for number: int in range(1, wanted + 1):
@@ -884,6 +916,38 @@ func _sprites() -> void:
 			var picture: int = int(object["sprite"])
 			_r.check(picture >= 1 and picture <= wanted,
 				"map %d has an object drawn with picture id %d." % [map.number, picture])
+
+
+## `IsBikeRidingAllowed`'s two answers, `ForcedBikeOrSurfMaps`' eight cells and
+## the two gate scripts that clear a forced ride, over the whole corpus.
+func _bike() -> void:
+	var tilesets: Array = Array(_r.data.gen1_special_warp_list("bike_riding_tilesets"))
+	_r.check(tilesets == BIKE_RIDING_TILESETS,
+		"BikeRidingTilesets reads %s." % str(tilesets))
+	var allowed: int = 0
+	for map: Gen2WorldMap in _maps.values():
+		var gate: bool = bool(map.scripts.get("clears_always_on_bike", false))
+		_r.check(gate == BIKE_GATE_MAPS.has(map.number),
+			"map %d answers %s to clearing a forced ride." % [map.number, gate])
+		if BIKE_RIDING_TILESETS.has(map.tileset) \
+			or Gen1Layout.BIKE_ALLOWED_MAPS.has(map.number):
+			allowed += 1
+		_forced_ride_cells(map)
+	_r.check(allowed == BIKE_ALLOWED_MAPS,
+		"the bike is allowed on %d maps." % allowed)
+	_r.note("gen1 bike allowed on %d maps, forced on %d cells" % [
+		allowed, FORCED_RIDES.size() * 2,
+	])
+
+
+func _forced_ride_cells(map: Gen2WorldMap) -> void:
+	var hits: Array = []
+	for y: int in map.collision_height:
+		for x: int in map.collision_width:
+			if _r.data.gen1_forces_ride(map.number, Vector2i(x, y)):
+				hits.append([x, y])
+	_r.check(hits == FORCED_RIDES.get(map.number, []),
+		"map %d forces a ride on %s." % [map.number, str(hits)])
 
 
 ## Every object `ShowObject` and `HideObject` can name: one object a global

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -9,9 +9,9 @@ extends RefCounted
 
 ## `data/maps/objects`' own totals, and the `LAST_MAP` warps inside them.
 const WARP_CENSUS: Dictionary = {
-	&"red": {"warps": 813, "last_map": 251, "driven": 554, "hops": 758},
-	&"blue": {"warps": 813, "last_map": 251, "driven": 554, "hops": 758},
-	&"yellow": {"warps": 817, "last_map": 253, "driven": 556, "hops": 756},
+	&"red": {"warps": 813, "last_map": 251, "driven": 554, "hops": 758, "edge": 394},
+	&"blue": {"warps": 813, "last_map": 251, "driven": 554, "hops": 758, "edge": 394},
+	&"yellow": {"warps": 817, "last_map": 253, "driven": 556, "hops": 756, "edge": 397},
 }
 
 ## `SilphCoElevator_Object`'s two warps name UNUSED_MAP_ED, which has no header;
@@ -161,6 +161,10 @@ const PRIZE_MENUS: Dictionary = {
 ## `LavenderTownLittleGirlText` asks and branches on the answer, and
 ## `GameCornerFishingGuruText` reaches `Has9990Coins` only with the COIN CASE in
 ## the bag, so its own flag decides which of two boxes it opens.
+## Route 16 and the cell its gate's south door lands on, which
+## `ForcedBikeOrSurfMaps`' first row names.
+const ROUTE_16: int = 27
+const ROUTE_16_GATE_DOOR := Vector2i(17, 10)
 const BIKE_SHOP: int = 66
 const BIKE_YOUNGSTER := Vector2i(1, 4)
 const BIKE_FLAG: int = 192
@@ -352,6 +356,7 @@ func _one_game() -> void:
 	_check_flying()
 	_check_a_dungeon_fall()
 	_check_an_escape_rope()
+	_check_the_bicycle()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -407,6 +412,7 @@ func _check_warps() -> void:
 	var warps: int = 0
 	var last_map: int = 0
 	var driven: int = 0
+	var edge: int = 0
 	var arrival_only: Array = []
 	var unstandable: Array = []
 	for map: Gen2WorldMap in _r.data.world_maps():
@@ -425,6 +431,17 @@ func _check_warps() -> void:
 			if facing < 0:
 				arrival_only.append([map.number, index])
 				continue
+			## `ExtraWarpCheck`'s own warps: neither a door nor a warp tile, so
+			## `CheckWarpsNoCollision` asks the map edge or the carpet in front
+			## and `CheckWarpsCollision` takes them on a step that never lands.
+			if not Gen2WorldCollision.gen1_is_warp_tile(
+				map.tileset, map.collision_at(cell.x, cell.y)
+			) and not Gen2WorldCollision.gen1_is_door_tile(
+				map.tileset, map.collision_at(cell.x, cell.y)
+			):
+				edge += 1
+				_r.check(world.blocked_step_warps(),
+					"map %d warp %d takes no blocked step." % [map.number, index])
 			## A `LAST_MAP` warp names no map of its own until one is walked out
 			## of, which [method _check_last_map_round_trip] is; the lift's two
 			## name a map with no header at all.
@@ -449,7 +466,11 @@ func _check_warps() -> void:
 		"%d warps taken, wanted %d" % [driven, pinned["driven"]])
 	_r.check(arrival_only == ARRIVAL_ONLY, "warps firing from no facing: %s" % [arrival_only])
 	_r.check(unstandable == UNSTANDABLE_WARPS, "warps on an impassable tile: %s" % [unstandable])
-	_r.note("%d warps, %d back to LAST_MAP, %d taken" % [warps, last_map, driven])
+	_r.check(edge == int(pinned["edge"]),
+		"%d warps need ExtraWarpCheck, wanted %d" % [edge, pinned["edge"]])
+	_r.note("%d warps, %d back to LAST_MAP, %d taken, %d off ExtraWarpCheck" % [
+		warps, last_map, driven, edge,
+	])
 
 
 ## The first facing `CheckWarpsNoCollision` would warp from, or -1.
@@ -1800,6 +1821,87 @@ func _check_a_dungeon_fall() -> void:
 			and road.player_cell == VICTORY_ROAD_LANDING,
 		"Victory Road's hole landed on %s at %s." % [road.map_id(), road.player_cell]
 	)
+
+
+## `ItemUseBicycle` and `CheckForceBikeOrSurf` walked together: mounted in Pallet
+## Town, refused in Red's house, put away by walking into it, forced by the gate
+## door onto Route 16 and refused there, and let go by the gate's own script.
+func _check_the_bicycle() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, PALLET_TOWN, PALLET_DOOR)
+	if world == null:
+		return
+	var bike: int = Gen1Layout.bike_sprite(_r.game_id)
+	var got_on: Dictionary = world.bike_request()
+	if not _r.check(
+		bool(got_on.get("ok", false)) and world.movement_mode == Gen2WorldAPI.MOVEMENT_BIKE
+			and world.player_sprite_number == bike,
+		"the bike left the player %s on sprite %d." % [
+			world.movement_mode, world.player_sprite_number,
+		]
+	):
+		return
+	world.gen1_fly_to(VIRIDIAN_CITY)
+	_r.check(
+		world.movement_mode == Gen2WorldAPI.MOVEMENT_WALK
+			and world.player_sprite_number == Gen2WorldSprite.SPRITE_PLAYER,
+		"flying left the player %s on sprite %d." % [
+			world.movement_mode, world.player_sprite_number,
+		]
+	)
+	var indoors: Gen2WorldAPI = _r.open_world(0, PALLET_TOWN, PALLET_DOOR)
+	if indoors == null:
+		return
+	indoors.bike_request()
+	indoors.player_facing = Gen2WorldSprite.FACING_UP
+	indoors.try_warp()
+	_r.check(
+		indoors.map_id() == Vector2i(0, REDS_HOUSE_1F)
+			and indoors.movement_mode == Gen2WorldAPI.MOVEMENT_WALK,
+		"riding into Red's house left the player %s." % indoors.movement_mode
+	)
+	_r.check(
+		StringName(indoors.bike_request().get("reason", &"")) == &"no_cycling_here",
+		"the bike was ridden indoors."
+	)
+	_check_the_cycling_road()
+
+
+## The gate's south door lands on `ForcedBikeOrSurfMaps`' own cell, and the
+## Bicycle is refused for as long as `BIT_ALWAYS_ON_BIKE` stands.
+func _check_the_cycling_road() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, ROUTE_16, ROUTE_16_GATE_DOOR)
+	if world == null:
+		return
+	world.player_facing = _firing_facing(world, ROUTE_16_GATE_DOOR)
+	if not _r.check(bool(world.try_warp().get("ok", false)),
+		"Route 16's gate door refused the warp."):
+		return
+	_r.check(world.movement_mode == Gen2WorldAPI.MOVEMENT_WALK,
+		"the gate left the player %s." % world.movement_mode)
+	var inside: Vector2i = world.player_cell
+	world.player_facing = _firing_facing(world, inside)
+	if not _r.check(bool(world.try_warp().get("ok", false)),
+		"the gate refused the way back onto Route 16."):
+		return
+	_r.check(
+		world.player_cell == ROUTE_16_GATE_DOOR and world.always_on_bike()
+			and world.movement_mode == Gen2WorldAPI.MOVEMENT_BIKE,
+		"leaving the gate left the player %s at %s." % [
+			world.movement_mode, world.player_cell,
+		]
+	)
+	_r.check(
+		StringName(world.bike_request().get("reason", &"")) == &"cannot_get_off",
+		"the Bicycle was put away on Cycling Road."
+	)
+	world.player_facing = _firing_facing(world, ROUTE_16_GATE_DOOR)
+	world.try_warp()
+	_r.check(
+		not world.always_on_bike()
+			and world.movement_mode == Gen2WorldAPI.MOVEMENT_WALK,
+		"the gate left the ride %s forced." % ["still" if world.always_on_bike() else "no longer"]
+	)
+	_r.note("gen1 bike forced on Route 16 at %s" % ROUTE_16_GATE_DOOR)
 
 
 ## `ItemUseEscapeRope`: refused outdoors and in Agatha's room, taken in a cave,

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -54,6 +54,7 @@ const KIND_HELP: Dictionary = {
 	&"pet_actor_arc": "cell: the same actor mid-ledge, at the top of the arc its span names",
 	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
 	&"dungeon_fall": "0 or 1: the step north onto a Generation 1 dungeon hole. 0 is LeaveMapAnim at its whitest, 1 the map DungeonWarpData lands on",
+	&"cycling_road": "none: the walk east into Route 16's gate and back out onto ForcedBikeOrSurfMaps' own cell, with the Bicycle refused behind it (`red 0 27 ... cycling_road@16,10`)",
 	&"script_fade": "special, frames: one of the five fade specials over the map",
 	&"door": "door mat: .CheckWarp's carpet, standing on an interior door's mat",
 	&"ice_slide": "direction, frames: DoPlayerMovement.CheckForced's run. Direction is down, up, left, right",
@@ -443,6 +444,7 @@ const STAGERS: Dictionary = {
 	&"elevator": &"_stage_elevator",
 	&"warp": &"_stage_warp",
 	&"dungeon_fall": &"_stage_dungeon_fall",
+	&"cycling_road": &"_stage_cycling_road",
 	&"door": &"_stage_door",
 	&"ledge": &"_stage_ledge",
 	&"ice_slide": &"_stage_ice_slide",
@@ -904,6 +906,30 @@ func _stage_dungeon_fall() -> void:
 	for _frame: int in WARP_FRAME_CAP:
 		if _screen.map_fade().is_empty():
 			break
+		_screen.advance_frame()
+
+
+## `CheckForceBikeOrSurf`: the gate's own door lands back on a cell of
+## `ForcedBikeOrSurfMaps`, so the walk out mounts the bike and every Bicycle
+## after it is refused by `.useOrTossItem`.
+func _stage_cycling_road() -> void:
+	_walk_a_warp(_screen.move_right)
+	_walk_a_warp(_screen.move_left)
+	_screen.preview_field_item(Gen1Layout.ITEM_BICYCLE)
+
+
+## Steps [param towards] until the map has changed, then spends the fade behind
+## it: a press landing inside one is eaten and the next walk goes nowhere.
+func _walk_a_warp(towards: Callable) -> void:
+	var from: Variant = _screen.world_snapshot().get("map")
+	for _frame: int in WARP_FRAME_CAP:
+		towards.call()
+		_screen.advance_frame()
+		if _screen.world_snapshot().get("map") != from:
+			break
+	for _frame: int in WARP_FRAME_CAP:
+		if _screen.map_fade().is_empty():
+			return
 		_screen.advance_frame()
 
 


### PR DESCRIPTION
## Added

`RedBikeSprite` is loaded by address and no `SpriteSheetPointerTable` row names it, so `Gen1WorldImporter` takes the 24-tile strip $180 bytes in front of SPRITE_RED's and appends it one picture id past the table's last.

`IsBikeRidingAllowed` replaces Crystal's `.CheckEnvironment` on a Generation 1 map: ROUTE_23, INDIGO_PLATEAU or a tileset on `BikeRidingTilesets`, and nothing about the cell stood on. 63 maps of every cartridge allow it, counted from pret's own map headers. `LoadPlayerSpriteGraphics` asks the same question on every map load, so riding into a house puts the bike away.

`ItemUseBicycle` gets off with no test and only gets on through that check, refusing with `NoCyclingAllowedHereText` where every other failed effect says `.Oak`. `.choseItem`'s `cp BICYCLE / jp z, .useOrTossItem` is why the Bicycle is the one bag row with no USE/TOSS box over it, and `.useOrTossItem`'s own `bit BIT_ALWAYS_ON_BIKE` refuses it with `CannotGetOffHereText` on Cycling Road whether or not the player is riding. Both lines leave the pack open, the way `jp ItemMenuLoop` does.

`CheckForceBikeOrSurf` runs behind every map load. `ForcedBikeOrSurfMaps`' eight cells are Route 16's and Route 18's four, which mount the bike and set `BIT_ALWAYS_ON_BIKE`, and Seafoam Islands B3F's and B4F's four, which force surfing. There is no `ResetBikeFlags` here, so the flag outlives a map change and only Route 16 Gate 1F's and Route 18 Gate 1F's per-frame scripts clear it; nothing interprets that half of a script, so the five bytes those two open with are matched out of the script's own bank. `HandleFlyWarpOrDungeonWarp` puts the player down on foot, so a fly, an Escape Rope, Dig, Teleport, a blackout and a dungeon hole all end a ride.

## Fixed

`CheckWarpsCollision` was missing, and 394 warps on Red and Blue and 397 on Yellow read through it. A step blocked while standing on a warp still takes it when `ExtraWarpCheck` passes, which is the only way out of a map whose exit is a warp at its own edge: walking west out of Route 16's gate went nowhere. `Gen2WorldAPI.blocked_step_warps` asks that check alone, where `CheckWarpsNoCollision` takes a door or warp tile in front of it, so a landed step on a Pokemon Center mat warps and a bump into the counter beside it does not.

`preview_field_item` pressed A twice on a row that opens no submenu and called into a host the first press had dropped.

## Changed

Cache format 122: the overworld sheet list carries `RedBikeSprite`, the map record says whether its script clears a forced ride, and `BikeRidingTilesets`, `ForcedBikeOrSurfMaps`, `GotOnBicycleText`, `GotOffBicycleText`, `NoCyclingAllowedHereText` and `CannotGetOffHereText` are imported. All six cartridges re-imported and each says `layout: Layout verified.`

## Proof

| Check | Result |
|---|---|
| `validate.gd -- all` | 93 topics pass |
| GUT, whole tree | 172 scripts, 4482 tests, 0 failures |
| `--warning-scan` | 0 warnings in 634 scripts |
| `replay_world.gd` | 33 routes, 0 failures |
| Story walk, three profiles | exit 0, 130 steps, no failure |
| `gen1_maps` | bike allowed on 63 maps, forced on 8 cells, on all three cartridges |
| `gen1_walk` | 394 / 394 / 397 warps answered by `ExtraWarpCheck` |