### PR TITLE
Play the Generation 1 Poke Flute

### DIFF
--- a/game/battle/battle.gd
+++ b/game/battle/battle.gd
@@ -2497,15 +2497,19 @@ func use_bag_item(item: int, target_index: int = -1, move_slot: int = -1) -> Dic
 
 ## `ItemUsePokeFlute`'s in-battle branch: everything asleep on the field and in
 ## both parties wakes, `WakeUpEntireParty` reaching the enemy's party only in a
-## trainer battle. The turn is spent either way and the key item is not.
+## trainer battle. `woken` is `wWereAnyMonsAsleep`, which picks the box behind
+## it. The turn is spent either way and the key item is not.
 func _play_poke_flute(item: int) -> Dictionary:
 	var woken: int = 0
-	for side: int in [PLAYER, ENEMY]:
-		if side == ENEMY and not is_trainer_battle:
-			woken += _wake_up(mon(ENEMY))
-			continue
-		for index: int in party(side).size():
-			woken += _wake_up(party(side).at(index))
+	for index: int in party(PLAYER).size():
+		woken += _wake_up(party(PLAYER).at(index))
+	if is_trainer_battle:
+		for index: int in party(ENEMY).size():
+			woken += _wake_up(party(ENEMY).at(index))
+	else:
+		var wild: int = _wake_up(mon(ENEMY))
+		if Gen1Layout.flute_counts_wild(data.id):
+			woken += wild
 	return {"ok": true, "kind": &"poke_flute", "item": item, "woken": woken, "spent": false}
 
 

--- a/game/battle/battle_screen.gd
+++ b/game/battle/battle_screen.gd
@@ -361,7 +361,7 @@ var _capture_selecting: bool = false:
 		_capture_selecting = value
 		_list_state_changed()
 var _capture_waiting: bool = false
-var _capture_messages: Array[String] = []
+var _box_queue: Array[String] = []
 ## The [constant Gen2Battle.CAUGHT] event built by [method complete_capture] and
 ## published on the box that prints its Gotcha line, so a subscriber has moved
 ## before the nickname prompt opens.
@@ -1878,6 +1878,10 @@ const ANIM_THROW_POKE_BALL: int = 0x100
 const NEW_DEX_DATA_TEXT: String = "%s's data\nwas newly added to\nthe #DEX."
 const BALL_BLOCKED_TEXT: String = "The trainer\nblocked the BALL!"
 const BALL_DONT_BE_A_THIEF_TEXT: String = "Don't be a thief!"
+## What a cache imported before `poke_flute_text` was carries instead.
+const FLUTE_NO_EFFECT_TEXT: String = "Played the #\nFLUTE."
+const FLUTE_HAD_EFFECT_TEXT: String = "<PLAYER> played the\n# FLUTE."
+const FLUTE_WOKE_UP_TEXT: String = "All sleeping\n#MON woke up."
 const BALL_BOX_FULL_TEXT: String = "The #MON BOX\nis full. That\ncan't be used now."
 ## `_BoxFullCannotThrowBallText`, `BoxFullCannotThrowBall`'s own words.
 const GEN1_BALL_BOX_FULL_TEXT: String = "The #MON BOX\nis full! Can't%suse that item!"
@@ -2988,9 +2992,9 @@ func use_selected_pack_item() -> Dictionary:
 ## `UseDisposableItem` spends the ball anyway. The turn goes with it:
 ## `wItemEffectSucceeded` and `wBattlePlayerAction` are one byte.
 func _block_ball_in_trainer_battle(ball: int) -> Dictionary:
-	_capture_messages.clear()
-	_capture_messages.append(BALL_BLOCKED_TEXT)
-	_capture_messages.append(BALL_DONT_BE_A_THIEF_TEXT)
+	_box_queue.clear()
+	_box_queue.append(BALL_BLOCKED_TEXT)
+	_box_queue.append(BALL_DONT_BE_A_THIEF_TEXT)
 	_begin_animation({
 		"param": ANIM_PARAM_NO_ITEM,
 		"index": ANIM_THROW_POKE_BALL,
@@ -3059,7 +3063,10 @@ func _use_pack_item(item: int, target: int, move_slot: int = -1) -> Dictionary:
 	## `UseDisposableItem`, which the Poke Flute alone is never handed to.
 	if bool(used.get("spent", true)):
 		item_used.emit(item, target)
-	show_message(_item_used_text(item))
+	if StringName(used.get("kind", &"")) == &"poke_flute":
+		_show_flute_boxes(int(used.get("woken", 0)) > 0)
+	else:
+		show_message(_item_used_text(item))
 	if _battle.is_over():
 		## `PokeDollEffect`'s `wForcedSwitch`: the battle is already over, so no
 		## turn is taken and the terminal text is what follows this line.
@@ -3153,7 +3160,7 @@ func _capture_guard() -> Dictionary:
 	if not _capture_refusal.is_empty():
 		show_message(_capture_refusal)
 		return _capture_failure(&"capture_refused_by_rules")
-	if _capture_waiting or not _capture_messages.is_empty() \
+	if _capture_waiting or not _box_queue.is_empty() \
 		or not _capture_result.is_empty():
 		return _capture_failure(&"capture_input_busy")
 	if not _pending.is_empty():
@@ -3198,7 +3205,7 @@ func complete_capture(result: Dictionary) -> Dictionary:
 	if not _capture_waiting:
 		return _capture_failure(&"capture_result_not_pending")
 	_capture_waiting = false
-	_capture_messages.clear()
+	_box_queue.clear()
 	_capture_result = result.duplicate(true)
 	_capture_terminal = false
 	if not bool(result.get("ok", false)):
@@ -3232,7 +3239,7 @@ func complete_capture(result: Dictionary) -> Dictionary:
 	var wobbles: int = clampi(int(result.get("wobbles", 0)), 0, 3)
 	var caught: bool = bool(result.get("caught", false))
 	if caught:
-		_capture_messages.append(
+		_box_queue.append(
 			(GEN1_CAUGHT_TEXT if _generation() == RomRegistry.GEN1 else CAUGHT_TEXT)
 			% _name_of(_enemy)
 		)
@@ -3242,11 +3249,11 @@ func complete_capture(result: Dictionary) -> Dictionary:
 		## instead, which comes with the switch question rather than here.
 		if bool(result.get("contest", false)) \
 			and not bool(result.get("replace_offer", false)):
-			_capture_messages.append("Caught %s!" % _name_of(_enemy))
+			_box_queue.append("Caught %s!" % _name_of(_enemy))
 		_capture_terminal = true
 		_capture_caught_event = _caught_event(result)
 	else:
-		_capture_messages.append(
+		_box_queue.append(
 			GEN1_BREAK_FREE_TEXT[wobbles] if _generation() == RomRegistry.GEN1
 			else BREAK_FREE_TEXT[wobbles]
 		)
@@ -3303,16 +3310,16 @@ func _show_capture_selection() -> void:
 	_reopen_menu_layer()
 
 
-func _show_next_capture_message() -> void:
-	if _capture_messages.is_empty():
+func _show_next_box() -> void:
+	if _box_queue.is_empty():
 		return
-	show_message(_capture_messages.pop_front())
+	show_message(_box_queue.pop_front())
 	## `Text_GotchaMonWasCaught` is always the last line of a caught throw, so
 	## the queue running dry on a terminal capture is that box. Published here
 	## rather than in [method complete_capture] because a subscriber asking for a
 	## line of its own owes the same ordering every event gets: after the line
 	## being shown when it asked.
-	if _capture_terminal and _capture_messages.is_empty() \
+	if _capture_terminal and _box_queue.is_empty() \
 		and not _capture_caught_event.is_empty():
 		var event: Dictionary = _capture_caught_event
 		_capture_caught_event = {}
@@ -3384,17 +3391,31 @@ func _item_refusal_text(reason: StringName) -> String:
 	).replace(Gen2WorldPC.PLAYER_MARKER, _player_label())
 
 
-func _gen1_item_text(key: String, fallback: String) -> String:
+func _gen1_item_text(key: String, fallback: String, run: String = "item_use") -> String:
 	if _data == null or _generation() != RomRegistry.GEN1:
 		return fallback
-	var text: String = _data.special_text("item_use_text", key)
+	var text: String = _data.special_text(run, key)
 	return fallback if text.is_empty() else text
 
 
-## `ItemUsedText`, the one line `PokeBallEffect` and every other battle item
-## print before their effect runs. A ball says it too: the throw, the rocking and
-## the click are the animation behind this line, and the next thing said is
-## already the outcome.
+## `ItemUsePokeFlute` reaches neither `PrintItemUseTextAndRemoveItem` nor
+## `UseDisposableItem`, so its own boxes are all a battle says.
+## `Music_PokeFluteInBattle` sits between the two and waits on a channel no
+## driver here fills.
+func _show_flute_boxes(woke: bool) -> void:
+	_box_queue.clear()
+	if not woke:
+		show_message(_gen1_item_text("no_effect", FLUTE_NO_EFFECT_TEXT, "poke_flute"))
+		return
+	show_message(_gen1_item_text(
+		"had_effect", FLUTE_HAD_EFFECT_TEXT, "poke_flute"
+	).replace(Gen2WorldPC.PLAYER_MARKER, _player_label()))
+	_box_queue.append(_gen1_item_text("woke_up", FLUTE_WOKE_UP_TEXT, "poke_flute"))
+
+
+## `ItemUseText00`, the line `PrintItemUseTextAndRemoveItem` prints in front of
+## an effect. A ball says it too: the throw, the rocking and the click are the
+## animation behind it, and the next thing said is already the outcome.
 func _item_used_text(item: int) -> String:
 	if _generation() == RomRegistry.GEN1:
 		## `_ItemUseText001` and `_ItemUseText002` with the name between them:
@@ -3560,7 +3581,7 @@ func _clear_capture_action() -> void:
 	_capture_spent_turn = {}
 	_capture_selecting = false
 	_capture_waiting = false
-	_capture_messages.clear()
+	_box_queue.clear()
 	_capture_caught_event = {}
 	_capture_terminal = false
 	_contest_already_caught_said = false
@@ -3918,8 +3939,8 @@ func _continue_after_messages() -> void:
 		return
 	if _a_list_owns_the_joypad():
 		return
-	if not _capture_messages.is_empty():
-		_show_next_capture_message()
+	if not _box_queue.is_empty():
+		_show_next_box()
 		return
 	## `PokeBallEffect`'s own `call ClearSprites`, which is the first thing after
 	## `Text_GotchaMonWasCaught` has been pressed past: the ball `anim_keepsprites`

--- a/game/data/game_data.gd
+++ b/game/data/game_data.gd
@@ -2618,6 +2618,20 @@ func gen1_forces_ride(map: int, cell: Vector2i) -> bool:
 	return false
 
 
+## The Snorlax whose flute cells hold [param cell] on [param map], as the
+## `SetEvent` and `CheckEvent` pair `ItemUsePokeFlute` reads there.
+func gen1_snorlax_flute(map: int, cell: Vector2i) -> Dictionary:
+	for row: Variant in _special_warps.get("snorlax_flute", []) as Array:
+		var flute: Dictionary = row
+		if int(flute.get("map", -1)) != map:
+			continue
+		for entry: Variant in flute.get("cells", []) as Array:
+			var coords: Dictionary = entry
+			if int(coords.get("x", -1)) == cell.x and int(coords.get("y", -1)) == cell.y:
+				return {"fight": int(flute["fight"]), "beat": int(flute["beat"])}
+	return {}
+
+
 ## One of the `db` lists ending in `-1` that `_import_special_warps` reads:
 ## `EscapeRopeTilesets`, `SafariZoneRestHouses` or `BikeRidingTilesets`.
 func gen1_special_warp_list(name: String) -> PackedInt32Array:

--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -138,7 +138,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_battle_anims,
 	_verify_facility_text,
 	_verify_dex_ratings,
-	_verify_bike_data,
+	_verify_overworld_coords,
 	_verify_world,
 ]
 
@@ -174,6 +174,7 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"pick_up_item": ["found_item_text", Gen1Layout.PICK_UP_TEXT_AT],
 	"item_use": ["item_use_text", Gen1Layout.ITEM_USE_TEXT_AT],
 	"bicycle": ["bicycle_text", Gen1Layout.BICYCLE_TEXT_AT],
+	"poke_flute": ["poke_flute_text", Gen1Layout.POKE_FLUTE_TEXT_AT],
 	"start_menu": ["start_menu_text", Gen1Layout.START_MENU_TEXT_AT],
 	"coin_case": ["coin_case_text", Gen1Layout.COIN_CASE_TEXT_AT],
 	"party_menu": ["party_menu_text", Gen1Layout.PARTY_MENU_TEXT_AT],
@@ -507,9 +508,10 @@ static func _verify_facility_text(rom: RomFile, layout: Dictionary) -> Dictionar
 	return _ok()
 
 
-## `BikeRidingTilesets`' five rows and `ForcedBikeOrSurfMaps`' eight, each
-## naming something the rest of the cache holds.
-static func _verify_bike_data(rom: RomFile, layout: Dictionary) -> Dictionary:
+## The tables an overworld routine walks against the player's cell, each naming
+## something the rest of the cache holds: `BikeRidingTilesets`' five rows,
+## `ForcedBikeOrSurfMaps`' eight and the two Snorlax flute lists.
+static func _verify_overworld_coords(rom: RomFile, layout: Dictionary) -> Dictionary:
 	var tilesets: Array = _byte_list(rom, int(layout["bike_riding_tilesets"]))
 	if tilesets.size() != Gen1Layout.BIKE_RIDING_TILESET_COUNT:
 		return _fail("BikeRidingTilesets holds %d rows." % tilesets.size())
@@ -522,6 +524,11 @@ static func _verify_bike_data(rom: RomFile, layout: Dictionary) -> Dictionary:
 	for row: Dictionary in forced:
 		if not Gen1Layout.is_real_map(int(row["map"])):
 			return _fail("ForcedBikeOrSurfMaps names map %d." % int(row["map"]))
+	var flutes: Array = _snorlax_flute(rom, layout)
+	for index: int in Gen1Layout.SNORLAX_FLUTES.size():
+		var cells: Array = (flutes[index] as Dictionary)["cells"]
+		if cells.size() != int(Gen1Layout.SNORLAX_FLUTES[index]["count"]):
+			return _fail("Snorlax flute list %d holds %d cells." % [index, cells.size()])
 	return _ok()
 
 
@@ -1123,7 +1130,26 @@ func _import_special_warps(rom: RomFile, layout: Dictionary) -> Dictionary:
 		"rest_houses": _byte_list(rom, int(layout["rest_houses"])),
 		"bike_riding_tilesets": _byte_list(rom, int(layout["bike_riding_tilesets"])),
 		"forced_bike_surf": _forced_bike_surf(rom, layout),
+		"snorlax_flute": _snorlax_flute(rom, layout),
 	}
+
+
+## `Route12SnorlaxFluteCoords` and `Route16SnorlaxFluteCoords`, adjacent the way
+## the two dungeon warp tables are, as `dbmapcoord`'s own `db y, x` pairs.
+static func _snorlax_flute(rom: RomFile, layout: Dictionary) -> Array:
+	var at: int = int(layout["snorlax_flute_coords"])
+	var out: Array = []
+	for flute: Dictionary in Gen1Layout.SNORLAX_FLUTES:
+		var cells: Array = []
+		while rom.u8(at) != Gen1Layout.TILESET_LIST_END:
+			cells.append({"y": rom.u8(at), "x": rom.u8(at + 1)})
+			at += Gen1Layout.SNORLAX_FLUTE_ROW_SIZE
+		at += 1
+		out.append({
+			"map": int(flute["map"]), "cells": cells,
+			"fight": int(flute["fight"]), "beat": int(flute["beat"]),
+		})
+	return out
 
 
 ## `ForcedBikeOrSurfMaps`, whose `db map, y, x` rows `CheckForceBikeOrSurf` walks

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -603,6 +603,10 @@ const ITEM_USE_TEXT_AT: Dictionary = {
 ## `GotOnBicycleText` and `GotOffBicycleText`, pinned away from the run above
 ## because Yellow's `DontHavePokemonText` sits between them and it.
 const BICYCLE_TEXT_AT: Dictionary = {"got_on": 0x00, "got_off": 0x0A}
+## `ItemUsePokeFlute`'s own three, in file order.
+const POKE_FLUTE_TEXT_AT: Dictionary = {
+	"no_effect": 0x00, "woke_up": 0x05, "had_effect": 0x0A,
+}
 ## `CannotGetOffHereText`, which `.useOrTossItem` prints in front of `UseItem`
 ## rather than through `ItemUseFailed`. `CannotUseItemsHereText` above it is the
 ## Colosseum's and no screen here reaches it.
@@ -749,6 +753,18 @@ const SEAFOAM_ISLANDS_B4F: int = 0xA2
 ## Gate 1F's and Route 18 Gate 1F's per-frame scripts open with.
 const ALWAYS_ON_BIKE_BIT: int = 5
 
+## `ItemUsePokeFlute`'s two maps and the events each branch reads, in the order
+## their coordinate tables sit in. Both cartridges number the four alike;
+## Yellow's third branch is Pikachu at PEWTER_POKECENTER, which nothing follows
+## the player here.
+const ROUTE_12: int = 0x17
+const ROUTE_16: int = 0x1B
+const SNORLAX_FLUTE_ROW_SIZE: int = 2
+const SNORLAX_FLUTES: Array[Dictionary] = [
+	{"map": ROUTE_12, "fight": 1166, "beat": 1167, "count": 4},
+	{"map": ROUTE_16, "fight": 1224, "beat": 1225, "count": 2},
+]
+
 ## `NOT_VISITED`, which `BuildFlyLocationsList` writes for a town the player has
 ## not been to, and `.townMapFlyLoop`'s own `ld c, 15` between two draws.
 const TOWN_MAP_NOT_VISITED: int = 0xFE
@@ -785,8 +801,11 @@ const BOX_COUNT: int = 12
 const BOX_CAPACITY: int = 20
 
 ## `EVENT_MET_BILL`, which puts BILL's PC on the machine's top menu where
-## SOMEONE's PC otherwise stands. Counted off `constants/event_constants.asm`.
-const EVENT_MET_BILL: int = 1360
+## SOMEONE's PC otherwise stands. Yellow's unused `EVENT_54F` sits below it in
+## `constants/event_constants.asm` and pushes it one higher.
+const MET_BILL_EVENTS: Dictionary = {
+	RomRegistry.RED: 1360, RomRegistry.BLUE: 1360, RomRegistry.YELLOW: 1361,
+}
 
 ## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
 ## it. `SwitchToMapRomBank` selects that bank once, which is what puts a map's
@@ -1432,6 +1451,10 @@ const RED_BLUE: Dictionary = {
 	"bike_riding_tilesets": 0x009E2,
 	"forced_bike_surf": 0x0C3E6,
 	"status_flags_6": 0xD732,
+	## `Route12SnorlaxFluteCoords` with `Route16SnorlaxFluteCoords` behind it,
+	## and the three boxes `ItemUsePokeFlute` prints from behind both.
+	"snorlax_flute_coords": 0x0E1FD,
+	"poke_flute_text": 0x0E20B,
 	"bicycle_text": 0x0E5F2,
 	"start_menu_text": 0x1342F,
 	"battle_font": 0x11EA0,
@@ -1645,6 +1668,8 @@ const YELLOW: Dictionary = {
 	"bike_riding_tilesets": 0x00822,
 	"forced_bike_surf": 0x0C12F,
 	"status_flags_6": 0xD731,
+	"snorlax_flute_coords": 0x0E0AC,
+	"poke_flute_text": 0x0E0BA,
 	"bicycle_text": 0x0E536,
 	"start_menu_text": 0x11FD9,
 	"battle_font": 0x10A20,
@@ -1932,6 +1957,16 @@ static func pic_bank(layout: Dictionary, index: int) -> int:
 ## behind Agatha's room.
 static func map_count(id: StringName) -> int:
 	return MAP_COUNT_YELLOW if id == RomRegistry.YELLOW else MAP_COUNT_RED_BLUE
+
+
+static func met_bill_event(id: StringName) -> int:
+	return int(MET_BILL_EVENTS.get(id, MET_BILL_EVENTS[RomRegistry.RED]))
+
+
+## `.inBattle`'s `wWereAnyMonsAsleep`: Yellow's `ld c, a` counts the wild's own
+## sleep, where Red and Blue clear it and print `PlayedFluteNoEffectText` anyway.
+static func flute_counts_wild(id: StringName) -> bool:
+	return id == RomRegistry.YELLOW
 
 
 ## `CheckIfInOutsideMap`: which maps write `wLastMap` on the way out of them.

--- a/game/world/start_menu_screen.gd
+++ b/game/world/start_menu_screen.gd
@@ -1591,6 +1591,8 @@ func _resolve_field_item(item: int) -> Dictionary:
 			request["rod"] = rod
 		Gen2WorldPack.FIELD_EFFECT_ITEMFINDER:
 			request["found"] = _world.hidden_item_nearby()
+		Gen2WorldPack.FIELD_EFFECT_POKE_FLUTE:
+			request.merge(_world.poke_flute_request(), true)
 		Gen2WorldPack.FIELD_EFFECT_CARD_KEY:
 			var slot: Dictionary = _world.card_key_request()
 			if not bool(slot.get("ok", false)):

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -8627,6 +8627,21 @@ func _gen1_check_escape() -> StringName:
 	return &""
 
 
+## `ItemUsePokeFlute`'s overworld half, which refuses nothing: only the box
+## changes. The flag a standing Snorlax sets is read by that map's own per-frame
+## script alone, so the walk-up line lands and the fight behind it does not.
+func poke_flute_request() -> Dictionary:
+	var request: Dictionary = {"ok": true, "woke": false}
+	if current_map == null:
+		return request
+	var flute: Dictionary = data.gen1_snorlax_flute(current_map.number, player_cell)
+	if flute.is_empty() or state.is_event_flag_active(int(flute["beat"])):
+		return request
+	state.set_event_flag(int(flute["fight"]), true)
+	request["woke"] = true
+	return request
+
+
 ## `EscapeRopeFunction`, which is `EscapeRopeOrDig` with the other type byte: the
 ## same `.CheckCanDig` and the same `.DoDig`, without a move to know. The type
 ## only picks which text the queued script says and whether `.FailDig` says

--- a/game/world/world_pack.gd
+++ b/game/world/world_pack.gd
@@ -371,6 +371,7 @@ const FIELD_EFFECT_SACRED_ASH: StringName = &"sacred_ash"
 const FIELD_EFFECT_CARD_KEY: StringName = &"card_key"
 const FIELD_EFFECT_BASEMENT_KEY: StringName = &"basement_key"
 const FIELD_EFFECT_SQUIRTBOTTLE: StringName = &"squirtbottle"
+const FIELD_EFFECT_POKE_FLUTE: StringName = &"poke_flute"
 const ITEM_BICYCLE: int = 0x07
 const ITEM_ESCAPE_ROPE: int = 0x13
 ## `CoinCaseEffect` is the one key item on `.Current` rather than `.Field`: it
@@ -415,12 +416,12 @@ const FIELD_EFFECTS: Dictionary = {
 	ITEM_SQUIRTBOTTLE: FIELD_EFFECT_SQUIRTBOTTLE,
 }
 ## `StartMenu_Item`'s `.useItem_closeMenu` rows in Generation 1's numbering: the
-## Bicycle and `UsableItems_CloseMenu`. The Poke Flute is the one of those with
-## no effect built here, so it lands on `ItemUseNotTime` like any other.
+## Bicycle and `UsableItems_CloseMenu`.
 const GEN1_FIELD_EFFECTS: Dictionary = {
 	Gen1Layout.ITEM_BICYCLE: FIELD_EFFECT_BICYCLE,
 	Gen1Layout.ITEM_ESCAPE_ROPE: FIELD_EFFECT_ESCAPE_ROPE,
 	Gen1Layout.ITEM_ITEMFINDER: FIELD_EFFECT_ITEMFINDER,
+	Gen1Layout.ITEM_POKE_FLUTE: FIELD_EFFECT_POKE_FLUTE,
 	Gen1Layout.ITEM_OLD_ROD: FIELD_EFFECT_ROD,
 	Gen1Layout.ITEM_GOOD_ROD: FIELD_EFFECT_ROD,
 	Gen1Layout.ITEM_SUPER_ROD: FIELD_EFFECT_ROD,

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -450,7 +450,9 @@ const GEN1_BOX_DIGITS: int = 2
 
 ## `DisplayPCMainMenu`'s list, `wNumHoFTeams` being the induction flag here
 ## the way [method top_menu_list] reads it.
-static func gen1_top_menu(state: Gen2WorldState, player_name: String) -> Array:
+static func gen1_top_menu(
+	data: GameData, state: Gen2WorldState, player_name: String
+) -> Array:
 	var pokedex: bool = state != null \
 		and state.is_engine_flag_active(Gen2WorldState.ENGINE_POKEDEX)
 	var league: bool = state != null and state.hall_of_fame()
@@ -460,8 +462,8 @@ static func gen1_top_menu(state: Gen2WorldState, player_name: String) -> Array:
 		if league:
 			rows.append(GEN1_PC_LEAGUE)
 	rows.append(GEN1_PC_LOG_OFF)
-	var met_bill: bool = state != null \
-		and state.is_event_flag_active(Gen1Layout.EVENT_MET_BILL)
+	var met_bill: bool = state != null and data != null \
+		and state.is_event_flag_active(Gen1Layout.met_bill_event(data.id))
 	var named: String = player_name if not player_name.is_empty() else "PLAYER"
 	var labels: Dictionary = {
 		GEN1_PC_BILLS: "BILL's PC" if met_bill else "SOMEONE's PC",

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -6535,6 +6535,13 @@ func _on_field_item_used(request: Dictionary) -> void:
 			_show_field_move_text(
 				_field_item_text("sacred_ash", "#MON were all\nhealed!")
 			)
+		## `PlayedFluteHadEffectText`'s own `text_asm` plays SFX_POKEFLUTE and
+		## waits it out; nothing else follows either box in the overworld.
+		Gen2WorldPack.FIELD_EFFECT_POKE_FLUTE:
+			_show_field_move_text(_field_item_text(
+				"flute_woke" if bool(request.get("woke", false)) else "flute_no_effect",
+				"Played the #\nFLUTE."
+			))
 		## `farsjump CardKeySlotScript` and `farsjump BasementDoorScript`, each
 		## `QueueScript`d by its own routine, so both run as any map script does.
 		Gen2WorldPack.FIELD_EFFECT_CARD_KEY, Gen2WorldPack.FIELD_EFFECT_BASEMENT_KEY:
@@ -6583,6 +6590,8 @@ func _on_bike_used(request: Dictionary) -> void:
 const GEN1_FIELD_ITEM_TEXTS: Dictionary = {
 	"got_on_bike": ["bicycle", "got_on"],
 	"got_off_bike": ["bicycle", "got_off"],
+	"flute_woke": ["poke_flute", "had_effect"],
+	"flute_no_effect": ["poke_flute", "no_effect"],
 }
 
 

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -2329,7 +2329,7 @@ func _open_gen1_top() -> void:
 	_mode = MODE.PC
 	_cursor = 0
 	_pc_rows = Gen2WorldPC.gen1_top_menu(
-		_world.state, _save.player_name if _save != null else ""
+		_data, _world.state, _save.player_name if _save != null else ""
 	)
 	_gen1_quiet()
 	_render_rows()
@@ -2338,7 +2338,9 @@ func _open_gen1_top() -> void:
 func _confirm_gen1_top_row(row: int) -> void:
 	match row:
 		Gen2WorldPC.GEN1_PC_BILLS:
-			var met: bool = _world.state.is_event_flag_active(Gen1Layout.EVENT_MET_BILL)
+			var met: bool = _world.state.is_event_flag_active(
+				Gen1Layout.met_bill_event(_data.id)
+			)
 			_open_gen1_box_text(
 				"pc", "accessed_bills" if met else "accessed_someones", &"gen1_bills"
 			)

--- a/tests/integration/test_battle_renderer.gd
+++ b/tests/integration/test_battle_renderer.gd
@@ -251,7 +251,7 @@ func test_a_capture_publishes_and_a_mod_line_lands_behind_it() -> void:
 	## `Text_GotchaMonWasCaught` is the whole of what a caught throw says: the
 	## rocking is the animation, and nothing is published before the line.
 	assert_eq(_caught.size(), 0, "published before the line that says why")
-	_battle_screen._show_next_capture_message()
+	_battle_screen._show_next_box()
 	assert_string_contains(String(_battle_screen.battle_snapshot()["message"]), "Gotcha!")
 	assert_eq(_caught.size(), 1)
 	assert_eq(int(_caught[0]["species"]), 16)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1` and its neighbours are 1535 lines of it, and
-## Generation 1 has added 1944 more to the shared code: 152 the region map, 150
+## Generation 1 has added 1981 more to the shared code: 152 the region map, 150
 ## the battle animation engine, 140 the transition, 130 the Pokedex, 108 the
-## three PCs, 95 the trainer card, 97 the bicycle, 85 the party menu, 85 the
-## dungeon warps, 66 the Day-Care, 42 the status screen, 40 the bag in battle.
-const MAX_COMMENT_LINES: int = 41149
+## three PCs, 97 the bicycle, 95 the trainer card, 85 the party menu, 85 the
+## dungeon warps, 66 the Day-Care, 42 the status screen, 37 the Poke Flute.
+const MAX_COMMENT_LINES: int = 41186
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_battle.gd
+++ b/tools/checks/gen1_battle.gd
@@ -389,6 +389,7 @@ func _the_bag_in_a_fight() -> void:
 	_bag_check(flute, "POKE FLUTE")
 	_r.check(int(flute.get("woken", 0)) == 2, "the flute woke %d" % int(flute.get("woken", 0)))
 	_r.check(not bool(flute.get("spent", true)), "the flute was spent")
+	_the_wild_sleeps_alone()
 
 	_r.check(
 		StringName(_bag_battle(true).use_bag_item(BAG_POKE_DOLL).get("reason", &"")) \
@@ -398,7 +399,23 @@ func _the_bag_in_a_fight() -> void:
 	var wild: Gen2Battle = _bag_battle()
 	_bag_check(wild.use_bag_item(BAG_POKE_DOLL), "POKE DOLL")
 	_r.check(wild.is_over(), "a POKE DOLL did not end the wild battle")
-	_r.note("gen1 battle bag: 9 rows used, refused or spent as the table says")
+	_r.note("gen1 battle bag: 10 rows used, refused or spent as the table says")
+
+
+## `wWereAnyMonsAsleep` against a wild that is the only sleeper, which is what
+## [method Gen1Layout.flute_counts_wild] parts.
+func _the_wild_sleeps_alone() -> void:
+	var battle: Gen2Battle = _bag_battle()
+	battle.mon(Gen2Battle.ENEMY).status = Gen2Status.SLEEP_MASK
+	var flute: Dictionary = battle.use_bag_item(BAG_POKE_FLUTE)
+	_bag_check(flute, "POKE FLUTE")
+	var counted: int = 1 if _r.game_id == RomRegistry.YELLOW else 0
+	_r.check(int(flute.get("woken", 0)) == counted,
+		"a sleeping wild counted %d, wanted %d" % [int(flute.get("woken", 0)), counted])
+	_r.check(
+		not Gen2Status.is_asleep(battle.mon(Gen2Battle.ENEMY).status),
+		"the flute left the wild asleep"
+	)
 
 
 func _bag_check(result: Dictionary, name: String) -> void:

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -228,6 +228,13 @@ const BIKE_ALLOWED_MAPS: int = 63
 ## `res BIT_ALWAYS_ON_BIKE, [hl]`.
 const BIKE_GATE_MAPS: Array[int] = [186, 190]
 
+## `Route12SnorlaxFluteCoords` and `Route16SnorlaxFluteCoords`: the four cells
+## around Route 12's Snorlax and the two either side of Route 16's.
+const SNORLAX_FLUTE_CELLS: Dictionary = {
+	23: [[10, 61], [9, 62], [11, 62], [10, 63]],
+	27: [[25, 10], [27, 10]],
+}
+
 ## Every `IsPlayerOnDungeonWarp` caller of the corpus, source map to its holes:
 ## the `dbmapcoord`, the map it drops onto and the `DungeonWarpData` tile it
 ## lands on. Victory Road 3F's first row is the boulder switch, which
@@ -273,6 +280,7 @@ func _one_game() -> void:
 	_hidden_events()
 	_dungeon_warps()
 	_bike()
+	_snorlax_flute()
 	_toggleables()
 	_wild_objects()
 	_palettes()
@@ -948,6 +956,21 @@ func _forced_ride_cells(map: Gen2WorldMap) -> void:
 				hits.append([x, y])
 	_r.check(hits == FORCED_RIDES.get(map.number, []),
 		"map %d forces a ride on %s." % [map.number, str(hits)])
+
+
+## Every cell `ItemUsePokeFlute` answers a Snorlax on, over the whole corpus.
+func _snorlax_flute() -> void:
+	var found: int = 0
+	for map: Gen2WorldMap in _maps.values():
+		var hits: Array = []
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				if not _r.data.gen1_snorlax_flute(map.number, Vector2i(x, y)).is_empty():
+					hits.append([x, y])
+		found += hits.size()
+		_r.check(hits == SNORLAX_FLUTE_CELLS.get(map.number, []),
+			"map %d wakes a Snorlax on %s." % [map.number, str(hits)])
+	_r.note("gen1 poke flute answers on %d cells" % found)
 
 
 ## Every object `ShowObject` and `HideObject` can name: one object a global

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -315,6 +315,12 @@ const PALLET_FLY_CELL := Vector2i(5, 6)
 ## `AGATHAS_ROOM`, the one map `ItemUseEscapeRope` refuses by name.
 const AGATHAS_ROOM_CELL := Vector2i(4, 11)
 
+## `Route12SnorlaxFluteCoords`' last row, one space east of the Snorlax.
+const ROUTE_12: int = 0x17
+const SNORLAX_CELL := Vector2i(11, 62)
+const SNORLAX_FIGHT_FLAG: int = 1166
+const SNORLAX_BEAT_FLAG: int = 1167
+
 var _r: RefCounted = null
 
 
@@ -357,6 +363,7 @@ func _one_game() -> void:
 	_check_a_dungeon_fall()
 	_check_an_escape_rope()
 	_check_the_bicycle()
+	_check_the_poke_flute()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -1902,6 +1909,35 @@ func _check_the_cycling_road() -> void:
 		"the gate left the ride %s forced." % ["still" if world.always_on_bike() else "no longer"]
 	)
 	_r.note("gen1 bike forced on Route 16 at %s" % ROUTE_16_GATE_DOOR)
+
+
+## `ItemUsePokeFlute` outside a battle: the cell beside Route 12's Snorlax sets
+## the fight event, a cell away does not, and neither does that cell once the
+## beat event stands.
+func _check_the_poke_flute() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, ROUTE_12, SNORLAX_CELL)
+	if world == null:
+		return
+	var flute: Dictionary = world.poke_flute_request()
+	_r.check(
+		bool(flute.get("ok", false)) and bool(flute.get("woke", false))
+			and world.event_flag_active(SNORLAX_FIGHT_FLAG),
+		"the flute beside the Snorlax answered %s." % [flute]
+	)
+	world.player_cell = SNORLAX_CELL + Vector2i.LEFT
+	world.state.set_event_flag(SNORLAX_FIGHT_FLAG, false)
+	_r.check(
+		not bool(world.poke_flute_request().get("woke", false))
+			and not world.event_flag_active(SNORLAX_FIGHT_FLAG),
+		"the flute woke a Snorlax a cell away."
+	)
+	world.player_cell = SNORLAX_CELL
+	world.state.set_event_flag(SNORLAX_BEAT_FLAG, true)
+	_r.check(
+		not bool(world.poke_flute_request().get("woke", false)),
+		"the flute woke a Snorlax that had already been beaten."
+	)
+	_r.note("gen1 poke flute set flag %d beside the Snorlax" % SNORLAX_FIGHT_FLAG)
 
 
 ## `ItemUseEscapeRope`: refused outdoors and in Agatha's room, taken in a cave,

--- a/tools/checks/pack.gd
+++ b/tools/checks/pack.gd
@@ -26,6 +26,17 @@ const CLOSE_ITEMS: Dictionary = {
 	0x9C: "SACRED ASH",
 	0xAF: "SQUIRTBOTTLE",
 }
+## `UsableItems_CloseMenu`'s six rows with the Bicycle, which `.choseItem` sends
+## straight to `.useOrTossItem` with no USE/TOSS box of its own.
+const GEN1_CLOSE_ITEMS: Dictionary = {
+	0x06: "BICYCLE",
+	0x1D: "ESCAPE ROPE",
+	0x47: "ITEMFINDER",
+	0x49: "POKé FLUTE",
+	0x4C: "OLD ROD",
+	0x4D: "GOOD ROD",
+	0x4E: "SUPER ROD",
+}
 
 ## The three maps and cells `card_key.asm`, `basement_key.asm` and
 ## `squirtbottle.asm` name, with the cell the player stands on to face each.
@@ -55,8 +66,7 @@ const REGISTERABLE_KEY_ITEMS: Dictionary = {
 	0x3D: "SUPER ROD",
 }
 
-## `ItemAttributes` is 256 rows on both pins, the last of which is the terminator
-## the item list never reaches.
+## `ItemAttributes` is 256 rows on both pins, the last being the terminator.
 const ITEM_ROWS: int = 255
 const NO_DEPOSIT_ROWS: Array[int] = [1, 2, 3]
 ## The TM and HM rows, whose ITEMMENU_PARTY nibble is `TeachTMHM` rather than an
@@ -83,7 +93,10 @@ func run(r: RefCounted) -> void:
 			continue
 		_verify_registerable(game_id, data)
 		_verify_submenus(game_id, data)
-		_verify_field_effects(game_id, data)
+		_verify_field_effects(
+			game_id, data, CLOSE_ITEMS, Gen2WorldPack.FIELD_EFFECTS
+		)
+		_verify_current_rows(game_id, data)
 		_verify_deposit_rule(game_id, data)
 		_verify_key_item_effects(game_id, data)
 		_verify_party_item_effects(game_id, data, TM_HM_PARTY_ROWS)
@@ -93,6 +106,9 @@ func run(r: RefCounted) -> void:
 	## `UseItem`'s jumptable is the same three answers on Generation 1, and the
 	## pack that reads it is this one, so its `.Party` rows are swept here too.
 	_r.each_game_of(RomRegistry.GEN1, func() -> void:
+		_verify_field_effects(
+			_r.game_id, _r.data, GEN1_CLOSE_ITEMS, Gen2WorldPack.GEN1_FIELD_EFFECTS
+		)
 		_verify_party_item_effects(_r.game_id, _r.data, GEN1_TM_HM_PARTY_ROWS)
 		_verify_battle_item_effects(_r.game_id, _r.data)
 	)
@@ -169,9 +185,11 @@ func _verify_submenus(game_id: StringName, data: GameData) -> void:
 
 ## `UseItem`'s jumptable over the real nibbles. Every ITEMMENU_CLOSE row has to
 ## have a `.Field` effect and nothing else may claim one: a row named by
-## FIELD_EFFECTS that the cartridge puts on `.Current` or `.Party` is dead, and
+## [param effects] that the cartridge puts on `.Current` or `.Party` is dead, and
 ## a CLOSE row with no entry falls through to `.Oak` in silence.
-func _verify_field_effects(game_id: StringName, data: GameData) -> void:
+func _verify_field_effects(
+	game_id: StringName, data: GameData, pinned: Dictionary, effects: Dictionary
+) -> void:
 	var close_rows: Dictionary = {}
 	for number: int in range(1, ITEM_ROWS + 1):
 		if data.item(number).is_empty():
@@ -179,23 +197,22 @@ func _verify_field_effects(game_id: StringName, data: GameData) -> void:
 		if Gen2WorldPack.field_use_kind(data, number) == Gen2WorldPack.ITEMMENU_CLOSE:
 			close_rows[number] = true
 		_r.check(
-			not Gen2WorldPack.FIELD_EFFECTS.has(number)
-				or close_rows.has(number),
+			not effects.has(number) or close_rows.has(number),
 			"%s: $%02X (%s) has a field effect but is not ITEMMENU_CLOSE." % [
 				game_id, number, data.item_name(number),
 			]
 		)
-	for number: int in CLOSE_ITEMS:
+	for number: int in pinned:
 		_r.check(
 			close_rows.has(number),
 			"%s: $%02X (%s) is not ITEMMENU_CLOSE on this cache." % [
-				game_id, number, String(CLOSE_ITEMS[number]),
+				game_id, number, String(pinned[number]),
 			]
 		)
 	_r.check(
-		close_rows.size() == CLOSE_ITEMS.size(),
+		close_rows.size() == pinned.size(),
 		"%s: %d rows are ITEMMENU_CLOSE, not the pinned %d." % [
-			game_id, close_rows.size(), CLOSE_ITEMS.size(),
+			game_id, close_rows.size(), pinned.size(),
 		]
 	)
 	for number: int in close_rows:
@@ -205,6 +222,14 @@ func _verify_field_effects(game_id: StringName, data: GameData) -> void:
 				game_id, number, data.item_name(number),
 			]
 		)
+
+
+## The whole of Crystal's `.Current` past the three repels: the Coin Case, the
+## two trophy boxes, and the Blue Card, which is Crystal's alone because Buena
+## is. A row here the cache does not make CURRENT is one the pack answers with
+## `.Oak`. Generation 1's `.Current` rows share no number and are swept in
+## [Gen2StartMenuScreen] instead.
+func _verify_current_rows(game_id: StringName, data: GameData) -> void:
 	_r.check(
 		Gen2WorldPack.field_effect(data, Gen2WorldPack.ITEM_COIN_CASE)
 			== Gen2WorldPack.FIELD_EFFECT_NONE
@@ -212,10 +237,6 @@ func _verify_field_effects(game_id: StringName, data: GameData) -> void:
 				== Gen2WorldPack.ITEMMENU_CURRENT,
 		"%s: the COIN CASE is not ITEMMENU_CURRENT." % game_id
 	)
-	## The whole of `.Current` past the three repels: the Coin Case above, the
-	## two trophy boxes, and the Blue Card, which is Crystal's alone because
-	## Buena is. A row here that the cache does not make CURRENT is a row the
-	## pack would answer with `.Oak`.
 	var current_rows: Array[int] = [Gen2WorldPack.ITEM_COIN_CASE]
 	current_rows.append_array(Gen2WorldPack.TROPHY_BOXES.keys())
 	if Gen2WorldState.is_crystal_profile(data):

--- a/tools/checks/pc.gd
+++ b/tools/checks/pc.gd
@@ -129,11 +129,19 @@ func _verify_gen1_menus(data: GameData) -> void:
 	var rows: Array[int] = []
 	for open_dex: bool in [false, true]:
 		state.set_engine_flag(Gen2WorldState.ENGINE_POKEDEX, open_dex)
-		rows.append(Gen2WorldPC.gen1_top_menu(state, "RED").size())
+		rows.append(Gen2WorldPC.gen1_top_menu(data, state, "RED").size())
 	state.set_hall_of_fame(true)
-	rows.append(Gen2WorldPC.gen1_top_menu(state, "RED").size())
+	rows.append(Gen2WorldPC.gen1_top_menu(data, state, "RED").size())
 	_r.check(rows == GEN1_TOP_MENU_ROWS,
 		"the machine's menu reads %s." % [rows])
+	## `EVENT_MET_BILL` is counted off the cartridge's own event list.
+	for met: bool in [false, true]:
+		state.set_event_flag(Gen1Layout.met_bill_event(data.id), met)
+		var top: String = String(
+			(Gen2WorldPC.gen1_top_menu(data, state, "RED")[0] as Dictionary)["name"]
+		)
+		_r.check(top.begins_with("BILL" if met else "SOMEONE"),
+			"the machine's first row reads %s with EVENT_MET_BILL %s." % [top, met])
 	var items: int = Gen2WorldPC.gen1_players_pc_menu().size()
 	var boxes: int = Gen2WorldPC.gen1_bills_pc_menu().size()
 	_r.check(

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -15,7 +15,7 @@ extends SceneTree
 const KIND_HELP: Dictionary = {
 	&"effects": "cell: the emote, boulder dust, grass rustle and headbutt tree over the first visible object",
 	&"battle_transition": "frames, index: DoBattleTransition over the map. 1 is the trainer branch; a Generation 1 cartridge reads BattleTransitions' own index, 0 the double circle, 2 the circle, 4 the horizontal stripes, 6 the vertical",
-	&"battle": "frames, 0: the wild fight preview_battle_request starts, settled past its transition. 1 opens the bag over it",
+	&"battle": "frames, 0: the wild fight preview_battle_request starts, settled past its transition. 1 opens the bag over it and 2 plays the POKé FLUTE from it",
 	&"battle_caught": "frames: the same fight against a species the dex already holds",
 	&"catch_tutorial": "frames: the Dude's own fight, which answers itself, that many frames in",
 	&"catch_dex": "none: NewPokedexEntry's page, over the fight the catch that opened it is still in",
@@ -55,6 +55,7 @@ const KIND_HELP: Dictionary = {
 	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
 	&"dungeon_fall": "0 or 1: the step north onto a Generation 1 dungeon hole. 0 is LeaveMapAnim at its whitest, 1 the map DungeonWarpData lands on",
 	&"cycling_road": "none: the walk east into Route 16's gate and back out onto ForcedBikeOrSurfMaps' own cell, with the Bicycle refused behind it (`red 0 27 ... cycling_road@16,10`)",
+	&"poke_flute": "none: ItemUsePokeFlute over the map, on a cell Route12SnorlaxFluteCoords names (`red 0 23 ... poke_flute@11,62`)",
 	&"script_fade": "special, frames: one of the five fade specials over the map",
 	&"door": "door mat: .CheckWarp's carpet, standing on an interior door's mat",
 	&"ice_slide": "direction, frames: DoPlayerMovement.CheckForced's run. Direction is down, up, left, right",
@@ -147,6 +148,7 @@ const GEN1_FIELD_ITEMS: Dictionary = {
 	&"field_item": Gen1Layout.ITEM_ITEMFINDER,
 	&"bike": Gen1Layout.ITEM_BICYCLE,
 	&"coin_case": Gen1Layout.ITEM_COIN_CASE,
+	&"poke_flute": Gen1Layout.ITEM_POKE_FLUTE,
 }
 
 ## One row of each shape the bag draws, by generation: a stack that shows its
@@ -201,6 +203,7 @@ const STAGED_FRAMES_BY_KIND: Dictionary = {
 	&"prizes": BOX_REVEAL_FRAMES, &"trade": BOX_REVEAL_FRAMES,
 	&"coins": BOX_REVEAL_FRAMES, &"deal": BOX_REVEAL_FRAMES,
 	&"ticket": BOX_REVEAL_FRAMES, &"day_care": BOX_REVEAL_FRAMES,
+	&"poke_flute": BOX_REVEAL_FRAMES,
 }
 ## Enough for the longest box in the game to finish revealing.
 const BOX_REVEAL_FRAMES: int = 120
@@ -488,7 +491,7 @@ func _stage_kind() -> void:
 	if STAGERS.has(_kind):
 		call(STAGERS[_kind])
 		return
-	if FIELD_ITEMS.has(_kind):
+	if FIELD_ITEMS.has(_kind) or GEN1_FIELD_ITEMS.has(_kind):
 		if _kind in FACE_UP_FIRST:
 			_screen.move_up()
 		_screen.preview_field_item(int(_field_item_number()))
@@ -568,20 +571,26 @@ func _stage_battle() -> void:
 	var caught: bool = _kind == &"battle_caught"
 	if caught:
 		_screen.world().state.set_species_caught(PREVIEW_BATTLE_SPECIES)
+	var flute: bool = _cell.y >= 2 and _generation() == RomRegistry.GEN1
+	if flute:
+		_screen.world().state.apply_changes(
+			{}, {}, {"items": {Gen1Layout.ITEM_POKE_FLUTE: 1}}
+		)
 	_screen.preview_battle_request()
 	_screen.settle_battle_transition()
 	_screen.advance_frames(frames)
 	for _press: int in (3 if caught else 0):
 		_screen.press_button(PokeButton.A)
 		_screen.advance_frames(frames)
-	if _cell.y == 1:
-		_open_battle_bag(frames)
+	if _cell.y >= 1:
+		_open_battle_bag(frames, flute)
 
 
 ## `BattleMenu`'s ITEM row. The appearance line and the send-out in front of it
 ## each owe a press, so A is spent until there is a cursor, and only then is it
-## moved one row down and used.
-func _open_battle_bag(frames: int) -> void:
+## moved one row down and used. [param flute] walks the list to the Poke Flute,
+## granted before the fight so the row is there to reach, and uses it.
+func _open_battle_bag(frames: int, flute: bool) -> void:
 	var host: Gen2BattleScreen = _screen.get("_battle_host")
 	for _press: int in BATTLE_MENU_WAIT:
 		if host == null or StringName(host.get("_menu_stage")) == &"main":
@@ -592,6 +601,15 @@ func _open_battle_bag(frames: int) -> void:
 	_screen.advance_frame()
 	_screen.press_button(PokeButton.A)
 	_screen.advance_frames(frames)
+	if not flute or host == null:
+		return
+	var rows: Array[int] = host.battle_pack_items()
+	for _down: int in maxi(rows.find(Gen1Layout.ITEM_POKE_FLUTE), 0):
+		_screen.press_button(PokeButton.DOWN)
+		_screen.advance_frame()
+	for _press: int in 2:  # The row, and then USE out of the box behind it.
+		_screen.press_button(PokeButton.A)
+		_screen.advance_frames(frames)
 
 
 ## `CatchTutorial`, played by `DudeAutoInputs` rather than by anybody. The first
@@ -1302,7 +1320,7 @@ func _stage_pack() -> void:
 ## no row for it at all.
 func _field_item_number() -> int:
 	if _generation() != RomRegistry.GEN1:
-		return int(FIELD_ITEMS[_kind])
+		return int(FIELD_ITEMS.get(_kind, 0))
 	return int(GEN1_FIELD_ITEMS.get(_kind, 0))
 
 


### PR DESCRIPTION
`Route12SnorlaxFluteCoords` and `Route16SnorlaxFluteCoords` are imported beside `ForcedBikeOrSurfMaps`, six cells on all three cartridges, and `Gen2WorldAPI.poke_flute_request` refuses nothing: the flag a standing Snorlax sets is read by that map's own per-frame script alone, so the walk-up line lands and the fight behind it does not. Yellow's third branch is Pikachu at PEWTER_POKECENTER, which nothing follows the player here.

`ItemUsePokeFlute` reaches neither `PrintItemUseTextAndRemoveItem` nor `UseDisposableItem`, so its own three boxes are all either screen says, where a generic "used the item" line had stood in a battle. `wWereAnyMonsAsleep` parts the cartridges: Yellow's `ld c, a` counts a sleeping wild where Red and Blue clear its status without counting it.

## Fixed

- `EVENT_MET_BILL` was Red's 1360 on all three cartridges. Yellow's unused `EVENT_54F` sits below it and puts it at 1361 there, so Yellow's machine could never say BILL's PC and the Time Capsule gate read a flag nothing sets.
- The battle screen asked `GameData.special_text` for the `item_use_text` run where the cache stores `item_use`, so every Generation 1 battle refusal printed hardcoded English rather than the cartridge's own box.

## Proving it

| Check | What it sweeps |
|---|---|
| `tools/checks/gen1_maps.gd` | Both coordinate lists against every cell of every map: 6 cells on Red, Blue and Yellow |
| `tools/checks/pack.gd` | Every ITEMMENU_CLOSE row of both generations has a field effect, and nothing else claims one |
| `tools/checks/pc.gd` | The machine's own first row on both sides of `EVENT_MET_BILL` |
| `tools/checks/gen1_walk.gd` | The flute beside Route 12's Snorlax, a cell away, and after the beat event |
| `tools/checks/gen1_battle.gd` | The flute over a sleeping wild on all three cartridges |

`tools/validate.gd -- all` passes every topic, GUT is 4482/4482 over 172 scripts, and the editor analyser reports 0 warnings in 634 scripts.

`tools/preview_world.gd -- red 0 23 <out.png> live poke_flute@11,62` photographs the wake-up and `-- red 0 0 <out.png> live battle 300 2` the box in a fight.