### PR TITLE
Open the shelf on the cartridge last played

### DIFF
--- a/game/launcher/cartridge_stage.gd
+++ b/game/launcher/cartridge_stage.gd
@@ -57,11 +57,17 @@ var _scroll: float = 0.0:
 		_place_all()
 
 
-static func create(palette: Gen2LauncherTheme, order: Array[StringName]) -> Gen2CartridgeStage:
+## [param opening] is where the row starts, an id it does not hold being the
+## first. It opens there rather than sliding: a step is the player's own.
+static func create(
+	palette: Gen2LauncherTheme, order: Array[StringName], opening: StringName = &""
+) -> Gen2CartridgeStage:
 	var stage := Gen2CartridgeStage.new()
 	stage._theme = palette
 	stage._order = order
 	stage._build()
+	stage.selected = maxi(order.find(opening), 0)
+	stage._scroll = float(stage.selected)
 	return stage
 
 
@@ -174,9 +180,8 @@ func _step_by(event: InputEvent) -> bool:
 	return false
 
 
-## The row is dragged rather than paged: a press takes hold of it, the pointer
-## carries it, and letting go settles on whatever is nearest. Touch arrives here
-## too, since the engine emulates a mouse from it.
+## The row is dragged rather than paged: a press takes hold of it and letting go
+## settles on the nearest. Touch arrives here, the engine emulating a mouse.
 func _on_click(click: InputEventMouseButton) -> void:
 	match click.button_index:
 		MOUSE_BUTTON_WHEEL_UP, MOUSE_BUTTON_WHEEL_LEFT:
@@ -216,8 +221,7 @@ func _on_click(click: InputEventMouseButton) -> void:
 	_settle()
 
 
-## Lights whichever card the pointer is over, and names it in the tooltip. The
-## cards take no pointer events of their own, so this is where hover lives.
+## The cards take no pointer events of their own, so hover lives here.
 func _hover(index: int) -> void:
 	for at: int in _cartridges.size():
 		_cartridges[at].set_hovered(at == index)
@@ -231,9 +235,8 @@ func _on_drag(motion: InputEventMouseMotion) -> void:
 	_scroll = _grab_scroll - (motion.position.x - _grab_x) / stride
 
 
-## Settles a dragged row on the nearest cartridge and makes that the selection.
-## The whole ring is shifted back into range at the same time, so a row dragged
-## round and round does not walk [member _scroll] away from its slot numbers.
+## The nearest cartridge, and the whole ring shifted back into range with it, so
+## a row dragged round and round does not walk [member _scroll] off its slots.
 func _settle() -> void:
 	var ring: int = _cartridges.size()
 	var nearest: float = roundf(_scroll)

--- a/game/launcher/shelf_page.gd
+++ b/game/launcher/shelf_page.gd
@@ -20,12 +20,16 @@ var _gap: Control = null
 var _details: Dictionary = {}
 var _compact: bool = false
 var _busy: bool = false
+var _opening: StringName = &""
 
 
-static func create(palette: Gen2LauncherTheme, compact: bool) -> Gen2ShelfPage:
+static func create(
+	palette: Gen2LauncherTheme, compact: bool, opening: StringName = &""
+) -> Gen2ShelfPage:
 	var page := Gen2ShelfPage.new()
 	page._theme = palette
 	page._compact = compact
+	page._opening = opening
 	page._build()
 	return page
 
@@ -33,7 +37,7 @@ static func create(palette: Gen2LauncherTheme, compact: bool) -> Gen2ShelfPage:
 func _build() -> void:
 	add_theme_constant_override("separation", Gen2LauncherUI.GAP_MD)
 
-	_stage = Gen2CartridgeStage.create(_theme, RomRegistry.ORDER)
+	_stage = Gen2CartridgeStage.create(_theme, RomRegistry.ORDER, _opening)
 	_stage.selection_changed.connect(_on_selection_changed)
 	_stage.insert_requested.connect(func(id: StringName) -> void: insert_requested.emit(id))
 	_stage.play_requested.connect(func(id: StringName) -> void: play_requested.emit(id))
@@ -57,8 +61,7 @@ func stage() -> Gen2CartridgeStage:
 	return _stage
 
 
-## Where a keyboard or a pad starts on this page: the carousel, which is what the
-## page is about and what ui_left and ui_right then turn.
+## Where a keyboard or a pad starts here: the carousel ui_left and ui_right turn.
 func focus_target() -> Control:
 	return _stage
 

--- a/game/main/main.gd
+++ b/game/main/main.gd
@@ -77,7 +77,9 @@ func _build() -> void:
 	_title_backdrop = Gen2LauncherTitleBackdrop.new()
 	add_child(_title_backdrop)
 
-	_shelf = Gen2ShelfPage.create(_palette, _shell.compact)
+	_shelf = Gen2ShelfPage.create(
+		_palette, _shell.compact, Gen2OptionsStore.current().last_played
+	)
 	_shelf.insert_requested.connect(_open_import_dialog)
 	_shelf.play_requested.connect(_launch_game)
 	_shelf.manage_requested.connect(_open_manage_sheet)
@@ -552,6 +554,7 @@ func launcher_snapshot() -> Dictionary:
 		"importing": _importing,
 		"page": String(_shell.current_page()) if _shell != null else "",
 		"theme": String(_palette.mode),
+		"shelf": String(_shelf.selected_id()) if _shelf != null else "",
 		"games": games,
 	}
 
@@ -686,6 +689,7 @@ func _launch_game(game_id: StringName) -> void:
 		)
 		return
 	_selected_game_id = game_id
+	_remember_last_played(game_id)
 	# The launch says itself with the transition; a toast announcing it would be
 	# a second, slower answer to the same press.
 	_shelf.set_busy(true)
@@ -694,6 +698,16 @@ func _launch_game(game_id: StringName) -> void:
 		await seated.play_start()
 	await _shell.flash()
 	get_tree().change_scene_to_file.call_deferred("res://game/save/save_screen.tscn")
+
+
+## Written where a launch is settled rather than where one is asked for: a bay
+## with no world has been turned away above, and an import is not a game played.
+func _remember_last_played(game_id: StringName) -> void:
+	var options: Gen2Options = Gen2OptionsStore.current()
+	if options.last_played == game_id:
+		return
+	options.last_played = game_id
+	Gen2OptionsStore.save(options)
 
 
 ## A cartridge this build cannot read was imported once; an empty bay was not.

--- a/game/options/options.gd
+++ b/game/options/options.gd
@@ -126,6 +126,7 @@ var touch_layout: PokeTouchLayout = PokeTouchLayout.new()
 ## time it is used. An installation setting rather than a run's, because the
 ## chord belongs to the machine: see [method Gen2InputRuntime.reset_chord_held].
 var soft_reset_acknowledged: bool = false
+var last_played: StringName = &""
 
 
 ## The cartridge block as the bytes the hardware kept, `DefaultOptions` order.
@@ -238,6 +239,7 @@ func to_dict() -> Dictionary:
 		"touch_mode": String(touch_mode),
 		"touch_layout": touch_layout.to_dict(),
 		"soft_reset_acknowledged": soft_reset_acknowledged,
+		"last_played": String(last_played),
 	}
 
 
@@ -281,6 +283,7 @@ static func parse(raw: Variant) -> Gen2Options:
 	options.touch_mode = _one_of(row.get("touch_mode", ""), TOUCH_MODES)
 	options.touch_layout = PokeTouchLayout.parse(row.get("touch_layout"))
 	options.soft_reset_acknowledged = bool(row.get("soft_reset_acknowledged", false))
+	options.last_played = StringName(String(row.get("last_played", "")))
 	return options
 
 

--- a/tests/unit/test_launcher.gd
+++ b/tests/unit/test_launcher.gd
@@ -93,6 +93,28 @@ func test_launcher_lists_every_supported_game() -> void:
 		assert_false(row["selected"])
 
 
+## The shelf opens on the cartridge last launched rather than on the first bay,
+## and an id the registry no longer lists opens it where it always did.
+func test_the_shelf_opens_on_the_cartridge_last_played() -> void:
+	Gen2OptionsStore.use_test_path()
+	for played: StringName in [RomRegistry.YELLOW, RomRegistry.SILVER]:
+		var options: Gen2Options = Gen2OptionsStore.current()
+		options.last_played = played
+		assert_true(Gen2OptionsStore.save(options))
+		await _open_launcher()
+		assert_eq(_launcher.launcher_snapshot()["shelf"], String(played))
+		_launcher.free()
+		_launcher = null
+		await get_tree().process_frame
+
+	var forgotten: Gen2Options = Gen2OptionsStore.current()
+	forgotten.last_played = &"a_cartridge_that_left"
+	assert_true(Gen2OptionsStore.save(forgotten))
+	await _open_launcher()
+	assert_eq(_launcher.launcher_snapshot()["shelf"], String(RomRegistry.ORDER[0]))
+	DirAccess.remove_absolute(Gen2OptionsStore.path())
+
+
 func test_launcher_opens_on_the_shelf_and_moves_between_its_pages() -> void:
 	await _open_launcher()
 	assert_eq(_launcher.launcher_snapshot()["page"], "shelf")

--- a/tests/unit/test_options.gd
+++ b/tests/unit/test_options.gd
@@ -213,6 +213,7 @@ func test_saving_then_loading_keeps_both_blocks() -> void:
 	options.music_volume = 2
 	options.video_mode = &"fullscreen"
 	options.max_fps = 120
+	options.last_played = RomRegistry.YELLOW
 	assert_true(Gen2OptionsStore.save(options))
 
 	Gen2OptionsStore.use_test_path()
@@ -222,6 +223,7 @@ func test_saving_then_loading_keeps_both_blocks() -> void:
 	assert_eq(loaded.music_volume, 2)
 	assert_eq(loaded.video_mode, &"fullscreen")
 	assert_eq(loaded.max_fps, 120)
+	assert_eq(loaded.last_played, RomRegistry.YELLOW)
 
 
 func test_a_missing_file_loads_defaults() -> void:


### PR DESCRIPTION
The carousel opened on Red whatever the player had been playing, so anyone whose game is Crystal turned the row four steps at every launch.

## Added

`Gen2Options.last_played` holds the cartridge the launcher last started, beside `zoom_step` for the same reason: a view the player left rather than anything a run holds.

`Gen2CartridgeStage.create` takes the cartridge to open on and starts both `selected` and `_scroll` there, so the row opens on it rather than sliding to it. A step is the player turning the carousel, and nothing has turned it yet. An id the row does not hold opens it at the first bay, which is where it always opened.

`launcher_snapshot` names the cartridge the shelf stands on.

## Where it is written

At `_launch_game`, once the launch is settled. A bay with no world behind it has been turned away above, and an import writes nothing: reading a dump is not playing it.

## Fixed

Three comments in the launcher restated the line below them and now carry only the fact.

Green: the unit tier at 3885 tests, the editor analyser at 0 warnings over 634 scripts, `tools/release.sh --gates` with the comment ceiling unmoved.
