### PR TITLE
Use the Generation 1 field moves and light Rock Tunnel

### DIFF
--- a/game/gen1/gen1_importer.gd
+++ b/game/gen1/gen1_importer.gd
@@ -139,6 +139,7 @@ static var LAYOUT_CHECKS: Array[Callable] = [
 	_verify_facility_text,
 	_verify_dex_ratings,
 	_verify_overworld_coords,
+	_verify_field_moves,
 	_verify_world,
 ]
 
@@ -176,6 +177,10 @@ const FACILITY_TEXT_RUNS: Dictionary = {
 	"bicycle": ["bicycle_text", Gen1Layout.BICYCLE_TEXT_AT],
 	"poke_flute": ["poke_flute_text", Gen1Layout.POKE_FLUTE_TEXT_AT],
 	"start_menu": ["start_menu_text", Gen1Layout.START_MENU_TEXT_AT],
+	"field_move": ["field_move_text", Gen1Layout.FIELD_MOVE_TEXT_AT],
+	"strength": ["strength_text", Gen1Layout.STRENGTH_TEXT_AT],
+	"cut": ["cut_text", Gen1Layout.CUT_TEXT_AT],
+	"surf": ["surf_text", Gen1Layout.SURF_TEXT_AT],
 	"coin_case": ["coin_case_text", Gen1Layout.COIN_CASE_TEXT_AT],
 	"party_menu": ["party_menu_text", Gen1Layout.PARTY_MENU_TEXT_AT],
 	"toss": ["toss_text", Gen1Layout.TOSS_TEXT_AT],
@@ -374,10 +379,18 @@ static func _verify_wild_constants(rom: RomFile, layout: Dictionary) -> Dictiona
 	at = int(layout["good_rod"])
 	for slot: int in Gen1Layout.GOOD_ROD_SLOTS.size():
 		var row: Array = Gen1Layout.GOOD_ROD_SLOTS[slot]
-		if rom.u8(at + slot * 2) != int(row[0]) or rom.u8(at + slot * 2 + 1) != int(row[1]):
+		if rom.u8(at + slot * 2) != int(row[0]) or rom.u8(at + slot * 2 + 1) != int(row[1]) \
+			or Gen1Layout.dex_of_index(rom, layout, int(row[1])) != int(row[2]):
 			return _fail("GoodRodMons row %d reads level %d, index %d." % [
 				slot, rom.u8(at + slot * 2), rom.u8(at + slot * 2 + 1),
 			])
+	var old_rod: int = int(layout["old_rod"])
+	if rom.u8(old_rod) != Gen1Layout.OPCODE_LD_BC \
+		or rom.u8(old_rod + 2) != int(Gen1Layout.OLD_ROD_SLOT[0]) \
+		or Gen1Layout.dex_of_index(
+			rom, layout, rom.u8(old_rod + 1)
+		) != int(Gen1Layout.OLD_ROD_SLOT[1]):
+		return _fail("ItemUseOldRod does not name a level 5 MAGIKARP.")
 	return _ok()
 
 
@@ -549,6 +562,30 @@ static func _verify_dex_ratings(rom: RomFile, layout: Dictionary) -> Dictionary:
 			rom, Gen1Layout.banked(RomFile.bank_of(table), rom.u16le(row + 1))
 		).is_empty():
 			return _fail("DexRatingsTable row %d has no text." % index)
+	return _ok()
+
+
+## `CutTreeBlockSwaps` and `DisplayPCMainMenu`'s own `CheckEvent`: two tables the
+## rest of the field moves are read through, each pinned against the dump so a
+## number here can never be the only thing that says what the cartridge does.
+static func _verify_field_moves(rom: RomFile, layout: Dictionary) -> Dictionary:
+	var at: int = int(layout["cut_tree_blocks"])
+	for block: int in Gen1Layout.CUT_BLOCK_SWAPS:
+		if rom.u8(at) != block or rom.u8(at + 1) != int(Gen1Layout.CUT_BLOCK_SWAPS[block]):
+			return _fail("CutTreeBlockSwaps row $%02X reads $%02X, $%02X." % [
+				block, rom.u8(at), rom.u8(at + 1),
+			])
+		at += Gen1Layout.CUT_BLOCK_SWAP_SIZE
+	if rom.u8(at) != Gen1Layout.CUT_BLOCK_SWAP_END:
+		return _fail("CutTreeBlockSwaps runs past its %d rows." % Gen1Layout.CUT_BLOCK_SWAPS.size())
+	var event: int = int(layout["pc_met_bill"])
+	if rom.u8(event) != Gen1Layout.OPCODE_LD_A_FAR \
+		or rom.u8(event + 3) != Gen1Layout.OPCODE_CB_PREFIX:
+		return _fail("DisplayPCMainMenu does not read an event flag at $%05X." % event)
+	var index: int = (rom.u16le(event + 1) - int(layout["event_flags"])) * 8 \
+		+ (rom.u8(event + 4) - Gen1Layout.OPCODE_BIT_A) / 8
+	if index != Gen1Layout.MET_BILL_EVENT:
+		return _fail("DisplayPCMainMenu reads event %d, not EVENT_MET_BILL." % index)
 	return _ok()
 
 

--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -117,10 +117,6 @@ const HP_BAR_PALETTES: Dictionary = {
 	"hp_green": 0x1F, "hp_yellow": 0x20, "hp_red": 0x21,
 }
 
-## `GBPalNormal`'s `rOBP0`, %11010000: an object's colours 1, 2 and 3 take
-## shades 0, 1 and 3, so a sprite never shows the palette's third colour.
-const OBJECT_SHADES: Array[int] = [0, 0, 1, 3]
-
 ## Evolutions by method until a zero byte, then (level, move) pairs until
 ## another; `EVOLVE_ITEM` is the only four-byte row.
 const EVOLVE_LEVEL: int = 1
@@ -599,6 +595,7 @@ const DAY_CARE_TEXT_AT: Dictionary = {
 ## refusals `ItemUseFailed` reaches and `TossItem_`'s own three.
 const ITEM_USE_TEXT_AT: Dictionary = {
 	"not_time": 0x00, "not_yours": 0x05, "no_effect": 0x0A, "no_cycling": 0x19,
+	"no_surfing": 0x1E,
 }
 ## `GotOnBicycleText` and `GotOffBicycleText`, pinned away from the run above
 ## because Yellow's `DontHavePokemonText` sits between them and it.
@@ -611,6 +608,21 @@ const POKE_FLUTE_TEXT_AT: Dictionary = {
 ## rather than through `ItemUseFailed`. `CannotUseItemsHereText` above it is the
 ## Colosseum's and no screen here reaches it.
 const START_MENU_TEXT_AT: Dictionary = {"cannot_get_off": 0x00}
+## `start_sub_menus.asm`'s own six in file order, and `field_move_messages.asm`'s
+## four. Yellow keeps each run whole and moves the second away from the first.
+const FIELD_MOVE_TEXT_AT: Dictionary = {
+	"flash_lights_area": 0x00, "warp_to_last_center": 0x23,
+	"cannot_teleport_now": 0x42, "cannot_fly_here": 0x5E,
+	"not_healthy_enough": 0x72, "new_badge_required": 0x87,
+}
+const STRENGTH_TEXT_AT: Dictionary = {
+	"used_strength": 0x00, "can_move_boulders": 0x15,
+	"current_too_fast": 0x2D, "cycling_is_fun": 0x4C,
+}
+## `UsedCut`'s two, and `ItemUseSurfboard`'s two.
+const CUT_TEXT_AT: Dictionary = {"nothing_to_cut": 0x00, "used_cut": 0x1D}
+const SURF_TEXT_AT: Dictionary = {"got_on": 0x00, "no_place_to_get_off": 0x11}
+
 ## `CoinCaseNumCoinsText`, a run of one: `ItemUseCoinCase` is the only reader.
 const COIN_CASE_TEXT_AT: Dictionary = {"coins": 0x00}
 ## `PartyMenuMessagePointers`' own five, in the order the table names them.
@@ -765,6 +777,62 @@ const SNORLAX_FLUTES: Array[Dictionary] = [
 	{"map": ROUTE_16, "fight": 1224, "beat": 1225, "count": 2},
 ]
 
+## `.outOfBattleMovePointers`' own `bit` on `wObtainedBadges`. Dig, Teleport and
+## Softboiled test none.
+const BOULDERBADGE: int = 0
+const CASCADEBADGE: int = 1
+const RAINBOWBADGE: int = 3
+const SOULBADGE: int = 4
+const FIELD_MOVE_BADGES: Dictionary = {
+	Gen2WorldFieldMove.MOVE_CUT: CASCADEBADGE,
+	Gen2WorldFieldMove.MOVE_FLY: THUNDERBADGE,
+	Gen2WorldFieldMove.MOVE_SURF: SOULBADGE,
+	Gen2WorldFieldMove.MOVE_STRENGTH: RAINBOWBADGE,
+	Gen2WorldFieldMove.MOVE_FLASH: BOULDERBADGE,
+}
+
+const TILESET_GYM: int = 7
+const CUT_TREE_TILE: int = 0x3D
+const CUT_GRASS_TILE: int = 0x52
+const CUT_GYM_TREE_TILE: int = 0x50
+## `CutTreeBlockSwaps`, byte identical in all three: the block holding the tree
+## and the one that replaces it. `ReplaceTreeTileBlock` walks the whole list
+## whatever the tileset, so a gym's own row sits beside the overworld's.
+const CUT_BLOCK_SWAPS: Dictionary = {
+	0x32: 0x6D, 0x33: 0x6C, 0x34: 0x6F, 0x35: 0x4C, 0x60: 0x6E,
+	0x0B: 0x0A, 0x3C: 0x35, 0x3F: 0x35, 0x3D: 0x36,
+}
+const CUT_BLOCK_SWAP_SIZE: int = 2
+const CUT_BLOCK_SWAP_END: int = 0xFF
+
+## `IsNextTileShoreOrWater`'s two shore tiles, which its `cp SHIP_PORT` skips on
+## the Vermilion dock alone.
+const SHORE_TILES: Array[int] = [0x48, 0x32]
+
+## `IsSurfingAllowed`'s Seafoam branch, which nothing reaches yet: only that
+## map's own per-frame script sets either boulder event.
+const SEAFOAM_B4F_STAIRS := Vector2i(7, 11)
+const SEAFOAM_BOULDER_EVENTS: Array[int] = [2512, 2513]
+
+## `CheckForCollisionWhenPushingBoulder`'s `cp $15`, which refuses a push whether
+## or not the tileset calls that tile passable.
+const BOULDER_STAIRS_TILE: int = 0x15
+
+## `wMapPalOffset`, which `LoadGBPal` subtracts from `FadePal4` in bytes before
+## writing rBGP, rOBP0 and rOBP1. Only the warp into ROCK_TUNNEL_1F writes it, so
+## that floor and B1F are the whole of Generation 1's darkness.
+const ROCK_TUNNEL_1F: int = 0x52
+const MAP_PAL_OFFSET_DARK: int = 6
+## `FadePal1` to `FadePal8` as the byte run `LoadGBPal` indexes: rBGP, rOBP0 and
+## rOBP1 a row, `dc`-packed.
+const FADE_PALS: Array[int] = [
+	0xFF, 0xFF, 0xFF, 0xFE, 0xFE, 0xF8, 0xF9, 0xE4, 0xE4, 0xE4, 0xD0, 0xE0,
+	0xE4, 0xD0, 0xE0, 0x90, 0x80, 0x90, 0x40, 0x40, 0x40, 0x00, 0x00, 0x00,
+]
+const FADE_PAL_BASE: int = 9
+const FADE_PAL_BACKGROUND: int = 0
+const FADE_PAL_OBJECT: int = 1
+
 ## `NOT_VISITED`, which `BuildFlyLocationsList` writes for a town the player has
 ## not been to, and `.townMapFlyLoop`'s own `ld c, 15` between two draws.
 const TOWN_MAP_NOT_VISITED: int = 0xFE
@@ -801,11 +869,13 @@ const BOX_COUNT: int = 12
 const BOX_CAPACITY: int = 20
 
 ## `EVENT_MET_BILL`, which puts BILL's PC on the machine's top menu where
-## SOMEONE's PC otherwise stands. Yellow's unused `EVENT_54F` sits below it in
-## `constants/event_constants.asm` and pushes it one higher.
-const MET_BILL_EVENTS: Dictionary = {
-	RomRegistry.RED: 1360, RomRegistry.BLUE: 1360, RomRegistry.YELLOW: 1361,
-}
+## SOMEONE's PC otherwise stands. Yellow's unused `EVENT_54F` sits below it and
+## its `const_next $550 - 1` re-anchors the run, so all three number it alike;
+## `pc_met_bill` pins `DisplayPCMainMenu`'s own read of it.
+const MET_BILL_EVENT: int = 1360
+const OPCODE_LD_A_FAR: int = 0xFA
+const OPCODE_CB_PREFIX: int = 0xCB
+const OPCODE_BIT_A: int = 0x47
 
 ## `MapHeaderPointers` is flat: one `dw` a map id, with `MapHeaderBanks` beside
 ## it. `SwitchToMapRomBank` selects that bank once, which is what puts a map's
@@ -1051,7 +1121,14 @@ const ENGINE_FLAG_BYTES: Dictionary = {
 	"obtained_hidden_items": HIDDEN_ITEM_FLAG_BYTES,
 	"obtained_hidden_coins": HIDDEN_COIN_FLAG_BYTES,
 	"town_visited": TOWN_VISITED_FLAG_BYTES,
+	## Appended, because a run's base is its position here and a saved index
+	## may not move.
+	"status_flags_1": 1,
 }
+## `PrintStrengthText` sets bit 0 and `IsSurfingAllowed` bit 1. Generation 1 has
+## no `ResetBikeFlags`, so bit 0 outlives the map it was set on.
+const STRENGTH_ACTIVE_BIT: int = 0
+const SURF_ALLOWED_BIT: int = 1
 const ENGINE_FLAG_FIRST: int = 256
 const ENGINE_FLAG_BITS: int = 8
 ## `flag_array NUM_CITY_MAPS`, rounded up to the two bytes the array occupies.
@@ -1214,9 +1291,12 @@ const WILD_POINTERS_END: int = 0xFFFF
 const WILD_CHANCE_SIZE: int = 2
 const WILD_SLOT_CHANCES: Array[int] = [50, 101, 140, 165, 190, 215, 228, 241, 252, 255]
 
-## `GoodRodMons`. The Old Rod has no table: `ItemUseOldRod` carries its one pair
-## as `lb bc, 5, MAGIKARP`, and neither rod reads the map.
-const GOOD_ROD_SLOTS: Array = [[10, 0x9D], [10, 0x47]]
+## `GoodRodMons`: level, the cartridge's internal index and the dex number the
+## cache speaks. Neither this rod nor the Old Rod reads the map at all.
+const GOOD_ROD_SLOTS: Array = [[10, 0x9D, 118], [10, 0x47, 60]]
+## `old_rod` pins `lb bc, 5, MAGIKARP`, which rgbds writes as one `ld bc`.
+const OLD_ROD_SLOT: Array = [5, 129]
+const OPCODE_LD_BC: int = 0x01
 
 ## `SuperRodData`, a map id and a pointer to `count` (level, species) rows that
 ## `ReadSuperRodData` picks between by rejecting a two-bit roll. Yellow's
@@ -1338,6 +1418,7 @@ const RED_BLUE: Dictionary = {
 	"print_text": 0x3C49,
 	"event_flags": 0xD747,
 	"status_flags_4": 0xD72E,
+	"status_flags_1": 0xD728,
 	## The rest of what `decode_script` reads; a row calling anything else is not.
 	"text_script_end": 0x24D7,
 	"yes_no_choice": 0x35EC,
@@ -1457,6 +1538,12 @@ const RED_BLUE: Dictionary = {
 	"poke_flute_text": 0x0E20B,
 	"bicycle_text": 0x0E5F2,
 	"start_menu_text": 0x1342F,
+	"field_move_text": 0xA40A9,
+	"strength_text": 0xA403C,
+	"cut_text": 0xA82F8,
+	"surf_text": 0xA685E,
+	"cut_tree_blocks": 0x0F100,
+	"pc_met_bill": 0x17EEC,
 	"battle_font": 0x11EA0,
 	"battle_hud_1": 0x12080,
 	"battle_hud_2": 0x12098,
@@ -1482,6 +1569,7 @@ const RED_BLUE: Dictionary = {
 	"wild_data": 0x0CEEB,
 	"wild_chances": 0x13918,
 	"good_rod": 0x0E27F,
+	"old_rod": 0x0E252,
 	"super_rod": 0x0E919,
 	## `data/battle_anims`, every one of them in bank $1E and reached from
 	## `AttackAnimationPointers`.
@@ -1573,6 +1661,7 @@ const YELLOW: Dictionary = {
 	"print_text": 0x3C36,
 	"event_flags": 0xD746,
 	"status_flags_4": 0xD72D,
+	"status_flags_1": 0xD727,
 	"text_script_end": 0x23D2,
 	"yes_no_choice": 0x35EF,
 	"disable_waiting": 0x2FDE,
@@ -1672,6 +1761,12 @@ const YELLOW: Dictionary = {
 	"poke_flute_text": 0x0E0BA,
 	"bicycle_text": 0x0E536,
 	"start_menu_text": 0x11FD9,
+	"field_move_text": 0xB40A7,
+	"strength_text": 0xB417E,
+	"cut_text": 0xB7166,
+	"surf_text": 0xB6B0E,
+	"cut_tree_blocks": 0x0EF80,
+	"pc_met_bill": 0x17D70,
 	"battle_font": 0x10A20,
 	"battle_hud_1": 0x10C00,
 	"battle_hud_2": 0x10C18,
@@ -1698,6 +1793,7 @@ const YELLOW: Dictionary = {
 	"wild_data": 0x0CB95,
 	"wild_chances": 0x138E2,
 	"good_rod": 0x0E12C,
+	"old_rod": 0x0E0FF,
 	## Yellow's is a flat slot table rather than an index into groups.
 	"super_rod": 0xF5EDA,
 	"attack_anims": 0x7A22A,
@@ -1959,10 +2055,6 @@ static func map_count(id: StringName) -> int:
 	return MAP_COUNT_YELLOW if id == RomRegistry.YELLOW else MAP_COUNT_RED_BLUE
 
 
-static func met_bill_event(id: StringName) -> int:
-	return int(MET_BILL_EVENTS.get(id, MET_BILL_EVENTS[RomRegistry.RED]))
-
-
 ## `.inBattle`'s `wWereAnyMonsAsleep`: Yellow's `ld c, a` counts the wild's own
 ## sleep, where Red and Blue clear it and print `PlayedFluteNoEffectText` anyway.
 static func flute_counts_wild(id: StringName) -> bool:
@@ -2112,6 +2204,56 @@ static func object_movement(byte_1: int, byte_2: int) -> int:
 			byte_2, Gen2WorldObject.MOVEMENT_SPINRANDOM_SLOW
 		)
 	return OBJECT_WALKING_MOVEMENTS.get(byte_2, Gen2WorldObject.MOVEMENT_WANDER)
+
+
+## `UsedCut`'s gate, as the tile it writes to `wCutTile` or -1: OVERWORLD takes a
+## cut tree or grass, GYM one tile of its own, every other tileset nothing.
+static func cut_tile(tileset: int, tile: int) -> int:
+	if tileset == TILESET_GYM:
+		return tile if tile == CUT_GYM_TREE_TILE else -1
+	if tileset != TILESET_OVERWORLD:
+		return -1
+	return tile if tile == CUT_TREE_TILE or tile == CUT_GRASS_TILE else -1
+
+
+## `ReplaceTreeTileBlock`'s walk, or -1 for a block the list does not name.
+static func cut_block_swap(block: int) -> int:
+	return int(CUT_BLOCK_SWAPS.get(block, -1))
+
+
+## `IsNextTileShoreOrWater`: a tileset off `WaterTilesets` answers no whatever is
+## in front, and the dock's own $32 is a landing rather than more sea.
+static func is_shore_or_water(tileset: int, water: bool, tile: int) -> bool:
+	if not water:
+		return false
+	if tile == WATER_TILE:
+		return true
+	return tileset != TILESET_SHIP_PORT and SHORE_TILES.has(tile)
+
+
+## Where `wStatusFlags1`'s two bits sit in the shared engine flag space.
+static func status_flag_1(bit: int) -> int:
+	return engine_flag_base("status_flags_1") + bit
+
+
+## `LoadGBPal`, whose `sub b` counts bytes back from `FadePal4`. An offset past
+## either end of the run answers the identity rather than reading nothing.
+static func gb_palette(offset: int, register: int) -> int:
+	var at: int = FADE_PAL_BASE - offset + register
+	if at < 0 or at >= FADE_PALS.size():
+		return FADE_PALS[FADE_PAL_BASE]
+	return FADE_PALS[at]
+
+
+## `ItemUseOldRod`'s one pair and `GoodRodMons`' two, as the `{level, species}`
+## slots the shared fishing resolution takes.
+static func rod_slots(rod: StringName) -> Array:
+	if rod == Gen2WorldEncounter.METHOD_OLD_ROD:
+		return [{"level": int(OLD_ROD_SLOT[0]), "species": int(OLD_ROD_SLOT[1])}]
+	var out: Array = []
+	for row: Array in GOOD_ROD_SLOTS:
+		out.append({"level": int(row[0]), "species": int(row[2])})
+	return out
 
 
 ## Whether the Super Rod is read as Yellow's flat slot table.

--- a/game/import/rom_cache.gd
+++ b/game/import/rom_cache.gd
@@ -77,7 +77,7 @@ const BYTES_KEY: String = "bytes"
 ## a dump the owner still has, so re-importing costs a few seconds and a
 ## migration would have to carry every past shape forever. Nothing but the cache
 ## is thrown away, since saves live under their own root.
-const FORMAT_VERSION: int = 122
+const FORMAT_VERSION: int = 123
 
 ## What [method state] answers. A stale cache is told from a missing one because
 ## they need different things said to whoever is looking at it: one is a

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -455,6 +455,7 @@ static func open_snapshot(
 	out.last_spawn_map = world_snapshot.last_spawn_map
 	out._gen1_last_map = world_snapshot.gen1_last_map
 	out._gen1_last_blackout_map = world_snapshot.gen1_last_blackout_map
+	out.gen1_map_pal_offset = world_snapshot.gen1_map_pal_offset
 	out.dig_warp = world_snapshot.dig_warp.duplicate()
 	out.backup_warp = world_snapshot.backup_warp.duplicate()
 	## `.SpawnAfterE4` and `.AfterRed`, which stand between `ClockContinue` and
@@ -1366,6 +1367,8 @@ func cut_request() -> Dictionary:
 		return _cut_failure(&"missing_map")
 	if not _pending_cut.is_empty():
 		return _cut_failure(&"cut_in_progress")
+	if _gen1:
+		return _gen1_cut_request()
 	## TryCutOW asks CheckPartyMove before the badge; the submenu path cannot
 	## reach here without the move at all.
 	if field_move_source(Gen2WorldFieldMove.MOVE_CUT).is_empty():
@@ -1409,7 +1412,11 @@ func complete_cut() -> Dictionary:
 	var request: Dictionary = _pending_cut
 	_pending_cut = {}
 	var block_cell: Vector2i = request["block_cell"]
-	var changed: Dictionary = change_block(block_cell.x, block_cell.y, int(request["block"]))
+	var block: int = int(request["block"])
+	## `ReplaceTreeTileBlock` returns on `$ff` without writing, so a Generation 1
+	## block outside `CutTreeBlockSwaps` cuts nothing and still says it did.
+	var changed: Dictionary = change_block(block_cell.x, block_cell.y, block) if block >= 0 \
+		else {"ok": true}
 	if not bool(changed.get("ok", false)):
 		return changed
 	return {
@@ -1421,6 +1428,37 @@ func complete_cut() -> Dictionary:
 		"block": int(request["block"]),
 		"animation": int(request["animation"]),
 	}
+
+
+## `.cut`, the CASCADEBADGE and `UsedCut` behind it. `UsedCut` reads the faced
+## tile against its own tileset rather than a permission, and
+## `ReplaceTreeTileBlock` swaps the block that tile sits in.
+func _gen1_cut_request() -> Dictionary:
+	if not _gen1_has_badge(Gen2WorldFieldMove.MOVE_CUT):
+		return _cut_failure(&"badge_required")
+	var target: Vector2i = facing_cell()
+	var tile: int = Gen1Layout.cut_tile(current_map.tileset, _gen1_tile_drawn_at(target))
+	if tile < 0:
+		return _cut_failure(&"nothing_to_cut")
+	var block_cell: Vector2i = _script_block_cell(target)
+	_pending_cut = {
+		"ok": true,
+		"kind": &"cut_requested",
+		"move": Gen2WorldFieldMove.MOVE_CUT,
+		"cell": target,
+		"block_cell": block_cell,
+		"block": Gen1Layout.cut_block_swap(block_at(block_cell.x, block_cell.y)),
+		"animation": Gen2WorldFieldMove.ANIMATION_GRASS \
+			if tile == Gen1Layout.CUT_GRASS_TILE else Gen2WorldFieldMove.ANIMATION_TREE,
+	}
+	return _pending_cut.duplicate(true)
+
+
+func _gen1_has_badge(field_move: int) -> bool:
+	var bit: int = int(Gen1Layout.FIELD_MOVE_BADGES.get(field_move, -1))
+	return bit < 0 or (state != null and state.is_engine_flag_active(
+		Gen2WorldState.gen1_badge_flag(bit)
+	))
 
 
 static func _cut_failure(reason: StringName) -> Dictionary:
@@ -1436,6 +1474,8 @@ func surf_request(species: int = 0) -> Dictionary:
 		return _surf_failure(&"missing_map")
 	if not _pending_surf.is_empty():
 		return _surf_failure(&"surf_in_progress")
+	if _gen1:
+		return _gen1_surf_request(species)
 	var crystal: bool = Gen2WorldState.is_crystal_profile(data)
 	if not state.is_engine_flag_active(
 		Gen2WorldState.badge_flag(Gen2WorldFieldMove.BADGE_FOG, crystal)
@@ -1485,7 +1525,7 @@ func complete_surf() -> Dictionary:
 		return _surf_failure(&"no_pending_surf")
 	var request: Dictionary = _pending_surf
 	_pending_surf = {}
-	movement_mode = MOVEMENT_SURF
+	movement_mode = StringName(request.get("movement", MOVEMENT_SURF))
 	player_sprite_number = int(request["sprite"])
 	player_cell = request["cell"]
 	_apply_map_music()
@@ -1497,6 +1537,69 @@ func complete_surf() -> Dictionary:
 		"cell": player_cell,
 		"sprite": player_sprite_number,
 	}
+
+
+## `.surf`: the SOULBADGE, `IsSurfingAllowed`, then `ItemUseSurfboard`, which is
+## one routine for getting on and off.
+func _gen1_surf_request(species: int) -> Dictionary:
+	if not _gen1_has_badge(Gen2WorldFieldMove.MOVE_SURF):
+		return _surf_failure(&"badge_required")
+	var refused: StringName = _gen1_surfing_allowed()
+	if refused != &"":
+		return _surf_failure(refused)
+	var target: Vector2i = facing_cell()
+	if movement_mode == MOVEMENT_SURF:
+		return _gen1_surf_off_request(target)
+	if collision_permission_at(target) != Gen2WorldCollision.WATER_TILE \
+		or _gen1_water_pair_blocked(target):
+		return _surf_failure(&"cannot_surf")
+	return _stage_gen1_surf(target, MOVEMENT_SURF, species)
+
+
+## `IsSurfingAllowed`: the forced ride first, then Seafoam Islands B4F's one cell
+## once both boulders are down the hole.
+func _gen1_surfing_allowed() -> StringName:
+	if always_on_bike():
+		return &"cycling_is_fun"
+	if current_map.number != Gen1Layout.SEAFOAM_ISLANDS_B4F \
+		or player_cell != Gen1Layout.SEAFOAM_B4F_STAIRS:
+		return &""
+	for event: int in Gen1Layout.SEAFOAM_BOULDER_EVENTS:
+		if state == null or not state.is_event_flag_active(event):
+			return &""
+	return &"current_too_fast"
+
+
+## `.tryToStopSurfing`: a sprite within the ordinary talking range, the water
+## tile pairs, then the tileset's own passable list.
+func _gen1_surf_off_request(target: Vector2i) -> Dictionary:
+	if object_at(target) != null or _gen1_water_pair_blocked(target) \
+		or not current_tileset.tile_passable(_gen1_tile_drawn_at(target)):
+		return _surf_failure(&"no_place_to_get_off")
+	return _stage_gen1_surf(target, MOVEMENT_WALK, 0)
+
+
+## `TilePairCollisionsWater`, which both halves of `ItemUseSurfboard` read.
+func _gen1_water_pair_blocked(target: Vector2i) -> bool:
+	return Gen2WorldCollision.gen1_pair_blocked(
+		current_map.tileset, _gen1_tile_drawn_at(player_cell),
+		_gen1_tile_drawn_at(target), true
+	)
+
+
+## `.makePlayerMoveForward` is a simulated press, so both halves end one cell on.
+func _stage_gen1_surf(target: Vector2i, mode: StringName, species: int) -> Dictionary:
+	_pending_surf = {
+		"ok": true,
+		"kind": &"surf_requested",
+		"move": Gen2WorldFieldMove.MOVE_SURF,
+		"cell": target,
+		"direction": _direction_for_facing(player_facing),
+		"movement": mode,
+		"sprite": Gen2WorldFieldMove.surf_sprite(species, true) if mode == MOVEMENT_SURF \
+			else _walking_sprite(),
+	}
+	return _pending_surf.duplicate(true)
 
 
 static func _surf_failure(reason: StringName) -> Dictionary:
@@ -1677,6 +1780,18 @@ func flash_request() -> Dictionary:
 		return _flash_failure(&"flash_in_progress")
 	if field_move_source(Gen2WorldFieldMove.MOVE_FLASH).is_empty():
 		return _flash_failure(&"move_not_known")
+	## `.flash` is the BOULDERBADGE and `wMapPalOffset = 0`: no map test and no
+	## flag, so the line lands wherever it is used.
+	if _gen1:
+		if not _gen1_has_badge(Gen2WorldFieldMove.MOVE_FLASH):
+			return _flash_failure(&"badge_required")
+		_pending_flash = {
+			"ok": true,
+			"kind": &"flash_requested",
+			"move": Gen2WorldFieldMove.MOVE_FLASH,
+			"wall_event": -1,
+		}
+		return _pending_flash.duplicate(true)
 	## The badge is checked before the map, so a player without it is told about
 	## the badge even standing in the dark.
 	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
@@ -1711,6 +1826,10 @@ func complete_flash() -> Dictionary:
 		return _flash_failure(&"no_pending_flash")
 	var wall_event: int = int(_pending_flash.get("wall_event", -1))
 	_pending_flash = {}
+	if _gen1:
+		gen1_map_pal_offset = 0
+		return {"ok": true, "kind": &"flash_used", "time_of_day": map_time_of_day(),
+			"wall_event": -1}
 	state.set_used_flash(true)
 	if wall_event >= 0:
 		state.set_event_flag(wall_event, true)
@@ -2020,9 +2139,11 @@ func strength_request(species: int = 0) -> Dictionary:
 		return _strength_failure(&"missing_map")
 	if not _pending_strength.is_empty():
 		return _strength_failure(&"strength_in_progress")
-	if not state.is_engine_flag_active(Gen2WorldState.badge_flag(
-		Gen2WorldFieldMove.BADGE_PLAIN, Gen2WorldState.is_crystal_profile(data)
-	)):
+	## `.strength` tests the RAINBOWBADGE and `PrintStrengthText` checks nothing.
+	if not (_gen1_has_badge(Gen2WorldFieldMove.MOVE_STRENGTH) if _gen1
+		else state.is_engine_flag_active(Gen2WorldState.badge_flag(
+			Gen2WorldFieldMove.BADGE_PLAIN, Gen2WorldState.is_crystal_profile(data)
+		))):
 		return _strength_failure(&"badge_required")
 	_pending_strength = {
 		"ok": true,
@@ -2045,9 +2166,7 @@ func complete_strength() -> Dictionary:
 		return _strength_failure(&"no_pending_strength")
 	var request: Dictionary = _pending_strength
 	_pending_strength = {}
-	state.set_engine_flag(
-		Gen2WorldState.strength_active_flag(Gen2WorldState.is_crystal_profile(data)), true
-	)
+	state.set_engine_flag(_strength_flag(), true)
 	return {
 		"ok": true,
 		"kind": &"strength_applied",
@@ -2058,9 +2177,15 @@ func complete_strength() -> Dictionary:
 
 ## BIKEFLAGS_STRENGTH_ACTIVE_F, the one condition CheckStrengthBoulder reads.
 func strength_active() -> bool:
-	return state.is_engine_flag_active(
-		Gen2WorldState.strength_active_flag(Gen2WorldState.is_crystal_profile(data))
-	)
+	return state.is_engine_flag_active(_strength_flag())
+
+
+## Where that bit lives. Generation 1 has no `ResetBikeFlags`, so its own
+## outlives every map change.
+func _strength_flag() -> int:
+	if _gen1:
+		return Gen1Layout.status_flag_1(Gen1Layout.STRENGTH_ACTIVE_BIT)
+	return Gen2WorldState.strength_active_flag(Gen2WorldState.is_crystal_profile(data))
 
 
 static func _strength_failure(reason: StringName) -> Dictionary:
@@ -2964,6 +3089,8 @@ func _fishing_context(rod: StringName) -> Dictionary:
 	var target: Vector2i = facing_cell()
 	if collision_permission_at(target) != Gen2WorldCollision.WATER_TILE:
 		return {"ok": false, "reason": &"not_facing_water"}
+	if _gen1:
+		return _gen1_fishing_context(rod, target)
 	var fish_group: int = current_map.fish_group
 	var selected_group: int = _fishing_group_for_state(fish_group)
 	var record: Dictionary = data.world_fishing_group(selected_group)
@@ -2973,6 +3100,26 @@ func _fishing_context(rod: StringName) -> Dictionary:
 		"ok": true,
 		"fish_group": fish_group,
 		"selected_fish_group": selected_group,
+		"record": record,
+		"facing_cell": target,
+	}
+
+
+## `FishingInit` reads the faced tile and the player's state and no more: only
+## the Super Rod looks at the map. A cast on a map `SuperRodData` does not name
+## is `wRodResponse` 2, the empty slot list below rather than a refusal.
+func _gen1_fishing_context(rod: StringName, target: Vector2i) -> Dictionary:
+	var group: int = data.world_fishing_map(current_map.number) \
+		if rod == Gen2WorldEncounter.METHOD_SUPER_ROD else 0
+	var record: Dictionary = data.world_fishing_group(group) if group > 0 else {}
+	if rod != Gen2WorldEncounter.METHOD_SUPER_ROD:
+		record = {"slots": Gen1Layout.rod_slots(rod)}
+	elif record.is_empty():
+		record = {"slots": []}
+	return {
+		"ok": true,
+		"fish_group": group,
+		"selected_fish_group": group,
 		"record": record,
 		"facing_cell": target,
 	}
@@ -3669,6 +3816,12 @@ var _gen1_last_map: int = -1
 ## on its own `FlyWarpDataPtr` tile. A zeroed byte is PALLET_TOWN, which is what
 ## a game that has healed nowhere lands on.
 var _gen1_last_blackout_map: int = Gen1Layout.PALLET_TOWN
+## `wMapPalOffset`, the whole of Generation 1's darkness. `LoadGBPal` shifts
+## every palette the screen draws with by it.
+var gen1_map_pal_offset: int = 0
+## `wMiscFlags`' `BIT_TRIED_PUSH_BOULDER`, which is not saved data and so rides
+## no snapshot: a cartridge reload arms the next push the same way.
+var _gen1_boulder_tried: bool = false
 ## The [method GameData.special_text] run `DisplayPokemonCenterDialogue_`'s own
 ## boxes are imported under.
 const GEN1_POKECENTER_RUN: String = "pokecenter"
@@ -3774,6 +3927,16 @@ func gen1_last_map() -> int:
 
 func gen1_last_blackout_map() -> int:
 	return _gen1_last_blackout_map
+
+
+## `CheckWarpsNoCollision`'s only two writes of it: the warp into ROCK_TUNNEL_1F
+## darkens the screen and `.goBackOutside` clears it, so B1F stays dark between
+## them. Every escape clears it through [method _gen1_leave_map_on_foot].
+func _gen1_apply_map_pal_offset(target_map: Gen2WorldMap) -> void:
+	if target_map.number == Gen1Layout.ROCK_TUNNEL_1F:
+		gen1_map_pal_offset = Gen1Layout.MAP_PAL_OFFSET_DARK
+	elif Gen1Layout.is_outside_tileset(target_map.tileset):
+		gen1_map_pal_offset = 0
 
 
 ## `CheckForHiddenEventOrBookshelfOrCardKeyDoor` runs on the A press ahead of
@@ -3998,9 +4161,7 @@ func _gen1_node_facing(node: Dictionary, steps: Array, run: Dictionary) -> bool:
 ## `wBeatGymFlags`, whose eight bits are Kanto's badges in the engine flags'
 ## own order.
 func _gen1_node_badge(node: Dictionary, steps: Array, run: Dictionary) -> bool:
-	var flag: int = Gen2WorldState.BADGE_ENGINE_FLAGS[
-		Gen2WorldState.KANTO_BADGE_FIRST + int(node["badge"])
-	]
+	var flag: int = Gen2WorldState.gen1_badge_flag(int(node["badge"]))
 	return _gen1_resolve_side(
 		node, state != null and state.is_engine_flag_active(flag), steps, run
 	)
@@ -7657,6 +7818,9 @@ func _refused_move(direction: Vector2i, reason: StringName) -> Dictionary:
 ## that commits a step or a turn passes through here; nothing else does.
 func _do_step(direction: Vector2i) -> void:
 	_player_turning_direction = 0x80 | TURNING_DIRECTION_ORDER.find(direction)
+	## `TryPushingBoulder` runs every overworld pass and resets its own flag
+	## whenever nothing pushable is in front, so a step or a turn disarms it.
+	_gen1_boulder_tried = false
 
 
 ## `.StandInPlace` and `._WalkInPlace`, which differ only in the movement byte
@@ -7774,14 +7938,27 @@ func _forced_step(direction: Vector2i, destination: Vector2i) -> Dictionary:
 func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary:
 	if not strength_active():
 		return {}
-	if not _step_permission_allows(destination, direction):
+	## `TryPushingBoulder` opens on `IsSpriteInFrontOfPlayer` with no permission
+	## test, so a boulder on a wall tile is pushed where `.CheckLandPerms` refuses.
+	if not _gen1 and not _step_permission_allows(destination, direction):
 		return {}
 	var boulder: Gen2WorldObject = object_at(destination)
 	if boulder == null or not boulder.is_strength_boulder() or boulder.is_stepping():
+		_gen1_boulder_tried = false
 		return {}
 	if Gen2WorldCollision.is_pit_tile(gen2_code_at(boulder.cell)):
 		return {}
 	var landing: Vector2i = boulder.cell + direction
+	if _gen1:
+		## The bit is set on the way past and read on the next pass, so the first
+		## bump into a boulder only arms the push.
+		if not _gen1_boulder_tried:
+			_gen1_boulder_tried = true
+			return {}
+		if _gen1_boulder_blocked(boulder, landing):
+			_gen1_boulder_tried = false
+			return {}
+		return _commit_boulder_push(boulder, landing, direction)
 	# CanObjectMoveInDirection with the boulder's own flags: WONT_DELETE,
 	# FIXED_FACING, SLIDING and MOVE_ANYWHERE, palette bit STRENGTH_BOULDER and
 	# no NOCLIP or SWIMMING. That leaves the destination's land permission, both
@@ -7789,6 +7966,27 @@ func _try_push_boulder(direction: Vector2i, destination: Vector2i) -> Dictionary
 	# the player's own. can_object_walk_to() is those four tests.
 	if not can_object_walk_to(landing, boulder, direction):
 		return {}
+	return _commit_boulder_push(boulder, landing, direction)
+
+
+## `CheckForCollisionWhenPushingBoulder`: the tile two ahead must be passable,
+## must not pair with the one stood on, must not be the stairs and must be empty.
+func _gen1_boulder_blocked(boulder: Gen2WorldObject, landing: Vector2i) -> bool:
+	if collision_permission_at(landing) != Gen2WorldCollision.LAND_TILE:
+		return true
+	if Gen2WorldCollision.gen1_pair_blocked(
+		current_map.tileset, _gen1_tile_drawn_at(player_cell),
+		_gen1_tile_drawn_at(boulder.cell), false
+	):
+		return true
+	if _gen1_tile_drawn_at(landing) == Gen1Layout.BOULDER_STAIRS_TILE:
+		return true
+	return object_at(landing) != null
+
+
+func _commit_boulder_push(
+	boulder: Gen2WorldObject, landing: Vector2i, direction: Vector2i
+) -> Dictionary:
 	boulder.cell = landing
 	# The stone queue is asked here, on the call that commits the cell, for the
 	# same reason the push itself is resolved here: the source waits for the
@@ -8022,6 +8220,8 @@ func _apply_map(
 	## and that is the map a `LAST_MAP` warp comes back out to.
 	if _gen1 and current_map != null and Gen1Layout.is_outside_tileset(current_map.tileset):
 		_gen1_last_map = current_map.number
+	if _gen1:
+		_gen1_apply_map_pal_offset(target_map)
 	## `RefreshPlayerSprite` clears `wPlayerTurningDirection`, and every warp and
 	## connection reaches it, so a slide never survives a map change.
 	_stand_in_place()
@@ -8266,9 +8466,7 @@ func gen1_visited_towns() -> PackedInt32Array:
 ## `.fly`: the THUNDERBADGE, then `CheckIfInOutsideMap` rather than a map
 ## environment, and `wFlyLocationsList` in place of the visited flypoints.
 func _gen1_fly_request() -> Dictionary:
-	if not state.is_engine_flag_active(Gen2WorldState.BADGE_ENGINE_FLAGS[
-		Gen2WorldState.KANTO_BADGE_FIRST + Gen1Layout.THUNDERBADGE
-	]):
+	if not _gen1_has_badge(Gen2WorldFieldMove.MOVE_FLY):
 		return _fly_failure(&"badge_required")
 	if not Gen1Layout.is_outside_tileset(current_map.tileset):
 		return _fly_failure(&"indoors")
@@ -8578,6 +8776,7 @@ func _gen1_leave_map_on_foot() -> void:
 		return
 	movement_mode = MOVEMENT_WALK
 	player_sprite_number = _walking_sprite()
+	gen1_map_pal_offset = 0
 	state.set_engine_flag(Gen2WorldState.always_on_bike_flag(data), false)
 
 

--- a/game/world/world_collision.gd
+++ b/game/world/world_collision.gd
@@ -546,12 +546,14 @@ const GEN1_DUNGEON_TILESETS: Array[int] = [3, 7, 10, 12, 13, 15, 17, 18, 19, 20,
 
 
 ## `CheckTilePassable`, with `IsNextTileShoreOrWater`'s own test in front of it,
-## as the permission a Generation 2 collision code would have answered. Tile $14
-## is water only on a `WaterTilesets` row: elsewhere it is Red's own doormat.
+## as the permission a Generation 2 collision code would have answered. A tile
+## that keeps `CollisionCheckOnWater` surfing is water and the passable list
+## answers the rest, which is why $14 is Red's own doormat off a water tileset
+## and why the Vermilion dock's own $32 is a landing rather than more sea.
 static func gen1_permission(tileset: Gen2WorldTileset, tile: int) -> int:
 	if tileset == null or tile < 0:
 		return WALL_TILE
-	if tileset.water and tile == Gen1Layout.WATER_TILE:
+	if Gen1Layout.is_shore_or_water(tileset.number, tileset.water, tile):
 		return WATER_TILE
 	return LAND_TILE if tileset.tile_passable(tile) else WALL_TILE
 

--- a/game/world/world_encounter.gd
+++ b/game/world/world_encounter.gd
@@ -175,6 +175,8 @@ static func resolve_fishing(
 ) -> Dictionary:
 	if record.is_empty() or rod not in [METHOD_OLD_ROD, METHOD_GOOD_ROD, METHOD_SUPER_ROD]:
 		return {}
+	if record.has("slots"):
+		return resolve_gen1_fishing(record, rod, random, force_encounter)
 	var generator := random if random != null else RandomNumberGenerator.new()
 	if random == null:
 		generator.randomize()
@@ -454,6 +456,93 @@ static func _blocked_by_repel(level: int, options: Dictionary) -> bool:
 	var steps: int = int(options.get("repel_steps", 0))
 	var lead_level: int = int(options.get("lead_level", -1))
 	return steps > 0 and lead_level > 0 and level < lead_level
+
+
+## `ItemUseOldRod`, `ItemUseGoodRod` and `ItemUseSuperRod`, which share only
+## `RodResponse`. The Old Rod never rolls and always bites; the other two spend a
+## `Random` on it and, on Red and Blue, re-roll the slot until it is in the list.
+## An empty answer is `wRodResponse` 0; a record with no slots is response 2.
+static func resolve_gen1_fishing(
+	record: Dictionary,
+	rod: StringName,
+	random: RandomNumberGenerator = null,
+	force_encounter: bool = false,
+) -> Dictionary:
+	var slots: Array = record.get("slots", [])
+	if slots.is_empty():
+		return {}
+	var generator := random if random != null else RandomNumberGenerator.new()
+	if random == null:
+		generator.randomize()
+	var rolls: Array[int] = []
+	var picked: int = 0
+	if rod != Gen2WorldEncounter.METHOD_OLD_ROD:
+		var flat: bool = (slots[0] as Dictionary).has("threshold")
+		picked = _gen1_rod_slot(slots, generator, rolls, flat, force_encounter)
+		if picked < 0:
+			return {}
+	var slot: Dictionary = slots[picked]
+	var species: int = int(slot.get("species", 0))
+	var level: int = int(slot.get("level", 0))
+	if species < 1 or level < 1:
+		return {}
+	return {
+		"kind": &"wild_encounter_requested",
+		"method": rod,
+		"source": SOURCE_FISHING,
+		"slot": picked,
+		"pokemon": species,
+		"level": level,
+		"rate": 0,
+		"encounter_roll": -1,
+		"slot_roll": rolls[0] if not rolls.is_empty() else -1,
+		"rolls": rolls,
+		"time_group": 0,
+		"forced": force_encounter,
+		"values": {
+			"kind": &"wild", "pokemon": species, "level": level,
+			"battle_type": Gen2Battle.BATTLETYPE_FISH,
+		},
+	}
+
+
+## Which slot bites, or -1. [param flat] is Yellow's Super Rod, whose
+## `GenerateRandomFishingEncounter` walks four thresholds with one roll and whose
+## bite is the caller's own `Random / and $1`.
+static func _gen1_rod_slot(
+	slots: Array, generator: RandomNumberGenerator, rolls: Array[int],
+	flat: bool, force_encounter: bool
+) -> int:
+	if flat:
+		var roll: int = generator.randi_range(0, 255)
+		rolls.append(roll)
+		var index: int = slots.size() - 1
+		for slot: int in slots.size():
+			if roll <= int((slots[slot] as Dictionary).get("threshold", 0xFF)):
+				index = slot
+				break
+		var bite: int = generator.randi_range(0, 255)
+		rolls.append(bite)
+		return index if force_encounter or bite % 2 == 1 else -1
+	## `.RandomLoop`: `srl a` drops bit 0 into carry and a set carry answers
+	## nothing. The two bits left name the slot, and a value at or above the list
+	## re-rolls the whole byte.
+	for _attempt: int in GEN1_ROD_ROLL_LIMIT:
+		var roll: int = generator.randi_range(0, 255)
+		rolls.append(roll)
+		if roll % 2 == 1:
+			if not force_encounter:
+				return -1
+			continue
+		var index: int = (roll >> 1) & 0x03
+		if index < slots.size():
+			return index
+	return -1
+
+
+## `.RandomLoop` has no bound of its own; this is the port's, and a run reaching
+## it answers no nibble rather than spinning.
+const GEN1_ROD_ROLL_LIMIT: int = 64
 
 
 static func _rod_index(rod: StringName) -> int:

--- a/game/world/world_fishing.gd
+++ b/game/world/world_fishing.gd
@@ -68,7 +68,11 @@ func begin(
 		return _failure(&"fishing_in_progress")
 	if not is_rod(rod):
 		return _failure(&"invalid_rod")
-	if fish_group <= 0 or selected_fish_group <= 0 or record.is_empty():
+	## Generation 1's record carries its own slots, because only the Super Rod
+	## reads the map and a map with no group is still cast at: `wRodResponse` 2
+	## is a box rather than a refusal.
+	if record.is_empty() or (not record.has("slots")
+		and (fish_group <= 0 or selected_fish_group <= 0)):
 		return _failure(&"no_fishing_group")
 
 	_context = {
@@ -84,6 +88,8 @@ func begin(
 	_pending_encounter = Gen2WorldEncounter.resolve_fishing(
 		record, rod, time_of_day, time_groups, random, force_encounter
 	)
+	_context["no_fish"] = (record.get("slots", []) as Array).is_empty() \
+		if record.has("slots") else false
 	_state = STATE_CASTING
 	return {
 		"ok": true,
@@ -108,7 +114,10 @@ func advance() -> Dictionary:
 			var no_bite := _result_context()
 			_reset()
 			no_bite["ok"] = true
-			no_bite["kind"] = &"fishing_no_bite"
+			## `FishingAnim`'s three answers: `wRodResponse` 2 is the map having
+			## no fishing group and 0 is a cast that caught nothing.
+			no_bite["kind"] = &"fishing_no_fish" if bool(no_bite.get("no_fish", false)) \
+				else &"fishing_no_bite"
 			no_bite["state"] = STATE_IDLE
 			return no_bite
 		_state = STATE_BITE

--- a/game/world/world_palette.gd
+++ b/game/world/world_palette.gd
@@ -143,6 +143,14 @@ const BATTLE_TOWER_FADE_STEP_FRAMES: int = 7
 
 ## One step of a palette fade: `CopyPals`' rule, which every `DmgToCgb*Pals`
 ## caller shares. The identity order answers the palette it was handed.
+## Which rBGP a Generation 1 map draws through: `LoadGBPal`'s own row while
+## nothing is fading, and the fade's row while one is, because the two write the
+## same register and the fade's landing restores the map's.
+static func gen1_fade_order(fade_order: int, map_pal_offset: int) -> int:
+	return Gen1Layout.gb_palette(map_pal_offset, Gen1Layout.FADE_PAL_BACKGROUND) \
+		if fade_order == FADE_IDENTITY else fade_order
+
+
 static func fade_palette(palette: PackedColorArray, order: int) -> PackedColorArray:
 	if order == FADE_IDENTITY or palette.size() < 4:
 		return palette
@@ -195,8 +203,11 @@ static func gen1_tile_palettes(
 	tileset: Gen2WorldTileset,
 	last_map: int = -1,
 	fade_order: int = FADE_IDENTITY,
+	map_pal_offset: int = 0,
 ) -> Array:
-	var colors: PackedColorArray = fade_palette(gen1_map_colors(data, map, last_map), fade_order)
+	var colors: PackedColorArray = fade_palette(
+		gen1_map_colors(data, map, last_map), gen1_fade_order(fade_order, map_pal_offset)
+	)
 	var out: Array = []
 	out.resize(tileset.tile_count)
 	out.fill(colors)
@@ -214,9 +225,15 @@ static func gen1_map_colors(
 
 ## The same four through `GBPalNormal`'s `rOBP0`, which is what every object on
 ## a Generation 1 map is drawn with. Colour 0 is the object's transparent index,
-## so a sprite never shows the map's own background colour.
-static func gen1_object_colors(colors: PackedColorArray) -> PackedColorArray:
-	return PokePalette.through_shades(colors, Gen1Layout.OBJECT_SHADES)
+## so a sprite never shows the map's own background colour. `LoadGBPal` writes
+## that register out of `FadePal4 - wMapPalOffset`, so an object in Rock Tunnel
+## darkens with the map behind it.
+static func gen1_object_colors(
+	colors: PackedColorArray, map_pal_offset: int = 0
+) -> PackedColorArray:
+	return fade_palette(colors, Gen1Layout.gb_palette(
+		map_pal_offset, Gen1Layout.FADE_PAL_OBJECT
+	))
 
 
 ## `FillWhiteBGColor`, which only the fade out of the map runs: every background
@@ -248,9 +265,12 @@ static func tile_palettes(
 	fade_order: int = FADE_IDENTITY,
 	white_fill: bool = false,
 	last_map: int = -1,
+	map_pal_offset: int = 0,
 ) -> Array:
 	if data.generation == RomRegistry.GEN1:
-		return gen1_tile_palettes(data, map, tileset, last_map, fade_order)
+		return gen1_tile_palettes(
+			data, map, tileset, last_map, fade_order, map_pal_offset
+		)
 	## `LoadMapPals` asks `LoadSpecialMapPalette` first, and its carry skips the
 	## environment and time-of-day pair entirely.
 	var special: Array = data.special_map_palettes(map.tileset, map.environment)

--- a/game/world/world_pc.gd
+++ b/game/world/world_pc.gd
@@ -463,7 +463,7 @@ static func gen1_top_menu(
 			rows.append(GEN1_PC_LEAGUE)
 	rows.append(GEN1_PC_LOG_OFF)
 	var met_bill: bool = state != null and data != null \
-		and state.is_event_flag_active(Gen1Layout.met_bill_event(data.id))
+		and state.is_event_flag_active(Gen1Layout.MET_BILL_EVENT)
 	var named: String = player_name if not player_name.is_empty() else "PLAYER"
 	var labels: Dictionary = {
 		GEN1_PC_BILLS: "BILL's PC" if met_bill else "SOMEONE's PC",

--- a/game/world/world_renderer.gd
+++ b/game/world/world_renderer.gd
@@ -353,6 +353,7 @@ func _tile_palettes_for(map: Gen2WorldMap, tileset: Gen2WorldTileset) -> Array:
 		_fade_order,
 		_fade_white_fill,
 		_world.gen1_last_map(),
+		_world.gen1_map_pal_offset,
 	)
 	if _transition_order == Gen2BattleTransition.IDENTITY:
 		return rows
@@ -970,7 +971,9 @@ func _sprite_palette(palette: int) -> PackedColorArray:
 func _overworld_sprite_colors(palette: int) -> PackedColorArray:
 	if _world.data.generation != RomRegistry.GEN1:
 		return _world.data.overworld_sprite_palette(palette, _time_of_day)
-	return Gen2WorldPalette.gen1_object_colors(_gen1_map_colors())
+	return Gen2WorldPalette.gen1_object_colors(
+		_gen1_map_colors(), _world.gen1_map_pal_offset
+	)
 
 
 func _gen1_map_colors() -> PackedColorArray:

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -54,9 +54,42 @@ const FIELD_MOVE_TEXT_RUNS_ON: Array[int] = [
 	Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.MOVE_FLASH,
 	Gen2WorldFieldMove.MOVE_TELEPORT,
 ]
-## `.TeleportScript`'s `pause 60`, two frames a unit, where the other two
-## escapes spend a `waitbutton`.
+## `_UsedStrengthText` ends `text_end` and `_WarpToLastPokemonCenterText` `done`;
+## `_FlashLightsAreaText` ends `prompt`, so Generation 1's Flash waits.
+const GEN1_FIELD_MOVE_TEXT_RUNS_ON: Array[int] = [
+	Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.MOVE_TELEPORT,
+]
+## `.TeleportScript`'s `pause 60`, two frames a unit, where the other two escapes
+## spend a `waitbutton`. `.canTeleport`'s `ld c, 60` is hardware frames.
 const TELEPORT_PAUSE_FRAMES: int = 120
+const GEN1_TELEPORT_PAUSE_FRAMES: int = 60
+## `ItemUseEscapeRope`'s `ld c, 30`, which is the whole of what it shows.
+const GEN1_ESCAPE_ROPE_FRAMES: int = 30
+
+## What each Generation 1 field move writes, as its `special_text` run and name.
+## Fly and Dig write nothing: `.fly` opens the region map and
+## `ItemUseEscapeRope` prints only when a rope was the item.
+const GEN1_FIELD_MOVE_TEXTS: Dictionary = {
+	Gen2WorldFieldMove.MOVE_CUT: ["cut", "used_cut"],
+	Gen2WorldFieldMove.MOVE_SURF: ["surf", "got_on"],
+	Gen2WorldFieldMove.MOVE_STRENGTH: ["strength", "used_strength"],
+	Gen2WorldFieldMove.MOVE_FLASH: ["field_move", "flash_lights_area"],
+	Gen2WorldFieldMove.MOVE_TELEPORT: ["field_move", "warp_to_last_center"],
+}
+## Every refusal the six share, by the reason the world answers with. A reason
+## with no row falls to `ItemUseNotTime`, which is what `UseItem` refuses in.
+const GEN1_FIELD_MOVE_REFUSALS: Dictionary = {
+	&"badge_required": ["field_move", "new_badge_required"],
+	&"nothing_to_cut": ["cut", "nothing_to_cut"],
+	&"cannot_surf": ["item_use", "no_surfing"],
+	&"no_place_to_get_off": ["surf", "no_place_to_get_off"],
+	&"cycling_is_fun": ["strength", "cycling_is_fun"],
+	&"current_too_fast": ["strength", "current_too_fast"],
+	&"indoors": ["field_move", "cannot_fly_here"],
+	&"not_outdoors": ["field_move", "cannot_teleport_now"],
+	&"not_enough_health": ["field_move", "not_healthy_enough"],
+}
+const GEN1_FIELD_MOVE_REFUSAL_DEFAULT: Array = ["item_use", "not_time"]
 ## constants/sfx_constants.asm's SFX_SANDSTORM, which is what ShakeHeadbuttTree
 ## plays (engine/events/field_moves.asm). SFX_HEADBUTT is a battle-move effect
 ## and is referenced by nothing in either pin's overworld code.
@@ -3567,29 +3600,38 @@ func preview_script_event() -> void:
 	_refresh_labels()
 
 
+## The same pair for any row of the submenu, badge and acknowledge included.
+func preview_field_move_row(move: int) -> void:
+	_preview_field_move(move)
+
+
+func preview_field_move_row_use(move: int) -> void:
+	_preview_field_move_use(move)
+
+
 ## Public screenshot driver for the party submenu's field-move entry. Grants the
 ## move's badge and teaches it to the first party member, then injects that save
 ## so persistence stays off, the way preview_party_transaction() does.
 func preview_field_move() -> void:
-	_preview_field_move(Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_CUT)
 
 
 ## The rest of that sequence, one step per call: the first chooses the submenu's
 ## field-move entry and shows its message, the second acknowledges it and
 ## commits.
 func preview_field_move_use() -> void:
-	_preview_field_move_use(Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.BADGE_HIVE)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_CUT)
 
 
 ## The same pair for Surf, which needs the scene opened beside water.
 func preview_surf() -> void:
 	_face_surfable_water()
-	_preview_field_move(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_SURF)
 
 
 func preview_surf_use() -> void:
 	_face_surfable_water()
-	_preview_field_move_use(Gen2WorldFieldMove.MOVE_SURF, Gen2WorldFieldMove.BADGE_FOG)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_SURF)
 
 
 ## `.TrySurf` reads the faced tile, so facing anywhere else photographs a refusal.
@@ -3615,38 +3657,34 @@ func _face_surfable_water() -> void:
 ## And for Whirlpool, facing a COLL_WHIRLPOOL cell: Dragon's Den B1F, Route 41 and
 ## Route 27 are the only maps that carry one.
 func preview_whirlpool() -> void:
-	_preview_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_WHIRLPOOL)
 
 
 func preview_whirlpool_use() -> void:
-	_preview_field_move_use(
-		Gen2WorldFieldMove.MOVE_WHIRLPOOL, Gen2WorldFieldMove.BADGE_GLACIER
-	)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_WHIRLPOOL)
 
 
 ## And for Strength, which needs nothing in front of the player: .TryStrength
 ## checks the badge and stops. To watch a boulder move, press a direction into one
 ## after the second call; Cianwood Gym (22/5) and Ice Path B1F carry them.
 func preview_strength() -> void:
-	_preview_field_move(Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.BADGE_PLAIN)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_STRENGTH)
 
 
 func preview_strength_use() -> void:
-	_preview_field_move_use(
-		Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.BADGE_PLAIN
-	)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_STRENGTH)
 
 
 ## And for Waterfall, in the water at a fall's foot; the facing is the driver's,
 ## below. The climb is paced, so the frames after the second call are the climb.
 func preview_waterfall() -> void:
 	_stage_waterfall_world()
-	_preview_field_move(Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_WATERFALL)
 
 
 func preview_waterfall_use() -> void:
 	_stage_waterfall_world()
-	_preview_field_move_use(Gen2WorldFieldMove.MOVE_WATERFALL, Gen2WorldFieldMove.BADGE_RISING)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_WATERFALL)
 
 
 ## The world a climber is in: `CheckMapCanWaterfall` passes only FACE_UP, and a
@@ -3662,23 +3700,36 @@ func _stage_waterfall_world() -> void:
 ## And for Flash, which checks no tile and is what makes a dark cave
 ## photographable at all.
 func preview_flash() -> void:
-	_preview_field_move(Gen2WorldFieldMove.MOVE_FLASH, Gen2WorldFieldMove.BADGE_ZEPHYR)
+	_preview_field_move(Gen2WorldFieldMove.MOVE_FLASH)
 
 
 func preview_flash_use() -> void:
-	_preview_field_move_use(Gen2WorldFieldMove.MOVE_FLASH, Gen2WorldFieldMove.BADGE_ZEPHYR)
+	_preview_field_move_use(Gen2WorldFieldMove.MOVE_FLASH)
 
 
-func _preview_field_move_use(move: int, badge: int) -> void:
+## Which badge flag that move is behind, which is the move's own `CheckBadge`
+## argument rather than a second table: `wObtainedBadges` orders Kanto's eight
+## differently and no caller should have to know that.
+func _field_move_badge_flag(move: int) -> int:
+	if _data != null and _data.generation == RomRegistry.GEN1:
+		return Gen2WorldState.gen1_badge_flag(
+			int(Gen1Layout.FIELD_MOVE_BADGES.get(move, Gen1Layout.BOULDERBADGE))
+		)
+	return Gen2WorldState.badge_flag(
+		Gen2WorldFieldMove.badge_for_move(move), Gen2WorldState.is_crystal_profile(_data)
+	)
+
+
+func _preview_field_move_use(move: int) -> void:
 	if _field_move_text:
 		_acknowledge_field_move_text()
 		return
-	_preview_field_move(move, badge)
+	_preview_field_move(move)
 	if _party_host != null:
 		_party_host.handle_button(PokeButton.A)
 
 
-func _preview_field_move(move: int, badge: int) -> void:
+func _preview_field_move(move: int) -> void:
 	if _world == null or _data == null:
 		return
 	var save: Gen2SaveData = _embedded_party_save()
@@ -3694,9 +3745,7 @@ func _preview_field_move(move: int, badge: int) -> void:
 	## the next catch, purchase or party change reported nothing but failure.
 	teacher.pp[0] = int(_data.move(move).get("pp", 0))
 	_injected_save = save
-	_world.state.set_engine_flag(Gen2WorldState.badge_flag(
-		badge, Gen2WorldState.is_crystal_profile(_data)
-	))
+	_world.state.set_engine_flag(_field_move_badge_flag(move))
 	_open_embedded_party()
 	if _party_host == null:
 		return
@@ -5033,6 +5082,10 @@ func _handle_fishing_result(result: Dictionary) -> void:
 	match StringName(result.get("kind", &"")):
 		&"fishing_no_bite":
 			_script_prompt = "Nothing was hooked. F: cast again"
+		## `FishingAnim`'s `NothingHereText`, which only a map with no
+		## `SuperRodData` row reaches.
+		&"fishing_no_fish":
+			_script_prompt = "No fish here. F: cast again"
 		&"fishing_bite":
 			_script_prompt = "A bite! Press A to reel in"
 		&"battle_requested":
@@ -6510,8 +6563,13 @@ func _on_field_item_used(request: Dictionary) -> void:
 		Gen2WorldPack.FIELD_EFFECT_BICYCLE:
 			_on_bike_used(request)
 		## Printed on the map being left; the acknowledge takes the warp.
+		## `ItemUseEscapeRope` prints nothing, so Generation 1 spends its own
+		## thirty frames and warps with the box never opening.
 		Gen2WorldPack.FIELD_EFFECT_ESCAPE_ROPE:
-			_show_field_move_text(_field_item_text("escape_rope", "Used an\nESCAPE ROPE."))
+			if _data != null and _data.generation == RomRegistry.GEN1:
+				_show_field_move_text("", false, false, GEN1_ESCAPE_ROPE_FRAMES)
+			else:
+				_show_field_move_text(_field_item_text("escape_rope", "Used an\nESCAPE ROPE."))
 		Gen2WorldPack.FIELD_EFFECT_ROD:
 			var rods: Array[StringName] = _world.available_fishing_rods()
 			select_fishing_rod(rods.find(StringName(request.get("rod", &""))))
@@ -6718,7 +6776,7 @@ func _run_party_action(action: Dictionary) -> void:
 ## follows it. Every line is [constant Gen2WorldFieldMove.USED_TEXTS]' own. Fly
 ## is the one row with no line: its script writes nothing before the region map.
 func _field_move_rows(slot: int, user: String) -> Dictionary:
-	var says: Callable = Gen2WorldFieldMove.used_text.bind(user)
+	var says: Callable = _used_field_move_text.bind(user)
 	return {
 		Gen2WorldFieldMove.MOVE_CUT: [
 			_world.cut_request, _cut_refusal,
@@ -6784,26 +6842,70 @@ func _run_field_move(action: Dictionary) -> void:
 		return
 	var row: Array = rows[move]
 	var answer: Dictionary = (row[0] as Callable).call()
+	var gen1: bool = _data != null and _data.generation == RomRegistry.GEN1
 	if not bool(answer.get("ok", false)):
-		_show_field_move_text(
-			(row[1] as Callable).call(StringName(answer.get("reason", &"")))
-		)
+		var reason: StringName = StringName(answer.get("reason", &""))
+		_show_field_move_text(_gen1_refusal_text(reason, user) if gen1
+			else (row[1] as Callable).call(reason))
 		return
-	if not String(row[2]).is_empty():
-		var runs_on: bool = FIELD_MOVE_TEXT_RUNS_ON.has(move)
-		_show_field_move_text(
-			row[2], not runs_on, not runs_on,
-			TELEPORT_PAUSE_FRAMES if move == Gen2WorldFieldMove.MOVE_TELEPORT else 0
-		)
+	var line: String = _gen1_used_line(move, user, answer) if gen1 else String(row[2])
+	if not line.is_empty():
+		var runs_on: bool = (GEN1_FIELD_MOVE_TEXT_RUNS_ON if gen1
+			else FIELD_MOVE_TEXT_RUNS_ON).has(move)
+		var pause: int = 0
+		if move == Gen2WorldFieldMove.MOVE_TELEPORT:
+			pause = GEN1_TELEPORT_PAUSE_FRAMES if gen1 else TELEPORT_PAUSE_FRAMES
+		_show_field_move_text(line, not runs_on, not runs_on, pause)
+	elif gen1 and move == Gen2WorldFieldMove.MOVE_SURF:
+		## `.stopSurfing` steps out of the water on the same frame, so the commit
+		## is owed with no box in front of it.
+		_show_field_move_text("", false, false, 0)
 	var after: Callable = row[3]
 	if after.is_valid():
 		after.call(answer)
 
 
-## `Script_UsedStrength` past its first box: `cry 0` on `wStrengthSpecies`.
+## `Script_UsedStrength` past its first box: `cry 0` on `wStrengthSpecies`, which
+## `UsedStrengthText`'s own `text_asm` plays in the same place.
 func _after_strength(_answer: Dictionary, slot: int, user: String) -> void:
 	_play_species_cry(_party_species(slot))
-	_player_event_texts.append(Gen2WorldFieldMove.move_boulders_text(user))
+	_player_event_texts.append(
+		_gen1_field_move_text(["strength", "can_move_boulders"], user)
+		if _data != null and _data.generation == RomRegistry.GEN1
+		else Gen2WorldFieldMove.move_boulders_text(user)
+	)
+
+
+func _used_field_move_text(move: int, user: String) -> String:
+	if _data == null or _data.generation != RomRegistry.GEN1:
+		return Gen2WorldFieldMove.used_text(move, user)
+	return _gen1_field_move_text(GEN1_FIELD_MOVE_TEXTS.get(move, []), user)
+
+
+## Surf is the one move whose line depends on the answer: `.stopSurfing` prints
+## nothing where getting on prints its own box.
+func _gen1_used_line(move: int, user: String, answer: Dictionary) -> String:
+	if move == Gen2WorldFieldMove.MOVE_SURF \
+		and StringName(answer.get("movement", &"")) != Gen2WorldAPI.MOVEMENT_SURF:
+		return ""
+	return _used_field_move_text(move, user)
+
+
+func _gen1_refusal_text(reason: StringName, user: String) -> String:
+	return _gen1_field_move_text(
+		GEN1_FIELD_MOVE_REFUSALS.get(reason, GEN1_FIELD_MOVE_REFUSAL_DEFAULT), user
+	)
+
+
+## One `special_text` row with its markers filled: `<PLAYER>` as every other box
+## takes it, and `wNameBuffer` the name `.choseOutOfBattleMove` put there.
+func _gen1_field_move_text(run: Array, user: String) -> String:
+	if _data == null or run.size() < 2:
+		return ""
+	var text: String = _data.special_text(String(run[0]), String(run[1]))
+	if _world != null:
+		text = _world.gen1_filled_text(text)
+	return Gen2TextStream.fill_all_markers(text, Gen2TextStream.RAM_MARKER, user)
 
 
 func _after_sweet_scent(answer: Dictionary) -> void:
@@ -7013,7 +7115,11 @@ func _run_heal_transfer(action: Dictionary) -> void:
 		int(action.get("target_slot", -1)), _injected_save == null
 	)
 	if not bool(result.get("ok", false)):
-		_show_field_move_text("It won't have any effect.")
+		_show_field_move_text(
+			_gen1_refusal_text(StringName(result.get("reason", &"")), "")
+			if _data != null and _data.generation == RomRegistry.GEN1
+			else "It won't have any effect."
+		)
 		return
 	## `PARTYMENUTEXT_HEAL_HP`, behind `ItemActionText`'s own `JoyWaitAorB`,
 	## which waits without an arrow the way `ProfOaksPCBoot`'s pages do.
@@ -7032,7 +7138,10 @@ func _show_field_move_text(
 	_field_move_text = true
 	_field_move_text_waits = waits
 	_field_move_text_frames = frames
-	if _text_box != null and _text_box.font != null:
+	if _text_box != null and text.is_empty():
+		## A move that owes a commit and writes nothing still runs through here.
+		_text_box.visible = false
+	elif _text_box != null and _text_box.font != null:
 		_apply_text_box_options()
 		_text_box.show_text(text, blink_cursor)
 		_text_box.visible = true

--- a/game/world/world_service_screen.gd
+++ b/game/world/world_service_screen.gd
@@ -2339,7 +2339,7 @@ func _confirm_gen1_top_row(row: int) -> void:
 	match row:
 		Gen2WorldPC.GEN1_PC_BILLS:
 			var met: bool = _world.state.is_event_flag_active(
-				Gen1Layout.met_bill_event(_data.id)
+				Gen1Layout.MET_BILL_EVENT
 			)
 			_open_gen1_box_text(
 				"pc", "accessed_bills" if met else "accessed_someones", &"gen1_bills"

--- a/game/world/world_snapshot.gd
+++ b/game/world/world_snapshot.gd
@@ -49,6 +49,7 @@ var dig_warp: Dictionary = {}
 ## Escape Rope, Dig and Teleport land beside. PALLET_TOWN is the zeroed byte's.
 var gen1_last_map: int = -1
 var gen1_last_blackout_map: int = Gen1Layout.PALLET_TOWN
+var gen1_map_pal_offset: int = 0
 ## `wBackupWarpNumber`, `wBackupMapGroup` and `wBackupMapNumber`, which
 ## `SavePlayerData` copies into `sCurMapData` alongside the dig warp: where the
 ## stairs out of a Pokemon Center's second floor lead and whose landmark that
@@ -83,6 +84,7 @@ static func from_world(world: Gen2WorldAPI) -> Gen2WorldSnapshot:
 	out.last_spawn_map = world.last_spawn_map
 	out.gen1_last_map = world.gen1_last_map()
 	out.gen1_last_blackout_map = world.gen1_last_blackout_map()
+	out.gen1_map_pal_offset = world.gen1_map_pal_offset
 	out.dig_warp = world.dig_warp.duplicate()
 	out.backup_warp = world.backup_warp.duplicate()
 	out.spawn_after_champion = world.spawn_after_champion
@@ -106,6 +108,7 @@ func to_dict() -> Dictionary:
 		"last_spawn_map": [last_spawn_map.x, last_spawn_map.y],
 		"gen1_last_map": gen1_last_map,
 		"gen1_last_blackout_map": gen1_last_blackout_map,
+		"gen1_map_pal_offset": gen1_map_pal_offset,
 		"dig_warp": dig_warp.duplicate(),
 		"backup_warp": backup_warp.duplicate(),
 		"spawn_after_champion": spawn_after_champion,
@@ -145,6 +148,7 @@ static func from_dict(raw: Variant) -> Gen2WorldSnapshot:
 	out.gen1_last_blackout_map = int(source.get(
 		"gen1_last_blackout_map", Gen1Layout.PALLET_TOWN
 	))
+	out.gen1_map_pal_offset = maxi(0, int(source.get("gen1_map_pal_offset", 0)))
 	out.dig_warp = _warp_from_value(source.get("dig_warp", {}))
 	out.backup_warp = _warp_from_value(source.get("backup_warp", {}))
 	out.spawn_after_champion = clampi(

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -954,6 +954,12 @@ func bargain_merchant_closed(crystal: bool = true) -> bool:
 ## indexed in source badge order: 0 is ZEPHYRBADGE and 15 EARTHBADGE. Out of
 ## range answers -1, which is_engine_flag_active() reads as inactive. This is
 ## what a CheckBadge caller uses, so no caller indexes the two arrays itself.
+## The Generation 1 badge [param bit] of `wObtainedBadges` as one of the sixteen
+## rows above, which is the one place Kanto's eight are indexed from.
+static func gen1_badge_flag(bit: int) -> int:
+	return badge_flag(KANTO_BADGE_FIRST + bit)
+
+
 static func badge_flag(badge: int, crystal: bool = true) -> int:
 	var flags: Array[int] = BADGE_ENGINE_FLAGS if crystal else BADGE_ENGINE_FLAGS_GOLD_SILVER
 	return flags[badge] if badge >= 0 and badge < flags.size() else -1

--- a/tests/unit/test_gen1_layout.gd
+++ b/tests/unit/test_gen1_layout.gd
@@ -360,13 +360,28 @@ func test_every_palette_row_is_inside_the_table() -> void:
 
 
 ## `GBPalNormal` writes %11010000, so an object's three drawn indices take
-## shades 0, 1 and 3 and never the palette's third colour.
+## shades 0, 1 and 3 and never the palette's third colour. That byte is
+## `FadePal4`'s own rOBP0, which is why the fade table answers for it.
 func test_the_object_register_skips_the_third_colour() -> void:
-	assert_eq(Gen1Layout.OBJECT_SHADES, [0, 0, 1, 3] as Array[int])
+	var colors := PackedColorArray([Color.RED, Color.GREEN, Color.BLUE, Color.BLACK])
+	assert_eq(Gen1Layout.gb_palette(0, Gen1Layout.FADE_PAL_OBJECT), 0xD0)
+	assert_eq(
+		Gen2WorldPalette.gen1_object_colors(colors),
+		PackedColorArray([Color.RED, Color.RED, Color.GREEN, Color.BLACK])
+	)
+
+
+## `LoadGBPal` subtracts `wMapPalOffset` from `FadePal4` in bytes, so Rock
+## Tunnel's own 6 reads `FadePal2`: rBGP $FE and rOBP0 $FE, which leaves one
+## drawn shade above black.
+func test_rock_tunnel_reads_two_rows_back() -> void:
+	var dark: int = Gen1Layout.MAP_PAL_OFFSET_DARK
+	assert_eq(Gen1Layout.gb_palette(dark, Gen1Layout.FADE_PAL_BACKGROUND), 0xFE)
+	assert_eq(Gen1Layout.gb_palette(dark, Gen1Layout.FADE_PAL_OBJECT), 0xFE)
 	var colors := PackedColorArray([Color.RED, Color.GREEN, Color.BLUE, Color.BLACK])
 	assert_eq(
-		PokePalette.through_shades(colors, Gen1Layout.OBJECT_SHADES),
-		PackedColorArray([Color.RED, Color.RED, Color.GREEN, Color.BLACK])
+		Gen2WorldPalette.gen1_object_colors(colors, dark),
+		PackedColorArray([Color.BLUE, Color.BLACK, Color.BLACK, Color.BLACK])
 	)
 
 
@@ -513,3 +528,66 @@ func test_the_two_movement_bytes_decode_to_one_template() -> void:
 	assert_eq(Gen1Layout.object_movement(0xFE, 0x02), Gen2WorldObject.MOVEMENT_WALK_LEFT_RIGHT)
 	## A fixed direction only stands a sprite still while byte 1 says STAY.
 	assert_eq(Gen1Layout.object_movement(0xFE, 0xD0), Gen2WorldObject.MOVEMENT_WANDER)
+
+
+## `UsedCut`: the OVERWORLD tileset takes a tree or grass, GYM its own one tile,
+## and every other tileset answers nothing whatever is in front.
+func test_only_two_tilesets_can_be_cut() -> void:
+	assert_eq(
+		Gen1Layout.cut_tile(Gen1Layout.TILESET_OVERWORLD, Gen1Layout.CUT_TREE_TILE),
+		Gen1Layout.CUT_TREE_TILE
+	)
+	assert_eq(
+		Gen1Layout.cut_tile(Gen1Layout.TILESET_OVERWORLD, Gen1Layout.CUT_GRASS_TILE),
+		Gen1Layout.CUT_GRASS_TILE
+	)
+	assert_eq(Gen1Layout.cut_tile(Gen1Layout.TILESET_GYM, Gen1Layout.CUT_TREE_TILE), -1)
+	assert_eq(
+		Gen1Layout.cut_tile(Gen1Layout.TILESET_GYM, Gen1Layout.CUT_GYM_TREE_TILE),
+		Gen1Layout.CUT_GYM_TREE_TILE
+	)
+	assert_eq(Gen1Layout.cut_tile(Gen1Layout.TILESET_CAVERN, Gen1Layout.CUT_TREE_TILE), -1)
+	assert_eq(Gen1Layout.cut_block_swap(0x32), 0x6D)
+	assert_eq(Gen1Layout.cut_block_swap(0xFF), -1)
+
+
+## `IsNextTileShoreOrWater`: a tileset off `WaterTilesets` answers nothing, and
+## the Vermilion dock's own $32 is a landing rather than more sea.
+func test_the_shore_tiles_are_water_off_the_dock() -> void:
+	for tile: int in [Gen1Layout.WATER_TILE, 0x32, 0x48]:
+		assert_true(Gen1Layout.is_shore_or_water(Gen1Layout.TILESET_OVERWORLD, true, tile))
+		assert_false(Gen1Layout.is_shore_or_water(Gen1Layout.TILESET_OVERWORLD, false, tile))
+	assert_true(
+		Gen1Layout.is_shore_or_water(Gen1Layout.TILESET_SHIP_PORT, true, Gen1Layout.WATER_TILE)
+	)
+	for tile: int in Gen1Layout.SHORE_TILES:
+		assert_false(Gen1Layout.is_shore_or_water(Gen1Layout.TILESET_SHIP_PORT, true, tile))
+
+
+## `.outOfBattleMovePointers`' own badge tests, and the three rows with none.
+func test_the_field_move_badges_are_the_jump_tables_own() -> void:
+	assert_eq(
+		int(Gen1Layout.FIELD_MOVE_BADGES[Gen2WorldFieldMove.MOVE_CUT]),
+		Gen1Layout.CASCADEBADGE
+	)
+	assert_eq(
+		int(Gen1Layout.FIELD_MOVE_BADGES[Gen2WorldFieldMove.MOVE_FLASH]),
+		Gen1Layout.BOULDERBADGE
+	)
+	for move: int in [
+		Gen2WorldFieldMove.MOVE_DIG, Gen2WorldFieldMove.MOVE_TELEPORT,
+		Gen2WorldFieldMove.MOVE_SOFTBOILED,
+	]:
+		assert_false(Gen1Layout.FIELD_MOVE_BADGES.has(move))
+
+
+## `ItemUseOldRod`'s one pair and `GoodRodMons`' two, as dex numbers.
+func test_the_two_map_free_rods_carry_their_own_slots() -> void:
+	var old_rod: Array = Gen1Layout.rod_slots(Gen2WorldEncounter.METHOD_OLD_ROD)
+	assert_eq(old_rod.size(), 1)
+	assert_eq(int((old_rod[0] as Dictionary)["species"]), 129)
+	assert_eq(int((old_rod[0] as Dictionary)["level"]), 5)
+	var good_rod: Array = Gen1Layout.rod_slots(Gen2WorldEncounter.METHOD_GOOD_ROD)
+	assert_eq(good_rod.size(), 2)
+	for slot: Dictionary in good_rod:
+		assert_eq(int(slot["level"]), 10)

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1535 lines of it, and
-## Generation 1 has added 1981 more to the shared code: 152 the region map, 150
-## the battle animation engine, 140 the transition, 130 the Pokedex, 108 the
-## three PCs, 97 the bicycle, 95 the trainer card, 85 the party menu, 85 the
-## dungeon warps, 66 the Day-Care, 42 the status screen, 37 the Poke Flute.
-const MAX_COMMENT_LINES: int = 41186
+## files cost: `game/gen1` and its neighbours are 1568 lines of it, and
+## Generation 1 has added 2112 more to the shared code: 152 the region map, 150
+## the battle animation engine, 140 the transition, 131 the field moves, 130 the
+## Pokedex, 108 the three PCs, 97 the bicycle, 95 the trainer card, 85 the party
+## menu, 85 the dungeon warps, 66 the Day-Care, 42 the status screen.
+const MAX_COMMENT_LINES: int = 41350
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_encounters.gd
+++ b/tests/unit/test_world_encounters.gd
@@ -590,3 +590,62 @@ func test_the_contest_timer_counts_the_minutes_down_across_midnight() -> void:
 		started, {"day": 1, "hour": 0, "minute": 15}
 	), 0)
 	assert_eq(Gen2WorldBugContest.minutes_remaining({}, started), 0)
+
+
+## `ItemUseOldRod` never rolls at all: `lb bc, 5, MAGIKARP` and a set bite.
+func test_the_generation_1_old_rod_always_bites() -> void:
+	var random := RandomNumberGenerator.new()
+	random.seed = 3
+	for _cast: int in 20:
+		var result: Dictionary = Gen2WorldEncounter.resolve_gen1_fishing(
+			{"slots": [{"level": 5, "species": 129}]},
+			Gen2WorldEncounter.METHOD_OLD_ROD, random
+		)
+		assert_eq(result["pokemon"], 129)
+		assert_eq(result["level"], 5)
+		assert_eq(result["values"]["battle_type"], Gen2Battle.BATTLETYPE_FISH)
+
+
+## `.RandomLoop`: an odd byte answers nothing, an even one whose two bits land
+## inside the list picks that slot, and anything else re-rolls the whole byte.
+func test_the_generation_1_good_rod_reads_bit_0_then_bits_1_and_2() -> void:
+	var record: Dictionary = {
+		"slots": [{"level": 10, "species": 118}, {"level": 10, "species": 60}],
+	}
+	var bites: int = 0
+	var random := RandomNumberGenerator.new()
+	random.seed = 5
+	for _cast: int in 3000:
+		if not Gen2WorldEncounter.resolve_gen1_fishing(
+			record, Gen2WorldEncounter.METHOD_GOOD_ROD, random
+		).is_empty():
+			bites += 1
+	assert_almost_eq(float(bites) / 3000.0, 1.0 / 3.0, 0.05)
+
+
+## `ReadSuperRodData`'s `ld e, $2`: a map `SuperRodData` does not name.
+func test_the_generation_1_super_rod_answers_nothing_off_the_table() -> void:
+	assert_true(Gen2WorldEncounter.resolve_gen1_fishing(
+		{"slots": []}, Gen2WorldEncounter.METHOD_SUPER_ROD, RandomNumberGenerator.new()
+	).is_empty())
+
+
+## Yellow's `GenerateRandomFishingEncounter` walks four thresholds with one roll
+## and the caller's own `and $1` decides the bite, so a forced cast lands on the
+## slot the roll names rather than re-rolling.
+func test_yellows_super_rod_picks_by_threshold() -> void:
+	var record: Dictionary = {"slots": [
+		{"level": 10, "species": 120, "threshold": 0x65},
+		{"level": 10, "species": 72, "threshold": 0xB1},
+		{"level": 5, "species": 120, "threshold": 0xE4},
+		{"level": 20, "species": 72, "threshold": 0xFF},
+	]}
+	var picked: Dictionary = {}
+	var random := RandomNumberGenerator.new()
+	random.seed = 9
+	for _cast: int in 400:
+		var result: Dictionary = Gen2WorldEncounter.resolve_gen1_fishing(
+			record, Gen2WorldEncounter.METHOD_SUPER_ROD, random, true
+		)
+		picked[int(result["slot"])] = true
+	assert_eq(picked.keys().size(), 4)

--- a/tools/checks/cut.gd
+++ b/tools/checks/cut.gd
@@ -36,8 +36,18 @@ const EXPECTED_CENSUS: Dictionary = {
 }
 
 
+## `UsedCut` and `CutTreeBlockSwaps` over the whole Generation 1 corpus: how many
+## cells the two tilesets accept, how many of those sit in a block the swap list
+## names, and the maps each is on. A cell whose block is not in the list is the
+## cartridge's own `ret z`: the box is printed and the tree stays.
+const GEN1_CENSUS: Dictionary = {
+	&"red": [1527, 1527, 30], &"blue": [1527, 1527, 30], &"yellow": [1527, 1527, 30],
+}
+
+
 func run(r: RefCounted) -> void:
 	_r = r
+	_r.each_game_of(RomRegistry.GEN1, _gen1_census)
 	for game_id: StringName in _r.GAME_IDS:
 		var data: GameData = GameData.open(game_id)
 		if data == null:
@@ -217,3 +227,26 @@ func _verify_ilex_forest(game_id: StringName, data: GameData, crystal: bool) -> 
 		StringName(wrong_world.cut_request().get("reason", &"")) == &"badge_required",
 		"%s: Ilex Forest accepted the other profile's Hive Badge flag." % game_id
 	)
+
+
+func _gen1_census() -> void:
+	var cells: int = 0
+	var resolved: int = 0
+	var maps: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var found: bool = false
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				if Gen1Layout.cut_tile(map.tileset, map.collision_at(x, y)) < 0:
+					continue
+				cells += 1
+				found = true
+				if Gen1Layout.cut_block_swap(map.block_at(x >> 1, y >> 1)) >= 0:
+					resolved += 1
+		maps += 1 if found else 0
+	var counts: Array = [cells, resolved, maps]
+	_r.note("%d cuttable cells, %d in a swapped block, across %d maps." % counts)
+	_r.check(counts == GEN1_CENSUS.get(_r.game_id, []),
+		"the Generation 1 census is %s, not the pinned %s." % [
+			counts, GEN1_CENSUS.get(_r.game_id, []),
+		])

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,25 +130,28 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 254, "text": 309, "branch": 111, "choice": 17, "flag": 43,
-		"give_item": 25, "has_item": 15, "take_item": 3, "unknown": 55,
+	&"red": {"rows": 261, "text": 328, "branch": 118, "choice": 20, "flag": 46,
+		"give_item": 28, "has_item": 15, "take_item": 3, "unknown": 59,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
 		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
-	&"blue": {"rows": 254, "text": 309, "branch": 111, "choice": 17, "flag": 43,
-		"give_item": 25, "has_item": 15, "take_item": 3, "unknown": 55,
+	&"blue": {"rows": 261, "text": 328, "branch": 118, "choice": 20, "flag": 46,
+		"give_item": 28, "has_item": 15, "take_item": 3, "unknown": 59,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
 		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
-	&"yellow": {"rows": 300, "text": 347, "branch": 106, "choice": 18, "flag": 37,
-		"give_item": 24, "has_item": 12, "take_item": 3, "unknown": 59,
+	&"yellow": {"rows": 307, "text": 366, "branch": 113, "choice": 21, "flag": 40,
+		"give_item": 27, "has_item": 12, "take_item": 3, "unknown": 63,
 		"pick_up_item": 108, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 7, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 6,
 		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
 }
+## `BIT_GOT_OLD_ROD` and its two neighbours share `wStatusFlags1` with
+## `BIT_STRENGTH_ACTIVE`, so reading that byte is what hands the three rods over.
+
 ## The eighth `call DisplayPokedex` in the source is `SilphCo11FPorygonText`,
 ## which no map text row names and the disassembly marks unreferenced. The
 ## `trade` rows are the eight `predef DoInGameTradeDialogue` sites plus

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -44,6 +44,18 @@ const UNSTANDABLE_WARPS: Array = [
 	[161, 5], [161, 6], [162, 0], [162, 1], [245, 2], [245, 3],
 ]
 
+## Viridian City's own cut tree, the first the corpus holds, and the block it
+## sits in. Route 10's northern tunnel mouth, Rock Tunnel 1F's stairs down and
+## the mouth it comes back out of.
+const CUT_TREE_CELL := Vector2i(8, 22)
+const CUT_TREE_BLOCK := Vector2i(4, 11)
+const ROUTE_10: int = 21
+const ROCK_TUNNEL_MOUTH := Vector2i(8, 17)
+const ROCK_TUNNEL_B1F: int = 232
+const ROCK_TUNNEL_STAIRS := Vector2i(37, 3)
+const ROCK_TUNNEL_B1F_STAIRS := Vector2i(33, 25)
+const ROCK_TUNNEL_EXIT := Vector2i(15, 3)
+
 ## Pallet Town's front door and the mat behind it: the round trip a `LAST_MAP`
 ## warp is, out through `RedsHouse1F_Object`'s first warp and back.
 const PALLET_TOWN: int = 0
@@ -364,6 +376,8 @@ func _one_game() -> void:
 	_check_an_escape_rope()
 	_check_the_bicycle()
 	_check_the_poke_flute()
+	_check_a_cut_tree()
+	_check_rock_tunnel_is_dark()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -1676,9 +1690,9 @@ func _check_a_gym_statue() -> void:
 		if world == null:
 			return
 		if badge:
-			world.state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
-				Gen2WorldState.KANTO_BADGE_FIRST
-			], true)
+			world.state.set_engine_flag(
+				Gen2WorldState.gen1_badge_flag(Gen1Layout.BOULDERBADGE), true
+			)
 		boxes.append(_box_text(world))
 	_r.check(boxes[0].begins_with(_statue_box()) and boxes[0] != boxes[1],
 		"the gym statues read %s." % [boxes])
@@ -1755,9 +1769,7 @@ func _check_flying() -> void:
 		StringName(world.fly_request().get("reason", &"")) == &"badge_required",
 		"flying was allowed with no THUNDERBADGE."
 	)
-	world.state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
-		Gen2WorldState.KANTO_BADGE_FIRST + Gen1Layout.THUNDERBADGE
-	], true)
+	world.state.set_engine_flag(Gen2WorldState.gen1_badge_flag(Gen1Layout.THUNDERBADGE), true)
 	var request: Dictionary = world.fly_request()
 	if not _r.check(bool(request.get("ok", false)), "flying was refused outdoors."):
 		return
@@ -1776,9 +1788,7 @@ func _check_flying() -> void:
 	if indoors == null:
 		return
 	indoors.set_party_summary(1, false, FLY_SPECIES, FLY_MOVES)
-	indoors.state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
-		Gen2WorldState.KANTO_BADGE_FIRST + Gen1Layout.THUNDERBADGE
-	], true)
+	indoors.state.set_engine_flag(Gen2WorldState.gen1_badge_flag(Gen1Layout.THUNDERBADGE), true)
 	_r.check(
 		StringName(indoors.fly_request().get("reason", &"")) == &"indoors",
 		"flying was allowed out of a house."
@@ -2048,3 +2058,84 @@ func _hidden_item_box() -> String:
 	return "%s found\n%s!" % [
 		Gen2WorldScriptRunner.UNNAMED, _r.data.item_name(HIDDEN_POTION),
 	]
+
+
+## `UsedCut` and `ReplaceTreeTileBlock` on the corpus's own first cut tree:
+## Viridian City's, which hides the path west out of the school's row.
+func _check_a_cut_tree() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, VIRIDIAN_CITY, CUT_TREE_CELL + Vector2i.DOWN)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	_r.field_move_party(world)
+	_r.check(
+		StringName(world.cut_request().get("reason", &"")) == &"badge_required",
+		"Cut was allowed with no CASCADEBADGE."
+	)
+	world.state.set_engine_flag(
+		Gen2WorldState.gen1_badge_flag(Gen1Layout.CASCADEBADGE), true
+	)
+	var before: int = world.block_at(CUT_TREE_BLOCK.x, CUT_TREE_BLOCK.y)
+	if not _r.check(bool(world.cut_request().get("ok", false)), "Cut was refused at the tree."):
+		return
+	world.complete_cut()
+	var after: int = world.block_at(CUT_TREE_BLOCK.x, CUT_TREE_BLOCK.y)
+	_r.check(
+		after == Gen1Layout.cut_block_swap(before) and after != before,
+		"cutting turned block $%02X into $%02X." % [before, after]
+	)
+	world.player_cell = CUT_TREE_CELL + Vector2i.DOWN * 2
+	_r.check(
+		StringName(world.cut_request().get("reason", &"")) == &"nothing_to_cut",
+		"Cut was offered with nothing in front."
+	)
+
+
+## `wMapPalOffset`: the warp into ROCK_TUNNEL_1F darkens both floors, `.flash`
+## clears it, and the way back out to Route 10 clears it again.
+func _check_rock_tunnel_is_dark() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, ROUTE_10, ROCK_TUNNEL_MOUTH)
+	if world == null:
+		return
+	_r.field_move_party(world)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if not _r.check(bool(world.try_warp().get("ok", false)), "the tunnel mouth refused."):
+		return
+	_r.check(
+		world.map_id() == Vector2i(0, Gen1Layout.ROCK_TUNNEL_1F)
+			and world.gen1_map_pal_offset == Gen1Layout.MAP_PAL_OFFSET_DARK,
+		"the tunnel is %s at offset %d." % [world.map_id(), world.gen1_map_pal_offset]
+	)
+	world.player_cell = ROCK_TUNNEL_STAIRS
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	if not _r.check(bool(world.try_warp().get("ok", false)), "the stairs down refused."):
+		return
+	_r.check(
+		world.map_id() == Vector2i(0, ROCK_TUNNEL_B1F)
+			and world.gen1_map_pal_offset == Gen1Layout.MAP_PAL_OFFSET_DARK,
+		"B1F is %s at offset %d." % [world.map_id(), world.gen1_map_pal_offset]
+	)
+	_r.check(
+		StringName(world.flash_request().get("reason", &"")) == &"badge_required",
+		"Flash was allowed with no BOULDERBADGE."
+	)
+	world.state.set_engine_flag(
+		Gen2WorldState.gen1_badge_flag(Gen1Layout.BOULDERBADGE), true
+	)
+	if not _r.check(bool(world.flash_request().get("ok", false)), "Flash was refused."):
+		return
+	world.complete_flash()
+	_r.check(world.gen1_map_pal_offset == 0, "Flash left the floor dark.")
+	world.player_cell = ROCK_TUNNEL_B1F_STAIRS
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	world.try_warp()
+	world.player_cell = ROCK_TUNNEL_EXIT
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	if not _r.check(bool(world.try_warp().get("ok", false)), "the way out refused."):
+		return
+	_r.check(
+		world.map_id() == Vector2i(0, ROUTE_10) and world.gen1_map_pal_offset == 0,
+		"leaving Rock Tunnel landed on %s at offset %d." % [
+			world.map_id(), world.gen1_map_pal_offset,
+		]
+	)

--- a/tools/checks/pc.gd
+++ b/tools/checks/pc.gd
@@ -136,7 +136,7 @@ func _verify_gen1_menus(data: GameData) -> void:
 		"the machine's menu reads %s." % [rows])
 	## `EVENT_MET_BILL` is counted off the cartridge's own event list.
 	for met: bool in [false, true]:
-		state.set_event_flag(Gen1Layout.met_bill_event(data.id), met)
+		state.set_event_flag(Gen1Layout.MET_BILL_EVENT, met)
 		var top: String = String(
 			(Gen2WorldPC.gen1_top_menu(data, state, "RED")[0] as Dictionary)["name"]
 		)

--- a/tools/checks/strength.gd
+++ b/tools/checks/strength.gd
@@ -42,8 +42,19 @@ const EXPECTED_CENSUS: Dictionary = {
 }
 
 
+## `BOULDER_MOVEMENT_BYTE_2` over the whole Generation 1 corpus, and Victory
+## Road 1F's own first boulder as the acceptance case: `maps/VictoryRoad1F.asm`
+## stands it at (5, 15) and its switch is the cell the route needs it on.
+const GEN1_CENSUS: Dictionary = {
+	&"red": [21, 8], &"blue": [21, 8], &"yellow": [21, 8],
+}
+const GEN1_PUSH_MAP: int = 0x6C
+const GEN1_PUSH_CELL := Vector2i(5, 15)
+
+
 func run(r: RefCounted) -> void:
 	_r = r
+	_r.each_game_of(RomRegistry.GEN1, _gen1_checks)
 	for game_id: StringName in _r.GAME_IDS:
 		var data: GameData = GameData.open(game_id)
 		if data == null:
@@ -203,3 +214,53 @@ func _gym_world(data: GameData, crystal: bool, active: bool) -> Gen2WorldAPI:
 	if world != null:
 		world.player_facing = Gen2WorldSprite.FACING_UP
 	return world
+
+
+
+func _gen1_checks() -> void:
+	var boulders: int = 0
+	var maps: Dictionary = {}
+	for map: Gen2WorldMap in _r.data.world_maps():
+		for row: Dictionary in map.events.get("objects", []):
+			if int(row.get("movement", 0)) != Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER:
+				continue
+			boulders += 1
+			maps[map.number] = true
+	var counts: Array = [boulders, maps.size()]
+	_r.note("%d boulders across %d maps." % counts)
+	_r.check(counts == GEN1_CENSUS.get(_r.game_id, []),
+		"the Generation 1 boulder census is %s, not the pinned %s." % [
+			counts, GEN1_CENSUS.get(_r.game_id, []),
+		])
+	_gen1_push()
+
+
+## `PrintStrengthText` refuses only the badge, and `TryPushingBoulder` arms on the
+## first bump and moves on the second.
+func _gen1_push() -> void:
+	var world: Gen2WorldAPI = _r.open_world(
+		0, GEN1_PUSH_MAP, GEN1_PUSH_CELL + Vector2i.DOWN
+	)
+	if world == null:
+		return
+	_r.field_move_party(world)
+	_r.check(
+		StringName(world.strength_request().get("reason", &"")) == &"badge_required",
+		"Strength was allowed with no RAINBOWBADGE."
+	)
+	world.state.set_engine_flag(Gen2WorldState.gen1_badge_flag(Gen1Layout.RAINBOWBADGE), true)
+	if not _r.check(bool(world.strength_request().get("ok", false)), "Strength was refused."):
+		return
+	world.complete_strength()
+	_r.check(world.strength_active(), "the Strength flag did not go on.")
+	var boulder: Gen2WorldObject = world.object_at(GEN1_PUSH_CELL)
+	if not _r.check(boulder != null, "no boulder stands at %s." % GEN1_PUSH_CELL):
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	world.move_result(Vector2i.UP)
+	_r.check(boulder.cell == GEN1_PUSH_CELL, "the first bump moved the boulder.")
+	world.move_result(Vector2i.UP)
+	_r.check(
+		boulder.cell == GEN1_PUSH_CELL + Vector2i.UP,
+		"the second bump left the boulder at %s." % boulder.cell
+	)

--- a/tools/checks/surf.gd
+++ b/tools/checks/surf.gd
@@ -46,8 +46,24 @@ const SWIM_OBJECT_CENSUS: int = 1
 const LAPRAS_STEP_FRAME_BUDGET: int = 16384
 
 
+## `ItemUseSurfboard` and `IsSurfingAllowed` over the whole Generation 1 corpus:
+## the cells `IsNextTileShoreOrWater` accepts from land and the maps they sit on,
+## then the two refusals and one get-on and get-off.
+const GEN1_CENSUS: Dictionary = {
+	&"red": [1701, 46], &"blue": [1701, 46], &"yellow": [1692, 46],
+}
+## Route 16, whose gate forces the bike, and the cell inside it that does; and
+## Pallet Town's own shore, which is the first water a Generation 1 walk meets.
+const GEN1_CYCLING_MAP: int = 0x1B
+const GEN1_CYCLING_CELL := Vector2i(16, 10)
+const GEN1_SHORE_MAP: int = 0x00
+const GEN1_SHORE_CELL := Vector2i(6, 13)
+const GEN1_WATER_CELL := Vector2i(6, 14)
+
+
 func run(r: RefCounted) -> void:
 	_r = r
+	_r.each_game_of(RomRegistry.GEN1, _gen1_checks)
 	for game_id: StringName in _r.GAME_IDS:
 		var data: GameData = GameData.open(game_id)
 		if data == null:
@@ -339,3 +355,89 @@ func _verify_swimming_objects(game_id: StringName, data: GameData, crystal: bool
 	print("%s: one swimming object, and it crosses all %d water cells its radius allows." % [
 		game_id, expected.size(),
 	])
+
+
+func _gen1_checks() -> void:
+	_gen1_census()
+	_gen1_pallet_town()
+	_gen1_cycling_road()
+
+
+func _gen1_census() -> void:
+	var cells: int = 0
+	var maps: int = 0
+	for map: Gen2WorldMap in _r.data.world_maps():
+		var tileset: Gen2WorldTileset = _r.data.world_tileset(map.tileset)
+		if tileset == null or not tileset.water:
+			continue
+		var found: bool = false
+		for y: int in map.collision_height:
+			for x: int in map.collision_width:
+				if not tileset.tile_passable(map.collision_at(x, y)):
+					continue
+				for step: Vector2i in [Vector2i.UP, Vector2i.DOWN, Vector2i.LEFT, Vector2i.RIGHT]:
+					var at: Vector2i = Vector2i(x, y) + step
+					if at.x < 0 or at.y < 0 or at.x >= map.collision_width \
+						or at.y >= map.collision_height:
+						continue
+					if Gen1Layout.is_shore_or_water(
+						map.tileset, tileset.water, map.collision_at(at.x, at.y)
+					):
+						cells += 1
+						found = true
+						break
+		maps += 1 if found else 0
+	var counts: Array = [cells, maps]
+	_r.note("%d cells offer a surf, across %d maps." % counts)
+	_r.check(counts == GEN1_CENSUS.get(_r.game_id, []),
+		"the Generation 1 surf census is %s, not the pinned %s." % [
+			counts, GEN1_CENSUS.get(_r.game_id, []),
+		])
+
+
+## The badge first, then the water, then `.stopSurfing` back onto the shore the
+## player left. Both halves step one cell in the direction faced.
+func _gen1_pallet_town() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, GEN1_SHORE_MAP, GEN1_SHORE_CELL)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	_r.field_move_party(world)
+	_r.check(
+		StringName(world.surf_request().get("reason", &"")) == &"badge_required",
+		"surfing was allowed with no SOULBADGE."
+	)
+	world.state.set_engine_flag(Gen2WorldState.gen1_badge_flag(Gen1Layout.SOULBADGE), true)
+	var on: Dictionary = world.surf_request()
+	if not _r.check(bool(on.get("ok", false)), "surfing was refused at the shore."):
+		return
+	world.complete_surf()
+	_r.check(
+		world.movement_mode == Gen2WorldAPI.MOVEMENT_SURF and world.player_cell == GEN1_WATER_CELL,
+		"getting on left the player %s in %s." % [world.player_cell, world.movement_mode]
+	)
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var off: Dictionary = world.surf_request()
+	if not _r.check(bool(off.get("ok", false)), "getting off was refused facing the shore."):
+		return
+	world.complete_surf()
+	_r.check(
+		world.movement_mode == Gen2WorldAPI.MOVEMENT_WALK and world.player_cell == GEN1_SHORE_CELL,
+		"getting off left the player %s in %s." % [world.player_cell, world.movement_mode]
+	)
+
+
+## `.forcedToRideBike`, which is the whole of what a Generation 1 walk can reach
+## of `IsSurfingAllowed`: Seafoam Islands B4F's own branch needs two boulder
+## events only that map's per-frame script writes.
+func _gen1_cycling_road() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, GEN1_CYCLING_MAP, GEN1_CYCLING_CELL)
+	if world == null:
+		return
+	_r.field_move_party(world)
+	world.state.set_engine_flag(Gen2WorldState.gen1_badge_flag(Gen1Layout.SOULBADGE), true)
+	world.state.set_engine_flag(Gen2WorldState.always_on_bike_flag(_r.data), true)
+	_r.check(
+		StringName(world.surf_request().get("reason", &"")) == &"cycling_is_fun",
+		"surfing on Cycling Road was not refused."
+	)

--- a/tools/checks/wild_encounters.gd
+++ b/tools/checks/wild_encounters.gd
@@ -63,9 +63,9 @@ const GEN1_CENSUS: Dictionary = {
 ## how many of them read the water table, the maps holding one, and the left
 ## shores among them.
 const GEN1_CELL_CENSUS: Dictionary = {
-	&"red": [17875, 3624, 57, 34],
-	&"blue": [17875, 3624, 57, 34],
-	&"yellow": [19317, 5172, 57, 38],
+	&"red": [17909, 3624, 57, 34],
+	&"blue": [17909, 3624, 57, 34],
+	&"yellow": [19355, 5172, 57, 38],
 }
 
 ## Viridian Forest's FOREST tileset is the one indoor map that does not roll off
@@ -123,6 +123,7 @@ func _verify_gen1_tables() -> void:
 	_gen1_route_1()
 	_gen1_sea_routes()
 	_gen1_super_rod()
+	_gen1_rod_casts()
 	_gen1_cells()
 	_gen1_rolls()
 	_r.note("gen1 encounters %s" % census)
@@ -318,6 +319,86 @@ func _gen1_super_rod() -> void:
 				slot.has("threshold") == (_r.game_id == RomRegistry.YELLOW),
 				"map %d's rod slot carries the wrong pick." % map.number
 			)
+
+
+## `ItemUseOldRod`, `ItemUseGoodRod` and `ItemUseSuperRod` rolled over Pallet
+## Town's own shore. The Old Rod never misses, the other two miss about half the
+## time, and a map `SuperRodData` does not name answers `wRodResponse` 2, which
+## is a cast with no slots to pick from.
+const GEN1_ROD_CASTS: int = 4000
+const GEN1_ROD_SEED: int = 11
+const GEN1_ROD_TOLERANCE: float = 0.03
+## Pallet Town's own shore, and Route 16's, which `SuperRodData` names no group
+## for on any of the three.
+const GEN1_ROD_CAST_CELL := Vector2i(6, 13)
+const GEN1_NO_FISH_MAP: int = 0x1B
+const GEN1_NO_FISH_CELL := Vector2i(14, 15)
+
+
+func _gen1_rod_casts() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, GEN1_ROD_MAP, GEN1_ROD_CAST_CELL)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_DOWN
+	for rod: StringName in Gen2WorldFishing.rods():
+		world.inventory.set_item_quantity(
+			Gen2WorldInventory.item_for_rod(rod, RomRegistry.GEN1), 1
+		)
+	var random := RandomNumberGenerator.new()
+	random.seed = GEN1_ROD_SEED
+	for rod: StringName in Gen2WorldFishing.rods():
+		var bites: int = 0
+		var species: Dictionary = {}
+		for _cast: int in GEN1_ROD_CASTS:
+			var started: Dictionary = world.fishing_request(rod, random)
+			if not _r.check(bool(started.get("ok", false)), "%s was refused." % rod):
+				return
+			var result: Dictionary = world.advance_fishing()
+			if StringName(result.get("kind", &"")) == &"fishing_bite":
+				bites += 1
+				species[int((result["encounter"] as Dictionary)["pokemon"])] = true
+			world.cancel_fishing()
+		var share: float = float(bites) / float(GEN1_ROD_CASTS)
+		var wanted: float = _gen1_bite_share(rod)
+		_r.check(absf(share - wanted) < GEN1_ROD_TOLERANCE,
+			"%s bit on %.3f of its casts, not %.2f." % [rod, share, wanted])
+		_r.note("%s: %.3f bites over %s" % [rod, share, species.keys()])
+	_gen1_no_fish(world)
+
+
+## `.RandomLoop` bites on an even roll whose two bits land inside the list and
+## re-rolls the whole byte otherwise, so a group of n slots bites n / (n + 4) of
+## the time. The Old Rod never rolls and Yellow's Super Rod spends `and $1`.
+func _gen1_bite_share(rod: StringName) -> float:
+	if rod == Gen2WorldEncounter.METHOD_OLD_ROD:
+		return 1.0
+	if rod == Gen2WorldEncounter.METHOD_SUPER_ROD:
+		if _r.game_id == RomRegistry.YELLOW:
+			return 0.5
+		var group: int = _r.data.world_fishing_map(GEN1_ROD_MAP)
+		var slots: int = (_r.data.world_fishing_group(group).get("slots", []) as Array).size()
+		return float(slots) / float(slots + Gen1Layout.SUPER_ROD_MAX_SLOTS)
+	var rows: int = Gen1Layout.GOOD_ROD_SLOTS.size()
+	return float(rows) / float(rows + Gen1Layout.SUPER_ROD_MAX_SLOTS)
+
+
+## `ReadSuperRodData`'s own `ld e, $2`: the cast happens and answers nothing.
+func _gen1_no_fish(world: Gen2WorldAPI) -> void:
+	var elsewhere: Gen2WorldAPI = _r.open_world(
+		0, GEN1_NO_FISH_MAP, GEN1_NO_FISH_CELL, world.state
+	)
+	if elsewhere == null:
+		return
+	elsewhere.inventory = world.inventory
+	elsewhere.player_facing = Gen2WorldSprite.FACING_DOWN
+	var started: Dictionary = elsewhere.fishing_request(Gen2WorldEncounter.METHOD_SUPER_ROD)
+	if not _r.check(bool(started.get("ok", false)),
+		"the Super Rod was refused where no group is named."):
+		return
+	_r.check(
+		StringName(elsewhere.advance_fishing().get("kind", &"")) == &"fishing_no_fish",
+		"a map with no fishing group did not answer NothingHereText."
+	)
 
 
 static func _gen1_rows(slots: Array) -> Array:

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -55,6 +55,8 @@ const KIND_HELP: Dictionary = {
 	&"warp": "warp tile: MapSetupScript_Door at its whitest, the frame the new map loads on",
 	&"dungeon_fall": "0 or 1: the step north onto a Generation 1 dungeon hole. 0 is LeaveMapAnim at its whitest, 1 the map DungeonWarpData lands on",
 	&"cycling_road": "none: the walk east into Route 16's gate and back out onto ForcedBikeOrSurfMaps' own cell, with the Bicycle refused behind it (`red 0 27 ... cycling_road@16,10`)",
+	&"field_move": "move, presses: one of `.outOfBattleMovePointers`' rows through the party submenu. Move 0 is CUT, faced up from the cell below the tree, 1 SURF, faced down from the cell above the water, 2 STRENGTH and 3 FLASH; 0 presses is the submenu, 1 the box the row writes and 2 what the acknowledge commits (`red 0 1 ... field_move@8,23 0 1`)",
+	&"dark_cave": "presses: the walk north into ROCK_TUNNEL_1F, which is the one map wMapPalOffset darkens, with Flash behind it. 0 the dark floor, 1 the submenu, 2 the box Flash writes, 3 the floor it lit (`red 0 21 ... dark_cave@8,18 0`)",
 	&"poke_flute": "none: ItemUsePokeFlute over the map, on a cell Route12SnorlaxFluteCoords names (`red 0 23 ... poke_flute@11,62`)",
 	&"script_fade": "special, frames: one of the five fade specials over the map",
 	&"door": "door mat: .CheckWarp's carpet, standing on an interior door's mat",
@@ -448,6 +450,8 @@ const STAGERS: Dictionary = {
 	&"warp": &"_stage_warp",
 	&"dungeon_fall": &"_stage_dungeon_fall",
 	&"cycling_road": &"_stage_cycling_road",
+	&"field_move": &"_stage_field_move",
+	&"dark_cave": &"_stage_dark_cave",
 	&"door": &"_stage_door",
 	&"ledge": &"_stage_ledge",
 	&"ice_slide": &"_stage_ice_slide",
@@ -927,6 +931,37 @@ func _stage_dungeon_fall() -> void:
 		_screen.advance_frame()
 
 
+const FIELD_MOVE_ROWS: Array[int] = [
+	Gen2WorldFieldMove.MOVE_CUT, Gen2WorldFieldMove.MOVE_SURF,
+	Gen2WorldFieldMove.MOVE_STRENGTH, Gen2WorldFieldMove.MOVE_FLASH,
+]
+
+
+func _stage_field_move() -> void:
+	var move: int = FIELD_MOVE_ROWS[clampi(_cell.x, 0, FIELD_MOVE_ROWS.size() - 1)]
+	## Cut's own cell is the one below the tree, the way `sign` and `gift` are
+	## placed; Surf's is the one above the water, which the opening facing meets.
+	if move == Gen2WorldFieldMove.MOVE_CUT:
+		_screen.press_button(PokeButton.UP)
+	_run_field_move(move, maxi(_cell.y, 0))
+
+
+func _run_field_move(move: int, presses: int) -> void:
+	_screen.preview_field_move_row(move)
+	for _press: int in presses:
+		_screen.preview_field_move_row_use(move)
+		_screen.advance_frames(BOX_REVEAL_FRAMES)
+
+
+## `wMapPalOffset`: the walk north into ROCK_TUNNEL_1F is what darkens it, so the
+## picture has to be taken past the warp rather than on a map opened directly.
+func _stage_dark_cave() -> void:
+	_walk_a_warp(_screen.move_up)
+	if _cell.x <= 0:
+		return
+	_run_field_move(Gen2WorldFieldMove.MOVE_FLASH, _cell.x - 1)
+
+
 ## `CheckForceBikeOrSurf`: the gate's own door lands back on a cell of
 ## `ForcedBikeOrSurfMaps`, so the walk out mounts the bike and every Bicycle
 ## after it is refused by `.useOrTossItem`.
@@ -1264,9 +1299,7 @@ func _stage_pokedex() -> void:
 func _stage_trainer_card() -> void:
 	var state: Gen2WorldState = _screen.get("_world").state
 	for badge: int in maxi(_cell.x, 0):
-		state.set_engine_flag(Gen2WorldState.BADGE_ENGINE_FLAGS[
-			Gen2WorldState.KANTO_BADGE_FIRST + badge
-		], true)
+		state.set_engine_flag(Gen2WorldState.gen1_badge_flag(badge), true)
 	_screen.preview_trainer_card()
 
 


### PR DESCRIPTION
`.outOfBattleMovePointers` is the whole rung. Its badge column is `Gen1Layout.FIELD_MOVE_BADGES`, read through `Gen2WorldState.gen1_badge_flag`, which is where Kanto's eight sit in the shared sixteen.

`UsedCut` reads the faced tile against its tileset rather than a permission, OVERWORLD taking a tree or grass and GYM one tile of its own, and `ReplaceTreeTileBlock` walks `CutTreeBlockSwaps` for the block that replaces the one that tile sits in. A block the list does not name prints the same box and leaves the tree standing.

`ItemUseSurfboard` is one routine both ways about, so `surf_request` answers for getting on and off: `IsSurfingAllowed` first, then `IsNextTileShoreOrWater`, `TilePairCollisionsWater`, and on the way off a sprite at talking range and the tileset's own passable list. `PrintStrengthText` checks nothing but the badge, and `TryPushingBoulder` sets `BIT_TRIED_PUSH_BOULDER` on the way past and reads it on the next pass, so the first bump into a boulder only arms the push. Every line comes out of four new `special_text` runs rather than hardcoded English, `.newBadgeRequired` included.

`wMapPalOffset` is the whole of Generation 1's darkness. `LoadGBPal` counts bytes back from `FadePal4` and writes rBGP, rOBP0 and rOBP1, so the warp into ROCK_TUNNEL_1F reads `FadePal2` and both floors draw at $FE until `.goBackOutside`, a blackout or any of the four escapes clears it.

`FishingInit` reads the faced tile and the player's state and no more, because only the Super Rod looks at the map. `resolve_gen1_fishing` is the three routines' shared `RodResponse`: `.RandomLoop` drops bit 0 into carry and answers nothing on a set one, the two bits left name the slot, and a value at or above the list re-rolls the whole byte, so a group of n slots bites n / (n + 4) of the time.

## Fixed

- `EVENT_MET_BILL` was pinned at 1361 on Yellow, where `const_next $550 - 1` re-anchors the run and all three number it 1360, so Yellow's machine could never say BILL's PC. `pc_met_bill` pins `DisplayPCMainMenu`'s own read of it now.
- `gen1_permission` answered water for tile $14 alone where `IsNextTileShoreOrWater` takes $32 and $48 as well, so a surfer was walled off every eastern shore and the Vermilion dock. 34 more cells on Red and Blue and 38 on Yellow roll an encounter.
- `wStatusFlags1` was not an engine flag run, and `BIT_GOT_OLD_ROD` and its neighbours share that byte with `BIT_STRENGTH_ACTIVE`, so the three fishermen could not hand a rod over and seven rows a cartridge were dropped whole.
- Generation 1's Escape Rope printed a hardcoded English box where `ItemUseEscapeRope` prints nothing and spends `ld c, 30`.
- `Gen1Layout.OBJECT_SHADES` was `FadePal4`'s own rOBP0 written out a second time.

## Proof

- `tools/validate.gd -- all`: 93 topics, no failures. `cut.gd`, `surf.gd` and `strength.gd` each sweep the Generation 1 corpus beside their own: 1527 cuttable cells over 30 maps, 1701 cells offering a surf over 46 on Red and Blue and 1692 on Yellow, and 21 boulders over 8 maps.
- `wild_encounters.gd` casts all three rods 4,000 times apiece on all three cartridges and reads the map with no group; `gen1_walk.gd` cuts Viridian City's tree, walks into Rock Tunnel dark and lights it.
- GUT: 3873 tests, 93,094 asserts, green. `replay_world.gd`: 33 routes, 0 failures. The three-profile story walk is clean.
- The editor analyser reports 0 warnings over 634 scripts.
- `tools/preview_world.gd` takes `field_move` and `dark_cave`.

Cache format 123, so all six cartridges want re-importing.
