### PR TITLE
Run a Generation 1 map's own per-frame script

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -1013,14 +1013,21 @@ const SCRIPT_RET: int = 0xC9
 const SCRIPT_CALL: int = 0xCD
 const SCRIPT_HRAM_BASE: int = 0xFF00
 ## `wGameProgressFlags`' own run of `w<Map>CurScript` bytes, 122 on all three
-## cartridges. A store there or to `wCurMapScript` names a map script index, and
-## this port has no interpreter to hand one to.
+## cartridges. A store there names the map script index `CallFunctionInTable`
+## dispatches on; `wCurMapScript` is the mirror `ExecuteCurMapScriptInTable`
+## keeps and nothing here reads.
 const MAP_SCRIPT_BYTES: int = 0x7A
+const MAP_SCRIPT_STATES: int = 32
+## What a `<Map>_ScriptPointers` word has to be to be a pointer at all.
+const SCRIPT_LOWEST: int = 0x0100
+const SCRIPT_CEILING: int = 0x8000
 ## How deep a `call` to a routine the layout does not name may nest.
 const SCRIPT_CALL_DEPTH: int = 2
 const SCRIPT_PUSH_AF: int = 0xF5
 const SCRIPT_POP_AF: int = 0xF1
-const SCRIPT_STACK_HL: Array[int] = [0xE5, 0xE1]
+const SCRIPT_PUSH_HL: int = 0xE5
+const SCRIPT_POP_HL: int = 0xE1
+const SCRIPT_STACK_HL: Array[int] = [SCRIPT_PUSH_HL, SCRIPT_POP_HL]
 ## The opcode following a map-load gate, `size` its own length and `target`
 ## whether the body is where it branches rather than the byte after it.
 const MAP_LOAD_GATE_BRANCHES: Dictionary = {
@@ -1046,6 +1053,9 @@ const SCRIPT_CALLS: Array[String] = [
 	"auto_textbox_on", "auto_textbox_off", "has_enough_money", "display_text_box",
 	"has_enough_coins", "print_predef_text", "display_text_id", "count_set_bits",
 	"start_simulating_joypad", "update_sprites", "play_sound", "play_sound_wait",
+	"call_function_in_table", "execute_map_script", "load_gym_names",
+	"delay_frames", "delay_3", "play_default_music", "check_map_trainers",
+	"player_coords_in_array", "start_trainer_battle", "end_trainer_battle",
 ]
 ## Routines named by a full ROM offset, the same address in another bank being another routine.
 const SCRIPT_BANKED_CALLS: Array[String] = ["coin_box"]
@@ -1054,13 +1064,35 @@ const SCRIPT_BANKED_CALLS: Array[String] = ["coin_box"]
 const SCRIPT_SILENT_CALLS: Array[String] = [
 	"play_cry", "wait_for_sound", "wait_for_button",
 	"auto_textbox_on", "auto_textbox_off", "count_set_bits", "update_sprites",
-	"play_sound", "play_sound_wait",
+	"play_sound", "play_sound_wait", "load_gym_names",
+	## A wait is frames of nothing and the map music is nobody's here. The three
+	## trainer rows every fighting map's own table opens with are the sight walk
+	## `Gen2WorldAPI.dispatch_sight_events` runs behind this script.
+	"delay_frames", "delay_3", "play_default_music", "check_map_trainers",
+	"start_trainer_battle", "end_trainer_battle",
 ]
 const SCRIPT_CONDITIONAL_CALLS: Array[int] = [0xC4, 0xCC, 0xD4, 0xDC]
+## The two of them the zero flag answers, `true` calling on a clear one.
+const SCRIPT_ZERO_CALLS: Dictionary = {0xC4: true, 0xCC: false}
+## `wSpriteStateData1`: sixteen slots of sixteen bytes, the player's own first
+## and a map's objects behind it in their table order, facing at offset nine.
+const SPRITE_SLOT_SIZE: int = 0x10
+const SPRITE_FACING_AT: int = 9
+const SPRITE_SLOTS: int = 16
+
+## The stores a row is walked past: nothing here reads any of them.
+const SCRIPT_SILENT_STORES: Array[String] = [
+	"joy_held", "auto_text_box_control", "joy_ignore", "update_sprites_enabled",
+	## A forced walk writes the pad bit over the player's own facing byte, and
+	## the `walk` node behind it carries the direction anyway.
+	"facing_direction",
+]
 ## `cp n` and the two conditional `ret`s behind it, whose value is the side
 ## taken when the comparison did not match.
 const SCRIPT_CP_N: int = 0xFE
 const SCRIPT_RET_BRANCHES: Dictionary = {0xC0: true, 0xC8: false}
+## The same two on carry, which `ret nc` behind `ArePlayerCoordsInArray` is.
+const SCRIPT_RET_CARRY_BRANCHES: Dictionary = {0xD8: true, 0xD0: false}
 ## `PrintPredefTextID`'s operand counts from 1. Yellow puts the Fan Club's two
 ## pictures at $0C and $0D, so every row past the fossils sits two higher there
 ## and an id read as Red's decodes, in the wrong bank, to something.
@@ -1454,6 +1486,21 @@ const RED_BLUE: Dictionary = {
 	"cur_party_species": 0xCF91,
 	"cur_map_script": 0xDA39,
 	"map_scripts": 0xD5F0,
+	## The per-frame half's own dispatch: `hl` is the table for one and `de` is
+	## for the other, which takes the trainer header in `hl` instead.
+	"call_function_in_table": 0x3D97,
+	"execute_map_script": 0x3160,
+	"delay_frames": 0x3739,
+	"delay_3": 0x3DD7,
+	"play_default_music": 0x2307,
+	"check_map_trainers": 0x3219,
+	"player_coords_in_array": 0x34BF,
+	"start_trainer_battle": 0x324C,
+	"end_trainer_battle": 0x3275,
+	"joy_ignore": 0xCD6B,
+	"update_sprites_enabled": 0xCFCB,
+	"obtained_badges": 0xD356,
+	"sprite_state_data": 0xC100,
 	## `ReplaceTileBlock` writes `wNewTileBlockID` at the block `bc` names, and
 	## `SilphCoMapList` is the ten floors `PrintCardKeyText` answers on.
 	"map_script_flags": 0xD126,
@@ -1694,6 +1741,19 @@ const YELLOW: Dictionary = {
 	"cur_party_species": 0xCF90,
 	"cur_map_script": 0xDA38,
 	"map_scripts": 0xD5EF,
+	"call_function_in_table": 0x3D93,
+	"execute_map_script": 0x30FC,
+	"delay_frames": 0x372F,
+	"delay_3": 0x3DDB,
+	"play_default_music": 0x216B,
+	"check_map_trainers": 0x31B5,
+	"player_coords_in_array": 0x34BC,
+	"start_trainer_battle": 0x31E8,
+	"end_trainer_battle": 0x3211,
+	"joy_ignore": 0xCD6B,
+	"update_sprites_enabled": 0xCFCA,
+	"obtained_badges": 0xD355,
+	"sprite_state_data": 0xC100,
 	"map_script_flags": 0xD125,
 	"new_tile_block": 0xD09E,
 	"replace_tile_block": 0x0ED1B,
@@ -2078,6 +2138,30 @@ static func text_predef_count(id: StringName) -> int:
 ## What one `HiddenCoins` row pays, off its own argument column.
 static func hidden_coin_amount(argument: int) -> int:
 	return int(HIDDEN_COIN_AMOUNTS.get(argument - ITEM_COIN, HIDDEN_COIN_DEFAULT))
+
+
+## The two bytes a script reads that the shared engine flags already hold:
+## `wObtainedBadges`, whose eight bits are Kanto's badges, and
+## `BIT_ALWAYS_ON_BIKE`, which is the state `BIKEFLAGS_ALWAYS_ON_BIKE_F` holds.
+## -1 for any other byte or bit.
+static func script_flag_alias(layout: Dictionary, address: int, bit: int) -> int:
+	if address == int(layout.get("obtained_badges", -1)):
+		return Gen2WorldState.gen1_badge_flag(bit)
+	if address != int(layout.get("status_flags_6", -1)) or bit != ALWAYS_ON_BIKE_BIT:
+		return -1
+	return Gen2WorldState.ENGINE_ALWAYS_ON_BIKE
+
+
+## Which map object's facing byte [param address] is, or -1. Slot 0 is the
+## player's, which is walked past instead.
+static func sprite_facing_slot(layout: Dictionary, address: int) -> int:
+	var base: int = int(layout["sprite_state_data"])
+	var offset: int = address - base
+	if offset < SPRITE_SLOT_SIZE or offset >= SPRITE_SLOTS * SPRITE_SLOT_SIZE \
+		or offset % SPRITE_SLOT_SIZE != SPRITE_FACING_AT:
+		return -1
+	@warning_ignore("integer_division")
+	return offset / SPRITE_SLOT_SIZE - 1
 
 
 ## Where one of [constant ENGINE_FLAG_BYTES]' runs starts, or -1.

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -729,6 +729,9 @@ static func _read_map(
 	var callback: Dictionary = _read_map_callback(
 		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), card_key_floors.has(map_id)
 	)
+	var states: Dictionary = _read_map_states(
+		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
+	)
 
 	return {
 		"ok": true,
@@ -750,9 +753,8 @@ static func _read_map(
 			"address": rom.u16le(header + MAP_SCRIPT_AT),
 			"scenes": [],
 			"callbacks": [] if callback.is_empty() else [callback],
-			"clears_always_on_bike": _clears_always_on_bike(
-				rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT)
-			),
+			"entry": states["entry"],
+			"states": states["states"],
 		},
 		"texts": texts,
 		"events": {
@@ -797,22 +799,88 @@ static func _script_ends(rom: RomFile, layout: Dictionary, map_count: int) -> Di
 	return out
 
 
-## Route 16 Gate 1F's and Route 18 Gate 1F's per-frame scripts open with
-## `ld hl, wStatusFlags6` / `res BIT_ALWAYS_ON_BIKE, [hl]` in front of their own
-## jump table, so a forced ride ends on the frame the gate is entered. Nothing
-## interprets that half of a map script here, so the five bytes are matched.
-static func _clears_always_on_bike(
-	rom: RomFile, layout: Dictionary, bank: int, script: int
-) -> bool:
-	var at: int = Gen1Layout.banked(bank, script)
-	if rom.u8(at) != Gen1Layout.SCRIPT_LD_HL \
-		or rom.u16le(at + 1) != int(layout["status_flags_6"]) \
-		or rom.u8(at + Gen1Layout.SCRIPT_LONG_SIZE) != Gen1Layout.SCRIPT_PREFIX:
-		return false
-	var code: int = rom.u8(at + Gen1Layout.SCRIPT_LONG_SIZE + 1)
-	return code >= Gen1Layout.SCRIPT_RES_BASE and code < Gen1Layout.SCRIPT_SET_BASE \
-		and (code & 7) == Gen1Layout.SCRIPT_OPERAND_HL \
-		and ((code >> 3) & 7) == Gen1Layout.ALWAYS_ON_BIKE_BIT
+## `RunMapScript` jumps to the map's own script every frame: what stands in
+## front of `CallFunctionInTable` runs each time and the table behind it holds
+## one body per state. No row records that table's length, so the states kept
+## are the reachable ones: index 0, and whatever a `set_map_script` names.
+static func _read_map_states(
+	rom: RomFile, layout: Dictionary, bank: int, script: int, texts: Array
+) -> Dictionary:
+	var entry: Array = decode_script(rom, layout, bank, script)
+	var dispatch: Dictionary = _map_script_dispatch(entry)
+	if dispatch.is_empty():
+		return {"entry": entry, "states": []}
+	var byte: int = int(dispatch["byte"])
+	var bodies: Array = _map_script_bodies(rom, layout, bank, int(dispatch["table"]))
+	var pending: Array[int] = _map_script_successors(entry, byte)
+	for row: Dictionary in texts:
+		pending.append_array(_map_script_successors(row.get("script", []) as Array, byte))
+	pending.append(0)
+	var reached: Dictionary = {}
+	while not pending.is_empty():
+		var index: int = pending.pop_back()
+		if reached.has(index) or index < 0 or index >= bodies.size():
+			continue
+		reached[index] = true
+		if bodies[index] != null:
+			pending.append_array(_map_script_successors(bodies[index] as Array, byte))
+	var rows: Array = []
+	for index: int in bodies.size():
+		if reached.has(index) and bodies[index] != null:
+			rows.append({"id": index, "nodes": bodies[index]})
+	return {"entry": entry, "states": rows}
+
+
+## Every body of one `<Map>_ScriptPointers` table, read while the word addresses
+## the cartridge. A row standing at a routine the layout names is that routine
+## rather than its machine code, which is how a fighting map's own three trainer
+## rows read; null is a body the walk did not get whole.
+static func _map_script_bodies(
+	rom: RomFile, layout: Dictionary, bank: int, table: int
+) -> Array:
+	var bodies: Array = []
+	while bodies.size() < Gen1Layout.MAP_SCRIPT_STATES:
+		var target: int = rom.u16le(
+			Gen1Layout.banked(bank, table + bodies.size() * Gen1Layout.POINTER_SIZE)
+		)
+		if target < Gen1Layout.SCRIPT_LOWEST or target >= Gen1Layout.SCRIPT_CEILING:
+			break
+		if _script_routine(layout, target) in Gen1Layout.SCRIPT_SILENT_CALLS:
+			bodies.append([])
+			continue
+		bodies.append(_walk_script(
+			{
+				"rom": rom, "layout": layout, "bank": bank,
+				"budget": [SCRIPT_BUDGET], "calls": [0],
+			},
+			target, {}, 0
+		))
+	return bodies
+
+
+## The dispatch node, which a branch above it puts on both of its sides.
+static func _map_script_dispatch(nodes: Array) -> Dictionary:
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "map_script_table":
+			return node
+		for key: String in node:
+			if not node[key] is Array or key == "either":
+				continue
+			var found: Dictionary = _map_script_dispatch(node[key] as Array)
+			if not found.is_empty():
+				return found
+	return {}
+
+
+static func _map_script_successors(nodes: Array, byte: int) -> Array[int]:
+	var out: Array[int] = []
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "set_map_script" and int(node["byte"]) == byte:
+			out.append(int(node["value"]))
+		for key: String in node:
+			if node[key] is Array and key != "either":
+				out.append_array(_map_script_successors(node[key] as Array, byte))
+	return out
 
 
 ## `IsPlayerOnDungeonWarp` and the copy Pokemon Mansion 3F keeps of it both open
@@ -888,9 +956,8 @@ static func _dungeon_destinations(
 
 
 ## `RunMapScript` runs the whole of a map's script every frame, so the work a map
-## does once is the body behind a `wCurrentMapScriptFlags` bit. That body is
-## decoded the way a `text_asm` row is; the per-frame state machine
-## `CallFunctionInTable` dispatches is not read at all.
+## does once is the body behind a `wCurrentMapScriptFlags` bit, decoded the way
+## a `text_asm` row is. [method _read_map_states] reads the rest.
 static func _read_map_callback(
 	rom: RomFile, layout: Dictionary, bank: int, script: int, card_key: bool
 ) -> Dictionary:
@@ -1582,6 +1649,9 @@ const SCRIPT_TESTS_DEX: int = -8
 const SCRIPT_TESTS_TILESET: int = -9
 const SCRIPT_TESTS_TILE: int = -10
 const SCRIPT_TESTS_COORD: int = -11
+## `ArePlayerCoordsInArray`, whose carry is the player standing on one row of a
+## `db y, x` list.
+const SCRIPT_TESTS_COORD_ARRAY: int = -12
 ## What `push af` saves and `pop af` puts back, which is how
 ## `CheckEventAfterBranchReuseA` still reads the event byte a block write
 ## clobbered.
@@ -1630,7 +1700,8 @@ static func _walk_script(
 		var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
 		if Gen1Layout.SCRIPT_BRANCHES.has(op) or Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op):
 			return _script_branch(ctx, op, pc, state, depth, out)
-		if Gen1Layout.SCRIPT_RET_BRANCHES.has(op):
+		if Gen1Layout.SCRIPT_RET_BRANCHES.has(op) \
+			or Gen1Layout.SCRIPT_RET_CARRY_BRANCHES.has(op):
 			return _script_ret_branch(ctx, op, pc, state, depth, out)
 		var next: int = _script_step(ctx, pc, state, out, depth)
 		if next == SCRIPT_END:
@@ -1705,10 +1776,10 @@ static func _script_flow(
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
 		Gen1Layout.SCRIPT_LD_MEM_A:
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE \
-				if _script_stored(ctx, rom.u16le(at + 1), state) else SCRIPT_UNREAD
+				if _script_stored(ctx, rom.u16le(at + 1), state, out) else SCRIPT_UNREAD
 		Gen1Layout.SCRIPT_LDH_MEM_A:
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE if _script_stored(
-				ctx, Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(at + 1), state
+				ctx, Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(at + 1), state, out
 			) else SCRIPT_UNREAD
 		Gen1Layout.SCRIPT_AND_A:
 			_script_test_bit(ctx, state, -1)
@@ -1726,6 +1797,16 @@ static func _script_flow(
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_PREFIX:
 			return _script_prefix(ctx, pc, state, out)
+	return _script_jumped(ctx, pc, at, state, out, depth)
+
+
+## What leaves this instruction for another, and the two register pairs a row
+## saves over one.
+static func _script_jumped(
+	ctx: Dictionary, pc: int, at: int, state: Dictionary, out: Array, depth: int
+) -> int:
+	var rom: RomFile = ctx["rom"]
+	match rom.u8(at):
 		Gen1Layout.SCRIPT_JR:
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE + _script_hop(rom.u8(at + 1))
 		Gen1Layout.SCRIPT_JP:
@@ -1734,25 +1815,40 @@ static func _script_flow(
 			return SCRIPT_END
 		Gen1Layout.SCRIPT_CALL:
 			return _script_call(ctx, pc, rom.u16le(at + 1), state, out, depth)
+		Gen1Layout.SCRIPT_PUSH_HL:
+			state["hl_saved"] = int(state.get("hl", -1))
+			return pc + 1
+		Gen1Layout.SCRIPT_POP_HL:
+			if not state.has("hl_saved"):
+				return SCRIPT_UNREAD
+			state["hl"] = int(state["hl_saved"])
+			return pc + 1
 		Gen1Layout.SCRIPT_PUSH_AF:
 			state["af"] = _script_pushed_af(state)
 			return pc + 1
 		Gen1Layout.SCRIPT_POP_AF:
 			return SCRIPT_UNREAD if not state.has("af") else _script_popped_af(state, pc)
 	if Gen1Layout.SCRIPT_CONDITIONAL_CALLS.has(rom.u8(at)):
-		return _script_call_if(ctx, pc, rom.u16le(at + 1), state)
+		return _script_call_if(ctx, pc, rom.u16le(at + 1), state, out, depth)
 	return SCRIPT_UNREAD
 
 
 ## A conditional `call`, which only a routine spending nothing here may be: both
 ## sides of `call z, WaitForTextScrollButtonPress` print the same boxes.
 static func _script_call_if(
-	ctx: Dictionary, pc: int, target: int, state: Dictionary
+	ctx: Dictionary, pc: int, target: int, state: Dictionary, out: Array, depth: int
 ) -> int:
+	var next: int = pc + Gen1Layout.SCRIPT_LONG_SIZE
+	var op: int = (ctx["rom"] as RomFile).u8(Gen1Layout.banked(int(ctx["bank"]), pc))
+	if state.has("known_zero") and Gen1Layout.SCRIPT_ZERO_CALLS.has(op):
+		var calls: bool = bool(Gen1Layout.SCRIPT_ZERO_CALLS[op]) \
+			!= bool(state["known_zero"])
+		state.erase("known_zero")
+		return _script_call(ctx, pc, target, state, out, depth) if calls else next
 	if not _script_routine(ctx["layout"], target) in Gen1Layout.SCRIPT_SILENT_CALLS:
 		return SCRIPT_UNREAD
 	_script_untested(state)
-	return pc + Gen1Layout.SCRIPT_LONG_SIZE
+	return next
 
 
 static func _script_pushed_af(state: Dictionary) -> Dictionary:
@@ -1775,7 +1871,9 @@ static func _script_popped_af(state: Dictionary, pc: int) -> int:
 
 ## What a branch is reading, and whether it is reading it out of carry.
 static func _script_untested(state: Dictionary) -> void:
-	for key: String in ["tests", "tests_in_carry", "tests_engine", "tests_and_a"]:
+	for key: String in [
+		"tests", "tests_in_carry", "tests_engine", "tests_and_a", "known_zero",
+	]:
 		state.erase(key)
 
 
@@ -1786,6 +1884,7 @@ static func _script_tested(
 	state["tests_in_carry"] = in_carry
 	state["tests_engine"] = engine
 	state.erase("tests_and_a")
+	state.erase("known_zero")
 
 
 ## One rotation of `CheckEvent flag, 1`'s run, or `add a` standing for all eight
@@ -1855,13 +1954,19 @@ static func _script_mask(ctx: Dictionary, state: Dictionary, mask: int) -> Varia
 
 
 ## `DisableWaitingAfterTextDisplay` by hand, `RemoveItemByID`'s own item, and
-## the map script index a row leaves behind it, which this port has no
-## interpreter to hand to and so stores nowhere.
-static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> bool:
+## the map script index a row leaves behind it, which the next frame's
+## `CallFunctionInTable` dispatches on.
+static func _script_stored(
+	ctx: Dictionary, address: int, state: Dictionary, out: Array
+) -> bool:
 	var layout: Dictionary = ctx["layout"]
-	var scripts: int = int(layout["map_scripts"])
-	if address == int(layout["cur_map_script"]) \
-		or (address >= scripts and address < scripts + Gen1Layout.MAP_SCRIPT_BYTES):
+	if address == int(layout["cur_map_script"]):
+		return true
+	var byte: int = _map_script_byte(layout, address)
+	if byte >= 0:
+		if not state.has("a"):
+			return false
+		out.append({"op": "set_map_script", "byte": byte, "value": int(state["a"])})
 		return true
 	if address == int(layout["do_not_wait"]):
 		if int(state.get("a", 0)) != 1:
@@ -1875,10 +1980,18 @@ static func _script_stored(ctx: Dictionary, address: int, state: Dictionary) -> 
 			return false
 		state[String(SCRIPT_STORED_REGISTERS[name])] = int(state["a"])
 		return true
-	## `Mansion1Script_Switches` blanks the held buttons and `OpenPokemonCenterPC`
-	## turns the automatic box off; this port reads nothing out of either.
-	if address == int(layout["joy_held"]) \
-		or address == int(layout["auto_text_box_control"]):
+	## `Mansion1Script_Switches` blanks the held buttons, `OpenPokemonCenterPC`
+	## turns the automatic box off, a map script hands `wJoyIgnore` a mask while
+	## it runs and `wUpdateSpritesEnabled` gates a redraw. Nothing here reads any
+	## of the four.
+	for silent: String in Gen1Layout.SCRIPT_SILENT_STORES:
+		if address == int(layout[silent]):
+			return true
+	var slot: int = Gen1Layout.sprite_facing_slot(layout, address)
+	if slot >= 0:
+		if not Gen1Layout.FACING_STEPS.has(int(state.get("a", -1))):
+			return false
+		out.append({"op": "object_facing", "object": slot, "facing": int(state["a"])})
 		return true
 	if _script_joypad_stored(layout, address, state):
 		return true
@@ -1943,6 +2056,9 @@ static func _script_flag(ctx: Dictionary, address: int, bit: int) -> int:
 ## outside `wEventFlags` a row reads.
 static func _script_engine_flag(ctx: Dictionary, address: int, bit: int) -> int:
 	var layout: Dictionary = ctx["layout"]
+	var alias: int = Gen1Layout.script_flag_alias(layout, address, bit)
+	if alias >= 0:
+		return alias
 	for run: String in Gen1Layout.ENGINE_FLAG_BYTES:
 		var base: int = int(layout.get(run, -1))
 		var width: int = int(Gen1Layout.ENGINE_FLAG_BYTES[run])
@@ -1966,7 +2082,17 @@ static func _script_prefix(
 		and code >= Gen1Layout.SCRIPT_BIT_BASE and code < Gen1Layout.SCRIPT_RES_BASE:
 		_script_test_bit(ctx, state, bit)
 		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
-	if operand != Gen1Layout.SCRIPT_OPERAND_HL or code < Gen1Layout.SCRIPT_RES_BASE:
+	if operand != Gen1Layout.SCRIPT_OPERAND_HL:
+		return SCRIPT_UNREAD
+	## `wCurrentMapScriptFlags` is clear on every frame but the one a map is
+	## loaded on, which [method _read_map_callback] reads instead, so the gate
+	## in front of a per-frame script tests false and its `res` spends nothing.
+	if int(state.get("hl", -1)) == int((ctx["layout"] as Dictionary)["map_script_flags"]):
+		if code < Gen1Layout.SCRIPT_RES_BASE:
+			_script_untested(state)
+			state["known_zero"] = true
+		return pc + Gen1Layout.SCRIPT_SHORT_SIZE
+	if code < Gen1Layout.SCRIPT_RES_BASE:
 		return SCRIPT_UNREAD
 	var written: int = _script_flag(ctx, int(state.get("hl", -1)), bit)
 	var engine: int = _script_engine_flag(ctx, int(state.get("hl", -1)), bit)
@@ -2023,6 +2149,15 @@ static func _script_call(
 			return _script_pokedex(ctx, state, out, next)
 		"give_pokemon":
 			return _script_gift_pokemon(ctx, state, out, next)
+	return _script_called(ctx, routine, target, state, out, next, depth)
+
+
+## The rest of [method _script_call]'s own rows.
+static func _script_called(
+	ctx: Dictionary, routine: String, target: int, state: Dictionary, out: Array,
+	next: int, depth: int
+) -> int:
+	match routine:
 		"has_enough_money":
 			return _script_money_asked(state, next)
 		"has_enough_coins":
@@ -2035,10 +2170,17 @@ static func _script_call(
 			return _script_map_text(state, out, next)
 		"start_simulating_joypad":
 			return _script_walk(state, out, next)
-	if _script_banked_routine(layout, int(ctx["bank"]), target) == "coin_box":
+		"player_coords_in_array":
+			return _script_coord_array(ctx, state, next)
+		"call_function_in_table":
+			return _script_map_script_table(ctx, state, out, int(state.get("hl", -1)))
+		"execute_map_script":
+			return _script_map_script_table(ctx, state, out, int(state.get("de", -1)))
+	var bank: int = int(ctx["bank"])
+	if _script_banked_routine(ctx["layout"], bank, target) == "coin_box":
 		out.append({"op": "coin_box"})
 		return next
-	return _script_routine_call(ctx, int(ctx["bank"]), target, state, out, next, depth)
+	return _script_routine_call(ctx, bank, target, state, out, next, depth)
 
 
 ## `StartSimulatingJoypadStates`, whose buffer is one walking step per entry.
@@ -2054,6 +2196,43 @@ static func _script_walk(state: Dictionary, out: Array, next: int) -> int:
 	state.erase("walk_pad")
 	state.erase("walk_steps")
 	return next
+
+
+## `ArePlayerCoordsInArray`: the `db y, x` list `hl` names, terminated by $FF,
+## and carry for the player standing on one of its rows.
+static func _script_coord_array(ctx: Dictionary, state: Dictionary, next: int) -> int:
+	var rom: RomFile = ctx["rom"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), int(state.get("hl", -1)))
+	var cells: Array = []
+	while rom.in_bounds(at, Gen1Layout.MAP_COORD_SIZE) \
+		and rom.u8(at) != Gen1Layout.MAP_COORD_END:
+		cells.append({"y": rom.u8(at), "x": rom.u8(at + 1)})
+		at += Gen1Layout.MAP_COORD_SIZE
+	if cells.is_empty():
+		return SCRIPT_UNREAD
+	state["cells"] = cells
+	_script_tested(state, SCRIPT_TESTS_COORD_ARRAY, true)
+	return next
+
+
+## `CallFunctionInTable` and `ExecuteCurMapScriptInTable`: the map's own state
+## machine, whose table is in `hl` for one and `de` for the other and whose
+## index is the `w<Map>CurScript` byte the `ld a` above it read.
+static func _script_map_script_table(
+	ctx: Dictionary, state: Dictionary, out: Array, table: int
+) -> int:
+	var byte: int = _map_script_byte(ctx["layout"], int(state.get("source", -1)))
+	if table < 0 or byte < 0:
+		return SCRIPT_UNREAD
+	out.append({"op": "map_script_table", "table": table, "byte": byte})
+	return SCRIPT_END
+
+
+static func _map_script_byte(layout: Dictionary, address: int) -> int:
+	var base: int = int(layout["map_scripts"])
+	if address < base or address >= base + Gen1Layout.MAP_SCRIPT_BYTES:
+		return -1
+	return address - base
 
 
 ## A `call` to a routine the layout does not name, walked in [param bank] and
@@ -2346,6 +2525,8 @@ static func _script_branch(
 ) -> Variant:
 	var tests: Variant = state.get("tests", SCRIPT_TESTS_NOTHING)
 	var carry: bool = Gen1Layout.SCRIPT_CARRY_BRANCHES.has(op)
+	if state.has("known_zero") and not carry:
+		return _script_known_branch(ctx, op, pc, state, depth, out)
 	if not _script_reads_flag(state, tests, carry):
 		return null
 	var rom: RomFile = ctx["rom"]
@@ -2377,24 +2558,64 @@ static func _script_branch(
 	return out
 
 
+## A branch whose zero flag the walk already knows: only the side taken is
+## walked, and it carries on in front of whatever the caller has read already.
+static func _script_known_branch(
+	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
+) -> Variant:
+	var rom: RomFile = ctx["rom"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), pc)
+	var short: bool = op < Gen1Layout.SCRIPT_HOP_LIMIT
+	var size: int = Gen1Layout.SCRIPT_SHORT_SIZE if short else Gen1Layout.SCRIPT_LONG_SIZE
+	var jumps: bool = bool(Gen1Layout.SCRIPT_BRANCHES[op]) != bool(state["known_zero"])
+	var target: int = pc + size
+	if jumps:
+		target = pc + size + _script_hop(rom.u8(at + 1)) if short else rom.u16le(at + 1)
+	state.erase("known_zero")
+	var walked: Variant = _walk_script(ctx, target, state, depth)
+	if walked == null:
+		return null
+	out.append_array(walked as Array)
+	return out
+
+
 ## A conditional `ret`, which a wrong facing is refused with: the side that
 ## returns prints nothing and the other carries on behind it.
 static func _script_ret_branch(
 	ctx: Dictionary, op: int, pc: int, state: Dictionary, depth: int, out: Array
 ) -> Variant:
 	var tests: Variant = state.get("tests", SCRIPT_TESTS_NOTHING)
-	if not _script_reads_flag(state, tests, false):
+	var carry: bool = Gen1Layout.SCRIPT_RET_CARRY_BRANCHES.has(op)
+	var table: Dictionary = Gen1Layout.SCRIPT_RET_CARRY_BRANCHES if carry \
+		else Gen1Layout.SCRIPT_RET_BRANCHES
+	if state.has("known_zero") and not carry:
+		if bool(table[op]) != bool(state["known_zero"]):
+			return _script_ended(state, out)
+		state.erase("known_zero")
+		return _script_walked_on(ctx, pc + 1, state, depth, out)
+	if not _script_reads_flag(state, tests, carry):
 		return null
 	var walked: Variant = _walk_script(ctx, pc + 1, state.duplicate(), depth + 1)
 	if walked == null:
 		return null
 	var branches: Array = [[], walked]
-	if not bool(Gen1Layout.SCRIPT_RET_BRANCHES[op]):
+	if not bool(table[op]):
 		branches.reverse()
-	var node: Variant = _script_node(tests, branches, state, out, false)
+	var node: Variant = _script_node(tests, branches, state, out, carry)
 	if node == null:
 		return null
 	out.append(node)
+	return out
+
+
+## The rest of a path, appended to what the caller has read already.
+static func _script_walked_on(
+	ctx: Dictionary, pc: int, state: Dictionary, depth: int, out: Array
+) -> Variant:
+	var walked: Variant = _walk_script(ctx, pc, state, depth)
+	if walked == null:
+		return null
+	out.append_array(walked as Array)
 	return out
 
 
@@ -2554,6 +2775,9 @@ static func _script_node(
 		SCRIPT_TESTS_COORD:
 			return {"op": "player_coord", "axis": int(state["axis"]),
 				"value": int(state["coord"]), "then": fell, "else": taken}
+		SCRIPT_TESTS_COORD_ARRAY:
+			return {"op": "player_in_array", "cells": state["cells"],
+				"then": taken, "else": fell}
 	var branch: Dictionary = {
 		"op": "branch", "flag": int(tests), "then": taken, "else": fell,
 	}

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3888,6 +3888,10 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"walk": &"_gen1_node_walk",
 	"day_care": &"_gen1_node_day_care",
 	"town_map": &"_gen1_node_town_map",
+	"set_map_script": &"_gen1_node_set_map_script",
+	"player_in_array": &"_gen1_node_player_in_array",
+	"object_facing": &"_gen1_node_object_facing",
+	"map_script_table": &"_gen1_node_map_script_table",
 }
 
 
@@ -4200,6 +4204,54 @@ func _gen1_node_player_coord(node: Dictionary, steps: Array, run: Dictionary) ->
 	var axis: int = int(node["axis"])
 	var standing: int = player_cell.y if axis == 0 else player_cell.x
 	return _gen1_resolve_side(node, standing == int(node["value"]), steps, run)
+
+
+## `ArePlayerCoordsInArray`, whose carry is the player standing on one row of
+## the `db y, x` list the caller named.
+func _gen1_node_player_in_array(
+	node: Dictionary, steps: Array, run: Dictionary
+) -> bool:
+	var standing: bool = false
+	for cell: Dictionary in node["cells"] as Array:
+		if player_cell == Vector2i(int(cell["x"]), int(cell["y"])):
+			standing = true
+			break
+	return _gen1_resolve_side(node, standing, steps, run)
+
+
+## One object's own byte of `wSpriteStateData1`, which a script writes by hand
+## to turn an NPC where `applymovement` would turn one on Generation 2.
+func _gen1_node_object_facing(
+	node: Dictionary, steps: Array, _run: Dictionary
+) -> bool:
+	steps.append({
+		"type": &"object_facing", "index": int(node["object"]),
+		"facing": facing_for_direction(Gen1Layout.FACING_STEPS[int(node["facing"])]),
+	})
+	return true
+
+
+## The store `CallFunctionInTable` dispatches on next frame.
+func _gen1_node_set_map_script(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({
+		"type": &"map_script", "byte": int(node["byte"]), "value": int(node["value"]),
+	})
+	return true
+
+
+## `CallFunctionInTable` itself: the body the map's own byte selects, resolved
+## where the entry script reaches the dispatch. An index the importer read no
+## body for runs nothing, the way an undecoded row says nothing.
+func _gen1_node_map_script_table(
+	node: Dictionary, steps: Array, run: Dictionary
+) -> bool:
+	if state == null or current_map == null:
+		return false
+	var index: int = state.gen1_map_script(int(node["byte"]))
+	for row: Dictionary in current_map.scripts.get("states", []) as Array:
+		if int(row.get("id", -1)) == index:
+			return _gen1_resolve_script(row.get("nodes", []) as Array, steps, run)
+	return true
 
 
 func _gen1_node_walk(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
@@ -4995,6 +5047,9 @@ func dispatch_sight_events() -> Array:
 func _gen1_sight() -> Array:
 	if _gen1_holding():
 		return []
+	var running: Array = _gen1_map_script()
+	if not running.is_empty():
+		return running
 	var request: Dictionary = _find_sight_request()
 	if request.is_empty():
 		return []
@@ -5012,6 +5067,21 @@ func _gen1_sight() -> Array:
 			"distance": int(request["distance"]),
 		},
 	}}] + steps
+	return _gen1_result()
+
+
+## `RunMapScript`, which `JoypadOverworld` runs every frame: what stands in
+## front of `CallFunctionInTable` and then the state the map's byte selects.
+func _gen1_map_script() -> Array:
+	if current_map == null or state == null:
+		return []
+	var entry: Array = current_map.scripts.get("entry", [])
+	if entry.is_empty():
+		return []
+	var steps: Array = []
+	if not _gen1_resolve_script(entry, steps, _gen1_run({})) or steps.is_empty():
+		return []
+	_gen1_steps = steps
 	return _gen1_result()
 
 
@@ -5135,6 +5205,12 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 		&"blackout_map":
 			_gen1_record_blackout_map()
 			return true
+		&"map_script":
+			state.set_gen1_map_script(int(step["byte"]), int(step["value"]))
+			return true
+		&"object_facing":
+			_turn_gen1_object(int(step["index"]), int(step["facing"]), events)
+			return true
 		&"walk":
 			events.append_array(_gen1_walk_player(
 				_movement_direction(int(step["direction"])), int(step["steps"])
@@ -5155,6 +5231,18 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 				events.append(changed)
 			return true
 	return false
+
+
+## The override the next object load reads, and the object standing now.
+func _turn_gen1_object(index: int, facing: int, events: Array) -> void:
+	if current_map == null or index < 0 or index >= objects.size():
+		return
+	_apply_object_override(&"object_facing", {
+		"map_group": current_map.group, "map_number": current_map.number,
+		"object_index": index, "facing": facing,
+	})
+	(objects[index] as Gen2WorldObject).facing = facing
+	events.append({"type": &"object_turned", "object_index": index, "facing": facing})
 
 
 ## Spends the head step and answers with whatever the next one waits on.
@@ -5936,6 +6024,10 @@ func _queue_map_callbacks(callback_type: int) -> void:
 		return
 	if _gen1:
 		_run_gen1_map_callback()
+		## `RunMapScript` runs on the first frame behind `EnterMap`, so what the
+		## map's own script writes is standing before the player may move. What
+		## it would show waits for the step dispatch, which resolves it again.
+		_spend_gen1_nodes(current_map.scripts.get("entry", []) as Array)
 		return
 	var bank: int = int(current_map.scripts.get("bank", 0))
 	for callback: Dictionary in current_map.scripts.get("callbacks", []):
@@ -5958,8 +6050,14 @@ func _run_gen1_map_callback() -> void:
 	if callbacks.is_empty():
 		return
 	_unlock_gen1_card_key_door()
+	_spend_gen1_nodes(callbacks[0]["nodes"] as Array)
+
+
+## Spends every step of [param nodes] that takes no turn of its own, stopping
+## at the first that would show something.
+func _spend_gen1_nodes(nodes: Array) -> void:
 	var steps: Array = []
-	if not _gen1_resolve_script(callbacks[0]["nodes"] as Array, steps, _gen1_run({})):
+	if nodes.is_empty() or not _gen1_resolve_script(nodes, steps, _gen1_run({})):
 		return
 	var events: Array = []
 	while not steps.is_empty() and _gen1_written(steps[0], events):
@@ -8747,13 +8845,10 @@ func always_on_bike() -> bool:
 ## `CheckForceBikeOrSurf`, which `EnterMap` runs behind the map load. A cell of
 ## `ForcedBikeOrSurfMaps` mounts the bike and sets `BIT_ALWAYS_ON_BIKE`, except
 ## on the two Seafoam Islands floors, which force surfing and set nothing; the
-## flag already standing returns before the walk. The two gate scripts open by
-## clearing it, which is the only way a forced ride ends.
+## flag already standing returns before the walk. The two gates' own per-frame
+## scripts clear it, which is the only way a forced ride ends.
 func _gen1_check_force_bike_or_surf() -> void:
 	if not _gen1 or current_map == null or state == null:
-		return
-	if current_map.scripts.get("clears_always_on_bike", false):
-		state.set_engine_flag(Gen2WorldState.always_on_bike_flag(data), false)
 		return
 	if always_on_bike() or not data.gen1_forces_ride(current_map.number, player_cell):
 		return

--- a/game/world/world_map.gd
+++ b/game/world/world_map.gd
@@ -99,9 +99,10 @@ static func _scripts_from_cache(value: Variant) -> Dictionary:
 		"address": int(script_values.get("address", 0)),
 		"scenes": _script_pointer_rows(script_values.get("scenes", [])),
 		"callbacks": _script_pointer_rows(script_values.get("callbacks", [])),
-		# Whether the per-frame half opens by clearing `BIT_ALWAYS_ON_BIKE`,
-		# which only the two cycling road gates do. Generation 1's alone.
-		"clears_always_on_bike": bool(script_values.get("clears_always_on_bike", false)),
+		# Generation 1's own per-frame half: what runs in front of
+		# `CallFunctionInTable` and one body per state behind it.
+		"entry": _script_pointer_rows(script_values.get("entry", [])),
+		"states": _script_pointer_rows(script_values.get("states", [])),
 	}
 
 

--- a/game/world/world_state.gd
+++ b/game/world/world_state.gd
@@ -306,6 +306,10 @@ var _npc_trades: Dictionary = {}
 ## of global indices a `ShowObject` or a `HideObject` has since moved away from
 ## that row: a state that has run neither is the cartridge's own new game.
 var _toggled_objects: Dictionary = {}
+## `wGameProgressFlags`' own `w<Map>CurScript` bytes, by their offset in that
+## run: which state of its own machine a map's per-frame script stands on. Zero
+## is the cartridge's own new game, so only a byte a script has moved is kept.
+var _gen1_map_scripts: Dictionary = {}
 ## `wCardKeyDoorY` and its neighbour: the block `PrintCardKeyText` last opened a
 ## Silph Co. door at. The floor's own callback turns it into that door's flag on
 ## the next load and clears it, so opening a second door on one visit loses the
@@ -535,6 +539,7 @@ func to_dict() -> Dictionary:
 		"kurt_apricorn_quantity": _kurt_apricorn_quantity,
 		"picked_fruit_trees": _picked_fruit_trees.duplicate(),
 		"toggled_objects": _toggled_objects.duplicate(),
+		"gen1_map_scripts": _gen1_map_scripts.duplicate(),
 		"card_key_door": [_card_key_door.x, _card_key_door.y],
 		"npc_trades": _npc_trades.duplicate(),
 		"registered_item": _registered_item,
@@ -587,6 +592,7 @@ static func from_dict(raw: Variant) -> Gen2WorldState:
 	_seed_counts(restored._pc_items, _map(source, "pc_items"), 1, -1, Gen2WorldPack.MAX_PC_ITEMS)
 	_seed_flags(restored._picked_fruit_trees, _map(source, "picked_fruit_trees"), 1)
 	_seed_flags(restored._toggled_objects, _map(source, "toggled_objects"), 0)
+	_seed_counts(restored._gen1_map_scripts, _map(source, "gen1_map_scripts"), 0)
 	restored._card_key_door = _vector_from_value(
 		source.get("card_key_door", [NO_CARD_KEY_DOOR.x, NO_CARD_KEY_DOOR.y])
 	)
@@ -744,6 +750,7 @@ func restore_from_dict(raw: Variant) -> void:
 	_kurt_apricorn_quantity = restored._kurt_apricorn_quantity
 	_picked_fruit_trees = restored._picked_fruit_trees.duplicate()
 	_toggled_objects = restored._toggled_objects.duplicate()
+	_gen1_map_scripts = restored._gen1_map_scripts.duplicate()
 	_card_key_door = restored._card_key_door
 	_npc_trades = restored._npc_trades.duplicate()
 	_registered_item = restored._registered_item
@@ -1720,6 +1727,20 @@ func set_object_toggled(index: int, toggled: bool) -> void:
 		_toggled_objects[index] = true
 	else:
 		_toggled_objects.erase(index)
+	changed.emit()
+
+
+func gen1_map_script(byte: int) -> int:
+	return int(_gen1_map_scripts.get(byte, 0))
+
+
+func set_gen1_map_script(byte: int, value: int) -> void:
+	if byte < 0 or gen1_map_script(byte) == value:
+		return
+	if value > 0:
+		_gen1_map_scripts[byte] = value
+	else:
+		_gen1_map_scripts.erase(byte)
 	changed.emit()
 
 

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -69,6 +69,21 @@ const LAYOUT: Dictionary = {
 	"start_simulating_joypad": 0x0320,
 	"simulated_joypad_index": 0xCD38,
 	"simulated_joypad_end": 0xCCD3,
+	"call_function_in_table": 0x0330,
+	"execute_map_script": 0x0340,
+	"player_coords_in_array": 0x0350,
+	"delay_3": 0x0360,
+	"delay_frames": 0x0370,
+	"play_default_music": 0x0380,
+	"check_map_trainers": 0x0390,
+	"start_trainer_battle": 0x03A0,
+	"end_trainer_battle": 0x03B0,
+	"load_gym_names": 0x03C0,
+	"joy_ignore": 0xCD6B,
+	"update_sprites_enabled": 0xCFCB,
+	"obtained_badges": 0xD356,
+	"sprite_state_data": 0xC100,
+	"status_flags_6": 0xD732,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
 const PREDEFS: Dictionary = {
@@ -81,13 +96,26 @@ const BYE: int = 0x1810
 const UNREAD_CALL: int = 0x0200
 ## `call z, nn`, one of [constant Gen1Layout.SCRIPT_CONDITIONAL_CALLS]' four.
 const CALL_Z: int = 0xCC
+## A `<Map>_ScriptPointers` table, the `w<Map>CurScript` byte it dispatches on
+## and one state body behind it.
+const TABLE: int = 0x1900
+const STATE: int = 0x1910
+const MAP_SCRIPT_BYTE: int = 4
+## `PewterCityPlayerLeavingEastCoords`' shape: `db y, x` rows under a $FF.
+const COORDS: int = 0x1930
+## `ret nc`, which a coordinate list is refused with, and `call nz`, which a map
+## load gate calls its own body through.
+const RET_NC: int = 0xD0
+const CALL_NZ: int = 0xC4
 
 
-func _rom(program: Array, strings: Dictionary = {}) -> RomFile:
+func _rom(program: Array, strings: Dictionary = {}, raw: Dictionary = {}) -> RomFile:
 	var data: PackedByteArray = PackedByteArray()
 	data.resize(RomFile.BANK_SIZE)
 	for offset: int in program.size():
 		data[AT + offset] = int(program[offset])
+	for address: int in raw:
+		data[address] = int(raw[address])
 	for address: int in strings:
 		## `TX_START`, the literal, and `<DONE>`: what a `text_far` target holds.
 		var text: PackedByteArray = Gen1Text.encode(String(strings[address]))
@@ -121,6 +149,86 @@ func _print(address: int) -> Array:
 
 func _decode(program: Array, strings: Dictionary = {}) -> Array:
 	return Gen1WorldImporter.decode_script(_rom(program, strings), LAYOUT, 0, AT)
+
+
+func _load_a(address: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_A_MEM, address & 0xFF, address >> 8]
+
+
+func _store_a(address: int) -> Array:
+	return [Gen1Layout.SCRIPT_LD_MEM_A, address & 0xFF, address >> 8]
+
+
+## `ld hl, <table>` / `ld a, [w<Map>CurScript]` / `jp CallFunctionInTable`.
+func _dispatch() -> Array:
+	return _load_hl(TABLE) \
+		+ _load_a(int(LAYOUT["map_scripts"]) + MAP_SCRIPT_BYTE) \
+		+ [Gen1Layout.SCRIPT_JP, LAYOUT["call_function_in_table"] & 0xFF,
+			int(LAYOUT["call_function_in_table"]) >> 8]
+
+
+func test_the_dispatch_names_the_table_and_the_byte_it_reads() -> void:
+	assert_eq(_decode(_dispatch()), [
+		{"op": "map_script_table", "table": TABLE, "byte": MAP_SCRIPT_BYTE},
+	])
+
+
+func test_a_store_to_a_map_script_byte_names_the_state_it_leaves() -> void:
+	var script: Array = _decode(
+		[Gen1Layout.SCRIPT_LD_A, 3] + _store_a(int(LAYOUT["map_scripts"]) + MAP_SCRIPT_BYTE)
+			+ [Gen1Layout.SCRIPT_RET]
+	)
+	assert_eq(script, [{"op": "set_map_script", "byte": MAP_SCRIPT_BYTE, "value": 3}])
+
+
+func test_a_map_script_store_the_walk_cannot_value_answers_nothing() -> void:
+	assert_eq(
+		_decode(_store_a(int(LAYOUT["map_scripts"])) + [Gen1Layout.SCRIPT_RET]), []
+	)
+
+
+## `wCurrentMapScriptFlags` is clear on every frame but the map's own load, so
+## the gate in front of a per-frame script tests false and the body it would
+## have called is not read at all.
+func test_the_map_load_gate_is_walked_past() -> void:
+	var gate: Array = _load_hl(int(LAYOUT["map_script_flags"])) \
+		+ [Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_BIT_BASE + Gen1Layout.SCRIPT_OPERAND_HL,
+			Gen1Layout.SCRIPT_PREFIX,
+			Gen1Layout.SCRIPT_RES_BASE + Gen1Layout.SCRIPT_OPERAND_HL,
+			CALL_NZ, UNREAD_CALL & 0xFF, UNREAD_CALL >> 8]
+	var script: Array = _decode(
+		gate + _print(HELLO) + _call(int(LAYOUT["text_script_end"])), _boxes()
+	)
+	assert_eq(script, [{"op": "text", "text": "HI"}])
+
+
+func test_a_coordinate_list_becomes_the_cells_it_holds() -> void:
+	var program: Array = _load_hl(COORDS) + _call(int(LAYOUT["player_coords_in_array"])) \
+		+ [RET_NC] + _print(HELLO) + _call(int(LAYOUT["text_script_end"]))
+	var script: Array = Gen1WorldImporter.decode_script(
+		_rom(program, _boxes(), {
+			COORDS: 7, COORDS + 1: 9, COORDS + 2: 8, COORDS + 3: 10,
+			COORDS + 4: Gen1Layout.MAP_COORD_END,
+		}),
+		LAYOUT, 0, AT
+	)
+	assert_eq(script, [{
+		"op": "player_in_array",
+		"cells": [{"y": 7, "x": 9}, {"y": 8, "x": 10}],
+		"then": [{"op": "text", "text": "HI"}], "else": [],
+	}])
+
+
+func test_a_store_to_a_sprite_facing_byte_turns_that_object() -> void:
+	var facing_byte: int = int(LAYOUT["sprite_state_data"]) \
+		+ 2 * Gen1Layout.SPRITE_SLOT_SIZE + Gen1Layout.SPRITE_FACING_AT
+	var script: Array = _decode(
+		[Gen1Layout.SCRIPT_LD_A, Gen1Layout.FACING_LEFT] + _store_a(facing_byte)
+			+ [Gen1Layout.SCRIPT_RET]
+	)
+	assert_eq(script, [
+		{"op": "object_facing", "object": 1, "facing": Gen1Layout.FACING_LEFT},
+	])
 
 
 func test_a_row_that_prints_one_box_decodes_to_it() -> void:
@@ -215,19 +323,6 @@ func test_a_call_to_the_maps_own_routine_is_walked_and_returned_from() -> void:
 	assert_eq(_decode(program, _boxes()), [
 		{"op": "text", "text": "HI"}, {"op": "text", "text": "BYE"},
 	])
-
-
-## The map script index a row leaves behind it. Nothing here interprets one, so
-## the write is walked past rather than ending the path.
-func test_a_map_script_write_is_walked_past() -> void:
-	var index: int = int(LAYOUT["map_scripts"]) + 0x17
-	var script: Array = _decode(
-		[Gen1Layout.SCRIPT_LD_A, 3, Gen1Layout.SCRIPT_LD_MEM_A,
-			index & 0xFF, index >> 8]
-			+ _print(HELLO) + _call(int(LAYOUT["text_script_end"])),
-		_boxes()
-	)
-	assert_eq(script, [{"op": "text", "text": "HI"}])
 
 
 func test_a_branch_side_this_decoder_cannot_read_is_marked_rather_than_dropped() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -17,11 +17,11 @@ const MAX_COMMENT_BLOCK: int = 8
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
 ## files cost: `game/gen1` and its neighbours are 1568 lines of it, and
-## Generation 1 has added 2112 more to the shared code: 152 the region map, 150
-## the battle animation engine, 140 the transition, 131 the field moves, 130 the
-## Pokedex, 108 the three PCs, 97 the bicycle, 95 the trainer card, 85 the party
-## menu, 85 the dungeon warps, 66 the Day-Care, 42 the status screen.
-const MAX_COMMENT_LINES: int = 41350
+## Generation 1 has added 2186 more to the shared code, the largest of them 152
+## the region map, 150 the battle animation engine, 140 the transition, 131 the
+## field moves, 130 the Pokedex, 108 the three PCs, 97 the bicycle, 95 the
+## trainer card, 74 the per-frame map scripts.
+const MAX_COMMENT_LINES: int = 41424
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tests/unit/test_world_api.gd
+++ b/tests/unit/test_world_api.gd
@@ -9895,7 +9895,10 @@ func _gen1_gate_map() -> Dictionary:
 		"x": 1, "y": 3, "destination": 0, "map_group": 0,
 		"map_number": Gen1Layout.WARP_TO_LAST_MAP,
 	}])
-	map["scripts"] = {"clears_always_on_bike": true}
+	map["scripts"] = {"entry": [
+		{"op": "flag", "flag": Gen2WorldState.ENGINE_ALWAYS_ON_BIKE,
+			"set": false, "engine": true},
+	]}
 	return map
 
 

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -130,24 +130,27 @@ const EMPTY_TEXTS: Dictionary = {&"red": 1, &"blue": 1, &"yellow": 1}
 
 ## The `text_asm` rows read as a script, and the nodes under them.
 const SCRIPT_CENSUS: Dictionary = {
-	&"red": {"rows": 261, "text": 328, "branch": 118, "choice": 20, "flag": 46,
+	&"red": {"rows": 263, "text": 334, "branch": 119, "choice": 21, "flag": 46,
 		"give_item": 28, "has_item": 15, "take_item": 3, "unknown": 59,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
-		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
-	&"blue": {"rows": 261, "text": 328, "branch": 118, "choice": 20, "flag": 46,
+		"player_coord": 4, "walk": 3, "replace_block": 1, "day_care": 1,
+		"set_map_script": 9, "player_in_array": 1},
+	&"blue": {"rows": 263, "text": 334, "branch": 119, "choice": 21, "flag": 46,
 		"give_item": 28, "has_item": 15, "take_item": 3, "unknown": 59,
 		"pick_up_item": 104, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 9, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 2,
-		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
-	&"yellow": {"rows": 307, "text": 366, "branch": 113, "choice": 21, "flag": 40,
-		"give_item": 27, "has_item": 12, "take_item": 3, "unknown": 63,
+		"player_coord": 4, "walk": 3, "replace_block": 1, "day_care": 1,
+		"set_map_script": 9, "player_in_array": 1},
+	&"yellow": {"rows": 309, "text": 373, "branch": 114, "choice": 22, "flag": 40,
+		"give_item": 27, "has_item": 12, "take_item": 3, "unknown": 62,
 		"pick_up_item": 108, "toggle_object": 12, "pokedex": 9, "give_pokemon": 5,
 		"trade": 7, "has_money": 3, "spend_money": 3, "money_box": 4,
 		"has_coins": 4, "add_coins": 4, "coin_box": 2, "facing": 13, "dex_count": 6,
-		"player_coord": 4, "walk": 2, "replace_block": 1, "day_care": 1},
+		"player_coord": 4, "walk": 3, "replace_block": 1, "day_care": 1,
+		"set_map_script": 10, "player_in_array": 1},
 }
 ## `BIT_GOT_OLD_ROD` and its two neighbours share `wStatusFlags1` with
 ## `BIT_STRENGTH_ACTIVE`, so reading that byte is what hands the three rods over.
@@ -195,6 +198,14 @@ const CALLBACK_CENSUS: Dictionary = {
 	&"red": {"gated": 36, "read": 21, "blocks": 79, "doors": 20, "floors": 10},
 	&"blue": {"gated": 36, "read": 21, "blocks": 79, "doors": 20, "floors": 10},
 	&"yellow": {"gated": 34, "read": 20, "blocks": 78, "doors": 20, "floors": 10},
+}
+
+## The maps with a state machine, the states reachable from index 0 and from
+## every `set_map_script` already read, and the bodies the walker gets whole.
+const STATE_CENSUS: Dictionary = {
+	&"red": {"tables": 92, "states": 56, "read": 5, "ops": 33},
+	&"blue": {"tables": 92, "states": 56, "read": 5, "ops": 33},
+	&"yellow": {"tables": 90, "states": 51, "read": 3, "ops": 16},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -280,6 +291,7 @@ func _one_game() -> void:
 		"the movement census reads %s." % str(_movements))
 	_texts()
 	_map_callbacks()
+	_map_states()
 	_hidden_events()
 	_dungeon_warps()
 	_bike()
@@ -537,6 +549,49 @@ func _map_callbacks() -> void:
 	_r.check(census == CALLBACK_CENSUS[_r.game_id],
 		"the map callbacks read %s." % [census])
 	_r.note("gen1 map callbacks %s" % [census])
+
+
+## `RunMapScript`'s own half, swept over the corpus.
+func _map_states() -> void:
+	var census: Dictionary = {"tables": 0, "states": 0, "read": 0, "ops": 0}
+	for map: Gen2WorldMap in _maps.values():
+		var entry: Array = map.scripts["entry"] as Array
+		var dispatch: Dictionary = _dispatch_node(entry)
+		var states: Array = map.scripts["states"] as Array
+		if dispatch.is_empty():
+			_r.check(states.is_empty(),
+				"map %d holds states with no dispatch." % map.number)
+			continue
+		census["tables"] += 1
+		census["states"] += states.size()
+		for row: Dictionary in states:
+			var nodes: Array = row["nodes"] as Array
+			census["read"] += 1 if not nodes.is_empty() else 0
+			census["ops"] += _node_count(nodes)
+	_r.check(census == STATE_CENSUS[_r.game_id], "the map states read %s." % [census])
+	_r.note("gen1 map states %s" % [census])
+
+
+func _dispatch_node(nodes: Array) -> Dictionary:
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "map_script_table":
+			return node
+		for key: String in node:
+			if not node[key] is Array or key == "either":
+				continue
+			var found: Dictionary = _dispatch_node(node[key] as Array)
+			if not found.is_empty():
+				return found
+	return {}
+
+
+func _node_count(nodes: Array) -> int:
+	var total: int = nodes.size()
+	for node: Dictionary in nodes:
+		for key: String in node:
+			if node[key] is Array and key != "either":
+				total += _node_count(node[key] as Array)
+	return total
 
 
 func _blocks_written(nodes: Array) -> int:
@@ -929,6 +984,21 @@ func _sprites() -> void:
 				"map %d has an object drawn with picture id %d." % [map.number, picture])
 
 
+## `res BIT_ALWAYS_ON_BIKE, [hl]` in a map's per-frame script, which reads
+## through the shared engine flag `BIKEFLAGS_ALWAYS_ON_BIKE_F` holds.
+func _clears_forced_ride(nodes: Array) -> bool:
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "flag" and bool(node.get("engine", false)) \
+			and not bool(node["set"]) \
+			and int(node["flag"]) == Gen2WorldState.ENGINE_ALWAYS_ON_BIKE:
+			return true
+		for key: String in node:
+			if node[key] is Array and key != "either" \
+				and _clears_forced_ride(node[key] as Array):
+				return true
+	return false
+
+
 ## `IsBikeRidingAllowed`'s two answers, `ForcedBikeOrSurfMaps`' eight cells and
 ## the two gate scripts that clear a forced ride, over the whole corpus.
 func _bike() -> void:
@@ -937,7 +1007,7 @@ func _bike() -> void:
 		"BikeRidingTilesets reads %s." % str(tilesets))
 	var allowed: int = 0
 	for map: Gen2WorldMap in _maps.values():
-		var gate: bool = bool(map.scripts.get("clears_always_on_bike", false))
+		var gate: bool = _clears_forced_ride(map.scripts["entry"] as Array)
 		_r.check(gate == BIKE_GATE_MAPS.has(map.number),
 			"map %d answers %s to clearing a forced ride." % [map.number, gate])
 		if BIKE_RIDING_TILESETS.has(map.tileset) \

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -76,6 +76,16 @@ const TOWN_MAP_POSTER_TILE: int = 0x3D
 ## `text_promptbutton` behind the string, which is the page break the stream
 ## keeps rather than a second box.
 const TOWN_MAP_POSTER_BOX: String = "A TOWN MAP." + Gen2TextStream.PAGE_BREAK
+## `Route22GateScriptCoords`' first cell, the `w<Map>CurScript` byte the gate
+## dispatches on, and the two states `Route22GateGuardText` leaves behind it.
+const ROUTE_22_GATE: int = 193
+const ROUTE_22_GATE_CELL := Vector2i(4, 2)
+const ROUTE_22_GATE_BYTE: int = 0x1E
+const ROUTE_22_GATE_MOVING: int = 1
+const ROUTE_22_GATE_NOOP: int = 2
+const ROUTE_22_GATE_PASS: String = "Oh! That is the"
+const ROUTE_22_GATE_REFUSED: String = "Only truly skilled"
+
 ## A party that knows FLY, and `FlyWarpDataPtr.ViridianCity`'s own tile.
 const FLY_SPECIES: Array[int] = [16]
 const FLY_MOVES: Array = [[Gen2WorldFieldMove.MOVE_FLY, 0, 0, 0]]
@@ -378,6 +388,7 @@ func _one_game() -> void:
 	_check_the_poke_flute()
 	_check_a_cut_tree()
 	_check_rock_tunnel_is_dark()
+	_check_a_map_script_runs()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -1919,6 +1930,36 @@ func _check_the_cycling_road() -> void:
 		"the gate left the ride %s forced." % ["still" if world.always_on_bike() else "no longer"]
 	)
 	_r.note("gen1 bike forced on Route 16 at %s" % ROUTE_16_GATE_DOOR)
+
+
+## `RunMapScript` driven on the world: Route 22 Gate's own state machine opens
+## on `ArePlayerCoordsInArray`, the guard's row branches on BOULDERBADGE, and
+## the index it leaves behind is what the next step dispatches on.
+func _check_a_map_script_runs() -> void:
+	for badge: bool in [true, false]:
+		var world: Gen2WorldAPI = _r.open_world(0, ROUTE_22_GATE, ROUTE_22_GATE_CELL)
+		if world == null:
+			return
+		if badge:
+			world.state.set_engine_flag(
+				Gen2WorldState.gen1_badge_flag(Gen1Layout.BOULDERBADGE), true
+			)
+		var spoken: String = _event_text(world.dispatch_sight_events())
+		var wanted: String = ROUTE_22_GATE_PASS if badge else ROUTE_22_GATE_REFUSED
+		if not _r.check(spoken.begins_with(wanted),
+			"the gate guard said %s with the badge %s." % [spoken, badge]):
+			continue
+		world.run_event_queue(true)
+		_r.check(
+			world.state.gen1_map_script(ROUTE_22_GATE_BYTE)
+				== (ROUTE_22_GATE_NOOP if badge else ROUTE_22_GATE_MOVING),
+			"the guard left the gate on state %d with the badge %s." % [
+				world.state.gen1_map_script(ROUTE_22_GATE_BYTE), badge,
+			]
+		)
+		_r.check(world.dispatch_sight_events().is_empty(),
+			"the gate spoke twice with the badge %s." % badge)
+	_r.note("gen1 walk ROUTE_22_GATE both ways past its guard")
 
 
 ## `ItemUsePokeFlute` outside a battle: the cell beside Route 12's Snorlax sets

--- a/tools/preview_world.gd
+++ b/tools/preview_world.gd
@@ -30,6 +30,7 @@ const KIND_HELP: Dictionary = {
 	&"sign": "frames: DisplayTextID's box, read by facing up from where the player stands. 0 spends the whole reveal, which is past a box owing no press",
 	&"gift": "presses: a `GiveItem` row, faced up from the cell after the @. 0 is the offer's first page, 4 the receipt box a bag with room earns",
 	&"trainer": "presses, frames: TalkToTrainer on the map's first trainer, faced from the cell below. 0 the before-battle box, 1 the fight the press behind it opens; a second number stops that many frames into the transition instead",
+	&"map_script": "frames, 0: RunMapScript's own state, stepped into by walking up out of the cell after the @. Route 22 Gate's guard is `-- red 0 193 <out.png> live map_script@4,3 300 0`",
 	&"sight": "frames, 0: CheckFightingMapTrainers on the map's first trainer who sees, walked into from the far end of its own line. 40 stands in the shock bubble, 120 in the walk-up, 400 in the before-battle box",
 	&"nurse": "presses: DisplayPokemonCenterDialogue_, talked to from below the counter. 0 the welcome, 1 the YES/NO, 2 the heal",
 	&"vending": "presses, rows down: VendingMachineMenu, read by facing up from the cell below one. 0 the list, 1 the box the chosen row lands in",
@@ -100,6 +101,8 @@ const BADGE_NAMES: Array[String] = [
 ]
 
 ## `.forced_dpad`'s own order, which the first number indexes.
+## Frames of UP held, which is one step and the landing behind it.
+const MAP_SCRIPT_STEP_FRAMES: int = 24
 const ICE_SLIDE_BUTTONS: Array[int] = [
 	PokeButton.DOWN, PokeButton.UP, PokeButton.LEFT, PokeButton.RIGHT,
 ]
@@ -411,7 +414,7 @@ const SELF_DRIVEN_KINDS: Array[StringName] = [
 	&"ice_slide", &"whiteout", &"view_cover", &"gift_nickname",
 	&"catch_nickname", &"catch_dex", &"mom_bank", &"bills_pc", &"players_pc",
 	&"pokemon_center_pc", &"start_menu", &"pokedex", &"trainer_card",
-	&"mod_notice", &"mod_page", &"sight",
+	&"mod_notice", &"mod_page", &"sight", &"map_script",
 	&"reset_question", &"launcher_question",
 ]
 
@@ -463,6 +466,7 @@ const STAGERS: Dictionary = {
 	&"gift": &"_stage_gift",
 	&"trainer": &"_stage_trainer",
 	&"sight": &"_stage_sight",
+	&"map_script": &"_stage_map_script",
 	&"nurse": &"_stage_nurse",
 	&"vending": &"_stage_vending",
 	&"prizes": &"_stage_prizes",
@@ -1110,6 +1114,19 @@ func _stage_trainer() -> void:
 		_screen.advance_frame()
 	if _cell.y <= 0:
 		_screen.settle_battle_transition()
+
+
+## `RunMapScript`, which runs on the step that lands: the cell after the @ is
+## the one below the trigger, walked up out of.
+func _stage_map_script() -> void:
+	var world: Gen2WorldAPI = _screen.get("_world")
+	for _press: int in MAP_SCRIPT_STEP_FRAMES:
+		if world != null and world.script_input_waiting():
+			break
+		_screen.press_button(PokeButton.UP)
+		_screen.advance_frame()
+	_screen.advance_frames(maxi(_cell.x, 0))
+
 
 
 ## `CheckFightingMapTrainers`, walked into from the far end of the line.


### PR DESCRIPTION
`RunMapScript` jumps to `<Map>_Script` on every frame `JoypadOverworld` reads: what stands in front of `CallFunctionInTable` runs each time and the table behind it holds one body per state. Nothing here read that half before, so two byte matches stood in for it.

## Added

`Gen1WorldImporter._read_map_states` decodes a map's entry script and the bodies of its `<Map>_ScriptPointers` table with the same walker a `text_asm` row is read by. No row records that table's length, so the pointers are read while they address the cartridge at all and the states kept are the reachable ones: index 0, and whatever a `set_map_script` on a reachable body, on the entry script or on one of the map's own text rows names. 92 maps of Red and Blue carry a table and 90 of Yellow, over 56 and 51 reachable states.
`Gen2WorldState` holds `wGameProgressFlags`' 122 `w<Map>CurScript` bytes and they ride the world snapshot, so a save comes back on the state its map was left on.
`Gen2WorldAPI` runs the entry script at map entry and again on every settled step, in front of the sight walk the cartridge reaches from inside it. An index with no decoded body runs nothing, the way an undecoded text row says nothing.
`ArePlayerCoordsInArray` decodes to a `player_in_array` node over its own `db y, x` list, and a store to a slot of `wSpriteStateData1` turns that object where `applymovement` turns one on Generation 2.
`tools/preview_world.gd`'s `map_script` kind photographs a state, stepped into by walking up out of the cell after the `@`.

## Changed

`wCurrentMapScriptFlags` is clear on every frame but a map's own load, so a `bit` on it is a known zero and the gate in front of a per-frame script folds instead of branching. `_script_known_branch`, `_script_ret_branch` and `_script_call_if` all take that fold.
`wObtainedBadges` and `wStatusFlags6`'s `BIT_ALWAYS_ON_BIKE` read through `Gen1Layout.script_flag_alias` onto the shared engine flags, so a row gated on a badge decodes at all. Route 22 Gate's guard is the first.
`ld hl` across a `push hl` / `pop hl`, `ret nc` and `ret c`, and stores to `wJoyIgnore` and `wUpdateSpritesEnabled` are read now. The three rows every fighting map's table opens with resolve to `CheckFightingMapTrainers`, `DisplayEnemyTrainerTextAndStartBattle` and `EndTrainerBattle`, which is the sight walk `dispatch_sight_events` already runs behind the script.
Red and Blue read 263 `text_asm` rows against 261 and Yellow 309 against 307.

## Fixed

Route 16 Gate 1F's and Route 18 Gate 1F's forced ride ends through the gate script's own `res BIT_ALWAYS_ON_BIKE, [hl]` rather than through five matched bytes, and `_clears_always_on_bike` is gone.

## Checks

`tools/checks/gen1_maps.gd` pins the state census on all three cartridges; `gen1_walk.gd` walks Route 22 Gate's guard both ways about the BOULDERBADGE and reads the index he leaves behind. The unit tier is 3,878 tests and the scene tier 4,496, `tools/validate.gd -- all` is 93 topics with no failure, `replay_world.gd` is 33 routes with no failure, and the editor analyser reports 0 warnings over 634 scripts.