### PR TITLE
Walk a Generation 1 map script's own objects and player

### DIFF
--- a/game/gen1/gen1_layout.gd
+++ b/game/gen1/gen1_layout.gd
@@ -952,6 +952,7 @@ const TRADE_RECEIVE_NAME: int = 0xCD1E
 ## `BOULDER_MOVEMENT_BYTE_2`. A STAY sprite still turns, because `TryWalking`
 ## writes the facing before `CanWalkOntoTile` refuses its step.
 const OBJECT_MOVEMENT_STAY: int = 0xFF
+const OBJECT_MOVEMENT_NONE: int = 0xFF
 const OBJECT_STANDING_MOVEMENTS: Dictionary = {
 	0x10: Gen2WorldObject.MOVEMENT_STRENGTH_BOULDER,
 	0xD0: Gen2WorldObject.MOVEMENT_FIXED_DOWN,
@@ -1003,9 +1004,31 @@ const SCRIPT_HIGH_BIT: int = 7
 const SCRIPT_AND_N: int = 0xE6
 const SCRIPT_LD_C: int = 0x0E
 const SCRIPT_LD_B_A: int = 0x47
+const SCRIPT_LD_C_A: int = 0x4F
+const SCRIPT_LDH_A_MEM: int = 0xF0
+const SCRIPT_DEC_A: int = 0x3D
+const SCRIPT_INC_A: int = 0x3C
+## `ld [hli], a`, which is how `AgathaScriptWalkIntoRoom` writes its six steps.
+const SCRIPT_LD_HLI_A: int = 0x22
 const SCRIPT_COORD_SOURCES: Array[String] = ["player_y", "player_x"]
 ## `PAD_DOWN` down to `PAD_RIGHT`, bits 7 to 4, as `Gen2WorldAPI`'s directions.
 const PAD_DIRECTIONS: Dictionary = {0x80: 0, 0x40: 1, 0x20: 2, 0x10: 3}
+## `wSimulatedJoypadStatesEnd`'s buffer, one walking step an entry. The longest
+## the corpus writes is `WalkToLance_RLEList`'s 37.
+const SIMULATED_JOYPAD_MAX: int = 48
+## `DecodeRLEList`'s pairs of a byte and a repeat count, under a $FF.
+const RLE_PAIR_SIZE: int = 2
+const RLE_END: int = 0xFF
+## `NPC_MOVEMENT_DOWN` to `..._RIGHT`, $00 to $C0: the top two bits are already
+## the order [constant PAD_DIRECTIONS] counts in, and a low bit set is
+## `NPC_CHANGE_FACING`, whose facing is whatever `c` last held.
+const NPC_MOVEMENT_SHIFT: int = 6
+const NPC_MOVEMENT_LOW_BITS: int = 0x3F
+const NPC_MOVEMENT_END: int = 0xFF
+const NPC_MOVEMENT_MAX: int = 32
+## Below `wSpriteStateData1`: an address at or above it is WRAM, so a `de`
+## naming one is `FindPathToPlayer`'s answer rather than a list in the bank.
+const SCRIPT_WRAM_BASE: int = 0xC000
 const SCRIPT_PREFIX: int = 0xCB
 const SCRIPT_JR: int = 0x18
 const SCRIPT_JP: int = 0xC3
@@ -1042,6 +1065,9 @@ const MAP_LOAD_GATE_BRANCHES: Dictionary = {
 ## A `dbmapcoord` list: `db y, x` rows under a terminator.
 const MAP_COORD_END: int = 0xFF
 const MAP_COORD_SIZE: int = 2
+## The keys a decoded node keeps its branches under, and the only arrays a
+## walker may recurse into: `either`, `cells` and `moves` are values.
+const SCRIPT_BRANCH_KEYS: Array[String] = ["then", "else", "yes", "no", "ok", "full"]
 ## Each key is a conditional `jr` or `jp`, the value whether it is taken when
 ## the tested bit was set; the carry rows read the flag a routine answers in.
 const SCRIPT_BRANCHES: Dictionary = {0x20: true, 0xC2: true, 0x28: false, 0xCA: false}
@@ -1056,15 +1082,28 @@ const SCRIPT_CALLS: Array[String] = [
 	"call_function_in_table", "execute_map_script", "load_gym_names",
 	"delay_frames", "delay_3", "play_default_music", "check_map_trainers",
 	"player_coords_in_array", "start_trainer_battle", "end_trainer_battle",
+	"play_music", "stop_all_music",
+	"set_sprite_facing", "set_sprite_facing_delay", "sprite_stay", "move_sprite",
+	"decode_rle",
 ]
 ## Routines named by a full ROM offset, the same address in another bank being another routine.
-const SCRIPT_BANKED_CALLS: Array[String] = ["coin_box"]
+const SCRIPT_BANKED_CALLS: Array[String] = [
+	"coin_box", "music_rival_start", "music_rival_tempo",
+	"music_rival_start_tempo", "music_cities1_tempo",
+]
+## The four of those a `farcall` spends nothing on: no audio driver here.
+const SCRIPT_SILENT_BANKED_CALLS: Array[String] = [
+	"music_rival_start", "music_rival_tempo", "music_rival_start_tempo",
+	"music_cities1_tempo",
+]
 ## The routines that spend nothing here: no audio driver, a press already ends
 ## every box, and `wAutoTextBoxDrawingControl` has no counterpart.
 const SCRIPT_SILENT_CALLS: Array[String] = [
 	"play_cry", "wait_for_sound", "wait_for_button",
 	"auto_textbox_on", "auto_textbox_off", "count_set_bits", "update_sprites",
 	"play_sound", "play_sound_wait", "load_gym_names",
+	## Red and Blue spell `StopAllMusic` as `PlaySound`; only Yellow has a routine.
+	"play_music", "stop_all_music",
 	## A wait is frames of nothing and the map music is nobody's here. The three
 	## trainer rows every fighting map's own table opens with are the sight walk
 	## `Gen2WorldAPI.dispatch_sight_events` runs behind this script.
@@ -1086,6 +1125,8 @@ const SCRIPT_SILENT_STORES: Array[String] = [
 	## A forced walk writes the pad bit over the player's own facing byte, and
 	## the `walk` node behind it carries the direction anyway.
 	"facing_direction",
+	## `hJoyPressed` beside `hJoyHeld`, and the sound id no driver here reads.
+	"joy_pressed", "new_sound_id",
 ]
 ## `cp n` and the two conditional `ret`s behind it, whose value is the side
 ## taken when the comparison did not match.
@@ -1229,6 +1270,14 @@ const SCREEN_HEIGHT_TILES: int = 18
 const SCREEN_PLAYER_COLUMN: int = 8
 const SCREEN_PLAYER_ROW: int = 9
 
+## `wStatusFlags5`'s two scripted-movement bits: one stands while the walk a
+## `MoveSprite` started is drawn, the other while the player spends
+## `wSimulatedJoypadStatesIndex`, which a body may read instead.
+const SCRIPTED_NPC_MOVEMENT_BIT: int = 0
+const SCRIPTED_MOVEMENT_STATE_BIT: int = 7
+const MOVEMENT_TEST_OBJECT: String = "object"
+const MOVEMENT_TEST_PLAYER: String = "player"
+
 ## `SPRITE_FACING_*`, which `CheckIfCoordsInFrontOfPlayerMatch` steps by.
 const FACING_DOWN: int = 0x00
 const FACING_UP: int = 0x04
@@ -1238,6 +1287,12 @@ const FACING_STEPS: Dictionary = {
 	FACING_DOWN: Vector2i(0, 1), FACING_UP: Vector2i(0, -1),
 	FACING_LEFT: Vector2i(-1, 0), FACING_RIGHT: Vector2i(1, 0),
 }
+## `PLAYER_DIR_*` as `UpdatePlayerSprite` reads them, one `bit` per row in this
+## order, so a byte with two set takes the first and zero reaches `.notMoving`,
+## which leaves the facing byte alone.
+const PLAYER_DIR_FACINGS: Array = [
+	[0x04, FACING_DOWN], [0x08, FACING_UP], [0x02, FACING_LEFT], [0x01, FACING_RIGHT],
+]
 
 ## `warp_event`'s indoor exit: `wLastMap`, the outdoor map the player came from.
 const WARP_TO_LAST_MAP: int = 0xFF
@@ -1663,6 +1718,23 @@ const RED_BLUE: Dictionary = {
 	"start_simulating_joypad": 0x3486,
 	"simulated_joypad_index": 0xCD38,
 	"simulated_joypad_end": 0xCCD3,
+	## `hSpriteFacingDirection`, above `hSpriteIndex` at `hTextID`'s own byte.
+	"sprite_facing_hram": 0xFF8D,
+	"joy_pressed": 0xFFB3,
+	"new_sound_id": 0xC0EE,
+	"status_flags_5": 0xD730,
+	"player_moving_direction": 0xD528,
+	"play_music": 0x23A1,
+	## `Music_RivalAlternateStart` and the three beside it, in bank $02.
+	"music_rival_start": 0x9B47,
+	"music_rival_tempo": 0x9B65,
+	"music_rival_start_tempo": 0x9B75,
+	"music_cities1_tempo": 0x9B81,
+	"set_sprite_facing": 0x34AE,
+	"set_sprite_facing_delay": 0x34A6,
+	"sprite_stay": 0x3541,
+	"move_sprite": 0x363A,
+	"decode_rle": 0x350C,
 	"obtained_hidden_items": 0xD6F0,
 	"obtained_hidden_coins": 0xD6FE,
 	## `_IsTilePassable` and the lists it walks share a bank, and the pointer in
@@ -1895,6 +1967,22 @@ const YELLOW: Dictionary = {
 	"start_simulating_joypad": 0x3415,
 	"simulated_joypad_index": 0xCD38,
 	"simulated_joypad_end": 0xCCD3,
+	"sprite_facing_hram": 0xFF8D,
+	"joy_pressed": 0xFFB3,
+	"new_sound_id": 0xC0EE,
+	"status_flags_5": 0xD72F,
+	"player_moving_direction": 0xD527,
+	"play_music": 0x2211,
+	"stop_all_music": 0x2233,
+	"music_rival_start": 0x99BD,
+	"music_rival_tempo": 0x99DB,
+	"music_rival_start_tempo": 0x99E7,
+	"music_cities1_tempo": 0x99F4,
+	"set_sprite_facing": 0x3490,
+	"set_sprite_facing_delay": 0x3488,
+	"sprite_stay": 0x353E,
+	"move_sprite": 0x363D,
+	"decode_rle": 0x3509,
 	"obtained_hidden_items": 0xD6EF,
 	"obtained_hidden_coins": 0xD6FD,
 	"tileset_collision_bank": 0x01,
@@ -2150,6 +2238,26 @@ static func script_flag_alias(layout: Dictionary, address: int, bit: int) -> int
 	if address != int(layout.get("status_flags_6", -1)) or bit != ALWAYS_ON_BIKE_BIT:
 		return -1
 	return Gen2WorldState.ENGINE_ALWAYS_ON_BIKE
+
+
+## Whether a test is asking about a walk still being drawn, and whose: a
+## `jr nz` behind any of the three is the side that is still waiting.
+static func script_movement_test(layout: Dictionary, address: int, bit: int) -> String:
+	if address == int(layout["simulated_joypad_index"]) and bit < 0:
+		return MOVEMENT_TEST_PLAYER
+	if address != int(layout.get("status_flags_5", -1)):
+		return ""
+	if bit == SCRIPTED_NPC_MOVEMENT_BIT:
+		return MOVEMENT_TEST_OBJECT
+	return MOVEMENT_TEST_PLAYER if bit == SCRIPTED_MOVEMENT_STATE_BIT else ""
+
+
+## `wPlayerMovingDirection` as the facing it draws, or -1 for zero.
+static func player_dir_facing(direction: int) -> int:
+	for row: Array in PLAYER_DIR_FACINGS:
+		if direction & int(row[0]) != 0:
+			return int(row[1])
+	return -1
 
 
 ## Which map object's facing byte [param address] is, or -1. Slot 0 is the

--- a/game/gen1/gen1_world_importer.gd
+++ b/game/gen1/gen1_world_importer.gd
@@ -732,6 +732,10 @@ static func _read_map(
 	var states: Dictionary = _read_map_states(
 		rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
 	)
+	if _extend_texts(rom, layout, bank, rom.u16le(header + 5), texts, events, callback, states):
+		states = _read_map_states(
+			rom, layout, bank, rom.u16le(header + MAP_SCRIPT_AT), texts
+		)
 
 	return {
 		"ok": true,
@@ -845,9 +849,6 @@ static func _map_script_bodies(
 		)
 		if target < Gen1Layout.SCRIPT_LOWEST or target >= Gen1Layout.SCRIPT_CEILING:
 			break
-		if _script_routine(layout, target) in Gen1Layout.SCRIPT_SILENT_CALLS:
-			bodies.append([])
-			continue
 		bodies.append(_walk_script(
 			{
 				"rom": rom, "layout": layout, "bank": bank,
@@ -863,8 +864,8 @@ static func _map_script_dispatch(nodes: Array) -> Dictionary:
 	for node: Dictionary in nodes:
 		if String(node["op"]) == "map_script_table":
 			return node
-		for key: String in node:
-			if not node[key] is Array or key == "either":
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if not node.has(key):
 				continue
 			var found: Dictionary = _map_script_dispatch(node[key] as Array)
 			if not found.is_empty():
@@ -877,8 +878,8 @@ static func _map_script_successors(nodes: Array, byte: int) -> Array[int]:
 	for node: Dictionary in nodes:
 		if String(node["op"]) == "set_map_script" and int(node["byte"]) == byte:
 			out.append(int(node["value"]))
-		for key: String in node:
-			if node[key] is Array and key != "either":
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key):
 				out.append_array(_map_script_successors(node[key] as Array, byte))
 	return out
 
@@ -1652,6 +1653,9 @@ const SCRIPT_TESTS_COORD: int = -11
 ## `ArePlayerCoordsInArray`, whose carry is the player standing on one row of a
 ## `db y, x` list.
 const SCRIPT_TESTS_COORD_ARRAY: int = -12
+## `wStatusFlags5`'s own two bits, and `wCoordIndex`, the row that list matched.
+const SCRIPT_TESTS_MOVEMENT: int = -13
+const SCRIPT_TESTS_COORD_INDEX: int = -14
 ## What `push af` saves and `pop af` puts back, which is how
 ## `CheckEventAfterBranchReuseA` still reads the event byte a block write
 ## clobbered.
@@ -1659,12 +1663,15 @@ const SCRIPT_AF_KEYS: Array[String] = [
 	"a", "source", "rotated", "tests", "tests_in_carry", "tests_engine",
 	"tests_and_a",
 ]
-## The four stores a row is read for that are `a` under another name: the box
+## The stores a row is read for that are `a` under another name: the box
 ## `DisplayTextBoxID` will draw, the row `DisplayTextID` will print, the object
-## a predef will toggle and the block `ReplaceTileBlock` will write.
+## a predef will toggle, the block `ReplaceTileBlock` will write and the facing
+## `SetSpriteFacingDirection` will hand its sprite. `hSpriteIndex` shares
+## `hTextID`'s byte, so the routine behind a store says which was meant.
 const SCRIPT_STORED_REGISTERS: Dictionary = {
 	"text_box_id": "text_box", "text_id_hram": "map_text",
 	"toggleable_index": "toggle", "new_tile_block": "new_block",
+	"sprite_facing_hram": "sprite_facing",
 }
 
 
@@ -1693,6 +1700,11 @@ static func _walk_script(
 ) -> Variant:
 	if depth > SCRIPT_DEPTH:
 		return null
+	## A `jp nc, CheckFightingMapTrainers` lands here rather than on a call, and
+	## a `<Map>_ScriptPointers` row may stand at a routine outright, so a routine
+	## that spends nothing is answered before its machine code is walked at all.
+	if _script_routine(ctx["layout"], pc) in Gen1Layout.SCRIPT_SILENT_CALLS:
+		return []
 	var out: Array = []
 	var budget: Array = ctx["budget"]
 	while budget[0] > 0:
@@ -1746,10 +1758,10 @@ static func _script_step(
 		Gen1Layout.SCRIPT_LD_C:
 			state["c"] = rom.u8(at + 1)
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
-		Gen1Layout.SCRIPT_LD_B_A:
+		Gen1Layout.SCRIPT_LD_B_A, Gen1Layout.SCRIPT_LD_C_A:
 			if not state.has("a"):
 				return SCRIPT_UNREAD
-			state["b"] = int(state["a"])
+			state["b" if rom.u8(at) == Gen1Layout.SCRIPT_LD_B_A else "c"] = int(state["a"])
 			return pc + 1
 		Gen1Layout.SCRIPT_LD_A:
 			_script_wrote_a(state)
@@ -1761,6 +1773,15 @@ static func _script_step(
 			_script_wrote_a(state)
 			state["a"] = 0
 			state.erase("tests")
+			return pc + 1
+		Gen1Layout.SCRIPT_DEC_A, Gen1Layout.SCRIPT_INC_A:
+			## `dec a` is what takes `DecodeRLEList`'s own sentinel back off its
+			## count, and `inc a` how a row spells PLAYER_DIR_RIGHT over `xor a`.
+			if not state.has("a"):
+				return SCRIPT_UNREAD
+			var step: int = 1 if rom.u8(at) == Gen1Layout.SCRIPT_INC_A else -1
+			_script_wrote_a(state)
+			state["a"] = int(state["a"]) + step
 			return pc + 1
 	return _script_flow(ctx, pc, at, state, out, depth)
 
@@ -1774,6 +1795,9 @@ static func _script_flow(
 		Gen1Layout.SCRIPT_LD_A_MEM:
 			_script_loaded(ctx, rom.u16le(at + 1), state)
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE
+		Gen1Layout.SCRIPT_LDH_A_MEM:
+			_script_loaded(ctx, Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(at + 1), state)
+			return pc + Gen1Layout.SCRIPT_SHORT_SIZE
 		Gen1Layout.SCRIPT_LD_MEM_A:
 			return pc + Gen1Layout.SCRIPT_LONG_SIZE \
 				if _script_stored(ctx, rom.u16le(at + 1), state, out) else SCRIPT_UNREAD
@@ -1781,6 +1805,8 @@ static func _script_flow(
 			return pc + Gen1Layout.SCRIPT_SHORT_SIZE if _script_stored(
 				ctx, Gen1Layout.SCRIPT_HRAM_BASE + rom.u8(at + 1), state, out
 			) else SCRIPT_UNREAD
+		Gen1Layout.SCRIPT_LD_HLI_A:
+			return _script_stored_hli(ctx, pc, state, out)
 		Gen1Layout.SCRIPT_AND_A:
 			_script_test_bit(ctx, state, -1)
 			state["tests_and_a"] = true
@@ -1974,7 +2000,7 @@ static func _script_stored(
 		state["no_press"] = true
 		return true
 	for name: String in SCRIPT_STORED_REGISTERS:
-		if address != int(layout[name]):
+		if address != int(layout.get(name, -1)):
 			continue
 		if not state.has("a"):
 			return false
@@ -1985,8 +2011,10 @@ static func _script_stored(
 	## it runs and `wUpdateSpritesEnabled` gates a redraw. Nothing here reads any
 	## of the four.
 	for silent: String in Gen1Layout.SCRIPT_SILENT_STORES:
-		if address == int(layout[silent]):
+		if address == int(layout.get(silent, -1)):
 			return true
+	if address == int(layout.get("player_moving_direction", -1)):
+		return _script_player_facing(state, out)
 	var slot: int = Gen1Layout.sprite_facing_slot(layout, address)
 	if slot >= 0:
 		if not Gen1Layout.FACING_STEPS.has(int(state.get("a", -1))):
@@ -2003,6 +2031,20 @@ static func _script_stored(
 	return true
 
 
+## `wPlayerMovingDirection`, which the comment beside it says a map script
+## writes to turn the player.
+static func _script_player_facing(state: Dictionary, out: Array) -> bool:
+	if not state.has("a"):
+		return false
+	var facing: int = Gen1Layout.player_dir_facing(int(state["a"]))
+	if facing >= 0:
+		out.append({"op": "player_facing", "facing": facing})
+	return true
+
+
+## `wSimulatedJoypadStatesIndex` is how many entries are left to spend and
+## `wSimulatedJoypadStatesEnd` the buffer, which Yellow's Oak's Lab writes two
+## bytes of by hand.
 static func _script_joypad_stored(
 	layout: Dictionary, address: int, state: Dictionary
 ) -> bool:
@@ -2011,10 +2053,30 @@ static func _script_joypad_stored(
 	if address == int(layout["simulated_joypad_index"]):
 		state["walk_steps"] = int(state["a"])
 		return true
-	if address != int(layout["simulated_joypad_end"]):
+	var offset: int = address - int(layout["simulated_joypad_end"])
+	if offset < 0 or offset > Gen1Layout.SIMULATED_JOYPAD_MAX:
 		return false
-	state["walk_pad"] = int(state["a"])
+	_script_joypad_wrote(state, offset, int(state["a"]))
 	return true
+
+
+static func _script_joypad_wrote(state: Dictionary, offset: int, pad: int) -> void:
+	var buffer: Array = state.get("walk_buffer", [])
+	while buffer.size() <= offset:
+		buffer.append(0)
+	buffer[offset] = pad
+	state["walk_buffer"] = buffer
+
+
+## `ld [hli], a`, which only the joypad buffer is written through here.
+static func _script_stored_hli(
+	ctx: Dictionary, pc: int, state: Dictionary, out: Array
+) -> int:
+	var address: int = int(state.get("hl", -1))
+	if address < 0 or not _script_stored(ctx, address, state, out):
+		return SCRIPT_UNREAD
+	state["hl"] = address + 1
+	return pc + 1
 
 
 ## What the flags hold, as the index and whether it is one of Generation 1's own
@@ -2025,6 +2087,10 @@ static func _script_tests(ctx: Dictionary, state: Dictionary, bit: int) -> Array
 	var source: int = int(state.get("source", -1))
 	if source == int(layout["current_menu_item"]):
 		return [SCRIPT_TESTS_CHOICE, false]
+	var movement: String = Gen1Layout.script_movement_test(layout, source, bit)
+	if not movement.is_empty():
+		state["movement_who"] = movement
+		return [SCRIPT_TESTS_MOVEMENT, false]
 	if bit >= 0:
 		var flag: int = _script_flag(ctx, source, bit)
 		if flag >= 0:
@@ -2176,6 +2242,24 @@ static func _script_called(
 			return _script_map_script_table(ctx, state, out, int(state.get("hl", -1)))
 		"execute_map_script":
 			return _script_map_script_table(ctx, state, out, int(state.get("de", -1)))
+	return _script_sprite_called(ctx, routine, target, state, out, next, depth)
+
+
+## The four routines a script moves an object with, and the buffer the fifth
+## fills for the player. The `...AndDelay` row is six frames of nothing more.
+static func _script_sprite_called(
+	ctx: Dictionary, routine: String, target: int, state: Dictionary, out: Array,
+	next: int, depth: int
+) -> int:
+	match routine:
+		"set_sprite_facing", "set_sprite_facing_delay":
+			return _script_object_facing(state, out, next)
+		"sprite_stay":
+			return _script_object_stay(state, out, next)
+		"move_sprite":
+			return _script_object_move(ctx, state, out, next)
+		"decode_rle":
+			return _script_decode_rle(ctx, state, next)
 	var bank: int = int(ctx["bank"])
 	if _script_banked_routine(ctx["layout"], bank, target) == "coin_box":
 		out.append({"op": "coin_box"})
@@ -2183,19 +2267,114 @@ static func _script_called(
 	return _script_routine_call(ctx, bank, target, state, out, next, depth)
 
 
+## `hSpriteIndex` counts the player as slot 0, so an object is one below it.
+static func _script_sprite_object(state: Dictionary) -> int:
+	return int(state.get("map_text", 0)) - 1 if state.has("map_text") else -1
+
+
+static func _script_object_facing(state: Dictionary, out: Array, next: int) -> int:
+	var object: int = _script_sprite_object(state)
+	var facing: int = int(state.get("sprite_facing", -1))
+	if object < 0 or not Gen1Layout.FACING_STEPS.has(facing):
+		return SCRIPT_UNREAD
+	out.append({"op": "object_facing", "object": object, "facing": facing})
+	return next
+
+
+## `SetSpriteMovementBytesToFF` puts STAY over the map's own template: the
+## object stops walking and turns where it stands.
+static func _script_object_stay(state: Dictionary, out: Array, next: int) -> int:
+	var object: int = _script_sprite_object(state)
+	if object < 0:
+		return SCRIPT_UNREAD
+	out.append({"op": "object_stay", "object": object})
+	return next
+
+
+static func _script_object_move(
+	ctx: Dictionary, state: Dictionary, out: Array, next: int
+) -> int:
+	var object: int = _script_sprite_object(state)
+	var moves: Array = _script_movement_list(ctx, int(state.get("de", -1)))
+	if object < 0 or moves.is_empty():
+		return SCRIPT_UNREAD
+	out.append({"op": "object_move", "object": object, "moves": moves})
+	return next
+
+
+## `MoveSprite`'s own list, `NPC_MOVEMENT_*` bytes under a $FF. A `de` naming
+## WRAM is `FindPathToPlayer`'s answer, which nothing here computes.
+static func _script_movement_list(ctx: Dictionary, address: int) -> Array:
+	if address < 0 or address >= Gen1Layout.SCRIPT_WRAM_BASE:
+		return []
+	var rom: RomFile = ctx["rom"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), address)
+	var moves: Array = []
+	while rom.in_bounds(at, 1) and moves.size() < Gen1Layout.NPC_MOVEMENT_MAX:
+		var byte: int = rom.u8(at)
+		if byte == Gen1Layout.NPC_MOVEMENT_END:
+			return moves
+		if byte & Gen1Layout.NPC_MOVEMENT_LOW_BITS != 0:
+			return []
+		moves.append(byte >> Gen1Layout.NPC_MOVEMENT_SHIFT)
+		at += 1
+	return []
+
+
+## `DecodeRLEList` into `wSimulatedJoypadStatesEnd`, repeats unrolled.
+static func _script_decode_rle(ctx: Dictionary, state: Dictionary, next: int) -> int:
+	var layout: Dictionary = ctx["layout"]
+	var address: int = int(state.get("de", -1))
+	if int(state.get("hl", -1)) != int(layout.get("simulated_joypad_end", -1)) \
+		or address < 0 or address >= Gen1Layout.SCRIPT_WRAM_BASE:
+		return SCRIPT_UNREAD
+	var rom: RomFile = ctx["rom"]
+	var at: int = Gen1Layout.banked(int(ctx["bank"]), address)
+	var buffer: Array = []
+	while rom.in_bounds(at, Gen1Layout.RLE_PAIR_SIZE) \
+		and buffer.size() <= Gen1Layout.SIMULATED_JOYPAD_MAX:
+		var pad: int = rom.u8(at)
+		if pad == Gen1Layout.RLE_END:
+			state["walk_buffer"] = buffer
+			_script_wrote_a(state)
+			state["a"] = buffer.size() + 1
+			return next
+		for _repeat: int in rom.u8(at + 1):
+			buffer.append(pad)
+		at += Gen1Layout.RLE_PAIR_SIZE
+	return SCRIPT_UNREAD
+
+
 ## `StartSimulatingJoypadStates`, whose buffer is one walking step per entry.
 static func _script_walk(state: Dictionary, out: Array, next: int) -> int:
-	var pad: int = int(state.get("walk_pad", 0))
-	if not Gen1Layout.PAD_DIRECTIONS.has(pad) or int(state.get("walk_steps", 0)) < 1:
+	var moves: Array = _script_walk_moves(state)
+	if moves.is_empty():
 		return SCRIPT_UNREAD
-	out.append({
-		"op": "walk",
-		"direction": int(Gen1Layout.PAD_DIRECTIONS[pad]),
-		"steps": int(state["walk_steps"]),
-	})
-	state.erase("walk_pad")
+	out.append({"op": "walk", "moves": moves})
+	state.erase("walk_buffer")
 	state.erase("walk_steps")
 	return next
+
+
+## `GetSimulatedInput` counts the index down before it reads the buffer at what
+## is left, so the entries are spent back to front; a run of one pad is a leg.
+static func _script_walk_moves(state: Dictionary) -> Array:
+	var buffer: Array = state.get("walk_buffer", [])
+	var count: int = int(state.get("walk_steps", 0))
+	if count < 1 or count > buffer.size():
+		return []
+	var moves: Array = []
+	for index: int in count:
+		var pad: int = int(buffer[count - 1 - index])
+		if not Gen1Layout.PAD_DIRECTIONS.has(pad):
+			return []
+		var direction: int = int(Gen1Layout.PAD_DIRECTIONS[pad])
+		var leg: Dictionary = moves[-1] if not moves.is_empty() else {}
+		if int(leg.get("direction", -1)) == direction:
+			leg["steps"] = int(leg["steps"]) + 1
+			continue
+		moves.append({"direction": direction, "steps": 1})
+	return moves
 
 
 ## `ArePlayerCoordsInArray`: the `db y, x` list `hl` names, terminated by $FF,
@@ -2211,6 +2390,7 @@ static func _script_coord_array(ctx: Dictionary, state: Dictionary, next: int) -
 	if cells.is_empty():
 		return SCRIPT_UNREAD
 	state["cells"] = cells
+	state["coord_array"] = true
 	_script_tested(state, SCRIPT_TESTS_COORD_ARRAY, true)
 	return next
 
@@ -2242,6 +2422,9 @@ static func _script_routine_call(
 	ctx: Dictionary, bank: int, target: int, state: Dictionary, out: Array,
 	next: int, depth: int
 ) -> int:
+	if _script_banked_routine(ctx["layout"], bank, target) \
+		in Gen1Layout.SCRIPT_SILENT_BANKED_CALLS:
+		return next
 	var nesting: Array = ctx["calls"]
 	if nesting[0] >= Gen1Layout.SCRIPT_CALL_DEPTH or bank < 0 or target < 0:
 		return SCRIPT_UNREAD
@@ -2653,6 +2836,10 @@ static func _script_compared(
 		state["coord"] = value
 		_script_tested(state, SCRIPT_TESTS_COORD)
 		return next
+	if source == int(layout["which_trade"]) and state.has("coord_array"):
+		state["coord_index"] = value
+		_script_tested(state, SCRIPT_TESTS_COORD_INDEX, true)
+		return next
 	if source != int(layout["num_set_bits"]):
 		return SCRIPT_UNREAD
 	state["dex_count"] = value
@@ -2778,6 +2965,14 @@ static func _script_node(
 		SCRIPT_TESTS_COORD_ARRAY:
 			return {"op": "player_in_array", "cells": state["cells"],
 				"then": taken, "else": fell}
+		SCRIPT_TESTS_MOVEMENT:
+			return {"op": "movement_running", "who": String(state["movement_who"]),
+				"then": taken, "else": fell}
+		SCRIPT_TESTS_COORD_INDEX:
+			## Carry is set below the row number, so the taken side is the
+			## earlier row of the list the player was found on.
+			return {"op": "coord_index", "below": int(state["coord_index"]),
+				"then": taken, "else": fell}
 	var branch: Dictionary = {
 		"op": "branch", "flag": int(tests), "then": taken, "else": fell,
 	}
@@ -2840,6 +3035,42 @@ static func _read_mart_items(rom: RomFile, at: int) -> Array:
 			return []
 		out.append(item)
 	return out
+
+
+## A row only a map script reaches stands above every id the map's events name,
+## and those are what bound the table: Mt. Moon B2F's tenth row is the super
+## nerd's line. True when the table grew and the states want reading again.
+static func _extend_texts(
+	rom: RomFile, layout: Dictionary, bank: int, address: int, texts: Array,
+	events: Dictionary, callback: Dictionary, states: Dictionary
+) -> bool:
+	var scripts: Array = [states["entry"], callback.get("nodes", [])]
+	for row: Dictionary in (states["states"] as Array) + texts:
+		scripts.append(row.get("script", row.get("nodes", [])))
+	for row: Dictionary in events.get("hidden_events", []) as Array:
+		scripts.append(row.get("script", []))
+	var highest: int = 0
+	for nodes: Array in scripts:
+		highest = maxi(highest, _highest_map_text(nodes))
+	if highest <= texts.size():
+		return false
+	var table: int = Gen1Layout.banked(bank, address)
+	while texts.size() < highest:
+		texts.append(_read_text(
+			rom, layout, bank, rom.u16le(table + texts.size() * Gen1Layout.POINTER_SIZE)
+		))
+	return true
+
+
+static func _highest_map_text(nodes: Array) -> int:
+	var highest: int = 0
+	for node: Dictionary in nodes:
+		if String(node["op"]) == "map_text":
+			highest = maxi(highest, int(node["text"]))
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key):
+				highest = maxi(highest, _highest_map_text(node[key] as Array))
+	return highest
 
 
 static func _highest_text_id(events: Dictionary) -> int:

--- a/game/world/world_api.gd
+++ b/game/world/world_api.gd
@@ -3891,6 +3891,11 @@ const GEN1_SCRIPT_NODES: Dictionary = {
 	"set_map_script": &"_gen1_node_set_map_script",
 	"player_in_array": &"_gen1_node_player_in_array",
 	"object_facing": &"_gen1_node_object_facing",
+	"object_move": &"_gen1_node_object_move",
+	"object_stay": &"_gen1_node_object_stay",
+	"movement_running": &"_gen1_node_movement_running",
+	"coord_index": &"_gen1_node_coord_index",
+	"player_facing": &"_gen1_node_player_facing",
 	"map_script_table": &"_gen1_node_map_script_table",
 }
 
@@ -4212,8 +4217,13 @@ func _gen1_node_player_in_array(
 	node: Dictionary, steps: Array, run: Dictionary
 ) -> bool:
 	var standing: bool = false
-	for cell: Dictionary in node["cells"] as Array:
+	var cells: Array = node["cells"]
+	for index: int in cells.size():
+		var cell: Dictionary = cells[index]
 		if player_cell == Vector2i(int(cell["x"]), int(cell["y"])):
+			## `CheckCoords` counts the row up before it compares, so the index
+			## a body reads back starts at one.
+			run["coord_index"] = index + 1
 			standing = true
 			break
 	return _gen1_resolve_side(node, standing, steps, run)
@@ -4255,8 +4265,46 @@ func _gen1_node_map_script_table(
 
 
 func _gen1_node_walk(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"walk", "moves": (node["moves"] as Array).duplicate(true)})
+	return true
+
+
+## `MoveSprite` returns as soon as it has copied the list, so its steps are
+## drawn behind the script rather than in front of it.
+func _gen1_node_object_move(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
 	steps.append({
-		"type": &"walk", "direction": int(node["direction"]), "steps": int(node["steps"]),
+		"type": &"object_move", "index": int(node["object"]),
+		"moves": (node["moves"] as Array).duplicate(),
+	})
+	return true
+
+
+func _gen1_node_object_stay(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({"type": &"object_stay", "index": int(node["object"])})
+	return true
+
+
+## The bits a state reads to hold still while the walk before it is drawn.
+func _gen1_node_movement_running(
+	node: Dictionary, steps: Array, run: Dictionary
+) -> bool:
+	var running: bool = gen1_object_movement_running() \
+		if String(node["who"]) == Gen1Layout.MOVEMENT_TEST_OBJECT \
+		else gen1_player_movement_running()
+	return _gen1_resolve_side(node, running, steps, run)
+
+
+## `wCoordIndex`, the row `ArePlayerCoordsInArray` matched on, counted from 1.
+func _gen1_node_coord_index(node: Dictionary, steps: Array, run: Dictionary) -> bool:
+	return _gen1_resolve_side(
+		node, int(run.get("coord_index", 0)) < int(node["below"]), steps, run
+	)
+
+
+func _gen1_node_player_facing(node: Dictionary, steps: Array, _run: Dictionary) -> bool:
+	steps.append({
+		"type": &"player_facing",
+		"facing": facing_for_direction(Gen1Layout.FACING_STEPS[int(node["facing"])]),
 	})
 	return true
 
@@ -5208,16 +5256,31 @@ func _gen1_written(step: Dictionary, events: Array) -> bool:
 		&"map_script":
 			state.set_gen1_map_script(int(step["byte"]), int(step["value"]))
 			return true
+		&"npc_trade":
+			state.apply_changes({}, {}, {"npc_trades": {int(step["trade_id"]): true}})
+			return true
+	return _gen1_drawn(step, events)
+
+
+## The rest of [method _gen1_written]: what a row moves or redraws.
+func _gen1_drawn(step: Dictionary, events: Array) -> bool:
+	match StringName(step["type"]):
 		&"object_facing":
 			_turn_gen1_object(int(step["index"]), int(step["facing"]), events)
 			return true
 		&"walk":
-			events.append_array(_gen1_walk_player(
-				_movement_direction(int(step["direction"])), int(step["steps"])
+			events.append_array(_gen1_walk_player(step["moves"] as Array))
+			return true
+		&"object_move":
+			events.append_array(_gen1_walk_object(
+				int(step["index"]), step["moves"] as Array
 			))
 			return true
-		&"npc_trade":
-			state.apply_changes({}, {}, {"npc_trades": {int(step["trade_id"]): true}})
+		&"object_stay":
+			_gen1_stand_object(int(step["index"]))
+			return true
+		&"player_facing":
+			player_facing = int(step["facing"])
 			return true
 		&"block":
 			## `PrintCardKeyText` writes `wCardKeyDoorY` and its neighbour behind
@@ -5279,25 +5342,73 @@ func _gen1_battle_won(step: Dictionary, result: Dictionary) -> void:
 	load_object_masks()
 
 
-## `ShowObject` and `HideObject`: one `wToggleableObjectFlags` bit by global
-## index, and `UpdateSprites` behind it.
 ## `CollisionCheckOnLand` skips every test while `wSimulatedJoypadStatesIndex`
 ## stands, so only the map bounds refuse. The row ends before the walk is drawn.
-func _gen1_walk_player(direction: Vector2i, steps: int) -> Array:
+func _gen1_walk_player(moves: Array) -> Array:
 	var generated: Array = []
-	for _step: int in steps:
-		var destination: Vector2i = player_cell + direction
-		if not _cell_in_bounds(destination):
-			_queue_player_step(Vector2i.ZERO, 0, false, direction, STEP_KIND_WALK)
-			generated.append({
-				"type": &"movement_blocked", "player": true, "cell": destination,
-			})
-			break
-		player_cell = destination
-		_queue_player_step(direction, STEP_PASSES_WALK, false, direction, STEP_KIND_WALK)
+	for leg: Dictionary in moves:
+		var direction: Vector2i = _movement_direction(int(leg["direction"]))
+		for _step: int in int(leg["steps"]):
+			var destination: Vector2i = player_cell + direction
+			if not _cell_in_bounds(destination):
+				_queue_player_step(Vector2i.ZERO, 0, false, direction, STEP_KIND_WALK)
+				generated.append({
+					"type": &"movement_blocked", "player": true, "cell": destination,
+				})
+				return generated
+			player_cell = destination
+			_queue_player_step(
+				direction, STEP_PASSES_WALK, false, direction, STEP_KIND_WALK
+			)
 	return generated
 
 
+## `MoveSprite`, whose whole list is queued here and drawn a step at a time by
+## [method advance_scripted_steps_pass]. `CanWalkOntoTile` allows a scripted step
+## outright, so only the map bounds refuse one, and `.reachedEnd` puts STAY back
+## over the movement byte the map gave the object.
+func _gen1_walk_object(index: int, moves: Array) -> Array:
+	var generated: Array = []
+	if current_map == null or index < 0 or index >= objects.size():
+		return generated
+	var object: Gen2WorldObject = objects[index]
+	_gen1_stand_object(index)
+	var facing: int = object.facing
+	for row: int in moves:
+		var direction: Vector2i = _movement_direction(row)
+		facing = facing_for_direction(direction)
+		var destination: Vector2i = object.cell + direction
+		if not _cell_in_bounds(destination):
+			## `NormalStep` writes the facing before `GetNextTile` refuses, so a
+			## step off the map turns the object where it stands.
+			object.queue_step(Vector2i.ZERO, 0, false, direction)
+			generated.append({
+				"type": &"movement_blocked", "object_index": index, "cell": destination,
+			})
+			continue
+		var vacated: Vector2i = object.cell
+		object.cell = destination
+		object.queue_step(direction, STEP_PASSES_WALK, false, direction, STEP_KIND_WALK)
+		_advance_followers(index, vacated)
+	var key: String = _object_key(current_map.group, current_map.number, index)
+	_object_position_overrides[key] = object.cell
+	_object_facing_overrides[key] = facing
+	return generated
+
+
+## `SetSpriteMovementBytesToFF`: STAY over movement byte 1 and NONE over byte 2,
+## which is the template a script stops a wanderer with. The write is WRAM the
+## next map load fills from `wMapSpriteData`, so nothing is recorded for it.
+func _gen1_stand_object(index: int) -> void:
+	if index < 0 or index >= objects.size():
+		return
+	(objects[index] as Gen2WorldObject).movement = Gen1Layout.object_movement(
+		Gen1Layout.OBJECT_MOVEMENT_STAY, Gen1Layout.OBJECT_MOVEMENT_NONE
+	)
+
+
+## `ShowObject` and `HideObject`: one `wToggleableObjectFlags` bit by global
+## index, and `UpdateSprites` behind it.
 func gen1_toggle_object(index: int, hidden: bool) -> void:
 	if index < 0 or state == null or data == null:
 		return
@@ -7064,17 +7175,17 @@ func try_warp(cell: Vector2i = player_cell) -> Dictionary:
 	# `wPrevWarp` is the warp walked through, which is what a Dig or an Escape
 	# Rope comes back out of. `WarpToNewMapScript`, the pitfall and the magnet
 	# train name DOOR, FALL and TRAIN, which are one setup-script body.
-	_apply_map(
-		target_map, target_tileset, _warp_landing_cell(target_map, target_warp, cell),
-		false, warp_index_at(cell), MAP_ENTRY_DOOR
-	)
+	var landing: Vector2i = _warp_landing_cell(target_map, target_warp, cell)
+	_apply_map(target_map, target_tileset, landing, false, warp_index_at(cell), MAP_ENTRY_DOOR)
 	return {
 		"ok": true,
 		"kind": &"warp",
 		"from_map": from_map,
 		"from_cell": from_cell,
 		"to_map": map_id(),
-		"to_cell": player_cell,
+		## Where the warp put the player, which the map's own entry script may
+		## already have walked away from: `HallOfFameDefaultScript` walks five.
+		"to_cell": landing,
 		"source": source_warp,
 		"destination": target_warp,
 	}
@@ -7564,8 +7675,24 @@ func script_wait_remaining() -> int:
 ## wStateFlags' SCRIPTED_MOVEMENT_STATE_F: one flag for all of them, cleared by
 ## whichever stream reaches its own `step_end`.
 func scripted_movement_in_progress() -> bool:
-	if _player_scripted_steps and player_step_in_progress():
-		return true
+	return gen1_player_movement_running() or gen1_object_movement_running()
+
+
+## Whether this world is a Generation 1 one, which is what says the map has a
+## per-frame script of its own to run.
+func is_gen1() -> bool:
+	return _gen1
+
+
+## `wSimulatedJoypadStatesIndex`, and BIT_SCRIPTED_MOVEMENT_STATE beside it: the
+## player is still spending the buttons a `walk` queued.
+func gen1_player_movement_running() -> bool:
+	return _player_scripted_steps and player_step_in_progress()
+
+
+## BIT_SCRIPTED_NPC_MOVEMENT, which `MoveSprite` sets and the last step of the
+## list clears.
+func gen1_object_movement_running() -> bool:
 	for object: Gen2WorldObject in objects:
 		if object.scripted_steps and not object.deleted:
 			return true

--- a/game/world/world_screen.gd
+++ b/game/world/world_screen.gd
@@ -329,6 +329,9 @@ var _start_menu_cursor: int = 0
 ## Pokegear reached by a script or by the debug key still returns to the world.
 var _reopen_start_menu: bool = false
 var _trainer_approach: Dictionary = {}
+## Whether a scripted walk was still being drawn last frame, which is the edge
+## [method _run_settled_gen1_map_script] runs the map's own script on.
+var _gen1_movement_drawn: bool = false
 var _active_battle_save: Gen2SaveData = null
 ## `wBattleScriptFlags` bit 7, which `Script_loadtrainer` sets and
 ## `Script_reloadmapafterbattle` reads: a trainer fight is the branch
@@ -1093,6 +1096,7 @@ func _advance_waits(map_pass: bool) -> void:
 		var wait_results: Array = _world.advance_script_wait_frame()
 		if not wait_results.is_empty():
 			_show_script_results(wait_results)
+	_run_settled_gen1_map_script()
 	_advance_sound_schedule()
 	## `_ContText`'s scroll ends on a frame rather than on a press, and the page
 	## it lands on may be the text's last, which is where the script runs on.
@@ -1106,6 +1110,24 @@ func _advance_waits(map_pass: bool) -> void:
 			_show_script_results(ring_results)
 		_refresh_labels()
 	_advance_audio_wait()
+
+
+## `RunMapScript` runs on every frame `JoypadOverworld` reads, so a state that
+## opens `ret nz` on a walk still being drawn gets its turn the frame the walk
+## ends. An ordinary step reaches the map script through
+## [method _after_map_settled]; a scripted walk has no step behind it, so this
+## is the frame it lands on.
+func _run_settled_gen1_map_script() -> void:
+	if _world == null or not _world.is_gen1():
+		return
+	var running: bool = _world.scripted_movement_in_progress()
+	var settled: bool = _gen1_movement_drawn and not running
+	_gen1_movement_drawn = running
+	if not settled or _world.script_busy() or not _map_fade.is_empty():
+		return
+	var results: Array = _world.dispatch_sight_events()
+	if not results.is_empty():
+		_show_script_results(results)
 
 
 ## The one wait whose condition is the audio device's rather than a counter's,

--- a/tests/unit/test_gen1_script.gd
+++ b/tests/unit/test_gen1_script.gd
@@ -84,6 +84,17 @@ const LAYOUT: Dictionary = {
 	"obtained_badges": 0xD356,
 	"sprite_state_data": 0xC100,
 	"status_flags_6": 0xD732,
+	"status_flags_5": 0xD730,
+	"sprite_facing_hram": 0xFF8D,
+	"player_moving_direction": 0xD528,
+	"joy_pressed": 0xFFB3,
+	"new_sound_id": 0xC0EE,
+	"set_sprite_facing": 0x03D0,
+	"set_sprite_facing_delay": 0x03E0,
+	"sprite_stay": 0x03F0,
+	"move_sprite": 0x0410,
+	"decode_rle": 0x0420,
+	"play_music": 0x0430,
 }
 ## `PredefPointers`' rows, by the id `predef` leaves in a.
 const PREDEFS: Dictionary = {
@@ -94,6 +105,8 @@ const AT: int = 0x1000
 const HELLO: int = 0x1800
 const BYE: int = 0x1810
 const UNREAD_CALL: int = 0x0200
+## Where a `MoveSprite` list and a `DecodeRLEList` one are laid down.
+const MOVEMENT_LIST: int = 0x1900
 ## `call z, nn`, one of [constant Gen1Layout.SCRIPT_CONDITIONAL_CALLS]' four.
 const CALL_Z: int = 0xCC
 ## A `<Map>_ScriptPointers` table, the `w<Map>CurScript` byte it dispatches on
@@ -106,6 +119,7 @@ const COORDS: int = 0x1930
 ## `ret nc`, which a coordinate list is refused with, and `call nz`, which a map
 ## load gate calls its own body through.
 const RET_NC: int = 0xD0
+const RET_NZ: int = 0xC0
 const CALL_NZ: int = 0xC4
 
 
@@ -147,8 +161,10 @@ func _print(address: int) -> Array:
 	return _load_hl(address) + _call(int(LAYOUT["print_text"]))
 
 
-func _decode(program: Array, strings: Dictionary = {}) -> Array:
-	return Gen1WorldImporter.decode_script(_rom(program, strings), LAYOUT, 0, AT)
+func _decode(
+	program: Array, strings: Dictionary = {}, raw: Dictionary = {}
+) -> Array:
+	return Gen1WorldImporter.decode_script(_rom(program, strings, raw), LAYOUT, 0, AT)
 
 
 func _load_a(address: int) -> Array:
@@ -157,6 +173,13 @@ func _load_a(address: int) -> Array:
 
 func _store_a(address: int) -> Array:
 	return [Gen1Layout.SCRIPT_LD_MEM_A, address & 0xFF, address >> 8]
+
+
+## `ld a, n` / `ldh [n], a`, which is how a row names a sprite and its facing.
+func _store_hram(address: int, value: int) -> Array:
+	return [
+		Gen1Layout.SCRIPT_LD_A, value, Gen1Layout.SCRIPT_LDH_MEM_A, address & 0xFF,
+	]
 
 
 ## `ld hl, <table>` / `ld a, [w<Map>CurScript]` / `jp CallFunctionInTable`.
@@ -229,6 +252,87 @@ func test_a_store_to_a_sprite_facing_byte_turns_that_object() -> void:
 	assert_eq(script, [
 		{"op": "object_facing", "object": 1, "facing": Gen1Layout.FACING_LEFT},
 	])
+
+
+## `hSpriteIndex` shares `hTextID`'s byte, so the routine behind the store is
+## what says an object was meant rather than a text row.
+func test_the_facing_routine_turns_the_sprite_its_hram_byte_names() -> void:
+	var script: Array = _decode(
+		_store_hram(int(LAYOUT["text_id_hram"]), 2)
+			+ _store_hram(int(LAYOUT["sprite_facing_hram"]), Gen1Layout.FACING_LEFT)
+			+ [Gen1Layout.SCRIPT_CALL, 0xE0, 0x03, Gen1Layout.SCRIPT_RET]
+	)
+	assert_eq(script, [
+		{"op": "object_facing", "object": 1, "facing": Gen1Layout.FACING_LEFT},
+	])
+
+
+func test_a_sprite_walk_carries_its_own_movement_list() -> void:
+	var script: Array = _decode(
+		_store_hram(int(LAYOUT["text_id_hram"]), 3)
+			+ [Gen1Layout.SCRIPT_LD_DE, MOVEMENT_LIST & 0xFF, MOVEMENT_LIST >> 8]
+			+ [Gen1Layout.SCRIPT_CALL, 0x10, 0x04, Gen1Layout.SCRIPT_RET],
+		{}, {
+			MOVEMENT_LIST: 0xC0, MOVEMENT_LIST + 1: 0x40,
+			MOVEMENT_LIST + 2: Gen1Layout.NPC_MOVEMENT_END,
+		}
+	)
+	assert_eq(script, [{"op": "object_move", "object": 2, "moves": [3, 1]}])
+
+
+## `FindPathToPlayer` writes its answer into WRAM, which no list in the bank
+## stands at, so Oak's own walk says nothing here.
+func test_a_sprite_walk_out_of_wram_answers_nothing() -> void:
+	assert_eq(_decode(
+		_store_hram(int(LAYOUT["text_id_hram"]), 3)
+			+ [Gen1Layout.SCRIPT_LD_DE, 0x97, 0xCC]
+			+ [Gen1Layout.SCRIPT_CALL, 0x10, 0x04, Gen1Layout.SCRIPT_RET]
+	), [])
+
+
+## `DecodeRLEList` unrolls its pairs into the buffer, and `GetSimulatedInput`
+## spends them back to front.
+func test_a_decoded_walk_spends_its_buffer_back_to_front() -> void:
+	var script: Array = _decode(
+		_load_hl(int(LAYOUT["simulated_joypad_end"]))
+			+ [Gen1Layout.SCRIPT_LD_DE, MOVEMENT_LIST & 0xFF, MOVEMENT_LIST >> 8]
+			+ [Gen1Layout.SCRIPT_CALL, 0x20, 0x04, Gen1Layout.SCRIPT_DEC_A]
+			+ _store_a(int(LAYOUT["simulated_joypad_index"]))
+			+ [Gen1Layout.SCRIPT_CALL, 0x20, 0x03, Gen1Layout.SCRIPT_RET],
+		{}, {
+			MOVEMENT_LIST: 0x20, MOVEMENT_LIST + 1: 1, MOVEMENT_LIST + 2: 0x40,
+			MOVEMENT_LIST + 3: 2, MOVEMENT_LIST + 4: Gen1Layout.RLE_END,
+		}
+	)
+	assert_eq(script, [{"op": "walk", "moves": [
+		{"direction": 1, "steps": 2}, {"direction": 2, "steps": 1},
+	]}])
+
+
+## A row spending more entries than it wrote reads whatever the buffer held, so
+## the walk is refused rather than invented.
+func test_a_walk_longer_than_its_buffer_answers_nothing() -> void:
+	assert_eq(_decode(
+		[Gen1Layout.SCRIPT_LD_A, 0x40] + _store_a(int(LAYOUT["simulated_joypad_end"]))
+			+ [Gen1Layout.SCRIPT_LD_A, 3]
+			+ _store_a(int(LAYOUT["simulated_joypad_index"]))
+			+ [Gen1Layout.SCRIPT_CALL, 0x20, 0x03, Gen1Layout.SCRIPT_RET]
+	), [])
+
+
+## `bit BIT_SCRIPTED_NPC_MOVEMENT, a` / `ret nz`, which is how a state holds
+## still while the walk the state before it started is drawn.
+func test_a_scripted_movement_bit_becomes_a_movement_branch() -> void:
+	var script: Array = _decode(
+		_load_a(int(LAYOUT["status_flags_5"]))
+			+ [Gen1Layout.SCRIPT_PREFIX, Gen1Layout.SCRIPT_BIT_BASE | 0x07]
+			+ [RET_NZ] + _print(HELLO) + [Gen1Layout.SCRIPT_RET],
+		{HELLO: "HI"}
+	)
+	assert_eq(script, [{
+		"op": "movement_running", "who": Gen1Layout.MOVEMENT_TEST_OBJECT,
+		"then": [], "else": [{"op": "text", "text": "HI"}],
+	}], "the box opens on the side that is no longer walking")
 
 
 func test_a_row_that_prints_one_box_decodes_to_it() -> void:

--- a/tests/unit/test_source_budget.gd
+++ b/tests/unit/test_source_budget.gd
@@ -16,12 +16,12 @@ const MAX_COMMENT_BLOCK: int = 8
 ## Comment lines under [constant COUNTED_ROOTS]. A ceiling, not a target: lower
 ## it whenever a pass leaves room. It moves up only while a generation the tree
 ## did not carry is being brought in, and then by what that generation's own
-## files cost: `game/gen1` and its neighbours are 1568 lines of it, and
-## Generation 1 has added 2186 more to the shared code, the largest of them 152
+## files cost: `game/gen1` and its neighbours are 1622 lines of it, and
+## Generation 1 has added 2235 more to the shared code, the largest of them 152
 ## the region map, 150 the battle animation engine, 140 the transition, 131 the
-## field moves, 130 the Pokedex, 108 the three PCs, 97 the bicycle, 95 the
-## trainer card, 74 the per-frame map scripts.
-const MAX_COMMENT_LINES: int = 41424
+## field moves, 130 the Pokedex, 108 the three PCs, 103 the movement a map
+## script runs, 97 the bicycle, 95 the trainer card, 74 those scripts.
+const MAX_COMMENT_LINES: int = 41527
 
 ## The functions still over [constant MAX_COMPLEXITY], as `path:function`. Empty,
 ## and it stays empty: a function over the ceiling fails the test rather than

--- a/tools/checks/gen1_maps.gd
+++ b/tools/checks/gen1_maps.gd
@@ -115,9 +115,9 @@ const PALETTE_CENSUS: Dictionary = {
 ## byte that opens it. Yellow's six bare `text_end`s are Jessie and James, whose
 ## two ids share one on three maps.
 const TEXT_CENSUS: Dictionary = {
-	&"red": {0x08: 626, 0x17: 456, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
-	&"blue": {0x08: 626, 0x17: 456, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
-	&"yellow": {0x08: 675, 0x17: 429, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3,
+	&"red": {0x08: 626, 0x17: 461, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"blue": {0x08: 626, 0x17: 461, 0xF5: 3, 0xF6: 12, 0xF7: 3, 0xFE: 14, 0xFF: 12},
+	&"yellow": {0x08: 675, 0x17: 434, 0x50: 6, 0xF5: 3, 0xF6: 12, 0xF7: 3,
 		0xFE: 14, 0xFF: 12},
 }
 
@@ -174,18 +174,18 @@ const TOGGLE_CENSUS: Dictionary = {
 ## One row of each list stands on UNUSED_MAP_6F, which has no header and so no
 ## record: the table holds 217 rows on Red and Blue and 213 on Yellow.
 const HIDDEN_CENSUS: Dictionary = {
-	&"red": {"rows": 216, "silent": 70, "text": 209, "branch": 69, "flag": 65,
+	&"red": {"rows": 216, "silent": 70, "text": 210, "branch": 69, "flag": 66,
 		"facing": 56, "name_item": 53, "give_item": 53, "facility": 21,
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
-		"map_text": 5, "choice": 3, "unknown": 2, "dex_count": 1},
-	&"blue": {"rows": 216, "silent": 70, "text": 209, "branch": 69, "flag": 65,
+		"map_text": 5, "choice": 3, "unknown": 1, "dex_count": 1},
+	&"blue": {"rows": 216, "silent": 70, "text": 210, "branch": 69, "flag": 66,
 		"facing": 56, "name_item": 53, "give_item": 53, "facility": 21,
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
-		"map_text": 5, "choice": 3, "unknown": 2, "dex_count": 1},
-	&"yellow": {"rows": 212, "silent": 69, "text": 211, "branch": 70, "flag": 66,
+		"map_text": 5, "choice": 3, "unknown": 1, "dex_count": 1},
+	&"yellow": {"rows": 212, "silent": 69, "text": 212, "branch": 70, "flag": 67,
 		"facing": 52, "name_item": 54, "give_item": 54, "facility": 17,
 		"badge": 14, "has_item": 12, "add_coins": 12, "has_coins": 12,
-		"map_text": 5, "choice": 3, "unknown": 2, "dex_count": 1},
+		"map_text": 5, "choice": 3, "unknown": 1, "dex_count": 1},
 }
 ## Of `BookshelfTileIDs`' 17 rows, all but one decode: the Indigo Plateau
 ## statues read `wXCoord` for which of their two boxes they answer with.
@@ -203,9 +203,9 @@ const CALLBACK_CENSUS: Dictionary = {
 ## The maps with a state machine, the states reachable from index 0 and from
 ## every `set_map_script` already read, and the bodies the walker gets whole.
 const STATE_CENSUS: Dictionary = {
-	&"red": {"tables": 92, "states": 56, "read": 5, "ops": 33},
-	&"blue": {"tables": 92, "states": 56, "read": 5, "ops": 33},
-	&"yellow": {"tables": 90, "states": 51, "read": 3, "ops": 16},
+	&"red": {"tables": 92, "states": 78, "read": 26, "ops": 105},
+	&"blue": {"tables": 92, "states": 78, "read": 26, "ops": 105},
+	&"yellow": {"tables": 90, "states": 70, "read": 22, "ops": 100},
 }
 
 ## The pin on which way a `wCurrentMenuItem` branch reads.
@@ -576,8 +576,8 @@ func _dispatch_node(nodes: Array) -> Dictionary:
 	for node: Dictionary in nodes:
 		if String(node["op"]) == "map_script_table":
 			return node
-		for key: String in node:
-			if not node[key] is Array or key == "either":
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if not node.has(key):
 				continue
 			var found: Dictionary = _dispatch_node(node[key] as Array)
 			if not found.is_empty():
@@ -588,8 +588,8 @@ func _dispatch_node(nodes: Array) -> Dictionary:
 func _node_count(nodes: Array) -> int:
 	var total: int = nodes.size()
 	for node: Dictionary in nodes:
-		for key: String in node:
-			if node[key] is Array and key != "either":
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key):
 				total += _node_count(node[key] as Array)
 	return total
 
@@ -645,7 +645,7 @@ func _walk_script(
 		if op == "give_item" or op == "has_item" or op == "take_item":
 			_r.check(not _r.data.item_name(int(node["item"])).is_empty(),
 				"map %d names item %d, which has no name." % [number, int(node["item"])])
-		for side: String in ["then", "else", "yes", "no", "ok", "full"]:
+		for side: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
 			if node.has(side):
 				_walk_script(font, node[side] as Array, census, wrong, number)
 
@@ -694,7 +694,7 @@ func _walk_hidden(
 		if (op == "give_item" or op == "has_item" or op == "name_item") \
 			and _r.data.item_name(int(node["item"])).is_empty():
 			wrong.append("map %d names item %d" % [number, int(node["item"])])
-		for side: String in ["then", "else", "yes", "no", "ok", "full"]:
+		for side: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
 			if node.has(side):
 				_walk_hidden(node[side] as Array, census, wrong, number)
 
@@ -992,9 +992,8 @@ func _clears_forced_ride(nodes: Array) -> bool:
 			and not bool(node["set"]) \
 			and int(node["flag"]) == Gen2WorldState.ENGINE_ALWAYS_ON_BIKE:
 			return true
-		for key: String in node:
-			if node[key] is Array and key != "either" \
-				and _clears_forced_ride(node[key] as Array):
+		for key: String in Gen1Layout.SCRIPT_BRANCH_KEYS:
+			if node.has(key) and _clears_forced_ride(node[key] as Array):
 				return true
 	return false
 

--- a/tools/checks/gen1_walk.gd
+++ b/tools/checks/gen1_walk.gd
@@ -86,6 +86,35 @@ const ROUTE_22_GATE_NOOP: int = 2
 const ROUTE_22_GATE_PASS: String = "Oh! That is the"
 const ROUTE_22_GATE_REFUSED: String = "Only truly skilled"
 
+## Frames enough for the longest walk either check drives, so a trail that never
+## drains ends the loop rather than hanging the suite.
+const SCRIPTED_WALK_PASSES: int = 256
+
+## `MtMoonB2FMoveSuperNerdScript`: the state it stands at, the nerd's own object
+## index, and the cell each coordinate list walks him to. He starts at (12, 8),
+## and `MtMoon3FSuperNerdMoveRightMovementData` falls through into the row below
+## it, so the dome side is two steps and the helix side one.
+const MT_MOON_B2F: int = 61
+const MT_MOON_B2F_BYTE: int = 0x17
+const MT_MOON_B2F_MOVE_NERD: int = 4
+const MT_MOON_B2F_NERD: int = 0
+## Yellow puts a Pikachu branch on the cell in front of each fossil, so the walk
+## stands on the corner both cartridges share.
+const MT_MOON_B2F_WALKS: Array = [
+	[Vector2i(11, 6), Vector2i(13, 7)], [Vector2i(14, 6), Vector2i(12, 7)],
+]
+const MT_MOON_B2F_NERD_BOX: String = "All right. Then\nthis is mine!"
+
+## `HallOfFameDefaultScript` walks the player five cells up out of the room's
+## own first warp, and `HallOfFameOakCongratulationsScript` behind it turns Oak
+## to face them. Champion's Room's third warp is the way in.
+const CHAMPIONS_ROOM: int = 120
+const CHAMPIONS_ROOM_STAIRS := Vector2i(3, 0)
+const HALL_OF_FAME_LANDING := Vector2i(4, 7)
+const HALL_OF_FAME_WALKED := Vector2i(4, 2)
+const HALL_OF_FAME_OAK: int = 0
+const HALL_OF_FAME_BOX: String = "OAK: Er-hem!"
+
 ## A party that knows FLY, and `FlyWarpDataPtr.ViridianCity`'s own tile.
 const FLY_SPECIES: Array[int] = [16]
 const FLY_MOVES: Array = [[Gen2WorldFieldMove.MOVE_FLY, 0, 0, 0]]
@@ -389,6 +418,8 @@ func _one_game() -> void:
 	_check_a_cut_tree()
 	_check_rock_tunnel_is_dark()
 	_check_a_map_script_runs()
+	_check_a_scripted_npc_walk()
+	_check_a_scripted_player_walk()
 
 
 ## `DisplayPokemonCenterDialogue_` walked whole. `AnimateHealingMachine` is a
@@ -487,9 +518,12 @@ func _check_warps() -> void:
 				continue
 			driven += 1
 			var destination: Dictionary = taken["destination"]
+			## The landing rather than where the player stands: the destination
+			## map's own script runs behind `EnterMap` and may walk them off it.
 			_r.check(
-				world.player_cell == Vector2i(int(destination["x"]), int(destination["y"])),
-				"map %d warp %d landed on %s" % [map.number, index, world.player_cell]
+				Vector2i(taken["to_cell"])
+					== Vector2i(int(destination["x"]), int(destination["y"])),
+				"map %d warp %d landed on %s" % [map.number, index, taken["to_cell"]]
 			)
 	_r.check(warps == int(pinned["warps"]), "%d warps, wanted %d" % [warps, pinned["warps"]])
 	_r.check(last_map == int(pinned["last_map"]),
@@ -1960,6 +1994,65 @@ func _check_a_map_script_runs() -> void:
 		_r.check(world.dispatch_sight_events().is_empty(),
 			"the gate spoke twice with the badge %s." % badge)
 	_r.note("gen1 walk ROUTE_22_GATE both ways past its guard")
+
+
+## `MoveSprite` driven on the world: Mt. Moon B2F's super nerd walks to whichever
+## fossil is left, and the state behind him holds its line until that walk has
+## been drawn.
+func _check_a_scripted_npc_walk() -> void:
+	for row: Array in MT_MOON_B2F_WALKS:
+		var world: Gen2WorldAPI = _r.open_world(0, MT_MOON_B2F, row[0])
+		if world == null:
+			return
+		world.state.set_gen1_map_script(MT_MOON_B2F_BYTE, MT_MOON_B2F_MOVE_NERD)
+		_r.check(world.dispatch_sight_events().is_empty(),
+			"the nerd said something on the frame he was sent walking.")
+		var nerd: Gen2WorldObject = world.objects[MT_MOON_B2F_NERD]
+		_r.check(nerd.cell == row[1],
+			"the nerd walked to %s from %s, not %s." % [nerd.cell, row[0], row[1]])
+		_r.check(world.gen1_object_movement_running(),
+			"the nerd's walk was over before a frame had drawn it.")
+		_r.check(world.dispatch_sight_events().is_empty(),
+			"the nerd spoke while his own walk was still being drawn.")
+		var passes: int = 0
+		while world.gen1_object_movement_running() and passes < SCRIPTED_WALK_PASSES:
+			world.advance_scripted_steps_pass()
+			passes += 1
+		_r.check(_event_text(world.dispatch_sight_events()) == MT_MOON_B2F_NERD_BOX,
+			"the nerd said nothing once his walk had been drawn.")
+	_r.note("gen1 walk MT_MOON_B2F both ways past its super nerd")
+
+
+## `HallOfFameDefaultScript`: the warp in walks the player five cells up on the
+## frame the map loads, and the state behind it turns Oak to face them.
+func _check_a_scripted_player_walk() -> void:
+	var world: Gen2WorldAPI = _r.open_world(0, CHAMPIONS_ROOM, CHAMPIONS_ROOM_STAIRS)
+	if world == null:
+		return
+	world.player_facing = Gen2WorldSprite.FACING_UP
+	var taken: Dictionary = world.try_warp()
+	if not _r.check(bool(taken.get("ok", false)), "the Hall of Fame door was refused."):
+		return
+	_r.check(Vector2i(taken["to_cell"]) == HALL_OF_FAME_LANDING,
+		"the door landed on %s." % [taken["to_cell"]])
+	_r.check(world.player_cell == HALL_OF_FAME_WALKED,
+		"the room walked the player to %s, not %s." % [
+			world.player_cell, HALL_OF_FAME_WALKED,
+		])
+	_r.check(world.dispatch_sight_events().is_empty(),
+		"Oak spoke while the player was still walking in.")
+	var passes: int = 0
+	while world.gen1_player_movement_running() and passes < SCRIPTED_WALK_PASSES:
+		world.advance_player_step_pass()
+		passes += 1
+	_r.check(_event_text(world.dispatch_sight_events()).begins_with(HALL_OF_FAME_BOX),
+		"Oak said nothing once the walk in had been drawn.")
+	var oak: Gen2WorldObject = world.objects[HALL_OF_FAME_OAK]
+	_r.check(oak.facing == Gen2WorldSprite.FACING_LEFT,
+		"Oak faced %d rather than the player." % oak.facing)
+	_r.check(world.player_facing == Gen2WorldSprite.FACING_RIGHT,
+		"the player faced %d rather than Oak." % world.player_facing)
+	_r.note("gen1 walk HALL_OF_FAME five cells in and Oak turning to meet it")
 
 
 ## `ItemUsePokeFlute` outside a battle: the cell beside Route 12's Snorlax sets


### PR DESCRIPTION
A Generation 1 map's per-frame script could decode a state body only while that body moved nobody. `SetSpriteFacingDirectionAndDelay`, `MoveSprite`, `SetSpriteMovementBytesToFF` and `DecodeRLEList` each dropped the whole body, and the map ran nothing.

## Added

`SetSpriteFacingDirection` and the `...AndDelay` row behind it emit the `object_facing` node a store to `wSpriteStateData1` already made. `SetSpriteMovementBytesToFF` emits `object_stay`, STAY over the template the map gave the object. `MoveSprite` emits `object_move`, whose `NPC_MOVEMENT_*` list `Gen2WorldAPI` queues onto the object the way an `applymovement` is queued, because `CanWalkOntoTile` allows a scripted step outright.

`DecodeRLEList` fills the player's own buffer, so a `walk` node carries a list of legs rather than one direction. `GetSimulatedInput` counts `wSimulatedJoypadStatesIndex` down before it reads the buffer, so the entries are spent back to front.

`wStatusFlags5`'s two scripted-movement bits and `wSimulatedJoypadStatesIndex` become one `movement_running` node, which is what holds a state still until the walk the state before it started has been drawn. `wCoordIndex` becomes `coord_index`, the row `ArePlayerCoordsInArray` matched on, counted from 1. `wPlayerMovingDirection` becomes `player_facing`, `UpdatePlayerSprite` reading its four bits in the order down, up, left, right.

`Gen2WorldScreen` runs `RunMapScript` again on the frame a scripted walk finishes being drawn, which is the frame a waiting state gets its turn. An ordinary step already reached the map script through `_after_map_settled`; a `MoveSprite` trail has no step behind it.

`PlayMusic`, `StopAllMusic` and the four `Music_*` routines join the silent calls, and `ld c, a`, `ldh a, [n]`, `inc a`, `dec a` and `ld [hli], a` are read.

## Fixed

A node's arrays were recursed into wherever one was found, so `cells`, `either` and a movement list were each walked as if they held nodes. `Gen1Layout.SCRIPT_BRANCH_KEYS` is the six keys a branch is kept under and the only arrays a walker reads.

A map's text table was bounded by the highest id the map's own events name, so a row only a map script reaches was never read at all: 5 more rows on every cartridge, Mt. Moon B2F's tenth among them.

`_walk_script` answers a routine that spends nothing before walking its machine code, so `jp nc, CheckFightingMapTrainers` is a return rather than a descent into the trainer scan.

`Gen2WorldAPI.try_warp` reports the cell the warp landed on rather than where the destination map's own script left the player.

## Numbers

| Cartridge | State bodies read, before | After | Reachable states |
|---|---|---|---|
| Red | 5 of 56 | 26 of 78 | 78 |
| Blue | 5 of 56 | 26 of 78 | 78 |
| Yellow | 3 of 51 | 22 of 70 | 70 |

`tools/checks/gen1_walk.gd` sends Mt. Moon B2F's super nerd to whichever fossil is left from both sides and holds his line until the walk is drawn, and takes Champion's Room's stairs into the Hall of Fame, where the room walks the player five cells up and Oak turns to meet them. `tools/checks/gen1_maps.gd` pins the state census on all three cartridges, and `tests/unit/test_gen1_script.gd` covers the two refusals the corpus has no row for: a `MoveSprite` whose list is `FindPathToPlayer`'s WRAM answer, and a walk longer than the buffer it wrote.

What is left needs something else: `RemoveGuardDrink`'s bag walk on the four drink gates, `FindPathToPlayer` in Oak's lab and Pallet Town, `CheckBoulderCoords` on Seafoam Islands B4F, and `FillMemory` behind Route 16 Gate's own walk, whose length is a coordinate row rather than a constant.

Green: `validate.gd -- all` over 93 topics, the unit tier at 3884 tests, `replay_world.gd` over 33 routes, the three-profile story walk byte for byte against `main`, and the editor analyser at 0 warnings over 634 scripts.
